### PR TITLE
fix(acp): isolate runtime framework switches

### DIFF
--- a/src/main/acp/runtime-coordinator.test.ts
+++ b/src/main/acp/runtime-coordinator.test.ts
@@ -752,10 +752,19 @@ describe('AcpRuntimeCoordinator', () => {
       expect.stringMatching(runtimeEventId(1, 'late-codex-artifact')),
       expect.stringMatching(runtimeEventId(2, 'fresh-claude-tool'))
     ])
-    expect(coordinator.getSnapshot().events.map((event) => event.id)).toEqual([
-      expect.stringMatching(runtimeEventId(2, 'fresh-claude-tool')),
-      expect.stringMatching(runtimeEventId(1, 'late-codex-artifact'))
-    ])
+    const adoptedSnapshotEventIds = coordinator.getSnapshot().events.map((event) => event.id)
+    expect(adoptedSnapshotEventIds).toEqual(
+      expect.arrayContaining([
+        expect.stringMatching(runtimeEventId(1, 'owner-tool')),
+        expect.stringMatching(runtimeEventId(1, 'late-codex-tool')),
+        expect.stringMatching(runtimeEventId(1, 'late-codex-stop')),
+        expect.stringMatching(runtimeEventId(1, 'late-codex-artifact')),
+        expect.stringMatching(runtimeEventId(2, 'fresh-claude-tool'))
+      ])
+    )
+    expect(adoptedSnapshotEventIds).not.toEqual(
+      expect.arrayContaining([expect.stringMatching(runtimeEventId(1, 'post-adoption-codex-tool'))])
+    )
 
     retirement.resolve()
     await switchRequest
