### PR TITLE
fix(logging): record renderer lifecycle failures

### DIFF
--- a/src/main/windows.test.ts
+++ b/src/main/windows.test.ts
@@ -546,6 +546,45 @@ describe('close chord interception', () => {
     }
   })
 
+  it.each([
+    ['close listener', signalRendererReady],
+    ['find listener', signalWindowFindReady]
+  ])('clears stale hang context when the %s READY handshake arrives', (_label, signalReady) => {
+    const now = vi.spyOn(Date, 'now').mockReturnValue(1_000)
+    try {
+      createMainWindow()
+      const window = currentWindow!
+
+      fireWebContentsEvent(window, 'unresponsive')
+      signalReady(window)
+      fireWebContentsEvent(window, 'render-process-gone', {}, { reason: 'crashed', exitCode: 1 })
+
+      expect(windowLogSpies.error).toHaveBeenCalledWith('renderer process gone', {
+        reason: 'crashed',
+        exitCode: 1,
+        wasUnresponsive: false
+      })
+    } finally {
+      now.mockRestore()
+    }
+  })
+
+  it('does not carry unresponsive state into a replacement renderer process', () => {
+    createMainWindow()
+    const window = currentWindow!
+
+    fireWebContentsEvent(window, 'unresponsive')
+    fireWebContentsEvent(window, 'render-process-gone', {}, { reason: 'crashed', exitCode: 1 })
+    windowLogSpies.error.mockClear()
+    fireWebContentsEvent(window, 'render-process-gone', {}, { reason: 'killed', exitCode: 2 })
+
+    expect(windowLogSpies.error).toHaveBeenCalledWith('renderer process gone', {
+      reason: 'killed',
+      exitCode: 2,
+      wasUnresponsive: false
+    })
+  })
+
   it('closes the find overlay when the renderer process is gone', () => {
     createMainWindow()
     const window = currentWindow!

--- a/src/main/windows.test.ts
+++ b/src/main/windows.test.ts
@@ -17,6 +17,18 @@ const { openExternalMock, ipcMainOnMock, ipcMainRemoveListenerMock } = vi.hoiste
   ipcMainRemoveListenerMock: vi.fn()
 }))
 
