### PR TITLE
feat(skills): import installed global skills

### DIFF
--- a/src/main/settings/ipc.test.ts
+++ b/src/main/settings/ipc.test.ts
@@ -601,6 +601,36 @@ describe('settings IPC handlers', () => {
     expect(onSkillsChanged).toHaveBeenCalledOnce()
   })
 
+  it('does not fire onSkillsChanged when an installed-skill batch makes no changes', async () => {
+    handlers.clear()
+    const service = createFakeService()
+    const onSkillsChanged = vi.fn()
+    const result = {
+      results: [
+        {
+          source: 'agents',
+          slug: 'existing',
+          status: 'unchanged' as const,
+          id: 'imported-existing'
+        },
+        { source: 'claude', slug: 'missing', error: 'Skill not found.' }
+      ],
+      skills: []
+    }
+    service.importAgentHomeSkills.mockResolvedValue(result)
+    registerSettingsIpcHandlers({ service: asService(service), onSkillsChanged })
+
+    expect(
+      await invoke('settings:import-agent-home-skills', {
+        skills: [
+          { source: 'agents', slug: 'existing' },
+          { source: 'claude', slug: 'missing' }
+        ]
+      })
+    ).toBe(result)
+    expect(onSkillsChanged).not.toHaveBeenCalled()
+  })
+
   it('registers the OpenCode / framework-switch channels', () => {
     handlers.clear()
     registerSettingsIpcHandlers({ service: asService(createFakeService()) })

--- a/src/main/settings/ipc.test.ts
+++ b/src/main/settings/ipc.test.ts
@@ -64,6 +64,8 @@ type FakeSettingsService = Record<
   | 'updateSkill'
   | 'deleteSkill'
   | 'importSkillZipBatch'
+  | 'listAgentHomeSkills'
+  | 'importAgentHomeSkills'
   | 'setConnectorEnabled',
   ReturnType<typeof vi.fn>
 >
@@ -141,6 +143,8 @@ const createFakeService = (): FakeSettingsService => ({
   updateSkill: vi.fn().mockResolvedValue([]),
   deleteSkill: vi.fn().mockResolvedValue([]),
   importSkillZipBatch: vi.fn().mockResolvedValue({ results: [], skills: [] }),
+  listAgentHomeSkills: vi.fn().mockResolvedValue([]),
+  importAgentHomeSkills: vi.fn().mockResolvedValue({ results: [], skills: [] }),
   setConnectorEnabled: vi.fn().mockResolvedValue({ connectors: [] })
 })
 
@@ -567,6 +571,34 @@ describe('settings IPC handlers', () => {
     expect(service.importSkillZipBatch).toHaveBeenCalledWith(request)
     expect(forwarded).toBe(result)
     expect(onSkillsChanged).toHaveBeenCalledTimes(1)
+  })
+
+  it('routes one installed-skill batch and fires onSkillsChanged once', async () => {
+    handlers.clear()
+    const service = createFakeService()
+    const onSkillsChanged = vi.fn()
+    const result = {
+      results: [
+        {
+          source: 'agents',
+          slug: 'shared',
+          status: 'imported',
+          id: 'imported-shared'
+        }
+      ],
+      skills: []
+    }
+    service.importAgentHomeSkills.mockResolvedValue(result)
+    registerSettingsIpcHandlers({ service: asService(service), onSkillsChanged })
+    const request = { skills: [{ source: 'agents', slug: 'shared' }] }
+
+    expect(await invoke('settings:list-agent-home-skills')).toEqual([])
+    const forwarded = await invoke('settings:import-agent-home-skills', request)
+
+    expect(service.listAgentHomeSkills).toHaveBeenCalledOnce()
+    expect(service.importAgentHomeSkills).toHaveBeenCalledWith(request)
+    expect(forwarded).toBe(result)
+    expect(onSkillsChanged).toHaveBeenCalledOnce()
   })
 
   it('registers the OpenCode / framework-switch channels', () => {

--- a/src/main/settings/ipc.ts
+++ b/src/main/settings/ipc.ts
@@ -15,7 +15,7 @@ import {
   type CreateSkillRequest,
   type DeleteProviderRequest,
   type DeleteSkillRequest,
-  type ImportAgentHomeSkillRequest,
+  type ImportAgentHomeSkillsRequest,
   type ImportSkillRequest,
   type ImportSkillZipRequest,
   type ImportSkillZipBatchRequest,
@@ -473,13 +473,13 @@ const registerSettingsIpcHandlers = ({
   ipcMain.handle('settings:scan-repo-skills', (_event, request: ScanRepoRequest) =>
     service.scanRepoSkills(request)
   )
-  // Lists the user's machine-level Claude skills (~/.claude/skills/) for the "From your agent home"
-  // import source. Read-only — the renderer calls importAgentHomeSkill to actually copy one in.
+  // Lists the generic global skill source plus the active framework's source. Read-only — the
+  // renderer submits checked source-id/slug pairs through the batch import handler below.
   ipcMain.handle('settings:list-agent-home-skills', () => service.listAgentHomeSkills())
   ipcMain.handle(
-    'settings:import-agent-home-skill',
-    async (_event, request: ImportAgentHomeSkillRequest) => {
-      const result = await service.importAgentHomeSkill(request)
+    'settings:import-agent-home-skills',
+    async (_event, request: ImportAgentHomeSkillsRequest) => {
+      const result = await service.importAgentHomeSkills(request)
       onSkillsChanged?.()
 
       return result

--- a/src/main/settings/ipc.ts
+++ b/src/main/settings/ipc.ts
@@ -480,7 +480,9 @@ const registerSettingsIpcHandlers = ({
     'settings:import-agent-home-skills',
     async (_event, request: ImportAgentHomeSkillsRequest) => {
       const result = await service.importAgentHomeSkills(request)
-      onSkillsChanged?.()
+      if (result.results.some((item) => item.status === 'imported' || item.status === 'updated')) {
+        onSkillsChanged?.()
+      }
 
       return result
     }

--- a/src/main/settings/service.test.ts
+++ b/src/main/settings/service.test.ts
@@ -127,6 +127,7 @@ const createService = (
     ) => Promise<void>
     userClaudeDir?: string
     userCodexDir?: string
+    userAgentsDir?: string
   } = {}
 ): InstanceType<typeof SettingsService> =>
   new SettingsService({
@@ -136,6 +137,7 @@ const createService = (
     // path is now used by claude-isolated skill-scanning; claude-default is gone.
     userClaudeDir: options.userClaudeDir ?? join(storageRoot, 'no-user-claude'),
     userCodexDir: options.userCodexDir ?? join(storageRoot, 'no-user-codex'),
+    userAgentsDir: options.userAgentsDir ?? join(storageRoot, 'no-user-agents'),
     executeClaudeProbe: options.executeClaudeProbe,
     // eslint-disable-next-line @typescript-eslint/no-explicit-any
     installManagedClaudeImpl: options.installManagedClaudeImpl as any,
@@ -3963,10 +3965,8 @@ describe('SettingsService: app icon variant', () => {
 })
 
 describe('SettingsService: listAgentHomeSkills framework routing', () => {
-  // The agent-home skill import is framework-agnostic: claude-code scans `~/.claude/skills/`,
-  // codex scans `~/.codex/skills/`, and opencode (which has no global skills convention) returns
-  // an empty list. The active framework is read from settings on every call so switching the
-  // agent framework takes effect without restarting the service.
+  // The shared ~/.agents/skills directory is always scanned. The active framework contributes one
+  // additional source: ~/.claude/skills for Claude Code or ~/.codex/skills for Codex.
 
   // Seeds a fake skill at <agentHome>/skills/<slug>/SKILL.md so the scanner picks it up.
   const seedSkill = async (agentHome: string, slug: string): Promise<void> => {
@@ -3978,60 +3978,56 @@ describe('SettingsService: listAgentHomeSkills framework routing', () => {
     )
   }
 
-  it('scans the user Claude home when the active framework is claude-code', async () => {
+  it('scans shared and Claude homes when the active framework is claude-code', async () => {
     const userClaudeDir = await mkdtemp(join(tmpdir(), 'os-list-agent-claude-'))
     const userCodexDir = await mkdtemp(join(tmpdir(), 'os-list-agent-codex-'))
+    const userAgentsDir = await mkdtemp(join(tmpdir(), 'os-list-agent-shared-'))
     await seedSkill(userClaudeDir, 'alpha')
-    // A Codex skill in the Codex home must not be picked up while the active framework is Claude.
-    await seedSkill(userCodexDir, 'should-not-appear')
-    const service = createService(undefined, { userClaudeDir, userCodexDir })
+    await seedSkill(userCodexDir, 'codex-only')
+    await seedSkill(userAgentsDir, 'shared')
+    const service = createService(undefined, { userClaudeDir, userCodexDir, userAgentsDir })
     await repository.setAgentFramework('claude-code')
 
     const items = await service.listAgentHomeSkills()
 
-    expect(items.map((item) => item.slug)).toEqual(['alpha'])
-    expect(items[0].path).toBe(join(userClaudeDir, 'skills', 'alpha'))
+    expect(items.map(({ source, slug }) => ({ source, slug }))).toEqual([
+      { source: 'agents', slug: 'shared' },
+      { source: 'claude', slug: 'alpha' }
+    ])
+    expect(items.every((item) => !('path' in item))).toBe(true)
   })
 
-  it('scans the user Codex home when the active framework is codex', async () => {
+  it('scans shared and Codex homes when the active framework is codex', async () => {
     const userClaudeDir = await mkdtemp(join(tmpdir(), 'os-list-agent-claude-'))
     const userCodexDir = await mkdtemp(join(tmpdir(), 'os-list-agent-codex-'))
+    const userAgentsDir = await mkdtemp(join(tmpdir(), 'os-list-agent-shared-'))
     await seedSkill(userCodexDir, 'beta')
-    // A Claude skill in the Claude home must not be picked up while the active framework is Codex.
-    await seedSkill(userClaudeDir, 'should-not-appear')
-    const service = createService(undefined, { userClaudeDir, userCodexDir })
+    await seedSkill(userClaudeDir, 'claude-only')
+    await seedSkill(userAgentsDir, 'shared')
+    const service = createService(undefined, { userClaudeDir, userCodexDir, userAgentsDir })
     await repository.setAgentFramework('codex')
 
     const items = await service.listAgentHomeSkills()
 
-    expect(items.map((item) => item.slug)).toEqual(['beta'])
-    expect(items[0].path).toBe(join(userCodexDir, 'skills', 'beta'))
+    expect(items.map(({ source, slug }) => ({ source, slug }))).toEqual([
+      { source: 'agents', slug: 'shared' },
+      { source: 'codex', slug: 'beta' }
+    ])
   })
 
-  it('returns an empty list when the active framework is opencode (no global home)', async () => {
+  it('scans only the shared home for other frameworks', async () => {
     const userClaudeDir = await mkdtemp(join(tmpdir(), 'os-list-agent-claude-'))
     const userCodexDir = await mkdtemp(join(tmpdir(), 'os-list-agent-codex-'))
-    // Even with skills present, opencode's lack of a global skills convention must hide the source.
-    await seedSkill(userClaudeDir, 'hidden-1')
-    await seedSkill(userCodexDir, 'hidden-2')
-    const service = createService(undefined, { userClaudeDir, userCodexDir })
+    const userAgentsDir = await mkdtemp(join(tmpdir(), 'os-list-agent-shared-'))
+    await seedSkill(userClaudeDir, 'hidden-claude')
+    await seedSkill(userCodexDir, 'hidden-codex')
+    await seedSkill(userAgentsDir, 'visible-shared')
+    const service = createService(undefined, { userClaudeDir, userCodexDir, userAgentsDir })
     await repository.setAgentFramework('opencode')
 
-    expect(await service.listAgentHomeSkills()).toEqual([])
-  })
-
-  it('re-reads the active framework on every call (no cached home dir)', async () => {
-    const userClaudeDir = await mkdtemp(join(tmpdir(), 'os-list-agent-claude-'))
-    const userCodexDir = await mkdtemp(join(tmpdir(), 'os-list-agent-codex-'))
-    await seedSkill(userClaudeDir, 'claude-only')
-    await seedSkill(userCodexDir, 'codex-only')
-    const service = createService(undefined, { userClaudeDir, userCodexDir })
-
-    await repository.setAgentFramework('claude-code')
-    expect((await service.listAgentHomeSkills()).map((i) => i.slug)).toEqual(['claude-only'])
-
-    await repository.setAgentFramework('codex')
-    expect((await service.listAgentHomeSkills()).map((i) => i.slug)).toEqual(['codex-only'])
+    expect(
+      (await service.listAgentHomeSkills()).map(({ source, slug }) => ({ source, slug }))
+    ).toEqual([{ source: 'agents', slug: 'visible-shared' }])
   })
 })
 
@@ -4128,10 +4124,9 @@ describe('SettingsService: logoutIsolatedClaude error propagation', () => {
   })
 })
 
-describe('SettingsService: importAgentHomeSkill path containment', () => {
-  // P1 / Medium from the Codex + Claude reviews: path authority lives in main. The renderer
-  // supplies a slug; the service resolves it against the active agent's skills dir and refuses
-  // any slug that escapes the configured home directory.
+describe('SettingsService: importAgentHomeSkills', () => {
+  // Path authority lives in main. The renderer supplies a source id plus slug; the service resolves
+  // both against the currently available global sources and returns one result per selected skill.
 
   const seedSkill = async (agentHome: string, slug: string): Promise<string> => {
     const skillDir = join(agentHome, 'skills', slug)
@@ -4143,41 +4138,48 @@ describe('SettingsService: importAgentHomeSkill path containment', () => {
     return skillDir
   }
 
-  it('imports the skill that lives under the active agent home', async () => {
+  it('batch-imports selected shared and framework-specific skills', async () => {
     const userClaudeDir = await mkdtemp(join(tmpdir(), 'os-import-agent-ok-'))
+    const userAgentsDir = await mkdtemp(join(tmpdir(), 'os-import-agent-shared-'))
     await seedSkill(userClaudeDir, 'alpha')
-    const service = createService(undefined, { userClaudeDir })
+    await seedSkill(userAgentsDir, 'shared')
+    const service = createService(undefined, { userClaudeDir, userAgentsDir })
     await repository.setAgentFramework('claude-code')
 
-    const result = await service.importAgentHomeSkill({ slug: 'alpha' })
+    const result = await service.importAgentHomeSkills({
+      skills: [
+        { source: 'agents', slug: 'shared' },
+        { source: 'claude', slug: 'alpha' }
+      ]
+    })
 
-    expect(result.status).toBe('imported')
-    expect(result.id).toBe('imported-alpha')
+    expect(result.results).toEqual([
+      { source: 'agents', slug: 'shared', status: 'imported', id: 'imported-shared' },
+      { source: 'claude', slug: 'alpha', status: 'imported', id: 'imported-alpha' }
+    ])
+    expect(result.skills.map((skill) => skill.id)).toEqual(
+      expect.arrayContaining(['imported-shared', 'imported-alpha'])
+    )
   })
 
-  it('rejects slugs that fail the SAFE_SLUG check before reaching the path resolver', async () => {
+  it('reports unsafe slugs and unavailable sources without aborting other selected skills', async () => {
     const userClaudeDir = await mkdtemp(join(tmpdir(), 'os-import-agent-escape-'))
-    const service = createService(undefined, { userClaudeDir })
+    const userAgentsDir = await mkdtemp(join(tmpdir(), 'os-import-agent-shared-'))
+    await seedSkill(userAgentsDir, 'safe')
+    const service = createService(undefined, { userClaudeDir, userAgentsDir })
     await repository.setAgentFramework('claude-code')
 
-    // Path-traversal payloads are caught by the SAFE_SLUG regex (no '/', '.', etc.), so the
-    // containment check downstream is defense-in-depth and is not exercised by valid slugs.
-    await expect(service.importAgentHomeSkill({ slug: '../../etc' })).rejects.toThrow(/unsafe slug/)
-    await expect(service.importAgentHomeSkill({ slug: '../sibling' })).rejects.toThrow(
-      /unsafe slug/
-    )
-    await expect(service.importAgentHomeSkill({ slug: 'has spaces' })).rejects.toThrow(
-      /unsafe slug/
-    )
-  })
+    const result = await service.importAgentHomeSkills({
+      skills: [
+        { source: 'agents', slug: 'safe' },
+        { source: 'claude', slug: '../../etc' },
+        { source: 'codex', slug: 'not-active' }
+      ]
+    })
 
-  it('rejects when the active framework has no global skills directory', async () => {
-    const service = createService()
-    await repository.setAgentFramework('opencode')
-
-    await expect(service.importAgentHomeSkill({ slug: 'alpha' })).rejects.toThrow(
-      /no global skills directory/
-    )
+    expect(result.results[0]).toMatchObject({ status: 'imported', id: 'imported-safe' })
+    expect(result.results[1]).toMatchObject({ error: expect.stringMatching(/unsafe slug/) })
+    expect(result.results[2]).toMatchObject({ error: expect.stringMatching(/not available/) })
   })
 })
 
@@ -4564,7 +4566,7 @@ describe('SettingsService: claude-isolated edit preserves expiresAt + keyRef', (
   })
 })
 
-describe('SettingsService: importAgentHomeSkill realpath containment', () => {
+describe('SettingsService: importAgentHomeSkills realpath containment', () => {
   // Round 6 of the AI review: a symlink that points outside the agent home is a containment
   // escape even when `resolve()` (lexical) is satisfied. The realpath fallback closes the gap.
   const seedSkill = async (agentHome: string, slug: string): Promise<string> => {
@@ -4577,6 +4579,10 @@ describe('SettingsService: importAgentHomeSkill realpath containment', () => {
   it('rejects a symlink inside the agent home that points outside it', async () => {
     const userClaudeDir = await mkdtemp(join(tmpdir(), 'os-import-symlink-'))
     const outside = await mkdtemp(join(tmpdir(), 'os-import-outside-'))
+    await writeFile(
+      join(outside, 'SKILL.md'),
+      '---\nname: outside\ndescription: Test\n---\nBody.\n'
+    )
     // Create a symlink at `<home>/skills/payload -> <outside>` so the basename is a valid slug
     // and `resolve(home, slug)` would land at the symlink target.
     const linkPath = join(userClaudeDir, 'skills', 'payload')
@@ -4585,23 +4591,43 @@ describe('SettingsService: importAgentHomeSkill realpath containment', () => {
     const service = createService(undefined, { userClaudeDir })
     await repository.setAgentFramework('claude-code')
 
-    await expect(service.importAgentHomeSkill({ slug: 'payload' })).rejects.toThrow(
-      /outside its home/
+    expect((await service.listAgentHomeSkills()).map((skill) => skill.slug)).not.toContain(
+      'payload'
     )
+
+    const result = await service.importAgentHomeSkills({
+      skills: [{ source: 'claude', slug: 'payload' }]
+    })
+
+    expect(result.results[0]).toMatchObject({
+      error: expect.stringMatching(/outside its source/)
+    })
   })
 
-  it('rejects a Skill-root symlink even when it stays within the agent home', async () => {
+  it('imports a framework skill symlink that resolves into another available global source', async () => {
     const userClaudeDir = await mkdtemp(join(tmpdir(), 'os-import-symlink-benign-'))
-    const target = await seedSkill(userClaudeDir, 'real-skill')
+    const userAgentsDir = await mkdtemp(join(tmpdir(), 'os-import-symlink-shared-'))
+    const target = await seedSkill(userAgentsDir, 'real-skill')
     const linkDir = join(userClaudeDir, 'skills', 'linked-skill')
     await mkdir(join(userClaudeDir, 'skills'), { recursive: true })
     await symlink(target, linkDir)
-    const service = createService(undefined, { userClaudeDir })
+    const service = createService(undefined, { userClaudeDir, userAgentsDir })
     await repository.setAgentFramework('claude-code')
 
-    await expect(service.importAgentHomeSkill({ slug: 'linked-skill' })).rejects.toThrow(
-      /symbolic link/
+    expect((await service.listAgentHomeSkills()).map((skill) => skill.slug)).toContain(
+      'linked-skill'
     )
+
+    const result = await service.importAgentHomeSkills({
+      skills: [{ source: 'claude', slug: 'linked-skill' }]
+    })
+
+    expect(result.results[0]).toEqual({
+      source: 'claude',
+      slug: 'linked-skill',
+      status: 'imported',
+      id: 'imported-linked-skill'
+    })
   })
 })
 

--- a/src/main/settings/service.test.ts
+++ b/src/main/settings/service.test.ts
@@ -4012,6 +4012,16 @@ describe('SettingsService: listAgentHomeSkills framework routing', () => {
     ])
   })
 
+  it('rejects when a missing shared source would mask an active-source failure', async () => {
+    const userClaudeDir = await mkdtemp(join(tmpdir(), 'os-list-agent-claude-unreadable-'))
+    const userAgentsDir = await mkdtemp(join(tmpdir(), 'os-list-agent-shared-missing-'))
+    await writeFile(join(userClaudeDir, 'skills'), 'not a directory')
+    const service = createService(undefined, { userClaudeDir, userAgentsDir })
+    await repository.setAgentFramework('claude-code')
+
+    await expect(service.listAgentHomeSkills()).rejects.toMatchObject({ code: 'ENOTDIR' })
+  })
+
   it('rejects the scan when every configured source fails', async () => {
     const userClaudeDir = await mkdtemp(join(tmpdir(), 'os-list-agent-claude-unreadable-'))
     const userAgentsDir = await mkdtemp(join(tmpdir(), 'os-list-agent-shared-unreadable-'))

--- a/src/main/settings/service.test.ts
+++ b/src/main/settings/service.test.ts
@@ -4732,6 +4732,35 @@ describe('SettingsService: importAgentHomeSkills realpath containment', () => {
     })
   })
 
+  it('rejects symlinks to an allowed skills root or a nested descendant', async () => {
+    const userClaudeDir = await mkdtemp(join(tmpdir(), 'os-import-symlink-depth-'))
+    const userAgentsDir = await mkdtemp(join(tmpdir(), 'os-import-symlink-shared-'))
+    const realSkill = await seedSkill(userAgentsDir, 'real-skill')
+    const nested = join(realSkill, 'references')
+    await mkdir(nested, { recursive: true })
+    await writeFile(join(nested, 'notes.md'), 'Nested content.')
+    await mkdir(join(userClaudeDir, 'skills'), { recursive: true })
+    await symlink(join(userAgentsDir, 'skills'), join(userClaudeDir, 'skills', 'root-alias'))
+    await symlink(nested, join(userClaudeDir, 'skills', 'nested-alias'))
+    const service = createService(undefined, { userClaudeDir, userAgentsDir })
+    await repository.setAgentFramework('claude-code')
+
+    const result = await service.importAgentHomeSkills({
+      skills: [
+        { source: 'claude', slug: 'root-alias' },
+        { source: 'claude', slug: 'nested-alias' }
+      ]
+    })
+
+    expect(result.results).toEqual([
+      expect.objectContaining({ error: expect.stringMatching(/top-level skill directory/) }),
+      expect.objectContaining({ error: expect.stringMatching(/top-level skill directory/) })
+    ])
+    expect(result.skills.map((skill) => skill.id)).not.toEqual(
+      expect.arrayContaining(['imported-root-alias', 'imported-nested-alias'])
+    )
+  })
+
   it('canonicalizes a framework symlink alias to the shared installed skill', async () => {
     const userClaudeDir = await mkdtemp(join(tmpdir(), 'os-import-symlink-benign-'))
     const userAgentsDir = await mkdtemp(join(tmpdir(), 'os-import-symlink-shared-'))

--- a/src/main/settings/service.test.ts
+++ b/src/main/settings/service.test.ts
@@ -4012,6 +4012,17 @@ describe('SettingsService: listAgentHomeSkills framework routing', () => {
     ])
   })
 
+  it('rejects the scan when every configured source fails', async () => {
+    const userClaudeDir = await mkdtemp(join(tmpdir(), 'os-list-agent-claude-unreadable-'))
+    const userAgentsDir = await mkdtemp(join(tmpdir(), 'os-list-agent-shared-unreadable-'))
+    await writeFile(join(userClaudeDir, 'skills'), 'not a directory')
+    await writeFile(join(userAgentsDir, 'skills'), 'not a directory')
+    const service = createService(undefined, { userClaudeDir, userAgentsDir })
+    await repository.setAgentFramework('claude-code')
+
+    await expect(service.listAgentHomeSkills()).rejects.toMatchObject({ code: 'ENOTDIR' })
+  })
+
   it('scans shared and Codex homes when the active framework is codex', async () => {
     const userClaudeDir = await mkdtemp(join(tmpdir(), 'os-list-agent-claude-'))
     const userCodexDir = await mkdtemp(join(tmpdir(), 'os-list-agent-codex-'))

--- a/src/main/settings/service.test.ts
+++ b/src/main/settings/service.test.ts
@@ -1,4 +1,4 @@
-import { chmod, mkdir, mkdtemp, readFile, rm, symlink, writeFile } from 'node:fs/promises'
+import { chmod, mkdir, mkdtemp, readFile, rename, rm, symlink, writeFile } from 'node:fs/promises'
 import { dirname, join, normalize } from 'node:path'
 import { tmpdir } from 'node:os'
 import { execPath } from 'node:process'
@@ -4851,6 +4851,128 @@ describe('SettingsService: importAgentHomeSkills realpath containment', () => {
       status: 'unchanged',
       id: 'imported-real-skill'
     })
+  })
+
+  it('matches a legacy import recorded under a symlink alias after canonicalization', async () => {
+    const userClaudeDir = await mkdtemp(join(tmpdir(), 'os-import-symlink-legacy-alias-'))
+    const userAgentsDir = await mkdtemp(join(tmpdir(), 'os-import-symlink-legacy-shared-'))
+    const target = await seedSkill(userAgentsDir, 'real-skill')
+    await seedSkill(userAgentsDir, 'linked-skill')
+    await mkdir(join(userClaudeDir, 'skills'), { recursive: true })
+    await symlink(target, join(userClaudeDir, 'skills', 'linked-skill'))
+
+    const legacyDir = join(storageRoot, 'skills', 'imported', 'linked-skill')
+    await mkdir(legacyDir, { recursive: true })
+    await writeFile(
+      join(legacyDir, 'SKILL.md'),
+      '---\nname: linked-skill\ndescription: Legacy alias import\n---\nLegacy body.\n'
+    )
+
+    const service = createService(undefined, { userClaudeDir, userAgentsDir })
+    await repository.setAgentFramework('claude-code')
+
+    const installed = await service.listAgentHomeSkills()
+    expect(installed).toEqual(
+      expect.arrayContaining([
+        expect.objectContaining({
+          source: 'agents',
+          slug: 'real-skill',
+          alreadyImported: true
+        })
+      ])
+    )
+    expect(installed).toEqual(
+      expect.arrayContaining([
+        expect.objectContaining({
+          source: 'agents',
+          slug: 'linked-skill',
+          alreadyImported: false
+        })
+      ])
+    )
+
+    const result = await service.importAgentHomeSkills({
+      skills: [{ source: 'agents', slug: 'real-skill' }]
+    })
+
+    expect(result.results[0]).toEqual({
+      source: 'agents',
+      slug: 'real-skill',
+      status: 'unchanged',
+      id: 'imported-linked-skill'
+    })
+    expect(result.skills.map((skill) => skill.id)).not.toContain('imported-real-skill')
+  })
+
+  it('updates an existing alias identity through its canonical installed-skill row', async () => {
+    const userClaudeDir = await mkdtemp(join(tmpdir(), 'os-import-symlink-source-alias-'))
+    const userAgentsDir = await mkdtemp(join(tmpdir(), 'os-import-symlink-source-shared-'))
+    const target = await seedSkill(userAgentsDir, 'real-skill')
+    await mkdir(join(userClaudeDir, 'skills'), { recursive: true })
+    await symlink(target, join(userClaudeDir, 'skills', 'linked-skill'))
+
+    const importedDir = join(storageRoot, 'skills', 'imported', 'linked-skill')
+    await mkdir(importedDir, { recursive: true })
+    await writeFile(
+      join(importedDir, 'SKILL.md'),
+      '---\nname: linked-skill\ndescription: Old alias import\n---\nOld body.\n'
+    )
+    await writeFile(
+      join(importedDir, '.source.json'),
+      JSON.stringify({
+        signature: 'stale-signature',
+        agentHome: { source: 'claude', slug: 'linked-skill' }
+      })
+    )
+
+    const service = createService(undefined, { userClaudeDir, userAgentsDir })
+    await repository.setAgentFramework('claude-code')
+
+    const result = await service.importAgentHomeSkills({
+      skills: [{ source: 'agents', slug: 'real-skill' }]
+    })
+
+    expect(result.results[0]).toEqual({
+      source: 'agents',
+      slug: 'real-skill',
+      status: 'updated',
+      id: 'imported-linked-skill'
+    })
+    expect(result.skills.map((skill) => skill.id)).not.toContain('imported-real-skill')
+    await expect(
+      readFile(join(importedDir, '.source.json'), 'utf8').then(JSON.parse)
+    ).resolves.toMatchObject({ agentHome: { source: 'agents', slug: 'real-skill' } })
+  })
+
+  it('recognizes unchanged alias metadata after the source moves behind a symlink', async () => {
+    const userClaudeDir = await mkdtemp(join(tmpdir(), 'os-import-symlink-moved-alias-'))
+    const userAgentsDir = await mkdtemp(join(tmpdir(), 'os-import-symlink-moved-shared-'))
+    const original = await seedSkill(userClaudeDir, 'linked-skill')
+    const service = createService(undefined, { userClaudeDir, userAgentsDir })
+    await repository.setAgentFramework('claude-code')
+
+    expect(
+      (
+        await service.importAgentHomeSkills({
+          skills: [{ source: 'claude', slug: 'linked-skill' }]
+        })
+      ).results[0]
+    ).toMatchObject({ status: 'imported', id: 'imported-linked-skill' })
+
+    const canonical = join(userAgentsDir, 'skills', 'real-skill')
+    await mkdir(join(userAgentsDir, 'skills'), { recursive: true })
+    await rename(original, canonical)
+    await symlink(canonical, original)
+
+    expect(await service.listAgentHomeSkills()).toEqual(
+      expect.arrayContaining([
+        expect.objectContaining({
+          source: 'agents',
+          slug: 'real-skill',
+          alreadyImported: true
+        })
+      ])
+    )
   })
 })
 

--- a/src/main/settings/service.test.ts
+++ b/src/main/settings/service.test.ts
@@ -4227,6 +4227,39 @@ describe('SettingsService: importAgentHomeSkills', () => {
     })
   })
 
+  it('does not re-offer a same-slug skill already imported from another flow', async () => {
+    const userAgentsDir = await mkdtemp(join(tmpdir(), 'os-import-agent-existing-'))
+    await seedSkill(userAgentsDir, 'existing')
+    const importedDir = join(storageRoot, 'skills', 'imported', 'existing')
+    await mkdir(importedDir, { recursive: true })
+    await writeFile(
+      join(importedDir, 'SKILL.md'),
+      '---\nname: existing\ndescription: GitHub import\n---\nBody.\n'
+    )
+    await writeFile(
+      join(importedDir, '.source.json'),
+      JSON.stringify({
+        url: 'https://github.com/example/skills/tree/main/existing',
+        signature: 'sig'
+      })
+    )
+    const service = createService(undefined, { userAgentsDir })
+
+    expect(await service.listAgentHomeSkills()).toEqual(
+      expect.arrayContaining([
+        expect.objectContaining({ source: 'agents', slug: 'existing', alreadyImported: true })
+      ])
+    )
+
+    const result = await service.importAgentHomeSkills({
+      skills: [{ source: 'agents', slug: 'existing' }]
+    })
+    expect(result.results[0]).toMatchObject({
+      status: 'unchanged',
+      id: 'imported-existing'
+    })
+  })
+
   it('keeps one same-slug source importable when a legacy import is ambiguous', async () => {
     const userClaudeDir = await mkdtemp(join(tmpdir(), 'os-import-agent-legacy-claude-'))
     const userAgentsDir = await mkdtemp(join(tmpdir(), 'os-import-agent-legacy-shared-'))

--- a/src/main/settings/service.test.ts
+++ b/src/main/settings/service.test.ts
@@ -4162,6 +4162,43 @@ describe('SettingsService: importAgentHomeSkills', () => {
     )
   })
 
+  it('tracks imported state independently for same-slug skills from different sources', async () => {
+    const userClaudeDir = await mkdtemp(join(tmpdir(), 'os-import-agent-duplicate-'))
+    const userAgentsDir = await mkdtemp(join(tmpdir(), 'os-import-agent-shared-'))
+    await seedSkill(userClaudeDir, 'duplicate')
+    await seedSkill(userAgentsDir, 'duplicate')
+    const service = createService(undefined, { userClaudeDir, userAgentsDir })
+    await repository.setAgentFramework('claude-code')
+
+    const first = await service.importAgentHomeSkills({
+      skills: [{ source: 'agents', slug: 'duplicate' }]
+    })
+
+    expect(first.results[0]).toMatchObject({
+      source: 'agents',
+      slug: 'duplicate',
+      status: 'imported',
+      id: 'imported-duplicate'
+    })
+    expect(await service.listAgentHomeSkills()).toEqual(
+      expect.arrayContaining([
+        expect.objectContaining({ source: 'agents', slug: 'duplicate', alreadyImported: true }),
+        expect.objectContaining({ source: 'claude', slug: 'duplicate', alreadyImported: false })
+      ])
+    )
+
+    const second = await service.importAgentHomeSkills({
+      skills: [{ source: 'claude', slug: 'duplicate' }]
+    })
+
+    expect(second.results[0]).toMatchObject({
+      source: 'claude',
+      slug: 'duplicate',
+      status: 'imported',
+      id: 'imported-duplicate-2'
+    })
+  })
+
   it('reports unsafe slugs and unavailable sources without aborting other selected skills', async () => {
     const userClaudeDir = await mkdtemp(join(tmpdir(), 'os-import-agent-escape-'))
     const userAgentsDir = await mkdtemp(join(tmpdir(), 'os-import-agent-shared-'))

--- a/src/main/settings/service.test.ts
+++ b/src/main/settings/service.test.ts
@@ -4309,6 +4309,25 @@ describe('SettingsService: importAgentHomeSkills', () => {
     expect(result.results[1]).toMatchObject({ error: expect.stringMatching(/unsafe slug/) })
     expect(result.results[2]).toMatchObject({ error: expect.stringMatching(/not available/) })
   })
+
+  it('reports malformed batch entries without aborting valid selected skills', async () => {
+    const userAgentsDir = await mkdtemp(join(tmpdir(), 'os-import-agent-malformed-'))
+    await seedSkill(userAgentsDir, 'safe')
+    const service = createService(undefined, { userAgentsDir })
+
+    const result = await service.importAgentHomeSkills({
+      skills: [null, { source: 'agents', slug: 'safe' }, undefined] as never
+    })
+
+    expect(result.results).toHaveLength(3)
+    expect(result.results[0]).toMatchObject({
+      error: expect.stringMatching(/valid source and slug/)
+    })
+    expect(result.results[1]).toMatchObject({ status: 'imported', id: 'imported-safe' })
+    expect(result.results[2]).toMatchObject({
+      error: expect.stringMatching(/valid source and slug/)
+    })
+  })
 })
 
 describe('SettingsService: claude-isolated login + status coordination', () => {

--- a/src/main/settings/service.test.ts
+++ b/src/main/settings/service.test.ts
@@ -3997,6 +3997,21 @@ describe('SettingsService: listAgentHomeSkills framework routing', () => {
     expect(items.every((item) => !('path' in item))).toBe(true)
   })
 
+  it('keeps framework-specific results when the shared source cannot be scanned', async () => {
+    const userClaudeDir = await mkdtemp(join(tmpdir(), 'os-list-agent-claude-readable-'))
+    const userAgentsDir = await mkdtemp(join(tmpdir(), 'os-list-agent-shared-unreadable-'))
+    await seedSkill(userClaudeDir, 'alpha')
+    await writeFile(join(userAgentsDir, 'skills'), 'not a directory')
+    const service = createService(undefined, { userClaudeDir, userAgentsDir })
+    await repository.setAgentFramework('claude-code')
+
+    const items = await service.listAgentHomeSkills()
+
+    expect(items.map(({ source, slug }) => ({ source, slug }))).toEqual([
+      { source: 'claude', slug: 'alpha' }
+    ])
+  })
+
   it('scans shared and Codex homes when the active framework is codex', async () => {
     const userClaudeDir = await mkdtemp(join(tmpdir(), 'os-list-agent-claude-'))
     const userCodexDir = await mkdtemp(join(tmpdir(), 'os-list-agent-codex-'))

--- a/src/main/settings/service.test.ts
+++ b/src/main/settings/service.test.ts
@@ -4263,7 +4263,7 @@ describe('SettingsService: importAgentHomeSkills', () => {
     })
   })
 
-  it('does not re-offer a same-slug skill already imported from another flow', async () => {
+  it('keeps a different same-slug GitHub import separate from an installed skill', async () => {
     const userAgentsDir = await mkdtemp(join(tmpdir(), 'os-import-agent-existing-'))
     await seedSkill(userAgentsDir, 'existing')
     const importedDir = join(storageRoot, 'skills', 'imported', 'existing')
@@ -4283,7 +4283,7 @@ describe('SettingsService: importAgentHomeSkills', () => {
 
     expect(await service.listAgentHomeSkills()).toEqual(
       expect.arrayContaining([
-        expect.objectContaining({ source: 'agents', slug: 'existing', alreadyImported: true })
+        expect.objectContaining({ source: 'agents', slug: 'existing', alreadyImported: false })
       ])
     )
 
@@ -4291,8 +4291,44 @@ describe('SettingsService: importAgentHomeSkills', () => {
       skills: [{ source: 'agents', slug: 'existing' }]
     })
     expect(result.results[0]).toMatchObject({
+      status: 'imported',
+      id: 'imported-existing-2'
+    })
+    expect(result.skills.map((skill) => skill.id)).toEqual(
+      expect.arrayContaining(['imported-existing', 'imported-existing-2'])
+    )
+  })
+
+  it('recognizes an identical same-slug GitHub import by content', async () => {
+    const userAgentsDir = await mkdtemp(join(tmpdir(), 'os-import-agent-identical-'))
+    await seedSkill(userAgentsDir, 'identical')
+    const importedDir = join(storageRoot, 'skills', 'imported', 'identical')
+    await mkdir(importedDir, { recursive: true })
+    await writeFile(
+      join(importedDir, 'SKILL.md'),
+      '---\nname: identical\ndescription: Test\n---\nBody.\n'
+    )
+    await writeFile(
+      join(importedDir, '.source.json'),
+      JSON.stringify({
+        url: 'https://github.com/example/skills/tree/main/identical',
+        signature: 'github-signature'
+      })
+    )
+    const service = createService(undefined, { userAgentsDir })
+
+    expect(await service.listAgentHomeSkills()).toEqual(
+      expect.arrayContaining([
+        expect.objectContaining({ source: 'agents', slug: 'identical', alreadyImported: true })
+      ])
+    )
+
+    const result = await service.importAgentHomeSkills({
+      skills: [{ source: 'agents', slug: 'identical' }]
+    })
+    expect(result.results[0]).toMatchObject({
       status: 'unchanged',
-      id: 'imported-existing'
+      id: 'imported-identical'
     })
   })
 
@@ -4305,7 +4341,7 @@ describe('SettingsService: importAgentHomeSkills', () => {
     await mkdir(legacyDir, { recursive: true })
     await writeFile(
       join(legacyDir, 'SKILL.md'),
-      '---\nname: duplicate\ndescription: Legacy\n---\nLegacy body.\n'
+      '---\nname: duplicate\ndescription: Test\n---\nBody.\n'
     )
     const service = createService(undefined, { userClaudeDir, userAgentsDir })
     await repository.setAgentFramework('claude-code')
@@ -4865,7 +4901,7 @@ describe('SettingsService: importAgentHomeSkills realpath containment', () => {
     await mkdir(legacyDir, { recursive: true })
     await writeFile(
       join(legacyDir, 'SKILL.md'),
-      '---\nname: linked-skill\ndescription: Legacy alias import\n---\nLegacy body.\n'
+      '---\nname: real-skill\ndescription: Test\n---\nBody.\n'
     )
 
     const service = createService(undefined, { userClaudeDir, userAgentsDir })

--- a/src/main/settings/service.test.ts
+++ b/src/main/settings/service.test.ts
@@ -4332,7 +4332,7 @@ describe('SettingsService: importAgentHomeSkills', () => {
     })
   })
 
-  it('keeps one same-slug source importable when a legacy import is ambiguous', async () => {
+  it('marks every identical same-slug source imported when legacy content matches', async () => {
     const userClaudeDir = await mkdtemp(join(tmpdir(), 'os-import-agent-legacy-claude-'))
     const userAgentsDir = await mkdtemp(join(tmpdir(), 'os-import-agent-legacy-shared-'))
     await seedSkill(userClaudeDir, 'duplicate')
@@ -4348,7 +4348,7 @@ describe('SettingsService: importAgentHomeSkills', () => {
 
     expect(await service.listAgentHomeSkills()).toEqual(
       expect.arrayContaining([
-        expect.objectContaining({ source: 'agents', slug: 'duplicate', alreadyImported: false }),
+        expect.objectContaining({ source: 'agents', slug: 'duplicate', alreadyImported: true }),
         expect.objectContaining({ source: 'claude', slug: 'duplicate', alreadyImported: true })
       ])
     )
@@ -4357,8 +4357,8 @@ describe('SettingsService: importAgentHomeSkills', () => {
       skills: [{ source: 'agents', slug: 'duplicate' }]
     })
     expect(result.results[0]).toMatchObject({
-      status: 'imported',
-      id: 'imported-duplicate-2'
+      status: 'unchanged',
+      id: 'imported-duplicate'
     })
   })
 
@@ -5000,6 +5000,60 @@ describe('SettingsService: importAgentHomeSkills realpath containment', () => {
     await rename(original, canonical)
     await symlink(canonical, original)
 
+    expect(await service.listAgentHomeSkills()).toEqual(
+      expect.arrayContaining([
+        expect.objectContaining({
+          source: 'agents',
+          slug: 'real-skill',
+          alreadyImported: true
+        })
+      ])
+    )
+
+    await repository.setAgentFramework('opencode')
+    expect(await service.listAgentHomeSkills()).toEqual(
+      expect.arrayContaining([
+        expect.objectContaining({
+          source: 'agents',
+          slug: 'real-skill',
+          alreadyImported: true
+        })
+      ])
+    )
+  })
+
+  it('migrates alias metadata when the framework skills root becomes a shared-root symlink', async () => {
+    const userClaudeDir = await mkdtemp(join(tmpdir(), 'os-import-symlink-root-alias-'))
+    const userAgentsDir = await mkdtemp(join(tmpdir(), 'os-import-symlink-root-shared-'))
+    const original = await seedSkill(userClaudeDir, 'real-skill')
+    const service = createService(undefined, { userClaudeDir, userAgentsDir })
+    await repository.setAgentFramework('claude-code')
+
+    expect(
+      (
+        await service.importAgentHomeSkills({
+          skills: [{ source: 'claude', slug: 'real-skill' }]
+        })
+      ).results[0]
+    ).toMatchObject({ status: 'imported', id: 'imported-real-skill' })
+
+    const sharedSkill = join(userAgentsDir, 'skills', 'real-skill')
+    await mkdir(join(userAgentsDir, 'skills'), { recursive: true })
+    await rename(original, sharedSkill)
+    await rm(join(userClaudeDir, 'skills'), { recursive: true })
+    await symlink(join(userAgentsDir, 'skills'), join(userClaudeDir, 'skills'))
+
+    expect(await service.listAgentHomeSkills()).toEqual(
+      expect.arrayContaining([
+        expect.objectContaining({
+          source: 'agents',
+          slug: 'real-skill',
+          alreadyImported: true
+        })
+      ])
+    )
+
+    await repository.setAgentFramework('opencode')
     expect(await service.listAgentHomeSkills()).toEqual(
       expect.arrayContaining([
         expect.objectContaining({

--- a/src/main/settings/service.test.ts
+++ b/src/main/settings/service.test.ts
@@ -4199,6 +4199,64 @@ describe('SettingsService: importAgentHomeSkills', () => {
     })
   })
 
+  it('recognizes an installed skill imported before source metadata was recorded', async () => {
+    const userAgentsDir = await mkdtemp(join(tmpdir(), 'os-import-agent-legacy-'))
+    await seedSkill(userAgentsDir, 'legacy')
+    const legacyDir = join(storageRoot, 'skills', 'imported', 'legacy')
+    await mkdir(legacyDir, { recursive: true })
+    await writeFile(
+      join(legacyDir, 'SKILL.md'),
+      '---\nname: legacy\ndescription: Test\n---\nBody.\n'
+    )
+    const service = createService(undefined, { userAgentsDir })
+
+    expect(await service.listAgentHomeSkills()).toEqual(
+      expect.arrayContaining([
+        expect.objectContaining({ source: 'agents', slug: 'legacy', alreadyImported: true })
+      ])
+    )
+
+    const result = await service.importAgentHomeSkills({
+      skills: [{ source: 'agents', slug: 'legacy' }]
+    })
+    expect(result.results[0]).toEqual({
+      source: 'agents',
+      slug: 'legacy',
+      status: 'unchanged',
+      id: 'imported-legacy'
+    })
+  })
+
+  it('keeps one same-slug source importable when a legacy import is ambiguous', async () => {
+    const userClaudeDir = await mkdtemp(join(tmpdir(), 'os-import-agent-legacy-claude-'))
+    const userAgentsDir = await mkdtemp(join(tmpdir(), 'os-import-agent-legacy-shared-'))
+    await seedSkill(userClaudeDir, 'duplicate')
+    await seedSkill(userAgentsDir, 'duplicate')
+    const legacyDir = join(storageRoot, 'skills', 'imported', 'duplicate')
+    await mkdir(legacyDir, { recursive: true })
+    await writeFile(
+      join(legacyDir, 'SKILL.md'),
+      '---\nname: duplicate\ndescription: Legacy\n---\nLegacy body.\n'
+    )
+    const service = createService(undefined, { userClaudeDir, userAgentsDir })
+    await repository.setAgentFramework('claude-code')
+
+    expect(await service.listAgentHomeSkills()).toEqual(
+      expect.arrayContaining([
+        expect.objectContaining({ source: 'agents', slug: 'duplicate', alreadyImported: false }),
+        expect.objectContaining({ source: 'claude', slug: 'duplicate', alreadyImported: true })
+      ])
+    )
+
+    const result = await service.importAgentHomeSkills({
+      skills: [{ source: 'agents', slug: 'duplicate' }]
+    })
+    expect(result.results[0]).toMatchObject({
+      status: 'imported',
+      id: 'imported-duplicate-2'
+    })
+  })
+
   it('reports unsafe slugs and unavailable sources without aborting other selected skills', async () => {
     const userClaudeDir = await mkdtemp(join(tmpdir(), 'os-import-agent-escape-'))
     const userAgentsDir = await mkdtemp(join(tmpdir(), 'os-import-agent-shared-'))
@@ -4641,7 +4699,7 @@ describe('SettingsService: importAgentHomeSkills realpath containment', () => {
     })
   })
 
-  it('imports a framework skill symlink that resolves into another available global source', async () => {
+  it('canonicalizes a framework symlink alias to the shared installed skill', async () => {
     const userClaudeDir = await mkdtemp(join(tmpdir(), 'os-import-symlink-benign-'))
     const userAgentsDir = await mkdtemp(join(tmpdir(), 'os-import-symlink-shared-'))
     const target = await seedSkill(userAgentsDir, 'real-skill')
@@ -4651,19 +4709,30 @@ describe('SettingsService: importAgentHomeSkills realpath containment', () => {
     const service = createService(undefined, { userClaudeDir, userAgentsDir })
     await repository.setAgentFramework('claude-code')
 
-    expect((await service.listAgentHomeSkills()).map((skill) => skill.slug)).toContain(
-      'linked-skill'
+    expect(await service.listAgentHomeSkills()).toEqual(
+      expect.arrayContaining([expect.objectContaining({ source: 'agents', slug: 'real-skill' })])
+    )
+    expect(await service.listAgentHomeSkills()).not.toEqual(
+      expect.arrayContaining([expect.objectContaining({ source: 'claude', slug: 'linked-skill' })])
     )
 
-    const result = await service.importAgentHomeSkills({
+    const canonical = await service.importAgentHomeSkills({
+      skills: [{ source: 'agents', slug: 'real-skill' }]
+    })
+    expect(canonical.results[0]).toMatchObject({
+      status: 'imported',
+      id: 'imported-real-skill'
+    })
+
+    const alias = await service.importAgentHomeSkills({
       skills: [{ source: 'claude', slug: 'linked-skill' }]
     })
 
-    expect(result.results[0]).toEqual({
+    expect(alias.results[0]).toEqual({
       source: 'claude',
       slug: 'linked-skill',
-      status: 'imported',
-      id: 'imported-linked-skill'
+      status: 'unchanged',
+      id: 'imported-real-skill'
     })
   })
 })

--- a/src/main/settings/service.ts
+++ b/src/main/settings/service.ts
@@ -22,11 +22,13 @@ import type {
   RemoveCustomServerRequest,
   SetCustomServerEnabledRequest,
   UpdateCustomServerRequest,
+  AgentHomeSkillSource,
   AgentHomeSkillView,
   CreateSkillRequest,
   DeleteSkillRequest,
   EnvironmentCheckResult,
-  ImportAgentHomeSkillRequest,
+  ImportAgentHomeSkillsRequest,
+  ImportAgentHomeSkillsResult,
   InstallClaudeRequest,
   InstallCodexRequest,
   InstallOpencodeRequest,
@@ -409,9 +411,12 @@ export type SettingsServiceOptions = {
   // The machine's own Claude config dir, used by the shared provider for auth/spawn and scanned as a
   // user skill source. Injectable so tests don't touch the real ~/.claude.
   userClaudeDir?: string
-  // The machine's own Codex config dir, scanned for the "From your agent home" skill source.
+  // The machine's own Codex config dir, scanned for installed skills while Codex is active.
   // Injectable for the same reason as userClaudeDir.
   userCodexDir?: string
+  // The framework-neutral Agents config dir. Codex and other compatible agents discover skills
+  // under ~/.agents/skills; it is scanned regardless of the active framework.
+  userAgentsDir?: string
   // Bundled-skill source, injectable so tests can point at a seeded temp dir instead of app resources.
   skillRegistry?: SkillRegistry
   // Writable personal/imported skill store, injectable so tests can use a temp storage root.
@@ -450,6 +455,7 @@ class SettingsService {
   private readonly codexDetectDeps: CodexDetectDeps
   private readonly userClaudeDir: string
   private readonly userCodexDir: string
+  private readonly userAgentsDir: string
   private readonly skillRegistry: SkillRegistry
   private readonly userSkills: UserSkillRepository
   private readonly executeClaudeProbe: ExecuteClaudeProbe
@@ -507,6 +513,7 @@ class SettingsService {
     }
     this.userClaudeDir = options.userClaudeDir ?? getUserClaudeConfigDir()
     this.userCodexDir = options.userCodexDir ?? join(homedir(), '.codex')
+    this.userAgentsDir = options.userAgentsDir ?? join(homedir(), '.agents')
     this.skillRegistry = options.skillRegistry ?? new SkillRegistry()
     this.userSkills = options.userSkills ?? new UserSkillRepository(this.storageRoot)
     this.executeClaudeProbe = options.executeClaudeProbe ?? executeClaudeProbe
@@ -1122,84 +1129,144 @@ class SettingsService {
     return { skills: await this.userSkills.scanRepo(request.repo, netFetch) }
   }
 
-  // Lists the skills under the active agent's machine-level home. The "From your agent home" import
-  // source is framework-agnostic: it resolves to `~/.claude/skills/` when the active framework is
-  // `claude-code` and to `~/.codex/skills/` when it is `codex`. OpenCode reads skills per-project
-  // (no global convention) so the source is hidden for that framework. The Claude path is anchored
-  // on `userClaudeDir` and the Codex path on `userCodexDir` so tests can inject a temp dir.
+  // Lists user-installed skills from the framework-neutral ~/.agents/skills source plus the active
+  // framework's own source (~/.claude/skills or ~/.codex/skills). Node's homedir() supplies the
+  // Windows USERPROFILE equivalent, so no platform-specific path parsing reaches the renderer.
   async listAgentHomeSkills(): Promise<AgentHomeSkillView[]> {
     const settings = await this.repository.getSettings()
     const framework = settings.agentFrameworkId ?? DEFAULT_AGENT_FRAMEWORK_ID
-    const homeSkillsDir = this.resolveAgentHomeSkillsDir(framework)
+    const sources = this.resolveAgentHomeSkillDirs(framework)
+    const groups = await Promise.all(
+      sources.map(async ({ source, dir }) => {
+        const skills = await this.userSkills.listAgentHomeSkills(dir)
+        const visible: AgentHomeSkillView[] = []
 
-    if (!homeSkillsDir) return []
+        for (const skill of skills) {
+          try {
+            await this.resolveAgentHomeSkillPath(source, skill.slug, sources)
+          } catch {
+            continue
+          }
 
-    return this.userSkills.listAgentHomeSkills(homeSkillsDir)
+          visible.push({
+            source,
+            slug: skill.slug,
+            name: skill.name,
+            description: skill.description,
+            alreadyImported: skill.alreadyImported
+          })
+        }
+
+        return visible
+      })
+    )
+
+    return groups.flat()
   }
 
-  // Resolves the per-framework global skills directory, or undefined when the active framework
-  // has no global skills convention. Kept private so callers go through `listAgentHomeSkills`.
-  private resolveAgentHomeSkillsDir(framework: AgentFrameworkId): string | undefined {
+  // The generic source is always available. A framework-specific source is additive, not a gate on
+  // the import feature, so Settings can keep the entry visible for OpenCode and future frameworks.
+  private resolveAgentHomeSkillDirs(
+    framework: AgentFrameworkId
+  ): { source: AgentHomeSkillSource; dir: string }[] {
+    const sources: { source: AgentHomeSkillSource; dir: string }[] = [
+      { source: 'agents', dir: join(this.userAgentsDir, 'skills') }
+    ]
+
     switch (framework) {
       case 'claude-code':
-        return join(this.userClaudeDir, 'skills')
+        sources.push({ source: 'claude', dir: join(this.userClaudeDir, 'skills') })
+        break
       case 'codex':
-        return join(this.userCodexDir, 'skills')
+        sources.push({ source: 'codex', dir: join(this.userCodexDir, 'skills') })
+        break
       case 'opencode':
-        return undefined
+        break
       default:
-        return undefined
+        break
     }
+
+    return sources
   }
 
-  // Imports a single agent-home skill by re-deriving its path against the active agent's home
-  // dir and copying the directory into the imported-skill store. Path authority stays in main: the
-  // renderer only supplies the slug returned by listAgentHomeSkills, and the service rejects any
-  // slug that escapes the resolved home (no .. traversal, no symlink-to-elsewhere).
-  // Returns the same shape importSkill returns so the renderer can apply the same post-import
-  // refresh (refresh skill list, mark skills-changed so the agent reloads).
-  async importAgentHomeSkill(request: ImportAgentHomeSkillRequest): Promise<ImportSkillResult> {
-    const sourcePath = await this.resolveAgentHomeSkillPath(request.slug)
-    const outcome = await this.userSkills.importAgentHomeSkill(sourcePath)
-
-    return { status: outcome.status, id: outcome.id, skills: await this.listSkills() }
-  }
-
-  // Resolves a renderer-supplied slug to an absolute path under the active agent's skills dir,
-  // refusing escapes. Centralises the containment check so the IPC and the import path agree on
-  // which directory is "the agent home" and a malicious slug cannot reach arbitrary host files.
-  // The home is resolved via realpath so a symlink that points outside the agent home (e.g. an
-  // attacker who writes `~/.claude/skills/innocent -> /etc` and tries to import `innocent`) is
-  // rejected even though `resolve(home, slug)` would pass the lexical containment check.
-  private async resolveAgentHomeSkillPath(slug: string): Promise<string> {
-    const settings = await this.repository.getSettings()
-    const framework = settings.agentFrameworkId ?? DEFAULT_AGENT_FRAMEWORK_ID
-    const homeSkillsDir = this.resolveAgentHomeSkillsDir(framework)
-
-    if (!homeSkillsDir) {
+  // Imports a checked batch while isolating failures per item. The repository's existing directory
+  // copy and conflict logic remains authoritative; this method adds only source routing and batching.
+  async importAgentHomeSkills(
+    request: ImportAgentHomeSkillsRequest
+  ): Promise<ImportAgentHomeSkillsResult> {
+    if (!request || !Array.isArray(request.skills)) {
+      throw new Error('Installed skills must be an array.')
+    }
+    if (request.skills.length > SKILL_IMPORT_LIMITS.maxSkillsPerBundle) {
       throw new Error(
-        `The active agent framework (${framework}) has no global skills directory to import from.`
+        `Cannot import more than ${SKILL_IMPORT_LIMITS.maxSkillsPerBundle} installed skills at once.`
       )
     }
+
+    const settings = await this.repository.getSettings()
+    const framework = settings.agentFrameworkId ?? DEFAULT_AGENT_FRAMEWORK_ID
+    const availableSources = this.resolveAgentHomeSkillDirs(framework)
+    const results: ImportAgentHomeSkillsResult['results'] = []
+
+    for (const skill of request.skills) {
+      const ref = { source: skill.source, slug: skill.slug }
+
+      try {
+        const sourcePath = await this.resolveAgentHomeSkillPath(
+          skill.source,
+          skill.slug,
+          availableSources
+        )
+        const outcome = await this.userSkills.importAgentHomeSkill(sourcePath, skill.slug)
+
+        results.push({ ...ref, status: outcome.status, id: outcome.id })
+      } catch (error) {
+        results.push({
+          ...ref,
+          error: error instanceof Error ? error.message : 'Could not import the installed skill.'
+        })
+      }
+    }
+
+    return { results, skills: await this.listSkills() }
+  }
+
+  // Resolves a renderer-supplied source + slug to an absolute path under an available global source,
+  // refusing unavailable framework sources and path escapes. This keeps all path authority in main.
+  // Candidate and source roots are resolved via realpath. This permits the common layout where a
+  // framework-specific skill is a symlink into ~/.agents/skills, while rejecting targets outside
+  // every source available to the active framework.
+  private async resolveAgentHomeSkillPath(
+    source: AgentHomeSkillSource,
+    slug: string,
+    availableSources: { source: AgentHomeSkillSource; dir: string }[]
+  ): Promise<string> {
+    const homeSkillsDir = availableSources.find((candidate) => candidate.source === source)?.dir
+    if (!homeSkillsDir) {
+      throw new Error(`Installed skill source "${String(source)}" is not available.`)
+    }
     if (!SAFE_SLUG.test(slug)) {
-      throw new Error(`Refusing to import agent-home skill with unsafe slug: ${slug}`)
+      throw new Error(`Refusing to import installed skill with unsafe slug: ${slug}`)
     }
 
-    // Realpath both sides so a symlink under the home that points outside the configured skills
-    // directory is rejected (lexical `resolve` would only catch `..` traversal, not symlinks).
-    const homeRoot = await realpath(homeSkillsDir).catch(() => resolve(homeSkillsDir))
-    const lexicalCandidate = resolve(homeRoot, slug)
+    const lexicalCandidate = resolve(homeSkillsDir, slug)
     const candidate = await realpath(lexicalCandidate).catch(() => lexicalCandidate)
-    const homeWithSep = homeRoot.endsWith(sep) ? homeRoot : homeRoot + sep
+    const allowedRoots = await Promise.all(
+      availableSources.map(({ dir }) => realpath(dir).catch(() => resolve(dir)))
+    )
+    const withinAllowedRoot = allowedRoots.some((root) => {
+      const rootWithSep = root.endsWith(sep) ? root : root + sep
 
-    if (candidate !== homeRoot && !candidate.startsWith(homeWithSep)) {
-      throw new Error(`Refusing to import agent-home skill outside its home: ${slug}`)
+      return candidate === root || candidate.startsWith(rootWithSep)
+    })
+
+    if (!withinAllowedRoot) {
+      throw new Error(`Refusing to import installed skill outside its source: ${slug}`)
     }
 
-    // Preserve the lexical source path after using the resolved target only for containment. The
-    // repository's copy filter must still see and reject a Skill-root symlink instead of receiving
-    // its already-resolved target and losing that provenance.
-    return lexicalCandidate
+    // Copy from the resolved directory so a safe root symlink is dereferenced once. Nested symlinks
+    // remain visible to the repository copy filter and are still rejected.
+    return candidate
   }
 
   // Projects a catalog skill into its renderer-safe view given the disabled set.

--- a/src/main/settings/service.ts
+++ b/src/main/settings/service.ts
@@ -403,6 +403,16 @@ export type UninstallResult = {
   activeBackendAffected: boolean
 }
 
+type AgentHomeSkillDir = { source: AgentHomeSkillSource; dir: string }
+
+type DiscoveredAgentHomeSkill = {
+  skill: AgentHomeSkillView
+  realPath: string
+  aliases: AgentHomeSkillRef[]
+  fallbackAliases: AgentHomeSkillRef[]
+  matchedFallbackSlugs: Set<string>
+}
+
 export type SettingsServiceOptions = {
   repository?: SettingsRepository
   storageRoot?: string
@@ -1137,6 +1147,16 @@ class SettingsService {
     const settings = await this.repository.getSettings()
     const framework = settings.agentFrameworkId ?? DEFAULT_AGENT_FRAMEWORK_ID
     const sources = this.resolveAgentHomeSkillDirs(framework)
+
+    return (await this.discoverAgentHomeSkills(sources)).map((item) => item.skill)
+  }
+
+  // Resolves duplicate source rows by their real directory while retaining every source/slug alias.
+  // The aliases are internal import identities: the renderer sees one canonical row, but records
+  // created before canonicalization can still be matched without creating a duplicate.
+  private async discoverAgentHomeSkills(
+    sources: AgentHomeSkillDir[]
+  ): Promise<DiscoveredAgentHomeSkill[]> {
     // Sources are additive, so one unreadable directory must not hide healthy results. If no source
     // yields a usable skill, preserve a real scan error instead of presenting a false empty state.
     const scanResults = await Promise.allSettled(
@@ -1145,7 +1165,8 @@ class SettingsService {
         const visible: {
           skill: AgentHomeSkillView
           realPath: string
-          fallbackImported: boolean
+          alias: AgentHomeSkillRef
+          fallbackAlias?: AgentHomeSkillRef
         }[] = []
 
         for (const skill of skills) {
@@ -1153,7 +1174,8 @@ class SettingsService {
             const realPath = await this.resolveAgentHomeSkillPath(source, skill.slug, sources)
             visible.push({
               realPath,
-              fallbackImported: skill.fallbackImported,
+              alias: { source, slug: skill.slug },
+              fallbackAlias: skill.fallbackImported ? { source, slug: skill.slug } : undefined,
               skill: {
                 source,
                 slug: skill.slug,
@@ -1178,43 +1200,69 @@ class SettingsService {
       throw firstFailure.reason
     }
 
-    const unique = new Map<string, { skill: AgentHomeSkillView; fallbackImported: boolean }>()
+    const unique = new Map<string, DiscoveredAgentHomeSkill>()
     for (const item of groups.flat()) {
       const pathKey = process.platform === 'win32' ? item.realPath.toLowerCase() : item.realPath
       const existing = unique.get(pathKey)
       if (existing) {
-        existing.fallbackImported ||= item.fallbackImported
+        existing.aliases.push(item.alias)
+        if (item.fallbackAlias) existing.fallbackAliases.push(item.fallbackAlias)
         existing.skill.alreadyImported ||= item.skill.alreadyImported
       } else {
-        unique.set(pathKey, { skill: item.skill, fallbackImported: item.fallbackImported })
+        unique.set(pathKey, {
+          skill: item.skill,
+          realPath: item.realPath,
+          aliases: [item.alias],
+          fallbackAliases: item.fallbackAlias ? [item.fallbackAlias] : [],
+          matchedFallbackSlugs: new Set()
+        })
       }
     }
 
     const discovered = [...unique.values()]
-    const fallbackBySlug = new Map<string, typeof discovered>()
+    await Promise.all(
+      discovered.map(async (item) => {
+        if (item.skill.alreadyImported) return
+        try {
+          item.skill.alreadyImported = await this.userSkills.matchesImportedAgentHomeSkill(
+            item.realPath,
+            item.aliases
+          )
+        } catch {
+          // Preserve a readable row when the canonical tree fails validation. Import reports the
+          // same validation error per item instead of one malformed tree hiding healthy choices.
+        }
+      })
+    )
+    const fallbackBySlug = new Map<
+      string,
+      { item: DiscoveredAgentHomeSkill; alias: AgentHomeSkillRef }[]
+    >()
     for (const item of discovered) {
-      if (!item.fallbackImported || item.skill.alreadyImported) continue
-      const candidates = fallbackBySlug.get(item.skill.slug) ?? []
-      candidates.push(item)
-      fallbackBySlug.set(item.skill.slug, candidates)
+      if (item.skill.alreadyImported) continue
+      for (const alias of item.fallbackAliases) {
+        const candidates = fallbackBySlug.get(alias.slug) ?? []
+        candidates.push({ item, alias })
+        fallbackBySlug.set(alias.slug, candidates)
+      }
     }
     // An imported skill without an agent-home identity may be a legacy install, GitHub import, or ZIP
     // import. If its slug is ambiguous, let only one framework row claim the fallback and leave the
     // shared row importable; marking every same-slug row would recreate the collision this fixes.
-    for (const candidates of fallbackBySlug.values()) {
-      const preferred = candidates.find((item) => item.skill.source !== 'agents') ?? candidates[0]
-      preferred.skill.alreadyImported = true
+    for (const [fallbackSlug, candidates] of fallbackBySlug) {
+      const preferred =
+        candidates.find((candidate) => candidate.alias.source !== 'agents') ?? candidates[0]
+      preferred.item.skill.alreadyImported = true
+      preferred.item.matchedFallbackSlugs.add(fallbackSlug)
     }
 
-    return discovered.map((item) => item.skill)
+    return discovered
   }
 
   // The generic source is always available. A framework-specific source is additive, not a gate on
   // the import feature, so Settings can keep the entry visible for OpenCode and future frameworks.
-  private resolveAgentHomeSkillDirs(
-    framework: AgentFrameworkId
-  ): { source: AgentHomeSkillSource; dir: string }[] {
-    const sources: { source: AgentHomeSkillSource; dir: string }[] = [
+  private resolveAgentHomeSkillDirs(framework: AgentFrameworkId): AgentHomeSkillDir[] {
+    const sources: AgentHomeSkillDir[] = [
       { source: 'agents', dir: join(this.userAgentsDir, 'skills') }
     ]
 
@@ -1252,12 +1300,15 @@ class SettingsService {
     const framework = settings.agentFrameworkId ?? DEFAULT_AGENT_FRAMEWORK_ID
     const availableSources = this.resolveAgentHomeSkillDirs(framework)
     // The picker normally just completed this scan. If an unrelated source becomes unreadable
-    // between listing and importing, keep per-item isolation and simply skip slug fallback matching.
-    const installedSkills = await this.listAgentHomeSkills().catch(() => [] as AgentHomeSkillView[])
-    const knownImported = new Set(
-      installedSkills
-        .filter((skill) => skill.alreadyImported)
-        .map((skill) => `${skill.source}:${skill.slug}`)
+    // between listing and importing, keep per-item isolation and simply skip compatibility aliases.
+    const discoveredSkills = await this.discoverAgentHomeSkills(availableSources).catch(
+      () => [] as DiscoveredAgentHomeSkill[]
+    )
+    const discoveredByPath = new Map(
+      discoveredSkills.map((item) => [
+        process.platform === 'win32' ? item.realPath.toLowerCase() : item.realPath,
+        item
+      ])
     )
     const results: ImportAgentHomeSkillsResult['results'] = []
 
@@ -1290,8 +1341,11 @@ class SettingsService {
         if (!canonicalSkill) {
           throw new Error(`Refusing to import installed skill outside a top-level skill directory.`)
         }
+        const pathKey = process.platform === 'win32' ? sourcePath.toLowerCase() : sourcePath
+        const discovered = discoveredByPath.get(pathKey)
         const outcome = await this.userSkills.importAgentHomeSkill(sourcePath, canonicalSkill, {
-          allowSlugFallback: knownImported.has(`${canonicalSkill.source}:${canonicalSkill.slug}`)
+          aliases: discovered?.aliases,
+          fallbackSlugs: discovered ? [...discovered.matchedFallbackSlugs] : undefined
         })
 
         results.push({ ...validatedRef, status: outcome.status, id: outcome.id })

--- a/src/main/settings/service.ts
+++ b/src/main/settings/service.ts
@@ -1261,11 +1261,10 @@ class SettingsService {
           skill.slug,
           availableSources
         )
-        const canonicalSkill = await this.canonicalAgentHomeSkillRef(
-          sourcePath,
-          skill,
-          availableSources
-        )
+        const canonicalSkill = await this.canonicalAgentHomeSkillRef(sourcePath, availableSources)
+        if (!canonicalSkill) {
+          throw new Error(`Refusing to import installed skill outside a top-level skill directory.`)
+        }
         const outcome = await this.userSkills.importAgentHomeSkill(sourcePath, canonicalSkill, {
           allowSlugFallback: knownImported.has(`${canonicalSkill.source}:${canonicalSkill.slug}`)
         })
@@ -1314,6 +1313,11 @@ class SettingsService {
     if (!withinAllowedRoot) {
       throw new Error(`Refusing to import installed skill outside its source: ${slug}`)
     }
+    if (!(await this.canonicalAgentHomeSkillRef(candidate, availableSources))) {
+      throw new Error(
+        `Refusing to import installed skill outside a top-level skill directory: ${slug}`
+      )
+    }
 
     // Copy from the resolved directory so a safe root symlink is dereferenced once. Nested symlinks
     // remain visible to the repository copy filter and are still rejected.
@@ -1325,9 +1329,8 @@ class SettingsService {
   // the visible row and a stale/direct import request converge on one installed-skill identity.
   private async canonicalAgentHomeSkillRef(
     realSkillPath: string,
-    fallback: AgentHomeSkillRef,
     availableSources: { source: AgentHomeSkillSource; dir: string }[]
-  ): Promise<AgentHomeSkillRef> {
+  ): Promise<AgentHomeSkillRef | undefined> {
     for (const source of availableSources) {
       const realRoot = await realpath(source.dir).catch(() => resolve(source.dir))
       const child = relative(realRoot, realSkillPath)
@@ -1343,7 +1346,7 @@ class SettingsService {
       }
     }
 
-    return fallback
+    return undefined
   }
 
   // Projects a catalog skill into its renderer-safe view given the disabled set.

--- a/src/main/settings/service.ts
+++ b/src/main/settings/service.ts
@@ -1217,16 +1217,36 @@ class SettingsService {
     }
 
     const discovered = [...unique.values()]
-    const unmatched = discovered.filter((item) => !item.skill.alreadyImported)
     try {
       const matches = await this.userSkills.matchImportedAgentHomeSkills(
-        unmatched.map((item) => ({ sourcePath: item.realPath, aliases: item.aliases }))
+        discovered.map((item) => ({
+          sourcePath: item.realPath,
+          canonical: { source: item.skill.source, slug: item.skill.slug },
+          aliases: item.aliases
+        }))
       )
       for (const [index, match] of matches.entries()) {
-        const item = unmatched[index]
+        const item = discovered[index]
         if (item) {
           item.skill.alreadyImported = match.identityImported
           item.fallbackAliases.push(...match.fallbackAliases)
+          if (match.identityMigrationNeeded) {
+            try {
+              await this.userSkills.importAgentHomeSkill(
+                item.realPath,
+                { source: item.skill.source, slug: item.skill.slug },
+                {
+                  aliases: item.aliases,
+                  expectedSignature: match.matchedIdentitySignature,
+                  expectedImportedIdentity: match.matchedImportedIdentity
+                }
+              )
+            } catch {
+              // Keep the row actionable when automatic metadata migration fails. A manual import
+              // retries the same atomic staging path and reports any persistent error per item.
+              item.skill.alreadyImported = false
+            }
+          }
         }
       }
     } catch {
@@ -1245,14 +1265,13 @@ class SettingsService {
         fallbackBySlug.set(alias.slug, candidates)
       }
     }
-    // An imported skill without an agent-home identity may be a legacy install, GitHub import, or ZIP
-    // import. If its slug is ambiguous, let only one framework row claim the fallback and leave the
-    // shared row importable; marking every same-slug row would recreate the collision this fixes.
+    // Content matching has already excluded unrelated same-slug imports. Every remaining candidate
+    // represents the same legacy bytes, so all source rows claim the fallback and stay idempotent.
     for (const [fallbackSlug, candidates] of fallbackBySlug) {
-      const preferred =
-        candidates.find((candidate) => candidate.alias.source !== 'agents') ?? candidates[0]
-      preferred.item.skill.alreadyImported = true
-      preferred.item.matchedFallbackSlugs.add(fallbackSlug)
+      for (const candidate of candidates) {
+        candidate.item.skill.alreadyImported = true
+        candidate.item.matchedFallbackSlugs.add(fallbackSlug)
+      }
     }
 
     return discovered

--- a/src/main/settings/service.ts
+++ b/src/main/settings/service.ts
@@ -1137,8 +1137,8 @@ class SettingsService {
     const settings = await this.repository.getSettings()
     const framework = settings.agentFrameworkId ?? DEFAULT_AGENT_FRAMEWORK_ID
     const sources = this.resolveAgentHomeSkillDirs(framework)
-    // Sources are additive, so one unreadable directory must not hide healthy results. If every
-    // configured source fails, preserve a real scan error instead of presenting a false empty state.
+    // Sources are additive, so one unreadable directory must not hide healthy results. If no source
+    // yields a usable skill, preserve a real scan error instead of presenting a false empty state.
     const scanResults = await Promise.allSettled(
       sources.map(async ({ source, dir }) => {
         const skills = await this.userSkills.listAgentHomeSkills(dir, source)
@@ -1170,14 +1170,13 @@ class SettingsService {
         return visible
       })
     )
-    if (!scanResults.some((result) => result.status === 'fulfilled')) {
-      const firstFailure = scanResults.find((result) => result.status === 'rejected')
-      if (firstFailure?.status === 'rejected') throw firstFailure.reason
-      throw new Error('Could not scan installed skill sources.')
-    }
     const groups = scanResults.flatMap((result) =>
       result.status === 'fulfilled' ? [result.value] : []
     )
+    const firstFailure = scanResults.find((result) => result.status === 'rejected')
+    if (groups.every((group) => group.length === 0) && firstFailure?.status === 'rejected') {
+      throw firstFailure.reason
+    }
 
     const unique = new Map<string, { skill: AgentHomeSkillView; fallbackImported: boolean }>()
     for (const item of groups.flat()) {

--- a/src/main/settings/service.ts
+++ b/src/main/settings/service.ts
@@ -1166,7 +1166,6 @@ class SettingsService {
           skill: AgentHomeSkillView
           realPath: string
           alias: AgentHomeSkillRef
-          fallbackAlias?: AgentHomeSkillRef
         }[] = []
 
         for (const skill of skills) {
@@ -1175,7 +1174,6 @@ class SettingsService {
             visible.push({
               realPath,
               alias: { source, slug: skill.slug },
-              fallbackAlias: skill.fallbackImported ? { source, slug: skill.slug } : undefined,
               skill: {
                 source,
                 slug: skill.slug,
@@ -1206,34 +1204,35 @@ class SettingsService {
       const existing = unique.get(pathKey)
       if (existing) {
         existing.aliases.push(item.alias)
-        if (item.fallbackAlias) existing.fallbackAliases.push(item.fallbackAlias)
         existing.skill.alreadyImported ||= item.skill.alreadyImported
       } else {
         unique.set(pathKey, {
           skill: item.skill,
           realPath: item.realPath,
           aliases: [item.alias],
-          fallbackAliases: item.fallbackAlias ? [item.fallbackAlias] : [],
+          fallbackAliases: [],
           matchedFallbackSlugs: new Set()
         })
       }
     }
 
     const discovered = [...unique.values()]
-    await Promise.all(
-      discovered.map(async (item) => {
-        if (item.skill.alreadyImported) return
-        try {
-          item.skill.alreadyImported = await this.userSkills.matchesImportedAgentHomeSkill(
-            item.realPath,
-            item.aliases
-          )
-        } catch {
-          // Preserve a readable row when the canonical tree fails validation. Import reports the
-          // same validation error per item instead of one malformed tree hiding healthy choices.
+    const unmatched = discovered.filter((item) => !item.skill.alreadyImported)
+    try {
+      const matches = await this.userSkills.matchImportedAgentHomeSkills(
+        unmatched.map((item) => ({ sourcePath: item.realPath, aliases: item.aliases }))
+      )
+      for (const [index, match] of matches.entries()) {
+        const item = unmatched[index]
+        if (item) {
+          item.skill.alreadyImported = match.identityImported
+          item.fallbackAliases.push(...match.fallbackAliases)
         }
-      })
-    )
+      }
+    } catch {
+      // Preserve readable rows when compatibility matching fails. Import reports validation errors
+      // per item instead of one malformed legacy tree hiding healthy installed choices.
+    }
     const fallbackBySlug = new Map<
       string,
       { item: DiscoveredAgentHomeSkill; alias: AgentHomeSkillRef }[]

--- a/src/main/settings/service.ts
+++ b/src/main/settings/service.ts
@@ -1138,7 +1138,7 @@ class SettingsService {
     const sources = this.resolveAgentHomeSkillDirs(framework)
     const groups = await Promise.all(
       sources.map(async ({ source, dir }) => {
-        const skills = await this.userSkills.listAgentHomeSkills(dir)
+        const skills = await this.userSkills.listAgentHomeSkills(dir, source)
         const visible: AgentHomeSkillView[] = []
 
         for (const skill of skills) {
@@ -1217,7 +1217,7 @@ class SettingsService {
           skill.slug,
           availableSources
         )
-        const outcome = await this.userSkills.importAgentHomeSkill(sourcePath, skill.slug)
+        const outcome = await this.userSkills.importAgentHomeSkill(sourcePath, skill)
 
         results.push({ ...ref, status: outcome.status, id: outcome.id })
       } catch (error) {

--- a/src/main/settings/service.ts
+++ b/src/main/settings/service.ts
@@ -1137,16 +1137,11 @@ class SettingsService {
     const settings = await this.repository.getSettings()
     const framework = settings.agentFrameworkId ?? DEFAULT_AGENT_FRAMEWORK_ID
     const sources = this.resolveAgentHomeSkillDirs(framework)
-    const groups = await Promise.all(
+    // Sources are additive, so one unreadable directory must not hide healthy results. If every
+    // configured source fails, preserve a real scan error instead of presenting a false empty state.
+    const scanResults = await Promise.allSettled(
       sources.map(async ({ source, dir }) => {
-        let skills: Awaited<ReturnType<UserSkillRepository['listAgentHomeSkills']>>
-        try {
-          skills = await this.userSkills.listAgentHomeSkills(dir, source)
-        } catch {
-          // Global sources are additive. A corrupt or unreadable shared/framework directory must not
-          // hide valid skills from the other independently configured source.
-          return []
-        }
+        const skills = await this.userSkills.listAgentHomeSkills(dir, source)
         const visible: {
           skill: AgentHomeSkillView
           realPath: string
@@ -1174,6 +1169,14 @@ class SettingsService {
 
         return visible
       })
+    )
+    if (!scanResults.some((result) => result.status === 'fulfilled')) {
+      const firstFailure = scanResults.find((result) => result.status === 'rejected')
+      if (firstFailure?.status === 'rejected') throw firstFailure.reason
+      throw new Error('Could not scan installed skill sources.')
+    }
+    const groups = scanResults.flatMap((result) =>
+      result.status === 'fulfilled' ? [result.value] : []
     )
 
     const unique = new Map<string, { skill: AgentHomeSkillView; fallbackImported: boolean }>()

--- a/src/main/settings/service.ts
+++ b/src/main/settings/service.ts
@@ -1253,12 +1253,28 @@ class SettingsService {
     const results: ImportAgentHomeSkillsResult['results'] = []
 
     for (const skill of request.skills) {
-      const ref = { source: skill.source, slug: skill.slug }
+      const candidate =
+        typeof skill === 'object' && skill !== null
+          ? (skill as { source?: unknown; slug?: unknown })
+          : undefined
+      const ref: Partial<AgentHomeSkillRef> = {}
+      if (
+        candidate?.source === 'agents' ||
+        candidate?.source === 'claude' ||
+        candidate?.source === 'codex'
+      ) {
+        ref.source = candidate.source
+      }
+      if (typeof candidate?.slug === 'string') ref.slug = candidate.slug
 
       try {
+        if (!ref.source || ref.slug === undefined) {
+          throw new Error('Installed skill entries must include a valid source and slug.')
+        }
+        const validatedRef: AgentHomeSkillRef = { source: ref.source, slug: ref.slug }
         const sourcePath = await this.resolveAgentHomeSkillPath(
-          skill.source,
-          skill.slug,
+          validatedRef.source,
+          validatedRef.slug,
           availableSources
         )
         const canonicalSkill = await this.canonicalAgentHomeSkillRef(sourcePath, availableSources)
@@ -1269,7 +1285,7 @@ class SettingsService {
           allowSlugFallback: knownImported.has(`${canonicalSkill.source}:${canonicalSkill.slug}`)
         })
 
-        results.push({ ...ref, status: outcome.status, id: outcome.id })
+        results.push({ ...validatedRef, status: outcome.status, id: outcome.id })
       } catch (error) {
         results.push({
           ...ref,

--- a/src/main/settings/service.ts
+++ b/src/main/settings/service.ts
@@ -2,7 +2,7 @@ import { execFile } from 'node:child_process'
 import { access, chmod, mkdir, readdir, realpath, writeFile } from 'node:fs/promises'
 import { constants } from 'node:fs'
 import { homedir } from 'node:os'
-import { dirname, join, resolve, sep } from 'node:path'
+import { dirname, isAbsolute, join, relative, resolve, sep } from 'node:path'
 import { createHash, randomUUID } from 'node:crypto'
 import { isDeepStrictEqual, promisify } from 'node:util'
 
@@ -22,6 +22,7 @@ import type {
   RemoveCustomServerRequest,
   SetCustomServerEnabledRequest,
   UpdateCustomServerRequest,
+  AgentHomeSkillRef,
   AgentHomeSkillSource,
   AgentHomeSkillView,
   CreateSkillRequest,
@@ -1139,29 +1140,64 @@ class SettingsService {
     const groups = await Promise.all(
       sources.map(async ({ source, dir }) => {
         const skills = await this.userSkills.listAgentHomeSkills(dir, source)
-        const visible: AgentHomeSkillView[] = []
+        const visible: {
+          skill: AgentHomeSkillView
+          realPath: string
+          legacyImported: boolean
+        }[] = []
 
         for (const skill of skills) {
           try {
-            await this.resolveAgentHomeSkillPath(source, skill.slug, sources)
+            const realPath = await this.resolveAgentHomeSkillPath(source, skill.slug, sources)
+            visible.push({
+              realPath,
+              legacyImported: skill.legacyImported,
+              skill: {
+                source,
+                slug: skill.slug,
+                name: skill.name,
+                description: skill.description,
+                alreadyImported: skill.alreadyImported
+              }
+            })
           } catch {
             continue
           }
-
-          visible.push({
-            source,
-            slug: skill.slug,
-            name: skill.name,
-            description: skill.description,
-            alreadyImported: skill.alreadyImported
-          })
         }
 
         return visible
       })
     )
 
-    return groups.flat()
+    const unique = new Map<string, { skill: AgentHomeSkillView; legacyImported: boolean }>()
+    for (const item of groups.flat()) {
+      const pathKey = process.platform === 'win32' ? item.realPath.toLowerCase() : item.realPath
+      const existing = unique.get(pathKey)
+      if (existing) {
+        existing.legacyImported ||= item.legacyImported
+        existing.skill.alreadyImported ||= item.skill.alreadyImported
+      } else {
+        unique.set(pathKey, { skill: item.skill, legacyImported: item.legacyImported })
+      }
+    }
+
+    const discovered = [...unique.values()]
+    const legacyBySlug = new Map<string, typeof discovered>()
+    for (const item of discovered) {
+      if (!item.legacyImported || item.skill.alreadyImported) continue
+      const candidates = legacyBySlug.get(item.skill.slug) ?? []
+      candidates.push(item)
+      legacyBySlug.set(item.skill.slug, candidates)
+    }
+    // Before source manifests existed, this feature scanned only the active framework directory.
+    // If a legacy slug is now ambiguous, assign it to that framework row and leave the shared row
+    // importable; marking every same-slug row would recreate the collision this identity fixes.
+    for (const candidates of legacyBySlug.values()) {
+      const preferred = candidates.find((item) => item.skill.source !== 'agents') ?? candidates[0]
+      preferred.skill.alreadyImported = true
+    }
+
+    return discovered.map((item) => item.skill)
   }
 
   // The generic source is always available. A framework-specific source is additive, not a gate on
@@ -1206,6 +1242,14 @@ class SettingsService {
     const settings = await this.repository.getSettings()
     const framework = settings.agentFrameworkId ?? DEFAULT_AGENT_FRAMEWORK_ID
     const availableSources = this.resolveAgentHomeSkillDirs(framework)
+    // The picker normally just completed this scan. If an unrelated source becomes unreadable
+    // between listing and importing, keep per-item import isolation and simply skip legacy matching.
+    const installedSkills = await this.listAgentHomeSkills().catch(() => [] as AgentHomeSkillView[])
+    const knownImported = new Set(
+      installedSkills
+        .filter((skill) => skill.alreadyImported)
+        .map((skill) => `${skill.source}:${skill.slug}`)
+    )
     const results: ImportAgentHomeSkillsResult['results'] = []
 
     for (const skill of request.skills) {
@@ -1217,7 +1261,14 @@ class SettingsService {
           skill.slug,
           availableSources
         )
-        const outcome = await this.userSkills.importAgentHomeSkill(sourcePath, skill)
+        const canonicalSkill = await this.canonicalAgentHomeSkillRef(
+          sourcePath,
+          skill,
+          availableSources
+        )
+        const outcome = await this.userSkills.importAgentHomeSkill(sourcePath, canonicalSkill, {
+          allowLegacySlugMatch: knownImported.has(`${canonicalSkill.source}:${canonicalSkill.slug}`)
+        })
 
         results.push({ ...ref, status: outcome.status, id: outcome.id })
       } catch (error) {
@@ -1267,6 +1318,32 @@ class SettingsService {
     // Copy from the resolved directory so a safe root symlink is dereferenced once. Nested symlinks
     // remain visible to the repository copy filter and are still rejected.
     return candidate
+  }
+
+  // A framework directory may alias a shared skill with a root symlink. Prefer the first direct
+  // source root that owns the resolved directory (the shared Agents root is ordered first), so both
+  // the visible row and a stale/direct import request converge on one installed-skill identity.
+  private async canonicalAgentHomeSkillRef(
+    realSkillPath: string,
+    fallback: AgentHomeSkillRef,
+    availableSources: { source: AgentHomeSkillSource; dir: string }[]
+  ): Promise<AgentHomeSkillRef> {
+    for (const source of availableSources) {
+      const realRoot = await realpath(source.dir).catch(() => resolve(source.dir))
+      const child = relative(realRoot, realSkillPath)
+      if (
+        child &&
+        !isAbsolute(child) &&
+        child !== '..' &&
+        !child.startsWith(`..${sep}`) &&
+        !child.includes(sep) &&
+        SAFE_SLUG.test(child)
+      ) {
+        return { source: source.source, slug: child }
+      }
+    }
+
+    return fallback
   }
 
   // Projects a catalog skill into its renderer-safe view given the disabled set.

--- a/src/main/settings/service.ts
+++ b/src/main/settings/service.ts
@@ -1139,7 +1139,14 @@ class SettingsService {
     const sources = this.resolveAgentHomeSkillDirs(framework)
     const groups = await Promise.all(
       sources.map(async ({ source, dir }) => {
-        const skills = await this.userSkills.listAgentHomeSkills(dir, source)
+        let skills: Awaited<ReturnType<UserSkillRepository['listAgentHomeSkills']>>
+        try {
+          skills = await this.userSkills.listAgentHomeSkills(dir, source)
+        } catch {
+          // Global sources are additive. A corrupt or unreadable shared/framework directory must not
+          // hide valid skills from the other independently configured source.
+          return []
+        }
         const visible: {
           skill: AgentHomeSkillView
           realPath: string

--- a/src/main/settings/service.ts
+++ b/src/main/settings/service.ts
@@ -1143,7 +1143,7 @@ class SettingsService {
         const visible: {
           skill: AgentHomeSkillView
           realPath: string
-          legacyImported: boolean
+          fallbackImported: boolean
         }[] = []
 
         for (const skill of skills) {
@@ -1151,7 +1151,7 @@ class SettingsService {
             const realPath = await this.resolveAgentHomeSkillPath(source, skill.slug, sources)
             visible.push({
               realPath,
-              legacyImported: skill.legacyImported,
+              fallbackImported: skill.fallbackImported,
               skill: {
                 source,
                 slug: skill.slug,
@@ -1169,30 +1169,30 @@ class SettingsService {
       })
     )
 
-    const unique = new Map<string, { skill: AgentHomeSkillView; legacyImported: boolean }>()
+    const unique = new Map<string, { skill: AgentHomeSkillView; fallbackImported: boolean }>()
     for (const item of groups.flat()) {
       const pathKey = process.platform === 'win32' ? item.realPath.toLowerCase() : item.realPath
       const existing = unique.get(pathKey)
       if (existing) {
-        existing.legacyImported ||= item.legacyImported
+        existing.fallbackImported ||= item.fallbackImported
         existing.skill.alreadyImported ||= item.skill.alreadyImported
       } else {
-        unique.set(pathKey, { skill: item.skill, legacyImported: item.legacyImported })
+        unique.set(pathKey, { skill: item.skill, fallbackImported: item.fallbackImported })
       }
     }
 
     const discovered = [...unique.values()]
-    const legacyBySlug = new Map<string, typeof discovered>()
+    const fallbackBySlug = new Map<string, typeof discovered>()
     for (const item of discovered) {
-      if (!item.legacyImported || item.skill.alreadyImported) continue
-      const candidates = legacyBySlug.get(item.skill.slug) ?? []
+      if (!item.fallbackImported || item.skill.alreadyImported) continue
+      const candidates = fallbackBySlug.get(item.skill.slug) ?? []
       candidates.push(item)
-      legacyBySlug.set(item.skill.slug, candidates)
+      fallbackBySlug.set(item.skill.slug, candidates)
     }
-    // Before source manifests existed, this feature scanned only the active framework directory.
-    // If a legacy slug is now ambiguous, assign it to that framework row and leave the shared row
-    // importable; marking every same-slug row would recreate the collision this identity fixes.
-    for (const candidates of legacyBySlug.values()) {
+    // An imported skill without an agent-home identity may be a legacy install, GitHub import, or ZIP
+    // import. If its slug is ambiguous, let only one framework row claim the fallback and leave the
+    // shared row importable; marking every same-slug row would recreate the collision this fixes.
+    for (const candidates of fallbackBySlug.values()) {
       const preferred = candidates.find((item) => item.skill.source !== 'agents') ?? candidates[0]
       preferred.skill.alreadyImported = true
     }
@@ -1243,7 +1243,7 @@ class SettingsService {
     const framework = settings.agentFrameworkId ?? DEFAULT_AGENT_FRAMEWORK_ID
     const availableSources = this.resolveAgentHomeSkillDirs(framework)
     // The picker normally just completed this scan. If an unrelated source becomes unreadable
-    // between listing and importing, keep per-item import isolation and simply skip legacy matching.
+    // between listing and importing, keep per-item isolation and simply skip slug fallback matching.
     const installedSkills = await this.listAgentHomeSkills().catch(() => [] as AgentHomeSkillView[])
     const knownImported = new Set(
       installedSkills
@@ -1267,7 +1267,7 @@ class SettingsService {
           availableSources
         )
         const outcome = await this.userSkills.importAgentHomeSkill(sourcePath, canonicalSkill, {
-          allowLegacySlugMatch: knownImported.has(`${canonicalSkill.source}:${canonicalSkill.slug}`)
+          allowSlugFallback: knownImported.has(`${canonicalSkill.source}:${canonicalSkill.slug}`)
         })
 
         results.push({ ...ref, status: outcome.status, id: outcome.id })

--- a/src/main/skills/user-skill-repository.test.ts
+++ b/src/main/skills/user-skill-repository.test.ts
@@ -1285,24 +1285,27 @@ describe('UserSkillRepository: agent-home import', () => {
     await seedSkill(home, 'alpha')
     await seedSkill(home, 'beta')
 
-    const items = await repo.listAgentHomeSkills(join(home, 'skills'))
+    const items = await repo.listAgentHomeSkills(join(home, 'skills'), 'agents')
 
     expect(items.map((i) => i.slug).sort()).toEqual(['alpha', 'beta'])
     expect(items.every((i) => i.alreadyImported === false)).toBe(true)
     expect(items[0].path).toBe(join(home, 'skills', items[0].slug))
   })
 
-  it('marks a skill as alreadyImported when an imported record with the same slug exists', async () => {
+  it('marks a skill as alreadyImported when the same source identity exists', async () => {
     // The renderer uses alreadyImported to flip the row to a "Imported" badge and hide the action
-    // button. The match is by slug (top-level dir name), not by content signature.
+    // button. The match is by source plus slug, not by content signature.
     const storage = await makeStorage()
     const repo = new UserSkillRepository(storage)
     const home = await mkdtemp(join(tmpdir(), 'os-list-agent-'))
     await seedSkill(home, 'alpha')
 
-    await repo.importAgentHomeSkill(join(home, 'skills', 'alpha'))
+    await repo.importAgentHomeSkill(join(home, 'skills', 'alpha'), {
+      source: 'agents',
+      slug: 'alpha'
+    })
 
-    const items = await repo.listAgentHomeSkills(join(home, 'skills'))
+    const items = await repo.listAgentHomeSkills(join(home, 'skills'), 'agents')
     expect(items[0].alreadyImported).toBe(true)
   })
 
@@ -1315,7 +1318,7 @@ describe('UserSkillRepository: agent-home import', () => {
     await mkdir(join(home, 'skills', 'empty-directory'))
     await seedSkill(home, 'alpha')
 
-    const items = await repo.listAgentHomeSkills(join(home, 'skills'))
+    const items = await repo.listAgentHomeSkills(join(home, 'skills'), 'agents')
     expect(items.map((i) => i.slug)).toEqual(['alpha'])
   })
 
@@ -1328,7 +1331,7 @@ describe('UserSkillRepository: agent-home import', () => {
       const target = await seedSkill(home, 'real-skill')
       await symlink(target, join(home, 'skills', 'linked-skill'))
 
-      const items = await repo.listAgentHomeSkills(join(home, 'skills'))
+      const items = await repo.listAgentHomeSkills(join(home, 'skills'), 'agents')
 
       expect(items.map((item) => item.slug)).toEqual(['linked-skill', 'real-skill'])
     }
@@ -1339,7 +1342,7 @@ describe('UserSkillRepository: agent-home import', () => {
     const repo = new UserSkillRepository(storage)
     const home = await mkdtemp(join(tmpdir(), 'os-list-agent-'))
 
-    const items = await repo.listAgentHomeSkills(join(home, 'skills'))
+    const items = await repo.listAgentHomeSkills(join(home, 'skills'), 'agents')
     expect(items).toEqual([])
   })
 
@@ -1349,7 +1352,10 @@ describe('UserSkillRepository: agent-home import', () => {
     const home = await mkdtemp(join(tmpdir(), 'os-import-agent-'))
     await seedSkill(home, 'alpha')
 
-    const outcome = await repo.importAgentHomeSkill(join(home, 'skills', 'alpha'))
+    const outcome = await repo.importAgentHomeSkill(join(home, 'skills', 'alpha'), {
+      source: 'agents',
+      slug: 'alpha'
+    })
 
     expect(outcome).toEqual({ status: 'imported', id: 'imported-alpha' })
     const skills = await repo.list()
@@ -1362,9 +1368,12 @@ describe('UserSkillRepository: agent-home import', () => {
     const home = await mkdtemp(join(tmpdir(), 'os-import-agent-'))
     // No seedSkill — the path resolves to a non-existent directory.
 
-    await expect(repo.importAgentHomeSkill(join(home, 'skills', 'missing'))).rejects.toThrow(
-      /not available/
-    )
+    await expect(
+      repo.importAgentHomeSkill(join(home, 'skills', 'missing'), {
+        source: 'agents',
+        slug: 'missing'
+      })
+    ).rejects.toThrow(/not available/)
     // No record should have been created on the failure path.
     expect(await repo.list()).toEqual([])
   })
@@ -1376,25 +1385,36 @@ describe('UserSkillRepository: agent-home import', () => {
     // Create a directory whose name fails the SAFE_SLUG regex.
     await mkdir(join(home, 'skills', 'has spaces'), { recursive: true })
 
-    await expect(repo.importAgentHomeSkill(join(home, 'skills', 'has spaces'))).rejects.toThrow(
-      /unsafe slug/
-    )
+    await expect(
+      repo.importAgentHomeSkill(join(home, 'skills', 'has spaces'), {
+        source: 'agents',
+        slug: 'has spaces'
+      })
+    ).rejects.toThrow(/unsafe slug/)
   })
 
-  it('appends a unique-suffix when the same slug is imported twice (no clobber)', async () => {
-    // The uniqueSlug mirror logic in importFromZip carries over to the agent-home import: a taken
-    // slug gets `-2`, `-3`, ... appended so re-running the import never overwrites an existing
-    // record. This is the "conflict" path the AI review called out.
+  it('deduplicates the same installed skill identity while suffixing a cross-source collision', async () => {
     const storage = await makeStorage()
     const repo = new UserSkillRepository(storage)
     const home = await mkdtemp(join(tmpdir(), 'os-import-agent-'))
     await seedSkill(home, 'alpha')
 
-    const first = await repo.importAgentHomeSkill(join(home, 'skills', 'alpha'))
-    const second = await repo.importAgentHomeSkill(join(home, 'skills', 'alpha'))
+    const first = await repo.importAgentHomeSkill(join(home, 'skills', 'alpha'), {
+      source: 'agents',
+      slug: 'alpha'
+    })
+    const repeated = await repo.importAgentHomeSkill(join(home, 'skills', 'alpha'), {
+      source: 'agents',
+      slug: 'alpha'
+    })
+    const secondSource = await repo.importAgentHomeSkill(join(home, 'skills', 'alpha'), {
+      source: 'claude',
+      slug: 'alpha'
+    })
 
     expect(first.id).toBe('imported-alpha')
-    expect(second.id).toBe('imported-alpha-2')
+    expect(repeated).toEqual({ status: 'unchanged', id: 'imported-alpha' })
+    expect(secondSource.id).toBe('imported-alpha-2')
     const skills = await repo.list()
     expect(skills.find((s) => s.id === 'imported-alpha')).toBeDefined()
     expect(skills.find((s) => s.id === 'imported-alpha-2')).toBeDefined()
@@ -1408,7 +1428,9 @@ describe('UserSkillRepository: agent-home import', () => {
     const link = join(home, 'skills', 'linked-skill')
     await symlink(target, link)
 
-    await expect(repo.importAgentHomeSkill(link)).rejects.toThrow(/symbolic link/)
+    await expect(
+      repo.importAgentHomeSkill(link, { source: 'agents', slug: 'linked-skill' })
+    ).rejects.toThrow(/symbolic link/)
     expect(await repo.list()).toEqual([])
   })
 
@@ -1424,7 +1446,9 @@ describe('UserSkillRepository: agent-home import', () => {
       await mkdir(join(source, 'references'), { recursive: true })
       await symlink(outside, join(source, 'references', 'outside.md'))
 
-      await expect(repo.importAgentHomeSkill(source)).rejects.toThrow(/symbolic link/)
+      await expect(
+        repo.importAgentHomeSkill(source, { source: 'agents', slug: 'alpha' })
+      ).rejects.toThrow(/symbolic link/)
       expect(await repo.list()).toEqual([])
     }
   )

--- a/src/main/skills/user-skill-repository.test.ts
+++ b/src/main/skills/user-skill-repository.test.ts
@@ -1306,17 +1306,33 @@ describe('UserSkillRepository: agent-home import', () => {
     expect(items[0].alreadyImported).toBe(true)
   })
 
-  it('skips entries that are not directories (loose files do not become skills)', async () => {
+  it('skips loose files and directories without a readable SKILL.md', async () => {
     const storage = await makeStorage()
     const repo = new UserSkillRepository(storage)
     const home = await mkdtemp(join(tmpdir(), 'os-list-agent-'))
     await mkdir(join(home, 'skills'), { recursive: true })
     await writeFile(join(home, 'skills', 'stray-file.txt'), 'not a skill')
+    await mkdir(join(home, 'skills', 'empty-directory'))
     await seedSkill(home, 'alpha')
 
     const items = await repo.listAgentHomeSkills(join(home, 'skills'))
     expect(items.map((i) => i.slug)).toEqual(['alpha'])
   })
+
+  it.skipIf(process.platform === 'win32')(
+    'lists directory symlinks that resolve to a readable skill',
+    async () => {
+      const storage = await makeStorage()
+      const repo = new UserSkillRepository(storage)
+      const home = await mkdtemp(join(tmpdir(), 'os-list-agent-link-'))
+      const target = await seedSkill(home, 'real-skill')
+      await symlink(target, join(home, 'skills', 'linked-skill'))
+
+      const items = await repo.listAgentHomeSkills(join(home, 'skills'))
+
+      expect(items.map((item) => item.slug)).toEqual(['linked-skill', 'real-skill'])
+    }
+  )
 
   it('returns an empty list for a missing agent-home skills dir (no error)', async () => {
     const storage = await makeStorage()

--- a/src/main/skills/user-skill-repository.test.ts
+++ b/src/main/skills/user-skill-repository.test.ts
@@ -1,4 +1,5 @@
 import {
+  chmod,
   mkdtemp,
   mkdir,
   readdir,
@@ -1294,7 +1295,7 @@ describe('UserSkillRepository: agent-home import', () => {
 
   it('marks a skill as alreadyImported when the same source identity exists', async () => {
     // The renderer uses alreadyImported to flip the row to a "Imported" badge and hide the action
-    // button. The match is by source plus slug, not by content signature.
+    // button. The match is by source plus slug and the current content signature.
     const storage = await makeStorage()
     const repo = new UserSkillRepository(storage)
     const home = await mkdtemp(join(tmpdir(), 'os-list-agent-'))
@@ -1418,6 +1419,89 @@ describe('UserSkillRepository: agent-home import', () => {
     const skills = await repo.list()
     expect(skills.find((s) => s.id === 'imported-alpha')).toBeDefined()
     expect(skills.find((s) => s.id === 'imported-alpha-2')).toBeDefined()
+  })
+
+  it('refreshes an installed skill when the same source identity changes', async () => {
+    const storage = await makeStorage()
+    const repo = new UserSkillRepository(storage)
+    const home = await mkdtemp(join(tmpdir(), 'os-import-agent-refresh-'))
+    const source = await seedSkill(home, 'alpha')
+    const skill = { source: 'agents', slug: 'alpha' } as const
+
+    await repo.importAgentHomeSkill(source, skill)
+    await writeFile(
+      join(source, 'SKILL.md'),
+      '---\nname: alpha\ndescription: Updated\n---\nUpdated body.\n'
+    )
+
+    expect((await repo.listAgentHomeSkills(join(home, 'skills'), 'agents'))[0]).toMatchObject({
+      alreadyImported: false
+    })
+
+    const updated = await repo.importAgentHomeSkill(source, skill)
+    const unchanged = await repo.importAgentHomeSkill(source, skill)
+
+    expect(updated).toEqual({ status: 'updated', id: 'imported-alpha' })
+    expect(unchanged).toEqual({ status: 'unchanged', id: 'imported-alpha' })
+    expect(
+      await readFile(join(storage, 'skills', 'imported', 'alpha', 'SKILL.md'), 'utf8')
+    ).toContain('Updated body.')
+    expect(
+      JSON.parse(
+        await readFile(join(storage, 'skills', 'imported', 'alpha', '.source.json'), 'utf8')
+      )
+    ).toMatchObject({ agentHome: skill, signature: expect.any(String) })
+  })
+
+  it('refreshes installed-skill directory structure and portable permission changes', async () => {
+    const storage = await makeStorage()
+    const repo = new UserSkillRepository(storage)
+    const home = await mkdtemp(join(tmpdir(), 'os-import-agent-structure-'))
+    const source = await seedSkill(home, 'alpha')
+    const skill = { source: 'agents', slug: 'alpha' } as const
+    await repo.importAgentHomeSkill(source, skill)
+
+    await mkdir(join(source, 'empty-reference-dir'))
+    expect(await repo.importAgentHomeSkill(source, skill)).toMatchObject({ status: 'updated' })
+    expect(
+      (
+        await stat(join(storage, 'skills', 'imported', 'alpha', 'empty-reference-dir'))
+      ).isDirectory()
+    ).toBe(true)
+
+    if (process.platform !== 'win32') {
+      await chmod(join(source, 'SKILL.md'), 0o744)
+      expect(await repo.importAgentHomeSkill(source, skill)).toMatchObject({ status: 'updated' })
+      expect(
+        (await stat(join(storage, 'skills', 'imported', 'alpha', 'SKILL.md'))).mode & 0o777
+      ).toBe(0o744)
+    }
+  })
+
+  it('preserves the prior imported copy when an installed-skill refresh fails validation', async () => {
+    const storage = await makeStorage()
+    const repo = new UserSkillRepository(storage)
+    const home = await mkdtemp(join(tmpdir(), 'os-import-agent-refresh-failure-'))
+    const source = await seedSkill(home, 'alpha')
+    const skill = { source: 'agents', slug: 'alpha' } as const
+    await repo.importAgentHomeSkill(source, skill)
+    const importedDir = join(storage, 'skills', 'imported', 'alpha')
+    const originalManifest = await readFile(join(importedDir, '.source.json'), 'utf8')
+
+    await writeFile(
+      join(source, 'SKILL.md'),
+      '---\nname: alpha\ndescription: Invalid refresh\n---\nReplacement body.\n'
+    )
+    await writeFile(join(source, '.source.json'), '{}')
+
+    await expect(repo.importAgentHomeSkill(source, skill)).rejects.toThrow(/reserved file/)
+    expect(await readFile(join(importedDir, 'SKILL.md'), 'utf8')).toContain('Body of alpha.')
+    expect(await readFile(join(importedDir, '.source.json'), 'utf8')).toBe(originalManifest)
+    expect(
+      (await readdir(join(storage, 'skills', 'imported'))).filter((entry) =>
+        entry.startsWith('.alpha.import-')
+      )
+    ).toEqual([])
   })
 
   it.skipIf(process.platform === 'win32')('rejects a symlink used as the Skill root', async () => {

--- a/src/main/skills/user-skill-repository.test.ts
+++ b/src/main/skills/user-skill-repository.test.ts
@@ -1442,6 +1442,99 @@ describe('UserSkillRepository: agent-home import', () => {
     expect(outcome).toEqual({ status: 'imported', id: 'imported-alpha-2' })
   })
 
+  it('does not update skill content during a stale canonical identity migration', async () => {
+    const storage = await makeStorage()
+    const repo = new UserSkillRepository(storage)
+    const home = await mkdtemp(join(tmpdir(), 'os-import-agent-stale-migration-'))
+    const source = await seedSkill(home, 'alpha')
+    await repo.importAgentHomeSkill(source, { source: 'claude', slug: 'linked-skill' })
+    const importedDir = join(storage, 'skills', 'imported', 'linked-skill')
+    const originalManifest = JSON.parse(
+      await readFile(join(importedDir, '.source.json'), 'utf8')
+    ) as { signature: string }
+
+    await writeFile(
+      join(source, 'SKILL.md'),
+      '---\nname: alpha\ndescription: Changed during scan\n---\nChanged body.\n'
+    )
+
+    await expect(
+      repo.importAgentHomeSkill(
+        source,
+        { source: 'agents', slug: 'alpha' },
+        {
+          aliases: [{ source: 'claude', slug: 'linked-skill' }],
+          expectedSignature: originalManifest.signature
+        }
+      )
+    ).rejects.toThrow(/changed during canonical identity migration/)
+    expect(await readFile(join(importedDir, 'SKILL.md'), 'utf8')).toContain('Body of alpha.')
+  })
+
+  it('does not recreate an imported alias deleted after canonical identity matching', async () => {
+    const storage = await makeStorage()
+    const repo = new UserSkillRepository(storage)
+    const home = await mkdtemp(join(tmpdir(), 'os-import-agent-deleted-migration-'))
+    const source = await seedSkill(home, 'alpha')
+    await repo.importAgentHomeSkill(source, { source: 'claude', slug: 'linked-skill' })
+
+    const [match] = await repo.matchImportedAgentHomeSkills([
+      {
+        sourcePath: source,
+        canonical: { source: 'agents', slug: 'alpha' },
+        aliases: [{ source: 'claude', slug: 'linked-skill' }]
+      }
+    ])
+    await repo.delete('imported-linked-skill')
+
+    await expect(
+      repo.importAgentHomeSkill(
+        source,
+        { source: 'agents', slug: 'alpha' },
+        {
+          aliases: [{ source: 'claude', slug: 'linked-skill' }],
+          expectedSignature: match.matchedIdentitySignature,
+          expectedImportedIdentity: match.matchedImportedIdentity
+        }
+      )
+    ).rejects.toThrow(/changed during canonical identity migration/)
+    expect(await repo.list()).toEqual([])
+  })
+
+  it('does not overwrite an imported alias changed after canonical identity matching', async () => {
+    const storage = await makeStorage()
+    const repo = new UserSkillRepository(storage)
+    const home = await mkdtemp(join(tmpdir(), 'os-import-agent-changed-migration-'))
+    const source = await seedSkill(home, 'alpha')
+    await repo.importAgentHomeSkill(source, { source: 'claude', slug: 'linked-skill' })
+
+    const [match] = await repo.matchImportedAgentHomeSkills([
+      {
+        sourcePath: source,
+        canonical: { source: 'agents', slug: 'alpha' },
+        aliases: [{ source: 'claude', slug: 'linked-skill' }]
+      }
+    ])
+    const importedDir = join(storage, 'skills', 'imported', 'linked-skill')
+    await writeFile(
+      join(importedDir, 'SKILL.md'),
+      '---\nname: linked-skill\ndescription: Concurrent edit\n---\nKeep this body.\n'
+    )
+
+    await expect(
+      repo.importAgentHomeSkill(
+        source,
+        { source: 'agents', slug: 'alpha' },
+        {
+          aliases: [{ source: 'claude', slug: 'linked-skill' }],
+          expectedSignature: match.matchedIdentitySignature,
+          expectedImportedIdentity: match.matchedImportedIdentity
+        }
+      )
+    ).rejects.toThrow(/changed during canonical identity migration/)
+    expect(await readFile(join(importedDir, 'SKILL.md'), 'utf8')).toContain('Keep this body.')
+  })
+
   it('refreshes an installed skill when the same source identity changes', async () => {
     const storage = await makeStorage()
     const repo = new UserSkillRepository(storage)

--- a/src/main/skills/user-skill-repository.test.ts
+++ b/src/main/skills/user-skill-repository.test.ts
@@ -1421,6 +1421,27 @@ describe('UserSkillRepository: agent-home import', () => {
     expect(skills.find((s) => s.id === 'imported-alpha-2')).toBeDefined()
   })
 
+  it('revalidates legacy fallback content during import', async () => {
+    const storage = await makeStorage()
+    const repo = new UserSkillRepository(storage)
+    const home = await mkdtemp(join(tmpdir(), 'os-import-agent-stale-fallback-'))
+    const source = await seedSkill(home, 'alpha')
+    const importedDir = join(storage, 'skills', 'imported', 'alpha')
+    await mkdir(importedDir, { recursive: true })
+    await writeFile(
+      join(importedDir, 'SKILL.md'),
+      '---\nname: alpha\ndescription: Different import\n---\nDifferent body.\n'
+    )
+
+    const outcome = await repo.importAgentHomeSkill(
+      source,
+      { source: 'agents', slug: 'alpha' },
+      { fallbackSlugs: ['alpha'] }
+    )
+
+    expect(outcome).toEqual({ status: 'imported', id: 'imported-alpha-2' })
+  })
+
   it('refreshes an installed skill when the same source identity changes', async () => {
     const storage = await makeStorage()
     const repo = new UserSkillRepository(storage)

--- a/src/main/skills/user-skill-repository.ts
+++ b/src/main/skills/user-skill-repository.ts
@@ -5,6 +5,8 @@ import { basename, dirname, join, resolve, sep } from 'node:path'
 import { dump as dumpYaml } from 'js-yaml'
 
 import type {
+  AgentHomeSkillRef,
+  AgentHomeSkillSource,
   SkillBundlePreview,
   SkillBundlePreviewResult,
   SkillReference,
@@ -110,6 +112,17 @@ export type ImportOutcome = { status: 'imported' | 'unchanged' | 'updated'; id: 
 
 // Records the origin + content signature of an imported skill so re-imports can be deduplicated.
 const SOURCE_MANIFEST = '.source.json'
+
+type ImportedSourceManifest = {
+  url?: string
+  signature?: string
+  agentHome?: AgentHomeSkillRef
+}
+
+const agentHomeKey = (skill: AgentHomeSkillRef): string => `${skill.source}:${skill.slug}`
+
+const isAgentHomeSkillSource = (value: unknown): value is AgentHomeSkillSource =>
+  value === 'agents' || value === 'claude' || value === 'codex'
 
 // Content signature over every file (sorted by path) used to detect upstream changes on re-import.
 const signatureOf = (files: FetchedSkillFile[]): string => {
@@ -768,16 +781,46 @@ class UserSkillRepository {
     return { urls, slugs }
   }
 
-  private async readSource(slug: string): Promise<{ url?: string; signature?: string } | null> {
+  private async readSource(slug: string): Promise<ImportedSourceManifest | null> {
     try {
       const raw = await readFile(join(this.skillDir('imported', slug), SOURCE_MANIFEST), 'utf8')
       const parsed = JSON.parse(raw) as unknown
-      return typeof parsed === 'object' && parsed !== null
-        ? (parsed as Record<string, string>)
-        : null
+      if (typeof parsed !== 'object' || parsed === null) return null
+
+      const record = parsed as Record<string, unknown>
+      const manifest: ImportedSourceManifest = {}
+      if (typeof record.url === 'string') manifest.url = record.url
+      if (typeof record.signature === 'string') manifest.signature = record.signature
+
+      if (typeof record.agentHome === 'object' && record.agentHome !== null) {
+        const agentHome = record.agentHome as Record<string, unknown>
+        if (isAgentHomeSkillSource(agentHome.source) && typeof agentHome.slug === 'string') {
+          manifest.agentHome = { source: agentHome.source, slug: agentHome.slug }
+        }
+      }
+
+      return manifest
     } catch {
       return null
     }
+  }
+
+  private async importedAgentHomeKeys(): Promise<Set<string>> {
+    const keys = new Set<string>()
+    for (const slug of await this.listSlugs('imported')) {
+      const source = await this.readSource(slug)
+      if (source?.agentHome) keys.add(agentHomeKey(source.agentHome))
+    }
+    return keys
+  }
+
+  private async findImportedSlugByAgentHome(skill: AgentHomeSkillRef): Promise<string | undefined> {
+    const key = agentHomeKey(skill)
+    for (const slug of await this.listSlugs('imported')) {
+      const source = await this.readSource(slug)
+      if (source?.agentHome && agentHomeKey(source.agentHome) === key) return slug
+    }
+    return undefined
   }
 
   // Writes an imported skill's files (replacing any prior copy) plus its source manifest.
@@ -959,7 +1002,10 @@ class UserSkillRepository {
   // A candidate must be a safe-slug directory with a readable SKILL.md; arbitrary sibling folders
   // are not import choices. Frontmatter supplies the displayed name/description, while the directory
   // name remains the stable slug. Hidden transaction directories are ignored.
-  async listAgentHomeSkills(homeSkillsDir: string): Promise<
+  async listAgentHomeSkills(
+    homeSkillsDir: string,
+    source: AgentHomeSkillSource
+  ): Promise<
     {
       slug: string
       name: string
@@ -985,9 +1031,9 @@ class UserSkillRepository {
       throw error
     }
 
-    // Cross-check the existing imported-skill slugs once (rather than per row) so the "already
-    // imported" badge stays in sync with the same ids the Settings list renders.
-    const importedSlugs = new Set(await this.listSlugs('imported'))
+    // Cross-check existing source identities once (rather than per row) so the "already imported"
+    // badge distinguishes same-slug skills discovered in different global sources.
+    const importedSkills = await this.importedAgentHomeKeys()
 
     const out: {
       slug: string
@@ -1014,7 +1060,7 @@ class UserSkillRepository {
         name,
         description,
         path,
-        alreadyImported: importedSlugs.has(slug)
+        alreadyImported: importedSkills.has(agentHomeKey({ source, slug }))
       })
     }
 
@@ -1024,12 +1070,10 @@ class UserSkillRepository {
   // Imports a single agent-home skill by copying its source subtree under the imported-skill store.
   // The copy preserves the directory layout (SKILL.md + references/) so the skill is byte-for-byte
   // the same shape Open Science would have produced from a fresh in-app edit. Suffix allocation
-  // mirrors importFromZip: a taken slug gets `-2`, `-3`, ... appended so re-running the import never
-  // clobbers an existing record.
-  async importAgentHomeSkill(
-    sourcePath: string,
-    requestedSlug = basename(sourcePath)
-  ): Promise<ImportOutcome> {
+  // mirrors importFromZip: the same source identity is unchanged, while a same-name skill from a
+  // different source gets `-2`, `-3`, ... appended and never clobbers an existing record.
+  async importAgentHomeSkill(sourcePath: string, skill: AgentHomeSkillRef): Promise<ImportOutcome> {
+    const requestedSlug = skill.slug
     if (!SAFE_SLUG.test(requestedSlug)) {
       throw new Error(`Refusing to import agent-home skill with unsafe slug: ${requestedSlug}`)
     }
@@ -1048,6 +1092,9 @@ class UserSkillRepository {
     return this.runExclusive(async () => {
       await this.doRecoverImportedTransactions()
 
+      const existingSlug = await this.findImportedSlugByAgentHome(skill)
+      if (existingSlug) return { status: 'unchanged', id: `imported-${existingSlug}` }
+
       const slug = await this.uniqueSlug('imported', requestedSlug)
       const destination = this.skillDir('imported', slug)
 
@@ -1057,12 +1104,20 @@ class UserSkillRepository {
           force: false,
           errorOnExist: true,
           filter: async (entry) => {
+            if (resolve(entry) === resolve(sourcePath, SOURCE_MANIFEST)) {
+              throw new Error(`Skill import may not include the reserved file ${SOURCE_MANIFEST}.`)
+            }
             if ((await lstat(entry)).isSymbolicLink()) {
               throw new Error(`Refusing to import an agent-home Skill containing a symbolic link.`)
             }
             return true
           }
         })
+        await writeFile(
+          join(destination, SOURCE_MANIFEST),
+          JSON.stringify({ agentHome: skill }, null, 2),
+          { flag: 'wx' }
+        )
       } catch (error) {
         await rm(destination, { recursive: true, force: true }).catch(() => undefined)
         throw error

--- a/src/main/skills/user-skill-repository.ts
+++ b/src/main/skills/user-skill-repository.ts
@@ -809,13 +809,13 @@ class UserSkillRepository {
     }
   }
 
-  private async importedAgentHomeKeys(): Promise<Set<string>> {
-    const keys = new Set<string>()
+  private async importedAgentHomeSignatures(): Promise<Map<string, string | undefined>> {
+    const signatures = new Map<string, string | undefined>()
     for (const slug of await this.listSlugs('imported')) {
       const source = await this.readSource(slug)
-      if (source?.agentHome) keys.add(agentHomeKey(source.agentHome))
+      if (source?.agentHome) signatures.set(agentHomeKey(source.agentHome), source.signature)
     }
-    return keys
+    return signatures
   }
 
   private async fallbackImportedSlugs(): Promise<Set<string>> {
@@ -838,6 +838,95 @@ class UserSkillRepository {
       if (allowSlugFallback && !source?.agentHome && slug === skill.slug) fallbackSlug = slug
     }
     return fallbackSlug
+  }
+
+  // Hashes one installed-skill tree without following symlinks. Paths use archive-style `/`
+  // separators so the same tree has the same identity on Windows and POSIX; directory entries and
+  // portable permission bits are included because cp preserves empty directories and executable
+  // scripts. Applying the shared per-skill caps also bounds local scan reads.
+  private async signatureOfAgentHomeSkill(root: string): Promise<string> {
+    const entries: (
+      | { kind: 'directory'; relativePath: string; mode: number }
+      | { kind: 'file'; path: string; relativePath: string; mode: number }
+    )[] = []
+    let declaredTotal = 0
+    let fileCount = 0
+
+    const visit = async (dir: string, prefix: string, depth: number): Promise<void> => {
+      const dirStat = await lstat(dir)
+      if (dirStat.isSymbolicLink()) {
+        throw new Error('Refusing to import an agent-home Skill containing a symbolic link.')
+      }
+      if (!dirStat.isDirectory()) throw new Error('Agent-home Skill source must be a directory.')
+      if (depth > SKILL_IMPORT_LIMITS.maxDepth) {
+        throw new Error(`Agent-home Skill exceeds the maximum directory depth.`)
+      }
+      entries.push({ kind: 'directory', relativePath: prefix, mode: dirStat.mode & 0o777 })
+
+      const children = (await readdir(dir, { withFileTypes: true })).sort((a, b) =>
+        a.name.localeCompare(b.name)
+      )
+      for (const entry of children) {
+        const path = join(dir, entry.name)
+        const relativePath = prefix ? `${prefix}/${entry.name}` : entry.name
+        const entryStat = await lstat(path)
+        if (entryStat.isSymbolicLink()) {
+          throw new Error('Refusing to import an agent-home Skill containing a symbolic link.')
+        }
+        if (entryStat.isDirectory()) {
+          await visit(path, relativePath, depth + 1)
+          continue
+        }
+        if (!entryStat.isFile()) {
+          throw new Error(`Agent-home Skill contains an unsupported filesystem entry.`)
+        }
+        if (relativePath === SOURCE_MANIFEST) {
+          throw new Error(`Skill import may not include the reserved file ${SOURCE_MANIFEST}.`)
+        }
+        if (fileCount >= SKILL_IMPORT_LIMITS.maxFiles) {
+          throw new Error(`Agent-home Skill has more than ${SKILL_IMPORT_LIMITS.maxFiles} files.`)
+        }
+        if (entryStat.size > SKILL_IMPORT_LIMITS.maxFileBytes) {
+          throw new Error(
+            `Agent-home Skill contains a file over ${mb(SKILL_IMPORT_LIMITS.maxFileBytes)}.`
+          )
+        }
+        declaredTotal += entryStat.size
+        if (declaredTotal > SKILL_IMPORT_LIMITS.maxTotalBytes) {
+          throw new Error(`Agent-home Skill exceeds ${mb(SKILL_IMPORT_LIMITS.maxTotalBytes)}.`)
+        }
+        fileCount += 1
+        entries.push({ kind: 'file', path, relativePath, mode: entryStat.mode & 0o777 })
+      }
+    }
+
+    await visit(root, '', 0)
+
+    const hash = createHash('sha256')
+    let actualTotal = 0
+    for (const entry of entries.sort((a, b) => a.relativePath.localeCompare(b.relativePath))) {
+      hash.update(entry.kind)
+      hash.update('\0')
+      hash.update(entry.relativePath)
+      hash.update('\0')
+      hash.update(entry.mode.toString(8))
+      hash.update('\0')
+      if (entry.kind === 'directory') continue
+
+      const content = await readFile(entry.path)
+      if (content.length > SKILL_IMPORT_LIMITS.maxFileBytes) {
+        throw new Error(
+          `Agent-home Skill contains a file over ${mb(SKILL_IMPORT_LIMITS.maxFileBytes)}.`
+        )
+      }
+      actualTotal += content.length
+      if (actualTotal > SKILL_IMPORT_LIMITS.maxTotalBytes) {
+        throw new Error(`Agent-home Skill exceeds ${mb(SKILL_IMPORT_LIMITS.maxTotalBytes)}.`)
+      }
+      hash.update(content)
+      hash.update('\0')
+    }
+    return hash.digest('hex')
   }
 
   // Writes an imported skill's files (replacing any prior copy) plus its source manifest.
@@ -887,7 +976,6 @@ class UserSkillRepository {
     const stem = basename(dir)
     const generation = nextGeneration()
     const staging = join(parent, `.${stem}.import-${generation}`)
-    const backup = join(parent, `.${stem}.backup-${generation}`)
     // Build the whole new copy in staging first; any failure here discards staging and never touches
     // the live skill.
     try {
@@ -914,6 +1002,18 @@ class UserSkillRepository {
       throw buildError
     }
 
+    await this.swapImportedStaging(slug, staging, generation)
+  }
+
+  // Atomically promotes a fully-built sibling staging directory. This is shared by downloaded and
+  // installed-skill imports so both refresh paths preserve the previous live copy on swap failure.
+  private async swapImportedStaging(
+    slug: string,
+    staging: string,
+    generation: string
+  ): Promise<void> {
+    const dir = this.skillDir('imported', slug)
+    const backup = join(dirname(dir), `.${basename(dir)}.backup-${generation}`)
     // Swap: move the old copy aside to the backup, move staging into place, then drop the backup. This
     // runs inside the caller's operation-level critical section (recovery + dedup + slug + swap share
     // one runExclusive), so it must NOT re-acquire the lock here — that would deadlock. If a crash
@@ -948,6 +1048,46 @@ class UserSkillRepository {
     } catch (error) {
       // Any swap failure leaves staging behind; discard it (the backup, if any, is intentionally kept).
       await rm(staging, { recursive: true, force: true }).catch(() => {})
+      throw error
+    }
+  }
+
+  // Copies a local installed skill into a sibling staging directory, validates the copied snapshot,
+  // and records both its stable source identity and content signature. The caller decides whether
+  // that snapshot is unchanged or should be promoted over the live imported copy.
+  private async stageAgentHomeSkill(
+    slug: string,
+    sourcePath: string,
+    skill: AgentHomeSkillRef
+  ): Promise<{ staging: string; generation: string; signature: string }> {
+    const destination = this.skillDir('imported', slug)
+    const generation = nextGeneration()
+    const staging = join(dirname(destination), `.${basename(destination)}.import-${generation}`)
+
+    try {
+      await cp(sourcePath, staging, {
+        recursive: true,
+        force: false,
+        errorOnExist: true,
+        filter: async (entry) => {
+          if (resolve(entry) === resolve(sourcePath, SOURCE_MANIFEST)) {
+            throw new Error(`Skill import may not include the reserved file ${SOURCE_MANIFEST}.`)
+          }
+          if ((await lstat(entry)).isSymbolicLink()) {
+            throw new Error(`Refusing to import an agent-home Skill containing a symbolic link.`)
+          }
+          return true
+        }
+      })
+      const signature = await this.signatureOfAgentHomeSkill(staging)
+      await writeFile(
+        join(staging, SOURCE_MANIFEST),
+        JSON.stringify({ signature, agentHome: skill }, null, 2),
+        { flag: 'wx' }
+      )
+      return { staging, generation, signature }
+    } catch (error) {
+      await rm(staging, { recursive: true, force: true }).catch(() => undefined)
       throw error
     }
   }
@@ -1052,7 +1192,7 @@ class UserSkillRepository {
     // Cross-check existing source identities once (rather than per row) so the "already imported"
     // badge distinguishes same-slug skills discovered in different global sources.
     const [importedSkills, fallbackSlugs] = await Promise.all([
-      this.importedAgentHomeKeys(),
+      this.importedAgentHomeSignatures(),
       this.fallbackImportedSlugs()
     ])
 
@@ -1077,12 +1217,24 @@ class UserSkillRepository {
         continue
       }
 
+      const key = agentHomeKey({ source, slug })
+      let alreadyImported = false
+      if (importedSkills.has(key)) {
+        try {
+          alreadyImported = importedSkills.get(key) === (await this.signatureOfAgentHomeSkill(path))
+        } catch {
+          // Keep a readable row selectable. Import performs the same validation and reports a
+          // per-item error, rather than one malformed installed tree hiding the rest of the scan.
+          alreadyImported = false
+        }
+      }
+
       out.push({
         slug,
         name,
         description,
         path,
-        alreadyImported: importedSkills.has(agentHomeKey({ source, slug })),
+        alreadyImported,
         fallbackImported: fallbackSlugs.has(slug)
       })
     }
@@ -1123,37 +1275,28 @@ class UserSkillRepository {
         skill,
         options.allowSlugFallback === true
       )
-      if (existingSlug) return { status: 'unchanged', id: `imported-${existingSlug}` }
-
-      const slug = await this.uniqueSlug('imported', requestedSlug)
-      const destination = this.skillDir('imported', slug)
-
-      try {
-        await cp(sourcePath, destination, {
-          recursive: true,
-          force: false,
-          errorOnExist: true,
-          filter: async (entry) => {
-            if (resolve(entry) === resolve(sourcePath, SOURCE_MANIFEST)) {
-              throw new Error(`Skill import may not include the reserved file ${SOURCE_MANIFEST}.`)
-            }
-            if ((await lstat(entry)).isSymbolicLink()) {
-              throw new Error(`Refusing to import an agent-home Skill containing a symbolic link.`)
-            }
-            return true
-          }
-        })
-        await writeFile(
-          join(destination, SOURCE_MANIFEST),
-          JSON.stringify({ agentHome: skill }, null, 2),
-          { flag: 'wx' }
-        )
-      } catch (error) {
-        await rm(destination, { recursive: true, force: true }).catch(() => undefined)
-        throw error
+      const existing = existingSlug ? await this.readSource(existingSlug) : null
+      if (
+        existingSlug &&
+        (!existing?.agentHome || agentHomeKey(existing.agentHome) !== agentHomeKey(skill))
+      ) {
+        // A controlled legacy/GitHub/ZIP slug fallback prevents a duplicate, but cannot safely claim
+        // that unrelated record as this installed source or replace its contents.
+        return { status: 'unchanged', id: `imported-${existingSlug}` }
       }
 
-      return { status: 'imported', id: `imported-${slug}` }
+      const slug = existingSlug ?? (await this.uniqueSlug('imported', requestedSlug))
+      const staged = await this.stageAgentHomeSkill(slug, sourcePath, skill)
+      if (existingSlug && existing?.signature === staged.signature) {
+        await rm(staged.staging, { recursive: true, force: true })
+        return { status: 'unchanged', id: `imported-${existingSlug}` }
+      }
+
+      await this.swapImportedStaging(slug, staged.staging, staged.generation)
+      return {
+        status: existingSlug ? 'updated' : 'imported',
+        id: `imported-${slug}`
+      }
     })
   }
 }

--- a/src/main/skills/user-skill-repository.ts
+++ b/src/main/skills/user-skill-repository.ts
@@ -794,7 +794,11 @@ class UserSkillRepository {
 
       if (typeof record.agentHome === 'object' && record.agentHome !== null) {
         const agentHome = record.agentHome as Record<string, unknown>
-        if (isAgentHomeSkillSource(agentHome.source) && typeof agentHome.slug === 'string') {
+        if (
+          isAgentHomeSkillSource(agentHome.source) &&
+          typeof agentHome.slug === 'string' &&
+          SAFE_SLUG.test(agentHome.slug)
+        ) {
           manifest.agentHome = { source: agentHome.source, slug: agentHome.slug }
         }
       }
@@ -814,13 +818,26 @@ class UserSkillRepository {
     return keys
   }
 
-  private async findImportedSlugByAgentHome(skill: AgentHomeSkillRef): Promise<string | undefined> {
+  private async legacyAgentHomeSlugs(): Promise<Set<string>> {
+    const slugs = new Set<string>()
+    for (const slug of await this.listSlugs('imported')) {
+      if ((await this.readSource(slug)) === null) slugs.add(slug)
+    }
+    return slugs
+  }
+
+  private async findImportedSlugByAgentHome(
+    skill: AgentHomeSkillRef,
+    allowLegacySlugMatch: boolean
+  ): Promise<string | undefined> {
     const key = agentHomeKey(skill)
+    let legacySlug: string | undefined
     for (const slug of await this.listSlugs('imported')) {
       const source = await this.readSource(slug)
       if (source?.agentHome && agentHomeKey(source.agentHome) === key) return slug
+      if (allowLegacySlugMatch && source === null && slug === skill.slug) legacySlug = slug
     }
-    return undefined
+    return legacySlug
   }
 
   // Writes an imported skill's files (replacing any prior copy) plus its source manifest.
@@ -1012,6 +1029,7 @@ class UserSkillRepository {
       description: string
       path: string
       alreadyImported: boolean
+      legacyImported: boolean
     }[]
   > {
     let entries: string[] = []
@@ -1033,7 +1051,10 @@ class UserSkillRepository {
 
     // Cross-check existing source identities once (rather than per row) so the "already imported"
     // badge distinguishes same-slug skills discovered in different global sources.
-    const importedSkills = await this.importedAgentHomeKeys()
+    const [importedSkills, legacySlugs] = await Promise.all([
+      this.importedAgentHomeKeys(),
+      this.legacyAgentHomeSlugs()
+    ])
 
     const out: {
       slug: string
@@ -1041,6 +1062,7 @@ class UserSkillRepository {
       description: string
       path: string
       alreadyImported: boolean
+      legacyImported: boolean
     }[] = []
     for (const slug of entries) {
       const path = join(homeSkillsDir, slug)
@@ -1060,7 +1082,8 @@ class UserSkillRepository {
         name,
         description,
         path,
-        alreadyImported: importedSkills.has(agentHomeKey({ source, slug }))
+        alreadyImported: importedSkills.has(agentHomeKey({ source, slug })),
+        legacyImported: legacySlugs.has(slug)
       })
     }
 
@@ -1072,7 +1095,11 @@ class UserSkillRepository {
   // the same shape Open Science would have produced from a fresh in-app edit. Suffix allocation
   // mirrors importFromZip: the same source identity is unchanged, while a same-name skill from a
   // different source gets `-2`, `-3`, ... appended and never clobbers an existing record.
-  async importAgentHomeSkill(sourcePath: string, skill: AgentHomeSkillRef): Promise<ImportOutcome> {
+  async importAgentHomeSkill(
+    sourcePath: string,
+    skill: AgentHomeSkillRef,
+    options: { allowLegacySlugMatch?: boolean } = {}
+  ): Promise<ImportOutcome> {
     const requestedSlug = skill.slug
     if (!SAFE_SLUG.test(requestedSlug)) {
       throw new Error(`Refusing to import agent-home skill with unsafe slug: ${requestedSlug}`)
@@ -1092,7 +1119,10 @@ class UserSkillRepository {
     return this.runExclusive(async () => {
       await this.doRecoverImportedTransactions()
 
-      const existingSlug = await this.findImportedSlugByAgentHome(skill)
+      const existingSlug = await this.findImportedSlugByAgentHome(
+        skill,
+        options.allowLegacySlugMatch === true
+      )
       if (existingSlug) return { status: 'unchanged', id: `imported-${existingSlug}` }
 
       const slug = await this.uniqueSlug('imported', requestedSlug)

--- a/src/main/skills/user-skill-repository.ts
+++ b/src/main/skills/user-skill-repository.ts
@@ -826,18 +826,37 @@ class UserSkillRepository {
     return slugs
   }
 
+  // Rechecks source identities against a caller-resolved directory. Settings uses this only after
+  // realpath containment succeeds, allowing a safe root symlink alias to share the canonical tree's
+  // signature without weakening the repository's nested-symlink rejection.
+  async matchesImportedAgentHomeSkill(
+    sourcePath: string,
+    aliases: readonly AgentHomeSkillRef[]
+  ): Promise<boolean> {
+    const imported = await this.importedAgentHomeSignatures()
+    const expected = aliases
+      .map((alias) => imported.get(agentHomeKey(alias)))
+      .filter((signature): signature is string => typeof signature === 'string')
+    if (expected.length === 0) return false
+
+    return expected.includes(await this.signatureOfAgentHomeSkill(sourcePath))
+  }
+
   private async findImportedSlugByAgentHome(
     skill: AgentHomeSkillRef,
-    allowSlugFallback: boolean
-  ): Promise<string | undefined> {
-    const key = agentHomeKey(skill)
+    aliases: readonly AgentHomeSkillRef[],
+    fallbackSlugs: ReadonlySet<string>
+  ): Promise<{ slug: string; kind: 'identity' | 'fallback' } | undefined> {
+    const acceptedKeys = new Set([skill, ...aliases].map(agentHomeKey))
     let fallbackSlug: string | undefined
     for (const slug of await this.listSlugs('imported')) {
       const source = await this.readSource(slug)
-      if (source?.agentHome && agentHomeKey(source.agentHome) === key) return slug
-      if (allowSlugFallback && !source?.agentHome && slug === skill.slug) fallbackSlug = slug
+      if (source?.agentHome && acceptedKeys.has(agentHomeKey(source.agentHome))) {
+        return { slug, kind: 'identity' }
+      }
+      if (!source?.agentHome && fallbackSlugs.has(slug)) fallbackSlug = slug
     }
-    return fallbackSlug
+    return fallbackSlug ? { slug: fallbackSlug, kind: 'fallback' } : undefined
   }
 
   // Hashes one installed-skill tree without following symlinks. Paths use archive-style `/`
@@ -1250,7 +1269,10 @@ class UserSkillRepository {
   async importAgentHomeSkill(
     sourcePath: string,
     skill: AgentHomeSkillRef,
-    options: { allowSlugFallback?: boolean } = {}
+    options: {
+      aliases?: readonly AgentHomeSkillRef[]
+      fallbackSlugs?: readonly string[]
+    } = {}
   ): Promise<ImportOutcome> {
     const requestedSlug = skill.slug
     if (!SAFE_SLUG.test(requestedSlug)) {
@@ -1271,15 +1293,14 @@ class UserSkillRepository {
     return this.runExclusive(async () => {
       await this.doRecoverImportedTransactions()
 
-      const existingSlug = await this.findImportedSlugByAgentHome(
+      const existingMatch = await this.findImportedSlugByAgentHome(
         skill,
-        options.allowSlugFallback === true
+        options.aliases ?? [],
+        new Set(options.fallbackSlugs ?? [])
       )
+      const existingSlug = existingMatch?.slug
       const existing = existingSlug ? await this.readSource(existingSlug) : null
-      if (
-        existingSlug &&
-        (!existing?.agentHome || agentHomeKey(existing.agentHome) !== agentHomeKey(skill))
-      ) {
+      if (existingSlug && existingMatch.kind === 'fallback') {
         // A controlled legacy/GitHub/ZIP slug fallback prevents a duplicate, but cannot safely claim
         // that unrelated record as this installed source or replace its contents.
         return { status: 'unchanged', id: `imported-${existingSlug}` }

--- a/src/main/skills/user-skill-repository.ts
+++ b/src/main/skills/user-skill-repository.ts
@@ -119,6 +119,12 @@ type ImportedSourceManifest = {
   agentHome?: AgentHomeSkillRef
 }
 
+type ImportedAgentHomeIdentitySnapshot = {
+  importedSlug: string
+  agentHome: AgentHomeSkillRef
+  signature: string
+}
+
 const agentHomeKey = (skill: AgentHomeSkillRef): string => `${skill.source}:${skill.slug}`
 
 const isAgentHomeSkillSource = (value: unknown): value is AgentHomeSkillSource =>
@@ -809,11 +815,18 @@ class UserSkillRepository {
     }
   }
 
-  private async importedAgentHomeSignatures(): Promise<Map<string, string | undefined>> {
-    const signatures = new Map<string, string | undefined>()
+  private async importedAgentHomeSignatures(): Promise<
+    Map<string, { importedSlug: string; signature?: string }>
+  > {
+    const signatures = new Map<string, { importedSlug: string; signature?: string }>()
     for (const slug of await this.listSlugs('imported')) {
       const source = await this.readSource(slug)
-      if (source?.agentHome) signatures.set(agentHomeKey(source.agentHome), source.signature)
+      if (source?.agentHome) {
+        signatures.set(agentHomeKey(source.agentHome), {
+          importedSlug: slug,
+          signature: source.signature
+        })
+      }
     }
     return signatures
   }
@@ -845,8 +858,20 @@ class UserSkillRepository {
   // signature without weakening nested-symlink rejection. Metadata-less records match by both slug
   // and content, so an unrelated GitHub/ZIP import cannot suppress a local installed skill.
   async matchImportedAgentHomeSkills(
-    candidates: readonly { sourcePath: string; aliases: readonly AgentHomeSkillRef[] }[]
-  ): Promise<{ identityImported: boolean; fallbackAliases: AgentHomeSkillRef[] }[]> {
+    candidates: readonly {
+      sourcePath: string
+      canonical: AgentHomeSkillRef
+      aliases: readonly AgentHomeSkillRef[]
+    }[]
+  ): Promise<
+    {
+      identityImported: boolean
+      identityMigrationNeeded: boolean
+      matchedIdentitySignature?: string
+      matchedImportedIdentity?: ImportedAgentHomeIdentitySnapshot
+      fallbackAliases: AgentHomeSkillRef[]
+    }[]
+  > {
     const candidateSlugs = new Set(
       candidates.flatMap((candidate) => candidate.aliases.map((alias) => alias.slug))
     )
@@ -856,25 +881,66 @@ class UserSkillRepository {
     ])
 
     return Promise.all(
-      candidates.map(async ({ sourcePath, aliases }) => {
-        const identitySignatures = aliases
-          .map((alias) => imported.get(agentHomeKey(alias)))
-          .filter((signature): signature is string => typeof signature === 'string')
+      candidates.map(async ({ sourcePath, canonical, aliases }) => {
+        const identityRecords = aliases.flatMap((alias) => {
+          const record = imported.get(agentHomeKey(alias))
+          return typeof record?.signature === 'string' ? [{ alias, ...record }] : []
+        })
         const fallbackAliases = aliases.filter((alias) => fallbackSignatures.has(alias.slug))
-        if (identitySignatures.length === 0 && fallbackAliases.length === 0) {
-          return { identityImported: false, fallbackAliases: [] }
+        if (identityRecords.length === 0 && fallbackAliases.length === 0) {
+          return {
+            identityImported: false,
+            identityMigrationNeeded: false,
+            matchedIdentitySignature: undefined,
+            matchedImportedIdentity: undefined,
+            fallbackAliases: []
+          }
         }
 
         try {
           const signature = await this.signatureOfAgentHomeSkill(sourcePath)
+          const matchingIdentities: (typeof identityRecords)[number][] = []
+          for (const record of identityRecords) {
+            if (record.signature !== signature) continue
+            try {
+              const importedSignature = await this.signatureOfAgentHomeSkill(
+                this.skillDir('imported', record.importedSlug),
+                { skipSourceManifest: true }
+              )
+              if (importedSignature === signature) matchingIdentities.push(record)
+            } catch {
+              // A missing or malformed imported tree cannot be migrated automatically. Leave the
+              // discovered row selectable so a deliberate import can repair it.
+            }
+          }
+          const canonicalKey = agentHomeKey(canonical)
+          const canonicalMatched = matchingIdentities.some(
+            ({ alias }) => agentHomeKey(alias) === canonicalKey
+          )
+          const migrationMatch = canonicalMatched ? undefined : matchingIdentities[0]
           return {
-            identityImported: identitySignatures.includes(signature),
+            identityImported: matchingIdentities.length > 0,
+            identityMigrationNeeded: migrationMatch !== undefined,
+            matchedIdentitySignature: matchingIdentities.length > 0 ? signature : undefined,
+            matchedImportedIdentity: migrationMatch
+              ? {
+                  importedSlug: migrationMatch.importedSlug,
+                  agentHome: migrationMatch.alias,
+                  signature
+                }
+              : undefined,
             fallbackAliases: fallbackAliases.filter(
               (alias) => fallbackSignatures.get(alias.slug) === signature
             )
           }
         } catch {
-          return { identityImported: false, fallbackAliases: [] }
+          return {
+            identityImported: false,
+            identityMigrationNeeded: false,
+            matchedIdentitySignature: undefined,
+            matchedImportedIdentity: undefined,
+            fallbackAliases: []
+          }
         }
       })
     )
@@ -1294,7 +1360,8 @@ class UserSkillRepository {
       let alreadyImported = false
       if (importedSkills.has(key)) {
         try {
-          alreadyImported = importedSkills.get(key) === (await this.signatureOfAgentHomeSkill(path))
+          alreadyImported =
+            importedSkills.get(key)?.signature === (await this.signatureOfAgentHomeSkill(path))
         } catch {
           // Keep a readable row selectable. Import performs the same validation and reports a
           // per-item error, rather than one malformed installed tree hiding the rest of the scan.
@@ -1325,6 +1392,8 @@ class UserSkillRepository {
     options: {
       aliases?: readonly AgentHomeSkillRef[]
       fallbackSlugs?: readonly string[]
+      expectedSignature?: string
+      expectedImportedIdentity?: ImportedAgentHomeIdentitySnapshot
     } = {}
   ): Promise<ImportOutcome> {
     const requestedSlug = skill.slug
@@ -1350,6 +1419,31 @@ class UserSkillRepository {
       const slug = existingSlug ?? (await this.uniqueSlug('imported', requestedSlug))
       const staged = await this.stageAgentHomeSkill(slug, sourcePath, skill)
       try {
+        if (options.expectedImportedIdentity) {
+          const expected = options.expectedImportedIdentity
+          const current = await this.readSource(expected.importedSlug)
+          let currentTreeSignature: string | undefined
+          try {
+            currentTreeSignature = await this.signatureOfAgentHomeSkill(
+              this.skillDir('imported', expected.importedSlug),
+              { skipSourceManifest: true }
+            )
+          } catch {
+            // Report every missing or malformed expected record as the same stale-scan condition.
+          }
+          if (
+            existingSlug !== expected.importedSlug ||
+            !current?.agentHome ||
+            agentHomeKey(current.agentHome) !== agentHomeKey(expected.agentHome) ||
+            current.signature !== expected.signature ||
+            currentTreeSignature !== expected.signature
+          ) {
+            throw new Error('Imported skill changed during canonical identity migration.')
+          }
+        }
+        if (options.expectedSignature && staged.signature !== options.expectedSignature) {
+          throw new Error('Installed skill changed during canonical identity migration.')
+        }
         if (!existingSlug) {
           const fallbackSlug = await this.findFallbackImportedSlug(
             new Set(options.fallbackSlugs ?? []),
@@ -1362,7 +1456,9 @@ class UserSkillRepository {
         }
 
         const existing = existingSlug ? await this.readSource(existingSlug) : null
-        if (existingSlug && existing?.signature === staged.signature) {
+        const identityUnchanged =
+          existing?.agentHome && agentHomeKey(existing.agentHome) === agentHomeKey(skill)
+        if (existingSlug && identityUnchanged && existing.signature === staged.signature) {
           await rm(staged.staging, { recursive: true, force: true })
           return { status: 'unchanged', id: `imported-${existingSlug}` }
         }

--- a/src/main/skills/user-skill-repository.ts
+++ b/src/main/skills/user-skill-repository.ts
@@ -818,26 +818,26 @@ class UserSkillRepository {
     return keys
   }
 
-  private async legacyAgentHomeSlugs(): Promise<Set<string>> {
+  private async fallbackImportedSlugs(): Promise<Set<string>> {
     const slugs = new Set<string>()
     for (const slug of await this.listSlugs('imported')) {
-      if ((await this.readSource(slug)) === null) slugs.add(slug)
+      if (!(await this.readSource(slug))?.agentHome) slugs.add(slug)
     }
     return slugs
   }
 
   private async findImportedSlugByAgentHome(
     skill: AgentHomeSkillRef,
-    allowLegacySlugMatch: boolean
+    allowSlugFallback: boolean
   ): Promise<string | undefined> {
     const key = agentHomeKey(skill)
-    let legacySlug: string | undefined
+    let fallbackSlug: string | undefined
     for (const slug of await this.listSlugs('imported')) {
       const source = await this.readSource(slug)
       if (source?.agentHome && agentHomeKey(source.agentHome) === key) return slug
-      if (allowLegacySlugMatch && source === null && slug === skill.slug) legacySlug = slug
+      if (allowSlugFallback && !source?.agentHome && slug === skill.slug) fallbackSlug = slug
     }
-    return legacySlug
+    return fallbackSlug
   }
 
   // Writes an imported skill's files (replacing any prior copy) plus its source manifest.
@@ -1029,7 +1029,7 @@ class UserSkillRepository {
       description: string
       path: string
       alreadyImported: boolean
-      legacyImported: boolean
+      fallbackImported: boolean
     }[]
   > {
     let entries: string[] = []
@@ -1051,9 +1051,9 @@ class UserSkillRepository {
 
     // Cross-check existing source identities once (rather than per row) so the "already imported"
     // badge distinguishes same-slug skills discovered in different global sources.
-    const [importedSkills, legacySlugs] = await Promise.all([
+    const [importedSkills, fallbackSlugs] = await Promise.all([
       this.importedAgentHomeKeys(),
-      this.legacyAgentHomeSlugs()
+      this.fallbackImportedSlugs()
     ])
 
     const out: {
@@ -1062,7 +1062,7 @@ class UserSkillRepository {
       description: string
       path: string
       alreadyImported: boolean
-      legacyImported: boolean
+      fallbackImported: boolean
     }[] = []
     for (const slug of entries) {
       const path = join(homeSkillsDir, slug)
@@ -1083,7 +1083,7 @@ class UserSkillRepository {
         description,
         path,
         alreadyImported: importedSkills.has(agentHomeKey({ source, slug })),
-        legacyImported: legacySlugs.has(slug)
+        fallbackImported: fallbackSlugs.has(slug)
       })
     }
 
@@ -1098,7 +1098,7 @@ class UserSkillRepository {
   async importAgentHomeSkill(
     sourcePath: string,
     skill: AgentHomeSkillRef,
-    options: { allowLegacySlugMatch?: boolean } = {}
+    options: { allowSlugFallback?: boolean } = {}
   ): Promise<ImportOutcome> {
     const requestedSlug = skill.slug
     if (!SAFE_SLUG.test(requestedSlug)) {
@@ -1121,7 +1121,7 @@ class UserSkillRepository {
 
       const existingSlug = await this.findImportedSlugByAgentHome(
         skill,
-        options.allowLegacySlugMatch === true
+        options.allowSlugFallback === true
       )
       if (existingSlug) return { status: 'unchanged', id: `imported-${existingSlug}` }
 

--- a/src/main/skills/user-skill-repository.ts
+++ b/src/main/skills/user-skill-repository.ts
@@ -956,13 +956,9 @@ class UserSkillRepository {
   }
 
   // Lists the skill directories under a machine-level agent home (typically ~/.claude/skills/).
-  // Each subdirectory is treated as one candidate skill: its SKILL.md frontmatter supplies the
-  // displayed name/description, and the directory name acts as the slug. Hidden entries (the
-  // transaction dirs .import-/ .backup-) are ignored so the list never leaks staging state.
-  //
-  // Surface is intentionally narrow: a directory that has no SKILL.md is listed with a fallback
-  // name so the user can still try to import it; the actual import copies the whole subtree
-  // regardless of contents.
+  // A candidate must be a safe-slug directory with a readable SKILL.md; arbitrary sibling folders
+  // are not import choices. Frontmatter supplies the displayed name/description, while the directory
+  // name remains the stable slug. Hidden transaction directories are ignored.
   async listAgentHomeSkills(homeSkillsDir: string): Promise<
     {
       slug: string
@@ -976,8 +972,11 @@ class UserSkillRepository {
 
     try {
       entries = (await readdir(homeSkillsDir, { withFileTypes: true }))
-        .filter((entry) => entry.isDirectory() && SAFE_SLUG.test(entry.name))
+        .filter(
+          (entry) => (entry.isDirectory() || entry.isSymbolicLink()) && SAFE_SLUG.test(entry.name)
+        )
         .map((entry) => entry.name)
+        .sort()
     } catch (error) {
       // A missing agent home just means "nothing to import"; surface other errors so a corrupt
       // permissions state can't silently hide skills the user expects to see.
@@ -1007,7 +1006,7 @@ class UserSkillRepository {
         if (typeof fields.name === 'string' && fields.name) name = fields.name
         if (typeof fields.description === 'string') description = fields.description
       } catch {
-        // No SKILL.md / unreadable: keep the fallback name/description so the UI still lists it.
+        continue
       }
 
       out.push({
@@ -1027,9 +1026,12 @@ class UserSkillRepository {
   // the same shape Open Science would have produced from a fresh in-app edit. Suffix allocation
   // mirrors importFromZip: a taken slug gets `-2`, `-3`, ... appended so re-running the import never
   // clobbers an existing record.
-  async importAgentHomeSkill(sourcePath: string): Promise<ImportOutcome> {
-    if (!SAFE_SLUG.test(basename(sourcePath))) {
-      throw new Error(`Refusing to import agent-home skill with unsafe slug: ${sourcePath}`)
+  async importAgentHomeSkill(
+    sourcePath: string,
+    requestedSlug = basename(sourcePath)
+  ): Promise<ImportOutcome> {
+    if (!SAFE_SLUG.test(requestedSlug)) {
+      throw new Error(`Refusing to import agent-home skill with unsafe slug: ${requestedSlug}`)
     }
 
     // Stat the source up front so a missing path fails loudly instead of leaving a half-copied
@@ -1046,7 +1048,7 @@ class UserSkillRepository {
     return this.runExclusive(async () => {
       await this.doRecoverImportedTransactions()
 
-      const slug = await this.uniqueSlug('imported', basename(sourcePath))
+      const slug = await this.uniqueSlug('imported', requestedSlug)
       const destination = this.skillDir('imported', slug)
 
       try {

--- a/src/main/skills/user-skill-repository.ts
+++ b/src/main/skills/user-skill-repository.ts
@@ -818,52 +818,110 @@ class UserSkillRepository {
     return signatures
   }
 
-  private async fallbackImportedSlugs(): Promise<Set<string>> {
-    const slugs = new Set<string>()
+  private async fallbackImportedSignatures(
+    candidateSlugs: ReadonlySet<string>
+  ): Promise<Map<string, string>> {
+    const signatures = new Map<string, string>()
     for (const slug of await this.listSlugs('imported')) {
-      if (!(await this.readSource(slug))?.agentHome) slugs.add(slug)
+      if (!candidateSlugs.has(slug)) continue
+      if ((await this.readSource(slug))?.agentHome) continue
+      try {
+        signatures.set(
+          slug,
+          await this.signatureOfAgentHomeSkill(this.skillDir('imported', slug), {
+            skipSourceManifest: true
+          })
+        )
+      } catch {
+        // A malformed imported tree cannot safely stand in for an installed skill. Leave it as an
+        // independent record so a healthy same-slug installed skill remains importable.
+      }
     }
-    return slugs
+    return signatures
   }
 
-  // Rechecks source identities against a caller-resolved directory. Settings uses this only after
-  // realpath containment succeeds, allowing a safe root symlink alias to share the canonical tree's
-  // signature without weakening the repository's nested-symlink rejection.
-  async matchesImportedAgentHomeSkill(
-    sourcePath: string,
-    aliases: readonly AgentHomeSkillRef[]
-  ): Promise<boolean> {
-    const imported = await this.importedAgentHomeSignatures()
-    const expected = aliases
-      .map((alias) => imported.get(agentHomeKey(alias)))
-      .filter((signature): signature is string => typeof signature === 'string')
-    if (expected.length === 0) return false
+  // Matches source identities and legacy records against a caller-resolved directory. Settings uses
+  // this only after realpath containment succeeds, allowing safe root aliases to share one canonical
+  // signature without weakening nested-symlink rejection. Metadata-less records match by both slug
+  // and content, so an unrelated GitHub/ZIP import cannot suppress a local installed skill.
+  async matchImportedAgentHomeSkills(
+    candidates: readonly { sourcePath: string; aliases: readonly AgentHomeSkillRef[] }[]
+  ): Promise<{ identityImported: boolean; fallbackAliases: AgentHomeSkillRef[] }[]> {
+    const candidateSlugs = new Set(
+      candidates.flatMap((candidate) => candidate.aliases.map((alias) => alias.slug))
+    )
+    const [imported, fallbackSignatures] = await Promise.all([
+      this.importedAgentHomeSignatures(),
+      this.fallbackImportedSignatures(candidateSlugs)
+    ])
 
-    return expected.includes(await this.signatureOfAgentHomeSkill(sourcePath))
+    return Promise.all(
+      candidates.map(async ({ sourcePath, aliases }) => {
+        const identitySignatures = aliases
+          .map((alias) => imported.get(agentHomeKey(alias)))
+          .filter((signature): signature is string => typeof signature === 'string')
+        const fallbackAliases = aliases.filter((alias) => fallbackSignatures.has(alias.slug))
+        if (identitySignatures.length === 0 && fallbackAliases.length === 0) {
+          return { identityImported: false, fallbackAliases: [] }
+        }
+
+        try {
+          const signature = await this.signatureOfAgentHomeSkill(sourcePath)
+          return {
+            identityImported: identitySignatures.includes(signature),
+            fallbackAliases: fallbackAliases.filter(
+              (alias) => fallbackSignatures.get(alias.slug) === signature
+            )
+          }
+        } catch {
+          return { identityImported: false, fallbackAliases: [] }
+        }
+      })
+    )
   }
 
   private async findImportedSlugByAgentHome(
     skill: AgentHomeSkillRef,
-    aliases: readonly AgentHomeSkillRef[],
-    fallbackSlugs: ReadonlySet<string>
-  ): Promise<{ slug: string; kind: 'identity' | 'fallback' } | undefined> {
+    aliases: readonly AgentHomeSkillRef[]
+  ): Promise<string | undefined> {
     const acceptedKeys = new Set([skill, ...aliases].map(agentHomeKey))
-    let fallbackSlug: string | undefined
     for (const slug of await this.listSlugs('imported')) {
       const source = await this.readSource(slug)
       if (source?.agentHome && acceptedKeys.has(agentHomeKey(source.agentHome))) {
-        return { slug, kind: 'identity' }
+        return slug
       }
-      if (!source?.agentHome && fallbackSlugs.has(slug)) fallbackSlug = slug
     }
-    return fallbackSlug ? { slug: fallbackSlug, kind: 'fallback' } : undefined
+    return undefined
+  }
+
+  private async findFallbackImportedSlug(
+    fallbackSlugs: ReadonlySet<string>,
+    sourceSignature: string
+  ): Promise<string | undefined> {
+    for (const slug of await this.listSlugs('imported')) {
+      if (!fallbackSlugs.has(slug)) continue
+      if ((await this.readSource(slug))?.agentHome) continue
+      try {
+        const importedSignature = await this.signatureOfAgentHomeSkill(
+          this.skillDir('imported', slug),
+          { skipSourceManifest: true }
+        )
+        if (importedSignature === sourceSignature) return slug
+      } catch {
+        // A malformed metadata-less record is not a safe fallback match.
+      }
+    }
+    return undefined
   }
 
   // Hashes one installed-skill tree without following symlinks. Paths use archive-style `/`
   // separators so the same tree has the same identity on Windows and POSIX; directory entries and
   // portable permission bits are included because cp preserves empty directories and executable
   // scripts. Applying the shared per-skill caps also bounds local scan reads.
-  private async signatureOfAgentHomeSkill(root: string): Promise<string> {
+  private async signatureOfAgentHomeSkill(
+    root: string,
+    options: { skipSourceManifest?: boolean } = {}
+  ): Promise<string> {
     const entries: (
       | { kind: 'directory'; relativePath: string; mode: number }
       | { kind: 'file'; path: string; relativePath: string; mode: number }
@@ -900,6 +958,7 @@ class UserSkillRepository {
           throw new Error(`Agent-home Skill contains an unsupported filesystem entry.`)
         }
         if (relativePath === SOURCE_MANIFEST) {
+          if (options.skipSourceManifest) continue
           throw new Error(`Skill import may not include the reserved file ${SOURCE_MANIFEST}.`)
         }
         if (fileCount >= SKILL_IMPORT_LIMITS.maxFiles) {
@@ -1188,7 +1247,6 @@ class UserSkillRepository {
       description: string
       path: string
       alreadyImported: boolean
-      fallbackImported: boolean
     }[]
   > {
     let entries: string[] = []
@@ -1210,10 +1268,7 @@ class UserSkillRepository {
 
     // Cross-check existing source identities once (rather than per row) so the "already imported"
     // badge distinguishes same-slug skills discovered in different global sources.
-    const [importedSkills, fallbackSlugs] = await Promise.all([
-      this.importedAgentHomeSignatures(),
-      this.fallbackImportedSlugs()
-    ])
+    const importedSkills = await this.importedAgentHomeSignatures()
 
     const out: {
       slug: string
@@ -1221,7 +1276,6 @@ class UserSkillRepository {
       description: string
       path: string
       alreadyImported: boolean
-      fallbackImported: boolean
     }[] = []
     for (const slug of entries) {
       const path = join(homeSkillsDir, slug)
@@ -1253,8 +1307,7 @@ class UserSkillRepository {
         name,
         description,
         path,
-        alreadyImported,
-        fallbackImported: fallbackSlugs.has(slug)
+        alreadyImported
       })
     }
 
@@ -1293,30 +1346,35 @@ class UserSkillRepository {
     return this.runExclusive(async () => {
       await this.doRecoverImportedTransactions()
 
-      const existingMatch = await this.findImportedSlugByAgentHome(
-        skill,
-        options.aliases ?? [],
-        new Set(options.fallbackSlugs ?? [])
-      )
-      const existingSlug = existingMatch?.slug
-      const existing = existingSlug ? await this.readSource(existingSlug) : null
-      if (existingSlug && existingMatch.kind === 'fallback') {
-        // A controlled legacy/GitHub/ZIP slug fallback prevents a duplicate, but cannot safely claim
-        // that unrelated record as this installed source or replace its contents.
-        return { status: 'unchanged', id: `imported-${existingSlug}` }
-      }
-
+      const existingSlug = await this.findImportedSlugByAgentHome(skill, options.aliases ?? [])
       const slug = existingSlug ?? (await this.uniqueSlug('imported', requestedSlug))
       const staged = await this.stageAgentHomeSkill(slug, sourcePath, skill)
-      if (existingSlug && existing?.signature === staged.signature) {
-        await rm(staged.staging, { recursive: true, force: true })
-        return { status: 'unchanged', id: `imported-${existingSlug}` }
-      }
+      try {
+        if (!existingSlug) {
+          const fallbackSlug = await this.findFallbackImportedSlug(
+            new Set(options.fallbackSlugs ?? []),
+            staged.signature
+          )
+          if (fallbackSlug) {
+            await rm(staged.staging, { recursive: true, force: true })
+            return { status: 'unchanged', id: `imported-${fallbackSlug}` }
+          }
+        }
 
-      await this.swapImportedStaging(slug, staged.staging, staged.generation)
-      return {
-        status: existingSlug ? 'updated' : 'imported',
-        id: `imported-${slug}`
+        const existing = existingSlug ? await this.readSource(existingSlug) : null
+        if (existingSlug && existing?.signature === staged.signature) {
+          await rm(staged.staging, { recursive: true, force: true })
+          return { status: 'unchanged', id: `imported-${existingSlug}` }
+        }
+
+        await this.swapImportedStaging(slug, staged.staging, staged.generation)
+        return {
+          status: existingSlug ? 'updated' : 'imported',
+          id: `imported-${slug}`
+        }
+      } catch (error) {
+        await rm(staged.staging, { recursive: true, force: true }).catch(() => undefined)
+        throw error
       }
     })
   }

--- a/src/main/web-service/http-server.test.ts
+++ b/src/main/web-service/http-server.test.ts
@@ -30,7 +30,11 @@ describe('startWebHttpServer', () => {
     roots.push(staticRoot)
     await writeFile(join(staticRoot, 'index.html'), '<!doctype html><title>Web test</title>')
     const rpc = {
-      channels: () => ['test:echo'],
+      channels: () => [
+        'test:echo',
+        'settings:list-agent-home-skills',
+        'settings:import-agent-home-skills'
+      ],
       invoke: vi.fn(async (_channel: string, _client: string, args: unknown[]) => args[0]),
       releaseClient: vi.fn(),
       dispose: vi.fn()
@@ -76,15 +80,20 @@ describe('startWebHttpServer', () => {
     })
     expect(await rpcResponse.json()).toEqual({ ok: true, result: { value: 1 } })
 
-    // Channels the browser reimplements client-side (native-dialog / window handlers) are rejected
-    // over /rpc without ever reaching the handler.
-    const blockedResponse = await fetch(`${base}/rpc/window%3Aclose`, {
-      method: 'POST',
-      headers: { cookie, 'content-type': 'application/json' },
-      body: JSON.stringify({ args: [] })
-    })
-    expect(blockedResponse.status).toBe(403)
-    expect(await blockedResponse.json()).toMatchObject({ ok: false })
+    // Channels unavailable to web clients are rejected over /rpc without reaching the handler.
+    for (const channel of [
+      'window:close',
+      'settings:list-agent-home-skills',
+      'settings:import-agent-home-skills'
+    ]) {
+      const blockedResponse = await fetch(`${base}/rpc/${encodeURIComponent(channel)}`, {
+        method: 'POST',
+        headers: { cookie, 'content-type': 'application/json' },
+        body: JSON.stringify({ args: [] })
+      })
+      expect(blockedResponse.status).toBe(403)
+      expect(await blockedResponse.json()).toMatchObject({ ok: false })
+    }
     expect(rpc.invoke).toHaveBeenCalledTimes(1)
 
     const socket = new WebSocket(`ws://127.0.0.1:${server.port}/events?client=test-client`, {

--- a/src/main/web-service/http-server.ts
+++ b/src/main/web-service/http-server.ts
@@ -16,15 +16,16 @@ import { TaskApiError, type HeadlessTaskApi } from './task-api'
 
 const MAX_RPC_BODY_BYTES = 64 * 1024 * 1024
 
-// Channels the web client reimplements in the browser (see src/renderer/web/bootstrap.ts) because
-// their main handlers require a real Electron WebContents: file:save-* open a native save dialog
-// parented to a window, and window:close resolves a BrowserWindow from the sender. The synthetic
-// RPC sender has neither, so a direct /rpc call would pop a desktop dialog or silently no-op. The
-// browser never routes these through /rpc, so reject them outright rather than expose that behavior.
-const WEB_CLIENT_OVERRIDDEN_CHANNELS = new Set([
+// Channels unavailable over web. The browser reimplements file saves and window close client-side
+// because their main handlers require a real Electron WebContents. Installed-skill discovery reads
+// desktop-user agent homes, so it must not be exposed by a headless daemon. Omit these channels from
+// bootstrap capability discovery and reject direct /rpc calls before they reach the IPC handlers.
+const WEB_UNAVAILABLE_RPC_CHANNELS = new Set([
   'file:save-blob',
   'file:save-managed',
-  'window:close'
+  'window:close',
+  'settings:list-agent-home-skills',
+  'settings:import-agent-home-skills'
 ])
 
 const MIME_TYPES: Record<string, string> = {
@@ -330,7 +331,10 @@ const startWebHttpServer = async (options: WebServerOptions): Promise<RunningWeb
       }
 
       if (url.pathname === '/api/bootstrap' && request.method === 'GET') {
-        json(response, 200, { ...options.bootstrap, rpcChannels: options.rpc.channels() })
+        const rpcChannels = options.rpc
+          .channels()
+          .filter((channel) => !WEB_UNAVAILABLE_RPC_CHANNELS.has(channel))
+        json(response, 200, { ...options.bootstrap, rpcChannels })
         return
       }
 
@@ -360,7 +364,7 @@ const startWebHttpServer = async (options: WebServerOptions): Promise<RunningWeb
 
       if (url.pathname.startsWith('/rpc/') && request.method === 'POST') {
         const channel = decodeURIComponent(url.pathname.slice('/rpc/'.length))
-        if (WEB_CLIENT_OVERRIDDEN_CHANNELS.has(channel)) {
+        if (WEB_UNAVAILABLE_RPC_CHANNELS.has(channel)) {
           json(response, 403, { ok: false, error: `Channel not available over web: ${channel}` })
           return
         }

--- a/src/preload/index.d.ts
+++ b/src/preload/index.d.ts
@@ -143,6 +143,9 @@ import type {
   ImportSkillZipRequest,
   ImportSkillZipBatchRequest,
   ImportSkillZipBatchResult,
+  ImportAgentHomeSkillsRequest,
+  ImportAgentHomeSkillsResult,
+  AgentHomeSkillView,
   PreviewSkillZipRequest,
   SkillBundlePreviewResult,
   ScanRepoRequest,
@@ -284,7 +287,9 @@ interface OpenScienceAPI {
     previewSkillZip(request: PreviewSkillZipRequest): Promise<SkillBundlePreviewResult>
     scanRepoSkills(request: ScanRepoRequest): Promise<ScanRepoResult>
     listAgentHomeSkills(): Promise<AgentHomeSkillView[]>
-    importAgentHomeSkill(request: ImportAgentHomeSkillRequest): Promise<ImportSkillResult>
+    importAgentHomeSkills(
+      request: ImportAgentHomeSkillsRequest
+    ): Promise<ImportAgentHomeSkillsResult>
     listConnectors(): Promise<ConnectorsSnapshot>
     getConnectorDetail(id: string): Promise<ConnectorDetailView>
     setConnectorEnabled(request: SetConnectorEnabledRequest): Promise<ConnectorsSnapshot>

--- a/src/preload/index.ts
+++ b/src/preload/index.ts
@@ -152,7 +152,8 @@ import type {
   ImportSkillZipRequest,
   ImportSkillZipBatchRequest,
   ImportSkillZipBatchResult,
-  ImportAgentHomeSkillRequest,
+  ImportAgentHomeSkillsRequest,
+  ImportAgentHomeSkillsResult,
   AgentHomeSkillView,
   PreviewSkillZipRequest,
   SkillBundlePreviewResult,
@@ -316,7 +317,9 @@ type OpenScienceAPI = {
     previewSkillZip: (request: PreviewSkillZipRequest) => Promise<SkillBundlePreviewResult>
     scanRepoSkills: (request: ScanRepoRequest) => Promise<ScanRepoResult>
     listAgentHomeSkills: () => Promise<AgentHomeSkillView[]>
-    importAgentHomeSkill: (request: ImportAgentHomeSkillRequest) => Promise<ImportSkillResult>
+    importAgentHomeSkills: (
+      request: ImportAgentHomeSkillsRequest
+    ) => Promise<ImportAgentHomeSkillsResult>
     listConnectors: () => Promise<ConnectorsSnapshot>
     getConnectorDetail: (id: string) => Promise<ConnectorDetailView>
     setConnectorEnabled: (request: SetConnectorEnabledRequest) => Promise<ConnectorsSnapshot>
@@ -766,12 +769,14 @@ const api: OpenScienceAPI = {
       ) as Promise<SkillBundlePreviewResult>,
     scanRepoSkills: (request: ScanRepoRequest) =>
       ipcRenderer.invoke('settings:scan-repo-skills', request) as Promise<ScanRepoResult>,
-    // "From your agent home" import source: lists the skills under ~/.claude/skills/ for the
-    // renderer to display, and copies one into the imported-skill store on demand.
+    // Lists installed skills from the shared global source plus the active framework's source.
     listAgentHomeSkills: () =>
       ipcRenderer.invoke('settings:list-agent-home-skills') as Promise<AgentHomeSkillView[]>,
-    importAgentHomeSkill: (request: ImportAgentHomeSkillRequest) =>
-      ipcRenderer.invoke('settings:import-agent-home-skill', request) as Promise<ImportSkillResult>,
+    importAgentHomeSkills: (request: ImportAgentHomeSkillsRequest) =>
+      ipcRenderer.invoke(
+        'settings:import-agent-home-skills',
+        request
+      ) as Promise<ImportAgentHomeSkillsResult>,
     listConnectors: () =>
       ipcRenderer.invoke('settings:list-connectors') as Promise<ConnectorsSnapshot>,
     getConnectorDetail: (id: string) =>

--- a/src/renderer/src/pages/settings/AgentHomeImportView.tsx
+++ b/src/renderer/src/pages/settings/AgentHomeImportView.tsx
@@ -1,6 +1,10 @@
-import { useEffect, useState } from 'react'
+import { useCallback, useEffect, useMemo, useState } from 'react'
 
-import type { AgentHomeSkillView } from '../../../../shared/settings'
+import type {
+  AgentHomeSkillRef,
+  AgentHomeSkillSource,
+  AgentHomeSkillView
+} from '../../../../shared/settings'
 import { Button } from '@/components/ui/button'
 import { useSettingsStore } from '@/stores/settings-store'
 
@@ -8,38 +12,50 @@ type AgentHomeImportViewProps = {
   onImported: () => void
 }
 
-// Imports skills from the user's machine-level agent home. The source directory is the active
-// agent's global skills folder: `~/.claude/skills/` for claude-code and `~/.codex/skills/` for
-// codex. Surfaced as a separate sub-view rather than a card on the main list because the source
-// is the user's own filesystem, not a public repo — the affordance needs a clear "this reads from
-// your machine" framing so the user can give informed consent. Mirrors SkillImportView's
-// structure (preview + import-selected) so the two paths feel familiar.
+const SOURCE_INFO: Record<AgentHomeSkillSource, { label: string; path: string }> = {
+  agents: { label: 'Shared', path: '~/.agents/skills' },
+  claude: { label: 'Claude Code', path: '~/.claude/skills' },
+  codex: { label: 'Codex', path: '~/.codex/skills' }
+}
+
+const skillKey = (skill: AgentHomeSkillRef): string => `${skill.source}:${skill.slug}`
+
+// Lists skills installed outside Open Science's isolated agent profile, then copies the checked
+// directories through the existing imported-skill pipeline. Main owns source routing and path
+// containment; this view handles only renderer-safe source ids, slugs, and display metadata.
 const AgentHomeImportView = ({ onImported }: AgentHomeImportViewProps): React.JSX.Element => {
   const listAgentHomeSkills = useSettingsStore((state) => state.listAgentHomeSkills)
-  const importAgentHomeSkill = useSettingsStore((state) => state.importAgentHomeSkill)
-  // The path mirror follows the active framework — main resolves it the same way. Reading from
-  // the store here keeps the description in lockstep with what is actually scanned when the user
-  // clicks "Rescan" / "Import".
+  const importAgentHomeSkills = useSettingsStore((state) => state.importAgentHomeSkills)
   const activeFrameworkId = useSettingsStore((state) => state.agentFrameworkId)
-  const agentHomeRoot =
-    activeFrameworkId === 'codex' ? '~/.codex/skills/' : '~/.claude/skills/'
-  const [busy, setBusy] = useState(true)
+  const [scanning, setScanning] = useState(true)
+  const [importing, setImporting] = useState(false)
   const [message, setMessage] = useState<string | null>(null)
   const [skills, setSkills] = useState<AgentHomeSkillView[] | null>(null)
-  const [importing, setImporting] = useState<string | undefined>(undefined)
+  const [selected, setSelected] = useState<Set<string>>(new Set())
 
-  // Auto-load on mount so the user sees what is available without an extra click. The list is
-  // small (one entry per top-level subdirectory of ~/.claude/skills/) and the read is local, so
-  // pulling it eagerly is cheap; deferring to a button would make the import source feel hidden.
-  // `busy` starts true so the first render already shows the spinner without an effect-time setBusy
-  // call. State updates only fire from the .then/.catch/.finally callbacks (response to the IPC),
-  // which the React lint rule allows.
+  const frameworkSource =
+    activeFrameworkId === 'codex'
+      ? SOURCE_INFO.codex
+      : activeFrameworkId === 'claude-code'
+        ? SOURCE_INFO.claude
+        : undefined
+
+  const applyScan = useCallback((items: AgentHomeSkillView[]): void => {
+    setSkills(items)
+    setSelected(
+      new Set(items.filter((skill) => !skill.alreadyImported).map((skill) => skillKey(skill)))
+    )
+  }, [])
+
+  // Discovery is local and bounded to one directory per visible source, so load eagerly. Including
+  // the framework id makes an already-open view follow a framework switch without retaining stale
+  // source rows.
   useEffect(() => {
     let cancelled = false
     listAgentHomeSkills()
       .then((items) => {
         if (cancelled) return
-        setSkills(items)
+        applyScan(items)
       })
       .catch((error) => {
         if (cancelled) return
@@ -47,56 +63,99 @@ const AgentHomeImportView = ({ onImported }: AgentHomeImportViewProps): React.JS
       })
       .finally(() => {
         if (cancelled) return
-        setBusy(false)
+        setScanning(false)
       })
 
     return () => {
       cancelled = true
     }
-  }, [listAgentHomeSkills])
+  }, [activeFrameworkId, applyScan, listAgentHomeSkills])
+
+  const selectable = useMemo(
+    () => skills?.filter((skill) => !skill.alreadyImported) ?? [],
+    [skills]
+  )
+  const allSelected = selectable.length > 0 && selected.size === selectable.length
 
   const rescan = async (): Promise<void> => {
-    setBusy(true)
+    setScanning(true)
     setMessage(null)
     try {
-      const items = await listAgentHomeSkills()
-      setSkills(items)
+      applyScan(await listAgentHomeSkills())
     } catch (error) {
       setMessage(error instanceof Error ? error.message : 'Scan failed.')
     } finally {
-      setBusy(false)
+      setScanning(false)
     }
   }
 
-  const importOne = async (skill: AgentHomeSkillView): Promise<void> => {
-    setImporting(skill.slug)
+  const toggle = (skill: AgentHomeSkillRef): void =>
+    setSelected((previous) => {
+      const next = new Set(previous)
+      const key = skillKey(skill)
+      if (next.has(key)) next.delete(key)
+      else next.add(key)
+      return next
+    })
+
+  const toggleAll = (): void =>
+    setSelected(() =>
+      allSelected ? new Set() : new Set(selectable.map((skill) => skillKey(skill)))
+    )
+
+  const invertSelection = (): void =>
+    setSelected((previous) => {
+      const next = new Set<string>()
+      for (const skill of selectable) {
+        const key = skillKey(skill)
+        if (!previous.has(key)) next.add(key)
+      }
+      return next
+    })
+
+  const importSelected = async (): Promise<void> => {
+    if (importing || selected.size === 0 || !skills) return
+
+    const requested = skills
+      .filter((skill) => selected.has(skillKey(skill)) && !skill.alreadyImported)
+      .map(({ source, slug }) => ({ source, slug }))
+    if (requested.length === 0) return
+
+    setImporting(true)
     setMessage(null)
     try {
-      const result = await importAgentHomeSkill(skill.slug)
-      setMessage(
-        result.status === 'imported'
-          ? `Imported "${skill.name}".`
-          : result.status === 'updated'
-            ? `Updated "${skill.name}".`
-            : `Already imported "${skill.name}".`
-      )
-      // Re-pull the list so the row's "already imported" badge flips and the action button hides.
-      const refreshed = await listAgentHomeSkills()
-      setSkills(refreshed)
-      onImported()
+      const result = await importAgentHomeSkills(requested)
+      const failures = result.results.filter((item) => item.error !== undefined)
+      const importedCount = result.results.length - failures.length
+
+      if (failures.length === 0) {
+        setMessage(`Imported ${importedCount} skill${importedCount === 1 ? '' : 's'}.`)
+      } else {
+        setMessage(
+          `Imported ${importedCount}; ${failures.length} failed. ${failures[0]?.error ?? ''}`.trim()
+        )
+      }
+      if (importedCount > 0) onImported()
+      applyScan(await listAgentHomeSkills())
     } catch (error) {
-      setMessage(error instanceof Error ? error.message : 'Could not import the skill.')
+      setMessage(error instanceof Error ? error.message : 'Could not import the selected skills.')
     } finally {
-      setImporting(undefined)
+      setImporting(false)
     }
   }
 
   return (
     <div className="p-5">
-      <h2 className="text-base font-semibold text-foreground">From your agent home</h2>
+      <h2 className="text-base font-semibold text-foreground">Import installed skills</h2>
       <p className="mt-0.5 text-[13px] leading-5 text-muted-foreground">
-        Skills under <code className="font-mono">{agentHomeRoot}</code> on this machine. Import
-        one to copy it into Open Science; the source file stays where it is.
+        Scan <code className="font-mono">{SOURCE_INFO.agents.path}</code>
+        {frameworkSource ? (
+          <>
+            {' and '}
+            <code className="font-mono">{frameworkSource.path}</code>
+          </>
+        ) : null}{' '}
+        on this computer. Check skills to copy into Open Science; the originals stay in place.
       </p>
 
       <div className="mt-4 flex items-center gap-2">
@@ -104,9 +163,9 @@ const AgentHomeImportView = ({ onImported }: AgentHomeImportViewProps): React.JS
           type="button"
           variant="outline"
           onClick={() => void rescan()}
-          disabled={busy}
+          disabled={scanning || importing}
         >
-          {busy ? 'Scanning…' : 'Rescan'}
+          {scanning ? 'Scanning…' : 'Rescan'}
         </Button>
         {skills ? (
           <span className="text-xs text-muted-foreground">
@@ -117,40 +176,70 @@ const AgentHomeImportView = ({ onImported }: AgentHomeImportViewProps): React.JS
       {message ? <p className="mt-2 text-xs text-muted-foreground">{message}</p> : null}
 
       {skills && skills.length > 0 ? (
-        <ul className="mt-5 flex flex-col divide-y divide-border">
-          {skills.map((skill) => (
-            <li key={skill.slug} className="flex items-center gap-3 py-2.5">
-              <div className="min-w-0 flex-1">
-                <span className="block truncate text-sm text-foreground">{skill.name}</span>
-                {skill.description ? (
-                  <span className="block truncate text-xs text-muted-foreground">
-                    {skill.description}
+        <div className="mt-5">
+          <div className="flex items-center justify-between">
+            <div className="flex items-center gap-3">
+              <label className="flex items-center gap-1.5 text-xs text-muted-foreground">
+                <input
+                  type="checkbox"
+                  aria-label="Select all installed skills"
+                  checked={allSelected}
+                  onChange={toggleAll}
+                  disabled={selectable.length === 0 || importing}
+                  className="size-4 shrink-0"
+                />
+                Select all
+              </label>
+              <Button
+                type="button"
+                variant="ghost"
+                size="sm"
+                onClick={invertSelection}
+                disabled={selectable.length === 0 || importing}
+              >
+                Invert
+              </Button>
+            </div>
+            <Button
+              type="button"
+              variant="outline"
+              onClick={() => void importSelected()}
+              disabled={importing || selected.size === 0}
+            >
+              {importing ? 'Importing…' : `Import selected (${selected.size})`}
+            </Button>
+          </div>
+
+          <ul className="mt-2 flex flex-col divide-y divide-border">
+            {skills.map((skill) => {
+              const source = SOURCE_INFO[skill.source]
+              return (
+                <li key={skillKey(skill)} className="flex items-center gap-3 py-2.5">
+                  <input
+                    type="checkbox"
+                    aria-label={`Select ${skill.name}`}
+                    checked={selected.has(skillKey(skill))}
+                    onChange={() => toggle(skill)}
+                    disabled={skill.alreadyImported || importing}
+                    className="size-4 shrink-0"
+                  />
+                  <div className="min-w-0 flex-1">
+                    <span className="block truncate text-sm text-foreground">{skill.name}</span>
+                    <span className="block truncate text-xs text-muted-foreground">
+                      {skill.description || skill.slug} · {source.path}
+                    </span>
+                  </div>
+                  <span className="shrink-0 rounded-full bg-muted px-2 py-0.5 text-xs text-muted-foreground">
+                    {skill.alreadyImported ? 'Imported' : source.label}
                   </span>
-                ) : (
-                  <span className="block truncate text-xs text-muted-foreground">{skill.slug}</span>
-                )}
-              </div>
-              {skill.alreadyImported ? (
-                <span className="shrink-0 rounded-full bg-muted px-2 py-0.5 text-xs text-muted-foreground">
-                  Imported
-                </span>
-              ) : (
-                <Button
-                  type="button"
-                  variant="outline"
-                  size="sm"
-                  onClick={() => void importOne(skill)}
-                  disabled={importing !== undefined}
-                >
-                  {importing === skill.slug ? 'Importing…' : 'Import'}
-                </Button>
-              )}
-            </li>
-          ))}
-        </ul>
-      ) : !busy && skills && skills.length === 0 ? (
+                </li>
+              )
+            })}
+          </ul>
+        </div>
+      ) : !scanning && skills && skills.length === 0 ? (
         <p className="mt-5 text-xs text-muted-foreground">
-          No skills found under <code className="font-mono">{agentHomeRoot}</code>.
+          No installed skills found in the scanned global folders.
         </p>
       ) : null}
     </div>

--- a/src/renderer/src/pages/settings/AgentHomeImportView.tsx
+++ b/src/renderer/src/pages/settings/AgentHomeImportView.tsx
@@ -1,6 +1,7 @@
-import { useCallback, useEffect, useMemo, useState } from 'react'
+import { useCallback, useEffect, useMemo, useRef, useState } from 'react'
 
 import type {
+  AgentFrameworkId,
   AgentHomeSkillRef,
   AgentHomeSkillSource,
   AgentHomeSkillView
@@ -31,7 +32,9 @@ const AgentHomeImportView = ({ onImported }: AgentHomeImportViewProps): React.JS
   const [importing, setImporting] = useState(false)
   const [message, setMessage] = useState<string | null>(null)
   const [skills, setSkills] = useState<AgentHomeSkillView[] | null>(null)
+  const [skillsFrameworkId, setSkillsFrameworkId] = useState<AgentFrameworkId | null>(null)
   const [selected, setSelected] = useState<Set<string>>(new Set())
+  const scanGeneration = useRef(0)
 
   const frameworkSource =
     activeFrameworkId === 'codex'
@@ -40,53 +43,76 @@ const AgentHomeImportView = ({ onImported }: AgentHomeImportViewProps): React.JS
         ? SOURCE_INFO.claude
         : undefined
 
-  const applyScan = useCallback((items: AgentHomeSkillView[]): void => {
-    setSkills(items)
-    setSelected(
-      new Set(items.filter((skill) => !skill.alreadyImported).map((skill) => skillKey(skill)))
-    )
-  }, [])
+  const applyScan = useCallback(
+    (items: AgentHomeSkillView[], frameworkId: AgentFrameworkId): void => {
+      setSkills(items)
+      setSkillsFrameworkId(frameworkId)
+      setSelected(
+        new Set(items.filter((skill) => !skill.alreadyImported).map((skill) => skillKey(skill)))
+      )
+    },
+    []
+  )
+
+  // Every scan entry point shares one generation. A framework switch or newer manual/post-import
+  // refresh invalidates older requests, so late results can never restore rows from a stale source.
+  const runScan = useCallback(
+    async (
+      frameworkId: AgentFrameworkId,
+      options: { preserveMessage?: boolean } = {}
+    ): Promise<void> => {
+      if (useSettingsStore.getState().agentFrameworkId !== frameworkId) return
+      const generation = ++scanGeneration.current
+      const isCurrent = (): boolean =>
+        scanGeneration.current === generation &&
+        useSettingsStore.getState().agentFrameworkId === frameworkId
+
+      try {
+        const items = await listAgentHomeSkills()
+        if (!isCurrent()) return
+        if (!options.preserveMessage) setMessage(null)
+        applyScan(items, frameworkId)
+      } catch (error) {
+        if (!isCurrent()) return
+        setSkills(null)
+        setSkillsFrameworkId(frameworkId)
+        setSelected(new Set())
+        setMessage(error instanceof Error ? error.message : 'Scan failed.')
+      } finally {
+        if (isCurrent()) setScanning(false)
+      }
+    },
+    [applyScan, listAgentHomeSkills]
+  )
 
   // Discovery is local and bounded to one directory per visible source, so load eagerly. Including
   // the framework id makes an already-open view follow a framework switch without retaining stale
   // source rows.
   useEffect(() => {
     let cancelled = false
-    listAgentHomeSkills()
-      .then((items) => {
-        if (cancelled) return
-        applyScan(items)
-      })
-      .catch((error) => {
-        if (cancelled) return
-        setMessage(error instanceof Error ? error.message : 'Scan failed.')
-      })
-      .finally(() => {
-        if (cancelled) return
-        setScanning(false)
-      })
+    void Promise.resolve().then(() => {
+      if (!cancelled) void runScan(activeFrameworkId)
+    })
 
     return () => {
       cancelled = true
+      scanGeneration.current += 1
     }
-  }, [activeFrameworkId, applyScan, listAgentHomeSkills])
+  }, [activeFrameworkId, runScan])
+
+  const currentSkills = skillsFrameworkId === activeFrameworkId ? skills : null
+  const isScanning = scanning || skillsFrameworkId !== activeFrameworkId
 
   const selectable = useMemo(
-    () => skills?.filter((skill) => !skill.alreadyImported) ?? [],
-    [skills]
+    () => currentSkills?.filter((skill) => !skill.alreadyImported) ?? [],
+    [currentSkills]
   )
   const allSelected = selectable.length > 0 && selected.size === selectable.length
 
   const rescan = async (): Promise<void> => {
     setScanning(true)
     setMessage(null)
-    try {
-      applyScan(await listAgentHomeSkills())
-    } catch (error) {
-      setMessage(error instanceof Error ? error.message : 'Scan failed.')
-    } finally {
-      setScanning(false)
-    }
+    await runScan(activeFrameworkId)
   }
 
   const toggle = (skill: AgentHomeSkillRef): void =>
@@ -114,9 +140,10 @@ const AgentHomeImportView = ({ onImported }: AgentHomeImportViewProps): React.JS
     })
 
   const importSelected = async (): Promise<void> => {
-    if (importing || selected.size === 0 || !skills) return
+    if (isScanning || importing || selected.size === 0 || !currentSkills) return
+    const frameworkId = activeFrameworkId
 
-    const requested = skills
+    const requested = currentSkills
       .filter((skill) => selected.has(skillKey(skill)) && !skill.alreadyImported)
       .map(({ source, slug }) => ({ source, slug }))
     if (requested.length === 0) return
@@ -127,6 +154,8 @@ const AgentHomeImportView = ({ onImported }: AgentHomeImportViewProps): React.JS
       const result = await importAgentHomeSkills(requested)
       const failures = result.results.filter((item) => item.error !== undefined)
       const importedCount = result.results.length - failures.length
+      if (importedCount > 0) onImported()
+      if (useSettingsStore.getState().agentFrameworkId !== frameworkId) return
 
       if (failures.length === 0) {
         setMessage(`Imported ${importedCount} skill${importedCount === 1 ? '' : 's'}.`)
@@ -135,10 +164,11 @@ const AgentHomeImportView = ({ onImported }: AgentHomeImportViewProps): React.JS
           `Imported ${importedCount}; ${failures.length} failed. ${failures[0]?.error ?? ''}`.trim()
         )
       }
-      if (importedCount > 0) onImported()
-      applyScan(await listAgentHomeSkills())
+      await runScan(frameworkId, { preserveMessage: true })
     } catch (error) {
-      setMessage(error instanceof Error ? error.message : 'Could not import the selected skills.')
+      if (useSettingsStore.getState().agentFrameworkId === frameworkId) {
+        setMessage(error instanceof Error ? error.message : 'Could not import the selected skills.')
+      }
     } finally {
       setImporting(false)
     }
@@ -163,19 +193,21 @@ const AgentHomeImportView = ({ onImported }: AgentHomeImportViewProps): React.JS
           type="button"
           variant="outline"
           onClick={() => void rescan()}
-          disabled={scanning || importing}
+          disabled={isScanning || importing}
         >
-          {scanning ? 'Scanning…' : 'Rescan'}
+          {isScanning ? 'Scanning…' : 'Rescan'}
         </Button>
-        {skills ? (
+        {currentSkills ? (
           <span className="text-xs text-muted-foreground">
-            {skills.length} skill{skills.length === 1 ? '' : 's'} found
+            {currentSkills.length} skill{currentSkills.length === 1 ? '' : 's'} found
           </span>
         ) : null}
       </div>
-      {message ? <p className="mt-2 text-xs text-muted-foreground">{message}</p> : null}
+      {skillsFrameworkId === activeFrameworkId && message ? (
+        <p className="mt-2 text-xs text-muted-foreground">{message}</p>
+      ) : null}
 
-      {skills && skills.length > 0 ? (
+      {currentSkills && currentSkills.length > 0 ? (
         <div className="mt-5">
           <div className="flex items-center justify-between">
             <div className="flex items-center gap-3">
@@ -185,7 +217,7 @@ const AgentHomeImportView = ({ onImported }: AgentHomeImportViewProps): React.JS
                   aria-label="Select all installed skills"
                   checked={allSelected}
                   onChange={toggleAll}
-                  disabled={selectable.length === 0 || importing}
+                  disabled={isScanning || selectable.length === 0 || importing}
                   className="size-4 shrink-0"
                 />
                 Select all
@@ -195,7 +227,7 @@ const AgentHomeImportView = ({ onImported }: AgentHomeImportViewProps): React.JS
                 variant="ghost"
                 size="sm"
                 onClick={invertSelection}
-                disabled={selectable.length === 0 || importing}
+                disabled={isScanning || selectable.length === 0 || importing}
               >
                 Invert
               </Button>
@@ -204,14 +236,14 @@ const AgentHomeImportView = ({ onImported }: AgentHomeImportViewProps): React.JS
               type="button"
               variant="outline"
               onClick={() => void importSelected()}
-              disabled={importing || selected.size === 0}
+              disabled={isScanning || importing || selected.size === 0}
             >
               {importing ? 'Importing…' : `Import selected (${selected.size})`}
             </Button>
           </div>
 
           <ul className="mt-2 flex flex-col divide-y divide-border">
-            {skills.map((skill) => {
+            {currentSkills.map((skill) => {
               const source = SOURCE_INFO[skill.source]
               return (
                 <li key={skillKey(skill)} className="flex items-center gap-3 py-2.5">
@@ -220,7 +252,7 @@ const AgentHomeImportView = ({ onImported }: AgentHomeImportViewProps): React.JS
                     aria-label={`Select ${skill.name}`}
                     checked={selected.has(skillKey(skill))}
                     onChange={() => toggle(skill)}
-                    disabled={skill.alreadyImported || importing}
+                    disabled={isScanning || skill.alreadyImported || importing}
                     className="size-4 shrink-0"
                   />
                   <div className="min-w-0 flex-1">
@@ -237,7 +269,7 @@ const AgentHomeImportView = ({ onImported }: AgentHomeImportViewProps): React.JS
             })}
           </ul>
         </div>
-      ) : !scanning && skills && skills.length === 0 ? (
+      ) : !isScanning && currentSkills && currentSkills.length === 0 ? (
         <p className="mt-5 text-xs text-muted-foreground">
           No installed skills found in the scanned global folders.
         </p>

--- a/src/renderer/src/pages/settings/SettingsPage.tsx
+++ b/src/renderer/src/pages/settings/SettingsPage.tsx
@@ -356,7 +356,7 @@ const SettingsPage = ({ open, onClose }: SettingsPageProps): React.JSX.Element =
             : skillsView.kind === 'import'
               ? 'Import from GitHub'
               : skillsView.kind === 'import-agent-home'
-                ? 'From your agent home'
+                ? 'Import installed skills'
                 : (() => {
                     const name = skills.find((skill) => skill.id === skillsView.id)?.name ?? ''
                     return skillsView.kind === 'edit' ? `Edit ${name}`.trim() : name

--- a/src/renderer/src/pages/settings/SettingsPage.tsx
+++ b/src/renderer/src/pages/settings/SettingsPage.tsx
@@ -172,6 +172,9 @@ const SettingsPage = ({ open, onClose }: SettingsPageProps): React.JSX.Element =
   const consumePendingSkill = useSettingsStore((state) => state.consumePendingSkill)
   const pendingSettingsPanel = useSettingsStore((state) => state.pendingSettingsPanel)
   const consumePendingSettingsPanel = useSettingsStore((state) => state.consumePendingSettingsPanel)
+  const canImportInstalledSkills =
+    typeof window.api.settings.listAgentHomeSkills === 'function' &&
+    typeof window.api.settings.importAgentHomeSkills === 'function'
 
   // Settings navigation history (browser-like back/forward). Panel switches and drill-downs push a
   // new location; the active panel and open sub-views are derived from the current entry.
@@ -728,7 +731,11 @@ const SettingsPage = ({ open, onClose }: SettingsPageProps): React.JSX.Element =
             <div className="min-h-0 flex-1 overflow-y-auto">
               <div className="mx-auto min-h-full w-full max-w-[880px]">
                 {activePanel === 'skills' ? (
-                  <SkillsPanel view={skillsView} onNavigate={navigateSkills} />
+                  <SkillsPanel
+                    view={skillsView}
+                    onNavigate={navigateSkills}
+                    canImportInstalledSkills={canImportInstalledSkills}
+                  />
                 ) : activePanel === 'connectors' ? (
                   connectorsView.kind === 'detail' ? (
                     <ConnectorDetailView id={connectorsView.id} />

--- a/src/renderer/src/pages/settings/SkillsPanel.render.test.tsx
+++ b/src/renderer/src/pages/settings/SkillsPanel.render.test.tsx
@@ -5,6 +5,7 @@ import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest'
 
 import { SkillsPanel } from './SkillsPanel'
 import { createInitialSettingsState, useSettingsStore } from '@/stores/settings-store'
+import { openRadixMenu } from './test-utils'
 
 let container: HTMLDivElement
 let root: Root
@@ -74,6 +75,40 @@ beforeEach(() => {
           alreadyImported: false
         }
       ]
+    }),
+    listAgentHomeSkills: vi.fn().mockResolvedValue([
+      {
+        source: 'agents',
+        slug: 'shared',
+        name: 'Shared',
+        description: 'Shared agent skill',
+        alreadyImported: false
+      },
+      {
+        source: 'claude',
+        slug: 'claude-alpha',
+        name: 'Claude Alpha',
+        description: 'Claude-specific skill',
+        alreadyImported: false
+      },
+      {
+        source: 'agents',
+        slug: 'existing',
+        name: 'Existing',
+        description: 'Already copied',
+        alreadyImported: true
+      }
+    ]),
+    importAgentHomeSkills: vi.fn().mockResolvedValue({
+      results: [
+        {
+          source: 'agents',
+          slug: 'shared',
+          status: 'imported',
+          id: 'imported-shared'
+        }
+      ],
+      skills: []
     })
   })
   container = document.createElement('div')
@@ -177,6 +212,21 @@ describe('SkillsPanel (list view)', () => {
     act(() => remove?.click())
     expect(useSettingsStore.getState().deleteSkill).toHaveBeenCalledWith('personal-mine')
   })
+
+  it('always offers installed-skill import, including for other frameworks', () => {
+    useSettingsStore.setState({ agentFrameworkId: 'opencode' })
+    act(() => {
+      root.render(<SkillsPanel view={{ kind: 'list' }} onNavigate={vi.fn()} />)
+    })
+
+    const addSkill = Array.from(document.body.querySelectorAll<HTMLButtonElement>('button')).find(
+      (button) => button.textContent?.includes('Add skill')
+    )
+    openRadixMenu(addSkill)
+
+    expect(document.body.textContent).toContain('Import installed skills')
+    expect(document.body.textContent).toContain('Scan global skill folders')
+  })
 })
 
 describe('SkillsPanel (sub-views)', () => {
@@ -264,6 +314,40 @@ describe('SkillsPanel (sub-views)', () => {
     expect(useSettingsStore.getState().importSkill).toHaveBeenCalledWith(
       'https://github.com/acme/skills/tree/main/pack/foo'
     )
+  })
+
+  it('preselects available installed skills and batch-imports the checked rows', async () => {
+    await act(async () => {
+      root.render(<SkillsPanel view={{ kind: 'import-agent-home' }} onNavigate={vi.fn()} />)
+      await Promise.resolve()
+      await Promise.resolve()
+    })
+
+    expect(document.body.textContent).toContain('Import installed skills')
+    expect(document.body.textContent).toContain('~/.agents/skills')
+    expect(document.body.textContent).toContain('~/.claude/skills')
+    expect(document.body.textContent).toContain('Import selected (2)')
+    expect(
+      document.body.querySelector<HTMLInputElement>('[aria-label="Select Existing"]')?.disabled
+    ).toBe(true)
+
+    act(() => {
+      document.body.querySelector<HTMLInputElement>('[aria-label="Select Claude Alpha"]')?.click()
+    })
+    expect(document.body.textContent).toContain('Import selected (1)')
+
+    const importSelected = Array.from(
+      document.body.querySelectorAll<HTMLButtonElement>('button')
+    ).find((button) => button.textContent?.includes('Import selected'))
+    await act(async () => {
+      importSelected?.click()
+      await Promise.resolve()
+      await Promise.resolve()
+    })
+
+    expect(useSettingsStore.getState().importAgentHomeSkills).toHaveBeenCalledWith([
+      { source: 'agents', slug: 'shared' }
+    ])
   })
 
   it('renders the upload view and returns to the create view on "Write from scratch instead"', () => {

--- a/src/renderer/src/pages/settings/SkillsPanel.render.test.tsx
+++ b/src/renderer/src/pages/settings/SkillsPanel.render.test.tsx
@@ -228,6 +228,24 @@ describe('SkillsPanel (list view)', () => {
     expect(document.body.textContent).toContain('Import installed skills')
     expect(document.body.textContent).toContain('Scan global skill folders')
   })
+
+  it('hides installed-skill import when the desktop bridge is unavailable', () => {
+    act(() => {
+      root.render(
+        <SkillsPanel
+          view={{ kind: 'list' }}
+          onNavigate={vi.fn()}
+          canImportInstalledSkills={false}
+        />
+      )
+    })
+    const addSkill = Array.from(document.body.querySelectorAll<HTMLButtonElement>('button')).find(
+      (button) => button.textContent?.includes('Add skill')
+    )
+    openRadixMenu(addSkill)
+
+    expect(document.body.textContent).not.toContain('Import installed skills')
+  })
 })
 
 describe('SkillsPanel (sub-views)', () => {

--- a/src/renderer/src/pages/settings/SkillsPanel.render.test.tsx
+++ b/src/renderer/src/pages/settings/SkillsPanel.render.test.tsx
@@ -3,6 +3,7 @@ import { act } from 'react'
 import { createRoot, type Root } from 'react-dom/client'
 import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest'
 
+import type { AgentHomeSkillView } from '../../../../shared/settings'
 import { SkillsPanel } from './SkillsPanel'
 import { createInitialSettingsState, useSettingsStore } from '@/stores/settings-store'
 import { openRadixMenu } from './test-utils'
@@ -348,6 +349,161 @@ describe('SkillsPanel (sub-views)', () => {
     expect(useSettingsStore.getState().importAgentHomeSkills).toHaveBeenCalledWith([
       { source: 'agents', slug: 'shared' }
     ])
+  })
+
+  it('invalidates installed-skill rows while a framework-switch rescan is pending', async () => {
+    let finishCodexScan: (skills: []) => void = () => undefined
+    const pendingCodexScan = new Promise<[]>((resolve) => {
+      finishCodexScan = resolve
+    })
+    const listAgentHomeSkills = vi
+      .fn()
+      .mockResolvedValueOnce([
+        {
+          source: 'claude',
+          slug: 'claude-alpha',
+          name: 'Claude Alpha',
+          description: 'Claude-specific skill',
+          alreadyImported: false
+        }
+      ])
+      .mockReturnValueOnce(pendingCodexScan)
+    useSettingsStore.setState({ agentFrameworkId: 'claude-code', listAgentHomeSkills })
+
+    await act(async () => {
+      root.render(<SkillsPanel view={{ kind: 'import-agent-home' }} onNavigate={vi.fn()} />)
+      await Promise.resolve()
+      await Promise.resolve()
+      await Promise.resolve()
+      await Promise.resolve()
+    })
+    expect(document.body.textContent).toContain('Claude Alpha')
+
+    await act(async () => {
+      useSettingsStore.setState({ agentFrameworkId: 'codex' })
+      await Promise.resolve()
+    })
+
+    expect(document.body.textContent).not.toContain('Claude Alpha')
+    expect(document.body.textContent).toContain('Scanning…')
+    const importSelected = Array.from(
+      document.body.querySelectorAll<HTMLButtonElement>('button')
+    ).find((button) => button.textContent?.includes('Import selected'))
+    expect(importSelected === undefined || importSelected.disabled).toBe(true)
+
+    await act(async () => {
+      finishCodexScan([])
+      await pendingCodexScan
+    })
+  })
+
+  it('does not restore cached rows when switching back before the new scan finishes', async () => {
+    const pendingScan = new Promise<AgentHomeSkillView[]>(() => undefined)
+    const listAgentHomeSkills = vi
+      .fn()
+      .mockResolvedValueOnce([
+        {
+          source: 'claude',
+          slug: 'claude-alpha',
+          name: 'Claude Alpha',
+          description: 'Claude-specific skill',
+          alreadyImported: false
+        }
+      ])
+      .mockReturnValue(pendingScan)
+    useSettingsStore.setState({ agentFrameworkId: 'claude-code', listAgentHomeSkills })
+
+    await act(async () => {
+      root.render(<SkillsPanel view={{ kind: 'import-agent-home' }} onNavigate={vi.fn()} />)
+      await Promise.resolve()
+      await Promise.resolve()
+    })
+    expect(document.body.textContent).toContain('Claude Alpha')
+
+    await act(async () => {
+      useSettingsStore.setState({ agentFrameworkId: 'codex' })
+      await Promise.resolve()
+    })
+    expect(listAgentHomeSkills).toHaveBeenCalledTimes(2)
+
+    act(() => useSettingsStore.setState({ agentFrameworkId: 'claude-code' }))
+
+    expect(document.body.textContent).not.toContain('Claude Alpha')
+    expect(document.body.textContent).toContain('Scanning…')
+  })
+
+  it('ignores an older manual rescan that finishes after a framework switch', async () => {
+    const finishScans: Array<(skills: AgentHomeSkillView[]) => void> = []
+    const listAgentHomeSkills = vi.fn(
+      () =>
+        new Promise<AgentHomeSkillView[]>((resolve) => {
+          finishScans.push(resolve)
+        })
+    )
+    useSettingsStore.setState({ agentFrameworkId: 'claude-code', listAgentHomeSkills })
+
+    await act(async () => {
+      root.render(<SkillsPanel view={{ kind: 'import-agent-home' }} onNavigate={vi.fn()} />)
+      await Promise.resolve()
+    })
+    expect(listAgentHomeSkills).toHaveBeenCalledTimes(1)
+    await act(async () => {
+      finishScans[0]([
+        {
+          source: 'claude',
+          slug: 'claude-alpha',
+          name: 'Claude Alpha',
+          description: 'Claude-specific skill',
+          alreadyImported: false
+        }
+      ])
+      await Promise.resolve()
+      await Promise.resolve()
+    })
+    const rescan = Array.from(document.body.querySelectorAll<HTMLButtonElement>('button')).find(
+      (button) => button.textContent?.trim() === 'Rescan'
+    )
+    expect(rescan).toBeDefined()
+    act(() => rescan?.click())
+    expect(listAgentHomeSkills).toHaveBeenCalledTimes(2)
+
+    await act(async () => {
+      useSettingsStore.setState({ agentFrameworkId: 'codex' })
+      await Promise.resolve()
+    })
+    expect(listAgentHomeSkills).toHaveBeenCalledTimes(3)
+    await act(async () => {
+      finishScans[2]([
+        {
+          source: 'codex',
+          slug: 'codex-beta',
+          name: 'Codex Beta',
+          description: 'Codex-specific skill',
+          alreadyImported: false
+        }
+      ])
+      await Promise.resolve()
+      await Promise.resolve()
+    })
+    expect(document.body.textContent).toContain('Codex Beta')
+
+    await act(async () => {
+      finishScans[1]([
+        {
+          source: 'claude',
+          slug: 'stale-claude',
+          name: 'Stale Claude',
+          description: 'Late result',
+          alreadyImported: false
+        }
+      ])
+      await Promise.resolve()
+      await Promise.resolve()
+    })
+
+    expect(document.body.textContent).toContain('Codex Beta')
+    expect(document.body.textContent).not.toContain('Stale Claude')
+    expect(document.body.textContent).not.toContain('Scanning…')
   })
 
   it('renders the upload view and returns to the create view on "Write from scratch instead"', () => {

--- a/src/renderer/src/pages/settings/SkillsPanel.tsx
+++ b/src/renderer/src/pages/settings/SkillsPanel.tsx
@@ -55,14 +55,6 @@ const SkillsPanel = ({ view, onNavigate }: SkillsPanelProps): React.JSX.Element 
   const setSkillEnabled = useSettingsStore((state) => state.setSkillEnabled)
   const createSkill = useSettingsStore((state) => state.createSkill)
   const deleteSkill = useSettingsStore((state) => state.deleteSkill)
-  // The "From your agent home" entry scans the active agent's global skills directory on disk.
-  // Claude resolves to `~/.claude/skills/` and Codex to `~/.codex/skills/`; opencode reads
-  // skills per-project (no global convention) so the entry is hidden for that framework.
-  const activeFrameworkId = useSettingsStore((state) => state.agentFrameworkId)
-  const showAgentHomeImport = activeFrameworkId === 'claude-code' || activeFrameworkId === 'codex'
-  const agentHomeSubtitle =
-    activeFrameworkId === 'codex' ? '~/.codex/skills/' : '~/.claude/skills/'
-
   const [filter, setFilter] = useState<SourceFilter>('all')
   const [query, setQuery] = useState('')
   const [collapsed, setCollapsed] = useState<Partial<Record<SkillSource, boolean>>>({})
@@ -181,18 +173,16 @@ const SkillsPanel = ({ view, onNavigate }: SkillsPanelProps): React.JSX.Element 
                 <span className="text-xs text-muted-foreground">Add a skill from a repo</span>
               </span>
             </DropdownMenuItem>
-            {showAgentHomeImport ? (
-              <DropdownMenuItem
-                className="gap-2.5"
-                onSelect={() => onNavigate({ kind: 'import-agent-home' })}
-              >
-                <FolderInput className="size-4 shrink-0" aria-hidden="true" />
-                <span className="flex flex-col">
-                  <span>From your agent home</span>
-                  <span className="text-xs text-muted-foreground">{agentHomeSubtitle}</span>
-                </span>
-              </DropdownMenuItem>
-            ) : null}
+            <DropdownMenuItem
+              className="gap-2.5"
+              onSelect={() => onNavigate({ kind: 'import-agent-home' })}
+            >
+              <FolderInput className="size-4 shrink-0" aria-hidden="true" />
+              <span className="flex flex-col">
+                <span>Import installed skills</span>
+                <span className="text-xs text-muted-foreground">Scan global skill folders</span>
+              </span>
+            </DropdownMenuItem>
           </DropdownMenuContent>
         </DropdownMenu>
       </div>

--- a/src/renderer/src/pages/settings/SkillsPanel.tsx
+++ b/src/renderer/src/pages/settings/SkillsPanel.tsx
@@ -56,9 +56,14 @@ const SOURCE_GROUPS: ReadonlyArray<{ source: SkillSource; label: string; subtitl
 type SkillsPanelProps = {
   view: SkillsView
   onNavigate: (view: SkillsView) => void
+  canImportInstalledSkills?: boolean
 }
 
-const SkillsPanel = ({ view, onNavigate }: SkillsPanelProps): React.JSX.Element => {
+const SkillsPanel = ({
+  view,
+  onNavigate,
+  canImportInstalledSkills = true
+}: SkillsPanelProps): React.JSX.Element => {
   const skills = useSettingsStore((state) => state.skills)
   const loadSkills = useSettingsStore((state) => state.loadSkills)
   const setSkillEnabled = useSettingsStore((state) => state.setSkillEnabled)
@@ -112,7 +117,13 @@ const SkillsPanel = ({ view, onNavigate }: SkillsPanelProps): React.JSX.Element 
     return <SkillImportView onImported={() => undefined} />
   }
   if (view.kind === 'import-agent-home') {
-    return <AgentHomeImportView key={agentFrameworkId} onImported={() => undefined} />
+    return canImportInstalledSkills ? (
+      <AgentHomeImportView key={agentFrameworkId} onImported={() => undefined} />
+    ) : (
+      <div className="p-5 text-sm text-muted-foreground">
+        Installed-skill import is available in the desktop app.
+      </div>
+    )
   }
   if (view.kind === 'upload') {
     return (
@@ -183,16 +194,18 @@ const SkillsPanel = ({ view, onNavigate }: SkillsPanelProps): React.JSX.Element 
                 <span className="text-xs text-muted-foreground">Add a skill from a repo</span>
               </span>
             </DropdownMenuItem>
-            <DropdownMenuItem
-              className="gap-2.5"
-              onSelect={() => onNavigate({ kind: 'import-agent-home' })}
-            >
-              <FolderInput className="size-4 shrink-0" aria-hidden="true" />
-              <span className="flex flex-col">
-                <span>Import installed skills</span>
-                <span className="text-xs text-muted-foreground">Scan global skill folders</span>
-              </span>
-            </DropdownMenuItem>
+            {canImportInstalledSkills ? (
+              <DropdownMenuItem
+                className="gap-2.5"
+                onSelect={() => onNavigate({ kind: 'import-agent-home' })}
+              >
+                <FolderInput className="size-4 shrink-0" aria-hidden="true" />
+                <span className="flex flex-col">
+                  <span>Import installed skills</span>
+                  <span className="text-xs text-muted-foreground">Scan global skill folders</span>
+                </span>
+              </DropdownMenuItem>
+            ) : null}
           </DropdownMenuContent>
         </DropdownMenu>
       </div>

--- a/src/renderer/src/pages/settings/SkillsPanel.tsx
+++ b/src/renderer/src/pages/settings/SkillsPanel.tsx
@@ -1,4 +1,13 @@
-import { ChevronDown, Download, FileUp, FolderInput, Pencil, Plus, Search, Trash2 } from 'lucide-react'
+import {
+  ChevronDown,
+  Download,
+  FileUp,
+  FolderInput,
+  Pencil,
+  Plus,
+  Search,
+  Trash2
+} from 'lucide-react'
 import { useEffect, useMemo, useState } from 'react'
 
 import type { SkillSource } from '../../../../shared/settings'
@@ -55,6 +64,7 @@ const SkillsPanel = ({ view, onNavigate }: SkillsPanelProps): React.JSX.Element 
   const setSkillEnabled = useSettingsStore((state) => state.setSkillEnabled)
   const createSkill = useSettingsStore((state) => state.createSkill)
   const deleteSkill = useSettingsStore((state) => state.deleteSkill)
+  const agentFrameworkId = useSettingsStore((state) => state.agentFrameworkId)
   const [filter, setFilter] = useState<SourceFilter>('all')
   const [query, setQuery] = useState('')
   const [collapsed, setCollapsed] = useState<Partial<Record<SkillSource, boolean>>>({})
@@ -102,7 +112,7 @@ const SkillsPanel = ({ view, onNavigate }: SkillsPanelProps): React.JSX.Element 
     return <SkillImportView onImported={() => undefined} />
   }
   if (view.kind === 'import-agent-home') {
-    return <AgentHomeImportView onImported={() => undefined} />
+    return <AgentHomeImportView key={agentFrameworkId} onImported={() => undefined} />
   }
   if (view.kind === 'upload') {
     return (

--- a/src/renderer/src/stores/settings-store.ts
+++ b/src/renderer/src/stores/settings-store.ts
@@ -40,7 +40,9 @@ import type {
   SettingsSnapshot,
   AppIconVariant,
   SkillView,
+  AgentHomeSkillRef,
   AgentHomeSkillView,
+  ImportAgentHomeSkillsResult,
   CreateSkillRequest,
   UpdateSkillRequest,
   ImportSkillResult,
@@ -261,11 +263,10 @@ type SettingsStore = SettingsStoreData & {
   previewSkillZip: (dataBase64: string) => Promise<SkillBundlePreviewResult>
   // Scans a GitHub repo for importable skill directories (does not mutate state).
   scanRepoSkills: (repo: string) => Promise<ScanRepoResult>
-  // Lists the skills under the user's machine-level Claude config (~/.claude/skills/) for the
-  // "From your agent home" import source. Read-only; the import action lives below.
+  // Lists the shared global skills plus the active framework's installed skills.
   listAgentHomeSkills: () => Promise<AgentHomeSkillView[]>
-  // Copies one agent-home skill into the imported-skill store, refreshing the catalog on success.
-  importAgentHomeSkill: (slug: string) => Promise<ImportSkillResult>
+  // Copies checked installed skills into the imported-skill store in one batch.
+  importAgentHomeSkills: (skills: AgentHomeSkillRef[]) => Promise<ImportAgentHomeSkillsResult>
   // Loads the bundled-connector list (enabled/auto-allow + NCBI credential state) from main.
   loadConnectors: () => Promise<void>
   // Toggles one connector; optimistic, then reconciled with the authoritative snapshot from main.
@@ -1095,13 +1096,11 @@ export const useSettingsStore = create<SettingsStore>((set, get) => ({
 
   scanRepoSkills: async (repo) => window.api.settings.scanRepoSkills({ repo }),
 
-  // The agent-home import surface: list is read-only, import copies one skill into the imported
-  // store and refreshes the catalog so the row can disappear (already-imported badge) immediately.
+  // Installed-skill discovery is read-only. Batch import returns the refreshed catalog directly.
   listAgentHomeSkills: async () => window.api.settings.listAgentHomeSkills(),
-  importAgentHomeSkill: async (slug) => {
-    const result = await window.api.settings.importAgentHomeSkill({ slug })
-
-    set(applySnapshot(await window.api.settings.getSettings()))
+  importAgentHomeSkills: async (skills) => {
+    const result = await window.api.settings.importAgentHomeSkills({ skills })
+    set({ skills: result.skills })
 
     return result
   },

--- a/src/renderer/web/api-map.generated.ts
+++ b/src/renderer/web/api-map.generated.ts
@@ -112,7 +112,7 @@ export const WEB_INVOKE_CHANNELS = {
   'settings.getPreflight': 'settings:get-preflight',
   'settings.getSettings': 'settings:get-settings',
   'settings.getSkillDetail': 'settings:get-skill-detail',
-  'settings.importAgentHomeSkill': 'settings:import-agent-home-skill',
+  'settings.importAgentHomeSkills': 'settings:import-agent-home-skills',
   'settings.importSkill': 'settings:import-skill',
   'settings.importSkillZip': 'settings:import-skill-zip',
   'settings.importSkillZipBatch': 'settings:import-skill-zip-batch',

--- a/src/renderer/web/bootstrap.ts
+++ b/src/renderer/web/bootstrap.ts
@@ -3,6 +3,7 @@ import { WEB_EVENT_CHANNELS, WEB_INVOKE_CHANNELS } from './api-map.generated'
 type BootstrapInfo = {
   platform: string
   versions: { electron: string; chrome: string; node: string }
+  rpcChannels: string[]
 }
 
 type Listener = (payload: unknown) => void
@@ -142,8 +143,10 @@ const installWebApi = async (): Promise<void> => {
     platform: bootstrap.platform,
     getRuntimeVersions: () => bootstrap.versions
   }
+  const availableRpcChannels = new Set(bootstrap.rpcChannels)
 
   for (const [path, channel] of Object.entries(WEB_INVOKE_CHANNELS)) {
+    if (!availableRpcChannels.has(channel)) continue
     assignPath(api, path, (...args: unknown[]) => invoke(channel, transformArgs(path, args)))
   }
   for (const [path, channel] of Object.entries(WEB_EVENT_CHANNELS)) {

--- a/src/shared/settings.ts
+++ b/src/shared/settings.ts
@@ -869,8 +869,8 @@ export type AgentHomeSkillView = {
   // Parsed from SKILL.md frontmatter; falls back to the slug when the name is absent or unparseable.
   name: string
   description: string
-  // True when an imported-skill record with the same slug already exists, so the UI can mark it as
-  // already pulled in and disable its checkbox.
+  // True when either the same source, slug, and content are already represented by an imported-skill
+  // record, or a controlled legacy slug fallback claims this row, so the UI can disable its checkbox.
   alreadyImported: boolean
 }
 
@@ -892,7 +892,7 @@ export type ImportAgentHomeSkillItemResult =
       id: string
       error?: undefined
     })
-  | (AgentHomeSkillRef & {
+  | (Partial<AgentHomeSkillRef> & {
       status?: undefined
       id?: undefined
       error: string

--- a/src/shared/settings.ts
+++ b/src/shared/settings.ts
@@ -854,31 +854,53 @@ export type ScanRepoRequest = {
   repo: string
 }
 
-// One skill the user's machine-level Claude config (typically ~/.claude/skills/<slug>/) contains.
-// Surfaced for the "From your agent home" import source so the renderer can list what's available
-// without reading the skill bodies; importing is a separate call (see service.importAgentHomeSkill).
+// A known user-level source that may contain installed skills. The shared Agents directory is
+// available for every framework; Claude and Codex directories are available only while that
+// framework is active.
+export type AgentHomeSkillSource = 'agents' | 'claude' | 'codex'
+
+// One skill found in a user-level source. Main returns renderer-safe metadata only: the source id and
+// slug are sufficient to request an import, while the absolute host path remains in the main process.
 export type AgentHomeSkillView = {
+  source: AgentHomeSkillSource
   // The directory name under the agent's skills/ dir. Used as the candidate slug and as the
   // identifier on disk; not a renderer-visible name (the SKILL.md frontmatter supplies that).
   slug: string
-  // Parsed from the skill's SKILL.md frontmatter; falls back to the slug when the file is missing
-  // or unparseable so the UI can still list a row for it.
+  // Parsed from SKILL.md frontmatter; falls back to the slug when the name is absent or unparseable.
   name: string
   description: string
-  // Absolute path to the source directory under the agent's home. The renderer never exposes this
-  // to the user; main uses it to copy on import.
-  path: string
-  // True when an imported-skill record with the same slug (or matching content signature) already
-  // exists, so the UI can mark it as already pulled in and skip the import button.
+  // True when an imported-skill record with the same slug already exists, so the UI can mark it as
+  // already pulled in and disable its checkbox.
   alreadyImported: boolean
 }
 
-// Request to import a single skill from the user's agent home into Open Science. `slug` is the
-// top-level directory name returned by listAgentHomeSkills; the main-process service re-derives
-// the absolute path against the active agent's home so a renderer-supplied path cannot reach
-// outside the configured skills directory.
-export type ImportAgentHomeSkillRequest = {
+export type AgentHomeSkillRef = {
+  source: AgentHomeSkillSource
   slug: string
+}
+
+// Batch import selected user-level skills. Main re-derives every absolute path from the trusted
+// source id + slug pair, so the renderer cannot use this interface to read arbitrary host paths.
+export type ImportAgentHomeSkillsRequest = {
+  skills: AgentHomeSkillRef[]
+}
+
+// One bad or concurrently removed source does not abort the rest of a checked batch.
+export type ImportAgentHomeSkillItemResult =
+  | (AgentHomeSkillRef & {
+      status: 'imported' | 'unchanged' | 'updated'
+      id: string
+      error?: undefined
+    })
+  | (AgentHomeSkillRef & {
+      status?: undefined
+      id?: undefined
+      error: string
+    })
+
+export type ImportAgentHomeSkillsResult = {
+  results: ImportAgentHomeSkillItemResult[]
+  skills: SkillView[]
 }
 
 // One skill directory found by a repo scan, with an importable URL and whether it's already imported.


### PR DESCRIPTION
## Problem

Open Science runs agent frameworks with isolated profiles, so skills installed in a user's global agent directories are not available inside a project unless they are copied into the project-managed skill store.

## Proposed change

- Keep an "Import installed skills" entry visible in Settings > Skills.
- Always scan `~/.agents/skills`; additionally scan `~/.codex/skills` for Codex and `~/.claude/skills` for Claude Code.
- Let users select multiple discovered skills and import them through the existing managed-skill flow.
- Resolve source paths in the main process, support safe cross-root skill symlinks, and reject traversal or links outside the currently allowed global roots.
- Return per-skill results so one invalid selection does not abort the remaining imports.

## Scope and non-goals

- Sources are read from the local user home on macOS, Linux, and Windows through Node's home/path APIs.
- The import is explicit and copies content; it does not sync later source changes.
- Inactive framework-specific directories are not scanned.
- Absolute source paths are not exposed to the renderer.

## Acceptance criteria and validation

- `npm run typecheck`
- `npm run lint` (0 errors; 34 pre-existing warnings)
- `npm test` (486 files passed, 10 skipped; 6689 tests passed, 112 skipped)
- `npm run check:web-api-map`
- Focused service, repository, IPC, and renderer tests cover source routing, multi-select import, partial failures, traversal, and symlink containment.

## Review focus

- Framework-to-source routing and realpath containment in the settings service.
- Safe handling of Claude symlinks into the shared `~/.agents/skills` root.
- Batch import result handling and selection behavior in the settings UI.
