### PR TITLE
fix(reviewer): wrap long check content

### DIFF
--- a/src/renderer/src/components/ReviewerCard.render.test.tsx
+++ b/src/renderer/src/components/ReviewerCard.render.test.tsx
@@ -491,6 +491,32 @@ describe('ReviewerCard — pass expand (pass check cards)', () => {
     expect(container.textContent).toContain(evidence)
   })
 
+  it('wraps long unbroken claim and evidence strings inside the check card', async () => {
+    const claim = `Claim ${'a'.repeat(96)}`
+    const evidence = `Checksum ${'0a248e260ca8609723a892eb0ba71c743ea742336a35'.repeat(2)}`
+    const review = makeReview({
+      outcome: 'pass',
+      checks: [makeCheck({ status: 'pass', claim, evidence, locator: undefined })]
+    })
+    await act(async () => {
+      root.render(<ReviewerCard review={review} defaultExpanded />)
+    })
+
+    const card = container.querySelector('[data-testid="reviewer-check-card"]')
+    const title = Array.from(card?.querySelectorAll('span') ?? []).find(
+      (element) => element.textContent === claim
+    )
+    const body = Array.from(card?.querySelectorAll('p') ?? []).find(
+      (element) => element.textContent === evidence
+    )
+
+    expect(title?.className).toContain('min-w-0')
+    expect(title?.className).toContain('break-words')
+    expect(title?.className).toContain('[overflow-wrap:anywhere]')
+    expect(body?.className).toContain('break-words')
+    expect(body?.className).toContain('[overflow-wrap:anywhere]')
+  })
+
   it('renders the claim as the check card title', async () => {
     const claim = 'No tool calls claimed'
     const review = makeReview({

--- a/src/renderer/src/components/ReviewerCard.tsx
+++ b/src/renderer/src/components/ReviewerCard.tsx
@@ -83,7 +83,9 @@ const ItemCard = ({
       >
         {badgeText}
       </span>
-      <span className="flex-1 text-xs font-semibold leading-snug text-text-000">{title}</span>
+      <span className="min-w-0 flex-1 break-words text-xs font-semibold leading-snug text-text-000 [overflow-wrap:anywhere]">
+        {title}
+      </span>
       {/* Re-flag marker: shown when this claim was re-flagged in the fix loop. */}
       {reflagCount != null && reflagCount > 0 && (
         <span
@@ -96,7 +98,11 @@ const ItemCard = ({
     </div>
 
     {/* Body — evidence for all check types */}
-    {body ? <p className="mt-2 text-xs leading-relaxed text-text-300">{body}</p> : null}
+    {body ? (
+      <p className="mt-2 break-words text-xs leading-relaxed text-text-300 [overflow-wrap:anywhere]">
+        {body}
+      </p>
+    ) : null}
 
     {/* Footer row: model pill (left) + Go to transcript button (right) */}
     <div className="mt-3 flex items-center justify-between gap-2">


### PR DESCRIPTION
## Problem

Reviewer check cards did not constrain long unbroken claim or evidence strings, such as checksums, allowing content to overflow the card.

## Proposed change

- Allow the claim flex item to shrink within the card.
- Apply word-breaking and overflow wrapping to claim and evidence text.
- Add a render regression test covering long unbroken strings.

## Scope and non-goals

- Limit the change to compact ReviewerCard check items.
- Do not change reviewer data, persistence, or evaluation behavior.

## Acceptance criteria and validation

- [x] Long unbroken claim and evidence strings wrap inside the card.
- [x] npm run typecheck
- [x] npm run lint (0 errors; 24 existing warnings)
- [x] npm test (526 files passed, 10 skipped; 7569 tests passed, 113 skipped)
- [x] npm run build:web

## Review focus

Please verify the wrapping behavior for checksum-like evidence and long claims in expanded Reviewer cards.