### PR TITLE
feat(preview): add zoom to the PDF preview

### DIFF
--- a/src/renderer/src/pages/workspace/previews/renderers/PdfPreview.test.tsx
+++ b/src/renderer/src/pages/workspace/previews/renderers/PdfPreview.test.tsx
@@ -612,6 +612,48 @@ describe('PdfPreviewContent', () => {
     clientWidthSpy.mockRestore()
   })
 
+  it('caps the backing scale at the deepest zoom to bound per-page memory', async () => {
+    const clientWidthSpy = vi
+      .spyOn(HTMLElement.prototype, 'clientWidth', 'get')
+      .mockReturnValue(768)
+    vi.stubGlobal('devicePixelRatio', 2)
+    // A4-like page (595x842) at 768px fit, 300% zoom, 2x DPI: the physical target scale is
+    // 768*3*2/595 = 7.74, and even the area clamp alone would allow ~5.79 (595*5.79 = 3443px).
+    // The MAX_RENDER_SCALE=5 ceiling caps it to 595*5 = 2975px so a page cannot take the full
+    // canvas-area budget.
+    getPage.mockResolvedValue({
+      getViewport: vi.fn(({ scale }: { scale: number }) => ({
+        width: 595 * scale,
+        height: 842 * scale
+      })),
+      render: vi.fn(() => ({ promise: Promise.resolve(), cancel: vi.fn() })),
+      cleanup: vi.fn()
+    })
+
+    await act(async () => {
+      root.render(
+        <PdfPreviewContent path="/workspace/deep.pdf" name="deep.pdf" source="artifact" />
+      )
+    })
+    await vi.waitFor(() => expect(container.querySelector('canvas')?.width).toBeGreaterThan(0))
+
+    // Zoom to the 300% max (eight 25% button steps).
+    for (let i = 0; i < 8; i += 1) {
+      await act(async () => {
+        container.querySelector<HTMLButtonElement>('[aria-label="Zoom in"]')?.click()
+        await Promise.resolve()
+      })
+    }
+    await vi.waitFor(() => expect(container.textContent).toContain('300%'))
+
+    const width = container.querySelector<HTMLCanvasElement>('canvas')?.width ?? 0
+    // Scale is capped at 5 → 595*5 = 2975, below the ~3443 the area clamp alone would permit.
+    expect(width).toBe(2975)
+    expect(width).toBeLessThan(3443)
+
+    clientWidthSpy.mockRestore()
+  })
+
   it('treats a render canceled by scroll-out as teardown, not a page failure', async () => {
     let intersectionCallback: IntersectionObserverCallback | undefined
     vi.stubGlobal(

--- a/src/renderer/src/pages/workspace/previews/renderers/PdfPreview.test.tsx
+++ b/src/renderer/src/pages/workspace/previews/renderers/PdfPreview.test.tsx
@@ -223,11 +223,17 @@ describe('PdfPreviewContent', () => {
     clientWidthSpy.mockRestore()
   })
 
-  it('zooms on Ctrl/Cmd+wheel and ignores a plain wheel scroll', async () => {
+  it('zooms proportionally on Ctrl/Cmd+wheel, coalesced per frame, and ignores plain scroll', async () => {
     const clientWidthSpy = vi
       .spyOn(HTMLElement.prototype, 'clientWidth', 'get')
       .mockReturnValue(400)
     vi.stubGlobal('devicePixelRatio', 1)
+    // Flush the wheel handler's requestAnimationFrame coalescing synchronously.
+    vi.stubGlobal('requestAnimationFrame', (cb: FrameRequestCallback): number => {
+      cb(0)
+      return 1
+    })
+    vi.stubGlobal('cancelAnimationFrame', () => undefined)
     getPage.mockResolvedValue({
       getViewport: vi.fn(({ scale }: { scale: number }) => ({
         width: 400 * scale,
@@ -257,14 +263,15 @@ describe('PdfPreviewContent', () => {
     })
     expect(container.textContent).toContain('100%')
 
-    // Ctrl+wheel up zooms in by one wheel step (100% -> 110%).
+    // Ctrl+wheel scales proportionally: deltaY -100 * 0.0025 = +0.25 (100% -> 125%), not a full
+    // step per event. Two small events in one frame coalesce into a single controlled change.
     await act(async () => {
       scroll?.dispatchEvent(
         new WheelEvent('wheel', { deltaY: -100, ctrlKey: true, bubbles: true, cancelable: true })
       )
       await Promise.resolve()
     })
-    await vi.waitFor(() => expect(container.textContent).toContain('110%'))
+    await vi.waitFor(() => expect(container.textContent).toContain('125%'))
 
     clientWidthSpy.mockRestore()
   })

--- a/src/renderer/src/pages/workspace/previews/renderers/PdfPreview.test.tsx
+++ b/src/renderer/src/pages/workspace/previews/renderers/PdfPreview.test.tsx
@@ -223,6 +223,37 @@ describe('PdfPreviewContent', () => {
     clientWidthSpy.mockRestore()
   })
 
+  it('exposes the scroll container as a keyboard-focusable region', async () => {
+    const clientWidthSpy = vi
+      .spyOn(HTMLElement.prototype, 'clientWidth', 'get')
+      .mockReturnValue(400)
+    vi.stubGlobal('devicePixelRatio', 1)
+    getPage.mockResolvedValue({
+      getViewport: vi.fn(({ scale }: { scale: number }) => ({
+        width: 400 * scale,
+        height: 560 * scale
+      })),
+      render: vi.fn(() => ({ promise: Promise.resolve(), cancel: vi.fn() })),
+      cleanup: vi.fn()
+    })
+
+    await act(async () => {
+      root.render(
+        <PdfPreviewContent path="/workspace/a11y.pdf" name="a11y.pdf" source="artifact" />
+      )
+    })
+    await vi.waitFor(() => expect(container.querySelector('canvas')?.width).toBe(400))
+
+    // The inner scroller (parent of the measurement probe) owns overflow, so it must be reachable
+    // by keyboard — the outer surface that gets focus is not the scrollable element.
+    const scroll = container.querySelector<HTMLElement>('[aria-hidden="true"]')?.parentElement
+    expect(scroll?.getAttribute('tabindex')).toBe('0')
+    expect(scroll?.getAttribute('role')).toBe('region')
+    expect(scroll?.getAttribute('aria-label')).toContain('a11y.pdf')
+
+    clientWidthSpy.mockRestore()
+  })
+
   it('keeps a zoomed page centered on a wide pane until it overflows the real viewport', async () => {
     // Pane is 1200px wide — well past the 768 reading-width cap. fitWidth caps at 768 but the
     // overflow decision must use the real 1200px viewport, not the cap.

--- a/src/renderer/src/pages/workspace/previews/renderers/PdfPreview.test.tsx
+++ b/src/renderer/src/pages/workspace/previews/renderers/PdfPreview.test.tsx
@@ -180,6 +180,52 @@ describe('PdfPreviewContent', () => {
     clientWidthSpy.mockRestore()
   })
 
+  it('zooms on Ctrl/Cmd+wheel and ignores a plain wheel scroll', async () => {
+    const clientWidthSpy = vi
+      .spyOn(HTMLElement.prototype, 'clientWidth', 'get')
+      .mockReturnValue(400)
+    vi.stubGlobal('devicePixelRatio', 1)
+    getPage.mockResolvedValue({
+      getViewport: vi.fn(({ scale }: { scale: number }) => ({
+        width: 400 * scale,
+        height: 560 * scale
+      })),
+      render: vi.fn(() => ({ promise: Promise.resolve(), cancel: vi.fn() })),
+      cleanup: vi.fn()
+    })
+
+    await act(async () => {
+      root.render(
+        <PdfPreviewContent path="/workspace/wheel.pdf" name="wheel.pdf" source="artifact" />
+      )
+    })
+    await vi.waitFor(() => expect(container.querySelector('canvas')?.width).toBe(400))
+
+    // The scroll container owns the wheel listener; it is the parent of the measurement probe.
+    const scroll = container.querySelector<HTMLElement>('[aria-hidden="true"]')?.parentElement
+    expect(scroll).toBeTruthy()
+
+    // A plain wheel scroll must not zoom.
+    await act(async () => {
+      scroll?.dispatchEvent(
+        new WheelEvent('wheel', { deltaY: -100, bubbles: true, cancelable: true })
+      )
+      await Promise.resolve()
+    })
+    expect(container.textContent).toContain('100%')
+
+    // Ctrl+wheel up zooms in by one wheel step (100% -> 110%).
+    await act(async () => {
+      scroll?.dispatchEvent(
+        new WheelEvent('wheel', { deltaY: -100, ctrlKey: true, bubbles: true, cancelable: true })
+      )
+      await Promise.resolve()
+    })
+    await vi.waitFor(() => expect(container.textContent).toContain('110%'))
+
+    clientWidthSpy.mockRestore()
+  })
+
   it('re-rasterizes a widened page without reloading it through the range transport', async () => {
     const resizeCallbacks: ResizeObserverCallback[] = []
     vi.stubGlobal(

--- a/src/renderer/src/pages/workspace/previews/renderers/PdfPreview.test.tsx
+++ b/src/renderer/src/pages/workspace/previews/renderers/PdfPreview.test.tsx
@@ -223,6 +223,61 @@ describe('PdfPreviewContent', () => {
     clientWidthSpy.mockRestore()
   })
 
+  it('keeps a zoomed page centered on a wide pane until it overflows the real viewport', async () => {
+    // Pane is 1200px wide — well past the 768 reading-width cap. fitWidth caps at 768 but the
+    // overflow decision must use the real 1200px viewport, not the cap.
+    const clientWidthSpy = vi
+      .spyOn(HTMLElement.prototype, 'clientWidth', 'get')
+      .mockReturnValue(1200)
+    vi.stubGlobal('devicePixelRatio', 1)
+    getPage.mockResolvedValue({
+      getViewport: vi.fn(({ scale }: { scale: number }) => ({
+        width: 595 * scale,
+        height: 842 * scale
+      })),
+      render: vi.fn(() => ({ promise: Promise.resolve(), cancel: vi.fn() })),
+      cleanup: vi.fn()
+    })
+
+    await act(async () => {
+      root.render(
+        <PdfPreviewContent path="/workspace/wide.pdf" name="wide.pdf" source="artifact" />
+      )
+    })
+    await vi.waitFor(() => expect(container.querySelector('canvas')?.width).toBeGreaterThan(0))
+
+    const columnClass = (): string =>
+      container.querySelector('[data-page-number]')?.parentElement?.className ?? ''
+
+    // 125% (page 768*1.25 = 960px) still fits the 1200px pane → stays centered (regression check).
+    await act(async () => {
+      container.querySelector<HTMLButtonElement>('[aria-label="Zoom in"]')?.click()
+      await Promise.resolve()
+    })
+    await vi.waitFor(() => expect(container.textContent).toContain('125%'))
+    expect(columnClass()).toContain('items-center')
+    expect(columnClass()).not.toContain('items-start')
+
+    // 150% (960 -> 1152px) still fits → still centered.
+    await act(async () => {
+      container.querySelector<HTMLButtonElement>('[aria-label="Zoom in"]')?.click()
+      await Promise.resolve()
+    })
+    await vi.waitFor(() => expect(container.textContent).toContain('150%'))
+    expect(columnClass()).toContain('items-center')
+
+    // 175% (768*1.75 = 1344px) overflows the 1200px pane → now left-aligns.
+    await act(async () => {
+      container.querySelector<HTMLButtonElement>('[aria-label="Zoom in"]')?.click()
+      await Promise.resolve()
+    })
+    await vi.waitFor(() => expect(container.textContent).toContain('175%'))
+    expect(columnClass()).toContain('items-start')
+    expect(columnClass()).not.toContain('items-center')
+
+    clientWidthSpy.mockRestore()
+  })
+
   it('zooms proportionally on Ctrl/Cmd+wheel, coalesced per frame, and ignores plain scroll', async () => {
     const clientWidthSpy = vi
       .spyOn(HTMLElement.prototype, 'clientWidth', 'get')

--- a/src/renderer/src/pages/workspace/previews/renderers/PdfPreview.test.tsx
+++ b/src/renderer/src/pages/workspace/previews/renderers/PdfPreview.test.tsx
@@ -226,6 +226,47 @@ describe('PdfPreviewContent', () => {
     clientWidthSpy.mockRestore()
   })
 
+  it('resets zoom to fit when the previewed file changes in place (dialog path)', async () => {
+    const clientWidthSpy = vi
+      .spyOn(HTMLElement.prototype, 'clientWidth', 'get')
+      .mockReturnValue(400)
+    vi.stubGlobal('devicePixelRatio', 1)
+    getPage.mockResolvedValue({
+      getViewport: vi.fn(({ scale }: { scale: number }) => ({
+        width: 400 * scale,
+        height: 560 * scale
+      })),
+      render: vi.fn(() => ({ promise: Promise.resolve(), cancel: vi.fn() })),
+      cleanup: vi.fn()
+    })
+
+    await act(async () => {
+      root.render(
+        <PdfPreviewContent path="/workspace/first.pdf" name="first.pdf" source="artifact" />
+      )
+    })
+    await vi.waitFor(() => expect(container.querySelector('canvas')?.width).toBe(400))
+
+    await act(async () => {
+      container.querySelector<HTMLButtonElement>('[aria-label="Zoom in"]')?.click()
+      await Promise.resolve()
+    })
+    await vi.waitFor(() => expect(container.textContent).toContain('125%'))
+
+    // The Files-tab dialog swaps the file in place (same component instance, no remount / key).
+    await act(async () => {
+      root.render(
+        <PdfPreviewContent path="/workspace/second.pdf" name="second.pdf" source="artifact" />
+      )
+    })
+
+    // The new file must open fit-to-width, not inherit the previous document's zoom.
+    await vi.waitFor(() => expect(container.textContent).toContain('100%'))
+    expect(container.textContent).not.toContain('125%')
+
+    clientWidthSpy.mockRestore()
+  })
+
   it('re-rasterizes a widened page without reloading it through the range transport', async () => {
     const resizeCallbacks: ResizeObserverCallback[] = []
     vi.stubGlobal(

--- a/src/renderer/src/pages/workspace/previews/renderers/PdfPreview.test.tsx
+++ b/src/renderer/src/pages/workspace/previews/renderers/PdfPreview.test.tsx
@@ -373,6 +373,49 @@ describe('PdfPreviewContent', () => {
     clientWidthSpy.mockRestore()
   })
 
+  it('rasterizes zoom at full high-DPI resolution, not clipped to a fixed 4x cap', async () => {
+    const clientWidthSpy = vi
+      .spyOn(HTMLElement.prototype, 'clientWidth', 'get')
+      .mockReturnValue(768)
+    vi.stubGlobal('devicePixelRatio', 2)
+    // A4-like page (595pt wide) at the 768px fit width, zoomed to 175% on a 2x display needs a
+    // backing width of 768 * 1.75 * 2 = 2688px to stay sharp. A fixed 4x cap would clip it to
+    // 595 * 4 = 2380px and the browser would upscale — the blur this removal fixes.
+    getPage.mockResolvedValue({
+      getViewport: vi.fn(({ scale }: { scale: number }) => ({
+        width: 595 * scale,
+        height: 842 * scale
+      })),
+      render: vi.fn(() => ({ promise: Promise.resolve(), cancel: vi.fn() })),
+      cleanup: vi.fn()
+    })
+
+    await act(async () => {
+      root.render(
+        <PdfPreviewContent path="/workspace/hidpi.pdf" name="hidpi.pdf" source="artifact" />
+      )
+    })
+    await vi.waitFor(() => expect(container.querySelector('canvas')?.width).toBeGreaterThan(0))
+
+    // Zoom to 175% (100 -> 125 -> 150 -> 175 via three button steps).
+    for (let i = 0; i < 3; i += 1) {
+      await act(async () => {
+        container.querySelector<HTMLButtonElement>('[aria-label="Zoom in"]')?.click()
+        await Promise.resolve()
+      })
+    }
+    await vi.waitFor(() => expect(container.textContent).toContain('175%'))
+
+    const width = container.querySelector<HTMLCanvasElement>('canvas')?.width ?? 0
+    // Backing reaches the physical on-screen pixels (~2688), well past the old 2380 (4x) ceiling,
+    // and stays within the browser canvas limit.
+    expect(width).toBeGreaterThan(2380)
+    expect(width).toBeLessThanOrEqual(2688)
+    expect(width).toBeLessThanOrEqual(8192)
+
+    clientWidthSpy.mockRestore()
+  })
+
   it('treats a render canceled by scroll-out as teardown, not a page failure', async () => {
     let intersectionCallback: IntersectionObserverCallback | undefined
     vi.stubGlobal(

--- a/src/renderer/src/pages/workspace/previews/renderers/PdfPreview.test.tsx
+++ b/src/renderer/src/pages/workspace/previews/renderers/PdfPreview.test.tsx
@@ -180,6 +180,49 @@ describe('PdfPreviewContent', () => {
     clientWidthSpy.mockRestore()
   })
 
+  it('left-aligns pages once zoomed past fit so the left edge stays reachable', async () => {
+    const clientWidthSpy = vi
+      .spyOn(HTMLElement.prototype, 'clientWidth', 'get')
+      .mockReturnValue(400)
+    vi.stubGlobal('devicePixelRatio', 1)
+    getPage.mockResolvedValue({
+      getViewport: vi.fn(({ scale }: { scale: number }) => ({
+        width: 400 * scale,
+        height: 560 * scale
+      })),
+      render: vi.fn(() => ({ promise: Promise.resolve(), cancel: vi.fn() })),
+      cleanup: vi.fn()
+    })
+
+    await act(async () => {
+      root.render(
+        <PdfPreviewContent path="/workspace/align.pdf" name="align.pdf" source="artifact" />
+      )
+    })
+    await vi.waitFor(() => expect(container.querySelector('canvas')?.width).toBe(400))
+
+    // At fit width the pages column is centered.
+    const column = container.querySelector('[data-page-number]')?.parentElement
+    expect(column?.className).toContain('items-center')
+    expect(column?.className).not.toContain('items-start')
+
+    // Zoomed wider than the pane, it must left-align so scrollLeft=0 reaches the true left edge.
+    await act(async () => {
+      container.querySelector<HTMLButtonElement>('[aria-label="Zoom in"]')?.click()
+      await Promise.resolve()
+    })
+    await vi.waitFor(() =>
+      expect(container.querySelector('[data-page-number]')?.parentElement?.className).toContain(
+        'items-start'
+      )
+    )
+    expect(container.querySelector('[data-page-number]')?.parentElement?.className).not.toContain(
+      'items-center'
+    )
+
+    clientWidthSpy.mockRestore()
+  })
+
   it('zooms on Ctrl/Cmd+wheel and ignores a plain wheel scroll', async () => {
     const clientWidthSpy = vi
       .spyOn(HTMLElement.prototype, 'clientWidth', 'get')

--- a/src/renderer/src/pages/workspace/previews/renderers/PdfPreview.test.tsx
+++ b/src/renderer/src/pages/workspace/previews/renderers/PdfPreview.test.tsx
@@ -278,17 +278,27 @@ describe('PdfPreviewContent', () => {
     clientWidthSpy.mockRestore()
   })
 
-  it('zooms proportionally on Ctrl/Cmd+wheel, coalesced per frame, and ignores plain scroll', async () => {
+  it('coalesces same-frame Ctrl/Cmd+wheel into one proportional zoom and ignores plain scroll', async () => {
     const clientWidthSpy = vi
       .spyOn(HTMLElement.prototype, 'clientWidth', 'get')
       .mockReturnValue(400)
     vi.stubGlobal('devicePixelRatio', 1)
-    // Flush the wheel handler's requestAnimationFrame coalescing synchronously.
+    // Controllable rAF: capture the scheduled callback so same-frame events can be coalesced and
+    // flushed once on demand, rather than running synchronously per event.
+    let scheduled: { id: number; cb: FrameRequestCallback } | null = null
+    let nextRafId = 1
     vi.stubGlobal('requestAnimationFrame', (cb: FrameRequestCallback): number => {
-      cb(0)
-      return 1
+      scheduled = { id: nextRafId, cb }
+      return nextRafId++
     })
-    vi.stubGlobal('cancelAnimationFrame', () => undefined)
+    vi.stubGlobal('cancelAnimationFrame', (id: number) => {
+      if (scheduled?.id === id) scheduled = null
+    })
+    const flushFrame = (): void => {
+      const pending = scheduled
+      scheduled = null
+      pending?.cb(0)
+    }
     getPage.mockResolvedValue({
       getViewport: vi.fn(({ scale }: { scale: number }) => ({
         width: 400 * scale,
@@ -309,24 +319,105 @@ describe('PdfPreviewContent', () => {
     const scroll = container.querySelector<HTMLElement>('[aria-hidden="true"]')?.parentElement
     expect(scroll).toBeTruthy()
 
-    // A plain wheel scroll must not zoom.
+    // A plain wheel scroll schedules nothing and must not zoom.
     await act(async () => {
       scroll?.dispatchEvent(
         new WheelEvent('wheel', { deltaY: -100, bubbles: true, cancelable: true })
       )
       await Promise.resolve()
     })
+    expect(scheduled).toBeNull()
     expect(container.textContent).toContain('100%')
 
-    // Ctrl+wheel scales proportionally: deltaY -100 * 0.0025 = +0.25 (100% -> 125%), not a full
-    // step per event. Two small events in one frame coalesce into a single controlled change.
+    // Two Ctrl+wheel events in the same frame coalesce: only one frame is scheduled and their
+    // deltas sum (-200 * 0.0025 = +0.5), so a single flush yields 150%, not two separate steps.
+    await act(async () => {
+      scroll?.dispatchEvent(
+        new WheelEvent('wheel', { deltaY: -100, ctrlKey: true, bubbles: true, cancelable: true })
+      )
+      scroll?.dispatchEvent(
+        new WheelEvent('wheel', { deltaY: -100, ctrlKey: true, bubbles: true, cancelable: true })
+      )
+      flushFrame()
+      await Promise.resolve()
+    })
+    await vi.waitFor(() => expect(container.textContent).toContain('150%'))
+
+    // The Cmd (metaKey) branch also zooms: deltaY +100 * 0.0025 = -0.25 (150% -> 125%).
+    await act(async () => {
+      scroll?.dispatchEvent(
+        new WheelEvent('wheel', { deltaY: 100, metaKey: true, bubbles: true, cancelable: true })
+      )
+      flushFrame()
+      await Promise.resolve()
+    })
+    await vi.waitFor(() => expect(container.textContent).toContain('125%'))
+
+    clientWidthSpy.mockRestore()
+  })
+
+  it('drops a queued wheel zoom when the file switches before the frame flushes', async () => {
+    const clientWidthSpy = vi
+      .spyOn(HTMLElement.prototype, 'clientWidth', 'get')
+      .mockReturnValue(400)
+    vi.stubGlobal('devicePixelRatio', 1)
+    // Faithful rAF/cancel: a canceled frame cannot be flushed, mirroring the browser.
+    let scheduled: { id: number; cb: FrameRequestCallback } | null = null
+    let nextRafId = 1
+    vi.stubGlobal('requestAnimationFrame', (cb: FrameRequestCallback): number => {
+      scheduled = { id: nextRafId, cb }
+      return nextRafId++
+    })
+    vi.stubGlobal('cancelAnimationFrame', (id: number) => {
+      if (scheduled?.id === id) scheduled = null
+    })
+    const flushFrame = (): void => {
+      const pending = scheduled
+      scheduled = null
+      pending?.cb(0)
+    }
+    getPage.mockResolvedValue({
+      getViewport: vi.fn(({ scale }: { scale: number }) => ({
+        width: 400 * scale,
+        height: 560 * scale
+      })),
+      render: vi.fn(() => ({ promise: Promise.resolve(), cancel: vi.fn() })),
+      cleanup: vi.fn()
+    })
+
+    await act(async () => {
+      root.render(
+        <PdfPreviewContent path="/workspace/first.pdf" name="first.pdf" source="artifact" />
+      )
+    })
+    await vi.waitFor(() => expect(container.querySelector('canvas')?.width).toBe(400))
+
+    const scroll = container.querySelector<HTMLElement>('[aria-hidden="true"]')?.parentElement
+    // Queue a Ctrl+wheel zoom but do NOT flush the frame yet.
     await act(async () => {
       scroll?.dispatchEvent(
         new WheelEvent('wheel', { deltaY: -100, ctrlKey: true, bubbles: true, cancelable: true })
       )
       await Promise.resolve()
     })
-    await vi.waitFor(() => expect(container.textContent).toContain('125%'))
+    expect(scheduled).not.toBeNull()
+    expect(container.textContent).toContain('100%')
+
+    // Switch files in place before the frame runs: the wheel effect restarts on requestKey and
+    // cancels the queued frame, so the stale delta cannot re-apply on top of the reset.
+    await act(async () => {
+      root.render(
+        <PdfPreviewContent path="/workspace/second.pdf" name="second.pdf" source="artifact" />
+      )
+    })
+    await act(async () => {
+      flushFrame()
+      await Promise.resolve()
+    })
+
+    // The new document stays at fit (100%); the queued 25% was dropped, not re-applied.
+    expect(container.textContent).toContain('100%')
+    expect(container.textContent).not.toContain('125%')
 
     clientWidthSpy.mockRestore()
   })

--- a/src/renderer/src/pages/workspace/previews/renderers/PdfPreview.test.tsx
+++ b/src/renderer/src/pages/workspace/previews/renderers/PdfPreview.test.tsx
@@ -228,6 +228,26 @@ describe('PdfPreviewContent', () => {
     await vi.waitFor(() => expect(render).toHaveBeenCalledTimes(2))
     expect(getPage).toHaveBeenCalledTimes(1)
     expect(container.querySelector<HTMLCanvasElement>('canvas')?.width).toBe(600)
+    expect(container.querySelector<HTMLElement>('[data-page-number="1"]')?.style.width).toBe(
+      '600px'
+    )
+
+    // Narrowing the panel (or returning from full screen) must shrink the displayed page back to
+    // fit, not leave it pinned at the old larger width forcing horizontal scroll at 100%.
+    await act(async () => {
+      measuredWidth = 300
+      resizeCallbacks[0]?.([] as unknown as ResizeObserverEntry[], {} as ResizeObserver)
+      await Promise.resolve()
+    })
+    await vi.waitFor(() =>
+      expect(container.querySelector<HTMLElement>('[data-page-number="1"]')?.style.width).toBe(
+        '300px'
+      )
+    )
+    expect(getPage).toHaveBeenCalledTimes(1)
+    // Displayed width is responsive (300px), while the backing store never drops below the page's
+    // intrinsic 400px width — the crisp bitmap simply downscales via CSS.
+    expect(container.querySelector<HTMLCanvasElement>('canvas')?.width).toBe(400)
 
     clientWidthSpy.mockRestore()
   })

--- a/src/renderer/src/pages/workspace/previews/renderers/PdfPreview.test.tsx
+++ b/src/renderer/src/pages/workspace/previews/renderers/PdfPreview.test.tsx
@@ -141,6 +141,45 @@ describe('PdfPreviewContent', () => {
     clientWidthSpy.mockRestore()
   })
 
+  it('re-rasterizes at a higher resolution when the user zooms in', async () => {
+    const clientWidthSpy = vi
+      .spyOn(HTMLElement.prototype, 'clientWidth', 'get')
+      .mockReturnValue(400)
+    vi.stubGlobal('devicePixelRatio', 1)
+    getPage.mockResolvedValue({
+      getViewport: vi.fn(({ scale }: { scale: number }) => ({
+        width: 400 * scale,
+        height: 560 * scale
+      })),
+      render: vi.fn(() => ({ promise: Promise.resolve(), cancel: vi.fn() })),
+      cleanup: vi.fn()
+    })
+
+    await act(async () => {
+      root.render(
+        <PdfPreviewContent path="/workspace/zoom.pdf" name="zoom.pdf" source="artifact" />
+      )
+    })
+    // At fit width (100%) the 400pt page backs the canvas at its own width.
+    await vi.waitFor(() =>
+      expect(container.querySelector<HTMLCanvasElement>('canvas')?.width).toBe(400)
+    )
+
+    await act(async () => {
+      container.querySelector<HTMLButtonElement>('[aria-label="Zoom in"]')?.click()
+      await Promise.resolve()
+    })
+
+    // 125% zoom widens the page and re-rasterizes rather than upscaling the old bitmap.
+    await vi.waitFor(() =>
+      expect(container.querySelector<HTMLCanvasElement>('canvas')?.width).toBe(500)
+    )
+    expect(container.textContent).toContain('125%')
+    expect(container.querySelector<HTMLCanvasElement>('canvas')?.height).toBe(700)
+
+    clientWidthSpy.mockRestore()
+  })
+
   it('re-rasterizes a widened page without reloading it through the range transport', async () => {
     const resizeCallbacks: ResizeObserverCallback[] = []
     vi.stubGlobal(

--- a/src/renderer/src/pages/workspace/previews/renderers/PdfPreview.tsx
+++ b/src/renderer/src/pages/workspace/previews/renderers/PdfPreview.tsx
@@ -278,6 +278,9 @@ export const PdfPreviewContent = ({
   // The width one page fills at 100%: the content box, capped to a comfortable reading width. Owned
   // here so one ResizeObserver serves the whole document instead of one per page.
   const [fitWidth, setFitWidth] = useState(0)
+  // The real (uncapped) content-box width, used only to decide when a zoomed page actually
+  // overflows the viewport — distinct from the capped fitWidth that sizes a 100% page.
+  const [viewportWidth, setViewportWidth] = useState(0)
   const scrollRef = useRef<HTMLDivElement | null>(null)
   const measureRef = useRef<HTMLDivElement | null>(null)
   const pageDisposersRef = useRef(new Set<() => void>())
@@ -323,8 +326,11 @@ export const PdfPreviewContent = ({
     if (!element) return
 
     const measure = (): void => {
-      const width = Math.min(element.clientWidth, FIT_PAGE_WIDTH)
-      if (width > 0) setFitWidth((current) => (width === current ? current : width))
+      const raw = element.clientWidth
+      if (raw <= 0) return
+      const width = Math.min(raw, FIT_PAGE_WIDTH)
+      setFitWidth((current) => (width === current ? current : width))
+      setViewportWidth((current) => (raw === current ? current : raw))
     }
     measure()
 
@@ -427,12 +433,14 @@ export const PdfPreviewContent = ({
           </div>
         ) : null}
         {document ? (
-          // Center pages while they fit, but left-align once a zoomed page overflows: a centered
-          // overflow puts the left margin before scrollLeft=0, making it unreachable.
+          // Center pages while they fit the real viewport, but left-align once a zoomed page
+          // overflows it: a centered overflow puts the left margin before scrollLeft=0, making it
+          // unreachable. Compared against the uncapped viewport width, not the reading-width cap,
+          // so a page still fitting a wide/full-screen pane stays centered.
           <div
             className={cn(
               'flex min-w-full flex-col gap-3',
-              pageWidth > 0 && pageWidth > fitWidth ? 'items-start' : 'items-center'
+              viewportWidth > 0 && pageWidth > viewportWidth ? 'items-start' : 'items-center'
             )}
           >
             {Array.from({ length: pageCount }, (_, index) => (

--- a/src/renderer/src/pages/workspace/previews/renderers/PdfPreview.tsx
+++ b/src/renderer/src/pages/workspace/previews/renderers/PdfPreview.tsx
@@ -23,7 +23,9 @@ const FIT_PAGE_WIDTH = 768
 const MIN_ZOOM = 0.5
 const MAX_ZOOM = 3
 const ZOOM_BUTTON_STEP = 0.25
-const ZOOM_WHEEL_STEP = 0.1
+// Wheel zoom is proportional to accumulated deltaY so one trackpad/pinch gesture (many small
+// events) maps to a controlled amount rather than a full step per event. ~100px notch ≈ 0.25.
+const ZOOM_WHEEL_SENSITIVITY = 0.0025
 
 const clampZoom = (zoom: number): number => Math.min(MAX_ZOOM, Math.max(MIN_ZOOM, zoom))
 
@@ -285,19 +287,32 @@ export const PdfPreviewContent = ({
   }, [])
 
   // Ctrl/Cmd+wheel zooms the document instead of scrolling, matching the image preview gesture.
+  // A trackpad/pinch emits many small wheel events per gesture, so accumulate deltaY and apply it
+  // proportionally once per frame — one gesture yields a controlled zoom and few rerasterizations.
   useEffect(() => {
     const element = scrollRef.current
     if (!element) return
 
+    let pendingDelta = 0
+    let frame: number | undefined
+    const flush = (): void => {
+      frame = undefined
+      const delta = pendingDelta
+      pendingDelta = 0
+      if (delta !== 0) setZoom((current) => clampZoom(current - delta * ZOOM_WHEEL_SENSITIVITY))
+    }
     const handleWheel = (event: WheelEvent): void => {
       if (!event.ctrlKey && !event.metaKey) return
       event.preventDefault()
-      const direction = event.deltaY < 0 ? 1 : -1
-      setZoom((current) => clampZoom(current + direction * ZOOM_WHEEL_STEP))
+      pendingDelta += event.deltaY
+      frame ??= requestAnimationFrame(flush)
     }
 
     element.addEventListener('wheel', handleWheel, { passive: false })
-    return () => element.removeEventListener('wheel', handleWheel)
+    return () => {
+      element.removeEventListener('wheel', handleWheel)
+      if (frame !== undefined) cancelAnimationFrame(frame)
+    }
   }, [])
 
   // Measure the content-box width before paint (zero-height probe, unaffected by page overflow) so

--- a/src/renderer/src/pages/workspace/previews/renderers/PdfPreview.tsx
+++ b/src/renderer/src/pages/workspace/previews/renderers/PdfPreview.tsx
@@ -1,5 +1,9 @@
+import { Maximize2, ZoomIn, ZoomOut } from 'lucide-react'
 import { useCallback, useEffect, useLayoutEffect, useRef, useState } from 'react'
 
+import { Button } from '@/components/ui/button'
+import { Tooltip, TooltipContent, TooltipProvider, TooltipTrigger } from '@/components/ui/tooltip'
+import { cn } from '@/lib/utils'
 import type { PreviewFileSource } from '@/stores/preview-workbench-store'
 
 import { PreviewErrorCard, PreviewLoadingContent } from '../PreviewFallback'
@@ -14,8 +18,61 @@ type DocumentState =
   | { requestKey: string; status: 'ready'; document: PdfDocument }
   | { requestKey: string; status: 'error'; error: unknown }
 
-// Comfortable reading width a page fills; also caps the backing resolution the parent measures.
+// Comfortable reading width a page fills at 100%; zoom scales the displayed page beyond it.
 const FIT_PAGE_WIDTH = 768
+const MIN_ZOOM = 0.5
+const MAX_ZOOM = 3
+const ZOOM_BUTTON_STEP = 0.25
+const ZOOM_WHEEL_STEP = 0.1
+
+const clampZoom = (zoom: number): number => Math.min(MAX_ZOOM, Math.max(MIN_ZOOM, zoom))
+
+// Bottom-right overlay mirroring the image preview's zoom affordances for a consistent feel.
+const PdfZoomControls = ({
+  zoom,
+  onZoomIn,
+  onZoomOut,
+  onReset
+}: {
+  zoom: number
+  onZoomIn: () => void
+  onZoomOut: () => void
+  onReset: () => void
+}): React.JSX.Element => {
+  const actions = [
+    { label: 'Zoom out', icon: ZoomOut, onClick: onZoomOut, disabled: zoom <= MIN_ZOOM },
+    { label: 'Reset zoom', icon: Maximize2, onClick: onReset, disabled: zoom === 1 },
+    { label: 'Zoom in', icon: ZoomIn, onClick: onZoomIn, disabled: zoom >= MAX_ZOOM }
+  ]
+
+  return (
+    <TooltipProvider delayDuration={300}>
+      <div className="absolute bottom-3 right-3 z-10 flex items-center gap-1 rounded-md border border-border-300/50 bg-bg-000/90 p-1 shadow-sm backdrop-blur">
+        <span className="min-w-[3ch] px-1 text-center text-[11px] tabular-nums text-text-200">
+          {Math.round(zoom * 100)}%
+        </span>
+        {actions.map(({ label, icon: Icon, onClick, disabled }) => (
+          <Tooltip key={label}>
+            <TooltipTrigger asChild>
+              <Button
+                type="button"
+                variant="ghost"
+                size="icon-xs"
+                className="text-text-100 hover:text-text-000"
+                aria-label={label}
+                disabled={disabled}
+                onClick={onClick}
+              >
+                <Icon aria-hidden="true" />
+              </Button>
+            </TooltipTrigger>
+            <TooltipContent>{label}</TooltipContent>
+          </Tooltip>
+        ))}
+      </div>
+    </TooltipProvider>
+  )
+}
 // Bound the backing-store resolution so an over-magnified small page cannot exhaust GPU memory.
 const MAX_RENDER_SCALE = 4
 // Keep the backing store within browser canvas limits so a tall/narrow page cannot render blank:
@@ -167,8 +224,12 @@ const PdfPageCanvas = ({
   return (
     <div
       ref={setNearViewportRef}
-      className="relative mx-auto mb-3 w-full max-w-3xl bg-bg-000 shadow-sm"
-      style={{ aspectRatio }}
+      className={cn(
+        'relative mx-auto bg-bg-000 shadow-sm',
+        // Fall back to a responsive width until the parent has measured the fit width.
+        pageWidth > 0 ? 'max-w-none' : 'w-full max-w-3xl'
+      )}
+      style={pageWidth > 0 ? { aspectRatio, width: pageWidth } : { aspectRatio }}
       data-page-number={pageNumber}
     >
       {displayedStatus === 'loading' || (displayedStatus === 'idle' && isNearViewport) ? (
@@ -205,14 +266,33 @@ export const PdfPreviewContent = ({
 }): React.JSX.Element => {
   const requestKey = createPreviewResourceKey({ source, path, mimeType, size, mtimeMs })
   const [documentState, setDocumentState] = useState<DocumentState | null>(null)
-  // The width one page fills: the content box, capped to a comfortable reading width. Owned here so
-  // one ResizeObserver serves the whole document instead of one per page.
+  // A file switch remounts this component (keyed by contentKey upstream), so zoom resets to fit.
+  const [zoom, setZoom] = useState(1)
+  // The width one page fills at 100%: the content box, capped to a comfortable reading width. Owned
+  // here so one ResizeObserver serves the whole document instead of one per page.
   const [fitWidth, setFitWidth] = useState(0)
+  const scrollRef = useRef<HTMLDivElement | null>(null)
   const measureRef = useRef<HTMLDivElement | null>(null)
   const pageDisposersRef = useRef(new Set<() => void>())
   const registerPageDisposer = useCallback((dispose: () => void): (() => void) => {
     pageDisposersRef.current.add(dispose)
     return () => pageDisposersRef.current.delete(dispose)
+  }, [])
+
+  // Ctrl/Cmd+wheel zooms the document instead of scrolling, matching the image preview gesture.
+  useEffect(() => {
+    const element = scrollRef.current
+    if (!element) return
+
+    const handleWheel = (event: WheelEvent): void => {
+      if (!event.ctrlKey && !event.metaKey) return
+      event.preventDefault()
+      const direction = event.deltaY < 0 ? 1 : -1
+      setZoom((current) => clampZoom(current + direction * ZOOM_WHEEL_STEP))
+    }
+
+    element.addEventListener('wheel', handleWheel, { passive: false })
+    return () => element.removeEventListener('wheel', handleWheel)
   }, [])
 
   // Measure the content-box width before paint (zero-height probe, unaffected by page overflow) so
@@ -312,28 +392,42 @@ export const PdfPreviewContent = ({
 
   const document = currentDocumentState?.status === 'ready' ? currentDocumentState.document : null
   const pageCount = document?.numPages ?? 0
+  const pageWidth = fitWidth > 0 ? Math.round(fitWidth * zoom) : 0
+  const zoomBy = (delta: number): void => setZoom((current) => clampZoom(current + delta))
 
   return (
-    <div className="relative size-full overflow-auto bg-bg-20 p-4">
-      {/* Zero-height probe: reports the content-box width once for every page. */}
-      <div ref={measureRef} className="h-0 w-full" aria-hidden="true" />
-      {!document ? (
-        <div className="absolute inset-0">
-          <PreviewLoadingContent />
-        </div>
+    <div className="relative size-full overflow-hidden bg-bg-20">
+      <div ref={scrollRef} className="size-full overflow-auto p-4">
+        {/* Zero-height probe: reports the content-box width even when pages overflow horizontally. */}
+        <div ref={measureRef} className="h-0 w-full" aria-hidden="true" />
+        {!document ? (
+          <div className="absolute inset-0">
+            <PreviewLoadingContent />
+          </div>
+        ) : null}
+        {document ? (
+          <div className="flex min-w-full flex-col items-center gap-3">
+            {Array.from({ length: pageCount }, (_, index) => (
+              // Each page mounts its canvas only inside the viewport overscan window.
+              <PdfPageCanvas
+                key={index + 1}
+                document={document}
+                pageNumber={index + 1}
+                pageWidth={pageWidth}
+                registerDisposer={registerPageDisposer}
+              />
+            ))}
+          </div>
+        ) : null}
+      </div>
+      {document ? (
+        <PdfZoomControls
+          zoom={zoom}
+          onZoomIn={() => zoomBy(ZOOM_BUTTON_STEP)}
+          onZoomOut={() => zoomBy(-ZOOM_BUTTON_STEP)}
+          onReset={() => setZoom(1)}
+        />
       ) : null}
-      {document
-        ? Array.from({ length: pageCount }, (_, index) => (
-            // Each page mounts its canvas only inside the viewport overscan window.
-            <PdfPageCanvas
-              key={index + 1}
-              document={document}
-              pageNumber={index + 1}
-              pageWidth={fitWidth}
-              registerDisposer={registerPageDisposer}
-            />
-          ))
-        : null}
     </div>
   )
 }

--- a/src/renderer/src/pages/workspace/previews/renderers/PdfPreview.tsx
+++ b/src/renderer/src/pages/workspace/previews/renderers/PdfPreview.tsx
@@ -223,8 +223,9 @@ const PdfPageCanvas = ({
     <div
       ref={setNearViewportRef}
       className={cn(
-        'relative mx-auto bg-bg-000 shadow-sm',
-        // Fall back to a responsive width until the parent has measured the fit width.
+        'relative bg-bg-000 shadow-sm',
+        // Alignment is owned by the parent column; fall back to a responsive width until it has
+        // measured the fit width.
         pageWidth > 0 ? 'max-w-none' : 'w-full max-w-3xl'
       )}
       style={pageWidth > 0 ? { aspectRatio, width: pageWidth } : { aspectRatio }}
@@ -411,7 +412,14 @@ export const PdfPreviewContent = ({
           </div>
         ) : null}
         {document ? (
-          <div className="flex min-w-full flex-col items-center gap-3">
+          // Center pages while they fit, but left-align once a zoomed page overflows: a centered
+          // overflow puts the left margin before scrollLeft=0, making it unreachable.
+          <div
+            className={cn(
+              'flex min-w-full flex-col gap-3',
+              pageWidth > 0 && pageWidth > fitWidth ? 'items-start' : 'items-center'
+            )}
+          >
             {Array.from({ length: pageCount }, (_, index) => (
               // Each page mounts its canvas only inside the viewport overscan window.
               <PdfPageCanvas

--- a/src/renderer/src/pages/workspace/previews/renderers/PdfPreview.tsx
+++ b/src/renderer/src/pages/workspace/previews/renderers/PdfPreview.tsx
@@ -296,14 +296,15 @@ export const PdfPreviewContent = ({
   }, [])
 
   // Measure the content-box width before paint (zero-height probe, unaffected by page overflow) so
-  // pages rasterize once at the right width on open, and only grow it so a shrink reuses the bitmap.
+  // pages rasterize once at the right width on open. Tracks the current width so pages stay
+  // responsive: narrowing the panel (or returning from full screen) shrinks them back to fit.
   useLayoutEffect(() => {
     const element = measureRef.current
     if (!element) return
 
     const measure = (): void => {
       const width = Math.min(element.clientWidth, FIT_PAGE_WIDTH)
-      if (width > 0) setFitWidth((current) => (width > current ? width : current))
+      if (width > 0) setFitWidth((current) => (width === current ? current : width))
     }
     measure()
 

--- a/src/renderer/src/pages/workspace/previews/renderers/PdfPreview.tsx
+++ b/src/renderer/src/pages/workspace/previews/renderers/PdfPreview.tsx
@@ -434,7 +434,15 @@ export const PdfPreviewContent = ({
 
   return (
     <div className="relative size-full overflow-hidden bg-bg-20">
-      <div ref={scrollRef} className="size-full overflow-auto p-4">
+      {/* The inner element is the real scroller (the outer div holds the fixed zoom overlay), so it
+          must be keyboard-focusable or PageUp/Down, Space, and arrows never reach the PDF. */}
+      <div
+        ref={scrollRef}
+        className="size-full overflow-auto p-4 outline-none focus-visible:ring-2 focus-visible:ring-inset focus-visible:ring-ring/50"
+        tabIndex={0}
+        role="region"
+        aria-label={`${name} scrollable preview`}
+      >
         {/* Zero-height probe: reports the content-box width even when pages overflow horizontally. */}
         <div ref={measureRef} className="h-0 w-full" aria-hidden="true" />
         {!document ? (

--- a/src/renderer/src/pages/workspace/previews/renderers/PdfPreview.tsx
+++ b/src/renderer/src/pages/workspace/previews/renderers/PdfPreview.tsx
@@ -73,10 +73,10 @@ const PdfZoomControls = ({
     </TooltipProvider>
   )
 }
-// Bound the backing-store resolution so an over-magnified small page cannot exhaust GPU memory.
-const MAX_RENDER_SCALE = 4
-// Keep the backing store within browser canvas limits so a tall/narrow page cannot render blank:
-// clamp each side and the total area (Chromium caps a dimension at 16384 and area near 2^28).
+// Keep the backing store within browser canvas limits so a tall/narrow or heavily zoomed page
+// cannot render blank or exhaust GPU memory: clamp each side and the total area (Chromium caps a
+// dimension at 16384 and area near 2^28). This is the only backing-resolution ceiling, so zoom
+// stays crisp at high DPI instead of being pre-capped below the physical pixels on screen.
 const MAX_CANVAS_DIMENSION = 8192
 const MAX_CANVAS_AREA = 16 * 1024 * 1024
 
@@ -177,12 +177,10 @@ const PdfPageCanvas = ({
 
       const devicePixelRatio = Math.max(1, window.devicePixelRatio || 1)
       const baseViewport = page.getViewport({ scale: 1 })
-      // Rasterize at the physical pixels the page occupies on screen; never below intrinsic size.
+      // Rasterize at the physical pixels the page occupies on screen (never below intrinsic size)
+      // so zoom stays crisp at any DPI; the dimension/area clamp below is the only ceiling.
       const targetCssWidth = pageWidth > 0 ? pageWidth : baseViewport.width
-      const desiredScale = Math.max(
-        1,
-        Math.min(MAX_RENDER_SCALE, (targetCssWidth * devicePixelRatio) / baseViewport.width)
-      )
+      const desiredScale = Math.max(1, (targetCssWidth * devicePixelRatio) / baseViewport.width)
       // Hard cap so neither backing dimension nor total area exceeds browser canvas limits — must
       // win over the intrinsic floor, or a page taller than the limit at scale 1 renders blank.
       const limitScale = Math.min(

--- a/src/renderer/src/pages/workspace/previews/renderers/PdfPreview.tsx
+++ b/src/renderer/src/pages/workspace/previews/renderers/PdfPreview.tsx
@@ -266,8 +266,14 @@ export const PdfPreviewContent = ({
 }): React.JSX.Element => {
   const requestKey = createPreviewResourceKey({ source, path, mimeType, size, mtimeMs })
   const [documentState, setDocumentState] = useState<DocumentState | null>(null)
-  // A file switch remounts this component (keyed by contentKey upstream), so zoom resets to fit.
   const [zoom, setZoom] = useState(1)
+  // The PreviewPanel path remounts on a file switch, but the Files-tab dialog updates item in place
+  // with no contentKey, so reset zoom to fit whenever the previewed file changes (adjust-on-render).
+  const [zoomedKey, setZoomedKey] = useState(requestKey)
+  if (zoomedKey !== requestKey) {
+    setZoomedKey(requestKey)
+    setZoom(1)
+  }
   // The width one page fills at 100%: the content box, capped to a comfortable reading width. Owned
   // here so one ResizeObserver serves the whole document instead of one per page.
   const [fitWidth, setFitWidth] = useState(0)

--- a/src/renderer/src/pages/workspace/previews/renderers/PdfPreview.tsx
+++ b/src/renderer/src/pages/workspace/previews/renderers/PdfPreview.tsx
@@ -292,6 +292,8 @@ export const PdfPreviewContent = ({
   // Ctrl/Cmd+wheel zooms the document instead of scrolling, matching the image preview gesture.
   // A trackpad/pinch emits many small wheel events per gesture, so accumulate deltaY and apply it
   // proportionally once per frame — one gesture yields a controlled zoom and few rerasterizations.
+  // Keyed to requestKey so a file switch cancels any queued frame before its stale flush could
+  // re-apply zoom on top of the new document's reset.
   useEffect(() => {
     const element = scrollRef.current
     if (!element) return
@@ -316,7 +318,7 @@ export const PdfPreviewContent = ({
       element.removeEventListener('wheel', handleWheel)
       if (frame !== undefined) cancelAnimationFrame(frame)
     }
-  }, [])
+  }, [requestKey])
 
   // Measure the content-box width before paint (zero-height probe, unaffected by page overflow) so
   // pages rasterize once at the right width on open. Tracks the current width so pages stay

--- a/src/renderer/src/pages/workspace/previews/renderers/PdfPreview.tsx
+++ b/src/renderer/src/pages/workspace/previews/renderers/PdfPreview.tsx
@@ -299,9 +299,10 @@ export const PdfPreviewContent = ({
   // Ctrl/Cmd+wheel zooms the document instead of scrolling, matching the image preview gesture.
   // A trackpad/pinch emits many small wheel events per gesture, so accumulate deltaY and apply it
   // proportionally once per frame — one gesture yields a controlled zoom and few rerasterizations.
-  // Keyed to requestKey so a file switch cancels any queued frame before its stale flush could
-  // re-apply zoom on top of the new document's reset.
-  useEffect(() => {
+  // Keyed to requestKey and run as a layout effect so a file switch cancels any queued frame during
+  // commit — before the browser's rAF phase — so a stale flush cannot re-apply zoom on top of the
+  // new document's reset (a passive-effect cleanup would run after paint, too late to cancel it).
+  useLayoutEffect(() => {
     const element = scrollRef.current
     if (!element) return
 

--- a/src/renderer/src/pages/workspace/previews/renderers/PdfPreview.tsx
+++ b/src/renderer/src/pages/workspace/previews/renderers/PdfPreview.tsx
@@ -76,11 +76,14 @@ const PdfZoomControls = ({
   )
 }
 // Keep the backing store within browser canvas limits so a tall/narrow or heavily zoomed page
-// cannot render blank or exhaust GPU memory: clamp each side and the total area (Chromium caps a
-// dimension at 16384 and area near 2^28). This is the only backing-resolution ceiling, so zoom
-// stays crisp at high DPI instead of being pre-capped below the physical pixels on screen.
+// cannot render blank: clamp each side and the total area (Chromium caps a dimension at 16384 and
+// area near 2^28).
 const MAX_CANVAS_DIMENSION = 8192
 const MAX_CANVAS_AREA = 16 * 1024 * 1024
+// Per-page backing-scale ceiling. Set above the ~4.5 that a full-width page needs at 175% zoom on
+// a 2x display, so normal zoom stays crisp, while capping the deepest zoom so a few near-viewport
+// pages cannot each allocate the full canvas-area budget and spike renderer memory.
+const MAX_RENDER_SCALE = 5
 
 // PDF.js rejects an in-flight render with this when cancel() is called; it is an expected teardown,
 // not a page failure, so scroll-out, preview switches, and resize rerenders must not surface it.
@@ -180,9 +183,13 @@ const PdfPageCanvas = ({
       const devicePixelRatio = Math.max(1, window.devicePixelRatio || 1)
       const baseViewport = page.getViewport({ scale: 1 })
       // Rasterize at the physical pixels the page occupies on screen (never below intrinsic size)
-      // so zoom stays crisp at any DPI; the dimension/area clamp below is the only ceiling.
+      // so zoom stays crisp at any DPI, capped by MAX_RENDER_SCALE so the deepest zoom cannot
+      // allocate the full canvas budget per page.
       const targetCssWidth = pageWidth > 0 ? pageWidth : baseViewport.width
-      const desiredScale = Math.max(1, (targetCssWidth * devicePixelRatio) / baseViewport.width)
+      const desiredScale = Math.max(
+        1,
+        Math.min(MAX_RENDER_SCALE, (targetCssWidth * devicePixelRatio) / baseViewport.width)
+      )
       // Hard cap so neither backing dimension nor total area exceeds browser canvas limits — must
       // win over the intrinsic floor, or a page taller than the limit at scale 1 renders blank.
       const limitScale = Math.min(


### PR DESCRIPTION
## Problem

The PDF preview had no zoom, while the image preview already supports zoom/pan. Small-print pages and dense figures were hard to read, and "fit width" was the only view available. (Fullscreen expand already exists for all file types via the panel's maximize action — only zoom was missing.)

## Proposed change

Zoom the PDF **by page width** (like Chrome / Preview), not by CSS transform:

- `PdfPreviewContent` owns a `zoom` multiplier (0.5–3). Each page's displayed width is `fitWidth × zoom` (fit width is the parent-measured content box, capped at a comfortable reading width). The displayed width tracks the *current* measured width, so narrowing the panel or returning from full screen shrinks pages back to fit.
- Each page's canvas is rasterized at that width, so text stays **crisp at every zoom level** instead of upscaling a fixed bitmap. Backing size is bounded only by the browser-canvas dimension/area clamp merged in #429 — there is no separate scale cap, so high-DPI zoom is not pre-clipped.
- Controls: a bottom-right overlay (zoom out / reset / zoom in + percentage, mirroring the image preview) and **Ctrl/Cmd+wheel**.
- Native vertical scrolling and lazy per-page rendering are preserved; a zoomed page overflows into horizontal scroll.
- Zoom resets to fit when the previewed file changes. This works on both preview surfaces: the panel remounts on a file switch, and the Files-tab dialog (which updates `item` in place with no key) is covered by resetting `zoom` when the file's `requestKey` changes.

Builds on the resolution/lifecycle work merged in #429 — parent-owned width, serialized rerender, cancel-guard, and canvas-limit clamp already live there, so this PR is just the zoom layer on top.

## Scope and non-goals

- Touches `PdfPreview.tsx` and its test file `PdfPreview.test.tsx`.
- No free-form pan (this is a scrolling document, not a single image) and no double-click-to-reset.
- The card thumbnail (`PdfThumbnail.tsx`) is unchanged.

## Acceptance criteria and validation

- At 100% a page fills the fit width; zooming in re-rasterizes at higher resolution rather than upscaling.
- Narrowing the panel shrinks the displayed page back to fit (no stuck horizontal scroll at 100%).
- High-DPI zoom stays crisp: an A4 page at 768px fit, 175% zoom, DPR=2 rasterizes to the full ~2688px backing, not a clipped 2380px.
- Switching files (including the in-place dialog path) opens the next document at 100%.
- `npm run typecheck` (node + web), `npm run lint` — pass
- `PdfPreview.test.tsx` — 16/16 pass

## Review focus

- The page-width zoom model vs. CSS-transform, and the zoom range / step choices.