### PR TITLE
feat(provider): add claude-opus-5 to Anthropic models

### DIFF
--- a/src/shared/provider-registry.ts
+++ b/src/shared/provider-registry.ts
@@ -119,6 +119,7 @@ export const OFFICIAL_VENDORS: OfficialVendor[] = [
     modelsListUrl: 'https://api.anthropic.com/v1/models',
     // Models with a 1M-context variant list both the standard id and the `[1m]` one.
     models: [
+      { id: 'claude-opus-5', contextWindow: 1_000_000 },
       { id: 'claude-opus-4-8', contextWindow: 1_000_000 },
       { id: 'claude-opus-4-8[1m]', contextWindow: 1_000_000 },
       { id: 'claude-sonnet-5', contextWindow: 1_000_000 },


### PR DESCRIPTION
Add `claude-opus-5` to the Anthropic provider's bundled model list.

## Changes

- `src/shared/provider-registry.ts`: add `{ id: 'claude-opus-5', contextWindow: 1_000_000 }` as the first entry in the Anthropic models array

## Testing

- typecheck: ✓
- lint: 0 errors ✓
- tests: 40/40 passed ✓
- format: ✓