### PR TITLE
fix(codex): preserve imported subscription routing

### DIFF
--- a/src/main/acp/runtime.ts
+++ b/src/main/acp/runtime.ts
@@ -2118,7 +2118,8 @@ class AcpRuntime {
       process = backend.framework.spawn({
         executablePath: backend.executablePath,
         env: backend.env,
-        args: backend.args ?? []
+        args: backend.args ?? [],
+        proxyEnvironmentMode: backend.proxyEnvironmentMode
       })
     } catch (error) {
       // Wrap (never mutate) the failure with the framework this spawn targeted: the connect-level catch

--- a/src/main/agent-framework/codex.test.ts
+++ b/src/main/agent-framework/codex.test.ts
@@ -709,6 +709,7 @@ describe('codexFramework', () => {
 
     framework.spawn({
       executablePath: '/usr/local/bin/codex-acp',
+      proxyEnvironmentMode: 'replace',
       env: {
         CODEX_HOME: '/data/codex-subscription',
         HTTP_PROXY: 'http://system-proxy.example.test:3128',
@@ -729,6 +730,7 @@ describe('codexFramework', () => {
 
     framework.spawn({
       executablePath: '/usr/local/bin/codex-acp',
+      proxyEnvironmentMode: 'replace',
       env: { CODEX_HOME: '/data/codex-subscription' },
       args: []
     })
@@ -737,6 +739,30 @@ describe('codexFramework', () => {
     expect(directEnv.HTTPS_PROXY).toBeUndefined()
     expect(directEnv.ALL_PROXY).toBeUndefined()
     expect(directEnv.NO_PROXY).toBeUndefined()
+  })
+
+  it('preserves inherited proxies when subscription proxy resolution fails', () => {
+    const spawnProcess = vi.fn().mockReturnValue(fakeChild)
+    const framework = createCodexFramework({
+      sourceEnv: {
+        PATH: '/parent-bin',
+        HTTPS_PROXY: 'http://inherited-proxy.example.test:3128',
+        NO_PROXY: 'inherited-bypass.example.test'
+      },
+      spawnProcess
+    })
+
+    framework.spawn({
+      executablePath: '/usr/local/bin/codex-acp',
+      proxyEnvironmentMode: 'inherit',
+      env: { CODEX_HOME: '/data/codex-subscription' },
+      args: []
+    })
+
+    expect(spawnProcess.mock.calls[0][2].env).toMatchObject({
+      HTTPS_PROXY: 'http://inherited-proxy.example.test:3128',
+      NO_PROXY: 'inherited-bypass.example.test'
+    })
   })
 })
 

--- a/src/main/agent-framework/codex.test.ts
+++ b/src/main/agent-framework/codex.test.ts
@@ -694,6 +694,50 @@ describe('codexFramework', () => {
     expect(env.OPENAI_API_KEY).toBeUndefined()
     expect(env.CODEX_PATH).toBeUndefined()
   })
+
+  it('replaces every inherited proxy shape for a subscription spawn', () => {
+    const spawnProcess = vi.fn().mockReturnValue(fakeChild)
+    const framework = createCodexFramework({
+      sourceEnv: {
+        PATH: '/parent-bin',
+        ALL_PROXY: 'socks5://stale-proxy.example.test:9050',
+        HTTPS_PROXY: 'http://stale-proxy.example.test:3128',
+        NO_PROXY: 'stale-bypass.example.test'
+      },
+      spawnProcess
+    })
+
+    framework.spawn({
+      executablePath: '/usr/local/bin/codex-acp',
+      env: {
+        CODEX_HOME: '/data/codex-subscription',
+        HTTP_PROXY: 'http://system-proxy.example.test:3128',
+        HTTPS_PROXY: 'http://system-proxy.example.test:3128',
+        NO_PROXY: 'localhost,127.0.0.1,::1'
+      },
+      args: []
+    })
+
+    const env = spawnProcess.mock.calls[0][2].env as NodeJS.ProcessEnv
+    expect(env).toMatchObject({
+      HTTP_PROXY: 'http://system-proxy.example.test:3128',
+      HTTPS_PROXY: 'http://system-proxy.example.test:3128',
+      NO_PROXY: 'localhost,127.0.0.1,::1'
+    })
+    expect(env.ALL_PROXY).toBeUndefined()
+    expect(env.NO_PROXY).not.toContain('stale-bypass.example.test')
+
+    framework.spawn({
+      executablePath: '/usr/local/bin/codex-acp',
+      env: { CODEX_HOME: '/data/codex-subscription' },
+      args: []
+    })
+    const directEnv = spawnProcess.mock.calls[1][2].env as NodeJS.ProcessEnv
+    expect(directEnv.HTTP_PROXY).toBeUndefined()
+    expect(directEnv.HTTPS_PROXY).toBeUndefined()
+    expect(directEnv.ALL_PROXY).toBeUndefined()
+    expect(directEnv.NO_PROXY).toBeUndefined()
+  })
 })
 
 describe('buildCodexConfig reasoning effort', () => {

--- a/src/main/agent-framework/codex.ts
+++ b/src/main/agent-framework/codex.ts
@@ -27,6 +27,7 @@ import type {
 } from './types'
 import { isCodexSubscriptionProvider } from '../../shared/settings'
 import { CODEX_VERSION } from '../settings/managed-codex'
+import { clearSystemProxyEnvironment } from '../settings/system-proxy'
 import codexNativeModelInstructions from './codex-native-model-instructions.md?raw'
 
 const CODEX_PROVIDER_ID = 'open-science'
@@ -275,6 +276,12 @@ const buildSpawnEnvironment = (
   const env = augmentedPathEnv(sourceEnv)
 
   for (const key of CODEX_ENV_KEYS) delete env[key]
+  // A subscription gets an authoritative proxy decision from Electron immediately before backend
+  // resolution. Drop every inherited proxy shape first so a stale ALL_PROXY/HTTP_PROXY cannot win
+  // over that decision (including DIRECT, represented by no proxy keys in input.env).
+  if (/[\\/]codex-subscription$/.test(input.env.CODEX_HOME ?? '')) {
+    clearSystemProxyEnvironment(env)
+  }
 
   return {
     ...env,

--- a/src/main/agent-framework/codex.ts
+++ b/src/main/agent-framework/codex.ts
@@ -276,10 +276,9 @@ const buildSpawnEnvironment = (
   const env = augmentedPathEnv(sourceEnv)
 
   for (const key of CODEX_ENV_KEYS) delete env[key]
-  // A subscription gets an authoritative proxy decision from Electron immediately before backend
-  // resolution. Drop every inherited proxy shape first so a stale ALL_PROXY/HTTP_PROXY cannot win
-  // over that decision (including DIRECT, represented by no proxy keys in input.env).
-  if (/[\\/]codex-subscription$/.test(input.env.CODEX_HOME ?? '')) {
+  // A resolved proxy or DIRECT decision is authoritative. A resolver failure uses `inherit` so a
+  // working proxy supplied by the process launcher remains available as the fallback.
+  if (input.proxyEnvironmentMode === 'replace') {
     clearSystemProxyEnvironment(env)
   }
 

--- a/src/main/agent-framework/types.ts
+++ b/src/main/agent-framework/types.ts
@@ -98,12 +98,17 @@ export type SessionSetup = {
   promptPrefix?: string
 }
 
+export type ProxyEnvironmentMode = 'inherit' | 'replace'
+
 // Already-resolved spawn inputs: env and args come from prepareModelConfig merged over the base
 // process env; configFiles are written by the runtime before this call.
 export type AgentSpawnInput = {
   executablePath: string
   env: Record<string, string>
   args: string[]
+  // `replace` means the host resolved an explicit proxy or DIRECT decision and inherited proxy
+  // variables must not override it. `inherit` preserves them after a host resolver failure.
+  proxyEnvironmentMode?: ProxyEnvironmentMode
   debug?: boolean
 }
 
@@ -158,6 +163,7 @@ export type ResolvedAgentBackend = {
   executablePath: string
   env: Record<string, string>
   args?: string[]
+  proxyEnvironmentMode?: ProxyEnvironmentMode
   // Framework-native session options retained by the runtime and passed through buildSessionSetup.
   sessionOptions?: Record<string, unknown>
   // Backend-resolved guidance appended to every session. Connector conventions use this channel for

--- a/src/main/settings/codex-auth.test.ts
+++ b/src/main/settings/codex-auth.test.ts
@@ -143,6 +143,19 @@ describe('createCodexAuthEnvironment', () => {
     expect(env.ALL_PROXY).toBeUndefined()
     expect(env.NO_PROXY).not.toContain('stale-bypass.example.test')
   })
+
+  it('preserves inherited proxies when system proxy resolution fails', () => {
+    const env = createCodexAuthEnvironment('isolated', '/data', {
+      PATH: 'bin',
+      HTTPS_PROXY: 'http://inherited-proxy.example.test:3128',
+      NO_PROXY: 'inherited-bypass.example.test'
+    })
+
+    expect(env).toMatchObject({
+      HTTPS_PROXY: 'http://inherited-proxy.example.test:3128',
+      NO_PROXY: 'inherited-bypass.example.test'
+    })
+  })
 })
 
 describe('importCodexAuthentication', () => {

--- a/src/main/settings/codex-auth.test.ts
+++ b/src/main/settings/codex-auth.test.ts
@@ -75,7 +75,7 @@ describe('createCodexAuthEnvironment', () => {
 })
 
 describe('importCodexAuthentication', () => {
-  it('copies only auth.json into the app-owned subscription home', async () => {
+  it('copies auth.json without unrelated Codex config or private runtime data', async () => {
     const root = await mkdtemp(join(tmpdir(), 'codex-auth-import-'))
     const source = join(root, 'source')
     const destination = join(root, 'destination')
@@ -86,6 +86,8 @@ describe('importCodexAuthentication', () => {
       await writeFile(join(source, 'config.toml'), 'model = "private"\n')
       await writeFile(join(source, 'skills', 'private-skill', 'SKILL.md'), '# Private')
       await writeFile(join(source, 'sessions', 'session.jsonl'), 'private session')
+      await mkdir(destination, { recursive: true })
+      await writeFile(join(destination, 'config.toml'), 'model_provider = "stale"\n')
 
       await importCodexAuthentication(source, destination)
 
@@ -96,6 +98,83 @@ describe('importCodexAuthentication', () => {
       expect(existsSync(join(destination, 'config.toml'))).toBe(false)
       expect(existsSync(join(destination, 'skills'))).toBe(false)
       expect(existsSync(join(destination, 'sessions'))).toBe(false)
+    } finally {
+      await rm(root, { recursive: true, force: true })
+    }
+  })
+
+  it('imports only the active ChatGPT-authenticated model-provider route', async () => {
+    const root = await mkdtemp(join(tmpdir(), 'codex-auth-route-import-'))
+    const source = join(root, 'source')
+    const destination = join(root, 'destination')
+    try {
+      await mkdir(source, { recursive: true })
+      await writeFile(join(source, 'auth.json'), '{"tokens":{"access_token":"secret"}}')
+      await writeFile(
+        join(source, 'config.toml'),
+        [
+          'model_provider = "subscription-route"',
+          'model = "private-model"',
+          '',
+          '[mcp_servers.private]',
+          'command = "private-command"',
+          '',
+          '[model_providers.subscription-route]',
+          'name = "OpenAI"',
+          'requires_openai_auth = true',
+          'supports_websockets = false',
+          'wire_api = "responses"',
+          'base_url = "http://127.0.0.1:1087/v1"',
+          'experimental_bearer_token = "must-not-be-copied"',
+          ''
+        ].join('\n')
+      )
+
+      await importCodexAuthentication(source, destination)
+
+      expect(await readFile(join(destination, 'config.toml'), 'utf8')).toBe(
+        [
+          'model_provider = "subscription-route"',
+          '',
+          '[model_providers."subscription-route"]',
+          'name = "OpenAI"',
+          'base_url = "http://127.0.0.1:1087/v1"',
+          'wire_api = "responses"',
+          'requires_openai_auth = true',
+          'supports_websockets = false',
+          ''
+        ].join('\n')
+      )
+      expect((await stat(join(destination, 'config.toml'))).mode & 0o777).toBe(0o600)
+    } finally {
+      await rm(root, { recursive: true, force: true })
+    }
+  })
+
+  it('does not import a model-provider route backed by separate credentials', async () => {
+    const root = await mkdtemp(join(tmpdir(), 'codex-auth-route-reject-'))
+    const source = join(root, 'source')
+    const destination = join(root, 'destination')
+    try {
+      await mkdir(source, { recursive: true })
+      await writeFile(join(source, 'auth.json'), '{"tokens":{"access_token":"secret"}}')
+      await writeFile(
+        join(source, 'config.toml'),
+        [
+          'model_provider = "private-gateway"',
+          '',
+          '[model_providers.private-gateway]',
+          'name = "Private"',
+          'requires_openai_auth = false',
+          'wire_api = "responses"',
+          'base_url = "https://private.example/v1"',
+          ''
+        ].join('\n')
+      )
+
+      await importCodexAuthentication(source, destination)
+
+      expect(existsSync(join(destination, 'config.toml'))).toBe(false)
     } finally {
       await rm(root, { recursive: true, force: true })
     }

--- a/src/main/settings/codex-auth.test.ts
+++ b/src/main/settings/codex-auth.test.ts
@@ -166,6 +166,81 @@ describe('importCodexAuthentication', () => {
     }
   })
 
+  it('replaces conflicting app-owned provider config without creating duplicate TOML keys', async () => {
+    const root = await mkdtemp(join(tmpdir(), 'codex-auth-route-conflict-'))
+    const source = join(root, 'source')
+    const destination = join(root, 'destination')
+    try {
+      await mkdir(source, { recursive: true })
+      await mkdir(destination, { recursive: true })
+      await writeFile(join(source, 'auth.json'), '{"tokens":{"access_token":"secret"}}')
+      await writeFile(
+        join(source, 'config.toml'),
+        [
+          'model_provider = "subscription-route"',
+          '',
+          '[model_providers.subscription-route]',
+          'name = "Imported"',
+          'requires_openai_auth = true',
+          'wire_api = "responses"',
+          'base_url = "http://127.0.0.1:1087/v1"',
+          ''
+        ].join('\n')
+      )
+      await writeFile(
+        join(destination, 'config.toml'),
+        [
+          '"model_provider" = "app-default-route"',
+          'model = "app-default"',
+          '',
+          '[model_providers.subscription-route]',
+          'name = "Stale"',
+          'base_url = "http://127.0.0.1:9999/v1"',
+          '',
+          '[model_providers.app-default-route]',
+          'name = "App default"',
+          'base_url = "https://app.example/v1"',
+          '',
+          '[mcp_servers.app]',
+          'command = "app-command"',
+          ''
+        ].join('\n')
+      )
+
+      await importCodexAuthentication(source, destination)
+
+      const configToml = await readFile(join(destination, 'config.toml'), 'utf8')
+      const activeConfigToml = configToml
+        .split('\n')
+        .filter((line) => !line.startsWith('#'))
+        .join('\n')
+      expect(
+        activeConfigToml.match(/^(?:model_provider|"model_provider"|'model_provider')\s*=/gm)
+      ).toHaveLength(1)
+      expect(activeConfigToml.match(/^\[model_providers\."subscription-route"\]$/gm)).toHaveLength(
+        1
+      )
+      expect(activeConfigToml).not.toContain('http://127.0.0.1:9999/v1')
+      expect(configToml).toContain('[model_providers.app-default-route]')
+      expect(configToml).toContain('base_url = "https://app.example/v1"')
+      expect(configToml).toContain('[mcp_servers.app]')
+      expect(configToml).toContain('command = "app-command"')
+
+      await writeFile(join(source, 'config.toml'), 'model = "private-model"\n')
+      await importCodexAuthentication(source, destination)
+
+      const restoredConfigToml = await readFile(join(destination, 'config.toml'), 'utf8')
+      expect(restoredConfigToml).toContain('"model_provider" = "app-default-route"')
+      expect(restoredConfigToml).toContain('[model_providers.subscription-route]')
+      expect(restoredConfigToml).toContain('base_url = "http://127.0.0.1:9999/v1"')
+      expect(restoredConfigToml).toContain('[model_providers.app-default-route]')
+      expect(restoredConfigToml).toContain('[mcp_servers.app]')
+      expect(restoredConfigToml).not.toContain('Open Science:')
+    } finally {
+      await rm(root, { recursive: true, force: true })
+    }
+  })
+
   it('does not import a model-provider route backed by separate credentials', async () => {
     const root = await mkdtemp(join(tmpdir(), 'codex-auth-route-reject-'))
     const source = join(root, 'source')

--- a/src/main/settings/codex-auth.test.ts
+++ b/src/main/settings/codex-auth.test.ts
@@ -87,7 +87,7 @@ describe('importCodexAuthentication', () => {
       await writeFile(join(source, 'skills', 'private-skill', 'SKILL.md'), '# Private')
       await writeFile(join(source, 'sessions', 'session.jsonl'), 'private session')
       await mkdir(destination, { recursive: true })
-      await writeFile(join(destination, 'config.toml'), 'model_provider = "stale"\n')
+      await writeFile(join(destination, 'config.toml'), 'model = "app-default"\n')
 
       await importCodexAuthentication(source, destination)
 
@@ -95,7 +95,9 @@ describe('importCodexAuthentication', () => {
         '{"tokens":{"access_token":"secret"}}'
       )
       expect((await stat(join(destination, 'auth.json'))).mode & 0o777).toBe(0o600)
-      expect(existsSync(join(destination, 'config.toml'))).toBe(false)
+      expect(await readFile(join(destination, 'config.toml'), 'utf8')).toBe(
+        'model = "app-default"\n'
+      )
       expect(existsSync(join(destination, 'skills'))).toBe(false)
       expect(existsSync(join(destination, 'sessions'))).toBe(false)
     } finally {
@@ -109,7 +111,9 @@ describe('importCodexAuthentication', () => {
     const destination = join(root, 'destination')
     try {
       await mkdir(source, { recursive: true })
+      await mkdir(destination, { recursive: true })
       await writeFile(join(source, 'auth.json'), '{"tokens":{"access_token":"secret"}}')
+      await writeFile(join(destination, 'config.toml'), 'model = "app-default"\n')
       await writeFile(
         join(source, 'config.toml'),
         [
@@ -134,18 +138,29 @@ describe('importCodexAuthentication', () => {
 
       expect(await readFile(join(destination, 'config.toml'), 'utf8')).toBe(
         [
+          'model = "app-default"',
+          '# Open Science: begin imported Codex route selection',
           'model_provider = "subscription-route"',
-          '',
+          '# Open Science: end imported Codex route selection',
+          '# Open Science: begin imported Codex provider',
           '[model_providers."subscription-route"]',
           'name = "OpenAI"',
           'base_url = "http://127.0.0.1:1087/v1"',
           'wire_api = "responses"',
           'requires_openai_auth = true',
           'supports_websockets = false',
+          '# Open Science: end imported Codex provider',
           ''
         ].join('\n')
       )
       expect((await stat(join(destination, 'config.toml'))).mode & 0o777).toBe(0o600)
+
+      await writeFile(join(source, 'config.toml'), 'model = "private-model"\n')
+      await importCodexAuthentication(source, destination)
+
+      expect(await readFile(join(destination, 'config.toml'), 'utf8')).toBe(
+        'model = "app-default"\n'
+      )
     } finally {
       await rm(root, { recursive: true, force: true })
     }

--- a/src/main/settings/codex-auth.test.ts
+++ b/src/main/settings/codex-auth.test.ts
@@ -114,21 +114,25 @@ describe('createCodexAuthEnvironment', () => {
   })
 
   it('applies the resolved system proxy to authentication sessions', () => {
-    expect(
-      createCodexAuthEnvironment(
-        'isolated',
-        '/data',
-        { PATH: 'bin' },
-        {
-          HTTP_PROXY: 'http://proxy.example.test:3128',
-          HTTPS_PROXY: 'http://proxy.example.test:3128',
-          http_proxy: 'http://proxy.example.test:3128',
-          https_proxy: 'http://proxy.example.test:3128',
-          NO_PROXY: 'localhost,127.0.0.1,::1',
-          no_proxy: 'localhost,127.0.0.1,::1'
-        }
-      )
-    ).toMatchObject({
+    const env = createCodexAuthEnvironment(
+      'isolated',
+      '/data',
+      {
+        PATH: 'bin',
+        ALL_PROXY: 'socks5://stale-proxy.example.test:9050',
+        NO_PROXY: 'stale-bypass.example.test'
+      },
+      {
+        HTTP_PROXY: 'http://proxy.example.test:3128',
+        HTTPS_PROXY: 'http://proxy.example.test:3128',
+        http_proxy: 'http://proxy.example.test:3128',
+        https_proxy: 'http://proxy.example.test:3128',
+        NO_PROXY: 'localhost,127.0.0.1,::1',
+        no_proxy: 'localhost,127.0.0.1,::1'
+      }
+    )
+
+    expect(env).toMatchObject({
       HTTP_PROXY: 'http://proxy.example.test:3128',
       HTTPS_PROXY: 'http://proxy.example.test:3128',
       http_proxy: 'http://proxy.example.test:3128',
@@ -136,6 +140,8 @@ describe('createCodexAuthEnvironment', () => {
       NO_PROXY: 'localhost,127.0.0.1,::1',
       no_proxy: 'localhost,127.0.0.1,::1'
     })
+    expect(env.ALL_PROXY).toBeUndefined()
+    expect(env.NO_PROXY).not.toContain('stale-bypass.example.test')
   })
 })
 

--- a/src/main/settings/codex-auth.test.ts
+++ b/src/main/settings/codex-auth.test.ts
@@ -213,7 +213,6 @@ describe('importCodexAuthentication', () => {
           "'supports_websockets' = false",
           '"wire_api" = "responses"',
           '"base_url" = "http://127.0.0.1:1087/v1"',
-          'experimental_bearer_token = "must-not-be-copied"',
           ''
         ].join('\n')
       )
@@ -245,6 +244,47 @@ describe('importCodexAuthentication', () => {
       expect(await readFile(join(destination, 'config.toml'), 'utf8')).toBe(
         'model = "app-default"\n'
       )
+    } finally {
+      await rm(root, { recursive: true, force: true })
+    }
+  })
+
+  it.each([
+    ['inline bearer token', 'experimental_bearer_token = "private-token"'],
+    ['API-key environment variable', 'env_key = "PRIVATE_TOKEN"'],
+    ['literal HTTP headers', 'http_headers = { Authorization = "private-token" }'],
+    ['dotted HTTP headers', 'http_headers.Authorization = "private-token"'],
+    ['environment HTTP headers', 'env_http_headers = { Authorization = "PRIVATE_TOKEN" }'],
+    ['query parameters', 'query_params = { api_key = "private-token" }'],
+    [
+      'nested HTTP headers',
+      '[model_providers.subscription-route.http_headers]\nAuthorization = "private-token"'
+    ]
+  ])('does not import a loopback route that depends on %s', async (_label, credentialLine) => {
+    const root = await mkdtemp(join(tmpdir(), 'codex-auth-route-secret-reject-'))
+    const source = join(root, 'source')
+    const destination = join(root, 'destination')
+    try {
+      await mkdir(source, { recursive: true })
+      await writeFile(join(source, 'auth.json'), '{"tokens":{"access_token":"secret"}}')
+      await writeFile(
+        join(source, 'config.toml'),
+        [
+          'model_provider = "subscription-route"',
+          '',
+          '[model_providers.subscription-route]',
+          'name = "OpenAI"',
+          'requires_openai_auth = true',
+          'wire_api = "responses"',
+          'base_url = "http://127.0.0.1:1087/v1"',
+          credentialLine,
+          ''
+        ].join('\n')
+      )
+
+      await importCodexAuthentication(source, destination)
+
+      expect(existsSync(join(destination, 'config.toml'))).toBe(false)
     } finally {
       await rm(root, { recursive: true, force: true })
     }

--- a/src/main/settings/codex-auth.test.ts
+++ b/src/main/settings/codex-auth.test.ts
@@ -29,15 +29,55 @@ const session = (overrides: Partial<CodexAuthSession> = {}): CodexAuthSession =>
 })
 
 describe('ensureCodexAuthHome', () => {
-  it('creates the same app-owned home for legacy shared and isolated modes', async () => {
+  it('creates the same app-owned home with file-only credentials for both auth modes', async () => {
     const root = await mkdtemp(join(tmpdir(), 'codex-auth-home-'))
     try {
       await ensureCodexAuthHome('shared', root)
       expect(existsSync(codexSubscriptionStorageDir(root))).toBe(true)
+      expect(await readFile(join(codexSubscriptionStorageDir(root), 'config.toml'), 'utf8')).toBe(
+        'cli_auth_credentials_store = "file"\n'
+      )
 
       await rm(codexSubscriptionStorageDir(root), { recursive: true, force: true })
       await ensureCodexAuthHome('isolated', root)
       expect(existsSync(codexSubscriptionStorageDir(root))).toBe(true)
+      expect(await readFile(join(codexSubscriptionStorageDir(root), 'config.toml'), 'utf8')).toBe(
+        'cli_auth_credentials_store = "file"\n'
+      )
+    } finally {
+      await rm(root, { recursive: true, force: true })
+    }
+  })
+
+  it('replaces a global-capable credential store without changing other profile config', async () => {
+    const root = await mkdtemp(join(tmpdir(), 'codex-auth-home-'))
+    const home = codexSubscriptionStorageDir(root)
+    try {
+      await mkdir(home, { recursive: true })
+      await writeFile(
+        join(home, 'config.toml'),
+        [
+          'model = "account-default"',
+          'cli_auth_credentials_store = "auto"',
+          '',
+          '[model_providers.local]',
+          'base_url = "http://127.0.0.1:1087/v1"',
+          ''
+        ].join('\n')
+      )
+
+      await ensureCodexAuthHome('isolated', root)
+
+      expect(await readFile(join(home, 'config.toml'), 'utf8')).toBe(
+        [
+          'model = "account-default"',
+          '',
+          'cli_auth_credentials_store = "file"',
+          '[model_providers.local]',
+          'base_url = "http://127.0.0.1:1087/v1"',
+          ''
+        ].join('\n')
+      )
     } finally {
       await rm(root, { recursive: true, force: true })
     }

--- a/src/main/settings/codex-auth.test.ts
+++ b/src/main/settings/codex-auth.test.ts
@@ -123,14 +123,18 @@ describe('createCodexAuthEnvironment', () => {
           HTTP_PROXY: 'http://proxy.example.test:3128',
           HTTPS_PROXY: 'http://proxy.example.test:3128',
           http_proxy: 'http://proxy.example.test:3128',
-          https_proxy: 'http://proxy.example.test:3128'
+          https_proxy: 'http://proxy.example.test:3128',
+          NO_PROXY: 'localhost,127.0.0.1,::1',
+          no_proxy: 'localhost,127.0.0.1,::1'
         }
       )
     ).toMatchObject({
       HTTP_PROXY: 'http://proxy.example.test:3128',
       HTTPS_PROXY: 'http://proxy.example.test:3128',
       http_proxy: 'http://proxy.example.test:3128',
-      https_proxy: 'http://proxy.example.test:3128'
+      https_proxy: 'http://proxy.example.test:3128',
+      NO_PROXY: 'localhost,127.0.0.1,::1',
+      no_proxy: 'localhost,127.0.0.1,::1'
     })
   })
 })

--- a/src/main/settings/codex-auth.test.ts
+++ b/src/main/settings/codex-auth.test.ts
@@ -112,6 +112,27 @@ describe('createCodexAuthEnvironment', () => {
       CODEX_HOME: expect.stringMatching(/[\\/]data[\\/]codex-subscription$/)
     })
   })
+
+  it('applies the resolved system proxy to authentication sessions', () => {
+    expect(
+      createCodexAuthEnvironment(
+        'isolated',
+        '/data',
+        { PATH: 'bin' },
+        {
+          HTTP_PROXY: 'http://proxy.example.test:3128',
+          HTTPS_PROXY: 'http://proxy.example.test:3128',
+          http_proxy: 'http://proxy.example.test:3128',
+          https_proxy: 'http://proxy.example.test:3128'
+        }
+      )
+    ).toMatchObject({
+      HTTP_PROXY: 'http://proxy.example.test:3128',
+      HTTPS_PROXY: 'http://proxy.example.test:3128',
+      http_proxy: 'http://proxy.example.test:3128',
+      https_proxy: 'http://proxy.example.test:3128'
+    })
+  })
 })
 
 describe('importCodexAuthentication', () => {

--- a/src/main/settings/codex-auth.test.ts
+++ b/src/main/settings/codex-auth.test.ts
@@ -425,6 +425,72 @@ describe('importCodexAuthentication', () => {
       }
     }
   )
+
+  it.each(['http://localhost:1087/v1#', 'http://localhost:1087/v1?'])(
+    'does not import a loopback route with an empty URL delimiter at %s',
+    async (baseUrl) => {
+      const root = await mkdtemp(join(tmpdir(), 'codex-auth-empty-url-delimiter-reject-'))
+      const source = join(root, 'source')
+      const destination = join(root, 'destination')
+      try {
+        await mkdir(source, { recursive: true })
+        await writeFile(join(source, 'auth.json'), '{"tokens":{"access_token":"secret"}}')
+        await writeFile(
+          join(source, 'config.toml'),
+          [
+            'model_provider = "subscription-route"',
+            '',
+            '[model_providers.subscription-route]',
+            'name = "OpenAI"',
+            'requires_openai_auth = true',
+            'wire_api = "responses"',
+            `base_url = ${JSON.stringify(baseUrl)}`,
+            ''
+          ].join('\n')
+        )
+
+        await importCodexAuthentication(source, destination)
+
+        expect(existsSync(join(destination, 'config.toml'))).toBe(false)
+      } finally {
+        await rm(root, { recursive: true, force: true })
+      }
+    }
+  )
+
+  it.each(['["model_providers"."subscription-route"]', "['model_providers'.'subscription-route']"])(
+    'imports a compatible route with quoted TOML table keys: %s',
+    async (tableHeader) => {
+      const root = await mkdtemp(join(tmpdir(), 'codex-auth-quoted-route-import-'))
+      const source = join(root, 'source')
+      const destination = join(root, 'destination')
+      try {
+        await mkdir(source, { recursive: true })
+        await writeFile(join(source, 'auth.json'), '{"tokens":{"access_token":"secret"}}')
+        await writeFile(
+          join(source, 'config.toml'),
+          [
+            'model_provider = "subscription-route"',
+            '',
+            tableHeader,
+            'name = "OpenAI"',
+            'requires_openai_auth = true',
+            'wire_api = "responses"',
+            'base_url = "http://127.0.0.1:1087/v1"',
+            ''
+          ].join('\n')
+        )
+
+        await importCodexAuthentication(source, destination)
+
+        await expect(readFile(join(destination, 'config.toml'), 'utf8')).resolves.toContain(
+          'base_url = "http://127.0.0.1:1087/v1"'
+        )
+      } finally {
+        await rm(root, { recursive: true, force: true })
+      }
+    }
+  )
 })
 
 describe('CodexAuthController', () => {
@@ -647,6 +713,36 @@ describe('CodexAuthController', () => {
       message: 'Codex sign-in was cancelled.'
     })
     expect(vi.mocked(isolated.close)).toHaveBeenCalledOnce()
+  })
+
+  it('waits for a cancelled isolated session to close completely', async () => {
+    let finishClose!: () => void
+    const closeGate = new Promise<void>((resolve) => {
+      finishClose = resolve
+    })
+    const isolated = session({
+      status: vi.fn().mockResolvedValue({ type: 'unauthenticated' }),
+      authenticateChatGpt: vi.fn(() => new Promise<void>(() => undefined)),
+      close: vi.fn(() => closeGate)
+    })
+    const controller = new CodexAuthController({
+      openSession: vi.fn().mockResolvedValue(isolated),
+      loginTimeoutMs: 60_000
+    })
+
+    const pending = controller.loginIsolated()
+    await vi.waitFor(() => expect(isolated.authenticateChatGpt).toHaveBeenCalledOnce())
+    let cancellationSettled = false
+    const cancellation = Promise.resolve(controller.cancelLogin()).then(() => {
+      cancellationSettled = true
+    })
+    await vi.waitFor(() => expect(isolated.close).toHaveBeenCalledOnce())
+    await Promise.resolve()
+
+    expect(cancellationSettled).toBe(false)
+    finishClose()
+    await cancellation
+    await expect(pending).resolves.toMatchObject({ message: 'Codex sign-in was cancelled.' })
   })
 
   it('rejects a second concurrent sign-in without opening a second session', async () => {

--- a/src/main/settings/codex-auth.test.ts
+++ b/src/main/settings/codex-auth.test.ts
@@ -117,18 +117,18 @@ describe('importCodexAuthentication', () => {
       await writeFile(
         join(source, 'config.toml'),
         [
-          'model_provider = "subscription-route"',
+          '"model_provider" = "subscription-route"',
           'model = "private-model"',
           '',
           '[mcp_servers.private]',
           'command = "private-command"',
           '',
           '[model_providers.subscription-route]',
-          'name = "OpenAI"',
-          'requires_openai_auth = true',
-          'supports_websockets = false',
-          'wire_api = "responses"',
-          'base_url = "http://127.0.0.1:1087/v1"',
+          '"name" = "OpenAI"',
+          '"requires_openai_auth" = true',
+          "'supports_websockets' = false",
+          '"wire_api" = "responses"',
+          '"base_url" = "http://127.0.0.1:1087/v1"',
           'experimental_bearer_token = "must-not-be-copied"',
           ''
         ].join('\n')

--- a/src/main/settings/codex-auth.test.ts
+++ b/src/main/settings/codex-auth.test.ts
@@ -179,6 +179,38 @@ describe('importCodexAuthentication', () => {
       await rm(root, { recursive: true, force: true })
     }
   })
+
+  it.each(['https://proxy.example/v1', 'http://192.0.2.1/v1'])(
+    'does not send shared authentication to a non-loopback route at %s',
+    async (baseUrl) => {
+      const root = await mkdtemp(join(tmpdir(), 'codex-auth-remote-route-reject-'))
+      const source = join(root, 'source')
+      const destination = join(root, 'destination')
+      try {
+        await mkdir(source, { recursive: true })
+        await writeFile(join(source, 'auth.json'), '{"tokens":{"access_token":"secret"}}')
+        await writeFile(
+          join(source, 'config.toml'),
+          [
+            'model_provider = "remote-route"',
+            '',
+            '[model_providers.remote-route]',
+            'name = "Remote"',
+            'requires_openai_auth = true',
+            'wire_api = "responses"',
+            `base_url = ${JSON.stringify(baseUrl)}`,
+            ''
+          ].join('\n')
+        )
+
+        await importCodexAuthentication(source, destination)
+
+        expect(existsSync(join(destination, 'config.toml'))).toBe(false)
+      } finally {
+        await rm(root, { recursive: true, force: true })
+      }
+    }
+  )
 })
 
 describe('CodexAuthController', () => {

--- a/src/main/settings/codex-auth.ts
+++ b/src/main/settings/codex-auth.ts
@@ -91,6 +91,11 @@ const parseTomlString = (literal: string): string | undefined => {
 const parseTomlKey = (literal: string): string | undefined =>
   /^[A-Za-z0-9_-]+$/.test(literal) ? literal : parseTomlString(literal)
 
+const parseTomlAssignmentKey = (line: string): string | undefined => {
+  const match = line.match(/^\s*("(?:\\.|[^"\\])*"|'[^']*'|[A-Za-z0-9_-]+)(?:\s*\.|\s*=)/)
+  return match ? parseTomlKey(match[1]) : undefined
+}
+
 const parseTomlScalarAssignment = (
   line: string
 ): { key: string; value: TomlScalar } | undefined => {
@@ -146,6 +151,17 @@ const isLoopbackHostname = (hostname: string): boolean => {
     : ipVersion === 6 && unwrappedHostname === '::1'
 }
 
+// These provider fields can carry credentials or make the route depend on values that the isolated
+// profile deliberately does not copy. Reject the whole route instead of persisting a sanitized but
+// unusable endpoint. Scalar retry/timing options remain safe to omit.
+const UNSAFE_IMPORTED_ROUTE_KEYS = new Set([
+  'env_key',
+  'experimental_bearer_token',
+  'http_headers',
+  'env_http_headers',
+  'query_params'
+])
+
 // Import only the active provider's non-secret route. This preserves a working local Codex network
 // path (for example a loopback proxy endpoint) without copying models, MCP servers, hooks,
 // headers, bearer tokens, or any other user configuration into the app-owned profile.
@@ -173,10 +189,20 @@ const extractCodexProviderRoute = (configToml: string): ImportedCodexProviderRou
 
   for (const line of lines) {
     if (/^\s*\[/.test(line)) {
-      inActiveProviderTable = parseModelProviderTableId(line) === activeProviderId
+      const providerTableId = parseModelProviderTableId(line)
+      const providerTableRootId = parseModelProviderTableRootId(line)
+      // Nested provider tables are not serialized into the app-owned profile and commonly carry
+      // headers/query parameters. Treat any nested dependency on the active route as incompatible.
+      if (providerTableRootId === activeProviderId && providerTableId !== activeProviderId) {
+        return undefined
+      }
+      inActiveProviderTable = providerTableId === activeProviderId
       continue
     }
     if (!inActiveProviderTable) continue
+
+    const assignmentKey = parseTomlAssignmentKey(line)
+    if (assignmentKey && UNSAFE_IMPORTED_ROUTE_KEYS.has(assignmentKey)) return undefined
 
     const assignment = parseTomlScalarAssignment(line)
     if (!assignment) continue

--- a/src/main/settings/codex-auth.ts
+++ b/src/main/settings/codex-auth.ts
@@ -60,6 +60,160 @@ const CODEX_ENV_KEYS = [
   'NO_BROWSER'
 ] as const
 
+type ImportedCodexProviderRoute = {
+  id: string
+  name: string
+  baseUrl: string
+  supportsWebsockets?: boolean
+}
+
+type TomlScalar = string | boolean
+
+const parseTomlString = (literal: string): string | undefined => {
+  const trimmed = literal.trim()
+
+  if (trimmed.startsWith('"') && trimmed.endsWith('"')) {
+    try {
+      const parsed = JSON.parse(trimmed) as unknown
+      return typeof parsed === 'string' ? parsed : undefined
+    } catch {
+      return undefined
+    }
+  }
+
+  if (trimmed.startsWith("'") && trimmed.endsWith("'")) return trimmed.slice(1, -1)
+  return undefined
+}
+
+const parseTomlScalarAssignment = (
+  line: string
+): { key: string; value: TomlScalar } | undefined => {
+  const stringMatch = line.match(
+    /^\s*([A-Za-z0-9_-]+)\s*=\s*("(?:\\.|[^"\\])*"|'[^']*')\s*(?:#.*)?$/
+  )
+  if (stringMatch) {
+    const value = parseTomlString(stringMatch[2])
+    return value === undefined ? undefined : { key: stringMatch[1], value }
+  }
+
+  const booleanMatch = line.match(/^\s*([A-Za-z0-9_-]+)\s*=\s*(true|false)\s*(?:#.*)?$/)
+  if (!booleanMatch) return undefined
+
+  return { key: booleanMatch[1], value: booleanMatch[2] === 'true' }
+}
+
+const parseModelProviderTableId = (line: string): string | undefined => {
+  const match = line.match(
+    /^\s*\[\s*model_providers\s*\.\s*("(?:\\.|[^"\\])*"|'[^']*'|[A-Za-z0-9_-]+)\s*\]\s*(?:#.*)?$/
+  )
+  if (!match) return undefined
+
+  const key = match[1]
+  return /^[A-Za-z0-9_-]+$/.test(key) ? key : parseTomlString(key)
+}
+
+// Import only the active provider's non-secret route. This preserves a working local Codex network
+// path (for example a loopback cc-switch endpoint) without copying models, MCP servers, hooks,
+// headers, bearer tokens, or any other user configuration into the app-owned profile.
+const extractCodexProviderRoute = (configToml: string): ImportedCodexProviderRoute | undefined => {
+  const lines = configToml.split(/\r?\n/)
+  let activeProviderId: string | undefined
+
+  for (const line of lines) {
+    if (/^\s*\[/.test(line)) break
+    const assignment = parseTomlScalarAssignment(line)
+    if (assignment?.key === 'model_provider' && typeof assignment.value === 'string') {
+      activeProviderId = assignment.value
+      break
+    }
+  }
+
+  if (!activeProviderId || activeProviderId.length > 128) return undefined
+
+  let inActiveProviderTable = false
+  let name: string | undefined
+  let baseUrl: string | undefined
+  let wireApi: string | undefined
+  let requiresOpenAiAuth: boolean | undefined
+  let supportsWebsockets: boolean | undefined
+
+  for (const line of lines) {
+    if (/^\s*\[/.test(line)) {
+      inActiveProviderTable = parseModelProviderTableId(line) === activeProviderId
+      continue
+    }
+    if (!inActiveProviderTable) continue
+
+    const assignment = parseTomlScalarAssignment(line)
+    if (!assignment) continue
+
+    if (assignment.key === 'name' && typeof assignment.value === 'string') {
+      name = assignment.value
+    } else if (assignment.key === 'base_url' && typeof assignment.value === 'string') {
+      baseUrl = assignment.value
+    } else if (assignment.key === 'wire_api' && typeof assignment.value === 'string') {
+      wireApi = assignment.value
+    } else if (assignment.key === 'requires_openai_auth' && typeof assignment.value === 'boolean') {
+      requiresOpenAiAuth = assignment.value
+    } else if (assignment.key === 'supports_websockets' && typeof assignment.value === 'boolean') {
+      supportsWebsockets = assignment.value
+    }
+  }
+
+  if (!baseUrl || wireApi !== 'responses' || requiresOpenAiAuth !== true) return undefined
+
+  try {
+    const url = new URL(baseUrl)
+    if (
+      (url.protocol !== 'http:' && url.protocol !== 'https:') ||
+      url.username ||
+      url.password ||
+      url.search ||
+      url.hash
+    ) {
+      return undefined
+    }
+  } catch {
+    return undefined
+  }
+
+  return {
+    id: activeProviderId,
+    name: name?.trim() || activeProviderId,
+    baseUrl,
+    ...(supportsWebsockets === undefined ? {} : { supportsWebsockets })
+  }
+}
+
+const serializeCodexProviderRoute = (route: ImportedCodexProviderRoute): string =>
+  [
+    `model_provider = ${JSON.stringify(route.id)}`,
+    '',
+    `[model_providers.${JSON.stringify(route.id)}]`,
+    `name = ${JSON.stringify(route.name)}`,
+    `base_url = ${JSON.stringify(route.baseUrl)}`,
+    'wire_api = "responses"',
+    'requires_openai_auth = true',
+    ...(route.supportsWebsockets === undefined
+      ? []
+      : [`supports_websockets = ${String(route.supportsWebsockets)}`]),
+    ''
+  ].join('\n')
+
+const writePrivateFileAtomically = async (
+  destinationPath: string,
+  content: string
+): Promise<void> => {
+  const temporaryPath = `${destinationPath}.${randomUUID()}.tmp`
+  try {
+    await writeFile(temporaryPath, content, { encoding: 'utf8', flag: 'wx', mode: 0o600 })
+    await chmod(temporaryPath, 0o600)
+    await rename(temporaryPath, destinationPath)
+  } finally {
+    await rm(temporaryPath, { force: true }).catch(() => undefined)
+  }
+}
+
 export const createCodexAuthEnvironment = (
   _mode: CodexAuthMode,
   storageRoot: string,
@@ -71,14 +225,17 @@ export const createCodexAuthEnvironment = (
   return { ...env, CODEX_HOME: codexSubscriptionStorageDir(storageRoot) }
 }
 
-// Provider setup may import an existing login, but runtime isolation is strict: copy the credential
-// file only. Global config, Skills, sessions, memories, and hooks remain outside Open Science.
+// Provider setup imports an existing login plus the safe, non-secret subset of its active provider
+// route. Global model defaults, MCP servers, Skills, sessions, memories, hooks, and tokens embedded in
+// provider config remain outside Open Science.
 export const importCodexAuthentication = async (
   sourceHome: string,
   destinationHome: string
 ): Promise<void> => {
   const sourcePath = join(sourceHome, 'auth.json')
   const destinationPath = join(destinationHome, 'auth.json')
+  const sourceConfigPath = join(sourceHome, 'config.toml')
+  const destinationConfigPath = join(destinationHome, 'config.toml')
   let content: string
 
   try {
@@ -89,14 +246,22 @@ export const importCodexAuthentication = async (
     throw new Error('The selected Codex profile does not contain importable authentication.')
   }
 
-  await mkdir(destinationHome, { recursive: true })
-  const temporaryPath = `${destinationPath}.${randomUUID()}.tmp`
+  let providerRoute: ImportedCodexProviderRoute | undefined
   try {
-    await writeFile(temporaryPath, content, { encoding: 'utf8', flag: 'wx', mode: 0o600 })
-    await chmod(temporaryPath, 0o600)
-    await rename(temporaryPath, destinationPath)
-  } finally {
-    await rm(temporaryPath, { force: true }).catch(() => undefined)
+    providerRoute = extractCodexProviderRoute(await readFile(sourceConfigPath, 'utf8'))
+  } catch (error) {
+    if ((error as NodeJS.ErrnoException).code !== 'ENOENT') throw error
+  }
+
+  await mkdir(destinationHome, { recursive: true })
+  await writePrivateFileAtomically(destinationPath, content)
+  if (providerRoute) {
+    await writePrivateFileAtomically(
+      destinationConfigPath,
+      serializeCodexProviderRoute(providerRoute)
+    )
+  } else {
+    await rm(destinationConfigPath, { force: true })
   }
 }
 

--- a/src/main/settings/codex-auth.ts
+++ b/src/main/settings/codex-auth.ts
@@ -424,15 +424,15 @@ export const createCodexAuthEnvironment = (
   _mode: CodexAuthMode,
   storageRoot: string,
   sourceEnv: NodeJS.ProcessEnv = process.env,
-  proxyEnv: SystemProxyEnvironment = {}
+  proxyEnv?: SystemProxyEnvironment
 ): NodeJS.ProcessEnv => {
   const env = augmentedPathEnv(sourceEnv)
   for (const key of CODEX_ENV_KEYS) delete env[key]
-  clearSystemProxyEnvironment(env)
+  if (proxyEnv !== undefined) clearSystemProxyEnvironment(env)
 
   return {
     ...env,
-    ...proxyEnv,
+    ...(proxyEnv ?? {}),
     CODEX_HOME: codexSubscriptionStorageDir(storageRoot)
   }
 }

--- a/src/main/settings/codex-auth.ts
+++ b/src/main/settings/codex-auth.ts
@@ -10,7 +10,7 @@ import * as acp from '@agentclientprotocol/sdk'
 import { codexSubscriptionStorageDir } from '../agent-framework/codex'
 import { terminateProcessTree } from '../process-tree'
 import { augmentedPathEnv } from './shell-path'
-import type { SystemProxyEnvironment } from './system-proxy'
+import { clearSystemProxyEnvironment, type SystemProxyEnvironment } from './system-proxy'
 
 export type CodexAuthMode = 'shared' | 'isolated'
 
@@ -428,6 +428,7 @@ export const createCodexAuthEnvironment = (
 ): NodeJS.ProcessEnv => {
   const env = augmentedPathEnv(sourceEnv)
   for (const key of CODEX_ENV_KEYS) delete env[key]
+  clearSystemProxyEnvironment(env)
 
   return {
     ...env,

--- a/src/main/settings/codex-auth.ts
+++ b/src/main/settings/codex-auth.ts
@@ -86,21 +86,28 @@ const parseTomlString = (literal: string): string | undefined => {
   return undefined
 }
 
+const parseTomlKey = (literal: string): string | undefined =>
+  /^[A-Za-z0-9_-]+$/.test(literal) ? literal : parseTomlString(literal)
+
 const parseTomlScalarAssignment = (
   line: string
 ): { key: string; value: TomlScalar } | undefined => {
   const stringMatch = line.match(
-    /^\s*([A-Za-z0-9_-]+)\s*=\s*("(?:\\.|[^"\\])*"|'[^']*')\s*(?:#.*)?$/
+    /^\s*("(?:\\.|[^"\\])*"|'[^']*'|[A-Za-z0-9_-]+)\s*=\s*("(?:\\.|[^"\\])*"|'[^']*')\s*(?:#.*)?$/
   )
   if (stringMatch) {
+    const key = parseTomlKey(stringMatch[1])
     const value = parseTomlString(stringMatch[2])
-    return value === undefined ? undefined : { key: stringMatch[1], value }
+    return key === undefined || value === undefined ? undefined : { key, value }
   }
 
-  const booleanMatch = line.match(/^\s*([A-Za-z0-9_-]+)\s*=\s*(true|false)\s*(?:#.*)?$/)
+  const booleanMatch = line.match(
+    /^\s*("(?:\\.|[^"\\])*"|'[^']*'|[A-Za-z0-9_-]+)\s*=\s*(true|false)\s*(?:#.*)?$/
+  )
   if (!booleanMatch) return undefined
 
-  return { key: booleanMatch[1], value: booleanMatch[2] === 'true' }
+  const key = parseTomlKey(booleanMatch[1])
+  return key === undefined ? undefined : { key, value: booleanMatch[2] === 'true' }
 }
 
 const parseModelProviderTableId = (line: string): string | undefined => {

--- a/src/main/settings/codex-auth.ts
+++ b/src/main/settings/codex-auth.ts
@@ -10,6 +10,7 @@ import * as acp from '@agentclientprotocol/sdk'
 import { codexSubscriptionStorageDir } from '../agent-framework/codex'
 import { terminateProcessTree } from '../process-tree'
 import { augmentedPathEnv } from './shell-path'
+import type { SystemProxyEnvironment } from './system-proxy'
 
 export type CodexAuthMode = 'shared' | 'isolated'
 
@@ -39,6 +40,7 @@ export type CodexAuthLaunch = {
   nativePath?: string
   mode: CodexAuthMode
   storageRoot: string
+  proxyEnv?: SystemProxyEnvironment
 }
 
 type CodexAuthControllerOptions = {
@@ -421,12 +423,17 @@ const writePrivateFileAtomically = async (
 export const createCodexAuthEnvironment = (
   _mode: CodexAuthMode,
   storageRoot: string,
-  sourceEnv: NodeJS.ProcessEnv = process.env
+  sourceEnv: NodeJS.ProcessEnv = process.env,
+  proxyEnv: SystemProxyEnvironment = {}
 ): NodeJS.ProcessEnv => {
   const env = augmentedPathEnv(sourceEnv)
   for (const key of CODEX_ENV_KEYS) delete env[key]
 
-  return { ...env, CODEX_HOME: codexSubscriptionStorageDir(storageRoot) }
+  return {
+    ...env,
+    ...proxyEnv,
+    CODEX_HOME: codexSubscriptionStorageDir(storageRoot)
+  }
 }
 
 // Provider setup imports an existing login plus the safe, non-secret subset of its active provider
@@ -746,7 +753,8 @@ export const openCodexAuthSession = async ({
   adapterPath,
   nativePath,
   mode,
-  storageRoot
+  storageRoot,
+  proxyEnv
 }: CodexAuthLaunch): Promise<CodexAuthSession> => {
   await ensureCodexAuthHome(mode, storageRoot)
 
@@ -754,7 +762,7 @@ export const openCodexAuthSession = async ({
   const needsShell = process.platform === 'win32' && /\.(cmd|bat)$/i.test(adapterPath)
   const command = isJavaScript ? process.execPath : needsShell ? `"${adapterPath}"` : adapterPath
   const args = isJavaScript ? [adapterPath] : []
-  const env = createCodexAuthEnvironment(mode, storageRoot)
+  const env = createCodexAuthEnvironment(mode, storageRoot, process.env, proxyEnv)
   if (isJavaScript) env.ELECTRON_RUN_AS_NODE = '1'
   if (nativePath) env.CODEX_PATH = nativePath
 

--- a/src/main/settings/codex-auth.ts
+++ b/src/main/settings/codex-auth.ts
@@ -113,6 +113,19 @@ const parseModelProviderTableId = (line: string): string | undefined => {
   return /^[A-Za-z0-9_-]+$/.test(key) ? key : parseTomlString(key)
 }
 
+const parseModelProviderTableRootId = (line: string): string | undefined => {
+  const match = line.match(
+    /^\s*\[\s*model_providers\s*\.\s*("(?:\\.|[^"\\])*"|'[^']*'|[A-Za-z0-9_-]+)(?:\s*\.|\s*\])/
+  )
+  if (!match) return undefined
+
+  const key = match[1]
+  return /^[A-Za-z0-9_-]+$/.test(key) ? key : parseTomlString(key)
+}
+
+const isModelProviderAssignment = (line: string): boolean =>
+  /^\s*(?:model_provider|"model_provider"|'model_provider')\s*=/.test(line)
+
 const isLoopbackHostname = (hostname: string): boolean => {
   const unwrappedHostname =
     hostname.startsWith('[') && hostname.endsWith(']') ? hostname.slice(1, -1) : hostname
@@ -217,8 +230,9 @@ const IMPORTED_ROUTE_SELECTION_BEGIN = '# Open Science: begin imported Codex rou
 const IMPORTED_ROUTE_SELECTION_END = '# Open Science: end imported Codex route selection'
 const IMPORTED_ROUTE_PROVIDER_BEGIN = '# Open Science: begin imported Codex provider'
 const IMPORTED_ROUTE_PROVIDER_END = '# Open Science: end imported Codex provider'
+const IMPORTED_ROUTE_PRESERVED_LINE = '# Open Science: preserved Codex config '
 
-const removeCompleteMarkedBlock = (lines: string[], begin: string, end: string): string[] => {
+const restoreCompleteMarkedBlock = (lines: string[], begin: string, end: string): string[] => {
   const result = [...lines]
   let beginIndex = result.indexOf(begin)
 
@@ -226,27 +240,44 @@ const removeCompleteMarkedBlock = (lines: string[], begin: string, end: string):
     const relativeEndIndex = result.slice(beginIndex + 1).indexOf(end)
     if (relativeEndIndex < 0) break
 
-    result.splice(beginIndex, relativeEndIndex + 2)
+    const endIndex = beginIndex + relativeEndIndex + 1
+    const preservedLines = result.slice(beginIndex + 1, endIndex).flatMap((line) => {
+      if (!line.startsWith(IMPORTED_ROUTE_PRESERVED_LINE)) return []
+      try {
+        const preservedLine = JSON.parse(
+          line.slice(IMPORTED_ROUTE_PRESERVED_LINE.length)
+        ) as unknown
+        return typeof preservedLine === 'string' ? [preservedLine] : []
+      } catch {
+        return []
+      }
+    })
+    result.splice(beginIndex, relativeEndIndex + 2, ...preservedLines)
     beginIndex = result.indexOf(begin)
   }
 
   return result
 }
 
+const hasCompleteMarkedBlock = (lines: string[], begin: string, end: string): boolean => {
+  const beginIndex = lines.indexOf(begin)
+  return beginIndex >= 0 && lines.slice(beginIndex + 1).includes(end)
+}
+
 const removeImportedCodexProviderRoute = (configToml: string): string => {
-  const withoutMarkedBlocks = removeCompleteMarkedBlock(
-    removeCompleteMarkedBlock(
-      configToml.split(/\r?\n/),
-      IMPORTED_ROUTE_SELECTION_BEGIN,
-      IMPORTED_ROUTE_SELECTION_END
-    ),
+  const lines = configToml.split(/\r?\n/)
+  const hasMarkedRoute =
+    hasCompleteMarkedBlock(lines, IMPORTED_ROUTE_SELECTION_BEGIN, IMPORTED_ROUTE_SELECTION_END) ||
+    hasCompleteMarkedBlock(lines, IMPORTED_ROUTE_PROVIDER_BEGIN, IMPORTED_ROUTE_PROVIDER_END)
+  const withoutMarkedBlocks = restoreCompleteMarkedBlock(
+    restoreCompleteMarkedBlock(lines, IMPORTED_ROUTE_SELECTION_BEGIN, IMPORTED_ROUTE_SELECTION_END),
     IMPORTED_ROUTE_PROVIDER_BEGIN,
     IMPORTED_ROUTE_PROVIDER_END
   ).join('\n')
 
   // Builds produced before route markers wrote only the sanitized route. Recognize that exact shape
   // so switching modes can clean it up without ever treating a mixed, user-authored config as ours.
-  const legacyRoute = extractCodexProviderRoute(withoutMarkedBlocks)
+  const legacyRoute = hasMarkedRoute ? undefined : extractCodexProviderRoute(withoutMarkedBlocks)
   if (
     legacyRoute &&
     withoutMarkedBlocks.trim() === serializeLegacyCodexProviderRoute(legacyRoute).trim()
@@ -257,11 +288,51 @@ const removeImportedCodexProviderRoute = (configToml: string): string => {
   return withoutMarkedBlocks
 }
 
+const removeConflictingCodexProviderRoute = (
+  lines: string[],
+  providerId: string
+): { lines: string[]; selection: string[]; provider: string[] } => {
+  const result: string[] = []
+  const selection: string[] = []
+  const provider: string[] = []
+  let inTopLevel = true
+  let inConflictingProviderTable = false
+
+  for (const line of lines) {
+    if (/^\s*\[/.test(line)) {
+      inTopLevel = false
+      inConflictingProviderTable = parseModelProviderTableRootId(line) === providerId
+      if (inConflictingProviderTable) {
+        provider.push(line)
+        continue
+      }
+    } else if (inConflictingProviderTable) {
+      provider.push(line)
+      continue
+    }
+
+    if (inTopLevel && isModelProviderAssignment(line)) {
+      selection.push(line)
+      continue
+    }
+    result.push(line)
+  }
+
+  return { lines: result, selection, provider }
+}
+
+const serializePreservedConfigLines = (lines: string[]): string[] =>
+  lines.map((line) => `${IMPORTED_ROUTE_PRESERVED_LINE}${JSON.stringify(line)}`)
+
 const serializeImportedCodexProviderRoute = (
   route: ImportedCodexProviderRoute,
   existingConfigToml: string
 ): string => {
-  const baseLines = removeImportedCodexProviderRoute(existingConfigToml).split(/\r?\n/)
+  const conflictingRoute = removeConflictingCodexProviderRoute(
+    removeImportedCodexProviderRoute(existingConfigToml).split(/\r?\n/),
+    route.id
+  )
+  const baseLines = conflictingRoute.lines
   while (baseLines.at(-1) === '') baseLines.pop()
 
   const firstTableIndex = baseLines.findIndex((line) => /^\s*\[/.test(line))
@@ -270,11 +341,13 @@ const serializeImportedCodexProviderRoute = (
     selectionIndex,
     0,
     IMPORTED_ROUTE_SELECTION_BEGIN,
+    ...serializePreservedConfigLines(conflictingRoute.selection),
     `model_provider = ${JSON.stringify(route.id)}`,
     IMPORTED_ROUTE_SELECTION_END
   )
   baseLines.push(
     IMPORTED_ROUTE_PROVIDER_BEGIN,
+    ...serializePreservedConfigLines(conflictingRoute.provider),
     `[model_providers.${JSON.stringify(route.id)}]`,
     `name = ${JSON.stringify(route.name)}`,
     `base_url = ${JSON.stringify(route.baseUrl)}`,

--- a/src/main/settings/codex-auth.ts
+++ b/src/main/settings/codex-auth.ts
@@ -119,7 +119,7 @@ const parseTomlScalarAssignment = (
 
 const parseModelProviderTableId = (line: string): string | undefined => {
   const match = line.match(
-    /^\s*\[\s*model_providers\s*\.\s*("(?:\\.|[^"\\])*"|'[^']*'|[A-Za-z0-9_-]+)\s*\]\s*(?:#.*)?$/
+    /^\s*\[\s*(?:model_providers|"model_providers"|'model_providers')\s*\.\s*("(?:\\.|[^"\\])*"|'[^']*'|[A-Za-z0-9_-]+)\s*\]\s*(?:#.*)?$/
   )
   if (!match) return undefined
 
@@ -129,7 +129,7 @@ const parseModelProviderTableId = (line: string): string | undefined => {
 
 const parseModelProviderTableRootId = (line: string): string | undefined => {
   const match = line.match(
-    /^\s*\[\s*model_providers\s*\.\s*("(?:\\.|[^"\\])*"|'[^']*'|[A-Za-z0-9_-]+)(?:\s*\.|\s*\])/
+    /^\s*\[\s*(?:model_providers|"model_providers"|'model_providers')\s*\.\s*("(?:\\.|[^"\\])*"|'[^']*'|[A-Za-z0-9_-]+)(?:\s*\.|\s*\])/
   )
   if (!match) return undefined
 
@@ -221,6 +221,10 @@ const extractCodexProviderRoute = (configToml: string): ImportedCodexProviderRou
   }
 
   if (!baseUrl || wireApi !== 'responses' || requiresOpenAiAuth !== true) return undefined
+
+  // WHATWG URL normalizes an empty trailing query or fragment away, so inspect the raw value as
+  // well. Imported routes never need either delimiter, even when no query/hash content follows it.
+  if (baseUrl.includes('?') || baseUrl.includes('#')) return undefined
 
   try {
     const url = new URL(baseUrl)
@@ -589,7 +593,7 @@ export class CodexAuthController {
   private readonly openSession: (mode: CodexAuthMode) => Promise<CodexAuthSession>
   private readonly loginTimeoutMs: number
   private readonly statusTimeoutMs: number
-  private activeLogin: AbortController | undefined
+  private activeLogin: { abort: AbortController; completion: Promise<void> } | undefined
 
   constructor(options: CodexAuthControllerOptions) {
     this.openSession = options.openSession
@@ -603,14 +607,13 @@ export class CodexAuthController {
   // abort, timeout, and teardown. The caller supplies the AbortController so it can register it
   // synchronously before any await (loginIsolated stores it in activeLogin, before this async helper
   // is even entered, so its re-entrancy guard cannot race); `onAborted` maps a timeout/cancel into a
-  // result, and `onSettled` runs in the finally for caller-side teardown (clearing activeLogin).
+  // result.
   private async withBoundedSession(
     mode: CodexAuthMode,
     timeoutMs: number,
     run: (session: CodexAuthSession, signal: AbortSignal) => Promise<CodexAuthStatus>,
     onAborted: (reason: unknown) => CodexAuthStatus,
-    abort: AbortController = new AbortController(),
-    onSettled?: () => void
+    abort: AbortController = new AbortController()
   ): Promise<CodexAuthStatus> {
     const timeout = setTimeout(() => abort.abort('timeout'), timeoutMs)
     let authSession: CodexAuthSession | undefined
@@ -629,7 +632,6 @@ export class CodexAuthController {
       throw error
     } finally {
       clearTimeout(timeout)
-      onSettled?.()
       await authSession?.close()
     }
   }
@@ -674,9 +676,16 @@ export class CodexAuthController {
 
     // Claim the in-progress slot synchronously, in the same tick as the guard above and before the
     // async helper is entered, so two rapid calls cannot both pass the guard and open two browser
-    // sign-ins. cancelLogin aborts this same controller; onSettled clears the slot on teardown.
+    // sign-ins. cancelLogin aborts this same controller and waits for the session teardown below.
     const abort = new AbortController()
-    this.activeLogin = abort
+    let finishCompletion!: () => void
+    const activeLogin = {
+      abort,
+      completion: new Promise<void>((resolve) => {
+        finishCompletion = resolve
+      })
+    }
+    this.activeLogin = activeLogin
 
     return this.withBoundedSession(
       'isolated',
@@ -707,15 +716,19 @@ export class CodexAuthController {
             ? 'Codex sign-in timed out after five minutes.'
             : 'Codex sign-in was cancelled.'
       }),
-      abort,
-      () => {
-        this.activeLogin = undefined
-      }
-    )
+      abort
+    ).finally(() => {
+      if (this.activeLogin === activeLogin) this.activeLogin = undefined
+      finishCompletion()
+    })
   }
 
-  cancelLogin(): void {
-    this.activeLogin?.abort('cancelled')
+  async cancelLogin(): Promise<void> {
+    const activeLogin = this.activeLogin
+    if (!activeLogin) return
+
+    activeLogin.abort.abort('cancelled')
+    await activeLogin.completion
   }
 
   async logoutIsolated(): Promise<CodexAuthStatus> {

--- a/src/main/settings/codex-auth.ts
+++ b/src/main/settings/codex-auth.ts
@@ -198,7 +198,7 @@ const extractCodexProviderRoute = (configToml: string): ImportedCodexProviderRou
   }
 }
 
-const serializeCodexProviderRoute = (route: ImportedCodexProviderRoute): string =>
+const serializeLegacyCodexProviderRoute = (route: ImportedCodexProviderRoute): string =>
   [
     `model_provider = ${JSON.stringify(route.id)}`,
     '',
@@ -212,6 +212,83 @@ const serializeCodexProviderRoute = (route: ImportedCodexProviderRoute): string 
       : [`supports_websockets = ${String(route.supportsWebsockets)}`]),
     ''
   ].join('\n')
+
+const IMPORTED_ROUTE_SELECTION_BEGIN = '# Open Science: begin imported Codex route selection'
+const IMPORTED_ROUTE_SELECTION_END = '# Open Science: end imported Codex route selection'
+const IMPORTED_ROUTE_PROVIDER_BEGIN = '# Open Science: begin imported Codex provider'
+const IMPORTED_ROUTE_PROVIDER_END = '# Open Science: end imported Codex provider'
+
+const removeCompleteMarkedBlock = (lines: string[], begin: string, end: string): string[] => {
+  const result = [...lines]
+  let beginIndex = result.indexOf(begin)
+
+  while (beginIndex >= 0) {
+    const relativeEndIndex = result.slice(beginIndex + 1).indexOf(end)
+    if (relativeEndIndex < 0) break
+
+    result.splice(beginIndex, relativeEndIndex + 2)
+    beginIndex = result.indexOf(begin)
+  }
+
+  return result
+}
+
+const removeImportedCodexProviderRoute = (configToml: string): string => {
+  const withoutMarkedBlocks = removeCompleteMarkedBlock(
+    removeCompleteMarkedBlock(
+      configToml.split(/\r?\n/),
+      IMPORTED_ROUTE_SELECTION_BEGIN,
+      IMPORTED_ROUTE_SELECTION_END
+    ),
+    IMPORTED_ROUTE_PROVIDER_BEGIN,
+    IMPORTED_ROUTE_PROVIDER_END
+  ).join('\n')
+
+  // Builds produced before route markers wrote only the sanitized route. Recognize that exact shape
+  // so switching modes can clean it up without ever treating a mixed, user-authored config as ours.
+  const legacyRoute = extractCodexProviderRoute(withoutMarkedBlocks)
+  if (
+    legacyRoute &&
+    withoutMarkedBlocks.trim() === serializeLegacyCodexProviderRoute(legacyRoute).trim()
+  ) {
+    return ''
+  }
+
+  return withoutMarkedBlocks
+}
+
+const serializeImportedCodexProviderRoute = (
+  route: ImportedCodexProviderRoute,
+  existingConfigToml: string
+): string => {
+  const baseLines = removeImportedCodexProviderRoute(existingConfigToml).split(/\r?\n/)
+  while (baseLines.at(-1) === '') baseLines.pop()
+
+  const firstTableIndex = baseLines.findIndex((line) => /^\s*\[/.test(line))
+  const selectionIndex = firstTableIndex < 0 ? baseLines.length : firstTableIndex
+  baseLines.splice(
+    selectionIndex,
+    0,
+    IMPORTED_ROUTE_SELECTION_BEGIN,
+    `model_provider = ${JSON.stringify(route.id)}`,
+    IMPORTED_ROUTE_SELECTION_END
+  )
+  baseLines.push(
+    IMPORTED_ROUTE_PROVIDER_BEGIN,
+    `[model_providers.${JSON.stringify(route.id)}]`,
+    `name = ${JSON.stringify(route.name)}`,
+    `base_url = ${JSON.stringify(route.baseUrl)}`,
+    'wire_api = "responses"',
+    'requires_openai_auth = true',
+    ...(route.supportsWebsockets === undefined
+      ? []
+      : [`supports_websockets = ${String(route.supportsWebsockets)}`]),
+    IMPORTED_ROUTE_PROVIDER_END,
+    ''
+  )
+
+  return baseLines.join('\n')
+}
 
 const writePrivateFileAtomically = async (
   destinationPath: string,
@@ -269,9 +346,15 @@ export const importCodexAuthentication = async (
   await mkdir(destinationHome, { recursive: true })
   await writePrivateFileAtomically(destinationPath, content)
   if (providerRoute) {
+    let existingConfigToml = ''
+    try {
+      existingConfigToml = await readFile(destinationConfigPath, 'utf8')
+    } catch (error) {
+      if ((error as NodeJS.ErrnoException).code !== 'ENOENT') throw error
+    }
     await writePrivateFileAtomically(
       destinationConfigPath,
-      serializeCodexProviderRoute(providerRoute)
+      serializeImportedCodexProviderRoute(providerRoute, existingConfigToml)
     )
   } else {
     await clearImportedCodexProviderRoute(destinationHome)
@@ -279,7 +362,24 @@ export const importCodexAuthentication = async (
 }
 
 export const clearImportedCodexProviderRoute = async (destinationHome: string): Promise<void> => {
-  await rm(join(destinationHome, 'config.toml'), { force: true })
+  const destinationConfigPath = join(destinationHome, 'config.toml')
+  let existingConfigToml: string
+
+  try {
+    existingConfigToml = await readFile(destinationConfigPath, 'utf8')
+  } catch (error) {
+    if ((error as NodeJS.ErrnoException).code === 'ENOENT') return
+    throw error
+  }
+
+  const cleanedConfigToml = removeImportedCodexProviderRoute(existingConfigToml)
+  if (cleanedConfigToml === existingConfigToml) return
+
+  if (cleanedConfigToml.trim()) {
+    await writePrivateFileAtomically(destinationConfigPath, cleanedConfigToml)
+  } else {
+    await rm(destinationConfigPath, { force: true })
+  }
 }
 
 const abortError = (message: string): Error => {

--- a/src/main/settings/codex-auth.ts
+++ b/src/main/settings/codex-auth.ts
@@ -1,6 +1,7 @@
 import { spawn } from 'node:child_process'
 import { randomUUID } from 'node:crypto'
 import { chmod, mkdir, readFile, rename, rm, writeFile } from 'node:fs/promises'
+import { isIP } from 'node:net'
 import { join } from 'node:path'
 import { Readable, Writable } from 'node:stream'
 
@@ -112,8 +113,19 @@ const parseModelProviderTableId = (line: string): string | undefined => {
   return /^[A-Za-z0-9_-]+$/.test(key) ? key : parseTomlString(key)
 }
 
+const isLoopbackHostname = (hostname: string): boolean => {
+  const unwrappedHostname =
+    hostname.startsWith('[') && hostname.endsWith(']') ? hostname.slice(1, -1) : hostname
+  if (unwrappedHostname === 'localhost') return true
+
+  const ipVersion = isIP(unwrappedHostname)
+  return ipVersion === 4
+    ? unwrappedHostname.startsWith('127.')
+    : ipVersion === 6 && unwrappedHostname === '::1'
+}
+
 // Import only the active provider's non-secret route. This preserves a working local Codex network
-// path (for example a loopback cc-switch endpoint) without copying models, MCP servers, hooks,
+// path (for example a loopback proxy endpoint) without copying models, MCP servers, hooks,
 // headers, bearer tokens, or any other user configuration into the app-owned profile.
 const extractCodexProviderRoute = (configToml: string): ImportedCodexProviderRoute | undefined => {
   const lines = configToml.split(/\r?\n/)
@@ -166,6 +178,7 @@ const extractCodexProviderRoute = (configToml: string): ImportedCodexProviderRou
     const url = new URL(baseUrl)
     if (
       (url.protocol !== 'http:' && url.protocol !== 'https:') ||
+      !isLoopbackHostname(url.hostname) ||
       url.username ||
       url.password ||
       url.search ||
@@ -261,8 +274,12 @@ export const importCodexAuthentication = async (
       serializeCodexProviderRoute(providerRoute)
     )
   } else {
-    await rm(destinationConfigPath, { force: true })
+    await clearImportedCodexProviderRoute(destinationHome)
   }
+}
+
+export const clearImportedCodexProviderRoute = async (destinationHome: string): Promise<void> => {
+  await rm(join(destinationHome, 'config.toml'), { force: true })
 }
 
 const abortError = (message: string): Error => {

--- a/src/main/settings/codex-auth.ts
+++ b/src/main/settings/codex-auth.ts
@@ -238,6 +238,40 @@ const IMPORTED_ROUTE_SELECTION_END = '# Open Science: end imported Codex route s
 const IMPORTED_ROUTE_PROVIDER_BEGIN = '# Open Science: begin imported Codex provider'
 const IMPORTED_ROUTE_PROVIDER_END = '# Open Science: end imported Codex provider'
 const IMPORTED_ROUTE_PRESERVED_LINE = '# Open Science: preserved Codex config '
+const CODEX_FILE_CREDENTIAL_STORE = 'cli_auth_credentials_store = "file"'
+
+const isCodexCredentialStoreAssignment = (line: string): boolean =>
+  /^\s*(?:cli_auth_credentials_store|"cli_auth_credentials_store"|'cli_auth_credentials_store')\s*=/.test(
+    line
+  )
+
+// CODEX_HOME isolates file-backed auth.json, but the default/auto store can still select the
+// process-wide OS keyring. Pin subscription profiles to file storage so status, login, and logout
+// cannot observe or mutate the user's global Codex CLI credential.
+const serializeCodexFileCredentialStore = (existingConfigToml: string): string => {
+  const lines = existingConfigToml.split(/\r?\n/)
+  const result: string[] = []
+  let inTopLevel = true
+
+  for (const line of lines) {
+    if (/^\s*\[/.test(line)) inTopLevel = false
+    if (inTopLevel && isCodexCredentialStoreAssignment(line)) continue
+    result.push(line)
+  }
+
+  while (result.at(-1) === '') result.pop()
+  const firstOwnedMarkerIndex = result.findIndex(
+    (line) => line === IMPORTED_ROUTE_SELECTION_BEGIN || line === IMPORTED_ROUTE_PROVIDER_BEGIN
+  )
+  const firstTableIndex = result.findIndex((line) => /^\s*\[/.test(line))
+  const insertionCandidates = [firstOwnedMarkerIndex, firstTableIndex].filter((index) => index >= 0)
+  const insertionIndex =
+    insertionCandidates.length > 0 ? Math.min(...insertionCandidates) : result.length
+  result.splice(insertionIndex, 0, CODEX_FILE_CREDENTIAL_STORE)
+  result.push('')
+
+  return result.join('\n')
+}
 
 const restoreCompleteMarkedBlock = (lines: string[], begin: string, end: string): string[] => {
   const result = [...lines]
@@ -462,6 +496,13 @@ export const clearImportedCodexProviderRoute = async (destinationHome: string): 
   }
 }
 
+// Switching away from an imported profile must discard the copied credential without invoking
+// Codex logout. Logging out a copied token can revoke the same session still used by the user's
+// global CLI profile; unlinking only the app-owned copy preserves that external login.
+export const clearAppOwnedCodexAuthentication = async (destinationHome: string): Promise<void> => {
+  await rm(join(destinationHome, 'auth.json'), { force: true })
+}
+
 const abortError = (message: string): Error => {
   const error = new Error(message)
   error.name = 'AbortError'
@@ -684,7 +725,21 @@ export const ensureCodexAuthHome = async (
   _mode: CodexAuthMode,
   storageRoot: string
 ): Promise<void> => {
-  await mkdir(codexSubscriptionStorageDir(storageRoot), { recursive: true })
+  const codexHome = codexSubscriptionStorageDir(storageRoot)
+  const configPath = join(codexHome, 'config.toml')
+  await mkdir(codexHome, { recursive: true })
+
+  let existingConfigToml = ''
+  try {
+    existingConfigToml = await readFile(configPath, 'utf8')
+  } catch (error) {
+    if ((error as NodeJS.ErrnoException).code !== 'ENOENT') throw error
+  }
+
+  const nextConfigToml = serializeCodexFileCredentialStore(existingConfigToml)
+  if (nextConfigToml !== existingConfigToml) {
+    await writePrivateFileAtomically(configPath, nextConfigToml)
+  }
 }
 
 export const openCodexAuthSession = async ({

--- a/src/main/settings/ipc.test.ts
+++ b/src/main/settings/ipc.test.ts
@@ -257,16 +257,13 @@ describe('settings IPC handlers', () => {
     expect(onActiveProviderChanged).toHaveBeenCalledOnce()
   })
 
-  it('does not reconnect when isolated logout times out', async () => {
-    // Reconnecting when the sign-out timed out would re-authenticate with the credential that is
-    // still in place — the opposite of what the user intended. Skip the reconnect so the live
-    // agent keeps its existing session until a retry clears the credential.
+  it('does not reconnect when app-owned isolated logout fails', async () => {
     handlers.clear()
     const service = createFakeService()
     service.logoutIsolatedCodex.mockResolvedValue({
       ok: false,
-      category: 'timeout',
-      message: 'Codex sign-out timed out.'
+      category: 'unknown',
+      message: 'The Open Science Codex login could not be removed.'
     })
     const onActiveProviderChanged = vi.fn()
     registerSettingsIpcHandlers({

--- a/src/main/settings/ipc.test.ts
+++ b/src/main/settings/ipc.test.ts
@@ -289,20 +289,34 @@ describe('settings IPC handlers', () => {
     })
 
     // Login succeeded and the active provider is still the isolated subscription: reconnect.
+    service.loginIsolatedCodex.mockResolvedValue({ ok: true, category: 'ok', applied: true })
     service.getSettingsView.mockResolvedValue({
       claude: {},
-      providers: [{ id: CODEX_SUBSCRIPTION_PROVIDER_ID, type: 'codex-isolated' }],
+      providers: [
+        {
+          id: CODEX_SUBSCRIPTION_PROVIDER_ID,
+          type: 'codex-isolated',
+          codexAuthMode: 'isolated'
+        }
+      ],
       activeProviderId: CODEX_SUBSCRIPTION_PROVIDER_ID
     })
     await invoke('settings:login-isolated-codex')
     expect(onActiveProviderChanged).toHaveBeenCalledOnce()
 
-    // Login succeeded but the provider was switched to shared mid-flow (outcome discarded): the
-    // shared runtime's credentials didn't change, so a reconnect would be redundant.
+    // Login succeeded but the provider was switched to imported auth mid-flow (outcome discarded):
+    // the imported runtime's credentials didn't change, so a reconnect would be redundant.
     onActiveProviderChanged.mockClear()
+    service.loginIsolatedCodex.mockResolvedValue({ ok: true, category: 'ok', applied: false })
     service.getSettingsView.mockResolvedValue({
       claude: {},
-      providers: [{ id: CODEX_SUBSCRIPTION_PROVIDER_ID, type: 'codex-shared' }],
+      providers: [
+        {
+          id: CODEX_SUBSCRIPTION_PROVIDER_ID,
+          type: 'codex-isolated',
+          codexAuthMode: 'imported'
+        }
+      ],
       activeProviderId: CODEX_SUBSCRIPTION_PROVIDER_ID
     })
     await invoke('settings:login-isolated-codex')

--- a/src/main/settings/ipc.ts
+++ b/src/main/settings/ipc.ts
@@ -422,9 +422,8 @@ const registerSettingsIpcHandlers = ({
   ipcMain.handle('settings:logout-isolated-codex', async () => {
     const result = await service.logoutIsolatedCodex()
 
-    // Reconnect only when the sign-out actually cleared the credential. A timed-out sign-out leaves
-    // it in place, so forcing the live agent to reconnect would just re-authenticate against the
-    // credential we failed to remove.
+    // Reconnect only when the app-owned credential was actually removed. If local cleanup fails,
+    // keep the live agent untouched because it may still hold the credential in memory.
     if (result.ok) {
       const snapshot = await service.getSettingsView()
       if (snapshot.activeProviderId === CODEX_SUBSCRIPTION_PROVIDER_ID) {

--- a/src/main/settings/ipc.ts
+++ b/src/main/settings/ipc.ts
@@ -401,16 +401,17 @@ const registerSettingsIpcHandlers = ({
     const result = await service.loginIsolatedCodex()
 
     // A fresh login changes the credentials the live agent relies on; reconnect so it picks them
-    // up. Skip when the outcome was discarded by a mid-flow switch to shared — reconnecting the
-    // now-shared runtime would be redundant (its credentials didn't change).
-    if (result.ok) {
+    // up. Skip when the outcome was discarded by a mid-flow switch to imported auth — reconnecting
+    // the imported runtime would be redundant (its credentials didn't change).
+    if (result.ok && result.applied !== false) {
       const snapshot = await service.getSettingsView()
       const active = snapshot.providers.find(
         (provider) => provider.id === snapshot.activeProviderId
       )
       if (
         snapshot.activeProviderId === CODEX_SUBSCRIPTION_PROVIDER_ID &&
-        active?.type === 'codex-isolated'
+        active?.type === 'codex-isolated' &&
+        active.codexAuthMode === 'isolated'
       ) {
         onActiveProviderChanged?.()
       }

--- a/src/main/settings/provider-env.ts
+++ b/src/main/settings/provider-env.ts
@@ -1,7 +1,11 @@
 import { join } from 'node:path'
 import { homedir } from 'node:os'
 
-import type { ChatApiEndpoint, ProviderType } from '../../shared/settings'
+import type {
+  ChatApiEndpoint,
+  CodexSubscriptionAuthMode,
+  ProviderType
+} from '../../shared/settings'
 import type { OfficialVendorId } from '../../shared/provider-registry'
 import type { CustomReasoningEffortTransport } from '../../shared/reasoning-effort'
 import { normalizeAnthropicBaseUrl } from './base-url'
@@ -12,6 +16,7 @@ import { normalizeAnthropicBaseUrl } from './base-url'
 // A provider resolved for spawning: the plaintext key is already decrypted by the caller.
 export type ResolvedProvider = {
   type: ProviderType
+  codexAuthMode?: CodexSubscriptionAuthMode
   // Retained for official providers even though they use the custom credential path at runtime.
   // Transport adapters need this stable identity because `none` has vendor-specific wire semantics.
   vendorId?: OfficialVendorId

--- a/src/main/settings/repository.test.ts
+++ b/src/main/settings/repository.test.ts
@@ -179,6 +179,29 @@ describe('settings repository', () => {
     expect(settings.activeProviderId).toBe('builtin-codex-subscription')
   })
 
+  it('migrates an ambiguous normalized Codex subscription as imported', () => {
+    const settings = sanitizeSettings({
+      activeProviderId: 'builtin-codex-subscription',
+      providers: [
+        {
+          id: 'builtin-codex-subscription',
+          type: 'codex-isolated',
+          name: 'Codex subscription'
+        }
+      ]
+    })
+
+    expect(settings.providers).toEqual([
+      expect.objectContaining({
+        id: 'builtin-codex-subscription',
+        type: 'codex-isolated',
+        codexAuthMode: 'imported',
+        name: 'Codex subscription'
+      })
+    ])
+    expect(settings.activeProviderId).toBe('builtin-codex-subscription')
+  })
+
   it('returns empty settings when nothing is stored yet', async () => {
     const repository = new SettingsRepository(await createStorageRoot())
 

--- a/src/main/settings/repository.test.ts
+++ b/src/main/settings/repository.test.ts
@@ -169,7 +169,7 @@ describe('settings repository', () => {
       expect.objectContaining({
         id: 'builtin-codex-subscription',
         type: 'codex-isolated',
-        codexAuthMode: 'imported',
+        codexAuthMode: 'isolated',
         name: 'Codex subscription'
       })
     ])
@@ -200,6 +200,26 @@ describe('settings repository', () => {
       })
     ])
     expect(settings.activeProviderId).toBe('builtin-codex-subscription')
+  })
+
+  it('preserves an explicit imported mode on a normalized Codex subscription', () => {
+    const settings = sanitizeSettings({
+      activeProviderId: 'builtin-codex-subscription',
+      providers: [
+        {
+          id: 'builtin-codex-subscription',
+          type: 'codex-isolated',
+          codexAuthMode: 'imported',
+          name: 'Codex subscription'
+        }
+      ]
+    })
+
+    expect(settings.providers[0]).toMatchObject({
+      id: 'builtin-codex-subscription',
+      type: 'codex-isolated',
+      codexAuthMode: 'imported'
+    })
   })
 
   it('returns empty settings when nothing is stored yet', async () => {

--- a/src/main/settings/repository.test.ts
+++ b/src/main/settings/repository.test.ts
@@ -143,6 +143,7 @@ describe('settings repository', () => {
       expect.objectContaining({
         id: 'builtin-codex-subscription',
         type: 'codex-isolated',
+        codexAuthMode: 'isolated',
         name: 'Codex subscription'
       })
     ])
@@ -168,6 +169,7 @@ describe('settings repository', () => {
       expect.objectContaining({
         id: 'builtin-codex-subscription',
         type: 'codex-isolated',
+        codexAuthMode: 'imported',
         name: 'Codex subscription'
       })
     ])

--- a/src/main/settings/repository.test.ts
+++ b/src/main/settings/repository.test.ts
@@ -179,7 +179,7 @@ describe('settings repository', () => {
     expect(settings.activeProviderId).toBe('builtin-codex-subscription')
   })
 
-  it('migrates an ambiguous normalized Codex subscription as imported', () => {
+  it('migrates an ambiguous normalized Codex subscription as isolated', () => {
     const settings = sanitizeSettings({
       activeProviderId: 'builtin-codex-subscription',
       providers: [
@@ -195,7 +195,7 @@ describe('settings repository', () => {
       expect.objectContaining({
         id: 'builtin-codex-subscription',
         type: 'codex-isolated',
-        codexAuthMode: 'imported',
+        codexAuthMode: 'isolated',
         name: 'Codex subscription'
       })
     ])

--- a/src/main/settings/repository.ts
+++ b/src/main/settings/repository.ts
@@ -215,6 +215,7 @@ const sanitizeProvider = (value: unknown): StoredProvider | undefined => {
   const lastValidationFailure = sanitizeValidationFailure(value.lastValidationFailure)
   const expiresAt = asNumber(value.expiresAt)
   const disconnectedAt = asNumber(value.disconnectedAt)
+  const codexAuthMode = asString(value.codexAuthMode)
   // Keep only a clean list of non-empty string model ids.
   const fetchedModels = Array.isArray(value.fetchedModels)
     ? value.fetchedModels.filter(
@@ -262,6 +263,12 @@ const sanitizeProvider = (value: unknown): StoredProvider | undefined => {
   if (expiresAt !== undefined) provider.expiresAt = expiresAt
   if (disconnectedAt !== undefined && type === 'claude-shared') {
     provider.disconnectedAt = disconnectedAt
+  }
+  if (
+    isCodexSubscriptionProvider(type) &&
+    (codexAuthMode === 'imported' || codexAuthMode === 'isolated')
+  ) {
+    provider.codexAuthMode = codexAuthMode
   }
 
   return provider

--- a/src/main/settings/repository.ts
+++ b/src/main/settings/repository.ts
@@ -404,14 +404,11 @@ const sanitizeSettings = (value: unknown): StoredSettings => {
         // subscription home, so sanitized/newly persisted state has one isolated form.
         type: 'codex-isolated' as const,
         // Releases before codexAuthMode normalized both setup choices to the subscription id, so
-        // that shape is ambiguous. Prefer imported to keep the refresh path available; the older
-        // dedicated isolated id remains an unambiguous isolated migration.
+        // that shape is ambiguous. Prefer isolated to preserve the established runtime behavior;
+        // legacy shared users can explicitly re-import into the new app-owned profile.
         codexAuthMode:
           selectedCodexProvider.codexAuthMode ??
-          (selectedCodexProvider.type === 'codex-shared' ||
-          selectedCodexProvider.id === CODEX_SUBSCRIPTION_PROVIDER_ID
-            ? 'imported'
-            : 'isolated'),
+          (selectedCodexProvider.type === 'codex-shared' ? 'imported' : 'isolated'),
         name: codexSubscriptionProviderIdentity().name
       }
     : undefined

--- a/src/main/settings/repository.ts
+++ b/src/main/settings/repository.ts
@@ -403,9 +403,15 @@ const sanitizeSettings = (value: unknown): StoredSettings => {
         // `codex-shared` is legacy setup input only. Runtime always uses the app-owned
         // subscription home, so sanitized/newly persisted state has one isolated form.
         type: 'codex-isolated' as const,
+        // Releases before codexAuthMode normalized both setup choices to the subscription id, so
+        // that shape is ambiguous. Prefer imported to keep the refresh path available; the older
+        // dedicated isolated id remains an unambiguous isolated migration.
         codexAuthMode:
           selectedCodexProvider.codexAuthMode ??
-          (selectedCodexProvider.type === 'codex-shared' ? 'imported' : 'isolated'),
+          (selectedCodexProvider.type === 'codex-shared' ||
+          selectedCodexProvider.id === CODEX_SUBSCRIPTION_PROVIDER_ID
+            ? 'imported'
+            : 'isolated'),
         name: codexSubscriptionProviderIdentity().name
       }
     : undefined

--- a/src/main/settings/repository.ts
+++ b/src/main/settings/repository.ts
@@ -406,9 +406,7 @@ const sanitizeSettings = (value: unknown): StoredSettings => {
         // Releases before codexAuthMode normalized both setup choices to the subscription id, so
         // that shape is ambiguous. Prefer isolated to preserve the established runtime behavior;
         // legacy shared users can explicitly re-import into the new app-owned profile.
-        codexAuthMode:
-          selectedCodexProvider.codexAuthMode ??
-          (selectedCodexProvider.type === 'codex-shared' ? 'imported' : 'isolated'),
+        codexAuthMode: selectedCodexProvider.codexAuthMode ?? 'isolated',
         name: codexSubscriptionProviderIdentity().name
       }
     : undefined

--- a/src/main/settings/repository.ts
+++ b/src/main/settings/repository.ts
@@ -403,6 +403,9 @@ const sanitizeSettings = (value: unknown): StoredSettings => {
         // `codex-shared` is legacy setup input only. Runtime always uses the app-owned
         // subscription home, so sanitized/newly persisted state has one isolated form.
         type: 'codex-isolated' as const,
+        codexAuthMode:
+          selectedCodexProvider.codexAuthMode ??
+          (selectedCodexProvider.type === 'codex-shared' ? 'imported' : 'isolated'),
         name: codexSubscriptionProviderIdentity().name
       }
     : undefined

--- a/src/main/settings/service.test.ts
+++ b/src/main/settings/service.test.ts
@@ -500,13 +500,15 @@ describe('SettingsService: providers', () => {
     expect((await repository.getSettings()).providers).toEqual([])
   })
 
-  it('validates imported and in-app subscription setup through the isolated status check', async () => {
+  it('validates imported and in-app subscription setup through their matching status checks', async () => {
     const codexAuth: CodexAuthControllerPort = {
-      getStatus: vi.fn().mockResolvedValue({
-        mode: 'shared',
-        supported: true,
-        authenticated: true
-      }),
+      getStatus: vi.fn((mode) =>
+        Promise.resolve({
+          mode,
+          supported: true,
+          authenticated: true
+        })
+      ),
       loginIsolated: vi.fn().mockResolvedValue({
         mode: 'isolated',
         supported: true,
@@ -521,16 +523,44 @@ describe('SettingsService: providers', () => {
     await expect(
       service.validateProvider({ providerId: CODEX_SHARED_PROVIDER_ID })
     ).resolves.toMatchObject({ ok: true })
+    expect(codexAuth.getStatus).toHaveBeenNthCalledWith(1, 'shared')
     await service.upsertProvider({ type: 'codex-isolated' })
     await expect(
       service.validateProvider({ providerId: CODEX_ISOLATED_PROVIDER_ID })
     ).resolves.toMatchObject({ ok: true })
-    expect(codexAuth.getStatus).toHaveBeenCalledWith('isolated')
+    expect(codexAuth.getStatus).toHaveBeenNthCalledWith(2, 'isolated')
     // Validation never opens the browser login; that is the explicit sign-in action's job.
     expect(codexAuth.loginIsolated).not.toHaveBeenCalled()
 
     const stored = await repository.getSettings()
     expect(stored.providers.every((provider) => provider.lastValidatedAt !== undefined)).toBe(true)
+  })
+
+  it('reports imported login guidance when imported subscription auth is unavailable', async () => {
+    const codexAuth: CodexAuthControllerPort = {
+      getStatus: vi.fn((mode) =>
+        Promise.resolve({
+          mode,
+          supported: true,
+          authenticated: false
+        })
+      ),
+      loginIsolated: vi.fn(),
+      cancelLogin: vi.fn(),
+      logoutIsolated: vi.fn()
+    }
+    const service = createService(undefined, { codexAuth })
+    await service.upsertProvider({ type: 'codex-shared' })
+
+    await expect(
+      service.validateProvider({ providerId: CODEX_SHARED_PROVIDER_ID })
+    ).resolves.toMatchObject({
+      ok: false,
+      category: 'auth',
+      message:
+        'No existing Codex login was found. Run `codex login` or use the isolated Open Science login.'
+    })
+    expect(codexAuth.getStatus).toHaveBeenCalledWith('shared')
   })
 
   it('does not apply a pending Codex validation after the subscription auth mode changes', async () => {

--- a/src/main/settings/service.test.ts
+++ b/src/main/settings/service.test.ts
@@ -268,7 +268,12 @@ describe('SettingsService: providers', () => {
 
     expect(snapshot.providers[0]).toMatchObject({
       id: CODEX_SUBSCRIPTION_PROVIDER_ID,
-      type: 'codex-isolated'
+      type: 'codex-isolated',
+      codexAuthMode: 'imported'
+    })
+    expect((await repository.getSettings()).providers[0]).toMatchObject({
+      type: 'codex-isolated',
+      codexAuthMode: 'imported'
     })
     expect(await readFile(join(storageRoot, 'codex-subscription', 'auth.json'), 'utf8')).toBe(
       '{"tokens":{"access_token":"secret"}}'
@@ -291,7 +296,7 @@ describe('SettingsService: providers', () => {
     ).rejects.toMatchObject({ code: 'ENOENT' })
   })
 
-  it('clears an imported Codex route when switching to an in-app sign-in', async () => {
+  it('preserves an imported Codex route on resave and clears it on an explicit mode switch', async () => {
     const userCodexDir = join(storageRoot, 'user-codex')
     await mkdir(userCodexDir, { recursive: true })
     await writeFile(join(userCodexDir, 'auth.json'), '{"tokens":{"access_token":"secret"}}')
@@ -310,16 +315,31 @@ describe('SettingsService: providers', () => {
     )
     const service = createService(undefined, { userCodexDir })
 
-    await service.upsertProvider({ type: 'codex-shared' })
+    const imported = await service.upsertProvider({ type: 'codex-shared' })
     await expect(
       readFile(join(storageRoot, 'codex-subscription', 'config.toml'), 'utf8')
     ).resolves.toContain('model_provider = "subscription-route"')
 
-    await service.upsertProvider({ type: 'codex-isolated' })
+    await service.upsertProvider({
+      id: imported.providers[0].id,
+      type: imported.providers[0].codexAuthMode === 'imported' ? 'codex-shared' : 'codex-isolated'
+    })
+    await expect(
+      readFile(join(storageRoot, 'codex-subscription', 'config.toml'), 'utf8')
+    ).resolves.toContain('model_provider = "subscription-route"')
+
+    const isolated = await service.upsertProvider({
+      id: imported.providers[0].id,
+      type: 'codex-isolated'
+    })
 
     await expect(
       readFile(join(storageRoot, 'codex-subscription', 'config.toml'), 'utf8')
     ).rejects.toMatchObject({ code: 'ENOENT' })
+    expect(isolated.providers[0]).toMatchObject({
+      type: 'codex-isolated',
+      codexAuthMode: 'isolated'
+    })
     expect(await readFile(join(storageRoot, 'codex-subscription', 'auth.json'), 'utf8')).toBe(
       '{"tokens":{"access_token":"secret"}}'
     )

--- a/src/main/settings/service.test.ts
+++ b/src/main/settings/service.test.ts
@@ -280,14 +280,17 @@ describe('SettingsService: providers', () => {
     )
     expect(await readFile(join(storageRoot, 'codex-subscription', 'config.toml'), 'utf8')).toBe(
       [
+        '# Open Science: begin imported Codex route selection',
         'model_provider = "subscription-route"',
-        '',
+        '# Open Science: end imported Codex route selection',
+        '# Open Science: begin imported Codex provider',
         '[model_providers."subscription-route"]',
         'name = "OpenAI"',
         'base_url = "http://127.0.0.1:1087/v1"',
         'wire_api = "responses"',
         'requires_openai_auth = true',
         'supports_websockets = false',
+        '# Open Science: end imported Codex provider',
         ''
       ].join('\n')
     )
@@ -327,6 +330,8 @@ describe('SettingsService: providers', () => {
     await expect(
       readFile(join(storageRoot, 'codex-subscription', 'config.toml'), 'utf8')
     ).resolves.toContain('model_provider = "subscription-route"')
+    const verifiedImportedProvider = (await repository.getSettings()).providers[0]
+    await repository.upsertProvider({ ...verifiedImportedProvider, lastValidatedAt: 123 })
 
     const isolated = await service.upsertProvider({
       id: imported.providers[0].id,
@@ -340,6 +345,7 @@ describe('SettingsService: providers', () => {
       type: 'codex-isolated',
       codexAuthMode: 'isolated'
     })
+    expect(isolated.providers[0].lastValidatedAt).toBeUndefined()
     expect(await readFile(join(storageRoot, 'codex-subscription', 'auth.json'), 'utf8')).toBe(
       '{"tokens":{"access_token":"secret"}}'
     )

--- a/src/main/settings/service.test.ts
+++ b/src/main/settings/service.test.ts
@@ -406,6 +406,40 @@ describe('SettingsService: providers', () => {
     expect(refreshed.providers[0].lastValidatedAt).toBeUndefined()
   })
 
+  it('discards an in-flight Codex validation when imported authentication is refreshed', async () => {
+    let resolveStatus!: (status: CodexAuthStatus) => void
+    const codexAuth: CodexAuthControllerPort = {
+      getStatus: vi.fn(
+        () =>
+          new Promise<CodexAuthStatus>((resolve) => {
+            resolveStatus = resolve
+          })
+      ),
+      loginIsolated: vi.fn(),
+      cancelLogin: vi.fn(),
+      logoutIsolated: vi.fn()
+    }
+    const service = createService(undefined, { codexAuth })
+    const imported = await service.upsertProvider({ type: 'codex-shared' })
+
+    const pendingValidation = service.validateProvider({
+      providerId: imported.providers[0].id
+    })
+    await writeFile(
+      join(storageRoot, 'no-user-codex', 'auth.json'),
+      '{"tokens":{"access_token":"refreshed"}}'
+    )
+    await service.upsertProvider({
+      id: imported.providers[0].id,
+      type: 'codex-shared',
+      reimportCodexAuthentication: true
+    })
+    resolveStatus({ mode: 'shared', supported: true, authenticated: true })
+
+    await expect(pendingValidation).resolves.toMatchObject({ ok: true, applied: false })
+    expect((await repository.getSettings()).providers[0].lastValidatedAt).toBeUndefined()
+  })
+
   it.each([
     ['codex-shared', CODEX_SHARED_PROVIDER_ID, 'Codex subscription'],
     ['codex-isolated', CODEX_ISOLATED_PROVIDER_ID, 'Codex subscription']

--- a/src/main/settings/service.test.ts
+++ b/src/main/settings/service.test.ts
@@ -323,15 +323,18 @@ describe('SettingsService: providers', () => {
       readFile(join(storageRoot, 'codex-subscription', 'config.toml'), 'utf8')
     ).resolves.toContain('model_provider = "subscription-route"')
 
-    await service.upsertProvider({
+    const verifiedImportedProvider = (await repository.getSettings()).providers[0]
+    await repository.upsertProvider({ ...verifiedImportedProvider, lastValidatedAt: 123 })
+    await rm(userCodexDir, { recursive: true, force: true })
+
+    const resaved = await service.upsertProvider({
       id: imported.providers[0].id,
       type: imported.providers[0].codexAuthMode === 'imported' ? 'codex-shared' : 'codex-isolated'
     })
     await expect(
       readFile(join(storageRoot, 'codex-subscription', 'config.toml'), 'utf8')
     ).resolves.toContain('model_provider = "subscription-route"')
-    const verifiedImportedProvider = (await repository.getSettings()).providers[0]
-    await repository.upsertProvider({ ...verifiedImportedProvider, lastValidatedAt: 123 })
+    expect(resaved.providers[0].lastValidatedAt).toBe(123)
 
     const isolated = await service.upsertProvider({
       id: imported.providers[0].id,

--- a/src/main/settings/service.test.ts
+++ b/src/main/settings/service.test.ts
@@ -291,6 +291,40 @@ describe('SettingsService: providers', () => {
     ).rejects.toMatchObject({ code: 'ENOENT' })
   })
 
+  it('clears an imported Codex route when switching to an in-app sign-in', async () => {
+    const userCodexDir = join(storageRoot, 'user-codex')
+    await mkdir(userCodexDir, { recursive: true })
+    await writeFile(join(userCodexDir, 'auth.json'), '{"tokens":{"access_token":"secret"}}')
+    await writeFile(
+      join(userCodexDir, 'config.toml'),
+      [
+        'model_provider = "subscription-route"',
+        '',
+        '[model_providers.subscription-route]',
+        'name = "OpenAI"',
+        'requires_openai_auth = true',
+        'wire_api = "responses"',
+        'base_url = "http://127.0.0.1:1087/v1"',
+        ''
+      ].join('\n')
+    )
+    const service = createService(undefined, { userCodexDir })
+
+    await service.upsertProvider({ type: 'codex-shared' })
+    await expect(
+      readFile(join(storageRoot, 'codex-subscription', 'config.toml'), 'utf8')
+    ).resolves.toContain('model_provider = "subscription-route"')
+
+    await service.upsertProvider({ type: 'codex-isolated' })
+
+    await expect(
+      readFile(join(storageRoot, 'codex-subscription', 'config.toml'), 'utf8')
+    ).rejects.toMatchObject({ code: 'ENOENT' })
+    expect(await readFile(join(storageRoot, 'codex-subscription', 'auth.json'), 'utf8')).toBe(
+      '{"tokens":{"access_token":"secret"}}'
+    )
+  })
+
   it.each([
     ['codex-shared', CODEX_SHARED_PROVIDER_ID, 'Codex subscription'],
     ['codex-isolated', CODEX_ISOLATED_PROVIDER_ID, 'Codex subscription']

--- a/src/main/settings/service.test.ts
+++ b/src/main/settings/service.test.ts
@@ -396,6 +396,45 @@ describe('SettingsService: providers', () => {
     })
   })
 
+  it('deleting a Codex subscription removes only its app-owned authentication and route', async () => {
+    const userCodexDir = join(storageRoot, 'user-codex')
+    await mkdir(userCodexDir, { recursive: true })
+    await writeFile(join(userCodexDir, 'auth.json'), '{"tokens":{"access_token":"global"}}')
+    await writeFile(
+      join(userCodexDir, 'config.toml'),
+      [
+        'model_provider = "subscription-route"',
+        '',
+        '[model_providers.subscription-route]',
+        'name = "OpenAI"',
+        'requires_openai_auth = true',
+        'wire_api = "responses"',
+        'base_url = "http://127.0.0.1:1087/v1"',
+        ''
+      ].join('\n')
+    )
+    const codexAuth: CodexAuthControllerPort = {
+      getStatus: vi.fn(),
+      loginIsolated: vi.fn(),
+      cancelLogin: vi.fn(),
+      logoutIsolated: vi.fn()
+    }
+    const service = createService(undefined, { codexAuth, userCodexDir })
+    await service.upsertProvider({ type: 'codex-shared' })
+    vi.mocked(codexAuth.cancelLogin).mockClear()
+
+    await service.deleteProvider(CODEX_SUBSCRIPTION_PROVIDER_ID)
+
+    expect(codexAuth.cancelLogin).toHaveBeenCalledOnce()
+    await expect(
+      readFile(join(storageRoot, 'codex-subscription', 'auth.json'), 'utf8')
+    ).rejects.toMatchObject({ code: 'ENOENT' })
+    await expect(
+      readFile(join(storageRoot, 'codex-subscription', 'config.toml'), 'utf8')
+    ).resolves.not.toContain('Open Science:')
+    await expect(readFile(join(userCodexDir, 'auth.json'), 'utf8')).resolves.toContain('global')
+  })
+
   it('refreshes an imported Codex profile only when re-import is explicitly requested', async () => {
     const userCodexDir = join(storageRoot, 'user-codex')
     await mkdir(userCodexDir, { recursive: true })
@@ -827,6 +866,34 @@ describe('SettingsService: providers', () => {
     expect(stored.lastValidationFailure).toBeUndefined()
   })
 
+  it('waits for isolated sign-in cancellation before importing authentication', async () => {
+    const userCodexDir = join(storageRoot, 'user-codex')
+    await mkdir(userCodexDir, { recursive: true })
+    await writeFile(join(userCodexDir, 'auth.json'), '{"tokens":{"access_token":"imported"}}')
+    let finishCancellation!: () => void
+    const cancellationGate = new Promise<void>((resolve) => {
+      finishCancellation = resolve
+    })
+    const codexAuth: CodexAuthControllerPort = {
+      getStatus: vi.fn(),
+      loginIsolated: vi.fn(),
+      cancelLogin: vi.fn(() => cancellationGate),
+      logoutIsolated: vi.fn()
+    }
+    const service = createService(undefined, { codexAuth, userCodexDir })
+    await service.upsertProvider({ type: 'codex-isolated' })
+    const appAuthPath = join(storageRoot, 'codex-subscription', 'auth.json')
+    await writeFile(appAuthPath, '{"tokens":{"access_token":"isolated"}}')
+
+    const switching = service.upsertProvider({ type: 'codex-shared' })
+    await vi.waitFor(() => expect(codexAuth.cancelLogin).toHaveBeenCalledOnce())
+    await expect(readFile(appAuthPath, 'utf8')).resolves.toContain('isolated')
+
+    finishCancellation()
+    await switching
+    await expect(readFile(appAuthPath, 'utf8')).resolves.toContain('imported')
+  })
+
   it('keeps the Codex account default when a subscription is activated without a model', async () => {
     const service = createService()
     const provider = (await service.upsertProvider({ type: 'codex-shared' })).providers[0]
@@ -903,6 +970,7 @@ describe('SettingsService: providers', () => {
     }
     const service = createService(undefined, { codexAuth })
     await service.upsertProvider({ type: 'codex-shared' })
+    codexAuth.cancelLogin.mockClear()
     const appAuthPath = join(storageRoot, 'codex-subscription', 'auth.json')
 
     const result = await service.logoutIsolatedCodex()

--- a/src/main/settings/service.test.ts
+++ b/src/main/settings/service.test.ts
@@ -239,11 +239,28 @@ afterEach(async () => {
 })
 
 describe('SettingsService: providers', () => {
-  it('imports only existing Codex authentication and persists an isolated provider', async () => {
+  it('imports existing Codex authentication and its safe active provider route', async () => {
     const userCodexDir = join(storageRoot, 'user-codex')
     await mkdir(join(userCodexDir, 'skills', 'private'), { recursive: true })
     await writeFile(join(userCodexDir, 'auth.json'), '{"tokens":{"access_token":"secret"}}')
-    await writeFile(join(userCodexDir, 'config.toml'), 'model = "private"\n')
+    await writeFile(
+      join(userCodexDir, 'config.toml'),
+      [
+        'model_provider = "subscription-route"',
+        'model = "private"',
+        '',
+        '[mcp_servers.private]',
+        'command = "private-command"',
+        '',
+        '[model_providers.subscription-route]',
+        'name = "OpenAI"',
+        'requires_openai_auth = true',
+        'supports_websockets = false',
+        'wire_api = "responses"',
+        'base_url = "http://127.0.0.1:1087/v1"',
+        ''
+      ].join('\n')
+    )
     await writeFile(join(userCodexDir, 'skills', 'private', 'SKILL.md'), '# Private')
     const service = createService(undefined, { userCodexDir })
 
@@ -256,9 +273,19 @@ describe('SettingsService: providers', () => {
     expect(await readFile(join(storageRoot, 'codex-subscription', 'auth.json'), 'utf8')).toBe(
       '{"tokens":{"access_token":"secret"}}'
     )
-    await expect(
-      readFile(join(storageRoot, 'codex-subscription', 'config.toml'), 'utf8')
-    ).rejects.toMatchObject({ code: 'ENOENT' })
+    expect(await readFile(join(storageRoot, 'codex-subscription', 'config.toml'), 'utf8')).toBe(
+      [
+        'model_provider = "subscription-route"',
+        '',
+        '[model_providers."subscription-route"]',
+        'name = "OpenAI"',
+        'base_url = "http://127.0.0.1:1087/v1"',
+        'wire_api = "responses"',
+        'requires_openai_auth = true',
+        'supports_websockets = false',
+        ''
+      ].join('\n')
+    )
     await expect(
       readFile(join(storageRoot, 'codex-subscription', 'skills', 'private', 'SKILL.md'), 'utf8')
     ).rejects.toMatchObject({ code: 'ENOENT' })

--- a/src/main/settings/service.test.ts
+++ b/src/main/settings/service.test.ts
@@ -354,6 +354,58 @@ describe('SettingsService: providers', () => {
     )
   })
 
+  it('refreshes an imported Codex profile only when re-import is explicitly requested', async () => {
+    const userCodexDir = join(storageRoot, 'user-codex')
+    await mkdir(userCodexDir, { recursive: true })
+    await writeFile(join(userCodexDir, 'auth.json'), '{"tokens":{"access_token":"old"}}')
+    await writeFile(
+      join(userCodexDir, 'config.toml'),
+      [
+        'model_provider = "old-route"',
+        '',
+        '[model_providers.old-route]',
+        'name = "Old route"',
+        'requires_openai_auth = true',
+        'wire_api = "responses"',
+        'base_url = "http://127.0.0.1:1087/v1"',
+        ''
+      ].join('\n')
+    )
+    const service = createService(undefined, { userCodexDir })
+    const imported = await service.upsertProvider({ type: 'codex-shared' })
+    const stored = (await repository.getSettings()).providers[0]
+    await repository.upsertProvider({ ...stored, lastValidatedAt: 123 })
+
+    await writeFile(join(userCodexDir, 'auth.json'), '{"tokens":{"access_token":"new"}}')
+    await writeFile(
+      join(userCodexDir, 'config.toml'),
+      [
+        'model_provider = "new-route"',
+        '',
+        '[model_providers.new-route]',
+        'name = "New route"',
+        'requires_openai_auth = true',
+        'wire_api = "responses"',
+        'base_url = "http://127.0.0.1:2087/v1"',
+        ''
+      ].join('\n')
+    )
+
+    const refreshed = await service.upsertProvider({
+      id: imported.providers[0].id,
+      type: 'codex-shared',
+      reimportCodexAuthentication: true
+    })
+
+    expect(await readFile(join(storageRoot, 'codex-subscription', 'auth.json'), 'utf8')).toBe(
+      '{"tokens":{"access_token":"new"}}'
+    )
+    await expect(
+      readFile(join(storageRoot, 'codex-subscription', 'config.toml'), 'utf8')
+    ).resolves.toContain('base_url = "http://127.0.0.1:2087/v1"')
+    expect(refreshed.providers[0].lastValidatedAt).toBeUndefined()
+  })
+
   it.each([
     ['codex-shared', CODEX_SHARED_PROVIDER_ID, 'Codex subscription'],
     ['codex-isolated', CODEX_ISOLATED_PROVIDER_ID, 'Codex subscription']

--- a/src/main/settings/service.test.ts
+++ b/src/main/settings/service.test.ts
@@ -142,7 +142,7 @@ const createService = (
     // When false, the ACP smoke test fails (adapter present but can't initialize).
     codexSmokeOk?: boolean
     codexAuth?: CodexAuthControllerPort
-    resolveCodexProxyEnvironment?: () => Promise<SystemProxyEnvironment>
+    resolveCodexProxyEnvironment?: () => Promise<SystemProxyEnvironment | undefined>
     claudeIsolatedAuth?: ClaudeIsolatedAuthControllerPort
     claudeSharedAuth?: ClaudeSharedAuthControllerPort
     executeClaudeProbe?: (
@@ -935,12 +935,17 @@ describe('SettingsService: providers', () => {
     const service = createService(undefined, { codexAuth })
     await service.upsertProvider({ type: 'codex-isolated' })
     await service.loginIsolatedCodex()
+    const appConfigPath = join(storageRoot, 'codex-subscription', 'config.toml')
+    await writeFile(appConfigPath, 'cli_auth_credentials_store = "auto"\n')
 
     const result = await service.logoutIsolatedCodex()
 
     expect(result).toEqual({ ok: true, category: 'ok' })
     expect(codexAuth.cancelLogin).toHaveBeenCalledOnce()
     expect(codexAuth.logoutIsolated).not.toHaveBeenCalled()
+    await expect(readFile(appConfigPath, 'utf8')).resolves.toBe(
+      'cli_auth_credentials_store = "file"\n'
+    )
     const stored = (await repository.getSettings()).providers[0]
     expect(stored.lastValidatedAt).toBeUndefined()
     expect(stored.lastValidationFailure).toBeUndefined()
@@ -2369,12 +2374,23 @@ describe('SettingsService: preflight & spawn config', () => {
     expect(backend.env.CODEX_HOME).toBe(join(storageRoot, 'codex-subscription'))
     expect(backend.env.HTTPS_PROXY).toBe('http://proxy.example.test:3128')
     expect(backend.env.NO_PROXY).toContain('127.0.0.1')
+    expect(backend.proxyEnvironmentMode).toBe('replace')
     expect(await readFile(join(storageRoot, 'codex-subscription', 'config.toml'), 'utf8')).toBe(
       'cli_auth_credentials_store = "file"\n'
     )
     expect(await readFile(join(storageRoot, 'codex', 'config.toml'), 'utf8')).toBe(
       'model = "account-default"\ncli_auth_credentials_store = "ephemeral"\n'
     )
+
+    const fallbackService = createService(undefined, {
+      codexDetected: { path: adapterPath, version: 'codex-acp 1.1.4' },
+      resolveCodexProxyEnvironment: () => Promise.resolve(undefined)
+    })
+    const fallbackBackend = await fallbackService.resolveActiveAgentBackend()
+
+    expect(fallbackBackend.proxyEnvironmentMode).toBe('inherit')
+    expect(fallbackBackend.env).not.toHaveProperty('HTTP_PROXY')
+    expect(fallbackBackend.env).not.toHaveProperty('HTTPS_PROXY')
   })
 
   it('resolves an unpinned subscription backend to the Codex account default', async () => {

--- a/src/main/settings/service.test.ts
+++ b/src/main/settings/service.test.ts
@@ -2325,7 +2325,9 @@ describe('SettingsService: preflight & spawn config', () => {
           HTTP_PROXY: 'http://proxy.example.test:3128',
           HTTPS_PROXY: 'http://proxy.example.test:3128',
           http_proxy: 'http://proxy.example.test:3128',
-          https_proxy: 'http://proxy.example.test:3128'
+          https_proxy: 'http://proxy.example.test:3128',
+          NO_PROXY: 'localhost,127.0.0.1,::1',
+          no_proxy: 'localhost,127.0.0.1,::1'
         })
     })
     await repository.setCodexInfo({
@@ -2366,6 +2368,7 @@ describe('SettingsService: preflight & spawn config', () => {
     expect(backend.env.CODEX_PATH).toBe('/data/codex-managed/native/codex')
     expect(backend.env.CODEX_HOME).toBe(join(storageRoot, 'codex-subscription'))
     expect(backend.env.HTTPS_PROXY).toBe('http://proxy.example.test:3128')
+    expect(backend.env.NO_PROXY).toContain('127.0.0.1')
     expect(await readFile(join(storageRoot, 'codex-subscription', 'config.toml'), 'utf8')).toBe(
       'cli_auth_credentials_store = "file"\n'
     )

--- a/src/main/settings/service.test.ts
+++ b/src/main/settings/service.test.ts
@@ -633,21 +633,15 @@ describe('SettingsService: providers', () => {
     })
   })
 
-  it('keeps the sign-in outcome when existing authentication is reimported mid-flow', async () => {
-    let resolveLogin!: (status: {
-      mode: 'isolated'
-      supported: boolean
-      authenticated: boolean
-    }) => void
+  it('discards a late isolated sign-in failure after authentication is imported mid-flow', async () => {
+    let resolveLogin!: (status: CodexAuthStatus) => void
     const codexAuth: CodexAuthControllerPort = {
       getStatus: vi.fn(),
       loginIsolated: vi.fn(
         () =>
-          new Promise<{ mode: 'isolated'; supported: boolean; authenticated: boolean }>(
-            (resolve) => {
-              resolveLogin = resolve
-            }
-          )
+          new Promise<CodexAuthStatus>((resolve) => {
+            resolveLogin = resolve
+          })
       ),
       cancelLogin: vi.fn(),
       logoutIsolated: vi.fn()
@@ -655,16 +649,23 @@ describe('SettingsService: providers', () => {
     const service = createService(undefined, { codexAuth })
     await service.upsertProvider({ type: 'codex-isolated' })
 
-    // Importing existing authentication converges on the same app-owned runtime profile, so it does
-    // not create a second profile boundary while the browser flow is open.
     const pending = service.loginIsolatedCodex()
     await service.upsertProvider({ type: 'codex-shared' })
-    resolveLogin({ mode: 'isolated', supported: true, authenticated: true })
+    const imported = (await repository.getSettings()).providers[0]
+    expect(imported.codexAuthMode).toBe('imported')
+    await repository.upsertProvider({ ...imported, lastValidatedAt: 123 })
+    resolveLogin({
+      mode: 'isolated',
+      supported: true,
+      authenticated: false,
+      message: 'Codex sign-in timed out.'
+    })
 
-    await expect(pending).resolves.toMatchObject({ ok: true, applied: true })
+    await expect(pending).resolves.toMatchObject({ ok: false, applied: false })
     const stored = (await repository.getSettings()).providers[0]
     expect(stored.type).toBe('codex-isolated')
-    expect(stored.lastValidatedAt).toBeDefined()
+    expect(stored.codexAuthMode).toBe('imported')
+    expect(stored.lastValidatedAt).toBe(123)
     expect(stored.lastValidationFailure).toBeUndefined()
   })
 

--- a/src/main/settings/service.test.ts
+++ b/src/main/settings/service.test.ts
@@ -19,6 +19,7 @@ import type { ClaudeSharedAuthControllerPort } from './claude-shared-auth'
 import type { UserSkillRepository } from '../skills/user-skill-repository'
 import type { ResponsesBridge } from './responses-bridge'
 import type { NativeResponsesCompatibilityProxy } from './native-responses-compatibility'
+import type { SystemProxyEnvironment } from './system-proxy'
 
 // Reversible fake safeStorage so provider keys can be encrypted/decrypted without an OS keychain.
 vi.mock('electron', () => ({
@@ -141,6 +142,7 @@ const createService = (
     // When false, the ACP smoke test fails (adapter present but can't initialize).
     codexSmokeOk?: boolean
     codexAuth?: CodexAuthControllerPort
+    resolveCodexProxyEnvironment?: () => Promise<SystemProxyEnvironment>
     claudeIsolatedAuth?: ClaudeIsolatedAuthControllerPort
     claudeSharedAuth?: ClaudeSharedAuthControllerPort
     executeClaudeProbe?: (
@@ -219,6 +221,8 @@ const createService = (
       managedCodexPath: options.managedCodexNativePath ?? options.codexDetected?.nativePath
     },
     codexAuth: options.codexAuth,
+    resolveCodexProxyEnvironment:
+      options.resolveCodexProxyEnvironment ?? (() => Promise.resolve({})),
     // eslint-disable-next-line @typescript-eslint/no-explicit-any
     claudeIsolatedAuth: options.claudeIsolatedAuth as any,
     // eslint-disable-next-line @typescript-eslint/no-explicit-any
@@ -2315,7 +2319,14 @@ describe('SettingsService: preflight & spawn config', () => {
     await writeFile(adapterPath, MANAGED_CODEX_ADAPTER_FIXTURE, 'utf8')
     await chmod(adapterPath, 0o755)
     const service = createService(undefined, {
-      codexDetected: { path: adapterPath, version: 'codex-acp 1.1.4' }
+      codexDetected: { path: adapterPath, version: 'codex-acp 1.1.4' },
+      resolveCodexProxyEnvironment: () =>
+        Promise.resolve({
+          HTTP_PROXY: 'http://proxy.example.test:3128',
+          HTTPS_PROXY: 'http://proxy.example.test:3128',
+          http_proxy: 'http://proxy.example.test:3128',
+          https_proxy: 'http://proxy.example.test:3128'
+        })
     })
     await repository.setCodexInfo({
       resolvedPath: adapterPath,
@@ -2354,6 +2365,7 @@ describe('SettingsService: preflight & spawn config', () => {
     expect(backend.env.NO_BROWSER).toBeUndefined()
     expect(backend.env.CODEX_PATH).toBe('/data/codex-managed/native/codex')
     expect(backend.env.CODEX_HOME).toBe(join(storageRoot, 'codex-subscription'))
+    expect(backend.env.HTTPS_PROXY).toBe('http://proxy.example.test:3128')
     expect(await readFile(join(storageRoot, 'codex-subscription', 'config.toml'), 'utf8')).toBe(
       'cli_auth_credentials_store = "file"\n'
     )

--- a/src/main/settings/service.test.ts
+++ b/src/main/settings/service.test.ts
@@ -354,6 +354,40 @@ describe('SettingsService: providers', () => {
     )
   })
 
+  it('clears an imported Codex route when isolated setup is recreated after deletion', async () => {
+    const userCodexDir = join(storageRoot, 'user-codex')
+    await mkdir(userCodexDir, { recursive: true })
+    await writeFile(join(userCodexDir, 'auth.json'), '{"tokens":{"access_token":"secret"}}')
+    await writeFile(
+      join(userCodexDir, 'config.toml'),
+      [
+        'model_provider = "subscription-route"',
+        '',
+        '[model_providers.subscription-route]',
+        'name = "OpenAI"',
+        'requires_openai_auth = true',
+        'wire_api = "responses"',
+        'base_url = "http://127.0.0.1:1087/v1"',
+        ''
+      ].join('\n')
+    )
+    const service = createService(undefined, { userCodexDir })
+
+    await service.upsertProvider({ type: 'codex-shared' })
+    await service.deleteProvider(CODEX_SUBSCRIPTION_PROVIDER_ID)
+    expect((await repository.getSettings()).providers).toEqual([])
+
+    const isolated = await service.upsertProvider({ type: 'codex-isolated' })
+
+    await expect(
+      readFile(join(storageRoot, 'codex-subscription', 'config.toml'), 'utf8')
+    ).rejects.toMatchObject({ code: 'ENOENT' })
+    expect(isolated.providers[0]).toMatchObject({
+      type: 'codex-isolated',
+      codexAuthMode: 'isolated'
+    })
+  })
+
   it('refreshes an imported Codex profile only when re-import is explicitly requested', async () => {
     const userCodexDir = join(storageRoot, 'user-codex')
     await mkdir(userCodexDir, { recursive: true })

--- a/src/main/settings/service.test.ts
+++ b/src/main/settings/service.test.ts
@@ -10,7 +10,7 @@ import {
   CODEX_SUBSCRIPTION_PROVIDER_ID,
   type ClaudeDetectResult
 } from '../../shared/settings'
-import type { CodexAuthControllerPort } from './codex-auth'
+import type { CodexAuthControllerPort, CodexAuthStatus } from './codex-auth'
 import type {
   ClaudeIsolatedAuthControllerPort,
   ClaudeIsolatedAuthStatus
@@ -528,6 +528,37 @@ describe('SettingsService: providers', () => {
 
     const stored = await repository.getSettings()
     expect(stored.providers.every((provider) => provider.lastValidatedAt !== undefined)).toBe(true)
+  })
+
+  it('does not apply a pending Codex validation after the subscription auth mode changes', async () => {
+    const userCodexDir = join(storageRoot, 'user-codex')
+    await mkdir(userCodexDir, { recursive: true })
+    await writeFile(join(userCodexDir, 'auth.json'), '{"tokens":{"access_token":"secret"}}')
+    let finishStatus!: () => void
+    const codexAuth: CodexAuthControllerPort = {
+      getStatus: vi.fn(
+        () =>
+          new Promise<CodexAuthStatus>((resolve) => {
+            finishStatus = () => resolve({ mode: 'isolated', supported: true, authenticated: true })
+          })
+      ),
+      loginIsolated: vi.fn(),
+      cancelLogin: vi.fn(),
+      logoutIsolated: vi.fn()
+    }
+    const service = createService(undefined, { codexAuth, userCodexDir })
+    await service.upsertProvider({ type: 'codex-shared' })
+
+    const validation = service.validateProvider({ providerId: CODEX_SUBSCRIPTION_PROVIDER_ID })
+    await vi.waitFor(() => expect(codexAuth.getStatus).toHaveBeenCalledOnce())
+    await service.upsertProvider({ type: 'codex-isolated' })
+    finishStatus()
+
+    await expect(validation).resolves.toMatchObject({ ok: true, applied: false })
+    const stored = (await repository.getSettings()).providers[0]
+    expect(stored.codexAuthMode).toBe('isolated')
+    expect(stored.lastValidatedAt).toBeUndefined()
+    expect(stored.lastValidationFailure).toBeUndefined()
   })
 
   it('reports an unauthenticated isolated status without triggering sign-in', async () => {

--- a/src/main/settings/service.test.ts
+++ b/src/main/settings/service.test.ts
@@ -280,6 +280,7 @@ describe('SettingsService: providers', () => {
     )
     expect(await readFile(join(storageRoot, 'codex-subscription', 'config.toml'), 'utf8')).toBe(
       [
+        'cli_auth_credentials_store = "file"',
         '# Open Science: begin imported Codex route selection',
         'model_provider = "subscription-route"',
         '# Open Science: end imported Codex route selection',
@@ -343,15 +344,15 @@ describe('SettingsService: providers', () => {
 
     await expect(
       readFile(join(storageRoot, 'codex-subscription', 'config.toml'), 'utf8')
+    ).resolves.toBe('cli_auth_credentials_store = "file"\n')
+    await expect(
+      readFile(join(storageRoot, 'codex-subscription', 'auth.json'), 'utf8')
     ).rejects.toMatchObject({ code: 'ENOENT' })
     expect(isolated.providers[0]).toMatchObject({
       type: 'codex-isolated',
       codexAuthMode: 'isolated'
     })
     expect(isolated.providers[0].lastValidatedAt).toBeUndefined()
-    expect(await readFile(join(storageRoot, 'codex-subscription', 'auth.json'), 'utf8')).toBe(
-      '{"tokens":{"access_token":"secret"}}'
-    )
   })
 
   it('clears an imported Codex route when isolated setup is recreated after deletion', async () => {
@@ -381,6 +382,9 @@ describe('SettingsService: providers', () => {
 
     await expect(
       readFile(join(storageRoot, 'codex-subscription', 'config.toml'), 'utf8')
+    ).resolves.toBe('cli_auth_credentials_store = "file"\n')
+    await expect(
+      readFile(join(storageRoot, 'codex-subscription', 'auth.json'), 'utf8')
     ).rejects.toMatchObject({ code: 'ENOENT' })
     expect(isolated.providers[0]).toMatchObject({
       type: 'codex-isolated',
@@ -854,7 +858,7 @@ describe('SettingsService: providers', () => {
     expect(snapshot.providers[0].lastValidatedAt).toBeUndefined()
   })
 
-  it('cancels isolated login and clears provider readiness on logout', async () => {
+  it('cancels isolated login and removes only the app-owned credential on logout', async () => {
     const codexAuth: CodexAuthControllerPort = {
       getStatus: vi.fn(),
       loginIsolated: vi.fn().mockResolvedValue({
@@ -872,50 +876,44 @@ describe('SettingsService: providers', () => {
     const service = createService(undefined, { codexAuth })
     await service.upsertProvider({ type: 'codex-isolated' })
     await service.loginIsolatedCodex()
+    const appAuthPath = join(storageRoot, 'codex-subscription', 'auth.json')
+    await writeFile(appAuthPath, '{"tokens":{"access_token":"isolated"}}')
 
     service.cancelCodexLogin()
     await service.logoutIsolatedCodex()
 
-    expect(codexAuth.cancelLogin).toHaveBeenCalledOnce()
-    expect(codexAuth.logoutIsolated).toHaveBeenCalledOnce()
+    expect(codexAuth.cancelLogin).toHaveBeenCalledTimes(2)
+    expect(codexAuth.logoutIsolated).not.toHaveBeenCalled()
+    await expect(readFile(appAuthPath, 'utf8')).rejects.toMatchObject({ code: 'ENOENT' })
     const stored = (await repository.getSettings()).providers[0]
     expect(stored.lastValidatedAt).toBeUndefined()
     expect(stored.lastValidationFailure).toBeUndefined()
   })
 
-  it('preserves the verified markers when isolated sign-out times out', async () => {
-    // The P1 fix: a timed-out sign-out never called logout(), so the credential may still be in the
-    // isolated home. Clearing lastValidatedAt would falsely mark the provider as signed out while
-    // the credential is usable — instead preserve the verified state and return the failure so the
-    // user knows to retry.
+  it('rejects isolated logout for imported authentication without deleting its copy', async () => {
     const codexAuth = {
       getStatus: vi.fn(),
-      loginIsolated: vi.fn().mockResolvedValue({
-        mode: 'isolated',
-        supported: true,
-        authenticated: true
-      }),
+      loginIsolated: vi.fn(),
       cancelLogin: vi.fn(),
-      logoutIsolated: vi.fn().mockResolvedValue({
-        mode: 'isolated',
-        supported: true,
-        authenticated: false,
-        message: 'Codex sign-out timed out.'
-      })
+      logoutIsolated: vi.fn()
     }
     const service = createService(undefined, { codexAuth })
-    await service.upsertProvider({ type: 'codex-isolated' })
-    await service.loginIsolatedCodex()
+    await service.upsertProvider({ type: 'codex-shared' })
+    const appAuthPath = join(storageRoot, 'codex-subscription', 'auth.json')
 
     const result = await service.logoutIsolatedCodex()
 
-    expect(result).toEqual({ ok: false, category: 'timeout', message: 'Codex sign-out timed out.' })
-    const stored = (await repository.getSettings()).providers[0]
-    expect(stored.lastValidatedAt).toBeGreaterThan(0)
-    expect(stored.lastValidationFailure).toBeUndefined()
+    expect(result).toEqual({
+      ok: false,
+      category: 'unknown',
+      message: 'No isolated Open Science Codex login is configured.'
+    })
+    expect(codexAuth.cancelLogin).not.toHaveBeenCalled()
+    expect(codexAuth.logoutIsolated).not.toHaveBeenCalled()
+    await expect(readFile(appAuthPath, 'utf8')).resolves.toContain('access_token')
   })
 
-  it('returns success when isolated sign-out completes cleanly', async () => {
+  it('returns success when the app-owned isolated credential is already absent', async () => {
     const codexAuth = {
       getStatus: vi.fn(),
       loginIsolated: vi.fn().mockResolvedValue({
@@ -937,6 +935,8 @@ describe('SettingsService: providers', () => {
     const result = await service.logoutIsolatedCodex()
 
     expect(result).toEqual({ ok: true, category: 'ok' })
+    expect(codexAuth.cancelLogin).toHaveBeenCalledOnce()
+    expect(codexAuth.logoutIsolated).not.toHaveBeenCalled()
     const stored = (await repository.getSettings()).providers[0]
     expect(stored.lastValidatedAt).toBeUndefined()
     expect(stored.lastValidationFailure).toBeUndefined()
@@ -2354,6 +2354,9 @@ describe('SettingsService: preflight & spawn config', () => {
     expect(backend.env.NO_BROWSER).toBeUndefined()
     expect(backend.env.CODEX_PATH).toBe('/data/codex-managed/native/codex')
     expect(backend.env.CODEX_HOME).toBe(join(storageRoot, 'codex-subscription'))
+    expect(await readFile(join(storageRoot, 'codex-subscription', 'config.toml'), 'utf8')).toBe(
+      'cli_auth_credentials_store = "file"\n'
+    )
     expect(await readFile(join(storageRoot, 'codex', 'config.toml'), 'utf8')).toBe(
       'model = "account-default"\ncli_auth_credentials_store = "ephemeral"\n'
     )

--- a/src/main/settings/service.ts
+++ b/src/main/settings/service.ts
@@ -2236,6 +2236,12 @@ class SettingsService {
         this.userCodexDir,
         codexSubscriptionStorageDir(this.storageRoot)
       )
+      // Re-import can replace auth.json and the loopback route without changing any persisted
+      // provider field. Advance the generation so a status check started against the previous copy
+      // cannot write its result onto the refreshed credentials.
+      if (reimportCodexAuthentication && requestedId) {
+        this.advanceProviderValidationGeneration(requestedId)
+      }
     } else if (request.type === 'codex-isolated' && existing?.codexAuthMode !== 'isolated') {
       await clearImportedCodexProviderRoute(codexSubscriptionStorageDir(this.storageRoot))
     }
@@ -2862,11 +2868,8 @@ class SettingsService {
       : undefined
 
     const validationGeneration = resolved.storedId
-      ? (this.providerValidationGenerations.get(resolved.storedId) ?? 0) + 1
+      ? this.advanceProviderValidationGeneration(resolved.storedId)
       : undefined
-    if (resolved.storedId && validationGeneration !== undefined) {
-      this.providerValidationGenerations.set(resolved.storedId, validationGeneration)
-    }
 
     // Test against the framework the agent will actually spawn with. An OpenAI-only gateway tested
     // while Claude Code is active would otherwise fail a raw /v1/messages probe and be reported as an
@@ -4145,6 +4148,12 @@ class SettingsService {
       left.key === right.key &&
       (left.apiEndpoints ?? []).join(',') === (right.apiEndpoints ?? []).join(',')
     )
+  }
+
+  private advanceProviderValidationGeneration(providerId: string): number {
+    const generation = (this.providerValidationGenerations.get(providerId) ?? 0) + 1
+    this.providerValidationGenerations.set(providerId, generation)
+    return generation
   }
 
   private async runClaudeSubscriptionProbe(

--- a/src/main/settings/service.ts
+++ b/src/main/settings/service.ts
@@ -2260,7 +2260,10 @@ class SettingsService {
 
     if (isCodexSubscriptionProvider(request.type)) {
       provider.apiEndpoints = ['responses']
-      credentialsChanged = existing !== undefined && existing.type !== request.type
+      provider.codexAuthMode = request.type === 'codex-shared' ? 'imported' : 'isolated'
+      credentialsChanged =
+        existing !== undefined &&
+        (request.type === 'codex-shared' || existing.codexAuthMode !== provider.codexAuthMode)
     } else if (request.type === 'claude-isolated') {
       // claude-isolated has no fields of its own: the type tells the renderer/env-builder what to do
       // with the encrypted token (stored separately on login). A model override is allowed. The
@@ -3827,6 +3830,7 @@ class SettingsService {
     return {
       id: provider.id,
       type: provider.type,
+      codexAuthMode: provider.codexAuthMode,
       name: provider.name,
       apiEndpoints: this.resolveProviderApiEndpoints(provider),
       baseUrl: provider.baseUrl,

--- a/src/main/settings/service.ts
+++ b/src/main/settings/service.ts
@@ -2433,10 +2433,12 @@ class SettingsService {
     )
     // The provider can be edited while the browser flow is open. Unless the stored record is still
     // the isolated subscription the login was started for, the outcome is stale and discarded —
-    // recording it could stamp a switched-to-shared (and unauthenticated) profile as verified. Flag
+    // recording it could overwrite a switched-to-imported profile's independent validation. Flag
     // it as not-applied so a caller gating navigation on success (onboarding) does not advance on a
     // result the stored provider never received.
-    if (provider?.type !== 'codex-isolated') return { ...result, applied: false }
+    if (provider?.type !== 'codex-isolated' || provider.codexAuthMode !== 'isolated') {
+      return { ...result, applied: false }
+    }
 
     await this.repository.upsertProvider(
       result.ok

--- a/src/main/settings/service.ts
+++ b/src/main/settings/service.ts
@@ -2205,14 +2205,6 @@ class SettingsService {
   // Encrypts any new key, recomputes its mask, and inserts/updates the provider record.
   async upsertProvider(request: UpsertProviderRequest): Promise<SettingsSnapshot> {
     const settings = await this.repository.getSettings()
-    if (request.type === 'codex-shared') {
-      await importCodexAuthentication(
-        this.userCodexDir,
-        codexSubscriptionStorageDir(this.storageRoot)
-      )
-    } else if (request.type === 'codex-isolated') {
-      await clearImportedCodexProviderRoute(codexSubscriptionStorageDir(this.storageRoot))
-    }
     // Both Codex and Claude subscription providers use a fixed builtin id so the add path, the
     // token-save path, and every id-keyed lookup in this service converge on a single record.
     // Without this, a random id from `createProviderId()` would shadow the token-holding record
@@ -2228,6 +2220,18 @@ class SettingsService {
     const existing = requestedId
       ? settings.providers.find((provider) => provider.id === requestedId)
       : undefined
+
+    // An imported subscription becomes app-owned after the initial copy. Ordinary edits must not
+    // depend on the external CLI profile still existing or re-read a route that changed afterward.
+    // Only a new import or an explicit isolated -> imported switch crosses that profile boundary.
+    if (request.type === 'codex-shared' && existing?.codexAuthMode !== 'imported') {
+      await importCodexAuthentication(
+        this.userCodexDir,
+        codexSubscriptionStorageDir(this.storageRoot)
+      )
+    } else if (request.type === 'codex-isolated' && existing?.codexAuthMode !== 'isolated') {
+      await clearImportedCodexProviderRoute(codexSubscriptionStorageDir(this.storageRoot))
+    }
 
     const provider: StoredProvider = {
       id: subscriptionIdentity?.id ?? existing?.id ?? this.createProviderId(),
@@ -2262,8 +2266,7 @@ class SettingsService {
       provider.apiEndpoints = ['responses']
       provider.codexAuthMode = request.type === 'codex-shared' ? 'imported' : 'isolated'
       credentialsChanged =
-        existing !== undefined &&
-        (request.type === 'codex-shared' || existing.codexAuthMode !== provider.codexAuthMode)
+        existing !== undefined && existing.codexAuthMode !== provider.codexAuthMode
     } else if (request.type === 'claude-isolated') {
       // claude-isolated has no fields of its own: the type tells the renderer/env-builder what to do
       // with the encrypted token (stored separately on login). A model override is allowed. The

--- a/src/main/settings/service.ts
+++ b/src/main/settings/service.ts
@@ -230,8 +230,10 @@ import type {
 } from './types'
 import { classifyStatus, validateProvider } from './validate'
 import {
+  clearAppOwnedCodexAuthentication,
   clearImportedCodexProviderRoute,
   CodexAuthController,
+  ensureCodexAuthHome,
   importCodexAuthentication,
   openCodexAuthSession,
   type CodexAuthControllerPort,
@@ -2243,7 +2245,15 @@ class SettingsService {
         this.advanceProviderValidationGeneration(requestedId)
       }
     } else if (request.type === 'codex-isolated' && existing?.codexAuthMode !== 'isolated') {
-      await clearImportedCodexProviderRoute(codexSubscriptionStorageDir(this.storageRoot))
+      const codexHome = codexSubscriptionStorageDir(this.storageRoot)
+      await clearImportedCodexProviderRoute(codexHome)
+      await clearAppOwnedCodexAuthentication(codexHome)
+    }
+    if (isCodexSubscriptionProvider(request.type)) {
+      await ensureCodexAuthHome(
+        request.type === 'codex-shared' ? 'shared' : 'isolated',
+        this.storageRoot
+      )
     }
 
     const provider: StoredProvider = {
@@ -2477,33 +2487,38 @@ class SettingsService {
   }
 
   async logoutIsolatedCodex(): Promise<ValidateProviderResult> {
-    const status = await this.codexAuth.logoutIsolated()
-
-    // A sign-out is confirmed only when the adapter acknowledged it cleanly, which is the only path
-    // that sets no message. A timeout or capability failure leaves the status ambiguous — the
-    // credential may still be in the isolated home — so we preserve the verified markers and surface
-    // the failure rather than falsely reporting the account as signed out.
-    const succeeded = status.authenticated === false && status.message === undefined
-
     const settings = await this.repository.getSettings()
     const provider = settings.providers.find(
       (candidate) => candidate.id === codexSubscriptionProviderIdentity().id
     )
-    if (provider && succeeded) {
-      await this.repository.upsertProvider({
-        ...provider,
-        lastValidatedAt: undefined,
-        lastValidationFailure: undefined
-      })
-    }
-
-    if (!succeeded) {
+    if (provider?.type !== 'codex-isolated' || provider.codexAuthMode !== 'isolated') {
       return {
         ok: false,
-        category: status.message?.toLowerCase().includes('timed out') ? 'timeout' : 'unknown',
-        message: status.message ?? 'Codex sign-out did not complete.'
+        category: 'unknown',
+        message: 'No isolated Open Science Codex login is configured.'
       }
     }
+
+    // Never call the adapter's account/logout here. A legacy isolated profile may still hold a
+    // token copied from the user's CLI profile, and remotely revoking it would sign the CLI out as
+    // well. Removing only the file under the app-owned CODEX_HOME disconnects Open Science while
+    // preserving every external Codex login.
+    this.codexAuth.cancelLogin()
+    try {
+      await clearAppOwnedCodexAuthentication(codexSubscriptionStorageDir(this.storageRoot))
+    } catch {
+      return {
+        ok: false,
+        category: 'unknown',
+        message: 'The Open Science Codex login could not be removed.'
+      }
+    }
+
+    await this.repository.upsertProvider({
+      ...provider,
+      lastValidatedAt: undefined,
+      lastValidationFailure: undefined
+    })
 
     return { ok: true, category: 'ok' }
   }
@@ -3587,6 +3602,12 @@ class SettingsService {
         ? await this.probeCodexNativeVersion(settings.codex?.nativePath)
         : undefined
     const provider = this.resolveProvider(activeProvider, effectiveModel)
+    if (framework.id === 'codex' && isCodexSubscriptionProvider(provider.type)) {
+      // Runtime resolution can be reached without opening a Settings auth session first. Enforce
+      // file-backed credentials here as well so a direct prompt never falls through to the user's
+      // global Codex keyring.
+      await ensureCodexAuthHome('isolated', this.storageRoot)
+    }
     // `codex-shared` is accepted only as a legacy/provider-time import request. Every runtime
     // subscription record converges on the same app-owned backend and profile boundary.
     const backendProviderId =

--- a/src/main/settings/service.ts
+++ b/src/main/settings/service.ts
@@ -229,6 +229,7 @@ import type {
 } from './types'
 import { classifyStatus, validateProvider } from './validate'
 import {
+  clearImportedCodexProviderRoute,
   CodexAuthController,
   importCodexAuthentication,
   openCodexAuthSession,
@@ -2209,6 +2210,8 @@ class SettingsService {
         this.userCodexDir,
         codexSubscriptionStorageDir(this.storageRoot)
       )
+    } else if (request.type === 'codex-isolated') {
+      await clearImportedCodexProviderRoute(codexSubscriptionStorageDir(this.storageRoot))
     }
     // Both Codex and Claude subscription providers use a fixed builtin id so the add path, the
     // token-save path, and every id-keyed lookup in this service converge on a single record.

--- a/src/main/settings/service.ts
+++ b/src/main/settings/service.ts
@@ -2224,8 +2224,14 @@ class SettingsService {
 
     // An imported subscription becomes app-owned after the initial copy. Ordinary edits must not
     // depend on the external CLI profile still existing or re-read a route that changed afterward.
-    // Only a new import or an explicit isolated -> imported switch crosses that profile boundary.
-    if (request.type === 'codex-shared' && existing?.codexAuthMode !== 'imported') {
+    // Only a new import, an explicit isolated -> imported switch, or the card's explicit re-import
+    // action crosses that profile boundary.
+    const reimportCodexAuthentication =
+      request.type === 'codex-shared' && request.reimportCodexAuthentication === true
+    if (
+      request.type === 'codex-shared' &&
+      (existing?.codexAuthMode !== 'imported' || reimportCodexAuthentication)
+    ) {
       await importCodexAuthentication(
         this.userCodexDir,
         codexSubscriptionStorageDir(this.storageRoot)
@@ -2267,7 +2273,8 @@ class SettingsService {
       provider.apiEndpoints = ['responses']
       provider.codexAuthMode = request.type === 'codex-shared' ? 'imported' : 'isolated'
       credentialsChanged =
-        existing !== undefined && existing.codexAuthMode !== provider.codexAuthMode
+        existing !== undefined &&
+        (existing.codexAuthMode !== provider.codexAuthMode || reimportCodexAuthentication)
     } else if (request.type === 'claude-isolated') {
       // claude-isolated has no fields of its own: the type tells the renderer/env-builder what to do
       // with the encrypted token (stored separately on login). A model override is allowed. The

--- a/src/main/settings/service.ts
+++ b/src/main/settings/service.ts
@@ -85,6 +85,7 @@ import {
   isCodexSubscriptionProvider,
   isProviderUsableByFramework,
   providerEndpoints,
+  resolveCodexSubscriptionType,
   requiresChatCompletionsBridge
 } from '../../shared/settings'
 import type { PackageMirror } from '../../shared/mirror'
@@ -2881,7 +2882,9 @@ class SettingsService {
             // action (loginIsolatedCodex), so testing or saving a provider never pops a browser the
             // user didn't ask for.
             await this.codexAuth.getStatus(
-              resolved.provider.type === 'codex-shared' ? 'shared' : 'isolated'
+              resolveCodexSubscriptionType(resolved.provider) === 'codex-shared'
+                ? 'shared'
+                : 'isolated'
             ),
             'Not signed in. Use Sign in to connect your ChatGPT account.'
           )

--- a/src/main/settings/service.ts
+++ b/src/main/settings/service.ts
@@ -4003,6 +4003,7 @@ class SettingsService {
 
     return {
       type: provider.type,
+      ...(provider.codexAuthMode === undefined ? {} : { codexAuthMode: provider.codexAuthMode }),
       baseUrl: provider.baseUrl,
       model,
       ...(contextWindow === undefined ? {} : { contextWindow }),
@@ -4122,6 +4123,7 @@ class SettingsService {
   private sameValidationTarget(left: ResolvedProvider, right: ResolvedProvider): boolean {
     return (
       left.type === right.type &&
+      left.codexAuthMode === right.codexAuthMode &&
       left.baseUrl === right.baseUrl &&
       left.openaiBaseUrl === right.openaiBaseUrl &&
       left.model === right.model &&

--- a/src/main/settings/service.ts
+++ b/src/main/settings/service.ts
@@ -512,7 +512,7 @@ export type SettingsServiceOptions = {
   codexAuth?: CodexAuthControllerPort
   // Resolves the user's current native/PAC proxy for Codex subscription traffic. Injectable so
   // tests do not depend on the host machine's Electron session configuration.
-  resolveCodexProxyEnvironment?: () => Promise<SystemProxyEnvironment>
+  resolveCodexProxyEnvironment?: () => Promise<SystemProxyEnvironment | undefined>
   // Encrypted-token controller for claude-isolated; default-constructed against this.storageRoot
   // when omitted. Storage is delegated to the host's SettingsRepository + encrypt/tryDecryptKey
   // pipeline, mirroring how CodexAuthController delegates to openCodexAuthSession.
@@ -546,7 +546,7 @@ class SettingsService {
   private readonly installManagedCodexImpl: (
     options: InstallManagedCodexOptions
   ) => Promise<ManagedCodexInstallOutcome>
-  private readonly resolveCodexProxyEnvironment: () => Promise<SystemProxyEnvironment>
+  private readonly resolveCodexProxyEnvironment: () => Promise<SystemProxyEnvironment | undefined>
   private readonly codexAuth: CodexAuthControllerPort
   private readonly claudeIsolatedAuth: ClaudeIsolatedAuthControllerPort
   private readonly claudeSharedAuth: ClaudeSharedAuthControllerPort
@@ -2513,6 +2513,10 @@ class SettingsService {
     // preserving every external Codex login.
     this.codexAuth.cancelLogin()
     try {
+      // Legacy isolated homes could still point at the OS keychain. Pin the app-owned profile to the
+      // file store before removing auth.json so future status/runtime checks cannot re-authenticate
+      // through a credential shared with the user's global CLI profile.
+      await ensureCodexAuthHome('isolated', this.storageRoot)
       await clearAppOwnedCodexAuthentication(codexSubscriptionStorageDir(this.storageRoot))
     } catch {
       return {
@@ -3662,10 +3666,9 @@ class SettingsService {
         instructions: connectorInstructions
       })
       await writeAgentConfigFiles(modelConfig.configFiles)
-      const proxyEnv =
+      const usesCodexSystemProxy =
         framework.id === 'codex' && isCodexSubscriptionProvider(provider.type)
-          ? await this.resolveCodexProxyEnvironment()
-          : {}
+      const proxyEnv = usesCodexSystemProxy ? await this.resolveCodexProxyEnvironment() : undefined
 
       // Protocol-driven frameworks apply an explicit model through the ACP session configOption. A Codex
       // subscription with no explicit selection leaves this undefined so Codex uses the account default.
@@ -3676,12 +3679,15 @@ class SettingsService {
         executablePath,
         env: {
           ...(modelConfig.env ?? {}),
-          ...proxyEnv,
+          ...(proxyEnv ?? {}),
           ...(framework.id === 'codex' && settings.codex?.nativePath
             ? { CODEX_PATH: settings.codex.nativePath }
             : {})
         },
         args: modelConfig.args,
+        ...(usesCodexSystemProxy
+          ? { proxyEnvironmentMode: proxyEnv === undefined ? 'inherit' : 'replace' }
+          : {}),
         sessionModel,
         ...(framework.id === 'codex' && isCodexSubscriptionProvider(provider.type) && sessionModel
           ? { sessionModelRequired: true }

--- a/src/main/settings/service.ts
+++ b/src/main/settings/service.ts
@@ -83,6 +83,7 @@ import {
   isClaudeSubscriptionProvider,
   isClaudeSubscriptionProviderId,
   isCodexSubscriptionProvider,
+  isCodexSubscriptionProviderId,
   isProviderUsableByFramework,
   providerEndpoints,
   resolveCodexSubscriptionType,
@@ -2242,6 +2243,9 @@ class SettingsService {
       request.type === 'codex-shared' &&
       (existing?.codexAuthMode !== 'imported' || reimportCodexAuthentication)
     ) {
+      // The isolated adapter owns auth.json until its session has closed. Waiting here prevents a
+      // late browser-login write from replacing the credentials copied immediately below.
+      await this.codexAuth.cancelLogin()
       await importCodexAuthentication(
         this.userCodexDir,
         codexSubscriptionStorageDir(this.storageRoot)
@@ -2253,6 +2257,7 @@ class SettingsService {
         this.advanceProviderValidationGeneration(requestedId)
       }
     } else if (request.type === 'codex-isolated' && existing?.codexAuthMode !== 'isolated') {
+      if (existing) await this.codexAuth.cancelLogin()
       const codexHome = codexSubscriptionStorageDir(this.storageRoot)
       await clearImportedCodexProviderRoute(codexHome)
       await clearAppOwnedCodexAuthentication(codexHome)
@@ -2435,6 +2440,13 @@ class SettingsService {
   }
 
   async deleteProvider(id: string): Promise<SettingsSnapshot> {
+    if (isCodexSubscriptionProviderId(id)) {
+      await this.codexAuth.cancelLogin()
+      const codexHome = codexSubscriptionStorageDir(this.storageRoot)
+      await clearImportedCodexProviderRoute(codexHome)
+      await clearAppOwnedCodexAuthentication(codexHome)
+    }
+
     if (isClaudeSubscriptionProviderId(id)) {
       this.claudeIsolatedAuth.cancelLogin()
       this.claudeSharedAuth.cancelLogin()
@@ -2446,7 +2458,7 @@ class SettingsService {
   }
 
   cancelCodexLogin(): void {
-    this.codexAuth.cancelLogin()
+    void this.codexAuth.cancelLogin()
   }
 
   cancelClaudeLogin(): void {
@@ -2511,7 +2523,7 @@ class SettingsService {
     // token copied from the user's CLI profile, and remotely revoking it would sign the CLI out as
     // well. Removing only the file under the app-owned CODEX_HOME disconnects Open Science while
     // preserving every external Codex login.
-    this.codexAuth.cancelLogin()
+    await this.codexAuth.cancelLogin()
     try {
       // Legacy isolated homes could still point at the OS keychain. Pin the app-owned profile to the
       // file store before removing auth.json so future status/runtime checks cannot re-authenticate

--- a/src/main/settings/service.ts
+++ b/src/main/settings/service.ts
@@ -239,6 +239,7 @@ import {
   type CodexAuthControllerPort,
   type CodexAuthStatus
 } from './codex-auth'
+import { resolveSystemProxyEnvironment, type SystemProxyEnvironment } from './system-proxy'
 import {
   ClaudeIsolatedAuthController,
   type ClaudeIsolatedAuthControllerPort,
@@ -509,6 +510,9 @@ export type SettingsServiceOptions = {
     options: InstallManagedCodexOptions
   ) => Promise<ManagedCodexInstallOutcome>
   codexAuth?: CodexAuthControllerPort
+  // Resolves the user's current native/PAC proxy for Codex subscription traffic. Injectable so
+  // tests do not depend on the host machine's Electron session configuration.
+  resolveCodexProxyEnvironment?: () => Promise<SystemProxyEnvironment>
   // Encrypted-token controller for claude-isolated; default-constructed against this.storageRoot
   // when omitted. Storage is delegated to the host's SettingsRepository + encrypt/tryDecryptKey
   // pipeline, mirroring how CodexAuthController delegates to openCodexAuthSession.
@@ -542,6 +546,7 @@ class SettingsService {
   private readonly installManagedCodexImpl: (
     options: InstallManagedCodexOptions
   ) => Promise<ManagedCodexInstallOutcome>
+  private readonly resolveCodexProxyEnvironment: () => Promise<SystemProxyEnvironment>
   private readonly codexAuth: CodexAuthControllerPort
   private readonly claudeIsolatedAuth: ClaudeIsolatedAuthControllerPort
   private readonly claudeSharedAuth: ClaudeSharedAuthControllerPort
@@ -601,6 +606,8 @@ class SettingsService {
     this.installManagedClaudeImpl = options.installManagedClaudeImpl ?? installManagedClaude
     this.installManagedOpencodeImpl = options.installManagedOpencodeImpl ?? installManagedOpencode
     this.installManagedCodexImpl = options.installManagedCodexImpl ?? installManagedCodex
+    this.resolveCodexProxyEnvironment =
+      options.resolveCodexProxyEnvironment ?? resolveSystemProxyEnvironment
     this.codexAuth =
       options.codexAuth ??
       new CodexAuthController({
@@ -613,7 +620,8 @@ class SettingsService {
             ),
             nativePath: settings.codex?.nativePath,
             mode,
-            storageRoot: this.storageRoot
+            storageRoot: this.storageRoot,
+            proxyEnv: await this.resolveCodexProxyEnvironment()
           })
         }
       })
@@ -3654,6 +3662,10 @@ class SettingsService {
         instructions: connectorInstructions
       })
       await writeAgentConfigFiles(modelConfig.configFiles)
+      const proxyEnv =
+        framework.id === 'codex' && isCodexSubscriptionProvider(provider.type)
+          ? await this.resolveCodexProxyEnvironment()
+          : {}
 
       // Protocol-driven frameworks apply an explicit model through the ACP session configOption. A Codex
       // subscription with no explicit selection leaves this undefined so Codex uses the account default.
@@ -3664,6 +3676,7 @@ class SettingsService {
         executablePath,
         env: {
           ...(modelConfig.env ?? {}),
+          ...proxyEnv,
           ...(framework.id === 'codex' && settings.codex?.nativePath
             ? { CODEX_PATH: settings.codex.nativePath }
             : {})

--- a/src/main/settings/system-proxy.test.ts
+++ b/src/main/settings/system-proxy.test.ts
@@ -28,15 +28,42 @@ describe('resolveSystemProxyEnvironment', () => {
   it('asks Electron to resolve the subscription origin', async () => {
     const resolveProxy = vi.fn().mockResolvedValue('HTTPS secure-proxy.example.test:8443')
 
-    await expect(resolveSystemProxyEnvironment(resolveProxy)).resolves.toMatchObject({
-      HTTPS_PROXY: 'https://secure-proxy.example.test:8443'
+    await expect(
+      resolveSystemProxyEnvironment(resolveProxy, {
+        NO_PROXY: 'metadata.example.test',
+        no_proxy: 'existing.internal'
+      })
+    ).resolves.toMatchObject({
+      HTTPS_PROXY: 'https://secure-proxy.example.test:8443',
+      NO_PROXY: expect.stringContaining('metadata.example.test'),
+      no_proxy: expect.stringContaining('existing.internal')
     })
     expect(resolveProxy).toHaveBeenCalledWith('https://chatgpt.com/')
+  })
+
+  it('bypasses the resolved proxy for every supported loopback route form', async () => {
+    const resolved = await resolveSystemProxyEnvironment(
+      vi.fn().mockResolvedValue('PROXY proxy.example.test:3128'),
+      {}
+    )
+
+    for (const host of ['localhost', '127.0.0.1', '127.0.0.0/8', '::1', '[::1]']) {
+      expect(resolved.NO_PROXY?.split(',')).toContain(host)
+      expect(resolved.no_proxy?.split(',')).toContain(host)
+    }
   })
 
   it('falls back to the inherited or direct network when resolution fails', async () => {
     const resolveProxy = vi.fn().mockRejectedValue(new Error('proxy resolver unavailable'))
 
     await expect(resolveSystemProxyEnvironment(resolveProxy)).resolves.toEqual({})
+  })
+
+  it('does not add bypass variables when the system selects direct access', async () => {
+    await expect(
+      resolveSystemProxyEnvironment(vi.fn().mockResolvedValue('DIRECT'), {
+        NO_PROXY: 'existing.internal'
+      })
+    ).resolves.toEqual({})
   })
 })

--- a/src/main/settings/system-proxy.test.ts
+++ b/src/main/settings/system-proxy.test.ts
@@ -1,0 +1,42 @@
+import { describe, expect, it, vi } from 'vitest'
+
+import { parseSystemProxyRules, resolveSystemProxyEnvironment } from './system-proxy'
+
+describe('parseSystemProxyRules', () => {
+  it('maps the first generic HTTP proxy to the standard child-process variables', () => {
+    expect(parseSystemProxyRules('PROXY proxy.example.test:3128; DIRECT')).toEqual({
+      HTTP_PROXY: 'http://proxy.example.test:3128',
+      HTTPS_PROXY: 'http://proxy.example.test:3128',
+      http_proxy: 'http://proxy.example.test:3128',
+      https_proxy: 'http://proxy.example.test:3128'
+    })
+  })
+
+  it('maps a SOCKS fallback to the protocol-neutral proxy variables', () => {
+    expect(parseSystemProxyRules('SOCKS5 localhost:9050')).toEqual({
+      ALL_PROXY: 'socks5://localhost:9050',
+      all_proxy: 'socks5://localhost:9050'
+    })
+  })
+
+  it('keeps a direct system decision direct', () => {
+    expect(parseSystemProxyRules('DIRECT')).toEqual({})
+  })
+})
+
+describe('resolveSystemProxyEnvironment', () => {
+  it('asks Electron to resolve the subscription origin', async () => {
+    const resolveProxy = vi.fn().mockResolvedValue('HTTPS secure-proxy.example.test:8443')
+
+    await expect(resolveSystemProxyEnvironment(resolveProxy)).resolves.toMatchObject({
+      HTTPS_PROXY: 'https://secure-proxy.example.test:8443'
+    })
+    expect(resolveProxy).toHaveBeenCalledWith('https://chatgpt.com/')
+  })
+
+  it('falls back to the inherited or direct network when resolution fails', async () => {
+    const resolveProxy = vi.fn().mockRejectedValue(new Error('proxy resolver unavailable'))
+
+    await expect(resolveSystemProxyEnvironment(resolveProxy)).resolves.toEqual({})
+  })
+})

--- a/src/main/settings/system-proxy.test.ts
+++ b/src/main/settings/system-proxy.test.ts
@@ -46,17 +46,18 @@ describe('resolveSystemProxyEnvironment', () => {
       vi.fn().mockResolvedValue('PROXY proxy.example.test:3128'),
       {}
     )
+    expect(resolved).toBeDefined()
 
     for (const host of ['localhost', '127.0.0.1', '127.0.0.0/8', '::1', '[::1]']) {
-      expect(resolved.NO_PROXY?.split(',')).toContain(host)
-      expect(resolved.no_proxy?.split(',')).toContain(host)
+      expect(resolved?.NO_PROXY?.split(',')).toContain(host)
+      expect(resolved?.no_proxy?.split(',')).toContain(host)
     }
   })
 
   it('falls back to the inherited or direct network when resolution fails', async () => {
     const resolveProxy = vi.fn().mockRejectedValue(new Error('proxy resolver unavailable'))
 
-    await expect(resolveSystemProxyEnvironment(resolveProxy)).resolves.toEqual({})
+    await expect(resolveSystemProxyEnvironment(resolveProxy)).resolves.toBeUndefined()
   })
 
   it('does not add bypass variables when the system selects direct access', async () => {

--- a/src/main/settings/system-proxy.ts
+++ b/src/main/settings/system-proxy.ts
@@ -104,7 +104,7 @@ export const parseSystemProxyRules = (rules: string): SystemProxyEnvironment => 
 export const resolveSystemProxyEnvironment = async (
   resolveProxy: ResolveProxy = (url) => session.defaultSession.resolveProxy(url),
   sourceEnv: NodeJS.ProcessEnv = process.env
-): Promise<SystemProxyEnvironment> => {
+): Promise<SystemProxyEnvironment | undefined> => {
   try {
     const proxyEnv = parseSystemProxyRules(await resolveProxy(CODEX_PROXY_TARGET_URL))
     if (Object.keys(proxyEnv).length === 0) return {}
@@ -117,8 +117,8 @@ export const resolveSystemProxyEnvironment = async (
 
     return { ...proxyEnv, NO_PROXY: noProxy, no_proxy: noProxy }
   } catch {
-    // A resolver failure must not block users whose network is reachable directly (or whose app
-    // process already carries proxy environment variables). The normal inherited environment stays.
-    return {}
+    // `undefined` is distinct from the empty environment produced by an explicit DIRECT decision.
+    // Callers preserve the app's inherited proxy variables only for this resolver-failure fallback.
+    return undefined
   }
 }

--- a/src/main/settings/system-proxy.ts
+++ b/src/main/settings/system-proxy.ts
@@ -5,21 +5,24 @@ import { session } from 'electron'
 // the native Codex process, which does not use Chromium's network stack itself.
 const CODEX_PROXY_TARGET_URL = 'https://chatgpt.com/'
 
-export type SystemProxyEnvironment = Partial<
-  Record<
-    | 'HTTP_PROXY'
-    | 'HTTPS_PROXY'
-    | 'http_proxy'
-    | 'https_proxy'
-    | 'ALL_PROXY'
-    | 'all_proxy'
-    | 'NO_PROXY'
-    | 'no_proxy',
-    string
-  >
->
+export const SYSTEM_PROXY_ENV_KEYS = [
+  'HTTP_PROXY',
+  'HTTPS_PROXY',
+  'http_proxy',
+  'https_proxy',
+  'ALL_PROXY',
+  'all_proxy',
+  'NO_PROXY',
+  'no_proxy'
+] as const
+
+export type SystemProxyEnvironment = Partial<Record<(typeof SYSTEM_PROXY_ENV_KEYS)[number], string>>
 
 export type ResolveProxy = (url: string) => Promise<string>
+
+export const clearSystemProxyEnvironment = (env: NodeJS.ProcessEnv): void => {
+  for (const key of SYSTEM_PROXY_ENV_KEYS) delete env[key]
+}
 
 // Imported subscription routes are intentionally restricted to loopback. Keep those local calls
 // out of a resolved corporate/system proxy while covering the common spellings understood by

--- a/src/main/settings/system-proxy.ts
+++ b/src/main/settings/system-proxy.ts
@@ -1,0 +1,92 @@
+import { session } from 'electron'
+
+// Resolve the same public origin the subscription contacts. Electron evaluates the user's native
+// proxy settings (including PAC rules) for this URL; the resulting endpoint can then be handed to
+// the native Codex process, which does not use Chromium's network stack itself.
+const CODEX_PROXY_TARGET_URL = 'https://chatgpt.com/'
+
+export type SystemProxyEnvironment = Partial<
+  Record<
+    'HTTP_PROXY' | 'HTTPS_PROXY' | 'http_proxy' | 'https_proxy' | 'ALL_PROXY' | 'all_proxy',
+    string
+  >
+>
+
+export type ResolveProxy = (url: string) => Promise<string>
+
+const proxyEnvironmentForDirective = (
+  kind: string,
+  address: string
+): SystemProxyEnvironment | undefined => {
+  const normalizedKind = kind.toUpperCase()
+  const scheme =
+    normalizedKind === 'HTTPS'
+      ? 'https'
+      : normalizedKind === 'SOCKS4'
+        ? 'socks4'
+        : normalizedKind === 'SOCKS' || normalizedKind === 'SOCKS5'
+          ? 'socks5'
+          : normalizedKind === 'PROXY' || normalizedKind === 'HTTP'
+            ? 'http'
+            : undefined
+  if (!scheme) return undefined
+
+  try {
+    const url = new URL(`${scheme}://${address}`)
+    if (
+      !url.hostname ||
+      url.username ||
+      url.password ||
+      (url.pathname !== '' && url.pathname !== '/') ||
+      url.search ||
+      url.hash
+    ) {
+      return undefined
+    }
+
+    // WHATWG URL reports the origin of non-special schemes such as socks5 as `null`; rebuild from
+    // the already-validated normalized host so every supported directive produces a usable URL.
+    const proxyUrl = `${scheme}://${url.host}`
+    if (scheme === 'socks4' || scheme === 'socks5') {
+      return { ALL_PROXY: proxyUrl, all_proxy: proxyUrl }
+    }
+
+    return {
+      HTTP_PROXY: proxyUrl,
+      HTTPS_PROXY: proxyUrl,
+      http_proxy: proxyUrl,
+      https_proxy: proxyUrl
+    }
+  } catch {
+    return undefined
+  }
+}
+
+// Electron returns a semicolon-delimited fallback list such as
+// `PROXY proxy.example:3128; DIRECT`. Preserve its order and use the first supported decision.
+export const parseSystemProxyRules = (rules: string): SystemProxyEnvironment => {
+  for (const rawDirective of rules.split(';')) {
+    const directive = rawDirective.trim()
+    if (!directive) continue
+
+    const [kind, ...addressParts] = directive.split(/\s+/)
+    if (kind.toUpperCase() === 'DIRECT') return {}
+
+    const environment = proxyEnvironmentForDirective(kind, addressParts.join(' '))
+    if (environment) return environment
+  }
+
+  return {}
+}
+
+export const resolveSystemProxyEnvironment = async (
+  resolveProxy: ResolveProxy = (url) => session.defaultSession.resolveProxy(url)
+): Promise<SystemProxyEnvironment> => {
+  try {
+    return parseSystemProxyRules(await resolveProxy(CODEX_PROXY_TARGET_URL))
+  } catch {
+    // A resolver failure must not block users whose network is reachable directly (or whose app
+    // process already carries proxy environment variables). The normal inherited environment stays.
+    return {}
+  }
+}

--- a/src/main/settings/system-proxy.ts
+++ b/src/main/settings/system-proxy.ts
@@ -7,12 +7,31 @@ const CODEX_PROXY_TARGET_URL = 'https://chatgpt.com/'
 
 export type SystemProxyEnvironment = Partial<
   Record<
-    'HTTP_PROXY' | 'HTTPS_PROXY' | 'http_proxy' | 'https_proxy' | 'ALL_PROXY' | 'all_proxy',
+    | 'HTTP_PROXY'
+    | 'HTTPS_PROXY'
+    | 'http_proxy'
+    | 'https_proxy'
+    | 'ALL_PROXY'
+    | 'all_proxy'
+    | 'NO_PROXY'
+    | 'no_proxy',
     string
   >
 >
 
 export type ResolveProxy = (url: string) => Promise<string>
+
+// Imported subscription routes are intentionally restricted to loopback. Keep those local calls
+// out of a resolved corporate/system proxy while covering the common spellings understood by
+// different HTTP stacks (host, IPv4 range/CIDR, and bracketed/unbracketed IPv6).
+const LOOPBACK_PROXY_BYPASS = [
+  'localhost',
+  '.localhost',
+  '127.0.0.1',
+  '127.0.0.0/8',
+  '::1',
+  '[::1]'
+] as const
 
 const proxyEnvironmentForDirective = (
   kind: string,
@@ -80,10 +99,20 @@ export const parseSystemProxyRules = (rules: string): SystemProxyEnvironment => 
 }
 
 export const resolveSystemProxyEnvironment = async (
-  resolveProxy: ResolveProxy = (url) => session.defaultSession.resolveProxy(url)
+  resolveProxy: ResolveProxy = (url) => session.defaultSession.resolveProxy(url),
+  sourceEnv: NodeJS.ProcessEnv = process.env
 ): Promise<SystemProxyEnvironment> => {
   try {
-    return parseSystemProxyRules(await resolveProxy(CODEX_PROXY_TARGET_URL))
+    const proxyEnv = parseSystemProxyRules(await resolveProxy(CODEX_PROXY_TARGET_URL))
+    if (Object.keys(proxyEnv).length === 0) return {}
+
+    const bypass = [sourceEnv.NO_PROXY, sourceEnv.no_proxy]
+      .flatMap((value) => value?.split(',') ?? [])
+      .map((value) => value.trim())
+      .filter(Boolean)
+    const noProxy = [...new Set([...bypass, ...LOOPBACK_PROXY_BYPASS])].join(',')
+
+    return { ...proxyEnv, NO_PROXY: noProxy, no_proxy: noProxy }
   } catch {
     // A resolver failure must not block users whose network is reachable directly (or whose app
     // process already carries proxy environment variables). The normal inherited environment stays.

--- a/src/main/settings/types.ts
+++ b/src/main/settings/types.ts
@@ -3,6 +3,7 @@ import type {
   ChatApiEndpoint,
   ClaudeSubscriptionProviderId,
   ClaudeInfo,
+  CodexSubscriptionAuthMode,
   CodexInfo,
   ProviderType,
   ProviderValidationFailure,
@@ -29,6 +30,9 @@ import type { AgentFrameworkId } from '../agent-framework'
 export type StoredProvider = {
   id: string
   type: ProviderType
+  // Records whether the app-owned Codex profile came from an import or an in-app sign-in. Runtime
+  // behavior still keys on the normalized codex-isolated provider type.
+  codexAuthMode?: CodexSubscriptionAuthMode
   name: string
   // Which chat APIs a custom gateway speaks. Official providers derive it from the registry; absent
   // means ['anthropic'] (all pre-existing providers). Legacy records may carry the removed scalar

--- a/src/renderer/src/pages/settings/ProviderForm.render.test.tsx
+++ b/src/renderer/src/pages/settings/ProviderForm.render.test.tsx
@@ -180,7 +180,7 @@ describe('ProviderForm field switching', () => {
     expect(container.querySelector('[aria-label="API key"]')).toBeNull()
     expect(container.querySelector('[aria-label="Model"]')).toBeNull()
     expect(container.textContent).toContain(
-      "Copies Codex authentication and, when compatible, the active provider's non-secret network route into Open Science"
+      "Copies Codex authentication and, when compatible, the active provider's non-secret loopback route into Open Science"
     )
     expect(container.textContent).toContain('Skills and sessions are not imported')
   })

--- a/src/renderer/src/pages/settings/ProviderForm.render.test.tsx
+++ b/src/renderer/src/pages/settings/ProviderForm.render.test.tsx
@@ -179,7 +179,9 @@ describe('ProviderForm field switching', () => {
     expect(container.querySelector('[aria-label="Provider name"]')).toBeNull()
     expect(container.querySelector('[aria-label="API key"]')).toBeNull()
     expect(container.querySelector('[aria-label="Model"]')).toBeNull()
-    expect(container.textContent).toContain('Copies only Codex authentication into Open Science')
+    expect(container.textContent).toContain(
+      "Copies Codex authentication and, when compatible, the active provider's non-secret network route into Open Science"
+    )
     expect(container.textContent).toContain('Skills and sessions are not imported')
   })
 

--- a/src/renderer/src/pages/settings/ProviderForm.tsx
+++ b/src/renderer/src/pages/settings/ProviderForm.tsx
@@ -279,7 +279,7 @@ const ProviderForm = ({
           </div>
           <p className="text-xs text-muted-foreground">
             {value.type === 'codex-shared'
-              ? "Copies Codex authentication and, when compatible, the active provider's non-secret network route into Open Science app data. Other global config, Skills and sessions are not imported."
+              ? "Copies Codex authentication and, when compatible, the active provider's non-secret loopback route into Open Science app data. Other global config, Skills and sessions are not imported."
               : 'Stores a separate Codex login in Open Science app data without changing your Codex CLI profile.'}
           </p>
         </div>

--- a/src/renderer/src/pages/settings/ProviderForm.tsx
+++ b/src/renderer/src/pages/settings/ProviderForm.tsx
@@ -279,7 +279,7 @@ const ProviderForm = ({
           </div>
           <p className="text-xs text-muted-foreground">
             {value.type === 'codex-shared'
-              ? 'Copies only Codex authentication into Open Science app data. Global config, Skills and sessions are not imported.'
+              ? "Copies Codex authentication and, when compatible, the active provider's non-secret network route into Open Science app data. Other global config, Skills and sessions are not imported."
               : 'Stores a separate Codex login in Open Science app data without changing your Codex CLI profile.'}
           </p>
         </div>

--- a/src/renderer/src/pages/settings/ProviderList.render.test.tsx
+++ b/src/renderer/src/pages/settings/ProviderList.render.test.tsx
@@ -236,6 +236,26 @@ describe('ProviderList', () => {
     expect(buttonByLabel('Sign out')).toBeUndefined()
   })
 
+  it('renders a normalized imported Codex provider with imported copy and actions', () => {
+    renderList([
+      provider({
+        id: 'builtin-codex-subscription',
+        type: 'codex-isolated',
+        codexAuthMode: 'imported',
+        name: 'Codex subscription',
+        models: [],
+        model: undefined,
+        maskedKey: undefined,
+        hasKey: false
+      })
+    ])
+
+    expect(container.textContent).toContain('Authentication imported into Open Science')
+    expect(buttonByLabel('Check Codex login')).toBeDefined()
+    expect(buttonByLabel('Sign in')).toBeUndefined()
+    expect(buttonByLabel('Sign out')).toBeUndefined()
+  })
+
   it('renders shared and isolated Codex modes as one subscription card', () => {
     renderList([
       provider({

--- a/src/renderer/src/pages/settings/ProviderList.render.test.tsx
+++ b/src/renderer/src/pages/settings/ProviderList.render.test.tsx
@@ -45,6 +45,7 @@ const renderList = (
     onCancel?: () => void
     onLogin?: () => void
     onLogout?: () => void
+    onReimport?: (provider: ProviderView) => void
     isCodexLoginPending?: boolean
     isClaudeSharedLoginPending?: boolean
     onLoginSharedClaude?: () => void
@@ -71,6 +72,7 @@ const renderList = (
         onCancelCodexLogin={callbacks.onCancel}
         onLoginIsolatedCodex={callbacks.onLogin}
         onLogoutIsolatedCodex={callbacks.onLogout}
+        onReimportCodexAuthentication={callbacks.onReimport}
         isClaudeSharedLoginPending={callbacks.isClaudeSharedLoginPending}
         onLoginSharedClaude={callbacks.onLoginSharedClaude}
         onCancelSharedClaudeLogin={callbacks.onCancelSharedClaudeLogin}
@@ -237,6 +239,7 @@ describe('ProviderList', () => {
   })
 
   it('renders a normalized imported Codex provider with imported copy and actions', () => {
+    const onReimport = vi.fn()
     const imported = provider({
       id: 'builtin-codex-subscription',
       type: 'codex-isolated',
@@ -247,10 +250,12 @@ describe('ProviderList', () => {
       maskedKey: undefined,
       hasKey: false
     })
-    renderList([imported])
+    renderList([imported], undefined, undefined, { onReimport })
 
     expect(container.textContent).toContain('Authentication imported into Open Science')
     expect(buttonByLabel('Check Codex login')).toBeDefined()
+    act(() => buttonByLabel('Re-import Codex login')?.click())
+    expect(onReimport).toHaveBeenCalledWith(imported)
     expect(buttonByLabel('Sign in')).toBeUndefined()
     expect(buttonByLabel('Sign out')).toBeUndefined()
 

--- a/src/renderer/src/pages/settings/ProviderList.render.test.tsx
+++ b/src/renderer/src/pages/settings/ProviderList.render.test.tsx
@@ -237,23 +237,28 @@ describe('ProviderList', () => {
   })
 
   it('renders a normalized imported Codex provider with imported copy and actions', () => {
-    renderList([
-      provider({
-        id: 'builtin-codex-subscription',
-        type: 'codex-isolated',
-        codexAuthMode: 'imported',
-        name: 'Codex subscription',
-        models: [],
-        model: undefined,
-        maskedKey: undefined,
-        hasKey: false
-      })
-    ])
+    const imported = provider({
+      id: 'builtin-codex-subscription',
+      type: 'codex-isolated',
+      codexAuthMode: 'imported',
+      name: 'Codex subscription',
+      models: [],
+      model: undefined,
+      maskedKey: undefined,
+      hasKey: false
+    })
+    renderList([imported])
 
     expect(container.textContent).toContain('Authentication imported into Open Science')
     expect(buttonByLabel('Check Codex login')).toBeDefined()
     expect(buttonByLabel('Sign in')).toBeUndefined()
     expect(buttonByLabel('Sign out')).toBeUndefined()
+
+    const onCancel = vi.fn()
+    renderList([imported], undefined, undefined, { onCancel, isCodexLoginPending: true })
+    act(() => buttonByLabel('Cancel sign-in')?.click())
+    expect(onCancel).toHaveBeenCalledOnce()
+    expect(buttonByLabel('Check Codex login')).toBeUndefined()
   })
 
   it('renders shared and isolated Codex modes as one subscription card', () => {

--- a/src/renderer/src/pages/settings/ProviderList.tsx
+++ b/src/renderer/src/pages/settings/ProviderList.tsx
@@ -23,6 +23,7 @@ import {
   isCodexSubscriptionProvider,
   providerEndpoints,
   providerValidationFailed,
+  resolveCodexSubscriptionType,
   selectClaudeSubscriptionProvider
 } from '../../../../shared/settings'
 import { getOfficialVendor } from '../../../../shared/provider-registry'
@@ -184,6 +185,9 @@ const ProviderList = ({
           // A passing test shows a green check. Suppressed while a test is in flight.
           const isVerified = !failure && !isBusy && provider.lastValidatedAt !== undefined
           const isCodexSubscription = isCodexSubscriptionProvider(provider.type)
+          const codexSubscriptionType = isCodexSubscription
+            ? resolveCodexSubscriptionType(provider)
+            : undefined
           // The provider sourcing the selected model (and the last remaining one) can't be deleted:
           // removing it would leave no model to run, so its delete action stays disabled.
           const canDelete = !isActiveSource && displayedProviders.length > 1
@@ -262,9 +266,9 @@ const ProviderList = ({
                     ) : null}
                   </div>
                   <div className="mt-1 space-y-0.5 text-xs text-muted-foreground">
-                    {provider.type === 'codex-shared' ? (
+                    {codexSubscriptionType === 'codex-shared' ? (
                       <div>Authentication imported into Open Science</div>
-                    ) : provider.type === 'codex-isolated' ? (
+                    ) : codexSubscriptionType === 'codex-isolated' ? (
                       <div>Codex login stored separately by Open Science</div>
                     ) : provider.type === 'claude-isolated' && isClaudeIsolatedLoginPending ? (
                       // Browser sign-in in flight. `claude setup-token` opens the browser itself and
@@ -322,7 +326,7 @@ const ProviderList = ({
                   </div>
                 </div>
                 <div className="flex shrink-0 items-center gap-1.5">
-                  {provider.type === 'codex-isolated' && isCodexLoginPending ? (
+                  {codexSubscriptionType === 'codex-isolated' && isCodexLoginPending ? (
                     <SettingsIconAction
                       label="Cancel sign-in"
                       icon={X}
@@ -343,7 +347,9 @@ const ProviderList = ({
                       className="border border-border text-foreground"
                     />
                   )}
-                  {provider.type === 'codex-isolated' && !isVerified && !isCodexLoginPending ? (
+                  {codexSubscriptionType === 'codex-isolated' &&
+                  !isVerified &&
+                  !isCodexLoginPending ? (
                     <SettingsIconAction
                       label="Sign in"
                       icon={LogIn}
@@ -352,7 +358,7 @@ const ProviderList = ({
                       className="border border-border text-foreground"
                     />
                   ) : null}
-                  {provider.type === 'codex-isolated' && isVerified ? (
+                  {codexSubscriptionType === 'codex-isolated' && isVerified ? (
                     <SettingsIconAction
                       label="Sign out"
                       icon={LogOut}

--- a/src/renderer/src/pages/settings/ProviderList.tsx
+++ b/src/renderer/src/pages/settings/ProviderList.tsx
@@ -326,7 +326,7 @@ const ProviderList = ({
                   </div>
                 </div>
                 <div className="flex shrink-0 items-center gap-1.5">
-                  {codexSubscriptionType === 'codex-isolated' && isCodexLoginPending ? (
+                  {isCodexSubscription && isCodexLoginPending ? (
                     <SettingsIconAction
                       label="Cancel sign-in"
                       icon={X}

--- a/src/renderer/src/pages/settings/ProviderList.tsx
+++ b/src/renderer/src/pages/settings/ProviderList.tsx
@@ -5,6 +5,7 @@ import {
   LogOut,
   Pencil,
   PlugZap,
+  RefreshCw,
   Route,
   TriangleAlert,
   Trash2,
@@ -47,6 +48,7 @@ type ProviderListProps = {
   onCancelCodexLogin?: () => void
   onLoginIsolatedCodex?: () => void
   onLogoutIsolatedCodex?: () => void
+  onReimportCodexAuthentication?: (provider: ProviderView) => void
   // Claude subscription's browser OAuth sign-in (shared mode): opens the browser and lands
   // credentials in ~/.claude. Mirrors the codex-isolated flow shape.
   isClaudeSharedLoginPending?: boolean
@@ -130,6 +132,7 @@ const ProviderList = ({
   onCancelCodexLogin,
   onLoginIsolatedCodex,
   onLogoutIsolatedCodex,
+  onReimportCodexAuthentication,
   isClaudeSharedLoginPending = false,
   onLoginSharedClaude,
   onCancelSharedClaudeLogin,
@@ -347,6 +350,15 @@ const ProviderList = ({
                       className="border border-border text-foreground"
                     />
                   )}
+                  {codexSubscriptionType === 'codex-shared' && !isCodexLoginPending ? (
+                    <SettingsIconAction
+                      label="Re-import Codex login"
+                      icon={RefreshCw}
+                      onClick={() => onReimportCodexAuthentication?.(provider)}
+                      disabled={isBusy}
+                      className="border border-border text-foreground"
+                    />
+                  ) : null}
                   {codexSubscriptionType === 'codex-isolated' &&
                   !isVerified &&
                   !isCodexLoginPending ? (

--- a/src/renderer/src/pages/settings/ProvidersPanel.tsx
+++ b/src/renderer/src/pages/settings/ProvidersPanel.tsx
@@ -37,6 +37,7 @@ const ProvidersPanel = ({
   )
   const agentFrameworkId = useSettingsStore((state) => state.agentFrameworkId)
   const deleteProvider = useSettingsStore((state) => state.deleteProvider)
+  const saveProvider = useSettingsStore((state) => state.saveProvider)
   const validateProvider = useSettingsStore((state) => state.validateProvider)
   const cancelCodexLogin = useSettingsStore((state) => state.cancelCodexLogin)
   const loginIsolatedCodex = useSettingsStore((state) => state.loginIsolatedCodex)
@@ -154,6 +155,28 @@ const ProvidersPanel = ({
       }
     } catch (error) {
       setProviderTestError(error instanceof Error ? error.message : 'Could not sign out of Codex.')
+    }
+  }
+
+  // Imported authentication is copied into the app-owned profile. Refresh only on this explicit
+  // action so ordinary edits stay self-contained, while users can still pick up a later CLI login or
+  // loopback-route change without toggling auth modes.
+  const handleCodexReimport = async (provider: ProviderView): Promise<void> => {
+    onBusyProviderChange(provider.id)
+    setProviderTestError(undefined)
+
+    try {
+      await saveProvider({
+        id: provider.id,
+        type: 'codex-shared',
+        reimportCodexAuthentication: true
+      })
+    } catch (error) {
+      setProviderTestError(
+        error instanceof Error ? error.message : 'Could not re-import the Codex login.'
+      )
+    } finally {
+      onBusyProviderChange(undefined)
     }
   }
 
@@ -307,6 +330,7 @@ const ProvidersPanel = ({
           onCancelCodexLogin={() => void cancelCodexLogin()}
           onLoginIsolatedCodex={() => void handleCodexLogin()}
           onLogoutIsolatedCodex={() => void handleCodexLogout()}
+          onReimportCodexAuthentication={(provider) => void handleCodexReimport(provider)}
           isClaudeSharedLoginPending={isClaudeSharedLoginPending}
           onLoginSharedClaude={() => void handleClaudeSharedLogin()}
           onCancelSharedClaudeLogin={() => void cancelSharedClaudeLogin()}

--- a/src/renderer/src/pages/settings/SettingsPage.tsx
+++ b/src/renderer/src/pages/settings/SettingsPage.tsx
@@ -45,6 +45,7 @@ import {
   getProviderFormErrors,
   hasProviderFormErrors,
   providerFormApiEndpoints,
+  providerTypeForForm,
   providerKindPatch,
   type ProviderFormValue
 } from './provider-form-value'
@@ -60,7 +61,7 @@ type ModelView = { kind: 'list' } | { kind: 'create' } | { kind: 'edit'; provide
 // Builds a form value from an existing provider (never carrying the plaintext key).
 const toFormValue = (provider: ProviderView): ProviderFormValue =>
   createEmptyProviderFormValue({
-    type: provider.type,
+    type: providerTypeForForm(provider),
     name: provider.name,
     baseUrl: provider.baseUrl ?? '',
     model: provider.model ?? '',

--- a/src/renderer/src/pages/settings/SettingsPage.tsx
+++ b/src/renderer/src/pages/settings/SettingsPage.tsx
@@ -15,7 +15,11 @@ import {
 import { Dialog } from 'radix-ui'
 import { useEffect, useState } from 'react'
 
-import type { ProviderView, UpsertProviderRequest } from '../../../../shared/settings'
+import {
+  resolveCodexSubscriptionType,
+  type ProviderView,
+  type UpsertProviderRequest
+} from '../../../../shared/settings'
 import { Button } from '@/components/ui/button'
 import { Tooltip, TooltipContent, TooltipProvider, TooltipTrigger } from '@/components/ui/tooltip'
 import { cn } from '@/lib/utils'
@@ -45,7 +49,6 @@ import {
   getProviderFormErrors,
   hasProviderFormErrors,
   providerFormApiEndpoints,
-  providerTypeForForm,
   providerKindPatch,
   type ProviderFormValue
 } from './provider-form-value'
@@ -61,7 +64,10 @@ type ModelView = { kind: 'list' } | { kind: 'create' } | { kind: 'edit'; provide
 // Builds a form value from an existing provider (never carrying the plaintext key).
 const toFormValue = (provider: ProviderView): ProviderFormValue =>
   createEmptyProviderFormValue({
-    type: providerTypeForForm(provider),
+    type:
+      provider.type === 'codex-shared' || provider.type === 'codex-isolated'
+        ? resolveCodexSubscriptionType(provider)
+        : provider.type,
     name: provider.name,
     baseUrl: provider.baseUrl ?? '',
     model: provider.model ?? '',

--- a/src/renderer/src/pages/settings/provider-form-value.test.ts
+++ b/src/renderer/src/pages/settings/provider-form-value.test.ts
@@ -8,6 +8,7 @@ import {
   getProviderFormErrors,
   hasProviderFormErrors,
   providerFormApiEndpoints,
+  providerTypeForForm,
   providerKindPatch,
   selectedKindKey
 } from './provider-form-value'
@@ -150,6 +151,15 @@ describe('provider-kind helpers', () => {
     )
     expect(selectedKindKey(createEmptyProviderFormValue({ type: 'codex-isolated' }))).toBe(
       'codex-subscription'
+    )
+  })
+
+  it('rehydrates an imported app-owned Codex provider as the import form mode', () => {
+    expect(providerTypeForForm({ type: 'codex-isolated', codexAuthMode: 'imported' })).toBe(
+      'codex-shared'
+    )
+    expect(providerTypeForForm({ type: 'codex-isolated', codexAuthMode: 'isolated' })).toBe(
+      'codex-isolated'
     )
   })
 

--- a/src/renderer/src/pages/settings/provider-form-value.test.ts
+++ b/src/renderer/src/pages/settings/provider-form-value.test.ts
@@ -8,7 +8,6 @@ import {
   getProviderFormErrors,
   hasProviderFormErrors,
   providerFormApiEndpoints,
-  providerTypeForForm,
   providerKindPatch,
   selectedKindKey
 } from './provider-form-value'
@@ -151,15 +150,6 @@ describe('provider-kind helpers', () => {
     )
     expect(selectedKindKey(createEmptyProviderFormValue({ type: 'codex-isolated' }))).toBe(
       'codex-subscription'
-    )
-  })
-
-  it('rehydrates an imported app-owned Codex provider as the import form mode', () => {
-    expect(providerTypeForForm({ type: 'codex-isolated', codexAuthMode: 'imported' })).toBe(
-      'codex-shared'
-    )
-    expect(providerTypeForForm({ type: 'codex-isolated', codexAuthMode: 'isolated' })).toBe(
-      'codex-isolated'
     )
   })
 

--- a/src/renderer/src/pages/settings/provider-form-value.ts
+++ b/src/renderer/src/pages/settings/provider-form-value.ts
@@ -4,6 +4,7 @@ import {
   preferredEndpoint,
   type AgentFrameworkId,
   type ChatApiEndpoint,
+  type ProviderView,
   type ProviderType
 } from '../../../../shared/settings'
 import {
@@ -77,6 +78,13 @@ export const providerFormApiEndpoints = (value: ProviderFormValue): ChatApiEndpo
   value.type === 'official' && value.vendorId
     ? resolveVendorApiEndpoints(value.vendorId)
     : [value.apiEndpoint]
+
+export const providerTypeForForm = (
+  provider: Pick<ProviderView, 'type' | 'codexAuthMode'>
+): ProviderType =>
+  provider.type === 'codex-isolated' && provider.codexAuthMode === 'imported'
+    ? 'codex-shared'
+    : provider.type
 
 // The provider kind pre-selected when the Add provider form opens, matched to the active agent
 // framework's most common official vendor: Claude Code → Anthropic, Codex → OpenAI,

--- a/src/renderer/src/pages/settings/provider-form-value.ts
+++ b/src/renderer/src/pages/settings/provider-form-value.ts
@@ -4,7 +4,6 @@ import {
   preferredEndpoint,
   type AgentFrameworkId,
   type ChatApiEndpoint,
-  type ProviderView,
   type ProviderType
 } from '../../../../shared/settings'
 import {
@@ -78,13 +77,6 @@ export const providerFormApiEndpoints = (value: ProviderFormValue): ChatApiEndpo
   value.type === 'official' && value.vendorId
     ? resolveVendorApiEndpoints(value.vendorId)
     : [value.apiEndpoint]
-
-export const providerTypeForForm = (
-  provider: Pick<ProviderView, 'type' | 'codexAuthMode'>
-): ProviderType =>
-  provider.type === 'codex-isolated' && provider.codexAuthMode === 'imported'
-    ? 'codex-shared'
-    : provider.type
 
 // The provider kind pre-selected when the Add provider form opens, matched to the active agent
 // framework's most common official vendor: Claude Code → Anthropic, Codex → OpenAI,

--- a/src/shared/settings.test.ts
+++ b/src/shared/settings.test.ts
@@ -8,6 +8,7 @@ import {
   isProviderUsableByFramework,
   preferredEndpoint,
   providerEndpoints,
+  resolveCodexSubscriptionType,
   requiresChatCompletionsBridge
 } from './settings'
 
@@ -67,13 +68,13 @@ describe('provider endpoint compatibility', () => {
     const codex = { id: 'codex' as const, supportedApiTypes: ['responses'] as const }
 
     expect(requiresChatCompletionsBridge({ apiEndpoints: ['openai'] }, codex)).toBe(true)
-    expect(
-      requiresChatCompletionsBridge({ apiEndpoints: ['anthropic', 'openai'] }, codex)
-    ).toBe(true)
+    expect(requiresChatCompletionsBridge({ apiEndpoints: ['anthropic', 'openai'] }, codex)).toBe(
+      true
+    )
     expect(requiresChatCompletionsBridge({ apiEndpoints: ['responses'] }, codex)).toBe(false)
-    expect(
-      requiresChatCompletionsBridge({ apiEndpoints: ['openai', 'responses'] }, codex)
-    ).toBe(false)
+    expect(requiresChatCompletionsBridge({ apiEndpoints: ['openai', 'responses'] }, codex)).toBe(
+      false
+    )
   })
 
   it('marks a vendor model bridge-unsupported only when the registry lists it', () => {
@@ -102,6 +103,19 @@ describe('provider endpoint compatibility', () => {
         false
       )
     }
+  })
+})
+
+describe('resolveCodexSubscriptionType', () => {
+  it('prefers the persisted auth mode and falls back to the legacy provider type', () => {
+    expect(
+      resolveCodexSubscriptionType({ type: 'codex-isolated', codexAuthMode: 'imported' })
+    ).toBe('codex-shared')
+    expect(
+      resolveCodexSubscriptionType({ type: 'codex-isolated', codexAuthMode: 'isolated' })
+    ).toBe('codex-isolated')
+    expect(resolveCodexSubscriptionType({ type: 'codex-shared' })).toBe('codex-shared')
+    expect(resolveCodexSubscriptionType({ type: 'codex-isolated' })).toBe('codex-isolated')
   })
 })
 

--- a/src/shared/settings.ts
+++ b/src/shared/settings.ts
@@ -475,6 +475,9 @@ export type ProviderDraft = {
 // Create/update request: an existing `id` edits in place, otherwise a new provider is created.
 export type UpsertProviderRequest = ProviderDraft & {
   id?: string
+  // Explicitly refreshes an existing imported Codex subscription from the user's CLI profile.
+  // Ordinary edits remain app-owned and never cross that external profile boundary.
+  reimportCodexAuthentication?: boolean
 }
 
 export type DeleteProviderRequest = {

--- a/src/shared/settings.ts
+++ b/src/shared/settings.ts
@@ -24,6 +24,11 @@ export const SETTINGS_FILE_VERSION = 2
 export type ProviderType =
   'custom' | 'claude-shared' | 'claude-isolated' | 'official' | 'codex-shared' | 'codex-isolated'
 
+// The stored Codex subscription always uses the app-owned runtime type. This discriminator preserves
+// which setup choice produced it so editing an imported profile does not masquerade as an isolated
+// sign-in and accidentally discard its imported loopback route.
+export type CodexSubscriptionAuthMode = 'imported' | 'isolated'
+
 export const CODEX_SHARED_PROVIDER_ID = 'builtin-codex-shared'
 export const CODEX_ISOLATED_PROVIDER_ID = 'builtin-codex-isolated'
 export const CODEX_SUBSCRIPTION_PROVIDER_ID = 'builtin-codex-subscription'
@@ -223,6 +228,7 @@ export type ProviderValidationFailure = {
 export type ProviderView = {
   id: string
   type: ProviderType
+  codexAuthMode?: CodexSubscriptionAuthMode
   name: string
   // Which chat APIs this provider's endpoint speaks; drives per-framework availability. Absent ⇒
   // treat as ['anthropic'] (every legacy provider).

--- a/src/shared/settings.ts
+++ b/src/shared/settings.ts
@@ -29,6 +29,17 @@ export type ProviderType =
 // sign-in and accidentally discard its imported loopback route.
 export type CodexSubscriptionAuthMode = 'imported' | 'isolated'
 
+// Stored Codex subscriptions share one runtime type, while renderer surfaces still need the setup
+// choice. Legacy codex-shared views have no discriminator, so their type remains the fallback.
+export const resolveCodexSubscriptionType = (provider: {
+  type: ProviderType
+  codexAuthMode?: CodexSubscriptionAuthMode
+}): 'codex-shared' | 'codex-isolated' =>
+  provider.codexAuthMode === 'imported' ||
+  (provider.codexAuthMode === undefined && provider.type === 'codex-shared')
+    ? 'codex-shared'
+    : 'codex-isolated'
+
 export const CODEX_SHARED_PROVIDER_ID = 'builtin-codex-shared'
 export const CODEX_ISOLATED_PROVIDER_ID = 'builtin-codex-isolated'
 export const CODEX_SUBSCRIPTION_PROVIDER_ID = 'builtin-codex-subscription'


### PR DESCRIPTION
## Problem

Importing an existing Codex sign-in copied `auth.json` but discarded the active model-provider route from the local Codex profile. On machines where local Codex uses an authenticated loopback route, Open Science instead fell back to the direct ChatGPT transport. A two-character prompt took about 114 seconds in the app; the direct-provider CLI repro took 117.99 seconds after five WebSocket retries, while the working local route completed in seconds.

The native Codex child also does not use Electron's proxy-aware network stack. A valid app-owned login could therefore succeed yet prompt or status traffic could stall when the user's current system/PAC proxy was required.

## Proposed change

- Import the active model provider only when it uses the Responses wire API, Codex/OpenAI authentication, and a strict loopback destination (`localhost`, `127.0.0.0/8`, or `::1`).
- Re-serialize an allowlisted, non-secret route containing only provider id, name, base URL, wire API, authentication mode, and optional WebSocket support. Reject routes that depend on omitted credential-bearing fields.
- Store the sanitized route with mode `0600` beside the imported authentication so app-owned Codex sessions reuse the same working local network path.
- Persist the selected authentication mode so ordinary edits retain imported routing, expose explicit re-import, and distinguish a switch to in-app sign-in.
- Mark imported route fragments and remove only those fragments when switching modes or deleting the provider, preserving unrelated app-owned config.
- Serialize authentication-mode transitions: an isolated sign-in is cancelled and its session is fully closed before app-owned credentials are imported, cleared, or deleted.
- Pin the app-owned credential store to file mode and implement logout/delete as local app-data cleanup, without remotely revoking or changing the user's Codex CLI login.
- Resolve the user's current system/PAC proxy at runtime for Codex subscription auth and prompt children. Resolved proxy and explicit `DIRECT` decisions replace inherited proxy variables; resolver failure preserves the inherited environment, and loopback addresses remain bypassed.
- Update Provider copy and actions to reflect imported versus in-app authentication accurately.

## Scope and non-goals

- Does not import model defaults, MCP servers, hooks, headers, bearer tokens, Skills, sessions, or other global Codex configuration.
- Rejects remote provider routes, separate-credential routes, and URLs with embedded credentials, query parameters, or fragments.
- Does not store proxy endpoints in `settings.json` or `config.toml`, and does not modify the user's system proxy or global Codex CLI profile.
- System-proxy resolution applies to the shared app-owned Codex subscription runtime used by both imported and in-app authentication. It does not change custom/official API-provider routing.
- Logout and provider deletion affect only the app-owned Codex subscription home; they never invoke remote account logout.

## Acceptance criteria and validation

- Imported subscription sessions retain a compatible loopback route without exposing unrelated configuration or forwarding ChatGPT credentials to remote hosts.
- Stale imported route fragments are removed when the source no longer has a safe route, the user switches to in-app sign-in, or the provider is deleted, without deleting unrelated app-owned config or global credentials.
- Authentication-mode changes cannot be overwritten by a late write from an isolated browser-login session.
- Empty query/fragment delimiters are rejected and legal quoted TOML provider-table keys are recognized.
- Runtime proxy routing follows the current system/PAC decision without persisting a proxy endpoint; loopback imported routes remain direct.
- `npm run typecheck`
- Targeted ESLint and Prettier for all changed files
- Final focused validation: 266 tests passed across Codex authentication and settings service behavior
- Earlier full-suite validation: 496 files passed, 6,988 tests passed, 10 files / 113 tests skipped
- Live isolated-config repro: `gpt-5.6-terra` completed in 12.97 seconds through the imported route versus 117.99 seconds through the direct provider.

## Review focus

Please focus on authentication-transition serialization, the TOML allowlist/parser boundary, strict loopback validation, runtime proxy inheritance/replacement semantics, and app-owned credential cleanup.
