### PR TITLE
fix(update): recover Windows in-place upgrades

### DIFF
--- a/build/installer.nsh
+++ b/build/installer.nsh
@@ -2,14 +2,154 @@
   nsExec::ExecToLog '"$SYSDIR\WindowsPowerShell\v1.0\powershell.exe" -NoProfile -NonInteractive -ExecutionPolicy Bypass -File "$INSTDIR\resources\windows-runtime-cache-uninstall.ps1"'
 !macroend
 
+!ifndef BUILD_UNINSTALLER
+!define MUI_CUSTOMFUNCTION_ABORT restorePreservedOnAbort
+
+Var perMachineInstallDirCache
+Var perUserInstallDirCache
+Var perMachineDataBackup
+Var perUserDataBackup
+Var dataProtectionFailed
+Var dataRestoreFailed
+
+# Move a data root outside the installation before the OLD uninstaller sees it. A deterministic
+# sibling path lets an elevated inner installer or a later retry recover data left by an
+# interrupted outer installer without relying on process-local registers.
+!macro preserveNestedDataRoot DIR BACKUP SLOT
+  StrCpy ${BACKUP} ""
+  ${if} "${DIR}" != ""
+    ClearErrors
+    GetFullPathName $R2 "${DIR}\.."
+    ${if} ${Errors}
+      DetailPrint `Could not safely preserve "${DIR}\OpenScience"; its parent path could not be resolved.`
+      MessageBox MB_OK|MB_ICONSTOP "Open Science could not safely protect its data folder before updating.$\r$\nThe existing data was left untouched."
+      StrCpy $dataProtectionFailed "1"
+    ${else}
+      StrCpy ${BACKUP} "$R2\.open-science-update-data-${SLOT}"
+      ${if} ${FileExists} "${DIR}\OpenScience\*.*"
+        ${if} ${FileExists} "${BACKUP}\*.*"
+          DetailPrint `Could not safely preserve "${DIR}\OpenScience" because the backup path already exists: ${BACKUP}`
+          MessageBox MB_OK|MB_ICONSTOP "Open Science found both the current data folder and an earlier update backup.$\r$\nNo data was changed. Please inspect:$\r$\n${BACKUP}"
+          StrCpy ${BACKUP} ""
+          StrCpy $dataProtectionFailed "1"
+        ${else}
+          ClearErrors
+          Rename "${DIR}\OpenScience" "${BACKUP}"
+          ${if} ${Errors}
+            DetailPrint `Could not safely preserve "${DIR}\OpenScience"; leaving the existing installation untouched.`
+            MessageBox MB_OK|MB_ICONSTOP "Open Science could not safely protect its data folder before updating.$\r$\nThe existing data was left untouched."
+            StrCpy ${BACKUP} ""
+            StrCpy $dataProtectionFailed "1"
+          ${else}
+            DetailPrint `Protected the data folder at: ${BACKUP}`
+          ${endif}
+        ${endif}
+      ${elseif} ${FileExists} "${BACKUP}\*.*"
+        # A previous installer exited before it could restore. Adopt that deterministic backup
+        # and restore it through the normal post-uninstall path.
+        DetailPrint `Found data preserved by an interrupted update at: ${BACKUP}`
+      ${else}
+        StrCpy ${BACKUP} ""
+      ${endif}
+    ${endif}
+  ${endif}
+!macroend
+
+!macro restoreNestedDataRoot DIR BACKUP
+  ${if} "${DIR}" != ""
+  ${andIf} "${BACKUP}" != ""
+    ${if} ${FileExists} "${BACKUP}\*.*"
+      ${if} ${FileExists} "${DIR}\OpenScience\*.*"
+        DetailPrint `The preserved data remains at: ${BACKUP}`
+        MessageBox MB_OK|MB_ICONSTOP "Open Science could not restore its data folder because the destination already exists.$\r$\nThe preserved data remains at:$\r$\n${BACKUP}"
+        StrCpy $dataRestoreFailed "1"
+      ${else}
+        CreateDirectory "${DIR}"
+        ClearErrors
+        Rename "${BACKUP}" "${DIR}\OpenScience"
+        ${if} ${Errors}
+          DetailPrint `The preserved data remains at: ${BACKUP}`
+          MessageBox MB_OK|MB_ICONSTOP "Open Science could not restore its data folder after updating.$\r$\nThe preserved data remains at:$\r$\n${BACKUP}"
+          StrCpy $dataRestoreFailed "1"
+        ${else}
+          DetailPrint `Restored the data folder to: ${DIR}\OpenScience`
+          StrCpy ${BACKUP} ""
+        ${endif}
+      ${endif}
+    ${else}
+      # Another installer instance may already have restored the deterministic backup.
+      StrCpy ${BACKUP} ""
+    ${endif}
+  ${endif}
+!macroend
+
+!macro restoreAllNestedDataRoots
+  StrCpy $dataRestoreFailed "0"
+  !insertmacro restoreNestedDataRoot $perMachineInstallDirCache $perMachineDataBackup
+  !insertmacro restoreNestedDataRoot $perUserInstallDirCache $perUserDataBackup
+!macroend
+
+!macro quitIfDataRestoreFailed
+  ${if} $dataRestoreFailed != "0"
+    SetErrorLevel 2
+    Quit
+  ${endif}
+!macroend
+
 !macro customInit
-  # Cache any stray per-user install location NOW (install start), BEFORE any uninstall pass
-  # runs: the HKCU uninstall pass deletes this value on success, so customUnInstallCheckCurrentUser
-  # — which runs after that pass — could never read it there. Declared inside this macro (rather
-  # than at file scope) because customInit only expands into the installer build; a file-scope
-  # Var would be declared-but-unused in the uninstaller build, and makensis fails that warning.
-  Var /GLOBAL perUserInstallDirCache
+  # Cache both registered locations before either uninstall pass can delete their registry data.
+  # More importantly, move any nested OpenScience data root OUTSIDE the install directory before
+  # the first old uninstaller runs. Its /KEEP_APP_DATA flag only protects the normal OS app-data
+  # directory; its update algorithm otherwise moves every child of the install directory into a
+  # disposable $PLUGINSDIR and deletes it on success.
+  StrCpy $perMachineInstallDirCache ""
+  StrCpy $perUserInstallDirCache ""
+  StrCpy $perMachineDataBackup ""
+  StrCpy $perUserDataBackup ""
+  StrCpy $dataProtectionFailed "0"
+  StrCpy $dataRestoreFailed "0"
+  ReadRegStr $perMachineInstallDirCache HKEY_LOCAL_MACHINE "${INSTALL_REGISTRY_KEY}" InstallLocation
   ReadRegStr $perUserInstallDirCache HKEY_CURRENT_USER "${INSTALL_REGISTRY_KEY}" InstallLocation
