### PR TITLE
ci(windows): balance PR speed and release validation

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -65,35 +65,6 @@ jobs:
       - name: Check CLI package
         run: npm run check:cli-package
 
-  # Preserve complete real-Windows coverage after merge without putting its ~11-minute runtime back
-  # on every PR. Two shards run in parallel with packaging. This remains advisory while the suite has
-  # known POSIX-only path assertions; the focused PR gate and packaged-app smoke below are blocking.
-  windows_full_test:
-    name: Windows full test (${{ matrix.shard }}/2, advisory)
-    if: ${{ !inputs.skip_verify && !inputs.mac_only }}
-    runs-on: windows-latest
-    continue-on-error: true
-    timeout-minutes: 25
-    strategy:
-      fail-fast: false
-      matrix:
-        shard: [1, 2]
-    steps:
-      - name: Checkout
-        uses: actions/checkout@v7
-
-      - name: Setup Node
-        uses: actions/setup-node@v7
-        with:
-          node-version: 22
-          cache: npm
-
-      - name: Install dependencies
-        run: npm ci
-
-      - name: Test complete suite shard
-        run: npm test -- --shard=${{ matrix.shard }}/2
-
   # Resolve the platform matrix. mac_only trims it to the two mac archs — used by the notarization
   # dry-run (notarize-dryrun.yml), which only needs a signed mac build. With mac_only false (the
   # release.yml / nightly.yml callers) the full matrix is emitted, so their behavior is unchanged.
@@ -258,6 +229,7 @@ jobs:
       # Windows runtime resources, request a clean shutdown, then silently uninstall it.
       - name: Smoke test Windows installer
         if: matrix.platform == 'win'
+        timeout-minutes: 10
         run: node scripts/windows-installer-smoke.mjs --installer-dir dist
 
       # Upload only the distributables + electron-updater metadata for the caller's publish job.

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -65,6 +65,35 @@ jobs:
       - name: Check CLI package
         run: npm run check:cli-package
 
+  # Preserve complete real-Windows coverage after merge without putting its ~11-minute runtime back
+  # on every PR. Two shards run in parallel with packaging. This remains advisory while the suite has
+  # known POSIX-only path assertions; the focused PR gate and packaged-app smoke below are blocking.
+  windows_full_test:
+    name: Windows full test (${{ matrix.shard }}/2, advisory)
+    if: ${{ !inputs.skip_verify && !inputs.mac_only }}
+    runs-on: windows-latest
+    continue-on-error: true
+    timeout-minutes: 25
+    strategy:
+      fail-fast: false
+      matrix:
+        shard: [1, 2]
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v7
+
+      - name: Setup Node
+        uses: actions/setup-node@v7
+        with:
+          node-version: 22
+          cache: npm
+
+      - name: Install dependencies
+        run: npm ci
+
+      - name: Test complete suite shard
+        run: npm test -- --shard=${{ matrix.shard }}/2
+
   # Resolve the platform matrix. mac_only trims it to the two mac archs — used by the notarization
   # dry-run (notarize-dryrun.yml), which only needs a signed mac build. With mac_only false (the
   # release.yml / nightly.yml callers) the full matrix is emitted, so their behavior is unchanged.
@@ -223,6 +252,13 @@ jobs:
             export CSC_IDENTITY_AUTO_DISCOVERY=false
             npx electron-builder ${{ matrix.eb_args }} "${eb_ver[@]}" --publish never
           fi
+
+      # Run the actual NSIS artifact, not the source tree: silent install into an isolated directory,
+      # start the packaged app in headless web mode, verify its authenticated bootstrap and bundled
+      # Windows runtime resources, request a clean shutdown, then silently uninstall it.
+      - name: Smoke test Windows installer
+        if: matrix.platform == 'win'
+        run: node scripts/windows-installer-smoke.mjs --installer-dir dist
 
       # Upload only the distributables + electron-updater metadata for the caller's publish job.
       - name: Upload build artifacts

--- a/.github/workflows/pr-check.yml
+++ b/.github/workflows/pr-check.yml
@@ -89,6 +89,17 @@ jobs:
           src/main/notebook/micromamba-cache-powershell.test.ts
           src/main/notebook/micromamba-cache-acl.integration.test.ts
 
+      # runtime-service.test.ts takes about 70 seconds and has unrelated POSIX assumptions on
+      # Windows. Run its one Windows-only shell integration case by name so this behavior remains a
+      # hard gate without restoring the noisy full-file cost.
+      - name: Test Windows notebook shell behavior
+        if: matrix.os == 'windows-latest'
+        run: >-
+          npx vitest run
+          src/main/notebook/runtime-service.test.ts
+          --testNamePattern
+          "isolates commands, propagates PowerShell failures, and preserves UTF-8 output on Windows"
+
       # Full test suite + coverage gate on macOS (thresholds live in vitest.config.ts).
       - name: Test (with coverage)
         if: matrix.os == 'macos-14'

--- a/.github/workflows/pr-check.yml
+++ b/.github/workflows/pr-check.yml
@@ -33,9 +33,9 @@ jobs:
       matrix:
         # macOS is the release/verification target and the only platform with the project's
         # arm64-only darwin native dependency present, so it runs the FULL gate (test + coverage +
-        # build). Linux/Windows validate the platform-independent code paths (lint + typecheck are
-        # hard-gated everywhere); their test leg is advisory (continue-on-error) because the missing
-        # darwin native package can trip suites that reach the ACP/native layer — see the test steps.
+        # build). Ubuntu provides the advisory cross-platform full-suite signal. Windows hard-gates
+        # the platform-independent checks plus a focused native-filesystem/PowerShell test suite;
+        # see the test steps for why the noisy full suite is intentionally omitted there.
         os: [macos-14, ubuntu-latest, windows-latest]
 
     steps:
@@ -62,23 +62,32 @@ jobs:
 
       # Guards against src/preload drifting from the generated web API map. Pure Node and
       # platform-independent, so hard-gate it on all three OSes rather than relying on the
-      # macOS-only vitest leg (the Linux/Windows test run is advisory).
+      # macOS coverage leg, Ubuntu advisory suite, or focused Windows suite.
       - name: Check web API map
         run: npm run check:web-api-map
 
-      # The general suite discovers these tests, but Linux/Windows tests are advisory. Keep the
-      # zero-dependency CLI/SDK contract and publishable tarball hard-gated on every platform.
+      # The general suite discovers these tests, but Ubuntu's run is advisory and Windows runs only
+      # a focused platform suite. Keep the zero-dependency CLI/SDK contract and publishable tarball
+      # hard-gated on every platform.
       - name: Test CLI and SDK
         run: npm run test:cli
 
       - name: Check CLI package
         run: npm run check:cli-package
 
-      # This exercises the production DACL writer and verifier on a real Windows filesystem. Keep
-      # it hard-gated even while the general Windows suite remains advisory.
-      - name: Test Windows micromamba cache ACL
+      # Keep the Windows signal focused and actionable. The full suite currently has many known
+      # POSIX-only failures and repeatedly builds fresh Prisma/SQLite schemas; on Windows that turns
+      # into more than ten minutes of advisory noise. Ubuntu still runs the cross-platform full suite,
+      # while this hard gate exercises the real Windows filesystem, DACL, icon, and PowerShell paths.
+      - name: Test Windows-specific behavior
         if: matrix.os == 'windows-latest'
-        run: npx vitest run src/main/notebook/micromamba-cache-acl.integration.test.ts
+        run: >-
+          npx vitest run
+          src/main/windows.test.ts
+          src/main/windows-icon-assets.test.ts
+          src/main/windows-powershell.test.ts
+          src/main/notebook/micromamba-cache-powershell.test.ts
+          src/main/notebook/micromamba-cache-acl.integration.test.ts
 
       # Full test suite + coverage gate on macOS (thresholds live in vitest.config.ts).
       - name: Test (with coverage)
@@ -86,10 +95,10 @@ jobs:
         run: npm run test:coverage
 
       # Cross-platform test signal, advisory only: a failure here is surfaced in the PR but does not
-      # block merge, because the darwin-only native dependency is absent on Linux/Windows and can fail
-      # suites that touch it. Promote to a hard gate once those suites are made platform-independent.
+      # block merge, because the darwin-only native dependency is absent on Linux and can fail suites
+      # that touch it. Promote to a hard gate once those suites are made platform-independent.
       - name: Test (advisory)
-        if: matrix.os != 'macos-14'
+        if: matrix.os == 'ubuntu-latest'
         continue-on-error: true
         run: npm run test
 

--- a/.github/workflows/pr-check.yml
+++ b/.github/workflows/pr-check.yml
@@ -89,16 +89,12 @@ jobs:
           src/main/notebook/micromamba-cache-powershell.test.ts
           src/main/notebook/micromamba-cache-acl.integration.test.ts
 
-      # runtime-service.test.ts takes about 70 seconds and has unrelated POSIX assumptions on
-      # Windows. Run its one Windows-only shell integration case by name so this behavior remains a
-      # hard gate without restoring the noisy full-file cost.
+      # Exercise the production Windows shell runner directly. The broader runtime-service suite
+      # takes about 70 seconds and has unrelated Windows failures, so its former combined shell case
+      # could time out without identifying which PowerShell contract regressed.
       - name: Test Windows notebook shell behavior
         if: matrix.os == 'windows-latest'
-        run: >-
-          npx vitest run
-          src/main/notebook/runtime-service.test.ts
-          --testNamePattern
-          "isolates commands, propagates PowerShell failures, and preserves UTF-8 output on Windows"
+        run: npx vitest run src/main/notebook/windows-shell.integration.test.ts
 
       # Full test suite + coverage gate on macOS (thresholds live in vitest.config.ts).
       - name: Test (with coverage)

--- a/.github/workflows/pr-check.yml
+++ b/.github/workflows/pr-check.yml
@@ -96,6 +96,16 @@ jobs:
         if: matrix.os == 'windows-latest'
         run: npx vitest run src/main/notebook/windows-shell.integration.test.ts
 
+      # Keep the public service boundary covered without running the rest of the heavy runtime-service
+      # suite. This verifies that Windows tree termination is persisted as a timed-out notebook run.
+      - name: Test Windows notebook shell service timeout
+        if: matrix.os == 'windows-latest'
+        run: >-
+          npx vitest run
+          src/main/notebook/runtime-service.test.ts
+          --testNamePattern
+          "kills a command that outlasts the timeout and returns a non-normal result"
+
       # Full test suite + coverage gate on macOS (thresholds live in vitest.config.ts).
       - name: Test (with coverage)
         if: matrix.os == 'macos-14'

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -42,6 +42,7 @@ jobs:
     needs: build
     if: startsWith(github.ref, 'refs/tags/')
     runs-on: windows-latest
+    timeout-minutes: 20
     permissions:
       contents: read
     steps:

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -35,11 +35,57 @@ jobs:
     uses: ./.github/workflows/notarize-mac.yml
     secrets: inherit
 
+  # The reusable build already hard-gates a fresh NSIS install/start/uninstall. On stable tags, also
+  # install the latest published stable version and run the new installer over it. This runs beside
+  # macOS notarization, so its few minutes normally do not extend the release critical path.
+  windows-upgrade-smoke:
+    needs: build
+    if: startsWith(github.ref, 'refs/tags/')
+    runs-on: windows-latest
+    permissions:
+      contents: read
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v7
+
+      - name: Download current Windows installer
+        uses: actions/download-artifact@v8
+        with:
+          name: windows-x64
+          path: current
+
+      - name: Download previous stable Windows installer
+        id: previous
+        shell: pwsh
+        env:
+          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+          CURRENT_TAG: ${{ github.ref_name }}
+        run: |
+          New-Item -ItemType Directory -Force previous | Out-Null
+          $releases = gh release list --exclude-drafts --exclude-pre-releases --limit 20 --json tagName
+          if ($LASTEXITCODE -ne 0) { exit $LASTEXITCODE }
+          $tag = ($releases | ConvertFrom-Json | Where-Object { $_.tagName -like 'v*' -and $_.tagName -ne $env:CURRENT_TAG } | Select-Object -First 1).tagName
+          if ([string]::IsNullOrWhiteSpace($tag)) {
+            "available=false" >> $env:GITHUB_OUTPUT
+            Write-Host "No previous stable release is available; fresh-install smoke already passed."
+            exit 0
+          }
+          gh release download $tag --pattern '*-win-x64-setup.exe' --dir previous
+          if ($LASTEXITCODE -ne 0) { exit $LASTEXITCODE }
+          "available=true" >> $env:GITHUB_OUTPUT
+
+      - name: Smoke test Windows upgrade
+        if: steps.previous.outputs.available == 'true'
+        run: >-
+          node scripts/windows-installer-smoke.mjs
+          --installer-dir current
+          --previous-installer-dir previous
+
   # Collect every platform's artifacts and publish them to the tag's Release in one shot (a single
   # publish job avoids the race of multiple build jobs writing the same Release). Depends on
   # notarize-mac so the mac dmg/zip it downloads are the stapled versions.
   publish:
-    needs: [build, notarize-mac]
+    needs: [build, notarize-mac, windows-upgrade-smoke]
     if: startsWith(github.ref, 'refs/tags/')
     runs-on: ubuntu-latest
     # Job-level permissions fully override the workflow-level block, so contents:write is restated

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -48,6 +48,11 @@ jobs:
       - name: Checkout
         uses: actions/checkout@v7
 
+      - name: Setup Node
+        uses: actions/setup-node@v7
+        with:
+          node-version: 22
+
       - name: Download current Windows installer
         uses: actions/download-artifact@v8
         with:

--- a/.github/workflows/windows-full-test.yml
+++ b/.github/workflows/windows-full-test.yml
@@ -1,0 +1,52 @@
+name: Windows Full Test (Advisory)
+
+# Preserve complete real-Windows coverage after merge and on stable tags without adding its runtime
+# to the reusable build workflow. This workflow is intentionally independent from nightly/release
+# packaging and publishing; the focused PR gate and packaged-app smoke remain blocking.
+on:
+  push:
+    branches:
+      - main
+    tags:
+      - 'v*'
+    paths-ignore:
+      - '**/*.md'
+      - 'docs/**'
+      - 'LICENSE'
+      - '.gitignore'
+  workflow_dispatch:
+
+permissions:
+  contents: read
+
+# A newer main push supersedes stale advisory coverage. Stable tags use distinct refs and therefore
+# retain their own signal.
+concurrency:
+  group: windows-full-test-${{ github.ref }}
+  cancel-in-progress: true
+
+jobs:
+  windows_full_test:
+    name: Windows full test (${{ matrix.shard }}/2, advisory)
+    runs-on: windows-latest
+    continue-on-error: true
+    timeout-minutes: 25
+    strategy:
+      fail-fast: false
+      matrix:
+        shard: [1, 2]
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v7
+
+      - name: Setup Node
+        uses: actions/setup-node@v7
+        with:
+          node-version: 22
+          cache: npm
+
+      - name: Install dependencies
+        run: npm ci
+
+      - name: Test complete suite shard
+        run: npm test -- --shard=${{ matrix.shard }}/2

--- a/scripts/pr-check-workflow.test.ts
+++ b/scripts/pr-check-workflow.test.ts
@@ -1,0 +1,52 @@
+import { readFileSync } from 'node:fs'
+import { join } from 'node:path'
+
+import { load } from 'js-yaml'
+import { describe, expect, it } from 'vitest'
+
+type WorkflowStep = {
+  'continue-on-error'?: boolean
+  if?: string
+  name?: string
+  run?: string
+}
+
+type Workflow = {
+  jobs: Record<string, { steps?: WorkflowStep[] }>
+}
+
+const workflow = load(
+  readFileSync(join(process.cwd(), '.github/workflows/pr-check.yml'), 'utf8')
+) as Workflow
+
+const getStep = (name: string): WorkflowStep => {
+  const step = workflow.jobs.verify?.steps?.find((candidate) => candidate.name === name)
+  if (!step) throw new Error(`Missing PR Check step: ${name}`)
+  return step
+}
+
+describe('PR Check platform test coverage', () => {
+  it('runs the full advisory suite on Ubuntu only', () => {
+    const step = getStep('Test (advisory)')
+
+    expect(step.if).toBe("matrix.os == 'ubuntu-latest'")
+    expect(step['continue-on-error']).toBe(true)
+    expect(step.run).toBe('npm run test')
+  })
+
+  it('hard-gates the focused Windows test suite', () => {
+    const step = getStep('Test Windows-specific behavior')
+
+    expect(step.if).toBe("matrix.os == 'windows-latest'")
+    expect(step['continue-on-error']).toBeUndefined()
+    for (const testFile of [
+      'src/main/windows.test.ts',
+      'src/main/windows-icon-assets.test.ts',
+      'src/main/windows-powershell.test.ts',
+      'src/main/notebook/micromamba-cache-powershell.test.ts',
+      'src/main/notebook/micromamba-cache-acl.integration.test.ts'
+    ]) {
+      expect(step.run).toContain(testFile)
+    }
+  })
+})

--- a/scripts/pr-check-workflow.test.ts
+++ b/scripts/pr-check-workflow.test.ts
@@ -55,10 +55,6 @@ describe('PR Check platform test coverage', () => {
 
     expect(step.if).toBe("matrix.os == 'windows-latest'")
     expect(step['continue-on-error']).toBeUndefined()
-    expect(step.run).toContain('src/main/notebook/runtime-service.test.ts')
-    expect(step.run).toContain('--testNamePattern')
-    expect(step.run).toContain(
-      'isolates commands, propagates PowerShell failures, and preserves UTF-8 output on Windows'
-    )
+    expect(step.run).toBe('npx vitest run src/main/notebook/windows-shell.integration.test.ts')
   })
 })

