### PR TITLE
fix(artifacts): prevent historical finalization ownership mismatch

### DIFF
--- a/src/main/acp/runtime-coordinator.test.ts
+++ b/src/main/acp/runtime-coordinator.test.ts
@@ -29,6 +29,9 @@ const emptySnapshot = (): AcpStateSnapshot => ({
   promptInFlightSessionIds: []
 })
 
+const runtimeEventId = (runtimeSequence: number, eventId: string): RegExp =>
+  new RegExp(`^runtime-${runtimeSequence}-[0-9a-f-]{36}:${eventId}$`, 'u')
+
 const createFakeRuntime = (options: {
   frameworkId: 'claude-code' | 'codex'
   sessionIds: string[]
@@ -639,7 +642,9 @@ describe('AcpRuntimeCoordinator', () => {
 
     // The draining runtime still owns the session until a fresh generation adopts it.
     created[0].emitEvent(overflowEvent('owner-overflow'))
-    expect(forwardedEvents.map((event) => event.id)).toEqual(['runtime-1:owner-overflow'])
+    expect(forwardedEvents.map((event) => event.id)).toEqual([
+      expect.stringMatching(runtimeEventId(1, 'owner-overflow'))
+    ])
 
     await coordinator.resumeSession({
       sessionId: session.sessionId,
@@ -648,16 +653,18 @@ describe('AcpRuntimeCoordinator', () => {
     })
 
     created[0].emitEvent(overflowEvent('late-retired-overflow'))
-    expect(forwardedEvents.map((event) => event.id)).toEqual(['runtime-1:owner-overflow'])
+    expect(forwardedEvents.map((event) => event.id)).toEqual([
+      expect.stringMatching(runtimeEventId(1, 'owner-overflow'))
+    ])
     expect(coordinator.getSnapshot().events.map((event) => event.id)).toEqual([])
 
     created[1].emitEvent(overflowEvent('fresh-owner-overflow'))
     expect(forwardedEvents.map((event) => event.id)).toEqual([
-      'runtime-1:owner-overflow',
-      'runtime-2:fresh-owner-overflow'
+      expect.stringMatching(runtimeEventId(1, 'owner-overflow')),
+      expect.stringMatching(runtimeEventId(2, 'fresh-owner-overflow'))
     ])
     expect(coordinator.getSnapshot().events.map((event) => event.id)).toEqual([
-      'runtime-2:fresh-owner-overflow'
+      expect.stringMatching(runtimeEventId(2, 'fresh-owner-overflow'))
     ])
 
     retirement.resolve()
@@ -699,7 +706,9 @@ describe('AcpRuntimeCoordinator', () => {
     })
 
     created[0].emitEvent(compactionEvent('owner-compaction', 'in_progress'))
-    expect(forwardedEvents.map((event) => event.id)).toEqual(['runtime-1:owner-compaction'])
+    expect(forwardedEvents.map((event) => event.id)).toEqual([
+      expect.stringMatching(runtimeEventId(1, 'owner-compaction'))
+    ])
 
     await coordinator.resumeSession({
       sessionId: session.sessionId,
@@ -708,16 +717,18 @@ describe('AcpRuntimeCoordinator', () => {
     })
 
     created[0].emitEvent(compactionEvent('late-retired-compaction', 'failed'))
-    expect(forwardedEvents.map((event) => event.id)).toEqual(['runtime-1:owner-compaction'])
+    expect(forwardedEvents.map((event) => event.id)).toEqual([
+      expect.stringMatching(runtimeEventId(1, 'owner-compaction'))
+    ])
     expect(coordinator.getSnapshot().events.map((event) => event.id)).toEqual([])
 
     created[1].emitEvent(compactionEvent('fresh-owner-compaction', 'completed'))
     expect(forwardedEvents.map((event) => event.id)).toEqual([
-      'runtime-1:owner-compaction',
-      'runtime-2:fresh-owner-compaction'
+      expect.stringMatching(runtimeEventId(1, 'owner-compaction')),
+      expect.stringMatching(runtimeEventId(2, 'fresh-owner-compaction'))
     ])
     expect(coordinator.getSnapshot().events.map((event) => event.id)).toEqual([
-      'runtime-2:fresh-owner-compaction'
+      expect.stringMatching(runtimeEventId(2, 'fresh-owner-compaction'))
     ])
 
     retirement.resolve()
@@ -1203,12 +1214,12 @@ describe('AcpRuntimeCoordinator', () => {
     created[1].emitEvent(event('session-2'))
 
     expect(forwardedEvents.map((item) => item.id)).toEqual([
-      'runtime-1:acp-event-1',
-      'runtime-2:acp-event-1'
+      expect.stringMatching(runtimeEventId(1, 'acp-event-1')),
+      expect.stringMatching(runtimeEventId(2, 'acp-event-1'))
     ])
     expect(coordinator.getSnapshot().events.map((item) => item.id)).toEqual([
-      'runtime-1:acp-event-1',
-      'runtime-2:acp-event-1'
+      expect.stringMatching(runtimeEventId(1, 'acp-event-1')),
+      expect.stringMatching(runtimeEventId(2, 'acp-event-1'))
     ])
 
     const permission: AcpPermissionRequest = {
@@ -1227,6 +1238,48 @@ describe('AcpRuntimeCoordinator', () => {
       cancelled: true
     })
     expect(created[1].respondToPermission).not.toHaveBeenCalled()
+  })
+
+  it('does not reuse persisted event namespaces across coordinator lifetimes', async () => {
+    const createCoordinator = (): {
+      coordinator: AcpRuntimeCoordinator
+      created: ReturnType<typeof createFakeRuntime>[]
+      forwardedEvents: AcpRuntimeEvent[]
+    } => {
+      const created: ReturnType<typeof createFakeRuntime>[] = []
+      const forwardedEvents: AcpRuntimeEvent[] = []
+      const coordinator = new AcpRuntimeCoordinator(
+        (callbacks) => {
+          const fake = createFakeRuntime({
+            frameworkId: 'codex',
+            sessionIds: ['session-1'],
+            callbacks
+          })
+          created.push(fake)
+          return fake.runtime
+        },
+        { onEvent: (event) => forwardedEvents.push(event) }
+      )
+
+      return { coordinator, created, forwardedEvents }
+    }
+    const event: AcpRuntimeEvent = {
+      id: 'acp-event-1',
+      timestamp: 1,
+      kind: 'system',
+      level: 'info',
+      sessionId: 'session-1',
+      title: 'event'
+    }
+    const first = createCoordinator()
+    const second = createCoordinator()
+
+    await first.coordinator.createSession()
+    await second.coordinator.createSession()
+    first.created[0].emitEvent(event)
+    second.created[0].emitEvent(event)
+
+    expect(first.forwardedEvents[0].id).not.toBe(second.forwardedEvents[0].id)
   })
 
   it('pins each activity workflow to the runtime generation active when it starts', async () => {

--- a/src/main/acp/runtime-coordinator.ts
+++ b/src/main/acp/runtime-coordinator.ts
@@ -1,4 +1,5 @@
 import type { ActiveSession } from '@agentclientprotocol/sdk'
+import { randomUUID } from 'node:crypto'
 
 import type {
   AcpCancelPromptRequest,
@@ -57,6 +58,9 @@ class AcpRuntimeCoordinator {
   private readonly reviewerRuntimes = new WeakMap<ActiveSession, AcpRuntime>()
   private readonly runtimeIds = new WeakMap<AcpRuntime, string>()
   private readonly permissionGrantStore = new ConversationPermissionGrantStore()
+  // Runtime events are persisted on Message nodes. A process-local sequence alone restarts at one
+  // after every app launch and can collide with a historical Session's event ids.
+  private readonly eventNamespace = randomUUID()
   private runtimeSequence = 0
   private initializationGeneration = 0
   private globalCancellationGeneration = 0
@@ -576,7 +580,7 @@ class AcpRuntimeCoordinator {
       this.permissionGrantStore
     )
     this.runtimeSequence += 1
-    this.runtimeIds.set(runtime, `runtime-${this.runtimeSequence}`)
+    this.runtimeIds.set(runtime, `runtime-${this.runtimeSequence}-${this.eventNamespace}`)
     this.runtimes.add(runtime)
     return runtime
   }

--- a/src/renderer/src/lib/acp/workspace-events.test.ts
+++ b/src/renderer/src/lib/acp/workspace-events.test.ts
@@ -898,6 +898,77 @@ describe('workspace runtime events', () => {
     })
   })
 
+  it('binds a restarted runtime Artifact event to the current response in a historical Session', async () => {
+    const finalizeRunArtifacts = vi.fn(async ({ messageId }: { messageId: string }) => [
+      createArtifactFile({
+        id: `transport-session-1:${messageId}:result.txt`,
+        sessionId: 'transport-session-1',
+        messageId,
+        runId: undefined
+      })
+    ])
+    const saveSession = vi.fn().mockResolvedValue(undefined)
+    const historicalPromptMessageId =
+      useSessionStore.getState().sessions[0].activeRun?.promptMessageId
+
+    await applyWorkspaceRuntimeEvent(
+      createEvent({
+        id: 'runtime-1:acp-event-1',
+        role: 'assistant',
+        messageId: 'historical-assistant-stream',
+        text: 'Historical response'
+      })
+    )
+    const historicalResponseMessageId = useSessionStore.getState().sessions[0].messages.at(-1)?.id
+    await applyWorkspaceRuntimeEvent(
+      createEvent({
+        id: 'runtime-1:acp-event-2',
+        kind: 'artifact',
+        runId: 'historical-artifact-run',
+        promptMessageId: historicalPromptMessageId,
+        artifactClaimId: 'historical-claim',
+        artifacts: [
+          createArtifactFile({ id: 'historical-version', runId: 'historical-artifact-run' })
+        ]
+      }),
+      { finalizeRunArtifacts, saveSession }
+    )
+    await applyWorkspaceRuntimeEvent(createEvent({ id: 'historical-stop', kind: 'stop' }))
+
+    const currentPrompt = useSessionStore.getState().appendUserMessage({
+      sessionId: 'transport-session-1',
+      content: 'Create a new result after restart'
+    })
+    await applyWorkspaceRuntimeEvent(
+      createEvent({
+        // Historical Sessions may already contain ids from the legacy restarting namespace.
+        id: 'runtime-1:acp-event-1',
+        role: 'assistant',
+        messageId: 'current-assistant-stream',
+        text: 'Current response'
+      })
+    )
+    const currentResponseMessageId = useSessionStore.getState().sessions[0].messages.at(-1)?.id
+    await applyWorkspaceRuntimeEvent(
+      createEvent({
+        id: 'runtime-1:acp-event-2',
+        kind: 'artifact',
+        runId: 'current-artifact-run',
+        promptMessageId: currentPrompt?.messageId,
+        artifactClaimId: 'current-claim',
+        artifacts: [createArtifactFile({ id: 'current-version', runId: 'current-artifact-run' })]
+      }),
+      { finalizeRunArtifacts, saveSession }
+    )
+    await applyWorkspaceRuntimeEvent(createEvent({ id: 'current-stop', kind: 'stop' }))
+
+    expect(currentResponseMessageId).not.toBe(historicalResponseMessageId)
+    expect(finalizeRunArtifacts).toHaveBeenLastCalledWith({
+      claimId: 'current-claim',
+      messageId: currentResponseMessageId
+    })
+  })
+
   it('finalizes every artifact claim deferred before the same stop event', async () => {
     const promptMessageId = useSessionStore.getState().sessions[0].activeRun?.promptMessageId
     await applyWorkspaceRuntimeEvent(

--- a/src/renderer/src/stores/session-store.ts
+++ b/src/renderer/src/stores/session-store.ts
@@ -1234,9 +1234,15 @@ export const useSessionStore = create<SessionStore>((set, get) => ({
       sessions: state.sessions.map((session) => {
         if (session.id !== sessionId) return session
 
+        // Legacy runtime namespaces restarted from `runtime-1` after every app launch, so a historical
+        // Message may carry the same event id as this run. Prompt ownership distinguishes a true replay
+        // from that collision while artifact events without prompt identity retain the old fallback.
+        const ownsArtifactPrompt = (message: ChatMessage): boolean =>
+          !promptMessageId || message.responseToMessageId === promptMessageId
+
         // Runtime event processing can replay visible events; event ids make the mutation idempotent.
-        const alreadyAppliedMessage = session.messages.find((message) =>
-          message.eventIds.includes(eventId)
+        const alreadyAppliedMessage = session.messages.find(
+          (message) => message.eventIds.includes(eventId) && ownsArtifactPrompt(message)
         )
 
         if (alreadyAppliedMessage) {
@@ -1253,8 +1259,8 @@ export const useSessionStore = create<SessionStore>((set, get) => ({
         // already-finalized Artifact whose owning Message is currently inactive. Resolve that event
         // against the full graph so the main-process claim is replayed with its original Message id;
         // rebinding it to the active response would correctly fail the provenance ownership check.
-        const alreadyAppliedGraphMessage = session.conversationGraph?.messages.find((message) =>
-          message.eventIds.includes(eventId)
+        const alreadyAppliedGraphMessage = session.conversationGraph?.messages.find(
+          (message) => message.eventIds.includes(eventId) && ownsArtifactPrompt(message)
         )
 
         if (alreadyAppliedGraphMessage) {


### PR DESCRIPTION
## Problem

Historical Sessions persist runtime event ids, but both the coordinator runtime namespace and the runtime event sequence restarted from one after an app relaunch. A new Artifact event could therefore collide with an event on an older response. Renderer replay then selected that historical Message, and durable provenance correctly rejected the current claim because its message did not belong to the declared prompt turn.

## Proposed change

- Add a UUID-backed coordinator-lifecycle namespace to every published runtime event id.
- Require matching prompt ownership when an Artifact event reuses an id already stored on a Message.
- Cover both cross-lifecycle namespace uniqueness and the legacy historical-collision finalization flow.

## Scope and non-goals

This does not migrate existing Session JSON, change Artifact provenance schemas, or relax durable ownership validation. The renderer guard handles already-persisted legacy collisions while new events no longer create them.

## Acceptance criteria and validation

All listed checks ran after the last material edit.

- Runtime event ids remain unique across coordinator lifetimes -> npm test -- src/main/acp/runtime-coordinator.test.ts src/renderer/src/lib/acp/workspace-events.test.ts -> 2 files passed, 87 tests passed.
- A legacy event-id collision binds the Artifact claim to the current prompt response -> same targeted command -> passed.
- Node and renderer types remain valid -> npm run typecheck -> passed.
- Repository lint gate -> npm run lint -> passed with 0 errors and 24 pre-existing warnings outside the changed files.
- Repository regression suite -> npm test -> 534 files passed, 10 skipped; 7979 tests passed, 136 skipped.

Uncovered risk: the historical collision regression uses the real renderer event/store flow but mocks Session persistence and finalization, so it does not reproduce the final ArtifactProvenanceRepository exception end to end. Existing provenance tests and the full suite cover the downstream fail-closed validator.

## Review focus

Please focus on the durability boundary of the new event namespace and whether prompt-scoped replay preserves legitimate inactive-Branch Artifact replays.