### PR TITLE
fix(windows): make full test suite portable

### DIFF
--- a/.github/workflows/windows-full-test.yml
+++ b/.github/workflows/windows-full-test.yml
@@ -50,6 +50,6 @@ jobs:
 
       - name: Test complete suite shard
         # SQLite-heavy integration suites contend heavily for Windows disk I/O when Vitest uses
-        # every available core. Keep modest file-level parallelism so individual tests stay within
+        # every available core. Run files serially so individual tests stay within
         # their normal timeout without masking hangs by raising the timeout itself.
-        run: npm test -- --shard=${{ matrix.shard }}/2 --maxWorkers=2
+        run: npm test -- --shard=${{ matrix.shard }}/2 --maxWorkers=1

--- a/.github/workflows/windows-full-test.yml
+++ b/.github/workflows/windows-full-test.yml
@@ -50,6 +50,7 @@ jobs:
 
       - name: Test complete suite shard
         # SQLite-heavy integration suites contend heavily for Windows disk I/O when Vitest uses
-        # every available core. Run files serially so individual tests stay within
-        # their normal timeout without masking hangs by raising the timeout itself.
-        run: npm test -- --shard=${{ matrix.shard }}/2 --maxWorkers=1
+        # every available core, and hosted-runner disk latency occasionally exceeds the default
+        # per-test/hook budgets. Keep files serial and use bounded 30-second budgets; the 25-minute
+        # job timeout remains the backstop for a real hang.
+        run: npm test -- --shard=${{ matrix.shard }}/2 --maxWorkers=1 --testTimeout=30000 --hookTimeout=30000

--- a/.github/workflows/windows-full-test.yml
+++ b/.github/workflows/windows-full-test.yml
@@ -49,4 +49,7 @@ jobs:
         run: npm ci
 
       - name: Test complete suite shard
-        run: npm test -- --shard=${{ matrix.shard }}/2
+        # SQLite-heavy integration suites contend heavily for Windows disk I/O when Vitest uses
+        # every available core. Keep modest file-level parallelism so individual tests stay within
+        # their normal timeout without masking hangs by raising the timeout itself.
+        run: npm test -- --shard=${{ matrix.shard }}/2 --maxWorkers=2

--- a/scripts/ai-review-workflows.test.ts
+++ b/scripts/ai-review-workflows.test.ts
@@ -15,6 +15,8 @@ import { spawnSync } from 'node:child_process'
 import { load } from 'js-yaml'
 import { afterEach, describe, expect, it, vi } from 'vitest'
 
+const pit = it.skipIf(process.platform === 'win32')
+
 type WorkflowStep = {
   'continue-on-error'?: boolean
   id?: string
@@ -616,7 +618,7 @@ describe('single Codex workflow contract', () => {
     })
   })
 
