### PR TITLE
feat(providers): update OpenRouter model catalog

### DIFF
--- a/src/shared/provider-registry.test.ts
+++ b/src/shared/provider-registry.test.ts
@@ -138,6 +138,10 @@ describe('provider registry', () => {
     expect(resolveVendorModelReasoningEffort('openrouter', 'anthropic/claude-haiku-4.5')).toEqual({
       supported: false
     })
+    expect(resolveVendorModelReasoningEffort('openrouter', 'anthropic/claude-opus-5')).toEqual({
+      supported: true,
+      slots: ['low', 'medium', 'high', 'xhigh', 'max']
+    })
     expect(resolveVendorModelReasoningEffort('openrouter', 'openai/gpt-5.6-terra')).toEqual({
       supported: true,
       slots: ['none', 'low', 'medium', 'high', 'max']
@@ -152,7 +156,11 @@ describe('provider registry', () => {
     })
     expect(resolveVendorModelReasoningEffort('openrouter', 'moonshotai/kimi-k3')).toEqual({
       supported: true,
-      slots: ['low', 'medium', 'high', 'xhigh', 'max']
+      slots: ['low', 'high', 'max', 'max', 'max']
+    })
+    expect(resolveVendorModelReasoningEffort('openrouter', 'google/gemini-3.6-flash')).toEqual({
+      supported: true,
+      slots: ['minimal', 'low', 'medium', 'high', 'high']
     })
     expect(
       resolveVendorModelReasoningEffort('openrouter', 'google/gemini-3.1-pro-preview')
@@ -198,7 +206,7 @@ describe('provider registry', () => {
     )
     // Curated (300+ live ids would flood the picker), so refresh-from-vendor is hidden.
     expect(resolveVendorModelsUrl('openrouter')).toBeUndefined()
-    expect(defaultVendorModel('openrouter')).toBe('anthropic/claude-opus-4.8')
+    expect(defaultVendorModel('openrouter')).toBe('anthropic/claude-opus-5')
   })
 
   it('routes Xiaomi MIMO through both APIs with a live model list', () => {
@@ -374,8 +382,10 @@ describe('provider registry', () => {
     })
 
     it('returns true for OpenRouter vision-capable models', () => {
+      expect(isVendorModelMultimodal('openrouter', 'anthropic/claude-opus-5')).toBe(true)
       expect(isVendorModelMultimodal('openrouter', 'anthropic/claude-opus-4.8')).toBe(true)
       expect(isVendorModelMultimodal('openrouter', 'openai/gpt-5.5')).toBe(true)
+      expect(isVendorModelMultimodal('openrouter', 'google/gemini-3.6-flash')).toBe(true)
       expect(isVendorModelMultimodal('openrouter', 'google/gemini-3.5-flash')).toBe(true)
       expect(isVendorModelMultimodal('openrouter', 'moonshotai/kimi-k3')).toBe(true)
     })
@@ -429,7 +439,9 @@ describe('provider registry', () => {
     })
 
     it('resolves OpenRouter cross-vendor slugs from OpenRouter metadata', () => {
+      expect(resolveModelContextWindow('openrouter', 'anthropic/claude-opus-5')).toBe(1_000_000)
       expect(resolveModelContextWindow('openrouter', 'anthropic/claude-opus-4.8')).toBe(1_000_000)
+      expect(resolveModelContextWindow('openrouter', 'google/gemini-3.6-flash')).toBe(1_048_576)
       expect(resolveModelContextWindow('openrouter', 'google/gemini-3.1-pro-preview')).toBe(
         1_048_576
       )

--- a/src/shared/provider-registry.ts
+++ b/src/shared/provider-registry.ts
@@ -471,6 +471,11 @@ export const OFFICIAL_VENDORS: OfficialVendor[] = [
     models: [
       // Anthropic
       {
+        id: 'anthropic/claude-opus-5',
+        contextWindow: 1_000_000,
+        reasoningEffort: 'standard-5'
+      },
+      {
         id: 'anthropic/claude-opus-4.8',
         contextWindow: 1_000_000,
         reasoningEffort: 'standard-5'
@@ -540,6 +545,11 @@ export const OFFICIAL_VENDORS: OfficialVendor[] = [
         reasoningEffort: 'unsupported'
       },
       {
+        id: 'google/gemini-3.6-flash',
+        contextWindow: 1_048_576,
+        reasoningEffort: 'minimal-low-medium-high'
+      },
+      {
         id: 'google/gemini-3.5-flash',
         contextWindow: 1_048_576,
         reasoningEffort: 'unsupported'
@@ -558,7 +568,7 @@ export const OFFICIAL_VENDORS: OfficialVendor[] = [
       {
         id: 'moonshotai/kimi-k3',
         contextWindow: 1_048_576,
-        reasoningEffort: 'standard-5'
+        reasoningEffort: 'low-high-max'
       },
       {
         id: 'qwen/qwen3.7-max',
@@ -571,6 +581,7 @@ export const OFFICIAL_VENDORS: OfficialVendor[] = [
     // text-only members (gpt-5.3-codex, deepseek-v4-pro, glm-5.2) are intentionally omitted.
     multimodal: {
       multimodalModels: [
+        'anthropic/claude-opus-5',
         'anthropic/claude-opus-4.8',
         'anthropic/claude-sonnet-5',
         'anthropic/claude-haiku-4.5',
@@ -583,6 +594,7 @@ export const OFFICIAL_VENDORS: OfficialVendor[] = [
         'openai/gpt-5.5-pro',
         'openai/gpt-5.5',
         'google/gemini-3.1-pro-preview',
+        'google/gemini-3.6-flash',
         'google/gemini-3.5-flash',
         'x-ai/grok-4.5',
         'moonshotai/kimi-k3',


### PR DESCRIPTION
## Summary

- add Anthropic Claude Opus 5 to the curated OpenRouter catalog and make it the default
- add Google Gemini 3.6 Flash with context, reasoning, and multimodal metadata
- align Kimi K3 reasoning choices with OpenRouter’s low/high/max capability
- keep the nonexistent kimi-k3-256k slug out of the catalog

## Validation

- npm run typecheck
- npx eslint src/shared/provider-registry.ts src/shared/provider-registry.test.ts
- npx vitest run --exclude=.worktree/** (6966 passed, 113 skipped)