### PR TITLE
ci(review): run one subscription-first AI review

### DIFF
--- a/.github/action/ai-review.md
+++ b/.github/action/ai-review.md
@@ -29,8 +29,8 @@ default. Keep API-key secrets configured for automatic fallback. Model, effort, 
 and round-limit variables continue to apply. `CODEX_REVIEW_MODEL` and `CODEX_REVIEW_EFFORT` take
 precedence; the legacy correctness variables and then architecture variables remain ordered
 fallbacks. When a legacy credential scope is selected, its model and effort variables are used as a
-bundle; shared or subscription-only configurations keep the legacy correctness-then-architecture
-fallback order.
+bundle; review-specific, shared, or subscription-only configurations keep the legacy
+correctness-then-architecture fallback order.
 
 `ENABLE_CODEX_REVIEW=false` disables automatic and manually dispatched reviews. For compatibility,
 legacy `CODEX_REVIEW_MODE=disabled` disables only automatic pull request events; a manual dispatch

--- a/.github/action/ai-review.md
+++ b/.github/action/ai-review.md
@@ -26,7 +26,9 @@ used because each workflow run now has one combined review.
 
 Set the `CODEX_REVIEW_AUTH_MODE` repository variable to `api-key` to override the subscription
 default. Keep API-key secrets configured for automatic fallback. Model, effort, fork, enablement,
-and round-limit variables continue to apply.
+and round-limit variables continue to apply. `CODEX_REVIEW_MODEL` and `CODEX_REVIEW_EFFORT` take
+precedence; the legacy correctness variables and then architecture variables remain ordered
+fallbacks.
 
 ## Codex subscription mode
 
@@ -55,10 +57,11 @@ Responses API proxy and key-isolation behavior.
 
 Before checking out pull request code, the subscription path sends a fixed, low-effort, no-tool
 Codex request from an empty temporary directory. The same credential-directory deny rule applies to
-this authentication preflight. If CLI setup fails or the account cannot authenticate or refresh,
-the workflow removes the temporary subscription credential and selects the API-key runtime. This
-adds one small Codex request to each subscription review but avoids rerunning a full review after an
-authentication failure.
+this authentication preflight. The CLI runs as the unprivileged `nobody` user with a clean
+environment, so it has neither passwordless sudo nor the fallback API key or base URL. If CLI setup,
+preflight isolation, or account authentication or refresh fails, the workflow removes the temporary
+subscription credential and selects the API-key runtime. This adds one small Codex request to each
+subscription review but avoids rerunning a full review after an authentication failure.
 
 ### 1. Create file-backed credentials
 

--- a/.github/action/ai-review.md
+++ b/.github/action/ai-review.md
@@ -20,15 +20,18 @@ The combined reviewer can use review-specific credentials instead:
 - `CODEX_REVIEW_API_KEY`
 - `CODEX_REVIEW_BASE_URL`
 
-For compatibility, `CODEX_CORRECTNESS_API_KEY` and `CODEX_CORRECTNESS_BASE_URL` remain fallbacks
-between the review-specific and shared secrets. Architecture-specific credentials are no longer
-used because each workflow run now has one combined review.
+For compatibility, correctness-specific and then architecture-specific credentials remain ordered
+fallbacks between the review-specific and shared secrets.
 
 Set the `CODEX_REVIEW_AUTH_MODE` repository variable to `api-key` to override the subscription
 default. Keep API-key secrets configured for automatic fallback. Model, effort, fork, enablement,
 and round-limit variables continue to apply. `CODEX_REVIEW_MODEL` and `CODEX_REVIEW_EFFORT` take
 precedence; the legacy correctness variables and then architecture variables remain ordered
 fallbacks.
+
+`ENABLE_CODEX_REVIEW=false` disables automatic and manually dispatched reviews. For compatibility,
+legacy `CODEX_REVIEW_MODE=disabled` disables only automatic pull request events; a manual dispatch
+still starts the single combined reviewer.
 
 ## Codex subscription mode
 

--- a/.github/action/ai-review.md
+++ b/.github/action/ai-review.md
@@ -21,13 +21,16 @@ The combined reviewer can use review-specific credentials instead:
 - `CODEX_REVIEW_BASE_URL`
 
 For compatibility, correctness-specific and then architecture-specific credentials remain ordered
-fallbacks between the review-specific and shared secrets.
+fallbacks between the review-specific and shared secrets. A scope is selected only when both its API
+key and base URL are configured; keys and endpoints from different scopes are never combined.
 
 Set the `CODEX_REVIEW_AUTH_MODE` repository variable to `api-key` to override the subscription
 default. Keep API-key secrets configured for automatic fallback. Model, effort, fork, enablement,
 and round-limit variables continue to apply. `CODEX_REVIEW_MODEL` and `CODEX_REVIEW_EFFORT` take
 precedence; the legacy correctness variables and then architecture variables remain ordered
-fallbacks.
+fallbacks. When a legacy credential scope is selected, its model and effort variables are used as a
+bundle; shared or subscription-only configurations keep the legacy correctness-then-architecture
+fallback order.
 
 `ENABLE_CODEX_REVIEW=false` disables automatic and manually dispatched reviews. For compatibility,
 legacy `CODEX_REVIEW_MODE=disabled` disables only automatic pull request events; a manual dispatch
@@ -58,13 +61,15 @@ The subscription path installs the pinned Codex CLI directly and does not pass s
 credentials through `openai/codex-action`. API-key mode continues using the pinned action for its
 Responses API proxy and key-isolation behavior.
 
-Before checking out pull request code, the subscription path sends a fixed, low-effort, no-tool
-Codex request from an empty temporary directory. The same credential-directory deny rule applies to
-this authentication preflight. The CLI runs as the unprivileged `nobody` user with a clean
-environment, so it has neither passwordless sudo nor the fallback API key or base URL. If CLI setup,
-preflight isolation, or account authentication or refresh fails, the workflow removes the temporary
-subscription credential and selects the API-key runtime. This adds one small Codex request to each
-subscription review but avoids rerunning a full review after an authentication failure.
+Before checking out pull request code, the subscription path installs the pinned CLI, prepares the
+packaged Linux sandbox prerequisites, verifies positive and negative filesystem probes, and sends a
+fixed, low-effort, no-tool Codex request from an empty temporary directory. The same
+credential-directory deny rule applies to these preflight checks. The CLI runs as the unprivileged
+`nobody` user with a clean environment, so it has neither passwordless sudo nor the fallback API key
+or base URL. If CLI setup, sandbox setup or probes, preflight isolation, or account authentication or
+refresh fails, the workflow removes the temporary subscription credential and selects the API-key
+runtime. This adds one small Codex request to each subscription review but avoids rerunning a full
+review after an authentication failure.
 
 ### 1. Create file-backed credentials
 

--- a/.github/action/ai-review.md
+++ b/.github/action/ai-review.md
@@ -2,32 +2,41 @@
 
 # AI review authentication
 
-The `AI PR Review` workflow supports API-key and Codex subscription authentication. API-key auth
-remains the default and is the only mode used for automatic or fork pull request reviews.
+The `AI PR Review (Single)` workflow supports API-key and Codex subscription authentication.
+Subscription auth is the default for every allowed automatic or manually dispatched pull request
+review. Invalid or missing subscription credentials fall back to API-key auth. API-key auth also
+remains available as an explicit override. The workflow replaces the disabled dual-review workflow
+with one combined Codex review per run.
 
 ## API-key mode
 
-Set the shared fallback secrets:
+Set the shared secrets:
 
 - `OPENAI_API_KEY`
 - `CODEX_BASE_URL` (the API root or full `/v1/responses` endpoint)
 
-The correctness and architecture reviewers can use independent credentials:
+The combined reviewer can use review-specific credentials instead:
 
-- `CODEX_CORRECTNESS_API_KEY` and `CODEX_CORRECTNESS_BASE_URL`
-- `CODEX_ARCHITECTURE_API_KEY` and `CODEX_ARCHITECTURE_BASE_URL`
+- `CODEX_REVIEW_API_KEY`
+- `CODEX_REVIEW_BASE_URL`
 
-Set the `CODEX_REVIEW_AUTH_MODE` repository variable to `api-key`, or leave it unset. Existing
-model, effort, reviewer-selection, fork, and round-limit variables continue to apply.
+For compatibility, `CODEX_CORRECTNESS_API_KEY` and `CODEX_CORRECTNESS_BASE_URL` remain fallbacks
+between the review-specific and shared secrets. Architecture-specific credentials are no longer
+used because each workflow run now has one combined review.
+
+Set the `CODEX_REVIEW_AUTH_MODE` repository variable to `api-key` to override the subscription
+default. Keep API-key secrets configured for automatic fallback. Model, effort, fork, enablement,
+and round-limit variables continue to apply.
 
 ## Codex subscription mode
 
 > [!WARNING]
 > OpenAI recommends API keys for CI/CD and says not to use ChatGPT-managed `auth.json` automation
-> for public or open-source repositories. This workflow offers a narrower opt-in for a dedicated
-> account: subscription credentials are accepted only for a manually dispatched review of a
-> same-repository pull request. They are never exposed to automatic or fork review jobs, which
-> continue using the configured API-key credentials.
+> for public or open-source repositories. This workflow uses a dedicated account for automatic and
+> manually dispatched pull request reviews, including fork reviews allowed by `FORK_REVIEW_MODE`.
+> The sandbox boundary below protects the credential from model-generated commands, but enabling
+> this mode still makes the dedicated subscription available to the trusted parent process of each
+> allowed review job.
 
 Use a dedicated Codex account because `auth.json` contains access and refresh tokens. Subscription
 jobs copy it into a temporary `CODEX_HOME`, remove passwordless sudo, and use a strict read-only
@@ -36,12 +45,20 @@ directory. The checkout is marked untrusted so PR-provided Codex configuration i
 repository instruction loading is disabled. Before review, positive and negative `codex sandbox`
 probes verify that the packaged Linux sandbox can read the checkout but cannot read the credential;
 the job fails closed if the sandbox or sudo boundary is ineffective. A runner-global `bwrap`
-executable is not required. Manual dispatch remains a trust decision because OpenAI does not
-recommend ChatGPT-managed auth for public or open-source CI.
+executable is not required. Every subscription review remains a trust decision because OpenAI does
+not recommend ChatGPT-managed auth for public or open-source CI; automatic reviews make that
+decision for every allowed pull request update.
 
 The subscription path installs the pinned Codex CLI directly and does not pass subscription
 credentials through `openai/codex-action`. API-key mode continues using the pinned action for its
 Responses API proxy and key-isolation behavior.
+
+Before checking out pull request code, the subscription path sends a fixed, low-effort, no-tool
+Codex request from an empty temporary directory. The same credential-directory deny rule applies to
+this authentication preflight. If CLI setup fails or the account cannot authenticate or refresh,
+the workflow removes the temporary subscription credential and selects the API-key runtime. This
+adds one small Codex request to each subscription review but avoids rerunning a full review after an
+authentication failure.
 
 ### 1. Create file-backed credentials
 
@@ -73,7 +90,8 @@ Continue only when `auth_mode` is `chatgpt` and `has_refresh_token` is `true`.
 
 ### 2. Configure GitHub
 
-Store the complete file as a repository secret, then select subscription auth:
+Store the complete file as a repository secret. Subscription is the workflow default; set the
+repository variable explicitly if you want the configuration recorded in GitHub:
 
 ```bash
 AUTH_FILE="${CODEX_HOME:-$HOME/.codex}/auth.json"
@@ -81,30 +99,32 @@ gh secret set CODEX_AUTH_JSON < "$AUTH_FILE"
 gh variable set CODEX_REVIEW_AUTH_MODE --body subscription
 ```
 
-`OPENAI_API_KEY` and `CODEX_BASE_URL` are ignored in subscription mode. Model and effort variables
-still apply, so select a model available to the dedicated Codex account.
+`OPENAI_API_KEY` and `CODEX_BASE_URL` remain available as the fallback when `CODEX_AUTH_JSON` is
+missing or is not a valid managed ChatGPT credential. Model and effort variables still apply, so
+select a model available to the dedicated Codex account.
 
 ### 3. Run a review
 
-Open **Actions → AI PR Review → Run workflow**, enter the same-repository pull request number, and
-choose `correctness`, `architecture`, or `both`. Automatic `pull_request_target` events and fork
-pull requests fall back to API-key auth and continue following `FORK_REVIEW_MODE`; keep the API-key
-secrets configured if those review paths should remain active.
+Every review allowed by `FORK_REVIEW_MODE` prefers subscription auth, whether it starts from an
+automatic pull request event or a manual dispatch. To run one manually, open
+**Actions → AI PR Review (Single) → Run workflow**, enter the pull request number, and run the
+workflow. The single reviewer checks correctness, security, regressions, repository standards,
+architecture, and integration in one Codex turn. If the subscription credential is unavailable,
+the same job selects the configured API-key runtime before checkout and review execution.
 
 ### Credential refresh limitation
 
 GitHub-hosted runners are ephemeral. Codex may refresh `auth.json` during a job, but the updated file
 is discarded with that runner and is not written back to the GitHub secret. If authentication starts
-returning `401` or can no longer refresh, run `codex login` again on the trusted machine and repeat
-the `gh secret set CODEX_AUTH_JSON` command. Each reviewer gets an independent temporary credential
-copy, so correctness and architecture reviews can run in parallel without a repository-wide lock.
-Newer runs cancel an older run for the same pull request and reviewer scope to avoid duplicate
-feedback and review-round consumption.
+returning `401` or can no longer refresh, the preflight selects API-key auth for that run. Run
+`codex login` again on the trusted machine and repeat the `gh secret set CODEX_AUTH_JSON` command to
+restore subscription usage. The reviewer gets one temporary credential copy per run. Newer runs
+cancel an older run for the same pull request to avoid duplicate feedback and review-round
+consumption.
 
-When `both` is selected, correctness and architecture start in parallel, so one workflow run has a
-natural maximum of two Codex review jobs. There is no repository-wide concurrency lock or
-cross-workflow maximum-N semaphore; GitHub Actions concurrency groups provide mutual exclusion, not
-a configurable shared capacity. Account or organization runner limits may still queue jobs.
+Each workflow run starts at most one Codex review job. There is no repository-wide concurrency lock;
+different pull requests can still be reviewed concurrently. Account or organization runner limits
+may still queue jobs.
 
 Never commit, log, upload as an artifact, or cache `auth.json`. For fully automatic refresh, use the
 official trusted private-runner or external secret-manager pattern instead.

--- a/.github/workflows/ai-codex-review.yml
+++ b/.github/workflows/ai-codex-review.yml
@@ -4,12 +4,13 @@ on:
   workflow_call:
     inputs:
       auth_mode:
-        description: Authentication mode (api-key or subscription)
+        description: Preferred authentication mode (subscription or api-key)
         required: true
         type: string
       scope:
-        description: Review scope (correctness or architecture)
-        required: true
+        description: Retired dual-review caller compatibility; ignored by the combined reviewer
+        required: false
+        default: review
         type: string
       pull_request_number:
         required: true
@@ -71,7 +72,7 @@ jobs:
     runs-on: ubuntu-latest
     timeout-minutes: 30
     concurrency:
-      group: ${{ format('codex-{0}-review-{1}', inputs.scope, inputs.pull_request_number) }}
+      group: ${{ format('codex-review-{0}', inputs.pull_request_number) }}
       cancel-in-progress: true
     permissions:
       contents: read
@@ -82,13 +83,17 @@ jobs:
     steps:
       # Install before credentials are written or untrusted repository files are checked out.
       - name: Set up Node.js for subscription auth
+        id: setup_subscription_node
         if: ${{ inputs.auth_mode == 'subscription' }}
+        continue-on-error: true
         uses: actions/setup-node@53b83947a5a98c8d113130e565377fae1a50d02f # v6.3.0
         with:
           node-version: '24'
 
       - name: Install Codex CLI for subscription auth
+        id: install_subscription_cli
         if: ${{ inputs.auth_mode == 'subscription' }}
+        continue-on-error: true
         env:
           CODEX_VERSION: 0.144.6
         shell: bash
@@ -102,10 +107,10 @@ jobs:
         env:
           CODEX_AUTH_JSON: ${{ inputs.auth_mode == 'subscription' && secrets.CODEX_AUTH_JSON || '' }}
           CODEX_AUTH_MODE: ${{ inputs.auth_mode }}
-          CODEX_BASE_URL: ${{ inputs.auth_mode == 'api-key' && secrets.CODEX_BASE_URL || '' }}
-          IS_FORK: ${{ inputs.is_fork }}
-          OPENAI_API_KEY: ${{ inputs.auth_mode == 'api-key' && secrets.OPENAI_API_KEY || '' }}
-          REVIEW_EVENT: ${{ inputs.review_event }}
+          CODEX_BASE_URL: ${{ secrets.CODEX_BASE_URL }}
+          CODEX_INSTALL_OUTCOME: ${{ steps.install_subscription_cli.outcome || 'skipped' }}
+          CODEX_MODEL: ${{ inputs.model }}
+          OPENAI_API_KEY: ${{ secrets.OPENAI_API_KEY }}
         shell: bash
         run: |
           set -euo pipefail
@@ -114,6 +119,85 @@ jobs:
           mkdir -p "$codex_home"
           chmod 700 "$codex_home"
           case "$CODEX_AUTH_MODE" in
