### PR TITLE
fix(artifact-provenance): recover prepared artifact runs

### DIFF
--- a/src/main/acp/runtime.test.ts
+++ b/src/main/acp/runtime.test.ts
@@ -39,6 +39,9 @@ import { stageUploadFixtures } from '../uploads/repository.test-utils'
 import { MAX_INLINE_IMAGE_TOTAL_BASE64_BYTES } from '../uploads/attachment-media'
 import { ConversationSkillImporter, SkillImportApprovalBroker } from '../skills/conversation-import'
 import { createProjectDbClient, ensureProjectSchema } from '../projects/prisma-client'
+import { NotebookLocalRpcServer } from '../notebook/local-rpc-server'
+import { NotebookRuntimeService } from '../notebook/runtime-service'
+import { NotebookRunRepository } from '../notebook/repository'
 import {
   beginMigration,
   clearMigrationPending,
@@ -3110,7 +3113,9 @@ describe('ACP runtime session management', () => {
           issuedBindings.push(binding)
           return 'run-capability-1'
         },
-        revokeRpcCapability: (token) => revokedTokens.push(token)
+        revokeRpcCapability: (token) => {
+          revokedTokens.push(token)
+        }
       }
     })
 
@@ -7780,6 +7785,271 @@ describe('ACP runtime session management', () => {
         artifactCount: 1
       }
     ])
