### PR TITLE
fix(notebook): activate R inventory and log installers

### DIFF
--- a/src/main/notebook/environment-state-tracker.test.ts
+++ b/src/main/notebook/environment-state-tracker.test.ts
@@ -4,7 +4,7 @@ import { join } from 'node:path'
 
 import { afterEach, describe, expect, it, vi } from 'vitest'
 
-import { EnvironmentStateTracker } from './environment-state-tracker'
+import { environmentCaptureProcessEnv, EnvironmentStateTracker } from './environment-state-tracker'
 
 let dataRoot: string | undefined
 
@@ -38,6 +38,121 @@ const readBinding = async (
 }
 
 describe('EnvironmentStateTracker', () => {
+  it('activates the complete Windows Conda DLL path for managed R probes', () => {
+    const inherited = { PATH: 'C:\\Windows\\System32', KEEP_ME: 'yes' }
+    const prefix = 'C:\\Users\\Helix\\OpenScience\\runtime\\envs\\.r'
+
+    expect(
+      environmentCaptureProcessEnv(
+        {
+          language: 'r',
+          environmentName: 'default-r',
+          runtimeSource: 'managed',
+          command: `${prefix}\\Lib\\R\\bin\\Rscript.exe`,
+          args: [],
+          condaPrefix: prefix
+        },
+        inherited,
+        'win32'
+      )
+    ).toEqual({
+      KEEP_ME: 'yes',
+      PATH: [
+        prefix,
+        `${prefix}\\Library\\mingw-w64\\bin`,
+        `${prefix}\\Library\\usr\\bin`,
+        `${prefix}\\Library\\bin`,
+        `${prefix}\\Scripts`,
+        `${prefix}\\bin`,
+        'C:\\Windows\\System32'
+      ].join(';')
+    })
+  })
+
+  it('passes the activated Windows Conda DLL path to default R inventory and fingerprint spawns', async () => {
+    dataRoot = await mkdtemp(join(tmpdir(), 'open-science-env-r-spawn-'))
+    const prefix = 'C:\\Users\\Helix\\OpenScience\\runtime\\envs\\.r'
+    const execute = vi.fn(
+      async (
+        _command: string,
+        _args: string[],
+        options: { timeout: number; maxBuffer: number; env: NodeJS.ProcessEnv }
+      ) => ({
+        stdout:
+          options.maxBuffer === 8 * 1024 * 1024
+            ? 'FILE\tconda-meta/history\t1\t1\n'
+            : 'RUNTIME\t4.5.1\twin32\tx86_64\n' +
+              'PACKAGE\tbase\t4.5.1\tbase\t4.5.1\t1\tenvironment\n',
+        stderr: ''
+      })
+    )
+    const tracker = new EnvironmentStateTracker({
+      dataRoot,
+      platform: 'win32',
+      execFile: execute
+    })
+
+    await expect(
+      tracker.prepareRun({
+        language: 'r',
+        environmentName: 'default-r',
+        runtimeSource: 'managed',
+        command: `${prefix}\\Lib\\R\\bin\\Rscript.exe`,
+        args: [],
+        condaPrefix: prefix
+      })
+    ).resolves.toMatchObject({ inventoryRefreshed: true })
+
+    expect(execute).toHaveBeenCalledTimes(3)
+    expect(execute.mock.calls.map(([, , options]) => options.maxBuffer)).toEqual([
+      8 * 1024 * 1024,
+      16 * 1024 * 1024,
+      8 * 1024 * 1024
+    ])
+    for (const [command, , options] of execute.mock.calls) {
+      expect(command).toBe(`${prefix}\\Lib\\R\\bin\\Rscript.exe`)
+      expect(options.env.PATH).toContain(`${prefix}\\Library\\bin`)
+    }
+  })
+
+  it('logs bounded child-process diagnostics when an inventory probe fails', async () => {
+    dataRoot = await mkdtemp(join(tmpdir(), 'open-science-env-probe-log-'))
+    const warn = vi.fn()
+    const tracker = new EnvironmentStateTracker({
+      dataRoot,
+      logger: { warn, error: vi.fn() },
+      inspectInstalled: vi.fn().mockRejectedValue(
+        Object.assign(new Error('Rscript failed'), {
+          code: 3221225781,
+          stderr: 'token=super-secret libgcc_s_seh-1.dll missing',
+          stdout: 'probe output'
+        })
+      ),
+      captureFingerprint: vi.fn().mockResolvedValue('stable-r')
+    })
+
+    await expect(
+      tracker.prepareRun({
+        language: 'r',
+        environmentName: 'default-r',
+        runtimeSource: 'managed',
+        command: 'C:\\runtime\\envs\\.r\\Lib\\R\\bin\\Rscript.exe',
+        args: [],
+        condaPrefix: 'C:\\runtime\\envs\\.r'
+      })
+    ).resolves.toMatchObject({ inventoryRefreshed: false })
+
+    expect(warn).toHaveBeenCalledWith(
+      'environment inventory probe failed',
+      expect.objectContaining({
+        language: 'r',
+        environmentName: 'default-r',
+        code: 3221225781,
+        stderr: expect.objectContaining({ text: expect.stringContaining('token=[redacted]') })
+      })
+    )
+  })
+
   it('inspects requested packages from the current installed inventory without importing them', async () => {
     dataRoot = await mkdtemp(join(tmpdir(), 'open-science-env-inspect-'))
     const inspectInstalled = vi.fn().mockResolvedValue({
@@ -872,5 +987,39 @@ describe('EnvironmentStateTracker', () => {
         loadedState: 'installed-only'
       })
     ])
+  })
+
+  it('keeps pre-activation R recovery state visible after adding a Conda prefix', async () => {
+    dataRoot = await mkdtemp(join(tmpdir(), 'open-science-env-r-upgrade-recovery-'))
+    const legacyTarget = {
+      language: 'r' as const,
+      environmentName: 'default-r',
+      runtimeSource: 'managed' as const,
+      command: 'C:\\runtime\\envs\\.r\\Lib\\R\\bin\\Rscript.exe',
+      args: []
+    }
+    const initial = new EnvironmentStateTracker({
+      dataRoot,
+      inspectInstalled: vi.fn().mockResolvedValue({ runtimeVersion: '4.5.1', packages: [] }),
+      captureFingerprint: vi.fn().mockResolvedValue('before-install')
+    })
+    await initial.markPackageMutationDirty(legacyTarget, {
+      operationId: 'operation-from-older-nightly',
+      operation: 'install',
+      packages: ['ggplot2']
+    })
+
+    const upgraded = new EnvironmentStateTracker({
+      dataRoot,
+      inspectInstalled: vi.fn().mockRejectedValue(new Error('environment still locked')),
+      captureFingerprint: vi.fn().mockResolvedValue('unknown')
+    })
+
+    await expect(
+      upgraded.prepareRun({
+        ...legacyTarget,
+        condaPrefix: 'C:\\runtime\\envs\\.r'
+      })
+    ).rejects.toThrow(/recovery failed before Notebook/)
   })
 })