+            api-key|subscription) ;;
+            *)
+              echo "Authentication mode must be api-key or subscription." >&2
+              exit 1
+              ;;
+          esac
+
+          effective_auth_mode="$CODEX_AUTH_MODE"
+          if [[ "$effective_auth_mode" == "subscription" &&
+            "$CODEX_INSTALL_OUTCOME" != "success" ]]; then
+            echo "::warning::Pinned Codex CLI setup failed; falling back to API-key auth."
+            effective_auth_mode=api-key
+          fi
+
+          if [[ "$effective_auth_mode" == "subscription" ]] &&
+            { [[ -z "$CODEX_AUTH_JSON" ]] || ! jq -e '
+                .auth_mode == "chatgpt" and
+                (.tokens | type == "object") and
+                ((.tokens.refresh_token // "") | length > 0)
+              ' <<< "$CODEX_AUTH_JSON" > /dev/null 2>&1; }; then
+            echo "::warning::Codex subscription credentials are unavailable; falling back to API-key auth."
+            effective_auth_mode=api-key
+          fi
+
+          if [[ "$effective_auth_mode" == "subscription" ]]; then
+            auth_file="$codex_home/auth.json"
+            printf '%s' "$CODEX_AUTH_JSON" > "$auth_file"
+            chmod 600 "$auth_file"
+
+            preflight_dir="$RUNNER_TEMP/codex-auth-preflight"
+            preflight_output="$RUNNER_TEMP/codex-auth-preflight.jsonl"
+            preflight_error="$RUNNER_TEMP/codex-auth-preflight.stderr"
+            mkdir -p "$preflight_dir"
+            preflight_key="$(jq -Rn --arg path "$preflight_dir" '$path')"
+            preflight_home_key="$(jq -Rn --arg path "$codex_home" '$path')"
+            {
+              echo 'default_permissions = "ai_review"'
+              echo 'project_doc_max_bytes = 0'
+              echo
+              printf '[projects.%s]\n' "$preflight_key"
+              echo 'trust_level = "untrusted"'
+              echo
+              echo '[permissions.ai_review]'
+              echo 'description = "Read-only auth preflight with credential isolation."'
+              echo 'extends = ":read-only"'
+              echo
+              echo '[permissions.ai_review.filesystem]'
+              printf '%s = "deny"\n' "$preflight_home_key"
+            } > "$codex_home/config.toml"
+            chmod 600 "$codex_home/config.toml"
+
+            set +e
+            printf '%s\n' 'Reply with exactly OK. Do not call tools.' | \
+              CODEX_HOME="$codex_home" codex exec \
+              --strict-config \
+              --skip-git-repo-check \
+              --cd "$preflight_dir" \
+              --model "$CODEX_MODEL" \
+              --config 'model_reasoning_effort="low"' \
+              --config 'default_permissions="ai_review"' \
+              --ephemeral \
+              --ignore-rules \
+              --json \
+              > "$preflight_output" \
+              2> "$preflight_error"
+            preflight_status=$?
+            set -e
+
+            if (( preflight_status != 0 )) ||
+              ! jq -s -e 'any(.[]; .type == "turn.completed")' \
+                "$preflight_output" > /dev/null 2>&1; then
+              echo "::warning::Codex subscription authentication failed; falling back to API-key auth."
+              effective_auth_mode=api-key
+              rm -f "$auth_file"
+            fi
+            rm -f "$preflight_output" "$preflight_error"
+          fi
+
+          case "$effective_auth_mode" in
             api-key)
               if [[ -z "$OPENAI_API_KEY" ]]; then
                 echo "Repository secret OPENAI_API_KEY is required for API-key auth." >&2
@@ -126,34 +210,7 @@ jobs:
               permission_profile=':read-only'
               ;;
             subscription)
-              if [[ "$REVIEW_EVENT" != "workflow_dispatch" ]]; then
-                echo "Codex subscription auth is limited to manual workflow_dispatch reviews." >&2
-                exit 1
-              fi
-              if [[ "$IS_FORK" == "true" ]]; then
-                echo "Codex subscription auth is limited to same-repository pull requests." >&2
-                exit 1
-              fi
-              auth_file="$codex_home/auth.json"
-              if [[ -z "$CODEX_AUTH_JSON" ]]; then
-                echo "CODEX_AUTH_JSON is required for subscription auth." >&2
-                exit 1
-              fi
-              printf '%s' "$CODEX_AUTH_JSON" > "$auth_file"
-              if ! jq -e '
-                .auth_mode == "chatgpt" and
-                (.tokens | type == "object") and
-                ((.tokens.refresh_token // "") | length > 0)
-              ' "$auth_file" > /dev/null; then
-                echo "Codex subscription auth must be a valid chatgpt auth.json with a refresh token." >&2
-                exit 1
-              fi
-              chmod 600 "$auth_file"
               permission_profile='ai_review'
-              ;;
-            *)
-              echo "Authentication mode must be api-key or subscription." >&2
-              exit 1
               ;;
           esac
 
@@ -165,7 +222,7 @@ jobs:
             echo
             printf '[projects.%s]\n' "$workspace_key"
             echo 'trust_level = "untrusted"'
-            if [[ "$CODEX_AUTH_MODE" == "subscription" ]]; then
+            if [[ "$effective_auth_mode" == "subscription" ]]; then
               echo
               echo '[permissions.ai_review]'
               echo 'description = "Read-only PR review with credential isolation."'
@@ -177,7 +234,7 @@ jobs:
           } > "$codex_home/config.toml"
           chmod 600 "$codex_home/config.toml"
           {
-            echo "auth_mode=$CODEX_AUTH_MODE"
+            echo "auth_mode=$effective_auth_mode"
             echo "codex_home=$codex_home"
           } >> "$GITHUB_OUTPUT"
 
@@ -208,7 +265,7 @@ jobs:
 
       - name: Resolve Responses API endpoint
         id: responses_endpoint
-        if: ${{ inputs.auth_mode == 'api-key' }}
+        if: ${{ steps.codex_auth.outputs.auth_mode == 'api-key' }}
         env:
           CODEX_BASE_URL: ${{ secrets.CODEX_BASE_URL }}
         shell: bash
@@ -230,49 +287,32 @@ jobs:
           PR_BRANCH: ${{ inputs.head_ref }}
           PR_DIFF_BASE: ${{ steps.diff_base.outputs.sha }}
           PR_TITLE: ${{ inputs.pull_request_title }}
-          REVIEW_SCOPE: ${{ inputs.scope }}
           REVIEW_SHA: ${{ inputs.review_sha }}
         shell: bash
         run: |
           set -euo pipefail
-          instructions_file="$RUNNER_TEMP/codex-${REVIEW_SCOPE}-instructions.txt"
-          prompt_file="$RUNNER_TEMP/codex-${REVIEW_SCOPE}-prompt.txt"
-          schema_file="$RUNNER_TEMP/codex-${REVIEW_SCOPE}-schema.json"
-
-          case "$REVIEW_SCOPE" in
-            correctness)
-              review_header='## Codex Correctness Review'
-              branch_valid=false
-              if [[ "$PR_BRANCH" =~ ^(feat|fix|docs|style|refactor|perf|test|build|ci|chore|revert)/[a-z0-9]+(-[a-z0-9]+)*$ ]]; then
-                branch_valid=true
-              fi
-              title_valid="$(
-                jq -nr \
-                  --arg title "$PR_TITLE" \
-                  '$title | test("^(feat|fix|docs|style|refactor|perf|test|build|ci|chore|revert)\\([a-z][A-Za-z0-9-]*\\)!?: [a-z]")'
-              )"
-              {
-                echo 'Apply the repository standards in CONTRIBUTING.md and the surrounding code.'
-                echo 'A trusted precheck evaluated the untrusted pull request metadata against the'
-                echo '<type>/<short-description> branch rule and <type>(<scope>): <description> title'
-                echo 'rule. Report a project-standard finding when either result below is false.'
-                echo "Branch name valid: ${branch_valid}"
-                echo "Pull request title valid: ${title_valid}"
-              } > "$instructions_file"
-              ;;
-            architecture)
-              review_header='## Codex Architecture Review'
-              {
-                echo 'Apply the repository architecture and integration conventions in CONTRIBUTING.md'
-                echo 'and the surrounding code. Do not repeat branch or pull request title checks; the'
-                echo 'correctness reviewer owns repository metadata and general correctness.'
-              } > "$instructions_file"
-              ;;
-            *)
-              echo "Review scope must be correctness or architecture." >&2
-              exit 1
-              ;;
-          esac
+          instructions_file="$RUNNER_TEMP/codex-review-instructions.txt"
+          prompt_file="$RUNNER_TEMP/codex-review-prompt.txt"
+          schema_file="$RUNNER_TEMP/codex-review-schema.json"
+          review_header='## Codex Review'
+          branch_valid=false
+          if [[ "$PR_BRANCH" =~ ^(feat|fix|docs|style|refactor|perf|test|build|ci|chore|revert)/[a-z0-9]+(-[a-z0-9]+)*$ ]]; then
+            branch_valid=true
+          fi
+          title_valid="$(
+            jq -nr \
+              --arg title "$PR_TITLE" \
+              '$title | test("^(feat|fix|docs|style|refactor|perf|test|build|ci|chore|revert)\\([a-z][A-Za-z0-9-]*\\)!?: [a-z]")'
+          )"
+          {
+            echo 'Apply the repository standards, architecture, and integration conventions in'
+            echo 'CONTRIBUTING.md and the surrounding code.'
+            echo 'A trusted precheck evaluated the untrusted pull request metadata against the'
+            echo '<type>/<short-description> branch rule and <type>(<scope>): <description> title'
+            echo 'rule. Report a project-standard finding when either result below is false.'
+            echo "Branch name valid: ${branch_valid}"
+            echo "Pull request title valid: ${title_valid}"
+          } > "$instructions_file"
 
           {
             echo
@@ -296,14 +336,12 @@ jobs:
             echo "Start with \`git diff --stat <base> HEAD\` and \`git diff <base> HEAD\`, substituting the"
             echo 'base commit above, then inspect relevant files and callers as needed.'
             echo
-            if [[ "$REVIEW_SCOPE" == "correctness" ]]; then
-              echo 'Focus on actionable correctness, security, regression, and repository-standard defects.'
-            else
-              echo 'Focus exclusively on architecture and integration: responsibility placement;'
-              echo 'main/preload/renderer/shared boundaries; IPC ownership; state flow; lifecycle cleanup;'
-              echo 'coupling; compatibility; packaging; cross-platform behavior; and user-visible workflows.'
-              echo 'Report a line-level defect only when it has concrete architectural or integration impact.'
-            fi
+            echo 'Focus on actionable correctness, security, regression, repository-standard,'
+            echo 'architecture, and integration defects. For architecture and integration, inspect'
+            echo 'responsibility placement; main/preload/renderer/shared boundaries; IPC ownership;'
+            echo 'state flow; lifecycle cleanup; coupling; compatibility; packaging; cross-platform'
+            echo 'behavior; and user-visible workflows. Report a line-level defect only when it has'
+            echo 'concrete impact.'
             echo
             echo 'Return the review through the required JSON schema. Use "needs changes" exactly when'
             echo 'findings is non-empty, and "mergeable" exactly when findings is empty. Every finding'
@@ -357,7 +395,7 @@ jobs:
       # The API action enables these only when it receives an API key or prompt. Subscription mode
       # installs the CLI directly, so prepare the packaged Linux sandbox before `codex exec`.
       - name: Prepare GitHub-hosted sandbox for subscription auth
-        if: ${{ inputs.auth_mode == 'subscription' }}
+        if: ${{ steps.codex_auth.outputs.auth_mode == 'subscription' }}
         shell: bash
         run: |
           set -euo pipefail
@@ -374,10 +412,10 @@ jobs:
           fi
 
       - name: Prepare Codex review runtime
-        if: ${{ inputs.auth_mode == 'api-key' }}
+        if: ${{ steps.codex_auth.outputs.auth_mode == 'api-key' }}
         uses: openai/codex-action@52fe01ec70a42f454c9d2ebd47598f9fd6893d56 # v1
         with:
-          openai-api-key: ${{ inputs.auth_mode == 'api-key' && secrets.OPENAI_API_KEY || '' }}
+          openai-api-key: ${{ steps.codex_auth.outputs.auth_mode == 'api-key' && secrets.OPENAI_API_KEY || '' }}
           responses-api-endpoint: ${{ steps.responses_endpoint.outputs.url }}
           codex-home: ${{ steps.codex_auth.outputs.codex_home }}
           codex-version: 0.144.6
@@ -386,7 +424,7 @@ jobs:
       # The API action drops sudo itself. Apply the same boundary to the directly installed
       # subscription CLI before reviewing untrusted repository content.
       - name: Harden subscription review runtime
-        if: ${{ inputs.auth_mode == 'subscription' }}
+        if: ${{ steps.codex_auth.outputs.auth_mode == 'subscription' }}
         env:
           CODEX_HOME: ${{ steps.codex_auth.outputs.codex_home }}
         shell: bash
@@ -446,7 +484,7 @@ jobs:
           CODEX_HOME: ${{ steps.codex_auth.outputs.codex_home }}
           CODEX_INSTRUCTIONS_FILE: ${{ steps.review_inputs.outputs.instructions_file }}
           CODEX_MODEL: ${{ inputs.model }}
-          CODEX_PERMISSION_PROFILE: ${{ inputs.auth_mode == 'subscription' && 'ai_review' || ':read-only' }}
+          CODEX_PERMISSION_PROFILE: ${{ steps.codex_auth.outputs.auth_mode == 'subscription' && 'ai_review' || ':read-only' }}
           CODEX_PROMPT_FILE: ${{ steps.review_inputs.outputs.prompt_file }}
           CODEX_SCHEMA_FILE: ${{ steps.review_inputs.outputs.schema_file }}
           CODEX_INTERNAL_ORIGINATOR_OVERRIDE: codex_github_action
@@ -510,11 +548,10 @@ jobs:
           CODEX_MODEL: ${{ inputs.model }}
           DURATION_SECONDS: ${{ steps.run_codex.outputs.duration_seconds }}
           EXECUTION_FILE: ${{ runner.temp }}/codex-execution.jsonl
-          REVIEW_SCOPE: ${{ inputs.scope }}
         shell: bash
         run: |
           set -euo pipefail
-          summary_title="Codex ${REVIEW_SCOPE} review telemetry"
+          summary_title='Codex review telemetry'
           if [[ ! -s "$EXECUTION_FILE" ]]; then
             echo "::warning::${summary_title} is unavailable."
             printf '### %s\n\nTelemetry is unavailable.\n' "$summary_title" >> "$GITHUB_STEP_SUMMARY"

--- a/.github/workflows/ai-codex-review.yml
+++ b/.github/workflows/ai-codex-review.yml
@@ -148,12 +148,13 @@ jobs:
             printf '%s' "$CODEX_AUTH_JSON" > "$auth_file"
             chmod 600 "$auth_file"
 
-            preflight_dir="$RUNNER_TEMP/codex-auth-preflight"
+            preflight_dir="$(mktemp -d /tmp/codex-auth-preflight-work.XXXXXX)"
+            preflight_home="$(mktemp -d /tmp/codex-auth-preflight-home.XXXXXX)"
             preflight_output="$RUNNER_TEMP/codex-auth-preflight.jsonl"
             preflight_error="$RUNNER_TEMP/codex-auth-preflight.stderr"
-            mkdir -p "$preflight_dir"
             preflight_key="$(jq -Rn --arg path "$preflight_dir" '$path')"
-            preflight_home_key="$(jq -Rn --arg path "$codex_home" '$path')"
+            preflight_home_key="$(jq -Rn --arg path "$preflight_home" '$path')"
+            cp "$auth_file" "$preflight_home/auth.json"
             {
               echo 'default_permissions = "ai_review"'
               echo 'project_doc_max_bytes = 0'
@@ -167,32 +168,51 @@ jobs:
               echo
               echo '[permissions.ai_review.filesystem]'
               printf '%s = "deny"\n' "$preflight_home_key"
-            } > "$codex_home/config.toml"
-            chmod 600 "$codex_home/config.toml"
+            } > "$preflight_home/config.toml"
+            chmod 600 "$preflight_home/auth.json" "$preflight_home/config.toml"
 
-            set +e
-            printf '%s\n' 'Reply with exactly OK. Do not call tools.' | \
-              CODEX_HOME="$codex_home" codex exec \
-              --strict-config \
-              --skip-git-repo-check \
-              --cd "$preflight_dir" \
-              --model "$CODEX_MODEL" \
-              --config 'model_reasoning_effort="low"' \
-              --config 'default_permissions="ai_review"' \
-              --ephemeral \
-              --ignore-rules \
-              --json \
-              > "$preflight_output" \
-              2> "$preflight_error"
-            preflight_status=$?
-            set -e
+            if preflight_uid="$(id -u nobody 2> /dev/null)" &&
+              preflight_gid="$(id -g nobody 2> /dev/null)" &&
+              sudo chown -R "$preflight_uid:$preflight_gid" "$preflight_home" "$preflight_dir"; then
+              set +e
+              # Redirect as the runner so the unprivileged process cannot rewrite status files.
+              # shellcheck disable=SC2024
+              printf '%s\n' 'Reply with exactly OK. Do not call tools.' | \
+                sudo -u nobody -- env -i \
+                PATH="$PATH" \
+                HOME="$preflight_home" \
+                CODEX_HOME="$preflight_home" \
+                codex exec \
+                --strict-config \
+                --skip-git-repo-check \
+                --cd "$preflight_dir" \
+                --model "$CODEX_MODEL" \
+                --config 'model_reasoning_effort="low"' \
+                --config 'default_permissions="ai_review"' \
+                --ephemeral \
+                --ignore-rules \
+                --json \
+                > "$preflight_output" \
+                2> "$preflight_error"
+              preflight_status=$?
+              set -e
 
-            if (( preflight_status != 0 )) ||
-              ! jq -s -e 'any(.[]; .type == "turn.completed")' \
-                "$preflight_output" > /dev/null 2>&1; then
-              echo "::warning::Codex subscription authentication failed; falling back to API-key auth."
+              if (( preflight_status == 0 )) &&
+                jq -s -e 'any(.[]; .type == "turn.completed")' \
+                  "$preflight_output" > /dev/null 2>&1 &&
+                sudo cp -- "$preflight_home/auth.json" "$auth_file"; then
+                chmod 600 "$auth_file"
+              else
+                echo "::warning::Codex subscription authentication failed; falling back to API-key auth."
+                effective_auth_mode=api-key
+                rm -f "$auth_file"
+              fi
+              sudo rm -rf -- "$preflight_home" "$preflight_dir"
+            else
+              echo "::warning::Codex subscription preflight isolation failed; falling back to API-key auth."
               effective_auth_mode=api-key
               rm -f "$auth_file"
+              rm -rf -- "$preflight_home" "$preflight_dir" 2> /dev/null || true
             fi
             rm -f "$preflight_output" "$preflight_error"
           fi

--- a/.github/workflows/ai-codex-review.yml
+++ b/.github/workflows/ai-codex-review.yml
@@ -102,6 +102,27 @@ jobs:
           npm install -g "@openai/codex@${CODEX_VERSION}"
           codex --version
 
+      # The API action enables these only when it receives an API key or prompt. Subscription mode
+      # installs the CLI directly, so prepare the packaged Linux sandbox before the auth preflight.
+      - name: Prepare GitHub-hosted sandbox for subscription auth
+        id: prepare_subscription_sandbox
+        if: ${{ inputs.auth_mode == 'subscription' }}
+        continue-on-error: true
+        shell: bash
+        run: |
+          set -euo pipefail
+          current_userns="$(sysctl -n kernel.unprivileged_userns_clone 2>/dev/null || true)"
+          if [[ -n "$current_userns" && "$current_userns" != "1" ]]; then
+            sudo sysctl -w kernel.unprivileged_userns_clone=1
+          fi
+
+          current_apparmor="$(
+            sysctl -n kernel.apparmor_restrict_unprivileged_userns 2>/dev/null || true
+          )"
+          if [[ -n "$current_apparmor" && "$current_apparmor" != "0" ]]; then
+            sudo sysctl -w kernel.apparmor_restrict_unprivileged_userns=0
+          fi
+
       - name: Prepare Codex authentication
         id: codex_auth
         env:
