### PR TITLE
fix(persistence): surface startup and session storage failures

### DIFF
--- a/src/main/ipc.ts
+++ b/src/main/ipc.ts
@@ -80,6 +80,7 @@ import { registerReviewerIpcHandlers } from './reviewer/ipc'
 import {
   createDefaultReviewRepository,
   createDefaultSessionRepository,
+  loadSessionsAfterProjectRecovery,
   registerSessionPersistenceIpcHandlers
 } from './session-persistence/ipc'
 import { registerProjectFilesIpcHandlers } from './project-files/ipc'
@@ -304,10 +305,8 @@ const registerIpcHandlers = async ({
     artifactProvenanceRepository
   )
   const sessionPersistenceBackend: SessionPersistenceBackend = {
-    loadAll: async () => {
-      await projectDeletionCoordinator.recoverPendingDeletions()
-      return sessionPersistenceCoordinator.loadAll()
-    },
+    loadAll: () =>
+      loadSessionsAfterProjectRecovery(projectDeletionCoordinator, sessionPersistenceCoordinator),
     saveSession: async (session) => {
       await projectDeletionCoordinator.recoverPendingDeletions()
       const created =

--- a/src/main/ipc.ts
+++ b/src/main/ipc.ts
@@ -352,10 +352,16 @@ const registerIpcHandlers = async ({
     onDeliveryError: (error) =>
       notificationsLog.warn('task notification delivery failed', errorLogFields(error))
   })
-  // The renderer pulls the notification click target once its sessions are hydrated (a push sent
-  // before the listener exists would be lost); consume-once semantics live in the service.
-  ipcMain.handle('notifications:take-pending-open-session', () =>
-    taskNotifications.takePendingOpenSession()
+  // The renderer peeks once sessions are hydrated, then conditionally consumes the same target.
+  // This lets partial recovery open an already-loaded conversation while retaining an omitted one
+  // for retry, without an older IPC round trip clearing a newer click target.
+  ipcMain.handle('notifications:peek-pending-open-session', () =>
+    taskNotifications.peekPendingOpenSession()
+  )
+  ipcMain.handle('notifications:take-pending-open-session', (_event, expectedSessionId: unknown) =>
+    typeof expectedSessionId === 'string'
+      ? taskNotifications.takePendingOpenSession(expectedSessionId)
+      : null
   )
   // One MCP client manager backs both dispatch (ConnectorService.call → custom server) and skill-doc
   // generation (listTools) for user-added custom MCP servers (stdio + remote). It lazily connects per

--- a/src/main/ipc.ts
+++ b/src/main/ipc.ts
@@ -358,9 +358,9 @@ const registerIpcHandlers = async ({
   ipcMain.handle('notifications:peek-pending-open-session', () =>
     taskNotifications.peekPendingOpenSession()
   )
-  ipcMain.handle('notifications:take-pending-open-session', (_event, expectedSessionId: unknown) =>
-    typeof expectedSessionId === 'string'
-      ? taskNotifications.takePendingOpenSession(expectedSessionId)
+  ipcMain.handle('notifications:take-pending-open-session', (_event, expectedToken: unknown) =>
+    typeof expectedToken === 'number' && Number.isSafeInteger(expectedToken) && expectedToken > 0
+      ? taskNotifications.takePendingOpenSession(expectedToken)
       : null
   )
   // One MCP client manager backs both dispatch (ConnectorService.call → custom server) and skill-doc

--- a/src/main/notifications/task-notifications.test.ts
+++ b/src/main/notifications/task-notifications.test.ts
@@ -391,15 +391,19 @@ describe('TaskNotificationService', () => {
     expect(deliveryErrors).toEqual([boom])
   })
 
-  it('holds the notification click target until the renderer takes it (consume-once)', () => {
+  it('peeks without consuming and only takes the expected notification target', () => {
     const { service } = createService({})
 
-    expect(service.takePendingOpenSession()).toBeNull()
+    expect(service.peekPendingOpenSession()).toBeNull()
 
     service.setPendingOpenSession('session-7')
 
-    expect(service.takePendingOpenSession()).toEqual({ sessionId: 'session-7' })
-    expect(service.takePendingOpenSession()).toBeNull()
+    expect(service.peekPendingOpenSession()).toEqual({ sessionId: 'session-7' })
+    expect(service.peekPendingOpenSession()).toEqual({ sessionId: 'session-7' })
+    expect(service.takePendingOpenSession('newer-session')).toBeNull()
+    expect(service.peekPendingOpenSession()).toEqual({ sessionId: 'session-7' })
+    expect(service.takePendingOpenSession('session-7')).toEqual({ sessionId: 'session-7' })
+    expect(service.peekPendingOpenSession()).toBeNull()
   })
 
   it('surfaces the window on click even without a session (degraded connector approval)', async () => {

--- a/src/main/notifications/task-notifications.test.ts
+++ b/src/main/notifications/task-notifications.test.ts
@@ -398,12 +398,29 @@ describe('TaskNotificationService', () => {
 
     service.setPendingOpenSession('session-7')
 
-    expect(service.peekPendingOpenSession()).toEqual({ sessionId: 'session-7' })
-    expect(service.peekPendingOpenSession()).toEqual({ sessionId: 'session-7' })
-    expect(service.takePendingOpenSession('newer-session')).toBeNull()
-    expect(service.peekPendingOpenSession()).toEqual({ sessionId: 'session-7' })
-    expect(service.takePendingOpenSession('session-7')).toEqual({ sessionId: 'session-7' })
+    expect(service.peekPendingOpenSession()).toEqual({ sessionId: 'session-7', token: 1 })
+    expect(service.peekPendingOpenSession()).toEqual({ sessionId: 'session-7', token: 1 })
+    expect(service.takePendingOpenSession(2)).toBeNull()
+    expect(service.peekPendingOpenSession()).toEqual({ sessionId: 'session-7', token: 1 })
+    expect(service.takePendingOpenSession(1)).toEqual({ sessionId: 'session-7', token: 1 })
     expect(service.peekPendingOpenSession()).toBeNull()
+  })
+
+  it('does not let an older same-session click consume a newer target', () => {
+    const { service } = createService({})
+
+    service.setPendingOpenSession('session-7')
+    const older = service.peekPendingOpenSession()
+
+    service.setPendingOpenSession('session-7')
+    const newer = service.peekPendingOpenSession()
+
+    expect(older?.sessionId).toBe('session-7')
+    expect(newer?.sessionId).toBe('session-7')
+    expect(newer?.token).not.toBe(older?.token)
+    expect(service.takePendingOpenSession(older!.token)).toBeNull()
+    expect(service.peekPendingOpenSession()).toEqual(newer)
+    expect(service.takePendingOpenSession(newer!.token)).toEqual(newer)
   })
 
   it('surfaces the window on click even without a session (degraded connector approval)', async () => {

--- a/src/main/notifications/task-notifications.ts
+++ b/src/main/notifications/task-notifications.ts
@@ -210,6 +210,7 @@ export class TaskNotificationService {
   // (window just recreated, React not mounted yet) is lost, so the payload lives here until the
   // renderer — once its sessions are hydrated — takes it. Consume-once.
   private pendingOpenSession: OpenSessionFromNotificationRequest | undefined
+  private pendingOpenSessionToken = 0
 
   // Active snippet for a session, or undefined when there is none.
   private snippetFor(sessionId: string): string | undefined {
@@ -230,7 +231,7 @@ export class TaskNotificationService {
   // Records the conversation a notification click should open, so a renderer that misses the push
   // nudge (still loading, sessions not yet hydrated) can pull it when ready.
   setPendingOpenSession(sessionId: string): void {
-    this.pendingOpenSession = { sessionId }
+    this.pendingOpenSession = { sessionId, token: ++this.pendingOpenSessionToken }
   }
 
   // Lets the renderer check whether the target already exists in a partially hydrated store without
@@ -242,10 +243,10 @@ export class TaskNotificationService {
   // Clears the pending click target only when it is still the one the renderer inspected. A newer
   // notification may replace it while the renderer awaits IPC, and must not be consumed by the
   // older attempt.
-  takePendingOpenSession(expectedSessionId: string): OpenSessionFromNotificationRequest | null {
+  takePendingOpenSession(expectedToken: number): OpenSessionFromNotificationRequest | null {
     const pending = this.pendingOpenSession
 
-    if (!pending || pending.sessionId !== expectedSessionId) return null
+    if (!pending || pending.token !== expectedToken) return null
 
     this.pendingOpenSession = undefined
 

--- a/src/main/notifications/task-notifications.ts
+++ b/src/main/notifications/task-notifications.ts
@@ -233,14 +233,23 @@ export class TaskNotificationService {
     this.pendingOpenSession = { sessionId }
   }
 
-  // Returns and clears the pending click target; the renderer calls this once its session store is
-  // hydrated (and on every push nudge). Null when there is nothing to open.
-  takePendingOpenSession(): OpenSessionFromNotificationRequest | null {
+  // Lets the renderer check whether the target already exists in a partially hydrated store without
+  // losing it when the remaining persistence scan still needs to be retried.
+  peekPendingOpenSession(): OpenSessionFromNotificationRequest | null {
+    return this.pendingOpenSession ?? null
+  }
+
+  // Clears the pending click target only when it is still the one the renderer inspected. A newer
+  // notification may replace it while the renderer awaits IPC, and must not be consumed by the
+  // older attempt.
+  takePendingOpenSession(expectedSessionId: string): OpenSessionFromNotificationRequest | null {
     const pending = this.pendingOpenSession
+
+    if (!pending || pending.sessionId !== expectedSessionId) return null
 
     this.pendingOpenSession = undefined
 
-    return pending ?? null
+    return pending
   }
 
   // Remembers the prompt's first line so the terminal event can name the task. Called when a

--- a/src/main/session-persistence/coordinator.test.ts
+++ b/src/main/session-persistence/coordinator.test.ts
@@ -462,6 +462,57 @@ describe('SessionPersistenceCoordinator', () => {
     expect(fileIndex.reconcileActiveSessions).toHaveBeenCalledWith([session])
   })
 
+  it('hydrates a read-only snapshot without running startup reconciliation', async () => {
+    const session = createSession()
+    const result = { sessions: [session], manifest: { version: 1 as const } }
+    const repository = createSessionRepository({
+      loadAllWithDiagnostics: vi.fn().mockResolvedValue({
+        result,
+        isComplete: true,
+        warnings: []
+      })
+    })
+    const fileIndex = createFileIndex()
+    const provenance = {
+      captureFinalizedMessages: vi.fn().mockResolvedValue(undefined),
+      reconcileSessionDeletions: vi.fn().mockResolvedValue(undefined),
+      prepareSessionDeletion: vi.fn(),
+      completeSessionDeletion: vi.fn(),
+      abortSessionDeletion: vi.fn()
+    }
+    const uploads = { upgradeLegacySessionUploads: vi.fn() }
+    const artifactStorage = {
+      prepareProjectReconciliation: vi.fn(),
+      reconcileSession: vi.fn()
+    }
+    const coordinator = new SessionPersistenceCoordinator(
+      repository,
+      fileIndex,
+      undefined,
+      provenance,
+      uploads,
+      artifactStorage
+    )
+
+    await expect(coordinator.loadAllReadOnly()).resolves.toEqual({
+      ...result,
+      diagnostics: {
+        isComplete: false,
+        warnings: [],
+        failure: 'startup-reconciliation-failed'
+      }
+    })
+
+    expect(fileIndex.markReconciliationIncomplete).toHaveBeenCalledOnce()
+    expect(fileIndex.reconcileActiveSessions).not.toHaveBeenCalled()
+    expect(fileIndex.syncSession).not.toHaveBeenCalled()
+    expect(repository.saveSession).not.toHaveBeenCalled()
+    expect(provenance.reconcileSessionDeletions).not.toHaveBeenCalled()
+    expect(uploads.upgradeLegacySessionUploads).not.toHaveBeenCalled()
+    expect(artifactStorage.prepareProjectReconciliation).not.toHaveBeenCalled()
+    expect(artifactStorage.reconcileSession).not.toHaveBeenCalled()
+  })
+
   it('reconciles path-free Upload copies only on the first complete load from multiple clients', async () => {
     const root = await mkdtemp(join(tmpdir(), 'open-science-upload-startup-reconcile-'))
     const client = createProjectDbClient(root)

--- a/src/main/session-persistence/coordinator.test.ts
+++ b/src/main/session-persistence/coordinator.test.ts
@@ -510,6 +510,7 @@ describe('SessionPersistenceCoordinator', () => {
     })
 
     expect(fileIndex.markReconciliationIncomplete).toHaveBeenCalledOnce()
+    expect(repository.loadAllWithDiagnostics).toHaveBeenCalledWith({ mode: 'read-only' })
     expect(fileIndex.reconcileActiveSessions).not.toHaveBeenCalled()
     expect(fileIndex.syncSession).not.toHaveBeenCalled()
     expect(repository.saveSession).not.toHaveBeenCalled()

--- a/src/main/session-persistence/coordinator.test.ts
+++ b/src/main/session-persistence/coordinator.test.ts
@@ -742,7 +742,8 @@ describe('SessionPersistenceCoordinator', () => {
     await expect(coordinator.loadAll()).resolves.toBe(incomplete.result)
     await expect(coordinator.loadAll()).resolves.toEqual({
       sessions: [upgradedSession],
-      manifest: complete.result.manifest
+      manifest: complete.result.manifest,
+      diagnostics: { isComplete: true, warnings: [] }
     })
 
     expect(uploads.upgradeLegacySessionUploads).toHaveBeenCalledOnce()
@@ -1317,14 +1318,23 @@ describe('SessionPersistenceCoordinator', () => {
   it('marks the index incomplete when the sessions scan is partial', async () => {
     const session = createSession()
     const result = { sessions: [session], manifest: { version: 1 as const } }
+    const warnings = [
+      {
+        kind: 'unreadable' as const,
+        projectId: 'project-1',
+        fileName: 'session-2.json',
+        recovered: false
+      }
+    ]
     const repository = createSessionRepository({
-      loadAllWithDiagnostics: vi.fn().mockResolvedValue({ result, isComplete: false })
+      loadAllWithDiagnostics: vi.fn().mockResolvedValue({ result, isComplete: false, warnings })
     })
     const markReconciliationIncomplete = vi.fn()
     const fileIndex = createFileIndex({ markReconciliationIncomplete })
     const coordinator = new SessionPersistenceCoordinator(repository, fileIndex)
 
     await expect(coordinator.loadAll()).resolves.toBe(result)
+    expect(result).toMatchObject({ diagnostics: { isComplete: false, warnings } })
     expect(markReconciliationIncomplete).toHaveBeenCalledOnce()
     expect(fileIndex.reconcileActiveSessions).not.toHaveBeenCalled()
   })
@@ -1352,6 +1362,12 @@ describe('SessionPersistenceCoordinator', () => {
     )
 
     await expect(coordinator.loadAll()).resolves.toBe(result)
+    expect(result).toMatchObject({
+      diagnostics: {
+        isComplete: false,
+        failure: 'startup-reconciliation-failed'
+      }
+    })
     expect(markReconciliationIncomplete).toHaveBeenCalledOnce()
     expect(fileIndex.reconcileActiveSessions).not.toHaveBeenCalled()
   })

--- a/src/main/session-persistence/coordinator.test.ts
+++ b/src/main/session-persistence/coordinator.test.ts
@@ -1277,6 +1277,28 @@ describe('SessionPersistenceCoordinator', () => {
     expect(syncSession).toHaveBeenCalledOnce()
   })
 
+  it('marks startup reconciliation incomplete when a Session file-index sync fails', async () => {
+    const session = createSession()
+    const result = { sessions: [session], manifest: { version: 1 as const } }
+    const repository = createSessionRepository({
+      loadAllWithDiagnostics: vi.fn().mockResolvedValue({ result, isComplete: true })
+    })
+    const markReconciliationIncomplete = vi.fn()
+    const fileIndex = createFileIndex({
+      markReconciliationIncomplete,
+      syncSession: vi.fn().mockRejectedValue(new Error('file index database is locked'))
+    })
+    const coordinator = new SessionPersistenceCoordinator(repository, fileIndex)
+
+    await expect(coordinator.loadAll()).resolves.toMatchObject({
+      diagnostics: {
+        isComplete: false,
+        failure: 'startup-reconciliation-failed'
+      }
+    })
+    expect(markReconciliationIncomplete).toHaveBeenCalledOnce()
+  })
+
   it('retries surviving project sessions after deleting a collision owner', async () => {
     const owner = createSession()
     const survivor = createSession({ id: 'session-2' })

--- a/src/main/session-persistence/coordinator.ts
+++ b/src/main/session-persistence/coordinator.ts
@@ -23,7 +23,7 @@ type ProjectSessionDeletionResult =
   { status: 'completed' } | { status: 'orphan-retained'; reason: 'missing-upload-authority' }
 
 type SessionMutationRepository = {
-  loadAllWithDiagnostics(): Promise<{
+  loadAllWithDiagnostics(options?: { mode?: 'repair' | 'read-only' }): Promise<{
     result: LoadAllSessionsResult
     isComplete: boolean
     warnings?: SessionLoadWarning[]
@@ -257,7 +257,7 @@ class SessionPersistenceCoordinator {
       // treat the process as an untouched startup boundary for destructive cleanup.
       this.destructiveStartupWindowOpen = false
       this.fileIndex.markReconciliationIncomplete()
-      const scan = await this.repository.loadAllWithDiagnostics()
+      const scan = await this.repository.loadAllWithDiagnostics({ mode: 'read-only' })
 
       return {
         ...scan.result,

--- a/src/main/session-persistence/coordinator.ts
+++ b/src/main/session-persistence/coordinator.ts
@@ -235,6 +235,30 @@ class SessionPersistenceCoordinator {
   ) {}
 
   /**
+   * Reads the Session authority without running recovery or derived-state reconciliation. This is
+   * the degraded path used when an earlier startup prerequisite failed: healthy transcripts remain
+   * navigable, while the incomplete marker keeps writes blocked until a full retry succeeds.
+   */
+  loadAllReadOnly(): Promise<LoadAllSessionsResult> {
+    return this.enqueue(async () => {
+      // Once any renderer has observed a degraded snapshot, later loads are no longer allowed to
+      // treat the process as an untouched startup boundary for destructive cleanup.
+      this.destructiveStartupWindowOpen = false
+      this.fileIndex.markReconciliationIncomplete()
+      const scan = await this.repository.loadAllWithDiagnostics()
+
+      return {
+        ...scan.result,
+        diagnostics: {
+          isComplete: false,
+          warnings: scan.warnings ?? [],
+          failure: 'startup-reconciliation-failed'
+        }
+      }
+    })
+  }
+
+  /**
    * Loads durable sessions, reconciles Upload storage, and backfills the file projection only after a
    * complete scan has restored active ownership. Chat hydration remains available on any failure.
    */

--- a/src/main/session-persistence/coordinator.ts
+++ b/src/main/session-persistence/coordinator.ts
@@ -5,7 +5,9 @@ import type {
   LoadAllSessionsResult,
   PersistedArtifact,
   PersistedChatSession,
-  SaveSessionManifestRequest
+  SaveSessionManifestRequest,
+  SessionLoadFailure,
+  SessionLoadWarning
 } from '../../shared/session-persistence'
 import type { ManagedFileSoftDeleteToken } from '../project-files/repository'
 import type { ProjectSessionDeletionState } from './repository'
@@ -24,6 +26,8 @@ type SessionMutationRepository = {
   loadAllWithDiagnostics(): Promise<{
     result: LoadAllSessionsResult
     isComplete: boolean
+    warnings?: SessionLoadWarning[]
+    failure?: SessionLoadFailure
   }>
   loadProjectWithDiagnostics(projectId: string): Promise<{
     sessions: PersistedChatSession[]
@@ -242,6 +246,11 @@ class SessionPersistenceCoordinator {
       const mayRunDestructiveStartupCleanup = this.destructiveStartupWindowOpen
       this.destructiveStartupWindowOpen = false
       const scan = await this.repository.loadAllWithDiagnostics()
+      scan.result.diagnostics = {
+        isComplete: scan.isComplete,
+        warnings: scan.warnings ?? [],
+        failure: scan.failure
+      }
       let result = scan.result
       let sessions = scan.result.sessions
 
@@ -330,6 +339,11 @@ class SessionPersistenceCoordinator {
         this.fileIndex.markReconciliationIncomplete()
         console.error('[session-persistence] startup reconciliation failed', error)
         // Keep chat hydration available while Files remains explicitly incomplete and retryable.
+        result.diagnostics = {
+          isComplete: false,
+          warnings: scan.warnings ?? [],
+          failure: 'startup-reconciliation-failed'
+        }
         return result
       }
 

--- a/src/main/session-persistence/coordinator.ts
+++ b/src/main/session-persistence/coordinator.ts
@@ -335,6 +335,9 @@ class SessionPersistenceCoordinator {
         // Reconciliation restores active owners left soft-deleted by an interrupted delete before any
         // scan-order-dependent sync can offer their canonical rows to another session.
         await this.fileIndex.reconcileActiveSessions(sessions)
+        for (const session of sessions) {
+          await this.fileIndex.syncSession(session)
+        }
       } catch (error) {
         this.fileIndex.markReconciliationIncomplete()
         console.error('[session-persistence] startup reconciliation failed', error)
@@ -345,10 +348,6 @@ class SessionPersistenceCoordinator {
           failure: 'startup-reconciliation-failed'
         }
         return result
-      }
-
-      for (const session of sessions) {
-        await this.fileIndex.syncSession(session).catch(() => undefined)
       }
 
       return result

--- a/src/main/session-persistence/ipc.test.ts
+++ b/src/main/session-persistence/ipc.test.ts
@@ -22,6 +22,7 @@ vi.mock('../lifecycle-broadcast', () => ({
 
 import {
   createSessionPersistenceHandlers,
+  loadSessionsAfterProjectRecovery,
   registerSessionPersistenceIpcHandlers,
   type SessionPersistenceBackend
 } from './ipc'
@@ -52,6 +53,58 @@ const createMockReviewRepository = (): ReviewRepository =>
   }) as unknown as ReviewRepository
 
 describe('session persistence IPC handlers', () => {
+  it('hydrates a read-only Session snapshot when Project deletion recovery fails', async () => {
+    const failure = new Error('Project deletion journal is locked')
+    const consoleError = vi.spyOn(console, 'error').mockImplementation(() => undefined)
+    const degraded = {
+      sessions: [createSession()],
+      manifest: { version: 1 as const },
+      diagnostics: {
+        isComplete: false,
+        warnings: [],
+        failure: 'startup-reconciliation-failed' as const
+      }
+    }
+    const projectRecovery = {
+      recoverPendingDeletions: vi.fn().mockRejectedValue(failure)
+    }
+    const sessionLoader = {
+      loadAll: vi.fn(),
+      loadAllReadOnly: vi.fn().mockResolvedValue(degraded)
+    }
+
+    await expect(loadSessionsAfterProjectRecovery(projectRecovery, sessionLoader)).resolves.toBe(
+      degraded
+    )
+
+    expect(sessionLoader.loadAll).not.toHaveBeenCalled()
+    expect(sessionLoader.loadAllReadOnly).toHaveBeenCalledOnce()
+    expect(consoleError).toHaveBeenCalledWith(
+      '[session-persistence] Project deletion recovery failed',
+      failure
+    )
+    consoleError.mockRestore()
+  })
+
+  it('runs ordinary startup loading after Project deletion recovery succeeds', async () => {
+    const loaded = { sessions: [createSession()], manifest: { version: 1 as const } }
+    const projectRecovery = {
+      recoverPendingDeletions: vi.fn().mockResolvedValue(undefined)
+    }
+    const sessionLoader = {
+      loadAll: vi.fn().mockResolvedValue(loaded),
+      loadAllReadOnly: vi.fn()
+    }
+
+    await expect(loadSessionsAfterProjectRecovery(projectRecovery, sessionLoader)).resolves.toBe(
+      loaded
+    )
+
+    expect(projectRecovery.recoverPendingDeletions).toHaveBeenCalledOnce()
+    expect(sessionLoader.loadAll).toHaveBeenCalledOnce()
+    expect(sessionLoader.loadAllReadOnly).not.toHaveBeenCalled()
+  })
+
   it('does not accept a physical managed-file cleanup hook', () => {
     // Session persistence owns authoritative JSON and index visibility only. Keeping the factory at
     // two parameters prevents deletion flows from acquiring a dependency that can remove file bytes.

--- a/src/main/session-persistence/ipc.test.ts
+++ b/src/main/session-persistence/ipc.test.ts
@@ -73,8 +73,14 @@ describe('session persistence IPC handlers', () => {
       loadAllReadOnly: vi.fn().mockResolvedValue(degraded)
     }
 
-    await expect(loadSessionsAfterProjectRecovery(projectRecovery, sessionLoader)).resolves.toBe(
-      degraded
+    await expect(loadSessionsAfterProjectRecovery(projectRecovery, sessionLoader)).resolves.toEqual(
+      {
+        ...degraded,
+        diagnostics: {
+          ...degraded.diagnostics,
+          isProjectDeletionRecoveryComplete: false
+        }
+      }
     )
 
     expect(sessionLoader.loadAll).not.toHaveBeenCalled()
@@ -96,8 +102,15 @@ describe('session persistence IPC handlers', () => {
       loadAllReadOnly: vi.fn()
     }
 
-    await expect(loadSessionsAfterProjectRecovery(projectRecovery, sessionLoader)).resolves.toBe(
-      loaded
+    await expect(loadSessionsAfterProjectRecovery(projectRecovery, sessionLoader)).resolves.toEqual(
+      {
+        ...loaded,
+        diagnostics: {
+          isComplete: true,
+          warnings: [],
+          isProjectDeletionRecoveryComplete: true
+        }
+      }
     )
 
     expect(projectRecovery.recoverPendingDeletions).toHaveBeenCalledOnce()

--- a/src/main/session-persistence/ipc.ts
+++ b/src/main/session-persistence/ipc.ts
@@ -32,6 +32,32 @@ type SessionPersistenceHandlers = {
   saveManifest: (request: SaveSessionManifestRequest) => Promise<void>
 }
 
+type ProjectDeletionRecoveryBackend = {
+  recoverPendingDeletions: () => Promise<void>
+}
+
+type SessionStartupLoader = {
+  loadAll: () => Promise<LoadAllSessionsResult>
+  loadAllReadOnly: () => Promise<LoadAllSessionsResult>
+}
+
+// Project deletion recovery is a prerequisite for mutating startup reconciliation. If it fails,
+// expose only the coordinator's explicit read-only snapshot so healthy transcripts remain navigable
+// without allowing partially recovered Project authority to drive cleanup or derived-state writes.
+const loadSessionsAfterProjectRecovery = async (
+  projectRecovery: ProjectDeletionRecoveryBackend,
+  sessionLoader: SessionStartupLoader
+): Promise<LoadAllSessionsResult> => {
+  try {
+    await projectRecovery.recoverPendingDeletions()
+  } catch (error) {
+    console.error('[session-persistence] Project deletion recovery failed', error)
+    return sessionLoader.loadAllReadOnly()
+  }
+
+  return sessionLoader.loadAll()
+}
+
 // Adapts the coordinator into small handlers that are easy to unit test.
 const createSessionPersistenceHandlers = (
   repository: SessionPersistenceBackend,
@@ -96,6 +122,7 @@ export {
   createDefaultReviewRepository,
   createDefaultSessionRepository,
   createSessionPersistenceHandlers,
+  loadSessionsAfterProjectRecovery,
   registerSessionPersistenceIpcHandlers
 }
 export type { SessionPersistenceBackend }

--- a/src/main/session-persistence/ipc.ts
+++ b/src/main/session-persistence/ipc.ts
@@ -41,6 +41,19 @@ type SessionStartupLoader = {
   loadAllReadOnly: () => Promise<LoadAllSessionsResult>
 }
 
+const withProjectDeletionRecoveryStatus = (
+  result: LoadAllSessionsResult,
+  isProjectDeletionRecoveryComplete: boolean
+): LoadAllSessionsResult => ({
+  ...result,
+  diagnostics: {
+    isComplete: result.diagnostics?.isComplete ?? true,
+    warnings: result.diagnostics?.warnings ?? [],
+    ...result.diagnostics,
+    isProjectDeletionRecoveryComplete
+  }
+})
+
 // Project deletion recovery is a prerequisite for mutating startup reconciliation. If it fails,
 // expose only the coordinator's explicit read-only snapshot so healthy transcripts remain navigable
 // without allowing partially recovered Project authority to drive cleanup or derived-state writes.
@@ -52,10 +65,10 @@ const loadSessionsAfterProjectRecovery = async (
     await projectRecovery.recoverPendingDeletions()
   } catch (error) {
     console.error('[session-persistence] Project deletion recovery failed', error)
-    return sessionLoader.loadAllReadOnly()
+    return withProjectDeletionRecoveryStatus(await sessionLoader.loadAllReadOnly(), false)
   }
 
-  return sessionLoader.loadAll()
+  return withProjectDeletionRecoveryStatus(await sessionLoader.loadAll(), true)
 }
 
 // Adapts the coordinator into small handlers that are easy to unit test.

--- a/src/main/session-persistence/repository.test.ts
+++ b/src/main/session-persistence/repository.test.ts
@@ -409,6 +409,31 @@ describe('session persistence repository (per-session files)', () => {
     expect(readSessionFile).toHaveBeenCalledOnce()
   })
 
+  it('keeps the scan incomplete when a listed Session disappears before it can be read', async () => {
+    const root = await createStorageRoot()
+    const session = createSession()
+    await new SessionRepository(root).saveSession(session)
+    const readSessionFile = vi
+      .fn()
+      .mockRejectedValue(
+        Object.assign(new Error('file disappeared during scan'), { code: 'ENOENT' })
+      )
+    const repository = new SessionRepository(root, { readSessionFile })
+
+    const scan = await repository.loadAllWithDiagnostics()
+
+    expect(scan.result.sessions).toEqual([])
+    expect(scan.isComplete).toBe(false)
+    expect(scan.warnings).toEqual([
+      {
+        kind: 'unreadable',
+        projectId: session.projectId,
+        fileName: `${session.id}.json`,
+        recovered: false
+      }
+    ])
+  })
+
   it('distinguishes an unreadable Session from an absent Session for terminal mutations', async () => {
     const root = await createStorageRoot()
     const session = createSession()

--- a/src/main/session-persistence/repository.test.ts
+++ b/src/main/session-persistence/repository.test.ts
@@ -331,6 +331,66 @@ describe('session persistence repository (per-session files)', () => {
     expect(nextScan.warnings).toEqual(scan.warnings)
   })
 
+  it('reports corrupt authority without moving files during a read-only scan', async () => {
+    const repository = new SessionRepository(await createStorageRoot())
+    const sessionsDir = join(storageRoot!, 'sessions')
+    const projectDir = join(sessionsDir, 'project-a')
+    await mkdir(projectDir, { recursive: true })
+    await writeFile(join(projectDir, 'broken.json'), '{broken session', 'utf8')
+    await writeFile(join(sessionsDir, 'manifest.json'), '{broken manifest', 'utf8')
+
+    const scan = await repository.loadAllWithDiagnostics({ mode: 'read-only' })
+
+    expect(scan.result.sessions).toEqual([])
+    expect(scan.isComplete).toBe(false)
+    expect(scan.warnings).toEqual([
+      {
+        kind: 'corrupt',
+        projectId: 'project-a',
+        fileName: 'broken.json',
+        recovered: false
+      },
+      {
+        kind: 'manifest-corrupt',
+        fileName: 'manifest.json',
+        recovered: false
+      }
+    ])
+    await expect(readFile(join(projectDir, 'broken.json'), 'utf8')).resolves.toBe('{broken session')
+    await expect(readFile(join(sessionsDir, 'manifest.json'), 'utf8')).resolves.toBe(
+      '{broken manifest'
+    )
+    expect(await readdir(projectDir)).toEqual(['broken.json'])
+    expect((await readdir(sessionsDir)).sort()).toEqual(['manifest.json', 'project-a'])
+  })
+
+  it('leaves structurally corrupt Session JSON in place during a read-only scan', async () => {
+    const repository = new SessionRepository(await createStorageRoot())
+    const projectDir = join(storageRoot!, 'sessions', 'project-a')
+    const damagedPath = join(projectDir, 'damaged.json')
+    const damagedJson = JSON.stringify({
+      version: 2,
+      session: { id: 'damaged', messages: 'not-an-array' }
+    })
+    await mkdir(projectDir, { recursive: true })
+    await writeFile(damagedPath, damagedJson, 'utf8')
+
+    const scan = await repository.loadAllWithDiagnostics({ mode: 'read-only' })
+
+    expect(scan.result.sessions).toEqual([])
+    expect(scan.isComplete).toBe(false)
+    expect(scan.warnings).toEqual([
+      {
+        kind: 'corrupt',
+        projectId: 'project-a',
+        fileName: 'damaged.json',
+        recovered: false
+      }
+    ])
+    await expect(readFile(damagedPath, 'utf8')).resolves.toBe(damagedJson)
+    await expect(readdir(projectDir)).resolves.toEqual(['damaged.json'])
+  })
+
   it('quarantines a structurally corrupt Session instead of normalizing it to empty', async () => {
     const repository = new SessionRepository(await createStorageRoot())
     const projectDir = join(storageRoot!, 'sessions', 'project-a')

--- a/src/main/session-persistence/repository.test.ts
+++ b/src/main/session-persistence/repository.test.ts
@@ -318,6 +318,17 @@ describe('session persistence repository (per-session files)', () => {
 
     expect(scan.result.sessions).toEqual([])
     expect(scan.isComplete).toBe(true)
+    expect(scan.warnings).toEqual([
+      {
+        kind: 'corrupt',
+        projectId: 'project-a',
+        fileName: 'broken.json',
+        recovered: true
+      }
+    ])
+
+    const nextScan = await repository.loadAllWithDiagnostics()
+    expect(nextScan.warnings).toEqual(scan.warnings)
   })
 
   it('keeps a terminal Project scan incomplete while a quarantined Session preserves authority', async () => {
@@ -384,6 +395,14 @@ describe('session persistence repository (per-session files)', () => {
 
     expect(scan.result.sessions).toEqual([])
     expect(scan.isComplete).toBe(false)
+    expect(scan.warnings).toEqual([
+      {
+        kind: 'unreadable',
+        projectId: session.projectId,
+        fileName: `${session.id}.json`,
+        recovered: false
+      }
+    ])
     await expect(
       readFile(join(root, 'sessions', session.projectId, `${session.id}.json`), 'utf8')
     ).resolves.toContain(session.id)
@@ -683,6 +702,34 @@ describe('session persistence repository (per-session files)', () => {
 
     await expect(repository.loadAll()).resolves.toMatchObject({
       manifest: { version: 1, lastProjectId: 'project-a', lastSessionId: 'session-1' }
+    })
+  })
+
+  it('isolates a corrupt manifest and reports the recovered selection data', async () => {
+    const root = await createStorageRoot()
+    const repository = new SessionRepository(root)
+    await mkdir(join(root, 'sessions'), { recursive: true })
+    await writeFile(join(root, 'sessions', 'manifest.json'), '{broken json', 'utf8')
+
+    await expect(repository.loadAllWithDiagnostics()).resolves.toMatchObject({
+      result: { sessions: [], manifest: { version: 1 } },
+      isComplete: true,
+      warnings: [
+        {
+          kind: 'manifest-corrupt',
+          fileName: 'manifest.json',
+          recovered: true
+        }
+      ]
+    })
+    expect(await readdir(join(root, 'sessions'))).toContainEqual(
+      expect.stringMatching(/^manifest\.json\.invalid-/)
+    )
+
+    await expect(repository.loadAllWithDiagnostics()).resolves.toMatchObject({
+      result: { sessions: [], manifest: { version: 1 } },
+      isComplete: true,
+      warnings: []
     })
   })
 

--- a/src/main/session-persistence/repository.test.ts
+++ b/src/main/session-persistence/repository.test.ts
@@ -331,6 +331,55 @@ describe('session persistence repository (per-session files)', () => {
     expect(nextScan.warnings).toEqual(scan.warnings)
   })
 
+  it('quarantines a structurally corrupt Session instead of normalizing it to empty', async () => {
+    const repository = new SessionRepository(await createStorageRoot())
+    const projectDir = join(storageRoot!, 'sessions', 'project-a')
+    await mkdir(projectDir, { recursive: true })
+    await writeFile(
+      join(projectDir, 'damaged.json'),
+      JSON.stringify({ version: 2, session: { id: 'damaged', messages: 'not-an-array' } }),
+      'utf8'
+    )
+
+    const scan = await repository.loadAllWithDiagnostics()
+
+    expect(scan.result.sessions).toEqual([])
+    expect(scan.isComplete).toBe(true)
+    expect(scan.warnings).toEqual([
+      {
+        kind: 'corrupt',
+        projectId: 'project-a',
+        fileName: 'damaged.json',
+        recovered: true
+      }
+    ])
+    await expect(readdir(projectDir)).resolves.toContainEqual(
+      expect.stringMatching(/^damaged\.json\.invalid-/)
+    )
+  })
+
+  it('uses a valid conversation graph when the compatibility message list is malformed', async () => {
+    const repository = new SessionRepository(await createStorageRoot())
+    const session = createSession()
+    await repository.saveSession(session)
+    const filePath = join(storageRoot!, 'sessions', session.projectId, `${session.id}.json`)
+    const stored = JSON.parse(await readFile(filePath, 'utf8')) as {
+      session: { messages: unknown }
+    }
+    stored.session.messages = 'damaged compatibility projection'
+    await writeFile(filePath, JSON.stringify(stored), 'utf8')
+
+    const scan = await repository.loadAllWithDiagnostics()
+
+    expect(scan.result.sessions).toEqual([
+      expect.objectContaining({
+        id: session.id,
+        messages: [expect.objectContaining({ id: 'message-1', content: 'Summarize this file' })]
+      })
+    ])
+    expect(scan.warnings).toEqual([])
+  })
+
   it('keeps a terminal Project scan incomplete while a quarantined Session preserves authority', async () => {
     const repository = new SessionRepository(await createStorageRoot())
     const projectDir = join(storageRoot!, 'sessions', 'project-a')
@@ -434,6 +483,26 @@ describe('session persistence repository (per-session files)', () => {
     ])
   })
 
+  it('keeps the scan incomplete when an enumerated Project directory disappears', async () => {
+    const root = await createStorageRoot()
+    const session = createSession()
+    await new SessionRepository(root).saveSession(session)
+    const sessionsDir = join(root, 'sessions')
+    const projectDir = join(sessionsDir, session.projectId)
+    const readDirectoryEntries = vi.fn(async (path: string) => {
+      const entries = await readdir(path, { withFileTypes: true })
+      if (path === sessionsDir) await rm(projectDir, { recursive: true, force: true })
+      return entries
+    })
+    const repository = new SessionRepository(root, { readDirectoryEntries })
+
+    const scan = await repository.loadAllWithDiagnostics()
+
+    expect(scan.result.sessions).toEqual([])
+    expect(scan.isComplete).toBe(false)
+    expect(readDirectoryEntries).toHaveBeenCalledWith(projectDir)
+  })
+
   it('distinguishes an unreadable Session from an absent Session for terminal mutations', async () => {
     const root = await createStorageRoot()
     const session = createSession()
@@ -461,6 +530,15 @@ describe('session persistence repository (per-session files)', () => {
     })
     await expect(repository.loadSessionWithDiagnostics('project-a', 'session-1')).resolves.toEqual({
       status: 'unreadable'
+    })
+  })
+
+  it('treats a directly loaded absent Project as an authoritative empty Project', async () => {
+    const repository = new SessionRepository(await createStorageRoot())
+
+    await expect(repository.loadProjectWithDiagnostics('missing-project')).resolves.toEqual({
+      sessions: [],
+      isComplete: true
     })
   })
 

--- a/src/main/session-persistence/repository.test.ts
+++ b/src/main/session-persistence/repository.test.ts
@@ -733,6 +733,31 @@ describe('session persistence repository (per-session files)', () => {
     })
   })
 
+  it('falls back to an empty selection without blocking a complete Session scan', async () => {
+    const root = await createStorageRoot()
+    const session = createSession()
+    await new SessionRepository(root).saveSession(session)
+    const readManifestFile = vi
+      .fn()
+      .mockRejectedValue(Object.assign(new Error('permission denied'), { code: 'EACCES' }))
+    const repository = new SessionRepository(root, { readManifestFile })
+
+    await expect(repository.loadAllWithDiagnostics()).resolves.toMatchObject({
+      result: {
+        sessions: [expect.objectContaining({ id: session.id })],
+        manifest: { version: 1 }
+      },
+      isComplete: true,
+      warnings: [
+        {
+          kind: 'manifest-unreadable',
+          fileName: 'manifest.json',
+          recovered: false
+        }
+      ]
+    })
+  })
+
   it('ignores a legacy single-file sessions.json (migration was removed)', async () => {
     const root = await createStorageRoot()
     const repository = new SessionRepository(root)

--- a/src/main/session-persistence/repository.ts
+++ b/src/main/session-persistence/repository.ts
@@ -545,7 +545,9 @@ class SessionRepository {
 
     for (const fileName of sessionFiles.names) {
       // The directory is the authoritative owning project, regardless of the file's stored projectId.
-      const read = await this.readSessionFile(join(projectDir, fileName), projectId)
+      const read = await this.readSessionFile(join(projectDir, fileName), projectId, {
+        missingIsIncomplete: true
+      })
       isComplete &&= read.isComplete
       if (options.quarantinedIsIncomplete && read.wasQuarantined) isComplete = false
       if (read.warning) {
@@ -576,7 +578,8 @@ class SessionRepository {
 
   private async readSessionFile(
     filePath: string,
-    projectId: string
+    projectId: string,
+    options: { missingIsIncomplete?: boolean } = {}
   ): Promise<{
     session?: PersistedChatSession
     isComplete: boolean
@@ -587,7 +590,7 @@ class SessionRepository {
     try {
       raw = await this.dependencies.readSessionFile(filePath)
     } catch (error) {
-      if (isMissingFileError(error)) return { isComplete: true }
+      if (isMissingFileError(error) && !options.missingIsIncomplete) return { isComplete: true }
       return {
         isComplete: false,
         warning: {

--- a/src/main/session-persistence/repository.ts
+++ b/src/main/session-persistence/repository.ts
@@ -45,6 +45,7 @@ type ProjectSessionDeletionState = 'live' | 'legacy-committed' | 'prepared' | 'a
 
 type SessionRepositoryDependencies = {
   remove(path: string, options: { force: boolean; recursive: boolean }): Promise<void>
+  readManifestFile(path: string): Promise<string>
   readSessionFile(path: string): Promise<string>
   renameFile(source: string, destination: string): Promise<void>
   wait(delayMs: number): Promise<void>
@@ -52,6 +53,7 @@ type SessionRepositoryDependencies = {
 
 const DEFAULT_DEPENDENCIES: SessionRepositoryDependencies = {
   remove: (path, options) => rm(path, options),
+  readManifestFile: (path) => readFile(path, 'utf8'),
   readSessionFile: (path) => readFile(path, 'utf8'),
   renameFile: (source, destination) => rename(source, destination),
   wait: (delayMs) => new Promise((resolve) => setTimeout(resolve, delayMs))
@@ -106,6 +108,7 @@ class SessionRepository {
   ) {
     this.dependencies = {
       remove: dependencies.remove ?? DEFAULT_DEPENDENCIES.remove,
+      readManifestFile: dependencies.readManifestFile ?? DEFAULT_DEPENDENCIES.readManifestFile,
       readSessionFile: dependencies.readSessionFile ?? DEFAULT_DEPENDENCIES.readSessionFile,
       renameFile: dependencies.renameFile ?? DEFAULT_DEPENDENCIES.renameFile,
       wait: dependencies.wait ?? DEFAULT_DEPENDENCIES.wait
@@ -185,9 +188,10 @@ class SessionRepository {
 
     return {
       result: { sessions, manifest: manifestRead.manifest },
-      isComplete: isComplete && manifestRead.isComplete,
-      warnings: manifestRead.warning ? [...warnings, manifestRead.warning] : warnings,
-      failure: manifestRead.isComplete ? undefined : 'manifest-unreadable'
+      // The manifest is only a last-open pointer. It must never make a complete Session authority
+      // scan read-only; a later selection write will retry persistence through the normal saver.
+      isComplete,
+      warnings: manifestRead.warning ? [...warnings, manifestRead.warning] : warnings
     }
   }
 
@@ -447,16 +451,24 @@ class SessionRepository {
 
   private async readManifest(): Promise<{
     manifest: PersistedSessionManifest
-    isComplete: boolean
     warning?: SessionLoadWarning
   }> {
     let raw: string
     try {
-      raw = await readFile(this.manifestPath, 'utf8')
+      raw = await this.dependencies.readManifestFile(this.manifestPath)
     } catch (error) {
+      if (!isMissingFileError(error)) {
+        return {
+          manifest: createEmptySessionManifest(),
+          warning: {
+            kind: 'manifest-unreadable',
+            fileName: MANIFEST_FILE,
+            recovered: false
+          }
+        }
+      }
       return {
-        manifest: createEmptySessionManifest(),
-        isComplete: isMissingFileError(error)
+        manifest: createEmptySessionManifest()
       }
     }
 
@@ -466,14 +478,12 @@ class SessionRepository {
         throw new Error('Invalid Session manifest')
       }
       return {
-        manifest: normalizeSessionManifest(parsed),
-        isComplete: true
+        manifest: normalizeSessionManifest(parsed)
       }
     } catch {
       const wasQuarantined = await this.tryBackupInvalidFile(this.manifestPath)
       return {
         manifest: createEmptySessionManifest(),
-        isComplete: wasQuarantined,
         warning: {
           kind: 'manifest-corrupt',
           fileName: MANIFEST_FILE,

--- a/src/main/session-persistence/repository.ts
+++ b/src/main/session-persistence/repository.ts
@@ -1,5 +1,5 @@
 import { lstat, mkdir, readFile, readdir, rename, rm, writeFile } from 'node:fs/promises'
-import { join } from 'node:path'
+import { basename, join } from 'node:path'
 
 import {
   createEmptySessionManifest,
@@ -10,7 +10,9 @@ import {
   type LoadAllSessionsResult,
   type PersistedChatSession,
   type PersistedSessionManifest,
-  type SaveSessionManifestRequest
+  type SaveSessionManifestRequest,
+  type SessionLoadFailure,
+  type SessionLoadWarning
 } from '../../shared/session-persistence'
 import { decodeSessionDataPaths, encodeSessionDataPaths } from './session-data-paths'
 
@@ -25,6 +27,8 @@ type SessionLoadDiagnostics = {
   // False means at least one directory or session file could not be read or safely quarantined.
   // Callers may hydrate the returned sessions but must not reconcile absent index rows as deletions.
   isComplete: boolean
+  warnings: SessionLoadWarning[]
+  failure?: SessionLoadFailure
 }
 
 type SessionLoadDiagnostic =
@@ -176,10 +180,15 @@ class SessionRepository {
   // Reports whether the live sessions tree was fully scanned so DB reconciliation never acts on a
   // partial read. Project recovery owns tombstone cleanup before ordinary hydration is allowed.
   async loadAllWithDiagnostics(): Promise<SessionLoadDiagnostics> {
-    const { sessions, isComplete } = await this.readAllSessions()
-    const manifest = await this.readManifest()
+    const { sessions, isComplete, warnings } = await this.readAllSessions()
+    const manifestRead = await this.readManifest()
 
-    return { result: { sessions, manifest }, isComplete }
+    return {
+      result: { sessions, manifest: manifestRead.manifest },
+      isComplete: isComplete && manifestRead.isComplete,
+      warnings: manifestRead.warning ? [...warnings, manifestRead.warning] : warnings,
+      failure: manifestRead.isComplete ? undefined : 'manifest-unreadable'
+    }
   }
 
   // Project deletion needs a complete view of only its target authority. An unrelated unreadable
@@ -436,13 +445,41 @@ class SessionRepository {
     }
   }
 
-  private async readManifest(): Promise<PersistedSessionManifest> {
+  private async readManifest(): Promise<{
+    manifest: PersistedSessionManifest
+    isComplete: boolean
+    warning?: SessionLoadWarning
+  }> {
+    let raw: string
     try {
-      const raw = await readFile(this.manifestPath, 'utf8')
+      raw = await readFile(this.manifestPath, 'utf8')
+    } catch (error) {
+      return {
+        manifest: createEmptySessionManifest(),
+        isComplete: isMissingFileError(error)
+      }
+    }
 
-      return normalizeSessionManifest(JSON.parse(raw) as unknown)
+    try {
+      const parsed = JSON.parse(raw) as unknown
+      if (typeof parsed !== 'object' || parsed === null || Array.isArray(parsed)) {
+        throw new Error('Invalid Session manifest')
+      }
+      return {
+        manifest: normalizeSessionManifest(parsed),
+        isComplete: true
+      }
     } catch {
-      return createEmptySessionManifest()
+      const wasQuarantined = await this.tryBackupInvalidFile(this.manifestPath)
+      return {
+        manifest: createEmptySessionManifest(),
+        isComplete: wasQuarantined,
+        warning: {
+          kind: 'manifest-corrupt',
+          fileName: MANIFEST_FILE,
+          recovered: wasQuarantined
+        }
+      }
     }
   }
 
@@ -451,23 +488,28 @@ class SessionRepository {
   private async readAllSessions(): Promise<{
     sessions: PersistedChatSession[]
     isComplete: boolean
+    warnings: SessionLoadWarning[]
   }> {
     const projectDirectories = await this.listDirectoryNames(this.sessionsDir)
     const sessions: PersistedChatSession[] = []
+    const warnings: SessionLoadWarning[] = []
     let isComplete = projectDirectories.isComplete
 
     for (const projectId of projectDirectories.names) {
-      const project = await this.readProjectSessions(projectId)
+      const project = await this.readProjectSessions(projectId, { warnings })
       sessions.push(...project.sessions)
       isComplete &&= project.isComplete
     }
 
-    return { sessions, isComplete }
+    return { sessions, isComplete, warnings }
   }
 
   private async readProjectSessions(
     projectIdValue: string,
-    options: { quarantinedIsIncomplete?: boolean } = {}
+    options: {
+      quarantinedIsIncomplete?: boolean
+      warnings?: SessionLoadWarning[]
+    } = {}
   ): Promise<ProjectSessionLoadDiagnostics> {
     const projectId = assertSafeSegment(projectIdValue)
     return this.readProjectSessionsAtDirectory(
@@ -480,11 +522,15 @@ class SessionRepository {
   private async readProjectSessionsAtDirectory(
     projectId: string,
     projectDir: string,
-    options: { quarantinedIsIncomplete?: boolean } = {}
+    options: {
+      quarantinedIsIncomplete?: boolean
+      warnings?: SessionLoadWarning[]
+    } = {}
   ): Promise<ProjectSessionLoadDiagnostics> {
     const sessionFiles = await this.listSessionFileNames(projectDir)
     const sessions: PersistedChatSession[] = []
     const activeQuarantines = new Set(sessionFiles.quarantinedPrimaryFileNames)
+    const warnedFiles = new Set<string>()
     let isComplete = sessionFiles.isComplete
 
     for (const fileName of sessionFiles.names) {
@@ -492,6 +538,10 @@ class SessionRepository {
       const read = await this.readSessionFile(join(projectDir, fileName), projectId)
       isComplete &&= read.isComplete
       if (options.quarantinedIsIncomplete && read.wasQuarantined) isComplete = false
+      if (read.warning) {
+        options.warnings?.push(read.warning)
+        warnedFiles.add(read.warning.fileName)
+      }
       if (read.session) {
         // A current primary that successfully normalizes supersedes retained historical backups for
         // the same file. Keep the backups, but do not let them permanently block terminal mutation.
@@ -500,6 +550,16 @@ class SessionRepository {
       }
     }
     if (options.quarantinedIsIncomplete && activeQuarantines.size > 0) isComplete = false
+    for (const fileName of activeQuarantines) {
+      if (!warnedFiles.has(fileName)) {
+        options.warnings?.push({
+          kind: 'corrupt',
+          projectId,
+          fileName,
+          recovered: true
+        })
+      }
+    }
 
     return { sessions, isComplete }
   }
@@ -511,13 +571,22 @@ class SessionRepository {
     session?: PersistedChatSession
     isComplete: boolean
     wasQuarantined?: boolean
+    warning?: SessionLoadWarning
   }> {
     let raw: string
     try {
       raw = await this.dependencies.readSessionFile(filePath)
     } catch (error) {
       if (isMissingFileError(error)) return { isComplete: true }
-      return { isComplete: false }
+      return {
+        isComplete: false,
+        warning: {
+          kind: 'unreadable',
+          projectId,
+          fileName: basename(filePath),
+          recovered: false
+        }
+      }
     }
 
     try {
@@ -526,13 +595,31 @@ class SessionRepository {
       })
       if (!session) {
         const wasQuarantined = await this.tryBackupInvalidFile(filePath)
-        return { isComplete: wasQuarantined, wasQuarantined }
+        return {
+          isComplete: wasQuarantined,
+          wasQuarantined,
+          warning: {
+            kind: 'corrupt',
+            projectId,
+            fileName: basename(filePath),
+            recovered: wasQuarantined
+          }
+        }
       }
 
       return { session: decodeSessionDataPaths({ ...session, projectId }), isComplete: true }
     } catch {
       const wasQuarantined = await this.tryBackupInvalidFile(filePath)
-      return { isComplete: wasQuarantined, wasQuarantined }
+      return {
+        isComplete: wasQuarantined,
+        wasQuarantined,
+        warning: {
+          kind: 'corrupt',
+          projectId,
+          fileName: basename(filePath),
+          recovered: wasQuarantined
+        }
+      }
     }
   }
 

--- a/src/main/session-persistence/repository.ts
+++ b/src/main/session-persistence/repository.ts
@@ -43,8 +43,15 @@ type ProjectSessionLoadDiagnostics = {
 
 type ProjectSessionDeletionState = 'live' | 'legacy-committed' | 'prepared' | 'absent'
 
+type SessionDirectoryEntry = {
+  name: string
+  isDirectory(): boolean
+  isFile(): boolean
+}
+
 type SessionRepositoryDependencies = {
   remove(path: string, options: { force: boolean; recursive: boolean }): Promise<void>
+  readDirectoryEntries(path: string): Promise<SessionDirectoryEntry[]>
   readManifestFile(path: string): Promise<string>
   readSessionFile(path: string): Promise<string>
   renameFile(source: string, destination: string): Promise<void>
@@ -53,6 +60,7 @@ type SessionRepositoryDependencies = {
 
 const DEFAULT_DEPENDENCIES: SessionRepositoryDependencies = {
   remove: (path, options) => rm(path, options),
+  readDirectoryEntries: (path) => readdir(path, { withFileTypes: true }),
   readManifestFile: (path) => readFile(path, 'utf8'),
   readSessionFile: (path) => readFile(path, 'utf8'),
   renameFile: (source, destination) => rename(source, destination),
@@ -108,6 +116,8 @@ class SessionRepository {
   ) {
     this.dependencies = {
       remove: dependencies.remove ?? DEFAULT_DEPENDENCIES.remove,
+      readDirectoryEntries:
+        dependencies.readDirectoryEntries ?? DEFAULT_DEPENDENCIES.readDirectoryEntries,
       readManifestFile: dependencies.readManifestFile ?? DEFAULT_DEPENDENCIES.readManifestFile,
       readSessionFile: dependencies.readSessionFile ?? DEFAULT_DEPENDENCIES.readSessionFile,
       renameFile: dependencies.renameFile ?? DEFAULT_DEPENDENCIES.renameFile,
@@ -506,7 +516,10 @@ class SessionRepository {
     let isComplete = projectDirectories.isComplete
 
     for (const projectId of projectDirectories.names) {
-      const project = await this.readProjectSessions(projectId, { warnings })
+      const project = await this.readProjectSessions(projectId, {
+        missingDirectoryIsIncomplete: true,
+        warnings
+      })
       sessions.push(...project.sessions)
       isComplete &&= project.isComplete
     }
@@ -517,6 +530,7 @@ class SessionRepository {
   private async readProjectSessions(
     projectIdValue: string,
     options: {
+      missingDirectoryIsIncomplete?: boolean
       quarantinedIsIncomplete?: boolean
       warnings?: SessionLoadWarning[]
     } = {}
@@ -533,11 +547,14 @@ class SessionRepository {
     projectId: string,
     projectDir: string,
     options: {
+      missingDirectoryIsIncomplete?: boolean
       quarantinedIsIncomplete?: boolean
       warnings?: SessionLoadWarning[]
     } = {}
   ): Promise<ProjectSessionLoadDiagnostics> {
-    const sessionFiles = await this.listSessionFileNames(projectDir)
+    const sessionFiles = await this.listSessionFileNames(projectDir, {
+      missingIsIncomplete: options.missingDirectoryIsIncomplete
+    })
     const sessions: PersistedChatSession[] = []
     const activeQuarantines = new Set(sessionFiles.quarantinedPrimaryFileNames)
     const warnedFiles = new Set<string>()
@@ -639,7 +656,7 @@ class SessionRepository {
   // ENOENT is an authoritative empty directory; any other readdir failure is a partial scan.
   private async listDirectoryNames(dir: string): Promise<{ names: string[]; isComplete: boolean }> {
     try {
-      const entries = await readdir(dir, { withFileTypes: true })
+      const entries = await this.dependencies.readDirectoryEntries(dir)
 
       return {
         names: entries.filter((entry) => entry.isDirectory()).map((entry) => entry.name),
@@ -653,13 +670,16 @@ class SessionRepository {
   // Lists only committed session JSON files. Quarantines are associated with their former primary so
   // terminal scans can distinguish orphan authority from a backup superseded by valid current JSON.
   // In-progress temp writes stay excluded and non-ENOENT directory failures disable reconciliation.
-  private async listSessionFileNames(dir: string): Promise<{
+  private async listSessionFileNames(
+    dir: string,
+    options: { missingIsIncomplete?: boolean } = {}
+  ): Promise<{
     names: string[]
     isComplete: boolean
     quarantinedPrimaryFileNames: string[]
   }> {
     try {
-      const entries = await readdir(dir, { withFileTypes: true })
+      const entries = await this.dependencies.readDirectoryEntries(dir)
 
       return {
         names: entries
@@ -680,7 +700,7 @@ class SessionRepository {
     } catch (error) {
       return {
         names: [],
-        isComplete: isMissingFileError(error),
+        isComplete: isMissingFileError(error) && !options.missingIsIncomplete,
         quarantinedPrimaryFileNames: []
       }
     }

--- a/src/main/session-persistence/repository.ts
+++ b/src/main/session-persistence/repository.ts
@@ -31,6 +31,10 @@ type SessionLoadDiagnostics = {
   failure?: SessionLoadFailure
 }
 
+type SessionScanOptions = {
+  mode?: 'repair' | 'read-only'
+}
+
 type SessionLoadDiagnostic =
   | { status: 'found'; session: PersistedChatSession }
   | { status: 'missing' }
@@ -193,9 +197,12 @@ class SessionRepository {
 
   // Reports whether the live sessions tree was fully scanned so DB reconciliation never acts on a
   // partial read. Project recovery owns tombstone cleanup before ordinary hydration is allowed.
-  async loadAllWithDiagnostics(): Promise<SessionLoadDiagnostics> {
-    const { sessions, isComplete, warnings } = await this.readAllSessions()
-    const manifestRead = await this.readManifest()
+  async loadAllWithDiagnostics(options: SessionScanOptions = {}): Promise<SessionLoadDiagnostics> {
+    const quarantineInvalidFiles = options.mode !== 'read-only'
+    const { sessions, isComplete, warnings } = await this.readAllSessions({
+      quarantineInvalidFiles
+    })
+    const manifestRead = await this.readManifest({ quarantineInvalidFiles })
 
     return {
       result: { sessions, manifest: manifestRead.manifest },
@@ -460,7 +467,7 @@ class SessionRepository {
     }
   }
 
-  private async readManifest(): Promise<{
+  private async readManifest(options: { quarantineInvalidFiles: boolean }): Promise<{
     manifest: PersistedSessionManifest
     warning?: SessionLoadWarning
   }> {
@@ -492,7 +499,8 @@ class SessionRepository {
         manifest: normalizeSessionManifest(parsed)
       }
     } catch {
-      const wasQuarantined = await this.tryBackupInvalidFile(this.manifestPath)
+      const wasQuarantined =
+        options.quarantineInvalidFiles && (await this.tryBackupInvalidFile(this.manifestPath))
       return {
         manifest: createEmptySessionManifest(),
         warning: {
@@ -505,8 +513,9 @@ class SessionRepository {
   }
 
   // Reads every project directory's session files and propagates completeness across every level.
-  // Invalid JSON is quarantined, while I/O errors keep reconciliation disabled until the next repair.
-  private async readAllSessions(): Promise<{
+  // Repair scans quarantine invalid data; read-only scans report it in place. I/O errors keep
+  // reconciliation disabled until the next repair.
+  private async readAllSessions(options: { quarantineInvalidFiles: boolean }): Promise<{
     sessions: PersistedChatSession[]
     isComplete: boolean
     warnings: SessionLoadWarning[]
@@ -519,6 +528,7 @@ class SessionRepository {
     for (const projectId of projectDirectories.names) {
       const project = await this.readProjectSessions(projectId, {
         missingDirectoryIsIncomplete: true,
+        quarantineInvalidFiles: options.quarantineInvalidFiles,
         warnings
       })
       sessions.push(...project.sessions)
@@ -533,6 +543,7 @@ class SessionRepository {
     options: {
       missingDirectoryIsIncomplete?: boolean
       quarantinedIsIncomplete?: boolean
+      quarantineInvalidFiles?: boolean
       warnings?: SessionLoadWarning[]
     } = {}
   ): Promise<ProjectSessionLoadDiagnostics> {
@@ -550,6 +561,7 @@ class SessionRepository {
     options: {
       missingDirectoryIsIncomplete?: boolean
       quarantinedIsIncomplete?: boolean
+      quarantineInvalidFiles?: boolean
       warnings?: SessionLoadWarning[]
     } = {}
   ): Promise<ProjectSessionLoadDiagnostics> {
@@ -564,7 +576,8 @@ class SessionRepository {
     for (const fileName of sessionFiles.names) {
       // The directory is the authoritative owning project, regardless of the file's stored projectId.
       const read = await this.readSessionFile(join(projectDir, fileName), projectId, {
-        missingIsIncomplete: true
+        missingIsIncomplete: true,
+        quarantineInvalidFiles: options.quarantineInvalidFiles
       })
       isComplete &&= read.isComplete
       if (options.quarantinedIsIncomplete && read.wasQuarantined) isComplete = false
@@ -597,7 +610,7 @@ class SessionRepository {
   private async readSessionFile(
     filePath: string,
     projectId: string,
-    options: { missingIsIncomplete?: boolean } = {}
+    options: { missingIsIncomplete?: boolean; quarantineInvalidFiles?: boolean } = {}
   ): Promise<{
     session?: PersistedChatSession
     isComplete: boolean
@@ -625,7 +638,8 @@ class SessionRepository {
         preserveLegacyUploadPaths: true
       })
       if (!session) {
-        const wasQuarantined = await this.tryBackupInvalidFile(filePath)
+        const wasQuarantined =
+          options.quarantineInvalidFiles !== false && (await this.tryBackupInvalidFile(filePath))
         return {
           isComplete: wasQuarantined,
           wasQuarantined,
@@ -640,7 +654,8 @@ class SessionRepository {
 
       return { session: decodeSessionDataPaths({ ...session, projectId }), isComplete: true }
     } catch {
-      const wasQuarantined = await this.tryBackupInvalidFile(filePath)
+      const wasQuarantined =
+        options.quarantineInvalidFiles !== false && (await this.tryBackupInvalidFile(filePath))
       return {
         isComplete: wasQuarantined,
         wasQuarantined,

--- a/src/preload/index.d.ts
+++ b/src/preload/index.d.ts
@@ -353,7 +353,7 @@ interface OpenScienceAPI {
     onOpenSession(listener: () => void): RemoveListener
     peekPendingOpenSession(): Promise<OpenSessionFromNotificationRequest | null>
     takePendingOpenSession(
-      expectedSessionId: string
+      expectedToken: number
     ): Promise<OpenSessionFromNotificationRequest | null>
   }
   github: {

--- a/src/preload/index.d.ts
+++ b/src/preload/index.d.ts
@@ -351,7 +351,10 @@ interface OpenScienceAPI {
   }
   notifications: {
     onOpenSession(listener: () => void): RemoveListener
-    takePendingOpenSession(): Promise<OpenSessionFromNotificationRequest | null>
+    peekPendingOpenSession(): Promise<OpenSessionFromNotificationRequest | null>
+    takePendingOpenSession(
+      expectedSessionId: string
+    ): Promise<OpenSessionFromNotificationRequest | null>
   }
   github: {
     getStars(): Promise<number | null>

--- a/src/preload/index.test.ts
+++ b/src/preload/index.test.ts
@@ -75,7 +75,7 @@ type PreloadApi = {
   }
   notifications: {
     peekPendingOpenSession: () => unknown
-    takePendingOpenSession: (expectedSessionId: string) => unknown
+    takePendingOpenSession: (expectedToken: number) => unknown
   }
   cli: {
     getStatus: () => unknown
@@ -428,9 +428,9 @@ const cases: ForwardingCase[] = [
   },
   {
     name: 'notifications.takePendingOpenSession → notifications:take-pending-open-session',
-    invoke: (a) => a.notifications.takePendingOpenSession('s-1'),
+    invoke: (a) => a.notifications.takePendingOpenSession(7),
     channel: 'notifications:take-pending-open-session',
-    args: ['s-1']
+    args: [7]
   }
 ]
 

--- a/src/preload/index.test.ts
+++ b/src/preload/index.test.ts
@@ -74,7 +74,8 @@ type PreloadApi = {
     compactSession: (request: unknown) => unknown
   }
   notifications: {
-    takePendingOpenSession: () => unknown
+    peekPendingOpenSession: () => unknown
+    takePendingOpenSession: (expectedSessionId: string) => unknown
   }
   cli: {
     getStatus: () => unknown
@@ -418,12 +419,18 @@ const cases: ForwardingCase[] = [
     channel: 'acp:compact-session',
     args: [{ sessionId: 's-1' }]
   },
-  // Notification click target: the renderer pulls it once sessions are hydrated.
+  // Notification click target: inspect first so partial hydration can retain an omitted session.
+  {
+    name: 'notifications.peekPendingOpenSession → notifications:peek-pending-open-session',
+    invoke: (a) => a.notifications.peekPendingOpenSession(),
+    channel: 'notifications:peek-pending-open-session',
+    args: []
+  },
   {
     name: 'notifications.takePendingOpenSession → notifications:take-pending-open-session',
-    invoke: (a) => a.notifications.takePendingOpenSession(),
+    invoke: (a) => a.notifications.takePendingOpenSession('s-1'),
     channel: 'notifications:take-pending-open-session',
-    args: []
+    args: ['s-1']
   }
 ]
 

--- a/src/preload/index.ts
+++ b/src/preload/index.ts
@@ -392,9 +392,9 @@ type OpenScienceAPI = {
     onOpenSession: (listener: () => void) => RemoveListener
     // Returns the retained conversation without consuming it, so partial hydration can defer it.
     peekPendingOpenSession: () => Promise<OpenSessionFromNotificationRequest | null>
-    // Clears the target only if it still matches the conversation the renderer inspected.
+    // Clears the target only if it still matches the click the renderer inspected.
     takePendingOpenSession: (
-      expectedSessionId: string
+      expectedToken: number
     ) => Promise<OpenSessionFromNotificationRequest | null>
   }
   github: {
@@ -936,10 +936,10 @@ const api: OpenScienceAPI = {
       ipcRenderer.invoke(
         'notifications:peek-pending-open-session'
       ) as Promise<OpenSessionFromNotificationRequest | null>,
-    takePendingOpenSession: (expectedSessionId) =>
+    takePendingOpenSession: (expectedToken) =>
       ipcRenderer.invoke(
         'notifications:take-pending-open-session',
-        expectedSessionId
+        expectedToken
       ) as Promise<OpenSessionFromNotificationRequest | null>
   },
   github: {

--- a/src/preload/index.ts
+++ b/src/preload/index.ts
@@ -388,10 +388,14 @@ type OpenScienceAPI = {
   }
   notifications: {
     // Fires when the user clicks a desktop notification. Payload-less nudge: the renderer then
-    // pulls the target via takePendingOpenSession (a push with payload could be lost mid-load).
+    // inspects the retained target (a push with payload could be lost mid-load).
     onOpenSession: (listener: () => void) => RemoveListener
-    // Returns and clears the conversation a notification click should open, once sessions load.
-    takePendingOpenSession: () => Promise<OpenSessionFromNotificationRequest | null>
+    // Returns the retained conversation without consuming it, so partial hydration can defer it.
+    peekPendingOpenSession: () => Promise<OpenSessionFromNotificationRequest | null>
+    // Clears the target only if it still matches the conversation the renderer inspected.
+    takePendingOpenSession: (
+      expectedSessionId: string
+    ) => Promise<OpenSessionFromNotificationRequest | null>
   }
   github: {
     getStars: () => Promise<number | null>
@@ -928,9 +932,14 @@ const api: OpenScienceAPI = {
   notifications: {
     // Main-process task notifications route their click through this channel.
     onOpenSession: (listener) => onIpcMessage('notifications:open-session', listener),
-    takePendingOpenSession: () =>
+    peekPendingOpenSession: () =>
       ipcRenderer.invoke(
-        'notifications:take-pending-open-session'
+        'notifications:peek-pending-open-session'
+      ) as Promise<OpenSessionFromNotificationRequest | null>,
+    takePendingOpenSession: (expectedSessionId) =>
+      ipcRenderer.invoke(
+        'notifications:take-pending-open-session',
+        expectedSessionId
       ) as Promise<OpenSessionFromNotificationRequest | null>
   },
   github: {

--- a/src/renderer/src/App.test.tsx
+++ b/src/renderer/src/App.test.tsx
@@ -10,11 +10,13 @@ const mocks = vi.hoisted(() => {
   return {
     settings: {
       isLoaded: false,
+      isLoading: false,
+      loadError: undefined as string | undefined,
       onboardingCompletedAt: undefined as number | undefined,
       isSettingsOpen: false,
       isSettingsLoaded: true,
       enqueueApproval: vi.fn(),
-      load: vi.fn().mockResolvedValue(undefined),
+      load: vi.fn().mockResolvedValue(true),
       checkEnvironment: vi.fn().mockResolvedValue(undefined),
       closeSettings: vi.fn()
     },
@@ -37,7 +39,14 @@ const mocks = vi.hoisted(() => {
       }),
       takePendingOpenSession: vi.fn().mockResolvedValue(null)
     },
-    sessionPersistenceReady: true,
+    sessionPersistence: {
+      isReady: true,
+      loadError: undefined as string | undefined,
+      loadWarning: undefined as string | undefined,
+      writeError: undefined as string | undefined,
+      retryLoad: vi.fn(),
+      retryWrites: vi.fn()
+    },
     startupView: 'home' as 'home' | 'onboarding',
     getInfo: vi.fn(),
     syncWindowFindAppearance: vi.fn()
@@ -45,7 +54,7 @@ const mocks = vi.hoisted(() => {
 })
 
 vi.mock('@/lib/session-persistence/session-persistence', () => ({
-  useSessionPersistence: () => mocks.sessionPersistenceReady
+  useSessionPersistence: () => mocks.sessionPersistence
 }))
 vi.mock('@/lib/deep-link', () => ({
   useDeepLinkNavigation: mocks.deepLinkNavigation
@@ -157,15 +166,22 @@ describe('App startup routing', () => {
     container = document.createElement('div')
     document.body.appendChild(container)
     mocks.settings.isLoaded = false
+    mocks.settings.isLoading = false
+    mocks.settings.loadError = undefined
     mocks.settings.onboardingCompletedAt = undefined
     mocks.settings.isSettingsOpen = false
-    mocks.settings.load.mockReset().mockResolvedValue(undefined)
+    mocks.settings.load.mockReset().mockResolvedValue(true)
     mocks.settings.checkEnvironment.mockReset().mockResolvedValue(undefined)
     mocks.skillImport.enqueue.mockClear()
     mocks.skillImport.dismiss.mockClear()
     mocks.navigation.view = 'home'
     mocks.startupView = 'home'
-    mocks.sessionPersistenceReady = true
+    mocks.sessionPersistence.isReady = true
+    mocks.sessionPersistence.loadError = undefined
+    mocks.sessionPersistence.loadWarning = undefined
+    mocks.sessionPersistence.writeError = undefined
+    mocks.sessionPersistence.retryLoad.mockClear()
+    mocks.sessionPersistence.retryWrites.mockClear()
     mocks.deepLinkNavigation.mockClear()
     mocks.syncWindowFindAppearance.mockClear()
     mocks.getInfo.mockResolvedValue({
@@ -205,15 +221,37 @@ describe('App startup routing', () => {
     await act(async () => root.render(<App />))
   }
 
-  it('keeps the shell blank until settings have loaded', async () => {
+  it('shows startup progress until settings have loaded', async () => {
     await render()
 
-    expect(container.innerHTML).toBe('')
+    expect(container.querySelector('[data-testid="settings-startup-loading"]')).not.toBeNull()
+    expect(container.textContent).toContain('Loading settings')
     expect(mocks.syncWindowFindAppearance).toHaveBeenCalledTimes(1)
   })
 
+  it('shows a settings load error and retries the complete initialization', async () => {
+    mocks.settings.loadError = 'settings IPC unavailable'
+    mocks.settings.load.mockReset().mockResolvedValueOnce(false).mockResolvedValueOnce(true)
+
+    await render()
+
+    expect(container.querySelector('[role="alert"]')?.textContent).toContain(
+      'settings IPC unavailable'
+    )
+    expect(mocks.settings.checkEnvironment).not.toHaveBeenCalled()
+
+    const retry = container.querySelector<HTMLButtonElement>(
+      '[data-testid="settings-startup-retry"]'
+    )
+    expect(retry).not.toBeNull()
+    await act(async () => retry?.dispatchEvent(new MouseEvent('click', { bubbles: true })))
+
+    expect(mocks.settings.load).toHaveBeenCalledTimes(2)
+    expect(mocks.settings.checkEnvironment).toHaveBeenCalledOnce()
+  })
+
   it('passes session persistence readiness to deep-link navigation', async () => {
-    mocks.sessionPersistenceReady = false
+    mocks.sessionPersistence.isReady = false
 
     await render()
 
@@ -246,6 +284,48 @@ describe('App startup routing', () => {
     expect(mocks.getInfo).toHaveBeenCalled()
   })
 
+  it('surfaces a session load failure with a retry action', async () => {
+    mocks.settings.isLoaded = true
+    mocks.sessionPersistence.isReady = false
+    mocks.sessionPersistence.loadError = 'sessions directory unavailable'
+
+    await render()
+
+    const alert = container.querySelector('[data-testid="session-persistence-alert"]')
+    expect(alert?.textContent).toContain('sessions directory unavailable')
+
+    container.querySelector<HTMLButtonElement>('[data-testid="session-persistence-retry"]')?.click()
+    expect(mocks.sessionPersistence.retryLoad).toHaveBeenCalledOnce()
+  })
+
+  it('warns that in-memory conversation changes are not durable and retries them', async () => {
+    mocks.settings.isLoaded = true
+    mocks.sessionPersistence.writeError = 'disk full'
+
+    await render()
+
+    const alert = container.querySelector('[data-testid="session-persistence-alert"]')
+    expect(alert?.textContent).toContain('Conversation storage needs attention')
+    expect(alert?.textContent).toContain('disk full')
+
+    container.querySelector<HTMLButtonElement>('[data-testid="session-persistence-retry"]')?.click()
+    expect(mocks.sessionPersistence.retryWrites).toHaveBeenCalledOnce()
+  })
+
+  it('reports quarantined corrupt conversation files without blocking healthy sessions', async () => {
+    mocks.settings.isLoaded = true
+    mocks.sessionPersistence.loadWarning =
+      '1 saved conversation file was damaged and moved aside. The remaining conversations were loaded.'
+
+    await render()
+
+    const alert = container.querySelector('[data-testid="session-persistence-alert"]')
+    expect(alert?.textContent).toContain('Saved conversation data was damaged')
+    expect(alert?.textContent).toContain('damaged and moved aside')
+    expect(container.querySelector('[data-testid="session-persistence-retry"]')).toBeNull()
+    expect(container.querySelector('[data-testid="home-page"]')).not.toBeNull()
+  })
+
   it('recovers pending Skill import approvals after the renderer starts', async () => {
     const pending = {
       id: 'approval-recovered',
@@ -269,10 +349,10 @@ describe('App startup routing', () => {
   })
 
   it('waits for persisted settings before checking the selected agent environment', async () => {
-    let resolveSettings: (() => void) | undefined
+    let resolveSettings: ((loaded: boolean) => void) | undefined
     mocks.settings.load.mockImplementation(
       () =>
-        new Promise<void>((resolve) => {
+        new Promise<boolean>((resolve) => {
           resolveSettings = resolve
         })
     )
@@ -282,7 +362,7 @@ describe('App startup routing', () => {
     expect(mocks.settings.load).toHaveBeenCalledOnce()
     expect(mocks.settings.checkEnvironment).not.toHaveBeenCalled()
 
-    await act(async () => resolveSettings?.())
+    await act(async () => resolveSettings?.(true))
 
     expect(mocks.settings.checkEnvironment).toHaveBeenCalledOnce()
   })
@@ -307,7 +387,7 @@ describe('App startup routing', () => {
 
   it('opens the notification-target conversation once session persistence is ready', async () => {
     mocks.settings.isLoaded = true
-    mocks.sessionPersistenceReady = false
+    mocks.sessionPersistence.isReady = false
     mocks.notifications.takePendingOpenSession.mockResolvedValue({ sessionId: 's-9' })
 
     await render()
@@ -316,7 +396,7 @@ describe('App startup routing', () => {
     expect(mocks.openSessionById).not.toHaveBeenCalled()
 
     // Hydration completes: the target is pulled and the conversation opens.
-    mocks.sessionPersistenceReady = true
+    mocks.sessionPersistence.isReady = true
     await act(async () => root.render(<App />))
     await act(async () => {
       await new Promise((resolve) => setTimeout(resolve, 0))

--- a/src/renderer/src/App.test.tsx
+++ b/src/renderer/src/App.test.tsx
@@ -290,6 +290,21 @@ describe('App startup routing', () => {
     ).toBe('true')
   })
 
+  it('renders the partial session recovery alert on an opaque surface', async () => {
+    mocks.settings.isLoaded = true
+    mocks.sessionPersistence.isHydrated = true
+    mocks.sessionPersistence.isReady = false
+    mocks.sessionPersistence.loadError = 'one saved conversation could not be read'
+
+    await render()
+
+    const alert = container.querySelector('[data-testid="session-persistence-alert"]')
+    expect(alert).not.toBeNull()
+    expect(alert?.classList.contains('bg-bg-000')).toBe(true)
+    expect(alert?.classList.contains('bg-bg-100')).toBe(false)
+    expect(container.querySelector('[data-testid="home-page"]')).not.toBeNull()
+  })
+
   it('routes first-run users to onboarding after settings hydration', async () => {
     mocks.settings.isLoaded = true
     mocks.startupView = 'onboarding'

--- a/src/renderer/src/App.test.tsx
+++ b/src/renderer/src/App.test.tsx
@@ -305,6 +305,30 @@ describe('App startup routing', () => {
     expect(container.querySelector('[data-testid="home-page"]')).not.toBeNull()
   })
 
+  it('reloads projects after a partial session load is retried successfully', async () => {
+    mocks.settings.isLoaded = true
+    mocks.sessionPersistence.isHydrated = true
+    mocks.sessionPersistence.isReady = false
+    mocks.loadProjects.mockClear()
+
+    await render()
+
+    expect(mocks.loadProjects).toHaveBeenCalledOnce()
+
+    mocks.sessionPersistence.isHydrated = false
+    mocks.sessionPersistence.isLoading = true
+    await act(async () => root.render(<App />))
+
+    expect(mocks.loadProjects).toHaveBeenCalledOnce()
+
+    mocks.sessionPersistence.isHydrated = true
+    mocks.sessionPersistence.isLoading = false
+    mocks.sessionPersistence.isReady = true
+    await act(async () => root.render(<App />))
+
+    expect(mocks.loadProjects).toHaveBeenCalledTimes(2)
+  })
+
   it('routes first-run users to onboarding after settings hydration', async () => {
     mocks.settings.isLoaded = true
     mocks.startupView = 'onboarding'

--- a/src/renderer/src/App.test.tsx
+++ b/src/renderer/src/App.test.tsx
@@ -264,7 +264,10 @@ describe('App startup routing', () => {
 
     await render()
 
-    expect(mocks.deepLinkNavigation).toHaveBeenCalledWith(false)
+    expect(mocks.deepLinkNavigation).toHaveBeenCalledWith({
+      isHydrated: false,
+      isReady: false
+    })
   })
 
   it('allows navigation and target-validated deletion after a partial session load', async () => {
@@ -277,7 +280,10 @@ describe('App startup routing', () => {
     expect(mocks.lifecycleSync).toHaveBeenCalledWith({
       isSessionPersistenceHydrated: true
     })
-    expect(mocks.deepLinkNavigation).toHaveBeenCalledWith(true)
+    expect(mocks.deepLinkNavigation).toHaveBeenCalledWith({
+      isHydrated: true,
+      isReady: false
+    })
     expect(
       container.querySelector<HTMLElement>('[data-testid="home-page"]')?.dataset.canDeleteProjects
     ).toBe('true')
@@ -426,7 +432,7 @@ describe('App startup routing', () => {
     )
   })
 
-  it('opens the notification-target conversation once sessions hydrate read-only', async () => {
+  it('retains a notification target until recovery completes', async () => {
     mocks.settings.isLoaded = true
     mocks.sessionPersistence.isHydrated = false
     mocks.sessionPersistence.isLoading = true
@@ -438,9 +444,19 @@ describe('App startup routing', () => {
     // Sessions still hydrating: the pending click target must not be consumed or dropped.
     expect(mocks.openSessionById).not.toHaveBeenCalled()
 
-    // A partial hydration is enough for navigation even though durable writes remain blocked.
+    // Partial hydration cannot prove an absent target was deleted, so the destructive take stays
+    // pending in main until a complete retry.
     mocks.sessionPersistence.isHydrated = true
     mocks.sessionPersistence.isLoading = false
+    await act(async () => root.render(<App />))
+    await act(async () => {
+      await new Promise((resolve) => setTimeout(resolve, 0))
+    })
+
+    expect(mocks.notifications.takePendingOpenSession).not.toHaveBeenCalled()
+    expect(mocks.openSessionById).not.toHaveBeenCalled()
+
+    mocks.sessionPersistence.isReady = true
     await act(async () => root.render(<App />))
     await act(async () => {
       await new Promise((resolve) => setTimeout(resolve, 0))
@@ -449,13 +465,10 @@ describe('App startup routing', () => {
     expect(mocks.openSessionById).toHaveBeenCalledWith('s-9')
   })
 
-  it('opens the conversation immediately when a notification nudge arrives hydrated', async () => {
+  it('does not consume a notification nudge during partial recovery', async () => {
     mocks.settings.isLoaded = true
     mocks.sessionPersistence.isReady = false
-    // The mount-time pull finds nothing; the nudge-triggered pull gets the click target.
-    mocks.notifications.takePendingOpenSession
-      .mockResolvedValueOnce(null)
-      .mockResolvedValue({ sessionId: 's-3' })
+    mocks.notifications.takePendingOpenSession.mockResolvedValue({ sessionId: 's-3' })
 
     await render()
 
@@ -463,6 +476,15 @@ describe('App startup routing', () => {
     expect(nudge).toBeDefined()
     await act(async () => {
       nudge?.()
+    })
+
+    expect(mocks.notifications.takePendingOpenSession).not.toHaveBeenCalled()
+    expect(mocks.openSessionById).not.toHaveBeenCalled()
+
+    mocks.sessionPersistence.isReady = true
+    await act(async () => root.render(<App />))
+    await act(async () => {
+      await new Promise((resolve) => setTimeout(resolve, 0))
     })
 
     expect(mocks.openSessionById).toHaveBeenCalledWith('s-3')

--- a/src/renderer/src/App.test.tsx
+++ b/src/renderer/src/App.test.tsx
@@ -535,7 +535,7 @@ describe('App startup routing', () => {
     })
 
     expect(mocks.notifications.takePendingOpenSession).toHaveBeenCalledWith('s-9')
-    expect(mocks.openSessionById).toHaveBeenCalledWith('s-9', 'automatic')
+    expect(mocks.openSessionById).toHaveBeenCalledWith('s-9', 'notification')
   })
 
   it('opens an already-hydrated notification target during partial recovery', async () => {
@@ -559,7 +559,7 @@ describe('App startup routing', () => {
     })
 
     expect(mocks.notifications.takePendingOpenSession).toHaveBeenCalledWith('s-3')
-    expect(mocks.openSessionById).toHaveBeenCalledWith('s-3', 'automatic')
+    expect(mocks.openSessionById).toHaveBeenCalledWith('s-3', 'notification')
   })
 
   it('discards a deferred notification when the user navigates elsewhere', async () => {
@@ -632,6 +632,6 @@ describe('App startup routing', () => {
     })
 
     expect(mocks.notifications.takePendingOpenSession).toHaveBeenCalledWith('s-4')
-    expect(mocks.openSessionById).toHaveBeenCalledWith('s-4', 'automatic')
+    expect(mocks.openSessionById).toHaveBeenCalledWith('s-4', 'notification')
   })
 })

--- a/src/renderer/src/App.test.tsx
+++ b/src/renderer/src/App.test.tsx
@@ -255,6 +255,7 @@ describe('App startup routing', () => {
     await act(async () => retry?.dispatchEvent(new MouseEvent('click', { bubbles: true })))
 
     expect(mocks.settings.load).toHaveBeenCalledTimes(2)
+    expect(mocks.settings.load).toHaveBeenLastCalledWith({ force: true })
     expect(mocks.settings.checkEnvironment).toHaveBeenCalledOnce()
   })
 

--- a/src/renderer/src/App.test.tsx
+++ b/src/renderer/src/App.test.tsx
@@ -6,7 +6,10 @@ import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest'
 const mocks = vi.hoisted(() => {
   // Captures the onOpenSession listener so tests can fire the notification nudge directly.
   const notificationNudgeBox: { current: (() => void) | undefined } = { current: undefined }
-  const navigationListeners = new Set<() => void>()
+  type NavigationState = { view: 'home' | 'workspace'; userNavigationRevision: number }
+  const navigationListeners = new Set<
+    (state: NavigationState, previousState: NavigationState) => void
+  >()
 
   return {
     settings: {
@@ -22,7 +25,7 @@ const mocks = vi.hoisted(() => {
       closeSettings: vi.fn()
     },
     skillImport: { enqueue: vi.fn(), dismiss: vi.fn() },
-    navigation: { view: 'home' as 'home' | 'workspace' },
+    navigation: { view: 'home' as 'home' | 'workspace', userNavigationRevision: 0 },
     sessions: [] as Array<{ id: string }>,
     environment: {
       ui: { state: 'idle' },
@@ -84,8 +87,10 @@ vi.mock('@/stores/navigation-store', () => ({
     <T,>(selector: (state: typeof mocks.navigation) => T): T => selector(mocks.navigation),
     // Notification navigation reaches the store imperatively (outside React) via getState().
     {
-      getState: () => ({ openSessionById: mocks.openSessionById }),
-      subscribe: (listener: () => void) => {
+      getState: () => ({ ...mocks.navigation, openSessionById: mocks.openSessionById }),
+      subscribe: (
+        listener: (state: typeof mocks.navigation, previousState: typeof mocks.navigation) => void
+      ) => {
         mocks.navigationListeners.add(listener)
         return () => mocks.navigationListeners.delete(listener)
       }
@@ -228,6 +233,8 @@ describe('App startup routing', () => {
     } as unknown as Window['api']
     mocks.openSessionById.mockClear()
     mocks.sessions = []
+    mocks.navigation.view = 'home'
+    mocks.navigation.userNavigationRevision = 0
     mocks.navigationListeners.clear()
     mocks.notifications.onOpenSession.mockClear()
     mocks.notifications.peekPendingOpenSession.mockReset().mockResolvedValue(null)
@@ -528,7 +535,7 @@ describe('App startup routing', () => {
     })
 
     expect(mocks.notifications.takePendingOpenSession).toHaveBeenCalledWith('s-9')
-    expect(mocks.openSessionById).toHaveBeenCalledWith('s-9')
+    expect(mocks.openSessionById).toHaveBeenCalledWith('s-9', 'automatic')
   })
 
   it('opens an already-hydrated notification target during partial recovery', async () => {
@@ -552,7 +559,7 @@ describe('App startup routing', () => {
     })
 
     expect(mocks.notifications.takePendingOpenSession).toHaveBeenCalledWith('s-3')
-    expect(mocks.openSessionById).toHaveBeenCalledWith('s-3')
+    expect(mocks.openSessionById).toHaveBeenCalledWith('s-3', 'automatic')
   })
 
   it('discards a deferred notification when the user navigates elsewhere', async () => {
@@ -575,7 +582,11 @@ describe('App startup routing', () => {
     expect(mocks.notifications.takePendingOpenSession).not.toHaveBeenCalled()
 
     await act(async () => {
-      for (const listener of mocks.navigationListeners) listener()
+      const previousNavigation = { ...mocks.navigation }
+      mocks.navigation.userNavigationRevision += 1
+      for (const listener of mocks.navigationListeners) {
+        listener(mocks.navigation, previousNavigation)
+      }
       await new Promise((resolve) => setTimeout(resolve, 0))
     })
 
@@ -589,5 +600,38 @@ describe('App startup routing', () => {
     })
 
     expect(mocks.openSessionById).not.toHaveBeenCalled()
+  })
+
+  it('retains a deferred notification across automatic navigation redirects', async () => {
+    mocks.settings.isLoaded = true
+    mocks.sessionPersistence.isReady = false
+    mocks.notifications.peekPendingOpenSession.mockResolvedValue({ sessionId: 's-4' })
+    mocks.notifications.takePendingOpenSession.mockResolvedValue({ sessionId: 's-4' })
+
+    await render()
+    await act(async () => {
+      await new Promise((resolve) => setTimeout(resolve, 0))
+    })
+
+    await act(async () => {
+      const previousNavigation = { ...mocks.navigation }
+      mocks.navigation.view = 'workspace'
+      for (const listener of mocks.navigationListeners) {
+        listener(mocks.navigation, previousNavigation)
+      }
+      await new Promise((resolve) => setTimeout(resolve, 0))
+    })
+
+    expect(mocks.notifications.takePendingOpenSession).not.toHaveBeenCalled()
+
+    mocks.sessions = [{ id: 's-4' }]
+    mocks.sessionPersistence.isReady = true
+    await act(async () => root.render(<App />))
+    await act(async () => {
+      await new Promise((resolve) => setTimeout(resolve, 0))
+    })
+
+    expect(mocks.notifications.takePendingOpenSession).toHaveBeenCalledWith('s-4')
+    expect(mocks.openSessionById).toHaveBeenCalledWith('s-4', 'automatic')
   })
 })

--- a/src/renderer/src/App.test.tsx
+++ b/src/renderer/src/App.test.tsx
@@ -803,6 +803,95 @@ describe('App startup routing', () => {
     expect(mocks.openSessionById).toHaveBeenCalledWith(target.sessionId, 'notification')
   })
 
+  it('does not let a pre-navigation queued task discard a later notification click', async () => {
+    const target = { sessionId: 's-new', token: 7 }
+    let pending: typeof target | null = null
+    let resolveFirstPeek: ((value: typeof target | null) => void) | undefined
+    let peekCount = 0
+    mocks.settings.isLoaded = true
+    mocks.sessions = [{ id: target.sessionId }]
+    mocks.notifications.peekPendingOpenSession.mockImplementation(() => {
+      peekCount += 1
+      if (peekCount === 1) {
+        return new Promise((resolve) => {
+          resolveFirstPeek = resolve
+        })
+      }
+      return Promise.resolve(pending ? { ...pending } : null)
+    })
+    mocks.notifications.takePendingOpenSession.mockImplementation(async (token: number) => {
+      if (pending?.token !== token) return null
+      const consumed = pending
+      pending = null
+      return consumed
+    })
+
+    await render()
+    expect(mocks.notifications.peekPendingOpenSession).toHaveBeenCalledOnce()
+
+    const nudge = mocks.notificationNudgeBox.current
+    nudge?.()
+    await act(async () => {
+      const previousNavigation = { ...mocks.navigation }
+      mocks.navigation.userNavigationRevision += 1
+      for (const listener of mocks.navigationListeners) {
+        listener(mocks.navigation, previousNavigation)
+      }
+    })
+
+    pending = target
+    nudge?.()
+    await act(async () => {
+      resolveFirstPeek?.(null)
+      await new Promise((resolve) => setTimeout(resolve, 0))
+    })
+
+    expect(mocks.notifications.takePendingOpenSession).toHaveBeenCalledWith(target.token)
+    expect(mocks.openSessionById).toHaveBeenCalledWith(target.sessionId, 'notification')
+  })
+
+  it('does not let a notification queued before navigation override that navigation', async () => {
+    const target = { sessionId: 's-old', token: 6 }
+    let pending: typeof target | null = null
+    let resolveFirstPeek: ((value: typeof target | null) => void) | undefined
+    let peekCount = 0
+    mocks.settings.isLoaded = true
+    mocks.sessions = [{ id: target.sessionId }]
+    mocks.notifications.peekPendingOpenSession.mockImplementation(() => {
+      peekCount += 1
+      if (peekCount === 1) {
+        return new Promise((resolve) => {
+          resolveFirstPeek = resolve
+        })
+      }
+      return Promise.resolve(pending ? { ...pending } : null)
+    })
+    mocks.notifications.takePendingOpenSession.mockImplementation(async (token: number) => {
+      if (pending?.token !== token) return null
+      const consumed = pending
+      pending = null
+      return consumed
+    })
+
+    await render()
+    expect(mocks.notifications.peekPendingOpenSession).toHaveBeenCalledOnce()
+
+    pending = target
+    mocks.notificationNudgeBox.current?.()
+    await act(async () => {
+      const previousNavigation = { ...mocks.navigation }
+      mocks.navigation.userNavigationRevision += 1
+      for (const listener of mocks.navigationListeners) {
+        listener(mocks.navigation, previousNavigation)
+      }
+      resolveFirstPeek?.(null)
+      await new Promise((resolve) => setTimeout(resolve, 0))
+    })
+
+    expect(mocks.notifications.takePendingOpenSession).toHaveBeenCalledWith(target.token)
+    expect(mocks.openSessionById).not.toHaveBeenCalled()
+  })
+
   it('discards a deferred notification when the user navigates elsewhere', async () => {
     let pending: { sessionId: string; token: number } | null = { sessionId: 's-3', token: 3 }
     mocks.settings.isLoaded = true

--- a/src/renderer/src/App.test.tsx
+++ b/src/renderer/src/App.test.tsx
@@ -57,6 +57,7 @@ const mocks = vi.hoisted(() => {
       isHydrated: true,
       isLoading: false,
       isReady: true,
+      hasCompleteSessionCatalog: true,
       loadError: undefined as string | undefined,
       loadWarning: undefined as string | undefined,
       writeError: undefined as string | undefined,
@@ -158,8 +159,18 @@ vi.mock('@/components/UpdateDialog', () => ({
   UpdateDialog: (): React.JSX.Element => <div data-testid="update-dialog" />
 }))
 vi.mock('@/pages/home/HomePage', () => ({
-  HomePage: ({ canDeleteProjects }: { canDeleteProjects: boolean }): React.JSX.Element => (
-    <div data-testid="home-page" data-can-delete-projects={String(canDeleteProjects)} />
+  HomePage: ({
+    canDeleteProjects,
+    hasCompleteSessionCatalog
+  }: {
+    canDeleteProjects: boolean
+    hasCompleteSessionCatalog: boolean
+  }): React.JSX.Element => (
+    <div
+      data-testid="home-page"
+      data-can-delete-projects={String(canDeleteProjects)}
+      data-has-complete-session-catalog={String(hasCompleteSessionCatalog)}
+    />
   )
 }))
 vi.mock('@/pages/onboarding/OnboardingWizard', () => ({
@@ -212,6 +223,7 @@ describe('App startup routing', () => {
     mocks.sessionPersistence.isReady = true
     mocks.sessionPersistence.isHydrated = true
     mocks.sessionPersistence.isLoading = false
+    mocks.sessionPersistence.hasCompleteSessionCatalog = true
     mocks.sessionPersistence.loadError = undefined
     mocks.sessionPersistence.loadWarning = undefined
     mocks.sessionPersistence.writeError = undefined
@@ -315,6 +327,7 @@ describe('App startup routing', () => {
     mocks.settings.isLoaded = true
     mocks.sessionPersistence.isHydrated = true
     mocks.sessionPersistence.isReady = false
+    mocks.sessionPersistence.hasCompleteSessionCatalog = false
 
     await render()
 
@@ -328,6 +341,10 @@ describe('App startup routing', () => {
     expect(
       container.querySelector<HTMLElement>('[data-testid="home-page"]')?.dataset.canDeleteProjects
     ).toBe('true')
+    expect(
+      container.querySelector<HTMLElement>('[data-testid="home-page"]')?.dataset
+        .hasCompleteSessionCatalog
+    ).toBe('false')
   })
 
   it('renders the partial session recovery alert on an opaque semantic surface', async () => {
@@ -488,6 +505,7 @@ describe('App startup routing', () => {
 
   it('reports quarantined corrupt conversation files without blocking healthy sessions', async () => {
     mocks.settings.isLoaded = true
+    mocks.sessionPersistence.hasCompleteSessionCatalog = false
     mocks.sessionPersistence.loadWarning =
       '1 saved conversation file was damaged and moved aside. The remaining conversations were loaded.'
 
@@ -498,6 +516,10 @@ describe('App startup routing', () => {
     expect(alert?.textContent).toContain('damaged and moved aside')
     expect(container.querySelector('[data-testid="session-persistence-retry"]')).toBeNull()
     expect(container.querySelector('[data-testid="home-page"]')).not.toBeNull()
+    expect(
+      container.querySelector<HTMLElement>('[data-testid="home-page"]')?.dataset
+        .hasCompleteSessionCatalog
+    ).toBe('false')
   })
 
   it('recovers pending Skill import approvals after the renderer starts', async () => {

--- a/src/renderer/src/App.test.tsx
+++ b/src/renderer/src/App.test.tsx
@@ -267,7 +267,7 @@ describe('App startup routing', () => {
     expect(mocks.deepLinkNavigation).toHaveBeenCalledWith(false)
   })
 
-  it('allows lifecycle sync after a partial session load enters read-only recovery', async () => {
+  it('allows navigation and target-validated deletion after a partial session load', async () => {
     mocks.settings.isLoaded = true
     mocks.sessionPersistence.isHydrated = true
     mocks.sessionPersistence.isReady = false
@@ -280,7 +280,7 @@ describe('App startup routing', () => {
     expect(mocks.deepLinkNavigation).toHaveBeenCalledWith(true)
     expect(
       container.querySelector<HTMLElement>('[data-testid="home-page"]')?.dataset.canDeleteProjects
-    ).toBe('false')
+    ).toBe('true')
   })
 
   it('routes first-run users to onboarding after settings hydration', async () => {

--- a/src/renderer/src/App.test.tsx
+++ b/src/renderer/src/App.test.tsx
@@ -46,6 +46,7 @@ const mocks = vi.hoisted(() => {
     },
     sessionPersistence: {
       isHydrated: true,
+      isLoading: false,
       isReady: true,
       loadError: undefined as string | undefined,
       loadWarning: undefined as string | undefined,
@@ -182,6 +183,7 @@ describe('App startup routing', () => {
     mocks.startupView = 'home'
     mocks.sessionPersistence.isReady = true
     mocks.sessionPersistence.isHydrated = true
+    mocks.sessionPersistence.isLoading = false
     mocks.sessionPersistence.loadError = undefined
     mocks.sessionPersistence.loadWarning = undefined
     mocks.sessionPersistence.writeError = undefined
@@ -286,6 +288,20 @@ describe('App startup routing', () => {
     await render()
 
     expect(container.querySelector('[data-testid="onboarding-page"]')).not.toBeNull()
+    expect(container.querySelector('[data-testid="home-page"]')).toBeNull()
+  })
+
+  it('blocks Home while the initial session snapshot is loading', async () => {
+    mocks.settings.isLoaded = true
+    mocks.sessionPersistence.isHydrated = false
+    mocks.sessionPersistence.isLoading = true
+    mocks.sessionPersistence.isReady = false
+
+    await render()
+
+    expect(
+      container.querySelector('[data-testid="session-persistence-startup-loading"]')
+    ).not.toBeNull()
     expect(container.querySelector('[data-testid="home-page"]')).toBeNull()
   })
 

--- a/src/renderer/src/App.test.tsx
+++ b/src/renderer/src/App.test.tsx
@@ -500,8 +500,8 @@ describe('App startup routing', () => {
     mocks.sessionPersistence.isHydrated = false
     mocks.sessionPersistence.isLoading = true
     mocks.sessionPersistence.isReady = false
-    mocks.notifications.peekPendingOpenSession.mockResolvedValue({ sessionId: 's-9' })
-    mocks.notifications.takePendingOpenSession.mockResolvedValue({ sessionId: 's-9' })
+    mocks.notifications.peekPendingOpenSession.mockResolvedValue({ sessionId: 's-9', token: 9 })
+    mocks.notifications.takePendingOpenSession.mockResolvedValue({ sessionId: 's-9', token: 9 })
 
     await render()
 
@@ -534,7 +534,7 @@ describe('App startup routing', () => {
       await new Promise((resolve) => setTimeout(resolve, 0))
     })
 
-    expect(mocks.notifications.takePendingOpenSession).toHaveBeenCalledWith('s-9')
+    expect(mocks.notifications.takePendingOpenSession).toHaveBeenCalledWith(9)
     expect(mocks.openSessionById).toHaveBeenCalledWith('s-9', 'notification')
   })
 
@@ -548,8 +548,8 @@ describe('App startup routing', () => {
       await new Promise((resolve) => setTimeout(resolve, 0))
     })
 
-    mocks.notifications.peekPendingOpenSession.mockResolvedValue({ sessionId: 's-3' })
-    mocks.notifications.takePendingOpenSession.mockResolvedValue({ sessionId: 's-3' })
+    mocks.notifications.peekPendingOpenSession.mockResolvedValue({ sessionId: 's-3', token: 3 })
+    mocks.notifications.takePendingOpenSession.mockResolvedValue({ sessionId: 's-3', token: 3 })
     const nudge = mocks.notificationNudgeBox.current
     expect(nudge).toBeDefined()
 
@@ -558,17 +558,17 @@ describe('App startup routing', () => {
       await new Promise((resolve) => setTimeout(resolve, 0))
     })
 
-    expect(mocks.notifications.takePendingOpenSession).toHaveBeenCalledWith('s-3')
+    expect(mocks.notifications.takePendingOpenSession).toHaveBeenCalledWith(3)
     expect(mocks.openSessionById).toHaveBeenCalledWith('s-3', 'notification')
   })
 
   it('discards a deferred notification when the user navigates elsewhere', async () => {
-    let pending: { sessionId: string } | null = { sessionId: 's-3' }
+    let pending: { sessionId: string; token: number } | null = { sessionId: 's-3', token: 3 }
     mocks.settings.isLoaded = true
     mocks.sessionPersistence.isReady = false
     mocks.notifications.peekPendingOpenSession.mockImplementation(async () => pending)
-    mocks.notifications.takePendingOpenSession.mockImplementation(async (sessionId: string) => {
-      if (pending?.sessionId !== sessionId) return null
+    mocks.notifications.takePendingOpenSession.mockImplementation(async (token: number) => {
+      if (pending?.token !== token) return null
       const consumed = pending
       pending = null
       return consumed
@@ -590,7 +590,7 @@ describe('App startup routing', () => {
       await new Promise((resolve) => setTimeout(resolve, 0))
     })
 
-    expect(mocks.notifications.takePendingOpenSession).toHaveBeenCalledWith('s-3')
+    expect(mocks.notifications.takePendingOpenSession).toHaveBeenCalledWith(3)
 
     mocks.sessions = [{ id: 's-3' }]
     mocks.sessionPersistence.isReady = true
@@ -602,11 +602,45 @@ describe('App startup routing', () => {
     expect(mocks.openSessionById).not.toHaveBeenCalled()
   })
 
+  it('does not consume a newer same-session click while clearing a deferred target', async () => {
+    let pending: { sessionId: string; token: number } | null = { sessionId: 's-3', token: 1 }
+    mocks.settings.isLoaded = true
+    mocks.sessionPersistence.isReady = false
+    mocks.notifications.peekPendingOpenSession.mockImplementation(async () =>
+      pending ? { ...pending } : null
+    )
+    mocks.notifications.takePendingOpenSession.mockImplementation(async (token: number) => {
+      if (pending?.token !== token) return null
+      const consumed = pending
+      pending = null
+      return consumed
+    })
+
+    await render()
+    await act(async () => {
+      await new Promise((resolve) => setTimeout(resolve, 0))
+    })
+
+    pending = { sessionId: 's-3', token: 2 }
+
+    await act(async () => {
+      const previousNavigation = { ...mocks.navigation }
+      mocks.navigation.userNavigationRevision += 1
+      for (const listener of mocks.navigationListeners) {
+        listener(mocks.navigation, previousNavigation)
+      }
+      await new Promise((resolve) => setTimeout(resolve, 0))
+    })
+
+    expect(mocks.notifications.takePendingOpenSession).toHaveBeenCalledWith(1)
+    expect(pending).toEqual({ sessionId: 's-3', token: 2 })
+  })
+
   it('retains a deferred notification across automatic navigation redirects', async () => {
     mocks.settings.isLoaded = true
     mocks.sessionPersistence.isReady = false
-    mocks.notifications.peekPendingOpenSession.mockResolvedValue({ sessionId: 's-4' })
-    mocks.notifications.takePendingOpenSession.mockResolvedValue({ sessionId: 's-4' })
+    mocks.notifications.peekPendingOpenSession.mockResolvedValue({ sessionId: 's-4', token: 4 })
+    mocks.notifications.takePendingOpenSession.mockResolvedValue({ sessionId: 's-4', token: 4 })
 
     await render()
     await act(async () => {
@@ -631,7 +665,7 @@ describe('App startup routing', () => {
       await new Promise((resolve) => setTimeout(resolve, 0))
     })
 
-    expect(mocks.notifications.takePendingOpenSession).toHaveBeenCalledWith('s-4')
+    expect(mocks.notifications.takePendingOpenSession).toHaveBeenCalledWith(4)
     expect(mocks.openSessionById).toHaveBeenCalledWith('s-4', 'notification')
   })
 })

--- a/src/renderer/src/App.test.tsx
+++ b/src/renderer/src/App.test.tsx
@@ -258,7 +258,8 @@ describe('App startup routing', () => {
     expect(mocks.settings.checkEnvironment).toHaveBeenCalledOnce()
   })
 
-  it('passes session persistence readiness to deep-link navigation', async () => {
+  it('waits for session hydration before enabling deep-link navigation', async () => {
+    mocks.sessionPersistence.isHydrated = false
     mocks.sessionPersistence.isReady = false
 
     await render()
@@ -276,6 +277,7 @@ describe('App startup routing', () => {
     expect(mocks.lifecycleSync).toHaveBeenCalledWith({
       isSessionPersistenceHydrated: true
     })
+    expect(mocks.deepLinkNavigation).toHaveBeenCalledWith(true)
     expect(
       container.querySelector<HTMLElement>('[data-testid="home-page"]')?.dataset.canDeleteProjects
     ).toBe('false')
@@ -424,8 +426,10 @@ describe('App startup routing', () => {
     )
   })
 
-  it('opens the notification-target conversation once session persistence is ready', async () => {
+  it('opens the notification-target conversation once sessions hydrate read-only', async () => {
     mocks.settings.isLoaded = true
+    mocks.sessionPersistence.isHydrated = false
+    mocks.sessionPersistence.isLoading = true
     mocks.sessionPersistence.isReady = false
     mocks.notifications.takePendingOpenSession.mockResolvedValue({ sessionId: 's-9' })
 
@@ -434,8 +438,9 @@ describe('App startup routing', () => {
     // Sessions still hydrating: the pending click target must not be consumed or dropped.
     expect(mocks.openSessionById).not.toHaveBeenCalled()
 
-    // Hydration completes: the target is pulled and the conversation opens.
-    mocks.sessionPersistence.isReady = true
+    // A partial hydration is enough for navigation even though durable writes remain blocked.
+    mocks.sessionPersistence.isHydrated = true
+    mocks.sessionPersistence.isLoading = false
     await act(async () => root.render(<App />))
     await act(async () => {
       await new Promise((resolve) => setTimeout(resolve, 0))
@@ -446,6 +451,7 @@ describe('App startup routing', () => {
 
   it('opens the conversation immediately when a notification nudge arrives hydrated', async () => {
     mocks.settings.isLoaded = true
+    mocks.sessionPersistence.isReady = false
     // The mount-time pull finds nothing; the nudge-triggered pull gets the click target.
     mocks.notifications.takePendingOpenSession
       .mockResolvedValueOnce(null)

--- a/src/renderer/src/App.test.tsx
+++ b/src/renderer/src/App.test.tsx
@@ -6,6 +6,7 @@ import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest'
 const mocks = vi.hoisted(() => {
   // Captures the onOpenSession listener so tests can fire the notification nudge directly.
   const notificationNudgeBox: { current: (() => void) | undefined } = { current: undefined }
+  const navigationListeners = new Set<() => void>()
 
   return {
     settings: {
@@ -22,6 +23,7 @@ const mocks = vi.hoisted(() => {
     },
     skillImport: { enqueue: vi.fn(), dismiss: vi.fn() },
     navigation: { view: 'home' as 'home' | 'workspace' },
+    sessions: [] as Array<{ id: string }>,
     environment: {
       ui: { state: 'idle' },
       init: vi.fn().mockResolvedValue(undefined),
@@ -42,8 +44,10 @@ const mocks = vi.hoisted(() => {
         notificationNudgeBox.current = listener
         return () => undefined
       }),
+      peekPendingOpenSession: vi.fn().mockResolvedValue(null),
       takePendingOpenSession: vi.fn().mockResolvedValue(null)
     },
+    navigationListeners,
     sessionPersistence: {
       isHydrated: true,
       isLoading: false,
@@ -79,8 +83,17 @@ vi.mock('@/stores/navigation-store', () => ({
   useNavigationStore: Object.assign(
     <T,>(selector: (state: typeof mocks.navigation) => T): T => selector(mocks.navigation),
     // Notification navigation reaches the store imperatively (outside React) via getState().
-    { getState: () => ({ openSessionById: mocks.openSessionById }) }
+    {
+      getState: () => ({ openSessionById: mocks.openSessionById }),
+      subscribe: (listener: () => void) => {
+        mocks.navigationListeners.add(listener)
+        return () => mocks.navigationListeners.delete(listener)
+      }
+    }
   )
+}))
+vi.mock('@/stores/session-store', () => ({
+  useSessionStore: { getState: () => ({ sessions: mocks.sessions }) }
 }))
 vi.mock('@/stores/notebook-env-store', () => ({
   useNotebookEnvStore: <T,>(selector: (state: typeof mocks.environment) => T): T =>
@@ -214,7 +227,10 @@ describe('App startup routing', () => {
       }
     } as unknown as Window['api']
     mocks.openSessionById.mockClear()
+    mocks.sessions = []
+    mocks.navigationListeners.clear()
     mocks.notifications.onOpenSession.mockClear()
+    mocks.notifications.peekPendingOpenSession.mockReset().mockResolvedValue(null)
     mocks.notifications.takePendingOpenSession.mockReset().mockResolvedValue(null)
     mocks.notificationNudgeBox.current = undefined
   })
@@ -477,6 +493,7 @@ describe('App startup routing', () => {
     mocks.sessionPersistence.isHydrated = false
     mocks.sessionPersistence.isLoading = true
     mocks.sessionPersistence.isReady = false
+    mocks.notifications.peekPendingOpenSession.mockResolvedValue({ sessionId: 's-9' })
     mocks.notifications.takePendingOpenSession.mockResolvedValue({ sessionId: 's-9' })
 
     await render()
@@ -484,8 +501,8 @@ describe('App startup routing', () => {
     // Sessions still hydrating: the pending click target must not be consumed or dropped.
     expect(mocks.openSessionById).not.toHaveBeenCalled()
 
-    // Partial hydration cannot prove an absent target was deleted, so the destructive take stays
-    // pending in main until a complete retry.
+    // Partial hydration cannot prove an absent target was deleted, so only the non-destructive peek
+    // runs and the target stays pending in main until a complete retry.
     mocks.sessionPersistence.isHydrated = true
     mocks.sessionPersistence.isLoading = false
     await act(async () => root.render(<App />))
@@ -493,40 +510,84 @@ describe('App startup routing', () => {
       await new Promise((resolve) => setTimeout(resolve, 0))
     })
 
+    expect(mocks.notifications.peekPendingOpenSession).toHaveBeenCalled()
     expect(mocks.notifications.takePendingOpenSession).not.toHaveBeenCalled()
     expect(mocks.openSessionById).not.toHaveBeenCalled()
 
+    mocks.sessionPersistence.isHydrated = false
+    mocks.sessionPersistence.isLoading = true
+    await act(async () => root.render(<App />))
+
+    mocks.sessions = [{ id: 's-9' }]
+    mocks.sessionPersistence.isHydrated = true
+    mocks.sessionPersistence.isLoading = false
     mocks.sessionPersistence.isReady = true
     await act(async () => root.render(<App />))
     await act(async () => {
       await new Promise((resolve) => setTimeout(resolve, 0))
     })
 
+    expect(mocks.notifications.takePendingOpenSession).toHaveBeenCalledWith('s-9')
     expect(mocks.openSessionById).toHaveBeenCalledWith('s-9')
   })
 
-  it('does not consume a notification nudge during partial recovery', async () => {
+  it('opens an already-hydrated notification target during partial recovery', async () => {
     mocks.settings.isLoaded = true
     mocks.sessionPersistence.isReady = false
-    mocks.notifications.takePendingOpenSession.mockResolvedValue({ sessionId: 's-3' })
+    mocks.sessions = [{ id: 's-3' }]
 
     await render()
+    await act(async () => {
+      await new Promise((resolve) => setTimeout(resolve, 0))
+    })
 
+    mocks.notifications.peekPendingOpenSession.mockResolvedValue({ sessionId: 's-3' })
+    mocks.notifications.takePendingOpenSession.mockResolvedValue({ sessionId: 's-3' })
     const nudge = mocks.notificationNudgeBox.current
     expect(nudge).toBeDefined()
+
     await act(async () => {
       nudge?.()
+      await new Promise((resolve) => setTimeout(resolve, 0))
+    })
+
+    expect(mocks.notifications.takePendingOpenSession).toHaveBeenCalledWith('s-3')
+    expect(mocks.openSessionById).toHaveBeenCalledWith('s-3')
+  })
+
+  it('discards a deferred notification when the user navigates elsewhere', async () => {
+    let pending: { sessionId: string } | null = { sessionId: 's-3' }
+    mocks.settings.isLoaded = true
+    mocks.sessionPersistence.isReady = false
+    mocks.notifications.peekPendingOpenSession.mockImplementation(async () => pending)
+    mocks.notifications.takePendingOpenSession.mockImplementation(async (sessionId: string) => {
+      if (pending?.sessionId !== sessionId) return null
+      const consumed = pending
+      pending = null
+      return consumed
+    })
+
+    await render()
+    await act(async () => {
+      await new Promise((resolve) => setTimeout(resolve, 0))
     })
 
     expect(mocks.notifications.takePendingOpenSession).not.toHaveBeenCalled()
-    expect(mocks.openSessionById).not.toHaveBeenCalled()
 
+    await act(async () => {
+      for (const listener of mocks.navigationListeners) listener()
+      await new Promise((resolve) => setTimeout(resolve, 0))
+    })
+
+    expect(mocks.notifications.takePendingOpenSession).toHaveBeenCalledWith('s-3')
+
+    mocks.sessions = [{ id: 's-3' }]
     mocks.sessionPersistence.isReady = true
     await act(async () => root.render(<App />))
     await act(async () => {
       await new Promise((resolve) => setTimeout(resolve, 0))
     })
 
-    expect(mocks.openSessionById).toHaveBeenCalledWith('s-3')
+    expect(mocks.openSessionById).not.toHaveBeenCalled()
   })
 })

--- a/src/renderer/src/App.test.tsx
+++ b/src/renderer/src/App.test.tsx
@@ -289,7 +289,13 @@ describe('App startup routing', () => {
   it('shows startup progress until settings have loaded', async () => {
     await render()
 
-    expect(container.querySelector('[data-testid="settings-startup-loading"]')).not.toBeNull()
+    const shell = container.querySelector('[data-testid="settings-startup-loading"]')
+    expect(shell).not.toBeNull()
+    expect(shell?.classList.contains('min-h-svh')).toBe(true)
+    expect(shell?.classList.contains('h-screen')).toBe(false)
+    expect(shell?.classList.contains('bg-background')).toBe(true)
+    expect(shell?.classList.contains('text-foreground')).toBe(true)
+    expect(shell?.classList.contains('text-muted-foreground')).toBe(false)
     expect(container.textContent).toContain('Loading settings')
     expect(mocks.syncWindowFindAppearance).toHaveBeenCalledTimes(1)
   })
@@ -300,9 +306,12 @@ describe('App startup routing', () => {
 
     await render()
 
-    expect(container.querySelector('[role="alert"]')?.textContent).toContain(
-      'settings IPC unavailable'
-    )
+    const shell = container.querySelector('[role="alert"]')
+    expect(shell?.textContent).toContain('settings IPC unavailable')
+    expect(shell?.classList.contains('min-h-svh')).toBe(true)
+    expect(shell?.classList.contains('h-screen')).toBe(false)
+    expect(shell?.classList.contains('text-foreground')).toBe(true)
+    expect(shell?.classList.contains('text-muted-foreground')).toBe(false)
     expect(mocks.settings.checkEnvironment).not.toHaveBeenCalled()
 
     const retry = container.querySelector<HTMLButtonElement>(
@@ -468,9 +477,12 @@ describe('App startup routing', () => {
 
     await render()
 
-    expect(
-      container.querySelector('[data-testid="session-persistence-startup-loading"]')
-    ).not.toBeNull()
+    const shell = container.querySelector('[data-testid="session-persistence-startup-loading"]')
+    expect(shell).not.toBeNull()
+    expect(shell?.classList.contains('min-h-svh')).toBe(true)
+    expect(shell?.classList.contains('h-screen')).toBe(false)
+    expect(shell?.classList.contains('text-foreground')).toBe(true)
+    expect(shell?.classList.contains('text-muted-foreground')).toBe(false)
     expect(container.querySelector('[data-testid="home-page"]')).toBeNull()
   })
 
@@ -501,6 +513,11 @@ describe('App startup routing', () => {
     const alert = container.querySelector('[data-testid="session-persistence-alert"]')
     expect(alert?.textContent).toContain('sessions directory unavailable')
     expect(container.querySelector('[data-testid="home-page"]')).toBeNull()
+    const shell = container.querySelector('[data-testid="session-persistence-startup-error"]')
+    expect(shell?.classList.contains('min-h-svh')).toBe(true)
+    expect(shell?.classList.contains('h-screen')).toBe(false)
+    expect(shell?.classList.contains('text-foreground')).toBe(true)
+    expect(shell?.classList.contains('text-muted-foreground')).toBe(false)
 
     const retry = container.querySelector<HTMLButtonElement>(
       '[data-testid="session-persistence-retry"]'

--- a/src/renderer/src/App.test.tsx
+++ b/src/renderer/src/App.test.tsx
@@ -275,6 +275,9 @@ describe('App startup routing', () => {
       '[data-testid="settings-startup-retry"]'
     )
     expect(retry).not.toBeNull()
+    expect(retry?.dataset.slot).toBe('button')
+    expect(retry?.className).toContain('focus-visible:ring-3')
+    expect(retry?.className).toContain('disabled:pointer-events-none')
     await act(async () => retry?.dispatchEvent(new MouseEvent('click', { bubbles: true })))
 
     expect(mocks.settings.load).toHaveBeenCalledTimes(2)
@@ -313,7 +316,7 @@ describe('App startup routing', () => {
     ).toBe('true')
   })
 
-  it('renders the partial session recovery alert on an opaque surface', async () => {
+  it('renders the partial session recovery alert on an opaque semantic surface', async () => {
     mocks.settings.isLoaded = true
     mocks.sessionPersistence.isHydrated = true
     mocks.sessionPersistence.isReady = false
@@ -323,7 +326,8 @@ describe('App startup routing', () => {
 
     const alert = container.querySelector('[data-testid="session-persistence-alert"]')
     expect(alert).not.toBeNull()
-    expect(alert?.classList.contains('bg-bg-000')).toBe(true)
+    expect(alert?.classList.contains('bg-card')).toBe(true)
+    expect(alert?.classList.contains('bg-bg-000')).toBe(false)
     expect(alert?.classList.contains('bg-bg-100')).toBe(false)
     expect(container.querySelector('[data-testid="home-page"]')).not.toBeNull()
   })
@@ -404,7 +408,12 @@ describe('App startup routing', () => {
     expect(alert?.textContent).toContain('sessions directory unavailable')
     expect(container.querySelector('[data-testid="home-page"]')).toBeNull()
 
-    container.querySelector<HTMLButtonElement>('[data-testid="session-persistence-retry"]')?.click()
+    const retry = container.querySelector<HTMLButtonElement>(
+      '[data-testid="session-persistence-retry"]'
+    )
+    expect(retry?.dataset.slot).toBe('button')
+    expect(retry?.className).toContain('focus-visible:ring-3')
+    retry?.click()
     expect(mocks.sessionPersistence.retryLoad).toHaveBeenCalledOnce()
   })
 

--- a/src/renderer/src/App.test.tsx
+++ b/src/renderer/src/App.test.tsx
@@ -693,6 +693,106 @@ describe('App startup routing', () => {
     expect(mocks.openSessionById).toHaveBeenCalledWith('s-3', 'notification')
   })
 
+  it('does not let a later notification peek override navigation while an earlier peek is pending', async () => {
+    const target = { sessionId: 's-3', token: 3 }
+    let pending: typeof target | null = target
+    let resolveFirstPeek: ((value: typeof target | null) => void) | undefined
+    let peekCount = 0
+    mocks.settings.isLoaded = true
+    mocks.sessionPersistence.isHydrated = false
+    mocks.sessionPersistence.isLoading = true
+    mocks.sessionPersistence.isReady = false
+    mocks.notifications.peekPendingOpenSession.mockImplementation(() => {
+      peekCount += 1
+      if (peekCount === 1) {
+        return new Promise((resolve) => {
+          resolveFirstPeek = resolve
+        })
+      }
+      return Promise.resolve(pending ? { ...pending } : null)
+    })
+    mocks.notifications.takePendingOpenSession.mockImplementation(async (token: number) => {
+      if (pending?.token !== token) return null
+      const consumed = pending
+      pending = null
+      return consumed
+    })
+
+    await render()
+    expect(mocks.notifications.peekPendingOpenSession).toHaveBeenCalledOnce()
+
+    await act(async () => {
+      const previousNavigation = { ...mocks.navigation }
+      mocks.navigation.userNavigationRevision += 1
+      for (const listener of mocks.navigationListeners) {
+        listener(mocks.navigation, previousNavigation)
+      }
+    })
+
+    mocks.sessions = [{ id: target.sessionId }]
+    mocks.sessionPersistence.isHydrated = true
+    mocks.sessionPersistence.isLoading = false
+    mocks.sessionPersistence.isReady = true
+    await act(async () => {
+      root.render(<App />)
+      await Promise.resolve()
+    })
+
+    expect(mocks.openSessionById).not.toHaveBeenCalled()
+
+    await act(async () => resolveFirstPeek?.(target))
+    expect(mocks.openSessionById).not.toHaveBeenCalled()
+  })
+
+  it('runs a queued notification peek after persistence becomes ready', async () => {
+    const target = { sessionId: 's-3', token: 3 }
+    let pending: typeof target | null = target
+    let resolveFirstPeek: ((value: typeof target | null) => void) | undefined
+    let peekCount = 0
+    mocks.settings.isLoaded = true
+    mocks.sessionPersistence.isHydrated = false
+    mocks.sessionPersistence.isLoading = true
+    mocks.sessionPersistence.isReady = false
+    mocks.notifications.peekPendingOpenSession.mockImplementation(() => {
+      peekCount += 1
+      if (peekCount === 1) {
+        return new Promise((resolve) => {
+          resolveFirstPeek = resolve
+        })
+      }
+      return Promise.resolve(pending ? { ...pending } : null)
+    })
+    mocks.notifications.takePendingOpenSession.mockImplementation(async (token: number) => {
+      if (pending?.token !== token) return null
+      const consumed = pending
+      pending = null
+      return consumed
+    })
+
+    await render()
+
+    mocks.sessions = [{ id: target.sessionId }]
+    mocks.sessionPersistence.isHydrated = true
+    mocks.sessionPersistence.isLoading = false
+    mocks.sessionPersistence.isReady = true
+    await act(async () => {
+      root.render(<App />)
+      await Promise.resolve()
+    })
+
+    expect(mocks.notifications.peekPendingOpenSession).toHaveBeenCalledOnce()
+
+    await act(async () => {
+      resolveFirstPeek?.(target)
+      await Promise.resolve()
+      await Promise.resolve()
+    })
+
+    expect(mocks.notifications.peekPendingOpenSession).toHaveBeenCalledTimes(2)
+    expect(mocks.notifications.takePendingOpenSession).toHaveBeenCalledWith(target.token)
+    expect(mocks.openSessionById).toHaveBeenCalledWith(target.sessionId, 'notification')
+  })
+
   it('discards a deferred notification when the user navigates elsewhere', async () => {
     let pending: { sessionId: string; token: number } | null = { sessionId: 's-3', token: 3 }
     mocks.settings.isLoaded = true

--- a/src/renderer/src/App.test.tsx
+++ b/src/renderer/src/App.test.tsx
@@ -29,6 +29,11 @@ const mocks = vi.hoisted(() => {
     },
     loadProjects: vi.fn().mockResolvedValue(undefined),
     deepLinkNavigation: vi.fn(),
+    lifecycleSync: vi.fn(() => ({
+      notice: undefined,
+      dismissNotice: vi.fn(),
+      viewNotice: vi.fn()
+    })),
     initUpdates: vi.fn(),
     openSessionById: vi.fn(),
     notificationNudgeBox,
@@ -40,6 +45,7 @@ const mocks = vi.hoisted(() => {
       takePendingOpenSession: vi.fn().mockResolvedValue(null)
     },
     sessionPersistence: {
+      isHydrated: true,
       isReady: true,
       loadError: undefined as string | undefined,
       loadWarning: undefined as string | undefined,
@@ -63,11 +69,7 @@ vi.mock('@/hooks/useCloseActivePaneShortcut', () => ({
   useCloseActivePaneShortcut: vi.fn()
 }))
 vi.mock('@/hooks/useLifecycleSync', () => ({
-  useLifecycleSync: () => ({
-    notice: undefined,
-    dismissNotice: vi.fn(),
-    viewNotice: vi.fn()
-  })
+  useLifecycleSync: mocks.lifecycleSync
 }))
 vi.mock('@/hooks/useWindowFindAppearanceSync', () => ({
   useWindowFindAppearanceSync: mocks.syncWindowFindAppearance
@@ -127,7 +129,9 @@ vi.mock('@/components/UpdateDialog', () => ({
   UpdateDialog: (): React.JSX.Element => <div data-testid="update-dialog" />
 }))
 vi.mock('@/pages/home/HomePage', () => ({
-  HomePage: (): React.JSX.Element => <div data-testid="home-page" />
+  HomePage: ({ canDeleteProjects }: { canDeleteProjects: boolean }): React.JSX.Element => (
+    <div data-testid="home-page" data-can-delete-projects={String(canDeleteProjects)} />
+  )
 }))
 vi.mock('@/pages/onboarding/OnboardingWizard', () => ({
   OnboardingWizard: (): React.JSX.Element => <div data-testid="onboarding-page" />
@@ -177,12 +181,14 @@ describe('App startup routing', () => {
     mocks.navigation.view = 'home'
     mocks.startupView = 'home'
     mocks.sessionPersistence.isReady = true
+    mocks.sessionPersistence.isHydrated = true
     mocks.sessionPersistence.loadError = undefined
     mocks.sessionPersistence.loadWarning = undefined
     mocks.sessionPersistence.writeError = undefined
     mocks.sessionPersistence.retryLoad.mockClear()
     mocks.sessionPersistence.retryWrites.mockClear()
     mocks.deepLinkNavigation.mockClear()
+    mocks.lifecycleSync.mockClear()
     mocks.syncWindowFindAppearance.mockClear()
     mocks.getInfo.mockResolvedValue({
       dataRoot: '/workspace/OpenScience',
@@ -258,6 +264,21 @@ describe('App startup routing', () => {
     expect(mocks.deepLinkNavigation).toHaveBeenCalledWith(false)
   })
 
+  it('allows lifecycle sync after a partial session load enters read-only recovery', async () => {
+    mocks.settings.isLoaded = true
+    mocks.sessionPersistence.isHydrated = true
+    mocks.sessionPersistence.isReady = false
+
+    await render()
+
+    expect(mocks.lifecycleSync).toHaveBeenCalledWith({
+      isSessionPersistenceHydrated: true
+    })
+    expect(
+      container.querySelector<HTMLElement>('[data-testid="home-page"]')?.dataset.canDeleteProjects
+    ).toBe('false')
+  })
+
   it('routes first-run users to onboarding after settings hydration', async () => {
     mocks.settings.isLoaded = true
     mocks.startupView = 'onboarding'
@@ -286,6 +307,7 @@ describe('App startup routing', () => {
 
   it('surfaces a session load failure with a retry action', async () => {
     mocks.settings.isLoaded = true
+    mocks.sessionPersistence.isHydrated = false
     mocks.sessionPersistence.isReady = false
     mocks.sessionPersistence.loadError = 'sessions directory unavailable'
 
@@ -293,6 +315,7 @@ describe('App startup routing', () => {
 
     const alert = container.querySelector('[data-testid="session-persistence-alert"]')
     expect(alert?.textContent).toContain('sessions directory unavailable')
+    expect(container.querySelector('[data-testid="home-page"]')).toBeNull()
 
     container.querySelector<HTMLButtonElement>('[data-testid="session-persistence-retry"]')?.click()
     expect(mocks.sessionPersistence.retryLoad).toHaveBeenCalledOnce()

--- a/src/renderer/src/App.test.tsx
+++ b/src/renderer/src/App.test.tsx
@@ -382,6 +382,35 @@ describe('App startup routing', () => {
     })
   })
 
+  it('reports retained session content as hidden during retry loading and hard failure', async () => {
+    mocks.settings.isLoaded = true
+    mocks.navigation.view = 'workspace'
+    mocks.sessions = [{ id: 'session-retained' }]
+
+    await render()
+
+    expect(mocks.syncUnreadTaskView).toHaveBeenLastCalledWith({
+      isSessionContentVisible: true
+    })
+
+    mocks.sessionPersistence.isHydrated = false
+    mocks.sessionPersistence.isLoading = true
+    mocks.sessionPersistence.isReady = false
+    await act(async () => root.render(<App />))
+
+    expect(mocks.syncUnreadTaskView).toHaveBeenLastCalledWith({
+      isSessionContentVisible: false
+    })
+
+    mocks.sessionPersistence.isLoading = false
+    mocks.sessionPersistence.loadError = 'saved conversations unavailable'
+    await act(async () => root.render(<App />))
+
+    expect(mocks.syncUnreadTaskView).toHaveBeenLastCalledWith({
+      isSessionContentVisible: false
+    })
+  })
+
   it('routes first-run users to onboarding after settings hydration', async () => {
     mocks.settings.isLoaded = true
     mocks.startupView = 'onboarding'

--- a/src/renderer/src/App.test.tsx
+++ b/src/renderer/src/App.test.tsx
@@ -62,6 +62,7 @@ const mocks = vi.hoisted(() => {
       loadError: undefined as string | undefined,
       loadWarning: undefined as string | undefined,
       writeError: undefined as string | undefined,
+      dismissLoadWarning: vi.fn(),
       retryLoad: vi.fn(),
       retryWrites: vi.fn()
     },
@@ -235,6 +236,7 @@ describe('App startup routing', () => {
     mocks.sessionPersistence.loadError = undefined
     mocks.sessionPersistence.loadWarning = undefined
     mocks.sessionPersistence.writeError = undefined
+    mocks.sessionPersistence.dismissLoadWarning.mockClear()
     mocks.sessionPersistence.retryLoad.mockClear()
     mocks.sessionPersistence.retryWrites.mockClear()
     mocks.settings.pendingApprovals = []
@@ -530,13 +532,17 @@ describe('App startup routing', () => {
 
   it('warns that in-memory conversation changes are not durable and retries them', async () => {
     mocks.settings.isLoaded = true
-    mocks.sessionPersistence.writeError = 'disk full'
+    mocks.sessionPersistence.writeError =
+      'Open Science could not save the latest conversation changes. Retry before closing the app.'
 
     await render()
 
     const alert = container.querySelector('[data-testid="session-persistence-alert"]')
     expect(alert?.textContent).toContain('Conversation storage needs attention')
-    expect(alert?.textContent).toContain('disk full')
+    expect(alert?.textContent).toContain(
+      'Open Science could not save the latest conversation changes. Retry before closing the app.'
+    )
+    expect(alert?.textContent).not.toContain('could not confirm')
 
     container.querySelector<HTMLButtonElement>('[data-testid="session-persistence-retry"]')?.click()
     expect(mocks.sessionPersistence.retryWrites).toHaveBeenCalledOnce()
@@ -554,6 +560,10 @@ describe('App startup routing', () => {
     expect(alert?.textContent).toContain('Saved conversation data was damaged')
     expect(alert?.textContent).toContain('damaged and moved aside')
     expect(container.querySelector('[data-testid="session-persistence-retry"]')).toBeNull()
+    container
+      .querySelector<HTMLButtonElement>('[data-testid="session-persistence-dismiss"]')
+      ?.click()
+    expect(mocks.sessionPersistence.dismissLoadWarning).toHaveBeenCalledOnce()
     expect(container.querySelector('[data-testid="home-page"]')).not.toBeNull()
     expect(
       container.querySelector<HTMLElement>('[data-testid="home-page"]')?.dataset

--- a/src/renderer/src/App.test.tsx
+++ b/src/renderer/src/App.test.tsx
@@ -58,6 +58,7 @@ const mocks = vi.hoisted(() => {
       isLoading: false,
       isReady: true,
       hasCompleteSessionCatalog: true,
+      canDeleteSessionsAndProjects: true,
       loadError: undefined as string | undefined,
       loadWarning: undefined as string | undefined,
       writeError: undefined as string | undefined,
@@ -192,11 +193,17 @@ vi.mock('@/pages/workspace/EnvStatusBanner', () => ({
 }))
 vi.mock('@/pages/workspace/WorkspacePage', () => ({
   WorkspacePage: ({
-    isSessionPersistenceReady
+    isSessionPersistenceReady,
+    canDeleteConversations
   }: {
     isSessionPersistenceReady: boolean
+    canDeleteConversations: boolean
   }): React.JSX.Element => (
-    <div data-testid="workspace-page">{String(isSessionPersistenceReady)}</div>
+    <div
+      data-testid="workspace-page"
+      data-ready={String(isSessionPersistenceReady)}
+      data-can-delete-conversations={String(canDeleteConversations)}
+    />
   )
 }))
 
@@ -224,6 +231,7 @@ describe('App startup routing', () => {
     mocks.sessionPersistence.isHydrated = true
     mocks.sessionPersistence.isLoading = false
     mocks.sessionPersistence.hasCompleteSessionCatalog = true
+    mocks.sessionPersistence.canDeleteSessionsAndProjects = true
     mocks.sessionPersistence.loadError = undefined
     mocks.sessionPersistence.loadWarning = undefined
     mocks.sessionPersistence.writeError = undefined
@@ -328,6 +336,7 @@ describe('App startup routing', () => {
     mocks.sessionPersistence.isHydrated = true
     mocks.sessionPersistence.isReady = false
     mocks.sessionPersistence.hasCompleteSessionCatalog = false
+    mocks.sessionPersistence.canDeleteSessionsAndProjects = true
 
     await render()
 
@@ -344,6 +353,19 @@ describe('App startup routing', () => {
     expect(
       container.querySelector<HTMLElement>('[data-testid="home-page"]')?.dataset
         .hasCompleteSessionCatalog
+    ).toBe('false')
+  })
+
+  it('disables deletion when Project deletion recovery is incomplete', async () => {
+    mocks.settings.isLoaded = true
+    mocks.sessionPersistence.isHydrated = true
+    mocks.sessionPersistence.isReady = false
+    mocks.sessionPersistence.canDeleteSessionsAndProjects = false
+
+    await render()
+
+    expect(
+      container.querySelector<HTMLElement>('[data-testid="home-page"]')?.dataset.canDeleteProjects
     ).toBe('false')
   })
 
@@ -575,7 +597,13 @@ describe('App startup routing', () => {
 
     await render()
 
-    expect(container.querySelector('[data-testid="workspace-page"]')?.textContent).toBe('true')
+    expect(
+      container.querySelector<HTMLElement>('[data-testid="workspace-page"]')?.dataset.ready
+    ).toBe('true')
+    expect(
+      container.querySelector<HTMLElement>('[data-testid="workspace-page"]')?.dataset
+        .canDeleteConversations
+    ).toBe('true')
     expect(container.querySelector('[data-testid="missing-root"]')?.textContent).toBe(
       '/Volumes/Science/OpenScience'
     )

--- a/src/renderer/src/App.tsx
+++ b/src/renderer/src/App.tsx
@@ -158,10 +158,14 @@ const App = (): React.JSX.Element | null => {
   // inline job rows. Updates are applied globally — the store filters by sessionId at query time.
   useEffect(() => window.api.compute.onJobUpdated(applyJobUpdate), [applyJobUpdate])
 
-  // Load the project list once on startup so Home can render immediately after hydration.
+  // Load projects after each completed startup hydration pass. A retry temporarily clears Session
+  // hydration, so its successful completion re-runs this effect and clears any project-list error
+  // left by the same transient storage outage.
   useEffect(() => {
+    if (!isSettingsLoaded || !isSessionPersistenceHydrated || isSessionPersistenceLoading) return
+
     void loadProjects()
-  }, [loadProjects])
+  }, [isSessionPersistenceHydrated, isSessionPersistenceLoading, isSettingsLoaded, loadProjects])
 
   // Hydrate the persisted framework before checking it. Running these concurrently can make a
   // Codex/OpenCode result look stale against the renderer's initial Claude selection and discard the

--- a/src/renderer/src/App.tsx
+++ b/src/renderer/src/App.tsx
@@ -79,6 +79,7 @@ const App = (): React.JSX.Element | null => {
     { currentDataRoot: string; defaultParent: string } | undefined
   >(undefined)
   const deferredNotification = useRef<OpenSessionFromNotificationRequest | undefined>(undefined)
+  const pendingNotificationOpenQueue = useRef<Promise<void>>(Promise.resolve())
   const [isCloseConfirmOpen, setIsCloseConfirmOpen] = useState(false)
   const startupView = isSettingsLoaded
     ? resolveStartupView({ onboardingDone: onboardingCompletedAt !== undefined })
@@ -157,45 +158,56 @@ const App = (): React.JSX.Element | null => {
   // Clicking a desktop notification opens the conversation the finished/failed task belongs to.
   // Main retains the target until this renderer confirms that the inspected session can be opened,
   // so a click that recreates the window or lands during partial recovery is not lost.
-  const openPendingNotificationSession = useCallback(async (): Promise<void> => {
+  const openPendingNotificationSession = useCallback((): Promise<void> => {
     const userNavigationRevision = useNavigationStore.getState().userNavigationRevision
-    const pending = await window.api.notifications.peekPendingOpenSession()
+    const attempt = async (): Promise<void> => {
+      const pending = await window.api.notifications.peekPendingOpenSession()
 
-    if (!pending) return
+      if (!pending) return
 
-    const sessionExists =
-      isSessionPersistenceHydrated &&
-      useSessionStore.getState().sessions.some((session) => session.id === pending.sessionId)
+      const sessionExists =
+        isSessionPersistenceHydrated &&
+        useSessionStore.getState().sessions.some((session) => session.id === pending.sessionId)
 
-    if (!sessionExists && !isSessionPersistenceReady) {
-      if (useNavigationStore.getState().userNavigationRevision === userNavigationRevision) {
-        const deferred = deferredNotification.current
-        if (!deferred || pending.token > deferred.token) deferredNotification.current = pending
-      } else {
-        // The user navigated while the peek was in flight. Drop only the stale target we saw; a
-        // newer notification that replaced it remains pending in main.
-        await window.api.notifications.takePendingOpenSession(pending.token)
+      if (!sessionExists && !isSessionPersistenceReady) {
+        if (useNavigationStore.getState().userNavigationRevision === userNavigationRevision) {
+          const deferred = deferredNotification.current
+          if (!deferred || pending.token > deferred.token) deferredNotification.current = pending
+        } else {
+          // The user navigated while the peek was in flight. Drop only the stale target we saw; a
+          // newer notification that replaced it remains pending in main.
+          await window.api.notifications.takePendingOpenSession(pending.token)
+        }
+        return
       }
-      return
+
+      const consumed = await window.api.notifications.takePendingOpenSession(pending.token)
+
+      if (!consumed) return
+
+      if (deferredNotification.current?.token === consumed.token) {
+        deferredNotification.current = undefined
+      }
+
+      // A navigation after this attempt began takes precedence over the older notification click.
+      if (
+        !sessionExists ||
+        useNavigationStore.getState().userNavigationRevision !== userNavigationRevision
+      ) {
+        return
+      }
+
+      useNavigationStore.getState().openSessionById(consumed.sessionId, 'notification')
     }
 
-    const consumed = await window.api.notifications.takePendingOpenSession(pending.token)
-
-    if (!consumed) return
-
-    if (deferredNotification.current?.token === consumed.token) {
-      deferredNotification.current = undefined
-    }
-
-    // A navigation after this attempt began takes precedence over the older notification click.
-    if (
-      !sessionExists ||
-      useNavigationStore.getState().userNavigationRevision !== userNavigationRevision
-    ) {
-      return
-    }
-
-    useNavigationStore.getState().openSessionById(consumed.sessionId, 'notification')
+    // Dependency changes and push nudges can request the same pending target concurrently. Serialize
+    // peeks so the earliest attempt's navigation revision decides whether that token is still valid;
+    // a later attempt then observes the consume-once result instead of reviving stale intent.
+    pendingNotificationOpenQueue.current = pendingNotificationOpenQueue.current.then(
+      attempt,
+      attempt
+    )
+    return pendingNotificationOpenQueue.current
   }, [isSessionPersistenceHydrated, isSessionPersistenceReady])
 
   // If a missing target is waiting for a persistence retry, explicit navigation transfers control

--- a/src/renderer/src/App.tsx
+++ b/src/renderer/src/App.tsx
@@ -1,5 +1,7 @@
 import { useCallback, useEffect, useRef, useState } from 'react'
 
+import type { OpenSessionFromNotificationRequest } from '../../shared/notifications'
+
 import { useDeepLinkNavigation } from '@/lib/deep-link'
 import { useSessionPersistence } from '@/lib/session-persistence/session-persistence'
 import { CloseConfirmModal } from '@/components/CloseConfirmModal'
@@ -70,7 +72,7 @@ const App = (): React.JSX.Element | null => {
   const [legacyMove, setLegacyMove] = useState<
     { currentDataRoot: string; defaultParent: string } | undefined
   >(undefined)
-  const deferredNotificationSessionId = useRef<string | undefined>(undefined)
+  const deferredNotification = useRef<OpenSessionFromNotificationRequest | undefined>(undefined)
 
   const retrySettingsInitialization = useCallback(async (): Promise<void> => {
     if (await loadSettings({ force: true })) await checkEnvironment()
@@ -131,10 +133,7 @@ const App = (): React.JSX.Element | null => {
     const userNavigationRevision = useNavigationStore.getState().userNavigationRevision
     const pending = await window.api.notifications.peekPendingOpenSession()
 
-    if (!pending) {
-      deferredNotificationSessionId.current = undefined
-      return
-    }
+    if (!pending) return
 
     const sessionExists =
       isSessionPersistenceHydrated &&
@@ -142,20 +141,23 @@ const App = (): React.JSX.Element | null => {
 
     if (!sessionExists && !isSessionPersistenceReady) {
       if (useNavigationStore.getState().userNavigationRevision === userNavigationRevision) {
-        deferredNotificationSessionId.current = pending.sessionId
+        const deferred = deferredNotification.current
+        if (!deferred || pending.token > deferred.token) deferredNotification.current = pending
       } else {
         // The user navigated while the peek was in flight. Drop only the stale target we saw; a
         // newer notification that replaced it remains pending in main.
-        await window.api.notifications.takePendingOpenSession(pending.sessionId)
+        await window.api.notifications.takePendingOpenSession(pending.token)
       }
       return
     }
 
-    const consumed = await window.api.notifications.takePendingOpenSession(pending.sessionId)
+    const consumed = await window.api.notifications.takePendingOpenSession(pending.token)
 
     if (!consumed) return
 
-    deferredNotificationSessionId.current = undefined
+    if (deferredNotification.current?.token === consumed.token) {
+      deferredNotification.current = undefined
+    }
 
     // A navigation after this attempt began takes precedence over the older notification click.
     if (
@@ -175,12 +177,12 @@ const App = (): React.JSX.Element | null => {
       useNavigationStore.subscribe((state, previousState) => {
         if (state.userNavigationRevision === previousState.userNavigationRevision) return
 
-        const deferredSessionId = deferredNotificationSessionId.current
+        const deferred = deferredNotification.current
 
-        if (!deferredSessionId) return
+        if (!deferred) return
 
-        deferredNotificationSessionId.current = undefined
-        void window.api.notifications.takePendingOpenSession(deferredSessionId)
+        deferredNotification.current = undefined
+        void window.api.notifications.takePendingOpenSession(deferred.token)
       }),
     []
   )

--- a/src/renderer/src/App.tsx
+++ b/src/renderer/src/App.tsx
@@ -36,7 +36,7 @@ const App = (): React.JSX.Element | null => {
   const isSessionPersistenceLoading = sessionPersistence.isLoading
   const isSessionPersistenceReady = sessionPersistence.isReady
   const lifecycleSync = useLifecycleSync({ isSessionPersistenceHydrated })
-  useDeepLinkNavigation(isSessionPersistenceReady)
+  useDeepLinkNavigation(isSessionPersistenceHydrated)
   const view = useNavigationStore((state) => state.view)
   // Cmd+W / Ctrl+W closes the open preview panel before it closes the window.
   useCloseActivePaneShortcut()
@@ -129,20 +129,20 @@ const App = (): React.JSX.Element | null => {
   }, [])
 
   // Fast path: a click while this renderer is alive arrives as a nudge; pull the target. A click
-  // mid-hydration is left pending and consumed by the effect below once sessions are ready.
+  // mid-hydration is left pending and consumed by the effect below once sessions are hydrated.
   useEffect(
     () =>
       window.api.notifications.onOpenSession(() => {
-        if (isSessionPersistenceReady) void openPendingNotificationSession()
+        if (isSessionPersistenceHydrated) void openPendingNotificationSession()
       }),
-    [isSessionPersistenceReady, openPendingNotificationSession]
+    [isSessionPersistenceHydrated, openPendingNotificationSession]
   )
 
   // Slow path: the click recreated the window before this listener existed. Consume the pending
   // target as soon as session persistence has hydrated the store.
   useEffect(() => {
-    if (isSessionPersistenceReady) void openPendingNotificationSession()
-  }, [isSessionPersistenceReady, openPendingNotificationSession])
+    if (isSessionPersistenceHydrated) void openPendingNotificationSession()
+  }, [isSessionPersistenceHydrated, openPendingNotificationSession])
 
   // Subscribe once to compute approval requests. The card must be answered before the SSH call runs.
   useEffect(

--- a/src/renderer/src/App.tsx
+++ b/src/renderer/src/App.tsx
@@ -165,7 +165,7 @@ const App = (): React.JSX.Element | null => {
       return
     }
 
-    useNavigationStore.getState().openSessionById(consumed.sessionId, 'automatic')
+    useNavigationStore.getState().openSessionById(consumed.sessionId, 'notification')
   }, [isSessionPersistenceHydrated, isSessionPersistenceReady])
 
   // If a missing target is waiting for a persistence retry, explicit navigation transfers control

--- a/src/renderer/src/App.tsx
+++ b/src/renderer/src/App.tsx
@@ -363,7 +363,7 @@ const App = (): React.JSX.Element | null => {
       ) : sessionPersistence.writeError ? (
         <SessionPersistenceAlert
           title="Conversation storage needs attention"
-          message={`${sessionPersistence.writeError} Open Science could not confirm that the latest changes were fully saved. Retry before closing the app.`}
+          message={sessionPersistence.writeError}
           onRetry={sessionPersistence.retryWrites}
         />
       ) : sessionPersistence.loadWarning ? (
@@ -371,6 +371,7 @@ const App = (): React.JSX.Element | null => {
           title="Saved conversation data was damaged"
           message={sessionPersistence.loadWarning}
           variant="warning"
+          onDismiss={sessionPersistence.dismissLoadWarning}
         />
       ) : null}
       {view === 'home' ? (

--- a/src/renderer/src/App.tsx
+++ b/src/renderer/src/App.tsx
@@ -36,7 +36,10 @@ const App = (): React.JSX.Element | null => {
   const isSessionPersistenceLoading = sessionPersistence.isLoading
   const isSessionPersistenceReady = sessionPersistence.isReady
   const lifecycleSync = useLifecycleSync({ isSessionPersistenceHydrated })
-  useDeepLinkNavigation(isSessionPersistenceHydrated)
+  useDeepLinkNavigation({
+    isHydrated: isSessionPersistenceHydrated,
+    isReady: isSessionPersistenceReady
+  })
   const view = useNavigationStore((state) => state.view)
   // Cmd+W / Ctrl+W closes the open preview panel before it closes the window.
   useCloseActivePaneShortcut()
@@ -129,20 +132,21 @@ const App = (): React.JSX.Element | null => {
   }, [])
 
   // Fast path: a click while this renderer is alive arrives as a nudge; pull the target. A click
-  // mid-hydration is left pending and consumed by the effect below once sessions are hydrated.
+  // mid-recovery is left pending and consumed by the effect below once the full scan can distinguish
+  // an omitted target from one that no longer exists.
   useEffect(
     () =>
       window.api.notifications.onOpenSession(() => {
-        if (isSessionPersistenceHydrated) void openPendingNotificationSession()
+        if (isSessionPersistenceReady) void openPendingNotificationSession()
       }),
-    [isSessionPersistenceHydrated, openPendingNotificationSession]
+    [isSessionPersistenceReady, openPendingNotificationSession]
   )
 
   // Slow path: the click recreated the window before this listener existed. Consume the pending
-  // target as soon as session persistence has hydrated the store.
+  // target only after session persistence has a complete store snapshot.
   useEffect(() => {
-    if (isSessionPersistenceHydrated) void openPendingNotificationSession()
-  }, [isSessionPersistenceHydrated, openPendingNotificationSession])
+    if (isSessionPersistenceReady) void openPendingNotificationSession()
+  }, [isSessionPersistenceReady, openPendingNotificationSession])
 
   // Subscribe once to compute approval requests. The card must be answered before the SSH call runs.
   useEffect(

--- a/src/renderer/src/App.tsx
+++ b/src/renderer/src/App.tsx
@@ -32,8 +32,9 @@ import { useUpdateStore } from '@/stores/update-store'
 const App = (): React.JSX.Element | null => {
   // Persistence is started once at the top so sessions stay loaded for both Home and Workspace.
   const sessionPersistence = useSessionPersistence()
+  const isSessionPersistenceHydrated = sessionPersistence.isHydrated
   const isSessionPersistenceReady = sessionPersistence.isReady
-  const lifecycleSync = useLifecycleSync({ isSessionPersistenceReady })
+  const lifecycleSync = useLifecycleSync({ isSessionPersistenceHydrated })
   useDeepLinkNavigation(isSessionPersistenceReady)
   const view = useNavigationStore((state) => state.view)
   // Cmd+W / Ctrl+W closes the open preview panel before it closes the window.
@@ -216,6 +217,24 @@ const App = (): React.JSX.Element | null => {
     return <OnboardingWizard />
   }
 
+  // A hard load failure leaves no trustworthy session snapshot. Keep the interactive surfaces
+  // closed until retry succeeds; partial loads set isHydrated and use the read-only alert below.
+  if (!isSessionPersistenceHydrated && sessionPersistence.loadError) {
+    return (
+      <main
+        data-testid="session-persistence-startup-error"
+        className="flex h-screen items-center justify-center bg-bg-10 p-6 text-text-100"
+      >
+        <SessionPersistenceAlert
+          title="Saved conversations could not be loaded"
+          message={sessionPersistence.loadError}
+          inline
+          onRetry={sessionPersistence.retryLoad}
+        />
+      </main>
+    )
+  }
+
   return (
     <>
       <EnvStatusBanner ui={envUi} onRetry={() => void retryEnv()} />
@@ -239,7 +258,7 @@ const App = (): React.JSX.Element | null => {
         />
       ) : null}
       {view === 'home' ? (
-        <HomePage />
+        <HomePage canDeleteProjects={isSessionPersistenceReady} />
       ) : (
         <WorkspacePage isSessionPersistenceReady={isSessionPersistenceReady} />
       )}

--- a/src/renderer/src/App.tsx
+++ b/src/renderer/src/App.tsx
@@ -34,6 +34,11 @@ import { useSessionJobStore } from '@/stores/session-job-store'
 import { useSkillImportStore } from '@/stores/skill-import-store'
 import { useUpdateStore } from '@/stores/update-store'
 
+type NotificationOpenIntent = {
+  generation: number
+  userNavigationRevision: number
+}
+
 const App = (): React.JSX.Element | null => {
   // Persistence is started once at the top so sessions stay loaded for both Home and Workspace.
   const sessionPersistence = useSessionPersistence()
@@ -80,6 +85,10 @@ const App = (): React.JSX.Element | null => {
   >(undefined)
   const deferredNotification = useRef<OpenSessionFromNotificationRequest | undefined>(undefined)
   const pendingNotificationOpenQueue = useRef<Promise<void>>(Promise.resolve())
+  const notificationOpenIntent = useRef<NotificationOpenIntent>({
+    generation: 0,
+    userNavigationRevision: useNavigationStore.getState().userNavigationRevision
+  })
   const [isCloseConfirmOpen, setIsCloseConfirmOpen] = useState(false)
   const startupView = isSettingsLoaded
     ? resolveStartupView({ onboardingDone: onboardingCompletedAt !== undefined })
@@ -158,57 +167,67 @@ const App = (): React.JSX.Element | null => {
   // Clicking a desktop notification opens the conversation the finished/failed task belongs to.
   // Main retains the target until this renderer confirms that the inspected session can be opened,
   // so a click that recreates the window or lands during partial recovery is not lost.
-  const openPendingNotificationSession = useCallback((): Promise<void> => {
-    const userNavigationRevision = useNavigationStore.getState().userNavigationRevision
-    const attempt = async (): Promise<void> => {
-      const pending = await window.api.notifications.peekPendingOpenSession()
+  const openPendingNotificationSession = useCallback(
+    (intent: NotificationOpenIntent = notificationOpenIntent.current): Promise<void> => {
+      const attempt = async (): Promise<void> => {
+        // A newer click owns the main-process token. Let its queued attempt observe it instead of
+        // allowing older recovery work to consume or discard that newer intent.
+        if (intent.generation !== notificationOpenIntent.current.generation) return
 
-      if (!pending) return
+        const pending = await window.api.notifications.peekPendingOpenSession()
 
-      const sessionExists =
-        isSessionPersistenceHydrated &&
-        useSessionStore.getState().sessions.some((session) => session.id === pending.sessionId)
+        if (!pending) return
+        if (intent.generation !== notificationOpenIntent.current.generation) return
 
-      if (!sessionExists && !isSessionPersistenceReady) {
-        if (useNavigationStore.getState().userNavigationRevision === userNavigationRevision) {
-          const deferred = deferredNotification.current
-          if (!deferred || pending.token > deferred.token) deferredNotification.current = pending
-        } else {
-          // The user navigated while the peek was in flight. Drop only the stale target we saw; a
-          // newer notification that replaced it remains pending in main.
-          await window.api.notifications.takePendingOpenSession(pending.token)
+        const sessionExists =
+          isSessionPersistenceHydrated &&
+          useSessionStore.getState().sessions.some((session) => session.id === pending.sessionId)
+
+        if (!sessionExists && !isSessionPersistenceReady) {
+          if (
+            useNavigationStore.getState().userNavigationRevision === intent.userNavigationRevision
+          ) {
+            const deferred = deferredNotification.current
+            if (!deferred || pending.token > deferred.token) deferredNotification.current = pending
+          } else {
+            // The user navigated while the peek was in flight. Drop only the stale target we saw; a
+            // newer notification that replaced it remains pending in main.
+            await window.api.notifications.takePendingOpenSession(pending.token)
+          }
+          return
         }
-        return
+
+        const consumed = await window.api.notifications.takePendingOpenSession(pending.token)
+
+        if (!consumed) return
+
+        if (deferredNotification.current?.token === consumed.token) {
+          deferredNotification.current = undefined
+        }
+
+        // A navigation after this attempt began takes precedence over the older notification click.
+        if (
+          intent.generation !== notificationOpenIntent.current.generation ||
+          !sessionExists ||
+          useNavigationStore.getState().userNavigationRevision !== intent.userNavigationRevision
+        ) {
+          return
+        }
+
+        useNavigationStore.getState().openSessionById(consumed.sessionId, 'notification')
       }
 
-      const consumed = await window.api.notifications.takePendingOpenSession(pending.token)
-
-      if (!consumed) return
-
-      if (deferredNotification.current?.token === consumed.token) {
-        deferredNotification.current = undefined
-      }
-
-      // A navigation after this attempt began takes precedence over the older notification click.
-      if (
-        !sessionExists ||
-        useNavigationStore.getState().userNavigationRevision !== userNavigationRevision
-      ) {
-        return
-      }
-
-      useNavigationStore.getState().openSessionById(consumed.sessionId, 'notification')
-    }
-
-    // Dependency changes and push nudges can request the same pending target concurrently. Serialize
-    // peeks so the earliest attempt's navigation revision decides whether that token is still valid;
-    // a later attempt then observes the consume-once result instead of reviving stale intent.
-    pendingNotificationOpenQueue.current = pendingNotificationOpenQueue.current.then(
-      attempt,
-      attempt
-    )
-    return pendingNotificationOpenQueue.current
-  }, [isSessionPersistenceHydrated, isSessionPersistenceReady])
+      // Dependency changes and push nudges can request the same pending target concurrently. Serialize
+      // peeks, keep each attempt paired with the navigation state of its causal click, and let a newer
+      // click generation supersede older queued recovery work.
+      pendingNotificationOpenQueue.current = pendingNotificationOpenQueue.current.then(
+        attempt,
+        attempt
+      )
+      return pendingNotificationOpenQueue.current
+    },
+    [isSessionPersistenceHydrated, isSessionPersistenceReady]
+  )
 
   // If a missing target is waiting for a persistence retry, explicit navigation transfers control
   // to the user. Conditionally consume that old target so recovery cannot yank them back later.
@@ -232,7 +251,12 @@ const App = (): React.JSX.Element | null => {
   useEffect(
     () =>
       window.api.notifications.onOpenSession(() => {
-        void openPendingNotificationSession()
+        const intent = {
+          generation: notificationOpenIntent.current.generation + 1,
+          userNavigationRevision: useNavigationStore.getState().userNavigationRevision
+        }
+        notificationOpenIntent.current = intent
+        void openPendingNotificationSession(intent)
       }),
     [openPendingNotificationSession]
   )

--- a/src/renderer/src/App.tsx
+++ b/src/renderer/src/App.tsx
@@ -71,7 +71,7 @@ const App = (): React.JSX.Element | null => {
   >(undefined)
 
   const retrySettingsInitialization = useCallback(async (): Promise<void> => {
-    if (await loadSettings()) await checkEnvironment()
+    if (await loadSettings({ force: true })) await checkEnvironment()
   }, [checkEnvironment, loadSettings])
 
   // Load app info and subscribe to update-status broadcasts once at startup.

--- a/src/renderer/src/App.tsx
+++ b/src/renderer/src/App.tsx
@@ -71,8 +71,6 @@ const App = (): React.JSX.Element | null => {
     { currentDataRoot: string; defaultParent: string } | undefined
   >(undefined)
   const deferredNotificationSessionId = useRef<string | undefined>(undefined)
-  const notificationNavigationGeneration = useRef(0)
-  const isOpeningNotificationSession = useRef(false)
 
   const retrySettingsInitialization = useCallback(async (): Promise<void> => {
     if (await loadSettings({ force: true })) await checkEnvironment()
@@ -130,7 +128,7 @@ const App = (): React.JSX.Element | null => {
   // Main retains the target until this renderer confirms that the inspected session can be opened,
   // so a click that recreates the window or lands during partial recovery is not lost.
   const openPendingNotificationSession = useCallback(async (): Promise<void> => {
-    const navigationGeneration = notificationNavigationGeneration.current
+    const userNavigationRevision = useNavigationStore.getState().userNavigationRevision
     const pending = await window.api.notifications.peekPendingOpenSession()
 
     if (!pending) {
@@ -143,7 +141,7 @@ const App = (): React.JSX.Element | null => {
       useSessionStore.getState().sessions.some((session) => session.id === pending.sessionId)
 
     if (!sessionExists && !isSessionPersistenceReady) {
-      if (notificationNavigationGeneration.current === navigationGeneration) {
+      if (useNavigationStore.getState().userNavigationRevision === userNavigationRevision) {
         deferredNotificationSessionId.current = pending.sessionId
       } else {
         // The user navigated while the peek was in flight. Drop only the stale target we saw; a
@@ -160,26 +158,23 @@ const App = (): React.JSX.Element | null => {
     deferredNotificationSessionId.current = undefined
 
     // A navigation after this attempt began takes precedence over the older notification click.
-    if (!sessionExists || notificationNavigationGeneration.current !== navigationGeneration) {
+    if (
+      !sessionExists ||
+      useNavigationStore.getState().userNavigationRevision !== userNavigationRevision
+    ) {
       return
     }
 
-    isOpeningNotificationSession.current = true
-    try {
-      useNavigationStore.getState().openSessionById(consumed.sessionId)
-    } finally {
-      isOpeningNotificationSession.current = false
-    }
+    useNavigationStore.getState().openSessionById(consumed.sessionId, 'automatic')
   }, [isSessionPersistenceHydrated, isSessionPersistenceReady])
 
   // If a missing target is waiting for a persistence retry, explicit navigation transfers control
   // to the user. Conditionally consume that old target so recovery cannot yank them back later.
   useEffect(
     () =>
-      useNavigationStore.subscribe(() => {
-        if (isOpeningNotificationSession.current) return
+      useNavigationStore.subscribe((state, previousState) => {
+        if (state.userNavigationRevision === previousState.userNavigationRevision) return
 
-        notificationNavigationGeneration.current += 1
         const deferredSessionId = deferredNotificationSessionId.current
 
         if (!deferredSessionId) return

--- a/src/renderer/src/App.tsx
+++ b/src/renderer/src/App.tsx
@@ -363,13 +363,14 @@ const App = (): React.JSX.Element | null => {
       ) : null}
       {view === 'home' ? (
         <HomePage
-          canDeleteProjects={isSessionPersistenceHydrated}
+          canDeleteProjects={sessionPersistence.canDeleteSessionsAndProjects}
           hasCompleteSessionCatalog={sessionPersistence.hasCompleteSessionCatalog}
         />
       ) : (
         <WorkspacePage
           isSessionPersistenceHydrated={isSessionPersistenceHydrated}
           isSessionPersistenceReady={isSessionPersistenceReady}
+          canDeleteConversations={sessionPersistence.canDeleteSessionsAndProjects}
         />
       )}
       <SettingsPage open={isSettingsOpen} onClose={closeSettings} />

--- a/src/renderer/src/App.tsx
+++ b/src/renderer/src/App.tsx
@@ -1,4 +1,4 @@
-import { useCallback, useEffect, useState } from 'react'
+import { useCallback, useEffect, useRef, useState } from 'react'
 
 import { useDeepLinkNavigation } from '@/lib/deep-link'
 import { useSessionPersistence } from '@/lib/session-persistence/session-persistence'
@@ -24,6 +24,7 @@ import { useNavigationStore } from '@/stores/navigation-store'
 import { useNotebookEnvStore } from '@/stores/notebook-env-store'
 import { useProjectStore } from '@/stores/project-store'
 import { useSettingsStore } from '@/stores/settings-store'
+import { useSessionStore } from '@/stores/session-store'
 import { useComputeStore } from '@/stores/compute-store'
 import { useSessionJobStore } from '@/stores/session-job-store'
 import { useSkillImportStore } from '@/stores/skill-import-store'
@@ -69,6 +70,9 @@ const App = (): React.JSX.Element | null => {
   const [legacyMove, setLegacyMove] = useState<
     { currentDataRoot: string; defaultParent: string } | undefined
   >(undefined)
+  const deferredNotificationSessionId = useRef<string | undefined>(undefined)
+  const notificationNavigationGeneration = useRef(0)
+  const isOpeningNotificationSession = useRef(false)
 
   const retrySettingsInitialization = useCallback(async (): Promise<void> => {
     if (await loadSettings({ force: true })) await checkEnvironment()
@@ -123,30 +127,85 @@ const App = (): React.JSX.Element | null => {
   }, [])
 
   // Clicking a desktop notification opens the conversation the finished/failed task belongs to.
-  // Main holds the target until it is pulled here, so a click that recreates the window (listener
-  // not yet registered, sessions not yet hydrated) cannot lose the navigation.
+  // Main retains the target until this renderer confirms that the inspected session can be opened,
+  // so a click that recreates the window or lands during partial recovery is not lost.
   const openPendingNotificationSession = useCallback(async (): Promise<void> => {
-    const pending = await window.api.notifications.takePendingOpenSession()
+    const navigationGeneration = notificationNavigationGeneration.current
+    const pending = await window.api.notifications.peekPendingOpenSession()
 
-    if (pending) useNavigationStore.getState().openSessionById(pending.sessionId)
-  }, [])
+    if (!pending) {
+      deferredNotificationSessionId.current = undefined
+      return
+    }
 
-  // Fast path: a click while this renderer is alive arrives as a nudge; pull the target. A click
-  // mid-recovery is left pending and consumed by the effect below once the full scan can distinguish
-  // an omitted target from one that no longer exists.
+    const sessionExists =
+      isSessionPersistenceHydrated &&
+      useSessionStore.getState().sessions.some((session) => session.id === pending.sessionId)
+
+    if (!sessionExists && !isSessionPersistenceReady) {
+      if (notificationNavigationGeneration.current === navigationGeneration) {
+        deferredNotificationSessionId.current = pending.sessionId
+      } else {
+        // The user navigated while the peek was in flight. Drop only the stale target we saw; a
+        // newer notification that replaced it remains pending in main.
+        await window.api.notifications.takePendingOpenSession(pending.sessionId)
+      }
+      return
+    }
+
+    const consumed = await window.api.notifications.takePendingOpenSession(pending.sessionId)
+
+    if (!consumed) return
+
+    deferredNotificationSessionId.current = undefined
+
+    // A navigation after this attempt began takes precedence over the older notification click.
+    if (!sessionExists || notificationNavigationGeneration.current !== navigationGeneration) {
+      return
+    }
+
+    isOpeningNotificationSession.current = true
+    try {
+      useNavigationStore.getState().openSessionById(consumed.sessionId)
+    } finally {
+      isOpeningNotificationSession.current = false
+    }
+  }, [isSessionPersistenceHydrated, isSessionPersistenceReady])
+
+  // If a missing target is waiting for a persistence retry, explicit navigation transfers control
+  // to the user. Conditionally consume that old target so recovery cannot yank them back later.
+  useEffect(
+    () =>
+      useNavigationStore.subscribe(() => {
+        if (isOpeningNotificationSession.current) return
+
+        notificationNavigationGeneration.current += 1
+        const deferredSessionId = deferredNotificationSessionId.current
+
+        if (!deferredSessionId) return
+
+        deferredNotificationSessionId.current = undefined
+        void window.api.notifications.takePendingOpenSession(deferredSessionId)
+      }),
+    []
+  )
+
+  // Fast path: a click while this renderer is alive arrives as a nudge. Already-hydrated targets
+  // open during partial recovery; unresolved ones remain pending for the retry path below.
   useEffect(
     () =>
       window.api.notifications.onOpenSession(() => {
-        if (isSessionPersistenceReady) void openPendingNotificationSession()
+        void openPendingNotificationSession()
       }),
-    [isSessionPersistenceReady, openPendingNotificationSession]
+    [openPendingNotificationSession]
   )
 
-  // Slow path: the click recreated the window before this listener existed. Consume the pending
-  // target only after session persistence has a complete store snapshot.
+  // Slow path: the click recreated the window before this listener existed. Peek immediately so
+  // navigation during initial loading can dismiss it, then recheck after every hydration pass; a
+  // partial snapshot may still open targets that it did load.
   useEffect(() => {
-    if (isSessionPersistenceReady) void openPendingNotificationSession()
-  }, [isSessionPersistenceReady, openPendingNotificationSession])
+    void openPendingNotificationSession()
+  }, [openPendingNotificationSession])
 
   // Subscribe once to compute approval requests. The card must be answered before the SSH call runs.
   useEffect(

--- a/src/renderer/src/App.tsx
+++ b/src/renderer/src/App.tsx
@@ -33,6 +33,7 @@ const App = (): React.JSX.Element | null => {
   // Persistence is started once at the top so sessions stay loaded for both Home and Workspace.
   const sessionPersistence = useSessionPersistence()
   const isSessionPersistenceHydrated = sessionPersistence.isHydrated
+  const isSessionPersistenceLoading = sessionPersistence.isLoading
   const isSessionPersistenceReady = sessionPersistence.isReady
   const lifecycleSync = useLifecycleSync({ isSessionPersistenceHydrated })
   useDeepLinkNavigation(isSessionPersistenceReady)
@@ -215,6 +216,18 @@ const App = (): React.JSX.Element | null => {
     }) === 'onboarding'
   ) {
     return <OnboardingWizard />
+  }
+
+  if (!isSessionPersistenceHydrated && isSessionPersistenceLoading) {
+    return (
+      <main
+        data-testid="session-persistence-startup-loading"
+        role="status"
+        className="flex h-screen items-center justify-center bg-bg-10 text-sm text-text-300"
+      >
+        Loading saved conversations…
+      </main>
+    )
   }
 
   // A hard load failure leaves no trustworthy session snapshot. Keep the interactive surfaces

--- a/src/renderer/src/App.tsx
+++ b/src/renderer/src/App.tsx
@@ -271,9 +271,12 @@ const App = (): React.JSX.Element | null => {
         />
       ) : null}
       {view === 'home' ? (
-        <HomePage canDeleteProjects={isSessionPersistenceReady} />
+        <HomePage canDeleteProjects={isSessionPersistenceHydrated} />
       ) : (
-        <WorkspacePage isSessionPersistenceReady={isSessionPersistenceReady} />
+        <WorkspacePage
+          isSessionPersistenceHydrated={isSessionPersistenceHydrated}
+          isSessionPersistenceReady={isSessionPersistenceReady}
+        />
       )}
       <SettingsPage open={isSettingsOpen} onClose={closeSettings} />
       <ConnectorApprovalDialog />

--- a/src/renderer/src/App.tsx
+++ b/src/renderer/src/App.tsx
@@ -91,6 +91,8 @@ const App = (): React.JSX.Element | null => {
   // Only acknowledge a conversation when no app-level gate covers the workspace. The hook performs
   // the remaining navigation/session/DOM checks before main is allowed to clear its unread marker.
   const isSessionContentVisible =
+    isSessionPersistenceHydrated &&
+    !isSessionPersistenceLoading &&
     startupView === 'app' &&
     view === 'workspace' &&
     !isSettingsOpen &&

--- a/src/renderer/src/App.tsx
+++ b/src/renderer/src/App.tsx
@@ -272,7 +272,7 @@ const App = (): React.JSX.Element | null => {
       return (
         <main
           role="alert"
-          className="flex h-screen items-center justify-center bg-background p-6 text-muted-foreground"
+          className="flex min-h-svh items-center justify-center bg-background p-6 text-foreground"
         >
           <div className="w-full max-w-md rounded-xl border border-border bg-card p-5 text-card-foreground shadow-sm">
             <h1 className="text-base font-semibold text-foreground">
@@ -298,9 +298,9 @@ const App = (): React.JSX.Element | null => {
       <main
         data-testid="settings-startup-loading"
         role="status"
-        className="flex h-screen items-center justify-center bg-background text-sm text-muted-foreground"
+        className="flex min-h-svh items-center justify-center bg-background text-foreground"
       >
-        Loading settings…
+        <span className="text-sm text-muted-foreground">Loading settings…</span>
       </main>
     )
   }
@@ -314,9 +314,9 @@ const App = (): React.JSX.Element | null => {
       <main
         data-testid="session-persistence-startup-loading"
         role="status"
-        className="flex h-screen items-center justify-center bg-background text-sm text-muted-foreground"
+        className="flex min-h-svh items-center justify-center bg-background text-foreground"
       >
-        Loading saved conversations…
+        <span className="text-sm text-muted-foreground">Loading saved conversations…</span>
       </main>
     )
   }
@@ -327,7 +327,7 @@ const App = (): React.JSX.Element | null => {
     return (
       <main
         data-testid="session-persistence-startup-error"
-        className="flex h-screen items-center justify-center bg-background p-6 text-muted-foreground"
+        className="flex min-h-svh items-center justify-center bg-background p-6 text-foreground"
       >
         <SessionPersistenceAlert
           title="Saved conversations could not be loaded"

--- a/src/renderer/src/App.tsx
+++ b/src/renderer/src/App.tsx
@@ -362,7 +362,10 @@ const App = (): React.JSX.Element | null => {
         />
       ) : null}
       {view === 'home' ? (
-        <HomePage canDeleteProjects={isSessionPersistenceHydrated} />
+        <HomePage
+          canDeleteProjects={isSessionPersistenceHydrated}
+          hasCompleteSessionCatalog={sessionPersistence.hasCompleteSessionCatalog}
+        />
       ) : (
         <WorkspacePage
           isSessionPersistenceHydrated={isSessionPersistenceHydrated}

--- a/src/renderer/src/App.tsx
+++ b/src/renderer/src/App.tsx
@@ -10,6 +10,7 @@ import { LegacyDataMoveDialog } from '@/components/LegacyDataMoveDialog'
 import { LifecycleToast } from '@/components/LifecycleToast'
 import { SessionPersistenceAlert } from '@/components/SessionPersistenceAlert'
 import { UpdateDialog } from '@/components/UpdateDialog'
+import { Button } from '@/components/ui/button'
 import { HomePage } from '@/pages/home/HomePage'
 import { OnboardingWizard } from '@/pages/onboarding/OnboardingWizard'
 import { resolveStartupView } from '@/pages/onboarding/startup-gate'
@@ -244,20 +245,23 @@ const App = (): React.JSX.Element | null => {
       return (
         <main
           role="alert"
-          className="flex h-screen items-center justify-center bg-bg-10 p-6 text-text-100"
+          className="flex h-screen items-center justify-center bg-background p-6 text-muted-foreground"
         >
-          <div className="w-full max-w-md rounded-xl border border-border-200 bg-bg-100 p-5 shadow-dialog">
-            <h1 className="text-base font-semibold text-text-000">Settings could not be loaded</h1>
-            <p className="mt-2 break-words text-sm text-text-300">{settingsLoadError}</p>
-            <button
+          <div className="w-full max-w-md rounded-xl border border-border bg-card p-5 text-card-foreground shadow-sm">
+            <h1 className="text-base font-semibold text-foreground">
+              Settings could not be loaded
+            </h1>
+            <p className="mt-2 break-words text-sm text-muted-foreground">{settingsLoadError}</p>
+            <Button
               type="button"
+              variant="outline"
               data-testid="settings-startup-retry"
               disabled={isSettingsLoading}
               onClick={() => void retrySettingsInitialization()}
-              className="mt-4 rounded-lg border border-border-200 px-3 py-1.5 text-sm font-medium text-text-000 hover:bg-bg-200 disabled:cursor-not-allowed disabled:opacity-60"
+              className="mt-4"
             >
               {isSettingsLoading ? 'Retrying…' : 'Retry'}
-            </button>
+            </Button>
           </div>
         </main>
       )
@@ -267,7 +271,7 @@ const App = (): React.JSX.Element | null => {
       <main
         data-testid="settings-startup-loading"
         role="status"
-        className="flex h-screen items-center justify-center bg-bg-10 text-sm text-text-300"
+        className="flex h-screen items-center justify-center bg-background text-sm text-muted-foreground"
       >
         Loading settings…
       </main>
@@ -287,7 +291,7 @@ const App = (): React.JSX.Element | null => {
       <main
         data-testid="session-persistence-startup-loading"
         role="status"
-        className="flex h-screen items-center justify-center bg-bg-10 text-sm text-text-300"
+        className="flex h-screen items-center justify-center bg-background text-sm text-muted-foreground"
       >
         Loading saved conversations…
       </main>
@@ -300,7 +304,7 @@ const App = (): React.JSX.Element | null => {
     return (
       <main
         data-testid="session-persistence-startup-error"
-        className="flex h-screen items-center justify-center bg-bg-10 p-6 text-text-100"
+        className="flex h-screen items-center justify-center bg-background p-6 text-muted-foreground"
       >
         <SessionPersistenceAlert
           title="Saved conversations could not be loaded"

--- a/src/renderer/src/App.tsx
+++ b/src/renderer/src/App.tsx
@@ -6,6 +6,7 @@ import { CloseConfirmModal } from '@/components/CloseConfirmModal'
 import { DataRootMissingDialog } from '@/components/DataRootMissingDialog'
 import { LegacyDataMoveDialog } from '@/components/LegacyDataMoveDialog'
 import { LifecycleToast } from '@/components/LifecycleToast'
+import { SessionPersistenceAlert } from '@/components/SessionPersistenceAlert'
 import { UpdateDialog } from '@/components/UpdateDialog'
 import { HomePage } from '@/pages/home/HomePage'
 import { OnboardingWizard } from '@/pages/onboarding/OnboardingWizard'
@@ -30,7 +31,8 @@ import { useUpdateStore } from '@/stores/update-store'
 
 const App = (): React.JSX.Element | null => {
   // Persistence is started once at the top so sessions stay loaded for both Home and Workspace.
-  const isSessionPersistenceReady = useSessionPersistence()
+  const sessionPersistence = useSessionPersistence()
+  const isSessionPersistenceReady = sessionPersistence.isReady
   const lifecycleSync = useLifecycleSync({ isSessionPersistenceReady })
   useDeepLinkNavigation(isSessionPersistenceReady)
   const view = useNavigationStore((state) => state.view)
@@ -39,6 +41,8 @@ const App = (): React.JSX.Element | null => {
   useWindowFindAppearanceSync()
   const loadProjects = useProjectStore((state) => state.loadProjects)
   const isSettingsLoaded = useSettingsStore((state) => state.isLoaded)
+  const isSettingsLoading = useSettingsStore((state) => state.isLoading)
+  const settingsLoadError = useSettingsStore((state) => state.loadError)
   const onboardingCompletedAt = useSettingsStore((state) => state.onboardingCompletedAt)
   const loadSettings = useSettingsStore((state) => state.load)
   const checkEnvironment = useSettingsStore((state) => state.checkEnvironment)
@@ -60,6 +64,10 @@ const App = (): React.JSX.Element | null => {
   const [legacyMove, setLegacyMove] = useState<
     { currentDataRoot: string; defaultParent: string } | undefined
   >(undefined)
+
+  const retrySettingsInitialization = useCallback(async (): Promise<void> => {
+    if (await loadSettings()) await checkEnvironment()
+  }, [checkEnvironment, loadSettings])
 
   // Load app info and subscribe to update-status broadcasts once at startup.
   useEffect(() => {
@@ -154,8 +162,8 @@ const App = (): React.JSX.Element | null => {
   // only launch check that would surface a Home repair action.
   useEffect(() => {
     let active = true
-    void loadSettings().then(() => {
-      if (active) void checkEnvironment()
+    void loadSettings().then((loaded) => {
+      if (active && loaded) void checkEnvironment()
     })
 
     return () => {
@@ -166,7 +174,38 @@ const App = (): React.JSX.Element | null => {
   // Settings carry the persisted first-run marker. No environment result is awaited here: existing
   // users proceed directly to Home while the launch check runs in the background.
   if (!isSettingsLoaded) {
-    return null
+    if (settingsLoadError) {
+      return (
+        <main
+          role="alert"
+          className="flex h-screen items-center justify-center bg-bg-10 p-6 text-text-100"
+        >
+          <div className="w-full max-w-md rounded-xl border border-border-200 bg-bg-100 p-5 shadow-dialog">
+            <h1 className="text-base font-semibold text-text-000">Settings could not be loaded</h1>
+            <p className="mt-2 break-words text-sm text-text-300">{settingsLoadError}</p>
+            <button
+              type="button"
+              data-testid="settings-startup-retry"
+              disabled={isSettingsLoading}
+              onClick={() => void retrySettingsInitialization()}
+              className="mt-4 rounded-lg border border-border-200 px-3 py-1.5 text-sm font-medium text-text-000 hover:bg-bg-200 disabled:cursor-not-allowed disabled:opacity-60"
+            >
+              {isSettingsLoading ? 'Retrying…' : 'Retry'}
+            </button>
+          </div>
+        </main>
+      )
+    }
+
+    return (
+      <main
+        data-testid="settings-startup-loading"
+        role="status"
+        className="flex h-screen items-center justify-center bg-bg-10 text-sm text-text-300"
+      >
+        Loading settings…
+      </main>
+    )
   }
 
   if (
@@ -180,6 +219,25 @@ const App = (): React.JSX.Element | null => {
   return (
     <>
       <EnvStatusBanner ui={envUi} onRetry={() => void retryEnv()} />
+      {sessionPersistence.loadError ? (
+        <SessionPersistenceAlert
+          title="Saved conversations could not be loaded"
+          message={sessionPersistence.loadError}
+          onRetry={sessionPersistence.retryLoad}
+        />
+      ) : sessionPersistence.writeError ? (
+        <SessionPersistenceAlert
+          title="Conversation storage needs attention"
+          message={`${sessionPersistence.writeError} Open Science could not confirm that the latest changes were fully saved. Retry before closing the app.`}
+          onRetry={sessionPersistence.retryWrites}
+        />
+      ) : sessionPersistence.loadWarning ? (
+        <SessionPersistenceAlert
+          title="Saved conversation data was damaged"
+          message={sessionPersistence.loadWarning}
+          variant="warning"
+        />
+      ) : null}
       {view === 'home' ? (
         <HomePage />
       ) : (

--- a/src/renderer/src/components/CloseConfirmModal.render.test.tsx
+++ b/src/renderer/src/components/CloseConfirmModal.render.test.tsx
@@ -145,7 +145,7 @@ describe('CloseConfirmModal', () => {
     })
     const row = await findButtonByName(/My Analysis — Fix data loader/)
     act(() => row.click())
-    expect(openSession).toHaveBeenCalledWith('p1', 's1')
+    expect(openSession).toHaveBeenCalledWith('p1', 's1', 'user')
     expect(sendResponse).toHaveBeenCalledWith({ requestId: 'r4', choice: 'cancel' })
   })
 

--- a/src/renderer/src/components/CloseConfirmModal.tsx
+++ b/src/renderer/src/components/CloseConfirmModal.tsx
@@ -83,7 +83,9 @@ export const CloseConfirmModal = (): React.JSX.Element | null => {
                 // it. Only navigable when we resolved its project (openSession needs the project id).
                 const openThisSession = (): void => {
                   if (!row.projectId) return
-                  useNavigationStore.getState().openSession(row.projectId, session.sessionId)
+                  useNavigationStore
+                    .getState()
+                    .openSession(row.projectId, session.sessionId, 'user')
                   reply('cancel')
                 }
                 return (

--- a/src/renderer/src/components/SessionPersistenceAlert.render.test.tsx
+++ b/src/renderer/src/components/SessionPersistenceAlert.render.test.tsx
@@ -70,4 +70,28 @@ describe('SessionPersistenceAlert', () => {
     act(() => retry?.click())
     expect(onRetry).toHaveBeenCalledOnce()
   })
+
+  it('renders a labelled shared Button for dismissing a persistent warning', () => {
+    const onDismiss = vi.fn()
+    act(() =>
+      root.render(
+        <SessionPersistenceAlert
+          variant="warning"
+          title="Saved conversation data was damaged"
+          message="The damaged file was moved aside."
+          onDismiss={onDismiss}
+        />
+      )
+    )
+
+    const dismiss = container.querySelector<HTMLButtonElement>(
+      '[data-testid="session-persistence-dismiss"]'
+    )
+
+    expect(dismiss?.dataset.slot).toBe('button')
+    expect(dismiss?.getAttribute('aria-label')).toBe('Dismiss storage warning')
+    expect(dismiss?.className).toContain('focus-visible:ring-3')
+    act(() => dismiss?.click())
+    expect(onDismiss).toHaveBeenCalledOnce()
+  })
 })

--- a/src/renderer/src/components/SessionPersistenceAlert.render.test.tsx
+++ b/src/renderer/src/components/SessionPersistenceAlert.render.test.tsx
@@ -1,0 +1,73 @@
+// @vitest-environment jsdom
+import { act } from 'react'
+import { createRoot, type Root } from 'react-dom/client'
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest'
+
+import { SessionPersistenceAlert } from './SessionPersistenceAlert'
+
+;(globalThis as { IS_REACT_ACT_ENVIRONMENT?: boolean }).IS_REACT_ACT_ENVIRONMENT = true
+
+let container: HTMLDivElement
+let root: Root
+
+beforeEach(() => {
+  container = document.createElement('div')
+  document.body.appendChild(container)
+  root = createRoot(container)
+})
+
+afterEach(() => {
+  act(() => root.unmount())
+  container.remove()
+})
+
+describe('SessionPersistenceAlert', () => {
+  it('renders the default error as a fixed semantic card without a retry action', () => {
+    act(() =>
+      root.render(
+        <SessionPersistenceAlert title="Storage unavailable" message="Retry after reconnecting." />
+      )
+    )
+
+    const alert = container.querySelector<HTMLElement>('[role="alert"]')
+
+    expect(alert?.textContent).toContain('Storage unavailable')
+    expect(alert?.textContent).toContain('Retry after reconnecting.')
+    expect(alert?.className).toContain('fixed')
+    expect(alert?.className).toContain('bg-card')
+    expect(alert?.className).toContain('border-destructive/40')
+    expect(alert?.className).not.toContain('border-border')
+    expect(container.querySelector('[data-testid="session-persistence-retry"]')).toBeNull()
+  })
+
+  it('renders an inline warning with the shared retry Button contract', () => {
+    const onRetry = vi.fn()
+    act(() =>
+      root.render(
+        <SessionPersistenceAlert
+          inline
+          variant="warning"
+          title="Some conversations were skipped"
+          message="Retry to scan storage again."
+          onRetry={onRetry}
+        />
+      )
+    )
+
+    const alert = container.querySelector<HTMLElement>('[role="alert"]')
+    const retry = container.querySelector<HTMLButtonElement>(
+      '[data-testid="session-persistence-retry"]'
+    )
+
+    expect(alert?.className).toContain('flex w-full max-w-md')
+    expect(alert?.className).toContain('border-border')
+    expect(alert?.className).not.toContain('fixed')
+    expect(alert?.className).not.toContain('border-destructive/40')
+    expect(retry?.dataset.slot).toBe('button')
+    expect(retry?.className).toContain('focus-visible:ring-3')
+    expect(retry?.className).toContain('disabled:pointer-events-none')
+
+    act(() => retry?.click())
+    expect(onRetry).toHaveBeenCalledOnce()
+  })
+})

--- a/src/renderer/src/components/SessionPersistenceAlert.tsx
+++ b/src/renderer/src/components/SessionPersistenceAlert.tsx
@@ -1,0 +1,40 @@
+type SessionPersistenceAlertProps = {
+  title: string
+  message: string
+  variant?: 'error' | 'warning'
+  onRetry?: () => void
+}
+
+const SessionPersistenceAlert = ({
+  title,
+  message,
+  variant = 'error',
+  onRetry
+}: SessionPersistenceAlertProps): React.JSX.Element => (
+  <div
+    role="alert"
+    data-testid="session-persistence-alert"
+    className={`fixed bottom-3 right-3 z-50 flex w-[min(420px,calc(100vw-24px))] items-start gap-3 rounded-xl border bg-bg-100 p-4 text-sm text-text-100 shadow-dialog ${
+      variant === 'warning'
+        ? 'border-amber-300 dark:border-amber-700/70'
+        : 'border-red-200 dark:border-red-800/60'
+    }`}
+  >
+    <div className="min-w-0 flex-1">
+      <p className="font-medium text-text-000">{title}</p>
+      <p className="mt-1 break-words text-xs leading-5 text-text-300">{message}</p>
+    </div>
+    {onRetry ? (
+      <button
+        type="button"
+        data-testid="session-persistence-retry"
+        onClick={onRetry}
+        className="shrink-0 rounded-lg border border-border-200 px-2.5 py-1 text-xs font-medium text-text-000 hover:bg-bg-200"
+      >
+        Retry
+      </button>
+    ) : null}
+  </div>
+)
+
+export { SessionPersistenceAlert }

--- a/src/renderer/src/components/SessionPersistenceAlert.tsx
+++ b/src/renderer/src/components/SessionPersistenceAlert.tsx
@@ -1,3 +1,5 @@
+import { Button } from '@/components/ui/button'
+
 type SessionPersistenceAlertProps = {
   title: string
   message: string
@@ -16,25 +18,25 @@ const SessionPersistenceAlert = ({
   <div
     role="alert"
     data-testid="session-persistence-alert"
-    className={`${inline ? 'flex w-full max-w-md' : 'fixed bottom-3 right-3 z-50 flex w-[min(420px,calc(100vw-24px))]'} items-start gap-3 rounded-xl border bg-bg-000 p-4 text-sm text-text-100 shadow-dialog ${
-      variant === 'warning'
-        ? 'border-amber-300 dark:border-amber-700/70'
-        : 'border-red-200 dark:border-red-800/60'
+    className={`${inline ? 'flex w-full max-w-md' : 'fixed bottom-3 right-3 z-50 flex w-[min(420px,calc(100vw-24px))]'} items-start gap-3 rounded-xl border bg-card p-4 text-sm text-muted-foreground shadow-sm ${
+      variant === 'warning' ? 'border-border' : 'border-destructive/40'
     }`}
   >
     <div className="min-w-0 flex-1">
-      <p className="font-medium text-text-000">{title}</p>
-      <p className="mt-1 break-words text-xs leading-5 text-text-300">{message}</p>
+      <p className="font-medium text-foreground">{title}</p>
+      <p className="mt-1 break-words text-xs leading-5 text-muted-foreground">{message}</p>
     </div>
     {onRetry ? (
-      <button
+      <Button
         type="button"
+        variant="outline"
+        size="sm"
         data-testid="session-persistence-retry"
         onClick={onRetry}
-        className="shrink-0 rounded-lg border border-border-200 px-2.5 py-1 text-xs font-medium text-text-000 hover:bg-bg-200"
+        className="shrink-0"
       >
         Retry
-      </button>
+      </Button>
     ) : null}
   </div>
 )

--- a/src/renderer/src/components/SessionPersistenceAlert.tsx
+++ b/src/renderer/src/components/SessionPersistenceAlert.tsx
@@ -1,3 +1,5 @@
+import { X } from 'lucide-react'
+
 import { Button } from '@/components/ui/button'
 
 type SessionPersistenceAlertProps = {
@@ -5,6 +7,7 @@ type SessionPersistenceAlertProps = {
   message: string
   variant?: 'error' | 'warning'
   inline?: boolean
+  onDismiss?: () => void
   onRetry?: () => void
 }
 
@@ -13,6 +16,7 @@ const SessionPersistenceAlert = ({
   message,
   variant = 'error',
   inline = false,
+  onDismiss,
   onRetry
 }: SessionPersistenceAlertProps): React.JSX.Element => (
   <div
@@ -36,6 +40,19 @@ const SessionPersistenceAlert = ({
         className="shrink-0"
       >
         Retry
+      </Button>
+    ) : null}
+    {onDismiss ? (
+      <Button
+        type="button"
+        variant="ghost"
+        size="icon-sm"
+        aria-label="Dismiss storage warning"
+        data-testid="session-persistence-dismiss"
+        onClick={onDismiss}
+        className="shrink-0"
+      >
+        <X aria-hidden="true" />
       </Button>
     ) : null}
   </div>

--- a/src/renderer/src/components/SessionPersistenceAlert.tsx
+++ b/src/renderer/src/components/SessionPersistenceAlert.tsx
@@ -2,6 +2,7 @@ type SessionPersistenceAlertProps = {
   title: string
   message: string
   variant?: 'error' | 'warning'
+  inline?: boolean
   onRetry?: () => void
 }
 
@@ -9,12 +10,13 @@ const SessionPersistenceAlert = ({
   title,
   message,
   variant = 'error',
+  inline = false,
   onRetry
 }: SessionPersistenceAlertProps): React.JSX.Element => (
   <div
     role="alert"
     data-testid="session-persistence-alert"
-    className={`fixed bottom-3 right-3 z-50 flex w-[min(420px,calc(100vw-24px))] items-start gap-3 rounded-xl border bg-bg-100 p-4 text-sm text-text-100 shadow-dialog ${
+    className={`${inline ? 'flex w-full max-w-md' : 'fixed bottom-3 right-3 z-50 flex w-[min(420px,calc(100vw-24px))]'} items-start gap-3 rounded-xl border bg-bg-100 p-4 text-sm text-text-100 shadow-dialog ${
       variant === 'warning'
         ? 'border-amber-300 dark:border-amber-700/70'
         : 'border-red-200 dark:border-red-800/60'

--- a/src/renderer/src/components/SessionPersistenceAlert.tsx
+++ b/src/renderer/src/components/SessionPersistenceAlert.tsx
@@ -16,7 +16,7 @@ const SessionPersistenceAlert = ({
   <div
     role="alert"
     data-testid="session-persistence-alert"
-    className={`${inline ? 'flex w-full max-w-md' : 'fixed bottom-3 right-3 z-50 flex w-[min(420px,calc(100vw-24px))]'} items-start gap-3 rounded-xl border bg-bg-100 p-4 text-sm text-text-100 shadow-dialog ${
+    className={`${inline ? 'flex w-full max-w-md' : 'fixed bottom-3 right-3 z-50 flex w-[min(420px,calc(100vw-24px))]'} items-start gap-3 rounded-xl border bg-bg-000 p-4 text-sm text-text-100 shadow-dialog ${
       variant === 'warning'
         ? 'border-amber-300 dark:border-amber-700/70'
         : 'border-red-200 dark:border-red-800/60'

--- a/src/renderer/src/hooks/useLifecycleSync.test.tsx
+++ b/src/renderer/src/hooks/useLifecycleSync.test.tsx
@@ -69,7 +69,11 @@ describe('useLifecycleSync', () => {
     document.body.appendChild(container)
     useProjectStore.setState({ ...createInitialProjectState(), isLoaded: true })
     useSessionStore.setState(createInitialSessionState())
-    useNavigationStore.setState({ view: 'home', activeProjectId: undefined })
+    useNavigationStore.setState({
+      view: 'home',
+      activeProjectId: undefined,
+      userNavigationRevision: 0
+    })
 
     const subscribe =
       <Payload,>(key: keyof typeof listeners) =>

--- a/src/renderer/src/hooks/useLifecycleSync.test.tsx
+++ b/src/renderer/src/hooks/useLifecycleSync.test.tsx
@@ -24,11 +24,11 @@ const listeners: {
 } = {}
 
 const Harness = ({
-  isSessionPersistenceReady = true
+  isSessionPersistenceHydrated = true
 }: {
-  isSessionPersistenceReady?: boolean
+  isSessionPersistenceHydrated?: boolean
 }): React.JSX.Element => {
-  const lifecycleSync = useLifecycleSync({ isSessionPersistenceReady })
+  const lifecycleSync = useLifecycleSync({ isSessionPersistenceHydrated })
   return (
     <button
       type="button"
@@ -127,7 +127,7 @@ describe('useLifecycleSync', () => {
   it('replays lifecycle events after initial snapshots finish hydrating', async () => {
     await act(async () => {
       useProjectStore.setState(createInitialProjectState())
-      root.render(<Harness isSessionPersistenceReady={false} />)
+      root.render(<Harness isSessionPersistenceHydrated={false} />)
     })
     await act(async () => {
       listeners.projectCreated?.(project)
@@ -191,7 +191,7 @@ describe('useLifecycleSync', () => {
     await act(async () => {
       useProjectStore.setState(createInitialProjectState())
       useSessionStore.setState(createInitialSessionState())
-      root.render(<Harness isSessionPersistenceReady={false} />)
+      root.render(<Harness isSessionPersistenceHydrated={false} />)
     })
     await act(async () => {
       listeners.projectDeleted?.({ projectId: project.id })

--- a/src/renderer/src/hooks/useLifecycleSync.ts
+++ b/src/renderer/src/hooks/useLifecycleSync.ts
@@ -73,7 +73,7 @@ const useLifecycleSync = ({
         useProjectStore.getState().removeProject(projectId)
         useSessionStore.getState().removeSessionsForProject(projectId)
         if (useNavigationStore.getState().activeProjectId === projectId) {
-          useNavigationStore.getState().goHome()
+          useNavigationStore.getState().goHome('automatic')
         }
         setNotice((current) => (current?.projectId === projectId ? undefined : current))
       })
@@ -118,7 +118,7 @@ const useLifecycleSync = ({
   const dismissNotice = useCallback(() => setNotice(undefined), [])
   const viewNotice = useCallback(() => {
     if (!notice) return
-    useNavigationStore.getState().openSession(notice.projectId, notice.sessionId)
+    useNavigationStore.getState().openSession(notice.projectId, notice.sessionId, 'user')
     setNotice(undefined)
   }, [notice])
 

--- a/src/renderer/src/hooks/useLifecycleSync.ts
+++ b/src/renderer/src/hooks/useLifecycleSync.ts
@@ -18,15 +18,15 @@ type LifecycleSyncResult = {
 }
 
 type LifecycleSyncOptions = {
-  isSessionPersistenceReady: boolean
+  isSessionPersistenceHydrated: boolean
 }
 
 const useLifecycleSync = ({
-  isSessionPersistenceReady
+  isSessionPersistenceHydrated
 }: LifecycleSyncOptions): LifecycleSyncResult => {
   const [notice, setNotice] = useState<ExternalSessionNotice | undefined>()
   const isProjectPersistenceReady = useProjectStore((state) => state.isLoaded)
-  const isHydrated = isSessionPersistenceReady && isProjectPersistenceReady
+  const isHydrated = isSessionPersistenceHydrated && isProjectPersistenceReady
   const isHydratedRef = useRef(isHydrated)
   const lifecycleClientIdRef = useRef<string | null | undefined>(undefined)
   const pendingActionsRef = useRef<Array<() => void>>([])

--- a/src/renderer/src/lib/compute/useJobAnalysisEffect.render.test.tsx
+++ b/src/renderer/src/lib/compute/useJobAnalysisEffect.render.test.tsx
@@ -1,0 +1,231 @@
+// @vitest-environment jsdom
+import { act } from 'react'
+import { createRoot, type Root } from 'react-dom/client'
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest'
+
+import type { JobSummary } from '../../../../shared/compute'
+import { createInitialSessionJobState, useSessionJobStore } from '../../stores/session-job-store'
+import { createInitialSessionState, useSessionStore } from '../../stores/session-store'
+import { useJobAnalysisEffect } from './useJobAnalysisEffect'
+
+;(globalThis as { IS_REACT_ACT_ENVIRONMENT?: boolean }).IS_REACT_ACT_ENVIRONMENT = true
+
+const makeCompletedJob = (): JobSummary => ({
+  job_id: 'job-1',
+  provider_id: 'ssh:biowulf',
+  display_name: 'biowulf',
+  shape: 'direct_ssh',
+  session_id: 'session-1',
+  status: 'success',
+  intent: 'Analyze results',
+  created_at: 1000,
+  started_at: 1100,
+  finished_at: 1200,
+  exit_code: 0,
+  error_code: undefined,
+  remote_workdir: undefined,
+  stdout_tail: undefined,
+  stderr_tail: undefined,
+  notified_at: 1300,
+  notification_consumed_at: undefined,
+  featured_files: [],
+  featured_file_count: 0,
+  left_on_remote_count: 0
+})
+
+describe('useJobAnalysisEffect persistence readiness', () => {
+  let container: HTMLDivElement
+  let root: Root
+  const sendMessage = vi.fn().mockResolvedValue({ sessionId: 'session-1', messageId: 'message-1' })
+  const jobsPendingNotification = vi.fn().mockResolvedValue([makeCompletedJob()])
+  const jobsMarkConsumed = vi.fn().mockResolvedValue(undefined)
+  const jobsList = vi.fn().mockResolvedValue([])
+
+  type AnalysisSendMessage = Parameters<typeof useJobAnalysisEffect>[0]['sendMessage']
+
+  const Probe = ({
+    enabled,
+    onSendMessage = sendMessage
+  }: {
+    enabled: boolean
+    onSendMessage?: AnalysisSendMessage
+  }): null => {
+    useJobAnalysisEffect({ enabled, sendMessage: onSendMessage })
+    return null
+  }
+
+  beforeEach(() => {
+    container = document.createElement('div')
+    document.body.appendChild(container)
+    root = createRoot(container)
+    sendMessage.mockClear()
+    jobsPendingNotification.mockClear()
+    jobsMarkConsumed.mockClear()
+    jobsList.mockClear()
+    useSessionJobStore.setState({
+      ...createInitialSessionJobState(),
+      hydratedSessionId: 'session-1',
+      isLoaded: true
+    })
+    useSessionStore.setState(createInitialSessionState())
+    window.api = {
+      compute: {
+        jobsPendingNotification,
+        jobsMarkConsumed,
+        jobsList
+      }
+    } as unknown as Window['api']
+  })
+
+  afterEach(() => {
+    act(() => root.unmount())
+    container.remove()
+  })
+
+  it('does not start job analysis while Session persistence is not ready', async () => {
+    await act(async () => {
+      root.render(<Probe enabled={false} />)
+      await new Promise((resolve) => setTimeout(resolve, 0))
+    })
+
+    expect(sendMessage).not.toHaveBeenCalled()
+    expect(jobsMarkConsumed).not.toHaveBeenCalled()
+  })
+
+  it('rechecks readiness before dispatching a delayed pending-job scan', async () => {
+    let resolvePendingJobs: ((jobs: JobSummary[]) => void) | undefined
+    jobsPendingNotification.mockImplementationOnce(
+      () =>
+        new Promise((resolve) => {
+          resolvePendingJobs = resolve
+        })
+    )
+
+    await act(async () => {
+      root.render(<Probe enabled />)
+      await Promise.resolve()
+    })
+    expect(jobsPendingNotification).toHaveBeenCalledWith('session-1')
+
+    await act(async () => root.render(<Probe enabled={false} />))
+    await act(async () => {
+      resolvePendingJobs?.([makeCompletedJob()])
+      await new Promise((resolve) => setTimeout(resolve, 0))
+    })
+
+    expect(sendMessage).not.toHaveBeenCalled()
+    expect(jobsMarkConsumed).not.toHaveBeenCalled()
+  })
+
+  it('rechecks readiness before a queued broadcast dispatch reaches the runtime', async () => {
+    jobsPendingNotification.mockResolvedValueOnce([])
+    await act(async () => root.render(<Probe enabled />))
+
+    act(() => {
+      useSessionJobStore.getState().applyUpdate(makeCompletedJob())
+      root.render(<Probe enabled={false} />)
+    })
+    await act(async () => new Promise((resolve) => setTimeout(resolve, 0)))
+
+    expect(sendMessage).not.toHaveBeenCalled()
+    expect(jobsMarkConsumed).not.toHaveBeenCalled()
+  })
+
+  it('removes a queued turn-end listener when persistence becomes unavailable', async () => {
+    jobsPendingNotification.mockResolvedValueOnce([])
+    useSessionStore.setState({
+      ...createInitialSessionState(),
+      sessions: [
+        {
+          id: 'session-1',
+          projectId: 'project-a',
+          title: 'Running',
+          cwd: '/workspace/project-a',
+          status: 'running',
+          messages: [],
+          createdAt: 1,
+          updatedAt: 1
+        }
+      ]
+    })
+
+    await act(async () => root.render(<Probe enabled />))
+    act(() => useSessionJobStore.getState().applyUpdate(makeCompletedJob()))
+    await act(async () => Promise.resolve())
+
+    await act(async () => root.render(<Probe enabled={false} />))
+    act(() => {
+      useSessionStore.setState((state) => ({
+        sessions: state.sessions.map((session) =>
+          session.id === 'session-1' ? { ...session, status: 'idle' } : session
+        )
+      }))
+    })
+    await act(async () => new Promise((resolve) => setTimeout(resolve, 0)))
+
+    expect(sendMessage).not.toHaveBeenCalled()
+    expect(jobsMarkConsumed).not.toHaveBeenCalled()
+  })
+
+  it('keeps one trigger when the runtime send callback changes during an analysis turn', async () => {
+    jobsPendingNotification.mockResolvedValueOnce([])
+    useSessionStore.setState({
+      ...createInitialSessionState(),
+      sessions: [
+        {
+          id: 'session-1',
+          projectId: 'project-a',
+          title: 'Ready',
+          cwd: '/workspace/project-a',
+          status: 'idle',
+          messages: [],
+          createdAt: 1,
+          updatedAt: 1
+        }
+      ]
+    })
+    const firstSend = vi.fn<AnalysisSendMessage>(async () => {
+      useSessionStore.setState((state) => ({
+        sessions: state.sessions.map((session) =>
+          session.id === 'session-1' ? { ...session, status: 'running' } : session
+        )
+      }))
+      return { sessionId: 'session-1', messageId: 'message-1' }
+    })
+    const replacementSend = vi
+      .fn<AnalysisSendMessage>()
+      .mockResolvedValue({ sessionId: 'session-1', messageId: 'message-2' })
+
+    await act(async () => root.render(<Probe enabled onSendMessage={firstSend} />))
+    act(() => useSessionJobStore.getState().applyUpdate(makeCompletedJob()))
+    await act(async () => new Promise((resolve) => setTimeout(resolve, 0)))
+    expect(firstSend).toHaveBeenCalledOnce()
+
+    await act(async () => root.render(<Probe enabled onSendMessage={replacementSend} />))
+    act(() => {
+      useSessionStore.setState((state) => ({
+        sessions: state.sessions.map((session) =>
+          session.id === 'session-1' ? { ...session, status: 'idle' } : session
+        )
+      }))
+    })
+    await act(async () => new Promise((resolve) => setTimeout(resolve, 0)))
+
+    expect(firstSend).toHaveBeenCalledOnce()
+    expect(replacementSend).not.toHaveBeenCalled()
+    expect(jobsMarkConsumed).toHaveBeenCalledOnce()
+  })
+
+  it('scans and dispatches pending analysis after persistence becomes ready', async () => {
+    await act(async () => root.render(<Probe enabled={false} />))
+    expect(jobsPendingNotification).not.toHaveBeenCalled()
+
+    await act(async () => {
+      root.render(<Probe enabled />)
+      await new Promise((resolve) => setTimeout(resolve, 0))
+    })
+
+    expect(jobsPendingNotification).toHaveBeenCalledWith('session-1')
+    expect(sendMessage).toHaveBeenCalledOnce()
+  })
+})

--- a/src/renderer/src/lib/compute/useJobAnalysisEffect.ts
+++ b/src/renderer/src/lib/compute/useJobAnalysisEffect.ts
@@ -5,12 +5,12 @@
 // the trigger is fed the job summary and decides whether to fire / queue an analysis turn.
 //
 // Design decisions:
-// - The trigger instance is stable (created once in a ref) so batching logic survives re-renders.
+// - One readiness-scoped effect owns the trigger and every subscription so delayed work cannot cross
+//   a persistence recovery boundary.
 // - `isSessionInFlight` reads from useSessionStore.getState() synchronously — no subscription needed.
-// - `onTurnEnd` subscribes to the Zustand store once (cleanup returned from useEffect).
 // - The restart-recovery scan fires whenever the active session id changes (session navigation).
 
-import { useEffect, useMemo } from 'react'
+import { useEffect, useEffectEvent } from 'react'
 
 import { useSessionJobStore } from '../../stores/session-job-store'
 import { useSessionStore } from '../../stores/session-store'
@@ -23,78 +23,94 @@ type SendMessageFn = (input: {
 }) => Promise<{ sessionId: string; messageId: string } | undefined>
 
 type UseJobAnalysisEffectOptions = {
+  enabled: boolean
   sendMessage: SendMessageFn
 }
 
 // Subscribes to all done-state compute:job-updated broadcasts and runs the analysis turn trigger.
 // Also scans for pending notifications on session load (restart recovery path).
-export const useJobAnalysisEffect = ({ sendMessage }: UseJobAnalysisEffectOptions): void => {
-  // Create the trigger once for the lifetime of the WorkspacePage mount. useMemo with empty deps
-  // gives a stable instance that survives re-renders without relying on ref mutation during render.
-  // eslint-disable-next-line react-hooks/exhaustive-deps
-  const trigger = useMemo(
-    () =>
-      createJobAnalysisTrigger({
-        isSessionInFlight: (sessionId) => {
-          const session = useSessionStore.getState().sessions.find((s) => s.id === sessionId)
-          return session?.status === 'running' || session?.status === 'waiting-permission'
-        },
-        sendPrompt: async (sessionId, text) => {
-          return sendMessage({ sessionId, text })
-        },
-        markConsumed: async (sessionId, jobIds) => {
-          if (typeof window.api?.compute?.jobsMarkConsumed === 'function') {
-            await window.api.compute.jobsMarkConsumed(sessionId, jobIds)
-            // Refresh the in-memory job store so CompletedJobCard re-renders with consumed state.
-            void useSessionJobStore.getState().hydrate(sessionId)
-          }
-        },
-        onTurnEnd: (sessionId, callback) => {
-          // Subscribe to session store state changes and fire the callback once when the target
-          // session transitions out of running/waiting-permission into idle.
-          const unsubscribe = useSessionStore.subscribe((state) => {
-            const session = state.sessions.find((s) => s.id === sessionId)
-            if (!session) return
-            if (session.status !== 'running' && session.status !== 'waiting-permission') {
-              unsubscribe()
-              callback()
-            }
-          })
-        },
-        log: (tag, message) => {
-          console.log(`[compute] ${tag}: ${message}`)
-        }
-      }),
-    // Intentionally empty: trigger is created once per WorkspacePage mount.
-    // sendMessage identity is stable (useCallback in useWorkspaceAgentRuntime).
-    []
+export const useJobAnalysisEffect = ({
+  enabled,
+  sendMessage
+}: UseJobAnalysisEffectOptions): void => {
+  const sendLatestMessage = useEffectEvent(
+    (input: Parameters<SendMessageFn>[0]): ReturnType<SendMessageFn> => sendMessage(input)
   )
 
-  // Subscribe to the job store's full map so we pick up any new done-state jobs, including
-  // those arriving via broadcast after the trigger was created.
   useEffect(() => {
-    const unsubscribe = useSessionJobStore.subscribe((state) => {
+    if (!enabled) return
+
+    let isActive = true
+    const turnEndUnsubscribes = new Set<() => void>()
+    const trigger = createJobAnalysisTrigger({
+      isSessionInFlight: (sessionId) => {
+        const session = useSessionStore.getState().sessions.find((s) => s.id === sessionId)
+        return session?.status === 'running' || session?.status === 'waiting-permission'
+      },
+      sendPrompt: async (sessionId, text) => {
+        if (!isActive) return undefined
+        return sendLatestMessage({ sessionId, text })
+      },
+      markConsumed: async (sessionId, jobIds) => {
+        if (!isActive) return
+        if (typeof window.api?.compute?.jobsMarkConsumed === 'function') {
+          await window.api.compute.jobsMarkConsumed(sessionId, jobIds)
+          // Refresh the in-memory job store so CompletedJobCard re-renders with consumed state.
+          void useSessionJobStore.getState().hydrate(sessionId)
+        }
+      },
+      onTurnEnd: (sessionId, callback) => {
+        // Keep runtime completion listeners inside the same readiness lifecycle as dispatch.
+        const unsubscribe = useSessionStore.subscribe((state) => {
+          const session = state.sessions.find((candidate) => candidate.id === sessionId)
+          if (!session) return
+          if (session.status !== 'running' && session.status !== 'waiting-permission') {
+            unsubscribe()
+            turnEndUnsubscribes.delete(unsubscribe)
+            if (isActive) callback()
+          }
+        })
+        turnEndUnsubscribes.add(unsubscribe)
+      },
+      log: (tag, message) => {
+        console.log(`[compute] ${tag}: ${message}`)
+      }
+    })
+
+    const feedNotifiedJobs = (state: ReturnType<typeof useSessionJobStore.getState>): void => {
       for (const job of state.jobsById.values()) {
         if (job.notified_at !== undefined && job.notified_at !== null) {
           trigger.onJobDone(job)
         }
       }
-    })
-    return unsubscribe
-  }, [trigger])
+    }
 
-  // Restart-recovery scan: when a session is hydrated, fetch any pending notifications from the
-  // main process (jobs that were notified but not consumed before the last app restart).
-  const hydratedSessionId = useSessionJobStore((s) => s.hydratedSessionId)
+    const scanPendingJobs = (sessionId: string | undefined): void => {
+      if (!sessionId) return
+      if (typeof window.api?.compute?.jobsPendingNotification !== 'function') return
 
-  useEffect(() => {
-    if (!hydratedSessionId) return
-    if (typeof window.api?.compute?.jobsPendingNotification !== 'function') return
+      void window.api.compute.jobsPendingNotification(sessionId).then((jobs) => {
+        if (!isActive) return
+        for (const job of jobs) trigger.onJobDone(job)
+      })
+    }
 
-    void window.api.compute.jobsPendingNotification(hydratedSessionId).then((jobs) => {
-      for (const job of jobs) {
-        trigger.onJobDone(job)
+    const initialState = useSessionJobStore.getState()
+    feedNotifiedJobs(initialState)
+    scanPendingJobs(initialState.hydratedSessionId)
+
+    const unsubscribeJobs = useSessionJobStore.subscribe((state, previousState) => {
+      feedNotifiedJobs(state)
+      if (state.hydratedSessionId !== previousState.hydratedSessionId) {
+        scanPendingJobs(state.hydratedSessionId)
       }
     })
-  }, [hydratedSessionId, trigger])
+
+    return () => {
+      isActive = false
+      unsubscribeJobs()
+      for (const unsubscribe of turnEndUnsubscribes) unsubscribe()
+      turnEndUnsubscribes.clear()
+    }
+  }, [enabled])
 }

--- a/src/renderer/src/lib/deep-link.navigation.test.tsx
+++ b/src/renderer/src/lib/deep-link.navigation.test.tsx
@@ -169,6 +169,32 @@ describe('deep-link navigation', () => {
     expect(window.location.search).toBe('?project=project-1&session=session-1')
   })
 
+  it('retains an unresolved target until a Project load with an empty error is retried', async () => {
+    window.history.replaceState({}, '', '/?project=project-1&session=session-1')
+    useProjectStore.setState({
+      projects: [],
+      isLoaded: true,
+      loadError: ''
+    })
+    useSessionStore.setState({ sessions: [session] })
+
+    await renderHook({ isHydrated: true, isReady: true })
+
+    expect(useNavigationStore.getState().view).toBe('home')
+    expect(window.location.search).toBe('?project=project-1&session=session-1')
+
+    await act(async () =>
+      useProjectStore.setState({ projects: [project], isLoaded: true, loadError: undefined })
+    )
+
+    expect(useNavigationStore.getState()).toMatchObject({
+      view: 'workspace',
+      activeProjectId: project.id
+    })
+    expect(useSessionStore.getState().selectedSessionId).toBe(session.id)
+    expect(window.location.search).toBe('?project=project-1&session=session-1')
+  })
+
   it('does not replay an unresolved target after the user navigates elsewhere', async () => {
     const otherProject: Project = { ...project, id: 'project-2', name: 'Other research' }
     const otherSession: ChatSession = {

--- a/src/renderer/src/lib/deep-link.navigation.test.tsx
+++ b/src/renderer/src/lib/deep-link.navigation.test.tsx
@@ -50,7 +50,11 @@ let root: Root | undefined
 
 beforeEach(() => {
   window.history.replaceState({}, '', '/')
-  useNavigationStore.setState({ view: 'home', activeProjectId: undefined })
+  useNavigationStore.setState({
+    view: 'home',
+    activeProjectId: undefined,
+    userNavigationRevision: 0
+  })
   useProjectStore.setState(createInitialProjectState())
   useSessionStore.setState(createInitialSessionState())
 })
@@ -130,7 +134,7 @@ describe('deep-link navigation', () => {
 
     expect(window.location.search).toBe('?project=project-1&session=session-1')
 
-    act(() => useNavigationStore.getState().openSession(otherProject.id, otherSession.id))
+    act(() => useNavigationStore.getState().openSession(otherProject.id, otherSession.id, 'user'))
     expect(useNavigationStore.getState()).toMatchObject({
       view: 'workspace',
       activeProjectId: otherProject.id
@@ -190,7 +194,7 @@ describe('deep-link navigation', () => {
     useSessionStore.setState({ sessions: [session, nextSession] })
 
     await renderHook({ isHydrated: true, isReady: true })
-    act(() => useNavigationStore.getState().openSession(project.id, nextSession.id))
+    act(() => useNavigationStore.getState().openSession(project.id, nextSession.id, 'user'))
 
     expect(window.location.search).toBe('?project=project-1&session=session-2')
   })

--- a/src/renderer/src/lib/deep-link.navigation.test.tsx
+++ b/src/renderer/src/lib/deep-link.navigation.test.tsx
@@ -53,7 +53,8 @@ beforeEach(() => {
   useNavigationStore.setState({
     view: 'home',
     activeProjectId: undefined,
-    userNavigationRevision: 0
+    userNavigationRevision: 0,
+    explicitNavigationRevision: 0
   })
   useProjectStore.setState(createInitialProjectState())
   useSessionStore.setState(createInitialSessionState())
@@ -94,6 +95,41 @@ describe('deep-link navigation', () => {
       activeProjectId: project.id
     })
     expect(useSessionStore.getState().selectedSessionId).toBe(session.id)
+  })
+
+  it('preserves notification navigation over a deferred startup deep link', async () => {
+    const notificationProject: Project = {
+      ...project,
+      id: 'project-2',
+      name: 'Notification research'
+    }
+    const notificationSession: ChatSession = {
+      ...session,
+      id: 'session-2',
+      projectId: notificationProject.id,
+      title: 'Notification session'
+    }
+    window.history.replaceState({}, '', '/?project=project-1&session=session-1')
+    useProjectStore.setState({
+      projects: [project, notificationProject],
+      isLoaded: false
+    })
+    useSessionStore.setState({ sessions: [session, notificationSession] })
+
+    await renderHook({ isHydrated: true, isReady: true })
+
+    act(() =>
+      useNavigationStore
+        .getState()
+        .openSession(notificationProject.id, notificationSession.id, 'notification')
+    )
+    act(() => useProjectStore.setState({ isLoaded: true }))
+
+    expect(useNavigationStore.getState()).toMatchObject({
+      view: 'workspace',
+      activeProjectId: notificationProject.id
+    })
+    expect(useSessionStore.getState().selectedSessionId).toBe(notificationSession.id)
   })
 
   it('opens an already-hydrated session during partial recovery', async () => {

--- a/src/renderer/src/lib/deep-link.navigation.test.tsx
+++ b/src/renderer/src/lib/deep-link.navigation.test.tsx
@@ -114,6 +114,39 @@ describe('deep-link navigation', () => {
     expect(window.location.search).toBe('?project=project-1&session=session-1')
   })
 
+  it('does not replay an unresolved target after the user navigates elsewhere', async () => {
+    const otherProject: Project = { ...project, id: 'project-2', name: 'Other research' }
+    const otherSession: ChatSession = {
+      ...session,
+      id: 'session-2',
+      projectId: otherProject.id,
+      title: 'Other session'
+    }
+    window.history.replaceState({}, '', '/?project=project-1&session=session-1')
+    useProjectStore.setState({ projects: [project, otherProject], isLoaded: true })
+    useSessionStore.setState({ sessions: [otherSession] })
+
+    const hook = await renderHook({ isHydrated: true, isReady: false })
+
+    expect(window.location.search).toBe('?project=project-1&session=session-1')
+
+    act(() => useNavigationStore.getState().openSession(otherProject.id, otherSession.id))
+    expect(useNavigationStore.getState()).toMatchObject({
+      view: 'workspace',
+      activeProjectId: otherProject.id
+    })
+
+    act(() => useSessionStore.setState({ sessions: [session, otherSession] }))
+    await hook.rerender({ isHydrated: true, isReady: true })
+
+    expect(useNavigationStore.getState()).toMatchObject({
+      view: 'workspace',
+      activeProjectId: otherProject.id
+    })
+    expect(useSessionStore.getState().selectedSessionId).toBe(otherSession.id)
+    expect(window.location.search).toBe('?project=project-2&session=session-2')
+  })
+
   it('returns Home when the session parameter is missing', async () => {
     window.history.replaceState({}, '', '/?project=project-1')
     useProjectStore.setState({ projects: [project], isLoaded: true })

--- a/src/renderer/src/lib/deep-link.navigation.test.tsx
+++ b/src/renderer/src/lib/deep-link.navigation.test.tsx
@@ -35,8 +35,13 @@ const session: ChatSession = {
   updatedAt: 1
 }
 
-const HookHarness = ({ isReady }: { isReady: boolean }): null => {
-  useDeepLinkNavigation(isReady)
+type HookHarnessProps = {
+  isHydrated: boolean
+  isReady: boolean
+}
+
+const HookHarness = ({ isHydrated, isReady }: HookHarnessProps): null => {
+  useDeepLinkNavigation({ isHydrated, isReady })
 
   return null
 }
@@ -57,31 +62,31 @@ afterEach(async () => {
 })
 
 const renderHook = async (
-  isReady: boolean
-): Promise<{ rerender: (nextIsReady: boolean) => Promise<void> }> => {
+  readiness: HookHarnessProps
+): Promise<{ rerender: (nextReadiness: HookHarnessProps) => Promise<void> }> => {
   const container = document.createElement('div')
   root = createRoot(container)
 
-  await act(async () => root?.render(createElement(HookHarness, { isReady })))
+  await act(async () => root?.render(createElement(HookHarness, readiness)))
 
   return {
-    rerender: async (nextIsReady) => {
-      await act(async () => root?.render(createElement(HookHarness, { isReady: nextIsReady })))
+    rerender: async (nextReadiness) => {
+      await act(async () => root?.render(createElement(HookHarness, nextReadiness)))
     }
   }
 }
 
 describe('deep-link navigation', () => {
-  it('opens a valid session only after projects and sessions are ready', async () => {
+  it('opens an already-hydrated session during partial recovery', async () => {
     window.history.replaceState({}, '', '/?project=project-1&session=session-1')
     useSessionStore.setState({ sessions: [session] })
 
-    const hook = await renderHook(false)
+    const hook = await renderHook({ isHydrated: false, isReady: false })
 
     act(() => useProjectStore.setState({ projects: [project], isLoaded: true }))
     expect(useNavigationStore.getState().view).toBe('home')
 
-    await hook.rerender(true)
+    await hook.rerender({ isHydrated: true, isReady: false })
 
     expect(useNavigationStore.getState()).toMatchObject({
       view: 'workspace',
@@ -90,12 +95,31 @@ describe('deep-link navigation', () => {
     expect(useSessionStore.getState().selectedSessionId).toBe(session.id)
   })
 
+  it('retains an unresolved target until a retry completes the Session scan', async () => {
+    window.history.replaceState({}, '', '/?project=project-1&session=session-1')
+    useProjectStore.setState({ projects: [project], isLoaded: true })
+
+    const hook = await renderHook({ isHydrated: true, isReady: false })
+
+    expect(useNavigationStore.getState().view).toBe('home')
+    expect(window.location.search).toBe('?project=project-1&session=session-1')
+
+    act(() => useSessionStore.setState({ sessions: [session] }))
+    await hook.rerender({ isHydrated: true, isReady: true })
+
+    expect(useNavigationStore.getState()).toMatchObject({
+      view: 'workspace',
+      activeProjectId: project.id
+    })
+    expect(window.location.search).toBe('?project=project-1&session=session-1')
+  })
+
   it('returns Home when the session parameter is missing', async () => {
     window.history.replaceState({}, '', '/?project=project-1')
     useProjectStore.setState({ projects: [project], isLoaded: true })
     useSessionStore.setState({ sessions: [session] })
 
-    await renderHook(true)
+    await renderHook({ isHydrated: true, isReady: false })
 
     expect(useNavigationStore.getState().view).toBe('home')
     expect(window.location.search).toBe('')
@@ -106,7 +130,7 @@ describe('deep-link navigation', () => {
     useProjectStore.setState({ projects: [project], isLoaded: true })
     useSessionStore.setState({ sessions: [{ ...session, projectId: 'project-2' }] })
 
-    await renderHook(true)
+    await renderHook({ isHydrated: true, isReady: true })
 
     expect(useNavigationStore.getState().view).toBe('home')
     expect(window.location.search).toBe('')
@@ -118,7 +142,7 @@ describe('deep-link navigation', () => {
     useSessionStore.setState({ sessions: [session] })
     const replaceState = vi.spyOn(window.history, 'replaceState')
 
-    await renderHook(true)
+    await renderHook({ isHydrated: true, isReady: true })
     replaceState.mockClear()
 
     act(() => useSessionStore.setState({ sessions: [{ ...session, title: 'Updated' }] }))
@@ -132,7 +156,7 @@ describe('deep-link navigation', () => {
     useProjectStore.setState({ projects: [project], isLoaded: true })
     useSessionStore.setState({ sessions: [session, nextSession] })
 
-    await renderHook(true)
+    await renderHook({ isHydrated: true, isReady: true })
     act(() => useNavigationStore.getState().openSession(project.id, nextSession.id))
 
     expect(window.location.search).toBe('?project=project-1&session=session-2')
@@ -144,7 +168,7 @@ describe('deep-link navigation', () => {
     useSessionStore.setState({ sessions: [session] })
     const replaceState = vi.spyOn(window.history, 'replaceState')
 
-    await renderHook(true)
+    await renderHook({ isHydrated: true, isReady: true })
     replaceState.mockClear()
     await act(async () => root?.unmount())
     root = undefined

--- a/src/renderer/src/lib/deep-link.navigation.test.tsx
+++ b/src/renderer/src/lib/deep-link.navigation.test.tsx
@@ -81,6 +81,21 @@ const renderHook = async (
 }
 
 describe('deep-link navigation', () => {
+  it('preserves notification navigation when no deep-link target was supplied', async () => {
+    window.history.replaceState({}, '', '/')
+    useProjectStore.setState({ projects: [project], isLoaded: true })
+    useSessionStore.setState({ sessions: [session] })
+    act(() => useNavigationStore.getState().openSession(project.id, session.id, 'automatic'))
+
+    await renderHook({ isHydrated: true, isReady: true })
+
+    expect(useNavigationStore.getState()).toMatchObject({
+      view: 'workspace',
+      activeProjectId: project.id
+    })
+    expect(useSessionStore.getState().selectedSessionId).toBe(session.id)
+  })
+
   it('opens an already-hydrated session during partial recovery', async () => {
     window.history.replaceState({}, '', '/?project=project-1&session=session-1')
     useSessionStore.setState({ sessions: [session] })

--- a/src/renderer/src/lib/deep-link.ts
+++ b/src/renderer/src/lib/deep-link.ts
@@ -9,6 +9,11 @@ type DeepLinkParams = {
   sessionId: string | undefined
 }
 
+type DeepLinkNavigationReadiness = {
+  isHydrated: boolean
+  isReady: boolean
+}
+
 const isWebLocation = (): boolean =>
   typeof window !== 'undefined' &&
   (window.location.protocol === 'http:' || window.location.protocol === 'https:')
@@ -41,9 +46,9 @@ const replaceNavigationParams = (
   window.history.replaceState(window.history.state, '', `${url.pathname}${url.search}${url.hash}`)
 }
 
-// Applies the initial URL only after both persisted data sources are ready, then keeps navigation
-// reflected in the address bar without introducing a client-side router.
-const useDeepLinkNavigation = (isSessionPersistenceReady: boolean): void => {
+// Opens already-hydrated targets during recovery, but retains unresolved initial parameters until a
+// complete Session scan can distinguish a missing target from one that was temporarily omitted.
+const useDeepLinkNavigation = ({ isHydrated, isReady }: DeepLinkNavigationReadiness): void => {
   const isProjectsLoaded = useProjectStore((state) => state.isLoaded)
   const initialParams = useRef<DeepLinkParams | undefined>(
     isWebLocation() ? readDeepLinkParams() : undefined
@@ -52,9 +57,8 @@ const useDeepLinkNavigation = (isSessionPersistenceReady: boolean): void => {
   const [isInitialized, setIsInitialized] = useState(() => !isWebLocation())
 
   useEffect(() => {
-    if (initialized.current || !isProjectsLoaded || !isSessionPersistenceReady) return
+    if (initialized.current || !isProjectsLoaded || !isHydrated) return
 
-    initialized.current = true
     const { projectId, sessionId } = initialParams.current ?? {}
     const projectExists = useProjectStore
       .getState()
@@ -68,12 +72,15 @@ const useDeepLinkNavigation = (isSessionPersistenceReady: boolean): void => {
 
     if (projectId && sessionId && sessionExists) {
       useNavigationStore.getState().openSession(projectId, sessionId)
+    } else if (projectId && sessionId && projectExists && !isReady) {
+      return
     } else {
       useNavigationStore.getState().goHome()
     }
 
+    initialized.current = true
     setIsInitialized(true)
-  }, [isProjectsLoaded, isSessionPersistenceReady])
+  }, [isHydrated, isProjectsLoaded, isReady])
 
   useEffect(() => {
     if (!isInitialized) return
@@ -101,4 +108,4 @@ const useDeepLinkNavigation = (isSessionPersistenceReady: boolean): void => {
 }
 
 export { isWebLocation, readDeepLinkParams, replaceNavigationParams, useDeepLinkNavigation }
-export type { DeepLinkParams }
+export type { DeepLinkNavigationReadiness, DeepLinkParams }

--- a/src/renderer/src/lib/deep-link.ts
+++ b/src/renderer/src/lib/deep-link.ts
@@ -63,8 +63,13 @@ const useDeepLinkNavigation = ({ isHydrated, isReady }: DeepLinkNavigationReadin
   useEffect(() => {
     if (isInitialized) return
 
-    return useNavigationStore.subscribe(() => {
-      if (initialized.current) return
+    return useNavigationStore.subscribe((state, previousState) => {
+      if (
+        initialized.current ||
+        state.userNavigationRevision === previousState.userNavigationRevision
+      ) {
+        return
+      }
 
       initialized.current = true
       initialParams.current = undefined
@@ -88,12 +93,12 @@ const useDeepLinkNavigation = ({ isHydrated, isReady }: DeepLinkNavigationReadin
 
     if (projectId && sessionId && sessionExists) {
       initialized.current = true
-      useNavigationStore.getState().openSession(projectId, sessionId)
+      useNavigationStore.getState().openSession(projectId, sessionId, 'automatic')
     } else if (projectId && sessionId && projectExists && !isReady) {
       return
     } else {
       initialized.current = true
-      useNavigationStore.getState().goHome()
+      useNavigationStore.getState().goHome('automatic')
     }
 
     setIsInitialized(true)

--- a/src/renderer/src/lib/deep-link.ts
+++ b/src/renderer/src/lib/deep-link.ts
@@ -50,6 +50,7 @@ const replaceNavigationParams = (
 // complete Session scan can distinguish a missing target from one that was temporarily omitted.
 const useDeepLinkNavigation = ({ isHydrated, isReady }: DeepLinkNavigationReadiness): void => {
   const isProjectsLoaded = useProjectStore((state) => state.isLoaded)
+  const projectLoadError = useProjectStore((state) => state.loadError)
   const initialParams = useRef<DeepLinkParams | undefined>(
     isWebLocation() ? readDeepLinkParams() : undefined
   )
@@ -77,7 +78,9 @@ const useDeepLinkNavigation = ({ isHydrated, isReady }: DeepLinkNavigationReadin
   }, [isInitialized])
 
   useEffect(() => {
-    if (initialized.current || !isProjectsLoaded || !isHydrated) return
+    if (initialized.current || !isProjectsLoaded || projectLoadError !== undefined || !isHydrated) {
+      return
+    }
 
     const { projectId, sessionId } = initialParams.current ?? {}
 
@@ -110,7 +113,7 @@ const useDeepLinkNavigation = ({ isHydrated, isReady }: DeepLinkNavigationReadin
     }
 
     setIsInitialized(true)
-  }, [isHydrated, isProjectsLoaded, isReady])
+  }, [isHydrated, isProjectsLoaded, isReady, projectLoadError])
 
   useEffect(() => {
     if (!isInitialized) return

--- a/src/renderer/src/lib/deep-link.ts
+++ b/src/renderer/src/lib/deep-link.ts
@@ -56,17 +56,16 @@ const useDeepLinkNavigation = ({ isHydrated, isReady }: DeepLinkNavigationReadin
   const initialized = useRef(!isWebLocation())
   const [isInitialized, setIsInitialized] = useState(() => !isWebLocation())
 
-  // While an initial target is deferred by partial recovery, any explicit navigation means the user
-  // has taken control. Drop the stale target so a later storage retry cannot override their choice.
-  // Session hydration itself does not touch this store, so background recovery is not mistaken for
-  // user navigation.
+  // While an initial target is deferred by partial recovery, an explicit in-app or notification
+  // navigation takes control. Drop the stale target so later loading cannot override that choice.
+  // Lifecycle redirects and Session hydration do not advance this revision.
   useEffect(() => {
     if (isInitialized) return
 
     return useNavigationStore.subscribe((state, previousState) => {
       if (
         initialized.current ||
-        state.userNavigationRevision === previousState.userNavigationRevision
+        state.explicitNavigationRevision === previousState.explicitNavigationRevision
       ) {
         return
       }

--- a/src/renderer/src/lib/deep-link.ts
+++ b/src/renderer/src/lib/deep-link.ts
@@ -81,6 +81,15 @@ const useDeepLinkNavigation = ({ isHydrated, isReady }: DeepLinkNavigationReadin
     if (initialized.current || !isProjectsLoaded || !isHydrated) return
 
     const { projectId, sessionId } = initialParams.current ?? {}
+
+    // No launch target means this hook has nothing to resolve. Preserve navigation that may already
+    // have been applied by a desktop-notification click while projects were still loading.
+    if (!projectId && !sessionId) {
+      initialized.current = true
+      setIsInitialized(true)
+      return
+    }
+
     const projectExists = useProjectStore
       .getState()
       .projects.some((project) => project.id === projectId)

--- a/src/renderer/src/lib/deep-link.ts
+++ b/src/renderer/src/lib/deep-link.ts
@@ -56,6 +56,22 @@ const useDeepLinkNavigation = ({ isHydrated, isReady }: DeepLinkNavigationReadin
   const initialized = useRef(!isWebLocation())
   const [isInitialized, setIsInitialized] = useState(() => !isWebLocation())
 
+  // While an initial target is deferred by partial recovery, any explicit navigation means the user
+  // has taken control. Drop the stale target so a later storage retry cannot override their choice.
+  // Session hydration itself does not touch this store, so background recovery is not mistaken for
+  // user navigation.
+  useEffect(() => {
+    if (isInitialized) return
+
+    return useNavigationStore.subscribe(() => {
+      if (initialized.current) return
+
+      initialized.current = true
+      initialParams.current = undefined
+      setIsInitialized(true)
+    })
+  }, [isInitialized])
+
   useEffect(() => {
     if (initialized.current || !isProjectsLoaded || !isHydrated) return
 
@@ -71,14 +87,15 @@ const useDeepLinkNavigation = ({ isHydrated, isReady }: DeepLinkNavigationReadin
         .sessions.some((session) => session.id === sessionId && session.projectId === projectId)
 
     if (projectId && sessionId && sessionExists) {
+      initialized.current = true
       useNavigationStore.getState().openSession(projectId, sessionId)
     } else if (projectId && sessionId && projectExists && !isReady) {
       return
     } else {
+      initialized.current = true
       useNavigationStore.getState().goHome()
     }
 
-    initialized.current = true
     setIsInitialized(true)
   }, [isHydrated, isProjectsLoaded, isReady])
 

--- a/src/renderer/src/lib/session-persistence/session-persistence.render.test.tsx
+++ b/src/renderer/src/lib/session-persistence/session-persistence.render.test.tsx
@@ -73,6 +73,7 @@ describe('session persistence startup', () => {
         data-hydrated={String(persistence.isHydrated)}
         data-loading={String(persistence.isLoading)}
         data-ready={String(persistence.isReady)}
+        data-catalog-complete={String(persistence.hasCompleteSessionCatalog)}
       >
         <span data-testid="load-error">{persistence.loadError ?? 'sessions available'}</span>
         <span data-testid="load-warning">{persistence.loadWarning ?? 'no load warnings'}</span>
@@ -107,6 +108,7 @@ describe('session persistence startup', () => {
 
     expect(loadAll).toHaveBeenCalledTimes(2)
     expect(container.querySelector('div')?.dataset.ready).toBe('true')
+    expect(container.querySelector('div')?.dataset.catalogComplete).toBe('true')
     expect(container.querySelector('div')?.dataset.hydrated).toBe('true')
     expect(container.querySelector('div')?.dataset.loading).toBe('false')
     expect(container.querySelector('[data-testid="load-error"]')?.textContent).toContain(
@@ -388,6 +390,7 @@ describe('session persistence startup', () => {
     await act(async () => root.render(<Probe />))
 
     expect(container.querySelector('div')?.dataset.ready).toBe('true')
+    expect(container.querySelector('div')?.dataset.catalogComplete).toBe('false')
     expect(container.querySelector('[data-testid="load-warning"]')?.textContent).toContain(
       'damaged and moved aside'
     )
@@ -434,6 +437,7 @@ describe('session persistence startup', () => {
     await act(async () => root.render(<Probe />))
 
     expect(container.querySelector('div')?.dataset.ready).toBe('true')
+    expect(container.querySelector('div')?.dataset.catalogComplete).toBe('true')
     expect(container.querySelector('[data-testid="load-warning"]')?.textContent).toContain(
       'Conversation selection data could not be read, so no conversation was selected'
     )

--- a/src/renderer/src/lib/session-persistence/session-persistence.render.test.tsx
+++ b/src/renderer/src/lib/session-persistence/session-persistence.render.test.tsx
@@ -50,7 +50,7 @@ describe('session persistence startup', () => {
     const persistence: SessionPersistenceState = useSessionPersistence()
 
     return (
-      <div data-ready={String(persistence.isReady)}>
+      <div data-hydrated={String(persistence.isHydrated)} data-ready={String(persistence.isReady)}>
         <span data-testid="load-error">{persistence.loadError ?? 'sessions available'}</span>
         <span data-testid="load-warning">{persistence.loadWarning ?? 'no load warnings'}</span>
         <span data-testid="write-error">{persistence.writeError ?? 'changes saved'}</span>
@@ -68,6 +68,7 @@ describe('session persistence startup', () => {
     await act(async () => root.render(<Probe />))
 
     expect(container.querySelector('div')?.dataset.ready).toBe('false')
+    expect(container.querySelector('div')?.dataset.hydrated).toBe('false')
     expect(container.querySelector('[data-testid="load-error"]')?.textContent).toContain(
       'sessions directory unavailable'
     )
@@ -79,6 +80,7 @@ describe('session persistence startup', () => {
 
     expect(loadAll).toHaveBeenCalledTimes(2)
     expect(container.querySelector('div')?.dataset.ready).toBe('true')
+    expect(container.querySelector('div')?.dataset.hydrated).toBe('true')
     expect(container.querySelector('[data-testid="load-error"]')?.textContent).toContain(
       'sessions available'
     )
@@ -182,6 +184,7 @@ describe('session persistence startup', () => {
     await act(async () => root.render(<Probe />))
 
     expect(container.querySelector('div')?.dataset.ready).toBe('false')
+    expect(container.querySelector('div')?.dataset.hydrated).toBe('true')
     expect(container.querySelector('[data-testid="load-error"]')?.textContent).toContain(
       'could not be read'
     )

--- a/src/renderer/src/lib/session-persistence/session-persistence.render.test.tsx
+++ b/src/renderer/src/lib/session-persistence/session-persistence.render.test.tsx
@@ -1,0 +1,265 @@
+// @vitest-environment jsdom
+import { act } from 'react'
+import { createRoot, type Root } from 'react-dom/client'
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest'
+
+import {
+  SESSION_MANIFEST_VERSION,
+  type LoadAllSessionsResult
+} from '../../../../shared/session-persistence'
+import { createInitialSessionState, useSessionStore } from '../../stores/session-store'
+import { useSessionPersistence, type SessionPersistenceState } from './session-persistence'
+
+const emptyLoadResult = (): LoadAllSessionsResult => ({
+  sessions: [],
+  manifest: { version: SESSION_MANIFEST_VERSION }
+})
+
+describe('session persistence startup', () => {
+  let container: HTMLDivElement
+  let root: Root
+  let loadAll: ReturnType<typeof vi.fn>
+  let saveSession: ReturnType<typeof vi.fn>
+
+  beforeEach(() => {
+    container = document.createElement('div')
+    document.body.appendChild(container)
+    root = createRoot(container)
+    loadAll = vi.fn().mockRejectedValueOnce(new Error('sessions directory unavailable'))
+    saveSession = vi.fn(async (session) => session)
+    window.api = {
+      sessions: {
+        loadAll,
+        saveSession,
+        deleteSession: vi.fn().mockResolvedValue(undefined),
+        saveManifest: vi.fn().mockResolvedValue(undefined)
+      },
+      artifacts: {
+        reconcilePendingArtifacts: vi.fn().mockResolvedValue([])
+      }
+    } as unknown as Window['api']
+    useSessionStore.setState(createInitialSessionState())
+  })
+
+  afterEach(async () => {
+    await act(async () => root.unmount())
+    container.remove()
+  })
+
+  const Probe = (): React.JSX.Element => {
+    const persistence: SessionPersistenceState = useSessionPersistence()
+
+    return (
+      <div data-ready={String(persistence.isReady)}>
+        <span data-testid="load-error">{persistence.loadError ?? 'sessions available'}</span>
+        <span data-testid="load-warning">{persistence.loadWarning ?? 'no load warnings'}</span>
+        <span data-testid="write-error">{persistence.writeError ?? 'changes saved'}</span>
+        <button type="button" data-testid="retry-load" onClick={persistence.retryLoad}>
+          Retry load
+        </button>
+        <button type="button" data-testid="retry-writes" onClick={persistence.retryWrites}>
+          Retry writes
+        </button>
+      </div>
+    )
+  }
+
+  it('keeps session actions blocked after a load failure and recovers on retry', async () => {
+    await act(async () => root.render(<Probe />))
+
+    expect(container.querySelector('div')?.dataset.ready).toBe('false')
+    expect(container.querySelector('[data-testid="load-error"]')?.textContent).toContain(
+      'sessions directory unavailable'
+    )
+
+    loadAll.mockResolvedValueOnce(emptyLoadResult())
+    await act(async () =>
+      container.querySelector<HTMLButtonElement>('[data-testid="retry-load"]')?.click()
+    )
+
+    expect(loadAll).toHaveBeenCalledTimes(2)
+    expect(container.querySelector('div')?.dataset.ready).toBe('true')
+    expect(container.querySelector('[data-testid="load-error"]')?.textContent).toContain(
+      'sessions available'
+    )
+  })
+
+  it('surfaces a save failure and retries the latest in-memory session', async () => {
+    let writesFail = true
+    loadAll.mockReset().mockResolvedValue(emptyLoadResult())
+    saveSession.mockImplementation(async (session) => {
+      if (writesFail) throw new Error('disk full')
+      return session
+    })
+
+    await act(async () => root.render(<Probe />))
+
+    await act(async () => {
+      useSessionStore.getState().appendUserMessage({
+        sessionId: 'session-1',
+        content: 'First version',
+        cwd: '/workspace/project',
+        projectId: 'project-a'
+      })
+      await Promise.resolve()
+    })
+    expect(container.querySelector('[data-testid="write-error"]')?.textContent).toContain(
+      'disk full'
+    )
+
+    await act(async () => {
+      useSessionStore.getState().appendUserMessage({
+        sessionId: 'session-1',
+        content: 'Latest version',
+        cwd: '/workspace/project'
+      })
+      await Promise.resolve()
+    })
+
+    writesFail = false
+    await act(async () =>
+      container.querySelector<HTMLButtonElement>('[data-testid="retry-writes"]')?.click()
+    )
+
+    expect(saveSession.mock.calls.at(-1)?.[0].messages).toEqual(
+      expect.arrayContaining([expect.objectContaining({ content: 'Latest version' })])
+    )
+    expect(container.querySelector('[data-testid="write-error"]')?.textContent).toContain(
+      'changes saved'
+    )
+  })
+
+  it('clears a failed write target after its session is durably deleted', async () => {
+    loadAll.mockReset().mockResolvedValue(emptyLoadResult())
+    saveSession.mockRejectedValue(new Error('disk full'))
+
+    await act(async () => root.render(<Probe />))
+
+    await act(async () => {
+      useSessionStore.getState().appendUserMessage({
+        sessionId: 'session-1',
+        content: 'Delete me after the failed save',
+        cwd: '/workspace/project',
+        projectId: 'project-a'
+      })
+      await Promise.resolve()
+    })
+    expect(container.querySelector('[data-testid="write-error"]')?.textContent).toContain(
+      'disk full'
+    )
+
+    await act(async () => {
+      // Production removes renderer state only after the authoritative delete IPC succeeds.
+      useSessionStore.getState().deleteSession('session-1')
+      await Promise.resolve()
+    })
+    await act(async () =>
+      container.querySelector<HTMLButtonElement>('[data-testid="retry-writes"]')?.click()
+    )
+
+    expect(saveSession).toHaveBeenCalledTimes(1)
+    expect(container.querySelector('[data-testid="write-error"]')?.textContent).toContain(
+      'changes saved'
+    )
+  })
+
+  it('keeps persistence blocked when the durable Session scan is incomplete', async () => {
+    loadAll.mockReset().mockResolvedValue({
+      ...emptyLoadResult(),
+      diagnostics: {
+        isComplete: false,
+        warnings: [
+          {
+            kind: 'unreadable',
+            projectId: 'project-a',
+            fileName: 'session-1.json',
+            recovered: false
+          }
+        ]
+      }
+    })
+
+    await act(async () => root.render(<Probe />))
+
+    expect(container.querySelector('div')?.dataset.ready).toBe('false')
+    expect(container.querySelector('[data-testid="load-error"]')?.textContent).toContain(
+      'could not be read'
+    )
+
+    await act(async () => {
+      useSessionStore.getState().appendUserMessage({
+        sessionId: 'session-2',
+        content: 'Must not save against a partial scan',
+        cwd: '/workspace/project',
+        projectId: 'project-a'
+      })
+      await Promise.resolve()
+    })
+    expect(saveSession).not.toHaveBeenCalled()
+  })
+
+  it('keeps persistence blocked when startup storage recovery is incomplete', async () => {
+    loadAll.mockReset().mockResolvedValue({
+      ...emptyLoadResult(),
+      diagnostics: {
+        isComplete: false,
+        warnings: [],
+        failure: 'startup-reconciliation-failed'
+      }
+    })
+
+    await act(async () => root.render(<Probe />))
+
+    expect(container.querySelector('div')?.dataset.ready).toBe('false')
+    expect(container.querySelector('[data-testid="load-error"]')?.textContent).toContain(
+      'storage recovery could not finish'
+    )
+  })
+
+  it('loads healthy conversations while warning about quarantined corrupt files', async () => {
+    loadAll.mockReset().mockResolvedValue({
+      ...emptyLoadResult(),
+      diagnostics: {
+        isComplete: true,
+        warnings: [
+          {
+            kind: 'corrupt',
+            projectId: 'project-a',
+            fileName: 'broken.json',
+            recovered: true
+          }
+        ]
+      }
+    })
+
+    await act(async () => root.render(<Probe />))
+
+    expect(container.querySelector('div')?.dataset.ready).toBe('true')
+    expect(container.querySelector('[data-testid="load-warning"]')?.textContent).toContain(
+      'damaged and moved aside'
+    )
+  })
+
+  it('loads conversations after corrupt selection data is isolated', async () => {
+    loadAll.mockReset().mockResolvedValue({
+      ...emptyLoadResult(),
+      diagnostics: {
+        isComplete: true,
+        warnings: [
+          {
+            kind: 'manifest-corrupt',
+            fileName: 'manifest.json',
+            recovered: true
+          }
+        ]
+      }
+    })
+
+    await act(async () => root.render(<Probe />))
+
+    expect(container.querySelector('div')?.dataset.ready).toBe('true')
+    expect(container.querySelector('[data-testid="load-warning"]')?.textContent).toContain(
+      'Conversation selection data was damaged and moved aside'
+    )
+  })
+})

--- a/src/renderer/src/lib/session-persistence/session-persistence.render.test.tsx
+++ b/src/renderer/src/lib/session-persistence/session-persistence.render.test.tsx
@@ -178,7 +178,7 @@ describe('session persistence startup', () => {
     )
   })
 
-  it('clears a failed write target after its session is durably deleted', async () => {
+  it('automatically clears a failed write target after its session is durably deleted', async () => {
     loadAll.mockReset().mockResolvedValue(emptyLoadResult())
     saveSession.mockRejectedValue(new Error('disk full'))
 
@@ -202,9 +202,6 @@ describe('session persistence startup', () => {
       useSessionStore.getState().deleteSession('session-1')
       await Promise.resolve()
     })
-    await act(async () =>
-      container.querySelector<HTMLButtonElement>('[data-testid="retry-writes"]')?.click()
-    )
 
     expect(saveSession).toHaveBeenCalledTimes(1)
     expect(container.querySelector('[data-testid="write-error"]')?.textContent).toContain(

--- a/src/renderer/src/lib/session-persistence/session-persistence.render.test.tsx
+++ b/src/renderer/src/lib/session-persistence/session-persistence.render.test.tsx
@@ -5,7 +5,8 @@ import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest'
 
 import {
   SESSION_MANIFEST_VERSION,
-  type LoadAllSessionsResult
+  type LoadAllSessionsResult,
+  type PersistedChatSession
 } from '../../../../shared/session-persistence'
 import { createInitialSessionState, useSessionStore } from '../../stores/session-store'
 import { useSessionPersistence, type SessionPersistenceState } from './session-persistence'
@@ -13,6 +14,20 @@ import { useSessionPersistence, type SessionPersistenceState } from './session-p
 const emptyLoadResult = (): LoadAllSessionsResult => ({
   sessions: [],
   manifest: { version: SESSION_MANIFEST_VERSION }
+})
+
+const createPersistedSession = (
+  overrides: Partial<PersistedChatSession> = {}
+): PersistedChatSession => ({
+  id: 'session-1',
+  projectId: 'project-a',
+  title: 'Restored',
+  cwd: '/workspace/project-a',
+  status: 'idle',
+  messages: [],
+  createdAt: 1,
+  updatedAt: 1,
+  ...overrides
 })
 
 describe('session persistence startup', () => {
@@ -231,6 +246,42 @@ describe('session persistence startup', () => {
       await Promise.resolve()
     })
     expect(saveSession).not.toHaveBeenCalled()
+  })
+
+  it('preserves a live session selection when retrying a partial recovery', async () => {
+    const manifestSession = createPersistedSession({ id: 'manifest-session' })
+    const selectedSession = createPersistedSession({
+      id: 'selected-session',
+      projectId: 'project-b',
+      cwd: '/workspace/project-b',
+      updatedAt: 2
+    })
+    const sessions = [manifestSession, selectedSession]
+    const manifest = {
+      version: SESSION_MANIFEST_VERSION,
+      lastProjectId: manifestSession.projectId,
+      lastSessionId: manifestSession.id
+    }
+    loadAll
+      .mockReset()
+      .mockResolvedValueOnce({
+        sessions,
+        manifest,
+        diagnostics: { isComplete: false, warnings: [] }
+      })
+      .mockResolvedValueOnce({ sessions, manifest })
+
+    await act(async () => root.render(<Probe />))
+
+    expect(useSessionStore.getState().selectedSessionId).toBe(manifestSession.id)
+    act(() => useSessionStore.getState().selectSession(selectedSession.id))
+
+    await act(async () =>
+      container.querySelector<HTMLButtonElement>('[data-testid="retry-load"]')?.click()
+    )
+
+    expect(container.querySelector('div')?.dataset.ready).toBe('true')
+    expect(useSessionStore.getState().selectedSessionId).toBe(selectedSession.id)
   })
 
   it('keeps persistence blocked when startup storage recovery is incomplete', async () => {

--- a/src/renderer/src/lib/session-persistence/session-persistence.render.test.tsx
+++ b/src/renderer/src/lib/session-persistence/session-persistence.render.test.tsx
@@ -50,7 +50,11 @@ describe('session persistence startup', () => {
     const persistence: SessionPersistenceState = useSessionPersistence()
 
     return (
-      <div data-hydrated={String(persistence.isHydrated)} data-ready={String(persistence.isReady)}>
+      <div
+        data-hydrated={String(persistence.isHydrated)}
+        data-loading={String(persistence.isLoading)}
+        data-ready={String(persistence.isReady)}
+      >
         <span data-testid="load-error">{persistence.loadError ?? 'sessions available'}</span>
         <span data-testid="load-warning">{persistence.loadWarning ?? 'no load warnings'}</span>
         <span data-testid="write-error">{persistence.writeError ?? 'changes saved'}</span>
@@ -69,6 +73,7 @@ describe('session persistence startup', () => {
 
     expect(container.querySelector('div')?.dataset.ready).toBe('false')
     expect(container.querySelector('div')?.dataset.hydrated).toBe('false')
+    expect(container.querySelector('div')?.dataset.loading).toBe('false')
     expect(container.querySelector('[data-testid="load-error"]')?.textContent).toContain(
       'sessions directory unavailable'
     )
@@ -81,9 +86,36 @@ describe('session persistence startup', () => {
     expect(loadAll).toHaveBeenCalledTimes(2)
     expect(container.querySelector('div')?.dataset.ready).toBe('true')
     expect(container.querySelector('div')?.dataset.hydrated).toBe('true')
+    expect(container.querySelector('div')?.dataset.loading).toBe('false')
     expect(container.querySelector('[data-testid="load-error"]')?.textContent).toContain(
       'sessions available'
     )
+  })
+
+  it('keeps startup blocked while a failed load retry is pending', async () => {
+    await act(async () => root.render(<Probe />))
+
+    let resolveRetry: ((result: LoadAllSessionsResult) => void) | undefined
+    loadAll.mockImplementationOnce(
+      () =>
+        new Promise<LoadAllSessionsResult>((resolve) => {
+          resolveRetry = resolve
+        })
+    )
+
+    await act(async () =>
+      container.querySelector<HTMLButtonElement>('[data-testid="retry-load"]')?.click()
+    )
+
+    expect(container.querySelector('div')?.dataset.hydrated).toBe('false')
+    expect(container.querySelector('div')?.dataset.loading).toBe('true')
+    expect(container.querySelector('div')?.dataset.ready).toBe('false')
+
+    await act(async () => resolveRetry?.(emptyLoadResult()))
+
+    expect(container.querySelector('div')?.dataset.hydrated).toBe('true')
+    expect(container.querySelector('div')?.dataset.loading).toBe('false')
+    expect(container.querySelector('div')?.dataset.ready).toBe('true')
   })
 
   it('surfaces a save failure and retries the latest in-memory session', async () => {

--- a/src/renderer/src/lib/session-persistence/session-persistence.render.test.tsx
+++ b/src/renderer/src/lib/session-persistence/session-persistence.render.test.tsx
@@ -94,6 +94,13 @@ describe('session persistence startup', () => {
         <button type="button" data-testid="retry-writes" onClick={persistence.retryWrites}>
           Retry writes
         </button>
+        <button
+          type="button"
+          data-testid="dismiss-load-warning"
+          onClick={persistence.dismissLoadWarning}
+        >
+          Dismiss warning
+        </button>
       </div>
     )
   }
@@ -157,7 +164,11 @@ describe('session persistence startup', () => {
     let writesFail = true
     loadAll.mockReset().mockResolvedValue(emptyLoadResult())
     saveSession.mockImplementation(async (session) => {
-      if (writesFail) throw new Error('disk full')
+      if (writesFail) {
+        throw new Error(
+          'ENOENT: could not write /Users/private/.open-science/sessions/project-a/session-1.json'
+        )
+      }
       return session
     })
 
@@ -172,8 +183,11 @@ describe('session persistence startup', () => {
       })
       await Promise.resolve()
     })
-    expect(container.querySelector('[data-testid="write-error"]')?.textContent).toContain(
-      'disk full'
+    expect(container.querySelector('[data-testid="write-error"]')?.textContent).toBe(
+      'Open Science could not save the latest conversation changes. Retry before closing the app.'
+    )
+    expect(container.querySelector('[data-testid="write-error"]')?.textContent).not.toContain(
+      '/Users/private'
     )
 
     await act(async () => {
@@ -213,8 +227,8 @@ describe('session persistence startup', () => {
       })
       await Promise.resolve()
     })
-    expect(container.querySelector('[data-testid="write-error"]')?.textContent).toContain(
-      'disk full'
+    expect(container.querySelector('[data-testid="write-error"]')?.textContent).toBe(
+      'Open Science could not save the latest conversation changes. Retry before closing the app.'
     )
 
     await act(async () => {
@@ -447,8 +461,8 @@ describe('session persistence startup', () => {
     expect(saveManifest).toHaveBeenCalledOnce()
     expect(container.querySelector('div')?.dataset.ready).toBe('false')
     expect(container.querySelector('div')?.dataset.loading).toBe('false')
-    expect(container.querySelector('[data-testid="write-error"]')?.textContent).toContain(
-      'manifest disk full'
+    expect(container.querySelector('[data-testid="write-error"]')?.textContent).toBe(
+      'Open Science could not save the latest conversation changes. Retry before closing the app.'
     )
     expect(reconcilePendingArtifactsApi).not.toHaveBeenCalled()
 
@@ -507,6 +521,36 @@ describe('session persistence startup', () => {
     expect(container.querySelector('[data-testid="load-warning"]')?.textContent).toContain(
       'damaged and moved aside'
     )
+  })
+
+  it('dismisses a recovery warning without blocking healthy conversations', async () => {
+    loadAll.mockReset().mockResolvedValue({
+      ...emptyLoadResult(),
+      diagnostics: {
+        isComplete: true,
+        warnings: [
+          {
+            kind: 'corrupt',
+            projectId: 'project-a',
+            fileName: 'broken.json',
+            recovered: true
+          }
+        ]
+      }
+    })
+
+    await act(async () => root.render(<Probe />))
+
+    expect(container.querySelector('[data-testid="load-warning"]')?.textContent).toContain(
+      'damaged and moved aside'
+    )
+    await act(async () => {
+      container.querySelector<HTMLButtonElement>('[data-testid="dismiss-load-warning"]')?.click()
+    })
+    expect(container.querySelector('[data-testid="load-warning"]')?.textContent).toBe(
+      'no load warnings'
+    )
+    expect(container.querySelector('div')?.dataset.ready).toBe('true')
   })
 
   it('loads conversations after corrupt selection data is isolated', async () => {

--- a/src/renderer/src/lib/session-persistence/session-persistence.render.test.tsx
+++ b/src/renderer/src/lib/session-persistence/session-persistence.render.test.tsx
@@ -40,7 +40,11 @@ describe('session persistence startup', () => {
     container = document.createElement('div')
     document.body.appendChild(container)
     root = createRoot(container)
-    loadAll = vi.fn().mockRejectedValueOnce(new Error('sessions directory unavailable'))
+    loadAll = vi
+      .fn()
+      .mockRejectedValueOnce(
+        new Error('EACCES: /Users/private/.open-science/sessions could not be read')
+      )
     saveSession = vi.fn(async (session) => session)
     window.api = {
       sessions: {
@@ -89,8 +93,11 @@ describe('session persistence startup', () => {
     expect(container.querySelector('div')?.dataset.ready).toBe('false')
     expect(container.querySelector('div')?.dataset.hydrated).toBe('false')
     expect(container.querySelector('div')?.dataset.loading).toBe('false')
-    expect(container.querySelector('[data-testid="load-error"]')?.textContent).toContain(
-      'sessions directory unavailable'
+    expect(container.querySelector('[data-testid="load-error"]')?.textContent).toBe(
+      'Open Science could not read saved conversation data. Retry to continue.'
+    )
+    expect(container.querySelector('[data-testid="load-error"]')?.textContent).not.toContain(
+      '/Users/private'
     )
 
     loadAll.mockResolvedValueOnce(emptyLoadResult())
@@ -209,6 +216,40 @@ describe('session persistence startup', () => {
     )
   })
 
+  it('ignores a save failure that arrives after its Session was deleted', async () => {
+    let rejectSave: ((reason: Error) => void) | undefined
+    loadAll.mockReset().mockResolvedValue(emptyLoadResult())
+    saveSession.mockImplementation(
+      () =>
+        new Promise<PersistedChatSession>((_resolve, reject) => {
+          rejectSave = reject
+        })
+    )
+
+    await act(async () => root.render(<Probe />))
+
+    await act(async () => {
+      useSessionStore.getState().appendUserMessage({
+        sessionId: 'session-1',
+        content: 'Delete me while the save is pending',
+        cwd: '/workspace/project',
+        projectId: 'project-a'
+      })
+      await Promise.resolve()
+    })
+    expect(saveSession).toHaveBeenCalledOnce()
+
+    await act(async () => {
+      useSessionStore.getState().deleteSession('session-1')
+      rejectSave?.(new Error('Session was deleted'))
+      await Promise.resolve()
+    })
+
+    expect(container.querySelector('[data-testid="write-error"]')?.textContent).toContain(
+      'changes saved'
+    )
+  })
+
   it('keeps persistence blocked when the durable Session scan is incomplete', async () => {
     loadAll.mockReset().mockResolvedValue({
       ...emptyLoadResult(),
@@ -279,6 +320,35 @@ describe('session persistence startup', () => {
 
     expect(container.querySelector('div')?.dataset.ready).toBe('true')
     expect(useSessionStore.getState().selectedSessionId).toBe(selectedSession.id)
+  })
+
+  it('preserves an explicitly empty selection when retrying a partial recovery', async () => {
+    const manifestSession = createPersistedSession({ id: 'manifest-session' })
+    const result = {
+      sessions: [manifestSession],
+      manifest: {
+        version: SESSION_MANIFEST_VERSION,
+        lastProjectId: manifestSession.projectId,
+        lastSessionId: manifestSession.id
+      }
+    }
+    loadAll
+      .mockReset()
+      .mockResolvedValueOnce({
+        ...result,
+        diagnostics: { isComplete: false, warnings: [] }
+      })
+      .mockResolvedValueOnce(result)
+
+    await act(async () => root.render(<Probe />))
+
+    act(() => useSessionStore.getState().clearSelection())
+    await act(async () =>
+      container.querySelector<HTMLButtonElement>('[data-testid="retry-load"]')?.click()
+    )
+
+    expect(container.querySelector('div')?.dataset.ready).toBe('true')
+    expect(useSessionStore.getState().selectedSessionId).toBeUndefined()
   })
 
   it('keeps persistence blocked when startup storage recovery is incomplete', async () => {

--- a/src/renderer/src/lib/session-persistence/session-persistence.render.test.tsx
+++ b/src/renderer/src/lib/session-persistence/session-persistence.render.test.tsx
@@ -13,7 +13,12 @@ import { useSessionPersistence, type SessionPersistenceState } from './session-p
 
 const emptyLoadResult = (): LoadAllSessionsResult => ({
   sessions: [],
-  manifest: { version: SESSION_MANIFEST_VERSION }
+  manifest: { version: SESSION_MANIFEST_VERSION },
+  diagnostics: {
+    isComplete: true,
+    warnings: [],
+    isProjectDeletionRecoveryComplete: true
+  }
 })
 
 const createPersistedSession = (
@@ -74,6 +79,7 @@ describe('session persistence startup', () => {
         data-loading={String(persistence.isLoading)}
         data-ready={String(persistence.isReady)}
         data-catalog-complete={String(persistence.hasCompleteSessionCatalog)}
+        data-deletion-ready={String(persistence.canDeleteSessionsAndProjects)}
       >
         <span data-testid="load-error">{persistence.loadError ?? 'sessions available'}</span>
         <span data-testid="load-warning">{persistence.loadWarning ?? 'no load warnings'}</span>
@@ -109,6 +115,7 @@ describe('session persistence startup', () => {
     expect(loadAll).toHaveBeenCalledTimes(2)
     expect(container.querySelector('div')?.dataset.ready).toBe('true')
     expect(container.querySelector('div')?.dataset.catalogComplete).toBe('true')
+    expect(container.querySelector('div')?.dataset.deletionReady).toBe('true')
     expect(container.querySelector('div')?.dataset.hydrated).toBe('true')
     expect(container.querySelector('div')?.dataset.loading).toBe('false')
     expect(container.querySelector('[data-testid="load-error"]')?.textContent).toContain(
@@ -257,6 +264,7 @@ describe('session persistence startup', () => {
       ...emptyLoadResult(),
       diagnostics: {
         isComplete: false,
+        isProjectDeletionRecoveryComplete: true,
         warnings: [
           {
             kind: 'unreadable',
@@ -272,6 +280,7 @@ describe('session persistence startup', () => {
 
     expect(container.querySelector('div')?.dataset.ready).toBe('false')
     expect(container.querySelector('div')?.dataset.hydrated).toBe('true')
+    expect(container.querySelector('div')?.dataset.deletionReady).toBe('true')
     expect(container.querySelector('[data-testid="load-error"]')?.textContent).toContain(
       'could not be read'
     )
@@ -359,13 +368,15 @@ describe('session persistence startup', () => {
       diagnostics: {
         isComplete: false,
         warnings: [],
-        failure: 'startup-reconciliation-failed'
+        failure: 'startup-reconciliation-failed',
+        isProjectDeletionRecoveryComplete: false
       }
     })
 
     await act(async () => root.render(<Probe />))
 
     expect(container.querySelector('div')?.dataset.ready).toBe('false')
+    expect(container.querySelector('div')?.dataset.deletionReady).toBe('false')
     expect(container.querySelector('[data-testid="load-error"]')?.textContent).toContain(
       'storage recovery could not finish'
     )

--- a/src/renderer/src/lib/session-persistence/session-persistence.render.test.tsx
+++ b/src/renderer/src/lib/session-persistence/session-persistence.render.test.tsx
@@ -41,6 +41,7 @@ describe('session persistence startup', () => {
   let loadAll: ReturnType<typeof vi.fn>
   let saveSession: ReturnType<typeof vi.fn>
   let saveManifest: ReturnType<typeof vi.fn>
+  let reconcilePendingArtifactsApi: ReturnType<typeof vi.fn>
 
   beforeEach(() => {
     container = document.createElement('div')
@@ -53,6 +54,7 @@ describe('session persistence startup', () => {
       )
     saveSession = vi.fn(async (session) => session)
     saveManifest = vi.fn().mockResolvedValue(undefined)
+    reconcilePendingArtifactsApi = vi.fn().mockResolvedValue([])
     window.api = {
       sessions: {
         loadAll,
@@ -61,7 +63,7 @@ describe('session persistence startup', () => {
         saveManifest
       },
       artifacts: {
-        reconcilePendingArtifacts: vi.fn().mockResolvedValue([])
+        reconcilePendingArtifacts: reconcilePendingArtifactsApi
       }
     } as unknown as Window['api']
     useSessionStore.setState(createInitialSessionState())
@@ -387,6 +389,79 @@ describe('session persistence startup', () => {
       lastProjectId: undefined,
       lastSessionId: undefined
     })
+  })
+
+  it('keeps persistence blocked until a failed retry manifest write succeeds', async () => {
+    const pendingArtifactPath =
+      '/data/artifacts/project-a/manifest-session/.pending/run-1/chart.png'
+    const manifestSession = createPersistedSession({
+      id: 'manifest-session',
+      messages: [
+        {
+          id: 'message-1',
+          role: 'agent',
+          content: 'Recovered output',
+          status: 'complete',
+          eventIds: [],
+          artifactIds: ['artifact-session:run-1:chart.png'],
+          createdAt: 1,
+          updatedAt: 1
+        }
+      ],
+      artifacts: [
+        {
+          id: 'artifact-session:run-1:chart.png',
+          kind: 'managed-file',
+          path: pendingArtifactPath,
+          name: 'chart.png',
+          mimeType: 'image/png'
+        }
+      ]
+    })
+    const result = {
+      sessions: [manifestSession],
+      manifest: {
+        version: SESSION_MANIFEST_VERSION,
+        lastProjectId: manifestSession.projectId,
+        lastSessionId: manifestSession.id
+      }
+    }
+    loadAll
+      .mockReset()
+      .mockResolvedValueOnce({
+        ...result,
+        diagnostics: { isComplete: false, warnings: [] }
+      })
+      .mockResolvedValueOnce(result)
+    saveManifest
+      .mockRejectedValueOnce(new Error('manifest disk full'))
+      .mockResolvedValueOnce(undefined)
+
+    await act(async () => root.render(<Probe />))
+
+    act(() => useSessionStore.getState().clearSelection())
+    await act(async () =>
+      container.querySelector<HTMLButtonElement>('[data-testid="retry-load"]')?.click()
+    )
+
+    expect(saveManifest).toHaveBeenCalledOnce()
+    expect(container.querySelector('div')?.dataset.ready).toBe('false')
+    expect(container.querySelector('div')?.dataset.loading).toBe('false')
+    expect(container.querySelector('[data-testid="write-error"]')?.textContent).toContain(
+      'manifest disk full'
+    )
+    expect(reconcilePendingArtifactsApi).not.toHaveBeenCalled()
+
+    await act(async () =>
+      container.querySelector<HTMLButtonElement>('[data-testid="retry-writes"]')?.click()
+    )
+
+    expect(saveManifest).toHaveBeenCalledTimes(2)
+    expect(container.querySelector('div')?.dataset.ready).toBe('true')
+    expect(container.querySelector('[data-testid="write-error"]')?.textContent).toContain(
+      'changes saved'
+    )
+    expect(reconcilePendingArtifactsApi).toHaveBeenCalledOnce()
   })
 
   it('keeps persistence blocked when startup storage recovery is incomplete', async () => {

--- a/src/renderer/src/lib/session-persistence/session-persistence.render.test.tsx
+++ b/src/renderer/src/lib/session-persistence/session-persistence.render.test.tsx
@@ -297,4 +297,50 @@ describe('session persistence startup', () => {
       'Conversation selection data was damaged and moved aside'
     )
   })
+
+  it('keeps conversations writable when selection data is unreadable', async () => {
+    loadAll.mockReset().mockResolvedValue({
+      ...emptyLoadResult(),
+      diagnostics: {
+        isComplete: true,
+        warnings: [
+          {
+            kind: 'manifest-unreadable',
+            fileName: 'manifest.json',
+            recovered: false
+          }
+        ]
+      }
+    })
+
+    await act(async () => root.render(<Probe />))
+
+    expect(container.querySelector('div')?.dataset.ready).toBe('true')
+    expect(container.querySelector('[data-testid="load-warning"]')?.textContent).toContain(
+      'Conversation selection data could not be read, so no conversation was selected'
+    )
+  })
+
+  it('does not claim damaged selection data was moved when quarantine failed', async () => {
+    loadAll.mockReset().mockResolvedValue({
+      ...emptyLoadResult(),
+      diagnostics: {
+        isComplete: true,
+        warnings: [
+          {
+            kind: 'manifest-corrupt',
+            fileName: 'manifest.json',
+            recovered: false
+          }
+        ]
+      }
+    })
+
+    await act(async () => root.render(<Probe />))
+
+    expect(container.querySelector('div')?.dataset.ready).toBe('true')
+    expect(container.querySelector('[data-testid="load-warning"]')?.textContent).toContain(
+      'Conversation selection data was damaged and could not be moved aside'
+    )
+  })
 })

--- a/src/renderer/src/lib/session-persistence/session-persistence.render.test.tsx
+++ b/src/renderer/src/lib/session-persistence/session-persistence.render.test.tsx
@@ -40,6 +40,7 @@ describe('session persistence startup', () => {
   let root: Root
   let loadAll: ReturnType<typeof vi.fn>
   let saveSession: ReturnType<typeof vi.fn>
+  let saveManifest: ReturnType<typeof vi.fn>
 
   beforeEach(() => {
     container = document.createElement('div')
@@ -51,12 +52,13 @@ describe('session persistence startup', () => {
         new Error('EACCES: /Users/private/.open-science/sessions could not be read')
       )
     saveSession = vi.fn(async (session) => session)
+    saveManifest = vi.fn().mockResolvedValue(undefined)
     window.api = {
       sessions: {
         loadAll,
         saveSession,
         deleteSession: vi.fn().mockResolvedValue(undefined),
-        saveManifest: vi.fn().mockResolvedValue(undefined)
+        saveManifest
       },
       artifacts: {
         reconcilePendingArtifacts: vi.fn().mockResolvedValue([])
@@ -319,18 +321,38 @@ describe('session persistence startup', () => {
         diagnostics: { isComplete: false, warnings: [] }
       })
       .mockResolvedValueOnce({ sessions, manifest })
+    let finishManifestSave: (() => void) | undefined
+    const manifestSave = new Promise<void>((resolve) => {
+      finishManifestSave = resolve
+    })
+    saveManifest.mockReturnValueOnce(manifestSave)
 
     await act(async () => root.render(<Probe />))
 
     expect(useSessionStore.getState().selectedSessionId).toBe(manifestSession.id)
     act(() => useSessionStore.getState().selectSession(selectedSession.id))
 
-    await act(async () =>
+    await act(async () => {
       container.querySelector<HTMLButtonElement>('[data-testid="retry-load"]')?.click()
-    )
+      await Promise.resolve()
+    })
+
+    expect(useSessionStore.getState().selectedSessionId).toBe(selectedSession.id)
+    expect(saveManifest).toHaveBeenCalledOnce()
+    expect(saveManifest).toHaveBeenCalledWith({
+      lastProjectId: selectedSession.projectId,
+      lastSessionId: selectedSession.id
+    })
+    expect(container.querySelector('div')?.dataset.ready).toBe('false')
+    expect(container.querySelector('div')?.dataset.loading).toBe('true')
+
+    await act(async () => {
+      finishManifestSave?.()
+      await manifestSave
+    })
 
     expect(container.querySelector('div')?.dataset.ready).toBe('true')
-    expect(useSessionStore.getState().selectedSessionId).toBe(selectedSession.id)
+    expect(container.querySelector('div')?.dataset.loading).toBe('false')
   })
 
   it('preserves an explicitly empty selection when retrying a partial recovery', async () => {
@@ -360,6 +382,11 @@ describe('session persistence startup', () => {
 
     expect(container.querySelector('div')?.dataset.ready).toBe('true')
     expect(useSessionStore.getState().selectedSessionId).toBeUndefined()
+    expect(saveManifest).toHaveBeenCalledOnce()
+    expect(saveManifest).toHaveBeenCalledWith({
+      lastProjectId: undefined,
+      lastSessionId: undefined
+    })
   })
 
   it('keeps persistence blocked when startup storage recovery is incomplete', async () => {

--- a/src/renderer/src/lib/session-persistence/session-persistence.test.ts
+++ b/src/renderer/src/lib/session-persistence/session-persistence.test.ts
@@ -144,6 +144,18 @@ describe('renderer session persistence bridge', () => {
     expect(useSessionStore.getState().sessions).toEqual([])
   })
 
+  it('keeps selection empty when a retry target no longer exists', async () => {
+    const manifestSession = createPersistedSession({ id: 'manifest-session' })
+    const api = createApi({
+      loadAll: vi.fn().mockResolvedValue(createLoadResult([manifestSession], manifestSession.id))
+    })
+
+    await loadPersistedSessions(api, () => true, { sessionId: 'deleted-session' })
+
+    expect(useSessionStore.getState().sessions).toHaveLength(1)
+    expect(useSessionStore.getState().selectedSessionId).toBeUndefined()
+  })
+
   it('does not echo an externally hydrated session back to persistence', async () => {
     const api = createApi()
     const save = createStoreSaver(api)

--- a/src/renderer/src/lib/session-persistence/session-persistence.test.ts
+++ b/src/renderer/src/lib/session-persistence/session-persistence.test.ts
@@ -568,6 +568,25 @@ describe('renderer session persistence bridge', () => {
     secondSave.resolve(saveSession.mock.calls[1][0])
     await flushMicrotasks()
   })
+
+  it('reports an earlier failed write even when a later queued write succeeds', async () => {
+    const api = createApi({
+      saveSession: vi.fn().mockRejectedValue(new Error('disk full')),
+      saveManifest: vi.fn().mockResolvedValue(undefined)
+    })
+    const save = createStoreSaver(api)
+
+    useSessionStore.getState().appendUserMessage({
+      sessionId: 'session-1',
+      content: 'Persist me',
+      cwd: '/workspace/project',
+      projectId: 'project-a'
+    })
+
+    await expect(save(useSessionStore.getState())).rejects.toThrow('disk full')
+    expect(api.saveSession).toHaveBeenCalledOnce()
+    expect(api.saveManifest).toHaveBeenCalledOnce()
+  })
 })
 
 type Deferred<T> = {
@@ -585,6 +604,7 @@ const createDeferred = <T>(): Deferred<T> => {
 }
 
 const flushMicrotasks = async (): Promise<void> => {
+  await Promise.resolve()
   await Promise.resolve()
   await Promise.resolve()
 }

--- a/src/renderer/src/lib/session-persistence/session-persistence.test.ts
+++ b/src/renderer/src/lib/session-persistence/session-persistence.test.ts
@@ -146,14 +146,23 @@ describe('renderer session persistence bridge', () => {
 
   it('keeps selection empty when a retry target no longer exists', async () => {
     const manifestSession = createPersistedSession({ id: 'manifest-session' })
+    const observedSelections: Array<string | undefined> = []
+    const unsubscribe = useSessionStore.subscribe((state) => {
+      observedSelections.push(state.selectedSessionId)
+    })
     const api = createApi({
       loadAll: vi.fn().mockResolvedValue(createLoadResult([manifestSession], manifestSession.id))
     })
 
-    await loadPersistedSessions(api, () => true, { sessionId: 'deleted-session' })
+    try {
+      await loadPersistedSessions(api, () => true, { sessionId: 'deleted-session' })
+    } finally {
+      unsubscribe()
+    }
 
     expect(useSessionStore.getState().sessions).toHaveLength(1)
     expect(useSessionStore.getState().selectedSessionId).toBeUndefined()
+    expect(observedSelections).toEqual([undefined])
   })
 
   it('does not echo an externally hydrated session back to persistence', async () => {

--- a/src/renderer/src/lib/session-persistence/session-persistence.ts
+++ b/src/renderer/src/lib/session-persistence/session-persistence.ts
@@ -13,7 +13,7 @@ import {
   toPersistedSession,
   useSessionStore
 } from '../../stores/session-store'
-import type { ChatSession } from '../../stores/session-store'
+import type { ChatSession, SessionHydrationSelection } from '../../stores/session-store'
 
 type SessionPersistenceApi = {
   loadAll: () => Promise<LoadAllSessionsResult>
@@ -102,10 +102,6 @@ type StoreSaverObserver = {
 
 type StoreSaver = (state: SessionStoreSnapshot, options?: StoreSaverOptions) => Promise<unknown>
 
-type RetrySessionSelection = {
-  sessionId: string | undefined
-}
-
 const pruneRemovedSessionWriteTargets = (
   targets: Set<string>,
   sessions: readonly Pick<ChatSession, 'id'>[]
@@ -128,27 +124,16 @@ const SAFE_SESSION_LOAD_ERROR =
 const loadPersistedSessions = async (
   api: SessionPersistenceApi,
   shouldHydrate: () => boolean = () => true,
-  preferredSelection?: RetrySessionSelection
+  preferredSelection?: SessionHydrationSelection
 ): Promise<LoadAllSessionsResult | undefined> => {
   const result = await api.loadAll()
   if (!shouldHydrate()) return undefined
 
-  const preferredSession = preferredSelection?.sessionId
-    ? result.sessions.find((session) => session.id === preferredSelection.sessionId)
-    : undefined
-  const manifest = preferredSession
-    ? {
-        ...result.manifest,
-        lastProjectId: preferredSession.projectId,
-        lastSessionId: preferredSession.id
-      }
-    : result.manifest
-
-  useSessionStore.getState().hydrateSessions(result.sessions, manifest)
   // Retry captures live navigation as an explicit tri-state. If the user had no selection, or the
   // selected Session disappeared before recovery completed, do not replay a stale disk manifest or
-  // fall through to the globally newest Session from another Project.
-  if (preferredSelection && !preferredSession) useSessionStore.getState().clearSelection()
+  // fall through to the globally newest Session from another Project. Passing the selection into
+  // hydration applies the sessions and selection atomically for all Zustand subscribers.
+  useSessionStore.getState().hydrateSessions(result.sessions, result.manifest, preferredSelection)
   return result
 }
 
@@ -272,7 +257,7 @@ const useSessionPersistence = (): SessionPersistenceState => {
   const [loadWarning, setLoadWarning] = useState<string | undefined>(undefined)
   const [writeError, setWriteError] = useState<string | undefined>(undefined)
   const [loadAttempt, setLoadAttempt] = useState(0)
-  const retrySelection = useRef<RetrySessionSelection | undefined>(undefined)
+  const retrySelection = useRef<SessionHydrationSelection | undefined>(undefined)
   const failedWriteTargets = useRef(new Set<string>())
   const saverRef = useRef<StoreSaver | undefined>(undefined)
   const retryLoad = useCallback(() => {

--- a/src/renderer/src/lib/session-persistence/session-persistence.ts
+++ b/src/renderer/src/lib/session-persistence/session-persistence.ts
@@ -102,6 +102,10 @@ type StoreSaverObserver = {
 
 type StoreSaver = (state: SessionStoreSnapshot, options?: StoreSaverOptions) => Promise<unknown>
 
+type RetrySessionSelection = {
+  sessionId: string | undefined
+}
+
 const pruneRemovedSessionWriteTargets = (
   targets: Set<string>,
   sessions: readonly Pick<ChatSession, 'id'>[]
@@ -117,17 +121,20 @@ const reportPersistenceError = (error: unknown): void => {
   console.warn('Session persistence failed', error)
 }
 
+const SAFE_SESSION_LOAD_ERROR =
+  'Open Science could not read saved conversation data. Retry to continue.'
+
 // Hydrates the in-memory session store from the per-session files loaded by the main process.
 const loadPersistedSessions = async (
   api: SessionPersistenceApi,
   shouldHydrate: () => boolean = () => true,
-  preferredSessionId?: string
+  preferredSelection?: RetrySessionSelection
 ): Promise<LoadAllSessionsResult | undefined> => {
   const result = await api.loadAll()
   if (!shouldHydrate()) return undefined
 
-  const preferredSession = preferredSessionId
-    ? result.sessions.find((session) => session.id === preferredSessionId)
+  const preferredSession = preferredSelection?.sessionId
+    ? result.sessions.find((session) => session.id === preferredSelection.sessionId)
     : undefined
   const manifest = preferredSession
     ? {
@@ -138,6 +145,10 @@ const loadPersistedSessions = async (
     : result.manifest
 
   useSessionStore.getState().hydrateSessions(result.sessions, manifest)
+  // Retry captures live navigation as an explicit tri-state. If the user had no selection, or the
+  // selected Session disappeared before recovery completed, do not replay a stale disk manifest or
+  // fall through to the globally newest Session from another Project.
+  if (preferredSelection && !preferredSession) useSessionStore.getState().clearSelection()
   return result
 }
 
@@ -261,13 +272,15 @@ const useSessionPersistence = (): SessionPersistenceState => {
   const [loadWarning, setLoadWarning] = useState<string | undefined>(undefined)
   const [writeError, setWriteError] = useState<string | undefined>(undefined)
   const [loadAttempt, setLoadAttempt] = useState(0)
-  const retrySelection = useRef<string | undefined>(undefined)
+  const retrySelection = useRef<RetrySessionSelection | undefined>(undefined)
   const failedWriteTargets = useRef(new Set<string>())
   const saverRef = useRef<StoreSaver | undefined>(undefined)
   const retryLoad = useCallback(() => {
     // A partial snapshot remains interactive. Keep the session the user chose from that snapshot so
     // a successful retry cannot replay the older on-disk manifest over their live navigation.
-    if (isHydrated) retrySelection.current = useSessionStore.getState().selectedSessionId
+    if (isHydrated) {
+      retrySelection.current = { sessionId: useSessionStore.getState().selectedSessionId }
+    }
     setIsHydrated(false)
     setIsLoading(true)
     setIsReady(false)
@@ -355,9 +368,7 @@ const useSessionPersistence = (): SessionPersistenceState => {
       } catch (error) {
         reportPersistenceError(error)
         if (isMounted) {
-          setLoadError(
-            error instanceof Error ? error.message : 'Saved conversations could not be loaded.'
-          )
+          setLoadError(SAFE_SESSION_LOAD_ERROR)
           setIsLoading(false)
         }
         return
@@ -371,6 +382,16 @@ const useSessionPersistence = (): SessionPersistenceState => {
         onFailure: (target, error) => {
           if (!isMounted) return
           failedWriteTargets.current.add(target)
+          pruneRemovedSessionWriteTargets(
+            failedWriteTargets.current,
+            useSessionStore.getState().sessions
+          )
+          // A queued save can lose a race with an authoritative deletion. Its tombstone rejection
+          // must not resurrect a retry target for a Session that no longer exists in the store.
+          if (!failedWriteTargets.current.has(target)) {
+            if (failedWriteTargets.current.size === 0) setWriteError(undefined)
+            return
+          }
           setWriteError(
             error instanceof Error ? error.message : 'Conversation changes could not be saved.'
           )

--- a/src/renderer/src/lib/session-persistence/session-persistence.ts
+++ b/src/renderer/src/lib/session-persistence/session-persistence.ts
@@ -263,6 +263,7 @@ const useSessionPersistence = (): SessionPersistenceState => {
   const [loadAttempt, setLoadAttempt] = useState(0)
   const retrySelection = useRef<SessionHydrationSelection | undefined>(undefined)
   const failedWriteTargets = useRef(new Set<string>())
+  const retryManifestWritePending = useRef(false)
   const saverRef = useRef<StoreSaver | undefined>(undefined)
   const retryLoad = useCallback(() => {
     // A partial snapshot remains interactive. Keep the session the user chose from that snapshot so
@@ -278,6 +279,7 @@ const useSessionPersistence = (): SessionPersistenceState => {
     setLoadError(undefined)
     setLoadWarning(undefined)
     setWriteError(undefined)
+    retryManifestWritePending.current = false
     setLoadAttempt((attempt) => attempt + 1)
   }, [isHydrated])
   const retryWrites = useCallback(() => {
@@ -373,6 +375,15 @@ const useSessionPersistence = (): SessionPersistenceState => {
         return
       }
 
+      let hasStartedPendingArtifactReconciliation = false
+      const startPendingArtifactReconciliation = (): void => {
+        if (hasStartedPendingArtifactReconciliation) return
+        hasStartedPendingArtifactReconciliation = true
+        // Runs after the saver subscribes so finalized references are persisted. A failed startup
+        // manifest write defers this until that retry succeeds and persistence becomes ready.
+        void reconcilePendingArtifacts(window.api.artifacts)
+      }
+
       // Snapshot the hydrated state as the diff baseline so hydration itself is not re-saved.
       const save = createStoreSaver(window.api.sessions, useSessionStore.getState(), {
         onFailure: (target, error) => {
@@ -395,6 +406,11 @@ const useSessionPersistence = (): SessionPersistenceState => {
         onSuccess: (target) => {
           if (!isMounted) return
           failedWriteTargets.current.delete(target)
+          if (target === 'manifest' && retryManifestWritePending.current) {
+            retryManifestWritePending.current = false
+            setIsReady(true)
+            startPendingArtifactReconciliation()
+          }
           if (failedWriteTargets.current.size === 0) setWriteError(undefined)
         }
       })
@@ -411,20 +427,22 @@ const useSessionPersistence = (): SessionPersistenceState => {
       // on retry. Force that tri-state selection (including an explicit empty selection) back to
       // disk before declaring persistence ready, because the saver baseline already contains it.
       if (preferredSelection !== undefined) {
-        await save(useSessionStore.getState(), {
-          forceTargets: new Set(['manifest'])
-        }).catch(reportPersistenceError)
+        try {
+          await save(useSessionStore.getState(), {
+            forceTargets: new Set(['manifest'])
+          })
+        } catch (error) {
+          retryManifestWritePending.current = true
+          reportPersistenceError(error)
+        }
         if (!isMounted) return
       }
 
       retrySelection.current = undefined
-      setIsReady(true)
       setIsLoading(false)
-
-      // Recover any artifacts a prior crash left in `.pending`; runs after the saver subscribes so the
-      // finalized references are persisted. Fire-and-forget: it must not delay the workspace becoming
-      // interactive, and failures are already reported per message.
-      void reconcilePendingArtifacts(window.api.artifacts)
+      if (retryManifestWritePending.current) return
+      setIsReady(true)
+      startPendingArtifactReconciliation()
     }
 
     void startPersistence()

--- a/src/renderer/src/lib/session-persistence/session-persistence.ts
+++ b/src/renderer/src/lib/session-persistence/session-persistence.ts
@@ -81,6 +81,7 @@ type SessionStoreSnapshot = {
 }
 
 type SessionPersistenceState = {
+  isHydrated: boolean
   isReady: boolean
   loadError: string | undefined
   loadWarning: string | undefined
@@ -230,6 +231,7 @@ const createStoreSaver = (
 
 // Starts session persistence and returns health/recovery state so App can gate input and surface failures.
 const useSessionPersistence = (): SessionPersistenceState => {
+  const [isHydrated, setIsHydrated] = useState(false)
   const [isReady, setIsReady] = useState(false)
   const [loadError, setLoadError] = useState<string | undefined>(undefined)
   const [loadWarning, setLoadWarning] = useState<string | undefined>(undefined)
@@ -238,6 +240,7 @@ const useSessionPersistence = (): SessionPersistenceState => {
   const failedWriteTargets = useRef(new Set<string>())
   const saverRef = useRef<StoreSaver | undefined>(undefined)
   const retryLoad = useCallback(() => {
+    setIsHydrated(false)
     setIsReady(false)
     setLoadError(undefined)
     setLoadWarning(undefined)
@@ -277,6 +280,7 @@ const useSessionPersistence = (): SessionPersistenceState => {
       try {
         const result = await loadPersistedSessions(window.api.sessions, () => isMounted)
         if (!result || !isMounted) return
+        setIsHydrated(true)
 
         if (result.diagnostics?.isComplete === false) {
           setLoadError(
@@ -356,7 +360,7 @@ const useSessionPersistence = (): SessionPersistenceState => {
     }
   }, [loadAttempt])
 
-  return { isReady, loadError, loadWarning, writeError, retryLoad, retryWrites }
+  return { isHydrated, isReady, loadError, loadWarning, writeError, retryLoad, retryWrites }
 }
 
 export { createStoreSaver, loadPersistedSessions, reconcilePendingArtifacts, useSessionPersistence }

--- a/src/renderer/src/lib/session-persistence/session-persistence.ts
+++ b/src/renderer/src/lib/session-persistence/session-persistence.ts
@@ -85,6 +85,7 @@ type SessionPersistenceState = {
   isLoading: boolean
   isReady: boolean
   hasCompleteSessionCatalog: boolean
+  canDeleteSessionsAndProjects: boolean
   loadError: string | undefined
   loadWarning: string | undefined
   writeError: string | undefined
@@ -255,6 +256,7 @@ const useSessionPersistence = (): SessionPersistenceState => {
   const [isLoading, setIsLoading] = useState(true)
   const [isReady, setIsReady] = useState(false)
   const [hasCompleteSessionCatalog, setHasCompleteSessionCatalog] = useState(false)
+  const [canDeleteSessionsAndProjects, setCanDeleteSessionsAndProjects] = useState(false)
   const [loadError, setLoadError] = useState<string | undefined>(undefined)
   const [loadWarning, setLoadWarning] = useState<string | undefined>(undefined)
   const [writeError, setWriteError] = useState<string | undefined>(undefined)
@@ -272,6 +274,7 @@ const useSessionPersistence = (): SessionPersistenceState => {
     setIsLoading(true)
     setIsReady(false)
     setHasCompleteSessionCatalog(false)
+    setCanDeleteSessionsAndProjects(false)
     setLoadError(undefined)
     setLoadWarning(undefined)
     setWriteError(undefined)
@@ -317,6 +320,9 @@ const useSessionPersistence = (): SessionPersistenceState => {
         setHasCompleteSessionCatalog(
           result.diagnostics?.isComplete !== false && sessionWarningCount === 0
         )
+        setCanDeleteSessionsAndProjects(
+          result.diagnostics?.isProjectDeletionRecoveryComplete === true
+        )
 
         if (result.diagnostics?.isComplete === false) {
           setLoadError(
@@ -359,6 +365,7 @@ const useSessionPersistence = (): SessionPersistenceState => {
         reportPersistenceError(error)
         if (isMounted) {
           setHasCompleteSessionCatalog(false)
+          setCanDeleteSessionsAndProjects(false)
           setLoadError(SAFE_SESSION_LOAD_ERROR)
           setIsLoading(false)
         }
@@ -422,6 +429,7 @@ const useSessionPersistence = (): SessionPersistenceState => {
     isLoading,
     isReady,
     hasCompleteSessionCatalog,
+    canDeleteSessionsAndProjects,
     loadError,
     loadWarning,
     writeError,

--- a/src/renderer/src/lib/session-persistence/session-persistence.ts
+++ b/src/renderer/src/lib/session-persistence/session-persistence.ts
@@ -305,11 +305,12 @@ const useSessionPersistence = (): SessionPersistenceState => {
 
     // Loads before subscribing so the initial empty store cannot overwrite disk state.
     const startPersistence = async (): Promise<void> => {
+      const preferredSelection = retrySelection.current
       try {
         const result = await loadPersistedSessions(
           window.api.sessions,
           () => isMounted,
-          retrySelection.current
+          preferredSelection
         )
         if (!result || !isMounted) return
         setIsHydrated(true)
@@ -372,9 +373,6 @@ const useSessionPersistence = (): SessionPersistenceState => {
         return
       }
 
-      retrySelection.current = undefined
-      setIsReady(true)
-      setIsLoading(false)
       // Snapshot the hydrated state as the diff baseline so hydration itself is not re-saved.
       const save = createStoreSaver(window.api.sessions, useSessionStore.getState(), {
         onFailure: (target, error) => {
@@ -408,6 +406,20 @@ const useSessionPersistence = (): SessionPersistenceState => {
         if (failedWriteTargets.current.size === 0) setWriteError(undefined)
         void save(state).catch(reportPersistenceError)
       })
+
+      // Hydration intentionally uses the user's live selection instead of the older disk manifest
+      // on retry. Force that tri-state selection (including an explicit empty selection) back to
+      // disk before declaring persistence ready, because the saver baseline already contains it.
+      if (preferredSelection !== undefined) {
+        await save(useSessionStore.getState(), {
+          forceTargets: new Set(['manifest'])
+        }).catch(reportPersistenceError)
+        if (!isMounted) return
+      }
+
+      retrySelection.current = undefined
+      setIsReady(true)
+      setIsLoading(false)
 
       // Recover any artifacts a prior crash left in `.pending`; runs after the saver subscribes so the
       // finalized references are persisted. Fire-and-forget: it must not delay the workspace becoming

--- a/src/renderer/src/lib/session-persistence/session-persistence.ts
+++ b/src/renderer/src/lib/session-persistence/session-persistence.ts
@@ -287,11 +287,9 @@ const useSessionPersistence = (): SessionPersistenceState => {
 
         if (result.diagnostics?.isComplete === false) {
           setLoadError(
-            result.diagnostics.failure === 'manifest-unreadable'
-              ? 'Conversation selection data could not be read. Retry before creating or saving conversations.'
-              : result.diagnostics.failure === 'startup-reconciliation-failed'
-                ? 'Saved conversations loaded, but storage recovery could not finish. Retry before creating or saving conversations.'
-                : 'Some saved conversations could not be read. Retry before creating or saving conversations.'
+            result.diagnostics.failure === 'startup-reconciliation-failed'
+              ? 'Saved conversations loaded, but storage recovery could not finish. Retry before creating or saving conversations.'
+              : 'Some saved conversations could not be read. Retry before creating or saving conversations.'
           )
           setIsLoading(false)
           return
@@ -300,14 +298,27 @@ const useSessionPersistence = (): SessionPersistenceState => {
         const loadWarnings = result.diagnostics?.warnings ?? []
         if (loadWarnings.length > 0) {
           const manifestWasRecovered = loadWarnings.some(
-            (warning) => warning.kind === 'manifest-corrupt'
+            (warning) => warning.kind === 'manifest-corrupt' && warning.recovered
+          )
+          const manifestRecoveryFailed = loadWarnings.some(
+            (warning) => warning.kind === 'manifest-corrupt' && !warning.recovered
+          )
+          const manifestWasUnreadable = loadWarnings.some(
+            (warning) => warning.kind === 'manifest-unreadable'
           )
           const sessionWarningCount = loadWarnings.filter(
-            (warning) => warning.kind !== 'manifest-corrupt'
+            (warning) =>
+              warning.kind !== 'manifest-corrupt' && warning.kind !== 'manifest-unreadable'
           ).length
           const warningMessages = [
             manifestWasRecovered
               ? 'Conversation selection data was damaged and moved aside.'
+              : undefined,
+            manifestRecoveryFailed
+              ? 'Conversation selection data was damaged and could not be moved aside, so no conversation was selected.'
+              : undefined,
+            manifestWasUnreadable
+              ? 'Conversation selection data could not be read, so no conversation was selected.'
               : undefined,
             sessionWarningCount > 0
               ? `${sessionWarningCount} saved conversation file${sessionWarningCount === 1 ? ' was' : 's were'} damaged and moved aside.`

--- a/src/renderer/src/lib/session-persistence/session-persistence.ts
+++ b/src/renderer/src/lib/session-persistence/session-persistence.ts
@@ -89,6 +89,7 @@ type SessionPersistenceState = {
   loadError: string | undefined
   loadWarning: string | undefined
   writeError: string | undefined
+  dismissLoadWarning: () => void
   retryLoad: () => void
   retryWrites: () => void
 }
@@ -121,6 +122,8 @@ const reportPersistenceError = (error: unknown): void => {
 
 const SAFE_SESSION_LOAD_ERROR =
   'Open Science could not read saved conversation data. Retry to continue.'
+const SAFE_SESSION_WRITE_ERROR =
+  'Open Science could not save the latest conversation changes. Retry before closing the app.'
 
 // Hydrates the in-memory session store from the per-session files loaded by the main process.
 const loadPersistedSessions = async (
@@ -265,6 +268,7 @@ const useSessionPersistence = (): SessionPersistenceState => {
   const failedWriteTargets = useRef(new Set<string>())
   const retryManifestWritePending = useRef(false)
   const saverRef = useRef<StoreSaver | undefined>(undefined)
+  const dismissLoadWarning = useCallback(() => setLoadWarning(undefined), [])
   const retryLoad = useCallback(() => {
     // A partial snapshot remains interactive. Keep the session the user chose from that snapshot so
     // a successful retry cannot replay the older on-disk manifest over their live navigation.
@@ -386,7 +390,7 @@ const useSessionPersistence = (): SessionPersistenceState => {
 
       // Snapshot the hydrated state as the diff baseline so hydration itself is not re-saved.
       const save = createStoreSaver(window.api.sessions, useSessionStore.getState(), {
-        onFailure: (target, error) => {
+        onFailure: (target) => {
           if (!isMounted) return
           failedWriteTargets.current.add(target)
           pruneRemovedSessionWriteTargets(
@@ -399,9 +403,7 @@ const useSessionPersistence = (): SessionPersistenceState => {
             if (failedWriteTargets.current.size === 0) setWriteError(undefined)
             return
           }
-          setWriteError(
-            error instanceof Error ? error.message : 'Conversation changes could not be saved.'
-          )
+          setWriteError(SAFE_SESSION_WRITE_ERROR)
         },
         onSuccess: (target) => {
           if (!isMounted) return
@@ -463,6 +465,7 @@ const useSessionPersistence = (): SessionPersistenceState => {
     loadError,
     loadWarning,
     writeError,
+    dismissLoadWarning,
     retryLoad,
     retryWrites
   }

--- a/src/renderer/src/lib/session-persistence/session-persistence.ts
+++ b/src/renderer/src/lib/session-persistence/session-persistence.ts
@@ -110,12 +110,24 @@ const reportPersistenceError = (error: unknown): void => {
 // Hydrates the in-memory session store from the per-session files loaded by the main process.
 const loadPersistedSessions = async (
   api: SessionPersistenceApi,
-  shouldHydrate: () => boolean = () => true
+  shouldHydrate: () => boolean = () => true,
+  preferredSessionId?: string
 ): Promise<LoadAllSessionsResult | undefined> => {
   const result = await api.loadAll()
   if (!shouldHydrate()) return undefined
 
-  useSessionStore.getState().hydrateSessions(result.sessions, result.manifest)
+  const preferredSession = preferredSessionId
+    ? result.sessions.find((session) => session.id === preferredSessionId)
+    : undefined
+  const manifest = preferredSession
+    ? {
+        ...result.manifest,
+        lastProjectId: preferredSession.projectId,
+        lastSessionId: preferredSession.id
+      }
+    : result.manifest
+
+  useSessionStore.getState().hydrateSessions(result.sessions, manifest)
   return result
 }
 
@@ -239,9 +251,13 @@ const useSessionPersistence = (): SessionPersistenceState => {
   const [loadWarning, setLoadWarning] = useState<string | undefined>(undefined)
   const [writeError, setWriteError] = useState<string | undefined>(undefined)
   const [loadAttempt, setLoadAttempt] = useState(0)
+  const retrySelection = useRef<string | undefined>(undefined)
   const failedWriteTargets = useRef(new Set<string>())
   const saverRef = useRef<StoreSaver | undefined>(undefined)
   const retryLoad = useCallback(() => {
+    // A partial snapshot remains interactive. Keep the session the user chose from that snapshot so
+    // a successful retry cannot replay the older on-disk manifest over their live navigation.
+    if (isHydrated) retrySelection.current = useSessionStore.getState().selectedSessionId
     setIsHydrated(false)
     setIsLoading(true)
     setIsReady(false)
@@ -249,7 +265,7 @@ const useSessionPersistence = (): SessionPersistenceState => {
     setLoadWarning(undefined)
     setWriteError(undefined)
     setLoadAttempt((attempt) => attempt + 1)
-  }, [])
+  }, [isHydrated])
   const retryWrites = useCallback(() => {
     const saver = saverRef.current
     if (!saver || failedWriteTargets.current.size === 0) return
@@ -281,7 +297,11 @@ const useSessionPersistence = (): SessionPersistenceState => {
     // Loads before subscribing so the initial empty store cannot overwrite disk state.
     const startPersistence = async (): Promise<void> => {
       try {
-        const result = await loadPersistedSessions(window.api.sessions, () => isMounted)
+        const result = await loadPersistedSessions(
+          window.api.sessions,
+          () => isMounted,
+          retrySelection.current
+        )
         if (!result || !isMounted) return
         setIsHydrated(true)
 
@@ -338,6 +358,7 @@ const useSessionPersistence = (): SessionPersistenceState => {
         return
       }
 
+      retrySelection.current = undefined
       setIsReady(true)
       setIsLoading(false)
       // Snapshot the hydrated state as the diff baseline so hydration itself is not re-saved.

--- a/src/renderer/src/lib/session-persistence/session-persistence.ts
+++ b/src/renderer/src/lib/session-persistence/session-persistence.ts
@@ -84,6 +84,7 @@ type SessionPersistenceState = {
   isHydrated: boolean
   isLoading: boolean
   isReady: boolean
+  hasCompleteSessionCatalog: boolean
   loadError: string | undefined
   loadWarning: string | undefined
   writeError: string | undefined
@@ -253,6 +254,7 @@ const useSessionPersistence = (): SessionPersistenceState => {
   const [isHydrated, setIsHydrated] = useState(false)
   const [isLoading, setIsLoading] = useState(true)
   const [isReady, setIsReady] = useState(false)
+  const [hasCompleteSessionCatalog, setHasCompleteSessionCatalog] = useState(false)
   const [loadError, setLoadError] = useState<string | undefined>(undefined)
   const [loadWarning, setLoadWarning] = useState<string | undefined>(undefined)
   const [writeError, setWriteError] = useState<string | undefined>(undefined)
@@ -269,6 +271,7 @@ const useSessionPersistence = (): SessionPersistenceState => {
     setIsHydrated(false)
     setIsLoading(true)
     setIsReady(false)
+    setHasCompleteSessionCatalog(false)
     setLoadError(undefined)
     setLoadWarning(undefined)
     setWriteError(undefined)
@@ -307,6 +310,13 @@ const useSessionPersistence = (): SessionPersistenceState => {
         )
         if (!result || !isMounted) return
         setIsHydrated(true)
+        const loadWarnings = result.diagnostics?.warnings ?? []
+        const sessionWarningCount = loadWarnings.filter(
+          (warning) => warning.kind !== 'manifest-corrupt' && warning.kind !== 'manifest-unreadable'
+        ).length
+        setHasCompleteSessionCatalog(
+          result.diagnostics?.isComplete !== false && sessionWarningCount === 0
+        )
 
         if (result.diagnostics?.isComplete === false) {
           setLoadError(
@@ -318,7 +328,6 @@ const useSessionPersistence = (): SessionPersistenceState => {
           return
         }
 
-        const loadWarnings = result.diagnostics?.warnings ?? []
         if (loadWarnings.length > 0) {
           const manifestWasRecovered = loadWarnings.some(
             (warning) => warning.kind === 'manifest-corrupt' && warning.recovered
@@ -329,10 +338,6 @@ const useSessionPersistence = (): SessionPersistenceState => {
           const manifestWasUnreadable = loadWarnings.some(
             (warning) => warning.kind === 'manifest-unreadable'
           )
-          const sessionWarningCount = loadWarnings.filter(
-            (warning) =>
-              warning.kind !== 'manifest-corrupt' && warning.kind !== 'manifest-unreadable'
-          ).length
           const warningMessages = [
             manifestWasRecovered
               ? 'Conversation selection data was damaged and moved aside.'
@@ -353,6 +358,7 @@ const useSessionPersistence = (): SessionPersistenceState => {
       } catch (error) {
         reportPersistenceError(error)
         if (isMounted) {
+          setHasCompleteSessionCatalog(false)
           setLoadError(SAFE_SESSION_LOAD_ERROR)
           setIsLoading(false)
         }
@@ -415,6 +421,7 @@ const useSessionPersistence = (): SessionPersistenceState => {
     isHydrated,
     isLoading,
     isReady,
+    hasCompleteSessionCatalog,
     loadError,
     loadWarning,
     writeError,

--- a/src/renderer/src/lib/session-persistence/session-persistence.ts
+++ b/src/renderer/src/lib/session-persistence/session-persistence.ts
@@ -1,4 +1,4 @@
-import { useEffect, useState } from 'react'
+import { useCallback, useEffect, useRef, useState } from 'react'
 
 import type { ArtifactFile, ReconcilePendingArtifactsRequest } from '../../../../shared/artifacts'
 import type {
@@ -80,7 +80,27 @@ type SessionStoreSnapshot = {
   selectedSessionId: string | undefined
 }
 
-// Keeps persistence failures visible to developers without blocking the chat UI.
+type SessionPersistenceState = {
+  isReady: boolean
+  loadError: string | undefined
+  loadWarning: string | undefined
+  writeError: string | undefined
+  retryLoad: () => void
+  retryWrites: () => void
+}
+
+type StoreSaverOptions = {
+  forceTargets?: ReadonlySet<string>
+}
+
+type StoreSaverObserver = {
+  onFailure?: (target: string, error: unknown) => void
+  onSuccess?: (target: string) => void
+}
+
+type StoreSaver = (state: SessionStoreSnapshot, options?: StoreSaverOptions) => Promise<unknown>
+
+// Retains full diagnostics in the console while the hook exposes renderer-safe recovery state.
 const reportPersistenceError = (error: unknown): void => {
   console.warn('Session persistence failed', error)
 }
@@ -89,11 +109,12 @@ const reportPersistenceError = (error: unknown): void => {
 const loadPersistedSessions = async (
   api: SessionPersistenceApi,
   shouldHydrate: () => boolean = () => true
-): Promise<void> => {
-  const { sessions, manifest } = await api.loadAll()
-  if (!shouldHydrate()) return
+): Promise<LoadAllSessionsResult | undefined> => {
+  const result = await api.loadAll()
+  if (!shouldHydrate()) return undefined
 
-  useSessionStore.getState().hydrateSessions(sessions, manifest)
+  useSessionStore.getState().hydrateSessions(result.sessions, result.manifest)
+  return result
 }
 
 // Indexes sessions by id for reference-equality diffing between store snapshots.
@@ -114,8 +135,9 @@ const hasStagedUploads = (session: ChatSession): boolean =>
 // and updates the manifest when selection moves. Explicit deletion owns its durable coordinator call.
 const createStoreSaver = (
   api: SessionPersistenceApi,
-  initial: SessionStoreSnapshot = useSessionStore.getState()
-): ((state: SessionStoreSnapshot) => Promise<unknown>) => {
+  initial: SessionStoreSnapshot = useSessionStore.getState(),
+  observer: StoreSaverObserver = {}
+): StoreSaver => {
   let previousSessions = initial.sessions
   let previousSelection = initial.selectedSessionId
   let queue: Promise<unknown> = Promise.resolve()
@@ -127,11 +149,11 @@ const createStoreSaver = (
     return queue
   }
 
-  return (state) => {
+  return (state, options) => {
     const nextSessions = state.sessions
     const previousById = indexById(previousSessions)
     const nextById = indexById(nextSessions)
-    const tasks: Array<() => Promise<unknown>> = []
+    const tasks: Array<{ target: string; run: () => Promise<unknown> }> = []
 
     // Persist new or mutated sessions; pending sessions never touch disk until they bind a real id. A
     // session without a projectId cannot map to a sessions/<projectId>/ path (the main repository rejects
@@ -139,9 +161,12 @@ const createStoreSaver = (
     for (const session of nextSessions) {
       if (session.isPending || !session.projectId) continue
 
+      const target = `session:${session.id}`
+      const isForced = options?.forceTargets?.has(target) === true
+
       if (
-        previousById.get(session.id) !== session &&
-        !isExternallyHydratedSession(session) &&
+        (previousById.get(session.id) !== session || isForced) &&
+        (isForced || !isExternallyHydratedSession(session)) &&
         !hasStagedUploads(session) &&
         // A terminal graph-integrity failure keeps the renderer responsive, but the flat projection
         // is no longer proven to match the immutable Branch graph. Preserve the last durable copy.
@@ -149,66 +174,168 @@ const createStoreSaver = (
       ) {
         const persisted = toPersistedSession(session)
 
-        tasks.push(async () => {
-          const durableSession = await api.saveSession(persisted)
-          useSessionStore.getState().applyDurableSessionProjection({
-            source: session,
-            session: durableSession
-          })
+        tasks.push({
+          target,
+          run: async () => {
+            const durableSession = await api.saveSession(persisted)
+            useSessionStore.getState().applyDurableSessionProjection({
+              source: session,
+              session: durableSession
+            })
+          }
         })
       }
     }
 
     // Track the last-open selection, ignoring transient pending selections.
-    if (state.selectedSessionId !== previousSelection) {
+    if (
+      state.selectedSessionId !== previousSelection ||
+      options?.forceTargets?.has('manifest') === true
+    ) {
       const selectedSession = state.selectedSessionId
         ? nextById.get(state.selectedSessionId)
         : undefined
 
       if (!selectedSession?.isPending) {
-        tasks.push(() =>
-          api.saveManifest({
-            lastSessionId: state.selectedSessionId,
-            lastProjectId: selectedSession?.projectId
-          })
-        )
+        tasks.push({
+          target: 'manifest',
+          run: () =>
+            api.saveManifest({
+              lastSessionId: state.selectedSessionId,
+              lastProjectId: selectedSession?.projectId
+            })
+        })
       }
     }
 
     previousSessions = nextSessions
     previousSelection = state.selectedSessionId
 
-    let lastTask: Promise<unknown> = Promise.resolve()
+    const scheduledTasks = tasks.map(({ target, run }) =>
+      enqueue(async () => {
+        try {
+          const result = await run()
+          observer.onSuccess?.(target)
+          return result
+        } catch (error) {
+          observer.onFailure?.(target, error)
+          throw error
+        }
+      })
+    )
 
-    for (const task of tasks) {
-      lastTask = enqueue(task)
-    }
-
-    return lastTask
+    return Promise.all(scheduledTasks).then(() => undefined)
   }
 }
 
-// Starts session persistence and returns readiness so the workspace can gate early input.
-const useSessionPersistence = (): boolean => {
+// Starts session persistence and returns health/recovery state so App can gate input and surface failures.
+const useSessionPersistence = (): SessionPersistenceState => {
   const [isReady, setIsReady] = useState(false)
+  const [loadError, setLoadError] = useState<string | undefined>(undefined)
+  const [loadWarning, setLoadWarning] = useState<string | undefined>(undefined)
+  const [writeError, setWriteError] = useState<string | undefined>(undefined)
+  const [loadAttempt, setLoadAttempt] = useState(0)
+  const failedWriteTargets = useRef(new Set<string>())
+  const saverRef = useRef<StoreSaver | undefined>(undefined)
+  const retryLoad = useCallback(() => {
+    setIsReady(false)
+    setLoadError(undefined)
+    setLoadWarning(undefined)
+    setWriteError(undefined)
+    setLoadAttempt((attempt) => attempt + 1)
+  }, [])
+  const retryWrites = useCallback(() => {
+    const saver = saverRef.current
+    if (!saver || failedWriteTargets.current.size === 0) return
+
+    const state = useSessionStore.getState()
+    const activeSessionTargets = new Set(state.sessions.map((session) => `session:${session.id}`))
+    for (const target of failedWriteTargets.current) {
+      if (target.startsWith('session:') && !activeSessionTargets.has(target)) {
+        failedWriteTargets.current.delete(target)
+      }
+    }
+    if (failedWriteTargets.current.size === 0) {
+      setWriteError(undefined)
+      return
+    }
+
+    void saver(state, {
+      forceTargets: new Set(failedWriteTargets.current)
+    }).catch(reportPersistenceError)
+  }, [])
 
   useEffect(() => {
     let isMounted = true
     let unsubscribe: (() => void) | undefined
+    let activeSaver: StoreSaver | undefined
+    saverRef.current = undefined
+    failedWriteTargets.current.clear()
 
     // Loads before subscribing so the initial empty store cannot overwrite disk state.
     const startPersistence = async (): Promise<void> => {
       try {
-        await loadPersistedSessions(window.api.sessions, () => isMounted)
+        const result = await loadPersistedSessions(window.api.sessions, () => isMounted)
+        if (!result || !isMounted) return
+
+        if (result.diagnostics?.isComplete === false) {
+          setLoadError(
+            result.diagnostics.failure === 'manifest-unreadable'
+              ? 'Conversation selection data could not be read. Retry before creating or saving conversations.'
+              : result.diagnostics.failure === 'startup-reconciliation-failed'
+                ? 'Saved conversations loaded, but storage recovery could not finish. Retry before creating or saving conversations.'
+                : 'Some saved conversations could not be read. Retry before creating or saving conversations.'
+          )
+          return
+        }
+
+        const loadWarnings = result.diagnostics?.warnings ?? []
+        if (loadWarnings.length > 0) {
+          const manifestWasRecovered = loadWarnings.some(
+            (warning) => warning.kind === 'manifest-corrupt'
+          )
+          const sessionWarningCount = loadWarnings.filter(
+            (warning) => warning.kind !== 'manifest-corrupt'
+          ).length
+          const warningMessages = [
+            manifestWasRecovered
+              ? 'Conversation selection data was damaged and moved aside.'
+              : undefined,
+            sessionWarningCount > 0
+              ? `${sessionWarningCount} saved conversation file${sessionWarningCount === 1 ? ' was' : 's were'} damaged and moved aside.`
+              : undefined,
+            'The remaining conversations were loaded.'
+          ]
+          setLoadWarning(warningMessages.filter(Boolean).join(' '))
+        }
       } catch (error) {
         reportPersistenceError(error)
+        if (isMounted) {
+          setLoadError(
+            error instanceof Error ? error.message : 'Saved conversations could not be loaded.'
+          )
+        }
+        return
       }
-
-      if (!isMounted) return
 
       setIsReady(true)
       // Snapshot the hydrated state as the diff baseline so hydration itself is not re-saved.
-      const save = createStoreSaver(window.api.sessions)
+      const save = createStoreSaver(window.api.sessions, useSessionStore.getState(), {
+        onFailure: (target, error) => {
+          if (!isMounted) return
+          failedWriteTargets.current.add(target)
+          setWriteError(
+            error instanceof Error ? error.message : 'Conversation changes could not be saved.'
+          )
+        },
+        onSuccess: (target) => {
+          if (!isMounted) return
+          failedWriteTargets.current.delete(target)
+          if (failedWriteTargets.current.size === 0) setWriteError(undefined)
+        }
+      })
+      activeSaver = save
+      saverRef.current = save
 
       unsubscribe = useSessionStore.subscribe((state) => {
         void save(state).catch(reportPersistenceError)
@@ -224,12 +351,13 @@ const useSessionPersistence = (): boolean => {
 
     return () => {
       isMounted = false
+      if (saverRef.current === activeSaver) saverRef.current = undefined
       unsubscribe?.()
     }
-  }, [])
+  }, [loadAttempt])
 
-  return isReady
+  return { isReady, loadError, loadWarning, writeError, retryLoad, retryWrites }
 }
 
 export { createStoreSaver, loadPersistedSessions, reconcilePendingArtifacts, useSessionPersistence }
-export type { ArtifactReconcileApi, SessionPersistenceApi }
+export type { ArtifactReconcileApi, SessionPersistenceApi, SessionPersistenceState }

--- a/src/renderer/src/lib/session-persistence/session-persistence.ts
+++ b/src/renderer/src/lib/session-persistence/session-persistence.ts
@@ -102,6 +102,16 @@ type StoreSaverObserver = {
 
 type StoreSaver = (state: SessionStoreSnapshot, options?: StoreSaverOptions) => Promise<unknown>
 
+const pruneRemovedSessionWriteTargets = (
+  targets: Set<string>,
+  sessions: readonly Pick<ChatSession, 'id'>[]
+): void => {
+  const activeSessionTargets = new Set(sessions.map((session) => `session:${session.id}`))
+  for (const target of targets) {
+    if (target.startsWith('session:') && !activeSessionTargets.has(target)) targets.delete(target)
+  }
+}
+
 // Retains full diagnostics in the console while the hook exposes renderer-safe recovery state.
 const reportPersistenceError = (error: unknown): void => {
   console.warn('Session persistence failed', error)
@@ -271,12 +281,7 @@ const useSessionPersistence = (): SessionPersistenceState => {
     if (!saver || failedWriteTargets.current.size === 0) return
 
     const state = useSessionStore.getState()
-    const activeSessionTargets = new Set(state.sessions.map((session) => `session:${session.id}`))
-    for (const target of failedWriteTargets.current) {
-      if (target.startsWith('session:') && !activeSessionTargets.has(target)) {
-        failedWriteTargets.current.delete(target)
-      }
-    }
+    pruneRemovedSessionWriteTargets(failedWriteTargets.current, state.sessions)
     if (failedWriteTargets.current.size === 0) {
       setWriteError(undefined)
       return
@@ -380,6 +385,8 @@ const useSessionPersistence = (): SessionPersistenceState => {
       saverRef.current = save
 
       unsubscribe = useSessionStore.subscribe((state) => {
+        pruneRemovedSessionWriteTargets(failedWriteTargets.current, state.sessions)
+        if (failedWriteTargets.current.size === 0) setWriteError(undefined)
         void save(state).catch(reportPersistenceError)
       })
 

--- a/src/renderer/src/lib/session-persistence/session-persistence.ts
+++ b/src/renderer/src/lib/session-persistence/session-persistence.ts
@@ -82,6 +82,7 @@ type SessionStoreSnapshot = {
 
 type SessionPersistenceState = {
   isHydrated: boolean
+  isLoading: boolean
   isReady: boolean
   loadError: string | undefined
   loadWarning: string | undefined
@@ -232,6 +233,7 @@ const createStoreSaver = (
 // Starts session persistence and returns health/recovery state so App can gate input and surface failures.
 const useSessionPersistence = (): SessionPersistenceState => {
   const [isHydrated, setIsHydrated] = useState(false)
+  const [isLoading, setIsLoading] = useState(true)
   const [isReady, setIsReady] = useState(false)
   const [loadError, setLoadError] = useState<string | undefined>(undefined)
   const [loadWarning, setLoadWarning] = useState<string | undefined>(undefined)
@@ -241,6 +243,7 @@ const useSessionPersistence = (): SessionPersistenceState => {
   const saverRef = useRef<StoreSaver | undefined>(undefined)
   const retryLoad = useCallback(() => {
     setIsHydrated(false)
+    setIsLoading(true)
     setIsReady(false)
     setLoadError(undefined)
     setLoadWarning(undefined)
@@ -290,6 +293,7 @@ const useSessionPersistence = (): SessionPersistenceState => {
                 ? 'Saved conversations loaded, but storage recovery could not finish. Retry before creating or saving conversations.'
                 : 'Some saved conversations could not be read. Retry before creating or saving conversations.'
           )
+          setIsLoading(false)
           return
         }
 
@@ -318,11 +322,13 @@ const useSessionPersistence = (): SessionPersistenceState => {
           setLoadError(
             error instanceof Error ? error.message : 'Saved conversations could not be loaded.'
           )
+          setIsLoading(false)
         }
         return
       }
 
       setIsReady(true)
+      setIsLoading(false)
       // Snapshot the hydrated state as the diff baseline so hydration itself is not re-saved.
       const save = createStoreSaver(window.api.sessions, useSessionStore.getState(), {
         onFailure: (target, error) => {
@@ -360,7 +366,16 @@ const useSessionPersistence = (): SessionPersistenceState => {
     }
   }, [loadAttempt])
 
-  return { isHydrated, isReady, loadError, loadWarning, writeError, retryLoad, retryWrites }
+  return {
+    isHydrated,
+    isLoading,
+    isReady,
+    loadError,
+    loadWarning,
+    writeError,
+    retryLoad,
+    retryWrites
+  }
 }
 
 export { createStoreSaver, loadPersistedSessions, reconcilePendingArtifacts, useSessionPersistence }

--- a/src/renderer/src/pages/home/DeleteProjectDialog.tsx
+++ b/src/renderer/src/pages/home/DeleteProjectDialog.tsx
@@ -17,6 +17,7 @@ import type { Project } from '../../../../shared/projects'
 type DeleteProjectDialogProps = {
   project: Project | undefined
   sessionCount: number
+  hasCompleteSessionCatalog: boolean
   canDelete: boolean
   onCancel: () => void
   onConfirmDelete: () => void
@@ -29,6 +30,7 @@ const deleteDialogConfirmButtonClassName =
 const DeleteProjectDialog = ({
   project,
   sessionCount,
+  hasCompleteSessionCatalog,
   canDelete,
   onCancel,
   onConfirmDelete
@@ -36,6 +38,9 @@ const DeleteProjectDialog = ({
   const dialogProject = useRetainedDialogValue(project)
   const dialogSessionCount =
     useRetainedDialogValue(project ? sessionCount : undefined) ?? sessionCount
+  const dialogHasCompleteSessionCatalog =
+    useRetainedDialogValue(project ? hasCompleteSessionCatalog : undefined) ??
+    hasCompleteSessionCatalog
 
   return (
     <AlertDialog.Root
@@ -54,9 +59,11 @@ const DeleteProjectDialog = ({
               </AlertDialog.Title>
               <AlertDialog.Description className={dialogDescriptionClassName}>
                 This will permanently delete &quot;{dialogProject?.name}&quot;
-                {dialogSessionCount > 0
-                  ? ` and its ${dialogSessionCount} ${dialogSessionCount === 1 ? 'session' : 'sessions'}`
-                  : ''}
+                {dialogHasCompleteSessionCatalog
+                  ? dialogSessionCount > 0
+                    ? ` and its ${dialogSessionCount} ${dialogSessionCount === 1 ? 'session' : 'sessions'}`
+                    : ''
+                  : ' and all of its saved conversations, including any that could not be loaded during recovery'}
                 . Generated artifacts remain on disk. This action cannot be undone.
               </AlertDialog.Description>
             </div>

--- a/src/renderer/src/pages/home/DeleteProjectDialog.tsx
+++ b/src/renderer/src/pages/home/DeleteProjectDialog.tsx
@@ -17,6 +17,7 @@ import type { Project } from '../../../../shared/projects'
 type DeleteProjectDialogProps = {
   project: Project | undefined
   sessionCount: number
+  canDelete: boolean
   onCancel: () => void
   onConfirmDelete: () => void
 }
@@ -28,6 +29,7 @@ const deleteDialogConfirmButtonClassName =
 const DeleteProjectDialog = ({
   project,
   sessionCount,
+  canDelete,
   onCancel,
   onConfirmDelete
 }: DeleteProjectDialogProps): React.JSX.Element => {
@@ -79,6 +81,7 @@ const DeleteProjectDialog = ({
               <Button
                 type="button"
                 className={deleteDialogConfirmButtonClassName}
+                disabled={!canDelete}
                 onClick={onConfirmDelete}
               >
                 Delete

--- a/src/renderer/src/pages/home/HomePage.persistence.test.tsx
+++ b/src/renderer/src/pages/home/HomePage.persistence.test.tsx
@@ -4,6 +4,7 @@ import { createRoot, type Root } from 'react-dom/client'
 import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest'
 
 import type { Project } from '../../../../shared/projects'
+import { useNavigationStore } from '@/stores/navigation-store'
 import { createInitialProjectState, useProjectStore } from '@/stores/project-store'
 import { createInitialSessionState, useSessionStore } from '@/stores/session-store'
 import { createInitialSettingsState, useSettingsStore } from '@/stores/settings-store'
@@ -83,6 +84,12 @@ describe('HomePage persistence recovery', () => {
       deleteProject
     } as never)
     useSessionStore.setState(createInitialSessionState())
+    useNavigationStore.setState({
+      view: 'home',
+      activeProjectId: undefined,
+      userNavigationRevision: 0,
+      explicitNavigationRevision: 0
+    })
     useSettingsStore.setState(createInitialSettingsState())
   })
 
@@ -123,5 +130,20 @@ describe('HomePage persistence recovery', () => {
     await act(async () => confirm?.click())
 
     expect(deleteProject).not.toHaveBeenCalled()
+  })
+
+  it('records explicit user takeover before starting Project deletion', async () => {
+    await act(async () => root.render(<HomePage canDeleteProjects />))
+
+    const deleteAction = [...container.querySelectorAll<HTMLButtonElement>('button')].find(
+      (button) => button.textContent?.trim() === 'Delete'
+    )
+    await act(async () => deleteAction?.click())
+    await act(async () =>
+      container.querySelector<HTMLButtonElement>('[data-testid="confirm-project-delete"]')?.click()
+    )
+
+    expect(useNavigationStore.getState().userNavigationRevision).toBe(1)
+    expect(deleteProject).toHaveBeenCalledWith(project.id)
   })
 })

--- a/src/renderer/src/pages/home/HomePage.persistence.test.tsx
+++ b/src/renderer/src/pages/home/HomePage.persistence.test.tsx
@@ -117,6 +117,22 @@ describe('HomePage persistence recovery', () => {
     ).toBe('false')
   })
 
+  it('does not present partial project Session counts as authoritative', async () => {
+    useSessionStore.getState().appendUserMessage({
+      sessionId: 'session-1',
+      projectId: project.id,
+      cwd: '/workspace/project-1',
+      content: 'Recovered conversation'
+    })
+
+    await act(async () =>
+      root.render(<HomePage canDeleteProjects hasCompleteSessionCatalog={false} />)
+    )
+
+    expect(container.textContent).toContain('Session count unavailable')
+    expect(container.textContent).not.toContain('1 session')
+  })
+
   it('guards confirmation when persistence becomes unavailable after the dialog opens', async () => {
     await act(async () => root.render(<HomePage canDeleteProjects hasCompleteSessionCatalog />))
 

--- a/src/renderer/src/pages/home/HomePage.persistence.test.tsx
+++ b/src/renderer/src/pages/home/HomePage.persistence.test.tsx
@@ -18,10 +18,12 @@ vi.mock('./DeleteProjectDialog', () => ({
   DeleteProjectDialog: ({
     project,
     canDelete,
+    hasCompleteSessionCatalog,
     onConfirmDelete
   }: {
     project: Project | undefined
     canDelete: boolean
+    hasCompleteSessionCatalog: boolean
     onConfirmDelete: () => void
   }) => (
     <button
@@ -29,6 +31,7 @@ vi.mock('./DeleteProjectDialog', () => ({
       data-testid="confirm-project-delete"
       data-can-delete={String(canDelete)}
       data-has-project={String(Boolean(project))}
+      data-has-complete-session-catalog={String(hasCompleteSessionCatalog)}
       onClick={onConfirmDelete}
     >
       Confirm delete
@@ -99,7 +102,9 @@ describe('HomePage persistence recovery', () => {
   })
 
   it('disables project deletion while session persistence is recovering', async () => {
-    await act(async () => root.render(<HomePage canDeleteProjects={false} />))
+    await act(async () =>
+      root.render(<HomePage canDeleteProjects={false} hasCompleteSessionCatalog={false} />)
+    )
 
     const deleteAction = [...container.querySelectorAll<HTMLButtonElement>('button')].find(
       (button) => button.textContent?.trim() === 'Delete'
@@ -113,7 +118,7 @@ describe('HomePage persistence recovery', () => {
   })
 
   it('guards confirmation when persistence becomes unavailable after the dialog opens', async () => {
-    await act(async () => root.render(<HomePage canDeleteProjects />))
+    await act(async () => root.render(<HomePage canDeleteProjects hasCompleteSessionCatalog />))
 
     const deleteAction = [...container.querySelectorAll<HTMLButtonElement>('button')].find(
       (button) => button.textContent?.trim() === 'Delete'
@@ -125,7 +130,9 @@ describe('HomePage persistence recovery', () => {
     )
     expect(confirm?.dataset.hasProject).toBe('true')
 
-    await act(async () => root.render(<HomePage canDeleteProjects={false} />))
+    await act(async () =>
+      root.render(<HomePage canDeleteProjects={false} hasCompleteSessionCatalog={false} />)
+    )
     expect(confirm?.dataset.canDelete).toBe('false')
     await act(async () => confirm?.click())
 
@@ -133,7 +140,9 @@ describe('HomePage persistence recovery', () => {
   })
 
   it('records explicit user takeover before starting Project deletion', async () => {
-    await act(async () => root.render(<HomePage canDeleteProjects />))
+    await act(async () =>
+      root.render(<HomePage canDeleteProjects hasCompleteSessionCatalog={false} />)
+    )
 
     const deleteAction = [...container.querySelectorAll<HTMLButtonElement>('button')].find(
       (button) => button.textContent?.trim() === 'Delete'
@@ -145,5 +154,9 @@ describe('HomePage persistence recovery', () => {
 
     expect(useNavigationStore.getState().userNavigationRevision).toBe(1)
     expect(deleteProject).toHaveBeenCalledWith(project.id)
+    expect(
+      container.querySelector<HTMLButtonElement>('[data-testid="confirm-project-delete"]')?.dataset
+        .hasCompleteSessionCatalog
+    ).toBe('false')
   })
 })

--- a/src/renderer/src/pages/home/HomePage.persistence.test.tsx
+++ b/src/renderer/src/pages/home/HomePage.persistence.test.tsx
@@ -1,0 +1,127 @@
+// @vitest-environment jsdom
+import { act, type ReactNode } from 'react'
+import { createRoot, type Root } from 'react-dom/client'
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest'
+
+import type { Project } from '../../../../shared/projects'
+import { createInitialProjectState, useProjectStore } from '@/stores/project-store'
+import { createInitialSessionState, useSessionStore } from '@/stores/session-store'
+import { createInitialSettingsState, useSettingsStore } from '@/stores/settings-store'
+import { HomePage } from './HomePage'
+
+vi.mock('@/components/GitHubStarBadge', () => ({ GitHubStarBadge: () => null }))
+vi.mock('@/components/ThemeControls', () => ({ ThemePreferenceMenu: () => null }))
+vi.mock('@/components/UpdateCapsule', () => ({ UpdateCapsule: () => null }))
+vi.mock('./ProjectFormDialog', () => ({ ProjectFormDialog: () => null }))
+vi.mock('./DeleteProjectDialog', () => ({
+  DeleteProjectDialog: ({
+    project,
+    canDelete,
+    onConfirmDelete
+  }: {
+    project: Project | undefined
+    canDelete: boolean
+    onConfirmDelete: () => void
+  }) => (
+    <button
+      type="button"
+      data-testid="confirm-project-delete"
+      data-can-delete={String(canDelete)}
+      data-has-project={String(Boolean(project))}
+      onClick={onConfirmDelete}
+    >
+      Confirm delete
+    </button>
+  )
+}))
+vi.mock('radix-ui', () => ({
+  DropdownMenu: {
+    Root: ({ children }: { children: ReactNode }) => <>{children}</>,
+    Trigger: ({ children }: { children: ReactNode }) => <>{children}</>,
+    Portal: ({ children }: { children: ReactNode }) => <>{children}</>,
+    Content: ({ children }: { children: ReactNode }) => <>{children}</>,
+    Separator: () => null,
+    Item: ({
+      children,
+      disabled,
+      onSelect
+    }: {
+      children: ReactNode
+      disabled?: boolean
+      onSelect?: () => void
+    }) => (
+      <button type="button" disabled={disabled} onClick={onSelect}>
+        {children}
+      </button>
+    )
+  }
+}))
+
+const project: Project = {
+  id: 'project-1',
+  name: 'Protected project',
+  description: '',
+  isExample: false,
+  createdAt: 1,
+  updatedAt: 1
+}
+
+describe('HomePage persistence recovery', () => {
+  let container: HTMLDivElement
+  let root: Root
+  let deleteProject: ReturnType<typeof vi.fn>
+
+  beforeEach(() => {
+    container = document.createElement('div')
+    document.body.appendChild(container)
+    root = createRoot(container)
+    deleteProject = vi.fn().mockResolvedValue(undefined)
+    useProjectStore.setState({
+      ...createInitialProjectState(),
+      projects: [project],
+      isLoaded: true,
+      deleteProject
+    } as never)
+    useSessionStore.setState(createInitialSessionState())
+    useSettingsStore.setState(createInitialSettingsState())
+  })
+
+  afterEach(async () => {
+    await act(async () => root.unmount())
+    container.remove()
+  })
+
+  it('disables project deletion while session persistence is recovering', async () => {
+    await act(async () => root.render(<HomePage canDeleteProjects={false} />))
+
+    const deleteAction = [...container.querySelectorAll<HTMLButtonElement>('button')].find(
+      (button) => button.textContent?.trim() === 'Delete'
+    )
+
+    expect(deleteAction?.disabled).toBe(true)
+    expect(
+      container.querySelector<HTMLButtonElement>('[data-testid="confirm-project-delete"]')?.dataset
+        .canDelete
+    ).toBe('false')
+  })
+
+  it('guards confirmation when persistence becomes unavailable after the dialog opens', async () => {
+    await act(async () => root.render(<HomePage canDeleteProjects />))
+
+    const deleteAction = [...container.querySelectorAll<HTMLButtonElement>('button')].find(
+      (button) => button.textContent?.trim() === 'Delete'
+    )
+    await act(async () => deleteAction?.click())
+
+    const confirm = container.querySelector<HTMLButtonElement>(
+      '[data-testid="confirm-project-delete"]'
+    )
+    expect(confirm?.dataset.hasProject).toBe('true')
+
+    await act(async () => root.render(<HomePage canDeleteProjects={false} />))
+    expect(confirm?.dataset.canDelete).toBe('false')
+    await act(async () => confirm?.click())
+
+    expect(deleteProject).not.toHaveBeenCalled()
+  })
+})

--- a/src/renderer/src/pages/home/HomePage.render.test.tsx
+++ b/src/renderer/src/pages/home/HomePage.render.test.tsx
@@ -60,7 +60,7 @@ describe('HomePage environment repair notice', () => {
       ])
     })
 
-    await act(async () => root.render(<HomePage />))
+    await act(async () => root.render(<HomePage canDeleteProjects />))
 
     expect(container.querySelector('[aria-label="Open environment repair"]')).toBeNull()
   })
@@ -79,7 +79,7 @@ describe('HomePage environment repair notice', () => {
       openSettingsToPanel
     } as never)
 
-    await act(async () => root.render(<HomePage />))
+    await act(async () => root.render(<HomePage canDeleteProjects />))
 
     const repairButton = container.querySelector<HTMLButtonElement>(
       '[aria-label="Open environment repair"]'
@@ -112,7 +112,7 @@ describe('HomePage environment repair notice', () => {
       openSettingsToPanel
     } as never)
 
-    await act(async () => root.render(<HomePage />))
+    await act(async () => root.render(<HomePage canDeleteProjects />))
     await act(async () =>
       container.querySelector<HTMLButtonElement>('[aria-label="Open environment repair"]')?.click()
     )
@@ -134,7 +134,7 @@ describe('HomePage environment repair notice', () => {
       openSettingsToPanel
     } as never)
 
-    await act(async () => root.render(<HomePage />))
+    await act(async () => root.render(<HomePage canDeleteProjects />))
     await act(async () =>
       container.querySelector<HTMLButtonElement>('[aria-label="Open environment repair"]')?.click()
     )
@@ -156,7 +156,7 @@ describe('HomePage environment repair notice', () => {
       openSettingsToPanel
     } as never)
 
-    await act(async () => root.render(<HomePage />))
+    await act(async () => root.render(<HomePage canDeleteProjects />))
     await act(async () =>
       container.querySelector<HTMLButtonElement>('[aria-label="Open environment repair"]')?.click()
     )
@@ -178,7 +178,7 @@ describe('HomePage environment repair notice', () => {
       openSettingsToPanel
     } as never)
 
-    await act(async () => root.render(<HomePage />))
+    await act(async () => root.render(<HomePage canDeleteProjects />))
     await act(async () =>
       container.querySelector<HTMLButtonElement>('[aria-label="Open environment repair"]')?.click()
     )

--- a/src/renderer/src/pages/home/HomePage.render.test.tsx
+++ b/src/renderer/src/pages/home/HomePage.render.test.tsx
@@ -60,7 +60,7 @@ describe('HomePage environment repair notice', () => {
       ])
     })
 
-    await act(async () => root.render(<HomePage canDeleteProjects />))
+    await act(async () => root.render(<HomePage canDeleteProjects hasCompleteSessionCatalog />))
 
     expect(container.querySelector('[aria-label="Open environment repair"]')).toBeNull()
   })
@@ -79,7 +79,7 @@ describe('HomePage environment repair notice', () => {
       openSettingsToPanel
     } as never)
 
-    await act(async () => root.render(<HomePage canDeleteProjects />))
+    await act(async () => root.render(<HomePage canDeleteProjects hasCompleteSessionCatalog />))
 
     const repairButton = container.querySelector<HTMLButtonElement>(
       '[aria-label="Open environment repair"]'
@@ -112,7 +112,7 @@ describe('HomePage environment repair notice', () => {
       openSettingsToPanel
     } as never)
 
-    await act(async () => root.render(<HomePage canDeleteProjects />))
+    await act(async () => root.render(<HomePage canDeleteProjects hasCompleteSessionCatalog />))
     await act(async () =>
       container.querySelector<HTMLButtonElement>('[aria-label="Open environment repair"]')?.click()
     )
@@ -134,7 +134,7 @@ describe('HomePage environment repair notice', () => {
       openSettingsToPanel
     } as never)
 
-    await act(async () => root.render(<HomePage canDeleteProjects />))
+    await act(async () => root.render(<HomePage canDeleteProjects hasCompleteSessionCatalog />))
     await act(async () =>
       container.querySelector<HTMLButtonElement>('[aria-label="Open environment repair"]')?.click()
     )
@@ -156,7 +156,7 @@ describe('HomePage environment repair notice', () => {
       openSettingsToPanel
     } as never)
 
-    await act(async () => root.render(<HomePage canDeleteProjects />))
+    await act(async () => root.render(<HomePage canDeleteProjects hasCompleteSessionCatalog />))
     await act(async () =>
       container.querySelector<HTMLButtonElement>('[aria-label="Open environment repair"]')?.click()
     )
@@ -178,7 +178,7 @@ describe('HomePage environment repair notice', () => {
       openSettingsToPanel
     } as never)
 
-    await act(async () => root.render(<HomePage canDeleteProjects />))
+    await act(async () => root.render(<HomePage canDeleteProjects hasCompleteSessionCatalog />))
     await act(async () =>
       container.querySelector<HTMLButtonElement>('[aria-label="Open environment repair"]')?.click()
     )

--- a/src/renderer/src/pages/home/HomePage.tsx
+++ b/src/renderer/src/pages/home/HomePage.tsx
@@ -206,6 +206,10 @@ const HomePage = ({ canDeleteProjects }: HomePageProps): React.JSX.Element => {
 
     const projectId = projectToDelete.id
 
+    // Deletion is an explicit user takeover even though it does not immediately navigate. Advance
+    // the navigation revision before the async mutation so deferred startup intents cannot reopen a
+    // conversation after the post-delete view has settled.
+    useNavigationStore.getState().recordUserNavigation()
     setProjectToDelete(undefined)
 
     void deleteProject(projectId)

--- a/src/renderer/src/pages/home/HomePage.tsx
+++ b/src/renderer/src/pages/home/HomePage.tsx
@@ -40,6 +40,10 @@ type ProjectSummary = {
 
 type ProjectFormState = { mode: 'create' } | { mode: 'edit'; projectId: string }
 
+type HomePageProps = {
+  canDeleteProjects: boolean
+}
+
 // Optional warnings (currently Python and reduced key protection) never create a Home alert. Only a
 // failed check that blocks the core flow asks an existing user to revisit environment setup.
 const getRequiredEnvironmentFailures = (
@@ -71,10 +75,10 @@ const menuItemClassName =
   'flex w-full cursor-pointer items-center gap-2 rounded-lg px-2 py-1.5 text-left text-sm text-text-100 transition-colors duration-150 ease-out outline-none data-[highlighted]:bg-bg-200 data-[highlighted]:text-text-000'
 
 const menuDangerItemClassName =
-  'flex w-full cursor-pointer items-center gap-2 rounded-lg px-2 py-1.5 text-left text-sm text-danger-000 transition-colors duration-150 ease-out outline-none data-[highlighted]:bg-danger-900'
+  'flex w-full cursor-pointer items-center gap-2 rounded-lg px-2 py-1.5 text-left text-sm text-danger-000 transition-colors duration-150 ease-out outline-none data-[highlighted]:bg-danger-900 data-[disabled]:pointer-events-none data-[disabled]:opacity-50'
 
 // Landing screen: pick a project or jump back into a recent session.
-const HomePage = (): React.JSX.Element => {
+const HomePage = ({ canDeleteProjects }: HomePageProps): React.JSX.Element => {
   const projects = useProjectStore((state) => state.projects)
   const loadError = useProjectStore((state) => state.loadError)
   const createProject = useProjectStore((state) => state.createProject)
@@ -149,6 +153,12 @@ const HomePage = (): React.JSX.Element => {
     setFormError(undefined)
   }
 
+  const openDeleteDialog = (project: Project): void => {
+    if (!canDeleteProjects) return
+
+    setProjectToDelete(project)
+  }
+
   const closeFormDialog = (): void => {
     if (isSubmitting) return
 
@@ -192,7 +202,7 @@ const HomePage = (): React.JSX.Element => {
 
   // Main coordinates durable project/session/index cleanup; renderer state changes only after it succeeds.
   const confirmDeleteProject = (): void => {
-    if (!projectToDelete) return
+    if (!canDeleteProjects || !projectToDelete) return
 
     const projectId = projectToDelete.id
 
@@ -339,7 +349,8 @@ const HomePage = (): React.JSX.Element => {
                           <DropdownMenu.Separator className="mx-1 my-1 h-px bg-border-300" />
                           <DropdownMenu.Item
                             className={menuDangerItemClassName}
-                            onSelect={() => setProjectToDelete(project)}
+                            disabled={!canDeleteProjects}
+                            onSelect={() => openDeleteDialog(project)}
                           >
                             <Trash2 className="size-4" strokeWidth={2} aria-hidden="true" />
                             Delete
@@ -419,6 +430,7 @@ const HomePage = (): React.JSX.Element => {
       <DeleteProjectDialog
         project={projectToDelete}
         sessionCount={deleteTargetSessionCount}
+        canDelete={canDeleteProjects}
         onCancel={() => setProjectToDelete(undefined)}
         onConfirmDelete={confirmDeleteProject}
       />

--- a/src/renderer/src/pages/home/HomePage.tsx
+++ b/src/renderer/src/pages/home/HomePage.tsx
@@ -325,7 +325,9 @@ const HomePage = ({
                       ) : null}
                     </button>
                     <span className="shrink-0 text-xs text-text-100">
-                      {sessionCount} {sessionCount === 1 ? 'session' : 'sessions'}
+                      {hasCompleteSessionCatalog
+                        ? `${sessionCount} ${sessionCount === 1 ? 'session' : 'sessions'}`
+                        : 'Session count unavailable'}
                     </span>
                     <span className="w-8 shrink-0 text-right text-xs text-text-300">
                       {formatRelativeTime(lastActivityAt)}

--- a/src/renderer/src/pages/home/HomePage.tsx
+++ b/src/renderer/src/pages/home/HomePage.tsx
@@ -190,7 +190,7 @@ const HomePage = ({ canDeleteProjects }: HomePageProps): React.JSX.Element => {
 
         setFormState(null)
 
-        if (isCreate) openProject(project.id)
+        if (isCreate) openProject(project.id, 'user')
       })
       .catch((error: unknown) => {
         setFormError(error instanceof Error ? error.message : 'Could not save project.')
@@ -307,7 +307,7 @@ const HomePage = ({ canDeleteProjects }: HomePageProps): React.JSX.Element => {
                     <button
                       type="button"
                       className="flex min-w-0 flex-1 cursor-pointer items-center gap-2 text-left"
-                      onClick={() => openProject(project.id)}
+                      onClick={() => openProject(project.id, 'user')}
                     >
                       <span className="truncate font-semibold text-text-000">{project.name}</span>
                       {project.isExample ? (
@@ -383,7 +383,7 @@ const HomePage = ({ canDeleteProjects }: HomePageProps): React.JSX.Element => {
                       key={session.id}
                       type="button"
                       className={cn(rowClassName, 'cursor-pointer items-start')}
-                      onClick={() => openSession(session.projectId, session.id)}
+                      onClick={() => openSession(session.projectId, session.id, 'user')}
                       title={session.title}
                     >
                       <span

--- a/src/renderer/src/pages/home/HomePage.tsx
+++ b/src/renderer/src/pages/home/HomePage.tsx
@@ -42,6 +42,7 @@ type ProjectFormState = { mode: 'create' } | { mode: 'edit'; projectId: string }
 
 type HomePageProps = {
   canDeleteProjects: boolean
+  hasCompleteSessionCatalog: boolean
 }
 
 // Optional warnings (currently Python and reduced key protection) never create a Home alert. Only a
@@ -78,7 +79,10 @@ const menuDangerItemClassName =
   'flex w-full cursor-pointer items-center gap-2 rounded-lg px-2 py-1.5 text-left text-sm text-danger-000 transition-colors duration-150 ease-out outline-none data-[highlighted]:bg-danger-900 data-[disabled]:pointer-events-none data-[disabled]:opacity-50'
 
 // Landing screen: pick a project or jump back into a recent session.
-const HomePage = ({ canDeleteProjects }: HomePageProps): React.JSX.Element => {
+const HomePage = ({
+  canDeleteProjects,
+  hasCompleteSessionCatalog
+}: HomePageProps): React.JSX.Element => {
   const projects = useProjectStore((state) => state.projects)
   const loadError = useProjectStore((state) => state.loadError)
   const createProject = useProjectStore((state) => state.createProject)
@@ -434,6 +438,7 @@ const HomePage = ({ canDeleteProjects }: HomePageProps): React.JSX.Element => {
       <DeleteProjectDialog
         project={projectToDelete}
         sessionCount={deleteTargetSessionCount}
+        hasCompleteSessionCatalog={hasCompleteSessionCatalog}
         canDelete={canDeleteProjects}
         onCancel={() => setProjectToDelete(undefined)}
         onConfirmDelete={confirmDeleteProject}

--- a/src/renderer/src/pages/home/home-dialogs.render.test.tsx
+++ b/src/renderer/src/pages/home/home-dialogs.render.test.tsx
@@ -121,6 +121,7 @@ describe('home dialogs shared chrome', () => {
     const tree = DeleteProjectDialog({
       project: createProject(),
       sessionCount: 2,
+      canDelete: true,
       onCancel,
       onConfirmDelete
     })

--- a/src/renderer/src/pages/home/home-dialogs.render.test.tsx
+++ b/src/renderer/src/pages/home/home-dialogs.render.test.tsx
@@ -121,6 +121,7 @@ describe('home dialogs shared chrome', () => {
     const tree = DeleteProjectDialog({
       project: createProject(),
       sessionCount: 2,
+      hasCompleteSessionCatalog: true,
       canDelete: true,
       onCancel,
       onConfirmDelete
@@ -134,5 +135,24 @@ describe('home dialogs shared chrome', () => {
       interceptsOutsideClick: false
     })
     expect(deleteButton?.props.className).toContain('bg-danger-000')
+  })
+
+  it('warns about unreadable conversations without showing an incomplete session count', async () => {
+    const { DeleteProjectDialog } = await import('./DeleteProjectDialog')
+
+    const tree = DeleteProjectDialog({
+      project: createProject(),
+      sessionCount: 1,
+      hasCompleteSessionCatalog: false,
+      canDelete: true,
+      onCancel: vi.fn(),
+      onConfirmDelete: vi.fn()
+    })
+    const text = getTextContent(tree)
+
+    expect(text).toContain(
+      'all of its saved conversations, including any that could not be loaded during recovery'
+    )
+    expect(text).not.toContain('its 1 session')
   })
 })

--- a/src/renderer/src/pages/workspace/ConversationPanel.interaction.test.tsx
+++ b/src/renderer/src/pages/workspace/ConversationPanel.interaction.test.tsx
@@ -109,6 +109,7 @@ const renderPanel = (props: Partial<Parameters<typeof ConversationPanel>[0]> = {
         draftDoc={emptyDoc}
         canSendMessage={false}
         canEditDraft
+        canResumeSession
         actionError={null}
         isPreviewPanelCollapsed={false}
         attachments={[]}
@@ -318,6 +319,40 @@ describe('ConversationPanel composer intake', () => {
     })
 
     expect(onDraftDocChange).toHaveBeenCalledWith({ nodes: [{ type: 'text', text: 'hello' }] })
+  })
+})
+
+describe('ConversationPanel interrupted Session recovery', () => {
+  it('keeps Resume disabled while Session persistence is unavailable', () => {
+    const onResumeSession = vi.fn().mockResolvedValue(undefined)
+    const interruptedSession: ChatSession = {
+      id: 'session-interrupted',
+      projectId: 'project-a',
+      title: 'Interrupted session',
+      cwd: '/workspace',
+      status: 'idle',
+      interrupted: true,
+      messages: [],
+      createdAt: Date.now(),
+      updatedAt: Date.now()
+    }
+
+    renderPanel({
+      activeSession: interruptedSession,
+      canResumeSession: false,
+      onResumeSession
+    })
+
+    const resumeButton = container.querySelector<HTMLButtonElement>(
+      'button[aria-label="Resume session"]'
+    )
+    expect(resumeButton?.disabled).toBe(true)
+    expect(resumeButton?.dataset.slot).toBe('button')
+    expect(resumeButton?.className).toContain('focus-visible:ring-3')
+    expect(resumeButton?.className).toContain('disabled:pointer-events-none')
+
+    act(() => resumeButton?.click())
+    expect(onResumeSession).not.toHaveBeenCalled()
   })
 })
 

--- a/src/renderer/src/pages/workspace/ConversationPanel.tsx
+++ b/src/renderer/src/pages/workspace/ConversationPanel.tsx
@@ -100,6 +100,7 @@ type ConversationPanelProps = {
   draftDoc: ComposerDoc
   canSendMessage: boolean
   canEditDraft: boolean
+  canResumeSession: boolean
   actionError: string | null
   isPreviewPanelCollapsed: boolean
   attachments: UploadedAttachment[]
@@ -153,6 +154,7 @@ const ConversationPanel = ({
   draftDoc,
   canSendMessage,
   canEditDraft,
+  canResumeSession,
   actionError,
   isPreviewPanelCollapsed,
   attachments,
@@ -216,7 +218,7 @@ const ConversationPanel = ({
 
   // Re-attaches the interrupted session; on success the banner unmounts, so guard the state update.
   const handleResume = async (): Promise<void> => {
-    if (isResuming) return
+    if (!canResumeSession || isResuming) return
 
     setIsResuming(true)
     try {
@@ -309,6 +311,7 @@ const ConversationPanel = ({
                 {activeSession?.interrupted ? (
                   <SessionInterruptedBanner
                     message={activeSession.error ?? 'This session was interrupted.'}
+                    isDisabled={!canResumeSession}
                     isResuming={isResuming}
                     onResume={() => void handleResume()}
                   />

--- a/src/renderer/src/pages/workspace/DeleteSessionDialog.tsx
+++ b/src/renderer/src/pages/workspace/DeleteSessionDialog.tsx
@@ -16,6 +16,7 @@ import type { ChatSession } from '@/stores/session-store'
 
 type DeleteSessionDialogProps = {
   session: ChatSession | undefined
+  canDelete: boolean
   onCancel: () => void
   onConfirmDelete: () => void
 }
@@ -26,6 +27,7 @@ const deleteDialogConfirmButtonClassName =
 // Destructive deletion requires confirmation before the session is removed from memory.
 const DeleteSessionDialog = ({
   session,
+  canDelete,
   onCancel,
   onConfirmDelete
 }: DeleteSessionDialogProps): React.JSX.Element => {
@@ -72,6 +74,7 @@ const DeleteSessionDialog = ({
               <Button
                 type="button"
                 className={deleteDialogConfirmButtonClassName}
+                disabled={!canDelete}
                 onClick={onConfirmDelete}
               >
                 Delete

--- a/src/renderer/src/pages/workspace/SessionInterruptedBanner.test.tsx
+++ b/src/renderer/src/pages/workspace/SessionInterruptedBanner.test.tsx
@@ -36,6 +36,7 @@ describe('SessionInterruptedBanner', () => {
       root.render(
         <SessionInterruptedBanner
           message="Session was interrupted before the app closed."
+          isDisabled={false}
           isResuming={false}
           onResume={onResume}
         />
@@ -58,13 +59,42 @@ describe('SessionInterruptedBanner', () => {
     const onResume = vi.fn()
     act(() => {
       root.render(
-        <SessionInterruptedBanner message="Interrupted." isResuming onResume={onResume} />
+        <SessionInterruptedBanner
+          message="Interrupted."
+          isDisabled={false}
+          isResuming
+          onResume={onResume}
+        />
       )
     })
 
     const button = getResumeButton()
     expect(button.disabled).toBe(true)
     expect(button.textContent).toContain('Resuming')
+
+    act(() => {
+      button.dispatchEvent(new MouseEvent('click', { bubbles: true }))
+    })
+
+    expect(onResume).not.toHaveBeenCalled()
+  })
+
+  it('disables the button and ignores clicks while Session persistence is unavailable', () => {
+    const onResume = vi.fn()
+    act(() => {
+      root.render(
+        <SessionInterruptedBanner
+          message="Interrupted."
+          isDisabled
+          isResuming={false}
+          onResume={onResume}
+        />
+      )
+    })
+
+    const button = getResumeButton()
+    expect(button.disabled).toBe(true)
+    expect(button.textContent).toContain('Resume')
 
     act(() => {
       button.dispatchEvent(new MouseEvent('click', { bubbles: true }))

--- a/src/renderer/src/pages/workspace/SessionInterruptedBanner.tsx
+++ b/src/renderer/src/pages/workspace/SessionInterruptedBanner.tsx
@@ -1,33 +1,34 @@
 import { Loader2, Play } from 'lucide-react'
 
-import { cn } from '@/lib/utils'
+import { Button } from '@/components/ui/button'
 
 type SessionInterruptedBannerProps = {
   message: string
+  isDisabled: boolean
   isResuming: boolean
   onResume: () => void
 }
 
-const resumeButtonClassName = cn(
-  'flex shrink-0 items-center gap-1.5 rounded-md px-2.5 py-1 text-[12px] font-medium text-text-000',
-  'cursor-pointer transition-colors duration-200 ease-out hover:bg-bg-300',
-  'disabled:cursor-not-allowed disabled:opacity-60 disabled:hover:bg-transparent'
-)
+const resumeButtonClassName =
+  'gap-1.5 rounded-md text-[12px] text-text-000 hover:bg-bg-300 hover:text-text-000'
 
 // Neutral recovery banner for a session interrupted by an app restart. The Resume button re-attaches
 // the ACP runtime; while that request is in flight it is disabled so a second click cannot double-resume.
 const SessionInterruptedBanner = ({
   message,
+  isDisabled,
   isResuming,
   onResume
 }: SessionInterruptedBannerProps): React.JSX.Element => (
   <div className="mb-2 flex items-center gap-3 rounded-lg border border-border-200 bg-bg-200 px-3 py-2">
     <p className="min-w-0 flex-1 text-[12px] leading-5 text-text-100">{message}</p>
-    <button
+    <Button
       type="button"
+      variant="ghost"
+      size="sm"
       className={resumeButtonClassName}
       onClick={onResume}
-      disabled={isResuming}
+      disabled={isDisabled || isResuming}
       aria-label="Resume session"
     >
       {isResuming ? (
@@ -36,7 +37,7 @@ const SessionInterruptedBanner = ({
         <Play className="size-3.5" strokeWidth={2} aria-hidden="true" />
       )}
       {isResuming ? 'Resuming…' : 'Resume'}
-    </button>
+    </Button>
   </div>
 )
 

--- a/src/renderer/src/pages/workspace/WorkspacePage.draft-preservation.test.tsx
+++ b/src/renderer/src/pages/workspace/WorkspacePage.draft-preservation.test.tsx
@@ -135,7 +135,12 @@ describe('WorkspacePage draft preservation', () => {
   beforeEach(() => {
     usePreviewWorkbenchStore.setState(createInitialPreviewWorkbenchState())
     useProjectStore.setState({ projects: [] })
-    useNavigationStore.setState({ view: 'workspace', activeProjectId: 'proj-1' })
+    useNavigationStore.setState({
+      view: 'workspace',
+      activeProjectId: 'proj-1',
+      userNavigationRevision: 0,
+      explicitNavigationRevision: 0
+    })
     useSessionStore.setState({
       ...createInitialSessionState(),
       sessions: [createSession('sess-a', 'proj-1'), createSession('sess-b', 'proj-1')],
@@ -392,6 +397,21 @@ describe('WorkspacePage draft preservation', () => {
     expect(useSessionStore.getState().sessions).not.toContainEqual(
       expect.objectContaining({ id: 'sess-b' })
     )
+  })
+
+  it('records explicit user takeover before starting Session deletion', async () => {
+    await renderPage(false)
+
+    const sessionB = useSessionStore.getState().sessions.find((session) => session.id === 'sess-b')!
+    await act(async () => {
+      sidebarProps.onDeleteSession(sessionB)
+    })
+    await act(async () => {
+      deleteDialogProps.onConfirmDelete()
+    })
+
+    expect(useNavigationStore.getState().userNavigationRevision).toBe(1)
+    expect(runtime.deleteRuntimeSession).toHaveBeenCalledWith('sess-b')
   })
 
   it('cancels in-flight and queued transfers before deleting their session draft', async () => {

--- a/src/renderer/src/pages/workspace/WorkspacePage.draft-preservation.test.tsx
+++ b/src/renderer/src/pages/workspace/WorkspacePage.draft-preservation.test.tsx
@@ -204,10 +204,10 @@ describe('WorkspacePage draft preservation', () => {
     container.remove()
   })
 
-  const renderPage = async (): Promise<void> => {
+  const renderPage = async (isSessionPersistenceReady = true): Promise<void> => {
     root = createRoot(container)
     await act(async () => {
-      root.render(<WorkspacePage isSessionPersistenceReady={true} />)
+      root.render(<WorkspacePage isSessionPersistenceReady={isSessionPersistenceReady} />)
     })
   }
 
@@ -370,6 +370,23 @@ describe('WorkspacePage draft preservation', () => {
     expect(deleteUpload).toHaveBeenCalledWith({ path: attachmentB.path })
     expect(runtime.deleteRuntimeSession).toHaveBeenCalledWith('sess-b')
     expect(conversationProps.draftDoc).toEqual(emptyDoc)
+  })
+
+  it('blocks session deletion while durable persistence is recovering', async () => {
+    await renderPage(false)
+
+    const sessionB = useSessionStore.getState().sessions.find((session) => session.id === 'sess-b')!
+    await act(async () => {
+      sidebarProps.onDeleteSession(sessionB)
+    })
+    await act(async () => {
+      deleteDialogProps.onConfirmDelete()
+    })
+
+    expect(runtime.deleteRuntimeSession).not.toHaveBeenCalled()
+    expect(useSessionStore.getState().sessions).toContainEqual(
+      expect.objectContaining({ id: 'sess-b' })
+    )
   })
 
   it('cancels in-flight and queued transfers before deleting their session draft', async () => {

--- a/src/renderer/src/pages/workspace/WorkspacePage.draft-preservation.test.tsx
+++ b/src/renderer/src/pages/workspace/WorkspacePage.draft-preservation.test.tsx
@@ -207,7 +207,12 @@ describe('WorkspacePage draft preservation', () => {
   const renderPage = async (isSessionPersistenceReady = true): Promise<void> => {
     root = createRoot(container)
     await act(async () => {
-      root.render(<WorkspacePage isSessionPersistenceReady={isSessionPersistenceReady} />)
+      root.render(
+        <WorkspacePage
+          isSessionPersistenceHydrated={true}
+          isSessionPersistenceReady={isSessionPersistenceReady}
+        />
+      )
     })
   }
 
@@ -372,7 +377,7 @@ describe('WorkspacePage draft preservation', () => {
     expect(conversationProps.draftDoc).toEqual(emptyDoc)
   })
 
-  it('blocks session deletion while durable persistence is recovering', async () => {
+  it('allows target-validated session deletion while other persistence is recovering', async () => {
     await renderPage(false)
 
     const sessionB = useSessionStore.getState().sessions.find((session) => session.id === 'sess-b')!
@@ -383,8 +388,8 @@ describe('WorkspacePage draft preservation', () => {
       deleteDialogProps.onConfirmDelete()
     })
 
-    expect(runtime.deleteRuntimeSession).not.toHaveBeenCalled()
-    expect(useSessionStore.getState().sessions).toContainEqual(
+    expect(runtime.deleteRuntimeSession).toHaveBeenCalledWith('sess-b')
+    expect(useSessionStore.getState().sessions).not.toContainEqual(
       expect.objectContaining({ id: 'sess-b' })
     )
   })

--- a/src/renderer/src/pages/workspace/WorkspacePage.draft-preservation.test.tsx
+++ b/src/renderer/src/pages/workspace/WorkspacePage.draft-preservation.test.tsx
@@ -30,11 +30,16 @@ let conversationProps: {
   onStageAttachmentFiles: (files: File[]) => void
 }
 let sidebarProps: {
+  canDeleteConversations: boolean
   onOpenSession: (id: string) => void
   onNewConversation: () => void
   onDeleteSession: (session: ChatSession) => void
 }
-let deleteDialogProps: { session: ChatSession | undefined; onConfirmDelete: () => void }
+let deleteDialogProps: {
+  session: ChatSession | undefined
+  canDelete: boolean
+  onConfirmDelete: () => void
+}
 
 // The runtime bridge is stubbed; sendMessage resolves truthy so the success path clears the composer.
 const runtime = vi.hoisted(() => ({
@@ -209,13 +214,17 @@ describe('WorkspacePage draft preservation', () => {
     container.remove()
   })
 
-  const renderPage = async (isSessionPersistenceReady = true): Promise<void> => {
+  const renderPage = async (
+    isSessionPersistenceReady = true,
+    canDeleteConversations = true
+  ): Promise<void> => {
     root = createRoot(container)
     await act(async () => {
       root.render(
         <WorkspacePage
           isSessionPersistenceHydrated={true}
           isSessionPersistenceReady={isSessionPersistenceReady}
+          canDeleteConversations={canDeleteConversations}
         />
       )
     })
@@ -383,7 +392,7 @@ describe('WorkspacePage draft preservation', () => {
   })
 
   it('allows target-validated session deletion while other persistence is recovering', async () => {
-    await renderPage(false)
+    await renderPage(false, true)
 
     const sessionB = useSessionStore.getState().sessions.find((session) => session.id === 'sess-b')!
     await act(async () => {
@@ -397,6 +406,51 @@ describe('WorkspacePage draft preservation', () => {
     expect(useSessionStore.getState().sessions).not.toContainEqual(
       expect.objectContaining({ id: 'sess-b' })
     )
+  })
+
+  it('blocks session deletion when Project deletion recovery is incomplete', async () => {
+    await renderPage(false, false)
+
+    const sessionB = useSessionStore.getState().sessions.find((session) => session.id === 'sess-b')!
+    await act(async () => {
+      sidebarProps.onDeleteSession(sessionB)
+    })
+    await act(async () => {
+      deleteDialogProps.onConfirmDelete()
+    })
+
+    expect(sidebarProps.canDeleteConversations).toBe(false)
+    expect(deleteDialogProps.session).toBeUndefined()
+    expect(deleteDialogProps.canDelete).toBe(false)
+    expect(runtime.deleteRuntimeSession).not.toHaveBeenCalled()
+  })
+
+  it('disables an open delete dialog when Project deletion recovery becomes incomplete', async () => {
+    await renderPage(false, true)
+
+    const sessionB = useSessionStore.getState().sessions.find((session) => session.id === 'sess-b')!
+    await act(async () => {
+      sidebarProps.onDeleteSession(sessionB)
+    })
+    expect(deleteDialogProps.session?.id).toBe('sess-b')
+    expect(deleteDialogProps.canDelete).toBe(true)
+
+    await act(async () => {
+      root.render(
+        <WorkspacePage
+          isSessionPersistenceHydrated={true}
+          isSessionPersistenceReady={false}
+          canDeleteConversations={false}
+        />
+      )
+    })
+    expect(deleteDialogProps.session?.id).toBe('sess-b')
+    expect(deleteDialogProps.canDelete).toBe(false)
+
+    await act(async () => {
+      deleteDialogProps.onConfirmDelete()
+    })
+    expect(runtime.deleteRuntimeSession).not.toHaveBeenCalled()
   })
 
   it('records explicit user takeover before starting Session deletion', async () => {

--- a/src/renderer/src/pages/workspace/WorkspacePage.draft-preservation.test.tsx
+++ b/src/renderer/src/pages/workspace/WorkspacePage.draft-preservation.test.tsx
@@ -25,9 +25,11 @@ let conversationProps: {
   draftDoc: ComposerDoc
   attachments: UploadedAttachment[]
   attachmentTransfers: ComposerUploadTransfer[]
+  canResumeSession: boolean
   onDraftDocChange: (doc: ComposerDoc) => void
   onSendMessage: (forcedSkillIds: string[]) => void
   onStageAttachmentFiles: (files: File[]) => void
+  onResumeSession: () => Promise<void>
 }
 let sidebarProps: {
   canDeleteConversations: boolean
@@ -45,6 +47,7 @@ let deleteDialogProps: {
 const runtime = vi.hoisted(() => ({
   sendMessage: vi.fn(),
   cancelRun: vi.fn(),
+  resumeInterruptedSession: vi.fn(),
   deleteRuntimeSession: vi.fn(),
   respondToPermission: vi.fn()
 }))
@@ -62,6 +65,7 @@ vi.mock('@/lib/acp/useWorkspaceAgentRuntime', () => ({
     pendingPermissions: [],
     sendMessage: runtime.sendMessage,
     cancelRun: runtime.cancelRun,
+    resumeInterruptedSession: runtime.resumeInterruptedSession,
     deleteRuntimeSession: runtime.deleteRuntimeSession,
     respondToPermission: runtime.respondToPermission
   })
@@ -406,6 +410,38 @@ describe('WorkspacePage draft preservation', () => {
     expect(useSessionStore.getState().sessions).not.toContainEqual(
       expect.objectContaining({ id: 'sess-b' })
     )
+  })
+
+  it('blocks interrupted-session resume while Session persistence is recovering', async () => {
+    useSessionStore.setState((state) => ({
+      sessions: state.sessions.map((session) =>
+        session.id === 'sess-a' ? { ...session, interrupted: true } : session
+      )
+    }))
+
+    await renderPage(false)
+
+    expect(conversationProps.canResumeSession).toBe(false)
+    await act(async () => {
+      await conversationProps.onResumeSession()
+    })
+    expect(runtime.resumeInterruptedSession).not.toHaveBeenCalled()
+
+    await act(async () => {
+      root.render(
+        <WorkspacePage
+          isSessionPersistenceHydrated={true}
+          isSessionPersistenceReady={true}
+          canDeleteConversations={true}
+        />
+      )
+    })
+
+    expect(conversationProps.canResumeSession).toBe(true)
+    await act(async () => {
+      await conversationProps.onResumeSession()
+    })
+    expect(runtime.resumeInterruptedSession).toHaveBeenCalledWith('sess-a')
   })
 
   it('blocks session deletion when Project deletion recovery is incomplete', async () => {

--- a/src/renderer/src/pages/workspace/WorkspacePage.edit-message.test.tsx
+++ b/src/renderer/src/pages/workspace/WorkspacePage.edit-message.test.tsx
@@ -174,7 +174,9 @@ describe('WorkspacePage inline edit resend', () => {
   const renderPage = async (): Promise<void> => {
     root = createRoot(container)
     await act(async () => {
-      root.render(<WorkspacePage isSessionPersistenceReady={true} />)
+      root.render(
+        <WorkspacePage isSessionPersistenceHydrated={true} isSessionPersistenceReady={true} />
+      )
     })
   }
 

--- a/src/renderer/src/pages/workspace/WorkspacePage.edit-message.test.tsx
+++ b/src/renderer/src/pages/workspace/WorkspacePage.edit-message.test.tsx
@@ -175,7 +175,11 @@ describe('WorkspacePage inline edit resend', () => {
     root = createRoot(container)
     await act(async () => {
       root.render(
-        <WorkspacePage isSessionPersistenceHydrated={true} isSessionPersistenceReady={true} />
+        <WorkspacePage
+          isSessionPersistenceHydrated={true}
+          isSessionPersistenceReady={true}
+          canDeleteConversations={true}
+        />
       )
     })
   }

--- a/src/renderer/src/pages/workspace/WorkspacePage.image-staging.test.tsx
+++ b/src/renderer/src/pages/workspace/WorkspacePage.image-staging.test.tsx
@@ -197,7 +197,9 @@ describe('WorkspacePage image attachment gating', () => {
   const renderPage = async (): Promise<void> => {
     root = createRoot(container)
     await act(async () => {
-      root.render(<WorkspacePage isSessionPersistenceReady={true} />)
+      root.render(
+        <WorkspacePage isSessionPersistenceHydrated={true} isSessionPersistenceReady={true} />
+      )
     })
   }
 

--- a/src/renderer/src/pages/workspace/WorkspacePage.image-staging.test.tsx
+++ b/src/renderer/src/pages/workspace/WorkspacePage.image-staging.test.tsx
@@ -198,7 +198,11 @@ describe('WorkspacePage image attachment gating', () => {
     root = createRoot(container)
     await act(async () => {
       root.render(
-        <WorkspacePage isSessionPersistenceHydrated={true} isSessionPersistenceReady={true} />
+        <WorkspacePage
+          isSessionPersistenceHydrated={true}
+          isSessionPersistenceReady={true}
+          canDeleteConversations={true}
+        />
       )
     })
   }

--- a/src/renderer/src/pages/workspace/WorkspacePage.notebook-hydration.test.tsx
+++ b/src/renderer/src/pages/workspace/WorkspacePage.notebook-hydration.test.tsx
@@ -141,7 +141,11 @@ describe('WorkspacePage notebook entry hydration', () => {
     root = createRoot(container)
     await act(async () => {
       root.render(
-        <WorkspacePage isSessionPersistenceHydrated={true} isSessionPersistenceReady={true} />
+        <WorkspacePage
+          isSessionPersistenceHydrated={true}
+          isSessionPersistenceReady={true}
+          canDeleteConversations={true}
+        />
       )
     })
 

--- a/src/renderer/src/pages/workspace/WorkspacePage.notebook-hydration.test.tsx
+++ b/src/renderer/src/pages/workspace/WorkspacePage.notebook-hydration.test.tsx
@@ -140,7 +140,9 @@ describe('WorkspacePage notebook entry hydration', () => {
 
     root = createRoot(container)
     await act(async () => {
-      root.render(<WorkspacePage isSessionPersistenceReady={true} />)
+      root.render(
+        <WorkspacePage isSessionPersistenceHydrated={true} isSessionPersistenceReady={true} />
+      )
     })
 
     expect(getReference).toHaveBeenCalledWith({

--- a/src/renderer/src/pages/workspace/WorkspacePage.preview-panel-resize.test.tsx
+++ b/src/renderer/src/pages/workspace/WorkspacePage.preview-panel-resize.test.tsx
@@ -182,7 +182,9 @@ describe('WorkspacePage preview panel resize sync', () => {
   const renderPage = async (): Promise<void> => {
     root = createRoot(container)
     await act(async () => {
-      root.render(<WorkspacePage isSessionPersistenceReady={true} />)
+      root.render(
+        <WorkspacePage isSessionPersistenceHydrated={true} isSessionPersistenceReady={true} />
+      )
     })
   }
 

--- a/src/renderer/src/pages/workspace/WorkspacePage.preview-panel-resize.test.tsx
+++ b/src/renderer/src/pages/workspace/WorkspacePage.preview-panel-resize.test.tsx
@@ -183,7 +183,11 @@ describe('WorkspacePage preview panel resize sync', () => {
     root = createRoot(container)
     await act(async () => {
       root.render(
-        <WorkspacePage isSessionPersistenceHydrated={true} isSessionPersistenceReady={true} />
+        <WorkspacePage
+          isSessionPersistenceHydrated={true}
+          isSessionPersistenceReady={true}
+          canDeleteConversations={true}
+        />
       )
     })
   }

--- a/src/renderer/src/pages/workspace/WorkspacePage.send-gate.test.tsx
+++ b/src/renderer/src/pages/workspace/WorkspacePage.send-gate.test.tsx
@@ -156,7 +156,9 @@ describe('WorkspacePage send gate while compacting', () => {
   const renderPage = async (): Promise<void> => {
     root = createRoot(container)
     await act(async () => {
-      root.render(<WorkspacePage isSessionPersistenceReady={true} />)
+      root.render(
+        <WorkspacePage isSessionPersistenceHydrated={true} isSessionPersistenceReady={true} />
+      )
     })
   }
 
@@ -194,13 +196,17 @@ describe('WorkspacePage send gate while compacting', () => {
 
     runtime.promptInFlightSessionIds = ['sess-a']
     await act(async () => {
-      root.render(<WorkspacePage isSessionPersistenceReady={true} />)
+      root.render(
+        <WorkspacePage isSessionPersistenceHydrated={true} isSessionPersistenceReady={true} />
+      )
     })
     expect(conversationProps.canSendMessage).toBe(false)
 
     runtime.promptInFlightSessionIds = []
     await act(async () => {
-      root.render(<WorkspacePage isSessionPersistenceReady={true} />)
+      root.render(
+        <WorkspacePage isSessionPersistenceHydrated={true} isSessionPersistenceReady={true} />
+      )
     })
     expect(conversationProps.canSendMessage).toBe(true)
   })

--- a/src/renderer/src/pages/workspace/WorkspacePage.send-gate.test.tsx
+++ b/src/renderer/src/pages/workspace/WorkspacePage.send-gate.test.tsx
@@ -157,7 +157,11 @@ describe('WorkspacePage send gate while compacting', () => {
     root = createRoot(container)
     await act(async () => {
       root.render(
-        <WorkspacePage isSessionPersistenceHydrated={true} isSessionPersistenceReady={true} />
+        <WorkspacePage
+          isSessionPersistenceHydrated={true}
+          isSessionPersistenceReady={true}
+          canDeleteConversations={true}
+        />
       )
     })
   }
@@ -197,7 +201,11 @@ describe('WorkspacePage send gate while compacting', () => {
     runtime.promptInFlightSessionIds = ['sess-a']
     await act(async () => {
       root.render(
-        <WorkspacePage isSessionPersistenceHydrated={true} isSessionPersistenceReady={true} />
+        <WorkspacePage
+          isSessionPersistenceHydrated={true}
+          isSessionPersistenceReady={true}
+          canDeleteConversations={true}
+        />
       )
     })
     expect(conversationProps.canSendMessage).toBe(false)
@@ -205,7 +213,11 @@ describe('WorkspacePage send gate while compacting', () => {
     runtime.promptInFlightSessionIds = []
     await act(async () => {
       root.render(
-        <WorkspacePage isSessionPersistenceHydrated={true} isSessionPersistenceReady={true} />
+        <WorkspacePage
+          isSessionPersistenceHydrated={true}
+          isSessionPersistenceReady={true}
+          canDeleteConversations={true}
+        />
       )
     })
     expect(conversationProps.canSendMessage).toBe(true)

--- a/src/renderer/src/pages/workspace/WorkspacePage.tsx
+++ b/src/renderer/src/pages/workspace/WorkspacePage.tsx
@@ -1049,9 +1049,11 @@ const WorkspacePage = ({
     void cancelRun(sessionId)
   }
 
-  // Re-attaches the visible interrupted session so the user can keep chatting; awaited by the banner.
+  // Re-attaches the visible interrupted session only after durable Session writes are available;
+  // awaited by the banner so it can keep duplicate clicks disabled while reconnecting.
   const resumeActiveSession = async (): Promise<void> => {
-    if (activeSession) await resumeInterruptedSession(activeSession.id)
+    if (!isSessionPersistenceReady || !activeSession) return
+    await resumeInterruptedSession(activeSession.id)
   }
 
   // Forwards visible permission decisions to the runtime bridge.
@@ -1183,6 +1185,7 @@ const WorkspacePage = ({
             draftDoc={draftDoc}
             canSendMessage={canSendMessage}
             canEditDraft={canEditDraft}
+            canResumeSession={isSessionPersistenceReady}
             actionError={visibleActionError}
             isPreviewPanelCollapsed={previewPanelState === 'collapsed'}
             attachments={attachments}

--- a/src/renderer/src/pages/workspace/WorkspacePage.tsx
+++ b/src/renderer/src/pages/workspace/WorkspacePage.tsx
@@ -50,6 +50,7 @@ import { WorkspaceSidebar } from './WorkspaceSidebar'
 import { useJobAnalysisEffect } from '@/lib/compute/useJobAnalysisEffect'
 
 type WorkspacePageProps = {
+  isSessionPersistenceHydrated: boolean
   isSessionPersistenceReady: boolean
 }
 
@@ -84,7 +85,10 @@ const getUploadFilename = (file: File, index: number): string => {
 }
 
 // Renders the workspace shell and bridges the chat surface to the session store.
-const WorkspacePage = ({ isSessionPersistenceReady }: WorkspacePageProps): React.JSX.Element => {
+const WorkspacePage = ({
+  isSessionPersistenceHydrated,
+  isSessionPersistenceReady
+}: WorkspacePageProps): React.JSX.Element => {
   // The page owns the imperative panel handle because open requests come from outside PreviewPanel.
   const previewPanelRef = useRef<PanelImperativeHandle | null>(null)
   const previewPanelAnimationRef = useRef<{ stop: () => void } | null>(null)
@@ -962,16 +966,17 @@ const WorkspacePage = ({ isSessionPersistenceReady }: WorkspacePageProps): React
     closeRenameDialog()
   }
 
-  // Opens destructive Session actions only after startup has restored complete durable authority.
+  // Explicit deletion is target-validated and fail-closed in main, so unrelated recovery warnings
+  // need not block cleanup of a readable Session after hydration has identified its durable key.
   const openDeleteDialog = (session: ChatSession): void => {
-    if (!isSessionPersistenceReady) return
+    if (!isSessionPersistenceHydrated) return
 
     setSessionToDelete(session)
   }
 
   // Deletes the selected session and repairs the chat surface if it was showing that session.
   const confirmDeleteSession = (): void => {
-    if (!isSessionPersistenceReady || !sessionToDelete) return
+    if (!isSessionPersistenceHydrated || !sessionToDelete) return
 
     const deletedSessionId = sessionToDelete.id
     const isActiveSession = deletedSessionId === selectedSessionId
@@ -1148,6 +1153,7 @@ const WorkspacePage = ({ isSessionPersistenceReady }: WorkspacePageProps): React
           activeSessionId={selectedSessionId}
           canCreateConversation={isSessionPersistenceReady}
           canMutateConversations={isSessionPersistenceReady}
+          canDeleteConversations={isSessionPersistenceHydrated}
           onGoHome={goHome}
           onNewConversation={openNewConversation}
           isFilesOpen={activePreviewItemId === PROJECT_FILES_PREVIEW_ID}

--- a/src/renderer/src/pages/workspace/WorkspacePage.tsx
+++ b/src/renderer/src/pages/workspace/WorkspacePage.tsx
@@ -118,7 +118,6 @@ const WorkspacePage = ({
   // Session data lives in zustand while draft/new-conversation state stays local to the chat surface.
   const allSessions = useSessionStore((state) => state.sessions)
   const selectedSessionId = useSessionStore((state) => state.selectedSessionId)
-  const selectSession = useSessionStore((state) => state.selectSession)
   const clearSelection = useSessionStore((state) => state.clearSelection)
   const renameSession = useSessionStore((state) => state.renameSession)
   const togglePinned = useSessionStore((state) => state.togglePinned)
@@ -446,7 +445,7 @@ const WorkspacePage = ({
 
   // The workspace requires an active project; if none is set (e.g. after a project delete), go home.
   useEffect(() => {
-    if (!activeProjectId) goHome()
+    if (!activeProjectId) goHome('automatic')
   }, [activeProjectId, goHome])
 
   // Switches the preview panel to the active project's own tabs (never another project's stale
@@ -702,6 +701,7 @@ const WorkspacePage = ({
     setNewConversationPermissionProfile(DEFAULT_PERMISSION_PROFILE)
     setNewConversationAutoReviewEnabled(false)
     setNewConversationEnabledComputeHosts([])
+    useNavigationStore.getState().recordUserNavigation()
     clearSelection()
   }
 
@@ -709,7 +709,7 @@ const WorkspacePage = ({
   const openSession = (sessionId: string): void => {
     // The draft effect saves the outgoing doc/attachments and restores the target session's state.
     setAttachmentError(null)
-    selectSession(sessionId)
+    useNavigationStore.getState().openSession(scopedProjectId, sessionId, 'user')
   }
 
   // Converts selected or pasted files into app-managed uploads before they appear in the composer.
@@ -1154,7 +1154,7 @@ const WorkspacePage = ({
           canCreateConversation={isSessionPersistenceReady}
           canMutateConversations={isSessionPersistenceReady}
           canDeleteConversations={isSessionPersistenceHydrated}
-          onGoHome={goHome}
+          onGoHome={() => goHome('user')}
           onNewConversation={openNewConversation}
           isFilesOpen={activePreviewItemId === PROJECT_FILES_PREVIEW_ID}
           onOpenFiles={openFilesPreview}

--- a/src/renderer/src/pages/workspace/WorkspacePage.tsx
+++ b/src/renderer/src/pages/workspace/WorkspacePage.tsx
@@ -962,9 +962,16 @@ const WorkspacePage = ({ isSessionPersistenceReady }: WorkspacePageProps): React
     closeRenameDialog()
   }
 
+  // Opens destructive Session actions only after startup has restored complete durable authority.
+  const openDeleteDialog = (session: ChatSession): void => {
+    if (!isSessionPersistenceReady) return
+
+    setSessionToDelete(session)
+  }
+
   // Deletes the selected session and repairs the chat surface if it was showing that session.
   const confirmDeleteSession = (): void => {
-    if (!sessionToDelete) return
+    if (!isSessionPersistenceReady || !sessionToDelete) return
 
     const deletedSessionId = sessionToDelete.id
     const isActiveSession = deletedSessionId === selectedSessionId
@@ -1140,7 +1147,7 @@ const WorkspacePage = ({ isSessionPersistenceReady }: WorkspacePageProps): React
           sessions={sessions}
           activeSessionId={selectedSessionId}
           canCreateConversation={isSessionPersistenceReady}
-          canModifyConversationMetadata={isSessionPersistenceReady}
+          canMutateConversations={isSessionPersistenceReady}
           onGoHome={goHome}
           onNewConversation={openNewConversation}
           isFilesOpen={activePreviewItemId === PROJECT_FILES_PREVIEW_ID}
@@ -1151,7 +1158,7 @@ const WorkspacePage = ({ isSessionPersistenceReady }: WorkspacePageProps): React
           onTogglePin={(session) => {
             if (isSessionPersistenceReady) togglePinned(session.id)
           }}
-          onDeleteSession={setSessionToDelete}
+          onDeleteSession={openDeleteDialog}
           onOpenSettings={openSettings}
         />
 

--- a/src/renderer/src/pages/workspace/WorkspacePage.tsx
+++ b/src/renderer/src/pages/workspace/WorkspacePage.tsx
@@ -978,6 +978,9 @@ const WorkspacePage = ({
   const confirmDeleteSession = (): void => {
     if (!isSessionPersistenceHydrated || !sessionToDelete) return
 
+    // Cancel deferred notification/deep-link navigation before the asynchronous authoritative
+    // deletion begins. The user's destructive action owns the view even if the target is unrelated.
+    useNavigationStore.getState().recordUserNavigation()
     const deletedSessionId = sessionToDelete.id
     const isActiveSession = deletedSessionId === selectedSessionId
     if (sessionDeletionCleanupRef.current[deletedSessionId]) {

--- a/src/renderer/src/pages/workspace/WorkspacePage.tsx
+++ b/src/renderer/src/pages/workspace/WorkspacePage.tsx
@@ -165,7 +165,7 @@ const WorkspacePage = ({
   } = useWorkspaceAgentRuntime()
 
   // Auto-trigger an analysis turn when a remote job finishes (design §11).
-  useJobAnalysisEffect({ sendMessage })
+  useJobAnalysisEffect({ enabled: isSessionPersistenceReady, sendMessage })
   const [draftDoc, setDraftDoc] = useState<ComposerDoc>(emptyDoc)
   const [newConversationPermissionProfile, setNewConversationPermissionProfile] =
     useState<PermissionProfileId>(DEFAULT_PERMISSION_PROFILE)

--- a/src/renderer/src/pages/workspace/WorkspacePage.tsx
+++ b/src/renderer/src/pages/workspace/WorkspacePage.tsx
@@ -940,6 +940,8 @@ const WorkspacePage = ({ isSessionPersistenceReady }: WorkspacePageProps): React
 
   // Opens the rename dialog with the current title prefilled.
   const openRenameDialog = (session: ChatSession): void => {
+    if (!isSessionPersistenceReady) return
+
     setSessionToRename(session)
     setRenameDraft(session.title)
   }
@@ -954,7 +956,7 @@ const WorkspacePage = ({ isSessionPersistenceReady }: WorkspacePageProps): React
   const confirmRenameSession = (event: React.FormEvent<HTMLFormElement>): void => {
     event.preventDefault()
 
-    if (!sessionToRename || renameDraft.trim().length === 0) return
+    if (!isSessionPersistenceReady || !sessionToRename || renameDraft.trim().length === 0) return
 
     renameSession(sessionToRename.id, renameDraft)
     closeRenameDialog()
@@ -1138,6 +1140,7 @@ const WorkspacePage = ({ isSessionPersistenceReady }: WorkspacePageProps): React
           sessions={sessions}
           activeSessionId={selectedSessionId}
           canCreateConversation={isSessionPersistenceReady}
+          canModifyConversationMetadata={isSessionPersistenceReady}
           onGoHome={goHome}
           onNewConversation={openNewConversation}
           isFilesOpen={activePreviewItemId === PROJECT_FILES_PREVIEW_ID}
@@ -1145,7 +1148,9 @@ const WorkspacePage = ({ isSessionPersistenceReady }: WorkspacePageProps): React
           onOpenSession={openSession}
           onRenameSession={openRenameDialog}
           onViewNotebook={setSessionToViewNotebook}
-          onTogglePin={(session) => togglePinned(session.id)}
+          onTogglePin={(session) => {
+            if (isSessionPersistenceReady) togglePinned(session.id)
+          }}
           onDeleteSession={setSessionToDelete}
           onOpenSettings={openSettings}
         />

--- a/src/renderer/src/pages/workspace/WorkspacePage.tsx
+++ b/src/renderer/src/pages/workspace/WorkspacePage.tsx
@@ -52,6 +52,7 @@ import { useJobAnalysisEffect } from '@/lib/compute/useJobAnalysisEffect'
 type WorkspacePageProps = {
   isSessionPersistenceHydrated: boolean
   isSessionPersistenceReady: boolean
+  canDeleteConversations: boolean
 }
 
 // Converts unknown async failures into composer-visible text.
@@ -87,7 +88,8 @@ const getUploadFilename = (file: File, index: number): string => {
 // Renders the workspace shell and bridges the chat surface to the session store.
 const WorkspacePage = ({
   isSessionPersistenceHydrated,
-  isSessionPersistenceReady
+  isSessionPersistenceReady,
+  canDeleteConversations
 }: WorkspacePageProps): React.JSX.Element => {
   // The page owns the imperative panel handle because open requests come from outside PreviewPanel.
   const previewPanelRef = useRef<PanelImperativeHandle | null>(null)
@@ -966,17 +968,17 @@ const WorkspacePage = ({
     closeRenameDialog()
   }
 
-  // Explicit deletion is target-validated and fail-closed in main, so unrelated recovery warnings
-  // need not block cleanup of a readable Session after hydration has identified its durable key.
+  // Explicit deletion is target-validated and may remain available after a partial Session scan, but
+  // main requires Project deletion-journal recovery before either deletion IPC can safely run.
   const openDeleteDialog = (session: ChatSession): void => {
-    if (!isSessionPersistenceHydrated) return
+    if (!isSessionPersistenceHydrated || !canDeleteConversations) return
 
     setSessionToDelete(session)
   }
 
   // Deletes the selected session and repairs the chat surface if it was showing that session.
   const confirmDeleteSession = (): void => {
-    if (!isSessionPersistenceHydrated || !sessionToDelete) return
+    if (!isSessionPersistenceHydrated || !canDeleteConversations || !sessionToDelete) return
 
     // Cancel deferred notification/deep-link navigation before the asynchronous authoritative
     // deletion begins. The user's destructive action owns the view even if the target is unrelated.
@@ -1156,7 +1158,7 @@ const WorkspacePage = ({
           activeSessionId={selectedSessionId}
           canCreateConversation={isSessionPersistenceReady}
           canMutateConversations={isSessionPersistenceReady}
-          canDeleteConversations={isSessionPersistenceHydrated}
+          canDeleteConversations={canDeleteConversations}
           onGoHome={() => goHome('user')}
           onNewConversation={openNewConversation}
           isFilesOpen={activePreviewItemId === PROJECT_FILES_PREVIEW_ID}
@@ -1252,6 +1254,7 @@ const WorkspacePage = ({
 
       <DeleteSessionDialog
         session={sessionToDelete}
+        canDelete={canDeleteConversations}
         onCancel={closeDeleteDialog}
         onConfirmDelete={confirmDeleteSession}
       />

--- a/src/renderer/src/pages/workspace/WorkspaceSidebar.render.test.tsx
+++ b/src/renderer/src/pages/workspace/WorkspaceSidebar.render.test.tsx
@@ -28,6 +28,7 @@ const renderSidebar = async (sessions: ChatSession[]): Promise<string> => {
       sessions={sessions}
       activeSessionId={sessions[0]?.id}
       canCreateConversation
+      canModifyConversationMetadata
       onGoHome={vi.fn()}
       onNewConversation={vi.fn()}
       isFilesOpen={false}
@@ -109,6 +110,7 @@ describe('WorkspaceSidebar accessible render', () => {
       sessions,
       activeSessionId: sessions[0].id,
       canCreateConversation: true,
+      canModifyConversationMetadata: true,
       onGoHome: vi.fn(),
       onNewConversation: vi.fn(),
       isFilesOpen: false,
@@ -151,6 +153,7 @@ describe('WorkspaceSidebar accessible render', () => {
       sessions: [createSession({ id: 'session-a', title: 'Notebook review' })],
       activeSessionId: 'session-a',
       canCreateConversation: true,
+      canModifyConversationMetadata: true,
       onGoHome: vi.fn(),
       onNewConversation: vi.fn(),
       isFilesOpen: true,
@@ -188,6 +191,7 @@ describe('WorkspaceSidebar accessible render', () => {
       sessions,
       activeSessionId: sessions[0].id,
       canCreateConversation: true,
+      canModifyConversationMetadata: true,
       onGoHome: vi.fn(),
       onNewConversation: vi.fn(),
       isFilesOpen: false,
@@ -234,6 +238,7 @@ describe('WorkspaceSidebar accessible render', () => {
       sessions,
       activeSessionId: sessions[0].id,
       canCreateConversation: true,
+      canModifyConversationMetadata: true,
       onGoHome: vi.fn(),
       onNewConversation: vi.fn(),
       isFilesOpen: false,
@@ -258,5 +263,33 @@ describe('WorkspaceSidebar accessible render', () => {
     expect(unpinItem?.props.onSelect).toBeTypeOf('function')
     ;(unpinItem?.props.onSelect as () => void)()
     expect(onTogglePin).toHaveBeenCalledWith(sessions[1])
+  })
+
+  it('disables metadata mutations while session persistence is recovering', async () => {
+    const { WorkspaceSidebar } = await import('./WorkspaceSidebar')
+    const session = createSession({ id: 'session-a', title: 'Notebook review' })
+    const tree = WorkspaceSidebar({
+      projectName: 'Example project',
+      sessions: [session],
+      activeSessionId: session.id,
+      canCreateConversation: false,
+      canModifyConversationMetadata: false,
+      onGoHome: vi.fn(),
+      onNewConversation: vi.fn(),
+      isFilesOpen: false,
+      onOpenFiles: vi.fn(),
+      onOpenSession: vi.fn(),
+      onRenameSession: vi.fn(),
+      onViewNotebook: vi.fn(),
+      onTogglePin: vi.fn(),
+      onDeleteSession: vi.fn(),
+      onOpenSettings: vi.fn()
+    })
+    const elements = collectElements(tree)
+    const pinItem = elements.find((element) => getTextContent(element).trim() === 'Pin')
+    const renameItem = elements.find((element) => getTextContent(element).trim() === 'Rename…')
+
+    expect(pinItem?.props.disabled).toBe(true)
+    expect(renameItem?.props.disabled).toBe(true)
   })
 })

--- a/src/renderer/src/pages/workspace/WorkspaceSidebar.render.test.tsx
+++ b/src/renderer/src/pages/workspace/WorkspaceSidebar.render.test.tsx
@@ -28,7 +28,7 @@ const renderSidebar = async (sessions: ChatSession[]): Promise<string> => {
       sessions={sessions}
       activeSessionId={sessions[0]?.id}
       canCreateConversation
-      canModifyConversationMetadata
+      canMutateConversations
       onGoHome={vi.fn()}
       onNewConversation={vi.fn()}
       isFilesOpen={false}
@@ -110,7 +110,7 @@ describe('WorkspaceSidebar accessible render', () => {
       sessions,
       activeSessionId: sessions[0].id,
       canCreateConversation: true,
-      canModifyConversationMetadata: true,
+      canMutateConversations: true,
       onGoHome: vi.fn(),
       onNewConversation: vi.fn(),
       isFilesOpen: false,
@@ -153,7 +153,7 @@ describe('WorkspaceSidebar accessible render', () => {
       sessions: [createSession({ id: 'session-a', title: 'Notebook review' })],
       activeSessionId: 'session-a',
       canCreateConversation: true,
-      canModifyConversationMetadata: true,
+      canMutateConversations: true,
       onGoHome: vi.fn(),
       onNewConversation: vi.fn(),
       isFilesOpen: true,
@@ -191,7 +191,7 @@ describe('WorkspaceSidebar accessible render', () => {
       sessions,
       activeSessionId: sessions[0].id,
       canCreateConversation: true,
-      canModifyConversationMetadata: true,
+      canMutateConversations: true,
       onGoHome: vi.fn(),
       onNewConversation: vi.fn(),
       isFilesOpen: false,
@@ -238,7 +238,7 @@ describe('WorkspaceSidebar accessible render', () => {
       sessions,
       activeSessionId: sessions[0].id,
       canCreateConversation: true,
-      canModifyConversationMetadata: true,
+      canMutateConversations: true,
       onGoHome: vi.fn(),
       onNewConversation: vi.fn(),
       isFilesOpen: false,
@@ -265,7 +265,7 @@ describe('WorkspaceSidebar accessible render', () => {
     expect(onTogglePin).toHaveBeenCalledWith(sessions[1])
   })
 
-  it('disables metadata mutations while session persistence is recovering', async () => {
+  it('disables durable session mutations while session persistence is recovering', async () => {
     const { WorkspaceSidebar } = await import('./WorkspaceSidebar')
     const session = createSession({ id: 'session-a', title: 'Notebook review' })
     const tree = WorkspaceSidebar({
@@ -273,7 +273,7 @@ describe('WorkspaceSidebar accessible render', () => {
       sessions: [session],
       activeSessionId: session.id,
       canCreateConversation: false,
-      canModifyConversationMetadata: false,
+      canMutateConversations: false,
       onGoHome: vi.fn(),
       onNewConversation: vi.fn(),
       isFilesOpen: false,
@@ -288,8 +288,10 @@ describe('WorkspaceSidebar accessible render', () => {
     const elements = collectElements(tree)
     const pinItem = elements.find((element) => getTextContent(element).trim() === 'Pin')
     const renameItem = elements.find((element) => getTextContent(element).trim() === 'Rename…')
+    const deleteItem = elements.find((element) => getTextContent(element).trim() === 'Delete')
 
     expect(pinItem?.props.disabled).toBe(true)
     expect(renameItem?.props.disabled).toBe(true)
+    expect(deleteItem?.props.disabled).toBe(true)
   })
 })

--- a/src/renderer/src/pages/workspace/WorkspaceSidebar.render.test.tsx
+++ b/src/renderer/src/pages/workspace/WorkspaceSidebar.render.test.tsx
@@ -29,6 +29,7 @@ const renderSidebar = async (sessions: ChatSession[]): Promise<string> => {
       activeSessionId={sessions[0]?.id}
       canCreateConversation
       canMutateConversations
+      canDeleteConversations
       onGoHome={vi.fn()}
       onNewConversation={vi.fn()}
       isFilesOpen={false}
@@ -111,6 +112,7 @@ describe('WorkspaceSidebar accessible render', () => {
       activeSessionId: sessions[0].id,
       canCreateConversation: true,
       canMutateConversations: true,
+      canDeleteConversations: true,
       onGoHome: vi.fn(),
       onNewConversation: vi.fn(),
       isFilesOpen: false,
@@ -154,6 +156,7 @@ describe('WorkspaceSidebar accessible render', () => {
       activeSessionId: 'session-a',
       canCreateConversation: true,
       canMutateConversations: true,
+      canDeleteConversations: true,
       onGoHome: vi.fn(),
       onNewConversation: vi.fn(),
       isFilesOpen: true,
@@ -192,6 +195,7 @@ describe('WorkspaceSidebar accessible render', () => {
       activeSessionId: sessions[0].id,
       canCreateConversation: true,
       canMutateConversations: true,
+      canDeleteConversations: true,
       onGoHome: vi.fn(),
       onNewConversation: vi.fn(),
       isFilesOpen: false,
@@ -239,6 +243,7 @@ describe('WorkspaceSidebar accessible render', () => {
       activeSessionId: sessions[0].id,
       canCreateConversation: true,
       canMutateConversations: true,
+      canDeleteConversations: true,
       onGoHome: vi.fn(),
       onNewConversation: vi.fn(),
       isFilesOpen: false,
@@ -265,7 +270,7 @@ describe('WorkspaceSidebar accessible render', () => {
     expect(onTogglePin).toHaveBeenCalledWith(sessions[1])
   })
 
-  it('disables durable session mutations while session persistence is recovering', async () => {
+  it('keeps target-validated deletion available while other mutations are recovering', async () => {
     const { WorkspaceSidebar } = await import('./WorkspaceSidebar')
     const session = createSession({ id: 'session-a', title: 'Notebook review' })
     const tree = WorkspaceSidebar({
@@ -274,6 +279,7 @@ describe('WorkspaceSidebar accessible render', () => {
       activeSessionId: session.id,
       canCreateConversation: false,
       canMutateConversations: false,
+      canDeleteConversations: true,
       onGoHome: vi.fn(),
       onNewConversation: vi.fn(),
       isFilesOpen: false,
@@ -292,6 +298,6 @@ describe('WorkspaceSidebar accessible render', () => {
 
     expect(pinItem?.props.disabled).toBe(true)
     expect(renameItem?.props.disabled).toBe(true)
-    expect(deleteItem?.props.disabled).toBe(true)
+    expect(deleteItem?.props.disabled).toBe(false)
   })
 })

--- a/src/renderer/src/pages/workspace/WorkspaceSidebar.tsx
+++ b/src/renderer/src/pages/workspace/WorkspaceSidebar.tsx
@@ -28,6 +28,7 @@ type WorkspaceSidebarProps = {
   activeSessionId: string | undefined
   canCreateConversation: boolean
   canMutateConversations: boolean
+  canDeleteConversations: boolean
   onGoHome: () => void
   onNewConversation: () => void
   isFilesOpen: boolean
@@ -75,6 +76,7 @@ const WorkspaceSidebar = ({
   activeSessionId,
   canCreateConversation,
   canMutateConversations,
+  canDeleteConversations,
   onGoHome,
   onNewConversation,
   isFilesOpen,
@@ -264,7 +266,7 @@ const WorkspaceSidebar = ({
                             {/* Delete uses the project's danger token pair for light surfaces. */}
                             <DropdownMenuItem
                               className="gap-2 text-danger-000 data-[highlighted]:bg-danger-900 data-[highlighted]:text-danger-000"
-                              disabled={!canMutateConversations}
+                              disabled={!canDeleteConversations}
                               onSelect={() => onDeleteSession(session)}
                             >
                               <span className={sessionMenuIconClassName}>

--- a/src/renderer/src/pages/workspace/WorkspaceSidebar.tsx
+++ b/src/renderer/src/pages/workspace/WorkspaceSidebar.tsx
@@ -27,6 +27,7 @@ type WorkspaceSidebarProps = {
   sessions: ChatSession[]
   activeSessionId: string | undefined
   canCreateConversation: boolean
+  canModifyConversationMetadata: boolean
   onGoHome: () => void
   onNewConversation: () => void
   isFilesOpen: boolean
@@ -73,6 +74,7 @@ const WorkspaceSidebar = ({
   sessions,
   activeSessionId,
   canCreateConversation,
+  canModifyConversationMetadata,
   onGoHome,
   onNewConversation,
   isFilesOpen,
@@ -228,6 +230,7 @@ const WorkspaceSidebar = ({
                             {/* Pin / Unpin toggles the conversation into or out of the pinned section. */}
                             <DropdownMenuItem
                               className="gap-2"
+                              disabled={!canModifyConversationMetadata}
                               onSelect={() => onTogglePin(session)}
                             >
                               <span className={sessionMenuIconClassName}>
@@ -241,6 +244,7 @@ const WorkspaceSidebar = ({
                             </DropdownMenuItem>
                             <DropdownMenuItem
                               className="gap-2"
+                              disabled={!canModifyConversationMetadata}
                               onSelect={() => onRenameSession(session)}
                             >
                               <span className={sessionMenuIconClassName}>

--- a/src/renderer/src/pages/workspace/WorkspaceSidebar.tsx
+++ b/src/renderer/src/pages/workspace/WorkspaceSidebar.tsx
@@ -27,7 +27,7 @@ type WorkspaceSidebarProps = {
   sessions: ChatSession[]
   activeSessionId: string | undefined
   canCreateConversation: boolean
-  canModifyConversationMetadata: boolean
+  canMutateConversations: boolean
   onGoHome: () => void
   onNewConversation: () => void
   isFilesOpen: boolean
@@ -74,7 +74,7 @@ const WorkspaceSidebar = ({
   sessions,
   activeSessionId,
   canCreateConversation,
-  canModifyConversationMetadata,
+  canMutateConversations,
   onGoHome,
   onNewConversation,
   isFilesOpen,
@@ -230,7 +230,7 @@ const WorkspaceSidebar = ({
                             {/* Pin / Unpin toggles the conversation into or out of the pinned section. */}
                             <DropdownMenuItem
                               className="gap-2"
-                              disabled={!canModifyConversationMetadata}
+                              disabled={!canMutateConversations}
                               onSelect={() => onTogglePin(session)}
                             >
                               <span className={sessionMenuIconClassName}>
@@ -244,7 +244,7 @@ const WorkspaceSidebar = ({
                             </DropdownMenuItem>
                             <DropdownMenuItem
                               className="gap-2"
-                              disabled={!canModifyConversationMetadata}
+                              disabled={!canMutateConversations}
                               onSelect={() => onRenameSession(session)}
                             >
                               <span className={sessionMenuIconClassName}>
@@ -264,6 +264,7 @@ const WorkspaceSidebar = ({
                             {/* Delete uses the project's danger token pair for light surfaces. */}
                             <DropdownMenuItem
                               className="gap-2 text-danger-000 data-[highlighted]:bg-danger-900 data-[highlighted]:text-danger-000"
+                              disabled={!canMutateConversations}
                               onSelect={() => onDeleteSession(session)}
                             >
                               <span className={sessionMenuIconClassName}>

--- a/src/renderer/src/pages/workspace/session-dialogs.render.test.tsx
+++ b/src/renderer/src/pages/workspace/session-dialogs.render.test.tsx
@@ -155,6 +155,7 @@ describe('workspace session dialogs behavior wiring', () => {
     const onConfirmDelete = vi.fn()
     const tree = DeleteSessionDialog({
       session: createSession({ title: 'Dataset cleanup' }),
+      canDelete: true,
       onCancel,
       onConfirmDelete
     })
@@ -179,6 +180,7 @@ describe('workspace session dialogs behavior wiring', () => {
     const onCancel = vi.fn()
     const tree = DeleteSessionDialog({
       session: createSession({ title: 'Dataset cleanup' }),
+      canDelete: true,
       onCancel,
       onConfirmDelete: vi.fn()
     })
@@ -186,5 +188,20 @@ describe('workspace session dialogs behavior wiring', () => {
     expectSettingsDialogChrome(tree, 'w-[min(420px,calc(100vw-2rem))]', onCancel, {
       interceptsOutsideClick: false
     })
+  })
+
+  it('disables Session deletion when persistence deletion recovery is unavailable', async () => {
+    const { DeleteSessionDialog } = await import('./DeleteSessionDialog')
+    const tree = DeleteSessionDialog({
+      session: createSession({ title: 'Protected session' }),
+      canDelete: false,
+      onCancel: vi.fn(),
+      onConfirmDelete: vi.fn()
+    })
+    const deleteButton = collectElements(tree).find(
+      (element) => getTextContent(element).trim() === 'Delete' && element.props.onClick
+    )
+
+    expect(deleteButton?.props.disabled).toBe(true)
   })
 })

--- a/src/renderer/src/pages/workspace/workspace-components.test.tsx
+++ b/src/renderer/src/pages/workspace/workspace-components.test.tsx
@@ -58,13 +58,11 @@ describe('workspace page component boundaries', () => {
     expect(workspacePageSource).toContain('isSessionPersistenceReady')
     expect(workspacePageSource).toContain('isSessionPersistenceReady &&')
     expect(workspacePageSource).toContain('canCreateConversation={isSessionPersistenceReady}')
-    expect(workspacePageSource).toContain(
-      'canModifyConversationMetadata={isSessionPersistenceReady}'
-    )
+    expect(workspacePageSource).toContain('canMutateConversations={isSessionPersistenceReady}')
     expect(workspacePageSource).toContain('canEditDraft={canEditDraft}')
     expect(workspacePageSource).toContain('if (!isSessionPersistenceReady) return')
     expect(workspaceSidebarSource).toContain('disabled={!canCreateConversation}')
-    expect(workspaceSidebarSource).toContain('disabled={!canModifyConversationMetadata}')
+    expect(workspaceSidebarSource).toContain('disabled={!canMutateConversations}')
     expect(conversationPanelSource).toContain('disabled={!canEditDraft}')
   })
 

--- a/src/renderer/src/pages/workspace/workspace-components.test.tsx
+++ b/src/renderer/src/pages/workspace/workspace-components.test.tsx
@@ -51,15 +51,20 @@ describe('workspace page component boundaries', () => {
     expect(appSource).toContain(
       "import { useSessionPersistence } from '@/lib/session-persistence/session-persistence'"
     )
-    expect(appSource).toContain('const isSessionPersistenceReady = useSessionPersistence()')
+    expect(appSource).toContain('const sessionPersistence = useSessionPersistence()')
+    expect(appSource).toContain('const isSessionPersistenceReady = sessionPersistence.isReady')
     expect(appSource).toContain('isSessionPersistenceReady={isSessionPersistenceReady}')
 
     expect(workspacePageSource).toContain('isSessionPersistenceReady')
     expect(workspacePageSource).toContain('isSessionPersistenceReady &&')
     expect(workspacePageSource).toContain('canCreateConversation={isSessionPersistenceReady}')
+    expect(workspacePageSource).toContain(
+      'canModifyConversationMetadata={isSessionPersistenceReady}'
+    )
     expect(workspacePageSource).toContain('canEditDraft={canEditDraft}')
     expect(workspacePageSource).toContain('if (!isSessionPersistenceReady) return')
     expect(workspaceSidebarSource).toContain('disabled={!canCreateConversation}')
+    expect(workspaceSidebarSource).toContain('disabled={!canModifyConversationMetadata}')
     expect(conversationPanelSource).toContain('disabled={!canEditDraft}')
   })
 

--- a/src/renderer/src/stores/navigation-store.test.ts
+++ b/src/renderer/src/stores/navigation-store.test.ts
@@ -24,7 +24,8 @@ beforeEach(() => {
   useNavigationStore.setState({
     view: 'home',
     activeProjectId: undefined,
-    userNavigationRevision: 0
+    userNavigationRevision: 0,
+    explicitNavigationRevision: 0
   })
 })
 
@@ -87,7 +88,7 @@ describe('navigation store', () => {
         version: SESSION_MANIFEST_VERSION
       })
 
-    useNavigationStore.getState().openSessionById('a', 'automatic')
+    useNavigationStore.getState().openSessionById('a', 'notification')
 
     expect(useNavigationStore.getState().view).toBe('workspace')
     expect(useNavigationStore.getState().activeProjectId).toBe('project-a')
@@ -95,7 +96,7 @@ describe('navigation store', () => {
   })
 
   it('stays put when a notification names a session that no longer exists', () => {
-    useNavigationStore.getState().openSessionById('gone', 'automatic')
+    useNavigationStore.getState().openSessionById('gone', 'notification')
 
     expect(useNavigationStore.getState().view).toBe('home')
     expect(useNavigationStore.getState().activeProjectId).toBeUndefined()
@@ -112,11 +113,18 @@ describe('navigation store', () => {
   it('advances user navigation revision only for explicit user actions', () => {
     useNavigationStore.getState().goHome('automatic')
     expect(useNavigationStore.getState().userNavigationRevision).toBe(0)
+    expect(useNavigationStore.getState().explicitNavigationRevision).toBe(0)
+
+    useNavigationStore.getState().goHome('notification')
+    expect(useNavigationStore.getState().userNavigationRevision).toBe(0)
+    expect(useNavigationStore.getState().explicitNavigationRevision).toBe(1)
 
     useNavigationStore.getState().goHome('user')
     expect(useNavigationStore.getState().userNavigationRevision).toBe(1)
+    expect(useNavigationStore.getState().explicitNavigationRevision).toBe(2)
 
     useNavigationStore.getState().recordUserNavigation()
     expect(useNavigationStore.getState().userNavigationRevision).toBe(2)
+    expect(useNavigationStore.getState().explicitNavigationRevision).toBe(3)
   })
 })

--- a/src/renderer/src/stores/navigation-store.test.ts
+++ b/src/renderer/src/stores/navigation-store.test.ts
@@ -21,7 +21,11 @@ const createSession = (overrides: Partial<PersistedChatSession>): PersistedChatS
 
 beforeEach(() => {
   useSessionStore.setState(createInitialSessionState())
-  useNavigationStore.setState({ view: 'home', activeProjectId: undefined })
+  useNavigationStore.setState({
+    view: 'home',
+    activeProjectId: undefined,
+    userNavigationRevision: 0
+  })
 })
 
 describe('navigation store', () => {
@@ -37,7 +41,7 @@ describe('navigation store', () => {
         { version: SESSION_MANIFEST_VERSION }
       )
 
-    useNavigationStore.getState().openProject('project-a')
+    useNavigationStore.getState().openProject('project-a', 'user')
 
     expect(useNavigationStore.getState().view).toBe('workspace')
     expect(useNavigationStore.getState().activeProjectId).toBe('project-a')
@@ -52,7 +56,7 @@ describe('navigation store', () => {
         version: SESSION_MANIFEST_VERSION
       })
 
-    useNavigationStore.getState().openProject('project-empty')
+    useNavigationStore.getState().openProject('project-empty', 'user')
 
     expect(useNavigationStore.getState().activeProjectId).toBe('project-empty')
     expect(useSessionStore.getState().selectedSessionId).toBeUndefined()
@@ -69,7 +73,7 @@ describe('navigation store', () => {
         { version: SESSION_MANIFEST_VERSION }
       )
 
-    useNavigationStore.getState().openSession('project-b', 'b')
+    useNavigationStore.getState().openSession('project-b', 'b', 'user')
 
     expect(useNavigationStore.getState().view).toBe('workspace')
     expect(useNavigationStore.getState().activeProjectId).toBe('project-b')
@@ -83,7 +87,7 @@ describe('navigation store', () => {
         version: SESSION_MANIFEST_VERSION
       })
 
-    useNavigationStore.getState().openSessionById('a')
+    useNavigationStore.getState().openSessionById('a', 'automatic')
 
     expect(useNavigationStore.getState().view).toBe('workspace')
     expect(useNavigationStore.getState().activeProjectId).toBe('project-a')
@@ -91,7 +95,7 @@ describe('navigation store', () => {
   })
 
   it('stays put when a notification names a session that no longer exists', () => {
-    useNavigationStore.getState().openSessionById('gone')
+    useNavigationStore.getState().openSessionById('gone', 'automatic')
 
     expect(useNavigationStore.getState().view).toBe('home')
     expect(useNavigationStore.getState().activeProjectId).toBeUndefined()
@@ -99,9 +103,20 @@ describe('navigation store', () => {
   })
 
   it('returns to the home screen without losing session state', () => {
-    useNavigationStore.getState().openSession('project-a', 'session-1')
-    useNavigationStore.getState().goHome()
+    useNavigationStore.getState().openSession('project-a', 'session-1', 'user')
+    useNavigationStore.getState().goHome('user')
 
     expect(useNavigationStore.getState().view).toBe('home')
+  })
+
+  it('advances user navigation revision only for explicit user actions', () => {
+    useNavigationStore.getState().goHome('automatic')
+    expect(useNavigationStore.getState().userNavigationRevision).toBe(0)
+
+    useNavigationStore.getState().goHome('user')
+    expect(useNavigationStore.getState().userNavigationRevision).toBe(1)
+
+    useNavigationStore.getState().recordUserNavigation()
+    expect(useNavigationStore.getState().userNavigationRevision).toBe(2)
   })
 })

--- a/src/renderer/src/stores/navigation-store.ts
+++ b/src/renderer/src/stores/navigation-store.ts
@@ -3,17 +3,33 @@ import { create } from 'zustand'
 import { useSessionStore } from './session-store'
 
 export type NavigationView = 'home' | 'workspace'
+export type NavigationOrigin = 'user' | 'automatic'
 
 type NavigationStore = {
   view: NavigationView
   activeProjectId: string | undefined
-  goHome: () => void
-  openProject: (projectId: string) => void
-  openSession: (projectId: string, sessionId: string) => void
+  // Advances only for explicit user navigation. Deferred startup intents observe this instead of
+  // treating lifecycle/deep-link redirects as user choices.
+  userNavigationRevision: number
+  recordUserNavigation: () => void
+  goHome: (origin: NavigationOrigin) => void
+  openProject: (projectId: string, origin: NavigationOrigin) => void
+  openSession: (projectId: string, sessionId: string, origin: NavigationOrigin) => void
   // Opens a session knowing only its id (e.g. a desktop-notification click); a no-op when the
   // session no longer exists or hasn't loaded yet.
-  openSessionById: (sessionId: string) => void
+  openSessionById: (sessionId: string, origin: NavigationOrigin) => void
 }
+
+const navigationState = (
+  state: NavigationStore,
+  origin: NavigationOrigin,
+  next: Pick<NavigationStore, 'view'> & Partial<Pick<NavigationStore, 'activeProjectId'>>
+): Pick<NavigationStore, 'view' | 'activeProjectId' | 'userNavigationRevision'> => ({
+  activeProjectId: state.activeProjectId,
+  userNavigationRevision:
+    origin === 'user' ? state.userNavigationRevision + 1 : state.userNavigationRevision,
+  ...next
+})
 
 // Picks the most recently updated non-pending session in a project so opening a project lands on its
 // latest conversation instead of a blank workspace.
@@ -28,12 +44,18 @@ const findMostRecentSessionId = (projectId: string): string | undefined =>
 export const useNavigationStore = create<NavigationStore>((set) => ({
   view: 'home',
   activeProjectId: undefined,
+  userNavigationRevision: 0,
+
+  // Records user-owned navigation that changes another store (for example, opening the local New
+  // Conversation draft clears Session selection without changing the top-level view).
+  recordUserNavigation: () =>
+    set((state) => ({ userNavigationRevision: state.userNavigationRevision + 1 })),
 
   // Returns to the home screen without discarding session state.
-  goHome: () => set({ view: 'home' }),
+  goHome: (origin) => set((state) => navigationState(state, origin, { view: 'home' })),
 
   // Enters a project's workspace, selecting its most recent session when one exists.
-  openProject: (projectId) => {
+  openProject: (projectId, origin) => {
     const mostRecentSessionId = findMostRecentSessionId(projectId)
 
     if (mostRecentSessionId) {
@@ -42,20 +64,24 @@ export const useNavigationStore = create<NavigationStore>((set) => ({
       useSessionStore.getState().clearSelection()
     }
 
-    set({ view: 'workspace', activeProjectId: projectId })
+    set((state) =>
+      navigationState(state, origin, { view: 'workspace', activeProjectId: projectId })
+    )
   },
 
   // Opens a specific session inside its project's workspace.
-  openSession: (projectId, sessionId) => {
+  openSession: (projectId, sessionId, origin) => {
     useSessionStore.getState().selectSession(sessionId)
 
-    set({ view: 'workspace', activeProjectId: projectId })
+    set((state) =>
+      navigationState(state, origin, { view: 'workspace', activeProjectId: projectId })
+    )
   },
 
   // Resolves the session's project from the session store, then navigates exactly like
   // openSession. Unknown ids stay put: a notification for a deleted conversation must not
   // yank the user to a blank workspace.
-  openSessionById: (sessionId) => {
+  openSessionById: (sessionId, origin) => {
     const session = useSessionStore
       .getState()
       .sessions.find((candidate) => candidate.id === sessionId)
@@ -64,6 +90,11 @@ export const useNavigationStore = create<NavigationStore>((set) => ({
 
     useSessionStore.getState().selectSession(sessionId)
 
-    set({ view: 'workspace', activeProjectId: session.projectId })
+    set((state) =>
+      navigationState(state, origin, {
+        view: 'workspace',
+        activeProjectId: session.projectId
+      })
+    )
   }
 }))

--- a/src/renderer/src/stores/navigation-store.ts
+++ b/src/renderer/src/stores/navigation-store.ts
@@ -3,7 +3,7 @@ import { create } from 'zustand'
 import { useSessionStore } from './session-store'
 
 export type NavigationView = 'home' | 'workspace'
-export type NavigationOrigin = 'user' | 'automatic'
+export type NavigationOrigin = 'user' | 'notification' | 'automatic'
 
 type NavigationStore = {
   view: NavigationView
@@ -11,6 +11,9 @@ type NavigationStore = {
   // Advances only for explicit user navigation. Deferred startup intents observe this instead of
   // treating lifecycle/deep-link redirects as user choices.
   userNavigationRevision: number
+  // Advances when an explicit navigation intent should supersede a deferred startup deep link.
+  // Desktop-notification clicks count here, but not as in-app user navigation above.
+  explicitNavigationRevision: number
   recordUserNavigation: () => void
   goHome: (origin: NavigationOrigin) => void
   openProject: (projectId: string, origin: NavigationOrigin) => void
@@ -24,10 +27,17 @@ const navigationState = (
   state: NavigationStore,
   origin: NavigationOrigin,
   next: Pick<NavigationStore, 'view'> & Partial<Pick<NavigationStore, 'activeProjectId'>>
-): Pick<NavigationStore, 'view' | 'activeProjectId' | 'userNavigationRevision'> => ({
+): Pick<
+  NavigationStore,
+  'view' | 'activeProjectId' | 'userNavigationRevision' | 'explicitNavigationRevision'
+> => ({
   activeProjectId: state.activeProjectId,
   userNavigationRevision:
     origin === 'user' ? state.userNavigationRevision + 1 : state.userNavigationRevision,
+  explicitNavigationRevision:
+    origin === 'automatic'
+      ? state.explicitNavigationRevision
+      : state.explicitNavigationRevision + 1,
   ...next
 })
 
@@ -45,11 +55,15 @@ export const useNavigationStore = create<NavigationStore>((set) => ({
   view: 'home',
   activeProjectId: undefined,
   userNavigationRevision: 0,
+  explicitNavigationRevision: 0,
 
   // Records user-owned navigation that changes another store (for example, opening the local New
   // Conversation draft clears Session selection without changing the top-level view).
   recordUserNavigation: () =>
-    set((state) => ({ userNavigationRevision: state.userNavigationRevision + 1 })),
+    set((state) => ({
+      userNavigationRevision: state.userNavigationRevision + 1,
+      explicitNavigationRevision: state.explicitNavigationRevision + 1
+    })),
 
   // Returns to the home screen without discarding session state.
   goHome: (origin) => set((state) => navigationState(state, origin, { view: 'home' })),

--- a/src/renderer/src/stores/session-store.ts
+++ b/src/renderer/src/stores/session-store.ts
@@ -203,6 +203,10 @@ type AppendMessageResult = {
   messageId: string
 }
 
+export type SessionHydrationSelection = {
+  sessionId: string | undefined
+}
+
 type SessionStore = SessionStoreData & {
   selectSession: (sessionId: string) => void
   clearSelection: () => void
@@ -217,7 +221,11 @@ type SessionStore = SessionStoreData & {
   replaceMessageUploads: (input: ReplaceMessageUploadsInput) => void
   recordArtifactError: (sessionId: string, error: string) => void
   clearArtifactError: (sessionId: string) => void
-  hydrateSessions: (sessions: PersistedChatSession[], manifest?: PersistedSessionManifest) => void
+  hydrateSessions: (
+    sessions: PersistedChatSession[],
+    manifest?: PersistedSessionManifest,
+    selection?: SessionHydrationSelection
+  ) => void
   upsertPersistedSession: (session: PersistedChatSession) => void
   applyDurableSessionProjection: (input: ApplyDurableSessionProjectionInput) => void
   finishRun: (sessionId: string) => void
@@ -1002,14 +1010,17 @@ export const useSessionStore = create<SessionStore>((set, get) => ({
 
   // Replaces renderer state with the per-session files loaded by the main process. Sessions arrive in
   // filesystem order, so sort newest-first; selection is restored from the manifest when still present.
-  hydrateSessions: (sessions, manifest) => {
+  hydrateSessions: (sessions, manifest, selection) => {
     const hydrated = [...sessions]
       .sort((left, right) => right.updatedAt - left.updatedAt)
       .map(hydrateSession)
-    const requestedSelection = manifest?.lastSessionId
+    const hasExplicitSelection = selection !== undefined
+    const requestedSelection = hasExplicitSelection ? selection.sessionId : manifest?.lastSessionId
     const selectedSessionId = hydrated.some((session) => session.id === requestedSelection)
       ? requestedSelection
-      : hydrated[0]?.id
+      : hasExplicitSelection
+        ? undefined
+        : hydrated[0]?.id
 
     set({ sessions: hydrated, selectedSessionId })
   },

--- a/src/renderer/src/stores/settings-store.test.ts
+++ b/src/renderer/src/stores/settings-store.test.ts
@@ -776,14 +776,20 @@ describe('settings store: startup loading', () => {
   })
 
   it('keeps startup blocked after an IPC failure and recovers on retry', async () => {
-    api.getPreflight.mockRejectedValueOnce(new Error('settings IPC unavailable'))
+    const rawError = new Error(
+      'EACCES: /Users/private/.open-science/settings.json could not be read'
+    )
+    const warn = vi.spyOn(console, 'warn').mockImplementation(() => undefined)
+    api.getPreflight.mockRejectedValueOnce(rawError)
 
     await expect(useSettingsStore.getState().load()).resolves.toBe(false)
     expect(useSettingsStore.getState()).toMatchObject({
       isLoaded: false,
       isLoading: false,
-      loadError: 'settings IPC unavailable'
+      loadError: 'Open Science could not load settings. Retry to continue.'
     })
+    expect(useSettingsStore.getState().loadError).not.toContain('/Users/private')
+    expect(warn).toHaveBeenCalledWith('Settings startup loading failed', rawError)
 
     await expect(useSettingsStore.getState().load()).resolves.toBe(true)
     expect(useSettingsStore.getState()).toMatchObject({

--- a/src/renderer/src/stores/settings-store.test.ts
+++ b/src/renderer/src/stores/settings-store.test.ts
@@ -745,6 +745,57 @@ describe('settings store: onboarding completion', () => {
   })
 })
 
+describe('settings store: startup loading', () => {
+  it('keeps startup blocked after an IPC failure and recovers on retry', async () => {
+    api.getPreflight.mockRejectedValueOnce(new Error('settings IPC unavailable'))
+
+    await expect(useSettingsStore.getState().load()).resolves.toBe(false)
+    expect(useSettingsStore.getState()).toMatchObject({
+      isLoaded: false,
+      isLoading: false,
+      loadError: 'settings IPC unavailable'
+    })
+
+    await expect(useSettingsStore.getState().load()).resolves.toBe(true)
+    expect(useSettingsStore.getState()).toMatchObject({
+      isLoaded: true,
+      isLoading: false,
+      loadError: undefined
+    })
+  })
+
+  it('keeps the newest retry result when an older load finishes later', async () => {
+    let resolveFirst: ((value: SettingsSnapshot) => void) | undefined
+    let resolveSecond: ((value: SettingsSnapshot) => void) | undefined
+    api.getSettings
+      .mockReturnValueOnce(
+        new Promise<SettingsSnapshot>((resolve) => {
+          resolveFirst = resolve
+        })
+      )
+      .mockReturnValueOnce(
+        new Promise<SettingsSnapshot>((resolve) => {
+          resolveSecond = resolve
+        })
+      )
+
+    const first = useSettingsStore.getState().load()
+    const second = useSettingsStore.getState().load()
+
+    resolveSecond?.({ ...snapshot([]), onboardingCompletedAt: 222 })
+    await second
+    resolveFirst?.({ ...snapshot([]), onboardingCompletedAt: 111 })
+    await first
+
+    expect(useSettingsStore.getState()).toMatchObject({
+      onboardingCompletedAt: 222,
+      isLoaded: true,
+      isLoading: false,
+      loadError: undefined
+    })
+  })
+})
+
 describe('settings store: provider/model selection', () => {
   it('passes the chosen model to the IPC and caches activeModel', async () => {
     api.setActiveProvider.mockResolvedValue({

--- a/src/renderer/src/stores/settings-store.test.ts
+++ b/src/renderer/src/stores/settings-store.test.ts
@@ -746,6 +746,35 @@ describe('settings store: onboarding completion', () => {
 })
 
 describe('settings store: startup loading', () => {
+  it('deduplicates concurrent StrictMode startup loads', async () => {
+    let resolveSettings: ((value: SettingsSnapshot) => void) | undefined
+    api.getSettings.mockReturnValue(
+      new Promise<SettingsSnapshot>((resolve) => {
+        resolveSettings = resolve
+      })
+    )
+
+    const first = useSettingsStore.getState().load()
+    const duplicate = useSettingsStore.getState().load()
+
+    expect(duplicate).toBe(first)
+    expect(api.getSettings).toHaveBeenCalledOnce()
+    expect(api.getPreflight).toHaveBeenCalledOnce()
+    expect(api.isEncryptionAvailable).toHaveBeenCalledOnce()
+    expect(api.isNpmAvailable).toHaveBeenCalledOnce()
+
+    resolveSettings?.({ ...snapshot([]), onboardingCompletedAt: 111 })
+
+    await expect(first).resolves.toBe(true)
+    await expect(duplicate).resolves.toBe(true)
+    expect(useSettingsStore.getState()).toMatchObject({
+      onboardingCompletedAt: 111,
+      isLoaded: true,
+      isLoading: false,
+      loadError: undefined
+    })
+  })
+
   it('keeps startup blocked after an IPC failure and recovers on retry', async () => {
     api.getPreflight.mockRejectedValueOnce(new Error('settings IPC unavailable'))
 
@@ -780,7 +809,7 @@ describe('settings store: startup loading', () => {
       )
 
     const first = useSettingsStore.getState().load()
-    const second = useSettingsStore.getState().load()
+    const second = useSettingsStore.getState().load({ force: true })
 
     resolveSecond?.({ ...snapshot([]), onboardingCompletedAt: 222 })
     await second

--- a/src/renderer/src/stores/settings-store.ts
+++ b/src/renderer/src/stores/settings-store.ts
@@ -160,7 +160,7 @@ type SettingsStoreData = {
 }
 
 type SettingsStore = SettingsStoreData & {
-  load: () => Promise<boolean>
+  load: (options?: { force?: boolean }) => Promise<boolean>
   refreshPreflight: () => Promise<Preflight>
   checkEnvironment: (options?: { force?: boolean }) => Promise<EnvironmentCheckResult | undefined>
   detectClaude: () => Promise<ClaudeDetectResult>
@@ -580,45 +580,60 @@ const resolveUpsertedProviderId = (
   return after.find((provider) => !beforeIds.has(provider.id))?.id
 }
 
+let settingsLoadPromise: Promise<boolean> | undefined
+
 // Renderer cache of the main-process settings service. The main process stays the source of truth
 // for secrets; this store only ever holds masked provider views.
 export const useSettingsStore = create<SettingsStore>((set, get) => ({
   ...createInitialSettingsState(),
 
   // Loads settings, preflight, and encryption availability in one startup pass.
-  load: async () => {
+  load: (options) => {
+    // StrictMode replays the startup effect. Reuse that identical in-flight pass so a duplicate
+    // request cannot supersede its successful result; an explicit user retry still starts a new
+    // generation and remains authoritative over any older request.
+    if (!options?.force && settingsLoadPromise) return settingsLoadPromise
+
     const generation = get().settingsLoadGeneration + 1
     set({ settingsLoadGeneration: generation, isLoading: true, loadError: undefined })
 
-    try {
-      const [snapshot, preflight, encryptionAvailable, npmAvailable] = await Promise.all([
-        window.api.settings.getSettings(),
-        window.api.settings.getPreflight(),
-        window.api.settings.isEncryptionAvailable(),
-        window.api.settings.isNpmAvailable()
-      ])
+    const loadPromise = (async (): Promise<boolean> => {
+      try {
+        const [snapshot, preflight, encryptionAvailable, npmAvailable] = await Promise.all([
+          window.api.settings.getSettings(),
+          window.api.settings.getPreflight(),
+          window.api.settings.isEncryptionAvailable(),
+          window.api.settings.isNpmAvailable()
+        ])
 
-      if (get().settingsLoadGeneration !== generation) return false
+        if (get().settingsLoadGeneration !== generation) return false
 
-      set({
-        ...applySnapshot(snapshot),
-        preflight,
-        encryptionAvailable,
-        npmAvailable,
-        isLoaded: true,
-        isLoading: false,
-        loadError: undefined
-      })
-      return true
-    } catch (error) {
-      if (get().settingsLoadGeneration !== generation) return false
+        set({
+          ...applySnapshot(snapshot),
+          preflight,
+          encryptionAvailable,
+          npmAvailable,
+          isLoaded: true,
+          isLoading: false,
+          loadError: undefined
+        })
+        return true
+      } catch (error) {
+        if (get().settingsLoadGeneration !== generation) return false
 
-      set({
-        isLoading: false,
-        loadError: error instanceof Error ? error.message : 'Settings could not be loaded.'
-      })
-      return false
-    }
+        set({
+          isLoading: false,
+          loadError: error instanceof Error ? error.message : 'Settings could not be loaded.'
+        })
+        return false
+      }
+    })()
+
+    settingsLoadPromise = loadPromise
+    void loadPromise.then(() => {
+      if (settingsLoadPromise === loadPromise) settingsLoadPromise = undefined
+    })
+    return loadPromise
   },
 
   // Re-checks the two startup gates without reloading the whole snapshot.

--- a/src/renderer/src/stores/settings-store.ts
+++ b/src/renderer/src/stores/settings-store.ts
@@ -86,6 +86,9 @@ type RuntimeInstallState = {
 
 type SettingsStoreData = {
   isLoaded: boolean
+  isLoading: boolean
+  loadError: string | undefined
+  settingsLoadGeneration: number
   claude: ClaudeInfo
   activeProviderId: string | undefined
   claudeSubscriptionProviderId: ClaudeSubscriptionProviderId | undefined
@@ -157,7 +160,7 @@ type SettingsStoreData = {
 }
 
 type SettingsStore = SettingsStoreData & {
-  load: () => Promise<void>
+  load: () => Promise<boolean>
   refreshPreflight: () => Promise<Preflight>
   checkEnvironment: (options?: { force?: boolean }) => Promise<EnvironmentCheckResult | undefined>
   detectClaude: () => Promise<ClaudeDetectResult>
@@ -328,6 +331,9 @@ const createInitialPreflight = (): Preflight => ({
 
 export const createInitialSettingsState = (): SettingsStoreData => ({
   isLoaded: false,
+  isLoading: false,
+  loadError: undefined,
+  settingsLoadGeneration: 0,
   claude: {},
   activeProviderId: undefined,
   claudeSubscriptionProviderId: undefined,
@@ -581,20 +587,38 @@ export const useSettingsStore = create<SettingsStore>((set, get) => ({
 
   // Loads settings, preflight, and encryption availability in one startup pass.
   load: async () => {
-    const [snapshot, preflight, encryptionAvailable, npmAvailable] = await Promise.all([
-      window.api.settings.getSettings(),
-      window.api.settings.getPreflight(),
-      window.api.settings.isEncryptionAvailable(),
-      window.api.settings.isNpmAvailable()
-    ])
+    const generation = get().settingsLoadGeneration + 1
+    set({ settingsLoadGeneration: generation, isLoading: true, loadError: undefined })
 
-    set({
-      ...applySnapshot(snapshot),
-      preflight,
-      encryptionAvailable,
-      npmAvailable,
-      isLoaded: true
-    })
+    try {
+      const [snapshot, preflight, encryptionAvailable, npmAvailable] = await Promise.all([
+        window.api.settings.getSettings(),
+        window.api.settings.getPreflight(),
+        window.api.settings.isEncryptionAvailable(),
+        window.api.settings.isNpmAvailable()
+      ])
+
+      if (get().settingsLoadGeneration !== generation) return false
+
+      set({
+        ...applySnapshot(snapshot),
+        preflight,
+        encryptionAvailable,
+        npmAvailable,
+        isLoaded: true,
+        isLoading: false,
+        loadError: undefined
+      })
+      return true
+    } catch (error) {
+      if (get().settingsLoadGeneration !== generation) return false
+
+      set({
+        isLoading: false,
+        loadError: error instanceof Error ? error.message : 'Settings could not be loaded.'
+      })
+      return false
+    }
   },
 
   // Re-checks the two startup gates without reloading the whole snapshot.

--- a/src/renderer/src/stores/settings-store.ts
+++ b/src/renderer/src/stores/settings-store.ts
@@ -581,6 +581,12 @@ const resolveUpsertedProviderId = (
 }
 
 let settingsLoadPromise: Promise<boolean> | undefined
+const SAFE_SETTINGS_LOAD_ERROR = 'Open Science could not load settings. Retry to continue.'
+
+// Keep raw IPC diagnostics in the developer channel while renderer state remains path-safe.
+const reportSettingsLoadError = (error: unknown): void => {
+  console.warn('Settings startup loading failed', error)
+}
 
 // Renderer cache of the main-process settings service. The main process stays the source of truth
 // for secrets; this store only ever holds masked provider views.
@@ -621,9 +627,10 @@ export const useSettingsStore = create<SettingsStore>((set, get) => ({
       } catch (error) {
         if (get().settingsLoadGeneration !== generation) return false
 
+        reportSettingsLoadError(error)
         set({
           isLoading: false,
-          loadError: error instanceof Error ? error.message : 'Settings could not be loaded.'
+          loadError: SAFE_SETTINGS_LOAD_ERROR
         })
         return false
       }

--- a/src/renderer/web/api-map.generated.ts
+++ b/src/renderer/web/api-map.generated.ts
@@ -68,6 +68,7 @@ export const WEB_INVOKE_CHANNELS = {
   'notebookEnv.getStatus': 'notebook-env:status',
   'notebookEnv.provision': 'notebook-env:provision',
   'notebookEnv.repair': 'notebook-env:repair',
+  'notifications.peekPendingOpenSession': 'notifications:peek-pending-open-session',
   'notifications.takePendingOpenSession': 'notifications:take-pending-open-session',
   'preview.delete': 'preview:delete',
   'preview.load': 'preview:load',

--- a/src/shared/notifications.ts
+++ b/src/shared/notifications.ts
@@ -1,6 +1,8 @@
 // The conversation a desktop-notification click should open. Main holds it (consume-once) until
 // the renderer pulls it via 'notifications:take-pending-open-session' once its session store is
-// hydrated — a push sent before the renderer's listener exists would be lost.
+// hydrated — a push sent before the renderer's listener exists would be lost. Token uniquely
+// identifies the click even when consecutive notifications target the same conversation.
 export type OpenSessionFromNotificationRequest = {
   sessionId: string
+  token: number
 }

--- a/src/shared/session-persistence.ts
+++ b/src/shared/session-persistence.ts
@@ -1185,10 +1185,33 @@ export const normalizeSessionManifest = (value: unknown): PersistedSessionManife
   return manifest
 }
 
+// Renderer-safe diagnostics for durable Session files omitted during startup hydration.
+export type SessionLoadWarning =
+  | {
+      kind: 'corrupt' | 'unreadable'
+      projectId: string
+      fileName: string
+      recovered: boolean
+    }
+  | {
+      kind: 'manifest-corrupt'
+      fileName: string
+      recovered: boolean
+    }
+
+export type SessionLoadFailure = 'manifest-unreadable' | 'startup-reconciliation-failed'
+
+export type SessionLoadDiagnostics = {
+  isComplete: boolean
+  warnings: SessionLoadWarning[]
+  failure?: SessionLoadFailure
+}
+
 // IPC payloads for the per-session persistence surface.
 export type LoadAllSessionsResult = {
   sessions: PersistedChatSession[]
   manifest: PersistedSessionManifest
+  diagnostics?: SessionLoadDiagnostics
 }
 
 export type DeleteSessionRequest = {

--- a/src/shared/session-persistence.ts
+++ b/src/shared/session-persistence.ts
@@ -1194,12 +1194,12 @@ export type SessionLoadWarning =
       recovered: boolean
     }
   | {
-      kind: 'manifest-corrupt'
+      kind: 'manifest-corrupt' | 'manifest-unreadable'
       fileName: string
       recovered: boolean
     }
 
-export type SessionLoadFailure = 'manifest-unreadable' | 'startup-reconciliation-failed'
+export type SessionLoadFailure = 'startup-reconciliation-failed'
 
 export type SessionLoadDiagnostics = {
   isComplete: boolean

--- a/src/shared/session-persistence.ts
+++ b/src/shared/session-persistence.ts
@@ -1156,6 +1156,13 @@ export const normalizeSessionFile = (
 
   const rawSession = isRecord(value.session) ? value.session : value
 
+  // A persisted Session needs one authoritative conversation representation. The compatibility
+  // message list may be absent or malformed only when a canonical graph can replace it; otherwise
+  // accepting the file would turn deterministic structural corruption into a valid empty Session.
+  if (rawSession.conversationGraph === undefined && !Array.isArray(rawSession.messages)) {
+    return undefined
+  }
+
   return sanitizeSession(rawSession, options)
 }
 

--- a/src/shared/session-persistence.ts
+++ b/src/shared/session-persistence.ts
@@ -1212,6 +1212,9 @@ export type SessionLoadDiagnostics = {
   isComplete: boolean
   warnings: SessionLoadWarning[]
   failure?: SessionLoadFailure
+  // The outer startup boundary stamps this after replaying pending Project deletions. Session and
+  // Project deletion IPC both enforce the same prerequisite, independently of scan completeness.
+  isProjectDeletionRecoveryComplete?: boolean
 }
 
 // IPC payloads for the per-session persistence surface.


### PR DESCRIPTION
## Problem

A failed Settings IPC left the renderer waiting forever behind a null App result. Session loading and saving failures were also reduced to console warnings, so unreadable or damaged data could look like an empty conversation list and unsaved changes could appear durable.

## Proposed change

- Give Settings startup explicit loading and error state, StrictMode-safe request deduplication, latest-attempt-wins retries, and a full initialization retry.
- Carry renderer-safe Session load diagnostics across IPC, quarantine deterministic corruption (including valid JSON with no authoritative conversation structure), and treat partial scans, post-enumeration Session/Project disappearance, and startup reconciliation/index failure as incomplete recovery.
- Separate readable hydration from durable write readiness so healthy conversations remain navigable while saver-backed mutations stay blocked; if Project deletion recovery fails, use an explicit read-only Session load that cannot reconcile, quarantine authority, or write derived state.
- Surface failed Session and manifest writes, retain failed targets, retry the latest in-memory state, and automatically clear obsolete targets even when a queued save rejection arrives after authoritative deletion.
- Preserve deep-link, notification, and retry-selection intent across recovery without overriding later user navigation; concurrent notification peeks are serialized against causal click generations and navigation revisions, explicit Project/Session deletion cancels deferred targets, recovery shells suppress stale unread acknowledgement, and explicit empty or missing retry selections apply atomically and are written back to the manifest before persistence becomes ready.
- Keep a Project deep link pending while the Project catalog itself is unavailable, and only resolve or reject it after a successful catalog load.
- Keep target-scoped Project and Session deletion available after ordinary partial hydration, but disable both when Project deletion-journal recovery itself failed; independently show an exact Session count only when the catalog is complete.
- Keep interrupted-Session Resume disabled until durable Session persistence is ready, with both a page-level guard and a disabled shared Button so reconnect/re-send cannot mutate partially recovered state.
- Keep automatic completed-job analysis disabled until durable Session persistence is ready, cancel pending scans and turn-end listeners when readiness is lost, and preserve one trigger across runtime callback identity changes.
- Render recovery surfaces with the App Shell's semantic design tokens and shared shadcn Buttons, keep raw main-process Settings, Session load, and Session write failures out of renderer-visible copy, and let users dismiss persistent quarantine warnings without changing recovery readiness.

## Scope and non-goals

This change is limited to Settings startup and Session persistence health/recovery behavior across main and renderer, including navigation intent and mutation gating while recovery is incomplete. It does not change the Session file schema or automatically reconstruct unrecoverable conversation content.

## Acceptance criteria and validation

Final verification statement: checks affected by the last material edit, both typechecks, full lint, and the full regression suite were rerun against commit `dae93d6`. Earlier behavior-specific results remain listed below; all files affected by the final edit pass the final focused run. Independent Standards and Spec reviews of `git diff 24b4e8e...dae93d6` found no remaining findings. Clean-checkout macOS, Ubuntu, Windows, CodeQL, and commit-message CI all pass; the local full-suite caveat is recorded explicitly below.

| Behavior | Command | Final result |
| --- | --- | --- |
| Settings startup shows progress/error, deduplicates StrictMode loads, and retries the full initialization | `npm test -- --run src/renderer/src/stores/settings-store.test.ts src/renderer/src/App.test.tsx` | PASS — 2 files / 93 tests |
| Session authority quarantines structural corruption, distinguishes direct absence from post-enumeration disappearance, and degrades to read-only hydration when Project deletion recovery fails | `npm test -- --run src/main/session-persistence/coordinator.test.ts src/main/session-persistence/repository.test.ts src/main/session-persistence/ipc.test.ts` | PASS — 3 files / 108 tests |
| Hydration/readiness gates, atomic retry selection, latest-state write retry, authoritative deletion, and late obsolete failure-target cleanup remain consistent | `npm test -- --run src/renderer/src/lib/session-persistence/session-persistence.test.ts src/renderer/src/lib/session-persistence/session-persistence.render.test.tsx src/renderer/src/stores/session-store.test.ts src/renderer/src/pages/home/HomePage.persistence.test.tsx src/renderer/src/pages/workspace/WorkspacePage.draft-preservation.test.tsx src/renderer/src/pages/workspace/WorkspaceSidebar.render.test.tsx src/renderer/src/pages/workspace/workspace-components.test.tsx` | PASS — 7 files / 158 tests |
| Project deletion stays target-scoped after partial hydration, while partial scans and quarantined Session files suppress misleading exact counts without treating manifest-only warnings as catalog loss | `../../node_modules/.bin/vitest run src/renderer/src/App.test.tsx src/renderer/src/lib/session-persistence/session-persistence.render.test.tsx src/renderer/src/pages/home/HomePage.persistence.test.tsx src/renderer/src/pages/home/HomePage.render.test.tsx src/renderer/src/pages/home/home-dialogs.render.test.tsx` | PASS — 5 files / 47 tests |
| Project and Session deletion remain available after ordinary partial scans but are disabled when Project deletion recovery failed; an already-open Session dialog disables confirmation when retry removes the capability | `../../node_modules/.bin/vitest run src/main/session-persistence/ipc.test.ts src/renderer/src/lib/session-persistence/session-persistence.render.test.tsx src/renderer/src/App.test.tsx src/renderer/src/pages/workspace/WorkspacePage.draft-preservation.test.tsx src/renderer/src/pages/workspace/session-dialogs.render.test.tsx` | PASS — 5 files / 65 tests |
| A complete retry durably writes the preserved selected or explicitly empty Session manifest before persistence reports ready; a failed write remains read-only and resumes deferred artifact reconciliation exactly once after write retry succeeds | `../../node_modules/.bin/vitest run src/renderer/src/lib/session-persistence/session-persistence.render.test.tsx src/renderer/src/lib/session-persistence/session-persistence.test.ts` | PASS — included in the final focused and full-suite runs |
| Deep links and notification clicks survive partial recovery, explicit deletion cancels deferred targets, repeated same-Session clicks remain distinct, and recovery shells cannot acknowledge retained content as visible | `npm test -- --run src/main/notifications/task-notifications.test.ts src/preload/index.test.ts src/renderer/src/App.test.tsx src/renderer/src/hooks/useUnreadTaskViewSync.test.tsx src/renderer/src/lib/deep-link.navigation.test.tsx src/renderer/src/stores/navigation-store.test.ts` | PASS — 6 files / 162 tests |
| Concurrent pending-notification peeks cannot let an older token override later user navigation, while a valid queued retry still opens after persistence becomes ready; the recovery alert directly verifies both layout variants and the shared Button contract | `../../node_modules/.bin/vitest run src/renderer/src/App.test.tsx src/renderer/src/components/SessionPersistenceAlert.render.test.tsx` | PASS — 2 files / 27 tests |
| Interrupted Session Resume cannot reconnect, mutate, or re-send while persistence is recovering; the control becomes available after readiness returns and follows the shared Button focus/disabled contract | `npm test -- src/renderer/src/pages/workspace/WorkspacePage.draft-preservation.test.tsx src/renderer/src/pages/workspace/ConversationPanel.interaction.test.tsx src/renderer/src/pages/workspace/SessionInterruptedBanner.test.tsx` | PASS — 3 files / 63 tests |
| Session write failures retain raw diagnostics only in the diagnostic channel, present renderer-safe recovery copy, and quarantined-data warnings can be dismissed without changing persistence readiness | `npm test -- src/renderer/src/App.test.tsx src/renderer/src/components/SessionPersistenceAlert.render.test.tsx src/renderer/src/lib/session-persistence/session-persistence.render.test.tsx` | PASS — 3 files / 43 tests |
| Recovery surfaces use semantic tokens and shared Buttons with the required focus/disabled contract, while unread visibility follows the rendered shell | `npm test -- --run src/renderer/src/App.test.tsx src/renderer/src/hooks/useUnreadTaskViewSync.test.tsx` | PASS — 2 files / 33 tests |
| App Shell roots use `min-h-svh bg-background text-foreground`; Settings errors are renderer-safe; incomplete catalogs hide exact counts; failed retry manifests keep readiness closed; and Project-load failures preserve pending deep links | `../../node_modules/.bin/vitest run src/renderer/src/App.test.tsx src/renderer/src/lib/session-persistence/session-persistence.render.test.tsx src/renderer/src/lib/session-persistence/session-persistence.test.ts src/renderer/src/pages/home/HomePage.persistence.test.tsx src/renderer/src/pages/home/HomePage.render.test.tsx src/renderer/src/stores/settings-store.test.ts src/renderer/src/lib/deep-link.navigation.test.tsx src/renderer/src/stores/project-store.test.ts` | PASS — 8 files / 152 tests |
| Degraded fallback scanning leaves malformed and structurally invalid authority untouched; automatic job analysis remains blocked across partial recovery and callback changes; notification clicks retain their causal navigation ordering in both queue directions | `npm test -- --run src/main/session-persistence/coordinator.test.ts src/main/session-persistence/repository.test.ts src/renderer/src/App.test.tsx src/renderer/src/lib/compute/useJobAnalysisEffect.render.test.tsx src/renderer/src/lib/compute/job-analysis-trigger.test.ts src/renderer/src/pages/workspace/WorkspacePage.draft-preservation.test.tsx` | PASS — 6 files / 165 tests |
| Node and renderer TypeScript contracts compile | `npm run typecheck:node`<br>`npm run typecheck:web` | PASS |
| Repository lint rules remain green | `npm run lint` | PASS — 0 errors / 22 pre-existing warnings in unchanged files |
| Cross-cutting regression suite | `npm test` | CLEAN CI PASS — macOS, Ubuntu, and Windows verification all pass. Locally, 547 files / 8,212 tests passed and 11 files / 139 tests skipped; the sole failure was the Prisma schema parity check because the shared parent `node_modules` client contains `PermissionGrant` from another worktree while this branch's schema does not. |

## Uncovered risks

- Tests inject deterministic filesystem, Project deletion recovery, and file-index failures; no packaged Electron end-to-end test reproduces a real OS disappearance race, live SQLite lock, or interrupted deletion-journal replay/tail failure.
- Notification ordering is covered with deterministic renderer IPC mocks, not a real OS notification click racing an Electron window navigation event.
- Resume readiness is covered through renderer component/store mocks, not a packaged restart where recovery and an interrupted ACP Session overlap in real time.
- Job-analysis readiness is covered through renderer stores and deterministic callbacks, not a packaged ACP turn racing a live persistence retry.
- Focus, disabled, opacity, and semantic-token behavior are verified through the rendered DOM/class contract, not cross-theme visual regression or keyboard end-to-end testing.
- Unrecoverable conversation content is surfaced and kept fail-closed but is not reconstructed automatically.

## Review focus

Please focus on readiness boundaries, truly read-only degraded hydration, scan completeness, automatic job-analysis gating, failure-target bookkeeping, atomic navigation intent, and unread acknowledgement while recovery shells cover retained Session state.
