### PR TITLE
fix(artifacts): retain generated files across Branch switches

### DIFF
--- a/src/renderer/src/lib/acp/workspace-events.test.ts
+++ b/src/renderer/src/lib/acp/workspace-events.test.ts
@@ -759,6 +759,73 @@ describe('workspace runtime events', () => {
     ])
   })
 
+  it('retains an unchanged post-stop Artifact after switching an edited Branch away and back', async () => {
+    const originalPromptMessageId =
+      useSessionStore.getState().sessions[0].activeRun?.promptMessageId
+    await applyWorkspaceRuntimeEvent(
+      createEvent({
+        id: 'assistant-event-original',
+        role: 'assistant',
+        messageId: 'assistant-message-original',
+        text: 'Saved the original plot.'
+      })
+    )
+    await applyWorkspaceRuntimeEvent(createEvent({ id: 'stop-original', kind: 'stop' }))
+
+    const originalBranchId =
+      useSessionStore.getState().sessions[0].conversationGraph?.frames[0].activeBranchId
+    useSessionStore
+      .getState()
+      .truncateSessionFromMessage('transport-session-1', originalPromptMessageId ?? '')
+    const editedPrompt = useSessionStore.getState().appendUserMessage({
+      sessionId: 'transport-session-1',
+      content: 'Save an edited plot'
+    })
+    await applyWorkspaceRuntimeEvent(
+      createEvent({
+        id: 'assistant-event-edited',
+        role: 'assistant',
+        messageId: 'assistant-message-edited',
+        text: 'Saved the edited plot.'
+      })
+    )
+    const responseMessageId = useSessionStore.getState().sessions[0].messages.at(-1)?.id
+    await applyWorkspaceRuntimeEvent(createEvent({ id: 'stop-edited', kind: 'stop' }))
+
+    const artifact = createArtifactFile({
+      id: 'artifact-version-2',
+      sessionId: 'transport-session-1',
+      messageId: responseMessageId,
+      runId: 'artifact-run-2'
+    })
+    const finalizeRunArtifacts = vi.fn().mockResolvedValue([artifact])
+    const saveSession = vi.fn().mockResolvedValue(undefined)
+    await applyWorkspaceRuntimeEvent(
+      createEvent({
+        id: 'artifact-event-after-edited-stop',
+        kind: 'artifact',
+        runId: 'artifact-run-2',
+        promptMessageId: editedPrompt?.messageId,
+        artifactSessionId: 'artifact-session-1',
+        artifactClaimId: 'claim-edited',
+        artifacts: [artifact]
+      }),
+      { finalizeRunArtifacts, saveSession }
+    )
+
+    const beforeSwitch = useSessionStore.getState().sessions[0]
+    const editedBranchId = beforeSwitch.conversationGraph?.frames[0].activeBranchId
+    expect(beforeSwitch.messages.at(-1)?.artifactIds).toEqual(['artifact-version-2'])
+
+    useSessionStore.getState().activateMessageBranch('transport-session-1', originalBranchId ?? '')
+    useSessionStore.getState().activateMessageBranch('transport-session-1', editedBranchId ?? '')
+
+    expect(useSessionStore.getState().sessions[0].messages.at(-1)).toMatchObject({
+      id: responseMessageId,
+      artifactIds: ['artifact-version-2']
+    })
+  })
+
   it('waits for stop before binding an artifact to the terminal response for its prompt', async () => {
     const promptMessageId = useSessionStore.getState().sessions[0].activeRun?.promptMessageId
     await applyWorkspaceRuntimeEvent(

--- a/src/renderer/src/stores/session-store.ts
+++ b/src/renderer/src/stores/session-store.ts
@@ -1241,7 +1241,8 @@ export const useSessionStore = create<SessionStore>((set, get) => ({
 
         if (
           arePersistedArtifactsEqual(session.artifacts, nextArtifacts) &&
-          areStringArraysEqual(message.artifactIds ?? [], incomingArtifactIds)
+          areStringArraysEqual(message.artifactIds ?? [], incomingArtifactIds) &&
+          areStringArraysEqual(graphMessage?.artifactIds ?? [], incomingArtifactIds)
         ) {
           return session
         }


### PR DESCRIPTION
## Problem

A deferred or post-stop Artifact can be attached in the same millisecond that `finishRun` publishes the terminal Message to the Conversation Graph. The flat Message then shows `GENERATED`, but the Graph can retain no `artifactIds`; switching Branches rebuilds from that stale Graph and hides the generated file even though the finalized Artifact Version remains durable.

## Proposed change

Treat Artifact finalization as a no-op only when the Session artifact metadata, flat Message, and Conversation Graph Message Node all carry the finalized Version ids. Add a frozen-time regression that exercises stop, unchanged finalization, and an edited-Branch round trip.

## Scope and non-goals

This does not relax the Conversation Graph timestamp conflict rules or repair already-persisted Sessions.

## Acceptance criteria and validation

- Post-stop unchanged Artifact descriptors remain attached after switching away and back.
- `npm run typecheck`
- `npm run lint` (0 errors; existing warnings only)
- `npm test` (527 files passed, 10 skipped; 7599 tests passed, 113 skipped)

## Review focus

Please review the finalization no-op guard and the regression test’s same-millisecond event ordering.