### PR TITLE
fix(windows): resolve PowerShell outside PATH

### DIFF
--- a/build/installer.nsh
+++ b/build/installer.nsh
@@ -1,5 +1,5 @@
 !macro customUnInstall
-  nsExec::ExecToLog 'powershell.exe -NoProfile -NonInteractive -ExecutionPolicy Bypass -File "$INSTDIR\resources\windows-runtime-cache-uninstall.ps1"'
+  nsExec::ExecToLog '"$SYSDIR\WindowsPowerShell\v1.0\powershell.exe" -NoProfile -NonInteractive -ExecutionPolicy Bypass -File "$INSTDIR\resources\windows-runtime-cache-uninstall.ps1"'
 !macroend
 
 !macro customInit

--- a/scripts/electron-builder-config.test.ts
+++ b/scripts/electron-builder-config.test.ts
@@ -27,6 +27,9 @@ describe('electron-builder Windows targets', () => {
     expect(config).toContain('from: build/windows-runtime-cache-uninstall.ps1')
     expect(config).toContain('include: build/installer.nsh')
     expect(include).toContain('windows-runtime-cache-uninstall.ps1')
+    const customUninstall = include.match(/!macro customUnInstall\n([\s\S]*?)!macroend/)?.[1]
+    expect(customUninstall).toContain('$SYSDIR\\WindowsPowerShell\\v1.0\\powershell.exe')
+    expect(customUninstall).not.toMatch(/ExecToLog 'powershell\.exe\b/)
     expect(cleanup).toContain('.open-science-cache.json')
     expect(cleanup).toContain('Get-CompactCacheLeaf')
     expect(cleanup).toContain('$compactLeaf = Get-CompactCacheLeaf $canonicalRoot $userIdentity')

--- a/src/main/notebook/micromamba-cache-powershell.test.ts
+++ b/src/main/notebook/micromamba-cache-powershell.test.ts
@@ -1,0 +1,38 @@
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest'
+
+const childProcessMocks = vi.hoisted(() => ({ execFileSync: vi.fn() }))
+
+vi.mock('node:child_process', () => childProcessMocks)
+
+import { hardenWindowsCacheAcl, readWindowsCacheAcl } from './micromamba-cache'
+
+const originalPlatform = Object.getOwnPropertyDescriptor(process, 'platform')
+
+describe('Windows micromamba cache PowerShell invocation', () => {
+  beforeEach(() => {
+    Object.defineProperty(process, 'platform', { configurable: true, value: 'win32' })
+    vi.stubEnv('SystemRoot', 'C:\\Windows')
+    childProcessMocks.execFileSync.mockReset().mockReturnValue(
+      JSON.stringify({
+        OwnerSid: 'S-1-5-21-current',
+        CurrentSid: 'S-1-5-21-current',
+        Rules: []
+      })
+    )
+  })
+
+  afterEach(() => {
+    Object.defineProperty(process, 'platform', originalPlatform!)
+    vi.unstubAllEnvs()
+  })
+
+  it('uses the system PowerShell executable for ACL writes and reads without relying on PATH', () => {
+    hardenWindowsCacheAcl('D:\\osp-cache')
+    readWindowsCacheAcl('D:\\osp-cache')
+
+    expect(childProcessMocks.execFileSync).toHaveBeenCalledTimes(2)
+    for (const [executable] of childProcessMocks.execFileSync.mock.calls) {
+      expect(executable).toBe('C:\\Windows\\System32\\WindowsPowerShell\\v1.0\\powershell.exe')
+    }
+  })
+})

--- a/src/main/notebook/micromamba-cache.ts
+++ b/src/main/notebook/micromamba-cache.ts
@@ -3,6 +3,7 @@ import { execFileSync } from 'node:child_process'
 import { lstatSync, mkdirSync, readFileSync, realpathSync, rmSync, writeFileSync } from 'node:fs'
 import { basename, dirname, join, resolve, win32 } from 'node:path'
 
+import { resolveWindowsPowerShellExecutable } from '../windows-powershell'
 import { DEFAULT_MAX_CACHE_RELATIVE_PATH as MANIFEST_DEFAULT_MAX_CACHE_RELATIVE_PATH } from './bundle-manifest'
 
 export const WINDOWS_MAX_USABLE_PATH = 259
@@ -105,7 +106,7 @@ export const windowsCacheAclHardeningScript = (path: string): string => {
 export const hardenWindowsCacheAcl = (path: string): void => {
   if (process.platform !== 'win32') return
   execFileSync(
-    'powershell.exe',
+    resolveWindowsPowerShellExecutable(),
     ['-NoProfile', '-NonInteractive', '-Command', windowsCacheAclHardeningScript(path)],
     { encoding: 'utf8', windowsHide: true }
   )
@@ -170,7 +171,7 @@ export const windowsCacheAclReadScript = (path: string): string => {
 export const readWindowsCacheAcl = (path: string): WindowsCacheAcl => {
   const script = windowsCacheAclReadScript(path)
   const raw = execFileSync(
-    'powershell.exe',
+    resolveWindowsPowerShellExecutable(),
     ['-NoProfile', '-NonInteractive', '-Command', script],
     {
       encoding: 'utf8',

--- a/src/main/notebook/runtime-service.test.ts
+++ b/src/main/notebook/runtime-service.test.ts
@@ -57,6 +57,7 @@ const createStorageRoot = async (): Promise<string> => {
 }
 
 afterEach(async () => {
+  vi.unstubAllEnvs()
   if (storageRoot) {
     await rm(storageRoot, { recursive: true, force: true })
     storageRoot = undefined
@@ -99,10 +100,13 @@ describe('resolveShellInvocation', () => {
     })
   })
 
-  it('uses a non-interactive PowerShell command on Windows instead of assuming sh exists', () => {
+  it('uses an absolute non-interactive PowerShell command on Windows without relying on PATH', () => {
+    vi.stubEnv('SystemRoot', 'C:\\Windows')
     const invocation = resolveShellInvocation('cp "source.png" "destination.png"', 'win32')
 
-    expect(invocation.executable).toBe('powershell.exe')
+    expect(invocation.executable).toBe(
+      'C:\\Windows\\System32\\WindowsPowerShell\\v1.0\\powershell.exe'
+    )
     expect(invocation.args.slice(0, -1)).toEqual([
       '-NoLogo',
       '-NoProfile',
@@ -133,6 +137,7 @@ describe('resolveShellInvocation', () => {
   })
 
   it('isolates PowerShell command syntax from the exit-code wrapper', () => {
+    vi.stubEnv('SystemRoot', 'C:\\Windows')
     const command = "Write-Output 'first'\n# keep this comment\nWrite-Output 'continued' `"
     const invocation = resolveShellInvocation(command, 'win32')
     const script = Buffer.from(invocation.args.at(-1) ?? '', 'base64').toString('utf16le')

--- a/src/main/notebook/runtime-service.ts
+++ b/src/main/notebook/runtime-service.ts
@@ -108,6 +108,7 @@ import {
 import { isChildUnconfirmedError } from './provisioner-runtime'
 import { getAppClaudeConfigDir } from '../settings/provider-env'
 import { terminateProcessTree } from '../process-tree'
+import { resolveWindowsPowerShellExecutable } from '../windows-powershell'
 import {
   EnvironmentManifestPublicationError,
   EnvironmentStateTracker,
@@ -730,7 +731,7 @@ const resolveShellInvocation = (
 ): ShellInvocation =>
   platform === 'win32'
     ? {
-        executable: 'powershell.exe',
+        executable: resolveWindowsPowerShellExecutable(),
         args: [
           '-NoLogo',
           '-NoProfile',

--- a/src/main/windows-powershell.test.ts
+++ b/src/main/windows-powershell.test.ts
@@ -18,9 +18,7 @@ describe('resolveWindowsPowerShellExecutable', () => {
     )
   })
 
-  it('fails when neither Windows root variable is available', () => {
-    expect(() => resolveWindowsPowerShellExecutable({})).toThrow(
-      'SystemRoot and WINDIR are unavailable'
-    )
+  it('falls back to PATH lookup when neither Windows root variable is available', () => {
+    expect(resolveWindowsPowerShellExecutable({})).toBe('powershell.exe')
   })
 })

--- a/src/main/windows-powershell.test.ts
+++ b/src/main/windows-powershell.test.ts
@@ -1,0 +1,26 @@
+import { describe, expect, it } from 'vitest'
+
+import { resolveWindowsPowerShellExecutable } from './windows-powershell'
+
+describe('resolveWindowsPowerShellExecutable', () => {
+  it('uses SystemRoot when PATH does not contain Windows system directories', () => {
+    expect(
+      resolveWindowsPowerShellExecutable({
+        SystemRoot: 'D:\\Windows',
+        PATH: 'C:\\Users\\sunsh\\bin'
+      })
+    ).toBe('D:\\Windows\\System32\\WindowsPowerShell\\v1.0\\powershell.exe')
+  })
+
+  it('uses WINDIR when SystemRoot is unavailable', () => {
+    expect(resolveWindowsPowerShellExecutable({ WINDIR: 'E:\\Windows' })).toBe(
+      'E:\\Windows\\System32\\WindowsPowerShell\\v1.0\\powershell.exe'
+    )
+  })
+
+  it('fails when neither Windows root variable is available', () => {
+    expect(() => resolveWindowsPowerShellExecutable({})).toThrow(
+      'SystemRoot and WINDIR are unavailable'
+    )
+  })
+})

--- a/src/main/windows-powershell.ts
+++ b/src/main/windows-powershell.ts
@@ -8,7 +8,7 @@ export const resolveWindowsPowerShellExecutable = (
 ): string => {
   const windowsRoot = env.SystemRoot || env.WINDIR
   if (!windowsRoot) {
-    throw new Error('Cannot resolve Windows PowerShell: SystemRoot and WINDIR are unavailable')
+    return 'powershell.exe'
   }
   return win32.join(windowsRoot, 'System32', 'WindowsPowerShell', 'v1.0', 'powershell.exe')
 }

--- a/src/main/windows-powershell.ts
+++ b/src/main/windows-powershell.ts
@@ -1,0 +1,14 @@
+import { win32 } from 'node:path'
+
+// Windows PowerShell 5.1 is an OS component with a stable location beneath the Windows root.
+// Resolve it directly so a damaged or intentionally minimal PATH cannot block managed runtimes,
+// notebook shell commands, or other security-sensitive operations that depend on PowerShell.
+export const resolveWindowsPowerShellExecutable = (
+  env: NodeJS.ProcessEnv = process.env
+): string => {
+  const windowsRoot = env.SystemRoot || env.WINDIR
+  if (!windowsRoot) {
+    throw new Error('Cannot resolve Windows PowerShell: SystemRoot and WINDIR are unavailable')
+  }
+  return win32.join(windowsRoot, 'System32', 'WindowsPowerShell', 'v1.0', 'powershell.exe')
+}


### PR DESCRIPTION
## Problem

Windows can retain PowerShell 5.1 at its standard SystemRoot location while omitting system directories from PATH. Managed runtime cache ACL preparation then fails with `spawnSync powershell.exe ENOENT`, blocking default-python environment updates.

## Proposed change

- Resolve Windows PowerShell 5.1 from `SystemRoot`, with `WINDIR` fallback.
- Reuse the absolute executable for managed cache ACL writes and reads, plus notebook shell commands.
- Preserve bare `powershell.exe` lookup only when both Windows root variables are unavailable, so existing process-level error handling remains intact.
- Invoke NSIS cleanup through `$SYSDIR`.
- Add regression coverage for PATH-independent resolution and each affected call site.

## Scope and non-goals

- Does not mutate PATH.
- Does not add a PowerShell 7 or `pwsh` fallback.
- Does not relax the cache ACL trust policy.

## Acceptance criteria and validation

- PATH-independent resolution uses `SystemRoot` and `WINDIR` fallback.
- Stripped environments without either root variable retain the existing PATH lookup behavior.
- Cache ACL and shell invocations use the absolute executable when the Windows root is available.
- Installer cleanup uses `$SYSDIR`.
- `npm run typecheck` passes.
- `npm run lint` passes with 0 errors; 24 pre-existing warnings remain.
- `npm test` passes: 529 files and 7,603 tests.

## Review focus

- Windows root fallback and fail-closed ACL behavior.
- NSIS quoting for the absolute executable.