### PR TITLE
style(workspace): refine notebook composer appearance

### DIFF
--- a/src/renderer/src/pages/workspace/ConversationPanel.interaction.test.tsx
+++ b/src/renderer/src/pages/workspace/ConversationPanel.interaction.test.tsx
@@ -235,6 +235,16 @@ describe('ConversationPanel composer intake', () => {
     expect(onCancelAttachmentTransfer).toHaveBeenCalledWith(transfer)
   })
 
+  it('uses a flat border without a card shadow', () => {
+    renderPanel()
+
+    const composerForm = getComposerForm()
+
+    expect(composerForm.classList.contains('border')).toBe(true)
+    expect(composerForm.classList.contains('border-border-200')).toBe(true)
+    expect(composerForm.classList.contains('shadow-card-opaque')).toBe(false)
+  })
+
   it('stages a pasted non-image file', () => {
     renderPanel()
     const pdf = new File(['%PDF'], 'report.pdf', { type: 'application/pdf' })
@@ -545,6 +555,16 @@ describe('ConversationPanel notebook bar', () => {
     createdAt: Date.now(),
     updatedAt: Date.now()
   }
+  const notebookReference = {
+    notebookId: 'nb-1',
+    sessionId: 'session-bar',
+    projectName: 'proj',
+    workspaceCwd: '/workspace',
+    notebookSessionRoot: '/nb',
+    dataRoot: '/data',
+    runtimeRoot: '/rt',
+    runJsonPath: '/run.json'
+  }
 
   it('hides the notebook bar when there is no notebookReference and no running job', () => {
     mockHasRunningJobs = false
@@ -556,20 +576,28 @@ describe('ConversationPanel notebook bar', () => {
 
   it('shows only the Notebook button when notebookReference exists and no running job', () => {
     mockHasRunningJobs = false
-    const ref = {
-      notebookId: 'nb-1',
-      sessionId: 'session-bar',
-      projectName: 'proj',
-      workspaceCwd: '/workspace',
-      notebookSessionRoot: '/nb',
-      dataRoot: '/data',
-      runtimeRoot: '/rt',
-      runJsonPath: '/run.json'
-    }
-    renderPanel({ activeSession: session, notebookReference: ref })
+    renderPanel({ activeSession: session, notebookReference })
 
     expect(container.querySelector('[aria-label="Open notebook"]')).not.toBeNull()
     expect(container.querySelector('[data-testid="remote-job-badge"]')).toBeNull()
+  })
+
+  it('animates the notebook bar upward when it appears', () => {
+    renderPanel({ activeSession: session, notebookReference })
+
+    const notebookBar = container.querySelector('[aria-label="Open notebook"]')?.parentElement
+
+    expect(notebookBar?.className).toContain('motion-safe:animate-in')
+    expect(notebookBar?.className).toContain('motion-safe:fade-in-0')
+    expect(notebookBar?.className).toContain('motion-safe:slide-in-from-bottom-1')
+  })
+
+  it('shows a pointer cursor over the Notebook button', () => {
+    renderPanel({ activeSession: session, notebookReference })
+
+    const notebookButton = container.querySelector('[aria-label="Open notebook"]')
+
+    expect(notebookButton?.className).toContain('cursor-pointer')
   })
 
   it('shows only the job badge when there is no notebookReference but there are running jobs', () => {
@@ -581,20 +609,43 @@ describe('ConversationPanel notebook bar', () => {
     expect(container.querySelector('[data-testid="remote-job-badge"]')).not.toBeNull()
   })
 
+  it('keeps the job-only bar compact and static', () => {
+    mockAllJobs = [{ job_id: 'job-1', status: 'running', created_at: Date.now() }]
+    renderPanel({ activeSession: session, notebookReference: undefined })
+
+    const jobBar = container.querySelector('[data-testid="remote-job-badge"]')?.parentElement
+
+    expect(jobBar?.classList.contains('min-h-9')).toBe(true)
+    expect(jobBar?.classList.contains('bg-bg-000')).toBe(true)
+    expect(jobBar?.classList.contains('motion-safe:animate-in')).toBe(false)
+  })
+
+  it('remounts the bar when a Notebook appears after jobs', () => {
+    mockAllJobs = [{ job_id: 'job-1', status: 'running', created_at: Date.now() }]
+    renderPanel({ activeSession: session, notebookReference: undefined })
+    const jobBar = container.querySelector('[data-testid="remote-job-badge"]')?.parentElement
+
+    renderPanel({ activeSession: session, notebookReference })
+    const notebookBar = container.querySelector('[aria-label="Open notebook"]')?.parentElement
+
+    expect(notebookBar).not.toBe(jobBar)
+    expect(notebookBar?.classList.contains('motion-safe:animate-in')).toBe(true)
+  })
+
+  it('does not layer card shadows behind the composer border', () => {
+    renderPanel({ activeSession: session, notebookReference })
+
+    const notebookBar = container.querySelector('[aria-label="Open notebook"]')?.parentElement
+    const composerBackdrop = getComposerForm().previousElementSibling
+
+    expect(notebookBar?.classList.contains('shadow-card')).toBe(false)
+    expect(composerBackdrop?.classList.contains('shadow-card')).toBe(false)
+  })
+
   it('shows both the Notebook button and the job badge when both are present', () => {
     mockHasRunningJobs = true
     mockAllJobs = [{ job_id: 'job-1', status: 'running', created_at: Date.now() }]
-    const ref = {
-      notebookId: 'nb-1',
-      sessionId: 'session-bar',
-      projectName: 'proj',
-      workspaceCwd: '/workspace',
-      notebookSessionRoot: '/nb',
-      dataRoot: '/data',
-      runtimeRoot: '/rt',
-      runJsonPath: '/run.json'
-    }
-    renderPanel({ activeSession: session, notebookReference: ref })
+    renderPanel({ activeSession: session, notebookReference })
 
     expect(container.querySelector('[aria-label="Open notebook"]')).not.toBeNull()
     expect(container.querySelector('[data-testid="remote-job-badge"]')).not.toBeNull()
@@ -605,8 +656,8 @@ describe('ConversationPanel notebook bar', () => {
     mockAllJobs = [{ job_id: 'job-1', status: 'done', created_at: Date.now() }]
     renderPanel({ activeSession: session, notebookReference: undefined })
 
-    // Bar should be visible (the container that wraps badge/notebook button)
-    const notebookBar = container.querySelector('.mb-2.flex.min-h-9')
+    // The badge's parent is the shared notebook/job bar.
+    const notebookBar = container.querySelector('[data-testid="remote-job-badge"]')?.parentElement
     expect(notebookBar).not.toBeNull()
     // Badge should be visible even though no jobs are running
     expect(container.querySelector('[data-testid="remote-job-badge"]')).not.toBeNull()

--- a/src/renderer/src/pages/workspace/ConversationPanel.tsx
+++ b/src/renderer/src/pages/workspace/ConversationPanel.tsx
@@ -357,12 +357,22 @@ const ConversationPanel = ({
                   }
                 />
 
+                {/* Switching between a compact job bar and Notebook chrome remounts this layer so a
+                    Notebook that becomes available after jobs still receives its entrance animation. */}
                 {notebookReference || hasAnyJobs ? (
-                  <div className="mb-2 flex min-h-9 items-center rounded-lg border border-border-200 bg-bg-000 px-2 shadow-card">
+                  <div
+                    key={notebookReference ? `notebook-${notebookReference.sessionId}` : 'jobs'}
+                    className={cn(
+                      'flex px-2',
+                      notebookReference
+                        ? 'relative -mb-8 min-h-[68px] items-start rounded-2xl bg-bg-200 pt-1 motion-safe:animate-in motion-safe:fade-in-0 motion-safe:slide-in-from-bottom-1 motion-safe:duration-200 motion-safe:ease-out'
+                        : 'mb-2 min-h-9 items-center rounded-lg border border-border-200 bg-bg-000 shadow-card'
+                    )}
+                  >
                     {notebookReference ? (
                       <button
                         type="button"
-                        className="flex h-7 items-center gap-1.5 rounded-md px-2 text-[12px] font-medium text-text-100 transition-colors duration-200 ease-out hover:bg-bg-200 hover:text-text-000"
+                        className="flex h-7 cursor-pointer items-center gap-1.5 rounded-md px-2 text-[12px] font-normal text-text-100 transition-colors duration-200 ease-out hover:bg-bg-300 hover:text-text-000"
                         aria-label="Open notebook"
                         aria-controls="right-panel"
                         onClick={() => onOpenNotebook(notebookReference)}
@@ -384,15 +394,12 @@ const ConversationPanel = ({
                 ) : null}
 
                 <div className="relative">
-                  <div
-                    aria-hidden="true"
-                    className="relative -mb-8 rounded-2xl bg-bg-200 pb-8 shadow-card"
-                  />
+                  <div aria-hidden="true" className="relative -mb-8 rounded-2xl bg-bg-200 pb-8" />
 
                   {/* Composer keeps draft input local until submit delegates to the session store.
                       Enter-to-send is owned by ComposerEditor; the form only guards native submit. */}
                   <form
-                    className="relative z-10 flex flex-col gap-2 rounded-2xl bg-bg-000 px-3 py-2 shadow-card-opaque transition-shadow duration-[180ms] ease-out"
+                    className="relative z-10 flex flex-col gap-2 rounded-2xl border border-border-200 bg-bg-000 px-3 py-2"
                     onSubmit={(event) => event.preventDefault()}
                     {...dropZoneProps}
                   >


### PR DESCRIPTION
## Summary

Refine the workspace composer and Notebook bar styling for a flatter, aligned visual treatment.

## Highlights

- Present the Notebook control as an attached layer above the composer.
- Add a subtle upward entrance animation when Notebook becomes available.
- Remove composer card shadows and use a consistent border.
- Show a pointer cursor when hovering over the Notebook control.
- Preserve the compact existing presentation for job-only states.

## Impact

This change affects the workspace conversation composer, Notebook entry point, and remote job indicator presentation. Message composition, Notebook opening, and job-list behavior remain unchanged.

## Test Results

- 62 related renderer tests passed across 7 test files.
- Web TypeScript check passed.
- Node TypeScript check passed.
- ESLint passed.
- Web production build passed.
- `git diff --check` passed.

## Potential Issues

None known.

## Author

- ljlj111 <18301503785@163.com>