### PR TITLE
feat(model-settings): map effort to model capabilities

### DIFF
--- a/src/main/acp/runtime-coordinator.test.ts
+++ b/src/main/acp/runtime-coordinator.test.ts
@@ -308,7 +308,7 @@ describe('AcpRuntimeCoordinator', () => {
     expect(coordinator.getSnapshot().permissionGrants).toEqual({})
   })
 
-  it('keeps reconnecting settings on the active generation and fans out live effort', async () => {
+  it('keeps reconnecting settings and model-resolved effort on the active generation', async () => {
     const created: ReturnType<typeof createFakeRuntime>[] = []
     const coordinator = new AcpRuntimeCoordinator((callbacks) => {
       const fake = createFakeRuntime({
@@ -330,13 +330,13 @@ describe('AcpRuntimeCoordinator', () => {
     expect(created).toHaveLength(2)
     expect(created[0].requestProviderReconnect).not.toHaveBeenCalled()
     expect(created[0].requestSkillsReload).not.toHaveBeenCalled()
-    expect(created[0].applyReasoningEffortChange).toHaveBeenCalledWith('high')
+    expect(created[0].applyReasoningEffortChange).not.toHaveBeenCalled()
     expect(created[1].requestProviderReconnect).toHaveBeenCalledOnce()
     expect(created[1].requestSkillsReload).toHaveBeenCalledOnce()
     expect(created[1].applyReasoningEffortChange).toHaveBeenCalledWith('high')
   })
 
-  it('keeps the active effort result when a retiring generation rejects', async () => {
+  it('surfaces an active generation effort failure without touching a retiring model', async () => {
     const created: ReturnType<typeof createFakeRuntime>[] = []
     const coordinator = new AcpRuntimeCoordinator((callbacks) => {
       const fake = createFakeRuntime({
@@ -351,9 +351,12 @@ describe('AcpRuntimeCoordinator', () => {
     await coordinator.createSession()
     await coordinator.requestAgentFrameworkSwitch()
     await coordinator.createSession()
-    created[0].applyReasoningEffortChange.mockRejectedValue(new Error('old effort failed'))
+    created[1].applyReasoningEffortChange.mockRejectedValue(new Error('active effort failed'))
 
-    await expect(coordinator.applyReasoningEffortChange('high')).resolves.toBe(true)
+    await expect(coordinator.applyReasoningEffortChange('high')).rejects.toThrow(
+      'active effort failed'
+    )
+    expect(created[0].applyReasoningEffortChange).not.toHaveBeenCalled()
     expect(created[1].applyReasoningEffortChange).toHaveBeenCalledWith('high')
   })
 

--- a/src/main/acp/runtime-coordinator.ts
+++ b/src/main/acp/runtime-coordinator.ts
@@ -13,7 +13,7 @@ import type {
   AcpSetPermissionProfileRequest,
   AcpStateSnapshot
 } from '../../shared/acp'
-import type { ReasoningEffort } from '../../shared/settings'
+import type { ResolvedReasoningEffort } from '../../shared/reasoning-effort'
 import { AcpRuntime, type AcpRuntimeCallbacks } from './runtime'
 import type { AcpRuntimeActivity, AcpRuntimeActivityOptions } from './runtime-activity'
 import { ConversationPermissionGrantStore } from './permission-broker'
@@ -250,20 +250,11 @@ class AcpRuntimeCoordinator {
     return this.getActiveRuntime().requestSkillsReload()
   }
 
-  async applyReasoningEffortChange(effort: ReasoningEffort): Promise<boolean> {
-    const active = this.getActiveRuntime()
-    const activeResult = active.applyReasoningEffortChange(effort)
-    const otherResults = Array.from(this.runtimes)
-      .filter((runtime) => runtime !== active)
-      .map((runtime) => runtime.applyReasoningEffortChange(effort))
-
-    // Effort is a non-disruptive live session option, so every still-running generation receives the
-    // global preference. Only the active result controls reconnect fallback: an old generation that
-    // cannot apply effort or rejects must not force the selected generation to respawn unnecessarily.
-    const results = await Promise.allSettled([activeResult, ...otherResults])
-    const activeOutcome = results[0]
-    if (activeOutcome.status === 'rejected') throw activeOutcome.reason
-    return activeOutcome.value
+  async applyReasoningEffortChange(effort: ResolvedReasoningEffort): Promise<boolean> {
+    // The settings layer resolved this value against the currently selected model. Retiring
+    // generations stay pinned to their own provider/model and therefore must not receive a value
+    // resolved for a different model profile.
+    return this.getActiveRuntime().applyReasoningEffortChange(effort)
   }
 
   writeArtifactForCurrentRun(

--- a/src/main/acp/runtime.test.ts
+++ b/src/main/acp/runtime.test.ts
@@ -8234,6 +8234,51 @@ describe('ACP runtime — session effort', () => {
     expect(setReasoningEffort).toHaveBeenNthCalledWith(2, undefined)
   })
 
+  it('defers a new-model effort while the old provider is waiting to reconnect', async () => {
+    const process = new FakeAgentProcess()
+    const promptStarted = createDeferred()
+    const finishPrompt = createDeferred()
+    const fakeAgent = startFakeAgent(process, ['s-old-model'], {
+      configOptions: [thoughtLevelOption(['default', 'high', 'max'])],
+      onPrompt: async () => {
+        promptStarted.resolve()
+        await finishPrompt.promise
+        return { stopReason: 'end_turn' }
+      }
+    })
+    const setReasoningEffort = vi.fn()
+    const runtime = new AcpRuntime({
+      appVersion: '0.1.0',
+      defaultCwd: '/workspace',
+      resolveBackend: () => ({
+        framework: {
+          ...claudeCodeFramework,
+          spawn: () => asAgentProcess(process)
+        },
+        executablePath: '/bin/claude',
+        env: {},
+        responsesBridgeLease: {
+          selectSkills: vi.fn(async () => []),
+          registerReviewerSession: vi.fn(),
+          unregisterReviewerSession: vi.fn(() => false),
+          setReasoningEffort,
+          release: vi.fn(async () => undefined)
+        }
+      })
+    })
+    await runtime.createSession({ cwd: '/workspace' })
+    const prompt = runtime.sendPrompt({ sessionId: 's-old-model', text: 'keep working' })
+    await promptStarted.promise
+    await runtime.requestProviderReconnect()
+
+    await expect(runtime.applyReasoningEffortChange('max')).resolves.toBe(false)
+    expect(fakeAgent.configChanges).toEqual([])
+    expect(setReasoningEffort).not.toHaveBeenCalled()
+
+    finishPrompt.resolve()
+    await prompt
+  })
+
   it('hands control back to the agent default when the level is cleared live', async () => {
     const process = new FakeAgentProcess()
     const fakeAgent = startFakeAgent(process, ['s-live'], {

--- a/src/main/acp/runtime.test.ts
+++ b/src/main/acp/runtime.test.ts
@@ -16,7 +16,7 @@ import { afterEach, describe, expect, it, vi } from 'vitest'
 
 import { AcpRuntime } from './runtime'
 import type { AcpPermissionRequest, AcpRuntimeEvent } from '../../shared/acp'
-import type { ReasoningEffort } from '../../shared/settings'
+import type { ModelReasoningEffort } from '../../shared/reasoning-effort'
 import { terminateProcessTree } from '../process-tree'
 import { AgentMcpHttpHost } from './mcp-http-host'
 import { SkillRegistry } from '../skills/registry'
@@ -2229,9 +2229,7 @@ describe('ACP runtime session management', () => {
     expect(fakeAgent.newSessions[0]._meta).toBeUndefined()
     expect(fakeAgent.prompts[0].text).toContain('hello opencode')
     expect(fakeAgent.prompts[0].text).toContain('write_artifact_file')
-    expect(fakeAgent.prompts[0].text).not.toContain(
-      '<open_science_skill_privacy_instructions>'
-    )
+    expect(fakeAgent.prompts[0].text).not.toContain('<open_science_skill_privacy_instructions>')
   })
 
   it('gives bridge-backed Codex the artifact server through its explicit function alias', async () => {
@@ -2333,9 +2331,7 @@ describe('ACP runtime session management', () => {
     await runtime.sendPrompt({ sessionId: session.sessionId, text: 'Search PubMed' })
 
     expect(fakeAgent.prompts[0].text).toContain('Search PubMed')
-    expect(fakeAgent.prompts[0].text).not.toContain(
-      '<open_science_skill_privacy_instructions>'
-    )
+    expect(fakeAgent.prompts[0].text).not.toContain('<open_science_skill_privacy_instructions>')
   })
 
   it('delivers the large-data-file guidance to Claude session metadata on create and resume', async () => {
@@ -7394,9 +7390,7 @@ describe('ACP runtime skill force-load + nudge', () => {
       }
     })
     const skillPath = '/data/codex/skills/os-mcp-pubmed/SKILL.md'
-    const catalog = [
-      { name: 'mcp-pubmed', description: 'Search PubMed.', path: skillPath }
-    ]
+    const catalog = [{ name: 'mcp-pubmed', description: 'Search PubMed.', path: skillPath }]
     const hooks = createSkillsHooks({ needForceLoad: [], catalog })
     const selectSkills = vi.fn(async () => [{ name: 'mcp-pubmed', path: skillPath }])
     const runtime = new AcpRuntime({
@@ -8081,7 +8075,7 @@ describe('ACP runtime — session effort', () => {
 
   const createEffortRuntime = (
     process: FakeAgentProcess,
-    sessionEffort: ReasoningEffort | undefined,
+    sessionEffort: ModelReasoningEffort | undefined,
     sessionModel?: string
   ): AcpRuntime =>
     new AcpRuntime({
@@ -8123,7 +8117,7 @@ describe('ACP runtime — session effort', () => {
     expect(fakeAgent.configChanges).toEqual([])
   })
 
-  it('clamps the desired level to the closest advertised value', async () => {
+  it('does not reinterpret an unadvertised model-resolved effort', async () => {
     const process = new FakeAgentProcess()
     const fakeAgent = startFakeAgent(process, ['s-effort'], {
       configOptions: [thoughtLevelOption(['low', 'medium'])]
@@ -8132,10 +8126,8 @@ describe('ACP runtime — session effort', () => {
 
     await runtime.createSession({ cwd: '/workspace' })
 
-    // 'max' is not advertised; the model's top level takes its place instead of a no-op.
-    expect(fakeAgent.configChanges).toEqual([
-      { sessionId: 's-effort', configId: 'effort', value: 'medium' }
-    ])
+    // The Agent layer is only a transport. It must not replace max with medium.
+    expect(fakeAgent.configChanges).toEqual([])
   })
 
   it('resolves effort against the option set reported after a model switch', async () => {
@@ -8160,11 +8152,9 @@ describe('ACP runtime — session effort', () => {
 
     await runtime.createSession({ cwd: '/workspace' })
 
-    // Clamping against the pre-switch set would apply 'high' — invalid for model-b. The post-switch
-    // set yields 'medium' instead.
+    // Neither the stale nor the post-switch option set contains the model-resolved max value.
     expect(fakeAgent.configChanges).toEqual([
-      { sessionId: 's-effort', configId: 'model', value: 'model-b' },
-      { sessionId: 's-effort', configId: 'effort', value: 'medium' }
+      { sessionId: 's-effort', configId: 'model', value: 'model-b' }
     ])
   })
 
@@ -8199,9 +8189,9 @@ describe('ACP runtime — session effort', () => {
     await runtime.createSession({ cwd: '/workspace' })
     expect(fakeAgent.configChanges).toEqual([])
 
-    const applied = await runtime.applyReasoningEffortChange('max')
+    const applied = await runtime.applyReasoningEffortChange('high')
 
-    // The open session gets the closest advertised level over ACP, still on the original process.
+    // The open session gets the exact model-resolved level over ACP, still on the original process.
     expect(applied).toBe(true)
     expect(spawn).toHaveBeenCalledTimes(1)
     expect(fakeAgent.configChanges).toEqual([
@@ -8211,6 +8201,37 @@ describe('ACP runtime — session effort', () => {
     // Sessions created later in the same process inherit the new level.
     await runtime.createSession({ cwd: '/workspace' })
     expect(fakeAgent.configChanges[1]).toMatchObject({ configId: 'effort', value: 'high' })
+  })
+
+  it('updates only the runtime-owned Responses bridge with a live effort change', async () => {
+    const process = new FakeAgentProcess()
+    startFakeAgent(process, ['s-bridge-effort'], {
+      configOptions: [thoughtLevelOption(['default', 'high'])]
+    })
+    const setReasoningEffort = vi.fn()
+    const runtime = new AcpRuntime({
+      appVersion: '0.1.0',
+      defaultCwd: '/workspace',
+      resolveBackend: () => ({
+        framework: { ...claudeCodeFramework, spawn: () => asAgentProcess(process) },
+        executablePath: '/bin/claude',
+        env: {},
+        responsesBridgeLease: {
+          selectSkills: vi.fn(async () => []),
+          registerReviewerSession: vi.fn(),
+          unregisterReviewerSession: vi.fn(() => false),
+          setReasoningEffort,
+          release: vi.fn(async () => undefined)
+        }
+      })
+    })
+    await runtime.createSession({ cwd: '/workspace' })
+
+    await runtime.applyReasoningEffortChange('high')
+    await runtime.applyReasoningEffortChange('default')
+
+    expect(setReasoningEffort).toHaveBeenNthCalledWith(1, 'high')
+    expect(setReasoningEffort).toHaveBeenNthCalledWith(2, undefined)
   })
 
   it('hands control back to the agent default when the level is cleared live', async () => {
@@ -8228,7 +8249,7 @@ describe('ACP runtime — session effort', () => {
       })
     })
     await runtime.createSession({ cwd: '/workspace' })
-    await runtime.applyReasoningEffortChange('max')
+    await runtime.applyReasoningEffortChange('high')
 
     const applied = await runtime.applyReasoningEffortChange('default')
 
@@ -8273,11 +8294,9 @@ describe('ACP runtime — session effort', () => {
 
     const applied = await runtime.applyReasoningEffortChange('max')
 
-    // The post-switch set tops out at 'medium'; the stale session/new set would wrongly yield 'high'.
+    // The post-switch set does not expose max, so the transport must not substitute medium.
     expect(applied).toBe(true)
-    expect(fakeAgent.configChanges).toEqual([
-      { sessionId: 's-live', configId: 'effort', value: 'medium' }
-    ])
+    expect(fakeAgent.configChanges).toEqual([])
   })
 
   it('reports failure so the caller reconnects when a live apply is rejected', async () => {

--- a/src/main/acp/runtime.ts
+++ b/src/main/acp/runtime.ts
@@ -43,11 +43,8 @@ import {
   type PermissionProfileId,
   type SessionPermissionProfileState
 } from '../../shared/permission-profiles'
-import {
-  DEFAULT_REASONING_EFFORT,
-  type AgentFrameworkId,
-  type ReasoningEffort
-} from '../../shared/settings'
+import { type AgentFrameworkId } from '../../shared/settings'
+import type { ModelReasoningEffort, ResolvedReasoningEffort } from '../../shared/reasoning-effort'
 import {
   claudeCodeFramework,
   type AgentFramework,
@@ -183,9 +180,7 @@ type AcpRuntimeSkillsOptions = {
   ) => Promise<Array<{ name: string; path: string }>>
   // Lists only enabled, materialized app-owned Skills from the active isolated Codex home. The
   // Chat Completions compatibility selector receives name + description; paths remain local.
-  catalogForCodexHome?: (
-    codexHome: string | undefined
-  ) => Promise<ResponsesBridgeSkillCandidate[]>
+  catalogForCodexHome?: (codexHome: string | undefined) => Promise<ResponsesBridgeSkillCandidate[]>
 }
 
 type ReviewerSessionRequest = {
@@ -683,7 +678,7 @@ class AcpRuntime {
   private selectedModelContextWindow: number | undefined
   // Reasoning-effort level to apply per session via the ACP thought_level configOption; undefined
   // means "don't override" (the agent keeps its own default). Refreshed on each connect.
-  private pendingSessionEffort: ReasoningEffort | undefined
+  private pendingSessionEffort: ModelReasoningEffort | undefined
   private pendingSessionOptions: Record<string, unknown> | undefined
   private pendingSystemPromptAppends: string[] = []
   // The latest configOptions each session reported — seeded from session/new and refreshed after a
@@ -906,10 +901,10 @@ class AcpRuntime {
   // Applies the user's reasoning-effort preference to a freshly built/resumed session via the ACP
   // thought_level configOption. No-op when no explicit level is set (pendingSessionEffort undefined —
   // the agent then keeps its own default) or when the agent advertises no effort option. The desired
-  // level is resolved to the closest advertised one, so a level the model lacks still lands on its
-  // nearest rung. `configOptions` should be the agent's latest option set (e.g. returned by a model
-  // switch just before); falls back to the session's original response. Best-effort: a failure is
-  // logged, never fatal to the session.
+  // level is already resolved by the model profile and therefore only an exact advertised match is
+  // sent. `configOptions` should be the agent's latest option set (e.g. returned by a model switch
+  // just before); falls back to the session's original response. Best-effort: a failure is logged,
+  // never fatal to the session.
   private async applySessionEffort(
     session: ActiveSession,
     configOptions?: SessionConfigOption[] | null
@@ -939,10 +934,11 @@ class AcpRuntime {
   // simply advertise no effort option are skipped (a reconnect could not give their model one
   // either). On success pendingSessionEffort tracks the new level, so sessions created later in
   // this process inherit it; the persisted setting covers the next respawn.
-  async applyReasoningEffortChange(effort: ReasoningEffort): Promise<boolean> {
+  async applyReasoningEffortChange(effort: ResolvedReasoningEffort): Promise<boolean> {
     if (!this.framework.supportsLiveEffortChange) return false
 
-    this.pendingSessionEffort = effort === DEFAULT_REASONING_EFFORT ? undefined : effort
+    this.pendingSessionEffort = effort === 'default' ? undefined : effort
+    this.responsesBridgeLease?.setReasoningEffort?.(this.pendingSessionEffort)
     if (!this.connection) return true
 
     let allApplied = true
@@ -2284,7 +2280,9 @@ class AcpRuntime {
         sessionOptions: this.pendingSessionOptions
       })
       const selectorAbortController =
-        this.framework.id === 'codex' && forced.length === 0 && this.responsesBridgeLease?.selectSkills
+        this.framework.id === 'codex' &&
+        forced.length === 0 &&
+        this.responsesBridgeLease?.selectSkills
           ? new AbortController()
           : undefined
       if (selectorAbortController) {

--- a/src/main/acp/runtime.ts
+++ b/src/main/acp/runtime.ts
@@ -936,6 +936,10 @@ class AcpRuntime {
   // this process inherit it; the persisted setting covers the next respawn.
   async applyReasoningEffortChange(effort: ResolvedReasoningEffort): Promise<boolean> {
     if (!this.framework.supportsLiveEffortChange) return false
+    // A provider/model switch may be waiting for an in-flight turn to finish. The incoming effort was
+    // resolved against that newly selected model, while this connection still owns the old one. Let
+    // the persisted setting reach the fresh backend after reconnect instead of leaking it here.
+    if (this.pendingProviderReconnect) return false
 
     this.pendingSessionEffort = effort === 'default' ? undefined : effort
     this.responsesBridgeLease?.setReasoningEffort?.(this.pendingSessionEffort)

--- a/src/main/acp/session-config.test.ts
+++ b/src/main/acp/session-config.test.ts
@@ -174,32 +174,24 @@ describe('resolveSessionEffortOption', () => {
     })
   })
 
-  it('clamps max to the model\u2019s highest advertised level, skipping the default sentinel', () => {
-    // Claude Code's effort select: a 'default' sentinel plus the model's supported levels.
+  it('does not reinterpret a model-resolved effort when the agent advertises different levels', () => {
+    // The model profile has already resolved the user's intent to max. The ACP adapter is only a
+    // transport and must not silently turn that into a different model API value.
     const options = [effortOption(['default', 'low', 'medium', 'high'])]
 
-    expect(resolveSessionEffortOption(options, 'max')).toEqual({
-      configId: 'thought_level',
-      value: 'high'
-    })
+    expect(resolveSessionEffortOption(options, 'max')).toBeUndefined()
   })
 
-  it('clamps low to the model\u2019s lowest advertised level', () => {
+  it('does not raise a model-resolved effort to the agent\u2019s lowest advertised level', () => {
     const options = [effortOption(['medium', 'high'])]
 
-    expect(resolveSessionEffortOption(options, 'low')).toEqual({
-      configId: 'thought_level',
-      value: 'medium'
-    })
+    expect(resolveSessionEffortOption(options, 'low')).toBeUndefined()
   })
 
-  it('resolves equidistant levels to the lower (cheaper) one', () => {
+  it('does not choose a neighboring level when the exact effort is absent', () => {
     const options = [effortOption(['medium', 'xhigh'])]
 
-    expect(resolveSessionEffortOption(options, 'high')).toEqual({
-      configId: 'thought_level',
-      value: 'medium'
-    })
+    expect(resolveSessionEffortOption(options, 'high')).toBeUndefined()
   })
 
   it('matches the literal default sentinel when the agent advertises it', () => {
@@ -214,11 +206,11 @@ describe('resolveSessionEffortOption', () => {
   })
 
   it('returns undefined when there is nothing usable to apply', () => {
-    // Only the 'default' sentinel advertised: no real level to clamp onto.
+    // Only the 'default' sentinel advertised: no exact concrete value is available.
     expect(resolveSessionEffortOption([effortOption(['default'])], 'high')).toBeUndefined()
     // 'default' without an advertised sentinel cannot be cleared; unknown levels never apply.
     expect(resolveSessionEffortOption([effortOption(['low'])], 'default')).toBeUndefined()
-    expect(resolveSessionEffortOption([effortOption(['low'])], 'turbo')).toBeUndefined()
+    expect(resolveSessionEffortOption([effortOption(['low'])], 'turbo' as never)).toBeUndefined()
     expect(resolveSessionEffortOption([effortOption(['low'])], undefined)).toBeUndefined()
     expect(resolveSessionEffortOption([], 'high')).toBeUndefined()
     expect(resolveSessionEffortOption(undefined, 'high')).toBeUndefined()

--- a/src/main/acp/session-config.ts
+++ b/src/main/acp/session-config.ts
@@ -1,4 +1,5 @@
 import type { SessionConfigOption } from '@agentclientprotocol/sdk'
+import type { ResolvedReasoningEffort } from '../../shared/reasoning-effort'
 
 // The config option id + value to apply via session/set_config_option. `alreadyCurrent` flags the
 // case where the option's currentValue already equals the desired model — the caller should treat
@@ -84,25 +85,14 @@ export const matchSessionModelOption = (
   return { configId: option.id, value: match }
 }
 
-// Canonical reasoning-effort scale, weakest to strongest. Effort levels are a relative scale: each
-// model advertises its own subset (Claude models draw from low/medium/high/xhigh/max), so a desired
-// level maps onto the closest advertised rung.
-const EFFORT_SCALE = ['low', 'medium', 'high', 'xhigh', 'max'] as const
-
-const effortRank = (value: string): number =>
-  EFFORT_SCALE.indexOf(value as (typeof EFFORT_SCALE)[number])
-
 // Finds the session's reasoning-effort select option (the ACP `thought_level` category; Claude Code
-// advertises it as `effort`) and resolves the desired level to the closest value the agent actually
-// offers: exact match first, otherwise the advertised level nearest on the canonical scale (ties go
-// to the lower, cheaper level — e.g. 'max' on a model topping out at 'high' applies 'high'). Returns
-// undefined when there is no effort option or it advertises no recognizable level, so the agent
-// keeps its own default rather than erroring. The 'default' desired level is special: it matches the
-// agent's literal 'default' sentinel (Claude Code advertises one to mean "clear any forced level"),
-// so a live change can hand control back to the agent.
+// advertises it as `effort`) and transports the model-resolved value only when it is advertised
+// exactly. The model profile owns all relative-level mapping; this ACP boundary must never silently
+// reinterpret `max` as `high` (or any other different API value). The `default` sentinel is retained
+// solely to clear an existing live override when the agent explicitly advertises that operation.
 export const resolveSessionEffortOption = (
   configOptions: readonly SessionConfigOption[] | null | undefined,
-  desiredEffort: string | undefined
+  desiredEffort: ResolvedReasoningEffort | undefined
 ): SessionModelSelection | undefined => {
   const option = (configOptions ?? []).find(
     (candidate) =>
@@ -114,36 +104,7 @@ export const resolveSessionEffortOption = (
 
   const values = collectSelectValues(option.options)
 
-  // Clearing back to the agent default is only possible when the sentinel is explicitly advertised.
-  if (desiredEffort === 'default') {
-    return values.includes('default') ? { configId: option.id, value: 'default' } : undefined
-  }
+  if (!desiredEffort || !values.includes(desiredEffort)) return undefined
 
-  const desiredRank = desiredEffort ? effortRank(desiredEffort) : -1
-
-  if (desiredRank < 0) return undefined
-
-  // Only real levels are clamp targets — sentinels like 'default' (the agent's own default) are not.
-  const candidates = values
-    .map((value) => ({ value, rank: effortRank(value) }))
-    .filter((candidate) => candidate.rank >= 0)
-
-  if (candidates.length === 0) return undefined
-
-  const exact = candidates.find((candidate) => candidate.rank === desiredRank)
-
-  if (exact) return { configId: option.id, value: exact.value }
-
-  let nearest = candidates[0]
-
-  for (const candidate of candidates) {
-    const distance = Math.abs(candidate.rank - desiredRank)
-    const bestDistance = Math.abs(nearest.rank - desiredRank)
-
-    if (distance < bestDistance || (distance === bestDistance && candidate.rank < nearest.rank)) {
-      nearest = candidate
-    }
-  }
-
-  return { configId: option.id, value: nearest.value }
+  return { configId: option.id, value: desiredEffort }
 }

--- a/src/main/agent-framework/codex.test.ts
+++ b/src/main/agent-framework/codex.test.ts
@@ -433,20 +433,23 @@ describe('codexFramework', () => {
 
 describe('buildCodexConfig reasoning effort', () => {
   it.each([
+    ['minimal', 'minimal'],
     ['low', 'low'],
     ['medium', 'medium'],
     ['high', 'high'],
-    // Codex config tops out at xhigh; the app's top level 'max' maps onto it.
-    ['max', 'xhigh']
+    ['xhigh', 'xhigh']
   ] as const)('maps the %s level to model_reasoning_effort %s', (effort, expected) => {
     expect(buildCodexConfig({ reasoningEffort: effort }).model_reasoning_effort).toBe(expected)
   })
 
-  it.each([undefined, 'default'] as const)('omits model_reasoning_effort for %s', (effort) => {
-    expect(buildCodexConfig({ reasoningEffort: effort })).not.toHaveProperty(
-      'model_reasoning_effort'
-    )
-  })
+  it.each([undefined, 'none', 'max', 'ultra'] as const)(
+    'does not clamp the unrepresentable %s value into a different Codex effort',
+    (effort) => {
+      expect(buildCodexConfig({ reasoningEffort: effort })).not.toHaveProperty(
+        'model_reasoning_effort'
+      )
+    }
+  )
 
   it('threads the ctx level into the serialized CODEX_CONFIG env', () => {
     const framework = createCodexFramework()
@@ -461,6 +464,6 @@ describe('buildCodexConfig reasoning effort', () => {
       { storageRoot: '/data', executablePath: '/runtime/codex-acp', reasoningEffort: 'max' }
     )
 
-    expect(JSON.parse(config.env?.CODEX_CONFIG ?? '').model_reasoning_effort).toBe('xhigh')
+    expect(JSON.parse(config.env?.CODEX_CONFIG ?? '')).not.toHaveProperty('model_reasoning_effort')
   })
 })

--- a/src/main/agent-framework/codex.test.ts
+++ b/src/main/agent-framework/codex.test.ts
@@ -122,12 +122,14 @@ describe('codexFramework', () => {
       {
         storageRoot: '/data',
         executablePath: '/runtime/codex-acp',
+        reasoningEffort: 'none',
         responsesBridge: { baseUrl: 'http://127.0.0.1:43123/v1', token: 'local-token' }
       }
     )
 
     expect(JSON.parse(config.env?.CODEX_CONFIG ?? '')).toMatchObject({
       model: 'MiniMax-M3',
+      model_reasoning_effort: 'none',
       model_context_window: 1_000_000,
       model_auto_compact_token_limit: 950_000,
       model_providers: {
@@ -433,15 +435,15 @@ describe('codexFramework', () => {
 
 describe('buildCodexConfig reasoning effort', () => {
   it.each([
-    ['none', 'low'],
-    ['minimal', 'low'],
+    ['none', 'none'],
+    ['minimal', 'minimal'],
     ['low', 'low'],
     ['medium', 'medium'],
     ['high', 'high'],
     ['xhigh', 'xhigh'],
-    ['max', 'xhigh'],
-    ['ultra', 'xhigh']
-  ] as const)('maps the %s level to model_reasoning_effort %s', (effort, expected) => {
+    ['max', 'max'],
+    ['ultra', 'ultra']
+  ] as const)('preserves the %s level as model_reasoning_effort %s', (effort, expected) => {
     expect(buildCodexConfig({ reasoningEffort: effort }).model_reasoning_effort).toBe(expected)
   })
 
@@ -464,6 +466,6 @@ describe('buildCodexConfig reasoning effort', () => {
       { storageRoot: '/data', executablePath: '/runtime/codex-acp', reasoningEffort: 'max' }
     )
 
-    expect(JSON.parse(config.env?.CODEX_CONFIG ?? '').model_reasoning_effort).toBe('xhigh')
+    expect(JSON.parse(config.env?.CODEX_CONFIG ?? '').model_reasoning_effort).toBe('max')
   })
 })

--- a/src/main/agent-framework/codex.test.ts
+++ b/src/main/agent-framework/codex.test.ts
@@ -433,23 +433,23 @@ describe('codexFramework', () => {
 
 describe('buildCodexConfig reasoning effort', () => {
   it.each([
-    ['minimal', 'minimal'],
+    ['none', 'low'],
+    ['minimal', 'low'],
     ['low', 'low'],
     ['medium', 'medium'],
     ['high', 'high'],
-    ['xhigh', 'xhigh']
+    ['xhigh', 'xhigh'],
+    ['max', 'xhigh'],
+    ['ultra', 'xhigh']
   ] as const)('maps the %s level to model_reasoning_effort %s', (effort, expected) => {
     expect(buildCodexConfig({ reasoningEffort: effort }).model_reasoning_effort).toBe(expected)
   })
 
-  it.each([undefined, 'none', 'max', 'ultra'] as const)(
-    'does not clamp the unrepresentable %s value into a different Codex effort',
-    (effort) => {
-      expect(buildCodexConfig({ reasoningEffort: effort })).not.toHaveProperty(
-        'model_reasoning_effort'
-      )
-    }
-  )
+  it('omits model_reasoning_effort when no model value is resolved', () => {
+    expect(buildCodexConfig({ reasoningEffort: undefined })).not.toHaveProperty(
+      'model_reasoning_effort'
+    )
+  })
 
   it('threads the ctx level into the serialized CODEX_CONFIG env', () => {
     const framework = createCodexFramework()
@@ -464,6 +464,6 @@ describe('buildCodexConfig reasoning effort', () => {
       { storageRoot: '/data', executablePath: '/runtime/codex-acp', reasoningEffort: 'max' }
     )
 
-    expect(JSON.parse(config.env?.CODEX_CONFIG ?? '')).not.toHaveProperty('model_reasoning_effort')
+    expect(JSON.parse(config.env?.CODEX_CONFIG ?? '').model_reasoning_effort).toBe('xhigh')
   })
 })

--- a/src/main/agent-framework/codex.ts
+++ b/src/main/agent-framework/codex.ts
@@ -104,28 +104,6 @@ const normalizeResponsesBaseUrl = (value: string | undefined): string | undefine
   return normalized
 }
 
-// Codex config has a smaller transport vocabulary than several provider APIs. Encode every resolved
-// model value into a valid Codex rung so direct Responses sessions still receive an explicit relative
-// effort. Chat-bridged requests additionally carry the exact model value as an upstream override, so
-// this transport encoding never replaces none/max/ultra at the real Chat Completions endpoint.
-const CODEX_REASONING_EFFORT: Readonly<
-  Record<ModelReasoningEffort, 'low' | 'medium' | 'high' | 'xhigh'>
-> = {
-  none: 'low',
-  minimal: 'low',
-  low: 'low',
-  medium: 'medium',
-  high: 'high',
-  xhigh: 'xhigh',
-  max: 'xhigh',
-  ultra: 'xhigh'
-}
-
-const codexReasoningEffortFor = (
-  effort: ModelReasoningEffort | undefined
-): 'low' | 'medium' | 'high' | 'xhigh' | undefined =>
-  effort === undefined ? undefined : CODEX_REASONING_EFFORT[effort]
-
 // Just the model + reasoning-effort fields a Codex config can carry, with no provider plumbing.
 // The bridge path layers the open-science custom provider on top of this; the codex-isolated path
 // uses it on its own so codex-acp can drive the ChatGPT subscription with the user's selected
@@ -134,10 +112,9 @@ const buildCodexModelOptions = (input: {
   model?: string
   reasoningEffort?: ModelReasoningEffort
 }): Record<string, unknown> => {
-  const codexEffort = codexReasoningEffortFor(input.reasoningEffort)
   return {
     ...(input.model ? { model: input.model } : {}),
-    ...(codexEffort ? { model_reasoning_effort: codexEffort } : {})
+    ...(input.reasoningEffort ? { model_reasoning_effort: input.reasoningEffort } : {})
   }
 }
 

--- a/src/main/agent-framework/codex.ts
+++ b/src/main/agent-framework/codex.ts
@@ -12,7 +12,7 @@ import {
 } from '../acp/permission-profile-controller'
 import type { PermissionProfileId } from '../../shared/permission-profiles'
 import { augmentedPathEnv } from '../settings/shell-path'
-import type { ReasoningEffort } from '../../shared/settings'
+import type { ModelReasoningEffort } from '../../shared/reasoning-effort'
 import type {
   AgentFramework,
   AgentAuthentication,
@@ -73,10 +73,7 @@ export const codexStorageDir = (storageRoot: string): string => join(storageRoot
 export const codexSubscriptionStorageDir = (storageRoot: string): string =>
   join(storageRoot, 'codex-subscription')
 
-const isolatedCodexHomeEnv = (
-  codexHome: string,
-  platform: NodeJS.Platform
-): NodeJS.ProcessEnv => ({
+const isolatedCodexHomeEnv = (codexHome: string, platform: NodeJS.Platform): NodeJS.ProcessEnv => ({
   // Codex discovers user-installed Skills under $HOME/.agents/skills in addition to
   // $CODEX_HOME/skills. Point both roots at the app-owned profile so a session cannot inherit the
   // desktop user's Skills. USERPROFILE is the native home source on Windows; HOME is retained there
@@ -107,14 +104,19 @@ const normalizeResponsesBaseUrl = (value: string | undefined): string | undefine
   return normalized
 }
 
-// Codex config takes low|medium|high|xhigh; the app's top level 'max' maps onto 'xhigh'.
-// 'default' is filtered upstream (never reaches here), but stay defensive and omit it too.
-const codexReasoningEffortFor = (effort: ReasoningEffort | undefined): string | undefined =>
-  effort === 'max'
-    ? 'xhigh'
-    : effort === 'low' || effort === 'medium' || effort === 'high'
-      ? effort
-      : undefined
+// Codex config has its own finite vocabulary. Pass exact values it can express and omit every other
+// model API value instead of silently translating it. Chat-bridged requests carry an independent
+// upstream override, so a model-resolved max/ultra/none is not lost there.
+const codexReasoningEffortFor = (
+  effort: ModelReasoningEffort | undefined
+): ModelReasoningEffort | undefined =>
+  effort === 'minimal' ||
+  effort === 'low' ||
+  effort === 'medium' ||
+  effort === 'high' ||
+  effort === 'xhigh'
+    ? effort
+    : undefined
 
 // Just the model + reasoning-effort fields a Codex config can carry, with no provider plumbing.
 // The bridge path layers the open-science custom provider on top of this; the codex-isolated path
@@ -122,7 +124,7 @@ const codexReasoningEffortFor = (effort: ReasoningEffort | undefined): string | 
 // model from session start (issue #277).
 const buildCodexModelOptions = (input: {
   model?: string
-  reasoningEffort?: ReasoningEffort
+  reasoningEffort?: ModelReasoningEffort
 }): Record<string, unknown> => {
   const codexEffort = codexReasoningEffortFor(input.reasoningEffort)
   return {
@@ -136,7 +138,7 @@ const buildCodexConfig = (provider: {
   model?: string
   contextWindow?: number
   key?: string
-  reasoningEffort?: ReasoningEffort
+  reasoningEffort?: ModelReasoningEffort
 }): Record<string, unknown> => {
   const baseUrl = normalizeResponsesBaseUrl(provider.baseUrl)
   const contextWindow =

--- a/src/main/agent-framework/codex.ts
+++ b/src/main/agent-framework/codex.ts
@@ -104,19 +104,27 @@ const normalizeResponsesBaseUrl = (value: string | undefined): string | undefine
   return normalized
 }
 
-// Codex config has its own finite vocabulary. Pass exact values it can express and omit every other
-// model API value instead of silently translating it. Chat-bridged requests carry an independent
-// upstream override, so a model-resolved max/ultra/none is not lost there.
+// Codex config has a smaller transport vocabulary than several provider APIs. Encode every resolved
+// model value into a valid Codex rung so direct Responses sessions still receive an explicit relative
+// effort. Chat-bridged requests additionally carry the exact model value as an upstream override, so
+// this transport encoding never replaces none/max/ultra at the real Chat Completions endpoint.
+const CODEX_REASONING_EFFORT: Readonly<
+  Record<ModelReasoningEffort, 'low' | 'medium' | 'high' | 'xhigh'>
+> = {
+  none: 'low',
+  minimal: 'low',
+  low: 'low',
+  medium: 'medium',
+  high: 'high',
+  xhigh: 'xhigh',
+  max: 'xhigh',
+  ultra: 'xhigh'
+}
+
 const codexReasoningEffortFor = (
   effort: ModelReasoningEffort | undefined
-): ModelReasoningEffort | undefined =>
-  effort === 'minimal' ||
-  effort === 'low' ||
-  effort === 'medium' ||
-  effort === 'high' ||
-  effort === 'xhigh'
-    ? effort
-    : undefined
+): 'low' | 'medium' | 'high' | 'xhigh' | undefined =>
+  effort === undefined ? undefined : CODEX_REASONING_EFFORT[effort]
 
 // Just the model + reasoning-effort fields a Codex config can carry, with no provider plumbing.
 // The bridge path layers the open-science custom provider on top of this; the codex-isolated path

--- a/src/main/agent-framework/opencode.test.ts
+++ b/src/main/agent-framework/opencode.test.ts
@@ -249,10 +249,19 @@ describe('opencodeFramework.prepareModelConfig', () => {
     })
   })
 
-  it("transports the model's resolved 'max' value unchanged in both layers", () => {
+  it.each([
+    ['none', 'low'],
+    ['minimal', 'low'],
+    ['low', 'low'],
+    ['medium', 'medium'],
+    ['high', 'high'],
+    ['xhigh', 'high'],
+    ['max', 'high'],
+    ['ultra', 'high']
+  ] as const)('encodes model effort %s as OpenCode transport level %s', (effort, expected) => {
     const config = opencodeFramework.prepareModelConfig(
       { type: 'custom', baseUrl: 'https://gw/v1', model: 'm', key: 'k' },
-      { storageRoot: '/data', executablePath: '/bin/opencode', reasoningEffort: 'max' }
+      { storageRoot: '/data', executablePath: '/bin/opencode', reasoningEffort: effort }
     )
 
     const fileConfig = JSON.parse(
@@ -261,10 +270,10 @@ describe('opencodeFramework.prepareModelConfig', () => {
     const content = JSON.parse(config.env?.OPENCODE_CONFIG_CONTENT ?? '{}')
 
     expect(fileConfig.provider.anthropic.models).toEqual({
-      m: { options: { reasoningEffort: 'max' } }
+      m: { options: { reasoningEffort: expected } }
     })
     expect(content.provider.anthropic.models).toEqual({
-      m: { options: { reasoningEffort: 'max' } }
+      m: { options: { reasoningEffort: expected } }
     })
   })
 

--- a/src/main/agent-framework/opencode.test.ts
+++ b/src/main/agent-framework/opencode.test.ts
@@ -257,7 +257,7 @@ describe('opencodeFramework.prepareModelConfig', () => {
     ['high', 'high'],
     ['xhigh', 'xhigh'],
     ['max', 'max'],
-    ['ultra', undefined]
+    ['ultra', 'max']
   ] as const)('encodes model effort %s as OpenCode transport level %s', (effort, expected) => {
     const config = opencodeFramework.prepareModelConfig(
       { type: 'custom', baseUrl: 'https://gw/v1', model: 'm', key: 'k' },
@@ -269,7 +269,7 @@ describe('opencodeFramework.prepareModelConfig', () => {
     )
     const content = JSON.parse(config.env?.OPENCODE_CONFIG_CONTENT ?? '{}')
 
-    const expectedModel = expected ? { options: { reasoningEffort: expected } } : {}
+    const expectedModel = { options: { reasoningEffort: expected } }
     expect(fileConfig.provider.anthropic.models).toEqual({ m: expectedModel })
     expect(content.provider.anthropic.models).toEqual({ m: expectedModel })
   })

--- a/src/main/agent-framework/opencode.test.ts
+++ b/src/main/agent-framework/opencode.test.ts
@@ -250,14 +250,14 @@ describe('opencodeFramework.prepareModelConfig', () => {
   })
 
   it.each([
-    ['none', 'low'],
-    ['minimal', 'low'],
+    ['none', 'none'],
+    ['minimal', 'minimal'],
     ['low', 'low'],
     ['medium', 'medium'],
     ['high', 'high'],
-    ['xhigh', 'high'],
-    ['max', 'high'],
-    ['ultra', 'high']
+    ['xhigh', 'xhigh'],
+    ['max', 'max'],
+    ['ultra', 'max']
   ] as const)('encodes model effort %s as OpenCode transport level %s', (effort, expected) => {
     const config = opencodeFramework.prepareModelConfig(
       { type: 'custom', baseUrl: 'https://gw/v1', model: 'm', key: 'k' },
@@ -276,6 +276,46 @@ describe('opencodeFramework.prepareModelConfig', () => {
       m: { options: { reasoningEffort: expected } }
     })
   })
+
+  it.each([
+    ['minimax', 'MiniMax-M3', 'none', { thinking: { type: 'disabled' } }],
+    ['minimax', 'MiniMax-M3', 'high', { thinking: { type: 'adaptive' } }],
+    ['xiaomimimo', 'mimo-v2.5-pro', 'none', { thinking: { type: 'disabled' } }],
+    ['xiaomimimo', 'mimo-v2.5-pro', 'high', { thinking: { type: 'enabled' } }],
+    ['deepseek', 'deepseek-v4-pro', 'none', { thinking: { type: 'disabled' } }],
+    [
+      'deepseek',
+      'deepseek-v4-pro',
+      'max',
+      { reasoningEffort: 'max', thinking: { type: 'enabled' } }
+    ],
+    ['openrouter', 'qwen/qwen3.7-max', 'none', { reasoning: { enabled: false } }],
+    ['openrouter', 'openai/gpt-5.5', 'high', { reasoning: { effort: 'high' } }]
+  ] as const)(
+    'encodes %s model %s effort %s with its provider-native options',
+    (vendorId, model, reasoningEffort, expected) => {
+      const config = opencodeFramework.prepareModelConfig(
+        {
+          type: 'custom',
+          vendorId,
+          baseUrl: 'https://gw.example/anthropic',
+          openaiBaseUrl: 'https://gw.example/v1',
+          apiEndpoints: ['anthropic', 'openai'],
+          model,
+          key: 'k'
+        },
+        { storageRoot: '/data', executablePath: '/bin/opencode', reasoningEffort }
+      )
+
+      const fileConfig = JSON.parse(
+        config.configFiles?.find((file) => file.path.endsWith('opencode.json'))?.content ?? '{}'
+      )
+      const content = JSON.parse(config.env?.OPENCODE_CONFIG_CONTENT ?? '{}')
+
+      expect(fileConfig.provider['openai-compatible'].models[model].options).toEqual(expected)
+      expect(content.provider['openai-compatible'].models[model].options).toEqual(expected)
+    }
+  )
 
   it('leaves the model block empty when no reasoning effort is set', () => {
     const config = opencodeFramework.prepareModelConfig(

--- a/src/main/agent-framework/opencode.test.ts
+++ b/src/main/agent-framework/opencode.test.ts
@@ -257,7 +257,7 @@ describe('opencodeFramework.prepareModelConfig', () => {
     ['high', 'high'],
     ['xhigh', 'xhigh'],
     ['max', 'max'],
-    ['ultra', 'max']
+    ['ultra', undefined]
   ] as const)('encodes model effort %s as OpenCode transport level %s', (effort, expected) => {
     const config = opencodeFramework.prepareModelConfig(
       { type: 'custom', baseUrl: 'https://gw/v1', model: 'm', key: 'k' },
@@ -269,12 +269,9 @@ describe('opencodeFramework.prepareModelConfig', () => {
     )
     const content = JSON.parse(config.env?.OPENCODE_CONFIG_CONTENT ?? '{}')
 
-    expect(fileConfig.provider.anthropic.models).toEqual({
-      m: { options: { reasoningEffort: expected } }
-    })
-    expect(content.provider.anthropic.models).toEqual({
-      m: { options: { reasoningEffort: expected } }
-    })
+    const expectedModel = expected ? { options: { reasoningEffort: expected } } : {}
+    expect(fileConfig.provider.anthropic.models).toEqual({ m: expectedModel })
+    expect(content.provider.anthropic.models).toEqual({ m: expectedModel })
   })
 
   it.each([
@@ -316,6 +313,26 @@ describe('opencodeFramework.prepareModelConfig', () => {
       expect(content.provider['openai-compatible'].models[model].options).toEqual(expected)
     }
   )
+
+  it('uses an explicit custom-provider transport without guessing from its URL or model', () => {
+    const config = opencodeFramework.prepareModelConfig(
+      {
+        type: 'custom',
+        baseUrl: 'https://private-gateway.example/v1',
+        apiEndpoints: ['openai'],
+        model: 'private-model',
+        key: 'k',
+        reasoningEffortTransport: 'deepseek'
+      },
+      { storageRoot: '/data', executablePath: '/bin/opencode', reasoningEffort: 'none' }
+    )
+
+    const content = JSON.parse(config.env?.OPENCODE_CONFIG_CONTENT ?? '{}')
+
+    expect(content.provider['openai-compatible'].models['private-model'].options).toEqual({
+      thinking: { type: 'disabled' }
+    })
+  })
 
   it('leaves the model block empty when no reasoning effort is set', () => {
     const config = opencodeFramework.prepareModelConfig(

--- a/src/main/agent-framework/opencode.test.ts
+++ b/src/main/agent-framework/opencode.test.ts
@@ -249,7 +249,7 @@ describe('opencodeFramework.prepareModelConfig', () => {
     })
   })
 
-  it("clamps the app's top level 'max' to opencode's 'high' in both layers", () => {
+  it("transports the model's resolved 'max' value unchanged in both layers", () => {
     const config = opencodeFramework.prepareModelConfig(
       { type: 'custom', baseUrl: 'https://gw/v1', model: 'm', key: 'k' },
       { storageRoot: '/data', executablePath: '/bin/opencode', reasoningEffort: 'max' }
@@ -260,12 +260,11 @@ describe('opencodeFramework.prepareModelConfig', () => {
     )
     const content = JSON.parse(config.env?.OPENCODE_CONFIG_CONTENT ?? '{}')
 
-    // opencode's reasoningEffort follows the AI SDK levels, which top out at 'high'.
     expect(fileConfig.provider.anthropic.models).toEqual({
-      m: { options: { reasoningEffort: 'high' } }
+      m: { options: { reasoningEffort: 'max' } }
     })
     expect(content.provider.anthropic.models).toEqual({
-      m: { options: { reasoningEffort: 'high' } }
+      m: { options: { reasoningEffort: 'max' } }
     })
   })
 

--- a/src/main/agent-framework/opencode.ts
+++ b/src/main/agent-framework/opencode.ts
@@ -135,6 +135,21 @@ const resolveOpencodeEndpoint = (
   return { bareModel, providerId, npm, baseURL }
 }
 
+// OpenCode/AI SDK exposes a three-rung transport vocabulary. The model profile remains authoritative
+// for UI and persistence; this complete encoder prevents provider-native literals from producing an
+// invalid OpenCode config. Unlike the Codex Chat bridge, OpenCode has no independent upstream override.
+const OPENCODE_REASONING_EFFORT: Readonly<Record<ModelReasoningEffort, 'low' | 'medium' | 'high'>> =
+  {
+    none: 'low',
+    minimal: 'low',
+    low: 'low',
+    medium: 'medium',
+    high: 'high',
+    xhigh: 'high',
+    max: 'high',
+    ultra: 'high'
+  }
+
 // The opencode per-model capability block. opencode strips image parts before calling the provider for
 // any model whose config does not declare vision — custom and freshly-registered models default to
 // text-only — so a base64 image sent over ACP silently never reaches the provider. A multimodal model
@@ -149,7 +164,9 @@ const buildModelCapabilities = (
   ...(provider.supportsImageInput
     ? { attachment: true, modalities: { input: ['text', 'image'] } }
     : {}),
-  ...(reasoningEffort ? { options: { reasoningEffort } } : {})
+  ...(reasoningEffort
+    ? { options: { reasoningEffort: OPENCODE_REASONING_EFFORT[reasoningEffort] } }
+    : {})
 })
 
 // The app-authoritative config layer (model + provider block + permission policy) passed verbatim to

--- a/src/main/agent-framework/opencode.ts
+++ b/src/main/agent-framework/opencode.ts
@@ -137,18 +137,20 @@ const resolveOpencodeEndpoint = (
 }
 
 // Current OpenCode accepts the provider-neutral ladder through `reasoningEffort` up to `max`.
-// `ultra` is a Codex-specific top rung, so it is the only value that needs an agent-level clamp.
+// `ultra` is a Codex-specific top rung, so omit it rather than silently approximating it as `max`.
 // Provider-specific wire shapes (thinking switches and OpenRouter's reasoning object) are resolved
 // separately and passed through model options by the openai-compatible AI SDK.
 const opencodeReasoningOptions = (
   provider: ResolvedProvider,
   effort: ModelReasoningEffort
-): Record<string, unknown> => {
-  const normalizedEffort = effort === 'ultra' ? 'max' : effort
+): Record<string, unknown> | undefined => {
+  if (effort === 'ultra') return undefined
+
   const transport = resolveChatReasoningTransport(
     provider.vendorId,
     provider.model,
-    normalizedEffort
+    effort,
+    provider.reasoningEffortTransport
   )
 
   return {
@@ -167,12 +169,18 @@ const opencodeReasoningOptions = (
 const buildModelCapabilities = (
   provider: ResolvedProvider,
   reasoningEffort?: ModelReasoningEffort
-): Record<string, unknown> => ({
-  ...(provider.supportsImageInput
-    ? { attachment: true, modalities: { input: ['text', 'image'] } }
-    : {}),
-  ...(reasoningEffort ? { options: opencodeReasoningOptions(provider, reasoningEffort) } : {})
-})
+): Record<string, unknown> => {
+  const reasoningOptions = reasoningEffort
+    ? opencodeReasoningOptions(provider, reasoningEffort)
+    : undefined
+
+  return {
+    ...(provider.supportsImageInput
+      ? { attachment: true, modalities: { input: ['text', 'image'] } }
+      : {}),
+    ...(reasoningOptions ? { options: reasoningOptions } : {})
+  }
+}
 
 // The app-authoritative config layer (model + provider block + permission policy) passed verbatim to
 // opencode via OPENCODE_CONFIG_CONTENT, which opencode deep-merges ABOVE both the app-owned global config

--- a/src/main/agent-framework/opencode.ts
+++ b/src/main/agent-framework/opencode.ts
@@ -137,19 +137,19 @@ const resolveOpencodeEndpoint = (
 }
 
 // Current OpenCode accepts the provider-neutral ladder through `reasoningEffort` up to `max`.
-// `ultra` is a Codex-specific top rung, so omit it rather than silently approximating it as `max`.
+// `ultra` is a Codex-specific top rung, so map it to OpenCode's highest transport value rather than
+// dropping the user's explicit top-effort selection and falling back to the provider default.
 // Provider-specific wire shapes (thinking switches and OpenRouter's reasoning object) are resolved
 // separately and passed through model options by the openai-compatible AI SDK.
 const opencodeReasoningOptions = (
   provider: ResolvedProvider,
   effort: ModelReasoningEffort
-): Record<string, unknown> | undefined => {
-  if (effort === 'ultra') return undefined
-
+): Record<string, unknown> => {
+  const transportEffort = effort === 'ultra' ? 'max' : effort
   const transport = resolveChatReasoningTransport(
     provider.vendorId,
     provider.model,
-    effort,
+    transportEffort,
     provider.reasoningEffortTransport
   )
 
@@ -170,15 +170,11 @@ const buildModelCapabilities = (
   provider: ResolvedProvider,
   reasoningEffort?: ModelReasoningEffort
 ): Record<string, unknown> => {
-  const reasoningOptions = reasoningEffort
-    ? opencodeReasoningOptions(provider, reasoningEffort)
-    : undefined
-
   return {
     ...(provider.supportsImageInput
       ? { attachment: true, modalities: { input: ['text', 'image'] } }
       : {}),
-    ...(reasoningOptions ? { options: reasoningOptions } : {})
+    ...(reasoningEffort ? { options: opencodeReasoningOptions(provider, reasoningEffort) } : {})
   }
 }
 

--- a/src/main/agent-framework/opencode.ts
+++ b/src/main/agent-framework/opencode.ts
@@ -12,6 +12,7 @@ import type { ModelReasoningEffort } from '../../shared/reasoning-effort'
 import { anthropicMessagesBase, openAiCompletionsBase } from '../settings/base-url'
 import { augmentedPathEnv } from '../settings/shell-path'
 import type { ResolvedProvider } from '../settings/provider-env'
+import { resolveChatReasoningTransport } from '../settings/reasoning-transport'
 import type {
   AgentFramework,
   AgentModelConfig,
@@ -135,28 +136,34 @@ const resolveOpencodeEndpoint = (
   return { bareModel, providerId, npm, baseURL }
 }
 
-// OpenCode/AI SDK exposes a three-rung transport vocabulary. The model profile remains authoritative
-// for UI and persistence; this complete encoder prevents provider-native literals from producing an
-// invalid OpenCode config. Unlike the Codex Chat bridge, OpenCode has no independent upstream override.
-const OPENCODE_REASONING_EFFORT: Readonly<Record<ModelReasoningEffort, 'low' | 'medium' | 'high'>> =
-  {
-    none: 'low',
-    minimal: 'low',
-    low: 'low',
-    medium: 'medium',
-    high: 'high',
-    xhigh: 'high',
-    max: 'high',
-    ultra: 'high'
+// Current OpenCode accepts the provider-neutral ladder through `reasoningEffort` up to `max`.
+// `ultra` is a Codex-specific top rung, so it is the only value that needs an agent-level clamp.
+// Provider-specific wire shapes (thinking switches and OpenRouter's reasoning object) are resolved
+// separately and passed through model options by the openai-compatible AI SDK.
+const opencodeReasoningOptions = (
+  provider: ResolvedProvider,
+  effort: ModelReasoningEffort
+): Record<string, unknown> => {
+  const normalizedEffort = effort === 'ultra' ? 'max' : effort
+  const transport = resolveChatReasoningTransport(
+    provider.vendorId,
+    provider.model,
+    normalizedEffort
+  )
+
+  return {
+    ...(transport.reasoningEffort ? { reasoningEffort: transport.reasoningEffort } : {}),
+    ...(transport.thinking ? { thinking: transport.thinking } : {}),
+    ...(transport.reasoning ? { reasoning: transport.reasoning } : {})
   }
+}
 
 // The opencode per-model capability block. opencode strips image parts before calling the provider for
 // any model whose config does not declare vision — custom and freshly-registered models default to
 // text-only — so a base64 image sent over ACP silently never reaches the provider. A multimodal model
 // must therefore advertise both the attachment capability and an image input modality. Empty (text-only)
-// otherwise, so a non-vision model is never told it can accept images. A reasoning-effort preference is
-// declared via the model's `options.reasoningEffort`, opencode's per-model knob passed through to the
-// AI SDK provider; providers that don't support it ignore the option.
+// otherwise, so a non-vision model is never told it can accept images. Reasoning preferences are
+// declared in the model's `options` block, which OpenCode passes through to the AI SDK provider.
 const buildModelCapabilities = (
   provider: ResolvedProvider,
   reasoningEffort?: ModelReasoningEffort
@@ -164,9 +171,7 @@ const buildModelCapabilities = (
   ...(provider.supportsImageInput
     ? { attachment: true, modalities: { input: ['text', 'image'] } }
     : {}),
-  ...(reasoningEffort
-    ? { options: { reasoningEffort: OPENCODE_REASONING_EFFORT[reasoningEffort] } }
-    : {})
+  ...(reasoningEffort ? { options: opencodeReasoningOptions(provider, reasoningEffort) } : {})
 })
 
 // The app-authoritative config layer (model + provider block + permission policy) passed verbatim to

--- a/src/main/agent-framework/opencode.ts
+++ b/src/main/agent-framework/opencode.ts
@@ -8,7 +8,7 @@ import {
 } from '../acp/permission-profile-controller'
 import type { PermissionProfileId } from '../../shared/permission-profiles'
 import { preferredEndpoint } from '../../shared/settings'
-import type { ReasoningEffort } from '../../shared/settings'
+import type { ModelReasoningEffort } from '../../shared/reasoning-effort'
 import { anthropicMessagesBase, openAiCompletionsBase } from '../settings/base-url'
 import { augmentedPathEnv } from '../settings/shell-path'
 import type { ResolvedProvider } from '../settings/provider-env'
@@ -144,18 +144,13 @@ const resolveOpencodeEndpoint = (
 // AI SDK provider; providers that don't support it ignore the option.
 const buildModelCapabilities = (
   provider: ResolvedProvider,
-  reasoningEffort?: ReasoningEffort
+  reasoningEffort?: ModelReasoningEffort
 ): Record<string, unknown> => ({
   ...(provider.supportsImageInput
     ? { attachment: true, modalities: { input: ['text', 'image'] } }
     : {}),
-  ...(reasoningEffort ? { options: { reasoningEffort: clampOpencodeEffort(reasoningEffort) } } : {})
+  ...(reasoningEffort ? { options: { reasoningEffort } } : {})
 })
-
-// opencode's reasoningEffort follows the AI SDK levels, which top out at 'high'; the app's top level
-// 'max' clamps down to it. 'default' is filtered upstream and never reaches here.
-const clampOpencodeEffort = (effort: ReasoningEffort): 'low' | 'medium' | 'high' =>
-  effort === 'low' || effort === 'medium' ? effort : 'high'
 
 // The app-authoritative config layer (model + provider block + permission policy) passed verbatim to
 // opencode via OPENCODE_CONFIG_CONTENT, which opencode deep-merges ABOVE both the app-owned global config
@@ -165,7 +160,7 @@ const clampOpencodeEffort = (effort: ReasoningEffort): 'low' | 'medium' | 'high'
 // real key can only ever go to the app's own endpoint. The key stays an env reference, never plaintext.
 const buildAppConfigContent = (
   provider: ResolvedProvider,
-  reasoningEffort?: ReasoningEffort
+  reasoningEffort?: ModelReasoningEffort
 ): Record<string, unknown> => {
   const { bareModel, providerId, npm, baseURL } = resolveOpencodeEndpoint(provider)
   const modelConfig = {
@@ -205,7 +200,7 @@ const buildOpencodeConfig = (
   provider: ResolvedProvider,
   baseConfig: Record<string, unknown> = {},
   instructionPaths: string[] = [],
-  reasoningEffort?: ReasoningEffort
+  reasoningEffort?: ModelReasoningEffort
 ): string => {
   const { bareModel, providerId, npm, baseURL } = resolveOpencodeEndpoint(provider)
 

--- a/src/main/agent-framework/types.ts
+++ b/src/main/agent-framework/types.ts
@@ -3,7 +3,8 @@ import type { SessionModeState } from '@agentclientprotocol/sdk'
 
 import type { PermissionProfileApplication } from '../acp/permission-profile-controller'
 import type { PermissionProfileId } from '../../shared/permission-profiles'
-import type { AgentFrameworkId, ChatApiEndpoint, ReasoningEffort } from '../../shared/settings'
+import type { AgentFrameworkId, ChatApiEndpoint } from '../../shared/settings'
+import type { ModelReasoningEffort } from '../../shared/reasoning-effort'
 import type { ResolvedProvider } from '../settings/provider-env'
 import type {
   ResponsesBridgeConnection,
@@ -62,10 +63,9 @@ export type ModelConfigContext = {
   // Compact connector conventions for frameworks that need host.mcp guidance in their baseline
   // instructions. Detailed connector schemas live in on-demand `mcp-*` skills. Empty ⇒ omitted.
   instructions?: string
-  // The user's reasoning-effort preference ('default'/undefined ⇒ don't override; the framework
-  // injects nothing and the agent keeps its own default). Each framework maps the level onto its
-  // native config channel — Codex's model_reasoning_effort, opencode's model options.
-  reasoningEffort?: ReasoningEffort
+  // The active model's already-resolved API effort. Undefined means don't override. Frameworks only
+  // transport this value through their native channel; they do not reinterpret the user's intent.
+  reasoningEffort?: ModelReasoningEffort
 }
 
 // System-prompt guidance the runtime wants appended for a session (artifact routing, notebook, skill
@@ -160,9 +160,9 @@ export type ResolvedAgentBackend = {
   // Subscription backends must run the model selected in the UI. When true, a missing/rejected live
   // model option fails session creation instead of silently using the agent's account default.
   sessionModelRequired?: boolean
-  // Reasoning-effort level to apply per session via the ACP `thought_level` configOption, resolved
-  // to the closest level the agent advertises. Undefined ⇒ the agent keeps its own default.
-  sessionEffort?: ReasoningEffort
+  // Model-resolved reasoning effort to apply per session via ACP. The runtime uses exact matching;
+  // undefined leaves the agent default unchanged.
+  sessionEffort?: ModelReasoningEffort
   // Exact context-window limit for the selected upstream provider model. Framework adapters may
   // report a fallback or bridge transport model instead, so the runtime treats this as authoritative.
   contextWindow?: number
@@ -178,6 +178,9 @@ export type ResolvedAgentBackend = {
     ) => Promise<ResponsesBridgeSkillInput[]>
     registerReviewerSession: (promptCacheKey: string) => void
     unregisterReviewerSession: (promptCacheKey: string) => boolean
+    // Updates the concrete effort on this runtime's own bridged provider/model. Keeping it on the
+    // lease prevents an active-model value from leaking into bridges owned by retiring generations.
+    setReasoningEffort?: (effort?: ModelReasoningEffort) => void
     release: () => Promise<void>
   }
 }

--- a/src/main/agent-framework/types.ts
+++ b/src/main/agent-framework/types.ts
@@ -63,8 +63,8 @@ export type ModelConfigContext = {
   // Compact connector conventions for frameworks that need host.mcp guidance in their baseline
   // instructions. Detailed connector schemas live in on-demand `mcp-*` skills. Empty ⇒ omitted.
   instructions?: string
-  // The active model's already-resolved API effort. Undefined means don't override. Frameworks only
-  // transport this value through their native channel; they do not reinterpret the user's intent.
+  // The active model's already-resolved API effort. Undefined means don't override. Frameworks encode
+  // this into their valid transport vocabulary without changing the persisted user intent.
   reasoningEffort?: ModelReasoningEffort
 }
 

--- a/src/main/settings/ipc.test.ts
+++ b/src/main/settings/ipc.test.ts
@@ -39,6 +39,7 @@ type FakeSettingsService = Record<
   | 'uninstallCodex'
   | 'setAgentFramework'
   | 'setReasoningEffort'
+  | 'resolveActiveReasoningEffort'
   | 'setNotificationsEnabled'
   | 'setClosePreference'
   | 'setAppIconVariant'
@@ -102,6 +103,7 @@ const createFakeService = (): FakeSettingsService => ({
   setReasoningEffort: vi
     .fn()
     .mockResolvedValue({ claude: {}, providers: [], reasoningEffort: 'high' }),
+  resolveActiveReasoningEffort: vi.fn().mockResolvedValue('high'),
   setNotificationsEnabled: vi
     .fn()
     .mockResolvedValue({ claude: {}, providers: [], notificationsEnabled: false }),
@@ -733,6 +735,7 @@ describe('settings IPC handlers', () => {
     const service = createFakeService()
     const snapshot = { claude: {}, providers: [], reasoningEffort: 'high' }
     service.setReasoningEffort.mockResolvedValue(snapshot)
+    service.resolveActiveReasoningEffort.mockResolvedValue('max')
     const onActiveProviderChanged = vi.fn()
     const onReasoningEffortChanged = vi.fn().mockResolvedValue(true)
     registerSettingsIpcHandlers({
@@ -745,7 +748,8 @@ describe('settings IPC handlers', () => {
 
     // A live ACP application (Claude Code, Codex) makes the level stick without a respawn.
     expect(service.setReasoningEffort).toHaveBeenCalledWith('high')
-    expect(onReasoningEffortChanged).toHaveBeenCalledWith('high')
+    expect(service.resolveActiveReasoningEffort).toHaveBeenCalledWith('high')
+    expect(onReasoningEffortChanged).toHaveBeenCalledWith('max')
     expect(onActiveProviderChanged).not.toHaveBeenCalled()
     expect(result).toBe(snapshot)
   })

--- a/src/main/settings/ipc.ts
+++ b/src/main/settings/ipc.ts
@@ -9,7 +9,6 @@ import {
   type AgentFrameworkId,
   type AppIconPreview,
   type AppIconVariant,
-  type ReasoningEffort,
   type SetAppIconVariantRequest,
   type SettingsSnapshot,
   type CreateSkillRequest,
@@ -45,6 +44,7 @@ import {
   type UpsertProviderRequest,
   type ValidateProviderRequest
 } from '../../shared/settings'
+import type { ResolvedReasoningEffort } from '../../shared/reasoning-effort'
 import { createDefaultSettingsService, SettingsService } from './service'
 import { createLogger } from '../logger'
 import { broadcastToRenderers } from '../renderer-broadcast'
@@ -65,7 +65,7 @@ export type SettingsIpcOptions = {
   // Called after the reasoning effort changes so the ACP runtime can live-apply it to open sessions.
   // Returns true when the level was applied over ACP (no reconnect needed); false means the active
   // framework only carries effort in its spawn config and onActiveProviderChanged must fire instead.
-  onReasoningEffortChanged?: (effort: ReasoningEffort) => Promise<boolean>
+  onReasoningEffortChanged?: (effort: ResolvedReasoningEffort) => Promise<boolean>
   // Called after a skill is toggled so the ACP runtime reloads skills on its next reconnect.
   onSkillsChanged?: () => void
   // Called after a connector/tool/credential change so bundled + custom skill docs re-sync.
@@ -217,11 +217,12 @@ const registerSettingsIpcHandlers = ({
 
       log.info('set reasoning effort requested', { effort: request.effort })
       const snapshot = await service.setReasoningEffort(request.effort)
+      const resolvedEffort = await service.resolveActiveReasoningEffort(request.effort)
 
       // Live-capable frameworks (Claude Code, Codex) apply the level to open sessions over ACP —
       // no respawn, the way a model switch feels. Others (opencode) bake effort into the spawn
       // config, so only the provider-switch reconnect can deliver it.
-      const appliedLive = (await onReasoningEffortChanged?.(request.effort)) ?? false
+      const appliedLive = (await onReasoningEffortChanged?.(resolvedEffort)) ?? false
 
       if (!appliedLive) {
         onActiveProviderChanged?.()

--- a/src/main/settings/provider-env.ts
+++ b/src/main/settings/provider-env.ts
@@ -3,6 +3,7 @@ import { homedir } from 'node:os'
 
 import type { ChatApiEndpoint, ProviderType } from '../../shared/settings'
 import type { OfficialVendorId } from '../../shared/provider-registry'
+import type { CustomReasoningEffortTransport } from '../../shared/reasoning-effort'
 import { normalizeAnthropicBaseUrl } from './base-url'
 
 // Resolves an active provider into the environment overrides that the ACP agent (and the claude
@@ -30,6 +31,8 @@ export type ResolvedProvider = {
   // Whether the active model accepts image input. opencode strips image parts for a custom/registered
   // model whose config does not declare vision, so this is surfaced into its per-model capabilities.
   supportsImageInput?: boolean
+  // Explicit only for user-defined gateways; official providers use vendorId for transport mapping.
+  reasoningEffortTransport?: CustomReasoningEffortTransport
 }
 
 export type ProviderEnvOptions = {

--- a/src/main/settings/provider-env.ts
+++ b/src/main/settings/provider-env.ts
@@ -2,6 +2,7 @@ import { join } from 'node:path'
 import { homedir } from 'node:os'
 
 import type { ChatApiEndpoint, ProviderType } from '../../shared/settings'
+import type { OfficialVendorId } from '../../shared/provider-registry'
 import { normalizeAnthropicBaseUrl } from './base-url'
 
 // Resolves an active provider into the environment overrides that the ACP agent (and the claude
@@ -10,6 +11,9 @@ import { normalizeAnthropicBaseUrl } from './base-url'
 // A provider resolved for spawning: the plaintext key is already decrypted by the caller.
 export type ResolvedProvider = {
   type: ProviderType
+  // Retained for official providers even though they use the custom credential path at runtime.
+  // Transport adapters need this stable identity because `none` has vendor-specific wire semantics.
+  vendorId?: OfficialVendorId
   // Anthropic /v1/messages base (also the sole base for a custom provider). Claude always uses this.
   baseUrl?: string
   // Distinct OpenAI /v1/chat/completions base for a dual-endpoint vendor (e.g. DeepSeek). Used only

--- a/src/main/settings/reasoning-transport.ts
+++ b/src/main/settings/reasoning-transport.ts
@@ -1,0 +1,44 @@
+import type { OfficialVendorId } from '../../shared/provider-registry'
+import type { ModelReasoningEffort } from '../../shared/reasoning-effort'
+
+export type ChatReasoningTransport = {
+  reasoningEffort?: ModelReasoningEffort
+  thinking?: { type: 'adaptive' | 'disabled' | 'enabled' }
+  reasoning?: { effort?: ModelReasoningEffort; enabled?: boolean }
+}
+
+// Model profiles describe the values the user may select; this resolver describes how an official
+// provider expects that value on its Chat Completions wire. `none` is especially non-portable:
+// GLM accepts it as reasoning_effort, while DeepSeek/MiniMax/MiMo use a thinking switch and
+// OpenRouter uses its normalized reasoning object. Custom providers stay literal because the user
+// explicitly chose their capability preset and may expose an OpenAI-compatible effort parameter.
+export const resolveChatReasoningTransport = (
+  vendorId: OfficialVendorId | undefined,
+  model: string | undefined,
+  effort: ModelReasoningEffort
+): ChatReasoningTransport => {
+  if (vendorId === 'openrouter') {
+    // Qwen 3.7 Max exposes a hybrid-thinking toggle but no continuous effort levels in OpenRouter's
+    // public model metadata. Other curated OpenRouter models use the gateway's normalized effort.
+    if (model === 'qwen/qwen3.7-max') {
+      return { reasoning: { enabled: effort !== 'none' } }
+    }
+    return effort === 'none' ? { reasoning: { enabled: false } } : { reasoning: { effort } }
+  }
+
+  if (vendorId === 'minimax') {
+    return { thinking: { type: effort === 'none' ? 'disabled' : 'adaptive' } }
+  }
+
+  if (vendorId === 'xiaomimimo') {
+    return { thinking: { type: effort === 'none' ? 'disabled' : 'enabled' } }
+  }
+
+  if (vendorId === 'deepseek') {
+    return effort === 'none'
+      ? { thinking: { type: 'disabled' } }
+      : { reasoningEffort: effort, thinking: { type: 'enabled' } }
+  }
+
+  return { reasoningEffort: effort }
+}

--- a/src/main/settings/reasoning-transport.ts
+++ b/src/main/settings/reasoning-transport.ts
@@ -1,5 +1,8 @@
 import type { OfficialVendorId } from '../../shared/provider-registry'
-import type { ModelReasoningEffort } from '../../shared/reasoning-effort'
+import type {
+  CustomReasoningEffortTransport,
+  ModelReasoningEffort
+} from '../../shared/reasoning-effort'
 
 export type ChatReasoningTransport = {
   reasoningEffort?: ModelReasoningEffort
@@ -10,31 +13,35 @@ export type ChatReasoningTransport = {
 // Model profiles describe the values the user may select; this resolver describes how an official
 // provider expects that value on its Chat Completions wire. `none` is especially non-portable:
 // GLM accepts it as reasoning_effort, while DeepSeek/MiniMax/MiMo use a thinking switch and
-// OpenRouter uses its normalized reasoning object. Custom providers stay literal because the user
-// explicitly chose their capability preset and may expose an OpenAI-compatible effort parameter.
+// OpenRouter uses its normalized reasoning object. Custom providers select one of the same request
+// shapes explicitly; absence remains the backwards-compatible literal reasoning_effort field.
 export const resolveChatReasoningTransport = (
   vendorId: OfficialVendorId | undefined,
   model: string | undefined,
-  effort: ModelReasoningEffort
+  effort: ModelReasoningEffort,
+  customTransport?: CustomReasoningEffortTransport
 ): ChatReasoningTransport => {
-  if (vendorId === 'openrouter') {
+  const transport = vendorId ?? customTransport
+
+  if (transport === 'openrouter') {
     // Qwen 3.7 Max exposes a hybrid-thinking toggle but no continuous effort levels in OpenRouter's
-    // public model metadata. Other curated OpenRouter models use the gateway's normalized effort.
-    if (model === 'qwen/qwen3.7-max') {
+    // public model metadata. Keep that model-name lookup scoped to the built-in provider catalog;
+    // custom gateways select only a request shape and are never inferred from user-entered ids.
+    if (vendorId === 'openrouter' && model === 'qwen/qwen3.7-max') {
       return { reasoning: { enabled: effort !== 'none' } }
     }
     return effort === 'none' ? { reasoning: { enabled: false } } : { reasoning: { effort } }
   }
 
-  if (vendorId === 'minimax') {
+  if (transport === 'minimax') {
     return { thinking: { type: effort === 'none' ? 'disabled' : 'adaptive' } }
   }
 
-  if (vendorId === 'xiaomimimo') {
+  if (transport === 'xiaomimimo') {
     return { thinking: { type: effort === 'none' ? 'disabled' : 'enabled' } }
   }
 
-  if (vendorId === 'deepseek') {
+  if (transport === 'deepseek') {
     return effort === 'none'
       ? { thinking: { type: 'disabled' } }
       : { reasoningEffort: effort, thinking: { type: 'enabled' } }

--- a/src/main/settings/repository.test.ts
+++ b/src/main/settings/repository.test.ts
@@ -426,6 +426,31 @@ describe('settings repository', () => {
     ).toBeUndefined()
   })
 
+  it('keeps only a known custom-model reasoning effort transport', () => {
+    const base = { id: 'p1', type: 'custom', name: 'Gateway' }
+
+    expect(
+      sanitizeSettings({ providers: [{ ...base, reasoningEffortTransport: 'deepseek' }] })
+        .providers[0].reasoningEffortTransport
+    ).toBe('deepseek')
+    expect(
+      sanitizeSettings({ providers: [{ ...base, reasoningEffortTransport: 'guessed' }] })
+        .providers[0].reasoningEffortTransport
+    ).toBeUndefined()
+    expect(
+      sanitizeSettings({
+        providers: [
+          {
+            ...base,
+            type: 'official',
+            vendorId: 'deepseek',
+            reasoningEffortTransport: 'openrouter'
+          }
+        ]
+      }).providers[0].reasoningEffortTransport
+    ).toBeUndefined()
+  })
+
   it('round-trips a recorded validation failure across a reload', async () => {
     const root = await createStorageRoot()
     const repository = new SettingsRepository(root)

--- a/src/main/settings/repository.test.ts
+++ b/src/main/settings/repository.test.ts
@@ -228,7 +228,7 @@ describe('settings repository', () => {
     expect(reloaded.reasoningEffort).toBe('high')
   })
 
-  it.each(['default', 'low', 'medium', 'high', 'max'] as const)(
+  it.each(['default', 'low', 'medium', 'high', 'xhigh', 'max'] as const)(
     'keeps the %s reasoning effort on load',
     (effort) => {
       expect(sanitizeSettings({ reasoningEffort: effort }).reasoningEffort).toBe(effort)
@@ -407,6 +407,23 @@ describe('settings repository', () => {
         sanitizeSettings({ providers: [{ ...base, contextWindow }] }).providers[0].contextWindow
       ).toBeUndefined()
     }
+  })
+
+  it('keeps only a known custom-model reasoning effort preset', () => {
+    const base = { id: 'p1', type: 'custom', name: 'Gateway' }
+
+    expect(
+      sanitizeSettings({ providers: [{ ...base, reasoningEffortPreset: 'none-high' }] })
+        .providers[0].reasoningEffortPreset
+    ).toBe('none-high')
+    expect(
+      sanitizeSettings({ providers: [{ ...base, reasoningEffortPreset: 'unsupported' }] })
+        .providers[0].reasoningEffortPreset
+    ).toBe('unsupported')
+    expect(
+      sanitizeSettings({ providers: [{ ...base, reasoningEffortPreset: 'dynamic' }] }).providers[0]
+        .reasoningEffortPreset
+    ).toBeUndefined()
   })
 
   it('round-trips a recorded validation failure across a reload', async () => {

--- a/src/main/settings/repository.ts
+++ b/src/main/settings/repository.ts
@@ -28,6 +28,7 @@ import {
   isReasoningEffort
 } from '../../shared/settings'
 import { isOfficialVendorId } from '../../shared/provider-registry'
+import { isReasoningEffortPresetSetting } from '../../shared/reasoning-effort'
 import type { PackageMirror } from '../../shared/mirror'
 import type { NotebookLanguage } from '../../shared/notebook'
 import type { RuntimeEnablement, RuntimeSelection } from '../../shared/notebook-runtime'
@@ -198,6 +199,9 @@ const sanitizeProvider = (value: unknown): StoredProvider | undefined => {
       ? rawContextWindow
       : undefined
   const supportsImageInput = asBoolean(value.supportsImageInput)
+  const reasoningEffortPreset = isReasoningEffortPresetSetting(value.reasoningEffortPreset)
+    ? value.reasoningEffortPreset
+    : undefined
   const region = asString(value.region)
   const keyRef = asString(value.keyRef)
   const keyMask = asString(value.keyMask)
@@ -235,6 +239,9 @@ const sanitizeProvider = (value: unknown): StoredProvider | undefined => {
   if (model) provider.model = model
   if (contextWindow !== undefined) provider.contextWindow = contextWindow
   if (supportsImageInput !== undefined) provider.supportsImageInput = supportsImageInput
+  if (reasoningEffortPreset !== undefined && type === 'custom') {
+    provider.reasoningEffortPreset = reasoningEffortPreset
+  }
   if (apiEndpoints.length > 0) provider.apiEndpoints = apiEndpoints
   if (vendorId) provider.vendorId = vendorId
   if (region) provider.region = region

--- a/src/main/settings/repository.ts
+++ b/src/main/settings/repository.ts
@@ -28,7 +28,10 @@ import {
   isReasoningEffort
 } from '../../shared/settings'
 import { isOfficialVendorId } from '../../shared/provider-registry'
-import { isReasoningEffortPresetSetting } from '../../shared/reasoning-effort'
+import {
+  isCustomReasoningEffortTransport,
+  isReasoningEffortPresetSetting
+} from '../../shared/reasoning-effort'
 import type { PackageMirror } from '../../shared/mirror'
 import type { NotebookLanguage } from '../../shared/notebook'
 import type { RuntimeEnablement, RuntimeSelection } from '../../shared/notebook-runtime'
@@ -202,6 +205,9 @@ const sanitizeProvider = (value: unknown): StoredProvider | undefined => {
   const reasoningEffortPreset = isReasoningEffortPresetSetting(value.reasoningEffortPreset)
     ? value.reasoningEffortPreset
     : undefined
+  const reasoningEffortTransport = isCustomReasoningEffortTransport(value.reasoningEffortTransport)
+    ? value.reasoningEffortTransport
+    : undefined
   const region = asString(value.region)
   const keyRef = asString(value.keyRef)
   const keyMask = asString(value.keyMask)
@@ -241,6 +247,9 @@ const sanitizeProvider = (value: unknown): StoredProvider | undefined => {
   if (supportsImageInput !== undefined) provider.supportsImageInput = supportsImageInput
   if (reasoningEffortPreset !== undefined && type === 'custom') {
     provider.reasoningEffortPreset = reasoningEffortPreset
+  }
+  if (reasoningEffortTransport !== undefined && type === 'custom') {
+    provider.reasoningEffortTransport = reasoningEffortTransport
   }
   if (apiEndpoints.length > 0) provider.apiEndpoints = apiEndpoints
   if (vendorId) provider.vendorId = vendorId

--- a/src/main/settings/responses-bridge.test.ts
+++ b/src/main/settings/responses-bridge.test.ts
@@ -484,6 +484,12 @@ describe('Responses-compatible bridge conversion', () => {
       responsesToChatRequest({ input: 'hello', reasoning: { effort: 'turbo' } })
     ).toThrow(/reasoning effort/)
     expect(() =>
+      responsesToChatRequest({ input: 'hello', reasoning: { effort: 'max' } })
+    ).not.toThrow()
+    expect(() =>
+      responsesToChatRequest({ input: 'hello', reasoning: { effort: 'ultra' } })
+    ).not.toThrow()
+    expect(() =>
       responsesToChatRequest({ input: 'hello', reasoning: { summary: 'verbose' } })
     ).toThrow(/reasoning summary/)
     expect(() =>

--- a/src/main/settings/responses-bridge.test.ts
+++ b/src/main/settings/responses-bridge.test.ts
@@ -548,6 +548,51 @@ describe('Responses-compatible bridge conversion', () => {
     }
   )
 
+  it('uses provider-native Chat controls when none is not a reasoning_effort literal', () => {
+    expect(
+      responsesToChatRequest({ model: 'catalog', input: 'hi' }, 'deepseek-v4-pro', undefined, [], {
+        reasoningEffortOverride: 'none',
+        vendorId: 'deepseek'
+      })
+    ).toMatchObject({ thinking: { type: 'disabled' } })
+    expect(
+      responsesToChatRequest({ model: 'catalog', input: 'hi' }, 'deepseek-v4-pro', undefined, [], {
+        reasoningEffortOverride: 'none',
+        vendorId: 'deepseek'
+      })
+    ).not.toHaveProperty('reasoning_effort')
+
+    expect(
+      responsesToChatRequest({ model: 'catalog', input: 'hi' }, 'mimo-v2.5-pro', undefined, [], {
+        reasoningEffortOverride: 'high',
+        vendorId: 'xiaomimimo'
+      })
+    ).toMatchObject({ thinking: { type: 'enabled' } })
+
+    expect(
+      responsesToChatRequest({ model: 'catalog', input: 'hi' }, 'qwen/qwen3.7-max', undefined, [], {
+        reasoningEffortOverride: 'none',
+        vendorId: 'openrouter'
+      })
+    ).toMatchObject({ reasoning: { enabled: false } })
+  })
+
+  it('uses OpenRouter reasoning objects and keeps GLM none as a literal effort', () => {
+    expect(
+      responsesToChatRequest({ model: 'catalog', input: 'hi' }, 'openai/gpt-5.5', undefined, [], {
+        reasoningEffortOverride: 'xhigh',
+        vendorId: 'openrouter'
+      })
+    ).toMatchObject({ reasoning: { effort: 'xhigh' } })
+
+    expect(
+      responsesToChatRequest({ model: 'catalog', input: 'hi' }, 'glm-5.2', undefined, [], {
+        reasoningEffortOverride: 'none',
+        vendorId: 'zhipu'
+      })
+    ).toMatchObject({ reasoning_effort: 'none' })
+  })
+
   it('strips the reasoning effort unless the user explicitly chose a level', () => {
     // Codex emits its own default effort even when the app never configured one; forwarding that
     // would change what existing bridged users send to gateways that may reject unknown params.

--- a/src/main/settings/responses-bridge.test.ts
+++ b/src/main/settings/responses-bridge.test.ts
@@ -583,6 +583,31 @@ describe('Responses-compatible bridge conversion', () => {
     ).toMatchObject({ reasoning: { enabled: false } })
   })
 
+  it('uses the selected native transport for a custom gateway', () => {
+    const request = responsesToChatRequest(
+      { model: 'catalog', input: 'hi' },
+      'private-model',
+      undefined,
+      [],
+      {
+        reasoningEffortOverride: 'none',
+        reasoningEffortTransport: 'minimax'
+      }
+    )
+
+    expect(request).toMatchObject({ thinking: { type: 'disabled' } })
+    expect(request).not.toHaveProperty('reasoning_effort')
+  })
+
+  it('does not infer the built-in OpenRouter Qwen toggle for a custom gateway', () => {
+    expect(
+      responsesToChatRequest({ model: 'catalog', input: 'hi' }, 'qwen/qwen3.7-max', undefined, [], {
+        reasoningEffortOverride: 'high',
+        reasoningEffortTransport: 'openrouter'
+      })
+    ).toMatchObject({ reasoning: { effort: 'high' } })
+  })
+
   it('uses OpenRouter reasoning objects and keeps GLM none as a literal effort', () => {
     expect(
       responsesToChatRequest({ model: 'catalog', input: 'hi' }, 'openai/gpt-5.5', undefined, [], {

--- a/src/main/settings/responses-bridge.test.ts
+++ b/src/main/settings/responses-bridge.test.ts
@@ -521,57 +521,32 @@ describe('Responses-compatible bridge conversion', () => {
     ).toMatchObject({ model: 'deepseek-v4-flash' })
   })
 
-  it('translates the reasoning effort into the Chat Completions parameter when explicitly chosen', () => {
+  it('uses the model-resolved effort override instead of Codex\u2019s request value', () => {
     expect(
       responsesToChatRequest(
         { model: 'model-a', input: 'hi', reasoning: { effort: 'high' } },
         undefined,
         undefined,
         [],
-        { forwardReasoningEffort: true }
+        { reasoningEffortOverride: 'max' }
       )
-    ).toMatchObject({ reasoning_effort: 'high' })
-    expect(
-      responsesToChatRequest(
-        { model: 'model-a', input: 'hi', reasoning: { effort: 'low' } },
-        undefined,
-        undefined,
-        [],
-        { forwardReasoningEffort: true }
-      )
-    ).toMatchObject({ reasoning_effort: 'low' })
+    ).toMatchObject({ reasoning_effort: 'max' })
   })
 
-  it('clamps the Codex-only xhigh effort to high for Chat Completions', () => {
-    expect(
-      responsesToChatRequest(
-        { model: 'model-a', input: 'hi', reasoning: { effort: 'xhigh' } },
-        undefined,
-        undefined,
-        [],
-        { forwardReasoningEffort: true }
-      )
-    ).toMatchObject({ reasoning_effort: 'high' })
-  })
-
-  it('omits the reasoning effort when there is nothing portable to send', () => {
-    // 'none' has no Chat Completions equivalent — the upstream default stands. No reasoning block
-    // means nothing is sent either.
-    expect(
-      responsesToChatRequest(
-        { model: 'model-a', input: 'hi', reasoning: { effort: 'none' } },
-        undefined,
-        undefined,
-        [],
-        { forwardReasoningEffort: true }
-      )
-    ).not.toHaveProperty('reasoning_effort')
-    expect(
-      responsesToChatRequest({ model: 'model-a', input: 'hi' }, undefined, undefined, [], {
-        forwardReasoningEffort: true
-      })
-    ).not.toHaveProperty('reasoning_effort')
-  })
+  it.each(['none', 'minimal', 'low', 'medium', 'high', 'xhigh', 'max', 'ultra'] as const)(
+    'transports the model-resolved %s effort without protocol-level clamping',
+    (effort) => {
+      expect(
+        responsesToChatRequest(
+          { model: 'model-a', input: 'hi', reasoning: { effort: 'high' } },
+          undefined,
+          undefined,
+          [],
+          { reasoningEffortOverride: effort }
+        )
+      ).toMatchObject({ reasoning_effort: effort })
+    }
+  )
 
   it('strips the reasoning effort unless the user explicitly chose a level', () => {
     // Codex emits its own default effort even when the app never configured one; forwarding that
@@ -695,7 +670,7 @@ describe('Responses-compatible bridge conversion', () => {
     }
   })
 
-  it('forwards the reasoning effort to the upstream gateway when explicitly chosen', async () => {
+  it('overrides Codex\u2019s effort with the model-resolved value at the upstream gateway', async () => {
     let upstreamRequest: Record<string, unknown> | undefined
     const upstreamFetch = vi.fn(
       async (_url: Parameters<typeof fetch>[0], init?: Parameters<typeof fetch>[1]) => {
@@ -717,7 +692,7 @@ describe('Responses-compatible bridge conversion', () => {
       }
     )
     const bridge = new ResponsesBridge(
-      { baseUrl: 'https://vendor.example/v1', key: 'upstream-key', forwardReasoningEffort: true },
+      { baseUrl: 'https://vendor.example/v1', key: 'upstream-key', reasoningEffort: 'max' },
       upstreamFetch
     )
     const connection = await bridge.start()
@@ -738,9 +713,8 @@ describe('Responses-compatible bridge conversion', () => {
       })
       await response.text()
 
-      // The Codex-only 'xhigh' reaches the gateway as 'high', not dropped.
       expect(response.status).toBe(200)
-      expect(upstreamRequest).toMatchObject({ reasoning_effort: 'high' })
+      expect(upstreamRequest).toMatchObject({ reasoning_effort: 'max' })
     } finally {
       await bridge.close()
     }
@@ -767,8 +741,8 @@ describe('Responses-compatible bridge conversion', () => {
         )
       }
     )
-    // No forwardReasoningEffort: Codex's own default effort must not change what existing bridged
-    // users send upstream.
+    // No resolved override: Codex's own default effort must not change what existing bridged users
+    // send upstream.
     const bridge = new ResponsesBridge(
       { baseUrl: 'https://vendor.example/v1', key: 'upstream-key' },
       upstreamFetch
@@ -843,13 +817,14 @@ describe('Responses-compatible bridge conversion', () => {
       await post()
       expect(upstreamRequest).not.toHaveProperty('reasoning_effort')
 
-      // The user picks a level (Codex applies it live over ACP — the bridge never reconnects).
-      bridge.setForwardReasoningEffort(true)
+      // The model profile resolves a concrete level (Codex applies it live over ACP — the bridge
+      // never reconnects).
+      bridge.setReasoningEffort('max')
       await post()
-      expect(upstreamRequest).toMatchObject({ reasoning_effort: 'high' })
+      expect(upstreamRequest).toMatchObject({ reasoning_effort: 'max' })
 
       // Back to default: stripping restored on the same live bridge.
-      bridge.setForwardReasoningEffort(false)
+      bridge.setReasoningEffort(undefined)
       await post()
       expect(upstreamRequest).not.toHaveProperty('reasoning_effort')
     } finally {
@@ -1554,8 +1529,16 @@ describe('Responses-compatible bridge conversion', () => {
 
 describe('Responses bridge Skill selector', () => {
   const catalog = [
-    { name: 'mcp-pubmed', description: 'Search biomedical literature.', path: '/private/pubmed/SKILL.md' },
-    { name: 'literature-review', description: 'Plan a systematic review.', path: '/private/review/SKILL.md' },
+    {
+      name: 'mcp-pubmed',
+      description: 'Search biomedical literature.',
+      path: '/private/pubmed/SKILL.md'
+    },
+    {
+      name: 'literature-review',
+      description: 'Plan a systematic review.',
+      path: '/private/review/SKILL.md'
+    },
     { name: 'statistics', description: 'Analyze numerical data.', path: '/private/stats/SKILL.md' },
     { name: 'writing', description: 'Improve prose.', path: '/private/writing/SKILL.md' }
   ]
@@ -1689,7 +1672,9 @@ describe('Responses bridge Skill selector', () => {
 
     const request = JSON.parse(upstreamBody) as {
       messages: Array<{ content: string }>
-      tools: Array<{ function: { parameters: { properties: { skill_names: { items: { enum: string[] } } } } } }>
+      tools: Array<{
+        function: { parameters: { properties: { skill_names: { items: { enum: string[] } } } } }
+      }>
     }
     const names = request.tools[0].function.parameters.properties.skill_names.items.enum
     expect(names).toHaveLength(128)

--- a/src/main/settings/responses-bridge.ts
+++ b/src/main/settings/responses-bridge.ts
@@ -3,6 +3,8 @@ import { createServer, type IncomingMessage, type Server, type ServerResponse } 
 
 import { createLogger } from '../logger'
 import { appendChatCompletions } from './base-url'
+import { resolveChatReasoningTransport } from './reasoning-transport'
+import type { OfficialVendorId } from '../../shared/provider-registry'
 import type { ModelReasoningEffort } from '../../shared/reasoning-effort'
 
 // The bridge deliberately keeps protocol payloads open-ended; validation rejects unsupported shapes
@@ -19,6 +21,7 @@ const log = createLogger('acp-bridge')
 export type ResponsesBridgeTarget = {
   baseUrl: string
   key?: string
+  vendorId?: OfficialVendorId
   // Codex uses a catalog model for its local metadata; bridge providers may need a different
   // upstream model id (for example, DeepSeek's model name).
   model?: string
@@ -556,7 +559,10 @@ export const responsesToChatRequest = (
   upstreamModel?: string,
   reasoningByCallId?: Map<string, string>,
   namespacedTools: readonly ResponsesBridgeNamespacedTool[] = [],
-  options?: { reasoningEffortOverride?: ModelReasoningEffort }
+  options?: {
+    reasoningEffortOverride?: ModelReasoningEffort
+    vendorId?: OfficialVendorId
+  }
 ): JsonObject => {
   for (const field of UNSUPPORTED_FIELDS) {
     if (body[field] !== undefined && body[field] !== null) {
@@ -631,6 +637,9 @@ export const responsesToChatRequest = (
   // Codex runs a catalog transport model and may omit, default, or clamp values that the real model
   // supports. Undefined intentionally strips Codex's own effort from the Chat request.
   const chatReasoningEffort = options?.reasoningEffortOverride
+  const reasoningTransport = chatReasoningEffort
+    ? resolveChatReasoningTransport(options?.vendorId, upstreamModel, chatReasoningEffort)
+    : undefined
 
   return {
     model: upstreamModel ?? body.model,
@@ -645,7 +654,11 @@ export const responsesToChatRequest = (
     ...(body.max_output_tokens === undefined || body.max_output_tokens === null
       ? {}
       : { max_tokens: body.max_output_tokens }),
-    ...(chatReasoningEffort ? { reasoning_effort: chatReasoningEffort } : {}),
+    ...(reasoningTransport?.reasoningEffort
+      ? { reasoning_effort: reasoningTransport.reasoningEffort }
+      : {}),
+    ...(reasoningTransport?.thinking ? { thinking: reasoningTransport.thinking } : {}),
+    ...(reasoningTransport?.reasoning ? { reasoning: reasoningTransport.reasoning } : {}),
     stream,
     // Responses stream options are not Chat Completions options. Request final usage explicitly and
     // do not forward fields such as include_obfuscation that a Chat-compatible gateway may reject.
@@ -1171,6 +1184,7 @@ export class ResponsesBridge {
     const changed =
       this.target.baseUrl !== target.baseUrl ||
       this.target.model !== target.model ||
+      this.target.vendorId !== target.vendorId ||
       this.target.key !== target.key
     this.target = target
     if (changed) this.reasoningByCallId.clear()
@@ -1292,7 +1306,10 @@ export class ResponsesBridge {
         this.target.model,
         this.reasoningByCallId,
         namespacedTools,
-        { reasoningEffortOverride: this.target.reasoningEffort }
+        {
+          reasoningEffortOverride: this.target.reasoningEffort,
+          vendorId: this.target.vendorId
+        }
       )
 
       // Reveals which real model actually serves the turn (Codex only ever sees the internal catalog

--- a/src/main/settings/responses-bridge.ts
+++ b/src/main/settings/responses-bridge.ts
@@ -3,6 +3,7 @@ import { createServer, type IncomingMessage, type Server, type ServerResponse } 
 
 import { createLogger } from '../logger'
 import { appendChatCompletions } from './base-url'
+import type { ModelReasoningEffort } from '../../shared/reasoning-effort'
 
 // The bridge deliberately keeps protocol payloads open-ended; validation rejects unsupported shapes
 // at the boundary before values reach the upstream request.
@@ -22,11 +23,9 @@ export type ResponsesBridgeTarget = {
   // upstream model id (for example, DeepSeek's model name).
   model?: string
   namespacedTools?: ResponsesBridgeNamespacedTool[]
-  // Forward reasoning.effort upstream as reasoning_effort ONLY when the user explicitly picked a
-  // level. Codex emits its own default effort even when the app never configured one, so
-  // unconditional forwarding would change what existing bridged users send to their gateway —
-  // and gateways fronting non-OpenAI models often reject unknown parameters.
-  forwardReasoningEffort?: boolean
+  // The active model's resolved API value. This explicitly overrides Codex's transport-model effort,
+  // which may use a smaller vocabulary or emit its own default. Undefined strips the field.
+  reasoningEffort?: ModelReasoningEffort
   reviewerScope?: {
     namespacedTools: ResponsesBridgeNamespacedTool[]
   }
@@ -557,7 +556,7 @@ export const responsesToChatRequest = (
   upstreamModel?: string,
   reasoningByCallId?: Map<string, string>,
   namespacedTools: readonly ResponsesBridgeNamespacedTool[] = [],
-  options?: { forwardReasoningEffort?: boolean }
+  options?: { reasoningEffortOverride?: ModelReasoningEffort }
 ): JsonObject => {
   for (const field of UNSUPPORTED_FIELDS) {
     if (body[field] !== undefined && body[field] !== null) {
@@ -628,27 +627,10 @@ export const responsesToChatRequest = (
   const toolChoice = hasTools ? requestedToolChoice : undefined
   const stream = body.stream !== false
 
-  // Translate the Responses reasoning effort into the Chat Completions equivalent (validated above),
-  // but only when the app's user explicitly picked a level: Codex also emits its own default effort,
-  // and forwarding that would change what existing bridged users send upstream. OpenAI-shaped
-  // gateways take `reasoning_effort`; the Codex-only 'xhigh' clamps to 'high', and 'none' is
-  // omitted — Chat Completions has no "reasoning off" switch, so the upstream default stands.
-  const requestedEffort =
-    options?.forwardReasoningEffort &&
-    body.reasoning &&
-    typeof body.reasoning === 'object' &&
-    !Array.isArray(body.reasoning)
-      ? (body.reasoning as JsonObject).effort
-      : undefined
-  const chatReasoningEffort =
-    requestedEffort === 'xhigh'
-      ? 'high'
-      : requestedEffort === 'minimal' ||
-          requestedEffort === 'low' ||
-          requestedEffort === 'medium' ||
-          requestedEffort === 'high'
-        ? requestedEffort
-        : undefined
+  // The model profile already chose the upstream API value. Never derive it from Codex's request:
+  // Codex runs a catalog transport model and may omit, default, or clamp values that the real model
+  // supports. Undefined intentionally strips Codex's own effort from the Chat request.
+  const chatReasoningEffort = options?.reasoningEffortOverride
 
   return {
     model: upstreamModel ?? body.model,
@@ -1194,11 +1176,10 @@ export class ResponsesBridge {
     if (changed) this.reasoningByCallId.clear()
   }
 
-  // Updates only the effort-forwarding policy on the live target, for when the user's reasoning-effort
-  // setting changes without a reconnect (Codex applies level changes live over ACP). Deliberately not
-  // a setTarget: the upstream provider is unchanged, so the reasoning cache must be preserved.
-  setForwardReasoningEffort(forward: boolean): void {
-    this.target = { ...this.target, forwardReasoningEffort: forward }
+  // Updates only the resolved upstream effort on the live target. Deliberately not a setTarget: the
+  // provider is unchanged, so the reasoning cache must be preserved.
+  setReasoningEffort(effort?: ModelReasoningEffort): void {
+    this.target = { ...this.target, reasoningEffort: effort }
   }
 
   registerReviewerSession(promptCacheKey: string): void {
@@ -1311,7 +1292,7 @@ export class ResponsesBridge {
         this.target.model,
         this.reasoningByCallId,
         namespacedTools,
-        { forwardReasoningEffort: this.target.forwardReasoningEffort }
+        { reasoningEffortOverride: this.target.reasoningEffort }
       )
 
       // Reveals which real model actually serves the turn (Codex only ever sees the internal catalog

--- a/src/main/settings/responses-bridge.ts
+++ b/src/main/settings/responses-bridge.ts
@@ -5,7 +5,10 @@ import { createLogger } from '../logger'
 import { appendChatCompletions } from './base-url'
 import { resolveChatReasoningTransport } from './reasoning-transport'
 import type { OfficialVendorId } from '../../shared/provider-registry'
-import type { ModelReasoningEffort } from '../../shared/reasoning-effort'
+import type {
+  CustomReasoningEffortTransport,
+  ModelReasoningEffort
+} from '../../shared/reasoning-effort'
 
 // The bridge deliberately keeps protocol payloads open-ended; validation rejects unsupported shapes
 // at the boundary before values reach the upstream request.
@@ -22,6 +25,7 @@ export type ResponsesBridgeTarget = {
   baseUrl: string
   key?: string
   vendorId?: OfficialVendorId
+  reasoningEffortTransport?: CustomReasoningEffortTransport
   // Codex uses a catalog model for its local metadata; bridge providers may need a different
   // upstream model id (for example, DeepSeek's model name).
   model?: string
@@ -571,6 +575,7 @@ export const responsesToChatRequest = (
   options?: {
     reasoningEffortOverride?: ModelReasoningEffort
     vendorId?: OfficialVendorId
+    reasoningEffortTransport?: CustomReasoningEffortTransport
   }
 ): JsonObject => {
   for (const field of UNSUPPORTED_FIELDS) {
@@ -647,7 +652,12 @@ export const responsesToChatRequest = (
   // supports. Undefined intentionally strips Codex's own effort from the Chat request.
   const chatReasoningEffort = options?.reasoningEffortOverride
   const reasoningTransport = chatReasoningEffort
-    ? resolveChatReasoningTransport(options?.vendorId, upstreamModel, chatReasoningEffort)
+    ? resolveChatReasoningTransport(
+        options?.vendorId,
+        upstreamModel,
+        chatReasoningEffort,
+        options?.reasoningEffortTransport
+      )
     : undefined
 
   return {
@@ -1194,6 +1204,7 @@ export class ResponsesBridge {
       this.target.baseUrl !== target.baseUrl ||
       this.target.model !== target.model ||
       this.target.vendorId !== target.vendorId ||
+      this.target.reasoningEffortTransport !== target.reasoningEffortTransport ||
       this.target.key !== target.key
     this.target = target
     if (changed) this.reasoningByCallId.clear()
@@ -1317,7 +1328,8 @@ export class ResponsesBridge {
         namespacedTools,
         {
           reasoningEffortOverride: this.target.reasoningEffort,
-          vendorId: this.target.vendorId
+          vendorId: this.target.vendorId,
+          reasoningEffortTransport: this.target.reasoningEffortTransport
         }
       )
 

--- a/src/main/settings/responses-bridge.ts
+++ b/src/main/settings/responses-bridge.ts
@@ -104,7 +104,16 @@ class BridgeHttpError extends Error {
 
 const ALLOWED_INCLUDE_VALUES = new Set(['reasoning.encrypted_content'])
 const ALLOWED_REASONING_KEYS = new Set(['effort', 'summary'])
-const ALLOWED_REASONING_EFFORTS = new Set(['none', 'minimal', 'low', 'medium', 'high', 'xhigh'])
+const ALLOWED_REASONING_EFFORTS = new Set([
+  'none',
+  'minimal',
+  'low',
+  'medium',
+  'high',
+  'xhigh',
+  'max',
+  'ultra'
+])
 const ALLOWED_REASONING_SUMMARIES = new Set(['auto', 'concise', 'detailed'])
 const ALLOWED_IMAGE_DETAILS = new Set(['auto', 'low', 'high'])
 const UPSTREAM_IMAGE_TYPES = new Set(['image', 'image_url', 'input_image', 'output_image'])

--- a/src/main/settings/service.test.ts
+++ b/src/main/settings/service.test.ts
@@ -2117,6 +2117,7 @@ describe('SettingsService: preflight & spawn config', () => {
       lastValidatedAt: Date.now()
     })
     await service.setActiveProvider(provider.id, 'deepseek-v4-flash')
+    await repository.setReasoningEffort('low')
 
     vi.stubEnv('OPEN_SCIENCE_AGENT_FRAMEWORK', 'codex')
     const backend = await service.resolveActiveAgentBackend()
@@ -2124,6 +2125,7 @@ describe('SettingsService: preflight & spawn config', () => {
     // Chat Completions provider ⇒ bridge ⇒ Codex runs the classic-tool-mode catalog model so it
     // advertises the shell_command function tool the bridge can forward (CODEX_BRIDGE_MODEL).
     expect(backend.sessionModel).toBe('gpt-5.4')
+    expect(backend.sessionEffort).toBe('none')
     expect(backend.contextWindow).toBe(1_000_000)
     expect(backend.providerConfiguration).toEqual({
       providerId: 'custom-gateway',
@@ -2171,6 +2173,8 @@ describe('SettingsService: preflight & spawn config', () => {
       ])
     })
     const upstreamMessages = JSON.stringify(upstreamRequest?.messages)
+    expect(upstreamRequest).toMatchObject({ thinking: { type: 'disabled' } })
+    expect(upstreamRequest).not.toHaveProperty('reasoning_effort')
     expect(upstreamMessages).not.toContain('<open_science_connector_instructions>')
     expect(upstreamMessages).not.toContain('host.mcp("pubmed", "search_articles"')
 
@@ -3768,7 +3772,7 @@ describe('SettingsService: reasoning effort', () => {
     expect((await repository.getSettings()).reasoningEffort).toBe('max')
   })
 
-  it("maps a five-level intent onto DeepSeek's two supported levels", async () => {
+  it("maps a five-level intent onto DeepSeek's three supported levels", async () => {
     const service = createService()
     const provider = (
       await service.upsertProvider({
@@ -3780,7 +3784,7 @@ describe('SettingsService: reasoning effort', () => {
     ).providers[0]
     await service.setActiveProvider(provider.id, 'deepseek-v4-pro')
 
-    expect(await service.resolveActiveReasoningEffort('low')).toBe('high')
+    expect(await service.resolveActiveReasoningEffort('low')).toBe('none')
     expect(await service.resolveActiveReasoningEffort('max')).toBe('max')
   })
 
@@ -3898,11 +3902,12 @@ describe('SettingsService: reasoning effort', () => {
 
     const backend = await service.resolveActiveAgentBackend()
 
-    expect(backend.sessionEffort).toBe('high')
-    // The level also reaches the framework's own config channel (opencode model options).
+    expect(backend.sessionEffort).toBe('none')
+    // The official vendor identity survives provider resolution, so OpenCode receives DeepSeek's
+    // native thinking switch instead of an invalid reasoningEffort: none literal.
     const content = JSON.parse(backend.env?.OPENCODE_CONFIG_CONTENT ?? '{}')
     expect(content.provider['openai-compatible'].models['deepseek-v4-pro']).toEqual(
-      expect.objectContaining({ options: { reasoningEffort: 'high' } })
+      expect.objectContaining({ options: { thinking: { type: 'disabled' } } })
     )
   })
 

--- a/src/main/settings/service.test.ts
+++ b/src/main/settings/service.test.ts
@@ -669,7 +669,7 @@ describe('SettingsService: providers', () => {
     expect(JSON.stringify(stored)).not.toContain('sk-super-secret')
   })
 
-  it('persists and exposes a custom model reasoning effort preset', async () => {
+  it('persists and exposes custom model reasoning effort settings', async () => {
     const service = createService()
 
     const snapshot = await service.upsertProvider({
@@ -678,11 +678,14 @@ describe('SettingsService: providers', () => {
       baseUrl: 'https://g/v1',
       model: 'm',
       reasoningEffortPreset: 'none-high',
+      reasoningEffortTransport: 'deepseek',
       key: 'sk-super-secret'
     })
 
     expect(snapshot.providers[0].reasoningEffortPreset).toBe('none-high')
+    expect(snapshot.providers[0].reasoningEffortTransport).toBe('deepseek')
     expect((await repository.getSettings()).providers[0].reasoningEffortPreset).toBe('none-high')
+    expect((await repository.getSettings()).providers[0].reasoningEffortTransport).toBe('deepseek')
   })
 
   it('persists a custom context window and carries it into the OpenCode model metadata', async () => {
@@ -3909,6 +3912,34 @@ describe('SettingsService: reasoning effort', () => {
     expect(content.provider['openai-compatible'].models['deepseek-v4-pro']).toEqual(
       expect.objectContaining({ options: { thinking: { type: 'disabled' } } })
     )
+  })
+
+  it('uses one effective catalog model for both the backend and its effort profile', async () => {
+    vi.stubEnv('OPEN_SCIENCE_AGENT_FRAMEWORK', 'opencode')
+    await repository.setAgentFramework('opencode')
+    const service = createService(undefined, {
+      opencodeDetected: { path: '/usr/local/bin/opencode', version: '1.19.0' }
+    })
+    const provider = (
+      await service.upsertProvider({
+        type: 'official',
+        name: 'Anthropic',
+        vendorId: 'anthropic',
+        key: 'k'
+      })
+    ).providers[0]
+    await service.setActiveProvider(provider.id, 'claude-haiku-4-5-20251001')
+    await repository.setReasoningEffort('max')
+
+    const stored = (await repository.getSettings()).providers[0]
+    await repository.upsertProvider({ ...stored, fetchedModels: ['claude-opus-5'] })
+
+    const backend = await service.resolveActiveAgentBackend()
+    const content = JSON.parse(backend.env?.OPENCODE_CONFIG_CONTENT ?? '{}')
+
+    expect(backend.sessionModel).toBe('claude-opus-5')
+    expect(backend.sessionEffort).toBe('max')
+    expect(content.model).toBe('anthropic/claude-opus-5')
   })
 
   it('isolates live effort changes between overlapping bridge generations', async () => {

--- a/src/main/settings/service.test.ts
+++ b/src/main/settings/service.test.ts
@@ -669,6 +669,22 @@ describe('SettingsService: providers', () => {
     expect(JSON.stringify(stored)).not.toContain('sk-super-secret')
   })
 
+  it('persists and exposes a custom model reasoning effort preset', async () => {
+    const service = createService()
+
+    const snapshot = await service.upsertProvider({
+      type: 'custom',
+      name: 'Gateway',
+      baseUrl: 'https://g/v1',
+      model: 'm',
+      reasoningEffortPreset: 'none-high',
+      key: 'sk-super-secret'
+    })
+
+    expect(snapshot.providers[0].reasoningEffortPreset).toBe('none-high')
+    expect((await repository.getSettings()).providers[0].reasoningEffortPreset).toBe('none-high')
+  })
+
   it('persists a custom context window and carries it into the OpenCode model metadata', async () => {
     vi.stubEnv('OPEN_SCIENCE_AGENT_FRAMEWORK', 'opencode')
     await repository.setAgentFramework('opencode')
@@ -3752,7 +3768,92 @@ describe('SettingsService: reasoning effort', () => {
     expect((await repository.getSettings()).reasoningEffort).toBe('max')
   })
 
-  it('surfaces the stored level as sessionEffort on the resolved OpenCode backend', async () => {
+  it("maps a five-level intent onto DeepSeek's two supported levels", async () => {
+    const service = createService()
+    const provider = (
+      await service.upsertProvider({
+        type: 'official',
+        name: 'DeepSeek',
+        vendorId: 'deepseek',
+        key: 'k'
+      })
+    ).providers[0]
+    await service.setActiveProvider(provider.id, 'deepseek-v4-pro')
+
+    expect(await service.resolveActiveReasoningEffort('low')).toBe('high')
+    expect(await service.resolveActiveReasoningEffort('max')).toBe('max')
+  })
+
+  it("maps the top intent onto StepFun's highest supported level", async () => {
+    const service = createService()
+    const provider = (
+      await service.upsertProvider({
+        type: 'official',
+        name: 'StepFun',
+        vendorId: 'stepfun',
+        key: 'k'
+      })
+    ).providers[0]
+    await service.setActiveProvider(provider.id, 'step-3.7-flash')
+
+    expect(await service.resolveActiveReasoningEffort('max')).toBe('high')
+  })
+
+  it('maps a custom model intent through its stored effort preset', async () => {
+    const service = createService()
+    const provider = (
+      await service.upsertProvider({
+        type: 'custom',
+        name: 'Gateway',
+        baseUrl: 'https://g/v1',
+        model: 'm',
+        reasoningEffortPreset: 'none-high',
+        key: 'k'
+      })
+    ).providers[0]
+    await service.setActiveProvider(provider.id)
+
+    expect(await service.resolveActiveReasoningEffort('low')).toBe('none')
+    expect(await service.resolveActiveReasoningEffort('max')).toBe('high')
+  })
+
+  it("returns 'default' for default intent and models that do not support effort", async () => {
+    const service = createService()
+    const provider = (
+      await service.upsertProvider({
+        type: 'custom',
+        name: 'Gateway',
+        baseUrl: 'https://g/v1',
+        model: 'm',
+        reasoningEffortPreset: 'unsupported',
+        key: 'k'
+      })
+    ).providers[0]
+    await service.setActiveProvider(provider.id)
+
+    expect(await service.resolveActiveReasoningEffort('max')).toBe('default')
+    expect(await service.resolveActiveReasoningEffort('default')).toBe('default')
+  })
+
+  it('uses the OpenAI and Anthropic registries for subscription models', async () => {
+    const service = createService()
+    const codex = (await service.upsertProvider({ type: 'codex-isolated' })).providers[0]
+    await service.setActiveProvider(codex.id, 'gpt-5.6-sol')
+
+    expect(await service.resolveActiveReasoningEffort('max')).toBe('ultra')
+
+    const claude = (
+      await service.upsertProvider({
+        type: 'claude-shared',
+        model: 'claude-haiku-4-5-20251001'
+      })
+    ).providers.find((provider) => provider.type === 'claude-shared')!
+    await service.setActiveProvider(claude.id, 'claude-haiku-4-5-20251001')
+
+    expect(await service.resolveActiveReasoningEffort('max')).toBe('default')
+  })
+
+  it('passes the model-mapped effort to both OpenCode delivery channels', async () => {
     // resolveActiveAgentBackend honors this forced-framework env above stored settings; set it
     // explicitly (a prior test may leave it stubbed) so this resolves OpenCode.
     vi.stubEnv('OPEN_SCIENCE_AGENT_FRAMEWORK', 'opencode')
@@ -3761,17 +3862,22 @@ describe('SettingsService: reasoning effort', () => {
       opencodeDetected: { path: '/usr/local/bin/opencode', version: '1.19.0' }
     })
     const provider = (
-      await service.upsertProvider({ type: 'official', name: 'Kimi', vendorId: 'kimi', key: 'k' })
+      await service.upsertProvider({
+        type: 'official',
+        name: 'DeepSeek',
+        vendorId: 'deepseek',
+        key: 'k'
+      })
     ).providers[0]
-    await service.setActiveProvider(provider.id)
-    await repository.setReasoningEffort('high')
+    await service.setActiveProvider(provider.id, 'deepseek-v4-pro')
+    await repository.setReasoningEffort('low')
 
     const backend = await service.resolveActiveAgentBackend()
 
     expect(backend.sessionEffort).toBe('high')
     // The level also reaches the framework's own config channel (opencode model options).
     const content = JSON.parse(backend.env?.OPENCODE_CONFIG_CONTENT ?? '{}')
-    expect(content.provider['openai-compatible'].models['kimi-k3']).toEqual(
+    expect(content.provider['openai-compatible'].models['deepseek-v4-pro']).toEqual(
       expect.objectContaining({ options: { reasoningEffort: 'high' } })
     )
   })
@@ -3822,7 +3928,7 @@ describe('SettingsService: reasoning effort', () => {
     expect((await service.resolveActiveAgentBackend()).sessionEffort).toBeUndefined()
   })
 
-  it('updates the live bridge forwarding policy when the level changes', async () => {
+  it('lets the owning runtime update its live bridge with a model-resolved effort', async () => {
     const localFetch = globalThis.fetch
     let upstreamRequest: Record<string, unknown> | undefined
     vi.stubGlobal(
@@ -3891,13 +3997,19 @@ describe('SettingsService: reasoning effort', () => {
     await post()
     expect(upstreamRequest).not.toHaveProperty('reasoning_effort')
 
-    // An explicit level forwards — Codex applies it live over ACP, no reconnect touches the bridge.
-    await service.setReasoningEffort('high')
+    // The active runtime owns this lease, so it updates only the bridge for its own provider/model.
+    backend.responsesBridgeLease?.setReasoningEffort?.('high')
     await post()
     expect(upstreamRequest).toMatchObject({ reasoning_effort: 'high' })
 
+    // The bridge receives the concrete mapped value, not a forwarding boolean: it replaces Codex's
+    // own request effort instead of letting an incompatible value leak to the selected model.
+    backend.responsesBridgeLease?.setReasoningEffort?.('max')
+    await post()
+    expect(upstreamRequest).toMatchObject({ reasoning_effort: 'max' })
+
     // Back to 'default': stripping is restored so Codex's own effort can't leak upstream.
-    await service.setReasoningEffort('default')
+    backend.responsesBridgeLease?.setReasoningEffort?.(undefined)
     await post()
     expect(upstreamRequest).not.toHaveProperty('reasoning_effort')
   })

--- a/src/main/settings/service.test.ts
+++ b/src/main/settings/service.test.ts
@@ -3853,6 +3853,30 @@ describe('SettingsService: reasoning effort', () => {
     expect(await service.resolveActiveReasoningEffort('max')).toBe('default')
   })
 
+  it('does not guess an effort profile for an unpinned Codex subscription model', async () => {
+    const adapterPath = join(storageRoot, 'bin', 'codex-acp')
+    await mkdir(dirname(adapterPath), { recursive: true })
+    await writeFile(adapterPath, MANAGED_CODEX_ADAPTER_FIXTURE, 'utf8')
+    await chmod(adapterPath, 0o755)
+    const service = createService(undefined, {
+      managedCodexAdapterPath: adapterPath,
+      managedCodexNativePath: execPath
+    })
+    await repository.setCodexInfo({
+      resolvedPath: adapterPath,
+      version: '1.1.4',
+      nativePath: execPath,
+      nativeVersion: '0.144.6'
+    })
+    const codex = (await service.upsertProvider({ type: 'codex-isolated' })).providers[0]
+    await service.setActiveProvider(codex.id)
+
+    expect(await service.resolveActiveReasoningEffort('max')).toBe('default')
+
+    await repository.setReasoningEffort('max')
+    expect((await service.resolveActiveAgentBackend()).sessionEffort).toBeUndefined()
+  })
+
   it('passes the model-mapped effort to both OpenCode delivery channels', async () => {
     // resolveActiveAgentBackend honors this forced-framework env above stored settings; set it
     // explicitly (a prior test may leave it stubbed) so this resolves OpenCode.

--- a/src/main/settings/service.test.ts
+++ b/src/main/settings/service.test.ts
@@ -3884,6 +3884,22 @@ describe('SettingsService: reasoning effort', () => {
     expect((await service.resolveActiveAgentBackend()).sessionEffort).toBeUndefined()
   })
 
+  it('does not guess an effort profile for an unpinned Claude subscription model', async () => {
+    vi.stubEnv('OPEN_SCIENCE_AGENT_FRAMEWORK', 'claude-code')
+    const service = createService()
+    await repository.setClaudeInfo({ resolvedPath: execPath, version: '2.1.0' })
+    const claude = (await service.upsertProvider({ type: 'claude-shared' })).providers.find(
+      (provider) => provider.type === 'claude-shared'
+    )!
+    await service.setActiveProvider(claude.id)
+    await repository.setReasoningEffort('max')
+
+    expect(await service.resolveActiveReasoningEffort('max')).toBe('default')
+    const backend = await service.resolveActiveAgentBackend()
+    expect(backend.sessionEffort).toBeUndefined()
+    expect(backend.env).not.toHaveProperty('ANTHROPIC_MODEL')
+  })
+
   it('passes the model-mapped effort to both OpenCode delivery channels', async () => {
     // resolveActiveAgentBackend honors this forced-framework env above stored settings; set it
     // explicitly (a prior test may leave it stubbed) so this resolves OpenCode.

--- a/src/main/settings/service.test.ts
+++ b/src/main/settings/service.test.ts
@@ -2289,7 +2289,7 @@ describe('SettingsService: preflight & spawn config', () => {
     ).resolves.toEqual([{ name: 'mcp-pubmed', path: '/skills/pubmed/SKILL.md' }])
     expect(selectSkills).toHaveBeenCalledWith('search PubMed', skillCatalog, undefined)
     bridges[0].registerReviewerSession('reviewer-one')
-    bridges[1].registerReviewerSession('reviewer-two')
+    bridges[2].registerReviewerSession('reviewer-two')
 
     const send = async (backend: typeof firstBackend, promptCacheKey: string): Promise<void> => {
       const response = await localFetch(`${backend.providerConfiguration?.baseUrl}/responses`, {
@@ -2333,7 +2333,7 @@ describe('SettingsService: preflight & spawn config', () => {
         responsesBridges: Map<string, unknown>
       }
     ).responsesBridges
-    expect(bridgePool.size).toBe(2)
+    expect(bridgePool.size).toBe(3)
     await firstBackend.responsesBridgeLease?.release()
     expect(bridgePool.size).toBe(2)
     await firstBackendPeer.responsesBridgeLease?.release()
@@ -3909,6 +3909,85 @@ describe('SettingsService: reasoning effort', () => {
     expect(content.provider['openai-compatible'].models['deepseek-v4-pro']).toEqual(
       expect.objectContaining({ options: { thinking: { type: 'disabled' } } })
     )
+  })
+
+  it('isolates live effort changes between overlapping bridge generations', async () => {
+    const localFetch = globalThis.fetch
+    const upstreamEfforts: unknown[] = []
+    vi.stubGlobal(
+      'fetch',
+      vi.fn(async (_url: Parameters<typeof fetch>[0], init?: Parameters<typeof fetch>[1]) => {
+        const body = JSON.parse(String(init?.body)) as Record<string, unknown>
+        upstreamEfforts.push(body.reasoning_effort)
+        return new Response(
+          [
+            'data: ' +
+              JSON.stringify({
+                id: 'chat-isolated-effort',
+                model: 'model-a',
+                choices: [{ index: 0, delta: {}, finish_reason: 'stop' }]
+              }),
+            '',
+            'data: [DONE]',
+            ''
+          ].join('\n'),
+          { headers: { 'content-type': 'text/event-stream' } }
+        )
+      })
+    )
+    const service = createService()
+    const bridgeService = service as unknown as {
+      ensureResponsesBridge: (
+        provider: {
+          type: 'custom'
+          baseUrl: string
+          apiEndpoints: ['openai']
+          model: string
+          key: string
+        },
+        effort: 'low' | 'max'
+      ) => Promise<{
+        baseUrl: string
+        token: string
+        lease: {
+          setReasoningEffort: (effort: 'low' | 'high' | 'max') => void
+          release: () => Promise<void>
+        }
+      }>
+    }
+    const provider = {
+      type: 'custom' as const,
+      baseUrl: 'https://vendor.example/v1',
+      apiEndpoints: ['openai'] as ['openai'],
+      model: 'model-a',
+      key: 'key-a'
+    }
+    const first = await bridgeService.ensureResponsesBridge(provider, 'low')
+    const second = await bridgeService.ensureResponsesBridge(provider, 'max')
+    const post = async (connection: { baseUrl: string; token: string }): Promise<void> => {
+      const response = await localFetch(`${connection.baseUrl}/responses`, {
+        method: 'POST',
+        headers: {
+          authorization: `Bearer ${connection.token}`,
+          'content-type': 'application/json'
+        },
+        body: JSON.stringify({ model: 'catalog', input: 'hi', stream: true })
+      })
+      await response.text()
+    }
+
+    try {
+      await post(first)
+      await post(second)
+      second.lease.setReasoningEffort('high')
+      await post(first)
+      await post(second)
+
+      expect(upstreamEfforts).toEqual(['low', 'max', 'low', 'high'])
+    } finally {
+      await first.lease.release()
+      await second.lease.release()
+    }
   })
 
   it('surfaces sessionEffort on the Claude backend too (the early-return path)', async () => {

--- a/src/main/settings/service.ts
+++ b/src/main/settings/service.ts
@@ -104,7 +104,10 @@ import {
   resolveVendorModelsUrl,
   resolveVendorOpenAiBaseUrl
 } from '../../shared/provider-registry'
-import { resolveProviderReasoningEffortProfile } from '../../shared/provider-reasoning-effort'
+import {
+  resolveProviderEffectiveModel,
+  resolveProviderReasoningEffortProfile
+} from '../../shared/provider-reasoning-effort'
 import {
   resolveReasoningEffortValue,
   type ModelReasoningEffort,
@@ -2191,6 +2194,8 @@ class SettingsService {
         request.supportsImageInput ?? existing?.supportsImageInput ?? false
       provider.reasoningEffortPreset =
         request.reasoningEffortPreset ?? existing?.reasoningEffortPreset ?? 'standard-5'
+      provider.reasoningEffortTransport =
+        request.reasoningEffortTransport ?? existing?.reasoningEffortTransport ?? 'reasoning-effort'
       // Which chat APIs this gateway speaks (drives per-framework availability); defaults to anthropic.
       provider.apiEndpoints = apiEndpoints
       credentialsChanged =
@@ -3207,7 +3212,8 @@ class SettingsService {
 
   private async resolveSpawnConfig(
     settings: StoredSettings,
-    forcedSkillIds: ReadonlySet<string>
+    forcedSkillIds: ReadonlySet<string>,
+    resolvedSelection?: { model?: string }
   ): Promise<AgentSpawnConfig> {
     let executablePath = settings.claude?.resolvedPath
 
@@ -3239,7 +3245,12 @@ class SettingsService {
     // ACP session injects this bundle as a local plugin plus highest-priority settings layer.
     const appConfigDir = await this.provisionClaudeRuntimeConfig(settings, forcedSkillIds)
 
-    const provider = this.resolveProvider(activeProvider, settings.activeModel)
+    const provider = this.resolveProvider(
+      activeProvider,
+      resolvedSelection
+        ? resolvedSelection.model
+        : this.resolveActiveModel(activeProvider, settings.activeModel)
+    )
     const envOverrides = buildProviderEnv(provider, {
       storageRoot: this.storageRoot,
       claudeExecutablePath: executablePath,
@@ -3329,10 +3340,18 @@ class SettingsService {
       throw new Error(NO_ACTIVE_PROVIDER_MESSAGE)
     }
 
-    const resolvedEffort = this.resolveReasoningEffortFromSettings(
-      settings,
-      settings.reasoningEffort ?? DEFAULT_REASONING_EFFORT
-    )
+    // Resolve the model exactly once for this backend generation. The same selection drives the
+    // model profile, bridge compatibility, and the framework config so a refreshed catalog cannot
+    // make the effort belong to one model while the request is sent to another.
+    const effectiveModel = this.resolveActiveModel(activeProvider, settings.activeModel)
+    const effortIntent = settings.reasoningEffort ?? DEFAULT_REASONING_EFFORT
+    const resolvedEffort =
+      effortIntent === DEFAULT_REASONING_EFFORT
+        ? DEFAULT_REASONING_EFFORT
+        : resolveReasoningEffortValue(
+            effortIntent,
+            resolveProviderReasoningEffortProfile(activeProvider, effectiveModel)
+          )
     const sessionEffort: ModelReasoningEffort | undefined =
       resolvedEffort === 'default' ? undefined : resolvedEffort
 
@@ -3351,20 +3370,14 @@ class SettingsService {
     const enabledConnectorIds = this.enabledConnectorIds(settings.connectors)
     const connectorInstructions = renderConnectorInstructions(enabledConnectorIds)
 
-    if (
-      framework.id === 'codex' &&
-      !isModelBridgeSupported(
-        activeProvider,
-        this.resolveActiveModel(activeProvider, settings.activeModel)
-      )
-    ) {
+    if (framework.id === 'codex' && !isModelBridgeSupported(activeProvider, effectiveModel)) {
       throw new Error(CODEX_BRIDGE_UNSUPPORTED_MESSAGE)
     }
 
     if (framework.id === 'claude-code') {
       // Claude path: app-owned runtime provisioning + Anthropic-shaped env + local-auth handling.
       const { envOverrides, executablePath, sessionOptions, contextWindow } =
-        await this.resolveSpawnConfig(settings, forcedSkillIds)
+        await this.resolveSpawnConfig(settings, forcedSkillIds, { model: effectiveModel })
 
       return {
         framework,
@@ -3384,7 +3397,7 @@ class SettingsService {
             settings.codex?.nativePath
           )
         : await this.resolveOpencodeExecutable(settings.opencodePath)
-    const provider = this.resolveProvider(activeProvider, settings.activeModel)
+    const provider = this.resolveProvider(activeProvider, effectiveModel)
     // `codex-shared` is accepted only as a legacy/provider-time import request. Every runtime
     // subscription record converges on the same app-owned backend and profile boundary.
     const backendProviderId =
@@ -3466,6 +3479,7 @@ class SettingsService {
       baseUrl: targetBaseUrl,
       key: provider.key,
       vendorId: provider.vendorId,
+      reasoningEffortTransport: provider.reasoningEffortTransport,
       model: provider.model,
       reasoningEffort,
       namespacedTools: [
@@ -3595,6 +3609,8 @@ class SettingsService {
       supportsImageInput: this.providerSupportsImageInput(provider, activeModel),
       reasoningEffortPreset:
         provider.type === 'custom' ? provider.reasoningEffortPreset : undefined,
+      reasoningEffortTransport:
+        provider.type === 'custom' ? provider.reasoningEffortTransport : undefined,
       vendorId: provider.vendorId,
       region: provider.region,
       models: this.availableModels(provider),
@@ -3699,16 +3715,10 @@ class SettingsService {
     provider: StoredProvider | undefined,
     requested?: string
   ): string | undefined {
-    if (!provider) return undefined
-
-    const available = this.availableModels(provider)
-
-    if (requested && available.includes(requested)) return requested
-    if (isCodexSubscriptionProvider(provider.type)) return undefined
-    // Prefer the provider's chosen default (custom's only model, or an official vendor's picked one).
-    if (provider.model && available.includes(provider.model)) return provider.model
-
-    return available[0] ?? provider.model
+    return resolveProviderEffectiveModel(
+      provider ? { ...provider, models: this.availableModels(provider) } : undefined,
+      requested
+    )
   }
 
   private resolveReasoningEffortFromSettings(
@@ -3768,7 +3778,10 @@ class SettingsService {
       ...(contextWindow === undefined ? {} : { contextWindow }),
       key,
       apiEndpoints: this.resolveProviderApiEndpoints(provider),
-      supportsImageInput: this.providerSupportsImageInput(provider, modelOverride)
+      supportsImageInput: this.providerSupportsImageInput(provider, modelOverride),
+      ...(provider.type === 'custom'
+        ? { reasoningEffortTransport: provider.reasoningEffortTransport }
+        : {})
     }
   }
 
@@ -3796,7 +3809,10 @@ class SettingsService {
         ? { contextWindow: resolveCustomModelContextWindow(draft.contextWindow ?? undefined) }
         : {}),
       key: draft.key,
-      apiEndpoints: draft.apiEndpoints ?? ['anthropic']
+      apiEndpoints: draft.apiEndpoints ?? ['anthropic'],
+      ...(draft.type === 'custom'
+        ? { reasoningEffortTransport: draft.reasoningEffortTransport }
+        : {})
     }
   }
 

--- a/src/main/settings/service.ts
+++ b/src/main/settings/service.ts
@@ -99,11 +99,19 @@ import {
   isVendorModelMultimodal,
   resolveCustomModelContextWindow,
   resolveModelContextWindow,
+  resolveVendorModelReasoningEffort,
   resolveVendorApiEndpoints,
   resolveVendorBaseUrl,
   resolveVendorModelsUrl,
   resolveVendorOpenAiBaseUrl
 } from '../../shared/provider-registry'
+import {
+  resolveReasoningEffortProfile,
+  resolveReasoningEffortValue,
+  type ModelReasoningEffort,
+  type ReasoningEffortProfile,
+  type ResolvedReasoningEffort
+} from '../../shared/reasoning-effort'
 import { resolveStorageRoot } from '../storage-root'
 import { buildAgentSpawnEnv } from '../acp/agent-process'
 import {
@@ -802,14 +810,16 @@ class SettingsService {
   async setReasoningEffort(effort: ReasoningEffort): Promise<SettingsSnapshot> {
     await this.repository.setReasoningEffort(effort)
 
-    // A live bridge never sees resolveActiveAgentBackend again until the next provider switch, so its
-    // forwarding policy must be updated in place: an explicit level forwards, 'default' restores
-    // stripping so Codex's own default effort never leaks upstream.
-    for (const { bridge } of this.responsesBridges.values()) {
-      bridge.setForwardReasoningEffort(effort !== DEFAULT_REASONING_EFFORT)
-    }
-
     return this.getSettingsView()
+  }
+
+  // Projects one of the app's five stable user-intent slots through the active model's static effort
+  // profile. This is intentionally async only because settings are read from disk; capability lookup
+  // is synchronous and never performs provider discovery or a network request.
+  async resolveActiveReasoningEffort(intent: ReasoningEffort): Promise<ResolvedReasoningEffort> {
+    const settings = await this.repository.getSettings()
+
+    return this.resolveReasoningEffortFromSettings(settings, intent)
   }
 
   // Whether desktop notifications for finished/failed agent tasks are on, read fresh so the
@@ -2180,6 +2190,8 @@ class SettingsService {
       if (contextWindow !== undefined) provider.contextWindow = contextWindow
       provider.supportsImageInput =
         request.supportsImageInput ?? existing?.supportsImageInput ?? false
+      provider.reasoningEffortPreset =
+        request.reasoningEffortPreset ?? existing?.reasoningEffortPreset ?? 'standard-5'
       // Which chat APIs this gateway speaks (drives per-framework availability); defaults to anthropic.
       provider.apiEndpoints = apiEndpoints
       credentialsChanged =
@@ -3303,17 +3315,9 @@ class SettingsService {
     const forcedSkillIds = new Set(context.forcedSkillIds ?? [])
     const framework = getAgentFramework(frameworkId)
     // 'default' means "don't override": nothing is sent over ACP or framework config, so the agent
-    // keeps its own default effort. A concrete level is delivered through two channels deliberately
-    // (defense-in-depth, mirroring how sessionModel reaches opencode): the framework's own config
-    // (Codex model_reasoning_effort, opencode model options) covers agents that ignore the protocol,
-    // while sessionEffort drives the ACP thought_level configOption — Claude Code's only channel —
-    // and, being applied per session after spawn, wins over the baked config when both fire. The
-    // channels clamp 'max' independently (Codex config → xhigh, opencode config → high, ACP → the
-    // nearest advertised rung), which is accepted: each stays within its own supported set.
-    const sessionEffort =
-      settings.reasoningEffort && settings.reasoningEffort !== DEFAULT_REASONING_EFFORT
-        ? settings.reasoningEffort
-        : undefined
+    // keeps its own default effort. A concrete intent is projected through the active model profile
+    // exactly once here, then delivered through the framework config and ACP session channels. Those
+    // transports receive the same model-native value and must not independently reinterpret it.
 
     // Enforce provider↔framework compatibility up front so an incompatible pair fails with a clear
     // message instead of spawning an agent that can't use the credentials — e.g. OpenCode + a Local
@@ -3325,6 +3329,13 @@ class SettingsService {
     if (!activeProvider) {
       throw new Error(NO_ACTIVE_PROVIDER_MESSAGE)
     }
+
+    const resolvedEffort = this.resolveReasoningEffortFromSettings(
+      settings,
+      settings.reasoningEffort ?? DEFAULT_REASONING_EFFORT
+    )
+    const sessionEffort: ModelReasoningEffort | undefined =
+      resolvedEffort === 'default' ? undefined : resolvedEffort
 
     if (
       !isProviderUsableByFramework(
@@ -3399,7 +3410,7 @@ class SettingsService {
     // A bridge may still serve a live Codex runtime from an earlier framework generation. Do not stop
     // or retarget it merely because the newly selected framework/provider does not need one.
     const responsesBridge = needsResponsesBridge
-      ? await this.ensureResponsesBridge(provider, sessionEffort !== undefined)
+      ? await this.ensureResponsesBridge(provider, sessionEffort)
       : undefined
     try {
       const modelConfig = framework.prepareModelConfig(provider, {
@@ -3445,7 +3456,7 @@ class SettingsService {
 
   private async ensureResponsesBridge(
     provider: ResolvedProvider,
-    forwardReasoningEffort: boolean
+    reasoningEffort: ModelReasoningEffort | undefined
   ): Promise<LeasedResponsesBridgeConnection> {
     // Resolve to the OpenAI base the bridge appends `/chat/completions` to: an official vendor's exact
     // versioned base, or a custom gateway root normalized to `<root>/v1`.
@@ -3456,7 +3467,7 @@ class SettingsService {
       baseUrl: targetBaseUrl,
       key: provider.key,
       model: provider.model,
-      forwardReasoningEffort,
+      reasoningEffort,
       namespacedTools: [
         ...CODEX_BRIDGE_NOTEBOOK_TOOLS,
         ...CODEX_BRIDGE_ARTIFACT_TOOLS,
@@ -3474,7 +3485,7 @@ class SettingsService {
       this.responsesBridges.set(fingerprint, entry)
     } else {
       // Reasoning effort is a live global preference, not part of the bridge's pinned routing target.
-      entry.bridge.setForwardReasoningEffort(forwardReasoningEffort)
+      entry.bridge.setReasoningEffort(reasoningEffort)
     }
     entry.leaseCount += 1
 
@@ -3501,6 +3512,7 @@ class SettingsService {
           leasedEntry.bridge.registerReviewerSession(promptCacheKey),
         unregisterReviewerSession: (promptCacheKey) =>
           leasedEntry.bridge.unregisterReviewerSession(promptCacheKey),
+        setReasoningEffort: (effort) => leasedEntry.bridge.setReasoningEffort(effort),
         release: async () => {
           if (released) return
           released = true
@@ -3519,8 +3531,8 @@ class SettingsService {
   }
 
   private responsesBridgeFingerprint(target: ResponsesBridgeTarget): string {
-    // forwardReasoningEffort is intentionally live mutable and therefore excluded from the pinned
-    // routing identity. Including it would split leases and prevent effort fan-out to existing bridges.
+    // reasoningEffort is intentionally live mutable and therefore excluded from the pinned routing
+    // identity. Including it would split leases and prevent effort fan-out to existing bridges.
     const pinnedTarget = {
       baseUrl: target.baseUrl,
       key: target.key,
@@ -3610,6 +3622,8 @@ class SettingsService {
       model: provider.model,
       contextWindow: provider.contextWindow,
       supportsImageInput: this.providerSupportsImageInput(provider, activeModel),
+      reasoningEffortPreset:
+        provider.type === 'custom' ? provider.reasoningEffortPreset : undefined,
       vendorId: provider.vendorId,
       region: provider.region,
       models: this.availableModels(provider),
@@ -3724,6 +3738,48 @@ class SettingsService {
     if (provider.model && available.includes(provider.model)) return provider.model
 
     return available[0] ?? provider.model
+  }
+
+  private resolveReasoningEffortFromSettings(
+    settings: StoredSettings,
+    intent: ReasoningEffort
+  ): ResolvedReasoningEffort {
+    if (intent === DEFAULT_REASONING_EFFORT) return DEFAULT_REASONING_EFFORT
+
+    const provider = settings.activeProviderId
+      ? settings.providers.find((candidate) => candidate.id === settings.activeProviderId)
+      : undefined
+    if (!provider) return DEFAULT_REASONING_EFFORT
+
+    const profile = this.resolveProviderReasoningEffortProfile(
+      provider,
+      this.resolveActiveModel(provider, settings.activeModel)
+    )
+
+    return resolveReasoningEffortValue(intent, profile)
+  }
+
+  private resolveProviderReasoningEffortProfile(
+    provider: StoredProvider,
+    model: string | undefined
+  ): ReasoningEffortProfile {
+    if (provider.type === 'official' && provider.vendorId) {
+      return resolveVendorModelReasoningEffort(provider.vendorId, model ?? '')
+    }
+
+    if (isCodexSubscriptionProvider(provider.type)) {
+      return resolveVendorModelReasoningEffort('openai', model ?? '')
+    }
+
+    if (isClaudeSubscriptionProvider(provider.type)) {
+      return resolveVendorModelReasoningEffort('anthropic', model ?? '')
+    }
+
+    if (provider.type === 'custom') {
+      return resolveReasoningEffortProfile(provider.reasoningEffortPreset)
+    }
+
+    return { supported: false }
   }
 
   // Decrypts a stored provider into the spawn/validation shape (plaintext key held only transiently).

--- a/src/main/settings/service.ts
+++ b/src/main/settings/service.ts
@@ -3464,6 +3464,7 @@ class SettingsService {
     const target = {
       baseUrl: targetBaseUrl,
       key: provider.key,
+      vendorId: provider.vendorId,
       model: provider.model,
       reasoningEffort,
       namespacedTools: [
@@ -3534,6 +3535,7 @@ class SettingsService {
     const pinnedTarget = {
       baseUrl: target.baseUrl,
       key: target.key,
+      vendorId: target.vendorId,
       model: target.model,
       namespacedTools: target.namespacedTools,
       reviewerScope: target.reviewerScope
@@ -3769,6 +3771,7 @@ class SettingsService {
 
       return {
         type: 'custom',
+        vendorId: provider.vendorId,
         baseUrl: resolveVendorBaseUrl(provider.vendorId, provider.region),
         openaiBaseUrl: resolveVendorOpenAiBaseUrl(provider.vendorId, provider.region),
         model,
@@ -3804,6 +3807,7 @@ class SettingsService {
     if (draft.type === 'official' && isOfficialVendorId(draft.vendorId)) {
       return {
         type: 'custom',
+        vendorId: draft.vendorId,
         baseUrl: resolveVendorBaseUrl(draft.vendorId, draft.region),
         openaiBaseUrl: resolveVendorOpenAiBaseUrl(draft.vendorId, draft.region),
         model: draft.model ?? defaultVendorModel(draft.vendorId),

--- a/src/main/settings/service.ts
+++ b/src/main/settings/service.ts
@@ -99,17 +99,15 @@ import {
   isVendorModelMultimodal,
   resolveCustomModelContextWindow,
   resolveModelContextWindow,
-  resolveVendorModelReasoningEffort,
   resolveVendorApiEndpoints,
   resolveVendorBaseUrl,
   resolveVendorModelsUrl,
   resolveVendorOpenAiBaseUrl
 } from '../../shared/provider-registry'
+import { resolveProviderReasoningEffortProfile } from '../../shared/provider-reasoning-effort'
 import {
-  resolveReasoningEffortProfile,
   resolveReasoningEffortValue,
   type ModelReasoningEffort,
-  type ReasoningEffortProfile,
   type ResolvedReasoningEffort
 } from '../../shared/reasoning-effort'
 import { resolveStorageRoot } from '../storage-root'
@@ -3751,38 +3749,12 @@ class SettingsService {
       : undefined
     if (!provider) return DEFAULT_REASONING_EFFORT
 
-    const profile = this.resolveProviderReasoningEffortProfile(
+    const profile = resolveProviderReasoningEffortProfile(
       provider,
       this.resolveActiveModel(provider, settings.activeModel)
     )
 
     return resolveReasoningEffortValue(intent, profile)
-  }
-
-  private resolveProviderReasoningEffortProfile(
-    provider: StoredProvider,
-    model: string | undefined
-  ): ReasoningEffortProfile {
-    if (provider.type === 'official' && provider.vendorId) {
-      return resolveVendorModelReasoningEffort(provider.vendorId, model ?? '')
-    }
-
-    if (isCodexSubscriptionProvider(provider.type)) {
-      // An unpinned Codex subscription delegates model selection to the account/runtime. Until the
-      // runtime reports that model, its effort vocabulary is unknown, so do not guess from the
-      // bundled OpenAI default and accidentally send a mismatched override.
-      return model ? resolveVendorModelReasoningEffort('openai', model) : { supported: false }
-    }
-
-    if (isClaudeSubscriptionProvider(provider.type)) {
-      return resolveVendorModelReasoningEffort('anthropic', model ?? '')
-    }
-
-    if (provider.type === 'custom') {
-      return resolveReasoningEffortProfile(provider.reasoningEffortPreset)
-    }
-
-    return { supported: false }
   }
 
   // Decrypts a stored provider into the spawn/validation shape (plaintext key held only transiently).

--- a/src/main/settings/service.ts
+++ b/src/main/settings/service.ts
@@ -3768,7 +3768,10 @@ class SettingsService {
     }
 
     if (isCodexSubscriptionProvider(provider.type)) {
-      return resolveVendorModelReasoningEffort('openai', model ?? '')
+      // An unpinned Codex subscription delegates model selection to the account/runtime. Until the
+      // runtime reports that model, its effort vocabulary is unknown, so do not guess from the
+      // bundled OpenAI default and accidentally send a mismatched override.
+      return model ? resolveVendorModelReasoningEffort('openai', model) : { supported: false }
     }
 
     if (isClaudeSubscriptionProvider(provider.type)) {

--- a/src/main/settings/service.ts
+++ b/src/main/settings/service.ts
@@ -3,7 +3,7 @@ import { access, chmod, mkdir, readdir, realpath, writeFile } from 'node:fs/prom
 import { constants } from 'node:fs'
 import { homedir } from 'node:os'
 import { dirname, isAbsolute, join, relative, resolve, sep } from 'node:path'
-import { createHash, randomUUID } from 'node:crypto'
+import { randomUUID } from 'node:crypto'
 import { isDeepStrictEqual, promisify } from 'node:util'
 
 import { z } from 'zod'
@@ -177,8 +177,7 @@ import {
 import {
   ResponsesBridge,
   type ResponsesBridgeConnection,
-  type ResponsesBridgeNamespacedTool,
-  type ResponsesBridgeTarget
+  type ResponsesBridgeNamespacedTool
 } from './responses-bridge'
 import { SettingsRepository } from './repository'
 import { sanitizeCustomMcpServer } from './repository'
@@ -233,10 +232,9 @@ export type AgentBackendResolutionContext = {
   forcedSkillIds?: string[]
 }
 
-type ResponsesBridgePoolEntry = {
+type ResponsesBridgeEntry = {
   bridge: ResponsesBridge
   connection: Promise<ResponsesBridgeConnection>
-  leaseCount: number
 }
 
 type LeasedResponsesBridgeConnection = ResponsesBridgeConnection & {
@@ -492,7 +490,10 @@ class SettingsService {
   private claudeSharedAuthStatusGeneration = 0
   private claudeSharedAuthStatusPromise:
     { generation: number; promise: Promise<boolean> } | undefined
-  private readonly responsesBridges = new Map<string, ResponsesBridgePoolEntry>()
+  // A bridge owns mutable per-runtime state (reasoning override, reviewer scopes, and reasoning
+  // replay). Track each backend generation separately so an overlapping reconnect cannot mutate the
+  // bridge still serving the retiring generation.
+  private readonly responsesBridges = new Map<string, ResponsesBridgeEntry>()
   private providerSequence = 0
   private readonly providerValidationGenerations = new Map<string, number>()
 
@@ -3476,27 +3477,17 @@ class SettingsService {
         namespacedTools: REVIEWER_BRIDGE_NAMESPACED_TOOLS
       }
     }
-    const fingerprint = this.responsesBridgeFingerprint(target)
-    let entry = this.responsesBridges.get(fingerprint)
-    if (!entry) {
-      const bridge = new ResponsesBridge(target)
-      entry = { bridge, connection: bridge.start(), leaseCount: 0 }
-      this.responsesBridges.set(fingerprint, entry)
-    } else {
-      // Reasoning effort is a live global preference, not part of the bridge's pinned routing target.
-      entry.bridge.setReasoningEffort(reasoningEffort)
-    }
-    entry.leaseCount += 1
+    const bridgeId = randomUUID()
+    const bridge = new ResponsesBridge(target)
+    const entry = { bridge, connection: bridge.start() }
+    this.responsesBridges.set(bridgeId, entry)
 
     let connection: ResponsesBridgeConnection
     try {
       connection = await entry.connection
     } catch (error) {
-      entry.leaseCount = Math.max(0, entry.leaseCount - 1)
-      if (entry.leaseCount === 0 && this.responsesBridges.get(fingerprint) === entry) {
-        this.responsesBridges.delete(fingerprint)
-        await entry.bridge.close().catch(() => undefined)
-      }
+      if (this.responsesBridges.get(bridgeId) === entry) this.responsesBridges.delete(bridgeId)
+      await entry.bridge.close().catch(() => undefined)
       throw error
     }
 
@@ -3515,32 +3506,12 @@ class SettingsService {
         release: async () => {
           if (released) return
           released = true
-          leasedEntry.leaseCount = Math.max(0, leasedEntry.leaseCount - 1)
-          if (
-            leasedEntry.leaseCount > 0 ||
-            this.responsesBridges.get(fingerprint) !== leasedEntry
-          ) {
-            return
-          }
-          this.responsesBridges.delete(fingerprint)
+          if (this.responsesBridges.get(bridgeId) !== leasedEntry) return
+          this.responsesBridges.delete(bridgeId)
           await leasedEntry.bridge.close()
         }
       }
     }
-  }
-
-  private responsesBridgeFingerprint(target: ResponsesBridgeTarget): string {
-    // reasoningEffort is intentionally live mutable and therefore excluded from the pinned routing
-    // identity. Including it would split leases and prevent effort fan-out to existing bridges.
-    const pinnedTarget = {
-      baseUrl: target.baseUrl,
-      key: target.key,
-      vendorId: target.vendorId,
-      model: target.model,
-      namespacedTools: target.namespacedTools,
-      reviewerScope: target.reviewerScope
-    }
-    return createHash('sha256').update(JSON.stringify(pinnedTarget)).digest('hex')
   }
 
   // Locates the opencode binary: an explicitly stored path wins, else a best-effort PATH lookup.

--- a/src/main/settings/types.ts
+++ b/src/main/settings/types.ts
@@ -10,7 +10,10 @@ import type {
 } from '../../shared/settings'
 import { SETTINGS_FILE_VERSION } from '../../shared/settings'
 import type { OfficialVendorId } from '../../shared/provider-registry'
-import type { ReasoningEffortPresetSetting } from '../../shared/reasoning-effort'
+import type {
+  CustomReasoningEffortTransport,
+  ReasoningEffortPresetSetting
+} from '../../shared/reasoning-effort'
 import type { PackageMirror } from '../../shared/mirror'
 import type { NotebookLanguage } from '../../shared/notebook'
 import type { RuntimeEnablement, RuntimeSelection } from '../../shared/notebook-runtime'
@@ -38,6 +41,8 @@ export type StoredProvider = {
   supportsImageInput?: boolean
   // Custom-model effort capability. Absence resolves to the standard five-level preset.
   reasoningEffortPreset?: ReasoningEffortPresetSetting
+  // Custom-gateway request shape. Absence resolves to the literal `reasoning_effort` field.
+  reasoningEffortTransport?: CustomReasoningEffortTransport
   // Set for official-vendor providers only.
   vendorId?: OfficialVendorId
   region?: string

--- a/src/main/settings/types.ts
+++ b/src/main/settings/types.ts
@@ -10,6 +10,7 @@ import type {
 } from '../../shared/settings'
 import { SETTINGS_FILE_VERSION } from '../../shared/settings'
 import type { OfficialVendorId } from '../../shared/provider-registry'
+import type { ReasoningEffortPresetSetting } from '../../shared/reasoning-effort'
 import type { PackageMirror } from '../../shared/mirror'
 import type { NotebookLanguage } from '../../shared/notebook'
 import type { RuntimeEnablement, RuntimeSelection } from '../../shared/notebook-runtime'
@@ -35,6 +36,8 @@ export type StoredProvider = {
   // Optional custom-model override. Absence is meaningful and resolves to the shared 200k default.
   contextWindow?: number
   supportsImageInput?: boolean
+  // Custom-model effort capability. Absence resolves to the standard five-level preset.
+  reasoningEffortPreset?: ReasoningEffortPresetSetting
   // Set for official-vendor providers only.
   vendorId?: OfficialVendorId
   region?: string

--- a/src/renderer/src/pages/onboarding/ProviderStep.render.test.tsx
+++ b/src/renderer/src/pages/onboarding/ProviderStep.render.test.tsx
@@ -129,6 +129,30 @@ describe('ProviderStep', () => {
     expect(onAdvance).toHaveBeenCalledOnce()
   })
 
+  it('includes a custom model effort preset in the provider request', async () => {
+    readyClaudeEnvironment()
+    const saveAndActivateProvider = vi
+      .fn()
+      .mockResolvedValue({ providerId: 'p1', validation: { ok: true, category: 'ok' } })
+    useSettingsStore.setState({ saveAndActivateProvider })
+
+    await renderStep({
+      initialValue: createEmptyProviderFormValue({
+        type: 'custom',
+        name: 'Gateway',
+        baseUrl: 'https://gateway.example',
+        model: 'model-a',
+        key: 'sk-test',
+        reasoningEffortPreset: 'none-high'
+      })
+    })
+    await clickButton(/test & continue/i)
+
+    expect(saveAndActivateProvider).toHaveBeenCalledWith(
+      expect.objectContaining({ reasoningEffortPreset: 'none-high' })
+    )
+  })
+
   it('returns to the previous step from the Back button', async () => {
     readyClaudeEnvironment()
     const onBack = vi.fn()

--- a/src/renderer/src/pages/onboarding/ProviderStep.tsx
+++ b/src/renderer/src/pages/onboarding/ProviderStep.tsx
@@ -38,6 +38,7 @@ const toUpsertRequest = (value: ProviderFormValue): UpsertProviderRequest => ({
   apiEndpoints: [value.apiEndpoint],
   supportsImageInput: value.supportsImageInput,
   reasoningEffortPreset: value.type === 'custom' ? value.reasoningEffortPreset : undefined,
+  reasoningEffortTransport: value.type === 'custom' ? value.reasoningEffortTransport : undefined,
   key: value.key || undefined
 })
 

--- a/src/renderer/src/pages/onboarding/ProviderStep.tsx
+++ b/src/renderer/src/pages/onboarding/ProviderStep.tsx
@@ -37,6 +37,7 @@ const toUpsertRequest = (value: ProviderFormValue): UpsertProviderRequest => ({
   // Persist the chosen API format so an OpenAI-compatible provider is validated + driven correctly.
   apiEndpoints: [value.apiEndpoint],
   supportsImageInput: value.supportsImageInput,
+  reasoningEffortPreset: value.type === 'custom' ? value.reasoningEffortPreset : undefined,
   key: value.key || undefined
 })
 

--- a/src/renderer/src/pages/settings/ProviderForm.render.test.tsx
+++ b/src/renderer/src/pages/settings/ProviderForm.render.test.tsx
@@ -110,6 +110,37 @@ describe('ProviderForm field switching', () => {
     )
   })
 
+  it('lets a custom model declare its reasoning effort group', () => {
+    render(
+      createEmptyProviderFormValue({
+        type: 'custom',
+        reasoningEffortPreset: 'none-high'
+      })
+    )
+
+    expect(
+      container
+        .querySelector('[aria-label="Supports reasoning effort"]')
+        ?.getAttribute('data-state')
+    ).toBe('checked')
+    expect(
+      container.querySelector('[aria-label="Reasoning effort levels"]')?.textContent
+    ).toContain('None / High')
+  })
+
+  it('lets a custom model explicitly disable reasoning effort', () => {
+    const onChange = vi.fn()
+    render(createEmptyProviderFormValue({ type: 'custom' }), { onChange })
+
+    act(() => {
+      container
+        .querySelector<HTMLButtonElement>('[aria-label="Supports reasoning effort"]')
+        ?.click()
+    })
+
+    expect(onChange).toHaveBeenCalledWith({ reasoningEffortPreset: 'unsupported' })
+  })
+
   it('describes existing Codex authentication as a one-time import', () => {
     render(
       createEmptyProviderFormValue({

--- a/src/renderer/src/pages/settings/ProviderForm.render.test.tsx
+++ b/src/renderer/src/pages/settings/ProviderForm.render.test.tsx
@@ -114,7 +114,8 @@ describe('ProviderForm field switching', () => {
     render(
       createEmptyProviderFormValue({
         type: 'custom',
-        reasoningEffortPreset: 'none-high'
+        reasoningEffortPreset: 'none-high',
+        reasoningEffortTransport: 'deepseek'
       })
     )
 
@@ -128,6 +129,9 @@ describe('ProviderForm field switching', () => {
     ).toContain('None / High')
     expect(container.textContent).toContain('exact effort levels accepted by this model')
     expect(container.textContent).toContain('maps five relative strengths onto them')
+    expect(
+      container.querySelector('[aria-label="Reasoning effort request format"]')?.textContent
+    ).toContain('DeepSeek thinking + effort')
   })
 
   it('lets a custom model explicitly disable reasoning effort', () => {

--- a/src/renderer/src/pages/settings/ProviderForm.render.test.tsx
+++ b/src/renderer/src/pages/settings/ProviderForm.render.test.tsx
@@ -126,6 +126,8 @@ describe('ProviderForm field switching', () => {
     expect(
       container.querySelector('[aria-label="Reasoning effort levels"]')?.textContent
     ).toContain('None / High')
+    expect(container.textContent).toContain('exact effort levels accepted by this model')
+    expect(container.textContent).toContain('maps five relative strengths onto them')
   })
 
   it('lets a custom model explicitly disable reasoning effort', () => {

--- a/src/renderer/src/pages/settings/ProviderForm.tsx
+++ b/src/renderer/src/pages/settings/ProviderForm.tsx
@@ -17,6 +17,8 @@ import {
 } from '../../../../shared/provider-registry'
 import {
   CUSTOM_REASONING_EFFORT_PRESETS,
+  CUSTOM_REASONING_EFFORT_TRANSPORTS,
+  type CustomReasoningEffortTransport,
   type ReasoningEffortPresetId
 } from '../../../../shared/reasoning-effort'
 import { getApiKeySecurityCopy } from './provider-key-security'
@@ -418,8 +420,8 @@ const ProviderForm = ({
                 <span className="block text-xs font-medium">Reasoning effort</span>
                 <span className="block text-xs text-muted-foreground">
                   Choose the exact effort levels accepted by this model. Open Science maps five
-                  relative strengths onto them. Disable when the model does not accept an effort
-                  parameter.
+                  relative strengths onto them, then sends the selected level using the request
+                  format below. Disable when the model does not accept an effort parameter.
                 </span>
               </label>
               <Switch
@@ -436,32 +438,65 @@ const ProviderForm = ({
             </div>
 
             {value.reasoningEffortPreset !== 'unsupported' ? (
-              <Select
-                value={value.reasoningEffortPreset}
-                disabled={disabled}
-                onValueChange={(reasoningEffortPreset) =>
-                  onChange({
-                    reasoningEffortPreset: reasoningEffortPreset as ReasoningEffortPresetId
-                  })
-                }
-              >
-                <SelectTrigger aria-label="Reasoning effort levels" disabled={disabled}>
-                  <span>
-                    {
-                      CUSTOM_REASONING_EFFORT_PRESETS.find(
-                        (preset) => preset.id === value.reasoningEffortPreset
-                      )?.label
+              <div className="space-y-3">
+                <Select
+                  value={value.reasoningEffortPreset}
+                  disabled={disabled}
+                  onValueChange={(reasoningEffortPreset) =>
+                    onChange({
+                      reasoningEffortPreset: reasoningEffortPreset as ReasoningEffortPresetId
+                    })
+                  }
+                >
+                  <SelectTrigger aria-label="Reasoning effort levels" disabled={disabled}>
+                    <span>
+                      {
+                        CUSTOM_REASONING_EFFORT_PRESETS.find(
+                          (preset) => preset.id === value.reasoningEffortPreset
+                        )?.label
+                      }
+                    </span>
+                  </SelectTrigger>
+                  <SelectContent>
+                    {CUSTOM_REASONING_EFFORT_PRESETS.map((preset) => (
+                      <SelectItem key={preset.id} value={preset.id}>
+                        {preset.label}
+                      </SelectItem>
+                    ))}
+                  </SelectContent>
+                </Select>
+
+                <div className="space-y-1.5">
+                  <span className="block text-xs font-medium">Request format</span>
+                  <Select
+                    value={value.reasoningEffortTransport}
+                    disabled={disabled}
+                    onValueChange={(reasoningEffortTransport) =>
+                      onChange({
+                        reasoningEffortTransport:
+                          reasoningEffortTransport as CustomReasoningEffortTransport
+                      })
                     }
-                  </span>
-                </SelectTrigger>
-                <SelectContent>
-                  {CUSTOM_REASONING_EFFORT_PRESETS.map((preset) => (
-                    <SelectItem key={preset.id} value={preset.id}>
-                      {preset.label}
-                    </SelectItem>
-                  ))}
-                </SelectContent>
-              </Select>
+                  >
+                    <SelectTrigger aria-label="Reasoning effort request format" disabled={disabled}>
+                      <span>
+                        {
+                          CUSTOM_REASONING_EFFORT_TRANSPORTS.find(
+                            (transport) => transport.id === value.reasoningEffortTransport
+                          )?.label
+                        }
+                      </span>
+                    </SelectTrigger>
+                    <SelectContent>
+                      {CUSTOM_REASONING_EFFORT_TRANSPORTS.map((transport) => (
+                        <SelectItem key={transport.id} value={transport.id}>
+                          {transport.label}
+                        </SelectItem>
+                      ))}
+                    </SelectContent>
+                  </Select>
+                </div>
+              </div>
             ) : null}
           </div>
 

--- a/src/renderer/src/pages/settings/ProviderForm.tsx
+++ b/src/renderer/src/pages/settings/ProviderForm.tsx
@@ -417,7 +417,9 @@ const ProviderForm = ({
               <label className="space-y-0.5" htmlFor="provider-reasoning-effort">
                 <span className="block text-xs font-medium">Reasoning effort</span>
                 <span className="block text-xs text-muted-foreground">
-                  Disable only when this model does not accept an effort parameter.
+                  Choose the exact effort levels accepted by this model. Open Science maps five
+                  relative strengths onto them. Disable when the model does not accept an effort
+                  parameter.
                 </span>
               </label>
               <Switch

--- a/src/renderer/src/pages/settings/ProviderForm.tsx
+++ b/src/renderer/src/pages/settings/ProviderForm.tsx
@@ -15,6 +15,10 @@ import {
   getOfficialVendorModelIds,
   resolveVendorApiKeyUrl
 } from '../../../../shared/provider-registry'
+import {
+  CUSTOM_REASONING_EFFORT_PRESETS,
+  type ReasoningEffortPresetId
+} from '../../../../shared/reasoning-effort'
 import { getApiKeySecurityCopy } from './provider-key-security'
 import { ProviderKindIcon } from './provider-icons'
 import {
@@ -406,6 +410,57 @@ const ProviderForm = ({
               disabled={disabled}
               onCheckedChange={(supportsImageInput) => onChange({ supportsImageInput })}
             />
+          </div>
+
+          <div className="space-y-3 border-t border-border-200 pt-3">
+            <div className="flex items-center justify-between gap-4">
+              <label className="space-y-0.5" htmlFor="provider-reasoning-effort">
+                <span className="block text-xs font-medium">Reasoning effort</span>
+                <span className="block text-xs text-muted-foreground">
+                  Disable only when this model does not accept an effort parameter.
+                </span>
+              </label>
+              <Switch
+                id="provider-reasoning-effort"
+                aria-label="Supports reasoning effort"
+                checked={value.reasoningEffortPreset !== 'unsupported'}
+                disabled={disabled}
+                onCheckedChange={(supported) =>
+                  onChange({
+                    reasoningEffortPreset: supported ? 'standard-5' : 'unsupported'
+                  })
+                }
+              />
+            </div>
+
+            {value.reasoningEffortPreset !== 'unsupported' ? (
+              <Select
+                value={value.reasoningEffortPreset}
+                disabled={disabled}
+                onValueChange={(reasoningEffortPreset) =>
+                  onChange({
+                    reasoningEffortPreset: reasoningEffortPreset as ReasoningEffortPresetId
+                  })
+                }
+              >
+                <SelectTrigger aria-label="Reasoning effort levels" disabled={disabled}>
+                  <span>
+                    {
+                      CUSTOM_REASONING_EFFORT_PRESETS.find(
+                        (preset) => preset.id === value.reasoningEffortPreset
+                      )?.label
+                    }
+                  </span>
+                </SelectTrigger>
+                <SelectContent>
+                  {CUSTOM_REASONING_EFFORT_PRESETS.map((preset) => (
+                    <SelectItem key={preset.id} value={preset.id}>
+                      {preset.label}
+                    </SelectItem>
+                  ))}
+                </SelectContent>
+              </Select>
+            ) : null}
           </div>
 
           {keyField}

--- a/src/renderer/src/pages/settings/ProvidersPanel.tsx
+++ b/src/renderer/src/pages/settings/ProvidersPanel.tsx
@@ -286,7 +286,7 @@ const ProvidersPanel = ({
       <SettingsSection
         title="Reasoning effort"
         aria-label="Reasoning effort"
-        description="Higher levels think longer, lower levels respond faster. Applies to subsequent requests."
+        description="Higher levels think longer, while lower levels respond faster. Choices follow the selected model and preserve relative strength when models change; some agent frameworks may approximate unsupported levels. Applies to subsequent requests."
         separated={visibleProviders.length > 0}
       >
         <div className="max-w-md">

--- a/src/renderer/src/pages/settings/ReasoningEffortSelect.render.test.tsx
+++ b/src/renderer/src/pages/settings/ReasoningEffortSelect.render.test.tsx
@@ -82,6 +82,35 @@ describe('ReasoningEffortSelect', () => {
     ).toEqual(['Default', 'Low', 'Medium', 'High'])
   })
 
+  it('shows the documented thinking switch for MiniMax-M3', async () => {
+    useSettingsStore.setState({
+      activeProviderId: 'minimax',
+      activeModel: 'MiniMax-M3',
+      providers: [
+        {
+          id: 'minimax',
+          type: 'official',
+          name: 'MiniMax',
+          vendorId: 'minimax',
+          models: ['MiniMax-M3'],
+          supportsImageInput: false,
+          hasKey: true,
+          needsKey: false
+        }
+      ]
+    })
+
+    await act(async () => {
+      root.render(<ReasoningEffortSelect />)
+    })
+
+    expect(
+      Array.from(container.querySelectorAll('[role="radio"]')).map((element) =>
+        element.textContent?.trim()
+      )
+    ).toEqual(['Default', 'None', 'High'])
+  })
+
   it('stores the highest five-slot intent when the model top choice covers multiple slots', async () => {
     const setReasoningEffort = vi.fn().mockResolvedValue(undefined)
     useSettingsStore.setState({

--- a/src/renderer/src/pages/settings/ReasoningEffortSelect.render.test.tsx
+++ b/src/renderer/src/pages/settings/ReasoningEffortSelect.render.test.tsx
@@ -281,6 +281,31 @@ describe('ReasoningEffortSelect', () => {
     expect(container.querySelector('[role="radio"]')?.textContent).toBe('Default')
   })
 
+  it('shows only Default when a Claude subscription delegates model selection to the CLI', async () => {
+    useSettingsStore.setState({
+      activeProviderId: 'builtin-claude-shared',
+      activeModel: undefined,
+      providers: [
+        {
+          id: 'builtin-claude-shared',
+          type: 'claude-shared',
+          name: 'Claude subscription',
+          models: [],
+          supportsImageInput: true,
+          hasKey: false,
+          needsKey: false
+        }
+      ]
+    })
+
+    await act(async () => {
+      root.render(<ReasoningEffortSelect />)
+    })
+
+    expect(container.querySelectorAll('[role="radio"]')).toHaveLength(1)
+    expect(container.querySelector('[role="radio"]')?.textContent).toBe('Default')
+  })
+
   it('defaults an unconfigured custom model to five choices', async () => {
     useSettingsStore.setState({
       activeProviderId: 'custom',

--- a/src/renderer/src/pages/settings/ReasoningEffortSelect.render.test.tsx
+++ b/src/renderer/src/pages/settings/ReasoningEffortSelect.render.test.tsx
@@ -32,7 +32,7 @@ describe('ReasoningEffortSelect', () => {
 
     const checked = container.querySelector('[role="radio"][aria-checked="true"]')
     expect(checked?.textContent).toBe('High')
-    expect(container.querySelectorAll('[role="radio"]')).toHaveLength(5)
+    expect(container.querySelectorAll('[role="radio"]')).toHaveLength(6)
   })
 
   it('calls the store action with the picked level', async () => {
@@ -51,5 +51,200 @@ describe('ReasoningEffortSelect', () => {
     })
 
     expect(setReasoningEffort).toHaveBeenCalledWith('max')
+  })
+
+  it('shows only the active model three effort levels plus the separate default choice', async () => {
+    useSettingsStore.setState({
+      activeProviderId: 'stepfun',
+      activeModel: 'step-3.7-flash',
+      providers: [
+        {
+          id: 'stepfun',
+          type: 'official',
+          name: 'StepFun',
+          vendorId: 'stepfun',
+          models: ['step-3.7-flash'],
+          supportsImageInput: true,
+          hasKey: true,
+          needsKey: false
+        }
+      ]
+    })
+
+    await act(async () => {
+      root.render(<ReasoningEffortSelect />)
+    })
+
+    expect(
+      Array.from(container.querySelectorAll('[role="radio"]')).map((element) =>
+        element.textContent?.trim()
+      )
+    ).toEqual(['Default', 'Low', 'Medium', 'High'])
+  })
+
+  it('stores the highest five-slot intent when the model top choice covers multiple slots', async () => {
+    const setReasoningEffort = vi.fn().mockResolvedValue(undefined)
+    useSettingsStore.setState({
+      activeProviderId: 'stepfun',
+      activeModel: 'step-3.7-flash',
+      reasoningEffort: 'medium',
+      setReasoningEffort,
+      providers: [
+        {
+          id: 'stepfun',
+          type: 'official',
+          name: 'StepFun',
+          vendorId: 'stepfun',
+          models: ['step-3.7-flash'],
+          supportsImageInput: true,
+          hasKey: true,
+          needsKey: false
+        }
+      ]
+    })
+
+    await act(async () => {
+      root.render(<ReasoningEffortSelect />)
+    })
+
+    const highSegment = Array.from(
+      container.querySelectorAll<HTMLButtonElement>('[role="radio"]')
+    ).find((button) => button.textContent === 'High')
+    act(() => highSegment?.click())
+
+    expect(setReasoningEffort).toHaveBeenCalledWith('max')
+  })
+
+  it('uses the saved effort preset for a custom model', async () => {
+    useSettingsStore.setState({
+      activeProviderId: 'custom',
+      activeModel: 'mimo-v2.5',
+      providers: [
+        {
+          id: 'custom',
+          type: 'custom',
+          name: 'Custom MiMo',
+          model: 'mimo-v2.5',
+          models: ['mimo-v2.5'],
+          supportsImageInput: false,
+          reasoningEffortPreset: 'none-high',
+          hasKey: true,
+          needsKey: false
+        }
+      ]
+    })
+
+    await act(async () => {
+      root.render(<ReasoningEffortSelect />)
+    })
+
+    expect(
+      Array.from(container.querySelectorAll('[role="radio"]')).map((element) =>
+        element.textContent?.trim()
+      )
+    ).toEqual(['Default', 'None', 'High'])
+  })
+
+  it('defaults an unconfigured custom model to five choices', async () => {
+    useSettingsStore.setState({
+      activeProviderId: 'custom',
+      activeModel: 'model-a',
+      providers: [
+        {
+          id: 'custom',
+          type: 'custom',
+          name: 'Legacy custom model',
+          model: 'model-a',
+          models: ['model-a'],
+          supportsImageInput: false,
+          hasKey: true,
+          needsKey: false
+        }
+      ]
+    })
+
+    await act(async () => {
+      root.render(<ReasoningEffortSelect />)
+    })
+
+    expect(
+      Array.from(container.querySelectorAll('[role="radio"]')).map((element) =>
+        element.textContent?.trim()
+      )
+    ).toEqual(['Default', 'Low', 'Medium', 'High', 'XHigh', 'Max'])
+  })
+
+  it('refreshes from static profiles when the selected provider and model change', async () => {
+    useSettingsStore.setState({
+      activeProviderId: 'stepfun',
+      activeModel: 'step-3.7-flash',
+      providers: [
+        {
+          id: 'stepfun',
+          type: 'official',
+          name: 'StepFun',
+          vendorId: 'stepfun',
+          models: ['step-3.7-flash'],
+          supportsImageInput: true,
+          hasKey: true,
+          needsKey: false
+        },
+        {
+          id: 'openrouter',
+          type: 'official',
+          name: 'OpenRouter',
+          vendorId: 'openrouter',
+          models: ['deepseek/deepseek-v4-pro'],
+          supportsImageInput: false,
+          hasKey: true,
+          needsKey: false
+        }
+      ]
+    })
+
+    await act(async () => {
+      root.render(<ReasoningEffortSelect />)
+    })
+    expect(container.querySelectorAll('[role="radio"]')).toHaveLength(4)
+
+    act(() => {
+      useSettingsStore.setState({
+        activeProviderId: 'openrouter',
+        activeModel: 'deepseek/deepseek-v4-pro'
+      })
+    })
+
+    expect(
+      Array.from(container.querySelectorAll('[role="radio"]')).map((element) =>
+        element.textContent?.trim()
+      )
+    ).toEqual(['Default', 'High', 'Max'])
+  })
+
+  it('shows only Default when a custom model explicitly disables effort', async () => {
+    useSettingsStore.setState({
+      activeProviderId: 'custom',
+      activeModel: 'model-a',
+      providers: [
+        {
+          id: 'custom',
+          type: 'custom',
+          name: 'No effort model',
+          model: 'model-a',
+          models: ['model-a'],
+          supportsImageInput: false,
+          reasoningEffortPreset: 'unsupported',
+          hasKey: true,
+          needsKey: false
+        }
+      ]
+    })
+
+    await act(async () => {
+      root.render(<ReasoningEffortSelect />)
+    })
+
+    expect(container.querySelectorAll('[role="radio"]')).toHaveLength(1)
+    expect(container.querySelector('[role="radio"]')?.textContent).toBe('Default')
   })
 })

--- a/src/renderer/src/pages/settings/ReasoningEffortSelect.render.test.tsx
+++ b/src/renderer/src/pages/settings/ReasoningEffortSelect.render.test.tsx
@@ -325,7 +325,7 @@ describe('ReasoningEffortSelect', () => {
       Array.from(container.querySelectorAll('[role="radio"]')).map((element) =>
         element.textContent?.trim()
       )
-    ).toEqual(['Default', 'High', 'Max'])
+    ).toEqual(['Default', 'None', 'High', 'XHigh'])
   })
 
   it('shows only Default when a custom model explicitly disables effort', async () => {

--- a/src/renderer/src/pages/settings/ReasoningEffortSelect.render.test.tsx
+++ b/src/renderer/src/pages/settings/ReasoningEffortSelect.render.test.tsx
@@ -145,6 +145,59 @@ describe('ReasoningEffortSelect', () => {
     ).toEqual(['Default', 'None', 'High'])
   })
 
+  it('uses the OpenAI model profile for a Codex subscription', async () => {
+    useSettingsStore.setState({
+      activeProviderId: 'builtin-codex-subscription',
+      activeModel: 'gpt-5.6-sol',
+      providers: [
+        {
+          id: 'builtin-codex-subscription',
+          type: 'codex-isolated',
+          name: 'Codex subscription',
+          models: ['gpt-5.6-sol'],
+          supportsImageInput: true,
+          hasKey: false,
+          needsKey: false
+        }
+      ]
+    })
+
+    await act(async () => {
+      root.render(<ReasoningEffortSelect />)
+    })
+
+    expect(
+      Array.from(container.querySelectorAll('[role="radio"]')).map((element) =>
+        element.textContent?.trim()
+      )
+    ).toEqual(['Default', 'Low', 'Medium', 'High', 'XHigh', 'Ultra'])
+  })
+
+  it('uses the Anthropic model profile for a Claude subscription', async () => {
+    useSettingsStore.setState({
+      activeProviderId: 'builtin-claude-isolated',
+      activeModel: 'claude-haiku-4-5-20251001',
+      providers: [
+        {
+          id: 'builtin-claude-isolated',
+          type: 'claude-isolated',
+          name: 'Claude subscription',
+          models: ['claude-haiku-4-5-20251001'],
+          supportsImageInput: true,
+          hasKey: true,
+          needsKey: false
+        }
+      ]
+    })
+
+    await act(async () => {
+      root.render(<ReasoningEffortSelect />)
+    })
+
+    expect(container.querySelectorAll('[role="radio"]')).toHaveLength(1)
+    expect(container.querySelector('[role="radio"]')?.textContent).toBe('Default')
+  })
+
   it('defaults an unconfigured custom model to five choices', async () => {
     useSettingsStore.setState({
       activeProviderId: 'custom',

--- a/src/renderer/src/pages/settings/ReasoningEffortSelect.render.test.tsx
+++ b/src/renderer/src/pages/settings/ReasoningEffortSelect.render.test.tsx
@@ -173,6 +173,31 @@ describe('ReasoningEffortSelect', () => {
     ).toEqual(['Default', 'Low', 'Medium', 'High', 'XHigh', 'Ultra'])
   })
 
+  it('shows only Default when a Codex subscription delegates model selection to the runtime', async () => {
+    useSettingsStore.setState({
+      activeProviderId: 'builtin-codex-subscription',
+      activeModel: undefined,
+      providers: [
+        {
+          id: 'builtin-codex-subscription',
+          type: 'codex-isolated',
+          name: 'Codex subscription',
+          models: ['gpt-5.6-sol'],
+          supportsImageInput: true,
+          hasKey: false,
+          needsKey: false
+        }
+      ]
+    })
+
+    await act(async () => {
+      root.render(<ReasoningEffortSelect />)
+    })
+
+    expect(container.querySelectorAll('[role="radio"]')).toHaveLength(1)
+    expect(container.querySelector('[role="radio"]')?.textContent).toBe('Default')
+  })
+
   it('uses the Anthropic model profile for a Claude subscription', async () => {
     useSettingsStore.setState({
       activeProviderId: 'builtin-claude-isolated',

--- a/src/renderer/src/pages/settings/ReasoningEffortSelect.render.test.tsx
+++ b/src/renderer/src/pages/settings/ReasoningEffortSelect.render.test.tsx
@@ -82,6 +82,35 @@ describe('ReasoningEffortSelect', () => {
     ).toEqual(['Default', 'Low', 'Medium', 'High'])
   })
 
+  it('uses an official provider catalog default when no active model override is stored', async () => {
+    useSettingsStore.setState({
+      activeProviderId: 'openai',
+      activeModel: undefined,
+      providers: [
+        {
+          id: 'openai',
+          type: 'official',
+          name: 'OpenAI',
+          vendorId: 'openai',
+          models: ['gpt-5.6-sol', 'gpt-5.5'],
+          supportsImageInput: true,
+          hasKey: true,
+          needsKey: false
+        }
+      ]
+    })
+
+    await act(async () => {
+      root.render(<ReasoningEffortSelect />)
+    })
+
+    expect(
+      Array.from(container.querySelectorAll('[role="radio"]')).map((element) =>
+        element.textContent?.trim()
+      )
+    ).toEqual(['Default', 'Low', 'Medium', 'High', 'XHigh', 'Ultra'])
+  })
+
   it('shows the documented thinking switch for MiniMax-M3', async () => {
     useSettingsStore.setState({
       activeProviderId: 'minimax',

--- a/src/renderer/src/pages/settings/ReasoningEffortSelect.tsx
+++ b/src/renderer/src/pages/settings/ReasoningEffortSelect.tsx
@@ -2,18 +2,11 @@ import { useState } from 'react'
 
 import { cn } from '@/lib/utils'
 import { useSettingsStore } from '@/stores/settings-store'
-import type { ReasoningEffort } from '../../../../shared/settings'
-
-// Reasoning-effort choices shown in Settings > Model, left to right from lightest to strongest.
-// 'default' keeps the agent's own default (nothing is sent); the concrete levels form a relative
-// scale that each agent/model maps onto its closest supported rung.
-const REASONING_EFFORT_OPTIONS: { value: ReasoningEffort; label: string }[] = [
-  { value: 'default', label: 'Default' },
-  { value: 'low', label: 'Low' },
-  { value: 'medium', label: 'Medium' },
-  { value: 'high', label: 'High' },
-  { value: 'max', label: 'Max' }
-]
+import {
+  resolveReasoningEffortControl,
+  resolveReasoningEffortProfile
+} from '../../../../shared/reasoning-effort'
+import { resolveVendorModelReasoningEffort } from '../../../../shared/provider-registry'
 
 // Segmented effort selector: the highlight block slides to the picked level. Fixed-width segments
 // keep the thumb math exact. Mirrored on ToolPermissionControl's radiogroup pattern. The new level
@@ -22,19 +15,37 @@ const REASONING_EFFORT_OPTIONS: { value: ReasoningEffort; label: string }[] = [
 const ReasoningEffortSelect = (): React.JSX.Element => {
   const reasoningEffort = useSettingsStore((state) => state.reasoningEffort)
   const setReasoningEffort = useSettingsStore((state) => state.setReasoningEffort)
+  const activeProviderId = useSettingsStore((state) => state.activeProviderId)
+  const activeModel = useSettingsStore((state) => state.activeModel)
+  const providers = useSettingsStore((state) => state.providers)
+  const activeProvider = providers.find((provider) => provider.id === activeProviderId)
+  const profile =
+    activeProvider?.type === 'official' && activeProvider.vendorId
+      ? resolveVendorModelReasoningEffort(activeProvider.vendorId, activeModel)
+      : resolveReasoningEffortProfile(activeProvider?.reasoningEffortPreset)
+  const control = resolveReasoningEffortControl(reasoningEffort, profile)
+  const options = [
+    { value: undefined, label: 'Default', intent: 'default' as const },
+    ...control.options
+  ]
   // The slide is a click affordance: enable it only after the user interacts, so the thumb never
   // sweeps across on first paint when the persisted level loads.
   const [interactive, setInteractive] = useState(false)
   const selectedIndex = Math.max(
     0,
-    REASONING_EFFORT_OPTIONS.findIndex((option) => option.value === reasoningEffort)
+    options.findIndex((option) =>
+      reasoningEffort === 'default'
+        ? option.intent === 'default'
+        : option.value === control.selectedValue
+    )
   )
 
   return (
     <div
       role="radiogroup"
       aria-label="Reasoning effort"
-      className="relative grid w-fit grid-cols-5 rounded-lg bg-muted p-0.5"
+      className="relative grid w-fit rounded-lg bg-muted p-0.5"
+      style={{ gridTemplateColumns: `repeat(${options.length}, 4rem)` }}
     >
       <span
         aria-hidden="true"
@@ -44,19 +55,19 @@ const ReasoningEffortSelect = (): React.JSX.Element => {
         )}
         style={{ transform: `translateX(${selectedIndex * 100}%)` }}
       />
-      {REASONING_EFFORT_OPTIONS.map((option) => (
+      {options.map((option) => (
         <button
-          key={option.value}
+          key={option.intent}
           type="button"
           role="radio"
-          aria-checked={reasoningEffort === option.value}
+          aria-checked={options[selectedIndex] === option}
           onClick={() => {
             setInteractive(true)
-            void setReasoningEffort(option.value)
+            void setReasoningEffort(option.intent)
           }}
           className={cn(
             'relative z-10 flex h-7 w-16 items-center justify-center rounded-md text-xs font-medium transition-colors motion-reduce:transition-none',
-            reasoningEffort === option.value
+            options[selectedIndex] === option
               ? 'text-foreground'
               : 'text-muted-foreground hover:text-foreground'
           )}

--- a/src/renderer/src/pages/settings/ReasoningEffortSelect.tsx
+++ b/src/renderer/src/pages/settings/ReasoningEffortSelect.tsx
@@ -2,15 +2,8 @@ import { useState } from 'react'
 
 import { cn } from '@/lib/utils'
 import { useSettingsStore } from '@/stores/settings-store'
-import {
-  resolveReasoningEffortControl,
-  resolveReasoningEffortProfile
-} from '../../../../shared/reasoning-effort'
-import { resolveVendorModelReasoningEffort } from '../../../../shared/provider-registry'
-import {
-  isClaudeSubscriptionProvider,
-  isCodexSubscriptionProvider
-} from '../../../../shared/settings'
+import { resolveProviderReasoningEffortProfile } from '../../../../shared/provider-reasoning-effort'
+import { resolveReasoningEffortControl } from '../../../../shared/reasoning-effort'
 
 // Segmented effort selector: the highlight block slides to the picked level. Fixed-width segments
 // keep the thumb math exact. Mirrored on ToolPermissionControl's radiogroup pattern. The new level
@@ -23,16 +16,7 @@ const ReasoningEffortSelect = (): React.JSX.Element => {
   const activeModel = useSettingsStore((state) => state.activeModel)
   const providers = useSettingsStore((state) => state.providers)
   const activeProvider = providers.find((provider) => provider.id === activeProviderId)
-  const profile =
-    activeProvider?.type === 'official' && activeProvider.vendorId
-      ? resolveVendorModelReasoningEffort(activeProvider.vendorId, activeModel)
-      : activeProvider && isCodexSubscriptionProvider(activeProvider.type)
-        ? activeModel
-          ? resolveVendorModelReasoningEffort('openai', activeModel)
-          : { supported: false as const }
-        : activeProvider && isClaudeSubscriptionProvider(activeProvider.type)
-          ? resolveVendorModelReasoningEffort('anthropic', activeModel)
-          : resolveReasoningEffortProfile(activeProvider?.reasoningEffortPreset)
+  const profile = resolveProviderReasoningEffortProfile(activeProvider, activeModel)
   const control = resolveReasoningEffortControl(reasoningEffort, profile)
   const options = [
     { value: undefined, label: 'Default', intent: 'default' as const },

--- a/src/renderer/src/pages/settings/ReasoningEffortSelect.tsx
+++ b/src/renderer/src/pages/settings/ReasoningEffortSelect.tsx
@@ -2,7 +2,10 @@ import { useState } from 'react'
 
 import { cn } from '@/lib/utils'
 import { useSettingsStore } from '@/stores/settings-store'
-import { resolveProviderReasoningEffortProfile } from '../../../../shared/provider-reasoning-effort'
+import {
+  resolveProviderEffectiveModel,
+  resolveProviderReasoningEffortProfile
+} from '../../../../shared/provider-reasoning-effort'
 import { resolveReasoningEffortControl } from '../../../../shared/reasoning-effort'
 
 // Segmented effort selector: the highlight block slides to the picked level. Fixed-width segments
@@ -16,7 +19,8 @@ const ReasoningEffortSelect = (): React.JSX.Element => {
   const activeModel = useSettingsStore((state) => state.activeModel)
   const providers = useSettingsStore((state) => state.providers)
   const activeProvider = providers.find((provider) => provider.id === activeProviderId)
-  const profile = resolveProviderReasoningEffortProfile(activeProvider, activeModel)
+  const effectiveModel = resolveProviderEffectiveModel(activeProvider, activeModel)
+  const profile = resolveProviderReasoningEffortProfile(activeProvider, effectiveModel)
   const control = resolveReasoningEffortControl(reasoningEffort, profile)
   const options = [
     { value: undefined, label: 'Default', intent: 'default' as const },

--- a/src/renderer/src/pages/settings/ReasoningEffortSelect.tsx
+++ b/src/renderer/src/pages/settings/ReasoningEffortSelect.tsx
@@ -7,6 +7,10 @@ import {
   resolveReasoningEffortProfile
 } from '../../../../shared/reasoning-effort'
 import { resolveVendorModelReasoningEffort } from '../../../../shared/provider-registry'
+import {
+  isClaudeSubscriptionProvider,
+  isCodexSubscriptionProvider
+} from '../../../../shared/settings'
 
 // Segmented effort selector: the highlight block slides to the picked level. Fixed-width segments
 // keep the thumb math exact. Mirrored on ToolPermissionControl's radiogroup pattern. The new level
@@ -22,7 +26,11 @@ const ReasoningEffortSelect = (): React.JSX.Element => {
   const profile =
     activeProvider?.type === 'official' && activeProvider.vendorId
       ? resolveVendorModelReasoningEffort(activeProvider.vendorId, activeModel)
-      : resolveReasoningEffortProfile(activeProvider?.reasoningEffortPreset)
+      : activeProvider && isCodexSubscriptionProvider(activeProvider.type)
+        ? resolveVendorModelReasoningEffort('openai', activeModel)
+        : activeProvider && isClaudeSubscriptionProvider(activeProvider.type)
+          ? resolveVendorModelReasoningEffort('anthropic', activeModel)
+          : resolveReasoningEffortProfile(activeProvider?.reasoningEffortPreset)
   const control = resolveReasoningEffortControl(reasoningEffort, profile)
   const options = [
     { value: undefined, label: 'Default', intent: 'default' as const },

--- a/src/renderer/src/pages/settings/ReasoningEffortSelect.tsx
+++ b/src/renderer/src/pages/settings/ReasoningEffortSelect.tsx
@@ -27,7 +27,9 @@ const ReasoningEffortSelect = (): React.JSX.Element => {
     activeProvider?.type === 'official' && activeProvider.vendorId
       ? resolveVendorModelReasoningEffort(activeProvider.vendorId, activeModel)
       : activeProvider && isCodexSubscriptionProvider(activeProvider.type)
-        ? resolveVendorModelReasoningEffort('openai', activeModel)
+        ? activeModel
+          ? resolveVendorModelReasoningEffort('openai', activeModel)
+          : { supported: false as const }
         : activeProvider && isClaudeSubscriptionProvider(activeProvider.type)
           ? resolveVendorModelReasoningEffort('anthropic', activeModel)
           : resolveReasoningEffortProfile(activeProvider?.reasoningEffortPreset)

--- a/src/renderer/src/pages/settings/SettingsPage.render.test.tsx
+++ b/src/renderer/src/pages/settings/SettingsPage.render.test.tsx
@@ -214,6 +214,8 @@ describe('SettingsPage layout', () => {
     // management; the agent framework moved to the Agent sub-panel.
     expect(document.body.textContent).toContain('Active model')
     expect(document.body.textContent).toContain('Reasoning effort')
+    expect(document.body.textContent).toContain('preserve relative strength when models change')
+    expect(document.body.textContent).toContain('may approximate unsupported levels')
     expect(document.body.textContent).toContain('Providers')
     expect(document.body.textContent).not.toContain('Agent framework')
     expect(document.body.querySelectorAll('[data-slot="settings-section"]')).toHaveLength(3)

--- a/src/renderer/src/pages/settings/SettingsPage.tsx
+++ b/src/renderer/src/pages/settings/SettingsPage.tsx
@@ -65,6 +65,7 @@ const toFormValue = (provider: ProviderView): ProviderFormValue =>
     contextWindow: provider.contextWindow?.toString() ?? '',
     apiEndpoint: provider.apiEndpoints?.[0] ?? 'anthropic',
     supportsImageInput: provider.supportsImageInput,
+    reasoningEffortPreset: provider.reasoningEffortPreset ?? 'standard-5',
     vendorId: provider.vendorId,
     region: provider.region
   })
@@ -86,6 +87,7 @@ const toUpsertRequest = (
       : undefined,
   apiEndpoints: [value.apiEndpoint],
   supportsImageInput: value.supportsImageInput,
+  reasoningEffortPreset: value.type === 'custom' ? value.reasoningEffortPreset : undefined,
   vendorId: value.vendorId,
   region: value.region,
   key: value.key || undefined

--- a/src/renderer/src/pages/settings/SettingsPage.tsx
+++ b/src/renderer/src/pages/settings/SettingsPage.tsx
@@ -66,6 +66,7 @@ const toFormValue = (provider: ProviderView): ProviderFormValue =>
     apiEndpoint: provider.apiEndpoints?.[0] ?? 'anthropic',
     supportsImageInput: provider.supportsImageInput,
     reasoningEffortPreset: provider.reasoningEffortPreset ?? 'standard-5',
+    reasoningEffortTransport: provider.reasoningEffortTransport ?? 'reasoning-effort',
     vendorId: provider.vendorId,
     region: provider.region
   })
@@ -88,6 +89,7 @@ const toUpsertRequest = (
   apiEndpoints: [value.apiEndpoint],
   supportsImageInput: value.supportsImageInput,
   reasoningEffortPreset: value.type === 'custom' ? value.reasoningEffortPreset : undefined,
+  reasoningEffortTransport: value.type === 'custom' ? value.reasoningEffortTransport : undefined,
   vendorId: value.vendorId,
   region: value.region,
   key: value.key || undefined

--- a/src/renderer/src/pages/settings/provider-form-value.ts
+++ b/src/renderer/src/pages/settings/provider-form-value.ts
@@ -10,6 +10,7 @@ import {
   getOfficialVendor,
   type OfficialVendorId
 } from '../../../../shared/provider-registry'
+import type { ReasoningEffortPresetSetting } from '../../../../shared/reasoning-effort'
 
 // Editable value for the provider form, kept in its own module so the component file only exports a
 // component (satisfying react-refresh) while the wizard and settings page share this shape/factory.
@@ -25,6 +26,8 @@ export type ProviderFormValue = {
   // the registry); it is stored as the single-entry apiEndpoints array.
   apiEndpoint: ChatApiEndpoint
   supportsImageInput: boolean
+  // Optional at rest for backwards compatibility; the form always materializes the five-level default.
+  reasoningEffortPreset: ReasoningEffortPresetSetting
   // Set when type is 'official': the chosen vendor and (for multi-region vendors) the endpoint. Base
   // URL and the model catalog then come from the registry rather than these free-text fields.
   vendorId?: OfficialVendorId
@@ -44,6 +47,7 @@ export const createEmptyProviderFormValue = (
   contextWindow: '',
   apiEndpoint: 'anthropic',
   supportsImageInput: false,
+  reasoningEffortPreset: 'standard-5',
   key: '',
   ...overrides
 })

--- a/src/renderer/src/pages/settings/provider-form-value.ts
+++ b/src/renderer/src/pages/settings/provider-form-value.ts
@@ -10,7 +10,10 @@ import {
   getOfficialVendor,
   type OfficialVendorId
 } from '../../../../shared/provider-registry'
-import type { ReasoningEffortPresetSetting } from '../../../../shared/reasoning-effort'
+import type {
+  CustomReasoningEffortTransport,
+  ReasoningEffortPresetSetting
+} from '../../../../shared/reasoning-effort'
 
 // Editable value for the provider form, kept in its own module so the component file only exports a
 // component (satisfying react-refresh) while the wizard and settings page share this shape/factory.
@@ -28,6 +31,8 @@ export type ProviderFormValue = {
   supportsImageInput: boolean
   // Optional at rest for backwards compatibility; the form always materializes the five-level default.
   reasoningEffortPreset: ReasoningEffortPresetSetting
+  // The request-body shape used by the custom gateway for model effort.
+  reasoningEffortTransport: CustomReasoningEffortTransport
   // Set when type is 'official': the chosen vendor and (for multi-region vendors) the endpoint. Base
   // URL and the model catalog then come from the registry rather than these free-text fields.
   vendorId?: OfficialVendorId
@@ -48,6 +53,7 @@ export const createEmptyProviderFormValue = (
   apiEndpoint: 'anthropic',
   supportsImageInput: false,
   reasoningEffortPreset: 'standard-5',
+  reasoningEffortTransport: 'reasoning-effort',
   key: '',
   ...overrides
 })

--- a/src/shared/provider-reasoning-effort.test.ts
+++ b/src/shared/provider-reasoning-effort.test.ts
@@ -1,0 +1,58 @@
+import { describe, expect, it } from 'vitest'
+
+import {
+  resolveProviderReasoningEffortProfile,
+  type ProviderReasoningEffortSource
+} from './provider-reasoning-effort'
+
+describe('resolveProviderReasoningEffortProfile', () => {
+  it.each<
+    [
+      name: string,
+      provider: ProviderReasoningEffortSource | undefined,
+      model: string | undefined,
+      expected: ReturnType<typeof resolveProviderReasoningEffortProfile>
+    ]
+  >([
+    [
+      'empty settings default',
+      undefined,
+      undefined,
+      { supported: true, slots: ['low', 'medium', 'high', 'xhigh', 'max'] }
+    ],
+    [
+      'official model override',
+      { type: 'official', vendorId: 'anthropic' },
+      'claude-haiku-4-5-20251001',
+      { supported: false }
+    ],
+    [
+      'pinned Codex subscription',
+      { type: 'codex-isolated' },
+      'gpt-5.6-sol',
+      { supported: true, slots: ['low', 'medium', 'high', 'xhigh', 'ultra'] }
+    ],
+    ['unpinned Codex subscription', { type: 'codex-shared' }, undefined, { supported: false }],
+    [
+      'Claude subscription',
+      { type: 'claude-isolated' },
+      'claude-haiku-4-5-20251001',
+      { supported: false }
+    ],
+    [
+      'custom model preset',
+      { type: 'custom', reasoningEffortPreset: 'none-high' },
+      'custom-model',
+      { supported: true, slots: ['none', 'high', 'high', 'high', 'high'] }
+    ],
+    [
+      'legacy custom model default',
+      { type: 'custom' },
+      'custom-model',
+      { supported: true, slots: ['low', 'medium', 'high', 'xhigh', 'max'] }
+    ],
+    ['malformed official provider', { type: 'official' }, 'model', { supported: false }]
+  ])('resolves the %s profile', (_name, provider, model, expected) => {
+    expect(resolveProviderReasoningEffortProfile(provider, model)).toEqual(expected)
+  })
+})

--- a/src/shared/provider-reasoning-effort.test.ts
+++ b/src/shared/provider-reasoning-effort.test.ts
@@ -45,6 +45,18 @@ describe('resolveProviderEffectiveModel', () => {
       )
     ).toBeUndefined()
   })
+
+  it('keeps an unpinned Claude subscription model unknown instead of using its catalog', () => {
+    expect(
+      resolveProviderEffectiveModel(
+        {
+          type: 'claude-shared',
+          models: ['claude-opus-5', 'claude-haiku-4-5-20251001']
+        },
+        undefined
+      )
+    ).toBeUndefined()
+  })
 })
 
 describe('resolveProviderReasoningEffortProfile', () => {
@@ -81,6 +93,7 @@ describe('resolveProviderReasoningEffortProfile', () => {
       'claude-haiku-4-5-20251001',
       { supported: false }
     ],
+    ['unpinned Claude subscription', { type: 'claude-shared' }, undefined, { supported: false }],
     [
       'custom model preset',
       { type: 'custom', reasoningEffortPreset: 'none-high' },

--- a/src/shared/provider-reasoning-effort.test.ts
+++ b/src/shared/provider-reasoning-effort.test.ts
@@ -1,9 +1,51 @@
 import { describe, expect, it } from 'vitest'
 
 import {
+  resolveProviderEffectiveModel,
   resolveProviderReasoningEffortProfile,
   type ProviderReasoningEffortSource
 } from './provider-reasoning-effort'
+
+describe('resolveProviderEffectiveModel', () => {
+  it('uses the catalog default when an official provider has no active override', () => {
+    expect(
+      resolveProviderEffectiveModel(
+        {
+          type: 'official',
+          vendorId: 'openai',
+          models: ['gpt-5.6-sol', 'gpt-5.5']
+        },
+        undefined
+      )
+    ).toBe('gpt-5.6-sol')
+  })
+
+  it('prefers a saved provider default and rejects a stale active override', () => {
+    expect(
+      resolveProviderEffectiveModel(
+        {
+          type: 'claude-isolated',
+          model: 'claude-haiku-4-5-20251001',
+          models: ['claude-haiku-4-5-20251001']
+        },
+        'removed-model'
+      )
+    ).toBe('claude-haiku-4-5-20251001')
+  })
+
+  it('keeps an unpinned Codex subscription model unknown', () => {
+    expect(
+      resolveProviderEffectiveModel(
+        {
+          type: 'codex-isolated',
+          model: 'gpt-5.6-sol',
+          models: ['gpt-5.6-sol']
+        },
+        undefined
+      )
+    ).toBeUndefined()
+  })
+})
 
 describe('resolveProviderReasoningEffortProfile', () => {
   it.each<

--- a/src/shared/provider-reasoning-effort.ts
+++ b/src/shared/provider-reasoning-effort.ts
@@ -1,0 +1,52 @@
+import { resolveVendorModelReasoningEffort, type OfficialVendorId } from './provider-registry'
+import {
+  resolveReasoningEffortProfile,
+  type ReasoningEffortPresetSetting,
+  type ReasoningEffortProfile
+} from './reasoning-effort'
+import type { ProviderType } from './settings'
+
+export type ProviderReasoningEffortSource = {
+  type: ProviderType
+  vendorId?: OfficialVendorId
+  reasoningEffortPreset?: ReasoningEffortPresetSetting
+}
+
+// Keeps a safe runtime fallback for malformed persisted data while making a newly-added ProviderType
+// fail type checking until its effort-profile behavior is explicitly defined below.
+const unsupportedProviderType = (providerType: never): ReasoningEffortProfile => {
+  void providerType
+  return { supported: false }
+}
+
+// Resolves the static effort capability shared by settings execution and renderer controls. The
+// selected model owns the visible vocabulary; subscriptions alias their vendor catalogs, while an
+// unpinned Codex subscription stays unknown until the runtime model is explicit.
+export const resolveProviderReasoningEffortProfile = (
+  provider: ProviderReasoningEffortSource | undefined,
+  model: string | undefined
+): ReasoningEffortProfile => {
+  // The settings control stays useful before a provider is configured, matching the custom-model
+  // compatibility default. Main-side execution still returns `default` before calling this resolver
+  // when no active provider exists.
+  if (!provider) return resolveReasoningEffortProfile(undefined)
+
+  const providerType = provider.type
+
+  switch (providerType) {
+    case 'official':
+      return provider.vendorId
+        ? resolveVendorModelReasoningEffort(provider.vendorId, model)
+        : { supported: false }
+    case 'codex-shared':
+    case 'codex-isolated':
+      return model ? resolveVendorModelReasoningEffort('openai', model) : { supported: false }
+    case 'claude-shared':
+    case 'claude-isolated':
+      return resolveVendorModelReasoningEffort('anthropic', model)
+    case 'custom':
+      return resolveReasoningEffortProfile(provider.reasoningEffortPreset)
+  }
+
+  return unsupportedProviderType(providerType)
+}

--- a/src/shared/provider-reasoning-effort.ts
+++ b/src/shared/provider-reasoning-effort.ts
@@ -4,7 +4,11 @@ import {
   type ReasoningEffortPresetSetting,
   type ReasoningEffortProfile
 } from './reasoning-effort'
-import { isCodexSubscriptionProvider, type ProviderType } from './settings'
+import {
+  isClaudeSubscriptionProvider,
+  isCodexSubscriptionProvider,
+  type ProviderType
+} from './settings'
 
 export type ProviderReasoningEffortSource = {
   type: ProviderType
@@ -14,9 +18,9 @@ export type ProviderReasoningEffortSource = {
   reasoningEffortPreset?: ReasoningEffortPresetSetting
 }
 
-// Resolves the effective selection with the same rules in main and renderer. Codex subscriptions
-// deliberately keep an omitted selection unknown because the account runtime owns its default model;
-// every other provider falls back through its saved default and then its available catalog.
+// Resolves the effective selection with the same rules in main and renderer. Subscription runtimes
+// keep an omitted selection unknown because the account/CLI owns its default model. A saved Claude
+// override remains explicit; other providers fall back through their saved default and catalog.
 export const resolveProviderEffectiveModel = (
   provider: ProviderReasoningEffortSource | undefined,
   requestedModel: string | undefined
@@ -37,6 +41,7 @@ export const resolveProviderEffectiveModel = (
   ) {
     return provider.model
   }
+  if (isClaudeSubscriptionProvider(provider.type)) return undefined
 
   return availableModels[0] ?? provider.model
 }
@@ -49,8 +54,8 @@ const unsupportedProviderType = (providerType: never): ReasoningEffortProfile =>
 }
 
 // Resolves the static effort capability shared by settings execution and renderer controls. The
-// selected model owns the visible vocabulary; subscriptions alias their vendor catalogs, while an
-// unpinned Codex subscription stays unknown until the runtime model is explicit.
+// selected model owns the visible vocabulary; subscriptions alias their vendor catalogs only after
+// a model is pinned, while an account/CLI-owned default stays unknown.
 export const resolveProviderReasoningEffortProfile = (
   provider: ProviderReasoningEffortSource | undefined,
   model: string | undefined
@@ -72,7 +77,7 @@ export const resolveProviderReasoningEffortProfile = (
       return model ? resolveVendorModelReasoningEffort('openai', model) : { supported: false }
     case 'claude-shared':
     case 'claude-isolated':
-      return resolveVendorModelReasoningEffort('anthropic', model)
+      return model ? resolveVendorModelReasoningEffort('anthropic', model) : { supported: false }
     case 'custom':
       return resolveReasoningEffortProfile(provider.reasoningEffortPreset)
   }

--- a/src/shared/provider-reasoning-effort.ts
+++ b/src/shared/provider-reasoning-effort.ts
@@ -4,12 +4,41 @@ import {
   type ReasoningEffortPresetSetting,
   type ReasoningEffortProfile
 } from './reasoning-effort'
-import type { ProviderType } from './settings'
+import { isCodexSubscriptionProvider, type ProviderType } from './settings'
 
 export type ProviderReasoningEffortSource = {
   type: ProviderType
   vendorId?: OfficialVendorId
+  model?: string
+  models?: readonly string[]
   reasoningEffortPreset?: ReasoningEffortPresetSetting
+}
+
+// Resolves the effective selection with the same rules in main and renderer. Codex subscriptions
+// deliberately keep an omitted selection unknown because the account runtime owns its default model;
+// every other provider falls back through its saved default and then its available catalog.
+export const resolveProviderEffectiveModel = (
+  provider: ProviderReasoningEffortSource | undefined,
+  requestedModel: string | undefined
+): string | undefined => {
+  if (!provider) return undefined
+
+  const availableModels = provider.models ?? []
+  if (
+    requestedModel &&
+    (availableModels.length === 0 || availableModels.includes(requestedModel))
+  ) {
+    return requestedModel
+  }
+  if (isCodexSubscriptionProvider(provider.type)) return undefined
+  if (
+    provider.model &&
+    (availableModels.length === 0 || availableModels.includes(provider.model))
+  ) {
+    return provider.model
+  }
+
+  return availableModels[0] ?? provider.model
 }
 
 // Keeps a safe runtime fallback for malformed persisted data while making a newly-added ProviderType

--- a/src/shared/provider-registry.test.ts
+++ b/src/shared/provider-registry.test.ts
@@ -105,9 +105,13 @@ describe('provider registry', () => {
   })
 
   it('resolves model-specific static reasoning effort profiles without network discovery', () => {
+    expect(resolveVendorModelReasoningEffort('openai', 'gpt-5.5')).toEqual({
+      supported: true,
+      slots: ['none', 'low', 'medium', 'high', 'xhigh']
+    })
     expect(resolveVendorModelReasoningEffort('deepseek', 'deepseek-v4-pro')).toEqual({
       supported: true,
-      slots: ['high', 'max', 'max', 'max', 'max']
+      slots: ['none', 'high', 'max', 'max', 'max']
     })
     expect(resolveVendorModelReasoningEffort('stepfun', 'step-3.7-flash')).toEqual({
       supported: true,
@@ -125,18 +129,26 @@ describe('provider registry', () => {
     })
     expect(resolveVendorModelReasoningEffort('openrouter', 'deepseek/deepseek-v4-pro')).toEqual({
       supported: true,
-      slots: ['high', 'max', 'max', 'max', 'max']
+      slots: ['none', 'high', 'xhigh', 'xhigh', 'xhigh']
     })
     expect(resolveVendorModelReasoningEffort('openrouter', 'z-ai/glm-5.2')).toEqual({
       supported: true,
-      slots: ['none', 'high', 'max', 'max', 'max']
+      slots: ['none', 'high', 'xhigh', 'xhigh', 'xhigh']
     })
     expect(resolveVendorModelReasoningEffort('openrouter', 'anthropic/claude-haiku-4.5')).toEqual({
       supported: false
     })
     expect(resolveVendorModelReasoningEffort('openrouter', 'openai/gpt-5.6-terra')).toEqual({
       supported: true,
-      slots: ['low', 'medium', 'high', 'xhigh', 'ultra']
+      slots: ['none', 'low', 'medium', 'high', 'max']
+    })
+    expect(resolveVendorModelReasoningEffort('openrouter', 'openai/gpt-5.5-pro')).toEqual({
+      supported: true,
+      slots: ['medium', 'high', 'xhigh', 'xhigh', 'xhigh']
+    })
+    expect(resolveVendorModelReasoningEffort('openrouter', 'openai/gpt-5.5')).toEqual({
+      supported: true,
+      slots: ['none', 'low', 'medium', 'high', 'xhigh']
     })
     expect(resolveVendorModelReasoningEffort('openrouter', 'moonshotai/kimi-k3')).toEqual({
       supported: true,
@@ -149,11 +161,12 @@ describe('provider registry', () => {
       supported: false
     })
     expect(resolveVendorModelReasoningEffort('openrouter', 'qwen/qwen3.7-max')).toEqual({
-      supported: false
+      supported: true,
+      slots: ['none', 'high', 'high', 'high', 'high']
     })
     expect(resolveVendorModelReasoningEffort('deepseek', undefined)).toEqual({
       supported: true,
-      slots: ['high', 'max', 'max', 'max', 'max']
+      slots: ['none', 'high', 'max', 'max', 'max']
     })
   })
 

--- a/src/shared/provider-registry.test.ts
+++ b/src/shared/provider-registry.test.ts
@@ -12,6 +12,7 @@ import {
   resolveVendorApiKeyUrl,
   resolveVendorBaseUrl,
   resolveVendorModelsUrl,
+  resolveVendorModelReasoningEffort,
   resolveVendorOpenAiBaseUrl,
   vendorHasRegions
 } from './provider-registry'
@@ -24,6 +25,7 @@ describe('provider registry', () => {
 
       expect(hasBaseUrl).not.toBe(hasRegions) // exactly one is set
       expect(vendor.models.length).toBeGreaterThan(0)
+      expect(vendor.reasoningEffort).toBeDefined()
     }
   })
 
@@ -100,6 +102,64 @@ describe('provider registry', () => {
   it('exposes the first catalog entry as the default model', () => {
     expect(defaultVendorModel('openai')).toBe('gpt-5.6-sol')
     expect(defaultVendorModel('zhipu')).toBe('glm-5.2')
+  })
+
+  it('resolves model-specific static reasoning effort profiles without network discovery', () => {
+    expect(resolveVendorModelReasoningEffort('deepseek', 'deepseek-v4-pro')).toEqual({
+      supported: true,
+      slots: ['high', 'max', 'max', 'max', 'max']
+    })
+    expect(resolveVendorModelReasoningEffort('stepfun', 'step-3.7-flash')).toEqual({
+      supported: true,
+      slots: ['low', 'medium', 'high', 'high', 'high']
+    })
+    expect(resolveVendorModelReasoningEffort('anthropic', 'claude-haiku-4-5-20251001')).toEqual({
+      supported: false
+    })
+    expect(resolveVendorModelReasoningEffort('openrouter', 'deepseek/deepseek-v4-pro')).toEqual({
+      supported: true,
+      slots: ['high', 'max', 'max', 'max', 'max']
+    })
+    expect(resolveVendorModelReasoningEffort('openrouter', 'z-ai/glm-5.2')).toEqual({
+      supported: true,
+      slots: ['none', 'high', 'max', 'max', 'max']
+    })
+    expect(resolveVendorModelReasoningEffort('openrouter', 'anthropic/claude-haiku-4.5')).toEqual({
+      supported: false
+    })
+    expect(resolveVendorModelReasoningEffort('openrouter', 'openai/gpt-5.6-terra')).toEqual({
+      supported: true,
+      slots: ['low', 'medium', 'high', 'xhigh', 'ultra']
+    })
+    expect(resolveVendorModelReasoningEffort('openrouter', 'moonshotai/kimi-k3')).toEqual({
+      supported: true,
+      slots: ['low', 'medium', 'high', 'xhigh', 'max']
+    })
+    expect(
+      resolveVendorModelReasoningEffort('openrouter', 'google/gemini-3.1-pro-preview')
+    ).toEqual({ supported: false })
+    expect(resolveVendorModelReasoningEffort('openrouter', 'x-ai/grok-4.5')).toEqual({
+      supported: false
+    })
+    expect(resolveVendorModelReasoningEffort('openrouter', 'qwen/qwen3.7-max')).toEqual({
+      supported: false
+    })
+    expect(resolveVendorModelReasoningEffort('deepseek', undefined)).toEqual({
+      supported: true,
+      slots: ['high', 'max', 'max', 'max', 'max']
+    })
+  })
+
+  it('ships only unsupported or two-to-five-choice static model profiles', () => {
+    for (const vendor of OFFICIAL_VENDORS) {
+      for (const model of vendor.models) {
+        const profile = resolveVendorModelReasoningEffort(vendor.id, model.id)
+        if (!profile.supported) continue
+
+        expect(new Set(profile.slots).size).toBeGreaterThanOrEqual(2)
+        expect(new Set(profile.slots).size).toBeLessThanOrEqual(5)
+      }
+    }
   })
 
   it('exposes a model-list URL only for vendors that provide one', () => {

--- a/src/shared/provider-registry.test.ts
+++ b/src/shared/provider-registry.test.ts
@@ -116,6 +116,13 @@ describe('provider registry', () => {
     expect(resolveVendorModelReasoningEffort('anthropic', 'claude-haiku-4-5-20251001')).toEqual({
       supported: false
     })
+    expect(resolveVendorModelReasoningEffort('minimax', 'MiniMax-M3')).toEqual({
+      supported: true,
+      slots: ['none', 'high', 'high', 'high', 'high']
+    })
+    expect(resolveVendorModelReasoningEffort('minimax', 'MiniMax-M2.7')).toEqual({
+      supported: false
+    })
     expect(resolveVendorModelReasoningEffort('openrouter', 'deepseek/deepseek-v4-pro')).toEqual({
       supported: true,
       slots: ['high', 'max', 'max', 'max', 'max']

--- a/src/shared/provider-registry.ts
+++ b/src/shared/provider-registry.ts
@@ -123,7 +123,12 @@ export const OFFICIAL_VENDORS: OfficialVendor[] = [
         reasoningEffort: 'low-medium-high-xhigh-ultra'
       },
       { id: 'gpt-5.6-luna', contextWindow: 1_050_000, reasoningEffort: 'standard-5' },
-      { id: 'gpt-5.5', contextWindow: 1_050_000 },
+      // GPT-5.5 documents none as its latency-first, no-reasoning mode.
+      {
+        id: 'gpt-5.5',
+        contextWindow: 1_050_000,
+        reasoningEffort: 'none-low-medium-high-xhigh'
+      },
       { id: 'gpt-5.4', contextWindow: 1_050_000 },
       { id: 'gpt-5.4-mini', contextWindow: 400_000 }
     ],
@@ -156,7 +161,8 @@ export const OFFICIAL_VENDORS: OfficialVendor[] = [
   {
     id: 'deepseek',
     label: 'DeepSeek',
-    reasoningEffort: 'high-max',
+    // DeepSeek V4 supports an explicit thinking-off switch plus high/max reasoning effort.
+    reasoningEffort: 'none-high-max',
     // DeepSeek exposes both routes: Anthropic /v1/messages under `/anthropic`, and the OpenAI-compatible
     // route under `/v1`. The same model ids work on both, so it's safe to prefer OpenAI where the
     // framework supports it (e.g. OpenCode). openaiBaseUrl is the exact version-carrying base clients
@@ -480,50 +486,52 @@ export const OFFICIAL_VENDORS: OfficialVendor[] = [
         reasoningEffort: 'unsupported'
       },
       // OpenAI
+      // These profiles are baked from OpenRouter's public model reasoning metadata. Where a model
+      // exposes six values, keep the product's five-option ceiling and span off through its top rung.
       {
         id: 'openai/gpt-5.6-terra-pro',
         contextWindow: 1_050_000,
-        reasoningEffort: 'low-medium-high-xhigh-ultra'
+        reasoningEffort: 'none-low-medium-high-max'
       },
       {
         id: 'openai/gpt-5.6-terra',
         contextWindow: 1_050_000,
-        reasoningEffort: 'low-medium-high-xhigh-ultra'
+        reasoningEffort: 'none-low-medium-high-max'
       },
       {
         id: 'openai/gpt-5.6-sol-pro',
         contextWindow: 1_050_000,
-        reasoningEffort: 'low-medium-high-xhigh-ultra'
+        reasoningEffort: 'none-low-medium-high-max'
       },
       {
         id: 'openai/gpt-5.6-sol',
         contextWindow: 1_050_000,
-        reasoningEffort: 'low-medium-high-xhigh-ultra'
+        reasoningEffort: 'none-low-medium-high-max'
       },
       {
         id: 'openai/gpt-5.6-luna-pro',
         contextWindow: 1_050_000,
-        reasoningEffort: 'standard-5'
+        reasoningEffort: 'none-low-medium-high-max'
       },
       {
         id: 'openai/gpt-5.6-luna',
         contextWindow: 1_050_000,
-        reasoningEffort: 'standard-5'
+        reasoningEffort: 'none-low-medium-high-max'
       },
       {
         id: 'openai/gpt-5.5-pro',
         contextWindow: 1_050_000,
-        reasoningEffort: 'low-medium-high-xhigh'
+        reasoningEffort: 'medium-high-xhigh'
       },
       {
         id: 'openai/gpt-5.5',
         contextWindow: 1_050_000,
-        reasoningEffort: 'low-medium-high-xhigh'
+        reasoningEffort: 'none-low-medium-high-xhigh'
       },
       {
         id: 'openai/gpt-5.3-codex',
         contextWindow: 400_000,
-        reasoningEffort: 'low-medium-high-xhigh'
+        reasoningEffort: 'none-low-medium-high-xhigh'
       },
       // Other top-ranked vendors on OpenRouter
       {
@@ -540,12 +548,12 @@ export const OFFICIAL_VENDORS: OfficialVendor[] = [
       {
         id: 'deepseek/deepseek-v4-pro',
         contextWindow: 1_048_576,
-        reasoningEffort: 'high-max'
+        reasoningEffort: 'none-high-xhigh'
       },
       {
         id: 'z-ai/glm-5.2',
         contextWindow: 1_048_576,
-        reasoningEffort: 'none-high-max'
+        reasoningEffort: 'none-high-xhigh'
       },
       {
         id: 'moonshotai/kimi-k3',
@@ -555,7 +563,7 @@ export const OFFICIAL_VENDORS: OfficialVendor[] = [
       {
         id: 'qwen/qwen3.7-max',
         contextWindow: 1_000_000,
-        reasoningEffort: 'unsupported'
+        reasoningEffort: 'none-high'
       }
     ],
     // OpenRouter's catalog is curated (no live refresh), and vision support is an unpredictable subset

--- a/src/shared/provider-registry.ts
+++ b/src/shared/provider-registry.ts
@@ -8,6 +8,11 @@
 // documented endpoint belongs here, including native Responses providers.
 
 import type { ChatApiEndpoint } from './settings'
+import {
+  resolveReasoningEffortProfile,
+  type ReasoningEffortPresetSetting,
+  type ReasoningEffortProfile
+} from './reasoning-effort'
 
 export type OfficialVendorId =
   | 'openai'
@@ -45,6 +50,8 @@ export type OfficialModel = {
   id: string
   // Advertised context-window size for this exact model, in tokens.
   contextWindow: number
+  // Optional override for a model whose effort levels differ from the vendor default.
+  reasoningEffort?: ReasoningEffortPresetSetting
 }
 
 export type OfficialVendor = {
@@ -58,6 +65,9 @@ export type OfficialVendor = {
   // Model ids offered in the composer once a key is stored. First entry is the default selection when
   // the vendor is first added.
   models: OfficialModel[]
+  // Static model capability used to project the app's five intent slots into the model's real
+  // 2-5 effort choices. Model entries may override it; no runtime capability fetch is required.
+  reasoningEffort: ReasoningEffortPresetSetting
   // Models this vendor is known (via our own dev testing, before release) NOT to drive cleanly over
   // the Codex Responses->Chat bridge. Ships with the app so such models are greyed in the picker
   // rather than user-tested. Absent/empty ⇒ every listed model is bridge-compatible.
@@ -95,15 +105,24 @@ export const OFFICIAL_VENDORS: OfficialVendor[] = [
   {
     id: 'openai',
     label: 'OpenAI',
+    reasoningEffort: 'low-medium-high-xhigh',
     apiEndpoints: ['responses'],
     baseUrl: 'https://api.openai.com',
     apiKeyUrl: 'https://platform.openai.com/api-keys',
     // The API exposes a broader mixed catalog (embeddings, image, and audio models); keep the coding
     // catalog curated here instead of importing every id from /v1/models.
     models: [
-      { id: 'gpt-5.6-sol', contextWindow: 1_050_000 },
-      { id: 'gpt-5.6-terra', contextWindow: 1_050_000 },
-      { id: 'gpt-5.6-luna', contextWindow: 1_050_000 },
+      {
+        id: 'gpt-5.6-sol',
+        contextWindow: 1_050_000,
+        reasoningEffort: 'low-medium-high-xhigh-ultra'
+      },
+      {
+        id: 'gpt-5.6-terra',
+        contextWindow: 1_050_000,
+        reasoningEffort: 'low-medium-high-xhigh-ultra'
+      },
+      { id: 'gpt-5.6-luna', contextWindow: 1_050_000, reasoningEffort: 'standard-5' },
       { id: 'gpt-5.5', contextWindow: 1_050_000 },
       { id: 'gpt-5.4', contextWindow: 1_050_000 },
       { id: 'gpt-5.4-mini', contextWindow: 400_000 }
@@ -114,6 +133,7 @@ export const OFFICIAL_VENDORS: OfficialVendor[] = [
   {
     id: 'anthropic',
     label: 'Anthropic',
+    reasoningEffort: 'standard-5',
     baseUrl: 'https://api.anthropic.com',
     apiKeyUrl: 'https://console.anthropic.com/settings/keys',
     modelsListUrl: 'https://api.anthropic.com/v1/models',
@@ -123,7 +143,11 @@ export const OFFICIAL_VENDORS: OfficialVendor[] = [
       { id: 'claude-opus-4-8', contextWindow: 1_000_000 },
       { id: 'claude-opus-4-8[1m]', contextWindow: 1_000_000 },
       { id: 'claude-sonnet-5', contextWindow: 1_000_000 },
-      { id: 'claude-haiku-4-5-20251001', contextWindow: 200_000 }
+      {
+        id: 'claude-haiku-4-5-20251001',
+        contextWindow: 200_000,
+        reasoningEffort: 'unsupported'
+      }
     ],
     // Every current Claude model is vision-capable, including any surfaced by the live model-list
     // refresh above — so this is a blanket rule, not the four bundled ids.
@@ -132,6 +156,7 @@ export const OFFICIAL_VENDORS: OfficialVendor[] = [
   {
     id: 'deepseek',
     label: 'DeepSeek',
+    reasoningEffort: 'high-max',
     // DeepSeek exposes both routes: Anthropic /v1/messages under `/anthropic`, and the OpenAI-compatible
     // route under `/v1`. The same model ids work on both, so it's safe to prefer OpenAI where the
     // framework supports it (e.g. OpenCode). openaiBaseUrl is the exact version-carrying base clients
@@ -151,6 +176,7 @@ export const OFFICIAL_VENDORS: OfficialVendor[] = [
   {
     id: 'zhipu',
     label: 'Zhipu AI (GLM)',
+    reasoningEffort: 'unsupported',
     // GLM serves overseas from Z.AI and mainland China from BigModel (智谱) — different hosts and
     // separate consoles, so they are distinct endpoints rather than one base URL. Each region also
     // publishes an OpenAI-compatible route under `/api/paas/v4` (not `/v1`), so Codex can bridge it.
@@ -172,7 +198,7 @@ export const OFFICIAL_VENDORS: OfficialVendor[] = [
       }
     ],
     models: [
-      { id: 'glm-5.2', contextWindow: 1_000_000 },
+      { id: 'glm-5.2', contextWindow: 1_000_000, reasoningEffort: 'none-high-max' },
       { id: 'glm-5.1', contextWindow: 200_000 },
       { id: 'glm-5', contextWindow: 200_000 },
       { id: 'glm-5v-turbo', contextWindow: 200_000 },
@@ -185,6 +211,7 @@ export const OFFICIAL_VENDORS: OfficialVendor[] = [
   {
     id: 'glmcodingplan',
     label: 'GLM Coding Plan',
+    reasoningEffort: 'unsupported',
     // The GLM Coding Plan subscription (Z.AI's z.ai/subscribe, BigModel's glm-coding): a quota-based
     // plan that reuses GLM's regions but routes the OpenAI path through `/api/coding/paas/v4` instead
     // of `/api/paas/v4`. The Anthropic route (`/api/anthropic`) is unchanged from the pay-as-you-go
@@ -209,7 +236,7 @@ export const OFFICIAL_VENDORS: OfficialVendor[] = [
     // The coding plan does not serve GLM's vision variant, so glm-5v-turbo is omitted and there is no
     // `multimodal` rule (image input stays disabled for this endpoint).
     models: [
-      { id: 'glm-5.2', contextWindow: 1_000_000 },
+      { id: 'glm-5.2', contextWindow: 1_000_000, reasoningEffort: 'none-high-max' },
       { id: 'glm-5.1', contextWindow: 200_000 },
       { id: 'glm-5', contextWindow: 200_000 },
       { id: 'glm-5-turbo', contextWindow: 200_000 }
@@ -218,6 +245,7 @@ export const OFFICIAL_VENDORS: OfficialVendor[] = [
   {
     id: 'kimi',
     label: 'Kimi (Moonshot)',
+    reasoningEffort: 'standard-5',
     // Moonshot serves both routes on one host: Anthropic /v1/messages under `/anthropic` and the
     // OpenAI-compatible /v1/chat/completions under `/v1` (see the live model list below). `both` lets
     // Codex drive it through the Responses->Chat bridge.
@@ -238,6 +266,7 @@ export const OFFICIAL_VENDORS: OfficialVendor[] = [
   {
     id: 'kimiforcode',
     label: 'Kimi For Coding',
+    reasoningEffort: 'low-high-max',
     // The Kimi Code subscription endpoint: quota-based models (billed against a periodically refreshing
     // quota rather than per token), so it ships a fixed catalog and exposes no live model list. It
     // serves both the Anthropic route and the OpenAI-compatible /v1/chat/completions under `/coding/v1`
@@ -247,7 +276,7 @@ export const OFFICIAL_VENDORS: OfficialVendor[] = [
     openaiBaseUrl: 'https://api.kimi.com/coding/v1',
     apiKeyUrl: 'https://www.kimi.com/code/docs',
     models: [
-      { id: 'kimi-k3', contextWindow: 1_000_000 },
+      { id: 'kimi-k3', contextWindow: 1_000_000, reasoningEffort: 'standard-5' },
       { id: 'kimi-for-coding', contextWindow: 256_000 },
       { id: 'kimi-for-coding-highspeed', contextWindow: 256_000 }
     ],
@@ -257,6 +286,7 @@ export const OFFICIAL_VENDORS: OfficialVendor[] = [
   {
     id: 'minimax',
     label: 'MiniMax',
+    reasoningEffort: 'unsupported',
     // MiniMax serves the Anthropic /v1/messages route under `/anthropic`, plus the OpenAI-compatible
     // /v1/chat/completions and OpenAI Responses /v1/responses under `/v1`, from a Global host (.io) and
     // a mainland-China one (.com). `baseUrl` is the Anthropic route; `openaiBaseUrl` is the `/v1` base
@@ -289,6 +319,7 @@ export const OFFICIAL_VENDORS: OfficialVendor[] = [
   {
     id: 'stepfun',
     label: 'StepFun',
+    reasoningEffort: 'low-medium-high',
     // StepFun serves all three routes on one host per region — Anthropic /v1/messages, the
     // OpenAI-compatible /v1/chat/completions, and OpenAI Responses /v1/responses — from an overseas
     // console (.ai) and a mainland-China one (.com). `baseUrl` is the bare root (the Anthropic client
@@ -323,6 +354,7 @@ export const OFFICIAL_VENDORS: OfficialVendor[] = [
   {
     id: 'stepplan',
     label: 'Step Plan',
+    reasoningEffort: 'low-medium-high',
     // StepFun's Step Plan is a quota-based subscription (platform.stepfun.com/plan-subscribe) that
     // routes under `/step_plan` on the mainland-China host: Anthropic /v1/messages and the
     // OpenAI-compatible /v1/chat/completions. `baseUrl` is the `/step_plan` root the Anthropic client
@@ -337,7 +369,7 @@ export const OFFICIAL_VENDORS: OfficialVendor[] = [
     models: [
       { id: 'step-3.7-flash', contextWindow: 262_144 },
       { id: 'step-3.5-flash', contextWindow: 262_144 },
-      { id: 'step-3.5-flash-2603', contextWindow: 262_144 },
+      { id: 'step-3.5-flash-2603', contextWindow: 262_144, reasoningEffort: 'low-high' },
       { id: 'step-router-v1', contextWindow: 262_144 }
     ],
     // Only the step-3.7-flash flagship is multimodal (vision); the agent/code builds are text-only.
@@ -346,6 +378,7 @@ export const OFFICIAL_VENDORS: OfficialVendor[] = [
   {
     id: 'xiaomimimo',
     label: 'Xiaomi MIMO',
+    reasoningEffort: 'none-high',
     // Xiaomi MiMo exposes both routes: Anthropic /v1/messages under `/anthropic` and the OpenAI-compatible
     // /v1/chat/completions under `/v1`. The same model ids work on both.
     apiEndpoints: ['anthropic', 'openai'],
@@ -362,6 +395,7 @@ export const OFFICIAL_VENDORS: OfficialVendor[] = [
   {
     id: 'sensenova',
     label: 'SenseNova',
+    reasoningEffort: 'unsupported',
     // SenseTime's SenseNova serves both routes on one host: the Anthropic-compatible /v1/messages
     // at the bare root and the OpenAI-compatible /v1/chat/completions under /v1. The same model ids
     // work on both. No modelsListUrl: the live /v1/models list also serves the image-generation-only
@@ -381,6 +415,7 @@ export const OFFICIAL_VENDORS: OfficialVendor[] = [
   {
     id: 'volcengine',
     label: 'Volcengine Ark',
+    reasoningEffort: 'minimal-low-medium-high',
     // ByteDance's Volcengine Ark serves all three routes on one host: the Anthropic-compatible
     // /v1/messages under /api/compatible, the OpenAI-compatible /v1/chat/completions under /api/v3,
     // and OpenAI Responses at /api/v3/responses (the probe derives it from `openaiBaseUrl`). The same
@@ -414,6 +449,9 @@ export const OFFICIAL_VENDORS: OfficialVendor[] = [
   {
     id: 'openrouter',
     label: 'OpenRouter',
+    // The gateway aggregates unrelated model families, so every curated entry below declares its
+    // own capability. Unknown additions stay conservative instead of pretending to support five.
+    reasoningEffort: 'unsupported',
     // Multi-vendor gateway: Anthropic /v1/messages under `/api` and the OpenAI-compatible
     // /v1/chat/completions under `/api/v1`. Its live catalog is 300+ ids, so this ships a curated set of
     // the top models across vendors (no modelsListUrl) rather than a "refresh from vendor" that would
@@ -424,27 +462,99 @@ export const OFFICIAL_VENDORS: OfficialVendor[] = [
     apiKeyUrl: 'https://openrouter.ai/workspaces/default/keys',
     models: [
       // Anthropic
-      { id: 'anthropic/claude-opus-4.8', contextWindow: 1_000_000 },
-      { id: 'anthropic/claude-sonnet-5', contextWindow: 1_000_000 },
-      { id: 'anthropic/claude-haiku-4.5', contextWindow: 200_000 },
+      {
+        id: 'anthropic/claude-opus-4.8',
+        contextWindow: 1_000_000,
+        reasoningEffort: 'standard-5'
+      },
+      {
+        id: 'anthropic/claude-sonnet-5',
+        contextWindow: 1_000_000,
+        reasoningEffort: 'standard-5'
+      },
+      {
+        id: 'anthropic/claude-haiku-4.5',
+        contextWindow: 200_000,
+        reasoningEffort: 'unsupported'
+      },
       // OpenAI
-      { id: 'openai/gpt-5.6-terra-pro', contextWindow: 1_050_000 },
-      { id: 'openai/gpt-5.6-terra', contextWindow: 1_050_000 },
-      { id: 'openai/gpt-5.6-sol-pro', contextWindow: 1_050_000 },
-      { id: 'openai/gpt-5.6-sol', contextWindow: 1_050_000 },
-      { id: 'openai/gpt-5.6-luna-pro', contextWindow: 1_050_000 },
-      { id: 'openai/gpt-5.6-luna', contextWindow: 1_050_000 },
-      { id: 'openai/gpt-5.5-pro', contextWindow: 1_050_000 },
-      { id: 'openai/gpt-5.5', contextWindow: 1_050_000 },
-      { id: 'openai/gpt-5.3-codex', contextWindow: 400_000 },
+      {
+        id: 'openai/gpt-5.6-terra-pro',
+        contextWindow: 1_050_000,
+        reasoningEffort: 'low-medium-high-xhigh-ultra'
+      },
+      {
+        id: 'openai/gpt-5.6-terra',
+        contextWindow: 1_050_000,
+        reasoningEffort: 'low-medium-high-xhigh-ultra'
+      },
+      {
+        id: 'openai/gpt-5.6-sol-pro',
+        contextWindow: 1_050_000,
+        reasoningEffort: 'low-medium-high-xhigh-ultra'
+      },
+      {
+        id: 'openai/gpt-5.6-sol',
+        contextWindow: 1_050_000,
+        reasoningEffort: 'low-medium-high-xhigh-ultra'
+      },
+      {
+        id: 'openai/gpt-5.6-luna-pro',
+        contextWindow: 1_050_000,
+        reasoningEffort: 'standard-5'
+      },
+      {
+        id: 'openai/gpt-5.6-luna',
+        contextWindow: 1_050_000,
+        reasoningEffort: 'standard-5'
+      },
+      {
+        id: 'openai/gpt-5.5-pro',
+        contextWindow: 1_050_000,
+        reasoningEffort: 'low-medium-high-xhigh'
+      },
+      {
+        id: 'openai/gpt-5.5',
+        contextWindow: 1_050_000,
+        reasoningEffort: 'low-medium-high-xhigh'
+      },
+      {
+        id: 'openai/gpt-5.3-codex',
+        contextWindow: 400_000,
+        reasoningEffort: 'low-medium-high-xhigh'
+      },
       // Other top-ranked vendors on OpenRouter
-      { id: 'google/gemini-3.1-pro-preview', contextWindow: 1_048_576 },
-      { id: 'google/gemini-3.5-flash', contextWindow: 1_048_576 },
-      { id: 'x-ai/grok-4.5', contextWindow: 500_000 },
-      { id: 'deepseek/deepseek-v4-pro', contextWindow: 1_048_576 },
-      { id: 'z-ai/glm-5.2', contextWindow: 1_048_576 },
-      { id: 'moonshotai/kimi-k3', contextWindow: 1_048_576 },
-      { id: 'qwen/qwen3.7-max', contextWindow: 1_000_000 }
+      {
+        id: 'google/gemini-3.1-pro-preview',
+        contextWindow: 1_048_576,
+        reasoningEffort: 'unsupported'
+      },
+      {
+        id: 'google/gemini-3.5-flash',
+        contextWindow: 1_048_576,
+        reasoningEffort: 'unsupported'
+      },
+      { id: 'x-ai/grok-4.5', contextWindow: 500_000, reasoningEffort: 'unsupported' },
+      {
+        id: 'deepseek/deepseek-v4-pro',
+        contextWindow: 1_048_576,
+        reasoningEffort: 'high-max'
+      },
+      {
+        id: 'z-ai/glm-5.2',
+        contextWindow: 1_048_576,
+        reasoningEffort: 'none-high-max'
+      },
+      {
+        id: 'moonshotai/kimi-k3',
+        contextWindow: 1_048_576,
+        reasoningEffort: 'standard-5'
+      },
+      {
+        id: 'qwen/qwen3.7-max',
+        contextWindow: 1_000_000,
+        reasoningEffort: 'unsupported'
+      }
     ],
     // OpenRouter's catalog is curated (no live refresh), and vision support is an unpredictable subset
     // across vendors — so it is an explicit id list rather than a blanket rule or pattern. The
@@ -487,6 +597,19 @@ export const getOfficialVendor = (id: OfficialVendorId): OfficialVendor | undefi
 // Projects the structured bundled catalog into the string ids used by settings persistence and UI.
 export const getOfficialVendorModelIds = (id: OfficialVendorId): string[] =>
   VENDORS_BY_ID.get(id)?.models.map((model) => model.id) ?? []
+
+// Resolves the bundled, model-specific effort capability. Unknown/live-fetched model ids use the
+// vendor default; a vendor without an explicit declaration keeps the product's standard five-level
+// compatibility default. This is intentionally synchronous and never consults the network.
+export const resolveVendorModelReasoningEffort = (
+  id: OfficialVendorId,
+  modelId: string | undefined
+): ReasoningEffortProfile => {
+  const vendor = VENDORS_BY_ID.get(id)
+  const model = vendor?.models.find((candidate) => candidate.id === modelId)
+
+  return resolveReasoningEffortProfile(model?.reasoningEffort ?? vendor?.reasoningEffort)
+}
 
 // Resolves the base URL for a vendor, honoring the chosen region and falling back to the first region
 // when none/an unknown one is given. Returns undefined for an unknown vendor.

--- a/src/shared/provider-registry.ts
+++ b/src/shared/provider-registry.ts
@@ -309,8 +309,10 @@ export const OFFICIAL_VENDORS: OfficialVendor[] = [
       }
     ],
     models: [
-      { id: 'MiniMax-M3', contextWindow: 1_000_000 },
-      { id: 'MiniMax-M3[1m]', contextWindow: 1_000_000 },
+      // MiniMax documents M3 reasoning as a binary thinking switch: none disables thinking and high
+      // enables Adaptive Thinking. Older M2 models remain conservative until documented otherwise.
+      { id: 'MiniMax-M3', contextWindow: 1_000_000, reasoningEffort: 'none-high' },
+      { id: 'MiniMax-M3[1m]', contextWindow: 1_000_000, reasoningEffort: 'none-high' },
       { id: 'MiniMax-M2.7', contextWindow: 204_800 },
       { id: 'MiniMax-M2.5', contextWindow: 204_800 }
     ]

--- a/src/shared/reasoning-effort.test.ts
+++ b/src/shared/reasoning-effort.test.ts
@@ -43,6 +43,22 @@ describe('resolveReasoningEffortControl', () => {
     expect(control.selectedValue).toBe('max')
   })
 
+  it('includes a true off option for a five-level model that supports none', () => {
+    const control = resolveReasoningEffortControl(
+      'low',
+      reasoningEffortProfile('none-low-medium-high-xhigh')
+    )
+
+    expect(control.options.map((option) => option.value)).toEqual([
+      'none',
+      'low',
+      'medium',
+      'high',
+      'xhigh'
+    ])
+    expect(control.selectedValue).toBe('none')
+  })
+
   it('shows two options when the model only distinguishes high and max', () => {
     const control = resolveReasoningEffortControl('high', reasoningEffortProfile('high-max'))
 

--- a/src/shared/reasoning-effort.test.ts
+++ b/src/shared/reasoning-effort.test.ts
@@ -1,0 +1,87 @@
+import { describe, expect, it } from 'vitest'
+
+import {
+  isReasoningEffortPresetSetting,
+  reasoningEffortProfile,
+  resolveReasoningEffortValue,
+  resolveReasoningEffortProfile,
+  resolveReasoningEffortControl
+} from './reasoning-effort'
+
+describe('isReasoningEffortPresetSetting', () => {
+  it('accepts supported presets and the explicit unsupported setting', () => {
+    expect(isReasoningEffortPresetSetting('standard-5')).toBe(true)
+    expect(isReasoningEffortPresetSetting('none-high')).toBe(true)
+    expect(isReasoningEffortPresetSetting('unsupported')).toBe(true)
+  })
+
+  it('rejects unknown and non-string settings', () => {
+    expect(isReasoningEffortPresetSetting('dynamic')).toBe(false)
+    expect(isReasoningEffortPresetSetting(5)).toBe(false)
+  })
+})
+
+describe('resolveReasoningEffortControl', () => {
+  it('shows three model options and lets the highest option cover the upper user intents', () => {
+    const control = resolveReasoningEffortControl('max', reasoningEffortProfile('low-medium-high'))
+
+    expect(control.options.map((option) => option.value)).toEqual(['low', 'medium', 'high'])
+    expect(control.selectedValue).toBe('high')
+    expect(control.options.at(-1)?.intent).toBe('max')
+  })
+
+  it('shows every option for a five-level model', () => {
+    const control = resolveReasoningEffortControl('max', reasoningEffortProfile('standard-5'))
+
+    expect(control.options.map((option) => option.value)).toEqual([
+      'low',
+      'medium',
+      'high',
+      'xhigh',
+      'max'
+    ])
+    expect(control.selectedValue).toBe('max')
+  })
+
+  it('shows two options when the model only distinguishes high and max', () => {
+    const control = resolveReasoningEffortControl('high', reasoningEffortProfile('high-max'))
+
+    expect(control.options.map((option) => option.value)).toEqual(['high', 'max'])
+    expect(control.selectedValue).toBe('max')
+    expect(control.options[1].intent).toBe('max')
+  })
+
+  it('lets the highest option of a four-level model cover the top two intents', () => {
+    const control = resolveReasoningEffortControl(
+      'max',
+      reasoningEffortProfile('low-medium-high-max')
+    )
+
+    expect(control.options.map((option) => option.value)).toEqual(['low', 'medium', 'high', 'max'])
+    expect(control.selectedValue).toBe('max')
+    expect(control.options.at(-1)?.intent).toBe('max')
+  })
+
+  it('defaults an unconfigured custom model to the standard five-level profile', () => {
+    expect(resolveReasoningEffortProfile(undefined)).toEqual(reasoningEffortProfile('standard-5'))
+  })
+
+  it('preserves an explicit custom-model unsupported choice', () => {
+    expect(resolveReasoningEffortProfile('unsupported')).toEqual({ supported: false })
+  })
+})
+
+describe('resolveReasoningEffortValue', () => {
+  it('projects a five-slot intent onto the active model profile', () => {
+    expect(resolveReasoningEffortValue('xhigh', reasoningEffortProfile('low-medium-high'))).toBe(
+      'high'
+    )
+  })
+
+  it('uses the default sentinel when the user or model disables an override', () => {
+    expect(resolveReasoningEffortValue('default', reasoningEffortProfile('standard-5'))).toBe(
+      'default'
+    )
+    expect(resolveReasoningEffortValue('max', { supported: false })).toBe('default')
+  })
+})

--- a/src/shared/reasoning-effort.ts
+++ b/src/shared/reasoning-effort.ts
@@ -26,6 +26,32 @@ export type ReasoningEffortPresetId =
 
 export type ReasoningEffortPresetSetting = ReasoningEffortPresetId | 'unsupported'
 
+// Custom gateways can expose the same model-effort vocabulary through different wire shapes. Keep
+// this explicit instead of guessing from a user-entered URL or model id: a compatible proxy may use
+// any hostname while still requiring its upstream provider's native request body.
+export type CustomReasoningEffortTransport =
+  'reasoning-effort' | 'deepseek' | 'minimax' | 'xiaomimimo' | 'openrouter'
+
+export const CUSTOM_REASONING_EFFORT_TRANSPORTS: ReadonlyArray<{
+  id: CustomReasoningEffortTransport
+  label: string
+}> = [
+  { id: 'reasoning-effort', label: 'OpenAI-compatible reasoning_effort' },
+  { id: 'deepseek', label: 'DeepSeek thinking + effort' },
+  { id: 'minimax', label: 'MiniMax adaptive thinking' },
+  { id: 'xiaomimimo', label: 'MiMo thinking switch' },
+  { id: 'openrouter', label: 'OpenRouter reasoning object' }
+]
+
+const CUSTOM_REASONING_EFFORT_TRANSPORT_IDS = new Set<string>(
+  CUSTOM_REASONING_EFFORT_TRANSPORTS.map(({ id }) => id)
+)
+
+export const isCustomReasoningEffortTransport = (
+  value: unknown
+): value is CustomReasoningEffortTransport =>
+  typeof value === 'string' && CUSTOM_REASONING_EFFORT_TRANSPORT_IDS.has(value)
+
 export const CUSTOM_REASONING_EFFORT_PRESETS: ReadonlyArray<{
   id: ReasoningEffortPresetId
   label: string

--- a/src/shared/reasoning-effort.ts
+++ b/src/shared/reasoning-effort.ts
@@ -1,0 +1,172 @@
+import type { ReasoningEffort } from './settings'
+
+export type ModelReasoningEffort =
+  'none' | 'minimal' | 'low' | 'medium' | 'high' | 'xhigh' | 'max' | 'ultra'
+
+// The concrete value delivered to an agent/model adapter after the active model profile projects
+// the app's five intent slots. `default` is the explicit sentinel for omitting an effort parameter.
+export type ResolvedReasoningEffort = ModelReasoningEffort | 'default'
+
+export type ReasoningEffortPresetId =
+  | 'standard-5'
+  | 'low-medium-high-xhigh'
+  | 'low-medium-high-xhigh-ultra'
+  | 'low-medium-high-max'
+  | 'low-medium-high'
+  | 'minimal-low-medium-high'
+  | 'none-high-max'
+  | 'low-high-max'
+  | 'none-high'
+  | 'low-high'
+  | 'high-max'
+
+export type ReasoningEffortPresetSetting = ReasoningEffortPresetId | 'unsupported'
+
+export const CUSTOM_REASONING_EFFORT_PRESETS: ReadonlyArray<{
+  id: ReasoningEffortPresetId
+  label: string
+}> = [
+  { id: 'standard-5', label: 'Low / Medium / High / XHigh / Max' },
+  { id: 'low-medium-high-xhigh-ultra', label: 'Low / Medium / High / XHigh / Ultra' },
+  { id: 'low-medium-high-max', label: 'Low / Medium / High / Max' },
+  { id: 'low-medium-high-xhigh', label: 'Low / Medium / High / XHigh' },
+  { id: 'minimal-low-medium-high', label: 'Minimal / Low / Medium / High' },
+  { id: 'low-medium-high', label: 'Low / Medium / High' },
+  { id: 'none-high-max', label: 'None / High / Max' },
+  { id: 'low-high-max', label: 'Low / High / Max' },
+  { id: 'high-max', label: 'High / Max' },
+  { id: 'none-high', label: 'None / High' },
+  { id: 'low-high', label: 'Low / High' }
+]
+
+export type ReasoningEffortProfile =
+  | { supported: false }
+  | {
+      supported: true
+      slots: readonly [
+        ModelReasoningEffort,
+        ModelReasoningEffort,
+        ModelReasoningEffort,
+        ModelReasoningEffort,
+        ModelReasoningEffort
+      ]
+    }
+
+export type ReasoningEffortOption = {
+  value: ModelReasoningEffort
+  label: string
+  intent: Exclude<ReasoningEffort, 'default'>
+}
+
+export type ReasoningEffortControl = {
+  options: ReasoningEffortOption[]
+  selectedValue?: ModelReasoningEffort
+}
+
+const INTENTS: readonly Exclude<ReasoningEffort, 'default'>[] = [
+  'low',
+  'medium',
+  'high',
+  'xhigh',
+  'max'
+]
+
+const PROFILES: Record<ReasoningEffortPresetId, ReasoningEffortProfile> = {
+  'standard-5': {
+    supported: true,
+    slots: ['low', 'medium', 'high', 'xhigh', 'max']
+  },
+  'low-medium-high-xhigh': {
+    supported: true,
+    slots: ['low', 'medium', 'high', 'xhigh', 'xhigh']
+  },
+  'low-medium-high-xhigh-ultra': {
+    supported: true,
+    slots: ['low', 'medium', 'high', 'xhigh', 'ultra']
+  },
+  'low-medium-high-max': {
+    supported: true,
+    slots: ['low', 'medium', 'high', 'max', 'max']
+  },
+  'low-medium-high': {
+    supported: true,
+    slots: ['low', 'medium', 'high', 'high', 'high']
+  },
+  'minimal-low-medium-high': {
+    supported: true,
+    slots: ['minimal', 'low', 'medium', 'high', 'high']
+  },
+  'none-high-max': {
+    supported: true,
+    slots: ['none', 'high', 'max', 'max', 'max']
+  },
+  'low-high-max': {
+    supported: true,
+    slots: ['low', 'high', 'max', 'max', 'max']
+  },
+  'none-high': {
+    supported: true,
+    slots: ['none', 'high', 'high', 'high', 'high']
+  },
+  'low-high': {
+    supported: true,
+    slots: ['low', 'high', 'high', 'high', 'high']
+  },
+  'high-max': {
+    supported: true,
+    slots: ['high', 'max', 'max', 'max', 'max']
+  }
+}
+
+const REASONING_EFFORT_PRESET_SETTINGS = new Set<string>([...Object.keys(PROFILES), 'unsupported'])
+
+export const isReasoningEffortPresetSetting = (
+  value: unknown
+): value is ReasoningEffortPresetSetting =>
+  typeof value === 'string' && REASONING_EFFORT_PRESET_SETTINGS.has(value)
+
+export const reasoningEffortProfile = (preset: ReasoningEffortPresetId): ReasoningEffortProfile =>
+  PROFILES[preset]
+
+export const resolveReasoningEffortProfile = (
+  preset: ReasoningEffortPresetSetting | undefined
+): ReasoningEffortProfile =>
+  preset === 'unsupported' ? { supported: false } : reasoningEffortProfile(preset ?? 'standard-5')
+
+export const resolveReasoningEffortValue = (
+  intent: ReasoningEffort,
+  profile: ReasoningEffortProfile
+): ResolvedReasoningEffort => {
+  if (intent === 'default' || !profile.supported) return 'default'
+
+  return profile.slots[INTENTS.indexOf(intent)]
+}
+
+const effortLabel = (value: ModelReasoningEffort): string =>
+  value === 'xhigh' ? 'XHigh' : value.charAt(0).toUpperCase() + value.slice(1)
+
+export const resolveReasoningEffortControl = (
+  intent: ReasoningEffort,
+  profile: ReasoningEffortProfile
+): ReasoningEffortControl => {
+  if (!profile.supported) return { options: [] }
+
+  const lastIntentByValue = new Map<ModelReasoningEffort, Exclude<ReasoningEffort, 'default'>>()
+
+  profile.slots.forEach((value, index) => {
+    lastIntentByValue.set(value, INTENTS[Math.min(index, INTENTS.length - 1)])
+  })
+
+  const options = [...lastIntentByValue.entries()].map(([value, optionIntent]) => ({
+    value,
+    label: effortLabel(value),
+    intent: optionIntent
+  }))
+
+  const selectedValue = resolveReasoningEffortValue(intent, profile)
+
+  return {
+    options,
+    selectedValue: selectedValue === 'default' ? undefined : selectedValue
+  }
+}

--- a/src/shared/reasoning-effort.ts
+++ b/src/shared/reasoning-effort.ts
@@ -12,9 +12,13 @@ export type ReasoningEffortPresetId =
   | 'low-medium-high-xhigh'
   | 'low-medium-high-xhigh-ultra'
   | 'low-medium-high-max'
+  | 'none-low-medium-high-xhigh'
+  | 'none-low-medium-high-max'
   | 'low-medium-high'
+  | 'medium-high-xhigh'
   | 'minimal-low-medium-high'
   | 'none-high-max'
+  | 'none-high-xhigh'
   | 'low-high-max'
   | 'none-high'
   | 'low-high'
@@ -30,9 +34,13 @@ export const CUSTOM_REASONING_EFFORT_PRESETS: ReadonlyArray<{
   { id: 'low-medium-high-xhigh-ultra', label: 'Low / Medium / High / XHigh / Ultra' },
   { id: 'low-medium-high-max', label: 'Low / Medium / High / Max' },
   { id: 'low-medium-high-xhigh', label: 'Low / Medium / High / XHigh' },
+  { id: 'none-low-medium-high-xhigh', label: 'None / Low / Medium / High / XHigh' },
+  { id: 'none-low-medium-high-max', label: 'None / Low / Medium / High / Max' },
   { id: 'minimal-low-medium-high', label: 'Minimal / Low / Medium / High' },
   { id: 'low-medium-high', label: 'Low / Medium / High' },
+  { id: 'medium-high-xhigh', label: 'Medium / High / XHigh' },
   { id: 'none-high-max', label: 'None / High / Max' },
+  { id: 'none-high-xhigh', label: 'None / High / XHigh' },
   { id: 'low-high-max', label: 'Low / High / Max' },
   { id: 'high-max', label: 'High / Max' },
   { id: 'none-high', label: 'None / High' },
@@ -88,9 +96,21 @@ const PROFILES: Record<ReasoningEffortPresetId, ReasoningEffortProfile> = {
     supported: true,
     slots: ['low', 'medium', 'high', 'max', 'max']
   },
+  'none-low-medium-high-xhigh': {
+    supported: true,
+    slots: ['none', 'low', 'medium', 'high', 'xhigh']
+  },
+  'none-low-medium-high-max': {
+    supported: true,
+    slots: ['none', 'low', 'medium', 'high', 'max']
+  },
   'low-medium-high': {
     supported: true,
     slots: ['low', 'medium', 'high', 'high', 'high']
+  },
+  'medium-high-xhigh': {
+    supported: true,
+    slots: ['medium', 'high', 'xhigh', 'xhigh', 'xhigh']
   },
   'minimal-low-medium-high': {
     supported: true,
@@ -99,6 +119,10 @@ const PROFILES: Record<ReasoningEffortPresetId, ReasoningEffortProfile> = {
   'none-high-max': {
     supported: true,
     slots: ['none', 'high', 'max', 'max', 'max']
+  },
+  'none-high-xhigh': {
+    supported: true,
+    slots: ['none', 'high', 'xhigh', 'xhigh', 'xhigh']
   },
   'low-high-max': {
     supported: true,

--- a/src/shared/settings.ts
+++ b/src/shared/settings.ts
@@ -5,7 +5,10 @@
 // only while the user is actively typing one in.
 
 import type { OfficialVendorId } from './provider-registry'
-import type { ReasoningEffortPresetSetting } from './reasoning-effort'
+import type {
+  CustomReasoningEffortTransport,
+  ReasoningEffortPresetSetting
+} from './reasoning-effort'
 import type { PackageMirror } from './mirror'
 import type { CloseActionPreference } from './window-controls'
 
@@ -218,6 +221,9 @@ export type ProviderView = {
   supportsImageInput: boolean
   // Custom-model effort declaration. Absence intentionally means the standard five-level preset.
   reasoningEffortPreset?: ReasoningEffortPresetSetting
+  // Request-body shape used to deliver the selected effort to a custom model endpoint. Absence uses
+  // the broadly compatible `reasoning_effort` field for existing settings.
+  reasoningEffortTransport?: CustomReasoningEffortTransport
   // Set for official-vendor providers: which vendor and (where applicable) which regional endpoint.
   vendorId?: OfficialVendorId
   region?: string
@@ -414,6 +420,8 @@ export type ProviderDraft = {
   supportsImageInput?: boolean
   // Optional custom-model effort declaration. Absence defaults to the standard five-level preset.
   reasoningEffortPreset?: ReasoningEffortPresetSetting
+  // Optional custom-gateway request shape. Absence defaults to the literal `reasoning_effort` field.
+  reasoningEffortTransport?: CustomReasoningEffortTransport
   // Which chat APIs a custom gateway speaks (form selector). Official providers take it from the
   // registry; omitted defaults to ['anthropic'].
   apiEndpoints?: ChatApiEndpoint[]

--- a/src/shared/settings.ts
+++ b/src/shared/settings.ts
@@ -5,6 +5,7 @@
 // only while the user is actively typing one in.
 
 import type { OfficialVendorId } from './provider-registry'
+import type { ReasoningEffortPresetSetting } from './reasoning-effort'
 import type { PackageMirror } from './mirror'
 import type { CloseActionPreference } from './window-controls'
 
@@ -215,6 +216,8 @@ export type ProviderView = {
   // User-configured context-window size for a custom model. Omitted means the runtime uses 200k.
   contextWindow?: number
   supportsImageInput: boolean
+  // Custom-model effort declaration. Absence intentionally means the standard five-level preset.
+  reasoningEffortPreset?: ReasoningEffortPresetSetting
   // Set for official-vendor providers: which vendor and (where applicable) which regional endpoint.
   vendorId?: OfficialVendorId
   region?: string
@@ -256,9 +259,9 @@ export type AgentFrameworkId = 'claude-code' | 'opencode' | 'codex'
 
 // How much reasoning effort the user asks the agent to spend. 'default' means "don't override": the
 // agent keeps its own default and nothing is sent. The concrete levels form a relative scale
-// (low < medium < high < max): each agent/model maps the level onto its own supported rungs, using
-// the closest one it has (e.g. 'max' becomes the model's top level).
-export type ReasoningEffort = 'default' | 'low' | 'medium' | 'high' | 'max'
+// (low < medium < high < xhigh < max): the active model's static profile maps the level onto its
+// concrete supported rungs (e.g. 'max' becomes the model's top level).
+export type ReasoningEffort = 'default' | 'low' | 'medium' | 'high' | 'xhigh' | 'max'
 
 export const DEFAULT_REASONING_EFFORT: ReasoningEffort = 'default'
 
@@ -266,7 +269,14 @@ export const DEFAULT_REASONING_EFFORT: ReasoningEffort = 'default'
 // is unfocused, so the default surprises no one staring at the window.
 export const DEFAULT_NOTIFICATIONS_ENABLED = true
 
-const REASONING_EFFORTS: readonly ReasoningEffort[] = ['default', 'low', 'medium', 'high', 'max']
+const REASONING_EFFORTS: readonly ReasoningEffort[] = [
+  'default',
+  'low',
+  'medium',
+  'high',
+  'xhigh',
+  'max'
+]
 
 // Runtime guard for untrusted values (IPC payloads, settings.json): only the known levels pass.
 export const isReasoningEffort = (value: unknown): value is ReasoningEffort =>
@@ -402,6 +412,8 @@ export type ProviderDraft = {
   // leaves it unchanged on partial edits. A provider with no override resolves to 200k at runtime.
   contextWindow?: number | null
   supportsImageInput?: boolean
+  // Optional custom-model effort declaration. Absence defaults to the standard five-level preset.
+  reasoningEffortPreset?: ReasoningEffortPresetSetting
   // Which chat APIs a custom gateway speaks (form selector). Official providers take it from the
   // registry; omitted defaults to ['anthropic'].
   apiEndpoints?: ChatApiEndpoint[]


### PR DESCRIPTION
## Problem

Reasoning effort was treated as one framework-level scale even though supported values belong to the selected model API. Framework adapters independently handled values, and custom models could not declare their actual capability set.

## Proposed change

- Add static per-provider and per-model effort profiles with five stable user-intent slots.
- Render only the selected model real concrete choices, plus a separate Default option.
- Let custom models enable or disable effort and choose a common 2-5 level preset; legacy/unconfigured custom models default to five levels.
- Resolve intent once in SettingsService, then let Claude Code, OpenCode, Codex, ACP, and the Responses bridge carry that resolved value.
- Encode resolved values into each framework valid transport vocabulary; preserve exact model-native values through the Codex Chat bridge upstream override.
- Keep live changes scoped to the active runtime and its bridge, including deferred provider reconnects.

## Scope and non-goals

- Provider and model switching performs no capability network request and uses no capability cache.
- Unknown OpenRouter model families are conservative and do not advertise unverified effort controls.
- Framework transport encoding does not alter the persisted five-slot user intent or model capability profile.

## Acceptance criteria and validation

- Built-in and custom model profiles synchronously refresh the effort control.
- Two-, three-, four-, and five-level profiles preserve relative intent across model switches.
- Agent framework switching does not change model effort choices.
- ACP uses exact matching; Codex and OpenCode generated configs contain only values valid for their transport vocabularies.
- npm run typecheck passes.
- npm run lint passes with 0 errors; 24 pre-existing unrelated warnings remain.
- npm test passes: 487 files, 6,774 tests; 10 files and 112 tests skipped.

## Review focus

Please focus on the static profile assignments, intent-slot projection, subscription-provider parity, framework transport encoders, and the active-versus-retiring runtime boundary for live effort changes.