### PR TITLE
fix(reviewer): refresh message branch review status

### DIFF
--- a/src/renderer/src/pages/workspace/WorkspaceMessageScroller.interaction.test.tsx
+++ b/src/renderer/src/pages/workspace/WorkspaceMessageScroller.interaction.test.tsx
@@ -3,8 +3,10 @@ import { act } from 'react'
 import { createRoot, type Root } from 'react-dom/client'
 import type { PropsWithChildren } from 'react'
 import type { ChatMessage, ChatSession } from '@/stores/session-store'
+import { createInitialReviewState, useReviewStore } from '@/stores/review-store'
 import { createUploadVersionReference, type UploadedAttachment } from '../../../../shared/uploads'
 import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest'
+import type { ReviewWithChecks } from '../../../../shared/reviewer'
 
 // pdfjs-dist references DOMMatrix at module load, which jsdom does not provide. This suite exercises
 // click/scroll behavior, not PDF rendering, so stub the library to keep the import graph loadable.
@@ -105,6 +107,7 @@ describe('WorkspaceMessageScroller artifact click behavior', () => {
   beforeEach(() => {
     upsertAndActivateItem.mockClear()
     announceWindowFindReady.mockClear()
+    useReviewStore.setState(createInitialReviewState())
     container = document.createElement('div')
     document.body.appendChild(container)
     window.api = {
@@ -133,6 +136,9 @@ describe('WorkspaceMessageScroller artifact click behavior', () => {
           .fn()
           .mockResolvedValue({ content: '', encoding: 'utf8', size: 0, truncated: false })
       },
+      reviewer: {
+        getForSession: vi.fn().mockResolvedValue([])
+      },
       window: {
         announceWindowFindReady
       }
@@ -144,6 +150,72 @@ describe('WorkspaceMessageScroller artifact click behavior', () => {
       root.unmount()
     })
     container.remove()
+  })
+
+  it('updates the visible message-branch review card when a running review completes', async () => {
+    const { WorkspaceMessageScroller } = await import('./WorkspaceMessageScroller')
+    const runningReview: ReviewWithChecks = {
+      id: 'review-1',
+      projectId: 'default',
+      sessionId: 'session-1',
+      turnMessageId: 'reply-1',
+      scope: {
+        turnMessageId: 'reply-1',
+        messageBranchId: 'message-branch-1',
+        blocks: [],
+        artifactVersionIds: []
+      },
+      lifecycle: 'running',
+      outcome: null,
+      model: 'test-model',
+      reviewerLog: [],
+      createdAt: 1_000,
+      updatedAt: 1_000,
+      checks: []
+    }
+    useReviewStore.getState().handleReviewUpdate({ review: runningReview })
+
+    const session = createSession({
+      status: 'idle',
+      messages: [
+        createMessage({ id: 'prompt-1' }),
+        createMessage({
+          id: 'reply-1',
+          role: 'agent',
+          content: 'Completed work',
+          responseToMessageId: 'prompt-1'
+        })
+      ]
+    })
+
+    root = createRoot(container)
+    await act(async () => {
+      root.render(
+        <WorkspaceMessageScroller
+          activeSession={session}
+          canEditMessage={false}
+          onSendEditedMessage={vi.fn()}
+        />
+      )
+    })
+    expect(container.textContent).toContain('Reviewing…')
+
+    await act(async () => {
+      useReviewStore.getState().handleReviewUpdate({
+        review: {
+          ...runningReview,
+          lifecycle: 'complete',
+          outcome: 'pass',
+          updatedAt: 2_000
+        }
+      })
+    })
+
+    expect(
+      useReviewStore.getState().getReviewForTurn('session-1', 'reply-1', 'default')?.lifecycle
+    ).toBe('complete')
+    expect(container.textContent).toContain('No issues found')
+    expect(container.textContent).not.toContain('Reviewing…')
   })
 
   it('upserts and activates the clicked artifact in the preview store, scoped to the active session', async () => {

--- a/src/renderer/src/pages/workspace/WorkspaceMessageScroller.render.test.tsx
+++ b/src/renderer/src/pages/workspace/WorkspaceMessageScroller.render.test.tsx
@@ -73,14 +73,15 @@ vi.mock('@/stores/preview-workbench-store', () => ({
 }))
 
 vi.mock('@/stores/review-store', () => ({
+  selectProjectSessionReviews: () => [],
   useReviewStore: (
     selector: (state: {
-      getReviewForTurn: () => undefined
+      reviewsBySession: Record<string, never[]>
       loadReviewsForSession: () => Promise<void>
     }) => unknown
   ) =>
     selector({
-      getReviewForTurn: () => undefined,
+      reviewsBySession: {},
       loadReviewsForSession: () => Promise.resolve()
     })
 }))

--- a/src/renderer/src/pages/workspace/WorkspaceMessageScroller.tsx
+++ b/src/renderer/src/pages/workspace/WorkspaceMessageScroller.tsx
@@ -9,7 +9,7 @@ import {
   usePreviewWorkbenchStore,
   createSessionReviewerPreviewItem
 } from '@/stores/preview-workbench-store'
-import { useReviewStore } from '@/stores/review-store'
+import { selectProjectSessionReviews, useReviewStore } from '@/stores/review-store'
 import { useSettingsStore } from '@/stores/settings-store'
 import { useSessionStore, type ChatSession } from '@/stores/session-store'
 import { useCallback, useEffect, useMemo, useRef, useState } from 'react'
@@ -125,7 +125,9 @@ const WorkspaceMessageScroller = ({
     const stop = window.api?.window?.announceWindowFindReady?.()
     return () => stop?.()
   }, [])
-  const getReviewForTurn = useReviewStore((state) => state.getReviewForTurn)
+  const currentSessionReviews = useReviewStore((state) =>
+    selectProjectSessionReviews(state.reviewsBySession, currentProjectId, currentSessionId)
+  )
   const loadReviewsForSession = useReviewStore((state) => state.loadReviewsForSession)
 
   // Job store for binding and CompletedJobCard rendering
@@ -457,7 +459,9 @@ const WorkspaceMessageScroller = ({
                     // Look up any review for this agent message (its id is the turnMessageId).
                     const review =
                       currentSessionId && item.message.role === 'agent'
-                        ? getReviewForTurn(currentSessionId, item.message.id, currentProjectId)
+                        ? currentSessionReviews.find(
+                            (candidate) => candidate.turnMessageId === item.message.id
+                          )
                         : undefined
 
                     // Jobs pre-assigned to this slot: each job appears in exactly one slot.

--- a/src/renderer/src/pages/workspace/WorkspacePage.send-gate.test.tsx
+++ b/src/renderer/src/pages/workspace/WorkspacePage.send-gate.test.tsx
@@ -13,11 +13,13 @@ import {
   usePreviewWorkbenchStore
 } from '@/stores/preview-workbench-store'
 import { useProjectStore } from '@/stores/project-store'
+import { createInitialReviewState, useReviewStore } from '@/stores/review-store'
 import {
   createInitialSessionState,
   useSessionStore,
   type ChatSession
 } from '@/stores/session-store'
+import type { ReviewWithChecks } from '../../../../shared/reviewer'
 
 import { type ComposerDoc } from './composer/composer-doc'
 
@@ -112,6 +114,7 @@ describe('WorkspacePage send gate while compacting', () => {
   beforeEach(() => {
     usePreviewWorkbenchStore.setState(createInitialPreviewWorkbenchState())
     useProjectStore.setState({ projects: [] })
+    useReviewStore.setState(createInitialReviewState())
     useNavigationStore.setState({ view: 'workspace', activeProjectId: 'proj-1' })
     useSessionStore.setState({
       ...createInitialSessionState(),
@@ -182,6 +185,50 @@ describe('WorkspacePage send gate while compacting', () => {
       useSessionStore.getState().finishRun('sess-a')
     })
     expect(conversationProps.canSendMessage).toBe(true)
+  })
+
+  it('blocks message-branch changes only while the project-scoped review is running', async () => {
+    await renderPage()
+    expect(conversationProps.canEditMessage).toBe(true)
+
+    const runningReview: ReviewWithChecks = {
+      id: 'review-1',
+      projectId: 'proj-1',
+      sessionId: 'sess-a',
+      turnMessageId: 'reply-1',
+      scope: {
+        turnMessageId: 'reply-1',
+        messageBranchId: 'message-branch-1',
+        blocks: [],
+        artifactVersionIds: []
+      },
+      lifecycle: 'running',
+      outcome: null,
+      model: 'test-model',
+      reviewerLog: [],
+      createdAt: 1_000,
+      updatedAt: 1_000,
+      checks: []
+    }
+
+    await act(async () => {
+      useReviewStore.getState().handleReviewUpdate({ review: runningReview })
+    })
+    expect(conversationProps.canEditMessage).toBe(false)
+    expect(useSessionStore.getState().sessions[0]?.branchSwitchBlocked).toBe(true)
+
+    await act(async () => {
+      useReviewStore.getState().handleReviewUpdate({
+        review: {
+          ...runningReview,
+          lifecycle: 'complete',
+          outcome: 'pass',
+          updatedAt: 2_000
+        }
+      })
+    })
+    expect(conversationProps.canEditMessage).toBe(true)
+    expect(useSessionStore.getState().sessions[0]?.branchSwitchBlocked).not.toBe(true)
   })
 
   it('disables sending while the runtime owns an otherwise idle session', async () => {

--- a/src/renderer/src/pages/workspace/WorkspacePage.tsx
+++ b/src/renderer/src/pages/workspace/WorkspacePage.tsx
@@ -21,7 +21,7 @@ import {
 } from '@/stores/preview-workbench-store'
 import type { ChatSession } from '@/stores/session-store'
 import { useSessionStore } from '@/stores/session-store'
-import { useReviewStore } from '@/stores/review-store'
+import { selectProjectSessionReviews, useReviewStore } from '@/stores/review-store'
 import {
   assembleReviewRunRequest,
   suppressNextAutoReview,
@@ -271,12 +271,16 @@ const WorkspacePage = ({ isSessionPersistenceReady }: WorkspacePageProps): React
     ? (activeSession.enabledComputeHosts ?? [])
     : newConversationEnabledComputeHosts
   // True while any review for the active session is in the 'running' lifecycle.
-  // Using a shallow comparison via reviewsBySession to avoid new array reference on every render.
+  // Select the Project-scoped review array so pushes stay reactive without cross-Project collisions.
   const activeSessionId = activeSession?.id
   const isReviewing = useReviewStore((state) => {
     if (!activeSessionId) return false
-    const reviews = state.reviewsBySession[activeSessionId]
-    return reviews ? reviews.some((review) => review.lifecycle === 'running') : false
+    const reviews = selectProjectSessionReviews(
+      state.reviewsBySession,
+      activeSession?.projectId,
+      activeSessionId
+    )
+    return reviews.some((review) => review.lifecycle === 'running')
   })
   // "Request review" is disabled when:
   //   - there is no active session or no completed agent turn yet, OR
@@ -290,15 +294,17 @@ const WorkspacePage = ({ isSessionPersistenceReady }: WorkspacePageProps): React
     const lastAgentMessage = [...activeSession.messages].reverse().find((m) => m.role === 'agent')
     if (!lastAgentMessage) return true
     if (isReviewing) return true
-    const reviews = state.reviewsBySession[activeSessionId]
-    if (reviews) {
-      // Newest-first, so find() returns the most recent review for the last turn. Only a fresh,
-      // completed verdict blocks a new review; a stale one (turn changed) or an errored one must stay
-      // retriable so the user isn't stuck without any review entry point.
-      const lastTurnReview = reviews.find((r) => r.turnMessageId === lastAgentMessage.id)
-      if (lastTurnReview && lastTurnReview.lifecycle === 'complete' && !lastTurnReview.stale) {
-        return true
-      }
+    const reviews = selectProjectSessionReviews(
+      state.reviewsBySession,
+      activeSession.projectId,
+      activeSessionId
+    )
+    // Newest-first, so find() returns the most recent review for the last turn. Only a fresh,
+    // completed verdict blocks a new review; a stale one (turn changed) or an errored one must stay
+    // retriable so the user isn't stuck without any review entry point.
+    const lastTurnReview = reviews.find((r) => r.turnMessageId === lastAgentMessage.id)
+    if (lastTurnReview && lastTurnReview.lifecycle === 'complete' && !lastTurnReview.stale) {
+      return true
     }
     return false
   })

--- a/src/renderer/src/pages/workspace/previews/PreviewToolContent.test.tsx
+++ b/src/renderer/src/pages/workspace/previews/PreviewToolContent.test.tsx
@@ -13,9 +13,13 @@ vi.mock('@/stores/navigation-store', () => ({
     selector({ activeProjectId: mocks.activeProjectId })
 }))
 vi.mock('@/stores/review-store', () => ({
-  useReviewStore: <T,>(
-    selector: (state: { getReviewsForSession: typeof mocks.getReviewsForSession }) => T
-  ): T => selector({ getReviewsForSession: mocks.getReviewsForSession })
+  selectProjectSessionReviews: (
+    _reviewsBySession: Record<string, never[]>,
+    projectId: string | undefined,
+    sessionId: string
+  ) => mocks.getReviewsForSession(sessionId, projectId),
+  useReviewStore: <T,>(selector: (state: { reviewsBySession: Record<string, never[]> }) => T): T =>
+    selector({ reviewsBySession: {} })
 }))
 vi.mock('../NotebookPreview', () => ({
   NotebookPreview: ({ item }: { item: PreviewToolItem }): React.JSX.Element => (

--- a/src/renderer/src/pages/workspace/previews/PreviewToolContent.tsx
+++ b/src/renderer/src/pages/workspace/previews/PreviewToolContent.tsx
@@ -1,4 +1,4 @@
-import { useReviewStore } from '@/stores/review-store'
+import { selectProjectSessionReviews, useReviewStore } from '@/stores/review-store'
 import { useNavigationStore } from '@/stores/navigation-store'
 import type { PreviewToolItem } from '@/stores/preview-workbench-store'
 
@@ -19,10 +19,11 @@ const SessionReviewerContent = ({
   projectId?: string
 }): React.JSX.Element | null => {
   const sessionId = item.reviewerSessionId ?? ''
-  const getReviewsForSession = useReviewStore((state) => state.getReviewsForSession)
+  const reviews = useReviewStore((state) =>
+    selectProjectSessionReviews(state.reviewsBySession, projectId, sessionId)
+  )
   // Select the review the finding actually points at; fall back to the newest when the item carries
   // no reviewId (e.g. a session-level entry point) or that review is gone.
-  const reviews = getReviewsForSession(sessionId, projectId)
   const review = reviews.find((r) => r.id === item.reviewerReviewId) ?? reviews[0]
 
   if (!review) {

--- a/src/renderer/src/stores/review-store.ts
+++ b/src/renderer/src/stores/review-store.ts
@@ -81,6 +81,19 @@ export const createInitialReviewState = (): ReviewStoreData => ({
 const loadsInFlight = new Set<string>()
 const reviewSessionKey = (projectId: string, sessionId: string): string =>
   `${projectId}\0${sessionId}`
+const EMPTY_REVIEWS: ReviewWithChecks[] = []
+
+// Reactive consumers must select the scoped review array itself instead of selecting one of the
+// store's stable query functions. That gives Zustand a value whose identity changes when a reviewer
+// push updates this Project + Session, while keeping unrelated Sessions from causing a render.
+export const selectProjectSessionReviews = (
+  reviewsBySession: Record<string, ReviewWithChecks[]>,
+  projectId: string | undefined,
+  sessionId: string | undefined
+): ReviewWithChecks[] => {
+  if (!sessionId) return EMPTY_REVIEWS
+  return reviewsBySession[reviewSessionKey(projectId ?? '', sessionId)] ?? EMPTY_REVIEWS
+}
 
 export const useReviewStore = create<ReviewStore>((set, get) => ({
   ...createInitialReviewState(),
@@ -123,7 +136,7 @@ export const useReviewStore = create<ReviewStore>((set, get) => ({
 
   getReviewsForSession: (sessionId: string, projectId?: string) =>
     projectId !== undefined
-      ? (get().reviewsBySession[reviewSessionKey(projectId, sessionId)] ?? [])
+      ? selectProjectSessionReviews(get().reviewsBySession, projectId, sessionId)
       : Object.values(get().reviewsBySession)
           .flat()
           .filter((review) => review.sessionId === sessionId)


### PR DESCRIPTION
## Problem

Reviewer lifecycle pushes update the renderer store, but the Message Branch transcript and Session Reviewer preview subscribed only to stable store query functions. A completed review therefore remained visually stuck at `Reviewing…` until another render, such as switching sessions. The project-scoped review-key migration also left the Workspace review/branch gates reading the old unscoped session key.

## Proposed change

- Add one stable selector for the review array owned by a Project + Session.
- Subscribe the Message Branch transcript, Workspace lifecycle gates, and Session Reviewer preview to that scoped array so reviewer pushes trigger the relevant render.
- Add regressions for the visible `running` to `complete/pass` transition and the matching Message Branch gate transition.

## Scope and non-goals

This does not change reviewer persistence, IPC payloads, lifecycle orchestration, or UI styling. It only corrects renderer subscriptions and scoped review lookup.

## Acceptance criteria and validation

All listed checks ran after the final rebase onto `origin/main`:

- Message Branch card updates immediately from `Reviewing…` to `No issues found` after the completion push -> `npm test -- src/renderer/src/stores/review-store.test.ts src/renderer/src/pages/workspace/WorkspaceMessageScroller.interaction.test.tsx src/renderer/src/pages/workspace/WorkspaceMessageScroller.render.test.tsx src/renderer/src/pages/workspace/WorkspacePage.send-gate.test.tsx src/renderer/src/pages/workspace/previews/PreviewToolContent.test.tsx` -> 5 files / 59 tests passed.
- Project-scoped review state blocks Message Branch changes only while the review is running -> same focused command -> passed.
- Renderer and main-process types remain valid -> `npm run typecheck` -> passed.
- Repository lint gate -> `npm run lint` -> passed with 0 errors and 24 pre-existing warnings outside this change.
- Full repository regression suite, including local HTTP/RPC tests run outside the restricted sandbox -> `npm test` -> 546 files / 8,154 tests passed; 11 files / 139 tests skipped by repository configuration.

Uncovered risk: this was not manually replayed in the packaged Electron UI. The exact store-push-to-DOM transition is covered by a jsdom integration test; IPC emission and provenance loading are unchanged.

## Review focus

Please focus on selector identity and Project + Session scoping in the three renderer consumers. Independent review of the evidence mapping is still pending.
