### PR TITLE
fix(security): harden DOI and trial query handling

### DIFF
--- a/resources/skills/literature-review/kernel.py
+++ b/resources/skills/literature-review/kernel.py
@@ -435,7 +435,7 @@ def extract_dois(text: str) -> list[str]:
         d = m.split("</")[0]
         if d.count("<") != d.count(">"):
             d = d.split("<")[0]
-        d = re.sub(r"(?:\*\*|__|[_\]\*>`,;:])+$", "", d)
+        d = d.rstrip("_]*>`,;:")
         if d.endswith("."):
             d = d[:-1]
         while d.endswith(")") and d.count("(") < d.count(")"):

--- a/resources/skills/literature-review/kernel.py
+++ b/resources/skills/literature-review/kernel.py
@@ -435,7 +435,7 @@ def extract_dois(text: str) -> list[str]:
         d = m.split("</")[0]
         if d.count("<") != d.count(">"):
             d = d.split("<")[0]
-        d = d.rstrip("_]*>`,;:")
+        d = d.rstrip("*_]>`,;:")
         if d.endswith("."):
             d = d[:-1]
         while d.endswith(")") and d.count("(") < d.count(")"):

--- a/resources/skills/literature-review/kernel.test.ts
+++ b/resources/skills/literature-review/kernel.test.ts
@@ -1,0 +1,18 @@
+import { execFileSync } from 'node:child_process'
+import { existsSync } from 'node:fs'
+import { dirname, resolve } from 'node:path'
+import { fileURLToPath } from 'node:url'
+
+import { describe, expect, it } from 'vitest'
+
+const python3 = ['/opt/homebrew/bin/python3', '/usr/local/bin/python3', '/usr/bin/python3'].find(
+  existsSync
+)
+const gate = python3 ? describe : describe.skip
+const testFile = resolve(dirname(fileURLToPath(import.meta.url)), 'test_kernel.py')
+
+gate('literature-review kernel', () => {
+  it('passes its Python regression tests', () => {
+    expect(() => execFileSync(python3 as string, [testFile], { timeout: 5_000 })).not.toThrow()
+  })
+})

--- a/resources/skills/literature-review/test_kernel.py
+++ b/resources/skills/literature-review/test_kernel.py
@@ -1,0 +1,20 @@
+import time
+import unittest
+
+from kernel import extract_dois
+
+
+class ExtractDoisTests(unittest.TestCase):
+    def test_rejecting_a_long_markdown_like_suffix_stays_fast(self) -> None:
+        candidate = "10.1234/" + "*" * 8_000 + "A"
+
+        started = time.monotonic()
+        result = extract_dois(candidate)
+        elapsed = time.monotonic() - started
+
+        self.assertEqual(result, [candidate])
+        self.assertLess(elapsed, 0.25)
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/resources/skills/literature-review/test_kernel.py
+++ b/resources/skills/literature-review/test_kernel.py
@@ -5,6 +5,9 @@ from kernel import extract_dois
 
 
 class ExtractDoisTests(unittest.TestCase):
+    def test_strips_trailing_markdown_emphasis(self) -> None:
+        self.assertEqual(extract_dois("**10.1234/foo**"), ["10.1234/foo"])
+
     def test_rejecting_a_long_markdown_like_suffix_stays_fast(self) -> None:
         candidate = "10.1234/" + "*" * 8_000 + "A"
 

--- a/src/main/connectors/descriptors/clinical-trials.test.ts
+++ b/src/main/connectors/descriptors/clinical-trials.test.ts
@@ -251,6 +251,21 @@ describe('search_by_sponsor', () => {
     expect(params.countTotal).toBe('true')
     expect(out.total).toBe(7)
   })
+
+  it('keeps backslashes and quotes inside the LeadSponsorName phrase', async () => {
+    const fetchImpl = vi.fn().mockResolvedValue(jsonRes({ studies: [] }))
+
+    await call(
+      'search_by_sponsor',
+      { sponsor_name: 'Acme\\" OR AREA[Phase]PHASE4 OR "' },
+      fetchImpl
+    )
+
+    const { params } = parseUrl(fetchImpl.mock.calls[0][0] as string)
+    expect(params['filter.advanced']).toBe(
+      String.raw`(AREA[LeadSponsorName]"Acme\\\" OR AREA[Phase]PHASE4 OR \"")`
+    )
+  })
 })
 
 describe('search_investigators', () => {

--- a/src/main/connectors/descriptors/clinical-trials.ts
+++ b/src/main/connectors/descriptors/clinical-trials.ts
@@ -135,7 +135,8 @@ function normalizeNct(id: unknown): string {
 
 // ── Essie expression builders (query.term / filter.advanced) ─────────────────
 
-const quotePhrase = (text: string): string => '"' + text.replace(/"/g, '\\"') + '"'
+const quotePhrase = (text: string): string =>
+  '"' + text.replace(/\\/g, '\\\\').replace(/"/g, '\\"') + '"'
 const areaPhrase = (area: string, phrase: string): string => `AREA[${area}]${quotePhrase(phrase)}`
 const areaTerm = (area: string, term: string): string => `AREA[${area}]${term}`
 const areaRange = (area: string, lo: string | null, hi: string | null): string =>


### PR DESCRIPTION
## Problem

CodeQL reports exponential regular-expression behavior in DOI suffix cleanup and incomplete string escaping in ClinicalTrials.gov phrase filters. Crafted inputs can consume excessive CPU or change the intended advanced-query structure.

## Proposed change

- Replace the DOI suffix regex with linear-time character trimming while preserving the accepted suffix character set.
- Escape backslashes before quotes when constructing ClinicalTrials.gov phrases.
- Add Python and Vitest regression coverage for an 8,000-character adversarial DOI suffix and an injection-shaped sponsor phrase.

## Scope and non-goals

- No dependency or lockfile updates; Dependabot alerts are intentionally out of scope.
- No web-service error response changes. Code-scanning alert 3 was separately dismissed as a false positive because the response exposes only Error.message or String(error), never Error.stack.

## Acceptance criteria and validation

- Adversarial DOI cleanup completes within the regression budget and preserves prior trimming semantics.
- ClinicalTrials.gov phrases retain literal backslashes and escaped quotes without breaking the phrase boundary.
- `npm run typecheck` passes.
- `npm run lint` passes with 0 errors; 24 existing warnings remain outside this change.
- Targeted tests pass: 2 files, 16 tests.
- Full `npm test` passes: 528 files and 7,601 tests; 10 files and 113 tests skipped.

## Review focus

- Equivalence of the `rstrip` character set to the former regex cleanup.
- Backslash-before-quote escaping order in ClinicalTrials.gov advanced filters.
- Regression tests' ability to distinguish the vulnerable implementations.
