### PR TITLE
feat(workspace): add whole-window find bar

### DIFF
--- a/eslint.config.mjs
+++ b/eslint.config.mjs
@@ -15,6 +15,8 @@ export default defineConfig(
       '**/dist-e2e-*',
       // Runtime kernel loop scripts shipped as raw resources (CommonJS, not part of the TS source tree).
       'resources/notebook/*.js',
+      // Whole-window find overlay: an ES-module page shipped as a raw resource (not part of the TS source tree).
+      'resources/find-overlay/*.js',
       // Git worktrees live under .claude/worktrees and hold full source copies; don't lint duplicates.
       '**/.claude/**',
       // Local subagent scratch (ledgers, briefs, ad-hoc demo scripts) — never shipped.

--- a/resources/find-overlay/findOverlay.js
+++ b/resources/find-overlay/findOverlay.js
@@ -1,0 +1,125 @@
+export const LAST_QUERY_STORAGE_KEY = 'open-science:window-find:last-query'
+
+export function createFindOverlay(deps) {
+  const { input, count, prev, next, close, api, storage } = deps
+
+  let currentRequestId = 0
+  count.textContent = '0 / 0'
+
+  const nextRequestId = () => {
+    currentRequestId += 1
+    return currentRequestId
+  }
+
+  const search = (text, { findNext = true, forward = true } = {}) => {
+    const requestId = nextRequestId()
+    api.findInPage({ requestId, text, findNext, forward })
+  }
+
+  const handleShow = () => {
+    input.focus()
+    const remembered = storage.getItem(LAST_QUERY_STORAGE_KEY) ?? ''
+    if (remembered) {
+      input.value = remembered
+      search(remembered, { findNext: true, forward: true })
+    }
+  }
+
+  const onInput = () => {
+    const value = input.value
+    storage.setItem(LAST_QUERY_STORAGE_KEY, value)
+    if (value === '') {
+      nextRequestId()
+      api.clearFind()
+      count.textContent = '0 / 0'
+    } else {
+      search(value, { findNext: true, forward: true })
+    }
+  }
+
+  const onResult = (result) => {
+    if (result.requestId !== currentRequestId) {
+      return
+    }
+    count.textContent = `${result.activeMatchOrdinal} / ${result.matches}`
+  }
+
+  const query = () => input.value
+
+  const goForward = () => {
+    if (query() === '') {
+      return
+    }
+    search(query(), { findNext: false, forward: true })
+  }
+
+  const goBackward = () => {
+    if (query() === '') {
+      return
+    }
+    search(query(), { findNext: false, forward: false })
+  }
+
+  const handleClose = () => {
+    api.closeFind()
+  }
+
+  const onKeydown = (event) => {
+    if (event.key === 'Enter') {
+      event.preventDefault()
+      if (event.shiftKey) {
+        goBackward()
+      } else {
+        goForward()
+      }
+    } else if (event.key === 'Escape') {
+      event.preventDefault()
+      handleClose()
+    }
+  }
+
+  input.addEventListener('input', onInput)
+  input.addEventListener('keydown', onKeydown)
+  prev.addEventListener('click', goBackward)
+  next.addEventListener('click', goForward)
+  close.addEventListener('click', handleClose)
+
+  const offResult = api.onFindInPageResult(onResult)
+  const offShow = api.onShowWindowFind(handleShow)
+
+  return {
+    destroy() {
+      offResult()
+      offShow()
+      input.removeEventListener('input', onInput)
+      input.removeEventListener('keydown', onKeydown)
+      prev.removeEventListener('click', goBackward)
+      next.removeEventListener('click', goForward)
+      close.removeEventListener('click', handleClose)
+    }
+  }
+}
+
+// Self-wire when loaded as the overlay page's module. Guarded on the overlay's own element ids so
+// importing this module in a test harness (jsdom, no #find-overlay-query) is a no-op.
+const bootOverlay = () => {
+  if (typeof document === 'undefined') return
+  const input = document.getElementById('find-overlay-query')
+  if (!(input instanceof HTMLInputElement)) return
+  const count = document.getElementById('find-overlay-count')
+  const prev = document.getElementById('find-overlay-prev')
+  const next = document.getElementById('find-overlay-next')
+  const close = document.getElementById('find-overlay-close')
+  if (!count || !prev || !next || !close) return
+  const api = window.api?.window
+  if (!api) return
+  createFindOverlay({ input, count, prev, next, close, api, storage: window.localStorage })
+}
+
+if (typeof document !== 'undefined') {
+  if (document.readyState === 'loading') {
+    document.addEventListener('DOMContentLoaded', bootOverlay, { once: true })
+  } else {
+    bootOverlay()
+  }
+}

--- a/resources/find-overlay/findOverlay.test.js
+++ b/resources/find-overlay/findOverlay.test.js
@@ -1,0 +1,276 @@
+// @vitest-environment jsdom
+import { describe, it, expect, vi, beforeEach } from 'vitest'
+import { createFindOverlay, LAST_QUERY_STORAGE_KEY } from './findOverlay.js'
+
+function setup() {
+  const input = document.createElement('input')
+  input.type = 'text'
+  const count = document.createElement('span')
+  const prev = document.createElement('button')
+  const next = document.createElement('button')
+  const close = document.createElement('button')
+  document.body.append(input, count, prev, next, close)
+
+  const resultListeners = new Set()
+  const showListeners = new Set()
+  const api = {
+    findInPage: vi.fn(),
+    clearFind: vi.fn(),
+    closeFind: vi.fn(),
+    onFindInPageResult: vi.fn((listener) => {
+      resultListeners.add(listener)
+      return () => resultListeners.delete(listener)
+    }),
+    onShowWindowFind: vi.fn((listener) => {
+      showListeners.add(listener)
+      return () => showListeners.delete(listener)
+    })
+  }
+
+  const store = new Map()
+  const storage = {
+    getItem: vi.fn((k) => (store.has(k) ? store.get(k) : null)),
+    setItem: vi.fn((k, v) => {
+      store.set(k, String(v))
+    })
+  }
+
+  const deps = { input, count, prev, next, close, api, storage }
+  const emitResult = (r) => resultListeners.forEach((l) => l(r))
+  const emitShow = () => showListeners.forEach((l) => l())
+  return { deps, api, storage, store, input, count, prev, next, close, emitResult, emitShow }
+}
+
+describe('createFindOverlay', () => {
+  let ctx
+  beforeEach(() => {
+    document.body.innerHTML = ''
+    ctx = setup()
+  })
+
+  it('subscribes to api events and returns a destroy() that unsubscribes both', () => {
+    const overlay = createFindOverlay(ctx.deps)
+    expect(ctx.api.onShowWindowFind).toHaveBeenCalledTimes(1)
+    expect(ctx.api.onFindInPageResult).toHaveBeenCalledTimes(1)
+
+    overlay.destroy()
+
+    // After destroy, emitted events must not reach handlers (no throw, no find calls).
+    expect(() => ctx.emitShow()).not.toThrow()
+    expect(() => ctx.emitResult({ requestId: 1, activeMatchOrdinal: 1, matches: 1, finalUpdate: true })).not.toThrow()
+  })
+
+  it('exports the storage key constant', () => {
+    expect(LAST_QUERY_STORAGE_KEY).toBe('open-science:window-find:last-query')
+  })
+
+  it('on show: focuses input and restores remembered query, searching with requestId 1', () => {
+    ctx.store.set(LAST_QUERY_STORAGE_KEY, 'protein')
+    const focusSpy = vi.spyOn(ctx.input, 'focus')
+
+    createFindOverlay(ctx.deps)
+    ctx.emitShow()
+
+    expect(focusSpy).toHaveBeenCalledTimes(1)
+    expect(ctx.input.value).toBe('protein')
+    expect(ctx.api.findInPage).toHaveBeenCalledTimes(1)
+    expect(ctx.api.findInPage).toHaveBeenCalledWith({
+      requestId: 1,
+      text: 'protein',
+      findNext: true,
+      forward: true
+    })
+  })
+
+  it('on show with empty/absent remembered query: leaves input blank and does not search', () => {
+    const focusSpy = vi.spyOn(ctx.input, 'focus')
+
+    createFindOverlay(ctx.deps)
+    ctx.emitShow()
+
+    expect(focusSpy).toHaveBeenCalledTimes(1)
+    expect(ctx.input.value).toBe('')
+    expect(ctx.api.findInPage).not.toHaveBeenCalled()
+  })
+
+  it('typing a non-empty value searches with an incremented requestId and persists', () => {
+    createFindOverlay(ctx.deps)
+
+    ctx.input.value = 'pro'
+    ctx.input.dispatchEvent(new Event('input', { bubbles: true }))
+
+    expect(ctx.storage.setItem).toHaveBeenCalledWith(LAST_QUERY_STORAGE_KEY, 'pro')
+    expect(ctx.api.findInPage).toHaveBeenCalledTimes(1)
+    expect(ctx.api.findInPage).toHaveBeenCalledWith({
+      requestId: 1,
+      text: 'pro',
+      findNext: true,
+      forward: true
+    })
+
+    ctx.input.value = 'prote'
+    ctx.input.dispatchEvent(new Event('input', { bubbles: true }))
+
+    expect(ctx.storage.setItem).toHaveBeenCalledWith(LAST_QUERY_STORAGE_KEY, 'prote')
+    expect(ctx.api.findInPage).toHaveBeenLastCalledWith({
+      requestId: 2,
+      text: 'prote',
+      findNext: true,
+      forward: true
+    })
+  })
+
+  it('typing an empty value clears the find and renders 0 / 0', () => {
+    createFindOverlay(ctx.deps)
+
+    ctx.input.value = ''
+    ctx.input.dispatchEvent(new Event('input', { bubbles: true }))
+
+    expect(ctx.storage.setItem).toHaveBeenCalledWith(LAST_QUERY_STORAGE_KEY, '')
+    expect(ctx.api.clearFind).toHaveBeenCalledTimes(1)
+    expect(ctx.api.findInPage).not.toHaveBeenCalled()
+    expect(ctx.count.textContent).toBe('0 / 0')
+  })
+
+  it('renders active / total from a matching result', () => {
+    createFindOverlay(ctx.deps)
+
+    ctx.input.value = 'protein'
+    ctx.input.dispatchEvent(new Event('input', { bubbles: true })) // requestId 1
+
+    ctx.emitResult({ requestId: 1, activeMatchOrdinal: 3, matches: 7, finalUpdate: true })
+    expect(ctx.count.textContent).toBe('3 / 7')
+  })
+
+  it('ignores stale results from an earlier requestId', () => {
+    createFindOverlay(ctx.deps)
+
+    ctx.input.value = 'protein'
+    ctx.input.dispatchEvent(new Event('input', { bubbles: true })) // requestId 1
+    ctx.input.value = 'variant'
+    ctx.input.dispatchEvent(new Event('input', { bubbles: true })) // requestId 2
+
+    // Late result for the abandoned "protein" search.
+    ctx.emitResult({ requestId: 1, activeMatchOrdinal: 2, matches: 9, finalUpdate: true })
+    expect(ctx.count.textContent).toBe('0 / 0')
+
+    // Fresh result for "variant" wins.
+    ctx.emitResult({ requestId: 2, activeMatchOrdinal: 1, matches: 4, finalUpdate: true })
+    expect(ctx.count.textContent).toBe('1 / 4')
+  })
+
+  it('next button searches forward with findNext:false and an incremented id', () => {
+    createFindOverlay(ctx.deps)
+    ctx.input.value = 'protein'
+    ctx.input.dispatchEvent(new Event('input', { bubbles: true })) // requestId 1
+
+    ctx.next.dispatchEvent(new Event('click', { bubbles: true }))
+
+    expect(ctx.api.findInPage).toHaveBeenLastCalledWith({
+      requestId: 2,
+      text: 'protein',
+      findNext: false,
+      forward: true
+    })
+  })
+
+  it('Enter (no shift) in input searches forward like the next button and prevents default', () => {
+    createFindOverlay(ctx.deps)
+    ctx.input.value = 'protein'
+    ctx.input.dispatchEvent(new Event('input', { bubbles: true })) // requestId 1
+
+    const evt = new KeyboardEvent('keydown', { key: 'Enter', shiftKey: false, bubbles: true, cancelable: true })
+    ctx.input.dispatchEvent(evt)
+
+    expect(evt.defaultPrevented).toBe(true)
+    expect(ctx.api.findInPage).toHaveBeenLastCalledWith({
+      requestId: 2,
+      text: 'protein',
+      findNext: false,
+      forward: true
+    })
+  })
+
+  it('previous button searches backward with findNext:false, forward:false', () => {
+    createFindOverlay(ctx.deps)
+    ctx.input.value = 'protein'
+    ctx.input.dispatchEvent(new Event('input', { bubbles: true })) // requestId 1
+
+    ctx.prev.dispatchEvent(new Event('click', { bubbles: true }))
+
+    expect(ctx.api.findInPage).toHaveBeenLastCalledWith({
+      requestId: 2,
+      text: 'protein',
+      findNext: false,
+      forward: false
+    })
+  })
+
+  it('Shift+Enter in input searches backward and prevents default', () => {
+    createFindOverlay(ctx.deps)
+    ctx.input.value = 'protein'
+    ctx.input.dispatchEvent(new Event('input', { bubbles: true })) // requestId 1
+
+    const evt = new KeyboardEvent('keydown', { key: 'Enter', shiftKey: true, bubbles: true, cancelable: true })
+    ctx.input.dispatchEvent(evt)
+
+    expect(evt.defaultPrevented).toBe(true)
+    expect(ctx.api.findInPage).toHaveBeenLastCalledWith({
+      requestId: 2,
+      text: 'protein',
+      findNext: false,
+      forward: false
+    })
+  })
+
+  it('next/prev do nothing when the query is empty', () => {
+    createFindOverlay(ctx.deps)
+    ctx.next.dispatchEvent(new Event('click', { bubbles: true }))
+    ctx.prev.dispatchEvent(new Event('click', { bubbles: true }))
+    expect(ctx.api.findInPage).not.toHaveBeenCalled()
+  })
+
+  it('close button calls api.closeFind()', () => {
+    createFindOverlay(ctx.deps)
+    ctx.close.dispatchEvent(new Event('click', { bubbles: true }))
+    expect(ctx.api.closeFind).toHaveBeenCalledTimes(1)
+  })
+
+  it('Escape in input calls api.closeFind() and prevents default; localStorage is not cleared', () => {
+    createFindOverlay(ctx.deps)
+    ctx.input.value = 'protein'
+    ctx.input.dispatchEvent(new Event('input', { bubbles: true }))
+    ctx.storage.setItem.mockClear()
+
+    const evt = new KeyboardEvent('keydown', { key: 'Escape', bubbles: true, cancelable: true })
+    ctx.input.dispatchEvent(evt)
+
+    expect(evt.defaultPrevented).toBe(true)
+    expect(ctx.api.closeFind).toHaveBeenCalledTimes(1)
+    expect(ctx.storage.setItem).not.toHaveBeenCalledWith(LAST_QUERY_STORAGE_KEY, '')
+    expect(ctx.storage.setItem).not.toHaveBeenCalledWith(LAST_QUERY_STORAGE_KEY, '')
+  })
+
+  it('destroy() detaches all DOM listeners so later events are inert', () => {
+    const overlay = createFindOverlay(ctx.deps)
+    ctx.input.value = 'protein'
+    ctx.input.dispatchEvent(new Event('input', { bubbles: true })) // requestId 1
+    ctx.api.findInPage.mockClear()
+    ctx.api.closeFind.mockClear()
+    ctx.storage.setItem.mockClear()
+
+    overlay.destroy()
+
+    ctx.input.value = 'variant'
+    ctx.input.dispatchEvent(new Event('input', { bubbles: true }))
+    ctx.input.dispatchEvent(new KeyboardEvent('keydown', { key: 'Enter', bubbles: true, cancelable: true }))
+    ctx.input.dispatchEvent(new KeyboardEvent('keydown', { key: 'Escape', bubbles: true, cancelable: true }))
+    ctx.next.dispatchEvent(new Event('click', { bubbles: true }))
+    ctx.prev.dispatchEvent(new Event('click', { bubbles: true }))
+    ctx.close.dispatchEvent(new Event('click', { bubbles: true }))
+
+    expect(ctx.api.findInPage).not.toHaveBeenCalled()
+    expect(ctx.api.closeFind).not.toHaveBeenCalled()
+    expect(ctx.storage.setItem).not.toHaveBeenCalled()
+  })
+})

--- a/resources/find-overlay/index.html
+++ b/resources/find-overlay/index.html
@@ -1,0 +1,164 @@
+<!doctype html>
+<html lang="en">
+  <head>
+    <meta charset="utf-8" />
+    <meta name="viewport" content="width=device-width, initial-scale=1" />
+    <title>Find in window</title>
+    <style>
+      :root {
+        --bg: #ffffff;
+        --border: #d8d8dc;
+        --text: #1a1a1a;
+        --muted: #6b6b72;
+        --hover: #ececee;
+        color-scheme: light;
+      }
+      @media (prefers-color-scheme: dark) {
+        :root {
+          --bg: #1f1f23;
+          --border: #3a3a42;
+          --text: #f2f2f3;
+          --muted: #a0a0a8;
+          --hover: #2e2e35;
+          color-scheme: dark;
+        }
+      }
+      * {
+        box-sizing: border-box;
+      }
+      html,
+      body {
+        height: 100%;
+        margin: 0;
+      }
+      body {
+        font-family: -apple-system, 'Segoe UI', system-ui, sans-serif;
+        background: var(--bg);
+        color: var(--text);
+        -webkit-user-select: none;
+        user-select: none;
+        overflow: hidden;
+      }
+      .bar {
+        display: flex;
+        height: 100%;
+        align-items: center;
+        gap: 4px;
+        padding: 0 8px;
+      }
+      .icon {
+        width: 16px;
+        height: 16px;
+        color: var(--muted);
+        flex: none;
+      }
+      /* Plain text field — visible characters, no password masking. */
+      input {
+        flex: 1 1 auto;
+        min-width: 0;
+        height: 28px;
+        border: 0;
+        background: transparent;
+        padding: 0 4px;
+        font-size: 13px;
+        color: var(--text);
+        outline: none;
+        -webkit-user-select: text;
+        user-select: text;
+      }
+      input::placeholder {
+        color: var(--muted);
+      }
+      .count {
+        min-width: 48px;
+        flex: none;
+        text-align: center;
+        font-size: 12px;
+        font-variant-numeric: tabular-nums;
+        color: var(--muted);
+      }
+      .divider {
+        width: 1px;
+        height: 20px;
+        background: var(--border);
+        flex: none;
+      }
+      .btn {
+        display: inline-flex;
+        width: 28px;
+        height: 28px;
+        flex: none;
+        align-items: center;
+        justify-content: center;
+        border: 0;
+        border-radius: 4px;
+        background: transparent;
+        color: var(--muted);
+        cursor: default;
+      }
+      .btn:hover {
+        background: var(--hover);
+        color: var(--text);
+      }
+      .btn svg {
+        width: 16px;
+        height: 16px;
+      }
+    </style>
+  </head>
+  <body>
+    <div class="bar" role="search" aria-label="Find in window">
+      <svg class="icon" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" aria-hidden="true">
+        <circle cx="11" cy="11" r="7"></circle>
+        <line x1="21" y1="21" x2="16.65" y2="16.65"></line>
+      </svg>
+      <input
+        id="find-overlay-query"
+        type="text"
+        autocomplete="off"
+        autocapitalize="off"
+        autocorrect="off"
+        spellcheck="false"
+        aria-label="Find text"
+        placeholder="Find"
+      />
+      <span class="count" id="find-overlay-count">0 / 0</span>
+      <span class="divider" aria-hidden="true"></span>
+      <button
+        type="button"
+        class="btn"
+        id="find-overlay-prev"
+        aria-label="Previous match"
+        title="Previous match (Shift+Enter)"
+      >
+        <svg viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" aria-hidden="true">
+          <polyline points="18 15 12 9 6 15"></polyline>
+        </svg>
+      </button>
+      <button
+        type="button"
+        class="btn"
+        id="find-overlay-next"
+        aria-label="Next match"
+        title="Next match (Enter)"
+      >
+        <svg viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" aria-hidden="true">
+          <polyline points="6 9 12 15 18 9"></polyline>
+        </svg>
+      </button>
+      <button
+        type="button"
+        class="btn"
+        id="find-overlay-close"
+        aria-label="Close find"
+        title="Close (Esc)"
+      >
+        <svg viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" aria-hidden="true">
+          <line x1="18" y1="6" x2="6" y2="18"></line>
+          <line x1="6" y1="6" x2="18" y2="18"></line>
+        </svg>
+      </button>
+    </div>
+    <script type="module" src="./findOverlay.js"></script>
+  </body>
+</html>

--- a/src/main/find-overlay-registry.ts
+++ b/src/main/find-overlay-registry.ts
@@ -1,0 +1,22 @@
+// Maps an overlay WebContentsView's webContents to the (main window, close handle) pair that owns it.
+//
+// Electron's BrowserWindow.fromWebContents resolves a webContents to the BrowserWindow that owns it as
+// the window's *main* webContents. A child WebContentsView's webContents is not that, so the lookup is
+// unreliable for the overlay. Instead the overlay manager records the pairing when it creates the view:
+// the find-IPC handler routes search requests to owner.mainWindow, and the close channel invokes
+// owner.closeOverlay to hide the bar.
+export type FindOverlayOwner = { mainWindow: unknown; closeOverlay: () => void }
+
+const owners = new WeakMap<object, FindOverlayOwner>()
+
+export const registerFindOverlayOwner = (overlay: object, owner: FindOverlayOwner): void => {
+  owners.set(overlay, owner)
+}
+
+export const unregisterFindOverlayOwner = (overlay: object): void => {
+  owners.delete(overlay)
+}
+
+export const resolveFindOverlayOwner = (
+  overlay: object | null | undefined
+): FindOverlayOwner | undefined => (overlay ? owners.get(overlay) : undefined)

--- a/src/main/find-overlay.test.ts
+++ b/src/main/find-overlay.test.ts
@@ -1,0 +1,160 @@
+import { describe, expect, it, vi, type Mock } from 'vitest'
+
+import {
+  computeOverlayBounds,
+  createFindOverlayManager,
+  type FindOverlayManager
+} from './find-overlay'
+import { WINDOW_FIND_SHOW_CHANNEL } from '../shared/window-controls'
+
+describe('computeOverlayBounds', () => {
+  it('anchors the bar to the top-right of the content area with a margin', () => {
+    expect(computeOverlayBounds(1000)).toEqual({ x: 572, y: 8, width: 420, height: 40 })
+  })
+
+  it('shrinks the width when the window is narrower than the preferred bar', () => {
+    // 300 wide: width clamps to contentWidth - 2*margin = 284, x stays at the left margin.
+    expect(computeOverlayBounds(300)).toEqual({ x: 8, y: 8, width: 284, height: 40 })
+  })
+
+  it('keeps a minimum width and never slides off the left edge on very narrow windows', () => {
+    expect(computeOverlayBounds(200)).toEqual({ x: 0, y: 8, width: 240, height: 40 })
+  })
+})
+
+const PRELOAD_PATH = '/p/index.js'
+const HTML_PATH = '/r/find-overlay/index.html'
+
+type FindOverlayTestFakes = {
+  view: {
+    webContents: { loadFile: Mock; send: Mock; focus: Mock }
+    setBounds: Mock
+    destroy: Mock
+  }
+  mainWindow: {
+    contentView: { addChildView: Mock }
+    getContentBounds: () => { width: number; height: number }
+    on: Mock
+    removeListener: Mock
+    webContents: { focus: Mock; stopFindInPage: Mock }
+  }
+  createView: Mock
+  registerOwner: Mock
+  manager: FindOverlayManager
+}
+
+const createFakes = (): FindOverlayTestFakes => {
+  const view = {
+    webContents: { loadFile: vi.fn(), send: vi.fn(), focus: vi.fn() },
+    setBounds: vi.fn(),
+    destroy: vi.fn()
+  }
+  const mainWindow = {
+    contentView: { addChildView: vi.fn() },
+    getContentBounds: () => ({ width: 1000, height: 800 }),
+    on: vi.fn(),
+    removeListener: vi.fn(),
+    webContents: { focus: vi.fn(), stopFindInPage: vi.fn() }
+  }
+  const createView = vi.fn(() => view)
+  const registerOwner = vi.fn()
+  const manager = createFindOverlayManager({
+    mainWindow,
+    createView,
+    preloadPath: PRELOAD_PATH,
+    overlayHtmlPath: HTML_PATH,
+    registerOwner
+  })
+  return { view, mainWindow, createView, registerOwner, manager }
+}
+
+describe('find overlay manager', () => {
+  it('open() creates, loads, attaches, positions, focuses the overlay and signals show', () => {
+    const { view, mainWindow, createView, registerOwner, manager } = createFakes()
+
+    manager.open()
+
+    expect(createView).toHaveBeenCalledWith({
+      webPreferences: { preload: PRELOAD_PATH, sandbox: true, contextIsolation: true }
+    })
+    expect(view.webContents.loadFile).toHaveBeenCalledWith(HTML_PATH)
+    expect(mainWindow.contentView.addChildView).toHaveBeenCalledWith(view)
+    expect(view.setBounds).toHaveBeenCalledWith({ x: 572, y: 8, width: 420, height: 40 })
+    expect(view.webContents.focus).toHaveBeenCalledTimes(1)
+    expect(view.webContents.send).toHaveBeenCalledWith(WINDOW_FIND_SHOW_CHANNEL)
+    expect(registerOwner).toHaveBeenCalledWith(view.webContents, {
+      mainWindow,
+      closeOverlay: expect.any(Function)
+    })
+  })
+
+  it('registers a closeOverlay that hides the bar (invoked by the find-IPC close channel)', () => {
+    const { view, mainWindow, registerOwner, manager } = createFakes()
+    manager.open()
+
+    const owner = registerOwner.mock.calls[0]?.[1] as { closeOverlay: () => void }
+    expect(owner.closeOverlay).toBeTypeOf('function')
+    view.setBounds.mockClear()
+    mainWindow.webContents.stopFindInPage.mockClear()
+
+    // Simulate the overlay's X button -> main -> owner.closeOverlay().
+    owner.closeOverlay()
+
+    expect(view.setBounds).toHaveBeenCalledWith({ x: 0, y: 0, width: 0, height: 0 })
+    expect(mainWindow.webContents.stopFindInPage).toHaveBeenCalledWith('clearSelection')
+    expect(manager.isOpen()).toBe(false)
+  })
+
+  it('reuses the same view across repeated opens and re-signals show each time', () => {
+    const { view, mainWindow, createView, manager } = createFakes()
+
+    manager.open()
+    manager.open()
+
+    expect(createView).toHaveBeenCalledTimes(1)
+    expect(mainWindow.contentView.addChildView).toHaveBeenCalledTimes(1)
+    expect(view.webContents.send).toHaveBeenCalledTimes(2)
+    expect(view.webContents.focus).toHaveBeenCalledTimes(2)
+  })
+
+  it('close() hides the overlay, clears the main selection, and returns focus to the main window', () => {
+    const { view, mainWindow, manager } = createFakes()
+    manager.open()
+    view.setBounds.mockClear()
+    mainWindow.webContents.stopFindInPage.mockClear()
+
+    manager.close()
+
+    expect(view.setBounds).toHaveBeenCalledWith({ x: 0, y: 0, width: 0, height: 0 })
+    expect(mainWindow.webContents.stopFindInPage).toHaveBeenCalledWith('clearSelection')
+    expect(mainWindow.webContents.focus).toHaveBeenCalledTimes(1)
+    expect(manager.isOpen()).toBe(false)
+  })
+
+  it('close() is a no-op when the overlay is already hidden', () => {
+    const { mainWindow, manager } = createFakes()
+
+    manager.close()
+
+    expect(mainWindow.webContents.stopFindInPage).not.toHaveBeenCalled()
+    expect(mainWindow.webContents.focus).not.toHaveBeenCalled()
+  })
+
+  it('repositions on resize while open and ignores resize while hidden', () => {
+    const { view, mainWindow, manager } = createFakes()
+    const resizeListener = mainWindow.on.mock.calls.find(([event]) => event === 'resize')?.[1] as
+      (() => void) | undefined
+    expect(resizeListener).toBeTruthy()
+
+    mainWindow.getContentBounds = () => ({ width: 1400, height: 900 })
+
+    // Hidden: a resize must not touch the overlay.
+    resizeListener!()
+
+    manager.open()
+    view.setBounds.mockClear()
+    resizeListener!()
+
+    expect(view.setBounds).toHaveBeenCalledWith(computeOverlayBounds(1400))
+  })
+})

--- a/src/main/find-overlay.ts
+++ b/src/main/find-overlay.ts
@@ -1,0 +1,126 @@
+import { WINDOW_FIND_SHOW_CHANNEL } from '../shared/window-controls'
+import type { FindOverlayOwner } from './find-overlay-registry'
+
+// Preferred geometry for the find overlay, in CSS pixels. 420px ~ 26rem at the app's 16px base.
+const OVERLAY_WIDTH = 420
+const OVERLAY_HEIGHT = 40
+const OVERLAY_MARGIN = 8
+const OVERLAY_MIN_WIDTH = 240
+
+// Computes the overlay's bounds within the main window's content area: pinned to the top-right with a
+// small margin, shrinking (down to a floor) on narrow windows and never sliding off the left edge.
+export const computeOverlayBounds = (
+  contentWidth: number
+): { x: number; y: number; width: number; height: number } => {
+  const width = Math.max(
+    OVERLAY_MIN_WIDTH,
+    Math.min(OVERLAY_WIDTH, contentWidth - OVERLAY_MARGIN * 2)
+  )
+  const x = Math.max(0, contentWidth - width - OVERLAY_MARGIN)
+  return { x, y: OVERLAY_MARGIN, width, height: OVERLAY_HEIGHT }
+}
+
+// The overlay view the manager drives. Kept structural so the manager is unit-testable without
+// importing electron: the real caller passes a `new WebContentsView(...)`. Method syntax (rather than
+// arrow properties) makes these bivariant, so a real Electron BrowserWindow / WebContentsView satisfies
+// the shape without manual casts.
+type OverlayWebContents = {
+  loadFile(path: string): void
+  send(channel: string, payload?: unknown): void
+  focus(): void
+}
+type OverlayView = {
+  webContents: OverlayWebContents
+  setBounds(bounds: { x: number; y: number; width: number; height: number }): void
+  destroy?(): void
+}
+
+// The main window the overlay searches and attaches to. Structural for the same testability reason.
+type OverlayMainWindow = {
+  contentView: { addChildView(view: OverlayView): void }
+  getContentBounds(): { width: number; height: number }
+  on(event: 'resize', listener: () => void): void
+  removeListener?(event: 'resize', listener: () => void): void
+  off?(event: 'resize', listener: () => void): void
+  webContents: { focus(): void; stopFindInPage(action: 'clearSelection'): void }
+}
+
+export type FindOverlayDeps = {
+  mainWindow: OverlayMainWindow
+  createView: (opts: {
+    webPreferences: { preload: string; sandbox: boolean; contextIsolation: boolean }
+  }) => OverlayView
+  preloadPath: string
+  overlayHtmlPath: string
+  // Records that this overlay's webContents is owned by this main window, so the find-IPC handler can
+  // route search requests to the right window and the close channel can invoke closeOverlay. Optional
+  // only for tests.
+  registerOwner?: (overlay: object, owner: FindOverlayOwner) => void
+}
+
+export type FindOverlayManager = {
+  open: () => void
+  close: () => void
+  destroy: () => void
+  isOpen: () => boolean
+}
+
+const ZERO_BOUNDS = { x: 0, y: 0, width: 0, height: 0 }
+
+// Owns the find overlay WebContentsView for one main window. The view is created lazily on first open
+// and stays attached for the life of the window: open/close toggle its bounds (real vs. zero) rather
+// than attaching/detaching, which keeps the overlay's webContents — and its remembered query — alive
+// across open/close cycles. The overlay is a separate webContents from the main window's, so its own
+// query text is never part of the main window's page search.
+export const createFindOverlayManager = (deps: FindOverlayDeps): FindOverlayManager => {
+  let view: OverlayView | null = null
+  let opened = false
+
+  const position = (): void => {
+    if (!view) return
+    const { width } = deps.mainWindow.getContentBounds()
+    view.setBounds(computeOverlayBounds(width))
+  }
+
+  const onResize = (): void => {
+    if (opened) position()
+  }
+  deps.mainWindow.on('resize', onResize)
+
+  const close = (): void => {
+    if (!opened) return
+    opened = false
+    view?.setBounds(ZERO_BOUNDS)
+    deps.mainWindow.webContents.stopFindInPage('clearSelection')
+    deps.mainWindow.webContents.focus()
+  }
+
+  return {
+    isOpen: () => opened,
+
+    open: () => {
+      if (!view) {
+        view = deps.createView({
+          webPreferences: { preload: deps.preloadPath, sandbox: true, contextIsolation: true }
+        })
+        view.webContents.loadFile(deps.overlayHtmlPath)
+        deps.mainWindow.contentView.addChildView(view)
+        // Register the owner with the close handle so the find-IPC close channel can hide this overlay.
+        deps.registerOwner?.(view.webContents, { mainWindow: deps.mainWindow, closeOverlay: close })
+      }
+      opened = true
+      position()
+      view.webContents.focus()
+      view.webContents.send(WINDOW_FIND_SHOW_CHANNEL)
+    },
+
+    close,
+
+    destroy: () => {
+      ;(deps.mainWindow.removeListener ?? deps.mainWindow.off)?.('resize', onResize)
+      view?.destroy?.()
+      view = null
+      opened = false
+    }
+  }
+}

--- a/src/main/ipc.ts
+++ b/src/main/ipc.ts
@@ -31,6 +31,7 @@ import { BackendShutdownCoordinator, UPDATE_SHUTDOWN_BUDGET_MS } from './lifecyc
 import { registerLifecycleIpcHandlers } from './lifecycle-broadcast'
 import { registerLogsIpcHandlers } from './logs-ipc'
 import { registerWindowIpcHandlers } from './window-ipc'
+import { registerWindowFindIpcHandlers } from './window-find-ipc'
 import { TaskNotificationService } from './notifications/task-notifications'
 import {
   buildConnectorApprovalBroadcast,
@@ -485,6 +486,7 @@ const registerIpcHandlers = async ({
   registerGithubIpcHandlers()
   registerCliInstallIpcHandlers()
   registerWindowIpcHandlers()
+  registerWindowFindIpcHandlers()
   const updateService = registerUpdateIpcHandlers()
   startUpdateScheduler(updateService)
   const runtime = registerAcpIpcHandlers({

--- a/src/main/window-find-ipc.test.ts
+++ b/src/main/window-find-ipc.test.ts
@@ -1,0 +1,166 @@
+import { beforeEach, describe, expect, it, type Mock, vi } from 'vitest'
+
+import { registerFindOverlayOwner } from './find-overlay-registry'
+import {
+  WINDOW_FIND_CLEAR_CHANNEL,
+  WINDOW_FIND_CLOSE_CHANNEL,
+  WINDOW_FIND_REQUEST_CHANNEL,
+  WINDOW_FIND_RESULT_CHANNEL,
+  type WindowFindResult
+} from '../shared/window-controls'
+
+const handlers = new Map<string, (event: unknown, payload: unknown) => void>()
+
+vi.mock('electron', () => ({
+  ipcMain: {
+    on: (channel: string, listener: (event: unknown, payload: unknown) => void) => {
+      handlers.set(channel, listener)
+    }
+  },
+  BrowserWindow: {}
+}))
+
+const { registerWindowFindIpcHandlers } = await import('./window-find-ipc')
+
+type FoundInPageResult = WindowFindResult & { requestId: number }
+type FindInPageOptions = { findNext: boolean; forward: boolean; matchCase: boolean }
+
+// The MAIN window: the webContents that actually gets searched and emits found-in-page.
+type TargetWindow = {
+  webContents: {
+    findInPage: Mock<(text: string, options: FindInPageOptions) => number>
+    stopFindInPage: Mock<(action: 'clearSelection') => void>
+    on: Mock<
+      (
+        event: 'found-in-page',
+        listener: (event: unknown, result: FoundInPageResult) => void
+      ) => void
+    >
+  }
+  emitFoundInPage: (result: FoundInPageResult) => void
+}
+
+// The OVERLAY window: a separate webContents that issues requests and receives results. Its own
+// content is never searched, so its query cannot become a false match.
+type OverlaySender = {
+  send: Mock<(channel: string, result: WindowFindResult) => void>
+}
+
+const createTargetWindow = (): TargetWindow => {
+  const foundListeners: Array<(event: unknown, result: FoundInPageResult) => void> = []
+  const webContents = {
+    findInPage: vi.fn<(text: string, options: FindInPageOptions) => number>(() => 17),
+    stopFindInPage: vi.fn<(action: 'clearSelection') => void>(),
+    on: vi.fn<
+      (
+        event: 'found-in-page',
+        listener: (event: unknown, result: FoundInPageResult) => void
+      ) => void
+    >((_event, listener) => {
+      foundListeners.push(listener)
+    })
+  }
+
+  return {
+    webContents,
+    emitFoundInPage: (result: FoundInPageResult): void => {
+      for (const listener of foundListeners) listener({}, result)
+    }
+  }
+}
+
+const createOverlay = (): OverlaySender => ({
+  send: vi.fn<(channel: string, result: WindowFindResult) => void>()
+})
+
+describe('window find IPC', () => {
+  beforeEach(() => handlers.clear())
+
+  it('searches the resolved MAIN window and returns the match count to the overlay sender', () => {
+    const target = createTargetWindow()
+    const overlay = createOverlay()
+    registerWindowFindIpcHandlers({ resolveMainWindow: () => target })
+
+    handlers.get(WINDOW_FIND_REQUEST_CHANNEL)!(
+      { sender: overlay },
+      { requestId: 1, text: 'protein', findNext: true, forward: true }
+    )
+    target.emitFoundInPage({ requestId: 17, activeMatchOrdinal: 1, matches: 4, finalUpdate: true })
+
+    // The search runs against the MAIN window's webContents, never the overlay's.
+    expect(target.webContents.findInPage).toHaveBeenCalledWith('protein', {
+      findNext: true,
+      forward: true,
+      matchCase: false
+    })
+    // The result is delivered to the overlay that asked, not echoed back to the main window.
+    expect(overlay.send).toHaveBeenCalledWith(WINDOW_FIND_RESULT_CHANNEL, {
+      requestId: 1,
+      activeMatchOrdinal: 1,
+      matches: 4,
+      finalUpdate: true
+    })
+  })
+
+  it('does not return an asynchronous result from a superseded query to the overlay', () => {
+    const target = createTargetWindow()
+    target.webContents.findInPage.mockReturnValueOnce(17).mockReturnValueOnce(18)
+    const overlay = createOverlay()
+    registerWindowFindIpcHandlers({ resolveMainWindow: () => target })
+
+    handlers.get(WINDOW_FIND_REQUEST_CHANNEL)!(
+      { sender: overlay },
+      { requestId: 1, text: 'protein', findNext: true, forward: true }
+    )
+    handlers.get(WINDOW_FIND_REQUEST_CHANNEL)!(
+      { sender: overlay },
+      { requestId: 2, text: 'variant', findNext: true, forward: true }
+    )
+    target.emitFoundInPage({ requestId: 17, activeMatchOrdinal: 1, matches: 4, finalUpdate: true })
+    target.emitFoundInPage({ requestId: 18, activeMatchOrdinal: 1, matches: 2, finalUpdate: true })
+
+    expect(overlay.send).toHaveBeenCalledTimes(1)
+    expect(overlay.send).toHaveBeenCalledWith(WINDOW_FIND_RESULT_CHANNEL, {
+      requestId: 2,
+      activeMatchOrdinal: 1,
+      matches: 2,
+      finalUpdate: true
+    })
+  })
+
+  it('clears the search selection on the MAIN window when the overlay closes', () => {
+    const target = createTargetWindow()
+    const overlay = createOverlay()
+    registerWindowFindIpcHandlers({ resolveMainWindow: () => target })
+
+    handlers.get(WINDOW_FIND_CLEAR_CHANNEL)!({ sender: overlay }, undefined)
+
+    expect(target.webContents.stopFindInPage).toHaveBeenCalledWith('clearSelection')
+  })
+
+  it('hides the overlay by invoking the registered owner close handler', () => {
+    // The overlay's X button / Esc send WINDOW_FIND_CLOSE_CHANNEL; main looks up the owner registered
+    // for that overlay (which knows how to hide it) and invokes its closeOverlay.
+    const target = createTargetWindow()
+    const overlay = createOverlay()
+    const closeOverlay = vi.fn()
+    registerFindOverlayOwner(overlay, { mainWindow: target, closeOverlay })
+    registerWindowFindIpcHandlers()
+
+    handlers.get(WINDOW_FIND_CLOSE_CHANNEL)!({ sender: overlay }, undefined)
+
+    expect(closeOverlay).toHaveBeenCalledTimes(1)
+  })
+
+  it('ignores a request when no main window can be resolved for the overlay', () => {
+    const target = createTargetWindow()
+    registerWindowFindIpcHandlers({ resolveMainWindow: () => null })
+
+    handlers.get(WINDOW_FIND_REQUEST_CHANNEL)!(
+      { sender: createOverlay() },
+      { requestId: 1, text: 'protein', findNext: true, forward: true }
+    )
+
+    expect(target.webContents.findInPage).not.toHaveBeenCalled()
+  })
+})

--- a/src/main/window-find-ipc.ts
+++ b/src/main/window-find-ipc.ts
@@ -1,0 +1,115 @@
+import { BrowserWindow, ipcMain, type IpcMainEvent, type WebContents } from 'electron'
+
+import { resolveFindOverlayOwner } from './find-overlay-registry'
+import {
+  WINDOW_FIND_CLEAR_CHANNEL,
+  WINDOW_FIND_CLOSE_CHANNEL,
+  WINDOW_FIND_REQUEST_CHANNEL,
+  WINDOW_FIND_RESULT_CHANNEL,
+  type WindowFindRequest,
+  type WindowFindResult
+} from '../shared/window-controls'
+
+// The MAIN window's webContents is what actually gets searched and emits found-in-page. It needs no
+// send(): results are delivered to the OVERLAY that issued the request, not echoed to the main window.
+type FindTargetWebContents = {
+  findInPage: (
+    text: string,
+    options: { findNext: boolean; forward: boolean; matchCase: boolean }
+  ) => number
+  stopFindInPage: (action: 'clearSelection') => void
+  on: (
+    event: 'found-in-page',
+    listener: (event: unknown, result: WindowFindResult & { requestId: number }) => void
+  ) => void
+}
+type FindWindow = { webContents: FindTargetWebContents }
+
+// The OVERLAY webContents issues requests and receives results. It is a separate WebContents (a
+// WebContentsView) so its own query text is never part of the main window's search.
+type OverlayWebContents = { send: (channel: string, payload: WindowFindResult) => void }
+
+type WindowFindIpcDeps = {
+  // Maps the overlay that issued a request to the MAIN window whose content should be searched.
+  // Defaults to BrowserWindow.fromWebContents, which resolves the owning BrowserWindow of a child
+  // WebContentsView to its parent.
+  resolveMainWindow?: (sender: WebContents) => FindWindow | null
+}
+
+const isWindowFindRequest = (value: unknown): value is WindowFindRequest => {
+  if (!value || typeof value !== 'object') return false
+  const request = value as Partial<WindowFindRequest>
+  return (
+    typeof request.text === 'string' &&
+    typeof request.findNext === 'boolean' &&
+    typeof request.forward === 'boolean'
+  )
+}
+
+// Registers native page-find for the overlay->main-window flow. The overlay owns the query UI; main
+// searches its own webContents and forwards each result back to the overlay that asked. The active
+// request is tracked per searched webContents so an asynchronous result from an earlier query cannot
+// overwrite the overlay's current count.
+const registerWindowFindIpcHandlers = (deps: WindowFindIpcDeps = {}): void => {
+  // Prefer the overlay->main registry (recorded when the overlay view was created); fall back to
+  // fromWebContents for any non-overlay sender.
+  const resolveMainWindow =
+    deps.resolveMainWindow ??
+    ((sender) =>
+      (resolveFindOverlayOwner(sender)?.mainWindow as FindWindow | null) ??
+      BrowserWindow.fromWebContents(sender))
+  const activeRequests = new WeakMap<
+    FindTargetWebContents,
+    { nativeRequestId: number; rendererRequestId: number; replyTo: OverlayWebContents }
+  >()
+  const listening = new WeakSet<FindTargetWebContents>()
+
+  const installResultListener = (webContents: FindTargetWebContents): void => {
+    if (listening.has(webContents)) return
+    listening.add(webContents)
+    webContents.on('found-in-page', (_event, result) => {
+      const activeRequest = activeRequests.get(webContents)
+      if (!activeRequest || activeRequest.nativeRequestId !== result.requestId) return
+      const update: WindowFindResult = {
+        requestId: activeRequest.rendererRequestId,
+        activeMatchOrdinal: result.activeMatchOrdinal,
+        matches: result.matches,
+        finalUpdate: result.finalUpdate
+      }
+      activeRequest.replyTo.send(WINDOW_FIND_RESULT_CHANNEL, update)
+    })
+  }
+
+  ipcMain.on(WINDOW_FIND_REQUEST_CHANNEL, (event: IpcMainEvent, request: unknown): void => {
+    if (!isWindowFindRequest(request) || request.text.length === 0) return
+    const webContents = resolveMainWindow(event.sender)?.webContents
+    if (!webContents) return
+
+    installResultListener(webContents)
+    activeRequests.set(webContents, {
+      nativeRequestId: webContents.findInPage(request.text, {
+        findNext: request.findNext,
+        forward: request.forward,
+        matchCase: false
+      }),
+      rendererRequestId: request.requestId,
+      replyTo: event.sender
+    })
+  })
+
+  ipcMain.on(WINDOW_FIND_CLEAR_CHANNEL, (event: IpcMainEvent): void => {
+    const webContents = resolveMainWindow(event.sender)?.webContents
+    if (!webContents) return
+    activeRequests.delete(webContents)
+    webContents.stopFindInPage('clearSelection')
+  })
+
+  // The overlay asked to close (X button or its own Escape). Invoke the owner's close handle, which
+  // hides the overlay view, clears the main selection, and refocuses the main window.
+  ipcMain.on(WINDOW_FIND_CLOSE_CHANNEL, (event: IpcMainEvent): void => {
+    resolveFindOverlayOwner(event.sender)?.closeOverlay()
+  })
+}
+
+export { registerWindowFindIpcHandlers }
+export type { WindowFindIpcDeps }

--- a/src/main/windows.test.ts
+++ b/src/main/windows.test.ts
@@ -4,6 +4,7 @@ import {
   CLOSE_ACTIVE_PANE_CHANNEL,
   CLOSE_ACTIVE_PANE_READY_CHANNEL,
   CLOSE_ACTIVE_PANE_UNREADY_CHANNEL,
+  WINDOW_FIND_READY_CHANNEL,
   type KeyChordInput
 } from '../shared/window-controls'
 
@@ -12,6 +13,20 @@ const { openExternalMock, ipcMainOnMock, ipcMainRemoveListenerMock } = vi.hoiste
   openExternalMock: vi.fn(),
   ipcMainOnMock: vi.fn(),
   ipcMainRemoveListenerMock: vi.fn()
+}))
+
+// The overlay manager is a collaborator with its own deep test suite; here we only need to observe
+// that the chord/Escape wiring drives it, so the real module is replaced with a spy object.
+const { findOverlayMock } = vi.hoisted(() => ({
+  findOverlayMock: {
+    open: vi.fn(),
+    close: vi.fn(),
+    destroy: vi.fn(),
+    isOpen: vi.fn(() => false)
+  }
+}))
+vi.mock('./find-overlay', () => ({
+  createFindOverlayManager: () => findOverlayMock
 }))
 
 // Captured window-open handler so tests can drive it directly, mirroring how Electron invokes it on a
@@ -93,7 +108,7 @@ class FakeBrowserWindow {
 
 vi.mock('electron', () => ({
   // isPackaged=true skips the dev title-suffix branch, keeping the fake focused on the open + close handlers.
-  app: { isPackaged: true },
+  app: { isPackaged: true, getAppPath: () => '/app' },
   BrowserWindow: class {
     constructor() {
       currentWindow = new FakeBrowserWindow()
@@ -101,6 +116,7 @@ vi.mock('electron', () => ({
       return currentWindow as unknown as object
     }
   },
+  WebContentsView: class {},
   ipcMain: { on: ipcMainOnMock, removeListener: ipcMainRemoveListenerMock },
   shell: { openExternal: openExternalMock }
 }))
@@ -116,6 +132,17 @@ const { createMainWindow } = await import('./windows')
 const closeChord = (overrides: Partial<KeyChordInput> = {}): KeyChordInput => ({
   type: 'keyDown',
   key: 'w',
+  control: process.platform !== 'darwin',
+  meta: process.platform === 'darwin',
+  alt: false,
+  shift: false,
+  isAutoRepeat: false,
+  ...overrides
+})
+
+const findChord = (overrides: Partial<KeyChordInput> = {}): KeyChordInput => ({
+  type: 'keyDown',
+  key: 'f',
   control: process.platform !== 'darwin',
   meta: process.platform === 'darwin',
   alt: false,
@@ -226,6 +253,10 @@ describe('close chord interception', () => {
     currentWindow = undefined
     ipcMainOnMock.mockReset()
     ipcMainRemoveListenerMock.mockReset()
+    findOverlayMock.open.mockClear()
+    findOverlayMock.close.mockClear()
+    findOverlayMock.destroy.mockClear()
+    findOverlayMock.isOpen.mockReturnValue(false)
   })
 
   // Fires an ipcMain handshake signal that main registered via ipcMain.on, spoofing the sender as this
@@ -242,6 +273,9 @@ describe('close chord interception', () => {
 
   const signalRendererGone = (window: FakeBrowserWindow): void =>
     fireHandshake(window, CLOSE_ACTIVE_PANE_UNREADY_CHANNEL)
+
+  const signalWindowFindReady = (window: FakeBrowserWindow): void =>
+    fireHandshake(window, WINDOW_FIND_READY_CHANNEL)
 
   // Drives one of the captured webContents lifecycle handlers (render-process-gone, unresponsive, ...).
   const fireWebContentsEvent = (
@@ -287,6 +321,39 @@ describe('close chord interception', () => {
     expect(preventDefault).toHaveBeenCalled()
     expect(window.sendMock).toHaveBeenCalledWith(CLOSE_ACTIVE_PANE_CHANNEL)
     expect(window.closeMock).not.toHaveBeenCalled()
+  })
+
+  it('opens the find overlay only after the Workspace listener is ready', () => {
+    createMainWindow()
+    const window = currentWindow!
+
+    signalWindowFindReady(window)
+    const preventDefault = fireInput(window, findChord())
+
+    expect(preventDefault).toHaveBeenCalled()
+    expect(findOverlayMock.open).toHaveBeenCalledTimes(1)
+    // The overlay is opened directly in main now; no OPEN message is sent to the renderer.
+    expect(window.sendMock).not.toHaveBeenCalled()
+    expect(window.closeMock).not.toHaveBeenCalled()
+  })
+
+  it('closes the find overlay on Escape while it is open, regardless of input focus', () => {
+    createMainWindow()
+    const window = currentWindow!
+    findOverlayMock.isOpen.mockReturnValue(true)
+
+    const preventDefault = fireInput(window, {
+      type: 'keyDown',
+      key: 'Escape',
+      control: false,
+      meta: false,
+      alt: false,
+      shift: false,
+      isAutoRepeat: false
+    })
+
+    expect(preventDefault).toHaveBeenCalled()
+    expect(findOverlayMock.close).toHaveBeenCalledTimes(1)
   })
 
   it('re-arms the direct-close fallback after a top-level navigation clears renderer readiness', () => {

--- a/src/main/windows.ts
+++ b/src/main/windows.ts
@@ -3,6 +3,7 @@ import {
   BrowserWindow,
   ipcMain,
   shell,
+  WebContentsView,
   type BrowserWindowConstructorOptions,
   type IpcMainEvent
 } from 'electron'
@@ -10,17 +11,25 @@ import { join } from 'path'
 import { is } from '@electron-toolkit/utils'
 import icon from '../../resources/icon.png?asset'
 import { isAllowedExternalNavigation, isAllowedFrameNavigation } from './navigation-policy'
+import { createFindOverlayManager, type FindOverlayDeps } from './find-overlay'
+import { registerFindOverlayOwner } from './find-overlay-registry'
 import {
   CLOSE_ACTIVE_PANE_CHANNEL,
   CLOSE_ACTIVE_PANE_READY_CHANNEL,
   CLOSE_ACTIVE_PANE_UNREADY_CHANNEL,
+  WINDOW_FIND_READY_CHANNEL,
+  WINDOW_FIND_UNREADY_CHANNEL,
   isCloseWindowChord,
+  isFindInPageChord,
   type CloseClassification,
   type CloseConfirmChoice
 } from '../shared/window-controls'
 
 const rendererEntry = join(__dirname, '../renderer/index.html')
 const preloadEntry = join(__dirname, '../preload/index.js')
+// The find overlay is a static page (no bundler entry) shipped under resources/, so it resolves the
+// same way in dev (project root) and packaged (asar root) via app.getAppPath().
+const findOverlayEntry = join(app.getAppPath(), 'resources/find-overlay/index.html')
 
 const loadRenderer = (window: BrowserWindow): void => {
   if (is.dev && process.env['ELECTRON_RENDERER_URL']) {
@@ -97,6 +106,7 @@ const createMainWindow = (opts?: MainWindowCloseOptions): BrowserWindow => {
   //     its subscription instead of having to re-handshake.
   // When either fails, main closes the window itself so the chord always does something.
   let rendererListenerReady = false
+  let windowFindListenerReady = false
   let rendererResponsive = true
   const onListenerReady = (event: IpcMainEvent): void => {
     if (event.sender !== window.webContents) return
@@ -110,17 +120,31 @@ const createMainWindow = (opts?: MainWindowCloseOptions): BrowserWindow => {
   const onListenerGone = (event: IpcMainEvent): void => {
     if (event.sender === window.webContents) rendererListenerReady = false
   }
+  const onWindowFindReady = (event: IpcMainEvent): void => {
+    if (event.sender !== window.webContents) return
+    windowFindListenerReady = true
+    rendererResponsive = true
+  }
+  const onWindowFindGone = (event: IpcMainEvent): void => {
+    if (event.sender === window.webContents) windowFindListenerReady = false
+  }
   ipcMain.on(CLOSE_ACTIVE_PANE_READY_CHANNEL, onListenerReady)
   ipcMain.on(CLOSE_ACTIVE_PANE_UNREADY_CHANNEL, onListenerGone)
+  ipcMain.on(WINDOW_FIND_READY_CHANNEL, onWindowFindReady)
+  ipcMain.on(WINDOW_FIND_UNREADY_CHANNEL, onWindowFindGone)
   // A top-level document swap replaces the mounted hook, which must re-subscribe; a dead render process
   // took its listener with it. Both revoke readiness until the next READY handshake. Gate on the main
   // frame and a real document change so a dynamic preview iframe loading (or a same-document hash /
   // pushState navigation) — neither of which remounts the hook — does not falsely disarm the forward.
   window.webContents.on('did-start-navigation', (details) => {
-    if (details.isMainFrame && !details.isSameDocument) rendererListenerReady = false
+    if (details.isMainFrame && !details.isSameDocument) {
+      rendererListenerReady = false
+      windowFindListenerReady = false
+    }
   })
   window.webContents.on('render-process-gone', () => {
     rendererListenerReady = false
+    windowFindListenerReady = false
   })
   window.webContents.on('unresponsive', () => {
     rendererResponsive = false
@@ -131,6 +155,22 @@ const createMainWindow = (opts?: MainWindowCloseOptions): BrowserWindow => {
   window.on('closed', () => {
     ipcMain.removeListener(CLOSE_ACTIVE_PANE_READY_CHANNEL, onListenerReady)
     ipcMain.removeListener(CLOSE_ACTIVE_PANE_UNREADY_CHANNEL, onListenerGone)
+    ipcMain.removeListener(WINDOW_FIND_READY_CHANNEL, onWindowFindReady)
+    ipcMain.removeListener(WINDOW_FIND_UNREADY_CHANNEL, onWindowFindGone)
+    findOverlay.destroy()
+  })
+
+  // The whole-window find bar lives in its own WebContentsView overlay, so its own query text is never
+  // part of the main window's page search. The overlay talks to main via the window-find IPC channels;
+  // main opens/closes it here in response to the chord and Escape.
+  const findOverlay = createFindOverlayManager({
+    // The structural dep narrows BrowserWindow to just the find-overlay surface; Electron's
+    // contentView.addChildView is typed against the base View (no webContents), so bridge the gap here.
+    mainWindow: window as unknown as FindOverlayDeps['mainWindow'],
+    createView: (opts) => new WebContentsView(opts),
+    preloadPath: preloadEntry,
+    overlayHtmlPath: findOverlayEntry,
+    registerOwner: registerFindOverlayOwner
   })
 
   // Intercept Cmd+W / Ctrl+W before the default menu "Close" role fires. preventDefault here also
@@ -144,6 +184,22 @@ const createMainWindow = (opts?: MainWindowCloseOptions): BrowserWindow => {
   // the pane and its ack lands after the timeout, main would then also close the window. We accept one
   // lost keystroke during a renderer crash over that regression.
   window.webContents.on('before-input-event', (event, input) => {
+    if (isFindInPageChord(input, process.platform)) {
+      if (windowFindListenerReady && rendererResponsive) {
+        event.preventDefault()
+        findOverlay.open()
+      }
+      return
+    }
+
+    // Escape closes an open find bar even when focus has wandered into the main content — the overlay's
+    // own handler covers the input-focused case, this covers the rest.
+    if (input.type === 'keyDown' && input.key === 'Escape' && findOverlay.isOpen()) {
+      event.preventDefault()
+      findOverlay.close()
+      return
+    }
+
     if (!isCloseWindowChord(input, process.platform)) return
 
     event.preventDefault()

--- a/src/preload/index.d.ts
+++ b/src/preload/index.d.ts
@@ -200,7 +200,12 @@ import type {
   ReviewRunResult,
   ReviewUpdateEvent
 } from '../shared/reviewer'
-import type { CloseConfirmRequest, CloseConfirmResponse } from '../shared/window-controls'
+import type {
+  CloseConfirmRequest,
+  CloseConfirmResponse,
+  WindowFindRequest,
+  WindowFindResult
+} from '../shared/window-controls'
 
 type RemoveListener = () => void
 type AcpListener<Payload> = (payload: Payload) => void
@@ -583,6 +588,14 @@ interface OpenScienceAPI {
     close(): Promise<void>
     // Fires when Cmd+W / Ctrl+W is pressed; the renderer decides pane-vs-window.
     onCloseActivePane(listener: () => void): RemoveListener
+    findInPage?(request: WindowFindRequest): void
+    clearFind?(): void
+    // Announces the Workspace is mounted (READY) and returns a teardown that announces UNREADY.
+    announceWindowFindReady?(): RemoveListener
+    onFindInPageResult?(listener: AcpListener<WindowFindResult>): RemoveListener
+    // Overlay-only: main signals the bar was shown; the overlay asks main to hide it.
+    onShowWindowFind?(listener: () => void): RemoveListener
+    closeFind?(): void
     // Fires when main asks to confirm a close/quit; the renderer renders the modal and replies.
     onCloseConfirmRequest?(listener: (payload: CloseConfirmRequest) => void): RemoveListener
     // Renderer -> main: modal-mounted ack, then the user's choice, keyed by requestId.

--- a/src/preload/index.test.ts
+++ b/src/preload/index.test.ts
@@ -10,11 +10,12 @@
 
 import { afterEach, beforeAll, describe, expect, it, vi } from 'vitest'
 
-const { invokeMock, sendMock, exposeMock, getPathForFileMock } = vi.hoisted(() => ({
+const { invokeMock, sendMock, exposeMock, getPathForFileMock, onMock } = vi.hoisted(() => ({
   invokeMock: vi.fn(),
   sendMock: vi.fn(),
   exposeMock: vi.fn(),
-  getPathForFileMock: vi.fn()
+  getPathForFileMock: vi.fn(),
+  onMock: vi.fn()
 }))
 
 vi.mock('electron', () => ({
@@ -22,7 +23,7 @@ vi.mock('electron', () => ({
   webUtils: { getPathForFile: getPathForFileMock },
   ipcRenderer: {
     invoke: invokeMock,
-    on: vi.fn(),
+    on: onMock,
     off: vi.fn(),
     send: sendMock,
     removeListener: vi.fn()
@@ -87,6 +88,13 @@ type PreloadApi = {
     stageLocalFile: (file: File, request: unknown) => Promise<unknown>
     claimLocalFile: (request: unknown) => Promise<void>
   }
+  window: {
+    findInPage?: (request: unknown) => void
+    clearFind?: () => void
+    closeFind?: () => void
+    onShowWindowFind?: (listener: () => void) => unknown
+    announceWindowFindReady?: () => unknown
+  }
 }
 
 let api: PreloadApi
@@ -108,6 +116,32 @@ afterEach(() => {
   invokeMock.mockClear()
   sendMock.mockClear()
   getPathForFileMock.mockReset()
+})
+
+describe('preload bridge — window find IPC channels', () => {
+  it('forwards find and clear requests without exposing a raw Electron object', () => {
+    const request = { requestId: 1, text: 'protein', findNext: true, forward: true }
+
+    api.window.findInPage?.(request)
+    api.window.clearFind?.()
+
+    expect(sendMock).toHaveBeenNthCalledWith(1, 'window:find-in-page', request)
+    expect(sendMock).toHaveBeenNthCalledWith(2, 'window:clear-find-in-page')
+  })
+
+  it('forwards the overlay close request and subscribes to the show event from main', () => {
+    api.window.closeFind?.()
+    api.window.onShowWindowFind?.(() => undefined)
+
+    expect(sendMock).toHaveBeenCalledWith('window:find-close')
+    expect(onMock).toHaveBeenCalledWith('window:find-show', expect.any(Function))
+  })
+
+  it('announces Workspace find readiness to main on mount', () => {
+    api.window.announceWindowFindReady?.()
+
+    expect(sendMock).toHaveBeenCalledWith('shortcut:window-find-ready')
+  })
 })
 
 // Each case: invoke a bridge method with sample args, then assert the exact channel + forwarded args.

--- a/src/preload/index.ts
+++ b/src/preload/index.ts
@@ -211,12 +211,20 @@ import type {
 } from '../shared/reviewer'
 import { REVIEWER_IPC } from '../shared/reviewer'
 import {
+  announceWindowFindReady,
   subscribeCloseActivePane,
   WINDOW_CLOSE_CHANNEL,
   WINDOW_CLOSE_CONFIRM_REQUEST_CHANNEL,
   WINDOW_CLOSE_CONFIRM_RESPONSE_CHANNEL,
+  WINDOW_FIND_CLEAR_CHANNEL,
+  WINDOW_FIND_CLOSE_CHANNEL,
+  WINDOW_FIND_REQUEST_CHANNEL,
+  WINDOW_FIND_RESULT_CHANNEL,
+  WINDOW_FIND_SHOW_CHANNEL,
   type CloseConfirmRequest,
-  type CloseConfirmResponse
+  type CloseConfirmResponse,
+  type WindowFindRequest,
+  type WindowFindResult
 } from '../shared/window-controls'
 
 type RemoveListener = () => void
@@ -630,6 +638,15 @@ type OpenScienceAPI = {
     close: () => Promise<void>
     // Fires when Cmd+W / Ctrl+W is pressed; the renderer decides pane-vs-window.
     onCloseActivePane: (listener: () => void) => RemoveListener
+    // Electron-only whole-window find. These are absent in the localhost Web UI, where the browser
+    // owns Cmd/Ctrl+F instead. The find bar itself is an Electron overlay; the Workspace only announces
+    // readiness, and the overlay subscribes to show events / requests searches via these.
+    findInPage?: (request: WindowFindRequest) => void
+    clearFind?: () => void
+    announceWindowFindReady?: () => RemoveListener
+    onFindInPageResult?: (listener: AcpListener<WindowFindResult>) => RemoveListener
+    onShowWindowFind?: (listener: () => void) => RemoveListener
+    closeFind?: () => void
     // Fires when main asks to confirm a close/quit; the renderer renders the modal and replies.
     onCloseConfirmRequest?: (listener: (payload: CloseConfirmRequest) => void) => RemoveListener
     // Renderer -> main: modal-mounted ack, then the user's choice, keyed by requestId.
@@ -1208,6 +1225,17 @@ const api: OpenScienceAPI = {
         },
         listener
       ),
+    findInPage: (request) => ipcRenderer.send(WINDOW_FIND_REQUEST_CHANNEL, request),
+    clearFind: () => ipcRenderer.send(WINDOW_FIND_CLEAR_CHANNEL),
+    // The Workspace announces it is mounted and searchable so main knows whether to intercept
+    // Cmd/Ctrl+F. Returns a teardown that announces UNREADY on unmount.
+    announceWindowFindReady: () =>
+      announceWindowFindReady({ send: (channel) => ipcRenderer.send(channel) }),
+    onFindInPageResult: (listener) => onIpcMessage(WINDOW_FIND_RESULT_CHANNEL, listener),
+    // Overlay-only surface: main signals the bar was shown (focus + restore remembered query), and the
+    // overlay asks main to hide it. The localhost Web UI never loads this overlay, so both stay optional.
+    onShowWindowFind: (listener) => onIpcMessage(WINDOW_FIND_SHOW_CHANNEL, listener),
+    closeFind: () => ipcRenderer.send(WINDOW_FIND_CLOSE_CHANNEL),
     onCloseConfirmRequest: (listener) =>
       onIpcMessage(WINDOW_CLOSE_CONFIRM_REQUEST_CHANNEL, listener),
     sendCloseConfirmResponse: (payload) =>

--- a/src/renderer/src/pages/workspace/WorkspaceMessageScroller.interaction.test.tsx
+++ b/src/renderer/src/pages/workspace/WorkspaceMessageScroller.interaction.test.tsx
@@ -6,6 +6,25 @@ import type { ChatMessage, ChatSession } from '@/stores/session-store'
 import type { UploadedAttachment } from '../../../../shared/uploads'
 import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest'
 
+// pdfjs-dist references DOMMatrix at module load, which jsdom does not provide. This suite exercises
+// click/scroll behavior, not PDF rendering, so stub the library to keep the import graph loadable.
+vi.mock('pdfjs-dist', () => {
+  class PDFDataRangeTransport {
+    requestAllRanges(): void {
+      /* no-op */
+    }
+  }
+  return {
+    getDocument: () => ({
+      promise: Promise.resolve({ numPages: 0, destroy: () => undefined }),
+      destroy: () => undefined
+    }),
+    GlobalWorkerOptions: { workerSrc: '' },
+    PDFDataRangeTransport,
+    version: 'test'
+  }
+})
+
 vi.mock('@/components/streamdown/AgentMarkdown', () => ({
   AgentMarkdown: ({ content }: { content: string }) => <div>{content}</div>
 }))
@@ -37,6 +56,7 @@ vi.mock('@/lib/utils', () => ({
 }))
 
 const upsertAndActivateItem = vi.fn()
+const announceWindowFindReady = vi.fn(() => () => undefined)
 
 vi.mock('@/stores/preview-workbench-store', () => ({
   usePreviewWorkbenchStore: {
@@ -84,6 +104,7 @@ describe('WorkspaceMessageScroller artifact click behavior', () => {
 
   beforeEach(() => {
     upsertAndActivateItem.mockClear()
+    announceWindowFindReady.mockClear()
     container = document.createElement('div')
     document.body.appendChild(container)
     window.api = {
@@ -106,6 +127,9 @@ describe('WorkspaceMessageScroller artifact click behavior', () => {
           .mockResolvedValue({ content: '', encoding: 'utf8', size: 0, truncated: false }),
         openFile: vi.fn().mockResolvedValue(undefined),
         finalizeRunArtifacts: vi.fn()
+      },
+      window: {
+        announceWindowFindReady
       }
     } as unknown as Window['api']
   })
@@ -178,6 +202,24 @@ describe('WorkspaceMessageScroller artifact click behavior', () => {
       size: 2048,
       mtimeMs: 1710000000100
     })
+  })
+
+  it('announces whole-window find readiness to main when the Workspace mounts', async () => {
+    const { WorkspaceMessageScroller } = await import('./WorkspaceMessageScroller')
+    root = createRoot(container)
+    await act(async () => {
+      root.render(
+        <WorkspaceMessageScroller
+          activeSession={createSession({ status: 'idle' })}
+          canEditMessage={false}
+          onSendEditedMessage={vi.fn()}
+        />
+      )
+    })
+
+    // The find bar is an Electron overlay owned by main; the Workspace's only job is to announce it is
+    // mounted and searchable so main intercepts Cmd/Ctrl+F.
+    expect(announceWindowFindReady).toHaveBeenCalledTimes(1)
   })
 
   it('does not write to the preview store for non-managed-file artifacts', async () => {

--- a/src/renderer/src/pages/workspace/WorkspaceMessageScroller.tsx
+++ b/src/renderer/src/pages/workspace/WorkspaceMessageScroller.tsx
@@ -110,6 +110,12 @@ const WorkspaceMessageScroller = ({
   onSendEditedMessage
 }: WorkspaceMessageScrollerProps): React.JSX.Element => {
   const currentSessionId = activeSession?.id
+  // The whole-window find bar is an Electron overlay owned by main; the Workspace only needs to tell
+  // main it is mounted and searchable so Cmd/Ctrl+F is intercepted (and re-arm UNREADY on unmount).
+  useEffect(() => {
+    const stop = window.api?.window?.announceWindowFindReady?.()
+    return () => stop?.()
+  }, [])
   const getReviewForTurn = useReviewStore((state) => state.getReviewForTurn)
   const loadReviewsForSession = useReviewStore((state) => state.loadReviewsForSession)
 

--- a/src/shared/window-controls.test.ts
+++ b/src/shared/window-controls.test.ts
@@ -4,6 +4,9 @@ import {
   CLOSE_ACTIVE_PANE_CHANNEL,
   CLOSE_ACTIVE_PANE_READY_CHANNEL,
   CLOSE_ACTIVE_PANE_UNREADY_CHANNEL,
+  WINDOW_FIND_READY_CHANNEL,
+  WINDOW_FIND_UNREADY_CHANNEL,
+  announceWindowFindReady,
   isCloseWindowChord,
   subscribeCloseActivePane,
   type KeyChordInput
@@ -102,5 +105,29 @@ describe('subscribeCloseActivePane', () => {
     expect(send).toHaveBeenCalledWith(CLOSE_ACTIVE_PANE_UNREADY_CHANNEL)
     // Teardown must not re-announce readiness, which would leave main forwarding into a gone listener.
     expect(send).not.toHaveBeenCalledWith(CLOSE_ACTIVE_PANE_READY_CHANNEL)
+  })
+})
+
+describe('announceWindowFindReady', () => {
+  // In the overlay-window architecture main opens the find bar directly (no OPEN message), so the
+  // Workspace only needs to announce that it is mounted and can be searched — READY on mount, UNREADY on
+  // teardown — so main knows whether Cmd/Ctrl+F should be intercepted at all. The helper's signature
+  // (Pick<'send'>) guarantees it cannot subscribe to anything.
+  it('announces readiness immediately', () => {
+    const send = vi.fn()
+
+    announceWindowFindReady({ send })
+
+    expect(send).toHaveBeenCalledWith(WINDOW_FIND_READY_CHANNEL)
+  })
+
+  it('announces teardown when the returned unsubscribe runs', () => {
+    const send = vi.fn()
+
+    const unsubscribe = announceWindowFindReady({ send })
+    send.mockClear()
+    unsubscribe()
+
+    expect(send).toHaveBeenCalledWith(WINDOW_FIND_UNREADY_CHANNEL)
   })
 })

--- a/src/shared/window-controls.ts
+++ b/src/shared/window-controls.ts
@@ -21,6 +21,36 @@ export const CLOSE_ACTIVE_PANE_READY_CHANNEL = 'shortcut:close-active-pane-ready
 // direct-close fallback so a stale "ready" flag never makes it swallow the chord into a gone listener.
 export const CLOSE_ACTIVE_PANE_UNREADY_CHANNEL = 'shortcut:close-active-pane-unready'
 
+// Renderer -> main: the Workspace find listener is mounted or unmounted. Main preserves the browser's
+// normal Cmd/Ctrl+F behavior outside Workspace rather than swallowing the chord into a missing UI.
+export const WINDOW_FIND_READY_CHANNEL = 'shortcut:window-find-ready'
+export const WINDOW_FIND_UNREADY_CHANNEL = 'shortcut:window-find-unready'
+
+// Renderer -> main requests and main -> renderer result events for Electron's native whole-window find.
+export const WINDOW_FIND_REQUEST_CHANNEL = 'window:find-in-page'
+export const WINDOW_FIND_CLEAR_CHANNEL = 'window:clear-find-in-page'
+export const WINDOW_FIND_RESULT_CHANNEL = 'window:find-in-page-result'
+
+// Main -> overlay: the find bar was just shown — focus the field and re-run the remembered query.
+export const WINDOW_FIND_SHOW_CHANNEL = 'window:find-show'
+
+// Overlay -> main: the user closed the find bar — hide the overlay and release the main-window focus.
+export const WINDOW_FIND_CLOSE_CHANNEL = 'window:find-close'
+
+export type WindowFindRequest = {
+  requestId: number
+  text: string
+  findNext: boolean
+  forward: boolean
+}
+
+export type WindowFindResult = {
+  requestId: number
+  activeMatchOrdinal: number
+  matches: number
+  finalUpdate: boolean
+}
+
 // The minimal IPC surface the renderer handshake needs, kept structural so the wiring can be unit-tested
 // without loading preload or importing electron.
 export type CloseActivePaneBridge = {
@@ -42,6 +72,17 @@ export const subscribeCloseActivePane = (
     removeListener()
     bridge.send(CLOSE_ACTIVE_PANE_UNREADY_CHANNEL)
   }
+}
+
+// In the overlay-window architecture main opens the find bar itself (no OPEN message reaches the
+// renderer), so the Workspace only needs to tell main that it is mounted and searchable. This announces
+// READY on mount and UNREADY on teardown, so main can keep intercepting Cmd/Ctrl+F only while a
+// searchable Workspace is actually present.
+export const announceWindowFindReady = (
+  bridge: Pick<CloseActivePaneBridge, 'send'>
+): (() => void) => {
+  bridge.send(WINDOW_FIND_READY_CHANNEL)
+  return () => bridge.send(WINDOW_FIND_UNREADY_CHANNEL)
 }
 
 // The subset of Electron's before-input-event Input that the chord test needs. Kept structural so the
@@ -66,6 +107,17 @@ export const isCloseWindowChord = (input: KeyChordInput, platform: string): bool
   if (input.type !== 'keyDown') return false
   if (input.isAutoRepeat) return false
   if (input.key.toLowerCase() !== 'w') return false
+  if (input.alt || input.shift) return false
+
+  return platform === 'darwin' ? input.meta && !input.control : input.control && !input.meta
+}
+
+// Matches the platform find chord. Shift is deliberately rejected: Cmd/Ctrl+Shift+F remains available
+// to any future feature that needs that distinct accelerator.
+export const isFindInPageChord = (input: KeyChordInput, platform: string): boolean => {
+  if (input.type !== 'keyDown') return false
+  if (input.isAutoRepeat) return false
+  if (input.key.toLowerCase() !== 'f') return false
   if (input.alt || input.shift) return false
 
   return platform === 'darwin' ? input.meta && !input.control : input.control && !input.meta


### PR DESCRIPTION
Resolves #337.

## Problem

The Workspace had no whole-window find. Users searching long agent transcripts or notebook output had no way to locate text across the rendered page.

## Proposed change

Add a whole-window find bar implemented as a dedicated `WebContentsView` overlay owned by the main window. Because the bar lives in its own webContents, its own query text is never part of the page being searched.

- `Cmd/Ctrl+F` opens the bar (intercepted in main's `before-input-event`, only while a searchable Workspace is mounted and the renderer is responsive — otherwise the browser default is preserved).
- Search-as-you-type with a live `current / total` match counter.
- `Enter` = next match; `Shift+Enter` = previous match.
- `Esc` closes the bar (works whether focus is in the bar or has drifted into the page); `X` button also closes.
- Reopening with `Cmd/Ctrl+F` refills and resumes the last query.

## Scope and non-goals

**Scope:** Electron app only — main-process overlay manager + IPC (`src/main/find-overlay*`, `src/main/window-find-ipc*`), preload bridge, shared window-control channels (`src/shared/window-controls`), Workspace readiness announcement, and the overlay page (`resources/find-overlay/`).

**Non-goals:** The localhost Web UI is untouched — the browser owns `Cmd/Ctrl+F` there, and the find preload surface stays optional/absent. Case-sensitive search and regex are intentionally not added (`matchCase` fixed to `false`).

## Acceptance criteria and validation

- `npm run typecheck` — clean (node + web).
- `npm run lint` — 0 errors (remaining warnings are pre-existing prettier formatting in unrelated files).
- `npm run test` — 7033 passed, 113 skipped, 0 failed. New unit coverage for overlay geometry (`find-overlay`), the overlay→main find IPC (`window-find-ipc`), window chord wiring (`windows`), shared helpers (`window-controls`), the overlay page logic (`findOverlay.test.js`), and Workspace readiness announcement.
- Manually verified in the running app: incremental search, next/prev navigation, Escape close (input-focused and focus-drifted), and reopen refilling the last query.

## Review focus

- IPC routing: the overlay→main-window owner registry (`find-overlay-registry`) and per-webContents active-request tracking (`window-find-ipc`) that prevent a stale async result from overwriting the live counter.
- `before-input-event` gating: the chord is intercepted only when the Workspace announced READY and the renderer is responsive, so a crashed renderer or a non-Workspace page never swallows `Cmd/Ctrl+F`.
- Overlay lifecycle: open/close toggles bounds (real vs zero) rather than attach/detach, keeping the overlay's webContents — and its remembered query — alive across open/close cycles.