### PR TITLE
fix(artifact-provenance): stabilize finalization failures

### DIFF
--- a/src/main/artifacts/ipc.test.ts
+++ b/src/main/artifacts/ipc.test.ts
@@ -4,11 +4,19 @@ import { tmpdir } from 'node:os'
 import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest'
 
 import { createArtifactVersionLocator } from '../../shared/artifact-provenance'
-import type { ArtifactFile, ArtifactWriteSource } from '../../shared/artifacts'
+import {
+  ARTIFACT_OWNERSHIP_PERSISTENCE_RACE,
+  type ArtifactFile,
+  type ArtifactWriteSource
+} from '../../shared/artifacts'
 import { createLinearConversationGraph } from '../../shared/conversation-graph'
 import type { PersistedChatSession } from '../../shared/session-persistence'
 import { createPngBytes, createPngInlineSource } from './artifact-test-fixtures'
-import { ArtifactProvenanceRepository } from './provenance-repository'
+import {
+  ArtifactFinalizationProofError,
+  ArtifactOwnershipPersistenceRaceError,
+  ArtifactProvenanceRepository
+} from './provenance-repository'
 import { ArtifactRepository } from './repository'
 import {
   createArtifactHandlers,
@@ -225,8 +233,15 @@ describe('artifact IPC handlers', () => {
     const repository = {
       finalizeRunArtifacts: vi.fn()
     } as unknown as ArtifactRepository
+    const diagnosticLogger = { error: vi.fn() }
     const provenance = {
-      finalizeRun: vi.fn().mockRejectedValue(new Error('corrupt Artifact Version proof'))
+      finalizeRun: vi
+        .fn()
+        .mockRejectedValue(
+          new ArtifactFinalizationProofError(
+            'corrupt Artifact Version proof for /Users/private/result.txt: secret artifact contents'
+          )
+        )
     }
     const registry = new ArtifactRunRegistry()
     const claimId = registry.register({
@@ -242,7 +257,8 @@ describe('artifact IPC handlers', () => {
       artifactVersionIds: ['version-1']
     })
     const handlers = createArtifactHandlers(repository, registry, {
-      provenance: provenance as never
+      provenance: provenance as never,
+      logger: diagnosticLogger
     })
 
     await expect(
@@ -251,6 +267,24 @@ describe('artifact IPC handlers', () => {
     expect(repository.finalizeRunArtifacts).not.toHaveBeenCalled()
     expect(provenance.finalizeRun).toHaveBeenCalledOnce()
     expect(registry.resolve(claimId).finalizedMessageId).toBeUndefined()
+    expect(diagnosticLogger.error).toHaveBeenCalledOnce()
+    expect(diagnosticLogger.error).toHaveBeenCalledWith(
+      'artifact finalization attempt failed',
+      expect.objectContaining({
+        stage: 'durable-finalization',
+        failureKind: 'invalid-proof',
+        durableFinalizationCompleted: false,
+        compatibilityPublicationCompleted: false,
+        claimId,
+        artifactRunId: 'run-1',
+        artifactVersionIds: ['version-1'],
+        messageId: 'message-forged',
+        messageBranchId: 'branch-1'
+      })
+    )
+    const diagnostic = JSON.stringify(diagnosticLogger.error.mock.calls[0])
+    expect(diagnostic).not.toContain('secret artifact contents')
+    expect(diagnostic).not.toContain('/Users/private')
   })
 
   it('does not bypass provenance when a claim is missing part of its durable context', async () => {
@@ -406,10 +440,15 @@ describe('artifact IPC handlers', () => {
 
   it('retries compatibility publication after provenance finalized but the first move failed', async () => {
     const finalizedArtifact = createFinalizedArtifact()
+    const diagnosticLogger = { error: vi.fn() }
     const repository = {
       finalizeRunArtifacts: vi
         .fn()
-        .mockRejectedValueOnce(new Error('compatibility storage unavailable'))
+        .mockRejectedValueOnce(
+          new Error(
+            'compatibility storage unavailable at /Users/private/result.txt: secret artifact contents'
+          )
+        )
         .mockResolvedValue([finalizedArtifact])
     } as unknown as ArtifactRepository
     const provenance = {
@@ -429,7 +468,8 @@ describe('artifact IPC handlers', () => {
       artifactVersionIds: ['version-1']
     })
     const handlers = createArtifactHandlers(repository, registry, {
-      provenance: provenance as never
+      provenance: provenance as never,
+      logger: diagnosticLogger
     })
 
     await expect(
@@ -438,6 +478,23 @@ describe('artifact IPC handlers', () => {
     expect(repository.finalizeRunArtifacts).toHaveBeenCalledOnce()
     expect(provenance.finalizeRun).toHaveBeenCalledOnce()
     expect(registry.resolve(claimId).finalizedMessageId).toBeUndefined()
+    expect(diagnosticLogger.error).toHaveBeenCalledWith(
+      'artifact finalization attempt failed',
+      expect.objectContaining({
+        stage: 'compatibility-publication',
+        failureKind: 'operational-failure',
+        durableFinalizationCompleted: true,
+        compatibilityPublicationCompleted: false,
+        claimId,
+        artifactRunId: 'run-1',
+        artifactVersionIds: ['version-1'],
+        messageId: 'message-1',
+        messageBranchId: 'branch-1'
+      })
+    )
+    const diagnostic = JSON.stringify(diagnosticLogger.error.mock.calls[0])
+    expect(diagnostic).not.toContain('secret artifact contents')
+    expect(diagnostic).not.toContain('/Users/private')
 
     await expect(
       handlers.finalizeRunArtifacts({ claimId, messageId: 'message-1' })
@@ -445,6 +502,7 @@ describe('artifact IPC handlers', () => {
     expect(repository.finalizeRunArtifacts).toHaveBeenCalledTimes(2)
     expect(provenance.finalizeRun).toHaveBeenCalledTimes(2)
     expect(registry.resolve(claimId).finalizedMessageId).toBe('message-1')
+    expect(diagnosticLogger.error).toHaveBeenCalledOnce()
   })
 
   it('keeps migration drain pending until an artifact finalization already in progress finishes', async () => {
@@ -726,13 +784,14 @@ describe('artifact IPC handler registration', () => {
     })
     registerArtifactIpcHandlers(repository, runRegistry)
 
-    await ipcHandlers.get('artifacts:finalize-run')?.(
+    const finalizeResult = await ipcHandlers.get('artifacts:finalize-run')?.(
       {},
       {
         claimId,
         messageId: 'message-1'
       }
     )
+    expect(finalizeResult).toEqual({ ok: true, artifacts: [] })
     expect(finalizeRunArtifacts).toHaveBeenCalledWith({
       projectName: 'default-project',
       sourceSessionId: 'artifact-session-1',
@@ -779,6 +838,43 @@ describe('artifact IPC handler registration', () => {
       path: '/managed/inside.txt',
       maxBytes: 16
     })
+  })
+
+  it('returns only the ownership persistence race as a stable IPC failure result', async () => {
+    const repository = { finalizeRunArtifacts: vi.fn() } as unknown as ArtifactRepository
+    const provenance = {
+      finalizeRun: vi
+        .fn()
+        .mockRejectedValue(
+          new ArtifactOwnershipPersistenceRaceError(
+            'The durable graph projection has not caught up with the selected owner.'
+          )
+        )
+    }
+    const runRegistry = new ArtifactRunRegistry()
+    const claimId = runRegistry.register({
+      projectName: 'default-project',
+      artifactSessionId: 'artifact-session-1',
+      sessionId: 'session-1',
+      runId: 'run-1',
+      rootFrameId: 'root-frame-1',
+      agentFrameId: 'agent-frame-1',
+      messageBranchId: 'branch-1',
+      runtimeSegmentId: 'runtime-1',
+      promptMessageId: 'prompt-1',
+      artifactVersionIds: ['version-1']
+    })
+    registerArtifactIpcHandlers(repository, runRegistry, undefined, provenance as never)
+
+    await expect(
+      ipcHandlers.get('artifacts:finalize-run')?.({}, { claimId, messageId: 'message-1' })
+    ).resolves.toEqual({
+      ok: false,
+      code: ARTIFACT_OWNERSHIP_PERSISTENCE_RACE,
+      message: 'The durable graph projection has not caught up with the selected owner.'
+    })
+    expect(repository.finalizeRunArtifacts).not.toHaveBeenCalled()
+    expect(runRegistry.resolve(claimId).finalizedMessageId).toBeUndefined()
   })
 
   it('resolves native Version preview locators through Provenance instead of filesystem paths', async () => {

--- a/src/main/artifacts/ipc.ts
+++ b/src/main/artifacts/ipc.ts
@@ -1,6 +1,11 @@
 import { ipcMain, shell } from 'electron'
 
-import type { ArtifactFile, ArtifactPreviewResult } from '../../shared/artifacts'
+import {
+  ARTIFACT_OWNERSHIP_PERSISTENCE_RACE,
+  type ArtifactFile,
+  type ArtifactPreviewResult,
+  type FinalizeRunArtifactsResult
+} from '../../shared/artifacts'
 import type {
   ArtifactLineageProvenance,
   ArtifactVersionExecutionProvenance,
@@ -21,9 +26,16 @@ import type {
 import { resolveDataRoot } from '../storage-root'
 import { withDataRootWrite } from '../storage/migration-state'
 import { readBoundedManagedFilePreview } from '../managed-file-preview'
+import { createLogger, type Logger } from '../logger'
 import { ArtifactRepository } from './repository'
 import { ArtifactRunRegistry } from './run-registry'
-import type { ArtifactProvenanceRepository } from './provenance-repository'
+import {
+  ArtifactFinalizationProofError,
+  ArtifactOwnershipPersistenceRaceError,
+  type ArtifactProvenanceRepository
+} from './provenance-repository'
+
+const log = createLogger('artifacts:finalization')
 
 type ArtifactHandlers = {
   finalizeRunArtifacts: (request: FinalizeRunArtifactsRequest) => Promise<ArtifactFile[]>
@@ -48,6 +60,7 @@ type ArtifactHandlers = {
 
 type ArtifactHandlerDependencies = {
   openPath?: (path: string) => Promise<string>
+  logger?: Pick<Logger, 'error'>
   // Run ids of turns in flight right now (live runtime state). Their pending files are still being
   // written, so the orphan scan excludes them; a crashed run is absent here and correctly surfaces.
   getActiveArtifactRunIds?: () => string[]
@@ -121,7 +134,13 @@ const createArtifactHandlers = (
         withClaimLock(finalizeLocks, request.claimId, () => {
           const claim = runRegistry.resolve(request.claimId)
           const finalize = (): Promise<ArtifactFile[]> =>
-            finalizeRunArtifacts(repository, runRegistry, request, dependencies.provenance)
+            finalizeRunArtifacts(
+              repository,
+              runRegistry,
+              request,
+              dependencies.provenance,
+              dependencies.logger ?? log
+            )
           return dependencies.withSessionMutation
             ? dependencies.withSessionMutation(claim.projectName, claim.sessionId, finalize)
             : finalize()
@@ -181,7 +200,8 @@ const finalizeRunArtifacts = async (
   repository: ArtifactRepository,
   runRegistry: ArtifactRunRegistry,
   request: FinalizeRunArtifactsRequest,
-  provenance?: Pick<ArtifactProvenanceRepository, 'finalizeRun'>
+  provenance?: Pick<ArtifactProvenanceRepository, 'finalizeRun'>,
+  logger: Pick<Logger, 'error'> = log
 ): Promise<ArtifactFile[]> => {
   const claim = runRegistry.resolve(request.claimId)
 
@@ -200,67 +220,103 @@ const finalizeRunArtifacts = async (
     })
   }
 
-  let provenanceArtifacts: ArtifactFile[] | undefined
-  let provenanceRequest: Parameters<ArtifactProvenanceRepository['finalizeRun']>[0] | undefined
-  if (provenance) {
-    if (
-      !claim.rootFrameId ||
-      !claim.agentFrameId ||
-      !claim.messageBranchId ||
-      !claim.runtimeSegmentId ||
-      !claim.promptMessageId
-    ) {
-      throw new Error('Artifact run claim is missing complete provenance context.')
-    }
-    if (!claim.artifactVersionIds || claim.artifactVersionIds.length === 0) {
-      throw new Error('Artifact run claim is missing exact Artifact Version ids.')
-    }
-    provenanceRequest = {
-      projectId: claim.projectName,
-      appSessionId: claim.sessionId,
-      artifactRunId: claim.runId,
-      artifactVersionIds: [...claim.artifactVersionIds],
-      rootFrameId: claim.rootFrameId,
-      agentFrameId: claim.agentFrameId,
-      messageBranchId: claim.messageBranchId,
-      runtimeSegmentId: claim.runtimeSegmentId,
-      promptMessageId: claim.promptMessageId,
-      messageId: request.messageId
-    }
-    // Commit the complete provenance proof and immutable message ownership before compatibility bytes
-    // move. A later compatibility failure is retryable because the prepared marker remains durable.
-    provenanceArtifacts = await provenance.finalizeRun(provenanceRequest)
-  }
+  let durableFinalizationCompleted = false
+  let compatibilityPublicationCompleted = false
+  let stage: 'durable-finalization' | 'compatibility-publication' = 'durable-finalization'
 
-  // Publish compatibility bytes only after the complete provenance transaction succeeds. The move is
-  // idempotent, so a finalized-but-unlinked run can replay here or during prepared-marker recovery.
-  const artifacts = await repository.finalizeRunArtifacts({
-    projectName: claim.projectName,
-    sourceSessionId: claim.artifactSessionId,
-    sessionId: claim.sessionId,
-    runId: claim.runId,
-    messageId: request.messageId,
-    ...(claim.artifactVersionIds ? { artifactVersionIds: claim.artifactVersionIds } : {}),
-    ...(claim.rootFrameId &&
-    claim.agentFrameId &&
-    claim.messageBranchId &&
-    claim.runtimeSegmentId &&
-    claim.promptMessageId
-      ? {
-          provenanceContext: {
-            rootFrameId: claim.rootFrameId,
-            agentFrameId: claim.agentFrameId,
-            messageBranchId: claim.messageBranchId,
-            runtimeSegmentId: claim.runtimeSegmentId,
-            promptMessageId: claim.promptMessageId
+  try {
+    let provenanceArtifacts: ArtifactFile[] | undefined
+    let provenanceRequest: Parameters<ArtifactProvenanceRepository['finalizeRun']>[0] | undefined
+    if (provenance) {
+      if (
+        !claim.rootFrameId ||
+        !claim.agentFrameId ||
+        !claim.messageBranchId ||
+        !claim.runtimeSegmentId ||
+        !claim.promptMessageId
+      ) {
+        throw new ArtifactFinalizationProofError(
+          'Artifact run claim is missing complete provenance context.'
+        )
+      }
+      if (!claim.artifactVersionIds || claim.artifactVersionIds.length === 0) {
+        throw new ArtifactFinalizationProofError(
+          'Artifact run claim is missing exact Artifact Version ids.'
+        )
+      }
+      provenanceRequest = {
+        projectId: claim.projectName,
+        appSessionId: claim.sessionId,
+        artifactRunId: claim.runId,
+        artifactVersionIds: [...claim.artifactVersionIds],
+        rootFrameId: claim.rootFrameId,
+        agentFrameId: claim.agentFrameId,
+        messageBranchId: claim.messageBranchId,
+        runtimeSegmentId: claim.runtimeSegmentId,
+        promptMessageId: claim.promptMessageId,
+        messageId: request.messageId
+      }
+      // Commit the complete provenance proof and immutable message ownership before compatibility bytes
+      // move. A later compatibility failure is retryable because the prepared marker remains durable.
+      provenanceArtifacts = await provenance.finalizeRun(provenanceRequest)
+      durableFinalizationCompleted = true
+    }
+
+    stage = 'compatibility-publication'
+    // Publish compatibility bytes only after the complete provenance transaction succeeds. The move is
+    // idempotent, so a finalized-but-unlinked run can replay here or during prepared-marker recovery.
+    const artifacts = await repository.finalizeRunArtifacts({
+      projectName: claim.projectName,
+      sourceSessionId: claim.artifactSessionId,
+      sessionId: claim.sessionId,
+      runId: claim.runId,
+      messageId: request.messageId,
+      ...(claim.artifactVersionIds ? { artifactVersionIds: claim.artifactVersionIds } : {}),
+      ...(claim.rootFrameId &&
+      claim.agentFrameId &&
+      claim.messageBranchId &&
+      claim.runtimeSegmentId &&
+      claim.promptMessageId
+        ? {
+            provenanceContext: {
+              rootFrameId: claim.rootFrameId,
+              agentFrameId: claim.agentFrameId,
+              messageBranchId: claim.messageBranchId,
+              runtimeSegmentId: claim.runtimeSegmentId,
+              promptMessageId: claim.promptMessageId
+            }
           }
-        }
-      : {})
-  })
+        : {})
+    })
+    compatibilityPublicationCompleted = true
 
-  runRegistry.markFinalized(request.claimId, request.messageId)
+    runRegistry.markFinalized(request.claimId, request.messageId)
 
-  return provenanceArtifacts ?? artifacts
+    return provenanceArtifacts ?? artifacts
+  } catch (error) {
+    const failureKind =
+      error instanceof ArtifactOwnershipPersistenceRaceError
+        ? ARTIFACT_OWNERSHIP_PERSISTENCE_RACE
+        : error instanceof ArtifactFinalizationProofError
+          ? 'invalid-proof'
+          : 'operational-failure'
+    logger.error('artifact finalization attempt failed', {
+      stage,
+      failureKind,
+      durableFinalizationCompleted,
+      compatibilityPublicationCompleted,
+      claimId: request.claimId,
+      artifactRunId: claim.runId,
+      messageId: request.messageId,
+      ...(claim.artifactVersionIds ? { artifactVersionIds: [...claim.artifactVersionIds] } : {}),
+      ...(claim.rootFrameId ? { rootFrameId: claim.rootFrameId } : {}),
+      ...(claim.agentFrameId ? { agentFrameId: claim.agentFrameId } : {}),
+      ...(claim.messageBranchId ? { messageBranchId: claim.messageBranchId } : {}),
+      ...(claim.runtimeSegmentId ? { runtimeSegmentId: claim.runtimeSegmentId } : {}),
+      ...(claim.promptMessageId ? { promptMessageId: claim.promptMessageId } : {})
+    })
+    throw error
+  }
 }
 
 // Artifacts are data-class: they follow the configurable data root (defaults to the config root).
@@ -291,8 +347,20 @@ const registerArtifactIpcHandlers = (
     withSessionMutation
   })
 
-  ipcMain.handle('artifacts:finalize-run', (_event, request: FinalizeRunArtifactsRequest) =>
-    handlers.finalizeRunArtifacts(request)
+  ipcMain.handle(
+    'artifacts:finalize-run',
+    async (_event, request: FinalizeRunArtifactsRequest): Promise<FinalizeRunArtifactsResult> => {
+      try {
+        return { ok: true, artifacts: await handlers.finalizeRunArtifacts(request) }
+      } catch (error) {
+        if (!(error instanceof ArtifactOwnershipPersistenceRaceError)) throw error
+        return {
+          ok: false,
+          code: ARTIFACT_OWNERSHIP_PERSISTENCE_RACE,
+          message: error.message
+        }
+      }
+    }
   )
   ipcMain.handle('artifacts:list-project-files', (_event, request: ListProjectArtifactsRequest) =>
     handlers.listProjectFiles(request)

--- a/src/main/artifacts/provenance-repository.test.ts
+++ b/src/main/artifacts/provenance-repository.test.ts
@@ -21,7 +21,10 @@ import type { PersistedChatSession } from '../../shared/session-persistence'
 import { createProjectDbClient, ensureProjectSchema } from '../projects/prisma-client'
 import { NotebookRunRepository } from '../notebook/repository'
 import { createPngBytes, createPngInlineSource } from './artifact-test-fixtures'
-import { ArtifactProvenanceRepository } from './provenance-repository'
+import {
+  ArtifactOwnershipPersistenceRaceError,
+  ArtifactProvenanceRepository
+} from './provenance-repository'
 import { ArtifactRepository } from './repository'
 
 let storageRoot: string | undefined
@@ -2022,7 +2025,7 @@ describe('artifact provenance repository', () => {
         messageBranchAncestry: [branch.id],
         messageAncestry: [prompt.id, 'message-forged']
       })
-    ).rejects.toThrow(/durable Session graph|Branch descendant/i)
+    ).rejects.toBeInstanceOf(ArtifactOwnershipPersistenceRaceError)
 
     const durablePrompt = conversationGraph.messages.find((message) => message.id === prompt.id)!
     durablePrompt.status = 'streaming'
@@ -2035,12 +2038,25 @@ describe('artifact provenance repository', () => {
         ...context,
         messageId: assistant.id
       })
-    ).rejects.toThrow(/Branch descendant/i)
+    ).rejects.toMatchObject({ name: 'ArtifactFinalizationProofError' })
 
     durablePrompt.status = 'complete'
     const durableAssistant = conversationGraph.messages.find(
       (message) => message.id === assistant.id
     )!
+    durableAssistant.role = 'user'
+    await expect(
+      repository.validateFinalizationOwnership({
+        projectId: 'project-1',
+        appSessionId: 'session-1',
+        artifactRunId: 'artifact-run-1',
+        artifactVersionIds: [version.versionId],
+        ...context,
+        messageId: assistant.id
+      })
+    ).rejects.toMatchObject({ name: 'ArtifactFinalizationProofError' })
+
+    durableAssistant.role = 'agent'
     durableAssistant.status = 'streaming'
     await expect(
       repository.validateFinalizationOwnership({
@@ -2257,7 +2273,7 @@ describe('artifact provenance repository', () => {
 
     await expect(
       repository.finalizeRun({ ...finalizeRequest, messageId: 'message-2' })
-    ).rejects.toThrow(/Branch descendant|different message/i)
+    ).rejects.toBeInstanceOf(ArtifactOwnershipPersistenceRaceError)
     await expect(
       repository.finalizeRun({
         ...finalizeRequest,

--- a/src/main/artifacts/provenance-repository.ts
+++ b/src/main/artifacts/provenance-repository.ts
@@ -227,10 +227,17 @@ type ArtifactFinalizationContext = Pick<
 
 type PreparedArtifactFinalizationContext = Omit<ArtifactFinalizationContext, 'messageId'>
 
-class ArtifactFinalizationProofError extends Error {
+export class ArtifactFinalizationProofError extends Error {
   constructor(message: string, cause?: unknown) {
     super(message, cause === undefined ? undefined : { cause })
     this.name = 'ArtifactFinalizationProofError'
+  }
+}
+
+export class ArtifactOwnershipPersistenceRaceError extends ArtifactFinalizationProofError {
+  constructor(message = 'Artifact finalization ownership is not durable yet.') {
+    super(message)
+    this.name = 'ArtifactOwnershipPersistenceRaceError'
   }
 }
 
@@ -258,18 +265,26 @@ const validateDurableMessageOwnership = (
 ): { messageBranchAncestry: string[]; messageAncestry: string[] } => {
   const graph = materializeSessionConversationGraph(session).conversationGraph!
   if (graph.rootFrameId !== context.rootFrameId) {
-    throw new Error('Artifact finalization root Frame does not match the durable Session graph.')
+    throw new ArtifactFinalizationProofError(
+      'Artifact finalization root Frame does not match the durable Session graph.'
+    )
   }
   const frame = graph.frames.find((candidate) => candidate.id === context.agentFrameId)
   const branch = graph.branches.find((candidate) => candidate.id === context.messageBranchId)
   if (!frame || !branch || branch.agentFrameId !== frame.id) {
-    throw new Error('Artifact finalization Branch does not belong to the declared Agent Frame.')
+    throw new ArtifactFinalizationProofError(
+      'Artifact finalization Branch does not belong to the declared Agent Frame.'
+    )
   }
   const segment = graph.runtimeSegments.find(
     (candidate) =>
       candidate.id === context.runtimeSegmentId && candidate.agentFrameId === context.agentFrameId
   )
-  if (!segment) throw new Error('Artifact finalization Runtime Segment is not durable.')
+  if (!segment) {
+    throw new ArtifactFinalizationProofError(
+      'Artifact finalization Runtime Segment is not durable.'
+    )
+  }
   const path = resolveMessageBranchPath(graph, context.messageBranchId)
   const promptIndex = path.findIndex((message) => message.id === context.promptMessageId)
   const finalIndex = path.findIndex((message) => message.id === context.messageId)
@@ -281,20 +296,32 @@ const validateDurableMessageOwnership = (
   // Runtime Segment, role, and ordered path identity remain the fail-closed ownership boundary.
   if (
     promptIndex < 0 ||
-    finalIndex <= promptIndex ||
     !promptMessage ||
     promptMessage.role !== 'user' ||
     promptMessage.status !== 'complete' ||
     promptMessage.agentFrameId !== context.agentFrameId ||
     promptMessage.introducedOnBranchId !== context.messageBranchId ||
-    promptMessage.runtimeSegmentId !== context.runtimeSegmentId ||
-    !finalMessage ||
+    promptMessage.runtimeSegmentId !== context.runtimeSegmentId
+  ) {
+    throw new ArtifactFinalizationProofError(
+      'Artifact finalization prompt does not match the declared durable ownership.'
+    )
+  }
+  if (finalIndex < 0 || !finalMessage) {
+    throw new ArtifactOwnershipPersistenceRaceError(
+      'Artifact finalization message is not durable yet.'
+    )
+  }
+  if (
+    finalIndex <= promptIndex ||
     finalMessage.role !== 'agent' ||
     finalMessage.agentFrameId !== context.agentFrameId ||
     finalMessage.introducedOnBranchId !== context.messageBranchId ||
     finalMessage.runtimeSegmentId !== context.runtimeSegmentId
   ) {
-    throw new Error('Artifact finalization message is not a Branch descendant of its prompt.')
+    throw new ArtifactFinalizationProofError(
+      'Artifact finalization message does not match the declared durable ownership.'
+    )
   }
   const branches = new Map(graph.branches.map((candidate) => [candidate.id, candidate]))
   const branchAncestry: string[] = []

--- a/src/main/web-service/task-api.test.ts
+++ b/src/main/web-service/task-api.test.ts
@@ -1,6 +1,7 @@
 import { describe, expect, it, vi } from 'vitest'
 
 import type { AcpRuntimeEvent } from '../../shared/acp'
+import { ARTIFACT_OWNERSHIP_PERSISTENCE_RACE } from '../../shared/artifacts'
 import type { PersistedChatSession } from '../../shared/session-persistence'
 import { HeadlessTaskApi } from './task-api'
 
@@ -453,8 +454,9 @@ describe('HeadlessTaskApi', () => {
     ])
   })
 
-  it('finalizes artifacts and persists the session when a prompt fails', async () => {
+  it('retries an ownership persistence race and preserves artifacts when a prompt fails', async () => {
     let emitEvent: ((event: AcpRuntimeEvent) => void) | undefined
+    let finalizeAttempts = 0
     const savedSessions: PersistedChatSession[] = []
     const invoke = vi.fn(async (channel: string, _clientId: string, args: unknown[]) => {
       if (channel === 'projects:list') return [project]
@@ -487,6 +489,14 @@ describe('HeadlessTaskApi', () => {
         throw new Error('raw provider failure')
       }
       if (channel === 'artifacts:finalize-run') {
+        finalizeAttempts += 1
+        if (finalizeAttempts === 1) {
+          return {
+            ok: false,
+            code: ARTIFACT_OWNERSHIP_PERSISTENCE_RACE,
+            message: 'The durable projection has not caught up yet.'
+          }
+        }
         return {
           ok: true,
           artifacts: [
@@ -529,9 +539,26 @@ describe('HeadlessTaskApi', () => {
       error: 'Provider rejected the request.',
       artifacts: [{ id: 'artifact-1', name: 'partial-report.md' }]
     })
-    expect(invoke).toHaveBeenCalledWith('artifacts:finalize-run', expect.any(String), [
-      { claimId: 'claim-1', messageId: 'agent-message' }
+    expect(finalizeAttempts).toBe(2)
+    expect(
+      invoke.mock.calls
+        .map(([channel]) => channel)
+        .filter((channel) => ['sessions:save-session', 'artifacts:finalize-run'].includes(channel))
+    ).toEqual([
+      'sessions:save-session',
+      'artifacts:finalize-run',
+      'sessions:save-session',
+      'artifacts:finalize-run',
+      'sessions:save-session'
     ])
+    expect(savedSessions[1]).toMatchObject({
+      status: 'running',
+      messages: [
+        { id: 'user-message', role: 'user' },
+        { id: 'agent-message', role: 'agent', status: 'complete' }
+      ]
+    })
+    expect(savedSessions[1].messages.at(-1)?.artifactIds).toBeUndefined()
     expect(savedSessions.at(-1)).toMatchObject({
       status: 'error',
       error: 'Provider rejected the request.',

--- a/src/main/web-service/task-api.test.ts
+++ b/src/main/web-service/task-api.test.ts
@@ -487,20 +487,23 @@ describe('HeadlessTaskApi', () => {
         throw new Error('raw provider failure')
       }
       if (channel === 'artifacts:finalize-run') {
-        return [
-          {
-            id: 'artifact-1',
-            projectName: project.id,
-            sessionId: 'session-failed',
-            messageId: 'agent-message',
-            name: 'partial-report.md',
-            path: '/artifacts/partial-report.md',
-            fileUrl: 'open-science-preview://artifact-1/partial-report.md',
-            mimeType: 'text/markdown',
-            size: 10,
-            mtimeMs: 12
-          }
-        ]
+        return {
+          ok: true,
+          artifacts: [
+            {
+              id: 'artifact-1',
+              projectName: project.id,
+              sessionId: 'session-failed',
+              messageId: 'agent-message',
+              name: 'partial-report.md',
+              path: '/artifacts/partial-report.md',
+              fileUrl: 'open-science-preview://artifact-1/partial-report.md',
+              mimeType: 'text/markdown',
+              size: 10,
+              mtimeMs: 12
+            }
+          ]
+        }
       }
       throw new Error(`Unexpected RPC channel: ${channel}`)
     })

--- a/src/main/web-service/task-api.test.ts
+++ b/src/main/web-service/task-api.test.ts
@@ -454,7 +454,7 @@ describe('HeadlessTaskApi', () => {
     ])
   })
 
-  it('retries an ownership persistence race and preserves artifacts when a prompt fails', async () => {
+  it('preserves finalized artifacts when a later claim fails after an ownership retry', async () => {
     let emitEvent: ((event: AcpRuntimeEvent) => void) | undefined
     let finalizeAttempts = 0
     const savedSessions: PersistedChatSession[] = []
@@ -479,8 +479,17 @@ describe('HeadlessTaskApi', () => {
           artifacts: []
         })
         emitEvent?.({
-          id: 'error-event',
+          id: 'artifact-event-later',
           timestamp: 11,
+          kind: 'artifact',
+          level: 'info',
+          sessionId: 'session-failed',
+          artifactClaimId: 'claim-2',
+          artifacts: []
+        })
+        emitEvent?.({
+          id: 'error-event',
+          timestamp: 12,
           kind: 'error',
           level: 'error',
           sessionId: 'session-failed',
@@ -490,12 +499,16 @@ describe('HeadlessTaskApi', () => {
       }
       if (channel === 'artifacts:finalize-run') {
         finalizeAttempts += 1
-        if (finalizeAttempts === 1) {
+        const request = args[0] as { claimId: string }
+        if (request.claimId === 'claim-1' && finalizeAttempts === 1) {
           return {
             ok: false,
             code: ARTIFACT_OWNERSHIP_PERSISTENCE_RACE,
             message: 'The durable projection has not caught up yet.'
           }
+        }
+        if (request.claimId === 'claim-2') {
+          throw new Error('compatibility publication failed')
         }
         return {
           ok: true,
@@ -539,7 +552,7 @@ describe('HeadlessTaskApi', () => {
       error: 'Provider rejected the request.',
       artifacts: [{ id: 'artifact-1', name: 'partial-report.md' }]
     })
-    expect(finalizeAttempts).toBe(2)
+    expect(finalizeAttempts).toBe(3)
     expect(
       invoke.mock.calls
         .map(([channel]) => channel)
@@ -548,6 +561,7 @@ describe('HeadlessTaskApi', () => {
       'sessions:save-session',
       'artifacts:finalize-run',
       'sessions:save-session',
+      'artifacts:finalize-run',
       'artifacts:finalize-run',
       'sessions:save-session'
     ])

--- a/src/main/web-service/task-api.ts
+++ b/src/main/web-service/task-api.ts
@@ -7,7 +7,7 @@ import {
   type AcpPromptRequest,
   type AcpRuntimeEvent
 } from '../../shared/acp'
-import type { ArtifactFile } from '../../shared/artifacts'
+import type { ArtifactFile, FinalizeRunArtifactsResult } from '../../shared/artifacts'
 import { DEFAULT_PERMISSION_PROFILE } from '../../shared/permission-profiles'
 import type { Project } from '../../shared/projects'
 import type {
@@ -478,11 +478,14 @@ class HeadlessTaskApi {
     const finalizedArtifacts: ArtifactFile[] = []
     for (const event of events) {
       if (event.kind !== 'artifact' || !event.artifactClaimId) continue
-      const artifacts = (await this.invoke('artifacts:finalize-run', {
+      const result = (await this.invoke('artifacts:finalize-run', {
         claimId: event.artifactClaimId,
         messageId: assistantMessageId
-      })) as ArtifactFile[]
-      finalizedArtifacts.push(...artifacts)
+      })) as FinalizeRunArtifactsResult
+      if (!result.ok) {
+        throw new Error(result.message)
+      }
+      finalizedArtifacts.push(...result.artifacts)
     }
     const assistantMessage: PersistedChatMessage = {
       id: assistantMessageId,

--- a/src/main/web-service/task-api.ts
+++ b/src/main/web-service/task-api.ts
@@ -47,6 +47,22 @@ type MutableTaskRun = TaskRun & {
   completion: Promise<void>
 }
 
+type CompletedTaskSession = {
+  session: PersistedChatSession
+  output: string
+  artifacts: ArtifactFile[]
+}
+
+class PartialTaskCompletionError extends Error {
+  constructor(
+    readonly completion: CompletedTaskSession,
+    readonly failure: unknown
+  ) {
+    super(failure instanceof Error ? failure.message : String(failure))
+    this.name = 'PartialTaskCompletionError'
+  }
+}
+
 class TaskApiError extends Error {
   constructor(
     readonly code: TaskApiErrorCode,
@@ -413,7 +429,12 @@ class HeadlessTaskApi {
     try {
       completed = await this.completeSession(session, run.events)
     } catch (error) {
-      completionError = error
+      if (error instanceof PartialTaskCompletionError) {
+        completed = error.completion
+        completionError = error.failure
+      } else {
+        completionError = error
+      }
     }
 
     const failure = completionError ?? promptError
@@ -466,7 +487,7 @@ class HeadlessTaskApi {
   private async completeSession(
     session: PersistedChatSession,
     events: AcpRuntimeEvent[]
-  ): Promise<{ session: PersistedChatSession; output: string; artifacts: ArtifactFile[] }> {
+  ): Promise<CompletedTaskSession> {
     const now = this.dependencies.now()
     const assistantEvents = events.filter(
       (event) => event.kind === 'message' && event.role === 'assistant'
@@ -492,69 +513,78 @@ class HeadlessTaskApi {
     }
     const activities = this.createActivities(events, now)
     const finalizedArtifacts: ArtifactFile[] = []
+    const buildCompletion = (): CompletedTaskSession => {
+      const uniqueArtifacts = [
+        ...new Map(finalizedArtifacts.map((artifact) => [artifact.id, artifact])).values()
+      ]
+      const persistedArtifacts = uniqueArtifacts.map(toPersistedArtifact)
+      const linkedAssistantMessage: PersistedChatMessage = {
+        ...assistantMessage,
+        artifactIds: uniqueArtifacts.length
+          ? uniqueArtifacts.map((artifact) => artifact.id)
+          : undefined
+      }
+      const hasAssistantMessage = Boolean(output || images.length || persistedArtifacts.length)
+
+      return {
+        output,
+        artifacts: uniqueArtifacts,
+        session: {
+          ...session,
+          status: 'idle',
+          activeRun: undefined,
+          messages: hasAssistantMessage
+            ? [...session.messages, linkedAssistantMessage]
+            : session.messages,
+          activities: [...(session.activities ?? []), ...activities],
+          artifacts: [...(session.artifacts ?? []), ...persistedArtifacts],
+          filesRevision:
+            persistedArtifacts.length > 0
+              ? (session.filesRevision ?? 0) + 1
+              : session.filesRevision,
+          updatedAt: now
+        }
+      }
+    }
     let ownershipSessionPersisted = false
     for (const event of events) {
       if (event.kind !== 'artifact' || !event.artifactClaimId) continue
-      const request = {
-        claimId: event.artifactClaimId,
-        messageId: assistantMessageId
-      }
-      let result = (await this.invoke(
-        'artifacts:finalize-run',
-        request
-      )) as FinalizeRunArtifactsResult
-      if (!result.ok) {
-        if (result.code !== ARTIFACT_OWNERSHIP_PERSISTENCE_RACE) {
-          throw new Error(result.message)
+      try {
+        const request = {
+          claimId: event.artifactClaimId,
+          messageId: assistantMessageId
         }
-        if (!ownershipSessionPersisted) {
-          await this.invoke('sessions:save-session', {
-            ...session,
-            messages: [...session.messages, assistantMessage],
-            activities: [...(session.activities ?? []), ...activities],
-            updatedAt: now
-          })
-          ownershipSessionPersisted = true
-        }
-        result = (await this.invoke(
+        let result = (await this.invoke(
           'artifacts:finalize-run',
           request
         )) as FinalizeRunArtifactsResult
         if (!result.ok) {
-          throw new Error(result.message)
+          if (result.code !== ARTIFACT_OWNERSHIP_PERSISTENCE_RACE) {
+            throw new Error(result.message)
+          }
+          if (!ownershipSessionPersisted) {
+            await this.invoke('sessions:save-session', {
+              ...session,
+              messages: [...session.messages, assistantMessage],
+              activities: [...(session.activities ?? []), ...activities],
+              updatedAt: now
+            })
+            ownershipSessionPersisted = true
+          }
+          result = (await this.invoke(
+            'artifacts:finalize-run',
+            request
+          )) as FinalizeRunArtifactsResult
+          if (!result.ok) {
+            throw new Error(result.message)
+          }
         }
-      }
-      finalizedArtifacts.push(...result.artifacts)
-    }
-    const linkedAssistantMessage: PersistedChatMessage = {
-      ...assistantMessage,
-      artifactIds: finalizedArtifacts.length
-        ? finalizedArtifacts.map((artifact) => artifact.id)
-        : undefined
-    }
-    const uniqueArtifacts = [
-      ...new Map(finalizedArtifacts.map((artifact) => [artifact.id, artifact])).values()
-    ]
-    const persistedArtifacts = uniqueArtifacts.map(toPersistedArtifact)
-    const hasAssistantMessage = Boolean(output || images.length || persistedArtifacts.length)
-
-    return {
-      output,
-      artifacts: uniqueArtifacts,
-      session: {
-        ...session,
-        status: 'idle',
-        activeRun: undefined,
-        messages: hasAssistantMessage
-          ? [...session.messages, linkedAssistantMessage]
-          : session.messages,
-        activities: [...(session.activities ?? []), ...activities],
-        artifacts: [...(session.artifacts ?? []), ...persistedArtifacts],
-        filesRevision:
-          persistedArtifacts.length > 0 ? (session.filesRevision ?? 0) + 1 : session.filesRevision,
-        updatedAt: now
+        finalizedArtifacts.push(...result.artifacts)
+      } catch (error) {
+        throw new PartialTaskCompletionError(buildCompletion(), error)
       }
     }
+    return buildCompletion()
   }
 
   private createActivities(events: AcpRuntimeEvent[], now: number): PersistedToolActivity[] {

--- a/src/main/web-service/task-api.ts
+++ b/src/main/web-service/task-api.ts
@@ -7,7 +7,11 @@ import {
   type AcpPromptRequest,
   type AcpRuntimeEvent
 } from '../../shared/acp'
-import type { ArtifactFile, FinalizeRunArtifactsResult } from '../../shared/artifacts'
+import {
+  ARTIFACT_OWNERSHIP_PERSISTENCE_RACE,
+  type ArtifactFile,
+  type FinalizeRunArtifactsResult
+} from '../../shared/artifacts'
 import { DEFAULT_PERMISSION_PROFILE } from '../../shared/permission-profiles'
 import type { Project } from '../../shared/projects'
 import type {
@@ -475,18 +479,6 @@ class HeadlessTaskApi {
         return image ? ({ id: event.id, ...image } satisfies PersistedMessageImage) : undefined
       })
       .filter((image): image is PersistedMessageImage => Boolean(image))
-    const finalizedArtifacts: ArtifactFile[] = []
-    for (const event of events) {
-      if (event.kind !== 'artifact' || !event.artifactClaimId) continue
-      const result = (await this.invoke('artifacts:finalize-run', {
-        claimId: event.artifactClaimId,
-        messageId: assistantMessageId
-      })) as FinalizeRunArtifactsResult
-      if (!result.ok) {
-        throw new Error(result.message)
-      }
-      finalizedArtifacts.push(...result.artifacts)
-    }
     const assistantMessage: PersistedChatMessage = {
       id: assistantMessageId,
       role: 'agent',
@@ -494,14 +486,52 @@ class HeadlessTaskApi {
       status: 'complete',
       responseToMessageId: session.activeRun?.promptMessageId,
       eventIds: assistantEvents.map((event) => event.id),
-      artifactIds: finalizedArtifacts.length
-        ? finalizedArtifacts.map((artifact) => artifact.id)
-        : undefined,
       images: images.length ? images : undefined,
       createdAt: now,
       updatedAt: now
     }
     const activities = this.createActivities(events, now)
+    const finalizedArtifacts: ArtifactFile[] = []
+    let ownershipSessionPersisted = false
+    for (const event of events) {
+      if (event.kind !== 'artifact' || !event.artifactClaimId) continue
+      const request = {
+        claimId: event.artifactClaimId,
+        messageId: assistantMessageId
+      }
+      let result = (await this.invoke(
+        'artifacts:finalize-run',
+        request
+      )) as FinalizeRunArtifactsResult
+      if (!result.ok) {
+        if (result.code !== ARTIFACT_OWNERSHIP_PERSISTENCE_RACE) {
+          throw new Error(result.message)
+        }
+        if (!ownershipSessionPersisted) {
+          await this.invoke('sessions:save-session', {
+            ...session,
+            messages: [...session.messages, assistantMessage],
+            activities: [...(session.activities ?? []), ...activities],
+            updatedAt: now
+          })
+          ownershipSessionPersisted = true
+        }
+        result = (await this.invoke(
+          'artifacts:finalize-run',
+          request
+        )) as FinalizeRunArtifactsResult
+        if (!result.ok) {
+          throw new Error(result.message)
+        }
+      }
+      finalizedArtifacts.push(...result.artifacts)
+    }
+    const linkedAssistantMessage: PersistedChatMessage = {
+      ...assistantMessage,
+      artifactIds: finalizedArtifacts.length
+        ? finalizedArtifacts.map((artifact) => artifact.id)
+        : undefined
+    }
     const uniqueArtifacts = [
       ...new Map(finalizedArtifacts.map((artifact) => [artifact.id, artifact])).values()
     ]
@@ -515,7 +545,9 @@ class HeadlessTaskApi {
         ...session,
         status: 'idle',
         activeRun: undefined,
-        messages: hasAssistantMessage ? [...session.messages, assistantMessage] : session.messages,
+        messages: hasAssistantMessage
+          ? [...session.messages, linkedAssistantMessage]
+          : session.messages,
         activities: [...(session.activities ?? []), ...activities],
         artifacts: [...(session.artifacts ?? []), ...persistedArtifacts],
         filesRevision:

--- a/src/preload/index.d.ts
+++ b/src/preload/index.d.ts
@@ -18,6 +18,7 @@ import type {
   ArtifactFile,
   ArtifactPreviewResult,
   FinalizeRunArtifactsRequest,
+  FinalizeRunArtifactsResult,
   ListProjectArtifactsRequest,
   OpenArtifactFileRequest,
   ReadArtifactPreviewRequest,
@@ -455,7 +456,7 @@ interface OpenScienceAPI {
     onState(listener: (state: OfficePreviewRuntimeState) => void): RemoveListener
   }
   artifacts: {
-    finalizeRunArtifacts(request: FinalizeRunArtifactsRequest): Promise<ArtifactFile[]>
+    finalizeRunArtifacts(request: FinalizeRunArtifactsRequest): Promise<FinalizeRunArtifactsResult>
     listProjectFiles(request: ListProjectArtifactsRequest): Promise<ArtifactFile[]>
     reconcilePendingArtifacts(request: ReconcilePendingArtifactsRequest): Promise<ArtifactFile[]>
     openFile(request: OpenArtifactFileRequest): Promise<void>

--- a/src/preload/index.ts
+++ b/src/preload/index.ts
@@ -20,6 +20,7 @@ import type {
   ArtifactFile,
   ArtifactPreviewResult,
   FinalizeRunArtifactsRequest,
+  FinalizeRunArtifactsResult,
   ListProjectArtifactsRequest,
   OpenArtifactFileRequest,
   ReadArtifactPreviewRequest,
@@ -500,7 +501,9 @@ type OpenScienceAPI = {
   }
   artifacts: {
     // Finalizes files produced during one runtime event after the renderer has selected a message.
-    finalizeRunArtifacts: (request: FinalizeRunArtifactsRequest) => Promise<ArtifactFile[]>
+    finalizeRunArtifacts: (
+      request: FinalizeRunArtifactsRequest
+    ) => Promise<FinalizeRunArtifactsResult>
     // Lists every on-disk artifact for a project so orphaned files (owning session deleted) still show.
     listProjectFiles: (request: ListProjectArtifactsRequest) => Promise<ArtifactFile[]>
     // Re-finalizes pending artifacts left behind by a crash, returning the message's finalized files.
@@ -1072,7 +1075,7 @@ const api: OpenScienceAPI = {
   artifacts: {
     // Keep generated file movement in the main process where filesystem trust checks live.
     finalizeRunArtifacts: (request) =>
-      ipcRenderer.invoke('artifacts:finalize-run', request) as Promise<ArtifactFile[]>,
+      ipcRenderer.invoke('artifacts:finalize-run', request) as Promise<FinalizeRunArtifactsResult>,
     // Lists every on-disk artifact for a project so orphaned files (owning session deleted) still show.
     listProjectFiles: (request) =>
       ipcRenderer.invoke('artifacts:list-project-files', request) as Promise<ArtifactFile[]>,

--- a/src/renderer/src/lib/acp/workspace-events.test.ts
+++ b/src/renderer/src/lib/acp/workspace-events.test.ts
@@ -1,5 +1,8 @@
 import type { AcpRuntimeEvent, AcpPermissionRequest } from '../../../../shared/acp'
-import type { ArtifactFile } from '../../../../shared/artifacts'
+import {
+  ARTIFACT_OWNERSHIP_PERSISTENCE_RACE,
+  type ArtifactFile
+} from '../../../../shared/artifacts'
 import { beforeEach, describe, expect, it, vi } from 'vitest'
 
 import {
@@ -1180,7 +1183,10 @@ describe('workspace runtime events', () => {
       .fn()
       .mockImplementationOnce(async () => {
         operationOrder.push('finalize')
-        throw new Error('Artifact finalization message is not a Branch descendant of its prompt.')
+        throw Object.assign(
+          new Error('The durable projection has not caught up with the selected message yet.'),
+          { code: ARTIFACT_OWNERSHIP_PERSISTENCE_RACE }
+        )
       })
       .mockImplementationOnce(async () => {
         operationOrder.push('finalize')
@@ -1205,6 +1211,79 @@ describe('workspace runtime events', () => {
     expect(operationOrder).toEqual(['save', 'finalize', 'save', 'finalize', 'save'])
     expect(finalizeRunArtifacts).toHaveBeenCalledTimes(2)
     expect(useSessionStore.getState().sessions[0].error).toBeUndefined()
+  })
+
+  it('keeps a proof failure terminal when only its human message resembles the old race text', async () => {
+    await applyWorkspaceRuntimeEvent(
+      createEvent({
+        id: 'assistant-event-terminal-proof',
+        role: 'assistant',
+        messageId: 'assistant-message-terminal-proof',
+        text: 'Saved the plot.'
+      })
+    )
+    const operationOrder: string[] = []
+    const saveSession = vi.fn().mockImplementation(async () => {
+      operationOrder.push('save')
+    })
+    const finalizeRunArtifacts = vi.fn().mockImplementation(async () => {
+      operationOrder.push('finalize')
+      throw new Error('Artifact finalization message is not a Branch descendant of its prompt.')
+    })
+
+    await applyWorkspaceRuntimeEvent(
+      createEvent({ id: 'stop-before-terminal-proof', kind: 'stop' })
+    )
+
+    await expect(
+      applyWorkspaceRuntimeEvent(
+        createEvent({
+          id: 'artifact-event-terminal-proof',
+          kind: 'artifact',
+          runId: 'artifact-run-terminal-proof',
+          artifactClaimId: 'claim-terminal-proof',
+          artifacts: [createArtifactFile({ runId: 'artifact-run-terminal-proof' })]
+        }),
+        { finalizeRunArtifacts, saveSession }
+      )
+    ).rejects.toThrow(/Branch descendant/)
+
+    expect(operationOrder).toEqual(['save', 'finalize'])
+    expect(finalizeRunArtifacts).toHaveBeenCalledOnce()
+  })
+
+  it('attempts the recoverable ownership persistence race at most twice', async () => {
+    await applyWorkspaceRuntimeEvent(
+      createEvent({
+        id: 'assistant-event-repeated-race',
+        role: 'assistant',
+        messageId: 'assistant-message-repeated-race',
+        text: 'Saved the plot.'
+      })
+    )
+    const race = Object.assign(new Error('Durable ownership is still unavailable.'), {
+      code: ARTIFACT_OWNERSHIP_PERSISTENCE_RACE
+    })
+    const finalizeRunArtifacts = vi.fn().mockRejectedValue(race)
+    const saveSession = vi.fn().mockResolvedValue(undefined)
+
+    await applyWorkspaceRuntimeEvent(createEvent({ id: 'stop-before-repeated-race', kind: 'stop' }))
+
+    await expect(
+      applyWorkspaceRuntimeEvent(
+        createEvent({
+          id: 'artifact-event-repeated-race',
+          kind: 'artifact',
+          runId: 'artifact-run-repeated-race',
+          artifactClaimId: 'claim-repeated-race',
+          artifacts: [createArtifactFile({ runId: 'artifact-run-repeated-race' })]
+        }),
+        { finalizeRunArtifacts, saveSession }
+      )
+    ).rejects.toThrow('Durable ownership is still unavailable.')
+
+    expect(finalizeRunArtifacts).toHaveBeenCalledTimes(2)
+    expect(saveSession).toHaveBeenCalledTimes(2)
   })
 
   it('auto-opens a generated molecule artifact in the preview panel', async () => {
@@ -1677,6 +1756,8 @@ describe('workspace runtime events', () => {
     await expect(
       applyWorkspaceRuntimeEvent(artifactEvent, { finalizeRunArtifacts, saveSession })
     ).rejects.toThrow('move failed')
+
+    expect(finalizeRunArtifacts).toHaveBeenCalledOnce()
 
     expect(useSessionStore.getState().sessions[0]).toMatchObject({
       status: 'error',

--- a/src/renderer/src/lib/acp/workspace-events.ts
+++ b/src/renderer/src/lib/acp/workspace-events.ts
@@ -1,5 +1,9 @@
 import type { AcpRuntimeEvent, AcpPermissionRequest } from '../../../../shared/acp'
-import type { ArtifactFile, FinalizeRunArtifactsRequest } from '../../../../shared/artifacts'
+import {
+  ARTIFACT_OWNERSHIP_PERSISTENCE_RACE,
+  type ArtifactFile,
+  type FinalizeRunArtifactsRequest
+} from '../../../../shared/artifacts'
 import type { ReviewRunNotStartedReason, ReviewRunRequest } from '../../../../shared/reviewer'
 import type { PersistedChatSession } from '../../../../shared/session-persistence'
 import { createPreviewFileItemFromArtifact } from '../../pages/workspace/preview-file-item'
@@ -81,15 +85,12 @@ const getEventErrorText = (event: AcpRuntimeEvent): string =>
 const getErrorText = (error: unknown): string =>
   error instanceof Error ? error.message : String(error)
 
-// A terminal message and its Branch projection are persisted by separate runtime events. Even though
-// Artifact finalization explicitly saves first, an already-queued Session save can briefly leave the
-// main process observing the prior Branch head. Retry only this narrow, fail-closed ownership race;
-// root/Frame/Branch identity mismatches and every other validation failure remain terminal.
+// A terminal message and its Branch projection are persisted by separate runtime events. Retry only
+// the main process's explicit persistence-race code; proof identity and publication failures remain
+// terminal regardless of their human-readable wording.
 const isArtifactOwnershipPersistenceRace = (error: unknown): boolean =>
   error instanceof Error &&
-  /Artifact finalization (?:message is not a Branch descendant of its prompt|ancestry does not prove message Branch ownership)/.test(
-    error.message
-  )
+  (error as Error & { code?: unknown }).code === ARTIFACT_OWNERSHIP_PERSISTENCE_RACE
 
 // Codex writes two informational diagnostics to stderr during otherwise-successful turns: skill
 // descriptions may be compacted to their context budget, and a timed-out WebSocket attempt may fall
@@ -115,8 +116,16 @@ type WorkspaceRuntimeEventDependencies = {
 }
 
 // Defaults to the preload artifact API while allowing tests to inject a fake finalizer.
-const finalizeRunArtifacts = (request: FinalizeRunArtifactsRequest): Promise<ArtifactFile[]> =>
-  window.api.artifacts.finalizeRunArtifacts(request)
+const finalizeRunArtifacts = async (
+  request: FinalizeRunArtifactsRequest
+): Promise<ArtifactFile[]> => {
+  const result = await window.api.artifacts.finalizeRunArtifacts(request)
+  if (result.ok) return result.artifacts
+
+  const error = new Error(result.message) as Error & { code: typeof result.code }
+  error.code = result.code
+  throw error
+}
 
 // Artifact finalization validates its renderer-selected Message against the durable Session graph.
 // Persist that graph explicitly instead of relying on the asynchronous store saver to win the IPC race.

--- a/src/shared/artifacts.ts
+++ b/src/shared/artifacts.ts
@@ -86,6 +86,16 @@ export type FinalizeRunArtifactsRequest = {
   messageId: string
 }
 
+// The only finalization failure the renderer may recover inside one event delivery. Other failures
+// remain rejected IPC calls so proof and compatibility errors cannot accidentally become retryable.
+export const ARTIFACT_OWNERSHIP_PERSISTENCE_RACE = 'ownership-persistence-race' as const
+
+export type ArtifactFinalizationErrorCode = typeof ARTIFACT_OWNERSHIP_PERSISTENCE_RACE
+
+export type FinalizeRunArtifactsResult =
+  | { ok: true; artifacts: ArtifactFile[] }
+  | { ok: false; code: ArtifactFinalizationErrorCode; message: string }
+
 // Renderer request to open one managed artifact through main-process path validation.
 export type OpenArtifactFileRequest = {
   path: string


### PR DESCRIPTION
## Problem

Artifact finalization retried one ownership-persistence race by matching a human-readable error message. That coupled renderer recovery to wording and risked treating unrelated proof failures as recoverable. The same finalization boundary also lacked a privacy-safe structured diagnostic that distinguished durable provenance finalization from compatibility publication.

## Proposed change

- Extend the existing `artifacts:finalize-run` IPC response with one stable `ownership-persistence-race` failure code.
- Classify only a missing durable final message as that recoverable race; keep prompt, role, frame, branch, runtime segment, and compatibility failures terminal.
- Retry the coded race once in the renderer, independently of its human-readable message.
- Emit one structured diagnostic through the existing artifact logger with the finalization stage, durable/publication completion state, and claim/provenance correlation IDs.
- Exclude exception text, artifact contents, user paths, prompts, project/session identifiers, and secrets from the diagnostic.

## Scope and non-goals

This keeps the existing artifact IPC route and logging sink; it does not add a parallel transport or logger. A bounded Better Harness Artifact Provenance evidence scan was also run without creating or installing an asset. The installed 0.3.0 collector did not expose the required request-root decision boundary for all omitted candidates, so this PR does not claim that separate repeated-workflow evidence item is complete.

## Acceptance criteria and validation

- `npm test -- src/main/artifacts/ipc.test.ts src/renderer/src/lib/acp/workspace-events.test.ts` — 82 passed
- `npm test -- src/main/artifacts/ipc.test.ts src/main/artifacts/provenance-repository.test.ts` — 54 passed
- `npm run typecheck` — passed
- `npm run lint` — 0 errors (24 pre-existing warnings)
- `npm test` — 7784 passed, 113 skipped

Tests prove the stable code drives the single retry when the message changes, legacy text alone remains terminal, invalid proof and compatibility failures do not retry, compatibility replay remains idempotent, and diagnostics identify stage/durable state without leaking injected content or paths.

## Review focus

- The boundary between a missing final message (recoverable persistence race) and a present-but-invalid ownership proof (terminal).
- The IPC result union as the smallest caller-visible discriminant.
- The diagnostic field allowlist and durable/publication state transitions.