--- a/src/main/notebook/environment-state-tracker.test.ts
+++ b/src/main/notebook/environment-state-tracker.test.ts
@@ -39,7 +39,7 @@ const readBinding = async (
 
 describe('EnvironmentStateTracker', () => {
   it('activates the complete Windows Conda DLL path for managed R probes', () => {
-    const inherited = { PATH: 'C:\\Windows\\System32', KEEP_ME: 'yes' }
+    const inherited = { Path: 'C:\\Windows\\System32', KEEP_ME: 'yes' }
     const prefix = 'C:\\Users\\Helix\\OpenScience\\runtime\\envs\\.r'
 
     expect(

--- a/src/main/notebook/environment-state-tracker.ts
+++ b/src/main/notebook/environment-state-tracker.ts
@@ -16,8 +16,16 @@ import {
   type NotebookLanguage,
   type NotebookPackageInstallerAttempt
 } from '../../shared/notebook'
+import { condaActivatedPath } from './runtime-paths'
+import { runtimeChildProcessErrorFields, type RuntimeDiagnosticLogger } from './runtime-diagnostics'
 
-const execFileAsync = promisify(execFile)
+type EnvironmentExecFile = (
+  command: string,
+  args: string[],
+  options: { timeout: number; maxBuffer: number; env: NodeJS.ProcessEnv }
+) => Promise<{ stdout: string; stderr?: string }>
+
+const execFileAsync = promisify(execFile) as EnvironmentExecFile
 const INSPECTION_TIMEOUT_MS = 30_000
 const MAX_INVENTORY_CACHE_AGE_MS = 24 * 60 * 60 * 1_000
 // The mutable binding cache is read on every run, so keep completed operation history bounded by
@@ -31,6 +39,9 @@ type EnvironmentCaptureTarget = {
   runtimeSource: 'managed' | 'external'
   command: string
   args?: string[]
+  // Conda prefix whose native DLL search path must be activated before spawning the interpreter.
+  // Required for Windows R; omitted for non-Conda external runtimes.
+  condaPrefix?: string
 }
 
 type InstalledEnvironmentInventory = {
@@ -125,10 +136,25 @@ type EnvironmentStateTrackerOptions = {
   dataRoot: string
   inspectInstalled?: (target: EnvironmentCaptureTarget) => Promise<InstalledEnvironmentInventory>
   captureFingerprint?: (target: EnvironmentCaptureTarget) => Promise<string | undefined>
+  execFile?: EnvironmentExecFile
   now?: () => Date
+  platform?: NodeJS.Platform
+  logger?: Pick<RuntimeDiagnosticLogger, 'warn' | 'error'>
   operationLogLimits?: {
     maxEntries: number
     maxBytes: number
+  }
+}
+
+const environmentCaptureProcessEnv = (
+  target: EnvironmentCaptureTarget,
+  inheritedEnv: NodeJS.ProcessEnv = process.env,
+  platform: NodeJS.Platform = process.platform
+): NodeJS.ProcessEnv => {
+  if (target.language !== 'r' || !target.condaPrefix) return inheritedEnv
+  return {
+    ...inheritedEnv,
+    PATH: condaActivatedPath(target.condaPrefix, inheritedEnv.PATH, platform)
   }
 }
 
@@ -538,7 +564,9 @@ const parseInventory = (
 }
 
 const inspectInstalledDefault = async (
-  target: EnvironmentCaptureTarget
+  target: EnvironmentCaptureTarget,
+  platform: NodeJS.Platform = process.platform,
+  execute: EnvironmentExecFile = execFileAsync
 ): Promise<InstalledEnvironmentInventory> => {
   const args = [
     ...(target.args ?? []),
@@ -546,16 +574,18 @@ const inspectInstalledDefault = async (
       ? ['-c', PYTHON_INVENTORY_SCRIPT]
       : ['--vanilla', '--slave', '-e', R_INVENTORY_SCRIPT])
   ]
-  const { stdout } = await execFileAsync(target.command, args, {
+  const { stdout } = await execute(target.command, args, {
     timeout: INSPECTION_TIMEOUT_MS,
     maxBuffer: 16 * 1024 * 1024,
-    env: process.env
+    env: environmentCaptureProcessEnv(target, process.env, platform)
   })
   return parseInventory(target.language, stdout)
 }
 
 const captureFingerprintDefault = async (
-  target: EnvironmentCaptureTarget
+  target: EnvironmentCaptureTarget,
+  platform: NodeJS.Platform = process.platform,
+  execute: EnvironmentExecFile = execFileAsync
 ): Promise<string | undefined> => {
   const args = [
     ...(target.args ?? []),
@@ -563,10 +593,10 @@ const captureFingerprintDefault = async (
       ? ['-c', PYTHON_FINGERPRINT_SCRIPT]
       : ['--vanilla', '--slave', '-e', R_FINGERPRINT_SCRIPT])
   ]
-  const { stdout } = await execFileAsync(target.command, args, {
+  const { stdout } = await execute(target.command, args, {
     timeout: INSPECTION_TIMEOUT_MS,
     maxBuffer: 8 * 1024 * 1024,
-    env: process.env
+    env: environmentCaptureProcessEnv(target, process.env, platform)
   })
   if (stdout.includes('UNWATCHABLE\t')) return undefined
   return sha256(`${target.language}\n${stdout}`)
@@ -580,12 +610,21 @@ class EnvironmentStateTracker {
     target: EnvironmentCaptureTarget
   ) => Promise<string | undefined>
   private readonly now: () => Date
+  private readonly platform: NodeJS.Platform
+  private readonly logger?: Pick<RuntimeDiagnosticLogger, 'warn' | 'error'>
   private readonly operationLogLimits: { maxEntries: number; maxBytes: number }
   private readonly targetQueues = new Map<string, Promise<void>>()
 
   constructor(private readonly options: EnvironmentStateTrackerOptions) {
-    this.inspectInstalled = options.inspectInstalled ?? inspectInstalledDefault
-    this.captureFingerprint = options.captureFingerprint ?? captureFingerprintDefault
+    this.platform = options.platform ?? process.platform
+    this.logger = options.logger
+    const execute = options.execFile ?? execFileAsync
+    this.inspectInstalled =
+      options.inspectInstalled ??
+      ((target) => inspectInstalledDefault(target, this.platform, execute))
+    this.captureFingerprint =
+      options.captureFingerprint ??
+      ((target) => captureFingerprintDefault(target, this.platform, execute))
     this.now = options.now ?? (() => new Date())
     this.operationLogLimits = options.operationLogLimits ?? {
       maxEntries: MAX_OPERATION_LOG_ENTRIES,
@@ -665,6 +704,12 @@ class EnvironmentStateTracker {
           cache.dirtyOperationId = undefined
           await this.writeBinding(target, cache)
         } catch (error) {
+          this.logProbeFailure(
+            requiresMutationRecovery ? 'error' : 'warn',
+            'environment inventory probe failed',
+            target,
+            error
+          )
           cache.state = 'dirty'
           cache.dirtyReason = requiresMutationRecovery ? 'recovery' : undefined
           await this.writeBinding(target, cache)
@@ -732,6 +777,7 @@ class EnvironmentStateTracker {
           cache.dirtyReason = undefined
           await this.writeBinding(target, cache)
         } catch (error) {
+          this.logProbeFailure('warn', 'environment inventory probe failed', target, error)
           warnings.push(`Installed package inventory unavailable: ${describeError(error)}`)
         }
       }
@@ -815,7 +861,13 @@ class EnvironmentStateTracker {
           cache.inventoryChecksum = beforeInventoryChecksum
           cache.stateFingerprint = await this.tryCaptureFingerprint(target)
           cache.verifiedAt = this.now().toISOString()
-        } catch {
+        } catch (error) {
+          this.logProbeFailure(
+            'warn',
+            'pre-install environment inventory probe failed',
+            target,
+            error
+          )
           beforeInventoryChecksum = undefined
         }
       }
@@ -909,6 +961,12 @@ class EnvironmentStateTracker {
         ]
         if (operation) await this.removeOperation(target, operation.operationId)
       } catch (error) {
+        this.logProbeFailure(
+          'error',
+          'post-install environment inventory probe failed',
+          target,
+          error
+        )
         verification = { result: 'failure', reason: 'inventory-refresh-failed' }
         const failedAttempt: NotebookInventoryRefreshAttempt = {
           attempt: baseLogEntry.inventoryRefreshAttempts.length + 1,
@@ -1009,7 +1067,30 @@ class EnvironmentStateTracker {
   private async tryCaptureFingerprint(
     target: EnvironmentCaptureTarget
   ): Promise<string | undefined> {
-    return this.captureFingerprint(target).catch(() => undefined)
+    return this.captureFingerprint(target).catch((error) => {
+      this.logProbeFailure('warn', 'environment fingerprint probe failed', target, error)
+      return undefined
+    })
+  }
+
+  private logProbeFailure(
+    level: 'warn' | 'error',
+    message: string,
+    target: EnvironmentCaptureTarget,
+    error: unknown
+  ): void {
+    try {
+      this.logger?.[level](message, {
+        ...runtimeChildProcessErrorFields(error),
+        language: target.language,
+        environmentName: target.environmentName,
+        runtimeSource: target.runtimeSource,
+        command: target.command,
+        ...(target.condaPrefix ? { condaPrefix: target.condaPrefix } : {})
+      })
+    } catch {
+      // Diagnostics are best-effort and must never replace the environment capture outcome.
+    }
   }
 
   private async publishOperationManifest(
@@ -1257,7 +1338,11 @@ class EnvironmentStateTracker {
   }
 }
 
-export { EnvironmentManifestPublicationError, EnvironmentStateTracker }
+export {
+  environmentCaptureProcessEnv,
+  EnvironmentManifestPublicationError,
+  EnvironmentStateTracker
+}
 export type {
   EnvironmentCaptureResult,
   EnvironmentRunCaptureStart,

--- a/src/main/notebook/environment-state-tracker.ts
+++ b/src/main/notebook/environment-state-tracker.ts
@@ -152,9 +152,21 @@ const environmentCaptureProcessEnv = (
   platform: NodeJS.Platform = process.platform
 ): NodeJS.ProcessEnv => {
   if (target.language !== 'r' || !target.condaPrefix) return inheritedEnv
+
+  const inheritedPath =
+    inheritedEnv.PATH ??
+    (platform === 'win32'
+      ? Object.entries(inheritedEnv).find(([key]) => key.toLowerCase() === 'path')?.[1]
+      : undefined)
+  const activatedEnv = { ...inheritedEnv }
+  if (platform === 'win32') {
+    for (const key of Object.keys(activatedEnv)) {
+      if (key.toLowerCase() === 'path') delete activatedEnv[key]
+    }
+  }
   return {
-    ...inheritedEnv,
-    PATH: condaActivatedPath(target.condaPrefix, inheritedEnv.PATH, platform)
+    ...activatedEnv,
+    PATH: condaActivatedPath(target.condaPrefix, inheritedPath, platform)
   }
 }
 

--- a/src/main/notebook/runtime-diagnostics.test.ts
+++ b/src/main/notebook/runtime-diagnostics.test.ts
@@ -1,0 +1,43 @@
+import { describe, expect, it } from 'vitest'
+
+import { boundedRuntimeDiagnostic, runtimeChildProcessErrorFields } from './runtime-diagnostics'
+
+describe('runtime diagnostics', () => {
+  it('redacts credentials and preserves both ends of long installer output', () => {
+    const diagnostic = boundedRuntimeDiagnostic(
+      `FETCH https://user:password@example.test/channel?token=secret\n` +
+        `${'x'.repeat(20_000)}\nsolver-tail-marker`
+    )
+    const serialized = JSON.stringify(diagnostic)
+
+    expect(serialized).not.toContain('password')
+    expect(serialized).not.toContain('token=secret')
+    expect(serialized).toContain('[redacted]')
+    expect(serialized).toContain('solver-tail-marker')
+    expect(diagnostic.truncated).toBe(true)
+  })
+
+  it('retains Node child-process exit diagnostics that Error serialization drops', () => {
+    const fields = runtimeChildProcessErrorFields(
+      Object.assign(new Error('Command failed'), {
+        code: 3221225781,
+        signal: null,
+        killed: false,
+        stdout: 'runtime output',
+        stderr: 'api_key=secret missing libgcc_s_seh-1.dll'
+      })
+    )
+
+    expect(fields).toMatchObject({
+      error: 'Command failed',
+      code: 3221225781,
+      signal: null,
+      killed: false,
+      stdout: { text: 'runtime output', truncated: false },
+      stderr: {
+        text: 'api_key=[redacted] missing libgcc_s_seh-1.dll',
+        truncated: false
+      }
+    })
+  })
+})

--- a/src/main/notebook/runtime-diagnostics.ts
+++ b/src/main/notebook/runtime-diagnostics.ts
@@ -1,0 +1,96 @@
+import { errorLogFields, type Logger } from '../logger'
+
+const MAX_RUNTIME_DIAGNOSTIC_CHARS = 7_800
+const RUNTIME_DIAGNOSTIC_EDGE_CHARS = 3_800
+
+type RuntimeDiagnosticLogger = Pick<Logger, 'info' | 'warn' | 'error'>
+
+type BoundedRuntimeDiagnostic = {
+  text: string
+  truncated: boolean
+  omittedChars?: number
+}
+
+const redactRuntimeDiagnosticText = (value: string): string =>
+  value
+    .replace(/https?:\/\/[^\s"'<>]+/gi, (rawUrl) => {
+      try {
+        const url = new URL(rawUrl)
+        url.username = ''
+        url.password = ''
+        url.pathname = url.pathname.replace(
+          /\/(t|token|auth|api[_-]?key|secret|password)\/[^/]+/gi,
+          '/$1/[redacted]'
+        )
+        for (const key of [...url.searchParams.keys()]) url.searchParams.set(key, '[redacted]')
+        url.hash = ''
+        return url.toString().replaceAll('%5Bredacted%5D', '[redacted]')
+      } catch {
+        return rawUrl
+      }
+    })
+    .replace(/\bBearer\s+[^\s"']+/gi, 'Bearer [redacted]')
+    .replace(/\b(api[_-]?key|token|secret|password)\b(\s*[:=]\s*)[^\s,"'&]+/gi, '$1$2[redacted]')
+    .replace(/\bsk-[A-Za-z0-9_-]{8,}\b/g, '[redacted]')
+
+const redactRuntimeDiagnosticValue = (value: unknown): unknown => {
+  if (typeof value === 'string') return redactRuntimeDiagnosticText(value)
+  if (Array.isArray(value)) return value.map(redactRuntimeDiagnosticValue)
+  if (value === null || typeof value !== 'object') return value
+  try {
+    return Object.fromEntries(
+      Object.entries(value).map(([key, nested]) => [key, redactRuntimeDiagnosticValue(nested)])
+    )
+  } catch {
+    return '[unreadable]'
+  }
+}
+
+const boundedRuntimeDiagnostic = (value: string): BoundedRuntimeDiagnostic => {
+  const redacted = redactRuntimeDiagnosticText(value)
+  if (redacted.length <= MAX_RUNTIME_DIAGNOSTIC_CHARS) {
+    return { text: redacted, truncated: false }
+  }
+  const omittedChars = redacted.length - RUNTIME_DIAGNOSTIC_EDGE_CHARS * 2
+  return {
+    text:
+      `${redacted.slice(0, RUNTIME_DIAGNOSTIC_EDGE_CHARS)}\n` +
+      `…[${omittedChars} chars omitted]…\n` +
+      redacted.slice(-RUNTIME_DIAGNOSTIC_EDGE_CHARS),
+    truncated: true,
+    omittedChars
+  }
+}
+
+const safeChildField = (error: unknown, key: string): unknown => {
+  try {
+    return error !== null && typeof error === 'object'
+      ? (error as Record<string, unknown>)[key]
+      : undefined
+  } catch {
+    return '[unreadable]'
+  }
+}
+
+const runtimeChildProcessErrorFields = (error: unknown): Record<string, unknown> => {
+  const fields = redactRuntimeDiagnosticValue(errorLogFields(error)) as Record<string, unknown>
+  for (const key of ['signal', 'killed'] as const) {
+    const value = safeChildField(error, key)
+    if (value !== undefined) fields[key] = redactRuntimeDiagnosticValue(value)
+  }
+  for (const key of ['stdout', 'stderr', 'cmd'] as const) {
+    const value = safeChildField(error, key)
+    if (typeof value === 'string') fields[key] = boundedRuntimeDiagnostic(value)
+    else if (Buffer.isBuffer(value)) fields[key] = boundedRuntimeDiagnostic(value.toString('utf8'))
+    else if (value !== undefined) fields[key] = redactRuntimeDiagnosticValue(value)
+  }
+  return fields
+}
+
+export {
+  boundedRuntimeDiagnostic,
+  redactRuntimeDiagnosticText,
+  redactRuntimeDiagnosticValue,
+  runtimeChildProcessErrorFields
+}
+export type { BoundedRuntimeDiagnostic, RuntimeDiagnosticLogger }

--- a/src/main/notebook/runtime-service-logging.integration.test.ts
+++ b/src/main/notebook/runtime-service-logging.integration.test.ts
@@ -1,0 +1,80 @@
+import { mkdtemp, readFile, rm } from 'node:fs/promises'
+import { tmpdir } from 'node:os'
+import { join } from 'node:path'
+
+import { afterAll, describe, expect, it, vi } from 'vitest'
+
+import { flushLogs, initLogger } from '../logger'
+import { NotebookRunRepository } from './repository'
+import { NotebookRuntimeService } from './runtime-service'
+
+let root: string | undefined
+
+afterAll(async () => {
+  await flushLogs()
+  if (root) await rm(root, { recursive: true, force: true })
+})
+
+describe('NotebookRuntimeService main-process logging', () => {
+  it('writes bounded redacted installer diagnostics through the default main.log sink', async () => {
+    root = await mkdtemp(join(tmpdir(), 'open-science-runtime-main-log-'))
+    const logDir = join(root, 'logs')
+    initLogger({ logDir, mirrorToConsole: false })
+    const service = new NotebookRuntimeService({
+      configRoot: root,
+      dataRoot: root,
+      projectName: 'default-project',
+      repository: new NotebookRunRepository(root),
+      environmentStateTracker: {
+        prepareRun: vi.fn(),
+        captureCompletedRun: vi.fn(),
+        inspectPackages: vi.fn(),
+        markPackageMutationDirty: vi.fn().mockResolvedValue(undefined),
+        refreshAfterPackageMutation: vi.fn().mockResolvedValue({ result: 'success' })
+      },
+      executorFactory: () => ({
+        execute: async () => {
+          throw new Error('not used')
+        },
+        shutdown: async () => ({ reaped: true })
+      }),
+      installPackagesImpl: vi.fn().mockResolvedValue({
+        ok: true,
+        needsRestart: true,
+        method: 'conda',
+        log:
+          'FETCH https://user:password@example.test/channel?token=secret\n' +
+          `${'x'.repeat(20_000)}\ntransaction-tail-marker`
+      })
+    })
+
+    await service.managePackages({ language: 'r', packages: ['ggplot2'] })
+    await flushLogs()
+
+    const serialized = await readFile(join(logDir, 'main.log'), 'utf8')
+    const record = serialized
+      .trim()
+      .split('\n')
+      .map((line) => JSON.parse(line) as Record<string, unknown>)
+      .find(
+        (candidate) =>
+          candidate.scope === 'notebook:runtime' && candidate.msg === 'package installer completed'
+      )
+    expect(record).toMatchObject({
+      level: 'info',
+      scope: 'notebook:runtime',
+      msg: 'package installer completed',
+      data: {
+        language: 'r',
+        environmentName: 'default-r',
+        packages: ['ggplot2'],
+        installerLog: {
+          truncated: true,
+          text: expect.stringContaining('transaction-tail-marker')
+        }
+      }
+    })
+    expect(serialized).not.toContain('user:password')
+    expect(serialized).not.toContain('token=secret')
+  })
+})

--- a/src/main/notebook/runtime-service.test.ts
+++ b/src/main/notebook/runtime-service.test.ts
@@ -3043,6 +3043,56 @@ describe('notebook runtime service', () => {
       expect(result.error).toMatch(/inventory refresh failed/i)
     })
 
+    it('writes bounded redacted installer diagnostics to the main-process logger', async () => {
+      const root = await createStorageRoot()
+      const info = vi.fn()
+      const service = new NotebookRuntimeService({
+        configRoot: root,
+        dataRoot: root,
+        projectName: 'default-project',
+        repository: new NotebookRunRepository(root),
+        logger: { info, warn: vi.fn(), error: vi.fn() },
+        environmentStateTracker: {
+          prepareRun: vi.fn(),
+          captureCompletedRun: vi.fn(),
+          inspectPackages: vi.fn(),
+          markPackageMutationDirty: vi.fn().mockResolvedValue(undefined),
+          refreshAfterPackageMutation: vi.fn().mockResolvedValue({ result: 'success' })
+        },
+        executorFactory: () => ({
+          execute: async () => {
+            throw new Error('not used')
+          },
+          shutdown: async () => ({ reaped: true })
+        }),
+        installPackagesImpl: vi.fn().mockResolvedValue({
+          ok: true,
+          needsRestart: true,
+          method: 'conda',
+          log:
+            'FETCH https://user:password@example.test/channel?token=secret\n' +
+            `${'x'.repeat(20_000)}\ntransaction-tail-marker`
+        })
+      })
+
+      await service.managePackages({ language: 'r', packages: ['ggplot2'] })
+
+      expect(info).toHaveBeenCalledWith(
+        'package installer completed',
+        expect.objectContaining({
+          language: 'r',
+          environmentName: 'default-r',
+          packages: ['ggplot2'],
+          method: 'conda',
+          installerLog: expect.objectContaining({ truncated: true })
+        })
+      )
+      const serialized = JSON.stringify(info.mock.calls)
+      expect(serialized).not.toContain('password')
+      expect(serialized).not.toContain('token=secret')
+      expect(serialized).toContain('transaction-tail-marker')
+    })
+
     it('resolves the effective mirror from the injected getPackageMirror + locale and forwards it as installPackages deps', async () => {
       const root = await createStorageRoot()
       const calls: Array<[InstallRequestForTest, Partial<InstallDepsForTest> | undefined]> = []

--- a/src/main/notebook/runtime-service.test.ts
+++ b/src/main/notebook/runtime-service.test.ts
@@ -3011,11 +3011,14 @@ describe('notebook runtime service', () => {
 
     it('reports failure when the post-install inventory refresh throws', async () => {
       const root = await createStorageRoot()
+      const info = vi.fn()
+      const warn = vi.fn()
       const service = new NotebookRuntimeService({
         configRoot: root,
         dataRoot: root,
         projectName: 'default-project',
         repository: new NotebookRunRepository(root),
+        logger: { info, warn, error: vi.fn() },
         environmentStateTracker: {
           prepareRun: vi.fn(),
           captureCompletedRun: vi.fn(),
@@ -3041,6 +3044,14 @@ describe('notebook runtime service', () => {
 
       expect(result).toMatchObject({ ok: false, needsRestart: false, method: 'conda' })
       expect(result.error).toMatch(/inventory refresh failed/i)
+      expect(info).not.toHaveBeenCalledWith('package installer completed', expect.anything())
+      expect(warn).toHaveBeenCalledWith(
+        'package installer completed',
+        expect.objectContaining({
+          ok: false,
+          error: expect.stringMatching(/inventory refresh failed/i)
+        })
+      )
     })
 
     it('writes bounded redacted installer diagnostics to the main-process logger', async () => {

--- a/src/main/notebook/runtime-service.ts
+++ b/src/main/notebook/runtime-service.ts
@@ -111,6 +111,7 @@ import {
 import { isChildUnconfirmedError } from './provisioner-runtime'
 import { getAppClaudeConfigDir } from '../settings/provider-env'
 import { terminateProcessTree } from '../process-tree'
+import { createLogger, getLogFilePath } from '../logger'
 import { resolveWindowsPowerShellExecutable } from '../windows-powershell'
 import {
   EnvironmentManifestPublicationError,
@@ -120,6 +121,12 @@ import {
   type PackageMutationVerification
 } from './environment-state-tracker'
 import { startWorkingFileObservation } from './working-file-observer'
+import {
+  boundedRuntimeDiagnostic,
+  redactRuntimeDiagnosticValue,
+  runtimeChildProcessErrorFields,
+  type RuntimeDiagnosticLogger
+} from './runtime-diagnostics'
 
 // Locale fallback when no explicit locale is injected (see shared/mirror.ts: non-CN locales resolve
 // to public hosts, so this default never silently forces a CN mirror).
@@ -366,6 +373,9 @@ type NotebookRuntimeServiceOptions = {
     request: InstallRequest,
     deps?: Partial<InstallDeps>
   ) => Promise<InstallResult>
+  // Structured main-process diagnostics for package operations and interpreter probes. Injectable so
+  // tests assert logging without initializing the rotating file sink.
+  logger?: RuntimeDiagnosticLogger
   // Provisioner-backed named-environment manager for manageEnvironments. Injectable so tests use a
   // fake; the production instance (the DefaultRuntimeProvisioner) is wired after construction in
   // main/ipc.ts via setEnvironmentManager, mirroring the mcp/mirror resolvers.
@@ -1118,6 +1128,7 @@ class NotebookRuntimeService {
     request: InstallRequest,
     deps?: Partial<InstallDeps>
   ) => Promise<InstallResult>
+  private readonly runtimeLogger?: RuntimeDiagnosticLogger
   private readonly environmentStateTracker: Pick<
     EnvironmentStateTracker,
     | 'prepareRun'
@@ -1149,8 +1160,15 @@ class NotebookRuntimeService {
         )
       })
     this.installPackagesImpl = options.installPackagesImpl ?? installPackagesDefault
+    this.runtimeLogger =
+      options.logger ?? (getLogFilePath() ? createLogger('notebook:runtime') : undefined)
     this.environmentStateTracker =
-      options.environmentStateTracker ?? new EnvironmentStateTracker({ dataRoot: options.dataRoot })
+      options.environmentStateTracker ??
+      new EnvironmentStateTracker({
+        dataRoot: options.dataRoot,
+        platform: options.platform,
+        logger: this.runtimeLogger
+      })
     this.environmentManager = options.environmentManager
   }
 
@@ -1285,7 +1303,10 @@ class NotebookRuntimeService {
       runtimeSource: binding?.source === 'external' ? 'external' : 'managed',
       command:
         resolvedInterpreter?.command ?? (language === 'r' ? rScriptBin(prefix) : pythonBin(prefix)),
-      args: resolvedInterpreter?.args
+      args: resolvedInterpreter?.args,
+      ...(language === 'r' && (resolvedInterpreter?.condaPrefix || binding?.source !== 'external')
+        ? { condaPrefix: resolvedInterpreter?.condaPrefix ?? prefix }
+        : {})
     }
   }
 
@@ -2878,37 +2899,62 @@ class NotebookRuntimeService {
         await this.environmentStateTracker.markPackageMutationDirty(environmentTarget, mutation)
         let installResult: InstallResult | undefined
         let deferredQuarantineError: Error | undefined
+        const installerStartedAt = Date.now()
         try {
-          installResult = await this.installPackagesImpl(pinnedRequest, {
-            storageRoot: this.options.dataRoot,
-            condaChannel: mirror.condaChannel,
-            pypiIndex: mirror.pypiIndex,
-            cranMirror: mirror.cranMirror,
-            caBundle: mirror.caBundle,
-            interpreter,
-            // Re-arm the per-spawn intent immediately before EACH installer spawn (conda then CRAN), so a
-            // second spawn whose PID isn't recorded yet blocks rather than trusting the first's PID.
-            onBeforeSpawn: () => recordSpawnIntentSync(runtimeRoot, operationId),
-            // Record each installer child's PID so startup recovery can block on a surviving conda/pip/R
-            // install (never reconcile the env under it) until it is provably gone. Recovery never signals
-            // the child. Persisted SYNCHRONOUSLY (crash-safe) so a spawned child is always probeable; the
-            // async journal update is the normal read path.
-            onChild: (childPid) => {
-              const childStartedAt = Date.now()
-              // Kernel-native identity token captured while the child is alive, so recovery can FALSIFY
-              // pid reuse (a changed token proves the pid is no longer ours); undefined off Linux — see
-              // readProcessStartToken. Never used to authorize a signal.
-              const childStartToken = readProcessStartToken(childPid)
-              recordOperationChildSync(runtimeRoot, operationId, {
-                childPid,
-                childStartedAt,
-                childStartToken
-              })
-              void journal
-                .update(operationId, { childPid, childStartedAt, childStartToken })
-                .catch(() => undefined)
-            }
-          })
+          try {
+            installResult = await this.installPackagesImpl(pinnedRequest, {
+              storageRoot: this.options.dataRoot,
+              condaChannel: mirror.condaChannel,
+              pypiIndex: mirror.pypiIndex,
+              cranMirror: mirror.cranMirror,
+              caBundle: mirror.caBundle,
+              interpreter,
+              // Re-arm the per-spawn intent immediately before EACH installer spawn (conda then CRAN), so a
+              // second spawn whose PID isn't recorded yet blocks rather than trusting the first's PID.
+              onBeforeSpawn: () => recordSpawnIntentSync(runtimeRoot, operationId),
+              // Record each installer child's PID so startup recovery can block on a surviving conda/pip/R
+              // install (never reconcile the env under it) until it is provably gone. Recovery never signals
+              // the child. Persisted SYNCHRONOUSLY (crash-safe) so a spawned child is always probeable; the
+              // async journal update is the normal read path.
+              onChild: (childPid) => {
+                const childStartedAt = Date.now()
+                // Kernel-native identity token captured while the child is alive, so recovery can FALSIFY
+                // pid reuse (a changed token proves the pid is no longer ours); undefined off Linux — see
+                // readProcessStartToken. Never used to authorize a signal.
+                const childStartToken = readProcessStartToken(childPid)
+                recordOperationChildSync(runtimeRoot, operationId, {
+                  childPid,
+                  childStartedAt,
+                  childStartToken
+                })
+                void journal
+                  .update(operationId, { childPid, childStartedAt, childStartToken })
+                  .catch(() => undefined)
+              }
+            })
+            this.logPackageInstallerResult(
+              operationId,
+              mutation.operation,
+              request.language,
+              envName,
+              environmentTarget.runtimeSource,
+              request.packages,
+              installResult,
+              Date.now() - installerStartedAt
+            )
+          } catch (error) {
+            this.logPackageInstallerFailure(
+              operationId,
+              mutation.operation,
+              request.language,
+              envName,
+              environmentTarget.runtimeSource,
+              request.packages,
+              error,
+              Date.now() - installerStartedAt
+            )
+            throw error
+          }
         } finally {
           let inventoryRefreshError: unknown
           const verification: PackageMutationVerification | undefined =
@@ -3080,6 +3126,66 @@ class NotebookRuntimeService {
     }
 
     return result
+  }
+
+  private logPackageInstallerResult(
+    operationId: string,
+    operation: 'create' | 'install' | 'uninstall' | 'update',
+    language: NotebookLanguage,
+    environmentName: string,
+    runtimeSource: 'managed' | 'external',
+    packages: string[],
+    result: InstallResult,
+    durationMs: number
+  ): void {
+    try {
+      const fields = redactRuntimeDiagnosticValue({
+        operationId,
+        operation,
+        language,
+        environmentName,
+        runtimeSource,
+        packages,
+        ok: result.ok,
+        needsRestart: result.needsRestart,
+        method: result.method,
+        fallbackUsed: result.fallbackUsed,
+        repairRequired: result.repairRequired,
+        prefix: result.prefix,
+        error: result.error,
+        durationMs,
+        installerLog: boundedRuntimeDiagnostic(result.log)
+      })
+      this.runtimeLogger?.[result.ok ? 'info' : 'warn']('package installer completed', fields)
+    } catch {
+      // Diagnostics are best-effort and must never replace the installer result.
+    }
+  }
+
+  private logPackageInstallerFailure(
+    operationId: string,
+    operation: 'create' | 'install' | 'uninstall' | 'update',
+    language: NotebookLanguage,
+    environmentName: string,
+    runtimeSource: 'managed' | 'external',
+    packages: string[],
+    error: unknown,
+    durationMs: number
+  ): void {
+    try {
+      this.runtimeLogger?.error('package installer threw', {
+        ...runtimeChildProcessErrorFields(error),
+        operationId,
+        operation,
+        language,
+        environmentName,
+        runtimeSource,
+        packages: redactRuntimeDiagnosticValue(packages),
+        durationMs
+      })
+    } catch {
+      // Diagnostics are best-effort and must never replace the installer failure.
+    }
   }
 
   // Named-environment management (design D2), delegating to the injected provisioner-backed manager.

--- a/src/main/notebook/runtime-service.ts
+++ b/src/main/notebook/runtime-service.ts
@@ -2900,6 +2900,7 @@ class NotebookRuntimeService {
         let installResult: InstallResult | undefined
         let deferredQuarantineError: Error | undefined
         const installerStartedAt = Date.now()
+        let installerDurationMs = 0
         try {
           try {
             installResult = await this.installPackagesImpl(pinnedRequest, {
@@ -2932,16 +2933,7 @@ class NotebookRuntimeService {
                   .catch(() => undefined)
               }
             })
-            this.logPackageInstallerResult(
-              operationId,
-              mutation.operation,
-              request.language,
-              envName,
-              environmentTarget.runtimeSource,
-              request.packages,
-              installResult,
-              Date.now() - installerStartedAt
-            )
+            installerDurationMs = Date.now() - installerStartedAt
           } catch (error) {
             this.logPackageInstallerFailure(
               operationId,
@@ -3038,6 +3030,18 @@ class NotebookRuntimeService {
           }
         }
         if (deferredQuarantineError) throw deferredQuarantineError
+        if (installResult) {
+          this.logPackageInstallerResult(
+            operationId,
+            mutation.operation,
+            request.language,
+            envName,
+            environmentTarget.runtimeSource,
+            request.packages,
+            installResult,
+            installerDurationMs
+          )
+        }
         return installResult
       })
     } catch (error) {


### PR DESCRIPTION
## Problem

On Windows, Conda-backed R environment inventory and fingerprint probes launched `Rscript.exe` with the raw main-process environment instead of the activated Conda PATH used by the kernel. After an agent package operation, the recovery probe could therefore fail to resolve DLLs such as `Library/bin/libgcc_s_seh-1.dll` and block kernel restart even when the environment itself was intact.

Installer and probe failures also lacked bounded, credential-safe child-process details in the main-process `main.log`, making nightly-package failures difficult to diagnose.

## Proposed change

- Give managed and external Conda R inventory/fingerprint probes the same activated PATH layout used by the kernel, including the Windows Conda DLL directories.
- Preserve the existing environment cache/recovery key while carrying the Conda prefix as execution context.
- Add structured installer and probe diagnostics to `main.log`, including exit metadata and bounded stdout/stderr/cmd fields.
- Redact URL credentials, bearer tokens, common secret parameters, and OpenAI-style secret keys from diagnostics.
- Cover the default subprocess boundary and the real rotating `main.log` sink, not only helper functions or injected loggers.

## Scope and non-goals

- Keep strict post-install recovery behavior; this change fixes the environment used by recovery probes rather than weakening the guard.
- Do not reset or reinstall user environments.
- Do not change renderer or spreadsheet behavior.
- Do not change the persisted cache/recovery target identity.

## Acceptance criteria and validation

| Behavior | Command | Result |
| --- | --- | --- |
| Windows Conda R fingerprint/inventory default spawns receive the activated DLL PATH | `npm test -- src/main/notebook/environment-state-tracker.test.ts src/main/notebook/runtime-diagnostics.test.ts src/main/notebook/runtime-service.test.ts src/main/notebook/runtime-service-logging.integration.test.ts` | Passed: 4 files, 173 tests |
| Installer records reach the real main-process `main.log`; diagnostic fields are bounded and redacted | Same focused test command | Passed, including disk-backed JSONL integration coverage |
| Legacy dirty/recovery state remains addressable after the execution-context addition | Same focused test command | Passed |
| TypeScript validation | `npm run typecheck` | Passed |
| Lint validation | `npm run lint` | Passed with 0 errors and 24 warnings in unrelated existing files |
| Patch whitespace validation | `git diff origin/main...HEAD --check` | Passed |
| Full repository suite | `npm test` | **Not green:** 8,142 passed, 3 failed, 139 skipped. All failures are in the unchanged `src/renderer/src/pages/workspace/previews/spreadsheet-cache-policy.test.ts` (cached row count, retained worksheet count, and pending-request cap). |

Independent standards and spec reviews found no remaining code-hunk or requirement gaps after the default-spawn and real-log-sink tests were added.

## Review focus

- Parity between the R probe PATH and the established kernel Conda activation PATH on Windows.
- Diagnostic size bounds and credential redaction before records reach `main.log`.
- Compatibility of existing dirty/recovery state across the added execution context.

## Uncovered risks

- A packaged Windows nightly smoke test is still needed to prove that the real `Rscript.exe` resolves `libgcc_s_seh-1.dll` and that kernel restart recovers after an agent installs an R package.
- The repository's required full `npm test` gate remains blocked by the three unrelated spreadsheet cache-policy failures above; the PR is Draft until that gate is resolved or accepted by maintainers.
