### PR TITLE
feat(skills): preview import candidates

### DIFF
--- a/src/main/settings/ipc.test.ts
+++ b/src/main/settings/ipc.test.ts
@@ -64,7 +64,9 @@ type FakeSettingsService = Record<
   | 'updateSkill'
   | 'deleteSkill'
   | 'importSkillZipBatch'
+  | 'previewGitHubSkill'
   | 'listAgentHomeSkills'
+  | 'previewAgentHomeSkill'
   | 'importAgentHomeSkills'
   | 'setConnectorEnabled',
   ReturnType<typeof vi.fn>
@@ -143,7 +145,9 @@ const createFakeService = (): FakeSettingsService => ({
   updateSkill: vi.fn().mockResolvedValue([]),
   deleteSkill: vi.fn().mockResolvedValue([]),
   importSkillZipBatch: vi.fn().mockResolvedValue({ results: [], skills: [] }),
+  previewGitHubSkill: vi.fn().mockResolvedValue({ name: 'GitHub preview' }),
   listAgentHomeSkills: vi.fn().mockResolvedValue([]),
+  previewAgentHomeSkill: vi.fn().mockResolvedValue({ name: 'Installed preview' }),
   importAgentHomeSkills: vi.fn().mockResolvedValue({ results: [], skills: [] }),
   setConnectorEnabled: vi.fn().mockResolvedValue({ connectors: [] })
 })