@@ -110,6 +131,7 @@ jobs:
           CODEX_BASE_URL: ${{ secrets.CODEX_BASE_URL }}
           CODEX_INSTALL_OUTCOME: ${{ steps.install_subscription_cli.outcome || 'skipped' }}
           CODEX_MODEL: ${{ inputs.model }}
+          CODEX_SANDBOX_OUTCOME: ${{ steps.prepare_subscription_sandbox.outcome || 'skipped' }}
           OPENAI_API_KEY: ${{ secrets.OPENAI_API_KEY }}
         shell: bash
         run: |
@@ -130,6 +152,12 @@ jobs:
           if [[ "$effective_auth_mode" == "subscription" &&
             "$CODEX_INSTALL_OUTCOME" != "success" ]]; then
             echo "::warning::Pinned Codex CLI setup failed; falling back to API-key auth."
+            effective_auth_mode=api-key
+          fi
+
+          if [[ "$effective_auth_mode" == "subscription" &&
+            "$CODEX_SANDBOX_OUTCOME" != "success" ]]; then
+            echo "::warning::Codex sandbox setup failed; falling back to API-key auth."
             effective_auth_mode=api-key
           fi
 
@@ -154,6 +182,8 @@ jobs:
             preflight_error="$RUNNER_TEMP/codex-auth-preflight.stderr"
             preflight_key="$(jq -Rn --arg path "$preflight_dir" '$path')"
             preflight_home_key="$(jq -Rn --arg path "$preflight_home" '$path')"
+            preflight_sentinel="$preflight_dir/sandbox-readable"
+            printf '%s\n' 'sandbox-ready' > "$preflight_sentinel"
             cp "$auth_file" "$preflight_home/auth.json"
             {
               echo 'default_permissions = "ai_review"'
@@ -175,37 +205,60 @@ jobs:
               preflight_gid="$(id -g nobody 2> /dev/null)" &&
               sudo chown -R "$preflight_uid:$preflight_gid" "$preflight_home" "$preflight_dir"; then
               set +e
-              # Redirect as the runner so the unprivileged process cannot rewrite status files.
-              # shellcheck disable=SC2024
-              printf '%s\n' 'Reply with exactly OK. Do not call tools.' | \
-                sudo -u nobody -- env -i \
+              sudo -u nobody -- env -i \
                 PATH="$PATH" \
                 HOME="$preflight_home" \
                 CODEX_HOME="$preflight_home" \
-                codex exec \
-                --strict-config \
-                --skip-git-repo-check \
-                --cd "$preflight_dir" \
-                --model "$CODEX_MODEL" \
-                --config 'model_reasoning_effort="low"' \
-                --config 'default_permissions="ai_review"' \
-                --ephemeral \
-                --ignore-rules \
-                --json \
-                > "$preflight_output" \
-                2> "$preflight_error"
-              preflight_status=$?
+                codex sandbox --permission-profile ai_review -C "$preflight_dir" -- \
+                test -r "$preflight_home/auth.json"
+              credential_probe_status=$?
+              sudo -u nobody -- env -i \
+                PATH="$PATH" \
+                HOME="$preflight_home" \
+                CODEX_HOME="$preflight_home" \
+                codex sandbox --permission-profile ai_review -C "$preflight_dir" -- \
+                test -r "$preflight_sentinel"
+              readable_probe_status=$?
               set -e
 
-              if (( preflight_status == 0 )) &&
-                jq -s -e 'any(.[]; .type == "turn.completed")' \
-                  "$preflight_output" > /dev/null 2>&1 &&
-                sudo cp -- "$preflight_home/auth.json" "$auth_file"; then
-                chmod 600 "$auth_file"
-              else
-                echo "::warning::Codex subscription authentication failed; falling back to API-key auth."
+              if (( credential_probe_status == 0 || readable_probe_status != 0 )); then
+                echo "::warning::Codex subscription sandbox probes failed; falling back to API-key auth."
                 effective_auth_mode=api-key
                 rm -f "$auth_file"
+              else
+                set +e
+                # Redirect as the runner so the unprivileged process cannot rewrite status files.
+                # shellcheck disable=SC2024
+                printf '%s\n' 'Reply with exactly OK. Do not call tools.' | \
+                sudo -u nobody -- env -i \
+                  PATH="$PATH" \
+                  HOME="$preflight_home" \
+                  CODEX_HOME="$preflight_home" \
+                  codex exec \
+                  --strict-config \
+                  --skip-git-repo-check \
+                  --cd "$preflight_dir" \
+                  --model "$CODEX_MODEL" \
+                  --config 'model_reasoning_effort="low"' \
+                  --config 'default_permissions="ai_review"' \
+                  --ephemeral \
+                  --ignore-rules \
+                  --json \
+                  > "$preflight_output" \
+                  2> "$preflight_error"
+                preflight_status=$?
+                set -e
+
+                if (( preflight_status == 0 )) &&
+                  jq -s -e 'any(.[]; .type == "turn.completed")' \
+                    "$preflight_output" > /dev/null 2>&1 &&
+                  sudo cp -- "$preflight_home/auth.json" "$auth_file"; then
+                  chmod 600 "$auth_file"
+                else
+                  echo "::warning::Codex subscription authentication failed; falling back to API-key auth."
+                  effective_auth_mode=api-key
+                  rm -f "$auth_file"
+                fi
               fi
               sudo rm -rf -- "$preflight_home" "$preflight_dir"
             else
@@ -411,25 +464,6 @@ jobs:
             echo "schema_file=$schema_file"
             echo "review_header=$review_header"
           } >> "$GITHUB_OUTPUT"
-
-      # The API action enables these only when it receives an API key or prompt. Subscription mode
-      # installs the CLI directly, so prepare the packaged Linux sandbox before `codex exec`.
-      - name: Prepare GitHub-hosted sandbox for subscription auth
-        if: ${{ steps.codex_auth.outputs.auth_mode == 'subscription' }}
-        shell: bash
-        run: |
-          set -euo pipefail
-          current_userns="$(sysctl -n kernel.unprivileged_userns_clone 2>/dev/null || true)"
-          if [[ -n "$current_userns" && "$current_userns" != "1" ]]; then
-            sudo sysctl -w kernel.unprivileged_userns_clone=1
-          fi
-
-          current_apparmor="$(
-            sysctl -n kernel.apparmor_restrict_unprivileged_userns 2>/dev/null || true
-          )"
-          if [[ -n "$current_apparmor" && "$current_apparmor" != "0" ]]; then
-            sudo sysctl -w kernel.apparmor_restrict_unprivileged_userns=0
-          fi
 
       - name: Prepare Codex review runtime
         if: ${{ steps.codex_auth.outputs.auth_mode == 'api-key' }}

--- a/.github/workflows/ai-review-labels.yml
+++ b/.github/workflows/ai-review-labels.yml
@@ -1,7 +1,8 @@
 name: AI Review Labels
 
 # Type and stale-label operations run from the base branch with a write-capable token. Review
-# outcome labels are applied by the final job in ai-review.yml from that run's published outputs.
+# outcome labels are applied by the final job in ai-review-single.yml from that run's published
+# output.
 on:
   pull_request_target:
     branches:

--- a/.github/workflows/ai-review-single.yml
+++ b/.github/workflows/ai-review-single.yml
@@ -5,7 +5,7 @@ name: AI PR Review (Single)
 # and their security boundaries.
 # - Shared API secrets: OPENAI_API_KEY and CODEX_BASE_URL
 # - Review-specific secrets: CODEX_REVIEW_API_KEY and CODEX_REVIEW_BASE_URL
-# - Legacy fallback secrets: correctness-specific and then architecture-specific API keys/base URLs
+# - Legacy fallback secrets: complete correctness-specific and then architecture-specific key/URL pairs
 #   (base URLs may omit the trailing slash or include the full /v1/responses endpoint)
 # - Subscription bootstrap secret: CODEX_AUTH_JSON
 # Set CODEX_REVIEW_AUTH_MODE to subscription (default) or api-key. Automatic and manually
@@ -14,8 +14,8 @@ name: AI PR Review (Single)
 # checkout and review execution.
 # Set ENABLE_CODEX_REVIEW=false to disable the automated reviewer.
 # Legacy CODEX_REVIEW_MODE=disabled keeps automatic reviews disabled while preserving dispatch.
-# CODEX_REVIEW_MODEL and CODEX_REVIEW_EFFORT select its model and effort. Legacy correctness and
-# architecture variables remain ordered fallbacks so existing repository configuration keeps working.
+# CODEX_REVIEW_MODEL and CODEX_REVIEW_EFFORT select its model and effort. A selected legacy
+# credential pair uses model/effort from the same scope; shared credentials keep ordered fallbacks.
 # Set FORK_REVIEW_MODE to disabled, manual, or automatic (default: manual). Same-repository PRs
 # always run. Manual mode permits workflow_dispatch reviews of forks; automatic mode also reviews
 # fork PRs on opened, synchronize, and reopened events. Disabled mode blocks both fork paths.
@@ -59,6 +59,7 @@ jobs:
       review_allowed: ${{ steps.target.outputs.review_allowed }}
       review_enabled: ${{ steps.target.outputs.review_enabled }}
       auth_mode: ${{ steps.target.outputs.auth_mode }}
+      credential_scope: ${{ steps.target.outputs.credential_scope }}
     steps:
       - name: Resolve pull request metadata
         id: target
@@ -71,6 +72,14 @@ jobs:
           CODEX_REVIEW_AUTH_MODE: ${{ vars.CODEX_REVIEW_AUTH_MODE || 'subscription' }}
           CODEX_REVIEW_MODE: ${{ vars.CODEX_REVIEW_MODE || 'correctness' }}
           ENABLE_CODEX_REVIEW: ${{ vars.ENABLE_CODEX_REVIEW || 'true' }}
+          REVIEW_API_KEY_CONFIGURED: ${{ secrets.CODEX_REVIEW_API_KEY != '' }}
+          REVIEW_BASE_URL_CONFIGURED: ${{ secrets.CODEX_REVIEW_BASE_URL != '' }}
+          CORRECTNESS_API_KEY_CONFIGURED: ${{ secrets.CODEX_CORRECTNESS_API_KEY != '' }}
+          CORRECTNESS_BASE_URL_CONFIGURED: ${{ secrets.CODEX_CORRECTNESS_BASE_URL != '' }}
+          ARCHITECTURE_API_KEY_CONFIGURED: ${{ secrets.CODEX_ARCHITECTURE_API_KEY != '' }}
+          ARCHITECTURE_BASE_URL_CONFIGURED: ${{ secrets.CODEX_ARCHITECTURE_BASE_URL != '' }}
+          SHARED_API_KEY_CONFIGURED: ${{ secrets.OPENAI_API_KEY != '' }}
+          SHARED_BASE_URL_CONFIGURED: ${{ secrets.CODEX_BASE_URL != '' }}
           REVIEW_EVENT: ${{ github.event_name }}
         shell: bash
         run: |
@@ -131,6 +140,20 @@ jobs:
             review_allowed=true
           fi
           effective_auth_mode="$CODEX_REVIEW_AUTH_MODE"
+          credential_scope=none
+          if [[ "$REVIEW_API_KEY_CONFIGURED" == "true" &&
+            "$REVIEW_BASE_URL_CONFIGURED" == "true" ]]; then
+            credential_scope=review
+          elif [[ "$CORRECTNESS_API_KEY_CONFIGURED" == "true" &&
+            "$CORRECTNESS_BASE_URL_CONFIGURED" == "true" ]]; then
+            credential_scope=correctness
+          elif [[ "$ARCHITECTURE_API_KEY_CONFIGURED" == "true" &&
+            "$ARCHITECTURE_BASE_URL_CONFIGURED" == "true" ]]; then
+            credential_scope=architecture
+          elif [[ "$SHARED_API_KEY_CONFIGURED" == "true" &&
+            "$SHARED_BASE_URL_CONFIGURED" == "true" ]]; then
+            credential_scope=shared
+          fi
 
           review_enabled="$ENABLE_CODEX_REVIEW"
           if [[ "$REVIEW_EVENT" != "workflow_dispatch" && "$CODEX_REVIEW_MODE" == "disabled" ]]; then
@@ -150,6 +173,7 @@ jobs:
             echo "review_allowed=$review_allowed"
             echo "review_enabled=$review_enabled"
             echo "auth_mode=$effective_auth_mode"
+            echo "credential_scope=$credential_scope"
           } >> "$GITHUB_OUTPUT"
 
   codex_review_gate:
@@ -225,12 +249,12 @@ jobs:
       pull_request_title: ${{ needs.review_target.outputs.title }}
       is_fork: ${{ needs.review_target.outputs.is_fork == 'true' }}
       fork_mode: ${{ needs.review_target.outputs.fork_mode }}
-      model: ${{ vars.CODEX_REVIEW_MODEL || vars.CODEX_CORRECTNESS_MODEL || vars.CODEX_ARCHITECTURE_MODEL || 'gpt-5.6-sol' }}
-      effort: ${{ vars.CODEX_REVIEW_EFFORT || vars.CODEX_CORRECTNESS_EFFORT || vars.CODEX_ARCHITECTURE_EFFORT || 'high' }}
+      model: ${{ vars.CODEX_REVIEW_MODEL || (needs.review_target.outputs.credential_scope == 'correctness' && vars.CODEX_CORRECTNESS_MODEL) || (needs.review_target.outputs.credential_scope == 'architecture' && vars.CODEX_ARCHITECTURE_MODEL) || ((needs.review_target.outputs.credential_scope == 'shared' || needs.review_target.outputs.credential_scope == 'none') && (vars.CODEX_CORRECTNESS_MODEL || vars.CODEX_ARCHITECTURE_MODEL)) || 'gpt-5.6-sol' }}
+      effort: ${{ vars.CODEX_REVIEW_EFFORT || (needs.review_target.outputs.credential_scope == 'correctness' && vars.CODEX_CORRECTNESS_EFFORT) || (needs.review_target.outputs.credential_scope == 'architecture' && vars.CODEX_ARCHITECTURE_EFFORT) || ((needs.review_target.outputs.credential_scope == 'shared' || needs.review_target.outputs.credential_scope == 'none') && (vars.CODEX_CORRECTNESS_EFFORT || vars.CODEX_ARCHITECTURE_EFFORT)) || 'high' }}
     secrets:
       CODEX_AUTH_JSON: ${{ needs.review_target.outputs.auth_mode == 'subscription' && secrets.CODEX_AUTH_JSON || '' }}
-      OPENAI_API_KEY: ${{ secrets.CODEX_REVIEW_API_KEY || secrets.CODEX_CORRECTNESS_API_KEY || secrets.CODEX_ARCHITECTURE_API_KEY || secrets.OPENAI_API_KEY }}
-      CODEX_BASE_URL: ${{ secrets.CODEX_REVIEW_BASE_URL || secrets.CODEX_CORRECTNESS_BASE_URL || secrets.CODEX_ARCHITECTURE_BASE_URL || secrets.CODEX_BASE_URL }}
+      OPENAI_API_KEY: ${{ (needs.review_target.outputs.credential_scope == 'review' && secrets.CODEX_REVIEW_API_KEY) || (needs.review_target.outputs.credential_scope == 'correctness' && secrets.CODEX_CORRECTNESS_API_KEY) || (needs.review_target.outputs.credential_scope == 'architecture' && secrets.CODEX_ARCHITECTURE_API_KEY) || (needs.review_target.outputs.credential_scope == 'shared' && secrets.OPENAI_API_KEY) || '' }}
+      CODEX_BASE_URL: ${{ (needs.review_target.outputs.credential_scope == 'review' && secrets.CODEX_REVIEW_BASE_URL) || (needs.review_target.outputs.credential_scope == 'correctness' && secrets.CODEX_CORRECTNESS_BASE_URL) || (needs.review_target.outputs.credential_scope == 'architecture' && secrets.CODEX_ARCHITECTURE_BASE_URL) || (needs.review_target.outputs.credential_scope == 'shared' && secrets.CODEX_BASE_URL) || '' }}
 
   post_codex_feedback:
     name: Post Codex feedback

--- a/.github/workflows/ai-review-single.yml
+++ b/.github/workflows/ai-review-single.yml
@@ -13,8 +13,8 @@ name: AI PR Review (Single)
 # and subscription CLI setup failures fall back to the configured API-key credentials before
 # checkout and review execution.
 # Set ENABLE_CODEX_REVIEW=false to disable the automated reviewer.
-# CODEX_REVIEW_MODEL and CODEX_REVIEW_EFFORT select its model and effort. Legacy correctness model
-# and effort variables remain fallbacks so existing repository configuration keeps working.
+# CODEX_REVIEW_MODEL and CODEX_REVIEW_EFFORT select its model and effort. Legacy correctness and
+# architecture variables remain ordered fallbacks so existing repository configuration keeps working.
 # Set FORK_REVIEW_MODE to disabled, manual, or automatic (default: manual). Same-repository PRs
 # always run. Manual mode permits workflow_dispatch reviews of forks; automatic mode also reviews
 # fork PRs on opened, synchronize, and reopened events. Disabled mode blocks both fork paths.
@@ -213,8 +213,8 @@ jobs:
       pull_request_title: ${{ needs.review_target.outputs.title }}
       is_fork: ${{ needs.review_target.outputs.is_fork == 'true' }}
       fork_mode: ${{ needs.review_target.outputs.fork_mode }}
-      model: ${{ vars.CODEX_REVIEW_MODEL || vars.CODEX_CORRECTNESS_MODEL || 'gpt-5.6-sol' }}
-      effort: ${{ vars.CODEX_REVIEW_EFFORT || vars.CODEX_CORRECTNESS_EFFORT || 'high' }}
+      model: ${{ vars.CODEX_REVIEW_MODEL || vars.CODEX_CORRECTNESS_MODEL || vars.CODEX_ARCHITECTURE_MODEL || 'gpt-5.6-sol' }}
+      effort: ${{ vars.CODEX_REVIEW_EFFORT || vars.CODEX_CORRECTNESS_EFFORT || vars.CODEX_ARCHITECTURE_EFFORT || 'high' }}
     secrets:
       CODEX_AUTH_JSON: ${{ needs.review_target.outputs.auth_mode == 'subscription' && secrets.CODEX_AUTH_JSON || '' }}
       OPENAI_API_KEY: ${{ secrets.CODEX_REVIEW_API_KEY || secrets.CODEX_CORRECTNESS_API_KEY || secrets.OPENAI_API_KEY }}

