### PR TITLE
feat(compute): use data root for harvested job results

### DIFF
--- a/src/main/compute/compute-service.test.ts
+++ b/src/main/compute/compute-service.test.ts
@@ -2391,6 +2391,41 @@ describe('ComputeService.getJobResult', () => {
     expect(featIdx).toBeLessThan(hidIdx)
   })
 
+  it('reads attach_job results from the data-root workspace when config and data roots differ', async () => {
+    const configRoot = await mkdtemp(join(tmpdir(), 'job-result-config-root-'))
+    const dataRoot = await mkdtemp(join(tmpdir(), 'job-result-data-root-'))
+    const dataHarvestDir = join(dataRoot, 'notebooks', 'proj-1', 'sess-1', 'hpc', 'job-result-1')
+    const configHarvestDir = join(
+      configRoot,
+      'notebooks',
+      'proj-1',
+      'sess-1',
+      'hpc',
+      'job-result-1'
+    )
+    await mkdir(join(dataHarvestDir, 'featured'), { recursive: true })
+    await mkdir(join(configHarvestDir, 'featured'), { recursive: true })
+    await writeFile(join(dataHarvestDir, 'featured', 'data-root.result'), 'readable by notebook')
+    await writeFile(
+      join(configHarvestDir, 'featured', 'stale-config.result'),
+      'must not be returned'
+    )
+
+    try {
+      const service = makeServiceWithStorageRoot(baseJob({ harvested_at: Date.now() }), dataRoot)
+      const result = await service.getJobResult('job-result-1')
+      expect(result.featured_files).toEqual([
+        join('hpc', 'job-result-1', 'featured', 'data-root.result')
+      ])
+      expect(result.output_files).toEqual([
+        join('hpc', 'job-result-1', 'featured', 'data-root.result')
+      ])
+    } finally {
+      await rm(configRoot, { recursive: true, force: true })
+      await rm(dataRoot, { recursive: true, force: true })
+    }
+  })
+
   it('harvest_failed: partial files returned, remote_workdir preserved', async () => {
     const harvestDir = join(tmpDir, 'notebooks', 'proj-1', 'sess-1', 'hpc', 'job-result-1')
     await mkdir(join(harvestDir, 'featured'), { recursive: true })

--- a/src/main/compute/harvest-engine.test.ts
+++ b/src/main/compute/harvest-engine.test.ts
@@ -10,9 +10,9 @@
  *             §6 (enumeration), §9 (harvest_failed).
  */
 
-import { mkdir } from 'node:fs/promises'
+import { mkdir, readFile, readdir, writeFile } from 'node:fs/promises'
 import { tmpdir } from 'node:os'
-import { join } from 'node:path'
+import { dirname, join } from 'node:path'
 import { randomBytes } from 'node:crypto'
 
 import { describe, expect, it, vi } from 'vitest'
@@ -23,6 +23,7 @@ import type { ScpRunner, ScpResult } from './scp-runner'
 import type { ComputeJobRepository } from './job-repository'
 import type { ComputeHostRepository } from './repository'
 import { getJobHarvestDir, harvestJob } from './harvest-engine'
+import { beginMigration, clearMigrationPending } from '../storage/migration-state'
 
 // ---------------------------------------------------------------------------
 // Helpers
@@ -112,6 +113,16 @@ const makeScpRunner = (failOnCall?: number): ScpRunner & { calls: string[][] } =
   }
 }
 
