### PR TITLE
fix(provenance): bound environment operation history

### DIFF
--- a/src/main/artifacts/provenance-repository.test.ts
+++ b/src/main/artifacts/provenance-repository.test.ts
@@ -844,6 +844,10 @@ describe('artifact provenance repository', () => {
           ]
         }
       ],
+      operationLogTruncation: {
+        omittedCount: 4,
+        earliestRetainedAt: '2026-07-27T11:58:00.000Z'
+      },
       complete: true,
       captureStatus: 'complete'
     }
@@ -1084,6 +1088,10 @@ describe('artifact provenance repository', () => {
             ]
           })
         ],
+        op_log_truncation: {
+          omitted_count: 4,
+          earliest_retained_at: '2026-07-27T11:58:00.000Z'
+        },
         source_manifest_checksum: environmentManifestChecksum,
         complete: true,
         capture_status: 'complete'

--- a/src/main/artifacts/provenance-repository.ts
+++ b/src/main/artifacts/provenance-repository.ts
@@ -937,6 +937,16 @@ const environmentEvidence = (
         }))
       }
     : {}),
+  ...(manifest.operationLogTruncation
+    ? {
+        op_log_truncation: {
+          omitted_count: manifest.operationLogTruncation.omittedCount,
+          ...(manifest.operationLogTruncation.earliestRetainedAt
+            ? { earliest_retained_at: manifest.operationLogTruncation.earliestRetainedAt }
+            : {})
+        }
+      }
+    : {}),
   captured_at: manifest.capturedAt,
   source_manifest_checksum: checksum,
   complete: manifest.complete,

--- a/src/main/notebook/environment-state-tracker.test.ts
+++ b/src/main/notebook/environment-state-tracker.test.ts
@@ -21,6 +21,12 @@ const target = {
   args: []
 }
 