--- a/.github/workflows/ai-review-single.yml
+++ b/.github/workflows/ai-review-single.yml
@@ -1,0 +1,365 @@
+name: AI PR Review (Single)
+
+# Authentication defaults to Codex subscription auth for every allowed review. See
+# .github/action/ai-review.md for the supported subscription and API-key fallback configurations
+# and their security boundaries.
+# - Shared API secrets: OPENAI_API_KEY and CODEX_BASE_URL
+# - Review-specific secrets: CODEX_REVIEW_API_KEY and CODEX_REVIEW_BASE_URL
+# - Legacy fallback secrets: CODEX_CORRECTNESS_API_KEY and CODEX_CORRECTNESS_BASE_URL
+#   (base URLs may omit the trailing slash or include the full /v1/responses endpoint)
+# - Subscription bootstrap secret: CODEX_AUTH_JSON
+# Set CODEX_REVIEW_AUTH_MODE to subscription (default) or api-key. Automatic and manually
+# dispatched reviews honor this preference. Missing, invalid, or rejected subscription credentials
+# and subscription CLI setup failures fall back to the configured API-key credentials before
+# checkout and review execution.
+# Set ENABLE_CODEX_REVIEW=false to disable the automated reviewer.
+# CODEX_REVIEW_MODEL and CODEX_REVIEW_EFFORT select its model and effort. Legacy correctness model
+# and effort variables remain fallbacks so existing repository configuration keeps working.
+# Set FORK_REVIEW_MODE to disabled, manual, or automatic (default: manual). Same-repository PRs
+# always run. Manual mode permits workflow_dispatch reviews of forks; automatic mode also reviews
+# fork PRs on opened, synchronize, and reopened events. Disabled mode blocks both fork paths.
+# Set CODEX_REVIEW_MAX_ROUNDS to the maximum successful comments per PR (default: 20,
+# 0 means unlimited). Rapid updates use concurrency cancellation so only the latest surviving run
+# publishes a review and consumes a round.
+#
+# The reviewer does not post comments directly. It writes one schema-validated verdict covering
+# correctness and architecture to a job output, and a separate trusted workflow publishes it.
+on:
+  pull_request_target:
+    branches:
+      - main
+    types: [opened, synchronize, reopened]
+  workflow_dispatch:
+    inputs:
+      pull_request_number:
+        description: Pull request number to review
+        required: true
+
+concurrency:
+  group: ai-pr-review-${{ github.event.inputs.pull_request_number || github.event.pull_request.number }}
+  cancel-in-progress: true
+
+jobs:
+  review_target:
+    name: Resolve AI review target
+    runs-on: ubuntu-latest
+    permissions:
+      pull-requests: read
+    outputs:
+      number: ${{ steps.target.outputs.number }}
+      head_ref: ${{ steps.target.outputs.head_ref }}
+      head_sha: ${{ steps.target.outputs.head_sha }}
+      base_sha: ${{ steps.target.outputs.base_sha }}
+      review_sha: ${{ steps.target.outputs.review_sha }}
+      state: ${{ steps.target.outputs.state }}
+      title: ${{ steps.target.outputs.title }}
+      is_fork: ${{ steps.target.outputs.is_fork }}
+      fork_mode: ${{ steps.target.outputs.fork_mode }}
+      review_allowed: ${{ steps.target.outputs.review_allowed }}
+      review_enabled: ${{ steps.target.outputs.review_enabled }}
+      auth_mode: ${{ steps.target.outputs.auth_mode }}
+    steps:
+      - name: Resolve pull request metadata
+        id: target
+        env:
+          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+          GH_REPO: ${{ github.repository }}
+          DISPATCH_PR_NUMBER: ${{ github.event.inputs.pull_request_number }}
+          EVENT_PR_NUMBER: ${{ github.event.pull_request.number }}
+          FORK_REVIEW_MODE: ${{ vars.FORK_REVIEW_MODE || 'manual' }}
+          CODEX_REVIEW_AUTH_MODE: ${{ vars.CODEX_REVIEW_AUTH_MODE || 'subscription' }}
+          ENABLE_CODEX_REVIEW: ${{ vars.ENABLE_CODEX_REVIEW || 'true' }}
+          REVIEW_EVENT: ${{ github.event_name }}
+        shell: bash
+        run: |
+          set -euo pipefail
+          case "$FORK_REVIEW_MODE" in
+            disabled|manual|automatic) ;;
+            *)
+              echo "FORK_REVIEW_MODE must be disabled, manual, or automatic." >&2
+              exit 1
+              ;;
+          esac
+          case "$ENABLE_CODEX_REVIEW" in
+            true|false) ;;
+            *)
+              echo "ENABLE_CODEX_REVIEW must be true or false." >&2
+              exit 1
+              ;;
+          esac
+          case "$CODEX_REVIEW_AUTH_MODE" in
+            api-key|subscription) ;;
+            *)
+              echo "CODEX_REVIEW_AUTH_MODE must be api-key or subscription." >&2
+              exit 1
+              ;;
+          esac
+          pr_number="${DISPATCH_PR_NUMBER:-$EVENT_PR_NUMBER}"
+          if [[ -z "$pr_number" ]]; then
+            echo "No pull request number available (workflow_dispatch input or pull_request event)." >&2
+            exit 1
+          fi
+
+          gh pr view "$pr_number" --repo "$GH_REPO" \
+            --json number,headRefName,headRefOid,baseRefOid,title,isCrossRepository,state,mergeCommit \
+            > pr.json
+          state="$(jq -r '.state' pr.json)"
+          head_sha="$(jq -r '.headRefOid' pr.json)"
+          review_sha="$head_sha"
+          if [[ "$state" == "MERGED" ]]; then
+            review_sha="$(jq -r '.mergeCommit.oid // empty' pr.json)"
+            if [[ -z "$review_sha" ]]; then
+              echo "Merged pull request has no merge commit OID." >&2
+              exit 1
+            fi
+          fi
+
+          is_fork="$(jq -r '.isCrossRepository' pr.json)"
+          review_allowed=false
+          if [[ "$is_fork" != "true" ]] ||
+            [[ "$REVIEW_EVENT" == "workflow_dispatch" && "$FORK_REVIEW_MODE" != "disabled" ]] ||
+            [[ "$REVIEW_EVENT" != "workflow_dispatch" && "$FORK_REVIEW_MODE" == "automatic" ]]; then
+            review_allowed=true
+          fi
+          effective_auth_mode="$CODEX_REVIEW_AUTH_MODE"
+
+          review_enabled="$ENABLE_CODEX_REVIEW"
+
+          {
+            echo "number=$(jq -r '.number' pr.json)"
+            echo "head_ref=$(jq -r '.headRefName' pr.json)"
+            echo "head_sha=$head_sha"
+            echo "base_sha=$(jq -r '.baseRefOid' pr.json)"
+            echo "review_sha=$review_sha"
+            echo "state=$state"
+            echo "title=$(jq -r '.title' pr.json)"
+            echo "is_fork=$is_fork"
+            echo "fork_mode=$FORK_REVIEW_MODE"
+            echo "review_allowed=$review_allowed"
+            echo "review_enabled=$review_enabled"
+            echo "auth_mode=$effective_auth_mode"
+          } >> "$GITHUB_OUTPUT"
+
+  codex_review_gate:
+    name: Check Codex review limits
+    needs: review_target
+    if: >-
+      ${{ needs.review_target.outputs.review_allowed == 'true' &&
+          needs.review_target.outputs.review_enabled == 'true' }}
+    runs-on: ubuntu-latest
+    permissions:
+      issues: read
+      pull-requests: read
+    outputs:
+      should_run: ${{ steps.gate.outputs.should_run }}
+    steps:
+      - name: Check Codex review counts
+        id: gate
+        env:
+          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+          GH_REPO: ${{ github.repository }}
+          PR_NUMBER: ${{ needs.review_target.outputs.number }}
+          CODEX_REVIEW_MAX_ROUNDS: ${{ vars.CODEX_REVIEW_MAX_ROUNDS || '20' }}
+        shell: bash
+        run: |
+          set -euo pipefail
+          max_reviews="$CODEX_REVIEW_MAX_ROUNDS"
+          if [[ ! "$max_reviews" =~ ^[0-9]+$ ]]; then
+            echo "CODEX_REVIEW_MAX_ROUNDS must be a non-negative integer." >&2
+            exit 1
+          fi
+
+          gh api --paginate --slurp \
+            "repos/${GH_REPO}/issues/${PR_NUMBER}/comments?per_page=100" > comments.json
+
+          review_count="$(
+            jq -r '
+              [.[][]
+                | select(.user.login == "github-actions[bot]")
+                | select((.body // "") | contains("<!-- ai-review:codex -->"))]
+              | length
+            ' comments.json
+          )"
+          round=$((review_count + 1))
+          if (( max_reviews > 0 && review_count >= max_reviews )); then
+            echo 'should_run=false' >> "$GITHUB_OUTPUT"
+            echo "- Codex review skipped: ${review_count} successful reviews already published (limit ${max_reviews})." \
+              >> "$GITHUB_STEP_SUMMARY"
+          else
+            echo 'should_run=true' >> "$GITHUB_OUTPUT"
+            if (( max_reviews == 0 )); then
+              echo "- Codex review round ${round} (unlimited)." >> "$GITHUB_STEP_SUMMARY"
+            else
+              echo "- Codex review round ${round} of ${max_reviews}." >> "$GITHUB_STEP_SUMMARY"
+            fi
+          fi
+
+  codex_review:
+    name: Review
+    needs: [review_target, codex_review_gate]
+    if: ${{ needs.codex_review_gate.outputs.should_run == 'true' }}
+    permissions:
+      contents: read
+    uses: ./.github/workflows/ai-codex-review.yml
+    with:
+      auth_mode: ${{ needs.review_target.outputs.auth_mode }}
+      pull_request_number: ${{ needs.review_target.outputs.number }}
+      head_ref: ${{ needs.review_target.outputs.head_ref }}
+      head_sha: ${{ needs.review_target.outputs.head_sha }}
+      base_sha: ${{ needs.review_target.outputs.base_sha }}
+      review_sha: ${{ needs.review_target.outputs.review_sha }}
+      review_state: ${{ needs.review_target.outputs.state }}
+      review_event: ${{ github.event_name }}
+      pull_request_title: ${{ needs.review_target.outputs.title }}
+      is_fork: ${{ needs.review_target.outputs.is_fork == 'true' }}
+      fork_mode: ${{ needs.review_target.outputs.fork_mode }}
+      model: ${{ vars.CODEX_REVIEW_MODEL || vars.CODEX_CORRECTNESS_MODEL || 'gpt-5.6-sol' }}
+      effort: ${{ vars.CODEX_REVIEW_EFFORT || vars.CODEX_CORRECTNESS_EFFORT || 'high' }}
+    secrets:
+      CODEX_AUTH_JSON: ${{ needs.review_target.outputs.auth_mode == 'subscription' && secrets.CODEX_AUTH_JSON || '' }}
+      OPENAI_API_KEY: ${{ secrets.CODEX_REVIEW_API_KEY || secrets.CODEX_CORRECTNESS_API_KEY || secrets.OPENAI_API_KEY }}
+      CODEX_BASE_URL: ${{ secrets.CODEX_REVIEW_BASE_URL || secrets.CODEX_CORRECTNESS_BASE_URL || secrets.CODEX_BASE_URL }}
+
+  post_codex_feedback:
+    name: Post Codex feedback
+    needs: codex_review
+    if: >-
+      ${{ needs.codex_review.result == 'success' &&
+          needs.codex_review.outputs.review_body != '' }}
+    uses: ./.github/workflows/ai-post-review.yml
+    permissions:
+      issues: write
+      pull-requests: write
+    with:
+      scope: review
+      marker: '<!-- ai-review:codex -->'
+      header: '## Codex Review'
+      review_body: ${{ needs.codex_review.outputs.review_body }}
+      pull_request_number: ${{ needs.codex_review.outputs.pr_number }}
+      head_sha: ${{ needs.codex_review.outputs.head_sha }}
+      max_rounds: ${{ vars.CODEX_REVIEW_MAX_ROUNDS || '20' }}
+
+  apply_review_outcome:
+    name: Apply review outcome label
+    if: ${{ always() && needs.review_target.result == 'success' }}
+    needs:
+      - review_target
+      - codex_review
+      - post_codex_feedback
+    runs-on: ubuntu-latest
+    permissions:
+      issues: write
+      pull-requests: write
+    steps:
+      - name: Apply ready-to-merge from published review outputs
+        uses: actions/github-script@v9
+        env:
+          PR_NUMBER: ${{ needs.review_target.outputs.number }}
+          REVIEW_HEAD_SHA: ${{ needs.review_target.outputs.head_sha }}
+          REVIEW_REQUIRED: ${{ needs.review_target.outputs.review_enabled }}
+          REVIEW_RESULT: ${{ needs.codex_review.result }}
+          REVIEW_POST_RESULT: ${{ needs.post_codex_feedback.result }}
+          REVIEW_POSTED: ${{ needs.post_codex_feedback.outputs.posted }}
+          REVIEW_BODY: ${{ needs.codex_review.outputs.review_body }}
+        with:
+          github-token: ${{ github.token }}
+          retries: 3
+          script: |
+            const issueNumber = Number(process.env.PR_NUMBER);
+            const reviewedHeadSha = process.env.REVIEW_HEAD_SHA;
+            const labelName = 'ready-to-merge';
+            const reviewers = [
+              {
+                name: 'Codex review',
+                header: '## Codex Review',
+                required: process.env.REVIEW_REQUIRED === 'true',
+                result: process.env.REVIEW_RESULT,
+                postResult: process.env.REVIEW_POST_RESULT,
+                posted: process.env.REVIEW_POSTED,
+                body: process.env.REVIEW_BODY,
+              },
+            ];
+
+            const removeReadyLabel = async () => {
+              try {
+                await github.rest.issues.removeLabel({
+                  owner: context.repo.owner,
+                  repo: context.repo.repo,
+                  issue_number: issueNumber,
+                  name: labelName,
+                });
+              } catch (error) {
+                if (error.status !== 404) throw error;
+              }
+            };
+
+            const { data: pullRequest } = await github.rest.pulls.get({
+              owner: context.repo.owner,
+              repo: context.repo.repo,
+              pull_number: issueNumber,
+            });
+            if (pullRequest.state !== 'open') {
+              core.notice('Removing ready-to-merge because the pull request is not open.');
+              await removeReadyLabel();
+              return;
+            }
+            if (!reviewedHeadSha || pullRequest.head.sha !== reviewedHeadSha) {
+              core.notice('Skipping labels because a newer pull request commit exists.');
+              return;
+            }
+
+            const active = reviewers.filter(({ required }) => required);
+            if (active.length === 0) {
+              core.warning('No AI reviewer ran; removing ready-to-merge.');
+              await removeReadyLabel();
+              return;
+            }
+
+            const unpublished = active.filter(
+              ({ result, postResult, posted }) =>
+                result !== 'success' || postResult !== 'success' || posted !== 'true',
+            );
+            if (unpublished.length > 0) {
+              const names = unpublished.map(({ name }) => name).join(', ');
+              core.warning(`Review output was not published for: ${names}; removing ${labelName}.`);
+              await removeReadyLabel();
+              return;
+            }
+
+            const verdicts = [];
+            for (const { name, header, body } of active) {
+              const matches = [...(body ?? '').matchAll(
+                /^\*\*Verdict:\s*(mergeable|needs changes)\*\*$/gm,
+              )];
+              if (!body?.startsWith(header) || matches.length !== 1) {
+                core.warning(`No unambiguous verdict output for "${name}"; removing ${labelName}.`);
+                await removeReadyLabel();
+                return;
+              }
+              verdicts.push(matches[0][1]);
+            }
+
+            if (verdicts.includes('needs changes')) {
+              core.notice('At least one reviewer requested changes; removing ready-to-merge.');
+              await removeReadyLabel();
+              return;
+            }
+
+            try {
+              await github.rest.issues.createLabel({
+                owner: context.repo.owner,
+                repo: context.repo.repo,
+                name: labelName,
+                color: '1f883d',
+                description: 'The completed AI reviewer found this pull request mergeable.',
+              });
+            } catch (error) {
+              if (error.status !== 422) throw error;
+            }
+
+            await github.rest.issues.addLabels({
+              owner: context.repo.owner,
+              repo: context.repo.repo,
+              issue_number: issueNumber,
+              labels: [labelName],
+            });

--- a/.github/workflows/ai-review-single.yml
+++ b/.github/workflows/ai-review-single.yml
@@ -5,7 +5,7 @@ name: AI PR Review (Single)
 # and their security boundaries.
 # - Shared API secrets: OPENAI_API_KEY and CODEX_BASE_URL
 # - Review-specific secrets: CODEX_REVIEW_API_KEY and CODEX_REVIEW_BASE_URL
-# - Legacy fallback secrets: CODEX_CORRECTNESS_API_KEY and CODEX_CORRECTNESS_BASE_URL
+# - Legacy fallback secrets: correctness-specific and then architecture-specific API keys/base URLs
 #   (base URLs may omit the trailing slash or include the full /v1/responses endpoint)
 # - Subscription bootstrap secret: CODEX_AUTH_JSON
 # Set CODEX_REVIEW_AUTH_MODE to subscription (default) or api-key. Automatic and manually
@@ -13,6 +13,7 @@ name: AI PR Review (Single)
 # and subscription CLI setup failures fall back to the configured API-key credentials before
 # checkout and review execution.
 # Set ENABLE_CODEX_REVIEW=false to disable the automated reviewer.
+# Legacy CODEX_REVIEW_MODE=disabled keeps automatic reviews disabled while preserving dispatch.
 # CODEX_REVIEW_MODEL and CODEX_REVIEW_EFFORT select its model and effort. Legacy correctness and
 # architecture variables remain ordered fallbacks so existing repository configuration keeps working.
 # Set FORK_REVIEW_MODE to disabled, manual, or automatic (default: manual). Same-repository PRs
@@ -68,6 +69,7 @@ jobs:
           EVENT_PR_NUMBER: ${{ github.event.pull_request.number }}
           FORK_REVIEW_MODE: ${{ vars.FORK_REVIEW_MODE || 'manual' }}
           CODEX_REVIEW_AUTH_MODE: ${{ vars.CODEX_REVIEW_AUTH_MODE || 'subscription' }}
+          CODEX_REVIEW_MODE: ${{ vars.CODEX_REVIEW_MODE || 'correctness' }}
           ENABLE_CODEX_REVIEW: ${{ vars.ENABLE_CODEX_REVIEW || 'true' }}
           REVIEW_EVENT: ${{ github.event_name }}
         shell: bash
@@ -91,6 +93,13 @@ jobs:
             api-key|subscription) ;;
             *)
               echo "CODEX_REVIEW_AUTH_MODE must be api-key or subscription." >&2
