### PR TITLE
fix(skills): harden conversational import routing

### DIFF
--- a/src/main/acp/attachment-content.ts
+++ b/src/main/acp/attachment-content.ts
@@ -87,7 +87,7 @@ const GENERIC_MIME_TYPES = new Set(['application/octet-stream', 'binary/octet-st
 // The lower-cased MIME essence (type/subtype) with any parameters and casing stripped, or undefined when
 // none was given. A real MIME arrives as `Text/CSV` or `application/json; charset=utf-8`, so every
 // comparison must run against this — not the raw string — or a valid text MIME reads as a concrete binary.
-const mimeEssence = (mimeType?: string): string | undefined => {
+export const mimeEssence = (mimeType?: string): string | undefined => {
   const essence = mimeType?.split(';', 1)[0]?.trim().toLowerCase()
 
   return essence ? essence : undefined

--- a/src/main/acp/ipc.test.ts
+++ b/src/main/acp/ipc.test.ts
@@ -164,19 +164,23 @@ afterEach(() => {
 })
 
 describe('registerAcpIpcHandlers — Skill import cancellation lifecycle', () => {
-  it('invalidates a stopped prompt after success and leaves session deletion to the coordinator', async () => {
+  it('invalidates a stopped prompt and a successfully deleted detached session', async () => {
     const onSessionCancelled = vi.fn()
     registerWithFakes({ onSessionCancelled })
 
     await handlers.get('acp:cancel')?.({}, { sessionId: 'session-1' })
     await handlers.get('acp:delete-session')?.({}, { sessionId: 'session-2' })
 
-    expect(onSessionCancelled).toHaveBeenCalledOnce()
+    expect(onSessionCancelled).toHaveBeenCalledTimes(2)
     expect(onSessionCancelled).toHaveBeenCalledWith('session-1')
+    expect(onSessionCancelled).toHaveBeenCalledWith('session-2')
     expect(cancelPrompt).toHaveBeenCalledWith({ sessionId: 'session-1' })
     expect(deleteSession).toHaveBeenCalledWith({ sessionId: 'session-2' })
     expect(cancelPrompt.mock.invocationCallOrder[0]).toBeLessThan(
       onSessionCancelled.mock.invocationCallOrder[0]
+    )
+    expect(deleteSession.mock.invocationCallOrder[0]).toBeLessThan(
+      onSessionCancelled.mock.invocationCallOrder[1]
     )
   })
 

--- a/src/main/acp/ipc.test.ts
+++ b/src/main/acp/ipc.test.ts
@@ -164,27 +164,26 @@ afterEach(() => {
 })
 
 describe('registerAcpIpcHandlers — Skill import cancellation lifecycle', () => {
-  it('invalidates a stopped prompt and a successfully deleted detached session', async () => {
+  it('invalidates a stopped prompt and deleted session before runtime teardown starts', async () => {
     const onSessionCancelled = vi.fn()
     registerWithFakes({ onSessionCancelled })
 
     await handlers.get('acp:cancel')?.({}, { sessionId: 'session-1' })
     await handlers.get('acp:delete-session')?.({}, { sessionId: 'session-2' })
 
-    expect(onSessionCancelled).toHaveBeenCalledTimes(2)
     expect(onSessionCancelled).toHaveBeenCalledWith('session-1')
     expect(onSessionCancelled).toHaveBeenCalledWith('session-2')
     expect(cancelPrompt).toHaveBeenCalledWith({ sessionId: 'session-1' })
     expect(deleteSession).toHaveBeenCalledWith({ sessionId: 'session-2' })
-    expect(cancelPrompt.mock.invocationCallOrder[0]).toBeLessThan(
-      onSessionCancelled.mock.invocationCallOrder[0]
+    expect(onSessionCancelled.mock.invocationCallOrder[0]).toBeLessThan(
+      cancelPrompt.mock.invocationCallOrder[0]
     )
-    expect(deleteSession.mock.invocationCallOrder[0]).toBeLessThan(
-      onSessionCancelled.mock.invocationCallOrder[1]
+    expect(onSessionCancelled.mock.invocationCallOrder[1]).toBeLessThan(
+      deleteSession.mock.invocationCallOrder[0]
     )
   })
 
-  it('preserves pending imports when prompt or session teardown fails', async () => {
+  it('keeps pending imports invalidated when prompt or session teardown fails', async () => {
     const onSessionCancelled = vi.fn()
     registerWithFakes({ onSessionCancelled })
     cancelPrompt.mockRejectedValueOnce(new Error('cancel failed'))
@@ -197,10 +196,12 @@ describe('registerAcpIpcHandlers — Skill import cancellation lifecycle', () =>
       handlers.get('acp:delete-session')?.({}, { sessionId: 'session-2' })
     ).rejects.toThrow('delete failed')
 
-    expect(onSessionCancelled).not.toHaveBeenCalled()
+    expect(onSessionCancelled).toHaveBeenCalledTimes(2)
+    expect(onSessionCancelled).toHaveBeenNthCalledWith(1, 'session-1')
+    expect(onSessionCancelled).toHaveBeenNthCalledWith(2, 'session-2')
   })
 
-  it('invalidates every pending import after all agent runtimes disconnect', async () => {
+  it('invalidates every pending import before all agent runtimes disconnect', async () => {
     const onAllSessionsCancelled = vi.fn()
     registerWithFakes({ onAllSessionsCancelled })
 
@@ -208,12 +209,12 @@ describe('registerAcpIpcHandlers — Skill import cancellation lifecycle', () =>
 
     expect(onAllSessionsCancelled).toHaveBeenCalledOnce()
     expect(disconnect).toHaveBeenCalledOnce()
-    expect(disconnect.mock.invocationCallOrder[0]).toBeLessThan(
-      onAllSessionsCancelled.mock.invocationCallOrder[0]
+    expect(onAllSessionsCancelled.mock.invocationCallOrder[0]).toBeLessThan(
+      disconnect.mock.invocationCallOrder[0]
     )
   })
 
-  it('preserves pending imports when global disconnect fails', async () => {
+  it('keeps pending imports invalidated when global disconnect fails', async () => {
     const onAllSessionsCancelled = vi.fn()
     registerWithFakes({ onAllSessionsCancelled })
     disconnect.mockRejectedValueOnce(new Error('disconnect failed'))
@@ -222,7 +223,10 @@ describe('registerAcpIpcHandlers — Skill import cancellation lifecycle', () =>
       'disconnect failed'
     )
 
-    expect(onAllSessionsCancelled).not.toHaveBeenCalled()
+    expect(onAllSessionsCancelled).toHaveBeenCalledOnce()
+    expect(onAllSessionsCancelled.mock.invocationCallOrder[0]).toBeLessThan(
+      disconnect.mock.invocationCallOrder[0]
+    )
   })
 })
 

--- a/src/main/acp/ipc.test.ts
+++ b/src/main/acp/ipc.test.ts
@@ -164,22 +164,19 @@ afterEach(() => {
 })
 
 describe('registerAcpIpcHandlers — Skill import cancellation lifecycle', () => {
-  it('invalidates pending imports only after a prompt is stopped or its session is deleted', async () => {
+  it('invalidates a stopped prompt after success and leaves session deletion to the coordinator', async () => {
     const onSessionCancelled = vi.fn()
     registerWithFakes({ onSessionCancelled })
 
     await handlers.get('acp:cancel')?.({}, { sessionId: 'session-1' })
     await handlers.get('acp:delete-session')?.({}, { sessionId: 'session-2' })
 
-    expect(onSessionCancelled).toHaveBeenNthCalledWith(1, 'session-1')
-    expect(onSessionCancelled).toHaveBeenNthCalledWith(2, 'session-2')
+    expect(onSessionCancelled).toHaveBeenCalledOnce()
+    expect(onSessionCancelled).toHaveBeenCalledWith('session-1')
     expect(cancelPrompt).toHaveBeenCalledWith({ sessionId: 'session-1' })
     expect(deleteSession).toHaveBeenCalledWith({ sessionId: 'session-2' })
     expect(cancelPrompt.mock.invocationCallOrder[0]).toBeLessThan(
       onSessionCancelled.mock.invocationCallOrder[0]
-    )
-    expect(deleteSession.mock.invocationCallOrder[0]).toBeLessThan(
-      onSessionCancelled.mock.invocationCallOrder[1]
     )
   })
 

--- a/src/main/acp/ipc.test.ts
+++ b/src/main/acp/ipc.test.ts
@@ -164,7 +164,7 @@ afterEach(() => {
 })
 
 describe('registerAcpIpcHandlers — Skill import cancellation lifecycle', () => {
-  it('invalidates pending imports when a prompt is stopped or its session is deleted', async () => {
+  it('invalidates pending imports only after a prompt is stopped or its session is deleted', async () => {
     const onSessionCancelled = vi.fn()
     registerWithFakes({ onSessionCancelled })
 
@@ -175,9 +175,31 @@ describe('registerAcpIpcHandlers — Skill import cancellation lifecycle', () =>
     expect(onSessionCancelled).toHaveBeenNthCalledWith(2, 'session-2')
     expect(cancelPrompt).toHaveBeenCalledWith({ sessionId: 'session-1' })
     expect(deleteSession).toHaveBeenCalledWith({ sessionId: 'session-2' })
+    expect(cancelPrompt.mock.invocationCallOrder[0]).toBeLessThan(
+      onSessionCancelled.mock.invocationCallOrder[0]
+    )
+    expect(deleteSession.mock.invocationCallOrder[0]).toBeLessThan(
+      onSessionCancelled.mock.invocationCallOrder[1]
+    )
   })
 
-  it('invalidates every pending import before all agent runtimes disconnect', async () => {
+  it('preserves pending imports when prompt or session teardown fails', async () => {
+    const onSessionCancelled = vi.fn()
+    registerWithFakes({ onSessionCancelled })
+    cancelPrompt.mockRejectedValueOnce(new Error('cancel failed'))
+    deleteSession.mockRejectedValueOnce(new Error('delete failed'))
+
+    await expect(handlers.get('acp:cancel')?.({}, { sessionId: 'session-1' })).rejects.toThrow(
+      'cancel failed'
+    )
+    await expect(
+      handlers.get('acp:delete-session')?.({}, { sessionId: 'session-2' })
+    ).rejects.toThrow('delete failed')
+
+    expect(onSessionCancelled).not.toHaveBeenCalled()
+  })
+
+  it('invalidates every pending import after all agent runtimes disconnect', async () => {
     const onAllSessionsCancelled = vi.fn()
     registerWithFakes({ onAllSessionsCancelled })
 
@@ -185,9 +207,21 @@ describe('registerAcpIpcHandlers — Skill import cancellation lifecycle', () =>
 
     expect(onAllSessionsCancelled).toHaveBeenCalledOnce()
     expect(disconnect).toHaveBeenCalledOnce()
-    expect(onAllSessionsCancelled.mock.invocationCallOrder[0]).toBeLessThan(
-      disconnect.mock.invocationCallOrder[0]
+    expect(disconnect.mock.invocationCallOrder[0]).toBeLessThan(
+      onAllSessionsCancelled.mock.invocationCallOrder[0]
     )
+  })
+
+  it('preserves pending imports when global disconnect fails', async () => {
+    const onAllSessionsCancelled = vi.fn()
+    registerWithFakes({ onAllSessionsCancelled })
+    disconnect.mockRejectedValueOnce(new Error('disconnect failed'))
+
+    await expect(handlers.get('acp:disconnect')?.({}, undefined)).rejects.toThrow(
+      'disconnect failed'
+    )
+
+    expect(onAllSessionsCancelled).not.toHaveBeenCalled()
   })
 })
 

--- a/src/main/acp/ipc.test.ts
+++ b/src/main/acp/ipc.test.ts
@@ -117,8 +117,9 @@ const registerWithFakes = (overrides?: {
     trackPrompt: ReturnType<typeof vi.fn>
     untrackPrompt: ReturnType<typeof vi.fn>
   }
-  onSessionCancelled?: (sessionId: string) => void
-  onAllSessionsCancelled?: () => void
+  onSessionCancellationRequested?: (sessionId: string) => void
+  onSessionUnavailable?: (sessionId: string) => void
+  onAllSessionsCancellationRequested?: () => void
 }): void => {
   const taskNotifications =
     overrides?.taskNotifications ??
@@ -138,8 +139,9 @@ const registerWithFakes = (overrides?: {
       resolveAgentBackend: vi.fn().mockResolvedValue({})
     } as never,
     taskNotifications: taskNotifications as never,
-    onSessionCancelled: overrides?.onSessionCancelled,
-    onAllSessionsCancelled: overrides?.onAllSessionsCancelled,
+    onSessionCancellationRequested: overrides?.onSessionCancellationRequested,
+    onSessionUnavailable: overrides?.onSessionUnavailable,
+    onAllSessionsCancellationRequested: overrides?.onAllSessionsCancellationRequested,
     initializationBarrier: overrides?.initializationBarrier
   }
 
@@ -165,27 +167,35 @@ afterEach(() => {
 
 describe('registerAcpIpcHandlers — Skill import cancellation lifecycle', () => {
   it('invalidates a stopped prompt and deleted session before runtime teardown starts', async () => {
-    const onSessionCancelled = vi.fn()
-    registerWithFakes({ onSessionCancelled })
+    const onSessionCancellationRequested = vi.fn()
+    const onSessionUnavailable = vi.fn()
+    registerWithFakes({ onSessionCancellationRequested, onSessionUnavailable })
 
     await handlers.get('acp:cancel')?.({}, { sessionId: 'session-1' })
     await handlers.get('acp:delete-session')?.({}, { sessionId: 'session-2' })
 
-    expect(onSessionCancelled).toHaveBeenCalledWith('session-1')
-    expect(onSessionCancelled).toHaveBeenCalledWith('session-2')
+    expect(onSessionCancellationRequested).toHaveBeenCalledTimes(2)
+    expect(onSessionCancellationRequested).toHaveBeenNthCalledWith(1, 'session-1')
+    expect(onSessionCancellationRequested).toHaveBeenNthCalledWith(2, 'session-2')
+    expect(onSessionUnavailable).toHaveBeenCalledOnce()
+    expect(onSessionUnavailable).toHaveBeenCalledWith('session-2')
     expect(cancelPrompt).toHaveBeenCalledWith({ sessionId: 'session-1' })
     expect(deleteSession).toHaveBeenCalledWith({ sessionId: 'session-2' })
-    expect(onSessionCancelled.mock.invocationCallOrder[0]).toBeLessThan(
+    expect(onSessionCancellationRequested.mock.invocationCallOrder[0]).toBeLessThan(
       cancelPrompt.mock.invocationCallOrder[0]
     )
-    expect(onSessionCancelled.mock.invocationCallOrder[1]).toBeLessThan(
+    expect(onSessionCancellationRequested.mock.invocationCallOrder[1]).toBeLessThan(
       deleteSession.mock.invocationCallOrder[0]
+    )
+    expect(deleteSession.mock.invocationCallOrder[0]).toBeLessThan(
+      onSessionUnavailable.mock.invocationCallOrder[0]
     )
   })
 
   it('keeps pending imports invalidated when prompt or session teardown fails', async () => {
-    const onSessionCancelled = vi.fn()
-    registerWithFakes({ onSessionCancelled })
+    const onSessionCancellationRequested = vi.fn()
+    const onSessionUnavailable = vi.fn()
+    registerWithFakes({ onSessionCancellationRequested, onSessionUnavailable })
     cancelPrompt.mockRejectedValueOnce(new Error('cancel failed'))
     deleteSession.mockRejectedValueOnce(new Error('delete failed'))
 
@@ -196,35 +206,36 @@ describe('registerAcpIpcHandlers — Skill import cancellation lifecycle', () =>
       handlers.get('acp:delete-session')?.({}, { sessionId: 'session-2' })
     ).rejects.toThrow('delete failed')
 
-    expect(onSessionCancelled).toHaveBeenCalledTimes(2)
-    expect(onSessionCancelled).toHaveBeenNthCalledWith(1, 'session-1')
-    expect(onSessionCancelled).toHaveBeenNthCalledWith(2, 'session-2')
+    expect(onSessionCancellationRequested).toHaveBeenCalledTimes(2)
+    expect(onSessionCancellationRequested).toHaveBeenNthCalledWith(1, 'session-1')
+    expect(onSessionCancellationRequested).toHaveBeenNthCalledWith(2, 'session-2')
+    expect(onSessionUnavailable).not.toHaveBeenCalled()
   })
 
   it('invalidates every pending import before all agent runtimes disconnect', async () => {
-    const onAllSessionsCancelled = vi.fn()
-    registerWithFakes({ onAllSessionsCancelled })
+    const onAllSessionsCancellationRequested = vi.fn()
+    registerWithFakes({ onAllSessionsCancellationRequested })
 
     await handlers.get('acp:disconnect')?.({}, undefined)
 
-    expect(onAllSessionsCancelled).toHaveBeenCalledOnce()
+    expect(onAllSessionsCancellationRequested).toHaveBeenCalledOnce()
     expect(disconnect).toHaveBeenCalledOnce()
-    expect(onAllSessionsCancelled.mock.invocationCallOrder[0]).toBeLessThan(
+    expect(onAllSessionsCancellationRequested.mock.invocationCallOrder[0]).toBeLessThan(
       disconnect.mock.invocationCallOrder[0]
     )
   })
 
   it('keeps pending imports invalidated when global disconnect fails', async () => {
-    const onAllSessionsCancelled = vi.fn()
-    registerWithFakes({ onAllSessionsCancelled })
+    const onAllSessionsCancellationRequested = vi.fn()
+    registerWithFakes({ onAllSessionsCancellationRequested })
     disconnect.mockRejectedValueOnce(new Error('disconnect failed'))
 
     await expect(handlers.get('acp:disconnect')?.({}, undefined)).rejects.toThrow(
       'disconnect failed'
     )
 
-    expect(onAllSessionsCancelled).toHaveBeenCalledOnce()
-    expect(onAllSessionsCancelled.mock.invocationCallOrder[0]).toBeLessThan(
+    expect(onAllSessionsCancellationRequested).toHaveBeenCalledOnce()
+    expect(onAllSessionsCancellationRequested.mock.invocationCallOrder[0]).toBeLessThan(
       disconnect.mock.invocationCallOrder[0]
     )
   })

--- a/src/main/acp/ipc.ts
+++ b/src/main/acp/ipc.ts
@@ -54,6 +54,8 @@ type AcpIpcOptions = AcpIpcArtifacts & {
   // Observes prompt starts and terminal turn events for desktop notifications. Optional so tests
   // and headless setups can run without a notification surface.
   taskNotifications?: TaskNotificationService
+  onSessionTurnStarted?: (sessionId: string, turnToken: string) => void
+  onSessionTurnEnded?: (sessionId: string, turnToken: string) => void
   onSessionCancelled?: (sessionId: string) => void
   onAllSessionsCancelled?: () => void
 }
@@ -83,6 +85,8 @@ const createRuntime = ({
   settingsService,
   initializationBarrier,
   taskNotifications,
+  onSessionTurnStarted,
+  onSessionTurnEnded,
   onSessionCancelled,
   onAllSessionsCancelled
 }: AcpIpcOptions): AcpRuntimeCoordinator => {
@@ -154,8 +158,14 @@ const createRuntime = ({
     callbacks,
     defaultCwd,
     initializationBarrier,
-    onAllSessionsCancelled,
-    onSessionCancelled
+    undefined,
+    onSessionCancelled,
+    {
+      onSessionTurnStarted,
+      onSessionTurnEnded,
+      onSessionCancellationRequested: onSessionCancelled,
+      onAllSessionsCancellationRequested: onAllSessionsCancelled
+    }
   )
 }
 

--- a/src/main/acp/ipc.ts
+++ b/src/main/acp/ipc.ts
@@ -56,8 +56,14 @@ type AcpIpcOptions = AcpIpcArtifacts & {
   taskNotifications?: TaskNotificationService
   onSessionTurnStarted?: (sessionId: string, turnToken: string) => void
   onSessionTurnEnded?: (sessionId: string, turnToken: string) => void
-  onSessionCancelled?: (sessionId: string) => void
-  onAllSessionsCancelled?: () => void
+  onSkillImportAttachmentEligible?: (
+    sessionId: string,
+    turnToken: string,
+    attachmentUri: string
+  ) => void
+  onSessionCancellationRequested?: (sessionId: string) => void
+  onSessionUnavailable?: (sessionId: string) => void
+  onAllSessionsCancellationRequested?: () => void
 }
 
 // Sends one runtime payload to every currently open renderer window.
@@ -87,8 +93,10 @@ const createRuntime = ({
   taskNotifications,
   onSessionTurnStarted,
   onSessionTurnEnded,
-  onSessionCancelled,
-  onAllSessionsCancelled
+  onSkillImportAttachmentEligible,
+  onSessionCancellationRequested,
+  onSessionUnavailable,
+  onAllSessionsCancellationRequested
 }: AcpIpcOptions): AcpRuntimeCoordinator => {
   const configRoot = resolveConfigRoot()
   const dataRoot = resolveDataRoot()
@@ -159,12 +167,13 @@ const createRuntime = ({
     defaultCwd,
     initializationBarrier,
     undefined,
-    onSessionCancelled,
+    onSessionUnavailable,
     {
       onSessionTurnStarted,
       onSessionTurnEnded,
-      onSessionCancellationRequested: onSessionCancelled,
-      onAllSessionsCancellationRequested: onAllSessionsCancelled
+      onSkillImportAttachmentEligible,
+      onSessionCancellationRequested,
+      onAllSessionsCancellationRequested
     }
   )
 }
@@ -227,11 +236,9 @@ const registerAcpIpcHandlers = (options: AcpIpcOptions): AcpRuntimeCoordinator =
 
     return runtime.getSnapshot()
   })
-  ipcMain.handle('acp:cancel', async (_event, request: AcpCancelPromptRequest) => {
-    const snapshot = await runtime.cancelPrompt(request)
-    options.onSessionCancelled?.(request.sessionId)
-    return snapshot
-  })
+  ipcMain.handle('acp:cancel', (_event, request: AcpCancelPromptRequest) =>
+    runtime.cancelPrompt(request)
+  )
   ipcMain.handle('acp:delete-session', async (_event, request: AcpDeleteSessionRequest) => {
     // The coordinator owns session disappearance notifications for delete, connection loss, and
     // retirement. Keeping that signal in one layer prevents a successful delete from firing twice.

--- a/src/main/acp/ipc.ts
+++ b/src/main/acp/ipc.ts
@@ -223,9 +223,9 @@ const registerAcpIpcHandlers = (options: AcpIpcOptions): AcpRuntimeCoordinator =
     return snapshot
   })
   ipcMain.handle('acp:delete-session', async (_event, request: AcpDeleteSessionRequest) => {
-    const snapshot = await runtime.deleteSession(request)
-    options.onSessionCancelled?.(request.sessionId)
-    return snapshot
+    // The coordinator owns session disappearance notifications for delete, connection loss, and
+    // retirement. Keeping that signal in one layer prevents a successful delete from firing twice.
+    return runtime.deleteSession(request)
   })
   ipcMain.handle('acp:respond-permission', (_event, response: AcpPermissionResponse) =>
     runtime.respondToPermission(response)

--- a/src/main/acp/ipc.ts
+++ b/src/main/acp/ipc.ts
@@ -83,6 +83,7 @@ const createRuntime = ({
   settingsService,
   initializationBarrier,
   taskNotifications,
+  onSessionCancelled,
   onAllSessionsCancelled
 }: AcpIpcOptions): AcpRuntimeCoordinator => {
   const configRoot = resolveConfigRoot()
@@ -153,7 +154,8 @@ const createRuntime = ({
     callbacks,
     defaultCwd,
     initializationBarrier,
-    onAllSessionsCancelled
+    onAllSessionsCancelled,
+    onSessionCancelled
   )
 }
 
@@ -215,13 +217,15 @@ const registerAcpIpcHandlers = (options: AcpIpcOptions): AcpRuntimeCoordinator =
 
     return runtime.getSnapshot()
   })
-  ipcMain.handle('acp:cancel', (_event, request: AcpCancelPromptRequest) => {
+  ipcMain.handle('acp:cancel', async (_event, request: AcpCancelPromptRequest) => {
+    const snapshot = await runtime.cancelPrompt(request)
     options.onSessionCancelled?.(request.sessionId)
-    return runtime.cancelPrompt(request)
+    return snapshot
   })
-  ipcMain.handle('acp:delete-session', (_event, request: AcpDeleteSessionRequest) => {
+  ipcMain.handle('acp:delete-session', async (_event, request: AcpDeleteSessionRequest) => {
+    const snapshot = await runtime.deleteSession(request)
     options.onSessionCancelled?.(request.sessionId)
-    return runtime.deleteSession(request)
+    return snapshot
   })
   ipcMain.handle('acp:respond-permission', (_event, response: AcpPermissionResponse) =>
     runtime.respondToPermission(response)

--- a/src/main/acp/mcp-http-host.test.ts
+++ b/src/main/acp/mcp-http-host.test.ts
@@ -172,7 +172,10 @@ describe('AgentMcpHttpHost', () => {
 
     const result = await client.callTool({
       name: 'request_skill_import',
-      arguments: { attachment_uri: 'file:///workspace/demo.skill' }
+      arguments: {
+        attachment_uri: 'file:///workspace/demo.skill',
+        turn_token: '00000000-0000-4000-8000-000000000001'
+      }
     })
     expect(JSON.stringify(result.content)).toContain('cancelled')
     expect(rpcRequest).toEqual({
@@ -181,6 +184,7 @@ describe('AgentMcpHttpHost', () => {
         method: 'skillImport',
         params: {
           sessionId: routingId,
+          turnToken: '00000000-0000-4000-8000-000000000001',
           attachmentUri: 'file:///workspace/demo.skill'
         }
       }

--- a/src/main/acp/mcp-http-host.ts
+++ b/src/main/acp/mcp-http-host.ts
@@ -181,7 +181,8 @@ class AgentMcpHttpHost {
     if (!skillImportEnvironment) return undefined
 
     return createSkillImportMcpServer({
-      requestImport: (attachmentUri) => callSkillImportRpc(skillImportEnvironment, attachmentUri)
+      requestImport: (attachmentUri, turnToken) =>
+        callSkillImportRpc(skillImportEnvironment, attachmentUri, turnToken)
     })
   }
 

--- a/src/main/acp/runtime-coordinator.test.ts
+++ b/src/main/acp/runtime-coordinator.test.ts
@@ -34,6 +34,7 @@ const createFakeRuntime = (options: {
   sessionIds: string[]
   callbacks: AcpRuntimeCallbacks
   permissionGrantStore?: ConversationPermissionGrantStore
+  beforePromptStart?: () => Promise<void>
   prompt?: (sessionId: string) => Promise<unknown>
 }): {
   runtime: AcpRuntime
@@ -41,6 +42,7 @@ const createFakeRuntime = (options: {
   createSession: ReturnType<typeof vi.fn>
   resetSessionContext: ReturnType<typeof vi.fn>
   resumeSession: ReturnType<typeof vi.fn>
+  cancelPrompt: ReturnType<typeof vi.fn>
   deleteSession: ReturnType<typeof vi.fn>
   disconnect: ReturnType<typeof vi.fn>
   requestRetirement: ReturnType<typeof vi.fn>
@@ -55,6 +57,7 @@ const createFakeRuntime = (options: {
 } => {
   let snapshot = emptySnapshot()
   let sessionIndex = 0
+  let turnSequence = 0
   const connect = vi.fn(async () => snapshot)
   const createSession = vi.fn(async () => {
     const sessionId = options.sessionIds[sessionIndex]
@@ -80,6 +83,7 @@ const createFakeRuntime = (options: {
     frameworkId: options.frameworkId,
     contextReset: true
   }))
+  const cancelPrompt = vi.fn(async () => snapshot)
   const deleteSession = vi.fn(async ({ sessionId }: { sessionId: string }) => {
     snapshot = {
       ...snapshot,
@@ -98,29 +102,35 @@ const createFakeRuntime = (options: {
   const shutdown = vi.fn()
   const shutdownForQuit = vi.fn(async () => ({ reaped: true }))
   const shutdownForUpdateGate = vi.fn(async () => ({ reaped: true }))
-  const sendPrompt = vi.fn(async ({ sessionId }: { sessionId: string }) => {
-    snapshot = {
-      ...snapshot,
-      promptInFlight: true,
-      promptInFlightSessionIds: [...snapshot.promptInFlightSessionIds, sessionId]
-    }
-    options.callbacks.onStateChanged?.(snapshot)
-
-    try {
-      return await (options.prompt
-        ? options.prompt(sessionId)
-        : Promise.resolve({ stopReason: 'end_turn' }))
-    } finally {
+  const sendPrompt = vi.fn(
+    async ({ sessionId }: { sessionId: string }, promptAttemptId?: string) => {
+      await options.beforePromptStart?.()
+      const turnToken = `turn-${++turnSequence}`
       snapshot = {
         ...snapshot,
-        promptInFlight: false,
-        promptInFlightSessionIds: snapshot.promptInFlightSessionIds.filter(
-          (candidate) => candidate !== sessionId
-        )
+        promptInFlight: true,
+        promptInFlightSessionIds: [...snapshot.promptInFlightSessionIds, sessionId]
       }
+      options.callbacks.onPromptStarted?.(sessionId, turnToken, promptAttemptId)
       options.callbacks.onStateChanged?.(snapshot)
+
+      try {
+        return await (options.prompt
+          ? options.prompt(sessionId)
+          : Promise.resolve({ stopReason: 'end_turn' }))
+      } finally {
+        options.callbacks.onPromptEnded?.(sessionId, turnToken)
+        snapshot = {
+          ...snapshot,
+          promptInFlight: false,
+          promptInFlightSessionIds: snapshot.promptInFlightSessionIds.filter(
+            (candidate) => candidate !== sessionId
+          )
+        }
+        options.callbacks.onStateChanged?.(snapshot)
+      }
     }
-  })
+  )
   const runtime = {
     getSnapshot: () => snapshot,
     getActivePromptSessions: () => [],
@@ -129,6 +139,7 @@ const createFakeRuntime = (options: {
     createSession,
     resumeSession,
     resetSessionContext,
+    cancelPrompt,
     deleteSession,
     revokePermissionGrant: vi.fn(
       ({ sessionId, categoryKey }: { sessionId: string; categoryKey: string }) => {
@@ -166,6 +177,7 @@ const createFakeRuntime = (options: {
     createSession,
     resetSessionContext,
     resumeSession,
+    cancelPrompt,
     deleteSession,
     disconnect,
     requestRetirement,
@@ -239,6 +251,7 @@ describe('AcpRuntimeCoordinator', () => {
     const initialization = createDeferred()
     const created: ReturnType<typeof createFakeRuntime>[] = []
     const onDisconnected = vi.fn()
+    const onAllSessionsCancellationRequested = vi.fn()
     const coordinator = new AcpRuntimeCoordinator(
       (callbacks) => {
         const fake = createFakeRuntime({
@@ -252,7 +265,9 @@ describe('AcpRuntimeCoordinator', () => {
       {},
       '',
       initialization.promise,
-      onDisconnected
+      onDisconnected,
+      undefined,
+      { onAllSessionsCancellationRequested }
     )
 
     const connecting = coordinator.connect()
@@ -262,6 +277,10 @@ describe('AcpRuntimeCoordinator', () => {
     await expect(connecting).rejects.toThrow(/superseded/i)
     expect(created[0].connect).not.toHaveBeenCalled()
     expect(vi.mocked(created[0].runtime.shutdown)).toHaveBeenCalledOnce()
+    expect(onAllSessionsCancellationRequested).toHaveBeenCalledOnce()
+    expect(onAllSessionsCancellationRequested.mock.invocationCallOrder[0]).toBeLessThan(
+      vi.mocked(created[0].runtime.shutdown).mock.invocationCallOrder[0]
+    )
     expect(vi.mocked(created[0].runtime.shutdown).mock.invocationCallOrder[0]).toBeLessThan(
       onDisconnected.mock.invocationCallOrder[0]
     )
@@ -288,6 +307,106 @@ describe('AcpRuntimeCoordinator', () => {
 
     expect(stores).toHaveLength(2)
     expect(stores[1]).toBe(stores[0])
+  })
+
+  it('forwards a real runtime prompt start to the session turn lifecycle', async () => {
+    const onSessionTurnStarted = vi.fn()
+    const onSessionTurnEnded = vi.fn()
+    const coordinator = new AcpRuntimeCoordinator(
+      (callbacks) =>
+        createFakeRuntime({ frameworkId: 'claude-code', sessionIds: ['session-1'], callbacks })
+          .runtime,
+      {},
+      '',
+      undefined,
+      undefined,
+      undefined,
+      { onSessionTurnStarted, onSessionTurnEnded }
+    )
+
+    const session = await coordinator.createSession({ cwd: '/workspace' })
+    await coordinator.sendPrompt({ sessionId: session.sessionId, text: 'import this Skill' })
+
+    expect(onSessionTurnStarted).toHaveBeenCalledOnce()
+    expect(onSessionTurnStarted).toHaveBeenCalledWith('session-1', 'turn-1')
+    expect(onSessionTurnEnded).toHaveBeenCalledOnce()
+    expect(onSessionTurnEnded).toHaveBeenCalledWith('session-1', 'turn-1')
+  })
+
+  it('does not reactivate a prompt attempt cancelled before its runtime turn starts', async () => {
+    const firstPromptStart = createDeferred<void>()
+    let promptAttempt = 0
+    const onSessionTurnStarted = vi.fn()
+    const onSessionCancellationRequested = vi.fn()
+    const coordinator = new AcpRuntimeCoordinator(
+      (callbacks) =>
+        createFakeRuntime({
+          frameworkId: 'claude-code',
+          sessionIds: ['session-1'],
+          callbacks,
+          beforePromptStart: () =>
+            promptAttempt++ === 0 ? firstPromptStart.promise : Promise.resolve()
+        }).runtime,
+      {},
+      '',
+      undefined,
+      undefined,
+      undefined,
+      { onSessionTurnStarted, onSessionCancellationRequested }
+    )
+
+    const session = await coordinator.createSession({ cwd: '/workspace' })
+    const cancelledBeforeStart = coordinator.sendPrompt({
+      sessionId: session.sessionId,
+      text: 'first turn'
+    })
+    await coordinator.cancelPrompt({ sessionId: session.sessionId })
+    firstPromptStart.resolve()
+    await cancelledBeforeStart
+
+    expect(onSessionCancellationRequested).toHaveBeenCalledWith('session-1')
+    expect(onSessionTurnStarted).not.toHaveBeenCalled()
+
+    await coordinator.sendPrompt({ sessionId: session.sessionId, text: 'next turn' })
+    expect(onSessionTurnStarted).toHaveBeenCalledOnce()
+    expect(onSessionTurnStarted).toHaveBeenCalledWith('session-1', 'turn-2')
+  })
+
+  it('matches out-of-order prompt starts to their exact coordinator attempts', async () => {
+    const firstPromptStart = createDeferred<void>()
+    let promptAttempt = 0
+    const onSessionTurnStarted = vi.fn()
+    const coordinator = new AcpRuntimeCoordinator(
+      (callbacks) =>
+        createFakeRuntime({
+          frameworkId: 'claude-code',
+          sessionIds: ['session-1'],
+          callbacks,
+          beforePromptStart: () =>
+            promptAttempt++ === 0 ? firstPromptStart.promise : Promise.resolve()
+        }).runtime,
+      {},
+      '',
+      undefined,
+      undefined,
+      undefined,
+      { onSessionTurnStarted }
+    )
+
+    const session = await coordinator.createSession({ cwd: '/workspace' })
+    const stalePrompt = coordinator.sendPrompt({
+      sessionId: session.sessionId,
+      text: 'cancelled before start'
+    })
+    await coordinator.cancelPrompt({ sessionId: session.sessionId })
+
+    await coordinator.sendPrompt({ sessionId: session.sessionId, text: 'new turn starts first' })
+    expect(onSessionTurnStarted).toHaveBeenCalledOnce()
+    expect(onSessionTurnStarted).toHaveBeenCalledWith('session-1', 'turn-1')
+
+    firstPromptStart.resolve()
+    await stalePrompt
+    expect(onSessionTurnStarted).toHaveBeenCalledOnce()
   })
 
   it('keeps detached conversation grants visible and revocable during framework rotation', async () => {
@@ -587,10 +706,13 @@ describe('AcpRuntimeCoordinator', () => {
     await coordinator.sendPrompt({ sessionId: 'session-1', text: 'continue on new runtime' })
 
     expect(vi.mocked(created[0].runtime.sendPrompt)).not.toHaveBeenCalled()
-    expect(vi.mocked(created[1].runtime.sendPrompt)).toHaveBeenCalledWith({
-      sessionId: 'session-1',
-      text: 'continue on new runtime'
-    })
+    expect(vi.mocked(created[1].runtime.sendPrompt)).toHaveBeenCalledWith(
+      {
+        sessionId: 'session-1',
+        text: 'continue on new runtime'
+      },
+      expect.any(String)
+    )
     expect(onSessionUnavailable).not.toHaveBeenCalled()
   })
 
@@ -598,6 +720,7 @@ describe('AcpRuntimeCoordinator', () => {
     const created: ReturnType<typeof createFakeRuntime>[] = []
     const onDisconnected = vi.fn()
     const onSessionUnavailable = vi.fn()
+    const onAllSessionsCancellationRequested = vi.fn()
     const coordinator = new AcpRuntimeCoordinator(
       (callbacks) => {
         const fake = createFakeRuntime({
@@ -612,7 +735,8 @@ describe('AcpRuntimeCoordinator', () => {
       '',
       undefined,
       onDisconnected,
-      onSessionUnavailable
+      onSessionUnavailable,
+      { onAllSessionsCancellationRequested }
     )
 
     await coordinator.createSession()
@@ -636,6 +760,10 @@ describe('AcpRuntimeCoordinator', () => {
     expect(settled).toBe(false)
     expect(created[0].runtime.shutdownForQuit).toHaveBeenCalledOnce()
     expect(created[1].runtime.shutdownForQuit).toHaveBeenCalledOnce()
+    expect(onAllSessionsCancellationRequested).toHaveBeenCalledOnce()
+    expect(onAllSessionsCancellationRequested.mock.invocationCallOrder[0]).toBeLessThan(
+      vi.mocked(created[0].runtime.shutdownForQuit).mock.invocationCallOrder[0]
+    )
     activeShutdown.resolve({ reaped: true })
     await expect(shuttingDown).rejects.toThrow('old shutdown failed')
     expect(onSessionUnavailable).toHaveBeenCalledTimes(2)
@@ -651,6 +779,7 @@ describe('AcpRuntimeCoordinator', () => {
     vi.mocked(created[0].runtime.shutdownForQuit).mockResolvedValueOnce({ reaped: true })
     await expect(coordinator.shutdownForQuit()).resolves.toEqual({ reaped: true })
     expect(created[0].runtime.shutdownForQuit).toHaveBeenCalledTimes(2)
+    expect(onAllSessionsCancellationRequested).toHaveBeenCalledTimes(2)
     expect(onDisconnected).toHaveBeenCalledOnce()
   })
 
@@ -715,10 +844,13 @@ describe('AcpRuntimeCoordinator', () => {
       cwd: '/workspace',
       previousFrameworkId: 'claude-code'
     })
-    expect(vi.mocked(created[1].runtime.sendPrompt)).toHaveBeenCalledWith({
-      sessionId: 'old-session',
-      text: 'continue on Codex'
-    })
+    expect(vi.mocked(created[1].runtime.sendPrompt)).toHaveBeenCalledWith(
+      {
+        sessionId: 'old-session',
+        text: 'continue on Codex'
+      },
+      expect.any(String)
+    )
   })
 
   it('invalidates the old framework context usage until the adopted session reports a new value', async () => {

--- a/src/main/acp/runtime-coordinator.test.ts
+++ b/src/main/acp/runtime-coordinator.test.ts
@@ -222,6 +222,7 @@ describe('AcpRuntimeCoordinator', () => {
   it('does not connect after shutdown supersedes initialization', async () => {
     const initialization = createDeferred()
     const created: ReturnType<typeof createFakeRuntime>[] = []
+    const onDisconnected = vi.fn()
     const coordinator = new AcpRuntimeCoordinator(
       (callbacks) => {
         const fake = createFakeRuntime({
@@ -234,7 +235,8 @@ describe('AcpRuntimeCoordinator', () => {
       },
       {},
       '',
-      initialization.promise
+      initialization.promise,
+      onDisconnected
     )
 
     const connecting = coordinator.connect()
@@ -243,6 +245,10 @@ describe('AcpRuntimeCoordinator', () => {
 
     await expect(connecting).rejects.toThrow(/superseded/i)
     expect(created[0].connect).not.toHaveBeenCalled()
+    expect(vi.mocked(created[0].runtime.shutdown)).toHaveBeenCalledOnce()
+    expect(vi.mocked(created[0].runtime.shutdown).mock.invocationCallOrder[0]).toBeLessThan(
+      onDisconnected.mock.invocationCallOrder[0]
+    )
   })
 
   it('shares one conversation permission store across runtime generations', async () => {
@@ -391,6 +397,37 @@ describe('AcpRuntimeCoordinator', () => {
     expect(created[1].disconnect).toHaveBeenCalledOnce()
     activeDisconnect.resolve(emptySnapshot())
     await expect(disconnecting).rejects.toThrow('old disconnect failed')
+  })
+
+  it('invalidates only sessions owned by a runtime that closes unexpectedly', async () => {
+    const created: ReturnType<typeof createFakeRuntime>[] = []
+    const onSessionUnavailable = vi.fn()
+    const coordinator = new AcpRuntimeCoordinator(
+      (callbacks) => {
+        const fake = createFakeRuntime({
+          frameworkId: created.length === 0 ? 'claude-code' : 'codex',
+          sessionIds: [`session-${created.length + 1}`],
+          callbacks
+        })
+        created.push(fake)
+        return fake.runtime
+      },
+      {},
+      '',
+      undefined,
+      undefined,
+      onSessionUnavailable
+    )
+
+    await coordinator.createSession()
+    await coordinator.requestAgentFrameworkSwitch()
+    await coordinator.createSession()
+
+    created[0].emitState({ status: 'closed', sessionId: undefined, sessionIds: [] })
+
+    expect(onSessionUnavailable).toHaveBeenCalledOnce()
+    expect(onSessionUnavailable).toHaveBeenCalledWith('session-1')
+    expect(onSessionUnavailable).not.toHaveBeenCalledWith('session-2')
   })
 
   it('attempts every runtime quit teardown before surfacing a partial failure', async () => {
@@ -703,18 +740,26 @@ describe('AcpRuntimeCoordinator', () => {
 
   it('removes a runtime from aggregation after its retirement completes', async () => {
     const created: ReturnType<typeof createFakeRuntime>[] = []
-    const coordinator = new AcpRuntimeCoordinator((callbacks) => {
-      const fake = createFakeRuntime({
-        frameworkId: created.length === 0 ? 'claude-code' : 'codex',
-        sessionIds: [`session-${created.length + 1}`],
-        callbacks
-      })
-      fake.requestRetirement.mockImplementation(async () => {
-        callbacks.onRetired?.()
-      })
-      created.push(fake)
-      return fake.runtime
-    })
+    const onSessionUnavailable = vi.fn()
+    const coordinator = new AcpRuntimeCoordinator(
+      (callbacks) => {
+        const fake = createFakeRuntime({
+          frameworkId: created.length === 0 ? 'claude-code' : 'codex',
+          sessionIds: [`session-${created.length + 1}`],
+          callbacks
+        })
+        fake.requestRetirement.mockImplementation(async () => {
+          callbacks.onRetired?.()
+        })
+        created.push(fake)
+        return fake.runtime
+      },
+      {},
+      '',
+      undefined,
+      undefined,
+      onSessionUnavailable
+    )
 
     await coordinator.createSession()
     created[0].emitEvent({
@@ -729,6 +774,8 @@ describe('AcpRuntimeCoordinator', () => {
 
     expect(coordinator.getSnapshot().events).toEqual([])
     expect(coordinator.getSnapshot().sessionIds).toEqual([])
+    expect(onSessionUnavailable).toHaveBeenCalledOnce()
+    expect(onSessionUnavailable).toHaveBeenCalledWith('session-1')
   })
 
   it('projects connection status from each session owning runtime', async () => {

--- a/src/main/acp/runtime-coordinator.test.ts
+++ b/src/main/acp/runtime-coordinator.test.ts
@@ -41,6 +41,7 @@ const createFakeRuntime = (options: {
   createSession: ReturnType<typeof vi.fn>
   resetSessionContext: ReturnType<typeof vi.fn>
   resumeSession: ReturnType<typeof vi.fn>
+  deleteSession: ReturnType<typeof vi.fn>
   disconnect: ReturnType<typeof vi.fn>
   requestRetirement: ReturnType<typeof vi.fn>
   requestProviderReconnect: ReturnType<typeof vi.fn>
@@ -78,6 +79,15 @@ const createFakeRuntime = (options: {
     frameworkId: options.frameworkId,
     contextReset: true
   }))
+  const deleteSession = vi.fn(async ({ sessionId }: { sessionId: string }) => {
+    snapshot = {
+      ...snapshot,
+      sessionId: snapshot.sessionId === sessionId ? undefined : snapshot.sessionId,
+      sessionIds: snapshot.sessionIds.filter((candidate) => candidate !== sessionId)
+    }
+    options.callbacks.onStateChanged?.(snapshot)
+    return snapshot
+  })
   const disconnect = vi.fn(async () => snapshot)
   const requestRetirement = vi.fn(async () => undefined)
   const requestProviderReconnect = vi.fn(async () => undefined)
@@ -118,6 +128,7 @@ const createFakeRuntime = (options: {
     createSession,
     resumeSession,
     resetSessionContext,
+    deleteSession,
     revokePermissionGrant: vi.fn(
       ({ sessionId, categoryKey }: { sessionId: string; categoryKey: string }) => {
         options.permissionGrantStore?.revoke(sessionId, categoryKey)
@@ -154,6 +165,7 @@ const createFakeRuntime = (options: {
     createSession,
     resetSessionContext,
     resumeSession,
+    deleteSession,
     disconnect,
     requestRetirement,
     requestProviderReconnect,
@@ -430,17 +442,54 @@ describe('AcpRuntimeCoordinator', () => {
     expect(onSessionUnavailable).not.toHaveBeenCalledWith('session-2')
   })
 
+  it('invalidates a successfully deleted session exactly once', async () => {
+    const created: ReturnType<typeof createFakeRuntime>[] = []
+    const onSessionUnavailable = vi.fn()
+    const coordinator = new AcpRuntimeCoordinator(
+      (callbacks) => {
+        const fake = createFakeRuntime({
+          frameworkId: 'claude-code',
+          sessionIds: ['session-1'],
+          callbacks
+        })
+        created.push(fake)
+        return fake.runtime
+      },
+      {},
+      '',
+      undefined,
+      undefined,
+      onSessionUnavailable
+    )
+
+    await coordinator.createSession()
+    await coordinator.deleteSession({ sessionId: 'session-1' })
+
+    expect(created[0].deleteSession).toHaveBeenCalledWith({ sessionId: 'session-1' })
+    expect(onSessionUnavailable).toHaveBeenCalledOnce()
+    expect(onSessionUnavailable).toHaveBeenCalledWith('session-1')
+  })
+
   it('attempts every runtime quit teardown before surfacing a partial failure', async () => {
     const created: ReturnType<typeof createFakeRuntime>[] = []
-    const coordinator = new AcpRuntimeCoordinator((callbacks) => {
-      const fake = createFakeRuntime({
-        frameworkId: created.length === 0 ? 'claude-code' : 'codex',
-        sessionIds: [`session-${created.length + 1}`],
-        callbacks
-      })
-      created.push(fake)
-      return fake.runtime
-    })
+    const onDisconnected = vi.fn()
+    const onSessionUnavailable = vi.fn()
+    const coordinator = new AcpRuntimeCoordinator(
+      (callbacks) => {
+        const fake = createFakeRuntime({
+          frameworkId: created.length === 0 ? 'claude-code' : 'codex',
+          sessionIds: [`session-${created.length + 1}`],
+          callbacks
+        })
+        created.push(fake)
+        return fake.runtime
+      },
+      {},
+      '',
+      undefined,
+      onDisconnected,
+      onSessionUnavailable
+    )
 
     await coordinator.createSession()
     await coordinator.requestAgentFrameworkSwitch()
@@ -463,6 +512,15 @@ describe('AcpRuntimeCoordinator', () => {
     expect(created[1].runtime.shutdownForQuit).toHaveBeenCalledOnce()
     activeShutdown.resolve({ reaped: true })
     await expect(shuttingDown).rejects.toThrow('old shutdown failed')
+    expect(onSessionUnavailable).toHaveBeenCalledOnce()
+    expect(onSessionUnavailable).toHaveBeenCalledWith('session-2')
+    expect(onSessionUnavailable).not.toHaveBeenCalledWith('session-1')
+    expect(onDisconnected).not.toHaveBeenCalled()
+
+    vi.mocked(created[0].runtime.shutdownForQuit).mockResolvedValueOnce({ reaped: true })
+    await expect(coordinator.shutdownForQuit()).resolves.toEqual({ reaped: true })
+    expect(created[0].runtime.shutdownForQuit).toHaveBeenCalledTimes(2)
+    expect(onDisconnected).toHaveBeenCalledOnce()
   })
 
   it('runs new sessions immediately and moves the old session after its active turn', async () => {

--- a/src/main/acp/runtime-coordinator.test.ts
+++ b/src/main/acp/runtime-coordinator.test.ts
@@ -51,6 +51,7 @@ const createFakeRuntime = (options: {
   emitEvent: (event: AcpRuntimeEvent) => void
   emitPermission: (request: AcpPermissionRequest) => void
   emitState: (overrides: Partial<AcpStateSnapshot>) => void
+  setStateSilently: (overrides: Partial<AcpStateSnapshot>) => void
 } => {
   let snapshot = emptySnapshot()
   let sessionIndex = 0
@@ -185,6 +186,9 @@ const createFakeRuntime = (options: {
     emitState: (overrides) => {
       snapshot = { ...snapshot, ...overrides }
       options.callbacks.onStateChanged?.(snapshot)
+    },
+    setStateSilently: (overrides) => {
+      snapshot = { ...snapshot, ...overrides }
     }
   }
 }
@@ -380,22 +384,33 @@ describe('AcpRuntimeCoordinator', () => {
 
   it('attempts every runtime disconnect and preserves the surviving snapshot primary', async () => {
     const created: ReturnType<typeof createFakeRuntime>[] = []
-    const coordinator = new AcpRuntimeCoordinator((callbacks) => {
-      const fake = createFakeRuntime({
-        frameworkId: created.length === 0 ? 'claude-code' : 'codex',
-        sessionIds: [`session-${created.length + 1}`],
-        callbacks
-      })
-      created.push(fake)
-      return fake.runtime
-    })
+    const onSessionUnavailable = vi.fn()
+    const coordinator = new AcpRuntimeCoordinator(
+      (callbacks) => {
+        const fake = createFakeRuntime({
+          frameworkId: created.length === 0 ? 'claude-code' : 'codex',
+          sessionIds: [`session-${created.length + 1}`],
+          callbacks
+        })
+        created.push(fake)
+        return fake.runtime
+      },
+      {},
+      '',
+      undefined,
+      undefined,
+      onSessionUnavailable
+    )
 
     await coordinator.createSession()
     await coordinator.requestAgentFrameworkSwitch()
     await coordinator.createSession()
     created[0].emitState({ cwd: '/surviving-old-runtime' })
     const activeDisconnect = createDeferred<AcpStateSnapshot>()
-    created[0].disconnect.mockRejectedValueOnce(new Error('old disconnect failed'))
+    created[0].disconnect.mockImplementationOnce(async () => {
+      created[0].setStateSilently({ sessionId: undefined, sessionIds: [] })
+      throw new Error('old disconnect failed')
+    })
     created[1].disconnect.mockReturnValueOnce(activeDisconnect.promise)
 
     let settled = false
@@ -415,6 +430,41 @@ describe('AcpRuntimeCoordinator', () => {
       cwd: '/surviving-old-runtime'
     })
     expect(created).toHaveLength(2)
+    expect(onSessionUnavailable).toHaveBeenCalledTimes(2)
+    expect(onSessionUnavailable).toHaveBeenCalledWith('session-1')
+    expect(onSessionUnavailable).toHaveBeenCalledWith('session-2')
+  })
+
+  it('preserves sessions still reported by a runtime whose teardown rejects', async () => {
+    const created: ReturnType<typeof createFakeRuntime>[] = []
+    const onSessionUnavailable = vi.fn()
+    const coordinator = new AcpRuntimeCoordinator(
+      (callbacks) => {
+        const fake = createFakeRuntime({
+          frameworkId: created.length === 0 ? 'claude-code' : 'codex',
+          sessionIds: [`session-${created.length + 1}`],
+          callbacks
+        })
+        created.push(fake)
+        return fake.runtime
+      },
+      {},
+      '',
+      undefined,
+      undefined,
+      onSessionUnavailable
+    )
+
+    await coordinator.createSession()
+    await coordinator.requestAgentFrameworkSwitch()
+    await coordinator.createSession()
+    created[0].disconnect.mockRejectedValueOnce(new Error('old disconnect failed early'))
+
+    await expect(coordinator.disconnect()).rejects.toThrow('old disconnect failed early')
+
+    expect(onSessionUnavailable).toHaveBeenCalledOnce()
+    expect(onSessionUnavailable).toHaveBeenCalledWith('session-2')
+    expect(onSessionUnavailable).not.toHaveBeenCalledWith('session-1')
   })
 
   it('invalidates only sessions owned by a runtime that closes unexpectedly', async () => {
@@ -476,6 +526,74 @@ describe('AcpRuntimeCoordinator', () => {
     expect(onSessionUnavailable).toHaveBeenCalledWith('session-1')
   })
 
+  it('invalidates a successfully deleted detached session without a runtime state event', async () => {
+    const created: ReturnType<typeof createFakeRuntime>[] = []
+    const onSessionUnavailable = vi.fn()
+    const coordinator = new AcpRuntimeCoordinator(
+      (callbacks) => {
+        const fake = createFakeRuntime({
+          frameworkId: 'claude-code',
+          sessionIds: [],
+          callbacks
+        })
+        created.push(fake)
+        return fake.runtime
+      },
+      {},
+      '',
+      undefined,
+      undefined,
+      onSessionUnavailable
+    )
+
+    await coordinator.deleteSession({ sessionId: 'detached-session' })
+
+    expect(created[0].deleteSession).toHaveBeenCalledWith({ sessionId: 'detached-session' })
+    expect(onSessionUnavailable).toHaveBeenCalledOnce()
+    expect(onSessionUnavailable).toHaveBeenCalledWith('detached-session')
+  })
+
+  it('preserves a session adopted by a new generation while the old delete is in flight', async () => {
+    const created: ReturnType<typeof createFakeRuntime>[] = []
+    const onSessionUnavailable = vi.fn()
+    const coordinator = new AcpRuntimeCoordinator(
+      (callbacks) => {
+        const fake = createFakeRuntime({
+          frameworkId: created.length === 0 ? 'claude-code' : 'codex',
+          sessionIds: created.length === 0 ? ['session-1'] : [],
+          callbacks
+        })
+        created.push(fake)
+        return fake.runtime
+      },
+      {},
+      '',
+      undefined,
+      undefined,
+      onSessionUnavailable
+    )
+
+    await coordinator.createSession()
+    await coordinator.requestAgentFrameworkSwitch()
+    const deleteDeferred = createDeferred<AcpStateSnapshot>()
+    created[0].deleteSession.mockReturnValueOnce(deleteDeferred.promise)
+
+    const deleting = coordinator.deleteSession({ sessionId: 'session-1' })
+    await vi.waitFor(() => expect(created[0].deleteSession).toHaveBeenCalledOnce())
+    await coordinator.resumeSession({ sessionId: 'session-1', cwd: '/workspace' })
+    deleteDeferred.resolve(emptySnapshot())
+
+    await expect(deleting).resolves.toMatchObject({ sessionIds: ['session-1'] })
+    await coordinator.sendPrompt({ sessionId: 'session-1', text: 'continue on new runtime' })
+
+    expect(vi.mocked(created[0].runtime.sendPrompt)).not.toHaveBeenCalled()
+    expect(vi.mocked(created[1].runtime.sendPrompt)).toHaveBeenCalledWith({
+      sessionId: 'session-1',
+      text: 'continue on new runtime'
+    })
+    expect(onSessionUnavailable).not.toHaveBeenCalled()
+  })
+
   it('attempts every runtime quit teardown and preserves the surviving snapshot primary', async () => {
     const created: ReturnType<typeof createFakeRuntime>[] = []
     const onDisconnected = vi.fn()
@@ -502,9 +620,10 @@ describe('AcpRuntimeCoordinator', () => {
     await coordinator.createSession()
     created[0].emitState({ cwd: '/surviving-old-runtime' })
     const activeShutdown = createDeferred<{ reaped: boolean }>()
-    vi.mocked(created[0].runtime.shutdownForQuit).mockRejectedValueOnce(
-      new Error('old shutdown failed')
-    )
+    vi.mocked(created[0].runtime.shutdownForQuit).mockImplementationOnce(async () => {
+      created[0].setStateSilently({ sessionId: undefined, sessionIds: [] })
+      throw new Error('old shutdown failed')
+    })
     vi.mocked(created[1].runtime.shutdownForQuit).mockReturnValueOnce(activeShutdown.promise)
 
     let settled = false
@@ -519,9 +638,9 @@ describe('AcpRuntimeCoordinator', () => {
     expect(created[1].runtime.shutdownForQuit).toHaveBeenCalledOnce()
     activeShutdown.resolve({ reaped: true })
     await expect(shuttingDown).rejects.toThrow('old shutdown failed')
-    expect(onSessionUnavailable).toHaveBeenCalledOnce()
+    expect(onSessionUnavailable).toHaveBeenCalledTimes(2)
+    expect(onSessionUnavailable).toHaveBeenCalledWith('session-1')
     expect(onSessionUnavailable).toHaveBeenCalledWith('session-2')
-    expect(onSessionUnavailable).not.toHaveBeenCalledWith('session-1')
     expect(onDisconnected).not.toHaveBeenCalled()
     expect(coordinator.getSnapshot()).toMatchObject({
       status: 'connected',

--- a/src/main/acp/runtime-coordinator.test.ts
+++ b/src/main/acp/runtime-coordinator.test.ts
@@ -35,6 +35,7 @@ const createFakeRuntime = (options: {
   callbacks: AcpRuntimeCallbacks
   permissionGrantStore?: ConversationPermissionGrantStore
   beforePromptStart?: () => Promise<void>
+  eligibleAttachmentUri?: string
   prompt?: (sessionId: string) => Promise<unknown>
 }): {
   runtime: AcpRuntime
@@ -112,6 +113,13 @@ const createFakeRuntime = (options: {
         promptInFlightSessionIds: [...snapshot.promptInFlightSessionIds, sessionId]
       }
       options.callbacks.onPromptStarted?.(sessionId, turnToken, promptAttemptId)
+      if (options.eligibleAttachmentUri) {
+        options.callbacks.onSkillImportAttachmentEligible?.(
+          sessionId,
+          turnToken,
+          options.eligibleAttachmentUri
+        )
+      }
       options.callbacks.onStateChanged?.(snapshot)
 
       try {
@@ -312,16 +320,21 @@ describe('AcpRuntimeCoordinator', () => {
   it('forwards a real runtime prompt start to the session turn lifecycle', async () => {
     const onSessionTurnStarted = vi.fn()
     const onSessionTurnEnded = vi.fn()
+    const onSkillImportAttachmentEligible = vi.fn()
     const coordinator = new AcpRuntimeCoordinator(
       (callbacks) =>
-        createFakeRuntime({ frameworkId: 'claude-code', sessionIds: ['session-1'], callbacks })
-          .runtime,
+        createFakeRuntime({
+          frameworkId: 'claude-code',
+          sessionIds: ['session-1'],
+          callbacks,
+          eligibleAttachmentUri: 'file:///current.skill'
+        }).runtime,
       {},
       '',
       undefined,
       undefined,
       undefined,
-      { onSessionTurnStarted, onSessionTurnEnded }
+      { onSessionTurnStarted, onSessionTurnEnded, onSkillImportAttachmentEligible }
     )
 
     const session = await coordinator.createSession({ cwd: '/workspace' })
@@ -331,6 +344,11 @@ describe('AcpRuntimeCoordinator', () => {
     expect(onSessionTurnStarted).toHaveBeenCalledWith('session-1', 'turn-1')
     expect(onSessionTurnEnded).toHaveBeenCalledOnce()
     expect(onSessionTurnEnded).toHaveBeenCalledWith('session-1', 'turn-1')
+    expect(onSkillImportAttachmentEligible).toHaveBeenCalledWith(
+      'session-1',
+      'turn-1',
+      'file:///current.skill'
+    )
   })
 
   it('does not reactivate a prompt attempt cancelled before its runtime turn starts', async () => {

--- a/src/main/acp/runtime-coordinator.test.ts
+++ b/src/main/acp/runtime-coordinator.test.ts
@@ -378,7 +378,7 @@ describe('AcpRuntimeCoordinator', () => {
     expect(created[1].applyReasoningEffortChange).toHaveBeenCalledWith('high')
   })
 
-  it('attempts every runtime disconnect before surfacing a partial failure', async () => {
+  it('attempts every runtime disconnect and preserves the surviving snapshot primary', async () => {
     const created: ReturnType<typeof createFakeRuntime>[] = []
     const coordinator = new AcpRuntimeCoordinator((callbacks) => {
       const fake = createFakeRuntime({
@@ -393,6 +393,7 @@ describe('AcpRuntimeCoordinator', () => {
     await coordinator.createSession()
     await coordinator.requestAgentFrameworkSwitch()
     await coordinator.createSession()
+    created[0].emitState({ cwd: '/surviving-old-runtime' })
     const activeDisconnect = createDeferred<AcpStateSnapshot>()
     created[0].disconnect.mockRejectedValueOnce(new Error('old disconnect failed'))
     created[1].disconnect.mockReturnValueOnce(activeDisconnect.promise)
@@ -409,6 +410,11 @@ describe('AcpRuntimeCoordinator', () => {
     expect(created[1].disconnect).toHaveBeenCalledOnce()
     activeDisconnect.resolve(emptySnapshot())
     await expect(disconnecting).rejects.toThrow('old disconnect failed')
+    expect(coordinator.getSnapshot()).toMatchObject({
+      status: 'connected',
+      cwd: '/surviving-old-runtime'
+    })
+    expect(created).toHaveLength(2)
   })
 
   it('invalidates only sessions owned by a runtime that closes unexpectedly', async () => {
@@ -470,7 +476,7 @@ describe('AcpRuntimeCoordinator', () => {
     expect(onSessionUnavailable).toHaveBeenCalledWith('session-1')
   })
 
-  it('attempts every runtime quit teardown before surfacing a partial failure', async () => {
+  it('attempts every runtime quit teardown and preserves the surviving snapshot primary', async () => {
     const created: ReturnType<typeof createFakeRuntime>[] = []
     const onDisconnected = vi.fn()
     const onSessionUnavailable = vi.fn()
@@ -494,6 +500,7 @@ describe('AcpRuntimeCoordinator', () => {
     await coordinator.createSession()
     await coordinator.requestAgentFrameworkSwitch()
     await coordinator.createSession()
+    created[0].emitState({ cwd: '/surviving-old-runtime' })
     const activeShutdown = createDeferred<{ reaped: boolean }>()
     vi.mocked(created[0].runtime.shutdownForQuit).mockRejectedValueOnce(
       new Error('old shutdown failed')
@@ -516,6 +523,11 @@ describe('AcpRuntimeCoordinator', () => {
     expect(onSessionUnavailable).toHaveBeenCalledWith('session-2')
     expect(onSessionUnavailable).not.toHaveBeenCalledWith('session-1')
     expect(onDisconnected).not.toHaveBeenCalled()
+    expect(coordinator.getSnapshot()).toMatchObject({
+      status: 'connected',
+      cwd: '/surviving-old-runtime'
+    })
+    expect(created).toHaveLength(2)
 
     vi.mocked(created[0].runtime.shutdownForQuit).mockResolvedValueOnce({ reaped: true })
     await expect(coordinator.shutdownForQuit()).resolves.toEqual({ reaped: true })

--- a/src/main/acp/runtime-coordinator.ts
+++ b/src/main/acp/runtime-coordinator.ts
@@ -46,7 +46,8 @@ class AcpRuntimeCoordinator {
     private readonly callbacks: AcpRuntimeCallbacks = {},
     private readonly defaultCwd = '',
     private readonly initializationBarrier?: Promise<unknown>,
-    private readonly onDisconnecting?: () => void
+    private readonly onDisconnected?: () => void,
+    private readonly onSessionUnavailable?: (sessionId: string) => void
   ) {
     this.activeRuntime = this.addRuntime()
     this.lastRuntime = this.activeRuntime
@@ -131,7 +132,6 @@ class AcpRuntimeCoordinator {
 
   async disconnect(emitClosedStatus = true): Promise<AcpStateSnapshot> {
     this.supersedeInitializationRequests()
-    this.onDisconnecting?.()
     const runtimes = Array.from(this.runtimes)
     const results = await Promise.allSettled(
       runtimes.map((runtime) => runtime.disconnect(emitClosedStatus))
@@ -142,6 +142,7 @@ class AcpRuntimeCoordinator {
     // Keep ownership when any teardown fails so a later disconnect/shutdown can retry the runtime.
     if (failure) throw failure.reason
     this.clearRuntimeOwnership()
+    this.onDisconnected?.()
     return this.getSnapshot()
   }
 
@@ -149,6 +150,7 @@ class AcpRuntimeCoordinator {
     this.supersedeInitializationRequests()
     for (const runtime of this.runtimes) runtime.shutdown()
     this.clearRuntimeOwnership()
+    this.onDisconnected?.()
   }
 
   async shutdownForQuit(): Promise<{ reaped: boolean }> {
@@ -420,6 +422,7 @@ class AcpRuntimeCoordinator {
       } else {
         this.sessionConnectionStatuses.delete(sessionId)
       }
+      this.onSessionUnavailable?.(sessionId)
     }
     for (const sessionId of attached) {
       const owner = this.sessionRuntimes.get(sessionId)
@@ -445,6 +448,7 @@ class AcpRuntimeCoordinator {
       } else {
         this.sessionConnectionStatuses.delete(sessionId)
       }
+      this.onSessionUnavailable?.(sessionId)
     }
     for (const [requestId, owner] of this.permissionRuntimes) {
       if (owner === runtime) this.permissionRuntimes.delete(requestId)
@@ -487,6 +491,7 @@ class AcpRuntimeCoordinator {
     // Preserve failed runtime ownership so a bounded caller can retry or use the synchronous guard.
     if (failure) throw failure.reason
     this.clearRuntimeOwnership()
+    this.onDisconnected?.()
     return {
       reaped: outcomes.every((outcome) => outcome.status === 'fulfilled' && outcome.value.reaped)
     }

--- a/src/main/acp/runtime-coordinator.ts
+++ b/src/main/acp/runtime-coordinator.ts
@@ -25,6 +25,20 @@ type RuntimeFactory = (
   permissionGrantStore: ConversationPermissionGrantStore
 ) => AcpRuntime
 
+type AcpRuntimeCoordinatorTeardownCallbacks = {
+  onSessionTurnStarted?: (sessionId: string, turnToken: string) => void
+  onSessionTurnEnded?: (sessionId: string, turnToken: string) => void
+  onSessionCancellationRequested?: (sessionId: string) => void
+  onAllSessionsCancellationRequested?: () => void
+}
+
+type PendingPromptStart = {
+  id: string
+  runtime: AcpRuntime
+  sessionCancellationGeneration: number
+  globalCancellationGeneration: number
+}
+
 // Keeps each framework generation in its own AcpRuntime. Framework changes preserve active turns, then
 // retire their runtime so every later turn resumes through the newly selected framework.
 class AcpRuntimeCoordinator {
@@ -38,6 +52,10 @@ class AcpRuntimeCoordinator {
   private readonly permissionGrantStore = new ConversationPermissionGrantStore()
   private runtimeSequence = 0
   private initializationGeneration = 0
+  private globalCancellationGeneration = 0
+  private promptAttemptSequence = 0
+  private readonly sessionCancellationGenerations = new Map<string, number>()
+  private readonly pendingPromptStarts = new Map<string, PendingPromptStart[]>()
   private activeRuntime: AcpRuntime | undefined
   private lastRuntime: AcpRuntime | undefined
 
@@ -47,7 +65,8 @@ class AcpRuntimeCoordinator {
     private readonly defaultCwd = '',
     private readonly initializationBarrier?: Promise<unknown>,
     private readonly onDisconnected?: () => void,
-    private readonly onSessionUnavailable?: (sessionId: string) => void
+    private readonly onSessionUnavailable?: (sessionId: string) => void,
+    private readonly teardownCallbacks: AcpRuntimeCoordinatorTeardownCallbacks = {}
   ) {
     this.activeRuntime = this.addRuntime()
     this.lastRuntime = this.activeRuntime
@@ -131,6 +150,9 @@ class AcpRuntimeCoordinator {
   }
 
   async disconnect(emitClosedStatus = true): Promise<AcpStateSnapshot> {
+    // User teardown intent invalidates held approvals synchronously. Runtime shutdown may take time or
+    // reject after partial cleanup, but a dialog that was already open must not remain actionable.
+    this.invalidateAllSessionTurns()
     this.supersedeInitializationRequests()
     const runtimes = Array.from(this.runtimes)
     const results = await Promise.allSettled(
@@ -141,7 +163,7 @@ class AcpRuntimeCoordinator {
     )
     if (failure) {
       // A multi-runtime teardown can partially succeed. Release only the runtimes that are definitely
-      // gone so their pending approvals cannot outlive them; failed runtimes retain ownership for retry.
+      // gone; failed runtimes retain their session and permission-routing ownership for retry.
       // A rejection can still happen after a runtime cleared some/all sessions, so reconcile those
       // actual disappearances too without releasing the failed runtime itself.
       results.forEach((result, index) => {
@@ -158,6 +180,7 @@ class AcpRuntimeCoordinator {
   }
 
   shutdown(): void {
+    this.invalidateAllSessionTurns()
     this.supersedeInitializationRequests()
     for (const runtime of this.runtimes) runtime.shutdown()
     this.clearRuntimeOwnership()
@@ -165,11 +188,13 @@ class AcpRuntimeCoordinator {
   }
 
   async shutdownForQuit(): Promise<{ reaped: boolean }> {
+    this.invalidateAllSessionTurns()
     this.supersedeInitializationRequests()
     return this.shutdownAll((runtime) => runtime.shutdownForQuit())
   }
 
   async shutdownForUpdateGate(): Promise<{ reaped: boolean }> {
+    this.invalidateAllSessionTurns()
     this.supersedeInitializationRequests()
     return this.shutdownAll((runtime) => runtime.shutdownForUpdateGate())
   }
@@ -203,15 +228,30 @@ class AcpRuntimeCoordinator {
   }
 
   sendPrompt(request: AcpPromptRequest): ReturnType<AcpRuntime['sendPrompt']> {
-    return this.runtimeForSession(request.sessionId).sendPrompt(request)
+    const runtime = this.runtimeForSession(request.sessionId)
+    const attempt: PendingPromptStart = {
+      id: `prompt-attempt-${++this.promptAttemptSequence}`,
+      runtime,
+      sessionCancellationGeneration:
+        this.sessionCancellationGenerations.get(request.sessionId) ?? 0,
+      globalCancellationGeneration: this.globalCancellationGeneration
+    }
+    const pending = this.pendingPromptStarts.get(request.sessionId) ?? []
+    pending.push(attempt)
+    this.pendingPromptStarts.set(request.sessionId, pending)
+    return runtime
+      .sendPrompt(request, attempt.id)
+      .finally(() => this.removePendingPromptStart(request.sessionId, attempt))
   }
 
   async cancelPrompt(request: AcpCancelPromptRequest): Promise<AcpStateSnapshot> {
+    this.invalidateSessionTurn(request.sessionId)
     await this.runtimeForSession(request.sessionId).cancelPrompt(request)
     return this.getSnapshot()
   }
 
   async deleteSession(request: AcpDeleteSessionRequest): Promise<AcpStateSnapshot> {
+    this.invalidateSessionTurn(request.sessionId)
     const runtime = this.runtimeForSession(request.sessionId)
     const ownedBeforeDelete = this.sessionRuntimes.get(request.sessionId) === runtime
     await runtime.deleteSession(request)
@@ -386,6 +426,44 @@ class AcpRuntimeCoordinator {
     this.initializationGeneration += 1
   }
 
+  private invalidateSessionTurn(sessionId: string): void {
+    this.sessionCancellationGenerations.set(
+      sessionId,
+      (this.sessionCancellationGenerations.get(sessionId) ?? 0) + 1
+    )
+    this.teardownCallbacks.onSessionCancellationRequested?.(sessionId)
+  }
+
+  private invalidateAllSessionTurns(): void {
+    this.globalCancellationGeneration += 1
+    this.teardownCallbacks.onAllSessionsCancellationRequested?.()
+  }
+
+  private takePendingPromptStart(
+    sessionId: string,
+    runtime: AcpRuntime,
+    attemptId: string | undefined
+  ): PendingPromptStart | undefined {
+    if (!attemptId) return undefined
+    const pending = this.pendingPromptStarts.get(sessionId)
+    if (!pending) return undefined
+    const index = pending.findIndex(
+      (attempt) => attempt.runtime === runtime && attempt.id === attemptId
+    )
+    if (index < 0) return undefined
+    const [attempt] = pending.splice(index, 1)
+    if (pending.length === 0) this.pendingPromptStarts.delete(sessionId)
+    return attempt
+  }
+
+  private removePendingPromptStart(sessionId: string, attempt: PendingPromptStart): void {
+    const pending = this.pendingPromptStarts.get(sessionId)
+    if (!pending) return
+    const index = pending.indexOf(attempt)
+    if (index >= 0) pending.splice(index, 1)
+    if (pending.length === 0) this.pendingPromptStarts.delete(sessionId)
+  }
+
   private getActiveRuntime(): AcpRuntime {
     if (!this.activeRuntime) this.activeRuntime = this.addRuntime()
     this.lastRuntime = this.activeRuntime
@@ -420,6 +498,22 @@ class AcpRuntimeCoordinator {
         onPermissionRequest: (request) => {
           this.permissionRuntimes.set(request.requestId, runtime)
           this.callbacks.onPermissionRequest?.(request)
+        },
+        onPromptStarted: (sessionId, turnToken, promptAttemptId) => {
+          const attempt = this.takePendingPromptStart(sessionId, runtime, promptAttemptId)
+          if (
+            attempt &&
+            attempt.globalCancellationGeneration === this.globalCancellationGeneration &&
+            attempt.sessionCancellationGeneration ===
+              (this.sessionCancellationGenerations.get(sessionId) ?? 0)
+          ) {
+            this.teardownCallbacks.onSessionTurnStarted?.(sessionId, turnToken)
+          }
+          this.callbacks.onPromptStarted?.(sessionId, turnToken)
+        },
+        onPromptEnded: (sessionId, turnToken) => {
+          this.teardownCallbacks.onSessionTurnEnded?.(sessionId, turnToken)
+          this.callbacks.onPromptEnded?.(sessionId, turnToken)
         },
         onRetired: () => this.handleRuntimeRetired(runtime)
       },
@@ -528,7 +622,7 @@ class AcpRuntimeCoordinator {
     )
     if (failure) {
       // Awaitable shutdown paths suppress each runtime's closed-state event. Account for partial
-      // success here so only approvals belonging to runtimes that really stopped are invalidated.
+      // success here so only runtimes that really stopped release their routing ownership.
       // Rejected teardowns may nevertheless have cleared their session maps before the failing step.
       outcomes.forEach((outcome, index) => {
         const runtime = runtimes[index]
@@ -551,6 +645,7 @@ class AcpRuntimeCoordinator {
     this.sessionRuntimes.clear()
     this.sessionConnectionStatuses.clear()
     this.permissionRuntimes.clear()
+    this.pendingPromptStarts.clear()
     this.activeRuntime = undefined
     this.lastRuntime = undefined
   }

--- a/src/main/acp/runtime-coordinator.ts
+++ b/src/main/acp/runtime-coordinator.ts
@@ -466,7 +466,13 @@ class AcpRuntimeCoordinator {
       if (owner === runtime) this.permissionRuntimes.delete(requestId)
     }
     if (this.activeRuntime === runtime) this.activeRuntime = undefined
-    if (this.lastRuntime === runtime) this.lastRuntime = this.activeRuntime
+    if (this.lastRuntime === runtime) {
+      // Partial teardown keeps rejected runtimes for retry. If the runtime that did stop was also the
+      // snapshot primary, retain one survivor as lastRuntime so the coordinator does not publish idle
+      // while a live generation still owns sessions or permissions. Do not make a retired survivor the
+      // active target for new work; getActiveRuntime may create the selected framework generation later.
+      this.lastRuntime = this.activeRuntime ?? Array.from(this.runtimes).at(-1)
+    }
   }
 
   private visibleSessionIds(runtime: AcpRuntime, snapshot: AcpStateSnapshot): string[] {

--- a/src/main/acp/runtime-coordinator.ts
+++ b/src/main/acp/runtime-coordinator.ts
@@ -28,6 +28,11 @@ type RuntimeFactory = (
 type AcpRuntimeCoordinatorTeardownCallbacks = {
   onSessionTurnStarted?: (sessionId: string, turnToken: string) => void
   onSessionTurnEnded?: (sessionId: string, turnToken: string) => void
+  onSkillImportAttachmentEligible?: (
+    sessionId: string,
+    turnToken: string,
+    attachmentUri: string
+  ) => void
   onSessionCancellationRequested?: (sessionId: string) => void
   onAllSessionsCancellationRequested?: () => void
 }
@@ -514,6 +519,14 @@ class AcpRuntimeCoordinator {
         onPromptEnded: (sessionId, turnToken) => {
           this.teardownCallbacks.onSessionTurnEnded?.(sessionId, turnToken)
           this.callbacks.onPromptEnded?.(sessionId, turnToken)
+        },
+        onSkillImportAttachmentEligible: (sessionId, turnToken, attachmentUri) => {
+          this.teardownCallbacks.onSkillImportAttachmentEligible?.(
+            sessionId,
+            turnToken,
+            attachmentUri
+          )
+          this.callbacks.onSkillImportAttachmentEligible?.(sessionId, turnToken, attachmentUri)
         },
         onRetired: () => this.handleRuntimeRetired(runtime)
       },

--- a/src/main/acp/runtime-coordinator.ts
+++ b/src/main/acp/runtime-coordinator.ts
@@ -142,8 +142,12 @@ class AcpRuntimeCoordinator {
     if (failure) {
       // A multi-runtime teardown can partially succeed. Release only the runtimes that are definitely
       // gone so their pending approvals cannot outlive them; failed runtimes retain ownership for retry.
+      // A rejection can still happen after a runtime cleared some/all sessions, so reconcile those
+      // actual disappearances too without releasing the failed runtime itself.
       results.forEach((result, index) => {
-        if (result.status === 'fulfilled') this.releaseRuntimeOwnership(runtimes[index])
+        const runtime = runtimes[index]
+        if (result.status === 'fulfilled') this.releaseRuntimeOwnership(runtime)
+        else this.releaseMissingRuntimeSessions(runtime, runtime.getSnapshot())
       })
       this.callbacks.onStateChanged?.(this.getSnapshot())
       throw failure.reason
@@ -209,9 +213,18 @@ class AcpRuntimeCoordinator {
 
   async deleteSession(request: AcpDeleteSessionRequest): Promise<AcpStateSnapshot> {
     const runtime = this.runtimeForSession(request.sessionId)
+    const ownedBeforeDelete = this.sessionRuntimes.get(request.sessionId) === runtime
     await runtime.deleteSession(request)
-    this.sessionRuntimes.delete(request.sessionId)
-    this.sessionConnectionStatuses.delete(request.sessionId)
+    const ownerAfterDelete = this.sessionRuntimes.get(request.sessionId)
+    // Attached deletes emit a runtime state change, whose reconciliation already notifies exactly once.
+    // Detached cleanup deliberately emits no state, so complete its session-scoped teardown here. A
+    // concurrent resume may have transferred the same app session to a new generation while the old
+    // agent delete was in flight; preserve that new owner and its connection status in full.
+    if (ownerAfterDelete === runtime || (!ownerAfterDelete && !ownedBeforeDelete)) {
+      this.sessionRuntimes.delete(request.sessionId)
+      this.sessionConnectionStatuses.delete(request.sessionId)
+      this.onSessionUnavailable?.(request.sessionId)
+    }
     return this.getSnapshot()
   }
 
@@ -419,6 +432,23 @@ class AcpRuntimeCoordinator {
   }
 
   private handleRuntimeState(runtime: AcpRuntime, snapshot: AcpStateSnapshot): void {
+    const attached = this.releaseMissingRuntimeSessions(runtime, snapshot)
+    for (const sessionId of attached) {
+      const owner = this.sessionRuntimes.get(sessionId)
+      // A late state emission from a retiring runtime must not steal back a session already adopted by
+      // the current generation.
+      if (!owner || !this.retiredRuntimes.has(runtime) || this.retiredRuntimes.has(owner)) {
+        this.sessionRuntimes.set(sessionId, runtime)
+        this.sessionConnectionStatuses.set(sessionId, snapshot.status)
+      }
+    }
+    this.callbacks.onStateChanged?.(this.getSnapshot())
+  }
+
+  private releaseMissingRuntimeSessions(
+    runtime: AcpRuntime,
+    snapshot: AcpStateSnapshot
+  ): Set<string> {
     const attached = new Set(snapshot.sessionIds)
     for (const [sessionId, owner] of this.sessionRuntimes) {
       if (owner !== runtime || attached.has(sessionId)) continue
@@ -431,16 +461,7 @@ class AcpRuntimeCoordinator {
       }
       this.onSessionUnavailable?.(sessionId)
     }
-    for (const sessionId of attached) {
-      const owner = this.sessionRuntimes.get(sessionId)
-      // A late state emission from a retiring runtime must not steal back a session already adopted by
-      // the current generation.
-      if (!owner || !this.retiredRuntimes.has(runtime) || this.retiredRuntimes.has(owner)) {
-        this.sessionRuntimes.set(sessionId, runtime)
-        this.sessionConnectionStatuses.set(sessionId, snapshot.status)
-      }
-    }
-    this.callbacks.onStateChanged?.(this.getSnapshot())
+    return attached
   }
 
   private handleRuntimeRetired(runtime: AcpRuntime): void {
@@ -508,8 +529,11 @@ class AcpRuntimeCoordinator {
     if (failure) {
       // Awaitable shutdown paths suppress each runtime's closed-state event. Account for partial
       // success here so only approvals belonging to runtimes that really stopped are invalidated.
+      // Rejected teardowns may nevertheless have cleared their session maps before the failing step.
       outcomes.forEach((outcome, index) => {
-        if (outcome.status === 'fulfilled') this.releaseRuntimeOwnership(runtimes[index])
+        const runtime = runtimes[index]
+        if (outcome.status === 'fulfilled') this.releaseRuntimeOwnership(runtime)
+        else this.releaseMissingRuntimeSessions(runtime, runtime.getSnapshot())
       })
       this.callbacks.onStateChanged?.(this.getSnapshot())
       throw failure.reason

--- a/src/main/acp/runtime-coordinator.ts
+++ b/src/main/acp/runtime-coordinator.ts
@@ -139,8 +139,15 @@ class AcpRuntimeCoordinator {
     const failure = results.find(
       (result): result is PromiseRejectedResult => result.status === 'rejected'
     )
-    // Keep ownership when any teardown fails so a later disconnect/shutdown can retry the runtime.
-    if (failure) throw failure.reason
+    if (failure) {
+      // A multi-runtime teardown can partially succeed. Release only the runtimes that are definitely
+      // gone so their pending approvals cannot outlive them; failed runtimes retain ownership for retry.
+      results.forEach((result, index) => {
+        if (result.status === 'fulfilled') this.releaseRuntimeOwnership(runtimes[index])
+      })
+      this.callbacks.onStateChanged?.(this.getSnapshot())
+      throw failure.reason
+    }
     this.clearRuntimeOwnership()
     this.onDisconnected?.()
     return this.getSnapshot()
@@ -437,6 +444,11 @@ class AcpRuntimeCoordinator {
   }
 
   private handleRuntimeRetired(runtime: AcpRuntime): void {
+    this.releaseRuntimeOwnership(runtime)
+    this.callbacks.onStateChanged?.(this.getSnapshot())
+  }
+
+  private releaseRuntimeOwnership(runtime: AcpRuntime): void {
     const retiredStatus = runtime.getSnapshot().status
     this.runtimes.delete(runtime)
     this.retiredRuntimes.delete(runtime)
@@ -455,7 +467,6 @@ class AcpRuntimeCoordinator {
     }
     if (this.activeRuntime === runtime) this.activeRuntime = undefined
     if (this.lastRuntime === runtime) this.lastRuntime = this.activeRuntime
-    this.callbacks.onStateChanged?.(this.getSnapshot())
   }
 
   private visibleSessionIds(runtime: AcpRuntime, snapshot: AcpStateSnapshot): string[] {
@@ -488,8 +499,15 @@ class AcpRuntimeCoordinator {
     const failure = outcomes.find(
       (outcome): outcome is PromiseRejectedResult => outcome.status === 'rejected'
     )
-    // Preserve failed runtime ownership so a bounded caller can retry or use the synchronous guard.
-    if (failure) throw failure.reason
+    if (failure) {
+      // Awaitable shutdown paths suppress each runtime's closed-state event. Account for partial
+      // success here so only approvals belonging to runtimes that really stopped are invalidated.
+      outcomes.forEach((outcome, index) => {
+        if (outcome.status === 'fulfilled') this.releaseRuntimeOwnership(runtimes[index])
+      })
+      this.callbacks.onStateChanged?.(this.getSnapshot())
+      throw failure.reason
+    }
     this.clearRuntimeOwnership()
     this.onDisconnected?.()
     return {

--- a/src/main/acp/runtime.test.ts
+++ b/src/main/acp/runtime.test.ts
@@ -1371,6 +1371,7 @@ describe('ACP runtime session management', () => {
     })
     const process = new FakeAgentProcess()
     const receivedPrompts: ContentBlock[][] = []
+    const onSkillImportAttachmentEligible = vi.fn()
     startFakeAgent(process, ['remote-session-1'], {
       onPrompt: ({ prompt }) => {
         receivedPrompts.push(prompt)
@@ -1380,7 +1381,8 @@ describe('ACP runtime session management', () => {
       appVersion: '0.1.0',
       defaultCwd: '/workspace',
       spawnAgent: () => asAgentProcess(process),
-      uploads: { repository: uploadRepository }
+      uploads: { repository: uploadRepository },
+      callbacks: { onSkillImportAttachmentEligible }
     })
 
     const session = await runtime.createSession({ cwd: '/workspace' })
@@ -1415,6 +1417,12 @@ describe('ACP runtime session management', () => {
         /<attached_local_archive>[\s\S]*renamed-garbage\.skill[\s\S]*"skillImportEligible":false/
       )
     })
+    expect(onSkillImportAttachmentEligible).toHaveBeenCalledOnce()
+    expect(onSkillImportAttachmentEligible).toHaveBeenCalledWith(
+      session.sessionId,
+      expect.stringMatching(/^[0-9a-f-]{36}$/),
+      expect.stringMatching(/example-package\.skill$/)
+    )
   })
 
   it('inlines an image attachment as pixels when the browser sent no usable MIME type', async () => {

--- a/src/main/acp/runtime.test.ts
+++ b/src/main/acp/runtime.test.ts
@@ -1315,7 +1315,7 @@ describe('ACP runtime session management', () => {
     ).resolves.toBe('hello from upload')
   })
 
-  it('keeps ordinary ZIP uploads as resources while sending explicit Skill packages as text', async () => {
+  it('keeps ordinary ZIPs on provider-safe references and marks only Skill packages eligible', async () => {
     const root = await createTemporaryRoot()
     const uploadRepository = new UploadRepository(root)
     const stagedAttachments = await uploadRepository.stageFiles({
@@ -1323,6 +1323,11 @@ describe('ACP runtime session management', () => {
         {
           name: 'ordinary-data.zip',
           mimeType: 'application/zip',
+          content: Buffer.from('zip-bytes').toString('base64')
+        },
+        {
+          name: 'ordinary-data.bin',
+          mimeType: ' Application/ZIP ; charset=binary ',
           content: Buffer.from('zip-bytes').toString('base64')
         },
         {
@@ -1355,17 +1360,21 @@ describe('ACP runtime session management', () => {
 
     expect(receivedPrompts).toHaveLength(1)
     expect(receivedPrompts[0][1]).toMatchObject({
-      type: 'resource_link',
-      name: 'ordinary-data.zip',
-      mimeType: 'application/zip',
-      uri: expect.stringMatching(
-        /file:\/\/\/.*\/uploads\/default-project\/remote-session-1\/ordinary-data\.zip/
+      type: 'text',
+      text: expect.stringMatching(
+        /<attached_local_archive>[\s\S]*ordinary-data\.zip[\s\S]*"skillImportEligible":false/
       )
     })
     expect(receivedPrompts[0][2]).toMatchObject({
       type: 'text',
       text: expect.stringMatching(
-        /"uri":"file:\/\/\/.*\/uploads\/default-project\/remote-session-1\/example-package\.skill"/
+        /<attached_local_archive>[\s\S]*ordinary-data\.bin[\s\S]*"skillImportEligible":false/
+      )
+    })
+    expect(receivedPrompts[0][3]).toMatchObject({
+      type: 'text',
+      text: expect.stringMatching(
+        /<attached_skill_package>[\s\S]*example-package\.skill[\s\S]*"skillImportEligible":true/
       )
     })
   })
@@ -2279,7 +2288,7 @@ describe('ACP runtime session management', () => {
 
     expect(receivedPrompts[0][1]).toMatchObject({
       type: 'text',
-      text: expect.stringMatching(/<attached_local_file>[\s\S]*current\.skill/)
+      text: expect.stringMatching(/<attached_skill_package>[\s\S]*current\.skill/)
     })
     expect(receivedPrompts[0][2]).toMatchObject({
       type: 'resource_link',

--- a/src/main/acp/runtime.test.ts
+++ b/src/main/acp/runtime.test.ts
@@ -2205,6 +2205,90 @@ describe('ACP runtime session management', () => {
     })
   })
 
+  it('advertises only current-session upload references to the Skill importer', async () => {
+    const root = await createTemporaryRoot()
+    const uploadRepository = new UploadRepository(root)
+    const staged = await uploadRepository.stageFiles({
+      files: [
+        {
+          name: 'current.skill',
+          mimeType: 'application/octet-stream',
+          content: Buffer.from('current skill bytes').toString('base64')
+        },
+        {
+          name: 'other.skill',
+          mimeType: 'application/octet-stream',
+          content: Buffer.from('other skill bytes').toString('base64')
+        }
+      ]
+    })
+    const [currentSessionUpload] = await uploadRepository.finalizePendingSessionUploads(
+      'remote-session-1',
+      [staged[0]]
+    )
+    const [otherSessionUpload] = await uploadRepository.finalizePendingSessionUploads(
+      'remote-session-2',
+      [staged[1]]
+    )
+
+    const process = new FakeAgentProcess()
+    const receivedPrompts: ContentBlock[][] = []
+    startFakeAgent(process, ['remote-session-1'], {
+      onPrompt: ({ prompt }) => {
+        receivedPrompts.push(prompt)
+      }
+    })
+    const runtime = new AcpRuntime({
+      appVersion: '0.1.0',
+      defaultCwd: '/workspace',
+      spawnAgent: () => asAgentProcess(process),
+      uploads: { repository: uploadRepository }
+    })
+
+    const session = await runtime.createSession({ cwd: '/workspace' })
+    await expect(
+      uploadRepository.resolveSessionUploadPath(session.sessionId, {
+        path: currentSessionUpload.path
+      })
+    ).resolves.toMatch(/remote-session-1\/current\.skill$/)
+    await expect(
+      uploadRepository.resolveSessionUploadPath(session.sessionId, {
+        path: otherSessionUpload.path
+      })
+    ).rejects.toThrow(/different session/)
+    await runtime.sendPrompt({
+      sessionId: session.sessionId,
+      text: 'compare these packages',
+      referencedArtifacts: [
+        {
+          id: 'current',
+          name: currentSessionUpload.originalName,
+          path: currentSessionUpload.path,
+          source: 'upload',
+          mimeType: currentSessionUpload.mimeType
+        },
+        {
+          id: 'other',
+          name: otherSessionUpload.originalName,
+          path: otherSessionUpload.path,
+          source: 'upload',
+          mimeType: otherSessionUpload.mimeType
+        }
+      ]
+    })
+
+    expect(receivedPrompts[0][1]).toMatchObject({
+      type: 'text',
+      text: expect.stringMatching(/<attached_local_file>[\s\S]*current\.skill/)
+    })
+    expect(receivedPrompts[0][2]).toMatchObject({
+      type: 'resource_link',
+      name: 'other.skill',
+      title: 'other.skill',
+      uri: expect.stringContaining('other.skill')
+    })
+  })
+
   it('resolves a bare-filename artifact write against the final-session notebook dir despite the alias', async () => {
     // Regression for the alias/final-id mismatch: the notebook MCP env is built at session creation
     // under a pre-start alias, but kernels write under the FINAL ACP session id. The per-turn handoff

--- a/src/main/acp/runtime.test.ts
+++ b/src/main/acp/runtime.test.ts
@@ -1315,13 +1315,13 @@ describe('ACP runtime session management', () => {
     ).resolves.toBe('hello from upload')
   })
 
-  it('sends Skill packages as text references instead of unsupported ZIP file parts', async () => {
+  it('keeps ordinary ZIP uploads as resources while sending explicit Skill packages as text', async () => {
     const root = await createTemporaryRoot()
     const uploadRepository = new UploadRepository(root)
     const stagedAttachments = await uploadRepository.stageFiles({
       files: [
         {
-          name: 'example-skill.zip',
+          name: 'ordinary-data.zip',
           mimeType: 'application/zip',
           content: Buffer.from('zip-bytes').toString('base64')
         },
@@ -1355,9 +1355,11 @@ describe('ACP runtime session management', () => {
 
     expect(receivedPrompts).toHaveLength(1)
     expect(receivedPrompts[0][1]).toMatchObject({
-      type: 'text',
-      text: expect.stringMatching(
-        /"uri":"file:\/\/\/.*\/uploads\/default-project\/remote-session-1\/example-skill\.zip"/
+      type: 'resource_link',
+      name: 'ordinary-data.zip',
+      mimeType: 'application/zip',
+      uri: expect.stringMatching(
+        /file:\/\/\/.*\/uploads\/default-project\/remote-session-1\/ordinary-data\.zip/
       )
     })
     expect(receivedPrompts[0][2]).toMatchObject({
@@ -1366,9 +1368,6 @@ describe('ACP runtime session management', () => {
         /"uri":"file:\/\/\/.*\/uploads\/default-project\/remote-session-1\/example-package\.skill"/
       )
     })
-    expect(receivedPrompts[0]).not.toContainEqual(
-      expect.objectContaining({ type: 'resource_link' })
-    )
   })
 
   it('inlines an image attachment as pixels when the browser sent no usable MIME type', async () => {
@@ -2098,6 +2097,21 @@ describe('ACP runtime session management', () => {
       }
     })
 
+    // An artifact-backed Skill package is not owned by the upload-only import tool, so the prompt
+    // must retain it as an ordinary resource instead of advertising an unusable import URI.
+    const skillArtifact = await artifactRepository.writePendingFile({
+      projectName: 'default-project',
+      sessionId: 'remote-session-1',
+      runId: 'run-1',
+      filename: 'generated.skill',
+      mimeType: 'application/octet-stream',
+      source: {
+        kind: 'inline',
+        content: Buffer.from('skill-archive-bytes').toString('base64'),
+        encoding: 'base64'
+      }
+    })
+
     const process = new FakeAgentProcess()
     const receivedPrompts: ContentBlock[][] = []
     startFakeAgent(process, ['remote-session-1'], {
@@ -2144,6 +2158,13 @@ describe('ACP runtime session management', () => {
           path: binaryArtifact.path,
           source: 'artifact',
           mimeType: binaryArtifact.mimeType
+        },
+        {
+          id: 'a3',
+          name: skillArtifact.name,
+          path: skillArtifact.path,
+          source: 'artifact',
+          mimeType: skillArtifact.mimeType
         }
       ]
     })
@@ -2173,6 +2194,14 @@ describe('ACP runtime session management', () => {
       title: 'data.bin',
       mimeType: 'application/octet-stream',
       uri: expect.stringContaining('data.bin')
+    })
+    // Artifact-backed Skill package -> ordinary resource link, never the upload-only import wrapper.
+    expect(receivedPrompts[0][4]).toMatchObject({
+      type: 'resource_link',
+      name: 'generated.skill',
+      title: 'generated.skill',
+      mimeType: 'application/octet-stream',
+      uri: expect.stringContaining('generated.skill')
     })
   })
 

--- a/src/main/acp/runtime.test.ts
+++ b/src/main/acp/runtime.test.ts
@@ -346,6 +346,32 @@ const createTemporaryRoot = async (): Promise<string> => {
   return temporaryRoot
 }
 
+const buildStoredSkillArchive = (skillName: string): Buffer => {
+  const path = Buffer.from('SKILL.md', 'utf8')
+  const content = Buffer.from(`---\nname: ${skillName}\n---\nFollow the workflow.`, 'utf8')
+  const local = Buffer.alloc(30 + path.length)
+  local.writeUInt32LE(0x04034b50, 0)
+  local.writeUInt32LE(content.length, 18)
+  local.writeUInt32LE(content.length, 22)
+  local.writeUInt16LE(path.length, 26)
+  path.copy(local, 30)
+
+  const central = Buffer.alloc(46 + path.length)
+  central.writeUInt32LE(0x02014b50, 0)
+  central.writeUInt32LE(content.length, 20)
+  central.writeUInt32LE(content.length, 24)
+  central.writeUInt16LE(path.length, 28)
+  path.copy(central, 46)
+
+  const end = Buffer.alloc(22)
+  end.writeUInt32LE(0x06054b50, 0)
+  end.writeUInt16LE(1, 8)
+  end.writeUInt16LE(1, 10)
+  end.writeUInt32LE(central.length, 12)
+  end.writeUInt32LE(local.length + content.length, 16)
+  return Buffer.concat([local, content, central, end])
+}
+
 const getEnvValue = (mcpServer: unknown, name: string): string => {
   if (
     typeof mcpServer !== 'object' ||
@@ -1318,6 +1344,7 @@ describe('ACP runtime session management', () => {
   it('keeps ordinary ZIPs on provider-safe references and marks only Skill packages eligible', async () => {
     const root = await createTemporaryRoot()
     const uploadRepository = new UploadRepository(root)
+    const skillArchive = buildStoredSkillArchive('Example Package')
     const stagedAttachments = await uploadRepository.stageFiles({
       files: [
         {
@@ -1333,7 +1360,12 @@ describe('ACP runtime session management', () => {
         {
           name: 'example-package.skill',
           mimeType: 'application/octet-stream',
-          content: Buffer.from('skill-bytes').toString('base64')
+          content: skillArchive.toString('base64')
+        },
+        {
+          name: 'renamed-garbage.skill',
+          mimeType: 'application/octet-stream',
+          content: Buffer.from('not a Skill archive').toString('base64')
         }
       ]
     })
@@ -1374,7 +1406,13 @@ describe('ACP runtime session management', () => {
     expect(receivedPrompts[0][3]).toMatchObject({
       type: 'text',
       text: expect.stringMatching(
-        /<attached_skill_package>[\s\S]*example-package\.skill[\s\S]*"skillImportEligible":true/
+        /<attached_skill_package>[\s\S]*example-package\.skill[\s\S]*"skillImportEligible":true[\s\S]*"skillImportTurnToken":"[0-9a-f-]{36}"/
+      )
+    })
+    expect(receivedPrompts[0][4]).toMatchObject({
+      type: 'text',
+      text: expect.stringMatching(
+        /<attached_local_archive>[\s\S]*renamed-garbage\.skill[\s\S]*"skillImportEligible":false/
       )
     })
   })
@@ -2204,25 +2242,26 @@ describe('ACP runtime session management', () => {
       mimeType: 'application/octet-stream',
       uri: expect.stringContaining('data.bin')
     })
-    // Artifact-backed Skill package -> ordinary resource link, never the upload-only import wrapper.
+    // Artifact-backed Skill package -> provider-safe ordinary archive reference, never the
+    // current-session import wrapper.
     expect(receivedPrompts[0][4]).toMatchObject({
-      type: 'resource_link',
-      name: 'generated.skill',
-      title: 'generated.skill',
-      mimeType: 'application/octet-stream',
-      uri: expect.stringContaining('generated.skill')
+      type: 'text',
+      text: expect.stringMatching(
+        /<attached_local_archive>[\s\S]*generated\.skill[\s\S]*"skillImportEligible":false/
+      )
     })
   })
 
   it('advertises only current-session upload references to the Skill importer', async () => {
     const root = await createTemporaryRoot()
     const uploadRepository = new UploadRepository(root)
+    const currentSkillArchive = buildStoredSkillArchive('Current Skill')
     const staged = await uploadRepository.stageFiles({
       files: [
         {
           name: 'current.skill',
           mimeType: 'application/octet-stream',
-          content: Buffer.from('current skill bytes').toString('base64')
+          content: currentSkillArchive.toString('base64')
         },
         {
           name: 'other.skill',
@@ -2288,13 +2327,15 @@ describe('ACP runtime session management', () => {
 
     expect(receivedPrompts[0][1]).toMatchObject({
       type: 'text',
-      text: expect.stringMatching(/<attached_skill_package>[\s\S]*current\.skill/)
+      text: expect.stringMatching(
+        /<attached_skill_package>[\s\S]*current\.skill[\s\S]*"skillImportTurnToken":"[0-9a-f-]{36}"/
+      )
     })
     expect(receivedPrompts[0][2]).toMatchObject({
-      type: 'resource_link',
-      name: 'other.skill',
-      title: 'other.skill',
-      uri: expect.stringContaining('other.skill')
+      type: 'text',
+      text: expect.stringMatching(
+        /<attached_local_archive>[\s\S]*other\.skill[\s\S]*"skillImportEligible":false/
+      )
     })
   })
 
@@ -7432,6 +7473,63 @@ describe('ACP runtime skill force-load + nudge', () => {
       })
     ),
     catalogForCodexHome: vi.fn(async () => options.catalog ?? [])
+  })
+
+  it('does not let a delayed pre-start attempt overwrite a newer active turn', async () => {
+    const process = new FakeAgentProcess()
+    const skillCheckEntered = createDeferred()
+    const releaseSkillCheck = createDeferred()
+    const newerPromptEntered = createDeferred()
+    const releaseNewerPrompt = createDeferred()
+    const onPromptStarted = vi.fn()
+    const onPromptEnded = vi.fn()
+    startFakeAgent(process, ['remote-session-1'], {
+      onPrompt: async ({ text }) => {
+        if (text === 'newer prompt') {
+          newerPromptEntered.resolve()
+          await releaseNewerPrompt.promise
+        }
+      }
+    })
+    const runtime = new AcpRuntime({
+      appVersion: '0.1.0',
+      defaultCwd: '/workspace',
+      spawnAgent: () => asAgentProcess(process),
+      callbacks: { onPromptStarted, onPromptEnded },
+      skills: {
+        needForceLoad: async () => {
+          skillCheckEntered.resolve()
+          await releaseSkillCheck.promise
+          return ['research']
+        },
+        namesForIds: async (ids) => ids
+      }
+    })
+    const session = await runtime.createSession({ cwd: '/workspace' })
+
+    const delayedPrompt = runtime.sendPrompt({
+      sessionId: session.sessionId,
+      text: 'delayed prompt',
+      forcedSkillIds: ['research']
+    })
+    await skillCheckEntered.promise
+    await runtime.cancelPrompt({ sessionId: session.sessionId })
+
+    const newerPrompt = runtime.sendPrompt({
+      sessionId: session.sessionId,
+      text: 'newer prompt'
+    })
+    await newerPromptEntered.promise
+    releaseSkillCheck.resolve()
+
+    await expect(delayedPrompt).rejects.toThrow(/already running/)
+    expect(onPromptStarted).toHaveBeenCalledOnce()
+    expect(process.killed).toBe(false)
+
+    releaseNewerPrompt.resolve()
+    await expect(newerPrompt).resolves.toMatchObject({ stopReason: 'end_turn' })
+    expect(onPromptEnded).toHaveBeenCalledOnce()
+    expect(onPromptEnded).toHaveBeenCalledWith(session.sessionId, onPromptStarted.mock.calls[0][1])
   })
 
   it('passes turn-forced skill ids to backend resolution per runtime instance', async () => {

--- a/src/main/acp/runtime.ts
+++ b/src/main/acp/runtime.ts
@@ -140,6 +140,11 @@ export type AcpRuntimeCallbacks = {
   onPermissionRequest?: (request: AcpPermissionRequest) => void
   onPromptStarted?: (sessionId: string, turnToken: string, promptAttemptId?: string) => void
   onPromptEnded?: (sessionId: string, turnToken: string) => void
+  onSkillImportAttachmentEligible?: (
+    sessionId: string,
+    turnToken: string,
+    attachmentUri: string
+  ) => void
   onRetired?: () => void
 }
 
@@ -3028,6 +3033,11 @@ class AcpRuntime {
     if (allowSkillImportReference && (await this.isSkillPackageFile(name, absolutePath))) {
       const turnToken = this.skillImportTurnTokens.get(sessionId)
       if (turnToken) {
+        try {
+          this.callbacks.onSkillImportAttachmentEligible?.(sessionId, turnToken, uri)
+        } catch (error) {
+          safeLogError('skill import attachment callback failed', errorLogFields(error))
+        }
         return [attachmentTextReference('attached_skill_package', true, turnToken)]
       }
     }

--- a/src/main/acp/runtime.ts
+++ b/src/main/acp/runtime.ts
@@ -108,8 +108,7 @@ import {
   type SkillImportMcpEnvironment,
   type SkillImportRpcConnection
 } from '../skills/mcp-server'
-import { isImportableSkillArchive } from '../skills/user-skill-repository'
-import { SKILL_IMPORT_LIMITS } from '../skills/import-limits'
+import { isImportableSkillArchivePath } from '../skills/skill-archive-sniffer'
 import { getNotebookDataRoot, getNotebookSessionRoot } from '../notebook/repository'
 import { codexStorageDir, codexSubscriptionStorageDir } from '../agent-framework/codex'
 import { getAppClaudeConfigDir } from '../settings/provider-env'
@@ -2898,7 +2897,10 @@ class AcpRuntime {
     sessionId: string,
     reference: ArtifactReference
   ): Promise<ContentBlock[]> {
-    const filePath = await this.resolveReferencedArtifactPath(reference)
+    const { filePath, allowSkillImportReference } = await this.resolveReferencedArtifactPath(
+      sessionId,
+      reference
+    )
     const { size } = await stat(filePath)
 
     return this.buildFileContentBlock({
@@ -2910,19 +2912,39 @@ class AcpRuntime {
       size,
       // The import tool currently owns only session uploads. Artifact-store paths remain ordinary
       // references so the prompt never advertises a URI that main will reject at the trust boundary.
-      allowSkillImportReference: reference.source === 'upload'
+      allowSkillImportReference
     })
   }
 
   // Resolves a referenced file through the managed-path validator for its owning repository.
-  private async resolveReferencedArtifactPath(reference: ArtifactReference): Promise<string> {
+  private async resolveReferencedArtifactPath(
+    sessionId: string,
+    reference: ArtifactReference
+  ): Promise<{ filePath: string; allowSkillImportReference: boolean }> {
     if (reference.source === 'upload') {
       if (!this.uploadRepository) throw new Error('Upload storage is not configured.')
-      return this.uploadRepository.resolveManagedUploadPath({ path: reference.path })
+      try {
+        return {
+          filePath: await this.uploadRepository.resolveSessionUploadPath(sessionId, {
+            path: reference.path
+          }),
+          allowSkillImportReference: true
+        }
+      } catch {
+        // Cross-session uploads remain readable generic references, but the session-scoped importer
+        // must never be advertised for a path its ownership boundary will reject.
+        return {
+          filePath: await this.uploadRepository.resolveManagedUploadPath({ path: reference.path }),
+          allowSkillImportReference: false
+        }
+      }
     }
 
     if (!this.artifactRepository) throw new Error('Artifact storage is not configured.')
-    return this.artifactRepository.resolveManagedFilePath({ path: reference.path })
+    return {
+      filePath: await this.artifactRepository.resolveManagedFilePath({ path: reference.path }),
+      allowSkillImportReference: false
+    }
   }
 
   // Builds the richest ACP content block that is safe for a resolved file, shared by uploads and
@@ -2944,7 +2966,7 @@ class AcpRuntime {
     // to expose their exact local URI: the agent passes it to the app-owned request_skill_import tool,
     // which performs parsing, validation and user confirmation. Keep the reference as JSON text so it
     // also remains usable when the user wants to inspect the archive instead of importing it.
-    if (allowSkillImportReference && (await this.isSkillPackageFile(name, absolutePath, size))) {
+    if (allowSkillImportReference && (await this.isSkillPackageFile(name, absolutePath))) {
       return [
         {
           type: 'text',
@@ -3046,13 +3068,13 @@ class AcpRuntime {
     return name.toLowerCase().endsWith('.pdf')
   }
 
-  private async isSkillPackageFile(name: string, filePath: string, size: number): Promise<boolean> {
+  private async isSkillPackageFile(name: string, filePath: string): Promise<boolean> {
     const normalizedName = name.toLowerCase()
 
     if (normalizedName.endsWith('.skill')) return true
-    if (!normalizedName.endsWith('.zip') || size > SKILL_IMPORT_LIMITS.maxBundleBytes) return false
+    if (!normalizedName.endsWith('.zip')) return false
 
-    return isImportableSkillArchive(await readFile(filePath))
+    return isImportableSkillArchivePath(filePath)
   }
 
   // Turns a PDF into a text resource block, degrading to an explanatory note when extraction fails

--- a/src/main/acp/runtime.ts
+++ b/src/main/acp/runtime.ts
@@ -70,7 +70,8 @@ import {
   buildOversizedAttachmentNotice,
   imageAttachmentMimeType,
   isTabularAttachment,
-  isTextLikeAttachment
+  isTextLikeAttachment,
+  mimeEssence
 } from './attachment-content'
 import { readBoundedManagedFilePreview } from '../managed-file-preview'
 import {
@@ -2962,21 +2963,31 @@ class AcpRuntime {
       descriptor
 
     // ACP providers such as OpenCode reject ZIP uploads before the prompt reaches the agent
-    // (`file part media type application/zip functionality not supported`). Skill packages only need
-    // to expose their exact local URI: the agent passes it to the app-owned request_skill_import tool,
-    // which performs parsing, validation and user confirmation. Keep the reference as JSON text so it
-    // also remains usable when the user wants to inspect the archive instead of importing it.
+    // (`file part media type application/zip functionality not supported`). Keep all ZIPs off that
+    // file-part path, but mark only importer-owned, manifest-confirmed archives as Skill packages so an
+    // ordinary ZIP remains inspectable without advertising request_skill_import.
+    const attachmentTextReference = (
+      tag: 'attached_skill_package' | 'attached_local_archive',
+      skillImportEligible: boolean
+    ): ContentBlock => ({
+      type: 'text',
+      text: [
+        `<${tag}>`,
+        JSON.stringify({ name, uri, mimeType, size, skillImportEligible }),
+        `</${tag}>`
+      ].join('\n')
+    })
     if (allowSkillImportReference && (await this.isSkillPackageFile(name, absolutePath))) {
-      return [
-        {
-          type: 'text',
-          text: [
-            '<attached_local_file>',
-            JSON.stringify({ name, uri, mimeType, size }),
-            '</attached_local_file>'
-          ].join('\n')
-        }
-      ]
+      return [attachmentTextReference('attached_skill_package', true)]
+    }
+
+    const normalizedMimeType = mimeEssence(mimeType)
+    if (
+      name.toLowerCase().endsWith('.zip') ||
+      normalizedMimeType === 'application/zip' ||
+      normalizedMimeType === 'application/x-zip-compressed'
+    ) {
+      return [attachmentTextReference('attached_local_archive', false)]
     }
 
     // Images are embedded as base64 so vision-capable agents receive the actual pixels.

--- a/src/main/acp/runtime.ts
+++ b/src/main/acp/runtime.ts
@@ -108,6 +108,8 @@ import {
   type SkillImportMcpEnvironment,
   type SkillImportRpcConnection
 } from '../skills/mcp-server'
+import { isImportableSkillArchive } from '../skills/user-skill-repository'
+import { SKILL_IMPORT_LIMITS } from '../skills/import-limits'
 import { getNotebookDataRoot, getNotebookSessionRoot } from '../notebook/repository'
 import { codexStorageDir, codexSubscriptionStorageDir } from '../agent-framework/codex'
 import { getAppClaudeConfigDir } from '../settings/provider-env'
@@ -2886,7 +2888,8 @@ class AcpRuntime {
       uri: pathToFileURL(filePath).href,
       name: attachment.originalName || attachment.name,
       mimeType: attachment.mimeType,
-      size
+      size,
+      allowSkillImportReference: true
     })
   }
 
@@ -2904,7 +2907,10 @@ class AcpRuntime {
       uri: pathToFileURL(filePath).href,
       name: reference.name,
       mimeType: reference.mimeType,
-      size
+      size,
+      // The import tool currently owns only session uploads. Artifact-store paths remain ordinary
+      // references so the prompt never advertises a URI that main will reject at the trust boundary.
+      allowSkillImportReference: reference.source === 'upload'
     })
   }
 
@@ -2928,15 +2934,17 @@ class AcpRuntime {
     name: string
     mimeType?: string
     size: number
+    allowSkillImportReference: boolean
   }): Promise<ContentBlock[]> {
-    const { sessionId, absolutePath, uri, name, mimeType, size } = descriptor
+    const { sessionId, absolutePath, uri, name, mimeType, size, allowSkillImportReference } =
+      descriptor
 
     // ACP providers such as OpenCode reject ZIP uploads before the prompt reaches the agent
     // (`file part media type application/zip functionality not supported`). Skill packages only need
     // to expose their exact local URI: the agent passes it to the app-owned request_skill_import tool,
     // which performs parsing, validation and user confirmation. Keep the reference as JSON text so it
     // also remains usable when the user wants to inspect the archive instead of importing it.
-    if (this.isSkillPackageFile(name)) {
+    if (allowSkillImportReference && (await this.isSkillPackageFile(name, absolutePath, size))) {
       return [
         {
           type: 'text',
@@ -3038,10 +3046,13 @@ class AcpRuntime {
     return name.toLowerCase().endsWith('.pdf')
   }
 
-  private isSkillPackageFile(name: string): boolean {
+  private async isSkillPackageFile(name: string, filePath: string, size: number): Promise<boolean> {
     const normalizedName = name.toLowerCase()
 
-    return normalizedName.endsWith('.zip') || normalizedName.endsWith('.skill')
+    if (normalizedName.endsWith('.skill')) return true
+    if (!normalizedName.endsWith('.zip') || size > SKILL_IMPORT_LIMITS.maxBundleBytes) return false
+
+    return isImportableSkillArchive(await readFile(filePath))
   }
 
   // Turns a PDF into a text resource block, degrading to an explanatory note when extraction fails

--- a/src/main/acp/runtime.ts
+++ b/src/main/acp/runtime.ts
@@ -12,6 +12,7 @@ import type {
   SessionNotification
 } from '@agentclientprotocol/sdk'
 import type { ChildProcessWithoutNullStreams } from 'node:child_process'
+import { randomUUID } from 'node:crypto'
 import { rmSync } from 'node:fs'
 import { mkdir, mkdtemp, readFile, stat, writeFile } from 'node:fs/promises'
 import { tmpdir } from 'node:os'
@@ -137,6 +138,8 @@ export type AcpRuntimeCallbacks = {
   onStateChanged?: (state: AcpStateSnapshot) => void
   onEvent?: (event: AcpRuntimeEvent) => void
   onPermissionRequest?: (request: AcpPermissionRequest) => void
+  onPromptStarted?: (sessionId: string, turnToken: string, promptAttemptId?: string) => void
+  onPromptEnded?: (sessionId: string, turnToken: string) => void
   onRetired?: () => void
 }
 
@@ -731,6 +734,7 @@ class AcpRuntime {
   // unregistered on session delete (the artifact routing id is tracked in artifactSessionIds).
   private readonly notebookRoutingIds = new Map<string, string>()
   private readonly skillImportRoutingIds = new Map<string, string>()
+  private readonly skillImportTurnTokens = new Map<string, string>()
   private artifactSessionSequence = 0
   private artifactRunSequence = 0
   private notebookSessionSequence = 0
@@ -2008,6 +2012,7 @@ class AcpRuntime {
       this.artifactSessionIds.clear()
       this.notebookRoutingIds.clear()
       this.skillImportRoutingIds.clear()
+      this.skillImportTurnTokens.clear()
       this.mcpHttpHost?.clear()
       this.agentToAppSessionId.clear()
       this.currentSessionId = undefined
@@ -2179,11 +2184,16 @@ class AcpRuntime {
   }
 
   // Sends one prompt turn to the targeted session and streams updates until stop.
-  async sendPrompt(request: AcpPromptRequest): Promise<PromptResponse> {
-    return this.withOperationLease(() => withDataRootWrite(() => this.sendPromptTurn(request)))
+  async sendPrompt(request: AcpPromptRequest, promptAttemptId?: string): Promise<PromptResponse> {
+    return this.withOperationLease(() =>
+      withDataRootWrite(() => this.sendPromptTurn(request, promptAttemptId))
+    )
   }
 
-  private async sendPromptTurn(request: AcpPromptRequest): Promise<PromptResponse> {
+  private async sendPromptTurn(
+    request: AcpPromptRequest,
+    promptAttemptId?: string
+  ): Promise<PromptResponse> {
     let activeSession = this.sessions.get(request.sessionId)
 
     if (!activeSession) {
@@ -2204,6 +2214,13 @@ class AcpRuntime {
     try {
       if (this.skillsHooks && forced.length > 0) {
         const toForce = await this.skillsHooks.needForceLoad(forced)
+
+        // The Skill check yields before a force-load reconnect mutates runtime-wide state. A newer turn
+        // may have claimed this session meanwhile, so refuse the stale reconnect before it can tear down
+        // that turn.
+        if (this.promptInFlightSessionIds.has(request.sessionId)) {
+          throw new Error('An ACP prompt is already running for this session')
+        }
 
         if (toForce.length > 0) {
           // Capture routing before disconnect clears it, so resume lands on the same conversation.
@@ -2240,13 +2257,27 @@ class AcpRuntime {
       throw error
     }
 
+    // Another prompt can claim this session while the force-load check above is awaiting. Re-acquire
+    // the turn lock before publishing its token so a delayed attempt cannot overwrite a newer turn's
+    // lifecycle state.
+    if (this.promptInFlightSessionIds.has(request.sessionId)) {
+      throw new Error('An ACP prompt is already running for this session')
+    }
+
     this.currentSessionId = request.sessionId
     // Claim ownership of this session's shared turn state so a superseded turn's later finally can tell it
     // no longer owns the lock/artifact run (see the guarded cleanup in this turn's finally).
     const promptTurn = ++this.promptTurnSequence
+    const skillImportTurnToken = randomUUID()
     this.promptInFlightSessionIds.add(request.sessionId)
     this.currentPromptTurnBySession.set(request.sessionId, promptTurn)
+    this.skillImportTurnTokens.set(request.sessionId, skillImportTurnToken)
     this.cancelledPromptTurnsBySession.delete(request.sessionId)
+    try {
+      this.callbacks.onPromptStarted?.(request.sessionId, skillImportTurnToken, promptAttemptId)
+    } catch (error) {
+      safeLogError('prompt-start callback failed', errorLogFields(error))
+    }
     this.emitState()
     log.info('prompt start', {
       sessionId: request.sessionId,
@@ -2496,6 +2527,14 @@ class AcpRuntime {
         this.clearOpenCodePermissionToolContext(request.sessionId)
         this.currentPromptTurnBySession.delete(request.sessionId)
         this.promptInFlightSessionIds.delete(request.sessionId)
+        if (this.skillImportTurnTokens.get(request.sessionId) === skillImportTurnToken) {
+          this.skillImportTurnTokens.delete(request.sessionId)
+        }
+        try {
+          this.callbacks.onPromptEnded?.(request.sessionId, skillImportTurnToken)
+        } catch (error) {
+          safeLogError('prompt-end callback failed', errorLogFields(error))
+        }
       }
       // emitState invokes the renderer onStateChanged callback; guard it so a throw there cannot skip
       // the reconnect below. maybeApplyPendingProviderReconnect is what resolves an armed reconnect
@@ -2641,6 +2680,7 @@ class AcpRuntime {
     this.artifactSessionIds.delete(request.sessionId)
     this.notebookRoutingIds.delete(request.sessionId)
     this.skillImportRoutingIds.delete(request.sessionId)
+    this.skillImportTurnTokens.delete(request.sessionId)
     this.promptInFlightSessionIds.delete(request.sessionId)
 
     // Only announce a deletion and shift the current session when something was actually attached; a
@@ -2968,22 +3008,35 @@ class AcpRuntime {
     // ordinary ZIP remains inspectable without advertising request_skill_import.
     const attachmentTextReference = (
       tag: 'attached_skill_package' | 'attached_local_archive',
-      skillImportEligible: boolean
+      skillImportEligible: boolean,
+      turnToken?: string
     ): ContentBlock => ({
       type: 'text',
       text: [
         `<${tag}>`,
-        JSON.stringify({ name, uri, mimeType, size, skillImportEligible }),
+        JSON.stringify({
+          name,
+          uri,
+          mimeType,
+          size,
+          skillImportEligible,
+          ...(turnToken ? { skillImportTurnToken: turnToken } : {})
+        }),
         `</${tag}>`
       ].join('\n')
     })
     if (allowSkillImportReference && (await this.isSkillPackageFile(name, absolutePath))) {
-      return [attachmentTextReference('attached_skill_package', true)]
+      const turnToken = this.skillImportTurnTokens.get(sessionId)
+      if (turnToken) {
+        return [attachmentTextReference('attached_skill_package', true, turnToken)]
+      }
     }
 
+    const normalizedName = name.toLowerCase()
     const normalizedMimeType = mimeEssence(mimeType)
     if (
-      name.toLowerCase().endsWith('.zip') ||
+      normalizedName.endsWith('.zip') ||
+      normalizedName.endsWith('.skill') ||
       normalizedMimeType === 'application/zip' ||
       normalizedMimeType === 'application/x-zip-compressed'
     ) {
@@ -3082,8 +3135,7 @@ class AcpRuntime {
   private async isSkillPackageFile(name: string, filePath: string): Promise<boolean> {
     const normalizedName = name.toLowerCase()
 
-    if (normalizedName.endsWith('.skill')) return true
-    if (!normalizedName.endsWith('.zip')) return false
+    if (!normalizedName.endsWith('.skill') && !normalizedName.endsWith('.zip')) return false
 
     return isImportableSkillArchivePath(filePath)
   }

--- a/src/main/ipc.ts
+++ b/src/main/ipc.ts
@@ -337,9 +337,12 @@ const registerIpcHandlers = async ({
   })
   const conversationSkillImporter = new ConversationSkillImporter({
     uploads: uploadRepository,
+    createCancellationGuard: (sessionId, turnToken) =>
+      skillImportApprovalBroker.createCancellationGuard(sessionId, turnToken),
     previewBundle: (bundle) => settingsService.previewSkillArchive(bundle),
     importBundle: (bundle, items) => settingsService.importSkillArchiveBatch(bundle, items),
-    requestApproval: (request) => skillImportApprovalBroker.request(request),
+    requestApproval: (request, cancellation) =>
+      skillImportApprovalBroker.request(request, cancellation),
     // If a prompt is active the coordinator defers the reconnect until its terminal event, making the
     // new Skill available on the next user turn without interrupting the importing tool call.
     onSkillsChanged: () => void runtimeRef.current?.requestSkillsReload()
@@ -492,6 +495,10 @@ const registerIpcHandlers = async ({
     notebookRpcServer,
     settingsService,
     taskNotifications,
+    onSessionTurnStarted: (sessionId, turnToken) =>
+      skillImportApprovalBroker.beginSessionTurn(sessionId, turnToken),
+    onSessionTurnEnded: (sessionId, turnToken) =>
+      skillImportApprovalBroker.endSessionTurn(sessionId, turnToken),
     onSessionCancelled: (sessionId) => skillImportApprovalBroker.cancelSession(sessionId),
     onAllSessionsCancelled: () => skillImportApprovalBroker.cancelAll(),
     initializationBarrier: initialConnectorSkillsReady

--- a/src/main/ipc.ts
+++ b/src/main/ipc.ts
@@ -337,8 +337,8 @@ const registerIpcHandlers = async ({
   })
   const conversationSkillImporter = new ConversationSkillImporter({
     uploads: uploadRepository,
-    createCancellationGuard: (sessionId, turnToken) =>
-      skillImportApprovalBroker.createCancellationGuard(sessionId, turnToken),
+    createCancellationGuard: (sessionId, turnToken, attachmentUri) =>
+      skillImportApprovalBroker.createCancellationGuard(sessionId, turnToken, attachmentUri),
     previewBundle: (bundle) => settingsService.previewSkillArchive(bundle),
     importBundle: (bundle, items) => settingsService.importSkillArchiveBatch(bundle, items),
     requestApproval: (request, cancellation) =>
@@ -499,8 +499,12 @@ const registerIpcHandlers = async ({
       skillImportApprovalBroker.beginSessionTurn(sessionId, turnToken),
     onSessionTurnEnded: (sessionId, turnToken) =>
       skillImportApprovalBroker.endSessionTurn(sessionId, turnToken),
-    onSessionCancelled: (sessionId) => skillImportApprovalBroker.cancelSession(sessionId),
-    onAllSessionsCancelled: () => skillImportApprovalBroker.cancelAll(),
+    onSkillImportAttachmentEligible: (sessionId, turnToken, attachmentUri) =>
+      skillImportApprovalBroker.allowSessionTurnAttachment(sessionId, turnToken, attachmentUri),
+    onSessionCancellationRequested: (sessionId) =>
+      skillImportApprovalBroker.cancelSession(sessionId),
+    onSessionUnavailable: (sessionId) => skillImportApprovalBroker.cancelSession(sessionId),
+    onAllSessionsCancellationRequested: () => skillImportApprovalBroker.cancelAll(),
     initializationBarrier: initialConnectorSkillsReady
   })
   runtimeRef.current = runtime

--- a/src/main/notebook/local-rpc-server.skill-import.test.ts
+++ b/src/main/notebook/local-rpc-server.skill-import.test.ts
@@ -32,6 +32,7 @@ describe('NotebookLocalRpcServer Skill import bridge', () => {
         method: 'skillImport',
         params: {
           sessionId: 'pre-session-alias',
+          turnToken: '00000000-0000-4000-8000-000000000001',
           attachmentUri: 'file:///managed/session/demo.skill'
         }
       })
@@ -46,6 +47,7 @@ describe('NotebookLocalRpcServer Skill import bridge', () => {
     })
     expect(request).toHaveBeenCalledWith({
       sessionId: 'session-1',
+      turnToken: '00000000-0000-4000-8000-000000000001',
       attachmentUri: 'file:///managed/session/demo.skill'
     })
   })

--- a/src/main/notebook/local-rpc-server.ts
+++ b/src/main/notebook/local-rpc-server.ts
@@ -217,11 +217,18 @@ class NotebookLocalRpcServer {
   private async dispatch(method: string, params: Record<string, unknown>): Promise<unknown> {
     if (method === 'skillImport') {
       if (!this.skillImporter) throw new Error('Conversation Skill import is not configured.')
-      if (typeof params.sessionId !== 'string' || typeof params.attachmentUri !== 'string') {
-        throw new Error('Skill import RPC params must include sessionId and attachmentUri.')
+      if (
+        typeof params.sessionId !== 'string' ||
+        typeof params.turnToken !== 'string' ||
+        typeof params.attachmentUri !== 'string'
+      ) {
+        throw new Error(
+          'Skill import RPC params must include sessionId, turnToken and attachmentUri.'
+        )
       }
       const request: ConversationSkillImportRequest = {
         sessionId: params.sessionId,
+        turnToken: params.turnToken,
         attachmentUri: params.attachmentUri
       }
       return this.skillImporter.request(request)

--- a/src/main/skills/conversation-import.test.ts
+++ b/src/main/skills/conversation-import.test.ts
@@ -127,14 +127,15 @@ describe('ConversationSkillImporter', () => {
     })
     const importer = new ConversationSkillImporter({
       uploads,
-      createCancellationGuard: (sessionId, turnToken) =>
-        broker.createCancellationGuard(sessionId, turnToken),
+      createCancellationGuard: (sessionId, turnToken, attachmentUri) =>
+        broker.createCancellationGuard(sessionId, turnToken, attachmentUri),
       previewBundle: (bundle) => skills.previewZip(bundle),
       importBundle: (bundle, items) => skills.importFromZipBatch(bundle, items),
       requestApproval: (request, cancellation) => broker.request(request, cancellation),
       onSkillsChanged
     })
     broker.beginSessionTurn('session-1', 'turn-1')
+    broker.allowSessionTurnAttachment('session-1', 'turn-1', pathToFileURL(attachment.path).href)
 
     const result = await importer.request({
       sessionId: 'session-1',
@@ -221,6 +222,48 @@ describe('ConversationSkillImporter', () => {
     expect(requestApproval).not.toHaveBeenCalled()
   })
 
+  it('rejects a session-owned Skill archive that was not eligible in the active turn', async () => {
+    const root = await mkdtemp(join(tmpdir(), 'conversation-skill-import-'))
+    roots.push(root)
+    const uploads = new UploadRepository(root)
+    const [staged] = await uploads.stageFiles({
+      files: [
+        {
+          name: 'older-turn.skill',
+          content: buildNamedSkillZip('Older Turn').toString('base64'),
+          mimeType: 'application/zip'
+        }
+      ]
+    })
+    const [attachment] = await uploads.finalizePendingSessionUploads('session-1', [staged])
+    const previewBundle = vi.fn()
+    const requestApproval = vi.fn()
+    const broker = new SkillImportApprovalBroker({
+      generateId: () => 'unused',
+      broadcast: vi.fn()
+    })
+    const importer = new ConversationSkillImporter({
+      uploads,
+      createCancellationGuard: (sessionId, turnToken, attachmentUri) =>
+        broker.createCancellationGuard(sessionId, turnToken, attachmentUri),
+      previewBundle,
+      importBundle: vi.fn(),
+      requestApproval
+    })
+    broker.beginSessionTurn('session-1', 'turn-2')
+    broker.allowSessionTurnAttachment('session-1', 'turn-2', 'file:///current-turn.skill')
+
+    await expect(
+      importer.request({
+        sessionId: 'session-1',
+        turnToken: 'turn-2',
+        attachmentUri: pathToFileURL(attachment.path).href
+      })
+    ).resolves.toEqual({ status: 'cancelled', skills: [] })
+    expect(previewBundle).not.toHaveBeenCalled()
+    expect(requestApproval).not.toHaveBeenCalled()
+  })
+
   it('cancels imports stopped during preview and requests that arrive after the stop', async () => {
     const root = await mkdtemp(join(tmpdir(), 'conversation-skill-import-'))
     roots.push(root)
@@ -258,14 +301,15 @@ describe('ConversationSkillImporter', () => {
     })
     const importer = new ConversationSkillImporter({
       uploads,
-      createCancellationGuard: (sessionId, turnToken) =>
-        broker.createCancellationGuard(sessionId, turnToken),
+      createCancellationGuard: (sessionId, turnToken, attachmentUri) =>
+        broker.createCancellationGuard(sessionId, turnToken, attachmentUri),
       previewBundle,
       importBundle,
       requestApproval: (request, cancellation) => broker.request(request, cancellation)
     })
 
     broker.beginSessionTurn('session-1', 'turn-1')
+    broker.allowSessionTurnAttachment('session-1', 'turn-1', pathToFileURL(attachment.path).href)
     const importing = importer.request({
       sessionId: 'session-1',
       turnToken: 'turn-1',
@@ -280,6 +324,7 @@ describe('ConversationSkillImporter', () => {
     expect(importBundle).not.toHaveBeenCalled()
 
     broker.beginSessionTurn('session-1', 'turn-2')
+    broker.allowSessionTurnAttachment('session-1', 'turn-2', pathToFileURL(attachment.path).href)
     await expect(
       importer.request({
         sessionId: 'session-1',
@@ -455,8 +500,13 @@ describe('SkillImportApprovalBroker lifecycle', () => {
     })
     broker.beginSessionTurn('session-1', 'turn-1')
     broker.beginSessionTurn('session-2', 'turn-a')
-    const first = broker.createCancellationGuard('session-1', 'turn-1')
-    const second = broker.createCancellationGuard('session-2', 'turn-a')
+    broker.allowSessionTurnAttachment('session-1', 'turn-1', 'file:///current.skill')
+    broker.allowSessionTurnAttachment('session-2', 'turn-a', 'file:///second.skill')
+    const first = broker.createCancellationGuard('session-1', 'turn-1', 'file:///current.skill')
+    const unlisted = broker.createCancellationGuard('session-1', 'turn-1', 'file:///older.skill')
+    const second = broker.createCancellationGuard('session-2', 'turn-a', 'file:///second.skill')
+    expect(first.isCancelled()).toBe(false)
+    expect(unlisted.isCancelled()).toBe(true)
 
     broker.cancelSession('session-1')
     expect(first.isCancelled()).toBe(true)
@@ -466,8 +516,9 @@ describe('SkillImportApprovalBroker lifecycle', () => {
     expect(second.isCancelled()).toBe(true)
 
     broker.beginSessionTurn('session-1', 'turn-2')
+    broker.allowSessionTurnAttachment('session-1', 'turn-2', 'file:///next.skill')
     expect(first.isCancelled()).toBe(true)
-    const next = broker.createCancellationGuard('session-1', 'turn-2')
+    const next = broker.createCancellationGuard('session-1', 'turn-2', 'file:///next.skill')
     expect(next.isCancelled()).toBe(false)
     broker.endSessionTurn('session-1', 'turn-2')
     expect(next.isCancelled()).toBe(true)

--- a/src/main/skills/conversation-import.test.ts
+++ b/src/main/skills/conversation-import.test.ts
@@ -76,6 +76,18 @@ const buildZip = (inputs: { path: string; content: Buffer }[]): Buffer => {
   return Buffer.concat([localBytes, centralBytes, end])
 }
 
+const buildNamedSkillZip = (name: string): Buffer =>
+  buildZip([
+    {
+      path: 'SKILL.md',
+      content: Buffer.from(`---\nname: ${name}\n---\nFollow the workflow.`, 'utf8')
+    }
+  ])
+
+const createActiveCancellationGuard = (): { isCancelled: () => boolean } => ({
+  isCancelled: () => false
+})
+
 describe('ConversationSkillImporter', () => {
   it('imports a session-owned Skill attachment after the user confirms its preview', async () => {
     const root = await mkdtemp(join(tmpdir(), 'conversation-skill-import-'))
@@ -115,14 +127,18 @@ describe('ConversationSkillImporter', () => {
     })
     const importer = new ConversationSkillImporter({
       uploads,
+      createCancellationGuard: (sessionId, turnToken) =>
+        broker.createCancellationGuard(sessionId, turnToken),
       previewBundle: (bundle) => skills.previewZip(bundle),
       importBundle: (bundle, items) => skills.importFromZipBatch(bundle, items),
-      requestApproval: (request) => broker.request(request),
+      requestApproval: (request, cancellation) => broker.request(request, cancellation),
       onSkillsChanged
     })
+    broker.beginSessionTurn('session-1', 'turn-1')
 
     const result = await importer.request({
       sessionId: 'session-1',
+      turnToken: 'turn-1',
       attachmentUri: pathToFileURL(attachment.path).href
     })
 
@@ -152,6 +168,7 @@ describe('ConversationSkillImporter', () => {
     const requestApproval = vi.fn()
     const importer = new ConversationSkillImporter({
       uploads,
+      createCancellationGuard: createActiveCancellationGuard,
       previewBundle: (bundle) => skills.previewZip(bundle),
       importBundle: (bundle, items) => skills.importFromZipBatch(bundle, items),
       requestApproval
@@ -160,10 +177,117 @@ describe('ConversationSkillImporter', () => {
     await expect(
       importer.request({
         sessionId: 'session-1',
+        turnToken: 'turn-1',
         attachmentUri: pathToFileURL(attachment.path).href
       })
     ).rejects.toThrow('different session')
     expect(requestApproval).not.toHaveBeenCalled()
+  })
+
+  it('rejects an ordinary session ZIP before preview or approval', async () => {
+    const root = await mkdtemp(join(tmpdir(), 'conversation-skill-import-'))
+    roots.push(root)
+    const uploads = new UploadRepository(root)
+    const [staged] = await uploads.stageFiles({
+      files: [
+        {
+          name: 'ordinary-data.zip',
+          content: buildZip([
+            { path: 'README.txt', content: Buffer.from('ordinary archive', 'utf8') }
+          ]).toString('base64'),
+          mimeType: 'application/zip'
+        }
+      ]
+    })
+    const [attachment] = await uploads.finalizePendingSessionUploads('session-1', [staged])
+    const previewBundle = vi.fn()
+    const requestApproval = vi.fn()
+    const importer = new ConversationSkillImporter({
+      uploads,
+      createCancellationGuard: createActiveCancellationGuard,
+      previewBundle,
+      importBundle: vi.fn(),
+      requestApproval
+    })
+
+    await expect(
+      importer.request({
+        sessionId: 'session-1',
+        turnToken: 'turn-1',
+        attachmentUri: pathToFileURL(attachment.path).href
+      })
+    ).rejects.toThrow('not eligible for Skill import')
+    expect(previewBundle).not.toHaveBeenCalled()
+    expect(requestApproval).not.toHaveBeenCalled()
+  })
+
+  it('cancels imports stopped during preview and requests that arrive after the stop', async () => {
+    const root = await mkdtemp(join(tmpdir(), 'conversation-skill-import-'))
+    roots.push(root)
+    const uploads = new UploadRepository(root)
+    const skills = new UserSkillRepository(root)
+    const [staged] = await uploads.stageFiles({
+      files: [
+        {
+          name: 'slow-preview.skill',
+          content: buildNamedSkillZip('Slow Preview').toString('base64'),
+          mimeType: 'application/zip'
+        }
+      ]
+    })
+    const [attachment] = await uploads.finalizePendingSessionUploads('session-1', [staged])
+    let markPreviewStarted!: () => void
+    let releasePreview!: () => void
+    const previewStarted = new Promise<void>((resolve) => {
+      markPreviewStarted = resolve
+    })
+    const previewGate = new Promise<void>((resolve) => {
+      releasePreview = resolve
+    })
+    const broadcast = vi.fn()
+    const broker = new SkillImportApprovalBroker({
+      generateId: () => 'approval-late',
+      broadcast
+    })
+    const importBundle = vi.fn()
+    const previewBundle = vi.fn(async (bundle: Buffer) => {
+      const preview = await skills.previewZip(bundle)
+      markPreviewStarted()
+      await previewGate
+      return preview
+    })
+    const importer = new ConversationSkillImporter({
+      uploads,
+      createCancellationGuard: (sessionId, turnToken) =>
+        broker.createCancellationGuard(sessionId, turnToken),
+      previewBundle,
+      importBundle,
+      requestApproval: (request, cancellation) => broker.request(request, cancellation)
+    })
+
+    broker.beginSessionTurn('session-1', 'turn-1')
+    const importing = importer.request({
+      sessionId: 'session-1',
+      turnToken: 'turn-1',
+      attachmentUri: pathToFileURL(attachment.path).href
+    })
+    await previewStarted
+    broker.cancelSession('session-1')
+    releasePreview()
+
+    await expect(importing).resolves.toEqual({ status: 'cancelled', skills: [] })
+    expect(broadcast).not.toHaveBeenCalled()
+    expect(importBundle).not.toHaveBeenCalled()
+
+    broker.beginSessionTurn('session-1', 'turn-2')
+    await expect(
+      importer.request({
+        sessionId: 'session-1',
+        turnToken: 'turn-1',
+        attachmentUri: pathToFileURL(attachment.path).href
+      })
+    ).resolves.toEqual({ status: 'cancelled', skills: [] })
+    expect(previewBundle).toHaveBeenCalledOnce()
   })
 
   it('rejects two approved candidates that replace the same installed Skill', async () => {
@@ -174,7 +298,7 @@ describe('ConversationSkillImporter', () => {
       files: [
         {
           name: 'duplicate-targets.skill',
-          content: Buffer.from('bundle contents').toString('base64'),
+          content: buildNamedSkillZip('Duplicate Targets').toString('base64'),
           mimeType: 'application/zip'
         }
       ]
@@ -183,6 +307,7 @@ describe('ConversationSkillImporter', () => {
     const importBundle = vi.fn().mockResolvedValue([])
     const importer = new ConversationSkillImporter({
       uploads,
+      createCancellationGuard: createActiveCancellationGuard,
       previewBundle: vi.fn().mockResolvedValue({
         previews: [
           {
@@ -221,6 +346,7 @@ describe('ConversationSkillImporter', () => {
     await expect(
       importer.request({
         sessionId: 'session-1',
+        turnToken: 'turn-1',
         attachmentUri: pathToFileURL(attachment.path).href
       })
     ).rejects.toThrow('cannot replace the same installed Skill more than once')
@@ -235,7 +361,7 @@ describe('ConversationSkillImporter', () => {
       files: [
         {
           name: 'replacement.skill',
-          content: Buffer.from('bundle contents').toString('base64'),
+          content: buildNamedSkillZip('Replacement').toString('base64'),
           mimeType: 'application/zip'
         }
       ]
@@ -244,6 +370,7 @@ describe('ConversationSkillImporter', () => {
     const importBundle = vi.fn().mockResolvedValue([])
     const importer = new ConversationSkillImporter({
       uploads,
+      createCancellationGuard: createActiveCancellationGuard,
       previewBundle: vi.fn().mockResolvedValue({
         previews: [
           {
@@ -269,6 +396,7 @@ describe('ConversationSkillImporter', () => {
     await expect(
       importer.request({
         sessionId: 'session-1',
+        turnToken: 'turn-1',
         attachmentUri: pathToFileURL(attachment.path).href
       })
     ).rejects.toThrow('replacement target does not match the approved preview')
@@ -318,6 +446,31 @@ describe('SkillImportApprovalBroker lifecycle', () => {
     await expect(cancelled).resolves.toEqual({ id: 'approval-1', cancelled: true })
     await expect(retained).resolves.toEqual({ id: 'approval-2', items: [] })
     expect(onSettled).toHaveBeenCalledTimes(2)
+  })
+
+  it('binds guards to one active turn token across cancellation and later turns', () => {
+    const broker = new SkillImportApprovalBroker({
+      generateId: () => 'unused',
+      broadcast: vi.fn()
+    })
+    broker.beginSessionTurn('session-1', 'turn-1')
+    broker.beginSessionTurn('session-2', 'turn-a')
+    const first = broker.createCancellationGuard('session-1', 'turn-1')
+    const second = broker.createCancellationGuard('session-2', 'turn-a')
+
+    broker.cancelSession('session-1')
+    expect(first.isCancelled()).toBe(true)
+    expect(second.isCancelled()).toBe(false)
+
+    broker.cancelAll()
+    expect(second.isCancelled()).toBe(true)
+
+    broker.beginSessionTurn('session-1', 'turn-2')
+    expect(first.isCancelled()).toBe(true)
+    const next = broker.createCancellationGuard('session-1', 'turn-2')
+    expect(next.isCancelled()).toBe(false)
+    broker.endSessionTurn('session-1', 'turn-2')
+    expect(next.isCancelled()).toBe(true)
   })
 
   it('cancels every pending approval when all agent runtimes disconnect', async () => {

--- a/src/main/skills/conversation-import.ts
+++ b/src/main/skills/conversation-import.ts
@@ -12,8 +12,13 @@ import type {
 } from '../../shared/settings'
 import type { UploadRepository } from '../uploads/repository'
 import { SKILL_IMPORT_LIMITS } from './import-limits'
+import { isImportableSkillArchivePath } from './skill-archive-sniffer'
 
 type SkillImportApprovalInfo = Omit<ConversationSkillImportApprovalRequest, 'id'>
+
+type SkillImportCancellationGuard = {
+  isCancelled: () => boolean
+}
 
 type SkillImportApprovalBrokerOptions = {
   broadcast: (request: ConversationSkillImportApprovalRequest) => void
@@ -39,6 +44,7 @@ class SkillImportApprovalBroker {
   private readonly timeoutMs: number
   private readonly setTimer: (fn: () => void, ms: number) => ReturnType<typeof setTimeout>
   private readonly clearTimer: (handle: ReturnType<typeof setTimeout>) => void
+  private readonly activeSessionTurnTokens = new Map<string, string>()
 
   constructor(private readonly options: SkillImportApprovalBrokerOptions) {
     this.timeoutMs = options.timeoutMs ?? 5 * 60_000
@@ -46,9 +52,38 @@ class SkillImportApprovalBroker {
     this.clearTimer = options.clearTimer ?? ((handle) => clearTimeout(handle))
   }
 
-  request(info: SkillImportApprovalInfo): Promise<ConversationSkillImportApprovalResponse> {
+  beginSessionTurn(sessionId: string, turnToken: string): void {
+    this.activeSessionTurnTokens.set(sessionId, turnToken)
+    // A new turn cannot inherit an unanswered dialog from an older turn of the same session.
+    for (const [id, pending] of this.pending) {
+      if (pending.sessionId === sessionId) this.settle({ id, cancelled: true })
+    }
+  }
+
+  endSessionTurn(sessionId: string, turnToken: string): void {
+    if (this.activeSessionTurnTokens.get(sessionId) !== turnToken) return
+    this.activeSessionTurnTokens.delete(sessionId)
+    for (const [id, pending] of this.pending) {
+      if (pending.sessionId === sessionId) this.settle({ id, cancelled: true })
+    }
+  }
+
+  createCancellationGuard(sessionId: string, turnToken: string): SkillImportCancellationGuard {
+    return {
+      isCancelled: () => this.activeSessionTurnTokens.get(sessionId) !== turnToken
+    }
+  }
+
+  request(
+    info: SkillImportApprovalInfo,
+    cancellation?: SkillImportCancellationGuard
+  ): Promise<ConversationSkillImportApprovalResponse> {
     const id = this.options.generateId()
     const request = { id, ...info }
+
+    // A teardown may have arrived while the importer was asynchronously sniffing/previewing the
+    // archive, before this approval was registered. Never broadcast a dialog for that stale request.
+    if (cancellation?.isCancelled()) return Promise.resolve({ id, cancelled: true })
 
     return new Promise((resolve) => {
       const timer = this.setTimer(() => this.settle({ id, cancelled: true }), this.timeoutMs)
@@ -66,12 +101,14 @@ class SkillImportApprovalBroker {
   }
 
   cancelSession(sessionId: string): void {
+    this.activeSessionTurnTokens.delete(sessionId)
     for (const [id, pending] of this.pending) {
       if (pending.sessionId === sessionId) this.settle({ id, cancelled: true })
     }
   }
 
   cancelAll(): void {
+    this.activeSessionTurnTokens.clear()
     for (const id of this.pending.keys()) this.settle({ id, cancelled: true })
   }
 
@@ -92,6 +129,7 @@ class SkillImportApprovalBroker {
 
 type ConversationSkillImporterOptions = {
   uploads: Pick<UploadRepository, 'resolveSessionUploadPath'>
+  createCancellationGuard: (sessionId: string, turnToken: string) => SkillImportCancellationGuard
   previewBundle: (bundle: Buffer) => Promise<SkillBundlePreviewResult>
   importBundle: (
     bundle: Buffer,
@@ -104,13 +142,15 @@ type ConversationSkillImporterOptions = {
     }>
   >
   requestApproval: (
-    request: SkillImportApprovalInfo
+    request: SkillImportApprovalInfo,
+    cancellation: SkillImportCancellationGuard
   ) => Promise<ConversationSkillImportApprovalResponse>
   onSkillsChanged?: () => void
 }
 
 type ConversationSkillImportRequest = {
   sessionId: string
+  turnToken: string
   attachmentUri: string
 }
 
@@ -165,6 +205,8 @@ class ConversationSkillImporter {
   constructor(private readonly options: ConversationSkillImporterOptions) {}
 
   async request(request: ConversationSkillImportRequest): Promise<ConversationSkillImportResult> {
+    const cancellation = this.options.createCancellationGuard(request.sessionId, request.turnToken)
+    if (cancellation.isCancelled()) return { status: 'cancelled', skills: [] }
     const requestedPath = attachmentPathFromUri(request.attachmentUri)
     const filePath = await this.options.uploads.resolveSessionUploadPath(request.sessionId, {
       path: requestedPath
@@ -176,6 +218,11 @@ class ConversationSkillImporter {
     if ((await stat(filePath)).size > SKILL_IMPORT_LIMITS.maxBundleBytes) {
       throw new Error('The attached Skill bundle is too large to import.')
     }
+    // Prompt tags are guidance for the model, not an authorization boundary. Re-run the same bounded
+    // classifier here so a forged tool call cannot turn an ordinary session ZIP into an import flow.
+    if (!(await isImportableSkillArchivePath(filePath))) {
+      throw new Error('The attached archive is not eligible for Skill import.')
+    }
 
     const previewed = await (async () => {
       const bundle = await readFile(filePath)
@@ -186,12 +233,15 @@ class ConversationSkillImporter {
       throw new Error('The attached bundle does not contain an importable Skill.')
     }
 
-    const approval = await this.options.requestApproval({
-      sessionId: request.sessionId,
-      attachmentName,
-      ...preview
-    })
-    if (approval.cancelled || approval.items.length === 0) {
+    const approval = await this.options.requestApproval(
+      {
+        sessionId: request.sessionId,
+        attachmentName,
+        ...preview
+      },
+      cancellation
+    )
+    if (cancellation.isCancelled() || approval.cancelled || approval.items.length === 0) {
       return { status: 'cancelled', skills: [] }
     }
 
@@ -203,6 +253,7 @@ class ConversationSkillImporter {
     if (sha256(bundle) !== previewed.digest) {
       throw new Error('The attached Skill bundle changed after it was previewed.')
     }
+    if (cancellation.isCancelled()) return { status: 'cancelled', skills: [] }
     const outcomes = await this.options.importBundle(bundle, items)
     const previewsByPath = new Map(
       preview.previews.map((candidate) => [candidate.subPath, candidate])
@@ -240,6 +291,7 @@ export { ConversationSkillImporter, SkillImportApprovalBroker }
 export type {
   ConversationSkillImporterOptions,
   ConversationSkillImportRequest,
+  SkillImportCancellationGuard,
   SkillImportApprovalBrokerOptions,
   SkillImportApprovalInfo
 }

--- a/src/main/skills/conversation-import.ts
+++ b/src/main/skills/conversation-import.ts
@@ -44,7 +44,10 @@ class SkillImportApprovalBroker {
   private readonly timeoutMs: number
   private readonly setTimer: (fn: () => void, ms: number) => ReturnType<typeof setTimeout>
   private readonly clearTimer: (handle: ReturnType<typeof setTimeout>) => void
-  private readonly activeSessionTurnTokens = new Map<string, string>()
+  private readonly activeSessionTurns = new Map<
+    string,
+    { turnToken: string; eligibleAttachmentUris: Set<string> }
+  >()
 
   constructor(private readonly options: SkillImportApprovalBrokerOptions) {
     this.timeoutMs = options.timeoutMs ?? 5 * 60_000
@@ -53,24 +56,39 @@ class SkillImportApprovalBroker {
   }
 
   beginSessionTurn(sessionId: string, turnToken: string): void {
-    this.activeSessionTurnTokens.set(sessionId, turnToken)
+    this.activeSessionTurns.set(sessionId, {
+      turnToken,
+      eligibleAttachmentUris: new Set()
+    })
     // A new turn cannot inherit an unanswered dialog from an older turn of the same session.
     for (const [id, pending] of this.pending) {
       if (pending.sessionId === sessionId) this.settle({ id, cancelled: true })
     }
   }
 
+  allowSessionTurnAttachment(sessionId: string, turnToken: string, attachmentUri: string): void {
+    const turn = this.activeSessionTurns.get(sessionId)
+    if (turn?.turnToken === turnToken) turn.eligibleAttachmentUris.add(attachmentUri)
+  }
+
   endSessionTurn(sessionId: string, turnToken: string): void {
-    if (this.activeSessionTurnTokens.get(sessionId) !== turnToken) return
-    this.activeSessionTurnTokens.delete(sessionId)
+    if (this.activeSessionTurns.get(sessionId)?.turnToken !== turnToken) return
+    this.activeSessionTurns.delete(sessionId)
     for (const [id, pending] of this.pending) {
       if (pending.sessionId === sessionId) this.settle({ id, cancelled: true })
     }
   }
 
-  createCancellationGuard(sessionId: string, turnToken: string): SkillImportCancellationGuard {
+  createCancellationGuard(
+    sessionId: string,
+    turnToken: string,
+    attachmentUri: string
+  ): SkillImportCancellationGuard {
     return {
-      isCancelled: () => this.activeSessionTurnTokens.get(sessionId) !== turnToken
+      isCancelled: () => {
+        const turn = this.activeSessionTurns.get(sessionId)
+        return turn?.turnToken !== turnToken || !turn.eligibleAttachmentUris.has(attachmentUri)
+      }
     }
   }
 
@@ -101,14 +119,14 @@ class SkillImportApprovalBroker {
   }
 
   cancelSession(sessionId: string): void {
-    this.activeSessionTurnTokens.delete(sessionId)
+    this.activeSessionTurns.delete(sessionId)
     for (const [id, pending] of this.pending) {
       if (pending.sessionId === sessionId) this.settle({ id, cancelled: true })
     }
   }
 
   cancelAll(): void {
-    this.activeSessionTurnTokens.clear()
+    this.activeSessionTurns.clear()
     for (const id of this.pending.keys()) this.settle({ id, cancelled: true })
   }
 
@@ -129,7 +147,11 @@ class SkillImportApprovalBroker {
 
 type ConversationSkillImporterOptions = {
   uploads: Pick<UploadRepository, 'resolveSessionUploadPath'>
-  createCancellationGuard: (sessionId: string, turnToken: string) => SkillImportCancellationGuard
+  createCancellationGuard: (
+    sessionId: string,
+    turnToken: string,
+    attachmentUri: string
+  ) => SkillImportCancellationGuard
   previewBundle: (bundle: Buffer) => Promise<SkillBundlePreviewResult>
   importBundle: (
     bundle: Buffer,
@@ -205,7 +227,11 @@ class ConversationSkillImporter {
   constructor(private readonly options: ConversationSkillImporterOptions) {}
 
   async request(request: ConversationSkillImportRequest): Promise<ConversationSkillImportResult> {
-    const cancellation = this.options.createCancellationGuard(request.sessionId, request.turnToken)
+    const cancellation = this.options.createCancellationGuard(
+      request.sessionId,
+      request.turnToken,
+      request.attachmentUri
+    )
     if (cancellation.isCancelled()) return { status: 'cancelled', skills: [] }
     const requestedPath = attachmentPathFromUri(request.attachmentUri)
     const filePath = await this.options.uploads.resolveSessionUploadPath(request.sessionId, {

--- a/src/main/skills/mcp-server.test.ts
+++ b/src/main/skills/mcp-server.test.ts
@@ -10,6 +10,7 @@ import {
 
 describe('Skill import MCP server', () => {
   it('exposes one high-level request tool without exposing filesystem writes', async () => {
+    const turnToken = '00000000-0000-4000-8000-000000000001'
     const requestImport = vi.fn().mockResolvedValue({
       status: 'imported',
       skills: [{ id: 'imported-demo', name: 'Demo', status: 'imported' }]
@@ -25,18 +26,24 @@ describe('Skill import MCP server', () => {
       expect.objectContaining({
         name: REQUEST_SKILL_IMPORT_TOOL_NAME,
         inputSchema: expect.objectContaining({
-          properties: expect.objectContaining({ attachment_uri: expect.any(Object) }),
-          required: ['attachment_uri']
+          properties: expect.objectContaining({
+            attachment_uri: expect.any(Object),
+            turn_token: expect.any(Object)
+          }),
+          required: ['attachment_uri', 'turn_token']
         })
       })
     ])
 
     const result = await client.callTool({
       name: REQUEST_SKILL_IMPORT_TOOL_NAME,
-      arguments: { attachment_uri: 'file:///managed/session/demo.skill' }
+      arguments: {
+        attachment_uri: 'file:///managed/session/demo.skill',
+        turn_token: turnToken
+      }
     })
 
-    expect(requestImport).toHaveBeenCalledWith('file:///managed/session/demo.skill')
+    expect(requestImport).toHaveBeenCalledWith('file:///managed/session/demo.skill', turnToken)
     expect(result).toMatchObject({
       content: [{ type: 'text', text: expect.stringContaining('imported-demo') }]
     })

--- a/src/main/skills/mcp-server.ts
+++ b/src/main/skills/mcp-server.ts
@@ -15,13 +15,13 @@ const requestSkillImportToolSchema = {
   attachment_uri: z
     .string()
     .url()
-    .describe('Exact file URI of the attached .zip or .skill package from the user prompt.')
+    .describe('Exact file URI of the attachment marked skillImportEligible in the user prompt.')
 }
 const SKILL_IMPORT_SYSTEM_PROMPT_APPEND = [
   '<open_science_skill_import_instructions>',
-  'When the user explicitly asks to install or import an attached .zip or .skill package, call request_skill_import with the exact attachment URI from the prompt.',
+  'When the user explicitly asks to install or import an attachment wrapped in <attached_skill_package> and marked skillImportEligible, call request_skill_import with its exact URI.',
   'The tool opens an application-owned preview and confirmation dialog. Never unpack or copy an attached Skill package into a Skill directory yourself.',
-  'Do not call the tool merely because a ZIP file is attached; the user must ask to import or install it.',
+  'An <attached_local_archive> is an ordinary ZIP reference, not an eligible Skill package. Do not call request_skill_import for it.',
   'A newly imported Skill becomes available on the next user turn after the agent runtime reloads.',
   '</open_science_skill_import_instructions>'
 ].join('\n')

--- a/src/main/skills/mcp-server.ts
+++ b/src/main/skills/mcp-server.ts
@@ -15,11 +15,15 @@ const requestSkillImportToolSchema = {
   attachment_uri: z
     .string()
     .url()
-    .describe('Exact file URI of the attachment marked skillImportEligible in the user prompt.')
+    .describe('Exact file URI of the attachment marked skillImportEligible in the user prompt.'),
+  turn_token: z
+    .string()
+    .uuid()
+    .describe('Exact skillImportTurnToken from the same eligible attachment reference.')
 }
 const SKILL_IMPORT_SYSTEM_PROMPT_APPEND = [
   '<open_science_skill_import_instructions>',
-  'When the user explicitly asks to install or import an attachment wrapped in <attached_skill_package> and marked skillImportEligible, call request_skill_import with its exact URI.',
+  'When the user explicitly asks to install or import an attachment wrapped in <attached_skill_package> and marked skillImportEligible, call request_skill_import with its exact URI as attachment_uri and skillImportTurnToken as turn_token.',
   'The tool opens an application-owned preview and confirmation dialog. Never unpack or copy an attached Skill package into a Skill directory yourself.',
   'An <attached_local_archive> is an ordinary ZIP reference, not an eligible Skill package. Do not call request_skill_import for it.',
   'A newly imported Skill becomes available on the next user turn after the agent runtime reloads.',
@@ -36,7 +40,10 @@ type SkillImportMcpEnvironment = SkillImportRpcConnection & {
 }
 
 type SkillImportMcpHandler = {
-  requestImport: (attachmentUri: string) => Promise<ConversationSkillImportResult>
+  requestImport: (
+    attachmentUri: string,
+    turnToken: string
+  ) => Promise<ConversationSkillImportResult>
 }
 
 type SkillImportMcpServerConfigRequest = SkillImportMcpEnvironment & {
@@ -62,11 +69,11 @@ const createSkillImportMcpServer = (handler: SkillImportMcpHandler): ModelContex
       description: REQUEST_SKILL_IMPORT_TOOL_DESCRIPTION,
       inputSchema: requestSkillImportToolSchema
     },
-    async ({ attachment_uri }) => ({
+    async ({ attachment_uri, turn_token }) => ({
       content: [
         {
           type: 'text',
-          text: JSON.stringify(await handler.requestImport(attachment_uri), null, 2)
+          text: JSON.stringify(await handler.requestImport(attachment_uri, turn_token), null, 2)
         }
       ]
     })
@@ -109,7 +116,8 @@ const createSkillImportMcpEnvironmentFromProcess = (
 
 const callSkillImportRpc = async (
   environment: SkillImportMcpEnvironment,
-  attachmentUri: string
+  attachmentUri: string,
+  turnToken: string
 ): Promise<ConversationSkillImportResult> => {
   const response = await fetch(environment.endpoint, {
     method: 'POST',
@@ -119,7 +127,7 @@ const callSkillImportRpc = async (
     },
     body: JSON.stringify({
       method: 'skillImport',
-      params: { sessionId: environment.sessionId, attachmentUri }
+      params: { sessionId: environment.sessionId, turnToken, attachmentUri }
     })
   })
   const payload = (await response.json()) as RpcResponse
@@ -134,7 +142,8 @@ const runSkillImportMcpServer = async (
   environment = createSkillImportMcpEnvironmentFromProcess()
 ): Promise<void> => {
   const server = createSkillImportMcpServer({
-    requestImport: (attachmentUri) => callSkillImportRpc(environment, attachmentUri)
+    requestImport: (attachmentUri, turnToken) =>
+      callSkillImportRpc(environment, attachmentUri, turnToken)
   })
   await server.connect(new StdioServerTransport())
 }

--- a/src/main/skills/skill-archive-sniffer.test.ts
+++ b/src/main/skills/skill-archive-sniffer.test.ts
@@ -5,10 +5,10 @@ import { deflateRawSync } from 'node:zlib'
 
 import { describe, expect, it } from 'vitest'
 
-import { isImportableSkillArchivePath } from './skill-archive-sniffer'
+import { inspectOuterArchive, isImportableSkillArchivePath } from './skill-archive-sniffer'
 import { UserSkillRepository } from './user-skill-repository'
 
-type ZipInput = { path: string; content: Buffer; method?: 0 | 8 }
+type ZipInput = { path: string; content: Buffer; method?: number }
 
 const crc32 = (buffer: Buffer): number => {
   let crc = 0xffffffff
@@ -30,7 +30,7 @@ const buildZip = (inputs: ZipInput[]): Buffer => {
   for (const input of inputs) {
     const method = input.method ?? 8
     const name = Buffer.from(input.path, 'utf8')
-    const compressed = method === 0 ? input.content : deflateRawSync(input.content)
+    const compressed = method === 8 ? deflateRawSync(input.content) : input.content
     const checksum = crc32(input.content)
     const local = Buffer.alloc(30 + name.length)
     local.writeUInt32LE(0x04034b50, 0)
@@ -87,6 +87,18 @@ const expectMatchesPreview = async (archive: Buffer, expected: boolean): Promise
   } finally {
     await rm(storage, { recursive: true, force: true })
   }
+}
+
+const incompressibleBytes = (size: number): Buffer => {
+  const bytes = Buffer.allocUnsafe(size)
+  let state = 0x12345678
+  for (let index = 0; index < size; index += 1) {
+    state ^= state << 13
+    state ^= state >>> 17
+    state ^= state << 5
+    bytes[index] = state & 0xff
+  }
+  return bytes
 }
 
 describe('isImportableSkillArchivePath', () => {
@@ -160,6 +172,53 @@ describe('isImportableSkillArchivePath', () => {
     await expectMatchesPreview(deflatedOuter, true)
   })
 
+  it('streams raw central records that the importer does not count as files', async () => {
+    const directories = Array.from({ length: 5_000 }, (_, index): ZipInput => ({
+      path: `metadata-${index}/`,
+      content: Buffer.alloc(0),
+      method: 0
+    }))
+    const archive = buildZip([
+      ...directories,
+      {
+        path: 'valid/SKILL.md',
+        content: Buffer.from('---\nname: Valid After Directories\n---\nBody')
+      }
+    ])
+
+    await expectMatchesPreview(archive, true)
+  })
+
+  it('fails closed when a deflated entry becomes unreadable during streaming', async () => {
+    const path = 'racy/SKILL.md'
+    const archive = buildZip([
+      {
+        path,
+        content: Buffer.concat([
+          Buffer.from('---\nname: Racy Skill\n---\n'),
+          incompressibleBytes(256 * 1024)
+        ])
+      }
+    ])
+    const dataOffset = 30 + Buffer.byteLength(path)
+    let dataReads = 0
+
+    await expect(
+      inspectOuterArchive({
+        size: archive.length,
+        read: async (position, length) => {
+          if (position === dataOffset || position === dataOffset + 64 * 1024) {
+            dataReads += 1
+            if (dataReads === 2) throw new Error('file truncated during read')
+          }
+          if (position < 0 || length < 0 || position + length > archive.length) return undefined
+          return archive.subarray(position, position + length)
+        }
+      })
+    ).resolves.toBe(false)
+    expect(dataReads).toBe(2)
+  })
+
   it('accepts importer-supported candidate counts and manifest sizes', async () => {
     const candidates = Array.from({ length: 33 }, (_, index) => ({
       path: `skill-${index.toString().padStart(2, '0')}/SKILL.md`,
@@ -169,10 +228,64 @@ describe('isImportableSkillArchivePath', () => {
     }))
     const largeManifest = Buffer.concat([
       Buffer.from('---\nname: Large Manifest\n---\n'),
-      Buffer.alloc(512 * 1024 + 1, 97)
+      Buffer.alloc(8 * 1024 * 1024, 97)
+    ])
+    const largeDeflatedManifest = Buffer.concat([
+      Buffer.from('---\nname: Large Deflated Manifest\n---\n'),
+      Buffer.alloc(8 * 1024 * 1024, 98)
+    ])
+    const largeFrontmatter = Buffer.concat([
+      Buffer.from('---\nname: Large Frontmatter\ndescription: |\n  '),
+      Buffer.alloc(4 * 1024 * 1024 + 1, 97),
+      Buffer.from('\n---\nBody')
     ])
 
     await expectMatchesPreview(buildZip(candidates), true)
-    await expectMatchesPreview(buildZip([{ path: 'large/SKILL.md', content: largeManifest }]), true)
+    await expectMatchesPreview(
+      buildZip([{ path: 'large/SKILL.md', content: largeManifest, method: 0 }]),
+      true
+    )
+    await expectMatchesPreview(
+      buildZip([{ path: 'large-deflated/SKILL.md', content: largeDeflatedManifest }]),
+      true
+    )
+    await expectMatchesPreview(
+      buildZip([{ path: 'large-frontmatter/SKILL.md', content: largeFrontmatter }]),
+      true
+    )
+    await expectMatchesPreview(
+      buildZip([
+        {
+          path: 'cr-only/SKILL.md',
+          content: Buffer.from('---\rname: CR-only Manifest\r---\rBody')
+        }
+      ]),
+      true
+    )
+  })
+
+  it('does not charge rejected loose roots against the nested candidate budget', async () => {
+    const rejectedLooseRoots = Array.from({ length: 256 }, (_, index): ZipInput[] => [
+      {
+        path: `rejected-${index.toString().padStart(3, '0')}/SKILL.md`,
+        content: Buffer.from(`---\nname: Rejected ${index}\n---\nBody`)
+      },
+      {
+        path: `rejected-${index.toString().padStart(3, '0')}/unsupported.bin`,
+        content: Buffer.from('cannot import'),
+        method: 99
+      }
+    ]).flat()
+    const nestedSkill = buildZip([
+      {
+        path: 'SKILL.md',
+        content: Buffer.from('---\nname: Nested After Rejections\n---\nBody')
+      }
+    ])
+
+    await expectMatchesPreview(
+      buildZip([...rejectedLooseRoots, { path: 'zz-valid.zip', content: nestedSkill, method: 0 }]),
+      true
+    )
   })
 })

--- a/src/main/skills/skill-archive-sniffer.test.ts
+++ b/src/main/skills/skill-archive-sniffer.test.ts
@@ -124,6 +124,18 @@ describe('isImportableSkillArchivePath', () => {
     await expect(inspect(Buffer.from('not a zip'))).resolves.toBe(false)
   })
 
+  it('matches importer EOCD lookup when a valid bundle has trailing bytes', async () => {
+    const bundle = buildZip([
+      {
+        path: 'trailing-data/SKILL.md',
+        content: Buffer.from('---\nname: Trailing Data\n---\nBody')
+      }
+    ])
+    const withTrailingData = Buffer.concat([bundle, Buffer.alloc(70 * 1024, 0x61)])
+
+    await expectMatchesPreview(withTrailingData, true)
+  })
+
   it('does not classify an ordinary ZIP by a nested filename or an ineligible deep manifest', async () => {
     const nestedFilename = buildZip([
       {
@@ -488,6 +500,32 @@ describe('isImportableSkillArchivePath', () => {
 
     await expect(inspectOuterArchive(reader())).resolves.toBe(true)
     await expect(inspectOuterArchive(reader(), 64 * 1024)).resolves.toBe(false)
+  })
+
+  it('stops the second deflated manifest inflate after the frontmatter closes', async () => {
+    const archive = buildZip([
+      {
+        path: 'large-body/SKILL.md',
+        content: Buffer.concat([
+          Buffer.from('---\nname: Large Body\n---\n'),
+          Buffer.alloc(96 * 1024, 97)
+        ])
+      }
+    ])
+    const reader = (): {
+      size: number
+      read: (position: number, length: number) => Promise<Buffer | undefined>
+    } => ({
+      size: archive.length,
+      read: async (position: number, length: number): Promise<Buffer | undefined> => {
+        if (position < 0 || length < 0 || position + length > archive.length) return undefined
+        return archive.subarray(position, position + length)
+      }
+    })
+
+    // Full entry validation consumes about 96 KiB. The frontmatter-only reread fits in the remaining
+    // budget, while re-inflating the whole manifest body a second time would exhaust it.
+    await expect(inspectOuterArchive(reader(), 128 * 1024)).resolves.toBe(true)
   })
 
   it('fails closed when cumulative stored-entry reads exhaust its work budget', async () => {

--- a/src/main/skills/skill-archive-sniffer.test.ts
+++ b/src/main/skills/skill-archive-sniffer.test.ts
@@ -528,6 +528,32 @@ describe('isImportableSkillArchivePath', () => {
     await expect(inspectOuterArchive(reader(), 128 * 1024)).resolves.toBe(true)
   })
 
+  it('reserves a separate bounded pass for manifest classification after entry validation', async () => {
+    const archive = buildZip([
+      {
+        path: 'near-validation-cap/SKILL.md',
+        content: Buffer.concat([
+          Buffer.from('---\nname: Near Validation Cap\n---\n'),
+          Buffer.alloc(120 * 1024, 97)
+        ])
+      }
+    ])
+    const reader = (): {
+      size: number
+      read: (position: number, length: number) => Promise<Buffer | undefined>
+    } => ({
+      size: archive.length,
+      read: async (position: number, length: number): Promise<Buffer | undefined> => {
+        if (position < 0 || length < 0 || position + length > archive.length) return undefined
+        return archive.subarray(position, position + length)
+      }
+    })
+
+    // Validation legitimately consumes almost this entire phase budget. Classification gets a fresh
+    // budget of the same size instead of double-charging the accepted manifest entry.
+    await expect(inspectOuterArchive(reader(), 128 * 1024)).resolves.toBe(true)
+  })
+
   it('fails closed when cumulative stored-entry reads exhaust its work budget', async () => {
     const archive = buildZip([
       { path: 'first.bin', content: Buffer.alloc(48 * 1024, 97), method: 0 },
@@ -580,7 +606,7 @@ describe('isImportableSkillArchivePath', () => {
     })
 
     await expect(inspectOuterArchive(reader())).resolves.toBe(true)
-    await expect(inspectOuterArchive(reader(), 64 * 1024)).resolves.toBe(false)
+    await expect(inspectOuterArchive(reader(), 32 * 1024)).resolves.toBe(false)
   })
 
   it('rejects an early named nested root when later manifest work exhausts the budget', async () => {

--- a/src/main/skills/skill-archive-sniffer.test.ts
+++ b/src/main/skills/skill-archive-sniffer.test.ts
@@ -108,15 +108,22 @@ describe('isImportableSkillArchivePath', () => {
     await expect(inspect(oversized)).resolves.toBe(false)
   })
 
-  it('recognizes an explicitly named nested .skill package from the central directory', async () => {
-    const archive = buildZip([
+  it('does not classify an ordinary ZIP by a nested filename or an ineligible deep manifest', async () => {
+    const nestedFilename = buildZip([
       {
         path: 'bundles/paper-finder.skill',
         content: Buffer.from('nested archive bytes'),
         method: 0
       }
     ])
+    const deepManifest = buildZip([
+      {
+        path: 'a/b/c/SKILL.md',
+        content: Buffer.from('---\nname: Too Deep\ndescription: hidden\n---\nBody')
+      }
+    ])
 
-    await expect(inspect(archive)).resolves.toBe(true)
+    await expect(inspect(nestedFilename)).resolves.toBe(false)
+    await expect(inspect(deepManifest)).resolves.toBe(false)
   })
 })

--- a/src/main/skills/skill-archive-sniffer.test.ts
+++ b/src/main/skills/skill-archive-sniffer.test.ts
@@ -136,6 +136,41 @@ describe('isImportableSkillArchivePath', () => {
     await expectMatchesPreview(withTrailingData, true)
   })
 
+  it('keeps earlier valid entries when a later central record is malformed', async () => {
+    const manifestPath = 'central-tail/SKILL.md'
+    const archive = buildZip([
+      {
+        path: manifestPath,
+        content: Buffer.from('---\nname: Central Tail\n---\nBody')
+      },
+      { path: 'central-tail/README.md', content: Buffer.from('Ignored trailing entry') }
+    ])
+    const eocdOffset = archive.length - 22
+    const centralOffset = archive.readUInt32LE(eocdOffset + 16)
+    const secondCentralOffset = centralOffset + 46 + Buffer.byteLength(manifestPath)
+    archive.writeUInt32LE(0xdeadbeef, secondCentralOffset)
+
+    await expectMatchesPreview(archive, true)
+  })
+
+  it('classifies the current entry before an overlong central extra field stops the walk', async () => {
+    const manifestPath = 'central-extra/SKILL.md'
+    const rejectedPath = 'central-extra/bad.bin'
+    const archive = buildZip([
+      {
+        path: manifestPath,
+        content: Buffer.from('---\nname: Central Extra\n---\nBody')
+      },
+      { path: rejectedPath, content: Buffer.from('unsupported'), method: 99 }
+    ])
+    const eocdOffset = archive.length - 22
+    const centralOffset = archive.readUInt32LE(eocdOffset + 16)
+    const secondCentralOffset = centralOffset + 46 + Buffer.byteLength(manifestPath)
+    archive.writeUInt16LE(0xffff, secondCentralOffset + 30)
+
+    await expectMatchesPreview(archive, false)
+  })
+
   it('does not classify an ordinary ZIP by a nested filename or an ineligible deep manifest', async () => {
     const nestedFilename = buildZip([
       {

--- a/src/main/skills/skill-archive-sniffer.test.ts
+++ b/src/main/skills/skill-archive-sniffer.test.ts
@@ -1,0 +1,122 @@
+import { mkdtemp, rm, writeFile } from 'node:fs/promises'
+import { tmpdir } from 'node:os'
+import { join } from 'node:path'
+import { deflateRawSync } from 'node:zlib'
+
+import { describe, expect, it } from 'vitest'
+
+import { SKILL_ARCHIVE_SNIFF_LIMITS, isImportableSkillArchivePath } from './skill-archive-sniffer'
+
+type ZipInput = { path: string; content: Buffer; method?: 0 | 8 }
+
+const crc32 = (buffer: Buffer): number => {
+  let crc = 0xffffffff
+  for (let index = 0; index < buffer.length; index += 1) {
+    let current = (crc ^ buffer[index]) & 0xff
+    for (let bit = 0; bit < 8; bit += 1) {
+      current = current & 1 ? 0xedb88320 ^ (current >>> 1) : current >>> 1
+    }
+    crc = (crc >>> 8) ^ current
+  }
+  return (crc ^ 0xffffffff) >>> 0
+}
+
+const buildZip = (inputs: ZipInput[]): Buffer => {
+  const locals: Buffer[] = []
+  const centrals: Buffer[] = []
+  let offset = 0
+
+  for (const input of inputs) {
+    const method = input.method ?? 8
+    const name = Buffer.from(input.path, 'utf8')
+    const compressed = method === 0 ? input.content : deflateRawSync(input.content)
+    const checksum = crc32(input.content)
+    const local = Buffer.alloc(30 + name.length)
+    local.writeUInt32LE(0x04034b50, 0)
+    local.writeUInt16LE(method, 8)
+    local.writeUInt32LE(checksum, 14)
+    local.writeUInt32LE(compressed.length, 18)
+    local.writeUInt32LE(input.content.length, 22)
+    local.writeUInt16LE(name.length, 26)
+    name.copy(local, 30)
+    locals.push(local, compressed)
+
+    const central = Buffer.alloc(46 + name.length)
+    central.writeUInt32LE(0x02014b50, 0)
+    central.writeUInt16LE(method, 10)
+    central.writeUInt32LE(checksum, 16)
+    central.writeUInt32LE(compressed.length, 20)
+    central.writeUInt32LE(input.content.length, 24)
+    central.writeUInt16LE(name.length, 28)
+    central.writeUInt32LE(offset, 42)
+    name.copy(central, 46)
+    centrals.push(central)
+    offset += local.length + compressed.length
+  }
+
+  const localBytes = Buffer.concat(locals)
+  const centralBytes = Buffer.concat(centrals)
+  const eocd = Buffer.alloc(22)
+  eocd.writeUInt32LE(0x06054b50, 0)
+  eocd.writeUInt16LE(inputs.length, 8)
+  eocd.writeUInt16LE(inputs.length, 10)
+  eocd.writeUInt32LE(centralBytes.length, 12)
+  eocd.writeUInt32LE(localBytes.length, 16)
+  return Buffer.concat([localBytes, centralBytes, eocd])
+}
+
+const inspect = async (archive: Buffer): Promise<boolean> => {
+  const root = await mkdtemp(join(tmpdir(), 'skill-archive-sniff-'))
+  const filePath = join(root, 'bundle.zip')
+  await writeFile(filePath, archive)
+
+  try {
+    return await isImportableSkillArchivePath(filePath)
+  } finally {
+    await rm(root, { recursive: true, force: true })
+  }
+}
+
+describe('isImportableSkillArchivePath', () => {
+  it('finds a named Skill manifest without inflating unrelated large entries', async () => {
+    const archive = buildZip([
+      { path: 'paper-finder/assets/model.bin', content: Buffer.alloc(2 * 1024 * 1024), method: 0 },
+      {
+        path: 'paper-finder/SKILL.md',
+        content: Buffer.from('---\nname: Paper Finder\ndescription: Finds papers.\n---\nRun it.')
+      }
+    ])
+
+    await expect(inspect(archive)).resolves.toBe(true)
+  })
+
+  it('rejects ordinary, unnamed, corrupt, and oversized-manifest archives', async () => {
+    const ordinary = buildZip([{ path: 'README.md', content: Buffer.from('dataset archive') }])
+    const unnamed = buildZip([
+      { path: 'SKILL.md', content: Buffer.from('---\ndescription: Missing name.\n---\nBody') }
+    ])
+    const oversized = buildZip([
+      {
+        path: 'SKILL.md',
+        content: Buffer.alloc(SKILL_ARCHIVE_SNIFF_LIMITS.maxManifestBytes + 1, 97)
+      }
+    ])
+
+    await expect(inspect(ordinary)).resolves.toBe(false)
+    await expect(inspect(unnamed)).resolves.toBe(false)
+    await expect(inspect(Buffer.from('not a zip'))).resolves.toBe(false)
+    await expect(inspect(oversized)).resolves.toBe(false)
+  })
+
+  it('recognizes an explicitly named nested .skill package from the central directory', async () => {
+    const archive = buildZip([
+      {
+        path: 'bundles/paper-finder.skill',
+        content: Buffer.from('nested archive bytes'),
+        method: 0
+      }
+    ])
+
+    await expect(inspect(archive)).resolves.toBe(true)
+  })
+})

--- a/src/main/skills/skill-archive-sniffer.test.ts
+++ b/src/main/skills/skill-archive-sniffer.test.ts
@@ -5,7 +5,8 @@ import { deflateRawSync } from 'node:zlib'
 
 import { describe, expect, it } from 'vitest'
 
-import { SKILL_ARCHIVE_SNIFF_LIMITS, isImportableSkillArchivePath } from './skill-archive-sniffer'
+import { isImportableSkillArchivePath } from './skill-archive-sniffer'
+import { UserSkillRepository } from './user-skill-repository'
 
 type ZipInput = { path: string; content: Buffer; method?: 0 | 8 }
 
@@ -77,6 +78,17 @@ const inspect = async (archive: Buffer): Promise<boolean> => {
   }
 }
 
+const expectMatchesPreview = async (archive: Buffer, expected: boolean): Promise<void> => {
+  const storage = await mkdtemp(join(tmpdir(), 'skill-archive-preview-'))
+  try {
+    const preview = await new UserSkillRepository(storage).previewZip(archive)
+    await expect(inspect(archive)).resolves.toBe(expected)
+    expect(preview.previews.length > 0).toBe(expected)
+  } finally {
+    await rm(storage, { recursive: true, force: true })
+  }
+}
+
 describe('isImportableSkillArchivePath', () => {
   it('finds a named Skill manifest without inflating unrelated large entries', async () => {
     const archive = buildZip([
@@ -90,22 +102,14 @@ describe('isImportableSkillArchivePath', () => {
     await expect(inspect(archive)).resolves.toBe(true)
   })
 
-  it('rejects ordinary, unnamed, corrupt, and oversized-manifest archives', async () => {
+  it('rejects ordinary, unnamed, and corrupt archives', async () => {
     const ordinary = buildZip([{ path: 'README.md', content: Buffer.from('dataset archive') }])
     const unnamed = buildZip([
       { path: 'SKILL.md', content: Buffer.from('---\ndescription: Missing name.\n---\nBody') }
     ])
-    const oversized = buildZip([
-      {
-        path: 'SKILL.md',
-        content: Buffer.alloc(SKILL_ARCHIVE_SNIFF_LIMITS.maxManifestBytes + 1, 97)
-      }
-    ])
-
     await expect(inspect(ordinary)).resolves.toBe(false)
     await expect(inspect(unnamed)).resolves.toBe(false)
     await expect(inspect(Buffer.from('not a zip'))).resolves.toBe(false)
-    await expect(inspect(oversized)).resolves.toBe(false)
   })
 
   it('does not classify an ordinary ZIP by a nested filename or an ineligible deep manifest', async () => {
@@ -125,5 +129,50 @@ describe('isImportableSkillArchivePath', () => {
 
     await expect(inspect(nestedFilename)).resolves.toBe(false)
     await expect(inspect(deepManifest)).resolves.toBe(false)
+  })
+
+  it('uses the same shallowest-root selection as full bundle discovery', async () => {
+    const archive = buildZip([
+      {
+        path: 'a/SKILL.md',
+        content: Buffer.from('---\ndescription: Missing name.\n---\nBody')
+      },
+      {
+        path: 'a/b/SKILL.md',
+        content: Buffer.from('---\nname: Hidden Nested Skill\n---\nBody')
+      }
+    ])
+
+    await expectMatchesPreview(archive, false)
+  })
+
+  it('recognizes one importer-supported level of nested Skill archive', async () => {
+    const inner = buildZip([
+      {
+        path: 'SKILL.md',
+        content: Buffer.from('---\nname: Nested Skill\ndescription: nested\n---\nBody')
+      }
+    ])
+    const storedOuter = buildZip([{ path: 'nested/alpha.zip', content: inner, method: 0 }])
+    const deflatedOuter = buildZip([{ path: 'nested/alpha.zip', content: inner }])
+
+    await expectMatchesPreview(storedOuter, true)
+    await expectMatchesPreview(deflatedOuter, true)
+  })
+
+  it('accepts importer-supported candidate counts and manifest sizes', async () => {
+    const candidates = Array.from({ length: 33 }, (_, index) => ({
+      path: `skill-${index.toString().padStart(2, '0')}/SKILL.md`,
+      content: Buffer.from(
+        index === 32 ? '---\nname: Candidate 33\n---\nBody' : '---\ndescription: no name\n---\nBody'
+      )
+    }))
+    const largeManifest = Buffer.concat([
+      Buffer.from('---\nname: Large Manifest\n---\n'),
+      Buffer.alloc(512 * 1024 + 1, 97)
+    ])
+
+    await expectMatchesPreview(buildZip(candidates), true)
+    await expectMatchesPreview(buildZip([{ path: 'large/SKILL.md', content: largeManifest }]), true)
   })
 })

--- a/src/main/skills/skill-archive-sniffer.test.ts
+++ b/src/main/skills/skill-archive-sniffer.test.ts
@@ -172,6 +172,78 @@ describe('isImportableSkillArchivePath', () => {
     await expectMatchesPreview(deflatedOuter, true)
   })
 
+  it('rejects a nested archive when strict extraction cannot inflate a sibling', async () => {
+    const manifestPath = 'SKILL.md'
+    const siblingPath = 'resource.bin'
+    const manifest = Buffer.from('---\nname: Broken Nested Skill\n---\nBody')
+    const sibling = Buffer.from('resource')
+    const inner = buildZip([
+      { path: manifestPath, content: manifest, method: 0 },
+      { path: siblingPath, content: sibling }
+    ])
+    const siblingLocalOffset = 30 + Buffer.byteLength(manifestPath) + manifest.length
+    const siblingDataOffset = siblingLocalOffset + 30 + Buffer.byteLength(siblingPath)
+    inner.fill(0xff, siblingDataOffset, siblingDataOffset + deflateRawSync(sibling).length)
+
+    await expectMatchesPreview(
+      buildZip([{ path: 'nested/broken.zip', content: inner, method: 0 }]),
+      false
+    )
+    await expectMatchesPreview(buildZip([{ path: 'nested/broken.zip', content: inner }]), false)
+  })
+
+  it('rejects a nested archive with an out-of-range sibling local header', async () => {
+    const manifestPath = 'SKILL.md'
+    const siblingPath = 'resource.bin'
+    const manifest = Buffer.from('---\nname: Out-of-range Nested Skill\n---\nBody')
+    const sibling = Buffer.from('resource')
+    const inner = buildZip([
+      { path: manifestPath, content: manifest, method: 0 },
+      { path: siblingPath, content: sibling, method: 0 }
+    ])
+    const centralOffset =
+      30 +
+      Buffer.byteLength(manifestPath) +
+      manifest.length +
+      30 +
+      Buffer.byteLength(siblingPath) +
+      sibling.length
+    const siblingCentralOffset = centralOffset + 46 + Buffer.byteLength(manifestPath)
+    inner.writeUInt32LE(inner.length + 1, siblingCentralOffset + 42)
+
+    await expectMatchesPreview(
+      buildZip([{ path: 'nested/out-of-range.zip', content: inner, method: 0 }]),
+      false
+    )
+  })
+
+  it('uses actual inflate size instead of an inner central-directory claim', async () => {
+    const manifestPath = 'SKILL.md'
+    const manifest = Buffer.from('---\nname: Inner Actual Size\n---\nBody')
+    const compressedSize = deflateRawSync(manifest).length
+    const inner = buildZip([{ path: manifestPath, content: manifest }])
+    const centralOffset = 30 + Buffer.byteLength(manifestPath) + compressedSize
+    inner.writeUInt32LE(51 * 1024 * 1024, centralOffset + 24)
+
+    await expectMatchesPreview(
+      buildZip([{ path: 'nested/actual-size.zip', content: inner, method: 0 }]),
+      true
+    )
+  })
+
+  it('matches importer clamping for an incomplete stored manifest entry', async () => {
+    const manifestPath = 'SKILL.md'
+    const manifest = Buffer.from('---\nname: Clamped Stored Manifest\n---\nBody')
+    const inner = buildZip([{ path: manifestPath, content: manifest, method: 0 }])
+    const centralOffset = 30 + Buffer.byteLength(manifestPath) + manifest.length
+    inner.writeUInt32LE(inner.length, centralOffset + 20)
+
+    await expectMatchesPreview(
+      buildZip([{ path: 'nested/clamped.zip', content: inner, method: 0 }]),
+      true
+    )
+  })
+
   it('streams raw central records that the importer does not count as files', async () => {
     const directories = Array.from({ length: 5_000 }, (_, index): ZipInput => ({
       path: `metadata-${index}/`,
@@ -217,6 +289,35 @@ describe('isImportableSkillArchivePath', () => {
       })
     ).resolves.toBe(false)
     expect(dataReads).toBe(2)
+  })
+
+  it('fails closed when a stored sibling becomes unreadable during streaming', async () => {
+    const manifestPath = 'racy-stored/SKILL.md'
+    const siblingPath = 'racy-stored/resource.bin'
+    const manifest = Buffer.from('---\nname: Racy Stored Skill\n---\nBody')
+    const sibling = incompressibleBytes(256 * 1024)
+    const archive = buildZip([
+      { path: manifestPath, content: manifest, method: 0 },
+      { path: siblingPath, content: sibling, method: 0 }
+    ])
+    const siblingLocalOffset = 30 + Buffer.byteLength(manifestPath) + manifest.length
+    const siblingDataOffset = siblingLocalOffset + 30 + Buffer.byteLength(siblingPath)
+    let siblingReads = 0
+
+    await expect(
+      inspectOuterArchive({
+        size: archive.length,
+        read: async (position, length) => {
+          if (position === siblingDataOffset || position === siblingDataOffset + 64 * 1024) {
+            siblingReads += 1
+            if (siblingReads === 2) throw new Error('file truncated during stored read')
+          }
+          if (position < 0 || length < 0 || position + length > archive.length) return undefined
+          return archive.subarray(position, position + length)
+        }
+      })
+    ).resolves.toBe(false)
+    expect(siblingReads).toBe(2)
   })
 
   it('accepts importer-supported candidate counts and manifest sizes', async () => {
@@ -287,5 +388,221 @@ describe('isImportableSkillArchivePath', () => {
       buildZip([...rejectedLooseRoots, { path: 'zz-valid.zip', content: nestedSkill, method: 0 }]),
       true
     )
+  })
+
+  it('rejects a loose root when a sibling has a malformed local header', async () => {
+    const manifestPath = 'broken/SKILL.md'
+    const manifest = Buffer.from('---\nname: Broken Resource Skill\n---\nBody')
+    const archive = buildZip([
+      { path: manifestPath, content: manifest, method: 0 },
+      { path: 'broken/resource.txt', content: Buffer.from('resource'), method: 0 }
+    ])
+    const siblingLocalOffset = 30 + Buffer.byteLength(manifestPath) + manifest.length
+    archive.writeUInt32LE(0, siblingLocalOffset)
+
+    await expectMatchesPreview(archive, false)
+  })
+
+  it('rejects a loose root when a sibling cannot be inflated', async () => {
+    const manifestPath = 'broken/SKILL.md'
+    const siblingPath = 'broken/resource.txt'
+    const manifest = Buffer.from('---\nname: Broken Deflate Skill\n---\nBody')
+    const sibling = Buffer.from('resource')
+    const archive = buildZip([
+      { path: manifestPath, content: manifest, method: 0 },
+      { path: siblingPath, content: sibling }
+    ])
+    const siblingLocalOffset = 30 + Buffer.byteLength(manifestPath) + manifest.length
+    const siblingDataOffset = siblingLocalOffset + 30 + Buffer.byteLength(siblingPath)
+    archive.fill(0xff, siblingDataOffset, siblingDataOffset + deflateRawSync(sibling).length)
+
+    await expectMatchesPreview(archive, false)
+  })
+
+  it('uses the actual inflated sibling size for loose-root caps', async () => {
+    const manifestPath = 'actual-size/SKILL.md'
+    const siblingPath = 'actual-size/resource.txt'
+    const manifest = Buffer.from('---\nname: Actual Size Skill\n---\nBody')
+    const sibling = Buffer.from('small resource')
+    const archive = buildZip([
+      { path: manifestPath, content: manifest, method: 0 },
+      { path: siblingPath, content: sibling }
+    ])
+    const siblingCompressedSize = deflateRawSync(sibling).length
+    const centralOffset =
+      30 +
+      Buffer.byteLength(manifestPath) +
+      manifest.length +
+      30 +
+      Buffer.byteLength(siblingPath) +
+      siblingCompressedSize
+    const siblingCentralOffset = centralOffset + 46 + Buffer.byteLength(manifestPath)
+    archive.writeUInt32LE(65 * 1024 * 1024, siblingCentralOffset + 24)
+
+    await expectMatchesPreview(archive, true)
+  })
+
+  it('does not count malformed local entries against the outer file cap', async () => {
+    const malformed = Array.from({ length: 4_096 }, (_, index): ZipInput => ({
+      path: `malformed-${index.toString().padStart(4, '0')}.txt`,
+      content: Buffer.alloc(0),
+      method: 0
+    }))
+    const manifestPath = 'after-malformed/SKILL.md'
+    const archive = buildZip([
+      ...malformed,
+      {
+        path: manifestPath,
+        content: Buffer.from('---\nname: After Malformed Entries\n---\nBody'),
+        method: 0
+      }
+    ])
+    let localOffset = 0
+    for (const input of malformed) {
+      archive.writeUInt32LE(0, localOffset)
+      localOffset += 30 + Buffer.byteLength(input.path)
+    }
+
+    await expectMatchesPreview(archive, true)
+  })
+
+  it('fails closed when cumulative attempted inflate output exhausts its work budget', async () => {
+    const archive = buildZip([
+      { path: 'first.bin', content: Buffer.alloc(48 * 1024, 97) },
+      { path: 'second.bin', content: Buffer.alloc(48 * 1024, 98) },
+      {
+        path: 'after-work/SKILL.md',
+        content: Buffer.from('---\nname: After Inflate Work\n---\nBody')
+      }
+    ])
+    const reader = (): {
+      size: number
+      read: (position: number, length: number) => Promise<Buffer | undefined>
+    } => ({
+      size: archive.length,
+      read: async (position: number, length: number): Promise<Buffer | undefined> => {
+        if (position < 0 || length < 0 || position + length > archive.length) return undefined
+        return archive.subarray(position, position + length)
+      }
+    })
+
+    await expect(inspectOuterArchive(reader())).resolves.toBe(true)
+    await expect(inspectOuterArchive(reader(), 64 * 1024)).resolves.toBe(false)
+  })
+
+  it('fails closed when cumulative stored-entry reads exhaust its work budget', async () => {
+    const archive = buildZip([
+      { path: 'first.bin', content: Buffer.alloc(48 * 1024, 97), method: 0 },
+      { path: 'second.bin', content: Buffer.alloc(48 * 1024, 98), method: 0 },
+      {
+        path: 'after-reads/SKILL.md',
+        content: Buffer.from('---\nname: After Stored Reads\n---\nBody'),
+        method: 0
+      }
+    ])
+    const reader = (): {
+      size: number
+      read: (position: number, length: number) => Promise<Buffer | undefined>
+    } => ({
+      size: archive.length,
+      read: async (position: number, length: number): Promise<Buffer | undefined> => {
+        if (position < 0 || length < 0 || position + length > archive.length) return undefined
+        return archive.subarray(position, position + length)
+      }
+    })
+
+    await expect(inspectOuterArchive(reader())).resolves.toBe(true)
+    await expect(inspectOuterArchive(reader(), 64 * 1024)).resolves.toBe(false)
+  })
+
+  it('rejects an early named root when later manifest work exhausts the budget', async () => {
+    const archive = buildZip([
+      {
+        path: 'a/SKILL.md',
+        content: Buffer.from('---\nname: Early Named Root\n---\nBody'),
+        method: 0
+      },
+      {
+        path: 'b/SKILL.md',
+        content: Buffer.concat([
+          Buffer.from('---\ndescription: no name\n---\n'),
+          Buffer.alloc(48 * 1024, 97)
+        ])
+      }
+    ])
+    const reader = (): {
+      size: number
+      read: (position: number, length: number) => Promise<Buffer | undefined>
+    } => ({
+      size: archive.length,
+      read: async (position: number, length: number): Promise<Buffer | undefined> => {
+        if (position < 0 || length < 0 || position + length > archive.length) return undefined
+        return archive.subarray(position, position + length)
+      }
+    })
+
+    await expect(inspectOuterArchive(reader())).resolves.toBe(true)
+    await expect(inspectOuterArchive(reader(), 64 * 1024)).resolves.toBe(false)
+  })
+
+  it('rejects an early named nested root when later manifest work exhausts the budget', async () => {
+    const inner = buildZip([
+      {
+        path: 'a/SKILL.md',
+        content: Buffer.from('---\nname: Early Nested Root\n---\nBody'),
+        method: 0
+      },
+      {
+        path: 'b/SKILL.md',
+        content: Buffer.concat([
+          Buffer.from('---\ndescription: no name\n---\n'),
+          Buffer.alloc(48 * 1024, 97)
+        ])
+      }
+    ])
+    const archive = buildZip([{ path: 'nested.zip', content: inner, method: 0 }])
+    const reader = (): {
+      size: number
+      read: (position: number, length: number) => Promise<Buffer | undefined>
+    } => ({
+      size: archive.length,
+      read: async (position: number, length: number): Promise<Buffer | undefined> => {
+        if (position < 0 || length < 0 || position + length > archive.length) return undefined
+        return archive.subarray(position, position + length)
+      }
+    })
+
+    await expect(inspectOuterArchive(reader())).resolves.toBe(true)
+    await expect(inspectOuterArchive(reader(), 64 * 1024)).resolves.toBe(false)
+  })
+
+  it('shares attempted inflate work across standalone nested archives', async () => {
+    const first = buildZip([{ path: 'first.bin', content: Buffer.alloc(48 * 1024, 97) }])
+    const second = buildZip([{ path: 'second.bin', content: Buffer.alloc(48 * 1024, 98) }])
+    const valid = buildZip([
+      {
+        path: 'SKILL.md',
+        content: Buffer.from('---\nname: After Nested Work\n---\nBody'),
+        method: 0
+      }
+    ])
+    const archive = buildZip([
+      { path: 'first.zip', content: first, method: 0 },
+      { path: 'second.zip', content: second, method: 0 },
+      { path: 'valid.zip', content: valid, method: 0 }
+    ])
+    const reader = (): {
+      size: number
+      read: (position: number, length: number) => Promise<Buffer | undefined>
+    } => ({
+      size: archive.length,
+      read: async (position: number, length: number): Promise<Buffer | undefined> => {
+        if (position < 0 || length < 0 || position + length > archive.length) return undefined
+        return archive.subarray(position, position + length)
+      }
+    })
+
+    await expect(inspectOuterArchive(reader())).resolves.toBe(true)
+    await expect(inspectOuterArchive(reader(), 64 * 1024)).resolves.toBe(false)
   })
 })

--- a/src/main/skills/skill-archive-sniffer.ts
+++ b/src/main/skills/skill-archive-sniffer.ts
@@ -1,6 +1,6 @@
 import { open, type FileHandle } from 'node:fs/promises'
 import { Readable } from 'node:stream'
-import { createInflateRaw, inflateRaw } from 'node:zlib'
+import { createInflateRaw } from 'node:zlib'
 
 import { parseSkillDocument } from './frontmatter'
 import { SKILL_IMPORT_LIMITS } from './import-limits'
@@ -25,19 +25,27 @@ type CentralEntry = {
   name: string
   method: number
   compressedSize: number
-  uncompressedSize: number
   localOffset: number
 }
 
 type ArchiveScan = {
   accepted: CentralEntry[]
   skippedPaths: string[]
+  actualSizes: Map<CentralEntry, number>
+  dataRanges: Map<CentralEntry, { offset: number; compressedSize: number }>
 }
 
 type ManifestRootInspection = {
   ownerRoots: string[]
   candidateRoots: string[]
   named: boolean[]
+}
+
+type InflateBudget = {
+  maxBytes: number
+  readBytes: number
+  inflatedBytes: number
+  exhausted: boolean
 }
 
 type ScanLimits = {
@@ -142,10 +150,6 @@ const isUnsafeArchivePath = (path: string): boolean =>
 
 const isNestedArchive = (path: string): boolean => /\.(zip|skill)$/i.test(path)
 
-const extractedEntrySize = (
-  entry: Pick<CentralEntry, 'method' | 'compressedSize' | 'uncompressedSize'>
-): number => (entry.method === 0 ? entry.compressedSize : entry.uncompressedSize)
-
 // Sequential, fixed-size buffering keeps a ZIP with thousands of directory/metadata records from
 // turning into two random-access reads per record. It also avoids allocating the full central
 // directory, whose raw record count is not capped by the importer (only accepted files are capped).
@@ -197,9 +201,9 @@ const centralCursor = (
   }
 }
 
-// Streams central-directory records instead of reading the whole ZIP or inflating unrelated files.
-// Size/count decisions mirror extractZipLenient (outer) and extractZip (one nested archive) using the
-// central metadata; candidate entry bytes are checked against their local header when actually read.
+// Streams central-directory records instead of reading the whole ZIP. This pass keeps structural path
+// decisions in central order; local-header readability, actual inflate sizes, and file/total caps are
+// applied by validateArchiveEntries so untrusted central size/count claims cannot change eligibility.
 const scanArchive = async (
   reader: ArchiveReader,
   limits: ScanLimits
@@ -234,7 +238,6 @@ const scanArchive = async (
 
   const accepted: CentralEntry[] = []
   const skippedPaths: string[] = []
-  let totalBytes = 0
   const cursor = centralCursor(reader, centralOffset, centralEnd)
 
   for (let index = 0; index < entryCount; index += 1) {
@@ -243,7 +246,6 @@ const scanArchive = async (
 
     const method = header.readUInt16LE(10)
     const compressedSize = header.readUInt32LE(20)
-    const uncompressedSize = header.readUInt32LE(24)
     const nameLength = header.readUInt16LE(28)
     const extraLength = header.readUInt16LE(30)
     const commentLength = header.readUInt16LE(32)
@@ -266,69 +268,42 @@ const scanArchive = async (
     }
 
     const depth = name.split('/').length - 1
-    const outputSize = method === 0 ? compressedSize : uncompressedSize
-    const violatesCaps =
-      depth > limits.maxDepth ||
-      accepted.length >= limits.maxFiles ||
-      outputSize > limits.maxFileBytes ||
-      totalBytes + outputSize > limits.maxTotalBytes
-    if (violatesCaps) {
+    if (depth > limits.maxDepth) {
       if (limits.strictCaps) return undefined
       skippedPaths.push(name)
       continue
     }
 
-    accepted.push({ name, method, compressedSize, uncompressedSize, localOffset })
-    totalBytes += outputSize
+    accepted.push({ name, method, compressedSize, localOffset })
   }
 
-  return { accepted, skippedPaths }
+  return { accepted, skippedPaths, actualSizes: new Map(), dataRanges: new Map() }
 }
 
-const entryDataOffset = async (
+type LocalEntryData =
+  | { kind: 'valid'; offset: number; availableSize: number; complete: boolean }
+  | { kind: 'wrong-signature' }
+  | { kind: 'unreadable' }
+
+const locateEntryData = async (
   reader: ArchiveReader,
   entry: CentralEntry
-): Promise<number | undefined> => {
+): Promise<LocalEntryData> => {
   const header = await reader.read(entry.localOffset, 30)
-  if (
-    !header ||
-    header.readUInt32LE(0) !== LOCAL_SIGNATURE ||
-    header.readUInt16LE(8) !== entry.method
-  ) {
-    return undefined
-  }
+  if (!header) return { kind: 'unreadable' }
+  if (header.readUInt32LE(0) !== LOCAL_SIGNATURE) return { kind: 'wrong-signature' }
 
   const offset = entry.localOffset + 30 + header.readUInt16LE(26) + header.readUInt16LE(28)
-  return offset + entry.compressedSize <= reader.size ? offset : undefined
-}
+  if (!Number.isSafeInteger(offset) || offset < 0 || offset > reader.size) {
+    return { kind: 'unreadable' }
+  }
 
-const inflateBounded = (compressed: Buffer, maxOutputLength: number): Promise<Buffer> =>
-  new Promise((resolve, reject) => {
-    inflateRaw(compressed, { maxOutputLength }, (error, result) => {
-      if (error) reject(error)
-      else resolve(result)
-    })
-  })
-
-const readEntry = async (
-  reader: ArchiveReader,
-  entry: CentralEntry,
-  maxOutputLength: number
-): Promise<Buffer | undefined> => {
-  if (entry.uncompressedSize > maxOutputLength) return undefined
-
-  const offset = await entryDataOffset(reader, entry)
-  if (offset === undefined) return undefined
-  const compressed = await reader.read(offset, entry.compressedSize)
-  if (!compressed) return undefined
-
-  try {
-    if (entry.method === 0) {
-      return compressed.length <= maxOutputLength ? compressed : undefined
-    }
-    return await inflateBounded(compressed, maxOutputLength)
-  } catch {
-    return undefined
+  const availableSize = Math.min(entry.compressedSize, reader.size - offset)
+  return {
+    kind: 'valid',
+    offset,
+    availableSize,
+    complete: availableSize === entry.compressedSize
   }
 }
 
@@ -384,25 +359,90 @@ const createFrontmatterScanner = (): {
   }
 }
 
+const consumeReadBudget = (budget: InflateBudget, bytes: number): boolean => {
+  budget.readBytes += bytes
+  if (budget.readBytes <= budget.maxBytes) return true
+
+  budget.exhausted = true
+  return false
+}
+
+const consumeInflateBudget = (budget: InflateBudget, bytes: number): boolean => {
+  budget.inflatedBytes += bytes
+  if (budget.inflatedBytes <= budget.maxBytes) return true
+
+  budget.exhausted = true
+  return false
+}
+
 const compressedEntryChunks = async function* (
   reader: ArchiveReader,
   offset: number,
-  size: number
+  size: number,
+  budget: InflateBudget
 ): AsyncGenerator<Buffer> {
   let consumed = 0
   while (consumed < size) {
     const length = Math.min(ENTRY_READ_CHUNK_BYTES, size - consumed)
     const chunk = await reader.read(offset + consumed, length)
     if (!chunk) throw new Error('Unreadable ZIP entry.')
+    if (!consumeReadBudget(budget, chunk.length)) {
+      throw new Error('ZIP entry read budget exhausted.')
+    }
     yield chunk
     consumed += length
+  }
+}
+
+const inflatedEntryChunks = async function* (
+  reader: ArchiveReader,
+  offset: number,
+  compressedSize: number,
+  budget: InflateBudget
+): AsyncGenerator<Buffer> {
+  const source = Readable.from(compressedEntryChunks(reader, offset, compressedSize, budget))
+  const output = source.pipe(createInflateRaw())
+  // pipe() does not forward source errors. A file truncated between stat/scan/read must reject this
+  // candidate through the consumed transform instead of becoming an unhandled main-process error.
+  source.on('error', (error: Error) => output.destroy(error))
+
+  try {
+    for await (const value of output) {
+      yield Buffer.isBuffer(value) ? value : Buffer.from(value as Uint8Array)
+    }
+  } finally {
+    output.destroy()
+    source.destroy()
+  }
+}
+
+const readInflatedEntry = async (
+  reader: ArchiveReader,
+  offset: number,
+  compressedSize: number,
+  maxOutputBytes: number,
+  inflateBudget: InflateBudget
+): Promise<Buffer | undefined> => {
+  const chunks: Buffer[] = []
+  let total = 0
+  try {
+    for await (const chunk of inflatedEntryChunks(reader, offset, compressedSize, inflateBudget)) {
+      if (!consumeInflateBudget(inflateBudget, chunk.length)) return undefined
+      total += chunk.length
+      if (total > maxOutputBytes) return undefined
+      chunks.push(chunk)
+    }
+    return Buffer.concat(chunks, total)
+  } catch {
+    return undefined
   }
 }
 
 const readStoredFrontmatter = async (
   reader: ArchiveReader,
   offset: number,
-  size: number
+  size: number,
+  budget: InflateBudget
 ): Promise<Buffer | undefined> => {
   if (size > MAX_SNIFF_FRONTMATTER_BYTES) return undefined
 
@@ -410,7 +450,7 @@ const readStoredFrontmatter = async (
   const chunks: Buffer[] = []
   let total = 0
   try {
-    for await (const chunk of compressedEntryChunks(reader, offset, size)) {
+    for await (const chunk of compressedEntryChunks(reader, offset, size, budget)) {
       chunks.push(chunk)
       total += chunk.length
       const result = scanner.push(chunk)
@@ -431,23 +471,16 @@ const readDeflatedFrontmatter = async (
   reader: ArchiveReader,
   offset: number,
   compressedSize: number,
-  uncompressedSize: number
+  inflateBudget: InflateBudget
 ): Promise<Buffer | undefined> => {
-  if (uncompressedSize > MAX_SNIFF_FRONTMATTER_BYTES) return undefined
-
   const scanner = createFrontmatterScanner()
   const chunks: Buffer[] = []
   let frontmatterEnd: number | undefined
   let total = 0
-  const source = Readable.from(compressedEntryChunks(reader, offset, compressedSize))
-  const output = source.pipe(createInflateRaw())
-  // pipe() does not forward source errors. A file truncated between stat/scan/read must reject this
-  // candidate through the consumed transform instead of becoming an unhandled main-process error.
-  source.on('error', (error: Error) => output.destroy(error))
 
   try {
-    for await (const value of output) {
-      const chunk = Buffer.isBuffer(value) ? value : Buffer.from(value as Uint8Array)
+    for await (const chunk of inflatedEntryChunks(reader, offset, compressedSize, inflateBudget)) {
+      if (!consumeInflateBudget(inflateBudget, chunk.length)) return undefined
       total += chunk.length
       if (total > MAX_SNIFF_FRONTMATTER_BYTES) return undefined
       if (frontmatterEnd !== undefined) continue
@@ -459,9 +492,6 @@ const readDeflatedFrontmatter = async (
     }
   } catch {
     return undefined
-  } finally {
-    output.destroy()
-    source.destroy()
   }
 
   if (frontmatterEnd === undefined) {
@@ -474,18 +504,22 @@ const readDeflatedFrontmatter = async (
 
 const readManifestFrontmatter = async (
   reader: ArchiveReader,
-  entry: CentralEntry
+  entry: CentralEntry,
+  range: { offset: number; compressedSize: number },
+  inflateBudget: InflateBudget
 ): Promise<Buffer | undefined> => {
-  const offset = await entryDataOffset(reader, entry)
-  if (offset === undefined) return undefined
-
   return entry.method === 0
-    ? readStoredFrontmatter(reader, offset, entry.compressedSize)
-    : readDeflatedFrontmatter(reader, offset, entry.compressedSize, entry.uncompressedSize)
+    ? readStoredFrontmatter(reader, range.offset, range.compressedSize, inflateBudget)
+    : readDeflatedFrontmatter(reader, range.offset, range.compressedSize, inflateBudget)
 }
 
-const manifestHasName = async (reader: ArchiveReader, entry: CentralEntry): Promise<boolean> => {
-  const frontmatter = await readManifestFrontmatter(reader, entry)
+const manifestHasName = async (
+  reader: ArchiveReader,
+  entry: CentralEntry,
+  range: { offset: number; compressedSize: number },
+  inflateBudget: InflateBudget
+): Promise<boolean> => {
+  const frontmatter = await readManifestFrontmatter(reader, entry, range, inflateBudget)
   if (!frontmatter) return false
 
   try {
@@ -493,6 +527,120 @@ const manifestHasName = async (reader: ArchiveReader, entry: CentralEntry): Prom
   } catch {
     return false
   }
+}
+
+const validatedEntrySizeAtOffset = async (
+  reader: ArchiveReader,
+  entry: CentralEntry,
+  offset: number,
+  compressedSize: number,
+  maxFileBytes: number,
+  inflateBudget: InflateBudget
+): Promise<number | undefined> => {
+  if (entry.method === 0) {
+    if (compressedSize > maxFileBytes) return undefined
+
+    let total = 0
+    try {
+      for await (const chunk of compressedEntryChunks(
+        reader,
+        offset,
+        compressedSize,
+        inflateBudget
+      )) {
+        total += chunk.length
+      }
+      return total
+    } catch {
+      return undefined
+    }
+  }
+
+  let total = 0
+  try {
+    for await (const chunk of inflatedEntryChunks(reader, offset, compressedSize, inflateBudget)) {
+      if (!consumeInflateBudget(inflateBudget, chunk.length)) return undefined
+      total += chunk.length
+      if (total > maxFileBytes) return undefined
+    }
+    return total
+  } catch {
+    return undefined
+  }
+}
+
+const validateArchiveEntries = async (
+  reader: ArchiveReader,
+  scan: ArchiveScan,
+  limits: ScanLimits,
+  inflateBudget: InflateBudget
+): Promise<ArchiveScan | undefined> => {
+  const accepted: CentralEntry[] = []
+  const skippedPaths = [...scan.skippedPaths]
+  const actualSizes = new Map<CentralEntry, number>()
+  const dataRanges = new Map<CentralEntry, { offset: number; compressedSize: number }>()
+  let total = 0
+
+  for (const entry of scan.accepted) {
+    if (accepted.length >= limits.maxFiles) {
+      if (limits.strictCaps) return undefined
+      skippedPaths.push(entry.name)
+      continue
+    }
+
+    const location = await locateEntryData(reader, entry)
+    if (location.kind === 'wrong-signature') {
+      // Strict extractZip silently skips an in-bounds local header with the wrong signature; the
+      // lenient outer extractor records it so any owning loose root is rejected as incomplete.
+      if (!limits.strictCaps) skippedPaths.push(entry.name)
+      continue
+    }
+    if (location.kind === 'unreadable' || (!location.complete && !limits.strictCaps)) {
+      if (limits.strictCaps) return undefined
+      skippedPaths.push(entry.name)
+      continue
+    }
+
+    const size = await validatedEntrySizeAtOffset(
+      reader,
+      entry,
+      location.offset,
+      location.availableSize,
+      limits.maxFileBytes,
+      inflateBudget
+    )
+    // Unlike importer preview, sniffing happens automatically. Bound total inflate work across both
+    // accepted and rejected entries so many individually-skipped bombs cannot multiply the CPU budget.
+    if (inflateBudget.exhausted) return undefined
+    if (size === undefined || total + size > limits.maxTotalBytes) {
+      if (limits.strictCaps) return undefined
+      skippedPaths.push(entry.name)
+      continue
+    }
+
+    total += size
+    accepted.push(entry)
+    actualSizes.set(entry, size)
+    dataRanges.set(entry, {
+      offset: location.offset,
+      compressedSize: location.availableSize
+    })
+  }
+
+  return { accepted, skippedPaths, actualSizes, dataRanges }
+}
+
+const looseRootIsWithinCaps = (entries: CentralEntry[], scan: ArchiveScan): boolean => {
+  if (entries.length > SKILL_IMPORT_LIMITS.maxFiles) return false
+
+  let total = 0
+  for (const entry of entries) {
+    const size = scan.actualSizes.get(entry)
+    if (size === undefined || size > SKILL_IMPORT_LIMITS.maxFileBytes) return false
+    total += size
+    if (total > SKILL_IMPORT_LIMITS.maxTotalBytes) return false
+  }
+  return true
 }
 
 const owningRoot = (
@@ -515,7 +663,8 @@ const inspectManifestRoots = async (
   reader: ArchiveReader,
   scan: ArchiveScan,
   requireCompleteLooseRoot: boolean,
-  maxCandidates: number
+  maxCandidates: number,
+  inflateBudget: InflateBudget
 ): Promise<ManifestRootInspection> => {
   const manifestEntries = scan.accepted.filter(
     (entry) => !isNestedArchive(entry.name) && skillManifestRootPath(entry.name) !== undefined
@@ -529,7 +678,7 @@ const inspectManifestRoots = async (
   }
 
   const rejectedRoots = new Set<string>()
-  const rootCounts = new Map<string, { files: number; bytes: number }>()
+  const entriesByRoot = new Map<string, CentralEntry[]>()
   if (requireCompleteLooseRoot) {
     for (const path of scan.skippedPaths) {
       const root = owningRoot(path, rootSet, true)
@@ -538,18 +687,10 @@ const inspectManifestRoots = async (
     for (const entry of scan.accepted) {
       const root = owningRoot(entry.name, rootSet, false)
       if (root === undefined) continue
-      const stats = rootCounts.get(root) ?? { files: 0, bytes: 0 }
-      const size = extractedEntrySize(entry)
-      stats.files += 1
-      stats.bytes += size
-      rootCounts.set(root, stats)
-      if (
-        stats.files > SKILL_IMPORT_LIMITS.maxFiles ||
-        size > SKILL_IMPORT_LIMITS.maxFileBytes ||
-        stats.bytes > SKILL_IMPORT_LIMITS.maxTotalBytes
-      ) {
-        rejectedRoots.add(root)
-      }
+      const rootEntries = entriesByRoot.get(root) ?? []
+      rootEntries.push(entry)
+      entriesByRoot.set(root, rootEntries)
+      if (rootEntries.length > SKILL_IMPORT_LIMITS.maxFiles) rejectedRoots.add(root)
     }
   }
 
@@ -557,13 +698,21 @@ const inspectManifestRoots = async (
   const named: boolean[] = []
 
   for (const root of ownerRoots) {
+    if (inflateBudget.exhausted) break
     if (rejectedRoots.has(root) || candidateRoots.length >= maxCandidates) continue
+    if (requireCompleteLooseRoot && !looseRootIsWithinCaps(entriesByRoot.get(root) ?? [], scan)) {
+      continue
+    }
     candidateRoots.push(root)
 
     // Full preview uses the first case-insensitive SKILL.md at the selected root, so duplicate-cased
     // entries cannot let the sniffer pick a different manifest than the importer.
     const manifest = manifestByRoot.get(root)
-    named.push(manifest ? await manifestHasName(reader, manifest) : false)
+    const range = manifest ? scan.dataRanges.get(manifest) : undefined
+    named.push(
+      manifest && range ? await manifestHasName(reader, manifest, range, inflateBudget) : false
+    )
+    if (inflateBudget.exhausted) break
   }
 
   return { ownerRoots, candidateRoots, named }
@@ -571,39 +720,60 @@ const inspectManifestRoots = async (
 
 const nestedArchiveReader = async (
   parent: ArchiveReader,
-  entry: CentralEntry
+  entry: CentralEntry,
+  range: { offset: number; compressedSize: number },
+  inflateBudget: InflateBudget
 ): Promise<ArchiveReader | undefined> => {
-  const offset = await entryDataOffset(parent, entry)
-  if (offset === undefined) return undefined
-
   if (entry.method === 0) {
-    if (entry.compressedSize > SKILL_IMPORT_LIMITS.maxSkillArchiveBytes) return undefined
-    return subrangeReader(parent, offset, entry.compressedSize)
+    if (range.compressedSize > SKILL_IMPORT_LIMITS.maxSkillArchiveBytes) return undefined
+    return subrangeReader(parent, range.offset, range.compressedSize)
   }
 
-  const bytes = await readEntry(parent, entry, SKILL_IMPORT_LIMITS.maxSkillArchiveBytes)
+  const bytes = await readInflatedEntry(
+    parent,
+    range.offset,
+    range.compressedSize,
+    SKILL_IMPORT_LIMITS.maxSkillArchiveBytes,
+    inflateBudget
+  )
   return bytes ? bufferReader(bytes) : undefined
 }
 
 const inspectNestedArchive = async (
   parent: ArchiveReader,
   entry: CentralEntry,
-  maxCandidates: number
+  range: { offset: number; compressedSize: number },
+  maxCandidates: number,
+  inflateBudget: InflateBudget
 ): Promise<boolean[]> => {
-  const nested = await nestedArchiveReader(parent, entry)
+  const nested = await nestedArchiveReader(parent, entry, range, inflateBudget)
   if (!nested) return []
 
   const scan = await scanArchive(nested, INNER_SCAN_LIMITS)
   if (!scan) return []
-  return (await inspectManifestRoots(nested, scan, false, maxCandidates)).named
+  const validated = await validateArchiveEntries(nested, scan, INNER_SCAN_LIMITS, inflateBudget)
+  if (!validated) return []
+  return (await inspectManifestRoots(nested, validated, false, maxCandidates, inflateBudget)).named
 }
 
-const inspectOuterArchive = async (reader: ArchiveReader): Promise<boolean> => {
-  const scan = await scanArchive(reader, OUTER_SCAN_LIMITS)
+const inspectOuterArchive = async (
+  reader: ArchiveReader,
+  maxAttemptedInflateBytes: number = OUTER_SCAN_LIMITS.maxTotalBytes
+): Promise<boolean> => {
+  const inflateBudget: InflateBudget = {
+    maxBytes: maxAttemptedInflateBytes,
+    readBytes: 0,
+    inflatedBytes: 0,
+    exhausted: false
+  }
+  const parsed = await scanArchive(reader, OUTER_SCAN_LIMITS)
+  if (!parsed) return false
+  const scan = await validateArchiveEntries(reader, parsed, OUTER_SCAN_LIMITS, inflateBudget)
   if (!scan) return false
 
   const candidateLimit = SKILL_IMPORT_LIMITS.maxSkillsPerBundle
-  const loose = await inspectManifestRoots(reader, scan, true, candidateLimit)
+  const loose = await inspectManifestRoots(reader, scan, true, candidateLimit, inflateBudget)
+  if (inflateBudget.exhausted) return false
   if (loose.named.some(Boolean)) return true
 
   let remainingCandidates = Math.max(0, candidateLimit - loose.candidateRoots.length)
@@ -616,7 +786,16 @@ const inspectOuterArchive = async (reader: ArchiveReader): Promise<boolean> => {
   )
 
   for (const archive of standaloneArchives) {
-    const nestedCandidates = await inspectNestedArchive(reader, archive, remainingCandidates)
+    const range = scan.dataRanges.get(archive)
+    if (!range) continue
+    const nestedCandidates = await inspectNestedArchive(
+      reader,
+      archive,
+      range,
+      remainingCandidates,
+      inflateBudget
+    )
+    if (inflateBudget.exhausted) return false
     if (nestedCandidates.some(Boolean)) return true
     remainingCandidates -= nestedCandidates.length
     if (remainingCandidates <= 0) break
@@ -625,10 +804,10 @@ const inspectOuterArchive = async (reader: ArchiveReader): Promise<boolean> => {
   return false
 }
 
-// Classifies a ZIP without loading the whole upload or inflating unrelated assets. Central records
-// are streamed; only selected manifests are inflated, plus one importer-supported level of nested
-// archive (asynchronously and under the same 64 MB cap as full discovery). Any ambiguity fails closed
-// to the ordinary resource path; the real importer still performs full preview/validation on approval.
+// Classifies a ZIP without loading the whole upload. Central records and entry validation are streamed;
+// validated bodies are discarded, while only selected frontmatter and one importer-supported nested
+// archive are retained under the same caps as full discovery. Any ambiguity fails closed to the ordinary
+// resource path; the real importer still performs full preview/validation on approval.
 const isImportableSkillArchivePath = async (filePath: string): Promise<boolean> => {
   let handle: FileHandle | undefined
   try {

--- a/src/main/skills/skill-archive-sniffer.ts
+++ b/src/main/skills/skill-archive-sniffer.ts
@@ -1,5 +1,6 @@
 import { open, type FileHandle } from 'node:fs/promises'
-import { inflateRaw } from 'node:zlib'
+import { Readable } from 'node:stream'
+import { createInflateRaw, inflateRaw } from 'node:zlib'
 
 import { parseSkillDocument } from './frontmatter'
 import { SKILL_IMPORT_LIMITS } from './import-limits'
@@ -10,6 +11,10 @@ const CENTRAL_SIGNATURE = 0x02014b50
 const LOCAL_SIGNATURE = 0x04034b50
 const EOCD_MIN_SIZE = 22
 const MAX_ZIP_COMMENT_BYTES = 0xffff
+const CENTRAL_READ_CHUNK_BYTES = 64 * 1024
+const ENTRY_READ_CHUNK_BYTES = 64 * 1024
+const MAX_SNIFF_FRONTMATTER_BYTES = SKILL_IMPORT_LIMITS.maxFileBytes
+const FRONTMATTER_DELIMITER = Buffer.from('---')
 
 type ArchiveReader = {
   size: number
@@ -27,6 +32,12 @@ type CentralEntry = {
 type ArchiveScan = {
   accepted: CentralEntry[]
   skippedPaths: string[]
+}
+
+type ManifestRootInspection = {
+  ownerRoots: string[]
+  candidateRoots: string[]
+  named: boolean[]
 }
 
 type ScanLimits = {
@@ -135,6 +146,57 @@ const extractedEntrySize = (
   entry: Pick<CentralEntry, 'method' | 'compressedSize' | 'uncompressedSize'>
 ): number => (entry.method === 0 ? entry.compressedSize : entry.uncompressedSize)
 
+// Sequential, fixed-size buffering keeps a ZIP with thousands of directory/metadata records from
+// turning into two random-access reads per record. It also avoids allocating the full central
+// directory, whose raw record count is not capped by the importer (only accepted files are capped).
+const centralCursor = (
+  reader: ArchiveReader,
+  start: number,
+  end: number
+): {
+  read: (length: number) => Promise<Buffer | undefined>
+  skip: (length: number) => boolean
+} => {
+  let position = start
+  let chunk: Buffer = Buffer.alloc(0)
+  let chunkStart = start
+
+  const ensureChunk = async (): Promise<boolean> => {
+    if (position >= chunkStart && position < chunkStart + chunk.length) return true
+    if (position >= end) return false
+
+    chunkStart = position
+    const next = await reader.read(position, Math.min(CENTRAL_READ_CHUNK_BYTES, end - position))
+    if (!next) return false
+    chunk = next
+    return true
+  }
+
+  return {
+    read: async (length) => {
+      if (!Number.isSafeInteger(length) || length < 0 || position + length > end) return undefined
+      if (length === 0) return Buffer.alloc(0)
+
+      const output = Buffer.allocUnsafe(length)
+      let written = 0
+      while (written < length) {
+        if (!(await ensureChunk())) return undefined
+        const chunkOffset = position - chunkStart
+        const copied = Math.min(length - written, chunk.length - chunkOffset)
+        chunk.copy(output, written, chunkOffset, chunkOffset + copied)
+        written += copied
+        position += copied
+      }
+      return output
+    },
+    skip: (length) => {
+      if (!Number.isSafeInteger(length) || length < 0 || position + length > end) return false
+      position += length
+      return true
+    }
+  }
+}
+
 // Streams central-directory records instead of reading the whole ZIP or inflating unrelated files.
 // Size/count decisions mirror extractZipLenient (outer) and extractZip (one nested archive) using the
 // central metadata; candidate entry bytes are checked against their local header when actually read.
@@ -173,10 +235,10 @@ const scanArchive = async (
   const accepted: CentralEntry[] = []
   const skippedPaths: string[] = []
   let totalBytes = 0
-  let pointer = centralOffset
+  const cursor = centralCursor(reader, centralOffset, centralEnd)
 
   for (let index = 0; index < entryCount; index += 1) {
-    const header = await reader.read(pointer, 46)
+    const header = await cursor.read(46)
     if (!header || header.readUInt32LE(0) !== CENTRAL_SIGNATURE) return undefined
 
     const method = header.readUInt16LE(10)
@@ -187,13 +249,12 @@ const scanArchive = async (
     const commentLength = header.readUInt16LE(32)
     const startDisk = header.readUInt16LE(34)
     const localOffset = header.readUInt32LE(42)
-    const next = pointer + 46 + nameLength + extraLength + commentLength
-    if (startDisk !== 0 || next > centralEnd) return undefined
+    if (startDisk !== 0) return undefined
 
-    const nameBytes = await reader.read(pointer + 46, nameLength)
+    const nameBytes = await cursor.read(nameLength)
     if (!nameBytes) return undefined
     const name = nameBytes.toString('utf8')
-    pointer = next
+    if (!cursor.skip(extraLength + commentLength)) return undefined
 
     // Match zip-extract's silent skips for directories, metadata, unsafe paths, and unsupported
     // methods. The outer lenient walk records real unsafe/method failures so a containing loose root
@@ -271,59 +332,241 @@ const readEntry = async (
   }
 }
 
-const manifestHasName = async (reader: ArchiveReader, entry: CentralEntry): Promise<boolean> => {
-  const manifest = await readEntry(reader, entry, SKILL_IMPORT_LIMITS.maxFileBytes)
-  if (!manifest) return false
+type FrontmatterScanResult = 'continue' | 'invalid' | { end: number }
+
+const createFrontmatterScanner = (): {
+  push: (chunk: Buffer) => FrontmatterScanResult
+  finish: () => FrontmatterScanResult
+} => {
+  let offset = 0
+  let lineIndex = 0
+  let lineLength = 0
+  let matchesDelimiter = true
+  let skipLineFeed = false
+
+  const finishLine = (end: number): FrontmatterScanResult => {
+    const isDelimiter = matchesDelimiter && lineLength === FRONTMATTER_DELIMITER.length
+    if (lineIndex === 0 && !isDelimiter) return 'invalid'
+    if (lineIndex > 0 && isDelimiter) return { end }
+
+    lineIndex += 1
+    lineLength = 0
+    matchesDelimiter = true
+    return 'continue'
+  }
+
+  return {
+    push: (chunk) => {
+      for (const byte of chunk) {
+        offset += 1
+        if (skipLineFeed) {
+          skipLineFeed = false
+          if (byte === 0x0a) continue
+        }
+        if (byte === 0x0d || byte === 0x0a) {
+          const result = finishLine(offset)
+          if (result !== 'continue') return result
+          skipLineFeed = byte === 0x0d
+          continue
+        }
+
+        if (
+          lineLength >= FRONTMATTER_DELIMITER.length ||
+          byte !== FRONTMATTER_DELIMITER[lineLength]
+        ) {
+          matchesDelimiter = false
+        }
+        lineLength += 1
+      }
+      return 'continue'
+    },
+    finish: () => finishLine(offset)
+  }
+}
+
+const compressedEntryChunks = async function* (
+  reader: ArchiveReader,
+  offset: number,
+  size: number
+): AsyncGenerator<Buffer> {
+  let consumed = 0
+  while (consumed < size) {
+    const length = Math.min(ENTRY_READ_CHUNK_BYTES, size - consumed)
+    const chunk = await reader.read(offset + consumed, length)
+    if (!chunk) throw new Error('Unreadable ZIP entry.')
+    yield chunk
+    consumed += length
+  }
+}
+
+const readStoredFrontmatter = async (
+  reader: ArchiveReader,
+  offset: number,
+  size: number
+): Promise<Buffer | undefined> => {
+  if (size > MAX_SNIFF_FRONTMATTER_BYTES) return undefined
+
+  const scanner = createFrontmatterScanner()
+  const chunks: Buffer[] = []
+  let total = 0
+  try {
+    for await (const chunk of compressedEntryChunks(reader, offset, size)) {
+      chunks.push(chunk)
+      total += chunk.length
+      const result = scanner.push(chunk)
+      if (result === 'invalid') return undefined
+      if (result !== 'continue') return Buffer.concat(chunks, total).subarray(0, result.end)
+    }
+  } catch {
+    return undefined
+  }
+
+  const result = scanner.finish()
+  return result !== 'continue' && result !== 'invalid'
+    ? Buffer.concat(chunks, total).subarray(0, result.end)
+    : undefined
+}
+
+const readDeflatedFrontmatter = async (
+  reader: ArchiveReader,
+  offset: number,
+  compressedSize: number,
+  uncompressedSize: number
+): Promise<Buffer | undefined> => {
+  if (uncompressedSize > MAX_SNIFF_FRONTMATTER_BYTES) return undefined
+
+  const scanner = createFrontmatterScanner()
+  const chunks: Buffer[] = []
+  let frontmatterEnd: number | undefined
+  let total = 0
+  const source = Readable.from(compressedEntryChunks(reader, offset, compressedSize))
+  const output = source.pipe(createInflateRaw())
+  // pipe() does not forward source errors. A file truncated between stat/scan/read must reject this
+  // candidate through the consumed transform instead of becoming an unhandled main-process error.
+  source.on('error', (error: Error) => output.destroy(error))
 
   try {
-    return Boolean(parseSkillDocument(manifest.toString('utf8')).name?.trim())
+    for await (const value of output) {
+      const chunk = Buffer.isBuffer(value) ? value : Buffer.from(value as Uint8Array)
+      total += chunk.length
+      if (total > MAX_SNIFF_FRONTMATTER_BYTES) return undefined
+      if (frontmatterEnd !== undefined) continue
+
+      chunks.push(chunk)
+      const result = scanner.push(chunk)
+      if (result === 'invalid') return undefined
+      if (result !== 'continue') frontmatterEnd = result.end
+    }
+  } catch {
+    return undefined
+  } finally {
+    output.destroy()
+    source.destroy()
+  }
+
+  if (frontmatterEnd === undefined) {
+    const result = scanner.finish()
+    if (result === 'continue' || result === 'invalid') return undefined
+    frontmatterEnd = result.end
+  }
+  return Buffer.concat(chunks).subarray(0, frontmatterEnd)
+}
+
+const readManifestFrontmatter = async (
+  reader: ArchiveReader,
+  entry: CentralEntry
+): Promise<Buffer | undefined> => {
+  const offset = await entryDataOffset(reader, entry)
+  if (offset === undefined) return undefined
+
+  return entry.method === 0
+    ? readStoredFrontmatter(reader, offset, entry.compressedSize)
+    : readDeflatedFrontmatter(reader, offset, entry.compressedSize, entry.uncompressedSize)
+}
+
+const manifestHasName = async (reader: ArchiveReader, entry: CentralEntry): Promise<boolean> => {
+  const frontmatter = await readManifestFrontmatter(reader, entry)
+  if (!frontmatter) return false
+
+  try {
+    return Boolean(parseSkillDocument(frontmatter.toString('utf8')).name?.trim())
   } catch {
     return false
   }
 }
 
-const skippedPathBelongsToRoot = (root: string, path: string): boolean =>
-  root === '' || path === root || path.startsWith(`${root}/`)
+const owningRoot = (
+  path: string,
+  roots: ReadonlySet<string>,
+  includeExactRoot: boolean
+): string | undefined => {
+  if (roots.has('')) return ''
 
-const acceptedPathBelongsToRoot = (root: string, path: string): boolean =>
-  root === '' || path.startsWith(`${root}/`)
-
-const looseRootIsComplete = (root: string, scan: ArchiveScan): boolean => {
-  if (scan.skippedPaths.some((path) => skippedPathBelongsToRoot(root, path))) return false
-
-  const files = scan.accepted.filter((entry) => acceptedPathBelongsToRoot(root, entry.name))
-  return (
-    files.length <= SKILL_IMPORT_LIMITS.maxFiles &&
-    files.every((entry) => extractedEntrySize(entry) <= SKILL_IMPORT_LIMITS.maxFileBytes) &&
-    files.reduce((total, entry) => total + extractedEntrySize(entry), 0) <=
-      SKILL_IMPORT_LIMITS.maxTotalBytes
-  )
+  const segments = path.split('/')
+  const maxSegments = Math.min(2, segments.length - (includeExactRoot ? 0 : 1))
+  for (let length = 1; length <= maxSegments; length += 1) {
+    const candidate = segments.slice(0, length).join('/')
+    if (roots.has(candidate)) return candidate
+  }
+  return undefined
 }
 
 const inspectManifestRoots = async (
   reader: ArchiveReader,
   scan: ArchiveScan,
-  requireCompleteLooseRoot: boolean
-): Promise<{ roots: string[]; named: boolean[] }> => {
+  requireCompleteLooseRoot: boolean,
+  maxCandidates: number
+): Promise<ManifestRootInspection> => {
   const manifestEntries = scan.accepted.filter(
     (entry) => !isNestedArchive(entry.name) && skillManifestRootPath(entry.name) !== undefined
   )
-  const roots = selectSkillManifestRoots(manifestEntries.map((entry) => entry.name))
+  const ownerRoots = selectSkillManifestRoots(manifestEntries.map((entry) => entry.name))
+  const rootSet = new Set(ownerRoots)
+  const manifestByRoot = new Map<string, CentralEntry>()
+  for (const entry of manifestEntries) {
+    const root = skillManifestRootPath(entry.name)
+    if (root !== undefined && !manifestByRoot.has(root)) manifestByRoot.set(root, entry)
+  }
+
+  const rejectedRoots = new Set<string>()
+  const rootCounts = new Map<string, { files: number; bytes: number }>()
+  if (requireCompleteLooseRoot) {
+    for (const path of scan.skippedPaths) {
+      const root = owningRoot(path, rootSet, true)
+      if (root !== undefined) rejectedRoots.add(root)
+    }
+    for (const entry of scan.accepted) {
+      const root = owningRoot(entry.name, rootSet, false)
+      if (root === undefined) continue
+      const stats = rootCounts.get(root) ?? { files: 0, bytes: 0 }
+      const size = extractedEntrySize(entry)
+      stats.files += 1
+      stats.bytes += size
+      rootCounts.set(root, stats)
+      if (
+        stats.files > SKILL_IMPORT_LIMITS.maxFiles ||
+        size > SKILL_IMPORT_LIMITS.maxFileBytes ||
+        stats.bytes > SKILL_IMPORT_LIMITS.maxTotalBytes
+      ) {
+        rejectedRoots.add(root)
+      }
+    }
+  }
+
+  const candidateRoots: string[] = []
   const named: boolean[] = []
 
-  for (const root of roots) {
-    if (requireCompleteLooseRoot && !looseRootIsComplete(root, scan)) {
-      named.push(false)
-      continue
-    }
+  for (const root of ownerRoots) {
+    if (rejectedRoots.has(root) || candidateRoots.length >= maxCandidates) continue
+    candidateRoots.push(root)
 
     // Full preview uses the first case-insensitive SKILL.md at the selected root, so duplicate-cased
     // entries cannot let the sniffer pick a different manifest than the importer.
-    const manifest = manifestEntries.find((entry) => skillManifestRootPath(entry.name) === root)
+    const manifest = manifestByRoot.get(root)
     named.push(manifest ? await manifestHasName(reader, manifest) : false)
   }
 
-  return { roots, named }
+  return { ownerRoots, candidateRoots, named }
 }
 
 const nestedArchiveReader = async (
@@ -344,40 +587,38 @@ const nestedArchiveReader = async (
 
 const inspectNestedArchive = async (
   parent: ArchiveReader,
-  entry: CentralEntry
+  entry: CentralEntry,
+  maxCandidates: number
 ): Promise<boolean[]> => {
   const nested = await nestedArchiveReader(parent, entry)
   if (!nested) return []
 
   const scan = await scanArchive(nested, INNER_SCAN_LIMITS)
   if (!scan) return []
-  return (await inspectManifestRoots(nested, scan, false)).named
+  return (await inspectManifestRoots(nested, scan, false, maxCandidates)).named
 }
 
 const inspectOuterArchive = async (reader: ArchiveReader): Promise<boolean> => {
   const scan = await scanArchive(reader, OUTER_SCAN_LIMITS)
   if (!scan) return false
 
-  const loose = await inspectManifestRoots(reader, scan, true)
   const candidateLimit = SKILL_IMPORT_LIMITS.maxSkillsPerBundle
-  const consideredLoose = loose.named.slice(0, candidateLimit)
-  if (consideredLoose.some(Boolean)) return true
+  const loose = await inspectManifestRoots(reader, scan, true, candidateLimit)
+  if (loose.named.some(Boolean)) return true
 
-  let remainingCandidates = Math.max(0, candidateLimit - loose.roots.length)
+  let remainingCandidates = Math.max(0, candidateLimit - loose.candidateRoots.length)
   if (remainingCandidates === 0) return false
 
-  const rootPrefixes = loose.roots.map((root) => (root === '' ? '' : `${root}/`))
+  const ownerRoots = new Set(loose.ownerRoots)
   const standaloneArchives = scan.accepted.filter(
     (entry) =>
-      isNestedArchive(entry.name) &&
-      !rootPrefixes.some((prefix) => prefix === '' || entry.name.startsWith(prefix))
+      isNestedArchive(entry.name) && owningRoot(entry.name, ownerRoots, false) === undefined
   )
 
   for (const archive of standaloneArchives) {
-    const nestedCandidates = await inspectNestedArchive(reader, archive)
-    const considered = nestedCandidates.slice(0, remainingCandidates)
-    if (considered.some(Boolean)) return true
-    remainingCandidates -= considered.length
+    const nestedCandidates = await inspectNestedArchive(reader, archive, remainingCandidates)
+    if (nestedCandidates.some(Boolean)) return true
+    remainingCandidates -= nestedCandidates.length
     if (remainingCandidates <= 0) break
   }
 
@@ -393,6 +634,7 @@ const isImportableSkillArchivePath = async (filePath: string): Promise<boolean> 
   try {
     handle = await open(filePath, 'r')
     const { size } = await handle.stat()
+    if (size > SKILL_IMPORT_LIMITS.maxBundleBytes) return false
     return await inspectOuterArchive(fileReader(handle, size))
   } catch {
     return false
@@ -401,4 +643,4 @@ const isImportableSkillArchivePath = async (filePath: string): Promise<boolean> 
   }
 }
 
-export { isImportableSkillArchivePath }
+export { inspectOuterArchive, isImportableSkillArchivePath }

--- a/src/main/skills/skill-archive-sniffer.ts
+++ b/src/main/skills/skill-archive-sniffer.ts
@@ -2,6 +2,7 @@ import { open, type FileHandle } from 'node:fs/promises'
 import { inflateRaw } from 'node:zlib'
 
 import { parseSkillDocument } from './frontmatter'
+import { isSkillManifestPath } from './skill-bundle-paths'
 
 const EOCD_SIGNATURE = 0x06054b50
 const CENTRAL_SIGNATURE = 0x02014b50
@@ -188,11 +189,7 @@ const isImportableSkillArchivePath = async (filePath: string): Promise<boolean> 
     for (const entry of entries) {
       if (!isSafeArchivePath(entry.name) || entry.name.endsWith('/')) continue
 
-      const normalizedName = entry.name.toLowerCase()
-      // A nested `.skill` file is itself an explicit package signal. The later importer still performs
-      // full bounded extraction and preview before the user can approve anything.
-      if (normalizedName.endsWith('.skill')) return true
-      if (normalizedName.split('/').pop() !== 'skill.md') continue
+      if (!isSkillManifestPath(entry.name)) continue
 
       candidateCount += 1
       totalCompressedBytes += entry.compressedSize

--- a/src/main/skills/skill-archive-sniffer.ts
+++ b/src/main/skills/skill-archive-sniffer.ts
@@ -10,7 +10,6 @@ const EOCD_SIGNATURE = 0x06054b50
 const CENTRAL_SIGNATURE = 0x02014b50
 const LOCAL_SIGNATURE = 0x04034b50
 const EOCD_MIN_SIZE = 22
-const MAX_ZIP_COMMENT_BYTES = 0xffff
 const CENTRAL_READ_CHUNK_BYTES = 64 * 1024
 const ENTRY_READ_CHUNK_BYTES = 64 * 1024
 const MAX_SNIFF_FRONTMATTER_BYTES = SKILL_IMPORT_LIMITS.maxFileBytes
@@ -128,14 +127,23 @@ const subrangeReader = (
   }
 }
 
-const findEocd = (tail: Buffer): number => {
-  for (let offset = tail.length - EOCD_MIN_SIZE; offset >= 0; offset -= 1) {
-    if (tail.readUInt32LE(offset) !== EOCD_SIGNATURE) continue
+// Match zip-extract's last-signature semantics without loading the whole bounded upload. Windows
+// overlap by the remainder of the fixed EOCD record so a signature split across reads is still found.
+const findEocd = async (reader: ArchiveReader): Promise<number | undefined> => {
+  let end = reader.size
+  while (end >= EOCD_MIN_SIZE) {
+    const start = Math.max(0, end - CENTRAL_READ_CHUNK_BYTES)
+    const chunk = await reader.read(start, end - start)
+    if (!chunk) return undefined
 
-    const commentLength = tail.readUInt16LE(offset + 20)
-    if (offset + EOCD_MIN_SIZE + commentLength === tail.length) return offset
+    for (let offset = chunk.length - EOCD_MIN_SIZE; offset >= 0; offset -= 1) {
+      if (chunk.readUInt32LE(offset) === EOCD_SIGNATURE) return start + offset
+    }
+
+    if (start === 0) break
+    end = start + EOCD_MIN_SIZE - 1
   }
-  return -1
+  return undefined
 }
 
 const isMetadataPath = (path: string): boolean =>
@@ -208,19 +216,17 @@ const scanArchive = async (
   reader: ArchiveReader,
   limits: ScanLimits
 ): Promise<ArchiveScan | undefined> => {
-  const tailSize = Math.min(reader.size, EOCD_MIN_SIZE + MAX_ZIP_COMMENT_BYTES)
-  const tail = await reader.read(reader.size - tailSize, tailSize)
-  if (!tail) return undefined
+  const eocd = await findEocd(reader)
+  if (eocd === undefined) return undefined
+  const eocdRecord = await reader.read(eocd, EOCD_MIN_SIZE)
+  if (!eocdRecord) return undefined
 
-  const eocd = findEocd(tail)
-  if (eocd < 0) return undefined
-
-  const diskNumber = tail.readUInt16LE(eocd + 4)
-  const centralDisk = tail.readUInt16LE(eocd + 6)
-  const entriesOnDisk = tail.readUInt16LE(eocd + 8)
-  const entryCount = tail.readUInt16LE(eocd + 10)
-  const centralSize = tail.readUInt32LE(eocd + 12)
-  const centralOffset = tail.readUInt32LE(eocd + 16)
+  const diskNumber = eocdRecord.readUInt16LE(4)
+  const centralDisk = eocdRecord.readUInt16LE(6)
+  const entriesOnDisk = eocdRecord.readUInt16LE(8)
+  const entryCount = eocdRecord.readUInt16LE(10)
+  const centralSize = eocdRecord.readUInt32LE(12)
+  const centralOffset = eocdRecord.readUInt32LE(16)
   const centralEnd = centralOffset + centralSize
 
   // Multi-disk and ZIP64 archives are unsupported by the real importer too.
@@ -475,7 +481,6 @@ const readDeflatedFrontmatter = async (
 ): Promise<Buffer | undefined> => {
   const scanner = createFrontmatterScanner()
   const chunks: Buffer[] = []
-  let frontmatterEnd: number | undefined
   let total = 0
 
   try {
@@ -483,23 +488,23 @@ const readDeflatedFrontmatter = async (
       if (!consumeInflateBudget(inflateBudget, chunk.length)) return undefined
       total += chunk.length
       if (total > MAX_SNIFF_FRONTMATTER_BYTES) return undefined
-      if (frontmatterEnd !== undefined) continue
 
       chunks.push(chunk)
       const result = scanner.push(chunk)
       if (result === 'invalid') return undefined
-      if (result !== 'continue') frontmatterEnd = result.end
+      // Entry validation already consumed the complete body. Stop this second, classification-only
+      // inflate as soon as the frontmatter closes so a large valid body is not charged twice against
+      // the shared automatic-sniff work budget.
+      if (result !== 'continue') return Buffer.concat(chunks, total).subarray(0, result.end)
     }
   } catch {
     return undefined
   }
 
-  if (frontmatterEnd === undefined) {
-    const result = scanner.finish()
-    if (result === 'continue' || result === 'invalid') return undefined
-    frontmatterEnd = result.end
-  }
-  return Buffer.concat(chunks).subarray(0, frontmatterEnd)
+  const result = scanner.finish()
+  return result !== 'continue' && result !== 'invalid'
+    ? Buffer.concat(chunks, total).subarray(0, result.end)
+    : undefined
 }
 
 const readManifestFrontmatter = async (

--- a/src/main/skills/skill-archive-sniffer.ts
+++ b/src/main/skills/skill-archive-sniffer.ts
@@ -167,6 +167,7 @@ const centralCursor = (
   end: number
 ): {
   read: (length: number) => Promise<Buffer | undefined>
+  remaining: () => number
   skip: (length: number) => boolean
 } => {
   let position = start
@@ -201,6 +202,7 @@ const centralCursor = (
       }
       return output
     },
+    remaining: () => Math.max(0, end - position),
     skip: (length) => {
       if (!Number.isSafeInteger(length) || length < 0 || position + length > end) return false
       position += length
@@ -244,11 +246,17 @@ const scanArchive = async (
 
   const accepted: CentralEntry[] = []
   const skippedPaths: string[] = []
-  const cursor = centralCursor(reader, centralOffset, centralEnd)
+  // The real extractors walk from centralOffset against the complete buffer and do not use the EOCD
+  // central-size field as their cursor boundary. Keep the same boundary here for classification parity.
+  const cursor = centralCursor(reader, centralOffset, reader.size)
 
   for (let index = 0; index < entryCount; index += 1) {
+    if (cursor.remaining() < 46) break
     const header = await cursor.read(46)
-    if (!header || header.readUInt32LE(0) !== CENTRAL_SIGNATURE) return undefined
+    // Match extractZip/extractZipLenient: a malformed trailing central record ends the walk but does
+    // not discard entries that were already decoded successfully.
+    if (!header) return undefined
+    if (header.readUInt32LE(0) !== CENTRAL_SIGNATURE) break
 
     const method = header.readUInt16LE(10)
     const compressedSize = header.readUInt32LE(20)
@@ -259,17 +267,26 @@ const scanArchive = async (
     const localOffset = header.readUInt32LE(42)
     if (startDisk !== 0) return undefined
 
-    const nameBytes = await cursor.read(nameLength)
+    // Buffer#toString clamps an overlong name range, so the importer still handles the current entry
+    // before its now-out-of-range pointer stops the next iteration. Reproduce that behavior without
+    // reading outside the bounded file.
+    const readableNameLength = Math.min(nameLength, cursor.remaining())
+    const nameBytes = await cursor.read(readableNameLength)
     if (!nameBytes) return undefined
     const name = nameBytes.toString('utf8')
-    if (!cursor.skip(extraLength + commentLength)) return undefined
+    const canContinue =
+      readableNameLength === nameLength && cursor.skip(extraLength + commentLength)
 
     // Match zip-extract's silent skips for directories, metadata, unsafe paths, and unsupported
     // methods. The outer lenient walk records real unsafe/method failures so a containing loose root
     // is rejected rather than classified from an incomplete bundle.
-    if (name.endsWith('/') || isMetadataPath(name)) continue
+    if (name.endsWith('/') || isMetadataPath(name)) {
+      if (!canContinue) break
+      continue
+    }
     if (isUnsafeArchivePath(name) || (method !== 0 && method !== 8)) {
       if (!limits.strictCaps) skippedPaths.push(name)
+      if (!canContinue) break
       continue
     }
 
@@ -277,10 +294,12 @@ const scanArchive = async (
     if (depth > limits.maxDepth) {
       if (limits.strictCaps) return undefined
       skippedPaths.push(name)
+      if (!canContinue) break
       continue
     }
 
     accepted.push({ name, method, compressedSize, localOffset })
+    if (!canContinue) break
   }
 
   return { accepted, skippedPaths, actualSizes: new Map(), dataRanges: new Map() }

--- a/src/main/skills/skill-archive-sniffer.ts
+++ b/src/main/skills/skill-archive-sniffer.ts
@@ -2,7 +2,8 @@ import { open, type FileHandle } from 'node:fs/promises'
 import { inflateRaw } from 'node:zlib'
 
 import { parseSkillDocument } from './frontmatter'
-import { isSkillManifestPath } from './skill-bundle-paths'
+import { SKILL_IMPORT_LIMITS } from './import-limits'
+import { selectSkillManifestRoots, skillManifestRootPath } from './skill-bundle-paths'
 
 const EOCD_SIGNATURE = 0x06054b50
 const CENTRAL_SIGNATURE = 0x02014b50
@@ -10,18 +11,10 @@ const LOCAL_SIGNATURE = 0x04034b50
 const EOCD_MIN_SIZE = 22
 const MAX_ZIP_COMMENT_BYTES = 0xffff
 
-// Prompt assembly needs only enough evidence to choose the Skill-import reference path. These caps
-// are deliberately much smaller than the real import limits: the importer performs the complete,
-// user-approved archive validation later, while this sniff must stay cheap on Electron's main thread.
-const SKILL_ARCHIVE_SNIFF_LIMITS = {
-  maxCentralDirectoryBytes: 1024 * 1024,
-  maxEntries: 4096,
-  maxManifestCandidates: 32,
-  maxManifestBytes: 512 * 1024,
-  maxCompressedManifestBytes: 512 * 1024,
-  maxTotalCompressedManifestBytes: 1024 * 1024,
-  maxDepth: 8
-} as const
+type ArchiveReader = {
+  size: number
+  read: (position: number, length: number) => Promise<Buffer | undefined>
+}
 
 type CentralEntry = {
   name: string
@@ -31,16 +24,89 @@ type CentralEntry = {
   localOffset: number
 }
 
-const readExact = async (
+type ArchiveScan = {
+  accepted: CentralEntry[]
+  skippedPaths: string[]
+}
+
+type ScanLimits = {
+  maxFiles: number
+  maxFileBytes: number
+  maxTotalBytes: number
+  maxDepth: number
+  strictCaps: boolean
+}
+
+const OUTER_SCAN_LIMITS: ScanLimits = {
+  maxFiles: SKILL_IMPORT_LIMITS.maxBundleEntries,
+  maxFileBytes: SKILL_IMPORT_LIMITS.maxSkillArchiveBytes,
+  maxTotalBytes: SKILL_IMPORT_LIMITS.maxBundleBytes,
+  maxDepth: SKILL_IMPORT_LIMITS.maxDepth,
+  strictCaps: false
+}
+
+const INNER_SCAN_LIMITS: ScanLimits = {
+  maxFiles: SKILL_IMPORT_LIMITS.maxFiles,
+  maxFileBytes: SKILL_IMPORT_LIMITS.maxFileBytes,
+  maxTotalBytes: SKILL_IMPORT_LIMITS.maxTotalBytes,
+  maxDepth: SKILL_IMPORT_LIMITS.maxDepth,
+  strictCaps: true
+}
+
+const readFromHandle = async (
   handle: FileHandle,
+  fileSize: number,
   position: number,
   length: number
 ): Promise<Buffer | undefined> => {
-  if (!Number.isSafeInteger(position) || position < 0 || length < 0) return undefined
+  if (
+    !Number.isSafeInteger(position) ||
+    !Number.isSafeInteger(length) ||
+    position < 0 ||
+    length < 0 ||
+    position + length > fileSize
+  ) {
+    return undefined
+  }
 
   const buffer = Buffer.allocUnsafe(length)
-  const { bytesRead } = await handle.read(buffer, 0, length, position)
-  return bytesRead === length ? buffer : undefined
+  let bytesRead = 0
+  while (bytesRead < length) {
+    const result = await handle.read(buffer, bytesRead, length - bytesRead, position + bytesRead)
+    if (result.bytesRead === 0) return undefined
+    bytesRead += result.bytesRead
+  }
+  return buffer
+}
+
+const fileReader = (handle: FileHandle, size: number): ArchiveReader => ({
+  size,
+  read: (position, length) => readFromHandle(handle, size, position, length)
+})
+
+const bufferReader = (buffer: Buffer): ArchiveReader => ({
+  size: buffer.length,
+  read: async (position, length) => {
+    if (position < 0 || length < 0 || position + length > buffer.length) return undefined
+    return buffer.subarray(position, position + length)
+  }
+})
+
+const subrangeReader = (
+  parent: ArchiveReader,
+  offset: number,
+  size: number
+): ArchiveReader | undefined => {
+  if (offset < 0 || size < 0 || offset + size > parent.size) return undefined
+  return {
+    size,
+    read: (position, length) => {
+      if (position < 0 || length < 0 || position + length > size) {
+        return Promise.resolve(undefined)
+      }
+      return parent.read(offset + position, length)
+    }
+  }
 }
 
 const findEocd = (tail: Buffer): number => {
@@ -53,22 +119,31 @@ const findEocd = (tail: Buffer): number => {
   return -1
 }
 
-const isSafeArchivePath = (path: string): boolean =>
-  path.length > 0 &&
-  !path.includes('\\') &&
-  !path.startsWith('/') &&
-  !path.startsWith('.') &&
-  !path.startsWith('__MACOSX/') &&
-  !/^[A-Za-z]:/.test(path) &&
-  !path.split('/').some((segment) => segment === '..') &&
-  path.split('/').length - 1 <= SKILL_ARCHIVE_SNIFF_LIMITS.maxDepth
+const isMetadataPath = (path: string): boolean =>
+  path.startsWith('__MACOSX/') || path.startsWith('.')
 
-const readCentralEntries = async (
-  handle: FileHandle,
-  fileSize: number
-): Promise<CentralEntry[] | undefined> => {
-  const tailSize = Math.min(fileSize, EOCD_MIN_SIZE + MAX_ZIP_COMMENT_BYTES)
-  const tail = await readExact(handle, fileSize - tailSize, tailSize)
+const isUnsafeArchivePath = (path: string): boolean =>
+  path.length === 0 ||
+  path.includes('\\') ||
+  path.startsWith('/') ||
+  /^[A-Za-z]:/.test(path) ||
+  path.split('/').some((segment) => segment === '..')
+
+const isNestedArchive = (path: string): boolean => /\.(zip|skill)$/i.test(path)
+
+const extractedEntrySize = (
+  entry: Pick<CentralEntry, 'method' | 'compressedSize' | 'uncompressedSize'>
+): number => (entry.method === 0 ? entry.compressedSize : entry.uncompressedSize)
+
+// Streams central-directory records instead of reading the whole ZIP or inflating unrelated files.
+// Size/count decisions mirror extractZipLenient (outer) and extractZip (one nested archive) using the
+// central metadata; candidate entry bytes are checked against their local header when actually read.
+const scanArchive = async (
+  reader: ArchiveReader,
+  limits: ScanLimits
+): Promise<ArchiveScan | undefined> => {
+  const tailSize = Math.min(reader.size, EOCD_MIN_SIZE + MAX_ZIP_COMMENT_BYTES)
+  const tail = await reader.read(reader.size - tailSize, tailSize)
   if (!tail) return undefined
 
   const eocd = findEocd(tail)
@@ -80,9 +155,9 @@ const readCentralEntries = async (
   const entryCount = tail.readUInt16LE(eocd + 10)
   const centralSize = tail.readUInt32LE(eocd + 12)
   const centralOffset = tail.readUInt32LE(eocd + 16)
+  const centralEnd = centralOffset + centralSize
 
-  // Multi-disk and ZIP64 archives are outside this prompt-time sniff. They remain ordinary resources
-  // and can still be inspected without doing expensive or ambiguous work in the main process.
+  // Multi-disk and ZIP64 archives are unsupported by the real importer too.
   if (
     diskNumber !== 0 ||
     centralDisk !== 0 ||
@@ -90,127 +165,235 @@ const readCentralEntries = async (
     entryCount === 0xffff ||
     centralSize === 0xffffffff ||
     centralOffset === 0xffffffff ||
-    entryCount > SKILL_ARCHIVE_SNIFF_LIMITS.maxEntries ||
-    centralSize > SKILL_ARCHIVE_SNIFF_LIMITS.maxCentralDirectoryBytes ||
-    centralOffset + centralSize > fileSize
+    centralEnd > reader.size
   ) {
     return undefined
   }
 
-  const directory = await readExact(handle, centralOffset, centralSize)
-  if (!directory) return undefined
+  const accepted: CentralEntry[] = []
+  const skippedPaths: string[] = []
+  let totalBytes = 0
+  let pointer = centralOffset
 
-  const entries: CentralEntry[] = []
-  let pointer = 0
   for (let index = 0; index < entryCount; index += 1) {
-    if (pointer + 46 > directory.length || directory.readUInt32LE(pointer) !== CENTRAL_SIGNATURE) {
-      return undefined
+    const header = await reader.read(pointer, 46)
+    if (!header || header.readUInt32LE(0) !== CENTRAL_SIGNATURE) return undefined
+
+    const method = header.readUInt16LE(10)
+    const compressedSize = header.readUInt32LE(20)
+    const uncompressedSize = header.readUInt32LE(24)
+    const nameLength = header.readUInt16LE(28)
+    const extraLength = header.readUInt16LE(30)
+    const commentLength = header.readUInt16LE(32)
+    const startDisk = header.readUInt16LE(34)
+    const localOffset = header.readUInt32LE(42)
+    const next = pointer + 46 + nameLength + extraLength + commentLength
+    if (startDisk !== 0 || next > centralEnd) return undefined
+
+    const nameBytes = await reader.read(pointer + 46, nameLength)
+    if (!nameBytes) return undefined
+    const name = nameBytes.toString('utf8')
+    pointer = next
+
+    // Match zip-extract's silent skips for directories, metadata, unsafe paths, and unsupported
+    // methods. The outer lenient walk records real unsafe/method failures so a containing loose root
+    // is rejected rather than classified from an incomplete bundle.
+    if (name.endsWith('/') || isMetadataPath(name)) continue
+    if (isUnsafeArchivePath(name) || (method !== 0 && method !== 8)) {
+      if (!limits.strictCaps) skippedPaths.push(name)
+      continue
     }
 
-    const method = directory.readUInt16LE(pointer + 10)
-    const compressedSize = directory.readUInt32LE(pointer + 20)
-    const uncompressedSize = directory.readUInt32LE(pointer + 24)
-    const nameLength = directory.readUInt16LE(pointer + 28)
-    const extraLength = directory.readUInt16LE(pointer + 30)
-    const commentLength = directory.readUInt16LE(pointer + 32)
-    const localOffset = directory.readUInt32LE(pointer + 42)
-    const next = pointer + 46 + nameLength + extraLength + commentLength
-    if (next > directory.length) return undefined
+    const depth = name.split('/').length - 1
+    const outputSize = method === 0 ? compressedSize : uncompressedSize
+    const violatesCaps =
+      depth > limits.maxDepth ||
+      accepted.length >= limits.maxFiles ||
+      outputSize > limits.maxFileBytes ||
+      totalBytes + outputSize > limits.maxTotalBytes
+    if (violatesCaps) {
+      if (limits.strictCaps) return undefined
+      skippedPaths.push(name)
+      continue
+    }
 
-    entries.push({
-      name: directory.toString('utf8', pointer + 46, pointer + 46 + nameLength),
-      method,
-      compressedSize,
-      uncompressedSize,
-      localOffset
-    })
-    pointer = next
+    accepted.push({ name, method, compressedSize, uncompressedSize, localOffset })
+    totalBytes += outputSize
   }
 
-  return entries
+  return { accepted, skippedPaths }
 }
 
-const inflateManifest = (compressed: Buffer): Promise<Buffer> =>
-  new Promise((resolve, reject) => {
-    inflateRaw(
-      compressed,
-      { maxOutputLength: SKILL_ARCHIVE_SNIFF_LIMITS.maxManifestBytes },
-      (error, result) => {
-        if (error) reject(error)
-        else resolve(result)
-      }
-    )
-  })
-
-const readManifest = async (
-  handle: FileHandle,
-  fileSize: number,
+const entryDataOffset = async (
+  reader: ArchiveReader,
   entry: CentralEntry
-): Promise<Buffer | undefined> => {
+): Promise<number | undefined> => {
+  const header = await reader.read(entry.localOffset, 30)
   if (
-    (entry.method !== 0 && entry.method !== 8) ||
-    entry.uncompressedSize > SKILL_ARCHIVE_SNIFF_LIMITS.maxManifestBytes ||
-    entry.compressedSize > SKILL_ARCHIVE_SNIFF_LIMITS.maxCompressedManifestBytes
+    !header ||
+    header.readUInt32LE(0) !== LOCAL_SIGNATURE ||
+    header.readUInt16LE(8) !== entry.method
   ) {
     return undefined
   }
 
-  const localHeader = await readExact(handle, entry.localOffset, 30)
-  if (!localHeader || localHeader.readUInt32LE(0) !== LOCAL_SIGNATURE) return undefined
+  const offset = entry.localOffset + 30 + header.readUInt16LE(26) + header.readUInt16LE(28)
+  return offset + entry.compressedSize <= reader.size ? offset : undefined
+}
 
-  const nameLength = localHeader.readUInt16LE(26)
-  const extraLength = localHeader.readUInt16LE(28)
-  const dataOffset = entry.localOffset + 30 + nameLength + extraLength
-  if (dataOffset + entry.compressedSize > fileSize) return undefined
+const inflateBounded = (compressed: Buffer, maxOutputLength: number): Promise<Buffer> =>
+  new Promise((resolve, reject) => {
+    inflateRaw(compressed, { maxOutputLength }, (error, result) => {
+      if (error) reject(error)
+      else resolve(result)
+    })
+  })
 
-  const compressed = await readExact(handle, dataOffset, entry.compressedSize)
+const readEntry = async (
+  reader: ArchiveReader,
+  entry: CentralEntry,
+  maxOutputLength: number
+): Promise<Buffer | undefined> => {
+  if (entry.uncompressedSize > maxOutputLength) return undefined
+
+  const offset = await entryDataOffset(reader, entry)
+  if (offset === undefined) return undefined
+  const compressed = await reader.read(offset, entry.compressedSize)
   if (!compressed) return undefined
 
   try {
-    return entry.method === 0 ? compressed : await inflateManifest(compressed)
+    if (entry.method === 0) {
+      return compressed.length <= maxOutputLength ? compressed : undefined
+    }
+    return await inflateBounded(compressed, maxOutputLength)
   } catch {
     return undefined
   }
 }
 
-// Classifies a ZIP by reading only its bounded central directory and candidate SKILL.md entries. It
-// never loads the whole archive or inflates unrelated assets. False is intentionally a safe fallback:
-// the attachment remains a generic resource instead of advertising an import path we cannot confirm.
+const manifestHasName = async (reader: ArchiveReader, entry: CentralEntry): Promise<boolean> => {
+  const manifest = await readEntry(reader, entry, SKILL_IMPORT_LIMITS.maxFileBytes)
+  if (!manifest) return false
+
+  try {
+    return Boolean(parseSkillDocument(manifest.toString('utf8')).name?.trim())
+  } catch {
+    return false
+  }
+}
+
+const skippedPathBelongsToRoot = (root: string, path: string): boolean =>
+  root === '' || path === root || path.startsWith(`${root}/`)
+
+const acceptedPathBelongsToRoot = (root: string, path: string): boolean =>
+  root === '' || path.startsWith(`${root}/`)
+
+const looseRootIsComplete = (root: string, scan: ArchiveScan): boolean => {
+  if (scan.skippedPaths.some((path) => skippedPathBelongsToRoot(root, path))) return false
+
+  const files = scan.accepted.filter((entry) => acceptedPathBelongsToRoot(root, entry.name))
+  return (
+    files.length <= SKILL_IMPORT_LIMITS.maxFiles &&
+    files.every((entry) => extractedEntrySize(entry) <= SKILL_IMPORT_LIMITS.maxFileBytes) &&
+    files.reduce((total, entry) => total + extractedEntrySize(entry), 0) <=
+      SKILL_IMPORT_LIMITS.maxTotalBytes
+  )
+}
+
+const inspectManifestRoots = async (
+  reader: ArchiveReader,
+  scan: ArchiveScan,
+  requireCompleteLooseRoot: boolean
+): Promise<{ roots: string[]; named: boolean[] }> => {
+  const manifestEntries = scan.accepted.filter(
+    (entry) => !isNestedArchive(entry.name) && skillManifestRootPath(entry.name) !== undefined
+  )
+  const roots = selectSkillManifestRoots(manifestEntries.map((entry) => entry.name))
+  const named: boolean[] = []
+
+  for (const root of roots) {
+    if (requireCompleteLooseRoot && !looseRootIsComplete(root, scan)) {
+      named.push(false)
+      continue
+    }
+
+    // Full preview uses the first case-insensitive SKILL.md at the selected root, so duplicate-cased
+    // entries cannot let the sniffer pick a different manifest than the importer.
+    const manifest = manifestEntries.find((entry) => skillManifestRootPath(entry.name) === root)
+    named.push(manifest ? await manifestHasName(reader, manifest) : false)
+  }
+
+  return { roots, named }
+}
+
+const nestedArchiveReader = async (
+  parent: ArchiveReader,
+  entry: CentralEntry
+): Promise<ArchiveReader | undefined> => {
+  const offset = await entryDataOffset(parent, entry)
+  if (offset === undefined) return undefined
+
+  if (entry.method === 0) {
+    if (entry.compressedSize > SKILL_IMPORT_LIMITS.maxSkillArchiveBytes) return undefined
+    return subrangeReader(parent, offset, entry.compressedSize)
+  }
+
+  const bytes = await readEntry(parent, entry, SKILL_IMPORT_LIMITS.maxSkillArchiveBytes)
+  return bytes ? bufferReader(bytes) : undefined
+}
+
+const inspectNestedArchive = async (
+  parent: ArchiveReader,
+  entry: CentralEntry
+): Promise<boolean[]> => {
+  const nested = await nestedArchiveReader(parent, entry)
+  if (!nested) return []
+
+  const scan = await scanArchive(nested, INNER_SCAN_LIMITS)
+  if (!scan) return []
+  return (await inspectManifestRoots(nested, scan, false)).named
+}
+
+const inspectOuterArchive = async (reader: ArchiveReader): Promise<boolean> => {
+  const scan = await scanArchive(reader, OUTER_SCAN_LIMITS)
+  if (!scan) return false
+
+  const loose = await inspectManifestRoots(reader, scan, true)
+  const candidateLimit = SKILL_IMPORT_LIMITS.maxSkillsPerBundle
+  const consideredLoose = loose.named.slice(0, candidateLimit)
+  if (consideredLoose.some(Boolean)) return true
+
+  let remainingCandidates = Math.max(0, candidateLimit - loose.roots.length)
+  if (remainingCandidates === 0) return false
+
+  const rootPrefixes = loose.roots.map((root) => (root === '' ? '' : `${root}/`))
+  const standaloneArchives = scan.accepted.filter(
+    (entry) =>
+      isNestedArchive(entry.name) &&
+      !rootPrefixes.some((prefix) => prefix === '' || entry.name.startsWith(prefix))
+  )
+
+  for (const archive of standaloneArchives) {
+    const nestedCandidates = await inspectNestedArchive(reader, archive)
+    const considered = nestedCandidates.slice(0, remainingCandidates)
+    if (considered.some(Boolean)) return true
+    remainingCandidates -= considered.length
+    if (remainingCandidates <= 0) break
+  }
+
+  return false
+}
+
+// Classifies a ZIP without loading the whole upload or inflating unrelated assets. Central records
+// are streamed; only selected manifests are inflated, plus one importer-supported level of nested
+// archive (asynchronously and under the same 64 MB cap as full discovery). Any ambiguity fails closed
+// to the ordinary resource path; the real importer still performs full preview/validation on approval.
 const isImportableSkillArchivePath = async (filePath: string): Promise<boolean> => {
   let handle: FileHandle | undefined
   try {
     handle = await open(filePath, 'r')
     const { size } = await handle.stat()
-    const entries = await readCentralEntries(handle, size)
-    if (!entries) return false
-
-    let candidateCount = 0
-    let totalCompressedBytes = 0
-    for (const entry of entries) {
-      if (!isSafeArchivePath(entry.name) || entry.name.endsWith('/')) continue
-
-      if (!isSkillManifestPath(entry.name)) continue
-
-      candidateCount += 1
-      totalCompressedBytes += entry.compressedSize
-      if (
-        candidateCount > SKILL_ARCHIVE_SNIFF_LIMITS.maxManifestCandidates ||
-        totalCompressedBytes > SKILL_ARCHIVE_SNIFF_LIMITS.maxTotalCompressedManifestBytes
-      ) {
-        return false
-      }
-
-      const manifest = await readManifest(handle, size, entry)
-      if (!manifest) continue
-
-      try {
-        if (parseSkillDocument(manifest.toString('utf8')).name?.trim()) return true
-      } catch {
-        // A malformed candidate does not prevent a later valid Skill root in the same bundle.
-      }
-    }
-
-    return false
+    return await inspectOuterArchive(fileReader(handle, size))
   } catch {
     return false
   } finally {
@@ -218,4 +401,4 @@ const isImportableSkillArchivePath = async (filePath: string): Promise<boolean> 
   }
 }
 
-export { SKILL_ARCHIVE_SNIFF_LIMITS, isImportableSkillArchivePath }
+export { isImportableSkillArchivePath }

--- a/src/main/skills/skill-archive-sniffer.ts
+++ b/src/main/skills/skill-archive-sniffer.ts
@@ -1,0 +1,224 @@
+import { open, type FileHandle } from 'node:fs/promises'
+import { inflateRaw } from 'node:zlib'
+
+import { parseSkillDocument } from './frontmatter'
+
+const EOCD_SIGNATURE = 0x06054b50
+const CENTRAL_SIGNATURE = 0x02014b50
+const LOCAL_SIGNATURE = 0x04034b50
+const EOCD_MIN_SIZE = 22
+const MAX_ZIP_COMMENT_BYTES = 0xffff
+
+// Prompt assembly needs only enough evidence to choose the Skill-import reference path. These caps
+// are deliberately much smaller than the real import limits: the importer performs the complete,
+// user-approved archive validation later, while this sniff must stay cheap on Electron's main thread.
+const SKILL_ARCHIVE_SNIFF_LIMITS = {
+  maxCentralDirectoryBytes: 1024 * 1024,
+  maxEntries: 4096,
+  maxManifestCandidates: 32,
+  maxManifestBytes: 512 * 1024,
+  maxCompressedManifestBytes: 512 * 1024,
+  maxTotalCompressedManifestBytes: 1024 * 1024,
+  maxDepth: 8
+} as const
+
+type CentralEntry = {
+  name: string
+  method: number
+  compressedSize: number
+  uncompressedSize: number
+  localOffset: number
+}
+
+const readExact = async (
+  handle: FileHandle,
+  position: number,
+  length: number
+): Promise<Buffer | undefined> => {
+  if (!Number.isSafeInteger(position) || position < 0 || length < 0) return undefined
+
+  const buffer = Buffer.allocUnsafe(length)
+  const { bytesRead } = await handle.read(buffer, 0, length, position)
+  return bytesRead === length ? buffer : undefined
+}
+
+const findEocd = (tail: Buffer): number => {
+  for (let offset = tail.length - EOCD_MIN_SIZE; offset >= 0; offset -= 1) {
+    if (tail.readUInt32LE(offset) !== EOCD_SIGNATURE) continue
+
+    const commentLength = tail.readUInt16LE(offset + 20)
+    if (offset + EOCD_MIN_SIZE + commentLength === tail.length) return offset
+  }
+  return -1
+}
+
+const isSafeArchivePath = (path: string): boolean =>
+  path.length > 0 &&
+  !path.includes('\\') &&
+  !path.startsWith('/') &&
+  !path.startsWith('.') &&
+  !path.startsWith('__MACOSX/') &&
+  !/^[A-Za-z]:/.test(path) &&
+  !path.split('/').some((segment) => segment === '..') &&
+  path.split('/').length - 1 <= SKILL_ARCHIVE_SNIFF_LIMITS.maxDepth
+
+const readCentralEntries = async (
+  handle: FileHandle,
+  fileSize: number
+): Promise<CentralEntry[] | undefined> => {
+  const tailSize = Math.min(fileSize, EOCD_MIN_SIZE + MAX_ZIP_COMMENT_BYTES)
+  const tail = await readExact(handle, fileSize - tailSize, tailSize)
+  if (!tail) return undefined
+
+  const eocd = findEocd(tail)
+  if (eocd < 0) return undefined
+
+  const diskNumber = tail.readUInt16LE(eocd + 4)
+  const centralDisk = tail.readUInt16LE(eocd + 6)
+  const entriesOnDisk = tail.readUInt16LE(eocd + 8)
+  const entryCount = tail.readUInt16LE(eocd + 10)
+  const centralSize = tail.readUInt32LE(eocd + 12)
+  const centralOffset = tail.readUInt32LE(eocd + 16)
+
+  // Multi-disk and ZIP64 archives are outside this prompt-time sniff. They remain ordinary resources
+  // and can still be inspected without doing expensive or ambiguous work in the main process.
+  if (
+    diskNumber !== 0 ||
+    centralDisk !== 0 ||
+    entriesOnDisk !== entryCount ||
+    entryCount === 0xffff ||
+    centralSize === 0xffffffff ||
+    centralOffset === 0xffffffff ||
+    entryCount > SKILL_ARCHIVE_SNIFF_LIMITS.maxEntries ||
+    centralSize > SKILL_ARCHIVE_SNIFF_LIMITS.maxCentralDirectoryBytes ||
+    centralOffset + centralSize > fileSize
+  ) {
+    return undefined
+  }
+
+  const directory = await readExact(handle, centralOffset, centralSize)
+  if (!directory) return undefined
+
+  const entries: CentralEntry[] = []
+  let pointer = 0
+  for (let index = 0; index < entryCount; index += 1) {
+    if (pointer + 46 > directory.length || directory.readUInt32LE(pointer) !== CENTRAL_SIGNATURE) {
+      return undefined
+    }
+
+    const method = directory.readUInt16LE(pointer + 10)
+    const compressedSize = directory.readUInt32LE(pointer + 20)
+    const uncompressedSize = directory.readUInt32LE(pointer + 24)
+    const nameLength = directory.readUInt16LE(pointer + 28)
+    const extraLength = directory.readUInt16LE(pointer + 30)
+    const commentLength = directory.readUInt16LE(pointer + 32)
+    const localOffset = directory.readUInt32LE(pointer + 42)
+    const next = pointer + 46 + nameLength + extraLength + commentLength
+    if (next > directory.length) return undefined
+
+    entries.push({
+      name: directory.toString('utf8', pointer + 46, pointer + 46 + nameLength),
+      method,
+      compressedSize,
+      uncompressedSize,
+      localOffset
+    })
+    pointer = next
+  }
+
+  return entries
+}
+
+const inflateManifest = (compressed: Buffer): Promise<Buffer> =>
+  new Promise((resolve, reject) => {
+    inflateRaw(
+      compressed,
+      { maxOutputLength: SKILL_ARCHIVE_SNIFF_LIMITS.maxManifestBytes },
+      (error, result) => {
+        if (error) reject(error)
+        else resolve(result)
+      }
+    )
+  })
+
+const readManifest = async (
+  handle: FileHandle,
+  fileSize: number,
+  entry: CentralEntry
+): Promise<Buffer | undefined> => {
+  if (
+    (entry.method !== 0 && entry.method !== 8) ||
+    entry.uncompressedSize > SKILL_ARCHIVE_SNIFF_LIMITS.maxManifestBytes ||
+    entry.compressedSize > SKILL_ARCHIVE_SNIFF_LIMITS.maxCompressedManifestBytes
+  ) {
+    return undefined
+  }
+
+  const localHeader = await readExact(handle, entry.localOffset, 30)
+  if (!localHeader || localHeader.readUInt32LE(0) !== LOCAL_SIGNATURE) return undefined
+
+  const nameLength = localHeader.readUInt16LE(26)
+  const extraLength = localHeader.readUInt16LE(28)
+  const dataOffset = entry.localOffset + 30 + nameLength + extraLength
+  if (dataOffset + entry.compressedSize > fileSize) return undefined
+
+  const compressed = await readExact(handle, dataOffset, entry.compressedSize)
+  if (!compressed) return undefined
+
+  try {
+    return entry.method === 0 ? compressed : await inflateManifest(compressed)
+  } catch {
+    return undefined
+  }
+}
+
+// Classifies a ZIP by reading only its bounded central directory and candidate SKILL.md entries. It
+// never loads the whole archive or inflates unrelated assets. False is intentionally a safe fallback:
+// the attachment remains a generic resource instead of advertising an import path we cannot confirm.
+const isImportableSkillArchivePath = async (filePath: string): Promise<boolean> => {
+  let handle: FileHandle | undefined
+  try {
+    handle = await open(filePath, 'r')
+    const { size } = await handle.stat()
+    const entries = await readCentralEntries(handle, size)
+    if (!entries) return false
+
+    let candidateCount = 0
+    let totalCompressedBytes = 0
+    for (const entry of entries) {
+      if (!isSafeArchivePath(entry.name) || entry.name.endsWith('/')) continue
+
+      const normalizedName = entry.name.toLowerCase()
+      // A nested `.skill` file is itself an explicit package signal. The later importer still performs
+      // full bounded extraction and preview before the user can approve anything.
+      if (normalizedName.endsWith('.skill')) return true
+      if (normalizedName.split('/').pop() !== 'skill.md') continue
+
+      candidateCount += 1
+      totalCompressedBytes += entry.compressedSize
+      if (
+        candidateCount > SKILL_ARCHIVE_SNIFF_LIMITS.maxManifestCandidates ||
+        totalCompressedBytes > SKILL_ARCHIVE_SNIFF_LIMITS.maxTotalCompressedManifestBytes
+      ) {
+        return false
+      }
+
+      const manifest = await readManifest(handle, size, entry)
+      if (!manifest) continue
+
+      try {
+        if (parseSkillDocument(manifest.toString('utf8')).name?.trim()) return true
+      } catch {
+        // A malformed candidate does not prevent a later valid Skill root in the same bundle.
+      }
+    }
+
+    return false
+  } catch {
+    return false
+  } finally {
+    await handle?.close().catch(() => undefined)
+  }
+}
+
+export { SKILL_ARCHIVE_SNIFF_LIMITS, isImportableSkillArchivePath }

--- a/src/main/skills/skill-archive-sniffer.ts
+++ b/src/main/skills/skill-archive-sniffer.ts
@@ -381,6 +381,12 @@ const consumeInflateBudget = (budget: InflateBudget, bytes: number): boolean => 
   return false
 }
 
+const resetInflateBudget = (budget: InflateBudget): void => {
+  budget.readBytes = 0
+  budget.inflatedBytes = 0
+  budget.exhausted = false
+}
+
 const compressedEntryChunks = async function* (
   reader: ArchiveReader,
   offset: number,
@@ -775,6 +781,11 @@ const inspectOuterArchive = async (
   if (!parsed) return false
   const scan = await validateArchiveEntries(reader, parsed, OUTER_SCAN_LIMITS, inflateBudget)
   if (!scan) return false
+
+  // Complete entry validation and post-validation classification are each independently bounded.
+  // Give metadata/nested-candidate reads their own pass so an importer-valid archive at the outer
+  // decompressed-size cap is not rejected merely because its manifest must be read again for `name`.
+  resetInflateBudget(inflateBudget)
 
   const candidateLimit = SKILL_IMPORT_LIMITS.maxSkillsPerBundle
   const loose = await inspectManifestRoots(reader, scan, true, candidateLimit, inflateBudget)

--- a/src/main/skills/skill-bundle-paths.ts
+++ b/src/main/skills/skill-bundle-paths.ts
@@ -21,12 +21,15 @@ const selectSkillManifestRoots = (paths: Iterable<string>): string[] => {
     if (root !== undefined) candidates.add(root)
   }
 
-  const all = [...candidates]
-  return all
-    .filter(
-      (root) =>
-        !all.some((other) => other !== root && (other === '' || root.startsWith(`${other}/`)))
-    )
+  return [...candidates]
+    .filter((root) => {
+      if (root === '') return true
+      const segments = root.split('/')
+      for (let length = 0; length < segments.length; length += 1) {
+        if (candidates.has(segments.slice(0, length).join('/'))) return false
+      }
+      return true
+    })
     .sort((left, right) => left.localeCompare(right))
 }
 

--- a/src/main/skills/skill-bundle-paths.ts
+++ b/src/main/skills/skill-bundle-paths.ts
@@ -1,0 +1,9 @@
+// A directly importable Skill root may be at the archive root or under at most two wrapper
+// directories. Keep this predicate shared by full discovery and prompt-time ZIP sniffing so the
+// prompt never advertises a package whose preview will later contain no candidates.
+const isSkillManifestPath = (path: string): boolean => {
+  const segments = path.split('/')
+  return segments.length <= 3 && segments[segments.length - 1].toLowerCase() === 'skill.md'
+}
+
+export { isSkillManifestPath }

--- a/src/main/skills/skill-bundle-paths.ts
+++ b/src/main/skills/skill-bundle-paths.ts
@@ -1,9 +1,33 @@
 // A directly importable Skill root may be at the archive root or under at most two wrapper
 // directories. Keep this predicate shared by full discovery and prompt-time ZIP sniffing so the
 // prompt never advertises a package whose preview will later contain no candidates.
-const isSkillManifestPath = (path: string): boolean => {
+const skillManifestRootPath = (path: string): string | undefined => {
   const segments = path.split('/')
-  return segments.length <= 3 && segments[segments.length - 1].toLowerCase() === 'skill.md'
+  if (segments.length > 3 || segments[segments.length - 1].toLowerCase() !== 'skill.md') {
+    return undefined
+  }
+  return segments.slice(0, -1).join('/')
 }
 
-export { isSkillManifestPath }
+const isSkillManifestPath = (path: string): boolean => skillManifestRootPath(path) !== undefined
+
+// Keeps only the shallowest manifest root on each branch. A nested SKILL.md beneath another root is
+// that outer Skill's resource, not a second candidate — even when the outer manifest later proves
+// invalid. Both full discovery and prompt-time sniffing must apply this before parsing names.
+const selectSkillManifestRoots = (paths: Iterable<string>): string[] => {
+  const candidates = new Set<string>()
+  for (const path of paths) {
+    const root = skillManifestRootPath(path)
+    if (root !== undefined) candidates.add(root)
+  }
+
+  const all = [...candidates]
+  return all
+    .filter(
+      (root) =>
+        !all.some((other) => other !== root && (other === '' || root.startsWith(`${other}/`)))
+    )
+    .sort((left, right) => left.localeCompare(right))
+}
+
+export { isSkillManifestPath, selectSkillManifestRoots, skillManifestRootPath }

--- a/src/main/skills/user-skill-repository.test.ts
+++ b/src/main/skills/user-skill-repository.test.ts
@@ -20,6 +20,7 @@ import { load as loadYaml } from 'js-yaml'
 
 import {
   UserSkillRepository,
+  isImportableSkillArchive,
   parseUserSkillId,
   toSlug,
   frontmatterBlock
@@ -395,6 +396,24 @@ describe('UserSkillRepository', () => {
     await expect(repo.importFromZip(zip)).rejects.toThrow(/SKILL\.md/)
     // Preview no longer throws: it returns nothing importable so the UI can say "no skills found".
     expect(await repo.previewZip(zip)).toEqual({ previews: [], skipped: [] })
+  })
+
+  it('classifies only ZIP archives containing a named importable Skill', () => {
+    const skill = buildZip([
+      {
+        path: 'paper-finder/SKILL.md',
+        content: Buffer.from('---\nname: Paper Finder\ndescription: Finds papers.\n---\nRun it.')
+      }
+    ])
+    const ordinary = buildZip([{ path: 'README.md', content: Buffer.from('dataset archive') }])
+    const unnamed = buildZip([
+      { path: 'SKILL.md', content: Buffer.from('---\ndescription: Missing name.\n---\nBody') }
+    ])
+
+    expect(isImportableSkillArchive(skill)).toBe(true)
+    expect(isImportableSkillArchive(ordinary)).toBe(false)
+    expect(isImportableSkillArchive(unnamed)).toBe(false)
+    expect(isImportableSkillArchive(Buffer.from('not a zip'))).toBe(false)
   })
 
   it('discovers one root for a root-level SKILL.md (subPath "")', async () => {

--- a/src/main/skills/user-skill-repository.test.ts
+++ b/src/main/skills/user-skill-repository.test.ts
@@ -20,7 +20,6 @@ import { load as loadYaml } from 'js-yaml'
 
 import {
   UserSkillRepository,
-  isImportableSkillArchive,
   parseUserSkillId,
   toSlug,
   frontmatterBlock
@@ -396,24 +395,6 @@ describe('UserSkillRepository', () => {
     await expect(repo.importFromZip(zip)).rejects.toThrow(/SKILL\.md/)
     // Preview no longer throws: it returns nothing importable so the UI can say "no skills found".
     expect(await repo.previewZip(zip)).toEqual({ previews: [], skipped: [] })
-  })
-
-  it('classifies only ZIP archives containing a named importable Skill', () => {
-    const skill = buildZip([
-      {
-        path: 'paper-finder/SKILL.md',
-        content: Buffer.from('---\nname: Paper Finder\ndescription: Finds papers.\n---\nRun it.')
-      }
-    ])
-    const ordinary = buildZip([{ path: 'README.md', content: Buffer.from('dataset archive') }])
-    const unnamed = buildZip([
-      { path: 'SKILL.md', content: Buffer.from('---\ndescription: Missing name.\n---\nBody') }
-    ])
-
-    expect(isImportableSkillArchive(skill)).toBe(true)
-    expect(isImportableSkillArchive(ordinary)).toBe(false)
-    expect(isImportableSkillArchive(unnamed)).toBe(false)
-    expect(isImportableSkillArchive(Buffer.from('not a zip'))).toBe(false)
   })
 
   it('discovers one root for a root-level SKILL.md (subPath "")', async () => {

--- a/src/main/skills/user-skill-repository.ts
+++ b/src/main/skills/user-skill-repository.ts
@@ -28,6 +28,7 @@ import {
 import { parseSkillDocument } from './frontmatter'
 import type { BundledSkill } from './registry'
 import { readSkillFile } from './skill-files'
+import { isSkillManifestPath } from './skill-bundle-paths'
 import { extractZip, extractZipLenient } from './zip-extract'
 
 const log = createLogger('skills')
@@ -183,9 +184,8 @@ type SkillRoot = { subPath: string; files: FetchedSkillFile[] }
 const findSkillRoots = (entries: { path: string; content: Buffer }[]): SkillRoot[] => {
   const candidates = new Set<string>()
   for (const entry of entries) {
+    if (!isSkillManifestPath(entry.path)) continue
     const segments = entry.path.split('/')
-    if (segments[segments.length - 1].toLowerCase() !== 'skill.md') continue
-    if (segments.length > 3) continue
     candidates.add(segments.slice(0, -1).join('/'))
   }
 

--- a/src/main/skills/user-skill-repository.ts
+++ b/src/main/skills/user-skill-repository.ts
@@ -345,6 +345,28 @@ const discoverSkillRoots = (zip: Buffer): SkillDiscovery => {
   return { roots: roots.sort((a, b) => a.subPath.localeCompare(b.subPath)), skipped }
 }
 
+// Pure, read-only classification for conversation attachments. A `.zip` is only advertised to the
+// Skill import tool when the same bounded archive discovery used by preview finds at least one
+// SKILL.md with a valid non-empty name. Invalid/ordinary archives fail closed and keep their generic
+// attachment representation; `.skill` files carry an explicit format signal and do not need this
+// content sniff.
+const isImportableSkillArchive = (zip: Buffer): boolean => {
+  try {
+    return discoverSkillRoots(zip).roots.some((root) => {
+      const skillMd = root.files.find((file) => file.relativePath.toLowerCase() === 'skill.md')
+      if (!skillMd) return false
+
+      try {
+        return Boolean(parseSkillDocument(skillMd.content.toString('utf8')).name?.trim())
+      } catch {
+        return false
+      }
+    })
+  } catch {
+    return false
+  }
+}
+
 // Reads and writes user-authored (personal) and imported skills under `<storageRoot>/skills/`.
 class UserSkillRepository {
   constructor(private readonly storageRoot: string) {}
@@ -1586,4 +1608,4 @@ class UserSkillRepository {
   }
 }
 
-export { UserSkillRepository, parseUserSkillId, toSlug, frontmatterBlock }
+export { UserSkillRepository, frontmatterBlock, isImportableSkillArchive, parseUserSkillId, toSlug }

--- a/src/main/skills/user-skill-repository.ts
+++ b/src/main/skills/user-skill-repository.ts
@@ -345,28 +345,6 @@ const discoverSkillRoots = (zip: Buffer): SkillDiscovery => {
   return { roots: roots.sort((a, b) => a.subPath.localeCompare(b.subPath)), skipped }
 }
 
-// Pure, read-only classification for conversation attachments. A `.zip` is only advertised to the
-// Skill import tool when the same bounded archive discovery used by preview finds at least one
-// SKILL.md with a valid non-empty name. Invalid/ordinary archives fail closed and keep their generic
-// attachment representation; `.skill` files carry an explicit format signal and do not need this
-// content sniff.
-const isImportableSkillArchive = (zip: Buffer): boolean => {
-  try {
-    return discoverSkillRoots(zip).roots.some((root) => {
-      const skillMd = root.files.find((file) => file.relativePath.toLowerCase() === 'skill.md')
-      if (!skillMd) return false
-
-      try {
-        return Boolean(parseSkillDocument(skillMd.content.toString('utf8')).name?.trim())
-      } catch {
-        return false
-      }
-    })
-  } catch {
-    return false
-  }
-}
-
 // Reads and writes user-authored (personal) and imported skills under `<storageRoot>/skills/`.
 class UserSkillRepository {
   constructor(private readonly storageRoot: string) {}
@@ -1608,4 +1586,4 @@ class UserSkillRepository {
   }
 }
 
-export { UserSkillRepository, frontmatterBlock, isImportableSkillArchive, parseUserSkillId, toSlug }
+export { UserSkillRepository, frontmatterBlock, parseUserSkillId, toSlug }

--- a/src/main/skills/user-skill-repository.ts
+++ b/src/main/skills/user-skill-repository.ts
@@ -28,7 +28,7 @@ import {
 import { parseSkillDocument } from './frontmatter'
 import type { BundledSkill } from './registry'
 import { readSkillFile } from './skill-files'
-import { isSkillManifestPath } from './skill-bundle-paths'
+import { selectSkillManifestRoots } from './skill-bundle-paths'
 import { extractZip, extractZipLenient } from './zip-extract'
 
 const log = createLogger('skills')
@@ -182,30 +182,15 @@ type SkillRoot = { subPath: string; files: FetchedSkillFile[] }
 // `*/SKILL.md`, or `*/*/SKILL.md`); deeper SKILL.md files are ignored. A root nested under a shallower
 // one is dropped so a single skill is never counted twice. Archive paths always use forward slashes.
 const findSkillRoots = (entries: { path: string; content: Buffer }[]): SkillRoot[] => {
-  const candidates = new Set<string>()
-  for (const entry of entries) {
-    if (!isSkillManifestPath(entry.path)) continue
-    const segments = entry.path.split('/')
-    candidates.add(segments.slice(0, -1).join('/'))
-  }
+  const roots = selectSkillManifestRoots(entries.map((entry) => entry.path))
 
-  // Keep only the shallowest root on each branch: a candidate under another (or under the archive
-  // root '') is that skill's own file, not a separate skill.
-  const all = [...candidates]
-  const roots = all.filter(
-    (subPath) =>
-      !all.some((other) => other !== subPath && (other === '' || subPath.startsWith(`${other}/`)))
-  )
-
-  return roots
-    .map((subPath) => {
-      const prefix = subPath === '' ? '' : `${subPath}/`
-      const files = entries
-        .filter((entry) => entry.path.startsWith(prefix))
-        .map((entry) => ({ relativePath: entry.path.slice(prefix.length), content: entry.content }))
-      return { subPath, files }
-    })
-    .sort((a, b) => a.subPath.localeCompare(b.subPath))
+  return roots.map((subPath) => {
+    const prefix = subPath === '' ? '' : `${subPath}/`
+    const files = entries
+      .filter((entry) => entry.path.startsWith(prefix))
+      .map((entry) => ({ relativePath: entry.path.slice(prefix.length), content: entry.content }))
+    return { subPath, files }
+  })
 }
 
 // True for an archive entry that is itself a skill bundle (a .zip / .skill nested inside the upload).

--- a/src/shared/skill-import.ts
+++ b/src/shared/skill-import.ts
@@ -1,7 +1,7 @@
 const SKILL_IMPORT_MCP_SERVER_NAME = 'open-science-skills'
 const REQUEST_SKILL_IMPORT_TOOL_NAME = 'request_skill_import'
 const REQUEST_SKILL_IMPORT_TOOL_DESCRIPTION =
-  'Open the application-owned preview and confirmation dialog for an attached .zip or .skill package. Call only when the user explicitly asks to install or import that attachment. Pass the exact file URI from the attachment resource; never guess or construct a path. The application validates ownership and does not write anything unless the user confirms.'
+  'Open the application-owned preview and confirmation dialog for an attachment explicitly marked skillImportEligible. Call only when the user asks to install or import that eligible .zip or .skill package. Pass its exact file URI; never guess or construct a path. Ordinary ZIP attachments are not eligible. The application validates ownership and does not write anything unless the user confirms.'
 
 export {
   REQUEST_SKILL_IMPORT_TOOL_DESCRIPTION,

--- a/src/shared/skill-import.ts
+++ b/src/shared/skill-import.ts
@@ -1,7 +1,7 @@
 const SKILL_IMPORT_MCP_SERVER_NAME = 'open-science-skills'
 const REQUEST_SKILL_IMPORT_TOOL_NAME = 'request_skill_import'
 const REQUEST_SKILL_IMPORT_TOOL_DESCRIPTION =
-  'Open the application-owned preview and confirmation dialog for an attachment explicitly marked skillImportEligible. Call only when the user asks to install or import that eligible .zip or .skill package. Pass its exact file URI; never guess or construct a path. Ordinary ZIP attachments are not eligible. The application validates ownership and does not write anything unless the user confirms.'
+  'Open the application-owned preview and confirmation dialog for an attachment explicitly marked skillImportEligible. Call only when the user asks to install or import that eligible .zip or .skill package. Pass its exact file URI as attachment_uri and skillImportTurnToken as turn_token; never guess or construct either value. Ordinary ZIP attachments are not eligible. The application validates turn ownership and does not write anything unless the user confirms.'
 
 export {
   REQUEST_SKILL_IMPORT_TOOL_DESCRIPTION,


### PR DESCRIPTION
## Problem

The final reviews on merged PR #449 identified several trust- and lifecycle-boundary gaps: conversational Skill import could be advertised for archives the session importer could not consume, ordinary archives could enter the Skill path, and a delayed import request could remain actionable after its prompt was stopped or superseded.

## Proposed change

- Classify `.zip` and `.skill` uploads with the bounded importer-aligned archive sniffer, including the supported nested archive level, and enforce the same eligibility check again at the main-process importer boundary.
- Keep ordinary, artifact-backed, cross-session, and invalid Skill archives on a provider-safe text-reference path marked `skillImportEligible: false`; only current-session manifest-confirmed packages advertise the app-owned importer.
- Bind each eligible attachment and `request_skill_import` call to a random per-turn token carried through the prompt, MCP tool, local RPC, approval broker, and importer. Register the exact URI only when runtime prompt construction emits its eligible reference, and require that per-turn URI allowlist before any path resolution or preview. Revoke the capability on normal prompt completion, Stop, Delete, disconnect, shutdown, or a newer turn.
- Bind runtime start callbacks to an exact coordinator prompt-attempt ID, and reacquire the per-session prompt lock after asynchronous Skill preflight before any force-load reconnect or turn-token publication. A cancelled delayed attempt therefore cannot consume or overwrite a newer turn.
- Invalidate pending approvals synchronously when teardown is requested, even if runtime teardown later fails, while keeping pre-teardown cancellation and confirmed session-unavailability callbacks separate and reconciling routing ownership from actual post-teardown snapshots.
- Preserve importer/sniffer parity for shallowest-root selection, nested archives, bounded candidate/read/inflate budgets, local-header/body validation, actual STORE/DEFLATE sizes, frontmatter-only rereads, EOCD lookup with trailing data, and tolerant termination after the last readable central-directory record. Complete entry validation and post-validation classification use separate bounded work phases so valid cap-edge bundles are not charged twice while each phase remains fail-closed.

## Scope and non-goals

This is a focused follow-up to #449. It does not add artifact-store imports, auto-import ZIP attachments, or change the approval UI.

## Acceptance criteria and validation

- Ordinary and invalid archives remain provider-safe generic references; only current-session, content-confirmed Skill packages advertise import.
- A tool call must present both the exact eligible attachment URI and the active prompt turn token; stale, cancelled, guessed, or cross-turn requests cannot open or complete an approval.
- Stop, Delete, disconnect, shutdown, and prompt completion immediately revoke the corresponding import capability, independent of later teardown success.
- Delayed pre-start prompts cannot tear down, overwrite, or inherit a newer active turn's import state.
- `npm run typecheck`
- `npm run lint` (0 errors; 24 existing warnings outside this diff)
- `npm test -- --maxWorkers=4` (6,933 passed; 112 skipped)
- Independent standards and behavior reviews: 0 findings

## Review focus

Please focus on the per-turn authorization boundary across prompt → MCP → RPC → importer, exact prompt-attempt matching around Stop/new-turn races, and archive-classification parity at both prompt and importer boundaries.
