### PR TITLE
fix(uploads): migrate legacy bytes into immutable versions

### DIFF
--- a/src/main/ipc.ts
+++ b/src/main/ipc.ts
@@ -312,16 +312,12 @@ const registerIpcHandlers = async ({
       await projectDeletionCoordinator.recoverPendingDeletions()
       const created =
         (await sessionRepository.loadSession(session.projectId, session.id)) === undefined
-      await sessionPersistenceCoordinator.saveSession(session)
-      return created
+      const durableSession = await sessionPersistenceCoordinator.saveSession(session)
+      return { created, session: durableSession }
     },
     deleteSession: async (projectId, sessionId) => {
       await projectDeletionCoordinator.recoverPendingDeletions()
       return sessionPersistenceCoordinator.deleteSession(projectId, sessionId)
-    },
-    deleteProjectSessions: async (projectId) => {
-      await projectDeletionCoordinator.recoverPendingDeletions()
-      return sessionPersistenceCoordinator.deleteProjectSessions(projectId)
     },
     saveManifest: async (request) => {
       await projectDeletionCoordinator.recoverPendingDeletions()

--- a/src/main/projects/deletion-coordinator.test.ts
+++ b/src/main/projects/deletion-coordinator.test.ts
@@ -1,6 +1,10 @@
 import { afterEach, describe, expect, it, vi } from 'vitest'
 
-import { ProjectDeletionCoordinator, type ProjectDeletionRepository } from './deletion-coordinator'
+import {
+  ProjectDeletionCoordinator,
+  type ProjectDeletionRepository,
+  type ProjectSessionDeletion
+} from './deletion-coordinator'
 import { beginMigration, clearMigrationPending } from '../storage/migration-state'
 
 afterEach(() => clearMigrationPending())
@@ -17,11 +21,9 @@ const project = {
 describe('ProjectDeletionCoordinator', () => {
   it('rejects deletion recovery while a data-root migration is pending', async () => {
     const projects = createProjects()
-    const coordinator = new ProjectDeletionCoordinator(
-      projects,
-      { deleteProjectSessions: vi.fn().mockResolvedValue(undefined) },
-      { delete: vi.fn().mockResolvedValue(undefined) }
-    )
+    const coordinator = new ProjectDeletionCoordinator(projects, createSessions(), {
+      delete: vi.fn().mockResolvedValue(undefined)
+    })
     beginMigration()
 
     await expect(coordinator.recoverPendingDeletions()).rejects.toThrow(/moving your data/i)
@@ -30,7 +32,7 @@ describe('ProjectDeletionCoordinator', () => {
 
   it('deletes the project row, sessions, index, and preview state', async () => {
     const projects = createProjects()
-    const sessions = { deleteProjectSessions: vi.fn().mockResolvedValue(undefined) }
+    const sessions = createSessions()
     const preview = { delete: vi.fn().mockResolvedValue(undefined) }
     const reviews = { deleteReviewsForProject: vi.fn().mockResolvedValue(undefined) }
     const provenance = { deleteProjectProvenance: vi.fn().mockResolvedValue(undefined) }
@@ -55,9 +57,9 @@ describe('ProjectDeletionCoordinator', () => {
 
   it('keeps the project row and clears intent when session and index cleanup fails', async () => {
     const projects = createProjects()
-    const sessions = {
+    const sessions = createSessions({
       deleteProjectSessions: vi.fn().mockRejectedValue(new Error('directory busy'))
-    }
+    })
     const coordinator = new ProjectDeletionCoordinator(projects, sessions, {
       delete: vi.fn().mockResolvedValue(undefined)
     })
@@ -68,10 +70,26 @@ describe('ProjectDeletionCoordinator', () => {
     expect(projects.deleteDeletionIntent).toHaveBeenCalledWith('project-1')
   })
 
+  it('keeps an online intent when Session authority committed before a derived failure', async () => {
+    const projects = createProjects()
+    const sessions = createSessions({
+      deleteProjectSessions: vi.fn().mockRejectedValue(new Error('index unavailable')),
+      getProjectSessionDeletionState: vi.fn().mockResolvedValue('prepared')
+    })
+    const coordinator = new ProjectDeletionCoordinator(projects, sessions, {
+      delete: vi.fn().mockResolvedValue(undefined)
+    })
+
+    await expect(coordinator.deleteProject('project-1')).rejects.toThrow('index unavailable')
+
+    expect(projects.delete).not.toHaveBeenCalled()
+    expect(projects.deleteDeletionIntent).not.toHaveBeenCalled()
+  })
+
   it('replays durable deletion intents after a process restart', async () => {
     const projects = createProjects()
     projects.listDeletionIntents = vi.fn().mockResolvedValue(['project-1'])
-    const sessions = { deleteProjectSessions: vi.fn().mockResolvedValue(undefined) }
+    const sessions = createSessions()
     const reviews = { deleteReviewsForProject: vi.fn().mockResolvedValue(undefined) }
     const coordinator = new ProjectDeletionCoordinator(
       projects,
@@ -86,6 +104,220 @@ describe('ProjectDeletionCoordinator', () => {
     expect(projects.delete).toHaveBeenCalledWith('project-1')
     expect(projects.deleteDeletionIntent).toHaveBeenCalledWith('project-1')
     expect(reviews.deleteReviewsForProject).toHaveBeenCalledWith('project-1')
+    expect(sessions.listLegacyProjectSessionTombstones).toHaveBeenCalledOnce()
+  })
+
+  it('adopts an orphaned legacy tombstone into an intent before preparing its Session authority', async () => {
+    const order: string[] = []
+    const projects = createProjects()
+    projects.get = vi.fn().mockResolvedValue(null)
+    projects.createDeletionIntent = vi.fn(async () => {
+      order.push('intent-created')
+    })
+    projects.deleteDeletionIntent = vi.fn(async () => {
+      order.push('intent-removed')
+    })
+    const sessions = createSessions({
+      listLegacyProjectSessionTombstones: vi.fn().mockResolvedValue(['project-old']),
+      deleteProjectSessions: vi.fn(async () => {
+        order.push('sessions-prepared')
+        return { status: 'completed' as const }
+      }),
+      completeProjectSessionDeletion: vi.fn(async () => {
+        order.push('tombstone-removed')
+      })
+    })
+    const provenance = {
+      deleteProjectProvenance: vi.fn(async () => {
+        order.push('provenance-removed')
+      })
+    }
+    const coordinator = new ProjectDeletionCoordinator(
+      projects,
+      sessions,
+      { delete: vi.fn().mockResolvedValue(undefined) },
+      undefined,
+      provenance
+    )
+
+    await coordinator.recoverPendingDeletions()
+
+    expect(order).toEqual([
+      'intent-created',
+      'sessions-prepared',
+      'provenance-removed',
+      'tombstone-removed',
+      'intent-removed'
+    ])
+  })
+
+  it('retains an adopted legacy intent when retained index deletion fails', async () => {
+    const projects = createProjects()
+    projects.get = vi.fn().mockResolvedValue(null)
+    const sessions = createSessions({
+      listLegacyProjectSessionTombstones: vi.fn().mockResolvedValue(['project-old']),
+      deleteProjectSessions: vi.fn().mockRejectedValue(new Error('index temporarily unavailable'))
+    })
+    const coordinator = new ProjectDeletionCoordinator(projects, sessions, {
+      delete: vi.fn().mockResolvedValue(undefined)
+    })
+
+    await expect(coordinator.recoverPendingDeletions()).rejects.toThrow(
+      'index temporarily unavailable'
+    )
+
+    expect(projects.createDeletionIntent).toHaveBeenCalledWith('project-old')
+    expect(projects.deleteDeletionIntent).not.toHaveBeenCalled()
+    expect(sessions.completeProjectSessionDeletion).not.toHaveBeenCalled()
+  })
+
+  it('drops the temporary intent and continues when an adopted orphan must be retained', async () => {
+    const projects = createProjects()
+    projects.get = vi.fn().mockResolvedValue(null)
+    const sessions = createSessions({
+      listLegacyProjectSessionTombstones: vi.fn().mockResolvedValue(['project-old']),
+      deleteProjectSessions: vi.fn().mockResolvedValue({
+        status: 'orphan-retained',
+        reason: 'missing-upload-authority'
+      })
+    })
+    const coordinator = new ProjectDeletionCoordinator(projects, sessions, {
+      delete: vi.fn().mockResolvedValue(undefined)
+    })
+
+    await expect(coordinator.recoverPendingDeletions()).resolves.toBeUndefined()
+
+    expect(projects.createDeletionIntent).toHaveBeenCalledWith('project-old')
+    expect(projects.deleteDeletionIntent).toHaveBeenCalledWith('project-old')
+    expect(sessions.completeProjectSessionDeletion).not.toHaveBeenCalled()
+  })
+
+  it('re-derives orphan authority policy when replaying an adopted intent after restart', async () => {
+    const projects = createProjects()
+    projects.get = vi.fn().mockResolvedValue(null)
+    projects.listDeletionIntents = vi.fn().mockResolvedValue(['project-old'])
+    const sessions = createSessions({
+      getProjectSessionDeletionState: vi.fn().mockResolvedValue('legacy-committed')
+    })
+    const coordinator = new ProjectDeletionCoordinator(projects, sessions, {
+      delete: vi.fn().mockResolvedValue(undefined)
+    })
+
+    await coordinator.recoverPendingDeletions()
+
+    expect(sessions.deleteProjectSessions).toHaveBeenCalledWith('project-old', {
+      requireExistingUploadAuthority: true
+    })
+  })
+
+  it('releases a replayed orphan-retained intent without adopting it twice in one recovery', async () => {
+    const projects = createProjects()
+    projects.get = vi.fn().mockResolvedValue(null)
+    projects.listDeletionIntents = vi.fn().mockResolvedValue(['project-old'])
+    const sessions = createSessions({
+      getProjectSessionDeletionState: vi.fn().mockResolvedValue('legacy-committed'),
+      listLegacyProjectSessionTombstones: vi.fn().mockResolvedValue(['project-old']),
+      deleteProjectSessions: vi.fn().mockResolvedValue({
+        status: 'orphan-retained',
+        reason: 'missing-upload-authority'
+      })
+    })
+    const coordinator = new ProjectDeletionCoordinator(projects, sessions, {
+      delete: vi.fn().mockResolvedValue(undefined)
+    })
+
+    await expect(coordinator.recoverPendingDeletions()).resolves.toBeUndefined()
+
+    expect(sessions.deleteProjectSessions).toHaveBeenCalledOnce()
+    expect(projects.deleteDeletionIntent).toHaveBeenCalledWith('project-old')
+    expect(sessions.completeProjectSessionDeletion).not.toHaveBeenCalled()
+  })
+
+  it('clears a stale pre-commit recovery intent and continues with later Projects', async () => {
+    const projects = createProjects()
+    projects.listDeletionIntents = vi.fn().mockResolvedValue(['project-1', 'project-2'])
+    const sessions = createSessions({
+      deleteProjectSessions: vi.fn(async (projectId: string) => {
+        if (projectId === 'project-1') throw new Error('transient session cleanup failure')
+        return { status: 'completed' as const }
+      }),
+      getProjectSessionDeletionState: vi.fn().mockResolvedValue('live')
+    })
+    const coordinator = new ProjectDeletionCoordinator(projects, sessions, {
+      delete: vi.fn().mockResolvedValue(undefined)
+    })
+
+    await expect(coordinator.recoverPendingDeletions()).resolves.toBeUndefined()
+
+    expect(sessions.deleteProjectSessions).toHaveBeenCalledTimes(2)
+    expect(projects.deleteDeletionIntent).toHaveBeenCalledWith('project-1')
+    expect(projects.delete).not.toHaveBeenCalledWith('project-1')
+    expect(projects.delete).toHaveBeenCalledWith('project-2')
+    expect(projects.deleteDeletionIntent).toHaveBeenCalledWith('project-2')
+  })
+
+  it('keeps a committed recovery intent when the Project row still exists and replay fails', async () => {
+    const projects = createProjects()
+    projects.listDeletionIntents = vi.fn().mockResolvedValue(['project-1'])
+    const sessions = createSessions({
+      deleteProjectSessions: vi.fn().mockRejectedValue(new Error('tail cleanup unavailable')),
+      getProjectSessionDeletionState: vi.fn().mockResolvedValue('prepared')
+    })
+    const coordinator = new ProjectDeletionCoordinator(projects, sessions, {
+      delete: vi.fn().mockResolvedValue(undefined)
+    })
+
+    await expect(coordinator.recoverPendingDeletions()).rejects.toThrow('tail cleanup unavailable')
+
+    expect(projects.deleteDeletionIntent).not.toHaveBeenCalled()
+  })
+
+  it('keeps a recovery intent when durable Session phase state is unknown', async () => {
+    const projects = createProjects()
+    projects.listDeletionIntents = vi.fn().mockResolvedValue(['project-1'])
+    const replayFailure = new Error('session replay failed')
+    const sessions = createSessions({
+      deleteProjectSessions: vi.fn().mockRejectedValue(replayFailure),
+      getProjectSessionDeletionState: vi.fn().mockRejectedValue(new Error('marker unreadable'))
+    })
+    const coordinator = new ProjectDeletionCoordinator(projects, sessions, {
+      delete: vi.fn().mockResolvedValue(undefined)
+    })
+
+    await expect(coordinator.recoverPendingDeletions()).rejects.toBe(replayFailure)
+
+    expect(projects.deleteDeletionIntent).not.toHaveBeenCalled()
+  })
+
+  it('keeps a recovery intent when failed replay finds Session authority absent', async () => {
+    const projects = createProjects()
+    projects.listDeletionIntents = vi.fn().mockResolvedValue(['project-1'])
+    const sessions = createSessions({
+      deleteProjectSessions: vi.fn().mockRejectedValue(new Error('session replay failed')),
+      getProjectSessionDeletionState: vi.fn().mockResolvedValue('absent')
+    })
+    const coordinator = new ProjectDeletionCoordinator(projects, sessions, {
+      delete: vi.fn().mockResolvedValue(undefined)
+    })
+
+    await expect(coordinator.recoverPendingDeletions()).rejects.toThrow('session replay failed')
+
+    expect(projects.deleteDeletionIntent).not.toHaveBeenCalled()
+  })
+
+  it('keeps the intent when committed Session tombstone cleanup fails', async () => {
+    const projects = createProjects()
+    const sessions = createSessions({
+      completeProjectSessionDeletion: vi.fn().mockRejectedValue(new Error('tombstone busy'))
+    })
+    const coordinator = new ProjectDeletionCoordinator(projects, sessions, {
+      delete: vi.fn().mockResolvedValue(undefined)
+    })
+
+    await expect(coordinator.deleteProject('project-1')).rejects.toThrow('tombstone busy')
+
+    expect(projects.delete).toHaveBeenCalledWith('project-1')
+    expect(projects.deleteDeletionIntent).not.toHaveBeenCalled()
   })
 
   it('keeps the recovery intent until derived project cleanup has finished', async () => {
@@ -97,9 +329,14 @@ describe('ProjectDeletionCoordinator', () => {
     projects.deleteDeletionIntent = vi.fn(async () => {
       order.push('intent')
     })
+    const sessions = createSessions({
+      completeProjectSessionDeletion: vi.fn(async () => {
+        order.push('tombstone')
+      })
+    })
     const coordinator = new ProjectDeletionCoordinator(
       projects,
-      { deleteProjectSessions: vi.fn().mockResolvedValue(undefined) },
+      sessions,
       {
         delete: vi.fn(async () => {
           order.push('preview')
@@ -119,16 +356,14 @@ describe('ProjectDeletionCoordinator', () => {
 
     await coordinator.deleteProject('project-1')
 
-    expect(order).toEqual(['project', 'preview', 'reviews', 'provenance', 'intent'])
+    expect(order).toEqual(['project', 'preview', 'reviews', 'provenance', 'tombstone', 'intent'])
   })
 
   it('reuses a successful recovery gate for later operations', async () => {
     const projects = createProjects()
-    const coordinator = new ProjectDeletionCoordinator(
-      projects,
-      { deleteProjectSessions: vi.fn().mockResolvedValue(undefined) },
-      { delete: vi.fn().mockResolvedValue(undefined) }
-    )
+    const coordinator = new ProjectDeletionCoordinator(projects, createSessions(), {
+      delete: vi.fn().mockResolvedValue(undefined)
+    })
 
     await coordinator.recoverPendingDeletions()
     await coordinator.recoverPendingDeletions()
@@ -140,11 +375,12 @@ describe('ProjectDeletionCoordinator', () => {
     const deletionGate = createDeferred<void>()
     const coordinator = new ProjectDeletionCoordinator(
       createProjects(),
-      {
+      createSessions({
         deleteProjectSessions: vi.fn(async () => {
           await deletionGate.promise
+          return { status: 'completed' as const }
         })
-      },
+      }),
       { delete: vi.fn().mockResolvedValue(undefined) }
     )
     await coordinator.recoverPendingDeletions()
@@ -166,11 +402,12 @@ describe('ProjectDeletionCoordinator', () => {
   it('keeps recovery blocked until every concurrently requested deletion finishes', async () => {
     const firstGate = createDeferred<void>()
     const secondGate = createDeferred<void>()
-    const sessions = {
+    const sessions = createSessions({
       deleteProjectSessions: vi.fn(async (projectId: string) => {
         await (projectId === 'project-1' ? firstGate.promise : secondGate.promise)
+        return { status: 'completed' as const }
       })
-    }
+    })
     const coordinator = new ProjectDeletionCoordinator(createProjects(), sessions, {
       delete: vi.fn().mockResolvedValue(undefined)
     })
@@ -201,6 +438,16 @@ const createProjects = (): ProjectDeletionRepository => ({
   createDeletionIntent: vi.fn().mockResolvedValue(undefined),
   deleteDeletionIntent: vi.fn().mockResolvedValue(undefined),
   listDeletionIntents: vi.fn().mockResolvedValue([])
+})
+
+const createSessions = (
+  overrides: Partial<ProjectSessionDeletion> = {}
+): ProjectSessionDeletion => ({
+  deleteProjectSessions: vi.fn().mockResolvedValue({ status: 'completed' }),
+  getProjectSessionDeletionState: vi.fn().mockResolvedValue('absent'),
+  completeProjectSessionDeletion: vi.fn().mockResolvedValue(undefined),
+  listLegacyProjectSessionTombstones: vi.fn().mockResolvedValue([]),
+  ...overrides
 })
 
 const createDeferred = <T>(): { promise: Promise<T>; resolve: (value: T) => void } => {

--- a/src/main/projects/deletion-coordinator.ts
+++ b/src/main/projects/deletion-coordinator.ts
@@ -1,4 +1,6 @@
 import type { Project } from '../../shared/projects'
+import type { ProjectSessionDeletionResult } from '../session-persistence/coordinator'
+import type { ProjectSessionDeletionState } from '../session-persistence/repository'
 import { withDataRootWrite } from '../storage/migration-state'
 
 type ProjectDeletionRepository = {
@@ -10,7 +12,15 @@ type ProjectDeletionRepository = {
 }
 
 type ProjectSessionDeletion = {
-  deleteProjectSessions(projectId: string): Promise<void>
+  // This capability is intentionally wired only into the durable whole-Project intent coordinator;
+  // ordinary Session IPC must use the strict per-Session deletion path instead.
+  deleteProjectSessions(
+    projectId: string,
+    options?: { requireExistingUploadAuthority?: boolean }
+  ): Promise<ProjectSessionDeletionResult>
+  getProjectSessionDeletionState(projectId: string): Promise<ProjectSessionDeletionState>
+  completeProjectSessionDeletion(projectId: string): Promise<void>
+  listLegacyProjectSessionTombstones(): Promise<string[]>
 }
 
 type PreviewDeletion = {
@@ -73,7 +83,9 @@ class ProjectDeletionCoordinator {
     if (this.recoveryPromise) return this.recoveryPromise
     if (this.isRecoveryComplete) return
 
-    const recovery = this.runPendingDeletionRecovery()
+    const recovery = this.runPendingDeletionRecovery().then((retainedProjectIds) =>
+      this.adoptLegacyProjectSessionTombstones(retainedProjectIds)
+    )
     this.recoveryPromise = recovery
     try {
       await recovery
@@ -96,7 +108,14 @@ class ProjectDeletionCoordinator {
     try {
       await this.sessions.deleteProjectSessions(projectId)
     } catch (error) {
-      await this.projects.deleteDeletionIntent(projectId)
+      try {
+        const state = await this.sessions.getProjectSessionDeletionState(projectId)
+        if (state === 'live' || state === 'absent') {
+          await this.projects.deleteDeletionIntent(projectId)
+        }
+      } catch {
+        // Unknown durable Session state is fail-closed; retain the intent for recovery.
+      }
       throw error
     }
 
@@ -104,10 +123,69 @@ class ProjectDeletionCoordinator {
   }
 
   // Replays intents serially so crash recovery follows the same ordering as an online deletion.
-  private async runPendingDeletionRecovery(): Promise<void> {
+  private async runPendingDeletionRecovery(): Promise<Set<string>> {
     const projectIds = await this.projects.listDeletionIntents()
+    const retainedProjectIds = new Set<string>()
     for (const projectId of projectIds) {
-      await this.sessions.deleteProjectSessions(projectId)
+      let result: ProjectSessionDeletionResult
+      try {
+        // An absent Project plus an unmarked tombstone identifies a cross-version orphan adoption.
+        // Re-derive its conservative policy from durable state so a crash immediately after intent
+        // creation cannot turn the next retry into authority-creating normal deletion.
+        const requireExistingUploadAuthority =
+          !(await this.projects.get(projectId)) &&
+          (await this.sessions.getProjectSessionDeletionState(projectId)) === 'legacy-committed'
+        if (requireExistingUploadAuthority) {
+          result = await this.sessions.deleteProjectSessions(projectId, {
+            requireExistingUploadAuthority: true
+          })
+        } else {
+          result = await this.sessions.deleteProjectSessions(projectId)
+        }
+      } catch (error) {
+        // A visible Project row is insufficient evidence of a pre-commit failure: a crash may occur
+        // after the atomic Session rename but before deleting that row. Clear the intent only when
+        // the durable tombstone positively proves the Session phase never committed. Unknown marker
+        // state and committed state both retain the intent and retry the irreversible tail.
+        let sessionState: ProjectSessionDeletionState
+        try {
+          sessionState = await this.sessions.getProjectSessionDeletionState(projectId)
+        } catch {
+          throw error
+        }
+        if (sessionState === 'live' && (await this.projects.get(projectId))) {
+          await this.projects.deleteDeletionIntent(projectId)
+          continue
+        }
+        throw error
+      }
+      if (result.status === 'orphan-retained') {
+        await this.projects.deleteDeletionIntent(projectId)
+        retainedProjectIds.add(projectId)
+        continue
+      }
+      await this.finishDeletion(projectId)
+    }
+    return retainedProjectIds
+  }
+
+  // Older releases could remove the Project row and intent before their best-effort physical
+  // tombstone cleanup. Adopt every surviving unmarked tombstone into the durable intent protocol
+  // before its Session migration can write a prepared marker or create new Version authority.
+  private async adoptLegacyProjectSessionTombstones(
+    retainedProjectIds: ReadonlySet<string>
+  ): Promise<void> {
+    const projectIds = await this.sessions.listLegacyProjectSessionTombstones()
+    for (const projectId of projectIds) {
+      if (retainedProjectIds.has(projectId)) continue
+      await this.projects.createDeletionIntent(projectId)
+      const result = await this.sessions.deleteProjectSessions(projectId, {
+        requireExistingUploadAuthority: true
+      })
+      if (result.status === 'orphan-retained') {
+        await this.projects.deleteDeletionIntent(projectId)
+        continue
+      }
       await this.finishDeletion(projectId)
     }
   }
@@ -129,7 +207,11 @@ class ProjectDeletionCoordinator {
     // removed even if the Project row is already gone.
     await this.provenance?.deleteProjectProvenance(projectId)
 
-    // Keep the intent until all derived cleanup has been attempted so a crash replays the full tail.
+    // The marked Session tombstone is the durable phase boundary. Remove it only after every Project
+    // tail has completed, and keep the intent if physical cleanup fails so recovery retries it.
+    await this.sessions.completeProjectSessionDeletion(projectId)
+
+    // Keep the intent until all derived and tombstone cleanup has completed.
     await this.projects.deleteDeletionIntent(projectId)
   }
 }

--- a/src/main/session-persistence/coordinator.test.ts
+++ b/src/main/session-persistence/coordinator.test.ts
@@ -1,6 +1,15 @@
+import { mkdir, mkdtemp, readFile, rm, writeFile } from 'node:fs/promises'
+import { tmpdir } from 'node:os'
+import { dirname, join } from 'node:path'
 import { describe, expect, it, vi } from 'vitest'
 
 import type { PersistedChatSession } from '../../shared/session-persistence'
+import { createProjectDbClient, ensureProjectSchema } from '../projects/prisma-client'
+import {
+  OrphanLegacyUploadAuthorityMissingError,
+  UnsafeLegacyUploadResidualError,
+  UploadRepository
+} from '../uploads/repository'
 import {
   SessionPersistenceCoordinator,
   type SessionFileIndex,
@@ -19,6 +28,49 @@ const createSession = (overrides: Partial<PersistedChatSession> = {}): Persisted
   updatedAt: 2,
   ...overrides
 })
+
+const createLegacyUploadSession = (sessionId: string): PersistedChatSession =>
+  createSession({
+    id: sessionId,
+    messages: [
+      {
+        id: `${sessionId}-message`,
+        role: 'user',
+        content: 'legacy upload',
+        status: 'complete',
+        eventIds: [],
+        uploads: [
+          {
+            id: `${sessionId}-upload`,
+            sessionId,
+            name: 'legacy.csv',
+            originalName: 'legacy.csv',
+            path: `/legacy/${sessionId}/legacy.csv`,
+            size: 11
+          }
+        ],
+        createdAt: 1,
+        updatedAt: 1
+      }
+    ]
+  })
+
+const toVersionedUploadSession = (session: PersistedChatSession): PersistedChatSession => {
+  const upgraded = structuredClone(session)
+  upgraded.messages[0].uploads = [
+    {
+      id: `${session.id}-upload`,
+      versionId: `${session.id}-upload-version`,
+      versionNumber: 1,
+      sessionId: session.id,
+      name: 'legacy.csv',
+      originalName: 'legacy.csv',
+      size: 11,
+      sha256: 'a'.repeat(64)
+    }
+  ]
+  return upgraded
+}
 
 describe('SessionPersistenceCoordinator', () => {
   it('serializes a pending save before deletion and rejects saves after the tombstone', async () => {
@@ -65,6 +117,29 @@ describe('SessionPersistenceCoordinator', () => {
     expect(repository.saveSession).toHaveBeenCalledOnce()
   })
 
+  it('returns the exact durable Session after publishing legacy Uploads in live-safe mode', async () => {
+    const legacySession = createLegacyUploadSession('session-1')
+    const durableSession = toVersionedUploadSession(legacySession)
+    const uploads = {
+      upgradeLegacySessionUploads: vi.fn().mockResolvedValue(durableSession)
+    }
+    const repository = createSessionRepository()
+    const coordinator = new SessionPersistenceCoordinator(
+      repository,
+      createFileIndex(),
+      undefined,
+      undefined,
+      uploads
+    )
+
+    await expect(coordinator.saveSession(legacySession)).resolves.toBe(durableSession)
+    expect(uploads.upgradeLegacySessionUploads).toHaveBeenCalledWith(
+      expect.objectContaining({ id: 'session-1' }),
+      { mode: 'live-save' }
+    )
+    expect(repository.saveSession).toHaveBeenCalledWith(durableSession)
+  })
+
   it('restores DB visibility and clears the tombstone when JSON deletion fails', async () => {
     const repository = createSessionRepository({
       deleteSession: vi.fn().mockRejectedValueOnce(new Error('disk locked'))
@@ -80,14 +155,16 @@ describe('SessionPersistenceCoordinator', () => {
       'delete-session-operation'
     )
 
-    await expect(coordinator.saveSession(createSession())).resolves.toBeUndefined()
+    await expect(coordinator.saveSession(createSession())).resolves.toMatchObject({
+      id: 'session-1'
+    })
     expect(repository.saveSession).toHaveBeenCalledOnce()
   })
 
   it('retains native Project files and completes the origin tombstone after JSON deletion', async () => {
     const session = createSession({ title: 'Retained analysis' })
     const repository = createSessionRepository({
-      loadSession: vi.fn().mockResolvedValue(session)
+      loadSessionWithDiagnostics: vi.fn().mockResolvedValue({ status: 'found', session })
     })
     const fileIndex = createFileIndex()
     const onFilesChanged = vi.fn()
@@ -168,7 +245,9 @@ describe('SessionPersistenceCoordinator', () => {
       }
     ]
     const repository = createSessionRepository({
-      loadSession: vi.fn().mockResolvedValue(legacySession),
+      loadSessionWithDiagnostics: vi
+        .fn()
+        .mockResolvedValue({ status: 'found', session: legacySession }),
       saveSession: vi.fn(async () => {
         order.push('save-upgraded')
       }),
@@ -177,9 +256,14 @@ describe('SessionPersistenceCoordinator', () => {
       })
     })
     const uploads = {
-      upgradeLegacySessionUploads: vi.fn(async () => {
-        order.push('upgrade')
-        return upgradedSession
+      upgradeLegacySessionUploads: vi.fn(async (session, options) => {
+        if (options?.mode === 'live-save') {
+          order.push('upgrade-live')
+          return upgradedSession
+        }
+        order.push('cleanup-terminal')
+        expect(session).toBe(upgradedSession)
+        return session
       })
     }
     const provenance = {
@@ -206,14 +290,64 @@ describe('SessionPersistenceCoordinator', () => {
 
     await coordinator.deleteSession('project-1', 'session-1')
 
-    expect(order).toEqual(['upgrade', 'save-upgraded', 'prepare-delete', 'delete-json'])
+    expect(order).toEqual([
+      'upgrade-live',
+      'save-upgraded',
+      'cleanup-terminal',
+      'prepare-delete',
+      'delete-json'
+    ])
+    expect(uploads.upgradeLegacySessionUploads).toHaveBeenNthCalledWith(1, legacySession, {
+      mode: 'live-save'
+    })
+    expect(uploads.upgradeLegacySessionUploads).toHaveBeenNthCalledWith(2, upgradedSession, {
+      mode: 'terminal-delete'
+    })
     expect(provenance.prepareSessionDeletion).toHaveBeenCalledWith(upgradedSession)
+  })
+
+  it('retains a legacy Session source when its path-free projection cannot be saved before deletion', async () => {
+    const legacySession = createLegacyUploadSession('session-1')
+    const upgradedSession = toVersionedUploadSession(legacySession)
+    let legacySourceRemoved = false
+    const repository = createSessionRepository({
+      loadSessionWithDiagnostics: vi
+        .fn()
+        .mockResolvedValue({ status: 'found', session: legacySession }),
+      saveSession: vi.fn().mockRejectedValue(new Error('session file unavailable'))
+    })
+    const uploads = {
+      upgradeLegacySessionUploads: vi.fn(async (_session, options) => {
+        if (options?.mode === 'terminal-delete') legacySourceRemoved = true
+        return upgradedSession
+      })
+    }
+    const fileIndex = createFileIndex()
+    const coordinator = new SessionPersistenceCoordinator(
+      repository,
+      fileIndex,
+      undefined,
+      undefined,
+      uploads
+    )
+
+    await expect(coordinator.deleteSession('project-1', 'session-1')).rejects.toThrow(
+      'session file unavailable'
+    )
+
+    expect(uploads.upgradeLegacySessionUploads).toHaveBeenCalledOnce()
+    expect(uploads.upgradeLegacySessionUploads).toHaveBeenCalledWith(legacySession, {
+      mode: 'live-save'
+    })
+    expect(legacySourceRemoved).toBe(false)
+    expect(fileIndex.softDeleteSession).not.toHaveBeenCalled()
+    expect(repository.deleteSession).not.toHaveBeenCalled()
   })
 
   it('aborts a retained origin tombstone when JSON deletion fails', async () => {
     const session = createSession()
     const repository = createSessionRepository({
-      loadSession: vi.fn().mockResolvedValue(session),
+      loadSessionWithDiagnostics: vi.fn().mockResolvedValue({ status: 'found', session }),
       deleteSession: vi.fn().mockRejectedValueOnce(new Error('disk locked'))
     })
     const fileIndex = createFileIndex()
@@ -258,7 +392,9 @@ describe('SessionPersistenceCoordinator', () => {
       'database unavailable'
     )
     expect(markReconciliationIncomplete).toHaveBeenCalledOnce()
-    await expect(coordinator.saveSession(createSession())).resolves.toBeUndefined()
+    await expect(coordinator.saveSession(createSession())).resolves.toMatchObject({
+      id: 'session-1'
+    })
   })
 
   it('hydrates sessions after indexing and reconciles only a complete scan', async () => {
@@ -289,6 +425,404 @@ describe('SessionPersistenceCoordinator', () => {
     )
     expect(fileIndex.syncSession).toHaveBeenCalledWith(session)
     expect(fileIndex.reconcileActiveSessions).toHaveBeenCalledWith([session])
+  })
+
+  it('reconciles path-free Upload copies only on the first complete load from multiple clients', async () => {
+    const root = await mkdtemp(join(tmpdir(), 'open-science-upload-startup-reconcile-'))
+    const client = createProjectDbClient(root)
+    await ensureProjectSchema(client)
+    const content = Buffer.from('sample,value\na,1\n')
+    const checksum = '5fe3f7b7e3492c63599954312dcb1e1d78488782753b6d3068c8d03292c7c1f6'
+    const contentStorageKey =
+      'uploads/project-1/session-1/upload-1/versions/upload-version-1/content'
+    const finalPath = join(root, ...contentStorageKey.split('/'))
+    const legacyPath = join(root, 'uploads', 'default-project', 'session-1', 'legacy.csv')
+    await mkdir(dirname(finalPath), { recursive: true })
+    await mkdir(dirname(legacyPath), { recursive: true })
+    await writeFile(finalPath, content)
+    await writeFile(legacyPath, content)
+    await client.fileOriginSession.create({
+      data: { projectId: 'project-1', sessionId: 'session-1' }
+    })
+    await client.uploadFile.create({
+      data: {
+        id: 'upload-1',
+        projectId: 'project-1',
+        sessionId: 'session-1',
+        filename: 'legacy.csv',
+        originalFilename: 'legacy.csv',
+        versions: {
+          create: {
+            id: 'upload-version-1',
+            versionNumber: 1,
+            state: 'ready',
+            contentStorageKey,
+            filename: 'legacy.csv',
+            originalFilename: 'legacy.csv',
+            contentType: 'text/csv',
+            sizeBytes: BigInt(content.byteLength),
+            checksum
+          }
+        }
+      }
+    })
+    const session = createSession({
+      messages: [
+        {
+          id: 'message-1',
+          role: 'user',
+          content: 'path-free upload',
+          status: 'complete',
+          eventIds: [],
+          uploads: [
+            {
+              id: 'upload-1',
+              versionId: 'upload-version-1',
+              versionNumber: 1,
+              sessionId: 'session-1',
+              name: 'legacy.csv',
+              originalName: 'legacy.csv',
+              size: content.byteLength,
+              sha256: checksum
+            }
+          ],
+          createdAt: 1,
+          updatedAt: 1
+        }
+      ]
+    })
+    const result = { sessions: [session], manifest: { version: 1 as const } }
+    const repository = createSessionRepository({
+      loadAllWithDiagnostics: vi.fn().mockResolvedValue({ result, isComplete: true })
+    })
+    const uploads = new UploadRepository(root, { getClient: () => Promise.resolve(client) })
+    const fileIndex = createFileIndex()
+    const coordinator = new SessionPersistenceCoordinator(
+      repository,
+      fileIndex,
+      undefined,
+      undefined,
+      uploads
+    )
+
+    try {
+      // No one-time normalizer participates here, representing pathsNormalizedAt already being set.
+      await expect(coordinator.loadAll()).resolves.toBe(result)
+
+      await expect(readFile(legacyPath)).rejects.toMatchObject({ code: 'ENOENT' })
+      await expect(readFile(finalPath)).resolves.toEqual(content)
+      expect(repository.saveSession).not.toHaveBeenCalled()
+      expect(fileIndex.reconcileActiveSessions).toHaveBeenCalledWith([session])
+      expect(fileIndex.syncSession).toHaveBeenCalledWith(session)
+
+      // A later renderer/task load is live-safe. Even if a historical path reappears, that call must
+      // not remove bytes that another already-hydrated client could still be rendering.
+      await writeFile(legacyPath, content)
+      await expect(coordinator.loadAll()).resolves.toBe(result)
+      await expect(readFile(legacyPath)).resolves.toEqual(content)
+    } finally {
+      await client.$disconnect()
+      await rm(root, { recursive: true, force: true })
+    }
+  })
+
+  it('persists path-only Upload upgrades before startup indexing', async () => {
+    const legacySession = createSession({
+      messages: [
+        {
+          id: 'message-1',
+          role: 'user',
+          content: 'legacy upload',
+          status: 'complete',
+          eventIds: [],
+          uploads: [
+            {
+              id: 'upload-1',
+              sessionId: 'session-1',
+              name: 'legacy.csv',
+              originalName: 'legacy.csv',
+              path: '/legacy/legacy.csv',
+              size: 11
+            }
+          ],
+          createdAt: 1,
+          updatedAt: 1
+        }
+      ]
+    })
+    const upgradedSession = structuredClone(legacySession)
+    upgradedSession.messages[0].uploads = [
+      {
+        id: 'upload-1',
+        versionId: 'upload-version-1',
+        versionNumber: 1,
+        sessionId: 'session-1',
+        name: 'legacy.csv',
+        originalName: 'legacy.csv',
+        size: 11,
+        sha256: 'a'.repeat(64)
+      }
+    ]
+    const result = { sessions: [legacySession], manifest: { version: 1 as const } }
+    const repository = createSessionRepository({
+      loadAllWithDiagnostics: vi.fn().mockResolvedValue({ result, isComplete: true })
+    })
+    const uploads = {
+      upgradeLegacySessionUploads: vi.fn().mockResolvedValue(upgradedSession)
+    }
+    const fileIndex = createFileIndex()
+    const coordinator = new SessionPersistenceCoordinator(
+      repository,
+      fileIndex,
+      undefined,
+      undefined,
+      uploads
+    )
+
+    const loaded = await coordinator.loadAll()
+
+    expect(loaded.sessions).toEqual([upgradedSession])
+    expect(uploads.upgradeLegacySessionUploads).toHaveBeenNthCalledWith(1, legacySession, {
+      mode: 'live-save'
+    })
+    expect(uploads.upgradeLegacySessionUploads).toHaveBeenNthCalledWith(2, upgradedSession, {
+      mode: 'reconcile'
+    })
+    expect(repository.saveSession).toHaveBeenCalledWith(upgradedSession)
+    expect(fileIndex.reconcileActiveSessions).toHaveBeenCalledWith([upgradedSession])
+    expect(fileIndex.syncSession).toHaveBeenCalledWith(upgradedSession)
+  })
+
+  it('retains every legacy source when one Upload prevents a complete startup projection', async () => {
+    const root = await mkdtemp(join(tmpdir(), 'open-science-upload-startup-partial-'))
+    const client = createProjectDbClient(root)
+    await ensureProjectSchema(client)
+    const content = Buffer.from('sample,value\na,1\n')
+    const retainedPath = join(root, 'uploads', 'default-project', 'session-1', 'retained.csv')
+    const missingPath = join(root, 'uploads', 'default-project', 'session-1', 'missing.csv')
+    await mkdir(dirname(retainedPath), { recursive: true })
+    await writeFile(retainedPath, content)
+    const legacySession = createSession({
+      messages: [
+        {
+          id: 'message-1',
+          role: 'user',
+          content: 'partially recoverable uploads',
+          status: 'complete',
+          eventIds: [],
+          uploads: [
+            {
+              id: 'upload-retained',
+              sessionId: 'session-1',
+              name: 'retained.csv',
+              originalName: 'retained.csv',
+              path: retainedPath,
+              size: content.byteLength
+            },
+            {
+              id: 'upload-missing',
+              sessionId: 'session-1',
+              name: 'missing.csv',
+              originalName: 'missing.csv',
+              path: missingPath,
+              size: content.byteLength
+            }
+          ],
+          createdAt: 1,
+          updatedAt: 1
+        }
+      ]
+    })
+    const result = { sessions: [legacySession], manifest: { version: 1 as const } }
+    const repository = createSessionRepository({
+      loadAllWithDiagnostics: vi.fn().mockResolvedValue({ result, isComplete: true })
+    })
+    const uploads = new UploadRepository(root, { getClient: () => Promise.resolve(client) })
+    const upgradeSpy = vi.spyOn(uploads, 'upgradeLegacySessionUploads')
+    const markReconciliationIncomplete = vi.fn()
+    const fileIndex = createFileIndex({ markReconciliationIncomplete })
+    const coordinator = new SessionPersistenceCoordinator(
+      repository,
+      fileIndex,
+      undefined,
+      undefined,
+      uploads
+    )
+
+    try {
+      await expect(coordinator.loadAll()).resolves.toBe(result)
+
+      await vi.waitFor(async () => {
+        await expect(
+          client.uploadVersion.findFirst({
+            where: { uploadFileId: 'upload-retained', state: 'ready' }
+          })
+        ).resolves.toBeTruthy()
+      })
+      await expect(readFile(retainedPath)).resolves.toEqual(content)
+      expect(upgradeSpy).toHaveBeenCalledWith(legacySession, { mode: 'live-save' })
+      expect(repository.saveSession).not.toHaveBeenCalled()
+      expect(markReconciliationIncomplete).toHaveBeenCalledOnce()
+      expect(fileIndex.reconcileActiveSessions).not.toHaveBeenCalled()
+    } finally {
+      await client.$disconnect()
+      await rm(root, { recursive: true, force: true })
+    }
+  })
+
+  it('closes destructive startup cleanup after an incomplete first load', async () => {
+    const legacySession = createLegacyUploadSession('session-1')
+    const upgradedSession = toVersionedUploadSession(legacySession)
+    const incomplete = {
+      result: { sessions: [], manifest: { version: 1 as const } },
+      isComplete: false
+    }
+    const complete = {
+      result: { sessions: [legacySession], manifest: { version: 1 as const } },
+      isComplete: true
+    }
+    const repository = createSessionRepository({
+      loadAllWithDiagnostics: vi
+        .fn()
+        .mockResolvedValueOnce(incomplete)
+        .mockResolvedValueOnce(complete)
+    })
+    const uploads = {
+      upgradeLegacySessionUploads: vi.fn().mockResolvedValue(upgradedSession)
+    }
+    const artifactStorage = { reconcileSession: vi.fn().mockResolvedValue(undefined) }
+    const coordinator = new SessionPersistenceCoordinator(
+      repository,
+      createFileIndex(),
+      undefined,
+      undefined,
+      uploads,
+      artifactStorage
+    )
+
+    await expect(coordinator.loadAll()).resolves.toBe(incomplete.result)
+    await expect(coordinator.loadAll()).resolves.toEqual({
+      sessions: [upgradedSession],
+      manifest: complete.result.manifest
+    })
+
+    expect(uploads.upgradeLegacySessionUploads).toHaveBeenCalledOnce()
+    expect(uploads.upgradeLegacySessionUploads).toHaveBeenCalledWith(legacySession, {
+      mode: 'live-save'
+    })
+    expect(repository.saveSession).toHaveBeenCalledWith(upgradedSession)
+    expect(artifactStorage.reconcileSession).toHaveBeenCalledWith(
+      'project-1',
+      'session-1',
+      upgradedSession,
+      { removeOrphanStaging: false }
+    )
+  })
+
+  it('marks startup reconciliation incomplete when one Session Upload reconciliation fails', async () => {
+    const first = createLegacyUploadSession('session-1')
+    const upgradedFirst = toVersionedUploadSession(first)
+    const second = createLegacyUploadSession('session-2')
+    const result = { sessions: [first, second], manifest: { version: 1 as const } }
+    let persistedFirst: PersistedChatSession | undefined
+    const repository = createSessionRepository({
+      loadAllWithDiagnostics: vi.fn().mockResolvedValue({ result, isComplete: true }),
+      saveSession: vi.fn(async (session) => {
+        persistedFirst = structuredClone(session)
+      })
+    })
+    const uploads = {
+      upgradeLegacySessionUploads: vi
+        .fn()
+        .mockResolvedValueOnce(upgradedFirst)
+        .mockRejectedValueOnce(new Error('upload reconciliation failed'))
+    }
+    const markReconciliationIncomplete = vi.fn()
+    const fileIndex = createFileIndex({ markReconciliationIncomplete })
+    const coordinator = new SessionPersistenceCoordinator(
+      repository,
+      fileIndex,
+      undefined,
+      undefined,
+      uploads
+    )
+
+    const loaded = await coordinator.loadAll()
+
+    expect(loaded.sessions).toEqual([upgradedFirst, second])
+    expect(persistedFirst).toEqual(upgradedFirst)
+    expect(uploads.upgradeLegacySessionUploads).toHaveBeenNthCalledWith(1, first, {
+      mode: 'live-save'
+    })
+    expect(uploads.upgradeLegacySessionUploads).toHaveBeenNthCalledWith(2, upgradedFirst, {
+      mode: 'reconcile'
+    })
+    expect(markReconciliationIncomplete).toHaveBeenCalledOnce()
+    expect(fileIndex.reconcileActiveSessions).not.toHaveBeenCalled()
+    expect(fileIndex.syncSession).not.toHaveBeenCalled()
+  })
+
+  it('hydrates an upgraded Session when its authoritative startup save fails', async () => {
+    const session = createLegacyUploadSession('session-1')
+    const upgradedSession = toVersionedUploadSession(session)
+    const result = { sessions: [session], manifest: { version: 1 as const } }
+    const repository = createSessionRepository({
+      loadAllWithDiagnostics: vi.fn().mockResolvedValue({ result, isComplete: true }),
+      saveSession: vi.fn().mockRejectedValue(new Error('session file unavailable'))
+    })
+    const uploads = {
+      upgradeLegacySessionUploads: vi.fn().mockResolvedValue(upgradedSession)
+    }
+    const markReconciliationIncomplete = vi.fn()
+    const fileIndex = createFileIndex({ markReconciliationIncomplete })
+    const coordinator = new SessionPersistenceCoordinator(
+      repository,
+      fileIndex,
+      undefined,
+      undefined,
+      uploads
+    )
+
+    const loaded = await coordinator.loadAll()
+
+    expect(loaded.sessions).toEqual([upgradedSession])
+    expect(uploads.upgradeLegacySessionUploads).toHaveBeenCalledOnce()
+    expect(uploads.upgradeLegacySessionUploads).toHaveBeenCalledWith(session, {
+      mode: 'live-save'
+    })
+    expect(markReconciliationIncomplete).toHaveBeenCalledOnce()
+    expect(fileIndex.reconcileActiveSessions).not.toHaveBeenCalled()
+  })
+
+  it('does not roll back upgraded hydration when downstream startup reconciliation fails', async () => {
+    const session = createLegacyUploadSession('session-1')
+    const upgradedSession = toVersionedUploadSession(session)
+    const result = { sessions: [session], manifest: { version: 1 as const } }
+    const repository = createSessionRepository({
+      loadAllWithDiagnostics: vi.fn().mockResolvedValue({ result, isComplete: true })
+    })
+    const uploads = {
+      upgradeLegacySessionUploads: vi.fn().mockResolvedValue(upgradedSession)
+    }
+    const markReconciliationIncomplete = vi.fn()
+    const fileIndex = createFileIndex({
+      markReconciliationIncomplete,
+      reconcileActiveSessions: vi.fn().mockRejectedValue(new Error('index unavailable'))
+    })
+    const coordinator = new SessionPersistenceCoordinator(
+      repository,
+      fileIndex,
+      undefined,
+      undefined,
+      uploads
+    )
+
+    const loaded = await coordinator.loadAll()
+
+    expect(loaded.sessions).toEqual([upgradedSession])
+    expect(repository.saveSession).toHaveBeenCalledWith(upgradedSession)
+    expect(markReconciliationIncomplete).toHaveBeenCalledOnce()
+    expect(fileIndex.syncSession).not.toHaveBeenCalled()
   })
 
   it('reconciles active owners before syncing sessions from a complete startup scan', async () => {
@@ -411,7 +945,7 @@ describe('SessionPersistenceCoordinator', () => {
     expect(fileIndex.reconcileActiveSessions).toHaveBeenCalledWith([session])
   })
 
-  it('restores a project index when deleting its session directory fails', async () => {
+  it('leaves the project index untouched when authoritative Session rename fails', async () => {
     const repository = createSessionRepository({
       deleteProjectSessions: vi.fn().mockRejectedValueOnce(new Error('directory busy'))
     })
@@ -419,9 +953,404 @@ describe('SessionPersistenceCoordinator', () => {
     const coordinator = new SessionPersistenceCoordinator(repository, fileIndex)
 
     await expect(coordinator.deleteProjectSessions('project-1')).rejects.toThrow('directory busy')
+    expect(fileIndex.softDeleteProject).not.toHaveBeenCalled()
+    await expect(coordinator.saveSession(createSession())).resolves.toMatchObject({
+      id: 'session-1'
+    })
+  })
+
+  it('retains the Project tombstone and retries a derived index failure after Session commit', async () => {
+    const repository = createSessionRepository({
+      getProjectSessionDeletionState: vi.fn().mockResolvedValue('prepared')
+    })
+    const fileIndex = createFileIndex({
+      softDeleteProject: vi
+        .fn()
+        .mockRejectedValueOnce(new Error('index unavailable'))
+        .mockResolvedValue('delete-project-operation')
+    })
+    const coordinator = new SessionPersistenceCoordinator(repository, fileIndex)
+
+    await expect(coordinator.deleteProjectSessions('project-1')).rejects.toThrow(
+      'index unavailable'
+    )
+    await expect(coordinator.saveSession(createSession())).rejects.toThrow(/project.*deleted/i)
+    expect(repository.deleteProjectSessions).toHaveBeenCalledOnce()
+
+    await expect(coordinator.deleteProjectSessions('project-1')).resolves.toEqual({
+      status: 'completed'
+    })
+    expect(repository.deleteProjectSessions).toHaveBeenCalledTimes(2)
+    expect(fileIndex.softDeleteProject).toHaveBeenCalledTimes(2)
+  })
+
+  it('retries committed tombstone cleanup after persisting its path-free Session projection', async () => {
+    const legacySession = createLegacyUploadSession('session-1')
+    const upgradedSession = toVersionedUploadSession(legacySession)
+    let durableSession = legacySession
+    const repository = createSessionRepository({
+      getProjectSessionDeletionState: vi.fn().mockResolvedValue('legacy-committed'),
+      loadCommittedProjectWithDiagnostics: vi.fn(async () => ({
+        sessions: [durableSession],
+        isComplete: true
+      })),
+      saveCommittedProjectSession: vi.fn(async (session) => {
+        durableSession = session
+      })
+    })
+    let terminalAttempts = 0
+    const uploads = {
+      upgradeLegacySessionUploads: vi.fn(async (session, options) => {
+        if (options?.mode === 'live-save') return upgradedSession
+        terminalAttempts += 1
+        if (terminalAttempts === 1) throw new Error('terminal cleanup interrupted')
+        return session
+      })
+    }
+    const coordinator = new SessionPersistenceCoordinator(
+      repository,
+      createFileIndex(),
+      undefined,
+      undefined,
+      uploads
+    )
+
+    await expect(coordinator.deleteProjectSessions('project-1')).rejects.toThrow(
+      'terminal cleanup interrupted'
+    )
+    expect(repository.saveCommittedProjectSession).toHaveBeenCalledWith(upgradedSession)
+    expect(repository.markCommittedProjectSessionsPrepared).not.toHaveBeenCalled()
+    expect(repository.deleteProjectSessions).not.toHaveBeenCalled()
+
+    await expect(coordinator.deleteProjectSessions('project-1')).resolves.toEqual({
+      status: 'completed'
+    })
+    expect(repository.saveCommittedProjectSession).toHaveBeenCalledOnce()
+    expect(repository.markCommittedProjectSessionsPrepared).toHaveBeenCalledOnce()
+    expect(repository.deleteProjectSessions).toHaveBeenCalledOnce()
+  })
+
+  it('reconciles retained Upload copies before project Session and index authority are removed', async () => {
+    const order: string[] = []
+    const session = toVersionedUploadSession(createLegacyUploadSession('session-1'))
+    const repository = createSessionRepository({
+      loadProjectWithDiagnostics: vi.fn().mockResolvedValue({
+        sessions: [session],
+        isComplete: true
+      }),
+      deleteProjectSessions: vi.fn(async () => {
+        order.push('delete-json')
+      })
+    })
+    const fileIndex = createFileIndex({
+      softDeleteProject: vi.fn(async () => {
+        order.push('soft-delete-index')
+        return 'delete-project-operation'
+      })
+    })
+    const uploads = {
+      upgradeLegacySessionUploads: vi.fn(async () => {
+        order.push('reconcile-upload-copy')
+        return session
+      })
+    }
+    const coordinator = new SessionPersistenceCoordinator(
+      repository,
+      fileIndex,
+      undefined,
+      undefined,
+      uploads
+    )
+
+    await coordinator.deleteProjectSessions('project-1')
+
+    expect(order).toEqual(['reconcile-upload-copy', 'delete-json', 'soft-delete-index'])
+    expect(uploads.upgradeLegacySessionUploads).toHaveBeenCalledWith(session, {
+      mode: 'terminal-delete'
+    })
+  })
+
+  it('terminal-cleans readable Sessions before deleting incomplete Project authority', async () => {
+    const order: string[] = []
+    const session = toVersionedUploadSession(createLegacyUploadSession('session-1'))
+    const repository = createSessionRepository({
+      loadProjectWithDiagnostics: vi.fn().mockResolvedValue({
+        sessions: [session],
+        isComplete: false
+      }),
+      deleteProjectSessions: vi.fn(async () => {
+        order.push('delete-project-sessions')
+      })
+    })
+    const fileIndex = createFileIndex({
+      markReconciliationIncomplete: vi.fn(() => {
+        order.push('mark-incomplete')
+      }),
+      softDeleteProject: vi.fn(async () => {
+        order.push('soft-delete-index')
+        return 'delete-project-operation'
+      })
+    })
+    const uploads = {
+      upgradeLegacySessionUploads: vi.fn(async () => {
+        order.push('terminal-cleanup')
+        return session
+      })
+    }
+    const coordinator = new SessionPersistenceCoordinator(
+      repository,
+      fileIndex,
+      undefined,
+      undefined,
+      uploads
+    )
+
+    await expect(coordinator.deleteProjectSessions('project-1')).resolves.toEqual({
+      status: 'completed'
+    })
+
+    expect(order).toEqual([
+      'mark-incomplete',
+      'terminal-cleanup',
+      'delete-project-sessions',
+      'soft-delete-index'
+    ])
+    expect(uploads.upgradeLegacySessionUploads).toHaveBeenCalledWith(session, {
+      mode: 'terminal-delete'
+    })
+  })
+
+  it('preserves incomplete orphaned tombstone authority instead of adopting its readable subset', async () => {
+    const session = toVersionedUploadSession(createLegacyUploadSession('session-1'))
+    const repository = createSessionRepository({
+      getProjectSessionDeletionState: vi.fn().mockResolvedValue('legacy-committed'),
+      loadCommittedProjectWithDiagnostics: vi.fn().mockResolvedValue({
+        sessions: [session],
+        isComplete: false
+      })
+    })
+    const uploads = {
+      upgradeLegacySessionUploads: vi.fn().mockResolvedValue(session)
+    }
+    const coordinator = new SessionPersistenceCoordinator(
+      repository,
+      createFileIndex(),
+      undefined,
+      undefined,
+      uploads
+    )
+
+    await expect(
+      coordinator.deleteProjectSessions('project-1', {
+        requireExistingUploadAuthority: true
+      })
+    ).rejects.toThrow(/incomplete Session authority/i)
+
+    expect(uploads.upgradeLegacySessionUploads).not.toHaveBeenCalled()
+    expect(repository.markCommittedProjectSessionsPrepared).not.toHaveBeenCalled()
+    expect(repository.deleteProjectSessions).not.toHaveBeenCalled()
+  })
+
+  it('returns orphan-retained only for positively missing Upload authority', async () => {
+    const session = createLegacyUploadSession('session-1')
+    const repository = createSessionRepository({
+      getProjectSessionDeletionState: vi.fn().mockResolvedValue('legacy-committed'),
+      loadCommittedProjectWithDiagnostics: vi.fn().mockResolvedValue({
+        sessions: [session],
+        isComplete: true
+      })
+    })
+    const fileIndex = createFileIndex()
+    const uploads = {
+      upgradeLegacySessionUploads: vi
+        .fn()
+        .mockRejectedValue(new OrphanLegacyUploadAuthorityMissingError('missing Upload authority'))
+    }
+    const coordinator = new SessionPersistenceCoordinator(
+      repository,
+      fileIndex,
+      undefined,
+      undefined,
+      uploads
+    )
+
+    await expect(
+      coordinator.deleteProjectSessions('project-1', {
+        requireExistingUploadAuthority: true
+      })
+    ).resolves.toEqual({
+      status: 'orphan-retained',
+      reason: 'missing-upload-authority'
+    })
+
+    expect(fileIndex.markReconciliationIncomplete).toHaveBeenCalledOnce()
     expect(fileIndex.softDeleteProject).toHaveBeenCalledWith('project-1')
-    expect(fileIndex.restoreProject).toHaveBeenCalledWith('project-1', 'delete-project-operation')
-    await expect(coordinator.saveSession(createSession())).resolves.toBeUndefined()
+    expect(repository.markCommittedProjectSessionsPrepared).not.toHaveBeenCalled()
+    expect(repository.deleteProjectSessions).not.toHaveBeenCalled()
+  })
+
+  it('rejects orphan retention when the Project index cannot be soft-deleted', async () => {
+    const session = createLegacyUploadSession('session-1')
+    const repository = createSessionRepository({
+      getProjectSessionDeletionState: vi.fn().mockResolvedValue('legacy-committed'),
+      loadCommittedProjectWithDiagnostics: vi.fn().mockResolvedValue({
+        sessions: [session],
+        isComplete: true
+      })
+    })
+    const fileIndex = createFileIndex({
+      softDeleteProject: vi.fn().mockRejectedValue(new Error('index temporarily unavailable'))
+    })
+    const uploads = {
+      upgradeLegacySessionUploads: vi
+        .fn()
+        .mockRejectedValue(new OrphanLegacyUploadAuthorityMissingError('missing Upload authority'))
+    }
+    const coordinator = new SessionPersistenceCoordinator(
+      repository,
+      fileIndex,
+      undefined,
+      undefined,
+      uploads
+    )
+
+    await expect(
+      coordinator.deleteProjectSessions('project-1', {
+        requireExistingUploadAuthority: true
+      })
+    ).rejects.toThrow('index temporarily unavailable')
+
+    expect(fileIndex.markReconciliationIncomplete).toHaveBeenCalledOnce()
+    expect(repository.markCommittedProjectSessionsPrepared).not.toHaveBeenCalled()
+    expect(repository.deleteProjectSessions).not.toHaveBeenCalled()
+  })
+
+  it('aborts Project deletion on transient Upload cleanup failure and retries from intact authority', async () => {
+    const first = createLegacyUploadSession('session-1')
+    const upgradedFirst = toVersionedUploadSession(first)
+    const second = createLegacyUploadSession('session-2')
+    const order: string[] = []
+    const repository = createSessionRepository({
+      loadProjectWithDiagnostics: vi.fn().mockResolvedValue({
+        sessions: [first, second],
+        isComplete: true
+      }),
+      saveSession: vi.fn(async (session) => {
+        order.push(`save:${session.id}`)
+      })
+    })
+    let secondUpgradeAttempts = 0
+    const uploads = {
+      upgradeLegacySessionUploads: vi.fn(async (session, options) => {
+        order.push(`${session.id}:${options?.mode}`)
+        if (session.id === 'session-1') return upgradedFirst
+        secondUpgradeAttempts += 1
+        if (secondUpgradeAttempts === 1) throw new Error('second upload upgrade failed')
+        return toVersionedUploadSession(second)
+      })
+    }
+    const fileIndex = createFileIndex()
+    const coordinator = new SessionPersistenceCoordinator(
+      repository,
+      fileIndex,
+      undefined,
+      undefined,
+      uploads
+    )
+
+    await expect(coordinator.deleteProjectSessions('project-1')).rejects.toThrow(
+      'second upload upgrade failed'
+    )
+
+    expect(order).toEqual([
+      'session-1:live-save',
+      'save:session-1',
+      'session-1:terminal-delete',
+      'session-2:live-save'
+    ])
+    expect(repository.saveSession).toHaveBeenCalledOnce()
+    expect(repository.saveSession).toHaveBeenCalledWith(upgradedFirst)
+    expect(fileIndex.softDeleteProject).not.toHaveBeenCalled()
+    expect(repository.deleteProjectSessions).not.toHaveBeenCalled()
+
+    await expect(coordinator.deleteProjectSessions('project-1')).resolves.toEqual({
+      status: 'completed'
+    })
+    expect(fileIndex.softDeleteProject).toHaveBeenCalledWith('project-1')
+    expect(repository.deleteProjectSessions).toHaveBeenCalledWith('project-1')
+  })
+
+  it('retains a legacy source and aborts Project deletion when path-free projection save fails', async () => {
+    const legacySession = createLegacyUploadSession('session-1')
+    const upgradedSession = toVersionedUploadSession(legacySession)
+    let legacySourceRemoved = false
+    const repository = createSessionRepository({
+      loadProjectWithDiagnostics: vi.fn().mockResolvedValue({
+        sessions: [legacySession],
+        isComplete: true
+      }),
+      saveSession: vi.fn().mockRejectedValue(new Error('session file unavailable'))
+    })
+    const uploads = {
+      upgradeLegacySessionUploads: vi.fn(async (_session, options) => {
+        if (options?.mode === 'terminal-delete') legacySourceRemoved = true
+        return upgradedSession
+      })
+    }
+    const fileIndex = createFileIndex()
+    const coordinator = new SessionPersistenceCoordinator(
+      repository,
+      fileIndex,
+      undefined,
+      undefined,
+      uploads
+    )
+
+    await expect(coordinator.deleteProjectSessions('project-1')).rejects.toThrow(
+      'session file unavailable'
+    )
+
+    expect(uploads.upgradeLegacySessionUploads).toHaveBeenCalledOnce()
+    expect(uploads.upgradeLegacySessionUploads).toHaveBeenCalledWith(legacySession, {
+      mode: 'live-save'
+    })
+    expect(legacySourceRemoved).toBe(false)
+    expect(fileIndex.markReconciliationIncomplete).not.toHaveBeenCalled()
+    expect(fileIndex.softDeleteProject).not.toHaveBeenCalled()
+    expect(repository.deleteProjectSessions).not.toHaveBeenCalled()
+  })
+
+  it('retains a proven unsafe Upload replacement while committing Project deletion', async () => {
+    const session = toVersionedUploadSession(createLegacyUploadSession('session-1'))
+    const repository = createSessionRepository({
+      loadProjectWithDiagnostics: vi.fn().mockResolvedValue({
+        sessions: [session],
+        isComplete: true
+      })
+    })
+    const uploads = {
+      upgradeLegacySessionUploads: vi
+        .fn()
+        .mockRejectedValue(
+          new UnsafeLegacyUploadResidualError('legacy path contains unrelated bytes')
+        )
+    }
+    const fileIndex = createFileIndex()
+    const coordinator = new SessionPersistenceCoordinator(
+      repository,
+      fileIndex,
+      undefined,
+      undefined,
+      uploads
+    )
+
+    await expect(coordinator.deleteProjectSessions('project-1')).resolves.toEqual({
+      status: 'completed'
+    })
+
+    expect(fileIndex.markReconciliationIncomplete).toHaveBeenCalledOnce()
+    expect(fileIndex.softDeleteProject).toHaveBeenCalledWith('project-1')
+    expect(repository.deleteProjectSessions).toHaveBeenCalledWith('project-1')
   })
 
   it('rejects late session saves after a project session directory was deleted', async () => {
@@ -440,7 +1369,9 @@ describe('SessionPersistenceCoordinator', () => {
       throw new Error('renderer unavailable')
     })
 
-    await expect(coordinator.deleteProjectSessions('project-1')).resolves.toBeUndefined()
+    await expect(coordinator.deleteProjectSessions('project-1')).resolves.toEqual({
+      status: 'completed'
+    })
     expect(repository.deleteProjectSessions).toHaveBeenCalledWith('project-1')
     await expect(coordinator.saveSession(createSession())).rejects.toThrow(/project.*deleted/i)
   })
@@ -618,10 +1549,20 @@ const createSessionRepository = (
     result: { sessions: [], manifest: { version: 1 } },
     isComplete: true
   }),
-  loadSession: vi.fn().mockResolvedValue(undefined),
+  loadProjectWithDiagnostics: vi.fn().mockResolvedValue({ sessions: [], isComplete: true }),
+  loadCommittedProjectWithDiagnostics: vi.fn().mockResolvedValue({
+    sessions: [],
+    isComplete: true
+  }),
+  loadSessionWithDiagnostics: vi.fn().mockResolvedValue({ status: 'missing' }),
   saveSession: vi.fn().mockResolvedValue(undefined),
+  saveCommittedProjectSession: vi.fn().mockResolvedValue(undefined),
   deleteSession: vi.fn().mockResolvedValue(undefined),
   deleteProjectSessions: vi.fn().mockResolvedValue(undefined),
+  getProjectSessionDeletionState: vi.fn().mockResolvedValue('absent'),
+  markCommittedProjectSessionsPrepared: vi.fn().mockResolvedValue(undefined),
+  completeProjectSessionDeletion: vi.fn().mockResolvedValue(undefined),
+  listLegacyProjectSessionTombstones: vi.fn().mockResolvedValue([]),
   saveManifest: vi.fn().mockResolvedValue(undefined),
   ...overrides
 })
@@ -631,7 +1572,6 @@ const createFileIndex = (overrides: Partial<SessionFileIndex> = {}): SessionFile
   softDeleteSession: vi.fn().mockResolvedValue('delete-session-operation'),
   restoreSession: vi.fn().mockResolvedValue(undefined),
   softDeleteProject: vi.fn().mockResolvedValue('delete-project-operation'),
-  restoreProject: vi.fn().mockResolvedValue(undefined),
   reconcileActiveSessions: vi.fn().mockResolvedValue(undefined),
   markReconciliationIncomplete: vi.fn(),
   ...overrides

--- a/src/main/session-persistence/coordinator.ts
+++ b/src/main/session-persistence/coordinator.ts
@@ -6,18 +6,46 @@ import type {
   SaveSessionManifestRequest
 } from '../../shared/session-persistence'
 import type { ManagedFileSoftDeleteToken } from '../project-files/repository'
+import type { ProjectSessionDeletionState } from './repository'
 import { materializeSessionConversationGraph } from '../../shared/session-persistence'
 import type { SessionDeletionReceipt } from '../artifacts/provenance-message-snapshot'
+import {
+  OrphanLegacyUploadAuthorityMissingError,
+  UnsafeLegacyUploadResidualError
+} from '../uploads/repository'
+
+type ProjectSessionDeletionResult =
+  { status: 'completed' } | { status: 'orphan-retained'; reason: 'missing-upload-authority' }
 
 type SessionMutationRepository = {
   loadAllWithDiagnostics(): Promise<{
     result: LoadAllSessionsResult
     isComplete: boolean
   }>
-  loadSession(projectId: string, sessionId: string): Promise<PersistedChatSession | undefined>
+  loadProjectWithDiagnostics(projectId: string): Promise<{
+    sessions: PersistedChatSession[]
+    isComplete: boolean
+  }>
+  loadCommittedProjectWithDiagnostics(projectId: string): Promise<{
+    sessions: PersistedChatSession[]
+    isComplete: boolean
+  }>
+  loadSessionWithDiagnostics(
+    projectId: string,
+    sessionId: string
+  ): Promise<
+    | { status: 'found'; session: PersistedChatSession }
+    | { status: 'missing' }
+    | { status: 'unreadable' }
+  >
   saveSession(session: PersistedChatSession): Promise<void>
+  saveCommittedProjectSession(session: PersistedChatSession): Promise<void>
   deleteSession(projectId: string, sessionId: string): Promise<void>
   deleteProjectSessions(projectId: string): Promise<void>
+  getProjectSessionDeletionState(projectId: string): Promise<ProjectSessionDeletionState>
+  markCommittedProjectSessionsPrepared(projectId: string): Promise<void>
+  completeProjectSessionDeletion(projectId: string): Promise<void>
+  listLegacyProjectSessionTombstones(): Promise<string[]>
   saveManifest(request: SaveSessionManifestRequest): Promise<void>
 }
 
@@ -33,7 +61,6 @@ type SessionFileIndex = {
     token: ManagedFileSoftDeleteToken
   ): Promise<void>
   softDeleteProject(projectId: string): Promise<ManagedFileSoftDeleteToken>
-  restoreProject(projectId: string, token: ManagedFileSoftDeleteToken): Promise<void>
   reconcileActiveSessions(sessions: PersistedChatSession[]): Promise<void>
   markReconciliationIncomplete(): void
 }
@@ -47,7 +74,10 @@ type SessionProvenancePersistence = {
 }
 
 type SessionUploadPersistence = {
-  upgradeLegacySessionUploads(session: PersistedChatSession): Promise<PersistedChatSession>
+  upgradeLegacySessionUploads(
+    session: PersistedChatSession,
+    options?: { mode?: 'reconcile' | 'live-save' | 'orphan-recovery' | 'terminal-delete' }
+  ): Promise<PersistedChatSession>
 }
 
 type ArtifactStorageReconciler = {
@@ -70,6 +100,7 @@ class SessionPersistenceCoordinator {
   private queue: Promise<unknown> = Promise.resolve()
   private readonly deletedSessions = new Set<string>()
   private readonly deletedProjects = new Set<string>()
+  private destructiveStartupWindowOpen = true
 
   constructor(
     private readonly repository: SessionMutationRepository,
@@ -81,11 +112,16 @@ class SessionPersistenceCoordinator {
   ) {}
 
   /**
-   * Loads durable sessions and backfills their file projection only after a complete scan has restored
-   * active ownership. Chat hydration remains available when indexing or reconciliation fails.
+   * Loads durable sessions, reconciles Upload storage, and backfills the file projection only after a
+   * complete scan has restored active ownership. Chat hydration remains available on any failure.
    */
   loadAll(): Promise<LoadAllSessionsResult> {
     return this.enqueue(async () => {
+      // Public loadAll can be called by multiple renderers/tasks. Only the first invocation in this
+      // process is a startup boundary; consume it before any await so failures and partial scans cannot
+      // reopen destructive cleanup while live clients may already hold the legacy projection.
+      const mayRunDestructiveStartupCleanup = this.destructiveStartupWindowOpen
+      this.destructiveStartupWindowOpen = false
       const scan = await this.repository.loadAllWithDiagnostics()
 
       if (!scan.isComplete) {
@@ -95,37 +131,67 @@ class SessionPersistenceCoordinator {
         return scan.result
       }
 
+      let durableResult = scan.result
       try {
-        await this.provenance?.reconcileSessionDeletions(scan.result.sessions)
-        for (const session of scan.result.sessions) {
+        if (this.uploads) {
+          const reconciledSessions = [...scan.result.sessions]
+          for (const [index, session] of scan.result.sessions.entries()) {
+            const requiresProjectionWrite = hasLegacySessionUpload(session)
+            if (requiresProjectionWrite) {
+              // Build the complete immutable projection without consuming any source. Promise.all
+              // publication may otherwise strand successful Uploads when a sibling upgrade fails.
+              const upgradedSession = await this.uploads.upgradeLegacySessionUploads(session, {
+                mode: 'live-save'
+              })
+              // Advance hydration before attempting the JSON write so a save failure still hands
+              // callers the readable immutable projection produced by the completed live-save.
+              reconciledSessions[index] = upgradedSession
+              durableResult = { ...scan.result, sessions: [...reconciledSessions] }
+              // Persist every immutable identity before startup reconciliation can consume a legacy
+              // source. A failed write remains retryable because live-save preserved every source.
+              await this.repository.saveSession(upgradedSession)
+              if (mayRunDestructiveStartupCleanup) {
+                await this.uploads.upgradeLegacySessionUploads(upgradedSession, {
+                  mode: 'reconcile'
+                })
+              }
+            } else {
+              await this.uploads.upgradeLegacySessionUploads(session, {
+                mode: mayRunDestructiveStartupCleanup ? 'reconcile' : 'live-save'
+              })
+            }
+          }
+        }
+
+        await this.provenance?.reconcileSessionDeletions(durableResult.sessions)
+        for (const session of durableResult.sessions) {
           await this.artifactStorage?.reconcileSession(session.projectId, session.id, session, {
-            // Startup runs before an Agent or Notebook writer can enter the Session. Destructive
-            // cleanup is forbidden on later read-triggered reconciliation paths.
-            removeOrphanStaging: true
+            removeOrphanStaging: mayRunDestructiveStartupCleanup
           })
         }
         // Reconciliation restores active owners left soft-deleted by an interrupted delete before any
         // scan-order-dependent sync can offer their canonical rows to another session.
-        await this.fileIndex.reconcileActiveSessions(scan.result.sessions)
+        await this.fileIndex.reconcileActiveSessions(durableResult.sessions)
       } catch (error) {
         this.fileIndex.markReconciliationIncomplete()
         console.error('[session-persistence] startup reconciliation failed', error)
-        // Keep chat hydration available while Files remains explicitly incomplete and retryable.
-        return scan.result
+        // Hydrate every Session whose immutable upgrade completed; later entries retain the scan
+        // projection. Files remains explicitly incomplete and the durable writes retry next startup.
+        return durableResult
       }
 
-      for (const session of scan.result.sessions) {
+      for (const session of durableResult.sessions) {
         await this.fileIndex.syncSession(session).catch(() => undefined)
       }
 
-      return scan.result
+      return durableResult
     })
   }
 
   // Persists authoritative JSON before updating the derived index. If indexing fails, the save stays
   // durable, the caller receives the error for its normal retry path, and Files is reset to show its
   // incomplete state rather than silently presenting stale metadata as complete.
-  saveSession(session: PersistedChatSession): Promise<void> {
+  saveSession(session: PersistedChatSession): Promise<PersistedChatSession> {
     return this.enqueue(async () => {
       if (this.deletedProjects.has(session.projectId)) {
         throw new Error('Cannot save a session whose project has been deleted.')
@@ -136,7 +202,9 @@ class SessionPersistenceCoordinator {
 
       const materializedSession = materializeSessionConversationGraph(session)
       const durableSession = this.uploads
-        ? await this.uploads.upgradeLegacySessionUploads(materializedSession)
+        ? await this.uploads.upgradeLegacySessionUploads(materializedSession, {
+            mode: 'live-save'
+          })
         : materializedSession
       await this.repository.saveSession(durableSession)
       await this.provenance?.captureFinalizedMessages(durableSession)
@@ -161,6 +229,7 @@ class SessionPersistenceCoordinator {
           kind: 'upsert'
         })
       }
+      return durableSession
     })
   }
 
@@ -182,24 +251,145 @@ class SessionPersistenceCoordinator {
     })
   }
 
-  // Soft-deletes index rows before removing the project session directory. A failed durable delete
-  // restores only rows tagged by this operation and clears the in-memory project tombstone.
-  deleteProjectSessions(projectId: string): Promise<void> {
+  // A path-only projection must become durable before terminal cleanup may consume its source.
+  // Keeping the live-save source through the JSON commit makes a failed save safely retryable; once
+  // the path-free identity is durable, terminal cleanup can run without stranding an active Session.
+  private async prepareSessionUploadsForTerminalDelete(
+    session: PersistedChatSession
+  ): Promise<PersistedChatSession> {
+    if (!this.uploads) return session
+
+    if (!hasLegacySessionUpload(session)) {
+      return this.uploads.upgradeLegacySessionUploads(session, { mode: 'terminal-delete' })
+    }
+
+    const upgradedSession = await this.uploads.upgradeLegacySessionUploads(session, {
+      mode: 'live-save'
+    })
+    await this.repository.saveSession(upgradedSession)
+    return this.uploads.upgradeLegacySessionUploads(upgradedSession, {
+      mode: 'terminal-delete'
+    })
+  }
+
+  // A whole-Project intent may retain only a positively identified unowned replacement. Path-only
+  // JSON must first be durably upgraded before terminal cleanup consumes its source: the later atomic
+  // Session-directory removal can still fail and restore a live Project. Every authority,
+  // publication, filesystem, save, and private-claim failure aborts that reversible phase.
+  private async prepareProjectSessionUploadsForTerminalDelete(
+    session: PersistedChatSession,
+    saveUpgradedSession: (session: PersistedChatSession) => Promise<void> = (upgraded) =>
+      this.repository.saveSession(upgraded),
+    requireExistingUploadAuthority = false
+  ): Promise<{ hasUnsafeResidual: boolean }> {
+    if (!this.uploads) return { hasUnsafeResidual: false }
+
+    let terminalSession = session
+    if (hasLegacySessionUpload(session)) {
+      terminalSession = await this.uploads.upgradeLegacySessionUploads(session, {
+        mode: requireExistingUploadAuthority ? 'orphan-recovery' : 'live-save'
+      })
+      await saveUpgradedSession(terminalSession)
+    }
+
+    try {
+      await this.uploads.upgradeLegacySessionUploads(terminalSession, {
+        mode: 'terminal-delete'
+      })
+      return { hasUnsafeResidual: false }
+    } catch (error) {
+      if (error instanceof UnsafeLegacyUploadResidualError) {
+        return { hasUnsafeResidual: true }
+      }
+      throw error
+    }
+  }
+
+  /**
+   * Completes the Session/index phase of an intent-authorized whole-Project deletion.
+   *
+   * This is deliberately not a general batch-Session delete. A durable Project deletion intent owns
+   * eventual cleanup of Project-scoped Versions and provenance after this method atomically removes
+   * Session authority. Per-Session deletion retains its stricter fail-closed contract.
+   */
+  deleteProjectSessions(
+    projectId: string,
+    options: { requireExistingUploadAuthority?: boolean } = {}
+  ): Promise<ProjectSessionDeletionResult> {
     return this.enqueue(async () => {
       this.deletedProjects.add(projectId)
-      let token: ManagedFileSoftDeleteToken | undefined
 
       try {
-        token = await this.fileIndex.softDeleteProject(projectId)
+        if (options.requireExistingUploadAuthority && !this.uploads) {
+          throw new Error('Upload recovery is unavailable for an orphaned Project tombstone.')
+        }
+        const deletionState = await this.repository.getProjectSessionDeletionState(projectId)
+        if (this.uploads && deletionState !== 'prepared') {
+          // Terminal deletion is the final point at which Session JSON and Upload SQLite authority
+          // coexist. Reconcile retained live-save copies before either authority is removed.
+          const scan =
+            deletionState === 'legacy-committed'
+              ? await this.repository.loadCommittedProjectWithDiagnostics(projectId)
+              : await this.repository.loadProjectWithDiagnostics(projectId)
+          if (!scan.isComplete) {
+            if (options.requireExistingUploadAuthority) {
+              throw new Error(
+                'Cannot adopt a legacy Project tombstone with incomplete Session authority.'
+              )
+            }
+            // Whole-Project deletion is backed by a durable user intent and may discard opaque
+            // Session authority. Still terminal-clean every readable Session below; unknown legacy
+            // bytes are deliberately retained rather than guessed from a possibly-colliding runtime
+            // Session id, while the atomic Project directory removal keeps recovery progressing.
+            this.fileIndex.markReconciliationIncomplete()
+          }
+          for (const session of scan.sessions) {
+            let cleanup: { hasUnsafeResidual: boolean }
+            try {
+              cleanup = await this.prepareProjectSessionUploadsForTerminalDelete(
+                session,
+                deletionState === 'legacy-committed'
+                  ? (upgraded) => this.repository.saveCommittedProjectSession(upgraded)
+                  : undefined,
+                options.requireExistingUploadAuthority === true
+              )
+            } catch (error) {
+              if (
+                options.requireExistingUploadAuthority &&
+                error instanceof OrphanLegacyUploadAuthorityMissingError
+              ) {
+                this.fileIndex.markReconciliationIncomplete()
+                // Sibling Upload work has fully settled before this typed error is surfaced. Commit
+                // derived index deletion now so a recovered Version cannot remain visible for a
+                // logically deleted Project whose legacy tombstone must be retained.
+                await this.fileIndex.softDeleteProject(projectId)
+                return { status: 'orphan-retained', reason: 'missing-upload-authority' }
+              }
+              throw error
+            }
+            if (cleanup.hasUnsafeResidual) {
+              // Never guess-delete a positively identified replacement. The Project intent can still
+              // commit because immutable Version authority exists and the unrelated bytes are kept.
+              this.fileIndex.markReconciliationIncomplete()
+            }
+          }
+        }
+        if (deletionState === 'legacy-committed') {
+          await this.repository.markCommittedProjectSessionsPrepared(projectId)
+        }
+        // The marked directory rename is the sole authoritative commit. Derived index deletion runs
+        // afterward so any failure is replayable from the durable Project intent and tombstone.
         await this.repository.deleteProjectSessions(projectId)
+        await this.fileIndex.softDeleteProject(projectId)
       } catch (error) {
         try {
-          if (token) await this.fileIndex.restoreProject(projectId, token)
-        } catch (restoreError) {
+          const state = await this.repository.getProjectSessionDeletionState(projectId)
+          if (state === 'live' || state === 'absent') {
+            this.deletedProjects.delete(projectId)
+          }
+        } catch {
+          // Unknown durable state is treated as committed: retain the in-memory tombstone and intent.
           this.fileIndex.markReconciliationIncomplete()
-          throw restoreError
-        } finally {
-          this.deletedProjects.delete(projectId)
         }
         throw error
       }
@@ -209,7 +399,24 @@ class SessionPersistenceCoordinator {
         sources: ['artifact', 'upload'],
         kind: 'reset'
       })
+      return { status: 'completed' }
     })
+  }
+
+  getProjectSessionDeletionState(projectId: string): Promise<ProjectSessionDeletionState> {
+    return this.enqueue(() => this.repository.getProjectSessionDeletionState(projectId))
+  }
+
+  markCommittedProjectSessionsPrepared(projectId: string): Promise<void> {
+    return this.enqueue(() => this.repository.markCommittedProjectSessionsPrepared(projectId))
+  }
+
+  completeProjectSessionDeletion(projectId: string): Promise<void> {
+    return this.enqueue(() => this.repository.completeProjectSessionDeletion(projectId))
+  }
+
+  listLegacyProjectSessionTombstones(): Promise<string[]> {
+    return this.enqueue(() => this.repository.listLegacyProjectSessionTombstones())
   }
 
   /**
@@ -297,12 +504,13 @@ class SessionPersistenceCoordinator {
       let jsonDeleted = false
 
       try {
-        let session = await this.repository.loadSession(projectId, sessionId)
-        if (session && this.uploads && hasLegacySessionUpload(session)) {
-          session = await this.uploads.upgradeLegacySessionUploads(session)
-          // Persist the immutable identity before tombstoning. If deletion is interrupted, startup
-          // reconciliation can now retain the Upload Version without relying on a legacy path.
-          await this.repository.saveSession(session)
+        const loadedSession = await this.repository.loadSessionWithDiagnostics(projectId, sessionId)
+        if (loadedSession.status === 'unreadable') {
+          throw new Error('Cannot delete a Session whose durable JSON is unreadable.')
+        }
+        let session = loadedSession.status === 'found' ? loadedSession.session : undefined
+        if (session && this.uploads) {
+          session = await this.prepareSessionUploadsForTerminalDelete(session)
         }
         if (session && this.provenance) {
           receipt = await this.provenance.prepareSessionDeletion(session)
@@ -403,4 +611,9 @@ class SessionPersistenceCoordinator {
 const sessionKey = (projectId: string, sessionId: string): string => `${projectId}:${sessionId}`
 
 export { SessionPersistenceCoordinator }
-export type { SessionFileIndex, SessionMutationRepository, SessionProvenancePersistence }
+export type {
+  ProjectSessionDeletionResult,
+  SessionFileIndex,
+  SessionMutationRepository,
+  SessionProvenancePersistence
+}

--- a/src/main/session-persistence/deletion-integration.test.ts
+++ b/src/main/session-persistence/deletion-integration.test.ts
@@ -1,5 +1,5 @@
 import { createHash } from 'node:crypto'
-import { mkdir, mkdtemp, readFile, rm, writeFile } from 'node:fs/promises'
+import { mkdir, mkdtemp, readFile, readdir, rename, rm, writeFile } from 'node:fs/promises'
 import { tmpdir } from 'node:os'
 import { dirname, join } from 'node:path'
 
@@ -11,8 +11,12 @@ vi.mock('electron', () => ({
 }))
 
 import type { PersistedChatSession } from '../../shared/session-persistence'
+import { ArtifactProvenanceRepository } from '../artifacts/provenance-repository'
 import { ManagedFileIndexRepository } from '../project-files/repository'
+import { ProjectDeletionCoordinator } from '../projects/deletion-coordinator'
 import { createProjectDbClient, ensureProjectSchema } from '../projects/prisma-client'
+import { ProjectRepository } from '../projects/repository'
+import { UploadRepository } from '../uploads/repository'
 import { SessionPersistenceCoordinator } from './coordinator'
 import { SessionRepository } from './repository'
 
@@ -34,7 +38,13 @@ describe('managed-file deletion integration', () => {
     await ensureProjectSchema(client)
     sessions = new SessionRepository(storageRoot)
     files = new ManagedFileIndexRepository(() => Promise.resolve(client), storageRoot)
-    coordinator = new SessionPersistenceCoordinator(sessions, files)
+    coordinator = new SessionPersistenceCoordinator(
+      sessions,
+      files,
+      undefined,
+      undefined,
+      new UploadRepository(storageRoot, { getClient: () => Promise.resolve(client) })
+    )
     uploadPath = join(
       storageRoot,
       'uploads',
@@ -94,21 +104,591 @@ describe('managed-file deletion integration', () => {
   })
 
   it('soft-deletes indexed rows but retains upload and artifact bytes after session deletion', async () => {
+    const legacyPath = join(storageRoot, 'uploads', 'default-project', SESSION_ID, 'input.csv')
+    await writeManagedFile(legacyPath, 'upload bytes')
+
     await coordinator.deleteSession(PROJECT_ID, SESSION_ID)
 
     await expect(sessions.loadAll()).resolves.toMatchObject({ sessions: [] })
     await expect(files.getOverview(PROJECT_ID)).resolves.toMatchObject({ totalCount: 0 })
     await expect(readFile(uploadPath, 'utf8')).resolves.toBe('upload bytes')
     await expect(readFile(artifactPath, 'utf8')).resolves.toBe('artifact bytes')
+    await expect(readFile(legacyPath)).rejects.toMatchObject({ code: 'ENOENT' })
+  })
+
+  it('deletes a recovered Session and its superseded quarantine without blocking Project deletion', async () => {
+    const projectDir = join(storageRoot, 'sessions', PROJECT_ID)
+    const quarantineName = `${SESSION_ID}.json.invalid-1710000000000-1`
+    await writeFile(join(projectDir, quarantineName), '{older malformed authority', 'utf8')
+
+    await expect(coordinator.deleteSession(PROJECT_ID, SESSION_ID)).resolves.toBeUndefined()
+
+    await expect(readFile(join(projectDir, `${SESSION_ID}.json`))).rejects.toMatchObject({
+      code: 'ENOENT'
+    })
+    await expect(readFile(join(projectDir, quarantineName))).rejects.toMatchObject({
+      code: 'ENOENT'
+    })
+    await expect(files.getOverview(PROJECT_ID)).resolves.toMatchObject({ totalCount: 0 })
+    await expect(coordinator.deleteProjectSessions(PROJECT_ID)).resolves.toEqual({
+      status: 'completed'
+    })
+    await expect(readdir(projectDir)).rejects.toMatchObject({ code: 'ENOENT' })
   })
 
   it('soft-deletes project rows but retains upload and artifact bytes after project deletion', async () => {
+    const legacyPath = join(storageRoot, 'uploads', 'default-project', SESSION_ID, 'input.csv')
+    await writeManagedFile(legacyPath, 'upload bytes')
+
     await coordinator.deleteProjectSessions(PROJECT_ID)
 
     await expect(sessions.loadAll()).resolves.toMatchObject({ sessions: [] })
     await expect(files.getOverview(PROJECT_ID)).resolves.toMatchObject({ totalCount: 0 })
     await expect(readFile(uploadPath, 'utf8')).resolves.toBe('upload bytes')
     await expect(readFile(artifactPath, 'utf8')).resolves.toBe('artifact bytes')
+    await expect(readFile(legacyPath)).rejects.toMatchObject({ code: 'ENOENT' })
+  })
+
+  it('terminal-cleans a path-only Upload from an unmarked legacy Project tombstone', async () => {
+    const legacyPath = join(storageRoot, 'uploads', 'default-project', SESSION_ID, 'input.csv')
+    const legacySession = createSession(uploadPath, artifactPath)
+    legacySession.messages[0].uploads = [
+      {
+        id: 'upload-1',
+        sessionId: SESSION_ID,
+        name: 'input.csv',
+        originalName: 'input.csv',
+        path: legacyPath,
+        size: 'upload bytes'.length
+      }
+    ]
+    await writeManagedFile(legacyPath, 'upload bytes')
+    const liveProjectDir = join(storageRoot, 'sessions', PROJECT_ID)
+    const tombstoneDir = join(storageRoot, 'deleted-sessions', PROJECT_ID)
+    await writeFile(
+      join(liveProjectDir, `${SESSION_ID}.json`),
+      JSON.stringify({ version: 2, session: legacySession }),
+      'utf8'
+    )
+    await mkdir(join(storageRoot, 'deleted-sessions'), { recursive: true })
+    await rename(liveProjectDir, tombstoneDir)
+
+    await coordinator.deleteProjectSessions(PROJECT_ID)
+
+    const durableTombstone = await readFile(join(tombstoneDir, `${SESSION_ID}.json`), 'utf8')
+    expect(durableTombstone).toContain('upload-version-1')
+    expect(durableTombstone).not.toContain(legacyPath)
+    await expect(sessions.getProjectSessionDeletionState(PROJECT_ID)).resolves.toBe('prepared')
+    await expect(readFile(legacyPath)).rejects.toMatchObject({ code: 'ENOENT' })
+    await expect(files.getOverview(PROJECT_ID)).resolves.toMatchObject({ totalCount: 0 })
+  })
+
+  it('adopts and safely completes an orphaned legacy tombstone with surviving Upload authority', async () => {
+    const legacyPath = join(storageRoot, 'uploads', 'default-project', SESSION_ID, 'input.csv')
+    const legacySession = createPathOnlySession(legacyPath)
+    const tombstoneDir = await replaceLiveSessionWithLegacyTombstone(storageRoot, legacySession)
+    await writeManagedFile(legacyPath, 'upload bytes')
+    await client.uploadVersion.update({
+      where: { id: 'upload-version-1' },
+      data: { state: 'staging' }
+    })
+    await rm(uploadPath, { force: true })
+    const projects = new ProjectRepository(() => Promise.resolve(client))
+    const provenanceRepository = new ArtifactProvenanceRepository({
+      storageRoot,
+      getClient: () => Promise.resolve(client)
+    })
+    let recoveredImmutableAuthority = false
+    const provenance = {
+      deleteProjectProvenance: vi.fn(async (projectId: string) => {
+        const version = await client.uploadVersion.findUnique({
+          where: { id: 'upload-version-1' }
+        })
+        recoveredImmutableAuthority =
+          version?.state === 'ready' && (await readFile(uploadPath, 'utf8')) === 'upload bytes'
+        await provenanceRepository.deleteProjectProvenance(projectId)
+      })
+    }
+    const projectDeletion = new ProjectDeletionCoordinator(
+      projects,
+      coordinator,
+      { delete: vi.fn().mockResolvedValue(undefined) },
+      undefined,
+      provenance
+    )
+
+    await expect(client.project.findUnique({ where: { id: PROJECT_ID } })).resolves.toBeNull()
+    await expect(
+      client.projectDeletionIntent.findUnique({ where: { projectId: PROJECT_ID } })
+    ).resolves.toBeNull()
+
+    await projectDeletion.recoverPendingDeletions()
+
+    expect(recoveredImmutableAuthority).toBe(true)
+    expect(provenance.deleteProjectProvenance).toHaveBeenCalledWith(PROJECT_ID)
+    await expect(readdir(tombstoneDir)).rejects.toMatchObject({ code: 'ENOENT' })
+    await expect(readFile(legacyPath)).rejects.toMatchObject({ code: 'ENOENT' })
+    await expect(readFile(uploadPath)).rejects.toMatchObject({ code: 'ENOENT' })
+    await expect(client.uploadFile.findUnique({ where: { id: 'upload-1' } })).resolves.toBeNull()
+    await expect(
+      client.uploadVersion.findUnique({ where: { id: 'upload-version-1' } })
+    ).resolves.toBeNull()
+    await expect(
+      client.projectDeletionIntent.findUnique({ where: { projectId: PROJECT_ID } })
+    ).resolves.toBeNull()
+  })
+
+  it('retains an orphan tombstone and bytes without blocking recovery when Upload authority is gone', async () => {
+    const legacyPath = join(storageRoot, 'uploads', 'default-project', SESSION_ID, 'input.csv')
+    const legacySession = createPathOnlySession(legacyPath)
+    const tombstoneDir = await replaceLiveSessionWithLegacyTombstone(storageRoot, legacySession)
+    await writeManagedFile(legacyPath, 'upload bytes')
+    await client.managedFile.deleteMany({ where: { projectId: PROJECT_ID } })
+    await client.uploadVersion.deleteMany({ where: { uploadFileId: 'upload-1' } })
+    await client.uploadFile.deleteMany({ where: { id: 'upload-1' } })
+    await client.fileOriginSession.deleteMany({ where: { projectId: PROJECT_ID } })
+    await rm(uploadPath, { force: true })
+    const projects = new ProjectRepository(() => Promise.resolve(client))
+    const unrelatedProject = await projects.create({ name: 'Unrelated project' })
+    const unrelatedSession = createSession('', '')
+    unrelatedSession.id = 'session-unrelated'
+    unrelatedSession.projectId = unrelatedProject.id
+    unrelatedSession.messages = []
+    unrelatedSession.artifacts = []
+    unrelatedSession.filesRevision = 0
+    await sessions.saveSession(unrelatedSession)
+    const projectDeletion = new ProjectDeletionCoordinator(
+      projects,
+      coordinator,
+      { delete: vi.fn().mockResolvedValue(undefined) },
+      undefined,
+      new ArtifactProvenanceRepository({
+        storageRoot,
+        getClient: () => Promise.resolve(client)
+      })
+    )
+
+    await expect(client.project.findUnique({ where: { id: PROJECT_ID } })).resolves.toBeNull()
+    await expect(
+      client.projectDeletionIntent.findUnique({ where: { projectId: PROJECT_ID } })
+    ).resolves.toBeNull()
+
+    await expect(projectDeletion.recoverPendingDeletions()).resolves.toBeUndefined()
+    await expect(projectDeletion.recoverPendingDeletions()).resolves.toBeUndefined()
+    await expect(projects.list()).resolves.toContainEqual(unrelatedProject)
+    const readableSessions = await coordinator.loadAll()
+    expect(
+      readableSessions.sessions.find((session) => session.id === unrelatedSession.id)
+    ).toBeDefined()
+
+    await expect(sessions.getProjectSessionDeletionState(PROJECT_ID)).resolves.toBe(
+      'legacy-committed'
+    )
+    await expect(readFile(legacyPath, 'utf8')).resolves.toBe('upload bytes')
+    await expect(readFile(join(tombstoneDir, `${SESSION_ID}.json`), 'utf8')).resolves.toContain(
+      legacyPath
+    )
+    await expect(
+      client.projectDeletionIntent.findUnique({ where: { projectId: PROJECT_ID } })
+    ).resolves.toBeNull()
+    await expect(client.uploadFile.findUnique({ where: { id: 'upload-1' } })).resolves.toBeNull()
+    await expect(
+      client.uploadVersion.findUnique({ where: { id: 'upload-version-1' } })
+    ).resolves.toBeNull()
+  })
+
+  it('settles mixed orphan publication before retaining the tombstone and soft-deleting its index', async () => {
+    const recoverableLegacyPath = join(
+      storageRoot,
+      'uploads',
+      'default-project',
+      SESSION_ID,
+      'input.csv'
+    )
+    const missingLegacyPath = join(
+      storageRoot,
+      'uploads',
+      'default-project',
+      SESSION_ID,
+      'missing.csv'
+    )
+    const mixedSession = createPathOnlySession(recoverableLegacyPath)
+    mixedSession.messages[0].uploads!.push({
+      id: 'upload-missing',
+      sessionId: SESSION_ID,
+      name: 'missing.csv',
+      originalName: 'missing.csv',
+      path: missingLegacyPath,
+      size: 'missing bytes'.length
+    })
+    const tombstoneDir = await replaceLiveSessionWithLegacyTombstone(storageRoot, mixedSession)
+    await writeManagedFile(recoverableLegacyPath, 'upload bytes')
+    await writeManagedFile(missingLegacyPath, 'missing bytes')
+    await client.uploadVersion.update({
+      where: { id: 'upload-version-1' },
+      data: { state: 'staging' }
+    })
+    await rm(uploadPath, { force: true })
+    const projects = new ProjectRepository(() => Promise.resolve(client))
+    const unrelatedProject = await projects.create({ name: 'Mixed recovery observer' })
+    const unrelatedSession = createSession('', '')
+    unrelatedSession.id = 'session-mixed-observer'
+    unrelatedSession.projectId = unrelatedProject.id
+    unrelatedSession.messages = []
+    unrelatedSession.artifacts = []
+    unrelatedSession.filesRevision = 0
+    await sessions.saveSession(unrelatedSession)
+    const projectDeletion = new ProjectDeletionCoordinator(
+      projects,
+      coordinator,
+      { delete: vi.fn().mockResolvedValue(undefined) },
+      undefined,
+      new ArtifactProvenanceRepository({
+        storageRoot,
+        getClient: () => Promise.resolve(client)
+      })
+    )
+
+    await expect(projectDeletion.recoverPendingDeletions()).resolves.toBeUndefined()
+
+    await expect(sessions.getProjectSessionDeletionState(PROJECT_ID)).resolves.toBe(
+      'legacy-committed'
+    )
+    await expect(readFile(recoverableLegacyPath, 'utf8')).resolves.toBe('upload bytes')
+    await expect(readFile(missingLegacyPath, 'utf8')).resolves.toBe('missing bytes')
+    await expect(readFile(join(tombstoneDir, `${SESSION_ID}.json`), 'utf8')).resolves.toContain(
+      'upload-missing'
+    )
+    await expect(readFile(uploadPath, 'utf8')).resolves.toBe('upload bytes')
+    await expect(
+      client.uploadVersion.findUnique({ where: { id: 'upload-version-1' } })
+    ).resolves.toMatchObject({ state: 'ready' })
+    await expect(
+      client.managedFile.findFirst({ where: { projectId: PROJECT_ID, deletedAt: null } })
+    ).resolves.toBeNull()
+    await expect(files.getOverview(PROJECT_ID)).resolves.toMatchObject({ totalCount: 0 })
+
+    // The recovery result is not observable until every sibling publication has settled. Yield once
+    // more to catch a dangling Promise that could otherwise reactivate ManagedFile after return.
+    await new Promise((resolve) => setTimeout(resolve, 0))
+    await expect(
+      client.managedFile.findFirst({ where: { projectId: PROJECT_ID, deletedAt: null } })
+    ).resolves.toBeNull()
+    await expect(
+      client.projectDeletionIntent.findUnique({ where: { projectId: PROJECT_ID } })
+    ).resolves.toBeNull()
+
+    await expect(projectDeletion.recoverPendingDeletions()).resolves.toBeUndefined()
+    await expect(projects.list()).resolves.toContainEqual(unrelatedProject)
+    const readableSessions = await coordinator.loadAll()
+    expect(
+      readableSessions.sessions.find((session) => session.id === unrelatedSession.id)
+    ).toBeDefined()
+  })
+
+  it('completes an orphan tombstone when Upload authority and every byte candidate are absent', async () => {
+    const legacyPath = join(storageRoot, 'uploads', 'default-project', SESSION_ID, 'input.csv')
+    const tombstoneDir = await replaceLiveSessionWithLegacyTombstone(
+      storageRoot,
+      createPathOnlySession(legacyPath)
+    )
+    await client.managedFile.deleteMany({ where: { projectId: PROJECT_ID } })
+    await client.uploadVersion.deleteMany({ where: { uploadFileId: 'upload-1' } })
+    await client.uploadFile.deleteMany({ where: { id: 'upload-1' } })
+    await client.fileOriginSession.deleteMany({ where: { projectId: PROJECT_ID } })
+    await rm(uploadPath, { force: true })
+    const projects = new ProjectRepository(() => Promise.resolve(client))
+    const projectDeletion = new ProjectDeletionCoordinator(
+      projects,
+      coordinator,
+      { delete: vi.fn().mockResolvedValue(undefined) },
+      undefined,
+      new ArtifactProvenanceRepository({
+        storageRoot,
+        getClient: () => Promise.resolve(client)
+      })
+    )
+
+    await expect(projectDeletion.recoverPendingDeletions()).resolves.toBeUndefined()
+
+    await expect(sessions.getProjectSessionDeletionState(PROJECT_ID)).resolves.toBe('absent')
+    await expect(readdir(tombstoneDir)).rejects.toMatchObject({ code: 'ENOENT' })
+    await expect(readFile(legacyPath)).rejects.toMatchObject({ code: 'ENOENT' })
+    await expect(
+      client.projectDeletionIntent.findUnique({ where: { projectId: PROJECT_ID } })
+    ).resolves.toBeNull()
+  })
+
+  it('retains an adopted intent when Upload authority lookup fails transiently', async () => {
+    const legacyPath = join(storageRoot, 'uploads', 'default-project', SESSION_ID, 'input.csv')
+    const tombstoneDir = await replaceLiveSessionWithLegacyTombstone(
+      storageRoot,
+      createPathOnlySession(legacyPath)
+    )
+    await writeManagedFile(legacyPath, 'upload bytes')
+    const projects = new ProjectRepository(() => Promise.resolve(client))
+    const failingSessions = new SessionPersistenceCoordinator(
+      sessions,
+      files,
+      undefined,
+      undefined,
+      new UploadRepository(storageRoot, {
+        getClient: () => Promise.reject(new Error('Upload database temporarily unavailable'))
+      })
+    )
+    const projectDeletion = new ProjectDeletionCoordinator(
+      projects,
+      failingSessions,
+      { delete: vi.fn().mockResolvedValue(undefined) },
+      undefined,
+      new ArtifactProvenanceRepository({
+        storageRoot,
+        getClient: () => Promise.resolve(client)
+      })
+    )
+
+    await expect(projectDeletion.recoverPendingDeletions()).rejects.toThrow(
+      'Upload database temporarily unavailable'
+    )
+
+    await expect(sessions.getProjectSessionDeletionState(PROJECT_ID)).resolves.toBe(
+      'legacy-committed'
+    )
+    await expect(readFile(legacyPath, 'utf8')).resolves.toBe('upload bytes')
+    await expect(readFile(join(tombstoneDir, `${SESSION_ID}.json`), 'utf8')).resolves.toContain(
+      legacyPath
+    )
+    await expect(
+      client.projectDeletionIntent.findUnique({ where: { projectId: PROJECT_ID } })
+    ).resolves.toBeTruthy()
+  })
+
+  it('retains a legacy source and aborts Project deletion when the path-free JSON save fails', async () => {
+    const legacyPath = join(storageRoot, 'uploads', 'default-project', SESSION_ID, 'input.csv')
+    const legacySession = createSession(uploadPath, artifactPath)
+    legacySession.messages[0].uploads = [
+      {
+        id: 'upload-1',
+        sessionId: SESSION_ID,
+        name: 'input.csv',
+        originalName: 'input.csv',
+        path: legacyPath,
+        size: 'upload bytes'.length
+      }
+    ]
+    await writeManagedFile(legacyPath, 'upload bytes')
+    await writeFile(
+      join(storageRoot, 'sessions', PROJECT_ID, `${SESSION_ID}.json`),
+      JSON.stringify({ version: 2, session: legacySession }),
+      'utf8'
+    )
+    const failingSessions = new SessionRepository(storageRoot)
+    vi.spyOn(failingSessions, 'saveSession').mockRejectedValue(
+      new Error('session file unavailable')
+    )
+    const projectCoordinator = new SessionPersistenceCoordinator(
+      failingSessions,
+      files,
+      undefined,
+      undefined,
+      new UploadRepository(storageRoot, { getClient: () => Promise.resolve(client) })
+    )
+
+    await expect(projectCoordinator.deleteProjectSessions(PROJECT_ID)).rejects.toThrow(
+      'session file unavailable'
+    )
+
+    expect(failingSessions.saveSession).toHaveBeenCalledOnce()
+    await expect(failingSessions.loadSession(PROJECT_ID, SESSION_ID)).resolves.toBeDefined()
+    await expect(readFile(legacyPath, 'utf8')).resolves.toBe('upload bytes')
+    await expect(files.getOverview(PROJECT_ID)).resolves.toMatchObject({ totalCount: 2 })
+  })
+
+  it('aborts Project deletion on transient Upload authority failure and succeeds on retry', async () => {
+    const legacyPath = join(storageRoot, 'uploads', 'default-project', SESSION_ID, 'input.csv')
+    await writeManagedFile(legacyPath, 'upload bytes')
+    const getClient = vi
+      .fn()
+      .mockRejectedValueOnce(new Error('Upload authority unavailable.'))
+      .mockResolvedValue(client)
+    const retryingCoordinator = new SessionPersistenceCoordinator(
+      sessions,
+      files,
+      undefined,
+      undefined,
+      new UploadRepository(storageRoot, { getClient })
+    )
+
+    await expect(retryingCoordinator.deleteProjectSessions(PROJECT_ID)).rejects.toThrow(
+      'Upload authority unavailable.'
+    )
+    await expect(sessions.loadSession(PROJECT_ID, SESSION_ID)).resolves.toBeDefined()
+    await expect(readFile(legacyPath, 'utf8')).resolves.toBe('upload bytes')
+    await expect(files.getOverview(PROJECT_ID)).resolves.toMatchObject({ totalCount: 2 })
+
+    await expect(retryingCoordinator.deleteProjectSessions(PROJECT_ID)).resolves.toEqual({
+      status: 'completed'
+    })
+    await expect(sessions.loadSession(PROJECT_ID, SESSION_ID)).resolves.toBeUndefined()
+    await expect(readFile(legacyPath)).rejects.toMatchObject({ code: 'ENOENT' })
+    await expect(files.getOverview(PROJECT_ID)).resolves.toMatchObject({ totalCount: 0 })
+  })
+
+  it('deletes a recovered Project when valid Session JSON supersedes an older quarantine', async () => {
+    const projectDir = join(storageRoot, 'sessions', PROJECT_ID)
+    await writeFile(
+      join(projectDir, `${SESSION_ID}.json.invalid-1710000000000-1`),
+      '{older malformed authority',
+      'utf8'
+    )
+
+    await expect(coordinator.deleteProjectSessions(PROJECT_ID)).resolves.toEqual({
+      status: 'completed'
+    })
+
+    await expect(readdir(projectDir)).rejects.toMatchObject({ code: 'ENOENT' })
+    await expect(files.getOverview(PROJECT_ID)).resolves.toMatchObject({ totalCount: 0 })
+  })
+
+  it('commits Project deletion without guessing away an unsafe legacy replacement', async () => {
+    const legacyPath = join(storageRoot, 'uploads', 'default-project', SESSION_ID, 'input.csv')
+    await writeManagedFile(legacyPath, 'unrelated replacement bytes')
+
+    await expect(coordinator.deleteProjectSessions(PROJECT_ID)).resolves.toEqual({
+      status: 'completed'
+    })
+
+    await expect(sessions.loadSession(PROJECT_ID, SESSION_ID)).resolves.toBeUndefined()
+    await expect(sessions.getProjectSessionDeletionState(PROJECT_ID)).resolves.toBe('prepared')
+    await expect(readFile(legacyPath, 'utf8')).resolves.toBe('unrelated replacement bytes')
+    await expect(
+      client.uploadVersion.findUnique({ where: { id: 'upload-version-1' } })
+    ).resolves.toBeDefined()
+    await expect(files.getOverview(PROJECT_ID)).resolves.toMatchObject({ totalCount: 0 })
+
+    // Simulate a completed provenance tail followed by tombstone-removal failure and restart. The
+    // prepared marker must prevent recovery from consulting authority that the tail already removed.
+    await client.managedFile.deleteMany({ where: { projectId: PROJECT_ID } })
+    await client.uploadVersion.deleteMany({ where: { uploadFileId: 'upload-1' } })
+    await client.uploadFile.deleteMany({ where: { id: 'upload-1' } })
+    await rm(uploadPath, { force: true })
+    const recoveryCoordinator = new SessionPersistenceCoordinator(
+      sessions,
+      files,
+      undefined,
+      undefined,
+      new UploadRepository(storageRoot, { getClient: () => Promise.resolve(client) })
+    )
+
+    await expect(recoveryCoordinator.deleteProjectSessions(PROJECT_ID)).resolves.toEqual({
+      status: 'completed'
+    })
+    await expect(readFile(legacyPath, 'utf8')).resolves.toBe('unrelated replacement bytes')
+  })
+
+  it('refuses Session deletion when its JSON is unreadable even though unlink would succeed', async () => {
+    const legacyPath = join(storageRoot, 'uploads', 'default-project', SESSION_ID, 'input.csv')
+    const sessionPath = join(storageRoot, 'sessions', PROJECT_ID, `${SESSION_ID}.json`)
+    await writeManagedFile(legacyPath, 'upload bytes')
+    const unreadableSessions = new SessionRepository(storageRoot, {
+      readSessionFile: vi
+        .fn()
+        .mockRejectedValue(Object.assign(new Error('permission denied'), { code: 'EACCES' }))
+    })
+    const guardedCoordinator = new SessionPersistenceCoordinator(
+      unreadableSessions,
+      files,
+      undefined,
+      undefined,
+      new UploadRepository(storageRoot, { getClient: () => Promise.resolve(client) })
+    )
+
+    await expect(guardedCoordinator.deleteSession(PROJECT_ID, SESSION_ID)).rejects.toThrow(
+      /cannot delete.*unreadable/i
+    )
+
+    await expect(readFile(sessionPath, 'utf8')).resolves.toContain(SESSION_ID)
+    await expect(readFile(legacyPath, 'utf8')).resolves.toBe('upload bytes')
+    await expect(
+      client.uploadVersion.findUnique({ where: { id: 'upload-version-1' } })
+    ).resolves.toBeDefined()
+    await expect(rm(sessionPath)).resolves.toBeUndefined()
+  })
+
+  it('deletes malformed Project authority after terminal-cleaning readable sibling Uploads', async () => {
+    const projectDir = join(storageRoot, 'sessions', PROJECT_ID)
+    const sessionPath = join(projectDir, `${SESSION_ID}.json`)
+    const siblingId = 'readable-session'
+    const siblingLegacyPath = join(
+      storageRoot,
+      'uploads',
+      'default-project',
+      siblingId,
+      'readable.csv'
+    )
+    const readableSibling = createSession(uploadPath, artifactPath)
+    readableSibling.id = siblingId
+    readableSibling.messages[0].uploads = [
+      {
+        id: 'readable-upload',
+        sessionId: siblingId,
+        name: 'readable.csv',
+        originalName: 'readable.csv',
+        path: siblingLegacyPath,
+        size: 'readable bytes'.length
+      }
+    ]
+    await writeManagedFile(siblingLegacyPath, 'readable bytes')
+    await writeFile(
+      join(projectDir, `${siblingId}.json`),
+      JSON.stringify({ version: 2, session: readableSibling }),
+      'utf8'
+    )
+    await writeFile(sessionPath, '{malformed Session JSON', 'utf8')
+
+    await expect(coordinator.deleteProjectSessions(PROJECT_ID)).resolves.toEqual({
+      status: 'completed'
+    })
+
+    await expect(readdir(projectDir)).rejects.toMatchObject({ code: 'ENOENT' })
+    await expect(readFile(siblingLegacyPath)).rejects.toMatchObject({ code: 'ENOENT' })
+    await expect(files.getOverview(PROJECT_ID)).resolves.toMatchObject({ totalCount: 0 })
+    await expect(
+      client.uploadVersion.findFirst({ where: { uploadFileId: 'readable-upload', state: 'ready' } })
+    ).resolves.toBeTruthy()
+  })
+
+  it('deletes the target Project without reading an unrelated unavailable Project', async () => {
+    const otherSession = createSession(uploadPath, artifactPath)
+    otherSession.id = 'session-b'
+    otherSession.projectId = 'project-b'
+    otherSession.messages = []
+    otherSession.artifacts = []
+    otherSession.filesRevision = 0
+    await sessions.saveSession(otherSession)
+    const legacyPath = join(storageRoot, 'uploads', 'default-project', SESSION_ID, 'input.csv')
+    await writeManagedFile(legacyPath, 'upload bytes')
+    const scopedSessions = new SessionRepository(storageRoot, {
+      readSessionFile: async (filePath) => {
+        if (filePath.includes(join('sessions', 'project-b'))) {
+          throw Object.assign(new Error('unrelated project unavailable'), { code: 'EACCES' })
+        }
+        return readFile(filePath, 'utf8')
+      }
+    })
+    const scopedCoordinator = new SessionPersistenceCoordinator(
+      scopedSessions,
+      files,
+      undefined,
+      undefined,
+      new UploadRepository(storageRoot, { getClient: () => Promise.resolve(client) })
+    )
+
+    await scopedCoordinator.deleteProjectSessions(PROJECT_ID)
+
+    await expect(sessions.loadSession(PROJECT_ID, SESSION_ID)).resolves.toBeUndefined()
+    await expect(sessions.loadSession('project-b', 'session-b')).resolves.toBeDefined()
+    await expect(readFile(legacyPath)).rejects.toMatchObject({ code: 'ENOENT' })
   })
 })
 
@@ -153,6 +733,38 @@ const createSession = (_uploadPath: string, artifactPath: string): PersistedChat
   createdAt: 100,
   updatedAt: 200
 })
+
+const createPathOnlySession = (legacyPath: string): PersistedChatSession => {
+  const session = createSession('', '')
+  session.artifacts = []
+  session.messages[0].uploads = [
+    {
+      id: 'upload-1',
+      sessionId: SESSION_ID,
+      name: 'input.csv',
+      originalName: 'input.csv',
+      path: legacyPath,
+      size: 'upload bytes'.length
+    }
+  ]
+  return session
+}
+
+const replaceLiveSessionWithLegacyTombstone = async (
+  storageRoot: string,
+  session: PersistedChatSession
+): Promise<string> => {
+  const liveProjectDir = join(storageRoot, 'sessions', PROJECT_ID)
+  const tombstoneDir = join(storageRoot, 'deleted-sessions', PROJECT_ID)
+  await rm(liveProjectDir, { recursive: true, force: true })
+  await mkdir(tombstoneDir, { recursive: true })
+  await writeFile(
+    join(tombstoneDir, `${SESSION_ID}.json`),
+    JSON.stringify({ version: 2, session }),
+    'utf8'
+  )
+  return tombstoneDir
+}
 
 const writeManagedFile = async (path: string, content: string): Promise<void> => {
   await mkdir(dirname(path), { recursive: true })

--- a/src/main/session-persistence/ipc.test.ts
+++ b/src/main/session-persistence/ipc.test.ts
@@ -65,9 +65,8 @@ describe('session persistence IPC handlers', () => {
     const loadResult = { sessions: [session], manifest: { version: 1 as const } }
     const repository = {
       loadAll: vi.fn().mockResolvedValue(loadResult),
-      saveSession: vi.fn().mockResolvedValue(false),
+      saveSession: vi.fn().mockResolvedValue({ created: false, session }),
       deleteSession: vi.fn().mockResolvedValue(undefined),
-      deleteProjectSessions: vi.fn().mockResolvedValue(undefined),
       saveManifest: vi.fn().mockResolvedValue(undefined)
     }
     const reviewRepository = createMockReviewRepository()
@@ -95,9 +94,8 @@ describe('session persistence IPC handlers', () => {
   it('does not report a successful session deletion when the repository fails', async () => {
     const repository = {
       loadAll: vi.fn().mockResolvedValue({ sessions: [], manifest: { version: 1 as const } }),
-      saveSession: vi.fn().mockResolvedValue(false),
+      saveSession: vi.fn().mockResolvedValue({ created: false, session: createSession() }),
       deleteSession: vi.fn().mockRejectedValueOnce(new Error('repository failed')),
-      deleteProjectSessions: vi.fn().mockResolvedValue(undefined),
       saveManifest: vi.fn().mockResolvedValue(undefined)
     }
     const handlers = createSessionPersistenceHandlers(repository, createMockReviewRepository())
@@ -116,11 +114,10 @@ describe('session persistence IPC handlers', () => {
     const order: string[] = []
     const repository = {
       loadAll: vi.fn().mockResolvedValue({ sessions: [], manifest: { version: 1 as const } }),
-      saveSession: vi.fn().mockResolvedValue(false),
+      saveSession: vi.fn().mockResolvedValue({ created: false, session: createSession() }),
       deleteSession: vi.fn(async () => {
         order.push('session')
       }),
-      deleteProjectSessions: vi.fn().mockResolvedValue(undefined),
       saveManifest: vi.fn().mockResolvedValue(undefined)
     }
     const reviewRepository = createMockReviewRepository()
@@ -136,12 +133,41 @@ describe('session persistence IPC handlers', () => {
 
   it('registers each persistence channel and forwards renderer requests', async () => {
     const session = createSession()
+    const durableSession = {
+      ...session,
+      title: 'Durable projection',
+      messages: [
+        {
+          id: 'message-1',
+          role: 'user' as const,
+          content: 'Legacy upload',
+          status: 'complete' as const,
+          eventIds: [],
+          uploads: [
+            {
+              id: 'upload-1',
+              versionId: 'upload-version-1',
+              versionNumber: 1,
+              sessionId: 'session-1',
+              name: 'legacy.csv',
+              originalName: 'legacy.csv',
+              size: 11,
+              sha256: 'a'.repeat(64)
+            }
+          ],
+          createdAt: 1,
+          updatedAt: 1
+        }
+      ]
+    }
     const loadResult = { sessions: [session], manifest: { version: 1 as const } }
     const repository: SessionPersistenceBackend = {
       loadAll: vi.fn().mockResolvedValue(loadResult),
-      saveSession: vi.fn().mockResolvedValueOnce(true).mockResolvedValueOnce(false),
+      saveSession: vi
+        .fn()
+        .mockResolvedValueOnce({ created: true, session: durableSession })
+        .mockResolvedValueOnce({ created: false, session: durableSession }),
       deleteSession: vi.fn().mockResolvedValue(undefined),
-      deleteProjectSessions: vi.fn().mockResolvedValue(undefined),
       saveManifest: vi.fn().mockResolvedValue(undefined)
     }
     const reviewRepository = createMockReviewRepository()
@@ -158,7 +184,9 @@ describe('session persistence IPC handlers', () => {
     const manifestRequest = { lastProjectId: 'project-a', lastSessionId: 'session-1' }
     const event = { sender: { id: -2, lifecycleClientId: 'web:browser-1' } }
     await expect(ipcHandlers.get('sessions:load-all')?.()).resolves.toBe(loadResult)
-    await ipcHandlers.get('sessions:save-session')?.(event, session)
+    await expect(ipcHandlers.get('sessions:save-session')?.(event, session)).resolves.toBe(
+      durableSession
+    )
     const updatedSession = { ...session, title: 'Updated session', updatedAt: 1710000000001 }
     await ipcHandlers.get('sessions:save-session')?.(event, updatedSession)
     await ipcHandlers.get('sessions:delete-session')?.(event, deleteRequest)
@@ -169,11 +197,11 @@ describe('session persistence IPC handlers', () => {
     expect(reviewRepository.deleteReviewsForSession).not.toHaveBeenCalled()
     expect(repository.saveManifest).toHaveBeenCalledWith(manifestRequest)
     expect(broadcastLifecycleEvent).toHaveBeenCalledWith('session:created', {
-      session,
+      session: durableSession,
       originClientId: 'web:browser-1'
     })
     expect(broadcastLifecycleEvent).toHaveBeenCalledWith('session:updated', {
-      session: updatedSession,
+      session: durableSession,
       originClientId: 'web:browser-1'
     })
     expect(broadcastLifecycleEvent).toHaveBeenCalledWith('session:deleted', deleteRequest)
@@ -182,9 +210,8 @@ describe('session persistence IPC handlers', () => {
   it('rejects session persistence while a data-root migration is pending', async () => {
     const repository: SessionPersistenceBackend = {
       loadAll: vi.fn().mockResolvedValue({ sessions: [], manifest: { version: 1 as const } }),
-      saveSession: vi.fn().mockResolvedValue(false),
+      saveSession: vi.fn().mockResolvedValue({ created: false, session: createSession() }),
       deleteSession: vi.fn().mockResolvedValue(undefined),
-      deleteProjectSessions: vi.fn().mockResolvedValue(undefined),
       saveManifest: vi.fn().mockResolvedValue(undefined)
     }
     registerSessionPersistenceIpcHandlers(repository, createMockReviewRepository())
@@ -197,5 +224,24 @@ describe('session persistence IPC handlers', () => {
       })
     ).rejects.toThrow(/moving your data/i)
     expect(repository.deleteSession).not.toHaveBeenCalled()
+  })
+
+  it('does not broadcast a stale projection when durable save propagation fails', async () => {
+    const failure = new Error('durable projection unavailable')
+    const repository: SessionPersistenceBackend = {
+      loadAll: vi.fn().mockResolvedValue({ sessions: [], manifest: { version: 1 as const } }),
+      saveSession: vi.fn().mockRejectedValue(failure),
+      deleteSession: vi.fn().mockResolvedValue(undefined),
+      saveManifest: vi.fn().mockResolvedValue(undefined)
+    }
+    registerSessionPersistenceIpcHandlers(repository, createMockReviewRepository())
+
+    await expect(
+      ipcHandlers.get('sessions:save-session')?.(
+        { sender: { id: 1, lifecycleClientId: 'electron:origin' } },
+        createSession()
+      )
+    ).rejects.toBe(failure)
+    expect(broadcastLifecycleEvent).not.toHaveBeenCalled()
   })
 })

--- a/src/main/session-persistence/ipc.ts
+++ b/src/main/session-persistence/ipc.ts
@@ -16,15 +16,18 @@ import { withDataRootWrite } from '../storage/migration-state'
 
 type SessionPersistenceBackend = {
   loadAll: () => Promise<LoadAllSessionsResult>
-  saveSession: (session: PersistedChatSession) => Promise<boolean>
+  saveSession: (
+    session: PersistedChatSession
+  ) => Promise<{ created: boolean; session: PersistedChatSession }>
   deleteSession: (projectId: string, sessionId: string) => Promise<void>
-  deleteProjectSessions: (projectId: string) => Promise<void>
   saveManifest: (request: SaveSessionManifestRequest) => Promise<void>
 }
 
 type SessionPersistenceHandlers = {
   loadAll: () => Promise<LoadAllSessionsResult>
-  saveSession: (session: PersistedChatSession) => Promise<boolean>
+  saveSession: (
+    session: PersistedChatSession
+  ) => Promise<{ created: boolean; session: PersistedChatSession }>
   deleteSession: (request: DeleteSessionRequest) => Promise<void>
   saveManifest: (request: SaveSessionManifestRequest) => Promise<void>
 }
@@ -66,15 +69,16 @@ const registerSessionPersistenceIpcHandlers = (
   // Hold the shared data-root lease at the IPC boundary so migration drains the complete operation.
   ipcMain.handle('sessions:load-all', () => withDataRootWrite(() => handlers.loadAll()))
   ipcMain.handle('sessions:save-session', async (event, session: PersistedChatSession) => {
-    await withDataRootWrite(async () => {
-      const created = await handlers.saveSession(session)
+    return withDataRootWrite(async () => {
+      const result = await handlers.saveSession(session)
       broadcastLifecycleEvent(
-        created ? LIFECYCLE_CHANNELS.sessionCreated : LIFECYCLE_CHANNELS.sessionUpdated,
+        result.created ? LIFECYCLE_CHANNELS.sessionCreated : LIFECYCLE_CHANNELS.sessionUpdated,
         {
-          session,
+          session: result.session,
           originClientId: getLifecycleClientId(event)
         }
       )
+      return result.session
     })
   })
   ipcMain.handle('sessions:delete-session', async (_event, request: DeleteSessionRequest) => {

--- a/src/main/session-persistence/repository.test.ts
+++ b/src/main/session-persistence/repository.test.ts
@@ -139,6 +139,9 @@ describe('session persistence repository (per-session files)', () => {
     expect(refreshed?.title).toBe('After correction')
     expect(refreshed?.messages.at(-1)?.id).toBe('message-2')
     await expect(repository.loadSession('project-a', 'missing')).resolves.toBeUndefined()
+    await expect(repository.loadSessionWithDiagnostics('project-a', 'missing')).resolves.toEqual({
+      status: 'missing'
+    })
   })
 
   it('never writes finalized upload absolute paths into Session JSON', async () => {
@@ -317,6 +320,57 @@ describe('session persistence repository (per-session files)', () => {
     expect(scan.isComplete).toBe(true)
   })
 
+  it('keeps a terminal Project scan incomplete while a quarantined Session preserves authority', async () => {
+    const repository = new SessionRepository(await createStorageRoot())
+    const projectDir = join(storageRoot!, 'sessions', 'project-a')
+    await mkdir(projectDir, { recursive: true })
+    await writeFile(join(projectDir, 'broken.json'), '{broken json', 'utf8')
+
+    const first = await repository.loadProjectWithDiagnostics('project-a')
+    const second = await repository.loadProjectWithDiagnostics('project-a')
+
+    expect(first).toEqual({ sessions: [], isComplete: false })
+    expect(second).toEqual({ sessions: [], isComplete: false })
+    expect(await readdir(projectDir)).toContainEqual(
+      expect.stringMatching(/^broken\.json\.invalid-/)
+    )
+  })
+
+  it('keeps a quarantined Session unreadable on later terminal lookups', async () => {
+    const repository = new SessionRepository(await createStorageRoot())
+    const projectDir = join(storageRoot!, 'sessions', 'project-a')
+    await mkdir(projectDir, { recursive: true })
+    await writeFile(join(projectDir, 'broken.json'), '{broken json', 'utf8')
+
+    await expect(repository.loadSessionWithDiagnostics('project-a', 'broken')).resolves.toEqual({
+      status: 'unreadable'
+    })
+    await expect(repository.loadSessionWithDiagnostics('project-a', 'broken')).resolves.toEqual({
+      status: 'unreadable'
+    })
+  })
+
+  it('lets a valid current Session supersede its retained older quarantine', async () => {
+    const repository = new SessionRepository(await createStorageRoot())
+    const session = createSession()
+    await repository.saveSession(session)
+    const projectDir = join(storageRoot!, 'sessions', session.projectId)
+    const quarantineName = `${session.id}.json.invalid-1710000000000-1`
+    await writeFile(join(projectDir, quarantineName), '{older malformed authority', 'utf8')
+
+    await expect(repository.loadSession(session.projectId, session.id)).resolves.toMatchObject({
+      id: session.id
+    })
+    await expect(
+      repository.loadSessionWithDiagnostics(session.projectId, session.id)
+    ).resolves.toEqual({ status: 'found', session: expect.objectContaining({ id: session.id }) })
+    await expect(repository.loadProjectWithDiagnostics(session.projectId)).resolves.toEqual({
+      sessions: [expect.objectContaining({ id: session.id })],
+      isComplete: true
+    })
+    await expect(readdir(projectDir)).resolves.toContain(quarantineName)
+  })
+
   it('keeps the scan incomplete without quarantining a session file that cannot be read', async () => {
     const root = await createStorageRoot()
     const session = createSession()
@@ -334,6 +388,63 @@ describe('session persistence repository (per-session files)', () => {
       readFile(join(root, 'sessions', session.projectId, `${session.id}.json`), 'utf8')
     ).resolves.toContain(session.id)
     expect(readSessionFile).toHaveBeenCalledOnce()
+  })
+
+  it('distinguishes an unreadable Session from an absent Session for terminal mutations', async () => {
+    const root = await createStorageRoot()
+    const session = createSession()
+    await new SessionRepository(root).saveSession(session)
+    const repository = new SessionRepository(root, {
+      readSessionFile: vi
+        .fn()
+        .mockRejectedValue(Object.assign(new Error('permission denied'), { code: 'EACCES' }))
+    })
+
+    await expect(
+      repository.loadSessionWithDiagnostics(session.projectId, session.id)
+    ).resolves.toEqual({ status: 'unreadable' })
+  })
+
+  it('keeps terminal diagnostics fail-closed when the Project path is not readable as a directory', async () => {
+    const root = await createStorageRoot()
+    await mkdir(join(root, 'sessions'), { recursive: true })
+    await writeFile(join(root, 'sessions', 'project-a'), 'not a directory', 'utf8')
+    const repository = new SessionRepository(root)
+
+    await expect(repository.loadProjectWithDiagnostics('project-a')).resolves.toEqual({
+      sessions: [],
+      isComplete: false
+    })
+    await expect(repository.loadSessionWithDiagnostics('project-a', 'session-1')).resolves.toEqual({
+      status: 'unreadable'
+    })
+  })
+
+  it('scans one Project completely without reading an unrelated unreadable Project', async () => {
+    const root = await createStorageRoot()
+    const writer = new SessionRepository(root)
+    const projectASession = createSession({ id: 'session-a', projectId: 'project-a' })
+    const projectBSession = createSession({ id: 'session-b', projectId: 'project-b' })
+    await writer.saveSession(projectASession)
+    await writer.saveSession(projectBSession)
+    const readSessionFile = vi.fn(async (filePath: string) => {
+      if (filePath.includes(`${join('sessions', 'project-b')}`)) {
+        throw Object.assign(new Error('unrelated project unavailable'), { code: 'EACCES' })
+      }
+      return readFile(filePath, 'utf8')
+    })
+    const repository = new SessionRepository(root, { readSessionFile })
+
+    await expect(repository.loadProjectWithDiagnostics('project-a')).resolves.toEqual({
+      sessions: [expect.objectContaining({ id: 'session-a', projectId: 'project-a' })],
+      isComplete: true
+    })
+    expect(readSessionFile).not.toHaveBeenCalledWith(
+      expect.stringContaining(join('sessions', 'project-b'))
+    )
+    await expect(repository.loadAllWithDiagnostics()).resolves.toMatchObject({
+      isComplete: false
+    })
   })
 
   it('keeps default dependencies when optional overrides are explicitly undefined', async () => {
@@ -415,19 +526,154 @@ describe('session persistence repository (per-session files)', () => {
     ])
   })
 
-  it('keeps a staged project deletion committed when recursive cleanup fails', async () => {
+  it('keeps valid primary JSON when removing a superseded quarantine fails', async () => {
     const root = await createStorageRoot()
-    const remove = vi.fn().mockRejectedValue(new Error('partial recursive cleanup'))
+    const session = createSession()
+    const quarantinePath = join(
+      root,
+      'sessions',
+      session.projectId,
+      `${session.id}.json.invalid-1710000000000-1`
+    )
+    const removalFailure = new Error('backup is locked')
+    const remove = vi.fn(async (path: string, options: { force: boolean; recursive: boolean }) => {
+      if (path === quarantinePath) throw removalFailure
+      await rm(path, options)
+    })
     const repository = new SessionRepository(root, { remove })
+    await repository.saveSession(session)
+    await writeFile(quarantinePath, '{older malformed authority', 'utf8')
+
+    await expect(repository.deleteSession(session.projectId, session.id)).rejects.toBe(
+      removalFailure
+    )
+
+    await expect(
+      repository.loadSessionWithDiagnostics(session.projectId, session.id)
+    ).resolves.toEqual({ status: 'found', session: expect.objectContaining({ id: session.id }) })
+    await expect(readFile(quarantinePath, 'utf8')).resolves.toBe('{older malformed authority')
+  })
+
+  it('does not delete orphan quarantines or current invalid primary authority', async () => {
+    const root = await createStorageRoot()
+    const projectDir = join(root, 'sessions', 'project-a')
+    const orphanPath = join(projectDir, 'orphan.json.invalid-1710000000000-1')
+    const invalidPath = join(projectDir, 'invalid.json')
+    await mkdir(projectDir, { recursive: true })
+    await writeFile(orphanPath, '{orphan authority', 'utf8')
+    await writeFile(invalidPath, '{current invalid authority', 'utf8')
+    const repository = new SessionRepository(root)
+
+    await expect(repository.deleteSession('project-a', 'orphan')).rejects.toThrow(/unreadable/i)
+    await expect(readFile(orphanPath, 'utf8')).resolves.toBe('{orphan authority')
+
+    await expect(repository.deleteSession('project-a', 'invalid')).rejects.toThrow(/unreadable/i)
+    const invalidBackup = (await readdir(projectDir)).find((name) =>
+      /^invalid\.json\.invalid-\d+-\d+$/u.test(name)
+    )
+    expect(invalidBackup).toBeDefined()
+    await expect(readFile(join(projectDir, invalidBackup!), 'utf8')).resolves.toBe(
+      '{current invalid authority'
+    )
+  })
+
+  it('keeps a marked Project tombstone through loadAll until tail completion', async () => {
+    const root = await createStorageRoot()
+    const repository = new SessionRepository(root)
     await repository.saveSession(createSession({ id: 'session-1', projectId: 'project-a' }))
     await repository.saveSession(createSession({ id: 'session-2', projectId: 'project-a' }))
 
     await expect(repository.deleteProjectSessions('project-a')).resolves.toBeUndefined()
     await expect(repository.loadAll()).resolves.toMatchObject({ sessions: [] })
-    expect(await readdir(join(root, 'deleted-sessions', 'project-a'))).toEqual([
+    expect((await readdir(join(root, 'deleted-sessions', 'project-a'))).sort()).toEqual([
+      '.project-deletion-committed',
       'session-1.json',
       'session-2.json'
     ])
+    await expect(repository.getProjectSessionDeletionState('project-a')).resolves.toBe('prepared')
+    await expect(repository.listLegacyProjectSessionTombstones()).resolves.toEqual([])
+
+    await repository.completeProjectSessionDeletion('project-a')
+
+    await expect(repository.getProjectSessionDeletionState('project-a')).resolves.toBe('absent')
+  })
+
+  it('commits an empty Project Session phase with a durable marker', async () => {
+    const root = await createStorageRoot()
+    const repository = new SessionRepository(root)
+
+    await repository.deleteProjectSessions('project-empty')
+
+    await expect(repository.getProjectSessionDeletionState('project-empty')).resolves.toBe(
+      'prepared'
+    )
+    await expect(readdir(join(root, 'deleted-sessions', 'project-empty'))).resolves.toEqual([
+      '.project-deletion-committed'
+    ])
+  })
+
+  it('discovers an unmarked legacy Project tombstone without deleting its authority', async () => {
+    const root = await createStorageRoot()
+    const legacyTombstone = join(root, 'deleted-sessions', 'project-old')
+    await mkdir(legacyTombstone, { recursive: true })
+    await writeFile(join(legacyTombstone, 'session.json'), '{}', 'utf8')
+    const repository = new SessionRepository(root)
+
+    await expect(repository.getProjectSessionDeletionState('project-old')).resolves.toBe(
+      'legacy-committed'
+    )
+    await repository.loadAll()
+
+    await expect(readdir(legacyTombstone)).resolves.toEqual(['session.json'])
+    await expect(repository.listLegacyProjectSessionTombstones()).resolves.toEqual(['project-old'])
+    await expect(readdir(legacyTombstone)).resolves.toEqual(['session.json'])
+  })
+
+  it('retains a tombstone with a malformed commit marker as unknown authority', async () => {
+    const root = await createStorageRoot()
+    const tombstone = join(root, 'deleted-sessions', 'project-unknown')
+    const marker = join(tombstone, '.project-deletion-committed')
+    await mkdir(marker, { recursive: true })
+    const repository = new SessionRepository(root)
+
+    await expect(repository.getProjectSessionDeletionState('project-unknown')).rejects.toThrow(
+      /marker is invalid/i
+    )
+    await expect(repository.listLegacyProjectSessionTombstones()).rejects.toThrow(
+      /marker is invalid/i
+    )
+    await repository.loadAll()
+
+    await expect(readdir(tombstone)).resolves.toEqual(['.project-deletion-committed'])
+  })
+
+  it('rejects conflicting live authority beside a marked Project tombstone', async () => {
+    const root = await createStorageRoot()
+    const repository = new SessionRepository(root)
+    await repository.saveSession(createSession({ projectId: 'project-conflict' }))
+    const tombstone = join(root, 'deleted-sessions', 'project-conflict')
+    await mkdir(tombstone, { recursive: true })
+    await writeFile(join(tombstone, '.project-deletion-committed'), '', 'utf8')
+
+    await expect(repository.getProjectSessionDeletionState('project-conflict')).rejects.toThrow(
+      /conflicting live authority/i
+    )
+    await expect(repository.listLegacyProjectSessionTombstones()).rejects.toThrow(
+      /conflicting live authority/i
+    )
+  })
+
+  it('rejects conflicting live authority beside an unmarked legacy tombstone', async () => {
+    const root = await createStorageRoot()
+    const repository = new SessionRepository(root)
+    await repository.saveSession(createSession({ projectId: 'project-legacy-conflict' }))
+    const tombstone = join(root, 'deleted-sessions', 'project-legacy-conflict')
+    await mkdir(tombstone, { recursive: true })
+    await writeFile(join(tombstone, 'old-session.json'), '{}', 'utf8')
+
+    await expect(
+      repository.getProjectSessionDeletionState('project-legacy-conflict')
+    ).rejects.toThrow(/conflicting live authority/i)
   })
 
   it('round-trips the manifest', async () => {

--- a/src/main/session-persistence/repository.ts
+++ b/src/main/session-persistence/repository.ts
@@ -1,4 +1,4 @@
-import { mkdir, readFile, readdir, rename, rm, writeFile } from 'node:fs/promises'
+import { lstat, mkdir, readFile, readdir, rename, rm, writeFile } from 'node:fs/promises'
 import { join } from 'node:path'
 
 import {
@@ -16,6 +16,7 @@ import { decodeSessionDataPaths, encodeSessionDataPaths } from './session-data-p
 
 const SESSIONS_DIR = 'sessions'
 const DELETED_SESSIONS_DIR = 'deleted-sessions'
+const PROJECT_DELETION_COMMIT_MARKER = '.project-deletion-committed'
 const MANIFEST_FILE = 'manifest.json'
 const FILE_REPLACEMENT_RETRY_DELAYS_MS = [25, 50, 100, 200, 400] as const
 
@@ -25,6 +26,18 @@ type SessionLoadDiagnostics = {
   // Callers may hydrate the returned sessions but must not reconcile absent index rows as deletions.
   isComplete: boolean
 }
+
+type SessionLoadDiagnostic =
+  | { status: 'found'; session: PersistedChatSession }
+  | { status: 'missing' }
+  | { status: 'unreadable' }
+
+type ProjectSessionLoadDiagnostics = {
+  sessions: PersistedChatSession[]
+  isComplete: boolean
+}
+
+type ProjectSessionDeletionState = 'live' | 'legacy-committed' | 'prepared' | 'absent'
 
 type SessionRepositoryDependencies = {
   remove(path: string, options: { force: boolean; recursive: boolean }): Promise<void>
@@ -131,21 +144,63 @@ class SessionRepository {
     projectId: string,
     sessionId: string
   ): Promise<PersistedChatSession | undefined> {
-    const read = await this.readSessionFile(
-      this.sessionFilePath(projectId, sessionId),
-      assertSafeSegment(projectId)
-    )
-    return read.session
+    const safeProjectId = assertSafeSegment(projectId)
+    return (
+      await this.readSessionFile(
+        this.sessionFilePath(safeProjectId, assertSafeSegment(sessionId)),
+        safeProjectId
+      )
+    ).session
   }
 
-  // Reports whether the sessions tree was fully scanned so DB reconciliation never acts on a partial
-  // read. Cleanup of previously renamed project tombstones is best-effort and does not re-expose them.
+  // Terminal mutations must distinguish absence from a transient/non-ENOENT read failure. Treating
+  // both as undefined could unlink the JSON before Upload cleanup has observed its final authority.
+  async loadSessionWithDiagnostics(
+    projectId: string,
+    sessionId: string
+  ): Promise<SessionLoadDiagnostic> {
+    const safeProjectId = assertSafeSegment(projectId)
+    const safeSessionId = assertSafeSegment(sessionId)
+    const read = await this.readSessionFile(
+      this.sessionFilePath(safeProjectId, safeSessionId),
+      safeProjectId
+    )
+    if (!read.isComplete || read.wasQuarantined) return { status: 'unreadable' }
+
+    const quarantine = await this.hasQuarantinedSessionFile(safeProjectId, safeSessionId)
+    if (!quarantine.isComplete) return { status: 'unreadable' }
+    if (read.session) return { status: 'found', session: read.session }
+    return quarantine.exists ? { status: 'unreadable' } : { status: 'missing' }
+  }
+
+  // Reports whether the live sessions tree was fully scanned so DB reconciliation never acts on a
+  // partial read. Project recovery owns tombstone cleanup before ordinary hydration is allowed.
   async loadAllWithDiagnostics(): Promise<SessionLoadDiagnostics> {
-    await this.cleanupDeletedProjects()
     const { sessions, isComplete } = await this.readAllSessions()
     const manifest = await this.readManifest()
 
     return { result: { sessions, manifest }, isComplete }
+  }
+
+  // Project deletion needs a complete view of only its target authority. An unrelated unreadable
+  // Project must not block deletion, while any target-directory failure remains fail-closed.
+  async loadProjectWithDiagnostics(projectId: string): Promise<ProjectSessionLoadDiagnostics> {
+    return this.readProjectSessions(assertSafeSegment(projectId), {
+      quarantinedIsIncomplete: true
+    })
+  }
+
+  async loadCommittedProjectWithDiagnostics(
+    projectId: string
+  ): Promise<ProjectSessionLoadDiagnostics> {
+    const safeProjectId = assertSafeSegment(projectId)
+    return this.readProjectSessionsAtDirectory(
+      safeProjectId,
+      this.deletedProjectDir(safeProjectId),
+      {
+        quarantinedIsIncomplete: true
+      }
+    )
   }
 
   // Writes one session file (serialized through the save queue to preserve write order).
@@ -153,26 +208,160 @@ class SessionRepository {
     return this.enqueue(() => this.writeSession(session))
   }
 
-  // Removes a single session file.
-  async deleteSession(projectId: string, sessionId: string): Promise<void> {
-    return this.enqueue(() => rm(this.sessionFilePath(projectId, sessionId), { force: true }))
+  async saveCommittedProjectSession(session: PersistedChatSession): Promise<void> {
+    return this.enqueue(async () => {
+      if ((await this.getProjectSessionDeletionState(session.projectId)) !== 'legacy-committed') {
+        throw new Error('Cannot save a Session outside committed Project deletion authority.')
+      }
+      await this.writeSessionToDirectory(session, this.deletedProjectDir(session.projectId))
+    })
   }
 
-  // Atomically removes the project from the readable sessions tree before best-effort cleanup.
+  // Removes a single session file.
+  async deleteSession(projectId: string, sessionId: string): Promise<void> {
+    return this.enqueue(async () => {
+      const safeProjectId = assertSafeSegment(projectId)
+      const safeSessionId = assertSafeSegment(sessionId)
+      const diagnostic = await this.loadSessionWithDiagnostics(safeProjectId, safeSessionId)
+      if (diagnostic.status === 'unreadable') {
+        throw new Error('Cannot delete a Session whose durable JSON is unreadable.')
+      }
+      if (diagnostic.status === 'missing') return
+
+      // The valid primary proves matching quarantines are superseded authority covered by this
+      // explicit Session deletion. Remove every backup first so any failure leaves that proof in
+      // place and the operation safely retryable; only then remove the current primary.
+      const quarantines = await this.listQuarantinedSessionFiles(safeProjectId, safeSessionId)
+      if (!quarantines.isComplete) {
+        throw new Error('Cannot delete a Session whose quarantine directory is unreadable.')
+      }
+      for (const fileName of quarantines.names) {
+        await this.dependencies.remove(join(this.projectDir(safeProjectId), fileName), {
+          force: true,
+          recursive: false
+        })
+      }
+      await this.dependencies.remove(this.sessionFilePath(safeProjectId, safeSessionId), {
+        force: true,
+        recursive: false
+      })
+    })
+  }
+
+  // Atomically moves a marked live directory into the durable deletion area. The marker/tombstone is
+  // retained until Project deletion finishes so recovery can distinguish a committed Session phase
+  // from an attempt that failed before the rename, including for Projects with no Session files.
   async deleteProjectSessions(projectId: string): Promise<void> {
     return this.enqueue(async () => {
-      const deletedProjectDir = this.deletedProjectDir(projectId)
+      const safeProjectId = assertSafeSegment(projectId)
+      const state = await this.getProjectSessionDeletionState(safeProjectId)
+      if (state === 'legacy-committed' || state === 'prepared') return
+
+      const liveProjectDir = this.projectDir(safeProjectId)
+      const deletedProjectDir = this.deletedProjectDir(safeProjectId)
       await mkdir(this.deletedSessionsDir, { recursive: true })
-
-      try {
-        await rename(this.projectDir(projectId), deletedProjectDir)
-      } catch (error) {
-        if (!isMissingFileError(error)) throw error
-      }
-
-      // Once renamed, the session JSON is logically deleted. Cleanup can safely retry on startup.
-      await this.removeDeletedProject(deletedProjectDir)
+      await this.dependencies.remove(deletedProjectDir, { recursive: true, force: true })
+      await mkdir(liveProjectDir, { recursive: true })
+      await writeFile(join(liveProjectDir, PROJECT_DELETION_COMMIT_MARKER), '', 'utf8')
+      await rename(liveProjectDir, deletedProjectDir)
     })
+  }
+
+  async getProjectSessionDeletionState(projectId: string): Promise<ProjectSessionDeletionState> {
+    const safeProjectId = assertSafeSegment(projectId)
+    const deletedProjectDir = this.deletedProjectDir(safeProjectId)
+    const liveProjectDir = this.projectDir(safeProjectId)
+    const markerPath = join(deletedProjectDir, PROJECT_DELETION_COMMIT_MARKER)
+
+    try {
+      const tombstone = await lstat(deletedProjectDir)
+      if (!tombstone.isDirectory() || tombstone.isSymbolicLink()) {
+        throw new Error(`Project Session deletion tombstone is invalid: ${projectId}`)
+      }
+    } catch (error) {
+      if (isMissingFileError(error)) {
+        try {
+          const live = await lstat(liveProjectDir)
+          if (!live.isDirectory() || live.isSymbolicLink()) {
+            throw new Error(`Project Session live authority is invalid: ${projectId}`)
+          }
+          return 'live'
+        } catch (liveError) {
+          if (isMissingFileError(liveError)) return 'absent'
+          throw liveError
+        }
+      }
+      throw error
+    }
+
+    let isPrepared = false
+    try {
+      const marker = await lstat(markerPath)
+      if (!marker.isFile() || marker.isSymbolicLink()) {
+        throw new Error(`Project Session deletion marker is invalid: ${projectId}`)
+      }
+      isPrepared = true
+    } catch (error) {
+      if (!isMissingFileError(error)) throw error
+    }
+
+    // Releases before the marker protocol atomically renamed the same directory and then removed it
+    // best-effort. A surviving unmarked tombstone therefore proves a possible committed old Session
+    // phase and must be treated fail-closed while a Project deletion intent is being recovered.
+    try {
+      await lstat(liveProjectDir)
+    } catch (error) {
+      if (isMissingFileError(error)) return isPrepared ? 'prepared' : 'legacy-committed'
+      throw error
+    }
+    throw new Error(`Project Session deletion has conflicting live authority: ${projectId}`)
+  }
+
+  async markCommittedProjectSessionsPrepared(projectId: string): Promise<void> {
+    await this.enqueue(async () => {
+      if ((await this.getProjectSessionDeletionState(projectId)) !== 'legacy-committed') return
+      await this.atomicWrite(
+        join(this.deletedProjectDir(assertSafeSegment(projectId)), PROJECT_DELETION_COMMIT_MARKER),
+        ''
+      )
+    })
+  }
+
+  async completeProjectSessionDeletion(projectId: string): Promise<void> {
+    await this.enqueue(() =>
+      this.dependencies.remove(this.deletedProjectDir(assertSafeSegment(projectId)), {
+        recursive: true,
+        force: true
+      })
+    )
+  }
+
+  async listLegacyProjectSessionTombstones(): Promise<string[]> {
+    let entries
+    try {
+      entries = await readdir(this.deletedSessionsDir, { withFileTypes: true })
+    } catch (error) {
+      if (isMissingFileError(error)) return []
+      throw error
+    }
+
+    const projectIds: string[] = []
+    for (const entry of entries) {
+      // Every direct child is deletion authority. Ignoring an unexpected file or symlink could hide
+      // an old tombstone from adoption and permanently strand the only legacy Upload locator.
+      if (!entry.isDirectory() || entry.isSymbolicLink()) {
+        throw new Error(`Project Session deletion tombstone is invalid: ${entry.name}`)
+      }
+      const projectId = assertSafeSegment(entry.name)
+      const state = await this.getProjectSessionDeletionState(projectId)
+      if (state === 'legacy-committed') projectIds.push(projectId)
+      else if (state !== 'prepared') {
+        // A tombstone observed by this scan must remain authoritative through classification. Treat
+        // concurrent disappearance or conflicting live authority as unknown instead of skipping it.
+        throw new Error(`Project Session deletion tombstone state changed: ${projectId}`)
+      }
+    }
+    return projectIds.sort()
   }
 
   // Persists the last-open project/session pointer.
@@ -194,6 +383,13 @@ class SessionRepository {
 
   // Writes through a unique temp file, then atomically replaces the target session file.
   private async writeSession(session: PersistedChatSession): Promise<void> {
+    await this.writeSessionToDirectory(session, this.projectDir(session.projectId))
+  }
+
+  private async writeSessionToDirectory(
+    session: PersistedChatSession,
+    projectDirectory: string
+  ): Promise<void> {
     const messages = [...session.messages, ...(session.conversationGraph?.messages ?? [])]
     const legacyUpload = messages
       .flatMap((message) => message.uploads ?? [])
@@ -203,10 +399,10 @@ class SessionRepository {
         `Session upload must be upgraded to an immutable Version before persistence: ${legacyUpload.id}`
       )
     }
-    const filePath = this.sessionFilePath(session.projectId, session.id)
+    const filePath = join(projectDirectory, `${assertSafeSegment(session.id)}.json`)
     const sanitizedSession = sanitizeSessionUploadedAttachments(session)
 
-    await mkdir(this.projectDir(session.projectId), { recursive: true })
+    await mkdir(projectDirectory, { recursive: true })
     await this.atomicWrite(filePath, createSessionFile(encodeSessionDataPaths(sanitizedSession)))
   }
 
@@ -240,19 +436,6 @@ class SessionRepository {
     }
   }
 
-  private async cleanupDeletedProjects(): Promise<void> {
-    const deletedProjects = await this.listDirectoryNames(this.deletedSessionsDir)
-    for (const projectId of deletedProjects.names) {
-      await this.removeDeletedProject(join(this.deletedSessionsDir, projectId))
-    }
-  }
-
-  // Physical cleanup happens after the atomic rename removed the directory from the readable tree.
-  // Failures are intentionally swallowed because startup will retry the tombstone later.
-  private async removeDeletedProject(path: string): Promise<void> {
-    await this.dependencies.remove(path, { recursive: true, force: true }).catch(() => undefined)
-  }
-
   private async readManifest(): Promise<PersistedSessionManifest> {
     try {
       const raw = await readFile(this.manifestPath, 'utf8')
@@ -274,18 +457,49 @@ class SessionRepository {
     let isComplete = projectDirectories.isComplete
 
     for (const projectId of projectDirectories.names) {
-      const projectDir = join(this.sessionsDir, projectId)
-      const sessionFiles = await this.listSessionFileNames(projectDir)
-      isComplete &&= sessionFiles.isComplete
+      const project = await this.readProjectSessions(projectId)
+      sessions.push(...project.sessions)
+      isComplete &&= project.isComplete
+    }
 
-      for (const fileName of sessionFiles.names) {
-        // The directory is the authoritative owning project, regardless of the file's stored projectId.
-        const read = await this.readSessionFile(join(projectDir, fileName), projectId)
-        isComplete &&= read.isComplete
+    return { sessions, isComplete }
+  }
 
-        if (read.session) sessions.push(read.session)
+  private async readProjectSessions(
+    projectIdValue: string,
+    options: { quarantinedIsIncomplete?: boolean } = {}
+  ): Promise<ProjectSessionLoadDiagnostics> {
+    const projectId = assertSafeSegment(projectIdValue)
+    return this.readProjectSessionsAtDirectory(
+      projectId,
+      join(this.sessionsDir, projectId),
+      options
+    )
+  }
+
+  private async readProjectSessionsAtDirectory(
+    projectId: string,
+    projectDir: string,
+    options: { quarantinedIsIncomplete?: boolean } = {}
+  ): Promise<ProjectSessionLoadDiagnostics> {
+    const sessionFiles = await this.listSessionFileNames(projectDir)
+    const sessions: PersistedChatSession[] = []
+    const activeQuarantines = new Set(sessionFiles.quarantinedPrimaryFileNames)
+    let isComplete = sessionFiles.isComplete
+
+    for (const fileName of sessionFiles.names) {
+      // The directory is the authoritative owning project, regardless of the file's stored projectId.
+      const read = await this.readSessionFile(join(projectDir, fileName), projectId)
+      isComplete &&= read.isComplete
+      if (options.quarantinedIsIncomplete && read.wasQuarantined) isComplete = false
+      if (read.session) {
+        // A current primary that successfully normalizes supersedes retained historical backups for
+        // the same file. Keep the backups, but do not let them permanently block terminal mutation.
+        activeQuarantines.delete(fileName)
+        sessions.push(read.session)
       }
     }
+    if (options.quarantinedIsIncomplete && activeQuarantines.size > 0) isComplete = false
 
     return { sessions, isComplete }
   }
@@ -293,7 +507,11 @@ class SessionRepository {
   private async readSessionFile(
     filePath: string,
     projectId: string
-  ): Promise<{ session?: PersistedChatSession; isComplete: boolean }> {
+  ): Promise<{
+    session?: PersistedChatSession
+    isComplete: boolean
+    wasQuarantined?: boolean
+  }> {
     let raw: string
     try {
       raw = await this.dependencies.readSessionFile(filePath)
@@ -306,11 +524,15 @@ class SessionRepository {
       const session = normalizeSessionFile(JSON.parse(raw) as unknown, {
         preserveLegacyUploadPaths: true
       })
-      if (!session) return { isComplete: await this.tryBackupInvalidFile(filePath) }
+      if (!session) {
+        const wasQuarantined = await this.tryBackupInvalidFile(filePath)
+        return { isComplete: wasQuarantined, wasQuarantined }
+      }
 
       return { session: decodeSessionDataPaths({ ...session, projectId }), isComplete: true }
     } catch {
-      return { isComplete: await this.tryBackupInvalidFile(filePath) }
+      const wasQuarantined = await this.tryBackupInvalidFile(filePath)
+      return { isComplete: wasQuarantined, wasQuarantined }
     }
   }
 
@@ -328,11 +550,14 @@ class SessionRepository {
     }
   }
 
-  // Lists only committed session JSON files. In-progress temp writes and quarantined invalid files are
-  // excluded, while non-ENOENT directory failures keep reconciliation disabled.
-  private async listSessionFileNames(
-    dir: string
-  ): Promise<{ names: string[]; isComplete: boolean }> {
+  // Lists only committed session JSON files. Quarantines are associated with their former primary so
+  // terminal scans can distinguish orphan authority from a backup superseded by valid current JSON.
+  // In-progress temp writes stay excluded and non-ENOENT directory failures disable reconciliation.
+  private async listSessionFileNames(dir: string): Promise<{
+    names: string[]
+    isComplete: boolean
+    quarantinedPrimaryFileNames: string[]
+  }> {
     try {
       const entries = await readdir(dir, { withFileTypes: true })
 
@@ -346,6 +571,40 @@ class SessionRepository {
               !entry.name.includes('.invalid-')
           )
           .map((entry) => entry.name),
+        isComplete: true,
+        quarantinedPrimaryFileNames: entries.flatMap((entry) => {
+          const match = /^(.*\.json)\.invalid-\d+-\d+$/u.exec(entry.name)
+          return match ? [match[1]] : []
+        })
+      }
+    } catch (error) {
+      return {
+        names: [],
+        isComplete: isMissingFileError(error),
+        quarantinedPrimaryFileNames: []
+      }
+    }
+  }
+
+  private async hasQuarantinedSessionFile(
+    projectId: string,
+    sessionId: string
+  ): Promise<{ exists: boolean; isComplete: boolean }> {
+    const quarantines = await this.listQuarantinedSessionFiles(projectId, sessionId)
+    return { exists: quarantines.names.length > 0, isComplete: quarantines.isComplete }
+  }
+
+  private async listQuarantinedSessionFiles(
+    projectId: string,
+    sessionId: string
+  ): Promise<{ names: string[]; isComplete: boolean }> {
+    try {
+      const entries = await readdir(this.projectDir(projectId))
+      const prefix = `${sessionId}.json.invalid-`
+      return {
+        names: entries.filter(
+          (entry) => entry.startsWith(prefix) && /^\d+-\d+$/u.test(entry.slice(prefix.length))
+        ),
         isComplete: true
       }
     } catch (error) {
@@ -377,4 +636,5 @@ const isMissingFileError = (error: unknown): boolean =>
   (error as { code?: unknown }).code === 'ENOENT'
 
 export { SessionRepository, getSessionPersistenceDir }
+export type { ProjectSessionDeletionState, ProjectSessionLoadDiagnostics, SessionLoadDiagnostic }
 export type { SessionLoadDiagnostics }

--- a/src/main/uploads/repository.test.ts
+++ b/src/main/uploads/repository.test.ts
@@ -1,13 +1,33 @@
-import { mkdir, mkdtemp, readFile, realpath, rm, stat, writeFile } from 'node:fs/promises'
+import { createHash } from 'node:crypto'
+import {
+  lstat,
+  mkdir,
+  mkdtemp,
+  readFile,
+  realpath,
+  rename,
+  rm,
+  stat,
+  symlink,
+  writeFile
+} from 'node:fs/promises'
 import { tmpdir } from 'node:os'
 import { dirname, join, relative, sep } from 'node:path'
 import { Readable } from 'node:stream'
 import { afterEach, describe, expect, it, vi } from 'vitest'
 
-import { createUploadVersionReference, PENDING_UPLOAD_SESSION_ID } from '../../shared/uploads'
+import {
+  createUploadVersionReference,
+  PENDING_UPLOAD_SESSION_ID,
+  type PersistedUploadedAttachment
+} from '../../shared/uploads'
 import type { PersistedChatSession } from '../../shared/session-persistence'
 import { createProjectDbClient, ensureProjectSchema } from '../projects/prisma-client'
-import { UploadRepository } from './repository'
+import {
+  OrphanLegacyUploadAuthorityMissingError,
+  UnsafeLegacyUploadResidualError,
+  UploadRepository
+} from './repository'
 import { stageUploadFixtures } from './repository.test-utils'
 
 let storageRoot: string | undefined
@@ -17,6 +37,73 @@ const createStorageRoot = async (): Promise<string> => {
   storageRoot = await mkdtemp(join(tmpdir(), 'open-science-uploads-'))
   return storageRoot
 }
+
+const createSessionWithGraphUpload = (
+  primaryUpload: PersistedUploadedAttachment,
+  graphUpload: PersistedUploadedAttachment
+): PersistedChatSession => ({
+  id: 'session-1',
+  projectId: 'project-1',
+  title: 'Conflicting Upload references',
+  cwd: '/workspace',
+  status: 'idle',
+  messages: [
+    {
+      id: 'message-primary',
+      role: 'user',
+      content: 'Primary upload',
+      status: 'complete',
+      eventIds: [],
+      uploads: [primaryUpload],
+      createdAt: 1,
+      updatedAt: 1
+    }
+  ],
+  conversationGraph: {
+    schemaVersion: 1,
+    rootFrameId: 'frame-root',
+    activeFrameId: 'frame-root',
+    frames: [
+      {
+        id: 'frame-root',
+        originBindingState: 'root',
+        kind: 'root',
+        status: 'completed',
+        activeBranchId: 'branch-root',
+        createdAt: 1,
+        completedAt: 1
+      }
+    ],
+    branches: [
+      {
+        id: 'branch-root',
+        agentFrameId: 'frame-root',
+        headMessageId: 'message-graph',
+        createdAt: 1,
+        updatedAt: 1
+      }
+    ],
+    messages: [
+      {
+        id: 'message-graph',
+        agentFrameId: 'frame-root',
+        introducedOnBranchId: 'branch-root',
+        role: 'user',
+        content: 'Graph upload',
+        status: 'complete',
+        eventIds: [],
+        uploads: [graphUpload],
+        createdAt: 1,
+        updatedAt: 1
+      }
+    ],
+    activities: [],
+    activityGroups: [],
+    runtimeSegments: []
+  },
+  createdAt: 1,
+  updatedAt: 1
+})
 
 afterEach(async () => {
   await disconnect?.()
@@ -494,8 +581,11 @@ describe('upload repository', () => {
       'content'
     ].join('/')
     const finalPath = join(root, ...storageKey.split('/'))
+    const legacyPath = join(root, 'uploads', 'default-project', 'session-1', 'renamed.txt')
+    await mkdir(dirname(legacyPath), { recursive: true })
     await mkdir(dirname(finalPath), { recursive: true })
-    await writeFile(finalPath, content)
+    await writeFile(legacyPath, content)
+    await rename(legacyPath, finalPath)
     await client.fileOriginSession.create({
       data: { projectId: 'project-1', sessionId: 'session-1' }
     })
@@ -524,6 +614,8 @@ describe('upload repository', () => {
 
     await repository.recoverStagingUploads()
 
+    await expect(readFile(legacyPath)).rejects.toMatchObject({ code: 'ENOENT' })
+    await expect(readFile(finalPath)).resolves.toEqual(content)
     await expect(
       client.uploadVersion.findUniqueOrThrow({ where: { id: versionId } })
     ).resolves.toMatchObject({ state: 'ready' })
@@ -538,6 +630,67 @@ describe('upload repository', () => {
         }
       })
     ).resolves.toMatchObject({ sourceVersionId: versionId })
+  })
+
+  it('recovers and removes a deterministic live-copy temp left before its final rename', async () => {
+    const root = await createStorageRoot()
+    const client = createProjectDbClient(root)
+    disconnect = () => client.$disconnect()
+    await ensureProjectSchema(client)
+    const repository = new UploadRepository(root, { getClient: () => Promise.resolve(client) })
+    const content = Buffer.from('copied before crash')
+    const checksum = createHash('sha256').update(content).digest('hex')
+    const versionId = 'upload-version-live-copy-crash'
+    const storageKey = [
+      'uploads',
+      'project-1',
+      'session-1',
+      'upload-live-copy-crash',
+      'versions',
+      versionId,
+      'content'
+    ].join('/')
+    const finalPath = join(root, ...storageKey.split('/'))
+    const temporaryPath = `${finalPath}.live-copy.tmp`
+    const legacyPath = join(root, 'uploads', 'default-project', 'session-1', 'legacy.txt')
+    await mkdir(dirname(finalPath), { recursive: true })
+    await mkdir(dirname(legacyPath), { recursive: true })
+    await writeFile(temporaryPath, content)
+    await writeFile(legacyPath, content)
+    await client.fileOriginSession.create({
+      data: { projectId: 'project-1', sessionId: 'session-1' }
+    })
+    await client.uploadFile.create({
+      data: {
+        id: 'upload-live-copy-crash',
+        projectId: 'project-1',
+        sessionId: 'session-1',
+        filename: 'legacy.txt',
+        originalFilename: 'legacy.txt',
+        versions: {
+          create: {
+            id: versionId,
+            versionNumber: 1,
+            state: 'staging',
+            contentStorageKey: storageKey,
+            filename: 'legacy.txt',
+            originalFilename: 'legacy.txt',
+            contentType: 'text/plain',
+            sizeBytes: BigInt(content.byteLength),
+            checksum
+          }
+        }
+      }
+    })
+
+    await repository.recoverStagingUploads()
+
+    await expect(readFile(finalPath)).resolves.toEqual(content)
+    await expect(readFile(temporaryPath)).rejects.toMatchObject({ code: 'ENOENT' })
+    await expect(readFile(legacyPath)).resolves.toEqual(content)
+    await expect(
+      client.uploadVersion.findUniqueOrThrow({ where: { id: versionId } })
+    ).resolves.toMatchObject({ state: 'ready' })
   })
 
   it('upgrades a legacy session upload before writing a path-free Session projection', async () => {
@@ -589,14 +742,653 @@ describe('upload repository', () => {
       versionNumber: 1,
       sha256: '5fe3f7b7e3492c63599954312dcb1e1d78488782753b6d3068c8d03292c7c1f6'
     })
-    expect(upload?.versionId).toMatch(/^[0-9a-f-]{36}$/u)
+    const versionId = upload?.versionId
+    expect(versionId).toMatch(/^[0-9a-f-]{36}$/u)
+    if (!versionId) throw new Error('Legacy upload upgrade did not create a Version identity.')
     expect(upload).not.toHaveProperty('path')
     expect(upload).not.toHaveProperty('createdAt')
-    await expect(readFile(legacyPath, 'utf8')).resolves.toBe('sample,value\na,1\n')
+    await expect(readFile(legacyPath, 'utf8')).rejects.toMatchObject({ code: 'ENOENT' })
     const version = await client.uploadVersion.findUniqueOrThrow({
-      where: { id: upload?.versionId }
+      where: { id: versionId }
     })
     expect(version).toMatchObject({ state: 'ready', createdAt: null })
+
+    const preview = await repository.readManagedUploadPreview({
+      path: createUploadVersionReference(versionId, {
+        projectId: 'project-1',
+        sessionId: 'session-1'
+      }),
+      projectId: 'project-1',
+      sessionId: 'session-1',
+      encoding: 'utf8'
+    })
+    expect(preview.content).toBe('sample,value\na,1\n')
+
+    // A crash before Session JSON persistence leaves the original path-only projection on disk.
+    // Retrying it must recover from the already-ready Version without recreating legacy bytes.
+    const retried = await repository.upgradeLegacySessionUploads(session)
+    expect(retried.messages[0].uploads?.[0]?.versionId).toBe(versionId)
+    await expect(
+      client.uploadVersion.count({ where: { uploadFileId: 'legacy-upload-1' } })
+    ).resolves.toBe(1)
+    await expect(readFile(legacyPath, 'utf8')).rejects.toMatchObject({ code: 'ENOENT' })
+  })
+
+  it('preserves the live legacy source until a later reconciliation observes the path-free projection', async () => {
+    const root = await createStorageRoot()
+    const client = createProjectDbClient(root)
+    disconnect = () => client.$disconnect()
+    await ensureProjectSchema(client)
+    const repository = new UploadRepository(root, { getClient: () => Promise.resolve(client) })
+    const content = 'sample,value\na,1\n'
+    const legacyPath = join(root, 'uploads', 'default-project', 'session-1', 'legacy.csv')
+    await mkdir(dirname(legacyPath), { recursive: true })
+    await writeFile(legacyPath, content)
+    const session: PersistedChatSession = {
+      id: 'session-1',
+      projectId: 'project-1',
+      title: 'Live legacy upload',
+      cwd: '/workspace',
+      status: 'idle',
+      messages: [
+        {
+          id: 'message-1',
+          role: 'user',
+          content: 'Inspect this',
+          status: 'complete',
+          eventIds: [],
+          uploads: [
+            {
+              id: 'legacy-upload-live',
+              sessionId: 'session-1',
+              name: 'legacy.csv',
+              originalName: 'legacy.csv',
+              path: legacyPath,
+              mimeType: 'text/csv',
+              size: Buffer.byteLength(content)
+            }
+          ],
+          createdAt: 1,
+          updatedAt: 1
+        }
+      ],
+      createdAt: 1,
+      updatedAt: 1
+    }
+
+    const durable = await repository.upgradeLegacySessionUploads(session, { mode: 'live-save' })
+    const versionId = durable.messages[0].uploads?.[0]?.versionId
+
+    expect(versionId).toBeTruthy()
+    expect(durable.messages[0].uploads?.[0]).not.toHaveProperty('path')
+    await expect(readFile(legacyPath, 'utf8')).resolves.toBe(content)
+    await expect(
+      repository.readManagedUploadPreview({
+        path: createUploadVersionReference(versionId!, {
+          projectId: 'project-1',
+          sessionId: 'session-1'
+        }),
+        projectId: 'project-1',
+        sessionId: 'session-1',
+        encoding: 'utf8'
+      })
+    ).resolves.toMatchObject({ content })
+
+    await repository.upgradeLegacySessionUploads(durable)
+
+    await expect(readFile(legacyPath)).rejects.toMatchObject({ code: 'ENOENT' })
+  })
+
+  it('retains orphan bytes without authority but drops a positively absent legacy reference', async () => {
+    const root = await createStorageRoot()
+    const client = createProjectDbClient(root)
+    disconnect = () => client.$disconnect()
+    await ensureProjectSchema(client)
+    const repository = new UploadRepository(root, { getClient: () => Promise.resolve(client) })
+    const content = 'sample,value\na,1\n'
+    const legacyPath = join(root, 'uploads', 'default-project', 'session-1', 'legacy.csv')
+    await mkdir(dirname(legacyPath), { recursive: true })
+    await writeFile(legacyPath, content)
+    const session: PersistedChatSession = {
+      id: 'session-1',
+      projectId: 'project-1',
+      title: 'Orphaned legacy upload',
+      cwd: '/workspace',
+      status: 'idle',
+      messages: [
+        {
+          id: 'message-1',
+          role: 'user',
+          content: 'Inspect this',
+          status: 'complete',
+          eventIds: [],
+          uploads: [
+            {
+              id: 'missing-upload-authority',
+              sessionId: 'session-1',
+              name: 'legacy.csv',
+              originalName: 'legacy.csv',
+              path: legacyPath,
+              mimeType: 'text/csv',
+              size: Buffer.byteLength(content)
+            }
+          ],
+          createdAt: 1,
+          updatedAt: 1
+        }
+      ],
+      createdAt: 1,
+      updatedAt: 1
+    }
+
+    await expect(
+      repository.upgradeLegacySessionUploads(session, { mode: 'orphan-recovery' })
+    ).rejects.toThrow(/legacy Upload authority is unavailable/i)
+
+    await expect(readFile(legacyPath, 'utf8')).resolves.toBe(content)
+    await expect(
+      client.uploadFile.findUnique({ where: { id: 'missing-upload-authority' } })
+    ).resolves.toBeNull()
+    await expect(client.uploadVersion.count()).resolves.toBe(0)
+    await expect(client.managedFile.count()).resolves.toBe(0)
+
+    await rm(legacyPath)
+    const versionsRoot = join(
+      root,
+      'uploads',
+      'project-1',
+      'session-1',
+      'missing-upload-authority',
+      'versions'
+    )
+    const externalEmptyDir = join(root, 'external-empty')
+    await mkdir(dirname(versionsRoot), { recursive: true })
+    await mkdir(externalEmptyDir)
+    await symlink(externalEmptyDir, versionsRoot)
+    await expect(
+      repository.upgradeLegacySessionUploads(session, { mode: 'orphan-recovery' })
+    ).rejects.toThrow(/legacy Upload authority is unavailable/i)
+    await rm(versionsRoot)
+
+    const liveCopyPath = join(versionsRoot, 'unknown-version', 'content.live-copy.tmp')
+    await mkdir(dirname(liveCopyPath), { recursive: true })
+    await writeFile(liveCopyPath, content)
+    await expect(
+      repository.upgradeLegacySessionUploads(session, { mode: 'orphan-recovery' })
+    ).rejects.toThrow(/legacy Upload authority is unavailable/i)
+    await rm(liveCopyPath)
+
+    const cleaned = await repository.upgradeLegacySessionUploads(session, {
+      mode: 'orphan-recovery'
+    })
+
+    expect(cleaned.messages[0].uploads).toEqual([])
+    await expect(
+      client.uploadFile.findUnique({ where: { id: 'missing-upload-authority' } })
+    ).resolves.toBeNull()
+  })
+
+  it('rejects conflicting orphan locators before a cached absence can drop graph bytes', async () => {
+    const root = await createStorageRoot()
+    const client = createProjectDbClient(root)
+    disconnect = () => client.$disconnect()
+    await ensureProjectSchema(client)
+    const repository = new UploadRepository(root, { getClient: () => Promise.resolve(client) })
+    const uploadId = 'conflicting-orphan-upload'
+    const absentPath = join(root, 'uploads', 'default-project', 'session-1', 'absent.csv')
+    const presentPath = join(root, 'uploads', 'default-project', 'session-1', 'present.csv')
+    const presentContent = Buffer.from('present graph bytes')
+    await mkdir(dirname(presentPath), { recursive: true })
+    await writeFile(presentPath, presentContent)
+    const primaryUpload: PersistedUploadedAttachment = {
+      id: uploadId,
+      sessionId: 'session-1',
+      name: 'absent.csv',
+      originalName: 'absent.csv',
+      path: absentPath,
+      mimeType: 'text/csv',
+      size: presentContent.byteLength
+    }
+    const graphUpload: PersistedUploadedAttachment = {
+      ...primaryUpload,
+      name: 'present.csv',
+      originalName: 'present.csv',
+      path: presentPath
+    }
+    const session = createSessionWithGraphUpload(primaryUpload, graphUpload)
+
+    let rejection: unknown
+    try {
+      await repository.upgradeLegacySessionUploads(session, { mode: 'orphan-recovery' })
+    } catch (error) {
+      rejection = error
+    }
+
+    expect(rejection).toBeInstanceOf(Error)
+    expect(rejection).not.toBeInstanceOf(OrphanLegacyUploadAuthorityMissingError)
+    expect((rejection as Error).message).toMatch(/conflicting immutable identity/i)
+    expect(session.messages[0].uploads?.[0]?.path).toBe(absentPath)
+    expect(session.conversationGraph?.messages[0].uploads?.[0]?.path).toBe(presentPath)
+    await expect(readFile(presentPath)).resolves.toEqual(presentContent)
+    await expect(readFile(absentPath)).rejects.toMatchObject({ code: 'ENOENT' })
+    await expect(client.uploadFile.count()).resolves.toBe(0)
+    await expect(client.uploadVersion.count()).resolves.toBe(0)
+    await expect(client.managedFile.count()).resolves.toBe(0)
+    await expect(client.managedFileSessionSync.count()).resolves.toBe(0)
+    await expect(client.fileOriginSession.count()).resolves.toBe(0)
+  })
+
+  it('rejects conflicting authoritative locators before publishing or rewriting either reference', async () => {
+    const root = await createStorageRoot()
+    const client = createProjectDbClient(root)
+    disconnect = () => client.$disconnect()
+    await ensureProjectSchema(client)
+    const repository = new UploadRepository(root, { getClient: () => Promise.resolve(client) })
+    const uploadId = 'conflicting-existing-upload'
+    const versionId = 'conflicting-existing-version'
+    const firstContent = Buffer.from('first locator bytes')
+    const secondContent = Buffer.from('second locator bytes')
+    const checksum = createHash('sha256').update(firstContent).digest('hex')
+    const firstPath = join(root, 'uploads', 'default-project', 'session-1', 'first.csv')
+    const secondPath = join(root, 'uploads', 'default-project', 'session-1', 'second.csv')
+    const contentStorageKey = [
+      'uploads',
+      'project-1',
+      'session-1',
+      uploadId,
+      'versions',
+      versionId,
+      'content'
+    ].join('/')
+    const finalPath = join(root, ...contentStorageKey.split('/'))
+    await mkdir(dirname(firstPath), { recursive: true })
+    await writeFile(firstPath, firstContent)
+    await writeFile(secondPath, secondContent)
+    await client.fileOriginSession.create({
+      data: { projectId: 'project-1', sessionId: 'session-1' }
+    })
+    await client.uploadFile.create({
+      data: {
+        id: uploadId,
+        projectId: 'project-1',
+        sessionId: 'session-1',
+        filename: 'first.csv',
+        originalFilename: 'first.csv',
+        versions: {
+          create: {
+            id: versionId,
+            versionNumber: 1,
+            state: 'staging',
+            contentStorageKey,
+            filename: 'first.csv',
+            originalFilename: 'first.csv',
+            contentType: 'text/csv',
+            sizeBytes: BigInt(firstContent.byteLength),
+            checksum
+          }
+        }
+      }
+    })
+    const primaryUpload: PersistedUploadedAttachment = {
+      id: uploadId,
+      sessionId: 'session-1',
+      name: 'first.csv',
+      originalName: 'first.csv',
+      path: firstPath,
+      mimeType: 'text/csv',
+      size: firstContent.byteLength
+    }
+    const graphUpload: PersistedUploadedAttachment = {
+      ...primaryUpload,
+      name: 'second.csv',
+      originalName: 'second.csv',
+      path: secondPath,
+      size: secondContent.byteLength
+    }
+    const session = createSessionWithGraphUpload(primaryUpload, graphUpload)
+
+    let rejection: unknown
+    try {
+      await repository.upgradeLegacySessionUploads(session, { mode: 'orphan-recovery' })
+    } catch (error) {
+      rejection = error
+    }
+
+    expect(rejection).toBeInstanceOf(Error)
+    expect(rejection).not.toBeInstanceOf(OrphanLegacyUploadAuthorityMissingError)
+    expect((rejection as Error).message).toMatch(/conflicting immutable identity/i)
+    expect(session.messages[0].uploads?.[0]?.path).toBe(firstPath)
+    expect(session.conversationGraph?.messages[0].uploads?.[0]?.path).toBe(secondPath)
+    await expect(readFile(firstPath)).resolves.toEqual(firstContent)
+    await expect(readFile(secondPath)).resolves.toEqual(secondContent)
+    await expect(readFile(finalPath)).rejects.toMatchObject({ code: 'ENOENT' })
+    await expect(
+      client.uploadVersion.findUniqueOrThrow({ where: { id: versionId } })
+    ).resolves.toMatchObject({ state: 'staging' })
+    await expect(client.uploadFile.count()).resolves.toBe(1)
+    await expect(client.uploadVersion.count()).resolves.toBe(1)
+    await expect(client.managedFile.count()).resolves.toBe(0)
+    await expect(client.managedFileSessionSync.count()).resolves.toBe(0)
+    await expect(client.fileOriginSession.count()).resolves.toBe(1)
+  })
+
+  it('removes a verified legacy copy when reusing an existing ready Upload Version', async () => {
+    const root = await createStorageRoot()
+    const client = createProjectDbClient(root)
+    disconnect = () => client.$disconnect()
+    await ensureProjectSchema(client)
+    const repository = new UploadRepository(root, { getClient: () => Promise.resolve(client) })
+    const content = Buffer.from('sample,value\na,1\n')
+    const checksum = '5fe3f7b7e3492c63599954312dcb1e1d78488782753b6d3068c8d03292c7c1f6'
+    const versionId = 'legacy-ready-version-1'
+    const contentStorageKey = [
+      'uploads',
+      'project-1',
+      'session-1',
+      'legacy-upload-ready',
+      'versions',
+      versionId,
+      'content'
+    ].join('/')
+    const finalPath = join(root, ...contentStorageKey.split('/'))
+    const legacyPath = join(root, 'uploads', 'default-project', 'session-1', 'legacy.csv')
+    const cleanupPrivateDir = `${legacyPath}.legacy-cleanup.private`
+    const cleanupPrivatePath = join(cleanupPrivateDir, 'candidate')
+    const unrelatedPath = join(root, 'uploads', 'default-project', 'session-1', 'other.csv')
+    await mkdir(dirname(finalPath), { recursive: true })
+    await mkdir(dirname(legacyPath), { recursive: true })
+    await writeFile(finalPath, content)
+    await writeFile(legacyPath, content)
+    await writeFile(unrelatedPath, content)
+    await client.fileOriginSession.create({
+      data: { projectId: 'project-1', sessionId: 'session-1' }
+    })
+    await client.uploadFile.create({
+      data: {
+        id: 'legacy-upload-ready',
+        projectId: 'project-1',
+        sessionId: 'session-1',
+        filename: 'legacy.csv',
+        originalFilename: 'legacy.csv',
+        versions: {
+          create: {
+            id: versionId,
+            versionNumber: 1,
+            state: 'ready',
+            contentStorageKey,
+            filename: 'legacy.csv',
+            originalFilename: 'legacy.csv',
+            contentType: 'text/csv',
+            sizeBytes: BigInt(content.byteLength),
+            checksum
+          }
+        }
+      }
+    })
+    const session: PersistedChatSession = {
+      id: 'session-1',
+      projectId: 'project-1',
+      title: 'Legacy ready upload',
+      cwd: '/workspace',
+      status: 'idle',
+      messages: [
+        {
+          id: 'message-1',
+          role: 'user',
+          content: 'Inspect this',
+          status: 'complete',
+          eventIds: [],
+          uploads: [
+            {
+              id: 'legacy-upload-ready',
+              sessionId: 'session-1',
+              name: 'legacy.csv',
+              originalName: 'legacy.csv',
+              path: legacyPath,
+              mimeType: 'text/csv',
+              size: content.byteLength
+            }
+          ],
+          createdAt: 1,
+          updatedAt: 1
+        }
+      ],
+      createdAt: 1,
+      updatedAt: 1
+    }
+
+    const upgraded = await repository.upgradeLegacySessionUploads(session)
+
+    expect(upgraded.messages[0].uploads?.[0]?.versionId).toBe(versionId)
+    await expect(
+      client.uploadVersion.count({ where: { uploadFileId: 'legacy-upload-ready' } })
+    ).resolves.toBe(1)
+    await expect(readFile(legacyPath)).rejects.toMatchObject({ code: 'ENOENT' })
+    await expect(readFile(finalPath)).resolves.toEqual(content)
+    await expect(readFile(unrelatedPath)).resolves.toEqual(content)
+    await expect(
+      repository.readManagedUploadPreview({
+        path: createUploadVersionReference(versionId, {
+          projectId: 'project-1',
+          sessionId: 'session-1'
+        }),
+        projectId: 'project-1',
+        sessionId: 'session-1',
+        encoding: 'utf8'
+      })
+    ).resolves.toMatchObject({ content: content.toString('utf8') })
+
+    await writeFile(legacyPath, content)
+    const reconciled = await repository.upgradeLegacySessionUploads(upgraded)
+    expect(reconciled.messages[0].uploads?.[0]?.versionId).toBe(versionId)
+    await expect(readFile(legacyPath)).rejects.toMatchObject({ code: 'ENOENT' })
+    await expect(readFile(finalPath)).resolves.toEqual(content)
+
+    await expect(repository.upgradeLegacySessionUploads(reconciled)).resolves.toMatchObject({
+      messages: [{ uploads: [{ versionId }] }]
+    })
+    await expect(readFile(unrelatedPath)).resolves.toEqual(content)
+
+    const replacement = Buffer.from('different bytes at the historical path')
+    await writeFile(legacyPath, replacement)
+    await expect(repository.upgradeLegacySessionUploads(reconciled)).resolves.toMatchObject({
+      messages: [{ uploads: [{ versionId }] }]
+    })
+    await expect(readFile(legacyPath)).resolves.toEqual(replacement)
+    await expect(readFile(finalPath)).resolves.toEqual(content)
+    await expect(
+      repository.upgradeLegacySessionUploads(reconciled, { mode: 'terminal-delete' })
+    ).rejects.toBeInstanceOf(UnsafeLegacyUploadResidualError)
+    await expect(readFile(legacyPath)).resolves.toEqual(replacement)
+
+    await writeFile(legacyPath, content)
+    const disappearingSourceRepository = new UploadRepository(root, {
+      getClient: () => Promise.resolve(client),
+      getLegacyFileChecksum: async (path) => {
+        await rm(path, { force: true })
+        throw Object.assign(new Error('Legacy source disappeared during verification.'), {
+          code: 'ENOENT'
+        })
+      }
+    })
+    await expect(
+      disappearingSourceRepository.upgradeLegacySessionUploads(reconciled)
+    ).resolves.toMatchObject({ messages: [{ uploads: [{ versionId }] }] })
+    await expect(readFile(legacyPath)).rejects.toMatchObject({ code: 'ENOENT' })
+    await expect(readFile(finalPath)).resolves.toEqual(content)
+
+    await writeFile(legacyPath, content)
+    const displacedLegacyPath = `${legacyPath}.verified-before-race`
+    const renameRaceReplacement = Buffer.from('replacement installed after legacy verification')
+    const renameRaceRepository = new UploadRepository(root, {
+      getClient: () => Promise.resolve(client),
+      renameLegacyForCleanup: async (source, destination) => {
+        await rename(source, displacedLegacyPath)
+        await writeFile(source, renameRaceReplacement)
+        await rename(source, destination)
+      }
+    })
+
+    await expect(
+      renameRaceRepository.upgradeLegacySessionUploads(reconciled)
+    ).resolves.toMatchObject({ messages: [{ uploads: [{ versionId }] }] })
+    await expect(readFile(legacyPath)).resolves.toEqual(renameRaceReplacement)
+    await expect(readFile(displacedLegacyPath)).resolves.toEqual(content)
+    await expect(stat(cleanupPrivateDir)).rejects.toMatchObject({
+      code: 'ENOENT'
+    })
+    await expect(readFile(finalPath)).resolves.toEqual(content)
+
+    await writeFile(legacyPath, content)
+    const sameInodeReplacement = Buffer.alloc(content.byteLength, 'x')
+    const inPlaceRaceRepository = new UploadRepository(root, {
+      getClient: () => Promise.resolve(client),
+      renameLegacyForCleanup: async (source, destination) => {
+        await writeFile(source, sameInodeReplacement)
+        await rename(source, destination)
+      }
+    })
+
+    await expect(
+      inPlaceRaceRepository.upgradeLegacySessionUploads(reconciled)
+    ).resolves.toMatchObject({ messages: [{ uploads: [{ versionId }] }] })
+    await expect(readFile(legacyPath)).resolves.toEqual(sameInodeReplacement)
+    await expect(stat(cleanupPrivateDir)).rejects.toMatchObject({
+      code: 'ENOENT'
+    })
+    await expect(readFile(finalPath)).resolves.toEqual(content)
+
+    await writeFile(legacyPath, content)
+    const collidingPrivateBytes = Buffer.from('concurrent private claim')
+    const privateClaimRaceRepository = new UploadRepository(root, {
+      getClient: () => Promise.resolve(client),
+      getLegacyFileChecksum: async () => {
+        await mkdir(cleanupPrivateDir)
+        await writeFile(cleanupPrivatePath, collidingPrivateBytes)
+        return checksum
+      }
+    })
+
+    await expect(
+      privateClaimRaceRepository.upgradeLegacySessionUploads(reconciled)
+    ).rejects.toThrow(/private claim is already occupied/i)
+    await expect(readFile(cleanupPrivatePath)).resolves.toEqual(collidingPrivateBytes)
+    await expect(readFile(legacyPath)).resolves.toEqual(content)
+    await expect(readFile(finalPath)).resolves.toEqual(content)
+    await rm(cleanupPrivateDir, { recursive: true, force: true })
+
+    await writeFile(legacyPath, content)
+    const crashAfterRename = new Error('simulated crash after legacy quarantine rename')
+    const crashRepository = new UploadRepository(root, {
+      getClient: () => Promise.resolve(client),
+      renameLegacyForCleanup: async (source, destination) => {
+        await rename(source, destination)
+        throw crashAfterRename
+      }
+    })
+
+    await expect(crashRepository.upgradeLegacySessionUploads(reconciled)).rejects.toBe(
+      crashAfterRename
+    )
+    await expect(readFile(legacyPath)).rejects.toMatchObject({ code: 'ENOENT' })
+    await expect(readFile(cleanupPrivatePath)).resolves.toEqual(content)
+
+    const recoveryRepository = new UploadRepository(root, {
+      getClient: () => Promise.resolve(client)
+    })
+    await expect(recoveryRepository.upgradeLegacySessionUploads(reconciled)).resolves.toMatchObject(
+      {
+        messages: [{ uploads: [{ versionId }] }]
+      }
+    )
+    await expect(readFile(cleanupPrivatePath)).rejects.toMatchObject({ code: 'ENOENT' })
+    await expect(stat(cleanupPrivateDir)).rejects.toMatchObject({ code: 'ENOENT' })
+    await expect(readFile(finalPath)).resolves.toEqual(content)
+
+    await writeFile(legacyPath, content)
+    const sameContentDisplacedPath = `${legacyPath}.same-content-crash-original`
+    let replacementIdentity: Awaited<ReturnType<typeof lstat>> | undefined
+    const sameContentCrash = new Error('simulated crash before private inode revalidation')
+    const sameContentCrashRepository = new UploadRepository(root, {
+      getClient: () => Promise.resolve(client),
+      renameLegacyForCleanup: async (source, destination) => {
+        await rename(source, sameContentDisplacedPath)
+        await writeFile(source, content)
+        replacementIdentity = await lstat(source)
+        await rename(source, destination)
+        throw sameContentCrash
+      }
+    })
+
+    await expect(sameContentCrashRepository.upgradeLegacySessionUploads(reconciled)).rejects.toBe(
+      sameContentCrash
+    )
+    await expect(readFile(legacyPath)).rejects.toMatchObject({ code: 'ENOENT' })
+    await expect(readFile(cleanupPrivatePath)).resolves.toEqual(content)
+
+    let reverifiedIdentity: Awaited<ReturnType<typeof lstat>> | undefined
+    const witnessResetRepository = new UploadRepository(root, {
+      getClient: () => Promise.resolve(client),
+      getLegacyFileChecksum: async (path) => {
+        reverifiedIdentity = await lstat(path)
+        return checksum
+      }
+    })
+    await expect(
+      witnessResetRepository.upgradeLegacySessionUploads(reconciled)
+    ).resolves.toMatchObject({ messages: [{ uploads: [{ versionId }] }] })
+    expect(replacementIdentity).toBeDefined()
+    expect(reverifiedIdentity?.dev).toBe(replacementIdentity?.dev)
+    expect(reverifiedIdentity?.ino).toBe(replacementIdentity?.ino)
+    await expect(readFile(sameContentDisplacedPath)).resolves.toEqual(content)
+    await expect(readFile(legacyPath)).rejects.toMatchObject({ code: 'ENOENT' })
+    await expect(stat(cleanupPrivateDir)).rejects.toMatchObject({ code: 'ENOENT' })
+    await expect(readFile(finalPath)).resolves.toEqual(content)
+
+    const isolatedPrivateBytes = Buffer.from('unverified quarantined bytes')
+    await mkdir(cleanupPrivateDir)
+    await writeFile(cleanupPrivatePath, isolatedPrivateBytes)
+    await writeFile(legacyPath, renameRaceReplacement)
+    await expect(
+      recoveryRepository.upgradeLegacySessionUploads(reconciled, { mode: 'terminal-delete' })
+    ).rejects.toThrow(/could not safely restore a private candidate/i)
+    await expect(readFile(cleanupPrivatePath)).resolves.toEqual(isolatedPrivateBytes)
+    await expect(readFile(legacyPath)).resolves.toEqual(renameRaceReplacement)
+    await expect(readFile(finalPath)).resolves.toEqual(content)
+
+    const missingVersionPath = join(root, 'uploads', 'default-project', 'session-1', 'missing.csv')
+    await writeFile(missingVersionPath, content)
+    const pathFreeUpload = reconciled.messages[0].uploads?.[0]
+    if (!pathFreeUpload) throw new Error('Expected the reconciled path-free Upload projection.')
+    const missingVersionSession: PersistedChatSession = {
+      ...reconciled,
+      messages: [
+        {
+          ...reconciled.messages[0],
+          uploads: [
+            {
+              ...pathFreeUpload,
+              id: 'missing-upload',
+              versionId: 'missing-version',
+              name: 'missing.csv',
+              originalName: 'missing.csv'
+            }
+          ]
+        }
+      ]
+    }
+    await expect(repository.upgradeLegacySessionUploads(missingVersionSession)).rejects.toThrow(
+      /Version authority is unavailable/i
+    )
+    await expect(readFile(missingVersionPath)).resolves.toEqual(content)
+
+    await writeFile(legacyPath, content)
+    const unavailableAuthorityRepository = new UploadRepository(root, {
+      getClient: () => Promise.reject(new Error('Upload authority unavailable.'))
+    })
+    await expect(
+      unavailableAuthorityRepository.upgradeLegacySessionUploads(reconciled)
+    ).rejects.toThrow('Upload authority unavailable.')
   })
 
   it('reads bounded previews only from managed uploads', async () => {

--- a/src/main/uploads/repository.ts
+++ b/src/main/uploads/repository.ts
@@ -1,5 +1,17 @@
 import { constants, createReadStream } from 'node:fs'
-import { copyFile, link, mkdir, open, realpath, rename, rm, stat } from 'node:fs/promises'
+import {
+  copyFile,
+  link,
+  lstat,
+  mkdir,
+  open,
+  readdir,
+  realpath,
+  rename,
+  rm,
+  rmdir,
+  stat
+} from 'node:fs/promises'
 import { basename, dirname, extname, isAbsolute, join, relative, resolve, sep } from 'node:path'
 import { createHash, randomUUID } from 'node:crypto'
 
@@ -30,11 +42,16 @@ import { readBoundedManagedFilePreview } from '../managed-file-preview'
 
 const UPLOADS_DIR = 'uploads'
 const STAGING_UPLOAD_SESSION_ID = '.staging'
+const LIVE_COPY_TEMP_SUFFIX = '.live-copy.tmp'
+const LEGACY_CLEANUP_PRIVATE_SUFFIX = '.legacy-cleanup.private'
+const LEGACY_CLEANUP_CANDIDATE = 'candidate'
 const SAFE_SEGMENT_PATTERN = /^[A-Za-z0-9][A-Za-z0-9._-]*$/
 
 type UploadRepositoryOptions = {
   maxFileBytes?: number
   getClient?: () => Promise<PrismaClient>
+  getLegacyFileChecksum?: (path: string) => Promise<string>
+  renameLegacyForCleanup?: (source: string, destination: string) => Promise<void>
   createLocalReadStream?: (
     sourcePath: string,
     options: { highWaterMark: number; signal: AbortSignal }
@@ -72,6 +89,14 @@ type CreateAttachmentInput = {
   originalName: string
   filePath: string
   mimeType?: string
+}
+
+type LegacyUploadUpgradeOptions = {
+  // Live callers cannot prove that every renderer has applied the returned path-free projection.
+  // Preserve the legacy source until a later startup/deletion reconciliation runs without live state.
+  // Orphan recovery also preserves it, but may only reuse authority left by the old deletion tail:
+  // recreating identity after provenance succeeded could claim unrelated residual bytes.
+  mode?: 'reconcile' | 'live-save' | 'orphan-recovery' | 'terminal-delete'
 }
 
 // Accepts only path segments that cannot escape the managed upload layout.
@@ -146,6 +171,48 @@ const sha256File = async (filePath: string): Promise<string> => {
   for await (const chunk of createReadStream(filePath)) hash.update(chunk)
   return hash.digest('hex')
 }
+
+type FileIdentity = Awaited<ReturnType<typeof lstat>>
+
+const hasSameFileIdentity = (left: FileIdentity, right: FileIdentity): boolean =>
+  left.dev === right.dev && left.ino === right.ino && left.size === right.size
+
+const hasSameFileSnapshot = (left: FileIdentity, right: FileIdentity): boolean =>
+  hasSameFileIdentity(left, right) &&
+  left.mtimeMs === right.mtimeMs &&
+  left.ctimeMs === right.ctimeMs
+
+class LegacyCleanupIncompleteError extends Error {}
+
+// Terminal Project deletion may leave bytes only when reconciliation has positively proved that the
+// deterministic legacy path no longer contains the Version-owned source. Callers must not use this
+// type for missing/corrupt Version authority or transient filesystem/private-claim failures.
+class UnsafeLegacyUploadResidualError extends Error {}
+
+// Orphan adoption may suppress only this positively proven cross-version state: the Upload row is
+// absent while candidate bytes exist or cannot safely be ruled out from the surviving locator.
+// Database/filesystem failures and malformed surviving authority keep their original retry behavior.
+class OrphanLegacyUploadAuthorityMissingError extends Error {}
+
+// Promise.all rejects before sibling publication settles. Orphan recovery must not let a late
+// sibling reactivate ManagedFile rows after its caller has already soft-deleted the Project index.
+// Prefer an ordinary failure over the suppressible missing-authority state so DB/FS errors retain
+// their durable intent instead of being accidentally collapsed into orphan-retained.
+const settleSiblingOperations = async <Value>(operations: Promise<Value>[]): Promise<Value[]> => {
+  const settled = await Promise.allSettled(operations)
+  const failures = settled.filter(
+    (result): result is PromiseRejectedResult => result.status === 'rejected'
+  )
+  const failure =
+    failures.find(
+      (result) => !(result.reason instanceof OrphanLegacyUploadAuthorityMissingError)
+    ) ?? failures[0]
+  if (failure) throw failure.reason
+  return settled.map((result) => (result as PromiseFulfilledResult<Value>).value)
+}
+
+type LegacyCleanupResult =
+  { status: 'absent' | 'removed' } | { status: 'unsafe-residual'; reason: string }
 
 // Owns app-managed uploads so renderer paths are always validated in the main process.
 class UploadRepository {
@@ -455,30 +522,74 @@ class UploadRepository {
     attachments: UploadedAttachment[],
     projectId = DEFAULT_UPLOAD_PROJECT_NAME
   ): Promise<UploadedAttachment[]> {
+    return this.finalizeSessionUploads(sessionId, attachments, projectId)
+  }
+
+  private async finalizeSessionUploads(
+    sessionId: string,
+    attachments: UploadedAttachment[],
+    projectId: string,
+    options: { preserveLegacySource?: boolean; requireExistingAuthority?: boolean } = {}
+  ): Promise<UploadedAttachment[]> {
     const safeSessionId = assertSafePathSegment(sessionId)
     const safeProjectId = assertSafePathSegment(projectId.trim() || DEFAULT_UPLOAD_PROJECT_NAME)
+    if (options.requireExistingAuthority && !this.options.getClient) {
+      throw new Error('Legacy Upload authority is unavailable for orphan recovery.')
+    }
 
-    return Promise.all(
+    const finalized = await Promise.all(
       attachments.map(async (attachment) => {
         if (this.options.getClient) {
-          return this.publishAttachment(safeProjectId, safeSessionId, attachment)
+          return this.publishAttachment(safeProjectId, safeSessionId, attachment, options)
         }
         const finalized = await this.finalizeAttachment(safeSessionId, attachment)
         return finalized
       })
     )
+    return finalized.filter(
+      (attachment): attachment is UploadedAttachment => attachment !== undefined
+    )
   }
 
   // Converts path-only Session records from pre-Version releases before the Session repository is
-  // allowed to write its path-free JSON projection. Repeated references in the top-level transcript
-  // and conversation graph share one publication operation and therefore one immutable Version.
-  async upgradeLegacySessionUploads(session: PersistedChatSession): Promise<PersistedChatSession> {
-    const upgrades = new Map<string, Promise<PersistedUploadedAttachment>>()
-    const upgrade = (upload: PersistedUploadedAttachment): Promise<PersistedUploadedAttachment> => {
+  // allowed to write its path-free JSON projection, and reconciles historical copies left behind by
+  // older Version-aware releases. Repeated references share one publication or reconciliation.
+  async upgradeLegacySessionUploads(
+    session: PersistedChatSession,
+    options: LegacyUploadUpgradeOptions = {}
+  ): Promise<PersistedChatSession> {
+    this.assertConsistentSessionUploadReferences(session)
+    const isLiveSave = options.mode === 'live-save' || options.mode === 'orphan-recovery'
+    const requireExistingAuthority = options.mode === 'orphan-recovery'
+    const isTerminalDelete = options.mode === 'terminal-delete'
+    const upgrades = new Map<string, Promise<PersistedUploadedAttachment | undefined>>()
+    const reconciliations = new Map<string, Promise<LegacyCleanupResult>>()
+    const upgrade = async (
+      upload: PersistedUploadedAttachment
+    ): Promise<PersistedUploadedAttachment | undefined> => {
       if (upload.versionId) {
-        return Promise.resolve(
-          toPersistedUploadedAttachment(toRuntimeUploadedAttachment(upload, session.projectId))
+        const persisted = toPersistedUploadedAttachment(
+          toRuntimeUploadedAttachment(upload, session.projectId)
         )
+        if (isLiveSave) return Promise.resolve(persisted)
+        const reconciliationKey = `${upload.id}:${upload.versionId}`
+        let reconciliation = reconciliations.get(reconciliationKey)
+        if (!reconciliation) {
+          reconciliation = this.removeVerifiedLegacyCopy({
+            projectId: session.projectId,
+            sessionId: upload.sessionId,
+            uploadFileId: upload.id,
+            versionId: upload.versionId,
+            filename: upload.name
+          })
+          reconciliations.set(reconciliationKey, reconciliation)
+        }
+        return reconciliation.then(async (cleanup) => {
+          if (isTerminalDelete) {
+            await this.assertLegacySourceAbsent(upload.sessionId, upload.name, cleanup)
+          }
+          return persisted
+        })
       }
 
       const existing = upgrades.get(upload.id)
@@ -487,11 +598,16 @@ class UploadRepository {
         if (!upload.path) {
           throw new Error(`Legacy upload has no recoverable path: ${upload.id}`)
         }
-        const [finalized] = await this.finalizePendingSessionUploads(
+        const [finalized] = await this.finalizeSessionUploads(
           session.id,
           [toRuntimeUploadedAttachment(upload, session.projectId)],
-          session.projectId
+          session.projectId,
+          { preserveLegacySource: isLiveSave, requireExistingAuthority }
         )
+        if (!finalized) return undefined
+        if (isTerminalDelete) {
+          await this.assertLegacySourceAbsent(upload.sessionId, upload.name, { status: 'absent' })
+        }
         return toPersistedUploadedAttachment(finalized)
       })()
       upgrades.set(upload.id, operation)
@@ -501,21 +617,65 @@ class UploadRepository {
       message: Message
     ): Promise<Message> => {
       if (!message.uploads?.length) return message
-      const uploads = await Promise.all(message.uploads.map(upgrade))
+      const uploads = (await settleSiblingOperations(message.uploads.map(upgrade))).filter(
+        (upload): upload is PersistedUploadedAttachment => upload !== undefined
+      )
       return { ...message, uploads } as Message
     }
+    const messagesOperation = settleSiblingOperations(session.messages.map(upgradeMessage))
+    const graphMessagesOperation = session.conversationGraph
+      ? settleSiblingOperations(session.conversationGraph.messages.map(upgradeMessage))
+      : undefined
+    await settleSiblingOperations<unknown>([
+      messagesOperation,
+      ...(graphMessagesOperation ? [graphMessagesOperation] : [])
+    ])
+    const messages = await messagesOperation
+    const graphMessages = await graphMessagesOperation
 
     return {
       ...session,
-      messages: await Promise.all(session.messages.map(upgradeMessage)),
+      messages,
       ...(session.conversationGraph
         ? {
             conversationGraph: {
               ...session.conversationGraph,
-              messages: await Promise.all(session.conversationGraph.messages.map(upgradeMessage))
+              messages: graphMessages!
             }
           }
         : {})
+    }
+  }
+
+  // Operation sharing is safe only after every occurrence across the flat transcript and graph has
+  // proven the same immutable identity. This synchronous, lexical preflight runs before any DB or
+  // filesystem work starts, so a conflicting historical locator cannot be overwritten or orphaned.
+  private assertConsistentSessionUploadReferences(session: PersistedChatSession): void {
+    const identities = new Map<string, string>()
+    const messages = [...session.messages, ...(session.conversationGraph?.messages ?? [])]
+    for (const upload of messages.flatMap((message) => message.uploads ?? [])) {
+      if (upload.sha256 && upload.checksum && upload.sha256 !== upload.checksum) {
+        throw new Error(`Session Upload reference has conflicting checksums: ${upload.id}`)
+      }
+      const identity = JSON.stringify([
+        upload.sessionId,
+        upload.name,
+        upload.originalName,
+        upload.path === undefined ? null : resolve(upload.path),
+        upload.versionId ?? null,
+        upload.versionNumber ?? null,
+        upload.sha256 ?? upload.checksum ?? null,
+        upload.size,
+        upload.mimeType ?? null,
+        upload.createdAt ?? null
+      ])
+      const existing = identities.get(upload.id)
+      if (existing !== undefined && existing !== identity) {
+        throw new Error(
+          `Session Upload references have conflicting immutable identity: ${upload.id}`
+        )
+      }
+      identities.set(upload.id, identity)
     }
   }
 
@@ -564,8 +724,7 @@ class UploadRepository {
             checksum: version.checksum,
             createdAt: version.createdAt?.toISOString()
           },
-          version,
-          { preserveSource: sourcePath === sourceCandidates[2] }
+          version
         )
       })
     )
@@ -929,8 +1088,9 @@ class UploadRepository {
   private async publishAttachment(
     projectId: string,
     sessionId: string,
-    attachment: UploadedAttachment
-  ): Promise<UploadedAttachment> {
+    attachment: UploadedAttachment,
+    options: { preserveLegacySource?: boolean; requireExistingAuthority?: boolean } = {}
+  ): Promise<UploadedAttachment | undefined> {
     const uploadFileId = assertSafePathSegment(attachment.id)
     const client = await this.options.getClient!()
     const existingFile = await client.uploadFile.findUnique({
@@ -946,9 +1106,37 @@ class UploadRepository {
       if (attachment.versionId && attachment.versionId !== existingVersion.id) {
         throw new Error('Upload Version identity conflicts with the existing immutable Version.')
       }
-      return this.completeStagingUpload(projectId, sessionId, attachment, existingVersion, {
-        preserveSource: attachment.sessionId === sessionId && !attachment.versionId
-      })
+      const published = await this.completeStagingUpload(
+        projectId,
+        sessionId,
+        attachment,
+        existingVersion,
+        { preserveSource: options.preserveLegacySource === true }
+      )
+      if (
+        !options.preserveLegacySource &&
+        attachment.sessionId === sessionId &&
+        !attachment.versionId
+      ) {
+        await this.removeVerifiedLegacyCopy({
+          projectId,
+          sessionId,
+          uploadFileId,
+          versionId: existingVersion.id,
+          filename: attachment.name,
+          legacyPath: attachment.path
+        })
+      }
+      return published
+    }
+
+    if (options.requireExistingAuthority) {
+      if (!(await this.hasOrphanLegacyCandidate(projectId, sessionId, uploadFileId, attachment))) {
+        return undefined
+      }
+      throw new OrphanLegacyUploadAuthorityMissingError(
+        `Legacy Upload authority is unavailable: ${uploadFileId}`
+      )
     }
 
     const sourcePath = await this.resolveManagedUploadPath({ path: attachment.path })
@@ -1026,8 +1214,67 @@ class UploadRepository {
     })
 
     return this.completeStagingUpload(projectId, sessionId, attachment, registered, {
-      preserveSource: attachment.sessionId === sessionId
+      preserveSource: options.preserveLegacySource === true
     })
+  }
+
+  // Missing legacy and private candidates are positive evidence that the old deletion tail already
+  // consumed the bytes. A mismatched recorded locator remains unknown and is retained fail-closed.
+  private async hasOrphanLegacyCandidate(
+    projectId: string,
+    sessionId: string,
+    uploadFileId: string,
+    attachment: UploadedAttachment
+  ): Promise<boolean> {
+    assertSafePathSegment(projectId)
+    assertSafePathSegment(sessionId)
+    assertSafePathSegment(uploadFileId)
+    const legacyRoot = this.getSessionUploadDir(sessionId)
+    const expectedLegacyPath = resolve(legacyRoot, attachment.name)
+    const privateClaimDir = `${expectedLegacyPath}${LEGACY_CLEANUP_PRIVATE_SUFFIX}`
+    assertPathInsideRoot(legacyRoot, expectedLegacyPath)
+    assertPathInsideRoot(legacyRoot, privateClaimDir)
+    if (resolve(attachment.path) !== expectedLegacyPath) return true
+
+    for (const candidate of [expectedLegacyPath, privateClaimDir]) {
+      try {
+        await lstat(candidate)
+        return true
+      } catch (error) {
+        if (!isMissingFileError(error)) throw error
+      }
+    }
+
+    // A live-save can crash after copying bytes into an authority-derived Version directory. The
+    // Version id is unavailable once SQLite authority is gone, so scan only this Upload's bounded
+    // versions root. Empty directories left by provenance cleanup are harmless; any surviving entry
+    // (including content.live-copy.tmp) is retained for manual/retry recovery.
+    const versionsRoot = resolve(
+      this.storageRoot,
+      UPLOADS_DIR,
+      projectId,
+      sessionId,
+      uploadFileId,
+      'versions'
+    )
+    assertPathInsideRoot(this.storageRoot, versionsRoot)
+    let versionsRootInfo
+    try {
+      versionsRootInfo = await lstat(versionsRoot)
+    } catch (error) {
+      if (isMissingFileError(error)) return false
+      throw error
+    }
+    if (!versionsRootInfo.isDirectory() || versionsRootInfo.isSymbolicLink()) return true
+    const versionEntries = await readdir(versionsRoot, { withFileTypes: true })
+    for (const versionEntry of versionEntries) {
+      if (!versionEntry.isDirectory() || versionEntry.isSymbolicLink()) return true
+      const entries = await readdir(join(versionsRoot, versionEntry.name), {
+        withFileTypes: true
+      })
+      if (entries.length > 0) return true
+    }
+    return false
   }
 
   private async completeStagingUpload(
@@ -1084,6 +1331,23 @@ class UploadRepository {
       } catch (error) {
         if (!isMissingFileError(error)) throw error
       }
+      await mkdir(dirname(finalPath), { recursive: true })
+      const temporaryPath = `${finalPath}${LIVE_COPY_TEMP_SUFFIX}`
+      if (await validateContent(temporaryPath)) {
+        // A prior live save completed its copy but exited before the atomic final rename. The
+        // deterministic path is derived from staging authority, so recovery can safely finish it.
+        await rename(temporaryPath, finalPath)
+        finalValid = await validateContent(finalPath)
+        if (!finalValid) {
+          throw new Error(`Recovered Upload Version content is corrupt: ${version.id}`)
+        }
+      } else {
+        // Remove a partial/corrupt crash residue before retrying from the still-authoritative source.
+        await rm(temporaryPath, { force: true })
+      }
+    }
+
+    if (!finalValid) {
       let sourcePath: string | undefined
       try {
         sourcePath = await this.resolveManagedUploadPath({ path: attachment.path })
@@ -1100,9 +1364,11 @@ class UploadRepository {
         })
         throw new Error(`Upload Version staging content is unavailable: ${version.id}`)
       }
-      await mkdir(dirname(finalPath), { recursive: true })
       if (options.preserveSource) {
-        const temporaryPath = `${finalPath}.${randomUUID()}.tmp`
+        // A live Session may still be rendering the path-only projection. Publish through an atomic
+        // temporary copy, but retain that sole readable path until a later startup/deletion pass can
+        // prove the path-free projection is authoritative without relying on renderer delivery.
+        const temporaryPath = `${finalPath}${LIVE_COPY_TEMP_SUFFIX}`
         try {
           await copyFile(sourcePath, temporaryPath, constants.COPYFILE_EXCL)
           if (!(await validateContent(temporaryPath))) {
@@ -1110,9 +1376,12 @@ class UploadRepository {
           }
           await rename(temporaryPath, finalPath)
         } finally {
-          await rm(temporaryPath, { force: true })
+          await rm(temporaryPath, { force: true }).catch(() => undefined)
         }
       } else {
+        // The staging row is durable before this atomic move. If the process exits before the row is
+        // marked ready, startup recovery validates the final path and completes publication. If the
+        // Session JSON still contains the legacy path, a retry resolves the same row by uploadFileId.
         await rename(sourcePath, finalPath)
       }
       finalValid = await validateContent(finalPath)
@@ -1120,6 +1389,9 @@ class UploadRepository {
         throw new Error(`Published Upload Version content is corrupt: ${version.id}`)
       }
     }
+
+    // A valid final path supersedes any deterministic crash residue from an earlier staging retry.
+    await rm(`${finalPath}${LIVE_COPY_TEMP_SUFFIX}`, { force: true })
 
     const client = await this.options.getClient!()
     const ready = await client.$transaction(async (tx) => {
@@ -1183,6 +1455,300 @@ class UploadRepository {
       checksum: ready.checksum,
       createdAt: ready.createdAt?.toISOString()
     }
+  }
+
+  // Reconciles copies left by releases that published a ready Version without consuming the legacy
+  // source. Cleanup is fail-closed: SQLite authority, both byte copies, the deterministic legacy path,
+  // and the source file identity must all remain valid through the final pre-delete check.
+  private async removeVerifiedLegacyCopy(input: {
+    projectId: string
+    sessionId: string
+    uploadFileId: string
+    versionId: string
+    filename: string
+    legacyPath?: string
+  }): Promise<LegacyCleanupResult> {
+    const projectId = assertSafePathSegment(input.projectId)
+    const sessionId = assertSafePathSegment(input.sessionId)
+    const uploadFileId = assertSafePathSegment(input.uploadFileId)
+    const versionId = assertSafePathSegment(input.versionId)
+    const legacyRoot = this.getSessionUploadDir(sessionId)
+    const expectedLegacyPath = resolve(legacyRoot, input.filename)
+    const cleanupPrivateDir = `${expectedLegacyPath}${LEGACY_CLEANUP_PRIVATE_SUFFIX}`
+    const cleanupPrivatePath = join(cleanupPrivateDir, LEGACY_CLEANUP_CANDIDATE)
+    assertPathInsideRoot(legacyRoot, expectedLegacyPath)
+    assertPathInsideRoot(legacyRoot, cleanupPrivateDir)
+    assertPathInsideRoot(legacyRoot, cleanupPrivatePath)
+
+    let initialLegacyInfo: FileIdentity | undefined
+    let privateDirInfo: FileIdentity | undefined
+    let privateInfo: FileIdentity | undefined
+    try {
+      initialLegacyInfo = await lstat(expectedLegacyPath)
+    } catch (error) {
+      if (!isMissingFileError(error)) throw error
+    }
+    try {
+      privateDirInfo = await lstat(cleanupPrivateDir)
+    } catch (error) {
+      if (!isMissingFileError(error)) throw error
+    }
+    if (privateDirInfo) {
+      if (!privateDirInfo.isDirectory() || privateDirInfo.isSymbolicLink()) {
+        throw new LegacyCleanupIncompleteError(
+          `Legacy upload cleanup found an unsafe private claim: ${input.filename}`
+        )
+      }
+      try {
+        privateInfo = await lstat(cleanupPrivatePath)
+      } catch (error) {
+        if (!isMissingFileError(error)) throw error
+        try {
+          await rmdir(cleanupPrivateDir)
+          privateDirInfo = undefined
+        } catch {
+          throw new LegacyCleanupIncompleteError(
+            `Legacy upload cleanup found an incomplete private claim: ${input.filename}`
+          )
+        }
+      }
+    }
+    if (!initialLegacyInfo && !privateInfo) return { status: 'absent' }
+
+    if (input.legacyPath && resolve(input.legacyPath) !== expectedLegacyPath) {
+      return {
+        status: 'unsafe-residual',
+        reason: 'the recorded legacy path does not match its deterministic Session path'
+      }
+    }
+
+    if (!this.options.getClient) {
+      throw new Error(`Upload Version authority is unavailable for legacy cleanup: ${versionId}`)
+    }
+
+    // The common path-free case has neither candidate, so the lstat checks above avoid a database read
+    // and full immutable-file hash on every subsequent Session save. Database failures after a
+    // candidate is found propagate so reconciliation remains incomplete and retries later.
+    const client = await this.options.getClient()
+    const version = await client.uploadVersion.findFirst({
+      where: {
+        id: versionId,
+        uploadFileId,
+        state: 'ready',
+        uploadFile: { is: { projectId, sessionId } }
+      },
+      select: {
+        contentStorageKey: true,
+        filename: true,
+        sizeBytes: true,
+        checksum: true
+      }
+    })
+    if (!version) {
+      throw new Error(`Ready Upload Version authority is unavailable: ${versionId}`)
+    }
+    if (version.filename !== input.filename) {
+      throw new Error(`Ready Upload Version filename does not match: ${versionId}`)
+    }
+
+    const finalPath = resolve(this.storageRoot, ...version.contentStorageKey.split('/'))
+    assertPathInsideRoot(this.storageRoot, finalPath, 'Upload storage key escapes storage.')
+    const finalInfo = await stat(finalPath)
+    if (
+      !finalInfo.isFile() ||
+      finalInfo.size !== Number(version.sizeBytes) ||
+      (await sha256File(finalPath)) !== version.checksum
+    ) {
+      throw new Error(`Ready Upload Version content is unavailable or corrupt: ${versionId}`)
+    }
+
+    // A pre-existing claim has lost the pre-rename inode witness held by its original process. Never
+    // delete that candidate from checksum alone: restore it without overwrite, release the claim, and
+    // make this invocation prove the legacy path again before acquiring a fresh claim.
+    if (privateInfo) {
+      await this.restoreLegacyCleanupPrivate(
+        cleanupPrivateDir,
+        cleanupPrivatePath,
+        expectedLegacyPath,
+        privateInfo
+      )
+    }
+
+    let verifiedLegacyInfo: FileIdentity
+    try {
+      initialLegacyInfo = await lstat(expectedLegacyPath)
+      if (!initialLegacyInfo.isFile() || initialLegacyInfo.isSymbolicLink()) {
+        return {
+          status: 'unsafe-residual',
+          reason: 'the deterministic legacy path is not a regular owned file'
+        }
+      }
+      const sourcePath = await this.resolveManagedUploadPath(
+        { path: expectedLegacyPath },
+        { projectId, sessionId }
+      )
+      const resolvedLegacyPath = await realpath(expectedLegacyPath)
+      const resolvedFinalPath = await realpath(finalPath)
+      if (
+        sourcePath !== resolvedLegacyPath ||
+        sourcePath === resolvedFinalPath ||
+        initialLegacyInfo.size !== Number(version.sizeBytes)
+      ) {
+        return {
+          status: 'unsafe-residual',
+          reason: 'the deterministic legacy path does not match the Version-owned source'
+        }
+      }
+
+      const legacyChecksum = await (this.options.getLegacyFileChecksum ?? sha256File)(
+        expectedLegacyPath
+      )
+      if (legacyChecksum !== version.checksum) {
+        return {
+          status: 'unsafe-residual',
+          reason: 'the deterministic legacy path contains different content'
+        }
+      }
+
+      verifiedLegacyInfo = await lstat(expectedLegacyPath)
+      const verifiedLegacyPath = await realpath(expectedLegacyPath)
+      if (
+        !verifiedLegacyInfo.isFile() ||
+        verifiedLegacyInfo.isSymbolicLink() ||
+        verifiedLegacyPath !== sourcePath ||
+        !hasSameFileSnapshot(verifiedLegacyInfo, initialLegacyInfo)
+      ) {
+        return {
+          status: 'unsafe-residual',
+          reason: 'the deterministic legacy path changed during ownership verification'
+        }
+      }
+    } catch (error) {
+      if (isMissingFileError(error)) return { status: 'absent' }
+      throw error
+    }
+
+    try {
+      // mkdir is the no-replace claim Node exposes portably. Once this empty directory is ours, the
+      // rename target inside it cannot collide with another cooperating cleanup process.
+      await mkdir(cleanupPrivateDir)
+    } catch (error) {
+      if (isFileExistsError(error)) {
+        throw new LegacyCleanupIncompleteError(
+          `Legacy upload cleanup private claim is already occupied: ${input.filename}`
+        )
+      }
+      throw error
+    }
+
+    try {
+      await (this.options.renameLegacyForCleanup ?? rename)(expectedLegacyPath, cleanupPrivatePath)
+    } catch (error) {
+      if (isMissingFileError(error)) {
+        try {
+          await rmdir(cleanupPrivateDir)
+        } catch {
+          throw new LegacyCleanupIncompleteError(
+            `Legacy upload cleanup could not release its private claim: ${input.filename}`
+          )
+        }
+        return { status: 'absent' }
+      }
+      throw error
+    }
+
+    const movedInfo = await lstat(cleanupPrivatePath)
+    const movedChecksum = await sha256File(cleanupPrivatePath)
+    const reverifiedMovedInfo = await lstat(cleanupPrivatePath)
+    if (
+      !hasSameFileIdentity(movedInfo, verifiedLegacyInfo) ||
+      movedChecksum !== version.checksum ||
+      !hasSameFileSnapshot(reverifiedMovedInfo, movedInfo)
+    ) {
+      await this.restoreLegacyCleanupPrivate(
+        cleanupPrivateDir,
+        cleanupPrivatePath,
+        expectedLegacyPath,
+        reverifiedMovedInfo
+      )
+      return {
+        status: 'unsafe-residual',
+        reason: 'the claimed legacy source changed before removal'
+      }
+    }
+
+    await rm(cleanupPrivatePath, { force: true })
+    await rmdir(cleanupPrivateDir)
+    return { status: 'removed' }
+  }
+
+  private async restoreLegacyCleanupPrivate(
+    cleanupPrivateDir: string,
+    cleanupPrivatePath: string,
+    expectedLegacyPath: string,
+    privateInfo: FileIdentity
+  ): Promise<void> {
+    if (!privateInfo.isFile() || privateInfo.isSymbolicLink()) {
+      throw new LegacyCleanupIncompleteError(
+        `Legacy upload cleanup left an unverifiable private candidate: ${basename(expectedLegacyPath)}`
+      )
+    }
+
+    try {
+      await link(cleanupPrivatePath, expectedLegacyPath)
+    } catch (error) {
+      if (isFileExistsError(error)) {
+        // If a previous restore linked the same inode before crashing, finish removal of the extra
+        // private name. Any different replacement wins EEXIST and remains untouched alongside it.
+        const currentLegacyInfo = await lstat(expectedLegacyPath).catch(() => undefined)
+        if (currentLegacyInfo && hasSameFileIdentity(currentLegacyInfo, privateInfo)) {
+          await rm(cleanupPrivatePath, { force: true })
+          await rmdir(cleanupPrivateDir)
+          return
+        }
+      }
+      throw new LegacyCleanupIncompleteError(
+        `Legacy upload cleanup could not safely restore a private candidate: ${basename(expectedLegacyPath)}`
+      )
+    }
+
+    await rm(cleanupPrivatePath, { force: true })
+    await rmdir(cleanupPrivateDir)
+  }
+
+  // Session/project deletion removes the final JSON authority needed to discover a legacy duplicate.
+  // Refuse that terminal commit while any deterministic candidate remains, including a replacement
+  // file that fail-closed checksum or inode validation deliberately would not delete.
+  private async assertLegacySourceAbsent(
+    sessionId: string,
+    filename: string,
+    cleanup: LegacyCleanupResult
+  ): Promise<void> {
+    const legacyRoot = this.getSessionUploadDir(assertSafePathSegment(sessionId))
+    const legacyPath = resolve(legacyRoot, filename)
+    const cleanupPrivateDir = `${legacyPath}${LEGACY_CLEANUP_PRIVATE_SUFFIX}`
+    assertPathInsideRoot(legacyRoot, legacyPath)
+    assertPathInsideRoot(legacyRoot, cleanupPrivateDir)
+    try {
+      await lstat(cleanupPrivateDir)
+      throw new LegacyCleanupIncompleteError(
+        `Legacy upload cleanup found an incomplete private claim: ${filename}`
+      )
+    } catch (error) {
+      if (!isMissingFileError(error)) throw error
+    }
+    try {
+      await lstat(legacyPath)
+    } catch (error) {
+      if (isMissingFileError(error)) return
+      throw error
+    }
+    if (cleanup.status === 'unsafe-residual') {
+      throw new UnsafeLegacyUploadResidualError(
+        `Legacy upload source is not owned by its ready Version: ${filename}; ${cleanup.reason}.`
+      )
+    }
+    throw new Error(`Legacy upload cleanup is incomplete: ${filename}`)
   }
 
   // Returns the top-level upload directory under the app persistence root.
@@ -1279,4 +1845,8 @@ class UploadRepository {
   }
 }
 
-export { UploadRepository }
+export {
+  OrphanLegacyUploadAuthorityMissingError,
+  UnsafeLegacyUploadResidualError,
+  UploadRepository
+}

--- a/src/preload/index.d.ts
+++ b/src/preload/index.d.ts
@@ -256,7 +256,7 @@ interface OpenScienceAPI {
   }
   sessions: {
     loadAll(): Promise<LoadAllSessionsResult>
-    saveSession(session: PersistedChatSession): Promise<void>
+    saveSession(session: PersistedChatSession): Promise<PersistedChatSession>
     deleteSession(request: DeleteSessionRequest): Promise<void>
     saveManifest(request: SaveSessionManifestRequest): Promise<void>
     onCreated(listener: AcpListener<SessionUpsertEvent>): RemoveListener

--- a/src/preload/index.ts
+++ b/src/preload/index.ts
@@ -291,7 +291,7 @@ type OpenScienceAPI = {
   }
   sessions: {
     loadAll: () => Promise<LoadAllSessionsResult>
-    saveSession: (session: PersistedChatSession) => Promise<void>
+    saveSession: (session: PersistedChatSession) => Promise<PersistedChatSession>
     deleteSession: (request: DeleteSessionRequest) => Promise<void>
     saveManifest: (request: SaveSessionManifestRequest) => Promise<void>
     onCreated: (listener: AcpListener<SessionUpsertEvent>) => RemoveListener
@@ -733,7 +733,8 @@ const api: OpenScienceAPI = {
     // Loads every per-session file plus the last-open manifest from the main process.
     loadAll: () => ipcRenderer.invoke('sessions:load-all') as Promise<LoadAllSessionsResult>,
     // Persists a single sanitized session file.
-    saveSession: (session) => ipcRenderer.invoke('sessions:save-session', session) as Promise<void>,
+    saveSession: (session) =>
+      ipcRenderer.invoke('sessions:save-session', session) as Promise<PersistedChatSession>,
     // Removes one session file.
     deleteSession: (request) =>
       ipcRenderer.invoke('sessions:delete-session', request) as Promise<void>,

--- a/src/renderer/src/lib/acp/workspace-events.ts
+++ b/src/renderer/src/lib/acp/workspace-events.ts
@@ -111,7 +111,7 @@ const isNonActionableCodexDiagnostic = (text: string): boolean => {
 
 type WorkspaceRuntimeEventDependencies = {
   finalizeRunArtifacts?: (request: FinalizeRunArtifactsRequest) => Promise<ArtifactFile[]>
-  saveSession?: (session: PersistedChatSession) => Promise<void>
+  saveSession?: (session: PersistedChatSession) => Promise<PersistedChatSession | void>
 }
 
 // Defaults to the preload artifact API while allowing tests to inject a fake finalizer.
@@ -120,8 +120,9 @@ const finalizeRunArtifacts = (request: FinalizeRunArtifactsRequest): Promise<Art
 
 // Artifact finalization validates its renderer-selected Message against the durable Session graph.
 // Persist that graph explicitly instead of relying on the asynchronous store saver to win the IPC race.
-const saveSessionForArtifactFinalization = (session: PersistedChatSession): Promise<void> =>
-  window.api.sessions.saveSession(session)
+const saveSessionForArtifactFinalization = (
+  session: PersistedChatSession
+): Promise<PersistedChatSession> => window.api.sessions.saveSession(session)
 
 const finalizeArtifactEvent = async (
   event: AcpRuntimeEvent,
@@ -157,9 +158,16 @@ const finalizeArtifactEvent = async (
       if (!attachedSession) {
         throw new Error('Artifact finalization Session is no longer available.')
       }
-      await (dependencies.saveSession ?? saveSessionForArtifactFinalization)(
-        toPersistedSession(attachedSession)
+      const submittedSession = toPersistedSession(attachedSession)
+      const durableSession = await (dependencies.saveSession ?? saveSessionForArtifactFinalization)(
+        submittedSession
       )
+      if (durableSession) {
+        useSessionStore.getState().applyDurableSessionProjection({
+          source: attachedSession,
+          session: durableSession
+        })
+      }
     }
 
     await persistLatestSession()

--- a/src/renderer/src/lib/session-persistence/session-persistence.test.ts
+++ b/src/renderer/src/lib/session-persistence/session-persistence.test.ts
@@ -5,7 +5,12 @@ import {
   type LoadAllSessionsResult,
   type PersistedChatSession
 } from '../../../../shared/session-persistence'
-import { createInitialSessionState, useSessionStore } from '../../stores/session-store'
+import { toRuntimeUploadedAttachment } from '../../../../shared/uploads'
+import {
+  createInitialSessionState,
+  isExternallyHydratedSession,
+  useSessionStore
+} from '../../stores/session-store'
 import {
   createStoreSaver,
   loadPersistedSessions,
@@ -37,7 +42,7 @@ const createLoadResult = (
 
 const createApi = (overrides: Partial<SessionPersistenceApi> = {}): SessionPersistenceApi => ({
   loadAll: vi.fn().mockResolvedValue(createLoadResult()),
-  saveSession: vi.fn().mockResolvedValue(undefined),
+  saveSession: vi.fn(async (session: PersistedChatSession) => session),
   deleteSession: vi.fn().mockResolvedValue(undefined),
   saveManifest: vi.fn().mockResolvedValue(undefined),
   ...overrides
@@ -262,6 +267,219 @@ describe('renderer session persistence bridge', () => {
     )
   })
 
+  it('applies the path-free durable projection returned by a live save to the originating store', async () => {
+    const legacyPath = '/data/uploads/default-project/session-1/legacy.csv'
+    const legacySession = createPersistedSession({
+      projectId: 'project-a',
+      messages: [
+        {
+          id: 'message-1',
+          role: 'user',
+          content: 'Analyze this upload',
+          status: 'complete',
+          eventIds: [],
+          uploads: [
+            {
+              id: 'upload-1',
+              sessionId: 'session-1',
+              name: 'legacy.csv',
+              originalName: 'legacy.csv',
+              path: legacyPath,
+              size: 12
+            }
+          ],
+          createdAt: 1,
+          updatedAt: 1
+        }
+      ]
+    })
+    useSessionStore.getState().hydrateSessions([legacySession])
+    const saveSession = vi.fn(async (submitted: PersistedChatSession) => {
+      const durable = structuredClone(submitted)
+      const versionedUpload = {
+        id: 'upload-1',
+        versionId: 'upload-version-1',
+        versionNumber: 1,
+        sessionId: 'session-1',
+        name: 'legacy.csv',
+        originalName: 'legacy.csv',
+        size: 12,
+        sha256: 'a'.repeat(64)
+      }
+      durable.messages[0].uploads = [versionedUpload]
+      const graphMessage = durable.conversationGraph?.messages.find(
+        (message) => message.id === 'message-1'
+      )
+      if (graphMessage) graphMessage.uploads = [versionedUpload]
+      return durable
+    })
+    const save = createStoreSaver(createApi({ saveSession }), useSessionStore.getState())
+
+    useSessionStore.getState().renameSession('session-1', 'Persist upgraded upload')
+    await save(useSessionStore.getState())
+
+    const stored = useSessionStore.getState().sessions[0]
+    const upload = stored.messages[0].uploads?.[0]
+    expect(upload).toMatchObject({ id: 'upload-1', versionId: 'upload-version-1' })
+    expect(upload).not.toHaveProperty('path')
+    expect(toRuntimeUploadedAttachment(upload!, stored.projectId).path).toBe(
+      'upload-version:project-a/session-1/upload-version-1'
+    )
+    expect(saveSession).toHaveBeenCalledOnce()
+  })
+
+  it('keeps the readable legacy projection in the live store when durable propagation fails', async () => {
+    const legacyPath = '/data/uploads/default-project/session-1/legacy.csv'
+    useSessionStore.getState().hydrateSessions([
+      createPersistedSession({
+        projectId: 'project-a',
+        messages: [
+          {
+            id: 'message-1',
+            role: 'user',
+            content: 'Analyze this upload',
+            status: 'complete',
+            eventIds: [],
+            uploads: [
+              {
+                id: 'upload-1',
+                sessionId: 'session-1',
+                name: 'legacy.csv',
+                originalName: 'legacy.csv',
+                path: legacyPath,
+                size: 12
+              }
+            ],
+            createdAt: 1,
+            updatedAt: 1
+          }
+        ]
+      })
+    ])
+    const save = createStoreSaver(
+      createApi({ saveSession: vi.fn().mockRejectedValue(new Error('IPC propagation failed')) }),
+      useSessionStore.getState()
+    )
+
+    useSessionStore.getState().renameSession('session-1', 'Save will fail')
+    await expect(save(useSessionStore.getState())).rejects.toThrow('IPC propagation failed')
+
+    const upload = useSessionStore.getState().sessions[0].messages[0].uploads?.[0]
+    expect(upload).toMatchObject({ path: legacyPath })
+    expect(upload).not.toHaveProperty('versionId')
+  })
+
+  it('merges a delayed durable Upload identity without overwriting a newer live message', () => {
+    const legacyPath = '/data/uploads/default-project/session-1/legacy.csv'
+    const persisted = createPersistedSession({
+      projectId: 'project-a',
+      messages: [
+        {
+          id: 'message-1',
+          role: 'user',
+          content: 'Analyze this upload',
+          status: 'complete',
+          eventIds: [],
+          uploads: [
+            {
+              id: 'upload-1',
+              sessionId: 'session-1',
+              name: 'legacy.csv',
+              originalName: 'legacy.csv',
+              path: legacyPath,
+              size: 12
+            }
+          ],
+          createdAt: 1,
+          updatedAt: 1
+        }
+      ]
+    })
+    useSessionStore.getState().hydrateSessions([persisted])
+    const source = useSessionStore.getState().sessions[0]
+    const durable = structuredClone(persisted)
+    durable.messages[0].uploads = [
+      {
+        id: 'upload-1',
+        versionId: 'upload-version-1',
+        versionNumber: 1,
+        sessionId: 'session-1',
+        name: 'legacy.csv',
+        originalName: 'legacy.csv',
+        size: 12,
+        sha256: 'a'.repeat(64)
+      }
+    ]
+
+    useSessionStore.getState().appendUserMessage({
+      sessionId: 'session-1',
+      content: 'Newer live message',
+      projectId: 'project-a'
+    })
+    useSessionStore.getState().applyDurableSessionProjection({ source, session: durable })
+
+    const projected = useSessionStore.getState().sessions[0]
+    expect(projected.messages.map((message) => message.content)).toEqual([
+      'Analyze this upload',
+      'Newer live message'
+    ])
+    expect(projected.messages[0].uploads?.[0]).toMatchObject({
+      versionId: 'upload-version-1'
+    })
+    expect(
+      projected.conversationGraph?.messages.find((message) => message.id === 'message-1')
+        ?.uploads?.[0]
+    ).toMatchObject({ versionId: 'upload-version-1' })
+    expect(isExternallyHydratedSession(projected)).toBe(true)
+  })
+
+  it('accepts an equal-revision Upload Version from another lifecycle client', () => {
+    const persisted = createPersistedSession({
+      projectId: 'project-a',
+      messages: [
+        {
+          id: 'message-1',
+          role: 'user',
+          content: 'Analyze this upload',
+          status: 'complete',
+          eventIds: [],
+          uploads: [
+            {
+              id: 'upload-1',
+              sessionId: 'session-1',
+              name: 'legacy.csv',
+              originalName: 'legacy.csv',
+              path: '/data/uploads/default-project/session-1/legacy.csv',
+              size: 12
+            }
+          ],
+          createdAt: 1,
+          updatedAt: 1
+        }
+      ]
+    })
+    useSessionStore.getState().hydrateSessions([persisted])
+    const durable = structuredClone(persisted)
+    durable.messages[0].uploads = [
+      {
+        id: 'upload-1',
+        versionId: 'upload-version-1',
+        versionNumber: 1,
+        sessionId: 'session-1',
+        name: 'legacy.csv',
+        originalName: 'legacy.csv',
+        size: 12,
+        sha256: 'a'.repeat(64)
+      }
+    ]
+
+    useSessionStore.getState().upsertPersistedSession(durable)
+
+    expect(useSessionStore.getState().sessions[0].messages[0].uploads?.[0]).toMatchObject({
+      versionId: 'upload-version-1'
+    })
+  })
+
   it('does not infer durable deletion from sessions removed from the store', async () => {
     useSessionStore.getState().appendUserMessage({
       sessionId: 'session-1',
@@ -308,8 +526,8 @@ describe('renderer session persistence bridge', () => {
   })
 
   it('queues writes so later snapshots do not resolve before earlier ones', async () => {
-    const firstSave = createDeferred<void>()
-    const secondSave = createDeferred<void>()
+    const firstSave = createDeferred<PersistedChatSession>()
+    const secondSave = createDeferred<PersistedChatSession>()
     const saveSession = vi
       .fn()
       .mockReturnValueOnce(firstSave.promise)
@@ -343,11 +561,11 @@ describe('renderer session persistence bridge', () => {
     await flushMicrotasks()
     expect(saveSession).toHaveBeenCalledTimes(1)
 
-    firstSave.resolve()
+    firstSave.resolve(saveSession.mock.calls[0][0])
     await flushMicrotasks()
     expect(saveSession).toHaveBeenCalledTimes(2)
 
-    secondSave.resolve()
+    secondSave.resolve(saveSession.mock.calls[1][0])
     await flushMicrotasks()
   })
 })

--- a/src/renderer/src/lib/session-persistence/session-persistence.ts
+++ b/src/renderer/src/lib/session-persistence/session-persistence.ts
@@ -17,7 +17,7 @@ import type { ChatSession } from '../../stores/session-store'
 
 type SessionPersistenceApi = {
   loadAll: () => Promise<LoadAllSessionsResult>
-  saveSession: (session: PersistedChatSession) => Promise<void>
+  saveSession: (session: PersistedChatSession) => Promise<PersistedChatSession>
   deleteSession: (request: DeleteSessionRequest) => Promise<void>
   saveManifest: (request: SaveSessionManifestRequest) => Promise<void>
 }
@@ -149,7 +149,13 @@ const createStoreSaver = (
       ) {
         const persisted = toPersistedSession(session)
 
-        tasks.push(() => api.saveSession(persisted))
+        tasks.push(async () => {
+          const durableSession = await api.saveSession(persisted)
+          useSessionStore.getState().applyDurableSessionProjection({
+            source: session,
+            session: durableSession
+          })
+        })
       }
     }
 

--- a/src/renderer/src/stores/session-store.ts
+++ b/src/renderer/src/stores/session-store.ts
@@ -193,6 +193,11 @@ type ReplaceMessageUploadsInput = {
   uploads: PersistedUploadedAttachment[]
 }
 
+type ApplyDurableSessionProjectionInput = {
+  source: ChatSession
+  session: PersistedChatSession
+}
+
 type AppendMessageResult = {
   sessionId: string
   messageId: string
@@ -214,6 +219,7 @@ type SessionStore = SessionStoreData & {
   clearArtifactError: (sessionId: string) => void
   hydrateSessions: (sessions: PersistedChatSession[], manifest?: PersistedSessionManifest) => void
   upsertPersistedSession: (session: PersistedChatSession) => void
+  applyDurableSessionProjection: (input: ApplyDurableSessionProjectionInput) => void
   finishRun: (sessionId: string) => void
   // opts.reportable overrides the report-affordance decision: pass false for a model-provider failure
   // (the agent relayed an upstream LLM/HTTP error), true to force it, or omit to let the store derive it
@@ -352,6 +358,81 @@ const hydrateSession = (session: PersistedChatSession): ChatSession => ({
   // flag them so the composer can surface a Resume button instead of a dead-end error.
   interrupted: session.error === INTERRUPTED_SESSION_ERROR ? true : undefined
 })
+
+const withTransientSessionState = (
+  session: PersistedChatSession,
+  source: ChatSession
+): ChatSession => {
+  const sourceMessages = new Map(source.messages.map((message) => [message.id, message]))
+  const hydrated = hydrateSession(session)
+  return {
+    ...hydrated,
+    messages: hydrated.messages.map((message) => ({
+      ...message,
+      sortIndex: sourceMessages.get(message.id)?.sortIndex
+    })),
+    isPending: source.isPending,
+    interrupted: source.interrupted,
+    fixLoopActive: source.fixLoopActive,
+    compacting: source.compacting,
+    agentStatus: source.agentStatus,
+    branchContextResetRequired: source.branchContextResetRequired,
+    branchSwitchBlocked: source.branchSwitchBlocked,
+    conversationGraphSyncBlocked: source.conversationGraphSyncBlocked
+  }
+}
+
+const isSameSubmittedUpload = (
+  current: PersistedUploadedAttachment,
+  submitted: PersistedUploadedAttachment
+): boolean =>
+  current.id === submitted.id &&
+  current.versionId === submitted.versionId &&
+  current.sessionId === submitted.sessionId &&
+  current.name === submitted.name &&
+  current.originalName === submitted.originalName &&
+  current.path === submitted.path &&
+  current.mimeType === submitted.mimeType &&
+  current.size === submitted.size
+
+// A save may resolve after a newer runtime event already replaced the source Session object. Merge
+// only the legacy Upload identities proven by that submitted snapshot; never overwrite newer text,
+// graph, status, or transient runtime state with an older durable response.
+const mergeDurableUploadProjection = <Message extends PersistedChatMessage>(
+  currentMessages: Message[],
+  submittedMessages: PersistedChatMessage[],
+  durableMessages: PersistedChatMessage[]
+): { messages: Message[]; changed: boolean } => {
+  const submittedById = new Map(submittedMessages.map((message) => [message.id, message]))
+  const durableById = new Map(durableMessages.map((message) => [message.id, message]))
+  let changed = false
+  const messages = currentMessages.map((message) => {
+    const submitted = submittedById.get(message.id)
+    const durable = durableById.get(message.id)
+    if (!message.uploads || !submitted?.uploads || !durable?.uploads) return message
+    const submittedUploads = new Map(submitted.uploads.map((upload) => [upload.id, upload]))
+    const durableUploads = new Map(durable.uploads.map((upload) => [upload.id, upload]))
+    let uploadsChanged = false
+    const uploads = message.uploads.map((upload) => {
+      const submittedUpload = submittedUploads.get(upload.id)
+      const durableUpload = durableUploads.get(upload.id)
+      if (
+        !submittedUpload ||
+        !durableUpload?.versionId ||
+        submittedUpload.versionId ||
+        !isSameSubmittedUpload(upload, submittedUpload)
+      ) {
+        return upload
+      }
+      uploadsChanged = true
+      return durableUpload
+    })
+    if (!uploadsChanged) return message
+    changed = true
+    return { ...message, uploads } as Message
+  })
+  return { messages, changed }
+}
 
 // Serializes one in-memory session into the durable per-file projection saved by the main process.
 export { stripTransientSessionState as toPersistedSession }
@@ -934,11 +1015,45 @@ export const useSessionStore = create<SessionStore>((set, get) => ({
   },
 
   // Applies a durable lifecycle event without letting this client's own save echo replace newer
-  // transient runtime state. Newer external snapshots remain authoritative.
+  // transient runtime state. An equal-revision response may still carry a newly published Upload
+  // Version, so merge that identity delta instead of discarding the whole event.
   upsertPersistedSession: (session) => {
     set((state) => {
       const existing = state.sessions.find((candidate) => candidate.id === session.id)
-      if (existing && existing.updatedAt >= session.updatedAt) return state
+      if (existing && existing.updatedAt > session.updatedAt) return state
+      if (existing && existing.updatedAt === session.updatedAt) {
+        const flat = mergeDurableUploadProjection(
+          existing.messages,
+          existing.messages,
+          session.messages
+        )
+        const graph = existing.conversationGraph
+          ? mergeDurableUploadProjection(
+              existing.conversationGraph.messages,
+              existing.conversationGraph.messages,
+              session.conversationGraph?.messages ?? session.messages
+            )
+          : undefined
+        if (!flat.changed && !graph?.changed) return state
+        const projected: ChatSession = {
+          ...existing,
+          messages: flat.messages,
+          ...(graph?.changed
+            ? {
+                conversationGraph: {
+                  ...existing.conversationGraph!,
+                  messages: graph.messages
+                }
+              }
+            : {})
+        }
+        externallyHydratedSessions.add(projected)
+        return {
+          sessions: state.sessions.map((candidate) =>
+            candidate.id === session.id ? projected : candidate
+          )
+        }
+      }
 
       const hydratedSession = hydrateSession(session)
       externallyHydratedSessions.add(hydratedSession)
@@ -948,6 +1063,67 @@ export const useSessionStore = create<SessionStore>((set, get) => ({
       ].sort((left, right) => right.updatedAt - left.updatedAt)
 
       return { sessions }
+    })
+  },
+
+  // Acknowledges the exact projection returned by this client's save. Reference equality makes an
+  // unchanged source safe to replace wholesale; a later live mutation receives only the immutable
+  // Upload identity delta so the older response cannot roll back newer conversation state.
+  applyDurableSessionProjection: ({ source, session }) => {
+    set((state) => {
+      const current = state.sessions.find((candidate) => candidate.id === session.id)
+      if (!current) return state
+
+      let projected: ChatSession
+      if (current === source) {
+        const flat = mergeDurableUploadProjection(
+          source.messages,
+          source.messages,
+          session.messages
+        )
+        const graph = source.conversationGraph
+          ? mergeDurableUploadProjection(
+              source.conversationGraph.messages,
+              source.conversationGraph.messages,
+              session.conversationGraph?.messages ?? session.messages
+            )
+          : undefined
+        if (!flat.changed && !graph?.changed) return state
+        projected = withTransientSessionState(session, current)
+      } else {
+        const flat = mergeDurableUploadProjection(
+          current.messages,
+          source.messages,
+          session.messages
+        )
+        const graph = current.conversationGraph
+          ? mergeDurableUploadProjection(
+              current.conversationGraph.messages,
+              source.conversationGraph?.messages ?? source.messages,
+              session.conversationGraph?.messages ?? session.messages
+            )
+          : undefined
+        if (!flat.changed && !graph?.changed) return state
+        projected = {
+          ...current,
+          messages: flat.messages,
+          ...(graph?.changed
+            ? {
+                conversationGraph: {
+                  ...current.conversationGraph!,
+                  messages: graph.messages
+                }
+              }
+            : {})
+        }
+      }
+
+      externallyHydratedSessions.add(projected)
+      return {
+        sessions: state.sessions.map((candidate) =>
+          candidate.id === session.id ? projected : candidate
+        )
+      }
     })
   },
 


### PR DESCRIPTION
## Problem

Legacy Session uploads can leave duplicate managed bytes after migration into immutable Upload Versions. Destructive migration can also strand a live or durable Session on stale paths when a save, sibling Upload, or later delete step fails. Historical quarantine backups must remain recoverable without permanently blocking a later valid Session deletion.

Follow-up to #481.

## Proposed change

- Publish live migrations through an atomic copy, persist the path-free Session, and return and broadcast that exact durable projection across IPC.
- Merge only proven Upload Version identity deltas into renderer state, preserving concurrent messages and transient state without creating a persistence echo.
- Make first-startup migration two-phase: complete every path-only Upload with `live-save`, update hydration, save the whole path-free Session, then reconcile legacy copies. Same-Session partial failures retain every legacy source.
- Make Session and Project terminal deletion two-phase: `live-save` -> durable Session save -> `terminal-delete`, so failed saves and later delete failures leave readable durable authority.
- Restrict destructive startup cleanup to the first process-level load; later readers use live-safe migration.
- Treat a valid current Session JSON as superseding matching historical quarantines without deleting backups during normal recovery; orphan/current-invalid/I/O cases remain fail-closed.
- On explicit Session deletion, re-prove the valid primary, remove only its matching superseded quarantines first, then remove the primary. Partial failures preserve retryable authority.
- Recover deterministic live-copy temp files and reconcile legacy copies with Project, Session, Upload, Version, path, checksum, and file-identity proofs.
- Use an atomic private claim for final deletion; crash recovery restores candidates without overwrite and reacquires a fresh inode witness before deletion.
- Return a discriminated cleanup outcome and tolerate only positively proven unsafe/unowned replacements during an explicit whole-Project deletion. Missing/corrupt authority, publication, database, filesystem, recovery, and claim failures remain fatal and retryable; direct Session deletion remains fail-closed.
- Commit whole-Project Session deletion through an atomic marked tombstone before derived index and Project/provenance cleanup. Durable state distinguishes live authority, legacy unmarked tombstones, prepared tombstones, and absence.
- Upgrade old unmarked tombstones in place, persist path-free Session JSON inside the tombstone, terminal-clean verified sources, and only then atomically write the prepared marker. Prepared recovery skips Upload reconciliation, so a crash after provenance removal can finish without deleted Version authority.
- Adopt historical unmarked tombstones even when an older release already removed their Project row and deletion intent: first persist a new intent, then reuse the normal recovery tail.
- Use a conservative orphan-recovery mode that may reuse surviving Upload authority but never recreate missing authority from legacy paths. Definitively missing authority with surviving byte candidates returns a retained outcome: preserve the tombstone, locator, and bytes, remove the temporary adoption intent, and allow unrelated Projects to continue. Transient I/O/database faults, incomplete scans, malformed markers, and conflicting state remain retryable failures.
- Treat an orphan reference as already cleaned only when the deterministic legacy path, private claim, and bounded immutable Version tree are all positively empty; filesystem uncertainty and symlinked roots remain fail-closed.
- Await every started Upload/message/graph sibling operation before returning from migration, prioritize ordinary database/filesystem errors over suppressible orphan outcomes, and soft-delete the whole Project file index before returning `orphan-retained` so no recovered sibling remains visible or writes late.
- Validate every repeated Upload ID across flat messages and the conversation graph before any database/filesystem work; only identical immutable identities may share publication or cleanup, while divergent locators fail closed without mutation.

## Scope and non-goals

This PR only changes legacy Upload migration, durable identity propagation, terminal diagnostics, and verified cleanup. It does not change general upload UX or producer conflict semantics.

## Acceptance criteria and validation

- Final focused repository/coordinator/deletion regression tests: 137 of 137 passed.
- Independent Standards/architecture and Spec/correctness reviews: pass, no remaining findings.
- Typecheck: passed for node and web.
- Targeted ESLint: passed.
- Full suite on base `7980ad5`: 530 files passed; 7673 tests passed and 113 skipped.
- Diff and commit checks: passed.

## Review focus

Please focus on same-Session partial publication, startup and terminal two-phase ordering, multi-client startup safety, superseded-versus-active quarantine authority, deterministic temp recovery, atomic fail-closed legacy deletion, the `legacy-committed` -> `prepared` tombstone transition, orphan tombstone adoption, and restart after Project provenance has already removed Upload authority.
