### PR TITLE
feat(model-settings): default custom API format by agent framework

### DIFF
--- a/src/renderer/src/pages/onboarding/ProviderStep.render.test.tsx
+++ b/src/renderer/src/pages/onboarding/ProviderStep.render.test.tsx
@@ -102,6 +102,51 @@ const submitClaudeFallbackToken = async (token: string): Promise<void> => {
 }
 
 describe('ProviderStep', () => {
+  it('defaults an untouched custom gateway to the active framework API format', async () => {
+    useSettingsStore.setState({
+      agentFrameworkId: 'opencode',
+      agentFrameworks: [
+        {
+          id: 'opencode',
+          displayName: 'OpenCode',
+          supportedApiTypes: ['anthropic', 'openai'],
+          supportsSkills: true
+        }
+      ]
+    })
+
+    await renderStep()
+
+    expect(container.querySelector('[aria-label="API format"]')?.textContent).toContain(
+      '/v1/chat/completions'
+    )
+  })
+
+  it('preserves a manually chosen API format when revisiting an otherwise blank draft', async () => {
+    useSettingsStore.setState({
+      agentFrameworkId: 'opencode',
+      agentFrameworks: [
+        {
+          id: 'opencode',
+          displayName: 'OpenCode',
+          supportedApiTypes: ['anthropic', 'openai'],
+          supportsSkills: true
+        }
+      ]
+    })
+
+    await renderStep({
+      initialValue: {
+        ...createEmptyProviderFormValue({ apiEndpoint: 'anthropic' }),
+        providerSelectionTouched: true
+      }
+    })
+
+    expect(container.querySelector('[aria-label="API format"]')?.textContent).toContain(
+      '/v1/messages'
+    )
+  })
+
   it('defers required-field errors until the first submit attempt', async () => {
     readyClaudeEnvironment()
 
@@ -325,6 +370,27 @@ describe('ProviderStep', () => {
     expect(container.querySelector('[aria-label="API key"]')).toBeNull()
   })
 
+  it('defaults a Codex custom gateway to the Responses API', async () => {
+    useSettingsStore.setState({
+      ...codexReadyState(),
+      agentFrameworks: [
+        {
+          id: 'codex',
+          displayName: 'Codex',
+          supportedApiTypes: ['responses'],
+          supportsSkills: true
+        }
+      ]
+    })
+
+    await renderStep()
+    await selectOption('Provider type', 'Custom Gateway')
+
+    expect(container.querySelector('[aria-label="API format"]')?.textContent).toContain(
+      '/v1/responses'
+    )
+  })
+
   it('keeps an existing provider draft when Codex is selected', async () => {
     useSettingsStore.setState(codexReadyState())
     const initialValue = {
@@ -341,6 +407,9 @@ describe('ProviderStep', () => {
       'https://gateway.example'
     )
     expect(container.querySelector<HTMLInputElement>('[aria-label="Model"]')?.value).toBe('gpt-5')
+    expect(container.querySelector('[aria-label="API format"]')?.textContent).toContain(
+      '/v1/messages'
+    )
   })
 
   // Switches the auth picker to the isolated "Sign in with Open Science" mode — the only path that

--- a/src/renderer/src/pages/onboarding/ProviderStep.render.test.tsx
+++ b/src/renderer/src/pages/onboarding/ProviderStep.render.test.tsx
@@ -138,13 +138,41 @@ describe('ProviderStep', () => {
     await renderStep({
       initialValue: {
         ...createEmptyProviderFormValue({ apiEndpoint: 'anthropic' }),
-        providerSelectionTouched: true
+        providerFormTouched: true
       }
     })
 
     expect(container.querySelector('[aria-label="API format"]')?.textContent).toContain(
       '/v1/messages'
     )
+  })
+
+  it('preserves any user-edited custom draft when the active framework changes', async () => {
+    await renderStep()
+
+    await act(async () => {
+      container.querySelector<HTMLButtonElement>('[aria-label="Supports image input"]')?.click()
+    })
+    await act(async () => {
+      useSettingsStore.setState({
+        agentFrameworkId: 'codex',
+        agentFrameworks: [
+          {
+            id: 'codex',
+            displayName: 'Codex',
+            supportedApiTypes: ['responses'],
+            supportsSkills: true
+          }
+        ]
+      })
+    })
+
+    expect(container.querySelector('[aria-label="Provider type"]')?.textContent).toContain(
+      'Custom Gateway'
+    )
+    expect(
+      container.querySelector('[aria-label="Supports image input"]')?.getAttribute('data-state')
+    ).toBe('checked')
   })
 
   it('defers required-field errors until the first submit attempt', async () => {

--- a/src/renderer/src/pages/onboarding/ProviderStep.tsx
+++ b/src/renderer/src/pages/onboarding/ProviderStep.tsx
@@ -107,7 +107,7 @@ const ProviderStep = ({
   useEffect(() => {
     setFormValue((current) => {
       if (
-        current.providerSelectionTouched ||
+        current.providerFormTouched ||
         current.name ||
         current.baseUrl ||
         current.model ||
@@ -340,7 +340,9 @@ const ProviderStep = ({
           ) : null}
           <ProviderForm
             value={formValue}
-            onChange={(patch) => setFormValue((current) => ({ ...current, ...patch }))}
+            onChange={(patch) =>
+              setFormValue((current) => ({ ...current, ...patch, providerFormTouched: true }))
+            }
             errors={showProviderErrors ? formErrors : undefined}
             disabled={isSaving}
             encryptionAvailable={encryptionAvailable}

--- a/src/renderer/src/pages/onboarding/ProviderStep.tsx
+++ b/src/renderer/src/pages/onboarding/ProviderStep.tsx
@@ -16,6 +16,7 @@ import { ClaudeIsolatedSignInModal } from '../settings/ClaudeIsolatedSignInModal
 import { ProviderForm } from '../settings/ProviderForm'
 import {
   createEmptyProviderFormValue,
+  defaultCustomApiEndpoint,
   getProviderFormErrors,
   hasProviderFormErrors,
   providerKindPatch,
@@ -83,6 +84,7 @@ const ProviderStep = ({
   const [showProviderErrors, setShowProviderErrors] = useState(false)
   const [validationMessage, setValidationMessage] = useState<string | undefined>(undefined)
   const [validationOk, setValidationOk] = useState(false)
+  const customApiEndpoint = defaultCustomApiEndpoint(frameworkEndpoints)
   // Mirrors the Settings teardown: a pending isolated sign-in lives in the main process for up to
   // five minutes, and its guard rejects a second attempt as "already in progress". If the wizard
   // unmounts mid-flow (app quit, relaunch, forced navigation), cancel it so the next attempt starts
@@ -99,17 +101,30 @@ const ProviderStep = ({
     [cancelCodexLogin, cancelIsolatedClaudeLogin, cancelSharedClaudeLogin]
   )
 
-  // Codex starts with its subscription provider, but an existing draft always wins when navigating
-  // back to this step.
+  // Seed an untouched draft from the active framework. Codex starts with its subscription provider;
+  // custom-provider flows use the framework's preferred API format. An existing draft always wins
+  // when navigating back to this step.
   useEffect(() => {
-    if (agentFrameworkId !== 'codex') return
+    setFormValue((current) => {
+      if (
+        current.providerSelectionTouched ||
+        current.name ||
+        current.baseUrl ||
+        current.model ||
+        current.key
+      ) {
+        return current
+      }
 
-    setFormValue((current) =>
-      current.name || current.baseUrl || current.model || current.key
-        ? current
-        : createEmptyProviderFormValue(providerKindPatch('codex-subscription'))
-    )
-  }, [agentFrameworkId, setFormValue])
+      if (agentFrameworkId === 'codex') {
+        return createEmptyProviderFormValue(providerKindPatch('codex-subscription'))
+      }
+
+      if (current.type !== 'custom' || current.apiEndpoint === customApiEndpoint) return current
+
+      return { ...current, apiEndpoint: customApiEndpoint }
+    })
+  }, [agentFrameworkId, customApiEndpoint, setFormValue])
 
   // Onboarding always creates a provider, so required fields must be filled before it can continue.
   const formErrors = getProviderFormErrors(formValue)
@@ -331,6 +346,7 @@ const ProviderStep = ({
             encryptionAvailable={encryptionAvailable}
             showCodexSubscriptions={agentFrameworkId === 'codex'}
             showClaudeIsolated={agentFrameworkId === 'claude-code'}
+            defaultCustomApiEndpoint={customApiEndpoint}
           />
           {formValue.type === 'claude-isolated' ? (
             <p className="mt-4 text-sm text-muted-foreground">

--- a/src/renderer/src/pages/settings/ProviderForm.tsx
+++ b/src/renderer/src/pages/settings/ProviderForm.tsx
@@ -194,12 +194,7 @@ const ProviderForm = ({
         </div>
         <Select
           value={selectedKey}
-          onValueChange={(key) =>
-            onChange({
-              ...providerKindPatch(key, defaultCustomApiEndpoint),
-              providerSelectionTouched: true
-            })
-          }
+          onValueChange={(key) => onChange(providerKindPatch(key, defaultCustomApiEndpoint))}
         >
           <SelectTrigger aria-label="Provider type">
             <span className="flex items-center gap-2">
@@ -266,10 +261,7 @@ const ProviderForm = ({
               value={value.type}
               disabled={disabled}
               onValueChange={(type) =>
-                onChange({
-                  type: type as 'codex-shared' | 'codex-isolated',
-                  providerSelectionTouched: true
-                })
+                onChange({ type: type as 'codex-shared' | 'codex-isolated' })
               }
             >
               <SelectTrigger aria-label="Codex authentication" disabled={disabled}>
@@ -300,10 +292,7 @@ const ProviderForm = ({
                 value={value.type}
                 disabled={disabled}
                 onValueChange={(type) =>
-                  onChange({
-                    type: type as 'claude-shared' | 'claude-isolated',
-                    providerSelectionTouched: true
-                  })
+                  onChange({ type: type as 'claude-shared' | 'claude-isolated' })
                 }
               >
                 <SelectTrigger aria-label="Claude authentication" disabled={disabled}>
@@ -399,10 +388,7 @@ const ProviderForm = ({
               value={value.apiEndpoint}
               disabled={disabled}
               onValueChange={(apiEndpoint) =>
-                onChange({
-                  apiEndpoint: apiEndpoint as ProviderFormValue['apiEndpoint'],
-                  providerSelectionTouched: true
-                })
+                onChange({ apiEndpoint: apiEndpoint as ProviderFormValue['apiEndpoint'] })
               }
             >
               <SelectTrigger aria-label="API format" disabled={disabled}>

--- a/src/renderer/src/pages/settings/ProviderForm.tsx
+++ b/src/renderer/src/pages/settings/ProviderForm.tsx
@@ -57,6 +57,8 @@ type ProviderFormProps = {
   // showCodexSubscriptions: claude-isolated is only meaningful while Claude Code is the active
   // framework, so the wizard/settings page toggles this rather than showing it unconditionally.
   showClaudeIsolated?: boolean
+  // Preferred protocol for a newly selected Custom Gateway, derived from the active framework.
+  defaultCustomApiEndpoint?: ProviderFormValue['apiEndpoint']
 }
 
 const fieldLabelClassName = 'text-xs font-medium text-muted-foreground'
@@ -123,7 +125,8 @@ const ProviderForm = ({
   disabled = false,
   encryptionAvailable = true,
   showCodexSubscriptions = false,
-  showClaudeIsolated = false
+  showClaudeIsolated = false,
+  defaultCustomApiEndpoint = 'anthropic'
 }: ProviderFormProps): React.JSX.Element => {
   const isCustom = value.type === 'custom'
   const isOfficial = value.type === 'official'
@@ -189,7 +192,15 @@ const ProviderForm = ({
           <span className={fieldLabelClassName}>Provider type</span>
           {selectedKind ? <FieldHelp content={selectedKind.description} /> : null}
         </div>
-        <Select value={selectedKey} onValueChange={(key) => onChange(providerKindPatch(key))}>
+        <Select
+          value={selectedKey}
+          onValueChange={(key) =>
+            onChange({
+              ...providerKindPatch(key, defaultCustomApiEndpoint),
+              providerSelectionTouched: true
+            })
+          }
+        >
           <SelectTrigger aria-label="Provider type">
             <span className="flex items-center gap-2">
               <ProviderKindIcon kindKey={selectedKey} />
@@ -255,7 +266,10 @@ const ProviderForm = ({
               value={value.type}
               disabled={disabled}
               onValueChange={(type) =>
-                onChange({ type: type as 'codex-shared' | 'codex-isolated' })
+                onChange({
+                  type: type as 'codex-shared' | 'codex-isolated',
+                  providerSelectionTouched: true
+                })
               }
             >
               <SelectTrigger aria-label="Codex authentication" disabled={disabled}>
@@ -286,7 +300,10 @@ const ProviderForm = ({
                 value={value.type}
                 disabled={disabled}
                 onValueChange={(type) =>
-                  onChange({ type: type as 'claude-shared' | 'claude-isolated' })
+                  onChange({
+                    type: type as 'claude-shared' | 'claude-isolated',
+                    providerSelectionTouched: true
+                  })
                 }
               >
                 <SelectTrigger aria-label="Claude authentication" disabled={disabled}>
@@ -382,7 +399,10 @@ const ProviderForm = ({
               value={value.apiEndpoint}
               disabled={disabled}
               onValueChange={(apiEndpoint) =>
-                onChange({ apiEndpoint: apiEndpoint as ProviderFormValue['apiEndpoint'] })
+                onChange({
+                  apiEndpoint: apiEndpoint as ProviderFormValue['apiEndpoint'],
+                  providerSelectionTouched: true
+                })
               }
             >
               <SelectTrigger aria-label="API format" disabled={disabled}>

--- a/src/renderer/src/pages/settings/SettingsPage.render.test.tsx
+++ b/src/renderer/src/pages/settings/SettingsPage.render.test.tsx
@@ -7,6 +7,12 @@ import { SettingsPage } from './SettingsPage'
 import { clickRadixMenuItem, openRadixMenu } from './test-utils'
 import { createInitialSettingsState, useSettingsStore } from '@/stores/settings-store'
 
+if (!Element.prototype.hasPointerCapture) {
+  Element.prototype.hasPointerCapture = (): boolean => false
+  Element.prototype.setPointerCapture = (): void => undefined
+  Element.prototype.releasePointerCapture = (): void => undefined
+}
+
 let container: HTMLDivElement
 let root: Root
 
@@ -611,6 +617,39 @@ describe('SettingsPage layout', () => {
       document.body.appendChild(container)
       root = createRoot(container)
     }
+  })
+
+  it('defaults a custom gateway to the active framework API format', async () => {
+    await act(async () => {
+      root.render(<SettingsPage open onClose={vi.fn()} />)
+    })
+    useSettingsStore.setState({
+      agentFrameworkId: 'opencode',
+      agentFrameworks: [
+        {
+          id: 'opencode',
+          displayName: 'OpenCode',
+          supportedApiTypes: ['anthropic', 'openai'],
+          supportsSkills: true
+        }
+      ],
+      opencode: { resolvedPath: '/x/opencode' }
+    })
+
+    const addProvider = Array.from(
+      document.body.querySelectorAll<HTMLButtonElement>('button')
+    ).find((button) => button.textContent?.trim() === 'Add provider')
+    act(() => addProvider?.click())
+
+    openRadixMenu(document.body.querySelector<HTMLElement>('[aria-label="Provider type"]'))
+    const customGateway = Array.from(
+      document.body.querySelectorAll<HTMLElement>('[role="option"]')
+    ).find((option) => option.textContent?.includes('Custom Gateway'))
+    clickRadixMenuItem(customGateway)
+
+    expect(document.body.querySelector('[aria-label="API format"]')?.textContent).toContain(
+      '/v1/chat/completions'
+    )
   })
 
   it('switches to the General panel and shows the diagnostic log file', async () => {

--- a/src/renderer/src/pages/settings/SettingsPage.render.test.tsx
+++ b/src/renderer/src/pages/settings/SettingsPage.render.test.tsx
@@ -652,6 +652,60 @@ describe('SettingsPage layout', () => {
     )
   })
 
+  it('preserves the saved API format when editing a custom gateway', async () => {
+    const api = (window as unknown as { api: { settings: Record<string, unknown> } }).api
+    const provider = {
+      id: 'custom-messages',
+      type: 'custom',
+      name: 'Messages gateway',
+      baseUrl: 'https://gateway.example',
+      model: 'model-a',
+      models: ['model-a'],
+      apiEndpoints: ['anthropic'],
+      supportsImageInput: false,
+      hasKey: true,
+      maskedKey: 'sk-…test',
+      needsKey: false
+    }
+    api.settings.getSettings = vi.fn().mockResolvedValue({
+      claude: {},
+      opencode: { resolvedPath: '/x/opencode' },
+      codex: {},
+      providers: [provider],
+      activeProviderId: provider.id,
+      activeModel: provider.model,
+      agentFrameworkId: 'opencode',
+      agentFrameworks: [
+        {
+          id: 'opencode',
+          displayName: 'OpenCode',
+          supportedApiTypes: ['anthropic', 'openai'],
+          supportsSkills: true
+        }
+      ]
+    })
+    api.settings.getPreflight = vi.fn().mockResolvedValue({
+      opencodeReady: true,
+      agentFrameworkId: 'opencode',
+      agentReady: true,
+      activeProviderReady: true
+    })
+
+    await act(async () => {
+      root.render(<SettingsPage open onClose={vi.fn()} />)
+    })
+    await act(async () => {
+      document.body.querySelector<HTMLButtonElement>('[aria-label="Edit"]')?.click()
+    })
+
+    expect(document.body.querySelector('[aria-label="Provider type"]')?.textContent).toContain(
+      'Custom Gateway'
+    )
+    expect(document.body.querySelector('[aria-label="API format"]')?.textContent).toContain(
+      '/v1/messages'
+    )
+  })
+
   it('switches to the General panel and shows the diagnostic log file', async () => {
     await act(async () => {
       root.render(<SettingsPage open onClose={vi.fn()} />)

--- a/src/renderer/src/pages/settings/SettingsPage.tsx
+++ b/src/renderer/src/pages/settings/SettingsPage.tsx
@@ -19,7 +19,7 @@ import type { ProviderView, UpsertProviderRequest } from '../../../../shared/set
 import { Button } from '@/components/ui/button'
 import { Tooltip, TooltipContent, TooltipProvider, TooltipTrigger } from '@/components/ui/tooltip'
 import { cn } from '@/lib/utils'
-import { useSettingsStore } from '@/stores/settings-store'
+import { selectFrameworkApiEndpoints, useSettingsStore } from '@/stores/settings-store'
 import type { SettingsPanelId } from './settings-navigation'
 import { useComputeStore } from '@/stores/compute-store'
 import { AgentPanel } from './AgentPanel'
@@ -40,6 +40,7 @@ import { resolveVendorModelsUrl } from '../../../../shared/provider-registry'
 import { ProviderForm } from './ProviderForm'
 import {
   createEmptyProviderFormValue,
+  defaultCustomApiEndpoint,
   defaultProviderKindKey,
   getProviderFormErrors,
   hasProviderFormErrors,
@@ -161,6 +162,8 @@ const INITIAL_LOCATION: NavLocation = {
 const SettingsPage = ({ open, onClose }: SettingsPageProps): React.JSX.Element => {
   const providers = useSettingsStore((state) => state.providers)
   const agentFrameworkId = useSettingsStore((state) => state.agentFrameworkId)
+  const frameworkEndpoints = useSettingsStore(selectFrameworkApiEndpoints)
+  const customApiEndpoint = defaultCustomApiEndpoint(frameworkEndpoints)
   const opencode = useSettingsStore((state) => state.opencode)
   const isDetectingOpencode = useSettingsStore((state) => state.isDetectingOpencode)
   const detectOpencode = useSettingsStore((state) => state.detectOpencode)
@@ -828,6 +831,7 @@ const SettingsPage = ({ open, onClose }: SettingsPageProps): React.JSX.Element =
                       showClaudeIsolated={
                         agentFrameworkId === 'claude-code' && editingProvider === undefined
                       }
+                      defaultCustomApiEndpoint={customApiEndpoint}
                     />
                     {statusMessage ? (
                       <p

--- a/src/renderer/src/pages/settings/provider-form-value.test.ts
+++ b/src/renderer/src/pages/settings/provider-form-value.test.ts
@@ -3,6 +3,7 @@ import { describe, expect, it } from 'vitest'
 import {
   PROVIDER_KINDS,
   createEmptyProviderFormValue,
+  defaultCustomApiEndpoint,
   defaultProviderKindKey,
   getProviderFormErrors,
   hasProviderFormErrors,
@@ -15,6 +16,18 @@ describe('defaultProviderKindKey', () => {
     expect(defaultProviderKindKey('claude-code')).toBe('official:anthropic')
     expect(defaultProviderKindKey('codex')).toBe('official:openai')
     expect(defaultProviderKindKey('opencode')).toBe('official:deepseek')
+  })
+})
+
+describe('defaultCustomApiEndpoint', () => {
+  it('uses each framework capability set to choose its preferred custom API format', () => {
+    expect(defaultCustomApiEndpoint(['anthropic'])).toBe('anthropic')
+    expect(defaultCustomApiEndpoint(['anthropic', 'openai'])).toBe('openai')
+    expect(defaultCustomApiEndpoint(['responses'])).toBe('responses')
+  })
+
+  it('falls back to the legacy Messages API while framework capabilities are unavailable', () => {
+    expect(defaultCustomApiEndpoint([])).toBe('anthropic')
   })
 })
 
@@ -150,10 +163,18 @@ describe('provider-kind helpers', () => {
   it('clears vendor-only fields when picking custom', () => {
     expect(providerKindPatch('custom')).toEqual({
       type: 'custom',
+      apiEndpoint: 'anthropic',
       vendorId: undefined,
       region: undefined,
       model: '',
       contextWindow: ''
+    })
+  })
+
+  it('seeds a custom provider with the active framework API format', () => {
+    expect(providerKindPatch('custom', 'openai')).toMatchObject({
+      type: 'custom',
+      apiEndpoint: 'openai'
     })
   })
 

--- a/src/renderer/src/pages/settings/provider-form-value.ts
+++ b/src/renderer/src/pages/settings/provider-form-value.ts
@@ -1,6 +1,7 @@
 import {
   claudeIsolatedProviderIdentity,
   codexSubscriptionProviderIdentity,
+  preferredEndpoint,
   type AgentFrameworkId,
   type ChatApiEndpoint,
   type ProviderType
@@ -28,6 +29,9 @@ export type ProviderFormValue = {
   // 'anthropic'. A custom provider serves exactly one endpoint (official providers take theirs from
   // the registry); it is stored as the single-entry apiEndpoints array.
   apiEndpoint: ChatApiEndpoint
+  // Form-only state: protects an explicit provider-kind/API-format choice when onboarding remounts.
+  // It is intentionally omitted from the persisted provider request.
+  providerSelectionTouched: boolean
   supportsImageInput: boolean
   // Optional at rest for backwards compatibility; the form always materializes the five-level default.
   reasoningEffortPreset: ReasoningEffortPresetSetting
@@ -51,12 +55,20 @@ export const createEmptyProviderFormValue = (
   model: '',
   contextWindow: '',
   apiEndpoint: 'anthropic',
+  providerSelectionTouched: false,
   supportsImageInput: false,
   reasoningEffortPreset: 'standard-5',
   reasoningEffortTransport: 'reasoning-effort',
   key: '',
   ...overrides
 })
+
+// Chooses the framework's preferred wire protocol for a new custom gateway. This mirrors runtime
+// endpoint selection: Responses wins when available, then Chat Completions, then Messages. The
+// legacy Messages default remains the safe fallback while framework capabilities are still loading.
+export const defaultCustomApiEndpoint = (
+  frameworkEndpoints: readonly ChatApiEndpoint[]
+): ChatApiEndpoint => preferredEndpoint(frameworkEndpoints, frameworkEndpoints) ?? 'anthropic'
 
 // The provider kind pre-selected when the Add provider form opens, matched to the active agent
 // framework's most common official vendor: Claude Code → Anthropic, Codex → OpenAI,
@@ -179,8 +191,12 @@ export const PROVIDER_KINDS: ProviderKind[] = [
 ]
 
 // The patch applied to the form value when a provider-kind is picked. Switching to an official vendor
-// seeds its default region + model; switching away clears vendor-only fields.
-export const providerKindPatch = (key: string): Partial<ProviderFormValue> => {
+// seeds its default region + model; switching to custom clears vendor-only fields and applies the
+// active framework's preferred endpoint.
+export const providerKindPatch = (
+  key: string,
+  customApiEndpoint: ChatApiEndpoint = 'anthropic'
+): Partial<ProviderFormValue> => {
   if (key === 'codex-subscription') {
     const identity = codexSubscriptionProviderIdentity()
     return {
@@ -226,7 +242,14 @@ export const providerKindPatch = (key: string): Partial<ProviderFormValue> => {
     }
   }
 
-  return { type: 'custom', vendorId: undefined, region: undefined, model: '', contextWindow: '' }
+  return {
+    type: 'custom',
+    apiEndpoint: customApiEndpoint,
+    vendorId: undefined,
+    region: undefined,
+    model: '',
+    contextWindow: ''
+  }
 }
 
 // Maps the current form value back to its provider-kind key (the dropdown's selected value).

--- a/src/renderer/src/pages/settings/provider-form-value.ts
+++ b/src/renderer/src/pages/settings/provider-form-value.ts
@@ -29,9 +29,9 @@ export type ProviderFormValue = {
   // 'anthropic'. A custom provider serves exactly one endpoint (official providers take theirs from
   // the registry); it is stored as the single-entry apiEndpoints array.
   apiEndpoint: ChatApiEndpoint
-  // Form-only state: protects an explicit provider-kind/API-format choice when onboarding remounts.
-  // It is intentionally omitted from the persisted provider request.
-  providerSelectionTouched: boolean
+  // Form-only state: protects any user-edited onboarding draft when the step remounts or the active
+  // framework changes. It is intentionally omitted from the persisted provider request.
+  providerFormTouched: boolean
   supportsImageInput: boolean
   // Optional at rest for backwards compatibility; the form always materializes the five-level default.
   reasoningEffortPreset: ReasoningEffortPresetSetting
@@ -55,7 +55,7 @@ export const createEmptyProviderFormValue = (
   model: '',
   contextWindow: '',
   apiEndpoint: 'anthropic',
-  providerSelectionTouched: false,
+  providerFormTouched: false,
   supportsImageInput: false,
   reasoningEffortPreset: 'standard-5',
   reasoningEffortTransport: 'reasoning-effort',


### PR DESCRIPTION
## Problem

Custom Gateway drafts always started with the Messages API, regardless of the active agent framework. OpenCode and Codex users had to change the API format manually before the provider was compatible.

## Proposed change

- Derive the Custom Gateway default from the active framework advertised endpoints using the existing endpoint preference.
- Apply that default only to blank or new Onboarding drafts and when Custom Gateway is newly selected in Onboarding or Settings.
- Preserve a saved custom provider API format when it is opened for editing, even when the active framework has a different default.
- Preserve every user-edited Onboarding provider field across remounts and framework changes.

## Scope and non-goals

This changes renderer form defaults only. It does not change persisted provider schemas, runtime protocol selection, validation rules, or existing saved providers.

## Acceptance criteria and validation

- Claude Code defaults to Messages API for a new Custom Gateway.
- OpenCode defaults to Chat Completions API for a new Custom Gateway.
- Codex defaults to Responses API for a new Custom Gateway.
- Editing a saved custom provider preserves its stored API format.
- Existing user-edited Onboarding drafts remain unchanged.
- `npm run typecheck`
- `npm run lint` (0 errors; existing warnings are outside this diff)
- `npm test` (6995 passed, 113 skipped)
- Focused renderer and helper tests cover both Provider Settings and Onboarding.

## Review focus

Please review the framework-capability default selection and the form-only touch state that prevents Onboarding remounts from overwriting user edits.