+const bindingPath = async (root: string): Promise<string> => {
+  const inventoryRoot = join(root, 'runtime', 'provenance', 'environment-inventory')
+  const [targetKey] = await readdir(inventoryRoot)
+  return join(inventoryRoot, targetKey, 'binding.json')
+}
+
 const readBinding = async (
   root: string
 ): Promise<{
@@ -28,9 +34,7 @@ const readBinding = async (
   operationLogTruncation?: { omittedCount: number; earliestRetainedAt?: string }
   dirtyOperationId?: string
 }> => {
-  const inventoryRoot = join(root, 'runtime', 'provenance', 'environment-inventory')
-  const [targetKey] = await readdir(inventoryRoot)
-  return JSON.parse(await readFile(join(inventoryRoot, targetKey, 'binding.json'), 'utf8'))
+  return JSON.parse(await readFile(await bindingPath(root), 'utf8'))
 }
 
 describe('EnvironmentStateTracker', () => {
@@ -324,7 +328,7 @@ describe('EnvironmentStateTracker', () => {
 
   it('bounds byte-heavy completed operation history by serialized size', async () => {
     dataRoot = await mkdtemp(join(tmpdir(), 'open-science-env-log-bytes-'))
-    const maxBytes = 1_000
+    const maxBytes = 2_500
     const tracker = new EnvironmentStateTracker({
       dataRoot,
       inspectInstalled: vi.fn().mockResolvedValue({ runtimeVersion: '3.13.2', packages: [] }),
@@ -349,11 +353,8 @@ describe('EnvironmentStateTracker', () => {
     }
 
     const binding = await readBinding(dataRoot)
-    const retainedBytes = binding.operationLog.reduce(
-      (total, operation) => total + Buffer.byteLength(JSON.stringify(operation), 'utf8'),
-      0
-    )
-    expect(retainedBytes).toBeLessThanOrEqual(maxBytes)
+    const persistedBytes = Buffer.byteLength(await readFile(await bindingPath(dataRoot), 'utf8'))
+    expect(persistedBytes).toBeLessThanOrEqual(maxBytes)
     expect(binding.operationLog.at(-1)?.operationId).toBe('large-operation-4')
     expect(binding.operationLogTruncation?.omittedCount).toBeGreaterThan(0)
   })

--- a/src/main/notebook/environment-state-tracker.test.ts
+++ b/src/main/notebook/environment-state-tracker.test.ts
@@ -21,6 +21,18 @@ const target = {
   args: []
 }
 
+const readBinding = async (
+  root: string
+): Promise<{
+  operationLog: Array<{ operationId: string; timestamp: string }>
+  operationLogTruncation?: { omittedCount: number; earliestRetainedAt?: string }
+  dirtyOperationId?: string
+}> => {
+  const inventoryRoot = join(root, 'runtime', 'provenance', 'environment-inventory')
+  const [targetKey] = await readdir(inventoryRoot)
+  return JSON.parse(await readFile(join(inventoryRoot, targetKey, 'binding.json'), 'utf8'))
+}
+
 describe('EnvironmentStateTracker', () => {
   it('reuses immutable installed inventory while capturing fresh live-Kernel state per run', async () => {
     dataRoot = await mkdtemp(join(tmpdir(), 'open-science-env-state-'))
@@ -251,6 +263,126 @@ describe('EnvironmentStateTracker', () => {
         })
       ])
     )
+  })
+
+  it('retains only the newest completed operations within the entry budget', async () => {
+    dataRoot = await mkdtemp(join(tmpdir(), 'open-science-env-log-count-'))
+    let timestamp = Date.parse('2026-07-27T10:00:00.000Z')
+    const tracker = new EnvironmentStateTracker({
+      dataRoot,
+      inspectInstalled: vi.fn().mockResolvedValue({
+        runtimeVersion: '3.13.2',
+        packages: [
+          {
+            name: 'numpy',
+            version: '2.2.0',
+            versionStatus: 'known',
+            ecosystem: 'python',
+            evidenceSources: ['python-importlib-metadata']
+          }
+        ]
+      }),
+      captureFingerprint: vi.fn().mockResolvedValue('stable-python'),
+      now: () => new Date((timestamp += 1_000)),
+      operationLogLimits: { maxEntries: 3, maxBytes: 1_000_000 }
+    })
+
+    for (let index = 1; index <= 5; index += 1) {
+      const operationId = `operation-${index}`
+      await tracker.markPackageMutationDirty(target, {
+        operationId,
+        operation: 'install',
+        packages: ['numpy']
+      })
+      await tracker.refreshAfterPackageMutation(target, {
+        operationId,
+        operation: 'install',
+        packages: ['numpy'],
+        result: 'success'
+      })
+    }
+
+    const capture = await tracker.captureCompletedRun(target)
+    expect(capture.manifest.operationLog?.map((operation) => operation.operationId)).toEqual([
+      'operation-3',
+      'operation-4',
+      'operation-5'
+    ])
+    expect(capture.manifest.operationLogTruncation).toEqual({
+      omittedCount: 2,
+      earliestRetainedAt: capture.manifest.operationLog?.[0].timestamp
+    })
+    await expect(readBinding(dataRoot)).resolves.toMatchObject({
+      operationLog: [
+        { operationId: 'operation-3' },
+        { operationId: 'operation-4' },
+        { operationId: 'operation-5' }
+      ],
+      operationLogTruncation: { omittedCount: 2 }
+    })
+  })
+
+  it('bounds byte-heavy completed operation history by serialized size', async () => {
+    dataRoot = await mkdtemp(join(tmpdir(), 'open-science-env-log-bytes-'))
+    const maxBytes = 1_000
+    const tracker = new EnvironmentStateTracker({
+      dataRoot,
+      inspectInstalled: vi.fn().mockResolvedValue({ runtimeVersion: '3.13.2', packages: [] }),
+      captureFingerprint: vi.fn().mockResolvedValue('stable-python'),
+      operationLogLimits: { maxEntries: 20, maxBytes }
+    })
+
+    for (let index = 1; index <= 4; index += 1) {
+      const operationId = `large-operation-${index}`
+      const packageSpec = `missing-${index}-${'x'.repeat(300)}`
+      await tracker.markPackageMutationDirty(target, {
+        operationId,
+        operation: 'install',
+        packages: [packageSpec]
+      })
+      await tracker.refreshAfterPackageMutation(target, {
+        operationId,
+        operation: 'install',
+        packages: [packageSpec],
+        result: 'failure'
+      })
+    }
+
+    const binding = await readBinding(dataRoot)
+    const retainedBytes = binding.operationLog.reduce(
+      (total, operation) => total + Buffer.byteLength(JSON.stringify(operation), 'utf8'),
+      0
+    )
+    expect(retainedBytes).toBeLessThanOrEqual(maxBytes)
+    expect(binding.operationLog.at(-1)?.operationId).toBe('large-operation-4')
+    expect(binding.operationLogTruncation?.omittedCount).toBeGreaterThan(0)
+  })
+
+  it('retains the recovery-critical operation even when it exceeds both budgets', async () => {
+    dataRoot = await mkdtemp(join(tmpdir(), 'open-science-env-log-recovery-'))
+    const tracker = new EnvironmentStateTracker({
+      dataRoot,
+      inspectInstalled: vi.fn().mockRejectedValue(new Error('inventory unavailable')),
+      captureFingerprint: vi.fn().mockResolvedValue('stable-python'),
+      operationLogLimits: { maxEntries: 0, maxBytes: 0 }
+    })
+
+    await tracker.markPackageMutationDirty(target, {
+      operationId: 'operation-pending-recovery',
+      operation: 'install',
+      packages: ['numpy']
+    })
+    await tracker.refreshAfterPackageMutation(target, {
+      operationId: 'operation-pending-recovery',
+      operation: 'install',
+      packages: ['numpy'],
+      result: 'success'
+    })
+
+    await expect(readBinding(dataRoot)).resolves.toMatchObject({
+      dirtyOperationId: 'operation-pending-recovery',
+      operationLog: [{ operationId: 'operation-pending-recovery' }]
+    })
   })
 
   it('marks a successful installer process as failed when the requested R package is absent', async () => {

--- a/src/main/notebook/environment-state-tracker.ts
+++ b/src/main/notebook/environment-state-tracker.ts
@@ -7,6 +7,7 @@ import { promisify } from 'node:util'
 import type {
   NotebookEnvironmentManifest,
   NotebookEnvironmentOperation,
+  NotebookEnvironmentOperationLogTruncation,
   NotebookEnvironmentPackageChange,
   NotebookEnvironmentPackage,
   NotebookInventoryRefreshAttempt,
@@ -18,6 +19,10 @@ import type {
 const execFileAsync = promisify(execFile)
 const INSPECTION_TIMEOUT_MS = 30_000
 const MAX_INVENTORY_CACHE_AGE_MS = 24 * 60 * 60 * 1_000
+// The mutable binding cache is read on every run, so keep completed operation history bounded by
+// both shape and serialized size. Recovery-critical entries may temporarily exceed these limits.
+const MAX_OPERATION_LOG_ENTRIES = 200
+const MAX_OPERATION_LOG_BYTES = 256 * 1_024
 
 type EnvironmentCaptureTarget = {
   language: NotebookLanguage
@@ -63,6 +68,7 @@ type EnvironmentInventoryBindingCache = {
   dirtyReason?: 'package-mutation' | 'fingerprint-changed' | 'recovery'
   verifiedAt?: string
   operationLog: NotebookEnvironmentOperation[]
+  operationLogTruncation?: NotebookEnvironmentOperationLogTruncation
 }
 
 type EnvironmentRunCaptureStart = {
@@ -102,6 +108,10 @@ type EnvironmentStateTrackerOptions = {
   inspectInstalled?: (target: EnvironmentCaptureTarget) => Promise<InstalledEnvironmentInventory>
   captureFingerprint?: (target: EnvironmentCaptureTarget) => Promise<string | undefined>
   now?: () => Date
+  operationLogLimits?: {
+    maxEntries: number
+    maxBytes: number
+  }
 }
 
 class EnvironmentManifestPublicationError extends Error {
@@ -117,6 +127,62 @@ const sha256 = (value: string): string => createHash('sha256').update(value).dig
 
 const describeError = (error: unknown): string =>
   error instanceof Error ? error.message : String(error)
+
+const operationLogEntryBytes = (operation: NotebookEnvironmentOperation): number =>
+  Buffer.byteLength(JSON.stringify(operation), 'utf8')
+
+const compactOperationLog = (
+  cache: EnvironmentInventoryBindingCache,
+  limits: { maxEntries: number; maxBytes: number }
+): boolean => {
+  const protectedOperationIds = new Set(cache.dirtyOperationId ? [cache.dirtyOperationId] : [])
+  const retainedIndexes = new Set<number>()
+  let retainedEntries = 0
+  let retainedBytes = 0
+
+  cache.operationLog.forEach((operation, index) => {
+    if (!protectedOperationIds.has(operation.operationId)) return
+    retainedIndexes.add(index)
+    retainedEntries += 1
+    retainedBytes += operationLogEntryBytes(operation)
+  })
+
+  // Retain a contiguous suffix of completed operations. Skipping an oversized recent entry while
+  // keeping older entries would make the visible history look complete when it contains a gap.
+  for (let index = cache.operationLog.length - 1; index >= 0; index -= 1) {
+    if (retainedIndexes.has(index)) continue
+    const operationBytes = operationLogEntryBytes(cache.operationLog[index])
+    if (retainedEntries >= limits.maxEntries || retainedBytes + operationBytes > limits.maxBytes) {
+      break
+    }
+    retainedIndexes.add(index)
+    retainedEntries += 1
+    retainedBytes += operationBytes
+  }
+
+  const retained = cache.operationLog.filter((_operation, index) => retainedIndexes.has(index))
+  const newlyOmitted = cache.operationLog.length - retained.length
+  const omittedCount = (cache.operationLogTruncation?.omittedCount ?? 0) + newlyOmitted
+  const earliestRetainedAt = retained
+    .map((operation) => operation.timestamp)
+    .filter((timestamp) => timestamp.length > 0)
+    .sort()[0]
+  const nextTruncation =
+    omittedCount > 0
+      ? {
+          omittedCount,
+          ...(earliestRetainedAt ? { earliestRetainedAt } : {})
+        }
+      : undefined
+  const changed =
+    newlyOmitted > 0 ||
+    cache.operationLogTruncation?.omittedCount !== nextTruncation?.omittedCount ||
+    cache.operationLogTruncation?.earliestRetainedAt !== nextTruncation?.earliestRetainedAt
+
+  cache.operationLog = retained
+  cache.operationLogTruncation = nextTruncation
+  return changed
+}
 
 const packageKey = (value: string): string => value.normalize('NFC').toLocaleLowerCase('und')
 
@@ -447,12 +513,17 @@ class EnvironmentStateTracker {
     target: EnvironmentCaptureTarget
   ) => Promise<string | undefined>
   private readonly now: () => Date
+  private readonly operationLogLimits: { maxEntries: number; maxBytes: number }
   private readonly targetQueues = new Map<string, Promise<void>>()
 
   constructor(private readonly options: EnvironmentStateTrackerOptions) {
     this.inspectInstalled = options.inspectInstalled ?? inspectInstalledDefault
     this.captureFingerprint = options.captureFingerprint ?? captureFingerprintDefault
     this.now = options.now ?? (() => new Date())
+    this.operationLogLimits = options.operationLogLimits ?? {
+      maxEntries: MAX_OPERATION_LOG_ENTRIES,
+      maxBytes: MAX_OPERATION_LOG_BYTES
+    }
   }
 
   async prepareRun(target: EnvironmentCaptureTarget): Promise<EnvironmentRunCaptureStart> {
@@ -519,6 +590,9 @@ class EnvironmentStateTracker {
     return this.serializeTarget(target, async () => {
       const capturedAt = this.now().toISOString()
       const cache = await this.readBinding(target)
+      if (compactOperationLog(cache, this.operationLogLimits)) {
+        await this.writeBinding(target, cache)
+      }
       let inventory: StoredInventory | undefined
       let inventorySource: NotebookEnvironmentManifest['installedInventory']['source'] =
         runStart.inventoryRefreshed ? 'full-scan' : 'cache-reused'
@@ -591,6 +665,9 @@ class EnvironmentStateTracker {
         ],
         packages,
         ...(cache.operationLog.length > 0 ? { operationLog: cache.operationLog } : {}),
+        ...(cache.operationLogTruncation
+          ? { operationLogTruncation: cache.operationLogTruncation }
+          : {}),
         complete,
         captureStatus: complete ? 'complete' : 'partial',
         ...(warnings.length > 0 ? { warnings } : {})
@@ -972,6 +1049,15 @@ class EnvironmentStateTracker {
         inventoryRefresh: operation.inventoryRefresh ?? 'published',
         inventoryRefreshAttempts: operation.inventoryRefreshAttempts ?? []
       }))
+      if (
+        parsed.operationLogTruncation &&
+        (!Number.isInteger(parsed.operationLogTruncation.omittedCount) ||
+          parsed.operationLogTruncation.omittedCount <= 0 ||
+          (parsed.operationLogTruncation.earliestRetainedAt !== undefined &&
+            typeof parsed.operationLogTruncation.earliestRetainedAt !== 'string'))
+      ) {
+        throw new Error('Invalid environment operation log truncation metadata.')
+      }
       return parsed
     } catch (error) {
       if (
@@ -990,6 +1076,7 @@ class EnvironmentStateTracker {
     target: EnvironmentCaptureTarget,
     cache: EnvironmentInventoryBindingCache
   ): Promise<void> {
+    compactOperationLog(cache, this.operationLogLimits)
     const path = join(this.targetDirectory(target), 'binding.json')
     await mkdir(dirname(path), { recursive: true })
     const temporary = `${path}.${process.pid}.tmp`

--- a/src/main/notebook/environment-state-tracker.ts
+++ b/src/main/notebook/environment-state-tracker.ts
@@ -4,16 +4,17 @@ import { mkdir, readFile, rename, rm, writeFile } from 'node:fs/promises'
 import { dirname, join } from 'node:path'
 import { promisify } from 'node:util'
 
-import type {
-  NotebookEnvironmentManifest,
-  NotebookEnvironmentOperation,
-  NotebookEnvironmentOperationLogTruncation,
-  NotebookEnvironmentPackageChange,
-  NotebookEnvironmentPackage,
-  NotebookInventoryRefreshAttempt,
-  NotebookLiveEnvironmentOverlay,
-  NotebookLanguage,
-  NotebookPackageInstallerAttempt
+import {
+  isNotebookEnvironmentOperationLogTruncation,
+  type NotebookEnvironmentManifest,
+  type NotebookEnvironmentOperation,
+  type NotebookEnvironmentOperationLogTruncation,
+  type NotebookEnvironmentPackageChange,
+  type NotebookEnvironmentPackage,
+  type NotebookInventoryRefreshAttempt,
+  type NotebookLiveEnvironmentOverlay,
+  type NotebookLanguage,
+  type NotebookPackageInstallerAttempt
 } from '../../shared/notebook'
 
 const execFileAsync = promisify(execFile)
@@ -22,7 +23,7 @@ const MAX_INVENTORY_CACHE_AGE_MS = 24 * 60 * 60 * 1_000
 // The mutable binding cache is read on every run, so keep completed operation history bounded by
 // both shape and serialized size. Recovery-critical entries may temporarily exceed these limits.
 const MAX_OPERATION_LOG_ENTRIES = 200
-const MAX_OPERATION_LOG_BYTES = 256 * 1_024
+const MAX_ENVIRONMENT_BINDING_BYTES = 256 * 1_024
 
 type EnvironmentCaptureTarget = {
   language: NotebookLanguage
@@ -128,8 +129,34 @@ const sha256 = (value: string): string => createHash('sha256').update(value).dig
 const describeError = (error: unknown): string =>
   error instanceof Error ? error.message : String(error)
 
-const operationLogEntryBytes = (operation: NotebookEnvironmentOperation): number =>
-  Buffer.byteLength(JSON.stringify(operation), 'utf8')
+const serializedBindingBytes = (cache: EnvironmentInventoryBindingCache): number =>
+  Buffer.byteLength(`${JSON.stringify(cache, null, 2)}\n`, 'utf8')
+
+const operationLogTruncationFor = (
+  retained: NotebookEnvironmentOperation[],
+  omittedCount: number
+): NotebookEnvironmentOperationLogTruncation | undefined => {
+  if (omittedCount <= 0) return undefined
+  const earliestRetainedAt = retained
+    .map((operation) => operation.timestamp)
+    .filter((timestamp) => timestamp.length > 0)
+    .sort()[0]
+  return {
+    omittedCount,
+    ...(earliestRetainedAt ? { earliestRetainedAt } : {})
+  }
+}
+
+const bindingWithOperationLog = (
+  cache: EnvironmentInventoryBindingCache,
+  operationLog: NotebookEnvironmentOperation[],
+  operationLogTruncation: NotebookEnvironmentOperationLogTruncation | undefined
+): EnvironmentInventoryBindingCache => {
+  const candidate = { ...cache, operationLog }
+  if (operationLogTruncation) candidate.operationLogTruncation = operationLogTruncation
+  else delete candidate.operationLogTruncation
+  return candidate
+}
 
 const compactOperationLog = (
   cache: EnvironmentInventoryBindingCache,
@@ -137,43 +164,45 @@ const compactOperationLog = (
 ): boolean => {
   const protectedOperationIds = new Set(cache.dirtyOperationId ? [cache.dirtyOperationId] : [])
   const retainedIndexes = new Set<number>()
-  let retainedEntries = 0
-  let retainedBytes = 0
 
   cache.operationLog.forEach((operation, index) => {
     if (!protectedOperationIds.has(operation.operationId)) return
     retainedIndexes.add(index)
-    retainedEntries += 1
-    retainedBytes += operationLogEntryBytes(operation)
   })
 
-  // Retain a contiguous suffix of completed operations. Skipping an oversized recent entry while
-  // keeping older entries would make the visible history look complete when it contains a gap.
+  // Retain a contiguous suffix of completed operations, plus any recovery-critical entry.
   for (let index = cache.operationLog.length - 1; index >= 0; index -= 1) {
     if (retainedIndexes.has(index)) continue
-    const operationBytes = operationLogEntryBytes(cache.operationLog[index])
-    if (retainedEntries >= limits.maxEntries || retainedBytes + operationBytes > limits.maxBytes) {
-      break
-    }
+    if (retainedIndexes.size >= limits.maxEntries) break
     retainedIndexes.add(index)
-    retainedEntries += 1
-    retainedBytes += operationBytes
   }
 
-  const retained = cache.operationLog.filter((_operation, index) => retainedIndexes.has(index))
-  const newlyOmitted = cache.operationLog.length - retained.length
-  const omittedCount = (cache.operationLogTruncation?.omittedCount ?? 0) + newlyOmitted
-  const earliestRetainedAt = retained
-    .map((operation) => operation.timestamp)
-    .filter((timestamp) => timestamp.length > 0)
-    .sort()[0]
-  const nextTruncation =
-    omittedCount > 0
-      ? {
-          omittedCount,
-          ...(earliestRetainedAt ? { earliestRetainedAt } : {})
-        }
-      : undefined
+  let retained = cache.operationLog.filter((_operation, index) => retainedIndexes.has(index))
+  const previouslyOmitted = cache.operationLogTruncation?.omittedCount ?? 0
+  const originalLength = cache.operationLog.length
+  let nextTruncation = operationLogTruncationFor(
+    retained,
+    previouslyOmitted + originalLength - retained.length
+  )
+
+  // Enforce the byte budget against the exact pretty-printed binding representation written below.
+  // A recovery-critical operation is retained even when it makes the binding temporarily exceed it.
+  while (
+    serializedBindingBytes(bindingWithOperationLog(cache, retained, nextTruncation)) >
+    limits.maxBytes
+  ) {
+    const removableIndex = retained.findIndex(
+      (operation) => !protectedOperationIds.has(operation.operationId)
+    )
+    if (removableIndex < 0) break
+    retained = retained.filter((_operation, index) => index !== removableIndex)
+    nextTruncation = operationLogTruncationFor(
+      retained,
+      previouslyOmitted + originalLength - retained.length
+    )
+  }
+
+  const newlyOmitted = originalLength - retained.length
   const changed =
     newlyOmitted > 0 ||
     cache.operationLogTruncation?.omittedCount !== nextTruncation?.omittedCount ||
@@ -522,7 +551,7 @@ class EnvironmentStateTracker {
     this.now = options.now ?? (() => new Date())
     this.operationLogLimits = options.operationLogLimits ?? {
       maxEntries: MAX_OPERATION_LOG_ENTRIES,
-      maxBytes: MAX_OPERATION_LOG_BYTES
+      maxBytes: MAX_ENVIRONMENT_BINDING_BYTES
     }
   }
 
@@ -1050,11 +1079,8 @@ class EnvironmentStateTracker {
         inventoryRefreshAttempts: operation.inventoryRefreshAttempts ?? []
       }))
       if (
-        parsed.operationLogTruncation &&
-        (!Number.isInteger(parsed.operationLogTruncation.omittedCount) ||
-          parsed.operationLogTruncation.omittedCount <= 0 ||
-          (parsed.operationLogTruncation.earliestRetainedAt !== undefined &&
-            typeof parsed.operationLogTruncation.earliestRetainedAt !== 'string'))
+        parsed.operationLogTruncation !== undefined &&
+        !isNotebookEnvironmentOperationLogTruncation(parsed.operationLogTruncation)
       ) {
         throw new Error('Invalid environment operation log truncation metadata.')
       }

--- a/src/main/storage/provenance-migration-validation.test.ts
+++ b/src/main/storage/provenance-migration-validation.test.ts
@@ -40,6 +40,25 @@ describe('validateProvenanceMigrationState', () => {
     )
   })
 
+  it('refuses malformed Environment operation-log truncation metadata', async () => {
+    const target = join(root, 'runtime', 'provenance', 'environment-inventory', 'environment-key')
+    await mkdir(target, { recursive: true })
+    await writeFile(
+      join(target, 'binding.json'),
+      JSON.stringify({
+        schemaVersion: 1,
+        generation: 1,
+        state: 'clean',
+        operationLog: [],
+        operationLogTruncation: { omittedCount: 0 }
+      })
+    )
+
+    await expect(validateProvenanceMigrationState(root)).rejects.toThrow(
+      /invalid Environment binding/i
+    )
+  })
+
   it('refuses an Artifact staging directory that has not reached an immutable lifecycle state', async () => {
     await mkdir(
       join(

--- a/src/main/storage/provenance-migration-validation.ts
+++ b/src/main/storage/provenance-migration-validation.ts
@@ -5,7 +5,10 @@ import { isAbsolute, join, relative, resolve, sep } from 'node:path'
 
 import { createProjectDbClient } from '../projects/prisma-client'
 import { validateConversationGraph } from '../../shared/conversation-graph'
-import { NOTEBOOK_RUN_FILE } from '../../shared/notebook'
+import {
+  isNotebookEnvironmentOperationLogTruncation,
+  NOTEBOOK_RUN_FILE
+} from '../../shared/notebook'
 import { normalizeSessionFile } from '../../shared/session-persistence'
 
 const SHA256_PATTERN = /^[a-f0-9]{64}$/
@@ -120,6 +123,12 @@ const validateEnvironmentState = async (root: string): Promise<Set<string>> => {
       throw new Error(`Unfinished Environment operation blocks migration: ${target.name}`)
     }
     if (binding && (binding.schemaVersion !== 1 || !Array.isArray(binding.operationLog))) {
+      throw new Error(`Invalid Environment binding blocks migration: ${target.name}`)
+    }
+    if (
+      binding?.operationLogTruncation !== undefined &&
+      !isNotebookEnvironmentOperationLogTruncation(binding.operationLogTruncation)
+    ) {
       throw new Error(`Invalid Environment binding blocks migration: ${target.name}`)
     }
   }

--- a/src/renderer/src/pages/workspace/ArtifactProvenancePanel.render.test.tsx
+++ b/src/renderer/src/pages/workspace/ArtifactProvenancePanel.render.test.tsx
@@ -258,6 +258,10 @@ const provenance = (): ArtifactVersionProvenance => ({
           ]
         }
       ],
+      op_log_truncation: {
+        omitted_count: 2,
+        earliest_retained_at: '2026-07-27T19:00:00.000Z'
+      },
       captured_at: '2026-07-27T19:01:01.000Z',
       source_manifest_checksum: 'c'.repeat(64),
       complete: true
@@ -709,6 +713,10 @@ describe('ArtifactProvenancePanel', () => {
     expect(container.textContent).not.toContain('libzlib')
     expect(container.textContent).toContain('Show all 2 packages')
     expect(container.textContent).toContain('Operations')
+    expect(container.textContent).toContain(
+      '2 earlier operations omitted from this bounded history.'
+    )
+    expect(container.textContent).toContain('Retained entries begin')
     expect(container.textContent).toContain('Inventory cache was reused without a full validation')
     expect(container.textContent).toContain('Live Kernel package state unavailable.')
     expect(container.textContent).toContain('create')

--- a/src/renderer/src/pages/workspace/ArtifactProvenancePanel.tsx
+++ b/src/renderer/src/pages/workspace/ArtifactProvenancePanel.tsx
@@ -578,6 +578,12 @@ const ArtifactProvenancePanel = ({
         .map(asRecord)
         .filter((operation): operation is Record<string, unknown> => operation !== undefined)
     : []
+  const operationLogTruncation = asRecord(environment?.op_log_truncation)
+  const omittedOperationCount =
+    typeof operationLogTruncation?.omitted_count === 'number'
+      ? operationLogTruncation.omitted_count
+      : 0
+  const earliestRetainedOperationAt = asString(operationLogTruncation?.earliest_retained_at)
   const environmentWarnings = Array.isArray(environment?.warnings)
     ? environment.warnings.filter((warning): warning is string => typeof warning === 'string')
     : []
@@ -1049,6 +1055,14 @@ const ArtifactProvenancePanel = ({
                       ? `Show relevant ${filteredEnvironmentPackages.length} packages`
                       : `Show all ${environmentPackages.length} packages`}
                   </button>
+                ) : null}
+                {omittedOperationCount > 0 ? (
+                  <p className="rounded-md bg-bg-100 px-3 py-2 text-xs text-text-300">
+                    {`${omittedOperationCount} earlier operation${omittedOperationCount === 1 ? '' : 's'} omitted from this bounded history.`}
+                    {earliestRetainedOperationAt
+                      ? ` Retained entries begin ${new Date(earliestRetainedOperationAt).toLocaleString()}.`
+                      : ''}
+                  </p>
                 ) : null}
                 {environmentOperations.length > 0 ? (
                   <div className="space-y-2">

--- a/src/shared/artifact-provenance.ts
+++ b/src/shared/artifact-provenance.ts
@@ -278,6 +278,10 @@ export type ArtifactVersionEnvironmentEvidence = {
       library_scope?: 'environment' | 'user' | 'system' | 'unknown'
     }>
   }>
+  op_log_truncation?: {
+    omitted_count: number
+    earliest_retained_at?: string
+  }
   captured_at: string
   source_manifest_checksum: string
   complete: boolean

--- a/src/shared/notebook.ts
+++ b/src/shared/notebook.ts
@@ -114,6 +114,11 @@ export type NotebookEnvironmentOperation = {
   packageChanges?: NotebookEnvironmentPackageChange[]
 }
 
+export type NotebookEnvironmentOperationLogTruncation = {
+  omittedCount: number
+  earliestRetainedAt?: string
+}
+
 export type NotebookEnvironmentManifest = {
   schemaVersion: 1
   captureKind: 'completed-run'
@@ -132,6 +137,7 @@ export type NotebookEnvironmentManifest = {
   inventorySources: Array<'kernel-native' | 'interpreter-native' | 'operation-log'>
   packages: NotebookEnvironmentPackage[]
   operationLog?: NotebookEnvironmentOperation[]
+  operationLogTruncation?: NotebookEnvironmentOperationLogTruncation
   complete: boolean
   captureStatus: 'complete' | 'partial'
   warnings?: string[]

--- a/src/shared/notebook.ts
+++ b/src/shared/notebook.ts
@@ -119,6 +119,18 @@ export type NotebookEnvironmentOperationLogTruncation = {
   earliestRetainedAt?: string
 }
 
+export const isNotebookEnvironmentOperationLogTruncation = (
+  value: unknown
+): value is NotebookEnvironmentOperationLogTruncation => {
+  if (typeof value !== 'object' || value === null || Array.isArray(value)) return false
+  const candidate = value as Record<string, unknown>
+  return (
+    Number.isInteger(candidate.omittedCount) &&
+    Number(candidate.omittedCount) > 0 &&
+    (candidate.earliestRetainedAt === undefined || typeof candidate.earliestRetainedAt === 'string')
+  )
+}
+
 export type NotebookEnvironmentManifest = {
   schemaVersion: 1
   captureKind: 'completed-run'


### PR DESCRIPTION
## Problem

The mutable environment operation history grew without a bound and was copied into each completed-run manifest and Artifact environment evidence. Long-lived environments could therefore make every later provenance snapshot progressively larger.

## Proposed change

- Bound retained environment operations by both entry count and serialized size.
- Preserve the operation needed for dirty/recovery state even when it exceeds the normal budget.
- Record cumulative truncation metadata, including the omitted count and earliest retained timestamp.
- Project truncation metadata through Artifact evidence and show it in the Provenance Environment tab.

## Scope and non-goals

- Existing immutable Artifact Version evidence is not rewritten.
- This change does not add Environment manifest garbage collection.
- This change does not change app-generated Artifact idempotency; the current connector path has no stable invocation identity, and content-based IDs would collapse intentional duplicate saves.

## Acceptance criteria and validation

- Focused Vitest: 3 files, 58 tests passed.
- `npm run typecheck`: passed.
- `npm run lint`: passed with 24 pre-existing warnings; targeted ESLint reported no issues.
- Full `npm test`: 525 files and 7,569 tests passed; two timing-sensitive `provisioner-runtime` timeout-tail tests failed under full-suite load and passed on immediate isolated rerun (18/18).
- `git diff --check main...HEAD`: passed.

## Review focus

- The dual count/byte retention budget.
- Protection of recovery-critical operations.
- Accuracy of truncation metadata across manifest, evidence, and UI projections.