+const makeWritingScpRunner = (): ScpRunner => ({
+  copy: vi.fn(async (_bin: string, args: string[]): Promise<ScpResult> => {
+    const destination = args.at(-1)
+    if (!destination) throw new Error('scp destination is required')
+    await mkdir(dirname(destination), { recursive: true })
+    await writeFile(destination, 'downloaded')
+    return { exitCode: 0, stderr: '', timedOut: false }
+  })
+})
+
 const makeHostRepo = (host: ReturnType<typeof sampleHost> | null): ComputeHostRepository =>
   ({
     get: vi.fn(() => Promise.resolve(host))
@@ -161,6 +172,45 @@ describe('getJobHarvestDir', () => {
 // ---------------------------------------------------------------------------
 
 describe('harvestJob — clean harvest', () => {
+  it('writes and reports harvest files from the data-root session workspace, never the config root', async () => {
+    const configRoot = await mkTmp()
+    const dataRoot = await mkTmp()
+    const job = makeJob({
+      output_manifest: JSON.stringify(['*.result', { glob: '*.log', visibility: 'hidden' }])
+    })
+    const broadcasts: import('../../shared/compute').JobSummary[] = []
+
+    await harvestJob(job, {
+      sshRunner: makeSshRunner(
+        findOutput([
+          { path: 'stdout', size_bytes: 10 },
+          { path: 'stderr', size_bytes: 10 },
+          { path: 'run.result', size_bytes: 10 },
+          { path: 'debug.log', size_bytes: 10 }
+        ])
+      ),
+      scpRunner: makeWritingScpRunner(),
+      hostRepository: makeHostRepo(sampleHost()),
+      jobRepository: makeJobRepo(job).repo,
+      storageRoot: dataRoot,
+      broadcast: (summary) => broadcasts.push(summary)
+    })
+
+    const dataHarvestDir = join(dataRoot, 'notebooks', 'proj-1', 'sess-1', 'hpc', 'job-1')
+    const configHarvestDir = join(configRoot, 'notebooks', 'proj-1', 'sess-1', 'hpc', 'job-1')
+    await expect(readFile(join(dataHarvestDir, 'featured', 'run.result'), 'utf8')).resolves.toBe(
+      'downloaded'
+    )
+    await expect(readFile(join(dataHarvestDir, 'stdout'), 'utf8')).resolves.toBe('downloaded')
+    await expect(readFile(join(dataHarvestDir, 'stderr'), 'utf8')).resolves.toBe('downloaded')
+    await expect(readFile(join(dataHarvestDir, 'hidden', 'debug.log'), 'utf8')).resolves.toBe(
+      'downloaded'
+    )
+    await expect(readdir(configHarvestDir)).rejects.toMatchObject({ code: 'ENOENT' })
+    expect(broadcasts).toHaveLength(1)
+    expect(broadcasts[0]?.featured_files).toEqual(['hpc/job-1/featured/run.result'])
+  })
+
   it('downloads featured and hidden files to correct subdirs, sets harvestedAt', async () => {
     const storageRoot = await mkTmp()
     const job = makeJob({
@@ -218,6 +268,32 @@ describe('harvestJob — clean harvest', () => {
     const finalUpdate = updates[0]!.data as Record<string, unknown>
     expect(JSON.parse(finalUpdate.leftOnRemote as string)).toEqual([])
     expect(finalUpdate.harvestError).toBeNull()
+  })
+})
+
+describe('harvestJob — data-root migration gate', () => {
+  it('does not start a harvest while a data-root migration is pending', async () => {
+    const dataRoot = await mkTmp()
+    const job = makeJob()
+    const { repo: jobRepository, updates } = makeJobRepo(job)
+
+    beginMigration()
+    try {
+      await expect(
+        harvestJob(job, {
+          sshRunner: makeSshRunner(''),
+          scpRunner: makeScpRunner(),
+          hostRepository: makeHostRepo(sampleHost()),
+          jobRepository,
+          storageRoot: dataRoot
+        })
+      ).rejects.toThrow('Open Science is moving your data')
+    } finally {
+      clearMigrationPending()
+    }
+
+    expect(updates).toEqual([])
+    expect(await readdir(dataRoot)).toEqual([])
   })
 })
 

--- a/src/main/compute/harvest-engine.ts
+++ b/src/main/compute/harvest-engine.ts
@@ -36,6 +36,7 @@ import {
 } from './harvest-classifier'
 import { getNotebookSessionRoot } from '../notebook/repository'
 import { buildComputeDonePayload } from './job-notifier'
+import { withDataRootWrite } from '../storage/migration-state'
 
 // ---------------------------------------------------------------------------
 // Public path helper
@@ -241,6 +242,13 @@ const buildLeftOnRemoteUri = (
  * previous harvest (re-downloads files, re-writes DB fields).
  */
 export const harvestJob = async (job: ComputeJob, deps: HarvestDeps): Promise<void> => {
+  // A harvest writes into the relocatable session workspace. Keep one writer lease across the
+  // entire operation so a data-root move cannot copy one subset of outputs then let later files
+  // land in the old root before commit.
+  return await withDataRootWrite(async () => harvestJobUnchecked(job, deps))
+}
+
+const harvestJobUnchecked = async (job: ComputeJob, deps: HarvestDeps): Promise<void> => {
   const { sshRunner, scpRunner, hostRepository, jobRepository, storageRoot } = deps
   const resolveFn = deps.resolveSshTargetFn ?? resolveSshTarget
 
@@ -268,7 +276,10 @@ export const harvestJob = async (job: ComputeJob, deps: HarvestDeps): Promise<vo
   }
 
   // Helper: finalize + broadcast + return (DRY for all early-exit paths).
-  const finalizeAndReturn = async (harvestError: string | null, leftOnRemoteJson: string): Promise<void> => {
+  const finalizeAndReturn = async (
+    harvestError: string | null,
+    leftOnRemoteJson: string
+  ): Promise<void> => {
     const updatedJob = await finalize(harvestError, leftOnRemoteJson)
     // Broadcast the compute_done notification. We already have host lookup result here for
     // displayName, but early-exit paths don't — so we delegate displayName lookup to the

--- a/src/main/compute/ipc.test.ts
+++ b/src/main/compute/ipc.test.ts
@@ -592,6 +592,46 @@ describe('toJobSummary — harvest features and left_on_remote parsing', () => {
     expect(summary.featured_file_count).toBe(2)
   })
 
+  it('scans the relocated data-root workspace rather than a separate config root', async () => {
+    const configRoot = await mkdtemp(join(tmpdir(), 'compute-ipc-config-root-'))
+    const dataRoot = await mkdtemp(join(tmpdir(), 'compute-ipc-data-root-'))
+    const dataFeatured = join(
+      dataRoot,
+      'notebooks',
+      'proj-1',
+      'sess-1',
+      'hpc',
+      'job-harvest',
+      'featured'
+    )
+    const configFeatured = join(
+      configRoot,
+      'notebooks',
+      'proj-1',
+      'sess-1',
+      'hpc',
+      'job-harvest',
+      'featured'
+    )
+    await mkdir(dataFeatured, { recursive: true })
+    await mkdir(configFeatured, { recursive: true })
+    await writeFile(join(dataFeatured, 'data-root.csv'), 'from data root')
+    await writeFile(join(configFeatured, 'stale-config.csv'), 'must not be reported')
+
+    try {
+      const summary = await toJobSummary(sampleJob(), 'Biowulf HPC', dataRoot)
+      expect(summary.featured_files).toEqual([
+        join('hpc', 'job-harvest', 'featured', 'data-root.csv')
+      ])
+      expect(summary.featured_files).not.toContain(
+        join('hpc', 'job-harvest', 'featured', 'stale-config.csv')
+      )
+    } finally {
+      await rm(configRoot, { recursive: true, force: true })
+      await rm(dataRoot, { recursive: true, force: true })
+    }
+  })
+
   it('parses left_on_remote JSON and exposes the array plus count', async () => {
     const summary = await toJobSummary(
       sampleJob({

--- a/src/main/compute/ipc.ts
+++ b/src/main/compute/ipc.ts
@@ -23,7 +23,7 @@ import type {
 } from '../../shared/remote-fs'
 import { encodeRemoteFsError } from '../../shared/remote-fs'
 import { getProjectDbClient } from '../projects/prisma-client'
-import { resolveStorageRoot } from '../storage-root'
+import { resolveDataRoot, resolveStorageRoot } from '../storage-root'
 import { SettingsRepository } from '../settings/repository'
 import { broadcastToRenderers } from '../renderer-broadcast'
 import { ComputeApprovalBroker } from './compute-approval-broker'
@@ -378,12 +378,13 @@ const registerComputeIpcHandlers = (
   enabledComputeHostsRegistry: EnabledComputeHostsRegistry
 } => {
   const storageRoot = resolveStorageRoot()
+  const dataRoot = resolveDataRoot()
 
   // Share the settings repository with the broker so project grants are persisted (issue 05).
   const settingsRepo = new SettingsRepository(storageRoot)
 
   // Broadcast dispatcher status transitions to the renderer, same hook shape as the JobPoller uses.
-  const onJobUpdated = createJobUpdatedBroadcaster(repository, storageRoot)
+  const onJobUpdated = createJobUpdatedBroadcaster(repository, dataRoot)
 
   const handlers = createComputeHandlers(
     repository,
@@ -394,7 +395,7 @@ const registerComputeIpcHandlers = (
     jobRepository,
     onJobUpdated,
     artifactResolver,
-    storageRoot
+    dataRoot
   )
 
   ipcMain.handle('compute:list', () => handlers.list())

--- a/src/main/ipc.ts
+++ b/src/main/ipc.ts
@@ -381,7 +381,7 @@ const registerIpcHandlers = async ({
     hostRepository,
     enabledComputeHostsRegistry: hostsRegistry
   } = registerComputeIpcHandlers(undefined, undefined, computeArtifactResolver)
-  const storageRoot = resolveStorageRoot()
+  const dataRoot = resolveDataRoot()
   // Start the JobPoller wired to the shared broadcaster so every state/tail change is pushed to all
   // renderer windows via 'compute:job-updated' (Phase 3d, design.md §9 + §15.3). The dispatcher
   // (inside ComputeService) uses the same hook, so submitted→running/error transitions broadcast too.
@@ -398,7 +398,7 @@ const registerIpcHandlers = async ({
   // observed transitions (submitted→running/error) are drained inside registerComputeIpcHandlers via
   // onJobUpdatedWithDrain (src/main/compute/ipc.ts). Dropping the notifyJobCompleted call below would
   // silently stop queued jobs from dispatching on completion — with no test failure at this seam.
-  const broadcastJobUpdatedHook = createJobUpdatedBroadcaster(hostRepository, storageRoot)
+  const broadcastJobUpdatedHook = createJobUpdatedBroadcaster(hostRepository, dataRoot)
   const jobPoller = new JobPoller({
     runner: sshRunner,
     hostRepository,
@@ -408,14 +408,14 @@ const registerIpcHandlers = async ({
       computeService.notifyJobCompleted(job)
     },
     broadcast: broadcastJobUpdated,
-    storageRoot,
+    storageRoot: dataRoot,
     harvestFn: (job) =>
       harvestJob(job, {
         sshRunner,
         scpRunner,
         hostRepository,
         jobRepository,
-        storageRoot,
+        storageRoot: dataRoot,
         broadcast: broadcastJobUpdated
       })
   })


### PR DESCRIPTION
## Problem

Fixes [#477](https://github.com/aipoch/open-science/issues/477).

On Windows, when a user selects a custom data location and restarts the app, Notebook execution runs under the relocated data root while remote-compute harvests still use the fixed `.open-science` configuration root. A successful remote job can therefore return `hpc/<job-id>/featured/...` paths that are missing from the Notebook workspace, causing `FileNotFoundError` during result analysis and stopping publication.

## Proposed change

Route compute service result lookup, job-update summaries, poller notifications, and harvest destinations through the resolved relocatable data root. Guard harvest writes with the data-root migration writer lease.

## Scope and non-goals

This change is limited to remote compute harvest paths and notification/result readers. It does not move configuration databases or alter the data-root migration protocol.

## Acceptance criteria and validation

- Harvested `hpc/<job-id>/...` files are written under the active data-root Notebook workspace.
- Featured-file notifications and `attach_job(job_id).result()` read from that same workspace.
- Harvests do not write while a data-root migration is pending.
- The Windows custom-data-root scenario from #477 no longer produces missing local result paths.
- `npm run typecheck`, `npm run lint`, and `npm run test` pass.

## Review focus

Verify that all compute paths that resolve harvest directories receive the data root while compute repositories and settings continue to use the configuration root.

Closes #477.