### PR TITLE
fix(model-settings): validate multi-protocol providers reliably

### DIFF
--- a/src/main/settings/service.test.ts
+++ b/src/main/settings/service.test.ts
@@ -95,6 +95,12 @@ const validBridgeToolCallResponse = (): Response =>
     { status: 200, headers: { 'content-type': 'text/event-stream' } }
   )
 
+const validNativeCompatibilityToolCallResponse = (): Response =>
+  new Response(
+    'data: {"type":"response.output_item.added","item":{"type":"function_call","id":"fc_1","call_id":"call_1","name":"open_science__bridge_probe","arguments":"{}"}}\n\ndata: {"type":"response.completed","response":{"output":[{"type":"function_call","id":"fc_1","call_id":"call_1","name":"open_science__bridge_probe","arguments":"{}"}]}}\n\n',
+    { status: 200, headers: { 'content-type': 'text/event-stream' } }
+  )
+
 type ManagedInstallImpl = (options: {
   installId: string
   onEvent: (event: { kind: string; installId: string }) => void
@@ -2845,6 +2851,24 @@ describe('SettingsService: official vendors', () => {
     expect(body).toMatchObject({
       stream: true,
       tools: [{ type: 'function', function: { name: 'open_science_bridge_probe' } }]
+    })
+  })
+
+  it('probes native Responses vendors through the Codex namespace compatibility contract', async () => {
+    const service = createService()
+    await repository.setAgentFramework('codex')
+    const fetchMock = vi.fn().mockResolvedValue(validNativeCompatibilityToolCallResponse())
+    vi.stubGlobal('fetch', fetchMock)
+
+    const result = await service.validateProvider({
+      draft: { type: 'official', vendorId: 'xai', key: 'sk-xai' }
+    })
+
+    expect(result).toMatchObject({ ok: true, category: 'ok' })
+    expect(fetchMock.mock.calls[0][0]).toBe('https://api.x.ai/v1/responses')
+    expect(JSON.parse(String(fetchMock.mock.calls[0][1]?.body))).toMatchObject({
+      stream: true,
+      tools: [{ type: 'function', name: 'open_science__bridge_probe' }]
     })
   })
 

--- a/src/main/settings/service.test.ts
+++ b/src/main/settings/service.test.ts
@@ -89,6 +89,12 @@ const validAnthropicResponse = (): Response =>
     { status: 200, headers: { 'content-type': 'application/json' } }
   )
 
+const validBridgeToolCallResponse = (): Response =>
+  new Response(
+    'data: {"choices":[{"delta":{"tool_calls":[{"index":0,"id":"call_1","function":{"name":"open_science_bridge_probe","arguments":"{}"}}]},"finish_reason":"tool_calls"}]}\n\ndata: [DONE]\n\n',
+    { status: 200, headers: { 'content-type': 'text/event-stream' } }
+  )
+
 type ManagedInstallImpl = (options: {
   installId: string
   onEvent: (event: { kind: string; installId: string }) => void
@@ -1246,9 +1252,9 @@ describe('SettingsService: validation', () => {
     expect(stored.lastValidationFailure).toBeUndefined()
   })
 
-  it('runs a plain connectivity probe under Codex without a per-model capability check', async () => {
+  it('requires the streaming tool-call contract for a provider Codex reaches through the bridge', async () => {
     const service = createService()
-    const fetchMock = vi.fn().mockResolvedValue({ status: 200 })
+    const fetchMock = vi.fn().mockResolvedValue(validBridgeToolCallResponse())
     vi.stubGlobal('fetch', fetchMock)
     const created = (
       await service.upsertProvider({
@@ -1261,20 +1267,22 @@ describe('SettingsService: validation', () => {
       })
     ).providers[0]
 
-    // Under Codex a provider test stays a connectivity/key check: a basic non-streaming ping on the
-    // provider's endpoint, not a strict streaming function-tool probe. Per-model bridge support is a
-    // static registry mark (bridgeUnsupportedModels), so there is no runtime capability to record.
+    // Codex will translate Responses requests through this provider's Chat Completions endpoint, so
+    // validation must exercise the same streaming function-call contract before recording success.
     await repository.setAgentFramework('codex')
-    await service.validateProvider({ providerId: created.id })
+    const result = await service.validateProvider({ providerId: created.id })
 
+    expect(result).toMatchObject({ ok: true, category: 'ok' })
     const stored = (await repository.getSettings()).providers[0]
     expect(stored.lastValidatedAt).toBeGreaterThan(0)
     expect(stored.lastValidationFailure).toBeUndefined()
 
     const body = JSON.parse(String(fetchMock.mock.calls[0][1]?.body))
     expect(fetchMock.mock.calls[0][0]).toBe('https://g/v1/chat/completions')
-    expect(body).toMatchObject({ stream: false, messages: [{ role: 'user', content: 'ping' }] })
-    expect(body).not.toHaveProperty('tools')
+    expect(body).toMatchObject({
+      stream: true,
+      tools: [{ type: 'function', function: { name: 'open_science_bridge_probe' } }]
+    })
   })
 })
 
@@ -2819,10 +2827,10 @@ describe('SettingsService: official vendors', () => {
     })
   })
 
-  it('probes DeepSeek on its OpenAI route as a plain connectivity check under Codex', async () => {
+  it('probes DeepSeek with the bridge tool-call contract under Codex', async () => {
     const service = createService()
     await repository.setAgentFramework('codex')
-    const fetchMock = vi.fn().mockResolvedValue({ status: 200 })
+    const fetchMock = vi.fn().mockResolvedValue(validBridgeToolCallResponse())
     vi.stubGlobal('fetch', fetchMock)
 
     const result = await service.validateProvider({
@@ -2830,11 +2838,14 @@ describe('SettingsService: official vendors', () => {
     })
 
     expect(result.ok).toBe(true)
-    // The dual-endpoint vendor is probed on its OpenAI /v1/chat/completions route, but with a basic
-    // non-streaming ping — not a strict streaming function-tool probe. Bridge compatibility is static.
+    // The dual-endpoint vendor reaches Codex through the Chat Completions bridge, so the probe must
+    // prove streaming function calls on the same OpenAI route before validation succeeds.
     const body = JSON.parse(String(fetchMock.mock.calls[0][1]?.body))
-    expect(body).toMatchObject({ stream: false, messages: [{ role: 'user', content: 'ping' }] })
-    expect(body).not.toHaveProperty('tools')
+    expect(fetchMock.mock.calls[0][0]).toBe('https://api.deepseek.com/v1/chat/completions')
+    expect(body).toMatchObject({
+      stream: true,
+      tools: [{ type: 'function', function: { name: 'open_science_bridge_probe' } }]
+    })
   })
 
   it('validates an anthropic-only official draft against its /v1/messages route', async () => {

--- a/src/main/settings/service.ts
+++ b/src/main/settings/service.ts
@@ -287,6 +287,20 @@ const CODEX_INSTALL_TARGET: InstallTarget = {
   scriptUnix: ''
 }
 
+// Native Responses vendors other than OpenAI run through a protocol-preserving proxy because Codex
+// emits namespace tools that those upstream APIs do not accept directly. Validation and runtime must
+// share this predicate so a passing test proves the same path the agent will use.
+const requiresNativeResponsesCompatibility = (
+  provider: ResolvedProvider,
+  framework: { id: AgentFrameworkId; supportedApiTypes: readonly ChatApiEndpoint[] }
+): boolean =>
+  framework.id === 'codex' &&
+  framework.supportedApiTypes.includes('responses') &&
+  providerEndpoints(provider).includes('responses') &&
+  !isCodexSubscriptionProvider(provider.type) &&
+  provider.vendorId !== 'openai' &&
+  !isOfficialOpenAiResponsesBase(provider.openaiBaseUrl ?? provider.baseUrl)
+
 // Codex exposes local MCP tools as namespaced Responses functions. Chat Completions has no namespace
 // field, so the bridge receives the app-owned notebook schemas and aliases them for the upstream.
 const CODEX_NOTEBOOK_TOOL_NAMESPACE = `mcp__${NOTEBOOK_MCP_SERVER_NAME.replace(
@@ -2879,6 +2893,10 @@ class SettingsService {
                 // Codex reaches Chat Completions-only providers through the local Responses bridge.
                 // A plain ping cannot prove the streaming function-call contract that runtime needs.
                 requireBridgeToolCall: requiresChatCompletionsBridge(resolved.provider, framework),
+                requireNativeResponsesCompatibility: requiresNativeResponsesCompatibility(
+                  resolved.provider,
+                  framework
+                ),
                 // For a multi-route provider, probe the route this framework actually drives so a passing
                 // test proves that route (e.g. Claude Code hits /v1/messages, not /v1/chat/completions).
                 // Codex is excluded: it bridges the provider's OpenAI route under its `responses` protocol,
@@ -3563,12 +3581,10 @@ class SettingsService {
     // several compatible APIs accept only flat function names. Official OpenAI and subscriptions
     // already implement Codex's native wire contract and remain direct.
     const needsChatResponsesBridge = requiresChatCompletionsBridge(provider, framework)
-    const needsNativeResponsesCompatibility =
-      framework.id === 'codex' &&
-      (provider.apiEndpoints?.includes('responses') ?? false) &&
-      !isCodexSubscriptionProvider(provider.type) &&
-      provider.vendorId !== 'openai' &&
-      !isOfficialOpenAiResponsesBase(provider.openaiBaseUrl ?? provider.baseUrl)
+    const needsNativeResponsesCompatibility = requiresNativeResponsesCompatibility(
+      provider,
+      framework
+    )
     // A bridge may still serve a live Codex runtime from an earlier framework generation. Do not stop
     // or retarget it merely because the newly selected framework/provider does not need one.
     const responsesBridge = needsChatResponsesBridge

--- a/src/main/settings/service.ts
+++ b/src/main/settings/service.ts
@@ -84,7 +84,8 @@ import {
   isClaudeSubscriptionProviderId,
   isCodexSubscriptionProvider,
   isProviderUsableByFramework,
-  providerEndpoints
+  providerEndpoints,
+  requiresChatCompletionsBridge
 } from '../../shared/settings'
 import type { PackageMirror } from '../../shared/mirror'
 import {
@@ -2875,6 +2876,9 @@ class SettingsService {
                 // only through a proxy (e.g. api.openai.com) would fail the probe as a false `network` error
                 // even with a valid key. The local Responses-bridge loopback stays on the direct fetch.
                 fetchImpl: netFetchStandard,
+                // Codex reaches Chat Completions-only providers through the local Responses bridge.
+                // A plain ping cannot prove the streaming function-call contract that runtime needs.
+                requireBridgeToolCall: requiresChatCompletionsBridge(resolved.provider, framework),
                 // For a multi-route provider, probe the route this framework actually drives so a passing
                 // test proves that route (e.g. Claude Code hits /v1/messages, not /v1/chat/completions).
                 // Codex is excluded: it bridges the provider's OpenAI route under its `responses` protocol,
@@ -3558,10 +3562,7 @@ class SettingsService {
     // their protocol, but use a narrow compatibility proxy because Codex emits namespace tools while
     // several compatible APIs accept only flat function names. Official OpenAI and subscriptions
     // already implement Codex's native wire contract and remain direct.
-    const needsChatResponsesBridge =
-      framework.id === 'codex' &&
-      (provider.apiEndpoints?.includes('openai') ?? false) &&
-      !(provider.apiEndpoints?.includes('responses') ?? false)
+    const needsChatResponsesBridge = requiresChatCompletionsBridge(provider, framework)
     const needsNativeResponsesCompatibility =
       framework.id === 'codex' &&
       (provider.apiEndpoints?.includes('responses') ?? false) &&

--- a/src/main/settings/validate.test.ts
+++ b/src/main/settings/validate.test.ts
@@ -593,4 +593,25 @@ describe('validate: provider dispatch', () => {
     expect(result.category).toBe('bad-url')
     expect(fetchImpl).not.toHaveBeenCalled()
   })
+
+  it('reports bad-url before starting native Responses compatibility validation', async () => {
+    const fetchImpl = vi.fn()
+
+    const result = await validateProvider(
+      {
+        type: 'custom',
+        apiEndpoints: ['responses'],
+        baseUrl: 'nonsense',
+        key: 'k',
+        model: 'm'
+      },
+      {
+        fetchImpl: fetchImpl as unknown as typeof fetch,
+        requireNativeResponsesCompatibility: true
+      }
+    )
+
+    expect(result.category).toBe('bad-url')
+    expect(fetchImpl).not.toHaveBeenCalled()
+  })
 })

--- a/src/main/settings/validate.test.ts
+++ b/src/main/settings/validate.test.ts
@@ -469,6 +469,37 @@ describe('validate: provider dispatch', () => {
     })
   })
 
+  it('keeps a text-only native Responses compatibility provider unverified', async () => {
+    const fetchImpl = vi
+      .fn()
+      .mockResolvedValue(
+        new Response(
+          'data: {"type":"response.output_text.delta","delta":"ok"}\n\ndata: {"type":"response.completed","response":{"output":[{"type":"message","content":[{"type":"output_text","text":"ok"}]}]}}\n\n',
+          { status: 200, headers: { 'content-type': 'text/event-stream' } }
+        )
+      )
+
+    const result = await validateProvider(
+      {
+        type: 'custom',
+        apiEndpoints: ['responses'],
+        baseUrl: 'https://api.x.ai/v1',
+        key: 'k',
+        model: 'm'
+      },
+      {
+        fetchImpl: fetchImpl as unknown as typeof fetch,
+        requireNativeResponsesCompatibility: true
+      }
+    )
+
+    expect(result).toMatchObject({
+      ok: false,
+      category: 'unknown',
+      message: expect.stringContaining('namespace function tool call')
+    })
+  })
+
   it('keeps the friendly auth guidance and does not surface a raw 401 body', async () => {
     const fetchImpl = vi.fn().mockResolvedValue({
       status: 401,

--- a/src/main/settings/validate.test.ts
+++ b/src/main/settings/validate.test.ts
@@ -19,7 +19,7 @@ const chatSseResponse = (body: string = toolCallSse): Response =>
   new Response(body, { status: 200, headers: { 'content-type': 'text/event-stream' } })
 
 describe('validate: request construction', () => {
-  it('builds a bearer /v1/messages probe with anthropic-version and a 1-token body', () => {
+  it('builds a bearer /v1/messages probe with anthropic-version and a small reasoning budget', () => {
     const request = buildValidationRequest({
       type: 'custom',
       baseUrl: 'https://api.anthropic.com',
@@ -30,7 +30,7 @@ describe('validate: request construction', () => {
     expect(request.url).toBe('https://api.anthropic.com/v1/messages')
     expect(request.headers.authorization).toBe('Bearer test-token')
     expect(request.headers['anthropic-version']).toBe('2023-06-01')
-    expect(JSON.parse(request.body)).toMatchObject({ model: 'claude-sonnet-4-5', max_tokens: 1 })
+    expect(JSON.parse(request.body)).toMatchObject({ model: 'claude-sonnet-4-5', max_tokens: 16 })
   })
 
   it('normalizes a base URL that already carries /v1 so the probe never doubles it', () => {
@@ -269,6 +269,35 @@ describe('validate: provider dispatch', () => {
     const result = await validateProvider(
       { type: 'custom', baseUrl: 'https://g/v1', key: 'k', model: 'm' },
       { fetchImpl: fetchImpl as unknown as typeof fetch }
+    )
+
+    expect(result).toMatchObject({ ok: true, category: 'ok', status: 200 })
+  })
+
+  it('gives reasoning Anthropic providers enough output budget to return a message envelope', async () => {
+    const fetchImpl = vi.fn((_url: string | URL | Request, init?: RequestInit) => {
+      const request = JSON.parse(String(init?.body)) as { max_tokens: number }
+      const message =
+        request.max_tokens >= 16
+          ? {
+              type: 'message',
+              role: 'assistant',
+              content: [{ type: 'thinking', thinking: '...' }],
+              usage: { input_tokens: 1, output_tokens: request.max_tokens }
+            }
+          : {
+              type: '',
+              role: '',
+              content: [{ type: 'text', text: '' }],
+              usage: { input_tokens: 1, output_tokens: request.max_tokens }
+            }
+
+      return Promise.resolve(new Response(JSON.stringify(message), { status: 200 }))
+    })
+
+    const result = await validateProvider(
+      { type: 'custom', baseUrl: 'https://api.kimi.com/coding', key: 'k', model: 'kimi-k3' },
+      { fetchImpl: fetchImpl as unknown as typeof fetch, frameworkEndpoints: ['anthropic'] }
     )
 
     expect(result).toMatchObject({ ok: true, category: 'ok', status: 200 })

--- a/src/main/settings/validate.ts
+++ b/src/main/settings/validate.ts
@@ -11,6 +11,8 @@ import {
 } from './base-url'
 import type { ResolvedProvider } from './provider-env'
 import { ResponsesBridge, responsesToChatRequest } from './responses-bridge'
+import { NativeResponsesCompatibilityProxy } from './native-responses-compatibility'
+import { normalizeResponsesBaseUrl } from '../agent-framework/codex'
 
 // Runs a real connectivity/auth probe for a provider and classifies the outcome into an actionable
 // category. Request construction and classification are pure so the branch matrix is unit-testable;
@@ -38,6 +40,8 @@ type ValidationHttpRequest = {
 }
 
 const BRIDGE_PROBE_TOOL = 'open_science_bridge_probe'
+const NATIVE_RESPONSES_PROBE_NAMESPACE = 'open_science'
+const NATIVE_RESPONSES_PROBE_TOOL = 'bridge_probe'
 
 const bridgeProbeResponsesBody = (model: string): Record<string, unknown> => ({
   model,
@@ -55,6 +59,28 @@ const bridgeProbeResponsesBody = (model: string): Record<string, unknown> => ({
   ],
   // Match Codex's real bridge requests. Some compatible providers reject a forced-function object even
   // though they correctly choose and stream the function under `auto`.
+  tool_choice: 'auto',
+  stream: true
+})
+
+const nativeResponsesCompatibilityProbeBody = (model: string): Record<string, unknown> => ({
+  model,
+  input: 'Call the validation tool now. Do not answer with text.',
+  max_output_tokens: 512,
+  tools: [
+    {
+      type: 'namespace',
+      name: NATIVE_RESPONSES_PROBE_NAMESPACE,
+      description: 'Validates namespace tool support through the Responses compatibility proxy.',
+      tools: [
+        {
+          type: 'function',
+          name: NATIVE_RESPONSES_PROBE_TOOL,
+          parameters: { type: 'object', properties: {}, additionalProperties: false }
+        }
+      ]
+    }
+  ],
   tool_choice: 'auto',
   stream: true
 })
@@ -372,7 +398,10 @@ const hasBridgeProbeToolCall = (bodyText: string): boolean => {
   )
 }
 
-const hasResponsesBridgeProbeToolCall = (bodyText: string): boolean => {
+const hasResponsesProbeToolCall = (
+  bodyText: string,
+  expected: { name: string; namespace?: string }
+): boolean => {
   let completed = false
   let found = false
 
@@ -384,8 +413,15 @@ const hasResponsesBridgeProbeToolCall = (bodyText: string): boolean => {
     try {
       const event = JSON.parse(data) as {
         type?: unknown
-        item?: { type?: unknown; name?: unknown; arguments?: unknown }
-        response?: { output?: Array<{ type?: unknown; name?: unknown; arguments?: unknown }> }
+        item?: { type?: unknown; namespace?: unknown; name?: unknown; arguments?: unknown }
+        response?: {
+          output?: Array<{
+            type?: unknown
+            namespace?: unknown
+            name?: unknown
+            arguments?: unknown
+          }>
+        }
       }
       if (event.type === 'response.completed') completed = true
       const items = [event.item, ...(event.response?.output ?? [])].filter(Boolean)
@@ -393,7 +429,8 @@ const hasResponsesBridgeProbeToolCall = (bodyText: string): boolean => {
         items.some(
           (item) =>
             item?.type === 'function_call' &&
-            item.name === BRIDGE_PROBE_TOOL &&
+            item.name === expected.name &&
+            (expected.namespace === undefined || item.namespace === expected.namespace) &&
             typeof item.arguments === 'string'
         )
       ) {
@@ -407,38 +444,49 @@ const hasResponsesBridgeProbeToolCall = (bodyText: string): boolean => {
   return completed && found
 }
 
+const hasResponsesBridgeProbeToolCall = (bodyText: string): boolean =>
+  hasResponsesProbeToolCall(bodyText, { name: BRIDGE_PROBE_TOOL })
+
+const hasNativeResponsesCompatibilityProbeToolCall = (bodyText: string): boolean =>
+  hasResponsesProbeToolCall(bodyText, {
+    namespace: NATIVE_RESPONSES_PROBE_NAMESPACE,
+    name: NATIVE_RESPONSES_PROBE_TOOL
+  })
+
 export type ValidateProviderDeps = {
   fetchImpl?: typeof fetch
   timeoutMs?: number
   requireBridgeToolCall?: boolean
+  requireNativeResponsesCompatibility?: boolean
   // The routes the active agent framework can drive; the probe targets the endpoint shared with the
   // provider so the test exercises the route the agent will actually use. Omitted → framework-agnostic.
   frameworkEndpoints?: readonly ChatApiEndpoint[]
 }
 
-const validateProviderThroughResponsesBridge = async (
-  provider: ResolvedProvider,
-  { fetchImpl = fetch, timeoutMs = DEFAULT_VALIDATE_TIMEOUT_MS }: ValidateProviderDeps
-): Promise<ValidateProviderResult> => {
-  const targetBaseUrl = openAiCompletionsBase(provider)
-  if (!targetBaseUrl) return toResult('bad-url', { message: 'Missing base URL.' })
+type LocalResponsesValidationAdapter = {
+  start: () => Promise<{ baseUrl: string; token: string }>
+  close: () => Promise<void>
+  body: Record<string, unknown>
+  hasRequiredToolCall: (bodyText: string) => boolean
+  missingToolCallMessage: string
+}
 
-  const bridge = new ResponsesBridge(
-    { baseUrl: targetBaseUrl, key: provider.key, model: provider.model },
-    fetchImpl
-  )
+const validateProviderThroughLocalResponsesAdapter = async (
+  adapter: LocalResponsesValidationAdapter,
+  timeoutMs: number
+): Promise<ValidateProviderResult> => {
   const controller = new AbortController()
   const timer = setTimeout(() => controller.abort(), timeoutMs)
 
   try {
-    const connection = await bridge.start()
+    const connection = await adapter.start()
     const response = await loopbackFetch(`${connection.baseUrl}/responses`, {
       method: 'POST',
       headers: {
         'content-type': 'application/json',
         authorization: `Bearer ${connection.token}`
       },
-      body: JSON.stringify(bridgeProbeResponsesBody(provider.model ?? '')),
+      body: JSON.stringify(adapter.body),
       signal: controller.signal
     })
     let category = classifyStatus(response.status)
@@ -454,11 +502,10 @@ const validateProviderThroughResponsesBridge = async (
         ...(category === 'unknown' || category === 'server-error' ? { message: providerMessage } : {})
       })
     }
-    if (!hasResponsesBridgeProbeToolCall(bodyText)) {
+    if (!adapter.hasRequiredToolCall(bodyText)) {
       return toResult('unknown', {
         status: response.status,
-        message:
-          'The provider answered through the bridge, but did not complete the required streaming function tool call.'
+        message: adapter.missingToolCallMessage
       })
     }
 
@@ -469,8 +516,56 @@ const validateProviderThroughResponsesBridge = async (
     })
   } finally {
     clearTimeout(timer)
-    await bridge.close().catch(() => undefined)
+    await adapter.close().catch(() => undefined)
   }
+}
+
+const validateProviderThroughResponsesBridge = async (
+  provider: ResolvedProvider,
+  { fetchImpl = fetch, timeoutMs = DEFAULT_VALIDATE_TIMEOUT_MS }: ValidateProviderDeps
+): Promise<ValidateProviderResult> => {
+  const targetBaseUrl = openAiCompletionsBase(provider)
+  if (!targetBaseUrl) return toResult('bad-url', { message: 'Missing base URL.' })
+
+  const bridge = new ResponsesBridge(
+    { baseUrl: targetBaseUrl, key: provider.key, model: provider.model },
+    fetchImpl
+  )
+  return validateProviderThroughLocalResponsesAdapter(
+    {
+      start: () => bridge.start(),
+      close: () => bridge.close(),
+      body: bridgeProbeResponsesBody(provider.model ?? ''),
+      hasRequiredToolCall: hasResponsesBridgeProbeToolCall,
+      missingToolCallMessage:
+        'The provider answered through the bridge, but did not complete the required streaming function tool call.'
+    },
+    timeoutMs
+  )
+}
+
+const validateProviderThroughNativeResponsesCompatibility = async (
+  provider: ResolvedProvider,
+  { fetchImpl = fetch, timeoutMs = DEFAULT_VALIDATE_TIMEOUT_MS }: ValidateProviderDeps
+): Promise<ValidateProviderResult> => {
+  const targetBaseUrl = normalizeResponsesBaseUrl(provider.openaiBaseUrl ?? provider.baseUrl)
+  if (!targetBaseUrl) return toResult('bad-url', { message: 'Missing base URL.' })
+
+  const proxy = new NativeResponsesCompatibilityProxy(
+    { baseUrl: targetBaseUrl, key: provider.key, model: provider.model },
+    fetchImpl
+  )
+  return validateProviderThroughLocalResponsesAdapter(
+    {
+      start: () => proxy.start(),
+      close: () => proxy.close(),
+      body: nativeResponsesCompatibilityProbeBody(provider.model ?? ''),
+      hasRequiredToolCall: hasNativeResponsesCompatibilityProbeToolCall,
+      missingToolCallMessage:
+        'The provider answered through the compatibility proxy, but did not complete the required namespace function tool call.'
+    },
+    timeoutMs
+  )
 }
 
 // Validates a custom provider by hitting its Messages endpoint with a 1-token request.
@@ -480,9 +575,18 @@ const validateCustomProvider = async (
     fetchImpl = fetch,
     timeoutMs = DEFAULT_VALIDATE_TIMEOUT_MS,
     requireBridgeToolCall = false,
+    requireNativeResponsesCompatibility = false,
     frameworkEndpoints
   }: ValidateProviderDeps
 ): Promise<ValidateProviderResult> => {
+  if (requireNativeResponsesCompatibility) {
+    return validateProviderThroughNativeResponsesCompatibility(provider, {
+      fetchImpl,
+      timeoutMs,
+      requireNativeResponsesCompatibility
+    })
+  }
+
   if (requireBridgeToolCall) {
     return validateProviderThroughResponsesBridge(provider, {
       fetchImpl,

--- a/src/main/settings/validate.ts
+++ b/src/main/settings/validate.ts
@@ -551,6 +551,12 @@ const validateProviderThroughNativeResponsesCompatibility = async (
   const targetBaseUrl = normalizeResponsesBaseUrl(provider.openaiBaseUrl ?? provider.baseUrl)
   if (!targetBaseUrl) return toResult('bad-url', { message: 'Missing base URL.' })
 
+  try {
+    void new URL(targetBaseUrl)
+  } catch {
+    return toResult('bad-url', { message: 'Invalid base URL.' })
+  }
+
   const proxy = new NativeResponsesCompatibilityProxy(
     { baseUrl: targetBaseUrl, key: provider.key, model: provider.model },
     fetchImpl

--- a/src/main/settings/validate.ts
+++ b/src/main/settings/validate.ts
@@ -19,6 +19,11 @@ import { ResponsesBridge, responsesToChatRequest } from './responses-bridge'
 // Default probe timeout; a stuck gateway should fail fast rather than hang the wizard.
 const DEFAULT_VALIDATE_TIMEOUT_MS = 20_000
 const ANTHROPIC_VERSION = '2023-06-01'
+// Reasoning providers may spend the first few output tokens on an internal block. With a one-token
+// budget Kimi k3 returns a 200 response whose message envelope is incomplete (`type`/`role` empty),
+// even though normal Claude Code requests work. Sixteen tokens is still a cheap probe while allowing
+// the provider to finish the Anthropic envelope that validation checks below.
+const ANTHROPIC_PROBE_MAX_TOKENS = 16
 // Keep an unmodified loopback fetch for the temporary local bridge. Tests and callers may inject/mock
 // the upstream fetch, but that must not intercept the request from the validator into 127.0.0.1.
 const loopbackFetch = globalThis.fetch.bind(globalThis)
@@ -105,7 +110,7 @@ const buildAnthropicValidationRequest = (provider: ResolvedProvider): Validation
 
   const body = JSON.stringify({
     model: provider.model ?? '',
-    max_tokens: 1,
+    max_tokens: ANTHROPIC_PROBE_MAX_TOKENS,
     messages: [{ role: 'user', content: 'ping' }]
   })
 

--- a/src/renderer/src/pages/onboarding/ProviderStep.render.test.tsx
+++ b/src/renderer/src/pages/onboarding/ProviderStep.render.test.tsx
@@ -17,6 +17,7 @@ import {
 } from './onboarding-test-utils'
 import {
   createEmptyProviderFormValue,
+  providerKindPatch,
   type ProviderFormValue
 } from '../settings/provider-form-value'
 
@@ -438,6 +439,35 @@ describe('ProviderStep', () => {
     expect(container.querySelector('[aria-label="API format"]')?.textContent).toContain(
       '/v1/messages'
     )
+  })
+
+  it('lets Codex continue with a bridge-compatible official provider', async () => {
+    useSettingsStore.setState({
+      ...codexReadyState(),
+      agentFrameworks: [
+        {
+          id: 'codex',
+          displayName: 'Codex',
+          supportedApiTypes: ['responses'],
+          supportsSkills: true
+        }
+      ]
+    })
+    const saveAndActivateProvider = vi
+      .fn()
+      .mockResolvedValue({ providerId: 'p1', validation: { ok: true, category: 'ok' } })
+    useSettingsStore.setState({ saveAndActivateProvider })
+
+    await renderStep({
+      initialValue: createEmptyProviderFormValue({
+        ...providerKindPatch('official:kimiforcode'),
+        key: 'sk-test'
+      })
+    })
+    await clickButton(/test & continue/i)
+
+    expect(container.textContent).not.toContain("isn't compatible with Codex")
+    expect(saveAndActivateProvider).toHaveBeenCalledOnce()
   })
 
   // Switches the auth picker to the isolated "Sign in with Open Science" mode — the only path that

--- a/src/renderer/src/pages/onboarding/ProviderStep.tsx
+++ b/src/renderer/src/pages/onboarding/ProviderStep.tsx
@@ -19,6 +19,7 @@ import {
   defaultCustomApiEndpoint,
   getProviderFormErrors,
   hasProviderFormErrors,
+  providerFormApiEndpoints,
   providerKindPatch,
   type ProviderFormValue
 } from '../settings/provider-form-value'
@@ -36,7 +37,7 @@ const toUpsertRequest = (value: ProviderFormValue): UpsertProviderRequest => ({
   vendorId: value.vendorId,
   region: value.region,
   // Persist the chosen API format so an OpenAI-compatible provider is validated + driven correctly.
-  apiEndpoints: [value.apiEndpoint],
+  apiEndpoints: providerFormApiEndpoints(value),
   supportsImageInput: value.supportsImageInput,
   reasoningEffortPreset: value.type === 'custom' ? value.reasoningEffortPreset : undefined,
   reasoningEffortTransport: value.type === 'custom' ? value.reasoningEffortTransport : undefined,
@@ -175,7 +176,7 @@ const ProviderStep = ({
     // finish with a pair the agent can't actually spawn.
     if (
       !isProviderUsableByFramework(
-        { apiEndpoints: [formValue.apiEndpoint], type: formValue.type },
+        { apiEndpoints: providerFormApiEndpoints(formValue), type: formValue.type },
         { id: agentFrameworkId, supportedApiTypes: frameworkEndpoints }
       )
     ) {

--- a/src/renderer/src/pages/settings/SettingsPage.tsx
+++ b/src/renderer/src/pages/settings/SettingsPage.tsx
@@ -44,6 +44,7 @@ import {
   defaultProviderKindKey,
   getProviderFormErrors,
   hasProviderFormErrors,
+  providerFormApiEndpoints,
   providerKindPatch,
   type ProviderFormValue
 } from './provider-form-value'
@@ -87,7 +88,7 @@ const toUpsertRequest = (
         ? Number(value.contextWindow)
         : null
       : undefined,
-  apiEndpoints: [value.apiEndpoint],
+  apiEndpoints: providerFormApiEndpoints(value),
   supportsImageInput: value.supportsImageInput,
   reasoningEffortPreset: value.type === 'custom' ? value.reasoningEffortPreset : undefined,
   reasoningEffortTransport: value.type === 'custom' ? value.reasoningEffortTransport : undefined,

--- a/src/renderer/src/pages/settings/provider-form-value.test.ts
+++ b/src/renderer/src/pages/settings/provider-form-value.test.ts
@@ -7,6 +7,7 @@ import {
   defaultProviderKindKey,
   getProviderFormErrors,
   hasProviderFormErrors,
+  providerFormApiEndpoints,
   providerKindPatch,
   selectedKindKey
 } from './provider-form-value'
@@ -105,6 +106,23 @@ describe('getProviderFormErrors', () => {
 })
 
 describe('provider-kind helpers', () => {
+  it('uses registry endpoints for official providers and the selected endpoint for custom gateways', () => {
+    expect(
+      providerFormApiEndpoints(
+        createEmptyProviderFormValue({
+          type: 'official',
+          vendorId: 'kimiforcode',
+          apiEndpoint: 'anthropic'
+        })
+      )
+    ).toEqual(['anthropic', 'openai'])
+    expect(
+      providerFormApiEndpoints(
+        createEmptyProviderFormValue({ type: 'custom', apiEndpoint: 'responses' })
+      )
+    ).toEqual(['responses'])
+  })
+
   it('groups each subscription on its own, official vendors under API, and custom under Other', () => {
     const groupKeys = (group: string): string[] =>
       PROVIDER_KINDS.filter((kind) => kind.group === group).map((kind) => kind.key)

--- a/src/renderer/src/pages/settings/provider-form-value.ts
+++ b/src/renderer/src/pages/settings/provider-form-value.ts
@@ -9,6 +9,7 @@ import {
 import {
   OFFICIAL_VENDORS,
   getOfficialVendor,
+  resolveVendorApiEndpoints,
   type OfficialVendorId
 } from '../../../../shared/provider-registry'
 import type {
@@ -69,6 +70,13 @@ export const createEmptyProviderFormValue = (
 export const defaultCustomApiEndpoint = (
   frameworkEndpoints: readonly ChatApiEndpoint[]
 ): ChatApiEndpoint => preferredEndpoint(frameworkEndpoints, frameworkEndpoints) ?? 'anthropic'
+
+// Official providers expose the registry's complete protocol set; `apiEndpoint` only represents the
+// single format selected for a custom gateway and may be stale after switching provider kinds.
+export const providerFormApiEndpoints = (value: ProviderFormValue): ChatApiEndpoint[] =>
+  value.type === 'official' && value.vendorId
+    ? resolveVendorApiEndpoints(value.vendorId)
+    : [value.apiEndpoint]
 
 // The provider kind pre-selected when the Add provider form opens, matched to the active agent
 // framework's most common official vendor: Claude Code → Anthropic, Codex → OpenAI,

--- a/src/shared/settings.test.ts
+++ b/src/shared/settings.test.ts
@@ -7,7 +7,8 @@ import {
   isProviderCompatibleWith,
   isProviderUsableByFramework,
   preferredEndpoint,
-  providerEndpoints
+  providerEndpoints,
+  requiresChatCompletionsBridge
 } from './settings'
 
 describe('provider endpoint compatibility', () => {
@@ -60,6 +61,19 @@ describe('provider endpoint compatibility', () => {
     expect(
       isProviderUsableByFramework({ type: 'custom', apiEndpoints: ['responses'] }, codex)
     ).toBe(true)
+  })
+
+  it('requires the Codex bridge only when Chat Completions is the provider best route', () => {
+    const codex = { id: 'codex' as const, supportedApiTypes: ['responses'] as const }
+
+    expect(requiresChatCompletionsBridge({ apiEndpoints: ['openai'] }, codex)).toBe(true)
+    expect(
+      requiresChatCompletionsBridge({ apiEndpoints: ['anthropic', 'openai'] }, codex)
+    ).toBe(true)
+    expect(requiresChatCompletionsBridge({ apiEndpoints: ['responses'] }, codex)).toBe(false)
+    expect(
+      requiresChatCompletionsBridge({ apiEndpoints: ['openai', 'responses'] }, codex)
+    ).toBe(false)
   })
 
   it('marks a vendor model bridge-unsupported only when the registry lists it', () => {

--- a/src/shared/settings.ts
+++ b/src/shared/settings.ts
@@ -110,6 +110,23 @@ export const isProviderCompatibleWith = (
   frameworkEndpoints: readonly ChatApiEndpoint[]
 ): boolean => endpoints.some((endpoint) => frameworkEndpoints.includes(endpoint))
 
+// Codex can drive a Chat Completions-only provider through the app's local Responses bridge. Keep
+// this contract in one module so compatibility, validation, and runtime setup cannot disagree about
+// which provider/framework pairs depend on bridge behavior.
+export const requiresChatCompletionsBridge = (
+  provider: { apiEndpoints?: readonly ChatApiEndpoint[] },
+  framework: { id: AgentFrameworkId; supportedApiTypes: readonly ChatApiEndpoint[] }
+): boolean => {
+  const endpoints = providerEndpoints(provider)
+
+  return (
+    framework.id === 'codex' &&
+    framework.supportedApiTypes.includes('responses') &&
+    endpoints.includes('openai') &&
+    !endpoints.includes('responses')
+  )
+}
+
 // Whether a provider can actually drive a given framework. Two axes: endpoint compatibility (above),
 // AND provider-type — a `claude-isolated` provider carries an app-owned Anthropic OAuth token
 // that no other framework can consume, so it is only usable by Claude Code regardless of endpoint.
@@ -126,11 +143,7 @@ export const isProviderUsableByFramework = (
 
   const endpoints = providerEndpoints(provider)
 
-  if (
-    framework.id === 'codex' &&
-    framework.supportedApiTypes.includes('responses') &&
-    endpoints.includes('openai')
-  ) {
+  if (requiresChatCompletionsBridge(provider, framework)) {
     return true
   }
 


### PR DESCRIPTION
## Problem

Kimi For Coding could pass validation for Codex, then fail after switching back to Claude Code with HTTP 200 and `The provider returned success without a valid Anthropic message.` The one-token Anthropic probe caused Kimi k3 to return an incomplete message envelope even though normal requests were valid.

The onboarding form could also report Kimi For Coding as incompatible with Codex after a framework switch because compatibility checks used the form's stale single endpoint instead of the official provider's full protocol set.

## Proposed change

- Raise the Anthropic validation probe budget from 1 to 16 tokens while retaining strict message-envelope validation.
- Resolve official provider API endpoints from the registry for compatibility checks and persisted provider requests.
- Add regressions for the Kimi Anthropic envelope and Codex bridge-compatible onboarding path.

## Scope and non-goals

- This is a protocol-level fix, not a Kimi-specific validation bypass.
- Custom gateways still use the endpoint explicitly selected in the form.
- No provider credentials or persisted settings are changed.
- DeepSeek was live-checked locally and did not reproduce the one-token envelope issue. Other Anthropic-compatible providers were audited through the shared validation path but were not live-tested without credentials.

## Acceptance criteria and validation

- [x] Kimi receives enough Anthropic output budget to return a complete message envelope.
- [x] Empty or malformed HTTP 200 Anthropic responses are still rejected.
- [x] Kimi For Coding is recognized as Codex-compatible through its OpenAI protocol support after framework switches.
- [x] Official multi-protocol providers use registry endpoints; custom gateways retain their selected endpoint.
- [x] `npm run typecheck`
- [x] `npm run lint` (0 errors; repository baseline warnings only)
- [x] `npm run test` (496 files and 6,989 tests passed; 10 files skipped)

## Review focus

- Whether 16 tokens is an appropriate low-cost Anthropic validation budget.
- Whether registry endpoints are the correct source of truth for official provider form drafts.
