### PR TITLE
fix(session-persistence): prevent stale Artifact session saves

### DIFF
--- a/src/main/artifacts/provenance-message-snapshot.test.ts
+++ b/src/main/artifacts/provenance-message-snapshot.test.ts
@@ -159,6 +159,17 @@ describe('Provenance Message snapshots', () => {
       getClient: () => Promise.resolve(client)
     })
 
+    const staleSession = structuredClone(session)
+    if (!staleSession.conversationGraph) {
+      throw new Error('Expected the Session conversation graph.')
+    }
+    staleSession.conversationGraph.branches[0].headMessageId = 'prompt-1'
+    staleSession.messages = staleSession.messages.filter((message) => message.id === 'prompt-1')
+    await expect(snapshots.validateFinalizedMessageBindings(staleSession)).rejects.toThrow(
+      'Artifact-owning Message is outside its bound Branch.'
+    )
+    await expect(snapshots.validateFinalizedMessageBindings(session)).resolves.toBeUndefined()
+
     const streamingSession = structuredClone(session)
     const streamingMessage = streamingSession.conversationGraph?.messages.find(
       (message) => message.id === 'message-1'
@@ -189,6 +200,10 @@ describe('Provenance Message snapshots', () => {
       messageCount: 2,
       checksum: expect.stringMatching(/^[a-f0-9]{64}$/u)
     })
+    await expect(snapshots.validateFinalizedMessageBindings(staleSession)).rejects.toThrow(
+      'Artifact-owning Message is outside its bound Branch.'
+    )
+    await expect(snapshots.validateFinalizedMessageBindings(session)).resolves.toBeUndefined()
     const read = await provenance.getVersionProvenance({
       projectId: 'project-1',
       appSessionId: 'session-1',

--- a/src/main/artifacts/provenance-message-snapshot.test.ts
+++ b/src/main/artifacts/provenance-message-snapshot.test.ts
@@ -2,7 +2,7 @@ import { createHash } from 'node:crypto'
 import { mkdir, mkdtemp, readFile, rm, writeFile } from 'node:fs/promises'
 import { tmpdir } from 'node:os'
 import { dirname, join } from 'node:path'
-import { afterEach, describe, expect, it } from 'vitest'
+import { afterEach, describe, expect, it, vi } from 'vitest'
 
 import {
   createLinearConversationGraph,
@@ -158,6 +158,7 @@ describe('Provenance Message snapshots', () => {
       storageRoot,
       getClient: () => Promise.resolve(client)
     })
+    const findVersions = vi.spyOn(client.artifactVersion, 'findMany')
 
     const staleSession = structuredClone(session)
     if (!staleSession.conversationGraph) {
@@ -167,6 +168,16 @@ describe('Provenance Message snapshots', () => {
     staleSession.messages = staleSession.messages.filter((message) => message.id === 'prompt-1')
     await expect(snapshots.validateFinalizedMessageBindings(staleSession)).rejects.toThrow(
       'Artifact-owning Message is outside its bound Branch.'
+    )
+    expect(findVersions).toHaveBeenLastCalledWith(
+      expect.objectContaining({
+        select: {
+          rootFrameId: true,
+          agentFrameId: true,
+          messageBranchId: true,
+          messageId: true
+        }
+      })
     )
     await expect(snapshots.validateFinalizedMessageBindings(session)).resolves.toBeUndefined()
 

--- a/src/main/artifacts/provenance-message-snapshot.ts
+++ b/src/main/artifacts/provenance-message-snapshot.ts
@@ -125,6 +125,34 @@ class ProvenanceMessageSnapshotRepository {
     this.now = options.now ?? (() => new Date())
   }
 
+  async validateFinalizedMessageBindings(input: PersistedChatSession): Promise<void> {
+    const session = materializeSessionConversationGraph(input)
+    if (!session.conversationGraph) throw new Error('Session conversation graph is unavailable.')
+    const client = await this.options.getClient()
+    const versions = await client.artifactVersion.findMany({
+      where: {
+        state: 'finalized',
+        messageId: { not: null },
+        artifact: { is: { projectId: session.projectId, sessionId: session.id } }
+      }
+    })
+    const scopes = new Map<string, (typeof versions)[number]>()
+    for (const version of versions) {
+      if (!version.messageId) continue
+      scopes.set(
+        [
+          version.rootFrameId,
+          version.agentFrameId,
+          version.messageBranchId,
+          version.messageId
+        ].join('\0'),
+        version
+      )
+    }
+
+    for (const version of scopes.values()) this.resolveScopePath(session, version)
+  }
+
   async captureFinalizedMessages(input: PersistedChatSession): Promise<void> {
     const session = materializeSessionConversationGraph(input)
     const graph = session.conversationGraph
@@ -601,18 +629,9 @@ class ProvenanceMessageSnapshotRepository {
       messageId: string | null
     }
   ): Promise<void> {
-    if (!version.messageId || !session.conversationGraph) return
-    if (session.conversationGraph.rootFrameId !== version.rootFrameId) {
-      throw new Error('Artifact Message snapshot root Frame does not match the Session graph.')
-    }
-    const branch = session.conversationGraph.branches.find(
-      (candidate) =>
-        candidate.id === version.messageBranchId && candidate.agentFrameId === version.agentFrameId
-    )
-    if (!branch) throw new Error('Artifact Message snapshot Branch is unavailable.')
-    const fullPath = resolveMessageBranchPath(session.conversationGraph, branch.id)
-    const terminalIndex = fullPath.findIndex((message) => message.id === version.messageId)
-    if (terminalIndex < 0) throw new Error('Artifact-owning Message is outside its bound Branch.')
+    const scope = this.resolveScopePath(session, version)
+    if (!scope || !version.messageId || !session.conversationGraph) return
+    const { fullPath, terminalIndex } = scope
     if (fullPath[terminalIndex]?.status === 'streaming') {
       // Artifact finalization may precede the assistant's final text chunks. Session autosave runs
       // during that window, but an immutable snapshot must wait for the owning Message to reach a
@@ -742,6 +761,30 @@ class ProvenanceMessageSnapshotRepository {
         data: { messageSnapshotId: snapshotId }
       })
     })
+  }
+
+  private resolveScopePath(
+    session: PersistedChatSession,
+    version: {
+      rootFrameId: string
+      agentFrameId: string
+      messageBranchId: string
+      messageId: string | null
+    }
+  ): { fullPath: PersistedMessageNode[]; terminalIndex: number } | undefined {
+    if (!version.messageId || !session.conversationGraph) return undefined
+    if (session.conversationGraph.rootFrameId !== version.rootFrameId) {
+      throw new Error('Artifact Message snapshot root Frame does not match the Session graph.')
+    }
+    const branch = session.conversationGraph.branches.find(
+      (candidate) =>
+        candidate.id === version.messageBranchId && candidate.agentFrameId === version.agentFrameId
+    )
+    if (!branch) throw new Error('Artifact Message snapshot Branch is unavailable.')
+    const fullPath = resolveMessageBranchPath(session.conversationGraph, branch.id)
+    const terminalIndex = fullPath.findIndex((message) => message.id === version.messageId)
+    if (terminalIndex < 0) throw new Error('Artifact-owning Message is outside its bound Branch.')
+    return { fullPath, terminalIndex }
   }
 
   private async linkVersions(

--- a/src/main/artifacts/provenance-message-snapshot.ts
+++ b/src/main/artifacts/provenance-message-snapshot.ts
@@ -31,6 +31,13 @@ type SessionDeletionReceipt =
   | { kind: 'ordinary'; projectId: string; sessionId: string }
   | { kind: 'retained'; projectId: string; sessionId: string; operationId: string }
 
+class FinalizedArtifactBindingConflictError extends Error {
+  constructor(message: string) {
+    super(message)
+    this.name = 'FinalizedArtifactBindingConflictError'
+  }
+}
+
 const storageKey = (...segments: string[]): string => segments.join('/')
 const sha256 = (value: string): string => createHash('sha256').update(value).digest('hex')
 const readOptionalText = async (path: string): Promise<string | undefined> =>
@@ -127,7 +134,9 @@ class ProvenanceMessageSnapshotRepository {
 
   async validateFinalizedMessageBindings(input: PersistedChatSession): Promise<void> {
     const session = materializeSessionConversationGraph(input)
-    if (!session.conversationGraph) throw new Error('Session conversation graph is unavailable.')
+    if (!session.conversationGraph) {
+      throw new FinalizedArtifactBindingConflictError('Session conversation graph is unavailable.')
+    }
     const client = await this.options.getClient()
     const versions = await client.artifactVersion.findMany({
       where: {
@@ -774,16 +783,26 @@ class ProvenanceMessageSnapshotRepository {
   ): { fullPath: PersistedMessageNode[]; terminalIndex: number } | undefined {
     if (!version.messageId || !session.conversationGraph) return undefined
     if (session.conversationGraph.rootFrameId !== version.rootFrameId) {
-      throw new Error('Artifact Message snapshot root Frame does not match the Session graph.')
+      throw new FinalizedArtifactBindingConflictError(
+        'Artifact Message snapshot root Frame does not match the Session graph.'
+      )
     }
     const branch = session.conversationGraph.branches.find(
       (candidate) =>
         candidate.id === version.messageBranchId && candidate.agentFrameId === version.agentFrameId
     )
-    if (!branch) throw new Error('Artifact Message snapshot Branch is unavailable.')
+    if (!branch) {
+      throw new FinalizedArtifactBindingConflictError(
+        'Artifact Message snapshot Branch is unavailable.'
+      )
+    }
     const fullPath = resolveMessageBranchPath(session.conversationGraph, branch.id)
     const terminalIndex = fullPath.findIndex((message) => message.id === version.messageId)
-    if (terminalIndex < 0) throw new Error('Artifact-owning Message is outside its bound Branch.')
+    if (terminalIndex < 0) {
+      throw new FinalizedArtifactBindingConflictError(
+        'Artifact-owning Message is outside its bound Branch.'
+      )
+    }
     return { fullPath, terminalIndex }
   }
 
@@ -891,5 +910,5 @@ class ProvenanceMessageSnapshotRepository {
   }
 }
 
-export { ProvenanceMessageSnapshotRepository }
+export { FinalizedArtifactBindingConflictError, ProvenanceMessageSnapshotRepository }
 export type { ProvenanceMessageSnapshotOptions, SessionDeletionReceipt }

--- a/src/main/artifacts/provenance-message-snapshot.ts
+++ b/src/main/artifacts/provenance-message-snapshot.ts
@@ -143,6 +143,12 @@ class ProvenanceMessageSnapshotRepository {
         state: 'finalized',
         messageId: { not: null },
         artifact: { is: { projectId: session.projectId, sessionId: session.id } }
+      },
+      select: {
+        rootFrameId: true,
+        agentFrameId: true,
+        messageBranchId: true,
+        messageId: true
       }
     })
     const scopes = new Map<string, (typeof versions)[number]>()
@@ -173,6 +179,12 @@ class ProvenanceMessageSnapshotRepository {
         messageId: { not: null },
         messageSnapshotId: null,
         artifact: { is: { projectId: session.projectId, sessionId: session.id } }
+      },
+      select: {
+        rootFrameId: true,
+        agentFrameId: true,
+        messageBranchId: true,
+        messageId: true
       }
     })
     const scopes = new Map<string, (typeof versions)[number]>()

--- a/src/main/ipc.ts
+++ b/src/main/ipc.ts
@@ -692,7 +692,7 @@ const registerIpcHandlers = async ({
         )
         return
       }
-      await sessionPersistenceCoordinator.saveSession({ ...session, specialistId })
+      await sessionPersistenceCoordinator.saveSessionSpecialistBinding(session, specialistId)
     },
     // Apply the switch to the live agent runtime. `runtime` is assigned above (registerAcpIpcHandlers),
     // but the closure is invoked per-request so a late-bound reference is unnecessary.

--- a/src/main/ipc.ts
+++ b/src/main/ipc.ts
@@ -312,11 +312,11 @@ const registerIpcHandlers = async ({
   const sessionPersistenceBackend: SessionPersistenceBackend = {
     loadAll: () =>
       loadSessionsAfterProjectRecovery(projectDeletionCoordinator, sessionPersistenceCoordinator),
-    saveSession: async (session) => {
+    saveSession: async (session, options) => {
       await projectDeletionCoordinator.recoverPendingDeletions()
       const created =
         (await sessionRepository.loadSession(session.projectId, session.id)) === undefined
-      const durableSession = await sessionPersistenceCoordinator.saveSession(session)
+      const durableSession = await sessionPersistenceCoordinator.saveSession(session, options)
       return { created, session: durableSession }
     },
     deleteSession: async (projectId, sessionId) => {

--- a/src/main/session-persistence/coordinator.test.ts
+++ b/src/main/session-persistence/coordinator.test.ts
@@ -361,6 +361,64 @@ describe('SessionPersistenceCoordinator', () => {
     expect(provenance.captureFinalizedMessages).toHaveBeenCalledWith(result)
   })
 
+  it('rebases a specialist binding onto the latest durable graph after a conflict', async () => {
+    const authoritativeSession = createSession({
+      specialistId: 'specialist-old',
+      messages: [
+        {
+          id: 'durable-message',
+          role: 'agent',
+          content: 'Artifact finalized',
+          status: 'complete',
+          eventIds: [],
+          createdAt: 3,
+          updatedAt: 3
+        }
+      ],
+      updatedAt: 3
+    })
+    const submittedSession = createSession({
+      messages: [
+        {
+          id: 'stale-message',
+          role: 'user',
+          content: 'Stale graph',
+          status: 'complete',
+          eventIds: [],
+          createdAt: 1,
+          updatedAt: 1
+        }
+      ],
+      updatedAt: 4
+    })
+    const repository = createSessionRepository({
+      loadSessionWithDiagnostics: vi
+        .fn()
+        .mockResolvedValue({ status: 'found', session: authoritativeSession })
+    })
+    const provenance = createProvenancePersistence({
+      validateFinalizedMessageBindings: vi
+        .fn()
+        .mockRejectedValueOnce(new FinalizedArtifactBindingConflictError('stale graph'))
+        .mockResolvedValue(undefined)
+    })
+    const coordinator = new SessionPersistenceCoordinator(
+      repository,
+      createFileIndex(),
+      undefined,
+      provenance
+    )
+
+    const result = await coordinator.saveSessionSpecialistBinding(
+      submittedSession,
+      'specialist-new'
+    )
+
+    expect(result.specialistId).toBe('specialist-new')
+    expect(result.messages).toEqual(authoritativeSession.messages)
+    expect(repository.saveSession).toHaveBeenCalledWith(result)
+  })
+
   it('restores DB visibility and clears the tombstone when JSON deletion fails', async () => {
     const repository = createSessionRepository({
       deleteSession: vi.fn().mockRejectedValueOnce(new Error('disk locked'))

--- a/src/main/session-persistence/coordinator.test.ts
+++ b/src/main/session-persistence/coordinator.test.ts
@@ -354,7 +354,9 @@ describe('SessionPersistenceCoordinator', () => {
       conflictRebaseFields: ['title', 'pinned']
     })
 
-    expect(result).toMatchObject({ title: 'Local rename', pinned: true, updatedAt: 4 })
+    expect(result).toMatchObject({ title: 'Local rename', pinned: true, updatedAt: 5 })
+    expect(result.updatedAt).toBeGreaterThan(authoritativeSession.updatedAt)
+    expect(result.updatedAt).toBeGreaterThan(submittedSession.updatedAt)
     expect(result.messages).toEqual(authoritativeSession.messages)
     expect(repository.saveSession).toHaveBeenCalledWith(result)
     expect(provenance.validateFinalizedMessageBindings).toHaveBeenCalledTimes(2)

--- a/src/main/session-persistence/coordinator.test.ts
+++ b/src/main/session-persistence/coordinator.test.ts
@@ -222,12 +222,77 @@ describe('SessionPersistenceCoordinator', () => {
       await expect(coordinator.saveSession(createSession())).resolves.toMatchObject({
         id: 'session-1'
       })
+      await expect(
+        coordinator.saveSession(createSession({ title: 'Retry validation' }))
+      ).resolves.toMatchObject({ id: 'session-1' })
     } finally {
       warn.mockRestore()
     }
 
-    expect(repository.saveSession).toHaveBeenCalledOnce()
-    expect(provenance.captureFinalizedMessages).toHaveBeenCalledOnce()
+    expect(provenance.validateFinalizedMessageBindings).toHaveBeenCalledTimes(2)
+    expect(repository.saveSession).toHaveBeenCalledTimes(2)
+    expect(provenance.captureFinalizedMessages).toHaveBeenCalledTimes(2)
+  })
+
+  it('revalidates finalized bindings only when topology or artifact bindings change', async () => {
+    const provenance = createProvenancePersistence()
+    const coordinator = new SessionPersistenceCoordinator(
+      createSessionRepository(),
+      createFileIndex(),
+      undefined,
+      provenance
+    )
+    const firstMessage = {
+      id: 'message-1',
+      role: 'agent' as const,
+      content: 'streaming',
+      status: 'streaming' as const,
+      eventIds: [],
+      createdAt: 1,
+      updatedAt: 1
+    }
+
+    await coordinator.saveSession(createSession({ messages: [firstMessage] }))
+    await coordinator.saveSession(
+      createSession({
+        title: 'Renamed while streaming',
+        messages: [{ ...firstMessage, content: 'more text', updatedAt: 2 }]
+      })
+    )
+
+    expect(provenance.validateFinalizedMessageBindings).toHaveBeenCalledOnce()
+
+    const secondMessage = {
+      id: 'message-2',
+      role: 'user' as const,
+      content: 'continue',
+      status: 'complete' as const,
+      eventIds: [],
+      createdAt: 3,
+      updatedAt: 3
+    }
+    await coordinator.saveSession(
+      createSession({
+        messages: [
+          { ...firstMessage, content: 'complete', status: 'complete', updatedAt: 2 },
+          secondMessage
+        ]
+      })
+    )
+
+    expect(provenance.validateFinalizedMessageBindings).toHaveBeenCalledTimes(2)
+
+    await coordinator.runSessionMutation('project-1', 'session-1', async () => undefined)
+    await coordinator.saveSession(
+      createSession({
+        messages: [
+          { ...firstMessage, content: 'complete', status: 'complete', updatedAt: 2 },
+          { ...secondMessage, content: 'continue after artifact finalization', updatedAt: 4 }
+        ]
+      })
+    )
+
+    expect(provenance.validateFinalizedMessageBindings).toHaveBeenCalledTimes(3)
   })
 
   it('rebases explicitly changed safe fields onto the latest durable graph after a conflict', async () => {

--- a/src/main/session-persistence/coordinator.test.ts
+++ b/src/main/session-persistence/coordinator.test.ts
@@ -9,6 +9,7 @@ import {
   type PersistedChatSession
 } from '../../shared/session-persistence'
 import type { ArtifactProjectReconciliationSnapshot } from '../artifacts/provenance-repository'
+import { FinalizedArtifactBindingConflictError } from '../artifacts/provenance-message-snapshot'
 import { createProjectDbClient, ensureProjectSchema } from '../projects/prisma-client'
 import {
   OrphanLegacyUploadAuthorityMissingError,
@@ -197,6 +198,72 @@ describe('SessionPersistenceCoordinator', () => {
     expect(durableSession.title).toBe('Durable latest')
     expect(repository.saveSession).not.toHaveBeenCalled()
     expect(provenance.captureFinalizedMessages).not.toHaveBeenCalled()
+  })
+
+  it('rebases explicitly changed safe fields onto the latest durable graph after a conflict', async () => {
+    const authoritativeSession = createSession({
+      title: 'Durable latest',
+      pinned: false,
+      messages: [
+        {
+          id: 'durable-message',
+          role: 'agent',
+          content: 'Artifact finalized',
+          status: 'complete',
+          eventIds: [],
+          createdAt: 3,
+          updatedAt: 3
+        }
+      ],
+      updatedAt: 3
+    })
+    const submittedSession = createSession({
+      title: 'Local rename',
+      pinned: true,
+      messages: [
+        {
+          id: 'stale-message',
+          role: 'user',
+          content: 'Stale graph',
+          status: 'complete',
+          eventIds: [],
+          createdAt: 1,
+          updatedAt: 1
+        }
+      ],
+      updatedAt: 4
+    })
+    const repository = createSessionRepository({
+      loadSessionWithDiagnostics: vi
+        .fn()
+        .mockResolvedValue({ status: 'found', session: authoritativeSession })
+    })
+    const provenance = createProvenancePersistence({
+      validateFinalizedMessageBindings: vi
+        .fn()
+        .mockRejectedValueOnce(
+          new FinalizedArtifactBindingConflictError(
+            'Artifact-owning Message is outside its bound Branch.'
+          )
+        )
+        .mockResolvedValue(undefined)
+    })
+    const coordinator = new SessionPersistenceCoordinator(
+      repository,
+      createFileIndex(),
+      undefined,
+      provenance
+    )
+
+    const result = await coordinator.saveSession(submittedSession, {
+      conflictRebaseFields: ['title', 'pinned']
+    })
+
+    expect(result).toMatchObject({ title: 'Local rename', pinned: true, updatedAt: 4 })
+    expect(result.messages).toEqual(authoritativeSession.messages)
+    expect(repository.saveSession).toHaveBeenCalledWith(result)
+    expect(provenance.validateFinalizedMessageBindings).toHaveBeenCalledTimes(2)
+    expect(provenance.captureFinalizedMessages).toHaveBeenCalledWith(result)
   })
 
   it('restores DB visibility and clears the tombstone when JSON deletion fails', async () => {
@@ -511,6 +578,7 @@ describe('SessionPersistenceCoordinator', () => {
     })
     const fileIndex = createFileIndex()
     const provenance = {
+      validateFinalizedMessageBindings: vi.fn().mockResolvedValue(undefined),
       captureFinalizedMessages: vi.fn().mockResolvedValue(undefined),
       reconcileSessionDeletions: vi.fn().mockResolvedValue(undefined),
       prepareSessionDeletion: vi.fn(),

--- a/src/main/session-persistence/coordinator.test.ts
+++ b/src/main/session-persistence/coordinator.test.ts
@@ -171,6 +171,34 @@ describe('SessionPersistenceCoordinator', () => {
     expect(repository.saveSession).toHaveBeenCalledWith(durableSession)
   })
 
+  it('does not overwrite Session JSON when finalized Artifact bindings reject the snapshot', async () => {
+    let durableSession = createSession({ title: 'Durable latest' })
+    const repository = createSessionRepository({
+      saveSession: vi.fn(async (session) => {
+        durableSession = session
+      })
+    })
+    const provenance = createProvenancePersistence({
+      validateFinalizedMessageBindings: vi
+        .fn()
+        .mockRejectedValue(new Error('Artifact-owning Message is outside its bound Branch.'))
+    })
+    const coordinator = new SessionPersistenceCoordinator(
+      repository,
+      createFileIndex(),
+      undefined,
+      provenance
+    )
+
+    await expect(coordinator.saveSession(createSession({ title: 'Queued stale' }))).rejects.toThrow(
+      'Artifact-owning Message is outside its bound Branch.'
+    )
+
+    expect(durableSession.title).toBe('Durable latest')
+    expect(repository.saveSession).not.toHaveBeenCalled()
+    expect(provenance.captureFinalizedMessages).not.toHaveBeenCalled()
+  })
+
   it('restores DB visibility and clears the tombstone when JSON deletion fails', async () => {
     const repository = createSessionRepository({
       deleteSession: vi.fn().mockRejectedValueOnce(new Error('disk locked'))
@@ -200,6 +228,7 @@ describe('SessionPersistenceCoordinator', () => {
     const fileIndex = createFileIndex()
     const onFilesChanged = vi.fn()
     const provenance = {
+      validateFinalizedMessageBindings: vi.fn().mockResolvedValue(undefined),
       captureFinalizedMessages: vi.fn().mockResolvedValue(undefined),
       reconcileSessionDeletions: vi.fn().mockResolvedValue(undefined),
       prepareSessionDeletion: vi.fn().mockResolvedValue({
@@ -298,6 +327,7 @@ describe('SessionPersistenceCoordinator', () => {
       })
     }
     const provenance = {
+      validateFinalizedMessageBindings: vi.fn().mockResolvedValue(undefined),
       captureFinalizedMessages: vi.fn().mockResolvedValue(undefined),
       reconcileSessionDeletions: vi.fn().mockResolvedValue(undefined),
       prepareSessionDeletion: vi.fn(async () => {
@@ -389,6 +419,7 @@ describe('SessionPersistenceCoordinator', () => {
       operationId: 'origin-delete-1'
     }
     const provenance = {
+      validateFinalizedMessageBindings: vi.fn().mockResolvedValue(undefined),
       captureFinalizedMessages: vi.fn().mockResolvedValue(undefined),
       reconcileSessionDeletions: vi.fn().mockResolvedValue(undefined),
       prepareSessionDeletion: vi.fn().mockResolvedValue(receipt),
@@ -1433,6 +1464,7 @@ describe('SessionPersistenceCoordinator', () => {
     const markReconciliationIncomplete = vi.fn()
     const fileIndex = createFileIndex({ markReconciliationIncomplete })
     const provenance = {
+      validateFinalizedMessageBindings: vi.fn(),
       captureFinalizedMessages: vi.fn(),
       reconcileSessionDeletions: vi.fn().mockRejectedValue(new Error('recovery failed')),
       prepareSessionDeletion: vi.fn(),
@@ -2226,6 +2258,7 @@ const createSessionDeletionHandlers = (
 const createProvenancePersistence = (
   overrides: Partial<SessionProvenancePersistence> = {}
 ): SessionProvenancePersistence => ({
+  validateFinalizedMessageBindings: vi.fn().mockResolvedValue(undefined),
   captureFinalizedMessages: vi.fn().mockResolvedValue(undefined),
   reconcileSessionDeletions: vi.fn().mockResolvedValue(undefined),
   prepareSessionDeletion: vi

--- a/src/main/session-persistence/coordinator.test.ts
+++ b/src/main/session-persistence/coordinator.test.ts
@@ -182,7 +182,11 @@ describe('SessionPersistenceCoordinator', () => {
     const provenance = createProvenancePersistence({
       validateFinalizedMessageBindings: vi
         .fn()
-        .mockRejectedValue(new Error('Artifact-owning Message is outside its bound Branch.'))
+        .mockRejectedValue(
+          new FinalizedArtifactBindingConflictError(
+            'Artifact-owning Message is outside its bound Branch.'
+          )
+        )
     })
     const coordinator = new SessionPersistenceCoordinator(
       repository,
@@ -198,6 +202,32 @@ describe('SessionPersistenceCoordinator', () => {
     expect(durableSession.title).toBe('Durable latest')
     expect(repository.saveSession).not.toHaveBeenCalled()
     expect(provenance.captureFinalizedMessages).not.toHaveBeenCalled()
+  })
+
+  it('keeps JSON-first durability when pre-save provenance lookup is unavailable', async () => {
+    const validationError = new Error('artifact database unavailable')
+    const repository = createSessionRepository()
+    const provenance = createProvenancePersistence({
+      validateFinalizedMessageBindings: vi.fn().mockRejectedValue(validationError)
+    })
+    const warn = vi.spyOn(console, 'warn').mockImplementation(() => undefined)
+    const coordinator = new SessionPersistenceCoordinator(
+      repository,
+      createFileIndex(),
+      undefined,
+      provenance
+    )
+
+    try {
+      await expect(coordinator.saveSession(createSession())).resolves.toMatchObject({
+        id: 'session-1'
+      })
+    } finally {
+      warn.mockRestore()
+    }
+
+    expect(repository.saveSession).toHaveBeenCalledOnce()
+    expect(provenance.captureFinalizedMessages).toHaveBeenCalledOnce()
   })
 
   it('rebases explicitly changed safe fields onto the latest durable graph after a conflict', async () => {

--- a/src/main/session-persistence/coordinator.ts
+++ b/src/main/session-persistence/coordinator.ts
@@ -183,7 +183,7 @@ const rebaseSafeSessionFields = (
         break
     }
   }
-  rebased.updatedAt = Math.max(authoritative.updatedAt, submitted.updatedAt)
+  rebased.updatedAt = Math.max(authoritative.updatedAt, submitted.updatedAt) + 1
   return rebased
 }
 

--- a/src/main/session-persistence/coordinator.ts
+++ b/src/main/session-persistence/coordinator.ts
@@ -1,3 +1,5 @@
+import { createHash } from 'node:crypto'
+
 import type { ProjectFilesChangedEvent } from '../../shared/project-files'
 import type { ProjectFileSource } from '../../shared/project-files'
 import type { ArtifactVersionFile } from '../../shared/artifact-provenance'
@@ -185,21 +187,48 @@ const rebaseSafeSessionFields = (
   return rebased
 }
 
-const findFinalizedArtifactBindingConflict = async (
+const sessionBindingTopologyHash = (session: PersistedChatSession): string => {
+  const graph = session.conversationGraph
+  const topology = graph
+    ? {
+        rootFrameId: graph.rootFrameId,
+        branches: graph.branches.map(({ id, agentFrameId, headMessageId }) => ({
+          id,
+          agentFrameId,
+          headMessageId
+        })),
+        messages: graph.messages.map(({ id, agentFrameId, parentMessageId }) => ({
+          id,
+          agentFrameId,
+          parentMessageId
+        }))
+      }
+    : null
+  return createHash('sha256').update(JSON.stringify(topology)).digest('hex')
+}
+
+type FinalizedArtifactBindingValidation =
+  | { status: 'valid' }
+  | { status: 'unavailable' }
+  | { status: 'conflict'; error: FinalizedArtifactBindingConflictError }
+
+const validateFinalizedArtifactBindings = async (
   provenance: SessionProvenancePersistence | undefined,
   session: PersistedChatSession
-): Promise<FinalizedArtifactBindingConflictError | undefined> => {
-  if (!provenance) return undefined
+): Promise<FinalizedArtifactBindingValidation> => {
+  if (!provenance) return { status: 'valid' }
 
   try {
     await provenance.validateFinalizedMessageBindings(session)
-    return undefined
+    return { status: 'valid' }
   } catch (error) {
-    if (error instanceof FinalizedArtifactBindingConflictError) return error
+    if (error instanceof FinalizedArtifactBindingConflictError) {
+      return { status: 'conflict', error }
+    }
     // Provenance is derived from authoritative Session JSON. A transient lookup failure must not
     // regress the JSON-first durability guarantee; capture/indexing keep their post-save retry path.
     console.warn('[session-persistence] pre-save provenance validation unavailable', error)
-    return undefined
+    return { status: 'unavailable' }
   }
 }
 
@@ -285,6 +314,7 @@ class SessionPersistenceCoordinator {
   private queue: Promise<unknown> = Promise.resolve()
   private readonly deletedSessions = new Set<string>()
   private readonly deletedProjects = new Set<string>()
+  private readonly validatedBindingTopologies = new Map<string, string>()
   private destructiveStartupWindowOpen = true
   private sessionDeletionHandlers: SessionDeletionHandlers | undefined
 
@@ -310,6 +340,7 @@ class SessionPersistenceCoordinator {
    */
   loadAllReadOnly(): Promise<LoadAllSessionsResult> {
     return this.enqueue(async () => {
+      this.validatedBindingTopologies.clear()
       // Once any renderer has observed a degraded snapshot, later loads are no longer allowed to
       // treat the process as an untouched startup boundary for destructive cleanup.
       this.destructiveStartupWindowOpen = false
@@ -333,6 +364,7 @@ class SessionPersistenceCoordinator {
    */
   loadAll(): Promise<LoadAllSessionsResult> {
     return this.enqueue(async () => {
+      this.validatedBindingTopologies.clear()
       // Public loadAll can be called by multiple renderers/tasks. Only the first invocation in this
       // process is a startup boundary; consume it before any await so failures and partial scans cannot
       // reopen destructive cleanup while live clients may already hold the legacy projection.
@@ -475,21 +507,24 @@ class SessionPersistenceCoordinator {
             mode: 'live-save'
           })
         : materializedSession
+      const key = sessionKey(session.projectId, session.id)
+      let bindingTopology = sessionBindingTopologyHash(durableSession)
+      let bindingValidation: FinalizedArtifactBindingValidation =
+        this.validatedBindingTopologies.get(key) === bindingTopology
+          ? { status: 'valid' }
+          : await validateFinalizedArtifactBindings(this.provenance, durableSession)
       // Reject a stale graph before it can replace the authoritative Session JSON. Capture remains
       // after the durable write so immutable evidence never includes Message bytes that were not saved.
-      const bindingConflict = await findFinalizedArtifactBindingConflict(
-        this.provenance,
-        durableSession
-      )
-      if (bindingConflict) {
+      // Streaming payload changes preserve this topology, avoiding a database lookup on every chunk.
+      if (bindingValidation.status === 'conflict') {
         const conflictRebaseFields = options.conflictRebaseFields ?? []
-        if (conflictRebaseFields.length === 0) throw bindingConflict
+        if (conflictRebaseFields.length === 0) throw bindingValidation.error
 
         const authoritative = await this.repository.loadSessionWithDiagnostics(
           session.projectId,
           session.id
         )
-        if (authoritative.status !== 'found') throw bindingConflict
+        if (authoritative.status !== 'found') throw bindingValidation.error
 
         const rebasedSession = rebaseSafeSessionFields(
           authoritative.session,
@@ -499,13 +534,19 @@ class SessionPersistenceCoordinator {
         durableSession = this.uploads
           ? await this.uploads.upgradeLegacySessionUploads(rebasedSession, { mode: 'live-save' })
           : rebasedSession
-        const rebasedConflict = await findFinalizedArtifactBindingConflict(
-          this.provenance,
-          durableSession
-        )
-        if (rebasedConflict) throw rebasedConflict
+        bindingTopology = sessionBindingTopologyHash(durableSession)
+        bindingValidation =
+          this.validatedBindingTopologies.get(key) === bindingTopology
+            ? { status: 'valid' }
+            : await validateFinalizedArtifactBindings(this.provenance, durableSession)
+        if (bindingValidation.status === 'conflict') throw bindingValidation.error
       }
       await this.repository.saveSession(durableSession)
+      // Cache only confirmed topology. A transient validation failure keeps the old fingerprint so
+      // the next autosave retries the narrow lookup instead of silently treating it as acknowledged.
+      if (bindingValidation.status === 'valid') {
+        this.validatedBindingTopologies.set(key, bindingTopology)
+      }
       await this.provenance?.captureFinalizedMessages(durableSession)
       let changedSources: ProjectFileSource[]
       try {
@@ -546,7 +587,13 @@ class SessionPersistenceCoordinator {
       if (this.deletedSessions.has(sessionKey(projectId, sessionId))) {
         throw new Error('Cannot mutate a session that has been deleted.')
       }
-      return mutation()
+      try {
+        return await mutation()
+      } finally {
+        // Artifact finalization can add a new binding without changing the Session graph. Force the
+        // next save to validate that new database scope before reusing a topology fingerprint.
+        this.validatedBindingTopologies.delete(sessionKey(projectId, sessionId))
+      }
     })
   }
 
@@ -686,6 +733,9 @@ class SessionPersistenceCoordinator {
         // The marked directory rename is the sole authoritative commit. Derived index deletion runs
         // afterward so any failure is replayable from the durable Project intent and tombstone.
         await this.repository.deleteProjectSessions(projectId)
+        for (const sessionId of deletedSessionIds) {
+          this.validatedBindingTopologies.delete(sessionKey(projectId, sessionId))
+        }
         await this.fileIndex.softDeleteProject(projectId)
       } catch (error) {
         try {
@@ -827,6 +877,7 @@ class SessionPersistenceCoordinator {
         }
         await this.repository.deleteSession(projectId, sessionId)
         jsonDeleted = true
+        this.validatedBindingTopologies.delete(key)
         await this.provenance?.completeSessionDeletion(receipt)
       } catch (error) {
         try {

--- a/src/main/session-persistence/coordinator.ts
+++ b/src/main/session-persistence/coordinator.ts
@@ -5,6 +5,7 @@ import type {
   LoadAllSessionsResult,
   PersistedArtifact,
   PersistedChatSession,
+  SaveSessionOptions,
   SaveSessionManifestRequest,
   SessionLoadFailure,
   SessionLoadWarning
@@ -12,7 +13,10 @@ import type {
 import type { ManagedFileSoftDeleteToken } from '../project-files/repository'
 import type { ProjectSessionDeletionState } from './repository'
 import { materializeSessionConversationGraph } from '../../shared/session-persistence'
-import type { SessionDeletionReceipt } from '../artifacts/provenance-message-snapshot'
+import {
+  FinalizedArtifactBindingConflictError,
+  type SessionDeletionReceipt
+} from '../artifacts/provenance-message-snapshot'
 import type { ArtifactProjectReconciliationSnapshot } from '../artifacts/provenance-repository'
 import {
   OrphanLegacyUploadAuthorityMissingError,
@@ -145,6 +149,40 @@ const appendUnique = (existing: string[] | undefined, incoming: readonly string[
     result.push(value)
   }
   return result
+}
+
+const rebaseSafeSessionFields = (
+  authoritative: PersistedChatSession,
+  submitted: PersistedChatSession,
+  fields: NonNullable<SaveSessionOptions['conflictRebaseFields']>
+): PersistedChatSession => {
+  const rebased = { ...authoritative }
+  for (const field of fields) {
+    switch (field) {
+      case 'title':
+        rebased.title = submitted.title
+        break
+      case 'permissionProfile':
+        rebased.permissionProfile = submitted.permissionProfile
+        break
+      case 'autoReviewEnabled':
+        rebased.autoReviewEnabled = submitted.autoReviewEnabled
+        break
+      case 'enabledComputeHosts':
+        rebased.enabledComputeHosts = submitted.enabledComputeHosts
+          ? [...submitted.enabledComputeHosts]
+          : undefined
+        break
+      case 'pinned':
+        rebased.pinned = submitted.pinned
+        break
+      case 'specialistId':
+        rebased.specialistId = submitted.specialistId
+        break
+    }
+  }
+  rebased.updatedAt = Math.max(authoritative.updatedAt, submitted.updatedAt)
+  return rebased
 }
 
 // Reattach native Versions through the Session authority, preserving graph-only inactive Branches.
@@ -401,7 +439,10 @@ class SessionPersistenceCoordinator {
   // Persists authoritative JSON before updating the derived index. If indexing fails, the save stays
   // durable, the caller receives the error for its normal retry path, and Files is reset to show its
   // incomplete state rather than silently presenting stale metadata as complete.
-  saveSession(session: PersistedChatSession): Promise<PersistedChatSession> {
+  saveSession(
+    session: PersistedChatSession,
+    options: SaveSessionOptions = {}
+  ): Promise<PersistedChatSession> {
     return this.enqueue(async () => {
       if (this.deletedProjects.has(session.projectId)) {
         throw new Error('Cannot save a session whose project has been deleted.')
@@ -411,14 +452,40 @@ class SessionPersistenceCoordinator {
       }
 
       const materializedSession = materializeSessionConversationGraph(session)
-      const durableSession = this.uploads
+      let durableSession = this.uploads
         ? await this.uploads.upgradeLegacySessionUploads(materializedSession, {
             mode: 'live-save'
           })
         : materializedSession
       // Reject a stale graph before it can replace the authoritative Session JSON. Capture remains
       // after the durable write so immutable evidence never includes Message bytes that were not saved.
-      await this.provenance?.validateFinalizedMessageBindings(durableSession)
+      try {
+        await this.provenance?.validateFinalizedMessageBindings(durableSession)
+      } catch (error) {
+        const conflictRebaseFields = options.conflictRebaseFields ?? []
+        if (
+          !(error instanceof FinalizedArtifactBindingConflictError) ||
+          conflictRebaseFields.length === 0
+        ) {
+          throw error
+        }
+
+        const authoritative = await this.repository.loadSessionWithDiagnostics(
+          session.projectId,
+          session.id
+        )
+        if (authoritative.status !== 'found') throw error
+
+        const rebasedSession = rebaseSafeSessionFields(
+          authoritative.session,
+          durableSession,
+          conflictRebaseFields
+        )
+        durableSession = this.uploads
+          ? await this.uploads.upgradeLegacySessionUploads(rebasedSession, { mode: 'live-save' })
+          : rebasedSession
+        await this.provenance?.validateFinalizedMessageBindings(durableSession)
+      }
       await this.repository.saveSession(durableSession)
       await this.provenance?.captureFinalizedMessages(durableSession)
       let changedSources: ProjectFileSource[]

--- a/src/main/session-persistence/coordinator.ts
+++ b/src/main/session-persistence/coordinator.ts
@@ -573,6 +573,18 @@ class SessionPersistenceCoordinator {
     })
   }
 
+  // Specialist switching reads the latest durable Session and changes only this safe binding. Keep
+  // that intent inside the persistence boundary so every caller receives graph-conflict recovery.
+  saveSessionSpecialistBinding(
+    session: PersistedChatSession,
+    specialistId: string | undefined
+  ): Promise<PersistedChatSession> {
+    return this.saveSession(
+      { ...session, specialistId },
+      { conflictRebaseFields: ['specialistId'] }
+    )
+  }
+
   // Joins late Session-owned side effects (for example Upload finalization) to the same ordering
   // boundary as JSON save and deletion. The mutation is rejected after a Session/Project tombstone.
   runSessionMutation<Result>(

--- a/src/main/session-persistence/coordinator.ts
+++ b/src/main/session-persistence/coordinator.ts
@@ -73,6 +73,7 @@ type SessionFileIndex = {
 }
 
 type SessionProvenancePersistence = {
+  validateFinalizedMessageBindings(session: PersistedChatSession): Promise<void>
   captureFinalizedMessages(session: PersistedChatSession): Promise<void>
   reconcileSessionDeletions(activeSessions: PersistedChatSession[]): Promise<void>
   prepareSessionDeletion(session: PersistedChatSession): Promise<SessionDeletionReceipt>
@@ -415,6 +416,9 @@ class SessionPersistenceCoordinator {
             mode: 'live-save'
           })
         : materializedSession
+      // Reject a stale graph before it can replace the authoritative Session JSON. Capture remains
+      // after the durable write so immutable evidence never includes Message bytes that were not saved.
+      await this.provenance?.validateFinalizedMessageBindings(durableSession)
       await this.repository.saveSession(durableSession)
       await this.provenance?.captureFinalizedMessages(durableSession)
       let changedSources: ProjectFileSource[]

--- a/src/main/session-persistence/coordinator.ts
+++ b/src/main/session-persistence/coordinator.ts
@@ -185,6 +185,24 @@ const rebaseSafeSessionFields = (
   return rebased
 }
 
+const findFinalizedArtifactBindingConflict = async (
+  provenance: SessionProvenancePersistence | undefined,
+  session: PersistedChatSession
+): Promise<FinalizedArtifactBindingConflictError | undefined> => {
+  if (!provenance) return undefined
+
+  try {
+    await provenance.validateFinalizedMessageBindings(session)
+    return undefined
+  } catch (error) {
+    if (error instanceof FinalizedArtifactBindingConflictError) return error
+    // Provenance is derived from authoritative Session JSON. A transient lookup failure must not
+    // regress the JSON-first durability guarantee; capture/indexing keep their post-save retry path.
+    console.warn('[session-persistence] pre-save provenance validation unavailable', error)
+    return undefined
+  }
+}
+
 // Reattach native Versions through the Session authority, preserving graph-only inactive Branches.
 const attachRecoveredMessageArtifacts = (
   session: PersistedChatSession,
@@ -459,22 +477,19 @@ class SessionPersistenceCoordinator {
         : materializedSession
       // Reject a stale graph before it can replace the authoritative Session JSON. Capture remains
       // after the durable write so immutable evidence never includes Message bytes that were not saved.
-      try {
-        await this.provenance?.validateFinalizedMessageBindings(durableSession)
-      } catch (error) {
+      const bindingConflict = await findFinalizedArtifactBindingConflict(
+        this.provenance,
+        durableSession
+      )
+      if (bindingConflict) {
         const conflictRebaseFields = options.conflictRebaseFields ?? []
-        if (
-          !(error instanceof FinalizedArtifactBindingConflictError) ||
-          conflictRebaseFields.length === 0
-        ) {
-          throw error
-        }
+        if (conflictRebaseFields.length === 0) throw bindingConflict
 
         const authoritative = await this.repository.loadSessionWithDiagnostics(
           session.projectId,
           session.id
         )
-        if (authoritative.status !== 'found') throw error
+        if (authoritative.status !== 'found') throw bindingConflict
 
         const rebasedSession = rebaseSafeSessionFields(
           authoritative.session,
@@ -484,7 +499,11 @@ class SessionPersistenceCoordinator {
         durableSession = this.uploads
           ? await this.uploads.upgradeLegacySessionUploads(rebasedSession, { mode: 'live-save' })
           : rebasedSession
-        await this.provenance?.validateFinalizedMessageBindings(durableSession)
+        const rebasedConflict = await findFinalizedArtifactBindingConflict(
+          this.provenance,
+          durableSession
+        )
+        if (rebasedConflict) throw rebasedConflict
       }
       await this.repository.saveSession(durableSession)
       await this.provenance?.captureFinalizedMessages(durableSession)

--- a/src/main/session-persistence/ipc.test.ts
+++ b/src/main/session-persistence/ipc.test.ts
@@ -145,6 +145,10 @@ describe('session persistence IPC handlers', () => {
     await handlers.saveSession(session)
     expect(repository.saveSession).toHaveBeenCalledWith(session)
 
+    const saveOptions = { conflictRebaseFields: ['title' as const] }
+    await handlers.saveSession(session, saveOptions)
+    expect(repository.saveSession).toHaveBeenLastCalledWith(session, saveOptions)
+
     await handlers.deleteSession({ projectId: 'project-a', sessionId: 'session-1' })
     expect(repository.deleteSession).toHaveBeenCalledWith('project-a', 'session-1')
     // Reviews are retained for Artifact Provenance after the session transcript is deleted.

--- a/src/main/session-persistence/ipc.ts
+++ b/src/main/session-persistence/ipc.ts
@@ -4,6 +4,7 @@ import type {
   DeleteSessionRequest,
   LoadAllSessionsResult,
   PersistedChatSession,
+  SaveSessionOptions,
   SaveSessionManifestRequest
 } from '../../shared/session-persistence'
 import { LIFECYCLE_CHANNELS } from '../../shared/lifecycle-events'
@@ -17,7 +18,8 @@ import { withDataRootWrite } from '../storage/migration-state'
 type SessionPersistenceBackend = {
   loadAll: () => Promise<LoadAllSessionsResult>
   saveSession: (
-    session: PersistedChatSession
+    session: PersistedChatSession,
+    options?: SaveSessionOptions
   ) => Promise<{ created: boolean; session: PersistedChatSession }>
   deleteSession: (projectId: string, sessionId: string) => Promise<void>
   saveManifest: (request: SaveSessionManifestRequest) => Promise<void>
@@ -26,7 +28,8 @@ type SessionPersistenceBackend = {
 type SessionPersistenceHandlers = {
   loadAll: () => Promise<LoadAllSessionsResult>
   saveSession: (
-    session: PersistedChatSession
+    session: PersistedChatSession,
+    options?: SaveSessionOptions
   ) => Promise<{ created: boolean; session: PersistedChatSession }>
   deleteSession: (request: DeleteSessionRequest) => Promise<void>
   saveManifest: (request: SaveSessionManifestRequest) => Promise<void>
@@ -81,7 +84,8 @@ const createSessionPersistenceHandlers = (
   void reviewRepository
   return {
     loadAll: () => repository.loadAll(),
-    saveSession: (session) => repository.saveSession(session),
+    saveSession: (session, options) =>
+      options ? repository.saveSession(session, options) : repository.saveSession(session),
     // A session delete tombstones its origin graph but deliberately retains Review rows, findings and
     // scope snapshots. Provenance remains readable from Files; project deletion owns final cleanup.
     deleteSession: (request) => repository.deleteSession(request.projectId, request.sessionId),
@@ -107,19 +111,22 @@ const registerSessionPersistenceIpcHandlers = (
   // loadAll can replay pending deletions and every mutation can materialize provenance/upload bytes.
   // Hold the shared data-root lease at the IPC boundary so migration drains the complete operation.
   ipcMain.handle('sessions:load-all', () => withDataRootWrite(() => handlers.loadAll()))
-  ipcMain.handle('sessions:save-session', async (event, session: PersistedChatSession) => {
-    return withDataRootWrite(async () => {
-      const result = await handlers.saveSession(session)
-      broadcastLifecycleEvent(
-        result.created ? LIFECYCLE_CHANNELS.sessionCreated : LIFECYCLE_CHANNELS.sessionUpdated,
-        {
-          session: result.session,
-          originClientId: getLifecycleClientId(event)
-        }
-      )
-      return result.session
-    })
-  })
+  ipcMain.handle(
+    'sessions:save-session',
+    async (event, session: PersistedChatSession, options?: SaveSessionOptions) => {
+      return withDataRootWrite(async () => {
+        const result = await handlers.saveSession(session, options)
+        broadcastLifecycleEvent(
+          result.created ? LIFECYCLE_CHANNELS.sessionCreated : LIFECYCLE_CHANNELS.sessionUpdated,
+          {
+            session: result.session,
+            originClientId: getLifecycleClientId(event)
+          }
+        )
+        return result.session
+      })
+    }
+  )
   ipcMain.handle('sessions:delete-session', async (_event, request: DeleteSessionRequest) => {
     await withDataRootWrite(async () => {
       await handlers.deleteSession(request)

--- a/src/preload/index.d.ts
+++ b/src/preload/index.d.ts
@@ -124,6 +124,7 @@ import type {
   DeleteSessionRequest,
   LoadAllSessionsResult,
   PersistedChatSession,
+  SaveSessionOptions,
   SaveSessionManifestRequest
 } from '../shared/session-persistence'
 import type {
@@ -274,7 +275,10 @@ interface OpenScienceAPI {
   }
   sessions: {
     loadAll(): Promise<LoadAllSessionsResult>
-    saveSession(session: PersistedChatSession): Promise<PersistedChatSession>
+    saveSession(
+      session: PersistedChatSession,
+      options?: SaveSessionOptions
+    ): Promise<PersistedChatSession>
     deleteSession(request: DeleteSessionRequest): Promise<void>
     saveManifest(request: SaveSessionManifestRequest): Promise<void>
     onCreated(listener: AcpListener<SessionUpsertEvent>): RemoveListener

--- a/src/preload/index.ts
+++ b/src/preload/index.ts
@@ -133,6 +133,7 @@ import type {
   DeleteSessionRequest,
   LoadAllSessionsResult,
   PersistedChatSession,
+  SaveSessionOptions,
   SaveSessionManifestRequest
 } from '../shared/session-persistence'
 import type {
@@ -310,7 +311,10 @@ type OpenScienceAPI = {
   }
   sessions: {
     loadAll: () => Promise<LoadAllSessionsResult>
-    saveSession: (session: PersistedChatSession) => Promise<PersistedChatSession>
+    saveSession: (
+      session: PersistedChatSession,
+      options?: SaveSessionOptions
+    ) => Promise<PersistedChatSession>
     deleteSession: (request: DeleteSessionRequest) => Promise<void>
     saveManifest: (request: SaveSessionManifestRequest) => Promise<void>
     onCreated: (listener: AcpListener<SessionUpsertEvent>) => RemoveListener
@@ -778,8 +782,10 @@ const api: OpenScienceAPI = {
     // Loads every per-session file plus the last-open manifest from the main process.
     loadAll: () => ipcRenderer.invoke('sessions:load-all') as Promise<LoadAllSessionsResult>,
     // Persists a single sanitized session file.
-    saveSession: (session) =>
-      ipcRenderer.invoke('sessions:save-session', session) as Promise<PersistedChatSession>,
+    saveSession: (session, options) =>
+      (options
+        ? ipcRenderer.invoke('sessions:save-session', session, options)
+        : ipcRenderer.invoke('sessions:save-session', session)) as Promise<PersistedChatSession>,
     // Removes one session file.
     deleteSession: (request) =>
       ipcRenderer.invoke('sessions:delete-session', request) as Promise<void>,

--- a/src/renderer/src/lib/acp/workspace-events.test.ts
+++ b/src/renderer/src/lib/acp/workspace-events.test.ts
@@ -9,7 +9,12 @@ import {
   createInitialPreviewWorkbenchState,
   usePreviewWorkbenchStore
 } from '../../stores/preview-workbench-store'
-import { createInitialSessionState, useSessionStore } from '../../stores/session-store'
+import {
+  createInitialSessionState,
+  toPersistedSession,
+  useSessionStore
+} from '../../stores/session-store'
+import { saveSessionInOrder } from '../session-persistence/session-persistence'
 import {
   applyWorkspaceRuntimeEvent,
   assembleReviewRunRequest,
@@ -760,6 +765,76 @@ describe('workspace runtime events', () => {
     expect(session.messages[1].artifactIds).toEqual([
       `transport-session-1:${responseMessageId}:result.txt`
     ])
+  })
+
+  it('keeps Artifact persistence behind an older queued Session save', async () => {
+    const promptMessageId = useSessionStore.getState().sessions[0].activeRun?.promptMessageId
+    await applyWorkspaceRuntimeEvent(
+      createEvent({
+        id: 'assistant-event-ordered-save',
+        role: 'assistant',
+        messageId: 'assistant-message-ordered-save',
+        text: 'Saved the plot.'
+      })
+    )
+    await applyWorkspaceRuntimeEvent(createEvent({ id: 'stop-ordered-save', kind: 'stop' }))
+
+    let releaseQueuedSave!: () => void
+    const queuedSaveBlocked = new Promise<void>((resolve) => {
+      releaseQueuedSave = resolve
+    })
+    let durableTitle = ''
+    const saveSession = vi.fn(async (submitted: ReturnType<typeof toPersistedSession>) => {
+      if (submitted.title === 'Queued stale') await queuedSaveBlocked
+      durableTitle = submitted.title
+      return submitted
+    })
+    vi.stubGlobal('window', {
+      api: {
+        sessions: {
+          saveSession,
+          saveManifest: vi.fn()
+        }
+      }
+    })
+
+    try {
+      const staleSession = toPersistedSession(useSessionStore.getState().sessions[0])
+      const queuedSave = saveSessionInOrder({ ...staleSession, title: 'Queued stale' })
+      await Promise.resolve()
+      await Promise.resolve()
+      useSessionStore.getState().renameSession('transport-session-1', 'Artifact latest')
+      const responseMessageId = useSessionStore.getState().sessions[0].messages[1].id
+      const finalizedArtifact = createArtifactFile({
+        id: `transport-session-1:${responseMessageId}:result.txt`,
+        sessionId: 'transport-session-1',
+        messageId: responseMessageId,
+        runId: undefined
+      })
+      const artifactSave = applyWorkspaceRuntimeEvent(
+        createEvent({
+          id: 'artifact-event-ordered-save',
+          kind: 'artifact',
+          runId: 'artifact-run-ordered-save',
+          promptMessageId,
+          artifactSessionId: 'artifact-session-1',
+          artifactClaimId: 'claim-ordered-save',
+          artifacts: [createArtifactFile({ runId: 'artifact-run-ordered-save' })]
+        }),
+        { finalizeRunArtifacts: vi.fn().mockResolvedValue([finalizedArtifact]) }
+      )
+
+      await Promise.resolve()
+      await Promise.resolve()
+      const writesBeforeRelease = saveSession.mock.calls.length
+      releaseQueuedSave()
+      await Promise.all([queuedSave, artifactSave])
+
+      expect(writesBeforeRelease).toBe(1)
+      expect(durableTitle).toBe('Artifact latest')
+    } finally {
+      vi.unstubAllGlobals()
+    }
   })
 
   it('retains an unchanged post-stop Artifact after switching an edited Branch away and back', async () => {

--- a/src/renderer/src/lib/acp/workspace-events.ts
+++ b/src/renderer/src/lib/acp/workspace-events.ts
@@ -16,6 +16,7 @@ import {
 } from '../../../../shared/activity-groups'
 import { toPersistedSession, useSessionStore } from '../../stores/session-store'
 import { useSettingsStore } from '../../stores/settings-store'
+import { saveSessionInOrder } from '../session-persistence/session-persistence'
 import {
   createRuntimeStreamId,
   getAcpRuntimeEventImage,
@@ -131,7 +132,7 @@ const finalizeRunArtifacts = async (
 // Persist that graph explicitly instead of relying on the asynchronous store saver to win the IPC race.
 const saveSessionForArtifactFinalization = (
   session: PersistedChatSession
-): Promise<PersistedChatSession> => window.api.sessions.saveSession(session)
+): Promise<PersistedChatSession> => saveSessionInOrder(session)
 
 const finalizeArtifactEvent = async (
   event: AcpRuntimeEvent,

--- a/src/renderer/src/lib/session-persistence/session-persistence.test.ts
+++ b/src/renderer/src/lib/session-persistence/session-persistence.test.ts
@@ -1,6 +1,7 @@
 import { beforeEach, describe, expect, it, vi } from 'vitest'
 
 import {
+  materializeSessionConversationGraph,
   SESSION_MANIFEST_VERSION,
   type LoadAllSessionsResult,
   type PersistedChatSession
@@ -197,13 +198,45 @@ describe('renderer session persistence bridge', () => {
   })
 
   it('reports only changed safe fields for stale-graph conflict rebasing', async () => {
-    const persisted = createPersistedSession({
-      projectId: 'project-a',
-      title: 'Original',
-      pinned: false
-    })
+    const persisted = materializeSessionConversationGraph(
+      createPersistedSession({
+        projectId: 'project-a',
+        title: 'Original',
+        pinned: false,
+        messages: [
+          {
+            id: 'stale-message',
+            role: 'user',
+            content: 'Stale graph',
+            status: 'complete',
+            eventIds: [],
+            createdAt: 1,
+            updatedAt: 1
+          }
+        ]
+      })
+    )
+    const durable = materializeSessionConversationGraph(
+      createPersistedSession({
+        projectId: 'project-a',
+        title: 'Local rename',
+        pinned: true,
+        messages: [
+          {
+            id: 'durable-message',
+            role: 'agent',
+            content: 'Artifact finalized',
+            status: 'complete',
+            eventIds: [],
+            createdAt: 2,
+            updatedAt: 2
+          }
+        ],
+        updatedAt: 2
+      })
+    )
     useSessionStore.getState().hydrateSessions([persisted])
-    const api = createApi()
+    const api = createApi({ saveSession: vi.fn().mockResolvedValue(durable) })
     const save = createStoreSaver(api, useSessionStore.getState())
 
     useSessionStore.getState().renameSession('session-1', 'Local rename')
@@ -213,6 +246,10 @@ describe('renderer session persistence bridge', () => {
     expect(api.saveSession).toHaveBeenCalledWith(
       expect.objectContaining({ title: 'Local rename', pinned: true }),
       { conflictRebaseFields: ['title', 'pinned'] }
+    )
+    expect(useSessionStore.getState().sessions[0].messages).toEqual(durable.messages)
+    expect(useSessionStore.getState().sessions[0].conversationGraph).toEqual(
+      durable.conversationGraph
     )
   })
 
@@ -459,7 +496,11 @@ describe('renderer session persistence bridge', () => {
       content: 'Newer live message',
       projectId: 'project-a'
     })
-    useSessionStore.getState().applyDurableSessionProjection({ source, session: durable })
+    useSessionStore.getState().applyDurableSessionProjection({
+      source,
+      session: durable,
+      mode: 'replace-persisted-if-current'
+    })
 
     const projected = useSessionStore.getState().sessions[0]
     expect(projected.messages.map((message) => message.content)).toEqual([

--- a/src/renderer/src/lib/session-persistence/session-persistence.test.ts
+++ b/src/renderer/src/lib/session-persistence/session-persistence.test.ts
@@ -253,6 +253,37 @@ describe('renderer session persistence bridge', () => {
     )
   })
 
+  it('retains safe-field rebase intent for a forced retry after a failed write', async () => {
+    const persisted = createPersistedSession({ projectId: 'project-a', title: 'Original' })
+    useSessionStore.getState().hydrateSessions([persisted])
+    const saveSession = vi
+      .fn()
+      .mockRejectedValueOnce(new Error('database busy'))
+      .mockImplementation(async (session: PersistedChatSession) => session)
+    const failedFields = new Map<string, readonly ['title']>()
+    const api = createApi({ saveSession })
+    const save = createStoreSaver(api, useSessionStore.getState(), {
+      onFailure: (target, _error, context) => {
+        if (context.conflictRebaseFields?.includes('title')) {
+          failedFields.set(target, ['title'])
+        }
+      }
+    })
+
+    useSessionStore.getState().renameSession('session-1', 'Local rename')
+    const state = useSessionStore.getState()
+    await expect(save(state)).rejects.toThrow('database busy')
+    await save(state, {
+      forceTargets: new Set(['session:session-1']),
+      conflictRebaseFieldsByTarget: failedFields
+    })
+
+    expect(saveSession).toHaveBeenLastCalledWith(
+      expect.objectContaining({ title: 'Local rename' }),
+      { conflictRebaseFields: ['title'] }
+    )
+  })
+
   it('does not persist unbound pending sessions', async () => {
     const api = createApi()
     const save = createStoreSaver(api)

--- a/src/renderer/src/lib/session-persistence/session-persistence.test.ts
+++ b/src/renderer/src/lib/session-persistence/session-persistence.test.ts
@@ -9,9 +9,11 @@ import { toRuntimeUploadedAttachment } from '../../../../shared/uploads'
 import {
   createInitialSessionState,
   isExternallyHydratedSession,
+  toPersistedSession,
   useSessionStore
 } from '../../stores/session-store'
 import {
+  createOrderedSessionPersistence,
   createStoreSaver,
   loadPersistedSessions,
   reconcilePendingArtifacts,
@@ -607,6 +609,43 @@ describe('renderer session persistence bridge', () => {
     await expect(save(useSessionStore.getState())).rejects.toThrow('disk full')
     expect(api.saveSession).toHaveBeenCalledOnce()
     expect(api.saveManifest).toHaveBeenCalledOnce()
+  })
+
+  it('keeps an explicit latest Session save after older store snapshots', async () => {
+    const firstSave = createDeferred<void>()
+    let durableTitle = ''
+    const saveSession = vi.fn(async (submitted: PersistedChatSession) => {
+      if (submitted.title === 'Queued first') await firstSave.promise
+      durableTitle = submitted.title
+      return submitted
+    })
+    const api = createApi({ saveSession })
+    const persistence = createOrderedSessionPersistence(api)
+
+    useSessionStore.getState().appendUserMessage({
+      sessionId: 'session-1',
+      content: 'First',
+      cwd: '/workspace/project',
+      projectId: 'project-a'
+    })
+    const save = createStoreSaver(api, useSessionStore.getState(), {}, persistence)
+
+    useSessionStore.getState().renameSession('session-1', 'Queued first')
+    const queuedFirst = save(useSessionStore.getState())
+    useSessionStore.getState().renameSession('session-1', 'Queued stale')
+    const queuedStale = save(useSessionStore.getState())
+    useSessionStore.getState().renameSession('session-1', 'Artifact latest')
+    const latestSession = toPersistedSession(useSessionStore.getState().sessions[0])
+    const explicitLatest = persistence.saveSession(latestSession)
+
+    await flushMicrotasks()
+    expect(saveSession).toHaveBeenCalledOnce()
+
+    firstSave.resolve()
+    await Promise.all([queuedFirst, queuedStale, explicitLatest])
+
+    expect(saveSession).toHaveBeenCalledTimes(3)
+    expect(durableTitle).toBe('Artifact latest')
   })
 })
 

--- a/src/renderer/src/lib/session-persistence/session-persistence.test.ts
+++ b/src/renderer/src/lib/session-persistence/session-persistence.test.ts
@@ -196,6 +196,26 @@ describe('renderer session persistence bridge', () => {
     )
   })
 
+  it('reports only changed safe fields for stale-graph conflict rebasing', async () => {
+    const persisted = createPersistedSession({
+      projectId: 'project-a',
+      title: 'Original',
+      pinned: false
+    })
+    useSessionStore.getState().hydrateSessions([persisted])
+    const api = createApi()
+    const save = createStoreSaver(api, useSessionStore.getState())
+
+    useSessionStore.getState().renameSession('session-1', 'Local rename')
+    useSessionStore.getState().togglePinned('session-1')
+    await save(useSessionStore.getState())
+
+    expect(api.saveSession).toHaveBeenCalledWith(
+      expect.objectContaining({ title: 'Local rename', pinned: true }),
+      { conflictRebaseFields: ['title', 'pinned'] }
+    )
+  })
+
   it('does not persist unbound pending sessions', async () => {
     const api = createApi()
     const save = createStoreSaver(api)

--- a/src/renderer/src/lib/session-persistence/session-persistence.ts
+++ b/src/renderer/src/lib/session-persistence/session-persistence.ts
@@ -274,7 +274,11 @@ const createStoreSaver = (
             )
             useSessionStore.getState().applyDurableSessionProjection({
               source: session,
-              session: durableSession
+              session: durableSession,
+              mode:
+                conflictRebaseFields.length > 0
+                  ? 'replace-persisted-if-current'
+                  : 'merge-upload-identities'
             })
           }
         })

--- a/src/renderer/src/lib/session-persistence/session-persistence.ts
+++ b/src/renderer/src/lib/session-persistence/session-persistence.ts
@@ -5,6 +5,8 @@ import type {
   DeleteSessionRequest,
   LoadAllSessionsResult,
   PersistedChatSession,
+  SaveSessionOptions,
+  SessionConflictRebaseField,
   SaveSessionManifestRequest
 } from '../../../../shared/session-persistence'
 import { PENDING_UPLOAD_SESSION_ID } from '../../../../shared/uploads'
@@ -17,12 +19,38 @@ import type { ChatSession, SessionHydrationSelection } from '../../stores/sessio
 
 type SessionPersistenceApi = {
   loadAll: () => Promise<LoadAllSessionsResult>
-  saveSession: (session: PersistedChatSession) => Promise<PersistedChatSession>
+  saveSession: (
+    session: PersistedChatSession,
+    options?: SaveSessionOptions
+  ) => Promise<PersistedChatSession>
   deleteSession: (request: DeleteSessionRequest) => Promise<void>
   saveManifest: (request: SaveSessionManifestRequest) => Promise<void>
 }
 
 type OrderedSessionPersistence = Pick<SessionPersistenceApi, 'saveSession' | 'saveManifest'>
+
+const SESSION_CONFLICT_REBASE_FIELDS = [
+  'title',
+  'permissionProfile',
+  'autoReviewEnabled',
+  'enabledComputeHosts',
+  'pinned',
+  'specialistId'
+] as const satisfies readonly SessionConflictRebaseField[]
+
+const conflictRebaseFieldChanged = (
+  previous: ChatSession,
+  next: ChatSession,
+  field: SessionConflictRebaseField
+): boolean => {
+  if (field !== 'enabledComputeHosts') return previous[field] !== next[field]
+  const previousHosts = previous.enabledComputeHosts ?? []
+  const nextHosts = next.enabledComputeHosts ?? []
+  return (
+    previousHosts.length !== nextHosts.length ||
+    previousHosts.some((host, index) => host !== nextHosts[index])
+  )
+}
 
 // Serializes every renderer-originated Session write through one ordering seam. Callers enqueue the
 // snapshot immediately, so a later explicit Artifact save cannot be overtaken by an older store save
@@ -42,7 +70,8 @@ const createOrderedSessionPersistence = (
   }
 
   return {
-    saveSession: (session) => enqueue(() => api.saveSession(session)),
+    saveSession: (session, options) =>
+      enqueue(() => (options ? api.saveSession(session, options) : api.saveSession(session))),
     saveManifest: (request) => enqueue(() => api.saveManifest(request))
   }
 }
@@ -50,7 +79,10 @@ const createOrderedSessionPersistence = (
 // The Store saver and Artifact finalization share this instance in production. Its adapters resolve
 // window.api lazily, keeping module import safe in tests before the preload bridge is installed.
 const liveSessionPersistence = createOrderedSessionPersistence({
-  saveSession: (session) => window.api.sessions.saveSession(session),
+  saveSession: (session, options) =>
+    options
+      ? window.api.sessions.saveSession(session, options)
+      : window.api.sessions.saveSession(session),
   saveManifest: (request) => window.api.sessions.saveManifest(request)
 })
 
@@ -226,11 +258,20 @@ const createStoreSaver = (
         !session.conversationGraphSyncBlocked
       ) {
         const persisted = toPersistedSession(session)
+        const previousSession = previousById.get(session.id)
+        const conflictRebaseFields = previousSession
+          ? SESSION_CONFLICT_REBASE_FIELDS.filter((field) =>
+              conflictRebaseFieldChanged(previousSession, session, field)
+            )
+          : []
 
         tasks.push({
           target,
           run: async () => {
-            const durableSession = await persistence.saveSession(persisted)
+            const durableSession = await persistence.saveSession(
+              persisted,
+              conflictRebaseFields.length > 0 ? { conflictRebaseFields } : undefined
+            )
             useSessionStore.getState().applyDurableSessionProjection({
               source: session,
               session: durableSession
@@ -418,33 +459,38 @@ const useSessionPersistence = (): SessionPersistenceState => {
       }
 
       // Snapshot the hydrated state as the diff baseline so hydration itself is not re-saved.
-      const save = createStoreSaver(window.api.sessions, useSessionStore.getState(), {
-        onFailure: (target) => {
-          if (!isMounted) return
-          failedWriteTargets.current.add(target)
-          pruneRemovedSessionWriteTargets(
-            failedWriteTargets.current,
-            useSessionStore.getState().sessions
-          )
-          // A queued save can lose a race with an authoritative deletion. Its tombstone rejection
-          // must not resurrect a retry target for a Session that no longer exists in the store.
-          if (!failedWriteTargets.current.has(target)) {
+      const save = createStoreSaver(
+        window.api.sessions,
+        useSessionStore.getState(),
+        {
+          onFailure: (target) => {
+            if (!isMounted) return
+            failedWriteTargets.current.add(target)
+            pruneRemovedSessionWriteTargets(
+              failedWriteTargets.current,
+              useSessionStore.getState().sessions
+            )
+            // A queued save can lose a race with an authoritative deletion. Its tombstone rejection
+            // must not resurrect a retry target for a Session that no longer exists in the store.
+            if (!failedWriteTargets.current.has(target)) {
+              if (failedWriteTargets.current.size === 0) setWriteError(undefined)
+              return
+            }
+            setWriteError(SAFE_SESSION_WRITE_ERROR)
+          },
+          onSuccess: (target) => {
+            if (!isMounted) return
+            failedWriteTargets.current.delete(target)
+            if (target === 'manifest' && retryManifestWritePending.current) {
+              retryManifestWritePending.current = false
+              setIsReady(true)
+              startPendingArtifactReconciliation()
+            }
             if (failedWriteTargets.current.size === 0) setWriteError(undefined)
-            return
           }
-          setWriteError(SAFE_SESSION_WRITE_ERROR)
         },
-        onSuccess: (target) => {
-          if (!isMounted) return
-          failedWriteTargets.current.delete(target)
-          if (target === 'manifest' && retryManifestWritePending.current) {
-            retryManifestWritePending.current = false
-            setIsReady(true)
-            startPendingArtifactReconciliation()
-          }
-          if (failedWriteTargets.current.size === 0) setWriteError(undefined)
-        }
-      }, liveSessionPersistence)
+        liveSessionPersistence
+      )
       activeSaver = save
       saverRef.current = save
 

--- a/src/renderer/src/lib/session-persistence/session-persistence.ts
+++ b/src/renderer/src/lib/session-persistence/session-persistence.ts
@@ -22,6 +22,41 @@ type SessionPersistenceApi = {
   saveManifest: (request: SaveSessionManifestRequest) => Promise<void>
 }
 
+type OrderedSessionPersistence = Pick<SessionPersistenceApi, 'saveSession' | 'saveManifest'>
+
+// Serializes every renderer-originated Session write through one ordering seam. Callers enqueue the
+// snapshot immediately, so a later explicit Artifact save cannot be overtaken by an older store save
+// that was still waiting behind an in-flight write.
+const createOrderedSessionPersistence = (
+  api: OrderedSessionPersistence
+): OrderedSessionPersistence => {
+  let queue: Promise<unknown> = Promise.resolve()
+
+  const enqueue = <Result>(task: () => Promise<Result>): Promise<Result> => {
+    const run = queue.then(task, task)
+    queue = run.then(
+      () => undefined,
+      () => undefined
+    )
+    return run
+  }
+
+  return {
+    saveSession: (session) => enqueue(() => api.saveSession(session)),
+    saveManifest: (request) => enqueue(() => api.saveManifest(request))
+  }
+}
+
+// The Store saver and Artifact finalization share this instance in production. Its adapters resolve
+// window.api lazily, keeping module import safe in tests before the preload bridge is installed.
+const liveSessionPersistence = createOrderedSessionPersistence({
+  saveSession: (session) => window.api.sessions.saveSession(session),
+  saveManifest: (request) => window.api.sessions.saveManifest(request)
+})
+
+const saveSessionInOrder = (session: PersistedChatSession): Promise<PersistedChatSession> =>
+  liveSessionPersistence.saveSession(session)
+
 // The one artifact command startup reconciliation needs; kept narrow so it is trivial to fake in tests.
 type ArtifactReconcileApi = {
   reconcilePendingArtifacts: (request: ReconcilePendingArtifactsRequest) => Promise<ArtifactFile[]>
@@ -161,18 +196,11 @@ const hasStagedUploads = (session: ChatSession): boolean =>
 const createStoreSaver = (
   api: SessionPersistenceApi,
   initial: SessionStoreSnapshot = useSessionStore.getState(),
-  observer: StoreSaverObserver = {}
+  observer: StoreSaverObserver = {},
+  persistence: OrderedSessionPersistence = createOrderedSessionPersistence(api)
 ): StoreSaver => {
   let previousSessions = initial.sessions
   let previousSelection = initial.selectedSessionId
-  let queue: Promise<unknown> = Promise.resolve()
-
-  // Runs each write regardless of whether an earlier one rejected, preserving order.
-  const enqueue = (task: () => Promise<unknown>): Promise<unknown> => {
-    queue = queue.then(task, task)
-
-    return queue
-  }
 
   return (state, options) => {
     const nextSessions = state.sessions
@@ -202,7 +230,7 @@ const createStoreSaver = (
         tasks.push({
           target,
           run: async () => {
-            const durableSession = await api.saveSession(persisted)
+            const durableSession = await persistence.saveSession(persisted)
             useSessionStore.getState().applyDurableSessionProjection({
               source: session,
               session: durableSession
@@ -225,7 +253,7 @@ const createStoreSaver = (
         tasks.push({
           target: 'manifest',
           run: () =>
-            api.saveManifest({
+            persistence.saveManifest({
               lastSessionId: state.selectedSessionId,
               lastProjectId: selectedSession?.projectId
             })
@@ -236,18 +264,19 @@ const createStoreSaver = (
     previousSessions = nextSessions
     previousSelection = state.selectedSessionId
 
-    const scheduledTasks = tasks.map(({ target, run }) =>
-      enqueue(async () => {
-        try {
-          const result = await run()
+    const scheduledTasks = tasks.map(({ target, run }) => {
+      // Invoke every task now so it takes its place in the shared persistence queue at snapshot time.
+      return run().then(
+        (result) => {
           observer.onSuccess?.(target)
           return result
-        } catch (error) {
+        },
+        (error: unknown) => {
           observer.onFailure?.(target, error)
           throw error
         }
-      })
-    )
+      )
+    })
 
     return Promise.all(scheduledTasks).then(() => undefined)
   }
@@ -415,7 +444,7 @@ const useSessionPersistence = (): SessionPersistenceState => {
           }
           if (failedWriteTargets.current.size === 0) setWriteError(undefined)
         }
-      })
+      }, liveSessionPersistence)
       activeSaver = save
       saverRef.current = save
 
@@ -471,5 +500,17 @@ const useSessionPersistence = (): SessionPersistenceState => {
   }
 }
 
-export { createStoreSaver, loadPersistedSessions, reconcilePendingArtifacts, useSessionPersistence }
-export type { ArtifactReconcileApi, SessionPersistenceApi, SessionPersistenceState }
+export {
+  createOrderedSessionPersistence,
+  createStoreSaver,
+  loadPersistedSessions,
+  reconcilePendingArtifacts,
+  saveSessionInOrder,
+  useSessionPersistence
+}
+export type {
+  ArtifactReconcileApi,
+  OrderedSessionPersistence,
+  SessionPersistenceApi,
+  SessionPersistenceState
+}

--- a/src/renderer/src/lib/session-persistence/session-persistence.ts
+++ b/src/renderer/src/lib/session-persistence/session-persistence.ts
@@ -163,10 +163,15 @@ type SessionPersistenceState = {
 
 type StoreSaverOptions = {
   forceTargets?: ReadonlySet<string>
+  conflictRebaseFieldsByTarget?: ReadonlyMap<string, readonly SessionConflictRebaseField[]>
+}
+
+type StoreSaverFailureContext = {
+  conflictRebaseFields?: readonly SessionConflictRebaseField[]
 }
 
 type StoreSaverObserver = {
-  onFailure?: (target: string, error: unknown) => void
+  onFailure?: (target: string, error: unknown, context: StoreSaverFailureContext) => void
   onSuccess?: (target: string) => void
 }
 
@@ -174,11 +179,15 @@ type StoreSaver = (state: SessionStoreSnapshot, options?: StoreSaverOptions) => 
 
 const pruneRemovedSessionWriteTargets = (
   targets: Set<string>,
-  sessions: readonly Pick<ChatSession, 'id'>[]
+  sessions: readonly Pick<ChatSession, 'id'>[],
+  conflictRebaseFields?: Map<string, SessionConflictRebaseField[]>
 ): void => {
   const activeSessionTargets = new Set(sessions.map((session) => `session:${session.id}`))
   for (const target of targets) {
-    if (target.startsWith('session:') && !activeSessionTargets.has(target)) targets.delete(target)
+    if (target.startsWith('session:') && !activeSessionTargets.has(target)) {
+      targets.delete(target)
+      conflictRebaseFields?.delete(target)
+    }
   }
 }
 
@@ -238,7 +247,11 @@ const createStoreSaver = (
     const nextSessions = state.sessions
     const previousById = indexById(previousSessions)
     const nextById = indexById(nextSessions)
-    const tasks: Array<{ target: string; run: () => Promise<unknown> }> = []
+    const tasks: Array<{
+      target: string
+      run: () => Promise<unknown>
+      failureContext: StoreSaverFailureContext
+    }> = []
 
     // Persist new or mutated sessions; pending sessions never touch disk until they bind a real id. A
     // session without a projectId cannot map to a sessions/<projectId>/ path (the main repository rejects
@@ -259,14 +272,21 @@ const createStoreSaver = (
       ) {
         const persisted = toPersistedSession(session)
         const previousSession = previousById.get(session.id)
-        const conflictRebaseFields = previousSession
+        const changedConflictRebaseFields = previousSession
           ? SESSION_CONFLICT_REBASE_FIELDS.filter((field) =>
               conflictRebaseFieldChanged(previousSession, session, field)
             )
           : []
+        const conflictRebaseFields = [
+          ...new Set([
+            ...changedConflictRebaseFields,
+            ...(options?.conflictRebaseFieldsByTarget?.get(target) ?? [])
+          ])
+        ]
 
         tasks.push({
           target,
+          failureContext: { conflictRebaseFields },
           run: async () => {
             const durableSession = await persistence.saveSession(
               persisted,
@@ -297,6 +317,7 @@ const createStoreSaver = (
       if (!selectedSession?.isPending) {
         tasks.push({
           target: 'manifest',
+          failureContext: {},
           run: () =>
             persistence.saveManifest({
               lastSessionId: state.selectedSessionId,
@@ -309,7 +330,7 @@ const createStoreSaver = (
     previousSessions = nextSessions
     previousSelection = state.selectedSessionId
 
-    const scheduledTasks = tasks.map(({ target, run }) => {
+    const scheduledTasks = tasks.map(({ target, run, failureContext }) => {
       // Invoke every task now so it takes its place in the shared persistence queue at snapshot time.
       return run().then(
         (result) => {
@@ -317,7 +338,7 @@ const createStoreSaver = (
           return result
         },
         (error: unknown) => {
-          observer.onFailure?.(target, error)
+          observer.onFailure?.(target, error, failureContext)
           throw error
         }
       )
@@ -340,6 +361,7 @@ const useSessionPersistence = (): SessionPersistenceState => {
   const [loadAttempt, setLoadAttempt] = useState(0)
   const retrySelection = useRef<SessionHydrationSelection | undefined>(undefined)
   const failedWriteTargets = useRef(new Set<string>())
+  const failedConflictRebaseFields = useRef(new Map<string, SessionConflictRebaseField[]>())
   const retryManifestWritePending = useRef(false)
   const saverRef = useRef<StoreSaver | undefined>(undefined)
   const dismissLoadWarning = useCallback(() => setLoadWarning(undefined), [])
@@ -365,14 +387,19 @@ const useSessionPersistence = (): SessionPersistenceState => {
     if (!saver || failedWriteTargets.current.size === 0) return
 
     const state = useSessionStore.getState()
-    pruneRemovedSessionWriteTargets(failedWriteTargets.current, state.sessions)
+    pruneRemovedSessionWriteTargets(
+      failedWriteTargets.current,
+      state.sessions,
+      failedConflictRebaseFields.current
+    )
     if (failedWriteTargets.current.size === 0) {
       setWriteError(undefined)
       return
     }
 
     void saver(state, {
-      forceTargets: new Set(failedWriteTargets.current)
+      forceTargets: new Set(failedWriteTargets.current),
+      conflictRebaseFieldsByTarget: new Map(failedConflictRebaseFields.current)
     }).catch(reportPersistenceError)
   }, [])
 
@@ -382,6 +409,7 @@ const useSessionPersistence = (): SessionPersistenceState => {
     let activeSaver: StoreSaver | undefined
     saverRef.current = undefined
     failedWriteTargets.current.clear()
+    failedConflictRebaseFields.current.clear()
 
     // Loads before subscribing so the initial empty store cannot overwrite disk state.
     const startPersistence = async (): Promise<void> => {
@@ -467,12 +495,22 @@ const useSessionPersistence = (): SessionPersistenceState => {
         window.api.sessions,
         useSessionStore.getState(),
         {
-          onFailure: (target) => {
+          onFailure: (target, _error, context) => {
             if (!isMounted) return
             failedWriteTargets.current.add(target)
+            const conflictRebaseFields = context.conflictRebaseFields
+            if (conflictRebaseFields && conflictRebaseFields.length > 0) {
+              failedConflictRebaseFields.current.set(target, [
+                ...new Set([
+                  ...(failedConflictRebaseFields.current.get(target) ?? []),
+                  ...conflictRebaseFields
+                ])
+              ])
+            }
             pruneRemovedSessionWriteTargets(
               failedWriteTargets.current,
-              useSessionStore.getState().sessions
+              useSessionStore.getState().sessions,
+              failedConflictRebaseFields.current
             )
             // A queued save can lose a race with an authoritative deletion. Its tombstone rejection
             // must not resurrect a retry target for a Session that no longer exists in the store.
@@ -485,6 +523,7 @@ const useSessionPersistence = (): SessionPersistenceState => {
           onSuccess: (target) => {
             if (!isMounted) return
             failedWriteTargets.current.delete(target)
+            failedConflictRebaseFields.current.delete(target)
             if (target === 'manifest' && retryManifestWritePending.current) {
               retryManifestWritePending.current = false
               setIsReady(true)
@@ -499,7 +538,11 @@ const useSessionPersistence = (): SessionPersistenceState => {
       saverRef.current = save
 
       unsubscribe = useSessionStore.subscribe((state) => {
-        pruneRemovedSessionWriteTargets(failedWriteTargets.current, state.sessions)
+        pruneRemovedSessionWriteTargets(
+          failedWriteTargets.current,
+          state.sessions,
+          failedConflictRebaseFields.current
+        )
         if (failedWriteTargets.current.size === 0) setWriteError(undefined)
         void save(state).catch(reportPersistenceError)
       })

--- a/src/renderer/src/stores/session-store.ts
+++ b/src/renderer/src/stores/session-store.ts
@@ -204,6 +204,7 @@ type ReplaceMessageUploadsInput = {
 type ApplyDurableSessionProjectionInput = {
   source: ChatSession
   session: PersistedChatSession
+  mode?: 'merge-upload-identities' | 'replace-persisted-if-current'
 }
 
 type AppendMessageResult = {
@@ -1101,16 +1102,18 @@ export const useSessionStore = create<SessionStore>((set, get) => ({
     })
   },
 
-  // Acknowledges the exact projection returned by this client's save. Reference equality makes an
-  // unchanged source safe to replace wholesale; a later live mutation receives only the immutable
-  // Upload identity delta so the older response cannot roll back newer conversation state.
-  applyDurableSessionProjection: ({ source, session }) => {
+  // Acknowledges the exact projection returned by this client's save. Conflict recovery may replace
+  // the full persisted projection while the submitted source is still current; a later live mutation
+  // receives only the immutable Upload identity delta so the response cannot roll it back.
+  applyDurableSessionProjection: ({ source, session, mode = 'merge-upload-identities' }) => {
     set((state) => {
       const current = state.sessions.find((candidate) => candidate.id === session.id)
       if (!current) return state
 
       let projected: ChatSession
-      if (current === source) {
+      if (current === source && mode === 'replace-persisted-if-current') {
+        projected = withTransientSessionState(session, current)
+      } else if (current === source) {
         const flat = mergeDurableUploadProjection(
           source.messages,
           source.messages,

--- a/src/shared/session-persistence.ts
+++ b/src/shared/session-persistence.ts
@@ -186,6 +186,20 @@ export type PersistedChatSession = {
   updatedAt: number
 }
 
+// Renderer-owned preferences that can be replayed onto a newer durable graph after a stale-graph
+// conflict. The field list records intent explicitly, including changes that clear optional values.
+export type SessionConflictRebaseField =
+  | 'title'
+  | 'permissionProfile'
+  | 'autoReviewEnabled'
+  | 'enabledComputeHosts'
+  | 'pinned'
+  | 'specialistId'
+
+export type SaveSessionOptions = {
+  conflictRebaseFields?: SessionConflictRebaseField[]
+}
+
 // Restored interrupted sessions carry this error verbatim; the renderer keys its resume banner off it.
 export const INTERRUPTED_SESSION_ERROR = 'Session was interrupted before the app closed.'
 


### PR DESCRIPTION
## Problem

Renderer store autosaves used a local queue, while Artifact finalization called the Session IPC save path directly. An older queued snapshot could therefore arrive after the latest Artifact-bound Session, replace the durable JSON, and make provenance capture fail with Artifact-owning Message is outside its bound Branch.

## Proposed change

- Route store saves, manifest saves, and Artifact finalization saves through one ordered renderer persistence seam.
- Validate every finalized Artifact Message binding before replacing durable Session JSON, including Versions that already have an immutable Message Snapshot.
- Add regression coverage for renderer ordering, the Artifact event path, pre-write rejection, and snapshot-before/snapshot-after binding validation.

## Scope and non-goals

- No schema migration, UI change, or Artifact format change.
- This does not introduce a general Session revision protocol; the fail-closed main-process guard is scoped to finalized Artifact Message bindings.
- This does not rewrite historical Session files that are already corrupt.

## Acceptance criteria and validation

All listed checks ran after the last material edit.

- Store autosaves cannot overtake the latest explicit Artifact save -> npm test -- src/renderer/src/lib/session-persistence/session-persistence.test.ts -> passed in the 17-test file.
- Artifact finalization shares the ordered save path -> npm test -- src/renderer/src/lib/acp/workspace-events.test.ts -> passed in the 58-test file.
- A stale finalized binding cannot overwrite durable Session JSON -> npm test -- src/main/session-persistence/coordinator.test.ts -> passed in the 57-test file.
- Stale graphs are rejected before and after Message Snapshot creation -> npm test -- src/main/artifacts/provenance-message-snapshot.test.ts -> passed in the 8-test file.
- Combined targeted suite -> 4 files, 140 tests passed.
- npm run typecheck -> passed.
- npm run lint -> passed with 0 errors; 24 existing warnings are outside the changed files.
- npm test -> 544 files and 8140 tests passed; 11 files and 139 tests skipped by project configuration.

One full-suite run hit unrelated timing failures in ProjectFilesView and notebook force-stop tests. Both files then passed independently, 209/209, and the subsequent full-suite rerun passed.

Uncovered risk: there is no real Electron end-to-end stress test for multi-window writers, and the main guard adds a bounded finalized-Version lookup to Session saves.

## Review focus

- Whether all renderer Session write paths share the intended queue.
- Whether finalized Artifact binding validation is correctly placed before JSON replacement.
- The query scope and fail-closed behavior for Sessions with long Artifact histories.