### PR TITLE
feat(providers): add doubao-seed-2-1-turbo to Volcengine Ark

### DIFF
--- a/src/shared/provider-registry.test.ts
+++ b/src/shared/provider-registry.test.ts
@@ -276,6 +276,7 @@ describe('provider registry', () => {
 
     it('returns true for Volcengine Ark Seed 2.x general models but not the coding model', () => {
       expect(isVendorModelMultimodal('volcengine', 'doubao-seed-2-1-pro-260628')).toBe(true)
+      expect(isVendorModelMultimodal('volcengine', 'doubao-seed-2-1-turbo-260628')).toBe(true)
       expect(isVendorModelMultimodal('volcengine', 'doubao-seed-2-0-pro-260215')).toBe(true)
       expect(isVendorModelMultimodal('volcengine', 'doubao-seed-2-0-lite-260215')).toBe(true)
       expect(isVendorModelMultimodal('volcengine', 'doubao-seed-2-0-mini-260215')).toBe(true)

--- a/src/shared/provider-registry.ts
+++ b/src/shared/provider-registry.ts
@@ -392,6 +392,7 @@ export const OFFICIAL_VENDORS: OfficialVendor[] = [
     apiKeyUrl: 'https://console.volcengine.com/ark/region:ark+cn-beijing/apikey',
     models: [
       { id: 'doubao-seed-2-1-pro-260628', contextWindow: 256_000 },
+      { id: 'doubao-seed-2-1-turbo-260628', contextWindow: 256_000 },
       { id: 'doubao-seed-2-0-pro-260215', contextWindow: 256_000 },
       { id: 'doubao-seed-2-0-lite-260215', contextWindow: 256_000 },
       { id: 'doubao-seed-2-0-mini-260215', contextWindow: 256_000 },
@@ -401,6 +402,7 @@ export const OFFICIAL_VENDORS: OfficialVendor[] = [
     multimodal: {
       multimodalModels: [
         'doubao-seed-2-1-pro-260628',
+        'doubao-seed-2-1-turbo-260628',
         'doubao-seed-2-0-pro-260215',
         'doubao-seed-2-0-lite-260215',
         'doubao-seed-2-0-mini-260215'


### PR DESCRIPTION
## Problem

Volcengine Ark published `doubao-seed-2-1-turbo` (260628), the turbo build of the Seed 2.1 generation, but it is missing from the bundled Volcengine Ark catalog so users cannot select it.

Model detail: https://console.volcengine.com/ark/region:cn-beijing/model/detail?name=doubao-seed-2-1-turbo

## Proposed change

Add `doubao-seed-2-1-turbo-260628` to the `volcengine` vendor in `src/shared/provider-registry.ts`:

- Catalog entry with a 256k context window, placed after the `doubao-seed-2-1-pro-260628` flagship so pro remains the default selection.
- Registered in the `multimodalModels` list alongside the other Seed 2.x general models, since the turbo build accepts image input (same as the rest of the generation).

It is served on the same three Ark routes (`/api/compatible`, `/api/v3`, `/api/v3/responses`) as the rest of the catalog, so no endpoint changes are needed.

## Scope and non-goals

- Scope: one model added to one vendor catalog plus its test assertion.
- Non-goals: no endpoint/base-url changes, no other vendor edits.

## Acceptance criteria and validation

- `npm run typecheck` — passes.
- `npm run lint` — passes on the changed files.
- `npm run test` — `provider-registry` suite passes (40 tests), including the new assertion that `doubao-seed-2-1-turbo-260628` resolves as multimodal.

## Review focus

- Confirm `doubao-seed-2-1-turbo-260628` is the correct id and that turbo belongs in the multimodal set (it shares the Seed 2.1 generation's vision capability).
- Placement after the pro flagship (keeping pro as the default) is intentional; flag if the turbo build should lead instead.