@@ -854,7 +863,9 @@ describe('AcpRuntimeCoordinator', () => {
     expect(forwardedEvents.map((event) => event.id)).toEqual([
       expect.stringMatching(runtimeEventId(1, 'owner-overflow'))
     ])
-    expect(coordinator.getSnapshot().events.map((event) => event.id)).toEqual([])
+    expect(coordinator.getSnapshot().events.map((event) => event.id)).toEqual([
+      expect.stringMatching(runtimeEventId(1, 'owner-overflow'))
+    ])
 
     created[1].emitEvent(overflowEvent('fresh-owner-overflow'))
     expect(forwardedEvents.map((event) => event.id)).toEqual([
@@ -862,6 +873,7 @@ describe('AcpRuntimeCoordinator', () => {
       expect.stringMatching(runtimeEventId(2, 'fresh-owner-overflow'))
     ])
     expect(coordinator.getSnapshot().events.map((event) => event.id)).toEqual([
+      expect.stringMatching(runtimeEventId(1, 'owner-overflow')),
       expect.stringMatching(runtimeEventId(2, 'fresh-owner-overflow'))
     ])
 
@@ -918,7 +930,9 @@ describe('AcpRuntimeCoordinator', () => {
     expect(forwardedEvents.map((event) => event.id)).toEqual([
       expect.stringMatching(runtimeEventId(1, 'owner-compaction'))
     ])
-    expect(coordinator.getSnapshot().events.map((event) => event.id)).toEqual([])
+    expect(coordinator.getSnapshot().events.map((event) => event.id)).toEqual([
+      expect.stringMatching(runtimeEventId(1, 'owner-compaction'))
+    ])
 
     created[1].emitEvent(compactionEvent('fresh-owner-compaction', 'completed'))
     expect(forwardedEvents.map((event) => event.id)).toEqual([
@@ -926,6 +940,7 @@ describe('AcpRuntimeCoordinator', () => {
       expect.stringMatching(runtimeEventId(2, 'fresh-owner-compaction'))
     ])
     expect(coordinator.getSnapshot().events.map((event) => event.id)).toEqual([
+      expect.stringMatching(runtimeEventId(1, 'owner-compaction')),
       expect.stringMatching(runtimeEventId(2, 'fresh-owner-compaction'))
     ])
 

--- a/src/main/acp/runtime-coordinator.test.ts
+++ b/src/main/acp/runtime-coordinator.test.ts
@@ -629,6 +629,78 @@ describe('AcpRuntimeCoordinator', () => {
     await reloadRequest
   })
 
+  it('drops late Codex tool events after Claude Code adopts the switched session', async () => {
+    const retirement = createDeferred<void>()
+    const created: ReturnType<typeof createFakeRuntime>[] = []
+    const forwardedEvents: AcpRuntimeEvent[] = []
+    const coordinator = new AcpRuntimeCoordinator(
+      (callbacks) => {
+        const fake = createFakeRuntime({
+          frameworkId: created.length === 0 ? 'codex' : 'claude-code',
+          sessionIds: [`agent-session-${created.length + 1}`],
+          callbacks
+        })
+        created.push(fake)
+        return fake.runtime
+      },
+      { onEvent: (event) => forwardedEvents.push(event) }
+    )
+
+    const session = await coordinator.createSession()
+    created[0].emitState({
+      promptInFlight: true,
+      promptInFlightSessionIds: [session.sessionId]
+    })
+    created[0].requestRetirement.mockReturnValue(retirement.promise)
+    const switchRequest = coordinator.requestAgentFrameworkSwitch()
+    const toolEvent = (id: string, providerToolName: string): AcpRuntimeEvent => ({
+      id,
+      timestamp: 1,
+      kind: 'tool',
+      level: 'info',
+      sessionId: session.sessionId,
+      toolCallId: id,
+      providerToolName,
+      title: providerToolName,
+      toolKind: providerToolName.startsWith('mcp.') ? 'execute' : 'other',
+      status: 'completed'
+    })
+
+    // The draining Codex turn still owns the session until Claude Code adopts it.
+    created[0].emitEvent(toolEvent('owner-tool', 'mcp.open-science-artifacts.write_artifact_file'))
+    expect(forwardedEvents.map((event) => event.id)).toEqual([
+      expect.stringMatching(runtimeEventId(1, 'owner-tool'))
+    ])
+
+    await coordinator.resumeSession({
+      sessionId: session.sessionId,
+      cwd: '/workspace',
+      previousFrameworkId: 'codex'
+    })
+
+    created[0].emitEvent(
+      toolEvent('late-codex-tool', 'mcp.open-science-artifacts.write_artifact_file')
+    )
+    expect(forwardedEvents.map((event) => event.id)).toEqual([
+      expect.stringMatching(runtimeEventId(1, 'owner-tool'))
+    ])
+    expect(coordinator.getSnapshot().events.map((event) => event.id)).toEqual([])
+
+    created[1].emitEvent(
+      toolEvent('fresh-claude-tool', 'mcp__open-science-artifacts__write_artifact_file')
+    )
+    expect(forwardedEvents.map((event) => event.id)).toEqual([
+      expect.stringMatching(runtimeEventId(1, 'owner-tool')),
+      expect.stringMatching(runtimeEventId(2, 'fresh-claude-tool'))
+    ])
+    expect(coordinator.getSnapshot().events.map((event) => event.id)).toEqual([
+      expect.stringMatching(runtimeEventId(2, 'fresh-claude-tool'))
+    ])
+
+    retirement.resolve()
+    await switchRequest
+  })
+
   it('drops late recoverable overflow events from a previous session owner', async () => {
     const retirement = createDeferred<void>()
     const created: ReturnType<typeof createFakeRuntime>[] = []

--- a/src/main/acp/runtime-coordinator.test.ts
+++ b/src/main/acp/runtime-coordinator.test.ts
@@ -39,6 +39,7 @@ const createFakeRuntime = (options: {
   permissionGrantStore?: ConversationPermissionGrantStore
   beforePromptStart?: () => Promise<void>
   beforeResume?: () => Promise<void>
+  afterResumeAttached?: () => Promise<void>
   eligibleAttachmentUri?: string
   prompt?: (sessionId: string) => Promise<unknown>
 }): {
@@ -83,6 +84,7 @@ const createFakeRuntime = (options: {
         : [...snapshot.sessionIds, sessionId]
     }
     options.callbacks.onStateChanged?.(snapshot)
+    await options.afterResumeAttached?.()
     return { sessionId, cwd: '/workspace', frameworkId: options.frameworkId, contextReset: true }
   })
   const resetSessionContext = vi.fn(async ({ sessionId }: { sessionId: string }) => ({
@@ -631,7 +633,7 @@ describe('AcpRuntimeCoordinator', () => {
     await reloadRequest
   })
 
-  it('isolates late Codex events while preserving Artifact finalization during adoption', async () => {
+  it('keeps draining events on the prior owner until adoption commits', async () => {
     const retirement = createDeferred<void>()
     const adoption = createDeferred<void>()
     const created: ReturnType<typeof createFakeRuntime>[] = []
@@ -642,7 +644,7 @@ describe('AcpRuntimeCoordinator', () => {
           frameworkId: created.length === 0 ? 'codex' : 'claude-code',
           sessionIds: [`agent-session-${created.length + 1}`],
           callbacks,
-          ...(created.length === 0 ? {} : { beforeResume: () => adoption.promise })
+          ...(created.length === 0 ? {} : { afterResumeAttached: () => adoption.promise })
         })
         created.push(fake)
         return fake.runtime
@@ -688,8 +690,22 @@ describe('AcpRuntimeCoordinator', () => {
       toolEvent('late-codex-tool', 'mcp.open-science-artifacts.write_artifact_file')
     )
     created[0].emitEvent({
-      id: 'late-codex-artifact',
+      id: 'late-codex-stop',
       timestamp: 2,
+      kind: 'stop',
+      level: 'info',
+      sessionId: session.sessionId,
+      title: 'Prompt stopped',
+      text: 'end_turn'
+    })
+    expect(forwardedEvents.map((event) => event.id)).toEqual([
+      expect.stringMatching(runtimeEventId(1, 'owner-tool')),
+      expect.stringMatching(runtimeEventId(1, 'late-codex-tool')),
+      expect.stringMatching(runtimeEventId(1, 'late-codex-stop'))
+    ])
+    created[0].emitEvent({
+      id: 'late-codex-artifact',
+      timestamp: 3,
       kind: 'artifact',
       level: 'info',
       sessionId: session.sessionId,
@@ -711,20 +727,28 @@ describe('AcpRuntimeCoordinator', () => {
     })
     expect(forwardedEvents.map((event) => event.id)).toEqual([
       expect.stringMatching(runtimeEventId(1, 'owner-tool')),
+      expect.stringMatching(runtimeEventId(1, 'late-codex-tool')),
+      expect.stringMatching(runtimeEventId(1, 'late-codex-stop')),
       expect.stringMatching(runtimeEventId(1, 'late-codex-artifact'))
     ])
     expect(coordinator.getSnapshot().events.map((event) => event.id)).toEqual([
+      expect.stringMatching(runtimeEventId(1, 'owner-tool')),
+      expect.stringMatching(runtimeEventId(1, 'late-codex-tool')),
+      expect.stringMatching(runtimeEventId(1, 'late-codex-stop')),
       expect.stringMatching(runtimeEventId(1, 'late-codex-artifact'))
     ])
 
     adoption.resolve()
     await resumeRequest
 
+    created[0].emitEvent(toolEvent('post-adoption-codex-tool', 'shell'))
     created[1].emitEvent(
       toolEvent('fresh-claude-tool', 'mcp__open-science-artifacts__write_artifact_file')
     )
     expect(forwardedEvents.map((event) => event.id)).toEqual([
       expect.stringMatching(runtimeEventId(1, 'owner-tool')),
+      expect.stringMatching(runtimeEventId(1, 'late-codex-tool')),
+      expect.stringMatching(runtimeEventId(1, 'late-codex-stop')),
       expect.stringMatching(runtimeEventId(1, 'late-codex-artifact')),
       expect.stringMatching(runtimeEventId(2, 'fresh-claude-tool'))
     ])

--- a/src/main/acp/runtime-coordinator.test.ts
+++ b/src/main/acp/runtime-coordinator.test.ts
@@ -654,6 +654,8 @@ describe('AcpRuntimeCoordinator', () => {
 
     const session = await coordinator.createSession()
     created[0].emitState({
+      status: 'error',
+      error: 'draining runtime disconnected',
       promptInFlight: true,
       promptInFlightSessionIds: [session.sessionId]
     })
@@ -740,6 +742,10 @@ describe('AcpRuntimeCoordinator', () => {
 
     adoption.resolve()
     await resumeRequest
+
+    expect(coordinator.getSnapshot().sessionConnectionStatuses).toEqual({
+      [session.sessionId]: 'connected'
+    })
 
     created[0].emitEvent(toolEvent('post-adoption-codex-tool', 'shell'))
     created[1].emitEvent(

--- a/src/main/acp/runtime-coordinator.test.ts
+++ b/src/main/acp/runtime-coordinator.test.ts
@@ -62,6 +62,7 @@ const createFakeRuntime = (options: {
   emitPermission: (request: AcpPermissionRequest) => void
   emitState: (overrides: Partial<AcpStateSnapshot>) => void
   setStateSilently: (overrides: Partial<AcpStateSnapshot>) => void
+  emitRetired: () => void
 } => {
   let snapshot = emptySnapshot()
   let sessionIndex = 0
@@ -222,7 +223,8 @@ const createFakeRuntime = (options: {
     },
     setStateSilently: (overrides) => {
       snapshot = { ...snapshot, ...overrides }
-    }
+    },
+    emitRetired: () => options.callbacks.onRetired?.()
   }
 }
 
@@ -856,6 +858,50 @@ describe('AcpRuntimeCoordinator', () => {
     expect(forwardedEvents.map((event) => event.id)).toEqual([
       expect.stringMatching(runtimeEventId(1, 'post-resume-old-stop'))
     ])
+
+    retirement.resolve()
+    await switchRequest
+  })
+
+  it('rejects adoption when the incoming runtime retires while the prior turn drains', async () => {
+    const retirement = createDeferred<void>()
+    const created: ReturnType<typeof createFakeRuntime>[] = []
+    const coordinator = new AcpRuntimeCoordinator((callbacks) => {
+      const fake = createFakeRuntime({
+        frameworkId: created.length === 0 ? 'codex' : 'claude-code',
+        sessionIds: [`agent-session-${created.length + 1}`],
+        callbacks
+      })
+      created.push(fake)
+      return fake.runtime
+    })
+
+    const session = await coordinator.createSession()
+    created[0].emitState({
+      promptInFlight: true,
+      promptInFlightSessionIds: [session.sessionId]
+    })
+    created[0].requestRetirement.mockReturnValue(retirement.promise)
+    const switchRequest = coordinator.requestAgentFrameworkSwitch()
+    await coordinator.connect()
+
+    const resumeRequest = coordinator.resumeSession({
+      sessionId: session.sessionId,
+      cwd: '/workspace',
+      previousFrameworkId: 'codex'
+    })
+    await vi.waitFor(() => expect(created[1].resumeSession).toHaveBeenCalledOnce())
+    await expect(created[1].resumeSession.mock.results[0]?.value).resolves.toMatchObject({
+      sessionId: session.sessionId
+    })
+
+    created[1].emitRetired()
+    created[0].emitState({ promptInFlight: false, promptInFlightSessionIds: [] })
+
+    await expect(resumeRequest).rejects.toThrow('superseded')
+    await expect(
+      coordinator.sendPrompt({ sessionId: session.sessionId, text: 'must resume again' })
+    ).rejects.toThrow('must resume')
 
     retirement.resolve()
     await switchRequest

--- a/src/main/acp/runtime-coordinator.test.ts
+++ b/src/main/acp/runtime-coordinator.test.ts
@@ -38,6 +38,7 @@ const createFakeRuntime = (options: {
   callbacks: AcpRuntimeCallbacks
   permissionGrantStore?: ConversationPermissionGrantStore
   beforePromptStart?: () => Promise<void>
+  beforeResume?: () => Promise<void>
   eligibleAttachmentUri?: string
   prompt?: (sessionId: string) => Promise<unknown>
 }): {
@@ -73,6 +74,7 @@ const createFakeRuntime = (options: {
     return { sessionId, cwd: '/workspace', frameworkId: options.frameworkId }
   })
   const resumeSession = vi.fn(async ({ sessionId }: { sessionId: string }) => {
+    await options.beforeResume?.()
     snapshot = {
       ...snapshot,
       sessionId,
@@ -629,8 +631,9 @@ describe('AcpRuntimeCoordinator', () => {
     await reloadRequest
   })
 
-  it('drops late Codex tool events after Claude Code adopts the switched session', async () => {
+  it('isolates late Codex events while preserving Artifact finalization during adoption', async () => {
     const retirement = createDeferred<void>()
+    const adoption = createDeferred<void>()
     const created: ReturnType<typeof createFakeRuntime>[] = []
     const forwardedEvents: AcpRuntimeEvent[] = []
     const coordinator = new AcpRuntimeCoordinator(
@@ -638,7 +641,8 @@ describe('AcpRuntimeCoordinator', () => {
         const fake = createFakeRuntime({
           frameworkId: created.length === 0 ? 'codex' : 'claude-code',
           sessionIds: [`agent-session-${created.length + 1}`],
-          callbacks
+          callbacks,
+          ...(created.length === 0 ? {} : { beforeResume: () => adoption.promise })
         })
         created.push(fake)
         return fake.runtime
@@ -672,33 +676,108 @@ describe('AcpRuntimeCoordinator', () => {
       expect.stringMatching(runtimeEventId(1, 'owner-tool'))
     ])
 
-    await coordinator.resumeSession({
+    await coordinator.connect()
+    const resumeRequest = coordinator.resumeSession({
       sessionId: session.sessionId,
       cwd: '/workspace',
       previousFrameworkId: 'codex'
     })
+    await vi.waitFor(() => expect(created[1].resumeSession).toHaveBeenCalledOnce())
 
     created[0].emitEvent(
       toolEvent('late-codex-tool', 'mcp.open-science-artifacts.write_artifact_file')
     )
+    created[0].emitEvent({
+      id: 'late-codex-artifact',
+      timestamp: 2,
+      kind: 'artifact',
+      level: 'info',
+      sessionId: session.sessionId,
+      runId: 'old-run',
+      promptMessageId: 'old-prompt',
+      artifactClaimId: 'old-claim',
+      artifacts: [
+        {
+          id: 'artifact-version-1',
+          projectName: 'project-1',
+          sessionId: session.sessionId,
+          name: 'result.csv',
+          path: '/workspace/result.csv',
+          fileUrl: 'file:///workspace/result.csv',
+          size: 12,
+          mtimeMs: 2
+        }
+      ]
+    })
     expect(forwardedEvents.map((event) => event.id)).toEqual([
-      expect.stringMatching(runtimeEventId(1, 'owner-tool'))
+      expect.stringMatching(runtimeEventId(1, 'owner-tool')),
+      expect.stringMatching(runtimeEventId(1, 'late-codex-artifact'))
     ])
-    expect(coordinator.getSnapshot().events.map((event) => event.id)).toEqual([])
+    expect(coordinator.getSnapshot().events.map((event) => event.id)).toEqual([
+      expect.stringMatching(runtimeEventId(1, 'late-codex-artifact'))
+    ])
+
+    adoption.resolve()
+    await resumeRequest
 
     created[1].emitEvent(
       toolEvent('fresh-claude-tool', 'mcp__open-science-artifacts__write_artifact_file')
     )
     expect(forwardedEvents.map((event) => event.id)).toEqual([
       expect.stringMatching(runtimeEventId(1, 'owner-tool')),
+      expect.stringMatching(runtimeEventId(1, 'late-codex-artifact')),
       expect.stringMatching(runtimeEventId(2, 'fresh-claude-tool'))
     ])
     expect(coordinator.getSnapshot().events.map((event) => event.id)).toEqual([
-      expect.stringMatching(runtimeEventId(2, 'fresh-claude-tool'))
+      expect.stringMatching(runtimeEventId(2, 'fresh-claude-tool')),
+      expect.stringMatching(runtimeEventId(1, 'late-codex-artifact'))
     ])
 
     retirement.resolve()
     await switchRequest
+  })
+
+  it('restores the draining runtime owner when fresh runtime adoption fails before attachment', async () => {
+    const created: ReturnType<typeof createFakeRuntime>[] = []
+    const forwardedEvents: AcpRuntimeEvent[] = []
+    const coordinator = new AcpRuntimeCoordinator(
+      (callbacks) => {
+        const fake = createFakeRuntime({
+          frameworkId: created.length === 0 ? 'codex' : 'claude-code',
+          sessionIds: [`agent-session-${created.length + 1}`],
+          callbacks
+        })
+        created.push(fake)
+        return fake.runtime
+      },
+      { onEvent: (event) => forwardedEvents.push(event) }
+    )
+
+    const session = await coordinator.createSession()
+    await coordinator.requestAgentFrameworkSwitch()
+    await coordinator.connect()
+    created[1].resumeSession.mockRejectedValue(new Error('resume failed'))
+
+    await expect(
+      coordinator.resumeSession({
+        sessionId: session.sessionId,
+        cwd: '/workspace',
+        previousFrameworkId: 'codex'
+      })
+    ).rejects.toThrow('resume failed')
+
+    created[0].emitEvent({
+      id: 'restored-owner-event',
+      timestamp: 1,
+      kind: 'message',
+      level: 'info',
+      sessionId: session.sessionId,
+      role: 'assistant',
+      text: 'old runtime remains authoritative'
+    })
+    expect(forwardedEvents.map((event) => event.id)).toEqual([
+      expect.stringMatching(runtimeEventId(1, 'restored-owner-event'))
+    ])
   })
 
   it('drops late recoverable overflow events from a previous session owner', async () => {

--- a/src/main/acp/runtime-coordinator.test.ts
+++ b/src/main/acp/runtime-coordinator.test.ts
@@ -734,17 +734,29 @@ describe('AcpRuntimeCoordinator', () => {
         }
       ]
     })
+    created[0].emitEvent({
+      id: 'late-codex-unprovenanced-artifact',
+      timestamp: 4,
+      kind: 'artifact',
+      level: 'info',
+      sessionId: session.sessionId,
+      runId: 'old-run',
+      artifactClaimId: 'old-unprovenanced-claim',
+      artifacts: []
+    })
     expect(forwardedEvents.map((event) => event.id)).toEqual([
       expect.stringMatching(runtimeEventId(1, 'owner-tool')),
       expect.stringMatching(runtimeEventId(1, 'late-codex-tool')),
       expect.stringMatching(runtimeEventId(1, 'late-codex-stop')),
-      expect.stringMatching(runtimeEventId(1, 'late-codex-artifact'))
+      expect.stringMatching(runtimeEventId(1, 'late-codex-artifact')),
+      expect.stringMatching(runtimeEventId(1, 'late-codex-unprovenanced-artifact'))
     ])
     expect(coordinator.getSnapshot().events.map((event) => event.id)).toEqual([
       expect.stringMatching(runtimeEventId(1, 'owner-tool')),
       expect.stringMatching(runtimeEventId(1, 'late-codex-tool')),
       expect.stringMatching(runtimeEventId(1, 'late-codex-stop')),
-      expect.stringMatching(runtimeEventId(1, 'late-codex-artifact'))
+      expect.stringMatching(runtimeEventId(1, 'late-codex-artifact')),
+      expect.stringMatching(runtimeEventId(1, 'late-codex-unprovenanced-artifact'))
     ])
 
     adoption.resolve()
@@ -756,6 +768,16 @@ describe('AcpRuntimeCoordinator', () => {
     })
 
     created[0].emitEvent(toolEvent('post-adoption-codex-tool', 'shell'))
+    created[0].emitEvent({
+      id: 'post-adoption-unprovenanced-artifact',
+      timestamp: 5,
+      kind: 'artifact',
+      level: 'info',
+      sessionId: session.sessionId,
+      runId: 'old-run',
+      artifactClaimId: 'post-adoption-unprovenanced-claim',
+      artifacts: []
+    })
     created[1].emitEvent(
       toolEvent('fresh-claude-tool', 'mcp__open-science-artifacts__write_artifact_file')
     )
@@ -764,6 +786,7 @@ describe('AcpRuntimeCoordinator', () => {
       expect.stringMatching(runtimeEventId(1, 'late-codex-tool')),
       expect.stringMatching(runtimeEventId(1, 'late-codex-stop')),
       expect.stringMatching(runtimeEventId(1, 'late-codex-artifact')),
+      expect.stringMatching(runtimeEventId(1, 'late-codex-unprovenanced-artifact')),
       expect.stringMatching(runtimeEventId(2, 'fresh-claude-tool'))
     ])
     const adoptedSnapshotEventIds = coordinator.getSnapshot().events.map((event) => event.id)
@@ -778,6 +801,16 @@ describe('AcpRuntimeCoordinator', () => {
     )
     expect(adoptedSnapshotEventIds).not.toEqual(
       expect.arrayContaining([expect.stringMatching(runtimeEventId(1, 'post-adoption-codex-tool'))])
+    )
+    expect(adoptedSnapshotEventIds).not.toEqual(
+      expect.arrayContaining([
+        expect.stringMatching(runtimeEventId(1, 'late-codex-unprovenanced-artifact'))
+      ])
+    )
+    expect(forwardedEvents.map((event) => event.id)).not.toEqual(
+      expect.arrayContaining([
+        expect.stringMatching(runtimeEventId(1, 'post-adoption-unprovenanced-artifact'))
+      ])
     )
 
     retirement.resolve()
@@ -1003,9 +1036,7 @@ describe('AcpRuntimeCoordinator', () => {
     expect(forwardedEvents.map((event) => event.id)).toEqual([
       expect.stringMatching(runtimeEventId(1, 'owner-overflow'))
     ])
-    expect(coordinator.getSnapshot().events.map((event) => event.id)).toEqual([
-      expect.stringMatching(runtimeEventId(1, 'owner-overflow'))
-    ])
+    expect(coordinator.getSnapshot().events).toEqual([])
 
     created[1].emitEvent(overflowEvent('fresh-owner-overflow'))
     expect(forwardedEvents.map((event) => event.id)).toEqual([
@@ -1013,7 +1044,6 @@ describe('AcpRuntimeCoordinator', () => {
       expect.stringMatching(runtimeEventId(2, 'fresh-owner-overflow'))
     ])
     expect(coordinator.getSnapshot().events.map((event) => event.id)).toEqual([
-      expect.stringMatching(runtimeEventId(1, 'owner-overflow')),
       expect.stringMatching(runtimeEventId(2, 'fresh-owner-overflow'))
     ])
 
@@ -1073,9 +1103,7 @@ describe('AcpRuntimeCoordinator', () => {
     expect(forwardedEvents.map((event) => event.id)).toEqual([
       expect.stringMatching(runtimeEventId(1, 'owner-compaction'))
     ])
-    expect(coordinator.getSnapshot().events.map((event) => event.id)).toEqual([
-      expect.stringMatching(runtimeEventId(1, 'owner-compaction'))
-    ])
+    expect(coordinator.getSnapshot().events).toEqual([])
 
     created[1].emitEvent(compactionEvent('fresh-owner-compaction', 'completed'))
     expect(forwardedEvents.map((event) => event.id)).toEqual([
@@ -1083,7 +1111,6 @@ describe('AcpRuntimeCoordinator', () => {
       expect.stringMatching(runtimeEventId(2, 'fresh-owner-compaction'))
     ])
     expect(coordinator.getSnapshot().events.map((event) => event.id)).toEqual([
-      expect.stringMatching(runtimeEventId(1, 'owner-compaction')),
       expect.stringMatching(runtimeEventId(2, 'fresh-owner-compaction'))
     ])
 

--- a/src/main/acp/runtime-coordinator.test.ts
+++ b/src/main/acp/runtime-coordinator.test.ts
@@ -613,14 +613,19 @@ describe('AcpRuntimeCoordinator', () => {
 
     expect(coordinator.getSnapshot().promptInFlightSessionIds).toEqual([session.sessionId])
 
-    await coordinator.resumeSession({
+    const resumeRequest = coordinator.resumeSession({
       sessionId: session.sessionId,
       cwd: '/workspace',
       previousFrameworkId: 'claude-code'
     })
+    await vi.waitFor(() => expect(created[1].resumeSession).toHaveBeenCalledOnce())
 
-    // The old generation is still draining the same logical session, but the fresh runtime now owns
-    // user actions for it, so retired ownership must not keep the new conversation locked.
+    // Adoption cannot publish the new owner until the prior turn clears its terminal state.
+    expect(coordinator.getSnapshot().promptInFlightSessionIds).toEqual([session.sessionId])
+    created[0].emitState({ promptInFlight: false, promptInFlightSessionIds: [] })
+    await resumeRequest
+
+    // Once the old turn settles, only the fresh runtime may publish prompt ownership.
     expect(coordinator.getSnapshot().promptInFlightSessionIds).toEqual([])
 
     created[1].emitState({
@@ -741,6 +746,7 @@ describe('AcpRuntimeCoordinator', () => {
     ])
 
     adoption.resolve()
+    created[0].emitState({ promptInFlight: false, promptInFlightSessionIds: [] })
     await resumeRequest
 
     expect(coordinator.getSnapshot().sessionConnectionStatuses).toEqual({
@@ -771,6 +777,85 @@ describe('AcpRuntimeCoordinator', () => {
     expect(adoptedSnapshotEventIds).not.toEqual(
       expect.arrayContaining([expect.stringMatching(runtimeEventId(1, 'post-adoption-codex-tool'))])
     )
+
+    retirement.resolve()
+    await switchRequest
+  })
+
+  it('waits for the prior turn terminal event after incoming resume succeeds', async () => {
+    const retirement = createDeferred<void>()
+    const adoption = createDeferred<void>()
+    const created: ReturnType<typeof createFakeRuntime>[] = []
+    const forwardedEvents: AcpRuntimeEvent[] = []
+    const coordinator = new AcpRuntimeCoordinator(
+      (callbacks) => {
+        const fake = createFakeRuntime({
+          frameworkId: created.length === 0 ? 'codex' : 'claude-code',
+          sessionIds: [`agent-session-${created.length + 1}`],
+          callbacks,
+          ...(created.length === 0 ? {} : { afterResumeAttached: () => adoption.promise })
+        })
+        created.push(fake)
+        return fake.runtime
+      },
+      { onEvent: (event) => forwardedEvents.push(event) }
+    )
+
+    const session = await coordinator.createSession()
+    created[0].emitState({
+      promptInFlight: true,
+      promptInFlightSessionIds: [session.sessionId]
+    })
+    created[0].requestRetirement.mockReturnValue(retirement.promise)
+    const switchRequest = coordinator.requestAgentFrameworkSwitch()
+    await coordinator.connect()
+
+    let resumeSettled = false
+    const resumeRequest = coordinator
+      .resumeSession({
+        sessionId: session.sessionId,
+        cwd: '/workspace',
+        previousFrameworkId: 'codex'
+      })
+      .finally(() => {
+        resumeSettled = true
+      })
+    await vi.waitFor(() => expect(created[1].resumeSession).toHaveBeenCalledOnce())
+
+    adoption.resolve()
+    await expect(created[1].resumeSession.mock.results[0]?.value).resolves.toMatchObject({
+      sessionId: session.sessionId
+    })
+    expect(resumeSettled).toBe(false)
+
+    created[0].emitEvent({
+      id: 'post-resume-old-stop',
+      timestamp: 1,
+      kind: 'stop',
+      level: 'info',
+      sessionId: session.sessionId,
+      title: 'Prompt stopped',
+      text: 'end_turn'
+    })
+    expect(forwardedEvents.map((event) => event.id)).toEqual([
+      expect.stringMatching(runtimeEventId(1, 'post-resume-old-stop'))
+    ])
+
+    created[0].emitState({ promptInFlight: false, promptInFlightSessionIds: [] })
+    await resumeRequest
+
+    created[0].emitEvent({
+      id: 'post-adoption-old-stop',
+      timestamp: 2,
+      kind: 'stop',
+      level: 'info',
+      sessionId: session.sessionId,
+      title: 'Prompt stopped',
+      text: 'end_turn'
+    })
+    expect(forwardedEvents.map((event) => event.id)).toEqual([
+      expect.stringMatching(runtimeEventId(1, 'post-resume-old-stop'))
+    ])
 
     retirement.resolve()
     await switchRequest
@@ -859,11 +944,14 @@ describe('AcpRuntimeCoordinator', () => {
       expect.stringMatching(runtimeEventId(1, 'owner-overflow'))
     ])
 
-    await coordinator.resumeSession({
+    const resumeRequest = coordinator.resumeSession({
       sessionId: session.sessionId,
       cwd: '/workspace',
       previousFrameworkId: 'claude-code'
     })
+    await vi.waitFor(() => expect(created[1].resumeSession).toHaveBeenCalledOnce())
+    created[0].emitState({ promptInFlight: false, promptInFlightSessionIds: [] })
+    await resumeRequest
 
     created[0].emitEvent(overflowEvent('late-retired-overflow'))
     expect(forwardedEvents.map((event) => event.id)).toEqual([
@@ -926,11 +1014,14 @@ describe('AcpRuntimeCoordinator', () => {
       expect.stringMatching(runtimeEventId(1, 'owner-compaction'))
     ])
 
-    await coordinator.resumeSession({
+    const resumeRequest = coordinator.resumeSession({
       sessionId: session.sessionId,
       cwd: '/workspace',
       previousFrameworkId: 'claude-code'
     })
+    await vi.waitFor(() => expect(created[1].resumeSession).toHaveBeenCalledOnce())
+    created[0].emitState({ promptInFlight: false, promptInFlightSessionIds: [] })
+    await resumeRequest
 
     created[0].emitEvent(compactionEvent('late-retired-compaction', 'failed'))
     expect(forwardedEvents.map((event) => event.id)).toEqual([

--- a/src/main/acp/runtime-coordinator.ts
+++ b/src/main/acp/runtime-coordinator.ts
@@ -275,6 +275,18 @@ class AcpRuntimeCoordinator {
       await this.waitForSessionDrain(owner, request.sessionId)
     }
 
+    if (
+      transfersOwnership &&
+      (this.pendingSessionAdoptions.get(request.sessionId) !== runtime ||
+        !this.runtimes.has(runtime) ||
+        this.retiredRuntimes.has(runtime))
+    ) {
+      if (this.pendingSessionAdoptions.get(request.sessionId) === runtime) {
+        this.pendingSessionAdoptions.delete(request.sessionId)
+      }
+      throw new Error('ACP session adoption was superseded before ownership could commit')
+    }
+
     if (transfersOwnership && this.pendingSessionAdoptions.get(request.sessionId) === runtime) {
       this.pendingSessionAdoptions.delete(request.sessionId)
     }

--- a/src/main/acp/runtime-coordinator.ts
+++ b/src/main/acp/runtime-coordinator.ts
@@ -67,6 +67,7 @@ class AcpRuntimeCoordinator {
   private promptAttemptSequence = 0
   private readonly sessionCancellationGenerations = new Map<string, number>()
   private readonly pendingPromptStarts = new Map<string, PendingPromptStart[]>()
+  private readonly pendingSessionAdoptions = new Map<string, AcpRuntime>()
   private activeRuntime: AcpRuntime | undefined
   private lastRuntime: AcpRuntime | undefined
 
@@ -244,38 +245,34 @@ class AcpRuntimeCoordinator {
     const runtime = owner && !this.retiredRuntimes.has(owner) ? owner : this.getActiveRuntime()
     const transfersOwnership = runtime !== owner
 
-    // An optimistic prompt may already point at the incoming Runtime Segment while resume is still in
-    // flight. Transfer routing ownership before awaiting the provider so events from a draining
-    // generation cannot settle or mutate that new turn during the adoption window.
-    if (transfersOwnership) this.sessionRuntimes.set(request.sessionId, runtime)
+    // Keep the prior owner authoritative until adoption finishes. The renderer does not create the
+    // incoming optimistic run until this promise resolves, so terminal events emitted while the old
+    // generation drains can still settle its own Runtime Segment without touching the next one.
+    if (transfersOwnership) this.pendingSessionAdoptions.set(request.sessionId, runtime)
 
     let response: AcpCreateSessionResponse
     try {
       response = await runtime.resumeSession(request)
     } catch (error) {
-      // A runtime may report its attached session before a later resume step fails. Keep that runtime
-      // as owner when attachment really happened; otherwise roll routing back to the prior generation
-      // and republish its snapshot so events suppressed during the failed adoption remain observable.
-      if (
-        transfersOwnership &&
-        this.sessionRuntimes.get(request.sessionId) === runtime &&
-        !runtime.getSnapshot().sessionIds.includes(request.sessionId)
-      ) {
-        if (owner) this.sessionRuntimes.set(request.sessionId, owner)
-        else this.sessionRuntimes.delete(request.sessionId)
-        this.callbacks.onStateChanged?.(this.getSnapshot())
+      if (transfersOwnership && this.pendingSessionAdoptions.get(request.sessionId) === runtime) {
+        this.pendingSessionAdoptions.delete(request.sessionId)
       }
       throw error
     }
 
+    if (transfersOwnership && this.pendingSessionAdoptions.get(request.sessionId) === runtime) {
+      this.pendingSessionAdoptions.delete(request.sessionId)
+    }
+
     if (
       response.sessionId !== request.sessionId &&
-      this.sessionRuntimes.get(request.sessionId) === runtime
+      this.sessionRuntimes.get(request.sessionId) === owner
     ) {
       this.sessionRuntimes.delete(request.sessionId)
     }
     this.sessionRuntimes.set(response.sessionId, runtime)
     this.lastRuntime = runtime
+    if (transfersOwnership) this.callbacks.onStateChanged?.(this.getSnapshot())
     return response
   }
 
@@ -630,6 +627,11 @@ class AcpRuntimeCoordinator {
   private handleRuntimeState(runtime: AcpRuntime, snapshot: AcpStateSnapshot): void {
     const attached = this.releaseMissingRuntimeSessions(runtime, snapshot)
     for (const sessionId of attached) {
+      // resumeSession owns the handoff commit. AcpRuntime emits its attached snapshot just before the
+      // resume promise resolves; treating that intermediate state as ownership would again suppress
+      // terminal events from the draining generation during the adoption window.
+      if (this.pendingSessionAdoptions.get(sessionId) === runtime) continue
+
       const owner = this.sessionRuntimes.get(sessionId)
       // A late state emission from a retiring runtime must not steal back a session already adopted by
       // the current generation.
@@ -678,6 +680,9 @@ class AcpRuntimeCoordinator {
         this.sessionConnectionStatuses.delete(sessionId)
       }
       this.onSessionUnavailable?.(sessionId)
+    }
+    for (const [sessionId, incoming] of this.pendingSessionAdoptions) {
+      if (incoming === runtime) this.pendingSessionAdoptions.delete(sessionId)
     }
     for (const [requestId, owner] of this.permissionRuntimes) {
       if (owner === runtime) this.permissionRuntimes.delete(requestId)
@@ -757,6 +762,7 @@ class AcpRuntimeCoordinator {
     this.runtimes.clear()
     this.retiredRuntimes.clear()
     this.sessionRuntimes.clear()
+    this.pendingSessionAdoptions.clear()
     this.sessionConnectionStatuses.clear()
     this.permissionRuntimes.clear()
     this.pendingPromptStarts.clear()

--- a/src/main/acp/runtime-coordinator.ts
+++ b/src/main/acp/runtime-coordinator.ts
@@ -57,6 +57,7 @@ class AcpRuntimeCoordinator {
   private readonly permissionRuntimes = new Map<string, AcpRuntime>()
   private readonly reviewerRuntimes = new WeakMap<ActiveSession, AcpRuntime>()
   private readonly runtimeIds = new WeakMap<AcpRuntime, string>()
+  private readonly publishedRuntimeEventIds = new WeakMap<AcpRuntime, Set<string>>()
   private readonly permissionGrantStore = new ConversationPermissionGrantStore()
   // Runtime events are persisted on Message nodes. A process-local sequence alone restarts at one
   // after every app launch and can collide with a historical Session's event ids.
@@ -625,6 +626,14 @@ class AcpRuntimeCoordinator {
   }
 
   private handleRuntimeState(runtime: AcpRuntime, snapshot: AcpStateSnapshot): void {
+    const retainedEventIds = new Set(snapshot.events.map((event) => event.id))
+    const publishedEventIds = this.publishedRuntimeEventIds.get(runtime)
+    if (publishedEventIds) {
+      for (const eventId of publishedEventIds) {
+        if (!retainedEventIds.has(eventId)) publishedEventIds.delete(eventId)
+      }
+    }
+
     const attached = this.releaseMissingRuntimeSessions(runtime, snapshot)
     for (const sessionId of attached) {
       // resumeSession owns the handoff commit. AcpRuntime emits its attached snapshot just before the
@@ -711,15 +720,28 @@ class AcpRuntimeCoordinator {
   }
 
   private shouldPublishEvent(runtime: AcpRuntime, event: AcpRuntimeEvent): boolean {
-    if (!event.sessionId || event.kind === 'artifact') return true
+    const publishedEventIds = this.publishedRuntimeEventIds.get(runtime)
+    if (publishedEventIds?.has(event.id)) return true
 
-    const owner = this.sessionRuntimes.get(event.sessionId)
+    const owner = event.sessionId ? this.sessionRuntimes.get(event.sessionId) : undefined
+    const shouldPublish =
+      !event.sessionId || event.kind === 'artifact' || owner === undefined || owner === runtime
+
+    if (shouldPublish) {
+      const remembered = publishedEventIds ?? new Set<string>()
+      remembered.add(event.id)
+      if (!publishedEventIds) this.publishedRuntimeEventIds.set(runtime, remembered)
+    }
+
     // Every session-scoped event belongs to the runtime generation that emitted it. Once a fresh
     // generation adopts the same logical session, late tool/message/stop events from the draining
     // generation must not mutate the new Runtime Segment. Artifact claims are the exception above:
     // providers may publish them after stop, and their explicit run/prompt ids finalize the prior turn.
-    // Preserve events while ownership is unknown so discovery and pre-adoption behavior stay intact.
-    return owner === undefined || owner === runtime
+    // Events already admitted while this runtime owned the session remain visible in later snapshots
+    // until the runtime's bounded event window drops them, so an ownership broadcast cannot erase a
+    // terminal event before the renderer consumes it. Preserve events while ownership is unknown so
+    // discovery and pre-adoption behavior stay intact.
+    return shouldPublish
   }
 
   private eventId(runtime: AcpRuntime, eventId: string): string {

--- a/src/main/acp/runtime-coordinator.ts
+++ b/src/main/acp/runtime-coordinator.ts
@@ -675,17 +675,13 @@ class AcpRuntimeCoordinator {
   }
 
   private shouldPublishEvent(runtime: AcpRuntime, event: AcpRuntimeEvent): boolean {
-    if (
-      !event.sessionId ||
-      (event.recoverable !== 'context-overflow' && event.kind !== 'compaction')
-    ) {
-      return true
-    }
+    if (!event.sessionId) return true
 
     const owner = this.sessionRuntimes.get(event.sessionId)
-    // A late overflow or compaction lifecycle transition from a draining generation must not mutate a
-    // newer owner's live turn. Preserve events while ownership is unknown so discovery and
-    // pre-adoption behavior stay intact.
+    // Every session-scoped event belongs to the runtime generation that emitted it. Once a fresh
+    // generation adopts the same logical session, late tool/message/stop events from the draining
+    // generation must not mutate the new Runtime Segment. Preserve events while ownership is unknown
+    // so discovery and pre-adoption behavior stay intact.
     return owner === undefined || owner === runtime
   }
 

--- a/src/main/acp/runtime-coordinator.ts
+++ b/src/main/acp/runtime-coordinator.ts
@@ -270,8 +270,13 @@ class AcpRuntimeCoordinator {
       this.sessionRuntimes.get(request.sessionId) === owner
     ) {
       this.sessionRuntimes.delete(request.sessionId)
+      this.sessionConnectionStatuses.delete(request.sessionId)
     }
     this.sessionRuntimes.set(response.sessionId, runtime)
+    // The incoming runtime's attached snapshot is deliberately ignored while adoption is pending.
+    // Commit its current connection status together with ownership so a stale status from the
+    // draining owner cannot classify later prompt failures as disconnects.
+    this.sessionConnectionStatuses.set(response.sessionId, runtime.getSnapshot().status)
     this.lastRuntime = runtime
     if (transfersOwnership) this.callbacks.onStateChanged?.(this.getSnapshot())
     return response

--- a/src/main/acp/runtime-coordinator.ts
+++ b/src/main/acp/runtime-coordinator.ts
@@ -23,6 +23,12 @@ import { ConversationPermissionGrantStore } from './permission-broker'
 
 const MAX_EVENTS = 500
 
+const isOwnershipScopedControlEvent = (event: AcpRuntimeEvent): boolean =>
+  event.kind === 'compaction' || event.recoverable === 'context-overflow'
+
+const hasArtifactProvenance = (event: AcpRuntimeEvent): boolean =>
+  Boolean(event.runId && event.promptMessageId && event.artifactClaimId)
+
 type RuntimeFactory = (
   callbacks: AcpRuntimeCallbacks,
   permissionGrantStore: ConversationPermissionGrantStore
@@ -783,12 +789,23 @@ class AcpRuntimeCoordinator {
   }
 
   private shouldPublishEvent(runtime: AcpRuntime, event: AcpRuntimeEvent): boolean {
-    const publishedEventIds = this.publishedRuntimeEventIds.get(runtime)
-    if (publishedEventIds?.has(event.id)) return true
-
     const owner = event.sessionId ? this.sessionRuntimes.get(event.sessionId) : undefined
+    const belongsToPreviousOwner = owner !== undefined && owner !== runtime
+    const publishedEventIds = this.publishedRuntimeEventIds.get(runtime)
+    if (publishedEventIds?.has(event.id)) {
+      // Chat/tool/stop events admitted during the drain stay visible long enough for the renderer to
+      // consume them. Control events must not survive ownership transfer, because a remounted hook has
+      // no durable dedup state and would execute the old recovery lifecycle again.
+      if (belongsToPreviousOwner && isOwnershipScopedControlEvent(event)) return false
+      if (belongsToPreviousOwner && event.kind === 'artifact') return hasArtifactProvenance(event)
+      return true
+    }
+
     const shouldPublish =
-      !event.sessionId || event.kind === 'artifact' || owner === undefined || owner === runtime
+      !event.sessionId ||
+      owner === undefined ||
+      owner === runtime ||
+      (event.kind === 'artifact' && hasArtifactProvenance(event))
 
     if (shouldPublish) {
       const remembered = publishedEventIds ?? new Set<string>()

--- a/src/main/acp/runtime-coordinator.ts
+++ b/src/main/acp/runtime-coordinator.ts
@@ -47,6 +47,12 @@ type PendingPromptStart = {
   globalCancellationGeneration: number
 }
 
+type PendingSessionDrain = {
+  runtime: AcpRuntime
+  promise: Promise<void>
+  resolve: () => void
+}
+
 // Keeps each framework generation in its own AcpRuntime. Framework changes preserve active turns, then
 // retire their runtime so every later turn resumes through the newly selected framework.
 class AcpRuntimeCoordinator {
@@ -69,6 +75,7 @@ class AcpRuntimeCoordinator {
   private readonly sessionCancellationGenerations = new Map<string, number>()
   private readonly pendingPromptStarts = new Map<string, PendingPromptStart[]>()
   private readonly pendingSessionAdoptions = new Map<string, AcpRuntime>()
+  private readonly pendingSessionDrains = new Map<string, PendingSessionDrain>()
   private activeRuntime: AcpRuntime | undefined
   private lastRuntime: AcpRuntime | undefined
 
@@ -259,6 +266,13 @@ class AcpRuntimeCoordinator {
         this.pendingSessionAdoptions.delete(request.sessionId)
       }
       throw error
+    }
+
+    if (transfersOwnership && owner) {
+      // The incoming provider can attach before the draining generation emits its terminal event.
+      // Keep the old owner authoritative until its active turn clears so stop/error settles the old
+      // Runtime Segment before the renderer is allowed to append a turn for the adopted runtime.
+      await this.waitForSessionDrain(owner, request.sessionId)
     }
 
     if (transfersOwnership && this.pendingSessionAdoptions.get(request.sessionId) === runtime) {
@@ -655,6 +669,7 @@ class AcpRuntimeCoordinator {
       }
     }
     this.callbacks.onStateChanged?.(this.getSnapshot())
+    this.resolveSessionDrain(runtime, snapshot)
   }
 
   private releaseMissingRuntimeSessions(
@@ -698,6 +713,11 @@ class AcpRuntimeCoordinator {
     for (const [sessionId, incoming] of this.pendingSessionAdoptions) {
       if (incoming === runtime) this.pendingSessionAdoptions.delete(sessionId)
     }
+    for (const [sessionId, pending] of this.pendingSessionDrains) {
+      if (pending.runtime !== runtime) continue
+      this.pendingSessionDrains.delete(sessionId)
+      pending.resolve()
+    }
     for (const [requestId, owner] of this.permissionRuntimes) {
       if (owner === runtime) this.permissionRuntimes.delete(requestId)
     }
@@ -722,6 +742,32 @@ class AcpRuntimeCoordinator {
       ...snapshot.pendingPermissions.map((request) => request.sessionId)
     ])
     return snapshot.sessionIds.filter((sessionId) => active.has(sessionId))
+  }
+
+  private waitForSessionDrain(runtime: AcpRuntime, sessionId: string): Promise<void> {
+    if (!runtime.getSnapshot().promptInFlightSessionIds.includes(sessionId)) {
+      return Promise.resolve()
+    }
+
+    const existing = this.pendingSessionDrains.get(sessionId)
+    if (existing?.runtime === runtime) return existing.promise
+    if (existing) existing.resolve()
+
+    let resolve!: () => void
+    const promise = new Promise<void>((promiseResolve) => {
+      resolve = promiseResolve
+    })
+    this.pendingSessionDrains.set(sessionId, { runtime, promise, resolve })
+    return promise
+  }
+
+  private resolveSessionDrain(runtime: AcpRuntime, snapshot: AcpStateSnapshot): void {
+    const inFlight = new Set(snapshot.promptInFlightSessionIds)
+    for (const [sessionId, pending] of this.pendingSessionDrains) {
+      if (pending.runtime !== runtime || inFlight.has(sessionId)) continue
+      this.pendingSessionDrains.delete(sessionId)
+      pending.resolve()
+    }
   }
 
   private shouldPublishEvent(runtime: AcpRuntime, event: AcpRuntimeEvent): boolean {
@@ -790,6 +836,8 @@ class AcpRuntimeCoordinator {
     this.retiredRuntimes.clear()
     this.sessionRuntimes.clear()
     this.pendingSessionAdoptions.clear()
+    for (const pending of this.pendingSessionDrains.values()) pending.resolve()
+    this.pendingSessionDrains.clear()
     this.sessionConnectionStatuses.clear()
     this.permissionRuntimes.clear()
     this.pendingPromptStarts.clear()

--- a/src/main/acp/runtime-coordinator.ts
+++ b/src/main/acp/runtime-coordinator.ts
@@ -242,7 +242,38 @@ class AcpRuntimeCoordinator {
     await this.waitForInitialization()
     const owner = this.findRuntimeForSession(request.sessionId)
     const runtime = owner && !this.retiredRuntimes.has(owner) ? owner : this.getActiveRuntime()
-    const response = await runtime.resumeSession(request)
+    const transfersOwnership = runtime !== owner
+
+    // An optimistic prompt may already point at the incoming Runtime Segment while resume is still in
+    // flight. Transfer routing ownership before awaiting the provider so events from a draining
+    // generation cannot settle or mutate that new turn during the adoption window.
+    if (transfersOwnership) this.sessionRuntimes.set(request.sessionId, runtime)
+
+    let response: AcpCreateSessionResponse
+    try {
+      response = await runtime.resumeSession(request)
+    } catch (error) {
+      // A runtime may report its attached session before a later resume step fails. Keep that runtime
+      // as owner when attachment really happened; otherwise roll routing back to the prior generation
+      // and republish its snapshot so events suppressed during the failed adoption remain observable.
+      if (
+        transfersOwnership &&
+        this.sessionRuntimes.get(request.sessionId) === runtime &&
+        !runtime.getSnapshot().sessionIds.includes(request.sessionId)
+      ) {
+        if (owner) this.sessionRuntimes.set(request.sessionId, owner)
+        else this.sessionRuntimes.delete(request.sessionId)
+        this.callbacks.onStateChanged?.(this.getSnapshot())
+      }
+      throw error
+    }
+
+    if (
+      response.sessionId !== request.sessionId &&
+      this.sessionRuntimes.get(request.sessionId) === runtime
+    ) {
+      this.sessionRuntimes.delete(request.sessionId)
+    }
     this.sessionRuntimes.set(response.sessionId, runtime)
     this.lastRuntime = runtime
     return response
@@ -675,13 +706,14 @@ class AcpRuntimeCoordinator {
   }
 
   private shouldPublishEvent(runtime: AcpRuntime, event: AcpRuntimeEvent): boolean {
-    if (!event.sessionId) return true
+    if (!event.sessionId || event.kind === 'artifact') return true
 
     const owner = this.sessionRuntimes.get(event.sessionId)
     // Every session-scoped event belongs to the runtime generation that emitted it. Once a fresh
     // generation adopts the same logical session, late tool/message/stop events from the draining
-    // generation must not mutate the new Runtime Segment. Preserve events while ownership is unknown
-    // so discovery and pre-adoption behavior stay intact.
+    // generation must not mutate the new Runtime Segment. Artifact claims are the exception above:
+    // providers may publish them after stop, and their explicit run/prompt ids finalize the prior turn.
+    // Preserve events while ownership is unknown so discovery and pre-adoption behavior stay intact.
     return owner === undefined || owner === runtime
   }
 

--- a/src/renderer/src/lib/acp/useWorkspaceAgentRuntime.test.ts
+++ b/src/renderer/src/lib/acp/useWorkspaceAgentRuntime.test.ts
@@ -1332,7 +1332,7 @@ describe('workspace agent message sending', () => {
       cwd: '/workspace/project'
     })
 
-    await expect(second).resolves.toBeUndefined()
+    await expect(second).resolves.toBeNull()
     expect(useSessionStore.getState().sessions[0]).toMatchObject({
       status: 'idle',
       activeRun: undefined,

--- a/src/renderer/src/lib/acp/useWorkspaceAgentRuntime.test.ts
+++ b/src/renderer/src/lib/acp/useWorkspaceAgentRuntime.test.ts
@@ -347,6 +347,81 @@ describe('workspace agent message sending', () => {
     expect(useSessionStore.getState().sessions[0].branchContextResetRequired).toBeUndefined()
   })
 
+  it('adopts the selected framework when a Branch reset and framework switch share a turn', async () => {
+    useSessionStore.getState().appendUserMessage({
+      sessionId: 'transport-session-1',
+      content: 'Original Claude branch turn',
+      cwd: '/workspace/project',
+      projectId: 'project-1',
+      agentFrameworkId: 'claude-code',
+      agentBackendId: 'claude-code:anthropic'
+    })
+    useSessionStore.getState().finishRun('transport-session-1')
+    useSessionStore.setState((state) => ({
+      sessions: state.sessions.map((session) => ({
+        ...session,
+        branchContextResetRequired: true
+      }))
+    }))
+    const shutdown = vi.fn().mockResolvedValue({
+      sessionId: 'transport-session-1',
+      status: 'shutdown'
+    })
+    vi.stubGlobal('window', { api: { notebook: { shutdown } } })
+    const resumeSession = vi.fn().mockResolvedValue({
+      sessionId: 'transport-session-1',
+      cwd: '/workspace/project',
+      contextReset: true,
+      frameworkId: 'codex',
+      backendId: 'codex:builtin-codex-subscription'
+    })
+    const sendPrompt = vi.fn().mockResolvedValue(createSnapshot(['transport-session-1']))
+    const runtime = {
+      // A draining runtime may still expose the logical session while the selected runtime takes over.
+      state: createSnapshot(['transport-session-1']),
+      createSession: vi.fn(),
+      resumeSession,
+      resetSessionContext: vi.fn(),
+      sendPrompt
+    }
+
+    await sendWorkspaceMessage(runtime, {
+      sessionId: 'transport-session-1',
+      text: 'Continue this branch with Codex',
+      cwd: '/workspace/project',
+      projectId: 'project-1',
+      agentFrameworkId: 'codex',
+      agentBackendId: 'codex:builtin-codex-subscription'
+    })
+    await flushRuntimeTasks()
+
+    expect(runtime.resetSessionContext).not.toHaveBeenCalled()
+    expect(resumeSession).toHaveBeenCalledWith(
+      'transport-session-1',
+      '/workspace/project',
+      'project-1',
+      'ask',
+      'claude-code',
+      'claude-code:anthropic'
+    )
+    expect(shutdown.mock.invocationCallOrder[0]).toBeLessThan(
+      resumeSession.mock.invocationCallOrder[0]
+    )
+    expect(resumeSession.mock.invocationCallOrder[0]).toBeLessThan(
+      sendPrompt.mock.invocationCallOrder[0]
+    )
+    const switchedSession = useSessionStore.getState().sessions[0]
+    const promptContext = sendPrompt.mock.calls[0]?.[9]
+    const promptSegment = switchedSession.conversationGraph?.runtimeSegments.find(
+      (segment) => segment.id === promptContext?.runtimeSegmentId
+    )
+    expect(promptSegment).toMatchObject({
+      frameworkId: 'codex',
+      backendId: 'codex:builtin-codex-subscription'
+    })
+    expect(switchedSession.branchContextResetRequired).toBeUndefined()
+  })
+
   it('keeps Branch replay required when the reset prompt is rejected', async () => {
     useSessionStore.getState().appendUserMessage({
       sessionId: 'transport-session-1',

--- a/src/renderer/src/lib/acp/useWorkspaceAgentRuntime.test.ts
+++ b/src/renderer/src/lib/acp/useWorkspaceAgentRuntime.test.ts
@@ -1898,6 +1898,49 @@ describe('resuming an interrupted session on demand', () => {
     expect(session.interrupted).toBeUndefined()
   })
 
+  it('restores the interrupted user turn when re-send preparation fails', async () => {
+    useSessionStore.getState().appendUserMessage({
+      sessionId: 'session-1',
+      content: 'Do not lose this interrupted prompt',
+      cwd: '/workspace/project',
+      projectId: 'default-project',
+      permissionProfile: 'ask'
+    })
+    useSessionStore.getState().markDisconnected('session-1')
+
+    const runtime = {
+      state: createSnapshot([]),
+      createSession: vi.fn(),
+      resumeSession: vi
+        .fn()
+        .mockResolvedValueOnce({ sessionId: 'session-1', cwd: '/workspace/project' })
+        .mockRejectedValueOnce(new Error('adoption failed')),
+      resetSessionContext: vi.fn(),
+      sendPrompt: vi.fn()
+    }
+
+    await resumeInterruptedWorkspaceSession(runtime, 'session-1')
+
+    const session = useSessionStore.getState().sessions[0]
+    expect(session.messages.filter((message) => message.role === 'user')).toEqual([
+      expect.objectContaining({ content: 'Do not lose this interrupted prompt' })
+    ])
+    expect(session.interrupted).toBe(true)
+    expect(runtime.sendPrompt).not.toHaveBeenCalled()
+
+    runtime.state = createSnapshot(['session-1'])
+    runtime.sendPrompt.mockResolvedValue(createSnapshot(['session-1']))
+    await resumeInterruptedWorkspaceSession(runtime, 'session-1')
+    await flushRuntimeTasks()
+
+    expect(runtime.resumeSession).toHaveBeenCalledTimes(2)
+    expect(runtime.sendPrompt).toHaveBeenCalledOnce()
+    expect(useSessionStore.getState().sessions[0].interrupted).toBeUndefined()
+    expect(
+      useSessionStore.getState().sessions[0].messages.filter((message) => message.role === 'user')
+    ).toEqual([expect.objectContaining({ content: 'Do not lose this interrupted prompt' })])
+  })
+
   it('replays a history preamble when an interrupted resume adopts a fresh agent session', async () => {
     // A completed prior turn that must be replayed once the agent's context is gone.
     useSessionStore.getState().appendUserMessage({
@@ -2443,6 +2486,35 @@ describe('recovering from a request-size overflow', () => {
     expect(recovered).toBe(false)
     expect(runtime.sendPrompt).not.toHaveBeenCalled()
     expect(useSessionStore.getState().sessions[0]?.status).toBe('error')
+  })
+
+  it('restores the overflowed user turn when retry preparation fails', async () => {
+    seedOverflowedConversation()
+
+    const runtime = {
+      state: createSnapshot([]),
+      createSession: vi.fn(),
+      resumeSession: vi.fn().mockRejectedValue(new Error('adoption failed')),
+      resetSessionContext: vi.fn().mockResolvedValue({
+        sessionId: 'session-1',
+        cwd: '/workspace/project',
+        contextReset: true
+      }),
+      sendPrompt: vi.fn()
+    }
+
+    const recovered = await recoverContextOverflowWorkspaceSession(runtime, 'session-1')
+
+    expect(recovered).toBe(false)
+    expect(useSessionStore.getState().sessions[0]?.messages).toEqual(
+      expect.arrayContaining([
+        expect.objectContaining({
+          role: 'user',
+          content: 'now compare with this new screenshot'
+        })
+      ])
+    )
+    expect(runtime.sendPrompt).not.toHaveBeenCalled()
   })
 
   it('triggers recovery once per overflow error event for an attached session', () => {

--- a/src/renderer/src/lib/acp/useWorkspaceAgentRuntime.test.ts
+++ b/src/renderer/src/lib/acp/useWorkspaceAgentRuntime.test.ts
@@ -412,7 +412,8 @@ describe('workspace agent message sending', () => {
       'project-1',
       'ask',
       'claude-code',
-      'claude-code:anthropic'
+      'claude-code:anthropic',
+      undefined
     )
     expect(shutdown.mock.invocationCallOrder[0]).toBeLessThan(
       resumeSession.mock.invocationCallOrder[0]
@@ -511,7 +512,8 @@ describe('workspace agent message sending', () => {
       'project-1',
       'ask',
       'claude-code',
-      'claude-code:anthropic'
+      'claude-code:anthropic',
+      undefined
     )
     expect(shutdown.mock.invocationCallOrder[0]).toBeLessThan(
       resumeSession.mock.invocationCallOrder[0]
@@ -532,6 +534,72 @@ describe('workspace agent message sending', () => {
       backendId: 'codex:builtin-codex-subscription'
     })
     expect(switchedSession.branchContextResetRequired).toBeUndefined()
+  })
+
+  it('drains accepted runtime events before opening the adopted run', async () => {
+    useSessionStore.getState().appendUserMessage({
+      sessionId: 'transport-session-1',
+      content: 'Original prompt',
+      cwd: '/workspace/project',
+      projectId: 'project-1',
+      agentFrameworkId: 'claude-code',
+      agentBackendId: 'claude-code:anthropic'
+    })
+    useSessionStore.getState().finishRun('transport-session-1')
+
+    const sendPrompt = vi.fn().mockResolvedValue(createSnapshot(['transport-session-1']))
+    const runtime = {
+      state: createSnapshot(),
+      createSession: vi.fn(),
+      resumeSession: vi.fn().mockResolvedValue({
+        sessionId: 'transport-session-1',
+        cwd: '/workspace/project',
+        contextReset: true,
+        frameworkId: 'codex',
+        backendId: 'codex:builtin-codex-subscription'
+      }),
+      resetSessionContext: vi.fn(),
+      sendPrompt
+    }
+    const drainRuntimeEvents = vi.fn(async () => {
+      await applyWorkspaceRuntimeEvent(
+        createEvent({
+          id: 'accepted-final-message',
+          sessionId: 'transport-session-1',
+          messageId: 'accepted-agent-message',
+          role: 'assistant',
+          text: 'Accepted final answer'
+        })
+      )
+      await applyWorkspaceRuntimeEvent(
+        createEvent({
+          id: 'accepted-stop',
+          sessionId: 'transport-session-1',
+          kind: 'stop'
+        })
+      )
+    })
+
+    await sendWorkspaceMessage(
+      runtime,
+      {
+        sessionId: 'transport-session-1',
+        text: 'Continue with Codex',
+        cwd: '/workspace/project',
+        projectId: 'project-1',
+        agentFrameworkId: 'codex',
+        agentBackendId: 'codex:builtin-codex-subscription'
+      },
+      undefined,
+      drainRuntimeEvents
+    )
+
+    expect(drainRuntimeEvents).toHaveBeenCalledOnce()
+    expect(sendPrompt.mock.calls[0]?.[5]).toContain('Accepted final answer')
+    expect(useSessionStore.getState().sessions[0]).toMatchObject({
+      status: 'running',
+      activeRun: { promptMessageId: expect.any(String) }
+    })
   })
 
   it('keeps Branch replay required when the reset prompt is rejected', async () => {
@@ -2876,7 +2944,94 @@ describe('resendEditedWorkspaceMessage', () => {
     vi.unstubAllGlobals()
   })
 
-  it('shows the resent bubble as a live run immediately, then replays the kept history', async () => {
+  it('adopts the selected runtime before resetting and opening the edited run', async () => {
+    seedConversation()
+    useSessionStore.setState((state) => ({
+      sessions: state.sessions.map((session) => ({
+        ...session,
+        agentFrameworkId: 'claude-code',
+        agentBackendId: 'claude-code:anthropic'
+      }))
+    }))
+
+    const resumeGate = createDeferred<{
+      sessionId: string
+      cwd: string
+      contextReset: boolean
+      frameworkId: 'codex'
+      backendId: string
+    }>()
+    const resetGate = createDeferred<{ sessionId: string; cwd: string; contextReset: boolean }>()
+    const runtime = {
+      state: createSnapshot(),
+      createSession: vi.fn(),
+      resumeSession: vi.fn(() => resumeGate.promise),
+      resetSessionContext: vi.fn(() => resetGate.promise),
+      sendPrompt: vi.fn().mockResolvedValue(createSnapshot(['session-1']))
+    }
+    const preparationChanged = vi.fn()
+    const drainRuntimeEvents = vi.fn().mockResolvedValue(undefined)
+    const originalMessages = useSessionStore.getState().sessions[0]?.messages
+
+    const resentPromise = resendEditedWorkspaceMessage(
+      runtime,
+      {
+        sessionId: 'session-1',
+        messageId: 'user-2',
+        text: 'second prompt, edited'
+      },
+      {
+        supportsImageInput: true,
+        agentFrameworkId: 'codex',
+        agentBackendId: 'codex:builtin-codex-subscription',
+        onSendPreparationStateChange: preparationChanged,
+        drainRuntimeEvents
+      }
+    )
+
+    await vi.waitFor(() => expect(runtime.resumeSession).toHaveBeenCalledOnce())
+    expect(preparationChanged).toHaveBeenCalledWith('session-1', true)
+    expect(useSessionStore.getState().sessions[0]?.messages).toEqual(originalMessages)
+    expect(runtime.resetSessionContext).not.toHaveBeenCalled()
+
+    resumeGate.resolve({
+      sessionId: 'session-1',
+      cwd: '/workspace/project',
+      contextReset: false,
+      frameworkId: 'codex',
+      backendId: 'codex:builtin-codex-subscription'
+    })
+    await vi.waitFor(() => expect(runtime.resetSessionContext).toHaveBeenCalledOnce())
+    expect(useSessionStore.getState().sessions[0]?.messages).toEqual(originalMessages)
+    expect(preparationChanged).not.toHaveBeenCalledWith('session-1', false)
+
+    resetGate.resolve({ sessionId: 'session-1', cwd: '/workspace/project', contextReset: true })
+    await expect(resentPromise).resolves.toBe(true)
+
+    expect(runtime.resumeSession).toHaveBeenCalledWith(
+      'session-1',
+      '/workspace/project',
+      'default-project',
+      'ask',
+      'claude-code',
+      'claude-code:anthropic',
+      undefined
+    )
+    expect(runtime.resetSessionContext).toHaveBeenCalledWith(
+      'session-1',
+      '/workspace/project',
+      'default-project',
+      'ask'
+    )
+    expect(drainRuntimeEvents).toHaveBeenCalledOnce()
+    expect(preparationChanged).toHaveBeenLastCalledWith('session-1', false)
+    expect(
+      useSessionStore.getState().sessions[0]?.messages.map((message) => message.content)
+    ).toEqual(['first prompt', 'first answer', 'second prompt, edited'])
+    expect(runtime.sendPrompt).toHaveBeenCalledOnce()
+  })
+
+  it('opens the resent run after reset, then replays the kept history', async () => {
     seedConversation()
 
     const resetGate = createDeferred<{ sessionId: string; cwd: string; contextReset: boolean }>()
@@ -2898,20 +3053,18 @@ describe('resendEditedWorkspaceMessage', () => {
     })
     await flushRuntimeTasks()
 
-    // While the context reset is still in flight, the transcript already shows the adjusted prompt
-    // as a live run — the same immediate feedback as a composer send.
+    // Keep the existing Branch visible until reset succeeds so a terminal event from the prior
+    // runtime cannot settle the edited run.
     const duringReset = useSessionStore.getState().sessions[0]
     expect(duringReset?.messages.map((message) => message.id)).toEqual([
       'user-1',
       'agent-1',
-      expect.any(String)
+      'user-2',
+      'agent-2',
+      'user-3'
     ])
-    expect(duringReset?.messages.at(-1)).toMatchObject({
-      role: 'user',
-      content: 'second prompt, edited'
-    })
-    expect(duringReset?.status).toBe('running')
-    expect(duringReset?.activeRun?.promptMessageId).toBe(duringReset?.messages.at(-1)?.id)
+    expect(duringReset?.status).toBe('idle')
+    expect(duringReset?.activeRun).toBeUndefined()
     expect(runtime.sendPrompt).not.toHaveBeenCalled()
 
     resetGate.resolve({ sessionId: 'session-1', cwd: '/workspace/project', contextReset: true })
@@ -3030,7 +3183,7 @@ describe('resendEditedWorkspaceMessage', () => {
     const resent = await resendEditedWorkspaceMessage(
       runtime,
       { sessionId: 'session-1', messageId: 'user-2', text: 'second prompt, edited' },
-      false
+      { supportsImageInput: false }
     )
 
     // The incompatible replay is rejected before the destructive cut: no reset, no prompt, and the
@@ -3080,7 +3233,7 @@ describe('resendEditedWorkspaceMessage', () => {
     const resent = await resendEditedWorkspaceMessage(
       runtime,
       { sessionId: 'session-1', messageId: 'user-2', text: 'second prompt, edited' },
-      false
+      { supportsImageInput: false }
     )
 
     // User uploads replay as image attachments, so they are gated exactly like agent-emitted images.
@@ -3139,7 +3292,7 @@ describe('resendEditedWorkspaceMessage', () => {
     const resent = await resendEditedWorkspaceMessage(
       runtime,
       { sessionId: 'session-1', messageId: 'user-2', text: 'second prompt, edited' },
-      true
+      { supportsImageInput: true }
     )
     await flushRuntimeTasks()
 

--- a/src/renderer/src/lib/acp/useWorkspaceAgentRuntime.test.ts
+++ b/src/renderer/src/lib/acp/useWorkspaceAgentRuntime.test.ts
@@ -368,13 +368,21 @@ describe('workspace agent message sending', () => {
       status: 'shutdown'
     })
     vi.stubGlobal('window', { api: { notebook: { shutdown } } })
-    const resumeSession = vi.fn().mockResolvedValue({
+    const resumeCanFinish = createDeferred<{
+      sessionId: string
+      cwd: string
+      contextReset: boolean
+      frameworkId: string
+      backendId: string
+    }>()
+    const resumeSession = vi.fn().mockReturnValue(resumeCanFinish.promise)
+    const resumeResult = {
       sessionId: 'transport-session-1',
       cwd: '/workspace/project',
       contextReset: true,
       frameworkId: 'codex',
       backendId: 'codex:builtin-codex-subscription'
-    })
+    }
     const sendPrompt = vi.fn().mockResolvedValue(createSnapshot(['transport-session-1']))
     const runtime = {
       // A draining runtime may still expose the logical session while the selected runtime takes over.
@@ -385,7 +393,7 @@ describe('workspace agent message sending', () => {
       sendPrompt
     }
 
-    await sendWorkspaceMessage(runtime, {
+    const sendRequest = sendWorkspaceMessage(runtime, {
       sessionId: 'transport-session-1',
       text: 'Continue this branch with Codex',
       cwd: '/workspace/project',
@@ -393,6 +401,18 @@ describe('workspace agent message sending', () => {
       agentFrameworkId: 'codex',
       agentBackendId: 'codex:builtin-codex-subscription'
     })
+    await vi.waitFor(() => expect(resumeSession).toHaveBeenCalledOnce())
+
+    // Keep the prior Runtime Segment active until adoption succeeds. A draining stop/error can then
+    // settle the prior turn without accidentally finishing the optimistic Codex run.
+    expect(useSessionStore.getState().sessions[0]).toMatchObject({
+      status: 'idle',
+      activeRun: undefined,
+      messages: [expect.objectContaining({ content: 'Original Claude branch turn' })]
+    })
+
+    resumeCanFinish.resolve(resumeResult)
+    await sendRequest
     await flushRuntimeTasks()
 
     expect(runtime.resetSessionContext).not.toHaveBeenCalled()
@@ -1284,7 +1304,7 @@ describe('workspace agent message sending', () => {
     expect(session.error).toBe('Agent run failed')
   })
 
-  it('marks restored sessions running before resume finishes to block duplicate submits', async () => {
+  it('blocks duplicate submits while adoption finishes before opening the restored run', async () => {
     const resumeCanFinish = createDeferred<{ sessionId: string; cwd?: string }>()
     const runtime = {
       state: createSnapshot(),
@@ -1313,7 +1333,11 @@ describe('workspace agent message sending', () => {
     })
 
     await expect(second).resolves.toBeUndefined()
-    expect(useSessionStore.getState().sessions[0]).toMatchObject({ status: 'running' })
+    expect(useSessionStore.getState().sessions[0]).toMatchObject({
+      status: 'idle',
+      activeRun: undefined,
+      messages: [expect.objectContaining({ content: 'Previous prompt' })]
+    })
     expect(runtime.resumeSession).toHaveBeenCalledTimes(1)
 
     resumeCanFinish.resolve({ sessionId: 'session-1', cwd: '/workspace/project' })

--- a/src/renderer/src/lib/acp/useWorkspaceAgentRuntime.test.ts
+++ b/src/renderer/src/lib/acp/useWorkspaceAgentRuntime.test.ts
@@ -1937,11 +1937,24 @@ describe('resuming an interrupted session on demand', () => {
       resetSessionContext: vi.fn(),
       sendPrompt: vi.fn().mockResolvedValue(createSnapshot(['session-1']))
     }
+    const preparationChanged = vi.fn()
+    const drainRuntimeEvents = vi.fn().mockResolvedValue(undefined)
 
-    await resumeInterruptedWorkspaceSession(runtime, 'session-1')
+    await resumeInterruptedWorkspaceSession(runtime, 'session-1', {
+      onSendPreparationStateChange: preparationChanged,
+      drainRuntimeEvents
+    })
     await flushRuntimeTasks()
 
     expect(runtime.resumeSession).toHaveBeenCalled()
+    expect(preparationChanged.mock.calls).toEqual([
+      ['session-1', true],
+      ['session-1', false]
+    ])
+    expect(drainRuntimeEvents).toHaveBeenCalledOnce()
+    expect(drainRuntimeEvents.mock.invocationCallOrder[0]).toBeLessThan(
+      runtime.sendPrompt.mock.invocationCallOrder[0]
+    )
     expect(runtime.sendPrompt).toHaveBeenCalledTimes(1)
     expect(runtime.sendPrompt).toHaveBeenCalledWith(
       'session-1',

--- a/src/renderer/src/lib/acp/useWorkspaceAgentRuntime.test.ts
+++ b/src/renderer/src/lib/acp/useWorkspaceAgentRuntime.test.ts
@@ -602,6 +602,58 @@ describe('workspace agent message sending', () => {
     })
   })
 
+  it('does not recreate a session deleted while runtime adoption is in flight', async () => {
+    useSessionStore.getState().appendUserMessage({
+      sessionId: 'transport-session-1',
+      content: 'Original prompt',
+      cwd: '/workspace/project',
+      projectId: 'project-1',
+      agentFrameworkId: 'claude-code',
+      agentBackendId: 'claude-code:anthropic'
+    })
+    useSessionStore.getState().finishRun('transport-session-1')
+
+    const resumeGate = createDeferred<{
+      sessionId: string
+      cwd: string
+      contextReset: boolean
+      frameworkId: 'codex'
+      backendId: string
+    }>()
+    const runtime = {
+      state: createSnapshot(),
+      createSession: vi.fn(),
+      resumeSession: vi.fn(() => resumeGate.promise),
+      resetSessionContext: vi.fn(),
+      sendPrompt: vi.fn()
+    }
+
+    const sendRequest = sendWorkspaceMessage(runtime, {
+      sessionId: 'transport-session-1',
+      text: 'Do not resurrect this conversation',
+      cwd: '/workspace/project',
+      projectId: 'project-1',
+      agentFrameworkId: 'codex',
+      agentBackendId: 'codex:builtin-codex-subscription'
+    })
+    await vi.waitFor(() => expect(runtime.resumeSession).toHaveBeenCalledOnce())
+
+    useSessionStore.getState().deleteSession('transport-session-1')
+    resumeGate.resolve({
+      sessionId: 'transport-session-1',
+      cwd: '/workspace/project',
+      contextReset: true,
+      frameworkId: 'codex',
+      backendId: 'codex:builtin-codex-subscription'
+    })
+
+    await expect(sendRequest).resolves.toBeUndefined()
+    expect(
+      useSessionStore.getState().sessions.some((session) => session.id === 'transport-session-1')
+    ).toBe(false)
+    expect(runtime.sendPrompt).not.toHaveBeenCalled()
+  })
+
   it('keeps Branch replay required when the reset prompt is rejected', async () => {
     useSessionStore.getState().appendUserMessage({
       sessionId: 'transport-session-1',
@@ -1977,6 +2029,38 @@ describe('resuming an interrupted session on demand', () => {
     expect(userMessages).toHaveLength(1)
     expect(userMessages[0].content).toBe('Continue the analysis')
     expect(session.interrupted).toBeUndefined()
+  })
+
+  it('does not recreate an interrupted session deleted while reconnecting', async () => {
+    useSessionStore.getState().appendUserMessage({
+      sessionId: 'session-1',
+      content: 'Do not resurrect this interrupted prompt',
+      cwd: '/workspace/project',
+      projectId: 'default-project',
+      permissionProfile: 'ask'
+    })
+    useSessionStore.getState().markDisconnected('session-1')
+
+    const resumeGate = createDeferred<{ sessionId: string; cwd: string }>()
+    const runtime = {
+      state: createSnapshot(),
+      createSession: vi.fn(),
+      resumeSession: vi.fn(() => resumeGate.promise),
+      resetSessionContext: vi.fn(),
+      sendPrompt: vi.fn().mockResolvedValue(createSnapshot(['session-1']))
+    }
+
+    const resumeRequest = resumeInterruptedWorkspaceSession(runtime, 'session-1')
+    await vi.waitFor(() => expect(runtime.resumeSession).toHaveBeenCalledOnce())
+
+    useSessionStore.getState().deleteSession('session-1')
+    resumeGate.resolve({ sessionId: 'session-1', cwd: '/workspace/project' })
+
+    await resumeRequest
+
+    expect(useSessionStore.getState().sessions).toEqual([])
+    expect(runtime.resumeSession).toHaveBeenCalledOnce()
+    expect(runtime.sendPrompt).not.toHaveBeenCalled()
   })
 
   it('restores the interrupted user turn when re-send preparation fails', async () => {

--- a/src/renderer/src/lib/acp/useWorkspaceAgentRuntime.test.ts
+++ b/src/renderer/src/lib/acp/useWorkspaceAgentRuntime.test.ts
@@ -1897,6 +1897,20 @@ describe('resuming an interrupted session on demand', () => {
       agentFrameworkId: 'codex',
       agentBackendId: 'codex:builtin-codex-subscription'
     })
+    const switchedSession = useSessionStore.getState().sessions[0]
+    const promptContext = runtime.sendPrompt.mock.calls[0]?.[9]
+    const promptNode = switchedSession.conversationGraph?.messages.find(
+      (message) => message.id === promptContext?.promptMessageId
+    )
+    const promptSegment = switchedSession.conversationGraph?.runtimeSegments.find(
+      (segment) => segment.id === promptContext?.runtimeSegmentId
+    )
+
+    expect(promptSegment).toMatchObject({
+      frameworkId: 'codex',
+      backendId: 'codex:builtin-codex-subscription'
+    })
+    expect(promptNode?.runtimeSegmentId).toBe(promptContext?.runtimeSegmentId)
   })
 
   it('does not replay a history preamble when the resume kept agent context', async () => {

--- a/src/renderer/src/lib/acp/useWorkspaceAgentRuntime.test.ts
+++ b/src/renderer/src/lib/acp/useWorkspaceAgentRuntime.test.ts
@@ -347,6 +347,86 @@ describe('workspace agent message sending', () => {
     expect(useSessionStore.getState().sessions[0].branchContextResetRequired).toBeUndefined()
   })
 
+  it('resets a detached same-framework Branch after adoption before replay', async () => {
+    useSessionStore.getState().appendUserMessage({
+      sessionId: 'transport-session-1',
+      content: 'Original branch turn',
+      cwd: '/workspace/project',
+      projectId: 'project-1',
+      agentFrameworkId: 'claude-code',
+      agentBackendId: 'claude-code:anthropic'
+    })
+    useSessionStore.getState().finishRun('transport-session-1')
+    useSessionStore.setState((state) => ({
+      sessions: state.sessions.map((session) => ({
+        ...session,
+        branchContextResetRequired: true
+      }))
+    }))
+    const shutdown = vi.fn().mockResolvedValue({
+      sessionId: 'transport-session-1',
+      status: 'shutdown'
+    })
+    vi.stubGlobal('window', { api: { notebook: { shutdown } } })
+    const resetSessionContext = vi.fn().mockResolvedValue({
+      sessionId: 'transport-session-1',
+      cwd: '/workspace/project',
+      contextReset: true,
+      frameworkId: 'claude-code',
+      backendId: 'claude-code:anthropic'
+    })
+    const resumeSession = vi.fn().mockResolvedValue({
+      sessionId: 'transport-session-1',
+      cwd: '/workspace/project',
+      contextReset: false,
+      frameworkId: 'claude-code',
+      backendId: 'claude-code:anthropic'
+    })
+    const runtime = {
+      state: createSnapshot(),
+      createSession: vi.fn(),
+      resumeSession,
+      resetSessionContext,
+      sendPrompt: vi.fn().mockResolvedValue(createSnapshot(['transport-session-1']))
+    }
+
+    await sendWorkspaceMessage(runtime, {
+      sessionId: 'transport-session-1',
+      text: 'Continue detached branch',
+      cwd: '/workspace/project',
+      projectId: 'project-1',
+      agentFrameworkId: 'claude-code',
+      agentBackendId: 'claude-code:anthropic'
+    })
+
+    expect(shutdown).toHaveBeenCalledOnce()
+    expect(resetSessionContext).toHaveBeenCalledWith(
+      'transport-session-1',
+      '/workspace/project',
+      'project-1',
+      'ask'
+    )
+    expect(resumeSession).toHaveBeenCalledWith(
+      'transport-session-1',
+      '/workspace/project',
+      'project-1',
+      'ask',
+      'claude-code',
+      'claude-code:anthropic'
+    )
+    expect(shutdown.mock.invocationCallOrder[0]).toBeLessThan(
+      resumeSession.mock.invocationCallOrder[0]
+    )
+    expect(resumeSession.mock.invocationCallOrder[0]).toBeLessThan(
+      resetSessionContext.mock.invocationCallOrder[0]
+    )
+    expect(resetSessionContext.mock.invocationCallOrder[0]).toBeLessThan(
+      runtime.sendPrompt.mock.invocationCallOrder[0]
+    )
+    expect(runtime.sendPrompt.mock.calls[0]?.[5]).toContain('Original branch turn')
+    expect(useSessionStore.getState().sessions[0].branchContextResetRequired).toBeUndefined()
+  })
+
   it('adopts the selected framework when a Branch reset and framework switch share a turn', async () => {
     useSessionStore.getState().appendUserMessage({
       sessionId: 'transport-session-1',
@@ -379,17 +459,21 @@ describe('workspace agent message sending', () => {
     const resumeResult = {
       sessionId: 'transport-session-1',
       cwd: '/workspace/project',
-      contextReset: true,
+      contextReset: false,
       frameworkId: 'codex',
       backendId: 'codex:builtin-codex-subscription'
     }
+    const resetSessionContext = vi.fn().mockResolvedValue({
+      ...resumeResult,
+      contextReset: true
+    })
     const sendPrompt = vi.fn().mockResolvedValue(createSnapshot(['transport-session-1']))
     const runtime = {
       // A draining runtime may still expose the logical session while the selected runtime takes over.
       state: createSnapshot(['transport-session-1']),
       createSession: vi.fn(),
       resumeSession,
-      resetSessionContext: vi.fn(),
+      resetSessionContext,
       sendPrompt
     }
 
@@ -415,7 +499,12 @@ describe('workspace agent message sending', () => {
     await sendRequest
     await flushRuntimeTasks()
 
-    expect(runtime.resetSessionContext).not.toHaveBeenCalled()
+    expect(resetSessionContext).toHaveBeenCalledWith(
+      'transport-session-1',
+      '/workspace/project',
+      'project-1',
+      'ask'
+    )
     expect(resumeSession).toHaveBeenCalledWith(
       'transport-session-1',
       '/workspace/project',
@@ -428,6 +517,9 @@ describe('workspace agent message sending', () => {
       resumeSession.mock.invocationCallOrder[0]
     )
     expect(resumeSession.mock.invocationCallOrder[0]).toBeLessThan(
+      resetSessionContext.mock.invocationCallOrder[0]
+    )
+    expect(resetSessionContext.mock.invocationCallOrder[0]).toBeLessThan(
       sendPrompt.mock.invocationCallOrder[0]
     )
     const switchedSession = useSessionStore.getState().sessions[0]
@@ -1321,27 +1413,35 @@ describe('workspace agent message sending', () => {
     })
     useSessionStore.getState().finishRun('session-1')
 
-    const first = sendWorkspaceMessage(runtime, {
-      sessionId: 'session-1',
-      text: 'Continue restored conversation',
-      cwd: '/workspace/project'
-    })
+    const preparationChanged = vi.fn()
+    const first = sendWorkspaceMessage(
+      runtime,
+      {
+        sessionId: 'session-1',
+        text: 'Continue restored conversation',
+        cwd: '/workspace/project'
+      },
+      preparationChanged
+    )
     const second = sendWorkspaceMessage(runtime, {
       sessionId: 'session-1',
       text: 'Duplicate submit',
       cwd: '/workspace/project'
     })
 
-    await expect(second).resolves.toBeNull()
+    await expect(second).resolves.toBeUndefined()
     expect(useSessionStore.getState().sessions[0]).toMatchObject({
       status: 'idle',
       activeRun: undefined,
       messages: [expect.objectContaining({ content: 'Previous prompt' })]
     })
     expect(runtime.resumeSession).toHaveBeenCalledTimes(1)
+    expect(preparationChanged).toHaveBeenCalledWith('session-1', true)
 
     resumeCanFinish.resolve({ sessionId: 'session-1', cwd: '/workspace/project' })
-    await expect(first).resolves.toMatchObject({ sessionId: 'session-1' })
+    const firstResult = await first
+    expect(firstResult).toMatchObject({ sessionId: 'session-1' })
+    expect(preparationChanged).toHaveBeenLastCalledWith('session-1', false)
     expect(runtime.sendPrompt).toHaveBeenCalledTimes(1)
   })
 

--- a/src/renderer/src/lib/acp/useWorkspaceAgentRuntime.ts
+++ b/src/renderer/src/lib/acp/useWorkspaceAgentRuntime.ts
@@ -87,6 +87,10 @@ type SendWorkspaceMessageResult = {
   messageId: string
 }
 
+// `null` means a duplicate submit was intentionally suppressed while the selected runtime adopts
+// the session. Unlike `undefined` (a genuine send failure), this must not restore the cleared draft.
+type SendWorkspaceMessageOutcome = SendWorkspaceMessageResult | null
+
 // Payload of an inline edit resend: the adjusted prompt text plus the mentions it carries. The
 // session/message ids stay separate because they address the truncation point, not the prompt.
 type ResendEditedMessageInput = {
@@ -496,7 +500,7 @@ const sendWorkspaceMessage = async (
     branchContextAlreadyReset,
     specialistId
   }: SendWorkspaceMessageInput
-): Promise<SendWorkspaceMessageResult | undefined> => {
+): Promise<SendWorkspaceMessageOutcome | undefined> => {
   const content = text.trim()
 
   // Empty drafts are allowed only when the user attached at least one file.
@@ -646,7 +650,7 @@ const sendWorkspaceMessage = async (
     let contextResetFromResume = false
 
     if (resumeCwd) {
-      if (sessionSendAdoptionsInFlight.has(targetSessionId)) return undefined
+      if (sessionSendAdoptionsInFlight.has(targetSessionId)) return null
       sessionSendAdoptionsInFlight.add(targetSessionId)
       try {
         const resumeResult = await runtime.resumeSession(
@@ -1330,7 +1334,9 @@ const useWorkspaceAgentRuntime = (): {
   promptInFlightSessionIds: string[]
   nativeContextCompactionSessionIds: string[]
   compactContext: (sessionId: string) => Promise<boolean>
-  sendMessage: (input: SendWorkspaceMessageInput) => Promise<SendWorkspaceMessageResult | undefined>
+  sendMessage: (
+    input: SendWorkspaceMessageInput
+  ) => Promise<SendWorkspaceMessageOutcome | undefined>
   resendEditedMessage: (
     sessionId: string,
     messageId: string,
@@ -1415,7 +1421,7 @@ const useWorkspaceAgentRuntime = (): {
 
   // Creates a session if needed, records the user message, then starts the prompt in the background.
   const sendMessage = useCallback(
-    (input: SendWorkspaceMessageInput): Promise<SendWorkspaceMessageResult | undefined> =>
+    (input: SendWorkspaceMessageInput): Promise<SendWorkspaceMessageOutcome | undefined> =>
       sendWorkspaceMessage(runtime, {
         ...input,
         supportsImageInput,

--- a/src/renderer/src/lib/acp/useWorkspaceAgentRuntime.ts
+++ b/src/renderer/src/lib/acp/useWorkspaceAgentRuntime.ts
@@ -550,10 +550,27 @@ const sendWorkspaceMessage = async (
       return appended
     }
 
+    // A framework/backend selection change takes effect at this turn boundary. A retired generation
+    // may still expose the old session briefly, so persisted ownership participates in this decision.
+    const frameworkChanged = Boolean(
+      agentFrameworkId &&
+      currentSession?.agentFrameworkId &&
+      agentFrameworkId !== currentSession.agentFrameworkId
+    )
+    const backendChanged = Boolean(
+      agentBackendId &&
+      currentSession?.agentBackendId &&
+      agentBackendId !== currentSession.agentBackendId
+    )
+    const runtimeMustAdoptSession =
+      frameworkChanged || backendChanged || !runtime.state.sessionIds.includes(targetSessionId)
+
     // Branch activation changes only the durable projection. Before the first continuation on that
     // path, drop both volatile contexts so neither the provider nor a live kernel can leak sibling-
-    // Branch state into the prompt. The active Branch transcript is replayed below after reset.
+    // Branch state into the prompt. When another runtime must adopt the session, its resume creates the
+    // fresh Agent context; resetting the old runtime first would execute this turn under the wrong owner.
     let branchContextResetPerformed = Boolean(branchContextAlreadyReset)
+    let agentContextResetPerformed = Boolean(branchContextAlreadyReset)
     if (currentSession?.branchContextResetRequired && !branchContextAlreadyReset) {
       const resetCwd = targetCwd || currentSession.cwd || runtime.state.cwd
       if (!resetCwd) {
@@ -562,15 +579,18 @@ const sendWorkspaceMessage = async (
       }
       try {
         await shutdownNotebookForBranchChange(targetSessionId, resetCwd, sessionProjectName)
-        const reset = await runtime.resetSessionContext(
-          targetSessionId,
-          resetCwd,
-          sessionProjectName,
-          currentSession.permissionProfile ?? permissionProfile
-        )
-        useSessionStore
-          .getState()
-          .markResumed(targetSessionId, reset?.frameworkId, reset?.backendId)
+        if (!runtimeMustAdoptSession) {
+          const reset = await runtime.resetSessionContext(
+            targetSessionId,
+            resetCwd,
+            sessionProjectName,
+            currentSession.permissionProfile ?? permissionProfile
+          )
+          useSessionStore
+            .getState()
+            .markResumed(targetSessionId, reset?.frameworkId, reset?.backendId)
+          agentContextResetPerformed = true
+        }
         branchContextResetPerformed = true
       } catch (error) {
         useSessionStore.getState().failRun(targetSessionId, getResumeFailureMessage(error))
@@ -586,16 +606,7 @@ const sendWorkspaceMessage = async (
       useSessionStore.getState().clearSpecialistSwitchResetRequired(targetSessionId)
     }
 
-    // A framework switch applies at the next turn boundary. The retiring runtime may still expose the
-    // old session for a brief teardown window, so compare persisted ownership as well as the snapshot.
-    const frameworkChanged = Boolean(
-      agentFrameworkId &&
-      currentSession?.agentFrameworkId &&
-      agentFrameworkId !== currentSession.agentFrameworkId
-    )
-    const shouldResumeSession =
-      !branchContextResetPerformed &&
-      (frameworkChanged || !runtime.state.sessionIds.includes(targetSessionId))
+    const shouldResumeSession = !agentContextResetPerformed && runtimeMustAdoptSession
     let resumeCwd: string | undefined
 
     if (shouldResumeSession) {
@@ -619,11 +630,12 @@ const sendWorkspaceMessage = async (
           parts,
           cwd: targetCwd,
           projectId: projectId ?? currentSession?.projectId,
-          // Bind the optimistic prompt to the selected Runtime Segment before async resume. Existing
-          // Session ownership fields are committed only by markResumed, while synchronizeSessionGraph
-          // can still attribute this turn and its Artifact provenance to the incoming framework/backend.
-          agentFrameworkId,
-          agentBackendId,
+          // Bind the optimistic prompt to the selected Runtime Segment only when this send will adopt
+          // that runtime. A local Branch reset otherwise continues on the current owner.
+          agentFrameworkId: shouldResumeSession
+            ? agentFrameworkId
+            : currentSession?.agentFrameworkId,
+          agentBackendId: shouldResumeSession ? agentBackendId : currentSession?.agentBackendId,
           agentModel
         })
 

--- a/src/renderer/src/lib/acp/useWorkspaceAgentRuntime.ts
+++ b/src/renderer/src/lib/acp/useWorkspaceAgentRuntime.ts
@@ -619,6 +619,11 @@ const sendWorkspaceMessage = async (
           parts,
           cwd: targetCwd,
           projectId: projectId ?? currentSession?.projectId,
+          // Bind the optimistic prompt to the selected Runtime Segment before async resume. Existing
+          // Session ownership fields are committed only by markResumed, while synchronizeSessionGraph
+          // can still attribute this turn and its Artifact provenance to the incoming framework/backend.
+          agentFrameworkId,
+          agentBackendId,
           agentModel
         })
 

--- a/src/renderer/src/lib/acp/useWorkspaceAgentRuntime.ts
+++ b/src/renderer/src/lib/acp/useWorkspaceAgentRuntime.ts
@@ -71,6 +71,9 @@ type SendWorkspaceMessageInput = {
   // Internal overflow-recovery handoff: that flow owns the compacting state and replaces it with the
   // retried run synchronously. Ordinary composer sends must never bypass the local compaction gate.
   allowCompactionRecovery?: boolean
+  // Internal retry seam: unlike a normal missing-at-start send, this request belongs to a captured
+  // durable session and must abort if that conversation was deleted during an earlier control turn.
+  requireExistingSession?: boolean
   // Immutable Specialist UUID from the new-conversation draft picker. Only used when creating a new
   // ACP session (sessionId === undefined). The renderer sends only the UUID; the main process reads
   // the latest Profile. Never passed for existing sessions (specialist binding is immutable).
@@ -507,6 +510,7 @@ const sendWorkspaceMessage = async (
     supportsImageInput,
     truncateFromMessageId,
     allowCompactionRecovery,
+    requireExistingSession,
     specialistId
   }: SendWorkspaceMessageInput,
   onSendPreparationStateChange?: SendPreparationStateChange,
@@ -524,6 +528,8 @@ const sendWorkspaceMessage = async (
     const currentSession = useSessionStore
       .getState()
       .sessions.find((session) => session.id === targetSessionId)
+
+    if (requireExistingSession && !currentSession) return undefined
 
     // Runtime ownership is authoritative while native compaction or another control turn is active.
     if (
@@ -693,6 +699,9 @@ const sendWorkspaceMessage = async (
     const preparedSession = useSessionStore
       .getState()
       .sessions.find((session) => session.id === targetSessionId)
+    // Preparation crosses async runtime and notebook boundaries. Deletion or hydration may remove the
+    // target meanwhile; never let the generic append seam recreate that stale existing-session id.
+    if ((currentSession || requireExistingSession) && !preparedSession) return undefined
 
     // An edited resend replays only the retained Branch prefix.
     const historyCutMessageId = truncateFromMessageId
@@ -987,6 +996,7 @@ const resumeInterruptedWorkspaceSession = async (
       permissionProfile: session.permissionProfile ?? DEFAULT_PERMISSION_PROFILE,
       // Replay the prior conversation when this resume adopted a fresh agent session.
       forceHistoryReplay: contextReset,
+      requireExistingSession: true,
       supportsImageInput,
       agentModel
     },

--- a/src/renderer/src/lib/acp/useWorkspaceAgentRuntime.ts
+++ b/src/renderer/src/lib/acp/useWorkspaceAgentRuntime.ts
@@ -1,4 +1,4 @@
-import { useCallback, useEffect, useRef } from 'react'
+import { useCallback, useEffect, useRef, useState } from 'react'
 
 import type {
   AcpConnectionStatus,
@@ -87,9 +87,7 @@ type SendWorkspaceMessageResult = {
   messageId: string
 }
 
-// `null` means a duplicate submit was intentionally suppressed while the selected runtime adopts
-// the session. Unlike `undefined` (a genuine send failure), this must not restore the cleared draft.
-type SendWorkspaceMessageOutcome = SendWorkspaceMessageResult | null
+type SendPreparationStateChange = (sessionId: string, inFlight: boolean) => void
 
 // Payload of an inline edit resend: the adjusted prompt text plus the mentions it carries. The
 // session/message ids stay separate because they address the truncation point, not the prompt.
@@ -119,10 +117,10 @@ type WorkspaceRuntimeEventProcessor = {
   process: (events: AcpRuntimeEvent[]) => Promise<void>
 }
 
-// Adoption intentionally completes before appendUserMessage creates the next run. Keep duplicate
-// sends closed during that idle-looking interval without exposing a premature activeRun that a
-// draining runtime's terminal event could settle.
-const sessionSendAdoptionsInFlight = new Set<string>()
+// Runtime adoption and Branch reset intentionally complete before appendUserMessage creates the next
+// run. Keep duplicate preparations closed during that idle-looking interval without exposing a
+// premature activeRun that a draining runtime's terminal event could settle.
+const sessionSendPreparationsInFlight = new Set<string>()
 
 // Strips the Electron IPC wrapper ("Error invoking remote method '…': Error: <cause>") and any
 // leading "Error:" so the underlying agent message can be shown to the user on its own. Used by both
@@ -499,8 +497,9 @@ const sendWorkspaceMessage = async (
     allowCompactionRecovery,
     branchContextAlreadyReset,
     specialistId
-  }: SendWorkspaceMessageInput
-): Promise<SendWorkspaceMessageOutcome | undefined> => {
+  }: SendWorkspaceMessageInput,
+  onSendPreparationStateChange?: SendPreparationStateChange
+): Promise<SendWorkspaceMessageResult | undefined> => {
   const content = text.trim()
 
   // Empty drafts are allowed only when the user attached at least one file.
@@ -571,41 +570,28 @@ const sendWorkspaceMessage = async (
       currentSession?.agentBackendId &&
       agentBackendId !== currentSession.agentBackendId
     )
-    const runtimeMustAdoptSession =
-      frameworkChanged || backendChanged || !runtime.state.sessionIds.includes(targetSessionId)
+    const selectedRuntimeChanged = frameworkChanged || backendChanged
+    const runtimeDetached = !runtime.state.sessionIds.includes(targetSessionId)
+    const runtimeMustAdoptSession = selectedRuntimeChanged || runtimeDetached
+    const branchResetRequired = Boolean(
+      currentSession?.branchContextResetRequired && !branchContextAlreadyReset
+    )
+    const sendPreparationRequired = branchResetRequired || runtimeMustAdoptSession
 
-    // Branch activation changes only the durable projection. Before the first continuation on that
-    // path, drop both volatile contexts so neither the provider nor a live kernel can leak sibling-
-    // Branch state into the prompt. When another runtime must adopt the session, its resume creates the
-    // fresh Agent context; resetting the old runtime first would execute this turn under the wrong owner.
+    if (sendPreparationRequired) {
+      if (sessionSendPreparationsInFlight.has(targetSessionId)) return undefined
+      sessionSendPreparationsInFlight.add(targetSessionId)
+      onSendPreparationStateChange?.(targetSessionId, true)
+    }
+
+    // Branch activation changes only the durable projection. Before the first continuation, drop
+    // Notebook context and guarantee a fresh Agent context. A selected-runtime change must adopt first
+    // so any required reset executes on the new owner. Only an already-attached selected runtime can
+    // reset directly; detached sessions adopt first so a stale coordinator owner cannot receive it.
     let branchContextResetPerformed = Boolean(branchContextAlreadyReset)
     let agentContextResetPerformed = Boolean(branchContextAlreadyReset)
-    if (currentSession?.branchContextResetRequired && !branchContextAlreadyReset) {
-      const resetCwd = targetCwd || currentSession.cwd || runtime.state.cwd
-      if (!resetCwd) {
-        useSessionStore.getState().failRun(targetSessionId, RESUME_WORKSPACE_MISSING_MESSAGE)
-        return undefined
-      }
-      try {
-        await shutdownNotebookForBranchChange(targetSessionId, resetCwd, sessionProjectName)
-        if (!runtimeMustAdoptSession) {
-          const reset = await runtime.resetSessionContext(
-            targetSessionId,
-            resetCwd,
-            sessionProjectName,
-            currentSession.permissionProfile ?? permissionProfile
-          )
-          useSessionStore
-            .getState()
-            .markResumed(targetSessionId, reset?.frameworkId, reset?.backendId)
-          agentContextResetPerformed = true
-        }
-        branchContextResetPerformed = true
-      } catch (error) {
-        useSessionStore.getState().failRun(targetSessionId, getResumeFailureMessage(error))
-        return undefined
-      }
-    }
+    let shouldResumeSession = false
+    let contextResetFromResume = false
 
     // A specialist switch on Claude replaced the agent session on the main side (identity is baked
     // into session _meta at creation). The runtime already adopted a fresh session, so here we only
@@ -615,19 +601,77 @@ const sendWorkspaceMessage = async (
       useSessionStore.getState().clearSpecialistSwitchResetRequired(targetSessionId)
     }
 
-    const shouldResumeSession = !agentContextResetPerformed && runtimeMustAdoptSession
-    let resumeCwd: string | undefined
+    try {
+      if (branchResetRequired) {
+        const resetCwd = targetCwd || currentSession?.cwd || runtime.state.cwd
+        if (!resetCwd) {
+          useSessionStore.getState().failRun(targetSessionId, RESUME_WORKSPACE_MISSING_MESSAGE)
+          return undefined
+        }
 
-    if (shouldResumeSession) {
-      // Empty string is treated as missing; fall back to runtime cwd
-      const effectiveCwd = targetCwd || runtime.state.cwd
-
-      if (!effectiveCwd) {
-        useSessionStore.getState().failRun(targetSessionId, RESUME_WORKSPACE_MISSING_MESSAGE)
-        return undefined
+        await shutdownNotebookForBranchChange(targetSessionId, resetCwd, sessionProjectName)
+        if (!selectedRuntimeChanged && !runtimeDetached) {
+          const reset = await runtime.resetSessionContext(
+            targetSessionId,
+            resetCwd,
+            sessionProjectName,
+            currentSession?.permissionProfile ?? permissionProfile
+          )
+          useSessionStore
+            .getState()
+            .markResumed(targetSessionId, reset?.frameworkId, reset?.backendId)
+          agentContextResetPerformed = true
+        }
+        branchContextResetPerformed = true
       }
 
-      resumeCwd = effectiveCwd
+      shouldResumeSession = !agentContextResetPerformed && runtimeMustAdoptSession
+      if (shouldResumeSession) {
+        // Empty string is treated as missing; fall back to runtime cwd.
+        const resumeCwd = targetCwd || runtime.state.cwd
+        if (!resumeCwd) {
+          useSessionStore.getState().failRun(targetSessionId, RESUME_WORKSPACE_MISSING_MESSAGE)
+          return undefined
+        }
+
+        const resumeResult = await runtime.resumeSession(
+          targetSessionId,
+          resumeCwd,
+          sessionProjectName,
+          currentSession?.permissionProfile ?? permissionProfile,
+          currentSession?.agentFrameworkId,
+          currentSession?.agentBackendId,
+          currentSession?.specialistId
+        )
+
+        contextResetFromResume = Boolean(resumeResult?.contextReset)
+        useSessionStore
+          .getState()
+          .markResumed(targetSessionId, resumeResult?.frameworkId, resumeResult?.backendId)
+
+        // A provider may resume an existing selected-runtime session without resetting its hidden
+        // history. Branch isolation requires a fresh context even in that case, now on the adopted owner.
+        if (branchContextResetPerformed && !contextResetFromResume) {
+          const reset = await runtime.resetSessionContext(
+            targetSessionId,
+            resumeCwd,
+            sessionProjectName,
+            currentSession?.permissionProfile ?? permissionProfile
+          )
+          useSessionStore
+            .getState()
+            .markResumed(targetSessionId, reset?.frameworkId, reset?.backendId)
+          contextResetFromResume = true
+        }
+      }
+    } catch (error) {
+      useSessionStore.getState().failRun(targetSessionId, getResumeFailureMessage(error))
+      return undefined
+    } finally {
+      if (sendPreparationRequired) {
+        sessionSendPreparationsInFlight.delete(targetSessionId)
+        onSendPreparationStateChange?.(targetSessionId, false)
+      }
     }
 
     // A pre-appended prompt replays only the turns that precede it, so the resent turn is not
@@ -647,33 +691,6 @@ const sendWorkspaceMessage = async (
     let historyPreamble: string | undefined
     let historyAttachments: UploadedAttachment[] | undefined
     let historyImages: AcpMessageImage[] | undefined
-    let contextResetFromResume = false
-
-    if (resumeCwd) {
-      if (sessionSendAdoptionsInFlight.has(targetSessionId)) return null
-      sessionSendAdoptionsInFlight.add(targetSessionId)
-      try {
-        const resumeResult = await runtime.resumeSession(
-          targetSessionId,
-          resumeCwd,
-          sessionProjectName,
-          currentSession?.permissionProfile ?? permissionProfile,
-          currentSession?.agentFrameworkId,
-          currentSession?.agentBackendId,
-          currentSession?.specialistId
-        )
-
-        contextResetFromResume = Boolean(resumeResult?.contextReset)
-        useSessionStore
-          .getState()
-          .markResumed(targetSessionId, resumeResult?.frameworkId, resumeResult?.backendId)
-      } catch (error) {
-        useSessionStore.getState().failRun(targetSessionId, getResumeFailureMessage(error))
-        return undefined
-      } finally {
-        sessionSendAdoptionsInFlight.delete(targetSessionId)
-      }
-    }
 
     const appended = preAppendedMessageId
       ? { sessionId: targetSessionId, messageId: preAppendedMessageId }
@@ -1332,11 +1349,10 @@ const useWorkspaceAgentRuntime = (): {
   permissionGrants: Record<string, AcpPermissionGrant[]>
   contextUsageBySession: Record<string, AcpContextUsage>
   promptInFlightSessionIds: string[]
+  sendPreparationInFlightSessionIds: string[]
   nativeContextCompactionSessionIds: string[]
   compactContext: (sessionId: string) => Promise<boolean>
-  sendMessage: (
-    input: SendWorkspaceMessageInput
-  ) => Promise<SendWorkspaceMessageOutcome | undefined>
+  sendMessage: (input: SendWorkspaceMessageInput) => Promise<SendWorkspaceMessageResult | undefined>
   resendEditedMessage: (
     sessionId: string,
     messageId: string,
@@ -1357,6 +1373,19 @@ const useWorkspaceAgentRuntime = (): {
   const activeModel = useSettingsStore((state) => state.activeModel)
   const activeProviderId = useSettingsStore((state) => state.activeProviderId)
   const agentFrameworkId = useSettingsStore((state) => state.agentFrameworkId)
+  const [sendPreparationInFlightSessionIds, setSendPreparationInFlightSessionIds] = useState<
+    string[]
+  >([])
+  const handleSendPreparationStateChange = useCallback<SendPreparationStateChange>(
+    (sessionId, inFlight) => {
+      setSendPreparationInFlightSessionIds((current) => {
+        const containsSession = current.includes(sessionId)
+        if (inFlight === containsSession) return current
+        return inFlight ? [...current, sessionId] : current.filter((id) => id !== sessionId)
+      })
+    },
+    []
+  )
   const eventProcessor = useRef(createWorkspaceRuntimeEventProcessor())
   // Tracks the last connection status so the disconnect effect fires only on a transition, not on
   // every unrelated snapshot re-render.
@@ -1421,15 +1450,26 @@ const useWorkspaceAgentRuntime = (): {
 
   // Creates a session if needed, records the user message, then starts the prompt in the background.
   const sendMessage = useCallback(
-    (input: SendWorkspaceMessageInput): Promise<SendWorkspaceMessageOutcome | undefined> =>
-      sendWorkspaceMessage(runtime, {
-        ...input,
-        supportsImageInput,
-        agentFrameworkId,
-        agentBackendId: activeProviderId ? `${agentFrameworkId}:${activeProviderId}` : undefined,
-        agentModel: activeModel
-      }),
-    [runtime, supportsImageInput, agentFrameworkId, activeProviderId, activeModel]
+    (input: SendWorkspaceMessageInput): Promise<SendWorkspaceMessageResult | undefined> =>
+      sendWorkspaceMessage(
+        runtime,
+        {
+          ...input,
+          supportsImageInput,
+          agentFrameworkId,
+          agentBackendId: activeProviderId ? `${agentFrameworkId}:${activeProviderId}` : undefined,
+          agentModel: activeModel
+        },
+        handleSendPreparationStateChange
+      ),
+    [
+      runtime,
+      supportsImageInput,
+      agentFrameworkId,
+      activeProviderId,
+      activeModel,
+      handleSendPreparationStateChange
+    ]
   )
 
   // Truncates the conversation at the edited message, then resends the adjusted prompt with the
@@ -1528,6 +1568,7 @@ const useWorkspaceAgentRuntime = (): {
     permissionGrants: runtime.state.permissionGrants,
     contextUsageBySession: runtime.state.contextUsageBySession,
     promptInFlightSessionIds: runtime.state.promptInFlightSessionIds,
+    sendPreparationInFlightSessionIds,
     nativeContextCompactionSessionIds: runtime.state.nativeContextCompactionSessionIds ?? [],
     compactContext,
     sendMessage,

--- a/src/renderer/src/lib/acp/useWorkspaceAgentRuntime.ts
+++ b/src/renderer/src/lib/acp/useWorkspaceAgentRuntime.ts
@@ -115,6 +115,11 @@ type WorkspaceRuntimeEventProcessor = {
   process: (events: AcpRuntimeEvent[]) => Promise<void>
 }
 
+// Adoption intentionally completes before appendUserMessage creates the next run. Keep duplicate
+// sends closed during that idle-looking interval without exposing a premature activeRun that a
+// draining runtime's terminal event could settle.
+const sessionSendAdoptionsInFlight = new Set<string>()
+
 // Strips the Electron IPC wrapper ("Error invoking remote method '…': Error: <cause>") and any
 // leading "Error:" so the underlying agent message can be shown to the user on its own. Used by both
 // the resume and createSession failure paths, since either crosses IPC and arrives wrapped.
@@ -621,27 +626,6 @@ const sendWorkspaceMessage = async (
       resumeCwd = effectiveCwd
     }
 
-    const appended = preAppendedMessageId
-      ? { sessionId: targetSessionId, messageId: preAppendedMessageId }
-      : useSessionStore.getState().appendUserMessage({
-          sessionId: targetSessionId,
-          content,
-          attachments,
-          parts,
-          cwd: targetCwd,
-          projectId: projectId ?? currentSession?.projectId,
-          // Bind the optimistic prompt to the selected Runtime Segment only when this send will adopt
-          // that runtime. A local Branch reset otherwise continues on the current owner.
-          agentFrameworkId: shouldResumeSession
-            ? agentFrameworkId
-            : currentSession?.agentFrameworkId,
-          agentBackendId: shouldResumeSession ? agentBackendId : currentSession?.agentBackendId,
-          agentModel
-        })
-
-    // appendUserMessage can reject stale session ids after local deletion or hydration changes.
-    if (!appended) return undefined
-
     // A pre-appended prompt replays only the turns that precede it, so the resent turn is not
     // duplicated into its own preamble.
     const preAppendedCutIndex =
@@ -653,15 +637,17 @@ const sendWorkspaceMessage = async (
         ? currentSession.messages.slice(0, preAppendedCutIndex)
         : currentSession?.messages
 
-    // Persisted sessions are marked running locally before async resume closes duplicate submits.
-    // A resume that lands on a freshly-adopted session (framework switch, or an unresumable restart)
-    // lost the agent's context, so replay the prior turns as a preamble on this first prompt.
+    // Resume before creating the optimistic run. A draining runtime can emit its terminal event while
+    // adoption is in flight; keeping the old Runtime Segment active until resume succeeds lets that
+    // event settle the prior turn instead of accidentally finishing the incoming prompt.
     let historyPreamble: string | undefined
     let historyAttachments: UploadedAttachment[] | undefined
     let historyImages: AcpMessageImage[] | undefined
     let contextResetFromResume = false
 
     if (resumeCwd) {
+      if (sessionSendAdoptionsInFlight.has(targetSessionId)) return undefined
+      sessionSendAdoptionsInFlight.add(targetSessionId)
       try {
         const resumeResult = await runtime.resumeSession(
           targetSessionId,
@@ -679,9 +665,32 @@ const sendWorkspaceMessage = async (
           .markResumed(targetSessionId, resumeResult?.frameworkId, resumeResult?.backendId)
       } catch (error) {
         useSessionStore.getState().failRun(targetSessionId, getResumeFailureMessage(error))
-        return appended
+        return undefined
+      } finally {
+        sessionSendAdoptionsInFlight.delete(targetSessionId)
       }
     }
+
+    const appended = preAppendedMessageId
+      ? { sessionId: targetSessionId, messageId: preAppendedMessageId }
+      : useSessionStore.getState().appendUserMessage({
+          sessionId: targetSessionId,
+          content,
+          attachments,
+          parts,
+          cwd: targetCwd,
+          projectId: projectId ?? currentSession?.projectId,
+          // Bind the optimistic prompt to the selected Runtime Segment only when this send adopted
+          // that runtime. A local Branch reset otherwise continues on the current owner.
+          agentFrameworkId: shouldResumeSession
+            ? agentFrameworkId
+            : currentSession?.agentFrameworkId,
+          agentBackendId: shouldResumeSession ? agentBackendId : currentSession?.agentBackendId,
+          agentModel
+        })
+
+    // appendUserMessage can reject stale session ids after local deletion or hydration changes.
+    if (!appended) return undefined
 
     // Replay prior turns when this resume reset the agent's context, or the caller already knows a reset
     // happened (interrupted-resume path — its internal re-resume above hits an already-attached session

--- a/src/renderer/src/lib/acp/useWorkspaceAgentRuntime.ts
+++ b/src/renderer/src/lib/acp/useWorkspaceAgentRuntime.ts
@@ -106,6 +106,13 @@ type ResendEditedWorkspaceMessageOptions = {
   drainRuntimeEvents?: RuntimeEventDrain
 }
 
+type ResumeInterruptedWorkspaceSessionOptions = {
+  supportsImageInput?: boolean
+  agentModel?: string
+  onSendPreparationStateChange?: SendPreparationStateChange
+  drainRuntimeEvents?: RuntimeEventDrain
+}
+
 type WorkspaceMessageRuntime = Pick<
   ReturnType<typeof useAcpRuntime>,
   'state' | 'createSession' | 'resumeSession' | 'resetSessionContext' | 'sendPrompt'
@@ -903,8 +910,12 @@ const restoreRemovedTurnProjection = (
 const resumeInterruptedWorkspaceSession = async (
   runtime: WorkspaceMessageRuntime,
   sessionId: string,
-  supportsImageInput?: boolean,
-  agentModel?: string
+  {
+    supportsImageInput,
+    agentModel,
+    onSendPreparationStateChange,
+    drainRuntimeEvents
+  }: ResumeInterruptedWorkspaceSessionOptions = {}
 ): Promise<void> => {
   const session = useSessionStore.getState().sessions.find((item) => item.id === sessionId)
 
@@ -962,21 +973,26 @@ const resumeInterruptedWorkspaceSession = async (
 
   useSessionStore.getState().removeMessage(sessionId, interruptedTurn.id)
 
-  const resent = await sendWorkspaceMessage(runtime, {
-    sessionId,
-    text: interruptedTurn.content,
-    attachments: (interruptedTurn.uploads ?? []).map((upload) =>
-      toRuntimeUploadedAttachment(upload, session.projectId)
-    ),
-    parts: interruptedTurn.parts,
-    cwd: resumeCwd,
-    projectId: session.projectId,
-    permissionProfile: session.permissionProfile ?? DEFAULT_PERMISSION_PROFILE,
-    // Replay the prior conversation when this resume adopted a fresh agent session.
-    forceHistoryReplay: contextReset,
-    supportsImageInput,
-    agentModel
-  })
+  const resent = await sendWorkspaceMessage(
+    runtime,
+    {
+      sessionId,
+      text: interruptedTurn.content,
+      attachments: (interruptedTurn.uploads ?? []).map((upload) =>
+        toRuntimeUploadedAttachment(upload, session.projectId)
+      ),
+      parts: interruptedTurn.parts,
+      cwd: resumeCwd,
+      projectId: session.projectId,
+      permissionProfile: session.permissionProfile ?? DEFAULT_PERMISSION_PROFILE,
+      // Replay the prior conversation when this resume adopted a fresh agent session.
+      forceHistoryReplay: contextReset,
+      supportsImageInput,
+      agentModel
+    },
+    onSendPreparationStateChange,
+    drainRuntimeEvents
+  )
 
   if (!resent) restoreRemovedTurnProjection(session, { interrupted: true })
 }
@@ -1547,8 +1563,13 @@ const useWorkspaceAgentRuntime = (): {
   // success the composer is unlocked; on failure the interrupted banner stays so a retry stays possible.
   const resumeInterruptedSession = useCallback(
     (sessionId: string): Promise<void> =>
-      resumeInterruptedWorkspaceSession(runtime, sessionId, supportsImageInput, activeModel),
-    [runtime, supportsImageInput, activeModel]
+      resumeInterruptedWorkspaceSession(runtime, sessionId, {
+        supportsImageInput,
+        agentModel: activeModel,
+        onSendPreparationStateChange: handleSendPreparationStateChange,
+        drainRuntimeEvents
+      }),
+    [runtime, supportsImageInput, activeModel, handleSendPreparationStateChange, drainRuntimeEvents]
   )
 
   // Sends a cancellation request while the runtime waits for the eventual stop event.

--- a/src/renderer/src/lib/acp/useWorkspaceAgentRuntime.ts
+++ b/src/renderer/src/lib/acp/useWorkspaceAgentRuntime.ts
@@ -32,7 +32,7 @@ import {
   RESUME_WORKSPACE_MISSING_MESSAGE
 } from '../../../../shared/run-error-classification'
 import { usePreviewWorkbenchStore } from '../../stores/preview-workbench-store'
-import { useSessionStore, type ChatMessage } from '../../stores/session-store'
+import { useSessionStore, type ChatMessage, type ChatSession } from '../../stores/session-store'
 import { useSettingsStore } from '../../stores/settings-store'
 import { useAcpRuntime } from './useAcpRuntime'
 import { buildHistoryPreamble, buildHistoryReplayMedia } from './history-preamble'
@@ -853,6 +853,37 @@ const findInterruptedUserTurn = (messages: ChatMessage[]): ChatMessage | undefin
   return undefined
 }
 
+// removeMessage creates an abandoned Branch before retry. If preparation fails before the shared send
+// appends a replacement prompt, restore the exact transcript/graph projection while preserving newer
+// runtime metadata and the failure recorded on the live session.
+const restoreRemovedTurnProjection = (
+  sessionBeforeRemoval: ChatSession,
+  options?: { interrupted?: boolean }
+): void => {
+  useSessionStore.setState((state) => ({
+    sessions: state.sessions.map((session) => {
+      if (session.id !== sessionBeforeRemoval.id) return session
+
+      return {
+        ...session,
+        messages: sessionBeforeRemoval.messages,
+        conversationGraph: sessionBeforeRemoval.conversationGraph,
+        filesRevision: sessionBeforeRemoval.filesRevision,
+        ...(options?.interrupted
+          ? {
+              status: 'error' as const,
+              activeRun: undefined,
+              interrupted: true,
+              compacting: undefined,
+              error: session.error ?? sessionBeforeRemoval.error
+            }
+          : {}),
+        updatedAt: Date.now()
+      }
+    })
+  }))
+}
+
 // Explicitly re-attaches an interrupted session's ACP runtime so the user can keep chatting. On
 // success the composer is unlocked; on failure the interrupted banner stays so a retry stays possible.
 const resumeInterruptedWorkspaceSession = async (
@@ -865,11 +896,17 @@ const resumeInterruptedWorkspaceSession = async (
 
   if (!session) return
 
-  // Already attached (e.g. a redundant click after a prior resume): just clear the banner.
-  if (runtime.state.sessionIds.includes(sessionId)) {
+  const interruptedTurn = findInterruptedUserTurn(session.messages)
+  const runtimeAlreadyAttached = runtime.state.sessionIds.includes(sessionId)
+
+  // Already attached and no unanswered retry remains (e.g. a redundant click after a prior resume):
+  // just clear the banner. A failed post-resume preparation deliberately keeps `interrupted` set so a
+  // second click skips provider resume but still re-attempts the preserved prompt below.
+  if (runtimeAlreadyAttached && !interruptedTurn) {
     useSessionStore.getState().markResumed(sessionId)
     return
   }
+  if (runtimeAlreadyAttached) useSessionStore.getState().markResumed(sessionId)
 
   // Empty string is treated as missing; fall back to runtime cwd
   const resumeCwd = session.cwd || runtime.state.cwd
@@ -881,37 +918,37 @@ const resumeInterruptedWorkspaceSession = async (
 
   let contextReset = false
 
-  try {
-    const resumeResult = await runtime.resumeSession(
-      sessionId,
-      resumeCwd,
-      session.projectId,
-      session.permissionProfile ?? DEFAULT_PERMISSION_PROFILE,
-      session.agentFrameworkId,
-      session.agentBackendId,
-      session.specialistId
-    )
-    // Adopting a fresh agent session (framework switch, or an unresumable restart) wipes the agent's
-    // context; capture that so the re-sent turn below replays the transcript. The shared send path's
-    // own re-resume can't observe this — by then the session is already attached.
-    contextReset = Boolean(resumeResult?.contextReset)
-    useSessionStore
-      .getState()
-      .markResumed(sessionId, resumeResult?.frameworkId, resumeResult?.backendId)
-  } catch (error) {
-    useSessionStore.getState().failRun(sessionId, getResumeFailureMessage(error))
-    return
+  if (!runtimeAlreadyAttached) {
+    try {
+      const resumeResult = await runtime.resumeSession(
+        sessionId,
+        resumeCwd,
+        session.projectId,
+        session.permissionProfile ?? DEFAULT_PERMISSION_PROFILE,
+        session.agentFrameworkId,
+        session.agentBackendId,
+        session.specialistId
+      )
+      // Adopting a fresh agent session (framework switch, or an unresumable restart) wipes the agent's
+      // context; capture that so the re-sent turn below replays the transcript. The shared send path's
+      // own re-resume can't observe this — by then the session is already attached.
+      contextReset = Boolean(resumeResult?.contextReset)
+      useSessionStore
+        .getState()
+        .markResumed(sessionId, resumeResult?.frameworkId, resumeResult?.backendId)
+    } catch (error) {
+      useSessionStore.getState().failRun(sessionId, getResumeFailureMessage(error))
+      return
+    }
   }
 
   // Continue the interrupted turn if it never got a successful reply. Removing the stale user message
   // first avoids a duplicate bubble, since the shared send path re-appends and re-prompts it once.
-  const interruptedTurn = findInterruptedUserTurn(session.messages)
-
   if (!interruptedTurn) return
 
   useSessionStore.getState().removeMessage(sessionId, interruptedTurn.id)
 
-  await sendWorkspaceMessage(runtime, {
+  const resent = await sendWorkspaceMessage(runtime, {
     sessionId,
     text: interruptedTurn.content,
     attachments: (interruptedTurn.uploads ?? []).map((upload) =>
@@ -926,6 +963,8 @@ const resumeInterruptedWorkspaceSession = async (
     supportsImageInput,
     agentModel
   })
+
+  if (!resent) restoreRemovedTurnProjection(session, { interrupted: true })
 }
 
 // After an auto-recovery, ignore further overflow events for this session for a short window so a retry
@@ -1096,6 +1135,8 @@ const recoverContextOverflowWorkspaceSession = async (
     allowCompactionRecovery: true,
     agentModel: session.agentModel
   })
+
+  if (!retried) restoreRemovedTurnProjection(session)
 
   return Boolean(retried)
 }

--- a/src/renderer/src/lib/acp/useWorkspaceAgentRuntime.ts
+++ b/src/renderer/src/lib/acp/useWorkspaceAgentRuntime.ts
@@ -63,19 +63,14 @@ type SendWorkspaceMessageInput = {
   // internal re-resume below runs against an already-attached session and can't report the reset
   // again, so this forces the prior turns to be replayed as a history preamble on the re-sent turn.
   forceHistoryReplay?: boolean
-  // Set by the edit-resend path, which appends the adjusted prompt optimistically (with its run
-  // already marked) so the bubble and waiting indicator show immediately. The duplicate-submit
-  // guard and the local append are skipped, and the replayed history stops before this message.
-  preAppendedMessageId?: string
   // Current Provider capability, injected by the hook so context replay cannot bypass image gating.
   supportsImageInput?: boolean
+  // Internal edit-resend seam: reset the selected runtime first, then replace the active Branch from
+  // this message and replay only the retained prefix into the fresh context.
+  truncateFromMessageId?: string
   // Internal overflow-recovery handoff: that flow owns the compacting state and replaces it with the
   // retried run synchronously. Ordinary composer sends must never bypass the local compaction gate.
   allowCompactionRecovery?: boolean
-  // Edit-resend performs the reset itself so it can roll back the optimistic Branch on failure. The
-  // common send path still owns replay completion and clears the durable retry marker only after the
-  // provider accepts the prompt.
-  branchContextAlreadyReset?: boolean
   // Immutable Specialist UUID from the new-conversation draft picker. Only used when creating a new
   // ACP session (sessionId === undefined). The renderer sends only the UUID; the main process reads
   // the latest Profile. Never passed for existing sessions (specialist binding is immutable).
@@ -88,6 +83,7 @@ type SendWorkspaceMessageResult = {
 }
 
 type SendPreparationStateChange = (sessionId: string, inFlight: boolean) => void
+type RuntimeEventDrain = () => Promise<void>
 
 // Payload of an inline edit resend: the adjusted prompt text plus the mentions it carries. The
 // session/message ids stay separate because they address the truncation point, not the prompt.
@@ -99,6 +95,15 @@ type ResendEditedMessageInput = {
   forcedSkillIds?: string[]
   // Files referenced via `@` mentions in the inline editor; attached to the resent prompt.
   referencedArtifacts?: FileReference[]
+}
+
+type ResendEditedWorkspaceMessageOptions = {
+  supportsImageInput?: boolean
+  agentFrameworkId?: AgentFrameworkId
+  agentBackendId?: string
+  agentModel?: string
+  onSendPreparationStateChange?: SendPreparationStateChange
+  drainRuntimeEvents?: RuntimeEventDrain
 }
 
 type WorkspaceMessageRuntime = Pick<
@@ -492,13 +497,13 @@ const sendWorkspaceMessage = async (
     referencedArtifacts,
     parts,
     forceHistoryReplay,
-    preAppendedMessageId,
     supportsImageInput,
+    truncateFromMessageId,
     allowCompactionRecovery,
-    branchContextAlreadyReset,
     specialistId
   }: SendWorkspaceMessageInput,
-  onSendPreparationStateChange?: SendPreparationStateChange
+  onSendPreparationStateChange?: SendPreparationStateChange,
+  drainRuntimeEvents?: RuntimeEventDrain
 ): Promise<SendWorkspaceMessageResult | undefined> => {
   const content = text.trim()
 
@@ -514,12 +519,11 @@ const sendWorkspaceMessage = async (
       .sessions.find((session) => session.id === targetSessionId)
 
     // Runtime ownership is authoritative while native compaction or another control turn is active.
-    // A pre-appended prompt may bypass only the local status guard because it marked its own run.
     if (
       runtime.state.promptInFlightSessionIds.includes(targetSessionId) ||
       (currentSession?.compacting && !allowCompactionRecovery) ||
-      (!preAppendedMessageId &&
-        (currentSession?.status === 'running' || currentSession?.status === 'waiting-permission'))
+      currentSession?.status === 'running' ||
+      currentSession?.status === 'waiting-permission'
     ) {
       return undefined
     }
@@ -574,7 +578,7 @@ const sendWorkspaceMessage = async (
     const runtimeDetached = !runtime.state.sessionIds.includes(targetSessionId)
     const runtimeMustAdoptSession = selectedRuntimeChanged || runtimeDetached
     const branchResetRequired = Boolean(
-      currentSession?.branchContextResetRequired && !branchContextAlreadyReset
+      truncateFromMessageId || currentSession?.branchContextResetRequired
     )
     const sendPreparationRequired = branchResetRequired || runtimeMustAdoptSession
 
@@ -588,8 +592,8 @@ const sendWorkspaceMessage = async (
     // Notebook context and guarantee a fresh Agent context. A selected-runtime change must adopt first
     // so any required reset executes on the new owner. Only an already-attached selected runtime can
     // reset directly; detached sessions adopt first so a stale coordinator owner cannot receive it.
-    let branchContextResetPerformed = Boolean(branchContextAlreadyReset)
-    let agentContextResetPerformed = Boolean(branchContextAlreadyReset)
+    let branchContextResetPerformed = false
+    let agentContextResetPerformed = false
     let shouldResumeSession = false
     let contextResetFromResume = false
 
@@ -663,6 +667,11 @@ const sendWorkspaceMessage = async (
             .markResumed(targetSessionId, reset?.frameworkId, reset?.backendId)
           contextResetFromResume = true
         }
+
+        // The coordinator waits for the prior owner to stop before committing adoption, but its
+        // retained events still cross the asynchronous renderer bridge. Apply the latest accepted
+        // snapshot before opening the new optimistic run so a terminal event cannot settle that run.
+        await drainRuntimeEvents?.()
       }
     } catch (error) {
       useSessionStore.getState().failRun(targetSessionId, getResumeFailureMessage(error))
@@ -674,16 +683,21 @@ const sendWorkspaceMessage = async (
       }
     }
 
-    // A pre-appended prompt replays only the turns that precede it, so the resent turn is not
-    // duplicated into its own preamble.
-    const preAppendedCutIndex =
-      preAppendedMessageId && currentSession
-        ? currentSession.messages.findIndex((message) => message.id === preAppendedMessageId)
+    const preparedSession = useSessionStore
+      .getState()
+      .sessions.find((session) => session.id === targetSessionId)
+
+    // An edited resend replays only the retained Branch prefix.
+    const historyCutMessageId = truncateFromMessageId
+    const historyCutIndex =
+      historyCutMessageId && preparedSession
+        ? preparedSession.messages.findIndex((message) => message.id === historyCutMessageId)
         : -1
+    if (truncateFromMessageId && historyCutIndex < 0) return undefined
     const historyMessages =
-      currentSession && preAppendedCutIndex >= 0
-        ? currentSession.messages.slice(0, preAppendedCutIndex)
-        : currentSession?.messages
+      preparedSession && historyCutIndex >= 0
+        ? preparedSession.messages.slice(0, historyCutIndex)
+        : preparedSession?.messages
 
     // Resume before creating the optimistic run. A draining runtime can emit its terminal event while
     // adoption is in flight; keeping the old Runtime Segment active until resume succeeds lets that
@@ -692,23 +706,23 @@ const sendWorkspaceMessage = async (
     let historyAttachments: UploadedAttachment[] | undefined
     let historyImages: AcpMessageImage[] | undefined
 
-    const appended = preAppendedMessageId
-      ? { sessionId: targetSessionId, messageId: preAppendedMessageId }
-      : useSessionStore.getState().appendUserMessage({
-          sessionId: targetSessionId,
-          content,
-          attachments,
-          parts,
-          cwd: targetCwd,
-          projectId: projectId ?? currentSession?.projectId,
-          // Bind the optimistic prompt to the selected Runtime Segment only when this send adopted
-          // that runtime. A local Branch reset otherwise continues on the current owner.
-          agentFrameworkId: shouldResumeSession
-            ? agentFrameworkId
-            : currentSession?.agentFrameworkId,
-          agentBackendId: shouldResumeSession ? agentBackendId : currentSession?.agentBackendId,
-          agentModel
-        })
+    if (truncateFromMessageId) {
+      useSessionStore.getState().truncateSessionFromMessage(targetSessionId, truncateFromMessageId)
+    }
+
+    const appended = useSessionStore.getState().appendUserMessage({
+      sessionId: targetSessionId,
+      content,
+      attachments,
+      parts,
+      cwd: targetCwd,
+      projectId: projectId ?? preparedSession?.projectId,
+      // Bind the optimistic prompt to the selected Runtime Segment only when this send adopted
+      // that runtime. A local Branch reset otherwise continues on the current owner.
+      agentFrameworkId: shouldResumeSession ? agentFrameworkId : preparedSession?.agentFrameworkId,
+      agentBackendId: shouldResumeSession ? agentBackendId : preparedSession?.agentBackendId,
+      agentModel
+    })
 
     // appendUserMessage can reject stale session ids after local deletion or hydration changes.
     if (!appended) return undefined
@@ -1170,8 +1184,14 @@ const cancelWorkspaceRun = async (
 const resendEditedWorkspaceMessage = async (
   runtime: WorkspaceMessageRuntime,
   input: ResendEditedMessageInput & { sessionId: string; messageId: string },
-  supportsImageInput?: boolean,
-  agentModel?: string
+  {
+    supportsImageInput,
+    agentFrameworkId,
+    agentBackendId,
+    agentModel,
+    onSendPreparationStateChange,
+    drainRuntimeEvents
+  }: ResendEditedWorkspaceMessageOptions = {}
 ): Promise<boolean> => {
   const session = useSessionStore.getState().sessions.find((item) => item.id === input.sessionId)
 
@@ -1206,59 +1226,30 @@ const resendEditedWorkspaceMessage = async (
     return false
   }
 
-  // The optimistic Branch projection + append replaces the visible downstream path while retaining
-  // the original Branch in Session JSON; the adjusted prompt becomes a live run immediately.
-  const preEditSession = session
-  useSessionStore.getState().truncateSessionFromMessage(input.sessionId, input.messageId)
-  const appended = useSessionStore.getState().appendUserMessage({
-    sessionId: input.sessionId,
-    content,
-    attachments: [],
-    parts: input.parts,
-    cwd: resumeCwd,
-    projectId: session.projectId,
-    agentModel
-  })
+  const resent = await sendWorkspaceMessage(
+    runtime,
+    {
+      sessionId: input.sessionId,
+      text: content,
+      attachments: [],
+      parts: input.parts,
+      cwd: resumeCwd,
+      projectId: session.projectId,
+      permissionProfile: session.permissionProfile ?? DEFAULT_PERMISSION_PROFILE,
+      forcedSkillIds: input.forcedSkillIds,
+      referencedArtifacts: input.referencedArtifacts,
+      agentFrameworkId,
+      agentBackendId,
+      agentModel,
+      // Reset/adopt while the old Branch remains visible, then replace it only after preparation.
+      truncateFromMessageId: input.messageId,
+      supportsImageInput
+    },
+    onSendPreparationStateChange,
+    drainRuntimeEvents
+  )
 
-  if (!appended) return false
-
-  try {
-    await shutdownNotebookForBranchChange(input.sessionId, resumeCwd, session.projectId)
-    await runtime.resetSessionContext(
-      input.sessionId,
-      resumeCwd,
-      session.projectId,
-      session.permissionProfile ?? DEFAULT_PERMISSION_PROFILE
-    )
-  } catch (error) {
-    // Roll the transcript back to the pre-edit state so a failed reset deletes nothing, then
-    // surface the failure on the restored conversation.
-    useSessionStore.setState((state) => ({
-      sessions: state.sessions.map((item) => (item.id === input.sessionId ? preEditSession : item))
-    }))
-    useSessionStore.getState().failRun(input.sessionId, getResumeFailureMessage(error))
-    return false
-  }
-
-  await sendWorkspaceMessage(runtime, {
-    sessionId: input.sessionId,
-    text: content,
-    attachments: [],
-    parts: input.parts,
-    cwd: resumeCwd,
-    projectId: session.projectId,
-    permissionProfile: session.permissionProfile ?? DEFAULT_PERMISSION_PROFILE,
-    forcedSkillIds: input.forcedSkillIds,
-    referencedArtifacts: input.referencedArtifacts,
-    // The fresh agent session lost the prior context, so replay the truncated transcript.
-    forceHistoryReplay: true,
-    preAppendedMessageId: appended.messageId,
-    supportsImageInput,
-    branchContextAlreadyReset: true,
-    agentModel
-  })
-
-  return true
+  return Boolean(resent)
 }
 
 // Scans runtime error events for the request-size overflow and triggers one auto-recovery per event.
@@ -1414,6 +1405,7 @@ const useWorkspaceAgentRuntime = (): {
   const activeModel = useSettingsStore((state) => state.activeModel)
   const activeProviderId = useSettingsStore((state) => state.activeProviderId)
   const agentFrameworkId = useSettingsStore((state) => state.agentFrameworkId)
+  const agentBackendId = activeProviderId ? `${agentFrameworkId}:${activeProviderId}` : undefined
   const [sendPreparationInFlightSessionIds, setSendPreparationInFlightSessionIds] = useState<
     string[]
   >([])
@@ -1428,6 +1420,10 @@ const useWorkspaceAgentRuntime = (): {
     []
   )
   const eventProcessor = useRef(createWorkspaceRuntimeEventProcessor())
+  const drainRuntimeEvents = useCallback(async (): Promise<void> => {
+    const snapshot = await window.api.acp.getState()
+    await eventProcessor.current.process(snapshot.events)
+  }, [])
   // Tracks the last connection status so the disconnect effect fires only on a transition, not on
   // every unrelated snapshot re-render.
   const previousStatusRef = useRef(runtime.state.status)
@@ -1498,18 +1494,20 @@ const useWorkspaceAgentRuntime = (): {
           ...input,
           supportsImageInput,
           agentFrameworkId,
-          agentBackendId: activeProviderId ? `${agentFrameworkId}:${activeProviderId}` : undefined,
+          agentBackendId,
           agentModel: activeModel
         },
-        handleSendPreparationStateChange
+        handleSendPreparationStateChange,
+        drainRuntimeEvents
       ),
     [
       runtime,
       supportsImageInput,
       agentFrameworkId,
-      activeProviderId,
+      agentBackendId,
       activeModel,
-      handleSendPreparationStateChange
+      handleSendPreparationStateChange,
+      drainRuntimeEvents
     ]
   )
 
@@ -1520,10 +1518,24 @@ const useWorkspaceAgentRuntime = (): {
       resendEditedWorkspaceMessage(
         runtime,
         { sessionId, messageId, ...input },
-        supportsImageInput,
-        activeModel
+        {
+          supportsImageInput,
+          agentFrameworkId,
+          agentBackendId,
+          agentModel: activeModel,
+          onSendPreparationStateChange: handleSendPreparationStateChange,
+          drainRuntimeEvents
+        }
       ),
-    [runtime, supportsImageInput, activeModel]
+    [
+      runtime,
+      supportsImageInput,
+      agentFrameworkId,
+      agentBackendId,
+      activeModel,
+      handleSendPreparationStateChange,
+      drainRuntimeEvents
+    ]
   )
 
   const compactContext = useCallback(

--- a/src/renderer/src/lib/compute/useJobAnalysisEffect.ts
+++ b/src/renderer/src/lib/compute/useJobAnalysisEffect.ts
@@ -20,7 +20,7 @@ import { createJobAnalysisTrigger } from '../compute/job-analysis-trigger'
 type SendMessageFn = (input: {
   sessionId?: string
   text: string
-}) => Promise<{ sessionId: string; messageId: string } | null | undefined>
+}) => Promise<{ sessionId: string; messageId: string } | undefined>
 
 type UseJobAnalysisEffectOptions = {
   enabled: boolean
@@ -49,9 +49,7 @@ export const useJobAnalysisEffect = ({
       },
       sendPrompt: async (sessionId, text) => {
         if (!isActive) return undefined
-        // A composer duplicate suppressed during runtime adoption uses null; automatic analysis
-        // treats it like any other unsent prompt so the completion notification stays retryable.
-        return (await sendLatestMessage({ sessionId, text })) ?? undefined
+        return sendLatestMessage({ sessionId, text })
       },
       markConsumed: async (sessionId, jobIds) => {
         if (!isActive) return

--- a/src/renderer/src/lib/compute/useJobAnalysisEffect.ts
+++ b/src/renderer/src/lib/compute/useJobAnalysisEffect.ts
@@ -20,7 +20,7 @@ import { createJobAnalysisTrigger } from '../compute/job-analysis-trigger'
 type SendMessageFn = (input: {
   sessionId?: string
   text: string
-}) => Promise<{ sessionId: string; messageId: string } | undefined>
+}) => Promise<{ sessionId: string; messageId: string } | null | undefined>
 
 type UseJobAnalysisEffectOptions = {
   enabled: boolean
@@ -49,7 +49,9 @@ export const useJobAnalysisEffect = ({
       },
       sendPrompt: async (sessionId, text) => {
         if (!isActive) return undefined
-        return sendLatestMessage({ sessionId, text })
+        // A composer duplicate suppressed during runtime adoption uses null; automatic analysis
+        // treats it like any other unsent prompt so the completion notification stays retryable.
+        return (await sendLatestMessage({ sessionId, text })) ?? undefined
       },
       markConsumed: async (sessionId, jobIds) => {
         if (!isActive) return

--- a/src/renderer/src/pages/workspace/WorkspacePage.draft-preservation.test.tsx
+++ b/src/renderer/src/pages/workspace/WorkspacePage.draft-preservation.test.tsx
@@ -412,6 +412,40 @@ describe('WorkspacePage draft preservation', () => {
     expect(conversationProps.draftDoc).toEqual(textDoc('keep this second prompt'))
   })
 
+  it('restores a failed prepared send only to its original conversation draft', async () => {
+    const failedSend = createDeferred<{ sessionId: string; messageId: string } | undefined>()
+    const attachment = createAttachment('failed-send-a')
+    runtime.sendMessage.mockReturnValueOnce(failedSend.promise)
+    await renderPage()
+
+    await act(async () => {
+      conversationProps.onDraftDocChange(textDoc('restore to session A'))
+    })
+    await stageAttachment(attachment)
+    await act(async () => {
+      conversationProps.onSendMessage([])
+    })
+    expect(runtime.sendMessage).toHaveBeenCalledOnce()
+    expect(runtime.sendMessage).toHaveBeenCalledWith(
+      expect.objectContaining({ attachments: [attachment] })
+    )
+    await openSession('sess-b')
+    await act(async () => {
+      conversationProps.onDraftDocChange(textDoc('keep session B draft'))
+    })
+
+    await act(async () => {
+      failedSend.resolve(undefined)
+      await failedSend.promise
+    })
+
+    expect(conversationProps.draftDoc).toEqual(textDoc('keep session B draft'))
+    expect(conversationProps.attachments).toEqual([])
+    await openSession('sess-a')
+    expect(conversationProps.draftDoc).toEqual(textDoc('restore to session A'))
+    expect(conversationProps.attachments).toEqual([attachment])
+  })
+
   it('drops a stored draft and deletes its staged files when the session is deleted', async () => {
     await renderPage()
 

--- a/src/renderer/src/pages/workspace/WorkspacePage.draft-preservation.test.tsx
+++ b/src/renderer/src/pages/workspace/WorkspacePage.draft-preservation.test.tsx
@@ -446,6 +446,37 @@ describe('WorkspacePage draft preservation', () => {
     expect(conversationProps.attachments).toEqual([attachment])
   })
 
+  it('preserves a newer same-conversation draft when prepared send restoration finishes', async () => {
+    const failedSend = createDeferred<{ sessionId: string; messageId: string } | undefined>()
+    const firstAttachment = createAttachment('failed-send-first')
+    const newerAttachment = createAttachment('failed-send-newer')
+    runtime.sendMessage.mockReturnValueOnce(failedSend.promise)
+    await renderPage()
+
+    await act(async () => {
+      conversationProps.onDraftDocChange(textDoc('first prompt'))
+    })
+    await stageAttachment(firstAttachment)
+    await act(async () => {
+      conversationProps.onSendMessage([])
+    })
+
+    await act(async () => {
+      conversationProps.onDraftDocChange(textDoc('keep this newer prompt'))
+    })
+    await stageAttachment(newerAttachment)
+
+    await act(async () => {
+      failedSend.resolve(undefined)
+      await failedSend.promise
+    })
+
+    expect(conversationProps.draftDoc).toEqual(textDoc('keep this newer prompt'))
+    expect(conversationProps.attachments).toEqual([newerAttachment])
+    expect(deleteUpload).toHaveBeenCalledWith({ path: firstAttachment.path })
+    expect(deleteUpload).not.toHaveBeenCalledWith({ path: newerAttachment.path })
+  })
+
   it('drops a stored draft and deletes its staged files when the session is deleted', async () => {
     await renderPage()
 

--- a/src/renderer/src/pages/workspace/WorkspacePage.draft-preservation.test.tsx
+++ b/src/renderer/src/pages/workspace/WorkspacePage.draft-preservation.test.tsx
@@ -369,6 +369,22 @@ describe('WorkspacePage draft preservation', () => {
     expect(deleteUpload).not.toHaveBeenCalled()
   })
 
+  it('does not restore a duplicate draft suppressed during session adoption', async () => {
+    runtime.sendMessage.mockResolvedValueOnce(null)
+    await renderPage()
+
+    await act(async () => {
+      conversationProps.onDraftDocChange(textDoc('send once'))
+    })
+    await act(async () => {
+      conversationProps.onSendMessage([])
+    })
+
+    expect(runtime.sendMessage).toHaveBeenCalledWith(expect.objectContaining({ text: 'send once' }))
+    expect(conversationProps.draftDoc).toEqual(emptyDoc)
+    expect(conversationProps.attachments).toEqual([])
+  })
+
   it('drops a stored draft and deletes its staged files when the session is deleted', async () => {
     await renderPage()
 

--- a/src/renderer/src/pages/workspace/WorkspacePage.draft-preservation.test.tsx
+++ b/src/renderer/src/pages/workspace/WorkspacePage.draft-preservation.test.tsx
@@ -131,6 +131,17 @@ const createAttachment = (id: string): UploadedAttachment => ({
 // Deterministic doc containing a single text run.
 const textDoc = (text: string): ComposerDoc => ({ nodes: [{ type: 'text', text }] })
 
+const createDeferred = <Value,>(): {
+  promise: Promise<Value>
+  resolve: (value: Value) => void
+} => {
+  let resolve!: (value: Value) => void
+  const promise = new Promise<Value>((promiseResolve) => {
+    resolve = promiseResolve
+  })
+  return { promise, resolve }
+}
+
 const deleteUpload = vi.fn(() => Promise.resolve())
 const stageLocalFile = vi.fn()
 const claimLocalFile = vi.fn(() => Promise.resolve())
@@ -369,20 +380,36 @@ describe('WorkspacePage draft preservation', () => {
     expect(deleteUpload).not.toHaveBeenCalled()
   })
 
-  it('does not restore a duplicate draft suppressed during session adoption', async () => {
-    runtime.sendMessage.mockResolvedValueOnce(null)
+  it('preserves a different draft submitted while the first send is preparing', async () => {
+    const firstSend = createDeferred<{ sessionId: string; messageId: string }>()
+    runtime.sendMessage.mockReturnValueOnce(firstSend.promise)
     await renderPage()
 
     await act(async () => {
-      conversationProps.onDraftDocChange(textDoc('send once'))
+      conversationProps.onDraftDocChange(textDoc('first prompt'))
+    })
+    await act(async () => {
+      conversationProps.onSendMessage([])
+    })
+    await act(async () => {
+      conversationProps.onDraftDocChange(textDoc('keep this second prompt'))
     })
     await act(async () => {
       conversationProps.onSendMessage([])
     })
 
-    expect(runtime.sendMessage).toHaveBeenCalledWith(expect.objectContaining({ text: 'send once' }))
-    expect(conversationProps.draftDoc).toEqual(emptyDoc)
+    expect(runtime.sendMessage).toHaveBeenCalledTimes(1)
+    expect(runtime.sendMessage).toHaveBeenCalledWith(
+      expect.objectContaining({ text: 'first prompt' })
+    )
+    expect(conversationProps.draftDoc).toEqual(textDoc('keep this second prompt'))
     expect(conversationProps.attachments).toEqual([])
+
+    await act(async () => {
+      firstSend.resolve({ sessionId: 'sess-a', messageId: 'm1' })
+      await firstSend.promise
+    })
+    expect(conversationProps.draftDoc).toEqual(textDoc('keep this second prompt'))
   })
 
   it('drops a stored draft and deletes its staged files when the session is deleted', async () => {

--- a/src/renderer/src/pages/workspace/WorkspacePage.send-gate.test.tsx
+++ b/src/renderer/src/pages/workspace/WorkspacePage.send-gate.test.tsx
@@ -26,6 +26,7 @@ import { type ComposerDoc } from './composer/composer-doc'
 // Capture the ConversationPanel props the page computes, notably canSendMessage and the draft callback.
 let conversationProps: {
   draftDoc: ComposerDoc
+  canEditDraft: boolean
   canSendMessage: boolean
   canEditMessage: boolean
   canCompactContext: boolean
@@ -35,6 +36,7 @@ let conversationProps: {
 
 const runtime = vi.hoisted(() => ({
   promptInFlightSessionIds: [] as string[],
+  sendPreparationInFlightSessionIds: [] as string[],
   nativeContextCompactionSessionIds: ['sess-a'] as string[],
   sendMessage: vi.fn(),
   compactContext: vi.fn(),
@@ -55,6 +57,7 @@ vi.mock('@/lib/acp/useWorkspaceAgentRuntime', () => ({
     actionError: null,
     pendingPermissions: [],
     promptInFlightSessionIds: runtime.promptInFlightSessionIds,
+    sendPreparationInFlightSessionIds: runtime.sendPreparationInFlightSessionIds,
     nativeContextCompactionSessionIds: runtime.nativeContextCompactionSessionIds,
     sendMessage: runtime.sendMessage,
     compactContext: runtime.compactContext,
@@ -123,6 +126,7 @@ describe('WorkspacePage send gate while compacting', () => {
     })
     vi.clearAllMocks()
     runtime.promptInFlightSessionIds = []
+    runtime.sendPreparationInFlightSessionIds = []
     runtime.nativeContextCompactionSessionIds = ['sess-a']
 
     window.api = {
@@ -268,6 +272,26 @@ describe('WorkspacePage send gate while compacting', () => {
       )
     })
     expect(conversationProps.canSendMessage).toBe(true)
+  })
+
+  it('locks draft submission and message editing while a send prepares runtime adoption', async () => {
+    await renderPage()
+
+    await act(async () => {
+      conversationProps.onDraftDocChange(textDoc('wait for adoption'))
+    })
+    expect(conversationProps.canEditDraft).toBe(true)
+    expect(conversationProps.canSendMessage).toBe(true)
+    expect(conversationProps.canEditMessage).toBe(true)
+
+    runtime.sendPreparationInFlightSessionIds = ['sess-a']
+    await act(async () => {
+      root.render(<WorkspacePage isSessionPersistenceReady={true} />)
+    })
+
+    expect(conversationProps.canEditDraft).toBe(false)
+    expect(conversationProps.canSendMessage).toBe(false)
+    expect(conversationProps.canEditMessage).toBe(false)
   })
 
   it('blocks new prompts after terminal conversation graph synchronization fails', async () => {

--- a/src/renderer/src/pages/workspace/WorkspacePage.send-gate.test.tsx
+++ b/src/renderer/src/pages/workspace/WorkspacePage.send-gate.test.tsx
@@ -286,7 +286,13 @@ describe('WorkspacePage send gate while compacting', () => {
 
     runtime.sendPreparationInFlightSessionIds = ['sess-a']
     await act(async () => {
-      root.render(<WorkspacePage isSessionPersistenceReady={true} />)
+      root.render(
+        <WorkspacePage
+          isSessionPersistenceHydrated={true}
+          isSessionPersistenceReady={true}
+          canDeleteConversations={true}
+        />
+      )
     })
 
     expect(conversationProps.canEditDraft).toBe(false)

--- a/src/renderer/src/pages/workspace/WorkspacePage.tsx
+++ b/src/renderer/src/pages/workspace/WorkspacePage.tsx
@@ -160,6 +160,7 @@ const WorkspacePage = ({
     permissionGrants,
     contextUsageBySession,
     promptInFlightSessionIds = [],
+    sendPreparationInFlightSessionIds = [],
     nativeContextCompactionSessionIds,
     compactContext,
     sendMessage,
@@ -235,6 +236,9 @@ const WorkspacePage = ({
       }
     >
   >({})
+  // Closes the synchronous gap before the hook's reactive preparation state re-renders this page.
+  // A second submit for the same draft key returns without clearing its possibly newer local draft.
+  const sendRequestsInFlightRef = useRef(new Set<string>())
   // Mutable cleanup ledgers bridge the async runtime-deletion window. Uploads that finish or queue
   // after confirmation are added here so a successful deletion cannot strand staged files.
   const sessionDeletionCleanupRef = useRef<
@@ -291,8 +295,11 @@ const WorkspacePage = ({
     () => sessions.find((session) => session.id === selectedSessionId),
     [selectedSessionId, sessions]
   )
+  const activeSessionHasSendPreparation = activeSession
+    ? sendPreparationInFlightSessionIds.includes(activeSession.id)
+    : false
   const activeSessionHasRuntimeInteraction = activeSession
-    ? promptInFlightSessionIds.includes(activeSession.id)
+    ? promptInFlightSessionIds.includes(activeSession.id) || activeSessionHasSendPreparation
     : false
   const visiblePermissionRequests = useMemo(
     () => getVisiblePermissionRequests(pendingPermissions, activeSession?.id),
@@ -360,7 +367,7 @@ const WorkspacePage = ({
   })
   const handleReviewUpdate = useReviewStore((state) => state.handleReviewUpdate)
   // Composer controls follow only the selected session and persistence readiness.
-  const canEditDraft = isSessionPersistenceReady
+  const canEditDraft = isSessionPersistenceReady && !activeSessionHasSendPreparation
   const isUploadingAttachments = attachmentTransfers.some(
     (transfer) =>
       transfer.status === 'queued' ||
@@ -973,6 +980,10 @@ const WorkspacePage = ({
       }
     }
 
+    const sendRequestKey = activeSession?.id ?? NEW_CONVERSATION_DRAFT_KEY
+    if (sendRequestsInFlightRef.current.has(sendRequestKey)) return
+    sendRequestsInFlightRef.current.add(sendRequestKey)
+
     const doc = draftDoc
     const attachmentsForSend = attachments
     // Capture new-conversation intent before send: auto-review defaults off, so only an explicit
@@ -1006,35 +1017,33 @@ const WorkspacePage = ({
         forcedSkillIds,
         // New-conversation only: the UUID is forwarded to createSession; main process reads latest Profile.
         specialistId: draftSpecialistId
-      }).then((result) => {
-        // Adoption-in-progress duplicate submits are deliberately suppressed. The original send owns
-        // this draft, so restoring it here would make the already-sent prompt appear unsent again.
-        if (result === null) return
-
-        if (!result) {
-          setDraftDoc(doc)
-          setAttachments(attachmentsForSend)
-          return
-        }
-
-        // Carry the composer's auto-review choice onto the freshly created session. bindPendingSession
-        // preserves the field, so stamping the (pending) session id here survives the durable-id swap.
-        if (wasNewConversation && draftAutoReviewEnabled) {
-          setAutoReviewEnabled(result.sessionId, true)
-        }
-        // Carry the draft compute host selection onto the newly created session.
-        if (wasNewConversation && draftEnabledComputeHosts.length > 0) {
-          setEnabledComputeHosts(result.sessionId, draftEnabledComputeHosts)
-          void window.api.compute
-            .enabledHostsSet(result.sessionId, draftEnabledComputeHosts)
-            .catch((err: unknown) => {
-              console.warn('Failed to sync draft compute hosts to registry for new session', err)
-            })
-        }
-        setNewConversationAutoReviewEnabled(false)
-        setNewConversationEnabledComputeHosts([])
-        setNewConversationSpecialistId(undefined)
       })
+        .then((result) => {
+          if (!result) {
+            setDraftDoc(doc)
+            setAttachments(attachmentsForSend)
+            return
+          }
+
+          // Carry the composer's auto-review choice onto the freshly created session. bindPendingSession
+          // preserves the field, so stamping the (pending) session id here survives the durable-id swap.
+          if (wasNewConversation && draftAutoReviewEnabled) {
+            setAutoReviewEnabled(result.sessionId, true)
+          }
+          // Carry the draft compute host selection onto the newly created session.
+          if (wasNewConversation && draftEnabledComputeHosts.length > 0) {
+            setEnabledComputeHosts(result.sessionId, draftEnabledComputeHosts)
+            void window.api.compute
+              .enabledHostsSet(result.sessionId, draftEnabledComputeHosts)
+              .catch((err: unknown) => {
+                console.warn('Failed to sync draft compute hosts to registry for new session', err)
+              })
+          }
+          setNewConversationAutoReviewEnabled(false)
+          setNewConversationEnabledComputeHosts([])
+          setNewConversationSpecialistId(undefined)
+        })
+        .finally(() => sendRequestsInFlightRef.current.delete(sendRequestKey))
     }
 
     // Runs the reconfigure barrier then dispatches the send on success. Extracted so that both the
@@ -1075,6 +1084,7 @@ const WorkspacePage = ({
           next.delete(sessionId)
           return next
         })
+        sendRequestsInFlightRef.current.delete(sendRequestKey)
         return
       }
 

--- a/src/renderer/src/pages/workspace/WorkspacePage.tsx
+++ b/src/renderer/src/pages/workspace/WorkspacePage.tsx
@@ -251,6 +251,17 @@ const WorkspacePage = ({
     >
   >({})
   const previousDraftKeyRef = useRef<string>(selectedSessionId ?? NEW_CONVERSATION_DRAFT_KEY)
+  // Tracks user-authored mutations separately from optimistic send clearing and conversation switches.
+  // A failed prepared send may restore its captured draft only if this version has not advanced.
+  const composerDraftVersionsRef = useRef<Record<string, number>>({})
+  const markComposerDraftChanged = (draftKey = previousDraftKeyRef.current): void => {
+    composerDraftVersionsRef.current[draftKey] =
+      (composerDraftVersionsRef.current[draftKey] ?? 0) + 1
+  }
+  const changeComposerDraftDoc = (doc: ComposerDoc): void => {
+    markComposerDraftChanged()
+    setDraftDoc(doc)
+  }
   const [attachments, setAttachments] = useState<UploadedAttachment[]>([])
   const [attachmentTransfers, setAttachmentTransfers] = useState<ComposerUploadTransfer[]>([])
   const attachmentTransfersRef = useRef<ComposerUploadTransfer[]>([])
@@ -795,6 +806,7 @@ const WorkspacePage = ({
     if (accepted.length === 0) return
 
     const draftKey = previousDraftKeyRef.current
+    markComposerDraftChanged(draftKey)
     const pending = accepted.map(
       (file, index): { file: File; transfer: ComposerUploadTransfer } => {
         const name = getUploadFilename(file, index)
@@ -888,6 +900,7 @@ const WorkspacePage = ({
 
   const cancelAttachmentTransfer = (transfer: ComposerUploadTransfer): void => {
     const draftKey = previousDraftKeyRef.current
+    markComposerDraftChanged(draftKey)
     cancelledAttachmentTransfersRef.current.add(transfer.transferId)
     attachmentTransferControllersRef.current[transfer.transferId]?.abort()
     updateDraftTransfers(draftKey, (transfers) =>
@@ -909,6 +922,7 @@ const WorkspacePage = ({
 
   // Removes one staged attachment from both local UI state and managed upload storage.
   const removeComposerAttachment = (attachment: UploadedAttachment): void => {
+    markComposerDraftChanged()
     setAttachments((currentAttachments) =>
       currentAttachments.filter((item) => item.id !== attachment.id)
     )
@@ -983,6 +997,7 @@ const WorkspacePage = ({
     const sendRequestKey = activeSession?.id ?? NEW_CONVERSATION_DRAFT_KEY
     if (sendRequestsInFlightRef.current.has(sendRequestKey)) return
     sendRequestsInFlightRef.current.add(sendRequestKey)
+    const sendDraftVersion = composerDraftVersionsRef.current[sendRequestKey] ?? 0
 
     const doc = draftDoc
     const attachmentsForSend = attachments
@@ -1020,18 +1035,24 @@ const WorkspacePage = ({
       })
         .then((result) => {
           if (!result) {
-            if (previousDraftKeyRef.current === sendRequestKey) {
-              setDraftDoc(doc)
-              setAttachments(attachmentsForSend)
-            } else {
-              // Preparation can fail after the user selects another conversation. Restore the captured
-              // draft to its original key without replacing the newly selected composer's live state.
-              composerDraftsRef.current[sendRequestKey] = {
-                doc,
-                attachments: attachmentsForSend,
-                attachmentTransfers:
-                  composerDraftsRef.current[sendRequestKey]?.attachmentTransfers ?? []
+            // A newer edit on the same draft key wins over this failed request. Otherwise restore the
+            // captured draft either to the active composer or to its inactive conversation slot.
+            if ((composerDraftVersionsRef.current[sendRequestKey] ?? 0) === sendDraftVersion) {
+              if (previousDraftKeyRef.current === sendRequestKey) {
+                setDraftDoc(doc)
+                setAttachments(attachmentsForSend)
+              } else {
+                composerDraftsRef.current[sendRequestKey] = {
+                  doc,
+                  attachments: attachmentsForSend,
+                  attachmentTransfers:
+                    composerDraftsRef.current[sendRequestKey]?.attachmentTransfers ?? []
+                }
               }
+            } else {
+              // The user replaced this draft while preparation was pending. Keep that newer intent and
+              // discard staged files that now belong only to the superseded failed request.
+              deleteAttachmentFiles(attachmentsForSend)
             }
             return
           }
@@ -1461,7 +1482,7 @@ const WorkspacePage = ({
             onCompactContext={compactActiveContext}
             canChangePermissionProfile={canChangePermissionProfile}
             autoReviewEnabled={activeAutoReviewEnabled}
-            onDraftDocChange={setDraftDoc}
+            onDraftDocChange={changeComposerDraftDoc}
             onSendMessage={sendCurrentMessage}
             onStageAttachmentFiles={stageAttachmentFiles}
             onRemoveAttachment={removeComposerAttachment}

--- a/src/renderer/src/pages/workspace/WorkspacePage.tsx
+++ b/src/renderer/src/pages/workspace/WorkspacePage.tsx
@@ -1007,6 +1007,10 @@ const WorkspacePage = ({
         // New-conversation only: the UUID is forwarded to createSession; main process reads latest Profile.
         specialistId: draftSpecialistId
       }).then((result) => {
+        // Adoption-in-progress duplicate submits are deliberately suppressed. The original send owns
+        // this draft, so restoring it here would make the already-sent prompt appear unsent again.
+        if (result === null) return
+
         if (!result) {
           setDraftDoc(doc)
           setAttachments(attachmentsForSend)

--- a/src/renderer/src/pages/workspace/WorkspacePage.tsx
+++ b/src/renderer/src/pages/workspace/WorkspacePage.tsx
@@ -1020,8 +1020,19 @@ const WorkspacePage = ({
       })
         .then((result) => {
           if (!result) {
-            setDraftDoc(doc)
-            setAttachments(attachmentsForSend)
+            if (previousDraftKeyRef.current === sendRequestKey) {
+              setDraftDoc(doc)
+              setAttachments(attachmentsForSend)
+            } else {
+              // Preparation can fail after the user selects another conversation. Restore the captured
+              // draft to its original key without replacing the newly selected composer's live state.
+              composerDraftsRef.current[sendRequestKey] = {
+                doc,
+                attachments: attachmentsForSend,
+                attachmentTransfers:
+                  composerDraftsRef.current[sendRequestKey]?.attachmentTransfers ?? []
+              }
+            }
             return
           }
 

--- a/src/renderer/src/pages/workspace/workspace-tool-activity-details.test.ts
+++ b/src/renderer/src/pages/workspace/workspace-tool-activity-details.test.ts
@@ -645,6 +645,22 @@ describe('workspace tool activity details', () => {
     expect(details?.sections[0]?.kind === 'code' && details.sections[0].text).not.toContain('a,b')
   })
 
+  it('does not classify artifact-file lookalikes as managed writes', () => {
+    const activity = createActivity({
+      providerToolName: 'delete_artifact_file',
+      toolKind: 'other',
+      title: 'Delete artifact file',
+      rawInput: { filename: 'obsolete.csv' },
+      rawOutput: { deleted: true }
+    })
+
+    const details = buildToolActivityDetails(activity)
+
+    expect(details?.displayName).toBe('delete_artifact_file')
+    expect(details?.sections.map((section) => section.label)).toEqual(['Input', 'Output'])
+    expect(details?.sections[1]?.kind === 'code' && details.sections[1].text).toContain('deleted')
+  })
+
   it('summarizes a Codex artifact receipt envelope when the MCP identity is only in the title', () => {
     const artifactReceipt = {
       artifact: {

--- a/src/renderer/src/pages/workspace/workspace-tool-activity-details.test.ts
+++ b/src/renderer/src/pages/workspace/workspace-tool-activity-details.test.ts
@@ -645,6 +645,47 @@ describe('workspace tool activity details', () => {
     expect(details?.sections[0]?.kind === 'code' && details.sections[0].text).not.toContain('a,b')
   })
 
+  it('summarizes a Codex artifact receipt envelope when the MCP identity is only in the title', () => {
+    const artifactReceipt = {
+      artifact: {
+        artifact_id: 'bfa741b1-2088-42b0-b075-812a640e1ec6',
+        version_id: 'de3cfa20-2cea-4f8a-87cd-7b482410e0ed',
+        version_number: 1,
+        filename: 'sin.png',
+        content_type: 'image/png',
+        size_bytes: 41671,
+        checksum: '75e5991b3bac5025d01ae83eb0d85fab922153411edb8d19859f728528f20a68',
+        producer_run_id: 'notebook-run-1785397616378-1',
+        environment: 'default-python'
+      }
+    }
+    const activity = createActivity({
+      toolKind: 'execute',
+      title: 'mcp.open-science-artifacts.write_artifact_file',
+      rawOutput: {
+        result: {
+          content: [{ type: 'text', text: JSON.stringify(artifactReceipt) }],
+          structuredContent: null,
+          _meta: null
+        },
+        error: null
+      }
+    })
+    const details = buildToolActivityDetails(activity)
+
+    expect(details?.displayName).toBe('Write file')
+    expect(details?.subtitle).toBe('sin.png')
+    expect(details?.metaLabel).toBe('41 KB')
+    expect(details?.sections.map((section) => section.label)).toEqual(['File'])
+    expect(details?.sections[0]?.kind === 'code' && details.sections[0].text).toContain('sin.png')
+    expect(details?.sections[0]?.kind === 'code' && details.sections[0].text).not.toContain(
+      'artifact_id'
+    )
+    expect(details?.sections[0]?.kind === 'code' && details.sections[0].text).not.toContain(
+      'structuredContent'
+    )
+  })
+
   it('renders a WebFetch with its URL, prompt, and fetched result', () => {
     const activity = createActivity({
       providerToolName: 'WebFetch',

--- a/src/renderer/src/pages/workspace/workspace-tool-activity-details.ts
+++ b/src/renderer/src/pages/workspace/workspace-tool-activity-details.ts
@@ -379,7 +379,7 @@ const buildGenericDetails = (activity: ToolActivity): ToolActivityDetails | unde
   }
 }
 
-const ARTIFACT_WRITE_ACTIVITY_TITLES = new Set([
+const ARTIFACT_WRITE_ACTIVITY_IDENTITIES = new Set([
   'write_artifact_file',
   'write artifact file',
   'save_artifacts',
@@ -396,10 +396,8 @@ const isArtifactWriteActivity = (activity: ToolActivity): boolean => {
   const title = trimDetail(activity.title)?.toLowerCase() ?? ''
 
   return (
-    providerName === 'save_artifacts' ||
-    providerName.includes('artifact_file') ||
-    providerName.includes('write_artifact') ||
-    ARTIFACT_WRITE_ACTIVITY_TITLES.has(title)
+    ARTIFACT_WRITE_ACTIVITY_IDENTITIES.has(providerName) ||
+    ARTIFACT_WRITE_ACTIVITY_IDENTITIES.has(title)
   )
 }
 

--- a/src/renderer/src/pages/workspace/workspace-tool-activity-details.ts
+++ b/src/renderer/src/pages/workspace/workspace-tool-activity-details.ts
@@ -379,14 +379,27 @@ const buildGenericDetails = (activity: ToolActivity): ToolActivityDetails | unde
   }
 }
 
+const ARTIFACT_WRITE_ACTIVITY_TITLES = new Set([
+  'write_artifact_file',
+  'write artifact file',
+  'save_artifacts',
+  'mcp__open-science-artifacts__write_artifact_file',
+  'mcp__open_science_artifacts__write_artifact_file',
+  'mcp.open-science-artifacts.write_artifact_file',
+  'open-science-artifacts_write_artifact_file',
+  'open_science_artifacts_write_artifact_file'
+])
+
 // Detects the managed artifact-writing MCP tool (open-science-artifacts / write_artifact_file).
 const isArtifactWriteActivity = (activity: ToolActivity): boolean => {
   const providerName = trimDetail(activity.providerToolName)?.toLowerCase() ?? ''
+  const title = trimDetail(activity.title)?.toLowerCase() ?? ''
 
   return (
     providerName === 'save_artifacts' ||
     providerName.includes('artifact_file') ||
-    providerName.includes('write_artifact')
+    providerName.includes('write_artifact') ||
+    ARTIFACT_WRITE_ACTIVITY_TITLES.has(title)
   )
 }
 
@@ -417,19 +430,49 @@ const isEditActivity = (activity: ToolActivity): boolean => {
   return EDIT_PROVIDER_TOOL_NAMES.has(providerName)
 }
 
-// Reads the artifact metadata the MCP tool echoes back as `{ "artifact": { … } }` JSON output.
-const extractArtifactOutput = (activity: ToolActivity): Record<string, unknown> | undefined => {
-  for (const text of collectToolTexts(activity)) {
-    try {
-      const parsed: unknown = JSON.parse(text)
+// Finds an Artifact receipt in direct JSON, MCP content blocks, or a Codex bridge result envelope.
+const extractArtifactRecord = (value: unknown, depth = 0): Record<string, unknown> | undefined => {
+  if (depth > 4) return undefined
 
-      if (isRecord(parsed) && isRecord(parsed.artifact)) return parsed.artifact
+  if (typeof value === 'string') {
+    try {
+      return extractArtifactRecord(JSON.parse(value) as unknown, depth + 1)
     } catch {
-      // Not a JSON payload; keep scanning the remaining content blocks.
+      return undefined
+    }
+  }
+
+  if (!isRecord(value)) return undefined
+  if (isRecord(value.artifact)) return value.artifact
+
+  for (const nested of [value.result, value.structuredContent]) {
+    const artifact = extractArtifactRecord(nested, depth + 1)
+
+    if (artifact) return artifact
+  }
+
+  if (Array.isArray(value.content)) {
+    for (const block of value.content) {
+      if (!isRecord(block) || block.type !== 'text' || typeof block.text !== 'string') continue
+
+      const artifact = extractArtifactRecord(block.text, depth + 1)
+
+      if (artifact) return artifact
     }
   }
 
   return undefined
+}
+
+// Reads the artifact metadata the MCP tool echoes back as `{ "artifact": { … } }` JSON output.
+const extractArtifactOutput = (activity: ToolActivity): Record<string, unknown> | undefined => {
+  for (const text of collectToolTexts(activity)) {
+    const artifact = extractArtifactRecord(text)
+
+    if (artifact) return artifact
+  }
+
+  return extractArtifactRecord(activity.rawOutput)
 }
 
 // Reads a trimmed string field from an optional record without leaking non-string values.
@@ -439,14 +482,34 @@ const getRecordString = (
 ): string | undefined =>
   record && typeof record[key] === 'string' ? trimDetail(record[key] as string) : undefined
 
+// Reads the first finite numeric field from one of the supported receipt spellings.
+const getRecordNumber = (
+  record: Record<string, unknown> | undefined,
+  ...keys: string[]
+): number | undefined => {
+  for (const key of keys) {
+    const value = record?.[key]
+
+    if (typeof value === 'number' && Number.isFinite(value)) return value
+  }
+
+  return undefined
+}
+
 // Summarizes a saved artifact file (name/type/size/path) without echoing its raw content payload.
 const buildArtifactDetails = (activity: ToolActivity): ToolActivityDetails | undefined => {
   const rawInput = isRecord(activity.rawInput) ? activity.rawInput : undefined
   const output = extractArtifactOutput(activity)
-  const filename = getRecordString(rawInput, 'filename') ?? getRecordString(output, 'name')
-  const mimeType = getRecordString(rawInput, 'mimeType') ?? getRecordString(output, 'mimeType')
+  const filename =
+    getRecordString(rawInput, 'filename') ??
+    getRecordString(output, 'name') ??
+    getRecordString(output, 'filename')
+  const mimeType =
+    getRecordString(rawInput, 'mimeType') ??
+    getRecordString(output, 'mimeType') ??
+    getRecordString(output, 'content_type')
   const path = getRecordString(output, 'path')
-  const size = typeof output?.size === 'number' ? output.size : undefined
+  const size = getRecordNumber(output, 'size', 'size_bytes')
   const sizeLabel = formatByteSize(size)
 
   if (!filename && !path) return undefined


### PR DESCRIPTION
## Problem

Switching an existing ACP session between Codex and Claude Code could let late session-scoped events from the draining runtime appear under the newly selected framework. This made Codex-style MCP activity look as though it had been invoked by Claude Code. The optimistic prompt created during the switch could also retain the previous runtime segment, and Codex artifact bridge receipts fell back to the generic Terminal/Command/Output presentation.

## Proposed change

- publish session-scoped runtime events only from the runtime generation that currently owns the session
- keep the draining runtime authoritative until asynchronous adoption succeeds and its prior active turn clears, then commit ownership to the selected runtime
- revalidate the incoming runtime after the prior turn drains so a retired or superseded adopter cannot acquire session ownership
- retain events admitted before ownership commits in the bounded runtime snapshot, while rejecting future stale events emitted by the old runtime
- commit the selected runtime's current connection status together with session ownership after adoption
- expose per-session runtime preparation state so the workspace blocks draft edits, sends, and message edits throughout adoption or Branch reset
- guard submissions synchronously by draft/session key so a second prompt cannot be dispatched or cleared before the reactive preparation lock renders
- restore a failed prepared send to its originating draft key when the user has selected another conversation
- version user-authored composer mutations so delayed failure restoration cannot overwrite newer intent in the same conversation
- restore interrupted and overflow-recovery user turns when replacement-send preparation fails, without rolling back newer runtime failure metadata
- preserve delayed Artifact finalization through explicit run/prompt provenance after ownership changes
- bind the next optimistic prompt to the selected framework and backend when that runtime adopts the session
- guarantee Branch isolation on attached, detached, and cross-runtime continuations: detached or changed runtimes adopt first, then reset the selected owner unless resume proves the context is already fresh
- recognize artifact-write MCP identities across provider naming conventions and summarize nested Codex bridge receipts as file activity without exposing internal receipt fields
- add regression coverage for runtime handoff, adoption failure, draining terminal events, Branch reset ownership, prompt provenance, preparation-state gating, newer-draft preservation, and artifact receipt presentation

## Scope and non-goals

- Session-less discovery events and events from the current owner remain publishable.
- This does not register unavailable MCP tools or change permission policy; a genuine `No such tool available` response remains a separate tool-registration/configuration issue.
- This does not change artifact persistence or add inline preview data when a receipt does not include a path.

## Acceptance criteria and validation

All change-specific checks below ran after the final material edit and passed.

- draining-runtime events, including terminal `stop`/`error` arriving after the incoming provider attaches, stay on the prior owner until its active prompt clears; events already admitted before ownership commits remain in subsequent bounded snapshots, post-adoption old-runtime events are absent, and fresh selected-runtime events publish
- the incoming optimistic run is not created until adoption succeeds, so a draining terminal event cannot settle the new Runtime Segment
- runtime preparation is reflected in the workspace UI, and the synchronous request guard preserves a different newer draft without issuing a duplicate runtime call
- a failed prepared send restores its doc and attachments to the original conversation without replacing a newly selected conversation's live draft
- a newer same-conversation draft wins over delayed failure restoration, and staged files belonging only to the superseded request are cleaned up
- interrupted and overflow-recovery retries restore their removed user turn and conversation graph when shared send preparation returns unsent; a later retry does not redundantly resume an already attached provider
- failed adoption leaves the prior runtime authoritative
- an incoming runtime that retires or is superseded while the prior turn drains is rejected before ownership commits
- successful adoption replaces any stale draining-runtime connection status, preventing later ordinary failures from being misclassified as disconnects
- delayed Artifact finalization remains publishable through the completed handoff
- the first switched prompt points at the selected framework/backend runtime segment
- a Branch continuation resets the attached selected runtime directly, or adopts a detached/changed runtime and resets the newly selected owner when resume reports `contextReset: false`
- a nested Codex artifact receipt renders as `Write file`, filename, and size without raw bridge metadata
- related coordinator, renderer runtime, composer, job-analysis, and tool-detail coverage -> six Vitest files -> 187 passed
- isolated repository verification after the final commit -> macOS, Ubuntu, and Windows PR Verify jobs passed
- TypeScript contracts remain valid -> `npm run typecheck` -> passed
- repository lint gate -> `npm run lint` -> passed with 0 errors (24 existing warnings)
- changed-file formatting and patch hygiene -> Prettier check and `git diff --check` -> passed

## Review focus

- Ownership commits only after `resumeSession` resolves and the prior owner's active prompt clears. Intermediate attached-state emissions from the incoming runtime do not steal routing, and a late old-runtime terminal event settles before the renderer can append the selected runtime's turn.
- The incoming runtime must still be registered, non-retired, and the pending adopter after the old-turn drain before ownership can commit.
- Ownership and the adopted runtime's connection status commit atomically; an old session-id status is removed when a provider remaps the id.
- Events admitted while a runtime owns the session are remembered per runtime and retained only for that runtime's bounded snapshot window. Events first emitted after ownership transfers are still filtered.
- The renderer resumes before creating the new optimistic run, so draining terminal events can settle the prior Runtime Segment safely.
- Runtime adoption and Branch reset publish a per-session preparation lock. A synchronous request guard closes the pre-render gap without conflating intentional suppression with send failure.
- Per-draft mutation versions distinguish the request's optimistic clear from later user edits, including attachment intake and removal, before any failed request restores captured state.
- Retry flows snapshot the transcript, conversation graph, and files revision before removing the unanswered turn, restoring that projection if preparation fails while retaining current runtime/error state.
- Detached same-runtime Branch continuations adopt before resetting, ensuring `resetSessionContext` targets the selected coordinator owner; cross-runtime continuations follow the same ownership-safe order.
- Artifact lifecycle events bypass owner filtering after a committed handoff because their explicit run/prompt/claim provenance safely finalizes the prior turn.
- Artifact receipt parsing is bounded and only activates for known artifact-write tool identities.

## Uncovered risk

The runtime handoff is covered with coordinator fakes rather than a live Claude Code/Codex dual-process end-to-end test.

Retained control-flow events remain unresolved: an admitted old-runtime `context-overflow` or compaction event can stay in coordinator snapshots after ownership changes, then re-trigger recovery when renderer-local deduplication resets on remount. These events should not use the sticky display/history retention path.
