### PR TITLE
fix(files): show filter menu and tooltips above the expanded files modal

### DIFF
--- a/src/renderer/src/pages/workspace/ProjectFilesView.tsx
+++ b/src/renderer/src/pages/workspace/ProjectFilesView.tsx
@@ -826,7 +826,11 @@ const ProjectFilesFilterMenu = ({
           />
         </Button>
       </DropdownMenuTrigger>
-      <DropdownMenuContent align="start" className="max-h-[360px] w-[320px] overflow-y-auto">
+      <DropdownMenuContent
+        align="start"
+        // The expanded files modal stacks at z-[56]; keep portaled popovers above it.
+        className="z-[70] max-h-[360px] w-[320px] overflow-y-auto"
+      >
         <DropdownMenuLabel>Artifacts</DropdownMenuLabel>
         <DropdownMenuGroup>
           {fixedOptions.map((option) => (
@@ -1495,7 +1499,7 @@ const ProjectFilesViewContent = ({
                     <LayoutGrid className="size-3.5" strokeWidth={1.8} aria-hidden="true" />
                   </ToggleGroup.Item>
                 </TooltipTrigger>
-                <TooltipContent>Grid view</TooltipContent>
+                <TooltipContent className="z-[70]">Grid view</TooltipContent>
               </Tooltip>
               <Tooltip>
                 <TooltipTrigger asChild>
@@ -1507,7 +1511,7 @@ const ProjectFilesViewContent = ({
                     <List className="size-3.5" strokeWidth={1.8} aria-hidden="true" />
                   </ToggleGroup.Item>
                 </TooltipTrigger>
-                <TooltipContent>List view</TooltipContent>
+                <TooltipContent className="z-[70]">List view</TooltipContent>
               </Tooltip>
             </ToggleGroup.Root>
             <Tooltip>
@@ -1568,7 +1572,7 @@ const ProjectFilesViewContent = ({
                     <X className="size-3.5" strokeWidth={2} aria-hidden="true" />
                   </Button>
                 </TooltipTrigger>
-                <TooltipContent>Clear search</TooltipContent>
+                <TooltipContent className="z-[70]">Clear search</TooltipContent>
               </Tooltip>
             </TooltipProvider>
           ) : null}


### PR DESCRIPTION
## Summary

Follow-up to #510. In the expanded files modal, clicking the Artifacts filter button did not show the dropdown menu. Portaled popovers (Radix dropdown menus and tooltips) default to `z-50`, while the expanded files surface stacks at `z-[56]` (overlay `z-[55]`), so the menu painted behind the modal and was invisible. The header tooltips (grid/list view, clear search) had the same latent problem.

## Highlights

- The Artifacts filter dropdown now opens correctly inside the expanded files modal; header tooltips also display there.

## Impact

- Usage-local `z-[70]` on the files view's filter `DropdownMenuContent` and three header `TooltipContent`s, matching the existing popover convention (`PreviewFileSurface` dropdown/tooltips, `FileBrowserModal`). The inline panel layout is unaffected, and `FilePreviewDialog` (`z-[60]`) stacking from within the modal is unchanged.
- No component defaults changed; no data or API changes.

## Test Results

- [x] `vitest run` on `PreviewPanel.test.tsx` and `preview-workbench-store.test.ts` — 37 tests passed
- [x] `npm run typecheck`
- [x] `npm run lint`
- [x] Headless web build + Playwright: expanded the files modal, opened the Artifacts filter (menu visible at `z-70`, options selectable), verified header tooltip renders above the modal

## Potential Issues

- None identified; the z-index bump is scoped to the files view usages only.

## Authors

- Roxi (@roxi3906)