+
+  # Protect HKCU independently of the mode selected during .onInit: the user can still switch to
+  # all-users on the assisted install-mode page, so that early mode is not the uninstall verdict.
+  !insertmacro preserveNestedDataRoot $perUserInstallDirCache $perUserDataBackup per-user
+
+  # An assisted per-machine install elevates into a second installer process. An unelevated outer
+  # process must not fail merely because it cannot rename a machine installation; the inner/admin
+  # .onInit protects HKLM regardless of the mode it initially inherits. If both registry entries
+  # point to one tree, the HKCU backup already protects it through both uninstall passes.
+  ${if} $dataProtectionFailed == "0"
+    ${if} $perMachineInstallDirCache == $perUserInstallDirCache
+      StrCpy $perMachineDataBackup $perUserDataBackup
+    ${elseif} ${UAC_IsAdmin}
+      !insertmacro preserveNestedDataRoot $perMachineInstallDirCache $perMachineDataBackup machine
+    ${elseif} $perMachineInstallDirCache != ""
+      DetailPrint `Deferring machine data-folder protection to the elevated installer.`
+    ${endif}
+  ${endif}
+  ${if} $dataProtectionFailed != "0"
+    # Undo any earlier successful move before refusing to start either old uninstaller.
+    !insertmacro restoreAllNestedDataRoots
+    SetErrorLevel 2
+    Quit
+  ${endif}
+!macroend
+
+# These callbacks cover cancellation or an installer failure before the post-uninstall hooks run.
+# The normal path restores each directory immediately after its matching old-uninstaller pass.
+!macro customHeader
+  Function restorePreservedOnAbort
+    !insertmacro restoreAllNestedDataRoots
+  FunctionEnd
+
+  Function .onInstFailed
+    !insertmacro restoreAllNestedDataRoots
+  FunctionEnd
+
+  Function .onGUIEnd
+    !insertmacro restoreAllNestedDataRoots
+  FunctionEnd
 !macroend
 
 # Resilient replacement for handleUninstallResult's default failure handling, installed via
@@ -59,17 +199,117 @@
     ${endif}
     ClearErrors
     Sleep 1000
+    # A custom data root may live inside the installation itself (the issue reporter uses
+    # <install>\OpenScience). The updated uninstaller moves EVERY child of ${DIR} into its
+    # disposable $PLUGINSDIR, so making that move reliable without protecting the data root
+    # would turn an update failure into silent data loss. Move the directory to a unique sibling
+    # on the same volume before retrying, then restore it regardless of the retry's exit code.
+    # A failed preserve leaves the original directory in place and aborts before the retry.
+    StrCpy $R7 ""
+    ${if} ${FileExists} "${DIR}\OpenScience\*.*"
+      ClearErrors
+      GetFullPathName $R2 "${DIR}\.."
+      GetTempFileName $R7 "$R2"
+      ${ifNot} ${Errors}
+        Delete "$R7"
+        ClearErrors
+        Rename "${DIR}\OpenScience" "$R7"
+      ${endif}
+      ${if} ${Errors}
+        Delete "$R7"
+        DetailPrint `Could not safely preserve "${DIR}\OpenScience"; leaving the existing installation untouched.`
+        MessageBox MB_OK|MB_ICONEXCLAMATION "$(uninstallFailed): $R0"
+        !insertmacro restoreAllNestedDataRoots
+        SetErrorLevel 2
+        Quit
+      ${endif}
+    ${endif}
+
+    # During an update, electron-builder's old uninstaller moves every installed file into its
+    # $PLUGINSDIR before deleting the old tree. Windows cannot atomically rename across volumes:
+    # for a custom D: install and the usual C: TEMP this becomes a slow, failure-prone copy of the
+    # whole installation. Give only the recovery child a unique temp directory beside the old
+    # install so its plugin directory stays on the same volume. If that directory cannot be
+    # created, retain the existing default-TEMP retry rather than turning recovery setup into a
+    # new fatal path. $R3/$R4 preserve this installer's environment across the child process.
+    StrCpy $R5 ""
+    ClearErrors
+    GetFullPathName $R2 "${DIR}\.."
+    GetTempFileName $R5 "$R2"
+    ${ifNot} ${Errors}
+      Delete "$R5"
+      ClearErrors
+      CreateDirectory "$R5"
+    ${endif}
+    ${ifNot} ${Errors}
+      ReadEnvStr $R3 "TEMP"
+      ReadEnvStr $R4 "TMP"
+      System::Call 'Kernel32::SetEnvironmentVariable(t, t)i ("TEMP", "$R5").rR6'
+      ${if} $R6 != 0
+        System::Call 'Kernel32::SetEnvironmentVariable(t, t)i ("TMP", "$R5").rR6'
+      ${endif}
+      ${if} $R6 == 0
+        # A partial environment update must not leak into the rest of the new installer.
+        System::Call 'Kernel32::SetEnvironmentVariable(t, t)i ("TEMP", "$R3").rR6'
+        System::Call 'Kernel32::SetEnvironmentVariable(t, t)i ("TMP", "$R4").rR6'
+        RMDir /r "$R5"
+        StrCpy $R5 ""
+      ${endif}
+    ${else}
+      StrCpy $R5 ""
+    ${endif}
+
     ExecWait '"$PLUGINSDIR\old-uninstaller.exe" /S /KEEP_APP_DATA $0 _?=${DIR}' $R0
+    ${if} $R5 != ""
+      System::Call 'Kernel32::SetEnvironmentVariable(t, t)i ("TEMP", "$R3").rR6'
+      System::Call 'Kernel32::SetEnvironmentVariable(t, t)i ("TMP", "$R4").rR6'
+      RMDir /r "$R5"
+      ClearErrors
+    ${endif}
+    ${if} $R7 != ""
+      # The retry may have removed ${DIR}; recreate only the parent and put the preserved data
+      # back before deciding whether the retry's exit code represents success or failure.
+      CreateDirectory "${DIR}"
+      ClearErrors
+      Rename "$R7" "${DIR}\OpenScience"
+      ${if} ${Errors}
+        DetailPrint `The preserved data remains at: $R7`
+        MessageBox MB_OK|MB_ICONSTOP "Open Science could not restore its data folder after updating.$\r$\nYour data remains at:$\r$\n$R7"
+        !insertmacro restoreAllNestedDataRoots
+        SetErrorLevel 2
+        Quit
+      ${endif}
+      StrCpy $R7 ""
+    ${endif}
     ${if} $R0 != 0
-      MessageBox MB_OK|MB_ICONEXCLAMATION "$(uninstallFailed): $R0"
-      DetailPrint `Uninstall was not successful. Uninstaller error code: $R0.`
-      SetErrorLevel 2
-      Quit
+      ${ifNot} ${FileExists} "${DIR}\${APP_EXECUTABLE_FILENAME}"
+        DetailPrint `Retry exited with $R0 but the previous installation is already removed; continuing.`
+      ${else}
+        MessageBox MB_OK|MB_ICONEXCLAMATION "$(uninstallFailed): $R0"
+        DetailPrint `Uninstall was not successful. Uninstaller error code: $R0.`
+        !insertmacro restoreAllNestedDataRoots
+        SetErrorLevel 2
+        Quit
+      ${endif}
     ${endif}
   ${endif}
 !macroend
 
 !macro customUnInstallCheck
+  # SHELL_CONTEXT resolves from the FINAL install-mode page selection, not the mode seen by
+  # customInit. A current-user install has no second pass, so restore every cached root. An
+  # all-users install restores HKLM here and keeps HKCU protected for the following explicit pass.
+  ${if} $installMode == "all"
+    ${if} $perMachineInstallDirCache == $perUserInstallDirCache
+      DetailPrint `Keeping the shared data folder protected for the matching per-user uninstall pass.`
+    ${else}
+      !insertmacro restoreNestedDataRoot $perMachineInstallDirCache $perMachineDataBackup
+      !insertmacro quitIfDataRestoreFailed
+    ${endif}
+  ${else}
+    !insertmacro restoreAllNestedDataRoots
+    !insertmacro quitIfDataRestoreFailed
+  ${endif}
   ${if} $R0 != 0
     # SHELL_CONTEXT pass: the old installation sits at $INSTDIR (an update installs over it).
     !insertmacro uninstallFailureRecoveryAt $INSTDIR
