### PR TITLE
fix(skills): allow importing referenced uploads

### DIFF
--- a/src/main/acp/ipc.test.ts
+++ b/src/main/acp/ipc.test.ts
@@ -134,6 +134,7 @@ const registerWithFakes = (overrides?: {
     runRegistry: {} as never,
     uploadRepository: {} as never,
     notebookRpcServer: {} as never,
+    authorizeSkillImportReferencedUploads: vi.fn(async () => () => undefined),
     settingsService: {
       captureActiveAgentBackendSelection: vi.fn().mockResolvedValue({}),
       resolveAgentBackend: vi.fn().mockResolvedValue({})

--- a/src/main/acp/ipc.ts
+++ b/src/main/acp/ipc.ts
@@ -48,6 +48,7 @@ type AcpIpcOptions = AcpIpcArtifacts & {
   mcpEntryPath: string
   uploadRepository: UploadRepository
   notebookRpcServer: NotebookLocalRpcServer
+  authorizeSkillImportReferencedUploads: (sessionId: string, paths: string[]) => Promise<() => void>
   // Drives the agent spawn env from the active provider so switching takes effect on reconnect.
   settingsService: SettingsService
   initializationBarrier?: Promise<unknown>
@@ -88,6 +89,7 @@ const createRuntime = ({
   runRegistry,
   uploadRepository,
   notebookRpcServer,
+  authorizeSkillImportReferencedUploads,
   settingsService,
   initializationBarrier,
   taskNotifications,
@@ -156,7 +158,8 @@ const createRuntime = ({
           mcpEntryPath,
           getRpcConnection: () => notebookRpcServer.ensureStarted(),
           registerSessionAlias: (aliasSessionId, sessionId) =>
-            notebookRpcServer.registerSessionAlias(aliasSessionId, sessionId)
+            notebookRpcServer.registerSessionAlias(aliasSessionId, sessionId),
+          authorizeReferencedUploads: authorizeSkillImportReferencedUploads
         },
         activityGroups: { mcpEntryPath },
         callbacks: runtimeCallbacks,

--- a/src/main/acp/runtime.test.ts
+++ b/src/main/acp/runtime.test.ts
@@ -8,7 +8,7 @@ import type {
 } from '@agentclientprotocol/sdk'
 import type { ChildProcessWithoutNullStreams } from 'node:child_process'
 import { EventEmitter } from 'node:events'
-import { mkdir, mkdtemp, readFile, readdir, rm, stat, writeFile } from 'node:fs/promises'
+import { mkdir, mkdtemp, readFile, readdir, realpath, rm, stat, writeFile } from 'node:fs/promises'
 import { tmpdir } from 'node:os'
 import { join, resolve } from 'node:path'
 import { PassThrough, Readable, Writable } from 'node:stream'
@@ -30,6 +30,7 @@ import {
 import type { UploadedAttachment } from '../../shared/uploads'
 import { UploadRepository } from '../uploads/repository'
 import { MAX_INLINE_IMAGE_TOTAL_BASE64_BYTES } from '../uploads/attachment-media'
+import { ConversationSkillImporter, SkillImportApprovalBroker } from '../skills/conversation-import'
 import {
   beginMigration,
   clearMigrationPending,
@@ -2345,6 +2346,140 @@ describe('ACP runtime session management', () => {
         /<attached_local_archive>[\s\S]*other\.skill[\s\S]*"skillImportEligible":false/
       )
     })
+  })
+
+  it('allows a cross-session Skill upload only while the user explicitly references it', async () => {
+    const root = await realpath(await createTemporaryRoot())
+    const uploads = new UploadRepository(root)
+    const [staged] = await uploads.stageFiles({
+      files: [
+        {
+          name: 'paper-finder.skill',
+          mimeType: 'application/zip',
+          content: buildStoredSkillArchive('Paper Finder').toString('base64')
+        }
+      ]
+    })
+    const [attachment] = await uploads.finalizePendingSessionUploads('owning-session', [staged])
+    const approvalBroker = new SkillImportApprovalBroker({
+      generateId: () => 'approval-1',
+      broadcast: vi.fn()
+    })
+    const importer = new ConversationSkillImporter({
+      uploads,
+      createCancellationGuard: (sessionId, turnToken, attachmentUri) =>
+        approvalBroker.createCancellationGuard(sessionId, turnToken, attachmentUri),
+      previewBundle: async () => ({
+        previews: [
+          {
+            subPath: 'paper-finder',
+            name: 'Paper Finder',
+            description: 'Finds papers.',
+            metadata: {},
+            body: 'Follow the workflow.',
+            files: ['SKILL.md'],
+            alreadyImported: false
+          }
+        ],
+        skipped: []
+      }),
+      importBundle: async (_bundle, items) =>
+        items.map((item) => ({
+          subPath: item.subPath,
+          outcome: { status: 'imported' as const, id: 'imported-paper-finder' }
+        })),
+      requestApproval: async (request) => ({
+        id: 'approval-1',
+        items: [{ subPath: request.previews[0].subPath }]
+      })
+    })
+    let importResult: Awaited<ReturnType<ConversationSkillImporter['request']>> | undefined
+    let activeTurnToken: string | undefined
+    let advertisedAttachmentUri: string | undefined
+    let promptError: unknown
+    const process = new FakeAgentProcess()
+    startFakeAgent(process, ['current-session'], {
+      onPrompt: async ({ prompt }) => {
+        try {
+          if (!activeTurnToken) throw new Error('Expected an active Skill import turn token.')
+          const reference = prompt.find(
+            (block) => block.type === 'text' && block.text.includes('<attached_skill_package>')
+          )
+          if (reference?.type !== 'text') {
+            throw new Error('Expected an import-eligible Skill package reference.')
+          }
+          advertisedAttachmentUri = (JSON.parse(reference.text.split('\n')[1]) as { uri: string })
+            .uri
+          importResult = await importer.request({
+            sessionId: 'current-session',
+            turnToken: activeTurnToken,
+            attachmentUri: advertisedAttachmentUri
+          })
+        } catch (error) {
+          promptError = error
+        }
+      }
+    })
+    const runtime = new AcpRuntime({
+      appVersion: '0.1.0',
+      defaultCwd: '/workspace',
+      spawnAgent: () => asAgentProcess(process),
+      uploads: { repository: uploads },
+      skillImport: {
+        mcpEntryPath: '/app/out/main/index.js',
+        getRpcConnection: async () => ({
+          endpoint: 'http://127.0.0.1:4567',
+          token: 'secret-token'
+        }),
+        authorizeReferencedUploads: (sessionId, paths) =>
+          importer.authorizeReferencedUploads(sessionId, paths)
+      },
+      callbacks: {
+        onPromptStarted: (sessionId, turnToken) => {
+          activeTurnToken = turnToken
+          approvalBroker.beginSessionTurn(sessionId, turnToken)
+        },
+        onPromptEnded: (sessionId, turnToken) =>
+          approvalBroker.endSessionTurn(sessionId, turnToken),
+        onSkillImportAttachmentEligible: (sessionId, turnToken, attachmentUri) =>
+          approvalBroker.allowSessionTurnAttachment(sessionId, turnToken, attachmentUri)
+      }
+    })
+
+    const session = await runtime.createSession({ cwd: '/workspace' })
+    await runtime.sendPrompt({
+      sessionId: session.sessionId,
+      text: 'import @Paper Finder',
+      referencedArtifacts: [
+        {
+          id: 'upload-1',
+          name: attachment.originalName,
+          path: attachment.path,
+          source: 'upload',
+          mimeType: attachment.mimeType
+        }
+      ]
+    })
+
+    expect(promptError).toBeUndefined()
+    expect(importResult).toEqual({
+      status: 'imported',
+      skills: [{ id: 'imported-paper-finder', name: 'Paper Finder', status: 'imported' }]
+    })
+    if (!advertisedAttachmentUri) throw new Error('Expected an advertised Skill attachment URI.')
+    approvalBroker.beginSessionTurn(session.sessionId, 'retry-turn')
+    approvalBroker.allowSessionTurnAttachment(
+      session.sessionId,
+      'retry-turn',
+      advertisedAttachmentUri
+    )
+    await expect(
+      importer.request({
+        sessionId: session.sessionId,
+        turnToken: 'retry-turn',
+        attachmentUri: advertisedAttachmentUri
+      })
+    ).rejects.toThrow('different session')
   })
 
   it('resolves a bare-filename artifact write against the final-session notebook dir despite the alias', async () => {

--- a/src/main/acp/runtime.ts
+++ b/src/main/acp/runtime.ts
@@ -253,6 +253,7 @@ type AcpRuntimeSkillImportOptions = {
   mcpCommand?: string
   getRpcConnection: () => Promise<SkillImportRpcConnection>
   registerSessionAlias?: (aliasSessionId: string, sessionId: string) => void
+  authorizeReferencedUploads?: (sessionId: string, paths: string[]) => Promise<() => void>
 }
 
 type AcpRuntimeActivityGroupOptions = {
@@ -2293,6 +2294,7 @@ class AcpRuntime {
     let skillActivityInputs: Array<{ name: string; path: string }> = []
     let skillActivitiesStarted = false
     let skillActivitiesFinalized = false
+    let revokeReferencedUploadGrant: (() => void) | undefined
 
     try {
       // Create a fresh run context before prompting so MCP writes can be attributed to this turn.
@@ -2381,6 +2383,10 @@ class AcpRuntime {
       const promptText = [request.historyPreamble, promptPrefix, nudgedText]
         .filter((segment): segment is string => Boolean(segment))
         .join('\n\n')
+      revokeReferencedUploadGrant = await this.authorizeReferencedSkillUploads(
+        request.sessionId,
+        request.referencedArtifacts ?? []
+      )
       const promptContent = this.attachCodexSkillInputs(
         await this.createPromptContent(request.sessionId, {
           ...request,
@@ -2493,6 +2499,7 @@ class AcpRuntime {
       })
       throw error
     } finally {
+      revokeReferencedUploadGrant?.()
       // A turn that fails or is aborted never reaches the stop branch; still surface any files it
       // wrote so they are attached to a message instead of being orphaned in the pending directory.
       if (!artifactEmitted) {
@@ -2900,6 +2907,27 @@ class AcpRuntime {
     return contentBlocks
   }
 
+  // Converts the user's explicit `@` selections into a turn-scoped capability for Skill import.
+  // Generic managed-path validation happens before the grant; the importer retains the stricter
+  // session-owner check for every path that was not selected in this turn.
+  private async authorizeReferencedSkillUploads(
+    sessionId: string,
+    references: ArtifactReference[]
+  ): Promise<(() => void) | undefined> {
+    const authorize = this.skillImportOptions?.authorizeReferencedUploads
+    if (!authorize) return undefined
+
+    const paths = references
+      .filter((reference) => {
+        if (reference.source !== 'upload') return false
+        const normalizedName = reference.name.toLowerCase()
+        return normalizedName.endsWith('.skill') || normalizedName.endsWith('.zip')
+      })
+      .map((reference) => reference.path)
+
+    return paths.length > 0 ? authorize(sessionId, paths) : undefined
+  }
+
   private imageOverflowResourceLink(
     block: ContentBlock,
     name: string,
@@ -2977,11 +3005,12 @@ class AcpRuntime {
           allowSkillImportReference: true
         }
       } catch {
-        // Cross-session uploads remain readable generic references, but the session-scoped importer
-        // must never be advertised for a path its ownership boundary will reject.
+        // An explicit `@` reference grants this exact managed upload path for the active turn. The
+        // importer still requires the matching turn token and URI allowlist entry, and rejects every
+        // unreferenced cross-session path through its normal ownership check.
         return {
           filePath: await this.uploadRepository.resolveManagedUploadPath({ path: reference.path }),
-          allowSkillImportReference: false
+          allowSkillImportReference: true
         }
       }
     }

--- a/src/main/ipc.ts
+++ b/src/main/ipc.ts
@@ -493,6 +493,8 @@ const registerIpcHandlers = async ({
     runRegistry: artifactRunRegistry,
     uploadRepository,
     notebookRpcServer,
+    authorizeSkillImportReferencedUploads: (sessionId, paths) =>
+      conversationSkillImporter.authorizeReferencedUploads(sessionId, paths),
     settingsService,
     taskNotifications,
     onSessionTurnStarted: (sessionId, turnToken) =>

--- a/src/main/skills/conversation-import.ts
+++ b/src/main/skills/conversation-import.ts
@@ -146,7 +146,7 @@ class SkillImportApprovalBroker {
 }
 
 type ConversationSkillImporterOptions = {
-  uploads: Pick<UploadRepository, 'resolveSessionUploadPath'>
+  uploads: Pick<UploadRepository, 'resolveManagedUploadPath' | 'resolveSessionUploadPath'>
   createCancellationGuard: (
     sessionId: string,
     turnToken: string,
@@ -224,7 +224,26 @@ const validateSelections = (
 // Owns the complete conversation import transaction behind one agent-facing request: attachment
 // ownership, bounded preview, user confirmation, selection validation, import, and reload signal.
 class ConversationSkillImporter {
+  private readonly referencedUploadGrants = new Map<string, { paths: ReadonlySet<string> }>()
+
   constructor(private readonly options: ConversationSkillImporterOptions) {}
+
+  // Grants one active turn access to uploads the user explicitly selected through `@`. Returning an
+  // identity-scoped disposer prevents a stale turn from revoking a newer turn's grant for the same
+  // conversation during context-reset recovery.
+  async authorizeReferencedUploads(sessionId: string, paths: string[]): Promise<() => void> {
+    const managedPaths = await Promise.all(
+      paths.map((path) => this.options.uploads.resolveManagedUploadPath({ path }))
+    )
+    const grant = { paths: new Set(managedPaths) }
+    this.referencedUploadGrants.set(sessionId, grant)
+
+    return () => {
+      if (this.referencedUploadGrants.get(sessionId) === grant) {
+        this.referencedUploadGrants.delete(sessionId)
+      }
+    }
+  }
 
   async request(request: ConversationSkillImportRequest): Promise<ConversationSkillImportResult> {
     const cancellation = this.options.createCancellationGuard(
@@ -234,9 +253,12 @@ class ConversationSkillImporter {
     )
     if (cancellation.isCancelled()) return { status: 'cancelled', skills: [] }
     const requestedPath = attachmentPathFromUri(request.attachmentUri)
-    const filePath = await this.options.uploads.resolveSessionUploadPath(request.sessionId, {
-      path: requestedPath
-    })
+    const managedPath = await this.options.uploads.resolveManagedUploadPath({ path: requestedPath })
+    const filePath = this.referencedUploadGrants.get(request.sessionId)?.paths.has(managedPath)
+      ? managedPath
+      : await this.options.uploads.resolveSessionUploadPath(request.sessionId, {
+          path: requestedPath
+        })
     const attachmentName = basename(filePath)
     if (!['.zip', '.skill'].includes(extname(attachmentName).toLowerCase())) {
       throw new Error('Skill import only accepts an attached .zip or .skill bundle.')


### PR DESCRIPTION
## Problem

Skill packages selected through @ from project files retained the original owning session URI and were rejected by the current-session-only import check.

## Proposed change

Grant the exact managed upload paths explicitly referenced in the current turn, revoke that authorization when the turn ends, and retain the existing session-owner fallback for every other path.

## Scope and non-goals

This does not relax access for unreferenced files and does not change ZIP validation, approval, or installation behavior.

## Acceptance criteria and validation

- An old-session .zip or .skill explicitly referenced through @ can be imported during the current turn.
- The authorization is revoked at turn completion.
- Unreferenced cross-session uploads remain rejected.
- npm run typecheck
- npm run lint (0 errors; existing warnings only)
- npm run test (6,890 passed; 112 skipped)

## Review focus

Please focus on the turn-scoped grant lifetime, exact canonical-path matching, and stale-disposer behavior.