### PR TITLE
feat(claude-code): keep built-in web tools available

### DIFF
--- a/src/main/acp/runtime.test.ts
+++ b/src/main/acp/runtime.test.ts
@@ -980,6 +980,9 @@ describe('ACP runtime session management', () => {
     expect(JSON.stringify(fakeAgent.newSessions[1]._meta)).not.toContain(
       BEGIN_ACTIVITY_GROUP_TOOL_NAME
     )
+    expect(fakeAgent.newSessions[1]._meta).toMatchObject({
+      claudeCode: { options: { tools: [] } }
+    })
     expect(fakeAgent.prompts[1].text).toBe('Review this turn')
   })
 
@@ -6120,7 +6123,12 @@ describe('ACP runtime session management', () => {
         mcpServers: [],
         // Every session (new or resumed) is restricted to the app-owned "user" settings scope.
         _meta: {
-          claudeCode: { options: { settingSources: ['user'] } },
+          claudeCode: {
+            options: {
+              settingSources: ['user'],
+              tools: { type: 'preset', preset: 'claude_code' }
+            }
+          },
           systemPrompt: {
             type: 'preset',
             preset: 'claude_code',

--- a/src/main/agent-framework/claude-code.test.ts
+++ b/src/main/agent-framework/claude-code.test.ts
@@ -19,7 +19,23 @@ describe('claudeCodeFramework', () => {
 
     expect(setup.meta).toMatchObject({
       claudeCode: {
-        options: { ...sessionOptions, settingSources: ['user'] }
+        options: {
+          ...sessionOptions,
+          settingSources: ['user'],
+          tools: { type: 'preset', preset: 'claude_code' }
+        }
+      }
+    })
+  })
+
+  it('keeps Claude web tools available through the complete built-in tool preset', () => {
+    const setup = claudeCodeFramework.buildSessionSetup({ systemPromptAppends: [] })
+
+    expect(setup.meta).toMatchObject({
+      claudeCode: {
+        options: {
+          tools: { type: 'preset', preset: 'claude_code' }
+        }
       }
     })
   })

--- a/src/main/agent-framework/claude-code.ts
+++ b/src/main/agent-framework/claude-code.ts
@@ -43,6 +43,11 @@ const renderClaudeMcpToolNames = (append: string): string =>
     append
   )
 
+// Select Claude Code's complete built-in tool set explicitly instead of relying on
+// claude-agent-acp's current fallback. This keeps WebFetch/WebSearch available if the adapter's
+// default changes, while reviewer sessions can still replace this with `tools: []` at their boundary.
+const CLAUDE_CODE_BUILTIN_TOOLS = { type: 'preset', preset: 'claude_code' } as const
+
 // Claude Code adapter. A faithful extraction of behavior currently inline in AcpRuntime /
 // agent-process / provider-env — moving the runtime onto AgentFramework must not change it.
 export const claudeCodeFramework: AgentFramework = {
@@ -86,7 +91,11 @@ export const claudeCodeFramework: AgentFramework = {
     // Shared mode adds app-owned settings/plugins at the SDK flag layer via sessionOptions.
     const meta: Record<string, unknown> = {
       claudeCode: {
-        options: { ...ctx.sessionOptions, settingSources: ['user'] }
+        options: {
+          tools: CLAUDE_CODE_BUILTIN_TOOLS,
+          ...ctx.sessionOptions,
+          settingSources: ['user']
+        }
       }
     }
 


### PR DESCRIPTION
## Problem

Open Science does not deny WebFetch today, and claude-agent-acp currently supplies the complete claude_code tool preset when no tools option is present. That means WebFetch availability still depends on an upstream adapter fallback that could change silently.

## Proposed change

Explicitly select the complete claude_code built-in tool preset for normal Claude Code ACP sessions. This keeps WebFetch and WebSearch in the session contract while retaining the existing app permission broker.

Add regression coverage for framework session metadata, resumed sessions, and the reviewer boundary. Reviewer sessions continue to override the preset with an empty built-in tool list.

## Scope and non-goals

- In scope: normal Claude Code ACP session tool availability and reviewer isolation.
- Non-goal: bypassing user permission decisions or Claude Code domain-safety checks.
- Non-goal: changing custom MCP connector permissions or other agent frameworks.

## Acceptance criteria and validation

All listed checks ran after the final material edit.

- Normal Claude Code ACP sessions explicitly receive the complete built-in preset -> npm test -- src/main/agent-framework/claude-code.test.ts src/main/acp/runtime.test.ts -> 263 passed.
- New and resumed sessions retain that preset, while reviewer sessions retain tools: [] -> same targeted command -> 263 passed.
- Node and web types remain valid -> npm run typecheck -> passed.
- Repository lint gate -> npm run lint -> passed with 0 errors and 24 pre-existing warnings outside the changed files.
- Full regression suite -> npm test -> 544 files passed, 11 skipped; 8133 tests passed, 139 skipped.
- Changed-file formatting -> npx prettier --check on the three changed files -> passed.

Uncovered risk: validation does not perform a live authenticated WebFetch call. The exact contents of the claude_code preset and WebFetch domain-safety preflight remain owned by the installed Claude Code runtime.

## Review focus

Confirm that making the complete built-in preset explicit is the desired compatibility contract and that reviewer sessions remain isolated from built-in tools.