### PR TITLE
fix(session-persistence): transform graph upload data paths

### DIFF
--- a/src/main/session-persistence/data-path-roundtrip.test.ts
+++ b/src/main/session-persistence/data-path-roundtrip.test.ts
@@ -1,7 +1,7 @@
 import { join } from 'node:path'
 
 import { describe, expect, it } from 'vitest'
-import type { PersistedChatSession } from '../../shared/session-persistence'
+import { normalizeSessionFile, type PersistedChatSession } from '../../shared/session-persistence'
 import { decodeSessionDataPaths, encodeSessionDataPaths } from './session-data-paths'
 
 const ROOT = '/data/os'
@@ -39,19 +39,45 @@ const session: PersistedChatSession = {
 
 describe('session data-path round-trip', () => {
   it('encodes data-root paths to $DATA and decodes against a new root', () => {
-    const enc = encodeSessionDataPaths(session, ROOT)
+    const materialized = normalizeSessionFile(session, { preserveLegacyUploadPaths: true })!
+    const enc = encodeSessionDataPaths(materialized, ROOT)
     expect(enc.artifacts?.[0].path).toBe('$DATA/artifacts/p/s1/m/x.png')
     expect(enc.messages[0].uploads?.[0].path).toBe('$DATA/uploads/f')
+    expect(enc.conversationGraph?.messages[0].uploads?.[0].path).toBe('$DATA/uploads/f')
     expect(enc.cwd).toBe('$DATA/notebooks/p/s1')
 
     const dec = decodeSessionDataPaths(enc, '/mnt/new')
     expect(dec.artifacts?.[0].path).toBe(join('/mnt/new', 'artifacts/p/s1/m/x.png'))
     expect(dec.messages[0].uploads?.[0].path).toBe(join('/mnt/new', 'uploads/f'))
+    expect(dec.conversationGraph?.messages[0].uploads?.[0].path).toBe(join('/mnt/new', 'uploads/f'))
     expect(dec.artifacts?.[0].fileUrl).toMatch(/^file:\/\/.*x\.png$/)
   })
 
   it('leaves an external cwd unchanged', () => {
     const s = { ...session, cwd: '/Users/x/project' }
     expect(encodeSessionDataPaths(s, ROOT).cwd).toBe('/Users/x/project')
+  })
+
+  it('decodes Upload paths in a graph materialized from a legacy Session', () => {
+    const legacy = normalizeSessionFile(
+      {
+        ...session,
+        cwd: '$DATA/notebooks/p/s1',
+        messages: session.messages.map((message) => ({
+          ...message,
+          uploads: message.uploads?.map((upload) => ({
+            ...upload,
+            path: '$DATA/uploads/f'
+          }))
+        }))
+      },
+      { preserveLegacyUploadPaths: true }
+    )
+    expect(legacy?.conversationGraph?.messages[0].uploads?.[0].path).toBe('$DATA/uploads/f')
+
+    const decoded = decodeSessionDataPaths(legacy!, '/mnt/new')
+    expect(decoded.conversationGraph?.messages[0].uploads?.[0]).toEqual(
+      decoded.messages[0].uploads?.[0]
+    )
   })
 })

--- a/src/main/session-persistence/session-data-paths.ts
+++ b/src/main/session-persistence/session-data-paths.ts
@@ -1,6 +1,10 @@
 import { pathToFileURL } from 'node:url'
 
-import type { PersistedArtifact, PersistedChatSession } from '../../shared/session-persistence'
+import type {
+  PersistedArtifact,
+  PersistedChatMessage,
+  PersistedChatSession
+} from '../../shared/session-persistence'
 import { decodeDataPath, encodeDataPath } from '../storage/data-path'
 
 // Replaces a data-root absolute path with a $DATA sentinel and drops the derived fileUrl.
@@ -25,34 +29,63 @@ const decodeArtifact = (
   return { ...artifact, path, fileUrl: pathToFileURL(path).href }
 }
 
+const transformMessageUploadPaths = <Message extends PersistedChatMessage>(
+  messages: readonly Message[],
+  transformPath: (path: string) => string
+): Message[] =>
+  messages.map((message) => ({
+    ...message,
+    uploads: message.uploads?.map((upload) =>
+      upload.path ? { ...upload, path: transformPath(upload.path) } : upload
+    )
+  }))
+
 // Encodes/decodes a session's persisted paths (cwd, upload paths, artifact paths) without touching
 // any other field. Pure and immutable: always returns a new session object.
 export const encodeSessionDataPaths = (
   session: PersistedChatSession,
   dataRoot?: string
-): PersistedChatSession => ({
-  ...session,
-  cwd: encodeDataPath(session.cwd, dataRoot) as string,
-  messages: session.messages.map((message) => ({
-    ...message,
-    uploads: message.uploads?.map((upload) =>
-      upload.path ? { ...upload, path: encodeDataPath(upload.path, dataRoot) as string } : upload
-    )
-  })),
-  artifacts: session.artifacts?.map((artifact) => encodeArtifact(artifact, dataRoot))
-})
+): PersistedChatSession => {
+  const encodeUploadPath = (path: string): string => encodeDataPath(path, dataRoot) as string
+  return {
+    ...session,
+    cwd: encodeDataPath(session.cwd, dataRoot) as string,
+    messages: transformMessageUploadPaths(session.messages, encodeUploadPath),
+    ...(session.conversationGraph
+      ? {
+          conversationGraph: {
+            ...session.conversationGraph,
+            messages: transformMessageUploadPaths(
+              session.conversationGraph.messages,
+              encodeUploadPath
+            )
+          }
+        }
+      : {}),
+    artifacts: session.artifacts?.map((artifact) => encodeArtifact(artifact, dataRoot))
+  }
+}
 
 export const decodeSessionDataPaths = (
   session: PersistedChatSession,
   dataRoot?: string
-): PersistedChatSession => ({
-  ...session,
-  cwd: decodeDataPath(session.cwd, dataRoot) as string,
-  messages: session.messages.map((message) => ({
-    ...message,
-    uploads: message.uploads?.map((upload) =>
-      upload.path ? { ...upload, path: decodeDataPath(upload.path, dataRoot) as string } : upload
-    )
-  })),
-  artifacts: session.artifacts?.map((artifact) => decodeArtifact(artifact, dataRoot))
-})
+): PersistedChatSession => {
+  const decodeUploadPath = (path: string): string => decodeDataPath(path, dataRoot) as string
+  return {
+    ...session,
+    cwd: decodeDataPath(session.cwd, dataRoot) as string,
+    messages: transformMessageUploadPaths(session.messages, decodeUploadPath),
+    ...(session.conversationGraph
+      ? {
+          conversationGraph: {
+            ...session.conversationGraph,
+            messages: transformMessageUploadPaths(
+              session.conversationGraph.messages,
+              decodeUploadPath
+            )
+          }
+        }
+      : {}),
+    artifacts: session.artifacts?.map((artifact) => decodeArtifact(artifact, dataRoot))
+  }
+}


### PR DESCRIPTION
## Problem

Legacy Sessions without a conversation graph are materialized with graph-owned copies of their messages. Session data-path decoding transformed only the flat message projection, leaving graph Upload references with $DATA paths while the active projection used absolute paths. Immutable Upload identity validation then blocked startup reconciliation.

## Proposed change

- Transform Upload paths in both flat messages and every conversation graph message during encode and decode.
- Share the message-level transformation so both projections stay symmetric.
- Cover legacy graph materialization and graph-aware data-root round trips.

## Scope and non-goals

- Keep immutable Upload identity validation unchanged.
- Do not rewrite or delete user data directly.
- Do not change Version-backed Upload behavior.

## Acceptance criteria and validation

- [x] Legacy path-only Upload references decode identically in both projections.
- [x] Graph Upload paths round-trip through $DATA encoding.
- [x] npm run typecheck
- [x] npm run lint
- [x] npm test — 531 files passed, 7707 tests passed

## Review focus

Please verify that path transforms preserve every graph message, including inactive Branch history, while leaving sessions without a graph unchanged.