@@ -77,6 +317,10 @@
 !macroend
 
 !macro customUnInstallCheckCurrentUser
+  # The old uninstall may have removed its registry key, so restore using the path cached before
+  # either pass rather than reading InstallLocation here.
+  !insertmacro restoreNestedDataRoot $perUserInstallDirCache $perUserDataBackup
+  !insertmacro quitIfDataRestoreFailed
   ${if} $R0 != 0
     # installMode==all pass: it removes a stray PER-USER install, which may live anywhere —
     # $INSTDIR/$appExe describe the new (machine-wide) target, not it. Use the location cached in
@@ -87,9 +331,12 @@
     ${if} $perUserInstallDirCache == ""
       MessageBox MB_OK|MB_ICONEXCLAMATION "$(uninstallFailed): $R0"
       DetailPrint `Uninstall was not successful. Uninstaller error code: $R0.`
+      !insertmacro restoreAllNestedDataRoots
       SetErrorLevel 2
       Quit
     ${endif}
     !insertmacro uninstallFailureRecoveryAt $perUserInstallDirCache
   ${endif}
 !macroend
+
+!endif

--- a/build/installer.nsh
+++ b/build/installer.nsh
@@ -113,7 +113,35 @@ Var dataRestoreFailed
 
   # Protect HKCU independently of the mode selected during .onInit: the user can still switch to
   # all-users on the assisted install-mode page, so that early mode is not the uninstall verdict.
-  !insertmacro preserveNestedDataRoot $perUserInstallDirCache $perUserDataBackup per-user
+  # One exception needs a non-destructive write probe: both registry entries may point at the
+  # same machine-owned Program Files tree. An unelevated outer process must defer that shared path
+  # to the inner installer instead of failing before the user has a chance to approve UAC.
+  StrCpy $R8 "1"
+  ${if} $perUserInstallDirCache != ""
+  ${andIf} $perMachineInstallDirCache == $perUserInstallDirCache
+  ${andIfNot} ${UAC_IsAdmin}
+    StrCpy $R8 "0"
+    StrCpy $R9 ""
+    ClearErrors
+    GetFullPathName $R2 "$perUserInstallDirCache\.."
+    ${ifNot} ${Errors}
+      GetTempFileName $R9 "$R2"
+      ${ifNot} ${Errors}
+        ClearErrors
+        Delete "$R9"
+        ${ifNot} ${Errors}
+          StrCpy $R8 "1"
+        ${endif}
+      ${endif}
+    ${endif}
+    ${if} $R8 == "0"
+      DetailPrint `Deferring shared data-folder protection to the elevated installer.`
+      ClearErrors
+    ${endif}
+  ${endif}
+  ${if} $R8 == "1"
+    !insertmacro preserveNestedDataRoot $perUserInstallDirCache $perUserDataBackup per-user
+  ${endif}
 
   # An assisted per-machine install elevates into a second installer process. An unelevated outer
   # process must not fail merely because it cannot rename a machine installation; the inner/admin

--- a/build/installer.nsh
+++ b/build/installer.nsh
@@ -119,6 +119,41 @@ FunctionEnd
   ${endif}
 !macroend
 
+# Run only after installMode is final. Interactive assisted installers reach this from the
+# instfiles-page preflight; silent installs have no page callbacks, so customInit calls it after
+# initMultiUser has resolved the command-line/previous-install mode. A distinct HKLM tree must not
+# be touched for a current-user install merely because the process already has admin rights.
+!macro protectMachineDataRootForSelectedMode
+  ${if} $dataProtectionFailed == "0"
+  ${andIf} $installMode == "all"
+    ${if} $perMachineInstallDirCache == $perUserInstallDirCache
+      StrCpy $perMachineDataBackup $perUserDataBackup
+    ${elseif} ${UAC_IsAdmin}
+      !insertmacro preserveNestedDataRoot $perMachineInstallDirCache $perMachineDataBackup machine
+    ${elseif} $perMachineInstallDirCache != ""
+      # The unelevated assisted outer process stops on the install-mode page while its elevated
+      # inner process completes the install. The inner process runs this same protection path.
+      DetailPrint `Deferring machine data-folder protection to the elevated installer.`
+    ${endif}
+  ${endif}
+  ${if} $dataProtectionFailed != "0"
+    # Undo any earlier successful move before refusing to start either old uninstaller.
+    !insertmacro restoreAllNestedDataRoots
+    SetErrorLevel 2
+    Quit
+  ${endif}
+!macroend
+
+# electron-builder already installs an instfiles PRE callback that sanitizes the selected install
+# directory. Preserve that callback and chain the final-mode data preflight after it.
+!macro customPageAfterChangeDir
+  !ifdef MUI_PAGE_CUSTOMFUNCTION_PRE
+    !define openScienceOriginalInstFilesPre ${MUI_PAGE_CUSTOMFUNCTION_PRE}
+    !undef MUI_PAGE_CUSTOMFUNCTION_PRE
+  !endif
+  !define MUI_PAGE_CUSTOMFUNCTION_PRE protectNestedDataRootsForInstall
+!macroend
+
 !macro customInit
   # Cache both registered locations before either uninstall pass can delete their registry data.
   # More importantly, move any nested OpenScience data root OUTSIDE the install directory before
@@ -172,30 +207,28 @@ FunctionEnd
     !insertmacro preserveNestedDataRoot $perUserInstallDirCache $perUserDataBackup per-user
   ${endif}
 
-  # An assisted per-machine install elevates into a second installer process. An unelevated outer
-  # process must not fail merely because it cannot rename a machine installation; the inner/admin
-  # .onInit protects HKLM regardless of the mode it initially inherits. If both registry entries
-  # point to one tree, the HKCU backup already protects it through both uninstall passes.
-  ${if} $dataProtectionFailed == "0"
-    ${if} $perMachineInstallDirCache == $perUserInstallDirCache
-      StrCpy $perMachineDataBackup $perUserDataBackup
-    ${elseif} ${UAC_IsAdmin}
-      !insertmacro preserveNestedDataRoot $perMachineInstallDirCache $perMachineDataBackup machine
-    ${elseif} $perMachineInstallDirCache != ""
-      DetailPrint `Deferring machine data-folder protection to the elevated installer.`
-    ${endif}
-  ${endif}
   ${if} $dataProtectionFailed != "0"
-    # Undo any earlier successful move before refusing to start either old uninstaller.
     !insertmacro restoreAllNestedDataRoots
     SetErrorLevel 2
     Quit
+  ${endif}
+  # Page callbacks do not run in silent mode. There is no later user choice in that mode, so the
+  # installMode selected by initMultiUser is already final and machine protection can run now.
+  ${if} ${Silent}
+    !insertmacro protectMachineDataRootForSelectedMode
   ${endif}
 !macroend
 
 # These callbacks cover cancellation or an installer failure before the post-uninstall hooks run.
 # The normal path restores each directory immediately after its matching old-uninstaller pass.
 !macro customHeader
+  Function protectNestedDataRootsForInstall
+    !ifdef openScienceOriginalInstFilesPre
+      Call ${openScienceOriginalInstFilesPre}
+    !endif
+    !insertmacro protectMachineDataRootForSelectedMode
+  FunctionEnd
+
   Function restorePreservedOnAbort
     !insertmacro restoreAllNestedDataRoots
   FunctionEnd

