### PR TITLE
fix(agent-harness): tighten navigation and diagnostic boundaries

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -70,6 +70,7 @@ local/
 .codegraph/
 .mcp.json
 .codex/
+.worktree/
 .playwright-cli/
 .claude/
 .ai/

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -14,7 +14,7 @@ project for everyone.
 
 ### Prerequisites
 
-- [Node.js](https://nodejs.org/) (LTS recommended) and npm
+- [Node.js](https://nodejs.org/) 22 (see [`.nvmrc`](.nvmrc)) and npm
 - Git
 
 ### Setup
@@ -33,6 +33,34 @@ installs native Electron app dependencies.
 ```bash
 npm run dev
 ```
+
+## Coding-agent navigation
+
+Run installation, development, and validation commands from the repository root:
+
+| Intent      | Root command                                             |
+| ----------- | -------------------------------------------------------- |
+| Install     | `npm install`                                            |
+| Run         | `npm run dev`                                            |
+| Validate    | `npm run typecheck`, `npm run lint`, and `npm test`      |
+| Target test | `npm test -- <affected-test-path> [-t '<test pattern>']` |
+
+Create Git worktrees only under the repository's `.worktree/<name>` directory, with each change
+branch based on the default branch. Do not remove or move another worktree.
+
+Get explicit approval before destructive Git or filesystem operations, dependency installation that
+downloads or executes new code, publishing packages or releases, handling credentials outside the
+project's existing flows, or external writes (such as pushes, pull requests, issues, and messages) that
+the task did not already request.
+
+Read the existing owner document before changing one of these areas, then run its focused checks:
+
+| Area     | Owner document                                                                          | Focused checks                                                                                        |
+| -------- | --------------------------------------------------------------------------------------- | ----------------------------------------------------------------------------------------------------- |
+| Renderer | [Design specification](docs/design.md)                                                  | `npm run typecheck:web`; targeted tests under `src/renderer/`                                         |
+| Notebook | [Current architecture](docs/PRD.md#8-current-architecture-what-is-actually-implemented) | `npm run typecheck:node`; targeted tests under `src/main/notebook/`                                   |
+| Settings | [Settings design](docs/design.md#settings)                                              | `npm run typecheck`; targeted tests under `src/main/settings/` and `src/renderer/src/pages/settings/` |
+| ACP      | [Current architecture](docs/PRD.md#8-current-architecture-what-is-actually-implemented) | `npm run typecheck:node`; targeted tests under `src/main/acp/`                                        |
 
 ## Project Structure
 
@@ -99,6 +127,16 @@ npm run test        # Vitest unit tests
 Pull requests are expected to keep type checking, linting, and the test suite
 green. New behavior should come with tests.
 
+These repository gates are not automatically evidence for every changed behavior. Pair each behavior
+with the smallest project-owned check that exercises it, and run that check after the last material
+edit. If the implementation changes afterward, rerun every affected check instead of reusing an older
+result.
+
+The final handoff must list the material changes, map each affected behavior to its project-owned check
+and final result (`behavior -> command -> result`), and identify any risk those checks did not cover.
+Only mark the change verified after an independent review confirms that this mapping covers the final
+state.
+
 ## Commit Messages
 
 Every commit subject must follow Conventional Commits with a scope:
@@ -148,11 +186,14 @@ ci(review): unify automated AI reviews
 
   ## Review focus
   ```
+
 - For architectural changes, data flows, state transitions, or interactions
   across multiple components, consider adding a Mermaid diagram when it makes
   the design easier to understand and review.
 - Small documentation, maintenance, and narrowly scoped fixes may use a concise
   summary, but should still state the expected behavior and validation.
+- Include the final evidence mapping from [Required Checks](#required-checks), state that the listed
+  checks ran after the last material edit, and call out uncovered risks.
 - Keep PRs reasonably small and scoped so they are easy to review.
 - Ensure the required checks above pass.
 - Merge pull requests using **squash merge only**. The squash commit subject must

--- a/eslint.config.mjs
+++ b/eslint.config.mjs
@@ -17,8 +17,9 @@ export default defineConfig(
       'resources/notebook/*.js',
       // Whole-window find overlay: an ES-module page shipped as a raw resource (not part of the TS source tree).
       'resources/find-overlay/*.js',
-      // Git worktrees live under .claude/worktrees and hold full source copies; don't lint duplicates.
+      // Git worktrees hold full source copies; don't lint duplicate source from either supported root.
       '**/.claude/**',
+      '**/.worktree/**',
       // Local subagent scratch (ledgers, briefs, ad-hoc demo scripts) — never shipped.
       '**/.superpowers/**',
       // Keep official shadcn registry output unmodified; local adaptations live in wrappers.

--- a/src/main/acp/runtime.test.ts
+++ b/src/main/acp/runtime.test.ts
@@ -158,6 +158,7 @@ const startFakeAgent = (
     // the session/cancel notification on delete instead of a close request.
     supportsClose?: boolean
     rejectModeChange?: boolean
+    newSessionError?: unknown
     onSetMode?: (context: { sessionId: string; modeId: string }) => Promise<void> | void
     onClose?: (sessionId: string) => Promise<void> | void
     onPrompt?: (context: {
@@ -219,6 +220,8 @@ const startFakeAgent = (
       return {}
     })
     .onRequest(acp.methods.agent.session.new, (ctx) => {
+      if (options.newSessionError !== undefined) throw options.newSessionError
+
       newSessions.push({
         cwd: ctx.params.cwd,
         mcpServers: ctx.params.mcpServers,
@@ -10154,7 +10157,7 @@ describe('ACP runtime — agent process lifecycle logging', () => {
     expect((call?.[1] as { signal: string }).signal).toBe('SIGKILL')
   })
 
-  it('logs an agent process error event with framework and pid', async () => {
+  it('logs an agent process error event with a safe category and lifecycle context', async () => {
     errorLogSpy.mockClear()
     const process = new FakeAgentProcess()
     process.pid = 9090
@@ -10166,15 +10169,23 @@ describe('ACP runtime — agent process lifecycle logging', () => {
     })
 
     await runtime.createSession({ cwd: '/workspace' })
-    process.emit('error', new Error('EPIPE'))
+    process.emit(
+      'error',
+      Object.assign(new Error('sensitive pipe failure'), {
+        code: 'EPIPE',
+        path: '/private/sensitive-socket'
+      })
+    )
 
     const call = errorLogSpy.mock.calls.find(([message]) => message === 'agent process error event')
     expect(call).toBeDefined()
-    const data = call?.[1] as { error: string; framework: string; pid: number; status: string }
-    expect(data.error).toBe('EPIPE')
-    expect(data.framework).toBe('claude-code')
-    expect(data.pid).toBe(9090)
-    expect(data.status).toBe('connected')
+    expect(call?.[1]).toEqual({
+      errorCategory: 'system',
+      framework: 'claude-code',
+      generation: 1,
+      status: 'connected'
+    })
+    expect(JSON.stringify(call?.[1])).not.toMatch(/sensitive pipe failure|sensitive-socket|9090/)
   })
 
   it('logs agent stderr with the framework the process was spawned under', async () => {
@@ -10226,7 +10237,7 @@ describe('ACP runtime — agent process lifecycle logging', () => {
 })
 
 describe('ACP runtime — connect failure logging', () => {
-  it('logs "agent connection failed" with error, cwd, and framework when spawn throws', async () => {
+  it('logs "agent connection failed" with a safe category and lifecycle context', async () => {
     errorLogSpy.mockClear()
     const runtime = new AcpRuntime({
       appVersion: '0.1.0',
@@ -10240,11 +10251,12 @@ describe('ACP runtime — connect failure logging', () => {
 
     const call = errorLogSpy.mock.calls.find(([message]) => message === 'agent connection failed')
     expect(call).toBeDefined()
-    const data = call?.[1] as { error: string; code: string; cwd: string; framework: string }
-    expect(data.error).toBe('spawn claude ENOENT')
-    expect(data.code).toBe('ENOENT')
-    expect(data.cwd).toBe(resolve('/workspace'))
-    expect(data.framework).toBe('claude-code')
+    expect(call?.[1]).toEqual({
+      errorCategory: 'not-found',
+      framework: 'claude-code',
+      generation: 1,
+      status: 'connecting'
+    })
   })
 
   it('logs "agent connection abandoned" (not failed) when the generation is superseded mid-spawn', async () => {
@@ -10269,10 +10281,12 @@ describe('ACP runtime — connect failure logging', () => {
       ([message]) => message === 'agent connection abandoned (superseded or shutting down)'
     )
     expect(abandoned).toBeDefined()
-    const data = abandoned?.[1] as { framework: string; agentProcessPid: number; cwd: string }
-    expect(data.framework).toBe('claude-code')
-    expect(data.agentProcessPid).toBe(1212)
-    expect(data.cwd).toBe(resolve('/workspace'))
+    expect(abandoned?.[1]).toEqual({
+      errorCategory: 'error',
+      framework: 'claude-code',
+      generation: 1,
+      status: 'connecting'
+    })
     // The supersede path must NOT also emit the error-level "failed" record.
     expect(errorLogSpy.mock.calls.some(([message]) => message === 'agent connection failed')).toBe(
       false
@@ -10304,9 +10318,12 @@ describe('ACP runtime — connect failure logging', () => {
 
     const call = errorLogSpy.mock.calls.find(([message]) => message === 'agent connection failed')
     expect(call).toBeDefined()
-    const data = call?.[1] as { error: string; framework: string }
-    expect(data.error).toBe('spawn opencode ENOENT')
-    expect(data.framework).toBe('opencode')
+    expect(call?.[1]).toEqual({
+      errorCategory: 'error',
+      framework: 'opencode',
+      generation: 1,
+      status: 'connecting'
+    })
   })
 
   it('logs "agent connection abandoned" when a real async resolveBackend is superseded mid-resolution by a public disconnect()', async () => {
@@ -10351,16 +10368,18 @@ describe('ACP runtime — connect failure logging', () => {
     await expect(createPromise).rejects.toThrow(/superseded|shutting down/i)
 
     // The connect resumes, spawns the child, then detects the supersede and abandons it. Key guarantees:
-    // logged as *abandoned* (a warning) with the spawned child's pid + target cwd/framework, and NOT
-    // also raised as the error-level "failed" record.
+    // logged as *abandoned* (a warning) with safe lifecycle context, and NOT also raised as the
+    // error-level "failed" record.
     const abandoned = warnLogSpy.mock.calls.find(
       ([message]) => message === 'agent connection abandoned (superseded or shutting down)'
     )
     expect(abandoned).toBeDefined()
-    const data = abandoned?.[1] as { cwd: string; framework: string; agentProcessPid: number }
-    expect(data.cwd).toBe(resolve('/workspace'))
-    expect(data.framework).toBe('claude-code')
-    expect(data.agentProcessPid).toBe(3434)
+    expect(abandoned?.[1]).toEqual({
+      errorCategory: 'error',
+      framework: 'claude-code',
+      generation: 1,
+      status: 'closed'
+    })
     expect(errorLogSpy.mock.calls.some(([message]) => message === 'agent connection failed')).toBe(
       false
     )
@@ -10392,9 +10411,12 @@ describe('ACP runtime — connect failure logging', () => {
 
     const call = errorLogSpy.mock.calls.find(([message]) => message === 'agent connection failed')
     expect(call).toBeDefined()
-    const data = call?.[1] as { error: string; framework: string }
-    expect(data.error).toBe('raw string spawn failure')
-    expect(data.framework).toBe('opencode')
+    expect(call?.[1]).toEqual({
+      errorCategory: 'string',
+      framework: 'opencode',
+      generation: 1,
+      status: 'connecting'
+    })
   })
 
   it('does not mutate a frozen spawn Error, still labels the framework, and re-throws it verbatim', async () => {
@@ -10816,7 +10838,12 @@ describe('ACP runtime — session effort', () => {
     expect(fakeAgent.configChanges).toEqual([])
     const call = warnLogSpy.mock.calls.find(([message]) => message === 'set session effort failed')
     expect(call).toBeDefined()
-    expect((call?.[1] as { sessionId: string }).sessionId).toBe('s-effort')
+    expect(call?.[1]).toEqual({
+      errorCategory: 'request',
+      framework: 'opencode',
+      generation: 1,
+      status: 'connected'
+    })
   })
 })
 
@@ -10840,36 +10867,25 @@ describe('ACP runtime — session-creation and spawn diagnostics', () => {
     const payloadOf = (message: string): Record<string, unknown> | undefined =>
       infoLogSpy.mock.calls.find(([m]) => m === message)?.[1] as Record<string, unknown> | undefined
 
-    // Every stage of a successful createSession leaves a breadcrumb, and each carries the context that
-    // makes it useful for diagnosis — not just the message name.
-    expect(payloadOf('createSession: starting')).toMatchObject({
-      request: { cwd: '/workspace', projectName: 'my-project' }
-    })
-    expect(payloadOf('createSession: ensureConnected')).toMatchObject({
-      sessionCwd: resolve('/workspace'),
-      projectName: 'my-project'
-    })
-    const mcpBreadcrumb = payloadOf('createSession: createMcpServers')
-    expect(typeof mcpBreadcrumb?.artifactSessionId).toBe('string')
-    expect(typeof mcpBreadcrumb?.notebookSessionId).toBe('string')
-    expect(typeof (payloadOf('createSession: buildSession')?.mcpServersCount as number)).toBe(
-      'number'
-    )
-    expect(payloadOf('createSession: configurePermissionProfile')).toMatchObject({
-      sessionId: session.sessionId
-    })
-    expect(payloadOf('createSession: applySessionModel')).toMatchObject({
-      sessionId: session.sessionId
-    })
-    expect(payloadOf('createSession: completed successfully')).toMatchObject({
-      sessionId: session.sessionId
-    })
-    expect(payloadOf('ensureConnected: attempting connection')).toMatchObject({
-      cwd: resolve('/workspace')
-    })
-    expect(payloadOf('ensureConnected: connection established')).toMatchObject({
-      cwd: resolve('/workspace')
-    })
+    // Every stage leaves a breadcrumb, but its payload is a strict lifecycle whitelist.
+    for (const message of [
+      'createSession: starting',
+      'createSession: ensureConnected',
+      'createSession: createMcpServers',
+      'createSession: buildSession',
+      'createSession: configurePermissionProfile',
+      'createSession: applySessionModel',
+      'createSession: completed successfully',
+      'ensureConnected: attempting connection',
+      'ensureConnected: connection established'
+    ]) {
+      expect(payloadOf(message)).toEqual({
+        framework: 'claude-code',
+        generation: expect.any(Number),
+        status: expect.stringMatching(/^(?:idle|connecting|connected)$/)
+      })
+    }
+    expect(session.sessionId).toBe('staged-session')
   })
 
   it('logs "createSession: failed" and "ensureConnected: connect failed" when the connection fails', async () => {
@@ -10893,10 +10909,15 @@ describe('ACP runtime — session-creation and spawn diagnostics', () => {
     const createFailure = errorLogSpy.mock.calls.find(
       ([message]) => message === 'createSession: failed'
     )
-    expect((createFailure?.[1] as { error: string }).error).toBe('spawn boom')
+    expect(createFailure?.[1]).toEqual({
+      errorCategory: 'error',
+      framework: 'claude-code',
+      generation: 1,
+      status: 'error'
+    })
   })
 
-  it('logs "createSession: configurePermissionProfile failed" with the full error when the profile setup throws', async () => {
+  it('logs a safe category when permission-profile setup throws', async () => {
     errorLogSpy.mockClear()
     const process = new FakeAgentProcess()
     startFakeAgent(process, ['perm-fail-session'])
@@ -10918,12 +10939,15 @@ describe('ACP runtime — session-creation and spawn diagnostics', () => {
       ([message]) => message === 'createSession: configurePermissionProfile failed'
     )
     expect(call).toBeDefined()
-    const data = call?.[1] as { error: string; code: string }
-    expect(data.error).toBe('permission setup failed')
-    expect(data.code).toBe('EPERM')
+    expect(call?.[1]).toEqual({
+      errorCategory: 'permission',
+      framework: 'claude-code',
+      generation: 1,
+      status: 'connected'
+    })
   })
 
-  it('logs the resolved backend (executable + env keys, values omitted) and the spawned pid', async () => {
+  it('logs backend and spawn success without executable, arguments, env, or pid', async () => {
     infoLogSpy.mockClear()
     const process = new FakeAgentProcess()
     process.pid = 7654
@@ -10933,9 +10957,9 @@ describe('ACP runtime — session-creation and spawn diagnostics', () => {
       defaultCwd: '/workspace',
       resolveBackend: () => ({
         framework: { ...claudeCodeFramework, spawn: () => asAgentProcess(process) },
-        executablePath: '/bin/agent',
+        executablePath: '/private/agent-secret/bin/agent',
         env: { ANTHROPIC_AUTH_TOKEN: 'secret-should-not-be-logged', REGION: 'us' },
-        args: ['--acp']
+        args: ['--token=argument-secret']
       })
     })
 
@@ -10943,19 +10967,22 @@ describe('ACP runtime — session-creation and spawn diagnostics', () => {
 
     const resolved = infoLogSpy.mock.calls.find(([message]) => message === 'agent backend resolved')
     expect(resolved).toBeDefined()
-    const resolvedData = resolved?.[1] as {
-      executablePath: string
-      envKeys: string[]
-      args: string[]
-    }
-    expect(resolvedData.executablePath).toBe('/bin/agent')
-    expect(resolvedData.envKeys).toEqual(['ANTHROPIC_AUTH_TOKEN', 'REGION'])
-    expect(resolvedData.args).toEqual(['--acp'])
-    // The env *values* must never be logged — only the keys.
-    expect(JSON.stringify(resolvedData)).not.toContain('secret-should-not-be-logged')
+    expect(resolved?.[1]).toEqual({
+      framework: 'claude-code',
+      generation: 1,
+      status: 'connecting'
+    })
+    expect(JSON.stringify(resolved?.[1])).not.toMatch(
+      /secret-should-not-be-logged|argument-secret|agent-secret|ANTHROPIC_AUTH_TOKEN/
+    )
 
     const spawned = infoLogSpy.mock.calls.find(([message]) => message === 'agent process spawned')
-    expect((spawned?.[1] as { pid: number }).pid).toBe(7654)
+    expect(spawned?.[1]).toEqual({
+      framework: 'claude-code',
+      generation: 1,
+      status: 'connecting'
+    })
+    expect(JSON.stringify(spawned?.[1])).not.toContain('7654')
   })
 
   it('logs "ensureConnected: connection is null after connect" when connect resolves without a connection', async () => {
@@ -10978,10 +11005,12 @@ describe('ACP runtime — session-creation and spawn diagnostics', () => {
       ([message]) => message === 'ensureConnected: connection is null after connect'
     )
     expect(call).toBeDefined()
-    // The branch carries the target cwd + current status, not just the message.
-    const data = call?.[1] as { cwd: string; status: string }
-    expect(data.cwd).toBe(resolve('/workspace'))
-    expect(typeof data.status).toBe('string')
+    expect(call?.[1]).toEqual({
+      errorCategory: 'connection-unavailable',
+      framework: 'claude-code',
+      generation: 0,
+      status: 'idle'
+    })
   })
 
   it('does not let a cleanup failure mask the original connection error', async () => {
@@ -11004,17 +11033,20 @@ describe('ACP runtime — session-creation and spawn diagnostics', () => {
     // The rejection is the ORIGINAL spawn failure, not the cleanup error.
     await expect(runtime.createSession({ cwd: '/workspace' })).rejects.toThrow(/spawn boom/)
 
-    // Both the original failure and the (non-masking) cleanup failure are recorded with context.
+    // Both failures are categorized without retaining their messages, and cleanup never masks the
+    // original rejection.
     const failed = errorLogSpy.mock.calls.find(([message]) => message === 'agent connection failed')
-    expect((failed?.[1] as { error: string }).error).toBe('spawn boom')
+    expect((failed?.[1] as { errorCategory: string }).errorCategory).toBe('error')
     const cleanup = errorLogSpy.mock.calls.find(
       ([message]) => message === 'agent connection cleanup failed'
     )
     expect(cleanup).toBeDefined()
-    const cleanupData = cleanup?.[1] as { error: string; framework: string; cwd: string }
-    expect(cleanupData.error).toBe('cleanup boom')
-    expect(cleanupData.framework).toBe('claude-code')
-    expect(cleanupData.cwd).toBe(resolve('/workspace'))
+    expect(cleanup?.[1]).toEqual({
+      errorCategory: 'error',
+      framework: 'claude-code',
+      generation: 1,
+      status: 'connecting'
+    })
   })
 
   it('survives a hostile Error (throwing message getter) through the real connectFresh path', async () => {
@@ -11050,8 +11082,100 @@ describe('ACP runtime — session-creation and spawn diagnostics', () => {
     // error is a safe string — never a raw throwing value that would break the renderer broadcast.
     const failed = errorLogSpy.mock.calls.find(([message]) => message === 'agent connection failed')
     expect(failed).toBeDefined()
-    expect((failed?.[1] as { error: string; framework: string }).framework).toBe('claude-code')
+    expect((failed?.[1] as { errorCategory: string; framework: string }).framework).toBe(
+      'claude-code'
+    )
+    expect((failed?.[1] as { errorCategory: string }).errorCategory).toBe('error')
     expect(typeof runtime.getSnapshot().error).toBe('string')
+  })
+
+  it('does not log request or provider-error secrets during session creation', async () => {
+    infoLogSpy.mockClear()
+    warnLogSpy.mockClear()
+    errorLogSpy.mockClear()
+    const requestSecret = 'request-research-secret'
+    const providerSecret = 'provider-credential-secret'
+    const process = new FakeAgentProcess()
+    startFakeAgent(process, ['unused-session'], {
+      newSessionError: acp.RequestError.internalError(
+        { credential: providerSecret, research: requestSecret },
+        `provider rejected ${providerSecret}`
+      )
+    })
+    const runtime = new AcpRuntime({
+      appVersion: '0.1.0',
+      defaultCwd: '/workspace',
+      spawnAgent: () => asAgentProcess(process)
+    })
+
+    await expect(
+      runtime.createSession({
+        cwd: `/private/${requestSecret}`,
+        projectName: requestSecret
+      })
+    ).rejects.toThrow()
+
+    const serializedLogs = JSON.stringify([
+      ...infoLogSpy.mock.calls,
+      ...warnLogSpy.mock.calls,
+      ...errorLogSpy.mock.calls
+    ])
+    expect(serializedLogs).not.toContain(requestSecret)
+    expect(serializedLogs).not.toContain(providerSecret)
+    const failure = errorLogSpy.mock.calls.find(([message]) => message === 'createSession: failed')
+    expect(failure?.[1]).toEqual({
+      errorCategory: 'request',
+      framework: 'claude-code',
+      generation: 1,
+      status: 'connected'
+    })
+  })
+
+  it('does not log spawn inputs or sensitive spawn-error fields', async () => {
+    infoLogSpy.mockClear()
+    warnLogSpy.mockClear()
+    errorLogSpy.mockClear()
+    const spawnSecret = 'spawn-provider-secret'
+    const spawnError = Object.assign(new Error(`spawn rejected ${spawnSecret}`), {
+      code: 'ENOENT',
+      data: { credential: spawnSecret },
+      path: `/private/${spawnSecret}`
+    })
+    const runtime = new AcpRuntime({
+      appVersion: '0.1.0',
+      defaultCwd: '/workspace',
+      resolveBackend: () => ({
+        framework: {
+          ...opencodeFramework,
+          spawn: () => {
+            throw spawnError
+          }
+        },
+        executablePath: `/private/${spawnSecret}/agent`,
+        env: { PROVIDER_TOKEN: spawnSecret },
+        args: [`--credential=${spawnSecret}`]
+      })
+    })
+
+    await expect(runtime.createSession({ cwd: `/workspace/${spawnSecret}` })).rejects.toBe(
+      spawnError
+    )
+
+    const serializedLogs = JSON.stringify([
+      ...infoLogSpy.mock.calls,
+      ...warnLogSpy.mock.calls,
+      ...errorLogSpy.mock.calls
+    ])
+    expect(serializedLogs).not.toContain(spawnSecret)
+    const failure = errorLogSpy.mock.calls.find(
+      ([message]) => message === 'agent connection failed'
+    )
+    expect(failure?.[1]).toEqual({
+      errorCategory: 'not-found',
+      framework: 'opencode',
+      generation: 1,
+      status: 'connecting'
+    })
   })
 })
 

--- a/src/main/acp/runtime.ts
+++ b/src/main/acp/runtime.ts
@@ -52,7 +52,7 @@ import {
   type AgentFramework,
   type ResolvedAgentBackend
 } from '../agent-framework'
-import { createLogger, errorLogFields } from '../logger'
+import { createLogger, diagnosticErrorFields, errorLogFields } from '../logger'
 import { terminateProcessTree } from '../process-tree'
 import {
   extractProviderToolName,
@@ -905,6 +905,16 @@ class AcpRuntime {
     }, options.permissionGrantStore)
   }
 
+  // Boundary-safe context for session-creation and process-spawn diagnostics. Keep this list explicit:
+  // workspace paths, request/provider payloads, model research content, and credentials do not belong
+  // in these lifecycle records.
+  private diagnosticContext(
+    framework: AgentFramework['id'] = this.framework.id,
+    generation = this.connectionGeneration
+  ): { framework: AgentFramework['id']; generation: number; status: AcpStateSnapshot['status'] } {
+    return { framework, generation, status: this.status }
+  }
+
   // Returns an immutable renderer-facing view of connection and session state.
   getSnapshot(): AcpStateSnapshot {
     const sessionIds = Array.from(this.sessions.keys())
@@ -978,12 +988,7 @@ class AcpRuntime {
     }
 
     this.permissionProfiles.set(appSessionId, application.state)
-    log.info('permission profile applied', {
-      sessionId: appSessionId,
-      selectedProfile: profile,
-      effectiveMode: application.state.currentModeId,
-      autoReviewStrategy: application.state.autoReviewStrategy
-    })
+    log.info('permission profile applied', this.diagnosticContext())
   }
 
   // Applies the active model to a freshly built/resumed session via the ACP model configOption, for
@@ -1004,7 +1009,7 @@ class AcpRuntime {
     const selection = matchSessionModelOption(configOptions, this.pendingSessionModel)
 
     if (!selection) {
-      log.info('no matching session model option', { desiredModel: this.pendingSessionModel })
+      log.info('no matching session model option', this.diagnosticContext())
       if (this.pendingSessionModelRequired) {
         session.dispose()
         throw new Error(
@@ -1019,10 +1024,7 @@ class AcpRuntime {
     // redundant session/set_config_option round-trip: codex-acp reloads on every call, and even
     // sending the same value back stalled the first prompt of a new session for ~2 min (issue #277).
     if (selection.alreadyCurrent) {
-      log.info('session model already current', {
-        sessionId: session.sessionId,
-        model: selection.value
-      })
+      log.info('session model already current', this.diagnosticContext())
       this.appliedSessionModels.set(session.sessionId, selection.value)
       return configOptions ?? null
     }
@@ -1036,7 +1038,7 @@ class AcpRuntime {
           value: selection.value
         }
       )) as { configOptions?: SessionConfigOption[] | null }
-      log.info('session model applied', { sessionId: session.sessionId, model: selection.value })
+      log.info('session model applied', this.diagnosticContext())
       this.appliedSessionModels.set(session.sessionId, selection.value)
       // The model switch rebuilds the agent's options (effort rungs are model-dependent). The
       // caller commits the fresh set to latestSessionConfigOptions once the session is registered,
@@ -1045,8 +1047,8 @@ class AcpRuntime {
     } catch (error) {
       const message = error instanceof Error ? error.message : String(error)
       log.warn('set session model failed', {
-        sessionId: session.sessionId,
-        error: message
+        ...diagnosticErrorFields(error),
+        ...this.diagnosticContext()
       })
       if (this.pendingSessionModelRequired) {
         session.dispose()
@@ -1078,7 +1080,7 @@ class AcpRuntime {
     const selection = resolveSessionEffortOption(effectiveOptions, this.pendingSessionEffort)
 
     if (!selection) {
-      log.info('no session effort option to apply', { desiredEffort: this.pendingSessionEffort })
+      log.info('no session effort option to apply', this.diagnosticContext())
       return
     }
 
@@ -1116,10 +1118,7 @@ class AcpRuntime {
       const selection = resolveSessionEffortOption(configOptions, effort)
 
       if (!selection) {
-        log.info('no session effort option to apply', {
-          desiredEffort: effort,
-          sessionId: session.sessionId
-        })
+        log.info('no session effort option to apply', this.diagnosticContext())
         continue
       }
 
@@ -1152,12 +1151,12 @@ class AcpRuntime {
         configId: selection.configId,
         value: selection.value
       })
-      log.info('session effort applied', { sessionId: session.sessionId, effort: selection.value })
+      log.info('session effort applied', this.diagnosticContext())
       return true
     } catch (error) {
       log.warn('set session effort failed', {
-        sessionId: session.sessionId,
-        error: error instanceof Error ? error.message : String(error)
+        ...diagnosticErrorFields(error),
+        ...this.diagnosticContext()
       })
       return false
     }
@@ -1190,12 +1189,11 @@ class AcpRuntime {
     request: AcpConnectRequest = {},
     generation: number
   ): Promise<AcpStateSnapshot> {
-    // Resolved up front (not this.cwd, which the pre-connect teardown below may still be mutating) so the
-    // failure log always names the target workspace even if we throw before assigning this.cwd.
+    // Resolve up front rather than reading this.cwd after the pre-connect teardown, which may still be
+    // mutating runtime state.
     const cwd = resolve(request.cwd || this.options.defaultCwd)
-    // Captured at function scope so the catch can log the spawned child's pid/killed state on *every*
-    // failure path — including "superseded during spawn", where the process is deliberately never
-    // assigned to this.agentProcess.
+    // Captured at function scope so the catch can clean up the spawned child on every failure path —
+    // including "superseded during spawn", where it is never assigned to this.agentProcess.
     let agentProcess: ChildProcessWithoutNullStreams | undefined
     // The framework THIS connect spawned under, bound atomically to the spawn (spawnAgentProcess returns
     // it alongside the process, and tags a spawn-throw with it) rather than re-read from the mutable
@@ -1212,7 +1210,7 @@ class AcpRuntime {
       this.cwd = cwd
       this.error = undefined
       this.setStatus('connecting')
-      log.info('connecting agent', { cwd: this.cwd, generation })
+      log.info('connecting agent', this.diagnosticContext(this.framework.id, generation))
 
       const spawned = await this.spawnAgentProcess()
       agentProcess = spawned.process
@@ -1243,7 +1241,7 @@ class AcpRuntime {
 
       this.applyResolvedBackend(spawned.backend)
       this.agentProcess = agentProcess
-      this.attachAgentProcessEvents(this.agentProcess)
+      this.attachAgentProcessEvents(this.agentProcess, generation)
 
       const stream = acp.ndJsonStream(
         Writable.toWeb(this.agentProcess.stdin) as WritableStream<Uint8Array>,
@@ -1332,18 +1330,12 @@ class AcpRuntime {
       // renderer broadcast, or a teardown hook — the original `cause` is still re-thrown below and never
       // replaced by a handling-time error.
       try {
-        // Shared process context so both the abandoned and the failed paths name the child — including
-        // the superseded-during-spawn case, where the local `agentProcess` holds the child
-        // this.agentProcess never received.
-        const processFields = {
-          cwd,
-          generation,
-          currentGeneration: this.connectionGeneration,
-          framework: spawnFailure ? spawnFailure.framework : spawnedFramework,
-          shuttingDown: this.shuttingDown,
-          agentProcessPid: agentProcess?.pid,
-          agentProcessKilled: agentProcess?.killed
-        }
+        // Shared lifecycle context keeps the resolved framework and attempted generation attached to
+        // both the abandoned and failed paths without retaining process or workspace details.
+        const processFields = this.diagnosticContext(
+          spawnFailure ? spawnFailure.framework : spawnedFramework,
+          generation
+        )
 
         if (generation !== this.connectionGeneration) {
           // Superseded (a newer reconnect bumped the generation) or shutting down: the fast-path re-throw
@@ -1351,7 +1343,7 @@ class AcpRuntime {
           // the failures that are otherwise invisible.
           try {
             log.warn('agent connection abandoned (superseded or shutting down)', {
-              ...errorLogFields(cause),
+              ...diagnosticErrorFields(cause),
               ...processFields
             })
           } catch {
@@ -1359,7 +1351,10 @@ class AcpRuntime {
           }
         } else {
           this.error = errorMessage(cause)
-          safeLogError('agent connection failed', { ...errorLogFields(cause), ...processFields })
+          safeLogError('agent connection failed', {
+            ...diagnosticErrorFields(cause),
+            ...processFields
+          })
           // A notification sink that throws synchronously must not skip cleanup or the re-throw.
           try {
             this.pushEvent({
@@ -1369,10 +1364,10 @@ class AcpRuntime {
               text: this.error
             })
           } catch (notifyError) {
-            safeLogError(
-              'agent connection failure notification failed',
-              errorLogFields(notifyError)
-            )
+            safeLogError('agent connection failure notification failed', {
+              ...diagnosticErrorFields(notifyError),
+              ...processFields
+            })
           }
           // Cleanup must not mask the original failure: a throw from session.dispose(),
           // connection.close(), or a teardown hook is logged with context but never replaces `cause`.
@@ -1380,7 +1375,7 @@ class AcpRuntime {
             await this.disconnectCurrent(false)
           } catch (cleanupError) {
             safeLogError('agent connection cleanup failed', {
-              ...errorLogFields(cleanupError),
+              ...diagnosticErrorFields(cleanupError),
               ...processFields
             })
           }
@@ -1388,14 +1383,23 @@ class AcpRuntime {
           try {
             this.emitState()
           } catch (notifyError) {
-            safeLogError('agent connection emitState failed', errorLogFields(notifyError))
+            safeLogError('agent connection emitState failed', {
+              ...diagnosticErrorFields(notifyError),
+              ...processFields
+            })
           }
         }
       } catch (handlingError) {
         // Last-resort guard: even the logger threw. Swallow it (best-effort re-log) so the original
         // cause below is what propagates.
         try {
-          log.error('error while handling agent connection failure', errorLogFields(handlingError))
+          log.error('error while handling agent connection failure', {
+            ...diagnosticErrorFields(handlingError),
+            ...this.diagnosticContext(
+              spawnFailure ? spawnFailure.framework : spawnedFramework,
+              generation
+            )
+          })
         } catch {
           /* nothing more we can safely do */
         }
@@ -1416,20 +1420,16 @@ class AcpRuntime {
     request: AcpCreateSessionRequest = {}
   ): Promise<AcpCreateSessionResponse> {
     try {
-      log.info('createSession: starting', { request })
+      log.info('createSession: starting', this.diagnosticContext())
       const sessionCwd = resolve(request.cwd || this.cwd || this.options.defaultCwd)
       const projectName = this.normalizeProjectName(request.projectName)
-      log.info('createSession: ensureConnected', { sessionCwd, projectName })
+      log.info('createSession: ensureConnected', this.diagnosticContext())
       const connection = await this.ensureConnected(sessionCwd)
       const artifactSessionId = this.createArtifactSessionId()
       const notebookSessionId = this.createNotebookSessionId()
       const skillImportSessionId = this.createSkillImportSessionId()
 
-      log.info('createSession: createMcpServers', {
-        artifactSessionId,
-        notebookSessionId,
-        skillImportSessionId
-      })
+      log.info('createSession: createMcpServers', this.diagnosticContext())
       const mcpServers = await this.createMcpServers({
         artifactSessionId,
         notebookSessionId,
@@ -1437,7 +1437,7 @@ class AcpRuntime {
         sessionCwd,
         projectName
       })
-      log.info('createSession: buildSession', { mcpServersCount: mcpServers.length })
+      log.info('createSession: buildSession', this.diagnosticContext())
       const session = await connection.agent
         .buildSession({
           cwd: sessionCwd,
@@ -1446,7 +1446,7 @@ class AcpRuntime {
         })
         .start()
 
-      log.info('createSession: configurePermissionProfile', { sessionId: session.sessionId })
+      log.info('createSession: configurePermissionProfile', this.diagnosticContext())
       try {
         await this.configurePermissionProfile(
           session.sessionId,
@@ -1454,12 +1454,15 @@ class AcpRuntime {
           normalizePermissionProfile(request.permissionProfile)
         )
       } catch (error) {
-        safeLogError('createSession: configurePermissionProfile failed', errorLogFields(error))
+        safeLogError('createSession: configurePermissionProfile failed', {
+          ...diagnosticErrorFields(error),
+          ...this.diagnosticContext()
+        })
         session.dispose()
         throw error
       }
 
-      log.info('createSession: applySessionModel', { sessionId: session.sessionId })
+      log.info('createSession: applySessionModel', this.diagnosticContext())
       const updatedConfigOptions = await this.applySessionModel(session)
       await this.applySessionEffort(session, updatedConfigOptions)
 
@@ -1488,7 +1491,7 @@ class AcpRuntime {
       })
       this.emitState()
 
-      log.info('createSession: completed successfully', { sessionId: session.sessionId })
+      log.info('createSession: completed successfully', this.diagnosticContext())
       return {
         sessionId: session.sessionId,
         cwd: sessionCwd,
@@ -1496,7 +1499,10 @@ class AcpRuntime {
         ...(this.backendId ? { backendId: this.backendId } : {})
       }
     } catch (error) {
-      safeLogError('createSession: failed', errorLogFields(error))
+      safeLogError('createSession: failed', {
+        ...diagnosticErrorFields(error),
+        ...this.diagnosticContext()
+      })
       throw error
     }
   }
@@ -2412,20 +2418,9 @@ class AcpRuntime {
       throw new Error('ACP agent spawn configuration is not available.')
     }
 
-    // Surfaces which backend + model this connect uses, so a fallback to the framework's own default
-    // model (e.g. opencode with no app model to inject) is diagnosable in the log rather than silent.
-    log.info('agent backend resolved', {
-      framework: backend.framework.id,
-      backendId: backend.backendId ?? '(unspecified)',
-      sessionModel: backend.sessionModel ?? '(framework default)',
-      contextUsageModel: backend.contextUsageModel ?? '(framework fallback)',
-      sessionEffort: backend.sessionEffort ?? '(agent default)',
-      contextWindow: backend.contextWindow ?? '(adapter reported)',
-      args: backend.args ?? [],
-      executablePath: backend.executablePath,
-      // Log env keys but not values (may contain credentials)
-      envKeys: Object.keys(backend.env ?? {})
-    })
+    // Record the resolved framework without retaining executable paths, arguments, environment names,
+    // provider identifiers, or model selections from the spawn configuration.
+    log.info('agent backend resolved', this.diagnosticContext(backend.framework.id))
 
     let process: ChildProcessWithoutNullStreams
     try {
@@ -2443,10 +2438,7 @@ class AcpRuntime {
       throw new SpawnFailure(backend.framework.id, error)
     }
 
-    log.info('agent process spawned', {
-      framework: backend.framework.id,
-      pid: process.pid
-    })
+    log.info('agent process spawned', this.diagnosticContext(backend.framework.id))
 
     return { process, framework: backend.framework.id, backend }
   }
@@ -3623,24 +3615,27 @@ class AcpRuntime {
       return this.connection
     }
 
-    log.info('ensureConnected: attempting connection', { cwd, status: this.status })
+    log.info('ensureConnected: attempting connection', this.diagnosticContext())
 
     try {
       await this.connect({ cwd })
     } catch (error) {
-      safeLogError('ensureConnected: connect failed', { cwd, ...errorLogFields(error) })
+      safeLogError('ensureConnected: connect failed', {
+        ...diagnosticErrorFields(error),
+        ...this.diagnosticContext()
+      })
       throw error
     }
 
     if (!this.connection) {
       safeLogError('ensureConnected: connection is null after connect', {
-        cwd,
-        status: this.status
+        ...this.diagnosticContext(),
+        errorCategory: 'connection-unavailable'
       })
       throw new Error('ACP connection failed')
     }
 
-    log.info('ensureConnected: connection established', { cwd })
+    log.info('ensureConnected: connection established', this.diagnosticContext())
     return this.connection
   }
 
@@ -3932,14 +3927,11 @@ class AcpRuntime {
       )
     }
 
-    // Log the MCP server launch specs (command/url, no secrets) — a bad command/entry path or an
-    // unstarted host can make the agent stall while it waits on an MCP server that never responds.
+    // Keep only the count plus lifecycle context. MCP launch specs can contain local paths or provider
+    // details and are not safe session-creation diagnostics.
     log.info('session MCP servers', {
-      count: servers.length,
-      servers: servers.map((server) => {
-        const record = server as { name?: string; command?: string; url?: string; args?: unknown }
-        return { name: record.name, command: record.command, url: record.url, args: record.args }
-      })
+      ...this.diagnosticContext(),
+      count: servers.length
     })
 
     return servers
@@ -5245,7 +5237,10 @@ class AcpRuntime {
   }
 
   // Captures process stderr/errors/exits and converts unexpected ones to events.
-  private attachAgentProcessEvents(agentProcess: ChildProcessWithoutNullStreams): void {
+  private attachAgentProcessEvents(
+    agentProcess: ChildProcessWithoutNullStreams,
+    generation: number
+  ): void {
     // Bind the framework this process was spawned under now. During a reconnect the runtime's
     // this.framework may already point at a new backend, so reading it inside the async handlers would
     // mislabel a late stderr/exit from the old process.
@@ -5286,10 +5281,8 @@ class AcpRuntime {
 
     agentProcess.on('error', (error) => {
       log.error('agent process error event', {
-        ...errorLogFields(error),
-        framework,
-        status: this.status,
-        pid: agentProcess.pid
+        ...diagnosticErrorFields(error),
+        ...this.diagnosticContext(framework, generation)
       })
 
       if (this.expectedProcessExits.has(agentProcess)) {

--- a/src/main/logger.test.ts
+++ b/src/main/logger.test.ts
@@ -4,7 +4,14 @@ import { join } from 'node:path'
 
 import { afterEach, describe, expect, it } from 'vitest'
 
-import { createLogger, errorLogFields, flushLogs, formatLine, initLogger } from './logger'
+import {
+  createLogger,
+  diagnosticErrorFields,
+  errorLogFields,
+  flushLogs,
+  formatLine,
+  initLogger
+} from './logger'
 
 let logDir: string | undefined
 
@@ -53,6 +60,36 @@ describe('logger: formatLine', () => {
 
     expect(() => JSON.parse(line)).not.toThrow()
     expect((JSON.parse(line) as { data: unknown }).data).toBe('[unserializable]')
+  })
+})
+
+describe('logger: diagnosticErrorFields', () => {
+  it('classifies a provider request error without retaining its payload', () => {
+    const secret = 'provider-secret-value'
+    const fields = diagnosticErrorFields(
+      Object.assign(new Error(`provider rejected ${secret}`), {
+        name: 'RequestError',
+        code: -32603,
+        data: { credential: secret },
+        path: `/private/${secret}`
+      })
+    )
+
+    expect(fields).toEqual({ errorCategory: 'request' })
+    expect(JSON.stringify(fields)).not.toContain(secret)
+  })
+
+  it('does not copy arbitrary error names or codes into the category', () => {
+    const secret = 'custom-secret-category'
+    const fields = diagnosticErrorFields({
+      name: secret,
+      code: secret,
+      message: secret,
+      data: { credential: secret }
+    })
+
+    expect(fields).toEqual({ errorCategory: 'object' })
+    expect(JSON.stringify(fields)).not.toContain(secret)
   })
 })
 

--- a/src/main/logger.test.ts
+++ b/src/main/logger.test.ts
@@ -81,15 +81,18 @@ describe('logger: diagnosticErrorFields', () => {
 
   it('does not copy arbitrary error names or codes into the category', () => {
     const secret = 'custom-secret-category'
-    const fields = diagnosticErrorFields({
-      name: secret,
-      code: secret,
-      message: secret,
-      data: { credential: secret }
-    })
+    for (const name of [secret, 'toString', 'constructor', '__proto__']) {
+      const fields = diagnosticErrorFields({
+        name,
+        code: secret,
+        message: secret,
+        data: { credential: secret }
+      })
 
-    expect(fields).toEqual({ errorCategory: 'object' })
-    expect(JSON.stringify(fields)).not.toContain(secret)
+      expect(fields).toEqual({ errorCategory: 'object' })
+      expect(typeof fields.errorCategory).toBe('string')
+      expect(JSON.stringify(fields)).not.toContain(secret)
+    }
   })
 })
 

--- a/src/main/logger.ts
+++ b/src/main/logger.ts
@@ -371,6 +371,66 @@ const bestEffortMessage = (error: unknown): string => {
   }
 }
 
+// Returns a coarse, fixed-vocabulary category for boundary diagnostics that must not retain provider
+// messages, request data, credentials, research content, stacks, or local paths. Raw numeric RPC codes
+// and identifier-shaped system codes are classified rather than copied, so a hostile `code` or `name`
+// property cannot smuggle arbitrary text into the log. Callers that explicitly own richer diagnostics
+// can continue to use errorLogFields instead.
+const diagnosticErrorFields = (error: unknown): { errorCategory: string } => {
+  try {
+    if (error === null) return { errorCategory: 'null' }
+
+    const type = typeof error
+    if (type !== 'object' && type !== 'function') return { errorCategory: type }
+
+    const code = safeRead(error as object, 'code')
+    if (typeof code === 'number' && Number.isFinite(code)) {
+      return { errorCategory: 'request' }
+    }
+    if (typeof code === 'string') {
+      if (code === 'ENOENT' || code === 'ENOTDIR') return { errorCategory: 'not-found' }
+      if (code === 'EACCES' || code === 'EPERM') return { errorCategory: 'permission' }
+      if (code === 'ETIMEDOUT' || code === 'ESOCKETTIMEDOUT') {
+        return { errorCategory: 'timeout' }
+      }
+      if (
+        code === 'ECONNREFUSED' ||
+        code === 'ECONNRESET' ||
+        code === 'ENETUNREACH' ||
+        code === 'EHOSTUNREACH' ||
+        code === 'EAI_AGAIN'
+      ) {
+        return { errorCategory: 'network' }
+      }
+      if (code.length <= 64 && /^(?:E[A-Z0-9_]+|ERR_[A-Z0-9_]+)$/.test(code)) {
+        return { errorCategory: 'system' }
+      }
+    }
+
+    const name = safeRead(error as object, 'name')
+    const categoriesByName: Record<string, string> = {
+      AbortError: 'aborted',
+      AggregateError: 'aggregate',
+      Error: 'error',
+      RangeError: 'range',
+      ReferenceError: 'reference',
+      RequestError: 'request',
+      SyntaxError: 'syntax',
+      SystemError: 'system',
+      TimeoutError: 'timeout',
+      TypeError: 'type',
+      URIError: 'uri'
+    }
+    if (typeof name === 'string' && categoriesByName[name]) {
+      return { errorCategory: categoriesByName[name] }
+    }
+
+    return { errorCategory: 'object' }
+  } catch {
+    return { errorCategory: 'unknown' }
+  }
+}
+
 // Expands an unknown thrown value into a log-safe record for nesting inside a larger context object.
 // toSerializable only unwraps a *top-level* Error; an Error nested inside `{ error, ...ctx }` serializes
 // to `{}` because its fields are non-enumerable — losing the message, stack, and (worse) the code/data
@@ -610,4 +670,12 @@ const createLogger = (scope: string): Logger => ({
   error: (message, data) => emit('error', scope, message, data)
 })
 
-export { createLogger, errorLogFields, flushLogs, formatLine, getLogFilePath, initLogger }
+export {
+  createLogger,
+  diagnosticErrorFields,
+  errorLogFields,
+  flushLogs,
+  formatLine,
+  getLogFilePath,
+  initLogger
+}

--- a/src/main/logger.ts
+++ b/src/main/logger.ts
@@ -421,7 +421,7 @@ const diagnosticErrorFields = (error: unknown): { errorCategory: string } => {
       TypeError: 'type',
       URIError: 'uri'
     }
-    if (typeof name === 'string' && categoriesByName[name]) {
+    if (typeof name === 'string' && Object.hasOwn(categoriesByName, name)) {
       return { errorCategory: categoriesByName[name] }
     }
 

--- a/vitest.config.ts
+++ b/vitest.config.ts
@@ -33,10 +33,11 @@ export default defineConfig({
     // read their target alias from COMPUTE_TEST_SSH_ALIAS. The file is gitignored; .env.example
     // documents the supported variables.
     setupFiles: ['./test/setup-dotenv.ts', './test/setup-jsdom-polyfills.ts'],
-    // Keep vitest's defaults (node_modules, dist, .git, ...) and also ignore git worktrees created
-    // under .claude/worktrees — those hold full source + node_modules copies that would otherwise be
-    // discovered and run as duplicate (and often stale) suites during local runs.
-    exclude: [...configDefaults.exclude, '**/.claude/**'],
+    // Keep vitest's defaults (node_modules, dist, .git, ...) and also ignore git worktrees — those hold
+    // full source + node_modules copies that would otherwise be discovered and run as duplicate (and
+    // often stale) suites during local runs. .worktree is the project-standard root; .claude remains
+    // excluded for existing local checkouts.
+    exclude: [...configDefaults.exclude, '**/.claude/**', '**/.worktree/**'],
     // Lift the 5s default: the full coverage run instruments 4400+ tests across parallel workers on a
     // shared CI runner, so a fast fully-mocked test can still be CPU-starved past 5s and time out
     // spuriously. 15s absorbs that contention without masking a genuine hang (real work is far slower).


### PR DESCRIPTION
## Problem

Coding agents lacked a compact repository-owned entry point for commands, worktree boundaries, owner documents, and final evidence. The standard `.worktree/` root was also visible to lint/test discovery, and ACP session/spawn diagnostics could retain overly broad error or request data.

## Proposed change

- Add minimal coding-agent navigation and a final evidence contract to `CONTRIBUTING.md` without adding `AGENTS.md` or a Skill.
- Exclude `.worktree/` through the existing Git, ESLint, and Vitest ignore boundaries without changing test inclusion or coverage rules.
- Reduce ACP session-creation/spawn diagnostics to lifecycle fields and fixed error categories while preserving the original thrown value and cleanup behavior.
- Add negative tests for request, provider-error, spawn, environment, local-path, and prototype-key leakage.

## Scope and non-goals

- No README architecture tutorial was copied.
- No worktree was removed or moved, no business test include rule changed, and no dependency was added.
- Existing raw agent `stderr` handling is unchanged.

## Acceptance criteria and validation

Material changes in the final two-commit state are listed above. Every check below ran after the last material edit, and an independent Codex review of final HEAD `e010759` returned `VERIFIED` with no standards or specification findings.

- Contributor navigation and evidence contract -> `git diff origin/main...HEAD --check` plus relative-link existence/navigation review -> pass; all new targets exist, and a fresh task found the renderer, notebook, settings, and ACP owner docs and focused commands from `CONTRIBUTING.md` alone.
- Worktree ignore boundaries -> `npm run lint` -> exit 0 (24 unrelated existing warnings); ESLint discovery reported zero `.worktree/` paths.
- Test discovery boundary -> updated Vitest discovery audit -> 541 tracked project files / 7,559 tests, zero `.worktree/` files; baseline was 541 / 7,555, so only the four new security tests increased the count.
- ACP session/spawn diagnostic behavior -> `npm test -- src/main/acp/runtime.test.ts -t "session-creation and spawn diagnostics"` -> 9/9 passed.
- Diagnostic category whitelist -> `npm test -- src/main/logger.test.ts` -> 58/58 passed, including `toString`, `constructor`, and `__proto__` collision cases.
- Node-side type safety -> `npm run typecheck:node` -> passed.
- Repository regression gate -> `NODE_NO_WARNINGS=1 npm test` -> 533 files passed, 10 skipped; 7,785 tests passed, 113 skipped. One unrelated `job-poller` assertion failed on the preceding full run, then passed in isolation and on this final full rerun.

Uncovered risks: local validation used Node 26 because Node 22 was not installed and downloading/executing it was not approved; CI remains the Node 22 check. Unchanged raw agent `stderr` can still contain provider-controlled text and is outside this structured-log whitelist.

## Review focus

- Confirm structured ACP logs expose only framework, generation, lifecycle status/counts, and fixed error categories.
- Confirm throwable identity and cleanup behavior are unchanged.
- Confirm `.worktree/` is excluded without broadening or narrowing business test inclusion.