+    await expect(
+      repository.findRunFinalizationMarker('default-project', events[0].runId!)
+    ).resolves.toMatchObject({
+      sourceSessionId: getEnvValue(
+        fakeAgent.newSessions[0].mcpServers[0],
+        'OPEN_SCIENCE_ARTIFACT_SESSION_ID'
+      ),
+      sessionId: 'remote-session-1',
+      provenanceContext: {
+        promptMessageId: events[0].promptMessageId
+      }
+    })
+    await expect(
+      repository.findRunFinalizationMarker('default-project', events[0].runId!)
+    ).resolves.not.toHaveProperty('messageId')
+  })
+
+  it('drains an accepted app-side Artifact write before freezing the claim and marker', async () => {
+    const storageRoot = await createTemporaryRoot()
+    const client = createProjectDbClient(storageRoot)
+    temporaryDisconnections.push(() => client.$disconnect())
+    await ensureProjectSchema(client)
+    const repository = new ArtifactRepository(storageRoot)
+    const durableProvenance = new ArtifactProvenanceRepository({
+      storageRoot,
+      getClient: () => Promise.resolve(client),
+      compatibilityRepository: repository
+    })
+    const writeStarted = createDeferred()
+    const releaseWrite = createDeferred()
+    const closeStarted = createDeferred()
+    const listRunVersions = vi.fn((request) => durableProvenance.listRunVersions(request))
+    let appWrite: ReturnType<AcpRuntime['writeArtifactForCurrentRun']> | undefined
+    let artifactClaimId: string | undefined
+    const process = new FakeAgentProcess()
+    startFakeAgent(process, ['remote-session-1'], {
+      onPrompt: async ({ sessionId }) => {
+        appWrite = runtime.writeArtifactForCurrentRun(sessionId, {
+          filename: 'late.txt',
+          content: 'accepted before stop',
+          mimeType: 'text/plain'
+        })
+        await writeStarted.promise
+      }
+    })
+    const runtime = new AcpRuntime({
+      appVersion: '0.1.0',
+      defaultCwd: '/workspace',
+      spawnAgent: () => asAgentProcess(process),
+      artifacts: {
+        configRoot: storageRoot,
+        dataRoot: storageRoot,
+        projectName: 'project-1',
+        mcpEntryPath: '/app/out/main/index.js',
+        repository,
+        provenance: {
+          listRunVersions,
+          writeAppGeneratedVersion: async (request) => {
+            writeStarted.resolve()
+            await releaseWrite.promise
+            return durableProvenance.writeAppGeneratedVersion(request)
+          }
+        },
+        issueRpcCapability: () => 'run-capability-1',
+        revokeRpcCapability: async () => {
+          closeStarted.resolve()
+        }
+      },
+      callbacks: {
+        onEvent: (event) => {
+          if (event.kind === 'artifact') artifactClaimId = event.artifactClaimId
+        }
+      }
+    })
+    const session = await runtime.createSession({ cwd: '/workspace', projectName: 'project-1' })
+    const prompt = runtime.sendPrompt({
+      sessionId: session.sessionId,
+      text: 'save late.txt',
+      provenanceContext: {
+        rootFrameId: 'root-frame-1',
+        agentFrameId: 'agent-frame-1',
+        messageBranchId: 'branch-1',
+        runtimeSegmentId: 'runtime-1',
+        promptMessageId: 'prompt-1'
+      }
+    })
+
+    await closeStarted.promise
+    expect(listRunVersions).not.toHaveBeenCalled()
+    expect(artifactClaimId).toBeUndefined()
+    await expect(
+      runtime.writeArtifactForCurrentRun(session.sessionId, {
+        filename: 'too-late.txt',
+        content: 'must be rejected'
+      })
+    ).rejects.toThrow(/No active assistant turn/i)
+
+    releaseWrite.resolve()
+    await appWrite
+    await prompt
+
+    expect(artifactClaimId).toBeTruthy()
+    const claim = resolveArtifactRunClaim(runtime, artifactClaimId!)
+    const version = await client.artifactVersion.findFirstOrThrow({
+      where: { artifactRunId: claim.runId }
+    })
+    expect(claim.artifactVersionIds).toEqual([version.id])
+    await expect(
+      repository.findRunFinalizationMarker('project-1', claim.runId)
+    ).resolves.toMatchObject({ artifactVersionIds: [version.id] })
+  })
+
+  it('drains an authorized Artifact RPC write before freezing the claim and marker', async () => {
+    const storageRoot = await createTemporaryRoot()
+    const client = createProjectDbClient(storageRoot)
+    temporaryDisconnections.push(() => client.$disconnect())
+    await ensureProjectSchema(client)
+    const repository = new ArtifactRepository(storageRoot)
+    const durableProvenance = new ArtifactProvenanceRepository({
+      storageRoot,
+      getClient: () => Promise.resolve(client),
+      compatibilityRepository: repository
+    })
+    const rpcWriteStarted = createDeferred()
+    const releaseRpcWrite = createDeferred()
+    const closeStarted = createDeferred()
+    const notebookService = new NotebookRuntimeService({
+      configRoot: storageRoot,
+      dataRoot: storageRoot,
+      projectName: 'project-1',
+      repository: new NotebookRunRepository(storageRoot)
+    })
+    const rpcServer = new NotebookLocalRpcServer(notebookService, {
+      artifactProvenance: {
+        createVersion: async (request) => {
+          rpcWriteStarted.resolve()
+          await releaseRpcWrite.promise
+          return durableProvenance.createVersion(request)
+        }
+      }
+    })
+    const rpcConnection = await rpcServer.ensureStarted()
+    const listRunVersions = vi.fn((request) => durableProvenance.listRunVersions(request))
+    let rpcWrite: Promise<Response> | undefined
+    let artifactClaimId: string | undefined
+    let currentRunFile = ''
+    const process = new FakeAgentProcess()
+    const fakeAgent = startFakeAgent(process, ['remote-session-1'], {
+      onPrompt: async ({ sessionId }) => {
+        const context = JSON.parse(await readFile(currentRunFile, 'utf8')) as {
+          artifactRunId: string
+          appSessionId: string
+          rootFrameId: string
+          agentFrameId: string
+          messageBranchId: string
+          runtimeSegmentId: string
+          promptMessageId: string
+          rpcCapabilityToken: string
+        }
+        const artifactStorageSessionId = getEnvValue(
+          fakeAgent.newSessions[0].mcpServers[0],
+          'OPEN_SCIENCE_ARTIFACT_SESSION_ID'
+        )
+        await repository.writePendingFile({
+          projectName: 'project-1',
+          sessionId: artifactStorageSessionId,
+          runId: context.artifactRunId,
+          filename: 'rpc-late.txt',
+          source: { kind: 'inline', content: 'accepted RPC bytes', encoding: 'utf8' }
+        })
+        rpcWrite = fetch(rpcConnection.endpoint, {
+          method: 'POST',
+          headers: {
+            authorization: `Bearer ${context.rpcCapabilityToken}`,
+            'content-type': 'application/json'
+          },
+          body: JSON.stringify({
+            method: 'artifactCreateVersion',
+            params: {
+              projectId: 'project-1',
+              appSessionId: sessionId,
+              artifactStorageSessionId,
+              artifactRunId: context.artifactRunId,
+              writeOperationId: 'write-rpc-late',
+              writeRequestChecksum: 'c'.repeat(64),
+              rootFrameId: context.rootFrameId,
+              agentFrameId: context.agentFrameId,
+              messageBranchId: context.messageBranchId,
+              runtimeSegmentId: context.runtimeSegmentId,
+              promptMessageId: context.promptMessageId,
+              filename: 'rpc-late.txt',
+              contentType: 'text/plain'
+            }
+          })
+        })
+        await rpcWriteStarted.promise
+      }
+    })
+    const runtime = new AcpRuntime({
+      appVersion: '0.1.0',
+      defaultCwd: '/workspace',
+      spawnAgent: () => asAgentProcess(process),
+      artifacts: {
+        configRoot: storageRoot,
+        dataRoot: storageRoot,
+        projectName: 'project-1',
+        mcpEntryPath: '/app/out/main/index.js',
+        repository,
+        provenance: {
+          listRunVersions,
+          writeAppGeneratedVersion: (request) => durableProvenance.writeAppGeneratedVersion(request)
+        },
+        getRpcConnection: () => Promise.resolve(rpcConnection),
+        issueRpcCapability: (binding) => rpcServer.issueArtifactRunCapability(binding),
+        revokeRpcCapability: async (token) => {
+          closeStarted.resolve()
+          await rpcServer.revokeArtifactRunCapability(token)
+        }
+      },
+      callbacks: {
+        onEvent: (event) => {
+          if (event.kind === 'artifact') artifactClaimId = event.artifactClaimId
+        }
+      }
+    })
+
+    try {
+      const session = await runtime.createSession({ cwd: '/workspace', projectName: 'project-1' })
+      currentRunFile = getEnvValue(
+        fakeAgent.newSessions[0].mcpServers[0],
+        'OPEN_SCIENCE_ARTIFACT_CURRENT_RUN_FILE'
+      )
+      const prompt = runtime.sendPrompt({
+        sessionId: session.sessionId,
+        text: 'save through RPC',
+        provenanceContext: {
+          rootFrameId: 'root-frame-1',
+          agentFrameId: 'agent-frame-1',
+          messageBranchId: 'branch-1',
+          runtimeSegmentId: 'runtime-1',
+          promptMessageId: 'prompt-1'
+        }
+      })
+
+      await closeStarted.promise
+      expect(listRunVersions).not.toHaveBeenCalled()
+      expect(artifactClaimId).toBeUndefined()
+
+      releaseRpcWrite.resolve()
+      await expect(rpcWrite!.then((response) => response.status)).resolves.toBe(200)
+      await prompt
+
+      expect(artifactClaimId).toBeTruthy()
+      const claim = resolveArtifactRunClaim(runtime, artifactClaimId!)
+      const version = await client.artifactVersion.findFirstOrThrow({
+        where: { artifactRunId: claim.runId }
+      })
+      expect(claim.artifactVersionIds).toEqual([version.id])
+      await expect(
+        repository.findRunFinalizationMarker('project-1', claim.runId)
+      ).resolves.toMatchObject({ artifactVersionIds: [version.id] })
+    } finally {
+      releaseRpcWrite.resolve()
+      await rpcServer.close()
+    }
   })
 
   it('finalizes an Artifact after a restored branch supplies ancestor-only provenance context', async () => {
@@ -7849,6 +8119,10 @@ describe('ACP runtime session management', () => {
     if (writeError) throw writeError
     expect(artifactClaimId).toBeTruthy()
     const claim = resolveArtifactRunClaim(runtime, artifactClaimId!)
+    const claimedVersion = await client.artifactVersion.findFirstOrThrow({
+      where: { artifactRunId: claim.runId }
+    })
+    expect(claim.artifactVersionIds).toEqual([claimedVersion.id])
     const createdAt = Date.now()
     const conversationGraph = {
       schemaVersion: 1 as const,
@@ -7968,6 +8242,7 @@ describe('ACP runtime session management', () => {
       projectId: claim.projectName,
       appSessionId: claim.sessionId,
       artifactRunId: claim.runId,
+      artifactVersionIds: claim.artifactVersionIds!,
       rootFrameId: claim.rootFrameId!,
       agentFrameId: claim.agentFrameId!,
       messageBranchId: claim.messageBranchId!,
@@ -8086,7 +8361,9 @@ describe('ACP runtime session management', () => {
         mcpCommand: '/usr/bin/electron',
         getRpcConnection: async () => ({ endpoint: 'http://127.0.0.1:4567', token: 'global' }),
         issueRpcCapability: () => 'activation-capability',
-        revokeRpcCapability: (token) => revokedTokens.push(token)
+        revokeRpcCapability: (token) => {
+          revokedTokens.push(token)
+        }
       },
       callbacks: {
         onEvent: (event) => events.push({ kind: event.kind, text: event.text })

--- a/src/main/acp/runtime.ts
+++ b/src/main/acp/runtime.ts
@@ -241,7 +241,7 @@ type AcpRuntimeArtifactOptions = {
   runRegistry?: ArtifactRunRegistry
   getRpcConnection?: () => Promise<NotebookRpcConnection>
   issueRpcCapability?: (binding: ArtifactRpcCapabilityBinding) => string
-  revokeRpcCapability?: (token: string) => void
+  revokeRpcCapability?: (token: string) => Promise<void> | void
   provenance?: Pick<
     import('../artifacts/provenance-repository').ArtifactProvenanceRepository,
     'listRunVersions' | 'writeAppGeneratedVersion'
@@ -272,6 +272,9 @@ type ActiveArtifactRun = {
   promptMessageId: string
   agentName: string
   rpcCapabilityToken?: string
+  writesClosed: boolean
+  inFlightAppWrites: Set<Promise<unknown>>
+  writeDrainPromise?: Promise<void>
 }
 
 type AcpRuntimeNotebookOptions = {
@@ -4056,7 +4059,9 @@ class AcpRuntime {
       runtimeSegmentId:
         provenanceContext?.runtimeSegmentId ?? `runtime-segment-${this.runtimeInstanceId}`,
       promptMessageId,
-      agentName: this.framework.displayName
+      agentName: this.framework.displayName,
+      writesClosed: false,
+      inFlightAppWrites: new Set()
     }
     // Notebook kernels are keyed by the FINAL ACP session id (the notebook RPC layer rewrites the
     // pre-start alias to it before touching disk). This handoff runs per turn with that final id, so
@@ -4134,19 +4139,34 @@ class AcpRuntime {
       return artifactRun
     } catch (error) {
       if (artifactRun.rpcCapabilityToken) {
-        this.artifactOptions.revokeRpcCapability?.(artifactRun.rpcCapabilityToken)
+        await this.artifactOptions.revokeRpcCapability?.(artifactRun.rpcCapabilityToken)
       }
       throw error
     }
+  }
+
+  // Seals both Artifact write entrances synchronously, then drains operations that already crossed
+  // either entrance. Every emit/cleanup path shares this promise so repeated teardown cannot observe
+  // a partially drained run or bypass an earlier revoke.
+  private closeArtifactRunWrites(artifactRun: ActiveArtifactRun): Promise<void> {
+    if (artifactRun.writeDrainPromise) return artifactRun.writeDrainPromise
+
+    artifactRun.writesClosed = true
+    const rpcDrain = artifactRun.rpcCapabilityToken
+      ? Promise.resolve(this.artifactOptions?.revokeRpcCapability?.(artifactRun.rpcCapabilityToken))
+      : Promise.resolve()
+    artifactRun.writeDrainPromise = (async () => {
+      await rpcDrain
+      await Promise.allSettled([...artifactRun.inFlightAppWrites])
+    })()
+    return artifactRun.writeDrainPromise
   }
 
   // Clears the handoff file after the prompt so late MCP writes cannot attach to a completed turn.
   private async clearArtifactRun(artifactRun: ActiveArtifactRun | undefined): Promise<void> {
     if (!artifactRun) return
 
-    if (artifactRun.rpcCapabilityToken) {
-      this.artifactOptions?.revokeRpcCapability?.(artifactRun.rpcCapabilityToken)
-    }
+    await this.closeArtifactRunWrites(artifactRun)
     await writeFile(artifactRun.currentRunFile, `${JSON.stringify({})}\n`, 'utf8')
     this.notebookOptions?.setArtifactProvenanceContext?.(artifactRun.appSessionId, undefined)
   }
@@ -4166,40 +4186,44 @@ class AcpRuntime {
     // session id — never a global "current" run, so a parallel session's in-flight turn cannot capture
     // this file. Fail closed when the session has no active run.
     const run = sessionId ? this.activeArtifactRuns.get(sessionId) : undefined
-    if (!run || !this.artifactRepository) {
+    if (!run || run.writesClosed || !this.artifactRepository) {
       throw new Error('No active assistant turn to attach a generated file to.')
     }
 
     const projectName = this.resolveSessionProjectName(sessionId)
     const provenance = this.artifactOptions?.provenance
-    if (provenance) {
-      return provenance.writeAppGeneratedVersion({
-        projectId: projectName,
-        appSessionId: sessionId,
-        artifactStorageSessionId: run.artifactSessionId,
-        artifactRunId: run.runId,
-        rootFrameId: run.rootFrameId,
-        agentFrameId: run.agentFrameId,
-        messageBranchId: run.messageBranchId,
-        messageBranchAncestry: run.messageBranchAncestry,
-        messageAncestry: run.messageAncestry,
-        runtimeSegmentId: run.runtimeSegmentId,
-        promptMessageId: run.promptMessageId,
-        agentName: run.agentName,
-        filename: input.filename,
-        content: input.content,
-        contentType: input.mimeType
-      })
-    }
-
-    return this.artifactRepository.writePendingFile({
-      projectName,
-      sessionId: run.artifactSessionId,
-      runId: run.runId,
-      filename: input.filename,
-      mimeType: input.mimeType,
-      source: { kind: 'inline', content: input.content, encoding: 'utf8' }
-    })
+    const write = provenance
+      ? provenance.writeAppGeneratedVersion({
+          projectId: projectName,
+          appSessionId: sessionId,
+          artifactStorageSessionId: run.artifactSessionId,
+          artifactRunId: run.runId,
+          rootFrameId: run.rootFrameId,
+          agentFrameId: run.agentFrameId,
+          messageBranchId: run.messageBranchId,
+          messageBranchAncestry: run.messageBranchAncestry,
+          messageAncestry: run.messageAncestry,
+          runtimeSegmentId: run.runtimeSegmentId,
+          promptMessageId: run.promptMessageId,
+          agentName: run.agentName,
+          filename: input.filename,
+          content: input.content,
+          contentType: input.mimeType
+        })
+      : this.artifactRepository.writePendingFile({
+          projectName,
+          sessionId: run.artifactSessionId,
+          runId: run.runId,
+          filename: input.filename,
+          mimeType: input.mimeType,
+          source: { kind: 'inline', content: input.content, encoding: 'utf8' }
+        })
+    run.inFlightAppWrites.add(write)
+    void write.then(
+      () => run.inFlightAppWrites.delete(write),
+      () => run.inFlightAppWrites.delete(write)
+    )
+    return write
   }
 
   // Publishes pending files as a claim event; the renderer later supplies the final message id.
@@ -4207,35 +4231,59 @@ class AcpRuntime {
     sessionId: string,
     artifactRun: ActiveArtifactRun | undefined
   ): Promise<void> {
-    if (
-      !this.artifactOptions ||
-      !this.artifactRepository ||
-      !this.artifactRunRegistry ||
-      !artifactRun
-    ) {
+    if (!artifactRun) return
+    await this.closeArtifactRunWrites(artifactRun)
+
+    if (!this.artifactOptions || !this.artifactRepository || !this.artifactRunRegistry) {
       return
     }
 
     const sessionProjectName = this.resolveSessionProjectName(sessionId)
-    const artifacts = this.artifactOptions.provenance
-      ? await this.artifactOptions.provenance.listRunVersions({
-          projectId: sessionProjectName,
-          appSessionId: sessionId,
-          artifactRunId: artifactRun.runId
-        })
-      : await this.artifactRepository.listPendingRunFiles({
-          projectName: sessionProjectName,
-          sessionId: artifactRun.artifactSessionId,
-          runId: artifactRun.runId
-        })
+    let artifacts: ArtifactFile[]
+    let artifactVersionIds: string[] | undefined
+    if (this.artifactOptions.provenance) {
+      const versions = await this.artifactOptions.provenance.listRunVersions({
+        projectId: sessionProjectName,
+        appSessionId: sessionId,
+        artifactRunId: artifactRun.runId
+      })
+      artifacts = versions
+      artifactVersionIds = versions.map((version) => version.versionId)
+    } else {
+      artifacts = await this.artifactRepository.listPendingRunFiles({
+        projectName: sessionProjectName,
+        sessionId: artifactRun.artifactSessionId,
+        runId: artifactRun.runId
+      })
+    }
 
     if (artifacts.length === 0) return
+
+    // Commit the runtime's decision to publish this completed run before exposing an in-memory claim.
+    // If the process exits before the renderer supplies its terminal message id, startup recovery can
+    // still prove this handoff against the durable conversation graph. A run that crashes mid-turn
+    // never reaches this point and therefore cannot be mistaken for a completed handoff.
+    await this.artifactRepository.prepareRunFinalization({
+      projectName: sessionProjectName,
+      sourceSessionId: artifactRun.artifactSessionId,
+      sessionId,
+      runId: artifactRun.runId,
+      ...(artifactVersionIds ? { artifactVersionIds } : {}),
+      provenanceContext: {
+        rootFrameId: artifactRun.rootFrameId,
+        agentFrameId: artifactRun.agentFrameId,
+        messageBranchId: artifactRun.messageBranchId,
+        runtimeSegmentId: artifactRun.runtimeSegmentId,
+        promptMessageId: artifactRun.promptMessageId
+      }
+    })
 
     const artifactClaimId = this.artifactRunRegistry.register({
       projectName: sessionProjectName,
       artifactSessionId: artifactRun.artifactSessionId,
       sessionId,
       runId: artifactRun.runId,
+      artifactVersionIds,
       rootFrameId: artifactRun.rootFrameId,
       agentFrameId: artifactRun.agentFrameId,
       messageBranchId: artifactRun.messageBranchId,

--- a/src/main/artifacts/ipc.test.ts
+++ b/src/main/artifacts/ipc.test.ts
@@ -5,7 +5,10 @@ import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest'
 
 import { createArtifactVersionLocator } from '../../shared/artifact-provenance'
 import type { ArtifactFile, ArtifactWriteSource } from '../../shared/artifacts'
+import { createLinearConversationGraph } from '../../shared/conversation-graph'
+import type { PersistedChatSession } from '../../shared/session-persistence'
 import { createPngBytes, createPngInlineSource } from './artifact-test-fixtures'
+import { ArtifactProvenanceRepository } from './provenance-repository'
 import { ArtifactRepository } from './repository'
 import {
   createArtifactHandlers,
@@ -18,6 +21,7 @@ import {
   clearMigrationPending,
   waitForDataRootWriters
 } from '../storage/migration-state'
+import { createProjectDbClient, ensureProjectSchema } from '../projects/prisma-client'
 
 // Capture every ipcMain.handle registration so registerArtifactIpcHandlers can be verified directly.
 // The mock is set up here (before importing the IPC module) so registering handlers in tests is
@@ -167,9 +171,6 @@ describe('artifact IPC handlers', () => {
       })
     } as unknown as ArtifactRepository
     const provenance = {
-      validateFinalizationOwnership: vi.fn(async () => {
-        callOrder.push('preflight')
-      }),
       finalizeRun: vi.fn(async () => {
         callOrder.push('sqlite')
         return [finalizedArtifact]
@@ -196,7 +197,8 @@ describe('artifact IPC handlers', () => {
       messageBranchAncestry: ['branch-parent', 'branch-1'],
       messageAncestry: ['prompt-1', 'message-1'],
       runtimeSegmentId: 'runtime-1',
-      promptMessageId: 'prompt-1'
+      promptMessageId: 'prompt-1',
+      artifactVersionIds: ['version-1']
     })
     const handlers = createArtifactHandlers(repository, registry, {
       provenance: provenance as never,
@@ -206,11 +208,12 @@ describe('artifact IPC handlers', () => {
     await handlers.finalizeRunArtifacts({ claimId, messageId: 'message-1' })
 
     expect(mutationScopes).toEqual([{ projectId: 'default-project', sessionId: 'session-1' }])
-    expect(callOrder).toEqual(['preflight', 'compatibility', 'sqlite'])
+    expect(callOrder).toEqual(['sqlite', 'compatibility'])
     expect(provenance.finalizeRun).toHaveBeenCalledWith(
       expect.objectContaining({
         messageId: 'message-1',
-        promptMessageId: 'prompt-1'
+        promptMessageId: 'prompt-1',
+        artifactVersionIds: ['version-1']
       })
     )
     expect(provenance.finalizeRun).not.toHaveBeenCalledWith(
@@ -218,15 +221,12 @@ describe('artifact IPC handlers', () => {
     )
   })
 
-  it('does not move compatibility files when durable provenance ownership is rejected', async () => {
+  it('does not move compatibility files when the complete provenance proof is rejected', async () => {
     const repository = {
       finalizeRunArtifacts: vi.fn()
     } as unknown as ArtifactRepository
     const provenance = {
-      validateFinalizationOwnership: vi
-        .fn()
-        .mockRejectedValue(new Error('durable Session graph rejected message')),
-      finalizeRun: vi.fn()
+      finalizeRun: vi.fn().mockRejectedValue(new Error('corrupt Artifact Version proof'))
     }
     const registry = new ArtifactRunRegistry()
     const claimId = registry.register({
@@ -238,7 +238,8 @@ describe('artifact IPC handlers', () => {
       agentFrameId: 'agent-frame-1',
       messageBranchId: 'branch-1',
       runtimeSegmentId: 'runtime-1',
-      promptMessageId: 'prompt-1'
+      promptMessageId: 'prompt-1',
+      artifactVersionIds: ['version-1']
     })
     const handlers = createArtifactHandlers(repository, registry, {
       provenance: provenance as never
@@ -246,20 +247,173 @@ describe('artifact IPC handlers', () => {
 
     await expect(
       handlers.finalizeRunArtifacts({ claimId, messageId: 'message-forged' })
-    ).rejects.toThrow(/durable Session graph/i)
+    ).rejects.toThrow(/corrupt Artifact Version proof/i)
     expect(repository.finalizeRunArtifacts).not.toHaveBeenCalled()
-    expect(provenance.finalizeRun).not.toHaveBeenCalled()
+    expect(provenance.finalizeRun).toHaveBeenCalledOnce()
     expect(registry.resolve(claimId).finalizedMessageId).toBeUndefined()
   })
 
-  it('leaves a recoverable compatibility marker when SQLite finalization fails', async () => {
+  it('does not bypass provenance when a claim is missing part of its durable context', async () => {
+    const repository = {
+      finalizeRunArtifacts: vi.fn()
+    } as unknown as ArtifactRepository
+    const provenance = { finalizeRun: vi.fn() }
+    const registry = new ArtifactRunRegistry()
+    const claimId = registry.register({
+      projectName: 'default-project',
+      artifactSessionId: 'artifact-session-1',
+      sessionId: 'session-1',
+      runId: 'run-1',
+      artifactVersionIds: ['version-1'],
+      rootFrameId: 'root-frame-1',
+      agentFrameId: 'agent-frame-1',
+      messageBranchId: 'branch-1',
+      runtimeSegmentId: 'runtime-1'
+    })
+    const handlers = createArtifactHandlers(repository, registry, {
+      provenance: provenance as never
+    })
+
+    await expect(
+      handlers.finalizeRunArtifacts({ claimId, messageId: 'message-1' })
+    ).rejects.toThrow(/complete provenance context/i)
+    expect(provenance.finalizeRun).not.toHaveBeenCalled()
+    expect(repository.finalizeRunArtifacts).not.toHaveBeenCalled()
+  })
+
+  it('keeps pending bytes in place when normal IPC encounters a corrupt provenance proof', async () => {
+    const root = await createStorageRoot()
+    const client = createProjectDbClient(root)
+    await ensureProjectSchema(client)
+    try {
+      const prompt = {
+        id: 'prompt-1',
+        role: 'user' as const,
+        content: 'draw',
+        status: 'complete' as const,
+        eventIds: [],
+        createdAt: 1,
+        updatedAt: 1
+      }
+      const message = {
+        id: 'message-1',
+        role: 'agent' as const,
+        content: 'done',
+        status: 'complete' as const,
+        eventIds: [],
+        createdAt: 2,
+        updatedAt: 2
+      }
+      const conversationGraph = createLinearConversationGraph({
+        sessionId: 'session-1',
+        messages: [prompt, message],
+        frameworkId: 'codex',
+        createdAt: 1,
+        updatedAt: 2
+      })
+      const session: PersistedChatSession = {
+        id: 'session-1',
+        projectId: 'project-1',
+        title: 'IPC proof',
+        cwd: '/workspace',
+        status: 'idle',
+        messages: [prompt, message],
+        conversationGraph,
+        createdAt: 1,
+        updatedAt: 2
+      }
+      const context = {
+        rootFrameId: conversationGraph.rootFrameId,
+        agentFrameId: conversationGraph.activeFrameId,
+        messageBranchId: conversationGraph.branches[0].id,
+        runtimeSegmentId: conversationGraph.runtimeSegments[0].id,
+        promptMessageId: prompt.id
+      }
+      const compatibility = new ArtifactRepository(root)
+      const provenance = new ArtifactProvenanceRepository({
+        storageRoot: root,
+        getClient: () => Promise.resolve(client),
+        compatibilityRepository: compatibility,
+        loadSession: async () => session
+      })
+      await compatibility.writePendingFile({
+        projectName: 'project-1',
+        sessionId: 'artifact-session-1',
+        runId: 'run-1',
+        filename: 'result.png',
+        source: createPngInlineSource('result bytes')
+      })
+      const version = await provenance.createVersion({
+        projectId: 'project-1',
+        appSessionId: 'session-1',
+        artifactStorageSessionId: 'artifact-session-1',
+        artifactRunId: 'run-1',
+        writeOperationId: 'write-1',
+        writeRequestChecksum: 'a'.repeat(64),
+        ...context,
+        filename: 'result.png'
+      })
+      await client.artifactVersion.update({
+        where: { id: version.versionId },
+        data: {
+          executionSnapshotJson: '{"schemaVersion":2}',
+          executionSnapshotChecksum: '0'.repeat(64)
+        }
+      })
+      await compatibility.prepareRunFinalization({
+        projectName: 'project-1',
+        sourceSessionId: 'artifact-session-1',
+        sessionId: 'session-1',
+        runId: 'run-1',
+        artifactVersionIds: [version.versionId],
+        provenanceContext: context
+      })
+      const registry = new ArtifactRunRegistry()
+      const claimId = registry.register({
+        projectName: 'project-1',
+        artifactSessionId: 'artifact-session-1',
+        sessionId: 'session-1',
+        runId: 'run-1',
+        artifactVersionIds: [version.versionId],
+        ...context
+      })
+      const handlers = createArtifactHandlers(compatibility, registry, { provenance })
+
+      await expect(
+        handlers.finalizeRunArtifacts({ claimId, messageId: message.id })
+      ).rejects.toThrow(/execution snapshot is corrupt/i)
+      await expect(
+        compatibility.listPendingRunFiles({
+          projectName: 'project-1',
+          sessionId: 'artifact-session-1',
+          runId: 'run-1'
+        })
+      ).resolves.toEqual([expect.objectContaining({ name: 'result.png' })])
+      await expect(
+        compatibility.listMessageFiles({
+          projectName: 'project-1',
+          sessionId: 'session-1',
+          messageId: message.id
+        })
+      ).resolves.toEqual([])
+      await expect(
+        client.artifactVersion.findUniqueOrThrow({ where: { id: version.versionId } })
+      ).resolves.toMatchObject({ state: 'pending', messageId: null })
+    } finally {
+      await client.$disconnect()
+    }
+  })
+
+  it('retries compatibility publication after provenance finalized but the first move failed', async () => {
     const finalizedArtifact = createFinalizedArtifact()
     const repository = {
-      finalizeRunArtifacts: vi.fn().mockResolvedValue([finalizedArtifact])
+      finalizeRunArtifacts: vi
+        .fn()
+        .mockRejectedValueOnce(new Error('compatibility storage unavailable'))
+        .mockResolvedValue([finalizedArtifact])
     } as unknown as ArtifactRepository
     const provenance = {
-      validateFinalizationOwnership: vi.fn().mockResolvedValue(undefined),
-      finalizeRun: vi.fn().mockRejectedValue(new Error('SQLite unavailable'))
+      finalizeRun: vi.fn().mockResolvedValue([finalizedArtifact])
     }
     const registry = new ArtifactRunRegistry()
     const claimId = registry.register({
@@ -271,7 +425,8 @@ describe('artifact IPC handlers', () => {
       agentFrameId: 'agent-frame-1',
       messageBranchId: 'branch-1',
       runtimeSegmentId: 'runtime-1',
-      promptMessageId: 'prompt-1'
+      promptMessageId: 'prompt-1',
+      artifactVersionIds: ['version-1']
     })
     const handlers = createArtifactHandlers(repository, registry, {
       provenance: provenance as never
@@ -279,10 +434,17 @@ describe('artifact IPC handlers', () => {
 
     await expect(
       handlers.finalizeRunArtifacts({ claimId, messageId: 'message-1' })
-    ).rejects.toThrow(/SQLite unavailable/)
+    ).rejects.toThrow(/compatibility storage unavailable/)
     expect(repository.finalizeRunArtifacts).toHaveBeenCalledOnce()
     expect(provenance.finalizeRun).toHaveBeenCalledOnce()
     expect(registry.resolve(claimId).finalizedMessageId).toBeUndefined()
+
+    await expect(
+      handlers.finalizeRunArtifacts({ claimId, messageId: 'message-1' })
+    ).resolves.toEqual([finalizedArtifact])
+    expect(repository.finalizeRunArtifacts).toHaveBeenCalledTimes(2)
+    expect(provenance.finalizeRun).toHaveBeenCalledTimes(2)
+    expect(registry.resolve(claimId).finalizedMessageId).toBe('message-1')
   })
 
   it('keeps migration drain pending until an artifact finalization already in progress finishes', async () => {

--- a/src/main/artifacts/ipc.ts
+++ b/src/main/artifacts/ipc.ts
@@ -59,7 +59,6 @@ type ArtifactHandlerDependencies = {
   provenance?: Pick<
     ArtifactProvenanceRepository,
     | 'finalizeRun'
-    | 'validateFinalizationOwnership'
     | 'getLineage'
     | 'getVersionProvenance'
     | 'getVersionCore'
@@ -182,7 +181,7 @@ const finalizeRunArtifacts = async (
   repository: ArtifactRepository,
   runRegistry: ArtifactRunRegistry,
   request: FinalizeRunArtifactsRequest,
-  provenance?: Pick<ArtifactProvenanceRepository, 'finalizeRun' | 'validateFinalizationOwnership'>
+  provenance?: Pick<ArtifactProvenanceRepository, 'finalizeRun'>
 ): Promise<ArtifactFile[]> => {
   const claim = runRegistry.resolve(request.claimId)
 
@@ -203,18 +202,24 @@ const finalizeRunArtifacts = async (
 
   let provenanceArtifacts: ArtifactFile[] | undefined
   let provenanceRequest: Parameters<ArtifactProvenanceRepository['finalizeRun']>[0] | undefined
-  if (
-    provenance &&
-    claim.rootFrameId &&
-    claim.agentFrameId &&
-    claim.messageBranchId &&
-    claim.runtimeSegmentId &&
-    claim.promptMessageId
-  ) {
+  if (provenance) {
+    if (
+      !claim.rootFrameId ||
+      !claim.agentFrameId ||
+      !claim.messageBranchId ||
+      !claim.runtimeSegmentId ||
+      !claim.promptMessageId
+    ) {
+      throw new Error('Artifact run claim is missing complete provenance context.')
+    }
+    if (!claim.artifactVersionIds || claim.artifactVersionIds.length === 0) {
+      throw new Error('Artifact run claim is missing exact Artifact Version ids.')
+    }
     provenanceRequest = {
       projectId: claim.projectName,
       appSessionId: claim.sessionId,
       artifactRunId: claim.runId,
+      artifactVersionIds: [...claim.artifactVersionIds],
       rootFrameId: claim.rootFrameId,
       agentFrameId: claim.agentFrameId,
       messageBranchId: claim.messageBranchId,
@@ -222,19 +227,20 @@ const finalizeRunArtifacts = async (
       promptMessageId: claim.promptMessageId,
       messageId: request.messageId
     }
-    // Preflight the renderer-provided terminal message against the durable conversation graph before
-    // touching compatibility storage. The same proof is repeated when SQLite ownership commits.
-    await provenance.validateFinalizationOwnership(provenanceRequest)
+    // Commit the complete provenance proof and immutable message ownership before compatibility bytes
+    // move. A later compatibility failure is retryable because the prepared marker remains durable.
+    provenanceArtifacts = await provenance.finalizeRun(provenanceRequest)
   }
 
-  // Publish the durable compatibility marker and move first. If SQLite finalization then fails or the
-  // process crashes, startup recovery can replay from this marker; the reverse order is unrecoverable.
+  // Publish compatibility bytes only after the complete provenance transaction succeeds. The move is
+  // idempotent, so a finalized-but-unlinked run can replay here or during prepared-marker recovery.
   const artifacts = await repository.finalizeRunArtifacts({
     projectName: claim.projectName,
     sourceSessionId: claim.artifactSessionId,
     sessionId: claim.sessionId,
     runId: claim.runId,
     messageId: request.messageId,
+    ...(claim.artifactVersionIds ? { artifactVersionIds: claim.artifactVersionIds } : {}),
     ...(claim.rootFrameId &&
     claim.agentFrameId &&
     claim.messageBranchId &&
@@ -251,10 +257,6 @@ const finalizeRunArtifacts = async (
         }
       : {})
   })
-
-  if (provenance && provenanceRequest) {
-    provenanceArtifacts = await provenance.finalizeRun(provenanceRequest)
-  }
 
   runRegistry.markFinalized(request.claimId, request.messageId)
 
@@ -273,7 +275,6 @@ const registerArtifactIpcHandlers = (
   provenance?: Pick<
     ArtifactProvenanceRepository,
     | 'finalizeRun'
-    | 'validateFinalizationOwnership'
     | 'getLineage'
     | 'getVersionProvenance'
     | 'getVersionCore'

--- a/src/main/artifacts/provenance-message-snapshot.test.ts
+++ b/src/main/artifacts/provenance-message-snapshot.test.ts
@@ -150,6 +150,7 @@ describe('Provenance Message snapshots', () => {
       projectId: 'project-1',
       appSessionId: 'session-1',
       artifactRunId: 'artifact-run-1',
+      artifactVersionIds: [version.versionId],
       messageId: 'message-1',
       ...context
     })

--- a/src/main/artifacts/provenance-repository.test.ts
+++ b/src/main/artifacts/provenance-repository.test.ts
@@ -67,7 +67,11 @@ describe('artifact provenance repository', () => {
       repository.reconcileSession('project-1', 'session-1', undefined, {
         removeOrphanStaging: true
       })
-    ).resolves.toEqual({ recoveredVersionIds: [], quarantinedVersionIds: [] })
+    ).resolves.toEqual({
+      recoveredVersionIds: [],
+      quarantinedVersionIds: [],
+      recoveredMessageArtifacts: []
+    })
     await expect(stat(stagingDirectory)).rejects.toMatchObject({ code: 'ENOENT' })
   })
 
@@ -737,7 +741,8 @@ describe('artifact provenance repository', () => {
 
     await expect(repository.reconcileSession('project-1', 'session-1')).resolves.toEqual({
       recoveredVersionIds: [versionId],
-      quarantinedVersionIds: [corruptVersionId]
+      quarantinedVersionIds: [corruptVersionId],
+      recoveredMessageArtifacts: []
     })
     await expect(
       readFile(join(storageRoot, ...contentStorageKey.split('/')), 'utf8')
@@ -2011,6 +2016,7 @@ describe('artifact provenance repository', () => {
         projectId: 'project-1',
         appSessionId: 'session-1',
         artifactRunId: 'artifact-run-1',
+        artifactVersionIds: [version.versionId],
         ...context,
         messageId: 'message-forged',
         messageBranchAncestry: [branch.id],
@@ -2025,6 +2031,7 @@ describe('artifact provenance repository', () => {
         projectId: 'project-1',
         appSessionId: 'session-1',
         artifactRunId: 'artifact-run-1',
+        artifactVersionIds: [version.versionId],
         ...context,
         messageId: assistant.id
       })
@@ -2040,6 +2047,7 @@ describe('artifact provenance repository', () => {
         projectId: 'project-1',
         appSessionId: 'session-1',
         artifactRunId: 'artifact-run-1',
+        artifactVersionIds: [version.versionId],
         ...context,
         messageId: assistant.id
       })
@@ -2133,11 +2141,16 @@ describe('artifact provenance repository', () => {
       where: { id: interrupted.id },
       data: { state: 'staging' }
     })
+    const finalizableVersions = await client.artifactVersion.findMany({
+      where: { artifactRunId: common.artifactRunId, state: 'pending' },
+      orderBy: { versionNumber: 'asc' }
+    })
 
     const finalizeRequest = {
       projectId: common.projectId,
       appSessionId: common.appSessionId,
       artifactRunId: common.artifactRunId,
+      artifactVersionIds: finalizableVersions.map((version) => version.id),
       rootFrameId: common.rootFrameId,
       agentFrameId: common.agentFrameId,
       messageBranchId: common.messageBranchId,
@@ -2145,6 +2158,21 @@ describe('artifact provenance repository', () => {
       promptMessageId: common.promptMessageId,
       messageId: 'message-1'
     }
+    await expect(
+      repository.finalizeRun({ ...finalizeRequest, artifactVersionIds: [] })
+    ).rejects.toThrow(/Artifact Version ids/i)
+    await expect(
+      repository.finalizeRun({
+        ...finalizeRequest,
+        artifactVersionIds: [finalizeRequest.artifactVersionIds[0]]
+      })
+    ).rejects.toThrow(/omitted from the finalization claim/i)
+    await expect(
+      repository.finalizeRun({
+        ...finalizeRequest,
+        artifactVersionIds: [...finalizeRequest.artifactVersionIds, 'version-not-in-run']
+      })
+    ).rejects.toThrow(/no longer eligible/i)
     const ancestryProbe = await client.artifactVersion.findFirstOrThrow({
       where: { artifactRunId: common.artifactRunId, versionNumber: 1 }
     })
@@ -2250,13 +2278,38 @@ describe('artifact provenance repository', () => {
       getClient: () => Promise.resolve(client),
       compatibilityRepository
     })
+    const prompt = {
+      id: 'prompt-1',
+      role: 'user' as const,
+      content: 'draw',
+      status: 'complete' as const,
+      eventIds: [],
+      createdAt: 1,
+      updatedAt: 1
+    }
+    const message = {
+      id: 'message-1',
+      role: 'agent' as const,
+      content: 'done',
+      status: 'complete' as const,
+      eventIds: [],
+      createdAt: 2,
+      updatedAt: 2
+    }
+    const conversationGraph = createLinearConversationGraph({
+      sessionId: 'session-1',
+      messages: [prompt, message],
+      frameworkId: 'codex',
+      createdAt: 1,
+      updatedAt: 2
+    })
     const context = {
-      rootFrameId: 'root-frame-1',
-      agentFrameId: 'root-frame-1',
-      messageBranchId: 'branch-1',
-      runtimeSegmentId: 'runtime-segment-1',
-      promptMessageId: 'prompt-1'
-    } as const
+      rootFrameId: conversationGraph.rootFrameId,
+      agentFrameId: conversationGraph.activeFrameId,
+      messageBranchId: conversationGraph.branches[0].id,
+      runtimeSegmentId: conversationGraph.runtimeSegments[0].id,
+      promptMessageId: prompt.id
+    }
     const request = {
       projectId: 'project-1',
       appSessionId: 'session-1',
@@ -2297,24 +2350,6 @@ describe('artifact provenance repository', () => {
       provenanceContext: context
     })
 
-    const prompt = {
-      id: 'prompt-1',
-      role: 'user' as const,
-      content: 'draw',
-      status: 'complete' as const,
-      eventIds: [],
-      createdAt: 1,
-      updatedAt: 1
-    }
-    const message = {
-      id: 'message-1',
-      role: 'agent' as const,
-      content: 'done',
-      status: 'complete' as const,
-      eventIds: [],
-      createdAt: 2,
-      updatedAt: 2
-    }
     const session: PersistedChatSession = {
       id: 'session-1',
       projectId: 'project-1',
@@ -2322,58 +2357,7 @@ describe('artifact provenance repository', () => {
       cwd: '/workspace',
       status: 'idle',
       messages: [prompt, message],
-      conversationGraph: {
-        schemaVersion: 1,
-        rootFrameId: context.rootFrameId,
-        activeFrameId: context.agentFrameId,
-        frames: [
-          {
-            id: context.agentFrameId,
-            originBindingState: 'root',
-            kind: 'root',
-            status: 'completed',
-            activeBranchId: context.messageBranchId,
-            createdAt: 1,
-            completedAt: 2
-          }
-        ],
-        branches: [
-          {
-            id: context.messageBranchId,
-            agentFrameId: context.agentFrameId,
-            headMessageId: message.id,
-            createdAt: 1,
-            updatedAt: 2
-          }
-        ],
-        messages: [
-          {
-            ...prompt,
-            agentFrameId: context.agentFrameId,
-            introducedOnBranchId: context.messageBranchId,
-            revisionRootMessageId: prompt.id,
-            runtimeSegmentId: context.runtimeSegmentId
-          },
-          {
-            ...message,
-            agentFrameId: context.agentFrameId,
-            introducedOnBranchId: context.messageBranchId,
-            parentMessageId: prompt.id,
-            runtimeSegmentId: context.runtimeSegmentId
-          }
-        ],
-        activities: [],
-        activityGroups: [],
-        runtimeSegments: [
-          {
-            id: context.runtimeSegmentId,
-            agentFrameId: context.agentFrameId,
-            frameworkId: 'codex',
-            startedAt: 1,
-            endedAt: 2
-          }
-        ]
-      },
+      conversationGraph,
       createdAt: 1,
       updatedAt: 2
     }
@@ -2401,6 +2385,265 @@ describe('artifact provenance repository', () => {
     await expect(
       client.artifactVersion.findUniqueOrThrow({ where: { id: version.versionId } })
     ).resolves.toMatchObject({ state: 'finalized', messageId: 'message-1' })
+  })
+
+  it('recovers a prepared run only to its unique durable turn message', async () => {
+    storageRoot = await mkdtemp(join(tmpdir(), 'open-science-artifact-intent-recovery-'))
+    const client = createProjectDbClient(storageRoot)
+    disconnect = () => client.$disconnect()
+    await ensureProjectSchema(client)
+    const compatibilityRepository = new ArtifactRepository(storageRoot)
+    const repository = new ArtifactProvenanceRepository({
+      storageRoot,
+      getClient: () => Promise.resolve(client),
+      compatibilityRepository
+    })
+    const prompt = {
+      id: 'prompt-1',
+      role: 'user' as const,
+      content: 'draw',
+      status: 'complete' as const,
+      eventIds: [],
+      createdAt: 1,
+      updatedAt: 1
+    }
+    const message = {
+      id: 'message-1',
+      role: 'agent' as const,
+      content: 'done',
+      // Renderer lifecycle persistence may lag the provider stop that prepared the durable handoff.
+      status: 'streaming' as const,
+      eventIds: [],
+      createdAt: 2,
+      updatedAt: 2
+    }
+    const conversationGraph = createLinearConversationGraph({
+      sessionId: 'session-1',
+      messages: [prompt, message],
+      frameworkId: 'codex',
+      createdAt: 1,
+      updatedAt: 2
+    })
+    const context = {
+      rootFrameId: conversationGraph.rootFrameId,
+      agentFrameId: conversationGraph.activeFrameId,
+      messageBranchId: conversationGraph.branches[0].id,
+      runtimeSegmentId: conversationGraph.runtimeSegments[0].id,
+      promptMessageId: prompt.id
+    }
+    const request = {
+      projectId: 'project-1',
+      appSessionId: 'session-1',
+      artifactStorageSessionId: 'artifact-session-1',
+      artifactRunId: 'artifact-run-before-renderer-finalize',
+      writeOperationId: 'write-before-renderer-finalize',
+      writeRequestChecksum: 'e'.repeat(64),
+      ...context,
+      filename: 'prepared.png'
+    } as const
+    await compatibilityRepository.writePendingFile({
+      projectName: request.projectId,
+      sessionId: request.artifactStorageSessionId,
+      runId: request.artifactRunId,
+      filename: request.filename,
+      source: createPngInlineSource('prepared-window')
+    })
+    const version = await repository.createVersion(request)
+    const session: PersistedChatSession = {
+      id: request.appSessionId,
+      projectId: request.projectId,
+      title: 'Prepared recovery',
+      cwd: '/workspace',
+      status: 'idle',
+      messages: [prompt, message],
+      conversationGraph,
+      createdAt: 1,
+      updatedAt: 2
+    }
+
+    // A streaming node plus pending Version alone does not prove that the runtime ended the turn and
+    // chose to publish it; a crash before the prepared witness must remain pending.
+    await expect(
+      repository.reconcileSession(request.projectId, request.appSessionId, session)
+    ).resolves.toMatchObject({ recoveredVersionIds: [], recoveredMessageArtifacts: [] })
+
+    // Simulate exit after the runtime durably prepared the handoff but before the renderer finalized it.
+    // The witness proves turn termination; the renderer-owned message status is allowed to lag.
+    await compatibilityRepository.prepareRunFinalization({
+      projectName: request.projectId,
+      sourceSessionId: request.artifactStorageSessionId,
+      sessionId: request.appSessionId,
+      runId: request.artifactRunId,
+      provenanceContext: context
+    })
+    const sessionWithoutTerminalMessage: PersistedChatSession = {
+      ...session,
+      messages: [prompt],
+      conversationGraph: {
+        ...session.conversationGraph!,
+        branches: session.conversationGraph!.branches.map((branch) => ({
+          ...branch,
+          headMessageId: prompt.id
+        })),
+        messages: session.conversationGraph!.messages.slice(0, 1)
+      }
+    }
+    await expect(
+      repository.reconcileSession(
+        request.projectId,
+        request.appSessionId,
+        sessionWithoutTerminalMessage
+      )
+    ).resolves.toMatchObject({ recoveredVersionIds: [], recoveredMessageArtifacts: [] })
+
+    const wrongBranchSession: PersistedChatSession = {
+      ...session,
+      conversationGraph: {
+        ...session.conversationGraph!,
+        branches: [
+          {
+            ...session.conversationGraph!.branches[0],
+            headMessageId: prompt.id
+          },
+          {
+            id: 'branch-other',
+            agentFrameId: context.agentFrameId,
+            headMessageId: message.id,
+            createdAt: 1,
+            updatedAt: 2
+          }
+        ],
+        messages: session.conversationGraph!.messages.map((node) =>
+          node.id === message.id ? { ...node, introducedOnBranchId: 'branch-other' } : node
+        )
+      }
+    }
+    await expect(
+      repository.reconcileSession(request.projectId, request.appSessionId, wrongBranchSession)
+    ).resolves.toMatchObject({ recoveredVersionIds: [], recoveredMessageArtifacts: [] })
+
+    const ambiguousMessage = {
+      ...message,
+      id: 'message-ambiguous',
+      content: 'later agent output',
+      createdAt: 3,
+      updatedAt: 3
+    }
+    const ambiguousSession: PersistedChatSession = {
+      ...session,
+      messages: [prompt, message, ambiguousMessage],
+      conversationGraph: {
+        ...session.conversationGraph!,
+        branches: session.conversationGraph!.branches.map((branch) => ({
+          ...branch,
+          headMessageId: ambiguousMessage.id,
+          updatedAt: 3
+        })),
+        messages: [
+          ...session.conversationGraph!.messages,
+          {
+            ...ambiguousMessage,
+            agentFrameId: context.agentFrameId,
+            introducedOnBranchId: context.messageBranchId,
+            parentMessageId: message.id,
+            runtimeSegmentId: context.runtimeSegmentId
+          }
+        ]
+      }
+    }
+    await expect(
+      repository.reconcileSession(request.projectId, request.appSessionId, ambiguousSession)
+    ).resolves.toMatchObject({ recoveredVersionIds: [], recoveredMessageArtifacts: [] })
+    await expect(
+      client.artifactVersion.findUniqueOrThrow({ where: { id: version.versionId } })
+    ).resolves.toMatchObject({ state: 'pending', messageId: null })
+
+    const recovered = await repository.reconcileSession(
+      request.projectId,
+      request.appSessionId,
+      session
+    )
+    expect(recovered).toMatchObject({
+      recoveredVersionIds: expect.arrayContaining([version.versionId]),
+      recoveredMessageArtifacts: [
+        {
+          messageId: message.id,
+          artifacts: [
+            expect.objectContaining({
+              id: version.versionId,
+              versionId: version.versionId,
+              artifactId: version.artifactId
+            })
+          ]
+        }
+      ]
+    })
+    await expect(
+      client.artifactVersion.findUniqueOrThrow({ where: { id: version.versionId } })
+    ).resolves.toMatchObject({ state: 'finalized', messageId: message.id })
+    await expect(
+      compatibilityRepository.findRunFinalizationMarker(request.projectId, request.artifactRunId)
+    ).resolves.toMatchObject({ messageId: message.id, provenanceContext: context })
+
+    // A failed Session JSON save retries the attachment even though SQLite is already finalized.
+    const attachmentRetry = await repository.reconcileSession(
+      request.projectId,
+      request.appSessionId,
+      session
+    )
+    expect(attachmentRetry).toMatchObject({
+      recoveredVersionIds: [],
+      recoveredMessageArtifacts: [
+        {
+          messageId: message.id,
+          artifacts: [expect.objectContaining({ id: version.versionId })]
+        }
+      ]
+    })
+
+    const messageLinkedSession: PersistedChatSession = {
+      ...session,
+      messages: session.messages.map((item) =>
+        item.id === message.id ? { ...item, artifactIds: [version.versionId] } : item
+      ),
+      conversationGraph: {
+        ...session.conversationGraph!,
+        messages: session.conversationGraph!.messages.map((item) =>
+          item.id === message.id ? { ...item, artifactIds: [version.versionId] } : item
+        )
+      }
+    }
+    await expect(
+      repository.reconcileSession(request.projectId, request.appSessionId, messageLinkedSession)
+    ).resolves.toMatchObject({
+      recoveredVersionIds: [],
+      recoveredMessageArtifacts: [
+        { messageId: message.id, artifacts: [expect.objectContaining({ id: version.versionId })] }
+      ]
+    })
+
+    const linkedSession: PersistedChatSession = {
+      ...messageLinkedSession,
+      artifacts: [
+        {
+          id: version.versionId,
+          artifactId: version.artifactId,
+          versionId: version.versionId,
+          versionNumber: version.versionNumber,
+          kind: 'managed-file',
+          path: version.path,
+          fileUrl: version.fileUrl,
+          name: version.name,
+          mimeType: version.mimeType,
+          size: version.size,
+          mtimeMs: version.mtimeMs,
+          sha256: version.checksum
+        }
+      ]
+    }
+    await expect(
+      repository.reconcileSession(request.projectId, request.appSessionId, linkedSession)
+    ).resolves.toMatchObject({ recoveredVersionIds: [], recoveredMessageArtifacts: [] })
   })
 
   it('withholds saved Review conclusions when an active source Session cannot be loaded', async () => {
@@ -2680,6 +2923,7 @@ describe('artifact provenance repository', () => {
       projectId: request.projectId,
       appSessionId: request.appSessionId,
       artifactRunId: request.artifactRunId,
+      artifactVersionIds: [version.versionId],
       rootFrameId: request.rootFrameId,
       agentFrameId: request.agentFrameId,
       messageBranchId: request.messageBranchId,
@@ -2743,7 +2987,11 @@ describe('artifact provenance repository', () => {
 
     await expect(
       repository.reconcileSession(request.projectId, request.appSessionId)
-    ).resolves.toEqual({ recoveredVersionIds: [version.versionId], quarantinedVersionIds: [] })
+    ).resolves.toEqual({
+      recoveredVersionIds: [version.versionId],
+      quarantinedVersionIds: [],
+      recoveredMessageArtifacts: []
+    })
     await expect(
       client.artifactVersion.findUniqueOrThrow({ where: { id: version.versionId } })
     ).resolves.toMatchObject({
@@ -2812,7 +3060,11 @@ describe('artifact provenance repository', () => {
 
     await expect(
       repository.reconcileSession(request.projectId, request.appSessionId)
-    ).resolves.toEqual({ recoveredVersionIds: [version.versionId], quarantinedVersionIds: [] })
+    ).resolves.toEqual({
+      recoveredVersionIds: [version.versionId],
+      quarantinedVersionIds: [],
+      recoveredMessageArtifacts: []
+    })
     await expect(
       client.artifactVersion.findUniqueOrThrow({ where: { id: version.versionId } })
     ).resolves.toMatchObject({
@@ -2882,7 +3134,11 @@ describe('artifact provenance repository', () => {
 
     await expect(
       repository.reconcileSession(request.projectId, request.appSessionId)
-    ).resolves.toEqual({ recoveredVersionIds: [], quarantinedVersionIds: [] })
+    ).resolves.toEqual({
+      recoveredVersionIds: [],
+      quarantinedVersionIds: [],
+      recoveredMessageArtifacts: []
+    })
     await expect(readFile(version.path)).resolves.toBeTruthy()
     await expect(
       client.artifactVersion.findUnique({ where: { id: version.versionId } })
@@ -2891,7 +3147,11 @@ describe('artifact provenance repository', () => {
     await rm(corruptMetadataPath)
     await expect(
       repository.reconcileSession(request.projectId, request.appSessionId)
-    ).resolves.toEqual({ recoveredVersionIds: [version.versionId], quarantinedVersionIds: [] })
+    ).resolves.toEqual({
+      recoveredVersionIds: [version.versionId],
+      quarantinedVersionIds: [],
+      recoveredMessageArtifacts: []
+    })
   })
 
   it('quarantines an unindexed Version when no immutable lifecycle proof exists', async () => {
@@ -2983,7 +3243,11 @@ describe('artifact provenance repository', () => {
 
     await expect(
       repository.reconcileSession(request.projectId, request.appSessionId)
-    ).resolves.toEqual({ recoveredVersionIds: [], quarantinedVersionIds: [version.versionId] })
+    ).resolves.toEqual({
+      recoveredVersionIds: [],
+      quarantinedVersionIds: [version.versionId],
+      recoveredMessageArtifacts: []
+    })
     await expect(readFile(version.path)).rejects.toMatchObject({ code: 'ENOENT' })
     const quarantineRoot = join(
       storageRoot,

--- a/src/main/artifacts/provenance-repository.ts
+++ b/src/main/artifacts/provenance-repository.ts
@@ -36,7 +36,11 @@ import type {
   ProvenanceExecutionInputFile,
   ReplayArtifactVersionRequest
 } from '../../shared/artifact-provenance'
-import { ArtifactCompatibilityScanIncompleteError, ArtifactRepository } from './repository'
+import {
+  ArtifactCompatibilityScanIncompleteError,
+  ArtifactRepository,
+  type PendingArtifactRunPublication
+} from './repository'
 import { defaultArtifactDurability, type ArtifactDurability } from './durability'
 import { NotebookRunRepository } from '../notebook/repository'
 import type {
@@ -195,6 +199,20 @@ type ProducerCapture =
 type ArtifactStorageReconciliationResult = {
   recoveredVersionIds: string[]
   quarantinedVersionIds: string[]
+  recoveredMessageArtifacts: Array<{ messageId: string; artifacts: ArtifactVersionFile[] }>
+}
+
+type ArtifactProjectReconciliationState = {
+  readonly projectId: string
+  readonly unfinishedCompatibilityPublications: readonly PendingArtifactRunPublication[]
+}
+
+const artifactProjectReconciliationState = Symbol('artifactProjectReconciliationState')
+
+// Opaque outside this module: callers may route a Project-scoped snapshot but cannot inspect or
+// construct its publication state. This keeps compatibility layout knowledge inside Provenance.
+export type ArtifactProjectReconciliationSnapshot = {
+  readonly [artifactProjectReconciliationState]: ArtifactProjectReconciliationState
 }
 
 type ArtifactFinalizationContext = Pick<
@@ -206,6 +224,33 @@ type ArtifactFinalizationContext = Pick<
   | 'promptMessageId'
   | 'messageId'
 >
+
+type PreparedArtifactFinalizationContext = Omit<ArtifactFinalizationContext, 'messageId'>
+
+class ArtifactFinalizationProofError extends Error {
+  constructor(message: string, cause?: unknown) {
+    super(message, cause === undefined ? undefined : { cause })
+    this.name = 'ArtifactFinalizationProofError'
+  }
+}
+
+type ArtifactFinalizationProofRequest = FinalizeArtifactVersionsRequest
+
+type ArtifactFinalizationProofVersion = PersistedVersionFileRecord & {
+  messageId: string | null
+  rootFrameId: string
+  agentFrameId: string
+  messageBranchId: string
+  runtimeSegmentId: string
+  promptMessageId: string
+  notebookSessionId: string | null
+  producerRunIndex: number | null
+  executionSnapshotChecksum: string | null
+  executionSnapshotStorageKey: string | null
+  executionSnapshotSchemaVersion: number | null
+  evidenceJson: string
+  artifact: { projectId: string; sessionId: string }
+}
 
 const validateDurableMessageOwnership = (
   session: PersistedChatSession,
@@ -264,6 +309,63 @@ const validateDurableMessageOwnership = (
   }
 }
 
+// Resolves the one agent message produced by the prepared prompt turn. It deliberately considers only
+// messages before the next user prompt on the declared Branch and Runtime Segment; choosing a latest
+// message (or accepting multiple candidates) could attach a crashed run to a later turn.
+const inferDurableFinalizationMessageId = (
+  session: PersistedChatSession,
+  context: PreparedArtifactFinalizationContext
+): string | undefined => {
+  const graph = materializeSessionConversationGraph(session).conversationGraph!
+  if (graph.rootFrameId !== context.rootFrameId) return undefined
+  const frame = graph.frames.find((candidate) => candidate.id === context.agentFrameId)
+  const branch = graph.branches.find((candidate) => candidate.id === context.messageBranchId)
+  const segment = graph.runtimeSegments.find(
+    (candidate) =>
+      candidate.id === context.runtimeSegmentId && candidate.agentFrameId === context.agentFrameId
+  )
+  if (!frame || !branch || branch.agentFrameId !== frame.id || !segment) return undefined
+
+  const path = resolveMessageBranchPath(graph, context.messageBranchId)
+  const promptIndex = path.findIndex((message) => message.id === context.promptMessageId)
+  if (promptIndex < 0) return undefined
+  const followingUserOffset = path
+    .slice(promptIndex + 1)
+    .findIndex((message) => message.role === 'user')
+  const turnEnd = followingUserOffset < 0 ? path.length : promptIndex + 1 + followingUserOffset
+  const candidates = path
+    .slice(promptIndex + 1, turnEnd)
+    .filter(
+      (message) =>
+        message.role === 'agent' &&
+        message.agentFrameId === context.agentFrameId &&
+        message.introducedOnBranchId === context.messageBranchId &&
+        message.runtimeSegmentId === context.runtimeSegmentId
+    )
+  if (candidates.length !== 1) return undefined
+
+  validateDurableMessageOwnership(session, { ...context, messageId: candidates[0].id })
+  return candidates[0].id
+}
+
+// Require Session metadata and every persisted owner projection to carry ArtifactFile.id.
+const isArtifactLinkedToDurableMessage = (
+  session: PersistedChatSession,
+  messageId: string,
+  versionId: string
+): boolean => {
+  const owners = [
+    session.messages.find((message) => message.id === messageId),
+    session.conversationGraph?.messages.find((message) => message.id === messageId)
+  ].filter((message): message is NonNullable<typeof message> => !!message)
+
+  return (
+    owners.length > 0 &&
+    owners.every((message) => message.artifactIds?.includes(versionId)) &&
+    !!session.artifacts?.some((artifact) => artifact.id === versionId)
+  )
+}
+
 type CanonicalJson =
   null | boolean | number | string | CanonicalJson[] | { [key: string]: CanonicalJson }
 
@@ -305,6 +407,168 @@ const canonicalize = (value: CanonicalJson): CanonicalJson => {
 const canonicalJson = (value: CanonicalJson): string => JSON.stringify(canonicalize(value))
 
 const sha256 = (value: Buffer | string): string => createHash('sha256').update(value).digest('hex')
+
+const normalizeArtifactFinalizationProofRequest = (
+  request: ArtifactFinalizationProofRequest
+): ArtifactFinalizationProofRequest => {
+  if (!Array.isArray(request.artifactVersionIds) || request.artifactVersionIds.length === 0) {
+    throw new ArtifactFinalizationProofError('Artifact Version ids are required for finalization.')
+  }
+  const artifactVersionIds = request.artifactVersionIds.map((versionId) =>
+    assertSafeSegment(versionId, 'artifact version id')
+  )
+  if (new Set(artifactVersionIds).size !== artifactVersionIds.length) {
+    throw new ArtifactFinalizationProofError('Artifact Version ids must be unique.')
+  }
+
+  return {
+    ...request,
+    artifactVersionIds,
+    projectId: assertSafeSegment(request.projectId, 'project id'),
+    appSessionId: assertSafeSegment(request.appSessionId, 'session id'),
+    artifactRunId: assertSafeSegment(request.artifactRunId, 'artifact run id'),
+    rootFrameId: assertSafeSegment(request.rootFrameId, 'root frame id'),
+    agentFrameId: assertSafeSegment(request.agentFrameId, 'agent frame id'),
+    messageBranchId: assertSafeSegment(request.messageBranchId, 'message branch id'),
+    runtimeSegmentId: assertSafeSegment(request.runtimeSegmentId, 'runtime segment id'),
+    promptMessageId: assertSafeSegment(request.promptMessageId, 'prompt message id'),
+    messageId: assertSafeSegment(request.messageId, 'message id')
+  }
+}
+
+const loadArtifactFinalizationProofVersions = async (
+  client: Pick<PrismaClient, 'artifactVersion'>,
+  request: ArtifactFinalizationProofRequest
+): Promise<ArtifactFinalizationProofVersion[]> =>
+  client.artifactVersion.findMany({
+    where: {
+      artifactRunId: request.artifactRunId,
+      rootFrameId: request.rootFrameId,
+      agentFrameId: request.agentFrameId,
+      messageBranchId: request.messageBranchId,
+      runtimeSegmentId: request.runtimeSegmentId,
+      promptMessageId: request.promptMessageId,
+      state: { in: ['pending', 'finalized'] },
+      artifact: { is: { projectId: request.projectId, sessionId: request.appSessionId } }
+    },
+    include: { artifact: true },
+    orderBy: [{ artifactId: 'asc' }, { versionNumber: 'asc' }]
+  })
+
+const validateArtifactFinalizationProof = (
+  matching: readonly ArtifactFinalizationProofVersion[],
+  request: ArtifactFinalizationProofRequest
+): void => {
+  const matchingIds = new Set(matching.map((version) => version.id))
+  const expectedIds = new Set(request.artifactVersionIds)
+  const missingExpectedVersionId = request.artifactVersionIds.find(
+    (versionId) => !matchingIds.has(versionId)
+  )
+  if (missingExpectedVersionId) {
+    throw new ArtifactFinalizationProofError(
+      `Artifact Version is no longer eligible for finalization: ${missingExpectedVersionId}`
+    )
+  }
+  const unexpectedMatchingVersion = matching.find((version) => !expectedIds.has(version.id))
+  if (unexpectedMatchingVersion) {
+    throw new ArtifactFinalizationProofError(
+      `Artifact Version was omitted from the finalization claim: ${unexpectedMatchingVersion.id}`
+    )
+  }
+
+  const conflicting = matching.find(
+    (version) => version.messageId && version.messageId !== request.messageId
+  )
+  if (conflicting) {
+    throw new ArtifactFinalizationProofError(
+      `Artifact Version ${conflicting.id} is already finalized to a different message.`
+    )
+  }
+
+  const durableBranchIds = new Set(request.messageBranchAncestry ?? [request.messageBranchId])
+  const durableMessageIds = new Set(
+    request.messageAncestry ?? [request.promptMessageId, request.messageId]
+  )
+  for (const version of matching) {
+    try {
+      const parsedEvidence = JSON.parse(version.evidenceJson) as Partial<ArtifactVersionEvidence>
+      if (
+        !parsedEvidence ||
+        typeof parsedEvidence !== 'object' ||
+        (parsedEvidence.producer?.state !== 'available' &&
+          parsedEvidence.producer?.state !== 'unavailable')
+      ) {
+        throw new ArtifactFinalizationProofError(
+          `Artifact Version evidence is invalid: ${version.id}`
+        )
+      }
+      const evidence = parsedEvidence as ArtifactVersionEvidence
+
+      if (!version.executionSnapshotJson) {
+        const hasProducerOrExecutionFields =
+          version.notebookSessionId !== null ||
+          version.producerRunId !== null ||
+          version.producerRunIndex !== null ||
+          version.executionSnapshotChecksum !== null ||
+          version.executionSnapshotStorageKey !== null ||
+          version.executionSnapshotSchemaVersion !== null
+        const isProvenUnavailableWithoutExecution =
+          evidence.producer.state === 'unavailable' &&
+          evidence.execution_status?.state === 'unavailable' &&
+          Array.isArray(evidence.inputs) &&
+          evidence.inputs.length === 0 &&
+          evidence.execution_snapshot_checksum === undefined &&
+          evidence.reproduction_code === undefined
+        if (hasProducerOrExecutionFields || !isProvenUnavailableWithoutExecution) {
+          throw new ArtifactFinalizationProofError(
+            `Artifact Version execution snapshot is missing: ${version.id}`
+          )
+        }
+        continue
+      }
+
+      if (
+        !version.executionSnapshotChecksum ||
+        sha256(version.executionSnapshotJson) !== version.executionSnapshotChecksum
+      ) {
+        throw new ArtifactFinalizationProofError(
+          `Artifact Version execution snapshot is corrupt: ${version.id}`
+        )
+      }
+      const snapshot = parseArtifactExecutionSnapshot(version.executionSnapshotJson)
+      validateArtifactExecutionSnapshot(snapshot, {
+        rootFrameId: version.rootFrameId,
+        agentFrameId: version.agentFrameId,
+        messageBranchId: version.messageBranchId,
+        promptMessageId: version.promptMessageId,
+        producerRunId: version.producerRunId,
+        producerRunIndex: version.producerRunIndex,
+        executionSnapshotChecksum: version.executionSnapshotChecksum,
+        evidence
+      })
+      const outsideDurableAncestry = snapshot.runs.some(
+        (run) =>
+          !durableBranchIds.has(run.messageBranchId) ||
+          (run.promptMessageId
+            ? !durableMessageIds.has(run.promptMessageId)
+            : run.messageBranchId !== request.messageBranchId)
+      )
+      if (outsideDurableAncestry) {
+        throw new ArtifactFinalizationProofError(
+          `Artifact Version execution snapshot is outside the durable Branch ancestry: ${version.id}`
+        )
+      }
+    } catch (error) {
+      if (error instanceof ArtifactFinalizationProofError) throw error
+      throw new ArtifactFinalizationProofError(
+        error instanceof Error
+          ? error.message
+          : `Artifact Version execution snapshot is invalid: ${version.id}`,
+        error
+      )
+    }
+  }
+}
 
 const storageKey = (...segments: string[]): string => segments.join('/')
 
@@ -2140,83 +2404,22 @@ class ArtifactProvenanceRepository {
   }
 
   private async finalizeVerifiedRun(
-    request: FinalizeArtifactVersionsRequest
+    request: ArtifactFinalizationProofRequest
   ): Promise<ArtifactVersionFile[]> {
-    const projectId = assertSafeSegment(request.projectId, 'project id')
-    const appSessionId = assertSafeSegment(request.appSessionId, 'session id')
-    const artifactRunId = assertSafeSegment(request.artifactRunId, 'artifact run id')
-    const rootFrameId = assertSafeSegment(request.rootFrameId, 'root frame id')
-    const agentFrameId = assertSafeSegment(request.agentFrameId, 'agent frame id')
-    const messageBranchId = assertSafeSegment(request.messageBranchId, 'message branch id')
-    const runtimeSegmentId = assertSafeSegment(request.runtimeSegmentId, 'runtime segment id')
-    const promptMessageId = assertSafeSegment(request.promptMessageId, 'prompt message id')
-    const messageId = assertSafeSegment(request.messageId, 'message id')
+    const normalizedRequest = normalizeArtifactFinalizationProofRequest(request)
     const client = await this.options.getClient()
     const versions = await client.$transaction(async (transaction) => {
-      const matching = await transaction.artifactVersion.findMany({
-        where: {
-          artifactRunId,
-          rootFrameId,
-          agentFrameId,
-          messageBranchId,
-          runtimeSegmentId,
-          promptMessageId,
-          state: { in: ['pending', 'finalized'] },
-          artifact: { is: { projectId, sessionId: appSessionId } }
-        },
-        include: { artifact: true },
-        orderBy: [{ artifactId: 'asc' }, { versionNumber: 'asc' }]
-      })
-      const conflicting = matching.find(
-        (version) => version.messageId && version.messageId !== messageId
-      )
-      if (conflicting) {
-        throw new Error(
-          `Artifact Version ${conflicting.id} is already finalized to a different message.`
-        )
-      }
-
-      const durableBranchIds = new Set(request.messageBranchAncestry ?? [messageBranchId])
-      const durableMessageIds = new Set(request.messageAncestry ?? [promptMessageId, messageId])
-      for (const version of matching) {
-        if (!version.executionSnapshotJson) continue
-        if (
-          !version.executionSnapshotChecksum ||
-          sha256(version.executionSnapshotJson) !== version.executionSnapshotChecksum
-        ) {
-          throw new Error(`Artifact Version execution snapshot is corrupt: ${version.id}`)
-        }
-        const snapshot = parseArtifactExecutionSnapshot(version.executionSnapshotJson)
-        validateArtifactExecutionSnapshot(snapshot, {
-          rootFrameId: version.rootFrameId,
-          agentFrameId: version.agentFrameId,
-          messageBranchId: version.messageBranchId,
-          promptMessageId: version.promptMessageId,
-          producerRunId: version.producerRunId,
-          producerRunIndex: version.producerRunIndex,
-          executionSnapshotChecksum: version.executionSnapshotChecksum,
-          evidence: JSON.parse(version.evidenceJson) as ArtifactVersionEvidence
-        })
-        const outsideDurableAncestry = snapshot.runs.some(
-          (run) =>
-            !durableBranchIds.has(run.messageBranchId) ||
-            (run.promptMessageId
-              ? !durableMessageIds.has(run.promptMessageId)
-              : run.messageBranchId !== messageBranchId)
-        )
-        if (outsideDurableAncestry) {
-          throw new Error(
-            `Artifact Version execution snapshot is outside the durable Branch ancestry: ${version.id}`
-          )
-        }
-      }
+      const matching = await loadArtifactFinalizationProofVersions(transaction, normalizedRequest)
+      // Validate the complete proof from the same transaction that commits message ownership. Recovery
+      // does not touch compatibility storage until this transaction succeeds.
+      validateArtifactFinalizationProof(matching, normalizedRequest)
 
       await transaction.artifactVersion.updateMany({
         where: {
           id: { in: matching.map((version) => version.id) },
           state: 'pending'
         },
-        data: { state: 'finalized', messageId }
+        data: { state: 'finalized', messageId: normalizedRequest.messageId }
       })
 
       return transaction.artifactVersion.findMany({
@@ -2260,21 +2463,49 @@ class ArtifactProvenanceRepository {
     )
   }
 
+  async prepareProjectReconciliation(
+    projectIdInput: string
+  ): Promise<ArtifactProjectReconciliationSnapshot> {
+    const projectId = assertSafeSegment(projectIdInput, 'project id')
+    const unfinishedCompatibilityPublications = this.options.compatibilityRepository
+      ? await this.options.compatibilityRepository.listPendingRunPublications(projectId)
+      : []
+    return {
+      [artifactProjectReconciliationState]: {
+        projectId,
+        unfinishedCompatibilityPublications
+      }
+    }
+  }
+
   async reconcileSession(
     projectIdInput: string,
     appSessionIdInput: string,
     durableSession?: PersistedChatSession,
-    options?: { removeOrphanStaging?: boolean }
+    options?: {
+      removeOrphanStaging?: boolean
+      projectReconciliation?: ArtifactProjectReconciliationSnapshot
+    }
   ): Promise<ArtifactStorageReconciliationResult> {
     const projectId = assertSafeSegment(projectIdInput, 'project id')
     const appSessionId = assertSafeSegment(appSessionIdInput, 'app session id')
+    const preparedProjectReconciliation = options?.projectReconciliation
+      ? options.projectReconciliation[artifactProjectReconciliationState]
+      : undefined
+    if (options?.projectReconciliation && !preparedProjectReconciliation) {
+      throw new Error('Artifact Project reconciliation snapshot is invalid.')
+    }
+    if (preparedProjectReconciliation && preparedProjectReconciliation.projectId !== projectId) {
+      throw new Error('Artifact Project reconciliation snapshot belongs to another Project.')
+    }
     const provenanceRoot = resolveStorageKey(
       this.options.storageRoot,
       storageKey('artifacts', projectId, appSessionId, '.provenance')
     )
     const result: ArtifactStorageReconciliationResult = {
       recoveredVersionIds: [],
-      quarantinedVersionIds: []
+      quarantinedVersionIds: [],
+      recoveredMessageArtifacts: []
     }
     const lineageEntries = await readdir(provenanceRoot, { withFileTypes: true }).catch(
       (error: unknown) => {
@@ -2386,30 +2617,63 @@ class ArtifactProvenanceRepository {
       }
     }
 
-    // Compatibility finalization publishes its marker before moving files. If the process exits after
-    // that commit but before SQLite finalization, replay only when the marker context and the durable
-    // conversation graph independently prove the same Branch/message ownership.
+    // Runtime publication first records a durable intent, then renderer finalization upgrades it with
+    // the terminal message before moving compatibility bytes. Recover either crash window only when
+    // the marker context and durable graph independently prove the same Branch/message ownership.
     if (
       durableSession &&
       durableSession.projectId === projectId &&
       durableSession.id === appSessionId &&
       this.options.compatibilityRepository
     ) {
-      const pendingVersions = await client.artifactVersion.findMany({
+      const allFinalizationVersions = await client.artifactVersion.findMany({
         where: {
-          state: 'pending',
+          state: { in: ['pending', 'finalized'] },
           artifact: { is: { projectId, sessionId: appSessionId } }
         }
       })
-      const runIds = [...new Set(pendingVersions.map((version) => version.artifactRunId))]
+      const candidateVersions = allFinalizationVersions.filter(
+        (version) =>
+          version.state === 'pending' ||
+          (version.messageId !== null &&
+            !isArtifactLinkedToDurableMessage(durableSession, version.messageId, version.id))
+      )
+      // Native Session linkage proves only that immutable Provenance content is attached. A single
+      // project scan adds the much narrower set whose compatibility publication is physically
+      // unfinished, without replaying every historical finalized run or rescanning Sessions per run.
+      // Direct callers deliberately get a fresh scan. Startup supplies one opaque Project snapshot
+      // to every Session, avoiding repeated scans without persisting stale repository state.
+      const unfinishedCompatibilityPublications =
+        preparedProjectReconciliation?.unfinishedCompatibilityPublications ??
+        (await this.options.compatibilityRepository.listPendingRunPublications(projectId))
+      const publicationByRunId = new Map(
+        unfinishedCompatibilityPublications.map((publication) => [publication.runId, publication])
+      )
+      const runIds = [
+        ...new Set([
+          ...candidateVersions.map((version) => version.artifactRunId),
+          ...unfinishedCompatibilityPublications.map((publication) => publication.runId)
+        ])
+      ]
       for (const artifactRunId of runIds) {
-        const marker = await this.options.compatibilityRepository.findRunFinalizationMarker(
-          projectId,
-          artifactRunId
-        )
+        const unfinishedPublication = publicationByRunId.get(artifactRunId)
+        const marker = unfinishedPublication
+          ? unfinishedPublication.marker
+            ? {
+                ...unfinishedPublication.marker,
+                sourceSessionId: unfinishedPublication.sourceSessionId
+              }
+            : undefined
+          : await this.options.compatibilityRepository.findRunFinalizationMarker(
+              projectId,
+              artifactRunId
+            )
         const markerContext = marker?.provenanceContext
         if (!marker || marker.sessionId !== appSessionId || !markerContext) continue
-        const runVersions = pendingVersions.filter(
+        // Exact-set proof covers the whole pending/finalized run, including Versions already linked
+        // to Session JSON. The candidate subset decides whether recovery is needed, not what the run
+        // owns; otherwise a partially linked run would look like it contained unexpected Versions.
+        const runVersions = allFinalizationVersions.filter(
           (version) => version.artifactRunId === artifactRunId
         )
         if (
@@ -2425,25 +2689,78 @@ class ArtifactProvenanceRepository {
         ) {
           continue
         }
+        let proof:
+          | {
+              messageId: string
+              ancestry: ReturnType<typeof validateDurableMessageOwnership>
+            }
+          | undefined
         try {
-          const ancestry = validateDurableMessageOwnership(durableSession, {
-            ...markerContext,
-            messageId: marker.messageId
-          })
-          const finalized = await this.finalizeRunWithDurableSession(
-            {
-              projectId,
-              appSessionId,
-              artifactRunId,
-              ...markerContext,
-              messageId: marker.messageId,
-              ...ancestry
-            },
-            durableSession
-          )
-          result.recoveredVersionIds.push(...finalized.map((version) => version.versionId!))
+          const messageId =
+            marker.messageId ?? inferDurableFinalizationMessageId(durableSession, markerContext)
+          if (messageId) {
+            proof = {
+              messageId,
+              ancestry: validateDurableMessageOwnership(durableSession, {
+                ...markerContext,
+                messageId
+              })
+            }
+          }
         } catch {
           // Leave the pending Version visible and retryable; an unproven marker is never guessed.
+        }
+        if (!proof) continue
+
+        const pendingVersionIds = new Set(
+          runVersions.filter((version) => version.state === 'pending').map((version) => version.id)
+        )
+        // Markers created before exact-set publication shipped have no frozen ids. Preserve that
+        // on-disk compatibility by deriving the whole run once; every new marker carries ids and is
+        // consumed verbatim, so recovery can never widen or narrow a modern runtime claim.
+        const markerVersionIds =
+          marker.artifactVersionIds ?? runVersions.map((version) => version.id)
+        const finalizationRequest: ArtifactFinalizationProofRequest = {
+          projectId,
+          appSessionId,
+          artifactRunId,
+          ...markerContext,
+          messageId: proof.messageId,
+          ...proof.ancestry,
+          artifactVersionIds: markerVersionIds
+        }
+        let finalized: ArtifactVersionFile[]
+        try {
+          // Commit complete ownership and execution proof before the irreversible compatibility move.
+          // A crash or I/O failure after this point leaves a finalized-but-unlinked Version, which the
+          // candidate selector above deliberately retries on the next startup.
+          finalized = await this.finalizeVerifiedRun(finalizationRequest)
+        } catch (error) {
+          if (error instanceof ArtifactFinalizationProofError) continue
+          throw error
+        }
+        // Replay unconditionally after the durable Version commit: a bound marker may have survived a
+        // crash before pending bytes moved. Operational compatibility failures escape and keep startup
+        // incomplete without exposing the not-yet-attached Version in Session JSON.
+        await this.options.compatibilityRepository.finalizeRunArtifacts({
+          projectName: projectId,
+          sourceSessionId: marker.sourceSessionId,
+          sessionId: appSessionId,
+          runId: artifactRunId,
+          messageId: proof.messageId,
+          artifactVersionIds: markerVersionIds,
+          provenanceContext: markerContext
+        })
+        result.recoveredVersionIds.push(
+          ...finalized
+            .filter((version) => pendingVersionIds.has(version.versionId!))
+            .map((version) => version.versionId!)
+        )
+        if (finalized.length > 0) {
+          result.recoveredMessageArtifacts.push({
+            messageId: proof.messageId,
+            artifacts: finalized
+          })
         }
       }
     }

--- a/src/main/artifacts/repository.test.ts
+++ b/src/main/artifacts/repository.test.ts
@@ -17,6 +17,7 @@ import { afterEach, describe, expect, it } from 'vitest'
 import type { ArtifactWriteSource } from '../../shared/artifacts'
 import { createPngBytes, createPngInlineSource } from './artifact-test-fixtures'
 import {
+  ArtifactCompatibilityScanIncompleteError,
   ArtifactRepository,
   getArtifactCurrentRunFilePath,
   getProjectArtifactDir
@@ -412,6 +413,226 @@ describe('artifact repository', () => {
     await expect(
       readdir(join(root, 'artifacts', 'default-project', 'session-1', '.pending'))
     ).resolves.not.toContain('run-1')
+  })
+
+  it('durably prepares a run for finalization before its terminal message is known', async () => {
+    const root = await createStorageRoot()
+    const repository = new ArtifactRepository(root)
+    const provenanceContext = {
+      rootFrameId: 'root-frame-1',
+      agentFrameId: 'agent-frame-1',
+      messageBranchId: 'branch-1',
+      runtimeSegmentId: 'runtime-segment-1',
+      promptMessageId: 'prompt-1'
+    }
+
+    await repository.prepareRunFinalization({
+      projectName: 'default-project',
+      sourceSessionId: 'artifact-session-1',
+      sessionId: 'session-1',
+      runId: 'run-1',
+      artifactVersionIds: ['version-1', 'version-2'],
+      provenanceContext
+    })
+
+    await expect(
+      repository.findRunFinalizationMarker('default-project', 'run-1')
+    ).resolves.toMatchObject({
+      sourceSessionId: 'artifact-session-1',
+      sessionId: 'session-1',
+      provenanceContext,
+      artifactVersionIds: ['version-1', 'version-2']
+    })
+    await expect(
+      repository.findRunFinalizationMarker('default-project', 'run-1')
+    ).resolves.not.toHaveProperty('messageId')
+
+    await repository.finalizeRunArtifacts({
+      projectName: 'default-project',
+      sourceSessionId: 'artifact-session-1',
+      sessionId: 'session-1',
+      runId: 'run-1',
+      messageId: 'message-1'
+    })
+
+    await expect(
+      repository.findRunFinalizationMarker('default-project', 'run-1')
+    ).resolves.toMatchObject({
+      sourceSessionId: 'artifact-session-1',
+      sessionId: 'session-1',
+      messageId: 'message-1',
+      provenanceContext,
+      artifactVersionIds: ['version-1', 'version-2']
+    })
+    await expect(
+      repository.prepareRunFinalization({
+        projectName: 'default-project',
+        sourceSessionId: 'artifact-session-1',
+        sessionId: 'session-1',
+        runId: 'run-1',
+        artifactVersionIds: ['version-2', 'version-1'],
+        provenanceContext
+      })
+    ).resolves.toBeUndefined()
+    await expect(
+      repository.finalizeRunArtifacts({
+        projectName: 'default-project',
+        sourceSessionId: 'artifact-session-1',
+        sessionId: 'session-1',
+        runId: 'run-1',
+        messageId: 'message-1',
+        artifactVersionIds: ['version-1']
+      })
+    ).rejects.toThrow(/Version ids conflict/i)
+    await expect(
+      repository.prepareRunFinalization({
+        projectName: 'default-project',
+        sourceSessionId: 'artifact-session-1',
+        sessionId: 'session-1',
+        runId: 'run-1',
+        artifactVersionIds: ['version-1', 'version-2'],
+        provenanceContext: { ...provenanceContext, messageBranchId: 'branch-other' }
+      })
+    ).rejects.toThrow(/context conflicts/i)
+  })
+
+  it('discovers an unmarked pending publication as ownerless', async () => {
+    const root = await createStorageRoot()
+    const repository = new ArtifactRepository(root)
+    await repository.writePendingFile({
+      projectName: 'default-project',
+      sessionId: 'storage-session-1',
+      runId: 'run-ownerless',
+      filename: 'draft.txt',
+      source: createInlineSource('draft')
+    })
+    await mkdir(
+      join(
+        root,
+        'artifacts',
+        'default-project',
+        'storage-session-1',
+        '.pending',
+        'run-empty',
+        '.metadata'
+      ),
+      { recursive: true }
+    )
+    const handoff = getArtifactCurrentRunFilePath(root, 'default-project', 'storage-session-1')
+    await writeFile(handoff, JSON.stringify({ runId: 'run-ownerless' }), 'utf8')
+
+    await expect(repository.listPendingRunPublications('default-project')).resolves.toEqual([
+      {
+        sourceSessionId: 'storage-session-1',
+        runId: 'run-ownerless'
+      }
+    ])
+  })
+
+  it('discovers a pending publication whose byte moved before its metadata sidecar', async () => {
+    const root = await createStorageRoot()
+    const repository = new ArtifactRepository(root)
+    const pending = await repository.writePendingFile({
+      projectName: 'default-project',
+      sessionId: 'storage-session-1',
+      runId: 'run-metadata-only',
+      filename: 'result.txt',
+      mimeType: 'text/plain',
+      source: createInlineSource('result')
+    })
+    await rm(pending.path)
+
+    await expect(repository.listPendingRunPublications('default-project')).resolves.toEqual([
+      {
+        sourceSessionId: 'storage-session-1',
+        runId: 'run-metadata-only'
+      }
+    ])
+  })
+
+  it('marks a corrupt pending publication marker as an incomplete scan', async () => {
+    const root = await createStorageRoot()
+    const repository = new ArtifactRepository(root)
+    await repository.writePendingFile({
+      projectName: 'default-project',
+      sessionId: 'storage-session-1',
+      runId: 'run-corrupt',
+      filename: 'result.txt',
+      source: createInlineSource('result')
+    })
+    const markerPath = join(
+      root,
+      'artifacts',
+      'default-project',
+      'storage-session-1',
+      '.runs',
+      'run-corrupt.json'
+    )
+    await mkdir(dirname(markerPath), { recursive: true })
+    await writeFile(markerPath, '{not-json', 'utf8')
+
+    await expect(repository.listPendingRunPublications('default-project')).rejects.toBeInstanceOf(
+      ArtifactCompatibilityScanIncompleteError
+    )
+  })
+
+  it('marks duplicate project-scoped pending run ids as an incomplete scan', async () => {
+    const root = await createStorageRoot()
+    const repository = new ArtifactRepository(root)
+    for (const sessionId of ['storage-session-1', 'storage-session-2']) {
+      await repository.writePendingFile({
+        projectName: 'default-project',
+        sessionId,
+        runId: 'run-duplicate',
+        filename: 'result.txt',
+        source: createInlineSource(sessionId)
+      })
+    }
+
+    await expect(repository.listPendingRunPublications('default-project')).rejects.toBeInstanceOf(
+      ArtifactCompatibilityScanIncompleteError
+    )
+  })
+
+  it('marks pending publication marker I/O failure as an incomplete scan', async () => {
+    const root = await createStorageRoot()
+    let failMarkerRead = false
+    const repository = new ArtifactRepository(root, {
+      syncFile: async () => undefined,
+      syncDirectory: async () => undefined,
+      readMarkerFile: async (path) => {
+        if (failMarkerRead && path.endsWith('run-io.json')) {
+          throw Object.assign(new Error('marker read failed'), { code: 'EIO' })
+        }
+        return readFile(path, 'utf8')
+      }
+    })
+    await repository.writePendingFile({
+      projectName: 'default-project',
+      sessionId: 'storage-session-1',
+      runId: 'run-io',
+      filename: 'result.txt',
+      source: createInlineSource('result')
+    })
+    await repository.prepareRunFinalization({
+      projectName: 'default-project',
+      sourceSessionId: 'storage-session-1',
+      sessionId: 'session-1',
+      runId: 'run-io',
+      artifactVersionIds: ['version-1'],
+      provenanceContext: {
+        rootFrameId: 'root-frame-1',
+        agentFrameId: 'agent-frame-1',
+        messageBranchId: 'branch-1',
+        runtimeSegmentId: 'runtime-segment-1',
+        promptMessageId: 'prompt-1'
+      }
+    })
+    failMarkerRead = true
+
+    await expect(repository.listPendingRunPublications('default-project')).rejects.toBeInstanceOf(
+      ArtifactCompatibilityScanIncompleteError
+    )
   })
 
   it('does not move files until the durable run marker directory barrier succeeds', async () => {

--- a/src/main/artifacts/repository.ts
+++ b/src/main/artifacts/repository.ts
@@ -38,7 +38,7 @@ const log = createLogger('artifacts:repository')
 const ARTIFACTS_DIR = 'artifacts'
 const PENDING_DIR = '.pending'
 const METADATA_DIR = '.metadata'
-// Per-run markers recording which app session + message a finalized run moved into, keyed by run id.
+// Per-run publication markers: prepared ownership context, later upgraded with the final message id.
 const RUNS_DIR = '.runs'
 // Handoff file (directly under a session's .pending) naming the in-flight turn's run id for MCP writes.
 const CURRENT_RUN_FILE = 'current-run.json'
@@ -74,10 +74,26 @@ export class ArtifactCompatibilityScanIncompleteError extends Error {
   }
 }
 
-type ArtifactRunFinalizationMarker = {
+export type ArtifactRunFinalizationMarker = {
   sessionId: string
-  messageId: string
+  messageId?: string
+  artifactVersionIds?: string[]
   provenanceContext?: NonNullable<MovePendingRunArtifactsRequest['provenanceContext']>
+}
+
+export type PendingArtifactRunPublication = {
+  sourceSessionId: string
+  runId: string
+  marker?: ArtifactRunFinalizationMarker
+}
+
+type PrepareArtifactRunFinalizationRequest = {
+  projectName: string
+  sourceSessionId: string
+  sessionId: string
+  runId: string
+  artifactVersionIds?: string[]
+  provenanceContext: NonNullable<MovePendingRunArtifactsRequest['provenanceContext']>
 }
 
 type ArtifactRepositoryWriteOptions = {
@@ -106,6 +122,10 @@ type BindPendingArtifactVersionRouting = (
   sourcePath: string
 ) => Promise<void>
 
+type ArtifactRepositoryStorage = ArtifactRepositoryDurability & {
+  readMarkerFile?: (path: string) => Promise<string>
+}
+
 export type { ArtifactRepositoryDurability }
 
 const defaultArtifactRepositoryDurability = defaultArtifactDurability
@@ -121,6 +141,19 @@ const assertSafePathSegment = (segment: string): string => {
   }
 
   return segment
+}
+
+const normalizeArtifactVersionIds = (versionIds: readonly string[]): string[] => {
+  if (!Array.isArray(versionIds) || versionIds.length === 0) {
+    throw new Error('Artifact run marker requires Artifact Version ids.')
+  }
+  const normalized = versionIds
+    .map(assertSafePathSegment)
+    .sort((left, right) => left.localeCompare(right))
+  if (new Set(normalized).size !== normalized.length) {
+    throw new Error('Artifact run marker Artifact Version ids must be unique.')
+  }
+  return normalized
 }
 
 // Allows display-friendly filenames while rejecting separators, reserved metadata names, and shell-hostile input.
@@ -294,7 +327,7 @@ class ArtifactRepository {
 
   constructor(
     private readonly storageRoot: string,
-    private readonly durability: ArtifactRepositoryDurability = defaultArtifactRepositoryDurability
+    private readonly durability: ArtifactRepositoryStorage = defaultArtifactRepositoryDurability
   ) {}
 
   // Writes a generated file into the run's pending directory before it is attached to a message.
@@ -686,6 +719,9 @@ class ArtifactRepository {
     const sourceSessionId = assertSafePathSegment(request.sourceSessionId ?? request.sessionId)
     const runId = assertSafePathSegment(request.runId)
     const messageId = assertSafePathSegment(request.messageId)
+    const artifactVersionIds = request.artifactVersionIds
+      ? normalizeArtifactVersionIds(request.artifactVersionIds)
+      : undefined
     const pendingDir = this.getPendingRunDir(projectName, sourceSessionId, runId)
     const messageDir = this.getMessageDir(projectName, sessionId, messageId)
     const entries = await this.readFileEntries(pendingDir)
@@ -695,6 +731,7 @@ class ArtifactRepository {
     await this.writeRunMarker(projectName, sourceSessionId, runId, {
       sessionId,
       messageId,
+      ...(artifactVersionIds ? { artifactVersionIds } : {}),
       ...(request.provenanceContext ? { provenanceContext: request.provenanceContext } : {})
     })
 
@@ -716,6 +753,33 @@ class ArtifactRepository {
     await rm(pendingDir, { recursive: true, force: true })
 
     return this.listMessageFiles({ projectName, sessionId, messageId })
+  }
+
+  // Durably records that the runtime has ended this turn and chosen to publish its run. The renderer
+  // does not know the terminal message id yet, so finalization later upgrades this intent in place.
+  // Publishing the intent before the event closes the process-crash gap without treating every pending
+  // write (including a mid-turn crash) as a completed handoff.
+  async prepareRunFinalization(request: PrepareArtifactRunFinalizationRequest): Promise<void> {
+    const projectName = assertSafePathSegment(request.projectName)
+    const sourceSessionId = assertSafePathSegment(request.sourceSessionId)
+    const sessionId = assertSafePathSegment(request.sessionId)
+    const runId = assertSafePathSegment(request.runId)
+    const artifactVersionIds = request.artifactVersionIds
+      ? normalizeArtifactVersionIds(request.artifactVersionIds)
+      : undefined
+    const provenanceContext = {
+      rootFrameId: assertSafePathSegment(request.provenanceContext.rootFrameId),
+      agentFrameId: assertSafePathSegment(request.provenanceContext.agentFrameId),
+      messageBranchId: assertSafePathSegment(request.provenanceContext.messageBranchId),
+      runtimeSegmentId: assertSafePathSegment(request.provenanceContext.runtimeSegmentId),
+      promptMessageId: assertSafePathSegment(request.provenanceContext.promptMessageId)
+    }
+
+    await this.writeRunMarker(projectName, sourceSessionId, runId, {
+      sessionId,
+      ...(artifactVersionIds ? { artifactVersionIds } : {}),
+      provenanceContext
+    })
   }
 
   // Lists files that have been written by the agent but not yet owned by a renderer message.
@@ -897,6 +961,57 @@ class ArtifactRepository {
     return files
   }
 
+  // Discovers only compatibility publications that still have direct artifact bytes or metadata
+  // sidecars under a run's `.pending` directory. A byte can already be in its message directory when
+  // a crash leaves its sidecar behind. The project scan establishes the unique source Session once,
+  // so recovery does not rescan every Session for every run. Missing markers remain ownerless;
+  // corrupt, duplicate, or unreadable publication state makes the scan incomplete instead of guessing.
+  async listPendingRunPublications(
+    projectNameValue: string
+  ): Promise<PendingArtifactRunPublication[]> {
+    const projectName = assertSafePathSegment(projectNameValue)
+    const projectDirectory = getProjectArtifactDir(this.storageRoot, projectName)
+    const publications: PendingArtifactRunPublication[] = []
+    const observedRunIds = new Set<string>()
+
+    try {
+      for (const sourceSessionId of await this.readSubdirectoryNames(projectDirectory)) {
+        if (!SAFE_SEGMENT_PATTERN.test(sourceSessionId)) continue
+        const pendingDirectory = join(projectDirectory, sourceSessionId, PENDING_DIR)
+        for (const runId of await this.readSubdirectoryNames(pendingDirectory)) {
+          if (!SAFE_SEGMENT_PATTERN.test(runId)) continue
+          const runDirectory = join(pendingDirectory, runId)
+          const files = await this.readFileEntries(runDirectory)
+          const metadataFiles =
+            files.length === 0 ? await this.readFileEntries(join(runDirectory, METADATA_DIR)) : []
+          if (files.length === 0 && metadataFiles.length === 0) continue
+          if (observedRunIds.has(runId)) {
+            throw new Error(
+              `Artifact pending publication run is ambiguous across compatibility storage: ${runId}`
+            )
+          }
+          observedRunIds.add(runId)
+
+          const markerResult = await this.readRunMarker(
+            this.getRunMarkerPath(projectName, sourceSessionId, runId)
+          )
+          if (markerResult.present && !markerResult.marker) {
+            throw new Error(`Artifact pending publication marker is corrupt: ${runId}`)
+          }
+          publications.push({
+            sourceSessionId,
+            runId,
+            ...(markerResult.marker ? { marker: markerResult.marker } : {})
+          })
+        }
+      }
+    } catch (error) {
+      throw new ArtifactCompatibilityScanIncompleteError(error)
+    }
+
+    return publications
+  }
+
   // Resolves a renderer-provided artifact path only after canonical root and symlink checks pass.
   async resolveManagedFilePath(request: OpenArtifactFileRequest): Promise<string> {
     if (
@@ -992,6 +1107,11 @@ class ArtifactRepository {
         log.warn('artifact recovery skipped: run marker present but unreadable', { requestedPath })
         return undefined
       }
+      if (!markerResult.marker.messageId) {
+        // A prepared run has not been bound to a durable message yet. Only Provenance startup recovery
+        // may infer that owner from the conversation graph; path recovery must never guess it.
+        return undefined
+      }
       const projectDir = dirname(sourceSessionDir)
       const candidate = join(
         projectDir,
@@ -1033,8 +1153,9 @@ class ArtifactRepository {
     )
   }
 
-  // Locates the single durable finalization marker for a run across compatibility storage Sessions.
-  // ArtifactRun ids are process-generated and project-scoped; duplicate/corrupt markers fail closed.
+  // Locates the single durable publication marker for a run across compatibility storage Sessions.
+  // It may be prepared (context only) or finalized (message-bound). ArtifactRun ids are process-
+  // generated and project-scoped; duplicate/corrupt markers fail closed.
   async findRunFinalizationMarker(
     projectNameValue: string,
     runIdValue: string
@@ -1059,10 +1180,10 @@ class ArtifactRepository {
     return matches.length === 1 ? matches[0] : undefined
   }
 
-  // Persists the app session + message a run finalized into. Written atomically (temp + rename) so a
-  // crash mid-write never leaves a half-written marker that would later read as corrupt. Publication is
-  // part of finalization: if it fails, no file move begins, preserving a retryable pending run rather
-  // than creating an unprovable compatibility/provenance split-brain.
+  // Persists a prepared run intent or its later app-session/message binding. Written atomically (temp +
+  // rename) so a crash mid-write never leaves a half-written marker that would later read as corrupt.
+  // If a finalize upgrade fails, no file move begins, preserving a retryable pending run rather than
+  // creating an unprovable compatibility/provenance split-brain.
   private async writeRunMarker(
     projectName: string,
     sourceSessionId: string,
@@ -1071,6 +1192,7 @@ class ArtifactRepository {
   ): Promise<void> {
     const markerPath = this.getRunMarkerPath(projectName, sourceSessionId, runId)
     const temporaryPath = `${markerPath}.${Date.now()}-${randomUUID()}.tmp`
+    let markerToWrite = marker
     try {
       const markerDirectory = dirname(markerPath)
       await mkdir(markerDirectory, { recursive: true })
@@ -1080,14 +1202,19 @@ class ArtifactRepository {
       const existing = await this.readRunMarker(markerPath)
       if (existing.present) {
         if (!existing.marker) throw new Error('Existing Artifact run marker is corrupt.')
+        if (existing.marker.sessionId !== marker.sessionId) {
+          throw new Error('Artifact run marker is already owned by a different message.')
+        }
         if (
-          existing.marker.sessionId !== marker.sessionId ||
+          existing.marker.messageId &&
+          marker.messageId &&
           existing.marker.messageId !== marker.messageId
         ) {
           throw new Error('Artifact run marker is already owned by a different message.')
         }
         if (
           existing.marker.provenanceContext &&
+          marker.provenanceContext &&
           JSON.stringify(existing.marker.provenanceContext) !==
             JSON.stringify(marker.provenanceContext)
         ) {
@@ -1095,15 +1222,39 @@ class ArtifactRepository {
             'Artifact run marker Provenance context conflicts with an existing commit.'
           )
         }
-        // Exact replay is already durable. A legacy context-free marker for the same owner is upgraded
-        // below so future startup recovery can prove the cross-store commit.
-        if (existing.marker.provenanceContext || !marker.provenanceContext) {
+        if (
+          existing.marker.artifactVersionIds &&
+          marker.artifactVersionIds &&
+          JSON.stringify(existing.marker.artifactVersionIds) !==
+            JSON.stringify(marker.artifactVersionIds)
+        ) {
+          throw new Error('Artifact run marker Version ids conflict with an existing commit.')
+        }
+        // Merge upgrades in either order so a generic pending-path replay retains the prepared context,
+        // while a late prepare replay can never erase an already-bound message id.
+        markerToWrite = {
+          sessionId: marker.sessionId,
+          ...(marker.messageId || existing.marker.messageId
+            ? { messageId: marker.messageId ?? existing.marker.messageId }
+            : {}),
+          ...(marker.provenanceContext || existing.marker.provenanceContext
+            ? {
+                provenanceContext: marker.provenanceContext ?? existing.marker.provenanceContext
+              }
+            : {}),
+          ...(marker.artifactVersionIds || existing.marker.artifactVersionIds
+            ? {
+                artifactVersionIds: marker.artifactVersionIds ?? existing.marker.artifactVersionIds
+              }
+            : {})
+        }
+        if (JSON.stringify(existing.marker) === JSON.stringify(markerToWrite)) {
           await this.durability.syncFile(markerPath)
           await this.durability.syncDirectory(markerDirectory)
           return
         }
       }
-      await writeFile(temporaryPath, `${JSON.stringify(marker)}\n`, 'utf8')
+      await writeFile(temporaryPath, `${JSON.stringify(markerToWrite)}\n`, 'utf8')
       await this.durability.syncFile(temporaryPath)
       await rename(temporaryPath, markerPath)
       await this.durability.syncDirectory(markerDirectory)
@@ -1115,20 +1266,20 @@ class ArtifactRepository {
 
   // Reads a run marker, distinguishing three states so recovery can act safely:
   //   { present: false }            — no marker file (legacy artifact, or a marker write that failed).
-  //   { present: true }             — a marker file exists but is unreadable/corrupt/invalid.
-  //   { present: true, marker }     — a valid marker pinning the run's app session + message.
-  // The present-but-invalid case must NOT fall back to a same-name scan: the run WAS marked, so a
-  // damaged marker means "cannot resolve", not "guess among other runs' files".
+  //   { present: true }             — marker contents are corrupt or invalid.
+  //   { present: true, marker }     — a valid prepared or message-bound marker.
+  // Storage I/O failures propagate so startup can mark reconciliation incomplete; only ENOENT is absent.
   private async readRunMarker(
     markerPath: string
   ): Promise<{ present: boolean; marker?: ArtifactRunFinalizationMarker }> {
     let raw: string
     try {
-      raw = await readFile(markerPath, 'utf8')
+      raw = this.durability.readMarkerFile
+        ? await this.durability.readMarkerFile(markerPath)
+        : await readFile(markerPath, 'utf8')
     } catch (error) {
       if (isMissingFileError(error)) return { present: false }
-      // Present but unreadable (e.g. permissions): treat as a damaged marker, not absent.
-      return { present: true }
+      throw error
     }
 
     try {
@@ -1136,16 +1287,35 @@ class ArtifactRepository {
       if (
         typeof parsed === 'object' &&
         parsed !== null &&
-        typeof (parsed as { sessionId?: unknown }).sessionId === 'string' &&
-        typeof (parsed as { messageId?: unknown }).messageId === 'string'
+        typeof (parsed as { sessionId?: unknown }).sessionId === 'string'
       ) {
-        const { sessionId, messageId, provenanceContext } = parsed as {
+        const { sessionId, messageId, artifactVersionIds, provenanceContext } = parsed as {
           sessionId: string
-          messageId: string
-          provenanceContext?: Record<string, unknown>
+          messageId?: unknown
+          artifactVersionIds?: unknown
+          provenanceContext?: unknown
         }
-        if (SAFE_SEGMENT_PATTERN.test(sessionId) && SAFE_SEGMENT_PATTERN.test(messageId)) {
-          if (provenanceContext) {
+        if (
+          SAFE_SEGMENT_PATTERN.test(sessionId) &&
+          (messageId === undefined ||
+            (typeof messageId === 'string' && SAFE_SEGMENT_PATTERN.test(messageId)))
+        ) {
+          let normalizedArtifactVersionIds: string[] | undefined
+          if (artifactVersionIds !== undefined) {
+            if (!Array.isArray(artifactVersionIds)) return { present: true }
+            try {
+              normalizedArtifactVersionIds = normalizeArtifactVersionIds(
+                artifactVersionIds as string[]
+              )
+            } catch {
+              return { present: true }
+            }
+          }
+          if (
+            typeof provenanceContext === 'object' &&
+            provenanceContext !== null &&
+            !Array.isArray(provenanceContext)
+          ) {
             const keys = [
               'rootFrameId',
               'agentFrameId',
@@ -1156,8 +1326,10 @@ class ArtifactRepository {
             if (
               keys.some(
                 (key) =>
-                  typeof provenanceContext[key] !== 'string' ||
-                  !SAFE_SEGMENT_PATTERN.test(provenanceContext[key] as string)
+                  typeof (provenanceContext as Record<string, unknown>)[key] !== 'string' ||
+                  !SAFE_SEGMENT_PATTERN.test(
+                    (provenanceContext as Record<string, unknown>)[key] as string
+                  )
               )
             ) {
               return { present: true }
@@ -1166,14 +1338,28 @@ class ArtifactRepository {
               present: true,
               marker: {
                 sessionId,
-                messageId,
+                ...(typeof messageId === 'string' ? { messageId } : {}),
+                ...(normalizedArtifactVersionIds
+                  ? { artifactVersionIds: normalizedArtifactVersionIds }
+                  : {}),
                 provenanceContext: Object.fromEntries(
-                  keys.map((key) => [key, provenanceContext[key]])
+                  keys.map((key) => [key, (provenanceContext as Record<string, unknown>)[key]])
                 ) as ArtifactRunFinalizationMarker['provenanceContext']
               }
             }
           }
-          return { present: true, marker: { sessionId, messageId } }
+          if (typeof messageId === 'string' && provenanceContext === undefined) {
+            return {
+              present: true,
+              marker: {
+                sessionId,
+                messageId,
+                ...(normalizedArtifactVersionIds
+                  ? { artifactVersionIds: normalizedArtifactVersionIds }
+                  : {})
+              }
+            }
+          }
         }
       }
       return { present: true }

--- a/src/main/artifacts/run-registry.ts
+++ b/src/main/artifacts/run-registry.ts
@@ -4,6 +4,7 @@ type ArtifactRunClaim = {
   artifactSessionId: string
   sessionId: string
   runId: string
+  artifactVersionIds?: string[]
   rootFrameId?: string
   agentFrameId?: string
   messageBranchId?: string
@@ -19,6 +20,7 @@ type RegisterArtifactRunClaimRequest = {
   artifactSessionId: string
   sessionId: string
   runId: string
+  artifactVersionIds?: string[]
   rootFrameId?: string
   agentFrameId?: string
   messageBranchId?: string
@@ -40,7 +42,8 @@ class ArtifactRunRegistry {
 
     this.claims.set(claimId, {
       claimId,
-      ...request
+      ...request,
+      artifactVersionIds: request.artifactVersionIds ? [...request.artifactVersionIds] : undefined
     })
 
     return claimId

--- a/src/main/notebook/local-rpc-server.test.ts
+++ b/src/main/notebook/local-rpc-server.test.ts
@@ -23,6 +23,17 @@ const createStorageRoot = async (): Promise<string> => {
   return storageRoot
 }
 
+const createDeferred = <Value = void>(): {
+  promise: Promise<Value>
+  resolve: (value: Value) => void
+} => {
+  let resolve!: (value: Value) => void
+  const promise = new Promise<Value>((promiseResolve) => {
+    resolve = promiseResolve
+  })
+  return { promise, resolve }
+}
+
 const registeredInput = {
   inputFileVersionId: 'upload-version-1',
   sourceKind: 'upload-version' as const,
@@ -326,6 +337,98 @@ describe('notebook local RPC server', () => {
         }
       ])
     } finally {
+      await server.close()
+    }
+  })
+
+  it('revokes new Artifact requests while draining one already-authorized write', async () => {
+    const root = await createStorageRoot()
+    const service = new NotebookRuntimeService({
+      configRoot: root,
+      dataRoot: root,
+      projectName: 'default-project',
+      repository: new NotebookRunRepository(root)
+    })
+    const createStarted = createDeferred()
+    const releaseCreate = createDeferred()
+    let now = 1_000
+    const server = new NotebookLocalRpcServer(service, {
+      token: 'secret-token',
+      now: () => now,
+      artifactProvenance: {
+        createVersion: async () => {
+          createStarted.resolve()
+          await releaseCreate.promise
+          return {
+            id: 'version-1',
+            artifactId: 'artifact-1',
+            versionId: 'version-1',
+            versionNumber: 1,
+            checksum: 'a'.repeat(64),
+            createdAt: '2026-07-27T00:00:00.000Z',
+            projectName: 'project-1',
+            sessionId: 'session-1',
+            runId: 'artifact-run-1',
+            name: 'sin.png',
+            path: '/managed/content',
+            fileUrl: 'file:///managed/content',
+            mimeType: 'image/png',
+            size: 12,
+            mtimeMs: 1
+          }
+        }
+      }
+    })
+    const connection = await server.ensureStarted()
+    const token = server.issueArtifactRunCapability(artifactCapabilityBinding, 100)
+    const call = (): Promise<Response> =>
+      fetch(connection.endpoint, {
+        method: 'POST',
+        headers: {
+          authorization: `Bearer ${token}`,
+          'content-type': 'application/json'
+        },
+        body: JSON.stringify({
+          method: 'artifactCreateVersion',
+          params: {
+            ...artifactCapabilityBinding,
+            writeOperationId: 'write-drain',
+            writeRequestChecksum: 'a'.repeat(64),
+            filename: 'sin.png'
+          }
+        })
+      })
+
+    try {
+      const acceptedRequest = call()
+      await createStarted.promise
+      now = 1_101
+      const expiredRequest = await call()
+      expect(expiredRequest.status).toBe(401)
+      await expect(expiredRequest.json()).resolves.toEqual({
+        error: 'Artifact RPC capability expired.'
+      })
+
+      let drained = false
+      const firstDrain = Promise.resolve(server.revokeArtifactRunCapability(token)).then(() => {
+        drained = true
+      })
+      const repeatedDrain = Promise.resolve(server.revokeArtifactRunCapability(token))
+      await Promise.resolve()
+      expect(drained).toBe(false)
+
+      const rejectedRequest = await call()
+      expect(rejectedRequest.status).toBe(401)
+
+      releaseCreate.resolve()
+      await expect(acceptedRequest.then((response) => response.status)).resolves.toBe(200)
+      await expect(Promise.all([firstDrain, repeatedDrain])).resolves.toEqual([
+        undefined,
+        undefined
+      ])
+      expect(drained).toBe(true)
+    } finally {
+      releaseCreate.resolve()
       await server.close()
     }
   })

--- a/src/main/notebook/local-rpc-server.ts
+++ b/src/main/notebook/local-rpc-server.ts
@@ -107,6 +107,8 @@ type NotebookRpcPayload = {
 type ArtifactRpcCapability = Omit<ArtifactRpcCapabilityBinding, 'allowedMethods'> & {
   allowedMethods: Set<ArtifactRpcMethod>
   expiresAt: number
+  inFlightRequests: number
+  drainWaiters: Set<() => void>
 }
 
 class RpcHttpError extends Error {
@@ -176,6 +178,7 @@ class NotebookLocalRpcServer {
   private readonly activeInputRunLeases = new Map<string, Set<NotebookInputRunLease>>()
   private readonly inputRunLeaseIds = new WeakMap<NotebookInputRunLease, string>()
   private readonly artifactRpcCapabilities = new Map<string, ArtifactRpcCapability>()
+  private readonly drainingArtifactRpcCapabilities = new Map<string, Promise<void>>()
 
   constructor(
     private readonly service: NotebookRuntimeService,
@@ -208,13 +211,31 @@ class NotebookLocalRpcServer {
       allowedMethods: new Set(
         binding.allowedMethods ?? ['artifactCreateVersion', 'artifactReplayVersion']
       ),
-      expiresAt: this.now() + ttlMs
+      expiresAt: this.now() + ttlMs,
+      inFlightRequests: 0,
+      drainWaiters: new Set()
     })
     return token
   }
 
-  revokeArtifactRunCapability(token: string): void {
+  revokeArtifactRunCapability(token: string): Promise<void> {
+    const draining = this.drainingArtifactRpcCapabilities.get(token)
+    if (draining) return draining
+
+    const capability = this.artifactRpcCapabilities.get(token)
     this.artifactRpcCapabilities.delete(token)
+    if (!capability || capability.inFlightRequests === 0) return Promise.resolve()
+
+    const drain = new Promise<void>((resolve) => {
+      capability.drainWaiters.add(resolve)
+    })
+    this.drainingArtifactRpcCapabilities.set(token, drain)
+    void drain.then(() => {
+      if (this.drainingArtifactRpcCapabilities.get(token) === drain) {
+        this.drainingArtifactRpcCapabilities.delete(token)
+      }
+    })
+    return drain
   }
 
   // Starts the server once on an ephemeral port and returns the connection details for MCP env.
@@ -289,15 +310,17 @@ class NotebookLocalRpcServer {
     this.activeTurnProjectIds.set(request.appSessionId, request.projectId)
   }
 
-  private bindArtifactRpcParams(
+  private acquireArtifactRpcRequest(
     method: ArtifactRpcMethod,
     token: string,
     params: Record<string, unknown>
-  ): Record<string, unknown> {
+  ): { params: Record<string, unknown>; release: () => void } {
     const capability = this.artifactRpcCapabilities.get(token)
     if (!capability) throw new RpcHttpError(401, 'Invalid Artifact RPC capability.')
     if (capability.expiresAt <= this.now()) {
-      this.artifactRpcCapabilities.delete(token)
+      // Expiry closes admission just like an explicit runtime revoke. Keep the shared drain promise
+      // reachable so a later turn teardown still waits for requests that acquired before expiry.
+      void this.revokeArtifactRunCapability(token)
       throw new RpcHttpError(401, 'Artifact RPC capability expired.')
     }
     if (!capability.allowedMethods.has(method)) {
@@ -325,14 +348,14 @@ class NotebookLocalRpcServer {
       }
     }
 
-    const trustedParams = { ...params }
-    delete trustedParams.messageBranchAncestry
-    delete trustedParams.messageAncestry
-    delete trustedParams.agentName
-    delete trustedParams.notebookSessionId
+    const sanitizedParams = { ...params }
+    delete sanitizedParams.messageBranchAncestry
+    delete sanitizedParams.messageAncestry
+    delete sanitizedParams.agentName
+    delete sanitizedParams.notebookSessionId
 
-    return {
-      ...trustedParams,
+    const trustedParams = {
+      ...sanitizedParams,
       projectId: capability.projectId,
       appSessionId: capability.appSessionId,
       artifactStorageSessionId: capability.artifactStorageSessionId,
@@ -355,6 +378,20 @@ class NotebookLocalRpcServer {
           }
         : {})
     }
+    capability.inFlightRequests += 1
+    let released = false
+    return {
+      params: trustedParams,
+      release: () => {
+        if (released) return
+        released = true
+        capability.inFlightRequests -= 1
+        if (capability.inFlightRequests === 0) {
+          for (const resolve of capability.drainWaiters) resolve()
+          capability.drainWaiters.clear()
+        }
+      }
+    }
   }
 
   // Authenticates one HTTP request, dispatches it, and serializes either result or error.
@@ -364,6 +401,7 @@ class NotebookLocalRpcServer {
       return
     }
 
+    let releaseArtifactRequest: (() => void) | undefined
     try {
       const payload = await readJsonBody(request)
       const method = typeof payload.method === 'string' ? payload.method : ''
@@ -373,7 +411,9 @@ class NotebookLocalRpcServer {
         ? authorization.slice('Bearer '.length)
         : ''
       if (isArtifactRpcMethod(method)) {
-        params = this.bindArtifactRpcParams(method, bearerToken, params)
+        const acquired = this.acquireArtifactRpcRequest(method, bearerToken, params)
+        params = acquired.params
+        releaseArtifactRequest = acquired.release
       } else if (authorization !== `Bearer ${this.token}`) {
         throw new RpcHttpError(401, 'Invalid notebook RPC token.')
       }
@@ -387,6 +427,8 @@ class NotebookLocalRpcServer {
       writeJson(response, error instanceof RpcHttpError ? error.statusCode : 500, {
         error: message
       })
+    } finally {
+      releaseArtifactRequest?.()
     }
   }
 

--- a/src/main/session-persistence/artifact-finalization-recovery.integration.test.ts
+++ b/src/main/session-persistence/artifact-finalization-recovery.integration.test.ts
@@ -1,0 +1,805 @@
+import { mkdir, mkdtemp, readFile, rename, rm, writeFile } from 'node:fs/promises'
+import { createHash } from 'node:crypto'
+import { tmpdir } from 'node:os'
+import { dirname, join } from 'node:path'
+
+import type { PrismaClient } from '@prisma/client'
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest'
+
+vi.mock('electron', () => ({
+  app: { getPath: () => '/home/user', isPackaged: true }
+}))
+
+import { createLinearConversationGraph } from '../../shared/conversation-graph'
+import type { PersistedChatSession } from '../../shared/session-persistence'
+import { createPngInlineSource } from '../artifacts/artifact-test-fixtures'
+import { ProvenanceMessageSnapshotRepository } from '../artifacts/provenance-message-snapshot'
+import { ArtifactProvenanceRepository } from '../artifacts/provenance-repository'
+import { ArtifactRepository } from '../artifacts/repository'
+import { ManagedFileIndexRepository } from '../project-files/repository'
+import { createProjectDbClient, ensureProjectSchema } from '../projects/prisma-client'
+import { SessionPersistenceCoordinator } from './coordinator'
+import { SessionRepository } from './repository'
+
+const PROJECT_ID = 'project-1'
+const SESSION_ID = 'session-1'
+const STORAGE_SESSION_ID = 'artifact-session-1'
+const RUN_ID = 'artifact-run-1'
+
+describe('artifact finalization startup recovery', () => {
+  let storageRoot: string
+  let client: PrismaClient
+  let sessions: SessionRepository
+  let files: ManagedFileIndexRepository
+
+  beforeEach(async () => {
+    storageRoot = await mkdtemp(join(tmpdir(), 'open-science-artifact-finalization-recovery-'))
+    client = createProjectDbClient(storageRoot)
+    await ensureProjectSchema(client)
+    sessions = new SessionRepository(storageRoot)
+    files = new ManagedFileIndexRepository(() => Promise.resolve(client), storageRoot)
+  })
+
+  afterEach(async () => {
+    await client.$disconnect()
+    await rm(storageRoot, { recursive: true, force: true })
+  })
+
+  it('persists an inspectable Message snapshot with the recovered Session attachment', async () => {
+    const compatibility = new ArtifactRepository(storageRoot)
+    const { provenance, version } = await prepareRecovery(compatibility)
+    const snapshots = new ProvenanceMessageSnapshotRepository({
+      storageRoot,
+      getClient: () => Promise.resolve(client)
+    })
+    const coordinator = new SessionPersistenceCoordinator(
+      sessions,
+      files,
+      undefined,
+      snapshots,
+      undefined,
+      provenance
+    )
+
+    const loaded = await coordinator.loadAll()
+
+    expect(loaded.sessions[0].messages[1].artifactIds).toEqual([version.versionId])
+    await expect(sessions.loadSession(PROJECT_ID, SESSION_ID)).resolves.toMatchObject({
+      messages: [expect.anything(), { artifactIds: [version.versionId] }],
+      artifacts: [expect.objectContaining({ id: version.versionId })]
+    })
+    await expect(
+      client.artifactVersion.findUniqueOrThrow({ where: { id: version.versionId } })
+    ).resolves.toMatchObject({ messageSnapshotId: expect.any(String) })
+    await expect(
+      provenance.getVersionMessages({
+        projectId: PROJECT_ID,
+        appSessionId: SESSION_ID,
+        artifactId: version.artifactId,
+        versionId: version.versionId
+      })
+    ).resolves.toMatchObject({
+      messages: {
+        state: 'available',
+        items: expect.arrayContaining([expect.objectContaining({ id: 'message-1' })])
+      }
+    })
+  })
+
+  it('moves pending compatibility bytes when a bound marker survived without its file move', async () => {
+    const compatibility = new ArtifactRepository(storageRoot)
+    const { provenance, context, version } = await prepareRecovery(compatibility)
+    // Legacy markers from before exact-set publication remain recoverable from the whole DB run.
+    await writeFile(
+      join(storageRoot, 'artifacts', PROJECT_ID, STORAGE_SESSION_ID, '.runs', `${RUN_ID}.json`),
+      `${JSON.stringify({ sessionId: SESSION_ID, messageId: 'message-1', provenanceContext: context })}\n`,
+      'utf8'
+    )
+    const coordinator = new SessionPersistenceCoordinator(
+      sessions,
+      files,
+      undefined,
+      undefined,
+      undefined,
+      provenance
+    )
+
+    await coordinator.loadAll()
+
+    await expect(
+      compatibility.listPendingRunFiles({
+        projectName: PROJECT_ID,
+        sessionId: STORAGE_SESSION_ID,
+        runId: RUN_ID
+      })
+    ).resolves.toEqual([])
+    await expect(
+      compatibility.listMessageFiles({
+        projectName: PROJECT_ID,
+        sessionId: SESSION_ID,
+        messageId: 'message-1'
+      })
+    ).resolves.toEqual([expect.objectContaining({ name: 'result.png' })])
+    await expect(
+      compatibility.findRunFinalizationMarker(PROJECT_ID, RUN_ID)
+    ).resolves.toMatchObject({ artifactVersionIds: [version.versionId] })
+  })
+
+  it('keeps pending compatibility bytes in place when execution proof is corrupt', async () => {
+    const compatibility = new ArtifactRepository(storageRoot)
+    const { provenance, version } = await prepareRecovery(compatibility)
+    await client.artifactVersion.update({
+      where: { id: version.versionId },
+      data: {
+        executionSnapshotJson: '{"schemaVersion":2}',
+        executionSnapshotChecksum: '0'.repeat(64)
+      }
+    })
+    const coordinator = new SessionPersistenceCoordinator(
+      sessions,
+      files,
+      undefined,
+      undefined,
+      undefined,
+      provenance
+    )
+
+    const loaded = await coordinator.loadAll()
+
+    expect(loaded.sessions[0].messages[1].artifactIds).toBeUndefined()
+    expect(loaded.sessions[0].artifacts).toBeUndefined()
+    await expect(
+      compatibility.findRunFinalizationMarker(PROJECT_ID, RUN_ID)
+    ).resolves.toMatchObject({
+      sourceSessionId: STORAGE_SESSION_ID,
+      sessionId: SESSION_ID
+    })
+    await expect(
+      compatibility.findRunFinalizationMarker(PROJECT_ID, RUN_ID)
+    ).resolves.not.toHaveProperty('messageId')
+    await expect(
+      compatibility.listPendingRunFiles({
+        projectName: PROJECT_ID,
+        sessionId: STORAGE_SESSION_ID,
+        runId: RUN_ID
+      })
+    ).resolves.toEqual([expect.objectContaining({ name: 'result.png' })])
+    await expect(
+      compatibility.listMessageFiles({
+        projectName: PROJECT_ID,
+        sessionId: SESSION_ID,
+        messageId: 'message-1'
+      })
+    ).resolves.toEqual([])
+    await expect(
+      client.artifactVersion.findUniqueOrThrow({ where: { id: version.versionId } })
+    ).resolves.toMatchObject({ state: 'pending', messageId: null })
+  })
+
+  it('leaves an unmarked compatibility publication ownerless', async () => {
+    const compatibility = new ArtifactRepository(storageRoot)
+    const { provenance, version } = await prepareRecovery(compatibility)
+    await rm(
+      join(storageRoot, 'artifacts', PROJECT_ID, STORAGE_SESSION_ID, '.runs', `${RUN_ID}.json`)
+    )
+    const coordinator = new SessionPersistenceCoordinator(
+      sessions,
+      files,
+      undefined,
+      undefined,
+      undefined,
+      provenance
+    )
+
+    const loaded = await coordinator.loadAll()
+
+    expect(loaded.sessions[0].messages[1].artifactIds).toBeUndefined()
+    await expect(
+      compatibility.listPendingRunFiles({
+        projectName: PROJECT_ID,
+        sessionId: STORAGE_SESSION_ID,
+        runId: RUN_ID
+      })
+    ).resolves.toEqual([expect.objectContaining({ name: 'result.png' })])
+    await expect(
+      client.artifactVersion.findUniqueOrThrow({ where: { id: version.versionId } })
+    ).resolves.toMatchObject({ state: 'pending', messageId: null })
+  })
+
+  it('leaves a compatibility publication without DB authority ownerless', async () => {
+    const compatibility = new ArtifactRepository(storageRoot)
+    const { provenance, version } = await prepareRecovery(compatibility)
+    await client.artifactVersion.delete({ where: { id: version.versionId } })
+    await rm(dirname(version.path), { recursive: true, force: true })
+    const coordinator = new SessionPersistenceCoordinator(
+      sessions,
+      files,
+      undefined,
+      undefined,
+      undefined,
+      provenance
+    )
+
+    const loaded = await coordinator.loadAll()
+
+    expect(loaded.sessions[0].messages[1].artifactIds).toBeUndefined()
+    await expect(
+      compatibility.listPendingRunFiles({
+        projectName: PROJECT_ID,
+        sessionId: STORAGE_SESSION_ID,
+        runId: RUN_ID
+      })
+    ).resolves.toEqual([expect.objectContaining({ name: 'result.png' })])
+    await expect(
+      client.artifactVersion.findUnique({ where: { id: version.versionId } })
+    ).resolves.toBeNull()
+  })
+
+  it('keeps pending bytes in place when producer evidence is available but its snapshot is missing', async () => {
+    const compatibility = new ArtifactRepository(storageRoot)
+    const { provenance, version } = await prepareRecovery(compatibility)
+    const persisted = await client.artifactVersion.findUniqueOrThrow({
+      where: { id: version.versionId }
+    })
+    const evidence = JSON.stringify({
+      ...(JSON.parse(persisted.evidenceJson) as object),
+      producer: { state: 'available' }
+    })
+    await client.artifactVersion.update({
+      where: { id: version.versionId },
+      data: {
+        evidenceJson: evidence,
+        evidenceChecksum: createHash('sha256').update(evidence).digest('hex'),
+        notebookSessionId: null,
+        producerRunId: null,
+        producerRunIndex: null,
+        executionSnapshotJson: null,
+        executionSnapshotChecksum: null,
+        executionSnapshotStorageKey: null,
+        executionSnapshotSchemaVersion: null
+      }
+    })
+    const coordinator = new SessionPersistenceCoordinator(
+      sessions,
+      files,
+      undefined,
+      undefined,
+      undefined,
+      provenance
+    )
+
+    const loaded = await coordinator.loadAll()
+
+    expect(loaded.sessions[0].messages[1].artifactIds).toBeUndefined()
+    await expect(
+      compatibility.listPendingRunFiles({
+        projectName: PROJECT_ID,
+        sessionId: STORAGE_SESSION_ID,
+        runId: RUN_ID
+      })
+    ).resolves.toEqual([expect.objectContaining({ name: 'result.png' })])
+    await expect(
+      client.artifactVersion.findUniqueOrThrow({ where: { id: version.versionId } })
+    ).resolves.toMatchObject({ state: 'pending', messageId: null })
+
+    // Even with unavailable producer evidence, a persisted snapshot-associated field must not be
+    // interpreted as the legitimate no-producer case.
+    await client.artifactVersion.update({
+      where: { id: version.versionId },
+      data: {
+        evidenceJson: persisted.evidenceJson,
+        evidenceChecksum: persisted.evidenceChecksum,
+        executionSnapshotChecksum: '0'.repeat(64)
+      }
+    })
+    await coordinator.loadAll()
+    await expect(
+      client.artifactVersion.findUniqueOrThrow({ where: { id: version.versionId } })
+    ).resolves.toMatchObject({ state: 'pending', messageId: null })
+
+    const malformedEvidence = JSON.parse(persisted.evidenceJson) as Record<string, unknown>
+    delete malformedEvidence.execution_status
+    const malformedEvidenceJson = JSON.stringify(malformedEvidence)
+    await client.artifactVersion.update({
+      where: { id: version.versionId },
+      data: {
+        evidenceJson: malformedEvidenceJson,
+        evidenceChecksum: createHash('sha256').update(malformedEvidenceJson).digest('hex'),
+        executionSnapshotChecksum: null
+      }
+    })
+    await coordinator.loadAll()
+    await expect(
+      client.artifactVersion.findUniqueOrThrow({ where: { id: version.versionId } })
+    ).resolves.toMatchObject({ state: 'pending', messageId: null })
+  })
+
+  it('replays a finalized-but-unlinked Version after compatibility finalization recovers', async () => {
+    let failDirectorySync = false
+    const compatibility = new ArtifactRepository(storageRoot, {
+      syncFile: async () => undefined,
+      syncDirectory: async () => {
+        if (failDirectorySync) throw new Error('compatibility storage is read-only')
+      }
+    })
+    const { provenance, version } = await prepareRecovery(compatibility)
+    failDirectorySync = true
+    const coordinator = new SessionPersistenceCoordinator(
+      sessions,
+      files,
+      undefined,
+      undefined,
+      undefined,
+      provenance
+    )
+
+    const first = await coordinator.loadAll()
+
+    expect(first.sessions[0].messages[1].artifactIds).toBeUndefined()
+    await expect(files.getOverview(PROJECT_ID)).resolves.toMatchObject({
+      artifactCount: 0,
+      isIndexComplete: false
+    })
+    await expect(
+      client.artifactVersion.findUniqueOrThrow({ where: { id: version.versionId } })
+    ).resolves.toMatchObject({ state: 'finalized', messageId: 'message-1' })
+    await expect(
+      compatibility.listPendingRunFiles({
+        projectName: PROJECT_ID,
+        sessionId: STORAGE_SESSION_ID,
+        runId: RUN_ID
+      })
+    ).resolves.toEqual([expect.objectContaining({ name: 'result.png' })])
+
+    failDirectorySync = false
+    const retried = await coordinator.loadAll()
+
+    expect(retried.sessions[0].messages[1].artifactIds).toEqual([version.versionId])
+    await expect(
+      compatibility.listPendingRunFiles({
+        projectName: PROJECT_ID,
+        sessionId: STORAGE_SESSION_ID,
+        runId: RUN_ID
+      })
+    ).resolves.toEqual([])
+    await expect(
+      compatibility.listMessageFiles({
+        projectName: PROJECT_ID,
+        sessionId: SESSION_ID,
+        messageId: 'message-1'
+      })
+    ).resolves.toEqual([expect.objectContaining({ name: 'result.png' })])
+  })
+
+  it('moves compatibility bytes for a finalized Version already linked to the active Message', async () => {
+    const compatibility = new ArtifactRepository(storageRoot)
+    const { provenance, version, context } = await prepareRecovery(compatibility)
+    await finalizeAndLinkVersion({ provenance, version, context })
+    const coordinator = new SessionPersistenceCoordinator(
+      sessions,
+      files,
+      undefined,
+      undefined,
+      undefined,
+      provenance
+    )
+
+    await coordinator.loadAll()
+
+    await expect(
+      compatibility.listPendingRunFiles({
+        projectName: PROJECT_ID,
+        sessionId: STORAGE_SESSION_ID,
+        runId: RUN_ID
+      })
+    ).resolves.toEqual([])
+    await expect(
+      compatibility.listMessageFiles({
+        projectName: PROJECT_ID,
+        sessionId: SESSION_ID,
+        messageId: 'message-1'
+      })
+    ).resolves.toEqual([expect.objectContaining({ name: 'result.png' })])
+  })
+
+  it('moves compatibility metadata left pending after its byte reached the Message directory', async () => {
+    const compatibility = new ArtifactRepository(storageRoot)
+    const { provenance, version, context } = await prepareRecovery(compatibility)
+    await finalizeAndLinkVersion({ provenance, version, context })
+    const [pending] = await compatibility.listPendingRunFiles({
+      projectName: PROJECT_ID,
+      sessionId: STORAGE_SESSION_ID,
+      runId: RUN_ID
+    })
+    const messageDirectory = join(storageRoot, 'artifacts', PROJECT_ID, SESSION_ID, 'message-1')
+    await mkdir(messageDirectory, { recursive: true })
+    await rename(pending.path, join(messageDirectory, pending.name))
+    await expect(
+      compatibility.listMessageFiles({
+        projectName: PROJECT_ID,
+        sessionId: SESSION_ID,
+        messageId: 'message-1'
+      })
+    ).resolves.toEqual([expect.not.objectContaining({ versionId: version.versionId })])
+    const coordinator = new SessionPersistenceCoordinator(
+      sessions,
+      files,
+      undefined,
+      undefined,
+      undefined,
+      provenance
+    )
+
+    await coordinator.loadAll()
+
+    await expect(
+      compatibility.listMessageFiles({
+        projectName: PROJECT_ID,
+        sessionId: SESSION_ID,
+        messageId: 'message-1'
+      })
+    ).resolves.toEqual([
+      expect.objectContaining({ name: 'result.png', versionId: version.versionId })
+    ])
+  })
+
+  it('moves compatibility bytes for a finalized Version linked only on an inactive Branch', async () => {
+    const compatibility = new ArtifactRepository(storageRoot)
+    const { provenance, version, context } = await prepareRecovery(compatibility)
+    await finalizeAndLinkVersion({ provenance, version, context, makeLinkedMessageInactive: true })
+    const coordinator = new SessionPersistenceCoordinator(
+      sessions,
+      files,
+      undefined,
+      undefined,
+      undefined,
+      provenance
+    )
+
+    const loaded = await coordinator.loadAll()
+
+    expect(loaded.sessions[0].messages).not.toContainEqual(
+      expect.objectContaining({ id: 'message-1' })
+    )
+    expect(
+      loaded.sessions[0].conversationGraph?.messages.find(({ id }) => id === 'message-1')
+        ?.artifactIds
+    ).toEqual([version.versionId])
+    await expect(
+      compatibility.listPendingRunFiles({
+        projectName: PROJECT_ID,
+        sessionId: STORAGE_SESSION_ID,
+        runId: RUN_ID
+      })
+    ).resolves.toEqual([])
+    await expect(
+      compatibility.listMessageFiles({
+        projectName: PROJECT_ID,
+        sessionId: SESSION_ID,
+        messageId: 'message-1'
+      })
+    ).resolves.toEqual([expect.objectContaining({ name: 'result.png' })])
+  })
+
+  it('reuses explicit Project reconciliation discovery across Session reconciliation calls', async () => {
+    const compatibility = new ArtifactRepository(storageRoot)
+    const { provenance } = await prepareRecovery(compatibility)
+    const discover = vi.spyOn(compatibility, 'listPendingRunPublications')
+    const durableSession = await sessions.loadSession(PROJECT_ID, SESSION_ID)
+    if (!durableSession) throw new Error('Recovery fixture Session is missing.')
+    const projectReconciliation = await provenance.prepareProjectReconciliation(PROJECT_ID)
+
+    await provenance.reconcileSession(PROJECT_ID, SESSION_ID, durableSession, {
+      projectReconciliation
+    })
+    await provenance.reconcileSession(PROJECT_ID, SESSION_ID, durableSession, {
+      projectReconciliation
+    })
+
+    expect(discover).toHaveBeenCalledOnce()
+  })
+
+  it('performs fresh publication discovery for direct reconciliation calls', async () => {
+    const compatibility = new ArtifactRepository(storageRoot)
+    const { provenance } = await prepareRecovery(compatibility)
+    const discover = vi.spyOn(compatibility, 'listPendingRunPublications')
+    const durableSession = await sessions.loadSession(PROJECT_ID, SESSION_ID)
+    if (!durableSession) throw new Error('Recovery fixture Session is missing.')
+
+    await provenance.reconcileSession(PROJECT_ID, SESSION_ID, durableSession)
+    await provenance.reconcileSession(PROJECT_ID, SESSION_ID, durableSession)
+
+    expect(discover).toHaveBeenCalledTimes(2)
+  })
+
+  it('recovers a pending Version when another Version from the same run is already linked', async () => {
+    const compatibility = new ArtifactRepository(storageRoot)
+    const { provenance, version: linkedVersion, context } = await prepareRecovery(compatibility)
+    const coordinator = new SessionPersistenceCoordinator(
+      sessions,
+      files,
+      undefined,
+      undefined,
+      undefined,
+      provenance
+    )
+    await coordinator.loadAll()
+
+    await compatibility.writePendingFile({
+      projectName: PROJECT_ID,
+      sessionId: STORAGE_SESSION_ID,
+      runId: RUN_ID,
+      filename: 'second.png',
+      source: createPngInlineSource('second recovered bytes')
+    })
+    const pendingVersion = await provenance.createVersion({
+      projectId: PROJECT_ID,
+      appSessionId: SESSION_ID,
+      artifactStorageSessionId: STORAGE_SESSION_ID,
+      artifactRunId: RUN_ID,
+      writeOperationId: 'write-2',
+      writeRequestChecksum: 'b'.repeat(64),
+      ...context,
+      filename: 'second.png'
+    })
+
+    // The new Version appeared after the prepared marker froze its exact set. Recovery must not
+    // silently recompute a wider claim from SQLite.
+    const withheld = await coordinator.loadAll()
+    expect(withheld.sessions[0].messages[1].artifactIds).toEqual([linkedVersion.versionId])
+    await expect(
+      client.artifactVersion.findUniqueOrThrow({ where: { id: pendingVersion.versionId } })
+    ).resolves.toMatchObject({ state: 'pending', messageId: null })
+
+    // Model the valid partial-link crash state: the durable marker originally froze both Versions,
+    // while Session JSON persisted only the first attachment before the process exited.
+    await writeFile(
+      join(storageRoot, 'artifacts', PROJECT_ID, STORAGE_SESSION_ID, '.runs', `${RUN_ID}.json`),
+      `${JSON.stringify({
+        sessionId: SESSION_ID,
+        messageId: 'message-1',
+        artifactVersionIds: [linkedVersion.versionId, pendingVersion.versionId].sort(),
+        provenanceContext: context
+      })}\n`,
+      'utf8'
+    )
+    const recovered = await coordinator.loadAll()
+
+    expect(recovered.sessions[0].messages[1].artifactIds).toEqual([
+      linkedVersion.versionId,
+      pendingVersion.versionId
+    ])
+    await expect(
+      client.artifactVersion.findUniqueOrThrow({ where: { id: pendingVersion.versionId } })
+    ).resolves.toMatchObject({ state: 'finalized', messageId: 'message-1' })
+  })
+
+  it('marks Files incomplete when a run marker cannot be read from storage', async () => {
+    let failMarkerRead = false
+    const compatibility = new ArtifactRepository(storageRoot, {
+      syncFile: async () => undefined,
+      syncDirectory: async () => undefined,
+      readMarkerFile: async (path) => {
+        if (failMarkerRead && path.endsWith(`${RUN_ID}.json`)) {
+          throw Object.assign(new Error('marker read failed'), { code: 'EIO' })
+        }
+        return readFile(path, 'utf8')
+      }
+    })
+    const { provenance, version } = await prepareRecovery(compatibility)
+    failMarkerRead = true
+    const coordinator = new SessionPersistenceCoordinator(
+      sessions,
+      files,
+      undefined,
+      undefined,
+      undefined,
+      provenance
+    )
+
+    const loaded = await coordinator.loadAll()
+
+    expect(loaded.sessions[0].messages[1].artifactIds).toBeUndefined()
+    await expect(files.getOverview(PROJECT_ID)).resolves.toMatchObject({
+      artifactCount: 0,
+      isIndexComplete: false
+    })
+    await expect(
+      client.artifactVersion.findUniqueOrThrow({ where: { id: version.versionId } })
+    ).resolves.toMatchObject({ state: 'pending', messageId: null })
+  })
+
+  const finalizeAndLinkVersion = async (input: {
+    provenance: ArtifactProvenanceRepository
+    version: Awaited<ReturnType<ArtifactProvenanceRepository['createVersion']>>
+    context: {
+      rootFrameId: string
+      agentFrameId: string
+      messageBranchId: string
+      runtimeSegmentId: string
+      promptMessageId: string
+    }
+    makeLinkedMessageInactive?: boolean
+  }): Promise<void> => {
+    const [finalized] = await input.provenance.finalizeRun({
+      projectId: PROJECT_ID,
+      appSessionId: SESSION_ID,
+      artifactRunId: RUN_ID,
+      artifactVersionIds: [input.version.versionId],
+      ...input.context,
+      messageId: 'message-1'
+    })
+    const session = await sessions.loadSession(PROJECT_ID, SESSION_ID)
+    if (!session?.conversationGraph) throw new Error('Recovery fixture Session graph is missing.')
+    const linkMessage = <T extends { id: string; artifactIds?: string[] }>(message: T): T =>
+      message.id === 'message-1' ? { ...message, artifactIds: [input.version.versionId] } : message
+    const activeBranchId = 'message-branch-active-replacement'
+    const activeMessage = {
+      id: 'active-replacement-prompt',
+      role: 'user' as const,
+      content: 'continue on another branch',
+      status: 'complete' as const,
+      eventIds: [],
+      createdAt: 3,
+      updatedAt: 3
+    }
+    const conversationGraph = input.makeLinkedMessageInactive
+      ? {
+          ...session.conversationGraph,
+          frames: session.conversationGraph.frames.map((frame) =>
+            frame.id === session.conversationGraph!.rootFrameId
+              ? { ...frame, activeBranchId }
+              : frame
+          ),
+          branches: [
+            ...session.conversationGraph.branches,
+            {
+              id: activeBranchId,
+              agentFrameId: session.conversationGraph.rootFrameId,
+              headMessageId: activeMessage.id,
+              createdAt: 3,
+              updatedAt: 3
+            }
+          ],
+          messages: [
+            ...session.conversationGraph.messages.map(linkMessage),
+            {
+              ...activeMessage,
+              agentFrameId: session.conversationGraph.rootFrameId,
+              introducedOnBranchId: activeBranchId,
+              revisionRootMessageId: activeMessage.id,
+              runtimeSegmentId: session.conversationGraph.runtimeSegments[0].id
+            }
+          ]
+        }
+      : {
+          ...session.conversationGraph,
+          messages: session.conversationGraph.messages.map(linkMessage)
+        }
+    await sessions.saveSession({
+      ...session,
+      messages: input.makeLinkedMessageInactive
+        ? [activeMessage]
+        : session.messages.map(linkMessage),
+      conversationGraph,
+      artifacts: [
+        {
+          id: finalized.versionId,
+          artifactId: finalized.artifactId,
+          versionId: finalized.versionId,
+          versionNumber: finalized.versionNumber,
+          kind: 'managed-file',
+          path: finalized.path,
+          fileUrl: finalized.fileUrl,
+          name: finalized.name,
+          mimeType: finalized.mimeType,
+          size: finalized.size,
+          mtimeMs: finalized.mtimeMs,
+          sha256: finalized.checksum
+        }
+      ]
+    })
+    await writeFile(
+      join(storageRoot, 'artifacts', PROJECT_ID, STORAGE_SESSION_ID, '.runs', `${RUN_ID}.json`),
+      `${JSON.stringify({
+        sessionId: SESSION_ID,
+        messageId: 'message-1',
+        artifactVersionIds: [input.version.versionId],
+        provenanceContext: input.context
+      })}\n`,
+      'utf8'
+    )
+  }
+
+  const prepareRecovery = async (
+    compatibility: ArtifactRepository
+  ): Promise<{
+    provenance: ArtifactProvenanceRepository
+    version: Awaited<ReturnType<ArtifactProvenanceRepository['createVersion']>>
+    context: {
+      rootFrameId: string
+      agentFrameId: string
+      messageBranchId: string
+      runtimeSegmentId: string
+      promptMessageId: string
+    }
+  }> => {
+    const provenance = new ArtifactProvenanceRepository({
+      storageRoot,
+      getClient: () => Promise.resolve(client),
+      compatibilityRepository: compatibility,
+      loadSession: (projectId, sessionId) => sessions.loadSession(projectId, sessionId)
+    })
+    const prompt = {
+      id: 'prompt-1',
+      role: 'user' as const,
+      content: 'create an image',
+      status: 'complete' as const,
+      eventIds: [],
+      createdAt: 1,
+      updatedAt: 1
+    }
+    const message = {
+      id: 'message-1',
+      role: 'agent' as const,
+      content: 'done',
+      status: 'streaming' as const,
+      eventIds: [],
+      createdAt: 2,
+      updatedAt: 2
+    }
+    const conversationGraph = createLinearConversationGraph({
+      sessionId: SESSION_ID,
+      messages: [prompt, message],
+      frameworkId: 'codex',
+      createdAt: 1,
+      updatedAt: 2
+    })
+    const context = {
+      rootFrameId: conversationGraph.rootFrameId,
+      agentFrameId: conversationGraph.activeFrameId,
+      messageBranchId: conversationGraph.branches[0].id,
+      runtimeSegmentId: conversationGraph.runtimeSegments[0].id,
+      promptMessageId: prompt.id
+    }
+    await compatibility.writePendingFile({
+      projectName: PROJECT_ID,
+      sessionId: STORAGE_SESSION_ID,
+      runId: RUN_ID,
+      filename: 'result.png',
+      source: createPngInlineSource('recovered bytes')
+    })
+    const version = await provenance.createVersion({
+      projectId: PROJECT_ID,
+      appSessionId: SESSION_ID,
+      artifactStorageSessionId: STORAGE_SESSION_ID,
+      artifactRunId: RUN_ID,
+      writeOperationId: 'write-1',
+      writeRequestChecksum: 'a'.repeat(64),
+      ...context,
+      filename: 'result.png'
+    })
+    await compatibility.prepareRunFinalization({
+      projectName: PROJECT_ID,
+      sourceSessionId: STORAGE_SESSION_ID,
+      sessionId: SESSION_ID,
+      runId: RUN_ID,
+      artifactVersionIds: [version.versionId],
+      provenanceContext: context
+    })
+    const session: PersistedChatSession = {
+      id: SESSION_ID,
+      projectId: PROJECT_ID,
+      title: 'Recovery',
+      cwd: '/workspace',
+      status: 'idle',
+      messages: [prompt, message],
+      conversationGraph,
+      filesRevision: 1,
+      createdAt: 1,
+      updatedAt: 2
+    }
+    await sessions.saveSession(session)
+    return { provenance, version, context }
+  }
+})

--- a/src/main/session-persistence/coordinator.test.ts
+++ b/src/main/session-persistence/coordinator.test.ts
@@ -3,7 +3,12 @@ import { tmpdir } from 'node:os'
 import { dirname, join } from 'node:path'
 import { describe, expect, it, vi } from 'vitest'
 
-import type { PersistedChatSession } from '../../shared/session-persistence'
+import type { ArtifactVersionFile } from '../../shared/artifact-provenance'
+import {
+  materializeSessionConversationGraph,
+  type PersistedChatSession
+} from '../../shared/session-persistence'
+import type { ArtifactProjectReconciliationSnapshot } from '../artifacts/provenance-repository'
 import { createProjectDbClient, ensureProjectSchema } from '../projects/prisma-client'
 import {
   OrphanLegacyUploadAuthorityMissingError,
@@ -13,7 +18,8 @@ import {
 import {
   SessionPersistenceCoordinator,
   type SessionFileIndex,
-  type SessionMutationRepository
+  type SessionMutationRepository,
+  type SessionProvenancePersistence
 } from './coordinator'
 
 const createSession = (overrides: Partial<PersistedChatSession> = {}): PersistedChatSession => ({
@@ -71,6 +77,30 @@ const toVersionedUploadSession = (session: PersistedChatSession): PersistedChatS
   ]
   return upgraded
 }
+
+const createRecoveredArtifact = (
+  overrides: Partial<ArtifactVersionFile> = {}
+): ArtifactVersionFile => ({
+  id: 'artifact-version-1',
+  artifactId: 'artifact-lineage-1',
+  versionId: 'artifact-version-1',
+  versionNumber: 1,
+  checksum: 'a'.repeat(64),
+  createdAt: '2026-07-29T00:00:00.000Z',
+  projectName: 'project-1',
+  sessionId: 'session-1',
+  runId: 'artifact-run-1',
+  name: 'result.csv',
+  path: '/managed/.provenance/artifact-lineage-1/versions/artifact-version-1/content',
+  fileUrl: 'file:///managed/result.csv',
+  mimeType: 'text/csv',
+  size: 12,
+  mtimeMs: 3,
+  ...overrides
+})
+
+const createProjectReconciliationSnapshot = (): ArtifactProjectReconciliationSnapshot =>
+  ({}) as ArtifactProjectReconciliationSnapshot
 
 describe('SessionPersistenceCoordinator', () => {
   it('serializes a pending save before deletion and rejects saves after the tombstone', async () => {
@@ -404,7 +434,11 @@ describe('SessionPersistenceCoordinator', () => {
       loadAllWithDiagnostics: vi.fn().mockResolvedValue({ result, isComplete: true })
     })
     const fileIndex = createFileIndex()
-    const artifactStorage = { reconcileSession: vi.fn().mockResolvedValue(undefined) }
+    const projectReconciliation = createProjectReconciliationSnapshot()
+    const artifactStorage = {
+      prepareProjectReconciliation: vi.fn().mockResolvedValue(projectReconciliation),
+      reconcileSession: vi.fn().mockResolvedValue(undefined)
+    }
     const coordinator = new SessionPersistenceCoordinator(
       repository,
       fileIndex,
@@ -420,7 +454,8 @@ describe('SessionPersistenceCoordinator', () => {
       'session-1',
       session,
       {
-        removeOrphanStaging: true
+        removeOrphanStaging: true,
+        projectReconciliation
       }
     )
     expect(fileIndex.syncSession).toHaveBeenCalledWith(session)
@@ -690,7 +725,11 @@ describe('SessionPersistenceCoordinator', () => {
     const uploads = {
       upgradeLegacySessionUploads: vi.fn().mockResolvedValue(upgradedSession)
     }
-    const artifactStorage = { reconcileSession: vi.fn().mockResolvedValue(undefined) }
+    const projectReconciliation = createProjectReconciliationSnapshot()
+    const artifactStorage = {
+      prepareProjectReconciliation: vi.fn().mockResolvedValue(projectReconciliation),
+      reconcileSession: vi.fn().mockResolvedValue(undefined)
+    }
     const coordinator = new SessionPersistenceCoordinator(
       repository,
       createFileIndex(),
@@ -715,7 +754,7 @@ describe('SessionPersistenceCoordinator', () => {
       'project-1',
       'session-1',
       upgradedSession,
-      { removeOrphanStaging: false }
+      { removeOrphanStaging: false, projectReconciliation }
     )
   })
 
@@ -822,6 +861,393 @@ describe('SessionPersistenceCoordinator', () => {
     expect(loaded.sessions).toEqual([upgradedSession])
     expect(repository.saveSession).toHaveBeenCalledWith(upgradedSession)
     expect(markReconciliationIncomplete).toHaveBeenCalledOnce()
+    expect(fileIndex.syncSession).not.toHaveBeenCalled()
+  })
+
+  it('prepares one Artifact reconciliation snapshot for sessions in the same Project', async () => {
+    const sessions = [createSession(), createSession({ id: 'session-2' })]
+    const result = { sessions, manifest: { version: 1 as const } }
+    const repository = createSessionRepository({
+      loadAllWithDiagnostics: vi.fn().mockResolvedValue({ result, isComplete: true })
+    })
+    const projectSnapshot = createProjectReconciliationSnapshot()
+    const artifactStorage = {
+      prepareProjectReconciliation: vi.fn().mockResolvedValue(projectSnapshot),
+      reconcileSession: vi.fn().mockResolvedValue(undefined)
+    }
+    const coordinator = new SessionPersistenceCoordinator(
+      repository,
+      createFileIndex(),
+      undefined,
+      undefined,
+      undefined,
+      artifactStorage
+    )
+
+    await coordinator.loadAll()
+
+    expect(artifactStorage.prepareProjectReconciliation).toHaveBeenCalledOnce()
+    expect(artifactStorage.prepareProjectReconciliation).toHaveBeenCalledWith('project-1')
+    expect(artifactStorage.reconcileSession).toHaveBeenCalledTimes(2)
+    for (const session of sessions) {
+      expect(artifactStorage.reconcileSession).toHaveBeenCalledWith(
+        'project-1',
+        session.id,
+        session,
+        {
+          removeOrphanStaging: true,
+          projectReconciliation: projectSnapshot
+        }
+      )
+    }
+  })
+
+  it('prepares separate Artifact reconciliation snapshots for different Projects', async () => {
+    const sessions = [
+      createSession(),
+      createSession({ id: 'session-2' }),
+      createSession({ id: 'session-3', projectId: 'project-2' })
+    ]
+    const result = { sessions, manifest: { version: 1 as const } }
+    const repository = createSessionRepository({
+      loadAllWithDiagnostics: vi.fn().mockResolvedValue({ result, isComplete: true })
+    })
+    const snapshots = new Map<string, ArtifactProjectReconciliationSnapshot>([
+      ['project-1', createProjectReconciliationSnapshot()],
+      ['project-2', createProjectReconciliationSnapshot()]
+    ])
+    const artifactStorage = {
+      prepareProjectReconciliation: vi.fn(async (projectId: string) => snapshots.get(projectId)!),
+      reconcileSession: vi.fn().mockResolvedValue(undefined)
+    }
+    const coordinator = new SessionPersistenceCoordinator(
+      repository,
+      createFileIndex(),
+      undefined,
+      undefined,
+      undefined,
+      artifactStorage
+    )
+
+    await coordinator.loadAll()
+
+    expect(artifactStorage.prepareProjectReconciliation).toHaveBeenCalledTimes(2)
+    expect(artifactStorage.prepareProjectReconciliation).toHaveBeenCalledWith('project-1')
+    expect(artifactStorage.prepareProjectReconciliation).toHaveBeenCalledWith('project-2')
+    for (const session of sessions) {
+      expect(artifactStorage.reconcileSession).toHaveBeenCalledWith(
+        session.projectId,
+        session.id,
+        session,
+        {
+          removeOrphanStaging: true,
+          projectReconciliation: snapshots.get(session.projectId)
+        }
+      )
+    }
+  })
+
+  it('marks Files incomplete when Project reconciliation preparation fails', async () => {
+    const session = createSession()
+    const result = { sessions: [session], manifest: { version: 1 as const } }
+    const repository = createSessionRepository({
+      loadAllWithDiagnostics: vi.fn().mockResolvedValue({ result, isComplete: true })
+    })
+    const markReconciliationIncomplete = vi.fn()
+    const fileIndex = createFileIndex({ markReconciliationIncomplete })
+    const artifactStorage = {
+      prepareProjectReconciliation: vi.fn().mockRejectedValue(new Error('scan failed')),
+      reconcileSession: vi.fn().mockResolvedValue(undefined)
+    }
+    const coordinator = new SessionPersistenceCoordinator(
+      repository,
+      fileIndex,
+      undefined,
+      undefined,
+      undefined,
+      artifactStorage
+    )
+
+    await expect(coordinator.loadAll()).resolves.toBe(result)
+
+    expect(markReconciliationIncomplete).toHaveBeenCalledOnce()
+    expect(artifactStorage.reconcileSession).not.toHaveBeenCalled()
+    expect(fileIndex.reconcileActiveSessions).not.toHaveBeenCalled()
+  })
+
+  it('persists recovered Artifact Versions on their owning message without replay churn', async () => {
+    const originalSession = materializeSessionConversationGraph(
+      createSession({
+        filesRevision: 4,
+        messages: [
+          {
+            id: 'message-1',
+            role: 'agent',
+            content: 'result',
+            status: 'streaming',
+            eventIds: [],
+            createdAt: 1,
+            updatedAt: 2
+          }
+        ]
+      })
+    )
+    let durableSession = originalSession
+    const repository = createSessionRepository({
+      loadAllWithDiagnostics: vi.fn(async () => ({
+        result: { sessions: [durableSession], manifest: { version: 1 as const } },
+        isComplete: true
+      })),
+      saveSession: vi.fn(async (session) => {
+        durableSession = structuredClone(session)
+      })
+    })
+    const recoveredArtifact = createRecoveredArtifact()
+    const artifactStorage = {
+      prepareProjectReconciliation: vi
+        .fn()
+        .mockResolvedValue(createProjectReconciliationSnapshot()),
+      reconcileSession: vi.fn().mockResolvedValue({
+        recoveredMessageArtifacts: [
+          { messageId: 'message-1', artifacts: [recoveredArtifact, recoveredArtifact] }
+        ]
+      })
+    }
+    const fileIndex = createFileIndex()
+    const coordinator = new SessionPersistenceCoordinator(
+      repository,
+      fileIndex,
+      undefined,
+      undefined,
+      undefined,
+      artifactStorage
+    )
+
+    const first = await coordinator.loadAll()
+    const recoveredSession = first.sessions[0]
+
+    // Message associations use ArtifactFile.id (the Artifact Version id), not lineage artifactId.
+    expect(recoveredSession.messages[0].artifactIds).toEqual(['artifact-version-1'])
+    expect(recoveredSession.conversationGraph?.messages[0].artifactIds).toEqual([
+      'artifact-version-1'
+    ])
+    expect(recoveredSession.artifacts).toEqual([
+      expect.objectContaining({
+        id: 'artifact-version-1',
+        artifactId: 'artifact-lineage-1',
+        versionId: 'artifact-version-1',
+        versionNumber: 1,
+        sha256: 'a'.repeat(64)
+      })
+    ])
+    expect(recoveredSession.filesRevision).toBe(5)
+    expect(repository.saveSession).toHaveBeenCalledOnce()
+    expect(fileIndex.reconcileActiveSessions).toHaveBeenCalledWith([recoveredSession])
+    expect(fileIndex.syncSession).toHaveBeenCalledWith(recoveredSession)
+
+    const replayed = await coordinator.loadAll()
+    expect(replayed.sessions[0].messages[0].artifactIds).toEqual(['artifact-version-1'])
+    expect(replayed.sessions[0].artifacts).toHaveLength(1)
+    expect(replayed.sessions[0].filesRevision).toBe(5)
+    expect(repository.saveSession).toHaveBeenCalledOnce()
+  })
+
+  it('returns the recovered Session view and retries when its JSON save fails', async () => {
+    const session = materializeSessionConversationGraph(
+      createSession({
+        messages: [
+          {
+            id: 'message-1',
+            role: 'agent',
+            content: 'result',
+            status: 'streaming',
+            eventIds: [],
+            createdAt: 1,
+            updatedAt: 2
+          }
+        ]
+      })
+    )
+    const result = { sessions: [session], manifest: { version: 1 as const } }
+    const repository = createSessionRepository({
+      loadAllWithDiagnostics: vi.fn().mockResolvedValue({ result, isComplete: true }),
+      saveSession: vi
+        .fn()
+        .mockRejectedValueOnce(new Error('session json is read-only'))
+        .mockResolvedValueOnce(undefined)
+    })
+    const markReconciliationIncomplete = vi.fn()
+    const fileIndex = createFileIndex({ markReconciliationIncomplete })
+    const provenance = createProvenancePersistence()
+    const artifactStorage = {
+      prepareProjectReconciliation: vi
+        .fn()
+        .mockResolvedValue(createProjectReconciliationSnapshot()),
+      reconcileSession: vi.fn().mockResolvedValue({
+        recoveredMessageArtifacts: [
+          {
+            messageId: 'message-1',
+            artifacts: [
+              createRecoveredArtifact({
+                checksum: 'b'.repeat(64),
+                name: 'result.txt',
+                path: '/managed/result.txt',
+                fileUrl: 'file:///managed/result.txt',
+                size: 6
+              })
+            ]
+          }
+        ]
+      })
+    }
+    const coordinator = new SessionPersistenceCoordinator(
+      repository,
+      fileIndex,
+      undefined,
+      provenance,
+      undefined,
+      artifactStorage
+    )
+
+    const loaded = await coordinator.loadAll()
+
+    expect(loaded.sessions[0].messages[0].artifactIds).toEqual(['artifact-version-1'])
+    expect(loaded.sessions[0].conversationGraph?.messages[0].artifactIds).toEqual([
+      'artifact-version-1'
+    ])
+    expect(loaded.sessions[0].artifacts?.[0]).toMatchObject({ id: 'artifact-version-1' })
+    expect(loaded.sessions[0].filesRevision).toBe(2)
+    expect(markReconciliationIncomplete).toHaveBeenCalledOnce()
+    expect(fileIndex.reconcileActiveSessions).not.toHaveBeenCalled()
+    expect(fileIndex.syncSession).not.toHaveBeenCalled()
+
+    const retried = await coordinator.loadAll()
+    expect(retried.sessions[0].messages[0].artifactIds).toEqual(['artifact-version-1'])
+    expect(provenance.captureFinalizedMessages).toHaveBeenCalledTimes(2)
+    expect(repository.saveSession).toHaveBeenCalledTimes(2)
+    expect(fileIndex.reconcileActiveSessions).toHaveBeenCalledOnce()
+    expect(fileIndex.syncSession).toHaveBeenCalledOnce()
+  })
+
+  it('retries the attachment without saving JSON when Message snapshot capture fails', async () => {
+    const session = materializeSessionConversationGraph(
+      createSession({
+        messages: [
+          {
+            id: 'message-1',
+            role: 'agent',
+            content: 'result',
+            status: 'streaming',
+            eventIds: [],
+            createdAt: 1,
+            updatedAt: 2
+          }
+        ]
+      })
+    )
+    const repository = createSessionRepository({
+      loadAllWithDiagnostics: vi.fn().mockResolvedValue({
+        result: { sessions: [session], manifest: { version: 1 as const } },
+        isComplete: true
+      })
+    })
+    const markReconciliationIncomplete = vi.fn()
+    const fileIndex = createFileIndex({ markReconciliationIncomplete })
+    const provenance = createProvenancePersistence({
+      captureFinalizedMessages: vi
+        .fn()
+        .mockRejectedValueOnce(new Error('snapshot storage is read-only'))
+        .mockResolvedValueOnce(undefined)
+    })
+    const artifactStorage = {
+      prepareProjectReconciliation: vi
+        .fn()
+        .mockResolvedValue(createProjectReconciliationSnapshot()),
+      reconcileSession: vi.fn().mockResolvedValue({
+        recoveredMessageArtifacts: [
+          { messageId: 'message-1', artifacts: [createRecoveredArtifact()] }
+        ]
+      })
+    }
+    const coordinator = new SessionPersistenceCoordinator(
+      repository,
+      fileIndex,
+      undefined,
+      provenance,
+      undefined,
+      artifactStorage
+    )
+
+    const first = await coordinator.loadAll()
+    expect(first.sessions[0].messages[0].artifactIds).toEqual(['artifact-version-1'])
+    expect(repository.saveSession).not.toHaveBeenCalled()
+    expect(markReconciliationIncomplete).toHaveBeenCalledOnce()
+
+    const retried = await coordinator.loadAll()
+    expect(retried.sessions[0].messages[0].artifactIds).toEqual(['artifact-version-1'])
+    expect(provenance.captureFinalizedMessages).toHaveBeenCalledTimes(2)
+    expect(repository.saveSession).toHaveBeenCalledOnce()
+    expect(fileIndex.reconcileActiveSessions).toHaveBeenCalledOnce()
+    expect(fileIndex.syncSession).toHaveBeenCalledOnce()
+  })
+
+  it('keeps earlier recovered Sessions when a later reconciliation fails', async () => {
+    const firstSession = materializeSessionConversationGraph(
+      createSession({
+        messages: [
+          {
+            id: 'message-1',
+            role: 'agent',
+            content: 'first result',
+            status: 'complete',
+            eventIds: [],
+            createdAt: 1,
+            updatedAt: 2
+          }
+        ]
+      })
+    )
+    const secondSession = createSession({ id: 'session-2', title: 'Second Session' })
+    const repository = createSessionRepository({
+      loadAllWithDiagnostics: vi.fn().mockResolvedValue({
+        result: { sessions: [firstSession, secondSession], manifest: { version: 1 as const } },
+        isComplete: true
+      })
+    })
+    const markReconciliationIncomplete = vi.fn()
+    const fileIndex = createFileIndex({ markReconciliationIncomplete })
+    const artifactStorage = {
+      prepareProjectReconciliation: vi
+        .fn()
+        .mockResolvedValue(createProjectReconciliationSnapshot()),
+      reconcileSession: vi
+        .fn()
+        .mockResolvedValueOnce({
+          recoveredMessageArtifacts: [
+            { messageId: 'message-1', artifacts: [createRecoveredArtifact()] }
+          ]
+        })
+        .mockRejectedValueOnce(new Error('artifact database unavailable'))
+    }
+    const coordinator = new SessionPersistenceCoordinator(
+      repository,
+      fileIndex,
+      undefined,
+      undefined,
+      undefined,
+      artifactStorage
+    )
+
+    const loaded = await coordinator.loadAll()
+
+    expect(loaded.sessions[0].messages[0].artifactIds).toEqual(['artifact-version-1'])
+    expect(loaded.sessions[0].conversationGraph?.messages[0].artifactIds).toEqual([
+      'artifact-version-1'
+    ])
+    expect(loaded.sessions[1]).toBe(secondSession)
+    expect(repository.saveSession).toHaveBeenCalledWith(loaded.sessions[0])
+    expect(markReconciliationIncomplete).toHaveBeenCalledOnce()
+    expect(fileIndex.reconcileActiveSessions).not.toHaveBeenCalled()
     expect(fileIndex.syncSession).not.toHaveBeenCalled()
   })
 
@@ -1574,6 +2000,19 @@ const createFileIndex = (overrides: Partial<SessionFileIndex> = {}): SessionFile
   softDeleteProject: vi.fn().mockResolvedValue('delete-project-operation'),
   reconcileActiveSessions: vi.fn().mockResolvedValue(undefined),
   markReconciliationIncomplete: vi.fn(),
+  ...overrides
+})
+
+const createProvenancePersistence = (
+  overrides: Partial<SessionProvenancePersistence> = {}
+): SessionProvenancePersistence => ({
+  captureFinalizedMessages: vi.fn().mockResolvedValue(undefined),
+  reconcileSessionDeletions: vi.fn().mockResolvedValue(undefined),
+  prepareSessionDeletion: vi
+    .fn()
+    .mockResolvedValue({ kind: 'ordinary', projectId: 'project-1', sessionId: 'session-1' }),
+  completeSessionDeletion: vi.fn().mockResolvedValue(undefined),
+  abortSessionDeletion: vi.fn().mockResolvedValue(undefined),
   ...overrides
 })
 

--- a/src/main/session-persistence/coordinator.ts
+++ b/src/main/session-persistence/coordinator.ts
@@ -1,7 +1,9 @@
 import type { ProjectFilesChangedEvent } from '../../shared/project-files'
 import type { ProjectFileSource } from '../../shared/project-files'
+import type { ArtifactVersionFile } from '../../shared/artifact-provenance'
 import type {
   LoadAllSessionsResult,
+  PersistedArtifact,
   PersistedChatSession,
   SaveSessionManifestRequest
 } from '../../shared/session-persistence'
@@ -9,6 +11,7 @@ import type { ManagedFileSoftDeleteToken } from '../project-files/repository'
 import type { ProjectSessionDeletionState } from './repository'
 import { materializeSessionConversationGraph } from '../../shared/session-persistence'
 import type { SessionDeletionReceipt } from '../artifacts/provenance-message-snapshot'
+import type { ArtifactProjectReconciliationSnapshot } from '../artifacts/provenance-repository'
 import {
   OrphanLegacyUploadAuthorityMissingError,
   UnsafeLegacyUploadResidualError
@@ -80,19 +83,135 @@ type SessionUploadPersistence = {
   ): Promise<PersistedChatSession>
 }
 
+type RecoveredMessageArtifacts = { messageId: string; artifacts: ArtifactVersionFile[] }
+
 type ArtifactStorageReconciler = {
+  prepareProjectReconciliation(projectId: string): Promise<ArtifactProjectReconciliationSnapshot>
   reconcileSession(
     projectId: string,
     sessionId: string,
     durableSession: PersistedChatSession,
-    options?: { removeOrphanStaging?: boolean }
-  ): Promise<unknown>
+    options?: {
+      removeOrphanStaging?: boolean
+      projectReconciliation?: ArtifactProjectReconciliationSnapshot
+    }
+  ): Promise<
+    | {
+        recoveredMessageArtifacts: RecoveredMessageArtifacts[]
+      }
+    | undefined
+  >
 }
 
 const hasLegacySessionUpload = (session: PersistedChatSession): boolean =>
   [...session.messages, ...(session.conversationGraph?.messages ?? [])].some((message) =>
     message.uploads?.some((upload) => !upload.versionId)
   )
+
+const toPersistedArtifact = (artifact: ArtifactVersionFile): PersistedArtifact => ({
+  id: artifact.id,
+  artifactId: artifact.artifactId,
+  versionId: artifact.versionId,
+  versionNumber: artifact.versionNumber,
+  kind: 'managed-file',
+  path: artifact.path,
+  fileUrl: artifact.fileUrl,
+  name: artifact.name,
+  mimeType: artifact.mimeType,
+  size: artifact.size,
+  mtimeMs: artifact.mtimeMs,
+  sha256: artifact.checksum
+})
+
+const persistedArtifactsEqual = (left: PersistedArtifact, right: PersistedArtifact): boolean =>
+  Object.entries(right).every(([field, value]) => left[field as keyof PersistedArtifact] === value)
+
+const appendUnique = (existing: string[] | undefined, incoming: readonly string[]): string[] => {
+  const result = [...(existing ?? [])]
+  const seen = new Set(result)
+  for (const value of incoming) {
+    if (seen.has(value)) continue
+    seen.add(value)
+    result.push(value)
+  }
+  return result
+}
+
+// Reattach native Versions through the Session authority, preserving graph-only inactive Branches.
+const attachRecoveredMessageArtifacts = (
+  session: PersistedChatSession,
+  recoveries: RecoveredMessageArtifacts[]
+): PersistedChatSession => {
+  if (recoveries.length === 0) return session
+
+  const materialized = materializeSessionConversationGraph(session)
+  const messageIds = new Set([
+    ...materialized.messages.map((message) => message.id),
+    ...(materialized.conversationGraph?.messages.map((message) => message.id) ?? [])
+  ])
+  const recoveredByMessage = new Map<string, Map<string, PersistedArtifact>>()
+  for (const recovery of recoveries) {
+    if (!messageIds.has(recovery.messageId)) continue
+    const artifacts = recoveredByMessage.get(recovery.messageId) ?? new Map()
+    for (const artifact of recovery.artifacts) {
+      artifacts.set(artifact.id, toPersistedArtifact(artifact))
+    }
+    if (artifacts.size > 0) recoveredByMessage.set(recovery.messageId, artifacts)
+  }
+  if (recoveredByMessage.size === 0) return session
+
+  const nextArtifacts = [...(materialized.artifacts ?? [])]
+  const artifactIndexes = new Map(nextArtifacts.map((artifact, index) => [artifact.id, index]))
+  let artifactsChanged = false
+  for (const artifacts of recoveredByMessage.values()) {
+    for (const artifact of artifacts.values()) {
+      const index = artifactIndexes.get(artifact.id)
+      if (index === undefined) {
+        artifactIndexes.set(artifact.id, nextArtifacts.length)
+        nextArtifacts.push(artifact)
+        artifactsChanged = true
+      } else if (!persistedArtifactsEqual(nextArtifacts[index], artifact)) {
+        nextArtifacts[index] = artifact
+        artifactsChanged = true
+      }
+    }
+  }
+
+  const now = Date.now()
+  let flatMessagesChanged = false
+  const messages = materialized.messages.map((message) => {
+    const artifacts = recoveredByMessage.get(message.id)
+    if (!artifacts) return message
+    const artifactIds = appendUnique(message.artifactIds, [...artifacts.keys()])
+    if (artifactIds.length === (message.artifactIds?.length ?? 0)) return message
+    flatMessagesChanged = true
+    return { ...message, artifactIds, updatedAt: now }
+  })
+  let graphMessagesChanged = false
+  const conversationGraph = materialized.conversationGraph
+    ? {
+        ...materialized.conversationGraph,
+        messages: materialized.conversationGraph.messages.map((message) => {
+          const artifacts = recoveredByMessage.get(message.id)
+          if (!artifacts) return message
+          const artifactIds = appendUnique(message.artifactIds, [...artifacts.keys()])
+          if (artifactIds.length === (message.artifactIds?.length ?? 0)) return message
+          graphMessagesChanged = true
+          return { ...message, artifactIds, updatedAt: now }
+        })
+      }
+    : undefined
+
+  if (!artifactsChanged && !flatMessagesChanged && !graphMessagesChanged) return session
+  return {
+    ...materialized,
+    artifacts: nextArtifacts,
+    messages,
+    conversationGraph,
+    filesRevision: (materialized.filesRevision ?? 0) + 1,
+    updatedAt: now
+  }
+}
 
 // Serializes authoritative session JSON and derived file-index mutations through one queue. This is
 // the consistency boundary that prevents a late save from racing or reviving a durable deletion.
@@ -123,19 +242,20 @@ class SessionPersistenceCoordinator {
       const mayRunDestructiveStartupCleanup = this.destructiveStartupWindowOpen
       this.destructiveStartupWindowOpen = false
       const scan = await this.repository.loadAllWithDiagnostics()
+      let result = scan.result
+      let sessions = scan.result.sessions
 
       if (!scan.isComplete) {
         // Without the full active-session set, syncing could let a readable duplicate steal a row from
         // a soft-deleted owner whose JSON was merely unreadable during this scan.
         this.fileIndex.markReconciliationIncomplete()
-        return scan.result
+        return result
       }
 
-      let durableResult = scan.result
       try {
         if (this.uploads) {
-          const reconciledSessions = [...scan.result.sessions]
-          for (const [index, session] of scan.result.sessions.entries()) {
+          for (let index = 0; index < sessions.length; index += 1) {
+            const session = sessions[index]
             const requiresProjectionWrite = hasLegacySessionUpload(session)
             if (requiresProjectionWrite) {
               // Build the complete immutable projection without consuming any source. Promise.all
@@ -145,8 +265,10 @@ class SessionPersistenceCoordinator {
               })
               // Advance hydration before attempting the JSON write so a save failure still hands
               // callers the readable immutable projection produced by the completed live-save.
-              reconciledSessions[index] = upgradedSession
-              durableResult = { ...scan.result, sessions: [...reconciledSessions] }
+              sessions = sessions.map((candidate, candidateIndex) =>
+                candidateIndex === index ? upgradedSession : candidate
+              )
+              result = { ...result, sessions }
               // Persist every immutable identity before startup reconciliation can consume a legacy
               // source. A failed write remains retryable because live-save preserved every source.
               await this.repository.saveSession(upgradedSession)
@@ -163,28 +285,59 @@ class SessionPersistenceCoordinator {
           }
         }
 
-        await this.provenance?.reconcileSessionDeletions(durableResult.sessions)
-        for (const session of durableResult.sessions) {
-          await this.artifactStorage?.reconcileSession(session.projectId, session.id, session, {
-            removeOrphanStaging: mayRunDestructiveStartupCleanup
-          })
+        await this.provenance?.reconcileSessionDeletions(sessions)
+        const projectReconciliations = new Map<string, ArtifactProjectReconciliationSnapshot>()
+        if (this.artifactStorage) {
+          for (const projectId of new Set(sessions.map((session) => session.projectId))) {
+            projectReconciliations.set(
+              projectId,
+              await this.artifactStorage.prepareProjectReconciliation(projectId)
+            )
+          }
+        }
+        for (let index = 0; index < sessions.length; index += 1) {
+          const session = sessions[index]
+          const artifactRecovery = await this.artifactStorage?.reconcileSession(
+            session.projectId,
+            session.id,
+            session,
+            {
+              // Only the first process-level load is a startup boundary. Later renderer/task readers
+              // may inspect recovery state but cannot destructively clean storage held by live clients.
+              removeOrphanStaging: mayRunDestructiveStartupCleanup,
+              projectReconciliation: projectReconciliations.get(session.projectId)!
+            }
+          )
+          const recoveredSession = attachRecoveredMessageArtifacts(
+            session,
+            artifactRecovery?.recoveredMessageArtifacts ?? []
+          )
+          if (recoveredSession !== session) {
+            sessions = sessions.map((candidate, candidateIndex) =>
+              candidateIndex === index ? recoveredSession : candidate
+            )
+            result = { ...result, sessions }
+            // Capture immutable Message evidence before JSON. If either write fails, the unchanged
+            // Session remains an attachment witness on the next startup and the whole sequence retries.
+            await this.provenance?.captureFinalizedMessages(recoveredSession)
+            await this.repository.saveSession(recoveredSession)
+          }
         }
         // Reconciliation restores active owners left soft-deleted by an interrupted delete before any
         // scan-order-dependent sync can offer their canonical rows to another session.
-        await this.fileIndex.reconcileActiveSessions(durableResult.sessions)
+        await this.fileIndex.reconcileActiveSessions(sessions)
       } catch (error) {
         this.fileIndex.markReconciliationIncomplete()
         console.error('[session-persistence] startup reconciliation failed', error)
-        // Hydrate every Session whose immutable upgrade completed; later entries retain the scan
-        // projection. Files remains explicitly incomplete and the durable writes retry next startup.
-        return durableResult
+        // Keep chat hydration available while Files remains explicitly incomplete and retryable.
+        return result
       }
 
-      for (const session of durableResult.sessions) {
+      for (const session of sessions) {
         await this.fileIndex.syncSession(session).catch(() => undefined)
       }
 
-      return durableResult
+      return result
     })
   }
 

--- a/src/shared/artifact-provenance.ts
+++ b/src/shared/artifact-provenance.ts
@@ -89,6 +89,7 @@ export type FinalizeArtifactVersionsRequest = {
   projectId: string
   appSessionId: string
   artifactRunId: string
+  artifactVersionIds: string[]
   rootFrameId: string
   agentFrameId: string
   messageBranchId: string

--- a/src/shared/artifacts.ts
+++ b/src/shared/artifacts.ts
@@ -117,6 +117,7 @@ export type MovePendingRunArtifactsRequest = {
   sourceSessionId?: string
   runId: string
   messageId: string
+  artifactVersionIds?: string[]
   provenanceContext?: {
     rootFrameId: string
     agentFrameId: string


### PR DESCRIPTION
## Problem

Artifact publication can crash after the provider turn ends but before the renderer durably attaches generated files to the owning message. Recovery must prove ownership, preserve the exact immutable Version set, finish compatibility publication, and restore Session metadata without accepting late writes or hiding operational failures.

Follow-up to #481.

## Proposed change

- Persist an atomic prepared finalization intent before publishing the renderer event, including the exact non-empty Artifact Version IDs.
- Seal and drain both App and local-RPC write ingress before freezing the run claim.
- Infer only one terminal agent message proven by the durable graph root, Agent Frame, Branch, Runtime Segment, and prompt turn.
- Enforce proof -> database finalization -> compatibility publication -> Session attachment ordering, with idempotent retry after every crash window.
- Discover unfinished byte and metadata-only compatibility publications across active and inactive Branches; fail closed on corrupt, duplicate, ambiguous, or unreadable authority.
- Reconcile flat messages, graph messages, artifacts, and immutable Message snapshots while preserving truthful incomplete Files state on failure.
- Prepare compatibility discovery once per Project during `loadAll()`, route it as an opaque snapshot to each Session, and retain fresh scans for direct repository calls.

## Scope and non-goals

This PR only closes artifact finalization and recovery crash windows. It does not change producer conflict semantics or renderer UX.

## Acceptance criteria and validation

- Artifact/session targeted tests: 156 of 156 passed.
- Independent Standards/architecture and Spec/correctness reviews: pass, no remaining findings.
- Typecheck: passed for node and web.
- Lint: 0 errors; existing warnings only.
- Full suite on base `7980ad5`: 531 files passed; 7638 tests passed and 113 skipped.
- Diff and commit checks: passed.

## Review focus

Please focus on write-ingress drain semantics, ownership-proof strictness, exact Version-set recovery, compatibility discovery across Branches, fail-closed error propagation, snapshot-to-Session ordering, and per-Project discovery isolation.
