### PR TITLE
fix(agent-framework): isolate OpenCode external skills

### DIFF
--- a/src/main/agent-framework/opencode.test.ts
+++ b/src/main/agent-framework/opencode.test.ts
@@ -98,6 +98,19 @@ describe('opencodeFramework.prepareModelConfig', () => {
     expect(config.env?.OPENCODE_CONFIG_CONTENT).toBeTruthy()
   })
 
+  it('disables external skill discovery so host-global skills cannot enter the app catalog', () => {
+    const config = opencodeFramework.prepareModelConfig(
+      { type: 'custom', baseUrl: 'https://gw/v1', model: 'm', key: 'k' },
+      { storageRoot: '/data', executablePath: '/bin/opencode' }
+    )
+
+    // OpenCode scans ~/.agents/skills and ~/.claude/skills independently from its XDG config.
+    // Keep both supported kill switches explicit so a host-global skill cannot be advertised in
+    // the app session even if OpenCode's internal/test-only home override changes or is ignored.
+    expect(config.env?.OPENCODE_DISABLE_EXTERNAL_SKILLS).toBe('true')
+    expect(config.env?.OPENCODE_DISABLE_CLAUDE_CODE_SKILLS).toBe('true')
+  })
+
   it('disables project config loading so a repo cannot inject opencode.json / .opencode config', () => {
     const config = opencodeFramework.prepareModelConfig(
       { type: 'custom', baseUrl: 'https://gw/v1', model: 'm', key: 'k' },

--- a/src/main/agent-framework/opencode.ts
+++ b/src/main/agent-framework/opencode.ts
@@ -360,9 +360,15 @@ export const opencodeFramework: AgentFramework = {
         // empty dir so the user's `~/.opencode` cannot inject config/providers/permissions — the last
         // non-repo override surface left after OPENCODE_DISABLE_PROJECT_CONFIG closes project config. This
         // changes ONLY opencode's notion of home; the child's real HOME is untouched, so shell/git tools
-        // behave normally. Tradeoff: opencode also won't read `~/.claude/CLAUDE.md` or home-level skills —
-        // acceptable since the app owns the whole opencode config.
+        // behave normally. The explicit skill flags below enforce the skill boundary independently.
         OPENCODE_TEST_HOME: opencodeHomeDir(ctx.storageRoot),
+        // OpenCode discovers `skills/**/SKILL.md` under both `.agents` and `.claude`, walking from the
+        // session cwd to the worktree root AND scanning those directories under its notion of home.
+        // OPENCODE_DISABLE_PROJECT_CONFIG does not cover this separate discovery path. Disable external
+        // discovery at the source so only the skills the app materialized into the isolated XDG config
+        // are advertised. Keep the narrower Claude flag explicit as defense in depth for that source.
+        OPENCODE_DISABLE_EXTERNAL_SKILLS: 'true',
+        OPENCODE_DISABLE_CLAUDE_CODE_SKILLS: 'true',
         // Refuse to load ANY project config: this stops the session cwd's opencode.json / opencode.jsonc
         // (walked up to the worktree root) and its .opencode/ directory from injecting config at all. A
         // repo therefore cannot flip permission["*"] to "allow", add an exact-id "allow" rule for an MCP


### PR DESCRIPTION
## Problem

OpenCode discovers skills under project and home .agents/.claude directories through a loader that is independent of project-config loading. Open Science disabled project config and redirected OpenCode home, but did not set the dedicated external-skill discovery flags, leaving the catalog boundary dependent on an internal/test-only home override. When that boundary is not honored, host-global skills are advertised alongside the app-managed catalog and the reported count is inflated.

## Proposed change

- Set OPENCODE_DISABLE_EXTERNAL_SKILLS for every OpenCode session.
- Set OPENCODE_DISABLE_CLAUDE_CODE_SKILLS explicitly as defense in depth for the Claude-compatible source.
- Add a regression test at the framework adapter seam that asserts both flags reach the spawn environment.

## Scope and non-goals

This keeps Open Science skills and connector docs materialized in the isolated XDG config discoverable. It does not change the app skill catalog, skill enablement settings, the built-in OpenCode skill, or other agent frameworks.

## Acceptance criteria and validation

- Host-global .agents/.claude skills cannot enter an OpenCode app session.
- App-materialized skills remain discoverable from the isolated config directory.
- npm run typecheck
- npm run lint (0 errors; existing warnings only)
- npm run test (486 passed files, 10 skipped; 6688 passed tests, 112 skipped)

## Review focus

Please verify the OpenCode environment-variable boundary and that keeping both disable flags explicit is the desired defense-in-depth policy.