--- a/build/installer.nsh
+++ b/build/installer.nsh
@@ -257,7 +257,7 @@ FunctionEnd
 # CHECK_APP_RUNNING declare their globals ($installationDir, $PowerShellPath, ...), and makensis
 # treats unknown variables as errors — so this stays self-contained: registers, built-in
 # constants, and the literal temp-uninstaller path uninstallOldVersion uses.
-!macro uninstallFailureRecoveryAt DIR
+!macro uninstallFailureRecoveryAt DIR REGISTERED_BACKUP
   ${ifNot} ${FileExists} "${DIR}\${APP_EXECUTABLE_FILENAME}"
     DetailPrint `Old uninstaller exited with $R0 but the previous installation is already removed; continuing.`
   ${else}
@@ -353,19 +353,29 @@ FunctionEnd
       ClearErrors
     ${endif}
     ${if} $R7 != ""
-      # The retry may have removed ${DIR}; recreate only the parent and put the preserved data
-      # back before deciding whether the retry's exit code represents success or failure.
-      CreateDirectory "${DIR}"
-      ClearErrors
-      Rename "$R7" "${DIR}\OpenScience"
-      ${if} ${Errors}
-        DetailPrint `The preserved data remains at: $R7`
-        MessageBox MB_OK|MB_ICONSTOP "Open Science could not restore its data folder after updating.$\r$\nYour data remains at:$\r$\n$R7"
-        !insertmacro restoreAllNestedDataRoots
-        SetErrorLevel 2
-        Quit
+      ${if} "${REGISTERED_BACKUP}" != ""
+      ${andIf} ${FileExists} "${REGISTERED_BACKUP}\*.*"
+        # customInit already holds the authoritative registered data outside the install tree.
+        # Do not overwrite either copy if the old process recreated data before it was killed;
+        # retain that additional directory at its unique sibling path for manual reconciliation.
+        DetailPrint `Additional data created during the update remains at: $R7`
+        MessageBox MB_OK|MB_ICONEXCLAMATION "Open Science found additional data created while closing the previous version.$\r$\nYour original data will be restored; the additional data remains at:$\r$\n$R7"
+      ${else}
+        # No registered backup exists (recovery can also be used independently). The retry may
+        # have removed ${DIR}; recreate only the parent and put the retry-local data back before
+        # deciding whether the retry's exit code represents success or failure.
+        CreateDirectory "${DIR}"
+        ClearErrors
+        Rename "$R7" "${DIR}\OpenScience"
+        ${if} ${Errors}
+          DetailPrint `The preserved data remains at: $R7`
+          MessageBox MB_OK|MB_ICONSTOP "Open Science could not restore its data folder after updating.$\r$\nYour data remains at:$\r$\n$R7"
+          !insertmacro restoreAllNestedDataRoots
+          SetErrorLevel 2
+          Quit
+        ${endif}
+        StrCpy $R7 ""
       ${endif}
-      StrCpy $R7 ""
     ${endif}
     ${if} $R0 != 0
       ${ifNot} ${FileExists} "${DIR}\${APP_EXECUTABLE_FILENAME}"
@@ -383,8 +393,20 @@ FunctionEnd
 
 !macro customUnInstallCheck
   # SHELL_CONTEXT resolves from the FINAL install-mode page selection, not the mode seen by
-  # customInit. A current-user install has no second pass, so restore every cached root. An
-  # all-users install restores HKLM here and keeps HKCU protected for the following explicit pass.
+  # customInit. Keep registered data outside the install tree through any non-zero-exit recovery:
+  # a live old process can recreate OpenScience, and restoring first would make the recovery path
+  # abort on that destination conflict. $R8 selects the authoritative backup for this pass.
+  ${if} $R0 != 0
+    StrCpy $R8 $perUserDataBackup
+    ${if} $installMode == "all"
+      StrCpy $R8 $perMachineDataBackup
+    ${endif}
+    # SHELL_CONTEXT pass: the old installation sits at $INSTDIR (an update installs over it).
+    !insertmacro uninstallFailureRecoveryAt $INSTDIR $R8
+  ${endif}
+
+  # A current-user install has no second pass, so restore every cached root. An all-users install
+  # restores HKLM here and keeps HKCU protected for the following explicit pass.
   ${if} $installMode == "all"
     ${if} $perMachineInstallDirCache == $perUserInstallDirCache
       DetailPrint `Keeping the shared data folder protected for the matching per-user uninstall pass.`
@@ -396,17 +418,9 @@ FunctionEnd
     !insertmacro restoreAllNestedDataRoots
     !insertmacro quitIfDataRestoreFailed
   ${endif}
-  ${if} $R0 != 0
-    # SHELL_CONTEXT pass: the old installation sits at $INSTDIR (an update installs over it).
-    !insertmacro uninstallFailureRecoveryAt $INSTDIR
-  ${endif}
 !macroend
 
 !macro customUnInstallCheckCurrentUser
-  # The old uninstall may have removed its registry key, so restore using the path cached before
-  # either pass rather than reading InstallLocation here.
-  !insertmacro restoreNestedDataRoot $perUserInstallDirCache $perUserDataBackup
-  !insertmacro quitIfDataRestoreFailed
   ${if} $R0 != 0
     # installMode==all pass: it removes a stray PER-USER install, which may live anywhere —
     # $INSTDIR/$appExe describe the new (machine-wide) target, not it. Use the location cached in
@@ -421,8 +435,13 @@ FunctionEnd
       SetErrorLevel 2
       Quit
     ${endif}
-    !insertmacro uninstallFailureRecoveryAt $perUserInstallDirCache
+    !insertmacro uninstallFailureRecoveryAt $perUserInstallDirCache $perUserDataBackup
   ${endif}
+  # The old uninstall may have removed its registry key, so restore using the path cached before
+  # either pass rather than reading InstallLocation here. Recovery must finish first because the
+  # still-preserved backup is what keeps a recreated data directory from short-circuiting retry.
+  !insertmacro restoreNestedDataRoot $perUserInstallDirCache $perUserDataBackup
+  !insertmacro quitIfDataRestoreFailed
 !macroend
 
 !endif

--- a/build/installer.nsh
+++ b/build/installer.nsh
@@ -174,10 +174,6 @@ Var dataRestoreFailed
   Function .onInstFailed
     !insertmacro restoreAllNestedDataRoots
   FunctionEnd
-
-  Function .onGUIEnd
-    !insertmacro restoreAllNestedDataRoots
-  FunctionEnd
 !macroend
 
 # Resilient replacement for handleUninstallResult's default failure handling, installed via

--- a/build/installer.nsh
+++ b/build/installer.nsh
@@ -12,6 +12,29 @@ Var perUserDataBackup
 Var dataProtectionFailed
 Var dataRestoreFailed
 
