### PR TITLE
fix(permission): apply dark syntax token colors

### DIFF
--- a/src/renderer/src/pages/workspace/WorkspaceToolCodeBlock.test.tsx
+++ b/src/renderer/src/pages/workspace/WorkspaceToolCodeBlock.test.tsx
@@ -42,6 +42,7 @@ describe('WorkspaceToolCodeBlock', () => {
   afterEach(() => {
     act(() => root.unmount())
     container.remove()
+    document.documentElement.classList.remove('dark')
     vi.clearAllMocks()
   })
 
@@ -57,6 +58,19 @@ describe('WorkspaceToolCodeBlock', () => {
     // The htmlStyle color must reach the DOM; jsdom normalizes the hex to rgb.
     expect((token as HTMLElement | null)?.style.color).toBe('rgb(215, 58, 73)')
     expect((token as HTMLElement | null)?.style.getPropertyValue('--shiki-dark')).toBe('#F97583')
+  })
+
+  it('uses the Shiki dark token color when the app is in dark mode', async () => {
+    document.documentElement.classList.add('dark')
+    root = createRoot(container)
+    await act(async () => {
+      root.render(<WorkspaceToolCodeBlock code="import" language="python" />)
+    })
+
+    const token = container.querySelector('span[style]')
+
+    // Shiki leaves the light color inline, so the dark utility must override it with !important.
+    expect(token?.className).toContain('dark:[color:var(--shiki-dark)]!')
   })
 
   it('does not report a successful copy when the Clipboard API rejects the request', async () => {

--- a/src/renderer/src/pages/workspace/WorkspaceToolCodeBlock.tsx
+++ b/src/renderer/src/pages/workspace/WorkspaceToolCodeBlock.tsx
@@ -112,8 +112,10 @@ const WorkspaceToolCodeBlock = ({
                   {line.map((token, tokenIndex) => (
                     <span
                       key={tokenIndex}
+                      className="dark:[color:var(--shiki-dark)]!"
                       // Dual-theme Shiki output puts the color (and a --shiki-dark var) in htmlStyle,
-                      // not token.color, so apply htmlStyle and fall back to color for single themes.
+                      // not token.color. Apply htmlStyle, then let the app's dark class switch to the
+                      // paired token color; !important is required to beat Shiki's inline light color.
                       style={{
                         color: token.color,
                         ...(token.htmlStyle as React.CSSProperties | undefined),


### PR DESCRIPTION
## Problem

Permission approval code blocks received both light and dark Shiki token colors, but continued to paint the inline light color after the app switched to dark mode. Plain identifiers therefore became nearly black against the dark code surface.

## Proposed change

- Apply the paired Shiki dark token color under the existing app-level dark theme selector.
- Use an important utility so the dark color overrides the inline light color emitted by Shiki.
- Add a regression test that exercises the shared code block in dark mode.

## Scope and non-goals

This is limited to syntax token presentation in the shared workspace tool code block used by Permission previews. It does not change permission decisions, notebook execution, or code contents.

## Acceptance criteria and validation

- [x] Dark Permission code tokens use the Shiki dark palette while light mode remains unchanged.
- [x] Targeted WorkspaceToolCodeBlock tests pass (4 tests).
- [x] npm run typecheck
- [x] npm run lint (0 errors; 26 existing warnings)
- [x] npm run build:web
- [x] npm test (506 files passed, 10 skipped; 7217 tests passed, 113 skipped)

## Review focus

Confirm the generated dark utility overrides the inline light token color and that the regression test guards the app dark-mode path.