### PR TITLE
ci(review): support Codex subscription auth

### DIFF
--- a/.github/action/ai-review.md
+++ b/.github/action/ai-review.md
@@ -88,6 +88,8 @@ is discarded with that runner and is not written back to the GitHub secret. If a
 returning `401` or can no longer refresh, run `codex login` again on the trusted machine and repeat
 the `gh secret set CODEX_AUTH_JSON` command. Each reviewer gets an independent temporary credential
 copy, so correctness and architecture reviews can run in parallel without a repository-wide lock.
+Newer runs cancel an older run for the same pull request and reviewer scope to avoid duplicate
+feedback and review-round consumption.
 
 Never commit, log, upload as an artifact, or cache `auth.json`. For fully automatic refresh, use the
 official trusted private-runner or external secret-manager pattern instead.

--- a/.github/action/ai-review.md
+++ b/.github/action/ai-review.md
@@ -86,8 +86,8 @@ secrets configured if those review paths should remain active.
 GitHub-hosted runners are ephemeral. Codex may refresh `auth.json` during a job, but the updated file
 is discarded with that runner and is not written back to the GitHub secret. If authentication starts
 returning `401` or can no longer refresh, run `codex login` again on the trusted machine and repeat
-the `gh secret set CODEX_AUTH_JSON` command. Subscription jobs are serialized to avoid concurrent
-use of the same credential copy.
+the `gh secret set CODEX_AUTH_JSON` command. Each reviewer gets an independent temporary credential
+copy, so correctness and architecture reviews can run in parallel without a repository-wide lock.
 
 Never commit, log, upload as an artifact, or cache `auth.json`. For fully automatic refresh, use the
 official trusted private-runner or external secret-manager pattern instead.

--- a/.github/action/ai-review.md
+++ b/.github/action/ai-review.md
@@ -33,10 +33,11 @@ Use a dedicated Codex account because `auth.json` contains access and refresh to
 jobs copy it into a temporary `CODEX_HOME`, remove passwordless sudo, and use a strict read-only
 permission profile that denies model-generated commands access to the entire authentication
 directory. The checkout is marked untrusted so PR-provided Codex configuration is ignored, and
-repository instruction loading is disabled. The job verifies that bubblewrap is installed and that
-the credential deny rule is enforced before review; it fails closed if the sandbox or sudo boundary
-is ineffective. Manual dispatch remains a trust decision because OpenAI does not recommend
-ChatGPT-managed auth for public or open-source CI.
+repository instruction loading is disabled. Before review, positive and negative `codex sandbox`
+probes verify that the packaged Linux sandbox can read the checkout but cannot read the credential;
+the job fails closed if the sandbox or sudo boundary is ineffective. A runner-global `bwrap`
+executable is not required. Manual dispatch remains a trust decision because OpenAI does not
+recommend ChatGPT-managed auth for public or open-source CI.
 
 ### 1. Create file-backed credentials
 

--- a/.github/action/ai-review.md
+++ b/.github/action/ai-review.md
@@ -39,6 +39,10 @@ the job fails closed if the sandbox or sudo boundary is ineffective. A runner-gl
 executable is not required. Manual dispatch remains a trust decision because OpenAI does not
 recommend ChatGPT-managed auth for public or open-source CI.
 
+The subscription path installs the pinned Codex CLI directly and does not pass subscription
+credentials through `openai/codex-action`. API-key mode continues using the pinned action for its
+Responses API proxy and key-isolation behavior.
+
 ### 1. Create file-backed credentials
 
 On a trusted machine, configure the Codex CLI to store credentials in a file:

--- a/.github/action/ai-review.md
+++ b/.github/action/ai-review.md
@@ -29,9 +29,13 @@ model, effort, reviewer-selection, fork, and round-limit variables continue to a
 > same-repository pull request. They are never exposed to automatic or fork review jobs, which
 > continue using the configured API-key credentials.
 
-Use a dedicated Codex account because `auth.json` contains access and refresh tokens. A malicious
-same-repository change could still attempt prompt injection during review; the manual dispatch is a
-trust decision, not a credential-isolation boundary.
+Use a dedicated Codex account because `auth.json` contains access and refresh tokens. Subscription
+jobs copy it into a temporary `CODEX_HOME`, remove passwordless sudo, and use a strict read-only
+permission profile that denies model-generated commands access to the entire authentication
+directory. The checkout is marked untrusted so PR-provided Codex configuration is ignored, and
+repository instruction loading is disabled. The job fails before review if either the sudo or
+filesystem boundary is ineffective. Manual dispatch remains a trust decision because OpenAI does
+not recommend ChatGPT-managed auth for public or open-source CI.
 
 ### 1. Create file-backed credentials
 
@@ -90,6 +94,11 @@ the `gh secret set CODEX_AUTH_JSON` command. Each reviewer gets an independent t
 copy, so correctness and architecture reviews can run in parallel without a repository-wide lock.
 Newer runs cancel an older run for the same pull request and reviewer scope to avoid duplicate
 feedback and review-round consumption.
+
+When `both` is selected, correctness and architecture start in parallel, so one workflow run has a
+natural maximum of two Codex review jobs. There is no repository-wide concurrency lock or
+cross-workflow maximum-N semaphore; GitHub Actions concurrency groups provide mutual exclusion, not
+a configurable shared capacity. Account or organization runner limits may still queue jobs.
 
 Never commit, log, upload as an artifact, or cache `auth.json`. For fully automatic refresh, use the
 official trusted private-runner or external secret-manager pattern instead.

--- a/.github/action/ai-review.md
+++ b/.github/action/ai-review.md
@@ -33,9 +33,10 @@ Use a dedicated Codex account because `auth.json` contains access and refresh to
 jobs copy it into a temporary `CODEX_HOME`, remove passwordless sudo, and use a strict read-only
 permission profile that denies model-generated commands access to the entire authentication
 directory. The checkout is marked untrusted so PR-provided Codex configuration is ignored, and
-repository instruction loading is disabled. The job fails before review if either the sudo or
-filesystem boundary is ineffective. Manual dispatch remains a trust decision because OpenAI does
-not recommend ChatGPT-managed auth for public or open-source CI.
+repository instruction loading is disabled. The job verifies that bubblewrap is installed and that
+the credential deny rule is enforced before review; it fails closed if the sandbox or sudo boundary
+is ineffective. Manual dispatch remains a trust decision because OpenAI does not recommend
+ChatGPT-managed auth for public or open-source CI.
 
 ### 1. Create file-backed credentials
 

--- a/.github/action/ai-review.md
+++ b/.github/action/ai-review.md
@@ -1,3 +1,5 @@
+<!-- Supplemental workflow maintainer notes; not part of the public documentation site. -->
+
 # AI review authentication
 
 The `AI PR Review` workflow supports API-key and Codex subscription authentication. API-key auth

--- a/.github/workflows/ai-codex-review.yml
+++ b/.github/workflows/ai-codex-review.yml
@@ -375,11 +375,6 @@ jobs:
         shell: bash
         run: |
           set -euo pipefail
-          if ! command -v bwrap > /dev/null 2>&1; then
-            echo "GitHub-hosted subscription reviews require bubblewrap." >&2
-            exit 1
-          fi
-
           current_user="$(id -un)"
           sudo -n bash -c '
             set -euo pipefail
@@ -417,6 +412,8 @@ jobs:
             echo "Subscription credential is unavailable to the Codex parent process." >&2
             exit 1
           fi
+          # These probes verify the packaged Codex Linux sandbox can both enforce a deny rule and
+          # retain normal repository reads. A runner-global bwrap executable is not required.
           if codex sandbox --permission-profile ai_review -C "$GITHUB_WORKSPACE" -- \
             test -r "$CODEX_HOME/auth.json"; then
             echo "Subscription credential remains readable inside the Codex sandbox." >&2

--- a/.github/workflows/ai-codex-review.yml
+++ b/.github/workflows/ai-codex-review.yml
@@ -3,6 +3,10 @@ name: Reusable Codex PR Review
 on:
   workflow_call:
     inputs:
+      auth_mode:
+        description: Authentication mode (api-key or subscription)
+        required: true
+        type: string
       scope:
         description: Review scope (correctness or architecture)
         required: true
@@ -44,10 +48,12 @@ on:
         required: true
         type: string
     secrets:
+      CODEX_AUTH_JSON:
+        required: false
       OPENAI_API_KEY:
-        required: true
+        required: false
       CODEX_BASE_URL:
-        required: true
+        required: false
     outputs:
       review_body:
         description: Normalized review comment body
@@ -65,8 +71,8 @@ jobs:
     runs-on: ubuntu-latest
     timeout-minutes: 30
     concurrency:
-      group: codex-${{ inputs.scope }}-review-${{ inputs.pull_request_number }}
-      cancel-in-progress: true
+      group: ${{ inputs.auth_mode == 'subscription' && format('codex-subscription-review-{0}', github.repository) || format('codex-{0}-review-{1}', inputs.scope, inputs.pull_request_number) }}
+      cancel-in-progress: ${{ inputs.auth_mode != 'subscription' }}
     permissions:
       contents: read
     outputs:
@@ -74,6 +80,68 @@ jobs:
       pr_number: ${{ inputs.pull_request_number }}
       head_sha: ${{ inputs.head_sha }}
     steps:
+      - name: Prepare Codex authentication
+        id: codex_auth
+        env:
+          CODEX_AUTH_JSON: ${{ inputs.auth_mode == 'subscription' && secrets.CODEX_AUTH_JSON || '' }}
+          CODEX_AUTH_MODE: ${{ inputs.auth_mode }}
+          CODEX_BASE_URL: ${{ inputs.auth_mode == 'api-key' && secrets.CODEX_BASE_URL || '' }}
+          IS_FORK: ${{ inputs.is_fork }}
+          OPENAI_API_KEY: ${{ inputs.auth_mode == 'api-key' && secrets.OPENAI_API_KEY || '' }}
+          REVIEW_EVENT: ${{ inputs.review_event }}
+        shell: bash
+        run: |
+          set -euo pipefail
+          codex_home="$RUNNER_TEMP/codex-home"
+          umask 077
+          mkdir -p "$codex_home"
+          chmod 700 "$codex_home"
+          case "$CODEX_AUTH_MODE" in
+            api-key)
+              if [[ -z "$OPENAI_API_KEY" ]]; then
+                echo "Repository secret OPENAI_API_KEY is required for API-key auth." >&2
+                exit 1
+              fi
+              if [[ -z "$CODEX_BASE_URL" ]]; then
+                echo "Repository secret CODEX_BASE_URL is required for API-key auth." >&2
+                exit 1
+              fi
+              ;;
+            subscription)
+              if [[ "$REVIEW_EVENT" != "workflow_dispatch" ]]; then
+                echo "Codex subscription auth is limited to manual workflow_dispatch reviews." >&2
+                exit 1
+              fi
+              if [[ "$IS_FORK" == "true" ]]; then
+                echo "Codex subscription auth is limited to same-repository pull requests." >&2
+                exit 1
+              fi
+              auth_file="$codex_home/auth.json"
+              if [[ -z "$CODEX_AUTH_JSON" ]]; then
+                echo "CODEX_AUTH_JSON is required for subscription auth." >&2
+                exit 1
+              fi
+              printf '%s' "$CODEX_AUTH_JSON" > "$auth_file"
+              if ! jq -e '
+                .auth_mode == "chatgpt" and
+                (.tokens | type == "object") and
+                ((.tokens.refresh_token // "") | length > 0)
+              ' "$auth_file" > /dev/null; then
+                echo "Codex subscription auth must be a valid chatgpt auth.json with a refresh token." >&2
+                exit 1
+              fi
+              chmod 600 "$auth_file"
+              ;;
+            *)
+              echo "Authentication mode must be api-key or subscription." >&2
+              exit 1
+              ;;
+          esac
+          {
+            echo "auth_mode=$CODEX_AUTH_MODE"
+            echo "codex_home=$codex_home"
+          } >> "$GITHUB_OUTPUT"
+
       - name: Checkout pull request review commit
         uses: actions/checkout@v7
         with:
@@ -101,6 +169,7 @@ jobs:
 
       - name: Resolve Responses API endpoint
         id: responses_endpoint
+        if: ${{ inputs.auth_mode == 'api-key' }}
         env:
           CODEX_BASE_URL: ${{ secrets.CODEX_BASE_URL }}
         shell: bash
@@ -115,16 +184,6 @@ jobs:
             endpoint="$endpoint/v1/responses"
           fi
           echo "url=$endpoint" >> "$GITHUB_OUTPUT"
-
-      - name: Validate API key
-        env:
-          OPENAI_API_KEY: ${{ secrets.OPENAI_API_KEY }}
-        shell: bash
-        run: |
-          if [[ -z "$OPENAI_API_KEY" ]]; then
-            echo "Repository secret OPENAI_API_KEY is required." >&2
-            exit 1
-          fi
 
       - name: Build Codex review inputs
         id: review_inputs
@@ -256,19 +315,39 @@ jobs:
             echo "review_header=$review_header"
           } >> "$GITHUB_OUTPUT"
 
+      # The pinned codex-action enables these only when it receives an API key or prompt. In
+      # subscription mode it is intentionally install-only, so prepare bubblewrap here before the
+      # later direct `codex exec` call.
+      - name: Prepare GitHub-hosted sandbox for subscription auth
+        if: ${{ inputs.auth_mode == 'subscription' }}
+        shell: bash
+        run: |
+          set -euo pipefail
+          current_userns="$(sysctl -n kernel.unprivileged_userns_clone 2>/dev/null || true)"
+          if [[ -n "$current_userns" && "$current_userns" != "1" ]]; then
+            sudo sysctl -w kernel.unprivileged_userns_clone=1
+          fi
+
+          current_apparmor="$(
+            sysctl -n kernel.apparmor_restrict_unprivileged_userns 2>/dev/null || true
+          )"
+          if [[ -n "$current_apparmor" && "$current_apparmor" != "0" ]]; then
+            sudo sysctl -w kernel.apparmor_restrict_unprivileged_userns=0
+          fi
+
       - name: Prepare Codex review runtime
         uses: openai/codex-action@52fe01ec70a42f454c9d2ebd47598f9fd6893d56 # v1
         with:
-          openai-api-key: ${{ secrets.OPENAI_API_KEY }}
+          openai-api-key: ${{ inputs.auth_mode == 'api-key' && secrets.OPENAI_API_KEY || '' }}
           responses-api-endpoint: ${{ steps.responses_endpoint.outputs.url }}
-          codex-home: ${{ runner.temp }}/codex-home
+          codex-home: ${{ steps.codex_auth.outputs.codex_home }}
           allow-users: ${{ inputs.is_fork && inputs.fork_mode == 'automatic' && '*' || '' }}
 
       - name: Run Codex review
         id: run_codex
         env:
           CODEX_EFFORT: ${{ inputs.effort }}
-          CODEX_HOME: ${{ runner.temp }}/codex-home
+          CODEX_HOME: ${{ steps.codex_auth.outputs.codex_home }}
           CODEX_INSTRUCTIONS_FILE: ${{ steps.review_inputs.outputs.instructions_file }}
           CODEX_MODEL: ${{ inputs.model }}
           CODEX_PROMPT_FILE: ${{ steps.review_inputs.outputs.prompt_file }}

--- a/.github/workflows/ai-codex-review.yml
+++ b/.github/workflows/ai-codex-review.yml
@@ -71,7 +71,7 @@ jobs:
     runs-on: ubuntu-latest
     timeout-minutes: 30
     concurrency:
-      group: ${{ inputs.auth_mode == 'subscription' && format('codex-subscription-review-{0}', github.repository) || format('codex-{0}-review-{1}', inputs.scope, inputs.pull_request_number) }}
+      group: ${{ format('codex-{0}-review-{1}', inputs.scope, inputs.pull_request_number) }}
       cancel-in-progress: ${{ inputs.auth_mode != 'subscription' }}
     permissions:
       contents: read

--- a/.github/workflows/ai-codex-review.yml
+++ b/.github/workflows/ai-codex-review.yml
@@ -375,6 +375,11 @@ jobs:
         shell: bash
         run: |
           set -euo pipefail
+          if ! command -v bwrap > /dev/null 2>&1; then
+            echo "GitHub-hosted subscription reviews require bubblewrap." >&2
+            exit 1
+          fi
+
           current_user="$(id -un)"
           sudo -n bash -c '
             set -euo pipefail

--- a/.github/workflows/ai-codex-review.yml
+++ b/.github/workflows/ai-codex-review.yml
@@ -106,6 +106,7 @@ jobs:
                 echo "Repository secret CODEX_BASE_URL is required for API-key auth." >&2
                 exit 1
               fi
+              permission_profile=':read-only'
               ;;
             subscription)
               if [[ "$REVIEW_EVENT" != "workflow_dispatch" ]]; then
@@ -131,12 +132,33 @@ jobs:
                 exit 1
               fi
               chmod 600 "$auth_file"
+              permission_profile='ai_review'
               ;;
             *)
               echo "Authentication mode must be api-key or subscription." >&2
               exit 1
               ;;
           esac
