### PR TITLE
fix(permissions): auto-approve Codex artifact saves

### DIFF
--- a/src/main/acp/permission-policy.test.ts
+++ b/src/main/acp/permission-policy.test.ts
@@ -205,6 +205,15 @@ describe('permission policy', () => {
 
     expect(
       resolveAutomaticPermission(
+        createPermissionRequest('other', undefined, {
+          providerToolName: 'write_artifact_file'
+        }),
+        { profile: 'ask', mcpServerNames: ['open-science-artifacts'] }
+      )
+    ).toBeUndefined()
+
+    expect(
+      resolveAutomaticPermission(
         createPermissionRequest('other', undefined, { title: 'write_artifact_file' }),
         { profile: 'ask', mcpServerNames: ['open-science-artifacts'] }
       )

--- a/src/main/acp/permission-policy.ts
+++ b/src/main/acp/permission-policy.ts
@@ -21,6 +21,19 @@ type PermissionPolicyContext = {
   mcpServerNames?: readonly string[]
 }
 
+const TRUSTED_MCP_TOOL_IDENTITY = Symbol('trusted-mcp-tool-identity')
+type TrustedMcpPermissionRequest = RequestPermissionRequest & {
+  [TRUSTED_MCP_TOOL_IDENTITY]?: string
+}
+
+// Carries a runtime-verified MCP identity across the broker without serializing it back to ACP. A
+// symbol key cannot be supplied by provider JSON, while its enumerable value survives the broker's
+// options projection spread before automatic policy resolution.
+const withTrustedMcpToolIdentity = (
+  params: RequestPermissionRequest,
+  identity: string
+): RequestPermissionRequest => Object.assign({}, params, { [TRUSTED_MCP_TOOL_IDENTITY]: identity })
+
 // MCP tool naming differs per framework: Claude Code namespaces them mcp__<server>__<tool>, Codex
 // reports mcp.<server>.<tool>, and opencode joins them <server>_<tool>. Claude's distinctive prefix is
 // self-identifying; the shorter Codex/opencode forms are checked against known session servers.
@@ -124,7 +137,10 @@ const isArtifactSaveTool = (
   const providerToolName = extractProviderToolName(params.toolCall)
   if (!providerToolName) return false
 
+  const trustedMcpIdentity = (params as TrustedMcpPermissionRequest)[TRUSTED_MCP_TOOL_IDENTITY]
+
   return (
+    trustedMcpIdentity === 'open-science-artifacts/write_artifact_file' ||
     providerToolName === 'mcp__open-science-artifacts__write_artifact_file' ||
     providerToolName === 'mcp__open_science_artifacts__write_artifact_file' ||
     providerToolName === 'mcp.open-science-artifacts.write_artifact_file' ||
@@ -183,6 +199,7 @@ export {
   isWithinWorkspace,
   resolveMcpProviderLeafIdentity,
   resolveAutomaticPermission,
-  resolveAllowOptionId
+  resolveAllowOptionId,
+  withTrustedMcpToolIdentity
 }
 export type { PermissionPolicyContext }

--- a/src/main/acp/runtime.test.ts
+++ b/src/main/acp/runtime.test.ts
@@ -4325,6 +4325,63 @@ describe('ACP runtime session management', () => {
     expect(permissionRequests).toHaveLength(0)
   })
 
+  it('auto-allows a Codex Artifact save restored from its sparse MCP approval', async () => {
+    const process = new FakeAgentProcess()
+    const permissionRequests: AcpPermissionRequest[] = []
+    let permissionResponse: unknown
+    startPermissionProbeAgent(process, {
+      newSessionId: 'codex-artifact-session',
+      toolCallId: 'codex-artifact-1',
+      toolTitle: 'unused-by-sparse-codex-approval',
+      sparseCodexMcpApproval: true,
+      codexMcpIdentity: {
+        server: 'open-science-artifacts',
+        tool: 'write_artifact_file',
+        arguments: {
+          filename: 'results.md',
+          mimeType: 'text/markdown',
+          content: '# Results'
+        }
+      },
+      modes: createModes(['read-only', 'agent', 'agent-full-access'], 'agent'),
+      permissionOptions: [
+        { optionId: 'allow-once', name: 'Allow once', kind: 'allow_once' },
+        { optionId: 'reject-once', name: 'Reject', kind: 'reject_once' }
+      ],
+      onPermissionResponse: (response) => {
+        permissionResponse = response
+      }
+    })
+    const root = await createTemporaryRoot()
+    const runtime = new AcpRuntime({
+      appVersion: '0.1.0',
+      defaultCwd: '/workspace',
+      spawnAgent: () => asAgentProcess(process),
+      framework: codexFramework,
+      artifacts: {
+        configRoot: root,
+        dataRoot: root,
+        projectName: 'default-project',
+        mcpEntryPath: '/app/out/main/index.js',
+        repository: new ArtifactRepository(root)
+      },
+      callbacks: {
+        onPermissionRequest: (request) => {
+          permissionRequests.push(request)
+          runtime.respondToPermission({ requestId: request.requestId, cancelled: true })
+        }
+      }
+    })
+    const session = await runtime.createSession({ cwd: '/workspace', permissionProfile: 'ask' })
+
+    await runtime.sendPrompt({ sessionId: session.sessionId, text: 'save results.md' })
+
+    expect(permissionRequests).toHaveLength(0)
+    expect(permissionResponse).toEqual({
+      outcome: { outcome: 'selected', optionId: 'allow-once' }
+    })
+  })
+
   it('auto-allows a Claude Code Artifact save identified by its qualified MCP title', async () => {
     const process = new FakeAgentProcess()
     const permissionRequests: AcpPermissionRequest[] = []

--- a/src/main/acp/runtime.test.ts
+++ b/src/main/acp/runtime.test.ts
@@ -430,6 +430,8 @@ const startPermissionProbeAgent = (
       tool: string
       arguments?: Record<string, unknown>
     }
+    codexMcpMarker?: boolean
+    codexMcpTitle?: string
     announceToolCall?: boolean
     sparseCodexMcpApproval?: boolean
     modes?: SessionModeState
@@ -486,14 +488,16 @@ const startPermissionProbeAgent = (
             sessionUpdate: 'tool_call',
             toolCallId: options.toolCallId,
             kind: 'execute',
-            title: `mcp.${options.codexMcpIdentity.server}.${options.codexMcpIdentity.tool}`,
+            title:
+              options.codexMcpTitle ??
+              `mcp.${options.codexMcpIdentity.server}.${options.codexMcpIdentity.tool}`,
             status: 'pending',
             rawInput: {
               server: options.codexMcpIdentity.server,
               tool: options.codexMcpIdentity.tool,
               arguments: options.codexMcpIdentity.arguments ?? {}
             },
-            _meta: { is_mcp_tool_call: true }
+            ...(options.codexMcpMarker === false ? {} : { _meta: { is_mcp_tool_call: true } })
           }
         })
       }
@@ -4380,6 +4384,63 @@ describe('ACP runtime session management', () => {
     expect(permissionResponse).toEqual({
       outcome: { outcome: 'selected', optionId: 'allow-once' }
     })
+  })
+
+  it.each([
+    { name: 'without the Codex MCP marker', codexMcpMarker: false },
+    {
+      name: 'with a mismatched qualified title',
+      codexMcpTitle: 'mcp.open-science-artifacts.unrelated_tool'
+    }
+  ])('does not auto-allow a Codex Artifact save $name', async (probeOptions) => {
+    const process = new FakeAgentProcess()
+    const permissionRequests: AcpPermissionRequest[] = []
+    let permissionResponse: unknown
+    startPermissionProbeAgent(process, {
+      newSessionId: 'untrusted-codex-artifact-session',
+      toolCallId: 'untrusted-codex-artifact-1',
+      toolTitle: 'unused-by-sparse-codex-approval',
+      sparseCodexMcpApproval: true,
+      codexMcpIdentity: {
+        server: 'open-science-artifacts',
+        tool: 'write_artifact_file'
+      },
+      ...probeOptions,
+      modes: createModes(['read-only', 'agent', 'agent-full-access'], 'agent'),
+      permissionOptions: [
+        { optionId: 'allow-once', name: 'Allow once', kind: 'allow_once' },
+        { optionId: 'reject-once', name: 'Reject', kind: 'reject_once' }
+      ],
+      onPermissionResponse: (response) => {
+        permissionResponse = response
+      }
+    })
+    const root = await createTemporaryRoot()
+    const runtime = new AcpRuntime({
+      appVersion: '0.1.0',
+      defaultCwd: '/workspace',
+      spawnAgent: () => asAgentProcess(process),
+      framework: codexFramework,
+      artifacts: {
+        configRoot: root,
+        dataRoot: root,
+        projectName: 'default-project',
+        mcpEntryPath: '/app/out/main/index.js',
+        repository: new ArtifactRepository(root)
+      },
+      callbacks: {
+        onPermissionRequest: (request) => {
+          permissionRequests.push(request)
+          runtime.respondToPermission({ requestId: request.requestId, cancelled: true })
+        }
+      }
+    })
+    const session = await runtime.createSession({ cwd: '/workspace', permissionProfile: 'ask' })
+
+    await runtime.sendPrompt({ sessionId: session.sessionId, text: 'save results.md' })
+
+    expect(permissionRequests).toHaveLength(1)
+    expect(permissionResponse).toEqual({ outcome: { outcome: 'cancelled' } })
   })
 
   it('auto-allows a Claude Code Artifact save identified by its qualified MCP title', async () => {

--- a/src/main/acp/runtime.ts
+++ b/src/main/acp/runtime.ts
@@ -84,7 +84,7 @@ import {
   ConversationPermissionGrantStore,
   resolveNotebookPermissionContext
 } from './permission-broker'
-import { isMcpToolName } from './permission-policy'
+import { isMcpToolName, withTrustedMcpToolIdentity } from './permission-policy'
 import { applyCurrentModeUpdate } from './permission-profile-controller'
 import {
   ARTIFACT_MCP_SERVER_NAME,
@@ -327,6 +327,7 @@ type ClientContextSessionAttacher = {
 type CodexMcpToolIdentity = {
   title: string
   providerToolName: string
+  mcpIdentity: string
   rawInput: unknown
 }
 
@@ -417,6 +418,7 @@ const codexMcpToolIdentity = (
   return {
     title: event.title ?? `mcp.${server}.${tool}`,
     providerToolName: tool,
+    mcpIdentity: `${server}/${tool}`,
     rawInput: event.rawInput.arguments
   }
 }
@@ -4475,15 +4477,18 @@ class AcpRuntime {
 
     const toolMeta = isRecord(params.toolCall._meta) ? params.toolCall._meta : {}
 
-    return {
-      ...params,
-      toolCall: {
-        ...params.toolCall,
-        title: params.toolCall.title ?? identity.title,
-        rawInput: params.toolCall.rawInput ?? identity.rawInput,
-        _meta: { ...toolMeta, toolName: identity.providerToolName }
-      }
-    }
+    return withTrustedMcpToolIdentity(
+      {
+        ...params,
+        toolCall: {
+          ...params.toolCall,
+          title: params.toolCall.title ?? identity.title,
+          rawInput: params.toolCall.rawInput ?? identity.rawInput,
+          _meta: { ...toolMeta, toolName: identity.providerToolName }
+        }
+      },
+      identity.mcpIdentity
+    )
   }
 
   private restoreClaudeCodeMcpToolInput(

--- a/src/main/acp/runtime.ts
+++ b/src/main/acp/runtime.ts
@@ -395,8 +395,15 @@ const isCodexMcpApproval = (params: RequestPermissionRequest): boolean => {
   return isRecord(meta) && meta.is_mcp_tool_approval === true
 }
 
+const isCodexMcpToolCall = (update: SessionNotification['update']): boolean => {
+  const meta = (update as SessionNotification['update'] & { _meta?: unknown })._meta
+
+  return isRecord(meta) && meta.is_mcp_tool_call === true
+}
+
 // Codex emits the full MCP identity in tool_call immediately before a sparse permission request.
-// Trust it only when the reported server is one this session was actually configured to use.
+// Trust it only when the adapter marks the event as MCP, its qualified title matches server/tool,
+// and the reported server is one this session was actually configured to use.
 const codexMcpToolIdentity = (
   event: AcpRuntimeEvent,
   mcpServerNames: readonly string[]
@@ -415,8 +422,11 @@ const codexMcpToolIdentity = (
     return undefined
   }
 
+  const title = `mcp.${server}.${tool}`
+  if (event.title !== title) return undefined
+
   return {
-    title: event.title ?? `mcp.${server}.${tool}`,
+    title,
     providerToolName: tool,
     mcpIdentity: `${server}/${tool}`,
     rawInput: event.rawInput.arguments
@@ -4356,6 +4366,8 @@ class AcpRuntime {
 
     const mcpServerNames = this.sessionMcpServerNames.get(sessionId) ?? []
     if (framework === 'codex') {
+      if (!isCodexMcpToolCall(notification.update)) return
+
       const identity = codexMcpToolIdentity(event, mcpServerNames)
       if (!identity) return
 


### PR DESCRIPTION
## Problem

Codex ACP emits Artifact saves as sparse MCP approval requests. Open Science restores the verified MCP server/tool identity, but the permission policy did not recognize the canonical Codex leaf name, so Codex showed a user approval prompt while Claude Code already completed the same app-owned save without one.

## Proposed change

Carry the runtime-verified Codex MCP identity through permission projection with an internal Symbol marker, and auto-approve only the exact `open-science-artifacts/write_artifact_file` capability. Add policy coverage for the untrusted bare-name rejection path and an end-to-end regression test using the sparse Codex MCP approval shape.

## Scope and non-goals

This changes only the app-owned Artifact save permission path. It does not auto-approve ordinary file writes, unverified bare tool names, third-party MCP tools, or other Codex permissions.

## Acceptance criteria and validation

- Codex Artifact saves receive one-call approval without emitting a renderer permission request.
- A bare `write_artifact_file` provider name remains insufficient without the runtime-verified MCP identity.
- Claude Code and OpenCode Artifact save behavior remains unchanged.
- `npm run typecheck`
- `npm run lint`
- `npm test`

## Review focus

Please verify that the internal trusted identity survives the broker option projection while remaining impossible to inject through ACP JSON.