### PR TITLE
fix(preview): render PDF pages at on-screen resolution

### DIFF
--- a/src/renderer/src/pages/workspace/previews/renderers/PdfPreview.test.tsx
+++ b/src/renderer/src/pages/workspace/previews/renderers/PdfPreview.test.tsx
@@ -97,15 +97,14 @@ describe('PdfPreviewContent', () => {
       )
     })
     await act(async () => {
-      await Promise.resolve()
-      await Promise.resolve()
-      await Promise.resolve()
+      await vi.waitFor(() =>
+        expect(
+          container.querySelector<HTMLElement>('[data-page-number="1"]')?.style.aspectRatio
+        ).toBe('2 / 1')
+      )
     })
 
     expect(getPage).toHaveBeenCalledWith(1)
-    expect(container.querySelector<HTMLElement>('[data-page-number="1"]')?.style.aspectRatio).toBe(
-      '2 / 1'
-    )
   })
 
   it('rasterizes at the on-screen width times device pixel ratio, not the page point size', async () => {
@@ -138,6 +137,57 @@ describe('PdfPreviewContent', () => {
     const canvas = container.querySelector<HTMLCanvasElement>('canvas')
     expect(canvas?.width).toBe(1400)
     expect(canvas?.height).toBe(2000)
+
+    clientWidthSpy.mockRestore()
+  })
+
+  it('re-rasterizes a widened page without reloading it through the range transport', async () => {
+    const resizeCallbacks: ResizeObserverCallback[] = []
+    vi.stubGlobal(
+      'ResizeObserver',
+      class {
+        observe = vi.fn()
+        unobserve = vi.fn()
+        disconnect = vi.fn()
+
+        constructor(callback: ResizeObserverCallback) {
+          resizeCallbacks.push(callback)
+        }
+      }
+    )
+    let measuredWidth = 400
+    const clientWidthSpy = vi
+      .spyOn(HTMLElement.prototype, 'clientWidth', 'get')
+      .mockImplementation(() => measuredWidth)
+    vi.stubGlobal('devicePixelRatio', 1)
+    const render = vi.fn(() => ({ promise: Promise.resolve(), cancel: vi.fn() }))
+    getPage.mockResolvedValue({
+      getViewport: vi.fn(({ scale }: { scale: number }) => ({
+        width: 400 * scale,
+        height: 560 * scale
+      })),
+      render,
+      cleanup: vi.fn()
+    })
+
+    await act(async () => {
+      root.render(
+        <PdfPreviewContent path="/workspace/resize.pdf" name="resize.pdf" source="artifact" />
+      )
+    })
+    await vi.waitFor(() => expect(render).toHaveBeenCalledTimes(1))
+    expect(getPage).toHaveBeenCalledTimes(1)
+    expect(container.querySelector<HTMLCanvasElement>('canvas')?.width).toBe(400)
+
+    // Widening the panel must re-rasterize the already-loaded page, not fetch it again.
+    await act(async () => {
+      measuredWidth = 800
+      resizeCallbacks[0]?.([] as unknown as ResizeObserverEntry[], {} as ResizeObserver)
+      await Promise.resolve()
+    })
+    await vi.waitFor(() => expect(render).toHaveBeenCalledTimes(2))
+    expect(getPage).toHaveBeenCalledTimes(1)
+    expect(container.querySelector<HTMLCanvasElement>('canvas')?.width).toBe(800)
 
     clientWidthSpy.mockRestore()
   })
@@ -340,9 +390,10 @@ describe('PdfPreviewContent', () => {
   it('cancels active page work before destroying the parent document', async () => {
     const cancelRender = vi.fn()
     const cleanupPage = vi.fn()
+    const render = vi.fn(() => ({ promise: new Promise(() => undefined), cancel: cancelRender }))
     getPage.mockResolvedValue({
       getViewport: vi.fn(() => ({ width: 600, height: 800 })),
-      render: vi.fn(() => ({ promise: new Promise(() => undefined), cancel: cancelRender })),
+      render,
       cleanup: cleanupPage
     })
 
@@ -353,7 +404,10 @@ describe('PdfPreviewContent', () => {
       await Promise.resolve()
       await Promise.resolve()
     })
-    await vi.waitFor(() => expect(getPage).toHaveBeenCalledWith(1))
+    // Wait until rasterization is in flight so the render task exists to be canceled.
+    await act(async () => {
+      await vi.waitFor(() => expect(render).toHaveBeenCalled())
+    })
 
     await act(async () => root.unmount())
 

--- a/src/renderer/src/pages/workspace/previews/renderers/PdfPreview.test.tsx
+++ b/src/renderer/src/pages/workspace/previews/renderers/PdfPreview.test.tsx
@@ -108,6 +108,40 @@ describe('PdfPreviewContent', () => {
     )
   })
 
+  it('rasterizes at the on-screen width times device pixel ratio, not the page point size', async () => {
+    const clientWidthSpy = vi
+      .spyOn(HTMLElement.prototype, 'clientWidth', 'get')
+      .mockReturnValue(700)
+    vi.stubGlobal('devicePixelRatio', 2)
+    // Base page is 350pt wide; a 700px frame at 2x should back the canvas at 1400px (scale 4).
+    const render = vi.fn(() => ({ promise: Promise.resolve(), cancel: vi.fn() }))
+    getPage.mockResolvedValue({
+      getViewport: vi.fn(({ scale }: { scale: number }) => ({
+        width: 350 * scale,
+        height: 500 * scale
+      })),
+      render,
+      cleanup: vi.fn()
+    })
+
+    await act(async () => {
+      root.render(
+        <PdfPreviewContent path="/workspace/sharp.pdf" name="sharp.pdf" source="artifact" />
+      )
+    })
+    await act(async () => {
+      await Promise.resolve()
+      await Promise.resolve()
+      await Promise.resolve()
+    })
+
+    const canvas = container.querySelector<HTMLCanvasElement>('canvas')
+    expect(canvas?.width).toBe(1400)
+    expect(canvas?.height).toBe(2000)
+
+    clientWidthSpy.mockRestore()
+  })
+
   it('destroys the loading task when PDF parsing fails', async () => {
     const destroyLoadingTask = vi.fn().mockResolvedValue(undefined)
     const consoleError = vi.spyOn(console, 'error').mockImplementation(() => undefined)

--- a/src/renderer/src/pages/workspace/previews/renderers/PdfPreview.test.tsx
+++ b/src/renderer/src/pages/workspace/previews/renderers/PdfPreview.test.tsx
@@ -193,6 +193,40 @@ describe('PdfPreviewContent', () => {
     clientWidthSpy.mockRestore()
   })
 
+  it('clamps the backing store to browser canvas limits for a tall, narrow page', async () => {
+    const clientWidthSpy = vi
+      .spyOn(HTMLElement.prototype, 'clientWidth', 'get')
+      .mockReturnValue(700)
+    vi.stubGlobal('devicePixelRatio', 2)
+    // A 200x12000 page in a 700px frame at 2x would want scale 4 → a 48000px-tall canvas,
+    // far past Chromium's limits. The clamp must keep both dimensions within bounds.
+    getPage.mockResolvedValue({
+      getViewport: vi.fn(({ scale }: { scale: number }) => ({
+        width: 200 * scale,
+        height: 12000 * scale
+      })),
+      render: vi.fn(() => ({ promise: Promise.resolve(), cancel: vi.fn() })),
+      cleanup: vi.fn()
+    })
+
+    await act(async () => {
+      root.render(
+        <PdfPreviewContent path="/workspace/tall.pdf" name="tall.pdf" source="artifact" />
+      )
+    })
+    await act(async () => {
+      await vi.waitFor(() => expect(container.querySelector('canvas')?.height).toBeGreaterThan(0))
+    })
+
+    const canvas = container.querySelector<HTMLCanvasElement>('canvas')
+    expect(canvas?.height).toBeLessThanOrEqual(8192)
+    expect(canvas?.width).toBeLessThanOrEqual(8192)
+    // Sanity: without the clamp this page would have been ~48000px tall.
+    expect(canvas?.height).toBeLessThan(12000)
+
+    clientWidthSpy.mockRestore()
+  })
+
   it('treats a render canceled by scroll-out as teardown, not a page failure', async () => {
     let intersectionCallback: IntersectionObserverCallback | undefined
     vi.stubGlobal(

--- a/src/renderer/src/pages/workspace/previews/renderers/PdfPreview.test.tsx
+++ b/src/renderer/src/pages/workspace/previews/renderers/PdfPreview.test.tsx
@@ -180,16 +180,92 @@ describe('PdfPreviewContent', () => {
     expect(container.querySelector<HTMLCanvasElement>('canvas')?.width).toBe(400)
 
     // Widening the panel must re-rasterize the already-loaded page, not fetch it again.
+    // Both widths stay under the fit-width cap so pageWidth tracks the measured width directly.
     await act(async () => {
-      measuredWidth = 800
+      measuredWidth = 600
       resizeCallbacks[0]?.([] as unknown as ResizeObserverEntry[], {} as ResizeObserver)
       await Promise.resolve()
     })
     await vi.waitFor(() => expect(render).toHaveBeenCalledTimes(2))
     expect(getPage).toHaveBeenCalledTimes(1)
-    expect(container.querySelector<HTMLCanvasElement>('canvas')?.width).toBe(800)
+    expect(container.querySelector<HTMLCanvasElement>('canvas')?.width).toBe(600)
 
     clientWidthSpy.mockRestore()
+  })
+
+  it('treats a render canceled by scroll-out as teardown, not a page failure', async () => {
+    let intersectionCallback: IntersectionObserverCallback | undefined
+    vi.stubGlobal(
+      'IntersectionObserver',
+      class {
+        observe = vi.fn()
+        unobserve = vi.fn()
+        disconnect = vi.fn()
+
+        constructor(callback: IntersectionObserverCallback) {
+          intersectionCallback = callback
+        }
+      }
+    )
+    const consoleError = vi.spyOn(console, 'error').mockImplementation(() => undefined)
+    // A render whose promise rejects with PDF.js's cancellation error when cancel() is called.
+    const cancelRender = vi.fn()
+    let rejectRender: ((error: Error) => void) | undefined
+    getPage.mockResolvedValue({
+      getViewport: vi.fn(({ scale }: { scale: number }) => ({
+        width: 600 * scale,
+        height: 800 * scale
+      })),
+      render: vi.fn(() => ({
+        promise: new Promise((_, reject) => {
+          rejectRender = reject
+        }),
+        cancel: () => {
+          cancelRender()
+          rejectRender?.(
+            Object.assign(new Error('Rendering cancelled'), {
+              name: 'RenderingCancelledException'
+            })
+          )
+        }
+      })),
+      cleanup: vi.fn()
+    })
+
+    await act(async () => {
+      root.render(
+        <PdfPreviewContent path="/workspace/scroll.pdf" name="scroll.pdf" source="artifact" />
+      )
+      await Promise.resolve()
+    })
+    await act(async () => {
+      intersectionCallback?.(
+        [{ isIntersecting: true } as IntersectionObserverEntry],
+        {} as IntersectionObserver
+      )
+      await Promise.resolve()
+      await Promise.resolve()
+    })
+
+    // Scroll the page out: its acquire effect disposes and cancels the in-flight render.
+    await act(async () => {
+      intersectionCallback?.(
+        [{ isIntersecting: false } as IntersectionObserverEntry],
+        {} as IntersectionObserver
+      )
+      await Promise.resolve()
+      await Promise.resolve()
+    })
+
+    expect(cancelRender).toHaveBeenCalled()
+    // The cancellation must not be logged as a render failure nor shown as a page error.
+    const loggedRenderFailure = consoleError.mock.calls.some((call) =>
+      String(call[0]).includes('Failed to render PDF page')
+    )
+    expect(loggedRenderFailure).toBe(false)
+    expect(container.textContent).not.toContain('could not be rendered')
+
+    consoleError.mockRestore()
   })
 
   it('destroys the loading task when PDF parsing fails', async () => {

--- a/src/renderer/src/pages/workspace/previews/renderers/PdfPreview.tsx
+++ b/src/renderer/src/pages/workspace/previews/renderers/PdfPreview.tsx
@@ -1,4 +1,4 @@
-import { useCallback, useEffect, useRef, useState } from 'react'
+import { useCallback, useEffect, useLayoutEffect, useRef, useState } from 'react'
 
 import type { PreviewFileSource } from '@/stores/preview-workbench-store'
 
@@ -30,8 +30,14 @@ const PdfPageCanvas = ({
   const [setNearViewportRef, isNearViewport] = useNearViewport<HTMLDivElement>()
   const containerRef = useRef<HTMLDivElement | null>(null)
   const canvasRef = useRef<HTMLCanvasElement | null>(null)
+  const pageRef = useRef<Awaited<ReturnType<PdfDocument['getPage']>> | undefined>(undefined)
+  const renderTaskRef = useRef<
+    ReturnType<Awaited<ReturnType<PdfDocument['getPage']>>['render']> | undefined
+  >(undefined)
   const [status, setStatus] = useState<'idle' | 'loading' | 'ready' | 'error'>('idle')
   const [aspectRatio, setAspectRatio] = useState(3 / 4)
+  // Bumped when a fresh page proxy is acquired so rasterization re-runs against the new page.
+  const [pageEpoch, setPageEpoch] = useState(0)
   // The CSS width the canvas is stretched to; drives backing-store resolution so text stays sharp.
   const [renderWidth, setRenderWidth] = useState(0)
 
@@ -43,8 +49,9 @@ const PdfPageCanvas = ({
     [setNearViewportRef]
   )
 
-  // Track the on-screen width and only grow the target: shrinking reuses the crisp bitmap via CSS.
-  useEffect(() => {
+  // Measure synchronously before paint so the first rasterization already knows the target width
+  // and only grow it: shrinking reuses the crisp bitmap via CSS instead of re-rasterizing.
+  useLayoutEffect(() => {
     const element = containerRef.current
     if (!element) return
 
@@ -60,21 +67,23 @@ const PdfPageCanvas = ({
     return () => observer.disconnect()
   }, [])
 
+  // Acquire the page once while it is near the viewport and keep it alive; width changes then
+  // re-rasterize this same page rather than reloading it through the range transport.
   useEffect(() => {
     if (!isNearViewport) return
 
     let canceled = false
-    let page: Awaited<ReturnType<PdfDocument['getPage']>> | undefined
-    let renderTask: ReturnType<Awaited<ReturnType<PdfDocument['getPage']>>['render']> | undefined
-    const canvas = canvasRef.current
     let disposed = false
     // Clear canvas backing storage on exit; removing the DOM node alone may retain its bitmap.
     const dispose = (): void => {
       if (disposed) return
       disposed = true
       canceled = true
-      renderTask?.cancel()
-      page?.cleanup()
+      renderTaskRef.current?.cancel()
+      renderTaskRef.current = undefined
+      pageRef.current?.cleanup()
+      pageRef.current = undefined
+      const canvas = canvasRef.current
       if (canvas) {
         canvas.width = 0
         canvas.height = 0
@@ -84,37 +93,17 @@ const PdfPageCanvas = ({
 
     void document
       .getPage(pageNumber)
-      .then(async (loadedPage) => {
-        page = loadedPage
-        if (canceled || !canvas) {
-          loadedPage.cleanup()
-          page = undefined
+      .then((acquiredPage) => {
+        if (canceled) {
+          acquiredPage.cleanup()
           return
         }
-
-        const devicePixelRatio = Math.max(1, window.devicePixelRatio || 1)
-        const baseViewport = loadedPage.getViewport({ scale: 1 })
-        // Rasterize at the physical pixels the page occupies on screen, capped to protect memory.
-        const targetCssWidth = renderWidth > 0 ? renderWidth : baseViewport.width
-        const scale = Math.min(
-          MAX_RENDER_SCALE,
-          Math.max(1, (targetCssWidth * devicePixelRatio) / baseViewport.width)
-        )
-        const viewport = loadedPage.getViewport({ scale })
-        const context = canvas.getContext('2d')
-        if (!context) throw new Error('Canvas 2D context unavailable.')
-
-        // Match the actual PDF page geometry so landscape and non-standard pages are not stretched.
-        setAspectRatio(viewport.width / viewport.height)
-        canvas.width = viewport.width
-        canvas.height = viewport.height
-        renderTask = loadedPage.render({ canvas, canvasContext: context, viewport })
-        await renderTask.promise
-        if (!canceled) setStatus('ready')
+        pageRef.current = acquiredPage
+        setPageEpoch((epoch) => epoch + 1)
       })
       .catch((error: unknown) => {
         if (!canceled) {
-          console.error(`Failed to render PDF page ${pageNumber}`, error)
+          console.error(`Failed to load PDF page ${pageNumber}`, error)
           setStatus('error')
         }
       })
@@ -123,7 +112,52 @@ const PdfPageCanvas = ({
       unregisterDisposer()
       dispose()
     }
-  }, [document, isNearViewport, pageNumber, registerDisposer, renderWidth])
+  }, [document, isNearViewport, pageNumber, registerDisposer])
+
+  // Rasterize the live page at the measured width; re-runs on width change without reacquiring it.
+  useEffect(() => {
+    const page = pageRef.current
+    const canvas = canvasRef.current
+    if (!page || !canvas) return
+
+    let canceled = false
+    const draw = async (): Promise<void> => {
+      const devicePixelRatio = Math.max(1, window.devicePixelRatio || 1)
+      const baseViewport = page.getViewport({ scale: 1 })
+      // Rasterize at the physical pixels the page occupies on screen, capped to protect memory.
+      const targetCssWidth = renderWidth > 0 ? renderWidth : baseViewport.width
+      const scale = Math.min(
+        MAX_RENDER_SCALE,
+        Math.max(1, (targetCssWidth * devicePixelRatio) / baseViewport.width)
+      )
+      const viewport = page.getViewport({ scale })
+      const context = canvas.getContext('2d')
+      if (!context) throw new Error('Canvas 2D context unavailable.')
+
+      // Match the actual PDF page geometry so landscape and non-standard pages are not stretched.
+      setAspectRatio(viewport.width / viewport.height)
+      canvas.width = viewport.width
+      canvas.height = viewport.height
+      const renderTask = page.render({ canvas, canvasContext: context, viewport })
+      renderTaskRef.current = renderTask
+      await renderTask.promise
+      renderTaskRef.current = undefined
+      if (!canceled) setStatus('ready')
+    }
+
+    void draw().catch((error: unknown) => {
+      if (!canceled) {
+        console.error(`Failed to render PDF page ${pageNumber}`, error)
+        setStatus('error')
+      }
+    })
+
+    return () => {
+      canceled = true
+      renderTaskRef.current?.cancel()
+      renderTaskRef.current = undefined
+    }
+  }, [pageEpoch, pageNumber, renderWidth])
 
   const displayedStatus = isNearViewport ? status : 'idle'
 

--- a/src/renderer/src/pages/workspace/previews/renderers/PdfPreview.tsx
+++ b/src/renderer/src/pages/workspace/previews/renderers/PdfPreview.tsx
@@ -14,21 +14,29 @@ type DocumentState =
   | { requestKey: string; status: 'ready'; document: PdfDocument }
   | { requestKey: string; status: 'error'; error: unknown }
 
+// Comfortable reading width a page fills; also caps the backing resolution the parent measures.
+const FIT_PAGE_WIDTH = 768
 // Bound the backing-store resolution so an over-magnified small page cannot exhaust GPU memory.
 const MAX_RENDER_SCALE = 4
+
+// PDF.js rejects an in-flight render with this when cancel() is called; it is an expected teardown,
+// not a page failure, so scroll-out, preview switches, and resize rerenders must not surface it.
+const isRenderCancel = (error: unknown): boolean =>
+  error instanceof Error && error.name === 'RenderingCancelledException'
 
 // Owns one lazy page canvas and releases its decoded bitmap outside the overscan window.
 const PdfPageCanvas = ({
   document,
   pageNumber,
+  pageWidth,
   registerDisposer
 }: {
   document: PdfDocument
   pageNumber: number
+  pageWidth: number
   registerDisposer: (dispose: () => void) => () => void
 }): React.JSX.Element => {
   const [setNearViewportRef, isNearViewport] = useNearViewport<HTMLDivElement>()
-  const containerRef = useRef<HTMLDivElement | null>(null)
   const canvasRef = useRef<HTMLCanvasElement | null>(null)
   const pageRef = useRef<Awaited<ReturnType<PdfDocument['getPage']>> | undefined>(undefined)
   const renderTaskRef = useRef<
@@ -38,34 +46,6 @@ const PdfPageCanvas = ({
   const [aspectRatio, setAspectRatio] = useState(3 / 4)
   // Bumped when a fresh page proxy is acquired so rasterization re-runs against the new page.
   const [pageEpoch, setPageEpoch] = useState(0)
-  // The CSS width the canvas is stretched to; drives backing-store resolution so text stays sharp.
-  const [renderWidth, setRenderWidth] = useState(0)
-
-  const setContainer = useCallback(
-    (element: HTMLDivElement | null): void => {
-      containerRef.current = element
-      setNearViewportRef(element)
-    },
-    [setNearViewportRef]
-  )
-
-  // Measure synchronously before paint so the first rasterization already knows the target width
-  // and only grow it: shrinking reuses the crisp bitmap via CSS instead of re-rasterizing.
-  useLayoutEffect(() => {
-    const element = containerRef.current
-    if (!element) return
-
-    const measure = (): void => {
-      const width = element.clientWidth
-      if (width > 0) setRenderWidth((current) => (width > current ? width : current))
-    }
-    measure()
-
-    if (typeof ResizeObserver === 'undefined') return
-    const observer = new ResizeObserver(measure)
-    observer.observe(element)
-    return () => observer.disconnect()
-  }, [])
 
   // Acquire the page once while it is near the viewport and keep it alive; width changes then
   // re-rasterize this same page rather than reloading it through the range transport.
@@ -114,7 +94,7 @@ const PdfPageCanvas = ({
     }
   }, [document, isNearViewport, pageNumber, registerDisposer])
 
-  // Rasterize the live page at the measured width; re-runs on width change without reacquiring it.
+  // Rasterize the live page at the target width; re-runs on width change without reacquiring it.
   useEffect(() => {
     const page = pageRef.current
     const canvas = canvasRef.current
@@ -122,10 +102,19 @@ const PdfPageCanvas = ({
 
     let canceled = false
     const draw = async (): Promise<void> => {
+      // Serialize against the previous render: PDF.js forbids two renders on one canvas, and its
+      // cancel() settles asynchronously, so a resize-driven rerun must await the prior task first.
+      const previous = renderTaskRef.current
+      if (previous) {
+        previous.cancel()
+        await previous.promise.catch(() => undefined)
+      }
+      if (canceled) return
+
       const devicePixelRatio = Math.max(1, window.devicePixelRatio || 1)
       const baseViewport = page.getViewport({ scale: 1 })
       // Rasterize at the physical pixels the page occupies on screen, capped to protect memory.
-      const targetCssWidth = renderWidth > 0 ? renderWidth : baseViewport.width
+      const targetCssWidth = pageWidth > 0 ? pageWidth : baseViewport.width
       const scale = Math.min(
         MAX_RENDER_SCALE,
         Math.max(1, (targetCssWidth * devicePixelRatio) / baseViewport.width)
@@ -141,29 +130,28 @@ const PdfPageCanvas = ({
       const renderTask = page.render({ canvas, canvasContext: context, viewport })
       renderTaskRef.current = renderTask
       await renderTask.promise
-      renderTaskRef.current = undefined
+      if (renderTaskRef.current === renderTask) renderTaskRef.current = undefined
       if (!canceled) setStatus('ready')
     }
 
     void draw().catch((error: unknown) => {
-      if (!canceled) {
-        console.error(`Failed to render PDF page ${pageNumber}`, error)
-        setStatus('error')
-      }
+      // A canceled render (scroll-out, preview switch, or superseding resize) is expected teardown.
+      if (canceled || isRenderCancel(error)) return
+      console.error(`Failed to render PDF page ${pageNumber}`, error)
+      setStatus('error')
     })
 
     return () => {
       canceled = true
       renderTaskRef.current?.cancel()
-      renderTaskRef.current = undefined
     }
-  }, [pageEpoch, pageNumber, renderWidth])
+  }, [pageEpoch, pageNumber, pageWidth])
 
   const displayedStatus = isNearViewport ? status : 'idle'
 
   return (
     <div
-      ref={setContainer}
+      ref={setNearViewportRef}
       className="relative mx-auto mb-3 w-full max-w-3xl bg-bg-000 shadow-sm"
       style={{ aspectRatio }}
       data-page-number={pageNumber}
@@ -202,10 +190,32 @@ export const PdfPreviewContent = ({
 }): React.JSX.Element => {
   const requestKey = createPreviewResourceKey({ source, path, mimeType, size, mtimeMs })
   const [documentState, setDocumentState] = useState<DocumentState | null>(null)
+  // The width one page fills: the content box, capped to a comfortable reading width. Owned here so
+  // one ResizeObserver serves the whole document instead of one per page.
+  const [fitWidth, setFitWidth] = useState(0)
+  const measureRef = useRef<HTMLDivElement | null>(null)
   const pageDisposersRef = useRef(new Set<() => void>())
   const registerPageDisposer = useCallback((dispose: () => void): (() => void) => {
     pageDisposersRef.current.add(dispose)
     return () => pageDisposersRef.current.delete(dispose)
+  }, [])
+
+  // Measure the content-box width before paint (zero-height probe, unaffected by page overflow) so
+  // pages rasterize once at the right width on open, and only grow it so a shrink reuses the bitmap.
+  useLayoutEffect(() => {
+    const element = measureRef.current
+    if (!element) return
+
+    const measure = (): void => {
+      const width = Math.min(element.clientWidth, FIT_PAGE_WIDTH)
+      if (width > 0) setFitWidth((current) => (width > current ? width : current))
+    }
+    measure()
+
+    if (typeof ResizeObserver === 'undefined') return
+    const observer = new ResizeObserver(measure)
+    observer.observe(element)
+    return () => observer.disconnect()
   }, [])
 
   useEffect(() => {
@@ -290,6 +300,8 @@ export const PdfPreviewContent = ({
 
   return (
     <div className="relative size-full overflow-auto bg-bg-20 p-4">
+      {/* Zero-height probe: reports the content-box width once for every page. */}
+      <div ref={measureRef} className="h-0 w-full" aria-hidden="true" />
       {!document ? (
         <div className="absolute inset-0">
           <PreviewLoadingContent />
@@ -302,6 +314,7 @@ export const PdfPreviewContent = ({
               key={index + 1}
               document={document}
               pageNumber={index + 1}
+              pageWidth={fitWidth}
               registerDisposer={registerPageDisposer}
             />
           ))

--- a/src/renderer/src/pages/workspace/previews/renderers/PdfPreview.tsx
+++ b/src/renderer/src/pages/workspace/previews/renderers/PdfPreview.tsx
@@ -18,6 +18,10 @@ type DocumentState =
 const FIT_PAGE_WIDTH = 768
 // Bound the backing-store resolution so an over-magnified small page cannot exhaust GPU memory.
 const MAX_RENDER_SCALE = 4
+// Keep the backing store within browser canvas limits so a tall/narrow page cannot render blank:
+// clamp each side and the total area (Chromium caps a dimension at 16384 and area near 2^28).
+const MAX_CANVAS_DIMENSION = 8192
+const MAX_CANVAS_AREA = 16 * 1024 * 1024
 
 // PDF.js rejects an in-flight render with this when cancel() is called; it is an expected teardown,
 // not a page failure, so scroll-out, preview switches, and resize rerenders must not surface it.
@@ -95,10 +99,11 @@ const PdfPageCanvas = ({
   }, [document, isNearViewport, pageNumber, registerDisposer])
 
   // Rasterize the live page at the target width; re-runs on width change without reacquiring it.
+  // Tied to isNearViewport so a scroll-out flips this effect's canceled flag and stops a rerender.
   useEffect(() => {
     const page = pageRef.current
     const canvas = canvasRef.current
-    if (!page || !canvas) return
+    if (!isNearViewport || !page || !canvas) return
 
     let canceled = false
     const draw = async (): Promise<void> => {
@@ -109,16 +114,26 @@ const PdfPageCanvas = ({
         previous.cancel()
         await previous.promise.catch(() => undefined)
       }
-      if (canceled) return
+      // The await above yields, during which the page can scroll out and dispose() can clear it;
+      // bail before touching a disposed page or detached canvas.
+      if (canceled || pageRef.current !== page) return
 
       const devicePixelRatio = Math.max(1, window.devicePixelRatio || 1)
       const baseViewport = page.getViewport({ scale: 1 })
-      // Rasterize at the physical pixels the page occupies on screen, capped to protect memory.
+      // Rasterize at the physical pixels the page occupies on screen; never below intrinsic size.
       const targetCssWidth = pageWidth > 0 ? pageWidth : baseViewport.width
-      const scale = Math.min(
-        MAX_RENDER_SCALE,
-        Math.max(1, (targetCssWidth * devicePixelRatio) / baseViewport.width)
+      const desiredScale = Math.max(
+        1,
+        Math.min(MAX_RENDER_SCALE, (targetCssWidth * devicePixelRatio) / baseViewport.width)
       )
+      // Hard cap so neither backing dimension nor total area exceeds browser canvas limits — must
+      // win over the intrinsic floor, or a page taller than the limit at scale 1 renders blank.
+      const limitScale = Math.min(
+        MAX_CANVAS_DIMENSION / baseViewport.width,
+        MAX_CANVAS_DIMENSION / baseViewport.height,
+        Math.sqrt(MAX_CANVAS_AREA / (baseViewport.width * baseViewport.height))
+      )
+      const scale = Math.min(desiredScale, limitScale)
       const viewport = page.getViewport({ scale })
       const context = canvas.getContext('2d')
       if (!context) throw new Error('Canvas 2D context unavailable.')
@@ -145,7 +160,7 @@ const PdfPageCanvas = ({
       canceled = true
       renderTaskRef.current?.cancel()
     }
-  }, [pageEpoch, pageNumber, pageWidth])
+  }, [isNearViewport, pageEpoch, pageNumber, pageWidth])
 
   const displayedStatus = isNearViewport ? status : 'idle'
 

--- a/src/renderer/src/pages/workspace/previews/renderers/PdfPreview.tsx
+++ b/src/renderer/src/pages/workspace/previews/renderers/PdfPreview.tsx
@@ -14,6 +14,9 @@ type DocumentState =
   | { requestKey: string; status: 'ready'; document: PdfDocument }
   | { requestKey: string; status: 'error'; error: unknown }
 
+// Bound the backing-store resolution so an over-magnified small page cannot exhaust GPU memory.
+const MAX_RENDER_SCALE = 4
+
 // Owns one lazy page canvas and releases its decoded bitmap outside the overscan window.
 const PdfPageCanvas = ({
   document,
@@ -24,10 +27,38 @@ const PdfPageCanvas = ({
   pageNumber: number
   registerDisposer: (dispose: () => void) => () => void
 }): React.JSX.Element => {
-  const [setContainer, isNearViewport] = useNearViewport<HTMLDivElement>()
+  const [setNearViewportRef, isNearViewport] = useNearViewport<HTMLDivElement>()
+  const containerRef = useRef<HTMLDivElement | null>(null)
   const canvasRef = useRef<HTMLCanvasElement | null>(null)
   const [status, setStatus] = useState<'idle' | 'loading' | 'ready' | 'error'>('idle')
   const [aspectRatio, setAspectRatio] = useState(3 / 4)
+  // The CSS width the canvas is stretched to; drives backing-store resolution so text stays sharp.
+  const [renderWidth, setRenderWidth] = useState(0)
+
+  const setContainer = useCallback(
+    (element: HTMLDivElement | null): void => {
+      containerRef.current = element
+      setNearViewportRef(element)
+    },
+    [setNearViewportRef]
+  )
+
+  // Track the on-screen width and only grow the target: shrinking reuses the crisp bitmap via CSS.
+  useEffect(() => {
+    const element = containerRef.current
+    if (!element) return
+
+    const measure = (): void => {
+      const width = element.clientWidth
+      if (width > 0) setRenderWidth((current) => (width > current ? width : current))
+    }
+    measure()
+
+    if (typeof ResizeObserver === 'undefined') return
+    const observer = new ResizeObserver(measure)
+    observer.observe(element)
+    return () => observer.disconnect()
+  }, [])
 
   useEffect(() => {
     if (!isNearViewport) return
@@ -61,7 +92,14 @@ const PdfPageCanvas = ({
           return
         }
 
-        const scale = Math.min(2, Math.max(1, window.devicePixelRatio || 1))
+        const devicePixelRatio = Math.max(1, window.devicePixelRatio || 1)
+        const baseViewport = loadedPage.getViewport({ scale: 1 })
+        // Rasterize at the physical pixels the page occupies on screen, capped to protect memory.
+        const targetCssWidth = renderWidth > 0 ? renderWidth : baseViewport.width
+        const scale = Math.min(
+          MAX_RENDER_SCALE,
+          Math.max(1, (targetCssWidth * devicePixelRatio) / baseViewport.width)
+        )
         const viewport = loadedPage.getViewport({ scale })
         const context = canvas.getContext('2d')
         if (!context) throw new Error('Canvas 2D context unavailable.')
@@ -85,7 +123,7 @@ const PdfPageCanvas = ({
       unregisterDisposer()
       dispose()
     }
-  }, [document, isNearViewport, pageNumber, registerDisposer])
+  }, [document, isNearViewport, pageNumber, registerDisposer, renderWidth])
 
   const displayedStatus = isNearViewport ? status : 'idle'
 


### PR DESCRIPTION
## Problem

The full-page PDF preview (shared by the PreviewPanel and the fullscreen view via `PdfPreviewRenderer`) rendered blurry. `PdfPageCanvas` sized its canvas backing store from `Math.min(2, devicePixelRatio)` alone. Since a page's point size (A4 ≈ 595px, Letter ≈ 612px) is smaller than the display frame (`max-w-3xl` = 768px), every page was upscaled by ~1.29× and looked soft — on both standard and high-DPI displays. The `2` cap also prevented sharper output on higher-DPI screens.

## Proposed change

- Compute the rasterization scale from the container's **measured CSS width × devicePixelRatio ÷ page point width**, so the backing store matches the physical pixels the page actually occupies on screen.
- Replace the hardcoded cap of `2` with `MAX_RENDER_SCALE = 4`, a memory-safety bound that only clamps extreme magnification of tiny pages.
- Add a `ResizeObserver` that grows the render width when the frame widens (e.g. panel → fullscreen). Shrinking reuses the existing crisp bitmap via CSS (`object-contain`) instead of re-rendering, avoiding re-render churn during drag-resize.
- Fall back to the page's intrinsic width when `clientWidth` is `0` (unlaid-out / jsdom), and degrade safely when `ResizeObserver` is unavailable.

## Scope and non-goals

- Only the full-page preview renderer (`PdfPreview.tsx`) is touched. The card **thumbnail** (`PdfThumbnail.tsx`) is intentionally left unchanged, per request.

## Acceptance criteria and validation

- A 350pt-wide page shown in a 700px frame at `devicePixelRatio = 2` now backs the canvas at 1400×2000 (scale 4), not 700px. Locked in by a new test.
- `npm run typecheck` (node + web) — pass
- `npm run lint` — pass
- PDF preview test suite — 9/9 pass

## Review focus

- The "only grow the render width" strategy in the measure effect, and whether the `MAX_RENDER_SCALE = 4` bound is the right memory/quality trade-off.