+
+          codex_home_key="$(jq -Rn --arg path "$codex_home" '$path')"
+          workspace_key="$(jq -Rn --arg path "$GITHUB_WORKSPACE" '$path')"
+          {
+            printf 'default_permissions = "%s"\n' "$permission_profile"
+            echo 'project_doc_max_bytes = 0'
+            echo
+            printf '[projects.%s]\n' "$workspace_key"
+            echo 'trust_level = "untrusted"'
+            if [[ "$CODEX_AUTH_MODE" == "subscription" ]]; then
+              echo
+              echo '[permissions.ai_review]'
+              echo 'description = "Read-only PR review with credential isolation."'
+              echo 'extends = ":read-only"'
+              echo
+              echo '[permissions.ai_review.filesystem]'
+              printf '%s = "deny"\n' "$codex_home_key"
+            fi
+          } > "$codex_home/config.toml"
+          chmod 600 "$codex_home/config.toml"
           {
             echo "auth_mode=$CODEX_AUTH_MODE"
             echo "codex_home=$codex_home"
@@ -341,7 +363,62 @@ jobs:
           openai-api-key: ${{ inputs.auth_mode == 'api-key' && secrets.OPENAI_API_KEY || '' }}
           responses-api-endpoint: ${{ steps.responses_endpoint.outputs.url }}
           codex-home: ${{ steps.codex_auth.outputs.codex_home }}
+          codex-version: 0.144.6
           allow-users: ${{ inputs.is_fork && inputs.fork_mode == 'automatic' && '*' || '' }}
+
+      # The action drops sudo when it receives an API key. Subscription auth is install-only, so
+      # apply the same boundary explicitly before reviewing untrusted repository content.
+      - name: Harden subscription review runtime
+        if: ${{ inputs.auth_mode == 'subscription' }}
+        env:
+          CODEX_HOME: ${{ steps.codex_auth.outputs.codex_home }}
+        shell: bash
+        run: |
+          set -euo pipefail
+          current_user="$(id -un)"
+          sudo -n bash -c '
+            set -euo pipefail
+            user="$1"
+            if id -nG "$user" | tr " " "\n" | grep -qx sudo; then
+              if command -v deluser > /dev/null 2>&1; then
+                deluser "$user" sudo
+              else
+                gpasswd -d "$user" sudo
+              fi
+            fi
+
+            temporary_file="$(mktemp)"
+            trap '\''rm -f "$temporary_file"'\'' EXIT
+            for sudoers_file in /etc/sudoers /etc/sudoers.d/*; do
+              [[ -f "$sudoers_file" ]] || continue
+              awk -v username="$user" '\''
+                {
+                  candidate = $0
+                  sub(/^[[:space:]]*/, "", candidate)
+                  split(candidate, fields, /[[:space:]]+/)
+                  if (fields[1] != username) print
+                }
+              '\'' "$sudoers_file" > "$temporary_file"
+              cat "$temporary_file" > "$sudoers_file"
+            done
+          ' bash "$current_user"
+          sudo -K || true
+
+          if sudo -n true 2> /dev/null; then
+            echo "Subscription review user still has passwordless sudo." >&2
+            exit 1
+          fi
+          if [[ ! -r "$CODEX_HOME/auth.json" ]]; then
+            echo "Subscription credential is unavailable to the Codex parent process." >&2
+            exit 1
+          fi
+          if codex sandbox --permission-profile ai_review -C "$GITHUB_WORKSPACE" -- \
+            test -r "$CODEX_HOME/auth.json"; then
+            echo "Subscription credential remains readable inside the Codex sandbox." >&2
+            exit 1
+          fi
+          codex sandbox --permission-profile ai_review -C "$GITHUB_WORKSPACE" -- \
+            test -r "$GITHUB_WORKSPACE/package.json"
 
       - name: Run Codex review
         id: run_codex
@@ -350,6 +427,7 @@ jobs:
           CODEX_HOME: ${{ steps.codex_auth.outputs.codex_home }}
           CODEX_INSTRUCTIONS_FILE: ${{ steps.review_inputs.outputs.instructions_file }}
           CODEX_MODEL: ${{ inputs.model }}
+          CODEX_PERMISSION_PROFILE: ${{ inputs.auth_mode == 'subscription' && 'ai_review' || ':read-only' }}
           CODEX_PROMPT_FILE: ${{ steps.review_inputs.outputs.prompt_file }}
           CODEX_SCHEMA_FILE: ${{ steps.review_inputs.outputs.schema_file }}
           CODEX_INTERNAL_ORIGINATOR_OVERRIDE: codex_github_action
@@ -367,6 +445,7 @@ jobs:
 
           set +e
           codex exec \
+            --strict-config \
             --skip-git-repo-check \
             --cd "$GITHUB_WORKSPACE" \
             --output-last-message "$final_message_file" \
@@ -377,7 +456,8 @@ jobs:
             --ignore-rules \
             --json \
             --config "developer_instructions=${developer_instructions}" \
-            --config 'default_permissions=":read-only"' \
+            --config project_doc_max_bytes=0 \
+            --config "default_permissions=\"${CODEX_PERMISSION_PROFILE}\"" \
             < "$CODEX_PROMPT_FILE" \
             > "$execution_file"
           codex_status=$?

--- a/.github/workflows/ai-codex-review.yml
+++ b/.github/workflows/ai-codex-review.yml
@@ -80,6 +80,23 @@ jobs:
       pr_number: ${{ inputs.pull_request_number }}
       head_sha: ${{ inputs.head_sha }}
     steps:
+      # Install before credentials are written or untrusted repository files are checked out.
+      - name: Set up Node.js for subscription auth
+        if: ${{ inputs.auth_mode == 'subscription' }}
+        uses: actions/setup-node@53b83947a5a98c8d113130e565377fae1a50d02f # v6.3.0
+        with:
+          node-version: '24'
+
+      - name: Install Codex CLI for subscription auth
+        if: ${{ inputs.auth_mode == 'subscription' }}
+        env:
+          CODEX_VERSION: 0.144.6
+        shell: bash
+        run: |
+          set -euo pipefail
+          npm install -g "@openai/codex@${CODEX_VERSION}"
+          codex --version
+
       - name: Prepare Codex authentication
         id: codex_auth
         env:
@@ -337,9 +354,8 @@ jobs:
             echo "review_header=$review_header"
           } >> "$GITHUB_OUTPUT"
 
-      # The pinned codex-action enables these only when it receives an API key or prompt. In
-      # subscription mode it is intentionally install-only, so prepare bubblewrap here before the
-      # later direct `codex exec` call.
+      # The API action enables these only when it receives an API key or prompt. Subscription mode
+      # installs the CLI directly, so prepare the packaged Linux sandbox before `codex exec`.
       - name: Prepare GitHub-hosted sandbox for subscription auth
         if: ${{ inputs.auth_mode == 'subscription' }}
         shell: bash
@@ -358,6 +374,7 @@ jobs:
           fi
 
       - name: Prepare Codex review runtime
+        if: ${{ inputs.auth_mode == 'api-key' }}
         uses: openai/codex-action@52fe01ec70a42f454c9d2ebd47598f9fd6893d56 # v1
         with:
           openai-api-key: ${{ inputs.auth_mode == 'api-key' && secrets.OPENAI_API_KEY || '' }}
@@ -366,8 +383,8 @@ jobs:
           codex-version: 0.144.6
           allow-users: ${{ inputs.is_fork && inputs.fork_mode == 'automatic' && '*' || '' }}
 
-      # The action drops sudo when it receives an API key. Subscription auth is install-only, so
-      # apply the same boundary explicitly before reviewing untrusted repository content.
+      # The API action drops sudo itself. Apply the same boundary to the directly installed
+      # subscription CLI before reviewing untrusted repository content.
       - name: Harden subscription review runtime
         if: ${{ inputs.auth_mode == 'subscription' }}
         env:

--- a/.github/workflows/ai-codex-review.yml
+++ b/.github/workflows/ai-codex-review.yml
@@ -72,7 +72,7 @@ jobs:
     timeout-minutes: 30
     concurrency:
       group: ${{ format('codex-{0}-review-{1}', inputs.scope, inputs.pull_request_number) }}
-      cancel-in-progress: ${{ inputs.auth_mode != 'subscription' }}
+      cancel-in-progress: true
     permissions:
       contents: read
     outputs:

--- a/.github/workflows/ai-review.yml
+++ b/.github/workflows/ai-review.yml
@@ -1,10 +1,14 @@
 name: AI PR Review
 
-# Required repository configuration:
-# - Shared fallback secrets: OPENAI_API_KEY and CODEX_BASE_URL
+# Authentication defaults to API keys. See docs/ai-review.md for the supported API-key and Codex
+# subscription configurations and their security boundaries.
+# - Shared fallback API secrets: OPENAI_API_KEY and CODEX_BASE_URL
 # - Reviewer-specific secrets: CODEX_CORRECTNESS_API_KEY / CODEX_CORRECTNESS_BASE_URL and
 #   CODEX_ARCHITECTURE_API_KEY / CODEX_ARCHITECTURE_BASE_URL
 #   (base URLs may omit the trailing slash or include the full /v1/responses endpoint)
+# - Subscription bootstrap secret: CODEX_AUTH_JSON
+# Set CODEX_REVIEW_AUTH_MODE to api-key (default) or subscription. Subscription mode uses a
+# GitHub-hosted runner and is limited to manually dispatched reviews of same-repository PRs.
 # Set ENABLE_CODEX_REVIEW=false to disable all automated reviewers. Set CODEX_REVIEW_MODE to both,
 # correctness, architecture, or disabled for automatic pull request events (default: correctness).
 # CODEX_REVIEW_MODEL and CODEX_REVIEW_EFFORT provide shared defaults. Override either reviewer with
@@ -42,7 +46,7 @@ on:
 
 concurrency:
   group: ai-pr-review-${{ github.event.inputs.pull_request_number || github.event.pull_request.number }}-${{ github.event_name == 'workflow_dispatch' && github.event.inputs.reviewer || 'both' }}
-  cancel-in-progress: true
+  cancel-in-progress: ${{ (vars.CODEX_REVIEW_AUTH_MODE || 'api-key') != 'subscription' }}
 
 jobs:
   review_target:
@@ -63,6 +67,7 @@ jobs:
       review_allowed: ${{ steps.target.outputs.review_allowed }}
       correctness_enabled: ${{ steps.target.outputs.correctness_enabled }}
       architecture_enabled: ${{ steps.target.outputs.architecture_enabled }}
+      auth_mode: ${{ steps.target.outputs.auth_mode }}
     steps:
       - name: Resolve pull request metadata
         id: target
