### PR TITLE
feat: combine model and reasoning effort pickers in composer

### DIFF
--- a/src/renderer/src/components/ui/dropdown-menu.tsx
+++ b/src/renderer/src/components/ui/dropdown-menu.tsx
@@ -26,7 +26,10 @@ function DropdownMenuSubTrigger({
 
 function DropdownMenuSubContent({
   className,
-  sideOffset = 2,
+  // Must clear the parent content's padding + border or the submenu visibly overlaps the parent
+  // menu: radix anchors the submenu to the SubTrigger's edge, which sits inside the parent's
+  // padding box. 8px covers both p-1 (4px) and p-1.5 (6px) parents with a small visual gap.
+  sideOffset = 8,
   alignOffset = -5,
   ...props
 }: React.ComponentProps<typeof DropdownMenuPrimitive.SubContent>): React.JSX.Element {

--- a/src/renderer/src/pages/workspace/ComposerModelPicker.render.test.tsx
+++ b/src/renderer/src/pages/workspace/ComposerModelPicker.render.test.tsx
@@ -4,6 +4,10 @@ import { createRoot, type Root } from 'react-dom/client'
 import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest'
 
 import type { ProviderView } from '../../../../shared/settings'
+import {
+  reasoningEffortProfile,
+  resolveReasoningEffortControl
+} from '../../../../shared/reasoning-effort'
 import { createInitialSettingsState, useSettingsStore } from '@/stores/settings-store'
 import { ComposerModelPicker } from './ComposerModelPicker'
 import { incompatibilityReason } from './composer-model-picker-utils'
@@ -86,6 +90,14 @@ const flush = async (): Promise<void> => {
   })
 }
 
+// Radix's RovingFocusGroup defers the focus move to a macrotask (setTimeout), so a microtask
+// flush isn't enough — drain real timers after each arrow key.
+const flushTimers = async (): Promise<void> => {
+  await act(async () => {
+    await new Promise((resolve) => setTimeout(resolve, 0))
+  })
+}
+
 const openMenu = async (trigger: Element): Promise<void> => {
   // Radix DropdownMenuTrigger toggles open on Enter/Space keydown; this is the interaction jsdom
   // supports most reliably and it mounts the portaled content.
@@ -95,8 +107,32 @@ const openMenu = async (trigger: Element): Promise<void> => {
   await flush()
 }
 
+// A Radix SubTrigger opens its submenu on ArrowRight (LTR) when the keydown originates on the
+// trigger itself; focusing first mirrors where roving focus would have put the user.
+const openSubmenu = async (subTrigger: HTMLElement): Promise<void> => {
+  act(() => {
+    subTrigger.focus()
+    subTrigger.dispatchEvent(new KeyboardEvent('keydown', { key: 'ArrowRight', bubbles: true }))
+  })
+  await flushTimers()
+}
+
+const arrowKey = async (key: 'ArrowDown' | 'ArrowUp'): Promise<void> => {
+  const target = (document.activeElement as Element | null) ?? document.body
+  act(() => {
+    target.dispatchEvent(new KeyboardEvent('keydown', { key, bubbles: true }))
+  })
+  await flushTimers()
+}
+
 const menuItems = (): HTMLElement[] =>
   Array.from(document.querySelectorAll<HTMLElement>('[role="menuitem"]'))
+
+const radioItems = (): HTMLElement[] =>
+  Array.from(document.querySelectorAll<HTMLElement>('[role="menuitemradio"]'))
+
+const subTriggers = (): HTMLElement[] =>
+  Array.from(document.querySelectorAll<HTMLElement>('[data-slot="dropdown-menu-sub-trigger"]'))
 
 describe('ComposerModelPicker', () => {
   it('renders nothing when there is a single selectable option', () => {
@@ -146,13 +182,19 @@ describe('ComposerModelPicker', () => {
     const trigger = container.querySelector('[aria-label="Select model"]')
     expect(trigger).not.toBeNull()
     await openMenu(trigger!)
+    // The catalog itself lives in the Model submenu; open it before asserting on its rows.
+    const modelRow = subTriggers().find((el) => el.textContent?.includes('Model'))
+    expect(modelRow, 'expected the "Model" subtrigger').toBeDefined()
+    await openSubmenu(modelRow!)
+    expect(document.body.textContent).toContain('ds2')
     expect(document.body.textContent).not.toContain('not supported over the Codex')
   })
 
   it('exposes each incompatible provider reason as a focusable, non-actionable menu item', async () => {
     // Claude Code (anthropic-only) + only OpenAI-speaking providers: the menu must state why each
     // provider is unavailable in an item roving focus can reach (not a label or a disabled item, both
-    // keyboard-unreachable), keep it unselectable, and still offer a way out to Settings.
+    // keyboard-unreachable), keep it unselectable, and still offer a way out to Settings. The reason
+    // row now lives inside the "Model" submenu; "Open Settings" stays on the first level.
     const openSettings = vi.fn()
     const setActiveProvider = vi.fn()
     useSettingsStore.setState({
@@ -189,9 +231,25 @@ describe('ComposerModelPicker', () => {
     // 1. Open the dropdown.
     await openMenu(trigger!)
 
-    // 2. The reason lives in a real menu item (reached by arrow-key roving focus). The full reason is
-    // exposed to assistive tech via aria-label/title while the visible label stays compact, and the
-    // item is marked unselectable.
+    // 2. With no active provider there is no effort row, so roving focus lands on the "Model"
+    // subtrigger first; ArrowDown/ArrowUp step between it and the first-level "Open Settings".
+    const modelRow = subTriggers().find((el) => el.textContent?.includes('Model'))
+    expect(modelRow, 'expected the "Model" subtrigger').toBeDefined()
+    expect(
+      document.activeElement,
+      'keyboard-open should place roving focus on the first (Model) item'
+    ).toBe(modelRow)
+    await arrowKey('ArrowDown')
+    expect((document.activeElement as HTMLElement | null)?.textContent).toContain('Open Settings')
+    await arrowKey('ArrowUp')
+    expect(document.activeElement, 'ArrowUp must return roving focus to the Model row').toBe(
+      modelRow
+    )
+
+    // 3. Open the Model submenu: the reason lives in a real menu item there (reached by arrow-key
+    // roving focus). The full reason is exposed to assistive tech via aria-label/title while the
+    // visible label stays compact, and the item is marked unselectable.
+    await openSubmenu(modelRow!)
     const reasonItem = menuItems().find((el) => el.getAttribute('aria-label') === expectedReason)
     expect(reasonItem, 'expected a menu item carrying the incompatibility reason').toBeDefined()
     expect(reasonItem?.getAttribute('aria-label')).toContain('OpenAI Gateway')
@@ -203,52 +261,20 @@ describe('ComposerModelPicker', () => {
     // keyboard user can land on it — proven by the absence of the data-disabled marker.
     expect(reasonItem?.hasAttribute('data-disabled')).toBe(false)
 
-    // 2b. Prove keyboard ARROW roving focus can actually land on the reason item — the point of
-    // leaving it aria-disabled rather than Radix-`disabled`. Absence of data-disabled alone only
-    // shows the `disabled` prop was avoided; a Radix-`disabled` item would be dropped from the
-    // roving-focus ring entirely and never reachable by arrow keys. Here we drive the real
-    // ArrowDown/ArrowUp roving focus and assert document.activeElement moves off, then back ONTO,
-    // the reason item via the arrow keys.
-    const content = document.querySelector<HTMLElement>('[role="menu"]')
-    expect(content, 'expected the portaled menu content to be mounted').not.toBeNull()
-    // Radix's RovingFocusGroup defers the focus move to a macrotask (setTimeout), so a microtask
-    // flush isn't enough — drain real timers after each arrow key.
-    const flushTimers = async (): Promise<void> => {
-      await act(async () => {
-        await new Promise((resolve) => setTimeout(resolve, 0))
-      })
-    }
-    const arrowKey = async (key: 'ArrowDown' | 'ArrowUp'): Promise<void> => {
-      const target = (document.activeElement as Element | null) ?? content!
-      act(() => {
-        target.dispatchEvent(new KeyboardEvent('keydown', { key, bubbles: true }))
-      })
-      await flushTimers()
-    }
-    // Keyboard-opening the menu lands roving focus on the first item, which is the reason item.
-    expect(
-      document.activeElement,
-      'keyboard-open should place roving focus on the first (reason) item'
-    ).toBe(reasonItem)
-    // Step off it with ArrowDown (onto the next real item), then back onto it with ArrowUp — proving
-    // arrow-key navigation genuinely traverses to the reason item rather than skipping it.
+    // 3b. Prove roving focus can actually land on the reason item: it is the submenu's only item,
+    // so an ArrowDown from wherever focus settled must move (or loop) onto it — a Radix-`disabled`
+    // item would be dropped from the roving-focus ring entirely and never reached.
     await arrowKey('ArrowDown')
     expect(
       document.activeElement,
-      'ArrowDown must move roving focus off the reason item onto the next item'
-    ).not.toBe(reasonItem)
-    expect((document.activeElement as HTMLElement | null)?.textContent).toContain('Open Settings')
-    await arrowKey('ArrowUp')
-    expect(
-      document.activeElement,
-      'ArrowUp must bring roving focus back onto the incompatibility reason item'
+      'ArrowDown inside the Model submenu must land on the reason item'
     ).toBe(reasonItem)
 
-    // 3. Activating the reason item must not switch the model (it is informational only).
+    // 4. Activating the reason item must not switch the model (it is informational only).
     act(() => reasonItem!.click())
     expect(setActiveProvider).not.toHaveBeenCalled()
 
-    // 4. Open Settings still works as the escape hatch.
+    // 5. Open Settings still works as the escape hatch, from the first level.
     const openSettingsItem = menuItems().find((el) => el.textContent?.includes('Open Settings'))
     expect(openSettingsItem, 'expected an "Open Settings" menu item').toBeDefined()
     act(() => openSettingsItem!.click())
@@ -338,5 +364,258 @@ describe('ComposerModelPicker', () => {
 
     const trigger = container.querySelector('[aria-label="Select model"]')
     expect(trigger?.textContent).toContain('my-model')
+  })
+
+  it('suffixes the trigger with the effort label when a non-default effort is set and supported', () => {
+    // gpt-5.2 is not in the bundled OpenAI catalog, so it resolves to the vendor-level profile
+    // (low-medium-high-xhigh) — supported, with the stored 'high' intent mapping to the High rung.
+    useSettingsStore.setState({
+      providers: [
+        provider({
+          id: 'off',
+          type: 'official',
+          vendorId: 'openai',
+          name: 'OpenAI',
+          models: ['gpt-5.2', 'gpt-5.5']
+        })
+      ],
+      activeProviderId: 'off',
+      activeModel: 'gpt-5.2',
+      reasoningEffort: 'high'
+    })
+    render()
+
+    const trigger = container.querySelector('[aria-label="Select model"]')
+    expect(trigger).not.toBeNull()
+    expect(trigger?.textContent).toContain('gpt-5.2')
+    expect(trigger?.textContent).toContain('· High')
+    // The provider name no longer appears on the trigger — the effort suffix replaced it.
+    expect(trigger?.textContent).not.toContain('OpenAI')
+  })
+
+  it('shows no effort suffix on the trigger when the effort intent is default', () => {
+    useSettingsStore.setState({
+      providers: [
+        provider({
+          id: 'off',
+          type: 'official',
+          vendorId: 'openai',
+          name: 'OpenAI',
+          models: ['gpt-5.2', 'gpt-5.5']
+        })
+      ],
+      activeProviderId: 'off',
+      activeModel: 'gpt-5.2',
+      reasoningEffort: 'default'
+    })
+    render()
+
+    const trigger = container.querySelector('[aria-label="Select model"]')
+    expect(trigger?.textContent).toContain('gpt-5.2')
+    expect(trigger?.textContent).not.toContain('·')
+  })
+
+  it('hides the effort row and suffix when the active model does not support reasoning effort', async () => {
+    // claude-haiku-4-5-20251001 is statically marked effort-unsupported in the vendor catalog, so
+    // neither the trigger suffix nor the "Reasoning effort" row may appear.
+    useSettingsStore.setState({
+      providers: [
+        provider({
+          id: 'ant',
+          type: 'official',
+          vendorId: 'anthropic',
+          name: 'Anthropic',
+          models: ['claude-haiku-4-5-20251001']
+        }),
+        provider({ id: 'p2', name: 'Gateway', models: ['gm'] })
+      ],
+      activeProviderId: 'ant',
+      activeModel: 'claude-haiku-4-5-20251001',
+      reasoningEffort: 'high'
+    })
+    render()
+
+    const trigger = container.querySelector('[aria-label="Select model"]')
+    expect(trigger).not.toBeNull()
+    expect(trigger?.textContent).not.toContain('· High')
+
+    await openMenu(trigger!)
+    expect(
+      subTriggers().find((el) => el.textContent?.includes('Reasoning effort')),
+      'expected no "Reasoning effort" subtrigger for an unsupported model'
+    ).toBeUndefined()
+    expect(subTriggers().some((el) => el.textContent?.includes('Model'))).toBe(true)
+  })
+
+  it('lists the profile effort levels in the effort submenu and applies the picked intent', async () => {
+    // DeepSeek's catalog profile is none-high-max: the submenu offers Default plus that profile's
+    // rungs, and picking one stores the intent the profile maps the rung to.
+    const setReasoningEffort = vi.fn()
+    useSettingsStore.setState({
+      providers: [
+        provider({
+          id: 'ds',
+          type: 'official',
+          vendorId: 'deepseek',
+          name: 'DeepSeek',
+          models: ['deepseek-v4-pro', 'deepseek-v4-flash']
+        })
+      ],
+      activeProviderId: 'ds',
+      activeModel: 'deepseek-v4-pro',
+      setReasoningEffort
+    })
+    render()
+
+    const control = resolveReasoningEffortControl(
+      'default',
+      reasoningEffortProfile('none-high-max')
+    )
+    expect(control.options.map((option) => option.label)).toEqual(['None', 'High', 'Max'])
+
+    const trigger = container.querySelector('[aria-label="Select model"]')
+    expect(trigger).not.toBeNull()
+    await openMenu(trigger!)
+
+    const effortRow = subTriggers().find((el) => el.textContent?.includes('Reasoning effort'))
+    expect(effortRow, 'expected the "Reasoning effort" subtrigger').toBeDefined()
+    // With the stored intent at default, the first-level capsule echoes "Default".
+    expect(effortRow?.textContent).toContain('Default')
+    await openSubmenu(effortRow!)
+
+    const effortOptions = radioItems()
+    expect(effortOptions.map((el) => el.textContent)).toEqual([
+      'Defaultprovider default',
+      'None',
+      'High',
+      'Max'
+    ])
+
+    // Default is the stored intent, so its row carries the selected marker (aria-checked + Check).
+    const defaultItem = effortOptions.find((el) => el.textContent === 'Defaultprovider default')
+    expect(defaultItem?.getAttribute('aria-checked')).toBe('true')
+    expect(defaultItem?.querySelector('svg.text-primary')).not.toBeNull()
+
+    const highItem = effortOptions.find((el) => el.textContent === 'High')
+    const highOption = control.options.find((option) => option.label === 'High')
+    act(() => highItem!.click())
+    expect(setReasoningEffort).toHaveBeenCalledWith(highOption?.intent)
+  })
+
+  it('summarizes the current model and provider in the Model row capsule', async () => {
+    useSettingsStore.setState({
+      providers: [
+        provider({
+          id: 'off',
+          type: 'official',
+          vendorId: 'openai',
+          name: 'OpenAI',
+          models: ['gpt-5.2', 'gpt-5.5']
+        })
+      ],
+      activeProviderId: 'off',
+      activeModel: 'gpt-5.2'
+    })
+    render()
+
+    const trigger = container.querySelector('[aria-label="Select model"]')
+    expect(trigger).not.toBeNull()
+    await openMenu(trigger!)
+
+    const modelRow = subTriggers().find((el) => el.textContent?.includes('Model'))
+    expect(modelRow, 'expected the "Model" subtrigger').toBeDefined()
+    expect(modelRow?.textContent).toContain('gpt-5.2 · OpenAI')
+  })
+
+  it('adapts the effort submenu to the standard-5 profile and echoes the current effort in the row capsule', async () => {
+    // A model absent from the Anthropic catalog resolves to the vendor default (standard-5): five
+    // distinct rungs. The stored 'medium' intent checks the rung the profile maps it to, and the
+    // first-level row capsule shows that rung's label.
+    useSettingsStore.setState({
+      providers: [
+        provider({
+          id: 'ant',
+          type: 'official',
+          vendorId: 'anthropic',
+          name: 'Anthropic',
+          models: ['claude-next', 'claude-next-mini']
+        }),
+        provider({ id: 'p2', name: 'Gateway', models: ['gm'] })
+      ],
+      activeProviderId: 'ant',
+      activeModel: 'claude-next',
+      reasoningEffort: 'medium'
+    })
+    render()
+
+    const control = resolveReasoningEffortControl('medium', reasoningEffortProfile('standard-5'))
+    expect(control.options).toHaveLength(5)
+    const selectedLabel = control.options.find(
+      (option) => option.value === control.selectedValue
+    )?.label
+
+    const trigger = container.querySelector('[aria-label="Select model"]')
+    expect(trigger).not.toBeNull()
+    await openMenu(trigger!)
+
+    const effortRow = subTriggers().find((el) => el.textContent?.includes('Reasoning effort'))
+    expect(effortRow, 'expected the "Reasoning effort" subtrigger').toBeDefined()
+    expect(effortRow?.textContent).toContain(selectedLabel!)
+
+    await openSubmenu(effortRow!)
+    const effortOptions = radioItems()
+    expect(effortOptions.map((el) => el.textContent)).toEqual([
+      'Defaultprovider default',
+      ...control.options.map((option) => option.label)
+    ])
+
+    // The rung the stored intent maps onto carries the selected marker (aria-checked + Check).
+    const checkedItem = effortOptions.find((el) => el.getAttribute('aria-checked') === 'true')
+    expect(checkedItem?.textContent).toBe(selectedLabel)
+    expect(checkedItem?.querySelector('svg.text-primary')).not.toBeNull()
+  })
+
+  it('keeps the grouped provider catalog in the Model submenu and switches on pick', async () => {
+    const setActiveProvider = vi.fn()
+    useSettingsStore.setState({
+      providers: [
+        provider({
+          id: 'off',
+          type: 'official',
+          vendorId: 'openai',
+          name: 'OpenAI',
+          models: ['gpt-5.2', 'gpt-5.5']
+        }),
+        provider({ id: 'gw', name: 'Gateway', models: ['gm'] })
+      ],
+      activeProviderId: 'off',
+      activeModel: 'gpt-5.2',
+      setActiveProvider
+    })
+    render()
+
+    const trigger = container.querySelector('[aria-label="Select model"]')
+    expect(trigger).not.toBeNull()
+    await openMenu(trigger!)
+
+    const modelRow = subTriggers().find((el) => el.textContent?.includes('Model'))
+    expect(modelRow, 'expected the "Model" subtrigger').toBeDefined()
+    await openSubmenu(modelRow!)
+
+    // Both provider groups render under their own heading, with every catalog model listed.
+    expect(document.body.textContent).toContain('OpenAI')
+    expect(document.body.textContent).toContain('Gateway')
+    expect(document.body.textContent).toContain('gpt-5.5')
+
+    // The active model row is the one carrying the selected marker (aria-checked + Check).
+    const activeModelItem = radioItems().find((el) => el.textContent === 'gpt-5.2')
+    expect(activeModelItem, 'expected the active model menu item').toBeDefined()
+    expect(activeModelItem?.getAttribute('aria-checked')).toBe('true')
+    expect(activeModelItem?.querySelector('svg.text-primary')).not.toBeNull()
+
+    const gatewayModel = radioItems().find((el) => el.textContent === 'gm')
+    expect(gatewayModel, 'expected the Gateway model menu item').toBeDefined()
+    act(() => gatewayModel!.click())
+    expect(setActiveProvider).toHaveBeenCalledWith('gw', 'gm')
   })
 })

--- a/src/renderer/src/pages/workspace/ComposerModelPicker.render.test.tsx
+++ b/src/renderer/src/pages/workspace/ComposerModelPicker.render.test.tsx
@@ -134,6 +134,11 @@ const radioItems = (): HTMLElement[] =>
 const subTriggers = (): HTMLElement[] =>
   Array.from(document.querySelectorAll<HTMLElement>('[data-slot="dropdown-menu-sub-trigger"]'))
 
+// The Model row's visible text is the current pick (provider + model), not a fixed label, so
+// tests locate it via its stable test id.
+const modelRowTrigger = (): HTMLElement | undefined =>
+  subTriggers().find((el) => el.getAttribute('data-testid') === 'model-row')
+
 describe('ComposerModelPicker', () => {
   it('renders nothing when there is a single selectable option', () => {
     useSettingsStore.setState({ providers: [provider({ id: 'p1', models: ['only'] })] })
@@ -183,7 +188,7 @@ describe('ComposerModelPicker', () => {
     expect(trigger).not.toBeNull()
     await openMenu(trigger!)
     // The catalog itself lives in the Model submenu; open it before asserting on its rows.
-    const modelRow = subTriggers().find((el) => el.textContent?.includes('Model'))
+    const modelRow = modelRowTrigger()
     expect(modelRow, 'expected the "Model" subtrigger').toBeDefined()
     await openSubmenu(modelRow!)
     expect(document.body.textContent).toContain('ds2')
@@ -233,7 +238,7 @@ describe('ComposerModelPicker', () => {
 
     // 2. With no active provider there is no effort row, so roving focus lands on the "Model"
     // subtrigger first; ArrowDown/ArrowUp step between it and the first-level "Open Settings".
-    const modelRow = subTriggers().find((el) => el.textContent?.includes('Model'))
+    const modelRow = modelRowTrigger()
     expect(modelRow, 'expected the "Model" subtrigger').toBeDefined()
     expect(
       document.activeElement,
@@ -444,7 +449,7 @@ describe('ComposerModelPicker', () => {
       subTriggers().find((el) => el.textContent?.includes('Reasoning effort')),
       'expected no "Reasoning effort" subtrigger for an unsupported model'
     ).toBeUndefined()
-    expect(subTriggers().some((el) => el.textContent?.includes('Model'))).toBe(true)
+    expect(modelRowTrigger(), 'expected the "Model" subtrigger to remain').toBeDefined()
   })
 
   it('lists the profile effort levels in the effort submenu and applies the picked intent', async () => {
@@ -502,7 +507,7 @@ describe('ComposerModelPicker', () => {
     expect(setReasoningEffort).toHaveBeenCalledWith(highOption?.intent)
   })
 
-  it('summarizes the current model and provider in the Model row capsule', async () => {
+  it('summarizes the current pick in the Model row as provider line over model name', async () => {
     useSettingsStore.setState({
       providers: [
         provider({
@@ -522,9 +527,13 @@ describe('ComposerModelPicker', () => {
     expect(trigger).not.toBeNull()
     await openMenu(trigger!)
 
-    const modelRow = subTriggers().find((el) => el.textContent?.includes('Model'))
+    // Two-line summary: the small bold provider line (with the provider's icon) sits above the
+    // model name — no `model · provider` capsule anymore.
+    const modelRow = modelRowTrigger()
     expect(modelRow, 'expected the "Model" subtrigger').toBeDefined()
-    expect(modelRow?.textContent).toContain('gpt-5.2 · OpenAI')
+    expect(modelRow?.textContent).toContain('OpenAI')
+    expect(modelRow?.textContent).toContain('gpt-5.2')
+    expect(modelRow?.textContent).not.toContain('·')
   })
 
   it('adapts the effort submenu to the standard-5 profile and echoes the current effort in the row capsule', async () => {
@@ -598,7 +607,7 @@ describe('ComposerModelPicker', () => {
     expect(trigger).not.toBeNull()
     await openMenu(trigger!)
 
-    const modelRow = subTriggers().find((el) => el.textContent?.includes('Model'))
+    const modelRow = modelRowTrigger()
     expect(modelRow, 'expected the "Model" subtrigger').toBeDefined()
     await openSubmenu(modelRow!)
 

--- a/src/renderer/src/pages/workspace/ComposerModelPicker.render.test.tsx
+++ b/src/renderer/src/pages/workspace/ComposerModelPicker.render.test.tsx
@@ -398,6 +398,39 @@ describe('ComposerModelPicker', () => {
     expect(trigger?.textContent).not.toContain('OpenAI')
   })
 
+  it('keeps the effort suffix fully visible and ellipsizes only the model name on the trigger', () => {
+    // Long model names must not swallow the effort suffix: the model span truncates, the suffix
+    // span is shrink-protected and never wraps.
+    useSettingsStore.setState({
+      providers: [
+        provider({
+          id: 'off',
+          type: 'official',
+          vendorId: 'openai',
+          name: 'OpenAI',
+          models: ['gpt-5.2-with-a-very-long-model-name', 'gpt-5.5']
+        })
+      ],
+      activeProviderId: 'off',
+      activeModel: 'gpt-5.2-with-a-very-long-model-name',
+      reasoningEffort: 'high'
+    })
+    render()
+
+    const trigger = container.querySelector('[aria-label="Select model"]')
+    expect(trigger).not.toBeNull()
+    expect(trigger?.textContent).toContain('· High')
+    const suffix = Array.from(trigger!.querySelectorAll('span')).find(
+      (el) => el.textContent?.trim() === '· High'
+    )
+    expect(suffix?.className).toContain('shrink-0')
+    expect(suffix?.className).not.toContain('truncate')
+    const modelName = Array.from(trigger!.querySelectorAll('span')).find(
+      (el) => el.textContent === 'gpt-5.2-with-a-very-long-model-name'
+    )
+    expect(modelName?.className).toContain('truncate')
+  })
+
   it('shows no effort suffix on the trigger when the effort intent is default', () => {
     useSettingsStore.setState({
       providers: [

--- a/src/renderer/src/pages/workspace/ComposerModelPicker.tsx
+++ b/src/renderer/src/pages/workspace/ComposerModelPicker.tsx
@@ -210,7 +210,7 @@ const ComposerModelPicker = (): React.JSX.Element | null => {
       {/* Two-level menu: the first level is two summary rows (effort, model) whose actual choices
           live in their submenus. This keeps the long provider catalog out of the top level, which
           now reads as a compact overview instead of a scrolling list. */}
-      <DropdownMenuContent side="top" align="end" sideOffset={8} className="w-72 p-1">
+      <DropdownMenuContent side="top" align="end" sideOffset={8} className="w-84 p-1">
         {showEffortRow ? (
           <DropdownMenuSub>
             <DropdownMenuSubTrigger className="items-center gap-2 px-2 py-1.5">
@@ -268,10 +268,12 @@ const ComposerModelPicker = (): React.JSX.Element | null => {
                 Provider and model for this chat
               </span>
             </span>
-            {/* The current pick echoes on the right (where the capsule used to sit): small bold
-                provider line with its own icon over the model name. */}
+            {/* The current pick echoes on the right inside a capsule: small bold provider line
+                with its own icon over the model name. The capsule is two lines tall, so it uses
+                a soft rounded-lg corner rather than the single-line pill's rounded-full; long
+                names ellipsize against the max width. */}
             {current ? (
-              <span className="flex max-w-[10rem] shrink-0 flex-col items-end text-right">
+              <span className="flex max-w-[12rem] shrink-0 flex-col items-end rounded-lg bg-bg-200 px-2 py-1 text-right">
                 <span className="flex max-w-full items-center gap-1 text-[11px] font-semibold leading-4 text-text-300">
                   <ProviderKindIcon
                     kindKey={providerKindKey(current.providerType, current.vendorId)}

--- a/src/renderer/src/pages/workspace/ComposerModelPicker.tsx
+++ b/src/renderer/src/pages/workspace/ComposerModelPicker.tsx
@@ -1,4 +1,4 @@
-import { AlertTriangle, Check, ChevronDown } from 'lucide-react'
+import { AlertTriangle, Brain, Check, ChevronDown, ChevronRight, Cpu } from 'lucide-react'
 
 import { Button } from '@/components/ui/button'
 import {
@@ -8,6 +8,9 @@ import {
   DropdownMenuItem,
   DropdownMenuLabel,
   DropdownMenuSeparator,
+  DropdownMenuSub,
+  DropdownMenuSubContent,
+  DropdownMenuSubTrigger,
   DropdownMenuTrigger
 } from '@/components/ui/dropdown-menu'
 import { cn } from '@/lib/utils'
@@ -21,6 +24,11 @@ import {
 } from '@/stores/settings-store'
 import { isProviderUsableByFramework } from '../../../../shared/settings'
 import { isModelBridgeSupported } from '../../../../shared/provider-registry'
+import {
+  resolveProviderEffectiveModel,
+  resolveProviderReasoningEffortProfile
+} from '../../../../shared/provider-reasoning-effort'
+import { resolveReasoningEffortControl } from '../../../../shared/reasoning-effort'
 import { incompatibilityReason } from './composer-model-picker-utils'
 
 const triggerClassName =
@@ -28,6 +36,37 @@ const triggerClassName =
 
 // Label for an option: the model name, or the provider name when the option carries no concrete model.
 const optionLabel = (option: ProviderModelOption): string => option.model || option.providerName
+
+// One radio row shape shared by both submenus: menuitemradio semantics, bold + trailing Check when
+// picked, optional leading icon and trailing hint. The three call sites (default effort, effort
+// rung, model) stay behavior-identical by construction.
+const MenuRadioItem = ({
+  checked,
+  onSelect,
+  leading,
+  hint,
+  children
+}: {
+  checked: boolean
+  onSelect: () => void
+  leading?: React.ReactNode
+  hint?: string
+  children: React.ReactNode
+}): React.JSX.Element => (
+  <DropdownMenuItem
+    role="menuitemradio"
+    aria-checked={checked}
+    onSelect={onSelect}
+    className={cn('gap-2', checked && 'font-medium')}
+  >
+    {leading}
+    <span className="min-w-0 flex-1 truncate">{children}</span>
+    {hint ? <span className="text-[11px] text-text-300">{hint}</span> : null}
+    {checked ? (
+      <Check className="size-4 shrink-0 text-primary" strokeWidth={2} aria-hidden="true" />
+    ) : null}
+  </DropdownMenuItem>
+)
 
 // Model/provider switcher shown in the composer toolbar. Reads the settings store directly (the store
 // is global) so the presentational ConversationPanel needn't thread provider state through. With no
@@ -45,10 +84,35 @@ const ComposerModelPicker = (): React.JSX.Element | null => {
   const agentFrameworkId = useSettingsStore((state) => state.agentFrameworkId)
   const agentFrameworks = useSettingsStore((state) => state.agentFrameworks)
   const frameworkEndpoints = useSettingsStore(selectFrameworkApiEndpoints)
+  const reasoningEffort = useSettingsStore((state) => state.reasoningEffort)
+  const setReasoningEffort = useSettingsStore((state) => state.setReasoningEffort)
 
   const frameworkName =
     agentFrameworks.find((framework) => framework.id === agentFrameworkId)?.displayName ??
     'this framework'
+
+  // Reasoning-effort state resolves through the same chain as the Settings page control: the
+  // effective model for the active provider, that model's static effort profile, then the control
+  // options the stored intent maps onto.
+  const activeProvider = providers.find((candidate) => candidate.id === activeProviderId)
+  const effectiveModel = resolveProviderEffectiveModel(activeProvider, activeModel)
+  const effortProfile = resolveProviderReasoningEffortProfile(activeProvider, effectiveModel)
+  const effortControl = resolveReasoningEffortControl(reasoningEffort, effortProfile)
+  const selectedEffortLabel = effortControl.options.find(
+    (option) => option.value === effortControl.selectedValue
+  )?.label
+
+  // The effort row only makes sense when the active provider's model can take an effort at all;
+  // without an active provider there is nothing the selection would apply to, so the row hides.
+  const showEffortRow =
+    activeProvider !== undefined && effortProfile.supported && effortControl.options.length > 0
+
+  // The trigger advertises a non-default effort as a suffix, derived from showEffortRow so the two
+  // visibility rules can never drift apart. 'default' means "whatever the provider does" — the
+  // common case — and stays quiet.
+  const effortSuffixLabel =
+    showEffortRow && reasoningEffort !== 'default' ? selectedEffortLabel : undefined
+  const defaultEffortChecked = reasoningEffort === 'default'
 
   // A provider is selectable only when it can actually drive the current framework (endpoint + type).
   const isCompatible = (provider: (typeof providers)[number], model: string): boolean =>
@@ -97,6 +161,14 @@ const ComposerModelPicker = (): React.JSX.Element | null => {
     (option) => option.providerId === activeProviderId && option.model === activeKeyModel
   )
 
+  // The Model row's capsule summarizes the current pick: model + provider, the provider alone when
+  // the option carries no concrete model, or a bare "Select" prompt when nothing is active.
+  const modelCapsuleLabel = current
+    ? current.model
+      ? `${current.model} · ${current.providerName}`
+      : current.providerName
+    : 'Select'
+
   // Group options by provider so official vendors show their catalog under one heading.
   const groups = providers
     .map((provider) => ({
@@ -125,8 +197,8 @@ const ComposerModelPicker = (): React.JSX.Element | null => {
                 {current ? (
                   <>
                     <span className="font-medium text-text-100">{optionLabel(current)}</span>
-                    {current.model ? (
-                      <span className="ml-1.5 text-text-300">· {current.providerName}</span>
+                    {effortSuffixLabel ? (
+                      <span className="ml-1.5 text-text-300">· {effortSuffixLabel}</span>
                     ) : null}
                   </>
                 ) : (
@@ -143,106 +215,181 @@ const ComposerModelPicker = (): React.JSX.Element | null => {
           <ChevronDown className="size-3.5 shrink-0" aria-hidden="true" />
         </Button>
       </DropdownMenuTrigger>
-      <DropdownMenuContent align="end" className="max-h-[320px] min-w-[15rem] overflow-y-auto">
-        {groups.map((group) => {
-          const compatible = group.options.some((option) =>
-            isCompatible(group.provider, option.model)
-          )
-          const endpointCompatible = isProviderUsableByFramework(
-            {
-              apiEndpoints: group.provider.apiEndpoints,
-              type: group.provider.type
-            },
-            { id: agentFrameworkId, supportedApiTypes: frameworkEndpoints }
-          )
-          const reason = compatible
-            ? undefined
-            : endpointCompatible && agentFrameworkId === 'codex'
-              ? `No model from ${group.provider.name} is supported over the Codex Chat Completions bridge.`
-              : incompatibilityReason(
-                  {
-                    apiEndpoints: group.provider.apiEndpoints,
-                    type: group.provider.type,
-                    name: group.provider.name
-                  },
-                  frameworkName,
-                  frameworkEndpoints
-                )
-
-          return (
-            <DropdownMenuGroup key={group.provider.id}>
-              <DropdownMenuLabel>{group.provider.name}</DropdownMenuLabel>
-              {compatible ? (
-                group.options.map((option) => {
-                  const isActive =
-                    option.providerId === activeProviderId && option.model === activeKeyModel
-                  const optionCompatible = isCompatible(group.provider, option.model)
-
-                  if (!optionCompatible) {
-                    // Endpoint is fine but this model is statically marked unsupported over the Codex
-                    // bridge. Grey it with a warning icon; the full reason is on hover (title) and read
-                    // by assistive tech (aria-label), so it isn't a long inline string.
-                    const optionReason = `${optionLabel(option)} is not supported over the Codex Chat Completions bridge.`
-                    return (
-                      <DropdownMenuItem
-                        key={`${option.providerId}:${option.model}`}
-                        aria-disabled
-                        aria-label={optionReason}
-                        title={optionReason}
-                        onSelect={(event) => event.preventDefault()}
-                        className="gap-2 text-text-300"
-                      >
-                        <AlertTriangle className="size-4 shrink-0" aria-hidden="true" />
-                        <span className="min-w-0 flex-1 truncate">{optionLabel(option)}</span>
-                        <span className="text-xs">unsupported</span>
-                      </DropdownMenuItem>
-                    )
+      {/* Two-level menu: the first level is two summary rows (effort, model) whose actual choices
+          live in their submenus. This keeps the long provider catalog out of the top level, which
+          now reads as a compact overview instead of a scrolling list. */}
+      <DropdownMenuContent side="top" align="end" sideOffset={8} className="w-72 p-1">
+        {showEffortRow ? (
+          <DropdownMenuSub>
+            <DropdownMenuSubTrigger className="items-center gap-2 px-2 py-1.5">
+              <Brain className="size-4 shrink-0 text-text-200" strokeWidth={2} aria-hidden="true" />
+              <span className="min-w-0 flex-1">
+                <span className="block text-[13px] font-medium leading-5">Reasoning effort</span>
+                <span className="block text-[11px] leading-4 text-text-300">
+                  How long the model thinks before answering
+                </span>
+              </span>
+              <span className="flex shrink-0 items-center gap-1 whitespace-nowrap rounded-full bg-bg-200 px-2 py-0.5 text-[11px] font-medium leading-4 text-text-100">
+                {defaultEffortChecked ? 'Default' : selectedEffortLabel}
+                <ChevronRight
+                  className="size-3 shrink-0 opacity-60"
+                  strokeWidth={2}
+                  aria-hidden="true"
+                />
+              </span>
+            </DropdownMenuSubTrigger>
+            <DropdownMenuSubContent className="w-56 p-1">
+              <MenuRadioItem
+                checked={defaultEffortChecked}
+                onSelect={() => void setReasoningEffort('default')}
+                hint="provider default"
+              >
+                Default
+              </MenuRadioItem>
+              {effortControl.options.map((option) => (
+                // Checked by concrete value, not intent: several intents can project onto one
+                // value, and the profile owns which one is selected.
+                <MenuRadioItem
+                  key={option.value}
+                  checked={
+                    reasoningEffort !== 'default' && option.value === effortControl.selectedValue
                   }
-
-                  return (
-                    <DropdownMenuItem
-                      key={`${option.providerId}:${option.model}`}
-                      role="menuitemradio"
-                      aria-checked={isActive}
-                      onSelect={() => void setActiveProvider(option.providerId, option.model)}
-                      className={cn('gap-2', isActive && 'font-medium')}
-                    >
-                      <ProviderKindIcon
-                        kindKey={providerKindKey(option.providerType, option.vendorId)}
-                        className="size-4 shrink-0"
-                      />
-                      <span className="min-w-0 flex-1 truncate">{optionLabel(option)}</span>
-                      {isActive ? (
-                        <Check
-                          className="size-4 shrink-0 text-primary"
-                          strokeWidth={2}
-                          aria-hidden="true"
-                        />
-                      ) : null}
-                    </DropdownMenuItem>
-                  )
-                })
-              ) : (
-                // An incompatible provider gets one greyed, non-actionable row: a short "Unavailable"
-                // label + warning icon, with the full reason on hover (title) and exposed to assistive
-                // tech (aria-label) — so the dropdown stays compact instead of wrapping a long
-                // sentence. It stays keyboard-reachable via roving focus (a `disabled` item is skipped,
-                // and a label is not focusable), aria-disabled marks it unselectable, and onSelect is
-                // prevented so it never switches the model.
-                <DropdownMenuItem
-                  aria-disabled
-                  aria-label={reason}
-                  title={reason}
-                  onSelect={(event) => event.preventDefault()}
-                  className="gap-2 text-text-300"
+                  onSelect={() => void setReasoningEffort(option.intent)}
                 >
-                  <AlertTriangle className="size-4 shrink-0" strokeWidth={2} aria-hidden="true" />
-                  <span className="min-w-0 flex-1 truncate">Unavailable for {frameworkName}</span>
-                </DropdownMenuItem>
-              )}
-            </DropdownMenuGroup>
-          )
-        })}
+                  {option.label}
+                </MenuRadioItem>
+              ))}
+            </DropdownMenuSubContent>
+          </DropdownMenuSub>
+        ) : null}
+        <DropdownMenuSub>
+          <DropdownMenuSubTrigger className="items-center gap-2 px-2 py-1.5">
+            {current ? (
+              <ProviderKindIcon
+                kindKey={providerKindKey(current.providerType, current.vendorId)}
+                className="size-4 shrink-0 text-text-200"
+              />
+            ) : (
+              <Cpu className="size-4 shrink-0 text-text-200" strokeWidth={2} aria-hidden="true" />
+            )}
+            <span className="min-w-0 flex-1">
+              <span className="block text-[13px] font-medium leading-5">Model</span>
+              <span className="block text-[11px] leading-4 text-text-300">
+                Provider and model for this chat
+              </span>
+            </span>
+            <span className="flex max-w-[10rem] shrink-0 items-center gap-1 whitespace-nowrap rounded-full bg-bg-200 px-2 py-0.5 text-[11px] font-medium leading-4 text-text-100">
+              <span className="min-w-0 truncate">{modelCapsuleLabel}</span>
+              <ChevronRight
+                className="size-3 shrink-0 opacity-60"
+                strokeWidth={2}
+                aria-hidden="true"
+              />
+            </span>
+          </DropdownMenuSubTrigger>
+          {/* The full grouped catalog (compatibility rows included) lives one level down so the
+              first level stays a summary; behavior per item is unchanged from the flat menu. */}
+          <DropdownMenuSubContent className="max-h-[320px] min-w-[15rem] overflow-y-auto p-1">
+            {groups.map((group) => {
+              const compatible = group.options.some((option) =>
+                isCompatible(group.provider, option.model)
+              )
+              const endpointCompatible = isProviderUsableByFramework(
+                {
+                  apiEndpoints: group.provider.apiEndpoints,
+                  type: group.provider.type
+                },
+                { id: agentFrameworkId, supportedApiTypes: frameworkEndpoints }
+              )
+              const reason = compatible
+                ? undefined
+                : endpointCompatible && agentFrameworkId === 'codex'
+                  ? `No model from ${group.provider.name} is supported over the Codex Chat Completions bridge.`
+                  : incompatibilityReason(
+                      {
+                        apiEndpoints: group.provider.apiEndpoints,
+                        type: group.provider.type,
+                        name: group.provider.name
+                      },
+                      frameworkName,
+                      frameworkEndpoints
+                    )
+
+              return (
+                <DropdownMenuGroup key={group.provider.id}>
+                  <DropdownMenuLabel>{group.provider.name}</DropdownMenuLabel>
+                  {compatible ? (
+                    group.options.map((option) => {
+                      const isActive =
+                        option.providerId === activeProviderId && option.model === activeKeyModel
+                      const optionCompatible = isCompatible(group.provider, option.model)
+
+                      if (!optionCompatible) {
+                        // Endpoint is fine but this model is statically marked unsupported over the Codex
+                        // bridge. Grey it with a warning icon; the full reason is on hover (title) and read
+                        // by assistive tech (aria-label), so it isn't a long inline string.
+                        const optionReason = `${optionLabel(option)} is not supported over the Codex Chat Completions bridge.`
+                        return (
+                          <DropdownMenuItem
+                            key={`${option.providerId}:${option.model}`}
+                            aria-disabled
+                            aria-label={optionReason}
+                            title={optionReason}
+                            onSelect={(event) => event.preventDefault()}
+                            className="gap-2 text-text-300"
+                          >
+                            <AlertTriangle className="size-4 shrink-0" aria-hidden="true" />
+                            <span className="min-w-0 flex-1 truncate">{optionLabel(option)}</span>
+                            <span className="text-xs">unsupported</span>
+                          </DropdownMenuItem>
+                        )
+                      }
+
+                      return (
+                        <MenuRadioItem
+                          key={`${option.providerId}:${option.model}`}
+                          checked={isActive}
+                          onSelect={() => void setActiveProvider(option.providerId, option.model)}
+                          leading={
+                            <ProviderKindIcon
+                              kindKey={providerKindKey(option.providerType, option.vendorId)}
+                              className="size-4 shrink-0"
+                            />
+                          }
+                        >
+                          {optionLabel(option)}
+                        </MenuRadioItem>
+                      )
+                    })
+                  ) : (
+                    // An incompatible provider gets one greyed, non-actionable row: a short "Unavailable"
+                    // label + warning icon, with the full reason on hover (title) and exposed to assistive
+                    // tech (aria-label) — so the dropdown stays compact instead of wrapping a long
+                    // sentence. It stays keyboard-reachable via roving focus (a `disabled` item is skipped,
+                    // and a label is not focusable), aria-disabled marks it unselectable, and onSelect is
+                    // prevented so it never switches the model.
+                    <DropdownMenuItem
+                      aria-disabled
+                      aria-label={reason}
+                      title={reason}
+                      onSelect={(event) => event.preventDefault()}
+                      className="gap-2 text-text-300"
+                    >
+                      <AlertTriangle
+                        className="size-4 shrink-0"
+                        strokeWidth={2}
+                        aria-hidden="true"
+                      />
+                      <span className="min-w-0 flex-1 truncate">
+                        Unavailable for {frameworkName}
+                      </span>
+                    </DropdownMenuItem>
+                  )}
+                </DropdownMenuGroup>
+              )
+            })}
+          </DropdownMenuSubContent>
+        </DropdownMenuSub>
         {hasUsable ? null : (
           <>
             <DropdownMenuSeparator />

--- a/src/renderer/src/pages/workspace/ComposerModelPicker.tsx
+++ b/src/renderer/src/pages/workspace/ComposerModelPicker.tsx
@@ -161,14 +161,6 @@ const ComposerModelPicker = (): React.JSX.Element | null => {
     (option) => option.providerId === activeProviderId && option.model === activeKeyModel
   )
 
-  // The Model row's capsule summarizes the current pick: model + provider, the provider alone when
-  // the option carries no concrete model, or a bare "Select" prompt when nothing is active.
-  const modelCapsuleLabel = current
-    ? current.model
-      ? `${current.model} · ${current.providerName}`
-      : current.providerName
-    : 'Select'
-
   // Group options by provider so official vendors show their catalog under one heading.
   const groups = providers
     .map((provider) => ({
@@ -263,29 +255,41 @@ const ComposerModelPicker = (): React.JSX.Element | null => {
           </DropdownMenuSub>
         ) : null}
         <DropdownMenuSub>
-          <DropdownMenuSubTrigger className="items-center gap-2 px-2 py-1.5">
-            {current ? (
-              <ProviderKindIcon
-                kindKey={providerKindKey(current.providerType, current.vendorId)}
-                className="size-4 shrink-0 text-text-200"
-              />
-            ) : (
-              <Cpu className="size-4 shrink-0 text-text-200" strokeWidth={2} aria-hidden="true" />
-            )}
+          <DropdownMenuSubTrigger
+            data-testid="model-row"
+            className="items-center gap-2 px-2 py-1.5"
+          >
+            {/* The leading icon stays a generic model glyph; the provider identity lives in the
+                two-line summary instead. */}
+            <Cpu className="size-4 shrink-0 text-text-200" strokeWidth={2} aria-hidden="true" />
             <span className="min-w-0 flex-1">
-              <span className="block text-[13px] font-medium leading-5">Model</span>
-              <span className="block text-[11px] leading-4 text-text-300">
-                Provider and model for this chat
-              </span>
+              {current ? (
+                <>
+                  {/* Provider line: small bold caption with the provider's own icon; the model
+                      name gets the primary line below it. */}
+                  <span className="flex items-center gap-1 text-[11px] font-semibold leading-4 text-text-300">
+                    <ProviderKindIcon
+                      kindKey={providerKindKey(current.providerType, current.vendorId)}
+                      className="size-3 shrink-0"
+                    />
+                    <span className="min-w-0 truncate">{current.providerName}</span>
+                  </span>
+                  <span className="block truncate text-[13px] font-medium leading-5">
+                    {optionLabel(current)}
+                  </span>
+                </>
+              ) : (
+                <>
+                  <span className="block text-[13px] font-medium leading-5">Model</span>
+                  <span className="block text-[11px] leading-4 text-text-300">Select</span>
+                </>
+              )}
             </span>
-            <span className="flex max-w-[10rem] shrink-0 items-center gap-1 whitespace-nowrap rounded-full bg-bg-200 px-2 py-0.5 text-[11px] font-medium leading-4 text-text-100">
-              <span className="min-w-0 truncate">{modelCapsuleLabel}</span>
-              <ChevronRight
-                className="size-3 shrink-0 opacity-60"
-                strokeWidth={2}
-                aria-hidden="true"
-              />
-            </span>
+            <ChevronRight
+              className="size-3.5 shrink-0 opacity-60"
+              strokeWidth={2}
+              aria-hidden="true"
+            />
           </DropdownMenuSubTrigger>
           {/* The full grouped catalog (compatibility rows included) lives one level down so the
               first level stays a summary; behavior per item is unchanged from the flat menu. */}

--- a/src/renderer/src/pages/workspace/ComposerModelPicker.tsx
+++ b/src/renderer/src/pages/workspace/ComposerModelPicker.tsx
@@ -273,26 +273,35 @@ const ComposerModelPicker = (): React.JSX.Element | null => {
                 a soft rounded-lg corner rather than the single-line pill's rounded-full; long
                 names ellipsize against the max width. */}
             {current ? (
-              <span className="flex max-w-[12rem] shrink-0 flex-col items-end rounded-lg bg-bg-200 px-2 py-1 text-right">
-                <span className="flex max-w-full items-center gap-1 text-[11px] font-semibold leading-4 text-text-300">
-                  <ProviderKindIcon
-                    kindKey={providerKindKey(current.providerType, current.vendorId)}
-                    className="size-3 shrink-0"
-                  />
-                  <span className="min-w-0 truncate">{current.providerName}</span>
+              <span className="flex shrink-0 items-center gap-1.5 rounded-lg bg-bg-200 px-2 py-1">
+                <span className="flex max-w-[12rem] flex-col items-end text-right">
+                  <span className="flex max-w-full items-center gap-1 text-[11px] font-semibold leading-4 text-text-300">
+                    <ProviderKindIcon
+                      kindKey={providerKindKey(current.providerType, current.vendorId)}
+                      className="size-3 shrink-0"
+                    />
+                    <span className="min-w-0 truncate">{current.providerName}</span>
+                  </span>
+                  <span className="block max-w-full truncate text-[13px] font-medium leading-5">
+                    {optionLabel(current)}
+                  </span>
                 </span>
-                <span className="block max-w-full truncate text-[13px] font-medium leading-5">
-                  {optionLabel(current)}
-                </span>
+                <ChevronRight
+                  className="size-3.5 shrink-0 opacity-60"
+                  strokeWidth={2}
+                  aria-hidden="true"
+                />
               </span>
             ) : (
-              <span className="shrink-0 text-[11px] text-text-300">Select</span>
+              <>
+                <span className="shrink-0 text-[11px] text-text-300">Select</span>
+                <ChevronRight
+                  className="size-3.5 shrink-0 opacity-60"
+                  strokeWidth={2}
+                  aria-hidden="true"
+                />
+              </>
             )}
-            <ChevronRight
-              className="size-3.5 shrink-0 opacity-60"
-              strokeWidth={2}
-              aria-hidden="true"
-            />
           </DropdownMenuSubTrigger>
           {/* The full grouped catalog (compatibility rows included) lives one level down so the
               first level stays a summary; behavior per item is unchanged from the flat menu. */}

--- a/src/renderer/src/pages/workspace/ComposerModelPicker.tsx
+++ b/src/renderer/src/pages/workspace/ComposerModelPicker.tsx
@@ -185,16 +185,22 @@ const ComposerModelPicker = (): React.JSX.Element | null => {
                   className="size-4"
                 />
               ) : null}
-              <span className="truncate">
+              <span className="flex min-w-0 items-center">
                 {current ? (
                   <>
-                    <span className="font-medium text-text-100">{optionLabel(current)}</span>
+                    {/* The model name alone ellipsizes under the trigger's max width; the effort
+                        suffix is the newer signal and stays fully visible. */}
+                    <span className="truncate font-medium text-text-100">
+                      {optionLabel(current)}
+                    </span>
                     {effortSuffixLabel ? (
-                      <span className="ml-1.5 text-text-300">· {effortSuffixLabel}</span>
+                      <span className="ml-1.5 shrink-0 whitespace-nowrap text-text-300">
+                        · {effortSuffixLabel}
+                      </span>
                     ) : null}
                   </>
                 ) : (
-                  'Select model'
+                  <span className="truncate">Select model</span>
                 )}
               </span>
             </>

--- a/src/renderer/src/pages/workspace/ComposerModelPicker.tsx
+++ b/src/renderer/src/pages/workspace/ComposerModelPicker.tsx
@@ -260,31 +260,32 @@ const ComposerModelPicker = (): React.JSX.Element | null => {
             className="items-center gap-2 px-2 py-1.5"
           >
             {/* The leading icon stays a generic model glyph; the provider identity lives in the
-                two-line summary instead. */}
+                right-hand two-line summary instead. */}
             <Cpu className="size-4 shrink-0 text-text-200" strokeWidth={2} aria-hidden="true" />
             <span className="min-w-0 flex-1">
-              {current ? (
-                <>
-                  {/* Provider line: small bold caption with the provider's own icon; the model
-                      name gets the primary line below it. */}
-                  <span className="flex items-center gap-1 text-[11px] font-semibold leading-4 text-text-300">
-                    <ProviderKindIcon
-                      kindKey={providerKindKey(current.providerType, current.vendorId)}
-                      className="size-3 shrink-0"
-                    />
-                    <span className="min-w-0 truncate">{current.providerName}</span>
-                  </span>
-                  <span className="block truncate text-[13px] font-medium leading-5">
-                    {optionLabel(current)}
-                  </span>
-                </>
-              ) : (
-                <>
-                  <span className="block text-[13px] font-medium leading-5">Model</span>
-                  <span className="block text-[11px] leading-4 text-text-300">Select</span>
-                </>
-              )}
+              <span className="block text-[13px] font-medium leading-5">Model</span>
+              <span className="block text-[11px] leading-4 text-text-300">
+                Provider and model for this chat
+              </span>
             </span>
+            {/* The current pick echoes on the right (where the capsule used to sit): small bold
+                provider line with its own icon over the model name. */}
+            {current ? (
+              <span className="flex max-w-[10rem] shrink-0 flex-col items-end text-right">
+                <span className="flex max-w-full items-center gap-1 text-[11px] font-semibold leading-4 text-text-300">
+                  <ProviderKindIcon
+                    kindKey={providerKindKey(current.providerType, current.vendorId)}
+                    className="size-3 shrink-0"
+                  />
+                  <span className="min-w-0 truncate">{current.providerName}</span>
+                </span>
+                <span className="block max-w-full truncate text-[13px] font-medium leading-5">
+                  {optionLabel(current)}
+                </span>
+              </span>
+            ) : (
+              <span className="shrink-0 text-[11px] text-text-300">Select</span>
+            )}
             <ChevronRight
               className="size-3.5 shrink-0 opacity-60"
               strokeWidth={2}


### PR DESCRIPTION
## Summary

Reworks the composer model picker into a single combined picker for model + reasoning effort. The trigger now shows `model · effort` (provider name removed). The first-level menu is two summary rows — **Reasoning effort** (current level capsule) and **Model** (selected model · provider capsule) — each opening a submenu: effort levels adapted to the active model's reasoning profile, and the full grouped provider catalog. Built entirely on the existing shared resolution chain (`resolveProviderEffectiveModel` → `resolveProviderReasoningEffortProfile` → `resolveReasoningEffortControl`) and the global settings store; zero changes to shared / main / preload.

## Highlights

- The composer trigger surfaces the current reasoning effort next to the model (e.g. `deepseek-v4-pro · High`); the provider name moves into the Model menu row.
- Reasoning effort is now switchable in place from the composer — options adapt per provider/model (e.g. OpenAI Low–XHigh, DeepSeek None/High/Max) and the row hides entirely for models without reasoning support.
- Changes apply live where the framework supports it (Claude Code, Codex) or on next reconnect (opencode) — same behavior as the Settings control, which stays in sync automatically.

## Impact

- Renderer only: `ComposerModelPicker.tsx` + its render test. Settings page, stores, IPC, main process untouched.
- Preserved picker behaviors: provider grouping, incompatibility-reason rows, Codex-bridge unsupported rows, warning triggers, and the `Open Settings` escape hatch (now at the first level).

## Test Results

- `ComposerModelPicker.render.test.tsx`: 16/16 — submenu keyboard navigation, per-profile options (standard-5 five rungs, DeepSeek None/High/Max), capsule echo, `aria-checked`/Check markers, all pre-existing degradation states.
- Related suites: 172/172 (`reasoning-effort`, `provider-reasoning-effort`, `settings-store`, `ReasoningEffortSelect`, `workspace-components`, `ConversationPanel`).
- eslint/prettier clean; tsc (web) reports no errors in the changed files.
- Manual walkthrough in the real app (headless web build): trigger suffix, two-level menu, per-model option recompute, and live persistence verified end to end.

## Potential Issues

- The two-level structure adds one click to model switching (accepted in the design review).
- Submenu flyout direction is driven by Radix collision detection (opens left or right depending on space); behavior and tests do not depend on direction.

## Authors

- @roxi3906