### PR TITLE
feat(permissions): classify tool access requests

### DIFF
--- a/src/main/acp/permission-broker.test.ts
+++ b/src/main/acp/permission-broker.test.ts
@@ -258,6 +258,7 @@ describe('ACP permission broker', () => {
     )
 
     expect(emitted[0]).toMatchObject({ isMcp: true })
+    expect(emitted[0]).not.toHaveProperty('mcpIdentity')
     expect(emitted[0].options.map((option) => option.scope).filter(Boolean)).toEqual(['once'])
   })
 
@@ -805,7 +806,10 @@ describe('ACP permission broker', () => {
     })
 
     const firstResponse = broker.requestPermission(leafRequest, context)
-    expect(emitted[0]).toMatchObject({ isMcp: true })
+    expect(emitted[0]).toMatchObject({
+      isMcp: true,
+      mcpIdentity: 'open-science-notebook/notebook_execute'
+    })
     broker.respond({ requestId: emitted[0].requestId, optionId: getSessionOptionId(emitted[0]) })
     await firstResponse
 

--- a/src/main/acp/permission-broker.ts
+++ b/src/main/acp/permission-broker.ts
@@ -432,6 +432,10 @@ class AcpPermissionBroker {
     const mcpServerNames = policyContext?.mcpServerNames ?? []
     const categoryKey = resolveCategoryKey(params, mcpServerNames)
     const isMcp = isMcpPermission(params, mcpServerNames)
+    const mcpIdentity = isMcp
+      ? (resolveMcpToolIdentity(params.toolCall.title, mcpServerNames) ??
+        resolveMcpToolIdentity(extractProviderToolName(params.toolCall), mcpServerNames))
+      : undefined
     const projectedProviderOptions = projectPermissionOptions(params, policyContext, isMcp)
     const providerPermissionOptions = projectedProviderOptions.filter(
       (option) =>
@@ -465,6 +469,7 @@ class AcpPermissionBroker {
       status: params.toolCall.status ?? undefined,
       providerToolName: extractProviderToolName(params.toolCall),
       isMcp,
+      ...(mcpIdentity ? { mcpIdentity } : {}),
       toolKind: params.toolCall.kind ?? undefined,
       toolLocations: params.toolCall.locations ?? undefined,
       rawInput: params.toolCall.rawInput,

--- a/src/renderer/src/pages/workspace/PermissionApprovalControls.interaction.test.tsx
+++ b/src/renderer/src/pages/workspace/PermissionApprovalControls.interaction.test.tsx
@@ -535,4 +535,64 @@ describe('PermissionApprovalControls interactions', () => {
       delete (window as { api?: unknown }).api
     }
   })
+
+  it('does not use a live Python environment for an R permission request', async () => {
+    const rNotebookRequest: AcpPermissionRequest = {
+      requestId: 'req-r-env',
+      sessionId: 'session-r-env',
+      toolCallId: 'tool-r-env',
+      title: 'mcp__open-science-notebook__notebook_execute',
+      providerToolName: 'mcp__open-science-notebook__notebook_execute',
+      rawInput: { kernelKind: 'r', code: 'x <- 1' },
+      options: [{ optionId: 'opt-once', name: 'Allow once', kind: 'allow_once' }]
+    }
+    ;(window as { api?: unknown }).api = {
+      notebook: {
+        state: async () => ({
+          environments: [
+            { kind: 'python', environment: 'default-python', processKey: 'python:default-python' }
+          ],
+          runs: []
+        })
+      },
+      runtime: {
+        listEnvironments: async () => ({
+          python: [],
+          r: [
+            {
+              language: 'r',
+              provenance: 'app-managed',
+              envId: '/envs/default-r',
+              interpreterPath: '/envs/default-r/bin/R',
+              label: 'default-r',
+              runnable: true
+            }
+          ]
+        }),
+        getEnablement: async () => ({ enabled: {}, installAuthorized: {} })
+      }
+    }
+    try {
+      act(() => {
+        root.render(
+          <PermissionApprovalControls
+            requests={[rNotebookRequest]}
+            onRespond={vi.fn()}
+            notebookLookup={{ sessionId: 'session-r-env', workspaceCwd: '' }}
+          />
+        )
+      })
+      await act(async () => {
+        await new Promise((resolve) => setTimeout(resolve, 0))
+      })
+      expect(container.querySelector('[data-testid="permission-env-badge"]')?.textContent).toBe(
+        'default-r'
+      )
+      expect(
+        container.querySelector('[data-testid="permission-category-badge"]')?.textContent
+      ).toBe('R execution')
+    } finally {
+      delete (window as { api?: unknown }).api
+    }
+  })
 })

--- a/src/renderer/src/pages/workspace/PermissionApprovalControls.interaction.test.tsx
+++ b/src/renderer/src/pages/workspace/PermissionApprovalControls.interaction.test.tsx
@@ -529,8 +529,8 @@ describe('PermissionApprovalControls interactions', () => {
         'default-python'
       )
       expect(
-        container.querySelector('[data-testid="permission-language-badge"]')?.textContent
-      ).toBe('python')
+        container.querySelector('[data-testid="permission-category-badge"]')?.textContent
+      ).toBe('Python execution')
     } finally {
       delete (window as { api?: unknown }).api
     }

--- a/src/renderer/src/pages/workspace/PermissionApprovalControls.interaction.test.tsx
+++ b/src/renderer/src/pages/workspace/PermissionApprovalControls.interaction.test.tsx
@@ -595,4 +595,87 @@ describe('PermissionApprovalControls interactions', () => {
       delete (window as { api?: unknown }).api
     }
   })
+
+  it('does not retain a Python environment badge while switching to an R request', async () => {
+    const pythonRequest: AcpPermissionRequest = {
+      requestId: 'req-transition-python',
+      sessionId: 'session-runtime-transition',
+      toolCallId: 'tool-transition-python',
+      title: 'mcp__open-science-notebook__notebook_execute',
+      providerToolName: 'mcp__open-science-notebook__notebook_execute',
+      rawInput: { kernelKind: 'python', code: 'x = 1' },
+      options: [{ optionId: 'opt-once', name: 'Allow once', kind: 'allow_once' }]
+    }
+    const rRequest: AcpPermissionRequest = {
+      ...pythonRequest,
+      requestId: 'req-transition-r',
+      toolCallId: 'tool-transition-r',
+      rawInput: { kernelKind: 'r', code: 'x <- 1' }
+    }
+    ;(window as { api?: unknown }).api = {
+      notebook: { state: async () => ({ environments: [], runs: [] }) },
+      runtime: {
+        listEnvironments: async () => ({
+          python: [
+            {
+              language: 'python',
+              provenance: 'app-managed',
+              envId: '/envs/default-python',
+              interpreterPath: '/envs/default-python/bin/python',
+              label: 'default-python',
+              runnable: true
+            }
+          ],
+          r: [
+            {
+              language: 'r',
+              provenance: 'app-managed',
+              envId: '/envs/default-r',
+              interpreterPath: '/envs/default-r/bin/R',
+              label: 'default-r',
+              runnable: true
+            }
+          ]
+        }),
+        getEnablement: async () => ({ enabled: {}, installAuthorized: {} })
+      }
+    }
+    try {
+      act(() => {
+        root.render(
+          <PermissionApprovalControls
+            requests={[pythonRequest]}
+            onRespond={vi.fn()}
+            notebookLookup={{ sessionId: 'session-runtime-transition', workspaceCwd: '' }}
+          />
+        )
+      })
+      await act(async () => {
+        await new Promise((resolve) => setTimeout(resolve, 0))
+      })
+      expect(container.querySelector('[data-testid="permission-env-badge"]')?.textContent).toBe(
+        'default-python'
+      )
+
+      act(() => {
+        root.render(
+          <PermissionApprovalControls
+            requests={[rRequest]}
+            onRespond={vi.fn()}
+            notebookLookup={{ sessionId: 'session-runtime-transition', workspaceCwd: '' }}
+          />
+        )
+      })
+      expect(container.querySelector('[data-testid="permission-env-badge"]')).toBeNull()
+
+      await act(async () => {
+        await new Promise((resolve) => setTimeout(resolve, 0))
+      })
+      expect(container.querySelector('[data-testid="permission-env-badge"]')?.textContent).toBe(
+        'default-r'
+      )
+    } finally {
+      delete (window as { api?: unknown }).api
+    }
+  })
 })