@@ -72,6 +77,7 @@ jobs:
           DISPATCH_PR_NUMBER: ${{ github.event.inputs.pull_request_number }}
           EVENT_PR_NUMBER: ${{ github.event.pull_request.number }}
           FORK_REVIEW_MODE: ${{ vars.FORK_REVIEW_MODE || 'manual' }}
+          CODEX_REVIEW_AUTH_MODE: ${{ vars.CODEX_REVIEW_AUTH_MODE || 'api-key' }}
           ENABLE_CODEX_REVIEW: ${{ vars.ENABLE_CODEX_REVIEW || 'true' }}
           CODEX_REVIEW_MODE: ${{ vars.CODEX_REVIEW_MODE || 'correctness' }}
           DISPATCH_REVIEWER: ${{ github.event.inputs.reviewer }}
@@ -100,7 +106,13 @@ jobs:
               exit 1
               ;;
           esac
-
+          case "$CODEX_REVIEW_AUTH_MODE" in
+            api-key|subscription) ;;
+            *)
+              echo "CODEX_REVIEW_AUTH_MODE must be api-key or subscription." >&2
+              exit 1
+              ;;
+          esac
           pr_number="${DISPATCH_PR_NUMBER:-$EVENT_PR_NUMBER}"
           if [[ -z "$pr_number" ]]; then
             echo "No pull request number available (workflow_dispatch input or pull_request event)." >&2
@@ -127,6 +139,10 @@ jobs:
             [[ "$REVIEW_EVENT" == "workflow_dispatch" && "$FORK_REVIEW_MODE" != "disabled" ]] ||
             [[ "$REVIEW_EVENT" != "workflow_dispatch" && "$FORK_REVIEW_MODE" == "automatic" ]]; then
             review_allowed=true
+          fi
+          if [[ "$CODEX_REVIEW_AUTH_MODE" == "subscription" ]] &&
+            [[ "$REVIEW_EVENT" != "workflow_dispatch" || "$is_fork" == "true" ]]; then
+            review_allowed=false
           fi
 
           selected_mode="$CODEX_REVIEW_MODE"
@@ -165,6 +181,7 @@ jobs:
             echo "review_allowed=$review_allowed"
             echo "correctness_enabled=$correctness_enabled"
             echo "architecture_enabled=$architecture_enabled"
+            echo "auth_mode=$CODEX_REVIEW_AUTH_MODE"
           } >> "$GITHUB_OUTPUT"
 
   codex_review_gate:
@@ -250,6 +267,7 @@ jobs:
       contents: read
     uses: ./.github/workflows/ai-codex-review.yml
     with:
+      auth_mode: ${{ needs.review_target.outputs.auth_mode }}
       scope: correctness
       pull_request_number: ${{ needs.review_target.outputs.number }}
       head_ref: ${{ needs.review_target.outputs.head_ref }}
@@ -264,6 +282,7 @@ jobs:
       model: ${{ vars.CODEX_CORRECTNESS_MODEL || vars.CODEX_REVIEW_MODEL || 'gpt-5.6-sol' }}
       effort: ${{ vars.CODEX_CORRECTNESS_EFFORT || vars.CODEX_REVIEW_EFFORT || 'high' }}
     secrets:
+      CODEX_AUTH_JSON: ${{ secrets.CODEX_AUTH_JSON }}
       OPENAI_API_KEY: ${{ secrets.CODEX_CORRECTNESS_API_KEY || secrets.OPENAI_API_KEY }}
       CODEX_BASE_URL: ${{ secrets.CODEX_CORRECTNESS_BASE_URL || secrets.CODEX_BASE_URL }}
 
@@ -275,6 +294,7 @@ jobs:
       contents: read
     uses: ./.github/workflows/ai-codex-review.yml
     with:
+      auth_mode: ${{ needs.review_target.outputs.auth_mode }}
       scope: architecture
       pull_request_number: ${{ needs.review_target.outputs.number }}
       head_ref: ${{ needs.review_target.outputs.head_ref }}
@@ -289,6 +309,7 @@ jobs:
       model: ${{ vars.CODEX_ARCHITECTURE_MODEL || vars.CODEX_REVIEW_MODEL || 'gpt-5.6-sol' }}
       effort: ${{ vars.CODEX_ARCHITECTURE_EFFORT || vars.CODEX_REVIEW_EFFORT || 'high' }}
     secrets:
+      CODEX_AUTH_JSON: ${{ secrets.CODEX_AUTH_JSON }}
       OPENAI_API_KEY: ${{ secrets.CODEX_ARCHITECTURE_API_KEY || secrets.OPENAI_API_KEY }}
       CODEX_BASE_URL: ${{ secrets.CODEX_ARCHITECTURE_BASE_URL || secrets.CODEX_BASE_URL }}
 

--- a/.github/workflows/ai-review.yml
+++ b/.github/workflows/ai-review.yml
@@ -7,8 +7,8 @@ name: AI PR Review
 #   CODEX_ARCHITECTURE_API_KEY / CODEX_ARCHITECTURE_BASE_URL
 #   (base URLs may omit the trailing slash or include the full /v1/responses endpoint)
 # - Subscription bootstrap secret: CODEX_AUTH_JSON
-# Set CODEX_REVIEW_AUTH_MODE to api-key (default) or subscription. Subscription mode uses a
-# GitHub-hosted runner and is limited to manually dispatched reviews of same-repository PRs.
+# Set CODEX_REVIEW_AUTH_MODE to api-key (default) or subscription. Subscription auth is used only
+# for manually dispatched same-repository PRs; automatic and fork reviews fall back to API keys.
 # Set ENABLE_CODEX_REVIEW=false to disable all automated reviewers. Set CODEX_REVIEW_MODE to both,
 # correctness, architecture, or disabled for automatic pull request events (default: correctness).
 # CODEX_REVIEW_MODEL and CODEX_REVIEW_EFFORT provide shared defaults. Override either reviewer with
@@ -140,9 +140,10 @@ jobs:
             [[ "$REVIEW_EVENT" != "workflow_dispatch" && "$FORK_REVIEW_MODE" == "automatic" ]]; then
             review_allowed=true
           fi
-          if [[ "$CODEX_REVIEW_AUTH_MODE" == "subscription" ]] &&
+          effective_auth_mode="$CODEX_REVIEW_AUTH_MODE"
+          if [[ "$effective_auth_mode" == "subscription" ]] &&
             [[ "$REVIEW_EVENT" != "workflow_dispatch" || "$is_fork" == "true" ]]; then
-            review_allowed=false
+            effective_auth_mode=api-key
           fi
 
           selected_mode="$CODEX_REVIEW_MODE"
@@ -181,7 +182,7 @@ jobs:
             echo "review_allowed=$review_allowed"
             echo "correctness_enabled=$correctness_enabled"
             echo "architecture_enabled=$architecture_enabled"
-            echo "auth_mode=$CODEX_REVIEW_AUTH_MODE"
+            echo "auth_mode=$effective_auth_mode"
           } >> "$GITHUB_OUTPUT"
 
   codex_review_gate:

--- a/.github/workflows/ai-review.yml
+++ b/.github/workflows/ai-review.yml
@@ -1,7 +1,7 @@
 name: AI PR Review
 
-# Authentication defaults to API keys. See docs/ai-review.md for the supported API-key and Codex
-# subscription configurations and their security boundaries.
+# Authentication defaults to API keys. See .github/action/ai-review.md for the supported API-key
+# and Codex subscription configurations and their security boundaries.
 # - Shared fallback API secrets: OPENAI_API_KEY and CODEX_BASE_URL
 # - Reviewer-specific secrets: CODEX_CORRECTNESS_API_KEY / CODEX_CORRECTNESS_BASE_URL and
 #   CODEX_ARCHITECTURE_API_KEY / CODEX_ARCHITECTURE_BASE_URL

--- a/.github/workflows/ai-review.yml
+++ b/.github/workflows/ai-review.yml
@@ -46,7 +46,7 @@ on:
 
 concurrency:
   group: ai-pr-review-${{ github.event.inputs.pull_request_number || github.event.pull_request.number }}-${{ github.event_name == 'workflow_dispatch' && github.event.inputs.reviewer || 'both' }}
-  cancel-in-progress: ${{ (vars.CODEX_REVIEW_AUTH_MODE || 'api-key') != 'subscription' }}
+  cancel-in-progress: true
 
 jobs:
   review_target:

--- a/.github/workflows/ai-review.yml
+++ b/.github/workflows/ai-review.yml
@@ -283,7 +283,7 @@ jobs:
       model: ${{ vars.CODEX_CORRECTNESS_MODEL || vars.CODEX_REVIEW_MODEL || 'gpt-5.6-sol' }}
       effort: ${{ vars.CODEX_CORRECTNESS_EFFORT || vars.CODEX_REVIEW_EFFORT || 'high' }}
     secrets:
-      CODEX_AUTH_JSON: ${{ secrets.CODEX_AUTH_JSON }}
+      CODEX_AUTH_JSON: ${{ needs.review_target.outputs.auth_mode == 'subscription' && secrets.CODEX_AUTH_JSON || '' }}
       OPENAI_API_KEY: ${{ secrets.CODEX_CORRECTNESS_API_KEY || secrets.OPENAI_API_KEY }}
       CODEX_BASE_URL: ${{ secrets.CODEX_CORRECTNESS_BASE_URL || secrets.CODEX_BASE_URL }}
 
