### PR TITLE
fix(preview-tabs): keep active preview tabs visible

### DIFF
--- a/src/renderer/src/pages/workspace/ConversationPanel.tsx
+++ b/src/renderer/src/pages/workspace/ConversationPanel.tsx
@@ -54,6 +54,7 @@ import { PermissionApprovalControls } from './PermissionApprovalControls'
 import { normalizeRunFailureError } from './error-report'
 import { ReportErrorDialog } from './ReportErrorDialog'
 import { SessionInterruptedBanner } from './SessionInterruptedBanner'
+import { ExtensionPreservingFileName } from './ExtensionPreservingFileName'
 import { WorkspaceMessageScroller } from './WorkspaceMessageScroller'
 
 const composerInteractiveTransitionClassName = 'transition-colors duration-200 ease-out'
@@ -431,9 +432,10 @@ const ConversationPanel = ({
                                   aria-hidden="true"
                                 />
                                 <div className="min-w-0 flex-1">
-                                  <div className="truncate text-[12px] leading-4">
-                                    {attachmentName}
-                                  </div>
+                                  <ExtensionPreservingFileName
+                                    name={attachmentName}
+                                    className="text-[12px] leading-4"
+                                  />
                                   <div className="truncate text-[11px] leading-3 text-text-300">
                                     {formatAttachmentSize(attachment.size)}
                                   </div>
@@ -481,9 +483,10 @@ const ConversationPanel = ({
                                   aria-hidden="true"
                                 />
                                 <div className="min-w-0 flex-1">
-                                  <div className="truncate text-[12px] leading-4">
-                                    {transfer.name}
-                                  </div>
+                                  <ExtensionPreservingFileName
+                                    name={transfer.name}
+                                    className="text-[12px] leading-4"
+                                  />
                                   <div
                                     className={`truncate text-[11px] leading-3 ${
                                       transfer.status === 'error' ? 'text-red-600' : 'text-text-300'

--- a/src/renderer/src/pages/workspace/ExtensionPreservingFileName.test.tsx
+++ b/src/renderer/src/pages/workspace/ExtensionPreservingFileName.test.tsx
@@ -1,0 +1,59 @@
+// @vitest-environment jsdom
+import { act } from 'react'
+import { createRoot, type Root } from 'react-dom/client'
+import { afterEach, beforeEach, describe, expect, it } from 'vitest'
+
+import { ExtensionPreservingFileName } from './ExtensionPreservingFileName'
+
+describe('ExtensionPreservingFileName', () => {
+  let container: HTMLDivElement
+  let root: Root
+
+  beforeEach(() => {
+    container = document.createElement('div')
+    document.body.appendChild(container)
+    root = createRoot(container)
+  })
+
+  afterEach(() => {
+    act(() => root.unmount())
+    container.remove()
+  })
+
+  const renderName = (name: string): void => {
+    act(() => root.render(<ExtensionPreservingFileName name={name} />))
+  }
+
+  it('separates only the final extension from a multi-dot filename', () => {
+    renderName('experiment.results.final.csv')
+
+    expect(container.querySelector('[data-testid="file-name-prefix"]')?.textContent).toBe(
+      'experiment.results.final'
+    )
+    expect(container.querySelector('[data-testid="file-name-extension"]')?.textContent).toBe('.csv')
+  })
+
+  it.each(['README', '.env'])('truncates %s as one name without an extension suffix', (name) => {
+    renderName(name)
+
+    expect(container.querySelector('[data-testid="file-name-prefix"]')?.textContent).toBe(name)
+    expect(container.querySelector('[data-testid="file-name-extension"]')).toBeNull()
+  })
+
+  it('keeps a short filename complete', () => {
+    renderName('note.md')
+
+    expect(container.textContent).toBe('note.md')
+  })
+
+  it('reserves room for the prefix when an extension is unusually long', () => {
+    renderName('sample.verylongcustomextension')
+
+    expect(container.querySelector('[data-testid="file-name-prefix"]')?.className).toContain(
+      'flex-1'
+    )
+    const extension = container.querySelector('[data-testid="file-name-extension"]')
+    expect(extension?.className).toContain('max-w-[50%]')
+    expect(extension?.className).toContain('text-ellipsis')
+  })
+})

--- a/src/renderer/src/pages/workspace/ExtensionPreservingFileName.test.tsx
+++ b/src/renderer/src/pages/workspace/ExtensionPreservingFileName.test.tsx
@@ -28,18 +28,17 @@ describe('ExtensionPreservingFileName', () => {
     renderName('very_long_experiment_analysis_result_2025.csv')
 
     expect(container.querySelector('[data-testid="file-name-head"]')?.textContent).toBe(
-      'very_long_experiment_analysis_'
+      'very_long_experiment_analysis_result'
     )
-    expect(container.querySelector('[data-testid="file-name-tail"]')?.textContent).toBe(
-      'result_2025'
-    )
+    expect(container.querySelector('[data-testid="file-name-tail"]')?.textContent).toBe('_2025')
+    expect(container.querySelector('[data-testid="file-name-ellipsis"]')).toBeNull()
     expect(container.querySelector('[data-testid="file-name-extension"]')?.textContent).toBe('.csv')
   })
 
   it.each(['README', '.env'])('truncates %s as one name without an extension suffix', (name) => {
     renderName(name)
 
-    expect(container.querySelector('[data-testid="file-name-head"]')?.textContent).toBe(name)
+    expect(container.textContent).toBe(name)
     expect(container.querySelector('[data-testid="file-name-extension"]')).toBeNull()
   })
 
@@ -47,6 +46,16 @@ describe('ExtensionPreservingFileName', () => {
     renderName('note.md')
 
     expect(container.textContent).toBe('note.md')
+  })
+
+  it('uses a shorter abbreviation in compact file cards', () => {
+    act(() =>
+      root.render(
+        <ExtensionPreservingFileName name="very_long_experiment_analysis_result_2025.csv" compact />
+      )
+    )
+
+    expect(container.textContent).toBe('ver...5.csv')
   })
 
   it('reserves room for the basename head when an extension is unusually long', () => {

--- a/src/renderer/src/pages/workspace/ExtensionPreservingFileName.test.tsx
+++ b/src/renderer/src/pages/workspace/ExtensionPreservingFileName.test.tsx
@@ -1,7 +1,7 @@
 // @vitest-environment jsdom
 import { act } from 'react'
 import { createRoot, type Root } from 'react-dom/client'
-import { afterEach, beforeEach, describe, expect, it } from 'vitest'
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest'
 
 import { ExtensionPreservingFileName } from './ExtensionPreservingFileName'
 
@@ -17,6 +17,8 @@ describe('ExtensionPreservingFileName', () => {
 
   afterEach(() => {
     act(() => root.unmount())
+    vi.restoreAllMocks()
+    vi.unstubAllGlobals()
     container.remove()
   })
 
@@ -48,20 +50,92 @@ describe('ExtensionPreservingFileName', () => {
     expect(container.textContent).toBe('note.md')
   })
 
-  it('uses a shorter abbreviation in compact file cards', () => {
+  it('uses a shorter abbreviation in compact file cards only when the name overflows', () => {
+    vi.spyOn(HTMLElement.prototype, 'getBoundingClientRect').mockImplementation(function (
+      this: HTMLElement
+    ) {
+      const width = this.getAttribute('data-testid') === 'file-name-root' ? 50 : 200
+      return { width } as DOMRect
+    })
+
     act(() =>
       root.render(
         <ExtensionPreservingFileName name="very_long_experiment_analysis_result_2025.csv" compact />
       )
     )
 
-    expect(container.textContent).toBe('ver...5.csv')
+    expect(container.querySelector('[data-testid="file-name-head"]')?.textContent).toBe('ver')
+    expect(container.querySelector('[data-testid="file-name-ellipsis"]')?.textContent).toBe('...')
+    expect(container.querySelector('[data-testid="file-name-tail"]')?.textContent).toBe('5')
+  })
+
+  it('restores the full compact-card name after its available width grows', () => {
+    let availableWidth = 50
+    let notifyResize: (() => void) | undefined
+    vi.spyOn(HTMLElement.prototype, 'getBoundingClientRect').mockImplementation(function (
+      this: HTMLElement
+    ) {
+      const width = this.getAttribute('data-testid') === 'file-name-root' ? availableWidth : 200
+      return { width } as DOMRect
+    })
+    vi.stubGlobal(
+      'ResizeObserver',
+      class {
+        constructor(callback: ResizeObserverCallback) {
+          notifyResize = () => callback([], this as unknown as ResizeObserver)
+        }
+
+        observe = vi.fn()
+        disconnect = vi.fn()
+      }
+    )
+
+    act(() =>
+      root.render(
+        <ExtensionPreservingFileName name="very_long_experiment_analysis_result_2025.csv" compact />
+      )
+    )
+    expect(container.querySelector('[data-testid="file-name-head"]')?.textContent).toBe('ver')
+    expect(container.querySelector('[data-testid="file-name-ellipsis"]')).not.toBeNull()
+
+    availableWidth = 300
+    act(() => notifyResize?.())
+
+    expect(container.querySelector('[data-testid="file-name-head"]')?.textContent).toBe(
+      'very_long_experiment_analysis_result'
+    )
+    expect(container.querySelector('[data-testid="file-name-ellipsis"]')).toBeNull()
+    expect(container.querySelector('[data-testid="file-name-tail"]')?.textContent).toBe('_2025')
+  })
+
+  it('keeps an emoji filename ending intact in compact file cards', () => {
+    vi.spyOn(HTMLElement.prototype, 'getBoundingClientRect').mockImplementation(function (
+      this: HTMLElement
+    ) {
+      const width = this.getAttribute('data-testid') === 'file-name-root' ? 50 : 200
+      return { width } as DOMRect
+    })
+
+    act(() =>
+      root.render(
+        <ExtensionPreservingFileName
+          name="very_long_experiment_analysis_result_2025_😀.csv"
+          compact
+        />
+      )
+    )
+
+    expect(container.querySelector('[data-testid="file-name-head"]')?.textContent).toBe('ver')
+    expect(container.querySelector('[data-testid="file-name-tail"]')?.textContent).toBe('😀')
   })
 
   it('reserves room for the basename head when an extension is unusually long', () => {
     renderName('sample.verylongcustomextension')
 
-    expect(container.querySelector('[data-testid="file-name-head"]')?.className).toContain('flex-1')
+    expect(container.querySelector('[data-testid="file-name-head"]')?.className).toContain('shrink')
+    expect(container.querySelector('[data-testid="file-name-head"]')?.className).not.toContain(
+      'flex-1'
+    )
     const extension = container.querySelector('[data-testid="file-name-extension"]')
     expect(extension?.className).toContain('max-w-[50%]')
     expect(extension?.className).toContain('text-ellipsis')

--- a/src/renderer/src/pages/workspace/ExtensionPreservingFileName.test.tsx
+++ b/src/renderer/src/pages/workspace/ExtensionPreservingFileName.test.tsx
@@ -24,11 +24,14 @@ describe('ExtensionPreservingFileName', () => {
     act(() => root.render(<ExtensionPreservingFileName name={name} />))
   }
 
-  it('separates only the final extension from a multi-dot filename', () => {
-    renderName('experiment.results.final.csv')
+  it('keeps the basename tail and final extension visible for a long filename', () => {
+    renderName('very_long_experiment_analysis_result_2025.csv')
 
-    expect(container.querySelector('[data-testid="file-name-prefix"]')?.textContent).toBe(
-      'experiment.results.final'
+    expect(container.querySelector('[data-testid="file-name-head"]')?.textContent).toBe(
+      'very_long_experiment_analysis_'
+    )
+    expect(container.querySelector('[data-testid="file-name-tail"]')?.textContent).toBe(
+      'result_2025'
     )
     expect(container.querySelector('[data-testid="file-name-extension"]')?.textContent).toBe('.csv')
   })
@@ -36,7 +39,7 @@ describe('ExtensionPreservingFileName', () => {
   it.each(['README', '.env'])('truncates %s as one name without an extension suffix', (name) => {
     renderName(name)
 
-    expect(container.querySelector('[data-testid="file-name-prefix"]')?.textContent).toBe(name)
+    expect(container.querySelector('[data-testid="file-name-head"]')?.textContent).toBe(name)
     expect(container.querySelector('[data-testid="file-name-extension"]')).toBeNull()
   })
 
@@ -46,12 +49,10 @@ describe('ExtensionPreservingFileName', () => {
     expect(container.textContent).toBe('note.md')
   })
 
-  it('reserves room for the prefix when an extension is unusually long', () => {
+  it('reserves room for the basename head when an extension is unusually long', () => {
     renderName('sample.verylongcustomextension')
 
-    expect(container.querySelector('[data-testid="file-name-prefix"]')?.className).toContain(
-      'flex-1'
-    )
+    expect(container.querySelector('[data-testid="file-name-head"]')?.className).toContain('flex-1')
     const extension = container.querySelector('[data-testid="file-name-extension"]')
     expect(extension?.className).toContain('max-w-[50%]')
     expect(extension?.className).toContain('text-ellipsis')

--- a/src/renderer/src/pages/workspace/ExtensionPreservingFileName.tsx
+++ b/src/renderer/src/pages/workspace/ExtensionPreservingFileName.tsx
@@ -1,25 +1,23 @@
 import { cn } from '@/lib/utils'
 
+import { getExtensionPreservingFileNameParts } from './extension-preserving-file-name'
+
 type ExtensionPreservingFileNameProps = {
   name: string
   className?: string
+  compact?: boolean
 }
-
-const BASENAME_TAIL_LENGTH = 11
 
 // Gives the basename room to truncate while keeping its ending and common final extensions visible.
 const ExtensionPreservingFileName = ({
   name,
-  className
+  className,
+  compact = false
 }: ExtensionPreservingFileNameProps): React.JSX.Element => {
-  const extensionIndex = name.lastIndexOf('.')
-  const hasExtension = extensionIndex > 0
-  const basename = hasExtension ? name.slice(0, extensionIndex) : name
-  const extension = hasExtension ? name.slice(extensionIndex) : ''
-  const hasLongBasename = basename.length > BASENAME_TAIL_LENGTH
-  // Split only long names so short filenames retain their original, uninterrupted rendering.
-  const head = hasLongBasename ? basename.slice(0, -BASENAME_TAIL_LENGTH) : basename
-  const tail = hasLongBasename ? basename.slice(-BASENAME_TAIL_LENGTH) : ''
+  const { head, tail, extension, isCompactAbbreviation } = getExtensionPreservingFileNameParts(
+    name,
+    compact
+  )
 
   return (
     <span
@@ -28,14 +26,19 @@ const ExtensionPreservingFileName = ({
         className
       )}
     >
-      <span data-testid="file-name-head" className="min-w-0 flex-1 truncate">
+      <span
+        data-testid="file-name-head"
+        className={cn('min-w-0', isCompactAbbreviation ? 'shrink-0' : 'flex-1 truncate')}
+      >
         {head}
       </span>
+      {isCompactAbbreviation ? (
+        <span data-testid="file-name-ellipsis" className="shrink-0">
+          ...
+        </span>
+      ) : null}
       {tail ? (
-        <span
-          data-testid="file-name-tail"
-          className="max-w-[50%] shrink-0 overflow-hidden text-ellipsis"
-        >
+        <span data-testid="file-name-tail" className="shrink-0">
           {tail}
         </span>
       ) : null}

--- a/src/renderer/src/pages/workspace/ExtensionPreservingFileName.tsx
+++ b/src/renderer/src/pages/workspace/ExtensionPreservingFileName.tsx
@@ -5,15 +5,21 @@ type ExtensionPreservingFileNameProps = {
   className?: string
 }
 
-// Gives the basename room to truncate while keeping common final extensions fully visible.
+const BASENAME_TAIL_LENGTH = 11
+
+// Gives the basename room to truncate while keeping its ending and common final extensions visible.
 const ExtensionPreservingFileName = ({
   name,
   className
 }: ExtensionPreservingFileNameProps): React.JSX.Element => {
   const extensionIndex = name.lastIndexOf('.')
   const hasExtension = extensionIndex > 0
-  const prefix = hasExtension ? name.slice(0, extensionIndex) : name
+  const basename = hasExtension ? name.slice(0, extensionIndex) : name
   const extension = hasExtension ? name.slice(extensionIndex) : ''
+  const hasLongBasename = basename.length > BASENAME_TAIL_LENGTH
+  // Split only long names so short filenames retain their original, uninterrupted rendering.
+  const head = hasLongBasename ? basename.slice(0, -BASENAME_TAIL_LENGTH) : basename
+  const tail = hasLongBasename ? basename.slice(-BASENAME_TAIL_LENGTH) : ''
 
   return (
     <span
@@ -22,9 +28,17 @@ const ExtensionPreservingFileName = ({
         className
       )}
     >
-      <span data-testid="file-name-prefix" className="min-w-0 flex-1 truncate">
-        {prefix}
+      <span data-testid="file-name-head" className="min-w-0 flex-1 truncate">
+        {head}
       </span>
+      {tail ? (
+        <span
+          data-testid="file-name-tail"
+          className="max-w-[50%] shrink-0 overflow-hidden text-ellipsis"
+        >
+          {tail}
+        </span>
+      ) : null}
       {extension ? (
         <span
           data-testid="file-name-extension"

--- a/src/renderer/src/pages/workspace/ExtensionPreservingFileName.tsx
+++ b/src/renderer/src/pages/workspace/ExtensionPreservingFileName.tsx
@@ -1,0 +1,40 @@
+import { cn } from '@/lib/utils'
+
+type ExtensionPreservingFileNameProps = {
+  name: string
+  className?: string
+}
+
+// Gives the basename room to truncate while keeping common final extensions fully visible.
+const ExtensionPreservingFileName = ({
+  name,
+  className
+}: ExtensionPreservingFileNameProps): React.JSX.Element => {
+  const extensionIndex = name.lastIndexOf('.')
+  const hasExtension = extensionIndex > 0
+  const prefix = hasExtension ? name.slice(0, extensionIndex) : name
+  const extension = hasExtension ? name.slice(extensionIndex) : ''
+
+  return (
+    <span
+      className={cn(
+        'flex min-w-0 max-w-full items-center overflow-hidden whitespace-nowrap',
+        className
+      )}
+    >
+      <span data-testid="file-name-prefix" className="min-w-0 flex-1 truncate">
+        {prefix}
+      </span>
+      {extension ? (
+        <span
+          data-testid="file-name-extension"
+          className="max-w-[50%] shrink-0 overflow-hidden text-ellipsis"
+        >
+          {extension}
+        </span>
+      ) : null}
+    </span>
+  )
+}
+
+export { ExtensionPreservingFileName }

--- a/src/renderer/src/pages/workspace/ExtensionPreservingFileName.tsx
+++ b/src/renderer/src/pages/workspace/ExtensionPreservingFileName.tsx
@@ -1,3 +1,5 @@
+import { useLayoutEffect, useRef, useState } from 'react'
+
 import { cn } from '@/lib/utils'
 
 import { getExtensionPreservingFileNameParts } from './extension-preserving-file-name'
@@ -14,21 +16,55 @@ const ExtensionPreservingFileName = ({
   className,
   compact = false
 }: ExtensionPreservingFileNameProps): React.JSX.Element => {
+  const rootRef = useRef<HTMLSpanElement>(null)
+  const measureRef = useRef<HTMLSpanElement>(null)
+  const [useCompactAbbreviation, setUseCompactAbbreviation] = useState(compact)
+
+  useLayoutEffect(() => {
+    if (!compact) return
+
+    const updateAbbreviation = (): void => {
+      const availableWidth = rootRef.current?.getBoundingClientRect().width ?? 0
+      const requiredWidth = measureRef.current?.getBoundingClientRect().width ?? 0
+      if (availableWidth === 0 || requiredWidth === 0) return
+      setUseCompactAbbreviation(requiredWidth > availableWidth)
+    }
+
+    updateAbbreviation()
+    const root = rootRef.current
+    if (!root || typeof ResizeObserver === 'undefined') return
+
+    const observer = new ResizeObserver(updateAbbreviation)
+    observer.observe(root)
+    return () => observer.disconnect()
+  }, [compact, name])
+
   const { head, tail, extension, isCompactAbbreviation } = getExtensionPreservingFileNameParts(
     name,
-    compact
+    compact && useCompactAbbreviation
   )
 
   return (
     <span
+      ref={rootRef}
+      data-testid="file-name-root"
       className={cn(
         'flex min-w-0 max-w-full items-center overflow-hidden whitespace-nowrap',
         className
       )}
     >
+      {compact ? (
+        <span
+          ref={measureRef}
+          aria-hidden="true"
+          className="pointer-events-none absolute invisible whitespace-nowrap"
+        >
+          {name}
+        </span>
+      ) : null}
       <span
         data-testid="file-name-head"
-        className={cn('min-w-0', isCompactAbbreviation ? 'shrink-0' : 'flex-1 truncate')}
+        className={cn('min-w-0', isCompactAbbreviation ? 'shrink-0' : 'shrink truncate')}
       >
         {head}
       </span>

--- a/src/renderer/src/pages/workspace/PreviewFileSurface.tsx
+++ b/src/renderer/src/pages/workspace/PreviewFileSurface.tsx
@@ -4,6 +4,7 @@ import { Button } from '@/components/ui/button'
 import { Tooltip, TooltipContent, TooltipProvider, TooltipTrigger } from '@/components/ui/tooltip'
 import type { PreviewFileItem } from '@/stores/preview-workbench-store'
 
+import { ExtensionPreservingFileName } from './ExtensionPreservingFileName'
 import { ManagedFileDownloadButton } from './ManagedFileDownloadButton'
 import { PreviewFileContent } from './previews/PreviewFileContent'
 
@@ -14,26 +15,6 @@ type PreviewFileSurfaceProps = {
   tooltipClassName?: string
   onClose: () => void
   onOpenFullScreen?: () => void
-}
-
-// Keeps the identifying tail and extension visible while the flexible prefix owns the ellipsis.
-const MiddleEllipsisFileName = ({ name }: { name: string }): React.JSX.Element => {
-  const extensionIndex = name.lastIndexOf('.')
-  const extensionLength = extensionIndex > 0 ? name.length - extensionIndex : 0
-  const trailingLength = Math.min(name.length, Math.max(extensionLength + 10, 18))
-  const splitIndex = Math.max(1, name.length - trailingLength)
-
-  return (
-    <span className="flex min-w-0 max-w-full flex-1 items-center overflow-hidden whitespace-nowrap">
-      <span className="min-w-0 truncate">{name.slice(0, splitIndex)}</span>
-      <span
-        data-testid="preview-title-tail"
-        className="min-w-0 max-w-[65%] shrink overflow-hidden text-ellipsis [direction:rtl] [unicode-bidi:plaintext]"
-      >
-        {name.slice(splitIndex)}
-      </span>
-    </span>
-  )
 }
 
 // The optional callback makes the maximize action available only in the compact workbench panel;
@@ -55,7 +36,7 @@ const PreviewFileHeader = ({
       <Tooltip>
         <TooltipTrigger asChild>
           <span className="min-w-0 flex-1 text-[12px] font-medium text-text-000">
-            <MiddleEllipsisFileName name={item.name} />
+            <ExtensionPreservingFileName name={item.name} className="flex-1" />
           </span>
         </TooltipTrigger>
         <TooltipContent className={tooltipClassName}>{item.title}</TooltipContent>
@@ -129,4 +110,4 @@ const PreviewFileSurface = ({
   </div>
 )
 
-export { MiddleEllipsisFileName, PreviewFileSurface }
+export { PreviewFileSurface }

--- a/src/renderer/src/pages/workspace/PreviewPanel.test.tsx
+++ b/src/renderer/src/pages/workspace/PreviewPanel.test.tsx
@@ -205,8 +205,11 @@ describe('PreviewPanel', () => {
     expect(tabBar?.className).toContain('min-w-0')
     expect(tabBar?.className).toContain('w-full')
     expect(tabBar?.querySelector('[role="tab"][aria-selected="true"]')).not.toBeNull()
-    expect(fileTab?.querySelector('[data-testid="file-name-prefix"]')?.textContent).toBe(
-      'global_climate_anomaly_analysis_1850-2025'
+    expect(fileTab?.querySelector('[data-testid="file-name-head"]')?.textContent).toBe(
+      'global_climate_anomaly_analysi'
+    )
+    expect(fileTab?.querySelector('[data-testid="file-name-tail"]')?.textContent).toBe(
+      's_1850-2025'
     )
     const tabExtension = fileTab?.querySelector('[data-testid="file-name-extension"]')
     expect(tabExtension?.textContent).toBe('.csv')

--- a/src/renderer/src/pages/workspace/PreviewPanel.test.tsx
+++ b/src/renderer/src/pages/workspace/PreviewPanel.test.tsx
@@ -181,7 +181,7 @@ describe('PreviewPanel', () => {
 
     const card = container.querySelector('[data-testid="preview-card"]')
     const header = card?.querySelector('[data-testid="preview-card-header"]')
-    const titleTail = header?.querySelector('[data-testid="preview-title-tail"]')
+    const headerFileName = header?.querySelector('[data-testid="file-name-root"]')
     const tabBar = container.querySelector('[aria-label="Open previews"]')
     const fileTab = tabBar?.querySelector(`[role="tab"][title="${name}"]`)
 
@@ -193,9 +193,15 @@ describe('PreviewPanel', () => {
     expect(card?.parentElement?.className).toContain('pr-1')
     expect(card?.parentElement?.className).not.toContain('px-2')
     expect(header?.className).toContain('h-8')
-    expect(titleTail?.textContent?.endsWith('.csv')).toBe(true)
-    expect(titleTail?.className).toContain('max-w-')
-    expect(titleTail?.className).toContain('overflow-hidden')
+    expect(headerFileName?.querySelector('[data-testid="file-name-head"]')?.textContent).toBe(
+      'global_climate_anomaly_analysis_1850'
+    )
+    expect(headerFileName?.querySelector('[data-testid="file-name-tail"]')?.textContent).toBe(
+      '-2025'
+    )
+    expect(headerFileName?.querySelector('[data-testid="file-name-extension"]')?.textContent).toBe(
+      '.csv'
+    )
     expect(header?.querySelector(`[aria-label="Download ${name}"]`)).not.toBeNull()
     expect(
       header?.querySelector(`[aria-label="Open full screen preview of ${name}"]`)

--- a/src/renderer/src/pages/workspace/PreviewPanel.test.tsx
+++ b/src/renderer/src/pages/workspace/PreviewPanel.test.tsx
@@ -69,6 +69,7 @@ describe('PreviewPanel', () => {
     await act(async () => {
       root.unmount()
     })
+    vi.unstubAllGlobals()
     container.remove()
   })
 
@@ -84,6 +85,50 @@ describe('PreviewPanel', () => {
         />
       )
     })
+  }
+
+  const renderTwoFileTabs = async (): Promise<void> => {
+    usePreviewWorkbenchStore.getState().upsertAndActivateItem(createFileItem({}))
+    usePreviewWorkbenchStore.getState().upsertItem(
+      createFileItem({
+        id: 'item-2',
+        title: 'file-2.pdf',
+        format: 'pdf',
+        path: '/workspace/file-2.pdf',
+        name: 'file-2.pdf'
+      })
+    )
+    await renderPanel()
+  }
+
+  const mockTabScrollGeometry = ({
+    tabIndex,
+    listBounds,
+    tabBounds,
+    scrollLeft = 0
+  }: {
+    tabIndex: number
+    listBounds: [number, number]
+    tabBounds: [number, number]
+    scrollLeft?: number
+  }): { tabBar: HTMLElement; scrollTo: ReturnType<typeof vi.fn> } => {
+    const tabBar = container.querySelector<HTMLElement>('[aria-label="Open previews"]')
+    const tabContainer = container.querySelectorAll<HTMLElement>('[role="presentation"]')[tabIndex]
+    if (!tabBar || !tabContainer) throw new Error('Expected preview tab geometry targets')
+
+    const scrollTo = vi.fn()
+    const rect = ([left, right]: [number, number]): DOMRect =>
+      ({ left, right, width: right - left }) as DOMRect
+    Object.defineProperty(tabBar, 'scrollTo', { configurable: true, value: scrollTo })
+    Object.defineProperty(tabBar, 'scrollLeft', {
+      configurable: true,
+      value: scrollLeft,
+      writable: true
+    })
+    vi.spyOn(tabBar, 'getBoundingClientRect').mockReturnValue(rect(listBounds))
+    vi.spyOn(tabContainer, 'getBoundingClientRect').mockReturnValue(rect(tabBounds))
+
+    return { tabBar, scrollTo }
   }
 
   it('shows an empty state and no tab bar when there are no preview items', async () => {
@@ -115,6 +160,7 @@ describe('PreviewPanel', () => {
       expect(panelId).not.toBeNull()
       expect(container.querySelector(`#${panelId}`)?.getAttribute('role')).toBe('tabpanel')
     }
+    expect(container.querySelector('[role="tab"][title="file-1.png"] .lucide-file')).not.toBeNull()
 
     const activeContent = container.querySelector('[data-testid="file-content"]')
     expect(activeContent?.textContent).toBe('file:image:artifact:file-1.png:/workspace/file-1.png')
@@ -137,6 +183,7 @@ describe('PreviewPanel', () => {
     const header = card?.querySelector('[data-testid="preview-card-header"]')
     const titleTail = header?.querySelector('[data-testid="preview-title-tail"]')
     const tabBar = container.querySelector('[aria-label="Open previews"]')
+    const fileTab = tabBar?.querySelector(`[role="tab"][title="${name}"]`)
 
     expect(card?.className).toContain('rounded-md')
     expect(card?.className).toContain('shadow-card')
@@ -155,7 +202,15 @@ describe('PreviewPanel', () => {
     ).not.toBeNull()
     expect(header?.querySelector(`[aria-label="Close preview of ${name}"]`)).not.toBeNull()
     expect(tabBar?.getAttribute('role')).toBe('tablist')
+    expect(tabBar?.className).toContain('min-w-0')
+    expect(tabBar?.className).toContain('w-full')
     expect(tabBar?.querySelector('[role="tab"][aria-selected="true"]')).not.toBeNull()
+    expect(fileTab?.querySelector('[data-testid="file-name-prefix"]')?.textContent).toBe(
+      'global_climate_anomaly_analysis_1850-2025'
+    )
+    const tabExtension = fileTab?.querySelector('[data-testid="file-name-extension"]')
+    expect(tabExtension?.textContent).toBe('.csv')
+    expect(tabExtension?.className).toContain('shrink-0')
     expect(container.querySelector('[role="tabpanel"]')).not.toBeNull()
     expect(tabBar?.querySelector(`[aria-label="Close preview of ${name}"]`)).not.toBeNull()
   })
@@ -234,6 +289,101 @@ describe('PreviewPanel', () => {
     expect(container.querySelector('[role="tab"][aria-selected="true"]')?.textContent).toContain(
       'file-2.pdf'
     )
+  })
+
+  it('scrolls a clipped active preview tab inside the tab list', async () => {
+    await renderTwoFileTabs()
+    const { scrollTo } = mockTabScrollGeometry({
+      tabIndex: 1,
+      listBounds: [100, 300],
+      tabBounds: [260, 360],
+      scrollLeft: 40
+    })
+
+    await act(async () => {
+      container
+        .querySelectorAll<HTMLButtonElement>('[role="tab"]')[1]
+        ?.dispatchEvent(new MouseEvent('click', { bubbles: true }))
+    })
+
+    expect(scrollTo).toHaveBeenCalledOnce()
+    expect(scrollTo).toHaveBeenCalledWith({
+      behavior: 'smooth',
+      left: 108
+    })
+  })
+
+  it('avoids smooth tab scrolling when the user prefers reduced motion', async () => {
+    vi.stubGlobal(
+      'matchMedia',
+      vi.fn(() => ({ matches: true }))
+    )
+    await renderTwoFileTabs()
+    const { scrollTo } = mockTabScrollGeometry({
+      tabIndex: 1,
+      listBounds: [100, 300],
+      tabBounds: [260, 360]
+    })
+
+    await act(async () => {
+      container
+        .querySelectorAll<HTMLButtonElement>('[role="tab"]')[1]
+        ?.dispatchEvent(new MouseEvent('click', { bubbles: true }))
+    })
+
+    expect(scrollTo).toHaveBeenCalledWith({
+      behavior: 'auto',
+      left: 68
+    })
+  })
+
+  it('does not scroll when the active preview tab is already fully visible', async () => {
+    await renderTwoFileTabs()
+    const { scrollTo } = mockTabScrollGeometry({
+      tabIndex: 1,
+      listBounds: [100, 300],
+      tabBounds: [160, 260]
+    })
+
+    await act(async () => {
+      container
+        .querySelectorAll<HTMLButtonElement>('[role="tab"]')[1]
+        ?.dispatchEvent(new MouseEvent('click', { bubbles: true }))
+    })
+
+    expect(scrollTo).not.toHaveBeenCalled()
+  })
+
+  it('rechecks active tab visibility when the preview panel width changes', async () => {
+    let notifyResize: (() => void) | undefined
+    const observe = vi.fn()
+    const disconnect = vi.fn()
+    vi.stubGlobal(
+      'ResizeObserver',
+      class {
+        constructor(callback: ResizeObserverCallback) {
+          notifyResize = () => callback([], this as unknown as ResizeObserver)
+        }
+
+        observe = observe
+        disconnect = disconnect
+      }
+    )
+    usePreviewWorkbenchStore.getState().upsertAndActivateItem(createFileItem({}))
+    await renderPanel()
+    const { tabBar, scrollTo } = mockTabScrollGeometry({
+      tabIndex: 0,
+      listBounds: [100, 260],
+      tabBounds: [220, 300]
+    })
+
+    await act(async () => {
+      notifyResize?.()
+    })
+
+    expect(observe).toHaveBeenCalledWith(tabBar)
+    expect(scrollTo).toHaveBeenCalledWith({ behavior: 'auto', left: 48 })
+    expect(disconnect).not.toHaveBeenCalled()
   })
 
   it('leaves vertical arrows available to the page for a horizontal tab list', async () => {
@@ -330,6 +480,8 @@ describe('PreviewPanel', () => {
     expect(container.querySelector('[data-testid="preview-card"]')).toBeNull()
     expect(container.querySelector('[data-testid="preview-card-header"]')).toBeNull()
     const toolTab = container.querySelector<HTMLElement>('[role="tab"]')
+    expect(toolTab?.querySelector('.lucide-book-open')).not.toBeNull()
+    expect(toolTab?.querySelector('.lucide-file, .lucide-folder-open')).toBeNull()
     expect(
       container.querySelector(`#${toolTab?.getAttribute('aria-controls')}`)?.getAttribute('role')
     ).toBe('tabpanel')
@@ -347,6 +499,8 @@ describe('PreviewPanel', () => {
     await renderPanel()
 
     expect(container.querySelector('button[title="Files"]')).not.toBeNull()
+    expect(container.querySelector('button[title="Files"] .lucide-folder-open')).not.toBeNull()
+    expect(container.querySelector('button[title="Files"] .lucide-file')).toBeNull()
     expect(container.querySelector('[data-testid="tool-content"]')?.textContent).toBe('tool:files')
     expect(container.querySelector('[data-testid="preview-card"]')).toBeNull()
   })

--- a/src/renderer/src/pages/workspace/PreviewPanel.test.tsx
+++ b/src/renderer/src/pages/workspace/PreviewPanel.test.tsx
@@ -206,11 +206,10 @@ describe('PreviewPanel', () => {
     expect(tabBar?.className).toContain('w-full')
     expect(tabBar?.querySelector('[role="tab"][aria-selected="true"]')).not.toBeNull()
     expect(fileTab?.querySelector('[data-testid="file-name-head"]')?.textContent).toBe(
-      'global_climate_anomaly_analysi'
+      'global_climate_anomaly_analysis_1850'
     )
-    expect(fileTab?.querySelector('[data-testid="file-name-tail"]')?.textContent).toBe(
-      's_1850-2025'
-    )
+    expect(fileTab?.querySelector('[data-testid="file-name-ellipsis"]')).toBeNull()
+    expect(fileTab?.querySelector('[data-testid="file-name-tail"]')?.textContent).toBe('-2025')
     const tabExtension = fileTab?.querySelector('[data-testid="file-name-extension"]')
     expect(tabExtension?.textContent).toBe('.csv')
     expect(tabExtension?.className).toContain('shrink-0')

--- a/src/renderer/src/pages/workspace/PreviewPanel.tsx
+++ b/src/renderer/src/pages/workspace/PreviewPanel.tsx
@@ -1,5 +1,5 @@
-import { X } from 'lucide-react'
-import { useEffect, useRef, useState } from 'react'
+import { BookOpen, File, FolderOpen, X } from 'lucide-react'
+import { useCallback, useEffect, useRef, useState } from 'react'
 import type { PanelImperativeHandle, PanelSize } from 'react-resizable-panels'
 
 import { dialogOverlayClassName, dialogPanelClassName } from '@/components/ui/dialog-chrome'
@@ -8,7 +8,8 @@ import { cn } from '@/lib/utils'
 import type { PreviewFileItem, PreviewItem } from '@/stores/preview-workbench-store'
 import { usePreviewWorkbenchStore } from '@/stores/preview-workbench-store'
 
-import { MiddleEllipsisFileName, PreviewFileSurface } from './PreviewFileSurface'
+import { ExtensionPreservingFileName } from './ExtensionPreservingFileName'
+import { PreviewFileSurface } from './PreviewFileSurface'
 import { PreviewFileContent } from './previews/PreviewFileContent'
 import { PreviewToolContent } from './previews/PreviewToolContent'
 
@@ -45,11 +46,34 @@ const getPreviewTabId = (itemId: string): string => `preview-tab-${encodeURIComp
 const getPreviewPanelId = (itemId: string): string => `preview-panel-${encodeURIComponent(itemId)}`
 const PREVIEW_MODAL_FOCUSABLE_SELECTOR =
   'button:not([disabled]), [href], input:not([disabled]), select:not([disabled]), textarea:not([disabled]), [tabindex]:not([tabindex="-1"])'
+const PREVIEW_TAB_EDGE_INSET = 8
+
+// Scrolls only when the complete tab falls outside the tab list's padded visible bounds.
+const scrollPreviewTabIntoView = (
+  tabList: HTMLElement,
+  tab: HTMLElement,
+  behavior: ScrollBehavior
+): void => {
+  const tabListRect = tabList.getBoundingClientRect()
+  if (tabListRect.width <= PREVIEW_TAB_EDGE_INSET * 2) return
+
+  const tabRect = tab.getBoundingClientRect()
+  const visibleLeft = tabListRect.left + PREVIEW_TAB_EDGE_INSET
+  const visibleRight = tabListRect.right - PREVIEW_TAB_EDGE_INSET
+  let offset = 0
+
+  if (tabRect.left < visibleLeft) offset = tabRect.left - visibleLeft
+  else if (tabRect.right > visibleRight) offset = tabRect.right - visibleRight
+  if (offset === 0) return
+
+  tabList.scrollTo({ left: tabList.scrollLeft + offset, behavior })
+}
 
 // One tab owns activation/keyboard behavior while its sibling close button preserves quick removal.
 const PreviewTab = ({
   tab,
   isActive,
+  containerRef,
   tabRef,
   onActivate,
   onClose,
@@ -57,12 +81,14 @@ const PreviewTab = ({
 }: {
   tab: PreviewItem
   isActive: boolean
+  containerRef: (element: HTMLDivElement | null) => void
   tabRef: (element: HTMLButtonElement | null) => void
   onActivate: (id: string) => void
   onClose: (id: string) => void
   onKeyDown: (event: React.KeyboardEvent<HTMLButtonElement>) => void
 }): React.JSX.Element => (
   <div
+    ref={containerRef}
     role="presentation"
     className={cn(
       previewTabClassName,
@@ -77,13 +103,20 @@ const PreviewTab = ({
       aria-controls={getPreviewPanelId(tab.id)}
       aria-selected={isActive}
       tabIndex={isActive ? 0 : -1}
-      className="flex min-w-0 flex-1 self-stretch items-center text-left outline-none focus-visible:ring-2 focus-visible:ring-inset focus-visible:ring-ring/50"
+      className="flex min-w-0 flex-1 items-center gap-1 self-stretch text-left outline-none focus-visible:ring-2 focus-visible:ring-inset focus-visible:ring-ring/50"
       onClick={() => onActivate(tab.id)}
       onKeyDown={onKeyDown}
       title={tab.title}
     >
       {tab.type === 'file' ? (
-        <MiddleEllipsisFileName name={tab.name} />
+        <File className="size-3.5 shrink-0" aria-hidden="true" />
+      ) : tab.toolKind === 'files' ? (
+        <FolderOpen className="size-3.5 shrink-0" aria-hidden="true" />
+      ) : tab.toolKind === 'notebook' ? (
+        <BookOpen className="size-3.5 shrink-0" strokeWidth={2} aria-hidden="true" />
+      ) : null}
+      {tab.type === 'file' ? (
+        <ExtensionPreservingFileName name={tab.name} className="flex-1" />
       ) : (
         <span className="min-w-0 truncate">{tab.title}</span>
       )}
@@ -115,7 +148,45 @@ const PreviewTabBar = ({
   onActivate: (id: string) => void
   onClose: (id: string) => void
 }): React.JSX.Element => {
+  const tabListRef = useRef<HTMLDivElement | null>(null)
+  const tabContainerRefs = useRef<Array<HTMLDivElement | null>>([])
   const tabRefs = useRef<Array<HTMLButtonElement | null>>([])
+
+  const scrollActiveTabIntoView = useCallback(
+    (behavior: ScrollBehavior): void => {
+      const tabList = tabListRef.current
+      if (!tabList) return
+
+      const activeIndex = tabs.findIndex((tab) => tab.id === activeItemId)
+      const activeTab = activeIndex === -1 ? null : tabContainerRefs.current[activeIndex]
+      if (activeTab) scrollPreviewTabIntoView(tabList, activeTab, behavior)
+    },
+    [activeItemId, tabs]
+  )
+
+  // External activation keeps the selected tab visible without moving keyboard focus.
+  useEffect(() => {
+    const reduceMotion = window.matchMedia?.('(prefers-reduced-motion: reduce)').matches === true
+    scrollActiveTabIntoView(reduceMotion ? 'auto' : 'smooth')
+  }, [scrollActiveTabIntoView])
+
+  // Panel expansion and drag-resizing can clip an unchanged active tab, so recheck on width changes.
+  useEffect(() => {
+    const tabList = tabListRef.current
+    if (!tabList || typeof ResizeObserver === 'undefined') return
+
+    let previousWidth = tabList.getBoundingClientRect().width
+    const observer = new ResizeObserver(() => {
+      const nextWidth = tabList.getBoundingClientRect().width
+      if (nextWidth === previousWidth) return
+
+      previousWidth = nextWidth
+      scrollActiveTabIntoView('auto')
+    })
+    observer.observe(tabList)
+
+    return () => observer.disconnect()
+  }, [scrollActiveTabIntoView])
 
   const moveToTab = (index: number): void => {
     const tab = tabs[index]
@@ -152,16 +223,20 @@ const PreviewTabBar = ({
 
   return (
     <div
+      ref={tabListRef}
       role="tablist"
       aria-label="Open previews"
       aria-orientation="horizontal"
-      className="flex shrink-0 items-center gap-1 overflow-x-auto px-2 pb-2"
+      className="flex min-w-0 w-full shrink-0 items-center gap-1 overflow-x-auto px-2 pb-2"
     >
       {tabs.map((tab, index) => (
         <PreviewTab
           key={tab.id}
           tab={tab}
           isActive={tab.id === activeItemId}
+          containerRef={(element) => {
+            tabContainerRefs.current[index] = element
+          }}
           tabRef={(element) => {
             tabRefs.current[index] = element
           }}

--- a/src/renderer/src/pages/workspace/ProjectFilesView.test.tsx
+++ b/src/renderer/src/pages/workspace/ProjectFilesView.test.tsx
@@ -493,7 +493,7 @@ describe('ProjectFilesView', () => {
     ])
 
     expect(container.textContent).toContain('Your uploads')
-    expect(container.textContent).toContain('iso621_bridg...inase.fasta')
+    expect(container.textContent).toContain('iso621_bridge_recombinase.fasta')
     expect(container.querySelector('[title="iso621_bridge_recombinase.fasta"]')).not.toBeNull()
     expect(container.textContent).not.toContain('Hidden session title')
     expect(
@@ -1503,6 +1503,9 @@ describe('ProjectFilesView', () => {
     const generatedMeta = generatedButton?.querySelector('[data-testid="project-file-meta"]')
 
     expect(generatedMeta?.className).toContain('flex-col')
+    expect(generatedMeta?.querySelector('[data-testid="file-name-extension"]')?.textContent).toBe(
+      '.png'
+    )
     expect(generatedButton?.textContent).toContain('4 KB')
     expect(generatedButton?.textContent).toContain('2 hours ago')
   })
@@ -2167,8 +2170,8 @@ describe('ProjectFilesView', () => {
       })
     ])
 
-    expect(container.textContent).toContain('denovo_desig...orklist.csv')
-    expect(container.textContent).not.toContain('denovo_design_worklist.csv')
+    expect(container.textContent).toContain('denovo_design_worklist.csv')
+    expect(container.querySelector('[data-testid="file-name-extension"]')?.textContent).toBe('.csv')
   })
 
   it('uses taller file cards and preview thumbnails', async () => {

--- a/src/renderer/src/pages/workspace/ProjectFilesView.tsx
+++ b/src/renderer/src/pages/workspace/ProjectFilesView.tsx
@@ -24,6 +24,7 @@ import type {
   ProjectFilesChangedEvent
 } from '../../../../shared/project-files'
 
+import { ExtensionPreservingFileName } from './ExtensionPreservingFileName'
 import { ArtifactPreview } from './artifact-preview'
 import {
   ARTIFACT_IMAGE_PREVIEW_BYTES,
@@ -322,17 +323,6 @@ const useInfiniteLoad = (
   return sentinelRef
 }
 
-const formatMiddleEllipsisName = (name: string): string => {
-  if (name.length < 26) return name
-
-  const headLength = 12
-  const tailLength = 11
-
-  if (name.length < headLength + tailLength + 3) return name
-
-  return `${name.slice(0, headLength)}...${name.slice(-tailLength)}`
-}
-
 const formatRelativeFileTime = (timestamp: number | undefined): string | undefined => {
   if (typeof timestamp !== 'number' || !Number.isFinite(timestamp)) return undefined
 
@@ -466,7 +456,6 @@ const FileTile = ({
   onPreview: () => void
 }): React.JSX.Element => {
   const sizeLabel = formatByteSize(size)
-  const displayName = formatMiddleEllipsisName(name)
   const relativeTimeLabel = formatRelativeFileTime(timestamp)
   const [setTileElement, isNearViewport] = useNearViewport<HTMLButtonElement>()
   const missing = useUnavailablePreviewProbe({
@@ -503,9 +492,10 @@ const FileTile = ({
           data-testid="project-file-meta"
           className="flex min-w-0 flex-1 flex-col justify-center gap-0.5 px-2 py-1.5"
         >
-          <span className="block min-w-0 truncate text-[11px] leading-5 text-text-000">
-            {displayName}
-          </span>
+          <ExtensionPreservingFileName
+            name={name}
+            className="text-[11px] leading-5 text-text-000"
+          />
           {sizeLabel || relativeTimeLabel ? (
             <span className="flex min-w-0 flex-wrap items-center gap-x-1.5 gap-y-0 text-[10px] leading-3 text-text-300">
               {sizeLabel ? <span className="shrink-0">{sizeLabel}</span> : null}

--- a/src/renderer/src/pages/workspace/WorkspaceMessageItem.mentions.test.tsx
+++ b/src/renderer/src/pages/workspace/WorkspaceMessageItem.mentions.test.tsx
@@ -88,8 +88,14 @@ const renderMessageItem = async (
   })
 }
 
-const expectSplitFileName = (button: Element | null, prefix: string, extension: string): void => {
-  expect(button?.querySelector('[data-testid="file-name-prefix"]')?.textContent).toBe(prefix)
+const expectSplitFileName = (
+  button: Element | null,
+  head: string,
+  tail: string,
+  extension: string
+): void => {
+  expect(button?.querySelector('[data-testid="file-name-head"]')?.textContent).toBe(head)
+  expect(button?.querySelector('[data-testid="file-name-tail"]')?.textContent).toBe(tail)
   const extensionNode = button?.querySelector('[data-testid="file-name-extension"]')
   expect(extensionNode?.textContent).toBe(extension)
   expect(extensionNode?.className).toContain('shrink-0')
@@ -163,7 +169,7 @@ describe('WorkspaceMessageItem file names', () => {
     await renderMessageItem(message)
 
     const button = container.querySelector(`[aria-label="Preview uploaded attachment ${name}"]`)
-    expectSplitFileName(button, 'long_uploaded_experiment_result', '.png')
+    expectSplitFileName(button, 'long_uploaded_experi', 'ment_result', '.png')
   })
 
   it('keeps a generated file extension visible separately from its truncating prefix', async () => {
@@ -199,7 +205,7 @@ describe('WorkspaceMessageItem file names', () => {
     await renderMessageItem(message, artifacts)
 
     const button = container.querySelector(`[aria-label="Preview generated file ${name}"]`)
-    expectSplitFileName(button, 'long_generated_experiment_result', '.csv')
+    expectSplitFileName(button, 'long_generated_experi', 'ment_result', '.csv')
   })
 })
 

--- a/src/renderer/src/pages/workspace/WorkspaceMessageItem.mentions.test.tsx
+++ b/src/renderer/src/pages/workspace/WorkspaceMessageItem.mentions.test.tsx
@@ -95,6 +95,7 @@ const expectSplitFileName = (
   extension: string
 ): void => {
   expect(button?.querySelector('[data-testid="file-name-head"]')?.textContent).toBe(head)
+  expect(button?.querySelector('[data-testid="file-name-ellipsis"]')?.textContent).toBe('...')
   expect(button?.querySelector('[data-testid="file-name-tail"]')?.textContent).toBe(tail)
   const extensionNode = button?.querySelector('[data-testid="file-name-extension"]')
   expect(extensionNode?.textContent).toBe(extension)
@@ -150,7 +151,7 @@ describe('WorkspaceMessageItem mention pills', () => {
 })
 
 describe('WorkspaceMessageItem file names', () => {
-  it('keeps an uploaded attachment extension visible separately from its truncating prefix', async () => {
+  it('uses the compact abbreviation for an uploaded attachment', async () => {
     const name = 'long_uploaded_experiment_result.png'
     const message = createMessage({
       uploads: [
@@ -169,10 +170,10 @@ describe('WorkspaceMessageItem file names', () => {
     await renderMessageItem(message)
 
     const button = container.querySelector(`[aria-label="Preview uploaded attachment ${name}"]`)
-    expectSplitFileName(button, 'long_uploaded_experi', 'ment_result', '.png')
+    expectSplitFileName(button, 'lon', 't', '.png')
   })
 
-  it('keeps a generated file extension visible separately from its truncating prefix', async () => {
+  it('uses the compact abbreviation for a generated file', async () => {
     ;(window as unknown as { api: unknown }).api = {
       previewResources: {
         acquire: vi.fn().mockResolvedValue({ kind: 'text', content: '' }),
@@ -205,7 +206,8 @@ describe('WorkspaceMessageItem file names', () => {
     await renderMessageItem(message, artifacts)
 
     const button = container.querySelector(`[aria-label="Preview generated file ${name}"]`)
-    expectSplitFileName(button, 'long_generated_experi', 'ment_result', '.csv')
+    expectSplitFileName(button, 'lon', 't', '.csv')
+    expect(button?.querySelector('span.text-text-300')?.className).toContain('ml-1')
   })
 })
 

--- a/src/renderer/src/pages/workspace/WorkspaceMessageItem.mentions.test.tsx
+++ b/src/renderer/src/pages/workspace/WorkspaceMessageItem.mentions.test.tsx
@@ -151,7 +151,7 @@ describe('WorkspaceMessageItem mention pills', () => {
 })
 
 describe('WorkspaceMessageItem file names', () => {
-  it('uses the compact abbreviation for an uploaded attachment', async () => {
+  it('uses the compact fallback for an uploaded attachment', async () => {
     const name = 'long_uploaded_experiment_result.png'
     const message = createMessage({
       uploads: [
@@ -173,7 +173,7 @@ describe('WorkspaceMessageItem file names', () => {
     expectSplitFileName(button, 'lon', 't', '.png')
   })
 
-  it('uses the compact abbreviation for a generated file', async () => {
+  it('uses the compact fallback for a generated file', async () => {
     ;(window as unknown as { api: unknown }).api = {
       previewResources: {
         acquire: vi.fn().mockResolvedValue({ kind: 'text', content: '' }),

--- a/src/renderer/src/pages/workspace/WorkspaceMessageItem.mentions.test.tsx
+++ b/src/renderer/src/pages/workspace/WorkspaceMessageItem.mentions.test.tsx
@@ -207,6 +207,7 @@ describe('WorkspaceMessageItem file names', () => {
 
     const button = container.querySelector(`[aria-label="Preview generated file ${name}"]`)
     expectSplitFileName(button, 'lon', 't', '.csv')
+    expect(button?.querySelector('div[class*="px-1.5"]')).not.toBeNull()
     expect(button?.querySelector('span.text-text-300')?.className).toContain('ml-1')
   })
 })

--- a/src/renderer/src/pages/workspace/WorkspaceMessageItem.mentions.test.tsx
+++ b/src/renderer/src/pages/workspace/WorkspaceMessageItem.mentions.test.tsx
@@ -43,6 +43,7 @@ afterEach(() => {
   act(() => root.unmount())
   container.remove()
   document.body.innerHTML = ''
+  delete (window as unknown as { api?: unknown }).api
 })
 
 const mentionMessage = createMessage({
@@ -67,6 +68,31 @@ const clickButton = (label: string): void => {
   act(() => {
     button?.dispatchEvent(new MouseEvent('click', { bubbles: true }))
   })
+}
+
+const renderMessageItem = async (
+  message: ChatMessage,
+  artifacts?: React.ComponentProps<typeof WorkspaceMessageItem>['artifacts']
+): Promise<void> => {
+  await act(async () => {
+    root.render(
+      <WorkspaceMessageItem
+        message={message}
+        artifacts={artifacts}
+        onPreviewArtifact={noop}
+        onPreviewUploadAttachment={noop}
+        onOpenSkillMention={noop}
+        onPreviewMentionArtifact={noop}
+      />
+    )
+  })
+}
+
+const expectSplitFileName = (button: Element | null, prefix: string, extension: string): void => {
+  expect(button?.querySelector('[data-testid="file-name-prefix"]')?.textContent).toBe(prefix)
+  const extensionNode = button?.querySelector('[data-testid="file-name-extension"]')
+  expect(extensionNode?.textContent).toBe(extension)
+  expect(extensionNode?.className).toContain('shrink-0')
 }
 
 describe('WorkspaceMessageItem mention pills', () => {
@@ -114,6 +140,66 @@ describe('WorkspaceMessageItem mention pills', () => {
       path: '/p/clinical trial03.pdf',
       source: 'artifact'
     })
+  })
+})
+
+describe('WorkspaceMessageItem file names', () => {
+  it('keeps an uploaded attachment extension visible separately from its truncating prefix', async () => {
+    const name = 'long_uploaded_experiment_result.png'
+    const message = createMessage({
+      uploads: [
+        {
+          id: 'upload-1',
+          sessionId: 'session-1',
+          name: 'stored.png',
+          originalName: name,
+          path: '/p/stored.png',
+          mimeType: 'image/png',
+          size: 1024
+        }
+      ]
+    })
+
+    await renderMessageItem(message)
+
+    const button = container.querySelector(`[aria-label="Preview uploaded attachment ${name}"]`)
+    expectSplitFileName(button, 'long_uploaded_experiment_result', '.png')
+  })
+
+  it('keeps a generated file extension visible separately from its truncating prefix', async () => {
+    ;(window as unknown as { api: unknown }).api = {
+      previewResources: {
+        acquire: vi.fn().mockResolvedValue({ kind: 'text', content: '' }),
+        release: vi.fn().mockResolvedValue(undefined)
+      },
+      artifacts: {
+        readPreview: vi.fn().mockResolvedValue({
+          content: '',
+          encoding: 'utf8',
+          size: 0,
+          truncated: false
+        })
+      }
+    }
+    const name = 'long_generated_experiment_result.csv'
+    const message = createMessage({ id: 'm-assistant', role: 'agent', content: 'Done' })
+    const artifacts = [
+      {
+        id: 'artifact-1',
+        kind: 'managed-file' as const,
+        path: `/p/${name}`,
+        fileUrl: `file:///p/${name}`,
+        name,
+        mimeType: 'text/csv',
+        size: 10,
+        mtimeMs: 1
+      }
+    ]
+
+    await renderMessageItem(message, artifacts)
+
+    const button = container.querySelector(`[aria-label="Preview generated file ${name}"]`)
+    expectSplitFileName(button, 'long_generated_experiment_result', '.csv')
   })
 })
 

--- a/src/renderer/src/pages/workspace/WorkspaceMessageItem.tsx
+++ b/src/renderer/src/pages/workspace/WorkspaceMessageItem.tsx
@@ -195,7 +195,7 @@ const ArtifactCard = ({
           </span>
         ) : null}
       </div>
-      <div className="flex min-w-0 flex-1 items-center px-2">
+      <div className="flex min-w-0 flex-1 items-center px-1.5">
         <ExtensionPreservingFileName
           name={artifactName}
           className="flex-1 text-[12px] leading-5"

--- a/src/renderer/src/pages/workspace/WorkspaceMessageItem.tsx
+++ b/src/renderer/src/pages/workspace/WorkspaceMessageItem.tsx
@@ -79,6 +79,8 @@ const uploadedAttachmentButtonClassName =
 // keeps a long file/skill name from overflowing the bubble.
 const mentionPillClassName =
   'inline-block max-w-[220px] truncate align-middle rounded px-1.5 py-0.5 mx-0.5 text-sm font-medium'
+const artifactMentionPillClassName =
+  'inline-flex max-w-[220px] align-middle rounded px-1.5 py-0.5 mx-0.5 text-sm font-medium'
 // Interactive additions layered onto the pill shape when a mention resolves to a clickable target.
 const mentionButtonClassName =
   'cursor-pointer hover:brightness-95 focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-border-200/60'
@@ -194,9 +196,13 @@ const ArtifactCard = ({
         ) : null}
       </div>
       <div className="flex min-w-0 flex-1 items-center px-2">
-        <ExtensionPreservingFileName name={artifactName} className="flex-1 text-[12px] leading-5" />
+        <ExtensionPreservingFileName
+          name={artifactName}
+          className="flex-1 text-[12px] leading-5"
+          compact
+        />
         {sizeLabel ? (
-          <span className="ml-2 shrink-0 text-[11px] text-text-300">{sizeLabel}</span>
+          <span className="ml-1 shrink-0 text-[11px] text-text-300">{sizeLabel}</span>
         ) : null}
       </div>
     </button>
@@ -295,7 +301,7 @@ const MessageUploadAttachmentList = ({
             title={attachment.path}
           >
             <Icon className="h-3.5 w-3.5 shrink-0 text-text-300" aria-hidden="true" />
-            <ExtensionPreservingFileName name={attachmentName} />
+            <ExtensionPreservingFileName name={attachmentName} compact />
           </button>
         )
       })}
@@ -338,14 +344,14 @@ const MessagePartsContent = ({
             key={index}
             type="button"
             className={cn(
-              mentionPillClassName,
+              artifactMentionPillClassName,
               mentionButtonClassName,
               'bg-mention-chip text-mention-chip-foreground'
             )}
             onClick={() => onPreviewMentionArtifact(part)}
             aria-label={`Preview ${part.name}`}
           >
-            @{part.name}
+            @<ExtensionPreservingFileName name={part.name} />
           </button>
         )
       }

--- a/src/renderer/src/pages/workspace/WorkspaceMessageItem.tsx
+++ b/src/renderer/src/pages/workspace/WorkspaceMessageItem.tsx
@@ -12,6 +12,7 @@ import { getUploadedAttachmentName } from '../../../../shared/uploads'
 import { ArtifactPreview } from './artifact-preview'
 import { ComposerEditor } from './composer/ComposerEditor'
 import { EditMessageConfirmDialog } from './EditMessageConfirmDialog'
+import { ExtensionPreservingFileName } from './ExtensionPreservingFileName'
 import {
   docFromMessageParts,
   docFromText,
@@ -193,7 +194,7 @@ const ArtifactCard = ({
         ) : null}
       </div>
       <div className="flex min-w-0 flex-1 items-center px-2">
-        <span className="min-w-0 flex-1 truncate text-[12px] leading-5">{artifactName}</span>
+        <ExtensionPreservingFileName name={artifactName} className="flex-1 text-[12px] leading-5" />
         {sizeLabel ? (
           <span className="ml-2 shrink-0 text-[11px] text-text-300">{sizeLabel}</span>
         ) : null}
@@ -294,7 +295,7 @@ const MessageUploadAttachmentList = ({
             title={attachment.path}
           >
             <Icon className="h-3.5 w-3.5 shrink-0 text-text-300" aria-hidden="true" />
-            <span className="min-w-0 truncate">{attachmentName}</span>
+            <ExtensionPreservingFileName name={attachmentName} />
           </button>
         )
       })}

--- a/src/renderer/src/pages/workspace/WorkspaceMessageScroller.render.test.tsx
+++ b/src/renderer/src/pages/workspace/WorkspaceMessageScroller.render.test.tsx
@@ -464,7 +464,8 @@ describe('WorkspaceMessageScroller loading render', () => {
     expect(html).toContain('/forecast')
     expect(html).toContain('bg-mention-chip')
     expect(html).toContain('text-mention-chip-foreground')
-    expect(html).toContain('@clinical trial03.pdf')
+    expect(html).toContain('aria-label="Preview clinical trial03.pdf"')
+    expect(html).toContain('file-name-extension')
   })
 
   it('renders plain content for user messages without structured parts', async () => {

--- a/src/renderer/src/pages/workspace/WorkspaceToolActivityRowButton.tsx
+++ b/src/renderer/src/pages/workspace/WorkspaceToolActivityRowButton.tsx
@@ -9,7 +9,7 @@ import { getActivitySurfaceClassName } from './workspace-tool-activity-style'
 type WorkspaceToolActivityRowButtonProps = {
   activity: ToolActivity
   label: string
-  subtitle?: string
+  subtitle?: ReactNode
   metaLabel?: string
   isExpanded: boolean
   canExpand?: boolean

--- a/src/renderer/src/pages/workspace/WorkspaceToolDetailsRow.tsx
+++ b/src/renderer/src/pages/workspace/WorkspaceToolDetailsRow.tsx
@@ -1,5 +1,6 @@
 import type { ToolActivity } from '@/stores/session-store'
 
+import { ExtensionPreservingFileName } from './ExtensionPreservingFileName'
 import { usePreviewFileContent } from './previews/usePreviewFileContent'
 
 // Byte cap for inline tool-output image previews. Co-located here (rather than in preview-support,
@@ -45,8 +46,6 @@ const WorkspaceToolImageOutput = ({
     maxBytes: PREVIEW_PANEL_IMAGE_MAX_BYTES,
     encoding: 'base64'
   })
-  const caption = [section.name, section.sizeLabel].filter(Boolean).join(' · ')
-
   if (state.status === 'ready' && state.preview.encoding === 'base64' && !state.preview.truncated) {
     return (
       <div className="space-y-1">
@@ -57,15 +56,31 @@ const WorkspaceToolImageOutput = ({
           className="max-h-64 max-w-full rounded-md border border-border-200 object-contain"
           draggable={false}
         />
-        {caption ? <div className="text-[11px] text-text-300">{caption}</div> : null}
+        {section.name || section.sizeLabel ? (
+          <div className="flex min-w-0 items-center gap-1 text-[11px] text-text-300">
+            {section.name ? <ExtensionPreservingFileName name={section.name} /> : null}
+            {section.name && section.sizeLabel ? <span className="shrink-0">·</span> : null}
+            {section.sizeLabel ? <span className="shrink-0">{section.sizeLabel}</span> : null}
+          </div>
+        ) : null}
       </div>
     )
   }
 
   const fallbackText =
-    state.status === 'loading' ? 'Loading preview…' : (section.name ?? section.path)
+    state.status === 'loading'
+      ? 'Loading preview…'
+      : (section.name ?? (section.path.split(/[\\/]/u).at(-1) || section.path))
 
-  return <div className="text-[12px] text-text-300">{fallbackText}</div>
+  return (
+    <div className="text-[12px] text-text-300">
+      {state.status === 'loading' ? (
+        fallbackText
+      ) : (
+        <ExtensionPreservingFileName name={fallbackText} />
+      )}
+    </div>
+  )
 }
 
 // Renders one detail section as a diff, an image preview, a collapsible code panel, or a plain
@@ -119,7 +134,13 @@ const WorkspaceToolDetailsRow = ({
   <WorkspaceToolActivityRowButton
     activity={activity}
     label={details.displayName}
-    subtitle={details.subtitle}
+    subtitle={
+      details.displayName === 'Write file' && details.subtitle ? (
+        <ExtensionPreservingFileName name={details.subtitle} />
+      ) : (
+        details.subtitle
+      )
+    }
     metaLabel={details.metaLabel}
     isExpanded={isExpanded}
     panelClassName="mx-1 mb-1.5 space-y-2.5 md:ml-[30px]"

--- a/src/renderer/src/pages/workspace/composer/ArtifactMentionPopup.render.test.tsx
+++ b/src/renderer/src/pages/workspace/composer/ArtifactMentionPopup.render.test.tsx
@@ -126,6 +126,35 @@ describe('ArtifactMentionPopup', () => {
     expect(text).toContain('output')
   })
 
+  it('uses the preview-tab abbreviation for a long filename while preserving its extension', () => {
+    const longName = 'very_long_experiment_analysis_result_2025.csv'
+    useSessionStore.setState({
+      ...createInitialSessionState(),
+      sessions: [
+        createSession({
+          artifacts: [
+            {
+              id: 'long-artifact',
+              kind: 'managed-file',
+              path: `/workspace/${longName}`,
+              fileUrl: `file:///workspace/${longName}`,
+              name: longName,
+              mimeType: 'text/csv',
+              size: 4096,
+              mtimeMs: 1710000002000
+            }
+          ]
+        })
+      ]
+    })
+
+    act(() => {
+      root.render(<ArtifactMentionPopup query="" onSelect={vi.fn()} onClose={vi.fn()} />)
+    })
+
+    expect(options()[0]?.querySelector('[data-testid="file-name-tail"]')?.textContent).toBe('_2025')
+  })
+
   it('filters rows by a case-insensitive filename query', () => {
     act(() => {
       root.render(<ArtifactMentionPopup query="REPORT" onSelect={vi.fn()} onClose={vi.fn()} />)
@@ -212,8 +241,12 @@ describe('ArtifactMentionPopup', () => {
     })
 
     const marks = Array.from(document.body.querySelectorAll('mark'))
-    expect(marks).toHaveLength(1)
-    expect(marks[0].textContent?.toLowerCase()).toBe('report')
+    expect(
+      marks
+        .map((mark) => mark.textContent)
+        .join('')
+        .toLowerCase()
+    ).toContain('report')
   })
 
   it('ranks a closer fuzzy match first within a section', () => {

--- a/src/renderer/src/pages/workspace/composer/ArtifactMentionPopup.tsx
+++ b/src/renderer/src/pages/workspace/composer/ArtifactMentionPopup.tsx
@@ -4,6 +4,9 @@ import { formatByteSize } from '@/lib/utils'
 import { useNavigationStore } from '@/stores/navigation-store'
 import { useSessionStore } from '@/stores/session-store'
 
+import { ExtensionPreservingFileName } from '../ExtensionPreservingFileName'
+import { getExtensionPreservingFileNameParts } from '../extension-preserving-file-name'
+
 import { ArtifactFileIcon } from './artifact-file-icon'
 import { fuzzyScore, type FuzzyMatch } from './fuzzy-match'
 import { HighlightedText } from './HighlightedText'
@@ -143,6 +146,19 @@ export const ArtifactMentionPopup = ({
   const renderRow = (row: ArtifactRow, index: number): React.JSX.Element => {
     const isActive = index === safeIndex
     const size = formatByteSize(row.size)
+    const parts = getExtensionPreservingFileNameParts(row.name)
+    const basenameLength = row.name.length - parts.extension.length
+    const tailStart = basenameLength - parts.tail.length
+    const visiblePositions = row.positions ?? []
+    // Re-map fuzzy-match offsets after the middle is replaced, preserving query highlights.
+    const headPositions = visiblePositions.filter((position) => position < parts.head.length)
+    const tailPositions = visiblePositions
+      .filter((position) => position >= tailStart && position < basenameLength)
+      .map((position) => position - tailStart)
+    const extensionPositions = visiblePositions
+      .filter((position) => position >= basenameLength)
+      .map((position) => position - basenameLength)
+
     return (
       <li
         key={`${row.source}:${row.id}`}
@@ -163,8 +179,22 @@ export const ArtifactMentionPopup = ({
           path={row.path}
           source={row.source}
         />
-        <span className="flex-1 min-w-0 truncate font-medium">
-          <HighlightedText text={row.name} positions={row.positions ?? []} />
+        <span className="flex min-w-0 flex-1 font-medium">
+          {row.positions?.length ? (
+            <>
+              <span className="min-w-0 flex-1 truncate">
+                <HighlightedText text={parts.head} positions={headPositions} />
+              </span>
+              <span className="shrink-0">
+                <HighlightedText text={parts.tail} positions={tailPositions} />
+              </span>
+              <span className="shrink-0">
+                <HighlightedText text={parts.extension} positions={extensionPositions} />
+              </span>
+            </>
+          ) : (
+            <ExtensionPreservingFileName name={row.name} />
+          )}
         </span>
         {size ? <span className="text-xs text-text-300 shrink-0">{size}</span> : null}
         <span className="text-[10px] px-1.5 py-0.5 rounded bg-accent text-accent-foreground shrink-0">

--- a/src/renderer/src/pages/workspace/composer/composer-doc.test.ts
+++ b/src/renderer/src/pages/workspace/composer/composer-doc.test.ts
@@ -310,6 +310,24 @@ describe('applyDocToDom + domToDoc round-trip', () => {
     expect(domToDoc(root)).toEqual(doc)
   })
 
+  it('keeps the tail and extension visible in a long artifact chip without changing its stored name', () => {
+    const name = 'very_long_experiment_analysis_result_2025.csv'
+    const root = document.createElement('div')
+    const doc: ComposerDoc = {
+      nodes: [{ type: 'artifact', id: 'a1', name, path: `/p/${name}`, source: 'artifact' }]
+    }
+
+    applyDocToDom(root, doc)
+
+    const chip = root.querySelector('span[data-mention-type="artifact"]')
+    expect(chip?.getAttribute('data-mention-filename')).toBe(name)
+    expect(chip?.querySelector('.truncate')?.textContent).toBe(
+      '@very_long_experiment_analysis_result'
+    )
+    expect(chip?.textContent).toBe(`@very_long_experiment_analysis_result_2025.csv`)
+    expect(domToDoc(root)).toEqual(doc)
+  })
+
   it('renders an artifact chip with the green mention attributes and @ label', () => {
     const root = document.createElement('div')
     applyDocToDom(root, {

--- a/src/renderer/src/pages/workspace/composer/composer-doc.ts
+++ b/src/renderer/src/pages/workspace/composer/composer-doc.ts
@@ -2,6 +2,8 @@
 // chips, and artifact chips. These functions are DOM-free except domToDoc/applyDocToDom, which
 // bridge the model to the contenteditable editor.
 
+import { getExtensionPreservingFileNameParts } from '../extension-preserving-file-name'
+
 import type { FileReference } from '../../../../../shared/artifacts'
 import type { MessagePart } from '../../../../../shared/session-persistence'
 
@@ -185,6 +187,8 @@ export const domToDoc = (root: HTMLElement): ComposerDoc => {
 // domToDoc still reads the full name back from textContent / the stored filename attribute.
 const CHIP_BASE_CLASS =
   'inline-block max-w-[220px] truncate align-middle rounded px-1.5 py-0.5 mx-0.5 text-sm font-medium select-all'
+const ARTIFACT_CHIP_BASE_CLASS =
+  'inline-flex max-w-[220px] align-middle rounded px-1.5 py-0.5 mx-0.5 text-sm font-medium select-all'
 
 // Render a skill chip span: an atomic, non-editable blue mention token. Exported so the mention hook
 // inserts the exact same markup it re-renders here, and the styling can never drift between the two.
@@ -219,8 +223,21 @@ export const createArtifactChip = (node: ComposerArtifactNode): HTMLSpanElement 
     span.setAttribute('data-mention-version-id', node.versionId)
   }
   // Green mention pill, distinct from the blue skill chip.
-  span.className = `${CHIP_BASE_CLASS} bg-mention-chip text-mention-chip-foreground`
-  span.textContent = `@${node.name}`
+  span.className = `${ARTIFACT_CHIP_BASE_CLASS} bg-mention-chip text-mention-chip-foreground`
+  span.title = node.name
+  const { head, tail, extension } = getExtensionPreservingFileNameParts(node.name)
+  const headSpan = document.createElement('span')
+  headSpan.className = 'min-w-0 flex-1 truncate'
+  headSpan.textContent = `@${head}`
+  span.append(headSpan)
+
+  for (const segment of [tail, extension]) {
+    if (!segment) continue
+    const segmentSpan = document.createElement('span')
+    segmentSpan.className = 'shrink-0'
+    segmentSpan.textContent = segment
+    span.append(segmentSpan)
+  }
   return span
 }
 

--- a/src/renderer/src/pages/workspace/extension-preserving-file-name.ts
+++ b/src/renderer/src/pages/workspace/extension-preserving-file-name.ts
@@ -19,20 +19,23 @@ const getExtensionPreservingFileNameParts = (
   const hasExtension = extensionIndex > 0
   const basename = hasExtension ? name.slice(0, extensionIndex) : name
   const extension = hasExtension ? name.slice(extensionIndex) : ''
-  const isCompactAbbreviation = compact && basename.length >= COMPACT_BASENAME_MIN_LENGTH
+  // File names can end in emoji; split by Unicode code point so a compact tail never becomes a
+  // lone UTF-16 surrogate and renders as a replacement character.
+  const basenameCharacters = Array.from(basename)
+  const isCompactAbbreviation = compact && basenameCharacters.length >= COMPACT_BASENAME_MIN_LENGTH
 
   if (isCompactAbbreviation) {
     return {
-      head: basename.slice(0, CARD_HEAD_LENGTH),
-      tail: basename.slice(-CARD_TAIL_LENGTH),
+      head: basenameCharacters.slice(0, CARD_HEAD_LENGTH).join(''),
+      tail: basenameCharacters.slice(-CARD_TAIL_LENGTH).join(''),
       extension,
       isCompactAbbreviation
     }
   }
 
   return {
-    head: basename.slice(0, -DEFAULT_TAIL_LENGTH),
-    tail: basename.slice(-DEFAULT_TAIL_LENGTH),
+    head: basenameCharacters.slice(0, -DEFAULT_TAIL_LENGTH).join(''),
+    tail: basenameCharacters.slice(-DEFAULT_TAIL_LENGTH).join(''),
     extension,
     isCompactAbbreviation
   }

--- a/src/renderer/src/pages/workspace/extension-preserving-file-name.ts
+++ b/src/renderer/src/pages/workspace/extension-preserving-file-name.ts
@@ -1,0 +1,42 @@
+type ExtensionPreservingFileNameParts = {
+  head: string
+  tail: string
+  extension: string
+  isCompactAbbreviation: boolean
+}
+
+const COMPACT_BASENAME_MIN_LENGTH = 24
+const DEFAULT_TAIL_LENGTH = 5
+const CARD_HEAD_LENGTH = 3
+const CARD_TAIL_LENGTH = 1
+
+// Keeps a small basename tail outside the flex-truncated head so normal surfaces respond to width.
+const getExtensionPreservingFileNameParts = (
+  name: string,
+  compact = false
+): ExtensionPreservingFileNameParts => {
+  const extensionIndex = name.lastIndexOf('.')
+  const hasExtension = extensionIndex > 0
+  const basename = hasExtension ? name.slice(0, extensionIndex) : name
+  const extension = hasExtension ? name.slice(extensionIndex) : ''
+  const isCompactAbbreviation = compact && basename.length >= COMPACT_BASENAME_MIN_LENGTH
+
+  if (isCompactAbbreviation) {
+    return {
+      head: basename.slice(0, CARD_HEAD_LENGTH),
+      tail: basename.slice(-CARD_TAIL_LENGTH),
+      extension,
+      isCompactAbbreviation
+    }
+  }
+
+  return {
+    head: basename.slice(0, -DEFAULT_TAIL_LENGTH),
+    tail: basename.slice(-DEFAULT_TAIL_LENGTH),
+    extension,
+    isCompactAbbreviation
+  }
+}
+
+export { getExtensionPreservingFileNameParts }
+export type { ExtensionPreservingFileNameParts }


### PR DESCRIPTION
## Summary

Keeps the active preview tab visible while making long filenames readable throughout the preview and chat workflows. Filenames now use responsive middle truncation: they stay complete when space allows and retain the filename tail and extension when space is constrained.

## Highlights

- Scrolls the active preview tab only when it falls outside the visible tab-strip bounds, including after panel resize or expansion.
- Adds distinct icons for file, Files, and Notebook preview tabs.
- Uses responsive filename rendering in preview tabs, file mentions, artifact suggestions, pending attachments, and Write file output labels.
- Keeps generated and uploaded file thumbnail cards intentionally compact to avoid layout shifts.
- Preserves artifact search highlighting, keyboard selection, mention round-tripping, and preview actions.

## Impact

Affects the preview workbench tab strip and filename presentation in chat and tool-output surfaces. Preview state, persistence, file loading, keyboard navigation, and close behavior remain unchanged.

## Tests

- 101 directly related renderer tests passed.
- `npm run typecheck:web` passed.
- ESLint passed for changed files.
- `git diff --check` passed.

## Potential Issues

No known product regressions.

## Author

- ljlj111 <18301503785@163.com>