+# Registry values that identify the same Windows directory may differ only in letter case or a
+# trailing separator. LogicLib's == comparison is already case-insensitive; trim separators here
+# so every later shared-path decision uses one canonical form. Keep drive roots such as C:\ intact.
+Function normalizeRegisteredInstallPath
+  Exch $R0
+  Push $R1
+
+  normalizeRegisteredInstallPath_loop:
+    StrLen $R1 $R0
+    IntCmp $R1 3 normalizeRegisteredInstallPath_done normalizeRegisteredInstallPath_done
+    StrCpy $R1 $R0 1 -1
+    StrCmp $R1 "\" normalizeRegisteredInstallPath_trim
+    StrCmp $R1 "/" normalizeRegisteredInstallPath_trim normalizeRegisteredInstallPath_done
+
+  normalizeRegisteredInstallPath_trim:
+    StrCpy $R0 $R0 -1
+    Goto normalizeRegisteredInstallPath_loop
+
+  normalizeRegisteredInstallPath_done:
+    Pop $R1
+    Exch $R0
+FunctionEnd
+
 # Move a data root outside the installation before the OLD uninstaller sees it. A deterministic
 # sibling path lets an elevated inner installer or a later retry recover data left by an
 # interrupted outer installer without relying on process-local registers.
@@ -110,6 +133,12 @@ Var dataRestoreFailed
   StrCpy $dataRestoreFailed "0"
   ReadRegStr $perMachineInstallDirCache HKEY_LOCAL_MACHINE "${INSTALL_REGISTRY_KEY}" InstallLocation
   ReadRegStr $perUserInstallDirCache HKEY_CURRENT_USER "${INSTALL_REGISTRY_KEY}" InstallLocation
+  Push $perMachineInstallDirCache
+  Call normalizeRegisteredInstallPath
+  Pop $perMachineInstallDirCache
+  Push $perUserInstallDirCache
+  Call normalizeRegisteredInstallPath
+  Pop $perUserInstallDirCache
 
   # Protect HKCU independently of the mode selected during .onInit: the user can still switch to
   # all-users on the assisted install-mode page, so that early mode is not the uninstall verdict.

--- a/build/packaging.test.ts
+++ b/build/packaging.test.ts
@@ -154,6 +154,37 @@ describe('NSIS installer include (build/installer.nsh)', () => {
     expect(clearPreservedPathAt).toBeGreaterThan(restoreQuitAt)
   })
 