@@ -310,7 +310,7 @@ jobs:
       model: ${{ vars.CODEX_ARCHITECTURE_MODEL || vars.CODEX_REVIEW_MODEL || 'gpt-5.6-sol' }}
       effort: ${{ vars.CODEX_ARCHITECTURE_EFFORT || vars.CODEX_REVIEW_EFFORT || 'high' }}
     secrets:
-      CODEX_AUTH_JSON: ${{ secrets.CODEX_AUTH_JSON }}
+      CODEX_AUTH_JSON: ${{ needs.review_target.outputs.auth_mode == 'subscription' && secrets.CODEX_AUTH_JSON || '' }}
       OPENAI_API_KEY: ${{ secrets.CODEX_ARCHITECTURE_API_KEY || secrets.OPENAI_API_KEY }}
       CODEX_BASE_URL: ${{ secrets.CODEX_ARCHITECTURE_BASE_URL || secrets.CODEX_BASE_URL }}
 

--- a/docs/ai-review.md
+++ b/docs/ai-review.md
@@ -1,0 +1,95 @@
+# AI review authentication
+
+The `AI PR Review` workflow supports API-key and Codex subscription authentication. API-key auth
+remains the default and is the only mode used for automatic or fork pull request reviews.
+
+## API-key mode
+
+Set the shared fallback secrets:
+
+- `OPENAI_API_KEY`
+- `CODEX_BASE_URL` (the API root or full `/v1/responses` endpoint)
+
+The correctness and architecture reviewers can use independent credentials:
+
+- `CODEX_CORRECTNESS_API_KEY` and `CODEX_CORRECTNESS_BASE_URL`
+- `CODEX_ARCHITECTURE_API_KEY` and `CODEX_ARCHITECTURE_BASE_URL`
+
+Set the `CODEX_REVIEW_AUTH_MODE` repository variable to `api-key`, or leave it unset. Existing
+model, effort, reviewer-selection, fork, and round-limit variables continue to apply.
+
+## Codex subscription mode
+
+> [!WARNING]
+> OpenAI recommends API keys for CI/CD and says not to use ChatGPT-managed `auth.json` automation
+> for public or open-source repositories. This workflow offers a narrower opt-in for a dedicated
+> account: subscription credentials are accepted only for a manually dispatched review of a
+> same-repository pull request. They are never exposed to automatic or fork review jobs.
+
+Use a dedicated Codex account because `auth.json` contains access and refresh tokens. A malicious
+same-repository change could still attempt prompt injection during review; the manual dispatch is a
+trust decision, not a credential-isolation boundary.
+
+### 1. Create file-backed credentials
+
+On a trusted machine, configure the Codex CLI to store credentials in a file:
+
+```toml
+cli_auth_credentials_store = "file"
+```
+
+Sign in with the dedicated account:
+
+```bash
+codex login
+codex login status
+```
+
+Verify the generated file without printing its tokens:
+
+```bash
+AUTH_FILE="${CODEX_HOME:-$HOME/.codex}/auth.json"
+jq '{
+  auth_mode,
+  has_refresh_token: ((.tokens.refresh_token // "") != ""),
+  last_refresh
+}' "$AUTH_FILE"
+```
+
+Continue only when `auth_mode` is `chatgpt` and `has_refresh_token` is `true`.
+
+### 2. Configure GitHub
+
+Store the complete file as a repository secret, then select subscription auth:
+
+```bash
+AUTH_FILE="${CODEX_HOME:-$HOME/.codex}/auth.json"
+gh secret set CODEX_AUTH_JSON < "$AUTH_FILE"
+gh variable set CODEX_REVIEW_AUTH_MODE --body subscription
+```
+
+`OPENAI_API_KEY` and `CODEX_BASE_URL` are ignored in subscription mode. Model and effort variables
+still apply, so select a model available to the dedicated Codex account.
+
+### 3. Run a review
+
+Open **Actions → AI PR Review → Run workflow**, enter the same-repository pull request number, and
+choose `correctness`, `architecture`, or `both`. Automatic `pull_request_target` events and fork
+pull requests do not start subscription-authenticated jobs.
+
+### Credential refresh limitation
+
+GitHub-hosted runners are ephemeral. Codex may refresh `auth.json` during a job, but the updated file
+is discarded with that runner and is not written back to the GitHub secret. If authentication starts
+returning `401` or can no longer refresh, run `codex login` again on the trusted machine and repeat
+the `gh secret set CODEX_AUTH_JSON` command. Subscription jobs are serialized to avoid concurrent
+use of the same credential copy.
+
+Never commit, log, upload as an artifact, or cache `auth.json`. For fully automatic refresh, use the
+official trusted private-runner or external secret-manager pattern instead.
+
+## References
+
+- [Codex authentication](https://learn.chatgpt.com/docs/auth)
+- [Maintain Codex account auth in CI/CD (advanced)](https://learn.chatgpt.com/docs/auth/ci-cd-auth)
+- [Codex GitHub Action](https://learn.chatgpt.com/docs/github-action)

--- a/docs/ai-review.md
+++ b/docs/ai-review.md
@@ -24,7 +24,8 @@ model, effort, reviewer-selection, fork, and round-limit variables continue to a
 > OpenAI recommends API keys for CI/CD and says not to use ChatGPT-managed `auth.json` automation
 > for public or open-source repositories. This workflow offers a narrower opt-in for a dedicated
 > account: subscription credentials are accepted only for a manually dispatched review of a
-> same-repository pull request. They are never exposed to automatic or fork review jobs.
+> same-repository pull request. They are never exposed to automatic or fork review jobs, which
+> continue using the configured API-key credentials.
 
 Use a dedicated Codex account because `auth.json` contains access and refresh tokens. A malicious
 same-repository change could still attempt prompt injection during review; the manual dispatch is a
@@ -75,7 +76,8 @@ still apply, so select a model available to the dedicated Codex account.
 
 Open **Actions → AI PR Review → Run workflow**, enter the same-repository pull request number, and
 choose `correctness`, `architecture`, or `both`. Automatic `pull_request_target` events and fork
-pull requests do not start subscription-authenticated jobs.
+pull requests fall back to API-key auth and continue following `FORK_REVIEW_MODE`; keep the API-key
+secrets configured if those review paths should remain active.
 
 ### Credential refresh limitation
 

--- a/scripts/ai-review-workflows.test.ts
+++ b/scripts/ai-review-workflows.test.ts
@@ -49,7 +49,7 @@ const publisherText = readFileSync(
   join(process.cwd(), '.github/workflows/ai-post-review.yml'),
   'utf8'
 )
-const reviewDocsText = readFileSync(join(process.cwd(), 'docs/ai-review.md'), 'utf8')
+const reviewDocsText = readFileSync(join(process.cwd(), '.github/action/ai-review.md'), 'utf8')
 const mainWorkflow = load(mainText) as Workflow
 const codexWorkflow = load(codexText) as Workflow
 const publisherWorkflow = load(publisherText) as Workflow

--- a/scripts/ai-review-workflows.test.ts
+++ b/scripts/ai-review-workflows.test.ts
@@ -1,4 +1,12 @@
-import { chmodSync, mkdtempSync, mkdirSync, readFileSync, rmSync, writeFileSync } from 'node:fs'
+import {
+  chmodSync,
+  mkdtempSync,
+  mkdirSync,
+  readFileSync,
+  rmSync,
+  statSync,
+  writeFileSync
+} from 'node:fs'
 import { tmpdir } from 'node:os'
 import { join } from 'node:path'
 import { spawnSync } from 'node:child_process'
@@ -17,6 +25,7 @@ type WorkflowStep = {
 }
 
 type WorkflowJob = {
+  concurrency?: { group: string; 'cancel-in-progress': boolean | string }
   steps?: WorkflowStep[]
   if?: string
   name?: string
@@ -30,7 +39,7 @@ type WorkflowJob = {
 }
 
 type Workflow = {
-  concurrency?: { group: string; 'cancel-in-progress': boolean }
+  concurrency?: { group: string; 'cancel-in-progress': boolean | string }
   jobs: Record<string, WorkflowJob>
 }
 
@@ -40,6 +49,7 @@ const publisherText = readFileSync(
   join(process.cwd(), '.github/workflows/ai-post-review.yml'),
   'utf8'
 )
+const reviewDocsText = readFileSync(join(process.cwd(), 'docs/ai-review.md'), 'utf8')
 const mainWorkflow = load(mainText) as Workflow
 const codexWorkflow = load(codexText) as Workflow
 const publisherWorkflow = load(publisherText) as Workflow
@@ -82,6 +92,7 @@ function simpleOutputs(path: string): Record<string, string> {
 }
 
 type TargetOptions = {
+  authMode?: 'api-key' | 'subscription'
   event?: 'pull_request_target' | 'workflow_dispatch'
   dispatchReviewer?: string
   automaticMode?: 'both' | 'correctness' | 'architecture' | 'disabled'
@@ -132,6 +143,7 @@ printf '%s' "$PR_JSON"
         DISPATCH_PR_NUMBER: event === 'workflow_dispatch' ? '392' : '',
         EVENT_PR_NUMBER: event === 'pull_request_target' ? '392' : '',
         FORK_REVIEW_MODE: options.forkMode ?? 'manual',
+        CODEX_REVIEW_AUTH_MODE: options.authMode ?? 'api-key',
         ENABLE_CODEX_REVIEW: options.enabled ?? 'true',
         CODEX_REVIEW_MODE: options.automaticMode ?? 'correctness',
         DISPATCH_REVIEWER: options.dispatchReviewer ?? 'both',
@@ -144,6 +156,60 @@ printf '%s' "$PR_JSON"
     status: result.status,
     stderr: result.stderr,
     outputs: result.status === 0 ? simpleOutputs(output) : {}
+  }
+}
+
+type AuthOptions = {
+  authJson?: string
+  authMode?: 'api-key' | 'subscription'
+  baseUrl?: string
+  event?: 'pull_request_target' | 'workflow_dispatch'
+  isFork?: boolean
+  openAiApiKey?: string
+}
+
+function runAuth(options: AuthOptions = {}): {
+  authFile: string
+  codexHome: string
+  mode: number | undefined
+  outputs: Record<string, string>
+  status: number | null
+  stderr: string
+} {
+  const root = fixtureRoot('dual-codex-auth-')
+  const codexHome = join(root, 'codex-home')
+  const authFile = join(codexHome, 'auth.json')
+  const output = join(root, 'github-output')
+  const result = spawnSync(
+    'bash',
+    ['-c', getRun(codexWorkflow, 'review', 'Prepare Codex authentication')],
+    {
+      cwd: root,
+      encoding: 'utf8',
+      env: {
+        ...process.env,
+        CODEX_AUTH_JSON: options.authJson ?? '',
+        CODEX_AUTH_MODE: options.authMode ?? 'api-key',
+        CODEX_BASE_URL: options.baseUrl ?? 'https://api.openai.com',
+        GITHUB_OUTPUT: output,
+        GITHUB_REPOSITORY: 'aipoch/open-science',
+        IS_FORK: String(options.isFork ?? false),
+        OPENAI_API_KEY: options.openAiApiKey ?? 'sk-test',
+        REVIEW_EVENT: options.event ?? 'workflow_dispatch',
+        RUNNER_TEMP: root
+      }
+    }
+  )
+  return {
+    authFile,
+    codexHome,
+    mode:
+      result.status === 0 && options.authMode === 'subscription'
+        ? statSync(authFile).mode
+        : undefined,
+    outputs: result.status === 0 ? simpleOutputs(output) : {},
+    status: result.status,
+    stderr: result.stderr
   }
 }
 
@@ -304,6 +370,15 @@ describe('dual Codex workflow contract', () => {
     expect(() => load(publisherText)).not.toThrow()
   })
 
+  it('documents subscription setup and credential refresh limitations', () => {
+    expect(reviewDocsText).toContain('gh secret set CODEX_AUTH_JSON')
+    expect(reviewDocsText).toContain('gh variable set CODEX_REVIEW_AUTH_MODE --body subscription')
+    expect(reviewDocsText).toContain('GitHub-hosted runners are ephemeral')
+    expect(reviewDocsText).toContain(
+      'manually dispatched review of a\n> same-repository pull request'
+    )
+  })
+
   it('removes Claude, Anthropic, and CodeGraph runtime configuration', () => {
     const all = `${mainText}\n${codexText}\n${publisherText}`
     expect(all).not.toMatch(/Claude|CLAUDE|Anthropic|ANTHROPIC|CodeGraph|CODEGRAPH/)
@@ -363,6 +438,27 @@ describe('dual Codex workflow contract', () => {
     expect(runTarget({ isFork: true, forkMode: 'automatic' }).outputs.review_allowed).toBe('true')
   })
 
+  it('limits subscription auth to manually dispatched same-repository reviews', () => {
+    expect(runTarget({ authMode: 'subscription' }).outputs).toMatchObject({
+      auth_mode: 'subscription',
+      review_allowed: 'false'
+    })
+    expect(
+      runTarget({
+        authMode: 'subscription',
+        event: 'workflow_dispatch'
+      }).outputs
+    ).toMatchObject({ auth_mode: 'subscription', review_allowed: 'true' })
+    const fork = runTarget({
+      authMode: 'subscription',
+      event: 'workflow_dispatch',
+      isFork: true,
+      forkMode: 'automatic'
+    })
+    expect(fork.status, fork.stderr).toBe(0)
+    expect(fork.outputs.review_allowed).toBe('false')
+  })
+
   it('rejects an invalid automatic review mode', () => {
     const root = fixtureRoot('dual-codex-invalid-mode-')
     const result = spawnSync(
@@ -374,6 +470,7 @@ describe('dual Codex workflow contract', () => {
         env: {
           ...process.env,
           FORK_REVIEW_MODE: 'manual',
+          CODEX_REVIEW_AUTH_MODE: 'api-key',
           CODEX_REVIEW_MODE: 'claude',
           ENABLE_CODEX_REVIEW: 'true'
         }
@@ -430,23 +527,95 @@ describe('dual Codex workflow contract', () => {
     expect(correctness.permissions).toEqual({ contents: 'read' })
     expect(architecture.permissions).toEqual({ contents: 'read' })
     expect(correctness.with).toMatchObject({
+      auth_mode: '${{ needs.review_target.outputs.auth_mode }}',
       scope: 'correctness',
       model: "${{ vars.CODEX_CORRECTNESS_MODEL || vars.CODEX_REVIEW_MODEL || 'gpt-5.6-sol' }}",
       effort: "${{ vars.CODEX_CORRECTNESS_EFFORT || vars.CODEX_REVIEW_EFFORT || 'high' }}"
     })
     expect(correctness.secrets).toEqual({
+      CODEX_AUTH_JSON: '${{ secrets.CODEX_AUTH_JSON }}',
       OPENAI_API_KEY: '${{ secrets.CODEX_CORRECTNESS_API_KEY || secrets.OPENAI_API_KEY }}',
       CODEX_BASE_URL: '${{ secrets.CODEX_CORRECTNESS_BASE_URL || secrets.CODEX_BASE_URL }}'
     })
     expect(architecture.with).toMatchObject({
+      auth_mode: '${{ needs.review_target.outputs.auth_mode }}',
       scope: 'architecture',
       model: "${{ vars.CODEX_ARCHITECTURE_MODEL || vars.CODEX_REVIEW_MODEL || 'gpt-5.6-sol' }}",
       effort: "${{ vars.CODEX_ARCHITECTURE_EFFORT || vars.CODEX_REVIEW_EFFORT || 'high' }}"
     })
     expect(architecture.secrets).toEqual({
+      CODEX_AUTH_JSON: '${{ secrets.CODEX_AUTH_JSON }}',
       OPENAI_API_KEY: '${{ secrets.CODEX_ARCHITECTURE_API_KEY || secrets.OPENAI_API_KEY }}',
       CODEX_BASE_URL: '${{ secrets.CODEX_ARCHITECTURE_BASE_URL || secrets.CODEX_BASE_URL }}'
     })
+  })
+
+  it('bootstraps managed subscription auth on a GitHub-hosted runner', () => {
+    const seed = JSON.stringify({
+      auth_mode: 'chatgpt',
+      tokens: { refresh_token: 'refresh-seed' },
+      last_refresh: '2026-07-25T00:00:00Z'
+    })
+    const result = runAuth({ authJson: seed, authMode: 'subscription' })
+    expect(result.status, result.stderr).toBe(0)
+    expect(result.outputs).toMatchObject({
+      auth_mode: 'subscription',
+      codex_home: result.codexHome
+    })
+    expect(readFileSync(result.authFile, 'utf8')).toBe(seed)
+    expect(result.mode! & 0o777).toBe(0o600)
+  })
+
+  it('rejects a subscription secret that is not managed ChatGPT auth', () => {
+    const result = runAuth({
+      authJson: JSON.stringify({ auth_mode: 'apikey', OPENAI_API_KEY: 'sk-wrong-mode' }),
+      authMode: 'subscription'
+    })
+    expect(result.status).not.toBe(0)
+    expect(result.stderr).toContain(
+      'Codex subscription auth must be a valid chatgpt auth.json with a refresh token.'
+    )
+  })
+
+  it('rejects subscription auth outside a manual same-repository review', () => {
+    const seed = JSON.stringify({
+      auth_mode: 'chatgpt',
+      tokens: { refresh_token: 'refresh-seed' }
+    })
+    const automatic = runAuth({
+      authJson: seed,
+      authMode: 'subscription',
+      event: 'pull_request_target'
+    })
+    expect(automatic.status).not.toBe(0)
+    expect(automatic.stderr).toContain('manual workflow_dispatch reviews')
+
+    const fork = runAuth({ authJson: seed, authMode: 'subscription', isFork: true })
+    expect(fork.status).not.toBe(0)
+    expect(fork.stderr).toContain('same-repository pull requests')
+  })
+
+  it('uses the API proxy only for API-key authentication', () => {
+    const prepareRuntime = getStep(codexWorkflow, 'review', 'Prepare Codex review runtime')
+    expect(prepareRuntime.with).toMatchObject({
+      'codex-home': '${{ steps.codex_auth.outputs.codex_home }}',
+      'openai-api-key': "${{ inputs.auth_mode == 'api-key' && secrets.OPENAI_API_KEY || '' }}",
+      'responses-api-endpoint': '${{ steps.responses_endpoint.outputs.url }}'
+    })
+    expect(getStep(codexWorkflow, 'review', 'Resolve Responses API endpoint').if).toBe(
+      "${{ inputs.auth_mode == 'api-key' }}"
+    )
+  })
+
+  it('prepares the GitHub-hosted Linux sandbox when the action runs install-only', () => {
+    const sandbox = getStep(
+      codexWorkflow,
+      'review',
+      'Prepare GitHub-hosted sandbox for subscription auth'
+    )
+    expect(sandbox.if).toBe("${{ inputs.auth_mode == 'subscription' }}")
+    expect(sandbox.run).toContain('kernel.unprivileged_userns_clone')
+    expect(sandbox.run).toContain('kernel.apparmor_restrict_unprivileged_userns')
   })
 
   it('gives each Codex reviewer a distinct, non-overlapping focus', () => {
@@ -700,7 +869,12 @@ printf '%s\n' \\
     expect(mainWorkflow.concurrency).toEqual({
       group:
         "ai-pr-review-${{ github.event.inputs.pull_request_number || github.event.pull_request.number }}-${{ github.event_name == 'workflow_dispatch' && github.event.inputs.reviewer || 'both' }}",
-      'cancel-in-progress': true
+      'cancel-in-progress': "${{ (vars.CODEX_REVIEW_AUTH_MODE || 'api-key') != 'subscription' }}"
+    })
+    expect(codexWorkflow.jobs.review.concurrency).toEqual({
+      group:
+        "${{ inputs.auth_mode == 'subscription' && format('codex-subscription-review-{0}', github.repository) || format('codex-{0}-review-{1}', inputs.scope, inputs.pull_request_number) }}",
+      'cancel-in-progress': "${{ inputs.auth_mode != 'subscription' }}"
     })
     expect(mainWorkflow.jobs.codex_correctness_review.needs).toEqual([
       'review_target',

--- a/scripts/ai-review-workflows.test.ts
+++ b/scripts/ai-review-workflows.test.ts
@@ -617,8 +617,9 @@ describe('dual Codex workflow contract', () => {
     expect(fork.stderr).toContain('same-repository pull requests')
   })
 
-  it('uses the API proxy only for API-key authentication', () => {
+  it('uses the API action only for API-key auth and installs the CLI directly for subscription auth', () => {
     const prepareRuntime = getStep(codexWorkflow, 'review', 'Prepare Codex review runtime')
+    expect(prepareRuntime.if).toBe("${{ inputs.auth_mode == 'api-key' }}")
     expect(prepareRuntime.with).toMatchObject({
       'codex-home': '${{ steps.codex_auth.outputs.codex_home }}',
       'codex-version': '0.144.6',
@@ -627,6 +628,22 @@ describe('dual Codex workflow contract', () => {
     })
     expect(getStep(codexWorkflow, 'review', 'Resolve Responses API endpoint').if).toBe(
       "${{ inputs.auth_mode == 'api-key' }}"
+    )
+    const setupNode = getStep(codexWorkflow, 'review', 'Set up Node.js for subscription auth')
+    expect(setupNode.if).toBe("${{ inputs.auth_mode == 'subscription' }}")
+    expect(setupNode.uses).toBe('actions/setup-node@53b83947a5a98c8d113130e565377fae1a50d02f')
+    expect(setupNode.with).toEqual({ 'node-version': '24' })
+    const installCli = getStep(codexWorkflow, 'review', 'Install Codex CLI for subscription auth')
+    expect(installCli.if).toBe("${{ inputs.auth_mode == 'subscription' }}")
+    expect(installCli.env).toEqual({ CODEX_VERSION: '0.144.6' })
+    expect(installCli.run).toContain('npm install -g "@openai/codex@${CODEX_VERSION}"')
+    expect(installCli.run).toContain('codex --version')
+    const stepNames = codexWorkflow.jobs.review.steps?.map(({ name }) => name) ?? []
+    expect(stepNames.indexOf('Install Codex CLI for subscription auth')).toBeLessThan(
+      stepNames.indexOf('Prepare Codex authentication')
+    )
+    expect(stepNames.indexOf('Prepare Codex authentication')).toBeLessThan(
+      stepNames.indexOf('Checkout pull request review commit')
     )
   })
 

--- a/scripts/ai-review-workflows.test.ts
+++ b/scripts/ai-review-workflows.test.ts
@@ -438,10 +438,10 @@ describe('dual Codex workflow contract', () => {
     expect(runTarget({ isFork: true, forkMode: 'automatic' }).outputs.review_allowed).toBe('true')
   })
 
-  it('limits subscription auth to manually dispatched same-repository reviews', () => {
+  it('uses subscription only for manual same-repository reviews and otherwise falls back to API auth', () => {
     expect(runTarget({ authMode: 'subscription' }).outputs).toMatchObject({
-      auth_mode: 'subscription',
-      review_allowed: 'false'
+      auth_mode: 'api-key',
+      review_allowed: 'true'
     })
     expect(
       runTarget({
@@ -456,7 +456,7 @@ describe('dual Codex workflow contract', () => {
       forkMode: 'automatic'
     })
     expect(fork.status, fork.stderr).toBe(0)
-    expect(fork.outputs.review_allowed).toBe('false')
+    expect(fork.outputs).toMatchObject({ auth_mode: 'api-key', review_allowed: 'true' })
   })
 
   it('rejects an invalid automatic review mode', () => {

--- a/scripts/ai-review-workflows.test.ts
+++ b/scripts/ai-review-workflows.test.ts
@@ -8,7 +8,7 @@ import {
   writeFileSync
 } from 'node:fs'
 import { tmpdir } from 'node:os'
-import { join } from 'node:path'
+import { dirname, join } from 'node:path'
 import { spawnSync } from 'node:child_process'
 
 import { load } from 'js-yaml'
@@ -171,6 +171,7 @@ type AuthOptions = {
 function runAuth(options: AuthOptions = {}): {
   authFile: string
   codexHome: string
+  configFile: string
   mode: number | undefined
   outputs: Record<string, string>
   status: number | null
@@ -179,6 +180,7 @@ function runAuth(options: AuthOptions = {}): {
   const root = fixtureRoot('dual-codex-auth-')
   const codexHome = join(root, 'codex-home')
   const authFile = join(codexHome, 'auth.json')
+  const configFile = join(codexHome, 'config.toml')
   const output = join(root, 'github-output')
   const result = spawnSync(
     'bash',
@@ -193,6 +195,7 @@ function runAuth(options: AuthOptions = {}): {
         CODEX_BASE_URL: options.baseUrl ?? 'https://api.openai.com',
         GITHUB_OUTPUT: output,
         GITHUB_REPOSITORY: 'aipoch/open-science',
+        GITHUB_WORKSPACE: root,
         IS_FORK: String(options.isFork ?? false),
         OPENAI_API_KEY: options.openAiApiKey ?? 'sk-test',
         REVIEW_EVENT: options.event ?? 'workflow_dispatch',
@@ -203,6 +206,7 @@ function runAuth(options: AuthOptions = {}): {
   return {
     authFile,
     codexHome,
+    configFile,
     mode:
       result.status === 0 && options.authMode === 'subscription'
         ? statSync(authFile).mode
@@ -533,7 +537,8 @@ describe('dual Codex workflow contract', () => {
       effort: "${{ vars.CODEX_CORRECTNESS_EFFORT || vars.CODEX_REVIEW_EFFORT || 'high' }}"
     })
     expect(correctness.secrets).toEqual({
-      CODEX_AUTH_JSON: '${{ secrets.CODEX_AUTH_JSON }}',
+      CODEX_AUTH_JSON:
+        "${{ needs.review_target.outputs.auth_mode == 'subscription' && secrets.CODEX_AUTH_JSON || '' }}",
       OPENAI_API_KEY: '${{ secrets.CODEX_CORRECTNESS_API_KEY || secrets.OPENAI_API_KEY }}',
       CODEX_BASE_URL: '${{ secrets.CODEX_CORRECTNESS_BASE_URL || secrets.CODEX_BASE_URL }}'
     })
@@ -544,7 +549,8 @@ describe('dual Codex workflow contract', () => {
       effort: "${{ vars.CODEX_ARCHITECTURE_EFFORT || vars.CODEX_REVIEW_EFFORT || 'high' }}"
     })
     expect(architecture.secrets).toEqual({
-      CODEX_AUTH_JSON: '${{ secrets.CODEX_AUTH_JSON }}',
+      CODEX_AUTH_JSON:
+        "${{ needs.review_target.outputs.auth_mode == 'subscription' && secrets.CODEX_AUTH_JSON || '' }}",
       OPENAI_API_KEY: '${{ secrets.CODEX_ARCHITECTURE_API_KEY || secrets.OPENAI_API_KEY }}',
       CODEX_BASE_URL: '${{ secrets.CODEX_ARCHITECTURE_BASE_URL || secrets.CODEX_BASE_URL }}'
     })
@@ -564,6 +570,22 @@ describe('dual Codex workflow contract', () => {
     })
     expect(readFileSync(result.authFile, 'utf8')).toBe(seed)
     expect(result.mode! & 0o777).toBe(0o600)
+    const config = readFileSync(result.configFile, 'utf8')
+    expect(config).toContain('default_permissions = "ai_review"')
+    expect(config).toContain('project_doc_max_bytes = 0')
+    expect(config).toContain(`[projects.${JSON.stringify(dirname(result.codexHome))}]`)
+    expect(config).toContain('trust_level = "untrusted"')
+    expect(config).toContain('extends = ":read-only"')
+    expect(config).toContain(`${JSON.stringify(result.codexHome)} = "deny"`)
+  })
+
+  it('ignores untrusted checkout configuration in API-key mode too', () => {
+    const result = runAuth({ authMode: 'api-key' })
+    expect(result.status, result.stderr).toBe(0)
+    const config = readFileSync(result.configFile, 'utf8')
+    expect(config).toContain('default_permissions = ":read-only"')
+    expect(config).toContain('project_doc_max_bytes = 0')
+    expect(config).toContain('trust_level = "untrusted"')
   })
 
   it('rejects a subscription secret that is not managed ChatGPT auth', () => {
@@ -599,6 +621,7 @@ describe('dual Codex workflow contract', () => {
     const prepareRuntime = getStep(codexWorkflow, 'review', 'Prepare Codex review runtime')
     expect(prepareRuntime.with).toMatchObject({
       'codex-home': '${{ steps.codex_auth.outputs.codex_home }}',
+      'codex-version': '0.144.6',
       'openai-api-key': "${{ inputs.auth_mode == 'api-key' && secrets.OPENAI_API_KEY || '' }}",
       'responses-api-endpoint': '${{ steps.responses_endpoint.outputs.url }}'
     })
@@ -616,6 +639,18 @@ describe('dual Codex workflow contract', () => {
     expect(sandbox.if).toBe("${{ inputs.auth_mode == 'subscription' }}")
     expect(sandbox.run).toContain('kernel.unprivileged_userns_clone')
     expect(sandbox.run).toContain('kernel.apparmor_restrict_unprivileged_userns')
+  })
+
+  it('drops sudo and verifies the subscription credential is denied to sandboxed commands', () => {
+    const hardening = getStep(codexWorkflow, 'review', 'Harden subscription review runtime')
+    expect(hardening.if).toBe("${{ inputs.auth_mode == 'subscription' }}")
+    expect(hardening.run).toContain('/etc/sudoers.d/*')
+    expect(hardening.run).toContain('sudo -n true')
+    expect(hardening.run).toContain('codex sandbox --permission-profile ai_review')
+    expect(hardening.run).toContain('test -r "$CODEX_HOME/auth.json"')
+    expect(hardening.run).toContain('test -r "$GITHUB_WORKSPACE/package.json"')
+    const syntax = spawnSync('bash', ['-n'], { encoding: 'utf8', input: hardening.run })
+    expect(syntax.status, syntax.stderr).toBe(0)
   })
 
   it('gives each Codex reviewer a distinct, non-overlapping focus', () => {
@@ -637,7 +672,9 @@ describe('dual Codex workflow contract', () => {
     for (const command of ['install dependencies', 'lint', 'tests', 'typecheck', 'build']) {
       expect(inputs).toContain(command)
     }
-    expect(run).toContain('--config \'default_permissions=":read-only"\'')
+    expect(run).toContain('--strict-config')
+    expect(run).toContain('--config project_doc_max_bytes=0')
+    expect(run).toContain('--config "default_permissions=\\"${CODEX_PERMISSION_PROFILE}\\""')
     expect(run).toContain('--ephemeral')
     expect(run).toContain('--ignore-rules')
     expect(run).toContain('--output-schema "$CODEX_SCHEMA_FILE"')
@@ -695,6 +732,7 @@ printf '%s\n' \\
         CODEX_HOME: join(root, 'codex-home'),
         CODEX_INSTRUCTIONS_FILE: instructions,
         CODEX_MODEL: 'codex-auto-review',
+        CODEX_PERMISSION_PROFILE: ':read-only',
         CODEX_PROMPT_FILE: prompt,
         CODEX_SCHEMA_FILE: schema,
         GITHUB_OUTPUT: output,
@@ -709,6 +747,7 @@ printf '%s\n' \\
     )
     const args = JSON.parse(readFileSync(argsFile, 'utf8')) as string[]
     expect(args).toContain('--json')
+    expect(args).toContain('--strict-config')
     expect(args).toContain('default_permissions=":read-only"')
     expect(readFileSync(stdinFile, 'utf8')).toBe('Review this pull request.\n')
     expect(readFileSync(output, 'utf8')).toContain('"verdict":"mergeable"')

--- a/scripts/ai-review-workflows.test.ts
+++ b/scripts/ai-review-workflows.test.ts
@@ -869,11 +869,11 @@ printf '%s\n' \\
     expect(mainWorkflow.concurrency).toEqual({
       group:
         "ai-pr-review-${{ github.event.inputs.pull_request_number || github.event.pull_request.number }}-${{ github.event_name == 'workflow_dispatch' && github.event.inputs.reviewer || 'both' }}",
-      'cancel-in-progress': "${{ (vars.CODEX_REVIEW_AUTH_MODE || 'api-key') != 'subscription' }}"
+      'cancel-in-progress': true
     })
     expect(codexWorkflow.jobs.review.concurrency).toEqual({
       group: "${{ format('codex-{0}-review-{1}', inputs.scope, inputs.pull_request_number) }}",
-      'cancel-in-progress': "${{ inputs.auth_mode != 'subscription' }}"
+      'cancel-in-progress': true
     })
     expect(mainWorkflow.jobs.codex_correctness_review.needs).toEqual([
       'review_target',

--- a/scripts/ai-review-workflows.test.ts
+++ b/scripts/ai-review-workflows.test.ts
@@ -645,6 +645,7 @@ describe('dual Codex workflow contract', () => {
     const hardening = getStep(codexWorkflow, 'review', 'Harden subscription review runtime')
     expect(hardening.if).toBe("${{ inputs.auth_mode == 'subscription' }}")
     expect(hardening.run).toContain('/etc/sudoers.d/*')
+    expect(hardening.run).toContain('command -v bwrap')
     expect(hardening.run).toContain('sudo -n true')
     expect(hardening.run).toContain('codex sandbox --permission-profile ai_review')
     expect(hardening.run).toContain('test -r "$CODEX_HOME/auth.json"')

--- a/scripts/ai-review-workflows.test.ts
+++ b/scripts/ai-review-workflows.test.ts
@@ -872,8 +872,7 @@ printf '%s\n' \\
       'cancel-in-progress': "${{ (vars.CODEX_REVIEW_AUTH_MODE || 'api-key') != 'subscription' }}"
     })
     expect(codexWorkflow.jobs.review.concurrency).toEqual({
-      group:
-        "${{ inputs.auth_mode == 'subscription' && format('codex-subscription-review-{0}', github.repository) || format('codex-{0}-review-{1}', inputs.scope, inputs.pull_request_number) }}",
+      group: "${{ format('codex-{0}-review-{1}', inputs.scope, inputs.pull_request_number) }}",
       'cancel-in-progress': "${{ inputs.auth_mode != 'subscription' }}"
     })
     expect(mainWorkflow.jobs.codex_correctness_review.needs).toEqual([

--- a/scripts/ai-review-workflows.test.ts
+++ b/scripts/ai-review-workflows.test.ts
@@ -645,7 +645,7 @@ describe('dual Codex workflow contract', () => {
     const hardening = getStep(codexWorkflow, 'review', 'Harden subscription review runtime')
     expect(hardening.if).toBe("${{ inputs.auth_mode == 'subscription' }}")
     expect(hardening.run).toContain('/etc/sudoers.d/*')
-    expect(hardening.run).toContain('command -v bwrap')
+    expect(hardening.run).not.toContain('command -v bwrap')
     expect(hardening.run).toContain('sudo -n true')
     expect(hardening.run).toContain('codex sandbox --permission-profile ai_review')
     expect(hardening.run).toContain('test -r "$CODEX_HOME/auth.json"')


### PR DESCRIPTION
## Problem

The AI review workflow requires API-key credentials and cannot use a dedicated Codex subscription account.

## Proposed change

- Add `CODEX_REVIEW_AUTH_MODE` with `api-key` as the default and `subscription` as an opt-in.
- Use subscription auth only for manually dispatched same-repository reviews; automatic and allowed fork reviews continue using API-key credentials.
- Validate and stage `CODEX_AUTH_JSON` in a permission-restricted temporary Codex home, and prepare the GitHub-hosted Linux sandbox for the install-only Codex action path.
- Document setup, dedicated-account guidance, security boundaries, and ephemeral-runner refresh limitations.

## Scope and non-goals

- Subscription credentials are not exposed to automatic or fork review jobs.
- Refreshed `auth.json` is not written back to repository secrets; maintainers must reseed it when authentication can no longer refresh.
- The existing reviewer selection, model, effort, fork policy, publishing, and round-limit behavior remain unchanged.

## Acceptance criteria and validation

- Subscription mode runs through manual `workflow_dispatch` for same-repository pull requests.
- Automatic and fork reviews preserve API-key fallback.
- Invalid or non-ChatGPT auth files fail closed.
- `actionlint .github/workflows/ai-review.yml .github/workflows/ai-codex-review.yml`
- `npm run typecheck`
- `npm run lint` (0 errors; 40 pre-existing warnings)
- `npm test` (6704 passed, 112 skipped)

## Review focus

Please focus on per-run authentication selection, secret scoping, and the GitHub-hosted sandbox setup for the subscription install-only path.