### PR TITLE
fix(workspace): harden whole-window find overlay

### DIFF
--- a/resources/find-overlay/findOverlay.js
+++ b/resources/find-overlay/findOverlay.js
@@ -1,9 +1,13 @@
 export const LAST_QUERY_STORAGE_KEY = 'open-science:window-find:last-query'
+const DARK_QUERY = '(prefers-color-scheme: dark)'
 
 export function createFindOverlay(deps) {
   const { input, count, prev, next, close, api, storage } = deps
+  const ownerDocument = input.ownerDocument
+  const systemTheme = ownerDocument.defaultView?.matchMedia?.(DARK_QUERY)
 
   let currentRequestId = 0
+  let followsSystem = false
   count.textContent = '0 / 0'
 
   const nextRequestId = () => {
@@ -16,7 +20,28 @@ export function createFindOverlay(deps) {
     api.findInPage({ requestId, text, findNext, forward })
   }
 
-  const handleShow = () => {
+  const applyTheme = (theme) => {
+    ownerDocument.documentElement.classList.toggle('dark', theme === 'dark')
+  }
+
+  const onSystemThemeChange = (event) => {
+    if (followsSystem) applyTheme(event.matches ? 'dark' : 'light')
+  }
+  systemTheme?.addEventListener('change', onSystemThemeChange)
+
+  const handleShow = (appearance) => {
+    followsSystem = appearance?.followsSystem === true
+    const theme =
+      followsSystem && systemTheme
+        ? systemTheme.matches
+          ? 'dark'
+          : 'light'
+        : appearance?.theme === 'dark' || appearance?.theme === 'light'
+          ? appearance.theme
+          : systemTheme?.matches
+            ? 'dark'
+            : 'light'
+    applyTheme(theme)
     input.focus()
     const remembered = storage.getItem(LAST_QUERY_STORAGE_KEY) ?? ''
     if (remembered) {
@@ -65,7 +90,7 @@ export function createFindOverlay(deps) {
   }
 
   const onKeydown = (event) => {
-    if (event.key === 'Enter') {
+    if (event.key === 'Enter' && event.target === input) {
       event.preventDefault()
       if (event.shiftKey) {
         goBackward()
@@ -79,7 +104,7 @@ export function createFindOverlay(deps) {
   }
 
   input.addEventListener('input', onInput)
-  input.addEventListener('keydown', onKeydown)
+  ownerDocument.addEventListener('keydown', onKeydown)
   prev.addEventListener('click', goBackward)
   next.addEventListener('click', goForward)
   close.addEventListener('click', handleClose)
@@ -92,10 +117,11 @@ export function createFindOverlay(deps) {
       offResult()
       offShow()
       input.removeEventListener('input', onInput)
-      input.removeEventListener('keydown', onKeydown)
+      ownerDocument.removeEventListener('keydown', onKeydown)
       prev.removeEventListener('click', goBackward)
       next.removeEventListener('click', goForward)
       close.removeEventListener('click', handleClose)
+      systemTheme?.removeEventListener('change', onSystemThemeChange)
     }
   }
 }

--- a/resources/find-overlay/findOverlay.js
+++ b/resources/find-overlay/findOverlay.js
@@ -29,7 +29,7 @@ export function createFindOverlay(deps) {
   }
   systemTheme?.addEventListener('change', onSystemThemeChange)
 
-  const handleShow = (appearance) => {
+  const handleAppearance = (appearance) => {
     followsSystem = appearance?.followsSystem === true
     const theme =
       followsSystem && systemTheme
@@ -42,6 +42,10 @@ export function createFindOverlay(deps) {
             ? 'dark'
             : 'light'
     applyTheme(theme)
+  }
+
+  const handleShow = (appearance) => {
+    handleAppearance(appearance)
     input.focus()
     const remembered = storage.getItem(LAST_QUERY_STORAGE_KEY) ?? ''
     if (remembered) {
@@ -111,11 +115,13 @@ export function createFindOverlay(deps) {
 
   const offResult = api.onFindInPageResult(onResult)
   const offShow = api.onShowWindowFind(handleShow)
+  const offAppearance = api.onWindowFindAppearance(handleAppearance)
 
   return {
     destroy() {
       offResult()
       offShow()
+      offAppearance()
       input.removeEventListener('input', onInput)
       ownerDocument.removeEventListener('keydown', onKeydown)
       prev.removeEventListener('click', goBackward)

--- a/resources/find-overlay/findOverlay.test.js
+++ b/resources/find-overlay/findOverlay.test.js
@@ -17,6 +17,7 @@ function setup() {
 
   const resultListeners = new Set()
   const showListeners = new Set()
+  const appearanceListeners = new Set()
   const api = {
     findInPage: vi.fn(),
     clearFind: vi.fn(),
@@ -28,6 +29,10 @@ function setup() {
     onShowWindowFind: vi.fn((listener) => {
       showListeners.add(listener)
       return () => showListeners.delete(listener)
+    }),
+    onWindowFindAppearance: vi.fn((listener) => {
+      appearanceListeners.add(listener)
+      return () => appearanceListeners.delete(listener)
     })
   }
 
@@ -57,6 +62,7 @@ function setup() {
   const emitResult = (r) => resultListeners.forEach((l) => l(r))
   const emitShow = (appearance = { theme: 'light', followsSystem: false }) =>
     showListeners.forEach((l) => l(appearance))
+  const emitAppearance = (appearance) => appearanceListeners.forEach((l) => l(appearance))
   const emitSystemTheme = (matches) => {
     systemDark = matches
     systemThemeListeners.forEach((listener) => listener({ matches }))
@@ -73,6 +79,7 @@ function setup() {
     close,
     emitResult,
     emitShow,
+    emitAppearance,
     emitSystemTheme,
     mediaQuery
   }
@@ -86,15 +93,17 @@ describe('createFindOverlay', () => {
     ctx = setup()
   })
 
-  it('subscribes to api events and returns a destroy() that unsubscribes both', () => {
+  it('subscribes to api events and returns a destroy() that unsubscribes all', () => {
     const overlay = createFindOverlay(ctx.deps)
     expect(ctx.api.onShowWindowFind).toHaveBeenCalledTimes(1)
     expect(ctx.api.onFindInPageResult).toHaveBeenCalledTimes(1)
+    expect(ctx.api.onWindowFindAppearance).toHaveBeenCalledTimes(1)
 
     overlay.destroy()
 
     // After destroy, emitted events must not reach handlers (no throw, no find calls).
     expect(() => ctx.emitShow()).not.toThrow()
+    expect(() => ctx.emitAppearance({ theme: 'dark', followsSystem: false })).not.toThrow()
     expect(() =>
       ctx.emitResult({ requestId: 1, activeMatchOrdinal: 1, matches: 1, finalUpdate: true })
     ).not.toThrow()
@@ -185,6 +194,21 @@ describe('createFindOverlay', () => {
     ctx.emitShow({ theme: 'dark', followsSystem: true })
 
     expect(document.documentElement.classList.contains('dark')).toBe(false)
+  })
+
+  it('applies an asynchronous appearance update without refocusing or rerunning the query', () => {
+    const focusSpy = vi.spyOn(ctx.input, 'focus')
+    ctx.store.set(LAST_QUERY_STORAGE_KEY, 'protein')
+    createFindOverlay(ctx.deps)
+    ctx.emitShow({ theme: 'light', followsSystem: false })
+    focusSpy.mockClear()
+    ctx.api.findInPage.mockClear()
+
+    ctx.emitAppearance({ theme: 'dark', followsSystem: false })
+
+    expect(document.documentElement.classList.contains('dark')).toBe(true)
+    expect(focusSpy).not.toHaveBeenCalled()
+    expect(ctx.api.findInPage).not.toHaveBeenCalled()
   })
 
   it('typing a non-empty value searches with an incremented requestId and persists', () => {
@@ -404,10 +428,12 @@ describe('createFindOverlay', () => {
     ctx.next.dispatchEvent(new Event('click', { bubbles: true }))
     ctx.prev.dispatchEvent(new Event('click', { bubbles: true }))
     ctx.close.dispatchEvent(new Event('click', { bubbles: true }))
+    ctx.emitAppearance({ theme: 'dark', followsSystem: false })
 
     expect(ctx.api.findInPage).not.toHaveBeenCalled()
     expect(ctx.api.closeFind).not.toHaveBeenCalled()
     expect(ctx.storage.setItem).not.toHaveBeenCalled()
+    expect(document.documentElement.classList.contains('dark')).toBe(false)
     expect(ctx.mediaQuery.removeEventListener).toHaveBeenCalledWith('change', expect.any(Function))
   })
 })

--- a/resources/find-overlay/findOverlay.test.js
+++ b/resources/find-overlay/findOverlay.test.js
@@ -1,6 +1,10 @@
 // @vitest-environment jsdom
+import { readFileSync } from 'node:fs'
+import { resolve } from 'node:path'
 import { describe, it, expect, vi, beforeEach } from 'vitest'
 import { createFindOverlay, LAST_QUERY_STORAGE_KEY } from './findOverlay.js'
+
+const overlayHtml = readFileSync(resolve('resources/find-overlay/index.html'), 'utf8')
 
 function setup() {
   const input = document.createElement('input')
@@ -35,16 +39,50 @@ function setup() {
     })
   }
 
+  let systemDark = false
+  const systemThemeListeners = new Set()
+  const mediaQuery = {
+    get matches() {
+      return systemDark
+    },
+    addEventListener: vi.fn((_event, listener) => systemThemeListeners.add(listener)),
+    removeEventListener: vi.fn((_event, listener) => systemThemeListeners.delete(listener))
+  }
+  Object.defineProperty(document.defaultView, 'matchMedia', {
+    configurable: true,
+    value: vi.fn(() => mediaQuery)
+  })
+
   const deps = { input, count, prev, next, close, api, storage }
   const emitResult = (r) => resultListeners.forEach((l) => l(r))
-  const emitShow = () => showListeners.forEach((l) => l())
-  return { deps, api, storage, store, input, count, prev, next, close, emitResult, emitShow }
+  const emitShow = (appearance = { theme: 'light', followsSystem: false }) =>
+    showListeners.forEach((l) => l(appearance))
+  const emitSystemTheme = (matches) => {
+    systemDark = matches
+    systemThemeListeners.forEach((listener) => listener({ matches }))
+  }
+  return {
+    deps,
+    api,
+    storage,
+    store,
+    input,
+    count,
+    prev,
+    next,
+    close,
+    emitResult,
+    emitShow,
+    emitSystemTheme,
+    mediaQuery
+  }
 }
 
 describe('createFindOverlay', () => {
   let ctx
   beforeEach(() => {
     document.body.innerHTML = ''
+    document.documentElement.classList.remove('dark')
     ctx = setup()
   })
 
@@ -57,11 +95,42 @@ describe('createFindOverlay', () => {
 
     // After destroy, emitted events must not reach handlers (no throw, no find calls).
     expect(() => ctx.emitShow()).not.toThrow()
-    expect(() => ctx.emitResult({ requestId: 1, activeMatchOrdinal: 1, matches: 1, finalUpdate: true })).not.toThrow()
+    expect(() =>
+      ctx.emitResult({ requestId: 1, activeMatchOrdinal: 1, matches: 1, finalUpdate: true })
+    ).not.toThrow()
   })
 
   it('exports the storage key constant', () => {
     expect(LAST_QUERY_STORAGE_KEY).toBe('open-science:window-find:last-query')
+  })
+
+  it('provides an accessible tooltip for every icon button', () => {
+    const markup = new DOMParser().parseFromString(overlayHtml, 'text/html')
+    const buttons = [...markup.querySelectorAll('button')]
+
+    expect(buttons).toHaveLength(3)
+    for (const button of buttons) {
+      const tooltipId = button.getAttribute('aria-describedby')
+      expect(button.hasAttribute('aria-label')).toBe(true)
+      expect(button.hasAttribute('title')).toBe(false)
+      expect(tooltipId).toBeTruthy()
+      expect(markup.getElementById(tooltipId)?.getAttribute('role')).toBe('tooltip')
+    }
+  })
+
+  it('uses app semantic tokens and visible keyboard focus styles', () => {
+    expect(overlayHtml).not.toMatch(/--(?:bg|text|hover):/)
+    expect(overlayHtml).toContain('--background:')
+    expect(overlayHtml).toContain('--foreground:')
+    expect(overlayHtml).toContain('--muted-foreground:')
+    expect(overlayHtml).toContain('--ring:')
+    expect(overlayHtml).toContain('.dark {')
+    expect(overlayHtml).toContain('input:focus-visible')
+    expect(overlayHtml).toContain('.btn:focus-visible')
+    expect(overlayHtml).toMatch(/\.btn\s*\{[^}]*outline:\s*none/s)
+    expect(overlayHtml).toMatch(/\.btn\s*\{[^}]*border-radius:\s*6px/s)
+    expect(overlayHtml).toMatch(/\.btn\s*\{[^}]*transition:\s*(?:background-color|color)/s)
+    expect(overlayHtml).toContain('@media (prefers-reduced-motion: reduce)')
   })
 
   it('on show: focuses input and restores remembered query, searching with requestId 1', () => {
@@ -91,6 +160,31 @@ describe('createFindOverlay', () => {
     expect(focusSpy).toHaveBeenCalledTimes(1)
     expect(ctx.input.value).toBe('')
     expect(ctx.api.findInPage).not.toHaveBeenCalled()
+  })
+
+  it('applies the renderer-resolved app theme whenever the overlay is shown', () => {
+    createFindOverlay(ctx.deps)
+
+    ctx.emitShow({ theme: 'dark', followsSystem: false })
+
+    expect(document.documentElement.classList.contains('dark')).toBe(true)
+  })
+
+  it('live-follows OS theme changes while the app preference is system', () => {
+    createFindOverlay(ctx.deps)
+    ctx.emitShow({ theme: 'light', followsSystem: true })
+
+    ctx.emitSystemTheme(true)
+
+    expect(document.documentElement.classList.contains('dark')).toBe(true)
+  })
+
+  it('uses the current OS theme instead of a stale renderer snapshot in system mode', () => {
+    createFindOverlay(ctx.deps)
+
+    ctx.emitShow({ theme: 'dark', followsSystem: true })
+
+    expect(document.documentElement.classList.contains('dark')).toBe(false)
   })
 
   it('typing a non-empty value searches with an incremented requestId and persists', () => {
@@ -179,7 +273,12 @@ describe('createFindOverlay', () => {
     ctx.input.value = 'protein'
     ctx.input.dispatchEvent(new Event('input', { bubbles: true })) // requestId 1
 
-    const evt = new KeyboardEvent('keydown', { key: 'Enter', shiftKey: false, bubbles: true, cancelable: true })
+    const evt = new KeyboardEvent('keydown', {
+      key: 'Enter',
+      shiftKey: false,
+      bubbles: true,
+      cancelable: true
+    })
     ctx.input.dispatchEvent(evt)
 
     expect(evt.defaultPrevented).toBe(true)
@@ -211,7 +310,12 @@ describe('createFindOverlay', () => {
     ctx.input.value = 'protein'
     ctx.input.dispatchEvent(new Event('input', { bubbles: true })) // requestId 1
 
-    const evt = new KeyboardEvent('keydown', { key: 'Enter', shiftKey: true, bubbles: true, cancelable: true })
+    const evt = new KeyboardEvent('keydown', {
+      key: 'Enter',
+      shiftKey: true,
+      bubbles: true,
+      cancelable: true
+    })
     ctx.input.dispatchEvent(evt)
 
     expect(evt.defaultPrevented).toBe(true)
@@ -221,6 +325,23 @@ describe('createFindOverlay', () => {
       findNext: false,
       forward: false
     })
+  })
+
+  it('does not hijack Enter from a focused action button', () => {
+    createFindOverlay(ctx.deps)
+    ctx.input.value = 'protein'
+    ctx.input.dispatchEvent(new Event('input', { bubbles: true }))
+    ctx.api.findInPage.mockClear()
+
+    const evt = new KeyboardEvent('keydown', {
+      key: 'Enter',
+      bubbles: true,
+      cancelable: true
+    })
+    ctx.prev.dispatchEvent(evt)
+
+    expect(evt.defaultPrevented).toBe(false)
+    expect(ctx.api.findInPage).not.toHaveBeenCalled()
   })
 
   it('next/prev do nothing when the query is empty', () => {
@@ -251,6 +372,17 @@ describe('createFindOverlay', () => {
     expect(ctx.storage.setItem).not.toHaveBeenCalledWith(LAST_QUERY_STORAGE_KEY, '')
   })
 
+  it('Escape closes the overlay after a navigation button receives focus', () => {
+    createFindOverlay(ctx.deps)
+    ctx.next.focus()
+
+    const evt = new KeyboardEvent('keydown', { key: 'Escape', bubbles: true, cancelable: true })
+    ctx.next.dispatchEvent(evt)
+
+    expect(evt.defaultPrevented).toBe(true)
+    expect(ctx.api.closeFind).toHaveBeenCalledTimes(1)
+  })
+
   it('destroy() detaches all DOM listeners so later events are inert', () => {
     const overlay = createFindOverlay(ctx.deps)
     ctx.input.value = 'protein'
@@ -263,8 +395,12 @@ describe('createFindOverlay', () => {
 
     ctx.input.value = 'variant'
     ctx.input.dispatchEvent(new Event('input', { bubbles: true }))
-    ctx.input.dispatchEvent(new KeyboardEvent('keydown', { key: 'Enter', bubbles: true, cancelable: true }))
-    ctx.input.dispatchEvent(new KeyboardEvent('keydown', { key: 'Escape', bubbles: true, cancelable: true }))
+    ctx.input.dispatchEvent(
+      new KeyboardEvent('keydown', { key: 'Enter', bubbles: true, cancelable: true })
+    )
+    ctx.input.dispatchEvent(
+      new KeyboardEvent('keydown', { key: 'Escape', bubbles: true, cancelable: true })
+    )
     ctx.next.dispatchEvent(new Event('click', { bubbles: true }))
     ctx.prev.dispatchEvent(new Event('click', { bubbles: true }))
     ctx.close.dispatchEvent(new Event('click', { bubbles: true }))
@@ -272,5 +408,6 @@ describe('createFindOverlay', () => {
     expect(ctx.api.findInPage).not.toHaveBeenCalled()
     expect(ctx.api.closeFind).not.toHaveBeenCalled()
     expect(ctx.storage.setItem).not.toHaveBeenCalled()
+    expect(ctx.mediaQuery.removeEventListener).toHaveBeenCalledWith('change', expect.any(Function))
   })
 })

--- a/resources/find-overlay/findOverlay.test.js
+++ b/resources/find-overlay/findOverlay.test.js
@@ -140,6 +140,8 @@ describe('createFindOverlay', () => {
     expect(overlayHtml).toMatch(/\.btn\s*\{[^}]*border-radius:\s*6px/s)
     expect(overlayHtml).toMatch(/\.btn\s*\{[^}]*transition:\s*(?:background-color|color)/s)
     expect(overlayHtml).toContain('@media (prefers-reduced-motion: reduce)')
+    expect(overlayHtml).toContain("matchMedia?.('(prefers-color-scheme: dark)')")
+    expect(overlayHtml.indexOf('matchMedia?.')).toBeLessThan(overlayHtml.indexOf('<style>'))
   })
 
   it('on show: focuses input and restores remembered query, searching with requestId 1', () => {
@@ -177,6 +179,16 @@ describe('createFindOverlay', () => {
     ctx.emitShow({ theme: 'dark', followsSystem: false })
 
     expect(document.documentElement.classList.contains('dark')).toBe(true)
+  })
+
+  it('lets an explicit light appearance override the dark-system startup fallback', () => {
+    createFindOverlay(ctx.deps)
+    ctx.emitSystemTheme(true)
+    document.documentElement.classList.add('dark')
+
+    ctx.emitShow({ theme: 'light', followsSystem: false })
+
+    expect(document.documentElement.classList.contains('dark')).toBe(false)
   })
 
   it('live-follows OS theme changes while the app preference is system', () => {

--- a/resources/find-overlay/index.html
+++ b/resources/find-overlay/index.html
@@ -6,22 +6,26 @@
     <title>Find in window</title>
     <style>
       :root {
-        --bg: #ffffff;
-        --border: #d8d8dc;
-        --text: #1a1a1a;
-        --muted: #6b6b72;
-        --hover: #ececee;
         color-scheme: light;
+        --background: #fafaf8;
+        --foreground: #202321;
+        --popover: #ffffff;
+        --popover-foreground: #202321;
+        --muted: #ececea;
+        --muted-foreground: #646762;
+        --border: #dededa;
+        --ring: oklch(0.58 0.11 184);
       }
-      @media (prefers-color-scheme: dark) {
-        :root {
-          --bg: #1f1f23;
-          --border: #3a3a42;
-          --text: #f2f2f3;
-          --muted: #a0a0a8;
-          --hover: #2e2e35;
-          color-scheme: dark;
-        }
+      .dark {
+        color-scheme: dark;
+        --background: #1a1a18;
+        --foreground: #e8e6df;
+        --popover: #26251f;
+        --popover-foreground: #e8e6df;
+        --muted: #33322b;
+        --muted-foreground: #a8a49a;
+        --border: #3a3931;
+        --ring: oklch(0.66 0.1 184);
       }
       * {
         box-sizing: border-box;
@@ -33,8 +37,8 @@
       }
       body {
         font-family: -apple-system, 'Segoe UI', system-ui, sans-serif;
-        background: var(--bg);
-        color: var(--text);
+        background: var(--background);
+        color: var(--foreground);
         -webkit-user-select: none;
         user-select: none;
         overflow: hidden;
@@ -49,7 +53,7 @@
       .icon {
         width: 16px;
         height: 16px;
-        color: var(--muted);
+        color: var(--muted-foreground);
         flex: none;
       }
       /* Plain text field — visible characters, no password masking. */
@@ -57,17 +61,22 @@
         flex: 1 1 auto;
         min-width: 0;
         height: 28px;
-        border: 0;
+        border: 1px solid transparent;
         background: transparent;
         padding: 0 4px;
         font-size: 13px;
-        color: var(--text);
+        color: var(--foreground);
         outline: none;
         -webkit-user-select: text;
         user-select: text;
       }
       input::placeholder {
-        color: var(--muted);
+        color: var(--muted-foreground);
+      }
+      input:focus-visible,
+      .btn:focus-visible {
+        border-color: color-mix(in srgb, var(--ring) 50%, transparent);
+        box-shadow: 0 0 0 3px color-mix(in srgb, var(--ring) 50%, transparent);
       }
       .count {
         min-width: 48px;
@@ -75,7 +84,7 @@
         text-align: center;
         font-size: 12px;
         font-variant-numeric: tabular-nums;
-        color: var(--muted);
+        color: var(--muted-foreground);
       }
       .divider {
         width: 1px;
@@ -90,25 +99,71 @@
         flex: none;
         align-items: center;
         justify-content: center;
-        border: 0;
-        border-radius: 4px;
+        border: 1px solid transparent;
+        border-radius: 6px;
         background: transparent;
-        color: var(--muted);
+        color: var(--muted-foreground);
         cursor: default;
+        outline: none;
+        transition:
+          background-color 150ms ease,
+          color 150ms ease;
       }
       .btn:hover {
-        background: var(--hover);
-        color: var(--text);
+        background: var(--muted);
+        color: var(--foreground);
       }
       .btn svg {
         width: 16px;
         height: 16px;
       }
+      .tooltip-anchor {
+        position: relative;
+        display: inline-flex;
+        flex: none;
+      }
+      .tooltip-content {
+        position: absolute;
+        z-index: 1;
+        top: 50%;
+        right: calc(100% + 4px);
+        visibility: hidden;
+        padding: 4px 6px;
+        transform: translateY(-50%);
+        border: 1px solid var(--border);
+        border-radius: 4px;
+        background: var(--popover);
+        color: var(--popover-foreground);
+        font-size: 11px;
+        line-height: 16px;
+        opacity: 0;
+        pointer-events: none;
+        white-space: nowrap;
+        transition: opacity 150ms ease;
+      }
+      .tooltip-anchor:hover .tooltip-content,
+      .tooltip-anchor:focus-within .tooltip-content {
+        visibility: visible;
+        opacity: 1;
+      }
+      @media (prefers-reduced-motion: reduce) {
+        .btn,
+        .tooltip-content {
+          transition: none;
+        }
+      }
     </style>
   </head>
   <body>
     <div class="bar" role="search" aria-label="Find in window">
-      <svg class="icon" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" aria-hidden="true">
+      <svg
+        class="icon"
+        viewBox="0 0 24 24"
+        fill="none"
+        stroke="currentColor"
+        stroke-width="2"
+        aria-hidden="true"
+      >
         <circle cx="11" cy="11" r="7"></circle>
         <line x1="21" y1="21" x2="16.65" y2="16.65"></line>
       </svg>
@@ -124,40 +179,73 @@
       />
       <span class="count" id="find-overlay-count">0 / 0</span>
       <span class="divider" aria-hidden="true"></span>
-      <button
-        type="button"
-        class="btn"
-        id="find-overlay-prev"
-        aria-label="Previous match"
-        title="Previous match (Shift+Enter)"
-      >
-        <svg viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" aria-hidden="true">
-          <polyline points="18 15 12 9 6 15"></polyline>
-        </svg>
-      </button>
-      <button
-        type="button"
-        class="btn"
-        id="find-overlay-next"
-        aria-label="Next match"
-        title="Next match (Enter)"
-      >
-        <svg viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" aria-hidden="true">
-          <polyline points="6 9 12 15 18 9"></polyline>
-        </svg>
-      </button>
-      <button
-        type="button"
-        class="btn"
-        id="find-overlay-close"
-        aria-label="Close find"
-        title="Close (Esc)"
-      >
-        <svg viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" aria-hidden="true">
-          <line x1="18" y1="6" x2="6" y2="18"></line>
-          <line x1="6" y1="6" x2="18" y2="18"></line>
-        </svg>
-      </button>
+      <span class="tooltip-anchor">
+        <button
+          type="button"
+          class="btn"
+          id="find-overlay-prev"
+          aria-label="Previous match"
+          aria-describedby="find-overlay-prev-tooltip"
+        >
+          <svg
+            viewBox="0 0 24 24"
+            fill="none"
+            stroke="currentColor"
+            stroke-width="2"
+            aria-hidden="true"
+          >
+            <polyline points="18 15 12 9 6 15"></polyline>
+          </svg>
+        </button>
+        <span class="tooltip-content" id="find-overlay-prev-tooltip" role="tooltip">
+          Previous match (Shift+Enter)
+        </span>
+      </span>
+      <span class="tooltip-anchor">
+        <button
+          type="button"
+          class="btn"
+          id="find-overlay-next"
+          aria-label="Next match"
+          aria-describedby="find-overlay-next-tooltip"
+        >
+          <svg
+            viewBox="0 0 24 24"
+            fill="none"
+            stroke="currentColor"
+            stroke-width="2"
+            aria-hidden="true"
+          >
+            <polyline points="6 9 12 15 18 9"></polyline>
+          </svg>
+        </button>
+        <span class="tooltip-content" id="find-overlay-next-tooltip" role="tooltip">
+          Next match (Enter)
+        </span>
+      </span>
+      <span class="tooltip-anchor">
+        <button
+          type="button"
+          class="btn"
+          id="find-overlay-close"
+          aria-label="Close find"
+          aria-describedby="find-overlay-close-tooltip"
+        >
+          <svg
+            viewBox="0 0 24 24"
+            fill="none"
+            stroke="currentColor"
+            stroke-width="2"
+            aria-hidden="true"
+          >
+            <line x1="18" y1="6" x2="6" y2="18"></line>
+            <line x1="6" y1="6" x2="18" y2="18"></line>
+          </svg>
+        </button>
+        <span class="tooltip-content" id="find-overlay-close-tooltip" role="tooltip">
+          Close (Esc)
+        </span>
+      </span>
     </div>
     <script type="module" src="./findOverlay.js"></script>
   </body>

--- a/resources/find-overlay/index.html
+++ b/resources/find-overlay/index.html
@@ -4,6 +4,14 @@
     <meta charset="utf-8" />
     <meta name="viewport" content="width=device-width, initial-scale=1" />
     <title>Find in window</title>
+    <script>
+      // Before the renderer-owned appearance arrives, match the OS for the first paint. The overlay
+      // logic removes this class for an explicit light preference before the view is reused.
+      document.documentElement.classList.toggle(
+        'dark',
+        window.matchMedia?.('(prefers-color-scheme: dark)').matches === true
+      )
+    </script>
     <style>
       :root {
         color-scheme: light;

--- a/src/main/find-overlay.test.ts
+++ b/src/main/find-overlay.test.ts
@@ -36,7 +36,7 @@ type FindOverlayTestFakes = {
     getContentBounds: () => { width: number; height: number }
     on: Mock
     removeListener: Mock
-    webContents: { focus: Mock; stopFindInPage: Mock }
+    webContents: { executeJavaScript: Mock; focus: Mock; stopFindInPage: Mock }
   }
   createView: Mock
   registerOwner: Mock
@@ -45,7 +45,7 @@ type FindOverlayTestFakes = {
 
 const createFakes = (): FindOverlayTestFakes => {
   const view = {
-    webContents: { loadFile: vi.fn(), send: vi.fn(), focus: vi.fn() },
+    webContents: { loadFile: vi.fn(() => Promise.resolve()), send: vi.fn(), focus: vi.fn() },
     setBounds: vi.fn(),
     destroy: vi.fn()
   }
@@ -54,7 +54,11 @@ const createFakes = (): FindOverlayTestFakes => {
     getContentBounds: () => ({ width: 1000, height: 800 }),
     on: vi.fn(),
     removeListener: vi.fn(),
-    webContents: { focus: vi.fn(), stopFindInPage: vi.fn() }
+    webContents: {
+      executeJavaScript: vi.fn(() => Promise.resolve({ theme: 'dark', followsSystem: false })),
+      focus: vi.fn(),
+      stopFindInPage: vi.fn()
+    }
   }
   const createView = vi.fn(() => view)
   const registerOwner = vi.fn()
@@ -69,10 +73,35 @@ const createFakes = (): FindOverlayTestFakes => {
 }
 
 describe('find overlay manager', () => {
-  it('open() creates, loads, attaches, positions, focuses the overlay and signals show', () => {
+  it('waits for the overlay page to load before focusing and signaling the first show', async () => {
+    const { view, manager } = createFakes()
+    let finishLoad: (() => void) | undefined
+    view.webContents.loadFile.mockReturnValueOnce(
+      new Promise<void>((resolve) => {
+        finishLoad = resolve
+      })
+    )
+
+    manager.open()
+
+    expect(view.webContents.focus).not.toHaveBeenCalled()
+    expect(view.webContents.send).not.toHaveBeenCalled()
+
+    finishLoad?.()
+    await vi.waitFor(() => expect(view.webContents.send).toHaveBeenCalledTimes(1))
+
+    expect(view.webContents.focus).toHaveBeenCalledTimes(1)
+    expect(view.webContents.send).toHaveBeenCalledWith(WINDOW_FIND_SHOW_CHANNEL, {
+      theme: 'dark',
+      followsSystem: false
+    })
+  })
+
+  it('open() creates, loads, attaches, positions, focuses the overlay and signals show', async () => {
     const { view, mainWindow, createView, registerOwner, manager } = createFakes()
 
     manager.open()
+    await vi.waitFor(() => expect(view.webContents.send).toHaveBeenCalledTimes(1))
 
     expect(createView).toHaveBeenCalledWith({
       webPreferences: { preload: PRELOAD_PATH, sandbox: true, contextIsolation: true }
@@ -81,7 +110,11 @@ describe('find overlay manager', () => {
     expect(mainWindow.contentView.addChildView).toHaveBeenCalledWith(view)
     expect(view.setBounds).toHaveBeenCalledWith({ x: 572, y: 8, width: 420, height: 40 })
     expect(view.webContents.focus).toHaveBeenCalledTimes(1)
-    expect(view.webContents.send).toHaveBeenCalledWith(WINDOW_FIND_SHOW_CHANNEL)
+    expect(mainWindow.webContents.executeJavaScript).toHaveBeenCalledTimes(1)
+    expect(view.webContents.send).toHaveBeenCalledWith(WINDOW_FIND_SHOW_CHANNEL, {
+      theme: 'dark',
+      followsSystem: false
+    })
     expect(registerOwner).toHaveBeenCalledWith(view.webContents, {
       mainWindow,
       closeOverlay: expect.any(Function)
@@ -105,16 +138,74 @@ describe('find overlay manager', () => {
     expect(manager.isOpen()).toBe(false)
   })
 
-  it('reuses the same view across repeated opens and re-signals show each time', () => {
+  it('reuses the same view across repeated opens and re-signals show each time', async () => {
     const { view, mainWindow, createView, manager } = createFakes()
 
     manager.open()
+    await vi.waitFor(() => expect(view.webContents.send).toHaveBeenCalledTimes(1))
     manager.open()
+    await vi.waitFor(() => expect(view.webContents.send).toHaveBeenCalledTimes(2))
 
     expect(createView).toHaveBeenCalledTimes(1)
     expect(mainWindow.contentView.addChildView).toHaveBeenCalledTimes(1)
     expect(view.webContents.send).toHaveBeenCalledTimes(2)
     expect(view.webContents.focus).toHaveBeenCalledTimes(2)
+  })
+
+  it('discards a pending appearance read when the overlay closes', async () => {
+    const { view, mainWindow, manager } = createFakes()
+    let finishAppearance: ((value: { theme: 'light'; followsSystem: boolean }) => void) | undefined
+    mainWindow.webContents.executeJavaScript.mockReturnValueOnce(
+      new Promise((resolve) => {
+        finishAppearance = resolve
+      })
+    )
+
+    manager.open()
+    await vi.waitFor(() =>
+      expect(mainWindow.webContents.executeJavaScript).toHaveBeenCalledTimes(1)
+    )
+    manager.close()
+    finishAppearance?.({ theme: 'light', followsSystem: true })
+    await Promise.resolve()
+
+    expect(view.webContents.focus).not.toHaveBeenCalled()
+    expect(view.webContents.send).not.toHaveBeenCalled()
+  })
+
+  it.each([
+    ['the appearance read rejects', () => Promise.reject(new Error('renderer unavailable'))],
+    ['the appearance read returns invalid data', () => Promise.resolve({ theme: 'sepia' })]
+  ])('falls back to system appearance when %s', async (_case, createAppearanceResult) => {
+    const { view, mainWindow, manager } = createFakes()
+    mainWindow.webContents.executeJavaScript.mockReturnValueOnce(createAppearanceResult())
+
+    manager.open()
+    await vi.waitFor(() => expect(view.webContents.send).toHaveBeenCalledTimes(1))
+
+    expect(view.webContents.send).toHaveBeenCalledWith(WINDOW_FIND_SHOW_CHANNEL, {
+      theme: 'light',
+      followsSystem: true
+    })
+  })
+
+  it('disposes a view whose page fails to load and creates a fresh view on retry', async () => {
+    const { view, createView, manager } = createFakes()
+    let failLoad: ((reason: Error) => void) | undefined
+    view.webContents.loadFile.mockReturnValueOnce(
+      new Promise<void>((_resolve, reject) => {
+        failLoad = reject
+      })
+    )
+
+    manager.open()
+    failLoad?.(new Error('load failed'))
+    await vi.waitFor(() => expect(manager.isOpen()).toBe(false))
+
+    expect(view.destroy).toHaveBeenCalledTimes(1)
+    manager.open()
+
+    expect(createView).toHaveBeenCalledTimes(2)
   })
 
   it('close() hides the overlay, clears the main selection, and returns focus to the main window', () => {

--- a/src/main/find-overlay.test.ts
+++ b/src/main/find-overlay.test.ts
@@ -5,7 +5,7 @@ import {
   createFindOverlayManager,
   type FindOverlayManager
 } from './find-overlay'
-import { WINDOW_FIND_SHOW_CHANNEL } from '../shared/window-controls'
+import { WINDOW_FIND_APPEARANCE_CHANNEL, WINDOW_FIND_SHOW_CHANNEL } from '../shared/window-controls'
 
 describe('computeOverlayBounds', () => {
   it('anchors the bar to the top-right of the content area with a margin', () => {
@@ -73,9 +73,10 @@ const createFakes = (): FindOverlayTestFakes => {
 }
 
 describe('find overlay manager', () => {
-  it('waits for the overlay page to load before focusing and signaling the first show', async () => {
-    const { view, manager } = createFakes()
+  it('waits for the overlay page to load, then focuses and shows without waiting for appearance', async () => {
+    const { view, mainWindow, manager } = createFakes()
     let finishLoad: (() => void) | undefined
+    mainWindow.webContents.executeJavaScript.mockReturnValueOnce(new Promise(() => {}))
     view.webContents.loadFile.mockReturnValueOnce(
       new Promise<void>((resolve) => {
         finishLoad = resolve
@@ -88,12 +89,12 @@ describe('find overlay manager', () => {
     expect(view.webContents.send).not.toHaveBeenCalled()
 
     finishLoad?.()
-    await vi.waitFor(() => expect(view.webContents.send).toHaveBeenCalledTimes(1))
+    await Promise.resolve()
 
     expect(view.webContents.focus).toHaveBeenCalledTimes(1)
     expect(view.webContents.send).toHaveBeenCalledWith(WINDOW_FIND_SHOW_CHANNEL, {
-      theme: 'dark',
-      followsSystem: false
+      theme: 'light',
+      followsSystem: true
     })
   })
 
@@ -101,7 +102,7 @@ describe('find overlay manager', () => {
     const { view, mainWindow, createView, registerOwner, manager } = createFakes()
 
     manager.open()
-    await vi.waitFor(() => expect(view.webContents.send).toHaveBeenCalledTimes(1))
+    await vi.waitFor(() => expect(view.webContents.send).toHaveBeenCalledTimes(2))
 
     expect(createView).toHaveBeenCalledWith({
       webPreferences: { preload: PRELOAD_PATH, sandbox: true, contextIsolation: true }
@@ -111,7 +112,11 @@ describe('find overlay manager', () => {
     expect(view.setBounds).toHaveBeenCalledWith({ x: 572, y: 8, width: 420, height: 40 })
     expect(view.webContents.focus).toHaveBeenCalledTimes(1)
     expect(mainWindow.webContents.executeJavaScript).toHaveBeenCalledTimes(1)
-    expect(view.webContents.send).toHaveBeenCalledWith(WINDOW_FIND_SHOW_CHANNEL, {
+    expect(view.webContents.send).toHaveBeenNthCalledWith(1, WINDOW_FIND_SHOW_CHANNEL, {
+      theme: 'light',
+      followsSystem: true
+    })
+    expect(view.webContents.send).toHaveBeenNthCalledWith(2, WINDOW_FIND_APPEARANCE_CHANNEL, {
       theme: 'dark',
       followsSystem: false
     })
@@ -138,18 +143,26 @@ describe('find overlay manager', () => {
     expect(manager.isOpen()).toBe(false)
   })
 
-  it('reuses the same view across repeated opens and re-signals show each time', async () => {
+  it('reuses the view and synchronously focuses/shows it while refreshing appearance', async () => {
     const { view, mainWindow, createView, manager } = createFakes()
 
     manager.open()
-    await vi.waitFor(() => expect(view.webContents.send).toHaveBeenCalledTimes(1))
-    manager.open()
     await vi.waitFor(() => expect(view.webContents.send).toHaveBeenCalledTimes(2))
+    manager.close()
+    view.webContents.send.mockClear()
+    view.webContents.focus.mockClear()
+    mainWindow.webContents.executeJavaScript.mockReturnValueOnce(new Promise(() => {}))
+
+    manager.open()
 
     expect(createView).toHaveBeenCalledTimes(1)
     expect(mainWindow.contentView.addChildView).toHaveBeenCalledTimes(1)
-    expect(view.webContents.send).toHaveBeenCalledTimes(2)
-    expect(view.webContents.focus).toHaveBeenCalledTimes(2)
+    expect(view.webContents.focus).toHaveBeenCalledTimes(1)
+    expect(view.webContents.send).toHaveBeenCalledTimes(1)
+    expect(view.webContents.send).toHaveBeenCalledWith(WINDOW_FIND_SHOW_CHANNEL, {
+      theme: 'dark',
+      followsSystem: false
+    })
   })
 
   it('discards a pending appearance read when the overlay closes', async () => {
@@ -169,20 +182,66 @@ describe('find overlay manager', () => {
     finishAppearance?.({ theme: 'light', followsSystem: true })
     await Promise.resolve()
 
-    expect(view.webContents.focus).not.toHaveBeenCalled()
-    expect(view.webContents.send).not.toHaveBeenCalled()
+    expect(view.webContents.focus).toHaveBeenCalledTimes(1)
+    expect(view.webContents.send).toHaveBeenCalledTimes(1)
+    expect(view.webContents.send).not.toHaveBeenCalledWith(
+      WINDOW_FIND_APPEARANCE_CHANNEL,
+      expect.anything()
+    )
+  })
+
+  it('ignores a stale appearance read after close and reopen', async () => {
+    const { view, mainWindow, manager } = createFakes()
+    let finishFirst: ((value: { theme: 'dark'; followsSystem: false }) => void) | undefined
+    let finishSecond: ((value: { theme: 'light'; followsSystem: false }) => void) | undefined
+    mainWindow.webContents.executeJavaScript
+      .mockReturnValueOnce(
+        new Promise((resolve) => {
+          finishFirst = resolve
+        })
+      )
+      .mockReturnValueOnce(
+        new Promise((resolve) => {
+          finishSecond = resolve
+        })
+      )
+
+    manager.open()
+    await vi.waitFor(() =>
+      expect(mainWindow.webContents.executeJavaScript).toHaveBeenCalledTimes(1)
+    )
+    manager.close()
+    manager.open()
+    expect(mainWindow.webContents.executeJavaScript).toHaveBeenCalledTimes(2)
+
+    finishFirst?.({ theme: 'dark', followsSystem: false })
+    await Promise.resolve()
+    expect(view.webContents.send).not.toHaveBeenCalledWith(
+      WINDOW_FIND_APPEARANCE_CHANNEL,
+      expect.anything()
+    )
+
+    finishSecond?.({ theme: 'light', followsSystem: false })
+    await vi.waitFor(() =>
+      expect(view.webContents.send).toHaveBeenCalledWith(WINDOW_FIND_APPEARANCE_CHANNEL, {
+        theme: 'light',
+        followsSystem: false
+      })
+    )
   })
 
   it.each([
     ['the appearance read rejects', () => Promise.reject(new Error('renderer unavailable'))],
     ['the appearance read returns invalid data', () => Promise.resolve({ theme: 'sepia' })]
-  ])('falls back to system appearance when %s', async (_case, createAppearanceResult) => {
+  ])('keeps the system fallback when %s', async (_case, createAppearanceResult) => {
     const { view, mainWindow, manager } = createFakes()
     mainWindow.webContents.executeJavaScript.mockReturnValueOnce(createAppearanceResult())
 
     manager.open()
-    await vi.waitFor(() => expect(view.webContents.send).toHaveBeenCalledTimes(1))
+    await Promise.resolve()
+    await Promise.resolve()
 
+    expect(view.webContents.send).toHaveBeenCalledTimes(1)
     expect(view.webContents.send).toHaveBeenCalledWith(WINDOW_FIND_SHOW_CHANNEL, {
       theme: 'light',
       followsSystem: true

--- a/src/main/find-overlay.test.ts
+++ b/src/main/find-overlay.test.ts
@@ -29,6 +29,7 @@ type FindOverlayTestFakes = {
   view: {
     webContents: { loadFile: Mock; send: Mock; focus: Mock }
     setBounds: Mock
+    setBackgroundColor: Mock
     destroy: Mock
   }
   mainWindow: {
@@ -36,7 +37,7 @@ type FindOverlayTestFakes = {
     getContentBounds: () => { width: number; height: number }
     on: Mock
     removeListener: Mock
-    webContents: { executeJavaScript: Mock; focus: Mock; stopFindInPage: Mock }
+    webContents: { focus: Mock; stopFindInPage: Mock }
   }
   createView: Mock
   registerOwner: Mock
@@ -47,6 +48,7 @@ const createFakes = (): FindOverlayTestFakes => {
   const view = {
     webContents: { loadFile: vi.fn(() => Promise.resolve()), send: vi.fn(), focus: vi.fn() },
     setBounds: vi.fn(),
+    setBackgroundColor: vi.fn(),
     destroy: vi.fn()
   }
   const mainWindow = {
@@ -54,11 +56,7 @@ const createFakes = (): FindOverlayTestFakes => {
     getContentBounds: () => ({ width: 1000, height: 800 }),
     on: vi.fn(),
     removeListener: vi.fn(),
-    webContents: {
-      executeJavaScript: vi.fn(() => Promise.resolve({ theme: 'dark', followsSystem: false })),
-      focus: vi.fn(),
-      stopFindInPage: vi.fn()
-    }
+    webContents: { focus: vi.fn(), stopFindInPage: vi.fn() }
   }
   const createView = vi.fn(() => view)
   const registerOwner = vi.fn()
@@ -74,9 +72,8 @@ const createFakes = (): FindOverlayTestFakes => {
 
 describe('find overlay manager', () => {
   it('waits for the overlay page to load, then focuses and shows without waiting for appearance', async () => {
-    const { view, mainWindow, manager } = createFakes()
+    const { view, manager } = createFakes()
     let finishLoad: (() => void) | undefined
-    mainWindow.webContents.executeJavaScript.mockReturnValueOnce(new Promise(() => {}))
     view.webContents.loadFile.mockReturnValueOnce(
       new Promise<void>((resolve) => {
         finishLoad = resolve
@@ -85,6 +82,8 @@ describe('find overlay manager', () => {
 
     manager.open()
 
+    expect(view.setBounds).toHaveBeenCalledWith({ x: 0, y: 0, width: 0, height: 0 })
+    expect(view.setBounds).not.toHaveBeenCalledWith({ x: 572, y: 8, width: 420, height: 40 })
     expect(view.webContents.focus).not.toHaveBeenCalled()
     expect(view.webContents.send).not.toHaveBeenCalled()
 
@@ -102,23 +101,19 @@ describe('find overlay manager', () => {
     const { view, mainWindow, createView, registerOwner, manager } = createFakes()
 
     manager.open()
-    await vi.waitFor(() => expect(view.webContents.send).toHaveBeenCalledTimes(2))
+    await vi.waitFor(() => expect(view.webContents.send).toHaveBeenCalledTimes(1))
 
     expect(createView).toHaveBeenCalledWith({
       webPreferences: { preload: PRELOAD_PATH, sandbox: true, contextIsolation: true }
     })
     expect(view.webContents.loadFile).toHaveBeenCalledWith(HTML_PATH)
     expect(mainWindow.contentView.addChildView).toHaveBeenCalledWith(view)
+    expect(view.setBackgroundColor).toHaveBeenCalledWith('#fafaf8')
     expect(view.setBounds).toHaveBeenCalledWith({ x: 572, y: 8, width: 420, height: 40 })
     expect(view.webContents.focus).toHaveBeenCalledTimes(1)
-    expect(mainWindow.webContents.executeJavaScript).toHaveBeenCalledTimes(1)
-    expect(view.webContents.send).toHaveBeenNthCalledWith(1, WINDOW_FIND_SHOW_CHANNEL, {
+    expect(view.webContents.send).toHaveBeenCalledWith(WINDOW_FIND_SHOW_CHANNEL, {
       theme: 'light',
       followsSystem: true
-    })
-    expect(view.webContents.send).toHaveBeenNthCalledWith(2, WINDOW_FIND_APPEARANCE_CHANNEL, {
-      theme: 'dark',
-      followsSystem: false
     })
     expect(registerOwner).toHaveBeenCalledWith(view.webContents, {
       mainWindow,
@@ -143,15 +138,15 @@ describe('find overlay manager', () => {
     expect(manager.isOpen()).toBe(false)
   })
 
-  it('reuses the view and synchronously focuses/shows it while refreshing appearance', async () => {
+  it('reuses the view and synchronously focuses/shows it with the cached appearance', async () => {
     const { view, mainWindow, createView, manager } = createFakes()
 
     manager.open()
-    await vi.waitFor(() => expect(view.webContents.send).toHaveBeenCalledTimes(2))
+    await vi.waitFor(() => expect(view.webContents.send).toHaveBeenCalledTimes(1))
     manager.close()
+    manager.updateAppearance({ theme: 'dark', followsSystem: false })
     view.webContents.send.mockClear()
     view.webContents.focus.mockClear()
-    mainWindow.webContents.executeJavaScript.mockReturnValueOnce(new Promise(() => {}))
 
     manager.open()
 
@@ -163,89 +158,35 @@ describe('find overlay manager', () => {
       theme: 'dark',
       followsSystem: false
     })
+    expect(view.setBackgroundColor).toHaveBeenLastCalledWith('#1a1a18')
   })
 
-  it('discards a pending appearance read when the overlay closes', async () => {
-    const { view, mainWindow, manager } = createFakes()
-    let finishAppearance: ((value: { theme: 'light'; followsSystem: boolean }) => void) | undefined
-    mainWindow.webContents.executeJavaScript.mockReturnValueOnce(
-      new Promise((resolve) => {
-        finishAppearance = resolve
-      })
-    )
-
+  it('updates an open overlay appearance without refocusing or signaling show', async () => {
+    const { view, manager } = createFakes()
     manager.open()
-    await vi.waitFor(() =>
-      expect(mainWindow.webContents.executeJavaScript).toHaveBeenCalledTimes(1)
-    )
-    manager.close()
-    finishAppearance?.({ theme: 'light', followsSystem: true })
-    await Promise.resolve()
+    await vi.waitFor(() => expect(view.webContents.send).toHaveBeenCalledTimes(1))
+    view.webContents.send.mockClear()
+    view.webContents.focus.mockClear()
 
-    expect(view.webContents.focus).toHaveBeenCalledTimes(1)
+    manager.updateAppearance({ theme: 'dark', followsSystem: false })
+
+    expect(view.webContents.focus).not.toHaveBeenCalled()
     expect(view.webContents.send).toHaveBeenCalledTimes(1)
-    expect(view.webContents.send).not.toHaveBeenCalledWith(
-      WINDOW_FIND_APPEARANCE_CHANNEL,
-      expect.anything()
-    )
-  })
-
-  it('ignores a stale appearance read after close and reopen', async () => {
-    const { view, mainWindow, manager } = createFakes()
-    let finishFirst: ((value: { theme: 'dark'; followsSystem: false }) => void) | undefined
-    let finishSecond: ((value: { theme: 'light'; followsSystem: false }) => void) | undefined
-    mainWindow.webContents.executeJavaScript
-      .mockReturnValueOnce(
-        new Promise((resolve) => {
-          finishFirst = resolve
-        })
-      )
-      .mockReturnValueOnce(
-        new Promise((resolve) => {
-          finishSecond = resolve
-        })
-      )
-
-    manager.open()
-    await vi.waitFor(() =>
-      expect(mainWindow.webContents.executeJavaScript).toHaveBeenCalledTimes(1)
-    )
-    manager.close()
-    manager.open()
-    expect(mainWindow.webContents.executeJavaScript).toHaveBeenCalledTimes(2)
-
-    finishFirst?.({ theme: 'dark', followsSystem: false })
-    await Promise.resolve()
-    expect(view.webContents.send).not.toHaveBeenCalledWith(
-      WINDOW_FIND_APPEARANCE_CHANNEL,
-      expect.anything()
-    )
-
-    finishSecond?.({ theme: 'light', followsSystem: false })
-    await vi.waitFor(() =>
-      expect(view.webContents.send).toHaveBeenCalledWith(WINDOW_FIND_APPEARANCE_CHANNEL, {
-        theme: 'light',
-        followsSystem: false
-      })
-    )
-  })
-
-  it.each([
-    ['the appearance read rejects', () => Promise.reject(new Error('renderer unavailable'))],
-    ['the appearance read returns invalid data', () => Promise.resolve({ theme: 'sepia' })]
-  ])('keeps the system fallback when %s', async (_case, createAppearanceResult) => {
-    const { view, mainWindow, manager } = createFakes()
-    mainWindow.webContents.executeJavaScript.mockReturnValueOnce(createAppearanceResult())
-
-    manager.open()
-    await Promise.resolve()
-    await Promise.resolve()
-
-    expect(view.webContents.send).toHaveBeenCalledTimes(1)
-    expect(view.webContents.send).toHaveBeenCalledWith(WINDOW_FIND_SHOW_CHANNEL, {
-      theme: 'light',
-      followsSystem: true
+    expect(view.webContents.send).toHaveBeenCalledWith(WINDOW_FIND_APPEARANCE_CHANNEL, {
+      theme: 'dark',
+      followsSystem: false
     })
+    expect(view.setBackgroundColor).toHaveBeenLastCalledWith('#1a1a18')
+  })
+
+  it('caches appearance updates while hidden without sending to the overlay', () => {
+    const { view, manager } = createFakes()
+
+    manager.updateAppearance({ theme: 'dark', followsSystem: false })
+
+    expect(view.webContents.send).not.toHaveBeenCalled()
+    manager.open()
+    expect(view.setBackgroundColor).toHaveBeenCalledWith('#1a1a18')
   })
 
   it('disposes a view whose page fails to load and creates a fresh view on retry', async () => {
@@ -290,7 +231,7 @@ describe('find overlay manager', () => {
     expect(mainWindow.webContents.focus).not.toHaveBeenCalled()
   })
 
-  it('repositions on resize while open and ignores resize while hidden', () => {
+  it('repositions on resize only after the page is loaded and while open', async () => {
     const { view, mainWindow, manager } = createFakes()
     const resizeListener = mainWindow.on.mock.calls.find(([event]) => event === 'resize')?.[1] as
       (() => void) | undefined
@@ -302,6 +243,7 @@ describe('find overlay manager', () => {
     resizeListener!()
 
     manager.open()
+    await Promise.resolve()
     view.setBounds.mockClear()
     resizeListener!()
 

--- a/src/main/find-overlay.ts
+++ b/src/main/find-overlay.ts
@@ -1,4 +1,4 @@
-import { WINDOW_FIND_SHOW_CHANNEL } from '../shared/window-controls'
+import { WINDOW_FIND_SHOW_CHANNEL, type WindowFindAppearance } from '../shared/window-controls'
 import type { FindOverlayOwner } from './find-overlay-registry'
 
 // Preferred geometry for the find overlay, in CSS pixels. 420px ~ 26rem at the app's 16px base.
@@ -25,7 +25,7 @@ export const computeOverlayBounds = (
 // arrow properties) makes these bivariant, so a real Electron BrowserWindow / WebContentsView satisfies
 // the shape without manual casts.
 type OverlayWebContents = {
-  loadFile(path: string): void
+  loadFile(path: string): Promise<void>
   send(channel: string, payload?: unknown): void
   focus(): void
 }
@@ -42,7 +42,11 @@ type OverlayMainWindow = {
   on(event: 'resize', listener: () => void): void
   removeListener?(event: 'resize', listener: () => void): void
   off?(event: 'resize', listener: () => void): void
-  webContents: { focus(): void; stopFindInPage(action: 'clearSelection'): void }
+  webContents: {
+    executeJavaScript(code: string): Promise<unknown>
+    focus(): void
+    stopFindInPage(action: 'clearSelection'): void
+  }
 }
 
 export type FindOverlayDeps = {
@@ -66,6 +70,30 @@ export type FindOverlayManager = {
 }
 
 const ZERO_BOUNDS = { x: 0, y: 0, width: 0, height: 0 }
+const FALLBACK_APPEARANCE: WindowFindAppearance = { theme: 'light', followsSystem: true }
+
+// The main renderer can be http://localhost in development while the overlay is file://, so their
+// localStorage is intentionally not shared. Read the renderer's already-applied class and its theme
+// preference in the renderer origin, then send only the small appearance contract to the overlay.
+const READ_APPEARANCE_SCRIPT = `(() => {
+  let preference = 'system'
+  try {
+    preference = window.localStorage.getItem('open-science-theme') ?? 'system'
+  } catch {}
+  return {
+    theme: document.documentElement.classList.contains('dark') ? 'dark' : 'light',
+    followsSystem: preference !== 'light' && preference !== 'dark'
+  }
+})()`
+
+const isWindowFindAppearance = (value: unknown): value is WindowFindAppearance => {
+  if (!value || typeof value !== 'object') return false
+  const appearance = value as Partial<WindowFindAppearance>
+  return (
+    (appearance.theme === 'light' || appearance.theme === 'dark') &&
+    typeof appearance.followsSystem === 'boolean'
+  )
+}
 
 // Owns the find overlay WebContentsView for one main window. The view is created lazily on first open
 // and stays attached for the life of the window: open/close toggle its bounds (real vs. zero) rather
@@ -74,7 +102,9 @@ const ZERO_BOUNDS = { x: 0, y: 0, width: 0, height: 0 }
 // query text is never part of the main window's page search.
 export const createFindOverlayManager = (deps: FindOverlayDeps): FindOverlayManager => {
   let view: OverlayView | null = null
+  let loadPromise: Promise<void> | null = null
   let opened = false
+  let showRequestId = 0
 
   const position = (): void => {
     if (!view) return
@@ -90,9 +120,30 @@ export const createFindOverlayManager = (deps: FindOverlayDeps): FindOverlayMana
   const close = (): void => {
     if (!opened) return
     opened = false
+    showRequestId += 1
     view?.setBounds(ZERO_BOUNDS)
     deps.mainWindow.webContents.stopFindInPage('clearSelection')
     deps.mainWindow.webContents.focus()
+  }
+
+  const readAppearance = async (): Promise<WindowFindAppearance> => {
+    try {
+      const appearance = await deps.mainWindow.webContents.executeJavaScript(READ_APPEARANCE_SCRIPT)
+      return isWindowFindAppearance(appearance) ? appearance : FALLBACK_APPEARANCE
+    } catch {
+      return FALLBACK_APPEARANCE
+    }
+  }
+
+  const showLoadedView = (): void => {
+    if (!opened || !view || loadPromise) return
+    const pendingView = view
+    const requestId = ++showRequestId
+    void readAppearance().then((appearance) => {
+      if (requestId !== showRequestId || !opened || view !== pendingView || loadPromise) return
+      pendingView.webContents.focus()
+      pendingView.webContents.send(WINDOW_FIND_SHOW_CHANNEL, appearance)
+    })
   }
 
   return {
@@ -103,15 +154,30 @@ export const createFindOverlayManager = (deps: FindOverlayDeps): FindOverlayMana
         view = deps.createView({
           webPreferences: { preload: deps.preloadPath, sandbox: true, contextIsolation: true }
         })
-        view.webContents.loadFile(deps.overlayHtmlPath)
+        const pendingView = view
+        const firstLoad = view.webContents.loadFile(deps.overlayHtmlPath)
+        loadPromise = firstLoad
+        void firstLoad.then(
+          () => {
+            if (loadPromise !== firstLoad) return
+            loadPromise = null
+            showLoadedView()
+          },
+          () => {
+            if (loadPromise !== firstLoad) return
+            loadPromise = null
+            close()
+            pendingView.destroy?.()
+            if (view === pendingView) view = null
+          }
+        )
         deps.mainWindow.contentView.addChildView(view)
         // Register the owner with the close handle so the find-IPC close channel can hide this overlay.
         deps.registerOwner?.(view.webContents, { mainWindow: deps.mainWindow, closeOverlay: close })
       }
       opened = true
       position()
-      view.webContents.focus()
-      view.webContents.send(WINDOW_FIND_SHOW_CHANNEL)
+      showLoadedView()
     },
 
     close,
@@ -120,7 +186,9 @@ export const createFindOverlayManager = (deps: FindOverlayDeps): FindOverlayMana
       ;(deps.mainWindow.removeListener ?? deps.mainWindow.off)?.('resize', onResize)
       view?.destroy?.()
       view = null
+      loadPromise = null
       opened = false
+      showRequestId += 1
     }
   }
 }

--- a/src/main/find-overlay.ts
+++ b/src/main/find-overlay.ts
@@ -36,6 +36,7 @@ type OverlayWebContents = {
 type OverlayView = {
   webContents: OverlayWebContents
   setBounds(bounds: { x: number; y: number; width: number; height: number }): void
+  setBackgroundColor(color: string): void
   destroy?(): void
 }
 
@@ -46,11 +47,7 @@ type OverlayMainWindow = {
   on(event: 'resize', listener: () => void): void
   removeListener?(event: 'resize', listener: () => void): void
   off?(event: 'resize', listener: () => void): void
-  webContents: {
-    executeJavaScript(code: string): Promise<unknown>
-    focus(): void
-    stopFindInPage(action: 'clearSelection'): void
-  }
+  webContents: { focus(): void; stopFindInPage(action: 'clearSelection'): void }
 }
 
 export type FindOverlayDeps = {
@@ -71,33 +68,13 @@ export type FindOverlayManager = {
   close: () => void
   destroy: () => void
   isOpen: () => boolean
+  updateAppearance: (appearance: WindowFindAppearance) => void
 }
 
 const ZERO_BOUNDS = { x: 0, y: 0, width: 0, height: 0 }
 const FALLBACK_APPEARANCE: WindowFindAppearance = { theme: 'light', followsSystem: true }
-
-// The main renderer can be http://localhost in development while the overlay is file://, so their
-// localStorage is intentionally not shared. Read the renderer's already-applied class and its theme
-// preference in the renderer origin, then send only the small appearance contract to the overlay.
-const READ_APPEARANCE_SCRIPT = `(() => {
-  let preference = 'system'
-  try {
-    preference = window.localStorage.getItem('open-science-theme') ?? 'system'
-  } catch {}
-  return {
-    theme: document.documentElement.classList.contains('dark') ? 'dark' : 'light',
-    followsSystem: preference !== 'light' && preference !== 'dark'
-  }
-})()`
-
-const isWindowFindAppearance = (value: unknown): value is WindowFindAppearance => {
-  if (!value || typeof value !== 'object') return false
-  const appearance = value as Partial<WindowFindAppearance>
-  return (
-    (appearance.theme === 'light' || appearance.theme === 'dark') &&
-    typeof appearance.followsSystem === 'boolean'
-  )
-}
+const LIGHT_BACKGROUND = '#fafaf8'
+const DARK_BACKGROUND = '#1a1a18'
 
 // Owns the find overlay WebContentsView for one main window. The view is created lazily on first open
 // and stays attached for the life of the window: open/close toggle its bounds (real vs. zero) rather
@@ -108,8 +85,10 @@ export const createFindOverlayManager = (deps: FindOverlayDeps): FindOverlayMana
   let view: OverlayView | null = null
   let loadPromise: Promise<void> | null = null
   let opened = false
-  let showRequestId = 0
   let cachedAppearance = FALLBACK_APPEARANCE
+
+  const backgroundFor = (appearance: WindowFindAppearance): string =>
+    appearance.theme === 'dark' ? DARK_BACKGROUND : LIGHT_BACKGROUND
 
   const position = (): void => {
     if (!view) return
@@ -118,26 +97,16 @@ export const createFindOverlayManager = (deps: FindOverlayDeps): FindOverlayMana
   }
 
   const onResize = (): void => {
-    if (opened) position()
+    if (opened && !loadPromise) position()
   }
   deps.mainWindow.on('resize', onResize)
 
   const close = (): void => {
     if (!opened) return
     opened = false
-    showRequestId += 1
     view?.setBounds(ZERO_BOUNDS)
     deps.mainWindow.webContents.stopFindInPage('clearSelection')
     deps.mainWindow.webContents.focus()
-  }
-
-  const readAppearance = async (): Promise<WindowFindAppearance | null> => {
-    try {
-      const appearance = await deps.mainWindow.webContents.executeJavaScript(READ_APPEARANCE_SCRIPT)
-      return isWindowFindAppearance(appearance) ? appearance : null
-    } catch {
-      return null
-    }
   }
 
   const appearancesEqual = (left: WindowFindAppearance, right: WindowFindAppearance): boolean =>
@@ -145,29 +114,10 @@ export const createFindOverlayManager = (deps: FindOverlayDeps): FindOverlayMana
 
   const showLoadedView = (): void => {
     if (!opened || !view || loadPromise) return
-    const pendingView = view
-    const requestId = ++showRequestId
-    const shownAppearance = cachedAppearance
-    // Keep the shortcut hot path synchronous: once the page is loaded, focus and SHOW immediately so
-    // keystrokes following Cmd/Ctrl+F land in the query field. Theme freshness is less important than
-    // input ownership and is reconciled below without refocusing or re-running the query.
-    pendingView.webContents.focus()
-    pendingView.webContents.send(WINDOW_FIND_SHOW_CHANNEL, shownAppearance)
-    void readAppearance().then((appearance) => {
-      if (
-        !appearance ||
-        requestId !== showRequestId ||
-        !opened ||
-        view !== pendingView ||
-        loadPromise
-      ) {
-        return
-      }
-      cachedAppearance = appearance
-      if (!appearancesEqual(appearance, shownAppearance)) {
-        pendingView.webContents.send(WINDOW_FIND_APPEARANCE_CHANNEL, appearance)
-      }
-    })
+    // Keep the shortcut path synchronous once the static overlay page is loaded so keystrokes
+    // immediately following Cmd/Ctrl+F land in the query field.
+    view.webContents.focus()
+    view.webContents.send(WINDOW_FIND_SHOW_CHANNEL, cachedAppearance)
   }
 
   return {
@@ -179,12 +129,15 @@ export const createFindOverlayManager = (deps: FindOverlayDeps): FindOverlayMana
           webPreferences: { preload: deps.preloadPath, sandbox: true, contextIsolation: true }
         })
         const pendingView = view
+        pendingView.setBounds(ZERO_BOUNDS)
+        pendingView.setBackgroundColor(backgroundFor(cachedAppearance))
         const firstLoad = view.webContents.loadFile(deps.overlayHtmlPath)
         loadPromise = firstLoad
         void firstLoad.then(
           () => {
             if (loadPromise !== firstLoad) return
             loadPromise = null
+            if (opened) position()
             showLoadedView()
           },
           () => {
@@ -200,11 +153,22 @@ export const createFindOverlayManager = (deps: FindOverlayDeps): FindOverlayMana
         deps.registerOwner?.(view.webContents, { mainWindow: deps.mainWindow, closeOverlay: close })
       }
       opened = true
-      position()
-      showLoadedView()
+      if (!loadPromise) {
+        position()
+        showLoadedView()
+      }
     },
 
     close,
+
+    updateAppearance: (appearance) => {
+      if (appearancesEqual(appearance, cachedAppearance)) return
+      cachedAppearance = appearance
+      view?.setBackgroundColor(backgroundFor(appearance))
+      if (opened && view && !loadPromise) {
+        view.webContents.send(WINDOW_FIND_APPEARANCE_CHANNEL, appearance)
+      }
+    },
 
     destroy: () => {
       ;(deps.mainWindow.removeListener ?? deps.mainWindow.off)?.('resize', onResize)
@@ -212,7 +176,6 @@ export const createFindOverlayManager = (deps: FindOverlayDeps): FindOverlayMana
       view = null
       loadPromise = null
       opened = false
-      showRequestId += 1
     }
   }
 }

--- a/src/main/find-overlay.ts
+++ b/src/main/find-overlay.ts
@@ -1,4 +1,8 @@
-import { WINDOW_FIND_SHOW_CHANNEL, type WindowFindAppearance } from '../shared/window-controls'
+import {
+  WINDOW_FIND_APPEARANCE_CHANNEL,
+  WINDOW_FIND_SHOW_CHANNEL,
+  type WindowFindAppearance
+} from '../shared/window-controls'
 import type { FindOverlayOwner } from './find-overlay-registry'
 
 // Preferred geometry for the find overlay, in CSS pixels. 420px ~ 26rem at the app's 16px base.
@@ -105,6 +109,7 @@ export const createFindOverlayManager = (deps: FindOverlayDeps): FindOverlayMana
   let loadPromise: Promise<void> | null = null
   let opened = false
   let showRequestId = 0
+  let cachedAppearance = FALLBACK_APPEARANCE
 
   const position = (): void => {
     if (!view) return
@@ -126,23 +131,42 @@ export const createFindOverlayManager = (deps: FindOverlayDeps): FindOverlayMana
     deps.mainWindow.webContents.focus()
   }
 
-  const readAppearance = async (): Promise<WindowFindAppearance> => {
+  const readAppearance = async (): Promise<WindowFindAppearance | null> => {
     try {
       const appearance = await deps.mainWindow.webContents.executeJavaScript(READ_APPEARANCE_SCRIPT)
-      return isWindowFindAppearance(appearance) ? appearance : FALLBACK_APPEARANCE
+      return isWindowFindAppearance(appearance) ? appearance : null
     } catch {
-      return FALLBACK_APPEARANCE
+      return null
     }
   }
+
+  const appearancesEqual = (left: WindowFindAppearance, right: WindowFindAppearance): boolean =>
+    left.theme === right.theme && left.followsSystem === right.followsSystem
 
   const showLoadedView = (): void => {
     if (!opened || !view || loadPromise) return
     const pendingView = view
     const requestId = ++showRequestId
+    const shownAppearance = cachedAppearance
+    // Keep the shortcut hot path synchronous: once the page is loaded, focus and SHOW immediately so
+    // keystrokes following Cmd/Ctrl+F land in the query field. Theme freshness is less important than
+    // input ownership and is reconciled below without refocusing or re-running the query.
+    pendingView.webContents.focus()
+    pendingView.webContents.send(WINDOW_FIND_SHOW_CHANNEL, shownAppearance)
     void readAppearance().then((appearance) => {
-      if (requestId !== showRequestId || !opened || view !== pendingView || loadPromise) return
-      pendingView.webContents.focus()
-      pendingView.webContents.send(WINDOW_FIND_SHOW_CHANNEL, appearance)
+      if (
+        !appearance ||
+        requestId !== showRequestId ||
+        !opened ||
+        view !== pendingView ||
+        loadPromise
+      ) {
+        return
+      }
+      cachedAppearance = appearance
+      if (!appearancesEqual(appearance, shownAppearance)) {
+        pendingView.webContents.send(WINDOW_FIND_APPEARANCE_CHANNEL, appearance)
+      }
     })
   }
 

--- a/src/main/windows.test.ts
+++ b/src/main/windows.test.ts
@@ -5,6 +5,7 @@ import {
   CLOSE_ACTIVE_PANE_READY_CHANNEL,
   CLOSE_ACTIVE_PANE_UNREADY_CHANNEL,
   WINDOW_FIND_READY_CHANNEL,
+  WINDOW_FIND_UNREADY_CHANNEL,
   type KeyChordInput
 } from '../shared/window-controls'
 
@@ -277,6 +278,9 @@ describe('close chord interception', () => {
   const signalWindowFindReady = (window: FakeBrowserWindow): void =>
     fireHandshake(window, WINDOW_FIND_READY_CHANNEL)
 
+  const signalWindowFindGone = (window: FakeBrowserWindow): void =>
+    fireHandshake(window, WINDOW_FIND_UNREADY_CHANNEL)
+
   // Drives one of the captured webContents lifecycle handlers (render-process-gone, unresponsive, ...).
   const fireWebContentsEvent = (
     window: FakeBrowserWindow,
@@ -337,6 +341,18 @@ describe('close chord interception', () => {
     expect(window.closeMock).not.toHaveBeenCalled()
   })
 
+  it('closes the find overlay when the searchable Workspace unmounts', () => {
+    createMainWindow()
+    const window = currentWindow!
+    signalWindowFindReady(window)
+    fireInput(window, findChord())
+    findOverlayMock.close.mockClear()
+
+    signalWindowFindGone(window)
+
+    expect(findOverlayMock.close).toHaveBeenCalledTimes(1)
+  })
+
   it('closes the find overlay on Escape while it is open, regardless of input focus', () => {
     createMainWindow()
     const window = currentWindow!
@@ -368,6 +384,18 @@ describe('close chord interception', () => {
 
     expect(window.closeMock).toHaveBeenCalledTimes(1)
     expect(window.sendMock).not.toHaveBeenCalled()
+  })
+
+  it('closes the find overlay before a top-level document navigation', () => {
+    createMainWindow()
+    const window = currentWindow!
+    signalWindowFindReady(window)
+    fireInput(window, findChord())
+    findOverlayMock.close.mockClear()
+
+    fireWebContentsEvent(window, 'did-start-navigation', mainFrameNavigation)
+
+    expect(findOverlayMock.close).toHaveBeenCalledTimes(1)
   })
 
   it('keeps forwarding when a subframe or same-document navigation fires', () => {
@@ -420,6 +448,18 @@ describe('close chord interception', () => {
     expect(window.sendMock).not.toHaveBeenCalled()
   })
 
+  it('closes the find overlay when the renderer process is gone', () => {
+    createMainWindow()
+    const window = currentWindow!
+    signalWindowFindReady(window)
+    fireInput(window, findChord())
+    findOverlayMock.close.mockClear()
+
+    fireWebContentsEvent(window, 'render-process-gone')
+
+    expect(findOverlayMock.close).toHaveBeenCalledTimes(1)
+  })
+
   it('closes directly while the renderer is unresponsive, then forwards again once responsive', () => {
     createMainWindow()
     const window = currentWindow!
@@ -437,6 +477,18 @@ describe('close chord interception', () => {
     fireInput(window, closeChord())
     expect(window.sendMock).toHaveBeenCalledWith(CLOSE_ACTIVE_PANE_CHANNEL)
     expect(window.closeMock).toHaveBeenCalledTimes(1)
+  })
+
+  it('closes the find overlay when the renderer becomes unresponsive', () => {
+    createMainWindow()
+    const window = currentWindow!
+    signalWindowFindReady(window)
+    fireInput(window, findChord())
+    findOverlayMock.close.mockClear()
+
+    fireWebContentsEvent(window, 'unresponsive')
+
+    expect(findOverlayMock.close).toHaveBeenCalledTimes(1)
   })
 
   it('forwards again after unresponsive -> crash -> reload -> ready, with no responsive event', () => {

--- a/src/main/windows.test.ts
+++ b/src/main/windows.test.ts
@@ -6,6 +6,7 @@ import {
   CLOSE_ACTIVE_PANE_UNREADY_CHANNEL,
   WINDOW_FIND_READY_CHANNEL,
   WINDOW_FIND_UNREADY_CHANNEL,
+  WINDOW_FIND_APPEARANCE_CHANGED_CHANNEL,
   type KeyChordInput
 } from '../shared/window-controls'
 
@@ -23,6 +24,7 @@ const { findOverlayMock } = vi.hoisted(() => ({
     open: vi.fn(),
     close: vi.fn(),
     destroy: vi.fn(),
+    updateAppearance: vi.fn(),
     isOpen: vi.fn(() => false)
   }
 }))
@@ -257,6 +259,7 @@ describe('close chord interception', () => {
     findOverlayMock.open.mockClear()
     findOverlayMock.close.mockClear()
     findOverlayMock.destroy.mockClear()
+    findOverlayMock.updateAppearance.mockClear()
     findOverlayMock.isOpen.mockReturnValue(false)
   })
 
@@ -267,6 +270,14 @@ describe('close chord interception', () => {
       ((event: { sender: unknown }) => void) | undefined
     expect(handler).toBeDefined()
     handler!({ sender: window.webContents })
+  }
+
+  const fireAppearance = (sender: unknown, appearance: unknown): void => {
+    const handler = ipcMainOnMock.mock.calls.find(
+      ([registered]) => registered === WINDOW_FIND_APPEARANCE_CHANGED_CHANNEL
+    )?.[1] as ((event: { sender: unknown }, payload: unknown) => void) | undefined
+    expect(handler).toBeDefined()
+    handler!({ sender }, appearance)
   }
 
   const signalRendererReady = (window: FakeBrowserWindow): void =>
@@ -339,6 +350,44 @@ describe('close chord interception', () => {
     // The overlay is opened directly in main now; no OPEN message is sent to the renderer.
     expect(window.sendMock).not.toHaveBeenCalled()
     expect(window.closeMock).not.toHaveBeenCalled()
+  })
+
+  it('forwards valid theme changes from this renderer to the overlay manager', () => {
+    createMainWindow()
+    const window = currentWindow!
+    const appearance = { theme: 'dark', followsSystem: false }
+
+    fireAppearance(window.webContents, appearance)
+
+    expect(findOverlayMock.updateAppearance).toHaveBeenCalledWith(appearance)
+  })
+
+  it('rejects malformed theme changes and messages from another renderer', () => {
+    createMainWindow()
+    const window = currentWindow!
+
+    fireAppearance(window.webContents, { theme: 'sepia', followsSystem: false })
+    fireAppearance({}, { theme: 'dark', followsSystem: false })
+
+    expect(findOverlayMock.updateAppearance).not.toHaveBeenCalled()
+  })
+
+  it('unregisters the window-scoped theme listener with the same handler on close', () => {
+    createMainWindow()
+    const window = currentWindow!
+    const registeredHandler = ipcMainOnMock.mock.calls.find(
+      ([registered]) => registered === WINDOW_FIND_APPEARANCE_CHANGED_CHANNEL
+    )?.[1]
+    const closedHandler = window.handlers.get('closed')?.[0]
+
+    expect(registeredHandler).toBeDefined()
+    expect(closedHandler).toBeDefined()
+    closedHandler!({ preventDefault: vi.fn(), defaultPrevented: false })
+
+    expect(ipcMainRemoveListenerMock).toHaveBeenCalledWith(
+      WINDOW_FIND_APPEARANCE_CHANGED_CHANNEL,
+      registeredHandler
+    )
   })
 
   it('closes the find overlay when the searchable Workspace unmounts', () => {

--- a/src/main/windows.ts
+++ b/src/main/windows.ts
@@ -17,10 +17,12 @@ import {
   CLOSE_ACTIVE_PANE_CHANNEL,
   CLOSE_ACTIVE_PANE_READY_CHANNEL,
   CLOSE_ACTIVE_PANE_UNREADY_CHANNEL,
+  WINDOW_FIND_APPEARANCE_CHANGED_CHANNEL,
   WINDOW_FIND_READY_CHANNEL,
   WINDOW_FIND_UNREADY_CHANNEL,
   isCloseWindowChord,
   isFindInPageChord,
+  isWindowFindAppearance,
   type CloseClassification,
   type CloseConfirmChoice
 } from '../shared/window-controls'
@@ -130,10 +132,15 @@ const createMainWindow = (opts?: MainWindowCloseOptions): BrowserWindow => {
     windowFindListenerReady = false
     findOverlay.close()
   }
+  const onWindowFindAppearanceChanged = (event: IpcMainEvent, appearance: unknown): void => {
+    if (event.sender !== window.webContents || !isWindowFindAppearance(appearance)) return
+    findOverlay.updateAppearance(appearance)
+  }
   ipcMain.on(CLOSE_ACTIVE_PANE_READY_CHANNEL, onListenerReady)
   ipcMain.on(CLOSE_ACTIVE_PANE_UNREADY_CHANNEL, onListenerGone)
   ipcMain.on(WINDOW_FIND_READY_CHANNEL, onWindowFindReady)
   ipcMain.on(WINDOW_FIND_UNREADY_CHANNEL, onWindowFindGone)
+  ipcMain.on(WINDOW_FIND_APPEARANCE_CHANGED_CHANNEL, onWindowFindAppearanceChanged)
   // A top-level document swap replaces the mounted hook, which must re-subscribe; a dead render process
   // took its listener with it. Both revoke readiness until the next READY handshake. Gate on the main
   // frame and a real document change so a dynamic preview iframe loading (or a same-document hash /
@@ -162,6 +169,7 @@ const createMainWindow = (opts?: MainWindowCloseOptions): BrowserWindow => {
     ipcMain.removeListener(CLOSE_ACTIVE_PANE_UNREADY_CHANNEL, onListenerGone)
     ipcMain.removeListener(WINDOW_FIND_READY_CHANNEL, onWindowFindReady)
     ipcMain.removeListener(WINDOW_FIND_UNREADY_CHANNEL, onWindowFindGone)
+    ipcMain.removeListener(WINDOW_FIND_APPEARANCE_CHANGED_CHANNEL, onWindowFindAppearanceChanged)
     findOverlay.destroy()
   })
 

--- a/src/main/windows.ts
+++ b/src/main/windows.ts
@@ -126,7 +126,9 @@ const createMainWindow = (opts?: MainWindowCloseOptions): BrowserWindow => {
     rendererResponsive = true
   }
   const onWindowFindGone = (event: IpcMainEvent): void => {
-    if (event.sender === window.webContents) windowFindListenerReady = false
+    if (event.sender !== window.webContents) return
+    windowFindListenerReady = false
+    findOverlay.close()
   }
   ipcMain.on(CLOSE_ACTIVE_PANE_READY_CHANNEL, onListenerReady)
   ipcMain.on(CLOSE_ACTIVE_PANE_UNREADY_CHANNEL, onListenerGone)
@@ -140,14 +142,17 @@ const createMainWindow = (opts?: MainWindowCloseOptions): BrowserWindow => {
     if (details.isMainFrame && !details.isSameDocument) {
       rendererListenerReady = false
       windowFindListenerReady = false
+      findOverlay.close()
     }
   })
   window.webContents.on('render-process-gone', () => {
     rendererListenerReady = false
     windowFindListenerReady = false
+    findOverlay.close()
   })
   window.webContents.on('unresponsive', () => {
     rendererResponsive = false
+    findOverlay.close()
   })
   window.webContents.on('responsive', () => {
     rendererResponsive = true

--- a/src/preload/index.d.ts
+++ b/src/preload/index.d.ts
@@ -596,6 +596,7 @@ interface OpenScienceAPI {
     onFindInPageResult?(listener: AcpListener<WindowFindResult>): RemoveListener
     // Overlay-only: main signals the bar was shown; the overlay asks main to hide it.
     onShowWindowFind?(listener: AcpListener<WindowFindAppearance>): RemoveListener
+    onWindowFindAppearance?(listener: AcpListener<WindowFindAppearance>): RemoveListener
     closeFind?(): void
     // Fires when main asks to confirm a close/quit; the renderer renders the modal and replies.
     onCloseConfirmRequest?(listener: (payload: CloseConfirmRequest) => void): RemoveListener

--- a/src/preload/index.d.ts
+++ b/src/preload/index.d.ts
@@ -203,6 +203,7 @@ import type {
 import type {
   CloseConfirmRequest,
   CloseConfirmResponse,
+  WindowFindAppearance,
   WindowFindRequest,
   WindowFindResult
 } from '../shared/window-controls'
@@ -594,7 +595,7 @@ interface OpenScienceAPI {
     announceWindowFindReady?(): RemoveListener
     onFindInPageResult?(listener: AcpListener<WindowFindResult>): RemoveListener
     // Overlay-only: main signals the bar was shown; the overlay asks main to hide it.
-    onShowWindowFind?(listener: () => void): RemoveListener
+    onShowWindowFind?(listener: AcpListener<WindowFindAppearance>): RemoveListener
     closeFind?(): void
     // Fires when main asks to confirm a close/quit; the renderer renders the modal and replies.
     onCloseConfirmRequest?(listener: (payload: CloseConfirmRequest) => void): RemoveListener

--- a/src/preload/index.d.ts
+++ b/src/preload/index.d.ts
@@ -597,6 +597,7 @@ interface OpenScienceAPI {
     // Overlay-only: main signals the bar was shown; the overlay asks main to hide it.
     onShowWindowFind?(listener: AcpListener<WindowFindAppearance>): RemoveListener
     onWindowFindAppearance?(listener: AcpListener<WindowFindAppearance>): RemoveListener
+    announceWindowFindAppearance?(appearance: WindowFindAppearance): void
     closeFind?(): void
     // Fires when main asks to confirm a close/quit; the renderer renders the modal and replies.
     onCloseConfirmRequest?(listener: (payload: CloseConfirmRequest) => void): RemoveListener

--- a/src/preload/index.test.ts
+++ b/src/preload/index.test.ts
@@ -98,6 +98,10 @@ type PreloadApi = {
     onWindowFindAppearance?: (
       listener: (appearance: { theme: 'light' | 'dark'; followsSystem: boolean }) => void
     ) => unknown
+    announceWindowFindAppearance?: (appearance: {
+      theme: 'light' | 'dark'
+      followsSystem: boolean
+    }) => void
     announceWindowFindReady?: () => unknown
   }
 }
@@ -164,6 +168,14 @@ describe('preload bridge — window find IPC channels', () => {
     api.window.announceWindowFindReady?.()
 
     expect(sendMock).toHaveBeenCalledWith('shortcut:window-find-ready')
+  })
+
+  it('forwards renderer theme changes to main as a typed appearance payload', () => {
+    const appearance = { theme: 'dark' as const, followsSystem: false }
+
+    api.window.announceWindowFindAppearance?.(appearance)
+
+    expect(sendMock).toHaveBeenCalledWith('window:find-appearance-changed', appearance)
   })
 })
 

--- a/src/preload/index.test.ts
+++ b/src/preload/index.test.ts
@@ -95,6 +95,9 @@ type PreloadApi = {
     onShowWindowFind?: (
       listener: (appearance: { theme: 'light' | 'dark'; followsSystem: boolean }) => void
     ) => unknown
+    onWindowFindAppearance?: (
+      listener: (appearance: { theme: 'light' | 'dark'; followsSystem: boolean }) => void
+    ) => unknown
     announceWindowFindReady?: () => unknown
   }
 }
@@ -132,21 +135,29 @@ describe('preload bridge — window find IPC channels', () => {
     expect(sendMock).toHaveBeenNthCalledWith(2, 'window:clear-find-in-page')
   })
 
-  it('forwards the overlay close request and the show appearance payload from main', () => {
-    const listener = vi.fn()
+  it('forwards the overlay close request and both appearance-bearing events from main', () => {
+    const showListener = vi.fn()
+    const appearanceListener = vi.fn()
     api.window.closeFind?.()
-    api.window.onShowWindowFind?.(listener)
+    api.window.onShowWindowFind?.(showListener)
+    api.window.onWindowFindAppearance?.(appearanceListener)
 
     expect(sendMock).toHaveBeenCalledWith('window:find-close')
     expect(onMock).toHaveBeenCalledWith('window:find-show', expect.any(Function))
+    expect(onMock).toHaveBeenCalledWith('window:find-appearance', expect.any(Function))
 
     const wrappedListener = onMock.mock.calls.find(
       ([channel]) => channel === 'window:find-show'
     )?.[1] as ((event: unknown, appearance: unknown) => void) | undefined
+    const wrappedAppearanceListener = onMock.mock.calls.find(
+      ([channel]) => channel === 'window:find-appearance'
+    )?.[1] as ((event: unknown, appearance: unknown) => void) | undefined
     const appearance = { theme: 'dark' as const, followsSystem: false }
     wrappedListener?.({}, appearance)
+    wrappedAppearanceListener?.({}, appearance)
 
-    expect(listener).toHaveBeenCalledWith(appearance)
+    expect(showListener).toHaveBeenCalledWith(appearance)
+    expect(appearanceListener).toHaveBeenCalledWith(appearance)
   })
 
   it('announces Workspace find readiness to main on mount', () => {

--- a/src/preload/index.test.ts
+++ b/src/preload/index.test.ts
@@ -92,7 +92,9 @@ type PreloadApi = {
     findInPage?: (request: unknown) => void
     clearFind?: () => void
     closeFind?: () => void
-    onShowWindowFind?: (listener: () => void) => unknown
+    onShowWindowFind?: (
+      listener: (appearance: { theme: 'light' | 'dark'; followsSystem: boolean }) => void
+    ) => unknown
     announceWindowFindReady?: () => unknown
   }
 }
@@ -116,6 +118,7 @@ afterEach(() => {
   invokeMock.mockClear()
   sendMock.mockClear()
   getPathForFileMock.mockReset()
+  onMock.mockClear()
 })
 
 describe('preload bridge — window find IPC channels', () => {
@@ -129,12 +132,21 @@ describe('preload bridge — window find IPC channels', () => {
     expect(sendMock).toHaveBeenNthCalledWith(2, 'window:clear-find-in-page')
   })
 
-  it('forwards the overlay close request and subscribes to the show event from main', () => {
+  it('forwards the overlay close request and the show appearance payload from main', () => {
+    const listener = vi.fn()
     api.window.closeFind?.()
-    api.window.onShowWindowFind?.(() => undefined)
+    api.window.onShowWindowFind?.(listener)
 
     expect(sendMock).toHaveBeenCalledWith('window:find-close')
     expect(onMock).toHaveBeenCalledWith('window:find-show', expect.any(Function))
+
+    const wrappedListener = onMock.mock.calls.find(
+      ([channel]) => channel === 'window:find-show'
+    )?.[1] as ((event: unknown, appearance: unknown) => void) | undefined
+    const appearance = { theme: 'dark' as const, followsSystem: false }
+    wrappedListener?.({}, appearance)
+
+    expect(listener).toHaveBeenCalledWith(appearance)
   })
 
   it('announces Workspace find readiness to main on mount', () => {

--- a/src/preload/index.ts
+++ b/src/preload/index.ts
@@ -223,6 +223,7 @@ import {
   WINDOW_FIND_SHOW_CHANNEL,
   type CloseConfirmRequest,
   type CloseConfirmResponse,
+  type WindowFindAppearance,
   type WindowFindRequest,
   type WindowFindResult
 } from '../shared/window-controls'
@@ -645,7 +646,7 @@ type OpenScienceAPI = {
     clearFind?: () => void
     announceWindowFindReady?: () => RemoveListener
     onFindInPageResult?: (listener: AcpListener<WindowFindResult>) => RemoveListener
-    onShowWindowFind?: (listener: () => void) => RemoveListener
+    onShowWindowFind?: (listener: AcpListener<WindowFindAppearance>) => RemoveListener
     closeFind?: () => void
     // Fires when main asks to confirm a close/quit; the renderer renders the modal and replies.
     onCloseConfirmRequest?: (listener: (payload: CloseConfirmRequest) => void) => RemoveListener

--- a/src/preload/index.ts
+++ b/src/preload/index.ts
@@ -219,6 +219,7 @@ import {
   WINDOW_FIND_CLEAR_CHANNEL,
   WINDOW_FIND_CLOSE_CHANNEL,
   WINDOW_FIND_APPEARANCE_CHANNEL,
+  WINDOW_FIND_APPEARANCE_CHANGED_CHANNEL,
   WINDOW_FIND_REQUEST_CHANNEL,
   WINDOW_FIND_RESULT_CHANNEL,
   WINDOW_FIND_SHOW_CHANNEL,
@@ -649,6 +650,7 @@ type OpenScienceAPI = {
     onFindInPageResult?: (listener: AcpListener<WindowFindResult>) => RemoveListener
     onShowWindowFind?: (listener: AcpListener<WindowFindAppearance>) => RemoveListener
     onWindowFindAppearance?: (listener: AcpListener<WindowFindAppearance>) => RemoveListener
+    announceWindowFindAppearance?: (appearance: WindowFindAppearance) => void
     closeFind?: () => void
     // Fires when main asks to confirm a close/quit; the renderer renders the modal and replies.
     onCloseConfirmRequest?: (listener: (payload: CloseConfirmRequest) => void) => RemoveListener
@@ -1239,6 +1241,8 @@ const api: OpenScienceAPI = {
     // overlay asks main to hide it. The localhost Web UI never loads this overlay, so both stay optional.
     onShowWindowFind: (listener) => onIpcMessage(WINDOW_FIND_SHOW_CHANNEL, listener),
     onWindowFindAppearance: (listener) => onIpcMessage(WINDOW_FIND_APPEARANCE_CHANNEL, listener),
+    announceWindowFindAppearance: (appearance) =>
+      ipcRenderer.send(WINDOW_FIND_APPEARANCE_CHANGED_CHANNEL, appearance),
     closeFind: () => ipcRenderer.send(WINDOW_FIND_CLOSE_CHANNEL),
     onCloseConfirmRequest: (listener) =>
       onIpcMessage(WINDOW_CLOSE_CONFIRM_REQUEST_CHANNEL, listener),

--- a/src/preload/index.ts
+++ b/src/preload/index.ts
@@ -218,6 +218,7 @@ import {
   WINDOW_CLOSE_CONFIRM_RESPONSE_CHANNEL,
   WINDOW_FIND_CLEAR_CHANNEL,
   WINDOW_FIND_CLOSE_CHANNEL,
+  WINDOW_FIND_APPEARANCE_CHANNEL,
   WINDOW_FIND_REQUEST_CHANNEL,
   WINDOW_FIND_RESULT_CHANNEL,
   WINDOW_FIND_SHOW_CHANNEL,
@@ -647,6 +648,7 @@ type OpenScienceAPI = {
     announceWindowFindReady?: () => RemoveListener
     onFindInPageResult?: (listener: AcpListener<WindowFindResult>) => RemoveListener
     onShowWindowFind?: (listener: AcpListener<WindowFindAppearance>) => RemoveListener
+    onWindowFindAppearance?: (listener: AcpListener<WindowFindAppearance>) => RemoveListener
     closeFind?: () => void
     // Fires when main asks to confirm a close/quit; the renderer renders the modal and replies.
     onCloseConfirmRequest?: (listener: (payload: CloseConfirmRequest) => void) => RemoveListener
@@ -1236,6 +1238,7 @@ const api: OpenScienceAPI = {
     // Overlay-only surface: main signals the bar was shown (focus + restore remembered query), and the
     // overlay asks main to hide it. The localhost Web UI never loads this overlay, so both stay optional.
     onShowWindowFind: (listener) => onIpcMessage(WINDOW_FIND_SHOW_CHANNEL, listener),
+    onWindowFindAppearance: (listener) => onIpcMessage(WINDOW_FIND_APPEARANCE_CHANNEL, listener),
     closeFind: () => ipcRenderer.send(WINDOW_FIND_CLOSE_CHANNEL),
     onCloseConfirmRequest: (listener) =>
       onIpcMessage(WINDOW_CLOSE_CONFIRM_REQUEST_CHANNEL, listener),

--- a/src/renderer/src/App.test.tsx
+++ b/src/renderer/src/App.test.tsx
@@ -39,7 +39,8 @@ const mocks = vi.hoisted(() => {
     },
     sessionPersistenceReady: true,
     startupView: 'home' as 'home' | 'onboarding',
-    getInfo: vi.fn()
+    getInfo: vi.fn(),
+    syncWindowFindAppearance: vi.fn()
   }
 })
 
@@ -58,6 +59,9 @@ vi.mock('@/hooks/useLifecycleSync', () => ({
     dismissNotice: vi.fn(),
     viewNotice: vi.fn()
   })
+}))
+vi.mock('@/hooks/useWindowFindAppearanceSync', () => ({
+  useWindowFindAppearanceSync: mocks.syncWindowFindAppearance
 }))
 vi.mock('@/stores/navigation-store', () => ({
   useNavigationStore: Object.assign(
@@ -163,6 +167,7 @@ describe('App startup routing', () => {
     mocks.startupView = 'home'
     mocks.sessionPersistenceReady = true
     mocks.deepLinkNavigation.mockClear()
+    mocks.syncWindowFindAppearance.mockClear()
     mocks.getInfo.mockResolvedValue({
       dataRoot: '/workspace/OpenScience',
       dataRootMissing: false,
@@ -204,6 +209,7 @@ describe('App startup routing', () => {
     await render()
 
     expect(container.innerHTML).toBe('')
+    expect(mocks.syncWindowFindAppearance).toHaveBeenCalledTimes(1)
   })
 
   it('passes session persistence readiness to deep-link navigation', async () => {

--- a/src/renderer/src/App.tsx
+++ b/src/renderer/src/App.tsx
@@ -18,6 +18,7 @@ import { EnvStatusBanner } from '@/pages/workspace/EnvStatusBanner'
 import { WorkspacePage } from '@/pages/workspace/WorkspacePage'
 import { useCloseActivePaneShortcut } from '@/hooks/useCloseActivePaneShortcut'
 import { useLifecycleSync } from '@/hooks/useLifecycleSync'
+import { useWindowFindAppearanceSync } from '@/hooks/useWindowFindAppearanceSync'
 import { useNavigationStore } from '@/stores/navigation-store'
 import { useNotebookEnvStore } from '@/stores/notebook-env-store'
 import { useProjectStore } from '@/stores/project-store'
@@ -35,6 +36,7 @@ const App = (): React.JSX.Element | null => {
   const view = useNavigationStore((state) => state.view)
   // Cmd+W / Ctrl+W closes the open preview panel before it closes the window.
   useCloseActivePaneShortcut()
+  useWindowFindAppearanceSync()
   const loadProjects = useProjectStore((state) => state.loadProjects)
   const isSettingsLoaded = useSettingsStore((state) => state.isLoaded)
   const onboardingCompletedAt = useSettingsStore((state) => state.onboardingCompletedAt)

--- a/src/renderer/src/hooks/useWindowFindAppearanceSync.test.tsx
+++ b/src/renderer/src/hooks/useWindowFindAppearanceSync.test.tsx
@@ -1,0 +1,78 @@
+// @vitest-environment jsdom
+import { act } from 'react'
+import { createRoot, type Root } from 'react-dom/client'
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest'
+
+const theme = vi.hoisted(() => ({
+  preference: 'light' as 'system' | 'light' | 'dark',
+  resolvedTheme: 'light' as 'light' | 'dark'
+}))
+
+vi.mock('@/stores/theme-store', () => ({
+  useThemeStore: <T,>(selector: (state: typeof theme) => T): T => selector(theme)
+}))
+
+import { useWindowFindAppearanceSync } from './useWindowFindAppearanceSync'
+
+const Harness = (): null => {
+  useWindowFindAppearanceSync()
+  return null
+}
+
+describe('useWindowFindAppearanceSync', () => {
+  let container: HTMLDivElement
+  let root: Root
+  const announceWindowFindAppearance = vi.fn()
+
+  beforeEach(() => {
+    theme.preference = 'light'
+    theme.resolvedTheme = 'light'
+    announceWindowFindAppearance.mockClear()
+    container = document.createElement('div')
+    document.body.appendChild(container)
+    root = createRoot(container)
+    window.api = {
+      window: { announceWindowFindAppearance }
+    } as unknown as Window['api']
+  })
+
+  afterEach(async () => {
+    await act(async () => root.unmount())
+    container.remove()
+  })
+
+  const render = async (): Promise<void> => {
+    await act(async () => root.render(<Harness />))
+  }
+
+  it('announces initial and changed explicit/system appearances', async () => {
+    await render()
+    expect(announceWindowFindAppearance).toHaveBeenLastCalledWith({
+      theme: 'light',
+      followsSystem: false
+    })
+
+    theme.preference = 'dark'
+    theme.resolvedTheme = 'dark'
+    await render()
+    expect(announceWindowFindAppearance).toHaveBeenLastCalledWith({
+      theme: 'dark',
+      followsSystem: false
+    })
+
+    theme.preference = 'system'
+    theme.resolvedTheme = 'light'
+    await render()
+    expect(announceWindowFindAppearance).toHaveBeenLastCalledWith({
+      theme: 'light',
+      followsSystem: true
+    })
+
+    theme.resolvedTheme = 'dark'
+    await render()
+    expect(announceWindowFindAppearance).toHaveBeenLastCalledWith({
+      theme: 'dark',
+      followsSystem: true
+    })
+  })
+})

--- a/src/renderer/src/hooks/useWindowFindAppearanceSync.ts
+++ b/src/renderer/src/hooks/useWindowFindAppearanceSync.ts
@@ -1,0 +1,18 @@
+import { useEffect } from 'react'
+
+import { useThemeStore } from '@/stores/theme-store'
+
+// The find bar is a separate file:// WebContentsView, so it cannot observe the main renderer's
+// origin-scoped theme preference. Push the resolved appearance whenever either half changes; main
+// caches it per window and forwards it only while the overlay is open.
+export const useWindowFindAppearanceSync = (): void => {
+  const preference = useThemeStore((state) => state.preference)
+  const resolvedTheme = useThemeStore((state) => state.resolvedTheme)
+
+  useEffect(() => {
+    window.api.window.announceWindowFindAppearance?.({
+      theme: resolvedTheme,
+      followsSystem: preference === 'system'
+    })
+  }, [preference, resolvedTheme])
+}

--- a/src/shared/window-controls.test.ts
+++ b/src/shared/window-controls.test.ts
@@ -8,6 +8,7 @@ import {
   WINDOW_FIND_UNREADY_CHANNEL,
   announceWindowFindReady,
   isCloseWindowChord,
+  isFindInPageChord,
   subscribeCloseActivePane,
   type KeyChordInput
 } from './window-controls'
@@ -73,6 +74,31 @@ describe('isCloseWindowChord', () => {
 
   it('ignores auto-repeat so a held chord cannot close the window after the pane closes', () => {
     expect(isCloseWindowChord(chord({ meta: true, isAutoRepeat: true }), 'darwin')).toBe(false)
+  })
+})
+
+describe('isFindInPageChord', () => {
+  it('matches Cmd+F on macOS and Ctrl+F on Windows and Linux', () => {
+    expect(isFindInPageChord(chord({ key: 'f', meta: true }), 'darwin')).toBe(true)
+    expect(isFindInPageChord(chord({ key: 'f', control: true }), 'win32')).toBe(true)
+    expect(isFindInPageChord(chord({ key: 'F', control: true }), 'linux')).toBe(true)
+  })
+
+  it('rejects the wrong primary modifier and chords with extra modifiers', () => {
+    expect(isFindInPageChord(chord({ key: 'f', control: true }), 'darwin')).toBe(false)
+    expect(isFindInPageChord(chord({ key: 'f', meta: true }), 'linux')).toBe(false)
+    expect(isFindInPageChord(chord({ key: 'f', meta: true, control: true }), 'darwin')).toBe(false)
+    expect(isFindInPageChord(chord({ key: 'f', meta: true, shift: true }), 'darwin')).toBe(false)
+    expect(isFindInPageChord(chord({ key: 'f', control: true, alt: true }), 'linux')).toBe(false)
+  })
+
+  it('rejects bare, unrelated, key-up, and auto-repeat input', () => {
+    expect(isFindInPageChord(chord({ key: 'f' }), 'darwin')).toBe(false)
+    expect(isFindInPageChord(chord({ key: 'q', meta: true }), 'darwin')).toBe(false)
+    expect(isFindInPageChord(chord({ key: 'f', meta: true, type: 'keyUp' }), 'darwin')).toBe(false)
+    expect(isFindInPageChord(chord({ key: 'f', control: true, isAutoRepeat: true }), 'linux')).toBe(
+      false
+    )
   })
 })
 

--- a/src/shared/window-controls.test.ts
+++ b/src/shared/window-controls.test.ts
@@ -7,6 +7,7 @@ import {
   WINDOW_FIND_READY_CHANNEL,
   WINDOW_FIND_UNREADY_CHANNEL,
   announceWindowFindReady,
+  isWindowFindAppearance,
   isCloseWindowChord,
   isFindInPageChord,
   subscribeCloseActivePane,
@@ -99,6 +100,19 @@ describe('isFindInPageChord', () => {
     expect(isFindInPageChord(chord({ key: 'f', control: true, isAutoRepeat: true }), 'linux')).toBe(
       false
     )
+  })
+})
+
+describe('isWindowFindAppearance', () => {
+  it('accepts the typed light/dark appearance contract', () => {
+    expect(isWindowFindAppearance({ theme: 'light', followsSystem: false })).toBe(true)
+    expect(isWindowFindAppearance({ theme: 'dark', followsSystem: true })).toBe(true)
+  })
+
+  it('rejects malformed appearance payloads received over IPC', () => {
+    expect(isWindowFindAppearance(null)).toBe(false)
+    expect(isWindowFindAppearance({ theme: 'sepia', followsSystem: false })).toBe(false)
+    expect(isWindowFindAppearance({ theme: 'dark', followsSystem: 'yes' })).toBe(false)
   })
 })
 

--- a/src/shared/window-controls.ts
+++ b/src/shared/window-controls.ts
@@ -36,6 +36,10 @@ export const WINDOW_FIND_RESULT_CHANNEL = 'window:find-in-page-result'
 // live-follow OS changes without trying to read the renderer's origin-scoped localStorage.
 export const WINDOW_FIND_SHOW_CHANNEL = 'window:find-show'
 
+// Main -> overlay: refresh only the overlay appearance after an asynchronous renderer lookup. Kept
+// separate from SHOW so a late theme result never steals focus or re-runs the remembered query.
+export const WINDOW_FIND_APPEARANCE_CHANNEL = 'window:find-appearance'
+
 // Overlay -> main: the user closed the find bar — hide the overlay and release the main-window focus.
 export const WINDOW_FIND_CLOSE_CHANNEL = 'window:find-close'
 

--- a/src/shared/window-controls.ts
+++ b/src/shared/window-controls.ts
@@ -31,7 +31,9 @@ export const WINDOW_FIND_REQUEST_CHANNEL = 'window:find-in-page'
 export const WINDOW_FIND_CLEAR_CHANNEL = 'window:clear-find-in-page'
 export const WINDOW_FIND_RESULT_CHANNEL = 'window:find-in-page-result'
 
-// Main -> overlay: the find bar was just shown — focus the field and re-run the remembered query.
+// Main -> overlay: the find bar was just shown — apply the main renderer's resolved appearance,
+// focus the field, and re-run the remembered query. `followsSystem` lets the separate file:// overlay
+// live-follow OS changes without trying to read the renderer's origin-scoped localStorage.
 export const WINDOW_FIND_SHOW_CHANNEL = 'window:find-show'
 
 // Overlay -> main: the user closed the find bar — hide the overlay and release the main-window focus.
@@ -49,6 +51,11 @@ export type WindowFindResult = {
   activeMatchOrdinal: number
   matches: number
   finalUpdate: boolean
+}
+
+export type WindowFindAppearance = {
+  theme: 'light' | 'dark'
+  followsSystem: boolean
 }
 
 // The minimal IPC surface the renderer handshake needs, kept structural so the wiring can be unit-tested

--- a/src/shared/window-controls.ts
+++ b/src/shared/window-controls.ts
@@ -40,6 +40,10 @@ export const WINDOW_FIND_SHOW_CHANNEL = 'window:find-show'
 // separate from SHOW so a late theme result never steals focus or re-runs the remembered query.
 export const WINDOW_FIND_APPEARANCE_CHANNEL = 'window:find-appearance'
 
+// Main renderer -> main: the app's resolved appearance changed. Main validates and caches this on the
+// window-owned overlay manager, which forwards it if the find bar is currently open.
+export const WINDOW_FIND_APPEARANCE_CHANGED_CHANNEL = 'window:find-appearance-changed'
+
 // Overlay -> main: the user closed the find bar — hide the overlay and release the main-window focus.
 export const WINDOW_FIND_CLOSE_CHANNEL = 'window:find-close'
 
@@ -60,6 +64,15 @@ export type WindowFindResult = {
 export type WindowFindAppearance = {
   theme: 'light' | 'dark'
   followsSystem: boolean
+}
+
+export const isWindowFindAppearance = (value: unknown): value is WindowFindAppearance => {
+  if (!value || typeof value !== 'object') return false
+  const appearance = value as Partial<WindowFindAppearance>
+  return (
+    (appearance.theme === 'light' || appearance.theme === 'dark') &&
+    typeof appearance.followsSystem === 'boolean'
+  )
 }
 
 // The minimal IPC surface the renderer handshake needs, kept structural so the wiring can be unit-tested


### PR DESCRIPTION
Follow-up to #466. Relates to #337.

## Problem

Post-merge review found several reliability and consistency gaps in the whole-window find overlay:

- the first show event could arrive before the overlay page registered its listener;
- the overlay stayed open when the searchable renderer became unavailable;
- the separate overlay origin could not reliably mirror app theme changes while Settings was open;
- the first dark-system open could briefly paint the light palette;
- document-level Enter handling overrode focused action buttons;
- focus, tooltip, motion, and theme styles did not fully match the app standards.

## Proposed change

- Keep the first overlay load at zero bounds until its page is ready, then focus and show synchronously on later opens while allowing recovery from load failures.
- Close the overlay when Workspace unmounts, top-level navigation begins, or the renderer crashes or becomes unresponsive.
- Push typed resolved appearance changes from the renderer through preload to the window-owned overlay manager, validating both sender and payload and cleaning up the window-scoped listener.
- Let the manager own the appearance cache and background color, remove the competing `executeJavaScript` sampler, and use a synchronous system-theme fallback before first paint while preserving explicit light overrides.
- Keep Escape global to the overlay while limiting Enter and Shift+Enter handling to the query input.
- Align controls with semantic theme tokens, accessible focus rings, custom tooltips, standard radius, and reduced-motion behavior.
- Add direct regression coverage for lifecycle, IPC forwarding, keyboard chords, theme races, and cleanup paths.

## Scope and non-goals

- Scope is limited to the Electron whole-window find overlay introduced by #466 and its shared/preload contract.
- This does not change search matching semantics or add whole-window find outside the searchable Workspace surface.
- This does not address the repository's existing lint warnings or dependency audit findings.

## Acceptance and validation

- [x] `npm run typecheck`
- [x] `npm run lint -- --no-cache` — 0 errors; 28 pre-existing warnings
- [x] Prettier check for all changed files
- [x] Full Vitest suite on Node 24 LTS — 505 files passed, 10 skipped; 7119 tests passed, 113 skipped
- [x] Final Spec review — no remaining actionable issues or scope creep
- [x] Final Standards review — no remaining actionable issues

## Review focus

- First-show and close/load-failure race handling in `src/main/find-overlay.ts`
- Renderer lifecycle closure paths in `src/main/windows.ts`
- Live theme propagation and validation across renderer, preload, main, and overlay
- Synchronous focus/show, zero-bounds initial load, and first-paint system-theme fallback
- Keyboard and accessibility behavior in `resources/find-overlay/`
