### PR TITLE
fix(opencode): use stable app MCP server names

### DIFF
--- a/src/main/acp/context-usage-static-context.test.ts
+++ b/src/main/acp/context-usage-static-context.test.ts
@@ -5,14 +5,21 @@ import { contextUsageMcpSections } from './context-usage-static-context'
 describe('contextUsageMcpSections', () => {
   it('uses OpenCode MCP tool names in its serialized schema baseline', () => {
     const sections = contextUsageMcpSections('opencode', {
-      activity: false,
-      artifacts: false,
+      activity: true,
+      artifacts: true,
       notebook: true,
-      skillImport: false
+      skillImport: true
     })
 
     const text = sections.map((section) => section.text).join('\n')
-    expect(text).toContain('open-science-notebook_notebook_execute')
+    expect(text).toContain('open_science_activity_begin_activity_group')
+    expect(text).toContain('open_science_artifacts_write_artifact_file')
+    expect(text).toContain('open_science_notebook_notebook_execute')
+    expect(text).toContain('open_science_skills_request_skill_import')
+    expect(text).not.toContain('open-science-activity_begin_activity_group')
+    expect(text).not.toContain('open-science-artifacts_write_artifact_file')
+    expect(text).not.toContain('open-science-notebook_notebook_execute')
+    expect(text).not.toContain('open-science-skills_request_skill_import')
     expect(text).not.toContain('mcp__open_science_notebook__notebook_execute')
   })
 

--- a/src/main/acp/context-usage-static-context.ts
+++ b/src/main/acp/context-usage-static-context.ts
@@ -12,6 +12,7 @@ import {
   requestSkillImportToolDefinition
 } from '../skills/mcp-server'
 import type { AgentFrameworkId } from '../agent-framework/types'
+import { modelFacingAppMcpToolName } from '../agent-framework/app-mcp-names'
 import { REQUEST_SKILL_IMPORT_TOOL_NAME } from '../../shared/skill-import'
 
 type ContextUsageMcpOptions = {
@@ -34,17 +35,6 @@ type ToolDefinition = {
   annotations?: Record<string, unknown>
 }
 
-const modelFacingMcpToolName = (
-  frameworkId: AgentFrameworkId,
-  codexBridgeAliases: boolean,
-  server: string,
-  tool: string
-): string => {
-  if (frameworkId === 'codex' && !codexBridgeAliases) return `mcp.${server}.${tool}`
-  if (frameworkId === 'opencode') return `${server}_${tool}`
-  return `mcp__${server.replace(/[^a-zA-Z0-9_]/g, '_')}__${tool}`
-}
-
 const serializeToolDefinitions = (
   frameworkId: AgentFrameworkId,
   codexBridgeAliases: boolean,
@@ -57,7 +47,7 @@ const serializeToolDefinitions = (
   // guessed here. Compact JSON best matches the wire representation without counting whitespace.
   text: JSON.stringify(
     tools.map(({ name, definition }) => ({
-      name: modelFacingMcpToolName(frameworkId, codexBridgeAliases, server, name),
+      name: modelFacingAppMcpToolName(frameworkId, server, name, codexBridgeAliases),
       title: definition.title,
       description: definition.description,
       inputSchema: z.toJSONSchema(z.object(definition.inputSchema), { target: 'draft-7' }),

--- a/src/main/acp/permission-broker.ts
+++ b/src/main/acp/permission-broker.ts
@@ -13,6 +13,7 @@ import {
   resolveAutomaticPermission,
   type PermissionPolicyContext
 } from './permission-policy'
+import { resolveCanonicalMcpToolIdentity } from '../agent-framework/app-mcp-names'
 
 type PendingPermission = {
   request: AcpPermissionRequest
@@ -105,34 +106,9 @@ const resolvePermissionTitle = (params: RequestPermissionRequest, isMcp: boolean
 const resolveMcpToolIdentity = (
   name: string | null | undefined,
   mcpServerNames: readonly string[]
-): string | undefined => {
-  if (!name) return undefined
-
-  if (name.startsWith('mcp__')) {
-    const [reportedServer, ...toolParts] = name.slice('mcp__'.length).split('__')
-    if (!reportedServer || toolParts.length === 0) return undefined
-
-    // Some bridges sanitize MCP server names for tool-call compatibility (hyphens become
-    // underscores). Project back to the configured server identity so the same app-owned grant is
-    // reused after a framework/runtime switch instead of creating a second category.
-    const server =
-      mcpServerNames.find(
-        (candidate) =>
-          candidate === reportedServer || candidate.replaceAll('-', '_') === reportedServer
-      ) ?? reportedServer
-    return `${server}/${toolParts.join('__')}`
-  }
-
-  for (const server of [...mcpServerNames].sort((left, right) => right.length - left.length)) {
-    const codexPrefix = `mcp.${server}.`
-    if (name.startsWith(codexPrefix)) return `${server}/${name.slice(codexPrefix.length)}`
-
-    const opencodePrefix = `${server}_`
-    if (name.startsWith(opencodePrefix)) return `${server}/${name.slice(opencodePrefix.length)}`
-  }
-
-  return resolveMcpProviderLeafIdentity(name, mcpServerNames)
-}
+): string | undefined =>
+  resolveCanonicalMcpToolIdentity(name, mcpServerNames) ??
+  resolveMcpProviderLeafIdentity(name, mcpServerNames)
 
 const commandSignature = (command: string): string => command.trim()
 

--- a/src/main/acp/permission-policy.test.ts
+++ b/src/main/acp/permission-policy.test.ts
@@ -95,12 +95,21 @@ describe('permission policy', () => {
   })
 
   it('recognizes MCP tool names across frameworks', () => {
-    const servers = ['open-science-artifacts', 'open-science-notebook']
+    const servers = [
+      'open-science-activity',
+      'open-science-artifacts',
+      'open-science-notebook',
+      'open-science-skills'
+    ]
 
     // Claude namespaces MCP tools mcp__<server>__<tool> — matched by prefix regardless of server list.
     expect(isMcpToolName('mcp__pencil__batch_get', [])).toBe(true)
     // opencode joins them <server>_<tool> — matched only against the session's known server names.
     expect(isMcpToolName('open-science-artifacts_write_artifact_file', servers)).toBe(true)
+    expect(isMcpToolName('open_science_activity_begin_activity_group', servers)).toBe(true)
+    expect(isMcpToolName('open_science_artifacts_write_artifact_file', servers)).toBe(true)
+    expect(isMcpToolName('open_science_notebook_notebook_execute', servers)).toBe(true)
+    expect(isMcpToolName('open_science_skills_request_skill_import', servers)).toBe(true)
     expect(isMcpToolName('open-science-notebook', servers)).toBe(true)
     // Codex uses mcp.<server>.<tool> — the generic mcp. prefix is not trusted without a known server.
     expect(isMcpToolName('mcp.open-science-notebook.notebook_execute', servers)).toBe(true)
@@ -190,6 +199,7 @@ describe('permission policy', () => {
       'mcp__open_science_artifacts__write_artifact_file',
       'mcp.open-science-artifacts.write_artifact_file',
       'open-science-artifacts_write_artifact_file',
+      'open_science_artifacts_write_artifact_file',
       'write'
     ]) {
       expect(

--- a/src/main/acp/permission-policy.ts
+++ b/src/main/acp/permission-policy.ts
@@ -11,13 +11,18 @@ import {
   isActivityGroupToolEvent
 } from '../../shared/activity-groups'
 import { extractProviderToolName } from './runtime-events'
+import {
+  appMcpServerAliases,
+  canonicalAppMcpServerName,
+  resolveCanonicalMcpToolIdentity
+} from '../agent-framework/app-mcp-names'
 
 type PermissionPolicyContext = {
   profile: PermissionProfileId
   frameworkId?: AgentFrameworkId
   autoReviewStrategy?: PermissionAutoReviewStrategy
   cwd?: string
-  // Agent-visible MCP server names, so MCP tools can be recognized across frameworks (see isMcpToolName).
+  // Canonical MCP server names, so framework-visible tools can resolve to stable policy identities.
   mcpServerNames?: readonly string[]
 }
 
@@ -55,8 +60,9 @@ const resolveMcpProviderLeafIdentity = (
 
   const identities = new Set(
     mcpServerNames.flatMap((server) => {
-      const tool = MCP_PROVIDER_LEAF_ALIASES[server]?.[name]
-      return tool ? [`${server}/${tool}`] : []
+      const canonicalServer = canonicalAppMcpServerName(server)
+      const tool = MCP_PROVIDER_LEAF_ALIASES[canonicalServer]?.[name]
+      return tool ? [`${canonicalServer}/${tool}`] : []
     })
   )
 
@@ -71,13 +77,15 @@ const isMcpToolName = (
 ): boolean =>
   name != null &&
   (name.startsWith(MCP_TOOL_PREFIX) ||
-    mcpServerNames.some(
-      (server) =>
-        name === server ||
-        name.startsWith(`${CODEX_MCP_TOOL_PREFIX}${server}.`) ||
-        name.startsWith(`${server}_`) ||
-        MCP_PROVIDER_LEAF_ALIASES[server]?.[name] != null
-    ))
+    resolveCanonicalMcpToolIdentity(name, mcpServerNames) != null ||
+    mcpServerNames.some((server) => {
+      const canonicalServer = canonicalAppMcpServerName(server)
+      return (
+        appMcpServerAliases(canonicalServer).includes(name) ||
+        name.startsWith(`${CODEX_MCP_TOOL_PREFIX}${canonicalServer}.`) ||
+        MCP_PROVIDER_LEAF_ALIASES[canonicalServer]?.[name] != null
+      )
+    }))
 
 // Tests whether a tool-reported path stays within the workspace after resolving relative paths.
 const isWithinWorkspace = (path: string, cwd: string): boolean => {
@@ -129,7 +137,8 @@ const isArtifactSaveTool = (
   params: RequestPermissionRequest,
   mcpServerNames: readonly string[]
 ): boolean => {
-  if (!mcpServerNames.includes('open-science-artifacts')) return false
+  if (!mcpServerNames.map(canonicalAppMcpServerName).includes('open-science-artifacts'))
+    return false
 
   // title is presentation text controlled by the Agent and cannot prove which provider capability
   // ACP is asking to execute. Only framework metadata supplied with the tool call may claim the
@@ -141,10 +150,8 @@ const isArtifactSaveTool = (
 
   return (
     trustedMcpIdentity === 'open-science-artifacts/write_artifact_file' ||
-    providerToolName === 'mcp__open-science-artifacts__write_artifact_file' ||
-    providerToolName === 'mcp__open_science_artifacts__write_artifact_file' ||
-    providerToolName === 'mcp.open-science-artifacts.write_artifact_file' ||
-    providerToolName === 'open-science-artifacts_write_artifact_file' ||
+    resolveCanonicalMcpToolIdentity(providerToolName, mcpServerNames) ===
+      'open-science-artifacts/write_artifact_file' ||
     resolveMcpProviderLeafIdentity(providerToolName, mcpServerNames) ===
       'open-science-artifacts/write_artifact_file'
   )

--- a/src/main/acp/runtime.test.ts
+++ b/src/main/acp/runtime.test.ts
@@ -1011,7 +1011,10 @@ describe('ACP runtime session management', () => {
       await runtime.sendPrompt({ sessionId: session.sessionId, text: 'Inspect the project' })
 
       expect(fakeAgent.newSessions[0].mcpServers).toEqual([
-        expect.objectContaining({ name: ACTIVITY_GROUP_MCP_SERVER_NAME })
+        expect.objectContaining({
+          name:
+            framework.id === 'opencode' ? 'open_science_activity' : ACTIVITY_GROUP_MCP_SERVER_NAME
+        })
       ])
       expect(fakeAgent.prompts[0].text).toContain(BEGIN_ACTIVITY_GROUP_TOOL_NAME)
       expect(fakeAgent.prompts[0].text).toContain(
@@ -1019,6 +1022,64 @@ describe('ACP runtime session management', () => {
       )
     }
   )
+
+  it('gives OpenCode stable underscore names for every app-owned MCP on create and resume', async () => {
+    const root = await createTemporaryRoot()
+    const process = new FakeAgentProcess()
+    const fakeAgent = startFakeAgent(process, ['opencode-session'], { supportsResume: true })
+    const runtime = new AcpRuntime({
+      appVersion: '0.2.0',
+      defaultCwd: '/workspace',
+      spawnAgent: () => asAgentProcess(process),
+      framework: opencodeFramework,
+      activityGroups: { mcpEntryPath: '/app/out/main/index.js' },
+      artifacts: {
+        configRoot: root,
+        dataRoot: root,
+        projectName: 'default-project',
+        mcpEntryPath: '/app/out/main/index.js'
+      },
+      notebook: {
+        projectName: 'default-project',
+        mcpEntryPath: '/app/out/main/index.js',
+        getRpcConnection: async () => ({ endpoint: 'http://127.0.0.1:4567', token: 'nb' })
+      },
+      skillImport: {
+        mcpEntryPath: '/app/out/main/index.js',
+        getRpcConnection: async () => ({
+          endpoint: 'http://127.0.0.1:4568',
+          token: 'skill'
+        })
+      }
+    })
+
+    const created = await runtime.createSession({ cwd: '/workspace' })
+    await runtime.sendPrompt({ sessionId: created.sessionId, text: 'Use every app tool' })
+    await runtime.resumeSession({ sessionId: 'resumed-opencode-session', cwd: '/workspace' })
+    await runtime.sendPrompt({ sessionId: 'resumed-opencode-session', text: 'Continue with tools' })
+
+    const expectedServerNames = [
+      'open_science_activity',
+      'open_science_artifacts',
+      'open_science_notebook',
+      'open_science_skills'
+    ]
+    expect(
+      fakeAgent.newSessions[0].mcpServers.map((server) => (server as { name: string }).name)
+    ).toEqual(expectedServerNames)
+    expect(
+      fakeAgent.resumedSessions[0].mcpServers.map((server) => (server as { name: string }).name)
+    ).toEqual(expectedServerNames)
+
+    for (const prompt of fakeAgent.prompts) {
+      expect(prompt.text).toContain('`open_science_activity_begin_activity_group`')
+      expect(prompt.text).toContain('`open_science_artifacts_write_artifact_file`')
+      expect(prompt.text).toContain('`open_science_notebook_notebook_execute`')
+      expect(prompt.text).toContain('open_science_skills_request_skill_import')
+      expect(prompt.text).not.toContain('`open-science-')
+    }
+  })
+
   it('applies native Full access before the first prompt', async () => {
     const process = new FakeAgentProcess()
     const fakeAgent = startFakeAgent(process, ['full-session'], {
@@ -2318,7 +2379,7 @@ describe('ACP runtime session management', () => {
             update: {
               sessionUpdate: 'tool_call',
               toolCallId,
-              title: 'open-science-notebook_notebook_execute',
+              title: 'open_science_notebook_notebook_execute',
               kind: 'other',
               status: 'pending',
               rawInput: { language: 'python', code: 'print(1)' }
@@ -2339,7 +2400,7 @@ describe('ACP runtime session management', () => {
           sessionId: ctx.params.sessionId,
           toolCall: {
             toolCallId,
-            title: 'open-science-notebook_notebook_execute',
+            title: 'open_science_notebook_notebook_execute',
             kind: 'other',
             status: 'pending',
             rawInput: {}
@@ -2354,7 +2415,7 @@ describe('ACP runtime session management', () => {
           update: {
             sessionUpdate: 'tool_call',
             toolCallId,
-            title: 'open-science-notebook_notebook_execute',
+            title: 'open_science_notebook_notebook_execute',
             kind: 'other',
             status: 'in_progress',
             rawInput: { language: 'r', code: 'print(2)' }
@@ -3631,15 +3692,15 @@ describe('ACP runtime session management', () => {
       expect(servers.map((server) => server.type)).toEqual(['http', 'http', 'http'])
       expect(servers.map((server) => server.name)).toEqual(
         expect.arrayContaining([
-          'open-science-artifacts',
-          'open-science-notebook',
-          'open-science-skills'
+          'open_science_artifacts',
+          'open_science_notebook',
+          'open_science_skills'
         ])
       )
-      const artifactServer = servers.find((server) => server.name === 'open-science-artifacts')
+      const artifactServer = servers.find((server) => server.name === 'open_science_artifacts')
       expect(artifactServer?.url).toMatch(/^http:\/\/127\.0\.0\.1:\d+\/mcp\/artifact\//)
       expect(artifactServer?.headers?.[0]).toMatchObject({ name: 'authorization' })
-      const skillImportServer = servers.find((server) => server.name === 'open-science-skills')
+      const skillImportServer = servers.find((server) => server.name === 'open_science_skills')
       expect(skillImportServer?.url).toMatch(/^http:\/\/127\.0\.0\.1:\d+\/mcp\/skill-import\//)
       expect(fakeAgent.prompts[0].text).toContain('request_skill_import')
 
@@ -4013,8 +4074,10 @@ describe('ACP runtime session management', () => {
     expect(runtime.getSnapshot().pendingPermissions).toEqual([])
   })
 
-  it('audits each permission request, classifying MCP origin without logging the tool title', async () => {
+  it('audits OpenCode MCP calls with canonical identities without logging raw tool titles', async () => {
     infoLogSpy.mockClear()
+    warnLogSpy.mockClear()
+    errorLogSpy.mockClear()
     const process = new FakeAgentProcess()
 
     acp
@@ -4031,12 +4094,22 @@ describe('ACP runtime session management', () => {
       }))
       .onRequest(acp.methods.agent.session.new, () => ({ sessionId: 'remote-session-1' }))
       .onRequest(acp.methods.agent.session.prompt, async (ctx) => {
-        // opencode renames the artifact MCP tool <server>_<tool>; classification must not rely on mcp__.
+        await ctx.client.notify(acp.methods.client.session.update, {
+          sessionId: 'remote-session-1',
+          update: {
+            sessionUpdate: 'tool_call',
+            toolCallId: 'tool-mcp',
+            title: 'open_science_artifacts_write_artifact_file',
+            kind: 'other',
+            status: 'pending',
+            rawInput: { filename: 'result.md', content: '# Result' }
+          }
+        })
         await ctx.client.request(acp.methods.client.session.requestPermission, {
           sessionId: 'remote-session-1',
           toolCall: {
             toolCallId: 'tool-mcp',
-            title: 'open-science-artifacts_write_artifact_file',
+            title: 'open_science_artifacts_write_artifact_file',
             kind: 'other',
             status: 'pending'
           },
@@ -4050,6 +4123,28 @@ describe('ACP runtime session management', () => {
             title: 'https://example.com/secret?token=abc123',
             kind: 'fetch',
             status: 'pending'
+          },
+          options: [{ optionId: 'allow-once', name: 'Allow once', kind: 'allow_once' }]
+        })
+        await ctx.client.notify(acp.methods.client.session.update, {
+          sessionId: 'remote-session-1',
+          update: {
+            sessionUpdate: 'tool_call',
+            toolCallId: 'tool-failed',
+            title: 'open_science_artifacts_write_artifact_file',
+            kind: 'other',
+            status: 'failed',
+            _meta: { toolName: 'open_science_artifacts_write_artifact_file' }
+          }
+        })
+        await ctx.client.request(acp.methods.client.session.requestPermission, {
+          sessionId: 'remote-session-1',
+          toolCall: {
+            toolCallId: 'tool-error',
+            title: 'open_science_artifacts_delete_artifact',
+            kind: 'other',
+            status: 'pending',
+            _meta: { toolName: 'open_science_artifacts_delete_artifact' }
           },
           options: [{ optionId: 'allow-once', name: 'Allow once', kind: 'allow_once' }]
         })
@@ -4070,6 +4165,7 @@ describe('ACP runtime session management', () => {
       appVersion: '0.1.0',
       defaultCwd: '/workspace',
       spawnAgent: () => asAgentProcess(process),
+      framework: opencodeFramework,
       artifacts: {
         configRoot: root,
         dataRoot: root,
@@ -4079,33 +4175,57 @@ describe('ACP runtime session management', () => {
       },
       callbacks: {
         onPermissionRequest: (request) => {
+          if (request.title === 'open_science_artifacts_delete_artifact') {
+            throw new Error('permission callback failed')
+          }
           runtime.respondToPermission({ requestId: request.requestId, optionId: 'allow-once' })
         }
       }
     })
     const session = await runtime.createSession({ cwd: '/workspace' })
 
-    await runtime.sendPrompt({ sessionId: session.sessionId, text: 'trigger permission audit' })
+    await expect(
+      runtime.sendPrompt({ sessionId: session.sessionId, text: 'trigger permission audit' })
+    ).rejects.toThrow('Internal error')
 
     const auditCalls = infoLogSpy.mock.calls.filter(
       ([message]) => message === 'permission request received'
     )
-    expect(auditCalls).toHaveLength(2)
+    expect(auditCalls).toHaveLength(3)
 
     const dataFor = (toolCallId: string): Record<string, unknown> =>
       auditCalls.find(
         ([, data]) => (data as { toolCallId?: string }).toolCallId === toolCallId
       )?.[1] as Record<string, unknown>
 
-    // The opencode-named MCP tool is classified as MCP even though it lacks the mcp__ prefix.
+    // OpenCode's model-facing identity is classified as MCP but logged with the canonical identity.
     expect(dataFor('tool-mcp').isMcp).toBe(true)
+    expect(dataFor('tool-mcp').tool).toBe('open-science-artifacts/write_artifact_file')
     expect(dataFor('tool-fetch').isMcp).toBe(false)
 
-    // No audit payload may carry the raw tool title (MCP tool name or WebFetch URL are user/sensitive).
-    for (const [, data] of auditCalls) {
+    const failureAudit = warnLogSpy.mock.calls.find(([message]) => message === 'tool call failed')
+    expect(failureAudit?.[1]).toMatchObject({
+      tool: 'open-science-artifacts/write_artifact_file',
+      toolCallId: 'tool-failed'
+    })
+
+    const errorAudit = errorLogSpy.mock.calls.find(
+      ([message]) => message === 'permission request failed'
+    )
+    expect(errorAudit?.[1]).toMatchObject({
+      tool: 'open-science-artifacts/delete_artifact',
+      toolCallId: 'tool-error'
+    })
+
+    // No audit payload may carry the raw model-facing title or WebFetch URL.
+    for (const [, data] of [
+      ...auditCalls,
+      ...(failureAudit ? [failureAudit] : []),
+      ...(errorAudit ? [errorAudit] : [])
+    ]) {
       const serialized = JSON.stringify(data)
       expect(serialized).not.toContain('example.com')
-      expect(serialized).not.toContain('write_artifact_file')
+      expect(serialized).not.toContain('open_science_artifacts_write_artifact_file')
     }
   })
 
@@ -4284,7 +4404,7 @@ describe('ACP runtime session management', () => {
           update: {
             sessionUpdate: 'tool_call',
             toolCallId,
-            title: 'open-science-notebook_notebook_execute',
+            title: 'open_science_notebook_notebook_execute',
             kind: 'other',
             status: 'pending',
             rawInput: {}
@@ -4296,7 +4416,7 @@ describe('ACP runtime session management', () => {
             sessionId: ctx.params.sessionId,
             toolCall: {
               toolCallId,
-              title: 'open-science-notebook_notebook_execute',
+              title: 'open_science_notebook_notebook_execute',
               kind: 'other',
               status: 'pending',
               locations: [],
@@ -4399,6 +4519,66 @@ describe('ACP runtime session management', () => {
     ])
   })
 
+  it('maps an OpenCode underscore MCP permission to a canonical notebook grant', async () => {
+    const process = new FakeAgentProcess()
+    const permissionRequests: AcpPermissionRequest[] = []
+    let permissionResponse: unknown
+    startPermissionProbeAgent(process, {
+      newSessionId: 'opencode-underscore-notebook-session',
+      toolCallId: 'opencode-underscore-notebook-call',
+      toolTitle: 'open_science_notebook_notebook_execute',
+      toolRawInput: { code: 'print(1)', language: 'python' },
+      permissionOptions: [
+        { optionId: 'once', kind: 'allow_once', name: 'Allow once' },
+        { optionId: 'always', kind: 'allow_always', name: 'Always allow' },
+        { optionId: 'reject', kind: 'reject_once', name: 'Reject' }
+      ],
+      onPermissionResponse: (response) => {
+        permissionResponse = response
+      }
+    })
+    const runtime = new AcpRuntime({
+      appVersion: '0.1.0',
+      defaultCwd: '/workspace',
+      spawnAgent: () => asAgentProcess(process),
+      framework: opencodeFramework,
+      notebook: {
+        projectName: 'default-project',
+        mcpEntryPath: '/app/out/main/index.js',
+        getRpcConnection: async () => ({ endpoint: 'http://127.0.0.1:4567', token: 'nb' })
+      },
+      callbacks: {
+        onPermissionRequest: (request) => {
+          permissionRequests.push(request)
+          const sessionOptionId = request.options.find(
+            (option) => option.scope === 'session'
+          )?.optionId
+          if (!sessionOptionId) throw new Error('Missing conversation permission option')
+          runtime.respondToPermission({ requestId: request.requestId, optionId: sessionOptionId })
+        }
+      }
+    })
+    const session = await runtime.createSession({ cwd: '/workspace', permissionProfile: 'ask' })
+
+    await runtime.sendPrompt({ sessionId: session.sessionId, text: 'run notebook code' })
+
+    expect(permissionRequests).toHaveLength(1)
+    expect(permissionRequests[0]).toMatchObject({
+      title: 'open_science_notebook_notebook_execute',
+      isMcp: true,
+      rawInput: { code: 'print(1)', language: 'python' }
+    })
+    expect(permissionResponse).toEqual({ outcome: { outcome: 'selected', optionId: 'once' } })
+    expect(runtime.getSnapshot().permissionGrants[session.sessionId]).toEqual([
+      {
+        categoryKey: 'mcp:open-science-notebook/notebook_execute:python',
+        kind: 'mcp',
+        label: 'Notebook REPL (Python)',
+        scope: 'session'
+      }
+    ])
+  })
+
   it('auto-allows the app-owned Artifact save without emitting a renderer permission', async () => {
     const process = new FakeAgentProcess()
     const permissionRequests: AcpPermissionRequest[] = []
@@ -4421,7 +4601,7 @@ describe('ACP runtime session management', () => {
           update: {
             sessionUpdate: 'tool_call',
             toolCallId,
-            title: 'open-science-artifacts_write_artifact_file',
+            title: 'open_science_artifacts_write_artifact_file',
             kind: 'other',
             status: 'pending',
             rawInput: {}
@@ -4432,7 +4612,7 @@ describe('ACP runtime session management', () => {
           sessionId: ctx.params.sessionId,
           toolCall: {
             toolCallId,
-            title: 'open-science-artifacts_write_artifact_file',
+            title: 'open_science_artifacts_write_artifact_file',
             kind: 'other',
             status: 'pending',
             rawInput: {}
@@ -4488,6 +4668,44 @@ describe('ACP runtime session management', () => {
     await runtime.sendPrompt({ sessionId: session.sessionId, text: 'write artifact' })
 
     expect(permissionRequests).toHaveLength(0)
+  })
+
+  it('auto-allows the OpenCode underscore Activity group declaration', async () => {
+    const process = new FakeAgentProcess()
+    const permissionRequests: AcpPermissionRequest[] = []
+    let permissionResponse: unknown
+    startPermissionProbeAgent(process, {
+      newSessionId: 'opencode-underscore-activity-session',
+      toolCallId: 'opencode-underscore-activity-call',
+      toolTitle: 'open_science_activity_begin_activity_group',
+      toolRawInput: { title: 'Inspect the project' },
+      permissionOptions: [
+        { optionId: 'once', kind: 'allow_once', name: 'Allow once' },
+        { optionId: 'reject', kind: 'reject_once', name: 'Reject' }
+      ],
+      onPermissionResponse: (response) => {
+        permissionResponse = response
+      }
+    })
+    const runtime = new AcpRuntime({
+      appVersion: '0.1.0',
+      defaultCwd: '/workspace',
+      spawnAgent: () => asAgentProcess(process),
+      framework: opencodeFramework,
+      activityGroups: { mcpEntryPath: '/app/out/main/index.js' },
+      callbacks: {
+        onPermissionRequest: (request) => {
+          permissionRequests.push(request)
+          runtime.respondToPermission({ requestId: request.requestId, cancelled: true })
+        }
+      }
+    })
+    const session = await runtime.createSession({ cwd: '/workspace', permissionProfile: 'ask' })
+
+    await runtime.sendPrompt({ sessionId: session.sessionId, text: 'inspect the project' })
+
+    expect(permissionRequests).toHaveLength(0)
+    expect(permissionResponse).toEqual({ outcome: { outcome: 'selected', optionId: 'once' } })
   })
 
   it('auto-allows a Codex Artifact save restored from its sparse MCP approval', async () => {

--- a/src/main/acp/runtime.ts
+++ b/src/main/acp/runtime.ts
@@ -52,6 +52,11 @@ import {
   type AgentFramework,
   type ResolvedAgentBackend
 } from '../agent-framework'
+import {
+  canonicalAppMcpServerName,
+  modelFacingAppMcpServerName,
+  resolveCanonicalMcpToolIdentity
+} from '../agent-framework/app-mcp-names'
 import { createLogger, diagnosticErrorFields, errorLogFields } from '../logger'
 import { terminateProcessTree } from '../process-tree'
 import {
@@ -698,8 +703,9 @@ class AcpRuntime {
   // compaction with `media_unstrippable`. Cleared after successful native compaction, on session
   // delete, and on disconnect.
   private readonly sessionInlineImageBytes = new Map<string, number>()
-  // Per-session names of the MCP servers the agent was actually given (from createMcpServers), so
-  // MCP-originated tool calls can be recognized across frameworks (Claude's mcp__<server>__<tool> vs
+  // Per-session canonical names of the MCP servers the agent was actually given (from
+  // createMcpServers), so MCP-originated tool calls can be recognized across frameworks (Claude's
+  // mcp__<server>__<tool> vs
   // opencode's <server>_<tool>) and never conservatively auto-approved. Derived per session rather
   // than hardcoded so it can't drift from what createMcpServers wires up.
   private readonly sessionMcpServerNames = new Map<string, string[]>()
@@ -3934,15 +3940,22 @@ class AcpRuntime {
       count: servers.length
     })
 
-    return servers
+    return servers.map((server) => {
+      const name = (server as { name?: unknown }).name
+      if (typeof name !== 'string') return server
+
+      const modelFacingName = modelFacingAppMcpServerName(this.framework.id, name)
+      return modelFacingName === name ? server : { ...server, name: modelFacingName }
+    })
   }
 
-  // Extracts the names of the MCP servers handed to a session so MCP-origin tool calls can be
+  // Extracts canonical names from the MCP servers handed to a session so MCP-origin tool calls can be
   // recognized later (see sessionMcpServerNames). Both stdio and http McpServer configs carry a name.
   private mcpServerNamesOf(servers: McpServer[]): string[] {
     return servers
       .map((server) => (server as { name?: unknown }).name)
       .filter((name): name is string => typeof name === 'string')
+      .map(canonicalAppMcpServerName)
   }
 
   // Drops one session's app-tool registrations from the http MCP host (no-op without a host).
@@ -4444,7 +4457,8 @@ class AcpRuntime {
       isMcpToolName(normalizedParams.toolCall?.title, mcpServerNames) ||
       isMcpToolName(toolName, mcpServerNames)
     log.info('permission request received', {
-      tool: toolName ?? normalizedParams.toolCall?.kind,
+      tool:
+        this.toolIdentityForDiagnostics(toolName, appSessionId) ?? normalizedParams.toolCall?.kind,
       isMcp,
       toolCallId: normalizedParams.toolCall?.toolCallId,
       sessionId: params.sessionId,
@@ -4489,7 +4503,11 @@ class AcpRuntime {
     } catch (error) {
       log.error('permission request failed', {
         message: errorMessage(error),
-        tool: extractProviderToolName(params.toolCall) ?? params.toolCall?.kind,
+        tool:
+          this.toolIdentityForDiagnostics(
+            extractProviderToolName(normalizedParams.toolCall),
+            appSessionId
+          ) ?? normalizedParams.toolCall?.kind,
         toolCallId: params.toolCall?.toolCallId,
         sessionId: params.sessionId
       })
@@ -5222,7 +5240,9 @@ class AcpRuntime {
     // raw output, or the URL/command-bearing title, to keep user data out of the log.
     if (event.kind === 'tool' && event.status === 'failed') {
       log.warn('tool call failed', {
-        tool: event.providerToolName ?? event.toolKind,
+        tool:
+          this.toolIdentityForDiagnostics(event.providerToolName, routed.sessionId) ??
+          event.toolKind,
         toolCallId: event.toolCallId,
         sessionId: event.sessionId,
         reason: extractToolFailureText(event.toolContent)
@@ -5234,6 +5254,20 @@ class AcpRuntime {
     }
 
     this.pushEvent(event)
+  }
+
+  private toolIdentityForDiagnostics(
+    providerToolName: string | undefined,
+    sessionId: string
+  ): string | undefined {
+    if (!providerToolName) return undefined
+
+    return (
+      resolveCanonicalMcpToolIdentity(
+        providerToolName,
+        this.sessionMcpServerNames.get(sessionId) ?? []
+      ) ?? providerToolName
+    )
   }
 
   // Captures process stderr/errors/exits and converts unexpected ones to events.

--- a/src/main/agent-framework/app-mcp-names.ts
+++ b/src/main/agent-framework/app-mcp-names.ts
@@ -1,0 +1,152 @@
+import type { AgentFrameworkId } from './types'
+
+type AppMcpServerDefinition = {
+  canonicalName: string
+  openCodeName: string
+  tools: readonly string[]
+}
+
+// App-owned MCP identity stays canonical inside Open Science. Framework-specific names are projected
+// only at the agent-facing seam so permissions, grants, policy, and diagnostics keep one stable key.
+const APP_MCP_SERVERS: readonly AppMcpServerDefinition[] = [
+  {
+    canonicalName: 'open-science-activity',
+    openCodeName: 'open_science_activity',
+    tools: ['begin_activity_group']
+  },
+  {
+    canonicalName: 'open-science-artifacts',
+    openCodeName: 'open_science_artifacts',
+    tools: ['write_artifact_file']
+  },
+  {
+    canonicalName: 'open-science-notebook',
+    openCodeName: 'open_science_notebook',
+    tools: [
+      'notebook_execute',
+      'repl_execute',
+      'bash_execute',
+      'notebook_state',
+      'list_notebook_runtimes',
+      'notebook_bind_runtime',
+      'notebook_switch_runtime',
+      'notebook_restart',
+      'notebook_shutdown',
+      'inspect_packages',
+      'manage_packages',
+      'manage_environments'
+    ]
+  },
+  {
+    canonicalName: 'open-science-skills',
+    openCodeName: 'open_science_skills',
+    tools: ['request_skill_import']
+  }
+]
+
+const APP_MCP_SERVER_BY_CANONICAL_NAME = new Map(
+  APP_MCP_SERVERS.map((definition) => [definition.canonicalName, definition])
+)
+const APP_MCP_SERVER_BY_OPENCODE_NAME = new Map(
+  APP_MCP_SERVERS.map((definition) => [definition.openCodeName, definition])
+)
+
+const canonicalAppMcpServerName = (name: string): string =>
+  APP_MCP_SERVER_BY_OPENCODE_NAME.get(name)?.canonicalName ?? name
+
+const modelFacingAppMcpServerName = (frameworkId: AgentFrameworkId, name: string): string => {
+  const canonicalName = canonicalAppMcpServerName(name)
+  const definition = APP_MCP_SERVER_BY_CANONICAL_NAME.get(canonicalName)
+
+  return frameworkId === 'opencode' && definition ? definition.openCodeName : canonicalName
+}
+
+const appMcpServerAliases = (name: string): readonly string[] => {
+  const canonicalName = canonicalAppMcpServerName(name)
+  const definition = APP_MCP_SERVER_BY_CANONICAL_NAME.get(canonicalName)
+
+  return definition ? [definition.canonicalName, definition.openCodeName] : [canonicalName]
+}
+
+const resolveCanonicalMcpToolIdentity = (
+  name: string | null | undefined,
+  mcpServerNames: readonly string[]
+): string | undefined => {
+  if (!name) return undefined
+
+  const canonicalServers = [
+    ...new Set(mcpServerNames.map((server) => canonicalAppMcpServerName(server)))
+  ]
+  const configuredServerFor = (reportedServer: string): string | undefined =>
+    canonicalServers.find((server) => appMcpServerAliases(server).includes(reportedServer))
+
+  if (name.startsWith('mcp__')) {
+    const [reportedServer, ...toolParts] = name.slice('mcp__'.length).split('__')
+    if (!reportedServer || toolParts.length === 0) return undefined
+
+    return `${configuredServerFor(reportedServer) ?? reportedServer}/${toolParts.join('__')}`
+  }
+
+  const serverAliases = canonicalServers
+    .flatMap((server) => appMcpServerAliases(server).map((alias) => ({ alias, server })))
+    .sort((left, right) => right.alias.length - left.alias.length)
+
+  for (const { alias, server } of serverAliases) {
+    const codexPrefix = `mcp.${alias}.`
+    if (name.startsWith(codexPrefix)) return `${server}/${name.slice(codexPrefix.length)}`
+
+    const openCodePrefix = `${alias}_`
+    if (name.startsWith(openCodePrefix)) return `${server}/${name.slice(openCodePrefix.length)}`
+  }
+
+  return undefined
+}
+
+const modelFacingAppMcpToolName = (
+  frameworkId: AgentFrameworkId,
+  server: string,
+  tool: string,
+  codexBridgeAliases = false
+): string => {
+  const canonicalServer = canonicalAppMcpServerName(server)
+  if (frameworkId === 'codex' && !codexBridgeAliases) {
+    return `mcp.${canonicalServer}.${tool}`
+  }
+  if (frameworkId === 'opencode') {
+    return `${modelFacingAppMcpServerName(frameworkId, canonicalServer)}_${tool}`
+  }
+
+  return `mcp__${canonicalServer.replace(/[^a-zA-Z0-9_]/g, '_')}__${tool}`
+}
+
+const renderAppMcpToolReferences = (frameworkId: AgentFrameworkId, text: string): string => {
+  if (frameworkId === 'codex') return text
+
+  let rendered = text
+  if (frameworkId === 'opencode') {
+    for (const definition of APP_MCP_SERVERS) {
+      rendered = rendered.replaceAll(definition.canonicalName, definition.openCodeName)
+    }
+  }
+
+  for (const definition of APP_MCP_SERVERS) {
+    for (const tool of definition.tools) {
+      const callableName =
+        frameworkId === 'claude-code'
+          ? `mcp__${definition.canonicalName}__${tool}`
+          : modelFacingAppMcpToolName(frameworkId, definition.canonicalName, tool)
+      rendered = rendered.replace(new RegExp(`\\b${tool}\\b`, 'g'), callableName)
+    }
+  }
+
+  return rendered
+}
+
+export {
+  appMcpServerAliases,
+  canonicalAppMcpServerName,
+  modelFacingAppMcpServerName,
+  modelFacingAppMcpToolName,
+  resolveCanonicalMcpToolIdentity,
+  renderAppMcpToolReferences
+}

--- a/src/main/agent-framework/claude-code.test.ts
+++ b/src/main/agent-framework/claude-code.test.ts
@@ -59,13 +59,23 @@ describe('claudeCodeFramework', () => {
     expect(setup.persistentSystemPrompt).toBe(systemPrompt.append)
   })
 
-  it.each([
-    ['Codex', codexFramework],
-    ['OpenCode', opencodeFramework]
-  ])('keeps generic MCP tool references unchanged for %s', (_name, framework) => {
+  it('keeps generic MCP tool references unchanged for Codex', () => {
     const append = 'Use `notebook_execute` and then `write_artifact_file`.'
 
-    expect(framework.buildSessionSetup({ systemPromptAppends: [append] }).promptPrefix).toBe(append)
+    expect(codexFramework.buildSessionSetup({ systemPromptAppends: [append] }).promptPrefix).toBe(
+      append
+    )
+  })
+
+  it('renders generic MCP tool references as OpenCode callable names', () => {
+    const append =
+      'Use `notebook_execute` from `open-science-notebook`, then `write_artifact_file`.'
+
+    expect(
+      opencodeFramework.buildSessionSetup({ systemPromptAppends: [append] }).promptPrefix
+    ).toBe(
+      'Use `open_science_notebook_notebook_execute` from `open_science_notebook`, then `open_science_artifacts_write_artifact_file`.'
+    )
   })
 
   it('keeps already-namespaced Claude MCP tool references unchanged', () => {

--- a/src/main/agent-framework/claude-code.ts
+++ b/src/main/agent-framework/claude-code.ts
@@ -16,32 +16,7 @@ import type {
   SessionSetup,
   SessionSetupContext
 } from './types'
-
-// Claude exposes ACP-provided MCP tools as mcp__<server>__<tool>; shared prompts stay framework-neutral.
-const CLAUDE_MCP_TOOL_NAMES = [
-  ['begin_activity_group', 'mcp__open-science-activity__begin_activity_group'],
-  ['write_artifact_file', 'mcp__open-science-artifacts__write_artifact_file'],
-  ['notebook_execute', 'mcp__open-science-notebook__notebook_execute'],
-  ['repl_execute', 'mcp__open-science-notebook__repl_execute'],
-  ['bash_execute', 'mcp__open-science-notebook__bash_execute'],
-  ['notebook_state', 'mcp__open-science-notebook__notebook_state'],
-  ['list_notebook_runtimes', 'mcp__open-science-notebook__list_notebook_runtimes'],
-  ['notebook_bind_runtime', 'mcp__open-science-notebook__notebook_bind_runtime'],
-  ['notebook_switch_runtime', 'mcp__open-science-notebook__notebook_switch_runtime'],
-  ['notebook_restart', 'mcp__open-science-notebook__notebook_restart'],
-  ['notebook_shutdown', 'mcp__open-science-notebook__notebook_shutdown'],
-  ['inspect_packages', 'mcp__open-science-notebook__inspect_packages'],
-  ['manage_packages', 'mcp__open-science-notebook__manage_packages'],
-  ['manage_environments', 'mcp__open-science-notebook__manage_environments'],
-  ['request_skill_import', 'mcp__open-science-skills__request_skill_import']
-] as const
-
-const renderClaudeMcpToolNames = (append: string): string =>
-  CLAUDE_MCP_TOOL_NAMES.reduce(
-    (rendered, [toolName, callableName]) =>
-      rendered.replace(new RegExp(`\\b${toolName}\\b`, 'g'), callableName),
-    append
-  )
+import { renderAppMcpToolReferences } from './app-mcp-names'
 
 // Select Claude Code's complete built-in tool set explicitly instead of relying on
 // claude-agent-acp's current fallback. This keeps WebFetch/WebSearch available if the adapter's
@@ -100,7 +75,7 @@ export const claudeCodeFramework: AgentFramework = {
     }
 
     const persistentSystemPrompt = ctx.systemPromptAppends
-      .map(renderClaudeMcpToolNames)
+      .map((append) => renderAppMcpToolReferences('claude-code', append))
       .filter(Boolean)
       .join('\n\n')
     if (persistentSystemPrompt) {
@@ -112,7 +87,7 @@ export const claudeCodeFramework: AgentFramework = {
     }
 
     const promptPrefix = ctx.turnPromptReminders
-      ?.map(renderClaudeMcpToolNames)
+      ?.map((append) => renderAppMcpToolReferences('claude-code', append))
       .filter(Boolean)
       .join('\n\n')
 

--- a/src/main/agent-framework/opencode.ts
+++ b/src/main/agent-framework/opencode.ts
@@ -21,6 +21,7 @@ import type {
   SessionSetup,
   SessionSetupContext
 } from './types'
+import { renderAppMcpToolReferences } from './app-mcp-names'
 
 // opencode speaks ACP over `opencode acp` (stdio JSON-RPC). Only the shapes that differ from Claude
 // are implemented here: model config (a generated opencode.json, not ANTHROPIC_* env), system-prompt
@@ -417,7 +418,11 @@ export const opencodeFramework: AgentFramework = {
     // No claude_code preset here; deliver appends as a prompt prefix instead of session meta.
     return {
       promptPrefix:
-        ctx.systemPromptAppends.length > 0 ? ctx.systemPromptAppends.join('\n\n') : undefined
+        ctx.systemPromptAppends.length > 0
+          ? ctx.systemPromptAppends
+              .map((append) => renderAppMcpToolReferences('opencode', append))
+              .join('\n\n')
+          : undefined
     }
   },
 


### PR DESCRIPTION
## Problem
OpenCode 1.18.3 derives callable names by joining its registered MCP server name with the tool name. Open Science supplied hyphenated app-owned server names, while model calls repeatedly used underscore server names, causing strict Invalid Tool dispatch failures documented in #516.

## Proposed change
- Project activity, artifacts, notebook, and skills to stable underscore-only server IDs at the OpenCode agent-facing seam for both session creation and resume.
- Map those names back to canonical hyphenated identities for permission policy, grants, and audit logging.
- Render exact OpenCode callable names in prompts and static context schemas while preserving Claude Code and Codex behavior.
- Add public `AcpRuntime` and focused regression coverage.

## Scope and non-goals
- This changes only app-owned MCP naming for OpenCode.
- It does not register duplicate aliases or add fuzzy hyphen/underscore dispatch.
- It does not address the separate session-persistence race discussed in #519.

## Acceptance criteria and validation
All checks were run after the final material edits.

- OpenCode create/resume names and prompt references: `npm test -- src/main/acp/runtime.test.ts` — 259/259 passed.
- Permission canonicalization, artifact auto-allow, activity recognition, and canonical diagnostic identities: covered by the same runtime suite — 259/259 passed.
- Static-context names and Claude Code compatibility: focused five-file suite — 81/81 passed.
- Type safety: `npm run typecheck` — passed.
- Lint: `npm run lint` — passed with 0 errors; 24 existing warnings remain in unrelated files.
- Full regression: `npm test` — 546 files passed, 11 skipped; 8155 tests passed, 139 skipped.

Remaining risk: the regression tests exercise the ACP protocol boundaries with fake processes, not a live OpenCode 1.18.3 provider session or stochastic model name generation.

Closes #516

## Review focus
- The model-facing versus canonical naming seam in `app-mcp-names.ts`.
- Security-sensitive permission identity normalization and artifact auto-allow behavior.
- Claude Code and Codex compatibility.