### PR TITLE
fix(update): route incompatible macOS signatures to installer

### DIFF
--- a/src/main/update/create-strategy.test.ts
+++ b/src/main/update/create-strategy.test.ts
@@ -1,10 +1,18 @@
-import { describe, expect, it, vi } from 'vitest'
+import { beforeEach, describe, expect, it, vi } from 'vitest'
+
+const spawnSync = vi.hoisted(() => vi.fn())
+
+vi.mock('node:child_process', () => ({ spawnSync }))
 
 // createUpdateStrategy constructs a concrete strategy per platform. Both strategies touch native
 // modules at construction (UpdateService reads app.getVersion(); ElectronUpdaterStrategy subscribes to
 // autoUpdater), so stub them enough to instantiate without a real Electron runtime.
 vi.mock('electron', () => ({
-  app: { getVersion: () => '0.0.0', isPackaged: false },
+  app: {
+    getPath: () => '/Applications/Open Science.app/Contents/MacOS/Open Science',
+    getVersion: () => '0.0.0',
+    isPackaged: false
+  },
   BrowserWindow: { getAllWindows: () => [] }
 }))
 vi.mock('electron-updater', () => ({
@@ -16,6 +24,15 @@ import { ElectronUpdaterStrategy } from './electron-updater-strategy'
 import { UpdateService } from './service'
 
 describe('createUpdateStrategy', () => {
+  beforeEach(() => {
+    spawnSync.mockReset()
+    spawnSync.mockReturnValue({
+      status: 0,
+      stdout: '',
+      stderr: 'Identifier=com.aipoch.open-science\nTeamIdentifier=87G9WFU9H3\n'
+    })
+  })
+
   it('uses ElectronUpdaterStrategy on win32', () => {
     expect(createUpdateStrategy('win32')).toBeInstanceOf(ElectronUpdaterStrategy)
   })
@@ -27,6 +44,54 @@ describe('createUpdateStrategy', () => {
   it('uses ElectronUpdaterStrategy on darwin for a packaged stable build', () => {
     expect(createUpdateStrategy('darwin', { isPackaged: true, version: '1.2.3' })).toBeInstanceOf(
       ElectronUpdaterStrategy
+    )
+  })
+
+  it('falls back to the installer on darwin for an ad-hoc-signed packaged stable build', () => {
+    spawnSync.mockReturnValueOnce({
+      status: 0,
+      stdout: '',
+      stderr: 'Identifier=com.aipoch.open-science\nSignature=adhoc\nTeamIdentifier=not set\n'
+    })
+
+    expect(createUpdateStrategy('darwin', { isPackaged: true, version: '1.2.3' })).toBeInstanceOf(
+      UpdateService
+    )
+  })
+
+  it('falls back to the installer on darwin for a stable build signed by another team', () => {
+    spawnSync.mockReturnValueOnce({
+      status: 0,
+      stdout: '',
+      stderr: 'Identifier=com.aipoch.open-science\nTeamIdentifier=OTHERTEAM1\n'
+    })
+
+    expect(createUpdateStrategy('darwin', { isPackaged: true, version: '1.2.3' })).toBeInstanceOf(
+      UpdateService
+    )
+  })
+
+  it('falls back to the installer on darwin for another app signed by the official team', () => {
+    spawnSync.mockReturnValueOnce({
+      status: 0,
+      stdout: '',
+      stderr: 'Identifier=com.aipoch.another-app\nTeamIdentifier=87G9WFU9H3\n'
+    })
+
+    expect(createUpdateStrategy('darwin', { isPackaged: true, version: '1.2.3' })).toBeInstanceOf(
+      UpdateService
+    )
+  })
+
+  it('falls back to the installer when the installed mac signature cannot be read', () => {
+    spawnSync.mockReturnValueOnce({
+      status: 1,
+      stdout: '',
+      stderr: 'code object is not signed at all'
+    })
+
+    expect(createUpdateStrategy('darwin', { isPackaged: true, version: '1.2.3' })).toBeInstanceOf(
+      UpdateService
     )
   })
 

--- a/src/main/update/create-strategy.ts
+++ b/src/main/update/create-strategy.ts
@@ -1,3 +1,6 @@
+import { spawnSync } from 'node:child_process'
+import { dirname, resolve } from 'node:path'
+
 import { app } from 'electron'
 
 import { ElectronUpdaterStrategy } from './electron-updater-strategy'
@@ -11,13 +14,34 @@ export type CreateStrategyOptions = {
   version?: string
 }
 
+const OFFICIAL_MAC_BUNDLE_ID = 'com.aipoch.open-science'
+const OFFICIAL_MAC_TEAM_ID = '87G9WFU9H3'
+
+// Read the installed bundle's signing metadata without performing a trust evaluation. The latter can
+// depend on machine policy/keychain state, while Squirrel.Mac only needs the current and replacement
+// bundles to carry compatible designated requirements. Stable CI releases are signed by this bundle
+// ID + Team ID; local packages are ad-hoc signed and report no TeamIdentifier.
+const hasOfficialMacSignature = (): boolean => {
+  const bundlePath = resolve(dirname(app.getPath('exe')), '../..')
+  const result = spawnSync('/usr/bin/codesign', ['-d', '--verbose=4', bundlePath], {
+    encoding: 'utf8'
+  })
+  if (result.status !== 0) return false
+
+  const details = new Set(`${result.stdout ?? ''}\n${result.stderr ?? ''}`.split(/\r?\n/))
+  return (
+    details.has(`Identifier=${OFFICIAL_MAC_BUNDLE_ID}`) &&
+    details.has(`TeamIdentifier=${OFFICIAL_MAC_TEAM_ID}`)
+  )
+}
+
 // macOS in-place auto-update (electron-updater / Squirrel.Mac) only works on a packaged build that is
-// Developer ID signed. CI signs *stable* mac builds; nightly builds are ad-hoc and dev runs are
-// unsigned/unpackaged — both would hit electron-updater's "could not get code signature" error. Gate
-// on packaged + a non-prerelease version (nightly is `x.y.z-nightly.<sha>`) so only signed stable
-// builds get the in-place path; everything else falls back to the manifest installer flow.
+// signed with the same Developer ID as the replacement. CI signs stable mac builds; local packages
+// and nightlies are ad-hoc, so ShipIt rejects an official replacement at apply time. Check the actual
+// installed signature rather than inferring it from the version, and fail closed to the manual
+// installer flow whenever compatibility cannot be established.
 const macCanAutoUpdate = (isPackaged: boolean, version: string): boolean =>
-  isPackaged && !version.includes('-')
+  isPackaged && !version.includes('-') && hasOfficialMacSignature()
 
 // Picks the update strategy for the host platform. Windows/Linux always get true in-place auto-update
 // via electron-updater. macOS gets it too on signed stable builds (see macCanAutoUpdate); otherwise


### PR DESCRIPTION
## Problem

Packaged macOS builds with a stable version string were assumed to be Developer ID signed. A locally packaged, ad-hoc-signed build therefore selected Squirrel.Mac, downloaded an official update, and only failed when ShipIt rejected the replacement's incompatible code requirement.

## Proposed change

- Inspect the installed macOS bundle metadata before selecting the in-place updater.
- Use Squirrel.Mac only when both the bundle ID and Apple Team ID match the official stable release identity.
- Fail closed to the existing manifest installer flow for ad-hoc, mismatched, or unreadable signatures, so the UI downloads and opens the installer instead of offering a restart that cannot succeed.
- Cover official, ad-hoc, wrong-team, wrong-bundle, and unreadable-signature routing.

## Scope and non-goals

- Windows and Linux update routing is unchanged.
- This does not perform a local trust evaluation; it reads signing metadata only, avoiding machine-specific trust/keychain failures.
- An already-installed v0.5.1 client cannot execute this new guard. Affected users still need to install the official DMG manually once; this change prevents recurrence in future clients that contain the guard.

## Acceptance criteria and validation

- `npm run typecheck` — passed
- `npm run lint` — passed with 0 errors (33 pre-existing warnings)
- `npm run test` — 486 files passed, 6,729 tests passed
- `npx vitest run src/main/update/create-strategy.test.ts` — 9 tests passed

## Review focus

- Whether bundle ID + Team ID is the correct compatibility gate for the official macOS updater.
- Whether every uncertain signature state should continue to fail closed to the installer flow.

Refs #438