+              exit 1
+              ;;
+          esac
+          case "$CODEX_REVIEW_MODE" in
+            both|correctness|architecture|disabled) ;;
+            *)
+              echo "CODEX_REVIEW_MODE must be both, correctness, architecture, or disabled." >&2
               exit 1
               ;;
           esac
@@ -124,6 +133,9 @@ jobs:
           effective_auth_mode="$CODEX_REVIEW_AUTH_MODE"
 
           review_enabled="$ENABLE_CODEX_REVIEW"
+          if [[ "$REVIEW_EVENT" != "workflow_dispatch" && "$CODEX_REVIEW_MODE" == "disabled" ]]; then
+            review_enabled=false
+          fi
 
           {
             echo "number=$(jq -r '.number' pr.json)"
@@ -217,8 +229,8 @@ jobs:
       effort: ${{ vars.CODEX_REVIEW_EFFORT || vars.CODEX_CORRECTNESS_EFFORT || vars.CODEX_ARCHITECTURE_EFFORT || 'high' }}
     secrets:
       CODEX_AUTH_JSON: ${{ needs.review_target.outputs.auth_mode == 'subscription' && secrets.CODEX_AUTH_JSON || '' }}
-      OPENAI_API_KEY: ${{ secrets.CODEX_REVIEW_API_KEY || secrets.CODEX_CORRECTNESS_API_KEY || secrets.OPENAI_API_KEY }}
-      CODEX_BASE_URL: ${{ secrets.CODEX_REVIEW_BASE_URL || secrets.CODEX_CORRECTNESS_BASE_URL || secrets.CODEX_BASE_URL }}
+      OPENAI_API_KEY: ${{ secrets.CODEX_REVIEW_API_KEY || secrets.CODEX_CORRECTNESS_API_KEY || secrets.CODEX_ARCHITECTURE_API_KEY || secrets.OPENAI_API_KEY }}
+      CODEX_BASE_URL: ${{ secrets.CODEX_REVIEW_BASE_URL || secrets.CODEX_CORRECTNESS_BASE_URL || secrets.CODEX_ARCHITECTURE_BASE_URL || secrets.CODEX_BASE_URL }}
 
   post_codex_feedback:
     name: Post Codex feedback

--- a/.github/workflows/ai-review-single.yml
+++ b/.github/workflows/ai-review-single.yml
@@ -15,7 +15,7 @@ name: AI PR Review (Single)
 # Set ENABLE_CODEX_REVIEW=false to disable the automated reviewer.
 # Legacy CODEX_REVIEW_MODE=disabled keeps automatic reviews disabled while preserving dispatch.
 # CODEX_REVIEW_MODEL and CODEX_REVIEW_EFFORT select its model and effort. A selected legacy
-# credential pair uses model/effort from the same scope; shared credentials keep ordered fallbacks.
+# credential pair uses model/effort from the same scope; generic credentials keep ordered fallbacks.
 # Set FORK_REVIEW_MODE to disabled, manual, or automatic (default: manual). Same-repository PRs
 # always run. Manual mode permits workflow_dispatch reviews of forks; automatic mode also reviews
 # fork PRs on opened, synchronize, and reopened events. Disabled mode blocks both fork paths.
@@ -249,8 +249,8 @@ jobs:
       pull_request_title: ${{ needs.review_target.outputs.title }}
       is_fork: ${{ needs.review_target.outputs.is_fork == 'true' }}
       fork_mode: ${{ needs.review_target.outputs.fork_mode }}
-      model: ${{ vars.CODEX_REVIEW_MODEL || (needs.review_target.outputs.credential_scope == 'correctness' && vars.CODEX_CORRECTNESS_MODEL) || (needs.review_target.outputs.credential_scope == 'architecture' && vars.CODEX_ARCHITECTURE_MODEL) || ((needs.review_target.outputs.credential_scope == 'shared' || needs.review_target.outputs.credential_scope == 'none') && (vars.CODEX_CORRECTNESS_MODEL || vars.CODEX_ARCHITECTURE_MODEL)) || 'gpt-5.6-sol' }}
-      effort: ${{ vars.CODEX_REVIEW_EFFORT || (needs.review_target.outputs.credential_scope == 'correctness' && vars.CODEX_CORRECTNESS_EFFORT) || (needs.review_target.outputs.credential_scope == 'architecture' && vars.CODEX_ARCHITECTURE_EFFORT) || ((needs.review_target.outputs.credential_scope == 'shared' || needs.review_target.outputs.credential_scope == 'none') && (vars.CODEX_CORRECTNESS_EFFORT || vars.CODEX_ARCHITECTURE_EFFORT)) || 'high' }}
+      model: ${{ vars.CODEX_REVIEW_MODEL || (needs.review_target.outputs.credential_scope == 'correctness' && vars.CODEX_CORRECTNESS_MODEL) || (needs.review_target.outputs.credential_scope == 'architecture' && vars.CODEX_ARCHITECTURE_MODEL) || ((needs.review_target.outputs.credential_scope == 'review' || needs.review_target.outputs.credential_scope == 'shared' || needs.review_target.outputs.credential_scope == 'none') && (vars.CODEX_CORRECTNESS_MODEL || vars.CODEX_ARCHITECTURE_MODEL)) || 'gpt-5.6-sol' }}
+      effort: ${{ vars.CODEX_REVIEW_EFFORT || (needs.review_target.outputs.credential_scope == 'correctness' && vars.CODEX_CORRECTNESS_EFFORT) || (needs.review_target.outputs.credential_scope == 'architecture' && vars.CODEX_ARCHITECTURE_EFFORT) || ((needs.review_target.outputs.credential_scope == 'review' || needs.review_target.outputs.credential_scope == 'shared' || needs.review_target.outputs.credential_scope == 'none') && (vars.CODEX_CORRECTNESS_EFFORT || vars.CODEX_ARCHITECTURE_EFFORT)) || 'high' }}
     secrets:
       CODEX_AUTH_JSON: ${{ needs.review_target.outputs.auth_mode == 'subscription' && secrets.CODEX_AUTH_JSON || '' }}
       OPENAI_API_KEY: ${{ (needs.review_target.outputs.credential_scope == 'review' && secrets.CODEX_REVIEW_API_KEY) || (needs.review_target.outputs.credential_scope == 'correctness' && secrets.CODEX_CORRECTNESS_API_KEY) || (needs.review_target.outputs.credential_scope == 'architecture' && secrets.CODEX_ARCHITECTURE_API_KEY) || (needs.review_target.outputs.credential_scope == 'shared' && secrets.OPENAI_API_KEY) || '' }}

--- a/.github/workflows/ai-review.yml
+++ b/.github/workflows/ai-review.yml
@@ -1,4 +1,7 @@
-name: AI PR Review
+name: AI PR Review (Disabled)
+
+on:
+  workflow_call:
 
 # Authentication defaults to API keys. See .github/action/ai-review.md for the supported API-key
 # and Codex subscription configurations and their security boundaries.
@@ -24,26 +27,8 @@ name: AI PR Review
 # Reviewer agents do not post comments directly. Each writes its schema-validated verdict to a job
 # output, and a separate trusted workflow publishes the comment. Both Codex reviewers use the same
 # read-only reusable workflow but run as independent parallel jobs.
-on:
-  pull_request_target:
-    branches:
-      - main
-    types: [opened, synchronize, reopened]
-  workflow_dispatch:
-    inputs:
-      pull_request_number:
-        description: Pull request number to review
-        required: true
-      reviewer:
-        description: Reviewer to run
-        required: true
-        default: both
-        type: choice
-        options:
-          - both
-          - correctness
-          - architecture
-
+# This retired dual-review workflow has no automatic or manual trigger. It remains callable only so
+# the archived definition stays valid; no workflow calls it. AI PR Review (Single) owns all triggers.
 concurrency:
   group: ai-pr-review-${{ github.event.inputs.pull_request_number || github.event.pull_request.number }}-${{ github.event_name == 'workflow_dispatch' && github.event.inputs.reviewer || 'both' }}
   cancel-in-progress: true

--- a/scripts/ai-review-labels.test.ts
+++ b/scripts/ai-review-labels.test.ts
@@ -11,7 +11,7 @@ const labelsWorkflow = load(
   readFileSync(join(process.cwd(), '.github/workflows/ai-review-labels.yml'), 'utf8')
 ) as { jobs: Record<string, WorkflowJob> }
 const reviewWorkflow = load(
-  readFileSync(join(process.cwd(), '.github/workflows/ai-review.yml'), 'utf8')
+  readFileSync(join(process.cwd(), '.github/workflows/ai-review-single.yml'), 'utf8')
 ) as { jobs: Record<string, WorkflowJob> }
 
 type MockFn = ReturnType<typeof vi.fn>
@@ -120,46 +120,33 @@ function reviewEnv(overrides: Record<string, string> = {}): Record<string, strin
   return {
     PR_NUMBER: '7',
     REVIEW_HEAD_SHA: 'sha1',
-    CORRECTNESS_REQUIRED: 'true',
-    CORRECTNESS_RESULT: 'success',
-    CORRECTNESS_POST_RESULT: 'success',
-    CORRECTNESS_POSTED: 'true',
-    CORRECTNESS_REVIEW_BODY: reviewBody('## Codex Correctness Review', 'mergeable'),
-    ARCHITECTURE_REQUIRED: 'false',
-    ARCHITECTURE_RESULT: 'skipped',
-    ARCHITECTURE_POST_RESULT: 'skipped',
-    ARCHITECTURE_POSTED: '',
-    ARCHITECTURE_REVIEW_BODY: '',
+    REVIEW_REQUIRED: 'true',
+    REVIEW_RESULT: 'success',
+    REVIEW_POST_RESULT: 'success',
+    REVIEW_POSTED: 'true',
+    REVIEW_BODY: reviewBody('## Codex Review', 'mergeable'),
     ...overrides
   }
 }
 
 describe('apply_review_outcome', () => {
-  it('labels ready-to-merge when the skipped reviewer is ignored and the rest mergeable', async () => {
+  it('labels ready-to-merge when the combined reviewer is mergeable', async () => {
     const { github, added, removed } = makeGithub()
     await runJob('apply_review_outcome', reviewContext(), github, reviewEnv())
     expect(added).toEqual([['ready-to-merge']])
     expect(removed).toEqual([])
   })
 
-  it('labels ready-to-merge when every completed reviewer is mergeable', async () => {
-    const { github, added, removed } = makeGithub()
-
+  it('removes ready-to-merge when the reviewer is disabled', async () => {
+    const { github, added, removed } = makeGithub({ labels: ['ready-to-merge'] })
     await runJob(
       'apply_review_outcome',
       reviewContext(),
       github,
-      reviewEnv({
-        ARCHITECTURE_REQUIRED: 'true',
-        ARCHITECTURE_RESULT: 'success',
-        ARCHITECTURE_POST_RESULT: 'success',
-        ARCHITECTURE_POSTED: 'true',
-        ARCHITECTURE_REVIEW_BODY: reviewBody('## Codex Architecture Review', 'mergeable')
-      })
+      reviewEnv({ REVIEW_REQUIRED: 'false' })
     )
-
-    expect(added).toEqual([['ready-to-merge']])
-    expect(removed).toEqual([])
+    expect(added).toEqual([])
+    expect(removed).toEqual(['ready-to-merge'])
   })
 
   it('fails closed when a reviewer job ran but did not succeed', async () => {
@@ -168,7 +155,7 @@ describe('apply_review_outcome', () => {
       'apply_review_outcome',
       reviewContext(),
       github,
-      reviewEnv({ ARCHITECTURE_REQUIRED: 'true', ARCHITECTURE_RESULT: 'failure' })
+      reviewEnv({ REVIEW_RESULT: 'failure' })
     )
     expect(added).toEqual([])
     expect(removed).toEqual(['ready-to-merge'])
@@ -181,10 +168,10 @@ describe('apply_review_outcome', () => {
       reviewContext(),
       github,
       reviewEnv({
-        CORRECTNESS_RESULT: 'skipped',
-        CORRECTNESS_POST_RESULT: 'skipped',
-        CORRECTNESS_POSTED: '',
-        CORRECTNESS_REVIEW_BODY: ''
+        REVIEW_RESULT: 'skipped',
+        REVIEW_POST_RESULT: 'skipped',
+        REVIEW_POSTED: '',
+        REVIEW_BODY: ''
       })
     )
     expect(added).toEqual([])
@@ -197,7 +184,7 @@ describe('apply_review_outcome', () => {
       'apply_review_outcome',
       reviewContext(),
       github,
-      reviewEnv({ CORRECTNESS_POSTED: 'false' })
+      reviewEnv({ REVIEW_POSTED: 'false' })
     )
     expect(added).toEqual([])
     expect(removed).toEqual(['ready-to-merge'])
@@ -209,9 +196,7 @@ describe('apply_review_outcome', () => {
       'apply_review_outcome',
       reviewContext(),
       github,
-      reviewEnv({
-        CORRECTNESS_REVIEW_BODY: reviewBody('## Codex Correctness Review', 'needs changes')
-      })
+      reviewEnv({ REVIEW_BODY: reviewBody('## Codex Review', 'needs changes') })
     )
     expect(added).toEqual([])
     expect(removed).toEqual(['ready-to-merge'])
@@ -223,7 +208,7 @@ describe('apply_review_outcome', () => {
       'apply_review_outcome',
       reviewContext(),
       github,
-      reviewEnv({ CORRECTNESS_REVIEW_BODY: 'review unavailable' })
+      reviewEnv({ REVIEW_BODY: 'review unavailable' })
     )
     expect(added).toEqual([])
     expect(removed).toEqual(['ready-to-merge'])

--- a/scripts/ai-review-workflows.test.ts
+++ b/scripts/ai-review-workflows.test.ts
@@ -101,6 +101,7 @@ type TargetOptions = {
   enabled?: string
   isFork?: boolean
   forkMode?: 'disabled' | 'manual' | 'automatic'
+  reviewMode?: 'both' | 'correctness' | 'architecture' | 'disabled'
 }
 
 function runTarget(options: TargetOptions = {}): {
@@ -146,6 +147,7 @@ printf '%s' "$PR_JSON"
         EVENT_PR_NUMBER: event === 'pull_request_target' ? '392' : '',
         FORK_REVIEW_MODE: options.forkMode ?? 'manual',
         CODEX_REVIEW_AUTH_MODE: options.authMode ?? 'subscription',
+        CODEX_REVIEW_MODE: options.reviewMode ?? 'correctness',
         ENABLE_CODEX_REVIEW: options.enabled ?? 'true',
         REVIEW_EVENT: event,
         GITHUB_OUTPUT: output
@@ -436,11 +438,17 @@ describe('single Codex workflow contract', () => {
   })
 
   it('uses one reviewer for automatic and manual runs', () => {
-    expect(mainText).not.toMatch(/\bCODEX_REVIEW_MODE\b/)
     expect(mainText).not.toContain('DISPATCH_REVIEWER')
     expect(runTarget().outputs.review_enabled).toBe('true')
     expect(runTarget({ event: 'workflow_dispatch' }).outputs.review_enabled).toBe('true')
     expect(runTarget({ enabled: 'false' }).outputs.review_enabled).toBe('false')
+  })
+
+  it('preserves the legacy manual-only review mode', () => {
+    expect(runTarget({ reviewMode: 'disabled' }).outputs.review_enabled).toBe('false')
+    expect(
+      runTarget({ event: 'workflow_dispatch', reviewMode: 'disabled' }).outputs.review_enabled
+    ).toBe('true')
   })
 
   it('rejects an invalid reviewer enable flag', () => {
@@ -547,9 +555,9 @@ describe('single Codex workflow contract', () => {
       CODEX_AUTH_JSON:
         "${{ needs.review_target.outputs.auth_mode == 'subscription' && secrets.CODEX_AUTH_JSON || '' }}",
       OPENAI_API_KEY:
-        '${{ secrets.CODEX_REVIEW_API_KEY || secrets.CODEX_CORRECTNESS_API_KEY || secrets.OPENAI_API_KEY }}',
+        '${{ secrets.CODEX_REVIEW_API_KEY || secrets.CODEX_CORRECTNESS_API_KEY || secrets.CODEX_ARCHITECTURE_API_KEY || secrets.OPENAI_API_KEY }}',
       CODEX_BASE_URL:
-        '${{ secrets.CODEX_REVIEW_BASE_URL || secrets.CODEX_CORRECTNESS_BASE_URL || secrets.CODEX_BASE_URL }}'
+        '${{ secrets.CODEX_REVIEW_BASE_URL || secrets.CODEX_CORRECTNESS_BASE_URL || secrets.CODEX_ARCHITECTURE_BASE_URL || secrets.CODEX_BASE_URL }}'
     })
   })
 

--- a/scripts/ai-review-workflows.test.ts
+++ b/scripts/ai-review-workflows.test.ts
@@ -1,5 +1,6 @@
 import {
   chmodSync,
+  existsSync,
   mkdtempSync,
   mkdirSync,
   readFileSync,
@@ -15,6 +16,7 @@ import { load } from 'js-yaml'
 import { afterEach, describe, expect, it, vi } from 'vitest'
 
 type WorkflowStep = {
+  'continue-on-error'?: boolean
   id?: string
   if?: string
   name?: string
@@ -43,7 +45,8 @@ type Workflow = {
   jobs: Record<string, WorkflowJob>
 }
 
-const mainText = readFileSync(join(process.cwd(), '.github/workflows/ai-review.yml'), 'utf8')
+const mainText = readFileSync(join(process.cwd(), '.github/workflows/ai-review-single.yml'), 'utf8')
+const retiredText = readFileSync(join(process.cwd(), '.github/workflows/ai-review.yml'), 'utf8')
 const codexText = readFileSync(join(process.cwd(), '.github/workflows/ai-codex-review.yml'), 'utf8')
 const publisherText = readFileSync(
   join(process.cwd(), '.github/workflows/ai-post-review.yml'),
@@ -51,6 +54,7 @@ const publisherText = readFileSync(
 )
 const reviewDocsText = readFileSync(join(process.cwd(), '.github/action/ai-review.md'), 'utf8')
 const mainWorkflow = load(mainText) as Workflow
+const retiredWorkflow = load(retiredText) as Record<string, unknown>
 const codexWorkflow = load(codexText) as Workflow
 const publisherWorkflow = load(publisherText) as Workflow
 const fixtureRoots: string[] = []
@@ -94,9 +98,7 @@ function simpleOutputs(path: string): Record<string, string> {
 type TargetOptions = {
   authMode?: 'api-key' | 'subscription'
   event?: 'pull_request_target' | 'workflow_dispatch'
-  dispatchReviewer?: string
-  automaticMode?: 'both' | 'correctness' | 'architecture' | 'disabled'
-  enabled?: 'true' | 'false'
+  enabled?: string
   isFork?: boolean
   forkMode?: 'disabled' | 'manual' | 'automatic'
 }
@@ -106,7 +108,7 @@ function runTarget(options: TargetOptions = {}): {
   stderr: string
   outputs: Record<string, string>
 } {
-  const root = fixtureRoot('dual-codex-target-')
+  const root = fixtureRoot('single-codex-target-')
   const bin = join(root, 'bin')
   const output = join(root, 'github-output')
   mkdirSync(bin)
@@ -143,10 +145,8 @@ printf '%s' "$PR_JSON"
         DISPATCH_PR_NUMBER: event === 'workflow_dispatch' ? '392' : '',
         EVENT_PR_NUMBER: event === 'pull_request_target' ? '392' : '',
         FORK_REVIEW_MODE: options.forkMode ?? 'manual',
-        CODEX_REVIEW_AUTH_MODE: options.authMode ?? 'api-key',
+        CODEX_REVIEW_AUTH_MODE: options.authMode ?? 'subscription',
         ENABLE_CODEX_REVIEW: options.enabled ?? 'true',
-        CODEX_REVIEW_MODE: options.automaticMode ?? 'correctness',
-        DISPATCH_REVIEWER: options.dispatchReviewer ?? 'both',
         REVIEW_EVENT: event,
         GITHUB_OUTPUT: output
       }
@@ -164,8 +164,10 @@ type AuthOptions = {
   authMode?: 'api-key' | 'subscription'
   baseUrl?: string
   event?: 'pull_request_target' | 'workflow_dispatch'
+  installAvailable?: boolean
   isFork?: boolean
   openAiApiKey?: string
+  subscriptionAvailable?: boolean
 }
 
 function runAuth(options: AuthOptions = {}): {
@@ -177,11 +179,28 @@ function runAuth(options: AuthOptions = {}): {
   status: number | null
   stderr: string
 } {
-  const root = fixtureRoot('dual-codex-auth-')
+  const root = fixtureRoot('single-codex-auth-')
+  const bin = join(root, 'bin')
   const codexHome = join(root, 'codex-home')
   const authFile = join(codexHome, 'auth.json')
   const configFile = join(codexHome, 'config.toml')
   const output = join(root, 'github-output')
+  mkdirSync(bin)
+  executable(
+    join(bin, 'codex'),
+    `#!/usr/bin/env bash
+set -euo pipefail
+if [[ -z "\${CODEX_HOME:-}" || ! -s "$CODEX_HOME/auth.json" ]]; then
+  echo 'staged subscription credential is unavailable' >&2
+  exit 2
+fi
+if [[ "$SUBSCRIPTION_AVAILABLE" != 'true' ]]; then
+  echo 'subscription authentication rejected' >&2
+  exit 1
+fi
+printf '%s\n' '{"type":"turn.completed"}'
+`
+  )
   const result = spawnSync(
     'bash',
     ['-c', getRun(codexWorkflow, 'review', 'Prepare Codex authentication')],
@@ -190,16 +209,20 @@ function runAuth(options: AuthOptions = {}): {
       encoding: 'utf8',
       env: {
         ...process.env,
+        PATH: `${bin}:${process.env.PATH}`,
         CODEX_AUTH_JSON: options.authJson ?? '',
         CODEX_AUTH_MODE: options.authMode ?? 'api-key',
         CODEX_BASE_URL: options.baseUrl ?? 'https://api.openai.com',
+        CODEX_INSTALL_OUTCOME: options.installAvailable === false ? 'failure' : 'success',
+        CODEX_MODEL: 'gpt-5.6-sol',
         GITHUB_OUTPUT: output,
         GITHUB_REPOSITORY: 'aipoch/open-science',
         GITHUB_WORKSPACE: root,
         IS_FORK: String(options.isFork ?? false),
         OPENAI_API_KEY: options.openAiApiKey ?? 'sk-test',
         REVIEW_EVENT: options.event ?? 'workflow_dispatch',
-        RUNNER_TEMP: root
+        RUNNER_TEMP: root,
+        SUBSCRIPTION_AVAILABLE: String(options.subscriptionAvailable ?? true)
       }
     }
   )
@@ -207,10 +230,7 @@ function runAuth(options: AuthOptions = {}): {
     authFile,
     codexHome,
     configFile,
-    mode:
-      result.status === 0 && options.authMode === 'subscription'
-        ? statSync(authFile).mode
-        : undefined,
+    mode: result.status === 0 && existsSync(authFile) ? statSync(authFile).mode : undefined,
     outputs: result.status === 0 ? simpleOutputs(output) : {},
     status: result.status,
     stderr: result.stderr
@@ -221,9 +241,9 @@ type ReviewComment = { body: string | null; user: { login: string } }
 
 function runGate(
   comments: ReviewComment[],
-  { correctness = 'true', architecture = 'true', max = '20' } = {}
+  { max = '20' } = {}
 ): { status: number | null; stderr: string; outputs: Record<string, string>; summary: string } {
-  const root = fixtureRoot('dual-codex-gate-')
+  const root = fixtureRoot('single-codex-gate-')
   const bin = join(root, 'bin')
   const output = join(root, 'github-output')
   const summary = join(root, 'summary')
@@ -248,8 +268,6 @@ printf '%s' "$COMMENTS_PAGES_JSON"
         COMMENTS_PAGES_JSON: JSON.stringify([comments]),
         GH_REPO: 'aipoch/open-science',
         PR_NUMBER: '392',
-        CORRECTNESS_ENABLED: correctness,
-        ARCHITECTURE_ENABLED: architecture,
         CODEX_REVIEW_MAX_ROUNDS: max,
         GITHUB_OUTPUT: output,
         GITHUB_STEP_SUMMARY: summary
@@ -264,13 +282,13 @@ printf '%s' "$COMMENTS_PAGES_JSON"
   }
 }
 
-function runReviewInputs(scope: 'correctness' | 'architecture'): {
+function runReviewInputs(): {
   prompt: string
   instructions: string
   schema: Record<string, unknown>
   outputs: Record<string, string>
 } {
-  const root = fixtureRoot(`dual-codex-${scope}-inputs-`)
+  const root = fixtureRoot('single-codex-review-inputs-')
   const output = join(root, 'github-output')
   const result = spawnSync(
     'bash',
@@ -284,7 +302,6 @@ function runReviewInputs(scope: 'correctness' | 'architecture'): {
         PR_BRANCH: 'ci/dual-codex-review',
         PR_DIFF_BASE: 'base-sha',
         PR_TITLE: 'ci(review): replace Claude with dual Codex reviews',
-        REVIEW_SCOPE: scope,
         REVIEW_SHA: 'review-sha',
         GITHUB_OUTPUT: output
       }
@@ -347,9 +364,9 @@ async function runPublisher({
   }
   const processStub = {
     env: {
-      REVIEW_BODY: '## Codex Architecture Review\n\n**Verdict: mergeable**',
-      REVIEW_HEADER: '## Codex Architecture Review',
-      REVIEW_MARKER: '<!-- ai-review:codex-architecture -->',
+      REVIEW_BODY: '## Codex Review\n\n**Verdict: mergeable**',
+      REVIEW_HEADER: '## Codex Review',
+      REVIEW_MARKER: '<!-- ai-review:codex -->',
       PR_NUMBER: '392',
       REVIEW_HEAD_SHA: 'head-sha',
       REVIEW_RUN_ID: '1234',
@@ -367,19 +384,28 @@ async function runPublisher({
   return { postedBodies, output }
 }
 
-describe('dual Codex workflow contract', () => {
-  it('parses all three workflows as YAML', () => {
+describe('single Codex workflow contract', () => {
+  it('parses all active and retired workflows as YAML', () => {
     expect(() => load(mainText)).not.toThrow()
+    expect(() => load(retiredText)).not.toThrow()
     expect(() => load(codexText)).not.toThrow()
     expect(() => load(publisherText)).not.toThrow()
+  })
+
+  it('keeps the retired dual-review workflow inert', () => {
+    expect(retiredText).toContain('name: AI PR Review (Disabled)')
+    expect(retiredWorkflow.on).toEqual({ workflow_call: null })
   })
 
   it('documents subscription setup and credential refresh limitations', () => {
     expect(reviewDocsText).toContain('gh secret set CODEX_AUTH_JSON')
     expect(reviewDocsText).toContain('gh variable set CODEX_REVIEW_AUTH_MODE --body subscription')
     expect(reviewDocsText).toContain('GitHub-hosted runners are ephemeral')
+    expect(reviewDocsText).toMatch(
+      /Subscription auth is the default for every allowed automatic or manually dispatched pull request\s+review\./
+    )
     expect(reviewDocsText).toContain(
-      'manually dispatched review of a\n> same-repository pull request'
+      'Invalid or missing subscription credentials fall back to API-key auth.'
     )
   })
 
@@ -388,53 +414,25 @@ describe('dual Codex workflow contract', () => {
     expect(all).not.toMatch(/Claude|CLAUDE|Anthropic|ANTHROPIC|CodeGraph|CODEGRAPH/)
   })
 
-  it('supports automatic and manual reviewer switching', () => {
-    expect(mainText).toContain("vars.CODEX_REVIEW_MODE || 'correctness'")
-    expect(mainText).toMatch(
-      /reviewer:\n(?:\s+.*\n)*?\s+default: both\n(?:\s+.*\n)*?\s+options:\n\s+- both\n\s+- correctness\n\s+- architecture/
-    )
-
-    expect(runTarget().outputs).toMatchObject({
-      correctness_enabled: 'true',
-      architecture_enabled: 'false'
-    })
-    expect(runTarget({ automaticMode: 'both' }).outputs).toMatchObject({
-      correctness_enabled: 'true',
-      architecture_enabled: 'true'
-    })
-    expect(runTarget({ automaticMode: 'architecture' }).outputs).toMatchObject({
-      correctness_enabled: 'false',
-      architecture_enabled: 'true'
-    })
-    expect(
-      runTarget({
-        event: 'workflow_dispatch',
-        automaticMode: 'architecture',
-        dispatchReviewer: 'correctness'
-      }).outputs
-    ).toMatchObject({ correctness_enabled: 'true', architecture_enabled: 'false' })
-    expect(runTarget({ enabled: 'false' }).outputs).toMatchObject({
-      correctness_enabled: 'false',
-      architecture_enabled: 'false'
-    })
-    expect(runTarget({ event: 'workflow_dispatch' }).outputs).toMatchObject({
-      correctness_enabled: 'true',
-      architecture_enabled: 'true'
-    })
+  it('uses one reviewer for automatic and manual runs', () => {
+    expect(mainText).not.toMatch(/\bCODEX_REVIEW_MODE\b/)
+    expect(mainText).not.toContain('DISPATCH_REVIEWER')
+    expect(runTarget().outputs.review_enabled).toBe('true')
+    expect(runTarget({ event: 'workflow_dispatch' }).outputs.review_enabled).toBe('true')
+    expect(runTarget({ enabled: 'false' }).outputs.review_enabled).toBe('false')
   })
 
-  it('rejects removed manual reviewer aliases', () => {
-    const result = runTarget({ event: 'workflow_dispatch', dispatchReviewer: 'codex' })
+  it('rejects an invalid reviewer enable flag', () => {
+    const result = runTarget({ enabled: 'sometimes' })
     expect(result.status).not.toBe(0)
-    expect(result.stderr).toContain('Dispatch reviewer must be both, correctness, or architecture.')
+    expect(result.stderr).toContain('ENABLE_CODEX_REVIEW must be true or false.')
   })
 
-  it('keeps fork review policy independent from reviewer selection', () => {
+  it('keeps fork review policy independent from the reviewer toggle', () => {
     expect(runTarget({ isFork: true, forkMode: 'manual' }).outputs.review_allowed).toBe('false')
     expect(
       runTarget({
         event: 'workflow_dispatch',
-        dispatchReviewer: 'architecture',
         isFork: true,
         forkMode: 'manual'
       }).outputs.review_allowed
@@ -442,9 +440,12 @@ describe('dual Codex workflow contract', () => {
     expect(runTarget({ isFork: true, forkMode: 'automatic' }).outputs.review_allowed).toBe('true')
   })
 
-  it('uses subscription only for manual same-repository reviews and otherwise falls back to API auth', () => {
-    expect(runTarget({ authMode: 'subscription' }).outputs).toMatchObject({
-      auth_mode: 'api-key',
+  it('prefers subscription for automatic and manual reviews before API fallback', () => {
+    expect(mainText).toContain(
+      "CODEX_REVIEW_AUTH_MODE: ${{ vars.CODEX_REVIEW_AUTH_MODE || 'subscription' }}"
+    )
+    expect(runTarget().outputs).toMatchObject({
+      auth_mode: 'subscription',
       review_allowed: 'true'
     })
     expect(
@@ -453,6 +454,7 @@ describe('dual Codex workflow contract', () => {
         event: 'workflow_dispatch'
       }).outputs
     ).toMatchObject({ auth_mode: 'subscription', review_allowed: 'true' })
+    expect(runTarget({ authMode: 'api-key' }).outputs.auth_mode).toBe('api-key')
     const fork = runTarget({
       authMode: 'subscription',
       event: 'workflow_dispatch',
@@ -460,31 +462,10 @@ describe('dual Codex workflow contract', () => {
       forkMode: 'automatic'
     })
     expect(fork.status, fork.stderr).toBe(0)
-    expect(fork.outputs).toMatchObject({ auth_mode: 'api-key', review_allowed: 'true' })
+    expect(fork.outputs).toMatchObject({ auth_mode: 'subscription', review_allowed: 'true' })
   })
 
-  it('rejects an invalid automatic review mode', () => {
-    const root = fixtureRoot('dual-codex-invalid-mode-')
-    const result = spawnSync(
-      'bash',
-      ['-c', getRun(mainWorkflow, 'review_target', 'Resolve pull request metadata')],
-      {
-        cwd: root,
-        encoding: 'utf8',
-        env: {
-          ...process.env,
-          FORK_REVIEW_MODE: 'manual',
-          CODEX_REVIEW_AUTH_MODE: 'api-key',
-          CODEX_REVIEW_MODE: 'claude',
-          ENABLE_CODEX_REVIEW: 'true'
-        }
-      }
-    )
-    expect(result.status).not.toBe(0)
-    expect(result.stderr).toContain('CODEX_REVIEW_MODE must be')
-  })
-
-  it('counts correctness and architecture review rounds independently', () => {
+  it('counts one combined review round and ignores retired architecture comments', () => {
     const comments: ReviewComment[] = [
       ...Array.from({ length: 19 }, () => ({
         body: '<!-- ai-review:codex -->\n## Codex Correctness Review',
@@ -501,58 +482,51 @@ describe('dual Codex workflow contract', () => {
     ]
     const result = runGate(comments)
     expect(result.status, result.stderr).toBe(0)
-    expect(result.outputs).toMatchObject({
-      correctness_should_run: 'true',
-      architecture_should_run: 'false'
-    })
-    expect(result.summary).toContain('correctness review round 20 of 20')
-    expect(result.summary).toContain('architecture review skipped')
+    expect(result.outputs.should_run).toBe('true')
+    expect(result.summary).toContain('Codex review round 20 of 20')
+
+    const atLimit = runGate([
+      ...comments,
+      {
+        body: '<!-- ai-review:codex -->\n## Codex Review',
+        user: { login: 'github-actions[bot]' }
+      }
+    ])
+    expect(atLimit.status, atLimit.stderr).toBe(0)
+    expect(atLimit.outputs.should_run).toBe('false')
+    expect(atLimit.summary).toContain('Codex review skipped')
   })
 
-  it('skips an unselected reviewer without consuming its round', () => {
-    const result = runGate([], { correctness: 'false', architecture: 'true', max: '0' })
+  it('supports an unlimited combined review round count', () => {
+    const result = runGate([], { max: '0' })
     expect(result.status, result.stderr).toBe(0)
-    expect(result.outputs).toMatchObject({
-      correctness_should_run: 'false',
-      architecture_should_run: 'true'
-    })
-    expect(result.summary).not.toContain('correctness review round')
-    expect(result.summary).toContain('architecture review round 1 (unlimited)')
+    expect(result.outputs.should_run).toBe('true')
+    expect(result.summary).toContain('Codex review round 1 (unlimited)')
   })
 
-  it('invokes the reusable Codex workflow twice with independent backends', () => {
-    const correctness = mainWorkflow.jobs.codex_correctness_review
-    const architecture = mainWorkflow.jobs.codex_architecture_review
-    expect(correctness.uses).toBe('./.github/workflows/ai-codex-review.yml')
-    expect(architecture.uses).toBe('./.github/workflows/ai-codex-review.yml')
-    expect(correctness.name).toBe('Correctness')
-    expect(architecture.name).toBe('Architecture')
+  it('invokes the reusable Codex workflow once for a combined review', () => {
+    const reviewJobs = Object.values(mainWorkflow.jobs).filter(
+      ({ uses }) => uses === './.github/workflows/ai-codex-review.yml'
+    )
+    const review = mainWorkflow.jobs.codex_review
+    expect(reviewJobs).toHaveLength(1)
+    expect(review).toBe(reviewJobs[0])
+    expect(review.name).toBe('Review')
     expect(codexWorkflow.jobs.review.name).toBe('Run Codex')
-    expect(correctness.permissions).toEqual({ contents: 'read' })
-    expect(architecture.permissions).toEqual({ contents: 'read' })
-    expect(correctness.with).toMatchObject({
+    expect(review.permissions).toEqual({ contents: 'read' })
+    expect(review.with).toMatchObject({
       auth_mode: '${{ needs.review_target.outputs.auth_mode }}',
-      scope: 'correctness',
-      model: "${{ vars.CODEX_CORRECTNESS_MODEL || vars.CODEX_REVIEW_MODEL || 'gpt-5.6-sol' }}",
-      effort: "${{ vars.CODEX_CORRECTNESS_EFFORT || vars.CODEX_REVIEW_EFFORT || 'high' }}"
+      model: "${{ vars.CODEX_REVIEW_MODEL || vars.CODEX_CORRECTNESS_MODEL || 'gpt-5.6-sol' }}",
+      effort: "${{ vars.CODEX_REVIEW_EFFORT || vars.CODEX_CORRECTNESS_EFFORT || 'high' }}"
     })
-    expect(correctness.secrets).toEqual({
+    expect(review.with).not.toHaveProperty('scope')
+    expect(review.secrets).toEqual({
       CODEX_AUTH_JSON:
         "${{ needs.review_target.outputs.auth_mode == 'subscription' && secrets.CODEX_AUTH_JSON || '' }}",
-      OPENAI_API_KEY: '${{ secrets.CODEX_CORRECTNESS_API_KEY || secrets.OPENAI_API_KEY }}',
-      CODEX_BASE_URL: '${{ secrets.CODEX_CORRECTNESS_BASE_URL || secrets.CODEX_BASE_URL }}'
-    })
-    expect(architecture.with).toMatchObject({
-      auth_mode: '${{ needs.review_target.outputs.auth_mode }}',
-      scope: 'architecture',
-      model: "${{ vars.CODEX_ARCHITECTURE_MODEL || vars.CODEX_REVIEW_MODEL || 'gpt-5.6-sol' }}",
-      effort: "${{ vars.CODEX_ARCHITECTURE_EFFORT || vars.CODEX_REVIEW_EFFORT || 'high' }}"
-    })
-    expect(architecture.secrets).toEqual({
-      CODEX_AUTH_JSON:
-        "${{ needs.review_target.outputs.auth_mode == 'subscription' && secrets.CODEX_AUTH_JSON || '' }}",
-      OPENAI_API_KEY: '${{ secrets.CODEX_ARCHITECTURE_API_KEY || secrets.OPENAI_API_KEY }}',
-      CODEX_BASE_URL: '${{ secrets.CODEX_ARCHITECTURE_BASE_URL || secrets.CODEX_BASE_URL }}'
+      OPENAI_API_KEY:
+        '${{ secrets.CODEX_REVIEW_API_KEY || secrets.CODEX_CORRECTNESS_API_KEY || secrets.OPENAI_API_KEY }}',
+      CODEX_BASE_URL:
+        '${{ secrets.CODEX_REVIEW_BASE_URL || secrets.CODEX_CORRECTNESS_BASE_URL || secrets.CODEX_BASE_URL }}'
     })
   })
 
@@ -588,18 +562,56 @@ describe('dual Codex workflow contract', () => {
     expect(config).toContain('trust_level = "untrusted"')
   })
 
-  it('rejects a subscription secret that is not managed ChatGPT auth', () => {
-    const result = runAuth({
+  it('falls back to API-key auth when subscription credentials are unavailable', () => {
+    const invalid = runAuth({
       authJson: JSON.stringify({ auth_mode: 'apikey', OPENAI_API_KEY: 'sk-wrong-mode' }),
       authMode: 'subscription'
     })
+    expect(invalid.status, invalid.stderr).toBe(0)
+    expect(invalid.outputs.auth_mode).toBe('api-key')
+    expect(existsSync(invalid.authFile)).toBe(false)
+
+    const missing = runAuth({ authMode: 'subscription' })
+    expect(missing.status, missing.stderr).toBe(0)
+    expect(missing.outputs.auth_mode).toBe('api-key')
+
+    const rejected = runAuth({
+      authJson: JSON.stringify({
+        auth_mode: 'chatgpt',
+        tokens: { refresh_token: 'revoked-refresh-token' }
+      }),
+      authMode: 'subscription',
+      subscriptionAvailable: false
+    })
+    expect(rejected.status, rejected.stderr).toBe(0)
+    expect(rejected.outputs.auth_mode).toBe('api-key')
+    expect(existsSync(rejected.authFile)).toBe(false)
+
+    const installFailed = runAuth({
+      authJson: JSON.stringify({
+        auth_mode: 'chatgpt',
+        tokens: { refresh_token: 'refresh-seed' }
+      }),
+      authMode: 'subscription',
+      installAvailable: false
+    })
+    expect(installFailed.status, installFailed.stderr).toBe(0)
+    expect(installFailed.outputs.auth_mode).toBe('api-key')
+  })
+
+  it('fails closed when neither subscription nor API-key credentials are available', () => {
+    const result = runAuth({
+      authMode: 'subscription',
+      baseUrl: '',
+      openAiApiKey: ''
+    })
     expect(result.status).not.toBe(0)
     expect(result.stderr).toContain(
-      'Codex subscription auth must be a valid chatgpt auth.json with a refresh token.'
+      'Repository secret OPENAI_API_KEY is required for API-key auth.'
     )
   })
 
-  it('rejects subscription auth outside a manual same-repository review', () => {
+  it('accepts subscription auth for automatic, manual, and fork reviews', () => {
     const seed = JSON.stringify({
       auth_mode: 'chatgpt',
       tokens: { refresh_token: 'refresh-seed' }
@@ -609,35 +621,43 @@ describe('dual Codex workflow contract', () => {
       authMode: 'subscription',
       event: 'pull_request_target'
     })
-    expect(automatic.status).not.toBe(0)
-    expect(automatic.stderr).toContain('manual workflow_dispatch reviews')
+    expect(automatic.status, automatic.stderr).toBe(0)
+    expect(automatic.outputs.auth_mode).toBe('subscription')
 
     const fork = runAuth({ authJson: seed, authMode: 'subscription', isFork: true })
-    expect(fork.status).not.toBe(0)
-    expect(fork.stderr).toContain('same-repository pull requests')
+    expect(fork.status, fork.stderr).toBe(0)
+    expect(fork.outputs.auth_mode).toBe('subscription')
   })
 
   it('uses the API action only for API-key auth and installs the CLI directly for subscription auth', () => {
     const prepareRuntime = getStep(codexWorkflow, 'review', 'Prepare Codex review runtime')
-    expect(prepareRuntime.if).toBe("${{ inputs.auth_mode == 'api-key' }}")
+    expect(prepareRuntime.if).toBe("${{ steps.codex_auth.outputs.auth_mode == 'api-key' }}")
     expect(prepareRuntime.with).toMatchObject({
       'codex-home': '${{ steps.codex_auth.outputs.codex_home }}',
       'codex-version': '0.144.6',
-      'openai-api-key': "${{ inputs.auth_mode == 'api-key' && secrets.OPENAI_API_KEY || '' }}",
+      'openai-api-key':
+        "${{ steps.codex_auth.outputs.auth_mode == 'api-key' && secrets.OPENAI_API_KEY || '' }}",
       'responses-api-endpoint': '${{ steps.responses_endpoint.outputs.url }}'
     })
     expect(getStep(codexWorkflow, 'review', 'Resolve Responses API endpoint').if).toBe(
-      "${{ inputs.auth_mode == 'api-key' }}"
+      "${{ steps.codex_auth.outputs.auth_mode == 'api-key' }}"
     )
     const setupNode = getStep(codexWorkflow, 'review', 'Set up Node.js for subscription auth')
+    expect(setupNode.id).toBe('setup_subscription_node')
     expect(setupNode.if).toBe("${{ inputs.auth_mode == 'subscription' }}")
+    expect(setupNode['continue-on-error']).toBe(true)
     expect(setupNode.uses).toBe('actions/setup-node@53b83947a5a98c8d113130e565377fae1a50d02f')
     expect(setupNode.with).toEqual({ 'node-version': '24' })
     const installCli = getStep(codexWorkflow, 'review', 'Install Codex CLI for subscription auth')
+    expect(installCli.id).toBe('install_subscription_cli')
     expect(installCli.if).toBe("${{ inputs.auth_mode == 'subscription' }}")
+    expect(installCli['continue-on-error']).toBe(true)
     expect(installCli.env).toEqual({ CODEX_VERSION: '0.144.6' })
     expect(installCli.run).toContain('npm install -g "@openai/codex@${CODEX_VERSION}"')
     expect(installCli.run).toContain('codex --version')
+    expect(getStep(codexWorkflow, 'review', 'Run Codex review').env?.CODEX_PERMISSION_PROFILE).toBe(
+      "${{ steps.codex_auth.outputs.auth_mode == 'subscription' && 'ai_review' || ':read-only' }}"
+    )
     const stepNames = codexWorkflow.jobs.review.steps?.map(({ name }) => name) ?? []
     expect(stepNames.indexOf('Install Codex CLI for subscription auth')).toBeLessThan(
       stepNames.indexOf('Prepare Codex authentication')
@@ -653,14 +673,14 @@ describe('dual Codex workflow contract', () => {
       'review',
       'Prepare GitHub-hosted sandbox for subscription auth'
     )
-    expect(sandbox.if).toBe("${{ inputs.auth_mode == 'subscription' }}")
+    expect(sandbox.if).toBe("${{ steps.codex_auth.outputs.auth_mode == 'subscription' }}")
     expect(sandbox.run).toContain('kernel.unprivileged_userns_clone')
     expect(sandbox.run).toContain('kernel.apparmor_restrict_unprivileged_userns')
   })
 
   it('drops sudo and verifies the subscription credential is denied to sandboxed commands', () => {
     const hardening = getStep(codexWorkflow, 'review', 'Harden subscription review runtime')
-    expect(hardening.if).toBe("${{ inputs.auth_mode == 'subscription' }}")
+    expect(hardening.if).toBe("${{ steps.codex_auth.outputs.auth_mode == 'subscription' }}")
     expect(hardening.run).toContain('/etc/sudoers.d/*')
     expect(hardening.run).not.toContain('command -v bwrap')
     expect(hardening.run).toContain('sudo -n true')
@@ -671,20 +691,17 @@ describe('dual Codex workflow contract', () => {
     expect(syntax.status, syntax.stderr).toBe(0)
   })
 
-  it('gives each Codex reviewer a distinct, non-overlapping focus', () => {
-    const correctness = runReviewInputs('correctness')
-    const architecture = runReviewInputs('architecture')
-    expect(correctness.outputs.review_header).toBe('## Codex Correctness Review')
-    expect(correctness.instructions).toContain('Branch name valid: true')
-    expect(correctness.prompt).toContain('correctness, security, regression')
-    expect(architecture.outputs.review_header).toBe('## Codex Architecture Review')
-    expect(architecture.instructions).not.toContain('Branch name valid')
-    expect(architecture.prompt).toContain('Focus exclusively on architecture and integration')
-    expect(architecture.prompt).toContain('IPC ownership')
-    expect(correctness.schema).toHaveProperty('properties')
+  it('combines correctness and architecture into one Codex review', () => {
+    const review = runReviewInputs()
+    expect(review.outputs.review_header).toBe('## Codex Review')
+    expect(review.instructions).toContain('Branch name valid: true')
+    expect(review.prompt).toContain('correctness, security, regression')
+    expect(review.prompt).toContain('architecture, and integration defects')
+    expect(review.prompt).toContain('IPC ownership')
+    expect(review.schema).toHaveProperty('properties')
   })
 
-  it('keeps both Codex reviewers static and read-only', () => {
+  it('keeps the Codex reviewer static and read-only', () => {
     const inputs = getRun(codexWorkflow, 'review', 'Build Codex review inputs')
     const run = getRun(codexWorkflow, 'review', 'Run Codex review')
     for (const command of ['install dependencies', 'lint', 'tests', 'typecheck', 'build']) {
@@ -811,7 +828,6 @@ printf '%s\n' \\
           CODEX_MODEL: 'codex-auto-review',
           DURATION_SECONDS: '7',
           EXECUTION_FILE: execution,
-          REVIEW_SCOPE: 'architecture',
           GITHUB_STEP_SUMMARY: summary
         }
       }
@@ -820,18 +836,18 @@ printf '%s\n' \\
     expect(result.stdout).toContain('Codex items: unique=2, tool_calls=1, failed=0')
     expect(result.stdout).toContain('Codex tokens: input=100, cached_input=80')
     const summaryText = readFileSync(summary, 'utf8')
-    expect(summaryText).toContain('### Codex architecture review telemetry')
+    expect(summaryText).toContain('### Codex review telemetry')
     expect(summaryText).toContain('| 1 | 100 | 80 | 20 | 5 |')
     expect(summaryText).toContain('| `command_execution` | 1 |')
   })
 
-  it('normalizes schema-valid results for either Codex header', async () => {
+  it('normalizes schema-valid results for the combined Codex header', async () => {
     await expect(
       normalize(
         JSON.stringify({ verdict: 'mergeable', summary: 'No issues.', findings: [] }),
-        '## Codex Architecture Review'
+        '## Codex Review'
       )
-    ).resolves.toContain('## Codex Architecture Review\n\n**Verdict: mergeable**')
+    ).resolves.toContain('## Codex Review\n\n**Verdict: mergeable**')
 
     await expect(
       normalize(
@@ -849,7 +865,7 @@ printf '%s\n' \\
             }
           ]
         }),
-        '## Codex Correctness Review'
+        '## Codex Review'
       )
     ).resolves.toContain('### [P1] Boundary is bypassed')
   })
@@ -871,49 +887,44 @@ printf '%s\n' \\
             }
           ]
         }),
-        '## Codex Correctness Review'
+        '## Codex Review'
       )
     ).rejects.toThrow('Codex verdict disagrees with its findings')
   })
 
-  it('publishes each reviewer through the shared trusted workflow', () => {
-    expect(mainWorkflow.jobs.post_codex_correctness_feedback.uses).toBe(
+  it('publishes the combined review through the shared trusted workflow', () => {
+    expect(mainWorkflow.jobs.post_codex_feedback.uses).toBe(
       './.github/workflows/ai-post-review.yml'
     )
-    expect(mainWorkflow.jobs.post_codex_correctness_feedback.with).toMatchObject({
-      scope: 'correctness',
+    expect(mainWorkflow.jobs.post_codex_feedback.with).toMatchObject({
+      scope: 'review',
       marker: '<!-- ai-review:codex -->',
-      header: '## Codex Correctness Review'
-    })
-    expect(mainWorkflow.jobs.post_codex_architecture_feedback.with).toMatchObject({
-      scope: 'architecture',
-      marker: '<!-- ai-review:codex-architecture -->',
-      header: '## Codex Architecture Review'
+      header: '## Codex Review'
     })
     expect(getStep(publisherWorkflow, 'publish', 'Post Codex review').with?.retries).toBe(3)
   })
 
-  it('publishes architecture feedback with trusted provenance', async () => {
+  it('publishes combined feedback with trusted provenance', async () => {
     const result = await runPublisher()
     expect(result.output).toBe('true')
     expect(result.postedBodies).toEqual([
       [
-        '<!-- ai-review:codex-architecture -->',
+        '<!-- ai-review:codex -->',
         '<!-- ai-review-meta head=head-sha run=1234 -->',
-        '## Codex Architecture Review',
+        '## Codex Review',
         '',
         '**Verdict: mergeable**'
       ].join('\n')
     ])
   })
 
-  it('does not publish stale feedback or exceed the per-reviewer round limit', async () => {
+  it('does not publish stale feedback or exceed the review round limit', async () => {
     await expect(runPublisher({ currentHead: 'newer-head' })).resolves.toMatchObject({
       output: 'false',
       postedBodies: []
     })
     const prior = Array.from({ length: 20 }, () => ({
-      body: '<!-- ai-review:codex-architecture -->',
+      body: '<!-- ai-review:codex -->',
       user: { login: 'github-actions[bot]' }
     }))
     await expect(runPublisher({ comments: prior })).resolves.toMatchObject({
@@ -922,23 +933,16 @@ printf '%s\n' \\
     })
   })
 
-  it('serializes each selected reviewer while allowing the two scopes to run in parallel', () => {
+  it('serializes duplicate runs of the single reviewer for each pull request', () => {
     expect(mainWorkflow.concurrency).toEqual({
       group:
-        "ai-pr-review-${{ github.event.inputs.pull_request_number || github.event.pull_request.number }}-${{ github.event_name == 'workflow_dispatch' && github.event.inputs.reviewer || 'both' }}",
+        'ai-pr-review-${{ github.event.inputs.pull_request_number || github.event.pull_request.number }}',
       'cancel-in-progress': true
     })
     expect(codexWorkflow.jobs.review.concurrency).toEqual({
-      group: "${{ format('codex-{0}-review-{1}', inputs.scope, inputs.pull_request_number) }}",
+      group: "${{ format('codex-review-{0}', inputs.pull_request_number) }}",
       'cancel-in-progress': true
     })
-    expect(mainWorkflow.jobs.codex_correctness_review.needs).toEqual([
-      'review_target',
-      'codex_review_gate'
-    ])
-    expect(mainWorkflow.jobs.codex_architecture_review.needs).toEqual([
-      'review_target',
-      'codex_review_gate'
-    ])
+    expect(mainWorkflow.jobs.codex_review.needs).toEqual(['review_target', 'codex_review_gate'])
   })
 })

--- a/scripts/ai-review-workflows.test.ts
+++ b/scripts/ai-review-workflows.test.ts
@@ -190,6 +190,10 @@ function runAuth(options: AuthOptions = {}): {
     join(bin, 'codex'),
     `#!/usr/bin/env bash
 set -euo pipefail
+if [[ -n "\${OPENAI_API_KEY:-}" || -n "\${CODEX_BASE_URL:-}" ]]; then
+  echo 'fallback API credentials leaked into subscription preflight' >&2
+  exit 3
+fi
 if [[ -z "\${CODEX_HOME:-}" || ! -s "$CODEX_HOME/auth.json" ]]; then
   echo 'staged subscription credential is unavailable' >&2
   exit 2
@@ -199,6 +203,23 @@ if [[ "$SUBSCRIPTION_AVAILABLE" != 'true' ]]; then
   exit 1
 fi
 printf '%s\n' '{"type":"turn.completed"}'
+`
+  )
+  executable(
+    join(bin, 'sudo'),
+    `#!/usr/bin/env bash
+set -euo pipefail
+if [[ "$1" == 'chown' ]]; then
+  exit 0
+fi
+if [[ "$1" == '-u' && "$2" == 'nobody' && "$3" == '--' ]]; then
+  shift 3
+  if [[ "$1" == 'env' && "$2" == '-i' ]]; then
+    shift 2
+    exec env -i SUBSCRIPTION_AVAILABLE="$SUBSCRIPTION_AVAILABLE" "$@"
+  fi
+fi
+exec "$@"
 `
   )
   const result = spawnSync(
@@ -516,8 +537,10 @@ describe('single Codex workflow contract', () => {
     expect(review.permissions).toEqual({ contents: 'read' })
     expect(review.with).toMatchObject({
       auth_mode: '${{ needs.review_target.outputs.auth_mode }}',
-      model: "${{ vars.CODEX_REVIEW_MODEL || vars.CODEX_CORRECTNESS_MODEL || 'gpt-5.6-sol' }}",
-      effort: "${{ vars.CODEX_REVIEW_EFFORT || vars.CODEX_CORRECTNESS_EFFORT || 'high' }}"
+      model:
+        "${{ vars.CODEX_REVIEW_MODEL || vars.CODEX_CORRECTNESS_MODEL || vars.CODEX_ARCHITECTURE_MODEL || 'gpt-5.6-sol' }}",
+      effort:
+        "${{ vars.CODEX_REVIEW_EFFORT || vars.CODEX_CORRECTNESS_EFFORT || vars.CODEX_ARCHITECTURE_EFFORT || 'high' }}"
     })
     expect(review.with).not.toHaveProperty('scope')
     expect(review.secrets).toEqual({
@@ -655,6 +678,15 @@ describe('single Codex workflow contract', () => {
     expect(installCli.env).toEqual({ CODEX_VERSION: '0.144.6' })
     expect(installCli.run).toContain('npm install -g "@openai/codex@${CODEX_VERSION}"')
     expect(installCli.run).toContain('codex --version')
+    const prepareAuth = getStep(codexWorkflow, 'review', 'Prepare Codex authentication')
+    expect(prepareAuth.run).toContain('sudo -u nobody -- env -i')
+    expect(prepareAuth.run).toContain(
+      'preflight_dir="$(mktemp -d /tmp/codex-auth-preflight-work.XXXXXX)"'
+    )
+    expect(prepareAuth.run).toContain(
+      'sudo chown -R "$preflight_uid:$preflight_gid" "$preflight_home" "$preflight_dir"'
+    )
+    expect(prepareAuth.run).toContain('CODEX_HOME="$preflight_home"')
     expect(getStep(codexWorkflow, 'review', 'Run Codex review').env?.CODEX_PERMISSION_PROFILE).toBe(
       "${{ steps.codex_auth.outputs.auth_mode == 'subscription' && 'ai_review' || ':read-only' }}"
     )

--- a/scripts/ai-review-workflows.test.ts
+++ b/scripts/ai-review-workflows.test.ts
@@ -601,9 +601,9 @@ describe('single Codex workflow contract', () => {
     expect(review.with).toMatchObject({
       auth_mode: '${{ needs.review_target.outputs.auth_mode }}',
       model:
-        "${{ vars.CODEX_REVIEW_MODEL || (needs.review_target.outputs.credential_scope == 'correctness' && vars.CODEX_CORRECTNESS_MODEL) || (needs.review_target.outputs.credential_scope == 'architecture' && vars.CODEX_ARCHITECTURE_MODEL) || ((needs.review_target.outputs.credential_scope == 'shared' || needs.review_target.outputs.credential_scope == 'none') && (vars.CODEX_CORRECTNESS_MODEL || vars.CODEX_ARCHITECTURE_MODEL)) || 'gpt-5.6-sol' }}",
+        "${{ vars.CODEX_REVIEW_MODEL || (needs.review_target.outputs.credential_scope == 'correctness' && vars.CODEX_CORRECTNESS_MODEL) || (needs.review_target.outputs.credential_scope == 'architecture' && vars.CODEX_ARCHITECTURE_MODEL) || ((needs.review_target.outputs.credential_scope == 'review' || needs.review_target.outputs.credential_scope == 'shared' || needs.review_target.outputs.credential_scope == 'none') && (vars.CODEX_CORRECTNESS_MODEL || vars.CODEX_ARCHITECTURE_MODEL)) || 'gpt-5.6-sol' }}",
       effort:
-        "${{ vars.CODEX_REVIEW_EFFORT || (needs.review_target.outputs.credential_scope == 'correctness' && vars.CODEX_CORRECTNESS_EFFORT) || (needs.review_target.outputs.credential_scope == 'architecture' && vars.CODEX_ARCHITECTURE_EFFORT) || ((needs.review_target.outputs.credential_scope == 'shared' || needs.review_target.outputs.credential_scope == 'none') && (vars.CODEX_CORRECTNESS_EFFORT || vars.CODEX_ARCHITECTURE_EFFORT)) || 'high' }}"
+        "${{ vars.CODEX_REVIEW_EFFORT || (needs.review_target.outputs.credential_scope == 'correctness' && vars.CODEX_CORRECTNESS_EFFORT) || (needs.review_target.outputs.credential_scope == 'architecture' && vars.CODEX_ARCHITECTURE_EFFORT) || ((needs.review_target.outputs.credential_scope == 'review' || needs.review_target.outputs.credential_scope == 'shared' || needs.review_target.outputs.credential_scope == 'none') && (vars.CODEX_CORRECTNESS_EFFORT || vars.CODEX_ARCHITECTURE_EFFORT)) || 'high' }}"
     })
     expect(review.with).not.toHaveProperty('scope')
     expect(review.secrets).toEqual({

--- a/scripts/ai-review-workflows.test.ts
+++ b/scripts/ai-review-workflows.test.ts
@@ -102,6 +102,9 @@ type TargetOptions = {
   isFork?: boolean
   forkMode?: 'disabled' | 'manual' | 'automatic'
   reviewMode?: 'both' | 'correctness' | 'architecture' | 'disabled'
+  credentialPairs?: Array<'review' | 'correctness' | 'architecture' | 'shared'>
+  credentialKeys?: Array<'review' | 'correctness' | 'architecture' | 'shared'>
+  credentialBaseUrls?: Array<'review' | 'correctness' | 'architecture' | 'shared'>
 }
 
 function runTarget(options: TargetOptions = {}): {
@@ -123,6 +126,9 @@ printf '%s' "$PR_JSON"
 `
   )
   const event = options.event ?? 'pull_request_target'
+  const credentialPairs = options.credentialPairs ?? ['shared']
+  const credentialKeys = options.credentialKeys ?? credentialPairs
+  const credentialBaseUrls = options.credentialBaseUrls ?? credentialPairs
   const result = spawnSync(
     'bash',
     ['-c', getRun(mainWorkflow, 'review_target', 'Resolve pull request metadata')],
@@ -149,6 +155,14 @@ printf '%s' "$PR_JSON"
         CODEX_REVIEW_AUTH_MODE: options.authMode ?? 'subscription',
         CODEX_REVIEW_MODE: options.reviewMode ?? 'correctness',
         ENABLE_CODEX_REVIEW: options.enabled ?? 'true',
+        REVIEW_API_KEY_CONFIGURED: String(credentialKeys.includes('review')),
+        REVIEW_BASE_URL_CONFIGURED: String(credentialBaseUrls.includes('review')),
+        CORRECTNESS_API_KEY_CONFIGURED: String(credentialKeys.includes('correctness')),
+        CORRECTNESS_BASE_URL_CONFIGURED: String(credentialBaseUrls.includes('correctness')),
+        ARCHITECTURE_API_KEY_CONFIGURED: String(credentialKeys.includes('architecture')),
+        ARCHITECTURE_BASE_URL_CONFIGURED: String(credentialBaseUrls.includes('architecture')),
+        SHARED_API_KEY_CONFIGURED: String(credentialKeys.includes('shared')),
+        SHARED_BASE_URL_CONFIGURED: String(credentialBaseUrls.includes('shared')),
         REVIEW_EVENT: event,
         GITHUB_OUTPUT: output
       }
@@ -169,6 +183,8 @@ type AuthOptions = {
   installAvailable?: boolean
   isFork?: boolean
   openAiApiKey?: string
+  sandboxAvailable?: boolean
+  sandboxProbeAvailable?: boolean
   subscriptionAvailable?: boolean
 }
 
@@ -200,6 +216,15 @@ if [[ -z "\${CODEX_HOME:-}" || ! -s "$CODEX_HOME/auth.json" ]]; then
   echo 'staged subscription credential is unavailable' >&2
   exit 2
 fi
+if [[ "\${1:-}" == 'sandbox' ]]; then
+  if [[ "$SANDBOX_PROBE_AVAILABLE" != 'true' ]]; then
+    exit 4
+  fi
+  if [[ " $* " == *'/auth.json'* ]]; then
+    exit 1
+  fi
+  exit 0
+fi
 if [[ "$SUBSCRIPTION_AVAILABLE" != 'true' ]]; then
   echo 'subscription authentication rejected' >&2
   exit 1
@@ -218,7 +243,10 @@ if [[ "$1" == '-u' && "$2" == 'nobody' && "$3" == '--' ]]; then
   shift 3
   if [[ "$1" == 'env' && "$2" == '-i' ]]; then
     shift 2
-    exec env -i SUBSCRIPTION_AVAILABLE="$SUBSCRIPTION_AVAILABLE" "$@"
+    exec env -i \
+      SANDBOX_PROBE_AVAILABLE="$SANDBOX_PROBE_AVAILABLE" \
+      SUBSCRIPTION_AVAILABLE="$SUBSCRIPTION_AVAILABLE" \
+      "$@"
   fi
 fi
 exec "$@"
@@ -237,6 +265,7 @@ exec "$@"
         CODEX_AUTH_MODE: options.authMode ?? 'api-key',
         CODEX_BASE_URL: options.baseUrl ?? 'https://api.openai.com',
         CODEX_INSTALL_OUTCOME: options.installAvailable === false ? 'failure' : 'success',
+        CODEX_SANDBOX_OUTCOME: options.sandboxAvailable === false ? 'failure' : 'success',
         CODEX_MODEL: 'gpt-5.6-sol',
         GITHUB_OUTPUT: output,
         GITHUB_REPOSITORY: 'aipoch/open-science',
@@ -245,6 +274,7 @@ exec "$@"
         OPENAI_API_KEY: options.openAiApiKey ?? 'sk-test',
         REVIEW_EVENT: options.event ?? 'workflow_dispatch',
         RUNNER_TEMP: root,
+        SANDBOX_PROBE_AVAILABLE: String(options.sandboxProbeAvailable ?? true),
         SUBSCRIPTION_AVAILABLE: String(options.subscriptionAvailable ?? true)
       }
     }
@@ -451,6 +481,31 @@ describe('single Codex workflow contract', () => {
     ).toBe('true')
   })
 
+  it('selects API credentials as an atomic pair with deterministic legacy priority', () => {
+    expect(runTarget({ credentialPairs: ['shared'] }).outputs.credential_scope).toBe('shared')
+    expect(
+      runTarget({ credentialPairs: ['architecture', 'shared'] }).outputs.credential_scope
+    ).toBe('architecture')
+    expect(
+      runTarget({ credentialPairs: ['correctness', 'architecture'] }).outputs.credential_scope
+    ).toBe('correctness')
+    expect(runTarget({ credentialPairs: ['review', 'correctness'] }).outputs.credential_scope).toBe(
+      'review'
+    )
+    expect(
+      runTarget({
+        credentialKeys: ['review', 'correctness'],
+        credentialBaseUrls: ['correctness']
+      }).outputs.credential_scope
+    ).toBe('correctness')
+    expect(
+      runTarget({
+        credentialKeys: ['architecture', 'shared'],
+        credentialBaseUrls: ['review', 'shared']
+      }).outputs.credential_scope
+    ).toBe('shared')
+  })
+
   it('rejects an invalid reviewer enable flag', () => {
     const result = runTarget({ enabled: 'sometimes' })
     expect(result.status).not.toBe(0)
@@ -546,18 +601,18 @@ describe('single Codex workflow contract', () => {
     expect(review.with).toMatchObject({
       auth_mode: '${{ needs.review_target.outputs.auth_mode }}',
       model:
-        "${{ vars.CODEX_REVIEW_MODEL || vars.CODEX_CORRECTNESS_MODEL || vars.CODEX_ARCHITECTURE_MODEL || 'gpt-5.6-sol' }}",
+        "${{ vars.CODEX_REVIEW_MODEL || (needs.review_target.outputs.credential_scope == 'correctness' && vars.CODEX_CORRECTNESS_MODEL) || (needs.review_target.outputs.credential_scope == 'architecture' && vars.CODEX_ARCHITECTURE_MODEL) || ((needs.review_target.outputs.credential_scope == 'shared' || needs.review_target.outputs.credential_scope == 'none') && (vars.CODEX_CORRECTNESS_MODEL || vars.CODEX_ARCHITECTURE_MODEL)) || 'gpt-5.6-sol' }}",
       effort:
-        "${{ vars.CODEX_REVIEW_EFFORT || vars.CODEX_CORRECTNESS_EFFORT || vars.CODEX_ARCHITECTURE_EFFORT || 'high' }}"
+        "${{ vars.CODEX_REVIEW_EFFORT || (needs.review_target.outputs.credential_scope == 'correctness' && vars.CODEX_CORRECTNESS_EFFORT) || (needs.review_target.outputs.credential_scope == 'architecture' && vars.CODEX_ARCHITECTURE_EFFORT) || ((needs.review_target.outputs.credential_scope == 'shared' || needs.review_target.outputs.credential_scope == 'none') && (vars.CODEX_CORRECTNESS_EFFORT || vars.CODEX_ARCHITECTURE_EFFORT)) || 'high' }}"
     })
     expect(review.with).not.toHaveProperty('scope')
     expect(review.secrets).toEqual({
       CODEX_AUTH_JSON:
         "${{ needs.review_target.outputs.auth_mode == 'subscription' && secrets.CODEX_AUTH_JSON || '' }}",
       OPENAI_API_KEY:
-        '${{ secrets.CODEX_REVIEW_API_KEY || secrets.CODEX_CORRECTNESS_API_KEY || secrets.CODEX_ARCHITECTURE_API_KEY || secrets.OPENAI_API_KEY }}',
+        "${{ (needs.review_target.outputs.credential_scope == 'review' && secrets.CODEX_REVIEW_API_KEY) || (needs.review_target.outputs.credential_scope == 'correctness' && secrets.CODEX_CORRECTNESS_API_KEY) || (needs.review_target.outputs.credential_scope == 'architecture' && secrets.CODEX_ARCHITECTURE_API_KEY) || (needs.review_target.outputs.credential_scope == 'shared' && secrets.OPENAI_API_KEY) || '' }}",
       CODEX_BASE_URL:
-        '${{ secrets.CODEX_REVIEW_BASE_URL || secrets.CODEX_CORRECTNESS_BASE_URL || secrets.CODEX_ARCHITECTURE_BASE_URL || secrets.CODEX_BASE_URL }}'
+        "${{ (needs.review_target.outputs.credential_scope == 'review' && secrets.CODEX_REVIEW_BASE_URL) || (needs.review_target.outputs.credential_scope == 'correctness' && secrets.CODEX_CORRECTNESS_BASE_URL) || (needs.review_target.outputs.credential_scope == 'architecture' && secrets.CODEX_ARCHITECTURE_BASE_URL) || (needs.review_target.outputs.credential_scope == 'shared' && secrets.CODEX_BASE_URL) || '' }}"
     })
   })
 
@@ -628,6 +683,28 @@ describe('single Codex workflow contract', () => {
     })
     expect(installFailed.status, installFailed.stderr).toBe(0)
     expect(installFailed.outputs.auth_mode).toBe('api-key')
+
+    const sandboxFailed = runAuth({
+      authJson: JSON.stringify({
+        auth_mode: 'chatgpt',
+        tokens: { refresh_token: 'refresh-seed' }
+      }),
+      authMode: 'subscription',
+      sandboxAvailable: false
+    })
+    expect(sandboxFailed.status, sandboxFailed.stderr).toBe(0)
+    expect(sandboxFailed.outputs.auth_mode).toBe('api-key')
+
+    const sandboxProbeFailed = runAuth({
+      authJson: JSON.stringify({
+        auth_mode: 'chatgpt',
+        tokens: { refresh_token: 'refresh-seed' }
+      }),
+      authMode: 'subscription',
+      sandboxProbeAvailable: false
+    })
+    expect(sandboxProbeFailed.status, sandboxProbeFailed.stderr).toBe(0)
+    expect(sandboxProbeFailed.outputs.auth_mode).toBe('api-key')
   })
 
   it('fails closed when neither subscription nor API-key credentials are available', () => {
@@ -713,9 +790,15 @@ describe('single Codex workflow contract', () => {
       'review',
       'Prepare GitHub-hosted sandbox for subscription auth'
     )
-    expect(sandbox.if).toBe("${{ steps.codex_auth.outputs.auth_mode == 'subscription' }}")
+    expect(sandbox.id).toBe('prepare_subscription_sandbox')
+    expect(sandbox.if).toBe("${{ inputs.auth_mode == 'subscription' }}")
+    expect(sandbox['continue-on-error']).toBe(true)
     expect(sandbox.run).toContain('kernel.unprivileged_userns_clone')
     expect(sandbox.run).toContain('kernel.apparmor_restrict_unprivileged_userns')
+    const stepNames = codexWorkflow.jobs.review.steps?.map(({ name }) => name) ?? []
+    expect(stepNames.indexOf('Prepare GitHub-hosted sandbox for subscription auth')).toBeLessThan(
+      stepNames.indexOf('Prepare Codex authentication')
+    )
   })
 
   it('drops sudo and verifies the subscription credential is denied to sandboxed commands', () => {


### PR DESCRIPTION
## Problem

The active AI review path still spends tokens on two reviewers and does not consistently prefer the configured Codex subscription for automatic pull request events.

## Proposed change

- Add one active AI PR Review (Single) workflow that combines correctness, security, standards, architecture, and integration review.
- Default every admitted automatic PR, workflow dispatch, and fork review to subscription auth.
- Fall back to the configured API key when the pinned Codex CLI cannot be installed, the subscription credential is missing or malformed, or its isolated authentication preflight fails.
- Preserve an explicit api-key override and the existing fork admission policy.
- Keep the previous dual-review workflow file, but remove its direct automatic and manual triggers.
- Keep supplemental subscription guidance internal under .github/action.

## Scope and non-goals

This changes GitHub workflow, internal documentation, label handling, and targeted workflow tests only. It does not modify src, add a repository-wide lock, or remove the legacy workflow file. Concurrency remains scoped per pull request, and each run starts at most one Codex review job.

## Acceptance criteria and validation

- Automatic PR and workflow dispatch paths both prefer subscription auth.
- Allowed fork reviews follow the same preference and fallback chain.
- Explicit api-key mode bypasses subscription setup.
- Subscription CLI setup, credential validation, or auth preflight failure selects API-key auth before checkout and review execution.
- The active workflow invokes one combined reviewer.
- 44 targeted Vitest tests pass.
- actionlint passes for the changed workflows.
- Prettier and targeted ESLint checks pass.
- npm run typecheck passes.
- Full npm test was not run because there are no src changes, as agreed for this change.

## Review focus

Please focus on the authentication selection and fallback chain, the isolation of the temporary subscription credential, and the per-PR trigger and concurrency behavior.