--- a/scripts/pr-check-workflow.test.ts
+++ b/scripts/pr-check-workflow.test.ts
@@ -49,4 +49,16 @@ describe('PR Check platform test coverage', () => {
       expect(step.run).toContain(testFile)
     }
   })
+
+  it('hard-gates the Windows notebook shell integration test', () => {
+    const step = getStep('Test Windows notebook shell behavior')
+
+    expect(step.if).toBe("matrix.os == 'windows-latest'")
+    expect(step['continue-on-error']).toBeUndefined()
+    expect(step.run).toContain('src/main/notebook/runtime-service.test.ts')
+    expect(step.run).toContain('--testNamePattern')
+    expect(step.run).toContain(
+      'isolates commands, propagates PowerShell failures, and preserves UTF-8 output on Windows'
+    )
+  })
 })

--- a/scripts/pr-check-workflow.test.ts
+++ b/scripts/pr-check-workflow.test.ts
@@ -57,4 +57,16 @@ describe('PR Check platform test coverage', () => {
     expect(step['continue-on-error']).toBeUndefined()
     expect(step.run).toBe('npx vitest run src/main/notebook/windows-shell.integration.test.ts')
   })
+
+  it('hard-gates the Windows notebook shell service timeout', () => {
+    const step = getStep('Test Windows notebook shell service timeout')
+
+    expect(step.if).toBe("matrix.os == 'windows-latest'")
+    expect(step['continue-on-error']).toBeUndefined()
+    expect(step.run).toContain('src/main/notebook/runtime-service.test.ts')
+    expect(step.run).toContain('--testNamePattern')
+    expect(step.run).toContain(
+      'kills a command that outlasts the timeout and returns a non-normal result'
+    )
+  })
 })

--- a/scripts/windows-installer-smoke.mjs
+++ b/scripts/windows-installer-smoke.mjs
@@ -1,9 +1,10 @@
 /* eslint-disable @typescript-eslint/explicit-function-return-type */
 
 import { spawn } from 'node:child_process'
+import { randomUUID } from 'node:crypto'
 import { access, mkdir, mkdtemp, readFile, readdir, rm, writeFile } from 'node:fs/promises'
-import { tmpdir } from 'node:os'
-import { basename, join, resolve } from 'node:path'
+import { homedir, tmpdir } from 'node:os'
+import { basename, join, resolve, win32 } from 'node:path'
 import { pathToFileURL } from 'node:url'
 
 const APP_EXECUTABLE = 'open-science.exe'
@@ -12,8 +13,9 @@ const PROCESS_TIMEOUT_MS = 120_000
 const STARTUP_TIMEOUT_MS = 60_000
 const SHUTDOWN_TIMEOUT_MS = 60_000
 const HTTP_REQUEST_TIMEOUT_MS = 15_000
+const TERMINATION_TIMEOUT_MS = 10_000
 const SMOKE_ROOT_PREFIX = 'open-science-installer-smoke-'
-const UPGRADE_SENTINEL_NAME = 'installer-smoke-upgrade-sentinel'
+const UPGRADE_SENTINEL_PREFIX = 'installer-smoke-upgrade-sentinel-'
 const UPGRADE_SENTINEL_CONTENT = 'previous-version-profile-preserved\n'
 
 const delay = (milliseconds) =>
@@ -92,18 +94,106 @@ const parsePackagedAppEndpoint = (output) => {
   }
 }
 