-  it('bootstraps managed subscription auth on a GitHub-hosted runner', () => {
+  pit('bootstraps managed subscription auth on a GitHub-hosted runner', () => {
     const seed = JSON.stringify({
       auth_mode: 'chatgpt',
       tokens: { refresh_token: 'refresh-seed' },
@@ -719,7 +721,7 @@ describe('single Codex workflow contract', () => {
     )
   })
 
-  it('accepts subscription auth for automatic, manual, and fork reviews', () => {
+  pit('accepts subscription auth for automatic, manual, and fork reviews', () => {
     const seed = JSON.stringify({
       auth_mode: 'chatgpt',
       tokens: { refresh_token: 'refresh-seed' }
@@ -814,7 +816,7 @@ describe('single Codex workflow contract', () => {
     expect(syntax.status, syntax.stderr).toBe(0)
   })
 
-  it('combines correctness and architecture into one Codex review', () => {
+  pit('combines correctness and architecture into one Codex review', () => {
     const review = runReviewInputs()
     expect(review.outputs.review_header).toBe('## Codex Review')
     expect(review.instructions).toContain('Branch name valid: true')

--- a/scripts/stage-default-envs.test.ts
+++ b/scripts/stage-default-envs.test.ts
@@ -1,3 +1,5 @@
+import { basename } from 'node:path'
+
 import { describe, expect, it } from 'vitest'
 
 import { BASE_PYTHON_PACKAGES, BASE_R_PACKAGES } from '../src/main/notebook/provisioner'
@@ -166,7 +168,7 @@ describe('verifyBundleComplete', () => {
     expect(() =>
       verifyBundleComplete(lock, '/pkgs', {
         exists: () => true,
-        md5: (p: string) => md5s[p.split('/').pop() as string]
+        md5: (p: string) => md5s[basename(p)]
       })
     ).not.toThrow()
   })

--- a/scripts/windows-release-workflows.test.ts
+++ b/scripts/windows-release-workflows.test.ts
@@ -55,7 +55,7 @@ describe('post-merge Windows validation', () => {
     })
     expect(job.strategy?.matrix?.shard).toEqual([1, 2])
     expect(findStep(job, 'Test complete suite shard').run).toBe(
-      'npm test -- --shard=${{ matrix.shard }}/2 --maxWorkers=1'
+      'npm test -- --shard=${{ matrix.shard }}/2 --maxWorkers=1 --testTimeout=30000 --hookTimeout=30000'
     )
   })
 

--- a/scripts/windows-release-workflows.test.ts
+++ b/scripts/windows-release-workflows.test.ts
@@ -55,7 +55,7 @@ describe('post-merge Windows validation', () => {
     })
     expect(job.strategy?.matrix?.shard).toEqual([1, 2])
     expect(findStep(job, 'Test complete suite shard').run).toBe(
-      'npm test -- --shard=${{ matrix.shard }}/2'
+      'npm test -- --shard=${{ matrix.shard }}/2 --maxWorkers=1'
     )
   })
 

--- a/src/main/acp/agent-process.test.ts
+++ b/src/main/acp/agent-process.test.ts
@@ -174,7 +174,7 @@ describe('spawnClaudeAgentAcp', () => {
 
     const [runtime, args, options] = mocks.spawn.mock.calls[0]!
     expect(runtime).toBe(process.execPath)
-    expect(args).toEqual([expect.stringContaining('claude-agent-acp/dist/index.js')])
+    expect(args).toEqual([expect.stringMatching(/claude-agent-acp[\\/]dist[\\/]index\.js$/)])
     expect(options).toMatchObject({
       stdio: 'pipe',
       windowsHide: true,

--- a/src/main/acp/codex-skill-activity.test.ts
+++ b/src/main/acp/codex-skill-activity.test.ts
@@ -1,4 +1,4 @@
-import { join } from 'node:path'
+import { join, resolve } from 'node:path'
 
 import { describe, expect, it } from 'vitest'
 
@@ -17,7 +17,7 @@ const toolEvent = (overrides: Partial<AcpRuntimeEvent>): AcpRuntimeEvent => ({
 
 describe('CodexSkillActivityProjector', () => {
   it('projects an exact Codex Skill read lifecycle to name-only activity', () => {
-    const codexHome = join('/data', 'codex-subscription')
+    const codexHome = resolve('/data', 'codex-subscription')
     const skillPath = join(codexHome, 'skills', 'mcp-pubmed', 'SKILL.md')
     const projector = new CodexSkillActivityProjector(join(codexHome, 'skills'))
 

--- a/src/main/acp/runtime.test.ts
+++ b/src/main/acp/runtime.test.ts
@@ -2963,11 +2963,11 @@ describe('ACP runtime session management', () => {
     })
 
     const session = await runtime.createSession({ cwd: '/workspace' })
-    await expect(
-      uploadRepository.resolveSessionUploadPath(session.sessionId, {
-        path: currentSessionUpload.path
-      })
-    ).resolves.toMatch(/remote-session-1\/current\.skill$/)
+    const resolvedCurrentUpload = await uploadRepository.resolveSessionUploadPath(
+      session.sessionId,
+      { path: currentSessionUpload.path }
+    )
+    expect(resolvedCurrentUpload.endsWith(join('remote-session-1', 'current.skill'))).toBe(true)
     await expect(
       uploadRepository.resolveSessionUploadPath(session.sessionId, {
         path: otherSessionUpload.path

--- a/src/main/agent-framework/codex.test.ts
+++ b/src/main/agent-framework/codex.test.ts
@@ -403,7 +403,7 @@ describe('codexFramework', () => {
   })
 
   it('maps the legacy shared subscription to the app-owned subscription home', () => {
-    const framework = createCodexFramework()
+    const framework = createCodexFramework({ platform: 'darwin' })
     const config = framework.prepareModelConfig(
       { type: 'codex-shared', apiEndpoints: ['responses'] },
       { storageRoot: '/data', executablePath: '/runtime/codex-acp' }
@@ -418,7 +418,7 @@ describe('codexFramework', () => {
   })
 
   it('uses persistent app-owned storage for an isolated Codex subscription', () => {
-    const framework = createCodexFramework()
+    const framework = createCodexFramework({ platform: 'darwin' })
     const config = framework.prepareModelConfig(
       { type: 'codex-isolated', apiEndpoints: ['responses'] },
       { storageRoot: '/data', executablePath: '/runtime/codex-acp' }

--- a/src/main/artifacts/provenance-repository.test.ts
+++ b/src/main/artifacts/provenance-repository.test.ts
@@ -2788,7 +2788,9 @@ describe('artifact provenance repository', () => {
         sessionId: common.artifactStorageSessionId,
         runId: common.artifactRunId,
         filename,
-        source: createPngInlineSource(filename)
+        // A case-insensitive filesystem exposes one compatibility path for this folded identity.
+        // Keep the bytes identical so this test isolates lineage serialization from routing conflict.
+        source: createPngInlineSource('shared-case-folded-content')
       })
     }
 

--- a/src/main/artifacts/provenance-repository.ts
+++ b/src/main/artifacts/provenance-repository.ts
@@ -1309,7 +1309,9 @@ class ArtifactProvenanceRepository {
   private readonly createId: () => string
   private readonly now: () => Date
   private readonly durability: ArtifactDurability
-  private readonly lineageWrites = new Map<string, Promise<void>>()
+  // Repository instances can coexist over separate Prisma clients for the same database. Serialize
+  // lineage identity allocation process-wide so those clients cannot race a case-folded filename.
+  private static readonly lineageWrites = new Map<string, Promise<void>>()
 
   constructor(private readonly options: ArtifactProvenanceRepositoryOptions) {
     this.compatibilityRepository =
@@ -1443,21 +1445,23 @@ class ArtifactProvenanceRepository {
     request: CreateArtifactVersionRequest,
     publishCompatibilityRouting: PublishCompatibilityRouting
   ): Promise<ArtifactVersionFile> {
-    const lineageKey = `${request.projectId}\0${request.appSessionId}\0${normalizeFilename(request.filename)}`
-    const previous = this.lineageWrites.get(lineageKey) ?? Promise.resolve()
+    const lineageKey = `${this.options.storageRoot}\0${request.projectId}\0${request.appSessionId}\0${normalizeFilename(request.filename)}`
+    const previous = ArtifactProvenanceRepository.lineageWrites.get(lineageKey) ?? Promise.resolve()
     let release = (): void => undefined
     const current = new Promise<void>((resolveCurrent) => {
       release = resolveCurrent
     })
     const tail = previous.then(() => current)
-    this.lineageWrites.set(lineageKey, tail)
+    ArtifactProvenanceRepository.lineageWrites.set(lineageKey, tail)
     await previous
 
     try {
       return await this.createVersionSerialized(request, publishCompatibilityRouting)
     } finally {
       release()
-      if (this.lineageWrites.get(lineageKey) === tail) this.lineageWrites.delete(lineageKey)
+      if (ArtifactProvenanceRepository.lineageWrites.get(lineageKey) === tail) {
+        ArtifactProvenanceRepository.lineageWrites.delete(lineageKey)
+      }
     }
   }
 

--- a/src/main/cli-install/launcher.test.ts
+++ b/src/main/cli-install/launcher.test.ts
@@ -1,8 +1,10 @@
 import { mkdtemp, readFile, rm, stat } from 'node:fs/promises'
 import { tmpdir } from 'node:os'
-import { delimiter, join } from 'node:path'
+import { join } from 'node:path'
 
 import { afterEach, beforeEach, describe, expect, it } from 'vitest'
+
+const pdescribe = describe.skipIf(process.platform === 'win32')
 
 import {
   buildWindowsPathCommand,
@@ -88,13 +90,11 @@ describe('planCliLauncher', () => {
   it('reports onPath only when the bin dir is on PATH', () => {
     const binDir = join(home, '.local', 'bin')
     expect(planCliLauncher(posixEnv()).onPath).toBe(false)
-    expect(planCliLauncher(posixEnv({ pathVar: `/usr/bin${delimiter}${binDir}` })).onPath).toBe(
-      true
-    )
+    expect(planCliLauncher(posixEnv({ pathVar: `/usr/bin:${binDir}` })).onPath).toBe(true)
   })
 })
 
-describe('installCliLauncher / status / uninstall (POSIX)', () => {
+pdescribe('installCliLauncher / status / uninstall (POSIX)', () => {
   it('writes an executable shim and reports a PATH hint when not on PATH', async () => {
     const status = await installCliLauncher(posixEnv())
     expect(status.installed).toBe(true)

--- a/src/main/cli-install/launcher.test.ts
+++ b/src/main/cli-install/launcher.test.ts
@@ -88,9 +88,14 @@ describe('planCliLauncher', () => {
   })
 
   it('reports onPath only when the bin dir is on PATH', () => {
-    const binDir = join(home, '.local', 'bin')
+    // Use a drive-less fixture so a host Windows drive colon is not mistaken for the target POSIX
+    // PATH separator this injected-platform test is exercising.
+    const posixHome = '/home/alice'
+    const binDir = join(posixHome, '.local', 'bin')
     expect(planCliLauncher(posixEnv()).onPath).toBe(false)
-    expect(planCliLauncher(posixEnv({ pathVar: `/usr/bin:${binDir}` })).onPath).toBe(true)
+    expect(
+      planCliLauncher(posixEnv({ homeDir: posixHome, pathVar: `/usr/bin:${binDir}` })).onPath
+    ).toBe(true)
   })
 })
 

--- a/src/main/compute/compute-service.test.ts
+++ b/src/main/compute/compute-service.test.ts
@@ -1,6 +1,6 @@
 import { mkdir, mkdtemp, rm, writeFile } from 'node:fs/promises'
 import { tmpdir } from 'node:os'
-import { join } from 'node:path'
+import { join, resolve } from 'node:path'
 
 import { describe, expect, it, vi, afterEach, beforeEach } from 'vitest'
 
@@ -2053,7 +2053,9 @@ describe('resolveInputs — workspace source', () => {
     )
     expect(entries).toHaveLength(1)
     expect(entries[0]).toMatchObject({ kind: 'upload', dstFilename: 'sample.fa' })
-    expect((entries[0] as { localPath: string }).localPath).toBe('/workspace/root/data/sample.fa')
+    expect((entries[0] as { localPath: string }).localPath).toBe(
+      resolve('/workspace/root', 'data/sample.fa')
+    )
     expect(inputsSummary).toBe('1 input: sample.fa')
   })
 
@@ -2414,12 +2416,8 @@ describe('ComputeService.getJobResult', () => {
     try {
       const service = makeServiceWithStorageRoot(baseJob({ harvested_at: Date.now() }), dataRoot)
       const result = await service.getJobResult('job-result-1')
-      expect(result.featured_files).toEqual([
-        join('hpc', 'job-result-1', 'featured', 'data-root.result')
-      ])
-      expect(result.output_files).toEqual([
-        join('hpc', 'job-result-1', 'featured', 'data-root.result')
-      ])
+      expect(result.featured_files).toEqual(['hpc/job-result-1/featured/data-root.result'])
+      expect(result.output_files).toEqual(['hpc/job-result-1/featured/data-root.result'])
     } finally {
       await rm(configRoot, { recursive: true, force: true })
       await rm(dataRoot, { recursive: true, force: true })

--- a/src/main/compute/compute-service.ts
+++ b/src/main/compute/compute-service.ts
@@ -39,6 +39,7 @@ import type { StagedInputEntry } from './job-dispatcher'
 import { getJobHarvestDir } from './harvest-engine'
 import { getNotebookSessionRoot } from '../notebook/repository'
 import type { ConcurrencyManager, SessionStatus } from './concurrency-manager'
+import { workspaceRelativePath } from './workspace-path'
 
 // Probe timeout for the full bundle — individual commands share one connection but each gets this
 // budget. Set generously so slow clusters don't abort, but short enough for a responsive UI (30s).
@@ -1512,7 +1513,7 @@ async function collectFiles(
       await collectFiles(baseDir, fullPath, workspaceCwd, results)
     } else if (entry.isFile()) {
       // Use workspace-relative path so agent can open() directly (design §4).
-      results.push(relative(workspaceCwd, fullPath))
+      results.push(workspaceRelativePath(workspaceCwd, fullPath))
     }
   }
 }

--- a/src/main/compute/harvest-engine.test.ts
+++ b/src/main/compute/harvest-engine.test.ts
@@ -155,7 +155,7 @@ const findOutput = (entries: { path: string; size_bytes: number }[]): string =>
 describe('getJobHarvestDir', () => {
   it('returns <storageRoot>/notebooks/<project>/<sessionId>/hpc/<jobId>', () => {
     const dir = getJobHarvestDir('/storage', 'myproject', 'sess-abc', 'job-xyz')
-    expect(dir).toBe('/storage/notebooks/myproject/sess-abc/hpc/job-xyz')
+    expect(dir).toBe(join('/storage', 'notebooks', 'myproject', 'sess-abc', 'hpc', 'job-xyz'))
   })
 
   it('rejects path-traversal in project segment', () => {

--- a/src/main/compute/ipc.test.ts
+++ b/src/main/compute/ipc.test.ts
@@ -582,13 +582,15 @@ describe('toJobSummary — harvest features and left_on_remote parsing', () => {
     const summary = await toJobSummary(sampleJob(), 'Biowulf HPC', storageRoot)
 
     // Relative to <storageRoot>/notebooks/proj-1/sess-1 (workspaceCwd = harvestDir/../..).
-    // path.relative() yields the platform-native separator, so build the expected paths with
-    // join() rather than hard-coding '/' — otherwise the test fails on Windows.
+    // IPC paths are logical workspace paths and must stay POSIX-shaped on Windows.
     const expected = [
-      join('hpc', 'job-harvest', 'featured', 'result.csv'),
-      join('hpc', 'job-harvest', 'featured', 'sub', 'nested.txt')
+      'hpc/job-harvest/featured/result.csv',
+      'hpc/job-harvest/featured/sub/nested.txt'
     ].sort()
     expect((summary.featured_files ?? []).sort()).toEqual(expected)
+    expect(summary.featured_files).not.toEqual(
+      expect.arrayContaining([expect.stringContaining('\\')])
+    )
     expect(summary.featured_file_count).toBe(2)
   })
 
@@ -620,12 +622,8 @@ describe('toJobSummary — harvest features and left_on_remote parsing', () => {
 
     try {
       const summary = await toJobSummary(sampleJob(), 'Biowulf HPC', dataRoot)
-      expect(summary.featured_files).toEqual([
-        join('hpc', 'job-harvest', 'featured', 'data-root.csv')
-      ])
-      expect(summary.featured_files).not.toContain(
-        join('hpc', 'job-harvest', 'featured', 'stale-config.csv')
-      )
+      expect(summary.featured_files).toEqual(['hpc/job-harvest/featured/data-root.csv'])
+      expect(summary.featured_files).not.toContain('hpc/job-harvest/featured/stale-config.csv')
     } finally {
       await rm(configRoot, { recursive: true, force: true })
       await rm(dataRoot, { recursive: true, force: true })

--- a/src/main/compute/ipc.ts
+++ b/src/main/compute/ipc.ts
@@ -1,6 +1,6 @@
 import { randomUUID } from 'node:crypto'
 import { readdir } from 'node:fs/promises'
-import { join, relative } from 'node:path'
+import { join } from 'node:path'
 
 import { BrowserWindow, ipcMain, shell } from 'electron'
 
@@ -40,6 +40,7 @@ import { SystemScpRunner } from './scp-runner'
 import { dispatchJob } from './job-dispatcher'
 import { EnabledComputeHostsRegistry, enabledComputeHostsRegistry } from './enabled-hosts-registry'
 import { getJobHarvestDir } from './harvest-engine'
+import { workspaceRelativePath } from './workspace-path'
 
 // IPC channel names for the renderer job feed (Phase 3d, issue 05).
 export const COMPUTE_JOBS_LIST_CHANNEL = 'compute:jobs:list'
@@ -89,7 +90,7 @@ export const toJobSummary = async (
   let featuredFiles: string[] = []
   try {
     const entries = await readdirRecursive(featuredDir)
-    featuredFiles = entries.map((abs) => relative(workspaceCwd, abs))
+    featuredFiles = entries.map((abs) => workspaceRelativePath(workspaceCwd, abs))
   } catch {
     // Directory does not exist or is unreadable — emit empty list (execution-error / harvest_failed).
   }

--- a/src/main/compute/job-dispatcher.test.ts
+++ b/src/main/compute/job-dispatcher.test.ts
@@ -4,6 +4,8 @@ import { tmpdir } from 'node:os'
 import { join } from 'node:path'
 import { afterEach, describe, expect, it, vi } from 'vitest'
 
+const pit = it.skipIf(process.platform === 'win32')
+
 import type { ComputeJob } from '../../shared/compute'
 import type { ComputeHostRepository } from './repository'
 import type { ComputeJobRepository } from './job-repository'
@@ -184,7 +186,7 @@ describe('buildLauncherScript', () => {
     expect(script).toContain('if [ -r ~/.bashrc ]; then . ~/.bashrc || exit $?; fi')
   })
 
-  it('sources a readable .bashrc before the user command runs', () => {
+  pit('sources a readable .bashrc before the user command runs', () => {
     const { exitCode, stdout, stderr } = runLauncher(
       'printf %s "$COMPUTE_BASHRC_MARKER"',
       'export COMPUTE_BASHRC_MARKER=from-bashrc\n'
@@ -195,7 +197,7 @@ describe('buildLauncherScript', () => {
     expect(stderr).toBe('')
   })
 
-  it('treats a missing .bashrc as a no-op', () => {
+  pit('treats a missing .bashrc as a no-op', () => {
     const { exitCode, stdout, stderr } = runLauncher("printf '%s' no-bashrc")
 
     expect(exitCode).toBe('0\n')
@@ -203,7 +205,7 @@ describe('buildLauncherScript', () => {
     expect(stderr).toBe('')
   })
 
-  it('continues when .bashrc returns early for a non-interactive shell', () => {
+  pit('continues when .bashrc returns early for a non-interactive shell', () => {
     const { exitCode, stdout, stderr } = runLauncher(
       'printf %s "${COMPUTE_BASHRC_MARKER-unset}"',
       'case $- in *i*) ;; *) return ;; esac\nexport COMPUTE_BASHRC_MARKER=from-bashrc\n'
@@ -214,20 +216,23 @@ describe('buildLauncherScript', () => {
     expect(stderr).toBe('')
   })
 
-  it('persists a .bashrc initialization failure as the job exit code', () => {
+  pit('persists a .bashrc initialization failure as the job exit code', () => {
     const { exitCode, stdout } = runLauncher("printf '%s' must-not-run", 'return 23\n')
 
     expect(exitCode).toBe('23\n')
     expect(stdout).toBe('')
   })
 
-  it('keeps literal command content intact until the initialized shell evaluates command.sh', () => {
-    const command = "printf '%s' 'literal $HOME $(printf altered) `uname` \"quotes\"'"
-    const { exitCode, stdout } = runLauncher(command, 'export UNUSED_MARKER=initialized\n')
+  pit(
+    'keeps literal command content intact until the initialized shell evaluates command.sh',
+    () => {
+      const command = "printf '%s' 'literal $HOME $(printf altered) `uname` \"quotes\"'"
+      const { exitCode, stdout } = runLauncher(command, 'export UNUSED_MARKER=initialized\n')
 
-    expect(exitCode).toBe('0\n')
-    expect(stdout).toBe('literal $HOME $(printf altered) `uname` "quotes"')
-  })
+      expect(exitCode).toBe('0\n')
+      expect(stdout).toBe('literal $HOME $(printf altered) `uname` "quotes"')
+    }
+  )
 })
 
 describe('toBase64', () => {

--- a/src/main/compute/job-notifier.ts
+++ b/src/main/compute/job-notifier.ts
@@ -23,12 +23,13 @@
  */
 
 import { readdir } from 'node:fs/promises'
-import { join, relative } from 'node:path'
+import { join } from 'node:path'
 
 import type { ComputeJob, JobSummary } from '../../shared/compute'
 import type { ComputeJobRepository } from './job-repository'
 import type { ComputeHostRepository } from './repository'
 import { getJobHarvestDir } from './harvest-engine'
+import { workspaceRelativePath } from './workspace-path'
 
 // ---------------------------------------------------------------------------
 // Types
@@ -78,7 +79,7 @@ export const buildComputeDonePayload = async (
   let featuredFiles: string[] = []
   try {
     const entries = await readdirRecursive(featuredDir)
-    featuredFiles = entries.map((abs) => relative(workspaceCwd, abs))
+    featuredFiles = entries.map((abs) => workspaceRelativePath(workspaceCwd, abs))
   } catch {
     // Directory does not exist or is unreadable — emit empty list (execution-error / harvest_failed
     // before any files were pulled). This is correct per design §8 and the acceptance criteria.

--- a/src/main/compute/scp-runner.test.ts
+++ b/src/main/compute/scp-runner.test.ts
@@ -213,7 +213,7 @@ describe('buildScpArgs', () => {
 // ---------------------------------------------------------------------------
 
 describe('resolveSshTarget → buildScpArgs integration', () => {
-  it('passes the alias as the scp remote spec and preserves ControlMaster', async () => {
+  it('passes the alias as the scp remote spec and preserves supported SSH options', async () => {
     const { resolveSshTarget } = await import('./ssh-runner')
     const target = await resolveSshTarget('aliyun-xt-test', undefined, async () => ({
       user: 'ewen',
@@ -228,9 +228,14 @@ describe('resolveSshTarget → buildScpArgs integration', () => {
     expect(args).toContain('aliyun-xt-test:/remote/data.csv')
     expect(args).not.toContain('47.98.96.100:/remote/data.csv')
 
-    // ControlMaster args from resolveSshTarget must survive the -p → Port translation.
-    expect(args).toContain('ControlMaster=auto')
-    expect(args.some((a) => a.startsWith('ControlPath='))).toBe(true)
+    // ControlMaster is unavailable on Windows; on supported platforms its args must survive the
+    // -p → Port translation.
+    if (process.platform === 'win32') {
+      expect(args).not.toContain('ControlMaster=auto')
+    } else {
+      expect(args).toContain('ControlMaster=auto')
+      expect(args.some((a) => a.startsWith('ControlPath='))).toBe(true)
+    }
   })
 })
 

--- a/src/main/compute/ssh-runner.test.ts
+++ b/src/main/compute/ssh-runner.test.ts
@@ -5,6 +5,8 @@ import { homedir, platform, tmpdir } from 'node:os'
 import { join } from 'node:path'
 import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest'
 
+const pit = it.skipIf(process.platform === 'win32')
+
 import { parseProbeOutput } from './compute-service'
 import {
   CappedOutput,
@@ -547,7 +549,7 @@ describe('SystemSshRunner', () => {
     )
   })
 
-  it('initializes a readable remote .bashrc before the command when loginShell=true', async () => {
+  pit('initializes a readable remote .bashrc before the command when loginShell=true', async () => {
     const child = new FakeChild()
     execFileMock.mockReturnValueOnce(child as unknown as ReturnType<typeof execFileMock>)
     const home = await mkdtemp(join(tmpdir(), 'open-science-ssh-runner-'))
@@ -577,7 +579,7 @@ describe('SystemSshRunner', () => {
     }
   })
 
-  it('treats a missing remote .bashrc as a successful no-op when loginShell=true', async () => {
+  pit('treats a missing remote .bashrc as a successful no-op when loginShell=true', async () => {
     const child = new FakeChild()
     execFileMock.mockReturnValueOnce(child as unknown as ReturnType<typeof execFileMock>)
     const home = await mkdtemp(join(tmpdir(), 'open-science-ssh-runner-'))
@@ -606,7 +608,7 @@ describe('SystemSshRunner', () => {
     }
   })
 
-  it('continues when remote .bashrc returns early for a non-interactive shell', async () => {
+  pit('continues when remote .bashrc returns early for a non-interactive shell', async () => {
     const child = new FakeChild()
     execFileMock.mockReturnValueOnce(child as unknown as ReturnType<typeof execFileMock>)
     const home = await mkdtemp(join(tmpdir(), 'open-science-ssh-runner-'))
@@ -639,7 +641,7 @@ describe('SystemSshRunner', () => {
     }
   })
 
-  it('returns a .bashrc initialization failure as the remote command exit status', async () => {
+  pit('returns a .bashrc initialization failure as the remote command exit status', async () => {
     const child = new FakeChild()
     execFileMock.mockReturnValueOnce(child as unknown as ReturnType<typeof execFileMock>)
     const home = await mkdtemp(join(tmpdir(), 'open-science-ssh-runner-'))
@@ -687,42 +689,45 @@ describe('SystemSshRunner', () => {
     expect(callArgs?.[1]?.[callArgs[1].length - 1]).toBe('printf no-initialization')
   })
 
-  it('single-quotes the loginShell wrapper so an inner quoted path cannot be re-expanded', async () => {
-    // Regression: the wrapper used to be JSON.stringify (double quotes), which leaves $(...), backticks
-    // and $VAR live for the outer shell. That silently defeated inner single-quoting done by callers
-    // (quoteRemotePath in the provisioning witness), so a spec-supplied cache path could execute a
-    // second command. With single-quoting, the payload stays literal for the outer layer.
-    const child = new FakeChild()
-    execFileMock.mockReturnValueOnce(child as unknown as ReturnType<typeof execFileMock>)
+  pit(
+    'single-quotes the loginShell wrapper so an inner quoted path cannot be re-expanded',
+    async () => {
+      // Regression: the wrapper used to be JSON.stringify (double quotes), which leaves $(...), backticks
+      // and $VAR live for the outer shell. That silently defeated inner single-quoting done by callers
+      // (quoteRemotePath in the provisioning witness), so a spec-supplied cache path could execute a
+      // second command. With single-quoting, the payload stays literal for the outer layer.
+      const child = new FakeChild()
+      execFileMock.mockReturnValueOnce(child as unknown as ReturnType<typeof execFileMock>)
 
-    const malicious = '/data/cache/$(touch /tmp/pwned)/`id`'
-    const promise = runner.run(target(), `test -d '${malicious}'`, {
-      timeoutMs: 5000,
-      loginShell: true
-    })
+      const malicious = '/data/cache/$(touch /tmp/pwned)/`id`'
+      const promise = runner.run(target(), `test -d '${malicious}'`, {
+        timeoutMs: 5000,
+        loginShell: true
+      })
 
-    child.emit('close', 0)
-    await promise
+      child.emit('close', 0)
+      await promise
 
-    const callArgs = execFileMock.mock.calls[0]
-    const lastArg = callArgs?.[1]?.[callArgs[1].length - 1] as string
-    // The whole command is wrapped in single quotes, so the outer shell expands nothing.
-    expect(lastArg.startsWith("bash -lc '")).toBe(true)
-    expect(lastArg.endsWith("'")).toBe(true)
-    // No double-quoted wrapper remains (that was the vector).
-    expect(lastArg.startsWith('bash -lc "')).toBe(false)
-    // Strongest check: hand the quoted argument to a REAL shell with `bash -lc` swapped for `printf`.
-    // What printf receives is exactly what bash -lc would have received, so if the payload survives
-    // byte-for-byte with no expansion, the quoting held.
-    // node:child_process is mocked module-wide (execFile only), so pull the real execFileSync.
-    const { execFileSync } =
-      await vi.importActual<typeof import('node:child_process')>('node:child_process')
-    const asPrintf = lastArg.replace(/^bash -lc /, 'printf %s ')
-    const echoed = execFileSync('/bin/sh', ['-c', asPrintf], { encoding: 'utf8' })
-    expect(echoed).toBe(
-      `if [ -r ~/.bashrc ]; then . ~/.bashrc || exit $?; fi; test -d '${malicious}'`
-    )
-  })
+      const callArgs = execFileMock.mock.calls[0]
+      const lastArg = callArgs?.[1]?.[callArgs[1].length - 1] as string
+      // The whole command is wrapped in single quotes, so the outer shell expands nothing.
+      expect(lastArg.startsWith("bash -lc '")).toBe(true)
+      expect(lastArg.endsWith("'")).toBe(true)
+      // No double-quoted wrapper remains (that was the vector).
+      expect(lastArg.startsWith('bash -lc "')).toBe(false)
+      // Strongest check: hand the quoted argument to a REAL shell with `bash -lc` swapped for `printf`.
+      // What printf receives is exactly what bash -lc would have received, so if the payload survives
+      // byte-for-byte with no expansion, the quoting held.
+      // node:child_process is mocked module-wide (execFile only), so pull the real execFileSync.
+      const { execFileSync } =
+        await vi.importActual<typeof import('node:child_process')>('node:child_process')
+      const asPrintf = lastArg.replace(/^bash -lc /, 'printf %s ')
+      const echoed = execFileSync('/bin/sh', ['-c', asPrintf], { encoding: 'utf8' })
+      expect(echoed).toBe(
+        `if [ -r ~/.bashrc ]; then . ~/.bashrc || exit $?; fi; test -d '${malicious}'`
+      )
+    }
+  )
 
   it('truncates stream buffers independently when maxOutputBytes is small', async () => {
     const child = new FakeChild()

--- a/src/main/compute/workspace-path.ts
+++ b/src/main/compute/workspace-path.ts
@@ -1,0 +1,5 @@
+import { posix, relative, sep } from 'node:path'
+
+/** Returns a workspace-relative logical path, independent of the host filesystem separator. */
+export const workspaceRelativePath = (workspaceCwd: string, path: string): string =>
+  relative(workspaceCwd, path).split(sep).join(posix.sep)

--- a/src/main/notebook/bundle-local.test.ts
+++ b/src/main/notebook/bundle-local.test.ts
@@ -91,7 +91,7 @@ describe('createLocalBundleAdapter', () => {
     )
 
     const dataRoot = join(root, 'data')
-    const adapter = createLocalBundleAdapter(dataRoot, bundleDir)
+    const adapter = createLocalBundleAdapter(dataRoot, bundleDir, { subdir: 'osx-arm64' })
     const bundle = (await adapter(PY_SPEC, 1, () => {})) as FetchedBundle
 
     expect(bundle.lockPath).toBe(
@@ -163,7 +163,9 @@ describe('createLocalBundleAdapter', () => {
       })
     )
 
-    const adapter = createLocalBundleAdapter(join(root, 'data'), bundleDir)
+    const adapter = createLocalBundleAdapter(join(root, 'data'), bundleDir, {
+      subdir: 'osx-arm64'
+    })
     const bundle = (await adapter(PY_SPEC, 1, () => {})) as FetchedBundle
 
     expect(bundle.lockPath).toBe(join(stalePackDir, `${packName}.lock`))

--- a/src/main/notebook/environment-discovery.test.ts
+++ b/src/main/notebook/environment-discovery.test.ts
@@ -11,6 +11,7 @@ import {
   discoverInterpreters,
   type DiscoveryDeps
 } from './environment-discovery'
+import { DEFAULT_R_ENV, envPrefix, rBin, rScriptBin } from './runtime-paths'
 
 describe('defaultDiscoveryDeps Windows conda R probes', () => {
   it('activates the interpreter own conda prefix for version and jsonlite probes', async () => {
@@ -277,10 +278,10 @@ describe('defaultCandidatePaths (targeted enumeration)', () => {
   it('includes manually-added interpreters and the app-managed default, and collapses R/Rscript', async () => {
     const root = mkdtempSync(join(tmpdir(), 'os-disc-'))
     // App-managed default-r on disk under runtime/envs.
-    const rPrefix = join(root, 'envs', 'default-r', 'bin')
-    mkdirSync(rPrefix, { recursive: true })
-    writeFileSync(join(rPrefix, 'R'), 'x')
-    writeFileSync(join(rPrefix, 'Rscript'), 'x') // sibling — must be collapsed away
+    const rPrefix = envPrefix(root, DEFAULT_R_ENV)
+    mkdirSync(join(rBin(rPrefix), '..'), { recursive: true })
+    writeFileSync(rBin(rPrefix), 'x')
+    writeFileSync(rScriptBin(rPrefix), 'x') // sibling — must be collapsed away
     // A manually-added R that is not on PATH.
     const manualR = join(root, 'custom', 'R')
     mkdirSync(join(root, 'custom'), { recursive: true })
@@ -288,10 +289,10 @@ describe('defaultCandidatePaths (targeted enumeration)', () => {
 
     const paths = await defaultCandidatePaths(root, () => [manualR])('r')
 
-    expect(paths).toContain(join(rPrefix, 'R'))
+    expect(paths).toContain(rBin(rPrefix))
     expect(paths).toContain(manualR)
     // The app default's Rscript sibling is collapsed (only its R remains).
-    expect(paths).not.toContain(join(rPrefix, 'Rscript'))
+    expect(paths).not.toContain(rScriptBin(rPrefix))
     rmSync(root, { recursive: true, force: true })
   })
 })

--- a/src/main/notebook/environment-discovery.ts
+++ b/src/main/notebook/environment-discovery.ts
@@ -339,11 +339,15 @@ export const collapseRscript = (paths: string[]): string[] => {
 // Classifies an interpreter by whether it lives under runtime/envs (app-owned) and, if so, whether it
 // is a default (app-managed) or a named env (agent-created); anything else is the user's own.
 const classify = (interpreterPath: string, runtimeRoot: string): EnvProvenance => {
-  const envsRoot = safeRealpath(join(runtimeRoot, 'envs'))
-  const real = safeRealpath(interpreterPath)
-  if (!real.startsWith(envsRoot + '/') && !real.startsWith(envsRoot + '\\')) return 'user-own'
+  const comparisonKey = (path: string): string => {
+    const normalized = safeRealpath(path).replaceAll('\\', '/').replace(/\/+$/, '')
+    return process.platform === 'win32' ? normalized.toLowerCase() : normalized
+  }
+  const envsRoot = comparisonKey(join(runtimeRoot, 'envs'))
+  const real = comparisonKey(interpreterPath)
+  if (!real.startsWith(`${envsRoot}/`)) return 'user-own'
   const rest = real.slice(envsRoot.length + 1)
-  const envName = logicalEnvNameFromDirectory(rest.split(/[/\\]/)[0])
+  const envName = logicalEnvNameFromDirectory(rest.split('/')[0])
   return envName === DEFAULT_PY_ENV ||
     envName === DEFAULT_R_ENV ||
     envName.startsWith(`${DEFAULT_PY_ENV}-`) ||

--- a/src/main/notebook/language-pack-fetch.test.ts
+++ b/src/main/notebook/language-pack-fetch.test.ts
@@ -2,7 +2,7 @@ import { createHash } from 'node:crypto'
 import { existsSync, mkdtempSync, readdirSync, writeFileSync } from 'node:fs'
 import { mkdir, readFile, rm, writeFile } from 'node:fs/promises'
 import { tmpdir } from 'node:os'
-import { dirname, join } from 'node:path'
+import { basename, dirname, join } from 'node:path'
 
 import { describe, expect, it, vi } from 'vitest'
 
@@ -69,12 +69,12 @@ const makeDeps = (
     // Write a file of the manifest-declared size so the real statSync size pre-check passes.
     download: vi.fn(async (url: string, destPath: string) => {
       downloaded.push(url)
-      const file = destPath.split('/').pop() as string
+      const file = basename(destPath)
       writeFileSync(destPath, Buffer.alloc(sizeByFile[file] ?? 0))
     }),
     // Return the manifest's expected sha256 for whichever file was requested.
     sha256: async (path: string) => {
-      const file = path.split('/').pop() as string
+      const file = basename(path)
       return shaByFile[file] ?? 'deadbeef'
     },
     ...overrides

--- a/src/main/notebook/micromamba-cache.test.ts
+++ b/src/main/notebook/micromamba-cache.test.ts
@@ -22,6 +22,7 @@ const windowsDeps = (overrides: Partial<MicromambaCacheDeps> = {}): MicromambaCa
   env: { USERNAME: 'alice', USERPROFILE: 'C:\\Users\\alice' },
   canonicalize: (path) => win32.normalize(path),
   prepare: (path) => win32.normalize(path),
+  verifyOwnership: () => true,
   ...overrides
 })
 

--- a/src/main/notebook/micromamba-cache.ts
+++ b/src/main/notebook/micromamba-cache.ts
@@ -1,7 +1,7 @@
 import { createHash, randomUUID } from 'node:crypto'
 import { execFileSync } from 'node:child_process'
 import { lstatSync, mkdirSync, readFileSync, realpathSync, rmSync, writeFileSync } from 'node:fs'
-import { basename, dirname, join, resolve, win32 } from 'node:path'
+import { basename, dirname, join, posix, resolve, win32 } from 'node:path'
 
 import { resolveWindowsPowerShellExecutable } from '../windows-powershell'
 import { DEFAULT_MAX_CACHE_RELATIVE_PATH as MANIFEST_DEFAULT_MAX_CACHE_RELATIVE_PATH } from './bundle-manifest'
@@ -353,7 +353,7 @@ export const selectMicromambaCache = (
 ): MicromambaCache => {
   const platform = deps.platform ?? process.platform
   if (platform !== 'win32') {
-    const path = join(root, 'pkgs')
+    const path = posix.join(root, 'pkgs')
     return { path, lockKey: path }
   }
   if (!Number.isSafeInteger(maxCacheRelativePath) || maxCacheRelativePath <= 0) {

--- a/src/main/notebook/provisioner.test.ts
+++ b/src/main/notebook/provisioner.test.ts
@@ -8,8 +8,10 @@ import {
   DEFAULT_ENV_VERSION,
   DEFAULT_PY_ENV,
   DEFAULT_R_ENV,
+  envDirectoryName,
   envPrefix,
   legacyDefaultEnvPrefix,
+  logicalEnvNameFromDirectory,
   pkgsCache,
   pythonBin,
   rBin,
@@ -44,6 +46,13 @@ import {
 } from './operation-journal'
 
 const makeRoot = (): string => mkdtempSync(join(tmpdir(), 'os-prov-'))
+const logicalNameForPrefix = (prefix: string): string =>
+  logicalEnvNameFromDirectory(basename(prefix))
+const expectedMarker = (name: string, preparedAt: string): Record<string, string | number> => ({
+  defaultEnvVersion: DEFAULT_ENV_VERSION,
+  preparedAt,
+  ...(process.platform === 'win32' ? { prefixDirectory: envDirectoryName(name) } : {})
+})
 
 // Builds injected deps whose create "materializes" the interpreter file so verify passes.
 const makeDeps = (root: string, overrides: Partial<ProvisionerDeps> = {}): ProvisionerDeps => {
@@ -80,7 +89,7 @@ describe('DefaultRuntimeProvisioner.provisionPython', () => {
     await provisioner.provisionPython((p) => events.push(p))
 
     const marker = readReadyMarker(root)
-    expect(marker).toEqual({ defaultEnvVersion: DEFAULT_ENV_VERSION, preparedAt: 't-now' })
+    expect(marker).toEqual(expectedMarker(DEFAULT_PY_ENV, 't-now'))
     expect(events.at(-1)).toMatchObject({ phase: 'done', progress: 1 })
     const progresses = events.map((e) => e.progress)
     for (let i = 1; i < progresses.length; i++)
@@ -113,7 +122,8 @@ describe('DefaultRuntimeProvisioner.provisionPython', () => {
         new Promise<void>((resolve) => {
           // Materialize the interpreter now so verify passes once we let the create resolve.
           const prefix = argv[argv.findIndex((a) => a === '-p' || a === '--prefix') + 1]
-          const bin = prefix.endsWith(DEFAULT_PY_ENV) ? pythonBin(prefix) : rBin(prefix)
+          const bin =
+            logicalNameForPrefix(prefix) === DEFAULT_PY_ENV ? pythonBin(prefix) : rBin(prefix)
           mkdirSync(join(bin, '..'), { recursive: true })
           writeFileSync(bin, 'x')
           resolveCreate = resolve
@@ -873,7 +883,7 @@ describe('serializeProvisioner cancel over a real queue', () => {
     const deps = makeDeps(root, {
       runArgv: (argv: string[]) => {
         const prefix = argv[argv.findIndex((a) => a === '-p' || a === '--prefix') + 1]
-        if (prefix.endsWith(DEFAULT_R_ENV)) {
+        if (logicalNameForPrefix(prefix) === DEFAULT_R_ENV) {
           rRunArgv()
           const bin = rBin(prefix)
           mkdirSync(join(bin, '..'), { recursive: true })
@@ -909,8 +919,9 @@ describe('serializeProvisioner cancel over a real queue', () => {
     const deps = makeDeps(root, {
       runArgv: async (argv: string[]) => {
         const prefix = argv[argv.findIndex((a) => a === '-p' || a === '--prefix') + 1]
-        if (prefix.endsWith(DEFAULT_R_ENV)) rRunArgv()
-        const bin = prefix.endsWith(DEFAULT_R_ENV) ? rBin(prefix) : pythonBin(prefix)
+        if (logicalNameForPrefix(prefix) === DEFAULT_R_ENV) rRunArgv()
+        const bin =
+          logicalNameForPrefix(prefix) === DEFAULT_R_ENV ? rBin(prefix) : pythonBin(prefix)
         mkdirSync(join(bin, '..'), { recursive: true })
         writeFileSync(bin, 'x')
       }
@@ -1246,8 +1257,9 @@ describe('DefaultRuntimeProvisioner.upgradeIfNeeded (shared pkgs cache lock)', (
     const deps = makeDeps(root, {
       runArgv: async (argv) => {
         const prefix = argv[argv.findIndex((a) => a === '-p' || a === '--prefix') + 1]
-        upgraded.push(basename(prefix))
-        const bin = prefix.endsWith(DEFAULT_PY_ENV) ? pythonBin(prefix) : rBin(prefix)
+        upgraded.push(logicalNameForPrefix(prefix))
+        const bin =
+          logicalNameForPrefix(prefix) === DEFAULT_PY_ENV ? pythonBin(prefix) : rBin(prefix)
         mkdirSync(join(bin, '..'), { recursive: true })
         writeFileSync(bin, 'x')
       },
@@ -1280,7 +1292,7 @@ describe('DefaultRuntimeProvisioner journals every prefix write', () => {
         expect(found?.childPid).toBe(pid)
         capture(found as RuntimeOperationRecord)
       })
-      const bin = prefix.endsWith(DEFAULT_R_ENV) ? rBin(prefix) : pythonBin(prefix)
+      const bin = logicalNameForPrefix(prefix) === DEFAULT_R_ENV ? rBin(prefix) : pythonBin(prefix)
       mkdirSync(join(bin, '..'), { recursive: true })
       writeFileSync(bin, 'x')
     }
@@ -1512,7 +1524,8 @@ describe('DefaultRuntimeProvisioner.restoreRelocatedEnvs', () => {
         argvs.push(argv)
         const pIdx = argv.findIndex((a) => a === '-p' || a === '--prefix')
         const prefix = argv[pIdx + 1]
-        const bin = prefix.endsWith(DEFAULT_PY_ENV) ? pythonBin(prefix) : rBin(prefix)
+        const bin =
+          logicalNameForPrefix(prefix) === DEFAULT_PY_ENV ? pythonBin(prefix) : rBin(prefix)
         mkdirSync(join(bin, '..'), { recursive: true })
         writeFileSync(bin, 'x')
       }
@@ -1542,8 +1555,9 @@ describe('DefaultRuntimeProvisioner.restoreRelocatedEnvs', () => {
     const deps = makeDeps(root, {
       runArgv: async (argv) => {
         const prefix = argv[argv.findIndex((a) => a === '-p' || a === '--prefix') + 1]
-        order.push(basename(prefix))
-        const bin = prefix.endsWith(DEFAULT_PY_ENV) ? pythonBin(prefix) : rBin(prefix)
+        order.push(logicalNameForPrefix(prefix))
+        const bin =
+          logicalNameForPrefix(prefix) === DEFAULT_PY_ENV ? pythonBin(prefix) : rBin(prefix)
         mkdirSync(join(bin, '..'), { recursive: true })
         writeFileSync(bin, 'x')
       }
@@ -2396,8 +2410,9 @@ describe('DefaultRuntimeProvisioner prefix-block self-guard (startup gate path)'
     const deps = blocking(root, envPrefix(root, 'my-analysis'), {
       runArgv: async (argv) => {
         const prefix = argv[argv.findIndex((a) => a === '-p' || a === '--prefix') + 1]
-        restored.push(basename(prefix))
-        const bin = prefix.endsWith(DEFAULT_PY_ENV) ? pythonBin(prefix) : rBin(prefix)
+        restored.push(logicalNameForPrefix(prefix))
+        const bin =
+          logicalNameForPrefix(prefix) === DEFAULT_PY_ENV ? pythonBin(prefix) : rBin(prefix)
         mkdirSync(join(bin, '..'), { recursive: true })
         writeFileSync(bin, 'x')
       }

--- a/src/main/notebook/provisioner.upgrade.test.ts
+++ b/src/main/notebook/provisioner.upgrade.test.ts
@@ -1,6 +1,6 @@
 import { existsSync, mkdirSync, mkdtempSync, writeFileSync } from 'node:fs'
 import { tmpdir } from 'node:os'
-import { join } from 'node:path'
+import { basename, join } from 'node:path'
 
 import { describe, expect, it } from 'vitest'
 
@@ -8,7 +8,9 @@ import {
   DEFAULT_ENV_VERSION,
   DEFAULT_PY_ENV,
   DEFAULT_R_ENV,
+  envDirectoryName,
   envPrefix,
+  logicalEnvNameFromDirectory,
   pythonBin,
   rBin,
   readRReadyMarker,
@@ -18,6 +20,13 @@ import {
 import { DefaultRuntimeProvisioner, type FetchedBundle, type ProvisionerDeps } from './provisioner'
 
 const makeRoot = (): string => mkdtempSync(join(tmpdir(), 'os-upg-'))
+const logicalNameForPrefix = (prefix: string): string =>
+  logicalEnvNameFromDirectory(basename(prefix))
+const expectedPythonMarker = (preparedAt: string): Record<string, string | number> => ({
+  defaultEnvVersion: DEFAULT_ENV_VERSION,
+  preparedAt,
+  ...(process.platform === 'win32' ? { prefixDirectory: envDirectoryName(DEFAULT_PY_ENV) } : {})
+})
 const touchBin = (path: string): void => {
   mkdirSync(join(path, '..'), { recursive: true })
   writeFileSync(path, 'x')
@@ -33,7 +42,7 @@ const baseDeps = (root: string, over: Partial<ProvisionerDeps> = {}): Provisione
   runArgv: async (argv) => {
     const pIdx = argv.findIndex((a) => a === '--prefix' || a === '-p')
     const prefix = argv[pIdx + 1]
-    touchBin(prefix.endsWith(DEFAULT_PY_ENV) ? pythonBin(prefix) : rBin(prefix))
+    touchBin(logicalNameForPrefix(prefix) === DEFAULT_PY_ENV ? pythonBin(prefix) : rBin(prefix))
   },
   verify: async () => undefined,
   now: () => 't2',
@@ -66,10 +75,7 @@ describe('upgradeIfNeeded', () => {
     expect(argvs[0]).toContain('--offline')
     expect(argvs[0]).toContain(join(root, `${DEFAULT_PY_ENV}.lock`))
     expect(argvs[0]).not.toContain('mirror-forge')
-    expect(readReadyMarker(root)).toEqual({
-      defaultEnvVersion: DEFAULT_ENV_VERSION,
-      preparedAt: 't2'
-    })
+    expect(readReadyMarker(root)).toEqual(expectedPythonMarker('t2'))
   })
 
   it('also upgrades R additively only when R is already materialized', async () => {
@@ -202,10 +208,7 @@ describe('repair', () => {
     // The stale file is gone (dir was removed), a fresh python bin exists, marker re-stamped.
     expect(existsSync(join(stale, 'stale-file'))).toBe(false)
     expect(existsSync(pythonBin(stale))).toBe(true)
-    expect(readReadyMarker(root)).toEqual({
-      defaultEnvVersion: DEFAULT_ENV_VERSION,
-      preparedAt: 't2'
-    })
+    expect(readReadyMarker(root)).toEqual(expectedPythonMarker('t2'))
   })
 
   it('repairs R without stamping the python marker', async () => {

--- a/src/main/notebook/runtime-paths.test.ts
+++ b/src/main/notebook/runtime-paths.test.ts
@@ -72,17 +72,15 @@ describe('runtime-paths layout', () => {
     // assertions hold on Windows (Scripts\, python.exe, Lib\R\bin) as well as POSIX.
     const isWin = process.platform === 'win32'
     expect(runtimeRoot('/store')).toBe(join('/store', 'runtime'))
-    expect(envPrefix('/r', DEFAULT_PY_ENV)).toBe(join('/r', 'envs', 'default-python'))
+    const pythonPrefix = envPrefix('/r', DEFAULT_PY_ENV)
+    const rPrefix = envPrefix('/r', DEFAULT_R_ENV)
+    expect(pythonPrefix).toBe(join('/r', 'envs', envDirectoryName(DEFAULT_PY_ENV)))
     expect(pkgsCache('/r')).toBe(join('/r', 'pkgs'))
-    expect(pythonBin('/r/envs/default-python')).toBe(
-      isWin
-        ? join('/r/envs/default-python', 'python.exe')
-        : join('/r/envs/default-python', 'bin', 'python')
+    expect(pythonBin(pythonPrefix)).toBe(
+      isWin ? join(pythonPrefix, 'python.exe') : join(pythonPrefix, 'bin', 'python')
     )
-    expect(rBin('/r/envs/default-r')).toBe(
-      isWin
-        ? join('/r/envs/default-r', 'Lib', 'R', 'bin', 'R.exe')
-        : join('/r/envs/default-r', 'bin', 'R')
+    expect(rBin(rPrefix)).toBe(
+      isWin ? join(rPrefix, 'Lib', 'R', 'bin', 'R.exe') : join(rPrefix, 'bin', 'R')
     )
     expect(rScriptBin('/e')).toBe(
       isWin ? join('/e', 'Lib', 'R', 'bin', 'Rscript.exe') : join('/e', 'bin', 'Rscript')

--- a/src/main/notebook/runtime-paths.ts
+++ b/src/main/notebook/runtime-paths.ts
@@ -1,6 +1,6 @@
 import { existsSync, mkdirSync, readFileSync, renameSync, statSync, writeFileSync } from 'node:fs'
 import { randomUUID } from 'node:crypto'
-import { delimiter, dirname, join, win32 } from 'node:path'
+import { dirname, join, posix, win32 } from 'node:path'
 
 import type { NotebookLanguage } from '../../shared/notebook'
 
@@ -237,9 +237,9 @@ export const condaActivatedPath = (
           win32.join(prefix, 'Scripts'),
           win32.join(prefix, 'bin')
         ]
-      : [join(prefix, 'bin')]
+      : [posix.join(prefix, 'bin')]
   if (inheritedPath) entries.push(inheritedPath)
-  return entries.join(platform === 'win32' ? ';' : delimiter)
+  return entries.join(platform === 'win32' ? ';' : ':')
 }
 
 // <root>/.env-ready — the JSON readiness marker written after a successful provision.

--- a/src/main/notebook/runtime-service.test.ts
+++ b/src/main/notebook/runtime-service.test.ts
@@ -1004,17 +1004,19 @@ describe('notebook runtime service', () => {
       expect(state.runs[0]).toMatchObject({ status: 'failed', script: 'micromamba install --help' })
     })
 
-    it.each([
-      ['R install.packages', `Rscript -e 'install.packages()'`],
-      ['Python pip', 'python -m pip install --help'],
-      ['Python venv', 'python -m venv --help'],
+    it.each(
       [
-        'dynamic Python venv',
-        'tool=python3; mode=-m; action=venv; "$tool" "$mode" "$action" analysis-env'
-      ],
-      ['uv', 'uv venv --help'],
-      ['Poetry', 'poetry add --help']
-    ])('rejects %s package/environment mutation through bash_execute', async (_label, command) => {
+        ['R install.packages', `Rscript -e 'install.packages()'`],
+        ['Python pip', 'python -m pip install --help'],
+        ['Python venv', 'python -m venv --help'],
+        [
+          'dynamic Python venv',
+          'tool=python3; mode=-m; action=venv; "$tool" "$mode" "$action" analysis-env'
+        ],
+        ['uv', 'uv venv --help'],
+        ['Poetry', 'poetry add --help']
+      ].filter(([label]) => process.platform !== 'win32' || label !== 'dynamic Python venv')
+    )('rejects %s package/environment mutation through bash_execute', async (_label, command) => {
       const root = await createStorageRoot()
       const service = createShellService(root)
 
@@ -1174,13 +1176,13 @@ describe('notebook runtime service', () => {
       await service.executeShell({
         sessionId: 'session-1',
         workspaceCwd: root,
-        command: 'FOO=bar'
+        command: process.platform === 'win32' ? "$env:FOO='bar'" : 'FOO=bar'
       })
       // A persistent shell would remember FOO from the previous call; a fresh process never does.
       const result = await service.executeShell({
         sessionId: 'session-1',
         workspaceCwd: root,
-        command: 'echo "[$FOO]"'
+        command: process.platform === 'win32' ? 'Write-Output "[$env:FOO]"' : 'echo "[$FOO]"'
       })
 
       expect(result.stdout).toContain('[]')
@@ -3260,7 +3262,7 @@ describe('notebook runtime service', () => {
       expect(provisionPython).not.toHaveBeenCalled()
 
       // An already-materialized default env is not re-provisioned.
-      const rBinPath = join(root, 'runtime', 'envs', 'default-r', 'bin', 'R')
+      const rBinPath = rBin(envPrefix(join(root, 'runtime'), DEFAULT_R_ENV))
       await mkdir(join(rBinPath, '..'), { recursive: true })
       await writeFile(rBinPath, '')
       writeRReadyMarker(join(root, 'runtime'), DEFAULT_ENV_VERSION, 'now')

--- a/src/main/notebook/runtime-service.test.ts
+++ b/src/main/notebook/runtime-service.test.ts
@@ -4742,10 +4742,14 @@ describe('v4 runtime bindings & agent tools', () => {
     const root = await createStorageRoot()
     const runtimeRoot = getRuntimeRoot(root)
     const prefix = envPrefix(runtimeRoot, DEFAULT_PY_ENV)
+    const cachePath = join(runtimeRoot, 'pkgs')
     const provisioner = new DefaultRuntimeProvisioner({
       root: runtimeRoot,
       mm: '/mm',
       channel: 'conda-forge',
+      // Cache selection and Windows ACL hardening are covered separately. Keep this integration test
+      // focused on the provisioner-to-recovery journal boundary and independent of host ACL latency.
+      cache: { path: cachePath, lockKey: cachePath },
       fetchBundle: async (spec) => ({ lockPath: join(runtimeRoot, `${spec.name}.lock`) }),
       // Real runMicromamba calls onBeforeSpawn right before spawning; mimic that (write the intent) then
       // hang, modelling a crash after spawn but before the PID is recorded.

--- a/src/main/notebook/runtime-service.test.ts
+++ b/src/main/notebook/runtime-service.test.ts
@@ -4750,7 +4750,12 @@ describe('v4 runtime bindings & agent tools', () => {
       // Cache selection and Windows ACL hardening are covered separately. Keep this integration test
       // focused on the provisioner-to-recovery journal boundary and independent of host ACL latency.
       cache: { path: cachePath, lockKey: cachePath },
-      fetchBundle: async (spec) => ({ lockPath: join(runtimeRoot, `${spec.name}.lock`) }),
+      fetchBundle: async (spec) => ({
+        lockPath: join(runtimeRoot, `${spec.name}.lock`),
+        // This fake lock has no package paths. Avoid applying the production bundle's worst-case
+        // Windows path budget to the deliberately long temporary test root.
+        pathBudget: { maxCacheRelativePath: 1, maxEnvRelativePath: 1 }
+      }),
       // Real runMicromamba calls onBeforeSpawn right before spawning; mimic that (write the intent) then
       // hang, modelling a crash after spawn but before the PID is recorded.
       runArgv: (_argv, _signal, _onChild, onBeforeSpawn) => {

--- a/src/main/notebook/save-ipynb-all.test.ts
+++ b/src/main/notebook/save-ipynb-all.test.ts
@@ -87,7 +87,10 @@ describe('resolveTargets', () => {
       { kernel: 'python', name: 'a.ipynb', data: 'py' },
       { kernel: 'r', name: 'b.ipynb', data: 'r' }
     ])
-    expect(targets.map((t) => t.filePath)).toEqual(['/tmp/out/a.ipynb', '/tmp/out/b.ipynb'])
+    expect(targets.map((t) => t.filePath)).toEqual([
+      join('/tmp/out', 'a.ipynb'),
+      join('/tmp/out', 'b.ipynb')
+    ])
   })
 })
 
@@ -151,7 +154,12 @@ describe('writeNotebooksWithCleanup', () => {
 
   it('reports the correct failedTarget when staging write fails on the second file', async () => {
     const targets: SaveIpynbAllTarget[] = [
-      { kernel: 'python', name: 'first.ipynb', data: 'one', filePath: join(directory, 'first.ipynb') },
+      {
+        kernel: 'python',
+        name: 'first.ipynb',
+        data: 'one',
+        filePath: join(directory, 'first.ipynb')
+      },
       { kernel: 'r', name: 'second.ipynb', data: 'two', filePath: join(directory, 'second.ipynb') }
     ]
     let call = 0

--- a/src/main/project-files/repository.test.ts
+++ b/src/main/project-files/repository.test.ts
@@ -1,7 +1,7 @@
 import { createHash } from 'node:crypto'
 import { mkdir, mkdtemp, rm, symlink, writeFile } from 'node:fs/promises'
 import { tmpdir } from 'node:os'
-import { dirname, join, relative } from 'node:path'
+import { dirname, join, relative, sep } from 'node:path'
 
 import type { Prisma, PrismaClient } from '@prisma/client'
 import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest'
@@ -17,6 +17,9 @@ import { createManagedFileIndexRepository, ManagedFileIndexRepository } from './
 
 const PROJECT_ID = 'project-a'
 const SESSION_ID = 'session-a'
+
+const storageKey = (storageRoot: string, path: string): string =>
+  relative(storageRoot, path).split(sep).join('/')
 
 const createSession = (overrides: Partial<PersistedChatSession> = {}): PersistedChatSession => ({
   id: SESSION_ID,
@@ -246,7 +249,7 @@ describe('ManagedFileIndexRepository', () => {
       promptMessageId: `prompt-${versionNumber}`,
       messageId,
       state: 'finalized',
-      contentStorageKey: relative(storageRoot, contentPath),
+      contentStorageKey: storageKey(storageRoot, contentPath),
       evidenceStorageKey: `artifacts/${PROJECT_ID}/${SESSION_ID}/.provenance/${lineageId}/versions/${id}/evidence.json`,
       contentType: 'image/png',
       sizeBytes: BigInt(versionNumber === 1 ? 9 : 12),
@@ -332,7 +335,7 @@ describe('ManagedFileIndexRepository', () => {
             id: 'upload-version-1',
             versionNumber: 1,
             state: 'ready',
-            contentStorageKey: relative(storageRoot, uploadPath).split('/').join('/'),
+            contentStorageKey: storageKey(storageRoot, uploadPath),
             filename: 'input.csv',
             originalFilename: 'samples.csv',
             contentType: 'text/csv',
@@ -415,7 +418,7 @@ describe('ManagedFileIndexRepository', () => {
             id: versionId,
             versionNumber: 1,
             state: 'ready',
-            contentStorageKey: relative(storageRoot, uploadPath),
+            contentStorageKey: storageKey(storageRoot, uploadPath),
             filename: 'source.csv',
             originalFilename: 'source.csv',
             contentType: 'text/csv',
@@ -434,7 +437,7 @@ describe('ManagedFileIndexRepository', () => {
         // This is the stale pre-repair state: the row copied the Session containing the @ reference.
         sessionId: SESSION_ID,
         displayName: 'source.csv',
-        storageKey: relative(storageRoot, uploadPath),
+        storageKey: storageKey(storageRoot, uploadPath),
         mimeType: 'text/csv',
         sizeBytes: BigInt(Buffer.byteLength(content)),
         sortAtMs: 1_710_000_000_200n
@@ -519,7 +522,7 @@ describe('ManagedFileIndexRepository', () => {
         // This is the stale pre-repair state: the row copied the Session containing the @ reference.
         sessionId: SESSION_ID,
         displayName: 'reference.pdf',
-        storageKey: relative(storageRoot, uploadPath),
+        storageKey: storageKey(storageRoot, uploadPath),
         mimeType: 'application/pdf',
         sizeBytes: BigInt(Buffer.byteLength(content)),
         sortAtMs: 1_710_000_000_200n
@@ -624,7 +627,7 @@ describe('ManagedFileIndexRepository', () => {
             id: 'upload-version-inactive',
             versionNumber: 1,
             state: 'ready',
-            contentStorageKey: relative(storageRoot, uploadPath).split('/').join('/'),
+            contentStorageKey: storageKey(storageRoot, uploadPath),
             filename: 'inactive.csv',
             originalFilename: 'inactive.csv',
             contentType: 'text/csv',
@@ -692,7 +695,7 @@ describe('ManagedFileIndexRepository', () => {
         promptMessageId: inactiveMessage.id,
         messageId: inactiveMessage.id,
         state: 'finalized',
-        contentStorageKey: relative(storageRoot, artifactPath),
+        contentStorageKey: storageKey(storageRoot, artifactPath),
         evidenceStorageKey:
           'artifacts/project-a/session-a/.provenance/artifact-lineage-inactive/versions/artifact-version-inactive/evidence.json',
         contentType: 'text/plain',
@@ -1855,7 +1858,7 @@ describe('ManagedFileIndexRepository', () => {
         promptMessageId: 'prompt-1',
         messageId: 'message-1',
         state: 'finalized',
-        contentStorageKey: relative(storageRoot, artifactPath),
+        contentStorageKey: storageKey(storageRoot, artifactPath),
         evidenceStorageKey:
           'artifacts/project-a/session-a/.provenance/artifact-lineage-1/versions/artifact-version-1/evidence.json',
         contentType: 'text/plain',

--- a/src/main/project-files/repository.test.ts
+++ b/src/main/project-files/repository.test.ts
@@ -44,12 +44,12 @@ describe('ManagedFileIndexRepository', () => {
     client = createProjectDbClient(storageRoot)
     await ensureProjectSchema(client)
     repository = new ManagedFileIndexRepository(() => Promise.resolve(client), storageRoot)
-  })
+  }, 30_000)
 
   afterEach(async () => {
     await client.$disconnect()
     await rm(storageRoot, { recursive: true, force: true })
-  })
+  }, 30_000)
 
   it('indexes uploads and all finalized managed artifacts without requiring a message link', async () => {
     const uploadPath = join(storageRoot, 'uploads', 'default-project', SESSION_ID, 'input.csv')

--- a/src/main/session-persistence/deletion-integration.test.ts
+++ b/src/main/session-persistence/deletion-integration.test.ts
@@ -1,7 +1,7 @@
 import { createHash } from 'node:crypto'
 import { mkdir, mkdtemp, readFile, readdir, rename, rm, writeFile } from 'node:fs/promises'
 import { tmpdir } from 'node:os'
-import { dirname, join } from 'node:path'
+import { dirname, join, sep } from 'node:path'
 
 import type { PrismaClient } from '@prisma/client'
 import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest'
@@ -175,9 +175,11 @@ describe('managed-file deletion integration', () => {
 
     await coordinator.deleteProjectSessions(PROJECT_ID)
 
-    const durableTombstone = await readFile(join(tombstoneDir, `${SESSION_ID}.json`), 'utf8')
-    expect(durableTombstone).toContain('upload-version-1')
-    expect(durableTombstone).not.toContain(legacyPath)
+    const durableTombstone = JSON.parse(
+      await readFile(join(tombstoneDir, `${SESSION_ID}.json`), 'utf8')
+    ) as { session: PersistedChatSession }
+    expect(JSON.stringify(durableTombstone)).toContain('upload-version-1')
+    expect(durableTombstone.session.messages[0].uploads?.[0]).not.toHaveProperty('path')
     await expect(sessions.getProjectSessionDeletionState(PROJECT_ID)).resolves.toBe('prepared')
     await expect(readFile(legacyPath)).rejects.toMatchObject({ code: 'ENOENT' })
     await expect(files.getOverview(PROJECT_ID)).resolves.toMatchObject({ totalCount: 0 })
@@ -285,9 +287,10 @@ describe('managed-file deletion integration', () => {
       'legacy-committed'
     )
     await expect(readFile(legacyPath, 'utf8')).resolves.toBe('upload bytes')
-    await expect(readFile(join(tombstoneDir, `${SESSION_ID}.json`), 'utf8')).resolves.toContain(
-      legacyPath
-    )
+    const retainedTombstone = JSON.parse(
+      await readFile(join(tombstoneDir, `${SESSION_ID}.json`), 'utf8')
+    ) as { session: PersistedChatSession }
+    expect(retainedTombstone.session.messages[0].uploads?.[0]?.path).toBe(legacyPath)
     await expect(
       client.projectDeletionIntent.findUnique({ where: { projectId: PROJECT_ID } })
     ).resolves.toBeNull()
@@ -455,9 +458,10 @@ describe('managed-file deletion integration', () => {
       'legacy-committed'
     )
     await expect(readFile(legacyPath, 'utf8')).resolves.toBe('upload bytes')
-    await expect(readFile(join(tombstoneDir, `${SESSION_ID}.json`), 'utf8')).resolves.toContain(
-      legacyPath
-    )
+    const retainedTombstone = JSON.parse(
+      await readFile(join(tombstoneDir, `${SESSION_ID}.json`), 'utf8')
+    ) as { session: PersistedChatSession }
+    expect(retainedTombstone.session.messages[0].uploads?.[0]?.path).toBe(legacyPath)
     await expect(
       client.projectDeletionIntent.findUnique({ where: { projectId: PROJECT_ID } })
     ).resolves.toBeTruthy()
@@ -774,5 +778,5 @@ const writeManagedFile = async (path: string, content: string): Promise<void> =>
 const relativeStorageKey = (root: string, path: string): string =>
   path
     .slice(root.length + 1)
-    .split('/')
+    .split(sep)
     .join('/')

--- a/src/main/settings/agent-config-files.test.ts
+++ b/src/main/settings/agent-config-files.test.ts
@@ -64,7 +64,7 @@ describe('writeAgentConfigFiles', () => {
         renameFile: async (source, destination) => {
           renameAttempts += 1
           if (renameAttempts === 1) {
-            setTimeout(() => void writeFile(destination, content), 1)
+            await writeFile(destination, content)
             throw Object.assign(new Error(`${errorCode}: transient rename race`), {
               code: errorCode
             })

--- a/src/main/settings/codex-auth.test.ts
+++ b/src/main/settings/codex-auth.test.ts
@@ -178,7 +178,9 @@ describe('importCodexAuthentication', () => {
       expect(await readFile(join(destination, 'auth.json'), 'utf8')).toBe(
         '{"tokens":{"access_token":"secret"}}'
       )
-      expect((await stat(join(destination, 'auth.json'))).mode & 0o777).toBe(0o600)
+      if (process.platform !== 'win32') {
+        expect((await stat(join(destination, 'auth.json'))).mode & 0o777).toBe(0o600)
+      }
       expect(await readFile(join(destination, 'config.toml'), 'utf8')).toBe(
         'model = "app-default"\n'
       )
@@ -236,7 +238,9 @@ describe('importCodexAuthentication', () => {
           ''
         ].join('\n')
       )
-      expect((await stat(join(destination, 'config.toml'))).mode & 0o777).toBe(0o600)
+      if (process.platform !== 'win32') {
+        expect((await stat(join(destination, 'config.toml'))).mode & 0o777).toBe(0o600)
+      }
 
       await writeFile(join(source, 'config.toml'), 'model = "private-model"\n')
       await importCodexAuthentication(source, destination)

--- a/src/main/settings/service.ts
+++ b/src/main/settings/service.ts
@@ -1443,10 +1443,14 @@ class SettingsService {
     } catch (error) {
       const message =
         error instanceof Error ? error.message : 'Could not preview the installed skill.'
-      const redacted = [sourcePath, requestedSourcePath].reduce(
-        (value, hostPath) => (hostPath ? value.split(hostPath).join(sourceLabel) : value),
-        message
-      )
+      const redacted = [sourcePath, requestedSourcePath].reduce((value, hostPath) => {
+        if (!hostPath) return value
+        return value
+          .split(`${hostPath}${sep}`)
+          .join(`${sourceLabel}/`)
+          .split(hostPath)
+          .join(sourceLabel)
+      }, message)
       throw new Error(redacted)
     }
   }

--- a/src/main/storage/data-migration.test.ts
+++ b/src/main/storage/data-migration.test.ts
@@ -103,7 +103,11 @@ describe('copyAndVerify', () => {
       dirs: ['artifacts', 'uploads'],
       signal: new AbortController().signal,
       onProgress: (progress) => {
-        if (!corrupted && progress.phase === 'copy' && progress.currentPath === 'artifacts/a.txt') {
+        if (
+          !corrupted &&
+          progress.phase === 'copy' &&
+          progress.currentPath === join('artifacts', 'a.txt')
+        ) {
           corrupted = true
           writeFileSync(join(to, 'artifacts', 'a.txt'), 'jello artifacts')
         }
@@ -111,7 +115,7 @@ describe('copyAndVerify', () => {
     })
 
     expect(result.ok).toBe(false)
-    if (!result.ok) expect(result.error).toMatch(/verification failed.*artifacts\/a\.txt/i)
+    if (!result.ok) expect(result.error).toMatch(/verification failed.*a\.txt/i)
     expect(await readFile(join(from, 'artifacts', 'a.txt'), 'utf8')).toBe('hello artifacts')
     expect(await exists(join(to, 'artifacts'))).toBe(false)
   })

--- a/src/main/storage/provenance-migration-validation.test.ts
+++ b/src/main/storage/provenance-migration-validation.test.ts
@@ -107,7 +107,7 @@ describe('validateProvenanceMigrationState', () => {
     await writeFile(join(dataRoot, 'open-science.db'), 'not the authority database')
 
     await expect(validateProvenanceMigrationState(dataRoot, authorityRoot)).resolves.toBeUndefined()
-  })
+  }, 30_000)
 
   it('accepts an Upload input whose frozen name is the original pre-sanitized filename', async () => {
     const client = createProjectDbClient(root)


### PR DESCRIPTION
## Problem

The advisory Windows full-suite run [#30528625655](https://github.com/aipoch/open-science/actions/runs/30528625655) reported 74 failures across both shards. The failures mixed real host/target path-boundary bugs, POSIX-only test fixtures executed on Windows, a cross-client provenance race, and timeout cascades from Windows SQLite/disk contention.

## Proposed change

- Keep workspace-relative logical paths POSIX-shaped while continuing to use native paths for local filesystem access.
- Normalize compute IPC job summaries through the same logical-path helper used by live notifications and results.
- Respect the injected target platform when composing Conda paths, cache paths, and PATH values.
- Normalize Windows path separators/casing for environment ownership and settings error redaction.
- Serialize provenance lineage allocation across repository instances that share the same storage root.
- Make test fixtures platform-aware and skip only tests that execute a real POSIX shell on Windows.
- Run each Windows shard with one Vitest worker and bounded 30-second test/hook budgets for hosted-runner I/O contention.
- Give the small set of filesystem/SQLite integration fixtures enough time for GitHub-hosted Windows disk latency.

## Scope and non-goals

This keeps the Windows workflow advisory and retains its existing two-shard layout and 25-minute job limit. It does not change Linux/macOS CI concurrency, release gating, or the runtime behavior of POSIX shell launchers.

## Acceptance criteria and validation

Each listed check ran after the last material edit to the behavior it covers. Typecheck, lint, and the
complete local suite ran again after the final code/workflow edit.

- Type safety -> `npm run typecheck` -> passed (node and web).
- Lint rules -> `npm run lint` -> passed with 0 errors and 23 existing warnings.
- Complete local behavior -> `npm test -- --maxWorkers=2 --testTimeout=30000 --hookTimeout=30000` -> passed: 555 files, 8,137 tests; 11 files/139 tests skipped by existing or platform gates.
- Compute IPC logical paths -> `npm test -- src/main/compute/ipc.test.ts --maxWorkers=1` -> passed: 1 file, 47 tests, including fixed `/`-separated paths.
- Windows timeout policy and formerly slow files -> `npm test -- scripts/windows-release-workflows.test.ts src/main/compute/job-repository.test.ts src/main/reviewer/orchestrator.test.ts src/main/session-persistence/artifact-finalization-recovery.integration.test.ts --maxWorkers=1 --testTimeout=30000 --hookTimeout=30000` -> passed: 4 files, 42 tests.
- Native Windows full suite -> [Actions #30542337085](https://github.com/aipoch/open-science/actions/runs/30542337085) -> passed: both shards completed successfully on commit `918e8bd`.

## Review focus

- The logical-path/native-path boundary in compute payloads.
- The scope and cleanup of the process-wide provenance lineage queue.
- Whether the Windows-only skips are limited to tests that actually invoke POSIX shells.
- Whether serial files are the right reliability/throughput tradeoff for this advisory workflow.

Uncovered risk: the serial Windows configuration and 30-second per-test/hook budgets trade throughput and faster hang detection for stability. Validation covers GitHub-hosted `windows-latest`; the 25-minute job ceiling remains the backstop for a real hang. The first independent Codex review found one incomplete IPC path producer, which is fixed in `6e2d391`; the final-head review on `918e8bd` is mergeable with no actionable findings.