--- a/src/renderer/src/pages/workspace/PermissionApprovalControls.interaction.test.tsx
+++ b/src/renderer/src/pages/workspace/PermissionApprovalControls.interaction.test.tsx
@@ -488,6 +488,8 @@ describe('PermissionApprovalControls interactions', () => {
       toolCallId: 'tool-env',
       title: 'mcp__open-science-notebook__notebook_execute',
       providerToolName: 'mcp__open-science-notebook__notebook_execute',
+      isMcp: true,
+      mcpIdentity: 'open-science-notebook/notebook_execute',
       rawInput: { kernelKind: 'python', code: 'print(1)' },
       options: [{ optionId: 'opt-once', name: 'Allow once', kind: 'allow_once' }]
     }
@@ -543,6 +545,8 @@ describe('PermissionApprovalControls interactions', () => {
       toolCallId: 'tool-r-env',
       title: 'mcp__open-science-notebook__notebook_execute',
       providerToolName: 'mcp__open-science-notebook__notebook_execute',
+      isMcp: true,
+      mcpIdentity: 'open-science-notebook/notebook_execute',
       rawInput: { kernelKind: 'r', code: 'x <- 1' },
       options: [{ optionId: 'opt-once', name: 'Allow once', kind: 'allow_once' }]
     }
@@ -603,6 +607,8 @@ describe('PermissionApprovalControls interactions', () => {
       toolCallId: 'tool-transition-python',
       title: 'mcp__open-science-notebook__notebook_execute',
       providerToolName: 'mcp__open-science-notebook__notebook_execute',
+      isMcp: true,
+      mcpIdentity: 'open-science-notebook/notebook_execute',
       rawInput: { kernelKind: 'python', code: 'x = 1' },
       options: [{ optionId: 'opt-once', name: 'Allow once', kind: 'allow_once' }]
     }

--- a/src/renderer/src/pages/workspace/PermissionApprovalControls.render.test.tsx
+++ b/src/renderer/src/pages/workspace/PermissionApprovalControls.render.test.tsx
@@ -225,7 +225,7 @@ describe('PermissionApprovalControls', () => {
     expect(html).not.toContain('Artifact save</span>')
   })
 
-  it('keeps MCP execute payloads labeled as external service input', () => {
+  it('keeps every MCP execute argument in the external-service input preview', () => {
     const html = renderToStaticMarkup(
       <PermissionApprovalControls
         requests={[
@@ -236,7 +236,7 @@ describe('PermissionApprovalControls', () => {
             isMcp: true,
             mcpIdentity: 'runner/execute',
             toolKind: 'execute',
-            rawInput: { command: 'export-report --publish' }
+            rawInput: { command: 'export-report --publish', target: 'production' }
           }
         ]}
         onRespond={() => undefined}
@@ -245,6 +245,9 @@ describe('PermissionApprovalControls', () => {
 
     expect(html).toContain('External service input')
     expect(html).not.toContain('Run command')
+    expect(html).toContain('data-language="json"')
+    expect(html).toContain('export-report --publish')
+    expect(html).toContain('production')
   })
 
   it('keeps an MCP request external while showing its humanized action and paths', () => {

--- a/src/renderer/src/pages/workspace/PermissionApprovalControls.render.test.tsx
+++ b/src/renderer/src/pages/workspace/PermissionApprovalControls.render.test.tsx
@@ -192,6 +192,28 @@ describe('PermissionApprovalControls', () => {
     expect(html).not.toContain('mcp.open-science-artifacts')
   })
 
+  it('keeps a humanized MCP action beside reviewable paths or arguments', () => {
+    const html = renderToStaticMarkup(
+      <PermissionApprovalControls
+        requests={[
+          {
+            ...permissionRequest,
+            title: 'mcp__open-science-artifacts__write_artifact_file',
+            isMcp: true,
+            toolKind: 'edit',
+            toolLocations: [{ path: 'report.md' }],
+            rawInput: { value: 'updated' }
+          }
+        ]}
+        onRespond={() => undefined}
+      />
+    )
+
+    expect(html).toContain('File access</span>')
+    expect(html).toContain('Open Science Artifacts / Write Artifact File')
+    expect(html).toContain('report.md')
+  })
+
   it('shows the title for a non-Bash execute request with no command preview', () => {
     // A non-Bash execute request whose command lives only in the title: extractPermissionCode
     // has no Bash fallback here, so the title is the only place the command can appear — the
@@ -438,6 +460,25 @@ describe('PermissionApprovalControls', () => {
       <PermissionApprovalControls requests={[write]} onRespond={() => undefined} />
     )
     expect(html).toContain('Write report.md')
+  })
+
+  it('shows a stable built-in provider name when the title is generic', () => {
+    const html = renderToStaticMarkup(
+      <PermissionApprovalControls
+        requests={[
+          {
+            ...permissionRequest,
+            title: 'WebFetch',
+            providerToolName: 'WebFetch',
+            toolKind: 'fetch'
+          }
+        ]}
+        onRespond={() => undefined}
+      />
+    )
+
+    expect(html).toContain('Network access</span>')
+    expect(html).toContain('WebFetch')
   })
 
   it('shows notebook control impact without exposing the MCP identifier', () => {

--- a/src/renderer/src/pages/workspace/PermissionApprovalControls.render.test.tsx
+++ b/src/renderer/src/pages/workspace/PermissionApprovalControls.render.test.tsx
@@ -350,6 +350,7 @@ describe('PermissionApprovalControls', () => {
       <PermissionApprovalControls requests={[brokerShape]} onRespond={() => undefined} />
     )
     expect(html).toContain('Run notebook cell')
+    expect(html).toContain('data-testid="permission-impact-info"')
     expect(html).toContain('data-testid="permission-tool-info"')
     expect(html).toContain('data-language="python"')
     expect(html).toContain('print(&quot;hi&quot;)')
@@ -502,7 +503,7 @@ describe('PermissionApprovalControls', () => {
     expect(html).toContain('WebFetch')
   })
 
-  it('keeps notebook control details in the information tooltip without exposing its identifier', () => {
+  it('keeps notebook control details in an impact tooltip without exposing its identifier', () => {
     const identifier = 'open_science_notebook_notebook_restart'
     const restart: AcpPermissionRequest = {
       requestId: 'restart-1',
@@ -521,6 +522,7 @@ describe('PermissionApprovalControls', () => {
     expect(html).toContain('Restart notebook?')
     expect(html).toContain('Notebook control</span>')
     expect(html).not.toContain('Running processes and unsaved runtime state may be lost.')
+    expect(html).toContain('data-testid="permission-impact-info"')
     expect(html).toContain('data-testid="permission-tool-info"')
     expect(html).not.toContain(identifier)
   })

--- a/src/renderer/src/pages/workspace/PermissionApprovalControls.render.test.tsx
+++ b/src/renderer/src/pages/workspace/PermissionApprovalControls.render.test.tsx
@@ -168,7 +168,7 @@ describe('PermissionApprovalControls', () => {
     expect(html).not.toContain('Command execution</span>')
   })
 
-  it('hides the protocol identity for execute-kind MCP requests', () => {
+  it('keeps an otherwise-opaque MCP request distinguishable without its protocol identity', () => {
     const html = renderToStaticMarkup(
       <PermissionApprovalControls
         requests={[
@@ -187,6 +187,7 @@ describe('PermissionApprovalControls', () => {
 
     expect(html).toContain('Use external service?')
     expect(html).not.toContain('Run command?')
+    expect(html).toContain('Open Science Artifacts / Write Artifact File')
     expect(html).not.toContain('write_artifact_file')
     expect(html).not.toContain('mcp.open-science-artifacts')
   })

--- a/src/renderer/src/pages/workspace/PermissionApprovalControls.render.test.tsx
+++ b/src/renderer/src/pages/workspace/PermissionApprovalControls.render.test.tsx
@@ -192,6 +192,29 @@ describe('PermissionApprovalControls', () => {
     expect(html).not.toContain('mcp.open-science-artifacts')
   })
 
+  it('humanizes a raw MCP protocol title even when isMcp is omitted', () => {
+    const rawTitle = 'mcp__open-science-artifacts__write_artifact_file'
+    const html = renderToStaticMarkup(
+      <PermissionApprovalControls
+        requests={[
+          {
+            ...permissionRequest,
+            title: rawTitle,
+            providerToolName: rawTitle,
+            isMcp: false,
+            toolKind: 'execute'
+          }
+        ]}
+        onRespond={() => undefined}
+      />
+    )
+
+    expect(html).toContain('Use external service?')
+    expect(html).toContain('Open Science Artifacts / Write Artifact File')
+    expect(html).not.toContain(rawTitle)
+    expect(html).not.toContain('Run command?')
+  })
+
   it('keeps MCP execute payloads labeled as external service input', () => {
     const html = renderToStaticMarkup(
       <PermissionApprovalControls

--- a/src/renderer/src/pages/workspace/PermissionApprovalControls.render.test.tsx
+++ b/src/renderer/src/pages/workspace/PermissionApprovalControls.render.test.tsx
@@ -148,7 +148,7 @@ describe('PermissionApprovalControls', () => {
     expect(html).not.toContain(secondRequestTitle)
   })
 
-  it('labels non-notebook MCP approvals as an external service instead of command execution', () => {
+  it('labels the managed artifact writer as artifact storage instead of command execution', () => {
     const html = renderToStaticMarkup(
       <PermissionApprovalControls
         requests={[
@@ -164,7 +164,8 @@ describe('PermissionApprovalControls', () => {
       />
     )
 
-    expect(html).toContain('External service</span>')
+    expect(html).toContain('Artifact storage</span>')
+    expect(html).toContain('Write artifact file?')
     expect(html).not.toContain('Command execution</span>')
   })
 
@@ -185,9 +186,9 @@ describe('PermissionApprovalControls', () => {
       />
     )
 
-    expect(html).toContain('Use external service?')
-    expect(html).not.toContain('Run command?')
-    expect(html).toContain('Open Science Artifacts / Write Artifact File')
+    expect(html).toContain('Write artifact file?')
+    expect(html).toContain('Artifact storage</span>')
+    expect(html).not.toContain('Use external service?')
     expect(html).not.toContain('write_artifact_file')
     expect(html).not.toContain('mcp.open-science-artifacts')
   })
@@ -209,8 +210,8 @@ describe('PermissionApprovalControls', () => {
       />
     )
 
-    expect(html).toContain('Use external service?')
-    expect(html).toContain('Open Science Artifacts / Write Artifact File')
+    expect(html).toContain('Write artifact file?')
+    expect(html).toContain('Artifact storage</span>')
     expect(html).not.toContain(rawTitle)
     expect(html).not.toContain('Run command?')
   })
@@ -253,12 +254,12 @@ describe('PermissionApprovalControls', () => {
       />
     )
 
-    expect(html).toContain('External service</span>')
-    expect(html).toContain('Open Science Artifacts / Write Artifact File')
+    expect(html).toContain('Artifact storage</span>')
+    expect(html).not.toContain('Open Science Artifacts / Write Artifact File')
     expect(html).toContain('report.md')
   })
 
-  it('shows the title for a non-Bash execute request with no command preview', () => {
+  it('keeps a non-Bash execute title in the impact tip when no command preview exists', () => {
     // A non-Bash execute request whose command lives only in the title: extractPermissionCode
     // has no Bash fallback here, so the title is the only place the command can appear — the
     // generic "Run command?" header must not leave the prompt opaque.
@@ -274,7 +275,8 @@ describe('PermissionApprovalControls', () => {
       <PermissionApprovalControls requests={[executeTitleOnly]} onRespond={() => undefined} />
     )
     expect(html).toContain('Run command?')
-    expect(html).toContain('python scripts/run_pipeline.py --full')
+    expect(html).toContain('data-testid="permission-impact-info"')
+    expect(html).not.toContain('python scripts/run_pipeline.py --full')
   })
 
   it('serializes prompts by rendering only the first pending request', () => {
@@ -285,7 +287,7 @@ describe('PermissionApprovalControls', () => {
       />
     )
 
-    expect(html).toContain(longRequestTitle)
+    expect(html).not.toContain(longRequestTitle)
     expect(html).not.toContain(secondRequestTitle)
   })
 
@@ -490,7 +492,7 @@ describe('PermissionApprovalControls', () => {
     expect(html).toContain('External service</span>')
   })
 
-  it('shows the request title as a detail line when the header hides the target', () => {
+  it('keeps the request title in the impact tip when the header hides the target', () => {
     // Provider "Write" with a target-bearing title and no rawInput: title must remain visible.
     const write: AcpPermissionRequest = {
       requestId: 'wr-1',
@@ -504,10 +506,11 @@ describe('PermissionApprovalControls', () => {
     const html = renderToStaticMarkup(
       <PermissionApprovalControls requests={[write]} onRespond={() => undefined} />
     )
-    expect(html).toContain('Write report.md')
+    expect(html).toContain('data-testid="permission-impact-info"')
+    expect(html).not.toContain('Write report.md')
   })
 
-  it('shows a stable built-in provider name when the title is generic', () => {
+  it('keeps a stable built-in provider name in the impact tip when the title is generic', () => {
     const html = renderToStaticMarkup(
       <PermissionApprovalControls
         requests={[
@@ -523,7 +526,8 @@ describe('PermissionApprovalControls', () => {
     )
 
     expect(html).toContain('Network access</span>')
-    expect(html).toContain('WebFetch')
+    expect(html).toContain('data-testid="permission-impact-info"')
+    expect(html).not.toContain('WebFetch')
   })
 
   it('keeps notebook control details in an impact tooltip without exposing its identifier', () => {

--- a/src/renderer/src/pages/workspace/PermissionApprovalControls.render.test.tsx
+++ b/src/renderer/src/pages/workspace/PermissionApprovalControls.render.test.tsx
@@ -55,13 +55,15 @@ const bashPermissionRequest: AcpPermissionRequest = {
   ]
 }
 
-// Real Claude Code MCP naming: mcp__<server>__<tool>. The dialog must recognize this format.
+// The broker resolves provider-specific MCP names to this stable identity before the dialog sees it.
 const notebookPermissionRequest: AcpPermissionRequest = {
   requestId: 'nb-1',
   sessionId: 'session-1',
   toolCallId: 'tool-nb',
   title: 'mcp__open-science-notebook__notebook_execute',
   providerToolName: 'mcp__open-science-notebook__notebook_execute',
+  isMcp: true,
+  mcpIdentity: 'open-science-notebook/notebook_execute',
   rawInput: { kernelKind: 'python', code: 'import numpy as np\nx = np.linspace(0, 1)' },
   options: [
     { optionId: 'allow-once', name: 'Allow once', kind: 'allow_once' },
@@ -76,6 +78,8 @@ const rNotebookRequest: AcpPermissionRequest = {
   toolCallId: 'tool-nb-r',
   title: 'mcp__open-science-notebook__notebook_execute',
   providerToolName: 'mcp__open-science-notebook__notebook_execute',
+  isMcp: true,
+  mcpIdentity: 'open-science-notebook/notebook_execute',
   rawInput: { code: 'df <- read.csv("x.csv")\nlibrary(ggplot2)' },
   options: [{ optionId: 'allow-once', name: 'Allow once', kind: 'allow_once' }]
 }
@@ -87,6 +91,8 @@ const replRequest: AcpPermissionRequest = {
   toolCallId: 'tool-repl',
   title: 'mcp__open-science-notebook__repl_execute',
   providerToolName: 'mcp__open-science-notebook__repl_execute',
+  isMcp: true,
+  mcpIdentity: 'open-science-notebook/repl_execute',
   rawInput: { code: 'const x = 1' },
   options: [{ optionId: 'allow-once', name: 'Allow once', kind: 'allow_once' }]
 }
@@ -98,6 +104,8 @@ const bashExecuteRequest: AcpPermissionRequest = {
   toolCallId: 'tool-bashx',
   title: 'mcp__open-science-notebook__bash_execute',
   providerToolName: 'mcp__open-science-notebook__bash_execute',
+  isMcp: true,
+  mcpIdentity: 'open-science-notebook/bash_execute',
   rawInput: { command: 'ls' },
   options: [{ optionId: 'allow-once', name: 'Allow once', kind: 'allow_once' }]
 }
@@ -148,7 +156,7 @@ describe('PermissionApprovalControls', () => {
     expect(html).not.toContain(secondRequestTitle)
   })
 
-  it('labels the managed artifact writer as artifact storage instead of command execution', () => {
+  it('labels the managed artifact writer as an artifact save instead of command execution', () => {
     const html = renderToStaticMarkup(
       <PermissionApprovalControls
         requests={[
@@ -157,6 +165,7 @@ describe('PermissionApprovalControls', () => {
             title: 'mcp.open-science-artifacts.write_artifact_file',
             providerToolName: 'write_artifact_file',
             isMcp: true,
+            mcpIdentity: 'open-science-artifacts/write_artifact_file',
             toolKind: 'execute'
           }
         ]}
@@ -164,8 +173,8 @@ describe('PermissionApprovalControls', () => {
       />
     )
 
-    expect(html).toContain('Artifact storage</span>')
-    expect(html).toContain('Write artifact file?')
+    expect(html).toContain('Artifact save</span>')
+    expect(html).toContain('Save as artifact?')
     expect(html).not.toContain('Command execution</span>')
   })
 
@@ -178,6 +187,7 @@ describe('PermissionApprovalControls', () => {
             title: 'mcp.open-science-artifacts.write_artifact_file',
             providerToolName: 'write_artifact_file',
             isMcp: true,
+            mcpIdentity: 'open-science-artifacts/write_artifact_file',
             toolKind: 'execute',
             rawInput: undefined
           }
@@ -186,14 +196,14 @@ describe('PermissionApprovalControls', () => {
       />
     )
 
-    expect(html).toContain('Write artifact file?')
-    expect(html).toContain('Artifact storage</span>')
+    expect(html).toContain('Save as artifact?')
+    expect(html).toContain('Artifact save</span>')
     expect(html).not.toContain('Use external service?')
     expect(html).not.toContain('write_artifact_file')
     expect(html).not.toContain('mcp.open-science-artifacts')
   })
 
-  it('humanizes a raw MCP protocol title even when isMcp is omitted', () => {
+  it('does not treat an unclassified raw MCP title as an artifact save', () => {
     const rawTitle = 'mcp__open-science-artifacts__write_artifact_file'
     const html = renderToStaticMarkup(
       <PermissionApprovalControls
@@ -210,10 +220,9 @@ describe('PermissionApprovalControls', () => {
       />
     )
 
-    expect(html).toContain('Write artifact file?')
-    expect(html).toContain('Artifact storage</span>')
-    expect(html).not.toContain(rawTitle)
-    expect(html).not.toContain('Run command?')
+    expect(html).toContain('Run command?')
+    expect(html).toContain('Command execution</span>')
+    expect(html).not.toContain('Artifact save</span>')
   })
 
   it('keeps MCP execute payloads labeled as external service input', () => {
@@ -225,6 +234,7 @@ describe('PermissionApprovalControls', () => {
             title: 'mcp__runner__execute',
             providerToolName: 'mcp__runner__execute',
             isMcp: true,
+            mcpIdentity: 'runner/execute',
             toolKind: 'execute',
             rawInput: { command: 'export-report --publish' }
           }
@@ -254,7 +264,7 @@ describe('PermissionApprovalControls', () => {
       />
     )
 
-    expect(html).toContain('Artifact storage</span>')
+    expect(html).toContain('Artifact save</span>')
     expect(html).not.toContain('Open Science Artifacts / Write Artifact File')
     expect(html).toContain('report.md')
   })
@@ -368,6 +378,7 @@ describe('PermissionApprovalControls', () => {
       providerToolName: 'notebook_execute',
       toolKind: 'execute',
       isMcp: true,
+      mcpIdentity: 'open-science-notebook/notebook_execute',
       rawInput: { kernelKind: 'python', code: 'print("hi")' },
       options: [{ optionId: 'allow-once', name: 'Allow once', kind: 'allow_once' }]
     }
@@ -392,6 +403,7 @@ describe('PermissionApprovalControls', () => {
       providerToolName: 'open-science-notebook_notebook_execute',
       toolKind: 'execute',
       isMcp: true,
+      mcpIdentity: 'open-science-notebook/notebook_execute',
       rawInput: { kernelKind: 'python', code: 'print("oc")' },
       options: [{ optionId: 'allow-once', name: 'Allow once', kind: 'allow_once' }]
     }
@@ -458,6 +470,7 @@ describe('PermissionApprovalControls', () => {
       title: 'database_execute',
       providerToolName: 'database_execute',
       isMcp: true,
+      mcpIdentity: 'database/execute',
       rawInput: { sql: 'DROP TABLE users' },
       options: [{ optionId: 'allow-once', name: 'Allow once', kind: 'allow_once' }]
     }
@@ -479,6 +492,7 @@ describe('PermissionApprovalControls', () => {
       title: 'mcp__acme-db__notebook_execute',
       providerToolName: 'mcp__acme-db__notebook_execute',
       isMcp: true,
+      mcpIdentity: 'acme-db/notebook_execute',
       rawInput: { target: 'prod', code: 'SELECT 1' },
       options: [{ optionId: 'allow-once', name: 'Allow once', kind: 'allow_once' }]
     }
@@ -530,7 +544,7 @@ describe('PermissionApprovalControls', () => {
     expect(html).not.toContain('WebFetch')
   })
 
-  it('keeps notebook control details in an impact tooltip without exposing its identifier', () => {
+  it('does not classify an untrusted notebook-looking name as notebook control', () => {
     const identifier = 'open_science_notebook_notebook_restart'
     const restart: AcpPermissionRequest = {
       requestId: 'restart-1',
@@ -546,11 +560,33 @@ describe('PermissionApprovalControls', () => {
       <PermissionApprovalControls requests={[restart]} onRespond={() => undefined} />
     )
 
-    expect(html).toContain('Restart notebook?')
-    expect(html).toContain('Notebook control</span>')
-    expect(html).not.toContain('Running processes and unsaved runtime state may be lost.')
+    expect(html).toContain('Allow tool access?')
+    expect(html).toContain('Tool access</span>')
+    expect(html).not.toContain('Restart notebook?')
     expect(html).toContain('data-testid="permission-impact-info"')
     expect(html).toContain('data-testid="permission-tool-info"')
+    expect(html).not.toContain('Notebook control</span>')
+  })
+
+  it('keeps trusted notebook control details in an impact tooltip without exposing its identifier', () => {
+    const identifier = 'mcp__open-science-notebook__notebook_restart'
+    const restart: AcpPermissionRequest = {
+      requestId: 'restart-1',
+      sessionId: 'session-1',
+      toolCallId: 'tool-restart',
+      title: identifier,
+      providerToolName: identifier,
+      isMcp: true,
+      mcpIdentity: 'open-science-notebook/notebook_restart',
+      options: [{ optionId: 'allow-once', name: 'Allow once', kind: 'allow_once' }]
+    }
+
+    const html = renderToStaticMarkup(
+      <PermissionApprovalControls requests={[restart]} onRespond={() => undefined} />
+    )
+
+    expect(html).toContain('Restart notebook?')
+    expect(html).toContain('Notebook control</span>')
     expect(html).not.toContain(identifier)
   })
 

--- a/src/renderer/src/pages/workspace/PermissionApprovalControls.render.test.tsx
+++ b/src/renderer/src/pages/workspace/PermissionApprovalControls.render.test.tsx
@@ -270,7 +270,7 @@ describe('PermissionApprovalControls', () => {
     expect(html).toContain('report.md')
   })
 
-  it('shows a title-only non-MCP execute command in the code preview', () => {
+  it('keeps a title-only non-MCP execute target visible without inventing a command preview', () => {
     const executeTitleOnly: AcpPermissionRequest = {
       requestId: 'exec-title-1',
       sessionId: 'session-1',
@@ -283,9 +283,8 @@ describe('PermissionApprovalControls', () => {
       <PermissionApprovalControls requests={[executeTitleOnly]} onRespond={() => undefined} />
     )
     expect(html).toContain('Run command?')
-    expect(html).toContain('data-testid="tool-code-block"')
+    expect(html).not.toContain('data-testid="tool-code-block"')
     expect(html).toContain('python scripts/run_pipeline.py --full')
-    expect(html).toContain('data-language="bash"')
   })
 
   it('serializes prompts by rendering only the first pending request', () => {
@@ -296,7 +295,7 @@ describe('PermissionApprovalControls', () => {
       />
     )
 
-    expect(html).not.toContain(longRequestTitle)
+    expect(html).toContain(longRequestTitle)
     expect(html).not.toContain(secondRequestTitle)
   })
 
@@ -505,8 +504,7 @@ describe('PermissionApprovalControls', () => {
     expect(html).toContain('External service</span>')
   })
 
-  it('keeps the request title in the impact tip when the header hides the target', () => {
-    // Provider "Write" with a target-bearing title and no rawInput: title must remain visible.
+  it('keeps the request title visible when it is the only file target', () => {
     const write: AcpPermissionRequest = {
       requestId: 'wr-1',
       sessionId: 'session-1',
@@ -520,10 +518,10 @@ describe('PermissionApprovalControls', () => {
       <PermissionApprovalControls requests={[write]} onRespond={() => undefined} />
     )
     expect(html).toContain('data-testid="permission-impact-info"')
-    expect(html).not.toContain('Write report.md')
+    expect(html).toContain('Write report.md')
   })
 
-  it('keeps a stable built-in provider name in the impact tip when the title is generic', () => {
+  it('keeps a stable built-in provider name visible when the title is generic', () => {
     const html = renderToStaticMarkup(
       <PermissionApprovalControls
         requests={[
@@ -540,7 +538,7 @@ describe('PermissionApprovalControls', () => {
 
     expect(html).toContain('Network access</span>')
     expect(html).toContain('data-testid="permission-impact-info"')
-    expect(html).not.toContain('WebFetch')
+    expect(html).toContain('WebFetch')
   })
 
   it('does not classify an untrusted notebook-looking name as notebook control', () => {

--- a/src/renderer/src/pages/workspace/PermissionApprovalControls.render.test.tsx
+++ b/src/renderer/src/pages/workspace/PermissionApprovalControls.render.test.tsx
@@ -255,6 +255,7 @@ describe('PermissionApprovalControls', () => {
             ...permissionRequest,
             title: 'mcp__open-science-artifacts__write_artifact_file',
             isMcp: true,
+            mcpIdentity: 'open-science-artifacts/write_artifact_file',
             toolKind: 'edit',
             toolLocations: [{ path: 'report.md' }],
             rawInput: { value: 'updated' }

--- a/src/renderer/src/pages/workspace/PermissionApprovalControls.render.test.tsx
+++ b/src/renderer/src/pages/workspace/PermissionApprovalControls.render.test.tsx
@@ -148,7 +148,7 @@ describe('PermissionApprovalControls', () => {
     expect(html).not.toContain(secondRequestTitle)
   })
 
-  it('labels non-notebook MCP approvals as MCP instead of command execution', () => {
+  it('labels non-notebook MCP approvals as an external service instead of command execution', () => {
     const html = renderToStaticMarkup(
       <PermissionApprovalControls
         requests={[
@@ -164,14 +164,11 @@ describe('PermissionApprovalControls', () => {
       />
     )
 
-    expect(html).toContain('MCP tool access</span>')
+    expect(html).toContain('External service</span>')
     expect(html).not.toContain('Command execution</span>')
   })
 
-  it('keeps the tool identity visible for execute-kind MCP requests', () => {
-    // An MCP tool reporting kind:'execute' (write_artifact_file) must not collapse into the
-    // generic "Run command?" shell wording — the provider name is the only identity left when
-    // the request carries no previewable command payload.
+  it('hides the protocol identity for execute-kind MCP requests', () => {
     const html = renderToStaticMarkup(
       <PermissionApprovalControls
         requests={[
@@ -188,8 +185,10 @@ describe('PermissionApprovalControls', () => {
       />
     )
 
-    expect(html).toContain('Run write_artifact_file?')
+    expect(html).toContain('Use external service?')
     expect(html).not.toContain('Run command?')
+    expect(html).not.toContain('write_artifact_file')
+    expect(html).not.toContain('mcp.open-science-artifacts')
   })
 
   it('shows the title for a non-Bash execute request with no command preview', () => {
@@ -344,31 +343,32 @@ describe('PermissionApprovalControls', () => {
         onRespond={() => undefined}
       />
     )
-    expect(html).toContain('data-testid="permission-language-badge"')
+    expect(html).toContain('data-testid="permission-category-badge"')
     expect(html).toContain('data-testid="permission-tool-info"')
-    expect(html).not.toContain('MCP tool access</span>')
+    expect(html).toContain('Python execution</span>')
+    expect(html).not.toContain('External service</span>')
   })
 
-  it('shows the kernel language badge for notebook prompts, matching the code highlight', () => {
+  it('shows a distinct execution category for each notebook runtime', () => {
     const pythonHtml = renderToStaticMarkup(
       <PermissionApprovalControls
         requests={[notebookPermissionRequest]}
         onRespond={() => undefined}
       />
     )
-    expect(pythonHtml).toContain('>python</span>')
+    expect(pythonHtml).toContain('>Python execution</span>')
 
     // The badge follows the inferred code language even without an explicit kernel field.
     const rHtml = renderToStaticMarkup(
       <PermissionApprovalControls requests={[rNotebookRequest]} onRespond={() => undefined} />
     )
-    expect(rHtml).toContain('>r</span>')
+    expect(rHtml).toContain('>R execution</span>')
 
     // repl_execute pins JavaScript even though its code looks generic.
     const replHtml = renderToStaticMarkup(
       <PermissionApprovalControls requests={[replRequest]} onRespond={() => undefined} />
     )
-    expect(replHtml).toContain('>javascript</span>')
+    expect(replHtml).toContain('>JS REPL</span>')
   })
 
   it('renders no code block when rawInput is absent', () => {
@@ -419,7 +419,7 @@ describe('PermissionApprovalControls', () => {
     expect(html).toContain('data-language="json"')
     expect(html).toContain('prod')
     expect(html).not.toContain('Run notebook cell')
-    expect(html).not.toContain('Notebook execution</span>')
+    expect(html).toContain('External service</span>')
   })
 
   it('shows the request title as a detail line when the header hides the target', () => {
@@ -437,6 +437,29 @@ describe('PermissionApprovalControls', () => {
       <PermissionApprovalControls requests={[write]} onRespond={() => undefined} />
     )
     expect(html).toContain('Write report.md')
+  })
+
+  it('shows notebook control impact without exposing the MCP identifier', () => {
+    const identifier = 'mcp__open-science-notebook__notebook_restart'
+    const restart: AcpPermissionRequest = {
+      requestId: 'restart-1',
+      sessionId: 'session-1',
+      toolCallId: 'tool-restart',
+      title: identifier,
+      providerToolName: identifier,
+      isMcp: true,
+      options: [{ optionId: 'allow-once', name: 'Allow once', kind: 'allow_once' }]
+    }
+
+    const html = renderToStaticMarkup(
+      <PermissionApprovalControls requests={[restart]} onRespond={() => undefined} />
+    )
+
+    expect(html).toContain('Restart notebook?')
+    expect(html).toContain('Notebook control</span>')
+    expect(html).toContain('Running processes and unsaved runtime state may be lost.')
+    expect(html).toContain('data-testid="permission-tool-info"')
+    expect(html).not.toContain(identifier)
   })
 
   it('surfaces a non-canonical option kind as its own labeled button', () => {

--- a/src/renderer/src/pages/workspace/PermissionApprovalControls.render.test.tsx
+++ b/src/renderer/src/pages/workspace/PermissionApprovalControls.render.test.tsx
@@ -270,10 +270,7 @@ describe('PermissionApprovalControls', () => {
     expect(html).toContain('report.md')
   })
 
-  it('keeps a non-Bash execute title in the impact tip when no command preview exists', () => {
-    // A non-Bash execute request whose command lives only in the title: extractPermissionCode
-    // has no Bash fallback here, so the title is the only place the command can appear — the
-    // generic "Run command?" header must not leave the prompt opaque.
+  it('shows a title-only non-MCP execute command in the code preview', () => {
     const executeTitleOnly: AcpPermissionRequest = {
       requestId: 'exec-title-1',
       sessionId: 'session-1',
@@ -286,8 +283,9 @@ describe('PermissionApprovalControls', () => {
       <PermissionApprovalControls requests={[executeTitleOnly]} onRespond={() => undefined} />
     )
     expect(html).toContain('Run command?')
-    expect(html).toContain('data-testid="permission-impact-info"')
-    expect(html).not.toContain('python scripts/run_pipeline.py --full')
+    expect(html).toContain('data-testid="tool-code-block"')
+    expect(html).toContain('python scripts/run_pipeline.py --full')
+    expect(html).toContain('data-language="bash"')
   })
 
   it('serializes prompts by rendering only the first pending request', () => {

--- a/src/renderer/src/pages/workspace/PermissionApprovalControls.render.test.tsx
+++ b/src/renderer/src/pages/workspace/PermissionApprovalControls.render.test.tsx
@@ -192,7 +192,7 @@ describe('PermissionApprovalControls', () => {
     expect(html).not.toContain('mcp.open-science-artifacts')
   })
 
-  it('keeps a humanized MCP action beside reviewable paths or arguments', () => {
+  it('keeps an MCP request external while showing its humanized action and paths', () => {
     const html = renderToStaticMarkup(
       <PermissionApprovalControls
         requests={[
@@ -209,7 +209,7 @@ describe('PermissionApprovalControls', () => {
       />
     )
 
-    expect(html).toContain('File access</span>')
+    expect(html).toContain('External service</span>')
     expect(html).toContain('Open Science Artifacts / Write Artifact File')
     expect(html).toContain('report.md')
   })

--- a/src/renderer/src/pages/workspace/PermissionApprovalControls.render.test.tsx
+++ b/src/renderer/src/pages/workspace/PermissionApprovalControls.render.test.tsx
@@ -502,7 +502,7 @@ describe('PermissionApprovalControls', () => {
     expect(html).toContain('WebFetch')
   })
 
-  it('shows notebook control impact without exposing the MCP identifier', () => {
+  it('keeps notebook control details in the information tooltip without exposing its identifier', () => {
     const identifier = 'open_science_notebook_notebook_restart'
     const restart: AcpPermissionRequest = {
       requestId: 'restart-1',
@@ -520,7 +520,7 @@ describe('PermissionApprovalControls', () => {
 
     expect(html).toContain('Restart notebook?')
     expect(html).toContain('Notebook control</span>')
-    expect(html).toContain('Running processes and unsaved runtime state may be lost.')
+    expect(html).not.toContain('Running processes and unsaved runtime state may be lost.')
     expect(html).toContain('data-testid="permission-tool-info"')
     expect(html).not.toContain(identifier)
   })

--- a/src/renderer/src/pages/workspace/PermissionApprovalControls.render.test.tsx
+++ b/src/renderer/src/pages/workspace/PermissionApprovalControls.render.test.tsx
@@ -192,6 +192,27 @@ describe('PermissionApprovalControls', () => {
     expect(html).not.toContain('mcp.open-science-artifacts')
   })
 
+  it('keeps MCP execute payloads labeled as external service input', () => {
+    const html = renderToStaticMarkup(
+      <PermissionApprovalControls
+        requests={[
+          {
+            ...permissionRequest,
+            title: 'mcp__runner__execute',
+            providerToolName: 'mcp__runner__execute',
+            isMcp: true,
+            toolKind: 'execute',
+            rawInput: { command: 'export-report --publish' }
+          }
+        ]}
+        onRespond={() => undefined}
+      />
+    )
+
+    expect(html).toContain('External service input')
+    expect(html).not.toContain('Run command')
+  })
+
   it('keeps an MCP request external while showing its humanized action and paths', () => {
     const html = renderToStaticMarkup(
       <PermissionApprovalControls
@@ -482,14 +503,14 @@ describe('PermissionApprovalControls', () => {
   })
 
   it('shows notebook control impact without exposing the MCP identifier', () => {
-    const identifier = 'mcp__open-science-notebook__notebook_restart'
+    const identifier = 'open_science_notebook_notebook_restart'
     const restart: AcpPermissionRequest = {
       requestId: 'restart-1',
       sessionId: 'session-1',
       toolCallId: 'tool-restart',
       title: identifier,
       providerToolName: identifier,
-      isMcp: true,
+      isMcp: false,
       options: [{ optionId: 'allow-once', name: 'Allow once', kind: 'allow_once' }]
     }
 

--- a/src/renderer/src/pages/workspace/PermissionApprovalControls.tsx
+++ b/src/renderer/src/pages/workspace/PermissionApprovalControls.tsx
@@ -308,19 +308,35 @@ const useNotebookEnvironment = (
   return kernelKind ? envName : undefined
 }
 
+const PermissionImpactTip = ({ description }: { description: string }): React.JSX.Element => (
+  <TooltipProvider delayDuration={200}>
+    <Tooltip>
+      <TooltipTrigger asChild>
+        <button
+          type="button"
+          aria-label="Permission impact information"
+          data-testid="permission-impact-info"
+          className="flex size-5 shrink-0 items-center justify-center rounded-md text-muted-foreground transition-colors hover:bg-muted hover:text-foreground"
+        >
+          <Info className="size-3.5" aria-hidden="true" />
+        </button>
+      </TooltipTrigger>
+      <TooltipContent className="max-w-none whitespace-nowrap">{description}</TooltipContent>
+    </Tooltip>
+  </TooltipProvider>
+)
+
 // Header cluster for permission prompts: a user-facing category, an available notebook environment,
-// and the existing information affordance.
+// and the authorization-scope information affordance.
 const PermissionHeaderBadges = ({
   lookup,
   runtime,
   categoryLabel,
-  description,
   scopeDescription
 }: {
   lookup: NotebookSessionRequest | undefined
   runtime?: NotebookRuntime
   categoryLabel: string
-  description: string
   scopeDescription: string
 }): React.JSX.Element => {
   const kernelKind = runtime === 'python' ? 'python' : runtime === 'r' ? 'r' : undefined
@@ -349,10 +365,7 @@ const PermissionHeaderBadges = ({
             </button>
           </TooltipTrigger>
           <TooltipContent className="max-w-none whitespace-nowrap">
-            <div className="space-y-1">
-              <p>{description}</p>
-              <p className="text-muted-foreground">{scopeDescription}</p>
-            </div>
+            {scopeDescription}
           </TooltipContent>
         </Tooltip>
       </TooltipProvider>
@@ -567,14 +580,16 @@ const PermissionApprovalControls = ({
     <div className="mb-2 flex w-full max-w-full flex-col gap-3 rounded-xl border border-border bg-card p-5 text-xs leading-5 text-card-foreground shadow-dialog outline-none motion-safe:animate-in motion-safe:fade-in-0 motion-safe:slide-in-from-bottom-1 motion-safe:duration-200">
       {/* Header: plain-language action plus its classification and notebook context. */}
       <div className="flex min-w-0 items-center gap-2">
-        <span className={cn(dialogTitleClassName, 'min-w-0 truncate')}>
-          {presentation.actionTitle}
-        </span>
+        <div className="flex min-w-0 items-center gap-1.5">
+          <span className={cn(dialogTitleClassName, 'min-w-0 truncate')}>
+            {presentation.actionTitle}
+          </span>
+          <PermissionImpactTip description={presentation.description} />
+        </div>
         <PermissionHeaderBadges
           lookup={notebookLookup}
           runtime={presentation.notebookRuntime}
           categoryLabel={presentation.categoryLabel}
-          description={presentation.description}
           scopeDescription={scopeDescription}
         />
       </div>

--- a/src/renderer/src/pages/workspace/PermissionApprovalControls.tsx
+++ b/src/renderer/src/pages/workspace/PermissionApprovalControls.tsx
@@ -12,6 +12,7 @@ import { cn } from '@/lib/utils'
 import { resolveNotebookLanguage, resolveNotebookRunToolName } from './notebook-tool-names'
 import {
   describePermissionRequest,
+  isArtifactWriteRequest,
   isMcpPermissionRequest,
   type NotebookRuntime
 } from './permission-request-presentation'
@@ -193,6 +194,7 @@ const extractPermissionCode = (request: AcpPermissionRequest): PermissionCode | 
 // A friendly action title for the code card header, matching the transcript's activity phrasing.
 const getPermissionActionTitle = (request: AcpPermissionRequest, fallback: string): string => {
   if (resolveNotebookToolName(request)) return 'Run notebook cell'
+  if (isArtifactWriteRequest(request)) return 'Artifact file input'
   if (isMcpPermissionRequest(request)) return 'External service input'
   if (request.toolKind === 'execute' || request.providerToolName === 'Bash') return 'Run command'
   return fallback
@@ -313,7 +315,13 @@ const useNotebookEnvironment = (
   return environment.name
 }
 
-const PermissionImpactTip = ({ description }: { description: string }): React.JSX.Element => (
+const PermissionImpactTip = ({
+  description,
+  detail
+}: {
+  description: string
+  detail?: string
+}): React.JSX.Element => (
   <TooltipProvider delayDuration={200}>
     <Tooltip>
       <TooltipTrigger asChild>
@@ -326,7 +334,12 @@ const PermissionImpactTip = ({ description }: { description: string }): React.JS
           <Info className="size-3.5" aria-hidden="true" />
         </button>
       </TooltipTrigger>
-      <TooltipContent className="max-w-none whitespace-nowrap">{description}</TooltipContent>
+      <TooltipContent className="max-w-none whitespace-nowrap">
+        <div className="space-y-1">
+          {detail ? <p>{detail}</p> : null}
+          <p className={detail ? 'text-muted-foreground' : undefined}>{description}</p>
+        </div>
+      </TooltipContent>
     </Tooltip>
   </TooltipProvider>
 )
@@ -564,8 +577,7 @@ const PermissionApprovalControls = ({
   const isMcp = isMcpPermissionRequest(request)
   const isShell = !isMcp && (request.toolKind === 'execute' || request.providerToolName === 'Bash')
 
-  // MCP action context stays visible alongside any code, arguments, or locations without exposing
-  // the provider's raw protocol spelling. Files, commands, and other native tools retain their target.
+  // Identity details are retained in the impact tip rather than consuming a line above the preview.
   const headerName = request.providerToolName ?? request.title
   const titleDetail = ((): string | undefined => {
     if (presentation.hideToolIdentity) return undefined
@@ -588,7 +600,7 @@ const PermissionApprovalControls = ({
           <span className={cn(dialogTitleClassName, 'min-w-0 truncate')}>
             {presentation.actionTitle}
           </span>
-          <PermissionImpactTip description={presentation.description} />
+          <PermissionImpactTip description={presentation.description} detail={titleDetail} />
         </div>
         <PermissionHeaderBadges
           lookup={notebookLookup}
@@ -597,11 +609,6 @@ const PermissionApprovalControls = ({
           scopeDescription={scopeDescription}
         />
       </div>
-
-      {/* Full request title (the target being authorized) when the header alone doesn't show it. */}
-      {titleDetail ? (
-        <div className="break-all text-xs text-muted-foreground">{titleDetail}</div>
-      ) : null}
 
       {/* Affected file targets — the canonical location field, shown so read/edit/delete
           prompts always reveal the path being authorized. Wraps to keep full values readable. */}

--- a/src/renderer/src/pages/workspace/PermissionApprovalControls.tsx
+++ b/src/renderer/src/pages/workspace/PermissionApprovalControls.tsx
@@ -187,10 +187,10 @@ const extractPermissionCode = (request: AcpPermissionRequest): PermissionCode | 
 }
 
 // A friendly action title for the code card header, matching the transcript's activity phrasing.
-const getPermissionActionTitle = (request: AcpPermissionRequest): string => {
+const getPermissionActionTitle = (request: AcpPermissionRequest, fallback: string): string => {
   if (resolveNotebookToolName(request)) return 'Run notebook cell'
   if (request.toolKind === 'execute' || request.providerToolName === 'Bash') return 'Run command'
-  return request.providerToolName ?? request.title
+  return fallback
 }
 
 // Activity-style collapsible card that shows the code about to run, defaulting to expanded.
@@ -539,14 +539,14 @@ const PermissionApprovalControls = ({
   const headerName = request.providerToolName ?? request.title
   const titleDetail = ((): string | undefined => {
     if (request.isMcp) {
-      return !permCode && !request.toolLocations?.length ? presentation.actionDetail : undefined
+      return presentation.actionDetail
     }
     if (!request.title || request.title === permCode?.code) return undefined
     if (!request.providerToolName) return request.title
     if (isShell) {
       return !permCode && request.title !== request.providerToolName ? request.title : undefined
     }
-    return request.title !== headerName ? request.title : undefined
+    return request.title !== headerName ? request.title : request.providerToolName
   })()
 
   return (
@@ -586,7 +586,10 @@ const PermissionApprovalControls = ({
       {permCode && (
         <PermissionCodeSection
           key={requestId}
-          title={getPermissionActionTitle(request)}
+          title={getPermissionActionTitle(
+            request,
+            presentation.actionDetail ?? presentation.actionTitle
+          )}
           code={permCode.code}
           language={permCode.language}
         />

--- a/src/renderer/src/pages/workspace/PermissionApprovalControls.tsx
+++ b/src/renderer/src/pages/workspace/PermissionApprovalControls.tsx
@@ -312,12 +312,12 @@ const PermissionHeaderBadges = ({
   lookup,
   runtime,
   categoryLabel,
-  description
+  scopeDescription
 }: {
   lookup: NotebookSessionRequest | undefined
   runtime?: NotebookRuntime
   categoryLabel: string
-  description: string
+  scopeDescription: string
 }): React.JSX.Element => {
   const kernelKind = runtime === 'python' ? 'python' : runtime === 'r' ? 'r' : undefined
   const envName = useNotebookEnvironment(lookup, kernelKind)
@@ -344,7 +344,9 @@ const PermissionHeaderBadges = ({
               <Info className="size-3.5" aria-hidden="true" />
             </button>
           </TooltipTrigger>
-          <TooltipContent className="max-w-72 whitespace-normal">{description}</TooltipContent>
+          <TooltipContent className="max-w-72 whitespace-normal">
+            {scopeDescription}
+          </TooltipContent>
         </Tooltip>
       </TooltipProvider>
     </span>
@@ -497,6 +499,12 @@ const PermissionApprovalControls = ({
   const allowOptionId = getAllowOptionId(request.options, effectiveScope)
   const denyOptionId = getDenyOptionId(request.options)
   const scopeLabel = effectiveScope === 'once' ? 'once' : 'for this conversation'
+  const scopeDescription =
+    !allowOptionId
+      ? 'No approval scope is available for this request.'
+      : effectiveScope === 'once'
+      ? 'Approval applies to this call only.'
+      : 'Approval applies until this conversation ends.'
   const hasScopePicker = availableScopes.size > 1
   const isSubmitting = submittingRequestId === request.requestId
   const respondOnce = (optionId?: string): void => {
@@ -533,9 +541,8 @@ const PermissionApprovalControls = ({
     request.isMcp !== true &&
     (request.toolKind === 'execute' || request.providerToolName === 'Bash')
 
-  // MCP identifiers are only needed when the request has no code, arguments, or locations to review.
-  // In that case, the presentation layer supplies a humanized service/action label rather than the
-  // provider's raw protocol spelling. Files, commands, and other native tools retain their target.
+  // MCP action context stays visible alongside any code, arguments, or locations without exposing
+  // the provider's raw protocol spelling. Files, commands, and other native tools retain their target.
   const headerName = request.providerToolName ?? request.title
   const titleDetail = ((): string | undefined => {
     if (request.isMcp) {
@@ -560,7 +567,7 @@ const PermissionApprovalControls = ({
           lookup={notebookLookup}
           runtime={presentation.notebookRuntime}
           categoryLabel={presentation.categoryLabel}
-          description={presentation.description}
+          scopeDescription={scopeDescription}
         />
       </div>
 

--- a/src/renderer/src/pages/workspace/PermissionApprovalControls.tsx
+++ b/src/renderer/src/pages/workspace/PermissionApprovalControls.tsx
@@ -10,6 +10,7 @@ import { dialogTitleClassName } from '@/components/ui/dialog-chrome'
 import { Tooltip, TooltipContent, TooltipProvider, TooltipTrigger } from '@/components/ui/tooltip'
 import { cn } from '@/lib/utils'
 import { resolveNotebookLanguage, resolveNotebookRunToolName } from './notebook-tool-names'
+import { describePermissionRequest, type NotebookRuntime } from './permission-request-presentation'
 import { WorkspaceToolCodeBlock } from './WorkspaceToolCodeBlock'
 
 type PermissionApprovalControlsProps = {
@@ -233,30 +234,6 @@ const PermissionCodeSection = ({
   )
 }
 
-const getPermissionRiskLabel = (request: AcpPermissionRequest): string => {
-  // Route via the shared identity check (both fields) so the badge agrees with the code-card
-  // header for real requests — the server segment may live only in the namespaced title while
-  // providerToolName carries the bare leaf name.
-  if (resolveNotebookToolName(request)) return 'Notebook execution'
-  if (request.isMcp) return 'MCP tool access'
-
-  switch (request.toolKind) {
-    case 'execute':
-      return 'Command execution'
-    case 'edit':
-    case 'delete':
-    case 'move':
-      return 'File change'
-    case 'fetch':
-      return 'Network access'
-    case 'read':
-    case 'search':
-      return 'File access'
-    default:
-      return 'Tool access'
-  }
-}
-
 // Per-session env-name lookups, cached so every prompt in the same chat reuses a single read.
 // Keyed by sessionId + kernel kind so a python badge and an R badge never share a stale answer.
 const notebookEnvCache = new Map<string, Promise<string | undefined>>()
@@ -329,52 +306,47 @@ const useNotebookEnvironment = (
   return kernelKind ? envName : undefined
 }
 
-// Header cluster for notebook prompts: kernel-language badge, the session's bound environment
-// (once the runtime has spawned or recorded one), and an info tooltip explaining where the code
-// runs and what an approval covers, phrased for the current kernel language.
-const NotebookHeaderBadges = ({
+// Header cluster for permission prompts: a user-facing category, an available notebook environment,
+// and the existing information affordance.
+const PermissionHeaderBadges = ({
   lookup,
-  language,
-  rawIdentity
+  runtime,
+  categoryLabel,
+  description
 }: {
   lookup: NotebookSessionRequest | undefined
-  language: string
-  rawIdentity: string | undefined
+  runtime?: NotebookRuntime
+  categoryLabel: string
+  description: string
 }): React.JSX.Element => {
-  const kernelKind = language === 'python' ? 'python' : language === 'r' ? 'r' : undefined
+  const kernelKind = runtime === 'python' ? 'python' : runtime === 'r' ? 'r' : undefined
   const envName = useNotebookEnvironment(lookup, kernelKind)
-  // Display form for the tooltip sentence: javascript/r read better capitalized.
-  const languageLabel = language === 'javascript' ? 'JavaScript' : language === 'r' ? 'R' : language
 
   return (
     <span className="ml-auto flex shrink-0 items-center gap-1.5">
-      <Badge variant="secondary" data-testid="permission-language-badge">
-        {language}
+      <Badge variant="secondary" data-testid="permission-category-badge">
+        {categoryLabel}
       </Badge>
       {envName ? (
         <Badge variant="secondary" data-testid="permission-env-badge">
           {envName}
         </Badge>
       ) : null}
-      {rawIdentity ? (
-        <TooltipProvider delayDuration={200}>
-          <Tooltip>
-            <TooltipTrigger asChild>
-              <button
-                type="button"
-                aria-label="Tool details"
-                data-testid="permission-tool-info"
-                className="flex size-5 items-center justify-center rounded-md text-muted-foreground transition-colors hover:bg-muted hover:text-foreground"
-              >
-                <Info className="size-3.5" aria-hidden="true" />
-              </button>
-            </TooltipTrigger>
-            <TooltipContent className="max-w-72 whitespace-normal">
-              {`Runs in this session's notebook environment${envName ? ` (${envName})` : ''}. Grants cover any ${languageLabel} call until this chat ends.`}
-            </TooltipContent>
-          </Tooltip>
-        </TooltipProvider>
-      ) : null}
+      <TooltipProvider delayDuration={200}>
+        <Tooltip>
+          <TooltipTrigger asChild>
+            <button
+              type="button"
+              aria-label="Permission information"
+              data-testid="permission-tool-info"
+              className="flex size-5 items-center justify-center rounded-md text-muted-foreground transition-colors hover:bg-muted hover:text-foreground"
+            >
+              <Info className="size-3.5" aria-hidden="true" />
+            </button>
+          </TooltipTrigger>
+          <TooltipContent className="max-w-72 whitespace-normal">{description}</TooltipContent>
+        </Tooltip>
+      </TooltipProvider>
     </span>
   )
 }
@@ -521,6 +493,7 @@ const PermissionApprovalControls = ({
   // Guard against a stale scope no longer offered by the current request.
   const effectiveScope = availableScopes.has(scope) ? scope : defaultScope
   const permCode = extractPermissionCode(request)
+  const presentation = describePermissionRequest(request)
   const allowOptionId = getAllowOptionId(request.options, effectiveScope)
   const denyOptionId = getDenyOptionId(request.options)
   const scopeLabel = effectiveScope === 'once' ? 'once' : 'for this conversation'
@@ -556,64 +529,38 @@ const PermissionApprovalControls = ({
     denyOptionId
   )
 
-  // Header asks a friendly action question; raw tool identifiers (namespaced MCP names like
-  // mcp__open-science-notebook__notebook_execute) are illegible in a sentence, so notebook and
-  // shell runs get plain-language phrasing. The provider name only heads the prompt for other
-  // tools, where it is typically a short readable name (Write, Edit). MCP requests are never
-  // collapsed into the shell wording: the broker preserves MCP identity even for kind:'execute'
-  // tools (e.g. open-science-artifacts_write_artifact_file), and the provider/title is the only
-  // place that identity stays visible when there is no code preview.
-  const notebookToolName = resolveNotebookToolName(request)
-  const isNotebook = notebookToolName !== undefined
   const isShell =
     request.isMcp !== true &&
     (request.toolKind === 'execute' || request.providerToolName === 'Bash')
-  const headerTitle = isNotebook
-    ? 'Run notebook code?'
-    : isShell
-      ? 'Run command?'
-      : `Run ${request.providerToolName ?? request.title}?`
 
-  // The title often carries the actual target (e.g. provider "Write" with title
-  // "Write report.md"). Surface it as a detail line when it adds information the header
-  // doesn't, and isn't already shown verbatim by the code card. Skipped for notebook
-  // prompts: there the title is just the tool identifier. For shell prompts the header is
-  // generic ("Run command?"), so when no code preview renders the command — e.g. a non-Bash
-  // execute request whose command lives only in the title — the title must stay visible,
-  // otherwise the user approves an opaque execution request.
+  // MCP titles are protocol identifiers, not user-facing details. Files, commands, and other
+  // native tools retain their target-bearing title when the code/path preview does not already show it.
   const headerName = request.providerToolName ?? request.title
   const titleDetail = ((): string | undefined => {
-    if (isNotebook || !request.title || request.title === permCode?.code) return undefined
+    if (request.isMcp || !request.title || request.title === permCode?.code) return undefined
+    if (!request.providerToolName) return request.title
     if (isShell) {
       return !permCode && request.title !== request.providerToolName ? request.title : undefined
     }
     return request.title !== headerName ? request.title : undefined
   })()
 
-  // Kernel language for the notebook header badge: the code preview's language when there is one,
-  // otherwise resolved from the tool identity alone (repl/bash suffixes, python default), so the
-  // badge always agrees with what the code block would highlight.
-  const permLanguage = notebookToolName
-    ? (permCode?.language ?? resolveNotebookLanguage(notebookToolName, undefined, undefined))
-    : undefined
-
   return (
     <div className="mb-2 flex w-full max-w-full flex-col gap-4 rounded-xl border border-border bg-card p-5 text-xs leading-5 text-card-foreground shadow-dialog outline-none motion-safe:animate-in motion-safe:fade-in-0 motion-safe:slide-in-from-bottom-1 motion-safe:duration-200">
-      {/* Header: action question + risk label (notebook prompts get language/env badges + tooltip) */}
+      {/* Header: plain-language action plus its classification and notebook context. */}
       <div className="flex min-w-0 items-center gap-2">
-        <span className={cn(dialogTitleClassName, 'min-w-0 truncate')}>{headerTitle}</span>
-        {notebookToolName && permLanguage ? (
-          <NotebookHeaderBadges
-            lookup={notebookLookup}
-            language={permLanguage}
-            rawIdentity={request.providerToolName ?? request.title}
-          />
-        ) : (
-          <Badge variant="secondary" className="ml-auto">
-            {getPermissionRiskLabel(request)}
-          </Badge>
-        )}
+        <span className={cn(dialogTitleClassName, 'min-w-0 truncate')}>
+          {presentation.actionTitle}
+        </span>
+        <PermissionHeaderBadges
+          lookup={notebookLookup}
+          runtime={presentation.notebookRuntime}
+          categoryLabel={presentation.categoryLabel}
+          description={presentation.description}
+        />
       </div>
+
+      <p className="text-xs text-muted-foreground">{presentation.description}</p>
 
       {/* Full request title (the target being authorized) when the header alone doesn't show it. */}
       {titleDetail ? (

--- a/src/renderer/src/pages/workspace/PermissionApprovalControls.tsx
+++ b/src/renderer/src/pages/workspace/PermissionApprovalControls.tsx
@@ -239,9 +239,9 @@ const PermissionCodeSection = ({
 // Keyed by sessionId + kernel kind so a python badge and an R badge never share a stale answer.
 const notebookEnvCache = new Map<string, Promise<string | undefined>>()
 
-// Resolves the environment a session's notebook kernels run in, best-known first: the live kernel
-// matching the requested kind, then any live env, then the most recent run's recorded env, and
-// finally the enabled runtime from Settings → Runtimes (what a kernel started now would bind).
+// Resolves the environment a session's notebook kernel of the requested kind runs in, best-known
+// first: the matching live kernel, then the latest matching run, and finally the enabled runtime
+// from Settings → Runtimes (what a kernel of that kind started now would bind).
 // Sessions with no notebook history and no bridge (tests) resolve to undefined — no badge.
 const lookupNotebookEnvironment = async (
   request: NotebookSessionRequest,
@@ -251,12 +251,13 @@ const lookupNotebookEnvironment = async (
   if (notebookApi) {
     try {
       const state = await notebookApi.state(request)
-      const live =
-        state.environments.find((e) => e.kind === kernelKind && e.environment)?.environment ??
-        state.environments.find((e) => e.environment)?.environment
+      const live = state.environments.find(
+        (environment) => environment.kind === kernelKind && environment.environment
+      )?.environment
       if (live) return live
       for (let i = state.runs.length - 1; i >= 0; i -= 1) {
-        const env = state.runs[i].environment
+        const run = state.runs[i]
+        const env = run.kernelKind === kernelKind ? run.environment : undefined
         if (env) return env
       }
     } catch {

--- a/src/renderer/src/pages/workspace/PermissionApprovalControls.tsx
+++ b/src/renderer/src/pages/workspace/PermissionApprovalControls.tsx
@@ -168,13 +168,13 @@ const extractPermissionCode = (request: AcpPermissionRequest): PermissionCode | 
     return undefined
   }
 
-  // Shell execute: prefer the structured command field (verbatim), but for a broker-classified
-  // non-MCP execute request also fall back to its title so the exact command remains reviewable.
+  // Shell execute: prefer the structured command field (verbatim), then use the title only for
+  // the known Bash provider. Other execute titles can be generic labels, not concrete commands.
   // MCP execute inputs are arbitrary tool arguments and must not be reinterpreted as local shell.
   if (isExecute) {
     const cmd = rawInput.command
     if (typeof cmd === 'string' && cmd.trim()) return { code: cmd, language: 'bash' }
-    if (!isMcpPermissionRequest(request) && request.title?.trim()) {
+    if (request.providerToolName === 'Bash' && request.title?.trim()) {
       return { code: request.title, language: 'bash' }
     }
   }
@@ -584,7 +584,8 @@ const PermissionApprovalControls = ({
   const isMcp = isMcpPermissionRequest(request)
   const isShell = !isMcp && (request.toolKind === 'execute' || request.providerToolName === 'Bash')
 
-  // Identity details are retained in the impact tip rather than consuming a line above the preview.
+  // Most identity details stay in the impact tip. When no path or preview exists, retain the only
+  // actionable target inline so the approval is reviewable without relying on hover.
   const headerName = request.providerToolName ?? request.title
   const titleDetail = ((): string | undefined => {
     if (presentation.hideToolIdentity) return undefined
@@ -598,6 +599,8 @@ const PermissionApprovalControls = ({
     }
     return request.title !== headerName ? request.title : request.providerToolName
   })()
+  const showInlineDetail =
+    !isMcp && Boolean(titleDetail) && !permCode && !request.toolLocations?.length
 
   return (
     <div className="mb-2 flex w-full max-w-full flex-col gap-3 rounded-xl border border-border bg-card p-5 text-xs leading-5 text-card-foreground shadow-dialog outline-none motion-safe:animate-in motion-safe:fade-in-0 motion-safe:slide-in-from-bottom-1 motion-safe:duration-200">
@@ -625,6 +628,10 @@ const PermissionApprovalControls = ({
             <span key={location.path}>{location.path}</span>
           ))}
         </div>
+      ) : null}
+
+      {showInlineDetail ? (
+        <p className="break-all text-xs text-muted-foreground">{titleDetail}</p>
       ) : null}
 
       {/* Activity-style card showing the code that will run.

--- a/src/renderer/src/pages/workspace/PermissionApprovalControls.tsx
+++ b/src/renderer/src/pages/workspace/PermissionApprovalControls.tsx
@@ -313,11 +313,13 @@ const PermissionHeaderBadges = ({
   lookup,
   runtime,
   categoryLabel,
+  description,
   scopeDescription
 }: {
   lookup: NotebookSessionRequest | undefined
   runtime?: NotebookRuntime
   categoryLabel: string
+  description: string
   scopeDescription: string
 }): React.JSX.Element => {
   const kernelKind = runtime === 'python' ? 'python' : runtime === 'r' ? 'r' : undefined
@@ -345,7 +347,12 @@ const PermissionHeaderBadges = ({
               <Info className="size-3.5" aria-hidden="true" />
             </button>
           </TooltipTrigger>
-          <TooltipContent className="max-w-72 whitespace-normal">{scopeDescription}</TooltipContent>
+          <TooltipContent className="max-w-72 whitespace-normal">
+            <div className="space-y-1">
+              <p>{description}</p>
+              <p className="text-muted-foreground">{scopeDescription}</p>
+            </div>
+          </TooltipContent>
         </Tooltip>
       </TooltipProvider>
     </span>
@@ -556,7 +563,7 @@ const PermissionApprovalControls = ({
   })()
 
   return (
-    <div className="mb-2 flex w-full max-w-full flex-col gap-4 rounded-xl border border-border bg-card p-5 text-xs leading-5 text-card-foreground shadow-dialog outline-none motion-safe:animate-in motion-safe:fade-in-0 motion-safe:slide-in-from-bottom-1 motion-safe:duration-200">
+    <div className="mb-2 flex w-full max-w-full flex-col gap-3 rounded-xl border border-border bg-card p-5 text-xs leading-5 text-card-foreground shadow-dialog outline-none motion-safe:animate-in motion-safe:fade-in-0 motion-safe:slide-in-from-bottom-1 motion-safe:duration-200">
       {/* Header: plain-language action plus its classification and notebook context. */}
       <div className="flex min-w-0 items-center gap-2">
         <span className={cn(dialogTitleClassName, 'min-w-0 truncate')}>
@@ -566,11 +573,10 @@ const PermissionApprovalControls = ({
           lookup={notebookLookup}
           runtime={presentation.notebookRuntime}
           categoryLabel={presentation.categoryLabel}
+          description={presentation.description}
           scopeDescription={scopeDescription}
         />
       </div>
-
-      <p className="text-xs text-muted-foreground">{presentation.description}</p>
 
       {/* Full request title (the target being authorized) when the header alone doesn't show it. */}
       {titleDetail ? (

--- a/src/renderer/src/pages/workspace/PermissionApprovalControls.tsx
+++ b/src/renderer/src/pages/workspace/PermissionApprovalControls.tsx
@@ -285,27 +285,28 @@ const useNotebookEnvironment = (
   lookup: NotebookSessionRequest | undefined,
   kernelKind: 'python' | 'r' | undefined
 ): string | undefined => {
-  const [envName, setEnvName] = useState<string | undefined>()
+  const [environment, setEnvironment] = useState<{ key: string; name: string | undefined }>()
   const lookupKey = lookup ? `${lookup.projectName ?? ''}:${lookup.sessionId}` : undefined
+  const key = lookupKey && kernelKind ? `${lookupKey}:${kernelKind}` : undefined
   useEffect(() => {
-    if (!lookup || !lookupKey || !kernelKind) return
+    if (!lookup || !key || !kernelKind) return
     let cancelled = false
-    const key = `${lookupKey}:${kernelKind}`
     let cached = notebookEnvCache.get(key)
     if (!cached) {
       cached = lookupNotebookEnvironment(lookup, kernelKind)
       notebookEnvCache.set(key, cached)
     }
     void cached.then((name) => {
-      if (!cancelled) setEnvName(name)
+      if (!cancelled) setEnvironment({ key, name })
     })
     return () => {
       cancelled = true
     }
     // lookup is a fresh object per render; the primitive key is the real dependency.
     // eslint-disable-next-line react-hooks/exhaustive-deps
-  }, [lookupKey, kernelKind])
-  return kernelKind ? envName : undefined
+  }, [key, kernelKind])
+  if (!environment || environment.key !== key) return undefined
+  return environment.name
 }
 
 const PermissionImpactTip = ({ description }: { description: string }): React.JSX.Element => (

--- a/src/renderer/src/pages/workspace/PermissionApprovalControls.tsx
+++ b/src/renderer/src/pages/workspace/PermissionApprovalControls.tsx
@@ -168,14 +168,13 @@ const extractPermissionCode = (request: AcpPermissionRequest): PermissionCode | 
     return undefined
   }
 
-  // Shell execute (Bash tool): prefer the structured command field (verbatim), but fall back to
-  // the request title so the full command stays inspectable even when rawInput is absent (the
-  // command may live only in title). Only trust title-as-bash for providerToolName === 'Bash';
-  // other MCP execute tools (arbitrary servers, diverse semantics) must not assume shell syntax.
+  // Shell execute: prefer the structured command field (verbatim), but for a broker-classified
+  // non-MCP execute request also fall back to its title so the exact command remains reviewable.
+  // MCP execute inputs are arbitrary tool arguments and must not be reinterpreted as local shell.
   if (isExecute) {
     const cmd = rawInput.command
     if (typeof cmd === 'string' && cmd.trim()) return { code: cmd, language: 'bash' }
-    if (request.providerToolName === 'Bash' && request.title?.trim()) {
+    if (!isMcpPermissionRequest(request) && request.title?.trim()) {
       return { code: request.title, language: 'bash' }
     }
   }

--- a/src/renderer/src/pages/workspace/PermissionApprovalControls.tsx
+++ b/src/renderer/src/pages/workspace/PermissionApprovalControls.tsx
@@ -136,7 +136,7 @@ type PermissionCode = { code: string; language?: string }
 // providerToolName (notebook_execute); only the namespaced field carries the server segment the
 // identity check needs, so we return whichever field matches (or undefined for non-notebook tools).
 const resolveNotebookToolName = (request: AcpPermissionRequest): string | undefined =>
-  resolveNotebookRunToolName(request.providerToolName, request.title)
+  isMcpPermissionRequest(request) ? resolveNotebookRunToolName(request.mcpIdentity) : undefined
 
 // Derives displayable code and language from the tool's raw input.
 const extractPermissionCode = (request: AcpPermissionRequest): PermissionCode | undefined => {
@@ -537,11 +537,19 @@ const PermissionApprovalControls = ({
   const allowOptionId = getAllowOptionId(request.options, effectiveScope)
   const denyOptionId = getDenyOptionId(request.options)
   const scopeLabel = effectiveScope === 'once' ? 'once' : 'for this conversation'
+  const notebookRuntimeLabel: Partial<Record<NotebookRuntime, string>> = {
+    python: 'Python',
+    r: 'R',
+    js: 'JavaScript REPL',
+    bash: 'notebook shell'
+  }
   const scopeDescription = !allowOptionId
     ? 'No approval scope is available for this request.'
     : effectiveScope === 'once'
       ? 'Approval applies to this call only.'
-      : 'Approval applies until this conversation ends.'
+      : presentation.notebookRuntime
+        ? `Approval covers later ${notebookRuntimeLabel[presentation.notebookRuntime]} calls in this conversation.`
+        : 'Approval applies until this conversation ends.'
   const hasScopePicker = availableScopes.size > 1
   const isSubmitting = submittingRequestId === request.requestId
   const respondOnce = (optionId?: string): void => {

--- a/src/renderer/src/pages/workspace/PermissionApprovalControls.tsx
+++ b/src/renderer/src/pages/workspace/PermissionApprovalControls.tsx
@@ -189,6 +189,7 @@ const extractPermissionCode = (request: AcpPermissionRequest): PermissionCode | 
 // A friendly action title for the code card header, matching the transcript's activity phrasing.
 const getPermissionActionTitle = (request: AcpPermissionRequest, fallback: string): string => {
   if (resolveNotebookToolName(request)) return 'Run notebook cell'
+  if (request.isMcp) return 'External service input'
   if (request.toolKind === 'execute' || request.providerToolName === 'Bash') return 'Run command'
   return fallback
 }
@@ -344,9 +345,7 @@ const PermissionHeaderBadges = ({
               <Info className="size-3.5" aria-hidden="true" />
             </button>
           </TooltipTrigger>
-          <TooltipContent className="max-w-72 whitespace-normal">
-            {scopeDescription}
-          </TooltipContent>
+          <TooltipContent className="max-w-72 whitespace-normal">{scopeDescription}</TooltipContent>
         </Tooltip>
       </TooltipProvider>
     </span>
@@ -499,10 +498,9 @@ const PermissionApprovalControls = ({
   const allowOptionId = getAllowOptionId(request.options, effectiveScope)
   const denyOptionId = getDenyOptionId(request.options)
   const scopeLabel = effectiveScope === 'once' ? 'once' : 'for this conversation'
-  const scopeDescription =
-    !allowOptionId
-      ? 'No approval scope is available for this request.'
-      : effectiveScope === 'once'
+  const scopeDescription = !allowOptionId
+    ? 'No approval scope is available for this request.'
+    : effectiveScope === 'once'
       ? 'Approval applies to this call only.'
       : 'Approval applies until this conversation ends.'
   const hasScopePicker = availableScopes.size > 1
@@ -545,6 +543,7 @@ const PermissionApprovalControls = ({
   // the provider's raw protocol spelling. Files, commands, and other native tools retain their target.
   const headerName = request.providerToolName ?? request.title
   const titleDetail = ((): string | undefined => {
+    if (presentation.hideToolIdentity) return undefined
     if (request.isMcp) {
       return presentation.actionDetail
     }

--- a/src/renderer/src/pages/workspace/PermissionApprovalControls.tsx
+++ b/src/renderer/src/pages/workspace/PermissionApprovalControls.tsx
@@ -171,7 +171,7 @@ const extractPermissionCode = (request: AcpPermissionRequest): PermissionCode | 
   // Shell execute: prefer the structured command field (verbatim), then use the title only for
   // the known Bash provider. Other execute titles can be generic labels, not concrete commands.
   // MCP execute inputs are arbitrary tool arguments and must not be reinterpreted as local shell.
-  if (isExecute) {
+  if (isExecute && !isMcpPermissionRequest(request)) {
     const cmd = rawInput.command
     if (typeof cmd === 'string' && cmd.trim()) return { code: cmd, language: 'bash' }
     if (request.providerToolName === 'Bash' && request.title?.trim()) {

--- a/src/renderer/src/pages/workspace/PermissionApprovalControls.tsx
+++ b/src/renderer/src/pages/workspace/PermissionApprovalControls.tsx
@@ -10,7 +10,11 @@ import { dialogTitleClassName } from '@/components/ui/dialog-chrome'
 import { Tooltip, TooltipContent, TooltipProvider, TooltipTrigger } from '@/components/ui/tooltip'
 import { cn } from '@/lib/utils'
 import { resolveNotebookLanguage, resolveNotebookRunToolName } from './notebook-tool-names'
-import { describePermissionRequest, type NotebookRuntime } from './permission-request-presentation'
+import {
+  describePermissionRequest,
+  isMcpPermissionRequest,
+  type NotebookRuntime
+} from './permission-request-presentation'
 import { WorkspaceToolCodeBlock } from './WorkspaceToolCodeBlock'
 
 type PermissionApprovalControlsProps = {
@@ -189,7 +193,7 @@ const extractPermissionCode = (request: AcpPermissionRequest): PermissionCode | 
 // A friendly action title for the code card header, matching the transcript's activity phrasing.
 const getPermissionActionTitle = (request: AcpPermissionRequest, fallback: string): string => {
   if (resolveNotebookToolName(request)) return 'Run notebook cell'
-  if (request.isMcp) return 'External service input'
+  if (isMcpPermissionRequest(request)) return 'External service input'
   if (request.toolKind === 'execute' || request.providerToolName === 'Bash') return 'Run command'
   return fallback
 }
@@ -557,16 +561,15 @@ const PermissionApprovalControls = ({
     denyOptionId
   )
 
-  const isShell =
-    request.isMcp !== true &&
-    (request.toolKind === 'execute' || request.providerToolName === 'Bash')
+  const isMcp = isMcpPermissionRequest(request)
+  const isShell = !isMcp && (request.toolKind === 'execute' || request.providerToolName === 'Bash')
 
   // MCP action context stays visible alongside any code, arguments, or locations without exposing
   // the provider's raw protocol spelling. Files, commands, and other native tools retain their target.
   const headerName = request.providerToolName ?? request.title
   const titleDetail = ((): string | undefined => {
     if (presentation.hideToolIdentity) return undefined
-    if (request.isMcp) {
+    if (isMcp) {
       return presentation.actionDetail
     }
     if (!request.title || request.title === permCode?.code) return undefined

--- a/src/renderer/src/pages/workspace/PermissionApprovalControls.tsx
+++ b/src/renderer/src/pages/workspace/PermissionApprovalControls.tsx
@@ -533,11 +533,15 @@ const PermissionApprovalControls = ({
     request.isMcp !== true &&
     (request.toolKind === 'execute' || request.providerToolName === 'Bash')
 
-  // MCP titles are protocol identifiers, not user-facing details. Files, commands, and other
-  // native tools retain their target-bearing title when the code/path preview does not already show it.
+  // MCP identifiers are only needed when the request has no code, arguments, or locations to review.
+  // In that case, the presentation layer supplies a humanized service/action label rather than the
+  // provider's raw protocol spelling. Files, commands, and other native tools retain their target.
   const headerName = request.providerToolName ?? request.title
   const titleDetail = ((): string | undefined => {
-    if (request.isMcp || !request.title || request.title === permCode?.code) return undefined
+    if (request.isMcp) {
+      return !permCode && !request.toolLocations?.length ? presentation.actionDetail : undefined
+    }
+    if (!request.title || request.title === permCode?.code) return undefined
     if (!request.providerToolName) return request.title
     if (isShell) {
       return !permCode && request.title !== request.providerToolName ? request.title : undefined

--- a/src/renderer/src/pages/workspace/PermissionApprovalControls.tsx
+++ b/src/renderer/src/pages/workspace/PermissionApprovalControls.tsx
@@ -348,7 +348,7 @@ const PermissionHeaderBadges = ({
               <Info className="size-3.5" aria-hidden="true" />
             </button>
           </TooltipTrigger>
-          <TooltipContent className="max-w-72 whitespace-normal">
+          <TooltipContent className="max-w-none whitespace-nowrap">
             <div className="space-y-1">
               <p>{description}</p>
               <p className="text-muted-foreground">{scopeDescription}</p>

--- a/src/renderer/src/pages/workspace/WorkspaceToolCodeBlock.test.tsx
+++ b/src/renderer/src/pages/workspace/WorkspaceToolCodeBlock.test.tsx
@@ -75,4 +75,20 @@ describe('WorkspaceToolCodeBlock', () => {
     expect(writeText).toHaveBeenCalledWith('import')
     expect(container.querySelector('[aria-label="Copied"]')).toBeNull()
   })
+
+  it('pins the copy button outside the scrollable code area', async () => {
+    root = createRoot(container)
+    await act(async () => {
+      root.render(<WorkspaceToolCodeBlock code="import" language="python" copyable />)
+    })
+
+    const codeBlock = container.querySelector('[data-testid="tool-code-block"]')
+    const copyButton = container.querySelector('[data-testid="code-copy-button"]')
+
+    expect(codeBlock?.tagName).toBe('PRE')
+    expect(codeBlock?.className).toContain('overflow-auto')
+    expect(codeBlock?.parentElement?.className).toContain('relative')
+    expect(copyButton?.parentElement).toBe(codeBlock?.parentElement)
+    expect(copyButton?.className).toContain('z-10')
+  })
 })

--- a/src/renderer/src/pages/workspace/WorkspaceToolCodeBlock.tsx
+++ b/src/renderer/src/pages/workspace/WorkspaceToolCodeBlock.tsx
@@ -83,11 +83,9 @@ const WorkspaceToolCodeBlock = ({
   const tokens = highlighted?.key === highlightKey ? highlighted.result.tokens : undefined
 
   return (
-    <pre
-      data-testid="tool-code-block"
-      data-language={language}
+    <div
       className={cn(
-        'relative max-h-[320px] overflow-auto rounded-md border border-border-200 bg-bg-000 px-3 py-2.5',
+        'group relative max-h-[320px] overflow-hidden rounded-md border border-border-200 bg-bg-000',
         className
       )}
     >
@@ -97,35 +95,41 @@ const WorkspaceToolCodeBlock = ({
           data-testid="code-copy-button"
           aria-label={copied ? 'Copied' : 'Copy code'}
           onClick={() => void copyCode()}
-          className="absolute right-2 top-2 rounded bg-bg-100/80 p-1.5 text-text-200 hover:bg-bg-200 hover:text-text-100"
+          className="absolute right-2 top-2 z-10 rounded bg-bg-100/80 p-1.5 text-text-200 backdrop-blur-sm hover:bg-bg-200 hover:text-text-100"
         >
           <Copy className="size-3.5" aria-hidden />
         </button>
       )}
-      <code className="block whitespace-pre font-mono text-[12px] leading-relaxed text-text-000">
-        {tokens
-          ? tokens.map((line, lineIndex) => (
-              <Fragment key={lineIndex}>
-                {line.map((token, tokenIndex) => (
-                  <span
-                    key={tokenIndex}
-                    // Dual-theme Shiki output puts the color (and a --shiki-dark var) in htmlStyle,
-                    // not token.color, so apply htmlStyle and fall back to color for single themes.
-                    style={{
-                      color: token.color,
-                      ...(token.htmlStyle as React.CSSProperties | undefined),
-                      ...fontStyleToCss(token.fontStyle)
-                    }}
-                  >
-                    {token.content}
-                  </span>
-                ))}
-                {lineIndex < tokens.length - 1 ? '\n' : null}
-              </Fragment>
-            ))
-          : source}
-      </code>
-    </pre>
+      <pre
+        data-testid="tool-code-block"
+        data-language={language}
+        className="m-0 max-h-[320px] overflow-auto px-3 py-2.5"
+      >
+        <code className="block whitespace-pre font-mono text-[12px] leading-relaxed text-text-000">
+          {tokens
+            ? tokens.map((line, lineIndex) => (
+                <Fragment key={lineIndex}>
+                  {line.map((token, tokenIndex) => (
+                    <span
+                      key={tokenIndex}
+                      // Dual-theme Shiki output puts the color (and a --shiki-dark var) in htmlStyle,
+                      // not token.color, so apply htmlStyle and fall back to color for single themes.
+                      style={{
+                        color: token.color,
+                        ...(token.htmlStyle as React.CSSProperties | undefined),
+                        ...fontStyleToCss(token.fontStyle)
+                      }}
+                    >
+                      {token.content}
+                    </span>
+                  ))}
+                  {lineIndex < tokens.length - 1 ? '\n' : null}
+                </Fragment>
+              ))
+            : source}
+        </code>
+      </pre>
+    </div>
   )
 }
 

--- a/src/renderer/src/pages/workspace/notebook-tool-names.test.ts
+++ b/src/renderer/src/pages/workspace/notebook-tool-names.test.ts
@@ -17,6 +17,7 @@ describe('isNotebookExecuteToolName', () => {
     expect(isNotebookExecuteToolName('open-science-notebook.notebook_execute')).toBe(true)
     // The exact broker-produced namespaced title.
     expect(isNotebookExecuteToolName('mcp.open-science-notebook.notebook_execute')).toBe(true)
+    expect(isNotebookExecuteToolName('open-science-notebook/notebook_execute')).toBe(true)
   })
 
   it('does not match the bare leaf name alone (no server segment to verify)', () => {

--- a/src/renderer/src/pages/workspace/notebook-tool-names.test.ts
+++ b/src/renderer/src/pages/workspace/notebook-tool-names.test.ts
@@ -1,6 +1,10 @@
 import { describe, expect, it } from 'vitest'
 
-import { isNotebookExecuteToolName, matchNotebookRunTool } from './notebook-tool-names'
+import {
+  isNotebookExecuteToolName,
+  matchNotebookControlTool,
+  matchNotebookRunTool
+} from './notebook-tool-names'
 
 describe('isNotebookExecuteToolName', () => {
   it('matches the notebook server run tools in Claude Code mcp__ form', () => {
@@ -62,6 +66,16 @@ describe('isNotebookExecuteToolName', () => {
 
   it('rejects notebook server tools that are not kernel-run tools', () => {
     expect(isNotebookExecuteToolName('mcp__open-science-notebook__notebook_state')).toBe(false)
+  })
+
+  it('matches notebook controls with the same exact server boundary', () => {
+    expect(matchNotebookControlTool('mcp__open-science-notebook__notebook_restart')).toBe(
+      'notebook_restart'
+    )
+    expect(matchNotebookControlTool('open_science_notebook_notebook_shutdown')).toBe(
+      'notebook_shutdown'
+    )
+    expect(matchNotebookControlTool('mcp__acme-db__notebook_restart')).toBeUndefined()
   })
 
   it('rejects empty or missing names', () => {

--- a/src/renderer/src/pages/workspace/notebook-tool-names.ts
+++ b/src/renderer/src/pages/workspace/notebook-tool-names.ts
@@ -22,7 +22,8 @@ const NOTEBOOK_SERVER_SEGMENT = 'open-science-notebook'
 
 // Returns the matched kernel-run suffix when a tool name is one of the notebook server's run tools,
 // else undefined. Frameworks namespace tools as mcp__<server>__<tool> (Claude Code / responses
-// bridge) or <server>.<tool> (others), so only `__` and `.` are treated as segment delimiters —
+// bridge), <server>.<tool> (others), or the broker-projected <server>/<tool> identity, so only
+// `__`, `.`, and `/` are treated as segment delimiters —
 // single underscores occur inside both the tool suffix (notebook_execute) and the sanitized server
 // name (open_science_notebook) and must not split. The segment immediately before the suffix must
 // equal the notebook server exactly, so a lookalike (open-science-notebook-staging) or an unrelated
@@ -37,7 +38,7 @@ const matchNotebookTool = (
   // Multi-char / dot delimited forms: mcp__<server>__<tool> (Claude Code, responses bridge),
   // <server>.<tool> and mcp.<server>.<tool> (dotted). The segment before the suffix must equal the
   // server exactly after normalizing `_`→`-`, so a lookalike server is rejected.
-  const segments = name.split(/__|\./u)
+  const segments = name.split(/__|\.|\//u)
   if (segments.length >= 2) {
     const suffix = segments[segments.length - 1]
     if (suffixes.some((known) => known === suffix)) {

--- a/src/renderer/src/pages/workspace/notebook-tool-names.ts
+++ b/src/renderer/src/pages/workspace/notebook-tool-names.ts
@@ -5,6 +5,16 @@
 
 // Provider tool suffixes (under the notebook MCP server) whose input/result is one kernel run.
 const NOTEBOOK_RUN_TOOL_SUFFIXES = ['notebook_execute', 'repl_execute', 'bash_execute'] as const
+const NOTEBOOK_CONTROL_TOOL_SUFFIXES = [
+  'notebook_state',
+  'list_notebook_runtimes',
+  'notebook_bind_runtime',
+  'notebook_switch_runtime',
+  'notebook_restart',
+  'notebook_shutdown',
+  'manage_packages',
+  'manage_environments'
+] as const
 
 // The notebook MCP server segment, hyphenated. The responses bridge sanitizes it to
 // open_science_notebook; we normalize `_`→`-` before the exact comparison so both forms match.
@@ -17,7 +27,10 @@ const NOTEBOOK_SERVER_SEGMENT = 'open-science-notebook'
 // name (open_science_notebook) and must not split. The segment immediately before the suffix must
 // equal the notebook server exactly, so a lookalike (open-science-notebook-staging) or an unrelated
 // server that merely contains the phrase is rejected, and a bare leaf name (no server segment) too.
-const matchNotebookRunTool = (toolName: string | undefined | null): string | undefined => {
+const matchNotebookTool = (
+  toolName: string | undefined | null,
+  suffixes: readonly string[]
+): string | undefined => {
   const name = toolName?.trim().toLowerCase() ?? ''
   if (!name) return undefined
 
@@ -27,7 +40,7 @@ const matchNotebookRunTool = (toolName: string | undefined | null): string | und
   const segments = name.split(/__|\./u)
   if (segments.length >= 2) {
     const suffix = segments[segments.length - 1]
-    if (NOTEBOOK_RUN_TOOL_SUFFIXES.some((known) => known === suffix)) {
+    if (suffixes.some((known) => known === suffix)) {
       const server = segments[segments.length - 2].replace(/_/gu, '-')
       if (server === NOTEBOOK_SERVER_SEGMENT) return suffix
     }
@@ -37,7 +50,7 @@ const matchNotebookRunTool = (toolName: string | undefined | null): string | und
   // inside the server name and the suffix, so it can't be used as a split delimiter — instead match
   // the exact known server spellings (hyphenated or sanitized) concatenated with each known suffix.
   // Exact equality anchors the server/suffix boundary, so lookalikes (…-staging, my-…) never match.
-  for (const suffix of NOTEBOOK_RUN_TOOL_SUFFIXES) {
+  for (const suffix of suffixes) {
     if (
       name === `${NOTEBOOK_SERVER_SEGMENT}_${suffix}` ||
       name === `open_science_notebook_${suffix}`
@@ -47,6 +60,12 @@ const matchNotebookRunTool = (toolName: string | undefined | null): string | und
   }
   return undefined
 }
+
+const matchNotebookRunTool = (toolName: string | undefined | null): string | undefined =>
+  matchNotebookTool(toolName, NOTEBOOK_RUN_TOOL_SUFFIXES)
+
+const matchNotebookControlTool = (toolName: string | undefined | null): string | undefined =>
+  matchNotebookTool(toolName, NOTEBOOK_CONTROL_TOOL_SUFFIXES)
 
 // True when a tool name is any of the notebook server's kernel-run tools.
 const isNotebookExecuteToolName = (toolName: string | undefined | null): boolean =>
@@ -120,7 +139,9 @@ const detectCellLanguage = (code: string): string => {
 
 export {
   NOTEBOOK_RUN_TOOL_SUFFIXES,
+  NOTEBOOK_CONTROL_TOOL_SUFFIXES,
   NOTEBOOK_SERVER_SEGMENT,
+  matchNotebookControlTool,
   matchNotebookRunTool,
   isNotebookExecuteToolName,
   resolveNotebookRunToolName,

--- a/src/renderer/src/pages/workspace/permission-request-presentation.test.ts
+++ b/src/renderer/src/pages/workspace/permission-request-presentation.test.ts
@@ -1,0 +1,62 @@
+import type { AcpPermissionRequest } from '../../../../shared/acp'
+import { describe, expect, it } from 'vitest'
+
+import { describePermissionRequest } from './permission-request-presentation'
+
+const request = (overrides: Partial<AcpPermissionRequest>): AcpPermissionRequest => ({
+  requestId: 'request-1',
+  sessionId: 'session-1',
+  toolCallId: 'tool-1',
+  title: 'Tool request',
+  options: [],
+  ...overrides
+})
+
+describe('describePermissionRequest', () => {
+  it.each([
+    ['python', 'notebook_execute', { kernelKind: 'python', code: 'print(1)' }, 'Python execution'],
+    ['r', 'notebook_execute', { code: 'library(ggplot2)' }, 'R execution'],
+    ['js', 'repl_execute', { code: 'const value = 1' }, 'JS REPL'],
+    ['bash', 'bash_execute', { command: 'pwd' }, 'Notebook shell']
+  ] as const)(
+    'classifies notebook %s execution independently',
+    (runtime, tool, rawInput, categoryLabel) => {
+      const presentation = describePermissionRequest(
+        request({
+          title: `mcp__open-science-notebook__${tool}`,
+          providerToolName: `mcp__open-science-notebook__${tool}`,
+          isMcp: true,
+          rawInput
+        })
+      )
+
+      expect(presentation).toMatchObject({ notebookRuntime: runtime, categoryLabel })
+    }
+  )
+
+  it('explains a notebook restart without exposing its protocol identifier', () => {
+    expect(
+      describePermissionRequest(
+        request({
+          title: 'mcp__open-science-notebook__notebook_restart',
+          providerToolName: 'mcp__open-science-notebook__notebook_restart',
+          isMcp: true
+        })
+      )
+    ).toEqual({
+      actionTitle: 'Restart notebook?',
+      categoryLabel: 'Notebook control',
+      description:
+        'Restarts the current notebook environment. Running processes and unsaved runtime state may be lost.'
+    })
+  })
+
+  it.each([
+    [request({ toolKind: 'read' }), 'File access'],
+    [request({ toolKind: 'fetch' }), 'Network access'],
+    [request({ providerToolName: 'Bash', toolKind: 'execute' }), 'Command execution'],
+    [request({ isMcp: true }), 'External service']
+  ])('classifies current non-notebook permission types', (permission, categoryLabel) => {
+    expect(describePermissionRequest(permission).categoryLabel).toBe(categoryLabel)
+  })
+})

--- a/src/renderer/src/pages/workspace/permission-request-presentation.test.ts
+++ b/src/renderer/src/pages/workspace/permission-request-presentation.test.ts
@@ -26,6 +26,7 @@ describe('describePermissionRequest', () => {
           title: `mcp__open-science-notebook__${tool}`,
           providerToolName: `mcp__open-science-notebook__${tool}`,
           isMcp: true,
+          mcpIdentity: `open-science-notebook/${tool}`,
           rawInput
         })
       )
@@ -40,7 +41,8 @@ describe('describePermissionRequest', () => {
         request({
           title: 'mcp__open-science-notebook__notebook_restart',
           providerToolName: 'mcp__open-science-notebook__notebook_restart',
-          isMcp: true
+          isMcp: true,
+          mcpIdentity: 'open-science-notebook/notebook_restart'
         })
       )
     ).toMatchObject({
@@ -57,7 +59,8 @@ describe('describePermissionRequest', () => {
       describePermissionRequest(
         request({
           title: 'mcp__open-science-notebook__list_notebook_runtimes',
-          isMcp: true
+          isMcp: true,
+          mcpIdentity: 'open-science-notebook/list_notebook_runtimes'
         })
       )
     ).toMatchObject({
@@ -80,27 +83,29 @@ describe('describePermissionRequest', () => {
       describePermissionRequest(
         request({
           title: 'mcp__research-service__search_papers',
-          isMcp: true
+          isMcp: true,
+          mcpIdentity: 'research-service/search_papers'
         })
       ).actionDetail
     ).toBe('Research Service / Search Papers')
   })
 
-  it('classifies the managed artifact writer as internal artifact storage', () => {
+  it('classifies the managed artifact writer as an artifact save', () => {
     expect(
       describePermissionRequest(
         request({
           title: 'mcp__open-science-artifacts__write_artifact_file',
-          isMcp: true
+          isMcp: true,
+          mcpIdentity: 'open-science-artifacts/write_artifact_file'
         })
       )
     ).toMatchObject({
-      actionTitle: 'Write artifact file?',
-      categoryLabel: 'Artifact storage'
+      actionTitle: 'Save as artifact?',
+      categoryLabel: 'Artifact save'
     })
   })
 
-  it('classifies a raw MCP protocol name even when the provider omits isMcp', () => {
+  it('does not infer MCP origin from a raw protocol name in the renderer', () => {
     expect(
       describePermissionRequest(
         request({
@@ -110,28 +115,55 @@ describe('describePermissionRequest', () => {
         })
       )
     ).toMatchObject({
-      actionTitle: 'Use external service?',
-      categoryLabel: 'External service',
-      actionDetail: 'Runner / Execute'
+      actionTitle: 'Run command?',
+      categoryLabel: 'Command execution'
     })
   })
 
-  it('uses the provider identity when an MCP title is generic', () => {
+  it('uses the broker-projected MCP identity when an MCP title is generic', () => {
     expect(
       describePermissionRequest(
         request({
           title: 'Run MCP tool',
           providerToolName: 'mcp__reviewer__review_document',
-          isMcp: true
+          isMcp: true,
+          mcpIdentity: 'reviewer/review_document'
         })
       ).actionDetail
     ).toBe('Reviewer / Review Document')
   })
 
-  it('does not split dots in a human-readable MCP title', () => {
+  it('keeps the stable MCP identity when a provider title is human-readable', () => {
     expect(
-      describePermissionRequest(request({ title: 'Write report.md', isMcp: true })).actionDetail
-    ).toBe('Write report.md')
+      describePermissionRequest(
+        request({
+          title: 'Write report.md',
+          isMcp: true,
+          mcpIdentity: 'research-service/write_report'
+        })
+      ).actionDetail
+    ).toBe('Research Service / Write Report')
+  })
+
+  it('does not give a sanitized notebook-looking non-MCP name notebook privileges', () => {
+    expect(
+      describePermissionRequest(
+        request({ title: 'open_science_notebook_notebook_restart', isMcp: false })
+      ).categoryLabel
+    ).toBe('Tool access')
+  })
+
+  it('uses a trusted canonical identity for Codex notebook execution', () => {
+    expect(
+      describePermissionRequest(
+        request({
+          title: 'execute',
+          isMcp: true,
+          mcpIdentity: 'open-science-notebook/notebook_execute',
+          rawInput: { language: 'r', code: 'x <- 1' }
+        })
+      )
+    ).toMatchObject({ actionTitle: 'Run R code?', categoryLabel: 'R execution' })
   })
 
   it('keeps unrecognized MCP requests in the external-service category', () => {

--- a/src/renderer/src/pages/workspace/permission-request-presentation.test.ts
+++ b/src/renderer/src/pages/workspace/permission-request-presentation.test.ts
@@ -105,6 +105,17 @@ describe('describePermissionRequest', () => {
     })
   })
 
+  it('does not classify an artifact-looking provider title without the broker identity', () => {
+    expect(
+      describePermissionRequest(
+        request({
+          title: 'mcp__open-science-artifacts__write_artifact_file',
+          isMcp: true
+        })
+      ).categoryLabel
+    ).toBe('External service')
+  })
+
   it('does not infer MCP origin from a raw protocol name in the renderer', () => {
     expect(
       describePermissionRequest(

--- a/src/renderer/src/pages/workspace/permission-request-presentation.test.ts
+++ b/src/renderer/src/pages/workspace/permission-request-presentation.test.ts
@@ -79,18 +79,32 @@ describe('describePermissionRequest', () => {
     expect(
       describePermissionRequest(
         request({
-          title: 'mcp__open-science-artifacts__write_artifact_file',
+          title: 'mcp__research-service__search_papers',
           isMcp: true
         })
       ).actionDetail
-    ).toBe('Open Science Artifacts / Write Artifact File')
+    ).toBe('Research Service / Search Papers')
+  })
+
+  it('classifies the managed artifact writer as internal artifact storage', () => {
+    expect(
+      describePermissionRequest(
+        request({
+          title: 'mcp__open-science-artifacts__write_artifact_file',
+          isMcp: true
+        })
+      )
+    ).toMatchObject({
+      actionTitle: 'Write artifact file?',
+      categoryLabel: 'Artifact storage'
+    })
   })
 
   it('classifies a raw MCP protocol name even when the provider omits isMcp', () => {
     expect(
       describePermissionRequest(
         request({
-          title: 'mcp__open-science-artifacts__write_artifact_file',
+          title: 'mcp__runner__execute',
           isMcp: false,
           toolKind: 'execute'
         })
@@ -98,7 +112,7 @@ describe('describePermissionRequest', () => {
     ).toMatchObject({
       actionTitle: 'Use external service?',
       categoryLabel: 'External service',
-      actionDetail: 'Open Science Artifacts / Write Artifact File'
+      actionDetail: 'Runner / Execute'
     })
   })
 
@@ -107,11 +121,11 @@ describe('describePermissionRequest', () => {
       describePermissionRequest(
         request({
           title: 'Run MCP tool',
-          providerToolName: 'mcp__open-science-artifacts__write_artifact_file',
+          providerToolName: 'mcp__reviewer__review_document',
           isMcp: true
         })
       ).actionDetail
-    ).toBe('Open Science Artifacts / Write Artifact File')
+    ).toBe('Reviewer / Review Document')
   })
 
   it('does not split dots in a human-readable MCP title', () => {

--- a/src/renderer/src/pages/workspace/permission-request-presentation.test.ts
+++ b/src/renderer/src/pages/workspace/permission-request-presentation.test.ts
@@ -86,6 +86,22 @@ describe('describePermissionRequest', () => {
     ).toBe('Open Science Artifacts / Write Artifact File')
   })
 
+  it('classifies a raw MCP protocol name even when the provider omits isMcp', () => {
+    expect(
+      describePermissionRequest(
+        request({
+          title: 'mcp__open-science-artifacts__write_artifact_file',
+          isMcp: false,
+          toolKind: 'execute'
+        })
+      )
+    ).toMatchObject({
+      actionTitle: 'Use external service?',
+      categoryLabel: 'External service',
+      actionDetail: 'Open Science Artifacts / Write Artifact File'
+    })
+  })
+
   it('uses the provider identity when an MCP title is generic', () => {
     expect(
       describePermissionRequest(

--- a/src/renderer/src/pages/workspace/permission-request-presentation.test.ts
+++ b/src/renderer/src/pages/workspace/permission-request-presentation.test.ts
@@ -59,4 +59,15 @@ describe('describePermissionRequest', () => {
   ])('classifies current non-notebook permission types', (permission, categoryLabel) => {
     expect(describePermissionRequest(permission).categoryLabel).toBe(categoryLabel)
   })
+
+  it('humanizes an otherwise-opaque MCP action without keeping its protocol spelling', () => {
+    expect(
+      describePermissionRequest(
+        request({
+          title: 'mcp__open-science-artifacts__write_artifact_file',
+          isMcp: true
+        })
+      ).actionDetail
+    ).toBe('Open Science Artifacts / Write Artifact File')
+  })
 })

--- a/src/renderer/src/pages/workspace/permission-request-presentation.test.ts
+++ b/src/renderer/src/pages/workspace/permission-request-presentation.test.ts
@@ -85,12 +85,12 @@ describe('describePermissionRequest', () => {
     ).toBe('Open Science Artifacts / Write Artifact File')
   })
 
-  it('keeps trusted file and network classifications for MCP requests', () => {
+  it('keeps unrecognized MCP requests in the external-service category', () => {
     expect(
       describePermissionRequest(request({ isMcp: true, toolKind: 'edit' })).categoryLabel
-    ).toBe('File access')
+    ).toBe('External service')
     expect(
       describePermissionRequest(request({ isMcp: true, toolKind: 'fetch' })).categoryLabel
-    ).toBe('Network access')
+    ).toBe('External service')
   })
 })

--- a/src/renderer/src/pages/workspace/permission-request-presentation.test.ts
+++ b/src/renderer/src/pages/workspace/permission-request-presentation.test.ts
@@ -116,6 +116,16 @@ describe('describePermissionRequest', () => {
     ).toBe('External service')
   })
 
+  it('keeps an unresolved MCP request distinguishable without granting it a special category', () => {
+    expect(
+      describePermissionRequest(request({ title: 'open-science-notebook', isMcp: true }))
+    ).toMatchObject({
+      actionTitle: 'Use Open Science Notebook?',
+      categoryLabel: 'External service',
+      actionDetail: 'Open Science Notebook'
+    })
+  })
+
   it('does not infer MCP origin from a raw protocol name in the renderer', () => {
     expect(
       describePermissionRequest(

--- a/src/renderer/src/pages/workspace/permission-request-presentation.test.ts
+++ b/src/renderer/src/pages/workspace/permission-request-presentation.test.ts
@@ -43,11 +43,12 @@ describe('describePermissionRequest', () => {
           isMcp: true
         })
       )
-    ).toEqual({
+    ).toMatchObject({
       actionTitle: 'Restart notebook?',
       categoryLabel: 'Notebook control',
       description:
-        'Restarts the current notebook environment. Running processes and unsaved runtime state may be lost.'
+        'Restarts the current notebook environment. Running processes and unsaved runtime state may be lost.',
+      hideToolIdentity: true
     })
   })
 
@@ -85,6 +86,24 @@ describe('describePermissionRequest', () => {
     ).toBe('Open Science Artifacts / Write Artifact File')
   })
 
+  it('uses the provider identity when an MCP title is generic', () => {
+    expect(
+      describePermissionRequest(
+        request({
+          title: 'Run MCP tool',
+          providerToolName: 'mcp__open-science-artifacts__write_artifact_file',
+          isMcp: true
+        })
+      ).actionDetail
+    ).toBe('Open Science Artifacts / Write Artifact File')
+  })
+
+  it('does not split dots in a human-readable MCP title', () => {
+    expect(
+      describePermissionRequest(request({ title: 'Write report.md', isMcp: true })).actionDetail
+    ).toBe('Write report.md')
+  })
+
   it('keeps unrecognized MCP requests in the external-service category', () => {
     expect(
       describePermissionRequest(request({ isMcp: true, toolKind: 'edit' })).categoryLabel
@@ -92,5 +111,9 @@ describe('describePermissionRequest', () => {
     expect(
       describePermissionRequest(request({ isMcp: true, toolKind: 'fetch' })).categoryLabel
     ).toBe('External service')
+  })
+
+  it.each(['edit', 'delete', 'move'] as const)('classifies %s as a file change', (toolKind) => {
+    expect(describePermissionRequest(request({ toolKind })).categoryLabel).toBe('File change')
   })
 })

--- a/src/renderer/src/pages/workspace/permission-request-presentation.test.ts
+++ b/src/renderer/src/pages/workspace/permission-request-presentation.test.ts
@@ -51,6 +51,20 @@ describe('describePermissionRequest', () => {
     })
   })
 
+  it('describes listing notebook runtimes as a read-only action', () => {
+    expect(
+      describePermissionRequest(
+        request({
+          title: 'mcp__open-science-notebook__list_notebook_runtimes',
+          isMcp: true
+        })
+      )
+    ).toMatchObject({
+      actionTitle: 'View notebook runtimes?',
+      description: 'Lists the notebook runtimes available to this conversation.'
+    })
+  })
+
   it.each([
     [request({ toolKind: 'read' }), 'File access'],
     [request({ toolKind: 'fetch' }), 'Network access'],
@@ -69,5 +83,14 @@ describe('describePermissionRequest', () => {
         })
       ).actionDetail
     ).toBe('Open Science Artifacts / Write Artifact File')
+  })
+
+  it('keeps trusted file and network classifications for MCP requests', () => {
+    expect(
+      describePermissionRequest(request({ isMcp: true, toolKind: 'edit' })).categoryLabel
+    ).toBe('File access')
+    expect(
+      describePermissionRequest(request({ isMcp: true, toolKind: 'fetch' })).categoryLabel
+    ).toBe('Network access')
   })
 })

--- a/src/renderer/src/pages/workspace/permission-request-presentation.ts
+++ b/src/renderer/src/pages/workspace/permission-request-presentation.ts
@@ -181,6 +181,16 @@ const describePermissionRequest = (request: AcpPermissionRequest): PermissionPre
     .find((tool): tool is string => tool !== undefined)
   if (controlTool) return notebookControlPresentation(controlTool)
 
+  // MCP metadata describes the provider's tool, not a trusted local capability. Only the
+  // explicitly modeled notebook tools above receive a more specific native classification.
+  if (request.isMcp) {
+    return withMcpActionDetail(request, {
+      actionTitle: 'Use external service?',
+      categoryLabel: 'External service',
+      description: 'Uses an MCP service configured for this conversation.'
+    })
+  }
+
   if (isNetworkTool(request)) {
     return withMcpActionDetail(request, {
       actionTitle: 'Access network resource?',
@@ -217,14 +227,6 @@ const describePermissionRequest = (request: AcpPermissionRequest): PermissionPre
       })
     default:
       break
-  }
-
-  if (request.isMcp) {
-    return withMcpActionDetail(request, {
-      actionTitle: 'Use external service?',
-      categoryLabel: 'External service',
-      description: 'Uses an MCP service configured for this conversation.'
-    })
   }
 
   if (request.providerToolName === 'Bash' || request.toolKind === 'execute') {

--- a/src/renderer/src/pages/workspace/permission-request-presentation.ts
+++ b/src/renderer/src/pages/workspace/permission-request-presentation.ts
@@ -136,15 +136,9 @@ const notebookControlPresentation = (tool: string): PermissionPresentation => {
 const providerToolName = (request: AcpPermissionRequest): string | undefined =>
   request.providerToolName?.trim() || undefined
 
-const hasMcpProtocolPrefix = (name: string | undefined): boolean =>
-  /^mcp(?:__|\.)/iu.test(name ?? '')
-
-// Broker-projected isMcp is authoritative when present, but raw protocol names are also enough for
-// the renderer to avoid exposing or misclassifying a request when a provider omitted that flag.
-const isMcpPermissionRequest = (request: AcpPermissionRequest): boolean =>
-  request.isMcp ||
-  hasMcpProtocolPrefix(request.title) ||
-  hasMcpProtocolPrefix(request.providerToolName)
+// MCP origin is broker-classified. Do not infer it from provider titles here: dotted and sanitized
+// spellings are ambiguous without the configured-server context available to the broker.
+const isMcpPermissionRequest = (request: AcpPermissionRequest): boolean => request.isMcp === true
 
 const ARTIFACT_SERVER_SEGMENT = 'open-science-artifacts'
 const ARTIFACT_WRITE_TOOL = 'write_artifact_file'
@@ -153,7 +147,7 @@ const isArtifactWriteToolName = (toolName: string | undefined): boolean => {
   const name = toolName?.trim().toLowerCase() ?? ''
   if (!name) return false
 
-  const segments = name.split(/__|\./u)
+  const segments = name.split(/__|\.|\//u)
   if (segments.length >= 2) {
     const tool = segments[segments.length - 1]
     const server = segments[segments.length - 2].replace(/_/gu, '-')
@@ -167,24 +161,18 @@ const isArtifactWriteToolName = (toolName: string | undefined): boolean => {
 }
 
 const isArtifactWriteRequest = (request: AcpPermissionRequest): boolean =>
-  isArtifactWriteToolName(request.title) || isArtifactWriteToolName(request.providerToolName)
+  isMcpPermissionRequest(request) &&
+  (isArtifactWriteToolName(request.mcpIdentity) ||
+    isArtifactWriteToolName(request.title) ||
+    isArtifactWriteToolName(request.providerToolName))
 
-// Keeps an otherwise-opaque MCP request distinguishable without surfacing its protocol spelling.
-// Provider names win when a bridge supplies only a boilerplate title.
-const isGenericMcpTitle = (title: string): boolean =>
-  /^(?:run )?(?:mcp )?(?:tool|tool request|tool call)$/iu.test(title)
+// The broker resolves a stable `server/tool` identity before the request reaches the renderer.
+// Keep it in the impact tip so a human-readable provider title cannot obscure the granted tool.
+const humanizeMcpIdentity = (identity: string | undefined): string | undefined => {
+  if (!identity) return undefined
 
-const isOpaqueToolCallId = (name: string): boolean => /^tool(?:u|call)?_[a-z0-9]+$/iu.test(name)
-
-const humanizeMcpAction = (request: AcpPermissionRequest): string | undefined => {
-  const title = request.title.trim()
-  const name = !title || isGenericMcpTitle(title) ? providerToolName(request) : title
-  if (!name || isOpaqueToolCallId(name)) return undefined
-
-  const usesDottedNamespace = /^mcp\./iu.test(name)
-  const normalized = name.replace(/^mcp(?:__|\.)/iu, '')
-  const segments = normalized
-    .split(usesDottedNamespace ? '.' : '__')
+  const segments = identity
+    .split('/')
     .filter(Boolean)
     .map((segment) =>
       segment
@@ -204,23 +192,22 @@ const isNetworkTool = (request: AcpPermissionRequest): boolean => {
 }
 
 const describePermissionRequest = (request: AcpPermissionRequest): PermissionPresentation => {
-  const notebookToolName = resolveNotebookRunToolName(request.providerToolName, request.title)
+  const isMcp = isMcpPermissionRequest(request)
+  const notebookToolName = isMcp ? resolveNotebookRunToolName(request.mcpIdentity) : undefined
   if (notebookToolName) {
     const input = getRequestInput(request)
     const language = resolveNotebookLanguage(notebookToolName, input, getCode(input))
     return { ...notebookExecutionPresentation(toNotebookRuntime(language)), hideToolIdentity: true }
   }
 
-  const controlTool = [request.providerToolName, request.title]
-    .map(matchNotebookControlTool)
-    .find((tool): tool is string => tool !== undefined)
+  const controlTool = isMcp ? matchNotebookControlTool(request.mcpIdentity) : undefined
   if (controlTool) return { ...notebookControlPresentation(controlTool), hideToolIdentity: true }
 
   if (isArtifactWriteRequest(request)) {
     return {
-      actionTitle: 'Write artifact file?',
-      categoryLabel: 'Artifact storage',
-      description: 'Saves a file to this conversation’s artifact storage.'
+      actionTitle: 'Save as artifact?',
+      categoryLabel: 'Artifact save',
+      description: 'Saves a file as an artifact for this conversation.'
     }
   }
 
@@ -231,7 +218,7 @@ const describePermissionRequest = (request: AcpPermissionRequest): PermissionPre
       actionTitle: 'Use external service?',
       categoryLabel: 'External service',
       description: 'Uses an MCP service configured for this conversation.',
-      actionDetail: humanizeMcpAction(request)
+      actionDetail: humanizeMcpIdentity(request.mcpIdentity)
     }
   }
 

--- a/src/renderer/src/pages/workspace/permission-request-presentation.ts
+++ b/src/renderer/src/pages/workspace/permission-request-presentation.ts
@@ -162,9 +162,7 @@ const isArtifactWriteToolName = (toolName: string | undefined): boolean => {
 
 const isArtifactWriteRequest = (request: AcpPermissionRequest): boolean =>
   isMcpPermissionRequest(request) &&
-  (isArtifactWriteToolName(request.mcpIdentity) ||
-    isArtifactWriteToolName(request.title) ||
-    isArtifactWriteToolName(request.providerToolName))
+  isArtifactWriteToolName(request.mcpIdentity)
 
 // The broker resolves a stable `server/tool` identity before the request reaches the renderer.
 // Keep it in the impact tip so a human-readable provider title cannot obscure the granted tool.

--- a/src/renderer/src/pages/workspace/permission-request-presentation.ts
+++ b/src/renderer/src/pages/workspace/permission-request-presentation.ts
@@ -13,6 +13,7 @@ type PermissionPresentation = {
   categoryLabel: string
   description: string
   actionDetail?: string
+  hideToolIdentity?: boolean
   notebookRuntime?: NotebookRuntime
 }
 
@@ -136,14 +137,21 @@ const providerToolName = (request: AcpPermissionRequest): string | undefined =>
   request.providerToolName?.trim() || undefined
 
 // Keeps an otherwise-opaque MCP request distinguishable without surfacing its protocol spelling.
-// The request title is preferred because providers can reduce providerToolName to a bare leaf.
-const humanizeMcpAction = (request: AcpPermissionRequest): string | undefined => {
-  const name = request.title.trim() || providerToolName(request)
-  if (!name) return undefined
+// Provider names win when a bridge supplies only a boilerplate title.
+const isGenericMcpTitle = (title: string): boolean =>
+  /^(?:run )?(?:mcp )?(?:tool|tool request|tool call)$/iu.test(title)
 
+const isOpaqueToolCallId = (name: string): boolean => /^tool(?:u|call)?_[a-z0-9]+$/iu.test(name)
+
+const humanizeMcpAction = (request: AcpPermissionRequest): string | undefined => {
+  const title = request.title.trim()
+  const name = !title || isGenericMcpTitle(title) ? providerToolName(request) : title
+  if (!name || isOpaqueToolCallId(name)) return undefined
+
+  const usesDottedNamespace = /^mcp\./iu.test(name)
   const normalized = name.replace(/^mcp(?:__|\.)/u, '')
   const segments = normalized
-    .split(/__|\./u)
+    .split(usesDottedNamespace ? '.' : '__')
     .filter(Boolean)
     .map((segment) =>
       segment
@@ -162,69 +170,64 @@ const isNetworkTool = (request: AcpPermissionRequest): boolean => {
   return request.toolKind === 'fetch' || name === 'webfetch' || name === 'websearch'
 }
 
-const withMcpActionDetail = (
-  request: AcpPermissionRequest,
-  presentation: PermissionPresentation
-): PermissionPresentation =>
-  request.isMcp ? { ...presentation, actionDetail: humanizeMcpAction(request) } : presentation
-
 const describePermissionRequest = (request: AcpPermissionRequest): PermissionPresentation => {
   const notebookToolName = resolveNotebookRunToolName(request.providerToolName, request.title)
   if (notebookToolName) {
     const input = getRequestInput(request)
     const language = resolveNotebookLanguage(notebookToolName, input, getCode(input))
-    return notebookExecutionPresentation(toNotebookRuntime(language))
+    return { ...notebookExecutionPresentation(toNotebookRuntime(language)), hideToolIdentity: true }
   }
 
   const controlTool = [request.providerToolName, request.title]
     .map(matchNotebookControlTool)
     .find((tool): tool is string => tool !== undefined)
-  if (controlTool) return notebookControlPresentation(controlTool)
+  if (controlTool) return { ...notebookControlPresentation(controlTool), hideToolIdentity: true }
 
   // MCP metadata describes the provider's tool, not a trusted local capability. Only the
   // explicitly modeled notebook tools above receive a more specific native classification.
   if (request.isMcp) {
-    return withMcpActionDetail(request, {
+    return {
       actionTitle: 'Use external service?',
       categoryLabel: 'External service',
-      description: 'Uses an MCP service configured for this conversation.'
-    })
+      description: 'Uses an MCP service configured for this conversation.',
+      actionDetail: humanizeMcpAction(request)
+    }
   }
 
   if (isNetworkTool(request)) {
-    return withMcpActionDetail(request, {
+    return {
       actionTitle: 'Access network resource?',
       categoryLabel: 'Network access',
       description: 'Sends a request to an external network resource.'
-    })
+    }
   }
 
   switch (request.toolKind) {
     case 'read':
     case 'search':
-      return withMcpActionDetail(request, {
+      return {
         actionTitle: 'Read files?',
         categoryLabel: 'File access',
         description: 'Reads or searches the listed files.'
-      })
+      }
     case 'edit':
-      return withMcpActionDetail(request, {
+      return {
         actionTitle: 'Edit files?',
-        categoryLabel: 'File access',
+        categoryLabel: 'File change',
         description: 'Changes the listed files.'
-      })
+      }
     case 'delete':
-      return withMcpActionDetail(request, {
+      return {
         actionTitle: 'Delete files?',
-        categoryLabel: 'File access',
+        categoryLabel: 'File change',
         description: 'Deletes the listed files.'
-      })
+      }
     case 'move':
-      return withMcpActionDetail(request, {
+      return {
         actionTitle: 'Move files?',
-        categoryLabel: 'File access',
+        categoryLabel: 'File change',
         description: 'Moves the listed files.'
-      })
+      }
     default:
       break
   }

--- a/src/renderer/src/pages/workspace/permission-request-presentation.ts
+++ b/src/renderer/src/pages/workspace/permission-request-presentation.ts
@@ -98,6 +98,12 @@ const notebookControlPresentation = (tool: string): PermissionPresentation => {
         categoryLabel: 'Notebook control',
         description: 'Reads the current notebook environment and runtime state.'
       }
+    case 'list_notebook_runtimes':
+      return {
+        actionTitle: 'View notebook runtimes?',
+        categoryLabel: 'Notebook control',
+        description: 'Lists the notebook runtimes available to this conversation.'
+      }
     case 'notebook_bind_runtime':
     case 'notebook_switch_runtime':
       return {
@@ -156,6 +162,12 @@ const isNetworkTool = (request: AcpPermissionRequest): boolean => {
   return request.toolKind === 'fetch' || name === 'webfetch' || name === 'websearch'
 }
 
+const withMcpActionDetail = (
+  request: AcpPermissionRequest,
+  presentation: PermissionPresentation
+): PermissionPresentation =>
+  request.isMcp ? { ...presentation, actionDetail: humanizeMcpAction(request) } : presentation
+
 const describePermissionRequest = (request: AcpPermissionRequest): PermissionPresentation => {
   const notebookToolName = resolveNotebookRunToolName(request.providerToolName, request.title)
   if (notebookToolName) {
@@ -169,13 +181,50 @@ const describePermissionRequest = (request: AcpPermissionRequest): PermissionPre
     .find((tool): tool is string => tool !== undefined)
   if (controlTool) return notebookControlPresentation(controlTool)
 
+  if (isNetworkTool(request)) {
+    return withMcpActionDetail(request, {
+      actionTitle: 'Access network resource?',
+      categoryLabel: 'Network access',
+      description: 'Sends a request to an external network resource.'
+    })
+  }
+
+  switch (request.toolKind) {
+    case 'read':
+    case 'search':
+      return withMcpActionDetail(request, {
+        actionTitle: 'Read files?',
+        categoryLabel: 'File access',
+        description: 'Reads or searches the listed files.'
+      })
+    case 'edit':
+      return withMcpActionDetail(request, {
+        actionTitle: 'Edit files?',
+        categoryLabel: 'File access',
+        description: 'Changes the listed files.'
+      })
+    case 'delete':
+      return withMcpActionDetail(request, {
+        actionTitle: 'Delete files?',
+        categoryLabel: 'File access',
+        description: 'Deletes the listed files.'
+      })
+    case 'move':
+      return withMcpActionDetail(request, {
+        actionTitle: 'Move files?',
+        categoryLabel: 'File access',
+        description: 'Moves the listed files.'
+      })
+    default:
+      break
+  }
+
   if (request.isMcp) {
-    return {
+    return withMcpActionDetail(request, {
       actionTitle: 'Use external service?',
       categoryLabel: 'External service',
-      description: 'Uses an MCP service configured for this conversation.',
-      actionDetail: humanizeMcpAction(request)
-    }
+      description: 'Uses an MCP service configured for this conversation.'
+    })
   }
 
   if (request.providerToolName === 'Bash' || request.toolKind === 'execute') {
@@ -186,46 +235,10 @@ const describePermissionRequest = (request: AcpPermissionRequest): PermissionPre
     }
   }
 
-  if (isNetworkTool(request)) {
-    return {
-      actionTitle: 'Access network resource?',
-      categoryLabel: 'Network access',
-      description: 'Sends a request to an external network resource.'
-    }
-  }
-
-  switch (request.toolKind) {
-    case 'read':
-    case 'search':
-      return {
-        actionTitle: 'Read files?',
-        categoryLabel: 'File access',
-        description: 'Reads or searches the listed files.'
-      }
-    case 'edit':
-      return {
-        actionTitle: 'Edit files?',
-        categoryLabel: 'File access',
-        description: 'Changes the listed files.'
-      }
-    case 'delete':
-      return {
-        actionTitle: 'Delete files?',
-        categoryLabel: 'File access',
-        description: 'Deletes the listed files.'
-      }
-    case 'move':
-      return {
-        actionTitle: 'Move files?',
-        categoryLabel: 'File access',
-        description: 'Moves the listed files.'
-      }
-    default:
-      return {
-        actionTitle: 'Allow tool access?',
-        categoryLabel: 'Tool access',
-        description: 'Allows this tool to run with the details shown below.'
-      }
+  return {
+    actionTitle: 'Allow tool access?',
+    categoryLabel: 'Tool access',
+    description: 'Allows this tool to run with the details shown below.'
   }
 }
 

--- a/src/renderer/src/pages/workspace/permission-request-presentation.ts
+++ b/src/renderer/src/pages/workspace/permission-request-presentation.ts
@@ -161,16 +161,16 @@ const isArtifactWriteToolName = (toolName: string | undefined): boolean => {
 }
 
 const isArtifactWriteRequest = (request: AcpPermissionRequest): boolean =>
-  isMcpPermissionRequest(request) &&
-  isArtifactWriteToolName(request.mcpIdentity)
+  isMcpPermissionRequest(request) && isArtifactWriteToolName(request.mcpIdentity)
 
-// The broker resolves a stable `server/tool` identity before the request reaches the renderer.
-// Keep it in the impact tip so a human-readable provider title cannot obscure the granted tool.
-const humanizeMcpIdentity = (identity: string | undefined): string | undefined => {
-  if (!identity) return undefined
+const humanizeMcpName = (name: string | undefined): string | undefined => {
+  const normalized = name?.trim().replace(/^mcp(?:__|\.)/iu, '') ?? ''
+  if (!normalized || /^(?:run )?(?:mcp )?(?:tool|tool request|tool call)$/iu.test(normalized)) {
+    return undefined
+  }
 
-  const segments = identity
-    .split('/')
+  const segments = normalized
+    .split(/__|\.|\//u)
     .filter(Boolean)
     .map((segment) =>
       segment
@@ -183,6 +183,16 @@ const humanizeMcpIdentity = (identity: string | undefined): string | undefined =
 
   return segments.length > 0 ? segments.join(' / ') : undefined
 }
+
+// The broker resolves a stable `server/tool` identity before the request reaches the renderer.
+// Keep it in the impact tip so a human-readable provider title cannot obscure the granted tool.
+const humanizeMcpIdentity = (identity: string | undefined): string | undefined =>
+  humanizeMcpName(identity)
+
+// A broker-classified MCP request can lack a stable grant identity (for example, a server-only
+// request). Keep that approval distinguishable without trusting the name for a privileged category.
+const humanizeUnresolvedMcp = (request: AcpPermissionRequest): string | undefined =>
+  humanizeMcpName(providerToolName(request) ?? request.title)
 
 const isNetworkTool = (request: AcpPermissionRequest): boolean => {
   const name = providerToolName(request)?.toLowerCase()
@@ -212,11 +222,12 @@ const describePermissionRequest = (request: AcpPermissionRequest): PermissionPre
   // MCP metadata describes the provider's tool, not a trusted local capability. Only the
   // explicitly modeled notebook tools above receive a more specific native classification.
   if (isMcpPermissionRequest(request)) {
+    const actionDetail = humanizeMcpIdentity(request.mcpIdentity) ?? humanizeUnresolvedMcp(request)
     return {
-      actionTitle: 'Use external service?',
+      actionTitle: actionDetail ? `Use ${actionDetail}?` : 'Use external service?',
       categoryLabel: 'External service',
       description: 'Uses an MCP service configured for this conversation.',
-      actionDetail: humanizeMcpIdentity(request.mcpIdentity)
+      actionDetail
     }
   }
 

--- a/src/renderer/src/pages/workspace/permission-request-presentation.ts
+++ b/src/renderer/src/pages/workspace/permission-request-presentation.ts
@@ -136,6 +136,16 @@ const notebookControlPresentation = (tool: string): PermissionPresentation => {
 const providerToolName = (request: AcpPermissionRequest): string | undefined =>
   request.providerToolName?.trim() || undefined
 
+const hasMcpProtocolPrefix = (name: string | undefined): boolean =>
+  /^mcp(?:__|\.)/iu.test(name ?? '')
+
+// Broker-projected isMcp is authoritative when present, but raw protocol names are also enough for
+// the renderer to avoid exposing or misclassifying a request when a provider omitted that flag.
+const isMcpPermissionRequest = (request: AcpPermissionRequest): boolean =>
+  request.isMcp ||
+  hasMcpProtocolPrefix(request.title) ||
+  hasMcpProtocolPrefix(request.providerToolName)
+
 // Keeps an otherwise-opaque MCP request distinguishable without surfacing its protocol spelling.
 // Provider names win when a bridge supplies only a boilerplate title.
 const isGenericMcpTitle = (title: string): boolean =>
@@ -149,7 +159,7 @@ const humanizeMcpAction = (request: AcpPermissionRequest): string | undefined =>
   if (!name || isOpaqueToolCallId(name)) return undefined
 
   const usesDottedNamespace = /^mcp\./iu.test(name)
-  const normalized = name.replace(/^mcp(?:__|\.)/u, '')
+  const normalized = name.replace(/^mcp(?:__|\.)/iu, '')
   const segments = normalized
     .split(usesDottedNamespace ? '.' : '__')
     .filter(Boolean)
@@ -185,7 +195,7 @@ const describePermissionRequest = (request: AcpPermissionRequest): PermissionPre
 
   // MCP metadata describes the provider's tool, not a trusted local capability. Only the
   // explicitly modeled notebook tools above receive a more specific native classification.
-  if (request.isMcp) {
+  if (isMcpPermissionRequest(request)) {
     return {
       actionTitle: 'Use external service?',
       categoryLabel: 'External service',
@@ -247,5 +257,5 @@ const describePermissionRequest = (request: AcpPermissionRequest): PermissionPre
   }
 }
 
-export { describePermissionRequest }
+export { describePermissionRequest, isMcpPermissionRequest }
 export type { NotebookRuntime, PermissionPresentation }

--- a/src/renderer/src/pages/workspace/permission-request-presentation.ts
+++ b/src/renderer/src/pages/workspace/permission-request-presentation.ts
@@ -1,0 +1,209 @@
+import type { AcpPermissionRequest } from '../../../../shared/acp'
+
+import {
+  matchNotebookControlTool,
+  resolveNotebookLanguage,
+  resolveNotebookRunToolName
+} from './notebook-tool-names'
+
+type NotebookRuntime = 'python' | 'r' | 'js' | 'bash'
+
+type PermissionPresentation = {
+  actionTitle: string
+  categoryLabel: string
+  description: string
+  notebookRuntime?: NotebookRuntime
+}
+
+type RequestInput = Record<string, unknown>
+
+const getRequestInput = (request: AcpPermissionRequest): RequestInput | undefined => {
+  const raw = request.rawInput
+  if (!raw || typeof raw !== 'object' || Array.isArray(raw)) return undefined
+
+  const record = raw as RequestInput
+  const nested = record.arguments
+  return nested && typeof nested === 'object' && !Array.isArray(nested)
+    ? (nested as RequestInput)
+    : record
+}
+
+const getCode = (input: RequestInput | undefined): string | undefined => {
+  for (const key of ['code', 'command', 'script']) {
+    const value = input?.[key]
+    if (typeof value === 'string' && value.trim()) return value
+  }
+  return undefined
+}
+
+const toNotebookRuntime = (language: string): NotebookRuntime => {
+  if (language === 'r') return 'r'
+  if (language === 'javascript') return 'js'
+  if (language === 'bash') return 'bash'
+  return 'python'
+}
+
+const notebookExecutionPresentation = (runtime: NotebookRuntime): PermissionPresentation => {
+  switch (runtime) {
+    case 'r':
+      return {
+        actionTitle: 'Run R code?',
+        categoryLabel: 'R execution',
+        description: 'Runs code in the current R notebook environment.',
+        notebookRuntime: runtime
+      }
+    case 'js':
+      return {
+        actionTitle: 'Run JS code?',
+        categoryLabel: 'JS REPL',
+        description: 'Runs code in the current JavaScript REPL.',
+        notebookRuntime: runtime
+      }
+    case 'bash':
+      return {
+        actionTitle: 'Run notebook command?',
+        categoryLabel: 'Notebook shell',
+        description: 'Runs a shell command in the current notebook session.',
+        notebookRuntime: runtime
+      }
+    default:
+      return {
+        actionTitle: 'Run Python code?',
+        categoryLabel: 'Python execution',
+        description: 'Runs code in the current Python notebook environment.',
+        notebookRuntime: runtime
+      }
+  }
+}
+
+const notebookControlPresentation = (tool: string): PermissionPresentation => {
+  switch (tool) {
+    case 'notebook_restart':
+      return {
+        actionTitle: 'Restart notebook?',
+        categoryLabel: 'Notebook control',
+        description:
+          'Restarts the current notebook environment. Running processes and unsaved runtime state may be lost.'
+      }
+    case 'notebook_shutdown':
+      return {
+        actionTitle: 'Shut down notebook?',
+        categoryLabel: 'Notebook control',
+        description: 'Stops the current notebook environment and its running processes.'
+      }
+    case 'notebook_state':
+      return {
+        actionTitle: 'View notebook state?',
+        categoryLabel: 'Notebook control',
+        description: 'Reads the current notebook environment and runtime state.'
+      }
+    case 'notebook_bind_runtime':
+    case 'notebook_switch_runtime':
+      return {
+        actionTitle: 'Change notebook runtime?',
+        categoryLabel: 'Notebook control',
+        description: 'Changes the runtime used by the current notebook session.'
+      }
+    case 'manage_packages':
+      return {
+        actionTitle: 'Manage notebook packages?',
+        categoryLabel: 'Notebook control',
+        description: 'Changes packages available in the current notebook environment.'
+      }
+    case 'manage_environments':
+      return {
+        actionTitle: 'Manage notebook environments?',
+        categoryLabel: 'Notebook control',
+        description: 'Changes notebook environment configuration.'
+      }
+    default:
+      return {
+        actionTitle: 'Use notebook controls?',
+        categoryLabel: 'Notebook control',
+        description: 'Changes or reads the current notebook environment.'
+      }
+  }
+}
+
+const providerToolName = (request: AcpPermissionRequest): string | undefined =>
+  request.providerToolName?.trim() || undefined
+
+const isNetworkTool = (request: AcpPermissionRequest): boolean => {
+  const name = providerToolName(request)?.toLowerCase()
+  return request.toolKind === 'fetch' || name === 'webfetch' || name === 'websearch'
+}
+
+const describePermissionRequest = (request: AcpPermissionRequest): PermissionPresentation => {
+  const notebookToolName = resolveNotebookRunToolName(request.providerToolName, request.title)
+  if (notebookToolName) {
+    const input = getRequestInput(request)
+    const language = resolveNotebookLanguage(notebookToolName, input, getCode(input))
+    return notebookExecutionPresentation(toNotebookRuntime(language))
+  }
+
+  const controlTool = [request.providerToolName, request.title]
+    .map(matchNotebookControlTool)
+    .find((tool): tool is string => tool !== undefined)
+  if (controlTool) return notebookControlPresentation(controlTool)
+
+  if (request.isMcp) {
+    return {
+      actionTitle: 'Use external service?',
+      categoryLabel: 'External service',
+      description: 'Uses an MCP service configured for this conversation.'
+    }
+  }
+
+  if (request.providerToolName === 'Bash' || request.toolKind === 'execute') {
+    return {
+      actionTitle: 'Run command?',
+      categoryLabel: 'Command execution',
+      description: 'Runs a command on this computer.'
+    }
+  }
+
+  if (isNetworkTool(request)) {
+    return {
+      actionTitle: 'Access network resource?',
+      categoryLabel: 'Network access',
+      description: 'Sends a request to an external network resource.'
+    }
+  }
+
+  switch (request.toolKind) {
+    case 'read':
+    case 'search':
+      return {
+        actionTitle: 'Read files?',
+        categoryLabel: 'File access',
+        description: 'Reads or searches the listed files.'
+      }
+    case 'edit':
+      return {
+        actionTitle: 'Edit files?',
+        categoryLabel: 'File access',
+        description: 'Changes the listed files.'
+      }
+    case 'delete':
+      return {
+        actionTitle: 'Delete files?',
+        categoryLabel: 'File access',
+        description: 'Deletes the listed files.'
+      }
+    case 'move':
+      return {
+        actionTitle: 'Move files?',
+        categoryLabel: 'File access',
+        description: 'Moves the listed files.'
+      }
+    default:
+      return {
+        actionTitle: 'Allow tool access?',
+        categoryLabel: 'Tool access',
+        description: 'Allows this tool to run with the details shown below.'
+      }
+  }
+}
+
+export { describePermissionRequest }
+export type { NotebookRuntime, PermissionPresentation }

--- a/src/renderer/src/pages/workspace/permission-request-presentation.ts
+++ b/src/renderer/src/pages/workspace/permission-request-presentation.ts
@@ -146,6 +146,29 @@ const isMcpPermissionRequest = (request: AcpPermissionRequest): boolean =>
   hasMcpProtocolPrefix(request.title) ||
   hasMcpProtocolPrefix(request.providerToolName)
 
+const ARTIFACT_SERVER_SEGMENT = 'open-science-artifacts'
+const ARTIFACT_WRITE_TOOL = 'write_artifact_file'
+
+const isArtifactWriteToolName = (toolName: string | undefined): boolean => {
+  const name = toolName?.trim().toLowerCase() ?? ''
+  if (!name) return false
+
+  const segments = name.split(/__|\./u)
+  if (segments.length >= 2) {
+    const tool = segments[segments.length - 1]
+    const server = segments[segments.length - 2].replace(/_/gu, '-')
+    if (server === ARTIFACT_SERVER_SEGMENT && tool === ARTIFACT_WRITE_TOOL) return true
+  }
+
+  return (
+    name === `${ARTIFACT_SERVER_SEGMENT}_${ARTIFACT_WRITE_TOOL}` ||
+    name === `open_science_artifacts_${ARTIFACT_WRITE_TOOL}`
+  )
+}
+
+const isArtifactWriteRequest = (request: AcpPermissionRequest): boolean =>
+  isArtifactWriteToolName(request.title) || isArtifactWriteToolName(request.providerToolName)
+
 // Keeps an otherwise-opaque MCP request distinguishable without surfacing its protocol spelling.
 // Provider names win when a bridge supplies only a boilerplate title.
 const isGenericMcpTitle = (title: string): boolean =>
@@ -192,6 +215,14 @@ const describePermissionRequest = (request: AcpPermissionRequest): PermissionPre
     .map(matchNotebookControlTool)
     .find((tool): tool is string => tool !== undefined)
   if (controlTool) return { ...notebookControlPresentation(controlTool), hideToolIdentity: true }
+
+  if (isArtifactWriteRequest(request)) {
+    return {
+      actionTitle: 'Write artifact file?',
+      categoryLabel: 'Artifact storage',
+      description: 'Saves a file to this conversation’s artifact storage.'
+    }
+  }
 
   // MCP metadata describes the provider's tool, not a trusted local capability. Only the
   // explicitly modeled notebook tools above receive a more specific native classification.
@@ -257,5 +288,5 @@ const describePermissionRequest = (request: AcpPermissionRequest): PermissionPre
   }
 }
 
-export { describePermissionRequest, isMcpPermissionRequest }
+export { describePermissionRequest, isArtifactWriteRequest, isMcpPermissionRequest }
 export type { NotebookRuntime, PermissionPresentation }

--- a/src/renderer/src/pages/workspace/permission-request-presentation.ts
+++ b/src/renderer/src/pages/workspace/permission-request-presentation.ts
@@ -12,6 +12,7 @@ type PermissionPresentation = {
   actionTitle: string
   categoryLabel: string
   description: string
+  actionDetail?: string
   notebookRuntime?: NotebookRuntime
 }
 
@@ -128,6 +129,28 @@ const notebookControlPresentation = (tool: string): PermissionPresentation => {
 const providerToolName = (request: AcpPermissionRequest): string | undefined =>
   request.providerToolName?.trim() || undefined
 
+// Keeps an otherwise-opaque MCP request distinguishable without surfacing its protocol spelling.
+// The request title is preferred because providers can reduce providerToolName to a bare leaf.
+const humanizeMcpAction = (request: AcpPermissionRequest): string | undefined => {
+  const name = request.title.trim() || providerToolName(request)
+  if (!name) return undefined
+
+  const normalized = name.replace(/^mcp(?:__|\.)/u, '')
+  const segments = normalized
+    .split(/__|\./u)
+    .filter(Boolean)
+    .map((segment) =>
+      segment
+        .split(/[-_]/u)
+        .filter(Boolean)
+        .map((word) => `${word.charAt(0).toUpperCase()}${word.slice(1)}`)
+        .join(' ')
+    )
+    .filter(Boolean)
+
+  return segments.length > 0 ? segments.join(' / ') : undefined
+}
+
 const isNetworkTool = (request: AcpPermissionRequest): boolean => {
   const name = providerToolName(request)?.toLowerCase()
   return request.toolKind === 'fetch' || name === 'webfetch' || name === 'websearch'
@@ -150,7 +173,8 @@ const describePermissionRequest = (request: AcpPermissionRequest): PermissionPre
     return {
       actionTitle: 'Use external service?',
       categoryLabel: 'External service',
-      description: 'Uses an MCP service configured for this conversation.'
+      description: 'Uses an MCP service configured for this conversation.',
+      actionDetail: humanizeMcpAction(request)
     }
   }
 

--- a/src/renderer/src/pages/workspace/workspace-components.test.tsx
+++ b/src/renderer/src/pages/workspace/workspace-components.test.tsx
@@ -319,7 +319,7 @@ describe('conversation message scroller integration', () => {
 
     // Outer container maintains width constraints (overflow-visible so the scope dropdown is not clipped)
     expect(permissionApprovalControlsSource).toContain(
-      'className="mb-2 flex w-full max-w-full flex-col gap-4 rounded-xl border border-border bg-card'
+      'className="mb-2 flex w-full max-w-full flex-col gap-3 rounded-xl border border-border bg-card'
     )
     // Header maintains min-w-0 for text truncation
     expect(permissionApprovalControlsSource).toContain(

--- a/src/shared/acp.ts
+++ b/src/shared/acp.ts
@@ -189,6 +189,9 @@ export type AcpPermissionRequest = {
   // Set by the permission broker after framework-aware classification so the renderer never has to
   // infer MCP origin from provider-specific titles or tool kinds.
   isMcp?: boolean
+  // Broker-resolved MCP server/tool identity (`server/tool`), projected only for display. This
+  // keeps presentation stable across provider-specific titles without exposing the protocol name.
+  mcpIdentity?: string
   toolKind?: ToolKind
   toolLocations?: ToolCallLocation[]
   rawInput?: unknown


### PR DESCRIPTION
Closes #365

## Problem

Permission approvals expose provider-specific tool identifiers that do not explain the action or its impact. Notebook execution also needs runtime-specific labels rather than one generic notebook category.

## Proposed change

- Add a pure renderer-side presentation classifier for pending permission requests.
- Show a plain-language action, impact summary, and category in the existing approval-card header.
- Distinguish Python, R, JS REPL, and notebook shell execution while preserving the existing environment badge and code preview.
- Explain notebook control operations such as restart without exposing raw MCP identifiers.
- Classify file, network, command, MCP-service, and fallback tool requests without altering ACP responses or session grants.

## Scope and non-goals

- Does not change permission matching, Once/This conversation semantics, IPC, persistence, or provider policy.
- Does not include the separate OpenCode Skill-loading authorization alignment.
- Raw protocol identifiers remain in local logs and are intentionally omitted from approval cards.

## Acceptance criteria and validation

- `npm run typecheck` passes.
- `npm run lint -- --quiet` passes.
- Targeted permission presentation and approval tests: 70 passed.
- `git diff --check` passes.
- Full `npm test` was run outside the sandbox; unrelated existing failures remain in ProjectFilesView, packaging, and several workspace preview test files.

## Review focus

- Exact notebook-server identity matching for execution and control tools.
- Presentation classification remains renderer-only and cannot affect authorization behavior.
- MCP identifiers are not shown in the approval card.