-const terminateProcessTree = async (child) => {
+const readPackagedAppConfigRoot = async (
+  bootstrap,
+  expectedVersion,
+  { auth, legacyConfigRoots = [], readToken = readFile } = {}
+) => {
+  if (
+    bootstrap.appName !== 'Open Science' ||
+    bootstrap.appVersion !== expectedVersion ||
+    bootstrap.platform !== 'win32'
+  ) {
+    throw new Error(`Unexpected installed app bootstrap: ${JSON.stringify(bootstrap)}`)
+  }
+  if (bootstrap.configRoot !== undefined) {
+    if (typeof bootstrap.configRoot !== 'string' || !win32.isAbsolute(bootstrap.configRoot)) {
+      throw new Error('Installed app did not report an absolute Windows config root.')
+    }
+    return bootstrap.configRoot
+  }
+
+  const candidates = [
+    ...new Map(
+      legacyConfigRoots
+        .filter((candidate) => typeof candidate === 'string' && win32.isAbsolute(candidate))
+        .map((candidate) => [win32.resolve(candidate).toLowerCase(), candidate])
+    ).values()
+  ]
+  if (candidates.length === 0) {
+    throw new Error('Installed app did not report an absolute Windows config root.')
+  }
+  const endpointToken = auth ? new URLSearchParams(auth).get('token') : undefined
+  if (!endpointToken) {
+    throw new Error('Cannot authenticate the legacy installed app config root without its token.')
+  }
+  // Older packaged builds do not report configRoot. Electron has ignored the child USERPROFILE in
+  // hosted runs, but retain the isolated profile as a compatibility candidate. The endpoint token
+  // authenticates whichever directory the previous app actually used instead of trusting either.
+  for (const candidate of candidates) {
+    try {
+      const storedToken = (await readToken(win32.join(candidate, 'web-token'), 'utf8')).trim()
+      if (storedToken === endpointToken) return candidate
+    } catch {
+      // Try the next authenticated candidate.
+    }
+  }
+  throw new Error('Cannot authenticate the legacy installed app config root from its token file.')
+}
+
+const terminateProcessTree = async (
+  child,
+  timeoutMs = TERMINATION_TIMEOUT_MS,
+  spawnProcess = spawn
+) => {
   if (!child.pid) return
-  await new Promise((resolveTermination) => {
-    const terminator = spawn('taskkill.exe', ['/pid', String(child.pid), '/T', '/F'], {
+  const killDirectly = () => {
+    try {
+      child.kill()
+    } catch {
+      // Best effort: the process may already have exited between the timeout and fallback.
+    }
+  }
+  let terminator
+  try {
+    terminator = spawnProcess('taskkill.exe', ['/pid', String(child.pid), '/T', '/F'], {
+      stdio: 'ignore',
       windowsHide: true
     })
-    terminator.once('error', () => resolveTermination())
-    terminator.once('exit', () => resolveTermination())
+  } catch {
+    killDirectly()
+    return
+  }
+  await new Promise((resolveTermination) => {
+    let settled = false
+    const finish = () => {
+      if (settled) return
+      settled = true
+      clearTimeout(timer)
+      resolveTermination()
+    }
+    const timer = setTimeout(() => {
+      try {
+        terminator.kill()
+      } catch {
+        // The taskkill process may have exited without delivering its event yet.
+      }
+      terminator.unref?.()
+      killDirectly()
+      finish()
+    }, timeoutMs)
+    terminator.once('error', () => {
+      killDirectly()
+      finish()
+    })
+    terminator.once('exit', (code) => {
+      if (code !== 0 && code !== null) killDirectly()
+      finish()
+    })
   })
 }
 
-const runProcess = (executable, args, options = {}) =>
+const runProcess = (executable, args, options = {}, terminate = terminateProcessTree) =>
   new Promise((resolveProcess, rejectProcess) => {
     const child = spawn(executable, args, {
       cwd: options.cwd,
@@ -113,6 +203,7 @@ const runProcess = (executable, args, options = {}) =>
     let stdout = ''
     let stderr = ''
     let settled = false
+    let timedOut = false
 
     child.stdout?.setEncoding('utf8')
     child.stderr?.setEncoding('utf8')
@@ -132,17 +223,24 @@ const runProcess = (executable, args, options = {}) =>
     }
 
     const timer = setTimeout(() => {
-      void terminateProcessTree(child).finally(() => {
+      timedOut = true
+      const finishTimeout = () => {
         finish(
           new Error(
             `${basename(executable)} timed out after ${options.timeoutMs ?? PROCESS_TIMEOUT_MS}ms.`
           )
         )
-      })
+      }
+      void Promise.resolve()
+        .then(() => terminate(child))
+        .then(finishTimeout, finishTimeout)
     }, options.timeoutMs ?? PROCESS_TIMEOUT_MS)
 
-    child.once('error', (error) => finish(error))
+    child.once('error', (error) => {
+      if (!timedOut) finish(error)
+    })
     child.once('exit', (code) => {
+      if (timedOut) return
       if (code !== 0 && !options.allowNonZero) {
         finish(
           new Error(
@@ -240,19 +338,20 @@ const assertPackagedResources = async (installDirectory) => {
   }
 }
 
-const upgradeSentinelPath = (profileDirectory) =>
-  join(profileDirectory, CONFIG_DIRECTORY, UPGRADE_SENTINEL_NAME)
+const upgradeSentinelPath = (configRoot, sentinelName) => join(configRoot, sentinelName)
 
-const writeUpgradeSentinel = async (profileDirectory) => {
-  const configDirectory = join(profileDirectory, CONFIG_DIRECTORY)
-  await mkdir(configDirectory, { recursive: true })
-  await writeFile(upgradeSentinelPath(profileDirectory), UPGRADE_SENTINEL_CONTENT, 'utf8')
+const writeUpgradeSentinel = async (configRoot, sentinelName) => {
+  await mkdir(configRoot, { recursive: true })
+  await writeFile(upgradeSentinelPath(configRoot, sentinelName), UPGRADE_SENTINEL_CONTENT, {
+    encoding: 'utf8',
+    flag: 'wx'
+  })
 }
 
-const assertUpgradeProfilePreserved = async (profileDirectory) => {
+const assertUpgradeProfilePreserved = async (configRoot, sentinelName) => {
   let content
   try {
-    content = await readFile(upgradeSentinelPath(profileDirectory), 'utf8')
+    content = await readFile(upgradeSentinelPath(configRoot, sentinelName), 'utf8')
   } catch {
     throw new Error('The Windows upgrade did not preserve the previous application profile.')
   }
@@ -261,7 +360,48 @@ const assertUpgradeProfilePreserved = async (profileDirectory) => {
   }
 }
 
-const launchAndProbe = async ({ installDirectory, expectedVersion, env }) => {
+const createUpgradeProfileGuard = (
+  enabled,
+  sentinelName = `${UPGRADE_SENTINEL_PREFIX}${randomUUID()}`
+) => {
+  let previousConfigRoot
+  let sentinelCreated = false
+
+  const verifyCycle = async (phase, configRoot) => {
+    if (!enabled) return
+    if (phase === 'previous') {
+      previousConfigRoot = configRoot
+      await writeUpgradeSentinel(configRoot, sentinelName)
+      sentinelCreated = true
+      return
+    }
+    if (!previousConfigRoot) {
+      throw new Error('The Windows upgrade did not report the previous application config root.')
+    }
+    if (resolve(previousConfigRoot).toLowerCase() !== resolve(configRoot).toLowerCase()) {
+      throw new Error(
+        `The Windows upgrade config root changed from ${previousConfigRoot} to ${configRoot}.`
+      )
+    }
+    await assertUpgradeProfilePreserved(configRoot, sentinelName)
+  }
+
+  const cleanup = async (primaryError) => {
+    if (!sentinelCreated || !previousConfigRoot) return
+    try {
+      await rm(upgradeSentinelPath(previousConfigRoot, sentinelName), { force: true })
+      sentinelCreated = false
+    } catch (cleanupError) {
+      if (!primaryError) throw cleanupError
+      const message = cleanupError instanceof Error ? cleanupError.message : String(cleanupError)
+      console.warn(`Windows upgrade sentinel cleanup also failed: ${message}`)
+    }
+  }
+
+  return { cleanup, verifyCycle }
+}
+
+const launchAndProbe = async ({ installDirectory, expectedVersion, env, legacyConfigRoots }) => {
   const executable = join(installDirectory, APP_EXECUTABLE)
 
   const child = spawn(executable, ['--open-science-headless', '--serve=0'], {
@@ -294,17 +434,15 @@ const launchAndProbe = async ({ installDirectory, expectedVersion, env }) => {
     if (!response.ok)
       throw new Error(`Installed app health probe returned HTTP ${response.status}.`)
     const bootstrap = await response.json()
-    if (
-      bootstrap.appName !== 'Open Science' ||
-      bootstrap.appVersion !== expectedVersion ||
-      bootstrap.platform !== 'win32'
-    ) {
-      throw new Error(`Unexpected installed app bootstrap: ${JSON.stringify(bootstrap)}`)
-    }
+    const configRoot = await readPackagedAppConfigRoot(bootstrap, expectedVersion, {
+      auth,
+      legacyConfigRoots
+    })
 
     await requestPackagedAppShutdown(endpoint, auth)
     const exitCode = await waitForShutdownExit(exit, child, output)
     if (exitCode !== 0) throw new Error(`Installed app exited with ${exitCode}.\n${output()}`)
+    return configRoot
   } catch (error) {
     await terminateProcessTree(child)
     const processOutput = output().trim()
@@ -315,15 +453,16 @@ const launchAndProbe = async ({ installDirectory, expectedVersion, env }) => {
   }
 }
 
-const installAndProbe = async ({ installer, installDirectory, phase, env }) => {
+const installAndProbe = async ({ installer, installDirectory, phase, env, legacyConfigRoots }) => {
   console.log(`Smoke testing ${phase} installer: ${basename(installer)}`)
   await runProcess(installer, ['/S', `/D=${installDirectory}`], { env })
   await assertPackagedResources(installDirectory)
   await runProcess(join(installDirectory, 'resources', 'micromamba.exe'), ['--version'], { env })
-  await launchAndProbe({
+  return launchAndProbe({
     installDirectory,
     expectedVersion: installerVersion(installer),
-    env
+    env,
+    legacyConfigRoots
   })
 }
 
@@ -397,7 +536,12 @@ const main = async () => {
   const root = await mkdtemp(join(process.env.RUNNER_TEMP || tmpdir(), SMOKE_ROOT_PREFIX))
   const installDirectory = join(root, 'app')
   const profileDirectory = join(root, 'profile')
+  const legacyConfigRoots = [
+    win32.join(homedir(), CONFIG_DIRECTORY),
+    win32.join(profileDirectory, CONFIG_DIRECTORY)
+  ]
   const env = windowsProfileEnvironment(profileDirectory)
+  const upgradeProfileGuard = createUpgradeProfileGuard(Boolean(previousInstaller))
   await Promise.all([
     mkdir(env.APPDATA, { recursive: true }),
     mkdir(env.LOCALAPPDATA, { recursive: true }),
@@ -409,22 +553,30 @@ const main = async () => {
     await executeSmokePlan(
       buildSmokePlan({ currentInstaller, previousInstaller }),
       async (cycle) => {
-        await installAndProbe({ ...cycle, installDirectory, env })
-        if (previousInstaller && cycle.phase === 'previous') {
-          await writeUpgradeSentinel(profileDirectory)
-        } else if (previousInstaller && cycle.phase === 'current') {
-          await assertUpgradeProfilePreserved(profileDirectory)
-        }
+        const configRoot = await installAndProbe({
+          ...cycle,
+          installDirectory,
+          env,
+          legacyConfigRoots: cycle.phase === 'previous' ? legacyConfigRoots : undefined
+        })
+        await upgradeProfileGuard.verifyCycle(cycle.phase, configRoot)
       }
     )
     await uninstallAndVerify(installDirectory, env)
     console.log('Windows installer smoke completed successfully.')
   } catch (error) {
     primaryError = error
-    throw error
-  } finally {
-    await cleanupSmokeRoot(root, primaryError)
   }
+
+  let sentinelCleanupError
+  try {
+    await upgradeProfileGuard.cleanup(primaryError)
+  } catch (error) {
+    sentinelCleanupError = error
+  }
+  await cleanupSmokeRoot(root, primaryError ?? sentinelCleanupError)
+  if (primaryError) throw primaryError
+  if (sentinelCleanupError) throw sentinelCleanupError
 }
 
 const invokedAsScript =
@@ -440,13 +592,17 @@ export {
   assertUpgradeProfilePreserved,
   buildSmokePlan,
   cleanupSmokeRoot,
+  createUpgradeProfileGuard,
   executeSmokePlan,
   fetchWithTimeout,
   findSetupInstaller,
   installerVersion,
   packagedResourcePaths,
   parsePackagedAppEndpoint,
+  readPackagedAppConfigRoot,
   requestPackagedAppShutdown,
+  runProcess,
+  terminateProcessTree,
   waitForShutdownExit,
   windowsProfileEnvironment,
   writeUpgradeSentinel

--- a/scripts/windows-installer-smoke.mjs
+++ b/scripts/windows-installer-smoke.mjs
@@ -63,6 +63,19 @@ const fetchWithTimeout = (
   fetchImpl = fetch
 ) => fetchImpl(input, { ...init, signal: AbortSignal.timeout(timeoutMs) })
 
+const requestPackagedAppShutdown = async (endpoint, auth, fetchImpl = fetchWithTimeout) => {
+  const response = await fetchImpl(`${endpoint}/api/shutdown?${auth}`, { method: 'POST' })
+  // Drain the response before waiting for Electron to exit. Leaving an Undici response body unread
+  // keeps its HTTP connection active, while the app's quit path waits for the web server to close.
+  // Waiting for exit first would therefore deadlock the smoke harness against the app under test.
+  const body = await response.text()
+  if (response.status !== 202) {
+    throw new Error(
+      `Installed app shutdown returned HTTP ${response.status}.${body ? ` ${body}` : ''}`
+    )
+  }
+}
+
 const terminateProcessTree = async (child) => {
   if (!child.pid) return
   await new Promise((resolveTermination) => {
@@ -267,10 +280,7 @@ const launchAndProbe = async ({ installDirectory, profileDirectory, expectedVers
       throw new Error(`Unexpected installed app bootstrap: ${JSON.stringify(bootstrap)}`)
     }
 
-    const shutdown = await fetchWithTimeout(`${endpoint}/api/shutdown?${auth}`, { method: 'POST' })
-    if (shutdown.status !== 202) {
-      throw new Error(`Installed app shutdown returned HTTP ${shutdown.status}.`)
-    }
+    await requestPackagedAppShutdown(endpoint, auth)
     const exitCode = await exit
     if (exitCode !== 0) throw new Error(`Installed app exited with ${exitCode}.\n${output()}`)
   } catch (error) {
@@ -414,6 +424,7 @@ export {
   findSetupInstaller,
   installerVersion,
   packagedResourcePaths,
+  requestPackagedAppShutdown,
   windowsProfileEnvironment,
   writeUpgradeSentinel
 }

--- a/scripts/windows-installer-smoke.mjs
+++ b/scripts/windows-installer-smoke.mjs
@@ -176,6 +176,19 @@ const packagedResourcePaths = (installDirectory) => [
   )
 ]
 
+const windowsProfileEnvironment = (profileDirectory, baseEnvironment = process.env) => {
+  const temporaryDirectory = join(profileDirectory, 'Temp')
+  return {
+    ...baseEnvironment,
+    HOME: profileDirectory,
+    USERPROFILE: profileDirectory,
+    APPDATA: join(profileDirectory, 'AppData', 'Roaming'),
+    LOCALAPPDATA: join(profileDirectory, 'AppData', 'Local'),
+    TEMP: temporaryDirectory,
+    TMP: temporaryDirectory
+  }
+}
+
 const assertPackagedResources = async (installDirectory) => {
   for (const path of packagedResourcePaths(installDirectory)) {
     if (!(await pathExists(path))) throw new Error(`Packaged Windows resource is missing: ${path}`)
@@ -203,31 +216,15 @@ const assertUpgradeProfilePreserved = async (profileDirectory) => {
   }
 }
 
-const launchAndProbe = async ({ installDirectory, profileDirectory, expectedVersion }) => {
+const launchAndProbe = async ({ installDirectory, profileDirectory, expectedVersion, env }) => {
   const executable = join(installDirectory, APP_EXECUTABLE)
   const configRoot = join(profileDirectory, CONFIG_DIRECTORY)
   const statePath = join(configRoot, 'web-service.json')
   const tokenPath = join(configRoot, 'web-token')
-  const appData = join(profileDirectory, 'AppData', 'Roaming')
-  const localAppData = join(profileDirectory, 'AppData', 'Local')
-  const temporaryDirectory = join(profileDirectory, 'Temp')
-  await Promise.all([
-    mkdir(appData, { recursive: true }),
-    mkdir(localAppData, { recursive: true }),
-    mkdir(temporaryDirectory, { recursive: true }),
-    rm(statePath, { force: true })
-  ])
+  await rm(statePath, { force: true })
 
   const child = spawn(executable, ['--open-science-headless', '--serve=0'], {
-    env: {
-      ...process.env,
-      HOME: profileDirectory,
-      USERPROFILE: profileDirectory,
-      APPDATA: appData,
-      LOCALAPPDATA: localAppData,
-      TEMP: temporaryDirectory,
-      TMP: temporaryDirectory
-    },
+    env,
     windowsHide: true
   })
   let stdout = ''
@@ -278,19 +275,24 @@ const launchAndProbe = async ({ installDirectory, profileDirectory, expectedVers
     if (exitCode !== 0) throw new Error(`Installed app exited with ${exitCode}.\n${output()}`)
   } catch (error) {
     await terminateProcessTree(child)
+    const processOutput = output().trim()
+    if (error instanceof Error && processOutput && !error.message.includes(processOutput)) {
+      error.message += `\n${processOutput}`
+    }
     throw error
   }
 }
 
-const installAndProbe = async ({ installer, installDirectory, profileDirectory, phase }) => {
+const installAndProbe = async ({ installer, installDirectory, profileDirectory, phase, env }) => {
   console.log(`Smoke testing ${phase} installer: ${basename(installer)}`)
-  await runProcess(installer, ['/S', `/D=${installDirectory}`])
+  await runProcess(installer, ['/S', `/D=${installDirectory}`], { env })
   await assertPackagedResources(installDirectory)
-  await runProcess(join(installDirectory, 'resources', 'micromamba.exe'), ['--version'])
+  await runProcess(join(installDirectory, 'resources', 'micromamba.exe'), ['--version'], { env })
   await launchAndProbe({
     installDirectory,
     profileDirectory,
-    expectedVersion: installerVersion(installer)
+    expectedVersion: installerVersion(installer),
+    env
   })
 }
 
@@ -303,10 +305,13 @@ const findUninstaller = async (installDirectory) => {
   return join(installDirectory, uninstallers[0])
 }
 
-const uninstallAndVerify = async (installDirectory) => {
+const uninstallAndVerify = async (installDirectory, env) => {
   const uninstaller = await findUninstaller(installDirectory)
   const installedPaths = [...packagedResourcePaths(installDirectory), uninstaller]
-  const result = await runProcess(uninstaller, ['/S', '/KEEP_APP_DATA'], { allowNonZero: true })
+  const result = await runProcess(uninstaller, ['/S', '/KEEP_APP_DATA'], {
+    allowNonZero: true,
+    env
+  })
   await waitFor('the installed application files to be removed', async () => {
     const pathsRemain = (await Promise.all(installedPaths.map(pathExists))).some(Boolean)
     if (pathsRemain) return undefined
@@ -338,7 +343,17 @@ const removeSmokeRoot = async (root) => {
   if (!basename(root).startsWith(SMOKE_ROOT_PREFIX)) {
     throw new Error(`Refusing to remove unexpected smoke root: ${root}`)
   }
-  await rm(root, { force: true, recursive: true })
+  await rm(root, { force: true, maxRetries: 10, recursive: true, retryDelay: 500 })
+}
+
+const cleanupSmokeRoot = async (root, primaryError, remove = removeSmokeRoot) => {
+  try {
+    await remove(root)
+  } catch (cleanupError) {
+    if (!primaryError) throw cleanupError
+    const message = cleanupError instanceof Error ? cleanupError.message : String(cleanupError)
+    console.warn(`Windows installer smoke cleanup also failed: ${message}`)
+  }
 }
 
 const main = async () => {
@@ -351,12 +366,19 @@ const main = async () => {
   const root = await mkdtemp(join(process.env.RUNNER_TEMP || tmpdir(), SMOKE_ROOT_PREFIX))
   const installDirectory = join(root, 'app')
   const profileDirectory = join(root, 'profile')
+  const env = windowsProfileEnvironment(profileDirectory)
+  await Promise.all([
+    mkdir(env.APPDATA, { recursive: true }),
+    mkdir(env.LOCALAPPDATA, { recursive: true }),
+    mkdir(env.TEMP, { recursive: true })
+  ])
 
+  let primaryError
   try {
     await executeSmokePlan(
       buildSmokePlan({ currentInstaller, previousInstaller }),
       async (cycle) => {
-        await installAndProbe({ ...cycle, installDirectory, profileDirectory })
+        await installAndProbe({ ...cycle, installDirectory, profileDirectory, env })
         if (previousInstaller && cycle.phase === 'previous') {
           await writeUpgradeSentinel(profileDirectory)
         } else if (previousInstaller && cycle.phase === 'current') {
@@ -364,10 +386,13 @@ const main = async () => {
         }
       }
     )
-    await uninstallAndVerify(installDirectory)
+    await uninstallAndVerify(installDirectory, env)
     console.log('Windows installer smoke completed successfully.')
+  } catch (error) {
+    primaryError = error
+    throw error
   } finally {
-    await removeSmokeRoot(root)
+    await cleanupSmokeRoot(root, primaryError)
   }
 }
 
@@ -383,10 +408,12 @@ if (invokedAsScript) {
 export {
   assertUpgradeProfilePreserved,
   buildSmokePlan,
+  cleanupSmokeRoot,
   executeSmokePlan,
   fetchWithTimeout,
   findSetupInstaller,
   installerVersion,
   packagedResourcePaths,
+  windowsProfileEnvironment,
   writeUpgradeSentinel
 }

--- a/scripts/windows-installer-smoke.mjs
+++ b/scripts/windows-installer-smoke.mjs
@@ -1,0 +1,392 @@
+/* eslint-disable @typescript-eslint/explicit-function-return-type */
+
+import { spawn } from 'node:child_process'
+import { access, mkdir, mkdtemp, readFile, readdir, rm, writeFile } from 'node:fs/promises'
+import { tmpdir } from 'node:os'
+import { basename, join, resolve } from 'node:path'
+import { pathToFileURL } from 'node:url'
+
+const APP_EXECUTABLE = 'open-science.exe'
+const CONFIG_DIRECTORY = '.open-science'
+const PROCESS_TIMEOUT_MS = 120_000
+const STARTUP_TIMEOUT_MS = 60_000
+const HTTP_REQUEST_TIMEOUT_MS = 15_000
+const SMOKE_ROOT_PREFIX = 'open-science-installer-smoke-'
+const UPGRADE_SENTINEL_NAME = 'installer-smoke-upgrade-sentinel'
+const UPGRADE_SENTINEL_CONTENT = 'previous-version-profile-preserved\n'
+
+const delay = (milliseconds) =>
+  new Promise((resolveDelay) => setTimeout(resolveDelay, milliseconds))
+
+const pathExists = async (path) => {
+  try {
+    await access(path)
+    return true
+  } catch {
+    return false
+  }
+}
+
+const findSetupInstaller = async (directory) => {
+  const entries = await readdir(directory, { withFileTypes: true })
+  const candidates = entries
+    .filter((entry) => entry.isFile() && /-win-x64-setup\.exe$/i.test(entry.name))
+    .map((entry) => join(directory, entry.name))
+
+  if (candidates.length !== 1) {
+    throw new Error(
+      `Expected exactly one Windows setup executable in ${directory}; found ${candidates.length}.`
+    )
+  }
+  return candidates[0]
+}
+
+const installerVersion = (installer) => {
+  const match = basename(installer).match(/^aipoch-open-science-(.+)-win-x64-setup\.exe$/i)
+  if (!match) throw new Error(`Cannot derive the app version from installer: ${installer}`)
+  return match[1]
+}
+
+const buildSmokePlan = ({ currentInstaller, previousInstaller }) => [
+  ...(previousInstaller ? [{ installer: previousInstaller, phase: 'previous' }] : []),
+  { installer: currentInstaller, phase: 'current' }
+]
+
+const executeSmokePlan = async (plan, runCycle) => {
+  for (const cycle of plan) await runCycle(cycle)
+}
+
+const fetchWithTimeout = (
+  input,
+  init = {},
+  timeoutMs = HTTP_REQUEST_TIMEOUT_MS,
+  fetchImpl = fetch
+) => fetchImpl(input, { ...init, signal: AbortSignal.timeout(timeoutMs) })
+
+const terminateProcessTree = async (child) => {
+  if (!child.pid) return
+  await new Promise((resolveTermination) => {
+    const terminator = spawn('taskkill.exe', ['/pid', String(child.pid), '/T', '/F'], {
+      windowsHide: true
+    })
+    terminator.once('error', () => resolveTermination())
+    terminator.once('exit', () => resolveTermination())
+  })
+}
+
+const runProcess = (executable, args, options = {}) =>
+  new Promise((resolveProcess, rejectProcess) => {
+    const child = spawn(executable, args, {
+      cwd: options.cwd,
+      env: options.env,
+      windowsHide: true
+    })
+    let stdout = ''
+    let stderr = ''
+    let settled = false
+
+    child.stdout?.setEncoding('utf8')
+    child.stderr?.setEncoding('utf8')
+    child.stdout?.on('data', (chunk) => {
+      stdout += chunk
+    })
+    child.stderr?.on('data', (chunk) => {
+      stderr += chunk
+    })
+
+    const finish = (error, code) => {
+      if (settled) return
+      settled = true
+      clearTimeout(timer)
+      if (error) rejectProcess(error)
+      else resolveProcess({ code, stdout, stderr })
+    }
+
+    const timer = setTimeout(() => {
+      void terminateProcessTree(child).finally(() => {
+        finish(
+          new Error(
+            `${basename(executable)} timed out after ${options.timeoutMs ?? PROCESS_TIMEOUT_MS}ms.`
+          )
+        )
+      })
+    }, options.timeoutMs ?? PROCESS_TIMEOUT_MS)
+
+    child.once('error', (error) => finish(error))
+    child.once('exit', (code) => {
+      if (code !== 0 && !options.allowNonZero) {
+        finish(
+          new Error(
+            `${basename(executable)} exited with ${code}.\n${stdout}${stderr ? `\n${stderr}` : ''}`
+          )
+        )
+        return
+      }
+      finish(undefined, code)
+    })
+  })
+
+const waitFor = async (description, check, timeoutMs = STARTUP_TIMEOUT_MS) => {
+  const deadline = Date.now() + timeoutMs
+  let lastError
+  while (Date.now() < deadline) {
+    try {
+      const value = await check()
+      if (value !== undefined && value !== false) return value
+    } catch (error) {
+      lastError = error
+    }
+    await delay(250)
+  }
+  throw new Error(
+    `Timed out waiting for ${description}.${lastError instanceof Error ? ` ${lastError.message}` : ''}`
+  )
+}
+
+const waitForChildExit = (child, timeoutMs, output) =>
+  new Promise((resolveExit, rejectExit) => {
+    let settled = false
+    const finish = (error, code) => {
+      if (settled) return
+      settled = true
+      clearTimeout(timer)
+      if (error) rejectExit(error)
+      else resolveExit(code)
+    }
+    const timer = setTimeout(() => {
+      void terminateProcessTree(child).finally(() => {
+        finish(new Error(`Installed app did not exit after shutdown.\n${output()}`))
+      })
+    }, timeoutMs)
+    child.once('error', (error) => finish(error))
+    child.once('exit', (code) => finish(undefined, code))
+  })
+
+const packagedResourcePaths = (installDirectory) => [
+  join(installDirectory, APP_EXECUTABLE),
+  join(installDirectory, 'resources', 'app.asar'),
+  join(installDirectory, 'resources', 'micromamba.exe'),
+  join(
+    installDirectory,
+    'resources',
+    'node_modules',
+    '.prisma',
+    'client',
+    'query_engine-windows.dll.node'
+  )
+]
+
+const assertPackagedResources = async (installDirectory) => {
+  for (const path of packagedResourcePaths(installDirectory)) {
+    if (!(await pathExists(path))) throw new Error(`Packaged Windows resource is missing: ${path}`)
+  }
+}
+
+const upgradeSentinelPath = (profileDirectory) =>
+  join(profileDirectory, CONFIG_DIRECTORY, UPGRADE_SENTINEL_NAME)
+
+const writeUpgradeSentinel = async (profileDirectory) => {
+  const configDirectory = join(profileDirectory, CONFIG_DIRECTORY)
+  await mkdir(configDirectory, { recursive: true })
+  await writeFile(upgradeSentinelPath(profileDirectory), UPGRADE_SENTINEL_CONTENT, 'utf8')
+}
+
+const assertUpgradeProfilePreserved = async (profileDirectory) => {
+  let content
+  try {
+    content = await readFile(upgradeSentinelPath(profileDirectory), 'utf8')
+  } catch {
+    throw new Error('The Windows upgrade did not preserve the previous application profile.')
+  }
+  if (content !== UPGRADE_SENTINEL_CONTENT) {
+    throw new Error('The Windows upgrade did not preserve the previous application profile.')
+  }
+}
+
+const launchAndProbe = async ({ installDirectory, profileDirectory, expectedVersion }) => {
+  const executable = join(installDirectory, APP_EXECUTABLE)
+  const configRoot = join(profileDirectory, CONFIG_DIRECTORY)
+  const statePath = join(configRoot, 'web-service.json')
+  const tokenPath = join(configRoot, 'web-token')
+  const appData = join(profileDirectory, 'AppData', 'Roaming')
+  const localAppData = join(profileDirectory, 'AppData', 'Local')
+  const temporaryDirectory = join(profileDirectory, 'Temp')
+  await Promise.all([
+    mkdir(appData, { recursive: true }),
+    mkdir(localAppData, { recursive: true }),
+    mkdir(temporaryDirectory, { recursive: true }),
+    rm(statePath, { force: true })
+  ])
+
+  const child = spawn(executable, ['--open-science-headless', '--serve=0'], {
+    env: {
+      ...process.env,
+      HOME: profileDirectory,
+      USERPROFILE: profileDirectory,
+      APPDATA: appData,
+      LOCALAPPDATA: localAppData,
+      TEMP: temporaryDirectory,
+      TMP: temporaryDirectory
+    },
+    windowsHide: true
+  })
+  let stdout = ''
+  let stderr = ''
+  child.stdout?.setEncoding('utf8')
+  child.stderr?.setEncoding('utf8')
+  child.stdout?.on('data', (chunk) => {
+    stdout += chunk
+  })
+  child.stderr?.on('data', (chunk) => {
+    stderr += chunk
+  })
+  const output = () => `${stdout}${stderr ? `\n${stderr}` : ''}`
+  const exit = waitForChildExit(child, STARTUP_TIMEOUT_MS, output)
+
+  try {
+    const { state, token } = await Promise.race([
+      waitFor('the installed app web service', async () => {
+        if (!(await pathExists(statePath)) || !(await pathExists(tokenPath))) return undefined
+        return {
+          state: JSON.parse(await readFile(statePath, 'utf8')),
+          token: (await readFile(tokenPath, 'utf8')).trim()
+        }
+      }),
+      exit.then((code) => {
+        throw new Error(`Installed app exited before becoming healthy (${code}).\n${output()}`)
+      })
+    ])
+    const endpoint = `http://127.0.0.1:${state.port}`
+    const auth = `token=${encodeURIComponent(token)}`
+    const response = await fetchWithTimeout(`${endpoint}/api/bootstrap?${auth}`)
+    if (!response.ok)
+      throw new Error(`Installed app health probe returned HTTP ${response.status}.`)
+    const bootstrap = await response.json()
+    if (
+      bootstrap.appName !== 'Open Science' ||
+      bootstrap.appVersion !== expectedVersion ||
+      bootstrap.platform !== 'win32'
+    ) {
+      throw new Error(`Unexpected installed app bootstrap: ${JSON.stringify(bootstrap)}`)
+    }
+
+    const shutdown = await fetchWithTimeout(`${endpoint}/api/shutdown?${auth}`, { method: 'POST' })
+    if (shutdown.status !== 202) {
+      throw new Error(`Installed app shutdown returned HTTP ${shutdown.status}.`)
+    }
+    const exitCode = await exit
+    if (exitCode !== 0) throw new Error(`Installed app exited with ${exitCode}.\n${output()}`)
+  } catch (error) {
+    await terminateProcessTree(child)
+    throw error
+  }
+}
+
+const installAndProbe = async ({ installer, installDirectory, profileDirectory, phase }) => {
+  console.log(`Smoke testing ${phase} installer: ${basename(installer)}`)
+  await runProcess(installer, ['/S', `/D=${installDirectory}`])
+  await assertPackagedResources(installDirectory)
+  await runProcess(join(installDirectory, 'resources', 'micromamba.exe'), ['--version'])
+  await launchAndProbe({
+    installDirectory,
+    profileDirectory,
+    expectedVersion: installerVersion(installer)
+  })
+}
+
+const findUninstaller = async (installDirectory) => {
+  const names = await readdir(installDirectory)
+  const uninstallers = names.filter((name) => /^Uninstall .+\.exe$/i.test(name))
+  if (uninstallers.length !== 1) {
+    throw new Error(`Expected one Windows uninstaller; found ${uninstallers.length}.`)
+  }
+  return join(installDirectory, uninstallers[0])
+}
+
+const uninstallAndVerify = async (installDirectory) => {
+  const uninstaller = await findUninstaller(installDirectory)
+  const installedPaths = [...packagedResourcePaths(installDirectory), uninstaller]
+  const result = await runProcess(uninstaller, ['/S', '/KEEP_APP_DATA'], { allowNonZero: true })
+  await waitFor('the installed application files to be removed', async () => {
+    const pathsRemain = (await Promise.all(installedPaths.map(pathExists))).some(Boolean)
+    if (pathsRemain) return undefined
+    if (!(await pathExists(installDirectory))) return true
+    return (await readdir(installDirectory)).length === 0 || undefined
+  })
+  if (result.code !== 0) {
+    console.warn(`Uninstaller reported ${result.code} after removing the application files.`)
+  }
+}
+
+const parseArguments = (argv) => {
+  const valueFor = (name) => {
+    const index = argv.indexOf(name)
+    return index === -1 ? undefined : argv[index + 1]
+  }
+  const installerDirectory = valueFor('--installer-dir')
+  if (!installerDirectory)
+    throw new Error('Usage: --installer-dir <path> [--previous-installer-dir <path>]')
+  return {
+    installerDirectory: resolve(installerDirectory),
+    previousInstallerDirectory: valueFor('--previous-installer-dir')
+      ? resolve(valueFor('--previous-installer-dir'))
+      : undefined
+  }
+}
+
+const removeSmokeRoot = async (root) => {
+  if (!basename(root).startsWith(SMOKE_ROOT_PREFIX)) {
+    throw new Error(`Refusing to remove unexpected smoke root: ${root}`)
+  }
+  await rm(root, { force: true, recursive: true })
+}
+
+const main = async () => {
+  if (process.platform !== 'win32') throw new Error('Windows installer smoke requires Windows.')
+  const options = parseArguments(process.argv.slice(2))
+  const currentInstaller = await findSetupInstaller(options.installerDirectory)
+  const previousInstaller = options.previousInstallerDirectory
+    ? await findSetupInstaller(options.previousInstallerDirectory)
+    : undefined
+  const root = await mkdtemp(join(process.env.RUNNER_TEMP || tmpdir(), SMOKE_ROOT_PREFIX))
+  const installDirectory = join(root, 'app')
+  const profileDirectory = join(root, 'profile')
+
+  try {
+    await executeSmokePlan(
+      buildSmokePlan({ currentInstaller, previousInstaller }),
+      async (cycle) => {
+        await installAndProbe({ ...cycle, installDirectory, profileDirectory })
+        if (previousInstaller && cycle.phase === 'previous') {
+          await writeUpgradeSentinel(profileDirectory)
+        } else if (previousInstaller && cycle.phase === 'current') {
+          await assertUpgradeProfilePreserved(profileDirectory)
+        }
+      }
+    )
+    await uninstallAndVerify(installDirectory)
+    console.log('Windows installer smoke completed successfully.')
+  } finally {
+    await removeSmokeRoot(root)
+  }
+}
+
+const invokedAsScript =
+  process.argv[1] !== undefined && import.meta.url === pathToFileURL(resolve(process.argv[1])).href
+if (invokedAsScript) {
+  main().catch((error) => {
+    console.error(error)
+    process.exitCode = 1
+  })
+}
+
+export {
+  assertUpgradeProfilePreserved,
+  buildSmokePlan,
+  executeSmokePlan,
+  fetchWithTimeout,
+  findSetupInstaller,
+  installerVersion,
+  packagedResourcePaths,
+  writeUpgradeSentinel
+}

--- a/scripts/windows-installer-smoke.mjs
+++ b/scripts/windows-installer-smoke.mjs
@@ -10,6 +10,7 @@ const APP_EXECUTABLE = 'open-science.exe'
 const CONFIG_DIRECTORY = '.open-science'
 const PROCESS_TIMEOUT_MS = 120_000
 const STARTUP_TIMEOUT_MS = 60_000
+const SHUTDOWN_TIMEOUT_MS = 60_000
 const HTTP_REQUEST_TIMEOUT_MS = 15_000
 const SMOKE_ROOT_PREFIX = 'open-science-installer-smoke-'
 const UPGRADE_SENTINEL_NAME = 'installer-smoke-upgrade-sentinel'
@@ -156,7 +157,19 @@ const waitFor = async (description, check, timeoutMs = STARTUP_TIMEOUT_MS) => {
   )
 }
 
-const waitForChildExit = (child, timeoutMs, output) =>
+const observeChildExit = (child) =>
+  new Promise((resolveExit, rejectExit) => {
+    child.once('error', rejectExit)
+    child.once('exit', resolveExit)
+  })
+
+const waitForShutdownExit = (
+  exit,
+  child,
+  output,
+  timeoutMs = SHUTDOWN_TIMEOUT_MS,
+  terminate = terminateProcessTree
+) =>
   new Promise((resolveExit, rejectExit) => {
     let settled = false
     const finish = (error, code) => {
@@ -167,12 +180,16 @@ const waitForChildExit = (child, timeoutMs, output) =>
       else resolveExit(code)
     }
     const timer = setTimeout(() => {
-      void terminateProcessTree(child).finally(() => {
-        finish(new Error(`Installed app did not exit after shutdown.\n${output()}`))
+      if (settled) return
+      settled = true
+      void terminate(child).finally(() => {
+        rejectExit(new Error(`Installed app did not exit after shutdown.\n${output()}`))
       })
     }, timeoutMs)
-    child.once('error', (error) => finish(error))
-    child.once('exit', (code) => finish(undefined, code))
+    exit.then(
+      (code) => finish(undefined, code),
+      (error) => finish(error)
+    )
   })
 
 const packagedResourcePaths = (installDirectory) => [
@@ -251,7 +268,7 @@ const launchAndProbe = async ({ installDirectory, profileDirectory, expectedVers
     stderr += chunk
   })
   const output = () => `${stdout}${stderr ? `\n${stderr}` : ''}`
-  const exit = waitForChildExit(child, STARTUP_TIMEOUT_MS, output)
+  const exit = observeChildExit(child)
 
   try {
     const { state, token } = await Promise.race([
@@ -281,7 +298,7 @@ const launchAndProbe = async ({ installDirectory, profileDirectory, expectedVers
     }
 
     await requestPackagedAppShutdown(endpoint, auth)
-    const exitCode = await exit
+    const exitCode = await waitForShutdownExit(exit, child, output)
     if (exitCode !== 0) throw new Error(`Installed app exited with ${exitCode}.\n${output()}`)
   } catch (error) {
     await terminateProcessTree(child)
@@ -425,6 +442,7 @@ export {
   installerVersion,
   packagedResourcePaths,
   requestPackagedAppShutdown,
+  waitForShutdownExit,
   windowsProfileEnvironment,
   writeUpgradeSentinel
 }

--- a/scripts/windows-installer-smoke.mjs
+++ b/scripts/windows-installer-smoke.mjs
@@ -77,6 +77,21 @@ const requestPackagedAppShutdown = async (endpoint, auth, fetchImpl = fetchWithT
   }
 }
 
+const parsePackagedAppEndpoint = (output) => {
+  const match = output.match(
+    /Open Science Web:\s+(http:\/\/127\.0\.0\.1:\d+\/\?token=[A-Za-z0-9_-]+)/
+  )
+  if (!match) return undefined
+
+  const url = new URL(match[1])
+  const token = url.searchParams.get('token')
+  if (!token) return undefined
+  return {
+    endpoint: url.origin,
+    auth: `token=${encodeURIComponent(token)}`
+  }
+}
+
 const terminateProcessTree = async (child) => {
   if (!child.pid) return
   await new Promise((resolveTermination) => {
@@ -246,12 +261,8 @@ const assertUpgradeProfilePreserved = async (profileDirectory) => {
   }
 }
 
-const launchAndProbe = async ({ installDirectory, profileDirectory, expectedVersion, env }) => {
+const launchAndProbe = async ({ installDirectory, expectedVersion, env }) => {
   const executable = join(installDirectory, APP_EXECUTABLE)
-  const configRoot = join(profileDirectory, CONFIG_DIRECTORY)
-  const statePath = join(configRoot, 'web-service.json')
-  const tokenPath = join(configRoot, 'web-token')
-  await rm(statePath, { force: true })
 
   const child = spawn(executable, ['--open-science-headless', '--serve=0'], {
     env,
@@ -271,20 +282,14 @@ const launchAndProbe = async ({ installDirectory, profileDirectory, expectedVers
   const exit = observeChildExit(child)
 
   try {
-    const { state, token } = await Promise.race([
+    const { endpoint, auth } = await Promise.race([
       waitFor('the installed app web service', async () => {
-        if (!(await pathExists(statePath)) || !(await pathExists(tokenPath))) return undefined
-        return {
-          state: JSON.parse(await readFile(statePath, 'utf8')),
-          token: (await readFile(tokenPath, 'utf8')).trim()
-        }
+        return parsePackagedAppEndpoint(output())
       }),
       exit.then((code) => {
         throw new Error(`Installed app exited before becoming healthy (${code}).\n${output()}`)
       })
     ])
-    const endpoint = `http://127.0.0.1:${state.port}`
-    const auth = `token=${encodeURIComponent(token)}`
     const response = await fetchWithTimeout(`${endpoint}/api/bootstrap?${auth}`)
     if (!response.ok)
       throw new Error(`Installed app health probe returned HTTP ${response.status}.`)
@@ -310,14 +315,13 @@ const launchAndProbe = async ({ installDirectory, profileDirectory, expectedVers
   }
 }
 
-const installAndProbe = async ({ installer, installDirectory, profileDirectory, phase, env }) => {
+const installAndProbe = async ({ installer, installDirectory, phase, env }) => {
   console.log(`Smoke testing ${phase} installer: ${basename(installer)}`)
   await runProcess(installer, ['/S', `/D=${installDirectory}`], { env })
   await assertPackagedResources(installDirectory)
   await runProcess(join(installDirectory, 'resources', 'micromamba.exe'), ['--version'], { env })
   await launchAndProbe({
     installDirectory,
-    profileDirectory,
     expectedVersion: installerVersion(installer),
     env
   })
@@ -405,7 +409,7 @@ const main = async () => {
     await executeSmokePlan(
       buildSmokePlan({ currentInstaller, previousInstaller }),
       async (cycle) => {
-        await installAndProbe({ ...cycle, installDirectory, profileDirectory, env })
+        await installAndProbe({ ...cycle, installDirectory, env })
         if (previousInstaller && cycle.phase === 'previous') {
           await writeUpgradeSentinel(profileDirectory)
         } else if (previousInstaller && cycle.phase === 'current') {
@@ -441,6 +445,7 @@ export {
   findSetupInstaller,
   installerVersion,
   packagedResourcePaths,
+  parsePackagedAppEndpoint,
   requestPackagedAppShutdown,
   waitForShutdownExit,
   windowsProfileEnvironment,

--- a/scripts/windows-installer-smoke.test.ts
+++ b/scripts/windows-installer-smoke.test.ts
@@ -13,6 +13,7 @@ import {
   findSetupInstaller,
   installerVersion,
   packagedResourcePaths,
+  requestPackagedAppShutdown,
   windowsProfileEnvironment,
   writeUpgradeSentinel
 } from './windows-installer-smoke.mjs'
@@ -65,6 +66,20 @@ describe('Windows installer smoke plan', () => {
     await expect(
       fetchWithTimeout('http://127.0.0.1/health', {}, 5, fetchImpl)
     ).rejects.toMatchObject({ name: 'TimeoutError' })
+  })
+
+  it('drains the shutdown response before waiting for the packaged app to exit', async () => {
+    const text = vi.fn().mockResolvedValue('{"ok":true}')
+    const fetchImpl = vi.fn().mockResolvedValue({ status: 202, text })
+
+    await expect(
+      requestPackagedAppShutdown('http://127.0.0.1:44100', 'token=test', fetchImpl)
+    ).resolves.toBeUndefined()
+
+    expect(fetchImpl).toHaveBeenCalledWith('http://127.0.0.1:44100/api/shutdown?token=test', {
+      method: 'POST'
+    })
+    expect(text).toHaveBeenCalledOnce()
   })
 
   it('detects when an upgrade removes the previous profile', async () => {

--- a/scripts/windows-installer-smoke.test.ts
+++ b/scripts/windows-installer-smoke.test.ts
@@ -7,11 +7,13 @@ import { describe, expect, it, vi } from 'vitest'
 import {
   assertUpgradeProfilePreserved,
   buildSmokePlan,
+  cleanupSmokeRoot,
   executeSmokePlan,
   fetchWithTimeout,
   findSetupInstaller,
   installerVersion,
   packagedResourcePaths,
+  windowsProfileEnvironment,
   writeUpgradeSentinel
 } from './windows-installer-smoke.mjs'
 
@@ -90,5 +92,34 @@ describe('Windows installer smoke plan', () => {
         'query_engine-windows.dll.node'
       )
     ])
+  })
+
+  it('uses one isolated Windows profile for installers and the packaged app', () => {
+    const profileDirectory = join('smoke', 'profile')
+
+    expect(windowsProfileEnvironment(profileDirectory, { SystemRoot: 'C:\\Windows' })).toEqual({
+      SystemRoot: 'C:\\Windows',
+      HOME: profileDirectory,
+      USERPROFILE: profileDirectory,
+      APPDATA: join(profileDirectory, 'AppData', 'Roaming'),
+      LOCALAPPDATA: join(profileDirectory, 'AppData', 'Local'),
+      TEMP: join(profileDirectory, 'Temp'),
+      TMP: join(profileDirectory, 'Temp')
+    })
+  })
+
+  it('preserves the primary smoke failure when cleanup also fails', async () => {
+    const remove = vi.fn().mockRejectedValue(new Error('locked DLL'))
+    const warning = vi.spyOn(console, 'warn').mockImplementation(() => undefined)
+
+    await expect(
+      cleanupSmokeRoot('safe-smoke-root', new Error('startup failed'), remove)
+    ).resolves.toBeUndefined()
+    expect(warning).toHaveBeenCalledWith(expect.stringContaining('locked DLL'))
+    await expect(cleanupSmokeRoot('safe-smoke-root', undefined, remove)).rejects.toThrow(
+      'locked DLL'
+    )
+
+    warning.mockRestore()
   })
 })

--- a/scripts/windows-installer-smoke.test.ts
+++ b/scripts/windows-installer-smoke.test.ts
@@ -13,6 +13,7 @@ import {
   findSetupInstaller,
   installerVersion,
   packagedResourcePaths,
+  parsePackagedAppEndpoint,
   requestPackagedAppShutdown,
   waitForShutdownExit,
   windowsProfileEnvironment,
@@ -81,6 +82,19 @@ describe('Windows installer smoke plan', () => {
       method: 'POST'
     })
     expect(text).toHaveBeenCalledOnce()
+  })
+
+  it('discovers the authenticated service endpoint from packaged app output', () => {
+    expect(
+      parsePackagedAppEndpoint(`
+[main] app starting
+Open Science Web: http://127.0.0.1:52378/?token=iUFHGSACwBz2k1kSJfPixHbclDywVg0CrcdTs42uvLE
+`)
+    ).toEqual({
+      auth: 'token=iUFHGSACwBz2k1kSJfPixHbclDywVg0CrcdTs42uvLE',
+      endpoint: 'http://127.0.0.1:52378'
+    })
+    expect(parsePackagedAppEndpoint('[main] app starting')).toBeUndefined()
   })
 
   it('gives shutdown its own timeout budget after startup completes', async () => {

--- a/scripts/windows-installer-smoke.test.ts
+++ b/scripts/windows-installer-smoke.test.ts
@@ -1,0 +1,94 @@
+import { mkdir, mkdtemp, writeFile } from 'node:fs/promises'
+import { tmpdir } from 'node:os'
+import { join } from 'node:path'
+
+import { describe, expect, it, vi } from 'vitest'
+
+import {
+  assertUpgradeProfilePreserved,
+  buildSmokePlan,
+  executeSmokePlan,
+  fetchWithTimeout,
+  findSetupInstaller,
+  installerVersion,
+  packagedResourcePaths,
+  writeUpgradeSentinel
+} from './windows-installer-smoke.mjs'
+
+describe('Windows installer smoke plan', () => {
+  it('selects one setup executable and rejects ambiguous artifacts', async () => {
+    const root = await mkdtemp(join(tmpdir(), 'open-science-installer-artifacts-'))
+    await writeFile(join(root, 'portable.zip'), '')
+    await writeFile(join(root, 'aipoch-open-science-0.8.0-win-x64-setup.exe'), '')
+
+    await expect(findSetupInstaller(root)).resolves.toBe(
+      join(root, 'aipoch-open-science-0.8.0-win-x64-setup.exe')
+    )
+
+    await mkdir(join(root, 'nested'))
+    await writeFile(join(root, 'aipoch-open-science-0.8.1-win-x64-setup.exe'), '')
+    await expect(findSetupInstaller(root)).rejects.toThrow(/exactly one Windows setup executable/)
+  })
+
+  it('derives the packaged version from stable and nightly installer names', () => {
+    expect(installerVersion('aipoch-open-science-0.8.0-win-x64-setup.exe')).toBe('0.8.0')
+    expect(installerVersion('aipoch-open-science-0.8.0-nightly.abc1234-win-x64-setup.exe')).toBe(
+      '0.8.0-nightly.abc1234'
+    )
+  })
+
+  it('checks the previous version before the current version in one install location', async () => {
+    const plan = buildSmokePlan({
+      currentInstaller: 'current.exe',
+      previousInstaller: 'previous.exe'
+    })
+    const runCycle = vi.fn().mockResolvedValue(undefined)
+
+    await executeSmokePlan(plan, runCycle)
+
+    expect(runCycle.mock.calls).toEqual([
+      [{ installer: 'previous.exe', phase: 'previous' }],
+      [{ installer: 'current.exe', phase: 'current' }]
+    ])
+  })
+
+  it('aborts an unresponsive installed-app health request', async () => {
+    const fetchImpl = vi.fn(
+      (_input: string | URL | Request, init?: RequestInit) =>
+        new Promise<Response>((_resolve, reject) => {
+          init?.signal?.addEventListener('abort', () => reject(init.signal?.reason), { once: true })
+        })
+    )
+
+    await expect(
+      fetchWithTimeout('http://127.0.0.1/health', {}, 5, fetchImpl)
+    ).rejects.toMatchObject({ name: 'TimeoutError' })
+  })
+
+  it('detects when an upgrade removes the previous profile', async () => {
+    const profile = await mkdtemp(join(tmpdir(), 'open-science-upgrade-profile-'))
+
+    await writeUpgradeSentinel(profile)
+    await expect(assertUpgradeProfilePreserved(profile)).resolves.toBeUndefined()
+
+    await writeFile(join(profile, '.open-science', 'installer-smoke-upgrade-sentinel'), 'reset')
+    await expect(assertUpgradeProfilePreserved(profile)).rejects.toThrow(/did not preserve/)
+  })
+
+  it('tracks multiple packaged resources for uninstall verification', () => {
+    const installDirectory = join('smoke', 'app')
+    expect(packagedResourcePaths(installDirectory)).toEqual([
+      join(installDirectory, 'open-science.exe'),
+      join(installDirectory, 'resources', 'app.asar'),
+      join(installDirectory, 'resources', 'micromamba.exe'),
+      join(
+        installDirectory,
+        'resources',
+        'node_modules',
+        '.prisma',
+        'client',
+        'query_engine-windows.dll.node'
+      )
+    ])
+  })
+})

--- a/scripts/windows-installer-smoke.test.ts
+++ b/scripts/windows-installer-smoke.test.ts
@@ -1,4 +1,5 @@
-import { mkdir, mkdtemp, writeFile } from 'node:fs/promises'
+import { EventEmitter } from 'node:events'
+import { mkdir, mkdtemp, readFile, writeFile } from 'node:fs/promises'
 import { tmpdir } from 'node:os'
 import { join } from 'node:path'
 
@@ -8,13 +9,17 @@ import {
   assertUpgradeProfilePreserved,
   buildSmokePlan,
   cleanupSmokeRoot,
+  createUpgradeProfileGuard,
   executeSmokePlan,
   fetchWithTimeout,
   findSetupInstaller,
   installerVersion,
   packagedResourcePaths,
   parsePackagedAppEndpoint,
+  readPackagedAppConfigRoot,
   requestPackagedAppShutdown,
+  runProcess,
+  terminateProcessTree,
   waitForShutdownExit,
   windowsProfileEnvironment,
   writeUpgradeSentinel
@@ -97,6 +102,52 @@ Open Science Web: http://127.0.0.1:52378/?token=iUFHGSACwBz2k1kSJfPixHbclDywVg0C
     expect(parsePackagedAppEndpoint('[main] app starting')).toBeUndefined()
   })
 
+  it('accepts only a packaged bootstrap that reports an absolute Windows config root', async () => {
+    const configRoot = 'C:\\Users\\runneradmin\\.open-science'
+    await expect(
+      readPackagedAppConfigRoot(
+        {
+          appName: 'Open Science',
+          appVersion: '0.8.0',
+          configRoot,
+          platform: 'win32'
+        },
+        '0.8.0'
+      )
+    ).resolves.toBe(configRoot)
+    await expect(
+      readPackagedAppConfigRoot(
+        { appName: 'Open Science', appVersion: '0.8.0', platform: 'win32' },
+        '0.8.0'
+      )
+    ).rejects.toThrow(/config root/)
+  })
+
+  it('authenticates whichever legacy config-root candidate the previous app actually used', async () => {
+    const runnerConfigRoot = 'C:\\Users\\runneradmin\\.open-science'
+    const isolatedConfigRoot = 'D:\\smoke\\profile\\.open-science'
+    const readToken = vi.fn(async (path: string) => {
+      if (path === `${isolatedConfigRoot}\\web-token`) return 'legacy-token\n'
+      throw Object.assign(new Error('missing'), { code: 'ENOENT' })
+    })
+
+    await expect(
+      readPackagedAppConfigRoot(
+        { appName: 'Open Science', appVersion: '0.7.0', platform: 'win32' },
+        '0.7.0',
+        {
+          auth: 'token=legacy-token',
+          legacyConfigRoots: [runnerConfigRoot, isolatedConfigRoot],
+          readToken
+        }
+      )
+    ).resolves.toBe(isolatedConfigRoot)
+    expect(readToken.mock.calls).toEqual([
+      [`${runnerConfigRoot}\\web-token`, 'utf8'],
+      [`${isolatedConfigRoot}\\web-token`, 'utf8']
+    ])
+  })
+
   it('gives shutdown its own timeout budget after startup completes', async () => {
     vi.useFakeTimers()
     const terminate = vi.fn().mockResolvedValue(undefined)
@@ -115,14 +166,104 @@ Open Science Web: http://127.0.0.1:52378/?token=iUFHGSACwBz2k1kSJfPixHbclDywVg0C
     vi.useRealTimers()
   })
 
-  it('detects when an upgrade removes the previous profile', async () => {
+  it('settles process-tree termination when taskkill never exits', async () => {
+    vi.useFakeTimers()
+    const terminator = Object.assign(new EventEmitter(), {
+      kill: vi.fn(),
+      unref: vi.fn()
+    })
+    const spawnProcess = vi.fn(() => terminator)
+    const child = { pid: 4242, kill: vi.fn() }
+
+    const termination = terminateProcessTree(child, 10, spawnProcess)
+    const assertion = expect(termination).resolves.toBeUndefined()
+
+    await vi.advanceTimersByTimeAsync(9)
+    expect(terminator.kill).not.toHaveBeenCalled()
+    await vi.advanceTimersByTimeAsync(1)
+    await assertion
+    expect(terminator.kill).toHaveBeenCalledOnce()
+    expect(terminator.unref).toHaveBeenCalledOnce()
+    expect(child.kill).toHaveBeenCalledOnce()
+    vi.useRealTimers()
+  })
+
+  it('rejects a timed-out process even when non-zero exits are otherwise allowed', async () => {
+    const terminateSlowly = async (child: { kill: () => unknown }): Promise<void> => {
+      child.kill()
+      await new Promise((resolve) => setTimeout(resolve, 50))
+    }
+    await expect(
+      runProcess(
+        process.execPath,
+        ['-e', 'setInterval(() => undefined, 1_000)'],
+        {
+          allowNonZero: true,
+          timeoutMs: 25
+        },
+        terminateSlowly
+      )
+    ).rejects.toThrow(/timed out after 25ms/)
+  })
+
+  it('writes and verifies the upgrade sentinel in the app-reported config root', async () => {
     const profile = await mkdtemp(join(tmpdir(), 'open-science-upgrade-profile-'))
+    const configRoot = join(profile, '.open-science')
+    const sentinelName = 'installer-smoke-upgrade-sentinel-test'
 
-    await writeUpgradeSentinel(profile)
-    await expect(assertUpgradeProfilePreserved(profile)).resolves.toBeUndefined()
+    await writeUpgradeSentinel(configRoot, sentinelName)
+    await expect(readFile(join(configRoot, sentinelName), 'utf8')).resolves.toBe(
+      'previous-version-profile-preserved\n'
+    )
+    await expect(assertUpgradeProfilePreserved(configRoot, sentinelName)).resolves.toBeUndefined()
 
-    await writeFile(join(profile, '.open-science', 'installer-smoke-upgrade-sentinel'), 'reset')
-    await expect(assertUpgradeProfilePreserved(profile)).rejects.toThrow(/did not preserve/)
+    await writeFile(join(configRoot, sentinelName), 'reset')
+    await expect(assertUpgradeProfilePreserved(configRoot, sentinelName)).rejects.toThrow(
+      /did not preserve/
+    )
+  })
+
+  it('rejects an upgrade that starts the current app with a different config root', async () => {
+    const previousConfigRoot = await mkdtemp(join(tmpdir(), 'open-science-previous-config-'))
+    const currentConfigRoot = await mkdtemp(join(tmpdir(), 'open-science-current-config-'))
+    const guard = createUpgradeProfileGuard(true, 'installer-smoke-upgrade-sentinel-root-change')
+
+    await guard.verifyCycle('previous', previousConfigRoot)
+    await expect(guard.verifyCycle('current', currentConfigRoot)).rejects.toThrow(
+      /config root changed/
+    )
+    await guard.cleanup()
+  })
+
+  it('removes the upgrade sentinel during cleanup after the current app preserves it', async () => {
+    const configRoot = await mkdtemp(join(tmpdir(), 'open-science-upgrade-config-'))
+    const sentinelName = 'installer-smoke-upgrade-sentinel-cleanup'
+    const guard = createUpgradeProfileGuard(true, sentinelName)
+
+    await guard.verifyCycle('previous', configRoot)
+    await guard.verifyCycle('current', configRoot)
+    await expect(readFile(join(configRoot, sentinelName), 'utf8')).resolves.toBe(
+      'previous-version-profile-preserved\n'
+    )
+    await guard.cleanup()
+
+    await expect(readFile(join(configRoot, sentinelName), 'utf8')).rejects.toMatchObject({
+      code: 'ENOENT'
+    })
+  })
+
+  it('never overwrites or removes a pre-existing upgrade sentinel collision', async () => {
+    const configRoot = await mkdtemp(join(tmpdir(), 'open-science-upgrade-collision-'))
+    const sentinelName = 'installer-smoke-upgrade-sentinel-collision'
+    const sentinelPath = join(configRoot, sentinelName)
+    const guard = createUpgradeProfileGuard(true, sentinelName)
+    await writeFile(sentinelPath, 'pre-existing')
+
+    await expect(guard.verifyCycle('previous', configRoot)).rejects.toMatchObject({
+      code: 'EEXIST'
+    })
+    await guard.cleanup()
+    await expect(readFile(sentinelPath, 'utf8')).resolves.toBe('pre-existing')
   })
 
   it('tracks multiple packaged resources for uninstall verification', () => {
@@ -142,7 +283,7 @@ Open Science Web: http://127.0.0.1:52378/?token=iUFHGSACwBz2k1kSJfPixHbclDywVg0C
     ])
   })
 
-  it('uses one isolated Windows profile for installers and the packaged app', () => {
+  it('builds an isolated profile environment for smoke child processes', () => {
     const profileDirectory = join('smoke', 'profile')
 
     expect(windowsProfileEnvironment(profileDirectory, { SystemRoot: 'C:\\Windows' })).toEqual({

--- a/scripts/windows-installer-smoke.test.ts
+++ b/scripts/windows-installer-smoke.test.ts
@@ -14,6 +14,7 @@ import {
   installerVersion,
   packagedResourcePaths,
   requestPackagedAppShutdown,
+  waitForShutdownExit,
   windowsProfileEnvironment,
   writeUpgradeSentinel
 } from './windows-installer-smoke.mjs'
@@ -80,6 +81,24 @@ describe('Windows installer smoke plan', () => {
       method: 'POST'
     })
     expect(text).toHaveBeenCalledOnce()
+  })
+
+  it('gives shutdown its own timeout budget after startup completes', async () => {
+    vi.useFakeTimers()
+    const terminate = vi.fn().mockResolvedValue(undefined)
+    const exit = new Promise<number>(() => undefined)
+
+    const result = waitForShutdownExit(exit, {}, () => 'still running', 60_000, terminate)
+    const assertion = expect(result).rejects.toThrow(
+      'Installed app did not exit after shutdown.\nstill running'
+    )
+
+    await vi.advanceTimersByTimeAsync(59_999)
+    expect(terminate).not.toHaveBeenCalled()
+    await vi.advanceTimersByTimeAsync(1)
+    await assertion
+    expect(terminate).toHaveBeenCalledOnce()
+    vi.useRealTimers()
   })
 
   it('detects when an upgrade removes the previous profile', async () => {

--- a/scripts/windows-release-workflows.test.ts
+++ b/scripts/windows-release-workflows.test.ts
@@ -70,6 +70,10 @@ describe('post-merge Windows validation', () => {
 
     expect(upgrade['runs-on']).toBe('windows-latest')
     expect(upgrade.needs).toBe('build')
+    expect(findStep(upgrade, 'Setup Node')).toMatchObject({
+      uses: 'actions/setup-node@v7',
+      with: { 'node-version': 22 }
+    })
     expect(findStep(upgrade, 'Download current Windows installer').uses).toBe(
       'actions/download-artifact@v8'
     )

--- a/scripts/windows-release-workflows.test.ts
+++ b/scripts/windows-release-workflows.test.ts
@@ -9,6 +9,7 @@ type WorkflowStep = {
   if?: string
   name?: string
   run?: string
+  'timeout-minutes'?: number
   uses?: string
   with?: Record<string, unknown>
 }
@@ -20,9 +21,16 @@ type WorkflowJob = {
   'runs-on'?: string
   steps?: WorkflowStep[]
   strategy?: { matrix?: Record<string, unknown> }
+  'timeout-minutes'?: number
 }
 
-type Workflow = { jobs: Record<string, WorkflowJob> }
+type Workflow = {
+  jobs: Record<string, WorkflowJob>
+  on?: {
+    push?: { branches?: string[]; tags?: string[] }
+    workflow_dispatch?: unknown
+  }
+}
 
 const readWorkflow = (name: string): Workflow =>
   load(readFileSync(join(process.cwd(), '.github', 'workflows', name), 'utf8')) as Workflow
@@ -34,15 +42,17 @@ const findStep = (job: WorkflowJob, name: string): WorkflowStep => {
 }
 
 describe('post-merge Windows validation', () => {
-  it('runs the complete Windows suite as two parallel advisory shards', () => {
-    const job = readWorkflow('build.yml').jobs.windows_full_test
+  it('runs the complete Windows suite independently from nightly and release publishing', () => {
+    const build = readWorkflow('build.yml')
+    const workflow = readWorkflow('windows-full-test.yml')
+    const job = workflow.jobs.windows_full_test
 
+    expect(build.jobs.windows_full_test).toBeUndefined()
+    expect(workflow.on?.push).toMatchObject({ branches: ['main'], tags: ['v*'] })
     expect(job).toMatchObject({
       'continue-on-error': true,
       'runs-on': 'windows-latest'
     })
-    expect(job.if).toContain('!inputs.skip_verify')
-    expect(job.if).toContain('!inputs.mac_only')
     expect(job.strategy?.matrix?.shard).toEqual([1, 2])
     expect(findStep(job, 'Test complete suite shard').run).toBe(
       'npm test -- --shard=${{ matrix.shard }}/2'
@@ -59,6 +69,7 @@ describe('post-merge Windows validation', () => {
 
     expect(smoke.if).toBe("matrix.platform == 'win'")
     expect(smoke.run).toBe('node scripts/windows-installer-smoke.mjs --installer-dir dist')
+    expect(smoke['timeout-minutes']).toBe(10)
     expect(buildIndex).toBeGreaterThan(-1)
     expect(smokeIndex).toBeGreaterThan(buildIndex)
     expect(uploadIndex).toBeGreaterThan(smokeIndex)
@@ -70,6 +81,7 @@ describe('post-merge Windows validation', () => {
 
     expect(upgrade['runs-on']).toBe('windows-latest')
     expect(upgrade.needs).toBe('build')
+    expect(upgrade['timeout-minutes']).toBe(20)
     expect(findStep(upgrade, 'Setup Node')).toMatchObject({
       uses: 'actions/setup-node@v7',
       with: { 'node-version': 22 }

--- a/scripts/windows-release-workflows.test.ts
+++ b/scripts/windows-release-workflows.test.ts
@@ -1,0 +1,86 @@
+import { readFileSync } from 'node:fs'
+import { join } from 'node:path'
+
+import { load } from 'js-yaml'
+import { describe, expect, it } from 'vitest'
+
+type WorkflowStep = {
+  env?: Record<string, string>
+  if?: string
+  name?: string
+  run?: string
+  uses?: string
+  with?: Record<string, unknown>
+}
+
+type WorkflowJob = {
+  'continue-on-error'?: boolean
+  if?: string
+  needs?: string | string[]
+  'runs-on'?: string
+  steps?: WorkflowStep[]
+  strategy?: { matrix?: Record<string, unknown> }
+}
+
+type Workflow = { jobs: Record<string, WorkflowJob> }
+
+const readWorkflow = (name: string): Workflow =>
+  load(readFileSync(join(process.cwd(), '.github', 'workflows', name), 'utf8')) as Workflow
+
+const findStep = (job: WorkflowJob, name: string): WorkflowStep => {
+  const step = job.steps?.find((candidate) => candidate.name === name)
+  if (!step) throw new Error(`Missing workflow step: ${name}`)
+  return step
+}
+
+describe('post-merge Windows validation', () => {
+  it('runs the complete Windows suite as two parallel advisory shards', () => {
+    const job = readWorkflow('build.yml').jobs.windows_full_test
+
+    expect(job).toMatchObject({
+      'continue-on-error': true,
+      'runs-on': 'windows-latest'
+    })
+    expect(job.if).toContain('!inputs.skip_verify')
+    expect(job.if).toContain('!inputs.mac_only')
+    expect(job.strategy?.matrix?.shard).toEqual([1, 2])
+    expect(findStep(job, 'Test complete suite shard').run).toBe(
+      'npm test -- --shard=${{ matrix.shard }}/2'
+    )
+  })
+
+  it('hard-gates every packaged Windows build on a fresh install/start/uninstall smoke', () => {
+    const job = readWorkflow('build.yml').jobs.build
+    const buildIndex = job.steps?.findIndex(({ name }) => name === 'Build & package') ?? -1
+    const smokeIndex =
+      job.steps?.findIndex(({ name }) => name === 'Smoke test Windows installer') ?? -1
+    const uploadIndex = job.steps?.findIndex(({ name }) => name === 'Upload build artifacts') ?? -1
+    const smoke = findStep(job, 'Smoke test Windows installer')
+
+    expect(smoke.if).toBe("matrix.platform == 'win'")
+    expect(smoke.run).toBe('node scripts/windows-installer-smoke.mjs --installer-dir dist')
+    expect(buildIndex).toBeGreaterThan(-1)
+    expect(smokeIndex).toBeGreaterThan(buildIndex)
+    expect(uploadIndex).toBeGreaterThan(smokeIndex)
+  })
+
+  it('runs the previous-stable upgrade smoke alongside notarization before publishing', () => {
+    const release = readWorkflow('release.yml')
+    const upgrade = release.jobs['windows-upgrade-smoke']
+
+    expect(upgrade['runs-on']).toBe('windows-latest')
+    expect(upgrade.needs).toBe('build')
+    expect(findStep(upgrade, 'Download current Windows installer').uses).toBe(
+      'actions/download-artifact@v8'
+    )
+    const previous = findStep(upgrade, 'Download previous stable Windows installer')
+    expect(previous.env?.CURRENT_TAG).toBe('${{ github.ref_name }}')
+    expect(previous.run).toContain('gh release download')
+    expect(previous.run).toContain("$_.tagName -like 'v*'")
+    expect(previous.run).toContain('$_.tagName -ne $env:CURRENT_TAG')
+    expect(findStep(upgrade, 'Smoke test Windows upgrade').run).toContain(
+      '--previous-installer-dir previous'
+    )
+    expect(release.jobs.publish.needs).toEqual(['build', 'notarize-mac', 'windows-upgrade-smoke'])
+  })
+})

--- a/src/main/notebook/runtime-service.test.ts
+++ b/src/main/notebook/runtime-service.test.ts
@@ -1095,7 +1095,9 @@ describe('notebook runtime service', () => {
         expect(unicodeOutput).toMatchObject({ exitCode: 0 })
         expect(unicodeOutput.stdout).toContain('分析完成')
         expect(trailingContinuation.exitCode).toBe(1)
-      }
+      },
+      // Four fresh PowerShell processes can exceed the shared 15s budget on a loaded Windows runner.
+      30_000
     )
 
     // POSIX-only: reads env via the shell. bash must NOT inherit arbitrary host env (secrets), only an

--- a/src/main/notebook/runtime-service.test.ts
+++ b/src/main/notebook/runtime-service.test.ts
@@ -186,7 +186,7 @@ describe('Windows shell support', () => {
     expect(normalizePowerShellStderr(errorClixml, 'win32')).toBe(errorClixml)
   })
 
-  it('keeps Windows shell location variables while excluding host secrets', () => {
+  it('keeps Windows shell runtime variables while excluding host secrets', () => {
     const env = buildShellEnv('/notebook/handoff', 'win32', {
       PATH: 'C:\\Windows\\System32',
       SystemRoot: 'C:\\Windows',
@@ -194,6 +194,7 @@ describe('Windows shell support', () => {
       ComSpec: 'C:\\Windows\\System32\\cmd.exe',
       PATHEXT: '.COM;.EXE;.BAT;.CMD',
       USERPROFILE: 'C:\\Users\\Ada',
+      PSDisableModuleAnalysisCacheCleanup: 'host-value-must-not-win',
       OPEN_SCIENCE_TEST_SECRET: 'must-not-leak'
     })
 
@@ -204,6 +205,7 @@ describe('Windows shell support', () => {
       ComSpec: 'C:\\Windows\\System32\\cmd.exe',
       PATHEXT: '.COM;.EXE;.BAT;.CMD',
       USERPROFILE: 'C:\\Users\\Ada',
+      PSDisableModuleAnalysisCacheCleanup: '1',
       OPEN_SCIENCE_HANDOFF_DIR: '/notebook/handoff'
     })
     expect(env.OPEN_SCIENCE_TEST_SECRET).toBeUndefined()

--- a/src/main/notebook/runtime-service.test.ts
+++ b/src/main/notebook/runtime-service.test.ts
@@ -1062,44 +1062,6 @@ describe('notebook runtime service', () => {
       }
     )
 
-    it.skipIf(process.platform !== 'win32')(
-      'isolates commands, propagates PowerShell failures, and preserves UTF-8 output on Windows',
-      async () => {
-        const root = await createStorageRoot()
-        const service = createShellService(root)
-
-        const cmdletFailure = await service.executeShell({
-          sessionId: 'session-1',
-          workspaceCwd: root,
-          command: 'Get-Item "missing-open-science-file"; Write-Output "continued"'
-        })
-        const nativeFailure = await service.executeShell({
-          sessionId: 'session-1',
-          workspaceCwd: root,
-          command: 'cmd.exe /d /c exit 7 | Out-Null'
-        })
-        const unicodeOutput = await service.executeShell({
-          sessionId: 'session-1',
-          workspaceCwd: root,
-          command: 'Write-Output "分析完成"'
-        })
-        const trailingContinuation = await service.executeShell({
-          sessionId: 'session-1',
-          workspaceCwd: root,
-          command: 'Write-Output "isolated" `'
-        })
-
-        expect(cmdletFailure.exitCode).toBe(1)
-        expect(cmdletFailure.stdout).not.toContain('continued')
-        expect(nativeFailure.exitCode).toBe(7)
-        expect(unicodeOutput).toMatchObject({ exitCode: 0 })
-        expect(unicodeOutput.stdout).toContain('分析完成')
-        expect(trailingContinuation.exitCode).toBe(1)
-      },
-      // Four fresh PowerShell processes can exceed the shared 15s budget on a loaded Windows runner.
-      30_000
-    )
-
     // POSIX-only: reads env via the shell. bash must NOT inherit arbitrary host env (secrets), only an
     // allowlist + the handoff channel — so a leaked connector token / API key can't reach the shell.
     it.skipIf(process.platform === 'win32')(

--- a/src/main/notebook/runtime-service.test.ts
+++ b/src/main/notebook/runtime-service.test.ts
@@ -194,6 +194,7 @@ describe('Windows shell support', () => {
       ComSpec: 'C:\\Windows\\System32\\cmd.exe',
       PATHEXT: '.COM;.EXE;.BAT;.CMD',
       USERPROFILE: 'C:\\Users\\Ada',
+      PSModulePath: 'C:\\host\\third-party-modules',
       OPEN_SCIENCE_TEST_SECRET: 'must-not-leak'
     })
 
@@ -204,6 +205,7 @@ describe('Windows shell support', () => {
       ComSpec: 'C:\\Windows\\System32\\cmd.exe',
       PATHEXT: '.COM;.EXE;.BAT;.CMD',
       USERPROFILE: 'C:\\Users\\Ada',
+      PSModulePath: 'C:\\Windows\\System32\\WindowsPowerShell\\v1.0\\Modules',
       OPEN_SCIENCE_HANDOFF_DIR: '/notebook/handoff'
     })
     expect(env.OPEN_SCIENCE_TEST_SECRET).toBeUndefined()

--- a/src/main/notebook/runtime-service.test.ts
+++ b/src/main/notebook/runtime-service.test.ts
@@ -211,10 +211,20 @@ describe('Windows shell support', () => {
 
   it('uses the Windows process-tree terminator for a timed-out shell command', () => {
     const child = {} as Parameters<typeof terminateShellOnTimeout>[0]
-    const terminateTree = vi.fn().mockResolvedValue({ reaped: true })
+    let finishTermination: ((result: { reaped: boolean }) => void) | undefined
+    const terminateTree = vi.fn(
+      () =>
+        new Promise<{ reaped: boolean }>((resolve) => {
+          finishTermination = resolve
+        })
+    )
 
-    expect(terminateShellOnTimeout(child, 'win32', terminateTree)).toBe(true)
+    const termination = terminateShellOnTimeout(child, 'win32', terminateTree)
+
+    expect(termination).toBeInstanceOf(Promise)
     expect(terminateTree).toHaveBeenCalledWith(child)
+    finishTermination?.({ reaped: true })
+    return expect(termination).resolves.toBe(true)
   })
 })
 

--- a/src/main/notebook/runtime-service.test.ts
+++ b/src/main/notebook/runtime-service.test.ts
@@ -194,8 +194,6 @@ describe('Windows shell support', () => {
       ComSpec: 'C:\\Windows\\System32\\cmd.exe',
       PATHEXT: '.COM;.EXE;.BAT;.CMD',
       USERPROFILE: 'C:\\Users\\Ada',
-      PSModuleAnalysisCachePath: 'host-value-must-not-win',
-      PSDisableModuleAnalysisCacheCleanup: 'host-value-must-not-win',
       OPEN_SCIENCE_TEST_SECRET: 'must-not-leak'
     })
 
@@ -206,8 +204,6 @@ describe('Windows shell support', () => {
       ComSpec: 'C:\\Windows\\System32\\cmd.exe',
       PATHEXT: '.COM;.EXE;.BAT;.CMD',
       USERPROFILE: 'C:\\Users\\Ada',
-      PSModuleAnalysisCachePath: 'nul',
-      PSDisableModuleAnalysisCacheCleanup: '1',
       OPEN_SCIENCE_HANDOFF_DIR: '/notebook/handoff'
     })
     expect(env.OPEN_SCIENCE_TEST_SECRET).toBeUndefined()

--- a/src/main/notebook/runtime-service.test.ts
+++ b/src/main/notebook/runtime-service.test.ts
@@ -121,6 +121,16 @@ describe('resolveShellInvocation', () => {
     const script = Buffer.from(invocation.args.at(-1) ?? '', 'base64').toString('utf16le')
     expect(script).toContain('[Console]::OutputEncoding = $openScienceUtf8')
     expect(script).toContain('$OutputEncoding = $openScienceUtf8')
+    expect(script).toContain('$env:PSModulePath = $env:OPEN_SCIENCE_PSMODULEPATH')
+    expect(script).toContain(
+      'Import-Module "$PSHOME\\Modules\\Microsoft.PowerShell.Management\\Microsoft.PowerShell.Management.psd1" -ErrorAction Stop'
+    )
+    expect(script).toContain(
+      'Import-Module "$PSHOME\\Modules\\Microsoft.PowerShell.Utility\\Microsoft.PowerShell.Utility.psd1" -ErrorAction Stop'
+    )
+    expect(script).toContain(
+      "[System.Environment]::SetEnvironmentVariable('OPEN_SCIENCE_PSMODULEPATH', $null, [System.EnvironmentVariableTarget]::Process)"
+    )
     expect(script).toContain("$ProgressPreference = 'SilentlyContinue'")
     expect(script).toContain("$ErrorActionPreference = 'Stop'")
     expect(script).toContain('catch {')
@@ -189,12 +199,14 @@ describe('Windows shell support', () => {
   it('keeps Windows shell runtime variables while excluding host secrets', () => {
     const env = buildShellEnv('/notebook/handoff', 'win32', {
       PATH: 'C:\\Windows\\System32',
+      ProgramFiles: 'C:\\Program Files',
       SystemRoot: 'C:\\Windows',
       WINDIR: 'C:\\Windows',
       ComSpec: 'C:\\Windows\\System32\\cmd.exe',
       PATHEXT: '.COM;.EXE;.BAT;.CMD',
       USERPROFILE: 'C:\\Users\\Ada',
       PSModulePath: 'C:\\host\\third-party-modules',
+      OPEN_SCIENCE_PSMODULEPATH: 'C:\\host\\controlled-modules',
       OPEN_SCIENCE_TEST_SECRET: 'must-not-leak'
     })
 
@@ -205,9 +217,13 @@ describe('Windows shell support', () => {
       ComSpec: 'C:\\Windows\\System32\\cmd.exe',
       PATHEXT: '.COM;.EXE;.BAT;.CMD',
       USERPROFILE: 'C:\\Users\\Ada',
-      PSModulePath: 'C:\\Windows\\System32\\WindowsPowerShell\\v1.0\\Modules',
+      PSModulePath:
+        'C:\\Program Files\\WindowsPowerShell\\Modules;C:\\Windows\\System32\\WindowsPowerShell\\v1.0\\Modules',
+      OPEN_SCIENCE_PSMODULEPATH:
+        'C:\\Program Files\\WindowsPowerShell\\Modules;C:\\Windows\\System32\\WindowsPowerShell\\v1.0\\Modules',
       OPEN_SCIENCE_HANDOFF_DIR: '/notebook/handoff'
     })
+    expect(env.ProgramFiles).toBeUndefined()
     expect(env.OPEN_SCIENCE_TEST_SECRET).toBeUndefined()
   })
 

--- a/src/main/notebook/runtime-service.test.ts
+++ b/src/main/notebook/runtime-service.test.ts
@@ -194,6 +194,7 @@ describe('Windows shell support', () => {
       ComSpec: 'C:\\Windows\\System32\\cmd.exe',
       PATHEXT: '.COM;.EXE;.BAT;.CMD',
       USERPROFILE: 'C:\\Users\\Ada',
+      PSModuleAnalysisCachePath: 'host-value-must-not-win',
       PSDisableModuleAnalysisCacheCleanup: 'host-value-must-not-win',
       OPEN_SCIENCE_TEST_SECRET: 'must-not-leak'
     })
@@ -205,6 +206,7 @@ describe('Windows shell support', () => {
       ComSpec: 'C:\\Windows\\System32\\cmd.exe',
       PATHEXT: '.COM;.EXE;.BAT;.CMD',
       USERPROFILE: 'C:\\Users\\Ada',
+      PSModuleAnalysisCachePath: 'nul',
       PSDisableModuleAnalysisCacheCleanup: '1',
       OPEN_SCIENCE_HANDOFF_DIR: '/notebook/handoff'
     })

--- a/src/main/notebook/runtime-service.ts
+++ b/src/main/notebook/runtime-service.ts
@@ -653,14 +653,6 @@ const buildShellEnv = (
     const value = sourceEnv[key]
     if (value !== undefined) env[key] = value
   }
-  if (platform === 'win32') {
-    // Windows PowerShell 5.1 writes its module-analysis cache on a delayed background task after the
-    // first cmdlet. These shells are disposable, so direct the cache to Windows' invalid device and
-    // disable the separate stale-entry cleanup; otherwise a fresh cmdlet shell can linger for ~10s.
-    // Microsoft documents `nul` as the supported way to disable this file cache.
-    env.PSModuleAnalysisCachePath = 'nul'
-    env.PSDisableModuleAnalysisCacheCleanup = '1'
-  }
   env.OPEN_SCIENCE_HANDOFF_DIR = handoffDir
   return env
 }

--- a/src/main/notebook/runtime-service.ts
+++ b/src/main/notebook/runtime-service.ts
@@ -3952,6 +3952,7 @@ export {
   resolveDefaultExecutorOptions,
   resolveLoopScriptPaths,
   resolveShellInvocation,
+  runShellCommand,
   terminateShellOnTimeout
 }
 export type {

--- a/src/main/notebook/runtime-service.ts
+++ b/src/main/notebook/runtime-service.ts
@@ -761,15 +761,20 @@ const resolveShellInvocation = (
       }
     : { executable: 'sh', args: ['-c', command] }
 
-// Returns true when it delegated the tree teardown to the Windows-specific terminator. The dependency
-// is injectable to keep this platform boundary covered without needing a Windows host in unit tests.
-const terminateShellOnTimeout = (
+// Returns true after the Windows-specific tree terminator settles. Waiting prevents the service from
+// reporting completion while taskkill still holds workspace files open. The dependency is injectable
+// to keep this platform boundary covered without needing a Windows host in unit tests.
+const terminateShellOnTimeout = async (
   child: ChildProcess,
   platform: NodeJS.Platform = process.platform,
   terminateTree: (process: ChildProcess) => Promise<unknown> = terminateProcessTree
-): boolean => {
+): Promise<boolean> => {
   if (platform !== 'win32') return false
-  void terminateTree(child)
+  try {
+    await terminateTree(child)
+  } catch {
+    // Preserve runShellCommand's never-reject contract even when the best-effort terminator fails.
+  }
   return true
 }
 
@@ -808,6 +813,10 @@ const runShellCommand = (options: {
     // running (e.g. SIGTERM-ignoring) process from a killed one — gate the SIGKILL escalation below
     // on this instead.
     let exited = false
+    // Once the timer fires, the timeout result owns settlement. In particular, taskkill causes an
+    // exit event before its promise resolves on Windows; that event must not be persisted as a normal
+    // failed exit instead of the timeout that initiated termination.
+    let timedOut = false
 
     const finish = (result: NotebookShellResult): void => {
       if (settled) return
@@ -817,33 +826,32 @@ const runShellCommand = (options: {
     }
 
     const timeoutTimer = setTimeout(() => {
-      if (terminateShellOnTimeout(child)) {
-        // child.kill() only reaches the PowerShell parent on Windows; a command it launched may
-        // survive. taskkill /T /F reaps the full tree while this promise still settles immediately.
-        finish({
-          stdout,
-          stderr:
-            stderr +
-            `${stderr && !stderr.endsWith('\n') ? '\n' : ''}Shell command timed out after ${timeoutMs}ms and was killed.`,
-          exitCode: null
-        })
-        return
-      }
-
-      // Escalate SIGTERM -> SIGKILL if the process ignores the polite signal; the promise itself
-      // settles immediately so a wedged process can never hang the caller past the timeout.
-      child.kill('SIGTERM')
-      const killTimer = setTimeout(() => {
-        if (!exited) child.kill('SIGKILL')
-      }, SHELL_KILL_GRACE_MS)
-      child.once('exit', () => clearTimeout(killTimer))
-
-      finish({
+      timedOut = true
+      const timeoutResult: NotebookShellResult = {
         stdout,
         stderr:
           stderr +
           `${stderr && !stderr.endsWith('\n') ? '\n' : ''}Shell command timed out after ${timeoutMs}ms and was killed.`,
         exitCode: null
+      }
+
+      void terminateShellOnTimeout(child).then((usedWindowsTerminator) => {
+        if (usedWindowsTerminator) {
+          // child.kill() only reaches the PowerShell parent on Windows; taskkill /T /F reaps the
+          // full tree. Settle only after it completes so callers can safely inspect or remove cwd.
+          finish(timeoutResult)
+          return
+        }
+
+        // Escalate SIGTERM -> SIGKILL if the process ignores the polite signal; the promise itself
+        // settles immediately so a wedged process can never hang the caller past the timeout.
+        child.kill('SIGTERM')
+        const killTimer = setTimeout(() => {
+          if (!exited) child.kill('SIGKILL')
+        }, SHELL_KILL_GRACE_MS)
+        child.once('exit', () => clearTimeout(killTimer))
+
+        finish(timeoutResult)
       })
     }, timeoutMs)
 
@@ -856,11 +864,11 @@ const runShellCommand = (options: {
       stderr += chunk
     })
     child.once('error', (error) => {
-      finish({ stdout, stderr: stderr || error.message, exitCode: null })
+      if (!timedOut) finish({ stdout, stderr: stderr || error.message, exitCode: null })
     })
     child.once('exit', (code) => {
       exited = true
-      finish({ stdout, stderr, exitCode: code })
+      if (!timedOut) finish({ stdout, stderr, exitCode: code })
     })
   })
 

--- a/src/main/notebook/runtime-service.ts
+++ b/src/main/notebook/runtime-service.ts
@@ -654,9 +654,11 @@ const buildShellEnv = (
     if (value !== undefined) env[key] = value
   }
   if (platform === 'win32') {
-    // Windows PowerShell 5.1 can keep a short-lived process alive for its fixed-delay module-analysis
-    // cache cleanup after the first cmdlet. Notebook shells are disposable, so skip that stale-entry
-    // cleanup while retaining the cache itself; this avoids adding roughly ten seconds per fresh shell.
+    // Windows PowerShell 5.1 writes its module-analysis cache on a delayed background task after the
+    // first cmdlet. These shells are disposable, so direct the cache to Windows' invalid device and
+    // disable the separate stale-entry cleanup; otherwise a fresh cmdlet shell can linger for ~10s.
+    // Microsoft documents `nul` as the supported way to disable this file cache.
+    env.PSModuleAnalysisCachePath = 'nul'
     env.PSDisableModuleAnalysisCacheCleanup = '1'
   }
   env.OPEN_SCIENCE_HANDOFF_DIR = handoffDir

--- a/src/main/notebook/runtime-service.ts
+++ b/src/main/notebook/runtime-service.ts
@@ -2,7 +2,7 @@ import { spawn, type ChildProcess } from 'node:child_process'
 import { randomUUID } from 'node:crypto'
 import { existsSync, realpathSync } from 'node:fs'
 import { readFile, realpath, rm, writeFile } from 'node:fs/promises'
-import { isAbsolute, join, relative, resolve, sep } from 'node:path'
+import { isAbsolute, join, relative, resolve, sep, win32 } from 'node:path'
 
 import type {
   NotebookCell,
@@ -652,6 +652,16 @@ const buildShellEnv = (
   for (const key of keys) {
     const value = sourceEnv[key]
     if (value !== undefined) env[key] = value
+  }
+  if (platform === 'win32') {
+    const windowsRoot = sourceEnv.SystemRoot ?? sourceEnv.WINDIR
+    if (windowsRoot) {
+      // PowerShell's built-in cmdlets are module-backed. Supplying no PSModulePath makes Windows
+      // PowerShell perform extremely slow first-use discovery on hosted machines, while inheriting
+      // the host value would expose arbitrary user/third-party modules. Pin discovery to the
+      // supported in-box module directory instead.
+      env.PSModulePath = win32.join(windowsRoot, 'System32', 'WindowsPowerShell', 'v1.0', 'Modules')
+    }
   }
   env.OPEN_SCIENCE_HANDOFF_DIR = handoffDir
   return env

--- a/src/main/notebook/runtime-service.ts
+++ b/src/main/notebook/runtime-service.ts
@@ -653,6 +653,12 @@ const buildShellEnv = (
     const value = sourceEnv[key]
     if (value !== undefined) env[key] = value
   }
+  if (platform === 'win32') {
+    // Windows PowerShell 5.1 can keep a short-lived process alive for its fixed-delay module-analysis
+    // cache cleanup after the first cmdlet. Notebook shells are disposable, so skip that stale-entry
+    // cleanup while retaining the cache itself; this avoids adding roughly ten seconds per fresh shell.
+    env.PSDisableModuleAnalysisCacheCleanup = '1'
+  }
   env.OPEN_SCIENCE_HANDOFF_DIR = handoffDir
   return env
 }

--- a/src/main/notebook/runtime-service.ts
+++ b/src/main/notebook/runtime-service.ts
@@ -654,13 +654,25 @@ const buildShellEnv = (
     if (value !== undefined) env[key] = value
   }
   if (platform === 'win32') {
+    const modulePaths: string[] = []
+    const programFiles = sourceEnv.ProgramFiles
+    if (programFiles) {
+      modulePaths.push(win32.join(programFiles, 'WindowsPowerShell', 'Modules'))
+    }
     const windowsRoot = sourceEnv.SystemRoot ?? sourceEnv.WINDIR
     if (windowsRoot) {
       // PowerShell's built-in cmdlets are module-backed. Supplying no PSModulePath makes Windows
       // PowerShell perform extremely slow first-use discovery on hosted machines, while inheriting
-      // the host value would expose arbitrary user/third-party modules. Pin discovery to the
-      // supported in-box module directory instead.
-      env.PSModulePath = win32.join(windowsRoot, 'System32', 'WindowsPowerShell', 'v1.0', 'Modules')
+      // the host value would expose arbitrary user/third-party modules. Preserve only the standard
+      // AllUsers and in-box module locations, excluding CurrentUser and host-specific additions.
+      modulePaths.push(win32.join(windowsRoot, 'System32', 'WindowsPowerShell', 'v1.0', 'Modules'))
+    }
+    if (modulePaths.length > 0) {
+      const controlledModulePath = modulePaths.join(win32.delimiter)
+      env.PSModulePath = controlledModulePath
+      // Windows PowerShell reconstructs PSModulePath at startup and can reinsert CurrentUser paths.
+      // Carry the controlled value through startup so the wrapper can restore it before user code.
+      env.OPEN_SCIENCE_PSMODULEPATH = controlledModulePath
     }
   }
   env.OPEN_SCIENCE_HANDOFF_DIR = handoffDir
@@ -728,6 +740,15 @@ type ShellInvocation = {
 const encodePowerShellCommand = (command: string): string => {
   const encodedCommand = Buffer.from(command, 'utf8').toString('base64')
   const script = [
+    'if ($env:OPEN_SCIENCE_PSMODULEPATH) {',
+    '  $env:PSModulePath = $env:OPEN_SCIENCE_PSMODULEPATH',
+    // Import the common in-box command modules by absolute path so their first use does not scan
+    // the larger AllUsers tree. Keep AllUsers first in PSModulePath so updated or additional
+    // machine modules retain Windows PowerShell's standard precedence for every other command.
+    '  Import-Module "$PSHOME\\Modules\\Microsoft.PowerShell.Management\\Microsoft.PowerShell.Management.psd1" -ErrorAction Stop',
+    '  Import-Module "$PSHOME\\Modules\\Microsoft.PowerShell.Utility\\Microsoft.PowerShell.Utility.psd1" -ErrorAction Stop',
+    "  [System.Environment]::SetEnvironmentVariable('OPEN_SCIENCE_PSMODULEPATH', $null, [System.EnvironmentVariableTarget]::Process)",
+    '}',
     '$openScienceUtf8 = [System.Text.UTF8Encoding]::new($false)',
     '[Console]::OutputEncoding = $openScienceUtf8',
     '$OutputEncoding = $openScienceUtf8',

--- a/src/main/notebook/windows-shell.integration.test.ts
+++ b/src/main/notebook/windows-shell.integration.test.ts
@@ -2,43 +2,62 @@ import { describe, expect, it } from 'vitest'
 
 import { runShellCommand } from './runtime-service'
 
+const POWERSHELL_PROCESS_TIMEOUT_MS = 30_000
+const POWERSHELL_TEST_TIMEOUT_MS = POWERSHELL_PROCESS_TIMEOUT_MS + 5_000
+
 const runPowerShell = (command: string): ReturnType<typeof runShellCommand> =>
   runShellCommand({
     command,
     cwd: process.cwd(),
     handoffDir: process.cwd(),
-    // Windows PowerShell 5.1 on hosted runners can spend just over 10 seconds shutting down after
-    // a first cmdlet, while native-only and parser-error paths finish in under a second. Production's
-    // default is 120 seconds; this tighter integration budget still detects a genuinely stuck shell.
-    timeoutMs: 15_000
+    // Cold Windows PowerShell 5.1 module discovery on hosted runners can exceed Vitest's 15-second
+    // default, while native-only and parser-error paths finish in under a second. Production allows
+    // 120 seconds; this tighter process budget still detects a genuinely stuck shell.
+    timeoutMs: POWERSHELL_PROCESS_TIMEOUT_MS
   })
 
 describe.runIf(process.platform === 'win32')('Windows notebook shell integration', () => {
-  it('stops after a failing cmdlet', async () => {
-    const result = await runPowerShell(
-      'Get-Item "missing-open-science-file"; Write-Output "continued"'
-    )
+  it(
+    'stops after a failing cmdlet',
+    async () => {
+      const result = await runPowerShell(
+        'Get-Item "missing-open-science-file"; Write-Output "continued"'
+      )
 
-    expect(result.exitCode).toBe(1)
-    expect(result.stdout).not.toContain('continued')
-  })
+      expect(result.exitCode).toBe(1)
+      expect(result.stdout).not.toContain('continued')
+    },
+    POWERSHELL_TEST_TIMEOUT_MS
+  )
 
-  it('propagates a native process exit code', async () => {
-    const result = await runPowerShell('cmd.exe /d /c exit 7 | Out-Null')
+  it(
+    'propagates a native process exit code',
+    async () => {
+      const result = await runPowerShell('cmd.exe /d /c exit 7 | Out-Null')
 
-    expect(result.exitCode).toBe(7)
-  })
+      expect(result.exitCode).toBe(7)
+    },
+    POWERSHELL_TEST_TIMEOUT_MS
+  )
 
-  it('preserves UTF-8 output', async () => {
-    const result = await runPowerShell('Write-Output "分析完成"')
+  it(
+    'preserves UTF-8 output',
+    async () => {
+      const result = await runPowerShell('Write-Output "分析完成"')
 
-    expect(result).toMatchObject({ exitCode: 0 })
-    expect(result.stdout).toContain('分析完成')
-  })
+      expect(result).toMatchObject({ exitCode: 0 })
+      expect(result.stdout).toContain('分析完成')
+    },
+    POWERSHELL_TEST_TIMEOUT_MS
+  )
 
-  it('rejects a trailing continuation without consuming the wrapper', async () => {
-    const result = await runPowerShell('Write-Output "isolated" `')
+  it(
+    'rejects a trailing continuation without consuming the wrapper',
+    async () => {
+      const result = await runPowerShell('Write-Output "isolated" `')
 
-    expect(result.exitCode).toBe(1)
-  })
+      expect(result.exitCode).toBe(1)
+    },
+    POWERSHELL_TEST_TIMEOUT_MS
+  )
 })

--- a/src/main/notebook/windows-shell.integration.test.ts
+++ b/src/main/notebook/windows-shell.integration.test.ts
@@ -2,7 +2,7 @@ import { describe, expect, it } from 'vitest'
 
 import { runShellCommand } from './runtime-service'
 
-const runPowerShell = (command: string) =>
+const runPowerShell = (command: string): ReturnType<typeof runShellCommand> =>
   runShellCommand({
     command,
     cwd: process.cwd(),

--- a/src/main/notebook/windows-shell.integration.test.ts
+++ b/src/main/notebook/windows-shell.integration.test.ts
@@ -7,7 +7,10 @@ const runPowerShell = (command: string): ReturnType<typeof runShellCommand> =>
     command,
     cwd: process.cwd(),
     handoffDir: process.cwd(),
-    timeoutMs: 10_000
+    // Windows PowerShell 5.1 on hosted runners can spend just over 10 seconds shutting down after
+    // a first cmdlet, while native-only and parser-error paths finish in under a second. Production's
+    // default is 120 seconds; this tighter integration budget still detects a genuinely stuck shell.
+    timeoutMs: 15_000
   })
 
 describe.runIf(process.platform === 'win32')('Windows notebook shell integration', () => {

--- a/src/main/notebook/windows-shell.integration.test.ts
+++ b/src/main/notebook/windows-shell.integration.test.ts
@@ -1,3 +1,5 @@
+import { join } from 'node:path'
+
 import { describe, expect, it } from 'vitest'
 
 import { runShellCommand } from './runtime-service'
@@ -10,6 +12,7 @@ const runPowerShell = (command: string): ReturnType<typeof runShellCommand> =>
     command,
     cwd: process.cwd(),
     handoffDir: process.cwd(),
+    runtimeRoot: join(process.cwd(), '.open-science-test-runtime'),
     // Cold Windows PowerShell 5.1 module discovery on hosted runners can exceed Vitest's 15-second
     // default, while native-only and parser-error paths finish in under a second. Production allows
     // 120 seconds; this tighter process budget still detects a genuinely stuck shell.
@@ -41,12 +44,27 @@ describe.runIf(process.platform === 'win32')('Windows notebook shell integration
   )
 
   it(
-    'preserves UTF-8 output',
+    'preserves UTF-8 output with only standard machine module paths',
     async () => {
-      const result = await runPowerShell('Write-Output "分析完成"')
+      const result = await runPowerShell(`
+Write-Output "分析完成"
+Write-Output "__OPEN_SCIENCE_PSMODULEPATH__=$env:PSModulePath"
+Write-Output "__OPEN_SCIENCE_INTERNAL__=[$env:OPEN_SCIENCE_PSMODULEPATH]"
+`)
 
       expect(result).toMatchObject({ exitCode: 0 })
       expect(result.stdout).toContain('分析完成')
+      const programFiles = process.env.ProgramFiles
+      const windowsRoot = process.env.SystemRoot ?? process.env.WINDIR
+      expect(programFiles).toBeTruthy()
+      expect(windowsRoot).toBeTruthy()
+      if (!programFiles || !windowsRoot) throw new Error('Missing standard Windows path variables.')
+      const modulePath = result.stdout.match(/^__OPEN_SCIENCE_PSMODULEPATH__=(.*)$/mu)?.[1]?.trim()
+      expect(modulePath?.split(';').map((entry) => entry.toLowerCase())).toEqual([
+        `${programFiles}\\WindowsPowerShell\\Modules`.toLowerCase(),
+        `${windowsRoot}\\System32\\WindowsPowerShell\\v1.0\\Modules`.toLowerCase()
+      ])
+      expect(result.stdout).toContain('__OPEN_SCIENCE_INTERNAL__=[]')
     },
     POWERSHELL_TEST_TIMEOUT_MS
   )

--- a/src/main/notebook/windows-shell.integration.test.ts
+++ b/src/main/notebook/windows-shell.integration.test.ts
@@ -1,0 +1,41 @@
+import { describe, expect, it } from 'vitest'
+
+import { runShellCommand } from './runtime-service'
+
+const runPowerShell = (command: string) =>
+  runShellCommand({
+    command,
+    cwd: process.cwd(),
+    handoffDir: process.cwd(),
+    timeoutMs: 10_000
+  })
+
+describe.runIf(process.platform === 'win32')('Windows notebook shell integration', () => {
+  it('stops after a failing cmdlet', async () => {
+    const result = await runPowerShell(
+      'Get-Item "missing-open-science-file"; Write-Output "continued"'
+    )
+
+    expect(result.exitCode).toBe(1)
+    expect(result.stdout).not.toContain('continued')
+  })
+
+  it('propagates a native process exit code', async () => {
+    const result = await runPowerShell('cmd.exe /d /c exit 7 | Out-Null')
+
+    expect(result.exitCode).toBe(7)
+  })
+
+  it('preserves UTF-8 output', async () => {
+    const result = await runPowerShell('Write-Output "分析完成"')
+
+    expect(result).toMatchObject({ exitCode: 0 })
+    expect(result.stdout).toContain('分析完成')
+  })
+
+  it('rejects a trailing continuation without consuming the wrapper', async () => {
+    const result = await runPowerShell('Write-Output "isolated" `')
+
+    expect(result.exitCode).toBe(1)
+  })
+})

--- a/src/main/web-service/controller.test.ts
+++ b/src/main/web-service/controller.test.ts
@@ -66,6 +66,7 @@ describe('createWebServiceController', () => {
 
     expect(result).toEqual({ port: 44100, url: 'http://127.0.0.1:44100/?token=tok-123' })
     expect(h.startServer).toHaveBeenCalledTimes(1)
+    expect(h.lastOptions().bootstrap.configRoot).toBe('/fake/root')
     expect(h.writeState).toHaveBeenCalledWith(
       '/fake/root',
       expect.objectContaining({ pid: 4242, port: 44100, appVersion: '9.9.9', attached: true })

--- a/src/main/web-service/http-server.test.ts
+++ b/src/main/web-service/http-server.test.ts
@@ -49,6 +49,7 @@ describe('startWebHttpServer', () => {
       bootstrap: {
         appName: 'Open Science',
         appVersion: '0.0.0',
+        configRoot: '/fake/root',
         platform: 'test',
         versions: { electron: '1', chrome: '1', node: '1' }
       }
@@ -67,6 +68,7 @@ describe('startWebHttpServer', () => {
     const bootstrap = await fetch(`${base}/api/bootstrap`, { headers: { cookie } })
     expect(await bootstrap.json()).toMatchObject({
       appName: 'Open Science',
+      configRoot: '/fake/root',
       rpcChannels: ['test:echo']
     })
 
@@ -166,6 +168,7 @@ describe('startWebHttpServer', () => {
       bootstrap: {
         appName: 'Open Science',
         appVersion: '0.0.0',
+        configRoot: '/fake/root',
         platform: 'test',
         versions: { electron: '1', chrome: '1', node: '1' }
       }
@@ -232,6 +235,7 @@ describe('startWebHttpServer', () => {
       bootstrap: {
         appName: 'Open Science',
         appVersion: '0.0.0',
+        configRoot: '/fake/root',
         platform: 'test',
         versions: { electron: '1', chrome: '1', node: '1' }
       }
@@ -317,6 +321,7 @@ describe('startWebHttpServer', () => {
       bootstrap: {
         appName: 'Open Science',
         appVersion: '0.0.0',
+        configRoot: '/fake/root',
         platform: 'test',
         versions: { electron: '1', chrome: '1', node: '1' }
       }
@@ -381,6 +386,7 @@ describe('startWebHttpServer', () => {
       bootstrap: {
         appName: 'Open Science',
         appVersion: '0.0.0',
+        configRoot: '/fake/root',
         platform: 'test',
         versions: { electron: '1', chrome: '1', node: '1' }
       }

--- a/src/main/web-service/http-server.ts
+++ b/src/main/web-service/http-server.ts
@@ -63,6 +63,7 @@ type WebServerOptions = {
   bootstrap: {
     appName: string
     appVersion: string
+    configRoot: string
     platform: string
     versions: { electron: string; chrome: string; node: string }
   }

--- a/src/main/web-service/index.ts
+++ b/src/main/web-service/index.ts
@@ -110,6 +110,7 @@ const createWebServiceController = (
       bootstrap: {
         appName: info.appName,
         appVersion: info.appVersion,
+        configRoot,
         platform: process.platform,
         versions: info.versions
       }


### PR DESCRIPTION
## Problem

The Windows PR Check was dominated by a non-blocking full Vitest run. In a comparable baseline, the advisory step took 661 seconds of a 953-second Windows job, reported known cross-platform failures, and could not block a regression.

Removing that run from PRs improves feedback time, but doing only that would move coverage gaps to users. Post-merge and release validation therefore retain broad Windows visibility and exercise the packaged installer itself.

The focused gate also exposed a real production-shell issue: the scrubbed Windows environment made module-backed PowerShell cmdlets spend tens of seconds in module discovery, while native-command and parser-only paths stayed below 0.5 seconds.

## Proposed change

- Make the PR Windows job a focused, blocking gate for Windows filesystem, ACL, icon, runtime-cache, PowerShell, and public notebook-shell timeout/status behavior.
- Give each focused PowerShell process a 30-second budget and each Vitest case a separate 35-second budget. Production remains at 120 seconds.
- Provide a controlled PowerShell module search path containing the standard all-users and in-box module directories, in Windows PowerShell's standard precedence, without inheriting CurrentUser or arbitrary host entries. Restore that value after Windows PowerShell 5.1 startup reconstruction, preload the common Management and Utility in-box modules by absolute manifest path to avoid the observed first-cmdlet scan, and clear the internal carrier before user code runs.
- Run the complete Windows Vitest suite after merge and on stable tags as two shards in a dedicated advisory workflow. It is independent from reusable packaging, publishing, notarization, and upgrade smoke.
- Hard-gate every nightly and stable Windows artifact on a real NSIS install, packaged-resource checks, bundled micromamba execution, packaged-app startup, authenticated bootstrap probe, clean shutdown, and uninstall.
- Discover the packaged service from the app's own loopback startup output, matching Electron's real Windows home resolution instead of assuming that `USERPROFILE` changes `app.getPath('home')`.
- Give startup and shutdown independent 60-second budgets, drain the shutdown response before waiting for process exit, and bound `taskkill.exe` itself to 10 seconds with a direct-child fallback.
- On stable tags, install the previous published desktop `v*` release first and upgrade it in place with the current installer before publishing.
- Pass one isolated profile environment to all smoke child processes, but use each packaged app's authenticated data as the source of truth for its actual config root. Current builds must report the root in bootstrap. Already-published builds may omit it, so the smoke checks both the runner's real OS-home root and the isolated-profile root and accepts only the candidate whose existing `web-token` matches the authenticated service token. Write a collision-resistant sentinel into that verified root, require the current app to report the same root, verify preservation, and clean up the marker on both success and failure.
- Pin Node 22 in the stable upgrade-smoke job instead of relying on the mutable runner image.
- During uninstall, verify that the executable, packaged resources, Prisma engine, uninstaller, and installation directory are removed.
- Retry Windows file-lock cleanup without masking the primary smoke failure.
- Apply 10-minute and 20-minute GitHub Actions hard limits to the fresh-install smoke step and stable upgrade-smoke job respectively.

```mermaid
flowchart TD
  PR["Pull request"] --> PRWin["Focused Windows gate<br/>blocking, 4m54 measured"]
  PR --> Mac["macOS full coverage gate"]
  PR --> Linux["Ubuntu full suite<br/>advisory"]

  Main["Push to main"] --> Nightly["Nightly workflow"]
  Tag["Stable v* tag"] --> ReleaseFlow["Release workflow"]
  Main --> WinFull["Dedicated Windows full suite<br/>2 advisory shards"]
  Tag --> WinFull
  Nightly --> Build["Reusable build"]
  ReleaseFlow --> Build

  Build --> Package["Windows package"]
  Package --> Fresh["Install → resources → micromamba → start → authenticated probe → shutdown → uninstall<br/>blocking, 10m hard cap"]
  Fresh --> Artifact["Windows artifact"]
  Artifact --> NightlyPublish["Nightly publish"]
  Artifact --> Upgrade["Previous stable → report actual config root → sentinel → in-place upgrade → verify preservation<br/>blocking on stable tags, 20m hard cap"]
  Upgrade --> StablePublish["Stable publish"]
```

## Duration impact

| Path | Baseline | Measured result / expectation |
| --- | ---: | ---: |
| Windows PR Check | about 15m53s | **4m54s**, all focused Windows checks passed (about 69% faster) |
| Full Windows suite after merge / on stable tags | previously serialized in the PR job | **7m16s and 8m41s** in the final run; dedicated advisory workflow, so neither runtime nor result delays packaging or publishing; about 15m57s of Windows runner usage |
| Windows build task | existing release path | **8m20s** including dependencies, packaging, fresh smoke, and artifact upload |
| Windows package step | existing release path | **4m52s** |
| Fresh installer smoke | new | **42s**, passed end to end |
| Manual Release build | comparable build path | **13m49s** end to end; successful |
| Nightly overall | commonly 14–20m | expected around **14–16m** including publish; the full-suite shards are a separate workflow and the smoke adds about 42s in the measured run |
| Stable release | build plus notarization | previous-release upgrade is still estimated at roughly **2–4m** and runs in parallel with macOS notarization, so wall time is the slower branch rather than their sum |

The successful manual Release run was not a stable tag, so the tag-only previous-version upgrade and macOS notarization branches were intentionally skipped. Their workflow shape and smoke logic are covered by tests, but the upgrade duration remains an estimate until the next real stable tag.

## Scope and trade-offs

- The complete Windows suite is restored for `main` pushes and stable `v*` tags, but remains a separate advisory workflow because it currently contains known POSIX-only assertions. Nightly/release publishing neither waits for nor fails with it.
- The focused PR Windows gate and installer smokes are blocking.
- The installer smoke verifies the managed-runtime manifest and executes bundled `micromamba.exe`, but deliberately does not download and provision full Python/R environments on every release. That network-heavy canary remains a possible separately scheduled follow-up.
- macOS retains the full coverage gate; Ubuntu retains the full advisory suite.
- The two Windows full-suite shards consume additional runner minutes even though they do not extend wall-clock time.

## Acceptance criteria and validation

- Final PR Check: Windows **4m54s**, Ubuntu **6m11s**, macOS **10m24s**; all passed.
- Manual Release workflow: **13m49s**, including successful real Windows package and fresh-install smoke.
- Windows packaging: **4m52s**; fresh installer smoke: **42s**.
- Related PR workflow, runtime-service, installer, web bootstrap, release workflow, and Windows-shell tests after rebasing onto the latest `main`: **185 passed**, 4 Windows-only cases skipped locally.
- Full local suite on the final rebased source: **8,002 passed**, 139 skipped.
- `npm run typecheck` and `npm run lint` passed after the final material edit (0 lint errors; 24 existing warnings outside the changed files).
- `actionlint -shellcheck=`, Prettier, and `git diff --check`.
- Latest published stable release contains the expected `*-win-x64-setup.exe` asset consumed by the upgrade gate.

| Affected behavior | Final project-owned check | Result |
| --- | --- | --- |
| Sanitized machine `PSModulePath`, absolute in-box preload, wrapper restoration, and carrier removal | `src/main/notebook/runtime-service.test.ts` plus `src/main/notebook/windows-shell.integration.test.ts` in the affected Vitest command | Unit coverage passed locally; 4 Windows-only integration cases are hard-gated by PR Check |
| Actual/legacy config-root discovery, token authentication, collision-safe sentinel lifecycle, and bounded termination | `scripts/windows-installer-smoke.test.ts` | Passed in the 185-test affected suite |
| Authenticated bootstrap reports the resolved config root | `src/main/web-service/controller.test.ts` and `src/main/web-service/http-server.test.ts` | Passed in the 185-test affected suite |
| Fresh/upgrade Actions hard limits, independent post-merge full-suite workflow, and PR workflow shape | `scripts/windows-release-workflows.test.ts` and `scripts/pr-check-workflow.test.ts` | Passed in the 185-test affected suite; final standalone-workflow regression also passed after the workflow-only edit |
| Compile, static, and broad regression safety after rebase | `npm run typecheck`, `npm run lint`, `npm test`, Prettier, Node syntax, `actionlint -shellcheck=`, `git diff --check` | Passed; full Vitest: 8,002 passed / 139 skipped |

Independent Standards and Spec reviews of the final rebased diff found no remaining issue and confirmed that the mapping covers the deterministic behavior changed here.

Uncovered runtime risks: the real previous-release-to-current NSIS path only runs on stable tags; local tests simulate rather than induce a genuinely hung `taskkill.exe`; effective Windows PowerShell behavior requires the PR's Windows runner; non-preloaded in-box modules can still incur their normal AllUsers-first cold discovery cost; and local YAML tests cannot prove GitHub event fan-out until the first `main` push or tag. Stable Release CI, 10/20-minute Actions caps, the blocking Windows PR Check, the 120-second production shell budget, and the standalone workflow's first live trigger are the corresponding confirmation layers.

## Review findings addressed

- `PSModulePath` now contains `%ProgramFiles%\WindowsPowerShell\Modules` and `$PSHOME\Modules` in standard order, then is restored inside the encoded wrapper so Windows PowerShell startup cannot silently reinsert CurrentUser paths. The wrapper imports the Management and Utility in-box manifests by absolute path, avoiding the live-observed slow AllUsers scan without changing precedence for other modules. The existing Windows UTF-8 process asserts the exact effective path and verifies that the internal carrier is removed. It deliberately does not require a particular AllUsers module to be preinstalled on every runner image.
- Upgrade preservation is checked in the actual verified config root rather than blindly assuming either Electron's OS home or the child `USERPROFILE`, eliminating the previous false-positive path. For already-published binaries, both locations are only candidates and the endpoint token authenticates which one the running app actually used. Current binaries still fail closed without an absolute reported `configRoot`; UUID markers use exclusive creation and unconditional cleanup so they neither overwrite nor remain in a real profile.
- `taskkill.exe` has an independent bounded wait, process timeouts cannot be converted into successful non-zero exits, and Actions-level limits provide defense in depth.
- The advisory complete Windows shards now run in a standalone `main`/`v*` workflow, so reusable `build.yml` callers no longer wait for them before nightly or stable publication.

The Windows-only integration assertion and packaged installer path are revalidated by the PR and Release workflows after push; the tag-only previous-version upgrade remains covered structurally until the next real stable tag.
