### PR TITLE
ci(dependabot): pause version updates

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -6,7 +6,7 @@ updates:
     directory: /
     schedule:
       interval: weekly
-    open-pull-requests-limit: 5
+    open-pull-requests-limit: 0
     groups:
       # Batch low-risk dev/tooling bumps into one PR to cut review noise.
       dev-dependencies:
@@ -17,4 +17,4 @@ updates:
     directory: /
     schedule:
       interval: weekly
-    open-pull-requests-limit: 5
+    open-pull-requests-limit: 0


### PR DESCRIPTION
## Problem

Dependabot currently opens scheduled version-update pull requests for both npm dependencies and GitHub Actions. These updates need to be paused temporarily.

## Proposed change

Set `open-pull-requests-limit` to `0` for the npm and GitHub Actions ecosystems.

## Scope and non-goals

- Pauses new Dependabot version-update pull requests for both configured ecosystems.
- Does not disable Dependabot security updates.
- Does not close existing Dependabot pull requests.

## Acceptance criteria and validation

- Both configured ecosystems have an open pull request limit of zero.
- `.github/dependabot.yml` parses successfully with `js-yaml`.
- `npm run typecheck`
- `npm run lint` (passes with existing warnings)
- `npm run test` (487 files passed, 10 skipped; 6,773 tests passed, 112 skipped)

## Review focus

Confirm that scheduled version updates are paused for both npm and GitHub Actions while security updates remain enabled.