@@ -599,6 +603,22 @@ describe('settings IPC handlers', () => {
     expect(service.importAgentHomeSkills).toHaveBeenCalledWith(request)
     expect(forwarded).toBe(result)
     expect(onSkillsChanged).toHaveBeenCalledOnce()
+  })
+
+  it('routes read-only candidate previews without firing the skills-changed callback', async () => {
+    handlers.clear()
+    const service = createFakeService()
+    const onSkillsChanged = vi.fn()
+    registerSettingsIpcHandlers({ service: asService(service), onSkillsChanged })
+    const github = { url: 'https://github.com/acme/skills/tree/main/foo' }
+    const installed = { source: 'agents', slug: 'foo' }
+
+    await invoke('settings:preview-github-skill', github)
+    await invoke('settings:preview-agent-home-skill', installed)
+
+    expect(service.previewGitHubSkill).toHaveBeenCalledWith(github)
+    expect(service.previewAgentHomeSkill).toHaveBeenCalledWith(installed)
+    expect(onSkillsChanged).not.toHaveBeenCalled()
   })
 
   it('registers the OpenCode / framework-switch channels', () => {

--- a/src/main/settings/ipc.ts
+++ b/src/main/settings/ipc.ts
@@ -19,6 +19,8 @@ import {
   type ImportSkillRequest,
   type ImportSkillZipRequest,
   type ImportSkillZipBatchRequest,
+  type PreviewAgentHomeSkillRequest,
+  type PreviewGitHubSkillRequest,
   type PreviewSkillZipRequest,
   type ScanRepoRequest,
   type InstallClaudeRequest,
@@ -470,12 +472,19 @@ const registerSettingsIpcHandlers = ({
   ipcMain.handle('settings:preview-skill-zip', (_event, request: PreviewSkillZipRequest) =>
     service.previewSkillZip(request)
   )
+  ipcMain.handle('settings:preview-github-skill', (_event, request: PreviewGitHubSkillRequest) =>
+    service.previewGitHubSkill(request)
+  )
   ipcMain.handle('settings:scan-repo-skills', (_event, request: ScanRepoRequest) =>
     service.scanRepoSkills(request)
   )
   // Lists the generic global skill source plus the active framework's source. Read-only — the
   // renderer submits checked source-id/slug pairs through the batch import handler below.
   ipcMain.handle('settings:list-agent-home-skills', () => service.listAgentHomeSkills())
+  ipcMain.handle(
+    'settings:preview-agent-home-skill',
+    (_event, request: PreviewAgentHomeSkillRequest) => service.previewAgentHomeSkill(request)
+  )
   ipcMain.handle(
     'settings:import-agent-home-skills',
     async (_event, request: ImportAgentHomeSkillsRequest) => {

--- a/src/main/settings/service.test.ts
+++ b/src/main/settings/service.test.ts
@@ -3256,6 +3256,29 @@ describe('SettingsService: skills', () => {
 
     expect(scanRepo).toHaveBeenCalledWith('o/r', netFetch)
   })
+
+  it('previews a selected GitHub skill through the proxy-aware bounded repository path', async () => {
+    const previewGitHubSkill = vi.fn().mockResolvedValue({
+      name: 'Demo',
+      description: 'Remote skill',
+      metadata: { license: 'MIT' },
+      body: '# Demo',
+      files: ['SKILL.md']
+    })
+    const service = new SettingsService({
+      repository,
+      storageRoot,
+      // eslint-disable-next-line @typescript-eslint/no-explicit-any
+      userSkills: { previewGitHubSkill } as any
+    })
+    const url = 'https://github.com/o/r/tree/main/skills/demo'
+
+    await expect(service.previewGitHubSkill({ url })).resolves.toMatchObject({
+      sourceLabel: 'github.com/o/r/skills/demo',
+      body: '# Demo'
+    })
+    expect(previewGitHubSkill).toHaveBeenCalledWith(url, netFetch)
+  })
 })
 
 describe('installClaude (app-managed source)', () => {
@@ -4023,6 +4046,54 @@ describe('SettingsService: listAgentHomeSkills framework routing', () => {
     await expect(service.listAgentHomeSkills()).rejects.toMatchObject({ code: 'ENOTDIR' })
   })
 
+  it('previews an installed candidate through its trusted source and slug without exposing host paths', async () => {
+    const userClaudeDir = await mkdtemp(join(tmpdir(), 'os-preview-agent-claude-'))
+    await seedSkill(userClaudeDir, 'alpha')
+    await writeFile(
+      join(userClaudeDir, 'skills', 'alpha', 'SKILL.md'),
+      '---\nname: Alpha\ndescription: Preview me\nauthor: Ada\n---\n# Safe body\n'
+    )
+    const service = createService(undefined, { userClaudeDir })
+    await repository.setAgentFramework('claude-code')
+
+    const preview = await service.previewAgentHomeSkill({ source: 'claude', slug: 'alpha' })
+
+    expect(preview).toEqual({
+      name: 'Alpha',
+      description: 'Preview me',
+      sourceLabel: '~/.claude/skills/alpha',
+      metadata: { author: 'Ada' },
+      body: '# Safe body\n',
+      files: ['SKILL.md']
+    })
+    expect(JSON.stringify(preview)).not.toContain(userClaudeDir)
+  })
+
+  it('redacts the installed skill host path from preview errors', async () => {
+    const userClaudeDir = await mkdtemp(join(tmpdir(), 'os-preview-agent-error-'))
+    await seedSkill(userClaudeDir, 'alpha')
+    const hostSkillPath = join(userClaudeDir, 'skills', 'alpha')
+    const previewAgentHomeSkill = vi
+      .fn()
+      .mockRejectedValue(new Error(`EACCES: ${join(hostSkillPath, 'SKILL.md')}`))
+    const service = new SettingsService({
+      repository,
+      storageRoot,
+      userClaudeDir,
+      // eslint-disable-next-line @typescript-eslint/no-explicit-any
+      userSkills: { previewAgentHomeSkill } as any
+    })
+    await repository.setAgentFramework('claude-code')
+
+    const error = await service
+      .previewAgentHomeSkill({ source: 'claude', slug: 'alpha' })
+      .catch((reason: unknown) => reason)
+
+    expect(error).toBeInstanceOf(Error)
+    expect((error as Error).message).not.toContain(userClaudeDir)
+    expect((error as Error).message).toContain('~/.claude/skills/alpha/SKILL.md')
+  })
+
   it('scans shared and Codex homes when the active framework is codex', async () => {
     const userClaudeDir = await mkdtemp(join(tmpdir(), 'os-list-agent-claude-'))
     const userCodexDir = await mkdtemp(join(tmpdir(), 'os-list-agent-codex-'))
@@ -4771,6 +4842,10 @@ describe('SettingsService: importAgentHomeSkills realpath containment', () => {
     const result = await service.importAgentHomeSkills({
       skills: [{ source: 'claude', slug: 'payload' }]
     })
+
+    await expect(
+      service.previewAgentHomeSkill({ source: 'claude', slug: 'payload' })
+    ).rejects.toThrow(/outside its source/)
 
     expect(result.results[0]).toMatchObject({
       error: expect.stringMatching(/outside its source/)

--- a/src/main/settings/service.ts
+++ b/src/main/settings/service.ts
@@ -56,9 +56,12 @@ import type {
   ImportSkillZipRequest,
   ImportSkillZipBatchRequest,
   ImportSkillZipBatchResult,
+  PreviewAgentHomeSkillRequest,
+  PreviewGitHubSkillRequest,
   PreviewSkillZipRequest,
   ReasoningEffort,
   SkillBundlePreviewResult,
+  SkillImportPreviewContent,
   ScanRepoRequest,
   ScanRepoResult,
   UpdateSkillRequest,
@@ -182,6 +185,7 @@ import { renderConnectorInstructions } from '../connectors/skill-doc'
 import { syncConnectorSkillDocs } from '../connectors/provision'
 import { SkillRegistry, type BundledSkill } from '../skills/registry'
 import { SAFE_SLUG, UserSkillRepository } from '../skills/user-skill-repository'
+import { parseGitHubSkillUrl } from '../skills/github-import'
 import { netFetch, netFetchStandard } from '../skills/net-fetch'
 import { decodeBoundedBase64, SKILL_IMPORT_LIMITS } from '../skills/import-limits'
 import { readSkillFile } from '../skills/skill-files'
@@ -1125,6 +1129,20 @@ class SettingsService {
     )
   }
 
+  // Lazily loads one selected GitHub candidate. The repository's bounded helper downloads only its
+  // SKILL.md; the display label is reconstructed from the public URL and contains no host paths.
+  async previewGitHubSkill(request: PreviewGitHubSkillRequest): Promise<SkillImportPreviewContent> {
+    const location = parseGitHubSkillUrl(request.url)
+    if (!location) throw new Error('Not a recognizable GitHub URL.')
+    const preview = await this.userSkills.previewGitHubSkill(request.url, netFetch)
+    const suffix = location.path ? `/${location.path}` : ''
+
+    return {
+      ...preview,
+      sourceLabel: `github.com/${location.owner}/${location.repo}${suffix}`
+    }
+  }
+
   // Scans a GitHub repo for importable skill directories (marking already-imported ones).
   async scanRepoSkills(request: ScanRepoRequest): Promise<ScanRepoResult> {
     return { skills: await this.userSkills.scanRepo(request.repo, netFetch) }
@@ -1208,6 +1226,50 @@ class SettingsService {
     }
 
     return discovered.map((item) => item.skill)
+  }
+
+  // Lazily loads one selected installed candidate through the same trusted source routing, realpath
+  // containment, and canonical top-level identity used by import. Only a tilde display label leaves
+  // main; the resolved absolute path stays private to this process.
+  async previewAgentHomeSkill(
+    request: PreviewAgentHomeSkillRequest
+  ): Promise<SkillImportPreviewContent> {
+    const settings = await this.repository.getSettings()
+    const framework = settings.agentFrameworkId ?? DEFAULT_AGENT_FRAMEWORK_ID
+    const availableSources = this.resolveAgentHomeSkillDirs(framework)
+    const requestedSourcePath = join(
+      availableSources.find((candidate) => candidate.source === request.source)?.dir ?? '',
+      request.slug
+    )
+    const sourcePath = await this.resolveAgentHomeSkillPath(
+      request.source,
+      request.slug,
+      availableSources
+    )
+    const canonical = await this.canonicalAgentHomeSkillRef(sourcePath, availableSources)
+    if (!canonical) {
+      throw new Error('Refusing to preview installed skill outside a top-level skill directory.')
+    }
+    const sourceRoot =
+      canonical.source === 'agents'
+        ? '~/.agents/skills'
+        : canonical.source === 'claude'
+          ? '~/.claude/skills'
+          : '~/.codex/skills'
+    const sourceLabel = `${sourceRoot}/${canonical.slug}`
+
+    try {
+      const preview = await this.userSkills.previewAgentHomeSkill(sourcePath)
+      return { ...preview, sourceLabel }
+    } catch (error) {
+      const message =
+        error instanceof Error ? error.message : 'Could not preview the installed skill.'
+      const redacted = [sourcePath, requestedSourcePath].reduce(
+        (value, hostPath) => (hostPath ? value.split(hostPath).join(sourceLabel) : value),
+        message
+      )
+      throw new Error(redacted)
+    }
   }
 
   // The generic source is always available. A framework-specific source is additive, not a gate on

--- a/src/main/skills/github-import.test.ts
+++ b/src/main/skills/github-import.test.ts
@@ -4,6 +4,7 @@ import { SKILL_IMPORT_LIMITS } from './import-limits'
 import {
   parseGitHubSkillUrl,
   parseGitHubRepo,
+  fetchSkillPreview,
   fetchSkillFiles,
   scanRepoForSkills,
   type FetchLike
@@ -82,6 +83,91 @@ const fakeFetch = (files: Record<string, string>): FetchLike => {
     }
   }
 }
+
+describe('fetchSkillPreview', () => {
+  it('lists candidate files while downloading only SKILL.md', async () => {
+    const downloads: string[] = []
+    const fetcher: FetchLike = async (url) => {
+      if (url.includes('/contents/')) {
+        return {
+          ok: true,
+          status: 200,
+          json: async () => [
+            {
+              type: 'file',
+              name: 'SKILL.md',
+              path: 'pack/foo/SKILL.md',
+              download_url: 'https://raw/SKILL.md'
+            },
+            {
+              type: 'file',
+              name: 'guide.md',
+              path: 'pack/foo/references/guide.md',
+              download_url: 'https://raw/guide.md'
+            }
+          ],
+          arrayBuffer: async () => new ArrayBuffer(0)
+        }
+      }
+
+      downloads.push(url)
+      const bytes = new TextEncoder().encode('# Preview body')
+      return {
+        ok: true,
+        status: 200,
+        json: async () => ({}),
+        arrayBuffer: async () =>
+          bytes.buffer.slice(bytes.byteOffset, bytes.byteOffset + bytes.byteLength)
+      }
+    }
+
+    await expect(
+      fetchSkillPreview({ owner: 'acme', repo: 'skills', ref: 'main', path: 'pack/foo' }, fetcher)
+    ).resolves.toEqual({
+      skillMd: Buffer.from('# Preview body'),
+      files: ['SKILL.md', 'references/guide.md']
+    })
+    expect(downloads).toEqual(['https://raw/SKILL.md'])
+  })
+
+  it('rejects an oversized SKILL.md before buffering its body', async () => {
+    let bodyRead = false
+    const fetcher: FetchLike = async (url) => {
+      if (url.includes('/contents/')) {
+        return {
+          ok: true,
+          status: 200,
+          json: async () => [
+            {
+              type: 'file',
+              name: 'SKILL.md',
+              path: 'pack/foo/SKILL.md',
+              download_url: 'https://raw/SKILL.md'
+            }
+          ],
+          arrayBuffer: async () => new ArrayBuffer(0)
+        }
+      }
+      return {
+        ok: true,
+        status: 200,
+        json: async () => ({}),
+        headers: {
+          get: (name) => (name.toLowerCase() === 'content-length' ? String(OVER_FILE) : null)
+        },
+        arrayBuffer: async () => {
+          bodyRead = true
+          return new ArrayBuffer(0)
+        }
+      }
+    }
+
+    await expect(
+      fetchSkillPreview({ owner: 'acme', repo: 'skills', ref: 'main', path: 'pack/foo' }, fetcher)
+    ).rejects.toThrow(/per-file limit/)
+    expect(bodyRead).toBe(false)
+  })
+})
 
 describe('fetchSkillFiles', () => {
   it('downloads files relative to the skill directory', async () => {

--- a/src/main/skills/github-import.ts
+++ b/src/main/skills/github-import.ts
@@ -113,6 +113,76 @@ const contentsUrl = (location: GitHubSkillLocation, path: string): string => {
 
 type ContentsEntry = { type: string; name: string; path: string; download_url: string | null }
 
+export type FetchedSkillPreview = { skillMd: Buffer; files: string[] }
+
+// Lists one selected skill directory and downloads only its root SKILL.md. Repo scans intentionally
+// return metadata only; opening a candidate calls this helper lazily. Directory depth, file count,
+// request count, and the downloaded body all use the same caps as full GitHub import.
+const fetchSkillPreview = async (
+  location: GitHubSkillLocation,
+  fetchImpl: FetchLike
+): Promise<FetchedSkillPreview> => {
+  const rootPrefix = location.path ? `${location.path}/` : ''
+  const files: string[] = []
+  let skillMd: Buffer | undefined
+  let requests = 0
+
+  const request: FetchLike = (url, init) => {
+    requests += 1
+    if (requests > SKILL_IMPORT_LIMITS.maxRequests) {
+      throw new Error(`Skill preview exceeded ${SKILL_IMPORT_LIMITS.maxRequests} requests.`)
+    }
+    return fetchImpl(url, init)
+  }
+
+  const walk = async (path: string, depth: number): Promise<void> => {
+    if (depth > SKILL_IMPORT_LIMITS.maxDepth) {
+      throw new Error(`Skill directory nesting exceeds ${SKILL_IMPORT_LIMITS.maxDepth} levels.`)
+    }
+
+    const response = await request(contentsUrl(location, path), { headers: GITHUB_HEADERS })
+    if (!response.ok) {
+      throw new Error(`GitHub API request failed (${response.status}) for ${path || 'repo root'}`)
+    }
+
+    const payload = (await response.json()) as ContentsEntry | ContentsEntry[]
+    const entries = Array.isArray(payload) ? payload : [payload]
+    for (const entry of entries) {
+      if (entry.type === 'dir') {
+        await walk(entry.path, depth + 1)
+        continue
+      }
+      if (entry.type !== 'file') continue
+      if (files.length >= SKILL_IMPORT_LIMITS.maxFiles) {
+        throw new Error(`Skill has too many files (limit ${SKILL_IMPORT_LIMITS.maxFiles}).`)
+      }
+
+      const relativePath = entry.path.startsWith(rootPrefix)
+        ? entry.path.slice(rootPrefix.length)
+        : entry.name
+      files.push(relativePath)
+
+      if (relativePath.toLowerCase() !== 'skill.md' || !entry.download_url) continue
+      const raw = await request(entry.download_url, { headers: { 'User-Agent': 'open-science' } })
+      if (!raw.ok) throw new Error(`Failed to download ${entry.path} (${raw.status})`)
+
+      const tooLarge = (): never => {
+        throw new Error(
+          `File ${entry.path} exceeds the ${SKILL_IMPORT_LIMITS.maxFileBytes}-byte per-file limit.`
+        )
+      }
+      const declared = Number(raw.headers?.get('content-length') ?? '')
+      if (Number.isFinite(declared) && declared > SKILL_IMPORT_LIMITS.maxFileBytes) tooLarge()
+      skillMd = await readBounded(raw, SKILL_IMPORT_LIMITS.maxFileBytes, tooLarge)
+    }
+  }
+
+  await walk(location.path, 0)
+  if (!skillMd) throw new Error('No SKILL.md found at the linked location.')
+
+  return { skillMd, files: files.sort() }
+}
+
 // Recursively downloads every file under a skill directory via the public GitHub contents API.
 const fetchSkillFiles = async (
   location: GitHubSkillLocation,
@@ -270,4 +340,10 @@ const scanRepoForSkills = async (
   return skills
 }
 
-export { parseGitHubSkillUrl, parseGitHubRepo, fetchSkillFiles, scanRepoForSkills }
+export {
+  parseGitHubSkillUrl,
+  parseGitHubRepo,
+  fetchSkillPreview,
+  fetchSkillFiles,
+  scanRepoForSkills
+}

--- a/src/main/skills/user-skill-repository.test.ts
+++ b/src/main/skills/user-skill-repository.test.ts
@@ -8,6 +8,7 @@ import {
   rm,
   stat,
   symlink,
+  truncate,
   writeFile
 } from 'node:fs/promises'
 import { tmpdir } from 'node:os'
@@ -336,6 +337,32 @@ describe('UserSkillRepository', () => {
     expect(await new UserSkillRepository(await makeStorage()).list()).toEqual([])
   })
 
+  it('previews one selected GitHub skill without importing it', async () => {
+    const repo = new UserSkillRepository(await makeStorage())
+    const preview = await repo.previewGitHubSkill(
+      SKILL_URL,
+      fakeFetch(
+        [
+          '---',
+          'name: Foo',
+          'description: A remote skill.',
+          'license: MIT',
+          '---',
+          '# Preview body'
+        ].join('\n')
+      )
+    )
+
+    expect(preview).toEqual({
+      name: 'Foo',
+      description: 'A remote skill.',
+      metadata: { license: 'MIT' },
+      body: '# Preview body',
+      files: ['SKILL.md']
+    })
+    expect(await repo.list()).toEqual([])
+  })
+
   it('imports a .zip bundle (SKILL.md + files) and dedups an identical re-import', async () => {
     const storage = await makeStorage()
     const repo = new UserSkillRepository(storage)
@@ -489,6 +516,8 @@ describe('UserSkillRepository', () => {
         {
           name: 'Bundled',
           description: 'A test bundle.',
+          metadata: {},
+          body: 'body',
           files: ['SKILL.md', 'scripts/run.py'],
           alreadyImported: false,
           replaceableId: undefined,
@@ -1292,6 +1321,60 @@ describe('UserSkillRepository: agent-home import', () => {
     expect(items.every((i) => i.alreadyImported === false)).toBe(true)
     expect(items[0].path).toBe(join(home, 'skills', items[0].slug))
   })
+
+  it('previews an installed skill body, metadata, and file names without importing it', async () => {
+    const repo = new UserSkillRepository(await makeStorage())
+    const home = await mkdtemp(join(tmpdir(), 'os-preview-agent-'))
+    const source = await seedSkill(home, 'alpha')
+    await writeFile(
+      join(source, 'SKILL.md'),
+      [
+        '---',
+        'name: Alpha',
+        'description: Installed preview.',
+        'license: Apache-2.0',
+        '---',
+        '# Installed body'
+      ].join('\n')
+    )
+    await mkdir(join(source, 'references'))
+    await writeFile(join(source, 'references', 'guide.md'), 'Guide')
+
+    await expect(repo.previewAgentHomeSkill(source)).resolves.toEqual({
+      name: 'Alpha',
+      description: 'Installed preview.',
+      metadata: { license: 'Apache-2.0' },
+      body: '# Installed body',
+      files: ['SKILL.md', 'references/guide.md']
+    })
+    expect(await repo.list()).toEqual([])
+  })
+
+  it('rejects an installed preview whose declared file sizes exceed the skill cap', async () => {
+    const repo = new UserSkillRepository(await makeStorage())
+    const home = await mkdtemp(join(tmpdir(), 'os-preview-agent-large-'))
+    const source = await seedSkill(home, 'alpha')
+    const largeReference = join(source, 'large.bin')
+    await writeFile(largeReference, '')
+    await truncate(largeReference, SKILL_IMPORT_LIMITS.maxFileBytes + 1)
+
+    await expect(repo.previewAgentHomeSkill(source)).rejects.toThrow(/file over/)
+  })
+
+  it.skipIf(process.platform === 'win32')(
+    'rejects a nested symlink while previewing an installed skill',
+    async () => {
+      const repo = new UserSkillRepository(await makeStorage())
+      const home = await mkdtemp(join(tmpdir(), 'os-preview-agent-link-'))
+      const source = await seedSkill(home, 'alpha')
+      const outside = join(home, 'outside.md')
+      await writeFile(outside, 'outside')
+      await mkdir(join(source, 'references'))
+      await symlink(outside, join(source, 'references', 'outside.md'))
+
+      await expect(repo.previewAgentHomeSkill(source)).rejects.toThrow(/symbolic link/)
+    }
+  )
 
   it('marks a skill as alreadyImported when the same source identity exists', async () => {
     // The renderer uses alreadyImported to flip the row to a "Imported" badge and hide the action

--- a/src/main/skills/user-skill-repository.ts
+++ b/src/main/skills/user-skill-repository.ts
@@ -17,6 +17,7 @@ import { SKILL_IMPORT_LIMITS } from '../../shared/skill-import-limits'
 import { createLogger } from '../logger'
 import {
   fetchSkillFiles,
+  fetchSkillPreview,
   parseGitHubSkillUrl,
   parseGitHubRepo,
   scanRepoForSkills,
@@ -134,6 +135,35 @@ const signatureOf = (files: FetchedSkillFile[]): string => {
     hash.update('\0')
   }
   return hash.digest('hex')
+}
+
+type ParsedSkillPreview = {
+  name: string
+  description: string
+  metadata: Record<string, string>
+  body: string
+  files: string[]
+}
+
+type AgentHomeTreeEntry =
+  | { kind: 'directory'; relativePath: string; mode: number }
+  | { kind: 'file'; path: string; relativePath: string; mode: number; size: number }
+
+const parsedSkillPreview = (
+  raw: string,
+  files: string[],
+  fallbackName: string
+): ParsedSkillPreview => {
+  const { fields, body } = parseFrontmatter(raw)
+  const { name: frontmatterName, description = '', ...metadata } = fields
+
+  return {
+    name: frontmatterName?.trim() || fallbackName,
+    description,
+    metadata,
+    body,
+    files: [...files].sort()
+  }
 }
 
 // One skill root inside an archive: the directory prefix holding a SKILL.md, plus that skill's files
@@ -553,6 +583,21 @@ class UserSkillRepository {
     })
   }
 
+  // Lazily reads one scanned GitHub candidate for the read-only renderer preview. Unlike import,
+  // this downloads only SKILL.md while retaining the bounded directory walk for the file list.
+  async previewGitHubSkill(url: string, fetchImpl?: FetchLike): Promise<ParsedSkillPreview> {
+    const location = parseGitHubSkillUrl(url)
+    if (!location) throw new Error('Not a recognizable GitHub URL.')
+
+    const fetcher = fetchImpl ?? (globalThis.fetch as unknown as FetchLike | undefined)
+    if (!fetcher) throw new Error('No fetch implementation available.')
+
+    const { skillMd, files } = await fetchSkillPreview(location, fetcher)
+    const fallbackName = location.path.split('/').filter(Boolean).pop() ?? location.repo
+
+    return parsedSkillPreview(skillMd.toString('utf8'), files, fallbackName)
+  }
+
   // Finds an already-imported skill whose recorded source URL matches, for dedup. Only real slugs are
   // scanned, so a hidden transaction dir can never be returned as a (bogus) slug.
   private async findImportedSlugByUrl(url: string): Promise<string | undefined> {
@@ -581,7 +626,7 @@ class UserSkillRepository {
       for (const root of roots) {
         try {
           const skillMd = root.files.find((file) => file.relativePath.toLowerCase() === 'skill.md')!
-          const { fields } = parseFrontmatter(skillMd.content.toString('utf8'))
+          const { fields, body } = parseFrontmatter(skillMd.content.toString('utf8'))
           const name = fields.name?.trim()
           if (!name) {
             skipped.push({ source: root.subPath || 'skill', reason: 'SKILL.md has no name' })
@@ -593,9 +638,14 @@ class UserSkillRepository {
           )
           const replaceableId = alreadyImported ? undefined : await this.replaceableImportedId(name)
 
+          const metadata = Object.fromEntries(
+            Object.entries(fields).filter(([key]) => key !== 'name' && key !== 'description')
+          )
           previews.push({
             name,
             description: fields.description ?? '',
+            metadata,
+            body,
             files: root.files.map((file) => file.relativePath).sort(),
             alreadyImported,
             replaceableId,
@@ -840,22 +890,18 @@ class UserSkillRepository {
     return fallbackSlug
   }
 
-  // Hashes one installed-skill tree without following symlinks. Paths use archive-style `/`
-  // separators so the same tree has the same identity on Windows and POSIX; directory entries and
-  // portable permission bits are included because cp preserves empty directories and executable
-  // scripts. Applying the shared per-skill caps also bounds local scan reads.
-  private async signatureOfAgentHomeSkill(root: string): Promise<string> {
-    const entries: (
-      | { kind: 'directory'; relativePath: string; mode: number }
-      | { kind: 'file'; path: string; relativePath: string; mode: number }
-    )[] = []
+  // One structural inspection path serves installed-skill scan signatures, import validation, and
+  // candidate previews. It never follows symlinks, emits archive-style relative paths on every OS,
+  // and enforces the shared depth/count/size caps before any caller reads file contents.
+  private async inspectAgentHomeSkill(root: string): Promise<AgentHomeTreeEntry[]> {
+    const entries: AgentHomeTreeEntry[] = []
     let declaredTotal = 0
     let fileCount = 0
 
     const visit = async (dir: string, prefix: string, depth: number): Promise<void> => {
       const dirStat = await lstat(dir)
       if (dirStat.isSymbolicLink()) {
-        throw new Error('Refusing to import an agent-home Skill containing a symbolic link.')
+        throw new Error('Refusing to read an agent-home Skill containing a symbolic link.')
       }
       if (!dirStat.isDirectory()) throw new Error('Agent-home Skill source must be a directory.')
       if (depth > SKILL_IMPORT_LIMITS.maxDepth) {
@@ -871,7 +917,7 @@ class UserSkillRepository {
         const relativePath = prefix ? `${prefix}/${entry.name}` : entry.name
         const entryStat = await lstat(path)
         if (entryStat.isSymbolicLink()) {
-          throw new Error('Refusing to import an agent-home Skill containing a symbolic link.')
+          throw new Error('Refusing to read an agent-home Skill containing a symbolic link.')
         }
         if (entryStat.isDirectory()) {
           await visit(path, relativePath, depth + 1)
@@ -896,11 +942,26 @@ class UserSkillRepository {
           throw new Error(`Agent-home Skill exceeds ${mb(SKILL_IMPORT_LIMITS.maxTotalBytes)}.`)
         }
         fileCount += 1
-        entries.push({ kind: 'file', path, relativePath, mode: entryStat.mode & 0o777 })
+        entries.push({
+          kind: 'file',
+          path,
+          relativePath,
+          mode: entryStat.mode & 0o777,
+          size: entryStat.size
+        })
       }
     }
 
     await visit(root, '', 0)
+    return entries
+  }
+
+  // Hashes one installed-skill tree without following symlinks. Paths use archive-style `/`
+  // separators so the same tree has the same identity on Windows and POSIX; directory entries and
+  // portable permission bits are included because cp preserves empty directories and executable
+  // scripts. Applying the shared per-skill caps also bounds local scan reads.
+  private async signatureOfAgentHomeSkill(root: string): Promise<string> {
+    const entries = await this.inspectAgentHomeSkill(root)
 
     const hash = createHash('sha256')
     let actualTotal = 0
@@ -1240,6 +1301,30 @@ class UserSkillRepository {
     }
 
     return out
+  }
+
+  // Reads a selected installed skill for preview without copying it. The same structural limits and
+  // symlink policy as import apply before SKILL.md is returned, while only renderer-safe relative file
+  // names and parsed content leave this repository interface.
+  async previewAgentHomeSkill(root: string): Promise<ParsedSkillPreview> {
+    const entries = await this.inspectAgentHomeSkill(root)
+    const files = entries.filter(
+      (entry): entry is Extract<AgentHomeTreeEntry, { kind: 'file' }> => entry.kind === 'file'
+    )
+    const skillMd = files.find((file) => file.relativePath === 'SKILL.md')
+    if (!skillMd) throw new Error('Agent-home Skill must contain a SKILL.md.')
+    const raw = await readFile(skillMd.path, 'utf8')
+    if (Buffer.byteLength(raw) > SKILL_IMPORT_LIMITS.maxFileBytes) {
+      throw new Error(
+        `Agent-home Skill contains a file over ${mb(SKILL_IMPORT_LIMITS.maxFileBytes)}.`
+      )
+    }
+
+    return parsedSkillPreview(
+      raw,
+      files.map((file) => file.relativePath),
+      basename(root)
+    )
   }
 
   // Imports a single agent-home skill by copying its source subtree under the imported-skill store.

--- a/src/preload/index.d.ts
+++ b/src/preload/index.d.ts
@@ -146,8 +146,11 @@ import type {
   ImportAgentHomeSkillsRequest,
   ImportAgentHomeSkillsResult,
   AgentHomeSkillView,
+  PreviewAgentHomeSkillRequest,
+  PreviewGitHubSkillRequest,
   PreviewSkillZipRequest,
   SkillBundlePreviewResult,
+  SkillImportPreviewContent,
   ScanRepoRequest,
   ScanRepoResult,
   ConnectorsSnapshot,
@@ -285,8 +288,10 @@ interface OpenScienceAPI {
     importSkillZip(request: ImportSkillZipRequest): Promise<ImportSkillResult>
     importSkillZipBatch(request: ImportSkillZipBatchRequest): Promise<ImportSkillZipBatchResult>
     previewSkillZip(request: PreviewSkillZipRequest): Promise<SkillBundlePreviewResult>
+    previewGitHubSkill(request: PreviewGitHubSkillRequest): Promise<SkillImportPreviewContent>
     scanRepoSkills(request: ScanRepoRequest): Promise<ScanRepoResult>
     listAgentHomeSkills(): Promise<AgentHomeSkillView[]>
+    previewAgentHomeSkill(request: PreviewAgentHomeSkillRequest): Promise<SkillImportPreviewContent>
     importAgentHomeSkills(
       request: ImportAgentHomeSkillsRequest
     ): Promise<ImportAgentHomeSkillsResult>

--- a/src/preload/index.test.ts
+++ b/src/preload/index.test.ts
@@ -61,6 +61,8 @@ type PreloadApi = {
     loginIsolatedClaudeBrowser: () => unknown
     cancelIsolatedClaudeLogin: () => unknown
     logoutIsolatedClaude: () => unknown
+    previewGitHubSkill: (request: unknown) => unknown
+    previewAgentHomeSkill: (request: unknown) => unknown
   }
   acp: {
     resumeSession: (request: unknown) => unknown
@@ -114,6 +116,8 @@ const sampleManifest = { projectId: 'p-1', sessionId: 's-1' }
 const sampleInstall = { executablePath: '/usr/local/bin/opencode' }
 const sampleFramework = { framework: 'opencode' }
 const sampleResumeRequest = { sessionId: 's-1', cwd: '/workspace/project' }
+const sampleGitHubPreview = { url: 'https://github.com/acme/skills/tree/main/foo' }
+const sampleAgentHomePreview = { source: 'agents', slug: 'foo' }
 
 const cases: ForwardingCase[] = [
   {
@@ -279,6 +283,18 @@ const cases: ForwardingCase[] = [
     invoke: (a) => a.settings.logoutIsolatedClaude(),
     channel: 'settings:logout-isolated-claude',
     args: []
+  },
+  {
+    name: 'settings.previewGitHubSkill → settings:preview-github-skill',
+    invoke: (a) => a.settings.previewGitHubSkill(sampleGitHubPreview),
+    channel: 'settings:preview-github-skill',
+    args: [sampleGitHubPreview]
+  },
+  {
+    name: 'settings.previewAgentHomeSkill → settings:preview-agent-home-skill',
+    invoke: (a) => a.settings.previewAgentHomeSkill(sampleAgentHomePreview),
+    channel: 'settings:preview-agent-home-skill',
+    args: [sampleAgentHomePreview]
   },
   // command-line launcher install/uninstall/status
   {

--- a/src/preload/index.ts
+++ b/src/preload/index.ts
@@ -155,8 +155,11 @@ import type {
   ImportAgentHomeSkillsRequest,
   ImportAgentHomeSkillsResult,
   AgentHomeSkillView,
+  PreviewAgentHomeSkillRequest,
+  PreviewGitHubSkillRequest,
   PreviewSkillZipRequest,
   SkillBundlePreviewResult,
+  SkillImportPreviewContent,
   ScanRepoRequest,
   ScanRepoResult,
   ConnectorsSnapshot,
@@ -315,8 +318,12 @@ type OpenScienceAPI = {
     importSkillZip: (request: ImportSkillZipRequest) => Promise<ImportSkillResult>
     importSkillZipBatch: (request: ImportSkillZipBatchRequest) => Promise<ImportSkillZipBatchResult>
     previewSkillZip: (request: PreviewSkillZipRequest) => Promise<SkillBundlePreviewResult>
+    previewGitHubSkill: (request: PreviewGitHubSkillRequest) => Promise<SkillImportPreviewContent>
     scanRepoSkills: (request: ScanRepoRequest) => Promise<ScanRepoResult>
     listAgentHomeSkills: () => Promise<AgentHomeSkillView[]>
+    previewAgentHomeSkill: (
+      request: PreviewAgentHomeSkillRequest
+    ) => Promise<SkillImportPreviewContent>
     importAgentHomeSkills: (
       request: ImportAgentHomeSkillsRequest
     ) => Promise<ImportAgentHomeSkillsResult>
@@ -767,11 +774,21 @@ const api: OpenScienceAPI = {
         'settings:preview-skill-zip',
         request
       ) as Promise<SkillBundlePreviewResult>,
+    previewGitHubSkill: (request: PreviewGitHubSkillRequest) =>
+      ipcRenderer.invoke(
+        'settings:preview-github-skill',
+        request
+      ) as Promise<SkillImportPreviewContent>,
     scanRepoSkills: (request: ScanRepoRequest) =>
       ipcRenderer.invoke('settings:scan-repo-skills', request) as Promise<ScanRepoResult>,
     // Lists installed skills from the shared global source plus the active framework's source.
     listAgentHomeSkills: () =>
       ipcRenderer.invoke('settings:list-agent-home-skills') as Promise<AgentHomeSkillView[]>,
+    previewAgentHomeSkill: (request: PreviewAgentHomeSkillRequest) =>
+      ipcRenderer.invoke(
+        'settings:preview-agent-home-skill',
+        request
+      ) as Promise<SkillImportPreviewContent>,
     importAgentHomeSkills: (request: ImportAgentHomeSkillsRequest) =>
       ipcRenderer.invoke(
         'settings:import-agent-home-skills',

--- a/src/renderer/src/pages/settings/AgentHomeImportView.tsx
+++ b/src/renderer/src/pages/settings/AgentHomeImportView.tsx
@@ -8,6 +8,8 @@ import type {
 } from '../../../../shared/settings'
 import { Button } from '@/components/ui/button'
 import { useSettingsStore } from '@/stores/settings-store'
+import { SkillImportCandidatePreview } from './SkillImportCandidatePreview'
+import { useSkillImportCandidatePreview } from './useSkillImportCandidatePreview'
 
 type AgentHomeImportViewProps = {
   onImported: () => void
@@ -27,6 +29,7 @@ const skillKey = (skill: AgentHomeSkillRef): string => `${skill.source}:${skill.
 const AgentHomeImportView = ({ onImported }: AgentHomeImportViewProps): React.JSX.Element => {
   const listAgentHomeSkills = useSettingsStore((state) => state.listAgentHomeSkills)
   const importAgentHomeSkills = useSettingsStore((state) => state.importAgentHomeSkills)
+  const previewAgentHomeSkill = useSettingsStore((state) => state.previewAgentHomeSkill)
   const activeFrameworkId = useSettingsStore((state) => state.agentFrameworkId)
   const [scanning, setScanning] = useState(true)
   const [importing, setImporting] = useState(false)
@@ -35,6 +38,7 @@ const AgentHomeImportView = ({ onImported }: AgentHomeImportViewProps): React.JS
   const [skillsFrameworkId, setSkillsFrameworkId] = useState<AgentFrameworkId | null>(null)
   const [selected, setSelected] = useState<Set<string>>(new Set())
   const scanGeneration = useRef(0)
+  const candidatePreview = useSkillImportCandidatePreview()
 
   const frameworkSource =
     activeFrameworkId === 'codex'
@@ -255,15 +259,26 @@ const AgentHomeImportView = ({ onImported }: AgentHomeImportViewProps): React.JS
                     disabled={isScanning || skill.alreadyImported || importing}
                     className="size-4 shrink-0"
                   />
-                  <div className="min-w-0 flex-1">
-                    <span className="block truncate text-sm text-foreground">{skill.name}</span>
-                    <span className="block truncate text-xs text-muted-foreground">
-                      {skill.description || skill.slug} · {source.path}
+                  <button
+                    type="button"
+                    aria-label={`Preview ${skill.name}`}
+                    onClick={() =>
+                      candidatePreview.openPreview(() =>
+                        previewAgentHomeSkill({ source: skill.source, slug: skill.slug })
+                      )
+                    }
+                    className="flex min-w-0 flex-1 items-center gap-3 rounded-md text-left outline-none transition-colors hover:bg-muted/40 focus-visible:ring-2 focus-visible:ring-ring"
+                  >
+                    <span className="min-w-0 flex-1 px-1 py-1">
+                      <span className="block truncate text-sm text-foreground">{skill.name}</span>
+                      <span className="block truncate text-xs text-muted-foreground">
+                        {skill.description || skill.slug} · {source.path}
+                      </span>
                     </span>
-                  </div>
-                  <span className="shrink-0 rounded-full bg-muted px-2 py-0.5 text-xs text-muted-foreground">
-                    {skill.alreadyImported ? 'Imported' : source.label}
-                  </span>
+                    <span className="shrink-0 rounded-full bg-muted px-2 py-0.5 text-xs text-muted-foreground">
+                      {skill.alreadyImported ? 'Imported' : source.label}
+                    </span>
+                  </button>
                 </li>
               )
             })}
@@ -274,6 +289,8 @@ const AgentHomeImportView = ({ onImported }: AgentHomeImportViewProps): React.JS
           No installed skills found in the scanned global folders.
         </p>
       ) : null}
+
+      <SkillImportCandidatePreview {...candidatePreview.previewProps} />
     </div>
   )
 }

--- a/src/renderer/src/pages/settings/SkillImportCandidatePreview.render.test.tsx
+++ b/src/renderer/src/pages/settings/SkillImportCandidatePreview.render.test.tsx
@@ -1,0 +1,122 @@
+// @vitest-environment jsdom
+import { act } from 'react'
+import { createRoot, type Root } from 'react-dom/client'
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest'
+
+import { SkillImportCandidatePreview } from './SkillImportCandidatePreview'
+import { useSkillImportCandidatePreview } from './useSkillImportCandidatePreview'
+
+vi.mock('@/components/streamdown/AgentMarkdown', () => ({
+  AgentMarkdown: ({ content }: { content: string }) => (
+    <div data-testid="agent-markdown">{content}</div>
+  )
+}))
+
+let container: HTMLDivElement
+let root: Root
+
+beforeEach(() => {
+  container = document.createElement('div')
+  document.body.appendChild(container)
+  root = createRoot(container)
+})
+
+afterEach(() => {
+  act(() => root.unmount())
+  container.remove()
+  document.body.innerHTML = ''
+})
+
+describe('SkillImportCandidatePreview', () => {
+  it('renders read-only candidate content and closes accessibly', () => {
+    const onOpenChange = vi.fn()
+    act(() => {
+      root.render(
+        <SkillImportCandidatePreview
+          open
+          onOpenChange={onOpenChange}
+          loading={false}
+          error={null}
+          content={{
+            name: 'Citation helper',
+            description: 'Formats citations.',
+            sourceLabel: 'github.com/acme/skills/citation',
+            metadata: { author: 'Ada', license: 'MIT' },
+            body: '# Instructions\nUse carefully.',
+            files: ['SKILL.md', 'references/style.md']
+          }}
+        />
+      )
+    })
+
+    const dialog = document.body.querySelector<HTMLElement>('[role="dialog"]')
+    expect(dialog?.textContent).toContain('Citation helper')
+    expect(dialog?.textContent).toContain('Formats citations.')
+    expect(dialog?.textContent).toContain('github.com/acme/skills/citation')
+    expect(dialog?.textContent).toContain('# Instructions')
+    expect(dialog?.textContent).toContain('references/style.md')
+    expect(dialog?.textContent).toContain('Ada')
+    expect(dialog?.querySelector('[role="switch"]')).toBeNull()
+
+    act(() => dialog?.querySelector<HTMLButtonElement>('[aria-label="Close preview"]')?.click())
+    expect(onOpenChange).toHaveBeenCalledWith(false)
+  })
+
+  it('isolates a failed candidate so the next candidate can still preview', async () => {
+    const goodContent = {
+      name: 'Good',
+      description: '',
+      sourceLabel: 'source/good',
+      metadata: {},
+      body: '# Good body',
+      files: ['SKILL.md']
+    }
+    const Harness = (): React.JSX.Element => {
+      const preview = useSkillImportCandidatePreview()
+      return (
+        <>
+          <button
+            type="button"
+            onClick={() =>
+              preview.openPreview(() => {
+                throw new Error('Unavailable')
+              })
+            }
+          >
+            Bad
+          </button>
+          <button
+            type="button"
+            onClick={() => preview.openPreview(() => Promise.resolve(goodContent))}
+          >
+            Good
+          </button>
+          <SkillImportCandidatePreview {...preview.previewProps} />
+        </>
+      )
+    }
+    act(() => root.render(<Harness />))
+
+    await act(async () => {
+      Array.from(document.body.querySelectorAll('button'))
+        .find((button) => button.textContent === 'Bad')
+        ?.click()
+      await Promise.resolve()
+      await Promise.resolve()
+    })
+    expect(document.body.querySelector('[role="alert"]')?.textContent).toContain('Unavailable')
+
+    act(() => {
+      document.body.querySelector<HTMLButtonElement>('[aria-label="Close preview"]')?.click()
+    })
+    await act(async () => {
+      Array.from(document.body.querySelectorAll('button'))
+        .find((button) => button.textContent === 'Good')
+        ?.click()
+      await Promise.resolve()
+    })
+
+    expect(document.body.querySelector('[role="dialog"]')?.textContent).toContain('Good body')
+    expect(document.body.querySelector('[role="alert"]')).toBeNull()
+  })
+})

--- a/src/renderer/src/pages/settings/SkillImportCandidatePreview.tsx
+++ b/src/renderer/src/pages/settings/SkillImportCandidatePreview.tsx
@@ -1,0 +1,138 @@
+import { FileText, LoaderCircle, X } from 'lucide-react'
+import { Dialog } from 'radix-ui'
+
+import type { SkillImportPreviewContent } from '../../../../shared/settings'
+import { AgentMarkdown } from '@/components/streamdown/AgentMarkdown'
+import { Button } from '@/components/ui/button'
+import {
+  dialogCloseButtonClassName,
+  dialogOverlayClassName,
+  dialogPanelClassName
+} from '@/components/ui/dialog-chrome'
+
+type SkillImportCandidatePreviewProps = {
+  open: boolean
+  onOpenChange: (open: boolean) => void
+  loading: boolean
+  error: string | null
+  content: SkillImportPreviewContent | null
+}
+
+const metadataLabel = (key: string): string =>
+  key.replace(/[-_]+/g, ' ').replace(/\b\w/g, (letter) => letter.toUpperCase())
+
+// One read-only preview module shared by every pre-import source. Callers adapt candidate identity
+// into SkillImportPreviewContent; loading, error isolation, accessibility, and presentation stay here.
+const SkillImportCandidatePreview = ({
+  open,
+  onOpenChange,
+  loading,
+  error,
+  content
+}: SkillImportCandidatePreviewProps): React.JSX.Element => {
+  const metadata = content ? Object.entries(content.metadata) : []
+
+  return (
+    <Dialog.Root open={open} onOpenChange={onOpenChange}>
+      <Dialog.Portal>
+        <Dialog.Overlay className={dialogOverlayClassName} />
+        <Dialog.Content
+          className={dialogPanelClassName(
+            'flex max-h-[min(88vh,760px)] w-[min(760px,calc(100vw-2rem))] flex-col overflow-hidden p-0'
+          )}
+        >
+          <div className="flex items-start justify-between gap-4 border-b border-border px-5 py-4">
+            <div className="min-w-0">
+              <div className="flex items-center gap-2">
+                <FileText className="size-5 shrink-0 text-primary" aria-hidden="true" />
+                <Dialog.Title className="truncate text-base font-semibold text-foreground">
+                  {content?.name ?? 'Skill preview'}
+                </Dialog.Title>
+              </div>
+              <Dialog.Description className="mt-1 break-all text-xs text-muted-foreground">
+                {content?.sourceLabel ?? 'Loading candidate content…'}
+              </Dialog.Description>
+            </div>
+            <Dialog.Close asChild>
+              <Button
+                type="button"
+                variant="ghost"
+                size="icon-sm"
+                aria-label="Close preview"
+                className={dialogCloseButtonClassName}
+              >
+                <X className="size-4" aria-hidden="true" />
+              </Button>
+            </Dialog.Close>
+          </div>
+
+          <div className="min-h-0 flex-1 overflow-y-auto px-5 py-4">
+            {loading ? (
+              <div
+                className="flex min-h-48 items-center justify-center gap-2 text-sm text-muted-foreground"
+                role="status"
+              >
+                <LoaderCircle
+                  className="size-4 animate-spin motion-reduce:animate-none"
+                  aria-hidden
+                />
+                Loading preview…
+              </div>
+            ) : error ? (
+              <div
+                className="rounded-lg border border-danger-000/30 bg-danger-000/10 px-3 py-2 text-sm text-danger-000"
+                role="alert"
+              >
+                {error}
+              </div>
+            ) : content ? (
+              <>
+                {content.description ? (
+                  <p className="text-sm leading-6 text-muted-foreground [text-wrap:pretty]">
+                    {content.description}
+                  </p>
+                ) : null}
+
+                <section className="mt-5 border-t border-border pt-4">
+                  <h2 className="mb-3 text-sm font-semibold text-foreground">SKILL.md</h2>
+                  <AgentMarkdown content={content.body} />
+                </section>
+
+                {metadata.length > 0 ? (
+                  <section className="mt-5 border-t border-border pt-4">
+                    <h2 className="mb-2 text-sm font-semibold text-foreground">Metadata</h2>
+                    <dl className="grid gap-x-5 gap-y-2 sm:grid-cols-2">
+                      {metadata.map(([key, value]) => (
+                        <div key={key} className="min-w-0">
+                          <dt className="text-xs font-medium text-muted-foreground">
+                            {metadataLabel(key)}
+                          </dt>
+                          <dd className="break-words text-sm text-foreground">{value}</dd>
+                        </div>
+                      ))}
+                    </dl>
+                  </section>
+                ) : null}
+
+                {content.files.length > 0 ? (
+                  <section className="mt-5 border-t border-border pt-4">
+                    <h2 className="mb-2 text-sm font-semibold text-foreground">Files</h2>
+                    <ul className="flex flex-col gap-1 font-mono text-xs text-muted-foreground">
+                      {content.files.map((file) => (
+                        <li key={file} className="break-all rounded bg-muted/50 px-2 py-1">
+                          {file}
+                        </li>
+                      ))}
+                    </ul>
+                  </section>
+                ) : null}
+              </>
+            ) : null}
+          </div>
+        </Dialog.Content>
+      </Dialog.Portal>
+    </Dialog.Root>
+  )
+}
+
+export { SkillImportCandidatePreview }

--- a/src/renderer/src/pages/settings/SkillImportView.tsx
+++ b/src/renderer/src/pages/settings/SkillImportView.tsx
@@ -4,6 +4,8 @@ import type { ScannedSkillView, SkillView } from '../../../../shared/settings'
 import { Button } from '@/components/ui/button'
 import { Input } from '@/components/ui/input'
 import { useSettingsStore } from '@/stores/settings-store'
+import { SkillImportCandidatePreview } from './SkillImportCandidatePreview'
+import { useSkillImportCandidatePreview } from './useSkillImportCandidatePreview'
 
 type SkillImportViewProps = {
   onImported: () => void
@@ -15,11 +17,13 @@ const SkillImportView = ({ onImported }: SkillImportViewProps): React.JSX.Elemen
   const skills = useSettingsStore((state) => state.skills)
   const importSkill = useSettingsStore((state) => state.importSkill)
   const scanRepoSkills = useSettingsStore((state) => state.scanRepoSkills)
+  const previewGitHubSkill = useSettingsStore((state) => state.previewGitHubSkill)
   const [input, setInput] = useState('')
   const [busy, setBusy] = useState(false)
   const [message, setMessage] = useState<string | null>(null)
   const [scanned, setScanned] = useState<ScannedSkillView[] | null>(null)
   const [selected, setSelected] = useState<Set<string>>(new Set())
+  const candidatePreview = useSkillImportCandidatePreview()
 
   const imported = skills.filter((skill: SkillView) => skill.source === 'imported')
 
@@ -157,15 +161,24 @@ const SkillImportView = ({ onImported }: SkillImportViewProps): React.JSX.Elemen
                   onChange={() => toggle(skill.url)}
                   className="size-4 shrink-0"
                 />
-                <div className="min-w-0 flex-1">
-                  <span className="block truncate text-sm text-foreground">{skill.name}</span>
-                  <span className="block truncate text-xs text-muted-foreground">{skill.path}</span>
-                </div>
-                {skill.alreadyImported ? (
-                  <span className="shrink-0 rounded-full bg-muted px-2 py-0.5 text-xs text-muted-foreground">
-                    Imported
+                <button
+                  type="button"
+                  aria-label={`Preview ${skill.name}`}
+                  onClick={() => candidatePreview.openPreview(() => previewGitHubSkill(skill.url))}
+                  className="flex min-w-0 flex-1 items-center gap-3 rounded-md text-left outline-none transition-colors hover:bg-muted/40 focus-visible:ring-2 focus-visible:ring-ring"
+                >
+                  <span className="min-w-0 flex-1 px-1 py-1">
+                    <span className="block truncate text-sm text-foreground">{skill.name}</span>
+                    <span className="block truncate text-xs text-muted-foreground">
+                      {skill.path}
+                    </span>
                   </span>
-                ) : null}
+                  {skill.alreadyImported ? (
+                    <span className="shrink-0 rounded-full bg-muted px-2 py-0.5 text-xs text-muted-foreground">
+                      Imported
+                    </span>
+                  ) : null}
+                </button>
               </li>
             ))}
           </ul>
@@ -187,6 +200,8 @@ const SkillImportView = ({ onImported }: SkillImportViewProps): React.JSX.Elemen
           No imported skills yet. Repos you import from will appear here.
         </p>
       )}
+
+      <SkillImportCandidatePreview {...candidatePreview.previewProps} />
     </div>
   )
 }

--- a/src/renderer/src/pages/settings/SkillUploadView.render.test.tsx
+++ b/src/renderer/src/pages/settings/SkillUploadView.render.test.tsx
@@ -68,6 +68,8 @@ beforeEach(() => {
           subPath: 'skills/one',
           name: 'One',
           description: 'First bundled skill',
+          metadata: { author: 'Ada' },
+          body: '# First bundle body',
           files: ['SKILL.md'],
           alreadyImported: false
         },
@@ -75,6 +77,8 @@ beforeEach(() => {
           subPath: 'skills/two',
           name: 'Two',
           description: 'Second bundled skill',
+          metadata: {},
+          body: '# Second bundle body',
           files: ['SKILL.md'],
           alreadyImported: false
         }
@@ -147,6 +151,38 @@ describe('SkillUploadView (batch upload)', () => {
       { subPath: 'skills/two', replaceId: undefined }
     ])
     expect(onUploaded).toHaveBeenCalled()
+  })
+
+  it('opens bundle candidate content from the bounded parse result without changing selection', async () => {
+    act(() => {
+      root.render(<SkillUploadView onUploaded={vi.fn()} onWriteInstead={vi.fn()} />)
+    })
+    await dropFiles([
+      new File([new Uint8Array([1, 2, 3])], 'pack.zip', { type: 'application/zip' })
+    ])
+
+    const checkbox = document.body.querySelector<HTMLInputElement>('[aria-label="Select One"]')
+    expect(checkbox?.checked).toBe(false)
+
+    await act(async () => {
+      document.body.querySelector<HTMLButtonElement>('[aria-label="Preview One"]')?.click()
+      await Promise.resolve()
+    })
+
+    expect(useSettingsStore.getState().previewSkillZip).toHaveBeenCalledTimes(1)
+    expect(document.body.querySelector('[role="dialog"]')?.textContent).toContain(
+      'First bundle body'
+    )
+    expect(document.body.querySelector('[role="dialog"]')?.textContent).toContain('Ada')
+    expect(checkbox?.checked).toBe(false)
+
+    act(() => {
+      document.body.querySelector<HTMLButtonElement>('[aria-label="Close preview"]')?.click()
+    })
+    expect(checkbox?.checked).toBe(false)
+    act(() => checkbox?.click())
+    expect(checkbox?.checked).toBe(true)
+    expect(document.body.querySelector('[role="dialog"]')).toBeNull()
   })
 
   it('rejects an oversized markdown file on file.size, before reading its contents', async () => {
@@ -225,5 +261,34 @@ describe('SkillUploadView (batch upload)', () => {
       description: 'A solo skill',
       body: '# Body'
     })
+  })
+
+  it('previews a bare Markdown candidate from its in-renderer body without changing selection', async () => {
+    act(() => {
+      root.render(<SkillUploadView onUploaded={vi.fn()} onWriteInstead={vi.fn()} />)
+    })
+    const md = new File(
+      ['---\nname: Solo\ndescription: A solo skill\nauthor: Ada\n---\n# Bare body'],
+      'solo.md',
+      { type: 'text/markdown' }
+    )
+    await dropFiles([md])
+
+    const checkbox = document.body.querySelector<HTMLInputElement>('[aria-label="Select Solo"]')
+    expect(checkbox?.checked).toBe(false)
+
+    await act(async () => {
+      document.body.querySelector<HTMLButtonElement>('[aria-label="Preview Solo"]')?.click()
+      await Promise.resolve()
+    })
+
+    const dialog = document.body.querySelector<HTMLElement>('[role="dialog"]')
+    expect(dialog?.textContent).toContain('Bare body')
+    expect(dialog?.textContent).toContain('Ada')
+    expect(dialog?.textContent).toContain('solo.md')
+    expect(checkbox?.checked).toBe(false)
+
+    act(() => dialog?.querySelector<HTMLButtonElement>('[aria-label="Close preview"]')?.click())
+    expect(checkbox?.checked).toBe(false)
   })
 })

--- a/src/renderer/src/pages/settings/SkillUploadView.tsx
+++ b/src/renderer/src/pages/settings/SkillUploadView.tsx
@@ -6,6 +6,8 @@ import { Button } from '@/components/ui/button'
 import { useFileDropZone } from '@/hooks/useFileDropZone'
 import { useSettingsStore } from '@/stores/settings-store'
 import { SKILL_IMPORT_LIMITS } from '../../../../shared/skill-import-limits'
+import { SkillImportCandidatePreview } from './SkillImportCandidatePreview'
+import { useSkillImportCandidatePreview } from './useSkillImportCandidatePreview'
 
 // Rounds a byte count to whole MB for a user-facing size-limit message.
 const mb = (bytes: number): string => `${Math.round(bytes / (1024 * 1024))} MB`
@@ -53,6 +55,8 @@ type Candidate =
       subPath: string
       name: string
       description: string
+      metadata: Record<string, string>
+      body: string
       files: string[]
       alreadyImported: boolean
       replaceableId?: string
@@ -63,6 +67,7 @@ type Candidate =
       fileName: string
       name: string
       description: string
+      metadata: Record<string, string>
       body: string
     }
 
@@ -85,19 +90,27 @@ const cleanMessage = (error: unknown): string => {
 // editor's consumeFrontmatter so an uploaded SKILL.md fills the same fields).
 const consumeFrontmatter = (
   text: string
-): { name?: string; description?: string; body: string } => {
-  const match = /^---\n([\s\S]*?)\n---\n?/.exec(text)
-  if (!match) return { body: text }
+): {
+  name?: string
+  description?: string
+  metadata: Record<string, string>
+  body: string
+} => {
+  const normalized = text.replace(/\r\n?/g, '\n')
+  const match = /^---\n([\s\S]*?)\n---\n?/.exec(normalized)
+  if (!match) return { metadata: {}, body: text }
 
   const fields: Record<string, string> = {}
   for (const line of match[1].split('\n')) {
     const field = /^([A-Za-z0-9_-]+):\s*(.*)$/.exec(line)
     if (field) fields[field[1].toLowerCase()] = field[2].trim()
   }
+  const { name, description, ...metadata } = fields
   return {
-    name: fields.name,
-    description: fields.description,
-    body: text.slice(match[0].length).replace(/^\n+/, '')
+    name,
+    description,
+    metadata,
+    body: normalized.slice(match[0].length).replace(/^\n+/, '')
   }
 }
 
@@ -127,6 +140,7 @@ const SkillUploadView = ({
   const [selected, setSelected] = useState<Set<string>>(new Set())
   const [summary, setSummary] = useState<string | null>(null)
   const [busy, setBusy] = useState(false)
+  const candidatePreview = useSkillImportCandidatePreview()
 
   // Parses one picked file into its candidates, capturing a per-file error instead of throwing.
   const parseFile = async (file: File): Promise<ParseResult> => {
@@ -163,6 +177,8 @@ const SkillUploadView = ({
             subPath: preview.subPath,
             name: preview.name,
             description: preview.description,
+            metadata: preview.metadata,
+            body: preview.body,
             files: preview.files,
             alreadyImported: preview.alreadyImported,
             replaceableId: preview.replaceableId
@@ -187,6 +203,7 @@ const SkillUploadView = ({
             fileName: file.name,
             name: parsed.name,
             description: parsed.description ?? '',
+            metadata: parsed.metadata,
             body: parsed.body
           }
         ]
@@ -393,21 +410,42 @@ const SkillUploadView = ({
                     disabled={busy}
                     className="size-4 shrink-0"
                   />
-                  <div className="min-w-0 flex-1">
-                    <span className="block truncate text-sm text-foreground">{candidate.name}</span>
-                    <span className="block truncate text-xs text-muted-foreground">
-                      {secondary}
+                  <button
+                    type="button"
+                    aria-label={`Preview ${candidate.name}`}
+                    onClick={() =>
+                      candidatePreview.openPreview(() =>
+                        Promise.resolve({
+                          name: candidate.name,
+                          description: candidate.description,
+                          sourceLabel: secondary,
+                          metadata: candidate.metadata,
+                          body: candidate.body,
+                          files:
+                            candidate.kind === 'bundle' ? candidate.files : [candidate.fileName]
+                        })
+                      )
+                    }
+                    className="flex min-w-0 flex-1 items-center gap-3 rounded-md text-left outline-none transition-colors hover:bg-muted/40 focus-visible:ring-2 focus-visible:ring-ring"
+                  >
+                    <span className="min-w-0 flex-1 px-1 py-1">
+                      <span className="block truncate text-sm text-foreground">
+                        {candidate.name}
+                      </span>
+                      <span className="block truncate text-xs text-muted-foreground">
+                        {secondary}
+                      </span>
                     </span>
-                  </div>
-                  {alreadyImported ? (
-                    <span className="shrink-0 rounded-full bg-muted px-2 py-0.5 text-xs text-muted-foreground">
-                      Already imported
-                    </span>
-                  ) : nameExists ? (
-                    <span className="shrink-0 rounded-full bg-muted px-2 py-0.5 text-xs text-muted-foreground">
-                      Name exists
-                    </span>
-                  ) : null}
+                    {alreadyImported ? (
+                      <span className="shrink-0 rounded-full bg-muted px-2 py-0.5 text-xs text-muted-foreground">
+                        Already imported
+                      </span>
+                    ) : nameExists ? (
+                      <span className="shrink-0 rounded-full bg-muted px-2 py-0.5 text-xs text-muted-foreground">
+                        Name exists
+                      </span>
+                    ) : null}
+                  </button>
                 </li>
               )
             })}
@@ -437,6 +475,7 @@ const SkillUploadView = ({
             Choose different files
           </Button>
         </div>
+        <SkillImportCandidatePreview {...candidatePreview.previewProps} />
       </div>
     )
   }

--- a/src/renderer/src/pages/settings/SkillsPanel.render.test.tsx
+++ b/src/renderer/src/pages/settings/SkillsPanel.render.test.tsx
@@ -61,6 +61,8 @@ beforeEach(() => {
           subPath: '',
           name: 'Bundled',
           description: 'From a bundle',
+          metadata: { license: 'MIT' },
+          body: '# Bundled body',
           files: ['SKILL.md'],
           alreadyImported: false
         }
@@ -76,6 +78,14 @@ beforeEach(() => {
           alreadyImported: false
         }
       ]
+    }),
+    previewGitHubSkill: vi.fn().mockResolvedValue({
+      name: 'Foo',
+      description: 'Remote preview',
+      sourceLabel: 'github.com/acme/skills/pack/foo',
+      metadata: { license: 'MIT' },
+      body: '# Remote body',
+      files: ['SKILL.md']
     }),
     listAgentHomeSkills: vi.fn().mockResolvedValue([
       {
@@ -100,6 +110,14 @@ beforeEach(() => {
         alreadyImported: true
       }
     ]),
+    previewAgentHomeSkill: vi.fn().mockResolvedValue({
+      name: 'Shared',
+      description: 'Shared agent skill',
+      sourceLabel: '~/.agents/skills/shared',
+      metadata: { author: 'Ada' },
+      body: '# Installed body',
+      files: ['SKILL.md', 'references/guide.md']
+    }),
     importAgentHomeSkills: vi.fn().mockResolvedValue({
       results: [
         {
@@ -317,6 +335,42 @@ describe('SkillsPanel (sub-views)', () => {
     )
   })
 
+  it('opens and closes a GitHub candidate preview without changing its selection', async () => {
+    act(() => {
+      root.render(<SkillsPanel view={{ kind: 'import' }} onNavigate={vi.fn()} />)
+    })
+    setValue('GitHub skill URL or repo', 'acme/skills')
+    const runScan = Array.from(document.body.querySelectorAll<HTMLButtonElement>('button')).find(
+      (button) => button.textContent?.trim() === 'Preview'
+    )
+    await act(async () => {
+      runScan?.click()
+      await Promise.resolve()
+    })
+
+    const checkbox = document.body.querySelector<HTMLInputElement>('[aria-label="Select Foo"]')
+    expect(checkbox?.checked).toBe(true)
+
+    await act(async () => {
+      document.body.querySelector<HTMLButtonElement>('[aria-label="Preview Foo"]')?.click()
+      await Promise.resolve()
+    })
+
+    expect(useSettingsStore.getState().previewGitHubSkill).toHaveBeenCalledWith(
+      'https://github.com/acme/skills/tree/main/pack/foo'
+    )
+    expect(document.body.querySelector('[role="dialog"]')?.textContent).toContain('Remote body')
+    expect(checkbox?.checked).toBe(true)
+
+    act(() => {
+      document.body.querySelector<HTMLButtonElement>('[aria-label="Close preview"]')?.click()
+    })
+    expect(checkbox?.checked).toBe(true)
+    act(() => checkbox?.click())
+    expect(checkbox?.checked).toBe(false)
+    expect(document.body.querySelector('[role="dialog"]')).toBeNull()
+  })
+
   it('preselects available installed skills and batch-imports the checked rows', async () => {
     await act(async () => {
       root.render(<SkillsPanel view={{ kind: 'import-agent-home' }} onNavigate={vi.fn()} />)
@@ -504,6 +558,39 @@ describe('SkillsPanel (sub-views)', () => {
     expect(document.body.textContent).toContain('Codex Beta')
     expect(document.body.textContent).not.toContain('Stale Claude')
     expect(document.body.textContent).not.toContain('Scanning…')
+  })
+
+  it('opens and closes an installed candidate preview without changing its selection', async () => {
+    await act(async () => {
+      root.render(<SkillsPanel view={{ kind: 'import-agent-home' }} onNavigate={vi.fn()} />)
+      await Promise.resolve()
+      await Promise.resolve()
+    })
+
+    const checkbox = document.body.querySelector<HTMLInputElement>('[aria-label="Select Shared"]')
+    expect(checkbox?.checked).toBe(true)
+
+    const preview = document.body.querySelector<HTMLButtonElement>('[aria-label="Preview Shared"]')
+    await act(async () => {
+      preview?.click()
+      await Promise.resolve()
+    })
+
+    expect(useSettingsStore.getState().previewAgentHomeSkill).toHaveBeenCalledWith({
+      source: 'agents',
+      slug: 'shared'
+    })
+    expect(document.body.querySelector('[role="dialog"]')?.textContent).toContain('Installed body')
+    expect(checkbox?.checked).toBe(true)
+
+    act(() => {
+      document.body.querySelector<HTMLButtonElement>('[aria-label="Close preview"]')?.click()
+    })
+    expect(checkbox?.checked).toBe(true)
+
+    act(() => checkbox?.click())
+    expect(checkbox?.checked).toBe(false)
+    expect(document.body.querySelector('[role="dialog"]')).toBeNull()
   })
 
   it('renders the upload view and returns to the create view on "Write from scratch instead"', () => {

--- a/src/renderer/src/pages/settings/useSkillImportCandidatePreview.ts
+++ b/src/renderer/src/pages/settings/useSkillImportCandidatePreview.ts
@@ -1,0 +1,64 @@
+import { useCallback, useRef, useState } from 'react'
+
+import type { SkillImportPreviewContent } from '../../../../shared/settings'
+
+type SkillImportCandidatePreviewState = {
+  open: boolean
+  onOpenChange: (open: boolean) => void
+  loading: boolean
+  error: string | null
+  content: SkillImportPreviewContent | null
+}
+
+type SkillImportCandidatePreviewController = {
+  openPreview: (load: () => Promise<SkillImportPreviewContent>) => void
+  previewProps: SkillImportCandidatePreviewState
+}
+
+const previewErrorMessage = (error: unknown): string => {
+  const message = error instanceof Error ? error.message : String(error)
+  return message.replace(/^Error invoking remote method '[^']*':\s*/, '').replace(/^Error:\s*/, '')
+}
+
+// Owns the async candidate lifecycle for all source adapters. A close or a newer row click
+// invalidates an in-flight result, so late IPC/network responses cannot reopen or replace the dialog.
+const useSkillImportCandidatePreview = (): SkillImportCandidatePreviewController => {
+  const [open, setOpen] = useState(false)
+  const [loading, setLoading] = useState(false)
+  const [error, setError] = useState<string | null>(null)
+  const [content, setContent] = useState<SkillImportPreviewContent | null>(null)
+  const generation = useRef(0)
+
+  const onOpenChange = useCallback((nextOpen: boolean): void => {
+    setOpen(nextOpen)
+    if (!nextOpen) {
+      generation.current += 1
+      setLoading(false)
+    }
+  }, [])
+
+  const openPreview = useCallback((load: () => Promise<SkillImportPreviewContent>): void => {
+    const request = generation.current + 1
+    generation.current = request
+    setOpen(true)
+    setLoading(true)
+    setError(null)
+    setContent(null)
+
+    void Promise.resolve()
+      .then(load)
+      .then((result) => {
+        if (generation.current === request) setContent(result)
+      })
+      .catch((reason) => {
+        if (generation.current === request) setError(previewErrorMessage(reason))
+      })
+      .finally(() => {
+        if (generation.current === request) setLoading(false)
+      })
+  }, [])
+
+  return { openPreview, previewProps: { open, onOpenChange, loading, error, content } }
+}
+
+export { useSkillImportCandidatePreview }

--- a/src/renderer/src/stores/settings-store.test.ts
+++ b/src/renderer/src/stores/settings-store.test.ts
@@ -56,6 +56,8 @@ type SettingsApi = {
   importSkillZip: ReturnType<typeof vi.fn>
   importSkillZipBatch: ReturnType<typeof vi.fn>
   previewSkillZip: ReturnType<typeof vi.fn>
+  previewGitHubSkill: ReturnType<typeof vi.fn>
+  previewAgentHomeSkill: ReturnType<typeof vi.fn>
   listConnectors: ReturnType<typeof vi.fn>
   getConnectorDetail: ReturnType<typeof vi.fn>
   setConnectorEnabled: ReturnType<typeof vi.fn>
@@ -192,6 +194,8 @@ beforeEach(() => {
     importSkillZip: vi.fn().mockResolvedValue({ status: 'imported', id: 'z', skills: [] }),
     importSkillZipBatch: vi.fn().mockResolvedValue({ results: [], skills: [] }),
     previewSkillZip: vi.fn().mockResolvedValue({ previews: [], skipped: [] }),
+    previewGitHubSkill: vi.fn(),
+    previewAgentHomeSkill: vi.fn(),
     listConnectors: vi
       .fn()
       .mockResolvedValue({ connectors: [], customServers: [], ncbi: { hasApiKey: false } }),
@@ -970,6 +974,35 @@ describe('settings store: openSettingsToPanel', () => {
   })
 })
 
+describe('settings store: skill import candidate previews', () => {
+  it('forwards renderer-safe GitHub and installed candidate identities', async () => {
+    const preview = {
+      name: 'Alpha',
+      description: 'Preview',
+      sourceLabel: 'source/alpha',
+      metadata: {},
+      body: '# Alpha',
+      files: ['SKILL.md']
+    }
+    api.previewGitHubSkill.mockResolvedValue(preview)
+    api.previewAgentHomeSkill.mockResolvedValue(preview)
+
+    await expect(
+      useSettingsStore
+        .getState()
+        .previewGitHubSkill('https://github.com/acme/skills/tree/main/alpha')
+    ).resolves.toBe(preview)
+    await expect(
+      useSettingsStore.getState().previewAgentHomeSkill({ source: 'agents', slug: 'alpha' })
+    ).resolves.toBe(preview)
+
+    expect(api.previewGitHubSkill).toHaveBeenCalledWith({
+      url: 'https://github.com/acme/skills/tree/main/alpha'
+    })
+    expect(api.previewAgentHomeSkill).toHaveBeenCalledWith({ source: 'agents', slug: 'alpha' })
+  })
+})
+
 describe('settings store: skill bundle upload', () => {
   it('previewSkillZip returns the importable previews plus any skipped skills', async () => {
     api.previewSkillZip.mockResolvedValue({
@@ -978,6 +1011,8 @@ describe('settings store: skill bundle upload', () => {
           subPath: 'skills/alpha',
           name: 'Alpha',
           description: '',
+          metadata: {},
+          body: '# Alpha',
           files: ['SKILL.md'],
           alreadyImported: false
         },
@@ -985,6 +1020,8 @@ describe('settings store: skill bundle upload', () => {
           subPath: 'skills/beta',
           name: 'Beta',
           description: '',
+          metadata: {},
+          body: '# Beta',
           files: ['SKILL.md'],
           alreadyImported: true
         }

--- a/src/renderer/src/stores/settings-store.ts
+++ b/src/renderer/src/stores/settings-store.ts
@@ -48,6 +48,7 @@ import type {
   ImportSkillResult,
   ImportSkillZipBatchResult,
   SkillBundlePreviewResult,
+  SkillImportPreviewContent,
   ScanRepoResult,
   UpsertProviderRequest,
   ValidateProviderRequest,
@@ -261,10 +262,12 @@ type SettingsStore = SettingsStoreData & {
   // Parses an uploaded bundle without importing it, for a confirm-before-import preview. Returns the
   // importable skills plus any the bundle contained that were skipped and why.
   previewSkillZip: (dataBase64: string) => Promise<SkillBundlePreviewResult>
+  previewGitHubSkill: (url: string) => Promise<SkillImportPreviewContent>
   // Scans a GitHub repo for importable skill directories (does not mutate state).
   scanRepoSkills: (repo: string) => Promise<ScanRepoResult>
   // Lists the shared global skills plus the active framework's installed skills.
   listAgentHomeSkills: () => Promise<AgentHomeSkillView[]>
+  previewAgentHomeSkill: (skill: AgentHomeSkillRef) => Promise<SkillImportPreviewContent>
   // Copies checked installed skills into the imported-skill store in one batch.
   importAgentHomeSkills: (skills: AgentHomeSkillRef[]) => Promise<ImportAgentHomeSkillsResult>
   // Loads the bundled-connector list (enabled/auto-allow + NCBI credential state) from main.
@@ -1094,10 +1097,13 @@ export const useSettingsStore = create<SettingsStore>((set, get) => ({
 
   previewSkillZip: async (dataBase64) => window.api.settings.previewSkillZip({ dataBase64 }),
 
+  previewGitHubSkill: async (url) => window.api.settings.previewGitHubSkill({ url }),
+
   scanRepoSkills: async (repo) => window.api.settings.scanRepoSkills({ repo }),
 
   // Installed-skill discovery is read-only. Batch import returns the refreshed catalog directly.
   listAgentHomeSkills: async () => window.api.settings.listAgentHomeSkills(),
+  previewAgentHomeSkill: async (skill) => window.api.settings.previewAgentHomeSkill(skill),
   importAgentHomeSkills: async (skills) => {
     const result = await window.api.settings.importAgentHomeSkills({ skills })
     set({ skills: result.skills })

--- a/src/renderer/web/api-map.generated.ts
+++ b/src/renderer/web/api-map.generated.ts
@@ -133,6 +133,8 @@ export const WEB_INVOKE_CHANNELS = {
   'settings.logoutIsolatedCodex': 'settings:logout-isolated-codex',
   'settings.logoutSharedClaude': 'settings:logout-shared-claude',
   'settings.markOnboardingComplete': 'settings:mark-onboarding-complete',
+  'settings.previewAgentHomeSkill': 'settings:preview-agent-home-skill',
+  'settings.previewGitHubSkill': 'settings:preview-github-skill',
   'settings.previewSkillZip': 'settings:preview-skill-zip',
   'settings.refreshProviderModels': 'settings:refresh-provider-models',
   'settings.removeCustomServer': 'settings:remove-custom-server',

--- a/src/shared/settings.ts
+++ b/src/shared/settings.ts
@@ -799,6 +799,22 @@ export type PreviewSkillZipRequest = {
   dataBase64: string
 }
 
+// Read-only SKILL.md content shown before import. Every source adapter returns this renderer-safe
+// shape: sourceLabel is a display path/URL (never an absolute host path), metadata contains parsed
+// frontmatter fields other than name/description, and files contains relative names only.
+export type SkillImportPreviewContent = {
+  name: string
+  description: string
+  sourceLabel: string
+  metadata: Record<string, string>
+  body: string
+  files: string[]
+}
+
+export type PreviewGitHubSkillRequest = {
+  url: string
+}
+
 // Import several skills from ONE uploaded bundle in a single call, so a bundle holding many skills is
 // unpacked once instead of re-decoded per skill. Each item selects a skill root by subPath (and may
 // target an existing imported skill to replace).
@@ -828,6 +844,8 @@ export type SkillBundlePreview = {
   subPath: string
   name: string
   description: string
+  metadata: Record<string, string>
+  body: string
   files: string[]
   alreadyImported: boolean
   replaceableId?: string
@@ -878,6 +896,8 @@ export type AgentHomeSkillRef = {
   source: AgentHomeSkillSource
   slug: string
 }
+
+export type PreviewAgentHomeSkillRequest = AgentHomeSkillRef
 
 // Batch import selected user-level skills. Main re-derives every absolute path from the trusted
 // source id + slug pair, so the renderer cannot use this interface to read arbitrary host paths.


### PR DESCRIPTION
## Problem

Pre-import skill candidates can be selected, but their `SKILL.md` content and supporting metadata cannot be inspected before import. This affects installed/global skills, GitHub scan results, and uploaded Markdown or skill bundles.

## Proposed change

- Add one accessible, read-only candidate preview dialog shared by all three import flows.
- Render parsed `SKILL.md` bodies with `AgentMarkdown`, plus candidate description, safe source label, extra frontmatter metadata, and relative file/reference names.
- Lazy-load installed candidates through trusted source/slug resolution and realpath containment, without exposing host paths to the renderer.
- Lazy-load GitHub candidate `SKILL.md` content through the existing bounded GitHub import path instead of downloading every body during scans.
- Reuse the already-extracted body and metadata for ZIP/`.skill` uploads and the body already held for bare Markdown uploads.
- Keep row checkboxes selection-only and isolate preview loading failures per candidate.

## Scope and non-goals

- This changes only pre-import candidate rows.
- Existing catalog rows continue to use `SkillDetailView`; this preview intentionally has no enable toggle.
- Import resource caps, symlink rejection, path containment, Windows-compatible relative names, and selection state are preserved.

## Acceptance criteria and validation

- Installed, GitHub, ZIP/`.skill`, and bare Markdown candidates open and close the same preview without toggling selection.
- Installed preview responses and errors do not expose absolute host paths.
- GitHub preview downloads only the selected root `SKILL.md` and enforces request, depth, file-count, and byte limits.
- Archive previews reuse their bounded extraction result instead of reopening the archive.
- `npm run typecheck` — passed.
- `npm run lint` — passed with zero errors (existing repository warnings remain).
- `npm test` — 487 files passed, 10 skipped; 6,722 tests passed, 112 skipped.
- `npm run dev` — Electron main/preload/renderer development build completed and the app launched.

## Review focus

- The shared `SkillImportPreviewContent` interface and source-specific adapters.
- Installed-skill realpath/symlink handling and host-path redaction.
- GitHub lazy-loading bounds and the absence of eager body downloads during scans.
- Checkbox-versus-row interaction and stale async preview result handling.

## Dependency

Depends on #433. While #433 is unmerged, this PR is intentionally stacked on and targets `feat/import-global-skills`. After #433 merges, rebase this branch onto `main` and retarget this PR to `main` before merging. This PR is separate from #433 and must not add preview commits to that branch.
