### PR TITLE
feat(uploads): support large file attachments

### DIFF
--- a/src/main/acp/attachment-content.test.ts
+++ b/src/main/acp/attachment-content.test.ts
@@ -2,9 +2,11 @@ import { describe, expect, it } from 'vitest'
 
 import {
   MAX_EMBEDDED_TEXT_UPLOAD_BYTES,
+  buildDatasetAttachmentNotice,
   buildOversizedAttachmentNotice,
   formatBytes,
   imageAttachmentMimeType,
+  isDatasetAttachment,
   isTabularAttachment,
   isTextLikeAttachment
 } from './attachment-content'
@@ -150,6 +152,26 @@ describe('buildOversizedAttachmentNotice', () => {
 
     expect(notice).toContain('line ranges or sections')
     expect(notice).not.toContain('file continues')
+  })
+})
+
+describe('binary dataset attachments', () => {
+  it('recognizes spreadsheet and columnar scientific data formats', () => {
+    expect(isDatasetAttachment('study.xlsx')).toBe(true)
+    expect(isDatasetAttachment('events.parquet', 'application/octet-stream')).toBe(true)
+    expect(isDatasetAttachment('matrix.h5')).toBe(true)
+    expect(isDatasetAttachment('movie.mp4')).toBe(false)
+  })
+
+  it('steers the agent toward schema inspection and notebook computation', () => {
+    const notice = buildDatasetAttachmentNotice({ name: 'study.xlsx', size: 3_000_000_000 })
+
+    expect(notice).toContain('study.xlsx')
+    expect(notice).toContain('available on disk')
+    expect(notice).toContain('schema')
+    expect(notice).toContain('sample')
+    expect(notice).toContain('notebook')
+    expect(notice).toContain('Do not load the whole file')
   })
 })
 

--- a/src/main/acp/attachment-content.test.ts
+++ b/src/main/acp/attachment-content.test.ts
@@ -3,6 +3,7 @@ import { describe, expect, it } from 'vitest'
 import {
   MAX_EMBEDDED_TEXT_UPLOAD_BYTES,
   buildDatasetAttachmentNotice,
+  buildDeferredMediaNotice,
   buildOversizedAttachmentNotice,
   formatBytes,
   imageAttachmentMimeType,
@@ -172,6 +173,20 @@ describe('binary dataset attachments', () => {
     expect(notice).toContain('sample')
     expect(notice).toContain('notebook')
     expect(notice).toContain('Do not load the whole file')
+  })
+})
+
+describe('buildDeferredMediaNotice', () => {
+  it.each([
+    ['image', 'microscopy.png'],
+    ['PDF', 'paper.pdf']
+  ] as const)('describes an oversized %s as an on-disk linked resource', (kind, name) => {
+    const notice = buildDeferredMediaNotice({ name, size: 3 * 1024 * 1024 * 1024, kind })
+
+    expect(notice).toContain(name)
+    expect(notice).toContain('3.0 GB')
+    expect(notice).toContain('too large for automatic in-memory processing')
+    expect(notice).toContain('available on disk via the linked resource below')
   })
 })
 