+const { windowLogSpies } = vi.hoisted(() => ({
+  windowLogSpies: {
+    info: vi.fn(),
+    warn: vi.fn(),
+    error: vi.fn()
+  }
+}))
+
+vi.mock('./logger', () => ({
+  createLogger: () => windowLogSpies
+}))
+
 // The overlay manager is a collaborator with its own deep test suite; here we only need to observe
 // that the chord/Escape wiring drives it, so the real module is replaced with a spy object.
 const { findOverlayMock } = vi.hoisted(() => ({
@@ -261,6 +273,9 @@ describe('close chord interception', () => {
     findOverlayMock.destroy.mockClear()
     findOverlayMock.updateAppearance.mockClear()
     findOverlayMock.isOpen.mockReturnValue(false)
+    windowLogSpies.info.mockClear()
+    windowLogSpies.warn.mockClear()
+    windowLogSpies.error.mockClear()
   })
 
   // Fires an ipcMain handshake signal that main registered via ipcMain.on, spoofing the sender as this
@@ -489,12 +504,46 @@ describe('close chord interception', () => {
 
     signalRendererReady(window)
     // The renderer crashed; its listener died with the process until a fresh one re-handshakes.
-    fireWebContentsEvent(window, 'render-process-gone')
+    fireWebContentsEvent(window, 'render-process-gone', {}, { reason: 'crashed', exitCode: 1 })
 
     fireInput(window, closeChord())
 
     expect(window.closeMock).toHaveBeenCalledTimes(1)
     expect(window.sendMock).not.toHaveBeenCalled()
+  })
+
+  it('records why the renderer process terminated', () => {
+    createMainWindow()
+    const window = currentWindow!
+
+    fireWebContentsEvent(window, 'render-process-gone', {}, { reason: 'crashed', exitCode: 139 })
+
+    expect(windowLogSpies.error).toHaveBeenCalledWith('renderer process gone', {
+      reason: 'crashed',
+      exitCode: 139,
+      wasUnresponsive: false
+    })
+  })
+
+  it('records the known hang duration when an unresponsive renderer terminates', () => {
+    const now = vi.spyOn(Date, 'now')
+    now.mockReturnValueOnce(2_000).mockReturnValueOnce(6_500)
+    try {
+      createMainWindow()
+      const window = currentWindow!
+
+      fireWebContentsEvent(window, 'unresponsive')
+      fireWebContentsEvent(window, 'render-process-gone', {}, { reason: 'oom', exitCode: 5 })
+
+      expect(windowLogSpies.error).toHaveBeenCalledWith('renderer process gone', {
+        reason: 'oom',
+        exitCode: 5,
+        wasUnresponsive: true,
+        unresponsiveDurationMs: 4_500
+      })
+    } finally {
+      now.mockRestore()
+    }
   })
 
   it('closes the find overlay when the renderer process is gone', () => {
@@ -504,7 +553,7 @@ describe('close chord interception', () => {
     fireInput(window, findChord())
     findOverlayMock.close.mockClear()
 
-    fireWebContentsEvent(window, 'render-process-gone')
+    fireWebContentsEvent(window, 'render-process-gone', {}, { reason: 'crashed', exitCode: 1 })
 
     expect(findOverlayMock.close).toHaveBeenCalledTimes(1)
   })
@@ -540,6 +589,33 @@ describe('close chord interception', () => {
     expect(findOverlayMock.close).toHaveBeenCalledTimes(1)
   })
 
+  it('records when the renderer becomes unresponsive', () => {
+    createMainWindow()
+    const window = currentWindow!
+
+    fireWebContentsEvent(window, 'unresponsive')
+
+    expect(windowLogSpies.warn).toHaveBeenCalledWith('renderer became unresponsive')
+  })
+
+  it('records renderer recovery with the unresponsive duration', () => {
+    const now = vi.spyOn(Date, 'now')
+    now.mockReturnValueOnce(1_000).mockReturnValueOnce(3_750)
+    try {
+      createMainWindow()
+      const window = currentWindow!
+
+      fireWebContentsEvent(window, 'unresponsive')
+      fireWebContentsEvent(window, 'responsive')
+
+      expect(windowLogSpies.info).toHaveBeenCalledWith('renderer became responsive', {
+        unresponsiveDurationMs: 2_750
+      })
+    } finally {
+      now.mockRestore()
+    }
+  })
+
   it('forwards again after unresponsive -> crash -> reload -> ready, with no responsive event', () => {
     createMainWindow()
     const window = currentWindow!
@@ -549,7 +625,7 @@ describe('close chord interception', () => {
     // process never emits 'responsive' (that is a same-process recovery signal), so READY alone must
     // clear the stale unresponsive state or the chord stays a direct close forever.
     fireWebContentsEvent(window, 'unresponsive')
-    fireWebContentsEvent(window, 'render-process-gone')
+    fireWebContentsEvent(window, 'render-process-gone', {}, { reason: 'crashed', exitCode: 1 })
     fireWebContentsEvent(window, 'did-start-navigation', mainFrameNavigation)
     signalRendererReady(window)
 

--- a/src/main/windows.ts
+++ b/src/main/windows.ts
@@ -14,6 +14,7 @@ import iconWindows from '../../resources/icon-light.ico?asset'
 import { isAllowedExternalNavigation, isAllowedFrameNavigation } from './navigation-policy'
 import { createFindOverlayManager, type FindOverlayDeps } from './find-overlay'
 import { registerFindOverlayOwner } from './find-overlay-registry'
+import { createLogger } from './logger'
 import {
   CLOSE_ACTIVE_PANE_CHANNEL,
   CLOSE_ACTIVE_PANE_READY_CHANNEL,
@@ -34,6 +35,7 @@ const icon = process.platform === 'win32' ? iconWindows : iconPng
 // The find overlay is a static page (no bundler entry) shipped under resources/, so it resolves the
 // same way in dev (project root) and packaged (asar root) via app.getAppPath().
 const findOverlayEntry = join(app.getAppPath(), 'resources/find-overlay/index.html')
+const log = createLogger('window')
 
 const loadRenderer = (window: BrowserWindow): void => {
   if (is.dev && process.env['ELECTRON_RENDERER_URL']) {
@@ -112,6 +114,7 @@ const createMainWindow = (opts?: MainWindowCloseOptions): BrowserWindow => {
   let rendererListenerReady = false
   let windowFindListenerReady = false
   let rendererResponsive = true
+  let rendererUnresponsiveAt: number | undefined
   const onListenerReady = (event: IpcMainEvent): void => {
     if (event.sender !== window.webContents) return
     rendererListenerReady = true
@@ -154,17 +157,39 @@ const createMainWindow = (opts?: MainWindowCloseOptions): BrowserWindow => {
       findOverlay.close()
     }
   })
-  window.webContents.on('render-process-gone', () => {
+  // Persist only fixed Electron lifecycle vocabulary and numeric timing/exit metadata. Current URLs,
+  // Session content, renderer console output, process arguments, and local paths stay out of main.log.
+  window.webContents.on('render-process-gone', (_event, details) => {
+    const wasUnresponsive = !rendererResponsive
+    log.error('renderer process gone', {
+      reason: details.reason,
+      exitCode: details.exitCode,
+      wasUnresponsive,
+      ...(rendererUnresponsiveAt === undefined
+        ? {}
+        : { unresponsiveDurationMs: Math.max(0, Date.now() - rendererUnresponsiveAt) })
+    })
     rendererListenerReady = false
     windowFindListenerReady = false
+    rendererUnresponsiveAt = undefined
     findOverlay.close()
   })
   window.webContents.on('unresponsive', () => {
+    if (rendererResponsive) {
+      rendererUnresponsiveAt = Date.now()
+      log.warn('renderer became unresponsive')
+    }
     rendererResponsive = false
     findOverlay.close()
   })
   window.webContents.on('responsive', () => {
+    if (!rendererResponsive && rendererUnresponsiveAt !== undefined) {
+      log.info('renderer became responsive', {
+        unresponsiveDurationMs: Math.max(0, Date.now() - rendererUnresponsiveAt)
+      })
+    }
     rendererResponsive = true
+    rendererUnresponsiveAt = undefined
   })
   window.on('closed', () => {
     ipcMain.removeListener(CLOSE_ACTIVE_PANE_READY_CHANNEL, onListenerReady)

--- a/src/main/windows.ts
+++ b/src/main/windows.ts
@@ -115,6 +115,10 @@ const createMainWindow = (opts?: MainWindowCloseOptions): BrowserWindow => {
   let windowFindListenerReady = false
   let rendererResponsive = true
   let rendererUnresponsiveAt: number | undefined
+  const clearRendererHangState = (): void => {
+    rendererResponsive = true
+    rendererUnresponsiveAt = undefined
+  }
   const onListenerReady = (event: IpcMainEvent): void => {
     if (event.sender !== window.webContents) return
     rendererListenerReady = true
@@ -122,7 +126,7 @@ const createMainWindow = (opts?: MainWindowCloseOptions): BrowserWindow => {
     // unresponsive state here too: after unresponsive -> render-process-gone -> reload, the fresh
     // process never emits 'responsive' (that only fires as recovery on the *same* process), so READY
     // is the only signal that the new renderer can act on the chord.
-    rendererResponsive = true
+    clearRendererHangState()
   }
   const onListenerGone = (event: IpcMainEvent): void => {
     if (event.sender === window.webContents) rendererListenerReady = false
@@ -130,7 +134,7 @@ const createMainWindow = (opts?: MainWindowCloseOptions): BrowserWindow => {
   const onWindowFindReady = (event: IpcMainEvent): void => {
     if (event.sender !== window.webContents) return
     windowFindListenerReady = true
-    rendererResponsive = true
+    clearRendererHangState()
   }
   const onWindowFindGone = (event: IpcMainEvent): void => {
     if (event.sender !== window.webContents) return
@@ -171,7 +175,7 @@ const createMainWindow = (opts?: MainWindowCloseOptions): BrowserWindow => {
     })
     rendererListenerReady = false
     windowFindListenerReady = false
-    rendererUnresponsiveAt = undefined
+    clearRendererHangState()
     findOverlay.close()
   })
   window.webContents.on('unresponsive', () => {
@@ -188,8 +192,7 @@ const createMainWindow = (opts?: MainWindowCloseOptions): BrowserWindow => {
         unresponsiveDurationMs: Math.max(0, Date.now() - rendererUnresponsiveAt)
       })
     }
-    rendererResponsive = true
-    rendererUnresponsiveAt = undefined
+    clearRendererHangState()
   })
   window.on('closed', () => {
     ipcMain.removeListener(CLOSE_ACTIVE_PANE_READY_CHANNEL, onListenerReady)


### PR DESCRIPTION
## Problem

Issue #503 reports an application hang, but main.log does not currently preserve enough renderer lifecycle context to distinguish a temporary renderer stall from a renderer process termination. This makes follow-up diagnosis depend on information that is lost when the affected process stops responding.

## Proposed change

- Record a warning when Electron marks the main renderer unresponsive.
- Record recovery and the measured unresponsive duration when the renderer becomes responsive again.
- Record render-process-gone reason, exit code, whether the renderer was already unresponsive, and the known hang duration.
- Reset hang state at READY and process boundaries so diagnostics cannot carry stale context into a replacement renderer.
- Keep the payload privacy-safe: only fixed lifecycle vocabulary and numeric timing or exit metadata are persisted.

## Scope and non-goals

- This is diagnostic instrumentation only; it does not claim to fix the underlying hang in #503.
- It does not add renderer console capture, profiling, automatic restart, or recovery behavior.
- It does not log URLs, session or user content, process arguments, or local paths.

Related to #503.

## Acceptance criteria and validation

| Behavior | Validation | Result |
| --- | --- | --- |
| Renderer hang, recovery, termination, and process-boundary state are covered | npm test -- src/main/windows.test.ts | 39 passed |
| Main and renderer TypeScript projects compile | npm run typecheck | Passed |
| Repository lint rules | npm run lint | Passed with 0 errors; 24 warnings outside this diff |
| Full regression suite | npm test -- --maxWorkers 4 | 544 files passed; 8,144 tests passed; 11 files and 139 tests skipped |
| Patch formatting | git diff --check origin/main...HEAD | Passed |

The full suite was run outside the filesystem sandbox because several existing fixtures bind local loopback sockets. The initial sandboxed attempt failed with EPERM on 127.0.0.1; the unrestricted rerun passed.

Remaining non-blocking risk: the lifecycle callbacks use mocked Electron events and a mocked logger. Existing logger tests cover file persistence, but there is no packaged Electron smoke test for these exact records in a physical main.log.

## Review focus

- Renderer lifecycle transition semantics, especially READY and replacement-process boundaries.
- Whether the structured fields are sufficient for issue follow-up without collecting user data.
- The deliberate separation between diagnostics and any future recovery or root-cause fix.