### PR TITLE
feat(files): add expand modal for project files tab

### DIFF
--- a/src/renderer/src/pages/workspace/PreviewPanel.test.tsx
+++ b/src/renderer/src/pages/workspace/PreviewPanel.test.tsx
@@ -513,6 +513,46 @@ describe('PreviewPanel', () => {
     expect(container.querySelector('[data-testid="preview-card"]')).toBeNull()
   })
 
+  it('expands a tool tab into a modal surface without remounting its content', async () => {
+    usePreviewWorkbenchStore.getState().upsertAndActivateItem({
+      id: 'tool:project:files',
+      sessionId: '__project_files__',
+      title: 'Files',
+      type: 'tool',
+      toolKind: 'files'
+    } as never)
+
+    await renderPanel()
+
+    const inlineContent = container.querySelector('[data-testid="tool-content"]')
+    expect(container.querySelector('[role="dialog"]')).toBeNull()
+    expect(container.querySelector('[role="tabpanel"]')?.className).toContain('overflow-y-auto')
+
+    await act(async () => {
+      usePreviewWorkbenchStore.getState().setToolItemExpanded('tool:project:files')
+    })
+
+    const dialog = document.body.querySelector<HTMLElement>('[role="dialog"]')
+    const overlay = Array.from(document.body.querySelectorAll<HTMLElement>('div')).find((element) =>
+      element.className.includes('bg-black/50')
+    )
+    expect(dialog).not.toBeNull()
+    expect(overlay).not.toBeNull()
+    expect(dialog?.getAttribute('aria-modal')).toBe('true')
+    expect(dialog?.getAttribute('aria-label')).toBe('Files')
+    expect(dialog?.className).toContain('h-[90vh]')
+    expect(dialog?.className).toContain('w-[90vw]')
+    expect(dialog?.querySelector('[data-testid="tool-content"]')).toBe(inlineContent)
+
+    await act(async () => {
+      dialog?.dispatchEvent(new KeyboardEvent('keydown', { key: 'Escape', bubbles: true }))
+    })
+
+    expect(usePreviewWorkbenchStore.getState().expandedToolItemId).toBeNull()
+    expect(document.body.querySelector('[role="dialog"]')).toBeNull()
+    expect(container.querySelector('[data-testid="tool-content"]')).toBe(inlineContent)
+  })
+
   it('activates a different tab on click and swaps the rendered content', async () => {
     usePreviewWorkbenchStore.getState().upsertAndActivateItem(createFileItem({}))
     usePreviewWorkbenchStore.getState().upsertItem(

--- a/src/renderer/src/pages/workspace/PreviewPanel.tsx
+++ b/src/renderer/src/pages/workspace/PreviewPanel.tsx
@@ -5,7 +5,11 @@ import type { PanelImperativeHandle, PanelSize } from 'react-resizable-panels'
 import { dialogOverlayClassName, dialogPanelClassName } from '@/components/ui/dialog-chrome'
 import { ResizablePanel } from '@/components/ui/resizable'
 import { cn } from '@/lib/utils'
-import type { PreviewFileItem, PreviewItem } from '@/stores/preview-workbench-store'
+import type {
+  PreviewFileItem,
+  PreviewItem,
+  PreviewToolItem
+} from '@/stores/preview-workbench-store'
 import { usePreviewWorkbenchStore } from '@/stores/preview-workbench-store'
 
 import { ExtensionPreservingFileName } from './ExtensionPreservingFileName'
@@ -249,29 +253,23 @@ const PreviewTabBar = ({
   )
 }
 
-// The same surface switches between panel and modal layout so stateful renderers never remount.
-const PreviewFilePanel = ({
-  item,
-  contentKey,
-  onClose
+// Shared modal behavior for surfaces that switch between panel and modal layout without
+// remounting: Escape closes, Tab traps focus inside, body scroll locks, and closing returns
+// focus to the owning tab. Escape is ignored while focus lives outside the surface (e.g. a
+// portaled dialog above it) so nested overlays close one layer at a time.
+const usePreviewModalSurface = ({
+  isOpen,
+  onClose,
+  surfaceRef,
+  itemId
 }: {
-  item: PreviewFileItem
-  contentKey: string
-  onClose: (id: string) => void
-}): React.JSX.Element => {
-  const [isFullScreenOpen, setIsFullScreenOpen] = useState(false)
-  const surfaceRef = useRef<HTMLElement | null>(null)
-
-  const closeFullScreen = (): void => {
-    setIsFullScreenOpen(false)
-  }
-
-  const openFullScreen = (): void => {
-    setIsFullScreenOpen(true)
-  }
-
+  isOpen: boolean
+  onClose: () => void
+  surfaceRef: React.RefObject<HTMLElement | null>
+  itemId: string
+}): void => {
   useEffect(() => {
-    if (!isFullScreenOpen) return
+    if (!isOpen) return
 
     const surface = surfaceRef.current
     const previousOverflow = document.body.style.overflow
@@ -280,8 +278,15 @@ const PreviewFilePanel = ({
 
     const handleKeyDown = (event: KeyboardEvent): void => {
       if (event.key === 'Escape') {
+        if (
+          surface &&
+          document.activeElement !== surface &&
+          !surface.contains(document.activeElement)
+        ) {
+          return
+        }
         event.preventDefault()
-        setIsFullScreenOpen(false)
+        onClose()
         return
       }
       if (event.key !== 'Tab' || !surface) return
@@ -310,9 +315,38 @@ const PreviewFilePanel = ({
     return () => {
       document.removeEventListener('keydown', handleKeyDown, true)
       document.body.style.overflow = previousOverflow
-      document.getElementById(getPreviewTabId(item.id))?.focus()
+      document.getElementById(getPreviewTabId(itemId))?.focus()
     }
-  }, [isFullScreenOpen, item.id])
+  }, [isOpen, onClose, surfaceRef, itemId])
+}
+
+// The same surface switches between panel and modal layout so stateful renderers never remount.
+const PreviewFilePanel = ({
+  item,
+  contentKey,
+  onClose
+}: {
+  item: PreviewFileItem
+  contentKey: string
+  onClose: (id: string) => void
+}): React.JSX.Element => {
+  const [isFullScreenOpen, setIsFullScreenOpen] = useState(false)
+  const surfaceRef = useRef<HTMLElement | null>(null)
+
+  const closeFullScreen = useCallback((): void => {
+    setIsFullScreenOpen(false)
+  }, [])
+
+  const openFullScreen = (): void => {
+    setIsFullScreenOpen(true)
+  }
+
+  usePreviewModalSurface({
+    isOpen: isFullScreenOpen,
+    onClose: closeFullScreen,
+    surfaceRef,
+    itemId: item.id
+  })
 
   return (
     <>
@@ -351,6 +385,59 @@ const PreviewFilePanel = ({
           onOpenFullScreen={isFullScreenOpen ? undefined : openFullScreen}
           provenanceEntry={isFullScreenOpen ? 'trailing' : 'menu'}
         />
+      </section>
+    </>
+  )
+}
+
+// Tool tabs (files/notebook/reviewer) reuse the same panel/modal layout switch as file previews.
+// The expanded state lives in the workbench store because the expand button is rendered by the
+// tool content itself (ProjectFilesView), not by this chrome. Overlay/panel stay below z-[60] so
+// dialogs opened from inside the tool content (FilePreviewDialog) stack above the modal.
+const PreviewToolPanel = ({ item }: { item: PreviewToolItem }): React.JSX.Element => {
+  const isExpanded = usePreviewWorkbenchStore((state) => state.expandedToolItemId === item.id)
+  const setToolItemExpanded = usePreviewWorkbenchStore((state) => state.setToolItemExpanded)
+  const surfaceRef = useRef<HTMLElement | null>(null)
+
+  const closeExpanded = useCallback((): void => {
+    setToolItemExpanded(null)
+  }, [setToolItemExpanded])
+
+  usePreviewModalSurface({
+    isOpen: isExpanded,
+    onClose: closeExpanded,
+    surfaceRef,
+    itemId: item.id
+  })
+
+  return (
+    <>
+      {isExpanded ? (
+        <div
+          aria-hidden="true"
+          data-state="open"
+          className={`${dialogOverlayClassName} z-[55] cursor-default`}
+          onClick={closeExpanded}
+        />
+      ) : null}
+      <section
+        ref={surfaceRef}
+        role={isExpanded ? 'dialog' : 'tabpanel'}
+        aria-modal={isExpanded || undefined}
+        aria-label={isExpanded ? item.title : undefined}
+        id={isExpanded ? undefined : getPreviewPanelId(item.id)}
+        aria-labelledby={isExpanded ? undefined : getPreviewTabId(item.id)}
+        tabIndex={isExpanded ? -1 : 0}
+        data-state={isExpanded ? 'open' : undefined}
+        className={
+          isExpanded
+            ? dialogPanelClassName(
+                'z-[56] flex h-[90vh] w-[90vw] max-w-none min-h-0 flex-col overflow-hidden overscroll-contain p-0'
+              )
+            : 'h-full min-h-0 w-full overflow-y-auto'
+        }
+      >
+        <PreviewActiveContent item={item} />
       </section>
     </>
   )
@@ -434,16 +521,7 @@ const PreviewPanel = ({
                 onClose={removeItem}
               />
             ) : (
-              <section
-                key={item.id}
-                role="tabpanel"
-                id={getPreviewPanelId(item.id)}
-                aria-labelledby={getPreviewTabId(item.id)}
-                tabIndex={0}
-                className="h-full min-h-0 w-full overflow-y-auto"
-              >
-                <PreviewActiveContent key={activeContentKey} item={item} />
-              </section>
+              <PreviewToolPanel key={item.id} item={item} />
             )
           })}
         </div>

--- a/src/renderer/src/pages/workspace/ProjectFilesView.tsx
+++ b/src/renderer/src/pages/workspace/ProjectFilesView.tsx
@@ -1510,7 +1510,7 @@ const ProjectFilesViewContent = ({
                   type="button"
                   variant="ghost"
                   size="icon"
-                  className="rounded-md text-text-100 hover:bg-muted hover:text-text-000"
+                  className="rounded-md text-text-000 hover:bg-muted"
                   aria-label={isFilesExpanded ? 'Exit full screen files' : 'Expand files'}
                   onClick={() =>
                     setToolItemExpanded(isFilesExpanded ? null : PROJECT_FILES_PREVIEW_ID)

--- a/src/renderer/src/pages/workspace/ProjectFilesView.tsx
+++ b/src/renderer/src/pages/workspace/ProjectFilesView.tsx
@@ -6,6 +6,8 @@ import {
   Folder,
   LayoutGrid,
   List,
+  Maximize2,
+  Minimize2,
   Paperclip,
   Plus,
   Search,
@@ -30,6 +32,10 @@ import { Tooltip, TooltipContent, TooltipProvider, TooltipTrigger } from '@/comp
 import { cn, formatByteSize } from '@/lib/utils'
 import { useNavigationStore } from '@/stores/navigation-store'
 import type { PreviewFileItem } from '@/stores/preview-workbench-store'
+import {
+  PROJECT_FILES_PREVIEW_ID,
+  usePreviewWorkbenchStore
+} from '@/stores/preview-workbench-store'
 import { useSessionStore } from '@/stores/session-store'
 import { useComputeStore } from '@/stores/compute-store'
 import { useSettingsStore } from '@/stores/settings-store'
@@ -1010,6 +1016,10 @@ const ProjectFilesViewContent = ({
   previewReader: ProjectFilePreviewReader
 }): React.JSX.Element => {
   const allSessions = useSessionStore((state) => state.sessions)
+  const isFilesExpanded = usePreviewWorkbenchStore(
+    (state) => state.expandedToolItemId === PROJECT_FILES_PREVIEW_ID
+  )
+  const setToolItemExpanded = usePreviewWorkbenchStore((state) => state.setToolItemExpanded)
   const [collapsedSectionIds, setCollapsedSectionIds] = useState<Set<string>>(() => new Set())
   const [selectedFilterId, setSelectedFilterId] = useState('all')
   const [selectedSessionFallback, setSelectedSessionFallback] = useState<ProjectFilesFilterOption>()
@@ -1459,40 +1469,65 @@ const ProjectFilesViewContent = ({
           onBrowseRemoteHost={(providerId) => setBrowseProviderId(providerId)}
         />
         <TooltipProvider delayDuration={200}>
-          <ToggleGroup.Root
-            type="single"
-            value={viewMode}
-            aria-label="File view"
-            className="flex h-8 shrink-0 items-center rounded-lg border border-border bg-card p-0.5"
-            onValueChange={(value) => {
-              if (value === 'grid' || value === 'list') setViewMode(value)
-            }}
-          >
+          <div className="flex shrink-0 items-center gap-1.5">
+            <ToggleGroup.Root
+              type="single"
+              value={viewMode}
+              aria-label="File view"
+              className="flex h-8 shrink-0 items-center rounded-lg border border-border bg-card p-0.5"
+              onValueChange={(value) => {
+                if (value === 'grid' || value === 'list') setViewMode(value)
+              }}
+            >
+              <Tooltip>
+                <TooltipTrigger asChild>
+                  <ToggleGroup.Item
+                    value="grid"
+                    aria-label="Grid view"
+                    className="flex size-7 items-center justify-center rounded-md text-text-300 outline-none hover:bg-muted hover:text-text-000 focus-visible:ring-3 focus-visible:ring-ring/50 aria-checked:bg-bg-400 aria-checked:text-text-000 aria-checked:shadow-sm aria-checked:hover:bg-bg-400"
+                  >
+                    <LayoutGrid className="size-3.5" strokeWidth={1.8} aria-hidden="true" />
+                  </ToggleGroup.Item>
+                </TooltipTrigger>
+                <TooltipContent>Grid view</TooltipContent>
+              </Tooltip>
+              <Tooltip>
+                <TooltipTrigger asChild>
+                  <ToggleGroup.Item
+                    value="list"
+                    aria-label="List view"
+                    className="flex size-7 items-center justify-center rounded-md text-text-300 outline-none hover:bg-muted hover:text-text-000 focus-visible:ring-3 focus-visible:ring-ring/50 aria-checked:bg-bg-400 aria-checked:text-text-000 aria-checked:shadow-sm aria-checked:hover:bg-bg-400"
+                  >
+                    <List className="size-3.5" strokeWidth={1.8} aria-hidden="true" />
+                  </ToggleGroup.Item>
+                </TooltipTrigger>
+                <TooltipContent>List view</TooltipContent>
+              </Tooltip>
+            </ToggleGroup.Root>
             <Tooltip>
               <TooltipTrigger asChild>
-                <ToggleGroup.Item
-                  value="grid"
-                  aria-label="Grid view"
-                  className="flex size-7 items-center justify-center rounded-md text-text-300 outline-none hover:bg-muted hover:text-text-000 focus-visible:ring-3 focus-visible:ring-ring/50 aria-checked:bg-bg-400 aria-checked:text-text-000 aria-checked:shadow-sm aria-checked:hover:bg-bg-400"
+                <Button
+                  type="button"
+                  variant="ghost"
+                  size="icon-xs"
+                  className="text-text-100 hover:text-text-000"
+                  aria-label={isFilesExpanded ? 'Exit full screen files' : 'Expand files'}
+                  onClick={() =>
+                    setToolItemExpanded(isFilesExpanded ? null : PROJECT_FILES_PREVIEW_ID)
+                  }
                 >
-                  <LayoutGrid className="size-3.5" strokeWidth={1.8} aria-hidden="true" />
-                </ToggleGroup.Item>
+                  {isFilesExpanded ? (
+                    <Minimize2 className="size-3.5" strokeWidth={1.8} aria-hidden="true" />
+                  ) : (
+                    <Maximize2 className="size-3.5" strokeWidth={1.8} aria-hidden="true" />
+                  )}
+                </Button>
               </TooltipTrigger>
-              <TooltipContent>Grid view</TooltipContent>
+              <TooltipContent className="z-[70]">
+                {isFilesExpanded ? 'Exit full screen' : 'Expand files'}
+              </TooltipContent>
             </Tooltip>
-            <Tooltip>
-              <TooltipTrigger asChild>
-                <ToggleGroup.Item
-                  value="list"
-                  aria-label="List view"
-                  className="flex size-7 items-center justify-center rounded-md text-text-300 outline-none hover:bg-muted hover:text-text-000 focus-visible:ring-3 focus-visible:ring-ring/50 aria-checked:bg-bg-400 aria-checked:text-text-000 aria-checked:shadow-sm aria-checked:hover:bg-bg-400"
-                >
-                  <List className="size-3.5" strokeWidth={1.8} aria-hidden="true" />
-                </ToggleGroup.Item>
-              </TooltipTrigger>
-              <TooltipContent>List view</TooltipContent>
-            </Tooltip>
-          </ToggleGroup.Root>
+          </div>
         </TooltipProvider>
       </div>
       <div className="flex shrink-0 items-center gap-3 border-y border-border-300/60 px-4 py-2">

--- a/src/renderer/src/pages/workspace/ProjectFilesView.tsx
+++ b/src/renderer/src/pages/workspace/ProjectFilesView.tsx
@@ -1509,8 +1509,8 @@ const ProjectFilesViewContent = ({
                 <Button
                   type="button"
                   variant="ghost"
-                  size="icon-sm"
-                  className="rounded-md text-text-300 hover:bg-muted hover:text-text-000"
+                  size="icon"
+                  className="rounded-md text-text-100 hover:bg-muted hover:text-text-000"
                   aria-label={isFilesExpanded ? 'Exit full screen files' : 'Expand files'}
                   onClick={() =>
                     setToolItemExpanded(isFilesExpanded ? null : PROJECT_FILES_PREVIEW_ID)

--- a/src/renderer/src/pages/workspace/ProjectFilesView.tsx
+++ b/src/renderer/src/pages/workspace/ProjectFilesView.tsx
@@ -1504,31 +1504,29 @@ const ProjectFilesViewContent = ({
                 <TooltipContent>List view</TooltipContent>
               </Tooltip>
             </ToggleGroup.Root>
-            <div className="flex h-8 shrink-0 items-center rounded-lg border border-border bg-card p-0.5">
-              <Tooltip>
-                <TooltipTrigger asChild>
-                  <Button
-                    type="button"
-                    variant="ghost"
-                    size="icon-sm"
-                    className="rounded-md text-text-300 hover:bg-muted hover:text-text-000"
-                    aria-label={isFilesExpanded ? 'Exit full screen files' : 'Expand files'}
-                    onClick={() =>
-                      setToolItemExpanded(isFilesExpanded ? null : PROJECT_FILES_PREVIEW_ID)
-                    }
-                  >
-                    {isFilesExpanded ? (
-                      <Minimize2 className="size-3.5" strokeWidth={1.8} aria-hidden="true" />
-                    ) : (
-                      <Maximize2 className="size-3.5" strokeWidth={1.8} aria-hidden="true" />
-                    )}
-                  </Button>
-                </TooltipTrigger>
-                <TooltipContent className="z-[70]">
-                  {isFilesExpanded ? 'Exit full screen' : 'Expand files'}
-                </TooltipContent>
-              </Tooltip>
-            </div>
+            <Tooltip>
+              <TooltipTrigger asChild>
+                <Button
+                  type="button"
+                  variant="ghost"
+                  size="icon-sm"
+                  className="rounded-md text-text-300 hover:bg-muted hover:text-text-000"
+                  aria-label={isFilesExpanded ? 'Exit full screen files' : 'Expand files'}
+                  onClick={() =>
+                    setToolItemExpanded(isFilesExpanded ? null : PROJECT_FILES_PREVIEW_ID)
+                  }
+                >
+                  {isFilesExpanded ? (
+                    <Minimize2 className="size-4" strokeWidth={1.8} aria-hidden="true" />
+                  ) : (
+                    <Maximize2 className="size-4" strokeWidth={1.8} aria-hidden="true" />
+                  )}
+                </Button>
+              </TooltipTrigger>
+              <TooltipContent className="z-[70]">
+                {isFilesExpanded ? 'Exit full screen' : 'Expand files'}
+              </TooltipContent>
+            </Tooltip>
           </div>
         </TooltipProvider>
       </div>

--- a/src/renderer/src/pages/workspace/ProjectFilesView.tsx
+++ b/src/renderer/src/pages/workspace/ProjectFilesView.tsx
@@ -1450,7 +1450,13 @@ const ProjectFilesViewContent = ({
 
   return (
     <div data-testid="files-view" className="flex h-full min-h-0 w-full flex-col bg-bg-10">
-      <div className="flex shrink-0 items-center justify-between gap-3 px-4 pb-2 pt-1">
+      <div
+        className={cn(
+          'flex shrink-0 items-center justify-between gap-3 px-4 pb-2',
+          // In the expanded modal the toolbar's top gap matches its distance to the search row.
+          isFilesExpanded ? 'pt-2' : 'pt-1'
+        )}
+      >
         <ProjectFilesFilterMenu
           label={isAllFilter ? 'Artifacts' : selectedFilterOption.label}
           options={filterOptions}

--- a/src/renderer/src/pages/workspace/ProjectFilesView.tsx
+++ b/src/renderer/src/pages/workspace/ProjectFilesView.tsx
@@ -1504,29 +1504,31 @@ const ProjectFilesViewContent = ({
                 <TooltipContent>List view</TooltipContent>
               </Tooltip>
             </ToggleGroup.Root>
-            <Tooltip>
-              <TooltipTrigger asChild>
-                <Button
-                  type="button"
-                  variant="ghost"
-                  size="icon-xs"
-                  className="text-text-100 hover:text-text-000"
-                  aria-label={isFilesExpanded ? 'Exit full screen files' : 'Expand files'}
-                  onClick={() =>
-                    setToolItemExpanded(isFilesExpanded ? null : PROJECT_FILES_PREVIEW_ID)
-                  }
-                >
-                  {isFilesExpanded ? (
-                    <Minimize2 className="size-3.5" strokeWidth={1.8} aria-hidden="true" />
-                  ) : (
-                    <Maximize2 className="size-3.5" strokeWidth={1.8} aria-hidden="true" />
-                  )}
-                </Button>
-              </TooltipTrigger>
-              <TooltipContent className="z-[70]">
-                {isFilesExpanded ? 'Exit full screen' : 'Expand files'}
-              </TooltipContent>
-            </Tooltip>
+            <div className="flex h-8 shrink-0 items-center rounded-lg border border-border bg-card p-0.5">
+              <Tooltip>
+                <TooltipTrigger asChild>
+                  <Button
+                    type="button"
+                    variant="ghost"
+                    size="icon-sm"
+                    className="rounded-md text-text-300 hover:bg-muted hover:text-text-000"
+                    aria-label={isFilesExpanded ? 'Exit full screen files' : 'Expand files'}
+                    onClick={() =>
+                      setToolItemExpanded(isFilesExpanded ? null : PROJECT_FILES_PREVIEW_ID)
+                    }
+                  >
+                    {isFilesExpanded ? (
+                      <Minimize2 className="size-3.5" strokeWidth={1.8} aria-hidden="true" />
+                    ) : (
+                      <Maximize2 className="size-3.5" strokeWidth={1.8} aria-hidden="true" />
+                    )}
+                  </Button>
+                </TooltipTrigger>
+                <TooltipContent className="z-[70]">
+                  {isFilesExpanded ? 'Exit full screen' : 'Expand files'}
+                </TooltipContent>
+              </Tooltip>
+            </div>
           </div>
         </TooltipProvider>
       </div>

--- a/src/renderer/src/stores/preview-workbench-store.test.ts
+++ b/src/renderer/src/stores/preview-workbench-store.test.ts
@@ -332,6 +332,49 @@ describe('preview workbench store', () => {
     })
   })
 
+  it('tracks the expanded tool item and clears it when the tab is removed', () => {
+    expect(usePreviewWorkbenchStore.getState().expandedToolItemId).toBeNull()
+
+    usePreviewWorkbenchStore.getState().upsertAndActivateItem(createProjectFilesPreviewItem())
+    usePreviewWorkbenchStore.getState().setToolItemExpanded(PROJECT_FILES_PREVIEW_ID)
+
+    expect(usePreviewWorkbenchStore.getState().expandedToolItemId).toBe(PROJECT_FILES_PREVIEW_ID)
+
+    usePreviewWorkbenchStore.getState().setToolItemExpanded(null)
+
+    expect(usePreviewWorkbenchStore.getState().expandedToolItemId).toBeNull()
+
+    usePreviewWorkbenchStore.getState().setToolItemExpanded(PROJECT_FILES_PREVIEW_ID)
+    usePreviewWorkbenchStore.getState().removeItem(PROJECT_FILES_PREVIEW_ID)
+
+    expect(usePreviewWorkbenchStore.getState().expandedToolItemId).toBeNull()
+  })
+
+  it('clears the expanded tool item when its session is removed', () => {
+    usePreviewWorkbenchStore.getState().upsertAndActivateItem({
+      id: 'tool:session-1:notebook',
+      sessionId: 'session-1',
+      type: 'tool',
+      toolKind: 'notebook',
+      title: 'Notebook'
+    })
+    usePreviewWorkbenchStore.getState().setToolItemExpanded('tool:session-1:notebook')
+
+    usePreviewWorkbenchStore.getState().removeSessionItems('session-1')
+
+    expect(usePreviewWorkbenchStore.getState().expandedToolItemId).toBeNull()
+  })
+
+  it('clears the expanded tool item when switching projects', () => {
+    usePreviewWorkbenchStore.getState().activateProject('project-1')
+    usePreviewWorkbenchStore.getState().upsertAndActivateItem(createProjectFilesPreviewItem())
+    usePreviewWorkbenchStore.getState().setToolItemExpanded(PROJECT_FILES_PREVIEW_ID)
+
+    usePreviewWorkbenchStore.getState().activateProject('project-2')
+
+    expect(usePreviewWorkbenchStore.getState().expandedToolItemId).toBeNull()
+  })
+
   it('removes all preview items for a deleted session', () => {
     usePreviewWorkbenchStore.getState().upsertAndActivateItem({
       id: 'file:session-1:/workspace/project/report.md',

--- a/src/renderer/src/stores/preview-workbench-store.ts
+++ b/src/renderer/src/stores/preview-workbench-store.ts
@@ -86,6 +86,8 @@ export type RestoredPreviewSlice = {
 type PreviewWorkbenchStoreData = PreviewSlice & {
   activeProjectId: string | undefined
   byProject: Record<string, PreviewSlice>
+  // Tool tab currently shown as a large modal instead of inline panel content (files tab only).
+  expandedToolItemId: string | null
 }
 
 type PreviewWorkbenchStore = PreviewWorkbenchStoreData & {
@@ -96,6 +98,7 @@ type PreviewWorkbenchStore = PreviewWorkbenchStoreData & {
   activateItem: (itemId: string) => void
   removeItem: (itemId: string) => void
   removeSessionItems: (sessionId: string) => void
+  setToolItemExpanded: (itemId: string | null) => void
   openPanel: () => void
   collapsePanel: () => void
   togglePanel: () => void
@@ -109,7 +112,8 @@ export const createInitialPreviewWorkbenchState = (): PreviewWorkbenchStoreData 
   panelState: 'collapsed',
   openRequestVersion: 0,
   activeProjectId: undefined,
-  byProject: {}
+  byProject: {},
+  expandedToolItemId: null
 })
 
 // The empty slice a project starts from before any preview tabs are opened.
@@ -256,7 +260,8 @@ export const usePreviewWorkbenchStore = create<PreviewWorkbenchStore>((set, get)
       // The active slice lives at top level, never duplicated in the stash.
       delete byProject[projectId]
 
-      return { ...targetSlice, activeProjectId: projectId, byProject }
+      // The expanded files surface is tied to the outgoing project's workbench layout.
+      return { ...targetSlice, activeProjectId: projectId, byProject, expandedToolItemId: null }
     })
   },
 
@@ -344,7 +349,8 @@ export const usePreviewWorkbenchStore = create<PreviewWorkbenchStore>((set, get)
 
       return {
         items,
-        activeItemId
+        activeItemId,
+        expandedToolItemId: state.expandedToolItemId === itemId ? null : state.expandedToolItemId
       }
     })
   },
@@ -363,9 +369,18 @@ export const usePreviewWorkbenchStore = create<PreviewWorkbenchStore>((set, get)
 
       return {
         items,
-        activeItemId
+        activeItemId,
+        // A session-scoped tool tab could own the expanded surface; clear it when its tab is gone.
+        expandedToolItemId: items.some((item) => item.id === state.expandedToolItemId)
+          ? state.expandedToolItemId
+          : null
       }
     })
+  },
+
+  // Expands a tool tab (files) into a large modal surface, or restores the inline panel layout.
+  setToolItemExpanded: (itemId) => {
+    set({ expandedToolItemId: itemId })
   },
 
   // Records an explicit open request so the resizable panel can expand even if it is already open.


### PR DESCRIPTION
## Summary

The project files tab in the preview panel can now be expanded into a large modal. A new "Expand files" button in the files view header swaps the existing `ProjectFilesView` between the inline preview panel and a 90vw × 90vh dialog surface without remounting it, so scroll position, active filter, loaded pagination pages, and thumbnails are fully preserved when moving between the two layouts. Escape, overlay click, or the header's minimize button returns to the inline panel.

## Highlights

- New "Expand files" button in the files tab header (next to the grid/list view toggle) opens the file library as a large centered modal; the button turns into a minimize affordance while expanded.
- File previews opened from the expanded files view stack above the modal, and nested overlays close one layer at a time with Escape.

## Impact

- Affects the preview workbench tool-tab chrome (`PreviewPanel`) and the project files view header; file preview tabs reuse the same extracted modal hook with unchanged layout.
- The workbench store now tracks the expanded tool tab and clears that state when the tab closes, its session is removed, or the active project switches, so no dangling modal state survives navigation.
- No data, persistence, or API changes.

## Test Results

- [x] `vitest run` on `preview-workbench-store.test.ts` and `PreviewPanel.test.tsx` — 37 tests passed (new: expand/collapse store transitions incl. tab/session/project cleanup; tool tab modal rendering without remount, Escape restore)
- [x] `npm run typecheck`
- [x] `npm run lint`
- [x] Headless web build + Playwright walkthrough: panel/modal layouts, tooltip, 90vw×90vh centering, nested `FilePreviewDialog` stacking, all three exit paths, scroll retention across expand/collapse

## Potential Issues

- The extracted modal hook now ignores Escape when focus lives in a portaled overlay above the surface; this also applies to pre-existing file preview full-screen mode (intentional: prevents one Escape from closing two layers).
- The expand button sits next to the view-mode toggle in the files header (the earlier "next to the file count" anchor no longer exists after the header redesign in #469).

## Authors

- Roxi (@roxi3906)