--- a/src/main/acp/attachment-content.ts
+++ b/src/main/acp/attachment-content.ts
@@ -73,6 +73,35 @@ const TEXT_LIKE_EXTENSIONS = new Set([
 // Column-oriented formats, so the reading hint can name rows/columns rather than generic ranges.
 const TABULAR_EXTENSIONS = new Set(['csv', 'tsv', 'tab', 'psv'])
 
+// Structured data formats that are best inspected with a dataframe/database tool. Text members of
+// this set still take the bounded-preview path; binary members use an on-disk notice plus link.
+const DATASET_EXTENSIONS = new Set([
+  ...TABULAR_EXTENSIONS,
+  'xls',
+  'xlsx',
+  'xlsb',
+  'ods',
+  'parquet',
+  'arrow',
+  'feather',
+  'h5',
+  'hdf',
+  'hdf5',
+  'nc',
+  'netcdf',
+  'sav',
+  'dta',
+  'sas7bdat'
+])
+
+const DATASET_MIME_TYPES = new Set([
+  'application/vnd.ms-excel',
+  'application/vnd.openxmlformats-officedocument.spreadsheetml.sheet',
+  'application/vnd.oasis.opendocument.spreadsheet',
+  'application/vnd.apache.arrow.file',
+  'application/vnd.apache.parquet'
+])
+
 // Lower-cased extension after the final dot, or '' when the name has none.
 const fileExtension = (name: string): string => {
   const dot = name.lastIndexOf('.')
@@ -126,6 +155,14 @@ export const isTabularAttachment = (name: string, mimeType?: string): boolean =>
   if (essence === 'text/csv' || essence === 'text/tab-separated-values') return true
 
   return TABULAR_EXTENSIONS.has(fileExtension(name))
+}
+
+export const isDatasetAttachment = (name: string, mimeType?: string): boolean => {
+  const essence = mimeEssence(mimeType)
+  return (
+    DATASET_EXTENSIONS.has(fileExtension(name)) ||
+    (essence ? DATASET_MIME_TYPES.has(essence) : false)
+  )
 }
 
 // Raster image extensions that vision-capable agents can read as pixels, mapped to the MIME type to
@@ -196,3 +233,18 @@ export const buildOversizedAttachmentNotice = (input: {
     trailer
   ].join('\n')
 }
+
+// Binary spreadsheets and scientific containers cannot provide a useful UTF-8 preview. Give the
+// agent an explicit analysis contract alongside the resource link instead of a context-free URI.
+export const buildDatasetAttachmentNotice = (input: { name: string; size: number }): string =>
+  [
+    `[Attached dataset "${input.name}" (${formatBytes(input.size)}) is available on disk via the linked resource below.`,
+    'Do not load the whole file into the conversation. Inspect its schema and a small sample first, then use the notebook or a streaming/query tool to compute over the full dataset.]'
+  ].join('\n')
+
+export const buildDeferredMediaNotice = (input: {
+  name: string
+  size: number
+  kind: 'image' | 'PDF'
+}): string =>
+  `[Attached ${input.kind} "${input.name}" (${formatBytes(input.size)}) is too large for automatic in-memory processing and is available on disk via the linked resource below.]`

--- a/src/main/acp/file-reference-resolver.test.ts
+++ b/src/main/acp/file-reference-resolver.test.ts
@@ -4,6 +4,7 @@ import { join } from 'node:path'
 import { afterEach, describe, expect, it } from 'vitest'
 
 import { UploadRepository } from '../uploads/repository'
+import { stageUploadFixtures } from '../uploads/repository.test-utils'
 import { createManagedFileReferenceResolver } from './file-reference-resolver'
 
 let root: string | undefined
@@ -17,7 +18,7 @@ describe('managed file reference resolver', () => {
   it('validates upload paths and returns trusted on-disk metadata', async () => {
     root = await mkdtemp(join(tmpdir(), 'file-reference-resolver-'))
     const uploads = new UploadRepository(root)
-    const [pending] = await uploads.stageFiles({
+    const [pending] = await stageUploadFixtures(uploads, {
       files: [
         {
           name: 'study.csv',

--- a/src/main/acp/file-reference-resolver.test.ts
+++ b/src/main/acp/file-reference-resolver.test.ts
@@ -1,0 +1,69 @@
+import { mkdtemp, realpath, rm } from 'node:fs/promises'
+import { tmpdir } from 'node:os'
+import { join } from 'node:path'
+import { afterEach, describe, expect, it } from 'vitest'
+
+import { UploadRepository } from '../uploads/repository'
+import { createManagedFileReferenceResolver } from './file-reference-resolver'
+
+let root: string | undefined
+
+afterEach(async () => {
+  if (root) await rm(root, { recursive: true, force: true })
+  root = undefined
+})
+
+describe('managed file reference resolver', () => {
+  it('validates upload paths and returns trusted on-disk metadata', async () => {
+    root = await mkdtemp(join(tmpdir(), 'file-reference-resolver-'))
+    const uploads = new UploadRepository(root)
+    const [pending] = await uploads.stageFiles({
+      files: [
+        {
+          name: 'study.csv',
+          mimeType: 'text/csv',
+          content: Buffer.from('id,value\n1,2\n').toString('base64')
+        }
+      ]
+    })
+    const [attachment] = await uploads.finalizePendingSessionUploads('session-1', [pending])
+    const resolver = createManagedFileReferenceResolver({ uploads })
+
+    const resolved = await resolver.resolve(
+      { sessionId: 'session-1' },
+      {
+        id: attachment.id,
+        name: attachment.originalName,
+        path: attachment.path,
+        source: 'upload',
+        mimeType: attachment.mimeType
+      }
+    )
+
+    expect(resolved).toMatchObject({
+      absolutePath: await realpath(attachment.path),
+      name: 'study.csv',
+      mimeType: 'text/csv',
+      size: 'id,value\n1,2\n'.length,
+      allowSkillImportReference: true
+    })
+    expect(resolved.uri).toMatch(/^file:/u)
+  })
+
+  it('leaves linked folders unavailable until a capability-validating adapter is registered', async () => {
+    const resolver = createManagedFileReferenceResolver({})
+
+    await expect(
+      resolver.resolve(
+        { sessionId: 'session-1' },
+        {
+          id: 'linked-1',
+          name: 'future.csv',
+          source: 'linked-folder',
+          rootId: 'root-1',
+          relativePath: 'data/future.csv'
+        }
+      )
+    ).rejects.toThrow(/not configured/i)
+  })
+})

--- a/src/main/acp/file-reference-resolver.ts
+++ b/src/main/acp/file-reference-resolver.ts
@@ -1,0 +1,108 @@
+import { stat } from 'node:fs/promises'
+import { pathToFileURL } from 'node:url'
+
+import type { FileReference } from '../../shared/artifacts'
+import type { ArtifactRepository } from '../artifacts/repository'
+import type { UploadRepository } from '../uploads/repository'
+
+export type FileReferenceContext = {
+  sessionId: string
+}
+
+export type ResolvedFileReference = {
+  absolutePath: string
+  uri: string
+  name: string
+  mimeType?: string
+  size: number
+  allowSkillImportReference: boolean
+}
+
+// This adapter is the deliberate extension seam for linked folders and other future file origins.
+// An adapter must validate its own capability before returning an absolute path.
+export type FileReferenceAdapter = {
+  source: FileReference['source']
+  resolve(
+    context: FileReferenceContext,
+    reference: FileReference
+  ): Promise<Omit<ResolvedFileReference, 'uri' | 'size'>>
+}
+
+export class FileReferenceResolver {
+  private readonly adapters = new Map<FileReference['source'], FileReferenceAdapter>()
+
+  constructor(adapters: FileReferenceAdapter[]) {
+    for (const adapter of adapters) this.adapters.set(adapter.source, adapter)
+  }
+
+  async resolve(
+    context: FileReferenceContext,
+    reference: FileReference
+  ): Promise<ResolvedFileReference> {
+    const adapter = this.adapters.get(reference.source)
+    if (!adapter) throw new Error(`File reference source is not configured: ${reference.source}`)
+
+    const resolved = await adapter.resolve(context, reference)
+    const fileInfo = await stat(resolved.absolutePath)
+    if (!fileInfo.isFile()) throw new Error('Referenced path is not a file.')
+
+    return {
+      ...resolved,
+      uri: pathToFileURL(resolved.absolutePath).href,
+      size: fileInfo.size
+    }
+  }
+}
+
+export const createManagedFileReferenceResolver = (dependencies: {
+  uploads?: UploadRepository
+  artifacts?: ArtifactRepository
+}): FileReferenceResolver => {
+  const adapters: FileReferenceAdapter[] = []
+
+  if (dependencies.uploads) {
+    adapters.push({
+      source: 'upload',
+      resolve: async ({ sessionId }, reference) => {
+        if (reference.source !== 'upload') throw new Error('Invalid upload reference.')
+        let absolutePath: string
+        try {
+          absolutePath = await dependencies.uploads!.resolveSessionUploadPath(sessionId, {
+            path: reference.path
+          })
+        } catch {
+          // A turn-scoped `@` selection may intentionally refer to a managed upload from an older
+          // session in the same project. It still has to pass canonical managed-root validation.
+          absolutePath = await dependencies.uploads!.resolveManagedUploadPath({
+            path: reference.path
+          })
+        }
+        return {
+          absolutePath,
+          name: reference.name,
+          mimeType: reference.mimeType,
+          allowSkillImportReference: true
+        }
+      }
+    })
+  }
+
+  if (dependencies.artifacts) {
+    adapters.push({
+      source: 'artifact',
+      resolve: async (_context, reference) => {
+        if (reference.source !== 'artifact') throw new Error('Invalid artifact reference.')
+        return {
+          absolutePath: await dependencies.artifacts!.resolveManagedFilePath({
+            path: reference.path
+          }),
+          name: reference.name,
+          mimeType: reference.mimeType,
+          allowSkillImportReference: false
+        }
+      }
+    })
+  }
+
+  return new FileReferenceResolver(adapters)
+}

--- a/src/main/acp/runtime.test.ts
+++ b/src/main/acp/runtime.test.ts
@@ -29,6 +29,7 @@ import {
 } from '../activity-groups/mcp-server'
 import type { UploadedAttachment } from '../../shared/uploads'
 import { UploadRepository } from '../uploads/repository'
+import { stageUploadFixtures } from '../uploads/repository.test-utils'
 import { MAX_INLINE_IMAGE_TOTAL_BASE64_BYTES } from '../uploads/attachment-media'
 import { ConversationSkillImporter, SkillImportApprovalBroker } from '../skills/conversation-import'
 import {
@@ -1281,7 +1282,7 @@ describe('ACP runtime session management', () => {
   it('sends staged uploads as ACP prompt content blocks', async () => {
     const root = await createTemporaryRoot()
     const uploadRepository = new UploadRepository(root)
-    const stagedAttachments = await uploadRepository.stageFiles({
+    const stagedAttachments = await stageUploadFixtures(uploadRepository, {
       files: [
         {
           name: 'paste.png',
@@ -1346,7 +1347,7 @@ describe('ACP runtime session management', () => {
     const root = await createTemporaryRoot()
     const uploadRepository = new UploadRepository(root)
     const skillArchive = buildStoredSkillArchive('Example Package')
-    const stagedAttachments = await uploadRepository.stageFiles({
+    const stagedAttachments = await stageUploadFixtures(uploadRepository, {
       files: [
         {
           name: 'ordinary-data.zip',
@@ -1429,7 +1430,7 @@ describe('ACP runtime session management', () => {
   it('keeps Skill packages as ordinary archive references when conversation import is disabled', async () => {
     const root = await createTemporaryRoot()
     const uploadRepository = new UploadRepository(root)
-    const stagedAttachments = await uploadRepository.stageFiles({
+    const stagedAttachments = await stageUploadFixtures(uploadRepository, {
       files: [
         {
           name: 'example-package.skill',
@@ -1481,7 +1482,7 @@ describe('ACP runtime session management', () => {
     const uploadRepository = new UploadRepository(root)
     // Some drag/drop and paste sources omit the MIME (undefined) or send a generic octet-stream; the
     // runtime must still recognize these as images by extension and send real pixels, not a file link.
-    const stagedAttachments = await uploadRepository.stageFiles({
+    const stagedAttachments = await stageUploadFixtures(uploadRepository, {
       files: [
         {
           name: 'no-mime.png',
@@ -1534,7 +1535,7 @@ describe('ACP runtime session management', () => {
   it('degrades an image attachment to a resource link when replay images consume the inline budget', async () => {
     const root = await createTemporaryRoot()
     const uploadRepository = new UploadRepository(root)
-    const [attachment] = await uploadRepository.stageFiles({
+    const [attachment] = await stageUploadFixtures(uploadRepository, {
       files: [
         {
           name: 'overflow.png',
@@ -1603,7 +1604,7 @@ describe('ACP runtime session management', () => {
     const session = await runtime.createSession({ cwd: '/workspace' })
 
     const stageImage = (name: string): Promise<UploadedAttachment[]> =>
-      uploadRepository.stageFiles({
+      stageUploadFixtures(uploadRepository, {
         files: [
           { name, mimeType: 'image/png', content: Buffer.from('png-bytes').toString('base64') }
         ]
@@ -1651,7 +1652,7 @@ describe('ACP runtime session management', () => {
     const tailMarker = '\nSENTINEL_PAST_PREVIEW_WINDOW'
     const csvBody = `${header}${filler}${tailMarker}`
     expect(Buffer.byteLength(csvBody, 'utf8')).toBeGreaterThan(512 * 1024)
-    const stagedAttachments = await uploadRepository.stageFiles({
+    const stagedAttachments = await stageUploadFixtures(uploadRepository, {
       files: [
         { name: 'big.csv', mimeType: 'text/csv', content: Buffer.from(csvBody).toString('base64') }
       ]
@@ -2052,7 +2053,7 @@ describe('ACP runtime session management', () => {
     const root = await createTemporaryRoot()
     const uploadRepository = new UploadRepository(root)
     // Non-PDF bytes make extraction fail deterministically; the block must still be text, not the file.
-    const stagedAttachments = await uploadRepository.stageFiles({
+    const stagedAttachments = await stageUploadFixtures(uploadRepository, {
       files: [
         {
           name: 'doc.pdf',
@@ -2165,7 +2166,7 @@ describe('ACP runtime session management', () => {
     const artifactRepository = new ArtifactRepository(root)
 
     // A referenced upload (an already-staged file) resolves through the upload path validator.
-    const [uploadRef] = await uploadRepository.stageFiles({
+    const [uploadRef] = await stageUploadFixtures(uploadRepository, {
       files: [
         {
           name: 'summary.txt',
@@ -2315,7 +2316,7 @@ describe('ACP runtime session management', () => {
     const root = await createTemporaryRoot()
     const uploadRepository = new UploadRepository(root)
     const currentSkillArchive = buildStoredSkillArchive('Current Skill')
-    const staged = await uploadRepository.stageFiles({
+    const staged = await stageUploadFixtures(uploadRepository, {
       files: [
         {
           name: 'current.skill',
@@ -2401,7 +2402,7 @@ describe('ACP runtime session management', () => {
   it('allows a cross-session Skill upload only while the user explicitly references it', async () => {
     const root = await realpath(await createTemporaryRoot())
     const uploads = new UploadRepository(root)
-    const [staged] = await uploads.stageFiles({
+    const [staged] = await stageUploadFixtures(uploads, {
       files: [
         {
           name: 'paper-finder.skill',

--- a/src/main/acp/runtime.ts
+++ b/src/main/acp/runtime.ts
@@ -68,8 +68,11 @@ import { describePromptError, isProviderPromptError } from './prompt-error'
 import {
   ATTACHMENT_PREVIEW_BYTES,
   MAX_EMBEDDED_TEXT_UPLOAD_BYTES,
+  buildDatasetAttachmentNotice,
+  buildDeferredMediaNotice,
   buildOversizedAttachmentNotice,
   imageAttachmentMimeType,
+  isDatasetAttachment,
   isTabularAttachment,
   isTextLikeAttachment,
   mimeEssence
@@ -118,6 +121,10 @@ import type { ResponsesBridgeSkillCandidate } from '../settings/responses-bridge
 import { withDataRootWrite } from '../storage/migration-state'
 import { opencodeStorageDir } from '../agent-framework/opencode'
 import { CodexSkillActivityProjector } from './codex-skill-activity'
+import {
+  createManagedFileReferenceResolver,
+  type FileReferenceResolver
+} from './file-reference-resolver'
 import type { UploadRepository } from '../uploads/repository'
 import type { UploadedAttachment } from '../../shared/uploads'
 import type { ArtifactFile, ArtifactReference } from '../../shared/artifacts'
@@ -130,6 +137,8 @@ import {
   consumeInlineImageBudget,
   extractPdfText,
   ImageContentError,
+  MAX_AUTO_EXTRACT_PDF_BYTES,
+  MAX_AUTO_PROCESS_IMAGE_BYTES,
   MAX_SESSION_INLINE_IMAGE_BYTES,
   type InlineImageBudget
 } from '../uploads/attachment-media'
@@ -738,6 +747,7 @@ class AcpRuntime {
   private readonly artifactRepository: ArtifactRepository | undefined
   private readonly artifactRunRegistry: ArtifactRunRegistry | undefined
   private readonly uploadRepository: UploadRepository | undefined
+  private readonly fileReferenceResolver: FileReferenceResolver
   private readonly artifactSessionIds = new Map<string, string>()
   // app session id -> the notebook routing id registered with the http MCP host, so it can be
   // unregistered on session delete (the artifact routing id is tracked in artifactSessionIds).
@@ -780,6 +790,10 @@ class AcpRuntime {
       ? (options.artifacts.runRegistry ?? new ArtifactRunRegistry())
       : undefined
     this.uploadRepository = options.uploads?.repository
+    this.fileReferenceResolver = createManagedFileReferenceResolver({
+      uploads: this.uploadRepository,
+      artifacts: this.artifactRepository
+    })
     this.permissionBroker = new AcpPermissionBroker((request) => {
       // Relabel to the app-facing id when this session was adopted onto a replaced agent.
       const sessionId = this.agentToAppSessionId.get(request.sessionId) ?? request.sessionId
@@ -2963,55 +2977,19 @@ class AcpRuntime {
     sessionId: string,
     reference: ArtifactReference
   ): Promise<ContentBlock[]> {
-    const { filePath, allowSkillImportReference } = await this.resolveReferencedArtifactPath(
-      sessionId,
-      reference
-    )
-    const { size } = await stat(filePath)
+    const resolvedReference = await this.fileReferenceResolver.resolve({ sessionId }, reference)
 
     return this.buildFileContentBlock({
       sessionId,
-      absolutePath: filePath,
-      uri: pathToFileURL(filePath).href,
-      name: reference.name,
-      mimeType: reference.mimeType,
-      size,
+      absolutePath: resolvedReference.absolutePath,
+      uri: resolvedReference.uri,
+      name: resolvedReference.name,
+      mimeType: resolvedReference.mimeType,
+      size: resolvedReference.size,
       // The import tool currently owns only session uploads. Artifact-store paths remain ordinary
       // references so the prompt never advertises a URI that main will reject at the trust boundary.
-      allowSkillImportReference
+      allowSkillImportReference: resolvedReference.allowSkillImportReference
     })
-  }
-
-  // Resolves a referenced file through the managed-path validator for its owning repository.
-  private async resolveReferencedArtifactPath(
-    sessionId: string,
-    reference: ArtifactReference
-  ): Promise<{ filePath: string; allowSkillImportReference: boolean }> {
-    if (reference.source === 'upload') {
-      if (!this.uploadRepository) throw new Error('Upload storage is not configured.')
-      try {
-        return {
-          filePath: await this.uploadRepository.resolveSessionUploadPath(sessionId, {
-            path: reference.path
-          }),
-          allowSkillImportReference: true
-        }
-      } catch {
-        // An explicit `@` reference grants this exact managed upload path for the active turn. The
-        // importer still requires the matching turn token and URI allowlist entry, and rejects every
-        // unreferenced cross-session path through its normal ownership check.
-        return {
-          filePath: await this.uploadRepository.resolveManagedUploadPath({ path: reference.path }),
-          allowSkillImportReference: true
-        }
-      }
-    }
-
-    if (!this.artifactRepository) throw new Error('Artifact storage is not configured.')
-    return {
-      filePath: await this.artifactRepository.resolveManagedFilePath({ path: reference.path }),
-      allowSkillImportReference: false
-    }
   }
 
   // Builds the richest ACP content block that is safe for a resolved file, shared by uploads and
@@ -3085,6 +3063,15 @@ class AcpRuntime {
     const imageMimeType = imageAttachmentMimeType(name, mimeType)
 
     if (imageMimeType) {
+      if (size > MAX_AUTO_PROCESS_IMAGE_BYTES) {
+        return [
+          {
+            type: 'text',
+            text: buildDeferredMediaNotice({ name, size, kind: 'image' })
+          },
+          { type: 'resource_link', uri, name, title: name, mimeType: imageMimeType, size }
+        ]
+      }
       const { data, mimeType: outMimeType } = await buildImageContentData(
         absolutePath,
         imageMimeType,
@@ -3109,6 +3096,15 @@ class AcpRuntime {
     // PDFs are never inlined as base64 (a 20MB file overflows the 32MB request limit); instead we
     // extract selectable text so the model reads readable content. Page images are a future option.
     if (this.isPdfFile(name, mimeType)) {
+      if (size > MAX_AUTO_EXTRACT_PDF_BYTES) {
+        return [
+          {
+            type: 'text',
+            text: buildDeferredMediaNotice({ name, size, kind: 'PDF' })
+          },
+          { type: 'resource_link', uri, name, title: name, mimeType: 'application/pdf', size }
+        ]
+      }
       return [await this.createPdfContentBlock(name, absolutePath, uri)]
     }
 
@@ -3143,6 +3139,13 @@ class AcpRuntime {
             tabular: isTabularAttachment(name, mimeType)
           })
         },
+        { type: 'resource_link', uri, name, title: name, mimeType, size }
+      ]
+    }
+
+    if (isDatasetAttachment(name, mimeType)) {
+      return [
+        { type: 'text', text: buildDatasetAttachmentNotice({ name, size }) },
         { type: 'resource_link', uri, name, title: name, mimeType, size }
       ]
     }

--- a/src/main/acp/runtime.ts
+++ b/src/main/acp/runtime.ts
@@ -127,7 +127,7 @@ import {
 } from './file-reference-resolver'
 import type { UploadRepository } from '../uploads/repository'
 import type { UploadedAttachment } from '../../shared/uploads'
-import type { ArtifactFile, ArtifactReference } from '../../shared/artifacts'
+import type { ArtifactFile, FileReference } from '../../shared/artifacts'
 import { isMediaOverflowError } from '../../shared/media-overflow'
 import type { AcpRuntimeActivity, AcpRuntimeActivityOptions } from './runtime-activity'
 import { REVIEWER_MCP_SERVER_NAME, REVIEWER_MCP_TOOLS } from '../../shared/reviewer'
@@ -2916,20 +2916,20 @@ class AcpRuntime {
   // session-owner check for every path that was not selected in this turn.
   private async authorizeReferencedSkillUploads(
     sessionId: string,
-    references: ArtifactReference[]
+    references: FileReference[]
   ): Promise<(() => void) | undefined> {
     if (!this.skillImportEnabled) return undefined
 
     const authorize = this.skillImportOptions?.authorizeReferencedUploads
     if (!authorize) return undefined
 
-    const paths = references
-      .filter((reference) => {
-        if (reference.source !== 'upload') return false
-        const normalizedName = reference.name.toLowerCase()
-        return normalizedName.endsWith('.skill') || normalizedName.endsWith('.zip')
-      })
-      .map((reference) => reference.path)
+    const paths = references.flatMap((reference) => {
+      if (reference.source !== 'upload') return []
+      const normalizedName = reference.name.toLowerCase()
+      return normalizedName.endsWith('.skill') || normalizedName.endsWith('.zip')
+        ? [reference.path]
+        : []
+    })
 
     return paths.length > 0 ? authorize(sessionId, paths) : undefined
   }
@@ -2975,7 +2975,7 @@ class AcpRuntime {
   // Converts one `@`-mentioned artifact into the same content block an equivalent upload produces.
   private async createReferencedArtifactContentBlock(
     sessionId: string,
-    reference: ArtifactReference
+    reference: FileReference
   ): Promise<ContentBlock[]> {
     const resolvedReference = await this.fileReferenceResolver.resolve({ sessionId }, reference)
 

--- a/src/main/skills/conversation-import.test.ts
+++ b/src/main/skills/conversation-import.test.ts
@@ -7,6 +7,7 @@ import { deflateRawSync } from 'node:zlib'
 import { afterEach, describe, expect, it, vi } from 'vitest'
 
 import { UploadRepository } from '../uploads/repository'
+import { stageUploadFixtures } from '../uploads/repository.test-utils'
 import {
   ConversationSkillImporter,
   SkillImportApprovalBroker,
@@ -103,7 +104,7 @@ describe('ConversationSkillImporter', () => {
         )
       }
     ])
-    const [staged] = await uploads.stageFiles({
+    const [staged] = await stageUploadFixtures(uploads, {
       files: [
         {
           name: 'paper-finder.skill',
@@ -162,7 +163,7 @@ describe('ConversationSkillImporter', () => {
         content: Buffer.from('---\nname: Private Skill\n---\nDo the thing.', 'utf8')
       }
     ])
-    const [staged] = await uploads.stageFiles({
+    const [staged] = await stageUploadFixtures(uploads, {
       files: [{ name: 'private.skill', content: zip.toString('base64') }]
     })
     const [attachment] = await uploads.finalizePendingSessionUploads('session-2', [staged])
@@ -189,7 +190,7 @@ describe('ConversationSkillImporter', () => {
     const root = await mkdtemp(join(tmpdir(), 'conversation-skill-import-'))
     roots.push(root)
     const uploads = new UploadRepository(root)
-    const [staged] = await uploads.stageFiles({
+    const [staged] = await stageUploadFixtures(uploads, {
       files: [
         {
           name: 'ordinary-data.zip',
@@ -226,7 +227,7 @@ describe('ConversationSkillImporter', () => {
     const root = await mkdtemp(join(tmpdir(), 'conversation-skill-import-'))
     roots.push(root)
     const uploads = new UploadRepository(root)
-    const [staged] = await uploads.stageFiles({
+    const [staged] = await stageUploadFixtures(uploads, {
       files: [
         {
           name: 'older-turn.skill',
@@ -269,7 +270,7 @@ describe('ConversationSkillImporter', () => {
     roots.push(root)
     const uploads = new UploadRepository(root)
     const skills = new UserSkillRepository(root)
-    const [staged] = await uploads.stageFiles({
+    const [staged] = await stageUploadFixtures(uploads, {
       files: [
         {
           name: 'slow-preview.skill',
@@ -339,7 +340,7 @@ describe('ConversationSkillImporter', () => {
     const root = await mkdtemp(join(tmpdir(), 'conversation-skill-import-'))
     roots.push(root)
     const uploads = new UploadRepository(root)
-    const [staged] = await uploads.stageFiles({
+    const [staged] = await stageUploadFixtures(uploads, {
       files: [
         {
           name: 'duplicate-targets.skill',
@@ -402,7 +403,7 @@ describe('ConversationSkillImporter', () => {
     const root = await mkdtemp(join(tmpdir(), 'conversation-skill-import-'))
     roots.push(root)
     const uploads = new UploadRepository(root)
-    const [staged] = await uploads.stageFiles({
+    const [staged] = await stageUploadFixtures(uploads, {
       files: [
         {
           name: 'replacement.skill',

--- a/src/main/storage/migration-state.test.ts
+++ b/src/main/storage/migration-state.test.ts
@@ -3,6 +3,7 @@ import { afterEach, describe, expect, it, vi } from 'vitest'
 vi.mock('electron', () => ({ dialog: { showMessageBoxSync: vi.fn() } }))
 
 const {
+  acquireDataRootWriter,
   beginMigration,
   clearMigrationPending,
   endMigration,
@@ -106,6 +107,23 @@ describe('migration-state', () => {
 
     releaseWrite?.()
     await activeWrite
+    await drainPromise
+    expect(drained).toBe(true)
+  })
+
+  it('keeps a logical writer active across calls until its idempotent release', async () => {
+    const release = acquireDataRootWriter()
+    beginMigration()
+
+    let drained = false
+    const drainPromise = waitForDataRootWriters().then(() => {
+      drained = true
+    })
+    await Promise.resolve()
+    expect(drained).toBe(false)
+
+    release()
+    release()
     await drainPromise
     expect(drained).toBe(true)
   })

--- a/src/main/storage/migration-state.ts
+++ b/src/main/storage/migration-state.ts
@@ -54,17 +54,31 @@ export const assertNoMigrationPending = (): void => {
   }
 }
 
-export const withDataRootWrite = async <Result>(write: () => Promise<Result>): Promise<Result> => {
+// Acquires one logical writer slot until the returned release callback is invoked. Long-lived
+// multi-call operations (for example a chunked upload) keep this lease across their entire protocol
+// so migration cannot begin in a gap between individual IPC requests. Release is idempotent.
+export const acquireDataRootWriter = (): (() => void) => {
   assertNoMigrationPending()
   activeDataRootWriters += 1
-  try {
-    return await write()
-  } finally {
+
+  let released = false
+  return () => {
+    if (released) return
+    released = true
     activeDataRootWriters -= 1
     if (activeDataRootWriters === 0) {
       for (const resolve of writerDrainWaiters) resolve()
       writerDrainWaiters.clear()
     }
+  }
+}
+
+export const withDataRootWrite = async <Result>(write: () => Promise<Result>): Promise<Result> => {
+  const release = acquireDataRootWriter()
+  try {
+    return await write()
+  } finally {
+    release()
   }
 }
 

--- a/src/main/uploads/attachment-media.test.ts
+++ b/src/main/uploads/attachment-media.test.ts
@@ -1,4 +1,4 @@
-import { mkdtemp, rm, writeFile } from 'node:fs/promises'
+import { mkdtemp, rm, truncate, writeFile } from 'node:fs/promises'
 import { tmpdir } from 'node:os'
 import { join } from 'node:path'
 
@@ -10,6 +10,8 @@ import {
   consumeInlineImageBudget,
   extractPdfText,
   ImageContentError,
+  MAX_AUTO_EXTRACT_PDF_BYTES,
+  MAX_AUTO_PROCESS_IMAGE_BYTES,
   MAX_IMAGE_PAYLOAD_BYTES,
   MAX_INLINE_IMAGE_TOTAL_BASE64_BYTES,
   MAX_SESSION_INLINE_IMAGE_BYTES,
@@ -90,6 +92,16 @@ describe('MAX_IMAGE_PAYLOAD_BYTES', () => {
 })
 
 describe('buildImageContentData', () => {
+  it('does not decode image sources above the automatic processing limit', async () => {
+    const filePath = join(root, 'huge.png')
+    await writeFile(filePath, Buffer.from('small fixture'))
+
+    await expect(
+      buildImageContentData(filePath, 'image/png', MAX_AUTO_PROCESS_IMAGE_BYTES + 1)
+    ).rejects.toMatchObject({ code: 'IMAGE_SOURCE_TOO_LARGE' })
+    expect(createFromPath).not.toHaveBeenCalled()
+  })
+
   it('passes small images through untouched as raw base64', async () => {
     const filePath = join(root, 'small.png')
     const bytes = Buffer.from('tiny-image-bytes')
@@ -221,6 +233,15 @@ describe('consumeInlineImageBudget', () => {
 })
 
 describe('extractPdfText', () => {
+  it('does not read PDF sources above the automatic extraction limit', async () => {
+    const filePath = join(root, 'huge.pdf')
+    await writeFile(filePath, Buffer.from('%PDF-1.4'))
+    await truncate(filePath, MAX_AUTO_EXTRACT_PDF_BYTES + 1)
+
+    await expect(extractPdfText(filePath)).rejects.toThrow(/automatic extraction limit/i)
+    expect(getDocument).not.toHaveBeenCalled()
+  })
+
   it('joins per-page text with page markers', async () => {
     const filePath = join(root, 'doc.pdf')
     await writeFile(filePath, Buffer.from('%PDF-1.4 fake'))

--- a/src/main/uploads/attachment-media.ts
+++ b/src/main/uploads/attachment-media.ts
@@ -1,11 +1,16 @@
 import { createRequire } from 'node:module'
-import { readFile } from 'node:fs/promises'
+import { readFile, stat } from 'node:fs/promises'
 import { dirname, join } from 'node:path'
 import { pathToFileURL } from 'node:url'
 
 // Images larger than this are downscaled/re-encoded before inlining so a single upload never
 // blows past the model's per-image (~5MB) and total-request (~32MB) limits after base64 growth.
 export const MAX_INLINE_IMAGE_BYTES = 2 * 1024 * 1024
+
+// Source files above these limits stay as resource links. They must never be decoded/read in full in
+// the main process merely because the managed upload storage now accepts multi-gigabyte files.
+export const MAX_AUTO_PROCESS_IMAGE_BYTES = 50 * 1024 * 1024
+export const MAX_AUTO_EXTRACT_PDF_BYTES = 50 * 1024 * 1024
 
 // A single image must stay under the provider per-image limit AFTER base64 growth. Anthropic rejects
 // an image near 5MB and OpenCode's default image config caps base64 at 5MB (5242880); base64 inflates
@@ -54,6 +59,7 @@ export type ImageContentErrorCode =
   | 'IMAGE_DECODE_FAILED'
   | 'IMAGE_PROCESSING_FAILED'
   | 'IMAGE_PAYLOAD_TOO_LARGE'
+  | 'IMAGE_SOURCE_TOO_LARGE'
   | 'IMAGE_TOTAL_BUDGET_EXCEEDED'
 
 type ImageContentErrorDetails = {
@@ -129,6 +135,14 @@ export const buildImageContentData = async (
   size: number
 ): Promise<ImageContentData> => {
   const fallbackMimeType = mimeType ?? 'application/octet-stream'
+
+  if (size > MAX_AUTO_PROCESS_IMAGE_BYTES) {
+    throw new ImageContentError(
+      'IMAGE_SOURCE_TOO_LARGE',
+      `Image source is ${size} bytes, exceeding the automatic processing limit.`,
+      { sourceBytes: size, limitBytes: MAX_AUTO_PROCESS_IMAGE_BYTES }
+    )
+  }
 
   if (size <= MAX_INLINE_IMAGE_BYTES) {
     return { data: (await readFile(filePath)).toString('base64'), mimeType: fallbackMimeType }
@@ -222,6 +236,12 @@ const resolvePdfjsAssetUrls = (): { cMapUrl: string; standardFontDataUrl: string
 // Extracts selectable text from a PDF so the model receives readable content instead of the raw
 // (base64) file, which would otherwise overflow the request size limit.
 export const extractPdfText = async (filePath: string): Promise<PdfTextResult> => {
+  const fileInfo = await stat(filePath)
+  if (fileInfo.size > MAX_AUTO_EXTRACT_PDF_BYTES) {
+    throw new Error(
+      `PDF source is ${fileInfo.size} bytes, exceeding the automatic extraction limit.`
+    )
+  }
   const pdfjs = (await import('pdfjs-dist/legacy/build/pdf.mjs')) as typeof import('pdfjs-dist')
   const { cMapUrl, standardFontDataUrl } = resolvePdfjsAssetUrls()
   const fileData = await readFile(filePath)

--- a/src/main/uploads/ipc.test.ts
+++ b/src/main/uploads/ipc.test.ts
@@ -300,6 +300,211 @@ describe('default upload repository', () => {
     expect(repository.abortTransfer).toHaveBeenCalledWith({ transferId: 'transfer-4' })
   })
 
+  it('aborts a native-path upload and releases its migration lease when its renderer is destroyed', async () => {
+    let rejectStage: ((error: Error) => void) | undefined
+    const repository = {
+      stageLocalFile: vi.fn(
+        () =>
+          new Promise((_resolve, reject) => {
+            rejectStage = reject
+          })
+      ),
+      abortTransfer: vi.fn(async () => {
+        rejectStage?.(new Error('Upload cancelled: data.csv'))
+      })
+    } as unknown as UploadRepository
+    registerUploadIpcHandlers(repository)
+    const stageLocalFile = ipcHandlers.get('uploads:stage-local-file')!
+    const sender = createIpcEvent()
+
+    const stagePromise = Promise.resolve(
+      stageLocalFile(sender.event, {
+        transferId: 'local-transfer-1',
+        sourcePath: '/fixtures/data.csv',
+        name: 'data.csv',
+        size: 10
+      })
+    )
+    await Promise.resolve()
+    beginMigration()
+    sender.emit('destroyed')
+    let drained = false
+    const drainPromise = waitForDataRootWriters().then(() => {
+      drained = true
+    })
+    await Promise.resolve()
+    expect(drained).toBe(false)
+
+    await expect(stagePromise).rejects.toThrow(/upload cancelled/i)
+    await drainPromise
+    expect(repository.abortTransfer).toHaveBeenCalledWith({ transferId: 'local-transfer-1' })
+    expect(drained).toBe(true)
+  })
+
+  it('deletes a native-path upload that finishes after its renderer starts navigating', async () => {
+    let finishStage: ((attachment: unknown) => void) | undefined
+    const attachment = {
+      id: 'attachment-1',
+      sessionId: '.pending',
+      name: 'data.csv',
+      originalName: 'data.csv',
+      path: '/managed/.pending/data.csv',
+      size: 10
+    }
+    const repository = {
+      stageLocalFile: vi.fn(
+        () =>
+          new Promise((resolve) => {
+            finishStage = resolve
+          })
+      ),
+      abortTransfer: vi.fn(async () => undefined),
+      deleteUpload: vi.fn(async () => undefined)
+    } as unknown as UploadRepository
+    registerUploadIpcHandlers(repository)
+    const stageLocalFile = ipcHandlers.get('uploads:stage-local-file')!
+    const sender = createIpcEvent()
+
+    const stagePromise = Promise.resolve(
+      stageLocalFile(sender.event, {
+        transferId: 'local-transfer-2',
+        sourcePath: '/fixtures/data.csv',
+        name: 'data.csv',
+        size: 10
+      })
+    )
+    await Promise.resolve()
+    sender.emit('did-start-navigation', {}, 'http://localhost/', false, false)
+    expect(repository.abortTransfer).not.toHaveBeenCalled()
+
+    sender.emit('did-start-navigation', {}, 'http://localhost/', false, true)
+    finishStage?.(attachment)
+
+    await expect(stagePromise).rejects.toThrow(/renderer is no longer available/i)
+    expect(repository.abortTransfer).toHaveBeenCalledWith({ transferId: 'local-transfer-2' })
+    expect(repository.deleteUpload).toHaveBeenCalledWith({ path: attachment.path })
+  })
+
+  it('keeps a completed native-path upload owned until the renderer claims it', async () => {
+    const attachment = {
+      id: 'attachment-awaiting-claim',
+      sessionId: '.pending',
+      name: 'data.csv',
+      originalName: 'data.csv',
+      path: '/managed/.pending/data.csv',
+      size: 10
+    }
+    const repository = {
+      stageLocalFile: vi.fn(async () => attachment),
+      abortTransfer: vi.fn(async () => undefined),
+      deleteUpload: vi.fn(async () => undefined)
+    } as unknown as UploadRepository
+    registerUploadIpcHandlers(repository)
+    const stageLocalFile = ipcHandlers.get('uploads:stage-local-file')!
+    const sender = createIpcEvent()
+
+    await expect(
+      stageLocalFile(sender.event, {
+        transferId: 'local-transfer-awaiting-claim',
+        sourcePath: '/fixtures/data.csv',
+        name: 'data.csv',
+        size: 10
+      })
+    ).resolves.toEqual(attachment)
+
+    beginMigration()
+    let drained = false
+    const drainPromise = waitForDataRootWriters().then(() => {
+      drained = true
+    })
+    await Promise.resolve()
+    expect(drained).toBe(false)
+
+    sender.emit('destroyed')
+    await drainPromise
+    await vi.waitFor(() => {
+      expect(repository.deleteUpload).toHaveBeenCalledWith({ path: attachment.path })
+    })
+    expect(drained).toBe(true)
+  })
+
+  it('releases a completed native-path upload after the owning renderer claims it', async () => {
+    const attachment = {
+      id: 'attachment-claimed',
+      sessionId: '.pending',
+      name: 'data.csv',
+      originalName: 'data.csv',
+      path: '/managed/.pending/data.csv',
+      size: 10
+    }
+    const repository = {
+      stageLocalFile: vi.fn(async () => attachment),
+      abortTransfer: vi.fn(async () => undefined),
+      deleteUpload: vi.fn(async () => undefined)
+    } as unknown as UploadRepository
+    registerUploadIpcHandlers(repository)
+    const stageLocalFile = ipcHandlers.get('uploads:stage-local-file')!
+    const claim = ipcHandlers.get('uploads:claim-local-file')!
+    const sender = createIpcEvent()
+
+    await stageLocalFile(sender.event, {
+      transferId: 'local-transfer-claimed',
+      sourcePath: '/fixtures/data.csv',
+      name: 'data.csv',
+      size: 10
+    })
+    await claim(sender.event, { transferId: 'local-transfer-claimed' })
+    sender.emit('destroyed')
+
+    expect(repository.deleteUpload).not.toHaveBeenCalled()
+  })
+
+  it('does not let another renderer cancel an active native-path upload', async () => {
+    let finishStage: ((attachment: unknown) => void) | undefined
+    const attachment = {
+      id: 'attachment-owned',
+      sessionId: '.pending',
+      name: 'data.csv',
+      originalName: 'data.csv',
+      path: '/managed/.pending/data.csv',
+      size: 10
+    }
+    const repository = {
+      stageLocalFile: vi.fn(
+        () =>
+          new Promise((resolve) => {
+            finishStage = resolve
+          })
+      ),
+      abortTransfer: vi.fn(async () => undefined)
+    } as unknown as UploadRepository
+    registerUploadIpcHandlers(repository)
+    const stageLocalFile = ipcHandlers.get('uploads:stage-local-file')!
+    const abort = ipcHandlers.get('uploads:abort-transfer')!
+    const claim = ipcHandlers.get('uploads:claim-local-file')!
+    const owner = createIpcEvent(1)
+    const otherRenderer = createIpcEvent(2)
+
+    const stagePromise = Promise.resolve(
+      stageLocalFile(owner.event, {
+        transferId: 'local-transfer-owned',
+        sourcePath: '/fixtures/data.csv',
+        name: 'data.csv',
+        size: 10
+      })
+    )
+    await Promise.resolve()
+
+    await expect(
+      abort(otherRenderer.event, { transferId: 'local-transfer-owned' })
+    ).rejects.toThrow(/another renderer/i)
+    expect(repository.abortTransfer).not.toHaveBeenCalled()
+
+    finishStage?.(attachment)
+    await expect(stagePromise).resolves.toEqual(attachment)
+    await claim(owner.event, { transferId: 'local-transfer-owned' })
+  })
+
   it('does not expose the removed whole-file base64 staging channel', () => {
     registerUploadIpcHandlers({} as UploadRepository)
 

--- a/src/main/uploads/ipc.test.ts
+++ b/src/main/uploads/ipc.test.ts
@@ -31,6 +31,43 @@ import { createDefaultUploadRepository, registerUploadIpcHandlers } from './ipc'
 import type { UploadRepository } from './repository'
 import { stageUploadFixtures } from './repository.test-utils'
 
+const createIpcEvent = (
+  id: number = 1
+): {
+  event: unknown
+  emit: (channel: string, ...args: unknown[]) => void
+} => {
+  const listeners = new Map<string, Set<(...args: unknown[]) => void>>()
+  const on = (channel: string, listener: (...args: unknown[]) => void): void => {
+    const channelListeners = listeners.get(channel) ?? new Set()
+    channelListeners.add(listener)
+    listeners.set(channel, channelListeners)
+  }
+  const removeListener = (channel: string, listener: (...args: unknown[]) => void): void => {
+    listeners.get(channel)?.delete(listener)
+  }
+  const sender = {
+    id,
+    send: vi.fn(),
+    on: vi.fn(on),
+    once: vi.fn((channel: string, listener: (...args: unknown[]) => void) => {
+      const onceListener = (...args: unknown[]): void => {
+        removeListener(channel, onceListener)
+        listener(...args)
+      }
+      on(channel, onceListener)
+    }),
+    removeListener: vi.fn(removeListener)
+  }
+
+  return {
+    event: { sender },
+    emit: (channel, ...args) => {
+      for (const listener of [...(listeners.get(channel) ?? [])]) listener(...args)
+    }
+  }
+}
+
 describe('default upload repository', () => {
   let homeRoot: string | undefined
 
@@ -93,10 +130,11 @@ describe('default upload repository', () => {
     const begin = ipcHandlers.get('uploads:begin-transfer')!
     const append = ipcHandlers.get('uploads:append-transfer')!
     const finish = ipcHandlers.get('uploads:finish-transfer')!
+    const { event } = createIpcEvent()
 
-    await begin(undefined, { transferId: 'transfer-1', name: 'data.csv', size: 10 })
+    await begin(event, { transferId: 'transfer-1', name: 'data.csv', size: 10 })
     beginMigration()
-    await append(undefined, {
+    await append(event, {
       transferId: 'transfer-1',
       offset: 0,
       chunk: new Uint8Array(10)
@@ -109,7 +147,7 @@ describe('default upload repository', () => {
     await Promise.resolve()
     expect(drained).toBe(false)
 
-    await finish(undefined, { transferId: 'transfer-1' })
+    await finish(event, { transferId: 'transfer-1' })
     await drainPromise
     expect(drained).toBe(true)
     expect(repository.appendTransfer).toHaveBeenCalledOnce()
@@ -130,12 +168,13 @@ describe('default upload repository', () => {
     registerUploadIpcHandlers(repository)
     const begin = ipcHandlers.get('uploads:begin-transfer')!
     const abort = ipcHandlers.get('uploads:abort-transfer')!
+    const { event } = createIpcEvent()
 
     const beginPromise = Promise.resolve(
-      begin(undefined, { transferId: 'transfer-2', name: 'data.csv', size: 10 })
+      begin(event, { transferId: 'transfer-2', name: 'data.csv', size: 10 })
     )
     beginMigration()
-    const abortPromise = Promise.resolve(abort(undefined, { transferId: 'transfer-2' }))
+    const abortPromise = Promise.resolve(abort(event, { transferId: 'transfer-2' }))
     let drained = false
     const drainPromise = waitForDataRootWriters().then(() => {
       drained = true
@@ -144,11 +183,121 @@ describe('default upload repository', () => {
     expect(drained).toBe(false)
 
     finishBegin?.()
-    await beginPromise
+    await expect(beginPromise).rejects.toThrow(/renderer is no longer available/i)
     await abortPromise
     await drainPromise
     expect(drained).toBe(true)
     expect(repository.abortTransfer).toHaveBeenCalledWith({ transferId: 'transfer-2' })
+  })
+
+  it('aborts transfers and releases migration leases when their renderer is destroyed', async () => {
+    const repository = {
+      beginTransfer: vi.fn(async () => ({
+        transferId: 'transfer-3',
+        name: 'data.csv',
+        receivedBytes: 0,
+        totalBytes: 10
+      })),
+      abortTransfer: vi.fn(async () => undefined)
+    } as unknown as UploadRepository
+    registerUploadIpcHandlers(repository)
+    const begin = ipcHandlers.get('uploads:begin-transfer')!
+    const sender = createIpcEvent()
+
+    await begin(sender.event, { transferId: 'transfer-3', name: 'data.csv', size: 10 })
+    beginMigration()
+    let drained = false
+    const drainPromise = waitForDataRootWriters().then(() => {
+      drained = true
+    })
+    await Promise.resolve()
+    expect(drained).toBe(false)
+
+    sender.emit('destroyed')
+    await drainPromise
+    expect(drained).toBe(true)
+    expect(repository.abortTransfer).toHaveBeenCalledWith({ transferId: 'transfer-3' })
+  })
+
+  it('keeps the teardown lease until an in-flight append has settled', async () => {
+    let finishAppend: ((status: unknown) => void) | undefined
+    const repository = {
+      beginTransfer: vi.fn(async () => ({
+        transferId: 'transfer-in-flight',
+        name: 'data.csv',
+        receivedBytes: 0,
+        totalBytes: 10
+      })),
+      appendTransfer: vi.fn(
+        () =>
+          new Promise((resolve) => {
+            finishAppend = resolve
+          })
+      ),
+      abortTransfer: vi.fn(async () => undefined)
+    } as unknown as UploadRepository
+    registerUploadIpcHandlers(repository)
+    const begin = ipcHandlers.get('uploads:begin-transfer')!
+    const append = ipcHandlers.get('uploads:append-transfer')!
+    const sender = createIpcEvent()
+
+    await begin(sender.event, {
+      transferId: 'transfer-in-flight',
+      name: 'data.csv',
+      size: 10
+    })
+    const appendPromise = Promise.resolve(
+      append(sender.event, {
+        transferId: 'transfer-in-flight',
+        offset: 0,
+        chunk: new Uint8Array(10)
+      })
+    )
+    await Promise.resolve()
+    expect(repository.appendTransfer).toHaveBeenCalledOnce()
+    beginMigration()
+    sender.emit('destroyed')
+    let drained = false
+    const drainPromise = waitForDataRootWriters().then(() => {
+      drained = true
+    })
+    await Promise.resolve()
+    expect(drained).toBe(false)
+
+    finishAppend?.({
+      transferId: 'transfer-in-flight',
+      name: 'data.csv',
+      receivedBytes: 10,
+      totalBytes: 10
+    })
+    await appendPromise
+    await drainPromise
+    expect(repository.abortTransfer).toHaveBeenCalledWith({ transferId: 'transfer-in-flight' })
+  })
+
+  it('aborts transfers when their renderer starts a main-frame navigation', async () => {
+    const repository = {
+      beginTransfer: vi.fn(async () => ({
+        transferId: 'transfer-4',
+        name: 'data.csv',
+        receivedBytes: 0,
+        totalBytes: 10
+      })),
+      abortTransfer: vi.fn(async () => undefined)
+    } as unknown as UploadRepository
+    registerUploadIpcHandlers(repository)
+    const begin = ipcHandlers.get('uploads:begin-transfer')!
+    const sender = createIpcEvent()
+
+    await begin(sender.event, { transferId: 'transfer-4', name: 'data.csv', size: 10 })
+    sender.emit('did-start-navigation', {}, 'http://localhost/', false, false)
+    expect(repository.abortTransfer).not.toHaveBeenCalled()
+
+    beginMigration()
+    const drainPromise = waitForDataRootWriters()
+    sender.emit('did-start-navigation', {}, 'http://localhost/', false, true)
+    await drainPromise
+    expect(repository.abortTransfer).toHaveBeenCalledWith({ transferId: 'transfer-4' })
   })
 
   it('does not expose the removed whole-file base64 staging channel', () => {

--- a/src/main/uploads/ipc.test.ts
+++ b/src/main/uploads/ipc.test.ts
@@ -29,6 +29,7 @@ import {
 } from '../storage/migration-state'
 import { createDefaultUploadRepository, registerUploadIpcHandlers } from './ipc'
 import type { UploadRepository } from './repository'
+import { stageUploadFixtures } from './repository.test-utils'
 
 describe('default upload repository', () => {
   let homeRoot: string | undefined
@@ -46,7 +47,7 @@ describe('default upload repository', () => {
     const repository = createDefaultUploadRepository()
     const content = 'event,count\nheadache,4\n'
 
-    const [attachment] = await repository.stageFiles({
+    const [attachment] = await stageUploadFixtures(repository, {
       files: [
         {
           name: 'adverse_events.csv',
@@ -75,7 +76,7 @@ describe('default upload repository', () => {
   it('keeps migration drain pending until an upload that already started finishes', async () => {
     let releaseUpload: (() => void) | undefined
     const repository = {
-      stageFiles: vi.fn(
+      beginTransfer: vi.fn(
         () =>
           new Promise<void>((resolve) => {
             releaseUpload = resolve
@@ -83,9 +84,11 @@ describe('default upload repository', () => {
       )
     } as unknown as UploadRepository
     registerUploadIpcHandlers(repository)
-    const stage = ipcHandlers.get('uploads:stage-files')!
+    const stage = ipcHandlers.get('uploads:begin-transfer')!
 
-    const uploadPromise = Promise.resolve(stage(undefined, { files: [] }))
+    const uploadPromise = Promise.resolve(
+      stage(undefined, { transferId: 'transfer-1', name: 'data.csv', size: 10 })
+    )
     beginMigration()
     let drained = false
     const drainPromise = waitForDataRootWriters().then(() => {
@@ -98,5 +101,11 @@ describe('default upload repository', () => {
     await uploadPromise
     await drainPromise
     expect(drained).toBe(true)
+  })
+
+  it('does not expose the removed whole-file base64 staging channel', () => {
+    registerUploadIpcHandlers({} as UploadRepository)
+
+    expect(ipcHandlers.has('uploads:stage-files')).toBe(false)
   })
 })

--- a/src/main/uploads/ipc.test.ts
+++ b/src/main/uploads/ipc.test.ts
@@ -73,23 +73,35 @@ describe('default upload repository', () => {
     ).resolves.toMatchObject({ content })
   })
 
-  it('keeps migration drain pending until an upload that already started finishes', async () => {
-    let releaseUpload: (() => void) | undefined
+  it('holds one migration writer lease across the complete chunk transfer', async () => {
     const repository = {
-      beginTransfer: vi.fn(
-        () =>
-          new Promise<void>((resolve) => {
-            releaseUpload = resolve
-          })
-      )
+      beginTransfer: vi.fn(async () => ({
+        transferId: 'transfer-1',
+        name: 'data.csv',
+        receivedBytes: 0,
+        totalBytes: 10
+      })),
+      appendTransfer: vi.fn(async () => ({
+        transferId: 'transfer-1',
+        name: 'data.csv',
+        receivedBytes: 10,
+        totalBytes: 10
+      })),
+      finishTransfer: vi.fn(async () => undefined)
     } as unknown as UploadRepository
     registerUploadIpcHandlers(repository)
-    const stage = ipcHandlers.get('uploads:begin-transfer')!
+    const begin = ipcHandlers.get('uploads:begin-transfer')!
+    const append = ipcHandlers.get('uploads:append-transfer')!
+    const finish = ipcHandlers.get('uploads:finish-transfer')!
 
-    const uploadPromise = Promise.resolve(
-      stage(undefined, { transferId: 'transfer-1', name: 'data.csv', size: 10 })
-    )
+    await begin(undefined, { transferId: 'transfer-1', name: 'data.csv', size: 10 })
     beginMigration()
+    await append(undefined, {
+      transferId: 'transfer-1',
+      offset: 0,
+      chunk: new Uint8Array(10)
+    })
+
     let drained = false
     const drainPromise = waitForDataRootWriters().then(() => {
       drained = true
@@ -97,10 +109,46 @@ describe('default upload repository', () => {
     await Promise.resolve()
     expect(drained).toBe(false)
 
-    releaseUpload?.()
-    await uploadPromise
+    await finish(undefined, { transferId: 'transfer-1' })
     await drainPromise
     expect(drained).toBe(true)
+    expect(repository.appendTransfer).toHaveBeenCalledOnce()
+    expect(repository.finishTransfer).toHaveBeenCalledOnce()
+  })
+
+  it('waits for begin before aborting and releases the transfer during migration', async () => {
+    let finishBegin: (() => void) | undefined
+    const repository = {
+      beginTransfer: vi.fn(
+        () =>
+          new Promise<void>((resolve) => {
+            finishBegin = resolve
+          })
+      ),
+      abortTransfer: vi.fn(async () => undefined)
+    } as unknown as UploadRepository
+    registerUploadIpcHandlers(repository)
+    const begin = ipcHandlers.get('uploads:begin-transfer')!
+    const abort = ipcHandlers.get('uploads:abort-transfer')!
+
+    const beginPromise = Promise.resolve(
+      begin(undefined, { transferId: 'transfer-2', name: 'data.csv', size: 10 })
+    )
+    beginMigration()
+    const abortPromise = Promise.resolve(abort(undefined, { transferId: 'transfer-2' }))
+    let drained = false
+    const drainPromise = waitForDataRootWriters().then(() => {
+      drained = true
+    })
+    await Promise.resolve()
+    expect(drained).toBe(false)
+
+    finishBegin?.()
+    await beginPromise
+    await abortPromise
+    await drainPromise
+    expect(drained).toBe(true)
+    expect(repository.abortTransfer).toHaveBeenCalledWith({ transferId: 'transfer-2' })
   })
 
   it('does not expose the removed whole-file base64 staging channel', () => {

--- a/src/main/uploads/ipc.ts
+++ b/src/main/uploads/ipc.ts
@@ -1,4 +1,4 @@
-import { ipcMain } from 'electron'
+import { ipcMain, type Event as ElectronEvent, type IpcMainInvokeEvent } from 'electron'
 
 import type { ReadArtifactPreviewRequest } from '../../shared/artifacts'
 import type {
@@ -7,7 +7,8 @@ import type {
   DeleteUploadRequest,
   FinalizeUploadSessionRequest,
   StageLocalUploadRequest,
-  UploadTransferRequest
+  UploadTransferRequest,
+  UploadTransferStatus
 } from '../../shared/uploads'
 import { resolveDataRoot } from '../storage-root'
 import { acquireDataRootWriter, withDataRootWrite } from '../storage/migration-state'
@@ -21,15 +22,82 @@ const createDefaultUploadRepository = (): UploadRepository =>
 const registerUploadIpcHandlers = (repository = createDefaultUploadRepository()): void => {
   // A chunk transfer spans several IPC calls but is one logical write. Holding the writer lease from
   // begin through finish/abort makes data-root migration wait across the gaps between chunks.
-  type ChunkWriter = {
-    release: () => void
-    ready: Promise<unknown>
+  type ChunkOwner = {
+    senderId: number
+    transferIds: Set<string>
   }
+  type ChunkWriter = {
+    owner: ChunkOwner
+    release: () => void
+    ready: Promise<UploadTransferStatus>
+    cancelled: boolean
+    settling: boolean
+    inFlight: Set<Promise<unknown>>
+    cleanup?: Promise<void>
+  }
+  const chunkOwners = new Map<number, ChunkOwner>()
   const chunkWriters = new Map<string, ChunkWriter>()
   const releaseChunkWriter = (transferId: string, writer: ChunkWriter): void => {
     if (chunkWriters.get(transferId) !== writer) return
     chunkWriters.delete(transferId)
+    writer.owner.transferIds.delete(transferId)
     writer.release()
+  }
+  const abortChunkWriter = (transferId: string, writer: ChunkWriter): Promise<void> => {
+    if (writer.cleanup) return writer.cleanup
+
+    writer.cancelled = true
+    writer.cleanup = (async () => {
+      try {
+        await writer.ready.catch(() => undefined)
+        await Promise.allSettled([...writer.inFlight])
+        await repository.abortTransfer({ transferId }).catch(() => undefined)
+      } finally {
+        releaseChunkWriter(transferId, writer)
+      }
+    })()
+    return writer.cleanup
+  }
+  const registerChunkOwner = (event: IpcMainInvokeEvent): ChunkOwner => {
+    const existing = chunkOwners.get(event.sender.id)
+    if (existing) return existing
+
+    const owner: ChunkOwner = { senderId: event.sender.id, transferIds: new Set() }
+    chunkOwners.set(owner.senderId, owner)
+    const releaseOwner = (): void => {
+      if (chunkOwners.get(owner.senderId) !== owner) return
+      chunkOwners.delete(owner.senderId)
+      event.sender.removeListener('destroyed', releaseOwner)
+      event.sender.removeListener('render-process-gone', releaseOwner)
+      event.sender.removeListener('did-start-navigation', releaseOnMainFrameNavigation)
+      for (const transferId of [...owner.transferIds]) {
+        const writer = chunkWriters.get(transferId)
+        if (writer?.owner === owner && !writer.settling) void abortChunkWriter(transferId, writer)
+      }
+    }
+    const releaseOnMainFrameNavigation = (
+      _navigationEvent: ElectronEvent,
+      _url: string,
+      _isInPlace: boolean,
+      isMainFrame: boolean
+    ): void => {
+      if (isMainFrame) releaseOwner()
+    }
+    event.sender.once('destroyed', releaseOwner)
+    event.sender.once('render-process-gone', releaseOwner)
+    event.sender.on('did-start-navigation', releaseOnMainFrameNavigation)
+    return owner
+  }
+  const getOwnedChunkWriter = (
+    event: IpcMainInvokeEvent,
+    transferId: string
+  ): ChunkWriter | undefined => {
+    const owner = registerChunkOwner(event)
+    const writer = chunkWriters.get(transferId)
+    if (writer && writer.owner !== owner) {
+      throw new Error(`Upload transfer belongs to another renderer: ${transferId}`)
+    }
+    return writer
   }
 
   // Uploads write/mutate under the data root, so block them during the data-root copy→commit window.
@@ -40,41 +108,71 @@ const registerUploadIpcHandlers = (repository = createDefaultUploadRepository())
       })
     )
   )
-  ipcMain.handle('uploads:begin-transfer', async (_event, request: BeginUploadTransferRequest) => {
+  ipcMain.handle('uploads:begin-transfer', async (event, request: BeginUploadTransferRequest) => {
+    const owner = registerChunkOwner(event)
     const existing = chunkWriters.get(request.transferId)
     if (existing) {
+      if (existing.owner !== owner) {
+        throw new Error(`Upload transfer belongs to another renderer: ${request.transferId}`)
+      }
       await existing.ready
       return repository.beginTransfer(request)
     }
 
     const writer: ChunkWriter = {
+      owner,
       release: acquireDataRootWriter(),
-      ready: repository.beginTransfer(request)
+      ready: repository.beginTransfer(request),
+      cancelled: false,
+      settling: false,
+      inFlight: new Set()
     }
     chunkWriters.set(request.transferId, writer)
+    owner.transferIds.add(request.transferId)
     try {
-      return await writer.ready
+      const status = await writer.ready
+      if (writer.cancelled) {
+        await writer.cleanup
+        throw new Error(`Upload renderer is no longer available: ${request.transferId}`)
+      }
+      return status
     } catch (error) {
       releaseChunkWriter(request.transferId, writer)
       throw error
     }
   })
-  ipcMain.handle('uploads:append-transfer', async (_event, request: AppendUploadTransferRequest) => {
-    const writer = chunkWriters.get(request.transferId)
+  ipcMain.handle('uploads:append-transfer', async (event, request: AppendUploadTransferRequest) => {
+    const writer = getOwnedChunkWriter(event, request.transferId)
     if (!writer) return withDataRootWrite(() => repository.appendTransfer(request))
 
     await writer.ready
-    return repository.appendTransfer(request)
+    if (writer.cancelled) {
+      throw new Error(`Upload renderer is no longer available: ${request.transferId}`)
+    }
+    const operation = repository.appendTransfer(request)
+    writer.inFlight.add(operation)
+    try {
+      return await operation
+    } finally {
+      writer.inFlight.delete(operation)
+    }
   })
-  ipcMain.handle('uploads:transfer-status', (_event, request: UploadTransferRequest) =>
-    repository.getTransferStatus(request)
-  )
-  ipcMain.handle('uploads:finish-transfer', async (_event, request: UploadTransferRequest) => {
-    const writer = chunkWriters.get(request.transferId)
+  ipcMain.handle('uploads:transfer-status', (event, request: UploadTransferRequest) => {
+    getOwnedChunkWriter(event, request.transferId)
+    return repository.getTransferStatus(request)
+  })
+  ipcMain.handle('uploads:finish-transfer', async (event, request: UploadTransferRequest) => {
+    const writer = getOwnedChunkWriter(event, request.transferId)
     if (!writer) return withDataRootWrite(() => repository.finishTransfer(request))
 
     try {
       await writer.ready
+      if (writer.cancelled) {
+        await writer.cleanup
+        throw new Error(`Upload renderer is no longer available: ${request.transferId}`)
+      }
+      writer.settling = true
+      await Promise.allSettled([...writer.inFlight])
       return await repository.finishTransfer(request)
     } catch (error) {
       await repository.abortTransfer(request).catch(() => undefined)
@@ -83,16 +181,11 @@ const registerUploadIpcHandlers = (repository = createDefaultUploadRepository())
       releaseChunkWriter(request.transferId, writer)
     }
   })
-  ipcMain.handle('uploads:abort-transfer', async (_event, request: UploadTransferRequest) => {
-    const writer = chunkWriters.get(request.transferId)
+  ipcMain.handle('uploads:abort-transfer', async (event, request: UploadTransferRequest) => {
+    const writer = getOwnedChunkWriter(event, request.transferId)
     if (!writer) return withDataRootWrite(() => repository.abortTransfer(request))
 
-    try {
-      await writer.ready.catch(() => undefined)
-      await repository.abortTransfer(request)
-    } finally {
-      releaseChunkWriter(request.transferId, writer)
-    }
+    await abortChunkWriter(request.transferId, writer)
   })
   ipcMain.handle('uploads:delete', (_event, request: DeleteUploadRequest) =>
     withDataRootWrite(() => repository.deleteUpload(request))

--- a/src/main/uploads/ipc.ts
+++ b/src/main/uploads/ipc.ts
@@ -10,7 +10,7 @@ import type {
   UploadTransferRequest
 } from '../../shared/uploads'
 import { resolveDataRoot } from '../storage-root'
-import { withDataRootWrite } from '../storage/migration-state'
+import { acquireDataRootWriter, withDataRootWrite } from '../storage/migration-state'
 import { UploadRepository } from './repository'
 
 // Uploads are data-class: they follow the configurable data root (defaults to the config root).
@@ -19,6 +19,19 @@ const createDefaultUploadRepository = (): UploadRepository =>
 
 // Registers the small upload IPC surface used by the renderer composer and preview panel.
 const registerUploadIpcHandlers = (repository = createDefaultUploadRepository()): void => {
+  // A chunk transfer spans several IPC calls but is one logical write. Holding the writer lease from
+  // begin through finish/abort makes data-root migration wait across the gaps between chunks.
+  type ChunkWriter = {
+    release: () => void
+    ready: Promise<unknown>
+  }
+  const chunkWriters = new Map<string, ChunkWriter>()
+  const releaseChunkWriter = (transferId: string, writer: ChunkWriter): void => {
+    if (chunkWriters.get(transferId) !== writer) return
+    chunkWriters.delete(transferId)
+    writer.release()
+  }
+
   // Uploads write/mutate under the data root, so block them during the data-root copy→commit window.
   ipcMain.handle('uploads:stage-local-file', (event, request: StageLocalUploadRequest) =>
     withDataRootWrite(() =>
@@ -27,21 +40,60 @@ const registerUploadIpcHandlers = (repository = createDefaultUploadRepository())
       })
     )
   )
-  ipcMain.handle('uploads:begin-transfer', (_event, request: BeginUploadTransferRequest) =>
-    withDataRootWrite(() => repository.beginTransfer(request))
-  )
-  ipcMain.handle('uploads:append-transfer', (_event, request: AppendUploadTransferRequest) =>
-    withDataRootWrite(() => repository.appendTransfer(request))
-  )
+  ipcMain.handle('uploads:begin-transfer', async (_event, request: BeginUploadTransferRequest) => {
+    const existing = chunkWriters.get(request.transferId)
+    if (existing) {
+      await existing.ready
+      return repository.beginTransfer(request)
+    }
+
+    const writer: ChunkWriter = {
+      release: acquireDataRootWriter(),
+      ready: repository.beginTransfer(request)
+    }
+    chunkWriters.set(request.transferId, writer)
+    try {
+      return await writer.ready
+    } catch (error) {
+      releaseChunkWriter(request.transferId, writer)
+      throw error
+    }
+  })
+  ipcMain.handle('uploads:append-transfer', async (_event, request: AppendUploadTransferRequest) => {
+    const writer = chunkWriters.get(request.transferId)
+    if (!writer) return withDataRootWrite(() => repository.appendTransfer(request))
+
+    await writer.ready
+    return repository.appendTransfer(request)
+  })
   ipcMain.handle('uploads:transfer-status', (_event, request: UploadTransferRequest) =>
     repository.getTransferStatus(request)
   )
-  ipcMain.handle('uploads:finish-transfer', (_event, request: UploadTransferRequest) =>
-    withDataRootWrite(() => repository.finishTransfer(request))
-  )
-  ipcMain.handle('uploads:abort-transfer', (_event, request: UploadTransferRequest) =>
-    withDataRootWrite(() => repository.abortTransfer(request))
-  )
+  ipcMain.handle('uploads:finish-transfer', async (_event, request: UploadTransferRequest) => {
+    const writer = chunkWriters.get(request.transferId)
+    if (!writer) return withDataRootWrite(() => repository.finishTransfer(request))
+
+    try {
+      await writer.ready
+      return await repository.finishTransfer(request)
+    } catch (error) {
+      await repository.abortTransfer(request).catch(() => undefined)
+      throw error
+    } finally {
+      releaseChunkWriter(request.transferId, writer)
+    }
+  })
+  ipcMain.handle('uploads:abort-transfer', async (_event, request: UploadTransferRequest) => {
+    const writer = chunkWriters.get(request.transferId)
+    if (!writer) return withDataRootWrite(() => repository.abortTransfer(request))
+
+    try {
+      await writer.ready.catch(() => undefined)
+      await repository.abortTransfer(request)
+    } finally {
+      releaseChunkWriter(request.transferId, writer)
+    }
+  })
   ipcMain.handle('uploads:delete', (_event, request: DeleteUploadRequest) =>
     withDataRootWrite(() => repository.deleteUpload(request))
   )

--- a/src/main/uploads/ipc.ts
+++ b/src/main/uploads/ipc.ts
@@ -8,7 +8,8 @@ import type {
   FinalizeUploadSessionRequest,
   StageLocalUploadRequest,
   UploadTransferRequest,
-  UploadTransferStatus
+  UploadTransferStatus,
+  UploadedAttachment
 } from '../../shared/uploads'
 import { resolveDataRoot } from '../storage-root'
 import { acquireDataRootWriter, withDataRootWrite } from '../storage/migration-state'
@@ -22,12 +23,12 @@ const createDefaultUploadRepository = (): UploadRepository =>
 const registerUploadIpcHandlers = (repository = createDefaultUploadRepository()): void => {
   // A chunk transfer spans several IPC calls but is one logical write. Holding the writer lease from
   // begin through finish/abort makes data-root migration wait across the gaps between chunks.
-  type ChunkOwner = {
+  type UploadOwner = {
     senderId: number
     transferIds: Set<string>
   }
   type ChunkWriter = {
-    owner: ChunkOwner
+    owner: UploadOwner
     release: () => void
     ready: Promise<UploadTransferStatus>
     cancelled: boolean
@@ -35,8 +36,17 @@ const registerUploadIpcHandlers = (repository = createDefaultUploadRepository())
     inFlight: Set<Promise<unknown>>
     cleanup?: Promise<void>
   }
-  const chunkOwners = new Map<number, ChunkOwner>()
+  type LocalWriter = {
+    owner: UploadOwner
+    release: () => void
+    cancelled: boolean
+    ready?: Promise<UploadedAttachment>
+    attachment?: UploadedAttachment
+    cleanup?: Promise<void>
+  }
+  const uploadOwners = new Map<number, UploadOwner>()
   const chunkWriters = new Map<string, ChunkWriter>()
+  const localWriters = new Map<string, LocalWriter>()
   const releaseChunkWriter = (transferId: string, writer: ChunkWriter): void => {
     if (chunkWriters.get(transferId) !== writer) return
     chunkWriters.delete(transferId)
@@ -58,21 +68,48 @@ const registerUploadIpcHandlers = (repository = createDefaultUploadRepository())
     })()
     return writer.cleanup
   }
-  const registerChunkOwner = (event: IpcMainInvokeEvent): ChunkOwner => {
-    const existing = chunkOwners.get(event.sender.id)
+  const releaseLocalWriter = (transferId: string, writer: LocalWriter): void => {
+    if (localWriters.get(transferId) !== writer) return
+    localWriters.delete(transferId)
+    writer.owner.transferIds.delete(transferId)
+    writer.release()
+  }
+  const abortLocalWriter = (transferId: string, writer: LocalWriter): Promise<void> => {
+    if (writer.cleanup) return writer.cleanup
+
+    writer.cancelled = true
+    writer.cleanup = (async () => {
+      try {
+        await repository.abortTransfer({ transferId }).catch(() => undefined)
+        const attachment = writer.attachment ?? (await writer.ready?.catch(() => undefined))
+        if (attachment) {
+          await repository.deleteUpload({ path: attachment.path }).catch(() => undefined)
+        }
+      } finally {
+        releaseLocalWriter(transferId, writer)
+      }
+    })()
+    return writer.cleanup
+  }
+  const registerUploadOwner = (event: IpcMainInvokeEvent): UploadOwner => {
+    const existing = uploadOwners.get(event.sender.id)
     if (existing) return existing
 
-    const owner: ChunkOwner = { senderId: event.sender.id, transferIds: new Set() }
-    chunkOwners.set(owner.senderId, owner)
+    const owner: UploadOwner = { senderId: event.sender.id, transferIds: new Set() }
+    uploadOwners.set(owner.senderId, owner)
     const releaseOwner = (): void => {
-      if (chunkOwners.get(owner.senderId) !== owner) return
-      chunkOwners.delete(owner.senderId)
+      if (uploadOwners.get(owner.senderId) !== owner) return
+      uploadOwners.delete(owner.senderId)
       event.sender.removeListener('destroyed', releaseOwner)
       event.sender.removeListener('render-process-gone', releaseOwner)
       event.sender.removeListener('did-start-navigation', releaseOnMainFrameNavigation)
       for (const transferId of [...owner.transferIds]) {
-        const writer = chunkWriters.get(transferId)
-        if (writer?.owner === owner && !writer.settling) void abortChunkWriter(transferId, writer)
+        const chunkWriter = chunkWriters.get(transferId)
+        if (chunkWriter?.owner === owner && !chunkWriter.settling) {
+          void abortChunkWriter(transferId, chunkWriter)
+        }
+        const localWriter = localWriters.get(transferId)
+        if (localWriter?.owner === owner) void abortLocalWriter(transferId, localWriter)
       }
     }
     const releaseOnMainFrameNavigation = (
@@ -92,8 +129,19 @@ const registerUploadIpcHandlers = (repository = createDefaultUploadRepository())
     event: IpcMainInvokeEvent,
     transferId: string
   ): ChunkWriter | undefined => {
-    const owner = registerChunkOwner(event)
+    const owner = registerUploadOwner(event)
     const writer = chunkWriters.get(transferId)
+    if (writer && writer.owner !== owner) {
+      throw new Error(`Upload transfer belongs to another renderer: ${transferId}`)
+    }
+    return writer
+  }
+  const getOwnedLocalWriter = (
+    event: IpcMainInvokeEvent,
+    transferId: string
+  ): LocalWriter | undefined => {
+    const owner = registerUploadOwner(event)
+    const writer = localWriters.get(transferId)
     if (writer && writer.owner !== owner) {
       throw new Error(`Upload transfer belongs to another renderer: ${transferId}`)
     }
@@ -101,15 +149,61 @@ const registerUploadIpcHandlers = (repository = createDefaultUploadRepository())
   }
 
   // Uploads write/mutate under the data root, so block them during the data-root copy→commit window.
-  ipcMain.handle('uploads:stage-local-file', (event, request: StageLocalUploadRequest) =>
-    withDataRootWrite(() =>
-      repository.stageLocalFile(request, (progress) => {
-        event.sender.send('uploads:transfer-progress', progress)
+  ipcMain.handle('uploads:stage-local-file', async (event, request: StageLocalUploadRequest) => {
+    const owner = registerUploadOwner(event)
+    const existing = localWriters.get(request.transferId) ?? chunkWriters.get(request.transferId)
+    if (existing) {
+      if (existing.owner !== owner) {
+        throw new Error(`Upload transfer belongs to another renderer: ${request.transferId}`)
+      }
+      throw new Error(`Upload transfer already exists: ${request.transferId}`)
+    }
+
+    const writer: LocalWriter = {
+      owner,
+      release: acquireDataRootWriter(),
+      cancelled: false
+    }
+    localWriters.set(request.transferId, writer)
+    owner.transferIds.add(request.transferId)
+    try {
+      writer.ready = repository.stageLocalFile(request, (progress) => {
+        if (!writer.cancelled) event.sender.send('uploads:transfer-progress', progress)
       })
-    )
-  )
+      const attachment = await writer.ready
+      writer.attachment = attachment
+      if (writer.cancelled) {
+        await writer.cleanup
+        throw new Error(`Upload renderer is no longer available: ${request.transferId}`)
+      }
+      return attachment
+    } catch (error) {
+      if (writer.cancelled) await writer.cleanup
+      else releaseLocalWriter(request.transferId, writer)
+      throw error
+    }
+  })
+  ipcMain.handle('uploads:claim-local-file', (event, request: UploadTransferRequest) => {
+    const writer = getOwnedLocalWriter(event, request.transferId)
+    // Chunk/Web transfers have no local ownership record, so claiming them is an idempotent no-op.
+    if (!writer) return
+    if (!writer.attachment) {
+      throw new Error(`Upload transfer is not ready to claim: ${request.transferId}`)
+    }
+    if (writer.cancelled) {
+      throw new Error(`Upload renderer is no longer available: ${request.transferId}`)
+    }
+    releaseLocalWriter(request.transferId, writer)
+  })
   ipcMain.handle('uploads:begin-transfer', async (event, request: BeginUploadTransferRequest) => {
-    const owner = registerChunkOwner(event)
+    const owner = registerUploadOwner(event)
+    const localWriter = localWriters.get(request.transferId)
+    if (localWriter) {
+      if (localWriter.owner !== owner) {
+        throw new Error(`Upload transfer belongs to another renderer: ${request.transferId}`)
+      }
+      throw new Error(`Upload transfer already exists: ${request.transferId}`)
+    }
     const existing = chunkWriters.get(request.transferId)
     if (existing) {
       if (existing.owner !== owner) {
@@ -182,6 +276,9 @@ const registerUploadIpcHandlers = (repository = createDefaultUploadRepository())
     }
   })
   ipcMain.handle('uploads:abort-transfer', async (event, request: UploadTransferRequest) => {
+    const localWriter = getOwnedLocalWriter(event, request.transferId)
+    if (localWriter) return abortLocalWriter(request.transferId, localWriter)
+
     const writer = getOwnedChunkWriter(event, request.transferId)
     if (!writer) return withDataRootWrite(() => repository.abortTransfer(request))
 

--- a/src/main/uploads/ipc.ts
+++ b/src/main/uploads/ipc.ts
@@ -2,8 +2,12 @@ import { ipcMain } from 'electron'
 
 import type { ReadArtifactPreviewRequest } from '../../shared/artifacts'
 import type {
+  AppendUploadTransferRequest,
+  BeginUploadTransferRequest,
   DeleteUploadRequest,
   FinalizeUploadSessionRequest,
+  StageLocalUploadRequest,
+  UploadTransferRequest,
   StageUploadFilesRequest
 } from '../../shared/uploads'
 import { resolveDataRoot } from '../storage-root'
@@ -19,6 +23,28 @@ const registerUploadIpcHandlers = (repository = createDefaultUploadRepository())
   // Uploads write/mutate under the data root, so block them during the data-root copy→commit window.
   ipcMain.handle('uploads:stage-files', (_event, request: StageUploadFilesRequest) =>
     withDataRootWrite(() => repository.stageFiles(request))
+  )
+  ipcMain.handle('uploads:stage-local-file', (event, request: StageLocalUploadRequest) =>
+    withDataRootWrite(() =>
+      repository.stageLocalFile(request, (progress) => {
+        event.sender.send('uploads:transfer-progress', progress)
+      })
+    )
+  )
+  ipcMain.handle('uploads:begin-transfer', (_event, request: BeginUploadTransferRequest) =>
+    withDataRootWrite(() => repository.beginTransfer(request))
+  )
+  ipcMain.handle('uploads:append-transfer', (_event, request: AppendUploadTransferRequest) =>
+    withDataRootWrite(() => repository.appendTransfer(request))
+  )
+  ipcMain.handle('uploads:transfer-status', (_event, request: UploadTransferRequest) =>
+    repository.getTransferStatus(request)
+  )
+  ipcMain.handle('uploads:finish-transfer', (_event, request: UploadTransferRequest) =>
+    withDataRootWrite(() => repository.finishTransfer(request))
+  )
+  ipcMain.handle('uploads:abort-transfer', (_event, request: UploadTransferRequest) =>
+    withDataRootWrite(() => repository.abortTransfer(request))
   )
   ipcMain.handle('uploads:delete', (_event, request: DeleteUploadRequest) =>
     withDataRootWrite(() => repository.deleteUpload(request))

--- a/src/main/uploads/ipc.ts
+++ b/src/main/uploads/ipc.ts
@@ -7,8 +7,7 @@ import type {
   DeleteUploadRequest,
   FinalizeUploadSessionRequest,
   StageLocalUploadRequest,
-  UploadTransferRequest,
-  StageUploadFilesRequest
+  UploadTransferRequest
 } from '../../shared/uploads'
 import { resolveDataRoot } from '../storage-root'
 import { withDataRootWrite } from '../storage/migration-state'
@@ -21,9 +20,6 @@ const createDefaultUploadRepository = (): UploadRepository =>
 // Registers the small upload IPC surface used by the renderer composer and preview panel.
 const registerUploadIpcHandlers = (repository = createDefaultUploadRepository()): void => {
   // Uploads write/mutate under the data root, so block them during the data-root copy→commit window.
-  ipcMain.handle('uploads:stage-files', (_event, request: StageUploadFilesRequest) =>
-    withDataRootWrite(() => repository.stageFiles(request))
-  )
   ipcMain.handle('uploads:stage-local-file', (event, request: StageLocalUploadRequest) =>
     withDataRootWrite(() =>
       repository.stageLocalFile(request, (progress) => {

--- a/src/main/uploads/repository.test-utils.ts
+++ b/src/main/uploads/repository.test-utils.ts
@@ -1,0 +1,42 @@
+import { randomUUID } from 'node:crypto'
+
+import { MAX_UPLOAD_CHUNK_BYTES, type UploadedAttachment } from '../../shared/uploads'
+import type { UploadRepository } from './repository'
+
+type UploadFixture = {
+  name: string
+  content: string
+  mimeType?: string
+}
+
+// Test-only fixture writer. Production callers have no whole-file/base64 staging API; tests feed
+// their compact fixtures through the same bounded chunk protocol used by pathless browser Files.
+export const stageUploadFixtures = async (
+  repository: UploadRepository,
+  request: { files: UploadFixture[] }
+): Promise<UploadedAttachment[]> => {
+  const attachments: UploadedAttachment[] = []
+
+  for (const file of request.files) {
+    const bytes = Buffer.from(file.content, 'base64')
+    const transferId = randomUUID()
+    await repository.beginTransfer({
+      transferId,
+      name: file.name,
+      mimeType: file.mimeType,
+      size: bytes.byteLength
+    })
+
+    for (let offset = 0; offset < bytes.byteLength; offset += MAX_UPLOAD_CHUNK_BYTES) {
+      await repository.appendTransfer({
+        transferId,
+        offset,
+        chunk: bytes.subarray(offset, offset + MAX_UPLOAD_CHUNK_BYTES)
+      })
+    }
+
+    attachments.push(await repository.finishTransfer({ transferId }))
+  }
+
+  return attachments
+}

--- a/src/main/uploads/repository.test.ts
+++ b/src/main/uploads/repository.test.ts
@@ -1,9 +1,9 @@
-import { mkdtemp, readFile, rm, stat } from 'node:fs/promises'
+import { mkdir, mkdtemp, readFile, rm, stat, writeFile } from 'node:fs/promises'
 import { tmpdir } from 'node:os'
 import { join } from 'node:path'
 import { afterEach, describe, expect, it } from 'vitest'
 
-import { MAX_UPLOAD_FILE_BYTES, PENDING_UPLOAD_SESSION_ID } from '../../shared/uploads'
+import { PENDING_UPLOAD_SESSION_ID } from '../../shared/uploads'
 import { UploadRepository } from './repository'
 
 let storageRoot: string | undefined
@@ -21,6 +21,37 @@ afterEach(async () => {
 })
 
 describe('upload repository', () => {
+  it('stages a local file by path without loading its bytes into the renderer', async () => {
+    const root = await createStorageRoot()
+    const repository = new UploadRepository(root)
+    const sourcePath = join(root, 'dataset.csv')
+    const content = Buffer.from('sample,value\na,1\nb,2\n')
+    const progress: number[] = []
+
+    await writeFile(sourcePath, content)
+
+    const attachment = await repository.stageLocalFile(
+      {
+        transferId: 'local-transfer-1',
+        sourcePath,
+        name: 'dataset.csv',
+        mimeType: 'text/csv',
+        size: content.byteLength
+      },
+      ({ receivedBytes }) => progress.push(receivedBytes)
+    )
+
+    expect(attachment).toMatchObject({
+      sessionId: PENDING_UPLOAD_SESSION_ID,
+      name: 'dataset.csv',
+      originalName: 'dataset.csv',
+      mimeType: 'text/csv',
+      size: content.byteLength
+    })
+    await expect(readFile(attachment.path)).resolves.toEqual(content)
+    expect(progress.at(-1)).toBe(content.byteLength)
+  })
+
   it('stages uploaded files under the default project pending directory', async () => {
     const root = await createStorageRoot()
     const repository = new UploadRepository(root)
@@ -51,10 +82,80 @@ describe('upload repository', () => {
     await expect(readFile(attachment.path, 'utf8')).resolves.toBe('png-bytes')
   })
 
-  it('rejects staging a file whose content exceeds the size limit', async () => {
+  it('stages pathless files in bounded, offset-checked chunks', async () => {
     const root = await createStorageRoot()
     const repository = new UploadRepository(root)
-    const oversized = Buffer.alloc(MAX_UPLOAD_FILE_BYTES + 1)
+    const content = Buffer.from('sample,value\na,1\nb,2\n')
+
+    await repository.beginTransfer({
+      transferId: 'chunk-transfer-1',
+      name: 'dataset.csv',
+      mimeType: 'text/csv',
+      size: content.byteLength
+    })
+    await repository.appendTransfer({
+      transferId: 'chunk-transfer-1',
+      offset: 0,
+      chunk: content.subarray(0, 10)
+    })
+
+    await expect(
+      repository.appendTransfer({
+        transferId: 'chunk-transfer-1',
+        offset: 0,
+        chunk: content.subarray(10)
+      })
+    ).rejects.toThrow(/offset/i)
+
+    await repository.appendTransfer({
+      transferId: 'chunk-transfer-1',
+      offset: 10,
+      chunk: content.subarray(10)
+    })
+    await expect(repository.getTransferStatus({ transferId: 'chunk-transfer-1' })).resolves.toEqual(
+      {
+        transferId: 'chunk-transfer-1',
+        name: 'dataset.csv',
+        receivedBytes: content.byteLength,
+        totalBytes: content.byteLength
+      }
+    )
+
+    const attachment = await repository.finishTransfer({ transferId: 'chunk-transfer-1' })
+
+    await expect(readFile(attachment.path)).resolves.toEqual(content)
+    await expect(
+      repository.getTransferStatus({ transferId: 'chunk-transfer-1' })
+    ).resolves.toBeNull()
+  })
+
+  it('aborts chunk transfers and clears crash-orphaned partial files', async () => {
+    const root = await createStorageRoot()
+    const stagingDir = join(root, 'uploads', 'default-project', '.staging')
+    const stalePath = join(stagingDir, 'stale.part')
+    await mkdir(stagingDir, { recursive: true })
+    await writeFile(stalePath, 'orphan')
+    const repository = new UploadRepository(root)
+
+    await repository.beginTransfer({ transferId: 'cancel-me', name: 'data.csv', size: 2 })
+    await expect(
+      repository.appendTransfer({
+        transferId: 'cancel-me',
+        offset: 0,
+        chunk: new Uint8Array()
+      })
+    ).rejects.toThrow(/must not be empty/i)
+    await repository.abortTransfer({ transferId: 'cancel-me' })
+
+    await expect(repository.getTransferStatus({ transferId: 'cancel-me' })).resolves.toBeNull()
+    await expect(stat(join(stagingDir, 'cancel-me.part'))).rejects.toMatchObject({ code: 'ENOENT' })
+    await expect(stat(stalePath)).rejects.toMatchObject({ code: 'ENOENT' })
+  })
+
+  it('rejects staging a file whose content exceeds the size limit', async () => {
+    const root = await createStorageRoot()
+    const repository = new UploadRepository(root, { maxFileBytes: 16 })
+    const oversized = Buffer.alloc(17)
 
     await expect(
       repository.stageFiles({

--- a/src/main/uploads/repository.test.ts
+++ b/src/main/uploads/repository.test.ts
@@ -1,7 +1,8 @@
 import { mkdir, mkdtemp, readFile, rm, stat, writeFile } from 'node:fs/promises'
 import { tmpdir } from 'node:os'
 import { join } from 'node:path'
-import { afterEach, describe, expect, it } from 'vitest'
+import { Readable } from 'node:stream'
+import { afterEach, describe, expect, it, vi } from 'vitest'
 
 import { PENDING_UPLOAD_SESSION_ID } from '../../shared/uploads'
 import { UploadRepository } from './repository'
@@ -51,6 +52,67 @@ describe('upload repository', () => {
     })
     await expect(readFile(attachment.path)).resolves.toEqual(content)
     expect(progress.at(-1)).toBe(content.byteLength)
+  })
+
+  it('cancels a local-path upload before asynchronous source validation finishes', async () => {
+    const root = await createStorageRoot()
+    const repository = new UploadRepository(root)
+    const sourcePath = join(root, 'dataset.csv')
+    const content = Buffer.from('sample,value\na,1\n')
+    await writeFile(sourcePath, content)
+
+    const stagePromise = repository.stageLocalFile({
+      transferId: 'local-transfer-cancel-early',
+      sourcePath,
+      name: 'dataset.csv',
+      mimeType: 'text/csv',
+      size: content.byteLength
+    })
+    const stageRejection = expect(stagePromise).rejects.toThrow(/upload cancelled/i)
+    await repository.abortTransfer({ transferId: 'local-transfer-cancel-early' })
+
+    await stageRejection
+    await expect(
+      stat(join(root, 'uploads', 'default-project', PENDING_UPLOAD_SESSION_ID, 'dataset.csv'))
+    ).rejects.toMatchObject({ code: 'ENOENT' })
+  })
+
+  it('interrupts a stalled local source stream and waits for staging cleanup', async () => {
+    const root = await createStorageRoot()
+    const sourcePath = join(root, 'slow-dataset.csv')
+    const content = Buffer.from('sample,value\na,1\n')
+    const stalledSource = new Readable({ read: () => undefined })
+    let sourceSignal: AbortSignal | undefined
+    const repository = new UploadRepository(root, {
+      createLocalReadStream: (_path, options) => {
+        sourceSignal = options.signal
+        options.signal.addEventListener(
+          'abort',
+          () => stalledSource.destroy(new Error('Source stream aborted.')),
+          { once: true }
+        )
+        return stalledSource as never
+      }
+    })
+    await writeFile(sourcePath, content)
+
+    const stagePromise = repository.stageLocalFile({
+      transferId: 'local-transfer-stalled',
+      sourcePath,
+      name: 'slow-dataset.csv',
+      mimeType: 'text/csv',
+      size: content.byteLength
+    })
+    const stageRejection = expect(stagePromise).rejects.toThrow(/source stream aborted/i)
+    await vi.waitFor(() => expect(sourceSignal).toBeDefined())
+
+    await repository.abortTransfer({ transferId: 'local-transfer-stalled' })
+
+    expect(sourceSignal?.aborted).toBe(true)
+    await stageRejection
+    await expect(
+      stat(join(root, 'uploads', 'default-project', '.staging', 'local-transfer-stalled.part'))
+    ).rejects.toMatchObject({ code: 'ENOENT' })
   })
 
   it('stages uploaded files under the default project pending directory', async () => {

--- a/src/main/uploads/repository.test.ts
+++ b/src/main/uploads/repository.test.ts
@@ -5,6 +5,7 @@ import { afterEach, describe, expect, it } from 'vitest'
 
 import { PENDING_UPLOAD_SESSION_ID } from '../../shared/uploads'
 import { UploadRepository } from './repository'
+import { stageUploadFixtures } from './repository.test-utils'
 
 let storageRoot: string | undefined
 
@@ -56,7 +57,7 @@ describe('upload repository', () => {
     const root = await createStorageRoot()
     const repository = new UploadRepository(root)
 
-    const [attachment] = await repository.stageFiles({
+    const [attachment] = await stageUploadFixtures(repository, {
       files: [
         {
           name: 'paste.png',
@@ -158,16 +159,16 @@ describe('upload repository', () => {
     const oversized = Buffer.alloc(17)
 
     await expect(
-      repository.stageFiles({
+      stageUploadFixtures(repository, {
         files: [{ name: 'huge.bin', content: oversized.toString('base64') }]
       })
-    ).rejects.toThrow(/maximum allowed size/)
+    ).rejects.toThrow(/16 B per-file limit/)
   })
 
   it('finalizes pending uploads into the real session directory without changing ids', async () => {
     const root = await createStorageRoot()
     const repository = new UploadRepository(root)
-    const [attachment] = await repository.stageFiles({
+    const [attachment] = await stageUploadFixtures(repository, {
       files: [
         {
           name: 'notes.txt',
@@ -194,7 +195,7 @@ describe('upload repository', () => {
   it('keeps finalized uploads reusable for the same session', async () => {
     const root = await createStorageRoot()
     const repository = new UploadRepository(root)
-    const [attachment] = await repository.stageFiles({
+    const [attachment] = await stageUploadFixtures(repository, {
       files: [
         {
           name: 'notes.txt',
@@ -220,7 +221,7 @@ describe('upload repository', () => {
   it('reads bounded previews only from managed uploads', async () => {
     const root = await createStorageRoot()
     const repository = new UploadRepository(root)
-    const [attachment] = await repository.stageFiles({
+    const [attachment] = await stageUploadFixtures(repository, {
       files: [
         {
           name: 'notes.txt',
@@ -250,7 +251,7 @@ describe('upload repository', () => {
   it('removes staged uploads only from the managed upload tree', async () => {
     const root = await createStorageRoot()
     const repository = new UploadRepository(root)
-    const [attachment] = await repository.stageFiles({
+    const [attachment] = await stageUploadFixtures(repository, {
       files: [
         {
           name: 'remove-me.txt',
@@ -270,7 +271,7 @@ describe('upload repository', () => {
   it('rejects deletion of finalized uploads while keeping their bytes readable', async () => {
     const root = await createStorageRoot()
     const repository = new UploadRepository(root)
-    const [staged] = await repository.stageFiles({
+    const [staged] = await stageUploadFixtures(repository, {
       files: [{ name: 'keep.txt', content: Buffer.from('durable upload').toString('base64') }]
     })
     const [finalized] = await repository.finalizePendingSessionUploads('session-1', [staged])

--- a/src/main/uploads/repository.ts
+++ b/src/main/uploads/repository.ts
@@ -1,21 +1,49 @@
-import { constants } from 'node:fs'
-import { copyFile, mkdir, realpath, rm, stat, writeFile } from 'node:fs/promises'
+import { constants, createReadStream } from 'node:fs'
+import { copyFile, link, mkdir, open, realpath, rm, stat, writeFile } from 'node:fs/promises'
 import { basename, extname, isAbsolute, join, relative, resolve, sep } from 'node:path'
 import { randomUUID } from 'node:crypto'
 
 import type { ArtifactPreviewResult, ReadArtifactPreviewRequest } from '../../shared/artifacts'
 import {
   DEFAULT_UPLOAD_PROJECT_NAME,
+  MAX_UPLOAD_CHUNK_BYTES,
   MAX_UPLOAD_FILE_BYTES,
   PENDING_UPLOAD_SESSION_ID,
+  type AppendUploadTransferRequest,
+  type BeginUploadTransferRequest,
   type DeleteUploadRequest,
+  type StageLocalUploadRequest,
   type StageUploadFilesRequest,
+  type UploadTransferProgress,
+  type UploadTransferRequest,
+  type UploadTransferStatus,
   type UploadedAttachment
 } from '../../shared/uploads'
 import { readBoundedManagedFilePreview } from '../managed-file-preview'
 
 const UPLOADS_DIR = 'uploads'
+const STAGING_UPLOAD_SESSION_ID = '.staging'
 const SAFE_SEGMENT_PATTERN = /^[A-Za-z0-9][A-Za-z0-9._-]*$/
+
+type UploadRepositoryOptions = {
+  maxFileBytes?: number
+}
+
+type ActiveUploadTransfer = {
+  transferId: string
+  name: string
+  mimeType?: string
+  totalBytes: number
+  receivedBytes: number
+  stagingPath: string
+  writing: boolean
+  cancelled: boolean
+}
+
+type ActiveLocalTransfer = {
+  stagingPath: string
+  cancelled: boolean
+}
 
 type CreateAttachmentInput = {
   id: string
@@ -95,8 +123,275 @@ const isFileExistsError = (error: unknown): boolean =>
 
 // Owns app-managed uploads so renderer paths are always validated in the main process.
 class UploadRepository {
+  private readonly activeTransfers = new Map<string, ActiveUploadTransfer>()
+  private readonly activeLocalTransfers = new Map<string, ActiveLocalTransfer>()
+  private stagingReady: Promise<void> | undefined
+
   // The storage root is the app persistence root; this class appends uploads/project/session.
-  constructor(private readonly storageRoot: string) {}
+  constructor(
+    private readonly storageRoot: string,
+    private readonly options: UploadRepositoryOptions = {}
+  ) {}
+
+  // Allocates an empty temporary file for sources that can only provide bytes (Web, clipboard,
+  // synthetic File objects). Chunks are appended through appendTransfer and committed by finish.
+  async beginTransfer(request: BeginUploadTransferRequest): Promise<UploadTransferStatus> {
+    const transferId = assertSafePathSegment(request.transferId)
+    const name = request.name.trim() || 'upload'
+    const maxFileBytes = this.options.maxFileBytes ?? MAX_UPLOAD_FILE_BYTES
+
+    if (!Number.isSafeInteger(request.size) || request.size < 0) {
+      throw new Error(`Invalid upload size: ${name}`)
+    }
+    if (request.size > maxFileBytes) {
+      throw new Error(`Upload exceeds the maximum allowed size: ${name}`)
+    }
+
+    const existing = this.activeTransfers.get(transferId)
+    if (existing) {
+      if (
+        existing.name !== name ||
+        existing.mimeType !== request.mimeType ||
+        existing.totalBytes !== request.size
+      ) {
+        throw new Error(`Upload transfer metadata does not match: ${transferId}`)
+      }
+      return this.toTransferStatus(existing)
+    }
+    if (this.activeLocalTransfers.has(transferId)) {
+      throw new Error(`Upload transfer already exists: ${transferId}`)
+    }
+
+    const stagingDir = this.getSessionUploadDir(STAGING_UPLOAD_SESSION_ID)
+    const stagingPath = join(stagingDir, `${transferId}.part`)
+    await this.ensureStagingDirectory()
+
+    const file = await open(stagingPath, 'wx')
+    await file.close()
+
+    const transfer: ActiveUploadTransfer = {
+      transferId,
+      name,
+      mimeType: request.mimeType,
+      totalBytes: request.size,
+      receivedBytes: 0,
+      stagingPath,
+      writing: false,
+      cancelled: false
+    }
+    this.activeTransfers.set(transferId, transfer)
+    return this.toTransferStatus(transfer)
+  }
+
+  // Accepts exactly one bounded chunk at the caller's expected offset. This makes retries safe:
+  // callers query status and resume from receivedBytes instead of duplicating data.
+  async appendTransfer(request: AppendUploadTransferRequest): Promise<UploadTransferStatus> {
+    const transfer = this.getActiveTransfer(request.transferId)
+    if (!(request.chunk instanceof Uint8Array)) {
+      throw new Error('Upload chunk must be binary data.')
+    }
+    if (request.chunk.byteLength > MAX_UPLOAD_CHUNK_BYTES) {
+      throw new Error('Upload chunk exceeds the maximum allowed chunk size.')
+    }
+    if (request.chunk.byteLength === 0) {
+      throw new Error('Upload chunk must not be empty.')
+    }
+    if (request.offset !== transfer.receivedBytes) {
+      throw new Error(
+        `Upload chunk offset mismatch: expected ${transfer.receivedBytes}, received ${request.offset}.`
+      )
+    }
+    if (transfer.writing) {
+      throw new Error(`Upload transfer is already receiving a chunk: ${transfer.transferId}`)
+    }
+    if (transfer.receivedBytes + request.chunk.byteLength > transfer.totalBytes) {
+      throw new Error(`Upload chunk exceeds the declared file size: ${transfer.name}`)
+    }
+
+    transfer.writing = true
+    let file: Awaited<ReturnType<typeof open>> | undefined
+    try {
+      file = await open(transfer.stagingPath, 'r+')
+      const bytes = Buffer.from(
+        request.chunk.buffer,
+        request.chunk.byteOffset,
+        request.chunk.byteLength
+      )
+      let written = 0
+      while (written < bytes.byteLength) {
+        const result = await file.write(
+          bytes,
+          written,
+          bytes.byteLength - written,
+          transfer.receivedBytes + written
+        )
+        written += result.bytesWritten
+      }
+      transfer.receivedBytes += written
+      if (transfer.cancelled) throw new Error(`Upload cancelled: ${transfer.name}`)
+      return this.toTransferStatus(transfer)
+    } finally {
+      transfer.writing = false
+      await file?.close()
+      if (transfer.cancelled) {
+        this.activeTransfers.delete(transfer.transferId)
+        await rm(transfer.stagingPath, { force: true })
+      }
+    }
+  }
+
+  async getTransferStatus(request: UploadTransferRequest): Promise<UploadTransferStatus | null> {
+    const transferId = assertSafePathSegment(request.transferId)
+    const transfer = this.activeTransfers.get(transferId)
+    return transfer ? this.toTransferStatus(transfer) : null
+  }
+
+  // Publishes a fully received temporary file into the same pending attachment namespace used by
+  // desktop-path uploads. Incomplete transfers remain resumable until explicitly aborted.
+  async finishTransfer(request: UploadTransferRequest): Promise<UploadedAttachment> {
+    const transfer = this.getActiveTransfer(request.transferId)
+    if (transfer.writing) {
+      throw new Error(`Upload transfer is still receiving a chunk: ${transfer.transferId}`)
+    }
+    if (transfer.receivedBytes !== transfer.totalBytes) {
+      throw new Error(
+        `Upload transfer is incomplete: received ${transfer.receivedBytes} of ${transfer.totalBytes} bytes.`
+      )
+    }
+
+    const pendingDir = this.getSessionUploadDir(PENDING_UPLOAD_SESSION_ID)
+    await mkdir(pendingDir, { recursive: true })
+    const { filename, filePath } = await this.moveToUniqueFile(
+      transfer.stagingPath,
+      pendingDir,
+      toSafeUploadFilename(transfer.name)
+    )
+    this.activeTransfers.delete(transfer.transferId)
+
+    return this.createAttachment({
+      id: randomUUID(),
+      sessionId: PENDING_UPLOAD_SESSION_ID,
+      filename,
+      originalName: transfer.name,
+      filePath,
+      mimeType: transfer.mimeType
+    })
+  }
+
+  // Cancellation is idempotent so renderer cleanup can safely race a failed transfer.
+  async abortTransfer(request: UploadTransferRequest): Promise<void> {
+    const transferId = assertSafePathSegment(request.transferId)
+    const localTransfer = this.activeLocalTransfers.get(transferId)
+    if (localTransfer) {
+      localTransfer.cancelled = true
+      return
+    }
+    const transfer = this.activeTransfers.get(transferId)
+    if (transfer?.writing) {
+      transfer.cancelled = true
+      return
+    }
+    this.activeTransfers.delete(transferId)
+    if (transfer) await rm(transfer.stagingPath, { force: true })
+  }
+
+  // Streams an existing desktop file into managed staging without routing its bytes through the
+  // renderer or a single IPC message. The temporary file is committed only after all bytes arrive.
+  async stageLocalFile(
+    request: StageLocalUploadRequest,
+    onProgress?: (progress: UploadTransferProgress) => void
+  ): Promise<UploadedAttachment> {
+    const transferId = assertSafePathSegment(request.transferId)
+    const originalName = request.name.trim() || 'upload'
+    const maxFileBytes = this.options.maxFileBytes ?? MAX_UPLOAD_FILE_BYTES
+    const sourceInfo = await stat(request.sourcePath)
+
+    if (!sourceInfo.isFile()) {
+      throw new Error(`Upload source is not a file: ${originalName}`)
+    }
+    if (sourceInfo.size > maxFileBytes || request.size > maxFileBytes) {
+      throw new Error(`Upload exceeds the maximum allowed size: ${originalName}`)
+    }
+    if (sourceInfo.size !== request.size) {
+      throw new Error(`Upload source changed before it could be staged: ${originalName}`)
+    }
+    if (this.activeLocalTransfers.has(transferId) || this.activeTransfers.has(transferId)) {
+      throw new Error(`Upload transfer already exists: ${transferId}`)
+    }
+
+    const stagingDir = this.getSessionUploadDir(STAGING_UPLOAD_SESSION_ID)
+    const pendingDir = this.getSessionUploadDir(PENDING_UPLOAD_SESSION_ID)
+    const stagingPath = join(stagingDir, `${transferId}.part`)
+    let receivedBytes = 0
+    let output: Awaited<ReturnType<typeof open>> | undefined
+
+    await this.ensureStagingDirectory()
+    await mkdir(pendingDir, { recursive: true })
+    const localTransfer: ActiveLocalTransfer = { stagingPath, cancelled: false }
+    this.activeLocalTransfers.set(transferId, localTransfer)
+
+    try {
+      output = await open(stagingPath, 'wx')
+
+      for await (const chunk of createReadStream(request.sourcePath, {
+        highWaterMark: MAX_UPLOAD_CHUNK_BYTES
+      })) {
+        if (localTransfer.cancelled) throw new Error(`Upload cancelled: ${originalName}`)
+        const bytes = Buffer.isBuffer(chunk) ? chunk : Buffer.from(chunk)
+        const nextReceivedBytes = receivedBytes + bytes.byteLength
+
+        if (nextReceivedBytes > maxFileBytes) {
+          throw new Error(`Upload exceeds the maximum allowed size: ${originalName}`)
+        }
+
+        let written = 0
+        while (written < bytes.byteLength) {
+          const result = await output.write(
+            bytes,
+            written,
+            bytes.byteLength - written,
+            receivedBytes + written
+          )
+          written += result.bytesWritten
+        }
+        receivedBytes = nextReceivedBytes
+        onProgress?.({
+          transferId,
+          name: originalName,
+          receivedBytes,
+          totalBytes: request.size
+        })
+      }
+
+      await output.close()
+      output = undefined
+
+      if (receivedBytes !== request.size) {
+        throw new Error(`Upload source changed while it was being staged: ${originalName}`)
+      }
+
+      const { filename, filePath } = await this.moveToUniqueFile(
+        stagingPath,
+        pendingDir,
+        toSafeUploadFilename(originalName)
+      )
+      this.activeLocalTransfers.delete(transferId)
+
+      return this.createAttachment({
+        id: randomUUID(),
+        sessionId: PENDING_UPLOAD_SESSION_ID,
+        filename,
+        originalName,
+        filePath,
+        mimeType: request.mimeType
+      })
+    } catch (error) {
+      this.activeLocalTransfers.delete(transferId)
+      await output?.close().catch(() => undefined)
+      await rm(stagingPath, { force: true })
+      throw error
+    }
+  }
 
   // Writes selected or pasted files to the pending session directory before a prompt is sent.
   async stageFiles(request: StageUploadFilesRequest): Promise<UploadedAttachment[]> {
@@ -110,8 +405,12 @@ class UploadRepository {
         const originalName = file.name.trim() || 'upload'
         const content = Buffer.from(file.content, 'base64')
 
-        // Authoritative per-file size guard so no entry point can persist an oversized upload.
-        if (content.byteLength > MAX_UPLOAD_FILE_BYTES) {
+        // Legacy whole-base64 callers retain the old cap. Large files must use path/chunk staging.
+        const legacyLimit = Math.min(
+          this.options.maxFileBytes ?? MAX_UPLOAD_FILE_BYTES,
+          50 * 1024 * 1024
+        )
+        if (content.byteLength > legacyLimit) {
           throw new Error(`Upload exceeds the maximum allowed size: ${originalName}`)
         }
 
@@ -237,7 +536,7 @@ class UploadRepository {
     assertPathInsideRoot(await realpath(pendingDir), sourcePath)
     await mkdir(targetDir, { recursive: true })
 
-    // Copy-then-delete keeps the target allocation exclusive while supporting cross-device moves.
+    // Commit without overwriting; same-volume storage reuses the inode and other filesystems fall back.
     const { filename, filePath } = await this.moveToUniqueFile(
       sourcePath,
       targetDir,
@@ -264,7 +563,39 @@ class UploadRepository {
 
   // Returns the staging or durable directory for one upload session.
   private getSessionUploadDir(sessionId: string): string {
-    return join(this.getProjectUploadDir(), assertSafeSessionId(sessionId))
+    const safeSessionId =
+      sessionId === STAGING_UPLOAD_SESSION_ID ? sessionId : assertSafeSessionId(sessionId)
+    return join(this.getProjectUploadDir(), safeSessionId)
+  }
+
+  // Transfers cannot survive a main-process restart. Clear crash-orphaned partial files before the
+  // first transfer in this repository instance; concurrent first calls share the cleanup promise.
+  private ensureStagingDirectory(): Promise<void> {
+    if (!this.stagingReady) {
+      const stagingDir = this.getSessionUploadDir(STAGING_UPLOAD_SESSION_ID)
+      this.stagingReady = (async () => {
+        await rm(stagingDir, { recursive: true, force: true })
+        await mkdir(stagingDir, { recursive: true })
+      })()
+    }
+
+    return this.stagingReady
+  }
+
+  private getActiveTransfer(transferId: string): ActiveUploadTransfer {
+    const safeTransferId = assertSafePathSegment(transferId)
+    const transfer = this.activeTransfers.get(safeTransferId)
+    if (!transfer) throw new Error(`Unknown upload transfer: ${safeTransferId}`)
+    return transfer
+  }
+
+  private toTransferStatus(transfer: ActiveUploadTransfer): UploadTransferStatus {
+    return {
+      transferId: transfer.transferId,
+      name: transfer.name,
+      receivedBytes: transfer.receivedBytes,
+      totalBytes: transfer.totalBytes
+    }
   }
 
   // Writes a new file without overwriting an existing upload with the same display name.
@@ -304,8 +635,14 @@ class UploadRepository {
       const filePath = join(targetDir, candidate)
 
       try {
-        // COPYFILE_EXCL provides the same no-overwrite guarantee as the staging write.
-        await copyFile(sourcePath, filePath, constants.COPYFILE_EXCL)
+        // A same-volume hard link commits the staged inode without a multi-GB second copy. Cross-
+        // device or unsupported filesystems fall back to exclusive copy, preserving old behavior.
+        try {
+          await link(sourcePath, filePath)
+        } catch (linkError) {
+          if (isFileExistsError(linkError)) throw linkError
+          await copyFile(sourcePath, filePath, constants.COPYFILE_EXCL)
+        }
         await rm(sourcePath, { force: true })
         return { filename: candidate, filePath }
       } catch (error) {

--- a/src/main/uploads/repository.ts
+++ b/src/main/uploads/repository.ts
@@ -1,5 +1,5 @@
 import { constants, createReadStream } from 'node:fs'
-import { copyFile, link, mkdir, open, realpath, rm, stat, writeFile } from 'node:fs/promises'
+import { copyFile, link, mkdir, open, realpath, rm, stat } from 'node:fs/promises'
 import { basename, extname, isAbsolute, join, relative, resolve, sep } from 'node:path'
 import { randomUUID } from 'node:crypto'
 
@@ -9,11 +9,11 @@ import {
   MAX_UPLOAD_CHUNK_BYTES,
   MAX_UPLOAD_FILE_BYTES,
   PENDING_UPLOAD_SESSION_ID,
+  formatUploadSizeLimit,
   type AppendUploadTransferRequest,
   type BeginUploadTransferRequest,
   type DeleteUploadRequest,
   type StageLocalUploadRequest,
-  type StageUploadFilesRequest,
   type UploadTransferProgress,
   type UploadTransferRequest,
   type UploadTransferStatus,
@@ -144,7 +144,9 @@ class UploadRepository {
       throw new Error(`Invalid upload size: ${name}`)
     }
     if (request.size > maxFileBytes) {
-      throw new Error(`Upload exceeds the maximum allowed size: ${name}`)
+      throw new Error(
+        `Upload exceeds the ${formatUploadSizeLimit(maxFileBytes)} per-file limit: ${name}`
+      )
     }
 
     const existing = this.activeTransfers.get(transferId)
@@ -310,7 +312,9 @@ class UploadRepository {
       throw new Error(`Upload source is not a file: ${originalName}`)
     }
     if (sourceInfo.size > maxFileBytes || request.size > maxFileBytes) {
-      throw new Error(`Upload exceeds the maximum allowed size: ${originalName}`)
+      throw new Error(
+        `Upload exceeds the ${formatUploadSizeLimit(maxFileBytes)} per-file limit: ${originalName}`
+      )
     }
     if (sourceInfo.size !== request.size) {
       throw new Error(`Upload source changed before it could be staged: ${originalName}`)
@@ -341,7 +345,9 @@ class UploadRepository {
         const nextReceivedBytes = receivedBytes + bytes.byteLength
 
         if (nextReceivedBytes > maxFileBytes) {
-          throw new Error(`Upload exceeds the maximum allowed size: ${originalName}`)
+          throw new Error(
+            `Upload exceeds the ${formatUploadSizeLimit(maxFileBytes)} per-file limit: ${originalName}`
+          )
         }
 
         let written = 0
@@ -391,45 +397,6 @@ class UploadRepository {
       await rm(stagingPath, { force: true })
       throw error
     }
-  }
-
-  // Writes selected or pasted files to the pending session directory before a prompt is sent.
-  async stageFiles(request: StageUploadFilesRequest): Promise<UploadedAttachment[]> {
-    const directory = this.getSessionUploadDir(PENDING_UPLOAD_SESSION_ID)
-
-    await mkdir(directory, { recursive: true })
-
-    return Promise.all(
-      request.files.map(async (file) => {
-        // Preserve the original display name separately from the sanitized filesystem name.
-        const originalName = file.name.trim() || 'upload'
-        const content = Buffer.from(file.content, 'base64')
-
-        // Legacy whole-base64 callers retain the old cap. Large files must use path/chunk staging.
-        const legacyLimit = Math.min(
-          this.options.maxFileBytes ?? MAX_UPLOAD_FILE_BYTES,
-          50 * 1024 * 1024
-        )
-        if (content.byteLength > legacyLimit) {
-          throw new Error(`Upload exceeds the maximum allowed size: ${originalName}`)
-        }
-
-        const { filename, filePath } = await this.writeUniqueFile(
-          directory,
-          toSafeUploadFilename(originalName),
-          content
-        )
-
-        return this.createAttachment({
-          id: randomUUID(),
-          sessionId: PENDING_UPLOAD_SESSION_ID,
-          filename,
-          originalName,
-          filePath,
-          mimeType: file.mimeType
-        })
-      })
-    )
   }
 
   // Moves pending attachments into their durable session directory once the runtime id is known.
@@ -596,29 +563,6 @@ class UploadRepository {
       receivedBytes: transfer.receivedBytes,
       totalBytes: transfer.totalBytes
     }
-  }
-
-  // Writes a new file without overwriting an existing upload with the same display name.
-  private async writeUniqueFile(
-    directory: string,
-    filename: string,
-    content: Buffer
-  ): Promise<{ filename: string; filePath: string }> {
-    for (let attempt = 0; attempt < 100; attempt += 1) {
-      const candidate = attempt === 0 ? filename : appendFilenameSuffix(filename, attempt + 1)
-      const filePath = join(directory, candidate)
-
-      try {
-        // The wx flag makes the write fail when another upload already claimed this filename.
-        await writeFile(filePath, content, { flag: 'wx' })
-        return { filename: candidate, filePath }
-      } catch (error) {
-        if (isFileExistsError(error)) continue
-        throw error
-      }
-    }
-
-    throw new Error(`Could not allocate upload filename: ${filename}`)
   }
 
   // Moves an already-staged file into a target directory while preserving unique filenames.

--- a/src/main/uploads/repository.ts
+++ b/src/main/uploads/repository.ts
@@ -27,6 +27,10 @@ const SAFE_SEGMENT_PATTERN = /^[A-Za-z0-9][A-Za-z0-9._-]*$/
 
 type UploadRepositoryOptions = {
   maxFileBytes?: number
+  createLocalReadStream?: (
+    sourcePath: string,
+    options: { highWaterMark: number; signal: AbortSignal }
+  ) => ReturnType<typeof createReadStream>
 }
 
 type ActiveUploadTransfer = {
@@ -43,6 +47,9 @@ type ActiveUploadTransfer = {
 type ActiveLocalTransfer = {
   stagingPath: string
   cancelled: boolean
+  abortController: AbortController
+  settled: Promise<void>
+  resolveSettled: () => void
 }
 
 type CreateAttachmentInput = {
@@ -286,6 +293,8 @@ class UploadRepository {
     const localTransfer = this.activeLocalTransfers.get(transferId)
     if (localTransfer) {
       localTransfer.cancelled = true
+      localTransfer.abortController.abort()
+      await localTransfer.settled
       return
     }
     const transfer = this.activeTransfers.get(transferId)
@@ -306,19 +315,6 @@ class UploadRepository {
     const transferId = assertSafePathSegment(request.transferId)
     const originalName = request.name.trim() || 'upload'
     const maxFileBytes = this.options.maxFileBytes ?? MAX_UPLOAD_FILE_BYTES
-    const sourceInfo = await stat(request.sourcePath)
-
-    if (!sourceInfo.isFile()) {
-      throw new Error(`Upload source is not a file: ${originalName}`)
-    }
-    if (sourceInfo.size > maxFileBytes || request.size > maxFileBytes) {
-      throw new Error(
-        `Upload exceeds the ${formatUploadSizeLimit(maxFileBytes)} per-file limit: ${originalName}`
-      )
-    }
-    if (sourceInfo.size !== request.size) {
-      throw new Error(`Upload source changed before it could be staged: ${originalName}`)
-    }
     if (this.activeLocalTransfers.has(transferId) || this.activeTransfers.has(transferId)) {
       throw new Error(`Upload transfer already exists: ${transferId}`)
     }
@@ -326,20 +322,52 @@ class UploadRepository {
     const stagingDir = this.getSessionUploadDir(STAGING_UPLOAD_SESSION_ID)
     const pendingDir = this.getSessionUploadDir(PENDING_UPLOAD_SESSION_ID)
     const stagingPath = join(stagingDir, `${transferId}.part`)
+    let resolveSettled = (): void => undefined
+    const settled = new Promise<void>((resolve) => {
+      resolveSettled = resolve
+    })
+    const localTransfer: ActiveLocalTransfer = {
+      stagingPath,
+      cancelled: false,
+      abortController: new AbortController(),
+      settled,
+      resolveSettled
+    }
     let receivedBytes = 0
     let output: Awaited<ReturnType<typeof open>> | undefined
 
-    await this.ensureStagingDirectory()
-    await mkdir(pendingDir, { recursive: true })
-    const localTransfer: ActiveLocalTransfer = { stagingPath, cancelled: false }
+    // Register before the first await so renderer teardown can cancel validation/directory setup too.
     this.activeLocalTransfers.set(transferId, localTransfer)
 
     try {
+      const sourceInfo = await stat(request.sourcePath)
+
+      if (!sourceInfo.isFile()) {
+        throw new Error(`Upload source is not a file: ${originalName}`)
+      }
+      if (sourceInfo.size > maxFileBytes || request.size > maxFileBytes) {
+        throw new Error(
+          `Upload exceeds the ${formatUploadSizeLimit(maxFileBytes)} per-file limit: ${originalName}`
+        )
+      }
+      if (sourceInfo.size !== request.size) {
+        throw new Error(`Upload source changed before it could be staged: ${originalName}`)
+      }
+      if (localTransfer.cancelled) throw new Error(`Upload cancelled: ${originalName}`)
+
+      await this.ensureStagingDirectory()
+      await mkdir(pendingDir, { recursive: true })
+      if (localTransfer.cancelled) throw new Error(`Upload cancelled: ${originalName}`)
       output = await open(stagingPath, 'wx')
 
-      for await (const chunk of createReadStream(request.sourcePath, {
-        highWaterMark: MAX_UPLOAD_CHUNK_BYTES
-      })) {
+      const sourceStream = (this.options.createLocalReadStream ?? createReadStream)(
+        request.sourcePath,
+        {
+          highWaterMark: MAX_UPLOAD_CHUNK_BYTES,
+          signal: localTransfer.abortController.signal
+        }
+      )
+      for await (const chunk of sourceStream) {
         if (localTransfer.cancelled) throw new Error(`Upload cancelled: ${originalName}`)
         const bytes = Buffer.isBuffer(chunk) ? chunk : Buffer.from(chunk)
         const nextReceivedBytes = receivedBytes + bytes.byteLength
@@ -381,7 +409,6 @@ class UploadRepository {
         pendingDir,
         toSafeUploadFilename(originalName)
       )
-      this.activeLocalTransfers.delete(transferId)
 
       return this.createAttachment({
         id: randomUUID(),
@@ -392,10 +419,14 @@ class UploadRepository {
         mimeType: request.mimeType
       })
     } catch (error) {
-      this.activeLocalTransfers.delete(transferId)
       await output?.close().catch(() => undefined)
       await rm(stagingPath, { force: true })
       throw error
+    } finally {
+      if (this.activeLocalTransfers.get(transferId) === localTransfer) {
+        this.activeLocalTransfers.delete(transferId)
+      }
+      localTransfer.resolveSettled()
     }
   }
 

--- a/src/main/web-service/http-server.test.ts
+++ b/src/main/web-service/http-server.test.ts
@@ -32,6 +32,7 @@ describe('startWebHttpServer', () => {
     const rpc = {
       channels: () => [
         'test:echo',
+        'uploads:stage-local-file',
         'settings:list-agent-home-skills',
         'settings:import-agent-home-skills'
       ],
@@ -83,6 +84,7 @@ describe('startWebHttpServer', () => {
     // Channels unavailable to web clients are rejected over /rpc without reaching the handler.
     for (const channel of [
       'window:close',
+      'uploads:stage-local-file',
       'settings:list-agent-home-skills',
       'settings:import-agent-home-skills'
     ]) {

--- a/src/main/web-service/http-server.test.ts
+++ b/src/main/web-service/http-server.test.ts
@@ -81,6 +81,25 @@ describe('startWebHttpServer', () => {
     })
     expect(await rpcResponse.json()).toEqual({ ok: true, result: { value: 1 } })
 
+    const binary = Uint8Array.from([0, 1, 127, 128, 255])
+    const encodedBinary = Buffer.from(binary).toString('base64')
+    const binaryRpcResponse = await fetch(`${base}/rpc/test%3Aecho`, {
+      method: 'POST',
+      headers: {
+        cookie,
+        'content-type': 'application/json',
+        'x-open-science-client': 'test-client'
+      },
+      body: JSON.stringify({ args: [{ $binary: encodedBinary }] })
+    })
+    expect(await binaryRpcResponse.json()).toEqual({
+      ok: true,
+      result: { $binary: encodedBinary }
+    })
+    const binaryRpcArgs = vi.mocked(rpc.invoke).mock.calls[1]?.[2]
+    expect(binaryRpcArgs?.[0]).toBeInstanceOf(Uint8Array)
+    expect(Array.from(binaryRpcArgs?.[0] as Uint8Array)).toEqual(Array.from(binary))
+
     // Channels unavailable to web clients are rejected over /rpc without reaching the handler.
     for (const channel of [
       'window:close',
@@ -96,7 +115,7 @@ describe('startWebHttpServer', () => {
       expect(blockedResponse.status).toBe(403)
       expect(await blockedResponse.json()).toMatchObject({ ok: false })
     }
-    expect(rpc.invoke).toHaveBeenCalledTimes(1)
+    expect(rpc.invoke).toHaveBeenCalledTimes(2)
 
     const socket = new WebSocket(`ws://127.0.0.1:${server.port}/events?client=test-client`, {
       headers: { cookie, origin: base }

--- a/src/main/web-service/http-server.ts
+++ b/src/main/web-service/http-server.ts
@@ -23,6 +23,7 @@ const MAX_RPC_BODY_BYTES = 64 * 1024 * 1024
 const WEB_UNAVAILABLE_RPC_CHANNELS = new Set([
   'file:save-blob',
   'file:save-managed',
+  'uploads:stage-local-file',
   'window:close',
   'settings:list-agent-home-skills',
   'settings:import-agent-home-skills'

--- a/src/preload/index.d.ts
+++ b/src/preload/index.d.ts
@@ -185,9 +185,14 @@ import type {
 import type { CliLauncherStatus } from '../shared/cli'
 import type { AppInfo, DownloadProgress, UpdateStatus } from '../shared/update'
 import type {
+  AppendUploadTransferRequest,
+  BeginUploadTransferRequest,
   DeleteUploadRequest,
   FinalizeUploadSessionRequest,
   StageUploadFilesRequest,
+  UploadTransferProgress,
+  UploadTransferRequest,
+  UploadTransferStatus,
   UploadedAttachment
 } from '../shared/uploads'
 import type {
@@ -440,6 +445,17 @@ interface OpenScienceAPI {
   uploads: {
     // Stages files selected or pasted in the renderer into app-managed upload storage.
     stageFiles(request: StageUploadFilesRequest): Promise<UploadedAttachment[]>
+    // Desktop-only path fast path; omitted by the Web capability map.
+    stageLocalFile?(
+      file: File,
+      request: BeginUploadTransferRequest
+    ): Promise<UploadedAttachment | null>
+    beginTransfer(request: BeginUploadTransferRequest): Promise<UploadTransferStatus>
+    appendTransfer(request: AppendUploadTransferRequest): Promise<UploadTransferStatus>
+    getTransferStatus(request: UploadTransferRequest): Promise<UploadTransferStatus | null>
+    finishTransfer(request: UploadTransferRequest): Promise<UploadedAttachment>
+    abortTransfer(request: UploadTransferRequest): Promise<void>
+    onTransferProgress(listener: AcpListener<UploadTransferProgress>): RemoveListener
     // Deletes a staged upload when the composer chip is removed or the draft is abandoned.
     deleteUpload(request: DeleteUploadRequest): Promise<void>
     // Moves pending uploads into the durable session directory once a session id exists.

--- a/src/preload/index.d.ts
+++ b/src/preload/index.d.ts
@@ -447,6 +447,8 @@ interface OpenScienceAPI {
       file: File,
       request: BeginUploadTransferRequest
     ): Promise<UploadedAttachment | null>
+    // Acknowledges that the renderer committed a native-path upload into its draft state.
+    claimLocalFile?(request: UploadTransferRequest): Promise<void>
     beginTransfer(request: BeginUploadTransferRequest): Promise<UploadTransferStatus>
     appendTransfer(request: AppendUploadTransferRequest): Promise<UploadTransferStatus>
     getTransferStatus(request: UploadTransferRequest): Promise<UploadTransferStatus | null>

--- a/src/preload/index.d.ts
+++ b/src/preload/index.d.ts
@@ -189,7 +189,6 @@ import type {
   BeginUploadTransferRequest,
   DeleteUploadRequest,
   FinalizeUploadSessionRequest,
-  StageUploadFilesRequest,
   UploadTransferProgress,
   UploadTransferRequest,
   UploadTransferStatus,
@@ -443,8 +442,6 @@ interface OpenScienceAPI {
     readPreview(request: ReadArtifactPreviewRequest): Promise<ArtifactPreviewResult>
   }
   uploads: {
-    // Stages files selected or pasted in the renderer into app-managed upload storage.
-    stageFiles(request: StageUploadFilesRequest): Promise<UploadedAttachment[]>
     // Desktop-only path fast path; omitted by the Web capability map.
     stageLocalFile?(
       file: File,

--- a/src/preload/index.test.ts
+++ b/src/preload/index.test.ts
@@ -10,14 +10,16 @@
 
 import { afterEach, beforeAll, describe, expect, it, vi } from 'vitest'
 
-const { invokeMock, sendMock, exposeMock } = vi.hoisted(() => ({
+const { invokeMock, sendMock, exposeMock, getPathForFileMock } = vi.hoisted(() => ({
   invokeMock: vi.fn(),
   sendMock: vi.fn(),
-  exposeMock: vi.fn()
+  exposeMock: vi.fn(),
+  getPathForFileMock: vi.fn()
 }))
 
 vi.mock('electron', () => ({
   contextBridge: { exposeInMainWorld: exposeMock },
+  webUtils: { getPathForFile: getPathForFileMock },
   ipcRenderer: {
     invoke: invokeMock,
     on: vi.fn(),
@@ -81,6 +83,9 @@ type PreloadApi = {
     attachFrame: (sessionId: string) => Promise<unknown>
     reportState: (sessionId: string, state: unknown) => void
   }
+  uploads: {
+    stageLocalFile: (file: File, request: unknown) => Promise<unknown>
+  }
 }
 
 let api: PreloadApi
@@ -101,6 +106,7 @@ beforeAll(async () => {
 afterEach(() => {
   invokeMock.mockClear()
   sendMock.mockClear()
+  getPathForFileMock.mockReset()
 })
 
 // Each case: invoke a bridge method with sample args, then assert the exact channel + forwarded args.
@@ -375,6 +381,25 @@ describe('preload bridge — sessions + agent-framework IPC channels', () => {
     expect(sendMock).toHaveBeenCalledWith('office-preview:report-state', 'office-session-1', {
       sessionId: 'office-session-1',
       phase: 'ready'
+    })
+  })
+
+  it('resolves native upload paths in preload and sends only metadata to main', async () => {
+    const file = { name: 'large.csv', size: 1024, type: 'text/csv' } as File
+    const request = {
+      transferId: 'transfer-1',
+      name: 'large.csv',
+      size: 1024,
+      mimeType: 'text/csv'
+    }
+    getPathForFileMock.mockReturnValue('/data/large.csv')
+
+    await api.uploads.stageLocalFile(file, request)
+
+    expect(getPathForFileMock).toHaveBeenCalledWith(file)
+    expect(invokeMock).toHaveBeenCalledWith('uploads:stage-local-file', {
+      ...request,
+      sourcePath: '/data/large.csv'
     })
   })
 })

--- a/src/preload/index.test.ts
+++ b/src/preload/index.test.ts
@@ -85,6 +85,7 @@ type PreloadApi = {
   }
   uploads: {
     stageLocalFile: (file: File, request: unknown) => Promise<unknown>
+    claimLocalFile: (request: unknown) => Promise<void>
   }
 }
 
@@ -386,6 +387,7 @@ describe('preload bridge — sessions + agent-framework IPC channels', () => {
 
   it('resolves native upload paths in preload and sends only metadata to main', async () => {
     const file = { name: 'large.csv', size: 1024, type: 'text/csv' } as File
+    const attachment = { path: '/managed/.pending/large.csv' }
     const request = {
       transferId: 'transfer-1',
       name: 'large.csv',
@@ -393,13 +395,19 @@ describe('preload bridge — sessions + agent-framework IPC channels', () => {
       mimeType: 'text/csv'
     }
     getPathForFileMock.mockReturnValue('/data/large.csv')
+    invokeMock.mockResolvedValueOnce(attachment)
 
-    await api.uploads.stageLocalFile(file, request)
+    await expect(api.uploads.stageLocalFile(file, request)).resolves.toBe(attachment)
+    await api.uploads.claimLocalFile({ transferId: request.transferId })
 
     expect(getPathForFileMock).toHaveBeenCalledWith(file)
     expect(invokeMock).toHaveBeenCalledWith('uploads:stage-local-file', {
       ...request,
       sourcePath: '/data/large.csv'
     })
+    expect(invokeMock).toHaveBeenCalledWith('uploads:claim-local-file', {
+      transferId: request.transferId
+    })
+    expect(invokeMock).toHaveBeenCalledTimes(2)
   })
 })

--- a/src/preload/index.ts
+++ b/src/preload/index.ts
@@ -493,6 +493,8 @@ type OpenScienceAPI = {
       file: File,
       request: BeginUploadTransferRequest
     ) => Promise<UploadedAttachment | null>
+    // Acknowledges that the renderer committed a native-path upload into its draft state.
+    claimLocalFile?: (request: UploadTransferRequest) => Promise<void>
     beginTransfer: (request: BeginUploadTransferRequest) => Promise<UploadTransferStatus>
     appendTransfer: (request: AppendUploadTransferRequest) => Promise<UploadTransferStatus>
     getTransferStatus: (request: UploadTransferRequest) => Promise<UploadTransferStatus | null>
@@ -1031,14 +1033,16 @@ const api: OpenScienceAPI = {
   },
   uploads: {
     // Upload IPC remains behind the preload bridge so renderer code never receives raw fs access.
-    stageLocalFile: (file, request) => {
+    stageLocalFile: async (file, request) => {
       const sourcePath = webUtils.getPathForFile(file)
-      if (!sourcePath) return Promise.resolve(null)
-      return ipcRenderer.invoke('uploads:stage-local-file', {
+      if (!sourcePath) return null
+      return (await ipcRenderer.invoke('uploads:stage-local-file', {
         ...request,
         sourcePath
-      }) as Promise<UploadedAttachment>
+      })) as UploadedAttachment
     },
+    claimLocalFile: (request) =>
+      ipcRenderer.invoke('uploads:claim-local-file', request) as Promise<void>,
     beginTransfer: (request) =>
       ipcRenderer.invoke('uploads:begin-transfer', request) as Promise<UploadTransferStatus>,
     appendTransfer: (request) =>

--- a/src/preload/index.ts
+++ b/src/preload/index.ts
@@ -198,7 +198,6 @@ import type {
   BeginUploadTransferRequest,
   DeleteUploadRequest,
   FinalizeUploadSessionRequest,
-  StageUploadFilesRequest,
   UploadTransferProgress,
   UploadTransferRequest,
   UploadTransferStatus,
@@ -489,8 +488,6 @@ type OpenScienceAPI = {
     readPreview: (request: ReadArtifactPreviewRequest) => Promise<ArtifactPreviewResult>
   }
   uploads: {
-    // Stages files selected or pasted in the renderer into app-managed upload storage.
-    stageFiles: (request: StageUploadFilesRequest) => Promise<UploadedAttachment[]>
     // Desktop-only path fast path. A null result means this File has no native path.
     stageLocalFile?: (
       file: File,
@@ -1034,8 +1031,6 @@ const api: OpenScienceAPI = {
   },
   uploads: {
     // Upload IPC remains behind the preload bridge so renderer code never receives raw fs access.
-    stageFiles: (request) =>
-      ipcRenderer.invoke('uploads:stage-files', request) as Promise<UploadedAttachment[]>,
     stageLocalFile: (file, request) => {
       const sourcePath = webUtils.getPathForFile(file)
       if (!sourcePath) return Promise.resolve(null)

--- a/src/preload/index.ts
+++ b/src/preload/index.ts
@@ -1,4 +1,4 @@
-import { contextBridge, ipcRenderer, type IpcRendererEvent } from 'electron'
+import { contextBridge, ipcRenderer, webUtils, type IpcRendererEvent } from 'electron'
 
 import type {
   AcpCancelPromptRequest,
@@ -194,9 +194,14 @@ import type {
 import type { CliLauncherStatus } from '../shared/cli'
 import type { AppInfo, DownloadProgress, UpdateStatus } from '../shared/update'
 import type {
+  AppendUploadTransferRequest,
+  BeginUploadTransferRequest,
   DeleteUploadRequest,
   FinalizeUploadSessionRequest,
   StageUploadFilesRequest,
+  UploadTransferProgress,
+  UploadTransferRequest,
+  UploadTransferStatus,
   UploadedAttachment
 } from '../shared/uploads'
 import type {
@@ -486,6 +491,17 @@ type OpenScienceAPI = {
   uploads: {
     // Stages files selected or pasted in the renderer into app-managed upload storage.
     stageFiles: (request: StageUploadFilesRequest) => Promise<UploadedAttachment[]>
+    // Desktop-only path fast path. A null result means this File has no native path.
+    stageLocalFile?: (
+      file: File,
+      request: BeginUploadTransferRequest
+    ) => Promise<UploadedAttachment | null>
+    beginTransfer: (request: BeginUploadTransferRequest) => Promise<UploadTransferStatus>
+    appendTransfer: (request: AppendUploadTransferRequest) => Promise<UploadTransferStatus>
+    getTransferStatus: (request: UploadTransferRequest) => Promise<UploadTransferStatus | null>
+    finishTransfer: (request: UploadTransferRequest) => Promise<UploadedAttachment>
+    abortTransfer: (request: UploadTransferRequest) => Promise<void>
+    onTransferProgress: (listener: AcpListener<UploadTransferProgress>) => RemoveListener
     // Deletes a staged upload when the composer chip is removed or the draft is abandoned.
     deleteUpload: (request: DeleteUploadRequest) => Promise<void>
     // Moves pending uploads into the durable session directory once a session id exists.
@@ -1020,6 +1036,28 @@ const api: OpenScienceAPI = {
     // Upload IPC remains behind the preload bridge so renderer code never receives raw fs access.
     stageFiles: (request) =>
       ipcRenderer.invoke('uploads:stage-files', request) as Promise<UploadedAttachment[]>,
+    stageLocalFile: (file, request) => {
+      const sourcePath = webUtils.getPathForFile(file)
+      if (!sourcePath) return Promise.resolve(null)
+      return ipcRenderer.invoke('uploads:stage-local-file', {
+        ...request,
+        sourcePath
+      }) as Promise<UploadedAttachment>
+    },
+    beginTransfer: (request) =>
+      ipcRenderer.invoke('uploads:begin-transfer', request) as Promise<UploadTransferStatus>,
+    appendTransfer: (request) =>
+      ipcRenderer.invoke('uploads:append-transfer', request) as Promise<UploadTransferStatus>,
+    getTransferStatus: (request) =>
+      ipcRenderer.invoke(
+        'uploads:transfer-status',
+        request
+      ) as Promise<UploadTransferStatus | null>,
+    finishTransfer: (request) =>
+      ipcRenderer.invoke('uploads:finish-transfer', request) as Promise<UploadedAttachment>,
+    abortTransfer: (request) =>
+      ipcRenderer.invoke('uploads:abort-transfer', request) as Promise<void>,
+    onTransferProgress: (listener) => onIpcMessage('uploads:transfer-progress', listener),
     deleteUpload: (request) => ipcRenderer.invoke('uploads:delete', request) as Promise<void>,
     finalizeSession: (request) =>
       ipcRenderer.invoke('uploads:finalize-session', request) as Promise<UploadedAttachment[]>,

--- a/src/renderer/src/lib/acp/useWorkspaceAgentRuntime.ts
+++ b/src/renderer/src/lib/acp/useWorkspaceAgentRuntime.ts
@@ -14,7 +14,7 @@ import {
   type SessionPermissionProfileState
 } from '../../../../shared/permission-profiles'
 import type { UploadedAttachment } from '../../../../shared/uploads'
-import type { ArtifactReference } from '../../../../shared/artifacts'
+import type { FileReference } from '../../../../shared/artifacts'
 import type { MessagePart } from '../../../../shared/session-persistence'
 import type { AgentFrameworkId } from '../../../../shared/settings'
 import { isMediaOverflowError } from '../../../../shared/media-overflow'
@@ -51,7 +51,7 @@ type SendWorkspaceMessageInput = {
   // Skills the user picked in the composer; force-loaded and nudged for this turn only.
   forcedSkillIds?: string[]
   // Existing files referenced via `@` mentions; attached to the prompt as content blocks.
-  referencedArtifacts?: ArtifactReference[]
+  referencedArtifacts?: FileReference[]
   // Structured mention segments of the draft, persisted so the sent bubble renders styled pills.
   parts?: MessagePart[]
   // Set by the interrupted-resume path when its own resume already reset the agent's context. The
@@ -80,7 +80,7 @@ type ResendEditedMessageInput = {
   // Skills picked in the inline editor; force-loaded and nudged for the resent turn only.
   forcedSkillIds?: string[]
   // Files referenced via `@` mentions in the inline editor; attached to the resent prompt.
-  referencedArtifacts?: ArtifactReference[]
+  referencedArtifacts?: FileReference[]
 }
 
 type WorkspaceMessageRuntime = Pick<
@@ -341,7 +341,7 @@ const startPendingSessionPrompt = (
   projectName: string | undefined,
   permissionProfile: PermissionProfileId,
   forcedSkillIds: string[] | undefined,
-  referencedArtifacts: ArtifactReference[] | undefined
+  referencedArtifacts: FileReference[] | undefined
 ): void => {
   void (async () => {
     let createdSession

--- a/src/renderer/src/pages/workspace/ConversationPanel.interaction.test.tsx
+++ b/src/renderer/src/pages/workspace/ConversationPanel.interaction.test.tsx
@@ -112,6 +112,7 @@ const renderPanel = (props: Partial<Parameters<typeof ConversationPanel>[0]> = {
         actionError={null}
         isPreviewPanelCollapsed={false}
         attachments={[]}
+        attachmentTransfers={[]}
         isUploadingAttachments={false}
         notebookReference={undefined}
         pendingPermissions={[]}
@@ -124,6 +125,7 @@ const renderPanel = (props: Partial<Parameters<typeof ConversationPanel>[0]> = {
         onSendMessage={vi.fn()}
         onStageAttachmentFiles={onStageAttachmentFiles}
         onRemoveAttachment={vi.fn()}
+        onCancelAttachmentTransfer={vi.fn()}
         onCancelRun={vi.fn()}
         onResumeSession={vi.fn().mockResolvedValue(undefined)}
         onOpenNotebook={vi.fn()}
@@ -197,6 +199,34 @@ afterEach(() => {
 })
 
 describe('ConversationPanel composer intake', () => {
+  it('shows per-file progress and cancels only the selected transfer', () => {
+    const onCancelAttachmentTransfer = vi.fn()
+    const transfer = {
+      transferId: 'transfer-1',
+      name: 'large.csv',
+      mimeType: 'text/csv',
+      receivedBytes: 25,
+      totalBytes: 100,
+      status: 'uploading' as const
+    }
+    renderPanel({
+      attachmentTransfers: [transfer],
+      isUploadingAttachments: true,
+      onCancelAttachmentTransfer
+    })
+
+    const progress = container.querySelector('[role="progressbar"]')
+    const cancel = container.querySelector(
+      'button[aria-label="Cancel attachment large.csv"]'
+    ) as HTMLButtonElement | null
+
+    expect(progress?.getAttribute('aria-valuenow')).toBe('25')
+    expect(container.textContent).toContain('25% of 100 B')
+    expect(cancel).not.toBeNull()
+    act(() => cancel?.click())
+    expect(onCancelAttachmentTransfer).toHaveBeenCalledWith(transfer)
+  })
+
   it('stages a pasted non-image file', () => {
     renderPanel()
     const pdf = new File(['%PDF'], 'report.pdf', { type: 'application/pdf' })

--- a/src/renderer/src/pages/workspace/ConversationPanel.interaction.test.tsx
+++ b/src/renderer/src/pages/workspace/ConversationPanel.interaction.test.tsx
@@ -199,6 +199,14 @@ afterEach(() => {
 })
 
 describe('ConversationPanel composer intake', () => {
+  it('shows file type and per-file size behavior before selection', () => {
+    renderPanel()
+
+    expect(container.querySelector('[data-testid="attachment-limits"]')?.textContent).toContain(
+      'Any file type · 10 GB per file. Large files are linked, not embedded.'
+    )
+  })
+
   it('shows per-file progress and cancels only the selected transfer', () => {
     const onCancelAttachmentTransfer = vi.fn()
     const transfer = {

--- a/src/renderer/src/pages/workspace/ConversationPanel.tsx
+++ b/src/renderer/src/pages/workspace/ConversationPanel.tsx
@@ -41,6 +41,7 @@ import type { ChatSession } from '@/stores/session-store'
 import { useSessionJobStore } from '@/stores/session-job-store'
 
 import { ComposerEditor } from './composer/ComposerEditor'
+import type { ComposerUploadTransfer } from './composer-upload-transfer'
 import { docToSkillIds, type ComposerDoc } from './composer/composer-doc'
 import { ComposerAgentControlsMenu } from './ComposerAgentControlsMenu'
 import { ComposerContextUsage } from './ComposerContextUsage'
@@ -83,7 +84,10 @@ const formatAttachmentSize = (size: number): string => {
 
   if (kilobytes < 1024) return `${Math.round(kilobytes)} KB`
 
-  return `${Math.round(kilobytes / 1024)} MB`
+  const megabytes = kilobytes / 1024
+  if (megabytes < 1024) return `${Math.round(megabytes)} MB`
+
+  return `${(megabytes / 1024).toFixed(1)} GB`
 }
 
 type ConversationPanelProps = {
@@ -94,6 +98,7 @@ type ConversationPanelProps = {
   actionError: string | null
   isPreviewPanelCollapsed: boolean
   attachments: UploadedAttachment[]
+  attachmentTransfers: ComposerUploadTransfer[]
   isUploadingAttachments: boolean
   notebookReference: NotebookSessionReference | undefined
   pendingPermissions: AcpPermissionRequest[]
@@ -109,6 +114,7 @@ type ConversationPanelProps = {
   onSendMessage: (forcedSkillIds: string[]) => void
   onStageAttachmentFiles: (files: File[]) => void
   onRemoveAttachment: (attachment: UploadedAttachment) => void
+  onCancelAttachmentTransfer: (transfer: ComposerUploadTransfer) => void
   onCancelRun: () => void
   onResumeSession: () => Promise<void>
   onOpenNotebook: (notebook: NotebookSessionReference) => void
@@ -142,6 +148,7 @@ const ConversationPanel = ({
   actionError,
   isPreviewPanelCollapsed,
   attachments,
+  attachmentTransfers,
   isUploadingAttachments,
   notebookReference,
   pendingPermissions,
@@ -155,6 +162,7 @@ const ConversationPanel = ({
   onSendMessage,
   onStageAttachmentFiles,
   onRemoveAttachment,
+  onCancelAttachmentTransfer,
   onCancelRun,
   onResumeSession,
   onOpenNotebook,
@@ -209,7 +217,7 @@ const ConversationPanel = ({
 
   // Drag-and-drop shares the same staging callback as the picker and paste paths.
   const { isDragging, dropZoneProps } = useFileDropZone({
-    enabled: canEditDraft,
+    enabled: canEditDraft && !isUploadingAttachments,
     onFiles: onStageAttachmentFiles
   })
 
@@ -233,7 +241,7 @@ const ConversationPanel = ({
 
   // Treats pasted clipboard files exactly like selected files, then keeps text paste behavior intact.
   const handleMessageDraftPaste = (event: React.ClipboardEvent<HTMLDivElement>): void => {
-    if (!canEditDraft) return
+    if (!canEditDraft || isUploadingAttachments) return
 
     const files = Array.from(event.clipboardData.files)
 
@@ -389,7 +397,7 @@ const ConversationPanel = ({
                       <FileDropOverlay label="Drop files to attach" className="rounded-2xl" />
                     ) : null}
                     <div className="flex flex-col gap-2">
-                      {attachments.length > 0 ? (
+                      {attachments.length > 0 || attachmentTransfers.length > 0 ? (
                         <div className="flex max-h-[92px] flex-wrap gap-2 overflow-y-auto border-b border-border-200 pb-2">
                           {/* Composer attachments remain removable until the prompt is submitted. */}
                           {attachments.map((attachment) => {
@@ -416,9 +424,81 @@ const ConversationPanel = ({
                                 <button
                                   type="button"
                                   className={attachmentRemoveButtonClassName}
-                                  disabled={!canEditDraft || isUploadingAttachments}
+                                  disabled={!canEditDraft}
                                   aria-label={`Remove attachment ${attachmentName}`}
                                   onClick={() => onRemoveAttachment(attachment)}
+                                >
+                                  <X className="size-3.5" strokeWidth={2.2} aria-hidden="true" />
+                                </button>
+                              </div>
+                            )
+                          })}
+                          {attachmentTransfers.map((transfer) => {
+                            const AttachmentIcon = transfer.mimeType?.startsWith('image/')
+                              ? ImageIcon
+                              : FileText
+                            const percent =
+                              transfer.totalBytes === 0
+                                ? 100
+                                : Math.min(
+                                    100,
+                                    Math.round((transfer.receivedBytes / transfer.totalBytes) * 100)
+                                  )
+                            const statusLabel =
+                              transfer.status === 'queued'
+                                ? 'Queued'
+                                : transfer.status === 'cancelling'
+                                  ? 'Cancelling…'
+                                  : transfer.status === 'error'
+                                    ? transfer.error || 'Upload failed'
+                                    : `${percent}% of ${formatAttachmentSize(transfer.totalBytes)}`
+
+                            return (
+                              <div
+                                key={transfer.transferId}
+                                className={`${attachmentChipClassName} h-11`}
+                              >
+                                <AttachmentIcon
+                                  className="size-4 shrink-0 text-text-300"
+                                  strokeWidth={2}
+                                  aria-hidden="true"
+                                />
+                                <div className="min-w-0 flex-1">
+                                  <div className="truncate text-[12px] leading-4">
+                                    {transfer.name}
+                                  </div>
+                                  <div
+                                    className={`truncate text-[11px] leading-3 ${
+                                      transfer.status === 'error' ? 'text-red-600' : 'text-text-300'
+                                    }`}
+                                    title={statusLabel}
+                                  >
+                                    {statusLabel}
+                                  </div>
+                                  {transfer.status === 'uploading' ? (
+                                    <div
+                                      className="mt-1 h-0.5 overflow-hidden rounded-full bg-bg-300"
+                                      role="progressbar"
+                                      aria-label={`Uploading ${transfer.name}`}
+                                      aria-valuemin={0}
+                                      aria-valuemax={100}
+                                      aria-valuenow={percent}
+                                    >
+                                      <div
+                                        className="h-full rounded-full bg-primary transition-[width]"
+                                        style={{ width: `${percent}%` }}
+                                      />
+                                    </div>
+                                  ) : null}
+                                </div>
+                                <button
+                                  type="button"
+                                  className={attachmentRemoveButtonClassName}
+                                  disabled={!canEditDraft || transfer.status === 'cancelling'}
+                                  aria-label={`${
+                                    transfer.status === 'error' ? 'Remove failed' : 'Cancel'
+                                  } attachment ${transfer.name}`}
+                                  onClick={() => onCancelAttachmentTransfer(transfer)}
                                 >
                                   <X className="size-3.5" strokeWidth={2.2} aria-hidden="true" />
                                 </button>
@@ -436,7 +516,7 @@ const ConversationPanel = ({
                           onSubmit={handleSubmit}
                           onPaste={handleMessageDraftPaste}
                           disabled={!canEditDraft}
-                          placeholder="Ask anything — / for skills, @ for artifacts"
+                          placeholder="Ask anything — / for skills, @ for files"
                           ariaLabel="Ask anything"
                         />
                       </div>

--- a/src/renderer/src/pages/workspace/ConversationPanel.tsx
+++ b/src/renderer/src/pages/workspace/ConversationPanel.tsx
@@ -8,7 +8,11 @@ import type {
   PermissionProfileId,
   SessionPermissionProfileState
 } from '../../../../shared/permission-profiles'
-import type { UploadedAttachment } from '../../../../shared/uploads'
+import {
+  MAX_UPLOAD_FILE_BYTES,
+  formatUploadSizeLimit,
+  type UploadedAttachment
+} from '../../../../shared/uploads'
 import { isReportableRunFailure } from '../../../../shared/run-error-classification'
 import {
   ArrowUp,
@@ -535,7 +539,7 @@ const ConversationPanel = ({
                               <Plus className="size-4" strokeWidth={2} aria-hidden="true" />
                             </button>
                           </DropdownMenuTrigger>
-                          <DropdownMenuContent side="top" align="start" className="w-48">
+                          <DropdownMenuContent side="top" align="start" className="w-64">
                             <DropdownMenuItem
                               data-testid="menu-attach-files"
                               onSelect={() => fileInputRef.current?.click()}
@@ -543,6 +547,13 @@ const ConversationPanel = ({
                               <FileText className="mr-2 size-4 text-text-300" aria-hidden="true" />
                               Attach files
                             </DropdownMenuItem>
+                            <div
+                              className="px-2 py-1.5 text-[11px] leading-4 text-text-300"
+                              data-testid="attachment-limits"
+                            >
+                              Any file type · {formatUploadSizeLimit(MAX_UPLOAD_FILE_BYTES)} per
+                              file. Large files are linked, not embedded.
+                            </div>
                             <DropdownMenuSeparator />
                             <DropdownMenuItem
                               data-testid="menu-request-review"

--- a/src/renderer/src/pages/workspace/WorkspaceMessageScroller.tsx
+++ b/src/renderer/src/pages/workspace/WorkspaceMessageScroller.tsx
@@ -303,6 +303,10 @@ const WorkspaceMessageScroller = ({
   // Opens an artifact mention in the preview panel, probing existence first so a stale link warns.
   const onPreviewMentionArtifact = async (part: ArtifactMentionPart): Promise<void> => {
     if (!currentSessionId) return
+    if (part.source === 'linked-folder') {
+      showMentionNotice('Linked-folder files are not available until the folder is connected.')
+      return
+    }
 
     const read =
       part.source === 'upload' ? window.api.uploads.readPreview : window.api.artifacts.readPreview

--- a/src/renderer/src/pages/workspace/WorkspacePage.draft-preservation.test.tsx
+++ b/src/renderer/src/pages/workspace/WorkspacePage.draft-preservation.test.tsx
@@ -412,6 +412,150 @@ describe('WorkspacePage draft preservation', () => {
     expect(stageLocalFile).toHaveBeenCalledTimes(1)
   })
 
+  it('deletes an attachment that finishes while active-session deletion is pending', async () => {
+    await renderPage()
+
+    // Returning to A leaves an inactive-draft snapshot in composerDraftsRef; active live state must
+    // win over that older snapshot when deletion eventually succeeds.
+    await openSession('sess-b')
+    await openSession('sess-a')
+
+    const attachment = createAttachment('att-finished-during-delete')
+    let finishUpload: ((value: UploadedAttachment) => void) | undefined
+    stageLocalFile.mockImplementationOnce(
+      () =>
+        new Promise((resolve) => {
+          finishUpload = resolve
+        })
+    )
+    let finishDeletion: (() => void) | undefined
+    runtime.deleteRuntimeSession.mockImplementationOnce(
+      (id: string) =>
+        new Promise((resolve) => {
+          finishDeletion = () => {
+            useSessionStore.getState().deleteSession(id)
+            resolve(true)
+          }
+        })
+    )
+
+    await act(async () => {
+      conversationProps.onStageAttachmentFiles([
+        new File(['data'], 'late.txt', { type: 'text/plain' })
+      ])
+      await Promise.resolve()
+    })
+
+    const sessionA = useSessionStore.getState().sessions.find((session) => session.id === 'sess-a')!
+    await act(async () => {
+      sidebarProps.onDeleteSession(sessionA)
+    })
+    await act(async () => {
+      deleteDialogProps.onConfirmDelete()
+      await Promise.resolve()
+    })
+
+    await act(async () => {
+      finishUpload?.(attachment)
+      await Promise.resolve()
+      await Promise.resolve()
+    })
+    expect(conversationProps.attachments).toEqual([attachment])
+
+    await act(async () => {
+      finishDeletion?.()
+      await Promise.resolve()
+      await Promise.resolve()
+    })
+
+    expect(deleteUpload).toHaveBeenCalledWith({ path: attachment.path })
+  })
+
+  it('deletes a staged attachment when deletion settles before the upload continuation', async () => {
+    await renderPage()
+
+    const attachment = createAttachment('att-resolved-before-continuation')
+    let finishUpload: ((value: UploadedAttachment) => void) | undefined
+    stageLocalFile.mockImplementationOnce(
+      () =>
+        new Promise((resolve) => {
+          finishUpload = resolve
+        })
+    )
+    let finishDeletion: (() => void) | undefined
+    runtime.deleteRuntimeSession.mockImplementationOnce(
+      (id: string) =>
+        new Promise((resolve) => {
+          finishDeletion = () => {
+            useSessionStore.getState().deleteSession(id)
+            resolve(true)
+          }
+        })
+    )
+
+    await act(async () => {
+      conversationProps.onStageAttachmentFiles([
+        new File(['data'], 'late-continuation.txt', { type: 'text/plain' })
+      ])
+      await Promise.resolve()
+    })
+    const sessionA = useSessionStore.getState().sessions.find((session) => session.id === 'sess-a')!
+    await act(async () => {
+      sidebarProps.onDeleteSession(sessionA)
+    })
+    await act(async () => {
+      deleteDialogProps.onConfirmDelete()
+      await Promise.resolve()
+    })
+
+    await act(async () => {
+      // Resolving in this order queues the upload's inner continuation, then deletion. Deletion
+      // aborts the controller before WorkspacePage receives the staged attachment.
+      finishUpload?.(attachment)
+      finishDeletion?.()
+      await Promise.resolve()
+      await Promise.resolve()
+      await Promise.resolve()
+    })
+
+    expect(deleteUpload).toHaveBeenCalledWith({ path: attachment.path })
+  })
+
+  it('ignores a duplicate deletion request while the same session deletion is pending', async () => {
+    await renderPage()
+
+    const finishDeletions: Array<(deleted: boolean) => void> = []
+    runtime.deleteRuntimeSession.mockImplementation(
+      () =>
+        new Promise((resolve) => {
+          finishDeletions.push(resolve)
+        })
+    )
+    const sessionA = useSessionStore.getState().sessions.find((session) => session.id === 'sess-a')!
+
+    await act(async () => {
+      sidebarProps.onDeleteSession(sessionA)
+    })
+    await act(async () => {
+      deleteDialogProps.onConfirmDelete()
+      await Promise.resolve()
+    })
+    await act(async () => {
+      sidebarProps.onDeleteSession(sessionA)
+    })
+    await act(async () => {
+      deleteDialogProps.onConfirmDelete()
+      await Promise.resolve()
+    })
+
+    expect(runtime.deleteRuntimeSession).toHaveBeenCalledTimes(1)
+
+    await act(async () => {
+      finishDeletions[0]?.(false)
+      await Promise.resolve()
+    })
+  })
+
   it('keeps a stored draft and its staged files when session deletion fails', async () => {
     await renderPage()
 

--- a/src/renderer/src/pages/workspace/WorkspacePage.draft-preservation.test.tsx
+++ b/src/renderer/src/pages/workspace/WorkspacePage.draft-preservation.test.tsx
@@ -124,6 +124,7 @@ const textDoc = (text: string): ComposerDoc => ({ nodes: [{ type: 'text', text }
 
 const deleteUpload = vi.fn(() => Promise.resolve())
 const stageLocalFile = vi.fn()
+const claimLocalFile = vi.fn(() => Promise.resolve())
 const abortTransfer = vi.fn(() => Promise.resolve())
 
 describe('WorkspacePage draft preservation', () => {
@@ -173,6 +174,7 @@ describe('WorkspacePage draft preservation', () => {
       uploads: {
         deleteUpload,
         stageLocalFile,
+        claimLocalFile,
         beginTransfer: vi.fn(),
         appendTransfer: vi.fn(),
         getTransferStatus: vi.fn(),
@@ -301,6 +303,7 @@ describe('WorkspacePage draft preservation', () => {
     const attachmentA = createAttachment('att-a')
     await stageAttachment(attachmentA)
     expect(conversationProps.attachments).toEqual([attachmentA])
+    expect(claimLocalFile).toHaveBeenCalledWith({ transferId: expect.any(String) })
 
     // Switching away must not delete the staged file and must clear the composer for B.
     await openSession('sess-b')

--- a/src/renderer/src/pages/workspace/WorkspacePage.draft-preservation.test.tsx
+++ b/src/renderer/src/pages/workspace/WorkspacePage.draft-preservation.test.tsx
@@ -17,12 +17,14 @@ import {
 } from '@/stores/session-store'
 import type { UploadedAttachment } from '../../../../shared/uploads'
 
+import type { ComposerUploadTransfer } from './composer-upload-transfer'
 import { emptyDoc, type ComposerDoc } from './composer/composer-doc'
 
 // Capture the props passed to the heavy child components so the test can drive selection and drafts.
 let conversationProps: {
   draftDoc: ComposerDoc
   attachments: UploadedAttachment[]
+  attachmentTransfers: ComposerUploadTransfer[]
   onDraftDocChange: (doc: ComposerDoc) => void
   onSendMessage: (forcedSkillIds: string[]) => void
   onStageAttachmentFiles: (files: File[]) => void
@@ -122,6 +124,7 @@ const textDoc = (text: string): ComposerDoc => ({ nodes: [{ type: 'text', text }
 
 const deleteUpload = vi.fn(() => Promise.resolve())
 const stageLocalFile = vi.fn()
+const abortTransfer = vi.fn(() => Promise.resolve())
 
 describe('WorkspacePage draft preservation', () => {
   let container: HTMLDivElement
@@ -174,7 +177,7 @@ describe('WorkspacePage draft preservation', () => {
         appendTransfer: vi.fn(),
         getTransferStatus: vi.fn(),
         finishTransfer: vi.fn(),
-        abortTransfer: vi.fn(() => Promise.resolve()),
+        abortTransfer,
         onTransferProgress: vi.fn(() => vi.fn())
       },
       reviewer: {
@@ -364,6 +367,49 @@ describe('WorkspacePage draft preservation', () => {
     expect(deleteUpload).toHaveBeenCalledWith({ path: attachmentB.path })
     expect(runtime.deleteRuntimeSession).toHaveBeenCalledWith('sess-b')
     expect(conversationProps.draftDoc).toEqual(emptyDoc)
+  })
+
+  it('cancels in-flight and queued transfers before deleting their session draft', async () => {
+    await renderPage()
+
+    let rejectFirstUpload: ((reason?: unknown) => void) | undefined
+    stageLocalFile.mockImplementationOnce(
+      () =>
+        new Promise((_resolve, reject) => {
+          rejectFirstUpload = reject
+        })
+    )
+    await act(async () => {
+      conversationProps.onStageAttachmentFiles([
+        new File(['first'], 'first.txt', { type: 'text/plain' }),
+        new File(['second'], 'second.txt', { type: 'text/plain' })
+      ])
+      await Promise.resolve()
+    })
+
+    const transferIds = conversationProps.attachmentTransfers.map(({ transferId }) => transferId)
+    expect(transferIds).toHaveLength(2)
+    expect(stageLocalFile).toHaveBeenCalledTimes(1)
+
+    const sessionA = useSessionStore.getState().sessions.find((session) => session.id === 'sess-a')!
+    await act(async () => {
+      sidebarProps.onDeleteSession(sessionA)
+    })
+    await act(async () => {
+      deleteDialogProps.onConfirmDelete()
+      await Promise.resolve()
+    })
+
+    for (const transferId of transferIds) {
+      expect(abortTransfer).toHaveBeenCalledWith({ transferId })
+    }
+
+    await act(async () => {
+      rejectFirstUpload?.(new Error('Upload cancelled'))
+      await Promise.resolve()
+      await Promise.resolve()
+    })
+    expect(stageLocalFile).toHaveBeenCalledTimes(1)
   })
 
   it('keeps a stored draft and its staged files when session deletion fails', async () => {

--- a/src/renderer/src/pages/workspace/WorkspacePage.draft-preservation.test.tsx
+++ b/src/renderer/src/pages/workspace/WorkspacePage.draft-preservation.test.tsx
@@ -121,7 +121,7 @@ const createAttachment = (id: string): UploadedAttachment => ({
 const textDoc = (text: string): ComposerDoc => ({ nodes: [{ type: 'text', text }] })
 
 const deleteUpload = vi.fn(() => Promise.resolve())
-const stageFiles = vi.fn()
+const stageLocalFile = vi.fn()
 
 describe('WorkspacePage draft preservation', () => {
   let container: HTMLDivElement
@@ -169,7 +169,13 @@ describe('WorkspacePage draft preservation', () => {
       },
       uploads: {
         deleteUpload,
-        stageFiles
+        stageLocalFile,
+        beginTransfer: vi.fn(),
+        appendTransfer: vi.fn(),
+        getTransferStatus: vi.fn(),
+        finishTransfer: vi.fn(),
+        abortTransfer: vi.fn(() => Promise.resolve()),
+        onTransferProgress: vi.fn(() => vi.fn())
       },
       reviewer: {
         onUpdated: vi.fn(() => vi.fn()),
@@ -202,7 +208,7 @@ describe('WorkspacePage draft preservation', () => {
 
   // Drives the composer's real staging pipeline so a per-session attachment lands in page state.
   const stageAttachment = async (attachment: UploadedAttachment): Promise<void> => {
-    stageFiles.mockResolvedValueOnce([attachment])
+    stageLocalFile.mockResolvedValueOnce(attachment)
     await act(async () => {
       conversationProps.onStageAttachmentFiles([
         new File(['data'], `${attachment.id}.txt`, { type: 'text/plain' })

--- a/src/renderer/src/pages/workspace/WorkspacePage.edit-message.test.tsx
+++ b/src/renderer/src/pages/workspace/WorkspacePage.edit-message.test.tsx
@@ -149,7 +149,7 @@ describe('WorkspacePage inline edit resend', () => {
         load: vi.fn(() => Promise.resolve(undefined)),
         save: vi.fn(() => Promise.resolve())
       },
-      uploads: { deleteUpload: vi.fn(), stageFiles: vi.fn() },
+      uploads: { deleteUpload: vi.fn() },
       reviewer: {
         onUpdated: vi.fn(() => vi.fn()),
         onSuppressNextAutoReview: vi.fn(() => vi.fn()),

--- a/src/renderer/src/pages/workspace/WorkspacePage.image-staging.test.tsx
+++ b/src/renderer/src/pages/workspace/WorkspacePage.image-staging.test.tsx
@@ -40,7 +40,7 @@ const runtime = vi.hoisted(() => ({
   respondToPermission: vi.fn()
 }))
 
-const stageFiles = vi.hoisted(() => vi.fn())
+const stageLocalFile = vi.hoisted(() => vi.fn())
 
 vi.mock('@/components/ui/resizable', () => ({
   ResizablePanelGroup: ({ children }: { children: React.ReactNode }): React.JSX.Element => (
@@ -162,7 +162,16 @@ describe('WorkspacePage image attachment gating', () => {
         load: vi.fn(() => Promise.resolve(undefined)),
         save: vi.fn(() => Promise.resolve())
       },
-      uploads: { deleteUpload: vi.fn(), stageFiles },
+      uploads: {
+        stageLocalFile,
+        beginTransfer: vi.fn(),
+        appendTransfer: vi.fn(),
+        getTransferStatus: vi.fn(),
+        finishTransfer: vi.fn(),
+        abortTransfer: vi.fn(() => Promise.resolve()),
+        deleteUpload: vi.fn(() => Promise.resolve()),
+        onTransferProgress: vi.fn(() => vi.fn())
+      },
       reviewer: {
         onUpdated: vi.fn(() => vi.fn()),
         onSuppressNextAutoReview: vi.fn(() => vi.fn()),
@@ -203,7 +212,7 @@ describe('WorkspacePage image attachment gating', () => {
       mimeType: 'image/png',
       size: 3
     }
-    stageFiles.mockResolvedValue([staged])
+    stageLocalFile.mockResolvedValue(staged)
     runtime.sendMessage.mockResolvedValue({ sessionId: 'sess-a' })
 
     await renderPage()
@@ -212,11 +221,10 @@ describe('WorkspacePage image attachment gating', () => {
       conversationProps.onStageAttachmentFiles([imageFile()])
     })
 
-    // The image is read (FileReader) and forwarded to the upload IPC, then surfaced as a composer
-    // attachment — wait on that observable state instead of a fixed tick so the async pipeline settles.
+    // The image takes the native-path upload adapter and then surfaces as a composer attachment.
     await act(async () => {
       await vi.waitFor(() => {
-        expect(stageFiles).toHaveBeenCalledTimes(1)
+        expect(stageLocalFile).toHaveBeenCalledTimes(1)
         expect(conversationProps.attachments).toEqual([staged])
       })
     })
@@ -245,7 +253,7 @@ describe('WorkspacePage image attachment gating', () => {
     await act(async () => {
       await vi.waitFor(() => expect(conversationProps.actionError).toBe(IMAGE_BLOCKED_MESSAGE))
     })
-    expect(stageFiles).not.toHaveBeenCalled()
+    expect(stageLocalFile).not.toHaveBeenCalled()
     expect(conversationProps.attachments).toEqual([])
   })
 
@@ -261,7 +269,7 @@ describe('WorkspacePage image attachment gating', () => {
       mimeType: 'image/png',
       size: 3
     }
-    stageFiles.mockResolvedValue([staged])
+    stageLocalFile.mockResolvedValue(staged)
 
     await renderPage()
 

--- a/src/renderer/src/pages/workspace/WorkspacePage.send-gate.test.tsx
+++ b/src/renderer/src/pages/workspace/WorkspacePage.send-gate.test.tsx
@@ -120,7 +120,7 @@ describe('WorkspacePage send gate while compacting', () => {
         load: vi.fn(() => Promise.resolve(undefined)),
         save: vi.fn(() => Promise.resolve())
       },
-      uploads: { deleteUpload: vi.fn(), stageFiles: vi.fn() },
+      uploads: { deleteUpload: vi.fn() },
       reviewer: {
         onUpdated: vi.fn(() => vi.fn()),
         onSuppressNextAutoReview: vi.fn(() => vi.fn()),

--- a/src/renderer/src/pages/workspace/WorkspacePage.tsx
+++ b/src/renderer/src/pages/workspace/WorkspacePage.tsx
@@ -732,10 +732,18 @@ const WorkspacePage = ({ isSessionPersistenceReady }: WorkspacePageProps): React
             }
           })
           if (controller.signal.aborted) {
-            await window.api.uploads.deleteUpload({ path: attachment.path }).catch(() => undefined)
+            await Promise.all([
+              window.api.uploads.deleteUpload({ path: attachment.path }).catch(() => undefined),
+              window.api.uploads
+                .abortTransfer({ transferId: transfer.transferId })
+                .catch(() => undefined)
+            ])
             continue
           }
           commitDraftAttachment(draftKey, transfer.transferId, attachment)
+          await window.api.uploads
+            .claimLocalFile?.({ transferId: transfer.transferId })
+            .catch((error) => console.warn('Failed to claim staged local upload', error))
         } catch (uploadError) {
           if (controller.signal.aborted) {
             updateDraftTransfers(draftKey, (transfers) =>

--- a/src/renderer/src/pages/workspace/WorkspacePage.tsx
+++ b/src/renderer/src/pages/workspace/WorkspacePage.tsx
@@ -182,6 +182,17 @@ const WorkspacePage = ({ isSessionPersistenceReady }: WorkspacePageProps): React
       }
     >
   >({})
+  // Mutable cleanup ledgers bridge the async runtime-deletion window. Uploads that finish or queue
+  // after confirmation are added here so a successful deletion cannot strand staged files.
+  const sessionDeletionCleanupRef = useRef<
+    Record<
+      string,
+      {
+        attachments: UploadedAttachment[]
+        attachmentTransfers: ComposerUploadTransfer[]
+      }
+    >
+  >({})
   const previousDraftKeyRef = useRef<string>(selectedSessionId ?? NEW_CONVERSATION_DRAFT_KEY)
   const [attachments, setAttachments] = useState<UploadedAttachment[]>([])
   const [attachmentTransfers, setAttachmentTransfers] = useState<ComposerUploadTransfer[]>([])
@@ -604,6 +615,14 @@ const WorkspacePage = ({ isSessionPersistenceReady }: WorkspacePageProps): React
     transferId: string,
     attachment: UploadedAttachment
   ): void => {
+    const deletionCleanup = sessionDeletionCleanupRef.current[draftKey]
+    if (deletionCleanup) {
+      deletionCleanup.attachmentTransfers = deletionCleanup.attachmentTransfers.filter(
+        (transfer) => transfer.transferId !== transferId
+      )
+      deletionCleanup.attachments.push(attachment)
+    }
+
     if (previousDraftKeyRef.current === draftKey) {
       setAttachmentTransfers((transfers) =>
         transfers.filter((transfer) => transfer.transferId !== transferId)
@@ -678,6 +697,10 @@ const WorkspacePage = ({ isSessionPersistenceReady }: WorkspacePageProps): React
       ...transfers,
       ...pending.map(({ transfer }) => transfer)
     ])
+    const deletionCleanup = sessionDeletionCleanupRef.current[draftKey]
+    if (deletionCleanup) {
+      deletionCleanup.attachmentTransfers.push(...pending.map(({ transfer }) => transfer))
+    }
 
     void (async () => {
       // Serialize files so a multi-select never holds one chunk per attachment in memory at once.
@@ -708,6 +731,10 @@ const WorkspacePage = ({ isSessionPersistenceReady }: WorkspacePageProps): React
               )
             }
           })
+          if (controller.signal.aborted) {
+            await window.api.uploads.deleteUpload({ path: attachment.path }).catch(() => undefined)
+            continue
+          }
           commitDraftAttachment(draftKey, transfer.transferId, attachment)
         } catch (uploadError) {
           if (controller.signal.aborted) {
@@ -759,6 +786,12 @@ const WorkspacePage = ({ isSessionPersistenceReady }: WorkspacePageProps): React
     setAttachments((currentAttachments) =>
       currentAttachments.filter((item) => item.id !== attachment.id)
     )
+    const deletionCleanup = sessionDeletionCleanupRef.current[previousDraftKeyRef.current]
+    if (deletionCleanup) {
+      deletionCleanup.attachments = deletionCleanup.attachments.filter(
+        (item) => item.id !== attachment.id
+      )
+    }
     void window.api.uploads.deleteUpload({ path: attachment.path }).catch((error) => {
       setAttachmentError(getErrorMessage(error))
     })
@@ -875,27 +908,36 @@ const WorkspacePage = ({ isSessionPersistenceReady }: WorkspacePageProps): React
 
     const deletedSessionId = sessionToDelete.id
     const isActiveSession = deletedSessionId === selectedSessionId
+    if (sessionDeletionCleanupRef.current[deletedSessionId]) {
+      setSessionToDelete(undefined)
+      return
+    }
     const storedDraft = composerDraftsRef.current[deletedSessionId]
-    const abandonedAttachments = storedDraft?.attachments ?? (isActiveSession ? attachments : [])
-    const abandonedTransfers =
-      storedDraft?.attachmentTransfers ?? (isActiveSession ? attachmentTransfers : [])
+    sessionDeletionCleanupRef.current[deletedSessionId] = {
+      attachments: [...(isActiveSession ? attachments : (storedDraft?.attachments ?? []))],
+      attachmentTransfers: [
+        ...(isActiveSession ? attachmentTransfers : (storedDraft?.attachmentTransfers ?? []))
+      ]
+    }
 
     setSessionToDelete(undefined)
     // Staged bytes and local draft state are owned by the session until runtime and durable deletion
     // both succeed. The store's successful deletion updates selection and lets the draft effect load
     // the fallback session without clearing that replacement draft here.
     void deleteRuntimeSession(deletedSessionId).then((deleted) => {
-      if (!deleted) return
+      const deletionCleanup = sessionDeletionCleanupRef.current[deletedSessionId]
+      delete sessionDeletionCleanupRef.current[deletedSessionId]
+      if (!deleted || !deletionCleanup) return
 
       delete composerDraftsRef.current[deletedSessionId]
-      for (const transfer of abandonedTransfers) {
+      for (const transfer of deletionCleanup.attachmentTransfers) {
         // Queued files have no controller yet. Mark every transfer before aborting the active one so
         // the serialized loop skips later entries after the in-flight request settles.
         cancelledAttachmentTransfersRef.current.add(transfer.transferId)
         attachmentTransferControllersRef.current[transfer.transferId]?.abort()
         void window.api.uploads.abortTransfer({ transferId: transfer.transferId })
       }
-      deleteAttachmentFiles(abandonedAttachments)
+      deleteAttachmentFiles(deletionCleanup.attachments)
     })
   }
 

--- a/src/renderer/src/pages/workspace/WorkspacePage.tsx
+++ b/src/renderer/src/pages/workspace/WorkspacePage.tsx
@@ -727,6 +727,7 @@ const WorkspacePage = ({ isSessionPersistenceReady }: WorkspacePageProps): React
           }
         } finally {
           delete attachmentTransferControllersRef.current[transfer.transferId]
+          cancelledAttachmentTransfersRef.current.delete(transfer.transferId)
         }
       }
     })()
@@ -888,6 +889,9 @@ const WorkspacePage = ({ isSessionPersistenceReady }: WorkspacePageProps): React
 
       delete composerDraftsRef.current[deletedSessionId]
       for (const transfer of abandonedTransfers) {
+        // Queued files have no controller yet. Mark every transfer before aborting the active one so
+        // the serialized loop skips later entries after the in-flight request settles.
+        cancelledAttachmentTransfersRef.current.add(transfer.transferId)
         attachmentTransferControllersRef.current[transfer.transferId]?.abort()
         void window.api.uploads.abortTransfer({ transferId: transfer.transferId })
       }

--- a/src/renderer/src/pages/workspace/WorkspacePage.tsx
+++ b/src/renderer/src/pages/workspace/WorkspacePage.tsx
@@ -27,9 +27,10 @@ import {
   suppressNextAutoReview,
   clearSuppressNextAutoReview
 } from '@/lib/acp/workspace-events'
-import type { StageUploadFile, UploadedAttachment } from '../../../../shared/uploads'
+import type { UploadedAttachment } from '../../../../shared/uploads'
 
 import { planComposerAttachmentIntake } from './composer-attachment-intake'
+import { stageComposerFile, type ComposerUploadTransfer } from './composer-upload-transfer'
 import {
   docIsEmpty,
   docToArtifactRefs,
@@ -74,21 +75,6 @@ const previewPanelAnimation = {
 
 const prefersReducedMotion = (): boolean =>
   window.matchMedia?.('(prefers-reduced-motion: reduce)').matches === true
-
-// Reads a browser File into the base64 payload expected by the upload IPC layer.
-const readFileAsBase64 = (file: File): Promise<string> =>
-  new Promise((resolve, reject) => {
-    const reader = new FileReader()
-
-    reader.onload = () => {
-      const result = typeof reader.result === 'string' ? reader.result : ''
-      const commaIndex = result.indexOf(',')
-
-      resolve(commaIndex >= 0 ? result.slice(commaIndex + 1) : result)
-    }
-    reader.onerror = () => reject(reader.error ?? new Error('File could not be read.'))
-    reader.readAsDataURL(file)
-  })
 
 // Provides stable names for pasted images, which often arrive without a useful filename.
 const getUploadFilename = (file: File, index: number): string => {
@@ -187,11 +173,21 @@ const WorkspacePage = ({ isSessionPersistenceReady }: WorkspacePageProps): React
   // Unsent composer state (rich doc + staged attachments) is kept per session (and per new conversation)
   // so switching away and back restores it. The active key's state is live; this map holds inactive keys.
   const composerDraftsRef = useRef<
-    Record<string, { doc: ComposerDoc; attachments: UploadedAttachment[] }>
+    Record<
+      string,
+      {
+        doc: ComposerDoc
+        attachments: UploadedAttachment[]
+        attachmentTransfers: ComposerUploadTransfer[]
+      }
+    >
   >({})
   const previousDraftKeyRef = useRef<string>(selectedSessionId ?? NEW_CONVERSATION_DRAFT_KEY)
   const [attachments, setAttachments] = useState<UploadedAttachment[]>([])
-  const [isUploadingAttachments, setIsUploadingAttachments] = useState(false)
+  const [attachmentTransfers, setAttachmentTransfers] = useState<ComposerUploadTransfer[]>([])
+  const attachmentTransfersRef = useRef<ComposerUploadTransfer[]>([])
+  const attachmentTransferControllersRef = useRef<Record<string, AbortController>>({})
+  const cancelledAttachmentTransfersRef = useRef(new Set<string>())
   const [attachmentError, setAttachmentError] = useState<string | null>(null)
   const [notebookReferences, setNotebookReferences] = useState<
     Record<string, NotebookSessionReference>
@@ -203,6 +199,26 @@ const WorkspacePage = ({ isSessionPersistenceReady }: WorkspacePageProps): React
     undefined
   )
   const [jobListModal, setJobListModal] = useState({ open: false, sessionId: '' })
+
+  useEffect(() => {
+    attachmentTransfersRef.current = attachmentTransfers
+  }, [attachmentTransfers])
+
+  useEffect(
+    () => () => {
+      const transferIds = new Set(Object.keys(attachmentTransferControllersRef.current))
+      for (const transfer of attachmentTransfersRef.current) transferIds.add(transfer.transferId)
+      for (const draft of Object.values(composerDraftsRef.current)) {
+        for (const transfer of draft.attachmentTransfers) transferIds.add(transfer.transferId)
+      }
+      for (const transferId of transferIds) {
+        cancelledAttachmentTransfersRef.current.add(transferId)
+        attachmentTransferControllersRef.current[transferId]?.abort()
+        void window.api.uploads.abortTransfer({ transferId })
+      }
+    },
+    []
+  )
   // The selected session is the only conversation rendered in the center panel.
   const activeSession = useMemo(
     () => sessions.find((session) => session.id === selectedSessionId),
@@ -266,12 +282,18 @@ const WorkspacePage = ({ isSessionPersistenceReady }: WorkspacePageProps): React
   const handleReviewUpdate = useReviewStore((state) => state.handleReviewUpdate)
   // Composer controls follow only the selected session and persistence readiness.
   const canEditDraft = isSessionPersistenceReady
+  const isUploadingAttachments = attachmentTransfers.some(
+    (transfer) =>
+      transfer.status === 'queued' ||
+      transfer.status === 'uploading' ||
+      transfer.status === 'cancelling'
+  )
   // Sending is disabled while the current session is running, awaiting a decision, or locked by the
   // fix loop (fixLoopActive). The fix loop lock persists across both the reviewer-review sub-phase and
   // the main agent-fix sub-phase; typing does not override the lock.
   const canSendMessage =
     isSessionPersistenceReady &&
-    !isUploadingAttachments &&
+    attachmentTransfers.length === 0 &&
     (!docIsEmpty(draftDoc) || attachments.length > 0) &&
     activeSession?.status !== 'running' &&
     activeSession?.status !== 'waiting-permission' &&
@@ -403,15 +425,21 @@ const WorkspacePage = ({ isSessionPersistenceReady }: WorkspacePageProps): React
 
     if (currentDraftKey === previousDraftKey) return
 
-    composerDraftsRef.current[previousDraftKey] = { doc: draftDoc, attachments }
+    composerDraftsRef.current[previousDraftKey] = {
+      doc: draftDoc,
+      attachments,
+      attachmentTransfers
+    }
     const nextDraft = composerDraftsRef.current[currentDraftKey] ?? {
       doc: emptyDoc,
-      attachments: []
+      attachments: [],
+      attachmentTransfers: []
     }
     setDraftDoc(nextDraft.doc)
     setAttachments(nextDraft.attachments)
+    setAttachmentTransfers(nextDraft.attachmentTransfers)
     previousDraftKeyRef.current = currentDraftKey
-  }, [selectedSessionId, draftDoc, attachments])
+  }, [selectedSessionId, draftDoc, attachments, attachmentTransfers])
 
   // The first agent-side notebook call promotes a notebook entry into the composer status bar.
   useEffect(() => {
@@ -558,6 +586,40 @@ const WorkspacePage = ({ isSessionPersistenceReady }: WorkspacePageProps): React
     })
   }
 
+  const updateDraftTransfers = (
+    draftKey: string,
+    update: (transfers: ComposerUploadTransfer[]) => ComposerUploadTransfer[]
+  ): void => {
+    if (previousDraftKeyRef.current === draftKey) {
+      setAttachmentTransfers(update)
+      return
+    }
+
+    const draft = composerDraftsRef.current[draftKey]
+    if (draft) draft.attachmentTransfers = update(draft.attachmentTransfers)
+  }
+
+  const commitDraftAttachment = (
+    draftKey: string,
+    transferId: string,
+    attachment: UploadedAttachment
+  ): void => {
+    if (previousDraftKeyRef.current === draftKey) {
+      setAttachmentTransfers((transfers) =>
+        transfers.filter((transfer) => transfer.transferId !== transferId)
+      )
+      setAttachments((currentAttachments) => [...currentAttachments, attachment])
+      return
+    }
+
+    const draft = composerDraftsRef.current[draftKey]
+    if (!draft) return
+    draft.attachmentTransfers = draft.attachmentTransfers.filter(
+      (transfer) => transfer.transferId !== transferId
+    )
+    draft.attachments.push(attachment)
+  }
+
   // Keeps New as a local draft reset after persistence hydration has selected restored sessions.
   const openNewConversation = (): void => {
     if (!isSessionPersistenceReady) return
@@ -586,33 +648,109 @@ const WorkspacePage = ({ isSessionPersistenceReady }: WorkspacePageProps): React
     }
 
     // Enforce the size and count limits up front so rejected files are never read or uploaded.
-    const { accepted, error } = planComposerAttachmentIntake(files, attachments.length)
+    const { accepted, error } = planComposerAttachmentIntake(
+      files,
+      attachments.length + attachmentTransfers.length
+    )
 
     setAttachmentError(error)
 
     if (accepted.length === 0) return
 
-    setIsUploadingAttachments(true)
+    const draftKey = previousDraftKeyRef.current
+    const pending = accepted.map(
+      (file, index): { file: File; transfer: ComposerUploadTransfer } => {
+        const name = getUploadFilename(file, index)
+        return {
+          file,
+          transfer: {
+            transferId: crypto.randomUUID(),
+            name,
+            mimeType: file.type || undefined,
+            receivedBytes: 0,
+            totalBytes: file.size,
+            status: 'queued'
+          }
+        }
+      }
+    )
+    setAttachmentTransfers((transfers) => [
+      ...transfers,
+      ...pending.map(({ transfer }) => transfer)
+    ])
 
     void (async () => {
-      try {
-        // Browser File objects cannot cross IPC directly, so send base64 content plus metadata.
-        const stagedFiles: StageUploadFile[] = await Promise.all(
-          accepted.map(async (file, index) => ({
-            name: getUploadFilename(file, index),
-            mimeType: file.type || undefined,
-            content: await readFileAsBase64(file)
-          }))
+      // Serialize files so a multi-select never holds one chunk per attachment in memory at once.
+      for (const { file, transfer } of pending) {
+        if (cancelledAttachmentTransfersRef.current.delete(transfer.transferId)) continue
+        const controller = new AbortController()
+        attachmentTransferControllersRef.current[transfer.transferId] = controller
+        updateDraftTransfers(draftKey, (transfers) =>
+          transfers.map((candidate) =>
+            candidate.transferId === transfer.transferId
+              ? { ...candidate, status: 'uploading' }
+              : candidate
+          )
         )
-        const stagedAttachments = await window.api.uploads.stageFiles({ files: stagedFiles })
 
-        setAttachments((currentAttachments) => [...currentAttachments, ...stagedAttachments])
-      } catch (error) {
-        setAttachmentError(getErrorMessage(error))
-      } finally {
-        setIsUploadingAttachments(false)
+        try {
+          const attachment = await stageComposerFile(file, window.api.uploads, {
+            transferId: transfer.transferId,
+            name: transfer.name,
+            signal: controller.signal,
+            onProgress: (progress) => {
+              updateDraftTransfers(draftKey, (transfers) =>
+                transfers.map((candidate) =>
+                  candidate.transferId === transfer.transferId
+                    ? { ...candidate, ...progress, status: 'uploading' }
+                    : candidate
+                )
+              )
+            }
+          })
+          commitDraftAttachment(draftKey, transfer.transferId, attachment)
+        } catch (uploadError) {
+          if (controller.signal.aborted) {
+            updateDraftTransfers(draftKey, (transfers) =>
+              transfers.filter((candidate) => candidate.transferId !== transfer.transferId)
+            )
+          } else {
+            const message = getErrorMessage(uploadError)
+            updateDraftTransfers(draftKey, (transfers) =>
+              transfers.map((candidate) =>
+                candidate.transferId === transfer.transferId
+                  ? { ...candidate, status: 'error', error: message }
+                  : candidate
+              )
+            )
+            if (previousDraftKeyRef.current === draftKey) setAttachmentError(message)
+          }
+        } finally {
+          delete attachmentTransferControllersRef.current[transfer.transferId]
+        }
       }
     })()
+  }
+
+  const cancelAttachmentTransfer = (transfer: ComposerUploadTransfer): void => {
+    const draftKey = previousDraftKeyRef.current
+    cancelledAttachmentTransfersRef.current.add(transfer.transferId)
+    attachmentTransferControllersRef.current[transfer.transferId]?.abort()
+    updateDraftTransfers(draftKey, (transfers) =>
+      transfers.map((candidate) =>
+        candidate.transferId === transfer.transferId
+          ? { ...candidate, status: 'cancelling' }
+          : candidate
+      )
+    )
+    void window.api.uploads
+      .abortTransfer({ transferId: transfer.transferId })
+      .catch(() => undefined)
+      .finally(() => {
+        updateDraftTransfers(draftKey, (transfers) =>
+          transfers.filter((candidate) => candidate.transferId !== transfer.transferId)
+        )
+      })
   }
 
   // Removes one staged attachment from both local UI state and managed upload storage.
@@ -738,6 +876,8 @@ const WorkspacePage = ({ isSessionPersistenceReady }: WorkspacePageProps): React
     const isActiveSession = deletedSessionId === selectedSessionId
     const storedDraft = composerDraftsRef.current[deletedSessionId]
     const abandonedAttachments = storedDraft?.attachments ?? (isActiveSession ? attachments : [])
+    const abandonedTransfers =
+      storedDraft?.attachmentTransfers ?? (isActiveSession ? attachmentTransfers : [])
 
     setSessionToDelete(undefined)
     // Staged bytes and local draft state are owned by the session until runtime and durable deletion
@@ -747,6 +887,10 @@ const WorkspacePage = ({ isSessionPersistenceReady }: WorkspacePageProps): React
       if (!deleted) return
 
       delete composerDraftsRef.current[deletedSessionId]
+      for (const transfer of abandonedTransfers) {
+        attachmentTransferControllersRef.current[transfer.transferId]?.abort()
+        void window.api.uploads.abortTransfer({ transferId: transfer.transferId })
+      }
       deleteAttachmentFiles(abandonedAttachments)
     })
   }
@@ -907,6 +1051,7 @@ const WorkspacePage = ({ isSessionPersistenceReady }: WorkspacePageProps): React
             actionError={visibleActionError}
             isPreviewPanelCollapsed={previewPanelState === 'collapsed'}
             attachments={attachments}
+            attachmentTransfers={attachmentTransfers}
             isUploadingAttachments={isUploadingAttachments}
             notebookReference={activeNotebookReference}
             pendingPermissions={visiblePermissionRequests}
@@ -920,6 +1065,7 @@ const WorkspacePage = ({ isSessionPersistenceReady }: WorkspacePageProps): React
             onSendMessage={sendCurrentMessage}
             onStageAttachmentFiles={stageAttachmentFiles}
             onRemoveAttachment={removeComposerAttachment}
+            onCancelAttachmentTransfer={cancelAttachmentTransfer}
             onCancelRun={cancelActiveRun}
             onResumeSession={resumeActiveSession}
             onOpenNotebook={openNotebookPreview}

--- a/src/renderer/src/pages/workspace/composer-attachment-intake.test.ts
+++ b/src/renderer/src/pages/workspace/composer-attachment-intake.test.ts
@@ -28,7 +28,7 @@ describe('planComposerAttachmentIntake', () => {
     const result = planComposerAttachmentIntake([valid, huge], 0)
 
     expect(result.accepted).toEqual([valid])
-    expect(result.error).toBe('big.zip exceeds the 50 MB limit')
+    expect(result.error).toBe('big.zip exceeds the 10 GB limit')
   })
 
   it('combines multiple oversized file names in the error', () => {
@@ -38,7 +38,7 @@ describe('planComposerAttachmentIntake', () => {
     const result = planComposerAttachmentIntake([first, second], 0)
 
     expect(result.accepted).toEqual([])
-    expect(result.error).toBe('one.bin, two.bin exceeds the 50 MB limit')
+    expect(result.error).toBe('one.bin, two.bin exceeds the 10 GB limit')
   })
 
   it('rejects the whole batch when it would exceed the attachment count', () => {

--- a/src/renderer/src/pages/workspace/composer-attachment-intake.ts
+++ b/src/renderer/src/pages/workspace/composer-attachment-intake.ts
@@ -6,7 +6,12 @@ export type ComposerAttachmentIntake = {
   error: string | null
 }
 
-const MB_LIMIT = MAX_UPLOAD_FILE_BYTES / (1024 * 1024)
+const formatLimit = (bytes: number): string => {
+  const gibibytes = bytes / (1024 * 1024 * 1024)
+  if (Number.isInteger(gibibytes)) return `${gibibytes} GB`
+
+  return `${Math.round(bytes / (1024 * 1024))} MB`
+}
 
 // Applies per-file size and total count limits before any file is read or uploaded.
 export const planComposerAttachmentIntake = (
@@ -25,7 +30,7 @@ export const planComposerAttachmentIntake = (
 
   const oversizedError =
     oversized.length > 0
-      ? `${oversized.map((file) => file.name).join(', ')} exceeds the ${MB_LIMIT} MB limit`
+      ? `${oversized.map((file) => file.name).join(', ')} exceeds the ${formatLimit(MAX_UPLOAD_FILE_BYTES)} limit`
       : null
 
   return { accepted: withinSize, error: oversizedError }

--- a/src/renderer/src/pages/workspace/composer-attachment-intake.ts
+++ b/src/renderer/src/pages/workspace/composer-attachment-intake.ts
@@ -1,16 +1,13 @@
-import { MAX_COMPOSER_ATTACHMENTS, MAX_UPLOAD_FILE_BYTES } from '../../../../shared/uploads'
+import {
+  MAX_COMPOSER_ATTACHMENTS,
+  MAX_UPLOAD_FILE_BYTES,
+  formatUploadSizeLimit
+} from '../../../../shared/uploads'
 
 // Result of applying the composer size/count limits to an incoming batch of files.
 export type ComposerAttachmentIntake = {
   accepted: File[]
   error: string | null
-}
-
-const formatLimit = (bytes: number): string => {
-  const gibibytes = bytes / (1024 * 1024 * 1024)
-  if (Number.isInteger(gibibytes)) return `${gibibytes} GB`
-
-  return `${Math.round(bytes / (1024 * 1024))} MB`
 }
 
 // Applies per-file size and total count limits before any file is read or uploaded.
@@ -30,7 +27,7 @@ export const planComposerAttachmentIntake = (
 
   const oversizedError =
     oversized.length > 0
-      ? `${oversized.map((file) => file.name).join(', ')} exceeds the ${formatLimit(MAX_UPLOAD_FILE_BYTES)} limit`
+      ? `${oversized.map((file) => file.name).join(', ')} exceeds the ${formatUploadSizeLimit(MAX_UPLOAD_FILE_BYTES)} limit`
       : null
 
   return { accepted: withinSize, error: oversizedError }

--- a/src/renderer/src/pages/workspace/composer-upload-transfer.test.ts
+++ b/src/renderer/src/pages/workspace/composer-upload-transfer.test.ts
@@ -81,4 +81,30 @@ describe('stageComposerFile', () => {
     expect(received).toEqual([0, 4, 8, 10])
     expect(api.finishTransfer).toHaveBeenCalledWith({ transferId: 'transfer-2' })
   })
+
+  it('deletes a finalized upload when cancellation wins the finish race', async () => {
+    const file = new File(['0123456789'], 'dataset.csv', { type: 'text/csv' })
+    const controller = new AbortController()
+    let resolveFinish: ((value: UploadedAttachment) => void) | undefined
+    const finish = new Promise<UploadedAttachment>((resolve) => {
+      resolveFinish = resolve
+    })
+    const api = createApi({ finishTransfer: vi.fn(() => finish) })
+
+    const staging = stageComposerFile(file, api, {
+      transferId: 'transfer-cancelled-during-finish',
+      name: file.name,
+      signal: controller.signal
+    })
+
+    await vi.waitFor(() => expect(api.finishTransfer).toHaveBeenCalledOnce())
+    controller.abort()
+    resolveFinish?.(attachment)
+
+    await expect(staging).rejects.toMatchObject({ name: 'AbortError' })
+    expect(api.deleteUpload).toHaveBeenCalledWith({ path: attachment.path })
+    expect(api.abortTransfer).toHaveBeenCalledWith({
+      transferId: 'transfer-cancelled-during-finish'
+    })
+  })
 })

--- a/src/renderer/src/pages/workspace/composer-upload-transfer.test.ts
+++ b/src/renderer/src/pages/workspace/composer-upload-transfer.test.ts
@@ -1,0 +1,84 @@
+// @vitest-environment jsdom
+import { describe, expect, it, vi } from 'vitest'
+
+import type { UploadedAttachment } from '../../../../shared/uploads'
+import { stageComposerFile, type UploadStagingApi } from './composer-upload-transfer'
+
+const attachment: UploadedAttachment = {
+  id: 'upload-1',
+  sessionId: '.pending',
+  name: 'dataset.csv',
+  originalName: 'dataset.csv',
+  path: '/uploads/dataset.csv',
+  mimeType: 'text/csv',
+  size: 10
+}
+
+const createApi = (overrides: Partial<UploadStagingApi> = {}): UploadStagingApi => ({
+  stageLocalFile: vi.fn().mockResolvedValue(null),
+  beginTransfer: vi.fn(async (request) => ({
+    transferId: request.transferId,
+    name: request.name,
+    receivedBytes: 0,
+    totalBytes: request.size
+  })),
+  appendTransfer: vi.fn(async (request) => ({
+    transferId: request.transferId,
+    name: 'dataset.csv',
+    receivedBytes: request.offset + request.chunk.byteLength,
+    totalBytes: 10
+  })),
+  getTransferStatus: vi.fn().mockResolvedValue(null),
+  finishTransfer: vi.fn().mockResolvedValue(attachment),
+  abortTransfer: vi.fn().mockResolvedValue(undefined),
+  deleteUpload: vi.fn().mockResolvedValue(undefined),
+  onTransferProgress: vi.fn(() => vi.fn()),
+  ...overrides
+})
+
+describe('stageComposerFile', () => {
+  it('prefers the desktop native-path adapter without reading File bytes', async () => {
+    const file = new File(['0123456789'], 'dataset.csv', { type: 'text/csv' })
+    const arrayBuffer = vi.spyOn(file, 'arrayBuffer')
+    const api = createApi({ stageLocalFile: vi.fn().mockResolvedValue(attachment) })
+
+    await expect(
+      stageComposerFile(file, api, { transferId: 'transfer-1', name: file.name })
+    ).resolves.toEqual(attachment)
+
+    expect(api.stageLocalFile).toHaveBeenCalledWith(file, {
+      transferId: 'transfer-1',
+      name: 'dataset.csv',
+      mimeType: 'text/csv',
+      size: 10
+    })
+    expect(arrayBuffer).not.toHaveBeenCalled()
+    expect(api.beginTransfer).not.toHaveBeenCalled()
+  })
+
+  it('falls back to bounded chunks when no native path is available', async () => {
+    const file = new File(['0123456789'], 'dataset.csv', { type: 'text/csv' })
+    const api = createApi()
+    const received: number[] = []
+
+    await stageComposerFile(file, api, {
+      transferId: 'transfer-2',
+      name: file.name,
+      chunkBytes: 4,
+      onProgress: (progress) => received.push(progress.receivedBytes)
+    })
+
+    expect(api.appendTransfer).toHaveBeenCalledTimes(3)
+    expect(
+      vi
+        .mocked(api.appendTransfer)
+        .mock.calls.map(([request]) => [request.offset, request.chunk.byteLength])
+    ).toEqual([
+      [0, 4],
+      [4, 4],
+      [8, 2]
+    ])
+    expect(received).toEqual([0, 4, 8, 10])
+    expect(api.finishTransfer).toHaveBeenCalledWith({ transferId: 'transfer-2' })
+  })
+})

--- a/src/renderer/src/pages/workspace/composer-upload-transfer.ts
+++ b/src/renderer/src/pages/workspace/composer-upload-transfer.ts
@@ -133,7 +133,12 @@ export const stageComposerFile = async (
     }
 
     assertNotAborted(options.signal)
-    return await api.finishTransfer({ transferId: request.transferId })
+    const attachment = await api.finishTransfer({ transferId: request.transferId })
+    if (options.signal?.aborted) {
+      await api.deleteUpload({ path: attachment.path }).catch(() => undefined)
+      throw abortError()
+    }
+    return attachment
   } catch (error) {
     await api.abortTransfer({ transferId: request.transferId }).catch(() => undefined)
     throw error

--- a/src/renderer/src/pages/workspace/composer-upload-transfer.ts
+++ b/src/renderer/src/pages/workspace/composer-upload-transfer.ts
@@ -1,0 +1,143 @@
+import {
+  MAX_UPLOAD_CHUNK_BYTES,
+  type AppendUploadTransferRequest,
+  type BeginUploadTransferRequest,
+  type UploadTransferProgress,
+  type UploadTransferRequest,
+  type UploadTransferStatus,
+  type UploadedAttachment
+} from '../../../../shared/uploads'
+
+// Narrow adapter consumed by the composer. Desktop preload adds stageLocalFile; Web intentionally
+// omits it and therefore uses the same chunk methods through RPC.
+export type UploadStagingApi = {
+  stageLocalFile?: (
+    file: File,
+    request: BeginUploadTransferRequest
+  ) => Promise<UploadedAttachment | null>
+  beginTransfer: (request: BeginUploadTransferRequest) => Promise<UploadTransferStatus>
+  appendTransfer: (request: AppendUploadTransferRequest) => Promise<UploadTransferStatus>
+  getTransferStatus: (request: UploadTransferRequest) => Promise<UploadTransferStatus | null>
+  finishTransfer: (request: UploadTransferRequest) => Promise<UploadedAttachment>
+  abortTransfer: (request: UploadTransferRequest) => Promise<void>
+  deleteUpload: (request: { path: string }) => Promise<void>
+  onTransferProgress: (listener: (progress: UploadTransferProgress) => void) => () => void
+}
+
+type StageComposerFileOptions = {
+  transferId: string
+  name: string
+  signal?: AbortSignal
+  onProgress?: (progress: UploadTransferProgress) => void
+  // Injectable for fast tests; production always uses MAX_UPLOAD_CHUNK_BYTES.
+  chunkBytes?: number
+}
+
+export type ComposerUploadTransfer = UploadTransferProgress & {
+  mimeType?: string
+  status: 'queued' | 'uploading' | 'cancelling' | 'error'
+  error?: string
+}
+
+const abortError = (): DOMException => new DOMException('Upload cancelled.', 'AbortError')
+
+const assertNotAborted = (signal?: AbortSignal): void => {
+  if (signal?.aborted) throw abortError()
+}
+
+const appendChunkWithRecovery = async (
+  api: UploadStagingApi,
+  request: AppendUploadTransferRequest,
+  signal?: AbortSignal
+): Promise<UploadTransferStatus> => {
+  let lastError: unknown
+
+  for (let attempt = 0; attempt < 3; attempt += 1) {
+    assertNotAborted(signal)
+    try {
+      return await api.appendTransfer(request)
+    } catch (error) {
+      lastError = error
+      assertNotAborted(signal)
+      const status = await api.getTransferStatus({ transferId: request.transferId })
+
+      // A lost response may hide a successful append. Resume from the authoritative main-process
+      // offset instead of sending the same bytes twice.
+      if (status && status.receivedBytes === request.offset + request.chunk.byteLength)
+        return status
+      if (!status || status.receivedBytes !== request.offset) throw error
+    }
+  }
+
+  throw lastError
+}
+
+// Stages one File through the desktop path adapter when possible, otherwise through bounded chunks.
+// The resulting attachment is always a managed path; no full-file base64 representation is created.
+export const stageComposerFile = async (
+  file: File,
+  api: UploadStagingApi,
+  options: StageComposerFileOptions
+): Promise<UploadedAttachment> => {
+  const request: BeginUploadTransferRequest = {
+    transferId: options.transferId,
+    name: options.name,
+    mimeType: file.type || undefined,
+    size: file.size
+  }
+  const chunkBytes = options.chunkBytes ?? MAX_UPLOAD_CHUNK_BYTES
+
+  if (!Number.isSafeInteger(chunkBytes) || chunkBytes <= 0 || chunkBytes > MAX_UPLOAD_CHUNK_BYTES) {
+    throw new Error('Invalid upload chunk size.')
+  }
+
+  options.onProgress?.({
+    transferId: request.transferId,
+    name: request.name,
+    receivedBytes: 0,
+    totalBytes: request.size
+  })
+
+  const removeProgressListener = api.onTransferProgress((progress) => {
+    if (progress.transferId === request.transferId) options.onProgress?.(progress)
+  })
+
+  try {
+    assertNotAborted(options.signal)
+
+    if (api.stageLocalFile) {
+      const localAttachment = await api.stageLocalFile(file, request)
+      if (localAttachment) {
+        if (options.signal?.aborted) {
+          await api.deleteUpload({ path: localAttachment.path }).catch(() => undefined)
+          throw abortError()
+        }
+        return localAttachment
+      }
+    }
+
+    let status = await api.beginTransfer(request)
+    if (status.receivedBytes > 0) options.onProgress?.(status)
+
+    while (status.receivedBytes < request.size) {
+      assertNotAborted(options.signal)
+      const end = Math.min(status.receivedBytes + chunkBytes, request.size)
+      const chunk = new Uint8Array(await file.slice(status.receivedBytes, end).arrayBuffer())
+      assertNotAborted(options.signal)
+      status = await appendChunkWithRecovery(
+        api,
+        { transferId: request.transferId, offset: status.receivedBytes, chunk },
+        options.signal
+      )
+      options.onProgress?.(status)
+    }
+
+    assertNotAborted(options.signal)
+    return await api.finishTransfer({ transferId: request.transferId })
+  } catch (error) {
+    await api.abortTransfer({ transferId: request.transferId }).catch(() => undefined)
+    throw error
+  } finally {
+    removeProgressListener()
+  }
+}

--- a/src/renderer/src/pages/workspace/composer/ComposerEditor.interaction.test.tsx
+++ b/src/renderer/src/pages/workspace/composer/ComposerEditor.interaction.test.tsx
@@ -204,6 +204,32 @@ describe('ComposerEditor', () => {
     expect(document.body.querySelector('[aria-hidden="true"]')).toBeNull()
   })
 
+  it('refreshes an artifact chip when only its MIME type changes', () => {
+    const artifact = {
+      type: 'artifact' as const,
+      id: 'artifact-1',
+      name: 'research-paper',
+      path: '/workspace/research-paper',
+      source: 'artifact' as const
+    }
+    renderEditor({ doc: { nodes: [artifact] } })
+    expect(
+      editor()
+        .querySelector('[data-mention-type="artifact"]')
+        ?.getAttribute('data-mention-mime-type')
+    ).toBeNull()
+
+    renderEditor({
+      doc: { nodes: [{ ...artifact, mimeType: 'application/pdf' }] }
+    })
+
+    expect(
+      editor()
+        .querySelector('[data-mention-type="artifact"]')
+        ?.getAttribute('data-mention-mime-type')
+    ).toBe('application/pdf')
+  })
+
   it('emits the typed text as a doc on input', () => {
     const onDocChange = vi.fn()
     renderEditor({ onDocChange })

--- a/src/renderer/src/pages/workspace/composer/ComposerEditor.tsx
+++ b/src/renderer/src/pages/workspace/composer/ComposerEditor.tsx
@@ -201,6 +201,7 @@ export const ComposerEditor = ({
       name: ref.name,
       path: ref.path,
       source: ref.source,
+      mimeType: ref.mimeType,
       versionId: ref.versionId
     })
     artifactMention.cancel()

--- a/src/renderer/src/pages/workspace/composer/ComposerEditor.tsx
+++ b/src/renderer/src/pages/workspace/composer/ComposerEditor.tsx
@@ -49,7 +49,12 @@ const nodesEqual = (a: ComposerNode[], b: ComposerNode[]): boolean => {
       return node.id === other.id && node.name === other.name
     }
     if (node.type === 'artifact' && other.type === 'artifact') {
-      if (node.id !== other.id || node.name !== other.name || node.source !== other.source) {
+      if (
+        node.id !== other.id ||
+        node.name !== other.name ||
+        node.source !== other.source ||
+        node.mimeType !== other.mimeType
+      ) {
         return false
       }
       if (node.source === 'linked-folder' && other.source === 'linked-folder') {

--- a/src/renderer/src/pages/workspace/composer/ComposerEditor.tsx
+++ b/src/renderer/src/pages/workspace/composer/ComposerEditor.tsx
@@ -49,13 +49,16 @@ const nodesEqual = (a: ComposerNode[], b: ComposerNode[]): boolean => {
       return node.id === other.id && node.name === other.name
     }
     if (node.type === 'artifact' && other.type === 'artifact') {
-      return (
-        node.id === other.id &&
-        node.name === other.name &&
-        node.path === other.path &&
-        node.source === other.source &&
-        node.versionId === other.versionId
-      )
+      if (node.id !== other.id || node.name !== other.name || node.source !== other.source) {
+        return false
+      }
+      if (node.source === 'linked-folder' && other.source === 'linked-folder') {
+        return node.rootId === other.rootId && node.relativePath === other.relativePath
+      }
+      if (node.source !== 'linked-folder' && other.source !== 'linked-folder') {
+        return node.path === other.path && node.versionId === other.versionId
+      }
+      return false
     }
     return false
   })

--- a/src/renderer/src/pages/workspace/composer/composer-doc.test.ts
+++ b/src/renderer/src/pages/workspace/composer/composer-doc.test.ts
@@ -31,7 +31,14 @@ describe('docToText', () => {
     const doc: ComposerDoc = {
       nodes: [
         { type: 'text', text: 'compare ' },
-        { type: 'artifact', id: 'a1', name: 'fig1.png', path: '/p/fig1.png', source: 'artifact' },
+        {
+          type: 'artifact',
+          id: 'a1',
+          name: 'fig1.png',
+          path: '/p/fig1.png',
+          source: 'artifact',
+          mimeType: 'image/png'
+        },
         { type: 'text', text: ' and ' },
         {
           type: 'artifact',
@@ -72,7 +79,14 @@ describe('docToArtifactRefs', () => {
   it('collects artifact refs in order and de-duplicates by path', () => {
     const doc: ComposerDoc = {
       nodes: [
-        { type: 'artifact', id: 'a1', name: 'fig1.png', path: '/p/fig1.png', source: 'artifact' },
+        {
+          type: 'artifact',
+          id: 'a1',
+          name: 'fig1.png',
+          path: '/p/fig1.png',
+          source: 'artifact',
+          mimeType: 'image/png'
+        },
         { type: 'text', text: ' and ' },
         { type: 'artifact', id: 'u1', name: 'notes.md', path: '/u/notes.md', source: 'upload' },
         // Same path as the first, mentioned again with a different chip id — collapsed.
@@ -80,8 +94,22 @@ describe('docToArtifactRefs', () => {
       ]
     }
     expect(docToArtifactRefs(doc)).toEqual([
-      { id: 'a1', name: 'fig1.png', path: '/p/fig1.png', source: 'artifact', versionId: undefined },
-      { id: 'u1', name: 'notes.md', path: '/u/notes.md', source: 'upload', versionId: undefined }
+      {
+        id: 'a1',
+        name: 'fig1.png',
+        path: '/p/fig1.png',
+        source: 'artifact',
+        mimeType: 'image/png',
+        versionId: undefined
+      },
+      {
+        id: 'u1',
+        name: 'notes.md',
+        path: '/u/notes.md',
+        source: 'upload',
+        mimeType: undefined,
+        versionId: undefined
+      }
     ])
   })
 

--- a/src/renderer/src/pages/workspace/composer/composer-doc.test.ts
+++ b/src/renderer/src/pages/workspace/composer/composer-doc.test.ts
@@ -116,6 +116,29 @@ describe('docToArtifactRefs', () => {
   it('returns an empty array when there are no artifact nodes', () => {
     expect(docToArtifactRefs(docFromText('plain text'))).toEqual([])
   })
+
+  it('preserves and de-duplicates linked-folder references by granted root and relative path', () => {
+    const linked = {
+      type: 'artifact' as const,
+      id: 'linked-1',
+      name: 'study.csv',
+      source: 'linked-folder' as const,
+      rootId: 'root-1',
+      relativePath: 'data/study.csv',
+      mimeType: 'text/csv'
+    }
+
+    expect(docToArtifactRefs({ nodes: [linked, { ...linked, id: 'linked-2' }] })).toEqual([
+      {
+        id: 'linked-1',
+        name: 'study.csv',
+        source: 'linked-folder',
+        rootId: 'root-1',
+        relativePath: 'data/study.csv',
+        mimeType: 'text/csv'
+      }
+    ])
+  })
 })
 
 describe('docArtifactCount', () => {
@@ -262,6 +285,31 @@ describe('applyDocToDom + domToDoc round-trip', () => {
     expect(domToDoc(root)).toEqual(doc)
   })
 
+  it('round-trips a future linked-folder chip without an absolute path', () => {
+    const doc: ComposerDoc = {
+      nodes: [
+        {
+          type: 'artifact',
+          id: 'linked-1',
+          name: 'study.csv',
+          source: 'linked-folder',
+          rootId: 'root-1',
+          relativePath: 'data/study.csv',
+          mimeType: 'text/csv'
+        }
+      ]
+    }
+    const root = document.createElement('div')
+
+    applyDocToDom(root, doc)
+
+    const chip = root.querySelector('span[data-mention-source="linked-folder"]')
+    expect(chip?.getAttribute('data-mention-path')).toBeNull()
+    expect(chip?.getAttribute('data-mention-root-id')).toBe('root-1')
+    expect(chip?.getAttribute('data-mention-relative-path')).toBe('data/study.csv')
+    expect(domToDoc(root)).toEqual(doc)
+  })
+
   it('renders an artifact chip with the green mention attributes and @ label', () => {
     const root = document.createElement('div')
     applyDocToDom(root, {
@@ -330,5 +378,32 @@ describe('docFromMessageParts', () => {
 
   it('returns the empty doc for an empty parts list', () => {
     expect(docFromMessageParts([])).toEqual(emptyDoc)
+  })
+
+  it('restores a linked-folder message part without introducing an absolute path', () => {
+    expect(
+      docFromMessageParts([
+        {
+          type: 'artifact',
+          id: 'linked-1',
+          name: 'study.csv',
+          source: 'linked-folder',
+          rootId: 'root-1',
+          relativePath: 'data/study.csv'
+        }
+      ])
+    ).toEqual({
+      nodes: [
+        {
+          type: 'artifact',
+          id: 'linked-1',
+          name: 'study.csv',
+          source: 'linked-folder',
+          rootId: 'root-1',
+          relativePath: 'data/study.csv',
+          mimeType: undefined
+        }
+      ]
+    })
   })
 })

--- a/src/renderer/src/pages/workspace/composer/composer-doc.ts
+++ b/src/renderer/src/pages/workspace/composer/composer-doc.ts
@@ -2,20 +2,12 @@
 // chips, and artifact chips. These functions are DOM-free except domToDoc/applyDocToDom, which
 // bridge the model to the contenteditable editor.
 
-import type { ArtifactReference } from '../../../../../shared/artifacts'
+import type { FileReference } from '../../../../../shared/artifacts'
 import type { MessagePart } from '../../../../../shared/session-persistence'
 
-// One artifact/upload reference chip in the composer doc. Mirrors ArtifactReference plus the DOM
-// label; `source` distinguishes a user upload from a generated output for the runtime resolver.
-export type ComposerArtifactNode = {
-  type: 'artifact'
-  id: string
-  name: string
-  path: string
-  source: 'upload' | 'artifact'
-  mimeType?: string
-  versionId?: string
-}
+// One file-reference chip in the composer doc. The linked-folder variant deliberately carries only
+// a granted root id plus a relative path, reserving the future source without exposing an absolute path.
+export type ComposerArtifactNode = { type: 'artifact' } & FileReference
 
 export type ComposerNode =
   | { type: 'text'; text: string }
@@ -51,20 +43,37 @@ export const docToSkillIds = (doc: ComposerDoc): string[] => {
 
 // Collect referenced artifacts in document order, de-duplicated by path so the runtime attaches
 // each underlying file once even if the user mentions it twice.
-export const docToArtifactRefs = (doc: ComposerDoc): ArtifactReference[] => {
-  const refs: ArtifactReference[] = []
-  const seenPaths = new Set<string>()
+export const docToArtifactRefs = (doc: ComposerDoc): FileReference[] => {
+  const refs: FileReference[] = []
+  const seenLocations = new Set<string>()
   for (const node of doc.nodes) {
-    if (node.type !== 'artifact' || seenPaths.has(node.path)) continue
-    seenPaths.add(node.path)
-    refs.push({
-      id: node.id,
-      name: node.name,
-      path: node.path,
-      source: node.source,
-      mimeType: node.mimeType,
-      versionId: node.versionId
-    })
+    if (node.type !== 'artifact') continue
+    const location =
+      node.source === 'linked-folder'
+        ? `${node.source}:${node.rootId}:${node.relativePath}`
+        : `${node.source}:${node.path}`
+    if (seenLocations.has(location)) continue
+    seenLocations.add(location)
+
+    if (node.source === 'linked-folder') {
+      refs.push({
+        id: node.id,
+        name: node.name,
+        source: node.source,
+        rootId: node.rootId,
+        relativePath: node.relativePath,
+        mimeType: node.mimeType
+      })
+    } else {
+      refs.push({
+        id: node.id,
+        name: node.name,
+        path: node.path,
+        source: node.source,
+        mimeType: node.mimeType,
+        versionId: node.versionId
+      })
+    }
   }
   return refs
 }
@@ -83,6 +92,17 @@ export const docFromMessageParts = (parts: MessagePart[]): ComposerDoc => {
   const nodes: ComposerNode[] = parts.map((part) => {
     if (part.type === 'text') return { type: 'text', text: part.text }
     if (part.type === 'skill') return { type: 'skill', id: part.id, name: part.name }
+    if (part.source === 'linked-folder') {
+      return {
+        type: 'artifact',
+        id: part.id,
+        name: part.name,
+        source: part.source,
+        rootId: part.rootId,
+        relativePath: part.relativePath,
+        mimeType: part.mimeType
+      }
+    }
     return {
       type: 'artifact',
       id: part.id,
@@ -108,13 +128,21 @@ const ARTIFACT_MENTION_TYPE = 'artifact'
 // Read one artifact chip element back into a node; returns null when required attributes are missing.
 const artifactNodeFromEl = (el: HTMLElement): ComposerArtifactNode | null => {
   const id = el.getAttribute('data-mention-id')
-  const path = el.getAttribute('data-mention-path')
-  if (id === null || path === null) return null
-  const source = el.getAttribute('data-mention-source') === 'upload' ? 'upload' : 'artifact'
+  if (id === null) return null
+  const source = el.getAttribute('data-mention-source')
   // Prefer the stored filename; fall back to the visible label with its leading `@` stripped.
   const name = el.getAttribute('data-mention-filename') ?? (el.textContent ?? '').replace(/^@/, '')
-  const versionId = el.getAttribute('data-mention-version-id') ?? undefined
   const mimeType = el.getAttribute('data-mention-mime-type') ?? undefined
+  if (source === 'linked-folder') {
+    const rootId = el.getAttribute('data-mention-root-id')
+    const relativePath = el.getAttribute('data-mention-relative-path')
+    if (rootId === null || relativePath === null) return null
+    return { type: 'artifact', id, name, source, rootId, relativePath, mimeType }
+  }
+
+  const path = el.getAttribute('data-mention-path')
+  if (path === null || (source !== 'upload' && source !== 'artifact')) return null
+  const versionId = el.getAttribute('data-mention-version-id') ?? undefined
   return { type: 'artifact', id, name, path, source, mimeType, versionId }
 }
 
@@ -178,11 +206,18 @@ export const createArtifactChip = (node: ComposerArtifactNode): HTMLSpanElement 
   span.setAttribute('contenteditable', 'false')
   span.setAttribute('data-mention-type', ARTIFACT_MENTION_TYPE)
   span.setAttribute('data-mention-id', node.id)
-  span.setAttribute('data-mention-path', node.path)
   span.setAttribute('data-mention-source', node.source)
   span.setAttribute('data-mention-filename', node.name)
+  if (node.source === 'linked-folder') {
+    span.setAttribute('data-mention-root-id', node.rootId)
+    span.setAttribute('data-mention-relative-path', node.relativePath)
+  } else {
+    span.setAttribute('data-mention-path', node.path)
+  }
   if (node.mimeType) span.setAttribute('data-mention-mime-type', node.mimeType)
-  if (node.versionId) span.setAttribute('data-mention-version-id', node.versionId)
+  if (node.source !== 'linked-folder' && node.versionId) {
+    span.setAttribute('data-mention-version-id', node.versionId)
+  }
   // Green mention pill, distinct from the blue skill chip.
   span.className = `${CHIP_BASE_CLASS} bg-mention-chip text-mention-chip-foreground`
   span.textContent = `@${node.name}`

--- a/src/renderer/src/pages/workspace/composer/composer-doc.ts
+++ b/src/renderer/src/pages/workspace/composer/composer-doc.ts
@@ -13,6 +13,7 @@ export type ComposerArtifactNode = {
   name: string
   path: string
   source: 'upload' | 'artifact'
+  mimeType?: string
   versionId?: string
 }
 
@@ -61,6 +62,7 @@ export const docToArtifactRefs = (doc: ComposerDoc): ArtifactReference[] => {
       name: node.name,
       path: node.path,
       source: node.source,
+      mimeType: node.mimeType,
       versionId: node.versionId
     })
   }
@@ -87,6 +89,7 @@ export const docFromMessageParts = (parts: MessagePart[]): ComposerDoc => {
       name: part.name,
       path: part.path,
       source: part.source,
+      mimeType: part.mimeType,
       versionId: part.versionId
     }
   })
@@ -111,7 +114,8 @@ const artifactNodeFromEl = (el: HTMLElement): ComposerArtifactNode | null => {
   // Prefer the stored filename; fall back to the visible label with its leading `@` stripped.
   const name = el.getAttribute('data-mention-filename') ?? (el.textContent ?? '').replace(/^@/, '')
   const versionId = el.getAttribute('data-mention-version-id') ?? undefined
-  return { type: 'artifact', id, name, path, source, versionId }
+  const mimeType = el.getAttribute('data-mention-mime-type') ?? undefined
+  return { type: 'artifact', id, name, path, source, mimeType, versionId }
 }
 
 // Read a contenteditable root into a doc, mapping chip spans to skill/artifact nodes and collapsing
@@ -177,6 +181,7 @@ export const createArtifactChip = (node: ComposerArtifactNode): HTMLSpanElement 
   span.setAttribute('data-mention-path', node.path)
   span.setAttribute('data-mention-source', node.source)
   span.setAttribute('data-mention-filename', node.name)
+  if (node.mimeType) span.setAttribute('data-mention-mime-type', node.mimeType)
   if (node.versionId) span.setAttribute('data-mention-version-id', node.versionId)
   // Green mention pill, distinct from the blue skill chip.
   span.className = `${CHIP_BASE_CLASS} bg-mention-chip text-mention-chip-foreground`

--- a/src/renderer/src/pages/workspace/preview-file-item.test.ts
+++ b/src/renderer/src/pages/workspace/preview-file-item.test.ts
@@ -177,4 +177,22 @@ describe('preview file item helpers', () => {
       format: 'image'
     })
   })
+
+  it('uses mention mime type when the file name has no previewable extension', () => {
+    expect(
+      createPreviewFileItemFromMention(
+        createMentionPart({
+          id: 'extensionless-pdf',
+          name: 'research-paper',
+          path: '/workspace/results/research-paper',
+          mimeType: 'application/pdf'
+        }),
+        'session-1'
+      )
+    ).toMatchObject({
+      name: 'research-paper',
+      mimeType: 'application/pdf',
+      format: 'pdf'
+    })
+  })
 })

--- a/src/renderer/src/pages/workspace/preview-file-item.test.ts
+++ b/src/renderer/src/pages/workspace/preview-file-item.test.ts
@@ -11,7 +11,7 @@ import {
 
 type MessageArtifact = NonNullable<ChatSession['artifacts']>[number]
 type MessageUploadAttachment = NonNullable<ChatSession['messages'][number]['uploads']>[number]
-type ArtifactMentionPart = Extract<MessagePart, { type: 'artifact' }>
+type ArtifactMentionPart = Extract<MessagePart, { type: 'artifact'; source: 'upload' | 'artifact' }>
 
 const createManagedArtifact = (overrides: Partial<MessageArtifact> = {}): MessageArtifact => ({
   id: 'artifact-1',

--- a/src/renderer/src/pages/workspace/preview-file-item.ts
+++ b/src/renderer/src/pages/workspace/preview-file-item.ts
@@ -11,6 +11,7 @@ export type MessageUploadAttachment = NonNullable<
   ChatSession['messages'][number]['uploads']
 >[number]
 type ArtifactMentionPart = Extract<MessagePart, { type: 'artifact' }>
+type ManagedArtifactMentionPart = Exclude<ArtifactMentionPart, { source: 'linked-folder' }>
 
 // Builds the common preview workbench file item for generated artifacts and user uploads.
 export const createPreviewFileItem = ({
@@ -91,7 +92,7 @@ export const createPreviewFileItemFromUpload = (
 
 // Converts a sent-message artifact mention into the same preview shape used by its source panel.
 export const createPreviewFileItemFromMention = (
-  part: ArtifactMentionPart,
+  part: ManagedArtifactMentionPart,
   sessionId: string
 ): PreviewFileItem =>
   createPreviewFileItem({

--- a/src/renderer/src/pages/workspace/preview-file-item.ts
+++ b/src/renderer/src/pages/workspace/preview-file-item.ts
@@ -100,5 +100,6 @@ export const createPreviewFileItemFromMention = (
     sessionId,
     path: part.path,
     name: part.name,
+    mimeType: part.mimeType,
     source: part.source === 'upload' ? 'upload' : undefined
   })

--- a/src/renderer/src/pages/workspace/previews/PreviewFileContent.test.tsx
+++ b/src/renderer/src/pages/workspace/previews/PreviewFileContent.test.tsx
@@ -130,7 +130,6 @@ describe('PreviewFileContent', () => {
         finalizeRunArtifacts: vi.fn()
       },
       uploads: {
-        stageFiles: vi.fn(),
         deleteUpload: vi.fn(),
         finalizeSession: vi.fn(),
         readPreview: vi.fn().mockResolvedValue({

--- a/src/renderer/web/api-map.generated.ts
+++ b/src/renderer/web/api-map.generated.ts
@@ -181,10 +181,16 @@ export const WEB_INVOKE_CHANNELS = {
   'update.download': 'update:download',
   'update.getAppInfo': 'update:get-app-info',
   'update.getStatus': 'update:get-status',
+  'uploads.abortTransfer': 'uploads:abort-transfer',
+  'uploads.appendTransfer': 'uploads:append-transfer',
+  'uploads.beginTransfer': 'uploads:begin-transfer',
   'uploads.deleteUpload': 'uploads:delete',
   'uploads.finalizeSession': 'uploads:finalize-session',
+  'uploads.finishTransfer': 'uploads:finish-transfer',
+  'uploads.getTransferStatus': 'uploads:transfer-status',
   'uploads.readPreview': 'uploads:read-preview',
   'uploads.stageFiles': 'uploads:stage-files',
+  'uploads.stageLocalFile': 'uploads:stage-local-file',
   'window.close': 'window:close'
 } as const
 
@@ -216,5 +222,6 @@ export const WEB_EVENT_CHANNELS = {
   'storage.onProgress': 'storage:migrate-progress',
   'update.onProgress': 'update:progress',
   'update.onStatus': 'update:status',
+  'uploads.onTransferProgress': 'uploads:transfer-progress',
   'window.onCloseActivePane': 'shortcut:close-active-pane'
 } as const

--- a/src/renderer/web/api-map.generated.ts
+++ b/src/renderer/web/api-map.generated.ts
@@ -189,7 +189,6 @@ export const WEB_INVOKE_CHANNELS = {
   'uploads.finishTransfer': 'uploads:finish-transfer',
   'uploads.getTransferStatus': 'uploads:transfer-status',
   'uploads.readPreview': 'uploads:read-preview',
-  'uploads.stageFiles': 'uploads:stage-files',
   'uploads.stageLocalFile': 'uploads:stage-local-file',
   'window.close': 'window:close'
 } as const

--- a/src/renderer/web/api-map.generated.ts
+++ b/src/renderer/web/api-map.generated.ts
@@ -184,6 +184,7 @@ export const WEB_INVOKE_CHANNELS = {
   'uploads.abortTransfer': 'uploads:abort-transfer',
   'uploads.appendTransfer': 'uploads:append-transfer',
   'uploads.beginTransfer': 'uploads:begin-transfer',
+  'uploads.claimLocalFile': 'uploads:claim-local-file',
   'uploads.deleteUpload': 'uploads:delete',
   'uploads.finalizeSession': 'uploads:finalize-session',
   'uploads.finishTransfer': 'uploads:finish-transfer',

--- a/src/shared/acp.ts
+++ b/src/shared/acp.ts
@@ -1,5 +1,5 @@
 import type { ToolCallContent, ToolCallLocation, ToolKind } from '@agentclientprotocol/sdk'
-import type { ArtifactFile, ArtifactReference } from './artifacts'
+import type { ArtifactFile, FileReference } from './artifacts'
 import type { UploadedAttachment } from './uploads'
 import type { PermissionProfileId, SessionPermissionProfileState } from './permission-profiles'
 import type { AgentFrameworkId } from './settings'
@@ -271,7 +271,7 @@ export type AcpPromptRequest = {
   // Skills the user explicitly picked in the composer; the runtime force-loads and nudges them.
   forcedSkillIds?: string[]
   // Existing files referenced via composer `@` mentions; appended as prompt content blocks.
-  referencedArtifacts?: ArtifactReference[]
+  referencedArtifacts?: FileReference[]
   // Transcript of prior turns injected only into the content sent to the agent (never the user-facing
   // message), so a freshly-adopted session after a framework switch keeps conversational continuity.
   historyPreamble?: string

--- a/src/shared/artifacts.ts
+++ b/src/shared/artifacts.ts
@@ -25,6 +25,19 @@ export type ArtifactReference = {
   versionId?: string
 }
 
+// Reserved reference shape for future user-linked folders. Persist only a granted root id and a
+// relative path; never expose or accept an arbitrary renderer-provided absolute path.
+export type LinkedFolderFileReference = {
+  id: string
+  name: string
+  source: 'linked-folder'
+  rootId: string
+  relativePath: string
+  mimeType?: string
+}
+
+export type FileReference = ArtifactReference | LinkedFolderFileReference
+
 export type ArtifactWriteEncoding = 'utf8' | 'base64'
 
 export type ArtifactWriteSource =

--- a/src/shared/session-persistence.test.ts
+++ b/src/shared/session-persistence.test.ts
@@ -25,6 +25,46 @@ const createSessionWithActivity = (activity: unknown): Record<string, unknown> =
 const getRestoredActivities = (session: unknown): PersistedChatSession['activities'] =>
   normalizeSessionFile(session)?.activities
 
+describe('message part persistence', () => {
+  it('preserves a linked-folder reference as root id plus relative path', () => {
+    const restored = normalizeSessionFile({
+      ...createSessionWithActivity(undefined),
+      activities: undefined,
+      messages: [
+        {
+          id: 'message-1',
+          role: 'user',
+          content: '@study.csv',
+          parts: [
+            {
+              type: 'artifact',
+              id: 'linked-1',
+              name: 'study.csv',
+              source: 'linked-folder',
+              rootId: 'root-1',
+              relativePath: 'data/study.csv',
+              path: '/must/not/be/persisted'
+            }
+          ],
+          createdAt: 1,
+          updatedAt: 1
+        }
+      ]
+    })
+
+    expect(restored?.messages[0].parts).toEqual([
+      {
+        type: 'artifact',
+        id: 'linked-1',
+        name: 'study.csv',
+        source: 'linked-folder',
+        rootId: 'root-1',
+        relativePath: 'data/study.csv'
+      }
+    ])
+  })
+})
+
 describe('message image persistence', () => {
   it('keeps only bounded raster images with recomputed byte metadata', () => {
     const images = sanitizeMessageImages([

--- a/src/shared/session-persistence.ts
+++ b/src/shared/session-persistence.ts
@@ -57,6 +57,7 @@ export type MessagePart =
       name: string
       path: string
       source: 'upload' | 'artifact'
+      mimeType?: string
       versionId?: string
     }
 
@@ -574,9 +575,14 @@ const sanitizeMessagePart = (part: unknown): MessagePart | undefined => {
       if (!id || !name || !path || (source !== 'upload' && source !== 'artifact')) return undefined
 
       const sanitized: MessagePart = { type: 'artifact', id, name, path, source }
+      const mimeType = asString(part.mimeType)
       const versionId = asString(part.versionId)
 
-      return versionId ? { ...sanitized, versionId } : sanitized
+      return {
+        ...sanitized,
+        ...(mimeType ? { mimeType } : {}),
+        ...(versionId ? { versionId } : {})
+      }
     }
     default:
       return undefined

--- a/src/shared/session-persistence.ts
+++ b/src/shared/session-persistence.ts
@@ -1,4 +1,5 @@
 import type { UploadedAttachment } from './uploads'
+import type { FileReference } from './artifacts'
 import {
   MAX_ACP_MESSAGE_IMAGES_PER_MESSAGE,
   MAX_ACP_MESSAGE_IMAGE_BYTES_PER_MESSAGE,
@@ -51,15 +52,7 @@ export type PersistedMessageImage = AcpMessageImage & {
 export type MessagePart =
   | { type: 'text'; text: string }
   | { type: 'skill'; id: string; name: string }
-  | {
-      type: 'artifact'
-      id: string
-      name: string
-      path: string
-      source: 'upload' | 'artifact'
-      mimeType?: string
-      versionId?: string
-    }
+  | ({ type: 'artifact' } & FileReference)
 
 export type PersistedChatMessage = {
   id: string
@@ -569,13 +562,31 @@ const sanitizeMessagePart = (part: unknown): MessagePart | undefined => {
     case 'artifact': {
       const id = asString(part.id)
       const name = asString(part.name)
-      const path = asString(part.path)
       const source = asString(part.source)
 
-      if (!id || !name || !path || (source !== 'upload' && source !== 'artifact')) return undefined
+      if (!id || !name) return undefined
+
+      const mimeType = asString(part.mimeType)
+      if (source === 'linked-folder') {
+        const rootId = asString(part.rootId)
+        const relativePath = asString(part.relativePath)
+        if (!rootId || !relativePath) return undefined
+
+        return {
+          type: 'artifact',
+          id,
+          name,
+          source,
+          rootId,
+          relativePath,
+          ...(mimeType ? { mimeType } : {})
+        }
+      }
+
+      const path = asString(part.path)
+      if (!path || (source !== 'upload' && source !== 'artifact')) return undefined
 
       const sanitized: MessagePart = { type: 'artifact', id, name, path, source }
-      const mimeType = asString(part.mimeType)
       const versionId = asString(part.versionId)
 
       return {

--- a/src/shared/uploads.test.ts
+++ b/src/shared/uploads.test.ts
@@ -1,0 +1,16 @@
+import { describe, expect, it } from 'vitest'
+
+import { formatUploadSizeLimit } from './uploads'
+
+describe('formatUploadSizeLimit', () => {
+  it('formats exact binary-unit boundaries for the user-facing upload limit', () => {
+    expect(formatUploadSizeLimit(1023)).toBe('1023 B')
+    expect(formatUploadSizeLimit(1024)).toBe('1 KB')
+    expect(formatUploadSizeLimit(1024 * 1024)).toBe('1 MB')
+    expect(formatUploadSizeLimit(1024 * 1024 * 1024)).toBe('1 GB')
+  })
+
+  it('retains one decimal place for fractional gigabyte limits', () => {
+    expect(formatUploadSizeLimit(1.5 * 1024 * 1024 * 1024)).toBe('1.5 GB')
+  })
+})

--- a/src/shared/uploads.ts
+++ b/src/shared/uploads.ts
@@ -12,14 +12,16 @@ export const MAX_UPLOAD_CHUNK_BYTES = 8 * 1024 * 1024
 // Composer total attachment cap; enforced renderer-side since main is stateless about composer state.
 export const MAX_COMPOSER_ATTACHMENTS = 10
 
-export type StageUploadFile = {
-  name: string
-  content: string
-  mimeType?: string
-}
+export const formatUploadSizeLimit = (bytes: number): string => {
+  const gibibytes = bytes / (1024 * 1024 * 1024)
+  if (bytes >= 1024 * 1024 * 1024) {
+    return `${Number.isInteger(gibibytes) ? gibibytes : gibibytes.toFixed(1)} GB`
+  }
 
-export type StageUploadFilesRequest = {
-  files: StageUploadFile[]
+  if (bytes >= 1024 * 1024) return `${Math.round(bytes / (1024 * 1024))} MB`
+  if (bytes >= 1024) return `${Math.round(bytes / 1024)} KB`
+
+  return `${bytes} B`
 }
 
 // Preload-only request used by the desktop fast path. The renderer supplies the File object;

--- a/src/shared/uploads.ts
+++ b/src/shared/uploads.ts
@@ -5,8 +5,10 @@ export const DEFAULT_UPLOAD_PROJECT_NAME = DEFAULT_ARTIFACT_PROJECT_NAME
 // New-conversation uploads are staged here until the runtime returns a durable session id.
 export const PENDING_UPLOAD_SESSION_ID = '.pending'
 
-// Per-file 50 MB cap enforced in both the composer and the main-process staging entry.
-export const MAX_UPLOAD_FILE_BYTES = 50 * 1024 * 1024
+// Per-file storage cap. Content sent to the model has separate, much smaller inline/read limits.
+export const MAX_UPLOAD_FILE_BYTES = 10 * 1024 * 1024 * 1024
+// Keeps both Electron IPC and the Web JSON/base64 fallback comfortably below their body limits.
+export const MAX_UPLOAD_CHUNK_BYTES = 8 * 1024 * 1024
 // Composer total attachment cap; enforced renderer-side since main is stateless about composer state.
 export const MAX_COMPOSER_ATTACHMENTS = 10
 
@@ -19,6 +21,37 @@ export type StageUploadFile = {
 export type StageUploadFilesRequest = {
   files: StageUploadFile[]
 }
+
+// Preload-only request used by the desktop fast path. The renderer supplies the File object;
+// preload resolves its native path so arbitrary renderer-provided paths never cross this boundary.
+export type StageLocalUploadRequest = {
+  transferId: string
+  sourcePath: string
+  name: string
+  mimeType?: string
+  size: number
+}
+
+export type UploadTransferProgress = {
+  transferId: string
+  name: string
+  receivedBytes: number
+  totalBytes: number
+}
+
+export type BeginUploadTransferRequest = Omit<StageLocalUploadRequest, 'sourcePath'>
+
+export type AppendUploadTransferRequest = {
+  transferId: string
+  offset: number
+  chunk: Uint8Array
+}
+
+export type UploadTransferRequest = {
+  transferId: string
+}
+
+export type UploadTransferStatus = UploadTransferProgress
 
 export type UploadedAttachment = {
   id: string


### PR DESCRIPTION
## Problem

Closes #405.

Chat attachments were capped at 50 MB because the renderer read each complete file into memory, encoded it as base64, and sent it as one IPC or Web RPC body. This made the transport—not the model request—the limiting factor, and the Web path could already exceed its 64 MB RPC body cap near the advertised limit.

## Proposed change

- Raise the managed-storage limit to 10 GB per file and show the limit before file selection.
- On desktop, resolve native `File` paths in preload and stream them directly into managed storage without exposing source paths to the renderer.
- For Web, clipboard, and pathless `File` objects, use an 8 MB begin/append/status/finish protocol with offset validation, bounded retry, progress, and cancellation.
- Remove the legacy whole-file base64 staging API from IPC, preload, Web RPC, and the upload repository.
- Stage into exclusive `.part` files, clean abandoned partials, and commit with hard-link/move semantics plus an exclusive-copy fallback.
- Show per-file queued/uploading/error/cancelling state and progress in Composer.
- Keep model payloads bounded: small text may be embedded; large text gets a bounded preview plus `resource_link`; dataset binaries and video are link-only; images and PDFs above the automatic-processing threshold are link-only.
- Route Composer `@` references through a source adapter resolver. Existing upload/artifact mentions remain supported, while the shared Composer, persistence, and runtime contracts reserve `linked-folder` references as `rootId + relativePath` without accepting renderer-provided absolute paths.

```mermaid
flowchart LR
  A[Desktop File with native path] -->|path metadata only| B[Main process stream copy]
  C[Web, clipboard, or pathless File] -->|8 MB offset chunks| D[Main process chunk writer]
  B --> E[Managed upload file]
  D --> E
  E --> F[Bounded preview or resource link]
  F --> G[Agent]
```

## Scope and non-goals

- Chunk transfers can recover from a failed append by querying the current offset during the live app session; persistence across an app restart is not included.
- Linked-folder selection, permission UI, and provider implementation are not included. This change only reserves and validates the cross-layer reference shape and resolver seam.
- Large files are never embedded wholesale in model requests. The 10 GB value is a storage/transfer cap, not an inline model-content limit.

## Acceptance criteria and validation

- Desktop files can bypass renderer memory and base64 transport.
- Web/pathless files use bounded chunks below the RPC body cap.
- The UI reports progress, supports cancellation, and states that any file type is accepted up to 10 GB per file.
- Current upload/artifact `@` mentions still round-trip; linked-folder references round-trip only as `rootId + relativePath` and remain unavailable until a capability-validating adapter is configured.
- `npm run check:web-api-map` — passed.
- `npm run typecheck` — passed.
- `npm run lint` — passed with 0 errors (24 existing warnings outside this change).
- `npm test` — 498 test files passed, 10 skipped; 7005 tests passed, 113 skipped.

## Review focus

- Native-path trust boundary and the absence of a whole-file base64 public API.
- Chunk offset/retry/cancellation behavior and atomic `.part` cleanup/finalization.
- Per-type model-content fallbacks for large data, image, PDF, and binary files.
- `@` reference resolution and the future linked-folder capability boundary.