+  it('keeps registered data backups outside the install tree until recovery finishes', () => {
+    // A still-running old process can recreate <install>\OpenScience after customInit moved the
+    // registered data aside. Run force-kill + retry before restoring the authoritative backup in
+    // both uninstall hooks. If recovery also preserves a newly-created directory, retain it at
+    // its unique sibling path instead of overwriting either copy or feeding it to the uninstaller.
+    const recovery =
+      include.match(
+        /!macro uninstallFailureRecoveryAt DIR REGISTERED_BACKUP([\s\S]*?)!macroend/
+      )?.[1] ?? ''
+    const shellCheck = include.match(/!macro customUnInstallCheck([\s\S]*?)!macroend/)?.[1] ?? ''
+    const userCheck =
+      include.match(/!macro customUnInstallCheckCurrentUser([\s\S]*?)!macroend/)?.[1] ?? ''
+    const conflictBranch =
+      recovery.match(/\$\{if\} "\$\{REGISTERED_BACKUP\}" != ""([\s\S]*?)\$\{else\}/)?.[1] ?? ''
+    const shellRecoveryAt = shellCheck.indexOf('!insertmacro uninstallFailureRecoveryAt')
+    const shellRestoreAt = shellCheck.indexOf('!insertmacro restoreNestedDataRoot')
+    const userRecoveryAt = userCheck.indexOf('!insertmacro uninstallFailureRecoveryAt')
+    const userRestoreAt = userCheck.indexOf('!insertmacro restoreNestedDataRoot')
+
+    expect(shellRecoveryAt).toBeGreaterThan(-1)
+    expect(shellRecoveryAt).toBeLessThan(shellRestoreAt)
+    expect(userRecoveryAt).toBeGreaterThan(-1)
+    expect(userRecoveryAt).toBeLessThan(userRestoreAt)
+    expect(shellCheck).toContain('!insertmacro uninstallFailureRecoveryAt $INSTDIR $R8')
+    expect(userCheck).toContain(
+      '!insertmacro uninstallFailureRecoveryAt $perUserInstallDirCache $perUserDataBackup'
+    )
+    expect(conflictBranch).toContain('Additional data created during the update remains at: $R7')
+    expect(conflictBranch).not.toContain('Rename "$R7" "${DIR}\\OpenScience"')
+  })
+
   it('protects registered nested data roots before the first old-uninstaller attempt', () => {
     // Recovery-only protection is too late: the first old uninstaller can succeed after moving
     // <install>\OpenScience into its disposable $PLUGINSDIR. customInit runs before the install
@@ -177,11 +208,11 @@ describe('NSIS installer include (build/installer.nsh)', () => {
       '!insertmacro preserveNestedDataRoot $perUserInstallDirCache $perUserDataBackup per-user'
     )
     expect(shellCheck.indexOf('!insertmacro restoreNestedDataRoot')).toBeGreaterThan(-1)
-    expect(shellCheck.indexOf('!insertmacro restoreNestedDataRoot')).toBeLessThan(
+    expect(shellCheck.indexOf('!insertmacro restoreNestedDataRoot')).toBeGreaterThan(
       shellCheck.indexOf('${if} $R0 != 0')
     )
     expect(userCheck.indexOf('!insertmacro restoreNestedDataRoot')).toBeGreaterThan(-1)
-    expect(userCheck.indexOf('!insertmacro restoreNestedDataRoot')).toBeLessThan(
+    expect(userCheck.indexOf('!insertmacro restoreNestedDataRoot')).toBeGreaterThan(
       userCheck.indexOf('${if} $R0 != 0')
     )
     expect(include).toContain('!define MUI_CUSTOMFUNCTION_ABORT restorePreservedOnAbort')
@@ -303,8 +334,10 @@ describe('NSIS installer include (build/installer.nsh)', () => {
     // value and fall back to the default fatal handling only when no per-user install was
     // registered at install start.
     expect(include).toMatch(/\$\{if\} \$perUserInstallDirCache == ""/)
-    expect(include).toContain('!insertmacro uninstallFailureRecoveryAt $perUserInstallDirCache')
-    expect(include).toContain('!insertmacro uninstallFailureRecoveryAt $INSTDIR')
+    expect(include).toContain(
+      '!insertmacro uninstallFailureRecoveryAt $perUserInstallDirCache $perUserDataBackup'
+    )
+    expect(include).toContain('!insertmacro uninstallFailureRecoveryAt $INSTDIR $R8')
     // The installer-only guard keeps the cache variables out of the separately compiled
     // uninstaller, where file-scope declarations would be unused and fail makensis warnings.
     const initHook = include.match(/!macro customInit([\s\S]*?)!macroend/)?.[1] ?? ''

--- a/build/packaging.test.ts
+++ b/build/packaging.test.ts
@@ -106,6 +106,106 @@ describe('NSIS installer include (build/installer.nsh)', () => {
     expect(include).toContain('_?=${DIR}')
   })
 
+  it('runs the retry with TEMP and TMP on the old installation volume', () => {
+    // electron-builder's updated uninstall atomically moves the old installation into the
+    // uninstaller's $PLUGINSDIR. A custom D: install with the ordinary C: TEMP turns that into a
+    // cross-volume move/copy — including a nested OpenScience data root — and can abort with exit
+    // code 2. The recovery attempt must give the child uninstaller a same-volume plugin directory,
+    // then restore this installer's environment after ExecWait returns.
+    const recovery =
+      include.match(/!macro uninstallFailureRecoveryAt DIR([\s\S]*?)!macroend/)?.[1] ?? ''
+    const retryAt = recovery.indexOf('ExecWait')
+
+    expect(recovery).toContain('GetFullPathName $R2 "${DIR}\\.."')
+    expect(recovery).toContain('GetTempFileName $R5 "$R2"')
+    expect(recovery).toMatch(/SetEnvironmentVariable\(t, t\)i \("TEMP", "\$R5"\)/)
+    expect(recovery).toMatch(/SetEnvironmentVariable\(t, t\)i \("TMP", "\$R5"\)/)
+    expect(recovery.indexOf('("TEMP", "$R5")')).toBeLessThan(retryAt)
+    expect(recovery.indexOf('("TMP", "$R5")')).toBeLessThan(retryAt)
+    expect(recovery.lastIndexOf('("TEMP", "$R3")')).toBeGreaterThan(retryAt)
+    expect(recovery.lastIndexOf('("TMP", "$R4")')).toBeGreaterThan(retryAt)
+  })
+
+  it('preserves a nested OpenScience data root around the uninstall retry', () => {
+    // The reporter's configured data root is <install dir>\OpenScience. An updated NSIS
+    // uninstaller moves every child of the install directory into its disposable $PLUGINSDIR, so
+    // a successful retry must first move that data root to a separate sibling and restore it
+    // before the new installer continues.
+    const recovery =
+      include.match(/!macro uninstallFailureRecoveryAt DIR([\s\S]*?)!macroend/)?.[1] ?? ''
+    const preserveAt = recovery.indexOf('Rename "${DIR}\\OpenScience" "$R7"')
+    const retryAt = recovery.indexOf('ExecWait')
+    const restoreAt = recovery.indexOf('Rename "$R7" "${DIR}\\OpenScience"')
+    const preserveErrorAt = recovery.indexOf('Could not safely preserve')
+    const preserveQuitAt = recovery.indexOf('Quit', preserveErrorAt)
+    const restoreErrorAt = recovery.indexOf('The preserved data remains at: $R7')
+    const restoreQuitAt = recovery.indexOf('Quit', restoreErrorAt)
+    const retryResultAt = recovery.indexOf('${if} $R0 != 0', retryAt)
+    const clearPreservedPathAt = recovery.indexOf('StrCpy $R7 ""', restoreAt)
+
+    expect(preserveAt).toBeGreaterThan(-1)
+    expect(preserveAt).toBeLessThan(retryAt)
+    expect(preserveErrorAt).toBeLessThan(preserveQuitAt)
+    expect(preserveQuitAt).toBeLessThan(retryAt)
+    expect(restoreAt).toBeGreaterThan(retryAt)
+    expect(restoreAt).toBeLessThan(retryResultAt)
+    expect(restoreErrorAt).toBeLessThan(restoreQuitAt)
+    expect(restoreQuitAt).toBeLessThan(retryResultAt)
+    expect(clearPreservedPathAt).toBeGreaterThan(restoreQuitAt)
+  })
+
+  it('protects registered nested data roots before the first old-uninstaller attempt', () => {
+    // Recovery-only protection is too late: the first old uninstaller can succeed after moving
+    // <install>\OpenScience into its disposable $PLUGINSDIR. customInit runs before the install
+    // section, so it must move registered data roots out first; each post-uninstall hook restores
+    // its root even when the first attempt returns zero.
+    const init = include.match(/!macro customInit([\s\S]*?)!macroend/)?.[1] ?? ''
+    const shellCheck = include.match(/!macro customUnInstallCheck([\s\S]*?)!macroend/)?.[1] ?? ''
+    const userCheck =
+      include.match(/!macro customUnInstallCheckCurrentUser([\s\S]*?)!macroend/)?.[1] ?? ''
+
+    expect(init).toContain('ReadRegStr $perMachineInstallDirCache HKEY_LOCAL_MACHINE')
+    expect(init).toContain('ReadRegStr $perUserInstallDirCache HKEY_CURRENT_USER')
+    expect(init).not.toContain('ReadRegStr $shellInstallDirCache SHELL_CONTEXT')
+    expect(init.match(/!insertmacro preserveNestedDataRoot/g) ?? []).toHaveLength(2)
+    expect(init).toContain(
+      '!insertmacro preserveNestedDataRoot $perMachineInstallDirCache $perMachineDataBackup machine'
+    )
+    expect(init).toContain(
+      '!insertmacro preserveNestedDataRoot $perUserInstallDirCache $perUserDataBackup per-user'
+    )
+    expect(shellCheck.indexOf('!insertmacro restoreNestedDataRoot')).toBeGreaterThan(-1)
+    expect(shellCheck.indexOf('!insertmacro restoreNestedDataRoot')).toBeLessThan(
+      shellCheck.indexOf('${if} $R0 != 0')
+    )
+    expect(userCheck.indexOf('!insertmacro restoreNestedDataRoot')).toBeGreaterThan(-1)
+    expect(userCheck.indexOf('!insertmacro restoreNestedDataRoot')).toBeLessThan(
+      userCheck.indexOf('${if} $R0 != 0')
+    )
+    expect(include).toContain('!define MUI_CUSTOMFUNCTION_ABORT restorePreservedOnAbort')
+    expect(include).toContain('Function restorePreservedOnAbort')
+    expect(include).toContain('Function .onInstFailed')
+    expect(include).toContain('Function .onGUIEnd')
+  })
+
+  it('accepts a non-zero retry after the old executable was removed', () => {
+    // The old assisted uninstaller can finish removing the application and still leak exit code 2.
+    // Recovery already recognizes that result before retrying; it must make the same filesystem
+    // check after the retry instead of showing a fatal dialog for a completed uninstall.
+    const recovery =
+      include.match(/!macro uninstallFailureRecoveryAt DIR([\s\S]*?)!macroend/)?.[1] ?? ''
+    const afterRetry = recovery.slice(recovery.indexOf('ExecWait'))
+    const removedCheck = '${FileExists} "${DIR}' + '\\' + '${APP_EXECUTABLE_FILENAME}"'
+
+    expect(
+      recovery.match(/\$\{FileExists\} "\$\{DIR\}\\\$\{APP_EXECUTABLE_FILENAME\}"/g) ?? []
+    ).toHaveLength(2)
+    expect(afterRetry.indexOf(removedCheck)).toBeGreaterThan(afterRetry.indexOf('${if} $R0 != 0'))
+    expect(afterRetry.indexOf(removedCheck)).toBeLessThan(
+      afterRetry.indexOf('MessageBox MB_OK|MB_ICONEXCLAMATION "$(uninstallFailed): $R0"')
+    )
+  })
+
   it('passes the install dir to PowerShell as an argument, with a directory-boundary match', () => {
     // Custom install dirs may contain apostrophes: interpolating the path into the script source
     // would break the command (or worse, inject into it). The dir goes in as $args[0] and the
@@ -124,11 +224,14 @@ describe('NSIS installer include (build/installer.nsh)', () => {
     expect(include).toMatch(/\$\{if\} \$perUserInstallDirCache == ""/)
     expect(include).toContain('!insertmacro uninstallFailureRecoveryAt $perUserInstallDirCache')
     expect(include).toContain('!insertmacro uninstallFailureRecoveryAt $INSTDIR')
-    // The cache is declared inside customInit itself: a file-scope Var would be declared-but-
-    // unused in the uninstaller build, which makensis fails as a warning.
+    // The installer-only guard keeps the cache variables out of the separately compiled
+    // uninstaller, where file-scope declarations would be unused and fail makensis warnings.
     const initHook = include.match(/!macro customInit([\s\S]*?)!macroend/)?.[1] ?? ''
-    expect(initHook).toMatch(
-      /Var \/GLOBAL perUserInstallDirCache[\s\S]*ReadRegStr \$perUserInstallDirCache HKEY_CURRENT_USER "\$\{INSTALL_REGISTRY_KEY\}" InstallLocation/
+    expect(include).toMatch(
+      /!ifndef BUILD_UNINSTALLER[\s\S]*Var perUserInstallDirCache[\s\S]*!macro customInit/
+    )
+    expect(initHook).toContain(
+      'ReadRegStr $perUserInstallDirCache HKEY_CURRENT_USER "${INSTALL_REGISTRY_KEY}" InstallLocation'
     )
     // The hook itself must not re-read the registry after the pass — that pins the broken order.
     // (Comments may name the value while explaining; strip them before checking.)
@@ -177,14 +280,16 @@ describe('NSIS installer include (build/installer.nsh)', () => {
   })
 
   it('the installed electron-builder still inserts customInit before the uninstall passes', () => {
-    // The per-user install-dir cache only ever runs if installer.nsi keeps inserting customInit
-    // in .onInit. Losing that insertion point leaves the HKCU hook with an always-empty cache —
-    // the exact fatal-path regression the cache fixed — while every source-text test stays green.
+    // The install-dir cache and data preservation only run if installer.nsi keeps inserting
+    // customInit in .onInit, before the install section invokes either old uninstaller.
     const installerNsi = readFileSync(
       join(appBuilderLibRoot, 'templates/nsis/installer.nsi'),
       'utf8'
     )
     expect(installerNsi).toContain('!ifmacrodef customInit')
     expect(installerNsi).toContain('!insertmacro customInit')
+    expect(installerNsi.indexOf('!insertmacro customInit')).toBeLessThan(
+      installerNsi.indexOf('Section "install"')
+    )
   })
 })

--- a/build/packaging.test.ts
+++ b/build/packaging.test.ts
@@ -160,6 +160,8 @@ describe('NSIS installer include (build/installer.nsh)', () => {
     // section, so it must move registered data roots out first; each post-uninstall hook restores
     // its root even when the first attempt returns zero.
     const init = include.match(/!macro customInit([\s\S]*?)!macroend/)?.[1] ?? ''
+    const machineProtection =
+      include.match(/!macro protectMachineDataRootForSelectedMode([\s\S]*?)!macroend/)?.[1] ?? ''
     const shellCheck = include.match(/!macro customUnInstallCheck([\s\S]*?)!macroend/)?.[1] ?? ''
     const userCheck =
       include.match(/!macro customUnInstallCheckCurrentUser([\s\S]*?)!macroend/)?.[1] ?? ''
@@ -167,8 +169,8 @@ describe('NSIS installer include (build/installer.nsh)', () => {
     expect(init).toContain('ReadRegStr $perMachineInstallDirCache HKEY_LOCAL_MACHINE')
     expect(init).toContain('ReadRegStr $perUserInstallDirCache HKEY_CURRENT_USER')
     expect(init).not.toContain('ReadRegStr $shellInstallDirCache SHELL_CONTEXT')
-    expect(init.match(/!insertmacro preserveNestedDataRoot/g) ?? []).toHaveLength(2)
-    expect(init).toContain(
+    expect(init.match(/!insertmacro preserveNestedDataRoot/g) ?? []).toHaveLength(1)
+    expect(machineProtection).toContain(
       '!insertmacro preserveNestedDataRoot $perMachineInstallDirCache $perMachineDataBackup machine'
     )
     expect(init).toContain(
@@ -189,6 +191,39 @@ describe('NSIS installer include (build/installer.nsh)', () => {
     // race the inner installer's later HKCU uninstall pass; interrupted backups are deterministic
     // and are adopted by the next installer instead.
     expect(include).not.toContain('Function .onGUIEnd')
+  })
+
+  it('waits for the final all-users mode before touching a distinct machine data root', () => {
+    // customInit runs before an elevated assisted user makes the final install-mode choice. A
+    // current-user install must not fail because an unrelated HKLM data folder is busy. Keep the
+    // silent path protected in customInit, but otherwise chain protection into the instfiles-page
+    // preflight, after the mode page has committed the final selection and before the section runs.
+    const init = include.match(/!macro customInit([\s\S]*?)!macroend/)?.[1] ?? ''
+    const machineProtection =
+      include.match(/!macro protectMachineDataRootForSelectedMode([\s\S]*?)!macroend/)?.[1] ?? ''
+    const pageHook = include.match(/!macro customPageAfterChangeDir([\s\S]*?)!macroend/)?.[1] ?? ''
+    const header = include.match(/!macro customHeader([\s\S]*?)!macroend/)?.[1] ?? ''
+    const selectedModeAt = machineProtection.indexOf('$installMode == "all"')
+    const preserveMachineAt = machineProtection.indexOf(
+      '!insertmacro preserveNestedDataRoot $perMachineInstallDirCache $perMachineDataBackup machine'
+    )
+
+    expect(init).not.toContain(
+      '!insertmacro preserveNestedDataRoot $perMachineInstallDirCache $perMachineDataBackup machine'
+    )
+    expect(init).toMatch(
+      /\$\{if\} \$\{Silent\}[\s\S]*!insertmacro protectMachineDataRootForSelectedMode/
+    )
+    expect(selectedModeAt).toBeGreaterThan(-1)
+    expect(selectedModeAt).toBeLessThan(preserveMachineAt)
+    expect(pageHook).toContain(
+      '!define openScienceOriginalInstFilesPre ${MUI_PAGE_CUSTOMFUNCTION_PRE}'
+    )
+    expect(pageHook).toContain(
+      '!define MUI_PAGE_CUSTOMFUNCTION_PRE protectNestedDataRootsForInstall'
+    )
+    expect(header).toContain('Call ${openScienceOriginalInstFilesPre}')
+    expect(header).toContain('!insertmacro protectMachineDataRootForSelectedMode')
   })
 
   it('defers a shared machine-owned data root to the elevated inner installer', () => {

--- a/build/packaging.test.ts
+++ b/build/packaging.test.ts
@@ -188,6 +188,23 @@ describe('NSIS installer include (build/installer.nsh)', () => {
     expect(include).toContain('Function .onGUIEnd')
   })
 
+  it('defers a shared machine-owned data root to the elevated inner installer', () => {
+    // With matching HKCU/HKLM registrations, an unelevated assisted outer process may not be
+    // allowed to rename a Program Files child. Probe the sibling directory non-destructively and
+    // defer to the elevated inner .onInit when it is not writable, instead of aborting before UAC.
+    const init = include.match(/!macro customInit([\s\S]*?)!macroend/)?.[1] ?? ''
+    const probeAt = init.indexOf('GetTempFileName $R9 "$R2"')
+    const preserveAt = init.indexOf(
+      '!insertmacro preserveNestedDataRoot $perUserInstallDirCache $perUserDataBackup per-user'
+    )
+
+    expect(init).toContain('${andIfNot} ${UAC_IsAdmin}')
+    expect(init).toContain('$perMachineInstallDirCache == $perUserInstallDirCache')
+    expect(probeAt).toBeGreaterThan(-1)
+    expect(probeAt).toBeLessThan(preserveAt)
+    expect(init).toContain('Deferring shared data-folder protection to the elevated installer.')
+  })
+
   it('accepts a non-zero retry after the old executable was removed', () => {
     // The old assisted uninstaller can finish removing the application and still leak exit code 2.
     // Recovery already recognizes that result before retrying; it must make the same filesystem

--- a/build/packaging.test.ts
+++ b/build/packaging.test.ts
@@ -185,7 +185,10 @@ describe('NSIS installer include (build/installer.nsh)', () => {
     expect(include).toContain('!define MUI_CUSTOMFUNCTION_ABORT restorePreservedOnAbort')
     expect(include).toContain('Function restorePreservedOnAbort')
     expect(include).toContain('Function .onInstFailed')
-    expect(include).toContain('Function .onGUIEnd')
+    // Normal GUI shutdown includes the unelevated -> elevated UAC handoff. Restoring there would
+    // race the inner installer's later HKCU uninstall pass; interrupted backups are deterministic
+    // and are adopted by the next installer instead.
+    expect(include).not.toContain('Function .onGUIEnd')
   })
 
   it('defers a shared machine-owned data root to the elevated inner installer', () => {

--- a/build/packaging.test.ts
+++ b/build/packaging.test.ts
@@ -208,6 +208,32 @@ describe('NSIS installer include (build/installer.nsh)', () => {
     expect(init).toContain('Deferring shared data-folder protection to the elevated installer.')
   })
 
+  it('normalizes registered Windows paths before testing whether they share a directory', () => {
+    // NSIS string equality is already case-insensitive, but registry values for the same Windows
+    // directory may differ by harmless trailing separators. Normalize both cached locations in
+    // place before any shared-path branch so the UAC probe, backup aliasing, and handoff restore
+    // all make the same decision.
+    const normalizer =
+      include.match(/Function normalizeRegisteredInstallPath([\s\S]*?)FunctionEnd/)?.[1] ?? ''
+    const init = include.match(/!macro customInit([\s\S]*?)!macroend/)?.[1] ?? ''
+    const normalizeMachineAt = init.indexOf(
+      'Push $perMachineInstallDirCache\n  Call normalizeRegisteredInstallPath'
+    )
+    const normalizeUserAt = init.indexOf(
+      'Push $perUserInstallDirCache\n  Call normalizeRegisteredInstallPath'
+    )
+    const firstSharedPathCheckAt = init.indexOf(
+      '$perMachineInstallDirCache == $perUserInstallDirCache'
+    )
+
+    expect(normalizer).toContain('StrCmp $R1 "\\"')
+    expect(normalizer).toContain('StrCmp $R1 "/"')
+    expect(normalizeMachineAt).toBeGreaterThan(-1)
+    expect(normalizeUserAt).toBeGreaterThan(-1)
+    expect(normalizeMachineAt).toBeLessThan(firstSharedPathCheckAt)
+    expect(normalizeUserAt).toBeLessThan(firstSharedPathCheckAt)
+  })
+
   it('accepts a non-zero retry after the old executable was removed', () => {
     // The old assisted uninstaller can finish removing the application and still leak exit code 2.
     // Recovery already recognizes that result before retrying; it must make the same filesystem

--- a/src/main/find-overlay.test.ts
+++ b/src/main/find-overlay.test.ts
@@ -1,3 +1,5 @@
+import { EventEmitter } from 'node:events'
+
 import { describe, expect, it, vi, type Mock } from 'vitest'
 
 import {
@@ -248,5 +250,23 @@ describe('find overlay manager', () => {
     resizeListener!()
 
     expect(view.setBounds).toHaveBeenCalledWith(computeOverlayBounds(1400))
+  })
+
+  it('removes its resize listener when the main window is destroyed', () => {
+    const mainWindow = Object.assign(new EventEmitter(), {
+      contentView: { addChildView: vi.fn() },
+      getContentBounds: () => ({ width: 1000, height: 800 }),
+      webContents: { focus: vi.fn(), stopFindInPage: vi.fn() }
+    })
+    const manager = createFindOverlayManager({
+      mainWindow,
+      createView: vi.fn(),
+      preloadPath: PRELOAD_PATH,
+      overlayHtmlPath: HTML_PATH
+    })
+
+    expect(mainWindow.listenerCount('resize')).toBe(1)
+    expect(() => manager.destroy()).not.toThrow()
+    expect(mainWindow.listenerCount('resize')).toBe(0)
   })
 })

--- a/src/main/find-overlay.ts
+++ b/src/main/find-overlay.ts
@@ -171,7 +171,11 @@ export const createFindOverlayManager = (deps: FindOverlayDeps): FindOverlayMana
     },
 
     destroy: () => {
-      ;(deps.mainWindow.removeListener ?? deps.mainWindow.off)?.('resize', onResize)
+      if (deps.mainWindow.removeListener) {
+        deps.mainWindow.removeListener('resize', onResize)
+      } else {
+        deps.mainWindow.off?.('resize', onResize)
+      }
       view?.destroy?.()
       view = null
       loadPromise = null


### PR DESCRIPTION
## Problem

Windows in-place upgrades can stop at `Failed to uninstall old application files...: 2`. The attached log also records a shutdown-time `EventEmitter.removeListener` receiver error. On custom-drive installs, electron-builder's updated uninstaller can move the old tree across volumes through `%TEMP%`; the reported configuration additionally stores `OpenScience` data inside the installation tree, so that directory must be protected before any old-uninstaller attempt.

Closes #512.

## Proposed change

- Call `BrowserWindow.removeListener` / `off` with the window as their receiver during find-overlay teardown.
- Protect a nested `<install>\OpenScience` data root in a deterministic same-volume sibling before the first old-uninstaller pass, then restore it on success, failure, cancellation, GUI shutdown, and elevated inner-installer flows.
- On a real uninstall failure, stop install-directory processes and retry once with child `TEMP`/`TMP` on the installation volume.
- Treat a non-zero old-uninstaller result as completed only when the old executable is already gone, including after the retry.
- Add EventEmitter regression coverage and source-contract coverage for the NSIS hook order, data preservation, environment restoration, and electron-builder insertion points.

## Scope and non-goals

This changes Windows NSIS upgrade recovery and the find-overlay shutdown path only. It does not alter update rollout, version selection, application data-root configuration, or manual uninstall behavior.

A physical Windows custom-drive upgrade was not available in this environment. The NSIS include was compiled successfully into a minimal x64 Windows installer with electron-builder 26.15.3, but a real `D:`-drive upgrade remains the main manual/CI validation target.

## Acceptance criteria and validation

- Destroying the overlay against a real `EventEmitter` no longer throws and removes the resize listener.
- Registered nested data roots are moved outside the install tree before the first old uninstaller and restored on every covered exit path.
- Recovery uses same-volume `TEMP`/`TMP`, restores the parent installer's environment, retries exactly once, and rechecks the executable sentinel.
- `npx vitest run src/main/find-overlay.test.ts build/packaging.test.ts`: 36 passed.
- `npm run typecheck`: passed.
- `npm run lint`: passed with 24 pre-existing warnings and 0 errors.
- `npm test`: 546 files passed, 8,163 tests passed, 139 skipped.
- Minimal `electron-builder --win nsis --x64` compile: passed.

## Review focus

Please focus on the NSIS preserve/restore behavior across assisted elevation and the two registry uninstall passes, plus restoration of `TEMP`/`TMP` after the retry. The remaining validation risk is runtime behavior on a physical Windows machine with the application and data root on a non-system drive.
