### PR TITLE
fix(acp): mark bounded Codex MCP test events

### DIFF
--- a/src/main/acp/runtime.test.ts
+++ b/src/main/acp/runtime.test.ts
@@ -5024,7 +5024,8 @@ describe('ACP runtime session management', () => {
             server: 'open-science-notebook',
             tool: 'notebook_execute',
             arguments: { code: `print(${index})` }
-          }
+          },
+          _meta: { is_mcp_tool_call: true }
         }
       })
     }


### PR DESCRIPTION
## Summary

- restore release verification by marking bounded Codex MCP identity fixtures as trusted adapter events
- keep the production trust gate unchanged

## Root cause

A prior permission hardening change required Codex MCP tool events to carry the adapter trust marker, but one pre-existing capacity and cleanup fixture was not updated. The runtime correctly ignored those unmarked events, leaving the expected pending identity collection empty.

## Validation

- formatting check passed
- whitespace/error check passed
- local tests were not run; CI is the release verification signal