### PR TITLE
feat(specialist): add personal specialists with capabilities and session binding

### DIFF
--- a/resources/notebook/repl_loop.js
+++ b/resources/notebook/repl_loop.js
@@ -919,7 +919,12 @@ async function hostMcp(server, method, args = undefined, kwargs = undefined) {
   const res = await capturedFetch(RPC_ENDPOINT, {
     method: 'POST',
     headers: { 'content-type': 'application/json', authorization: 'Bearer ' + (RPC_TOKEN || '') },
-    body: JSON.stringify({ method: 'mcpCall', params: { server, method, args: callArgs } })
+    // Forward the notebook session id so the RPC server resolves the ACP session + specialist scope.
+    // Without it the ConnectorService gate rejects the call with missing_session.
+    body: JSON.stringify({
+      method: 'mcpCall',
+      params: { server, method, args: callArgs, sessionId: COMPUTE_SESSION_ID }
+    })
   })
   const body = await res.json().catch(() => ({}))
   if (!res.ok) throw new Error(body.error || 'host.mcp HTTP ' + res.status)

--- a/src/main/acp/ipc.test.ts
+++ b/src/main/acp/ipc.test.ts
@@ -124,6 +124,9 @@ const registerWithFakes = (overrides?: {
   onSessionCancellationRequested?: (sessionId: string) => void
   onSessionUnavailable?: (sessionId: string) => void
   onAllSessionsCancellationRequested?: () => void
+  profileService?: { getById: (id: string) => Promise<unknown> }
+  specialistSkillCatalog?: Array<{ id: string; frameworkName: string; displayName: string }>
+  provisionedConnectorSkillNames?: string[]
 }): void => {
   const taskNotifications =
     overrides?.taskNotifications ??
@@ -141,13 +144,20 @@ const registerWithFakes = (overrides?: {
     authorizeSkillImportReferencedUploads: vi.fn(async () => () => undefined),
     settingsService: {
       captureActiveAgentBackendSelection: vi.fn().mockResolvedValue({}),
-      resolveAgentBackend: vi.fn().mockResolvedValue({})
+      resolveAgentBackend: vi.fn().mockResolvedValue({}),
+      listSpecialistSkillCatalog: vi
+        .fn()
+        .mockResolvedValue(overrides?.specialistSkillCatalog ?? []),
+      provisionedConnectorSkillNames: vi
+        .fn()
+        .mockResolvedValue(overrides?.provisionedConnectorSkillNames ?? [])
     } as never,
     taskNotifications: taskNotifications as never,
     onSessionCancellationRequested: overrides?.onSessionCancellationRequested,
     onSessionUnavailable: overrides?.onSessionUnavailable,
     onAllSessionsCancellationRequested: overrides?.onAllSessionsCancellationRequested,
-    initializationBarrier: overrides?.initializationBarrier
+    initializationBarrier: overrides?.initializationBarrier,
+    profileService: overrides?.profileService as never
   }
 
   registerAcpIpcHandlers(options)
@@ -169,6 +179,114 @@ afterEach(() => {
   sendPrompt.mockReset()
   sendPrompt.mockResolvedValue(undefined)
   errorLogSpy.mockClear()
+  AcpRuntimeMock.mockClear()
+})
+
+describe('registerAcpIpcHandlers — Specialist identity resolver', () => {
+  it('passes a ProfileService-backed resolver into each runtime', async () => {
+    const profile = {
+      name: 'RNA-seq Reviewer',
+      systemPrompt: 'Review RNA-seq quality.',
+      enabled: true
+    }
+    const profileService = { getById: vi.fn().mockResolvedValue(profile) }
+
+    registerWithFakes({ profileService })
+
+    const options = AcpRuntimeMock.mock.calls.at(-1)?.[0] as {
+      resolveSpecialistIdentity?: (id: string, framework: string) => Promise<unknown>
+    }
+    expect(options.resolveSpecialistIdentity).toBeTypeOf('function')
+    await expect(
+      options.resolveSpecialistIdentity?.('uuid-1', 'claude-code')
+    ).resolves.toMatchObject({
+      append: expect.stringContaining('RNA-seq Reviewer'),
+      prefix: ''
+    })
+    expect(profileService.getById).toHaveBeenCalledWith('uuid-1')
+  })
+
+  it('wires the production ProfileService and live catalog into the Specialist Skill resolver', async () => {
+    const profileService = {
+      getById: vi.fn().mockResolvedValue({
+        enabled: true,
+        capabilityMode: 'selected',
+        fullAccess: { excludedSkillIds: [], excludedConnectorIds: [], connectorTools: [] },
+        selectedCapabilities: { skillIds: ['main-disabled'], connectorIds: [], connectorTools: [] }
+      })
+    }
+    registerWithFakes({
+      profileService,
+      specialistSkillCatalog: [
+        { id: 'main-disabled', frameworkName: 'Main Disabled', displayName: 'Main Disabled' }
+      ]
+    })
+    const options = AcpRuntimeMock.mock.calls.at(-1)?.[0] as {
+      resolveSpecialistSkills?: (id: string) => Promise<unknown>
+    }
+    await expect(options.resolveSpecialistSkills?.('uuid-1')).resolves.toEqual({
+      kind: 'specialist',
+      skillIds: ['main-disabled'],
+      frameworkNames: ['Main Disabled'],
+      missingSkillIds: []
+    })
+  })
+
+  it('merges only the specialist-allowed connector skills into the whitelist (selected mode)', async () => {
+    const profileService = {
+      getById: vi.fn().mockResolvedValue({
+        enabled: true,
+        capabilityMode: 'selected',
+        fullAccess: { excludedSkillIds: [], excludedConnectorIds: [], connectorTools: [] },
+        selectedCapabilities: {
+          skillIds: ['skill-a'],
+          connectorIds: ['chemistry'],
+          connectorTools: []
+        }
+      })
+    }
+    registerWithFakes({
+      profileService,
+      specialistSkillCatalog: [{ id: 'skill-a', frameworkName: 'Skill A', displayName: 'Skill A' }],
+      provisionedConnectorSkillNames: ['mcp-chemistry', 'mcp-literature']
+    })
+    const options = AcpRuntimeMock.mock.calls.at(-1)?.[0] as {
+      resolveSpecialistSkills?: (id: string) => Promise<unknown>
+    }
+    const result = (await options.resolveSpecialistSkills?.('uuid-1')) as {
+      frameworkNames: string[]
+    }
+    // Selected mode: only connectorIds are allowed, so mcp-literature is filtered out.
+    expect(result.frameworkNames).toEqual(['Skill A', 'mcp-chemistry'])
+  })
+
+  it('excludes full-access blocked connectors from the whitelist (full mode)', async () => {
+    const profileService = {
+      getById: vi.fn().mockResolvedValue({
+        enabled: true,
+        capabilityMode: 'full',
+        fullAccess: {
+          excludedSkillIds: [],
+          excludedConnectorIds: ['literature'],
+          connectorTools: []
+        },
+        selectedCapabilities: { skillIds: [], connectorIds: [], connectorTools: [] }
+      })
+    }
+    registerWithFakes({
+      profileService,
+      specialistSkillCatalog: [],
+      provisionedConnectorSkillNames: ['mcp-chemistry', 'mcp-literature']
+    })
+    const options = AcpRuntimeMock.mock.calls.at(-1)?.[0] as {
+      resolveSpecialistSkills?: (id: string) => Promise<unknown>
+    }
+    const result = (await options.resolveSpecialistSkills?.('uuid-1')) as {
+      frameworkNames: string[]
+    }
+    // Full mode: all connectors except excludedConnectorIds; literature is excluded.
+    expect(result.frameworkNames).toEqual(['mcp-chemistry'])
+  })
 })
 
 describe('registerAcpIpcHandlers — Skill import cancellation lifecycle', () => {

--- a/src/main/acp/ipc.ts
+++ b/src/main/acp/ipc.ts
@@ -41,6 +41,15 @@ import type { UploadRepository } from '../uploads/repository'
 import { broadcastToRenderers } from '../renderer-broadcast'
 import { withDataRootWrite } from '../storage/migration-state'
 import { createLogger, errorLogFields } from '../logger'
+import type { ProfileService } from '../specialist/service'
+import {
+  buildSpecialistIdentityAppend,
+  buildSpecialistIdentityPrefix
+} from '../specialist/identity'
+import {
+  resolveEffectiveSpecialistSkills,
+  filterSpecialistConnectorSkills
+} from '../../shared/specialist'
 
 const log = createLogger('acp')
 
@@ -79,6 +88,9 @@ type AcpIpcOptions = AcpIpcArtifacts & {
   onSessionCancellationRequested?: (sessionId: string) => void
   onSessionUnavailable?: (sessionId: string) => void
   onAllSessionsCancellationRequested?: () => void
+  // Provides fresh Specialist Profiles for first-turn identity injection. Optional so existing
+  // tests and headless setups that construct the runtime without specialist support are unaffected.
+  profileService?: ProfileService
 }
 
 // Sends one runtime payload to every currently open renderer window.
@@ -113,7 +125,8 @@ const createRuntime = ({
   onSkillImportAttachmentEligible,
   onSessionCancellationRequested,
   onSessionUnavailable,
-  onAllSessionsCancellationRequested
+  onAllSessionsCancellationRequested,
+  profileService
 }: AcpIpcOptions): AcpRuntimeCoordinator => {
   const configRoot = resolveConfigRoot()
   const dataRoot = resolveDataRoot()
@@ -182,6 +195,8 @@ const createRuntime = ({
           getRpcConnection: () => notebookRpcServer.ensureStarted(),
           registerSessionAlias: (aliasSessionId, sessionId) =>
             notebookRpcServer.registerSessionAlias(aliasSessionId, sessionId),
+          registerSessionSpecialist: (sessionId, specialistId) =>
+            notebookRpcServer.registerSessionSpecialist(sessionId, specialistId),
           setArtifactProvenanceContext: (sessionId, context) =>
             notebookRpcServer.setArtifactProvenanceContext(sessionId, context),
           registerTurnInputs: (request) => notebookRpcServer.registerNotebookTurnInputs(request)
@@ -196,7 +211,60 @@ const createRuntime = ({
         },
         activityGroups: { mcpEntryPath },
         callbacks: runtimeCallbacks,
-        permissionGrantStore
+        permissionGrantStore,
+        // Main process resolves the latest Profile so the renderer never needs to send systemPrompt.
+        resolveSpecialistIdentity: profileService
+          ? async (specialistId: string, frameworkId: string) => {
+              let profile
+              try {
+                profile = await profileService.getById(specialistId)
+              } catch {
+                // Profile not found or corrupt
+                return undefined
+              }
+              if (!profile.enabled) return undefined
+              const append = buildSpecialistIdentityAppend(profile)
+              const prefix = buildSpecialistIdentityPrefix(profile)
+              // For Claude, only the append matters (session-level meta).
+              // For Codex/OpenCode, only the prefix matters (per-turn).
+              // Return both so the runtime can choose by framework.
+              if (frameworkId === 'claude-code') return { append, prefix: '' }
+              return { append: '', prefix }
+            }
+          : undefined,
+        resolveSpecialistSkills: profileService
+          ? async (specialistId) => {
+              try {
+                const profile = await profileService.getById(specialistId)
+                if (!profile.enabled) {
+                  return { kind: 'unavailable', reason: 'The bound specialist is disabled.' }
+                }
+                const effective = resolveEffectiveSpecialistSkills(
+                  profile,
+                  await settingsService.listSpecialistSkillCatalog()
+                )
+                if (effective.kind === 'specialist') {
+                  // Connector tools are delivered as mcp-<id> skills on disk. Claude's options.skills
+                  // whitelist is restrictive, so without these names the agent cannot load the connector
+                  // skill docs and never discovers the tools. Include only the connectors this specialist
+                  // is allowed to use (selectedCapabilities.connectorIds, or all minus full-access
+                  // exclusions) so discovery matches the capability scope; the per-call ConnectorService
+                  // gate still enforces the same config at call time.
+                  const provisioned = await settingsService.provisionedConnectorSkillNames()
+                  const connectorSkills = filterSpecialistConnectorSkills(provisioned, profile)
+                  if (connectorSkills.length > 0) {
+                    return {
+                      ...effective,
+                      frameworkNames: [...effective.frameworkNames, ...connectorSkills]
+                    }
+                  }
+                }
+                return effective
+              } catch {
+                return { kind: 'unavailable', reason: 'The bound specialist is unavailable.' }
+              }
+            }
+          : undefined
       })
     },
     callbacks,

--- a/src/main/acp/runtime-coordinator.test.ts
+++ b/src/main/acp/runtime-coordinator.test.ts
@@ -45,6 +45,7 @@ const createFakeRuntime = (options: {
   connect: ReturnType<typeof vi.fn>
   createSession: ReturnType<typeof vi.fn>
   resetSessionContext: ReturnType<typeof vi.fn>
+  switchSpecialist: ReturnType<typeof vi.fn>
   compactSession: ReturnType<typeof vi.fn>
   resumeSession: ReturnType<typeof vi.fn>
   cancelPrompt: ReturnType<typeof vi.fn>
@@ -88,6 +89,7 @@ const createFakeRuntime = (options: {
     frameworkId: options.frameworkId,
     contextReset: true
   }))
+  const switchSpecialist = vi.fn(async () => ({ contextReset: false }))
   const compactSession = vi.fn(async () => ({ stopReason: 'end_turn' }))
   const cancelPrompt = vi.fn(async () => snapshot)
   const deleteSession = vi.fn(async ({ sessionId }: { sessionId: string }) => {
@@ -151,6 +153,7 @@ const createFakeRuntime = (options: {
     createSession,
     resumeSession,
     resetSessionContext,
+    switchSpecialist,
     compactSession,
     cancelPrompt,
     deleteSession,
@@ -188,6 +191,7 @@ const createFakeRuntime = (options: {
     connect,
     createSession,
     resetSessionContext,
+    switchSpecialist,
     compactSession,
     resumeSession,
     cancelPrompt,
@@ -219,6 +223,25 @@ const createFakeRuntime = (options: {
 }
 
 describe('AcpRuntimeCoordinator', () => {
+  it('forwards switchSpecialist to the owning runtime and returns its contextReset flag', async () => {
+    const created: ReturnType<typeof createFakeRuntime>[] = []
+    const coordinator = new AcpRuntimeCoordinator((callbacks) => {
+      const fake = createFakeRuntime({
+        frameworkId: 'claude-code',
+        sessionIds: [`session-${created.length + 1}`],
+        callbacks
+      })
+      created.push(fake)
+      return fake.runtime
+    })
+    const session = await coordinator.createSession()
+
+    const result = await coordinator.switchSpecialist(session.sessionId, 'sp-b')
+
+    expect(created[0].switchSpecialist).toHaveBeenCalledWith(session.sessionId, 'sp-b')
+    expect(result).toEqual({ contextReset: false })
+  })
+
   it('routes native compaction to the session owner and publishes only owned capabilities', async () => {
     const created: ReturnType<typeof createFakeRuntime>[] = []
     const coordinator = new AcpRuntimeCoordinator((callbacks) => {

--- a/src/main/acp/runtime-coordinator.ts
+++ b/src/main/acp/runtime-coordinator.ts
@@ -257,6 +257,17 @@ class AcpRuntimeCoordinator {
     return response
   }
 
+  // Hot-switches the specialist on a live session. Delegates to the owning runtime so a framework
+  // generation switch cannot strand a binding on a retired runtime.
+  async switchSpecialist(
+    sessionId: string,
+    specialistId: string | undefined
+  ): Promise<{ contextReset: boolean }> {
+    await this.waitForInitialization()
+    const runtime = this.runtimeForSession(sessionId)
+    return runtime.switchSpecialist(sessionId, specialistId)
+  }
+
   async compactSession(request: AcpCompactSessionRequest): Promise<AcpStateSnapshot> {
     await this.waitForInitialization()
     await this.runtimeForSession(request.sessionId).compactSession(request)

--- a/src/main/acp/runtime.test.ts
+++ b/src/main/acp/runtime.test.ts
@@ -11690,3 +11690,115 @@ describe('prompt streaming after a context reset', () => {
     })
   })
 })
+
+describe('Specialist Skill scoping', () => {
+  const specialistSkillResolver = (
+    specialistId: string
+  ): Promise<{
+    kind: 'specialist'
+    skillIds: string[]
+    frameworkNames: string[]
+    missingSkillIds: string[]
+  }> =>
+    Promise.resolve(
+      specialistId === 'zero'
+        ? { kind: 'specialist' as const, skillIds: [], frameworkNames: [], missingSkillIds: [] }
+        : {
+            kind: 'specialist' as const,
+            skillIds: ['allowed'],
+            frameworkNames: ['Allowed Skill'],
+            missingSkillIds: []
+          }
+    )
+
+  it('sends Claude an exact whitelist and rejects an out-of-scope forced chip', async () => {
+    const process = new FakeAgentProcess()
+    const agent = startFakeAgent(process, ['specialist-session'])
+    const runtime = new AcpRuntime({
+      appVersion: '0.1.0',
+      defaultCwd: '/workspace',
+      spawnAgent: () => asAgentProcess(process),
+      framework: claudeCodeFramework,
+      resolveSpecialistIdentity: async () => ({ append: 'Specialist identity', prefix: '' }),
+      resolveSpecialistSkills: async () => ({
+        kind: 'specialist',
+        skillIds: ['allowed'],
+        frameworkNames: ['Allowed Skill'],
+        missingSkillIds: []
+      })
+    })
+
+    const session = await runtime.createSession({ cwd: '/workspace', specialistId: 'sp-1' })
+    expect(agent.newSessions[0]?._meta).toMatchObject({
+      claudeCode: { options: { skills: ['Allowed Skill'] } }
+    })
+    await expect(
+      runtime.sendPrompt({
+        sessionId: session.sessionId,
+        text: 'bypass',
+        forcedSkillIds: ['blocked']
+      })
+    ).rejects.toThrow('not available to the active specialist')
+    expect(agent.prompts).toHaveLength(0)
+  })
+
+  it.each([codexFramework, opencodeFramework])(
+    'adds allowed-Skill guidance on every %s turn',
+    async (framework) => {
+      const process = new FakeAgentProcess()
+      const agent = startFakeAgent(process, ['guided-session'], {
+        modes: createModes(['read-only', 'agent', 'agent-full-access'], 'agent')
+      })
+      const runtime = new AcpRuntime({
+        appVersion: '0.1.0',
+        defaultCwd: '/workspace',
+        spawnAgent: () => asAgentProcess(process),
+        framework,
+        resolveSpecialistIdentity: async () => ({ append: '', prefix: 'Specialist identity' }),
+        resolveSpecialistSkills: specialistSkillResolver
+      })
+
+      const session = await runtime.createSession({ cwd: '/workspace', specialistId: 'sp-1' })
+      await runtime.sendPrompt({ sessionId: session.sessionId, text: 'work' })
+      await runtime.sendPrompt({ sessionId: session.sessionId, text: 'continue' })
+      expect(agent.prompts[0]?.text).toContain('Allowed Specialist Skills for this session')
+      expect(agent.prompts[0]?.text).toContain('Allowed Skill')
+      expect(agent.prompts[1]?.text).toContain('Allowed Specialist Skills for this session')
+    }
+  )
+
+  it('sends the current whitelist on ACP resume, with empty Specialist distinct from Main', async () => {
+    const process = new FakeAgentProcess()
+    const agent = startFakeAgent(process, ['unused'])
+    const runtime = new AcpRuntime({
+      appVersion: '0.1.0',
+      defaultCwd: '/workspace',
+      spawnAgent: () => asAgentProcess(process),
+      framework: claudeCodeFramework,
+      resolveSpecialistSkills: specialistSkillResolver
+    })
+    await runtime.resumeSession({ sessionId: 'restored', cwd: '/workspace', specialistId: 'zero' })
+    expect(agent.resumedSessions[0]?._meta).toMatchObject({
+      claudeCode: { options: { skills: [] } }
+    })
+  })
+
+  it('omits Claude skills only for unbound Main while a zero-Skill Specialist sends []', async () => {
+    const process = new FakeAgentProcess()
+    const agent = startFakeAgent(process, ['zero-session', 'main-session'])
+    const runtime = new AcpRuntime({
+      appVersion: '0.1.0',
+      defaultCwd: '/workspace',
+      spawnAgent: () => asAgentProcess(process),
+      framework: claudeCodeFramework,
+      resolveSpecialistIdentity: async () => ({ append: '', prefix: '' }),
+      resolveSpecialistSkills: specialistSkillResolver
+    })
+    await runtime.createSession({ cwd: '/workspace', specialistId: 'zero' })
+    await runtime.createSession({ cwd: '/workspace' })
+    expect(agent.newSessions[0]?._meta).toMatchObject({ claudeCode: { options: { skills: [] } } })
+    expect(agent.newSessions[1]?._meta).not.toMatchObject({
+      claudeCode: { options: { skills: expect.anything() } }
+    })
+  })
+})

--- a/src/main/acp/runtime.ts
+++ b/src/main/acp/runtime.ts
@@ -46,6 +46,7 @@ import {
   type SessionPermissionProfileState
 } from '../../shared/permission-profiles'
 import { type AgentFrameworkId } from '../../shared/settings'
+import type { EffectiveSpecialistSkills } from '../../shared/specialist'
 import type { ModelReasoningEffort, ResolvedReasoningEffort } from '../../shared/reasoning-effort'
 import {
   claudeCodeFramework,
@@ -204,6 +205,18 @@ type AcpRuntimeOptions = {
   // injectable so tests can drive the degrade-to-file path with small fixtures.
   inlineImageBudgetBytes?: number
   contextUsageTracker?: ContextUsageTracker
+  // Resolves the identity-inject text for a specialist UUID at session-creation time.
+  // The main process reads the latest Profile from ProfileService; the runtime never caches it.
+  // Returns undefined when the specialist is not found, disabled, or its Profile is corrupt —
+  // the caller should have validated before calling createSession.
+  resolveSpecialistIdentity?: (
+    specialistId: string,
+    framework: string
+  ) => Promise<{ append: string; prefix: string } | undefined>
+  // Re-resolves capabilities from the latest Specialist profile and installed catalog. This is
+  // intentionally separate from Main Agent enablement: a Main-disabled installed Skill remains
+  // eligible for a Specialist.
+  resolveSpecialistSkills?: (specialistId: string) => Promise<EffectiveSpecialistSkills>
 }
 
 // Turn-scoped skill force-load hooks, wired from the settings service. Optional so tests that construct
@@ -295,6 +308,7 @@ type AcpRuntimeNotebookOptions = {
   mcpCommand?: string
   getRpcConnection?: () => Promise<NotebookRpcConnection>
   registerSessionAlias?: (aliasSessionId: string, sessionId: string) => void
+  registerSessionSpecialist?: (sessionId: string, specialistId: string | undefined) => void
   setArtifactProvenanceContext?: (
     sessionId: string,
     context: import('../../shared/notebook').NotebookRunProvenanceContext | undefined
@@ -755,6 +769,10 @@ class AcpRuntime {
   // framework while moving to a different on-disk session store, where the old id is not resumable.
   private readonly sessionBackendIds = new Map<string, string>()
   private readonly promptInFlightSessionIds = new Set<string>()
+  // Per-session specialist identity prompt prefix (Codex / OpenCode only). Injected once at
+  // createSession time and prepended to every prompt turn for the session's lifetime.
+  private readonly sessionSpecialistPrefixes = new Map<string, string>()
+  private readonly sessionSpecialistIds = new Map<string, string>()
   // Framework control turns use a separate lock so an overflowed prompt's late `finally` can release
   // only its own prompt lock without making an in-progress native compaction look idle.
   private readonly contextCompactionInFlightSessionIds = new Set<string>()
@@ -1435,6 +1453,32 @@ class AcpRuntime {
       const notebookSessionId = this.createNotebookSessionId()
       const skillImportSessionId = this.createSkillImportSessionId()
 
+      // Resolve specialist identity before starting the ACP session so the identity append is
+      // included in session/new. Main process reads the latest Profile — renderer only sends the UUID.
+      let specialistAppend: string | undefined
+      let specialistPrefix: string | undefined
+      let specialistSkills: EffectiveSpecialistSkills | undefined
+      if (request.specialistId) {
+        if (!this.options.resolveSpecialistIdentity) {
+          // A UUID must never quietly fall back to Main Agent just because startup omitted the
+          // ProfileService wiring. Failing closed preserves the user's selected identity.
+          throw new Error('Specialist identity resolution is unavailable.')
+        }
+        const identity = await this.options.resolveSpecialistIdentity(
+          request.specialistId,
+          this.framework.id
+        )
+        if (!identity) {
+          // Profile is unavailable (disabled, deleted, or corrupt): fail fast.
+          throw new Error(
+            `Specialist ${request.specialistId} is unavailable (disabled, deleted, or corrupt).`
+          )
+        }
+        specialistAppend = identity.append || undefined
+        specialistPrefix = identity.prefix || undefined
+        specialistSkills = await this.options.resolveSpecialistSkills?.(request.specialistId)
+      }
+
       log.info('createSession: createMcpServers', this.diagnosticContext())
       const mcpServers = await this.createMcpServers({
         artifactSessionId,
@@ -1444,13 +1488,22 @@ class AcpRuntime {
         projectName
       })
       log.info('createSession: buildSession', this.diagnosticContext())
+      const extraAppends = specialistAppend ? [specialistAppend] : []
       const session = await connection.agent
         .buildSession({
           cwd: sessionCwd,
           mcpServers,
-          ...this.buildSessionMetaArg()
+          ...this.buildSessionMetaArg(extraAppends, specialistSkills)
         })
         .start()
+
+      // For Codex / OpenCode the specialist identity rides every prompt turn as a prefix.
+      // Store it now; sendPromptTurn reads it when composing each prompt.
+      if (specialistPrefix) {
+        this.sessionSpecialistPrefixes.set(session.sessionId, specialistPrefix)
+      }
+      if (request.specialistId)
+        this.sessionSpecialistIds.set(session.sessionId, request.specialistId)
 
       log.info('createSession: configurePermissionProfile', this.diagnosticContext())
       try {
@@ -1485,6 +1538,7 @@ class AcpRuntime {
       if (this.backendId) this.sessionBackendIds.set(session.sessionId, this.backendId)
       this.rememberArtifactSession(session.sessionId, artifactSessionId)
       this.rememberNotebookSession(session.sessionId, notebookSessionId)
+      this.notebookOptions?.registerSessionSpecialist?.(session.sessionId, request.specialistId)
       this.rememberSkillImportSession(session.sessionId, skillImportSessionId)
       this.currentSessionId = session.sessionId
       this.cwd = sessionCwd
@@ -1553,6 +1607,7 @@ class AcpRuntime {
   private async resumeSessionOperation(
     request: AcpResumeSessionRequest
   ): Promise<AcpCreateSessionResponse> {
+    if (request.specialistId) this.sessionSpecialistIds.set(request.sessionId, request.specialistId)
     const sessionCwd = resolve(request.cwd || this.cwd || this.options.defaultCwd)
     const projectName = this.normalizeProjectName(request.projectName)
 
@@ -1641,6 +1696,69 @@ class AcpRuntime {
     this.contextCompactionInFlightSessionIds.delete(request.sessionId)
 
     return this.adoptFreshSession(connection, request, sessionCwd, projectName)
+  }
+
+  // Hot-switches the specialist bound to a live session. Updates the per-session skills and identity
+  // maps so the next prompt reflects the new specialist. For Claude (identity baked into session
+  // _meta at creation) the agent session is replaced via a context reset so the new identity append
+  // takes effect immediately; Codex/OpenCode carry identity as a per-turn prefix (updated in the map)
+  // and need no reset. Returns `contextReset` so the renderer knows to replay conversation history
+  // into the next prompt (only true for Claude, whose fresh session starts with no provider context).
+  async switchSpecialist(
+    sessionId: string,
+    specialistId: string | undefined
+  ): Promise<{ contextReset: boolean }> {
+    return this.withOperationLease(() => this.switchSpecialistOperation(sessionId, specialistId))
+  }
+
+  private async switchSpecialistOperation(
+    sessionId: string,
+    specialistId: string | undefined
+  ): Promise<{ contextReset: boolean }> {
+    if (this.hasSessionInteractionInFlight(sessionId)) {
+      throw new Error('Cannot switch specialist while the Agent is running.')
+    }
+
+    // Skills map drives per-turn skill resolution for every framework.
+    if (specialistId === undefined) {
+      this.sessionSpecialistIds.delete(sessionId)
+    } else {
+      this.sessionSpecialistIds.set(sessionId, specialistId)
+    }
+
+    // Per-turn identity prefix (Codex / OpenCode). Claude uses a session _meta append instead, which
+    // adoptFreshSession re-bakes from sessionSpecialistIds during the context reset below.
+    if (specialistId !== undefined && this.options.resolveSpecialistIdentity) {
+      const identity = await this.options.resolveSpecialistIdentity(specialistId, this.framework.id)
+      if (identity?.prefix) {
+        this.sessionSpecialistPrefixes.set(sessionId, identity.prefix)
+      } else {
+        this.sessionSpecialistPrefixes.delete(sessionId)
+      }
+    } else {
+      this.sessionSpecialistPrefixes.delete(sessionId)
+    }
+
+    // Keep notebook routing metadata in sync so MCP calls carry the new specialist context.
+    this.notebookOptions?.registerSessionSpecialist?.(sessionId, specialistId)
+
+    // Claude bakes the specialist identity into the session _meta at session/new. A live identity
+    // change therefore requires replacing the agent session so the new append takes effect. Only do
+    // this when a session is actually attached; an unattached session will pick up the new binding
+    // (now recorded in the maps above) when it is later created or resumed.
+    const requiresContextReset = this.framework.id === 'claude-code' && this.sessions.has(sessionId)
+    if (requiresContextReset) {
+      await this.resetSessionContextOperation({
+        sessionId,
+        cwd: this.sessionCwds.get(sessionId),
+        projectName: this.sessionProjectNames.get(sessionId),
+        ...(this.permissionProfiles.get(sessionId)?.selectedProfile
+          ? { permissionProfile: this.permissionProfiles.get(sessionId)!.selectedProfile }
+          : {})
+      } as AcpResumeSessionRequest)
+    }
+
+    return { contextReset: requiresContextReset }
   }
 
   // Invokes the framework's own context compaction command on the attached agent session. The
@@ -1894,7 +2012,10 @@ class AcpRuntime {
         sessionId: request.sessionId,
         cwd: sessionCwd,
         mcpServers,
-        ...this.buildSessionMetaArg()
+        ...this.buildSessionMetaArg(
+          [],
+          await this.resolveCurrentSpecialistSkills(request.sessionId)
+        )
       })
     } catch (error) {
       if (!isUnresumableSessionError(error)) throw error
@@ -1977,11 +2098,18 @@ class AcpRuntime {
       sessionCwd,
       projectName
     })
+    // A freshly adopted session carries no prior _meta, so the specialist identity append (Claude)
+    // must be re-resolved from the live binding. Without this, a context reset or specialist switch
+    // would silently drop the session's specialist identity.
+    const specialistAppend = await this.resolveCurrentSpecialistIdentityAppend(request.sessionId)
     const adopted = await connection.agent
       .buildSession({
         cwd: sessionCwd,
         mcpServers,
-        ...this.buildSessionMetaArg()
+        ...this.buildSessionMetaArg(
+          specialistAppend ? [specialistAppend] : [],
+          await this.resolveCurrentSpecialistSkills(request.sessionId)
+        )
       })
       .start()
 
@@ -2514,6 +2642,28 @@ class AcpRuntime {
       throw new Error('An ACP prompt is already running for this session')
     }
 
+    // A chip can survive a catalog/profile edit in the renderer. Re-resolve immediately before
+    // dispatch so it cannot be used to escape the active Specialist scope.
+    // Avoid yielding for ordinary (non-Specialist) sessions. The prompt lock below is intentionally
+    // claimed in the caller's synchronous turn so a context reset cannot race a just-dispatched prompt
+    // before it has registered ownership. Specialist sessions still await their authoritative scope
+    // resolution before dispatch, preserving the fail-closed validation path.
+    const currentSpecialistSkills =
+      this.sessionSpecialistIds.has(request.sessionId) && this.options.resolveSpecialistSkills
+        ? await this.resolveCurrentSpecialistSkills(request.sessionId)
+        : undefined
+    if (currentSpecialistSkills && currentSpecialistSkills.kind !== 'main') {
+      if (currentSpecialistSkills.kind === 'unavailable') {
+        throw new Error(currentSpecialistSkills.reason)
+      }
+      const rejected = (request.forcedSkillIds ?? []).find(
+        (id) => !currentSpecialistSkills.skillIds.includes(id)
+      )
+      if (rejected) {
+        throw new Error(`Skill "${rejected}" is not available to the active specialist.`)
+      }
+    }
+
     // Turn-scoped skill force-load: a skill the user picked but has toggled off must run this turn only.
     // If any pick is currently disabled, mark the picks forced and respawn the agent (drop the connection,
     // then resume the same session) so the fresh spawn's provisioning materializes them with full context
@@ -2656,11 +2806,20 @@ class AcpRuntime {
       // Framework-neutral delivery of the system-prompt guidance: Claude carries the complete appends in
       // session _meta but repeats the short activity declaration reminder here; frameworks without a
       // session preset carry the complete guidance as a prompt prefix.
-      const { promptPrefix } = this.framework.buildSessionSetup({
-        systemPromptAppends: this.getSystemPromptAppends(),
+      const { promptPrefix: frameworkPromptPrefix } = this.framework.buildSessionSetup({
+        systemPromptAppends: this.getSystemPromptAppends(
+          this.specialistSkillGuidance(currentSpecialistSkills)
+        ),
         turnPromptReminders: this.getTurnPromptReminders(),
         sessionOptions: this.pendingSessionOptions
       })
+      // For Codex/OpenCode, prepend the per-session specialist identity prefix (set at createSession).
+      // Claude carries its identity in session-level _meta; no per-turn prefix needed there.
+      const sessionSpecialistPrefix = this.sessionSpecialistPrefixes.get(request.sessionId)
+      const promptPrefix =
+        [sessionSpecialistPrefix, frameworkPromptPrefix]
+          .filter((segment): segment is string => Boolean(segment))
+          .join('\n\n') || undefined
       const selectorAbortController =
         this.framework.id === 'codex' &&
         forced.length === 0 &&
@@ -3069,6 +3228,8 @@ class AcpRuntime {
     this.skillImportTurnTokens.delete(request.sessionId)
     this.promptInFlightSessionIds.delete(request.sessionId)
     this.contextCompactionInFlightSessionIds.delete(request.sessionId)
+    this.sessionSpecialistPrefixes.delete(request.sessionId)
+    this.sessionSpecialistIds.delete(request.sessionId)
 
     // Only announce a deletion and shift the current session when something was actually attached; a
     // detached cleanup (post-switch) must not emit a spurious event or move currentSessionId.
@@ -4067,7 +4228,7 @@ class AcpRuntime {
     )
   }
 
-  private getSystemPromptAppends(): string[] {
+  private getSystemPromptAppends(skillGuidance?: string): string[] {
     // Each append names MCP tools that only exist when that tooling is actually wired for this session;
     // omit it otherwise so the agent isn't told to use tools it wasn't given.
     return [
@@ -4079,8 +4240,46 @@ class AcpRuntime {
         : []),
       ...(this.artifactToolingAvailable() ? [ARTIFACT_FILE_SYSTEM_PROMPT_APPEND] : []),
       ...(this.notebookToolingAvailable() ? [NOTEBOOK_SYSTEM_PROMPT_APPEND] : []),
-      ...(this.skillImportToolingAvailable() ? [SKILL_IMPORT_SYSTEM_PROMPT_APPEND] : [])
+      ...(this.skillImportToolingAvailable() ? [SKILL_IMPORT_SYSTEM_PROMPT_APPEND] : []),
+      ...(skillGuidance ? [skillGuidance] : [])
     ]
+  }
+
+  private async resolveCurrentSpecialistSkills(
+    sessionId: string
+  ): Promise<EffectiveSpecialistSkills | undefined> {
+    const specialistId = this.sessionSpecialistIds.get(sessionId)
+    if (!specialistId || !this.options.resolveSpecialistSkills) return undefined
+    try {
+      return await this.options.resolveSpecialistSkills(specialistId)
+    } catch {
+      return { kind: 'unavailable', reason: 'The bound specialist is unavailable.' }
+    }
+  }
+
+  // Resolves the session-meta identity APPEND for the session's current specialist binding. Only
+  // meaningful for Claude (append mode); returns undefined for Codex/OpenCode (prefix mode) or when
+  // no specialist is bound. Used by adoptFreshSession so a context reset re-bakes the identity.
+  private async resolveCurrentSpecialistIdentityAppend(
+    sessionId: string
+  ): Promise<string | undefined> {
+    const specialistId = this.sessionSpecialistIds.get(sessionId)
+    if (!specialistId || !this.options.resolveSpecialistIdentity) return undefined
+    try {
+      const identity = await this.options.resolveSpecialistIdentity(specialistId, this.framework.id)
+      return identity?.append || undefined
+    } catch {
+      return undefined
+    }
+  }
+
+  // Codex and OpenCode have no session-native whitelist. Their guidance is intentionally factual
+  // rather than presented as an isolation boundary; enforcement remains the picker/send gate.
+  private specialistSkillGuidance(
+    skills: EffectiveSpecialistSkills | undefined
+  ): string | undefined {
+    if (this.framework.id === 'claude-code' || skills?.kind !== 'specialist') return undefined
+    return `Allowed Specialist Skills for this session:\n${skills.frameworkNames.map((name) => `- ${name}`).join('\n')}`
   }
 
   private getTurnPromptReminders(): string[] {
@@ -4092,10 +4291,22 @@ class AcpRuntime {
   // Builds the ACP `_meta` argument for session/new and session/resume, delegating the framework-specific
   // shape to the active framework. Claude applies its settingSources restriction, resolved backend
   // options, and system-prompt appends; opencode returns no meta and uses a prompt prefix instead.
-  private buildSessionMetaArg(): { _meta?: Record<string, unknown> } {
+  // `extraAppends` lets createSession inject a one-off specialist identity without touching the
+  // shared pendingSystemPromptAppends that apply to every session on this runtime generation.
+  private buildSessionMetaArg(
+    extraAppends: string[] = [],
+    specialistSkills?: EffectiveSpecialistSkills
+  ): { _meta?: Record<string, unknown> } {
+    const skillWhitelist =
+      specialistSkills?.kind === 'specialist'
+        ? specialistSkills.frameworkNames
+        : specialistSkills?.kind === 'unavailable'
+          ? []
+          : undefined
     const setup = this.framework.buildSessionSetup({
-      systemPromptAppends: this.getSystemPromptAppends(),
-      sessionOptions: this.pendingSessionOptions
+      systemPromptAppends: [...this.getSystemPromptAppends(), ...extraAppends],
+      sessionOptions: this.pendingSessionOptions,
+      ...(skillWhitelist !== undefined ? { skillWhitelist } : {})
     })
 
     return setup.meta ? { _meta: setup.meta } : {}

--- a/src/main/agent-framework/claude-code.test.ts
+++ b/src/main/agent-framework/claude-code.test.ts
@@ -40,6 +40,17 @@ describe('claudeCodeFramework', () => {
     })
   })
 
+  it('preserves an explicit empty Specialist whitelist while Main omits it', () => {
+    expect(
+      claudeCodeFramework.buildSessionSetup({ systemPromptAppends: [], skillWhitelist: [] }).meta
+    ).toMatchObject({ claudeCode: { options: { skills: [] } } })
+    expect(
+      claudeCodeFramework.buildSessionSetup({ systemPromptAppends: [] }).meta
+    ).not.toMatchObject({
+      claudeCode: { options: { skills: expect.anything() } }
+    })
+  })
+
   it('renders Open Science MCP tool references as Claude callable names', () => {
     const setup = claudeCodeFramework.buildSessionSetup({
       systemPromptAppends: [

--- a/src/main/agent-framework/claude-code.ts
+++ b/src/main/agent-framework/claude-code.ts
@@ -69,7 +69,8 @@ export const claudeCodeFramework: AgentFramework = {
         options: {
           tools: CLAUDE_CODE_BUILTIN_TOOLS,
           ...ctx.sessionOptions,
-          settingSources: ['user']
+          settingSources: ['user'],
+          ...(ctx.skillWhitelist !== undefined ? { skills: ctx.skillWhitelist } : {})
         }
       }
     }

--- a/src/main/agent-framework/types.ts
+++ b/src/main/agent-framework/types.ts
@@ -88,6 +88,9 @@ export type SessionSetupContext = {
   // Framework-native options resolved with the active backend and applied to every session created
   // on that connection. Claude uses this to inject app-owned settings/plugins into shared auth mode.
   sessionOptions?: Record<string, unknown>
+  // undefined is the Main Agent and must omit the native field; [] is an explicit Specialist
+  // zero-skill whitelist and must be preserved verbatim by supporting frameworks.
+  skillWhitelist?: string[]
 }
 
 // Framework-specific session configuration returned to the runtime. `meta` becomes the ACP `_meta`

--- a/src/main/connectors/service.test.ts
+++ b/src/main/connectors/service.test.ts
@@ -1,6 +1,9 @@
 import { describe, it, expect, vi } from 'vitest'
 import { ConnectorService } from './service'
 import { ParserEngine } from './engine'
+import type { SpecialistProfileView } from '../../shared/specialist'
+
+const internal = { origin: 'internal' as const }
 
 const jsonRes = (body: unknown): Response =>
   ({ ok: true, status: 200, json: async () => body }) as Response
@@ -15,9 +18,9 @@ describe('ConnectorService', () => {
       }),
       resolveApiKey: () => undefined
     })
-    await expect(svc.call('chemistry', 'pubchem_get_compounds', { cids: [1] })).rejects.toThrow(
-      /not enabled/
-    )
+    await expect(
+      svc.call('chemistry', 'pubchem_get_compounds', { cids: [1] }, internal)
+    ).rejects.toThrow(/not enabled/)
   })
   it('treats a bundled connector as enabled by default (opt-out model)', async () => {
     const svc = new ConnectorService({
@@ -25,14 +28,14 @@ describe('ConnectorService', () => {
       resolveApiKey: () => undefined
     })
     // No disabledConnectorIds ⇒ chemistry is enabled, so an unknown method (not enablement) is what fails.
-    await expect(svc.call('chemistry', 'nope', {})).rejects.toThrow(/unknown tool/)
+    await expect(svc.call('chemistry', 'nope', {}, internal)).rejects.toThrow(/unknown tool/)
   })
   it('rejects an unknown method', async () => {
     const svc = new ConnectorService({
       getConnectors: () => ({ enabledIds: ['chemistry'], autoAllowIds: [] }),
       resolveApiKey: () => undefined
     })
-    await expect(svc.call('chemistry', 'nope', {})).rejects.toThrow(/unknown tool/)
+    await expect(svc.call('chemistry', 'nope', {}, internal)).rejects.toThrow(/unknown tool/)
   })
   it('routes an enabled call through the engine with resolved credentials', async () => {
     const fetchImpl = vi
@@ -48,7 +51,7 @@ describe('ConnectorService', () => {
       }),
       resolveApiKey: (ref) => (ref === 'ref' ? 'SECRET' : undefined)
     })
-    const out = await svc.call('chemistry', 'pubchem_get_compounds', { cids: [1] })
+    const out = await svc.call('chemistry', 'pubchem_get_compounds', { cids: [1] }, internal)
     expect(out).toEqual({ n_requested: 1, duplicates: [], records: [{ CID: 1 }], not_found: [] })
   })
   it('routes a bundled tool with a registered local handler through it, not the engine', async () => {
@@ -64,9 +67,12 @@ describe('ConnectorService', () => {
       'molecule',
       'preview_molecule',
       { smiles: 'C' },
-      { sessionId: 's-1' }
+      { origin: 'internal', sessionId: 's-1' }
     )
-    expect(localHandler).toHaveBeenCalledWith({ smiles: 'C' }, { sessionId: 's-1' })
+    expect(localHandler).toHaveBeenCalledWith(
+      { smiles: 'C' },
+      { origin: 'internal', sessionId: 's-1' }
+    )
     expect(out).toEqual({ ok: true })
     expect(engine.call).not.toHaveBeenCalled()
   })
@@ -75,9 +81,9 @@ describe('ConnectorService', () => {
       getConnectors: () => ({ enabledIds: ['molecule'], autoAllowIds: [] }),
       resolveApiKey: () => undefined
     })
-    await expect(svc.call('molecule', 'preview_molecule', { smiles: 'C' })).rejects.toThrow(
-      /handled by the app runtime/
-    )
+    await expect(
+      svc.call('molecule', 'preview_molecule', { smiles: 'C' }, internal)
+    ).rejects.toThrow(/handled by the app runtime/)
   })
   it('rejects a blocked tool', async () => {
     const svc = new ConnectorService({
@@ -88,9 +94,9 @@ describe('ConnectorService', () => {
       }),
       resolveApiKey: () => undefined
     })
-    await expect(svc.call('chemistry', 'pubchem_get_compounds', { cids: [1] })).rejects.toThrow(
-      /blocked by policy/
-    )
+    await expect(
+      svc.call('chemistry', 'pubchem_get_compounds', { cids: [1] }, internal)
+    ).rejects.toThrow(/blocked by policy/)
   })
 
   it('requests approval for an ask-flagged tool and runs it when allowed', async () => {
@@ -108,7 +114,7 @@ describe('ConnectorService', () => {
       resolveApiKey: () => undefined,
       requestApproval
     })
-    const out = await svc.call('chemistry', 'pubchem_get_compounds', { cids: [1] })
+    const out = await svc.call('chemistry', 'pubchem_get_compounds', { cids: [1] }, internal)
     expect(out).toEqual({ n_requested: 1, duplicates: [], records: [{ CID: 1 }], not_found: [] })
     expect(requestApproval).toHaveBeenCalledWith({
       connector: 'chemistry',
@@ -137,7 +143,12 @@ describe('ConnectorService', () => {
       requestApproval
     })
 
-    await svc.call('chemistry', 'pubchem_get_compounds', { cids: [1] }, { sessionId: 'session-42' })
+    await svc.call(
+      'chemistry',
+      'pubchem_get_compounds',
+      { cids: [1] },
+      { origin: 'internal', sessionId: 'session-42' }
+    )
 
     expect(requestApproval).toHaveBeenCalledWith({
       connector: 'chemistry',
@@ -160,9 +171,9 @@ describe('ConnectorService', () => {
       resolveApiKey: () => undefined,
       requestApproval
     })
-    await expect(svc.call('chemistry', 'pubchem_get_compounds', { cids: [1] })).rejects.toThrow(
-      /denied by user/
-    )
+    await expect(
+      svc.call('chemistry', 'pubchem_get_compounds', { cids: [1] }, internal)
+    ).rejects.toThrow(/denied by user/)
     expect(fetchImpl).not.toHaveBeenCalled()
   })
 
@@ -177,7 +188,7 @@ describe('ConnectorService', () => {
       resolveApiKey: () => undefined,
       requestApproval
     })
-    await svc.call('chemistry', 'pubchem_get_compounds', { cids: [1] })
+    await svc.call('chemistry', 'pubchem_get_compounds', { cids: [1] }, internal)
     expect(requestApproval).not.toHaveBeenCalled()
   })
 
@@ -196,7 +207,7 @@ describe('ConnectorService', () => {
       resolveApiKey: () => undefined,
       requestApproval
     })
-    await svc.call('chemistry', 'pubchem_get_compounds', { cids: [1] })
+    await svc.call('chemistry', 'pubchem_get_compounds', { cids: [1] }, internal)
     expect(requestApproval).not.toHaveBeenCalled()
   })
 
@@ -222,7 +233,7 @@ describe('ConnectorService', () => {
         }),
         resolveApiKey: () => undefined
       })
-      const out = await svc.call('myserver', 'do_thing', { x: 1 })
+      const out = await svc.call('myserver', 'do_thing', { x: 1 }, internal)
       expect(out).toEqual({ ok: true })
       expect(call).toHaveBeenCalledWith(
         {
@@ -260,7 +271,7 @@ describe('ConnectorService', () => {
         }),
         resolveApiKey: () => undefined
       })
-      const out = await svc.call('remoteserver', 'do_thing', { x: 1 })
+      const out = await svc.call('remoteserver', 'do_thing', { x: 1 }, internal)
       expect(out).toEqual({ ok: true })
       expect(call).toHaveBeenCalledWith(
         {
@@ -291,7 +302,7 @@ describe('ConnectorService', () => {
         }),
         resolveApiKey: () => undefined
       })
-      await expect(svc.call('myserver', 'do_thing', {})).rejects.toThrow(/not enabled/)
+      await expect(svc.call('myserver', 'do_thing', {}, internal)).rejects.toThrow(/not enabled/)
       expect(call).not.toHaveBeenCalled()
     })
 
@@ -309,7 +320,9 @@ describe('ConnectorService', () => {
         }),
         resolveApiKey: () => undefined
       })
-      await expect(svc.call('myserver', 'dangerous', {})).rejects.toThrow(/blocked by policy/)
+      await expect(svc.call('myserver', 'dangerous', {}, internal)).rejects.toThrow(
+        /blocked by policy/
+      )
       expect(call).not.toHaveBeenCalled()
     })
 
@@ -318,7 +331,7 @@ describe('ConnectorService', () => {
         getConnectors: () => ({ enabledIds: [], autoAllowIds: [], customMcpServers: [] }),
         resolveApiKey: () => undefined
       })
-      await expect(svc.call('nope', 'do_thing', {})).rejects.toThrow(/not enabled/)
+      await expect(svc.call('nope', 'do_thing', {}, internal)).rejects.toThrow(/not enabled/)
     })
 
     it('threads context.sessionId through to requestApproval for custom MCP tools', async () => {
@@ -338,7 +351,12 @@ describe('ConnectorService', () => {
         requestApproval
       })
 
-      await svc.call('myserver', 'do_thing', { x: 1 }, { sessionId: 'session-99' })
+      await svc.call(
+        'myserver',
+        'do_thing',
+        { x: 1 },
+        { origin: 'internal', sessionId: 'session-99' }
+      )
 
       expect(requestApproval).toHaveBeenCalledWith({
         connector: 'myserver',
@@ -347,5 +365,212 @@ describe('ConnectorService', () => {
         sessionId: 'session-99'
       })
     })
+
+    it('fails closed after a custom connector cannot authenticate or start, without exposing its error', async () => {
+      const call = vi
+        .fn()
+        .mockRejectedValue(
+          new Error('401 Unauthorized for https://private.example with Bearer SECRET')
+        )
+      const svc = new ConnectorService({
+        mcpClientManager: { call },
+        getConnectors: () => ({
+          enabledIds: [],
+          autoAllowIds: [],
+          customMcpServers: [
+            {
+              id: 'srv-1',
+              name: 'secured-server',
+              transport: 'streamable_http',
+              url: 'https://private.example/mcp',
+              enabled: false
+            }
+          ]
+        }),
+        resolveApiKey: () => undefined,
+        resolveSpecialistProfile: async () => ({
+          id: 'specialist-1',
+          name: 'Secured Server Bot',
+          description: '',
+          systemPrompt: 'profile secret',
+          enabled: true,
+          capabilityMode: 'selected',
+          fullAccess: { excludedSkillIds: [], excludedConnectorIds: [], connectorTools: [] },
+          selectedCapabilities: {
+            skillIds: [],
+            connectorIds: ['secured-server'],
+            connectorTools: []
+          },
+          revision: 1
+        })
+      })
+      const context = {
+        origin: 'agent' as const,
+        sessionId: 'specialist-session',
+        specialistId: 'specialist-1'
+      }
+      await expect(
+        svc.call('secured-server', 'lookup', { token: 'ARG_SECRET' }, context)
+      ).rejects.toThrow('connector_unauthenticated')
+      await expect(
+        svc.call('secured-server', 'lookup', { token: 'ARG_SECRET' }, context)
+      ).rejects.toThrow('connector_unauthenticated')
+      expect(call).toHaveBeenCalledTimes(1)
+      await svc
+        .call('secured-server', 'lookup', { token: 'ARG_SECRET' }, context)
+        .catch((error: Error) => {
+          expect(error.message).not.toContain('ARG_SECRET')
+          expect(error.message).not.toContain('SECRET')
+          expect(error.message).not.toContain('private.example')
+        })
+    })
+  })
+})
+
+describe('ConnectorService specialist capability gate', () => {
+  const specialist = (overrides: Partial<SpecialistProfileView> = {}): SpecialistProfileView => ({
+    id: 'specialist-1',
+    name: 'Connector Bot',
+    description: '',
+    systemPrompt: 'do not disclose profile-secret-prompt',
+    enabled: true,
+    capabilityMode: 'full',
+    fullAccess: { excludedSkillIds: [], excludedConnectorIds: [], connectorTools: [] },
+    selectedCapabilities: { skillIds: [], connectorIds: [], connectorTools: [] },
+    revision: 1,
+    ...overrides
+  })
+
+  it('keeps Main and Specialist connector scopes independent and enforces both modes before dispatch', async () => {
+    const localHandler = vi.fn().mockResolvedValue({ ok: true })
+    let current = specialist()
+    const svc = new ConnectorService({
+      engine: { call: vi.fn() } as unknown as ParserEngine,
+      getConnectors: () => ({
+        enabledIds: [],
+        autoAllowIds: [],
+        disabledConnectorIds: ['molecule'],
+        blockedToolIds: ['molecule/preview_molecule']
+      }),
+      resolveApiKey: () => undefined,
+      resolveSpecialistProfile: async () => current,
+      localToolHandlers: { 'molecule/preview_molecule': localHandler }
+    })
+
+    // Main remains disabled, while a Specialist that explicitly has Full access can use the installed
+    // connector without inheriting Main's block list.
+    await expect(
+      svc.call('molecule', 'preview_molecule', { smiles: 'SECRET_ARGS' }, internal)
+    ).rejects.toThrow(/connector not enabled/)
+    for (const framework of ['claude-code', 'codex', 'opencode']) {
+      await expect(
+        svc.call(
+          'molecule',
+          'preview_molecule',
+          { smiles: 'SECRET_ARGS' },
+          { origin: 'agent', sessionId: `session-${framework}`, specialistId: current.id }
+        )
+      ).resolves.toEqual({ ok: true })
+    }
+    expect(localHandler).toHaveBeenCalledTimes(3)
+
+    current = specialist({
+      capabilityMode: 'full',
+      fullAccess: { excludedSkillIds: [], excludedConnectorIds: ['molecule'], connectorTools: [] }
+    })
+    await expect(
+      svc.call(
+        'molecule',
+        'preview_molecule',
+        { smiles: 'SECRET_ARGS' },
+        {
+          origin: 'agent',
+          sessionId: 'full-excluded',
+          specialistId: current.id
+        }
+      )
+    ).rejects.toThrow('specialist_capability_denied')
+
+    current = specialist({
+      capabilityMode: 'selected',
+      selectedCapabilities: { skillIds: [], connectorIds: ['chemistry'], connectorTools: [] }
+    })
+    await expect(
+      svc.call(
+        'molecule',
+        'preview_molecule',
+        { smiles: 'SECRET_ARGS' },
+        {
+          origin: 'agent',
+          sessionId: 'selected-omitted',
+          specialistId: current.id
+        }
+      )
+    ).rejects.toThrow('specialist_capability_denied')
+    expect(localHandler).toHaveBeenCalledTimes(3)
+  })
+
+  it('fails closed for missing agent session/profile/connector without exposing call data', async () => {
+    const localHandler = vi.fn()
+    const svc = new ConnectorService({
+      engine: { call: vi.fn() } as unknown as ParserEngine,
+      getConnectors: () => ({ enabledIds: [], autoAllowIds: [] }),
+      resolveApiKey: () => undefined,
+      resolveSpecialistProfile: async () =>
+        specialist({
+          capabilityMode: 'selected',
+          selectedCapabilities: {
+            skillIds: [],
+            connectorIds: ['not-installed'],
+            connectorTools: []
+          }
+        }),
+      localToolHandlers: { 'molecule/preview_molecule': localHandler }
+    })
+    await expect(
+      svc.call('molecule', 'preview_molecule', { token: 'SECRET_ARGS' }, { origin: 'agent' })
+    ).rejects.toThrow('missing_session')
+    await expect(
+      svc.call(
+        'not-installed',
+        'run',
+        { token: 'SECRET_ARGS' },
+        {
+          origin: 'agent',
+          sessionId: 'specialist-session',
+          specialistId: 'specialist-1'
+        }
+      )
+    ).rejects.toThrow('connector_unavailable')
+    await svc
+      .call(
+        'not-installed',
+        'run',
+        { token: 'SECRET_ARGS' },
+        {
+          origin: 'agent',
+          sessionId: 'specialist-session',
+          specialistId: 'specialist-1'
+        }
+      )
+      .catch((error: Error) => {
+        expect(error.message).not.toContain('SECRET_ARGS')
+        expect(error.message).not.toContain('profile-secret-prompt')
+      })
+    expect(localHandler).not.toHaveBeenCalled()
+  })
+
+  it('allows only explicitly marked internal calls to bypass the agent session gate', async () => {
+    const localHandler = vi.fn().mockResolvedValue({ ok: true })
+    const svc = new ConnectorService({
+      engine: { call: vi.fn() } as unknown as ParserEngine,
+      getConnectors: () => ({ enabledIds: [], autoAllowIds: [] }),
+      resolveApiKey: () => undefined,
+      localToolHandlers: { 'molecule/preview_molecule': localHandler }
+    })
+    await expect(
+      svc.call('molecule', 'preview_molecule', {}, { origin: 'internal' })
+    ).resolves.toEqual({ ok: true })
+    await expect(svc.call('molecule', 'preview_molecule', {})).rejects.toThrow('missing_session')
   })
 })

--- a/src/main/connectors/service.ts
+++ b/src/main/connectors/service.ts
@@ -5,6 +5,7 @@ import type { CustomMcpServerConfig } from './mcp-client-manager'
 import type { ConnectorCredentials, ToolDescriptor } from './types'
 import type { StoredConnectors } from '../settings/types'
 import type { ApprovalDecision } from '../../shared/settings'
+import type { SpecialistProfileView } from '../../shared/specialist'
 
 type McpClientManagerLike = {
   call(
@@ -39,12 +40,41 @@ type ConnectorServiceDeps = {
     string,
     (args: Record<string, unknown>, context: ConnectorCallContext) => Promise<unknown>
   >
+  // Resolves the current specialist profile immediately before agent dispatch. This is intentionally
+  // a function (rather than a session-start snapshot) so edited/deleted profiles take effect on the
+  // next connector call.
+  resolveSpecialistProfile?: (specialistId: string) => Promise<SpecialistProfileView | undefined>
 }
 
 // Optional routing context for a connector call. Present for calls that originate inside a session
 // (e.g. notebook host.mcp); absent for context-free callers.
 export type ConnectorCallContext = {
   sessionId?: string
+  // Agent calls are untrusted model output and must be tied to a known session. Internal callers
+  // must opt in explicitly so they cannot accidentally inherit a session capability scope.
+  origin?: 'agent' | 'internal'
+  // This field is populated only by the main-process session registry, never from connector RPC
+  // parameters. It selects an independent Specialist capability configuration for this call.
+  specialistId?: string
+}
+
+type ConnectorAccess = {
+  bypassMainEnablement: boolean
+  bypassMainPolicy: boolean
+  specialistScoped: boolean
+}
+
+// Deliberately contains only a stable category. In particular it must not interpolate connector
+// arguments, custom-server headers, credentials, or a Specialist's system prompt into an error that
+// may be rendered back to an agent.
+class ConnectorGateError extends Error {
+  constructor(
+    readonly category: string,
+    message = `connector call rejected: ${category}`
+  ) {
+    super(message)
+    this.name = 'ConnectorGateError'
+  }
 }
 
 // Agent-agnostic gate: enforces enabled state + per-tool policy, prompts for approval on un-trusted
@@ -52,6 +82,12 @@ export type ConnectorCallContext = {
 // user-added custom MCP server's McpClientManager. See docs/internal/2026-07-12-custom-mcp-connectors-plan4.md §3.2.
 export class ConnectorService {
   private readonly engine: ParserEngine
+  // A connector that cannot authenticate or start is physically unavailable to every scope. Main
+  // enablement is only a logical preference and may be overridden by a Specialist; this state may not.
+  private readonly unavailableCustomConnectors = new Map<
+    string,
+    'connector_unavailable' | 'connector_unauthenticated'
+  >()
   constructor(private readonly deps: ConnectorServiceDeps) {
     this.engine = deps.engine ?? new ParserEngine()
   }
@@ -67,15 +103,50 @@ export class ConnectorService {
     args: Record<string, unknown>,
     context: ConnectorCallContext = {}
   ): Promise<unknown> {
+    const access = await this.resolveAccess(connector, context)
     const descriptor = getDescriptor(connector, method)
     const isBundled = descriptor !== undefined || ALL_CONNECTOR_IDS.includes(connector)
-    if (isBundled) return this.callBundled(connector, method, args, descriptor, context)
+    if (isBundled) return this.callBundled(connector, method, args, descriptor, context, access)
 
     const custom = (this.deps.getConnectors()?.customMcpServers ?? []).find(
       (s) => s.name === connector
     )
-    if (!custom) throw new Error(`connector not enabled: ${connector}`)
-    return this.callCustom(custom, method, args, context)
+    if (!custom) {
+      throw new ConnectorGateError(
+        'connector_unavailable',
+        access.specialistScoped ? undefined : `connector not enabled: ${connector}`
+      )
+    }
+    return this.callCustom(custom, method, args, context, access)
+  }
+
+  private async resolveAccess(
+    connector: string,
+    context: ConnectorCallContext
+  ): Promise<ConnectorAccess> {
+    if (context.origin === 'internal') {
+      return { bypassMainEnablement: false, bypassMainPolicy: false, specialistScoped: false }
+    }
+    // No call may silently become "internal". Agent entry points must mark their origin and supply a
+    // session; internal code must make the same origin declaration explicitly.
+    if (!context.sessionId) throw new ConnectorGateError('missing_session')
+    if (!context.specialistId) {
+      return { bypassMainEnablement: false, bypassMainPolicy: false, specialistScoped: false }
+    }
+    if (!this.deps.resolveSpecialistProfile) throw new ConnectorGateError('specialist_unavailable')
+
+    const profile = await this.deps.resolveSpecialistProfile(context.specialistId)
+    if (!profile || !profile.enabled) throw new ConnectorGateError('specialist_unavailable')
+
+    const allowed =
+      profile.capabilityMode === 'full'
+        ? !profile.fullAccess.excludedConnectorIds.includes(connector)
+        : profile.selectedCapabilities.connectorIds.includes(connector)
+    if (!allowed) throw new ConnectorGateError('specialist_capability_denied')
+
+    // A Specialist's configuration is independent from Main's enabled and Allow/Ask/Block settings.
+    // Physical availability is still checked by the actual bundled/custom dispatch path below.
+    return { bypassMainEnablement: true, bypassMainPolicy: true, specialistScoped: true }
   }
 
   private async callBundled(
@@ -83,15 +154,21 @@ export class ConnectorService {
     method: string,
     args: Record<string, unknown>,
     descriptor: ToolDescriptor | undefined,
-    context: ConnectorCallContext
+    context: ConnectorCallContext,
+    access: ConnectorAccess
   ): Promise<unknown> {
-    if (!this.isEnabled(connector)) throw new Error(`connector not enabled: ${connector}`)
-    if (!descriptor) throw new Error(`unknown tool: ${connector}/${method}`)
-
-    if (this.isBlocked(connector, method)) {
-      throw new Error(`tool blocked by policy: ${connector}/${method}`)
+    if (!access.bypassMainEnablement && !this.isEnabled(connector)) {
+      throw new ConnectorGateError('connector_disabled', `connector not enabled: ${connector}`)
     }
-    await this.ensureApproved(connector, method, args, context.sessionId)
+    if (!descriptor)
+      throw new ConnectorGateError('connector_unavailable', `unknown tool: ${connector}/${method}`)
+
+    if (!access.bypassMainPolicy && this.isBlocked(connector, method)) {
+      throw new ConnectorGateError('tool_blocked', `tool blocked by policy: ${connector}/${method}`)
+    }
+    if (!access.bypassMainPolicy) {
+      await this.ensureApproved(connector, method, args, context.sessionId)
+    }
 
     // Bundled tools that need privileged local behavior run here, after the same gate, instead of the
     // read-only HTTP engine.
@@ -105,16 +182,49 @@ export class ConnectorService {
     custom: NonNullable<StoredConnectors['customMcpServers']>[number],
     method: string,
     args: Record<string, unknown>,
-    context: ConnectorCallContext
+    context: ConnectorCallContext,
+    access: ConnectorAccess
   ): Promise<unknown> {
-    if (!custom.enabled) throw new Error(`connector not enabled: ${custom.name}`)
-    if (this.isBlocked(custom.name, method)) {
-      throw new Error(`tool blocked by policy: ${custom.name}/${method}`)
+    const physicalFailure = this.unavailableCustomConnectors.get(custom.name)
+    if (physicalFailure) throw new ConnectorGateError(physicalFailure)
+    if (!access.bypassMainEnablement && !custom.enabled) {
+      throw new ConnectorGateError('connector_disabled', `connector not enabled: ${custom.name}`)
     }
-    if (!this.deps.mcpClientManager) throw new Error('connector runtime not configured')
-    await this.ensureApproved(custom.name, method, args, context.sessionId)
+    if (!this.isCustomConfigRunnable(custom)) throw new ConnectorGateError('connector_unavailable')
+    if (!access.bypassMainPolicy && this.isBlocked(custom.name, method)) {
+      throw new ConnectorGateError(
+        'tool_blocked',
+        `tool blocked by policy: ${custom.name}/${method}`
+      )
+    }
+    if (!this.deps.mcpClientManager) throw new ConnectorGateError('connector_runtime_unavailable')
+    if (!access.bypassMainPolicy) {
+      await this.ensureApproved(custom.name, method, args, context.sessionId)
+    }
 
-    return this.deps.mcpClientManager.call(toCustomMcpConfig(custom), method, args)
+    try {
+      const result = await this.deps.mcpClientManager.call(toCustomMcpConfig(custom), method, args)
+      this.unavailableCustomConnectors.delete(custom.name)
+      return result
+    } catch (error) {
+      // Never relay a transport error: custom server URLs, headers, or server-provided diagnostics
+      // can contain credentials. Record only the availability category for subsequent fail-closed
+      // dispatches; a successful connection clears the transient state.
+      const category =
+        error instanceof Error &&
+        /(?:401|403|unauthoriz|authenticat|forbidden)/i.test(error.message)
+          ? 'connector_unauthenticated'
+          : 'connector_unavailable'
+      this.unavailableCustomConnectors.set(custom.name, category)
+      throw new ConnectorGateError(category)
+    }
+  }
+
+  private isCustomConfigRunnable(
+    custom: NonNullable<StoredConnectors['customMcpServers']>[number]
+  ): boolean {
+    if (custom.transport === 'stdio') return Boolean(custom.command)
+    return Boolean(custom.url)
   }
 
   private isBlocked(connector: string, method: string): boolean {

--- a/src/main/ipc.ts
+++ b/src/main/ipc.ts
@@ -94,6 +94,9 @@ import { tryDecryptKey } from './settings/crypto'
 import { registerSettingsIpcHandlers } from './settings/ipc'
 import { getAppClaudeConfigDir } from './settings/provider-env'
 import { createDefaultSettingsService, type SettingsService } from './settings/service'
+import { createProfileService } from './specialist/service'
+import { registerSpecialistIpcHandlers } from './specialist/ipc'
+import { SessionBindingService } from './specialist/session-binding'
 import type { StoredConnectors } from './settings/types'
 import type { AppIconPreview, AppIconVariant } from '../shared/settings'
 import { registerStorageIpcHandlers } from './storage/ipc'
@@ -330,6 +333,11 @@ const registerIpcHandlers = async ({
   // Read fresh on every call so a future connectors-settings mutation (Plan 2 UI) only needs to call
   // refreshConnectorSkillDocs again to take effect, without reconstructing the connector service.
   let connectorsSnapshot: StoredConnectors | undefined
+  // Resolved lazily per connector call so dispatch always sees the latest persisted Specialist profile.
+  const profileService = createProfileService(resolveStorageRoot())
+  // Per-session specialist binding store. Shared between the SET_SESSION_SPECIALIST barrier
+  // (validate + record) and the runtime switch so a hot-switch lands on the same source of truth.
+  const sessionBindingService = new SessionBindingService(profileService)
   // Desktop notifications for finished/failed agent tasks and approval waits. Delivery is
   // Electron's Notification (Notification Center on macOS, toasts on Windows, libnotify on Linux);
   // the service itself stays Electron-free so its filtering rules are unit-testable. The click
@@ -427,6 +435,13 @@ const registerIpcHandlers = async ({
         argsPreview: previewArgs(args),
         ...(sessionId ? { sessionId } : {})
       }),
+    resolveSpecialistProfile: async (specialistId) => {
+      try {
+        return await profileService.getById(specialistId)
+      } catch {
+        return undefined
+      }
+    },
     localToolHandlers: { 'molecule/preview_molecule': moleculePreviewHandler }
   })
   // Register compute IPC handlers early so computeService can be wired into the notebook RPC server.
@@ -572,6 +587,8 @@ const registerIpcHandlers = async ({
   registerWindowFindIpcHandlers()
   const updateService = registerUpdateIpcHandlers()
   startUpdateScheduler(updateService)
+  // ACP identity resolution and the Specialist settings IPC must use the same service instance.
+  // Creating it only for settings leaves create-session unable to resolve a selected UUID.
   const runtime = registerAcpIpcHandlers({
     mcpEntryPath: mainEntryPath,
     repository: artifactRepository,
@@ -593,7 +610,8 @@ const registerIpcHandlers = async ({
       skillImportApprovalBroker.cancelSession(sessionId),
     onSessionUnavailable: (sessionId) => skillImportApprovalBroker.cancelSession(sessionId),
     onAllSessionsCancellationRequested: () => skillImportApprovalBroker.cancelAll(),
-    initializationBarrier: initialConnectorSkillsReady
+    initializationBarrier: initialConnectorSkillsReady,
+    profileService
   })
   runtimeRef.current = runtime
   // Single shared teardown owner for both the before-quit handler (index.ts) and the pre-update-install
@@ -639,6 +657,51 @@ const registerIpcHandlers = async ({
     listAppIconPreviews
   })
   registerNotebookIpcHandlers(notebookService)
+  // Wire session deletion to the binding store so stale in-memory bindings do not accumulate.
+  // The renderer calls sessions:delete-session (via sessionPersistenceBackend) and acp:delete-session
+  // separately; both paths should clear the binding. Override the backend deleteSession callback here
+  // so all durable-path deletions — regardless of whether the ACP session was attached — clear the
+  // binding in one place.
+  const originalDeleteSession =
+    sessionPersistenceBackend.deleteSession.bind(sessionPersistenceBackend)
+  sessionPersistenceBackend.deleteSession = async (projectId, sessionId) => {
+    await originalDeleteSession(projectId, sessionId)
+    sessionBindingService.clearSession(sessionId)
+  }
+  const specialistPersistLog = createLogger('specialist:persist')
+  registerSpecialistIpcHandlers(
+    profileService,
+    sessionBindingService,
+    // Persist only the specialist UUID to the durable session file — never a profile snapshot.
+    // Read the current session file, patch specialistId, and save so the binding survives restarts.
+    // Reading all sessions to locate the target is intentional: sessionId alone is not sufficient to
+    // open the file (it lives under sessions/<projectId>/<sessionId>.json), and this operation is
+    // infrequent enough that the scan cost is acceptable.
+    async (sessionId, specialistId) => {
+      const allSessions = await sessionRepository.loadAll()
+      const session = allSessions.sessions.find((s) => s.id === sessionId)
+      if (!session) {
+        // The session has not yet been persisted (created but not saved). The specialistId will be
+        // written when the renderer calls sessions:save-session for the first time.
+        specialistPersistLog.debug(
+          'session not yet durable; specialistId will be written on first save',
+          {
+            sessionId,
+            specialistId
+          }
+        )
+        return
+      }
+      await sessionPersistenceCoordinator.saveSession({ ...session, specialistId })
+    },
+    // Apply the switch to the live agent runtime. `runtime` is assigned above (registerAcpIpcHandlers),
+    // but the closure is invoked per-request so a late-bound reference is unnecessary.
+    (sessionId, specialistId) => runtime.switchSpecialist(sessionId, specialistId),
+    // A specialist capability edit (skills/connectors/enabled) must reach live sessions on the next
+    // turn: reconnect so the agent respawns (re-provisioning skills) and resumes with the updated
+    // specialist whitelist in the session _meta.
+    () => void runtime.requestSkillsReload()
+  )
   // Runtime selection UI (Settings/Onboarding): survey managed+external per language, persist the
   // choice, and pick an interpreter file. The runtime root MUST match the executor/service's
   // (getRuntimeRoot(<dataRoot>)); read lazily so a data-root switch is reflected without re-register.

--- a/src/main/notebook/local-rpc-server.mcpcall.test.ts
+++ b/src/main/notebook/local-rpc-server.mcpcall.test.ts
@@ -54,7 +54,48 @@ describe('mcpCall RPC', () => {
         params: { server: 'molecule', method: 'preview_molecule', args: {}, sessionId: 's-42' }
       })
     })
-    expect(seenContext).toEqual({ sessionId: 's-42' })
+    expect(seenContext).toEqual({ sessionId: 's-42', origin: 'agent' })
+  })
+
+  it('uses the registered Specialist scope rather than RPC-supplied identity data', async () => {
+    let seenContext:
+      { sessionId?: string; origin?: 'agent' | 'internal'; specialistId?: string } | undefined
+    const capturing = {
+      call: async (
+        _s: string,
+        _m: string,
+        _a: Record<string, unknown>,
+        context?: { sessionId?: string; origin?: 'agent' | 'internal'; specialistId?: string }
+      ) => {
+        seenContext = context
+        return { ok: true }
+      }
+    }
+    server = new NotebookLocalRpcServer({ execute: async () => ({}) } as never, {
+      connectorService: capturing
+    })
+    server.registerSessionSpecialist('real-session', 'specialist-1')
+    server.registerSessionAlias('notebook-session', 'real-session')
+    const { endpoint, token } = await server.ensureStarted()
+    await fetch(endpoint, {
+      method: 'POST',
+      headers: { authorization: `Bearer ${token}`, 'content-type': 'application/json' },
+      body: JSON.stringify({
+        method: 'mcpCall',
+        params: {
+          server: 'molecule',
+          method: 'preview_molecule',
+          args: {},
+          sessionId: 'notebook-session',
+          specialistId: 'forged-specialist'
+        }
+      })
+    })
+    expect(seenContext).toEqual({
+      sessionId: 'real-session',
+      origin: 'agent',
+      specialistId: 'specialist-1'
+    })
   })
 })
 

--- a/src/main/notebook/local-rpc-server.ts
+++ b/src/main/notebook/local-rpc-server.ts
@@ -37,7 +37,11 @@ type NotebookLocalRpcServerOptions = {
       server: string,
       method: string,
       args: Record<string, unknown>,
-      context?: { sessionId?: string }
+      context?: {
+        sessionId?: string
+        origin?: 'agent' | 'internal'
+        specialistId?: string
+      }
     ): Promise<unknown>
   }
   computeService?: {
@@ -173,6 +177,10 @@ class NotebookLocalRpcServer {
   private server: Server | undefined
   private startPromise: Promise<NotebookRpcConnection> | undefined
   private readonly sessionAliases = new Map<string, string>()
+  // The session → Specialist relationship is established by the ACP runtime, not supplied by the
+  // notebook process. Keeping it here prevents an agent from selecting another Specialist's scope
+  // by forging an RPC parameter.
+  private readonly sessionSpecialists = new Map<string, string>()
   private readonly artifactProvenanceContexts = new Map<string, NotebookRunProvenanceContext>()
   private readonly activeTurnProjectIds = new Map<string, string>()
   private readonly activeInputRunLeases = new Map<string, Set<NotebookInputRunLease>>()
@@ -289,6 +297,11 @@ class NotebookLocalRpcServer {
   // Remembers the final ACP session id for notebook aliases created before session start.
   registerSessionAlias(aliasSessionId: string, sessionId: string): void {
     this.sessionAliases.set(aliasSessionId, sessionId)
+  }
+
+  registerSessionSpecialist(sessionId: string, specialistId: string | undefined): void {
+    if (specialistId) this.sessionSpecialists.set(sessionId, specialistId)
+    else this.sessionSpecialists.delete(sessionId)
   }
 
   // Pins Notebook executions to the app-owned active turn. The MCP caller cannot submit or override
@@ -520,7 +533,13 @@ class NotebookLocalRpcServer {
       const toolMethod = typeof params.method === 'string' ? params.method : ''
       const args = isRecord(params.args) ? params.args : {}
       const sessionId = typeof params.sessionId === 'string' ? params.sessionId : undefined
-      return this.connectorService.call(server, toolMethod, args, { sessionId })
+      return this.connectorService.call(server, toolMethod, args, {
+        sessionId,
+        origin: 'agent',
+        ...(sessionId && this.sessionSpecialists.get(sessionId)
+          ? { specialistId: this.sessionSpecialists.get(sessionId) }
+          : {})
+      })
     }
 
     // computeCall routes compute API operations to ComputeService (design.md §2). The `op` field

--- a/src/main/settings/service.test.ts
+++ b/src/main/settings/service.test.ts
@@ -3492,6 +3492,18 @@ describe('SettingsService: skills', () => {
     expect(detail.body).toContain('demo body')
   })
 
+  it('keeps a Main-disabled installed Skill in the Specialist catalog', async () => {
+    const service = await createSkillService()
+    await service.setSkillEnabled({ id: 'demo', enabled: false })
+
+    expect(await service.listSkills()).toEqual([
+      expect.objectContaining({ id: 'demo', enabled: false })
+    ])
+    expect(await service.listSpecialistSkillCatalog()).toEqual([
+      expect.objectContaining({ id: 'demo', frameworkName: 'demo' })
+    ])
+  })
+
   it('creates, edits, and deletes a personal skill alongside featured skills', async () => {
     const service = await createSkillService()
 

--- a/src/main/settings/service.ts
+++ b/src/main/settings/service.ts
@@ -1006,6 +1006,32 @@ class SettingsService {
     return skills.map((skill) => this.toSkillView(skill, disabled))
   }
 
+  // Specialist scopes intentionally see the installed catalog irrespective of Main Agent toggles.
+  // The result is rebuilt for every caller so future imports and removals take effect on the next turn.
+  async listSpecialistSkillCatalog(): Promise<
+    Array<{ id: string; frameworkName: string; displayName: string }>
+  > {
+    const skills = await this.skillCatalog()
+    return skills.map((skill) => ({
+      id: skill.id,
+      frameworkName: skill.source === 'featured' ? skill.id : skill.name,
+      displayName: skill.name
+    }))
+  }
+
+  // Returns the mcp-<id> skill names for connectors provisioned at the Main Agent level (enabled
+  // bundled connectors + enabled custom MCP servers). Specialist sessions merge these into their
+  // skill whitelist so the agent can discover connector tools; the per-call ConnectorService gate
+  // still enforces the specialist's own connector access config.
+  async provisionedConnectorSkillNames(): Promise<string[]> {
+    const connectors = await this.getConnectors()
+    const bundled = this.enabledConnectorIds(connectors)
+    const custom = (connectors?.customMcpServers ?? [])
+      .filter((server) => server.enabled)
+      .map((server) => server.id)
+    return Array.from(new Set([...bundled, ...custom].map((id) => `mcp-${id}`)))
+  }
+
   // Returns the subset of forced ids that are currently disabled in settings — i.e. the picks that need
   // a respawn to materialize. Enabled picks are already present and need no reconnect.
   async skillsNeedingForceLoad(forcedIds: string[]): Promise<string[]> {
@@ -3220,16 +3246,21 @@ class SettingsService {
   // Projects stored custom MCP servers into renderer views (no secret env/header values).
   private toCustomServerViews(connectors: StoredConnectors | undefined): CustomServerView[] {
     return (connectors?.customMcpServers ?? [])
-      .map((s) => ({
-        id: s.id,
-        name: s.name,
-        description: s.description,
-        transport: s.transport,
-        enabled: s.enabled,
-        command: s.command,
-        args: s.args,
-        url: s.url
-      }))
+      .map((s) => {
+        const unavailable =
+          (s.transport === 'stdio' && !s.command) || (s.transport !== 'stdio' && !s.url)
+        return {
+          id: s.id,
+          name: s.name,
+          description: s.description,
+          transport: s.transport,
+          enabled: s.enabled,
+          command: s.command,
+          args: s.args,
+          url: s.url,
+          ...(unavailable ? { availability: 'unavailable' as const } : {})
+        }
+      })
       .sort((a, b) => a.name.localeCompare(b.name))
   }
 

--- a/src/main/specialist/identity.test.ts
+++ b/src/main/specialist/identity.test.ts
@@ -1,0 +1,76 @@
+import { describe, it, expect } from 'vitest'
+import { buildSpecialistIdentityAppend, buildSpecialistIdentityPrefix } from './identity'
+import type { SpecialistProfileView } from '../../shared/specialist'
+import { emptyFullAccessConfig, emptySelectedConfig } from '../../shared/specialist'
+
+const makeProfile = (overrides: Partial<SpecialistProfileView> = {}): SpecialistProfileView => ({
+  id: 'uuid-1',
+  name: 'RNA-seq Reviewer',
+  description: 'Reviews RNA-seq analysis quality.',
+  systemPrompt: 'You are RNA-seq Reviewer. Focus on batch effects and QC.',
+  enabled: true,
+  capabilityMode: 'full',
+  fullAccess: emptyFullAccessConfig(),
+  selectedCapabilities: emptySelectedConfig(),
+  revision: 1,
+  ...overrides
+})
+
+describe('buildSpecialistIdentityAppend', () => {
+  it('produces non-empty text for a profile with a systemPrompt', () => {
+    const text = buildSpecialistIdentityAppend(makeProfile())
+    expect(text.length).toBeGreaterThan(0)
+  })
+
+  it('includes the specialist name', () => {
+    const text = buildSpecialistIdentityAppend(makeProfile())
+    expect(text).toContain('RNA-seq Reviewer')
+  })
+
+  it('includes the systemPrompt content verbatim', () => {
+    const text = buildSpecialistIdentityAppend(makeProfile())
+    expect(text).toContain('You are RNA-seq Reviewer. Focus on batch effects and QC.')
+  })
+
+  it('states that it overrides the Main Agent identity', () => {
+    const text = buildSpecialistIdentityAppend(makeProfile())
+    expect(text.toLowerCase()).toMatch(/override|replace|instead of main/i)
+  })
+
+  it('states that app safety and tool rules remain in effect', () => {
+    const text = buildSpecialistIdentityAppend(makeProfile())
+    expect(text.toLowerCase()).toMatch(/safety|tool rule|workflow rule|still apply/i)
+  })
+
+  it('returns empty string when systemPrompt is empty', () => {
+    const text = buildSpecialistIdentityAppend(makeProfile({ systemPrompt: '' }))
+    expect(text).toBe('')
+  })
+
+  it('returns empty string when systemPrompt is whitespace only', () => {
+    const text = buildSpecialistIdentityAppend(makeProfile({ systemPrompt: '   ' }))
+    expect(text).toBe('')
+  })
+})
+
+describe('buildSpecialistIdentityPrefix', () => {
+  it('produces non-empty text for a profile with a systemPrompt', () => {
+    const text = buildSpecialistIdentityPrefix(makeProfile())
+    expect(text.length).toBeGreaterThan(0)
+  })
+
+  it('includes the name', () => {
+    const text = buildSpecialistIdentityPrefix(makeProfile())
+    expect(text).toContain('RNA-seq Reviewer')
+  })
+
+  it('includes the systemPrompt content', () => {
+    const text = buildSpecialistIdentityPrefix(makeProfile())
+    expect(text).toContain('You are RNA-seq Reviewer. Focus on batch effects and QC.')
+  })
+
+  it('returns empty string when systemPrompt is empty', () => {
+    const text = buildSpecialistIdentityPrefix(makeProfile({ systemPrompt: '' }))
+    expect(text).toBe('')
+  })
+})

--- a/src/main/specialist/identity.ts
+++ b/src/main/specialist/identity.ts
@@ -1,0 +1,45 @@
+// Builds framework-neutral identity injection text from a Specialist Profile's systemPrompt.
+// The resulting text is appended to (or prefixed to) the session's effective system prompt so it
+// overrides the Main Agent behavioural identity while leaving all safety, tool, and workflow rules
+// intact. The specialist's capability config (Skills / Connectors) is handled separately.
+
+import type { SpecialistProfileView } from '../../shared/specialist'
+
+// Sentinel tag included in both append and prefix so downstream tests can detect the block.
+export const SPECIALIST_IDENTITY_TAG = '[open-science:specialist-identity]'
+
+// Builds the system-prompt APPEND text for Claude Code (preset 'claude_code', append mode).
+// Returns an empty string when there is nothing to inject (no systemPrompt set).
+export const buildSpecialistIdentityAppend = (profile: SpecialistProfileView): string => {
+  const prompt = profile.systemPrompt.trim()
+  if (!prompt) return ''
+
+  return [
+    SPECIALIST_IDENTITY_TAG,
+    `# Specialist identity — ${profile.name}`,
+    '',
+    '> The following overrides the Main Agent general identity description for this session.',
+    '> App safety rules, tool rules, and workflow instructions still apply and are not replaced.',
+    '',
+    prompt
+  ].join('\n')
+}
+
+// Builds the per-turn PROMPT PREFIX text for Codex and OpenCode (no session-meta append channel).
+// Returns an empty string when there is nothing to inject (no systemPrompt set).
+export const buildSpecialistIdentityPrefix = (profile: SpecialistProfileView): string => {
+  const prompt = profile.systemPrompt.trim()
+  if (!prompt) return ''
+
+  return [
+    SPECIALIST_IDENTITY_TAG,
+    `[Specialist: ${profile.name}]`,
+    '(This overrides the Main Agent identity for this session.',
+    ' App safety rules, tool rules, and workflow instructions still apply.)',
+    '',
+    prompt,
+    '',
+    '---',
+    ''
+  ].join('\n')
+}

--- a/src/main/specialist/ipc.test.ts
+++ b/src/main/specialist/ipc.test.ts
@@ -1,0 +1,54 @@
+import { describe, expect, it, vi } from 'vitest'
+
+import type { SpecialistProfileView } from '../../shared/specialist'
+import { SPECIALIST_IPC } from '../../shared/specialist'
+import { SessionBindingService } from './session-binding'
+import { registerSpecialistIpcHandlers } from './ipc'
+import type { ProfileService } from './service'
+
+const handlers = new Map<string, (event: unknown, payload: unknown) => unknown>()
+
+vi.mock('electron', () => ({
+  ipcMain: {
+    handle: (channel: string, handler: (event: unknown, payload: unknown) => unknown) => {
+      handlers.set(channel, handler)
+    }
+  }
+}))
+
+const profile = {
+  id: 'specialist-1',
+  name: 'RESEARCHER',
+  description: '',
+  systemPrompt: 'Research.',
+  enabled: true,
+  capabilityMode: 'full',
+  fullAccess: { excludedSkillIds: [], excludedConnectorIds: [], connectorTools: [] },
+  selectedCapabilities: { skillIds: [], connectorIds: [], connectorTools: [] },
+  revision: 1
+} as SpecialistProfileView
+
+const createProfileService = (): ProfileService =>
+  ({
+    getById: vi.fn().mockResolvedValue(profile),
+    listForSettings: vi.fn().mockResolvedValue([]),
+    subscribe: vi.fn()
+  }) as unknown as ProfileService
+
+describe('specialist session IPC', () => {
+  it('registers and persists a session specialist switch', async () => {
+    handlers.clear()
+    const binding = new SessionBindingService(createProfileService())
+    const persistSessionSpecialist = vi.fn().mockResolvedValue(undefined)
+
+    registerSpecialistIpcHandlers(createProfileService(), binding, persistSessionSpecialist)
+
+    const handler = handlers.get(SPECIALIST_IPC.SET_SESSION_SPECIALIST)
+    expect(handler).toBeDefined()
+
+    await handler?.(undefined, { sessionId: 'session-1', specialistId: profile.id })
+
+    expect(persistSessionSpecialist).toHaveBeenCalledWith('session-1', profile.id)
+    expect(binding.getBinding('session-1')).toBe(profile.id)
+  })
+})

--- a/src/main/specialist/ipc.ts
+++ b/src/main/specialist/ipc.ts
@@ -1,0 +1,183 @@
+import { ipcMain } from 'electron'
+
+import type {
+  CreateSpecialistRequest,
+  UpdateSpecialistRequest,
+  SetSpecialistEnabledRequest,
+  DeleteSpecialistRequest,
+  DuplicateSpecialistRequest,
+  CreateSpecialistInput,
+  SpecialistListItem,
+  SpecialistProfileView,
+  SetSessionSpecialistRequest,
+  SetSessionSpecialistResponse,
+  ResolveSessionSpecialistRequest,
+  SessionSpecialistResolution
+} from '../../shared/specialist'
+import { SPECIALIST_IPC } from '../../shared/specialist'
+import { ProfileService } from './service'
+import { SessionBindingService } from './session-binding'
+import { createLogger } from '../logger'
+import { broadcastToRenderers } from '../renderer-broadcast'
+
+const log = createLogger('specialist:ipc')
+
+type PersistSessionSpecialist = (
+  sessionId: string,
+  specialistId: string | undefined
+) => Promise<void>
+
+// Broadcasts a catalog-changed event to all renderer windows.
+const broadcastCatalogChanged = (): void => {
+  broadcastToRenderers(SPECIALIST_IPC.CATALOG_CHANGED, undefined)
+}
+
+// Registers all specialist IPC handlers against ipcMain.
+// Call once per app lifecycle, after the ProfileService is ready.
+export const registerSpecialistIpcHandlers = (
+  service: ProfileService,
+  sessionBindingService: SessionBindingService,
+  // Persists the specialist UUID to the durable session file before exposing the binding to the
+  // runtime. Required — an absent writer silently disables durability, which is the same failure
+  // shape the previous TODO introduced. Tests pass a vi.fn() mock; headless callers may pass an
+  // explicit no-op if session persistence is unavailable in their environment.
+  persistSessionSpecialist: PersistSessionSpecialist,
+  // Applies a switch to the live agent runtime. Kept as a callback so this module stays decoupled
+  // from the ACP coordinator. Returns whether the runtime replaced the agent session (context reset),
+  // which tells the renderer to replay conversation history into the next prompt.
+  switchSessionSpecialist?: (
+    sessionId: string,
+    specialistId: string | undefined
+  ) => Promise<{ contextReset: boolean }>,
+  // Notifies the runtime that a specialist profile's capabilities changed (skills/connectors/enabled).
+  // The runtime reconnects so live sessions re-provision skills and re-apply the updated whitelist on
+  // the next turn. Optional so headless/tests can omit it.
+  onProfilesChanged?: () => void
+): void => {
+  // Subscribe once so every mutation (create, setEnabled) triggers a broadcast.
+  service.subscribe(broadcastCatalogChanged)
+
+  ipcMain.handle(SPECIALIST_IPC.LIST, async (): Promise<SpecialistListItem[]> => {
+    try {
+      return await service.listForSettings()
+    } catch (error) {
+      log.error('specialist:list failed', { error })
+      throw error
+    }
+  })
+
+  ipcMain.handle(
+    SPECIALIST_IPC.CREATE,
+    async (_event, request: CreateSpecialistRequest): Promise<SpecialistProfileView> => {
+      // Re-validate in main process — renderer input is untrusted.
+      try {
+        return await service.create(request)
+      } catch (error) {
+        log.error('specialist:create failed', { error })
+        throw error
+      }
+    }
+  )
+
+  ipcMain.handle(
+    SPECIALIST_IPC.UPDATE,
+    async (_event, request: UpdateSpecialistRequest): Promise<SpecialistProfileView> => {
+      // Re-validate in main process — renderer input is untrusted.
+      try {
+        const updated = await service.update(request)
+        // A capability edit (skills/connectors) must reach live sessions: trigger a reconnect so the
+        // next turn re-provisions skills and re-applies the updated specialist whitelist.
+        onProfilesChanged?.()
+        return updated
+      } catch (error) {
+        log.error('specialist:update failed', { error })
+        throw error
+      }
+    }
+  )
+
+  ipcMain.handle(
+    SPECIALIST_IPC.SET_ENABLED,
+    async (_event, request: SetSpecialistEnabledRequest): Promise<SpecialistProfileView> => {
+      try {
+        const updated = await service.setEnabled(request.id, request.enabled)
+        onProfilesChanged?.()
+        return updated
+      } catch (error) {
+        log.error('specialist:set-enabled failed', { error })
+        throw error
+      }
+    }
+  )
+
+  ipcMain.handle(
+    SPECIALIST_IPC.DELETE,
+    async (_event, request: DeleteSpecialistRequest): Promise<void> => {
+      try {
+        await service.delete(request.id, request.expectedRevision)
+        onProfilesChanged?.()
+      } catch (error) {
+        log.error('specialist:delete failed', { error })
+        throw error
+      }
+    }
+  )
+
+  ipcMain.handle(
+    SPECIALIST_IPC.DUPLICATE,
+    async (_event, request: DuplicateSpecialistRequest): Promise<CreateSpecialistInput> =>
+      service.duplicate(request.id)
+  )
+
+  // Session switching. This handler is a named seam: the future host.agents.switch() SDK (issue 08)
+  // will resolve name→UUID and call this same channel, not a parallel path.
+  ipcMain.handle(
+    SPECIALIST_IPC.SET_SESSION_SPECIALIST,
+    async (_event, request: SetSessionSpecialistRequest): Promise<SetSessionSpecialistResponse> => {
+      if (!request || typeof request.sessionId !== 'string') {
+        throw new Error('SET_SESSION_SPECIALIST: sessionId must be a string.')
+      }
+      if (request.specialistId !== undefined && typeof request.specialistId !== 'string') {
+        throw new Error('SET_SESSION_SPECIALIST: specialistId must be a string or undefined.')
+      }
+      // Validate the UUID exists and is enabled before accepting it.
+      if (request.specialistId !== undefined) {
+        const resolution = await sessionBindingService.resolve(
+          request.sessionId,
+          request.specialistId
+        )
+        if (resolution.kind === 'unavailable') {
+          // Surface the reason so the renderer can show a meaningful message.
+          throw new Error(resolution.reason)
+        }
+      }
+      // Make the durable session file authoritative before exposing the new binding to runtime.
+      // Otherwise an app restart between these steps would silently restore the old specialist.
+      await persistSessionSpecialist(request.sessionId, request.specialistId)
+      sessionBindingService.setBinding(request.sessionId, request.specialistId)
+
+      // Apply the switch to the live agent session so the new specialist takes effect now, not
+      // just on the next session create/resume. When no runtime is wired (headless/tests) this is
+      // a no-op and the binding recorded above still takes effect on the next create/resume.
+      let contextReset = false
+      if (switchSessionSpecialist) {
+        const result = await switchSessionSpecialist(request.sessionId, request.specialistId)
+        contextReset = result.contextReset
+      }
+      return { contextReset }
+    }
+  )
+
+  ipcMain.handle(
+    SPECIALIST_IPC.RESOLVE_SESSION_SPECIALIST,
+    async (
+      _event,
+      request: ResolveSessionSpecialistRequest
+    ): Promise<SessionSpecialistResolution> => {
+      if (!request || typeof request.sessionId !== 'string') {
+        throw new Error('RESOLVE_SESSION_SPECIALIST: sessionId must be a string.')
+      }
+      return sessionBindingService.resolve(request.sessionId)
+    }
+  )
+}

--- a/src/main/specialist/repository.test.ts
+++ b/src/main/specialist/repository.test.ts
@@ -1,0 +1,257 @@
+import { tmpdir } from 'node:os'
+import { join } from 'node:path'
+import { mkdir, rm, writeFile, chmod } from 'node:fs/promises'
+import { randomUUID } from 'node:crypto'
+import { describe, it, expect, beforeEach, afterEach } from 'vitest'
+
+import { SpecialistRepository } from './repository'
+import { sanitizeSpecialist } from './repository'
+import type { StoredSpecialist } from './types'
+import { emptyFullAccessConfig, emptySelectedConfig } from '../../shared/specialist'
+
+// ---------------------------------------------------------------------------
+// Sanitization unit tests
+// ---------------------------------------------------------------------------
+
+describe('sanitizeSpecialist', () => {
+  const valid: StoredSpecialist = {
+    id: 'uuid-1',
+    name: 'RNA-seq Reviewer',
+    description: 'Reviews differential expression.',
+    systemPrompt: '',
+    enabled: true,
+    capabilityMode: 'full',
+    fullAccess: emptyFullAccessConfig(),
+    selectedCapabilities: emptySelectedConfig(),
+    revision: 1
+  }
+
+  it('accepts a valid record', () => {
+    expect(sanitizeSpecialist(valid)).toMatchObject({ id: 'uuid-1', name: 'RNA-seq Reviewer' })
+  })
+
+  it('drops record missing required id', () => {
+    expect(sanitizeSpecialist({ ...valid, id: undefined })).toBeUndefined()
+  })
+
+  it('drops record missing required name', () => {
+    expect(sanitizeSpecialist({ ...valid, name: undefined })).toBeUndefined()
+  })
+
+  it('preserves a stable public name alongside its displayName', () => {
+    const legacy = { ...valid, name: 'RNA_SEQ_REVIEWER', displayName: 'RNA-seq Reviewer' }
+    const result = sanitizeSpecialist(legacy)
+    expect(result?.name).toBe('RNA_SEQ_REVIEWER')
+    expect(result?.displayName).toBe('RNA-seq Reviewer')
+  })
+
+  it('falls back to legacy UPPER_SNAKE name when displayName is absent', () => {
+    const legacy = { ...valid, name: 'RNA_SEQ_REVIEWER', displayName: undefined }
+    const result = sanitizeSpecialist(legacy)
+    expect(result?.name).toBe('RNA_SEQ_REVIEWER')
+  })
+
+  it('drops record with unknown capabilityMode', () => {
+    expect(sanitizeSpecialist({ ...valid, capabilityMode: 'unknown' })).toBeUndefined()
+  })
+
+  it('preserves iconKey and colorKey when present', () => {
+    const result = sanitizeSpecialist({ ...valid, iconKey: 'dna', colorKey: 'teal' })
+    expect(result?.iconKey).toBe('dna')
+    expect(result?.colorKey).toBe('teal')
+  })
+
+  it('omits iconKey/colorKey when absent', () => {
+    const result = sanitizeSpecialist(valid)
+    expect(result?.iconKey).toBeUndefined()
+    expect(result?.colorKey).toBeUndefined()
+  })
+})
+
+// ---------------------------------------------------------------------------
+// Repository integration tests (real temp dir)
+// ---------------------------------------------------------------------------
+
+let tmpDir: string
+
+const makeSpecialist = (overrides: Partial<StoredSpecialist> = {}): StoredSpecialist => ({
+  id: randomUUID(),
+  name: `Bot ${randomUUID().slice(0, 6)}`,
+  description: 'A test specialist.',
+  systemPrompt: '',
+  enabled: true,
+  capabilityMode: 'full',
+  fullAccess: emptyFullAccessConfig(),
+  selectedCapabilities: emptySelectedConfig(),
+  revision: 1,
+  ...overrides
+})
+
+beforeEach(async () => {
+  tmpDir = join(tmpdir(), `specialist-repo-${randomUUID()}`)
+  await mkdir(tmpDir, { recursive: true })
+})
+
+afterEach(async () => {
+  await rm(tmpDir, { recursive: true, force: true })
+})
+
+describe('SpecialistRepository.getAll', () => {
+  it('returns empty document on a fresh directory', async () => {
+    const repo = new SpecialistRepository(tmpDir)
+    const doc = await repo.getAll()
+    expect(doc.specialists).toHaveLength(0)
+  })
+
+  it('throws on corrupt JSON file instead of returning empty (prevents silent data loss)', async () => {
+    await writeFile(join(tmpDir, 'specialists.json'), 'INVALID JSON', 'utf8')
+    const repo = new SpecialistRepository(tmpDir)
+    await expect(repo.getAll()).rejects.toThrow()
+  })
+
+  it('throws on non-ENOENT filesystem error instead of returning empty', async () => {
+    // Create the file then make it unreadable to trigger EACCES.
+    // Skip on CI environments that run as root (root ignores chmod 000).
+    const filePath = join(tmpDir, 'specialists.json')
+    await writeFile(filePath, '{}', 'utf8')
+    await chmod(filePath, 0o000)
+    const repo = new SpecialistRepository(tmpDir)
+    try {
+      await expect(repo.getAll()).rejects.toThrow()
+    } finally {
+      await chmod(filePath, 0o644)
+    }
+  })
+})
+
+describe('SpecialistRepository.insert', () => {
+  it('persists a new specialist', async () => {
+    const repo = new SpecialistRepository(tmpDir)
+    const sp = makeSpecialist()
+    await repo.insert(sp)
+    const doc = await repo.getAll()
+    expect(doc.specialists).toHaveLength(1)
+    expect(doc.specialists[0].id).toBe(sp.id)
+  })
+
+  it('rejects duplicate id', async () => {
+    const repo = new SpecialistRepository(tmpDir)
+    const sp = makeSpecialist()
+    await repo.insert(sp)
+    await expect(repo.insert(sp)).rejects.toThrow()
+  })
+
+  it('rejects duplicate name', async () => {
+    const repo = new SpecialistRepository(tmpDir)
+    const sp1 = makeSpecialist({ name: 'SAME_NAME' })
+    const sp2 = makeSpecialist({ name: 'SAME_NAME' })
+    await repo.insert(sp1)
+    await expect(repo.insert(sp2)).rejects.toThrow()
+  })
+
+  it('survives restart (data persists to disk)', async () => {
+    const sp = makeSpecialist()
+    await new SpecialistRepository(tmpDir).insert(sp)
+
+    // New instance reads from disk.
+    const doc = await new SpecialistRepository(tmpDir).getAll()
+    expect(doc.specialists[0].id).toBe(sp.id)
+  })
+})
+
+describe('SpecialistRepository.setEnabled', () => {
+  it('toggles enabled state', async () => {
+    const repo = new SpecialistRepository(tmpDir)
+    const sp = makeSpecialist({ enabled: true })
+    await repo.insert(sp)
+    await repo.setEnabled(sp.id, false)
+    const doc = await repo.getAll()
+    expect(doc.specialists[0].enabled).toBe(false)
+  })
+
+  it('throws for unknown id', async () => {
+    const repo = new SpecialistRepository(tmpDir)
+    await expect(repo.setEnabled('no-such-id', false)).rejects.toThrow()
+  })
+})
+
+describe('SpecialistRepository.update', () => {
+  it('updates fields and increments revision', async () => {
+    const repo = new SpecialistRepository(tmpDir)
+    const sp = makeSpecialist({ revision: 1 })
+    await repo.insert(sp)
+    await repo.update(sp.id, { name: 'Updated' }, 1)
+    const doc = await repo.getAll()
+    expect(doc.specialists[0].name).toBe('Updated')
+    expect(doc.specialists[0].revision).toBe(2)
+  })
+
+  it('rejects revision conflict', async () => {
+    const repo = new SpecialistRepository(tmpDir)
+    const sp = makeSpecialist({ revision: 1 })
+    await repo.insert(sp)
+    await expect(repo.update(sp.id, { name: 'X' }, 99)).rejects.toThrow(/revision/i)
+  })
+
+  it('id remains immutable across update', async () => {
+    const repo = new SpecialistRepository(tmpDir)
+    const sp = makeSpecialist({ id: 'fixed-id', revision: 1 })
+    await repo.insert(sp)
+    await repo.update(sp.id, { id: 'hacked-id' } as Partial<StoredSpecialist>, 1)
+    const doc = await repo.getAll()
+    expect(doc.specialists[0].id).toBe('fixed-id')
+  })
+
+  it('rejects name change to existing name', async () => {
+    const repo = new SpecialistRepository(tmpDir)
+    const sp1 = makeSpecialist({ name: 'NAME_ONE' })
+    const sp2 = makeSpecialist({ name: 'NAME_TWO', revision: 1 })
+    await repo.insert(sp1)
+    await repo.insert(sp2)
+    await expect(repo.update(sp2.id, { name: 'NAME_ONE' }, 1)).rejects.toThrow()
+  })
+})
+
+describe('SpecialistRepository — data-loss guard', () => {
+  it('a read failure followed by an insert must NOT truncate the store', async () => {
+    const repo = new SpecialistRepository(tmpDir)
+
+    // Populate the store with two specialists via a healthy write.
+    const sp1 = makeSpecialist()
+    const sp2 = makeSpecialist()
+    await repo.insert(sp1)
+    await repo.insert(sp2)
+
+    // Corrupt the file to simulate a truncated-write / disk-corruption scenario.
+    await writeFile(join(tmpDir, 'specialists.json'), 'CORRUPTED', 'utf8')
+
+    // The insert must reject (because getAll now throws) rather than silently
+    // writing a document containing only the new specialist.
+    const sp3 = makeSpecialist()
+    await expect(repo.insert(sp3)).rejects.toThrow()
+
+    // Restore the file to a valid state and confirm sp1 + sp2 are still there.
+    await writeFile(
+      join(tmpDir, 'specialists.json'),
+      JSON.stringify({ version: 1, specialists: [sp1, sp2] }, null, 2),
+      'utf8'
+    )
+    const doc = await repo.getAll()
+    expect(doc.specialists).toHaveLength(2)
+    expect(doc.specialists.map((s) => s.id)).toContain(sp1.id)
+    expect(doc.specialists.map((s) => s.id)).toContain(sp2.id)
+  })
+})
+
+describe('SpecialistRepository — old schema detection', () => {
+  it('ignores old experimental schema with kebab-case agentId', async () => {
+    const oldSchema = JSON.stringify({
+      version: 1,
+      specialists: [{ agentId: 'rna-seq-reviewer', name: 'RNA Reviewer', enabled: true }]
+    })
+    await writeFile(join(tmpDir, 'specialists.json'), oldSchema, 'utf8')
+    const repo = new SpecialistRepository(tmpDir)
+    const doc = await repo.getAll()
+    expect(doc.specialists).toHaveLength(0)
+  })
+})

--- a/src/main/specialist/repository.ts
+++ b/src/main/specialist/repository.ts
@@ -1,0 +1,307 @@
+import { mkdir, readFile, rename, writeFile } from 'node:fs/promises'
+import { join } from 'node:path'
+
+import { createLogger } from '../logger'
+import {
+  createEmptySpecialists,
+  SPECIALISTS_FILE_VERSION,
+  type StoredSpecialist,
+  type StoredSpecialists
+} from './types'
+import type {
+  SpecialistCapabilityMode,
+  SpecialistFullAccessConfig,
+  SpecialistSelectedConfig,
+  ConnectorToolRule
+} from '../../shared/specialist'
+
+const SPECIALISTS_FILE = 'specialists.json'
+
+const log = createLogger('specialist.repository')
+
+// ---------------------------------------------------------------------------
+// Sanitization helpers (untrusted disk data → safe in-memory shapes)
+// ---------------------------------------------------------------------------
+
+const isRecord = (v: unknown): v is Record<string, unknown> =>
+  typeof v === 'object' && v !== null && !Array.isArray(v)
+
+const asString = (v: unknown): string | undefined => (typeof v === 'string' ? v : undefined)
+
+const asBoolean = (v: unknown): boolean | undefined => (typeof v === 'boolean' ? v : undefined)
+
+const asNumber = (v: unknown): number | undefined =>
+  typeof v === 'number' && Number.isFinite(v) ? v : undefined
+
+const asStringArray = (v: unknown): string[] =>
+  Array.isArray(v) ? v.filter((x): x is string => typeof x === 'string') : []
+
+const CAPABILITY_MODES = new Set<SpecialistCapabilityMode>(['full', 'selected'])
+
+const sanitizeConnectorToolRule = (v: unknown): ConnectorToolRule | undefined => {
+  if (!isRecord(v)) return undefined
+  const connectorId = asString(v.connectorId)
+  if (!connectorId) return undefined
+  const rule: ConnectorToolRule = { connectorId }
+  const includedMethods = asStringArray(v.includedMethods)
+  const excludedMethods = asStringArray(v.excludedMethods)
+  const includeToolsPattern = asString(v.includeToolsPattern)
+  const excludeToolsPattern = asString(v.excludeToolsPattern)
+  if (includedMethods.length) rule.includedMethods = includedMethods
+  if (excludedMethods.length) rule.excludedMethods = excludedMethods
+  if (includeToolsPattern) rule.includeToolsPattern = includeToolsPattern
+  if (excludeToolsPattern) rule.excludeToolsPattern = excludeToolsPattern
+  return rule
+}
+
+const sanitizeFullAccessConfig = (v: unknown): SpecialistFullAccessConfig => {
+  if (!isRecord(v)) return { excludedSkillIds: [], excludedConnectorIds: [], connectorTools: [] }
+  return {
+    excludedSkillIds: asStringArray(v.excludedSkillIds),
+    excludedConnectorIds: asStringArray(v.excludedConnectorIds),
+    connectorTools: Array.isArray(v.connectorTools)
+      ? v.connectorTools
+          .map(sanitizeConnectorToolRule)
+          .filter((r): r is ConnectorToolRule => r !== undefined)
+      : []
+  }
+}
+
+const sanitizeSelectedConfig = (v: unknown): SpecialistSelectedConfig => {
+  if (!isRecord(v)) return { skillIds: [], connectorIds: [], connectorTools: [] }
+  return {
+    skillIds: asStringArray(v.skillIds),
+    connectorIds: asStringArray(v.connectorIds),
+    connectorTools: Array.isArray(v.connectorTools)
+      ? v.connectorTools
+          .map(sanitizeConnectorToolRule)
+          .filter((r): r is ConnectorToolRule => r !== undefined)
+      : []
+  }
+}
+
+// Rebuild one stored specialist, dropping unknown or malformed records.
+// Older experimental documents may only have one human-readable name. Preserve
+// them as a display name and derive a durable public identifier on first write.
+export const sanitizeStoredSpecialist = (v: unknown): StoredSpecialist | undefined => {
+  if (!isRecord(v)) return undefined
+  const id = asString(v.id)
+  const legacyName = asString(v.name)
+  const displayName = asString(v.displayName) ?? legacyName
+  const name = legacyName
+  const description = asString(v.description)
+  const systemPrompt = asString(v.systemPrompt)
+  const enabled = asBoolean(v.enabled)
+  const capabilityModeRaw = asString(v.capabilityMode) as SpecialistCapabilityMode | undefined
+
+  if (
+    !id ||
+    !name ||
+    !displayName ||
+    description === undefined ||
+    systemPrompt === undefined ||
+    enabled === undefined ||
+    !capabilityModeRaw ||
+    !CAPABILITY_MODES.has(capabilityModeRaw)
+  ) {
+    return undefined
+  }
+
+  const revision = asNumber(v.revision) ?? 1
+  const specialist: StoredSpecialist = {
+    id,
+    name,
+    displayName,
+    description,
+    systemPrompt,
+    enabled,
+    capabilityMode: capabilityModeRaw,
+    fullAccess: sanitizeFullAccessConfig(v.fullAccess),
+    selectedCapabilities: sanitizeSelectedConfig(v.selectedCapabilities),
+    revision
+  }
+  const iconKey = asString(v.iconKey)
+  const colorKey = asString(v.colorKey)
+  if (iconKey) specialist.iconKey = iconKey
+  if (colorKey) specialist.colorKey = colorKey
+  return specialist
+}
+
+const sanitizeSpecialists = (v: unknown): StoredSpecialists => {
+  if (!isRecord(v)) return createEmptySpecialists()
+  // Detect old experimental feat/specialist schema (kebab-case agentId) and ignore it.
+  if (Array.isArray(v.specialists)) {
+    const first = v.specialists[0]
+    if (isRecord(first) && typeof first.agentId === 'string' && /[a-z]/.test(first.agentId)) {
+      log.warn('ignoring old experimental specialist schema (kebab-case agentId detected)')
+      return createEmptySpecialists()
+    }
+  }
+  // Deliberate policy: a malformed *individual* record is silently dropped rather than
+  // failing the whole read.  Rationale: a single corrupt record is most likely from a
+  // schema migration or manual edit gone wrong; surfacing all valid specialists is better
+  // than blocking all access.  The risk of silent loss on next write is mitigated by
+  // getAll() now throwing on OS-level read failures — the dangerous path (transient
+  // EMFILE/EACCES producing an empty document that then gets written back) is closed.
+  // If you change this policy, audit callers of sanitizeSpecialists in mutate().
+  const specialists = Array.isArray(v.specialists)
+    ? v.specialists
+        .map(sanitizeStoredSpecialist)
+        .filter((s): s is StoredSpecialist => s !== undefined)
+    : []
+  return { version: SPECIALISTS_FILE_VERSION, specialists }
+}
+
+// ---------------------------------------------------------------------------
+// Repository class
+// ---------------------------------------------------------------------------
+
+// Owns durable reads/writes of specialists.json. Uses atomic write (tmp + rename)
+// and serializes concurrent mutations through a queue — identical to SettingsRepository.
+export class SpecialistRepository {
+  private saveQueue: Promise<void> = Promise.resolve()
+  private writeSequence = 0
+
+  constructor(private readonly storageDir: string) {}
+
+  private get filePath(): string {
+    return join(this.storageDir, SPECIALISTS_FILE)
+  }
+
+  async getAll(): Promise<StoredSpecialists> {
+    let raw: string
+    try {
+      raw = await readFile(this.filePath, 'utf8')
+    } catch (err) {
+      // ENOENT is the normal first-run state — return an empty document.
+      // Any other OS error (EMFILE, EACCES, truncated read, etc.) must propagate so
+      // that mutate() aborts rather than silently overwriting a store we could not read.
+      if ((err as NodeJS.ErrnoException).code === 'ENOENT') {
+        return createEmptySpecialists()
+      }
+      log.error('failed to read specialists file — aborting to prevent data loss', {
+        path: this.filePath,
+        code: (err as NodeJS.ErrnoException).code
+        // intentionally omitting file contents — systemPrompt must not reach the log
+      })
+      throw err
+    }
+
+    // JSON.parse failure (truncated write, disk corruption) must also propagate.
+    // We do not return empty here because the file exists but is unreadable — a
+    // subsequent write would permanently destroy every specialist the file contained.
+    let parsed: unknown
+    try {
+      parsed = JSON.parse(raw) as unknown
+    } catch (err) {
+      log.error('failed to parse specialists file — aborting to prevent data loss', {
+        path: this.filePath
+        // intentionally omitting raw content — systemPrompt must not reach the log
+      })
+      throw err
+    }
+
+    return sanitizeSpecialists(parsed)
+  }
+
+  // Insert a new specialist (caller supplies a fully-formed record).
+  async insert(specialist: StoredSpecialist): Promise<StoredSpecialists> {
+    return this.mutate((doc) => {
+      // Check uniqueness of id and name.
+      if (doc.specialists.some((s) => s.id === specialist.id)) {
+        throw new Error(`Specialist with id ${specialist.id} already exists.`)
+      }
+      if (doc.specialists.some((s) => s.name === specialist.name)) {
+        throw new Error(`Specialist with name "${specialist.name}" already exists.`)
+      }
+      return { ...doc, specialists: [...doc.specialists, specialist] }
+    })
+  }
+
+  // Replace an existing specialist by id (revision must match expectedRevision).
+  async update(
+    id: string,
+    patch: Partial<StoredSpecialist>,
+    expectedRevision: number
+  ): Promise<StoredSpecialists> {
+    return this.mutate((doc) => {
+      const index = doc.specialists.findIndex((s) => s.id === id)
+      if (index < 0) throw new Error(`Specialist ${id} not found.`)
+      const current = doc.specialists[index]
+      if (current.revision !== expectedRevision) {
+        throw new Error(
+          `Revision conflict: expected ${expectedRevision}, found ${current.revision}.`
+        )
+      }
+      // Name uniqueness when renaming.
+      if (patch.name && patch.name !== current.name) {
+        if (doc.specialists.some((s) => s.id !== id && s.name === patch.name)) {
+          throw new Error(`Specialist with name "${patch.name}" already exists.`)
+        }
+      }
+      const updated: StoredSpecialist = {
+        ...current,
+        ...patch,
+        id, // id is immutable
+        revision: current.revision + 1
+      }
+      const specialists = [...doc.specialists]
+      specialists[index] = updated
+      return { ...doc, specialists }
+    })
+  }
+
+  // Toggle enabled without revision check (simple toggle).
+  async setEnabled(id: string, enabled: boolean): Promise<StoredSpecialists> {
+    return this.mutate((doc) => {
+      const index = doc.specialists.findIndex((s) => s.id === id)
+      if (index < 0) throw new Error(`Specialist ${id} not found.`)
+      const specialists = [...doc.specialists]
+      specialists[index] = {
+        ...specialists[index],
+        enabled,
+        revision: specialists[index].revision + 1
+      }
+      return { ...doc, specialists }
+    })
+  }
+
+  // Delete a specialist by id.
+  async delete(id: string, expectedRevision?: number): Promise<StoredSpecialists> {
+    return this.mutate((doc) => {
+      const current = doc.specialists.find((s) => s.id === id)
+      if (!current) throw new Error(`Specialist ${id} not found.`)
+      if (expectedRevision !== undefined && current.revision !== expectedRevision) {
+        throw new Error(
+          `Revision conflict: expected ${expectedRevision}, found ${current.revision}.`
+        )
+      }
+      return { ...doc, specialists: doc.specialists.filter((s) => s.id !== id) }
+    })
+  }
+
+  // Serializes mutations so concurrent callers cannot clobber each other.
+  private mutate(fn: (doc: StoredSpecialists) => StoredSpecialists): Promise<StoredSpecialists> {
+    const run = this.saveQueue.then(async () => {
+      const current = await this.getAll()
+      const next = fn(current)
+      await this.write(next)
+      return next
+    })
+    this.saveQueue = run.then(
+      () => undefined,
+      () => undefined
+    )
+    return run
+  }
+
+  private async write(doc: StoredSpecialists): Promise<void> {
+    await mkdir(this.storageDir, { recursive: true })
+    this.writeSequence += 1
+    const tmp = `${this.filePath}.${Date.now()}-${this.writeSequence}.tmp`
+    await writeFile(tmp, `${JSON.stringify(doc, null, 2)}\n`, 'utf8')
+    await rename(tmp, this.filePath)
+  }
+}
+
+export { sanitizeStoredSpecialist as sanitizeSpecialist, sanitizeSpecialists }

--- a/src/main/specialist/service.test.ts
+++ b/src/main/specialist/service.test.ts
@@ -1,0 +1,485 @@
+import { tmpdir } from 'node:os'
+import { join } from 'node:path'
+import { mkdir, rm } from 'node:fs/promises'
+import { randomUUID } from 'node:crypto'
+import { describe, it, expect, beforeEach, afterEach, vi } from 'vitest'
+
+import { ProfileService } from './service'
+import { SpecialistRepository } from './repository'
+
+let tmpDir: string
+let service: ProfileService
+
+beforeEach(async () => {
+  tmpDir = join(tmpdir(), `profile-service-${randomUUID()}`)
+  await mkdir(tmpDir, { recursive: true })
+  service = new ProfileService(new SpecialistRepository(tmpDir))
+})
+
+afterEach(async () => {
+  await rm(tmpDir, { recursive: true, force: true })
+})
+
+describe('ProfileService.list', () => {
+  it('returns empty array on fresh store', async () => {
+    expect(await service.list()).toHaveLength(0)
+  })
+
+  it('does not include Reviewer', async () => {
+    const result = await service.list()
+    expect(result.every((r) => r.id !== 'reviewer')).toBe(true)
+  })
+})
+
+describe('ProfileService.create', () => {
+  it('creates a specialist with immutable UUID', async () => {
+    const view = await service.create({ name: 'RNA-seq Reviewer' })
+    expect(view.id).toBeTruthy()
+    expect(typeof view.id).toBe('string')
+  })
+
+  it('stores the provided name verbatim', async () => {
+    const view = await service.create({ name: 'RNA-seq Reviewer' })
+    expect(view.name).toBe('RNA-seq Reviewer')
+  })
+
+  it('defaults to Full access mode', async () => {
+    const view = await service.create({ name: 'My Bot' })
+    expect(view.capabilityMode).toBe('full')
+  })
+
+  it('initialises both empty capability configs', async () => {
+    const view = await service.create({ name: 'My Bot' })
+    expect(view.fullAccess.excludedSkillIds).toEqual([])
+    expect(view.fullAccess.excludedConnectorIds).toEqual([])
+    expect(view.selectedCapabilities.skillIds).toEqual([])
+  })
+
+  it('persists connector settings supplied by the editor when creating a specialist', async () => {
+    const view = await service.create({
+      name: 'Connector Bot',
+      capabilityMode: 'selected',
+      fullAccess: {
+        excludedSkillIds: [],
+        excludedConnectorIds: ['pubmed'],
+        connectorTools: []
+      },
+      selectedCapabilities: {
+        skillIds: [],
+        connectorIds: ['chemistry'],
+        connectorTools: []
+      }
+    })
+    expect(view.capabilityMode).toBe('selected')
+    expect(view.fullAccess.excludedConnectorIds).toEqual(['pubmed'])
+    expect(view.selectedCapabilities.connectorIds).toEqual(['chemistry'])
+  })
+
+  it('sets enabled=true by default', async () => {
+    const view = await service.create({ name: 'My Bot' })
+    expect(view.enabled).toBe(true)
+  })
+
+  it('rejects empty name', async () => {
+    await expect(service.create({ name: '' })).rejects.toThrow()
+  })
+
+  it('rejects duplicate name', async () => {
+    await service.create({ name: 'My Bot' })
+    await expect(service.create({ name: 'My Bot' })).rejects.toThrow()
+  })
+
+  it('rejects an unsupported capability mode before persisting the profile', async () => {
+    await expect(
+      service.create({ name: 'My Bot', capabilityMode: 'unrestricted' } as never)
+    ).rejects.toThrow(/capability mode/i)
+
+    expect(await service.list()).toEqual([])
+  })
+
+  it('rejects non-string optional identity fields before persisting the profile', async () => {
+    await expect(service.create({ name: 'My Bot', description: 42 } as never)).rejects.toThrow(
+      /description must be a string/i
+    )
+
+    expect(await service.list()).toEqual([])
+  })
+
+  it('specialist is visible in list after creation', async () => {
+    await service.create({ name: 'RNA-seq Reviewer' })
+    const list = await service.list()
+    expect(list).toHaveLength(1)
+    expect(list[0].name).toBe('RNA-seq Reviewer')
+  })
+})
+
+describe('ProfileService.getById', () => {
+  it('returns the specialist by id', async () => {
+    const created = await service.create({ name: 'RNA-seq Reviewer' })
+    const found = await service.getById(created.id)
+    expect(found.id).toBe(created.id)
+  })
+
+  it('throws for unknown id', async () => {
+    await expect(service.getById('no-such-id')).rejects.toThrow()
+  })
+})
+
+describe('ProfileService.getByName', () => {
+  it('returns specialist by name', async () => {
+    const created = await service.create({ name: 'RNA-seq Reviewer' })
+    const found = await service.getByName(created.name)
+    expect(found.id).toBe(created.id)
+  })
+
+  it('throws for unknown name', async () => {
+    await expect(service.getByName('No Such Name')).rejects.toThrow()
+  })
+})
+
+describe('ProfileService.setEnabled', () => {
+  it('toggles enabled state', async () => {
+    const created = await service.create({ name: 'My Bot' })
+    const disabled = await service.setEnabled(created.id, false)
+    expect(disabled.enabled).toBe(false)
+
+    const re = await service.setEnabled(created.id, true)
+    expect(re.enabled).toBe(true)
+  })
+
+  it('throws for unknown id', async () => {
+    await expect(service.setEnabled('no-such-id', false)).rejects.toThrow()
+  })
+})
+
+describe('ProfileService.update', () => {
+  it('updates identity fields and bumps revision', async () => {
+    const created = await service.create({ name: 'RNA-seq Reviewer' })
+    const updated = await service.update({
+      id: created.id,
+      revision: created.revision,
+      name: 'RNA-seq Auditor',
+      description: 'Updated description.',
+      systemPrompt: 'Be rigorous.'
+    })
+    expect(updated.id).toBe(created.id)
+    expect(updated.name).toBe('RNA-seq Auditor')
+    expect(updated.description).toBe('Updated description.')
+    expect(updated.systemPrompt).toBe('Be rigorous.')
+    expect(updated.revision).toBe(created.revision + 1)
+  })
+
+  it('persists changes and leaves unmentioned fields intact', async () => {
+    const created = await service.create({ name: 'My Bot' })
+    await service.update({
+      id: created.id,
+      revision: created.revision,
+      description: 'New description.'
+    })
+    const found = await service.getById(created.id)
+    // name not provided → unchanged
+    expect(found.name).toBe('My Bot')
+    expect(found.description).toBe('New description.')
+  })
+
+  it('persists connector exclusions and inclusions independently across mode switches', async () => {
+    const created = await service.create({ name: 'Connector Bot' })
+    const full = await service.update({
+      id: created.id,
+      revision: created.revision,
+      fullAccess: {
+        excludedSkillIds: ['skill-a'],
+        excludedConnectorIds: ['pubmed'],
+        connectorTools: []
+      }
+    })
+    const selected = await service.update({
+      id: created.id,
+      revision: full.revision,
+      capabilityMode: 'selected',
+      selectedCapabilities: {
+        skillIds: ['skill-b'],
+        connectorIds: ['chemistry'],
+        connectorTools: []
+      }
+    })
+
+    expect(selected.capabilityMode).toBe('selected')
+    expect(selected.fullAccess.excludedConnectorIds).toEqual(['pubmed'])
+    expect(selected.selectedCapabilities.connectorIds).toEqual(['chemistry'])
+
+    const switchedBack = await service.update({
+      id: created.id,
+      revision: selected.revision,
+      capabilityMode: 'full'
+    })
+    expect(switchedBack.fullAccess.excludedConnectorIds).toEqual(['pubmed'])
+    expect(switchedBack.selectedCapabilities.connectorIds).toEqual(['chemistry'])
+  })
+
+  it('rejects malformed capability patches before persistence', async () => {
+    const created = await service.create({ name: 'Connector Bot' })
+    await expect(
+      service.update({
+        id: created.id,
+        revision: created.revision,
+        fullAccess: { excludedSkillIds: [], excludedConnectorIds: [42], connectorTools: [] }
+      } as never)
+    ).rejects.toThrow(/capability configuration/i)
+    expect((await service.getById(created.id)).revision).toBe(created.revision)
+  })
+
+  it('keeps the immutable id and supports renaming', async () => {
+    const created = await service.create({ name: 'My Bot' })
+    const updated = await service.update({
+      id: created.id,
+      revision: created.revision,
+      name: 'Custom Renamed'
+    })
+    expect(updated.id).toBe(created.id)
+    expect(updated.name).toBe('Custom Renamed')
+  })
+
+  it('allows keeping the same name (self excluded from uniqueness)', async () => {
+    const created = await service.create({ name: 'My Bot' })
+    const updated = await service.update({
+      id: created.id,
+      revision: created.revision,
+      name: created.name
+    })
+    expect(updated.name).toBe(created.name)
+  })
+
+  it('rejects a name that collides with another specialist', async () => {
+    const first = await service.create({ name: 'Alpha Bot' })
+    const second = await service.create({ name: 'Beta Bot' })
+    await expect(
+      service.update({ id: second.id, revision: second.revision, name: first.name })
+    ).rejects.toThrow(/already in use/i)
+
+    expect(await service.list()).toHaveLength(2)
+  })
+
+  it('rejects a stale revision (optimistic concurrency conflict)', async () => {
+    const created = await service.create({ name: 'My Bot' })
+    await expect(
+      service.update({ id: created.id, revision: created.revision + 1, name: 'X' })
+    ).rejects.toThrow(/revision conflict/i)
+  })
+
+  it('notifies listeners after a successful update', async () => {
+    const created = await service.create({ name: 'My Bot' })
+    const listener = vi.fn()
+    service.subscribe(listener)
+    await service.update({ id: created.id, revision: created.revision, description: 'new' })
+    expect(listener).toHaveBeenCalledOnce()
+  })
+
+  it('rejects an update missing revision', async () => {
+    const created = await service.create({ name: 'My Bot' })
+    await expect(service.update({ id: created.id } as never)).rejects.toThrow(/id and revision/i)
+  })
+})
+
+describe('ProfileService.listForSettings', () => {
+  it('includes custom specialists', async () => {
+    await service.create({ name: 'My Bot' })
+    const items = await service.listForSettings()
+    expect(items.some((i) => i.kind === 'custom')).toBe(true)
+  })
+
+  it('always includes built-in Reviewer placeholder', async () => {
+    const items = await service.listForSettings()
+    const reviewer = items.find((i) => i.kind === 'reviewer')
+    expect(reviewer).toBeDefined()
+  })
+
+  it('Reviewer id is "reviewer"', async () => {
+    const items = await service.listForSettings()
+    const reviewer = items.find((i) => i.kind === 'reviewer')
+    expect(reviewer?.id).toBe('reviewer')
+  })
+})
+
+describe('ProfileService.subscribe', () => {
+  it('notifies listener after create', async () => {
+    const listener = vi.fn()
+    service.subscribe(listener)
+    await service.create({ name: 'My Bot' })
+    expect(listener).toHaveBeenCalledOnce()
+  })
+
+  it('notifies listener after setEnabled', async () => {
+    const created = await service.create({ name: 'My Bot' })
+    const listener = vi.fn()
+    service.subscribe(listener)
+    await service.setEnabled(created.id, false)
+    expect(listener).toHaveBeenCalledOnce()
+  })
+
+  it('unsubscribe stops notifications', async () => {
+    const listener = vi.fn()
+    const unsub = service.subscribe(listener)
+    unsub()
+    await service.create({ name: 'My Bot' })
+    expect(listener).not.toHaveBeenCalled()
+  })
+})
+
+describe('ProfileService lifecycle mutations', () => {
+  it('keeps UUID stable across public rename and rejects a stale delete', async () => {
+    const created = await service.create({ name: 'RNA Reviewer', displayName: 'RNA reviewer' })
+    const renamed = await service.rename({
+      id: created.id,
+      name: 'RNA Auditor',
+      expectedRevision: created.revision
+    })
+    expect(renamed).toMatchObject({ id: created.id, name: 'RNA Auditor' })
+    await expect(service.delete(created.id, created.revision)).rejects.toThrow(/revision conflict/i)
+    expect(await service.getById(created.id)).toMatchObject({ name: 'RNA Auditor' })
+  })
+
+  it('duplicates deeply without persisting until the caller creates it', async () => {
+    const created = await service.create({
+      name: 'Chemist',
+      displayName: 'Chemist',
+      selectedCapabilities: {
+        skillIds: ['chemistry'],
+        connectorIds: ['pubmed'],
+        connectorTools: []
+      }
+    })
+    const draft = await service.duplicate(created.id)
+    // New single-name model: duplicate returns a free-form "Copy" suffix name.
+    expect(draft).toMatchObject({ name: 'Chemist Copy', displayName: 'Chemist Copy' })
+    expect(await service.list()).toHaveLength(1)
+    draft.selectedCapabilities?.skillIds.push('other')
+    expect((await service.getById(created.id)).selectedCapabilities.skillIds).toEqual(['chemistry'])
+  })
+
+  it('serializes collection patches through revision checks', async () => {
+    const created = await service.create({ name: 'CURATOR', displayName: 'Curator' })
+    const attached = await service.attachSkill(created.id, 'skill-a', created.revision)
+    expect(attached.selectedCapabilities.skillIds).toEqual(['skill-a'])
+    await expect(service.attachConnector(created.id, 'pubmed', created.revision)).rejects.toThrow(
+      /revision conflict/i
+    )
+  })
+})
+
+describe('ProfileService restart persistence', () => {
+  it('persists enabled=false across a service restart (re-create from same store)', async () => {
+    const created = await service.create({ name: 'PERSISTENT_BOT' })
+    expect(created.enabled).toBe(true)
+
+    await service.setEnabled(created.id, false)
+
+    // Simulate restart: create a new service instance from the same storage directory.
+    const restarted = new ProfileService(new SpecialistRepository(tmpDir))
+    const afterRestart = await restarted.getById(created.id)
+    expect(afterRestart.enabled).toBe(false)
+  })
+
+  it('preserves all specialist data after restart', async () => {
+    const created = await service.create({
+      name: 'RESTART_BOT',
+      displayName: 'Restart Bot',
+      description: 'Survives restart',
+      capabilityMode: 'selected',
+      selectedCapabilities: { skillIds: ['skill-x'], connectorIds: ['conn-y'], connectorTools: [] }
+    })
+
+    const restarted = new ProfileService(new SpecialistRepository(tmpDir))
+    const found = await restarted.getById(created.id)
+
+    expect(found.id).toBe(created.id)
+    expect(found.name).toBe('RESTART_BOT')
+    expect(found.displayName).toBe('Restart Bot')
+    expect(found.enabled).toBe(true)
+    expect(found.capabilityMode).toBe('selected')
+    expect(found.selectedCapabilities.skillIds).toEqual(['skill-x'])
+  })
+})
+
+describe('ProfileService session binding with stable IDs', () => {
+  it('keeps the UUID stable after rename — a stored session binding still resolves', async () => {
+    const created = await service.create({ name: 'RNA_REVIEWER' })
+    const originalId = created.id
+
+    // Simulate a session binding: record the profile UUID.
+    const sessionBinding = { profileId: created.id }
+
+    // Rename the profile.
+    await service.rename({
+      id: created.id,
+      name: 'RNA_AUDITOR',
+      expectedRevision: created.revision
+    })
+
+    // The session binding UUID still resolves to the renamed profile.
+    const resolved = await service.getById(sessionBinding.profileId)
+    expect(resolved.id).toBe(originalId)
+    expect(resolved.name).toBe('RNA_AUDITOR')
+  })
+
+  it('reports missing for a deleted profile UUID without erroring the catalog', async () => {
+    const created = await service.create({ name: 'TEMP_BOT' })
+    await service.delete(created.id)
+
+    // The deleted UUID no longer resolves.
+    await expect(service.getById(created.id)).rejects.toThrow(/not found/i)
+
+    // Other profiles are unaffected.
+    const other = await service.create({ name: 'OTHER_BOT' })
+    const found = await service.getById(other.id)
+    expect(found.name).toBe('OTHER_BOT')
+  })
+})
+
+describe('ProfileService stable Skill/Connector references', () => {
+  it('skill attachment tracks by ID — renamed display name does not break the binding', async () => {
+    // Attach a skill by stable ID. In a real app the skill catalog has a stable id
+    // and a separate display name. Profile stores the id, never the display name.
+    const created = await service.create({ name: 'ID_TRACKER', capabilityMode: 'selected' })
+    const withSkill = await service.attachSkill(created.id, 'skill-stable-id', created.revision)
+    expect(withSkill.selectedCapabilities.skillIds).toContain('skill-stable-id')
+
+    // Renaming a skill's display name is a catalog-layer change; the stored skill id
+    // remains unchanged. Profile attachment is independent of display name.
+    const fetched = await service.getById(created.id)
+    expect(fetched.selectedCapabilities.skillIds).toContain('skill-stable-id')
+  })
+
+  it('deleted skill ID stays in the profile — renderer shows it as missing', async () => {
+    const created = await service.create({ name: 'MISSING_REF_BOT', capabilityMode: 'selected' })
+    const withSkill = await service.attachSkill(created.id, 'soon-deleted-skill', created.revision)
+    expect(withSkill.selectedCapabilities.skillIds).toContain('soon-deleted-skill')
+
+    // Deleting the skill from the catalog is a catalog-layer operation.
+    // The profile still holds the id — renderer must display it as "missing".
+    const fetched = await service.getById(created.id)
+    expect(fetched.selectedCapabilities.skillIds).toContain('soon-deleted-skill')
+  })
+
+  it('two skills with different IDs but same display name are tracked by ID independently', async () => {
+    const created = await service.create({
+      name: 'DUAL_SKILL_BOT',
+      capabilityMode: 'selected',
+      selectedCapabilities: {
+        skillIds: ['skill-v1', 'skill-v2'],
+        connectorIds: [],
+        connectorTools: []
+      }
+    })
+
+    const fetched = await service.getById(created.id)
+    // Both IDs are stored even if they have the same display name in the catalog.
+    expect(fetched.selectedCapabilities.skillIds).toContain('skill-v1')
+    expect(fetched.selectedCapabilities.skillIds).toContain('skill-v2')
+
+    // Detaching one does not affect the other.
+    const detached = await service.detachSkill(created.id, 'skill-v1', fetched.revision)
+    expect(detached.selectedCapabilities.skillIds).not.toContain('skill-v1')
+    expect(detached.selectedCapabilities.skillIds).toContain('skill-v2')
+  })
+})

--- a/src/main/specialist/service.ts
+++ b/src/main/specialist/service.ts
@@ -1,0 +1,416 @@
+import { randomUUID } from 'node:crypto'
+
+import { createLogger } from '../logger'
+import { SpecialistRepository } from './repository'
+import type { StoredSpecialist } from './types'
+import type {
+  SpecialistProfileView,
+  SpecialistListItem,
+  CreateSpecialistInput,
+  UpdateSpecialistInput,
+  SpecialistCapabilityMode,
+  SpecialistFullAccessConfig,
+  SpecialistSelectedConfig
+} from '../../shared/specialist'
+import {
+  validateCreateSpecialistInput,
+  validateUpdateSpecialistInput,
+  validateSpecialistPublicName,
+  emptyFullAccessConfig,
+  emptySelectedConfig
+} from '../../shared/specialist'
+
+const isStringArray = (value: unknown): value is string[] =>
+  Array.isArray(value) && value.every((item) => typeof item === 'string')
+
+const isConnectorToolRuleArray = (value: unknown): boolean =>
+  Array.isArray(value) &&
+  value.every(
+    (rule) =>
+      rule &&
+      typeof rule === 'object' &&
+      typeof (rule as { connectorId?: unknown }).connectorId === 'string' &&
+      (
+        [
+          (rule as { includedMethods?: unknown }).includedMethods,
+          (rule as { excludedMethods?: unknown }).excludedMethods
+        ] as unknown[]
+      ).every((methods) => methods === undefined || isStringArray(methods)) &&
+      [
+        (rule as { includeToolsPattern?: unknown }).includeToolsPattern,
+        (rule as { excludeToolsPattern?: unknown }).excludeToolsPattern
+      ].every((pattern) => pattern === undefined || typeof pattern === 'string')
+  )
+
+const assertCapabilityConfigShape = (
+  input: Pick<UpdateSpecialistInput, 'capabilityMode' | 'fullAccess' | 'selectedCapabilities'>
+): void => {
+  if (
+    input.capabilityMode !== undefined &&
+    input.capabilityMode !== 'full' &&
+    input.capabilityMode !== 'selected'
+  ) {
+    throw new Error('Capability mode must be "full" or "selected".')
+  }
+  if (input.fullAccess !== undefined) {
+    const config = input.fullAccess
+    if (
+      !config ||
+      typeof config !== 'object' ||
+      !isStringArray((config as SpecialistFullAccessConfig).excludedSkillIds) ||
+      !isStringArray((config as SpecialistFullAccessConfig).excludedConnectorIds) ||
+      !isConnectorToolRuleArray((config as SpecialistFullAccessConfig).connectorTools)
+    ) {
+      throw new Error('Full access capability configuration is invalid.')
+    }
+  }
+  if (input.selectedCapabilities !== undefined) {
+    const config = input.selectedCapabilities
+    if (
+      !config ||
+      typeof config !== 'object' ||
+      !isStringArray((config as SpecialistSelectedConfig).skillIds) ||
+      !isStringArray((config as SpecialistSelectedConfig).connectorIds) ||
+      !isConnectorToolRuleArray((config as SpecialistSelectedConfig).connectorTools)
+    ) {
+      throw new Error('Selected capabilities configuration is invalid.')
+    }
+  }
+}
+
+const log = createLogger('specialist.service')
+
+// ---------------------------------------------------------------------------
+// View projection
+// ---------------------------------------------------------------------------
+
+const toView = (s: StoredSpecialist): SpecialistProfileView => ({
+  id: s.id,
+  name: s.name,
+  displayName: s.displayName ?? s.name,
+  description: s.description,
+  systemPrompt: s.systemPrompt,
+  iconKey: s.iconKey,
+  colorKey: s.colorKey,
+  enabled: s.enabled,
+  capabilityMode: s.capabilityMode,
+  fullAccess: s.fullAccess,
+  selectedCapabilities: s.selectedCapabilities,
+  revision: s.revision
+})
+
+const assertCreateInputShape = (input: CreateSpecialistInput): void => {
+  if (!input || typeof input !== 'object' || typeof input.name !== 'string') {
+    throw new Error('Name must be a string.')
+  }
+
+  const optionalTextFields = [
+    ['description', input.description],
+    ['display name', input.displayName],
+    ['system prompt', input.systemPrompt],
+    ['icon', input.iconKey],
+    ['color', input.colorKey]
+  ] as const
+  for (const [label, value] of optionalTextFields) {
+    if (value !== undefined && typeof value !== 'string') {
+      throw new Error(`${label[0].toUpperCase()}${label.slice(1)} must be a string.`)
+    }
+  }
+
+  if (
+    input.capabilityMode !== undefined &&
+    input.capabilityMode !== 'full' &&
+    input.capabilityMode !== 'selected'
+  ) {
+    throw new Error('Capability mode must be "full" or "selected".')
+  }
+  assertCapabilityConfigShape(input)
+}
+
+// ---------------------------------------------------------------------------
+// ProfileService
+// ---------------------------------------------------------------------------
+
+// The single domain service for Specialist Profiles.
+// Settings, IPC handlers, and future SDK callers must use this — never bypass
+// it to write directly to the repository.
+export class ProfileService {
+  private readonly listeners: Set<() => void> = new Set()
+
+  constructor(private readonly repo: SpecialistRepository) {}
+
+  // Returns all custom specialists as views (no Reviewer, no Main Agent, no None).
+  async list(): Promise<SpecialistProfileView[]> {
+    const doc = await this.repo.getAll()
+    return doc.specialists.map(toView)
+  }
+
+  // Returns the full list for the Settings UI, including the built-in Reviewer placeholder.
+  async listForSettings(): Promise<SpecialistListItem[]> {
+    const custom = await this.list()
+    const items: SpecialistListItem[] = custom.map((v) => ({ kind: 'custom' as const, ...v }))
+    items.push({ kind: 'reviewer', id: 'reviewer' })
+    return items
+  }
+
+  async getById(id: string): Promise<SpecialistProfileView> {
+    const doc = await this.repo.getAll()
+    const found = doc.specialists.find((s) => s.id === id)
+    if (!found) throw new Error(`Specialist ${id} not found.`)
+    return toView(found)
+  }
+
+  async getByName(name: string): Promise<SpecialistProfileView> {
+    const doc = await this.repo.getAll()
+    const found = doc.specialists.find((s) => s.name === name)
+    if (!found) throw new Error(`Specialist "${name}" not found.`)
+    return toView(found)
+  }
+
+  async create(input: CreateSpecialistInput): Promise<SpecialistProfileView> {
+    assertCreateInputShape(input)
+
+    const doc = await this.repo.getAll()
+    const existingNames = doc.specialists.map((s) => s.name)
+    const existingIds = new Map(doc.specialists.map((s) => [s.name, s.id]))
+
+    // validateCreateSpecialistInput now applies the public-name format rule when
+    // displayName is present, so create and update share one symmetric rule set.
+    const errors = validateCreateSpecialistInput(input, existingNames, existingIds)
+    if (errors.length > 0) {
+      throw new Error(errors.map((e) => e.message).join('; '))
+    }
+
+    const name = input.name
+
+    const stored: StoredSpecialist = {
+      id: randomUUID(),
+      name,
+      displayName: input.displayName ?? name,
+      description: input.description ?? '',
+      systemPrompt: input.systemPrompt ?? '',
+      iconKey: input.iconKey,
+      colorKey: input.colorKey,
+      enabled: true,
+      capabilityMode: input.capabilityMode ?? 'full',
+      fullAccess: input.fullAccess ?? emptyFullAccessConfig(),
+      selectedCapabilities: input.selectedCapabilities ?? emptySelectedConfig(),
+      revision: 1
+    }
+
+    // Do NOT log systemPrompt content per cross-cutting requirement.
+    log.info('creating specialist', { id: stored.id, name: stored.name })
+
+    await this.repo.insert(stored)
+    this.notify()
+    return toView(stored)
+  }
+
+  async setEnabled(id: string, enabled: boolean): Promise<SpecialistProfileView> {
+    const updatedDoc = await this.repo.setEnabled(id, enabled)
+    this.notify()
+    const found = updatedDoc.specialists.find((s) => s.id === id)
+    if (!found) throw new Error(`Specialist ${id} not found after setEnabled.`)
+    return toView(found)
+  }
+
+  // Atomically patches identity/instructions fields on an existing specialist.
+  // Re-validates display name and public name (uniqueness skips the record's own
+  // id so self-rename is allowed). `revision` must match the stored record
+  // (optimistic concurrency); the repository bumps it and rejects stale writes.
+  async update(input: UpdateSpecialistInput): Promise<SpecialistProfileView> {
+    if (!input || typeof input.id !== 'string' || typeof input.revision !== 'number') {
+      throw new Error('Update requires id and revision.')
+    }
+    assertCapabilityConfigShape(input)
+
+    const doc = await this.repo.getAll()
+    const existingNames = doc.specialists.map((s) => s.name)
+    const existingIds = new Map(doc.specialists.map((s) => [s.name, s.id]))
+
+    const errors = validateUpdateSpecialistInput(input, existingNames, existingIds)
+    if (errors.length > 0) {
+      throw new Error(errors.map((e) => e.message).join('; '))
+    }
+
+    const patch: Partial<StoredSpecialist> = {}
+    if (input.name !== undefined) patch.name = input.name
+    if (input.displayName !== undefined) patch.displayName = input.displayName
+    if (input.description !== undefined) patch.description = input.description
+    if (input.systemPrompt !== undefined) patch.systemPrompt = input.systemPrompt
+    if (input.iconKey !== undefined) patch.iconKey = input.iconKey
+    if (input.colorKey !== undefined) patch.colorKey = input.colorKey
+    if (input.capabilityMode !== undefined) patch.capabilityMode = input.capabilityMode
+    if (input.fullAccess !== undefined) patch.fullAccess = input.fullAccess
+    if (input.selectedCapabilities !== undefined) {
+      patch.selectedCapabilities = input.selectedCapabilities
+    }
+
+    log.info('updating specialist', { id: input.id, name: patch.name })
+
+    const updatedDoc = await this.repo.update(input.id, patch, input.revision)
+    this.notify()
+    const updated = updatedDoc.specialists.find((s) => s.id === input.id)
+    if (!updated) throw new Error(`Specialist ${input.id} not found after update.`)
+    return toView(updated)
+  }
+
+  // Naming is kept as a separate lifecycle mutation so SDK approval flows can
+  // re-check the exact record and revision immediately before committing.
+  async rename(input: {
+    id: string
+    name: string
+    expectedRevision?: number
+  }): Promise<SpecialistProfileView> {
+    // Use the same relaxed public-name validator as create() for consistency.
+    const nameError = validateSpecialistPublicName(input.name)
+    if (nameError) throw new Error(nameError)
+    const current = await this.getById(input.id)
+    const revision = input.expectedRevision ?? current.revision
+    return this.update({ id: input.id, name: input.name, revision })
+  }
+
+  async delete(id: string, expectedRevision?: number): Promise<void> {
+    await this.repo.delete(id, expectedRevision)
+    this.notify()
+  }
+
+  async duplicate(id: string): Promise<Omit<CreateSpecialistInput, 'name'> & { name: string }> {
+    const source = await this.getById(id)
+    const names = new Set((await this.list()).map((profile) => profile.name))
+    // Use the display name (which equals name in the single-name model) as the base.
+    const sourceName = source.displayName ?? source.name
+    const base = `${sourceName} Copy`
+    let name = base.slice(0, 80)
+    let suffix = 2
+    while (names.has(name)) {
+      const tail = ` ${suffix++}`
+      name = `${base.slice(0, 80 - tail.length)}${tail}`
+    }
+    return {
+      name,
+      displayName: name,
+      description: source.description,
+      systemPrompt: source.systemPrompt,
+      iconKey: source.iconKey,
+      colorKey: source.colorKey,
+      capabilityMode: source.capabilityMode,
+      fullAccess: structuredClone(source.fullAccess),
+      selectedCapabilities: structuredClone(source.selectedCapabilities)
+    }
+  }
+
+  private async patchCollection(
+    id: string,
+    expectedRevision: number,
+    mode: SpecialistCapabilityMode,
+    field: 'skillIds' | 'connectorIds' | 'excludedSkillIds' | 'excludedConnectorIds',
+    value: string,
+    attach: boolean
+  ): Promise<SpecialistProfileView> {
+    const current = await this.getById(id)
+    if (mode === 'full') {
+      const config = structuredClone(current.fullAccess)
+      const values = config[field as 'excludedSkillIds' | 'excludedConnectorIds']
+      config[field as 'excludedSkillIds' | 'excludedConnectorIds'] = attach
+        ? [...new Set([...values, value])]
+        : values.filter((entry) => entry !== value)
+      return this.update({ id, revision: expectedRevision, fullAccess: config })
+    }
+    const config = structuredClone(current.selectedCapabilities)
+    const values = config[field as 'skillIds' | 'connectorIds']
+    config[field as 'skillIds' | 'connectorIds'] = attach
+      ? [...new Set([...values, value])]
+      : values.filter((entry) => entry !== value)
+    return this.update({ id, revision: expectedRevision, selectedCapabilities: config })
+  }
+
+  async attachSkill(
+    id: string,
+    skillId: string,
+    expectedRevision: number,
+    mode: SpecialistCapabilityMode = 'selected'
+  ): Promise<SpecialistProfileView> {
+    return this.patchCollection(
+      id,
+      expectedRevision,
+      mode,
+      mode === 'full' ? 'excludedSkillIds' : 'skillIds',
+      skillId,
+      mode !== 'full'
+    )
+  }
+
+  async detachSkill(
+    id: string,
+    skillId: string,
+    expectedRevision: number,
+    mode: SpecialistCapabilityMode = 'selected'
+  ): Promise<SpecialistProfileView> {
+    return this.patchCollection(
+      id,
+      expectedRevision,
+      mode,
+      mode === 'full' ? 'excludedSkillIds' : 'skillIds',
+      skillId,
+      mode === 'full'
+    )
+  }
+
+  async attachConnector(
+    id: string,
+    connectorId: string,
+    expectedRevision: number,
+    mode: SpecialistCapabilityMode = 'selected'
+  ): Promise<SpecialistProfileView> {
+    return this.patchCollection(
+      id,
+      expectedRevision,
+      mode,
+      mode === 'full' ? 'excludedConnectorIds' : 'connectorIds',
+      connectorId,
+      mode !== 'full'
+    )
+  }
+
+  async detachConnector(
+    id: string,
+    connectorId: string,
+    expectedRevision: number,
+    mode: SpecialistCapabilityMode = 'selected'
+  ): Promise<SpecialistProfileView> {
+    return this.patchCollection(
+      id,
+      expectedRevision,
+      mode,
+      mode === 'full' ? 'excludedConnectorIds' : 'connectorIds',
+      connectorId,
+      mode === 'full'
+    )
+  }
+
+  // Subscribes a listener to be called whenever the profile catalog changes.
+  // Returns an unsubscribe function.
+  subscribe(listener: () => void): () => void {
+    this.listeners.add(listener)
+    return () => this.listeners.delete(listener)
+  }
+
+  private notify(): void {
+    for (const listener of this.listeners) {
+      try {
+        listener()
+      } catch (error) {
+        log.error('specialist catalog listener threw', { error })
+      }
+    }
+  }
+}
+
+// ---------------------------------------------------------------------------
+// Factory
+// ---------------------------------------------------------------------------
+
+export const createProfileService = (storageDir: string): ProfileService => {
+  return new ProfileService(new SpecialistRepository(storageDir))
+}

--- a/src/main/specialist/session-binding.test.ts
+++ b/src/main/specialist/session-binding.test.ts
@@ -1,0 +1,342 @@
+import { describe, it, expect, vi } from 'vitest'
+import { SessionBindingService } from './session-binding'
+import type { ProfileService } from './service'
+import type { SpecialistProfileView } from '../../shared/specialist'
+import { emptyFullAccessConfig, emptySelectedConfig } from '../../shared/specialist'
+
+// ---------------------------------------------------------------------------
+// Helpers
+// ---------------------------------------------------------------------------
+
+const makeProfile = (overrides: Partial<SpecialistProfileView> = {}): SpecialistProfileView => ({
+  id: 'uuid-sp1',
+  name: 'DEBUGGER',
+  displayName: 'Debugger',
+  description: 'A debugging specialist.',
+  systemPrompt: 'You are a debugger.',
+  enabled: true,
+  capabilityMode: 'full',
+  fullAccess: emptyFullAccessConfig(),
+  selectedCapabilities: emptySelectedConfig(),
+  revision: 1,
+  ...overrides
+})
+
+const makeService = (profiles: Map<string, SpecialistProfileView> = new Map()): ProfileService => {
+  return {
+    getById: vi.fn(async (id: string) => {
+      const p = profiles.get(id)
+      if (!p) throw new Error(`Specialist ${id} not found.`)
+      return p
+    })
+  } as unknown as ProfileService
+}
+
+// ---------------------------------------------------------------------------
+// Tests: setBinding / getBinding
+// ---------------------------------------------------------------------------
+
+describe('SessionBindingService.setBinding', () => {
+  it('stores a specialist UUID for a session', () => {
+    const svc = new SessionBindingService(makeService())
+    svc.setBinding('session-a', 'uuid-sp1')
+    expect(svc.getBinding('session-a')).toBe('uuid-sp1')
+  })
+
+  it('clears a binding when undefined is passed', () => {
+    const svc = new SessionBindingService(makeService())
+    svc.setBinding('session-a', 'uuid-sp1')
+    svc.setBinding('session-a', undefined)
+    expect(svc.getBinding('session-a')).toBeUndefined()
+  })
+
+  it('does not affect other sessions', () => {
+    const svc = new SessionBindingService(makeService())
+    svc.setBinding('session-a', 'uuid-sp1')
+    svc.setBinding('session-b', 'uuid-sp2')
+    expect(svc.getBinding('session-a')).toBe('uuid-sp1')
+    expect(svc.getBinding('session-b')).toBe('uuid-sp2')
+  })
+
+  it('last-write-wins when switching multiple times', () => {
+    const svc = new SessionBindingService(makeService())
+    svc.setBinding('session-a', 'uuid-sp1')
+    svc.setBinding('session-a', 'uuid-sp2')
+    svc.setBinding('session-a', 'uuid-sp3')
+    expect(svc.getBinding('session-a')).toBe('uuid-sp3')
+  })
+})
+
+// ---------------------------------------------------------------------------
+// Tests: resolve — main / bound / unavailable
+// ---------------------------------------------------------------------------
+
+describe('SessionBindingService.resolve', () => {
+  it("returns 'main' when no binding is recorded", async () => {
+    const svc = new SessionBindingService(makeService())
+    const result = await svc.resolve('session-a')
+    expect(result.kind).toBe('main')
+  })
+
+  it("returns 'main' after binding is cleared", async () => {
+    const svc = new SessionBindingService(makeService())
+    svc.setBinding('session-a', 'uuid-sp1')
+    svc.setBinding('session-a', undefined)
+    const result = await svc.resolve('session-a')
+    expect(result.kind).toBe('main')
+  })
+
+  it("returns 'bound' with the profile when UUID is found and enabled", async () => {
+    const profile = makeProfile()
+    const svc = new SessionBindingService(makeService(new Map([['uuid-sp1', profile]])))
+    svc.setBinding('session-a', 'uuid-sp1')
+    const result = await svc.resolve('session-a')
+    expect(result.kind).toBe('bound')
+    if (result.kind === 'bound') {
+      expect(result.profile.id).toBe('uuid-sp1')
+      expect(result.profile.name).toBe('DEBUGGER')
+    }
+  })
+
+  it("returns 'unavailable' when UUID is not found in catalog", async () => {
+    const svc = new SessionBindingService(makeService())
+    svc.setBinding('session-a', 'uuid-deleted')
+    const result = await svc.resolve('session-a')
+    expect(result.kind).toBe('unavailable')
+    if (result.kind === 'unavailable') {
+      expect(result.reason).toContain('uuid-deleted')
+    }
+  })
+
+  it("returns 'unavailable' when profile is disabled", async () => {
+    const profile = makeProfile({ enabled: false })
+    const svc = new SessionBindingService(makeService(new Map([['uuid-sp1', profile]])))
+    svc.setBinding('session-a', 'uuid-sp1')
+    const result = await svc.resolve('session-a')
+    expect(result.kind).toBe('unavailable')
+    if (result.kind === 'unavailable') {
+      expect(result.reason).toContain('disabled')
+    }
+  })
+
+  it('resolves an override UUID instead of the stored binding', async () => {
+    const profile2 = makeProfile({ id: 'uuid-sp2', name: 'RESEARCHER' })
+    const svc = new SessionBindingService(makeService(new Map([['uuid-sp2', profile2]])))
+    svc.setBinding('session-a', 'uuid-sp1') // stored binding
+    const result = await svc.resolve('session-a', 'uuid-sp2') // override
+    expect(result.kind).toBe('bound')
+    if (result.kind === 'bound') {
+      expect(result.profile.id).toBe('uuid-sp2')
+    }
+  })
+
+  it('isolates sessions — resolve for one does not affect another', async () => {
+    const profile1 = makeProfile({ id: 'uuid-sp1', name: 'DEBUGGER' })
+    const profile2 = makeProfile({ id: 'uuid-sp2', name: 'RESEARCHER' })
+    const svc = new SessionBindingService(
+      makeService(
+        new Map([
+          ['uuid-sp1', profile1],
+          ['uuid-sp2', profile2]
+        ])
+      )
+    )
+    svc.setBinding('session-a', 'uuid-sp1')
+    svc.setBinding('session-b', 'uuid-sp2')
+
+    const [ra, rb] = await Promise.all([svc.resolve('session-a'), svc.resolve('session-b')])
+    expect(ra.kind).toBe('bound')
+    expect(rb.kind).toBe('bound')
+    if (ra.kind === 'bound') expect(ra.profile.id).toBe('uuid-sp1')
+    if (rb.kind === 'bound') expect(rb.profile.id).toBe('uuid-sp2')
+  })
+})
+
+// ---------------------------------------------------------------------------
+// Tests: clearSession
+// ---------------------------------------------------------------------------
+
+describe('SessionBindingService.clearSession', () => {
+  it('removes the binding for the session', async () => {
+    const svc = new SessionBindingService(makeService())
+    svc.setBinding('session-a', 'uuid-sp1')
+    svc.clearSession('session-a')
+    const result = await svc.resolve('session-a')
+    expect(result.kind).toBe('main')
+  })
+
+  it('does not affect other sessions when clearing', () => {
+    const svc = new SessionBindingService(makeService())
+    svc.setBinding('session-a', 'uuid-sp1')
+    svc.setBinding('session-b', 'uuid-sp2')
+    svc.clearSession('session-a')
+    expect(svc.getBinding('session-a')).toBeUndefined()
+    expect(svc.getBinding('session-b')).toBe('uuid-sp2')
+  })
+})
+
+// ---------------------------------------------------------------------------
+// Tests: None clears binding (clears and returns main)
+// ---------------------------------------------------------------------------
+
+describe('SessionBindingService — None clears binding', () => {
+  it('binding cleared to undefined resolves to main (no separate Main profile)', async () => {
+    const profile = makeProfile()
+    const svc = new SessionBindingService(makeService(new Map([['uuid-sp1', profile]])))
+    svc.setBinding('session-a', 'uuid-sp1')
+    svc.setBinding('session-a', undefined) // None
+    const result = await svc.resolve('session-a')
+    expect(result.kind).toBe('main')
+  })
+})
+
+// ---------------------------------------------------------------------------
+// Tests: Lazy reconfigure — profile update reads latest revision
+// ---------------------------------------------------------------------------
+
+describe('SessionBindingService — lazy profile update', () => {
+  it('reads the latest profile on each resolve (not a cached snapshot)', async () => {
+    const profile = makeProfile({ revision: 1, systemPrompt: 'v1' })
+    const catalog = new Map<string, SpecialistProfileView>([['uuid-sp1', profile]])
+    const svc = new SessionBindingService(makeService(catalog))
+    svc.setBinding('session-a', 'uuid-sp1')
+
+    // First resolve returns revision 1.
+    let result = await svc.resolve('session-a')
+    expect(result.kind).toBe('bound')
+    if (result.kind === 'bound') expect(result.profile.revision).toBe(1)
+
+    // Simulate profile update (e.g. user edited identity).
+    catalog.set('uuid-sp1', { ...profile, revision: 2, systemPrompt: 'v2' })
+
+    // Second resolve returns the new revision — not a stale snapshot.
+    result = await svc.resolve('session-a')
+    expect(result.kind).toBe('bound')
+    if (result.kind === 'bound') {
+      expect(result.profile.revision).toBe(2)
+      expect(result.profile.systemPrompt).toBe('v2')
+    }
+  })
+
+  it('catalog-change event does not trigger bulk session resume (lazy resolution only)', async () => {
+    // The binding service must not iterate sessions or trigger per-session resume when the catalog
+    // changes. Correct behavior: each resolve() call reads the latest catalog on demand; the service
+    // holds no subscriber that iterates sessions or triggers any resume operation.
+    const profile = makeProfile({ id: 'uuid-sp1', revision: 1 })
+    const catalog = new Map<string, SpecialistProfileView>([['uuid-sp1', profile]])
+    const svc = new SessionBindingService(makeService(catalog))
+    svc.setBinding('session-a', 'uuid-sp1')
+
+    // Simulate a catalog-changed event by mutating the catalog backing the service.
+    catalog.set('uuid-sp1', { ...profile, revision: 2 })
+
+    // Only an explicit resolve() call reads the new data — not an automatic side effect.
+    const result = await svc.resolve('session-a')
+    expect(result.kind).toBe('bound')
+    if (result.kind === 'bound') {
+      // Updated revision is visible, but only because we called resolve(), not due to a push.
+      expect(result.profile.revision).toBe(2)
+    }
+
+    // No session iteration happened proactively — resolve was called exactly once above.
+    // The service has no method that processes all sessions at once.
+    expect(typeof (svc as unknown as Record<string, unknown>).resumeAllSessions).toBe('undefined')
+    expect(typeof (svc as unknown as Record<string, unknown>).bulkResume).toBe('undefined')
+    expect(typeof (svc as unknown as Record<string, unknown>).onCatalogChanged).toBe('undefined')
+  })
+})
+
+// ---------------------------------------------------------------------------
+// Tests: I/O failure vs not-found discrimination
+// ---------------------------------------------------------------------------
+
+describe('SessionBindingService.resolve — I/O failure discrimination', () => {
+  it("returns 'unavailable' with an I/O reason for non-not-found errors", async () => {
+    const brokenService: ProfileService = {
+      getById: vi.fn().mockRejectedValue(new Error('EACCES: permission denied'))
+    } as unknown as ProfileService
+    const svc = new SessionBindingService(brokenService)
+    svc.setBinding('session-a', 'uuid-sp1')
+
+    const result = await svc.resolve('session-a')
+    expect(result.kind).toBe('unavailable')
+    if (result.kind === 'unavailable') {
+      // Must not claim the specialist was deleted — it was an I/O error.
+      expect(result.reason).not.toContain('not found')
+      expect(result.reason).toContain('store error')
+    }
+  })
+
+  it("returns 'unavailable' with a not-found reason for a missing specialist", async () => {
+    const svc = new SessionBindingService(makeService()) // empty catalog
+    svc.setBinding('session-a', 'uuid-deleted')
+
+    const result = await svc.resolve('session-a')
+    expect(result.kind).toBe('unavailable')
+    if (result.kind === 'unavailable') {
+      expect(result.reason).toContain('not found')
+    }
+  })
+})
+
+// ---------------------------------------------------------------------------
+// Tests: clearSession is invoked when a session is deleted
+// ---------------------------------------------------------------------------
+
+describe('SessionBindingService.clearSession — deletion wiring', () => {
+  it('removes the binding when the session is deleted', async () => {
+    const profile = makeProfile()
+    const svc = new SessionBindingService(makeService(new Map([['uuid-sp1', profile]])))
+    svc.setBinding('session-a', 'uuid-sp1')
+
+    // Simulate session deletion
+    svc.clearSession('session-a')
+
+    const result = await svc.resolve('session-a')
+    expect(result.kind).toBe('main')
+    expect(svc.getBinding('session-a')).toBeUndefined()
+  })
+
+  it('does not affect bindings for other sessions on clearSession', () => {
+    const svc = new SessionBindingService(makeService())
+    svc.setBinding('session-a', 'uuid-sp1')
+    svc.setBinding('session-b', 'uuid-sp2')
+
+    svc.clearSession('session-a')
+
+    expect(svc.getBinding('session-a')).toBeUndefined()
+    expect(svc.getBinding('session-b')).toBe('uuid-sp2')
+  })
+})
+
+// ---------------------------------------------------------------------------
+// Tests: restart round-trip (persist → re-read → binding restored)
+// ---------------------------------------------------------------------------
+
+describe('SessionBindingService — restart round-trip simulation', () => {
+  it('binding is the new UUID after simulated restart (re-create service with persisted UUID)', async () => {
+    const profile = makeProfile({ id: 'uuid-sp2', name: 'RESEARCHER' })
+    const catalog = new Map<string, SpecialistProfileView>([['uuid-sp2', profile]])
+
+    // First service instance — represents the running app.
+    const svc1 = new SessionBindingService(makeService(catalog))
+    svc1.setBinding('session-a', 'uuid-sp2')
+
+    // Simulate restart: create a fresh service (in-memory state cleared).
+    const svc2 = new SessionBindingService(makeService(catalog))
+    // On restart, the renderer calls sessions:load-all and then re-hydrates each session's
+    // specialistId from the durable file into the new binding service. Simulate that here.
+    const persistedSpecialistId = svc1.getBinding('session-a')
+    expect(persistedSpecialistId).toBe('uuid-sp2')
+    if (persistedSpecialistId !== undefined) {
+      svc2.setBinding('session-a', persistedSpecialistId)
+    }
+
+    // After restart hydration the binding is the new UUID, not the old default.
+    const result = await svc2.resolve('session-a')
+    expect(result.kind).toBe('bound')
+    if (result.kind === 'bound') {
+      expect(result.profile.id).toBe('uuid-sp2')
+    }
+  })
+})

--- a/src/main/specialist/session-binding.ts
+++ b/src/main/specialist/session-binding.ts
@@ -1,0 +1,97 @@
+// Per-session specialist binding store.
+//
+// Responsibilities:
+//   • Record a mutable UUID binding for each app session (in memory).
+//   • Resolve that binding against the live ProfileService catalog to produce a
+//     SessionSpecialistResolution (main | bound | unavailable).
+//   • Act as the named seam for the reconfigure barrier: the future SDK
+//     host.agents.switch() will resolve name→UUID and call setBinding() here,
+//     not a second switching path (see issues/deferred/08).
+//
+// Session persistence (UUID only, never a snapshot) is handled by the caller
+// writing specialistId to the persisted session file; this service holds the
+// live in-memory view and the resolution logic.
+
+import { createLogger } from '../logger'
+import type { ProfileService } from './service'
+import type { SessionSpecialistResolution, SpecialistProfileView } from '../../shared/specialist'
+
+const log = createLogger('specialist.session-binding')
+
+export class SessionBindingService {
+  // sessionId → specialist UUID (undefined = no binding = main agent)
+  private readonly bindings = new Map<string, string | undefined>()
+
+  constructor(private readonly profileService: ProfileService) {}
+
+  // Records (or clears) the specialist UUID for one session. Persisting the
+  // UUID to the session file is the caller's responsibility (IPC handler writes
+  // it via the notebook registry or session persistence layer).
+  setBinding(sessionId: string, specialistId: string | undefined): void {
+    if (specialistId === undefined) {
+      this.bindings.delete(sessionId)
+    } else {
+      this.bindings.set(sessionId, specialistId)
+    }
+    log.debug('session specialist binding updated', { sessionId, specialistId })
+  }
+
+  // Reads the current in-memory binding for a session. Returns undefined when
+  // no binding has been recorded (main agent).
+  getBinding(sessionId: string): string | undefined {
+    return this.bindings.get(sessionId)
+  }
+
+  // Resolves the current binding against the live catalog.
+  // - 'main'        — no UUID binding present.
+  // - 'bound'       — UUID found, profile enabled.
+  // - 'unavailable' — UUID unknown, disabled, or corrupt.
+  //
+  // If `overrideSpecialistId` is provided, that UUID is resolved instead of the
+  // stored binding (used by the IPC handler to validate a proposed new binding).
+  async resolve(
+    sessionId: string,
+    overrideSpecialistId?: string
+  ): Promise<SessionSpecialistResolution> {
+    const specialistId = overrideSpecialistId ?? this.bindings.get(sessionId)
+    if (!specialistId) return { kind: 'main' }
+
+    let profile: SpecialistProfileView | undefined
+    try {
+      profile = await this.profileService.getById(specialistId)
+    } catch (error) {
+      // Distinguish a genuine not-found (profile deleted) from a transient I/O failure (corrupt
+      // store, permission error). getById throws "Specialist <id> not found." for missing profiles;
+      // any other error is an I/O or data failure. Log the real error so a corrupt store is
+      // diagnosable rather than silently misreported as a deletion.
+      const message = error instanceof Error ? error.message : String(error)
+      const isNotFound = message.includes('not found')
+      if (!isNotFound) {
+        log.error('specialist catalog read failed; treating binding as unavailable', {
+          sessionId,
+          specialistId,
+          error
+        })
+        return {
+          kind: 'unavailable',
+          reason: `Specialist ${specialistId} could not be loaded (store error).`
+        }
+      }
+      log.warn('session specialist not found; binding unavailable', { sessionId, specialistId })
+      return { kind: 'unavailable', reason: `Specialist ${specialistId} not found.` }
+    }
+
+    if (!profile.enabled) {
+      log.warn('session specialist disabled; binding unavailable', { sessionId, specialistId })
+      return { kind: 'unavailable', reason: `Specialist "${profile.name}" is disabled.` }
+    }
+
+    log.debug('session specialist resolved', { sessionId, specialistId, kind: 'bound' })
+    return { kind: 'bound', profile }
+  }
+
+  // Removes all bindings for a session (called when a session is deleted).
+  clearSession(sessionId: string): void {
+    this.bindings.delete(sessionId)
+  }
+}

--- a/src/main/specialist/specialist-identity-injection.test.ts
+++ b/src/main/specialist/specialist-identity-injection.test.ts
@@ -1,0 +1,578 @@
+// Tests for specialist first-turn identity injection.
+// Covers: Claude append, Codex/OpenCode prefix, None, unavailable race.
+
+import { describe, it, expect, vi } from 'vitest'
+import {
+  buildSpecialistIdentityAppend,
+  buildSpecialistIdentityPrefix,
+  SPECIALIST_IDENTITY_TAG
+} from './identity'
+import { AcpRuntime } from '../acp/runtime'
+import { claudeCodeFramework, codexFramework, opencodeFramework } from '../agent-framework'
+import { emptyFullAccessConfig, emptySelectedConfig } from '../../shared/specialist'
+import type { SpecialistProfileView } from '../../shared/specialist'
+import * as acp from '@agentclientprotocol/sdk'
+import { EventEmitter } from 'node:events'
+import type { ChildProcessWithoutNullStreams } from 'node:child_process'
+import { PassThrough } from 'node:stream'
+import { Readable, Writable } from 'node:stream'
+
+// ---------------------------------------------------------------------------
+// Fake agent process helpers (mirrors runtime.test.ts pattern)
+// ---------------------------------------------------------------------------
+
+class FakeAgentProcess extends EventEmitter {
+  stdin = new PassThrough()
+  stdout = new PassThrough()
+  stderr = new PassThrough()
+  killed = false
+  kill(): boolean {
+    this.killed = true
+    this.emit('exit', 0, null)
+    return true
+  }
+}
+
+const asAgentProcess = (p: FakeAgentProcess): ChildProcessWithoutNullStreams =>
+  p as unknown as ChildProcessWithoutNullStreams
+
+interface FakeAgentResult {
+  newSessions: Array<{ cwd: string; mcpServers: unknown[]; _meta?: unknown }>
+  prompts: Array<{ sessionId: string; text: string }>
+}
+
+const startFakeAgent = (process: FakeAgentProcess, sessionIds: string[]): FakeAgentResult => {
+  const newSessions: Array<{ cwd: string; mcpServers: unknown[]; _meta?: unknown }> = []
+  const prompts: Array<{ sessionId: string; text: string }> = []
+  let sessionIndex = 0
+
+  acp
+    .agent({ name: 'test-agent' })
+    .onRequest(acp.methods.agent.initialize, () => ({
+      protocolVersion: acp.PROTOCOL_VERSION,
+      agentCapabilities: {
+        loadSession: false,
+        sessionCapabilities: { close: {}, resume: {} }
+      },
+      authMethods: []
+    }))
+    .onRequest(acp.methods.agent.authenticate, () => ({}))
+    .onRequest(acp.methods.agent.providers.set, () => ({}))
+    .onRequest(acp.methods.agent.session.new, (ctx) => {
+      newSessions.push({
+        cwd: ctx.params.cwd,
+        mcpServers: ctx.params.mcpServers,
+        ...(ctx.params._meta === undefined ? {} : { _meta: ctx.params._meta })
+      })
+      const sessionId = sessionIds[sessionIndex++]
+      return { sessionId }
+    })
+    .onRequest(acp.methods.agent.session.resume, () => ({}))
+    .onRequest(acp.methods.agent.session.setMode, () => ({}))
+    .onRequest(acp.methods.agent.session.setConfigOption, () => ({ configOptions: [] }))
+    .onRequest(acp.methods.agent.session.prompt, async (ctx) => {
+      const text = ctx.params.prompt
+        .map((content) => (content.type === 'text' ? content.text : ''))
+        .join('')
+      prompts.push({ sessionId: ctx.params.sessionId, text })
+      await ctx.client.notify(acp.methods.client.session.update, {
+        sessionId: ctx.params.sessionId,
+        update: {
+          sessionUpdate: 'agent_message_chunk',
+          messageId: `reply-${ctx.params.sessionId}`,
+          content: { type: 'text', text: 'ok' }
+        }
+      })
+      return { stopReason: 'end_turn' }
+    })
+    .onNotification(acp.methods.agent.session.cancel, () => undefined)
+    .onRequest(acp.methods.agent.session.close, () => ({}))
+    .connect(
+      acp.ndJsonStream(
+        Writable.toWeb(process.stdout) as WritableStream<Uint8Array>,
+        Readable.toWeb(process.stdin) as ReadableStream<Uint8Array>
+      )
+    )
+
+  return { newSessions, prompts }
+}
+
+// ---------------------------------------------------------------------------
+// Profile helpers
+// ---------------------------------------------------------------------------
+
+const CODEX_MODES = {
+  currentModeId: 'agent',
+  availableModes: ['read-only', 'agent', 'agent-full-access'].map((id) => ({ id, name: id }))
+}
+
+// startFakeAgent with optional modes (Codex requires modes to configure permission profile)
+const startFakeAgentWithModes = (
+  process: FakeAgentProcess,
+  sessionIds: string[],
+  modes?: { currentModeId: string; availableModes: Array<{ id: string; name: string }> }
+): FakeAgentResult => {
+  const newSessions: Array<{ cwd: string; mcpServers: unknown[]; _meta?: unknown }> = []
+  const prompts: Array<{ sessionId: string; text: string }> = []
+  let sessionIndex = 0
+
+  acp
+    .agent({ name: 'test-agent' })
+    .onRequest(acp.methods.agent.initialize, () => ({
+      protocolVersion: acp.PROTOCOL_VERSION,
+      agentCapabilities: {
+        loadSession: false,
+        sessionCapabilities: { close: {}, resume: {} }
+      },
+      authMethods: []
+    }))
+    .onRequest(acp.methods.agent.authenticate, () => ({}))
+    .onRequest(acp.methods.agent.providers.set, () => ({}))
+    .onRequest(acp.methods.agent.session.new, (ctx) => {
+      newSessions.push({
+        cwd: ctx.params.cwd,
+        mcpServers: ctx.params.mcpServers,
+        ...(ctx.params._meta === undefined ? {} : { _meta: ctx.params._meta })
+      })
+      const sessionId = sessionIds[sessionIndex++]
+      return { sessionId, ...(modes ? { modes } : {}) }
+    })
+    .onRequest(acp.methods.agent.session.resume, () => ({}))
+    .onRequest(acp.methods.agent.session.setMode, () => ({}))
+    .onRequest(acp.methods.agent.session.setConfigOption, () => ({ configOptions: [] }))
+    .onRequest(acp.methods.agent.session.prompt, async (ctx) => {
+      const text = ctx.params.prompt
+        .map((content) => (content.type === 'text' ? content.text : ''))
+        .join('')
+      prompts.push({ sessionId: ctx.params.sessionId, text })
+      await ctx.client.notify(acp.methods.client.session.update, {
+        sessionId: ctx.params.sessionId,
+        update: {
+          sessionUpdate: 'agent_message_chunk',
+          messageId: `reply-${ctx.params.sessionId}`,
+          content: { type: 'text', text: 'ok' }
+        }
+      })
+      return { stopReason: 'end_turn' }
+    })
+    .onNotification(acp.methods.agent.session.cancel, () => undefined)
+    .onRequest(acp.methods.agent.session.close, () => ({}))
+    .connect(
+      acp.ndJsonStream(
+        Writable.toWeb(process.stdout) as WritableStream<Uint8Array>,
+        Readable.toWeb(process.stdin) as ReadableStream<Uint8Array>
+      )
+    )
+
+  return { newSessions, prompts }
+}
+
+// ---------------------------------------------------------------------------
+// Profile helpers
+// ---------------------------------------------------------------------------
+
+const makeProfile = (overrides: Partial<SpecialistProfileView> = {}): SpecialistProfileView => ({
+  id: 'uuid-sp1',
+  name: 'RNA-seq Reviewer',
+  description: 'Reviews RNA-seq analysis quality.',
+  systemPrompt: 'You are RNA-seq Reviewer. Focus on batch effects and QC.',
+  enabled: true,
+  capabilityMode: 'full',
+  fullAccess: emptyFullAccessConfig(),
+  selectedCapabilities: emptySelectedConfig(),
+  revision: 1,
+  ...overrides
+})
+
+// ---------------------------------------------------------------------------
+// Tests: Claude Code first-turn append
+// ---------------------------------------------------------------------------
+
+describe('specialist identity injection — Claude Code', () => {
+  it('includes SPECIALIST_IDENTITY_TAG in session _meta when specialistId is provided', async () => {
+    const process = new FakeAgentProcess()
+    const fakeAgent = startFakeAgent(process, ['session-sp1'])
+    const profile = makeProfile()
+    const registerSessionSpecialist = vi.fn()
+
+    const runtime = new AcpRuntime({
+      appVersion: '0.1.0',
+      defaultCwd: '/workspace',
+      resolveBackend: () => ({
+        framework: { ...claudeCodeFramework, spawn: () => asAgentProcess(process) },
+        executablePath: '/bin/agent',
+        env: {}
+      }),
+      resolveSpecialistIdentity: async (specialistId, frameworkId) => {
+        expect(specialistId).toBe('uuid-sp1')
+        expect(frameworkId).toBe('claude-code')
+        return { append: buildSpecialistIdentityAppend(profile), prefix: '' }
+      },
+      notebook: {
+        projectName: 'test',
+        mcpEntryPath: '/test/mcp.js',
+        getRpcConnection: async () => ({ endpoint: 'http://127.0.0.1', token: 'test' }),
+        registerSessionSpecialist
+      }
+    })
+
+    await runtime.createSession({ cwd: '/workspace', specialistId: 'uuid-sp1' })
+
+    const metaStr = JSON.stringify(fakeAgent.newSessions[0]._meta)
+    expect(metaStr).toContain(SPECIALIST_IDENTITY_TAG)
+    expect(metaStr).toContain('RNA-seq Reviewer')
+    expect(registerSessionSpecialist).toHaveBeenCalledWith('session-sp1', 'uuid-sp1')
+  })
+
+  it('does NOT inject specialist tag when specialistId is absent', async () => {
+    const process = new FakeAgentProcess()
+    const fakeAgent = startFakeAgent(process, ['session-no-sp'])
+    const resolveSpecialistIdentity = vi.fn()
+
+    const runtime = new AcpRuntime({
+      appVersion: '0.1.0',
+      defaultCwd: '/workspace',
+      resolveBackend: () => ({
+        framework: { ...claudeCodeFramework, spawn: () => asAgentProcess(process) },
+        executablePath: '/bin/agent',
+        env: {}
+      }),
+      resolveSpecialistIdentity
+    })
+
+    await runtime.createSession({ cwd: '/workspace' })
+
+    expect(resolveSpecialistIdentity).not.toHaveBeenCalled()
+    const metaStr = JSON.stringify(fakeAgent.newSessions[0]._meta ?? {})
+    expect(metaStr).not.toContain(SPECIALIST_IDENTITY_TAG)
+  })
+
+  it('throws when specialist is unavailable', async () => {
+    const process = new FakeAgentProcess()
+    startFakeAgent(process, ['session-unavail'])
+
+    const runtime = new AcpRuntime({
+      appVersion: '0.1.0',
+      defaultCwd: '/workspace',
+      resolveBackend: () => ({
+        framework: { ...claudeCodeFramework, spawn: () => asAgentProcess(process) },
+        executablePath: '/bin/agent',
+        env: {}
+      }),
+      resolveSpecialistIdentity: async () => undefined
+    })
+
+    await expect(
+      runtime.createSession({ cwd: '/workspace', specialistId: 'uuid-deleted' })
+    ).rejects.toThrow(/unavailable/)
+  })
+
+  it('fails closed when startup did not wire a specialist resolver', async () => {
+    const process = new FakeAgentProcess()
+    const fakeAgent = startFakeAgent(process, ['session-no-resolver'])
+
+    const runtime = new AcpRuntime({
+      appVersion: '0.1.0',
+      defaultCwd: '/workspace',
+      resolveBackend: () => ({
+        framework: { ...claudeCodeFramework, spawn: () => asAgentProcess(process) },
+        executablePath: '/bin/agent',
+        env: {}
+      })
+    })
+
+    await expect(
+      runtime.createSession({ cwd: '/workspace', specialistId: 'uuid-sp1' })
+    ).rejects.toThrow(/identity resolution is unavailable/)
+    expect(fakeAgent.newSessions).toHaveLength(0)
+  })
+})
+
+// ---------------------------------------------------------------------------
+// Tests: Codex first-turn prefix
+// ---------------------------------------------------------------------------
+
+describe('specialist identity injection — Codex', () => {
+  it('includes SPECIALIST_IDENTITY_TAG in first-turn prompt prefix', async () => {
+    const process = new FakeAgentProcess()
+    const fakeAgent = startFakeAgentWithModes(process, ['session-codex-sp1'], CODEX_MODES)
+    const profile = makeProfile()
+    const registerSessionSpecialist = vi.fn()
+
+    const runtime = new AcpRuntime({
+      appVersion: '0.1.0',
+      defaultCwd: '/workspace',
+      resolveBackend: () => ({
+        framework: { ...codexFramework, spawn: () => asAgentProcess(process) },
+        executablePath: '/bin/codex-acp',
+        env: {}
+      }),
+      framework: codexFramework,
+      resolveSpecialistIdentity: async (_id, frameworkId) => {
+        expect(frameworkId).toBe('codex')
+        return { append: '', prefix: buildSpecialistIdentityPrefix(profile) }
+      },
+      notebook: {
+        projectName: 'test',
+        mcpEntryPath: '/test/mcp.js',
+        getRpcConnection: async () => ({ endpoint: 'http://127.0.0.1', token: 'test' }),
+        registerSessionSpecialist
+      }
+    })
+
+    await runtime.createSession({ cwd: '/workspace', specialistId: 'uuid-sp1' })
+    await runtime.sendPrompt({ sessionId: 'session-codex-sp1', text: 'Hello' })
+
+    expect(fakeAgent.prompts[0].text).toContain(SPECIALIST_IDENTITY_TAG)
+    expect(fakeAgent.prompts[0].text).toContain('RNA-seq Reviewer')
+    expect(registerSessionSpecialist).toHaveBeenCalledWith('session-codex-sp1', 'uuid-sp1')
+  })
+
+  it('does NOT inject specialist tag for Codex when no specialistId', async () => {
+    const process = new FakeAgentProcess()
+    const fakeAgent = startFakeAgentWithModes(process, ['session-codex-no-sp'], CODEX_MODES)
+    const resolveSpecialistIdentity = vi.fn()
+
+    const runtime = new AcpRuntime({
+      appVersion: '0.1.0',
+      defaultCwd: '/workspace',
+      resolveBackend: () => ({
+        framework: { ...codexFramework, spawn: () => asAgentProcess(process) },
+        executablePath: '/bin/codex-acp',
+        env: {}
+      }),
+      framework: codexFramework,
+      resolveSpecialistIdentity
+    })
+
+    await runtime.createSession({ cwd: '/workspace' })
+    await runtime.sendPrompt({ sessionId: 'session-codex-no-sp', text: 'Hello' })
+
+    expect(resolveSpecialistIdentity).not.toHaveBeenCalled()
+    expect(fakeAgent.prompts[0].text).not.toContain(SPECIALIST_IDENTITY_TAG)
+  })
+})
+
+// ---------------------------------------------------------------------------
+// Tests: OpenCode first-turn prefix
+// ---------------------------------------------------------------------------
+
+describe('specialist identity injection — OpenCode', () => {
+  it('includes SPECIALIST_IDENTITY_TAG in first-turn prompt prefix', async () => {
+    const process = new FakeAgentProcess()
+    const fakeAgent = startFakeAgent(process, ['session-opencode-sp1'])
+    const profile = makeProfile()
+    const registerSessionSpecialist = vi.fn()
+
+    const runtime = new AcpRuntime({
+      appVersion: '0.1.0',
+      defaultCwd: '/workspace',
+      resolveBackend: () => ({
+        framework: { ...opencodeFramework, spawn: () => asAgentProcess(process) },
+        executablePath: '/bin/opencode-acp',
+        env: {}
+      }),
+      framework: opencodeFramework,
+      resolveSpecialistIdentity: async (_id, frameworkId) => {
+        expect(frameworkId).toBe('opencode')
+        return { append: '', prefix: buildSpecialistIdentityPrefix(profile) }
+      },
+      notebook: {
+        projectName: 'test',
+        mcpEntryPath: '/test/mcp.js',
+        getRpcConnection: async () => ({ endpoint: 'http://127.0.0.1', token: 'test' }),
+        registerSessionSpecialist
+      }
+    })
+
+    await runtime.createSession({ cwd: '/workspace', specialistId: 'uuid-sp1' })
+    await runtime.sendPrompt({ sessionId: 'session-opencode-sp1', text: 'Hello' })
+
+    expect(fakeAgent.prompts[0].text).toContain(SPECIALIST_IDENTITY_TAG)
+    expect(registerSessionSpecialist).toHaveBeenCalledWith('session-opencode-sp1', 'uuid-sp1')
+  })
+})
+
+// ---------------------------------------------------------------------------
+// Tests: Hot-switching specialist on a live session
+// ---------------------------------------------------------------------------
+
+describe('specialist hot-switch — Claude Code', () => {
+  it('switchSpecialist replaces the session and re-bakes the new identity append', async () => {
+    const process = new FakeAgentProcess()
+    const fakeAgent = startFakeAgent(process, ['session-claude', 'session-claude-reset'])
+    const profileA = makeProfile({ id: 'sp-a', name: 'Specialist A', systemPrompt: 'You are A.' })
+    const profileB = makeProfile({ id: 'sp-b', name: 'Specialist B', systemPrompt: 'You are B.' })
+    const registerSessionSpecialist = vi.fn()
+
+    const runtime = new AcpRuntime({
+      appVersion: '0.1.0',
+      defaultCwd: '/workspace',
+      resolveBackend: () => ({
+        framework: { ...claudeCodeFramework, spawn: () => asAgentProcess(process) },
+        executablePath: '/bin/agent',
+        env: {}
+      }),
+      resolveSpecialistIdentity: async (specialistId: string) =>
+        specialistId === 'sp-a'
+          ? { append: buildSpecialistIdentityAppend(profileA), prefix: '' }
+          : { append: buildSpecialistIdentityAppend(profileB), prefix: '' },
+      notebook: {
+        projectName: 'test',
+        mcpEntryPath: '/test/mcp.js',
+        getRpcConnection: async () => ({ endpoint: 'http://127.0.0.1', token: 'test' }),
+        registerSessionSpecialist
+      }
+    })
+
+    await runtime.createSession({ cwd: '/workspace', specialistId: 'sp-a' })
+    expect(JSON.stringify(fakeAgent.newSessions[0]._meta)).toContain('Specialist A')
+
+    const result = await runtime.switchSpecialist('session-claude', 'sp-b')
+
+    // Claude bakes identity at session creation, so a switch must replace the session.
+    expect(result.contextReset).toBe(true)
+    expect(fakeAgent.newSessions).toHaveLength(2)
+    expect(JSON.stringify(fakeAgent.newSessions[1]._meta)).toContain('Specialist B')
+    expect(JSON.stringify(fakeAgent.newSessions[1]._meta)).not.toContain('Specialist A')
+    expect(registerSessionSpecialist).toHaveBeenLastCalledWith('session-claude', 'sp-b')
+  })
+
+  it('switchSpecialist to undefined (Main Agent) resets and drops the identity append', async () => {
+    const process = new FakeAgentProcess()
+    const fakeAgent = startFakeAgent(process, ['session-claude2', 'session-claude2-reset'])
+    const profile = makeProfile()
+    const registerSessionSpecialist = vi.fn()
+
+    const runtime = new AcpRuntime({
+      appVersion: '0.1.0',
+      defaultCwd: '/workspace',
+      resolveBackend: () => ({
+        framework: { ...claudeCodeFramework, spawn: () => asAgentProcess(process) },
+        executablePath: '/bin/agent',
+        env: {}
+      }),
+      resolveSpecialistIdentity: async () => ({
+        append: buildSpecialistIdentityAppend(profile),
+        prefix: ''
+      }),
+      notebook: {
+        projectName: 'test',
+        mcpEntryPath: '/test/mcp.js',
+        getRpcConnection: async () => ({ endpoint: 'http://127.0.0.1', token: 'test' }),
+        registerSessionSpecialist
+      }
+    })
+
+    await runtime.createSession({ cwd: '/workspace', specialistId: 'uuid-sp1' })
+    const result = await runtime.switchSpecialist('session-claude2', undefined)
+
+    expect(result.contextReset).toBe(true)
+    expect(fakeAgent.newSessions).toHaveLength(2)
+    expect(JSON.stringify(fakeAgent.newSessions[1]._meta ?? {})).not.toContain(
+      SPECIALIST_IDENTITY_TAG
+    )
+    expect(registerSessionSpecialist).toHaveBeenLastCalledWith('session-claude2', undefined)
+  })
+})
+
+describe('specialist hot-switch — Codex', () => {
+  it('switchSpecialist updates the per-turn prefix without resetting the session', async () => {
+    const process = new FakeAgentProcess()
+    const fakeAgent = startFakeAgentWithModes(process, ['session-codex'], CODEX_MODES)
+    const profileA = makeProfile({ id: 'sp-a', name: 'Specialist A', systemPrompt: 'You are A.' })
+    const profileB = makeProfile({ id: 'sp-b', name: 'Specialist B', systemPrompt: 'You are B.' })
+    const registerSessionSpecialist = vi.fn()
+
+    const runtime = new AcpRuntime({
+      appVersion: '0.1.0',
+      defaultCwd: '/workspace',
+      resolveBackend: () => ({
+        framework: { ...codexFramework, spawn: () => asAgentProcess(process) },
+        executablePath: '/bin/codex-acp',
+        env: {}
+      }),
+      framework: codexFramework,
+      resolveSpecialistIdentity: async (specialistId: string) =>
+        specialistId === 'sp-a'
+          ? { append: '', prefix: buildSpecialistIdentityPrefix(profileA) }
+          : { append: '', prefix: buildSpecialistIdentityPrefix(profileB) },
+      notebook: {
+        projectName: 'test',
+        mcpEntryPath: '/test/mcp.js',
+        getRpcConnection: async () => ({ endpoint: 'http://127.0.0.1', token: 'test' }),
+        registerSessionSpecialist
+      }
+    })
+
+    await runtime.createSession({ cwd: '/workspace', specialistId: 'sp-a' })
+    await runtime.sendPrompt({ sessionId: 'session-codex', text: 'Hello' })
+    expect(fakeAgent.prompts[0].text).toContain('Specialist A')
+
+    // Codex carries identity as a per-turn prefix, so switching updates the map only — no reset.
+    const result = await runtime.switchSpecialist('session-codex', 'sp-b')
+    expect(result.contextReset).toBe(false)
+    expect(fakeAgent.newSessions).toHaveLength(1)
+
+    await runtime.sendPrompt({ sessionId: 'session-codex', text: 'Again' })
+    expect(fakeAgent.prompts[1].text).toContain('Specialist B')
+    expect(fakeAgent.prompts[1].text).not.toContain('Specialist A')
+    expect(registerSessionSpecialist).toHaveBeenLastCalledWith('session-codex', 'sp-b')
+  })
+})
+
+// ---------------------------------------------------------------------------
+// Tests: Session persistence round-trip for specialistId
+// ---------------------------------------------------------------------------
+
+describe('session-persistence specialistId field', () => {
+  it('round-trips specialistId through normalizeSessionFile', async () => {
+    const { normalizeSessionFile } = await import('../../shared/session-persistence')
+    const raw = {
+      id: 'session-sp',
+      projectId: 'proj-1',
+      title: 'Specialist session',
+      cwd: '/workspace',
+      status: 'idle',
+      specialistId: 'uuid-sp1',
+      messages: [],
+      createdAt: 1,
+      updatedAt: 1
+    }
+    const restored = normalizeSessionFile(raw)
+    expect(restored?.specialistId).toBe('uuid-sp1')
+  })
+
+  it('omits specialistId when absent', async () => {
+    const { normalizeSessionFile } = await import('../../shared/session-persistence')
+    const raw = {
+      id: 'session-no-sp',
+      projectId: 'proj-1',
+      title: 'No specialist',
+      cwd: '/workspace',
+      status: 'idle',
+      messages: [],
+      createdAt: 1,
+      updatedAt: 1
+    }
+    const restored = normalizeSessionFile(raw)
+    expect(restored?.specialistId).toBeUndefined()
+  })
+
+  it('rejects arbitrary objects as specialistId', async () => {
+    const { normalizeSessionFile } = await import('../../shared/session-persistence')
+    const raw = {
+      id: 'session-bad-sp',
+      projectId: 'proj-1',
+      title: 'Bad specialist',
+      cwd: '/workspace',
+      status: 'idle',
+      specialistId: { __proto__: null, id: 'injection' },
+      messages: [],
+      createdAt: 1,
+      updatedAt: 1
+    }
+    const restored = normalizeSessionFile(raw)
+    expect(restored?.specialistId).toBeUndefined()
+  })
+})

--- a/src/main/specialist/types.ts
+++ b/src/main/specialist/types.ts
@@ -1,0 +1,37 @@
+// Main-process-only stored shapes for the specialist profile store (specialists.json).
+// No secret fields; systemPrompt is considered non-secret user content.
+
+import type {
+  SpecialistCapabilityMode,
+  SpecialistFullAccessConfig,
+  SpecialistSelectedConfig
+} from '../../shared/specialist'
+
+// The persisted document stored in specialists.json.
+export type StoredSpecialist = {
+  id: string // immutable UUID
+  name: string // public UPPER_SNAKE identifier
+  displayName?: string
+  description: string
+  systemPrompt: string
+  iconKey?: string
+  colorKey?: string
+  enabled: boolean
+  capabilityMode: SpecialistCapabilityMode
+  fullAccess: SpecialistFullAccessConfig
+  selectedCapabilities: SpecialistSelectedConfig
+  revision: number
+}
+
+// The whole specialists.json document.
+export type StoredSpecialists = {
+  version: 1
+  specialists: StoredSpecialist[]
+}
+
+export const SPECIALISTS_FILE_VERSION = 1 as const
+
+export const createEmptySpecialists = (): StoredSpecialists => ({
+  version: SPECIALISTS_FILE_VERSION,
+  specialists: []
+})

--- a/src/preload/index.d.ts
+++ b/src/preload/index.d.ts
@@ -218,6 +218,19 @@ import type {
   ReviewUpdateEvent
 } from '../shared/reviewer'
 import type {
+  CreateSpecialistRequest,
+  UpdateSpecialistRequest,
+  SetSpecialistEnabledRequest,
+  DeleteSpecialistRequest,
+  DuplicateSpecialistRequest,
+  SpecialistListItem,
+  SpecialistProfileView,
+  SetSessionSpecialistRequest,
+  SetSessionSpecialistResponse,
+  ResolveSessionSpecialistRequest,
+  SessionSpecialistResolution
+} from '../shared/specialist'
+import type {
   CloseConfirmRequest,
   CloseConfirmResponse,
   WindowFindAppearance,
@@ -348,6 +361,22 @@ interface OpenScienceAPI {
     respondSkillImportApproval(response: ConversationSkillImportApprovalResponse): Promise<void>
     respondConnectorApproval(request: RespondApprovalRequest): Promise<void>
     onInstallLog(listener: AcpListener<ClaudeInstallEvent>): RemoveListener
+  }
+  specialist: {
+    list(): Promise<SpecialistListItem[]>
+    create(request: CreateSpecialistRequest): Promise<SpecialistProfileView>
+    update(request: UpdateSpecialistRequest): Promise<SpecialistProfileView>
+    setEnabled(request: SetSpecialistEnabledRequest): Promise<SpecialistProfileView>
+    delete(request: DeleteSpecialistRequest): Promise<void>
+    duplicate(request: DuplicateSpecialistRequest): Promise<CreateSpecialistRequest>
+    onCatalogChanged(listener: () => void): RemoveListener
+    // Session switching (issue 07).
+    setSessionSpecialist(
+      request: SetSessionSpecialistRequest
+    ): Promise<SetSessionSpecialistResponse>
+    resolveSessionSpecialist(
+      request: ResolveSessionSpecialistRequest
+    ): Promise<SessionSpecialistResolution>
   }
   logs: {
     getPath(): Promise<string | null>

--- a/src/preload/index.ts
+++ b/src/preload/index.ts
@@ -227,6 +227,20 @@ import type {
   ReviewUpdateEvent
 } from '../shared/reviewer'
 import { REVIEWER_IPC } from '../shared/reviewer'
+import type {
+  CreateSpecialistRequest,
+  UpdateSpecialistRequest,
+  SetSpecialistEnabledRequest,
+  DeleteSpecialistRequest,
+  DuplicateSpecialistRequest,
+  SpecialistListItem,
+  SpecialistProfileView,
+  SetSessionSpecialistRequest,
+  SetSessionSpecialistResponse,
+  ResolveSessionSpecialistRequest,
+  SessionSpecialistResolution
+} from '../shared/specialist'
+import { SPECIALIST_IPC } from '../shared/specialist'
 import {
   announceWindowFindReady,
   subscribeCloseActivePane,
@@ -385,6 +399,22 @@ type OpenScienceAPI = {
     respondSkillImportApproval: (response: ConversationSkillImportApprovalResponse) => Promise<void>
     respondConnectorApproval: (request: RespondApprovalRequest) => Promise<void>
     onInstallLog: (listener: AcpListener<ClaudeInstallEvent>) => RemoveListener
+  }
+  specialist: {
+    list: () => Promise<SpecialistListItem[]>
+    create: (request: CreateSpecialistRequest) => Promise<SpecialistProfileView>
+    update: (request: UpdateSpecialistRequest) => Promise<SpecialistProfileView>
+    setEnabled: (request: SetSpecialistEnabledRequest) => Promise<SpecialistProfileView>
+    delete(request: DeleteSpecialistRequest): Promise<void>
+    duplicate(request: DuplicateSpecialistRequest): Promise<CreateSpecialistRequest>
+    onCatalogChanged: (listener: () => void) => RemoveListener
+    // Session switching (issue 07).
+    setSessionSpecialist: (
+      request: SetSessionSpecialistRequest
+    ) => Promise<SetSessionSpecialistResponse>
+    resolveSessionSpecialist: (
+      request: ResolveSessionSpecialistRequest
+    ) => Promise<SessionSpecialistResolution>
   }
   logs: {
     getPath: () => Promise<string | null>
@@ -933,6 +963,32 @@ const api: OpenScienceAPI = {
       ipcRenderer.invoke('connectors:approval-respond', request) as Promise<void>,
     // Streams live installer output while a one-click install runs.
     onInstallLog: (listener) => onIpcMessage('settings:install-log', listener)
+  },
+  specialist: {
+    list: () => ipcRenderer.invoke(SPECIALIST_IPC.LIST) as Promise<SpecialistListItem[]>,
+    create: (request: CreateSpecialistRequest) =>
+      ipcRenderer.invoke(SPECIALIST_IPC.CREATE, request) as Promise<SpecialistProfileView>,
+    update: (request: UpdateSpecialistRequest) =>
+      ipcRenderer.invoke(SPECIALIST_IPC.UPDATE, request) as Promise<SpecialistProfileView>,
+    setEnabled: (request: SetSpecialistEnabledRequest) =>
+      ipcRenderer.invoke(SPECIALIST_IPC.SET_ENABLED, request) as Promise<SpecialistProfileView>,
+    delete: (request: DeleteSpecialistRequest) =>
+      ipcRenderer.invoke(SPECIALIST_IPC.DELETE, request) as Promise<void>,
+    duplicate: (request: DuplicateSpecialistRequest) =>
+      ipcRenderer.invoke(SPECIALIST_IPC.DUPLICATE, request) as Promise<CreateSpecialistRequest>,
+    onCatalogChanged: (listener: () => void) =>
+      onIpcMessage(SPECIALIST_IPC.CATALOG_CHANGED, listener),
+    // Session switching (issue 07).
+    setSessionSpecialist: (request: SetSessionSpecialistRequest) =>
+      ipcRenderer.invoke(
+        SPECIALIST_IPC.SET_SESSION_SPECIALIST,
+        request
+      ) as Promise<SetSessionSpecialistResponse>,
+    resolveSessionSpecialist: (request: ResolveSessionSpecialistRequest) =>
+      ipcRenderer.invoke(
+        SPECIALIST_IPC.RESOLVE_SESSION_SPECIALIST,
+        request
+      ) as Promise<SessionSpecialistResolution>
   },
   logs: {
     getPath: () => ipcRenderer.invoke('logs:get-path') as Promise<string | null>,

--- a/src/renderer/src/lib/acp/useAcpRuntime.ts
+++ b/src/renderer/src/lib/acp/useAcpRuntime.ts
@@ -45,7 +45,8 @@ const useAcpRuntime = (): {
   createSession: (
     cwd?: string,
     projectName?: string,
-    permissionProfile?: PermissionProfileId
+    permissionProfile?: PermissionProfileId,
+    specialistId?: string
   ) => Promise<AcpCreateSessionResponse>
   resumeSession: (
     sessionId: AcpResumeSessionRequest['sessionId'],
@@ -53,7 +54,8 @@ const useAcpRuntime = (): {
     projectName?: string,
     permissionProfile?: PermissionProfileId,
     previousFrameworkId?: AcpResumeSessionRequest['previousFrameworkId'],
-    previousBackendId?: AcpResumeSessionRequest['previousBackendId']
+    previousBackendId?: AcpResumeSessionRequest['previousBackendId'],
+    specialistId?: AcpResumeSessionRequest['specialistId']
   ) => Promise<AcpCreateSessionResponse>
   resetSessionContext: (
     sessionId: AcpResumeSessionRequest['sessionId'],
@@ -209,9 +211,14 @@ const useAcpRuntime = (): {
 
   // Creates a protocol session and returns the runtime-provided id.
   const createSession = useCallback(
-    (cwd?: string, projectName?: string, permissionProfile?: PermissionProfileId) =>
+    (
+      cwd?: string,
+      projectName?: string,
+      permissionProfile?: PermissionProfileId,
+      specialistId?: string
+    ) =>
       runValueAction(setIsConnecting, () =>
-        window.api.acp.createSession({ cwd, projectName, permissionProfile })
+        window.api.acp.createSession({ cwd, projectName, permissionProfile, specialistId })
       ),
     [runValueAction]
   )
@@ -224,7 +231,8 @@ const useAcpRuntime = (): {
       projectName?: string,
       permissionProfile?: PermissionProfileId,
       previousFrameworkId?: AcpResumeSessionRequest['previousFrameworkId'],
-      previousBackendId?: AcpResumeSessionRequest['previousBackendId']
+      previousBackendId?: AcpResumeSessionRequest['previousBackendId'],
+      specialistId?: AcpResumeSessionRequest['specialistId']
     ) =>
       runValueAction(setIsConnecting, () =>
         window.api.acp.resumeSession({
@@ -233,7 +241,8 @@ const useAcpRuntime = (): {
           projectName,
           permissionProfile,
           previousFrameworkId,
-          previousBackendId
+          previousBackendId,
+          specialistId
         })
       ),
     [runValueAction]

--- a/src/renderer/src/lib/acp/useWorkspaceAgentRuntime.test.ts
+++ b/src/renderer/src/lib/acp/useWorkspaceAgentRuntime.test.ts
@@ -455,7 +455,7 @@ describe('workspace agent message sending', () => {
       agentModel: 'model-used-by-run'
     })
 
-    expect(runtime.createSession).toHaveBeenCalledWith('/workspace/project', undefined, 'ask')
+    expect(runtime.createSession).toHaveBeenCalledWith('/workspace/project', undefined, 'ask', undefined)
     expect(runtime.sendPrompt).not.toHaveBeenCalled()
     expect(useSessionStore.getState().sessions[0]).toMatchObject({
       id: sent?.sessionId,
@@ -522,7 +522,7 @@ describe('workspace agent message sending', () => {
       projectName: 'project-1'
     })
 
-    expect(runtime.createSession).toHaveBeenCalledWith(undefined, 'project-1', 'ask')
+    expect(runtime.createSession).toHaveBeenCalledWith(undefined, 'project-1', 'ask', undefined)
   })
 
   it('does not persist the runtime home when managed session creation omits cwd', async () => {
@@ -890,8 +890,8 @@ describe('workspace agent message sending', () => {
       projectName: 'project-1'
     })
 
-    expect(runtime.createSession).toHaveBeenNthCalledWith(1, undefined, 'project-1', 'ask')
-    expect(runtime.createSession).toHaveBeenNthCalledWith(2, undefined, 'project-1', 'ask')
+    expect(runtime.createSession).toHaveBeenNthCalledWith(1, undefined, 'project-1', 'ask', undefined)
+    expect(runtime.createSession).toHaveBeenNthCalledWith(2, undefined, 'project-1', 'ask', undefined)
   })
 
   it('does not submit another prompt for a session that already owns a run', async () => {
@@ -1493,7 +1493,8 @@ describe('resuming an interrupted session on demand', () => {
       'default-project',
       expect.any(String),
       'codex',
-      'codex:codex-isolated'
+      'codex:codex-isolated',
+      undefined
     )
     expect(useSessionStore.getState().sessions[0]).toMatchObject({ status: 'idle' })
     expect(useSessionStore.getState().sessions[0].error).toBeUndefined()
@@ -1886,7 +1887,8 @@ describe('resuming an interrupted session on demand', () => {
       'default-project',
       'ask',
       'claude-code',
-      'claude-code:anthropic'
+      'claude-code:anthropic',
+      undefined
     )
     const preamble = runtime.sendPrompt.mock.calls[0]?.[5]
     expect(preamble).toContain('Analyze the data with Claude')

--- a/src/renderer/src/lib/acp/useWorkspaceAgentRuntime.ts
+++ b/src/renderer/src/lib/acp/useWorkspaceAgentRuntime.ts
@@ -76,6 +76,10 @@ type SendWorkspaceMessageInput = {
   // common send path still owns replay completion and clears the durable retry marker only after the
   // provider accepts the prompt.
   branchContextAlreadyReset?: boolean
+  // Immutable Specialist UUID from the new-conversation draft picker. Only used when creating a new
+  // ACP session (sessionId === undefined). The renderer sends only the UUID; the main process reads
+  // the latest Profile. Never passed for existing sessions (specialist binding is immutable).
+  specialistId?: string
 }
 
 type SendWorkspaceMessageResult = {
@@ -376,13 +380,19 @@ const startPendingSessionPrompt = (
   projectName: string | undefined,
   permissionProfile: PermissionProfileId,
   forcedSkillIds: string[] | undefined,
-  referencedArtifacts: FileReference[] | undefined
+  referencedArtifacts: FileReference[] | undefined,
+  specialistId: string | undefined
 ): void => {
   void (async () => {
     let createdSession
 
     try {
-      createdSession = await runtime.createSession(cwd, projectName, permissionProfile)
+      createdSession = await runtime.createSession(
+        cwd,
+        projectName,
+        permissionProfile,
+        specialistId
+      )
     } catch (error) {
       // Unwrap the IPC wrapper so an app-authored setup failure (model-incompat / no provider / Codex
       // bridge / missing executable) is recognized by the classifier and hides the report button.
@@ -478,7 +488,8 @@ const sendWorkspaceMessage = async (
     preAppendedMessageId,
     supportsImageInput,
     allowCompactionRecovery,
-    branchContextAlreadyReset
+    branchContextAlreadyReset,
+    specialistId
   }: SendWorkspaceMessageInput
 ): Promise<SendWorkspaceMessageResult | undefined> => {
   const content = text.trim()
@@ -533,7 +544,8 @@ const sendWorkspaceMessage = async (
         sessionProjectName,
         currentSession.permissionProfile ?? DEFAULT_PERMISSION_PROFILE,
         forcedSkillIds,
-        referencedArtifacts
+        referencedArtifacts,
+        undefined // existing pending sessions do not re-apply specialistId
       )
       return appended
     }
@@ -564,6 +576,14 @@ const sendWorkspaceMessage = async (
         useSessionStore.getState().failRun(targetSessionId, getResumeFailureMessage(error))
         return undefined
       }
+    }
+
+    // A specialist switch on Claude replaced the agent session on the main side (identity is baked
+    // into session _meta at creation). The runtime already adopted a fresh session, so here we only
+    // need to replay prior turns as a history preamble — no resetSessionContext, no notebook shutdown.
+    const specialistSwitchReplay = Boolean(currentSession?.specialistSwitchResetRequired)
+    if (specialistSwitchReplay) {
+      useSessionStore.getState().clearSpecialistSwitchResetRequired(targetSessionId)
     }
 
     // A framework switch applies at the next turn boundary. The retiring runtime may still expose the
@@ -632,7 +652,8 @@ const sendWorkspaceMessage = async (
           sessionProjectName,
           currentSession?.permissionProfile ?? permissionProfile,
           currentSession?.agentFrameworkId,
-          currentSession?.agentBackendId
+          currentSession?.agentBackendId,
+          currentSession?.specialistId
         )
 
         contextResetFromResume = Boolean(resumeResult?.contextReset)
@@ -650,7 +671,10 @@ const sendWorkspaceMessage = async (
     // and can't report the reset again). historyMessages ends before the newly appended user message,
     // so this is the prior conversation only — the turn being sent is not duplicated in.
     if (
-      (branchContextResetPerformed || contextResetFromResume || forceHistoryReplay) &&
+      (branchContextResetPerformed ||
+        contextResetFromResume ||
+        forceHistoryReplay ||
+        specialistSwitchReplay) &&
       historyMessages
     ) {
       historyPreamble = buildHistoryPreamble(historyMessages)
@@ -739,7 +763,8 @@ const sendWorkspaceMessage = async (
     permissionProfile,
     agentFrameworkId,
     agentBackendId,
-    agentModel
+    agentModel,
+    specialistId
   })
 
   if (!pending) return undefined
@@ -754,7 +779,8 @@ const sendWorkspaceMessage = async (
     projectName,
     permissionProfile ?? DEFAULT_PERMISSION_PROFILE,
     forcedSkillIds,
-    referencedArtifacts
+    referencedArtifacts,
+    specialistId
   )
 
   return pending
@@ -815,7 +841,8 @@ const resumeInterruptedWorkspaceSession = async (
       session.projectId,
       session.permissionProfile ?? DEFAULT_PERMISSION_PROFILE,
       session.agentFrameworkId,
-      session.agentBackendId
+      session.agentBackendId,
+      session.specialistId
     )
     // Adopting a fresh agent session (framework switch, or an unresumable restart) wipes the agent's
     // context; capture that so the re-sent turn below replays the transcript. The shared send path's

--- a/src/renderer/src/pages/settings/SettingsPage.render.test.tsx
+++ b/src/renderer/src/pages/settings/SettingsPage.render.test.tsx
@@ -116,6 +116,12 @@ const installApi = (): void => {
       }),
       install: vi.fn(),
       uninstall: vi.fn()
+    },
+    specialist: {
+      list: vi.fn().mockResolvedValue([{ kind: 'reviewer', id: 'reviewer' }]),
+      create: vi.fn(),
+      setEnabled: vi.fn(),
+      onCatalogChanged: vi.fn(() => vi.fn())
     }
   }
 }
@@ -185,8 +191,8 @@ describe('SettingsPage layout', () => {
     expect(dialog?.getAttribute('data-slot')).toBe('settings-surface')
     expect(dialog?.className).toContain('overscroll-contain')
 
-    // Left navigation grouped as Capabilities (Skills, Connectors, Compute, Network) and Workspace
-    // (Model with its Agent sub-item, Runtimes, Storage, General).
+    // Left navigation grouped as Capabilities (Skills, Connectors, Specialists, Compute, Network)
+    // and Workspace (Model with its Agent sub-item, Runtimes, Storage, General).
     const nav = document.body.querySelector('nav[aria-label="Settings"]')
     expect(nav).not.toBeNull()
     expect(nav?.className).toContain('bg-background')
@@ -194,16 +200,17 @@ describe('SettingsPage layout', () => {
     expect(nav?.textContent).toContain('Capabilities')
     expect(nav?.textContent).toContain('Workspace')
     const navItems = nav?.querySelectorAll('li') ?? []
-    expect(navItems).toHaveLength(9)
+    expect(navItems).toHaveLength(10)
     expect(navItems[0]?.textContent).toContain('Skills')
     expect(navItems[1]?.textContent).toContain('Connectors')
-    expect(navItems[2]?.textContent).toContain('Compute')
-    expect(navItems[3]?.textContent).toContain('Network')
-    expect(navItems[4]?.textContent).toContain('Model')
-    expect(navItems[5]?.textContent).toContain('Agent')
-    expect(navItems[6]?.textContent).toContain('Runtimes')
-    expect(navItems[7]?.textContent).toContain('Storage')
-    expect(navItems[8]?.textContent).toContain('General')
+    expect(navItems[2]?.textContent).toContain('Specialists')
+    expect(navItems[3]?.textContent).toContain('Compute')
+    expect(navItems[4]?.textContent).toContain('Network')
+    expect(navItems[5]?.textContent).toContain('Model')
+    expect(navItems[6]?.textContent).toContain('Agent')
+    expect(navItems[7]?.textContent).toContain('Runtimes')
+    expect(navItems[8]?.textContent).toContain('Storage')
+    expect(navItems[9]?.textContent).toContain('General')
     // Model is the default active panel.
     expect(nav?.querySelector('[aria-current="page"]')?.textContent).toContain('Model')
 
@@ -901,6 +908,33 @@ describe('SettingsPage layout', () => {
 
     expect(navButton('Storage')?.getAttribute('aria-current')).toBe('page')
     expect(useSettingsStore.getState().pendingSettingsPanel).toBeUndefined()
+  })
+
+  it('opens the specialist creation form from Write from scratch', async () => {
+    useSettingsStore.setState({ pendingSettingsPanel: 'specialists' })
+
+    await act(async () => {
+      root.render(<SettingsPage open onClose={vi.fn()} />)
+    })
+    await act(async () => {
+      await Promise.resolve()
+    })
+
+    openRadixMenu(
+      Array.from(document.body.querySelectorAll<HTMLButtonElement>('button')).find((button) =>
+        button.textContent?.includes('Add specialist')
+      )
+    )
+    const writeFromScratch = Array.from(
+      document.body.querySelectorAll<HTMLElement>('[role="menuitem"]')
+    ).find((item) => item.textContent?.includes('Write from scratch'))
+    await act(async () => {
+      clickRadixMenuItem(writeFromScratch)
+      await Promise.resolve()
+    })
+
+    expect(document.body.querySelector('h3')?.textContent).toBe('Identity')
+    expect(document.body.querySelector<HTMLInputElement>('#sp-name')).not.toBeNull()
   })
 
   it('pushes Agent after storage recovery so Back returns to Storage', async () => {

--- a/src/renderer/src/pages/settings/SettingsPage.tsx
+++ b/src/renderer/src/pages/settings/SettingsPage.tsx
@@ -9,6 +9,7 @@ import {
   Settings2,
   SlidersHorizontal,
   TerminalSquare,
+  Users,
   X,
   Zap
 } from 'lucide-react'
@@ -20,12 +21,14 @@ import {
   type ProviderView,
   type UpsertProviderRequest
 } from '../../../../shared/settings'
+import type { SpecialistListItem } from '../../../../shared/specialist'
 import { Button } from '@/components/ui/button'
 import { Tooltip, TooltipContent, TooltipProvider, TooltipTrigger } from '@/components/ui/tooltip'
 import { cn } from '@/lib/utils'
 import { selectFrameworkApiEndpoints, useSettingsStore } from '@/stores/settings-store'
 import type { SettingsPanelId } from './settings-navigation'
 import { useComputeStore } from '@/stores/compute-store'
+import { useSpecialistStore } from '@/stores/specialist-store'
 import { AgentPanel } from './AgentPanel'
 import { ProvidersPanel } from './ProvidersPanel'
 import { GeneralPanel } from './GeneralPanel'
@@ -34,6 +37,7 @@ import { StoragePanel } from './StoragePanel'
 import { RuntimesPanel } from './RuntimesPanel'
 import { SkillsPanel, type SkillsView } from './SkillsPanel'
 import { ConnectorsPanel, type ConnectorsView } from './ConnectorsPanel'
+import { SpecialistsPanel, type SpecialistsView } from './SpecialistsPanel'
 import { ConnectorDetailView } from './ConnectorDetailView'
 import { ConnectorAddForm } from './ConnectorAddForm'
 import { ConnectorsNavIcon } from './connector-icons'
@@ -120,6 +124,7 @@ const SETTINGS_GROUPS: ReadonlyArray<{ label: string; panels: ReadonlyArray<Sett
     panels: [
       { id: 'skills', label: 'Skills', Icon: ScrollText },
       { id: 'connectors', label: 'Connectors', Icon: ConnectorsNavIcon },
+      { id: 'specialists', label: 'Specialists', Icon: Users },
       { id: 'compute', label: 'Compute', Icon: Zap },
       { id: 'network', label: 'Network', Icon: Globe }
     ]
@@ -154,6 +159,7 @@ type NavLocation = {
   connectors?: ConnectorsView
   network?: NetworkView
   compute?: ComputeView
+  specialists?: SpecialistsView
 }
 
 const INITIAL_LOCATION: NavLocation = {
@@ -162,7 +168,8 @@ const INITIAL_LOCATION: NavLocation = {
   model: { kind: 'list' },
   connectors: { kind: 'list' },
   network: { kind: 'list' },
-  compute: { kind: 'list' }
+  compute: { kind: 'list' },
+  specialists: { kind: 'list' }
 }
 
 // App-level model settings surface. Reuses the onboarding cards/form; manages providers (CRUD +
@@ -201,6 +208,7 @@ const SettingsPage = ({ open, onClose }: SettingsPageProps): React.JSX.Element =
   const connectors = useSettingsStore((state) => state.connectors)
   const customServers = useSettingsStore((state) => state.customServers)
   const computeHosts = useComputeStore((state) => state.hosts)
+  const specialistItems = useSpecialistStore((state) => state.items)
   const [formValue, setFormValue] = useState<ProviderFormValue>(() =>
     createEmptyProviderFormValue()
   )
@@ -295,6 +303,7 @@ const SettingsPage = ({ open, onClose }: SettingsPageProps): React.JSX.Element =
   const connectorsView: ConnectorsView = currentLocation.connectors ?? { kind: 'list' }
   const networkView: NetworkView = currentLocation.network ?? { kind: 'list' }
   const computeView: ComputeView = currentLocation.compute ?? { kind: 'list' }
+  const specialistsView: SpecialistsView = currentLocation.specialists ?? { kind: 'list' }
   const canGoBack = historyIndex > 0
   const canGoForward = historyIndex < history.length - 1
 
@@ -303,6 +312,7 @@ const SettingsPage = ({ open, onClose }: SettingsPageProps): React.JSX.Element =
     const nextConnectors = location.connectors ?? { kind: 'list' }
     const nextNetwork = location.network ?? { kind: 'list' }
     const nextCompute = location.compute ?? { kind: 'list' }
+    const nextSpecialists = location.specialists ?? { kind: 'list' }
     if (
       location.panel === activePanel &&
       location.skills.kind === skillsView.kind &&
@@ -317,7 +327,10 @@ const SettingsPage = ({ open, onClose }: SettingsPageProps): React.JSX.Element =
       nextNetwork.kind === networkView.kind &&
       nextCompute.kind === computeView.kind &&
       ('providerId' in nextCompute ? nextCompute.providerId : undefined) ===
-        ('providerId' in computeView ? computeView.providerId : undefined)
+        ('providerId' in computeView ? computeView.providerId : undefined) &&
+      nextSpecialists.kind === specialistsView.kind &&
+      ('id' in nextSpecialists ? nextSpecialists.id : undefined) ===
+        ('id' in specialistsView ? specialistsView.id : undefined)
     ) {
       return
     }
@@ -336,6 +349,10 @@ const SettingsPage = ({ open, onClose }: SettingsPageProps): React.JSX.Element =
   // Navigates within the connectors panel (list/detail/add/edit) as a history entry.
   const navigateConnectors = (connectors: ConnectorsView): void =>
     navigate({ panel: 'connectors', skills: skillsView, model: modelView, connectors })
+
+  // Navigates within the specialists panel (list/create) as a history entry.
+  const navigateSpecialists = (specialists: SpecialistsView): void =>
+    navigate({ panel: 'specialists', skills: skillsView, model: modelView, specialists })
 
   // Navigates within the network panel (package-mirror list vs. configure) as a history entry, so the
   // configure form gets a proper "Network / Package mirror" breadcrumb + back/forward.
@@ -440,6 +457,29 @@ const SettingsPage = ({ open, onClose }: SettingsPageProps): React.JSX.Element =
           model: currentLocation.model,
           connectors: currentLocation.connectors,
           compute: { kind: 'list' }
+        },
+        leaf
+      }
+    }
+    if (activePanel === 'specialists' && specialistsView.kind !== 'list') {
+      const editingSpecialist =
+        specialistsView.kind === 'edit'
+          ? specialistItems.find(
+              (item): item is Extract<SpecialistListItem, { kind: 'custom' }> =>
+                item.kind === 'custom' && item.id === specialistsView.id
+            )
+          : undefined
+      const leaf =
+        specialistsView.kind === 'create'
+          ? 'New specialist'
+          : (editingSpecialist?.name ?? 'Edit specialist')
+      return {
+        rootLabel: 'Specialists',
+        rootTo: {
+          panel: 'specialists',
+          skills: currentLocation.skills,
+          model: currentLocation.model,
+          specialists: { kind: 'list' }
         },
         leaf
       }
@@ -751,6 +791,8 @@ const SettingsPage = ({ open, onClose }: SettingsPageProps): React.JSX.Element =
                     onNavigate={navigateSkills}
                     canImportInstalledSkills={canImportInstalledSkills}
                   />
+                ) : activePanel === 'specialists' ? (
+                  <SpecialistsPanel view={specialistsView} onNavigate={navigateSpecialists} />
                 ) : activePanel === 'connectors' ? (
                   connectorsView.kind === 'detail' ? (
                     <ConnectorDetailView id={connectorsView.id} />

--- a/src/renderer/src/pages/settings/SpecialistEditor.render.test.tsx
+++ b/src/renderer/src/pages/settings/SpecialistEditor.render.test.tsx
@@ -1,0 +1,589 @@
+// @vitest-environment jsdom
+import { act } from 'react'
+import { createRoot, type Root } from 'react-dom/client'
+import { fireEvent } from '@testing-library/react'
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest'
+
+import { SpecialistEditor } from './SpecialistEditor'
+import { clickRadixMenuItem, openRadixMenu } from './test-utils'
+import { useSettingsStore } from '@/stores/settings-store'
+
+;(globalThis as { IS_REACT_ACT_ENVIRONMENT?: boolean }).IS_REACT_ACT_ENVIRONMENT = true
+
+if (!Element.prototype.hasPointerCapture) {
+  Element.prototype.hasPointerCapture = (): boolean => false
+  Element.prototype.setPointerCapture = (): void => undefined
+  Element.prototype.releasePointerCapture = (): void => undefined
+}
+
+let container: HTMLDivElement
+let root: Root
+
+beforeEach(() => {
+  useSettingsStore.setState({
+    skills: [],
+    loadSkills: vi.fn().mockResolvedValue(undefined),
+    loadConnectors: vi.fn().mockResolvedValue(undefined)
+  })
+  container = document.createElement('div')
+  document.body.appendChild(container)
+  root = createRoot(container)
+})
+
+afterEach(() => {
+  act(() => root.unmount())
+  container.remove()
+  document.body.innerHTML = ''
+})
+
+describe('SpecialistEditor', () => {
+  it('edits Skill scopes independently, shows Main-disabled and missing IDs, and preserves the other mode', async () => {
+    const onSaveEdit = vi.fn().mockResolvedValue(undefined)
+    useSettingsStore.setState({
+      skills: [
+        {
+          id: 'main-disabled',
+          name: 'Main disabled',
+          description: '',
+          source: 'featured',
+          enabled: false,
+          updatedAt: ''
+        },
+        {
+          id: 'included',
+          name: 'Included',
+          description: '',
+          source: 'featured',
+          enabled: true,
+          updatedAt: ''
+        }
+      ],
+      loadSkills: vi.fn().mockResolvedValue(undefined)
+    })
+    await act(async () => {
+      root.render(
+        <SpecialistEditor
+          editSpecialist={{
+            id: 'skills-bot',
+            name: 'Skills Bot',
+            description: '',
+            systemPrompt: '',
+            enabled: true,
+            capabilityMode: 'full',
+            fullAccess: {
+              excludedSkillIds: ['included'],
+              excludedConnectorIds: [],
+              connectorTools: []
+            },
+            selectedCapabilities: {
+              skillIds: ['main-disabled', 'missing-stable-id'],
+              connectorIds: [],
+              connectorTools: []
+            },
+            revision: 1
+          }}
+          onCancel={vi.fn()}
+          onSave={vi.fn()}
+          onSaveEdit={onSaveEdit}
+        />
+      )
+    })
+    // Full access is on by default.
+    expect(
+      document.body.querySelector('[aria-label="Full access"]')?.getAttribute('aria-checked')
+    ).toBe('true')
+
+    // Turn Full access off to edit the Skills whitelist.
+    await act(async () => {
+      fireEvent.click(document.body.querySelector<HTMLButtonElement>('[aria-label="Full access"]')!)
+    })
+    expect(
+      document.body.querySelector('[aria-label="Full access"]')?.getAttribute('aria-checked')
+    ).toBe('false')
+
+    // Skills tab is active by default. Both persisted selections render, including the
+    // Main-disabled (still usable here) and a stale missing ID.
+    expect(document.body.textContent).toContain('Main disabled · available here')
+    expect(document.body.textContent).toContain('missing-stable-id')
+    expect(document.body.textContent).toContain('Missing · unavailable')
+    expect(document.body.textContent).not.toContain('Hard enforced')
+    expect(document.body.textContent).not.toContain('Guidance only')
+
+    // Remove "Main disabled" from the whitelist, leaving only the missing reference.
+    await act(async () => {
+      fireEvent.click(
+        document.body.querySelector<HTMLButtonElement>('[aria-label="Remove Main disabled"]')!
+      )
+    })
+    await act(async () => {
+      fireEvent.click(
+        Array.from(document.body.querySelectorAll<HTMLButtonElement>('button')).find(
+          (button) => button.textContent === 'Save changes'
+        )!
+      )
+    })
+    expect(onSaveEdit).toHaveBeenCalledWith(
+      expect.objectContaining({
+        capabilityMode: 'selected',
+        fullAccess: expect.objectContaining({ excludedSkillIds: ['included'] }),
+        selectedCapabilities: expect.objectContaining({ skillIds: ['missing-stable-id'] })
+      })
+    )
+  })
+
+  it('persists Full exclusions and Selected inclusions without losing either mode', async () => {
+    const onSaveEdit = vi.fn().mockResolvedValue(undefined)
+    useSettingsStore.setState({
+      connectors: [
+        {
+          id: 'chemistry',
+          displayName: 'Chemistry',
+          description: '',
+          sources: [],
+          requiresNcbi: false,
+          enabled: true,
+          autoAllow: false,
+          group: 'featured'
+        },
+        {
+          id: 'pubmed',
+          displayName: 'PubMed',
+          description: '',
+          sources: [],
+          requiresNcbi: true,
+          enabled: false,
+          autoAllow: false,
+          group: 'directory'
+        }
+      ],
+      customServers: [
+        {
+          id: 'broken-server',
+          name: 'Broken Server',
+          transport: 'stdio',
+          enabled: true,
+          availability: 'unavailable'
+        }
+      ],
+      loadConnectors: vi.fn().mockResolvedValue(undefined)
+    })
+    await act(async () => {
+      root.render(
+        <SpecialistEditor
+          editSpecialist={{
+            id: 'connector-bot',
+            name: 'Connector Bot',
+            description: '',
+            systemPrompt: '',
+            enabled: true,
+            capabilityMode: 'full',
+            fullAccess: {
+              excludedSkillIds: [],
+              excludedConnectorIds: ['pubmed'],
+              connectorTools: []
+            },
+            selectedCapabilities: {
+              skillIds: [],
+              connectorIds: ['Broken Server'],
+              connectorTools: []
+            },
+            revision: 1
+          }}
+          onCancel={vi.fn()}
+          onSave={vi.fn()}
+          onSaveEdit={onSaveEdit}
+        />
+      )
+    })
+
+    // Turn Full access off, then open the Connectors tab.
+    await act(async () => {
+      fireEvent.click(document.body.querySelector<HTMLButtonElement>('[aria-label="Full access"]')!)
+    })
+    await act(async () => {
+      fireEvent.click(
+        Array.from(document.body.querySelectorAll<HTMLButtonElement>('[role="tab"]')).find((tab) =>
+          tab.textContent?.includes('Connectors')
+        )!
+      )
+    })
+
+    // The persisted unavailable custom server stays visible (and removable) instead of silently
+    // broadening the profile. Main-disabled connectors (PubMed) are not in the list yet.
+    expect(document.body.textContent).toContain('Broken Server')
+    expect(document.body.textContent).toContain('Unavailable — unavailable')
+
+    // Remove the broken server, then add Chemistry from the add menu.
+    await act(async () => {
+      fireEvent.click(
+        document.body.querySelector<HTMLButtonElement>('[aria-label="Remove Broken Server"]')!
+      )
+    })
+    // Open the native add-connector popover and pick Chemistry (the dropdown was reworked from
+    // Radix DropdownMenu to a native positioned popover, so drive the trigger + item directly).
+    await act(async () => {
+      fireEvent.click(
+        Array.from(document.body.querySelectorAll<HTMLButtonElement>('button')).find(
+          (button) => button.textContent === '＋ Add a connector'
+        )!
+      )
+    })
+    await act(async () => {
+      fireEvent.click(
+        Array.from(document.body.querySelectorAll<HTMLButtonElement>('button')).find(
+          (button) => button.textContent === 'Chemistry'
+        )!
+      )
+    })
+
+    await act(async () => {
+      Array.from(document.body.querySelectorAll<HTMLButtonElement>('button'))
+        .find((button) => button.textContent === 'Save changes')
+        ?.click()
+    })
+    expect(onSaveEdit).toHaveBeenCalledWith(
+      expect.objectContaining({
+        capabilityMode: 'selected',
+        fullAccess: expect.objectContaining({ excludedConnectorIds: ['pubmed'] }),
+        selectedCapabilities: expect.objectContaining({ connectorIds: ['chemistry'] })
+      })
+    )
+  })
+
+  it('saves the icon and color selected for a new specialist', async () => {
+    const onSave = vi.fn().mockResolvedValue(undefined)
+    await act(async () => {
+      root.render(<SpecialistEditor onCancel={vi.fn()} onSave={onSave} />)
+    })
+
+    await act(async () => {
+      fireEvent.change(document.body.querySelector<HTMLInputElement>('#sp-name')!, {
+        target: { value: 'RNA Reviewer' }
+      })
+    })
+
+    const icon = document.body.querySelector<HTMLButtonElement>('[aria-label="Specialist icon"]')
+    expect(icon).not.toBeNull()
+    openRadixMenu(icon)
+    await act(async () => {
+      clickRadixMenuItem(
+        Array.from(document.body.querySelectorAll<HTMLElement>('[role="option"]')).find(
+          (option) => option.textContent === 'Microscope'
+        )
+      )
+    })
+
+    const color = document.body.querySelector<HTMLButtonElement>('[aria-label="Specialist color"]')
+    expect(color).not.toBeNull()
+    openRadixMenu(color)
+    await act(async () => {
+      clickRadixMenuItem(
+        Array.from(document.body.querySelectorAll<HTMLElement>('[role="option"]')).find(
+          (option) => option.textContent === 'Teal'
+        )
+      )
+    })
+
+    await act(async () => {
+      Array.from(document.body.querySelectorAll<HTMLButtonElement>('button'))
+        .find((button) => button.textContent === 'Create specialist')
+        ?.click()
+    })
+
+    expect(onSave).toHaveBeenCalledWith(
+      expect.objectContaining({
+        name: 'RNA Reviewer',
+        iconKey: 'microscope',
+        colorKey: 'teal'
+      })
+    )
+  })
+
+  it('shows a field-level error instead of submitting a duplicate name', async () => {
+    const onSave = vi.fn().mockResolvedValue(undefined)
+    await act(async () => {
+      root.render(
+        <SpecialistEditor existingNames={['RNA Reviewer']} onCancel={vi.fn()} onSave={onSave} />
+      )
+    })
+
+    await act(async () => {
+      fireEvent.change(document.body.querySelector<HTMLInputElement>('#sp-name')!, {
+        target: { value: 'RNA Reviewer' }
+      })
+      Array.from(document.body.querySelectorAll<HTMLButtonElement>('button'))
+        .find((button) => button.textContent === 'Create specialist')
+        ?.click()
+    })
+
+    expect(document.body.querySelector('#sp-name-err')?.textContent).toContain('already in use')
+    expect(onSave).not.toHaveBeenCalled()
+  })
+
+  it('prefills the form and calls onSaveEdit with id and revision in edit mode', async () => {
+    const onSaveEdit = vi.fn().mockResolvedValue(undefined)
+    await act(async () => {
+      root.render(
+        <SpecialistEditor
+          editSpecialist={{
+            id: 'rna-reviewer',
+            name: 'RNA Reviewer',
+            description: 'Reviews RNA-seq.',
+            systemPrompt: 'Be rigorous.',
+            iconKey: 'microscope',
+            colorKey: 'teal',
+            enabled: true,
+            capabilityMode: 'full',
+            fullAccess: { excludedSkillIds: [], excludedConnectorIds: [], connectorTools: [] },
+            selectedCapabilities: { skillIds: [], connectorIds: [], connectorTools: [] },
+            revision: 3
+          }}
+          existingNames={['Other Name']}
+          onCancel={vi.fn()}
+          onSave={vi.fn()}
+          onSaveEdit={onSaveEdit}
+        />
+      )
+    })
+
+    // Prefilled identity.
+    expect(document.body.querySelector<HTMLInputElement>('#sp-name')?.value).toBe('RNA Reviewer')
+
+    // Edit mode uses the "Save changes" button and routes through onSaveEdit.
+    await act(async () => {
+      Array.from(document.body.querySelectorAll<HTMLButtonElement>('button'))
+        .find((button) => button.textContent === 'Save changes')
+        ?.click()
+    })
+
+    expect(onSaveEdit).toHaveBeenCalledWith(
+      expect.objectContaining({
+        id: 'rna-reviewer',
+        revision: 3,
+        name: 'RNA Reviewer'
+      })
+    )
+    // Create path is not used in edit mode.
+    expect(document.body.querySelector('#sp-name-err')).toBeNull()
+  })
+
+  it('renders a live preview avatar reflecting the selected icon', async () => {
+    await act(async () => {
+      root.render(
+        <SpecialistEditor
+          editSpecialist={{
+            id: 'rna-reviewer',
+            name: 'RNA Reviewer',
+            description: '',
+            systemPrompt: '',
+            iconKey: 'microscope',
+            colorKey: 'teal',
+            enabled: true,
+            capabilityMode: 'full',
+            fullAccess: { excludedSkillIds: [], excludedConnectorIds: [], connectorTools: [] },
+            selectedCapabilities: { skillIds: [], connectorIds: [], connectorTools: [] },
+            revision: 1
+          }}
+          existingNames={[]}
+          onCancel={vi.fn()}
+          onSave={vi.fn()}
+          onSaveEdit={vi.fn()}
+        />
+      )
+    })
+
+    // The live preview renders the selected icon glyph.
+    expect(document.body.querySelector('[data-specialist-icon="microscope"]')).not.toBeNull()
+  })
+
+  it('caps Name and Description inputs and shows live character counters', async () => {
+    await act(async () => {
+      root.render(<SpecialistEditor onCancel={vi.fn()} onSave={vi.fn()} />)
+    })
+    expect(document.body.querySelector<HTMLInputElement>('#sp-name')!.maxLength).toBe(80)
+    expect(document.body.querySelector<HTMLInputElement>('#sp-description')!.maxLength).toBe(200)
+    expect(document.body.textContent).toContain('/ 80')
+    expect(document.body.textContent).toContain('/ 200')
+  })
+
+  it('shows the saved identity bar only in edit mode', async () => {
+    const findSavedTag = (): HTMLElement | undefined =>
+      Array.from(document.body.querySelectorAll<HTMLElement>('span')).find(
+        (el) => el.textContent?.trim() === 'Saved'
+      )
+
+    // Create mode: nothing is saved yet, so no identity bar.
+    await act(async () => {
+      root.render(<SpecialistEditor onCancel={vi.fn()} onSave={vi.fn()} />)
+    })
+    expect(findSavedTag()).toBeUndefined()
+
+    // Edit mode: the saved identity bar renders the persisted name + description.
+    await act(async () => {
+      root.render(
+        <SpecialistEditor
+          editSpecialist={{
+            id: 'rna-reviewer',
+            name: 'RNA Reviewer',
+            description: 'Reviews RNA-seq.',
+            systemPrompt: '',
+            iconKey: 'microscope',
+            colorKey: 'teal',
+            enabled: true,
+            capabilityMode: 'full',
+            fullAccess: { excludedSkillIds: [], excludedConnectorIds: [], connectorTools: [] },
+            selectedCapabilities: { skillIds: [], connectorIds: [], connectorTools: [] },
+            revision: 1
+          }}
+          existingNames={[]}
+          onCancel={vi.fn()}
+          onSave={vi.fn()}
+          onSaveEdit={vi.fn()}
+        />
+      )
+    })
+    expect(findSavedTag()).toBeTruthy()
+  })
+
+  it('shows conflict banner and preserves local edits when onSaveEdit throws a revision conflict', async () => {
+    const revisionConflictError = new Error('Revision conflict: expected 1, found 2.')
+    const onSaveEdit = vi.fn().mockRejectedValue(revisionConflictError)
+
+    await act(async () => {
+      root.render(
+        <SpecialistEditor
+          editSpecialist={{
+            id: 'conflict-bot',
+            name: 'Conflict Bot',
+            description: 'Original description',
+            systemPrompt: '',
+            enabled: true,
+            capabilityMode: 'full',
+            fullAccess: { excludedSkillIds: [], excludedConnectorIds: [], connectorTools: [] },
+            selectedCapabilities: { skillIds: [], connectorIds: [], connectorTools: [] },
+            revision: 1
+          }}
+          existingNames={[]}
+          onCancel={vi.fn()}
+          onSave={vi.fn()}
+          onSaveEdit={onSaveEdit}
+        />
+      )
+    })
+
+    // Edit the description to simulate unsaved local changes.
+    await act(async () => {
+      fireEvent.change(document.body.querySelector<HTMLInputElement>('#sp-description')!, {
+        target: { value: 'My unsaved edit' }
+      })
+    })
+
+    // Click Save — triggers the revision conflict.
+    await act(async () => {
+      Array.from(document.body.querySelectorAll<HTMLButtonElement>('button'))
+        .find((btn) => btn.textContent === 'Save changes')
+        ?.click()
+    })
+
+    // Conflict banner must appear.
+    expect(document.body.querySelector('[aria-label="Revision conflict"]')).not.toBeNull()
+    expect(document.body.textContent).toContain('Someone else saved a newer version')
+
+    // Local edits must be preserved — description field retains the unsaved text.
+    expect(document.body.querySelector<HTMLInputElement>('#sp-description')?.value).toBe(
+      'My unsaved edit'
+    )
+
+    // Save button is disabled while conflict is active (prevents a write that
+    // would still lose the newer server version).
+    const saveButton = Array.from(document.body.querySelectorAll<HTMLButtonElement>('button')).find(
+      (btn) => btn.textContent === 'Save changes'
+    )
+    expect(saveButton?.disabled).toBe(true)
+  })
+
+  it('calls onReload when the user clicks Reload in the conflict banner', async () => {
+    const revisionConflictError = new Error('Revision conflict: expected 1, found 2.')
+    const onSaveEdit = vi.fn().mockRejectedValue(revisionConflictError)
+    const onReload = vi.fn().mockResolvedValue(undefined)
+
+    await act(async () => {
+      root.render(
+        <SpecialistEditor
+          editSpecialist={{
+            id: 'reload-bot',
+            name: 'Reload Bot',
+            description: '',
+            systemPrompt: '',
+            enabled: true,
+            capabilityMode: 'full',
+            fullAccess: { excludedSkillIds: [], excludedConnectorIds: [], connectorTools: [] },
+            selectedCapabilities: { skillIds: [], connectorIds: [], connectorTools: [] },
+            revision: 1
+          }}
+          existingNames={[]}
+          onCancel={vi.fn()}
+          onSave={vi.fn()}
+          onSaveEdit={onSaveEdit}
+          onReload={onReload}
+        />
+      )
+    })
+
+    // Trigger conflict.
+    await act(async () => {
+      Array.from(document.body.querySelectorAll<HTMLButtonElement>('button'))
+        .find((btn) => btn.textContent === 'Save changes')
+        ?.click()
+    })
+
+    // Conflict banner appears with a Reload button.
+    const reloadBtn = Array.from(document.body.querySelectorAll<HTMLButtonElement>('button')).find(
+      (btn) => btn.textContent === 'Reload'
+    )
+    expect(reloadBtn).not.toBeNull()
+
+    // Click Reload — must call onReload once.
+    await act(async () => {
+      reloadBtn?.click()
+    })
+
+    expect(onReload).toHaveBeenCalledOnce()
+  })
+
+  it('does not show a conflict banner for non-conflict errors', async () => {
+    const onSaveEdit = vi.fn().mockRejectedValue(new Error('Network error'))
+
+    await act(async () => {
+      root.render(
+        <SpecialistEditor
+          editSpecialist={{
+            id: 'net-err-bot',
+            name: 'Net Err Bot',
+            description: '',
+            systemPrompt: '',
+            enabled: true,
+            capabilityMode: 'full',
+            fullAccess: { excludedSkillIds: [], excludedConnectorIds: [], connectorTools: [] },
+            selectedCapabilities: { skillIds: [], connectorIds: [], connectorTools: [] },
+            revision: 1
+          }}
+          existingNames={[]}
+          onCancel={vi.fn()}
+          onSave={vi.fn()}
+          onSaveEdit={onSaveEdit}
+        />
+      )
+    })
+
+    await act(async () => {
+      Array.from(document.body.querySelectorAll<HTMLButtonElement>('button'))
+        .find((btn) => btn.textContent === 'Save changes')
+        ?.click()
+    })
+
+    // Must show the generic error, not the conflict banner.
+    expect(document.body.querySelector('[aria-label="Revision conflict"]')).toBeNull()
+    expect(document.body.textContent).toContain('Network error')
+  })
+})

--- a/src/renderer/src/pages/settings/SpecialistEditor.tsx
+++ b/src/renderer/src/pages/settings/SpecialistEditor.tsx
@@ -1,0 +1,1061 @@
+import { useEffect, useMemo, useRef, useState, useCallback } from 'react'
+import { Button } from '@/components/ui/button'
+import { Input } from '@/components/ui/input'
+import { Textarea } from '@/components/ui/textarea'
+import { Select, SelectContent, SelectItem, SelectTrigger } from '@/components/ui/select'
+import { cn } from '@/lib/utils'
+import {
+  SPECIALIST_DESCRIPTION_MAX_LENGTH,
+  SPECIALIST_NAME_MAX_LENGTH,
+  validateCreateSpecialistInput,
+  type CreateSpecialistInput,
+  type UpdateSpecialistInput,
+  type SpecialistFieldError,
+  type SpecialistProfileView
+} from '../../../../shared/specialist'
+import { SpecialistAvatar } from './specialist-avatar'
+import { AVATAR_COLORS, AVATAR_ICONS } from './specialist-icons'
+import { useSettingsStore } from '@/stores/settings-store'
+
+type SpecialistEditorProps = {
+  onCancel: () => void
+  onSave: (input: CreateSpecialistInput) => Promise<void>
+  existingNames?: string[]
+  // Edit mode: when provided, the form is prefilled from this profile and Save
+  // calls onSaveEdit (with id + revision for optimistic concurrency) instead of
+  // onSave.
+  editSpecialist?: SpecialistProfileView
+  initialInput?: CreateSpecialistInput
+  onSaveEdit?: (input: UpdateSpecialistInput) => Promise<void>
+  // Called when the user clicks "Reload" after a revision conflict.
+  // Should fetch the latest profile from the store and return it.
+  onReload?: () => Promise<SpecialistProfileView | undefined>
+}
+
+type FormState = {
+  name: string
+  description: string
+  systemPrompt: string
+  iconKey: string
+  colorKey: string
+  capabilityMode: 'full' | 'selected'
+  excludedSkillIds: string[]
+  selectedSkillIds: string[]
+  excludedConnectorIds: string[]
+  connectorIds: string[]
+  // Pinned at mount from editSpecialist.revision; updated only on a successful save
+  // or explicit Reload. Never updated by prop changes — that would silently defeat
+  // the optimistic concurrency guard.
+  baseRevision: number
+}
+
+type ConnectorRow = {
+  id: string
+  name: string
+  description?: string
+  mainEnabled: boolean
+  available: boolean
+  availability?: 'unavailable' | 'unauthenticated'
+}
+
+type SkillRow = {
+  id: string
+  name: string
+  description?: string
+  source?: string
+  mainEnabled: boolean
+  missing: boolean
+}
+
+const ICON_OPTIONS = [
+  { key: 'brain', label: 'Brain' },
+  { key: 'beaker', label: 'Beaker' },
+  { key: 'book-open', label: 'Book' },
+  { key: 'flask-conical', label: 'Flask' },
+  { key: 'microscope', label: 'Microscope' },
+  { key: 'search', label: 'Search' }
+] as const
+
+const COLOR_OPTIONS = [
+  { key: 'blue', label: 'Blue' },
+  { key: 'green', label: 'Green' },
+  { key: 'teal', label: 'Teal' },
+  { key: 'amber', label: 'Amber' },
+  { key: 'purple', label: 'Purple' },
+  { key: 'slate', label: 'Slate' }
+] as const
+
+const SpecialistEditor = ({
+  onCancel,
+  onSave,
+  onSaveEdit,
+  onReload,
+  existingNames = [],
+  editSpecialist,
+  initialInput
+}: SpecialistEditorProps): React.JSX.Element => {
+  const isEdit = editSpecialist !== undefined
+  const connectors = useSettingsStore((state) => state.connectors)
+  const skills = useSettingsStore((state) => state.skills)
+  const customServers = useSettingsStore((state) => state.customServers)
+  const loadConnectors = useSettingsStore((state) => state.loadConnectors)
+  const loadSkills = useSettingsStore((state) => state.loadSkills)
+  const [form, setForm] = useState<FormState>(() =>
+    editSpecialist
+      ? {
+          name: editSpecialist.name,
+          description: editSpecialist.description,
+          systemPrompt: editSpecialist.systemPrompt,
+          iconKey: editSpecialist.iconKey ?? 'brain',
+          colorKey: editSpecialist.colorKey ?? 'purple',
+          capabilityMode: editSpecialist.capabilityMode,
+          excludedSkillIds: editSpecialist.fullAccess.excludedSkillIds,
+          selectedSkillIds: editSpecialist.selectedCapabilities.skillIds,
+          excludedConnectorIds: editSpecialist.fullAccess.excludedConnectorIds,
+          connectorIds: editSpecialist.selectedCapabilities.connectorIds,
+          // Pin base revision at mount so concurrent remote writes do not silently
+          // refresh it. Only a successful save or an explicit Reload may update it.
+          baseRevision: editSpecialist.revision
+        }
+      : {
+          name: initialInput?.name ?? '',
+          description: initialInput?.description ?? '',
+          systemPrompt: initialInput?.systemPrompt ?? '',
+          iconKey: initialInput?.iconKey ?? 'brain',
+          colorKey: initialInput?.colorKey ?? 'purple',
+          capabilityMode: initialInput?.capabilityMode ?? 'full',
+          excludedSkillIds: initialInput?.fullAccess?.excludedSkillIds ?? [],
+          selectedSkillIds: initialInput?.selectedCapabilities?.skillIds ?? [],
+          excludedConnectorIds: initialInput?.fullAccess?.excludedConnectorIds ?? [],
+          connectorIds: initialInput?.selectedCapabilities?.connectorIds ?? [],
+          baseRevision: 0
+        }
+  )
+  const [fieldErrors, setFieldErrors] = useState<SpecialistFieldError[]>([])
+  const [isSaving, setIsSaving] = useState(false)
+  const [saveError, setSaveError] = useState<string | undefined>()
+  // Tracks a revision conflict that requires the user to reload before saving.
+  const [hasConflict, setHasConflict] = useState(false)
+  const [isReloading, setIsReloading] = useState(false)
+  const [activeCapTab, setActiveCapTab] = useState<'skills' | 'connectors'>('skills')
+  const [skillSearchQuery, setSkillSearchQuery] = useState('')
+  const [connectorSearchQuery, setConnectorSearchQuery] = useState('')
+  const skillSearchRef = useRef<HTMLInputElement>(null)
+  const connectorSearchRef = useRef<HTMLInputElement>(null)
+  const [skillPopoverOpen, setSkillPopoverOpen] = useState(false)
+  const [connectorPopoverOpen, setConnectorPopoverOpen] = useState(false)
+  const skillDropdownRef = useRef<HTMLDivElement>(null)
+  const connectorDropdownRef = useRef<HTMLDivElement>(null)
+  const skillTriggerRef = useRef<HTMLButtonElement>(null)
+  const connectorTriggerRef = useRef<HTMLButtonElement>(null)
+
+  const closeSkillDropdown = useCallback(() => setSkillPopoverOpen(false), [])
+  const closeConnectorDropdown = useCallback(() => setConnectorPopoverOpen(false), [])
+
+  useEffect(() => {
+    if (!skillPopoverOpen) return
+    const handle = (e: MouseEvent): void => {
+      if (skillDropdownRef.current && !skillDropdownRef.current.contains(e.target as Node)) {
+        closeSkillDropdown()
+      }
+    }
+    document.addEventListener('mousedown', handle)
+    return () => document.removeEventListener('mousedown', handle)
+  }, [skillPopoverOpen, closeSkillDropdown])
+
+  useEffect(() => {
+    if (!connectorPopoverOpen) return
+    const handle = (e: MouseEvent): void => {
+      if (
+        connectorDropdownRef.current &&
+        !connectorDropdownRef.current.contains(e.target as Node)
+      ) {
+        closeConnectorDropdown()
+      }
+    }
+    document.addEventListener('mousedown', handle)
+    return () => document.removeEventListener('mousedown', handle)
+  }, [connectorPopoverOpen, closeConnectorDropdown])
+
+  useEffect(() => {
+    void loadConnectors()
+  }, [loadConnectors])
+
+  useEffect(() => {
+    if (skills.length === 0) void loadSkills()
+  }, [skills.length, loadSkills])
+
+  // Persist references to unavailable entries so a temporarily missing connector is visible and
+  // cannot silently broaden the profile when it returns. Main-disabled installed connectors remain
+  // selectable: Main's toggle is not a Specialist capability limit.
+  const connectorRows = useMemo(() => {
+    const known: ConnectorRow[] = [
+      ...connectors.map((connector) => ({
+        id: connector.id,
+        name: connector.displayName,
+        description: connector.description,
+        mainEnabled: connector.enabled,
+        available: true
+      })),
+      ...customServers.map((server) => ({
+        id: server.name,
+        name: server.name,
+        description: server.description,
+        mainEnabled: server.enabled,
+        available: server.availability === undefined,
+        availability: server.availability
+      }))
+    ]
+    const ids = new Set(known.map((row) => row.id))
+    for (const id of [...form.excludedConnectorIds, ...form.connectorIds]) {
+      if (!ids.has(id)) known.push({ id, name: id, mainEnabled: false, available: false })
+    }
+    return known.sort((a, b) => a.name.localeCompare(b.name))
+  }, [connectors, customServers, form.connectorIds, form.excludedConnectorIds])
+
+  // Main-disabled installed Skills remain selectable for a Specialist. Persisted IDs absent from
+  // the live catalog are rendered locally so the user can remove them without blocking the session.
+  const skillRows = useMemo(() => {
+    const known: SkillRow[] = skills.map((skill) => ({
+      id: skill.id,
+      name: skill.name,
+      description: skill.description,
+      source: skill.source,
+      mainEnabled: skill.enabled,
+      missing: false
+    }))
+    const ids = new Set(known.map((skill) => skill.id))
+    for (const id of [...form.excludedSkillIds, ...form.selectedSkillIds]) {
+      if (!ids.has(id)) known.push({ id, name: id, mainEnabled: false, missing: true })
+    }
+    return known.sort((a, b) => a.name.localeCompare(b.name))
+  }, [skills, form.excludedSkillIds, form.selectedSkillIds])
+
+  // Selected-capabilities mode lists. Skills and Connectors are both whitelists: they start empty
+  // and are added explicitly. Persisted IDs missing from the catalog stay visible (and removable)
+  // so a stale reference never locks the session. Main-disabled installed items remain addable:
+  // Main's toggle is not a Specialist capability limit.
+  const selectedSkillRows = useMemo(
+    () =>
+      form.selectedSkillIds.map((id) => {
+        const found = skillRows.find((row) => row.id === id)
+        return found ?? { id, name: id, mainEnabled: false, missing: true }
+      }),
+    [form.selectedSkillIds, skillRows]
+  )
+  const addableSkills = useMemo(
+    () =>
+      skills
+        .filter((skill) => !form.selectedSkillIds.includes(skill.id))
+        .map((skill) => ({
+          id: skill.id,
+          name: skill.name,
+          description: skill.description,
+          source: skill.source
+        }))
+        .sort((a, b) => a.name.localeCompare(b.name)),
+    [skills, form.selectedSkillIds]
+  )
+
+  const selectedConnectorRows = useMemo(
+    () =>
+      form.connectorIds.map((id) => {
+        const found = connectorRows.find((row) => row.id === id)
+        return found ?? { id, name: id, mainEnabled: false, available: false }
+      }),
+    [form.connectorIds, connectorRows]
+  )
+  const addableConnectors = useMemo(() => {
+    const all: ConnectorRow[] = [
+      ...connectors.map((connector) => ({
+        id: connector.id,
+        name: connector.displayName,
+        description: connector.description,
+        mainEnabled: connector.enabled,
+        available: true
+      })),
+      ...customServers.map((server) => ({
+        id: server.name,
+        name: server.name,
+        description: server.description,
+        mainEnabled: server.enabled,
+        available: server.availability === undefined,
+        availability: server.availability
+      }))
+    ]
+    return all
+      .filter((row) => row.available && !form.connectorIds.includes(row.id))
+      .sort((a, b) => a.name.localeCompare(b.name))
+  }, [connectors, customServers, form.connectorIds])
+
+  const filteredAddableSkills = useMemo(() => {
+    if (!skillSearchQuery.trim()) return addableSkills
+    const q = skillSearchQuery.toLowerCase()
+    return addableSkills.filter(
+      (skill) =>
+        skill.name.toLowerCase().includes(q) ||
+        (skill.description && skill.description.toLowerCase().includes(q))
+    )
+  }, [addableSkills, skillSearchQuery])
+
+  const filteredAddableConnectors = useMemo(() => {
+    if (!connectorSearchQuery.trim()) return addableConnectors
+    const q = connectorSearchQuery.toLowerCase()
+    return addableConnectors.filter(
+      (connector) =>
+        connector.name.toLowerCase().includes(q) ||
+        (connector.description && connector.description.toLowerCase().includes(q))
+    )
+  }, [addableConnectors, connectorSearchQuery])
+
+  const addSkill = (id: string): void =>
+    setForm((prev) =>
+      prev.selectedSkillIds.includes(id)
+        ? prev
+        : { ...prev, selectedSkillIds: [...prev.selectedSkillIds, id] }
+    )
+  const removeSkill = (id: string): void =>
+    setForm((prev) => ({
+      ...prev,
+      selectedSkillIds: prev.selectedSkillIds.filter((skillId) => skillId !== id)
+    }))
+  const addConnector = (id: string): void =>
+    setForm((prev) =>
+      prev.connectorIds.includes(id) ? prev : { ...prev, connectorIds: [...prev.connectorIds, id] }
+    )
+  const removeConnector = (id: string): void =>
+    setForm((prev) => ({
+      ...prev,
+      connectorIds: prev.connectorIds.filter((connectorId) => connectorId !== id)
+    }))
+
+  const getFieldError = (field: SpecialistFieldError['field']): string | undefined =>
+    fieldErrors.find((e) => e.field === field)?.message
+
+  const isFullAccess = form.capabilityMode === 'full'
+
+  const validate = (): boolean => {
+    // Client-side validation using the shared validator.
+    const input: CreateSpecialistInput = {
+      name: form.name,
+      description: form.description || undefined,
+      systemPrompt: form.systemPrompt || undefined
+    }
+    const errors = validateCreateSpecialistInput(input, existingNames)
+    setFieldErrors(errors)
+    return errors.length === 0
+  }
+
+  const handleSave = async (): Promise<void> => {
+    if (!validate()) return
+
+    setIsSaving(true)
+    setSaveError(undefined)
+    setHasConflict(false)
+    try {
+      const trimmed = {
+        name: form.name.trim(),
+        displayName: form.name.trim(),
+        description: form.description.trim() || undefined,
+        systemPrompt: form.systemPrompt.trim() || undefined,
+        iconKey: form.iconKey,
+        colorKey: form.colorKey,
+        capabilityMode: form.capabilityMode,
+        fullAccess: {
+          ...(editSpecialist?.fullAccess ?? {
+            excludedSkillIds: [],
+            excludedConnectorIds: [],
+            connectorTools: []
+          }),
+          excludedSkillIds: form.excludedSkillIds,
+          excludedConnectorIds: form.excludedConnectorIds
+        },
+        selectedCapabilities: {
+          ...(editSpecialist?.selectedCapabilities ?? {
+            skillIds: [],
+            connectorIds: [],
+            connectorTools: []
+          }),
+          skillIds: form.selectedSkillIds,
+          connectorIds: form.connectorIds
+        }
+      }
+      if (editSpecialist) {
+        // Send the base revision pinned at mount (or last successful save / reload),
+        // not the current prop revision, which may have been refreshed by a remote
+        // write and would silently defeat the optimistic concurrency guard.
+        await onSaveEdit?.({
+          id: editSpecialist.id,
+          revision: form.baseRevision,
+          ...trimmed
+        })
+        // Advance the base revision only after a confirmed save.
+        setForm((prev) => ({ ...prev, baseRevision: prev.baseRevision + 1 }))
+      } else {
+        await onSave(trimmed)
+      }
+    } catch (error) {
+      const message =
+        error instanceof Error
+          ? error.message
+          : isEdit
+            ? 'Could not save changes.'
+            : 'Could not create specialist.'
+      // Detect optimistic concurrency conflict — preserve local edits and show the
+      // conflict banner instead of a generic error so the user can choose to reload.
+      if (/revision conflict/i.test(message)) {
+        setHasConflict(true)
+      } else {
+        setSaveError(message)
+      }
+    } finally {
+      setIsSaving(false)
+    }
+  }
+
+  // Reloads the latest revision from the store. The caller is expected to return the
+  // fresh profile. When it does, form state (including baseRevision) is reset from the
+  // fresh data so the user's stale edits are fully replaced. The conflict banner is
+  // cleared and Save is re-enabled only after this reset completes.
+  const handleReload = async (): Promise<void> => {
+    if (!onReload) return
+    setIsReloading(true)
+    try {
+      const fresh = await onReload()
+      if (fresh) {
+        setForm({
+          name: fresh.name,
+          description: fresh.description,
+          systemPrompt: fresh.systemPrompt,
+          iconKey: fresh.iconKey ?? 'brain',
+          colorKey: fresh.colorKey ?? 'purple',
+          capabilityMode: fresh.capabilityMode,
+          excludedSkillIds: fresh.fullAccess.excludedSkillIds,
+          selectedSkillIds: fresh.selectedCapabilities.skillIds,
+          excludedConnectorIds: fresh.fullAccess.excludedConnectorIds,
+          connectorIds: fresh.selectedCapabilities.connectorIds,
+          baseRevision: fresh.revision
+        })
+        setHasConflict(false)
+      }
+    } finally {
+      setIsReloading(false)
+    }
+  }
+
+  return (
+    <div className="p-5">
+      <div className="max-w-2xl">
+        {/* Save error — shown at the top so it is immediately visible */}
+        {saveError ? (
+          <div
+            className="mb-4 flex items-start gap-2 rounded-lg border border-destructive/30 bg-destructive/5 p-3 text-sm text-destructive"
+            role="alert"
+          >
+            <svg className="mt-0.5 shrink-0" width="16" height="16" viewBox="0 0 16 16" fill="none">
+              <circle cx="8" cy="8" r="7" stroke="currentColor" strokeWidth="1.5" />
+              <path
+                d="M8 4.5v4M8 10.5v.5"
+                stroke="currentColor"
+                strokeWidth="1.5"
+                strokeLinecap="round"
+              />
+            </svg>
+            <span>{saveError}</span>
+          </div>
+        ) : null}
+
+        {/* Saved identity bar — stable reference of what's currently persisted (edit only).
+            In create mode there is nothing saved yet, so the bar is omitted. */}
+        {isEdit && editSpecialist ? (
+          <div className="mb-5 flex items-start gap-3 rounded-lg border border-border bg-muted/30 p-3">
+            <SpecialistAvatar iconKey={editSpecialist.iconKey} colorKey={editSpecialist.colorKey} />
+            <div className="min-w-0 flex-1">
+              <div className="flex flex-wrap items-center gap-2">
+                <span className="text-[15px] font-semibold text-foreground">
+                  {editSpecialist.name}
+                </span>
+                <span className="rounded bg-muted px-1.5 py-0.5 text-[10px] font-semibold uppercase tracking-wide text-muted-foreground">
+                  Saved
+                </span>
+              </div>
+              <p className="mt-0.5 line-clamp-2 max-w-xl text-xs text-muted-foreground">
+                {editSpecialist.description || 'No description'}
+              </p>
+            </div>
+          </div>
+        ) : null}
+
+        {/* Identity section */}
+        <section className="mb-6">
+          <h3 className="mb-1 text-base font-semibold text-foreground">Identity</h3>
+          <p className="mb-4 text-[13px] leading-5 text-muted-foreground">
+            How this specialist appears in the registry and session picker.
+          </p>
+
+          {/* Live preview — reflects the current icon + color + name, matching the list */}
+          <div className="mb-4 flex items-center gap-3 rounded-lg border border-border p-3">
+            <SpecialistAvatar iconKey={form.iconKey} colorKey={form.colorKey} size="lg" />
+            <div className="min-w-0 flex-1">
+              <span className="block truncate text-sm font-semibold text-foreground">
+                {form.name.trim() || 'Untitled specialist'}
+              </span>
+              <span className="text-xs text-muted-foreground">
+                Preview — matches the list and picker.
+              </span>
+            </div>
+            <span className="shrink-0 rounded bg-primary/10 px-1.5 py-0.5 text-[10px] font-semibold uppercase tracking-wide text-primary">
+              Live
+            </span>
+          </div>
+
+          <div className="mb-4 grid gap-4 sm:grid-cols-2">
+            <div>
+              <label className="mb-1.5 block text-xs font-semibold">Icon</label>
+              <Select
+                value={form.iconKey}
+                onValueChange={(iconKey) => setForm((prev) => ({ ...prev, iconKey }))}
+              >
+                <SelectTrigger aria-label="Specialist icon">
+                  <span className="flex items-center gap-2">
+                    {(() => {
+                      const Icon = AVATAR_ICONS[form.iconKey] ?? AVATAR_ICONS.brain
+                      return <Icon className="size-4 shrink-0" aria-hidden="true" />
+                    })()}
+                    <span>{ICON_OPTIONS.find((option) => option.key === form.iconKey)?.label}</span>
+                  </span>
+                </SelectTrigger>
+                <SelectContent>
+                  {ICON_OPTIONS.map((option) => {
+                    const Icon = AVATAR_ICONS[option.key] ?? AVATAR_ICONS.brain
+                    return (
+                      <SelectItem key={option.key} value={option.key}>
+                        <span className="flex items-center gap-2">
+                          <Icon className="size-4 shrink-0" aria-hidden="true" />
+                          {option.label}
+                        </span>
+                      </SelectItem>
+                    )
+                  })}
+                </SelectContent>
+              </Select>
+            </div>
+            <div>
+              <label className="mb-1.5 block text-xs font-semibold">Color</label>
+              <Select
+                value={form.colorKey}
+                onValueChange={(colorKey) => setForm((prev) => ({ ...prev, colorKey }))}
+              >
+                <SelectTrigger aria-label="Specialist color">
+                  <span className="flex items-center gap-2">
+                    <span
+                      className="size-3.5 shrink-0 rounded border border-black/10"
+                      style={{ background: AVATAR_COLORS[form.colorKey] }}
+                      aria-hidden="true"
+                    />
+                    <span>
+                      {COLOR_OPTIONS.find((option) => option.key === form.colorKey)?.label}
+                    </span>
+                  </span>
+                </SelectTrigger>
+                <SelectContent>
+                  {COLOR_OPTIONS.map((option) => (
+                    <SelectItem key={option.key} value={option.key}>
+                      <span className="flex items-center gap-2">
+                        <span
+                          className="size-3.5 shrink-0 rounded border border-black/10"
+                          style={{ background: AVATAR_COLORS[option.key] }}
+                          aria-hidden="true"
+                        />
+                        {option.label}
+                      </span>
+                    </SelectItem>
+                  ))}
+                </SelectContent>
+              </Select>
+            </div>
+          </div>
+
+          {/* Name */}
+          <div className="mb-4">
+            <label
+              htmlFor="sp-name"
+              className="mb-1.5 flex items-baseline justify-between text-xs font-semibold"
+            >
+              <span>Name</span>
+              <span className="font-normal tabular-nums text-muted-foreground">
+                {form.name.length} / {SPECIALIST_NAME_MAX_LENGTH}
+              </span>
+            </label>
+            <Input
+              id="sp-name"
+              value={form.name}
+              maxLength={SPECIALIST_NAME_MAX_LENGTH}
+              onChange={(e) => {
+                setForm((prev) => ({ ...prev, name: e.target.value }))
+                setFieldErrors((prev) => prev.filter((er) => er.field !== 'name'))
+              }}
+              placeholder="e.g. RNA-seq Reviewer"
+              aria-describedby={getFieldError('name') ? 'sp-name-err' : undefined}
+              aria-invalid={!!getFieldError('name')}
+              className={cn(getFieldError('name') && 'border-destructive')}
+            />
+            {getFieldError('name') ? (
+              <p id="sp-name-err" className="mt-1 text-xs text-destructive" role="alert">
+                {getFieldError('name')}
+              </p>
+            ) : null}
+          </div>
+
+          {/* Description */}
+          <div className="mb-0">
+            <label
+              htmlFor="sp-description"
+              className="mb-1.5 flex items-baseline justify-between text-xs font-semibold"
+            >
+              <span>
+                Description <span className="font-normal text-muted-foreground">(optional)</span>
+              </span>
+              <span className="font-normal tabular-nums text-muted-foreground">
+                {form.description.length} / {SPECIALIST_DESCRIPTION_MAX_LENGTH}
+              </span>
+            </label>
+            <Input
+              id="sp-description"
+              value={form.description}
+              maxLength={SPECIALIST_DESCRIPTION_MAX_LENGTH}
+              onChange={(e) => {
+                setForm((prev) => ({ ...prev, description: e.target.value }))
+                setFieldErrors((prev) => prev.filter((er) => er.field !== 'description'))
+              }}
+              aria-describedby={getFieldError('description') ? 'sp-description-err' : undefined}
+              aria-invalid={!!getFieldError('description')}
+              className={cn(getFieldError('description') && 'border-destructive')}
+              placeholder="Short description shown in the list and picker"
+            />
+            {getFieldError('description') ? (
+              <p id="sp-description-err" className="mt-1 text-xs text-destructive" role="alert">
+                {getFieldError('description')}
+              </p>
+            ) : null}
+          </div>
+        </section>
+
+        {/* Instructions section */}
+        <section className="mb-6 border-t border-border pt-5">
+          <h3 className="mb-1 text-base font-semibold text-foreground">Instructions</h3>
+          <p className="mb-4 text-[13px] leading-5 text-muted-foreground">
+            Appended to the app&rsquo;s base prompt — does not replace safety rules or tool
+            instructions. Optional.
+          </p>
+          <div>
+            <label htmlFor="sp-system-prompt" className="sr-only">
+              Instructions
+            </label>
+            <Textarea
+              id="sp-system-prompt"
+              value={form.systemPrompt}
+              onChange={(e) => setForm((prev) => ({ ...prev, systemPrompt: e.target.value }))}
+              placeholder="Optional — leave empty to use the base prompt as-is."
+              className="min-h-[120px] resize-y text-[13px]"
+            />
+          </div>
+        </section>
+
+        {/* Capabilities */}
+        <section className="border-t border-border pt-5">
+          <h3 className="mb-1 text-base font-semibold text-foreground">Capabilities</h3>
+          <p className="mb-4 text-[13px] leading-5 text-muted-foreground">
+            Skills and connectors this specialist can use. Anything not chosen here stays invisible
+            and unreachable in its sessions, even when enabled globally.
+          </p>
+
+          {/* Full access — single option, default selected. Loads every Main Agent skill and
+              connector; selecting it disables the Select capabilities panel below. */}
+          <button
+            type="button"
+            role="switch"
+            aria-checked={isFullAccess}
+            aria-label="Full access"
+            onClick={() =>
+              setForm((prev) => ({
+                ...prev,
+                capabilityMode: prev.capabilityMode === 'full' ? 'selected' : 'full'
+              }))
+            }
+            className={cn(
+              'mb-2 flex items-start gap-3 rounded-lg border p-3 text-left transition-colors',
+              isFullAccess ? 'border-primary bg-primary/5' : 'border-border bg-card hover:bg-muted'
+            )}
+          >
+            <span
+              className={cn(
+                'mt-0.5 flex size-[18px] shrink-0 items-center justify-center rounded-full border-2',
+                isFullAccess ? 'border-primary' : 'border-text-300'
+              )}
+            >
+              {isFullAccess ? <span className="size-2.5 rounded-full bg-primary" /> : null}
+            </span>
+            <span className="min-w-0 flex-1">
+              <span className="flex items-center gap-2 text-[13px] font-semibold">
+                Full access
+                <span className="rounded bg-primary px-1.5 py-px text-[9.5px] font-semibold uppercase tracking-wide text-primary-foreground">
+                  Default
+                </span>
+              </span>
+              <span className="mt-0.5 block text-[11.5px] leading-snug text-muted-foreground">
+                Use all of the Main Agent&rsquo;s skills and connectors, including new ones added
+                later. No need to configure each item.
+              </span>
+            </span>
+          </button>
+
+          <div className="my-3 flex items-center gap-3" aria-hidden="true">
+            <span className="h-px flex-1 bg-border" />
+            <span className="text-[11px] text-text-300">or choose specific capabilities</span>
+            <span className="h-px flex-1 bg-border" />
+          </div>
+
+          {/* Select capabilities — greyed and non-interactive while Full access is on. Clicking the
+              greyed panel turns Full access off so the lists become editable. */}
+          <div className="relative">
+            <div
+              className={cn(
+                'rounded-lg',
+                isFullAccess && 'pointer-events-none opacity-45 select-none'
+              )}
+            >
+              <div className="mb-3 flex items-center justify-between">
+                <div
+                  className="inline-flex gap-0.5 rounded-lg bg-muted p-1"
+                  role="tablist"
+                  aria-label="Capability type"
+                >
+                  <button
+                    type="button"
+                    role="tab"
+                    aria-selected={activeCapTab === 'skills'}
+                    onClick={() => setActiveCapTab('skills')}
+                    className={cn(
+                      'rounded-md px-3 py-1 text-[12.5px] font-medium',
+                      activeCapTab === 'skills'
+                        ? 'bg-card text-foreground shadow-sm'
+                        : 'text-muted-foreground hover:text-foreground'
+                    )}
+                  >
+                    Skills{' '}
+                    <span className="ml-0.5 text-[11px] opacity-75">
+                      {form.selectedSkillIds.length}
+                    </span>
+                  </button>
+                  <button
+                    type="button"
+                    role="tab"
+                    aria-selected={activeCapTab === 'connectors'}
+                    onClick={() => setActiveCapTab('connectors')}
+                    className={cn(
+                      'rounded-md px-3 py-1 text-[12.5px] font-medium',
+                      activeCapTab === 'connectors'
+                        ? 'bg-card text-foreground shadow-sm'
+                        : 'text-muted-foreground hover:text-foreground'
+                    )}
+                  >
+                    Connectors{' '}
+                    <span className="ml-0.5 text-[11px] opacity-75">
+                      {form.connectorIds.length}
+                    </span>
+                  </button>
+                </div>
+
+                {/* Add button + dropdown — right side of the same row */}
+                {activeCapTab === 'skills' ? (
+                  <div className="relative" ref={skillDropdownRef}>
+                    <button
+                      ref={skillTriggerRef}
+                      type="button"
+                      onClick={() => {
+                        setSkillPopoverOpen((prev) => !prev)
+                        setSkillSearchQuery('')
+                        setTimeout(() => skillSearchRef.current?.focus(), 0)
+                      }}
+                      className="flex h-[28px] items-center rounded-lg border border-dashed border-border bg-card px-3 text-[12px] text-muted-foreground hover:bg-muted"
+                    >
+                      ＋ Add a skill
+                    </button>
+                    {skillPopoverOpen ? (
+                      <div className="absolute right-0 top-full z-50 mt-1 flex max-h-[260px] w-[240px] flex-col overflow-y-auto rounded-lg border border-border bg-card shadow-md">
+                        <div className="sticky top-0 z-10 border-b border-border bg-card p-2">
+                          <input
+                            ref={skillSearchRef}
+                            type="search"
+                            placeholder="Search skills…"
+                            value={skillSearchQuery}
+                            onChange={(e) => setSkillSearchQuery(e.target.value)}
+                            className="w-full rounded-md border border-border bg-card px-2.5 py-1.5 text-[12.5px] text-foreground placeholder:text-muted-foreground outline-none focus:border-primary"
+                          />
+                        </div>
+                        <div className="flex-1">
+                          {filteredAddableSkills.length === 0 ? (
+                            <p className="px-3 py-3 text-[12px] text-muted-foreground">
+                              {skillSearchQuery ? 'No matching skills' : 'No more skills to add'}
+                            </p>
+                          ) : (
+                            filteredAddableSkills.map((skill) => (
+                              <button
+                                key={skill.id}
+                                type="button"
+                                onClick={() => {
+                                  addSkill(skill.id)
+                                  setSkillPopoverOpen(false)
+                                }}
+                                className="flex h-[38px] w-full items-center gap-2 px-3 text-left hover:bg-muted"
+                              >
+                                <span className="min-w-0 flex-1 truncate font-mono text-[12.5px]">
+                                  {skill.name}
+                                </span>
+                              </button>
+                            ))
+                          )}
+                        </div>
+                      </div>
+                    ) : null}
+                  </div>
+                ) : (
+                  <div className="relative" ref={connectorDropdownRef}>
+                    <button
+                      ref={connectorTriggerRef}
+                      type="button"
+                      onClick={() => {
+                        setConnectorPopoverOpen((prev) => !prev)
+                        setConnectorSearchQuery('')
+                        setTimeout(() => connectorSearchRef.current?.focus(), 0)
+                      }}
+                      className="flex h-[28px] items-center rounded-lg border border-dashed border-border bg-card px-3 text-[12px] text-muted-foreground hover:bg-muted"
+                    >
+                      ＋ Add a connector
+                    </button>
+                    {connectorPopoverOpen ? (
+                      <div className="absolute right-0 top-full z-50 mt-1 flex max-h-[260px] w-[240px] flex-col overflow-y-auto rounded-lg border border-border bg-card shadow-md">
+                        <div className="sticky top-0 z-10 border-b border-border bg-card p-2">
+                          <input
+                            ref={connectorSearchRef}
+                            type="search"
+                            placeholder="Search connectors…"
+                            value={connectorSearchQuery}
+                            onChange={(e) => setConnectorSearchQuery(e.target.value)}
+                            className="w-full rounded-md border border-border bg-card px-2.5 py-1.5 text-[12.5px] text-foreground placeholder:text-muted-foreground outline-none focus:border-primary"
+                          />
+                        </div>
+                        <div className="flex-1">
+                          {filteredAddableConnectors.length === 0 ? (
+                            <p className="px-3 py-3 text-[12px] text-muted-foreground">
+                              {connectorSearchQuery
+                                ? 'No matching connectors'
+                                : 'No more connectors to add'}
+                            </p>
+                          ) : (
+                            filteredAddableConnectors.map((connector) => (
+                              <button
+                                key={connector.id}
+                                type="button"
+                                onClick={() => {
+                                  addConnector(connector.id)
+                                  setConnectorPopoverOpen(false)
+                                }}
+                                className="flex h-[38px] w-full items-center gap-2 px-3 text-left hover:bg-muted"
+                              >
+                                <span className="min-w-0 flex-1 truncate text-[12.5px]">
+                                  {connector.name}
+                                </span>
+                              </button>
+                            ))
+                          )}
+                        </div>
+                      </div>
+                    ) : null}
+                  </div>
+                )}
+              </div>
+
+              {activeCapTab === 'skills' ? (
+                <div>
+                  <div className="overflow-hidden rounded-lg border border-border">
+                    {selectedSkillRows.length === 0 ? (
+                      <p className="px-3 py-3.5 text-[12px] text-muted-foreground">
+                        No skills added yet.
+                      </p>
+                    ) : (
+                      selectedSkillRows.map((skill) => (
+                        <div
+                          key={skill.id}
+                          className="flex h-[40px] items-center gap-2.5 border-b border-border px-3 last:border-b-0"
+                        >
+                          <div className="min-w-0 flex-1">
+                            <div className="truncate font-mono text-[12.5px]">{skill.name}</div>
+                            {!skill.missing && skill.description ? (
+                              <div className="truncate text-[11px] text-muted-foreground">
+                                {skill.description}
+                              </div>
+                            ) : null}
+                          </div>
+                          {skill.missing ? (
+                            <span className="shrink-0 text-[11px] text-muted-foreground">
+                              Missing · unavailable
+                            </span>
+                          ) : (
+                            <>
+                              {skill.source ? (
+                                <span className="shrink-0 rounded bg-muted px-1.5 py-0.5 text-[10px] capitalize text-muted-foreground">
+                                  {skill.source}
+                                </span>
+                              ) : null}
+                              {!skill.mainEnabled ? (
+                                <span className="shrink-0 text-[11px] text-muted-foreground">
+                                  Main disabled · available here
+                                </span>
+                              ) : null}
+                            </>
+                          )}
+                          <button
+                            type="button"
+                            aria-label={`Remove ${skill.name}`}
+                            onClick={() => removeSkill(skill.id)}
+                            className="flex size-[22px] shrink-0 items-center justify-center rounded text-[12px] text-muted-foreground hover:bg-muted hover:text-destructive"
+                          >
+                            ✕
+                          </button>
+                        </div>
+                      ))
+                    )}
+                  </div>
+                  <p className="mt-2.5 flex gap-2 rounded-lg bg-muted p-2.5 text-[11.5px] leading-snug text-muted-foreground">
+                    <span aria-hidden="true">ⓘ</span>
+                    <span>
+                      Skills start empty and must be added. Skills not listed here are hidden from
+                      this specialist, and Skill calls to them are rejected.
+                    </span>
+                  </p>
+                </div>
+              ) : null}
+
+              {activeCapTab === 'connectors' ? (
+                <div>
+                  <div className="overflow-hidden rounded-lg border border-border">
+                    {selectedConnectorRows.length === 0 ? (
+                      <p className="px-3 py-3.5 text-[12px] text-muted-foreground">
+                        No connectors added yet.
+                      </p>
+                    ) : (
+                      selectedConnectorRows.map((connector) => (
+                        <div
+                          key={connector.id}
+                          className="flex h-[40px] items-center gap-2.5 border-b border-border px-3 last:border-b-0"
+                        >
+                          <div className="min-w-0 flex-1">
+                            <div className="truncate text-[12.5px]">{connector.name}</div>
+                            {connector.available && connector.description ? (
+                              <div className="truncate text-[11px] text-muted-foreground">
+                                {connector.description}
+                              </div>
+                            ) : null}
+                          </div>
+                          {!connector.available ? (
+                            <span className="shrink-0 text-[11px] text-muted-foreground">
+                              Unavailable — {connector.availability ?? 'not installed'}
+                            </span>
+                          ) : !connector.mainEnabled ? (
+                            <span className="shrink-0 text-[11px] text-muted-foreground">
+                              Main disabled · available here
+                            </span>
+                          ) : null}
+                          <button
+                            type="button"
+                            aria-label={`Remove ${connector.name}`}
+                            onClick={() => removeConnector(connector.id)}
+                            className="flex size-[22px] shrink-0 items-center justify-center rounded text-[12px] text-muted-foreground hover:bg-muted hover:text-destructive"
+                          >
+                            ✕
+                          </button>
+                        </div>
+                      ))
+                    )}
+                  </div>
+                  <p className="mt-2.5 flex gap-2 rounded-lg bg-muted p-2.5 text-[11.5px] leading-snug text-muted-foreground">
+                    <span aria-hidden="true">ⓘ</span>
+                    <span>
+                      Connectors start empty and must be added. Connectors not listed here are
+                      blocked at runtime for this specialist&rsquo;s sessions.
+                    </span>
+                  </p>
+                </div>
+              ) : null}
+            </div>
+
+            {isFullAccess ? (
+              <button
+                type="button"
+                aria-label="Enable select capabilities"
+                onClick={() => setForm((prev) => ({ ...prev, capabilityMode: 'selected' }))}
+                className="absolute inset-0 cursor-pointer rounded-lg"
+              />
+            ) : null}
+          </div>
+        </section>
+
+        {/* Revision conflict banner — shown when another save raced ahead.
+            Local edits are preserved so the user can review before reloading. */}
+        {hasConflict ? (
+          <div
+            role="alert"
+            aria-label="Revision conflict"
+            className="mt-4 flex items-start gap-3 rounded-lg border border-amber-200 bg-amber-50 p-3 text-sm dark:border-amber-900 dark:bg-amber-950"
+          >
+            <div className="min-w-0 flex-1">
+              <p className="font-semibold text-amber-900 dark:text-amber-100">
+                Someone else saved a newer version
+              </p>
+              <p className="mt-0.5 text-xs text-amber-700 dark:text-amber-300">
+                Your local edits are preserved. Reload to get the latest version (your unsaved
+                changes will be discarded), or cancel and try again.
+              </p>
+            </div>
+            {onReload ? (
+              <Button
+                type="button"
+                size="sm"
+                variant="outline"
+                onClick={() => void handleReload()}
+                disabled={isReloading}
+                className="shrink-0 border-amber-300 text-amber-900 hover:bg-amber-100 dark:border-amber-700 dark:text-amber-100"
+              >
+                {isReloading ? 'Reloading…' : 'Reload'}
+              </Button>
+            ) : null}
+          </div>
+        ) : null}
+
+        {/* Footer actions */}
+        <div className="mt-6 flex justify-end gap-2">
+          <Button type="button" variant="ghost" onClick={onCancel} disabled={isSaving}>
+            Cancel
+          </Button>
+          <Button
+            type="button"
+            onClick={() => void handleSave()}
+            disabled={isSaving || !form.name.trim() || hasConflict}
+          >
+            {isSaving
+              ? isEdit
+                ? 'Saving…'
+                : 'Creating…'
+              : isEdit
+                ? 'Save changes'
+                : 'Create specialist'}
+          </Button>
+        </div>
+      </div>
+    </div>
+  )
+}
+
+export { SpecialistEditor }

--- a/src/renderer/src/pages/settings/SpecialistsPanel.render.test.tsx
+++ b/src/renderer/src/pages/settings/SpecialistsPanel.render.test.tsx
@@ -1,0 +1,350 @@
+// @vitest-environment jsdom
+import { act } from 'react'
+import { createRoot, type Root } from 'react-dom/client'
+import { fireEvent } from '@testing-library/react'
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest'
+
+import { SpecialistsPanel } from './SpecialistsPanel'
+import { clickRadixMenuItem, openRadixMenu } from './test-utils'
+import { useSpecialistStore } from '@/stores/specialist-store'
+import type { SpecialistListItem } from '../../../../shared/specialist'
+
+;(globalThis as { IS_REACT_ACT_ENVIRONMENT?: boolean }).IS_REACT_ACT_ENVIRONMENT = true
+
+if (!Element.prototype.hasPointerCapture) {
+  Element.prototype.hasPointerCapture = (): boolean => false
+  Element.prototype.setPointerCapture = (): void => undefined
+  Element.prototype.releasePointerCapture = (): void => undefined
+}
+
+let container: HTMLDivElement
+let root: Root
+const initialStore = useSpecialistStore.getState()
+const specialistItems: SpecialistListItem[] = [
+  {
+    kind: 'custom',
+    id: 'rna-reviewer',
+    name: 'RNA Reviewer',
+    description: 'Reviews RNA-seq analyses.',
+    systemPrompt: '',
+    iconKey: 'microscope',
+    colorKey: 'teal',
+    enabled: true,
+    capabilityMode: 'full',
+    fullAccess: { excludedSkillIds: [], excludedConnectorIds: [], connectorTools: [] },
+    selectedCapabilities: { skillIds: [], connectorIds: [], connectorTools: [] },
+    revision: 1
+  },
+  {
+    kind: 'custom',
+    id: 'literature-reviewer',
+    name: 'Literature Reviewer',
+    description: 'Finds relevant papers.',
+    systemPrompt: '',
+    enabled: true,
+    capabilityMode: 'selected',
+    fullAccess: { excludedSkillIds: [], excludedConnectorIds: [], connectorTools: [] },
+    selectedCapabilities: { skillIds: [], connectorIds: [], connectorTools: [] },
+    revision: 1
+  },
+  { kind: 'reviewer', id: 'reviewer' }
+]
+
+beforeEach(() => {
+  window.api = {
+    specialist: {
+      list: vi.fn().mockResolvedValue(specialistItems),
+      create: vi.fn(),
+      setEnabled: vi.fn(),
+      onCatalogChanged: vi.fn(() => vi.fn())
+    },
+    settings: {
+      listConnectors: vi.fn().mockResolvedValue({ connectors: [], customServers: [], ncbi: null }),
+      listSkills: vi.fn().mockResolvedValue([])
+    }
+  } as unknown as Window['api']
+  useSpecialistStore.setState({
+    ...initialStore,
+    isLoaded: true,
+    items: specialistItems
+  })
+  container = document.createElement('div')
+  document.body.appendChild(container)
+  root = createRoot(container)
+})
+
+afterEach(() => {
+  act(() => root.unmount())
+  container.remove()
+  document.body.innerHTML = ''
+  useSpecialistStore.setState(initialStore, true)
+  delete (window as unknown as { api?: unknown }).api
+})
+
+describe('SpecialistsPanel', () => {
+  it('filters specialists by a user-entered search term', async () => {
+    await act(async () => {
+      root.render(<SpecialistsPanel view={{ kind: 'list' }} onNavigate={vi.fn()} />)
+    })
+
+    const search = document.body.querySelector<HTMLInputElement>('input[type="search"]')
+    expect(search).not.toBeNull()
+    await act(async () => {
+      fireEvent.change(search!, { target: { value: 'literature' } })
+    })
+
+    expect(document.body.textContent).toContain('Literature Reviewer')
+    expect(document.body.textContent).not.toContain('RNA Reviewer')
+  })
+
+  it('shows item counts in each filter tab', async () => {
+    await act(async () => {
+      root.render(<SpecialistsPanel view={{ kind: 'list' }} onNavigate={vi.fn()} />)
+    })
+
+    const tabs = document.body.querySelectorAll<HTMLButtonElement>(
+      '[aria-label="Filter specialists by category"] [role="tab"]'
+    )
+    const labels = Array.from(tabs).map((tab) => tab.textContent ?? '')
+    // 2 custom + 1 built-in reviewer = 3 total
+    expect(labels).toEqual(['All(3)', 'Custom(2)', 'Built-in(1)'])
+  })
+
+  it('filters the list to custom specialists when the Custom tab is clicked', async () => {
+    await act(async () => {
+      root.render(<SpecialistsPanel view={{ kind: 'list' }} onNavigate={vi.fn()} />)
+    })
+
+    const tabs = document.body.querySelectorAll<HTMLButtonElement>(
+      '[aria-label="Filter specialists by category"] [role="tab"]'
+    )
+    const custom = Array.from(tabs).find((tab) => tab.textContent?.includes('Custom'))
+    expect(custom).toBeDefined()
+    await act(async () => {
+      custom!.click()
+    })
+
+    expect(document.body.textContent).toContain('RNA Reviewer')
+    expect(document.body.textContent).not.toContain('Used by Auto-review')
+  })
+
+  it('shows each custom specialist capability mode in the list summary', async () => {
+    await act(async () => {
+      root.render(<SpecialistsPanel view={{ kind: 'list' }} onNavigate={vi.fn()} />)
+    })
+
+    expect(document.body.textContent).toContain('Full access')
+    expect(document.body.textContent).toContain('Selected capabilities')
+  })
+
+  it('renders the saved icon for a custom specialist', async () => {
+    await act(async () => {
+      root.render(<SpecialistsPanel view={{ kind: 'list' }} onNavigate={vi.fn()} />)
+    })
+
+    expect(document.body.querySelector('[data-specialist-icon="microscope"]')).not.toBeNull()
+  })
+
+  it('navigates to the edit view when a custom specialist row body is clicked', async () => {
+    const onNavigate = vi.fn()
+    await act(async () => {
+      root.render(<SpecialistsPanel view={{ kind: 'list' }} onNavigate={onNavigate} />)
+    })
+
+    const editButton = document.body.querySelector<HTMLButtonElement>(
+      '[aria-label="Edit RNA Reviewer"]'
+    )
+    expect(editButton).not.toBeNull()
+    await act(async () => {
+      editButton!.click()
+    })
+
+    expect(onNavigate).toHaveBeenCalledWith({ kind: 'edit', id: 'rna-reviewer' })
+  })
+
+  it('renders the editor prefilled with the specialist data in the edit view', async () => {
+    await act(async () => {
+      root.render(
+        <SpecialistsPanel view={{ kind: 'edit', id: 'rna-reviewer' }} onNavigate={vi.fn()} />
+      )
+    })
+
+    const name = document.body.querySelector<HTMLInputElement>('#sp-name')
+    expect(name?.value).toBe('RNA Reviewer')
+    expect(
+      Array.from(document.body.querySelectorAll<HTMLButtonElement>('button')).some(
+        (button) => button.textContent === 'Save changes'
+      )
+    ).toBe(true)
+  })
+
+  it('falls back to the list when the edited specialist no longer exists', async () => {
+    await act(async () => {
+      root.render(
+        <SpecialistsPanel view={{ kind: 'edit', id: 'missing-id' }} onNavigate={vi.fn()} />
+      )
+    })
+
+    // No editor fields — the list view is rendered instead.
+    expect(document.body.querySelector('#sp-name')).toBeNull()
+    expect(
+      document.body.querySelector('[aria-label="Filter specialists by category"]')
+    ).not.toBeNull()
+  })
+
+  // ---------------------------------------------------------------------------
+  // Concurrency and reload (Findings 1, 2, 3)
+  // ---------------------------------------------------------------------------
+
+  it('F1: save payload carries the original revision even after a catalog-changed refreshes props', async () => {
+    // rev 1 at mount
+    const updateMock = vi.fn().mockResolvedValue(specialistItems[0])
+    useSpecialistStore.setState({
+      ...useSpecialistStore.getState(),
+      update: updateMock,
+      load: async () => {
+        // Simulate remote write: rev bumped to 2 in the store
+        useSpecialistStore.setState({
+          items: specialistItems.map((item) =>
+            item.kind === 'custom' && item.id === 'rna-reviewer' ? { ...item, revision: 2 } : item
+          )
+        })
+      }
+    })
+
+    await act(async () => {
+      root.render(
+        <SpecialistsPanel view={{ kind: 'edit', id: 'rna-reviewer' }} onNavigate={vi.fn()} />
+      )
+    })
+
+    // Dirty the form so the save button becomes active.
+    await act(async () => {
+      fireEvent.change(document.body.querySelector<HTMLInputElement>('#sp-name')!, {
+        target: { value: 'RNA Reviewer Edited' }
+      })
+    })
+
+    // Simulate catalog-changed: trigger load which bumps store to rev 2.
+    const onCatalogChangedCb = (window.api.specialist.onCatalogChanged as ReturnType<typeof vi.fn>)
+      .mock.calls[0]?.[0] as (() => void) | undefined
+    if (onCatalogChangedCb) {
+      await act(async () => {
+        onCatalogChangedCb()
+      })
+    }
+
+    // Click Save — payload must still carry revision 1 (the pinned base revision).
+    await act(async () => {
+      Array.from(document.body.querySelectorAll<HTMLButtonElement>('button'))
+        .find((btn) => btn.textContent === 'Save changes')
+        ?.click()
+    })
+
+    expect(updateMock).toHaveBeenCalledWith(expect.objectContaining({ revision: 1 }))
+  })
+
+  it('F2: Reload actually replaces form content with the latest profile data', async () => {
+    // updateMock rejects with a conflict so the banner appears.
+    const updateMock = vi
+      .fn()
+      .mockRejectedValue(new Error('Revision conflict: expected 1, found 2.'))
+    // After reload, list returns rev 2 with updated name.
+    const updatedItems = specialistItems.map((item) =>
+      item.kind === 'custom' && item.id === 'rna-reviewer'
+        ? { ...item, revision: 2, name: 'RNA Reviewer Updated', description: 'Updated desc' }
+        : item
+    ) as SpecialistListItem[]
+
+    let listCallCount = 0
+    ;(window.api.specialist as unknown as { list: ReturnType<typeof vi.fn> }).list = vi.fn(
+      async () => {
+        listCallCount++
+        if (listCallCount > 1) return updatedItems
+        return specialistItems
+      }
+    )
+    useSpecialistStore.setState({
+      ...useSpecialistStore.getState(),
+      update: updateMock,
+      load: async () => {
+        const items = await window.api.specialist.list()
+        useSpecialistStore.setState({ items })
+      }
+    })
+
+    await act(async () => {
+      root.render(
+        <SpecialistsPanel view={{ kind: 'edit', id: 'rna-reviewer' }} onNavigate={vi.fn()} />
+      )
+    })
+
+    // Click Save to trigger conflict.
+    await act(async () => {
+      Array.from(document.body.querySelectorAll<HTMLButtonElement>('button'))
+        .find((btn) => btn.textContent === 'Save changes')
+        ?.click()
+    })
+
+    expect(document.body.querySelector('[aria-label="Revision conflict"]')).not.toBeNull()
+
+    // Click Reload.
+    await act(async () => {
+      Array.from(document.body.querySelectorAll<HTMLButtonElement>('button'))
+        .find((btn) => btn.textContent === 'Reload')
+        ?.click()
+    })
+
+    // Form should now show the updated name from the reloaded profile.
+    expect(document.body.querySelector<HTMLInputElement>('#sp-name')?.value).toBe(
+      'RNA Reviewer Updated'
+    )
+    // Conflict banner is gone.
+    expect(document.body.querySelector('[aria-label="Revision conflict"]')).toBeNull()
+  })
+
+  it('F3: a rejected delete keeps the dialog open and shows an error', async () => {
+    const deleteMock = vi.fn().mockRejectedValue(new Error('Revision conflict — try again.'))
+    useSpecialistStore.setState({
+      ...useSpecialistStore.getState(),
+      delete: deleteMock,
+      load: vi.fn().mockResolvedValue(undefined)
+    })
+
+    await act(async () => {
+      root.render(<SpecialistsPanel view={{ kind: 'list' }} onNavigate={vi.fn()} />)
+    })
+
+    // Open the actions dropdown for RNA Reviewer.
+    const actionsBtn = document.body.querySelector<HTMLButtonElement>(
+      '[aria-label="Actions for RNA Reviewer"]'
+    )
+    expect(actionsBtn).not.toBeNull()
+    openRadixMenu(actionsBtn)
+    await act(async () => {
+      // small tick to let Radix open the menu
+    })
+
+    // Click Delete in the dropdown.
+    const deleteItem = Array.from(
+      document.body.querySelectorAll<HTMLElement>('[role="menuitem"]')
+    ).find((item) => item.textContent?.includes('Delete'))
+    expect(deleteItem).not.toBeNull()
+    await act(async () => {
+      clickRadixMenuItem(deleteItem)
+    })
+
+    // Confirm deletion in the dialog.
+    const confirmBtn = Array.from(document.body.querySelectorAll<HTMLButtonElement>('button')).find(
+      (btn) => btn.textContent === 'Delete' && btn.closest('[role="alertdialog"]') !== null
+    )
+    expect(confirmBtn).not.toBeNull()
+    await act(async () => {
+      confirmBtn!.click()
+    })
+
+    // Dialog stays open and shows the error.
+    expect(document.body.querySelector('[role="alertdialog"]')).not.toBeNull()
+    expect(document.body.textContent).toMatch(/revision conflict|try again/i)
+  })
+})

--- a/src/renderer/src/pages/settings/SpecialistsPanel.tsx
+++ b/src/renderer/src/pages/settings/SpecialistsPanel.tsx
@@ -1,0 +1,417 @@
+import { useEffect, useMemo, useState } from 'react'
+import { ChevronDown, Copy, Pencil, Plus, Search, Trash2 } from 'lucide-react'
+import { AlertDialog } from 'radix-ui'
+import { Button } from '@/components/ui/button'
+import {
+  dialogDescriptionClassName,
+  dialogOverlayClassName,
+  dialogPanelClassName,
+  dialogTitleClassName
+} from '@/components/ui/dialog-chrome'
+import {
+  DropdownMenu,
+  DropdownMenuContent,
+  DropdownMenuItem,
+  DropdownMenuTrigger
+} from '@/components/ui/dropdown-menu'
+import { Input } from '@/components/ui/input'
+import { SettingsToggle } from './SettingsLayout'
+import { useSpecialistStore } from '@/stores/specialist-store'
+import type { CreateSpecialistInput } from '../../../../shared/specialist'
+import { SpecialistEditor } from './SpecialistEditor'
+import { SpecialistAvatar } from './specialist-avatar'
+
+// Sub-view for the Specialists panel (parallels SkillsView).
+export type SpecialistsView =
+  | { kind: 'list' }
+  | { kind: 'create'; draft?: CreateSpecialistInput }
+  | { kind: 'edit'; id: string }
+
+type CategoryFilter = 'all' | 'custom' | 'builtin'
+
+const FILTER_LABELS: Record<CategoryFilter, string> = {
+  all: 'All',
+  custom: 'Custom',
+  builtin: 'Built-in'
+}
+
+type SpecialistsPanelProps = {
+  view: SpecialistsView
+  onNavigate: (view: SpecialistsView) => void
+}
+
+const SpecialistsPanel = ({ view, onNavigate }: SpecialistsPanelProps): React.JSX.Element => {
+  const items = useSpecialistStore((s) => s.items)
+  const isLoaded = useSpecialistStore((s) => s.isLoaded)
+  const load = useSpecialistStore((s) => s.load)
+  const setEnabled = useSpecialistStore((s) => s.setEnabled)
+  const createSpecialist = useSpecialistStore((s) => s.create)
+  const updateSpecialist = useSpecialistStore((s) => s.update)
+  const deleteSpecialist = useSpecialistStore((s) => s.delete)
+  const duplicateSpecialist = useSpecialistStore((s) => s.duplicate)
+  const [filter, setFilter] = useState<CategoryFilter>('all')
+  const [query, setQuery] = useState('')
+  const [deletingItem, setDeletingItem] = useState<{
+    id: string
+    revision: number
+    name: string
+  } | null>(null)
+  const [deleteError, setDeleteError] = useState<string | undefined>()
+
+  // Memoised so visibleCustomItems' memo can reference a stable value.
+  const customItems = useMemo(() => items.filter((i) => i.kind === 'custom'), [items])
+
+  useEffect(() => {
+    void load()
+
+    // Subscribe to catalog-changed push events so the list stays in sync.
+    const unsub = window.api.specialist.onCatalogChanged(() => void load())
+    return unsub
+  }, [load])
+
+  // Separate Custom vs Built-in (Reviewer) items.
+  const reviewerItems = items.filter((i) => i.kind === 'reviewer')
+  const visibleCustomItems = useMemo(() => {
+    const term = query.trim().toLowerCase()
+    if (filter === 'builtin') return []
+    if (!term) return customItems
+    return customItems.filter(
+      (item) =>
+        (item.displayName ?? item.name).toLowerCase().includes(term) ||
+        item.name.toLowerCase().includes(term) ||
+        item.description.toLowerCase().includes(term)
+    )
+  }, [customItems, filter, query])
+  const visibleReviewerItems = useMemo(() => {
+    if (filter === 'custom') return []
+    const term = query.trim().toLowerCase()
+    if (!term || 'reviewer used by auto-review'.includes(term)) return reviewerItems
+    return []
+  }, [filter, query, reviewerItems])
+
+  if (view.kind === 'create') {
+    return (
+      <SpecialistEditor
+        existingNames={customItems.map((item) => item.name)}
+        initialInput={view.draft}
+        onCancel={() => onNavigate({ kind: 'list' })}
+        onSave={async (input: CreateSpecialistInput) => {
+          await createSpecialist(input)
+          onNavigate({ kind: 'list' })
+        }}
+      />
+    )
+  }
+
+  if (view.kind === 'edit') {
+    // Reuse the create editor prefilled from the stored profile. Capabilities
+    // stay informational; only identity/instructions are editable here.
+    const specialist = customItems.find((item) => item.kind === 'custom' && item.id === view.id)
+    if (specialist && specialist.kind === 'custom') {
+      return (
+        <SpecialistEditor
+          key={specialist.id}
+          editSpecialist={specialist}
+          existingNames={customItems.filter((item) => item.id !== view.id).map((item) => item.name)}
+          onCancel={() => onNavigate({ kind: 'list' })}
+          onSave={async () => onNavigate({ kind: 'list' })}
+          onSaveEdit={async (input) => {
+            await updateSpecialist(input)
+            onNavigate({ kind: 'list' })
+          }}
+          onReload={async () => {
+            // Load the fresh list and read the result from the store directly —
+            // not from the render closure, which captured the pre-load items.
+            await load()
+            const refreshed = useSpecialistStore
+              .getState()
+              .items.find((item) => item.kind === 'custom' && item.id === view.id)
+            if (refreshed && refreshed.kind === 'custom') return refreshed
+            return undefined
+          }}
+        />
+      )
+    }
+    // Profile no longer exists (deleted/stale) — fall through to the list.
+  }
+
+  return (
+    <div className="p-5">
+      {/* Toolbar */}
+      <div className="mb-4 flex items-center gap-2">
+        <div
+          className="flex items-center gap-0.5 rounded-lg border border-border bg-muted/40 p-0.5"
+          role="tablist"
+          aria-label="Filter specialists by category"
+        >
+          {(['all', 'custom', 'builtin'] as const).map((key) => {
+            const count =
+              key === 'all'
+                ? items.length
+                : key === 'custom'
+                  ? customItems.length
+                  : reviewerItems.length
+            const active = filter === key
+            return (
+              <button
+                key={key}
+                type="button"
+                role="tab"
+                aria-selected={active}
+                onClick={() => setFilter(key)}
+                className={`inline-flex items-center gap-1 rounded-md px-2.5 py-1 text-xs font-medium transition-colors motion-reduce:transition-none ${
+                  active
+                    ? 'bg-muted text-foreground'
+                    : 'text-muted-foreground hover:text-foreground'
+                }`}
+              >
+                {FILTER_LABELS[key]}
+                <span className="tabular-nums text-muted-foreground">({count})</span>
+              </button>
+            )
+          })}
+        </div>
+        <div className="relative flex-1">
+          <Search
+            className="pointer-events-none absolute left-2.5 top-1/2 size-4 -translate-y-1/2 text-muted-foreground"
+            aria-hidden="true"
+          />
+          <Input
+            type="search"
+            aria-label="Search specialists"
+            placeholder="Search specialists…"
+            value={query}
+            onChange={(event) => setQuery(event.target.value)}
+            className="pl-8"
+          />
+        </div>
+        <DropdownMenu>
+          <DropdownMenuTrigger asChild>
+            <Button variant="outline" className="shrink-0">
+              <Plus data-icon="inline-start" aria-hidden="true" />
+              Add specialist
+              <ChevronDown data-icon="inline-end" className="opacity-70" aria-hidden="true" />
+            </Button>
+          </DropdownMenuTrigger>
+          <DropdownMenuContent align="end">
+            <DropdownMenuItem className="gap-2.5" onSelect={() => onNavigate({ kind: 'create' })}>
+              <Pencil className="size-4 shrink-0" aria-hidden="true" />
+              <span className="flex flex-col">
+                <span>Write from scratch</span>
+                <span className="text-xs text-muted-foreground">
+                  Configure instructions and capabilities yourself
+                </span>
+              </span>
+            </DropdownMenuItem>
+          </DropdownMenuContent>
+        </DropdownMenu>
+      </div>
+
+      {!isLoaded ? (
+        <p className="text-sm text-muted-foreground">Loading…</p>
+      ) : (
+        <div className="flex flex-col gap-6">
+          {/* Custom specialists group */}
+          {filter !== 'builtin' ? (
+            <div>
+              <div className="mb-1 flex flex-col gap-0.5">
+                <span className="text-sm font-semibold text-foreground">Custom</span>
+                <span className="text-xs text-muted-foreground">Created by you.</span>
+              </div>
+
+              {visibleCustomItems.length > 0 ? (
+                <ul className="mt-2 flex flex-col divide-y divide-border">
+                  {visibleCustomItems.map((item) => {
+                    if (item.kind !== 'custom') return null
+                    return (
+                      <li
+                        key={item.id}
+                        data-slot="settings-list-row"
+                        className="flex min-h-14 items-center gap-2 py-2.5"
+                      >
+                        {/* Click the row body to open the editor (prefilled) */}
+                        <button
+                          type="button"
+                          onClick={() => onNavigate({ kind: 'edit', id: item.id })}
+                          aria-label={`Edit ${item.displayName ?? item.name}`}
+                          className="flex min-w-0 flex-1 cursor-pointer items-center gap-2 rounded-md text-left focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-ring"
+                        >
+                          {/* Avatar */}
+                          <SpecialistAvatar iconKey={item.iconKey} colorKey={item.colorKey} />
+
+                          {/* Body: name + description */}
+                          <div className="min-w-0 flex-1">
+                            <span className="block truncate text-sm text-foreground">
+                              {item.displayName ?? item.name}
+                            </span>
+                            {item.description ? (
+                              <span className="block truncate text-xs text-muted-foreground">
+                                {item.description}
+                              </span>
+                            ) : null}
+                            <span className="block text-[11px] text-muted-foreground">
+                              {item.capabilityMode === 'full'
+                                ? 'Full access'
+                                : 'Selected capabilities'}
+                            </span>
+                          </div>
+                        </button>
+
+                        {/* Enabled toggle */}
+                        <SettingsToggle
+                          enabled={item.enabled}
+                          aria-label={`Toggle ${item.displayName ?? item.name}`}
+                          onToggle={() => void setEnabled(item.id, !item.enabled)}
+                        />
+                        <DropdownMenu>
+                          <DropdownMenuTrigger asChild>
+                            <Button
+                              variant="ghost"
+                              size="icon"
+                              aria-label={`Actions for ${item.displayName ?? item.name}`}
+                            >
+                              <ChevronDown aria-hidden="true" />
+                            </Button>
+                          </DropdownMenuTrigger>
+                          <DropdownMenuContent align="end">
+                            <DropdownMenuItem
+                              className="gap-2 text-xs"
+                              onSelect={() =>
+                                void duplicateSpecialist(item.id).then((draft) =>
+                                  onNavigate({ kind: 'create', draft })
+                                )
+                              }
+                            >
+                              <Copy className="size-3.5" aria-hidden="true" /> Duplicate
+                            </DropdownMenuItem>
+                            <DropdownMenuItem
+                              className="gap-2 text-xs text-destructive"
+                              onSelect={() =>
+                                setDeletingItem({
+                                  id: item.id,
+                                  revision: item.revision,
+                                  name: item.displayName ?? item.name
+                                })
+                              }
+                            >
+                              <Trash2 className="size-3.5" aria-hidden="true" /> Delete
+                            </DropdownMenuItem>
+                          </DropdownMenuContent>
+                        </DropdownMenu>
+                      </li>
+                    )
+                  })}
+                </ul>
+              ) : (
+                <p className="mt-2 py-2 text-xs text-muted-foreground">
+                  No specialists yet. Use &ldquo;Add specialist&rdquo; to create one.
+                </p>
+              )}
+            </div>
+          ) : null}
+
+          {/* Built-in group (Reviewer only) */}
+          {visibleReviewerItems.length > 0 ? (
+            <div>
+              <div className="mb-1 flex flex-col gap-0.5">
+                <span className="text-sm font-semibold text-foreground">Built-in</span>
+                <span className="text-xs text-muted-foreground">
+                  Shipped with the app. Not configurable.
+                </span>
+              </div>
+              <ul className="mt-2 flex flex-col divide-y divide-border">
+                {visibleReviewerItems.map(() => (
+                  <li
+                    key="reviewer"
+                    data-slot="settings-list-row"
+                    className="flex min-h-14 items-center gap-2 py-2.5"
+                  >
+                    <span
+                      className="flex size-7 shrink-0 items-center justify-center rounded-lg bg-[#dcfce7] text-[13px]"
+                      aria-hidden="true"
+                    >
+                      ✓
+                    </span>
+                    <div className="min-w-0 flex-1">
+                      <span className="block truncate text-sm text-foreground">Reviewer</span>
+                      <span className="block truncate text-xs text-muted-foreground">
+                        Used by Auto-review
+                      </span>
+                    </div>
+                    {/* No toggle, no actions for Reviewer */}
+                  </li>
+                ))}
+              </ul>
+            </div>
+          ) : null}
+        </div>
+      )}
+
+      {/* Delete confirmation dialog */}
+      <AlertDialog.Root
+        open={deletingItem !== null}
+        onOpenChange={(open) => {
+          if (!open) {
+            setDeletingItem(null)
+            setDeleteError(undefined)
+          }
+        }}
+      >
+        <AlertDialog.Portal>
+          <AlertDialog.Overlay className={dialogOverlayClassName} />
+          <AlertDialog.Content className={dialogPanelClassName('w-[min(440px,calc(100vw-2rem))]')}>
+            <AlertDialog.Title className={dialogTitleClassName}>
+              Delete {deletingItem?.name}?
+            </AlertDialog.Title>
+            <AlertDialog.Description className={dialogDescriptionClassName}>
+              This will permanently remove this specialist and all its configurations. This action
+              cannot be undone.
+            </AlertDialog.Description>
+            {deleteError ? (
+              <p
+                role="alert"
+                className="mt-3 rounded-lg border border-amber-200 bg-amber-50 px-3 py-2 text-xs text-amber-900 dark:border-amber-900 dark:bg-amber-950 dark:text-amber-100"
+              >
+                {deleteError}
+              </p>
+            ) : null}
+            <div className="mt-6 flex justify-end gap-2">
+              <AlertDialog.Cancel asChild>
+                <Button type="button" variant="outline">
+                  Cancel
+                </Button>
+              </AlertDialog.Cancel>
+              <Button
+                type="button"
+                variant="destructive"
+                onClick={() => {
+                  if (!deletingItem) return
+                  const item = deletingItem
+                  void (async () => {
+                    try {
+                      await deleteSpecialist(item.id, item.revision)
+                      setDeletingItem(null)
+                      setDeleteError(undefined)
+                    } catch (err) {
+                      // Reload the list so a retry picks up the current revision.
+                      void load()
+                      setDeleteError(
+                        err instanceof Error
+                          ? err.message
+                          : 'This specialist changed — review and try again.'
+                      )
+                    }
+                  })()
+                }}
+              >
+                Delete
+              </Button>
+            </div>
+          </AlertDialog.Content>
+        </AlertDialog.Portal>
+      </AlertDialog.Root>
+    </div>
+  )
+}
+
+export { SpecialistsPanel }

--- a/src/renderer/src/pages/settings/settings-navigation.ts
+++ b/src/renderer/src/pages/settings/settings-navigation.ts
@@ -5,6 +5,7 @@ export type SettingsPanelId =
   | 'agent'
   | 'skills'
   | 'connectors'
+  | 'specialists'
   | 'compute'
   | 'general'
   | 'storage'

--- a/src/renderer/src/pages/settings/specialist-avatar.tsx
+++ b/src/renderer/src/pages/settings/specialist-avatar.tsx
@@ -1,0 +1,27 @@
+import { Brain } from 'lucide-react'
+import { AVATAR_ICONS, getAvatarStyle } from './specialist-icons'
+
+// The specialist avatar: a lucide icon on a rounded pastel tile. Rendered both
+// in the settings list (size "md") and as a live preview in the editor (size "lg").
+export const SpecialistAvatar = ({
+  iconKey,
+  colorKey,
+  size = 'md'
+}: {
+  iconKey?: string
+  colorKey?: string
+  size?: 'md' | 'lg'
+}): React.JSX.Element => {
+  const Icon = iconKey ? (AVATAR_ICONS[iconKey] ?? Brain) : Brain
+  const tile = size === 'lg' ? 'size-14' : 'size-7'
+  const glyph = size === 'lg' ? 'size-7' : 'size-3.5'
+  return (
+    <span
+      className={`flex ${tile} shrink-0 items-center justify-center rounded-lg text-[13px]`}
+      style={getAvatarStyle(colorKey)}
+      aria-hidden="true"
+    >
+      <Icon className={glyph} data-specialist-icon={iconKey ?? 'brain'} />
+    </span>
+  )
+}

--- a/src/renderer/src/pages/settings/specialist-icons.ts
+++ b/src/renderer/src/pages/settings/specialist-icons.ts
@@ -1,0 +1,35 @@
+import type { CSSProperties } from 'react'
+import {
+  Brain,
+  Beaker,
+  BookOpen,
+  FlaskConical,
+  Microscope,
+  Search,
+  type LucideIcon
+} from 'lucide-react'
+
+// The color palette used for specialist avatar backgrounds. Shared between the
+// list and the editor so the preview matches the rendered row exactly.
+export const AVATAR_COLORS: Record<string, string> = {
+  teal: '#e0f2f1',
+  purple: '#ede9fe',
+  amber: '#fef3c7',
+  green: '#dcfce7',
+  blue: '#dbeafe',
+  slate: '#f1f5f9'
+}
+export const DEFAULT_AVATAR_COLOR = '#ececea'
+
+export const AVATAR_ICONS: Record<string, LucideIcon> = {
+  brain: Brain,
+  beaker: Beaker,
+  'book-open': BookOpen,
+  'flask-conical': FlaskConical,
+  microscope: Microscope,
+  search: Search
+}
+
+export const getAvatarStyle = (colorKey?: string): CSSProperties => ({
+  background: colorKey ? (AVATAR_COLORS[colorKey] ?? DEFAULT_AVATAR_COLOR) : DEFAULT_AVATAR_COLOR
+})

--- a/src/renderer/src/pages/workspace/ComposerAgentControlsMenu.interaction.test.tsx
+++ b/src/renderer/src/pages/workspace/ComposerAgentControlsMenu.interaction.test.tsx
@@ -103,6 +103,23 @@ vi.mock('radix-ui', () => ({
   }
 }))
 
+// Stub the specialist submenu so its store/catalog wiring stays out of this menu-level suite.
+// The marker surfaces whether the menu included it and forwards key props as data attributes.
+vi.mock('./SpecialistSubmenu', () => ({
+  SpecialistSubmenu: (props: {
+    selectedId?: string
+    unavailable?: boolean
+    readOnly?: boolean
+  }): React.JSX.Element => (
+    <div
+      data-testid="specialist-submenu-stub"
+      data-selected-id={props.selectedId ?? ''}
+      data-unavailable={String(props.unavailable ?? false)}
+      data-read-only={String(props.readOnly ?? false)}
+    />
+  )
+}))
+
 const createHost = (overrides: Partial<ComputeHost> = {}): ComputeHost => ({
   id: 'host-1',
   providerId: 'ssh:cluster-1',
@@ -675,5 +692,83 @@ describe('ComposerAgentControlsMenu', () => {
     })
 
     expect(findButton('cluster-1').disabled).toBe(true)
+  })
+
+  it('renders a Compute submenu trigger above the SSH hosts', () => {
+    act(() => {
+      root.render(
+        <ComposerAgentControlsMenu
+          profile="ask"
+          autoReviewEnabled={false}
+          enabledComputeHosts={[]}
+          onProfileChange={vi.fn()}
+          onAutoReviewChange={vi.fn()}
+          onComputeHostToggle={vi.fn()}
+        />
+      )
+    })
+
+    expect(container.textContent).toContain('Compute')
+    // SSH hosts + Manage compute stay nested under that single Compute submenu.
+    expect(container.textContent).toContain('SSH')
+    expect(container.textContent).toContain('Manage compute...')
+  })
+
+  it('does not render the specialist submenu when showSpecialist is false', () => {
+    act(() => {
+      root.render(
+        <ComposerAgentControlsMenu
+          profile="ask"
+          autoReviewEnabled={false}
+          onProfileChange={vi.fn()}
+          onAutoReviewChange={vi.fn()}
+        />
+      )
+    })
+
+    expect(container.querySelector('[data-testid="specialist-submenu-stub"]')).toBeNull()
+  })
+
+  it('renders the specialist submenu and forwards its props when showSpecialist is true', () => {
+    const onSpecialistChange = vi.fn()
+    act(() => {
+      root.render(
+        <ComposerAgentControlsMenu
+          profile="ask"
+          autoReviewEnabled={false}
+          showSpecialist
+          specialistId="uuid-1"
+          specialistUnavailable={false}
+          specialistReadOnly={false}
+          onSpecialistChange={onSpecialistChange}
+          onProfileChange={vi.fn()}
+          onAutoReviewChange={vi.fn()}
+        />
+      )
+    })
+
+    const stub = container.querySelector('[data-testid="specialist-submenu-stub"]')
+    expect(stub).not.toBeNull()
+    expect(stub?.getAttribute('data-selected-id')).toBe('uuid-1')
+  })
+
+  it('locks the specialist submenu down while a session is running', () => {
+    act(() => {
+      root.render(
+        <ComposerAgentControlsMenu
+          profile="ask"
+          autoReviewEnabled={false}
+          readOnly // session running -> mutating controls frozen
+          showSpecialist
+          specialistId="uuid-1"
+          onSpecialistChange={vi.fn()}
+          onProfileChange={vi.fn()}
+          onAutoReviewChange={vi.fn()}
+        />
+      )
+    })
+
+    const stub = container.querySelector('[data-testid="specialist-submenu-stub"]')
+    expect(stub?.getAttribute('data-read-only')).toBe('true')
   })
 })

--- a/src/renderer/src/pages/workspace/ComposerAgentControlsMenu.tsx
+++ b/src/renderer/src/pages/workspace/ComposerAgentControlsMenu.tsx
@@ -1,11 +1,13 @@
 // Unified composer menu: per-session agent controls (permission profile + auto-review) and
-// compute host selection, behind a single icon trigger. Replaces the earlier split into
-// ComposerPermissionProfilePicker, ComposerAutoReviewToggle, and ComputeHostSelector.
-// A primary-color dot on the trigger marks any deviation from the defaults (profile 'ask',
-// auto-review off); session grants keep their own count pill. The first-level menu shows the
-// current permission level as a borderless colored capsule (ask = neutral, auto = blue,
-// full = warning amber); picking a level lives in a submenu. SSH hosts are appended below
-// auto-review, reading from the global compute store like ComposerModelPicker.
+// resource selection (specialist + compute), behind a single icon trigger. Replaces the
+// earlier split into ComposerPermissionProfilePicker, ComposerAutoReviewToggle, the
+// standalone SpecialistPicker, and ComputeHostSelector. A primary-color dot on the trigger
+// marks any deviation from the defaults (profile 'ask', auto-review off); session grants
+// keep their own count pill. The first-level menu shows the current permission level as a
+// borderless colored capsule (ask = neutral, auto = blue, full = warning amber); picking a
+// level lives in a submenu. Specialist and Compute are hover-expanded submenus below
+// auto-review: Specialist offers None / personal specialists / Create new…; Compute folds
+// the SSH host list and "Manage compute…" together. Both read from global stores.
 
 import {
   DEFAULT_PERMISSION_PROFILE,
@@ -18,6 +20,7 @@ import {
   Check,
   ChevronRight,
   ScanEye,
+  Server,
   Settings,
   Shield,
   ShieldAlert,
@@ -27,6 +30,8 @@ import {
 } from 'lucide-react'
 import { useState } from 'react'
 import { AlertDialog } from 'radix-ui'
+
+import { SpecialistSubmenu } from './SpecialistSubmenu'
 
 import { Button } from '@/components/ui/button'
 import {
@@ -78,6 +83,14 @@ type ComposerAgentControlsMenuProps = {
   // renders without a compute binding (e.g. in isolation tests); the composer passes both.
   enabledComputeHosts?: string[]
   onComputeHostToggle?: (providerId: string, enabled: boolean) => void
+  // Specialist submenu: shown when showSpecialist is true (the composer decides, mirroring the
+  // old standalone picker's visibility rule). specialistReadOnly marks a bound session whose
+  // identity is fixed; the menu's readOnly (session running) also locks it down.
+  showSpecialist?: boolean
+  specialistId?: string
+  specialistUnavailable?: boolean
+  specialistReadOnly?: boolean
+  onSpecialistChange?: (specialistId: string | undefined) => void
 }
 
 const permissionProfiles: Array<{
@@ -132,7 +145,12 @@ const ComposerAgentControlsMenu = ({
   onRevokeGrant,
   onClearGrants,
   enabledComputeHosts,
-  onComputeHostToggle
+  onComputeHostToggle,
+  showSpecialist = false,
+  specialistId,
+  specialistUnavailable = false,
+  specialistReadOnly = false,
+  onSpecialistChange
 }: ComposerAgentControlsMenuProps): React.JSX.Element => {
   const [confirmFullAccess, setConfirmFullAccess] = useState(false)
   const selectedProfile = permissionProfiles.find((candidate) => candidate.id === profile)!
@@ -376,62 +394,95 @@ const ComposerAgentControlsMenu = ({
             </div>
           ) : null}
 
-          {/* Compute hosts: appended below the agent controls so a single trigger covers
-              both. SSH hosts are single-select; Manage compute opens the settings panel. */}
+          {/* Specialist + Compute live in hover-expanded submenus below the agent controls.
+              Specialist shows the personal-specialist picker (was a standalone toolbar button);
+              Compute folds the old inline SSH host list and "Manage compute…" into one submenu. */}
           <DropdownMenuSeparator />
-          {sshHosts.length > 0 ? (
-            <>
-              <DropdownMenuLabel className="text-[10.5px] uppercase tracking-wide text-text-300 font-normal">
-                SSH
-              </DropdownMenuLabel>
-              <DropdownMenuGroup>
-                {sshHosts.map((host) => {
-                  const isEnabled = enabledComputeHosts?.includes(host.providerId) ?? false
-                  return (
-                    <DropdownMenuItem
-                      key={host.providerId}
-                      disabled={readOnly}
-                      onSelect={(event) => {
-                        event.preventDefault()
-                        handleHostToggle(host.providerId, isEnabled)
-                      }}
-                      className="items-center gap-2 px-2 py-1.5"
-                    >
-                      <span
-                        className={cn(
-                          'min-w-0 flex-1 truncate text-[13px] leading-5',
-                          isEnabled ? 'font-medium text-text-100' : 'font-normal text-text-200'
-                        )}
-                      >
-                        {host.displayName}
-                      </span>
-                      {/* pointer-events-none: the Switch is a visual indicator only;
-                          the row's onSelect is the single toggle entry point. */}
-                      <Switch
-                        size="sm"
-                        checked={isEnabled}
-                        aria-hidden="true"
-                        tabIndex={-1}
-                        className="pointer-events-none"
-                      />
-                    </DropdownMenuItem>
-                  )
-                })}
-              </DropdownMenuGroup>
-            </>
-          ) : (
-            <DropdownMenuItem disabled className="px-2 py-1.5 text-[13px] text-text-300">
-              {isLoaded ? 'No SSH hosts registered' : 'Loading…'}
-            </DropdownMenuItem>
-          )}
-          <DropdownMenuSeparator />
-          <DropdownMenuItem
-            onSelect={() => openSettingsToCompute()}
-            className="items-center gap-2 px-2 py-1.5 text-[13px] text-text-200"
-          >
-            <Settings className="size-4 shrink-0" aria-hidden="true" />
-            Manage compute...
-          </DropdownMenuItem>
+          {showSpecialist ? (
+            <SpecialistSubmenu
+              selectedId={specialistId}
+              onChange={onSpecialistChange ?? (() => undefined)}
+              unavailable={specialistUnavailable}
+              readOnly={specialistReadOnly || readOnly}
+            />
+          ) : null}
+
+          <DropdownMenuSub>
+            <DropdownMenuSubTrigger className="items-center gap-2 px-2 py-1.5">
+              <Server
+                className="size-4 shrink-0 text-text-200"
+                strokeWidth={2}
+                aria-hidden="true"
+              />
+              <span className="min-w-0 flex-1">
+                <span className="block text-[13px] font-medium leading-5">Compute</span>
+                <span className="block text-[11px] leading-4 text-text-300">
+                  Run jobs on a remote SSH host, or manage hosts.
+                </span>
+              </span>
+              <ChevronRight
+                className="size-4 shrink-0 opacity-60"
+                strokeWidth={2}
+                aria-hidden="true"
+              />
+            </DropdownMenuSubTrigger>
+            <DropdownMenuSubContent className="w-72 p-1">
+              {/* SSH hosts are single-select; Manage compute opens the settings panel. */}
+              {sshHosts.length > 0 ? (
+                <>
+                  <DropdownMenuLabel className="text-[10.5px] uppercase tracking-wide text-text-300 font-normal">
+                    SSH
+                  </DropdownMenuLabel>
+                  <DropdownMenuGroup>
+                    {sshHosts.map((host) => {
+                      const isEnabled = enabledComputeHosts?.includes(host.providerId) ?? false
+                      return (
+                        <DropdownMenuItem
+                          key={host.providerId}
+                          disabled={readOnly}
+                          onSelect={(event) => {
+                            event.preventDefault()
+                            handleHostToggle(host.providerId, isEnabled)
+                          }}
+                          className="items-center gap-2 px-2 py-1.5"
+                        >
+                          <span
+                            className={cn(
+                              'min-w-0 flex-1 truncate text-[13px] leading-5',
+                              isEnabled ? 'font-medium text-text-100' : 'font-normal text-text-200'
+                            )}
+                          >
+                            {host.displayName}
+                          </span>
+                          {/* pointer-events-none: the Switch is a visual indicator only;
+                              the row's onSelect is the single toggle entry point. */}
+                          <Switch
+                            size="sm"
+                            checked={isEnabled}
+                            aria-hidden="true"
+                            tabIndex={-1}
+                            className="pointer-events-none"
+                          />
+                        </DropdownMenuItem>
+                      )
+                    })}
+                  </DropdownMenuGroup>
+                </>
+              ) : (
+                <DropdownMenuItem disabled className="px-2 py-1.5 text-[13px] text-text-300">
+                  {isLoaded ? 'No SSH hosts registered' : 'Loading…'}
+                </DropdownMenuItem>
+              )}
+              <DropdownMenuSeparator />
+              <DropdownMenuItem
+                onSelect={() => openSettingsToCompute()}
+                className="items-center gap-2 px-2 py-1.5 text-[13px] text-text-200"
+              >
+                <Settings className="size-4 shrink-0" aria-hidden="true" />
+                Manage compute...
+              </DropdownMenuItem>
+            </DropdownMenuSubContent>
+          </DropdownMenuSub>
         </DropdownMenuContent>
       </DropdownMenu>
 

--- a/src/renderer/src/pages/workspace/ConversationPanel.tsx
+++ b/src/renderer/src/pages/workspace/ConversationPanel.tsx
@@ -15,6 +15,7 @@ import {
 } from '../../../../shared/uploads'
 import { isReportableRunFailure } from '../../../../shared/run-error-classification'
 import {
+  AlertTriangle,
   ArrowUp,
   BookOpen,
   FileText,
@@ -28,6 +29,7 @@ import {
   X
 } from 'lucide-react'
 import { useRef, useState } from 'react'
+import { resolveEffectiveSpecialistSkills } from '../../../../shared/specialist'
 
 import { FileDropOverlay } from '@/components/FileDropOverlay'
 import { RemoteJobBadge } from '@/components/RemoteJobBadge'
@@ -43,6 +45,8 @@ import { useFileDropZone } from '@/hooks/useFileDropZone'
 import { cn } from '@/lib/utils'
 import type { ChatSession } from '@/stores/session-store'
 import { useSessionJobStore } from '@/stores/session-job-store'
+import { useSettingsStore } from '@/stores/settings-store'
+import { useSpecialistStore } from '@/stores/specialist-store'
 
 import { ComposerEditor } from './composer/ComposerEditor'
 import type { ComposerUploadTransfer } from './composer-upload-transfer'
@@ -146,6 +150,17 @@ type ConversationPanelProps = {
   onSendEditedMessage: (messageId: string, doc: ComposerDoc) => void
   // Open job list modal for a specific session.
   onOpenJobList?: (sessionId: string) => void
+  // Specialist picker. For new conversations: undefined = None. For existing sessions: always shown.
+  specialistId?: string
+  specialistUnavailable?: boolean
+  // True when the user has selected a different specialist while the current turn is still running.
+  specialistHasPendingSwitch?: boolean
+  onSpecialistChange?: (specialistId: string | undefined) => void
+  // Reconfigure failure recovery callbacks.
+  reconfigureError?: { sessionId: string; specialistName: string; message: string } | null
+  onReconfigureRetry?: () => void
+  onReconfigureChooseOther?: () => void
+  onReconfigureUseNone?: () => void
 }
 
 // Middle chat surface owns the visible conversation and local message composer UI.
@@ -191,8 +206,18 @@ const ConversationPanel = ({
   isRequestReviewDisabled,
   canEditMessage,
   onSendEditedMessage,
-  onOpenJobList
+  onOpenJobList,
+  specialistId,
+  specialistUnavailable = false,
+  specialistHasPendingSwitch = false,
+  onSpecialistChange,
+  reconfigureError,
+  onReconfigureRetry,
+  onReconfigureChooseOther,
+  onReconfigureUseNone
 }: ConversationPanelProps): React.JSX.Element => {
+  const specialistItems = useSpecialistStore((state) => state.items)
+  const catalogSkills = useSettingsStore((state) => state.skills)
   const fileInputRef = useRef<HTMLInputElement | null>(null)
   // Local so the interrupted banner can show a spinner and block a double-resume until the request settles.
   const [isResuming, setIsResuming] = useState(false)
@@ -215,6 +240,24 @@ const ConversationPanel = ({
   // Fall back to classifying the raw error for sessions persisted before the flag existed (undefined).
   const isRunErrorReportable =
     activeSession?.errorReportable ?? isReportableRunFailure(activeSession?.error)
+
+  const activeSpecialist = specialistId
+    ? specialistItems.find((item) => item.kind === 'custom' && item.id === specialistId)
+    : undefined
+  const effectiveSpecialistSkills = resolveEffectiveSpecialistSkills(
+    activeSpecialist?.kind === 'custom' ? activeSpecialist : undefined,
+    catalogSkills.map((skill) => ({
+      id: skill.id,
+      frameworkName: skill.source === 'featured' ? skill.id : skill.name,
+      displayName: skill.name
+    }))
+  )
+  const allowedSkillIds =
+    effectiveSpecialistSkills.kind === 'specialist'
+      ? effectiveSpecialistSkills.skillIds
+      : specialistId
+        ? []
+        : undefined
 
   // Re-attaches the interrupted session; on success the banner unmounts, so guard the state update.
   const handleResume = async (): Promise<void> => {
@@ -406,6 +449,54 @@ const ConversationPanel = ({
                 <div className="relative">
                   <div aria-hidden="true" className="relative -mb-8 rounded-2xl bg-bg-200 pb-8" />
 
+                  {/* Reconfigure failure banner: shown directly above the composer when a pre-send
+                      specialist reconfigure failed. Draft is preserved; three recovery actions. */}
+                  {reconfigureError ? (
+                    <div
+                      className="relative z-10 mb-2 flex items-start gap-2.5 rounded-xl border border-red-500/25 bg-red-500/[0.08] px-3 py-2.5"
+                      role="alert"
+                      data-testid="reconfigure-error-banner"
+                    >
+                      <AlertTriangle
+                        className="mt-0.5 size-3.5 shrink-0 text-red-400"
+                        strokeWidth={2}
+                        aria-hidden="true"
+                      />
+                      <div className="min-w-0 flex-1">
+                        <div className="text-[12px] font-medium leading-5 text-red-300">
+                          Could not switch to {reconfigureError.specialistName}
+                        </div>
+                        <div className="text-[11px] leading-4 text-red-400/80">
+                          The agent session could not be reconfigured. Your draft has been
+                          preserved.
+                        </div>
+                        <div className="mt-2 flex flex-wrap gap-1.5">
+                          <button
+                            type="button"
+                            onClick={onReconfigureRetry}
+                            className="flex h-6 items-center rounded px-2 text-[11px] font-medium text-red-300 hover:bg-red-500/15 border border-red-500/30"
+                          >
+                            Retry
+                          </button>
+                          <button
+                            type="button"
+                            onClick={onReconfigureChooseOther}
+                            className="flex h-6 items-center rounded px-2 text-[11px] text-red-400/80 hover:bg-red-500/10 border border-red-500/20"
+                          >
+                            Choose another specialist
+                          </button>
+                          <button
+                            type="button"
+                            onClick={onReconfigureUseNone}
+                            className="flex h-6 items-center rounded px-2 text-[11px] text-red-400/80 hover:bg-red-500/10 border border-red-500/20"
+                          >
+                            Use None (Main Agent)
+                          </button>
+                        </div>
+                      </div>
+                    </div>
+                  ) : null}
+
                   {/* Composer keeps draft input local until submit delegates to the session store.
                       Enter-to-send is owned by ComposerEditor; the form only guards native submit. */}
                   <form
@@ -541,6 +632,7 @@ const ConversationPanel = ({
                           disabled={!canEditDraft}
                           placeholder="Ask anything — / for skills, @ for files"
                           ariaLabel="Ask anything"
+                          allowedSkillIds={allowedSkillIds}
                         />
                       </div>
 
@@ -610,7 +702,30 @@ const ConversationPanel = ({
                           onAutoReviewChange={onAutoReviewToggle}
                           onRevokeGrant={onRevokePermissionGrant}
                           onClearGrants={onClearPermissionGrants}
+                          showSpecialist={
+                            // Show for new conversations when a change handler is provided,
+                            // or for any existing session (so the user can always switch).
+                            (!activeSession && onSpecialistChange !== undefined) ||
+                            activeSession !== undefined
+                          }
+                          specialistId={specialistId}
+                          specialistUnavailable={specialistUnavailable}
+                          onSpecialistChange={onSpecialistChange}
                         />
+
+                        {/* Pending-switch chip: appears to the right of the specialist badge when
+                            the user picked a different specialist during a running turn. The badge
+                            still shows the currently-effective specialist; this chip signals the
+                            next message will use the newly selected one. */}
+                        {specialistHasPendingSwitch ? (
+                          <span
+                            className="flex shrink-0 items-center gap-1.5 whitespace-nowrap rounded-full border border-blue-500/25 bg-blue-500/10 px-2 py-0.5 text-[11px] italic text-blue-400"
+                            data-testid="specialist-pending-switch-chip"
+                            aria-label="Specialist switch pending"
+                          >
+                            Switches after this response
+                          </span>
+                        ) : null}
 
                         <div className="flex-1" />
 

--- a/src/renderer/src/pages/workspace/SpecialistSubmenu.render.test.tsx
+++ b/src/renderer/src/pages/workspace/SpecialistSubmenu.render.test.tsx
@@ -1,0 +1,328 @@
+// @vitest-environment jsdom
+import { act, type PropsWithChildren } from 'react'
+import { createRoot, type Root } from 'react-dom/client'
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest'
+
+import { SpecialistSubmenu } from './SpecialistSubmenu'
+import { useSpecialistStore } from '@/stores/specialist-store'
+import { useSettingsStore } from '@/stores/settings-store'
+import type { SpecialistListItem } from '../../../../shared/specialist'
+
+;(globalThis as { IS_REACT_ACT_ENVIRONMENT?: boolean }).IS_REACT_ACT_ENVIRONMENT = true
+
+// Mock dropdown-menu to avoid Portal/open-state issues in jsdom.
+// Submenus render inline so tests can assert on data-testid attributes without
+// needing to drive Radix pointer hover to open the submenu.
+vi.mock('@/components/ui/dropdown-menu', () => ({
+  DropdownMenu: ({ children }: PropsWithChildren): React.JSX.Element => <div>{children}</div>,
+  DropdownMenuContent: ({ children }: PropsWithChildren): React.JSX.Element => (
+    <div data-testid="dd-content">{children}</div>
+  ),
+  DropdownMenuSub: ({ children }: PropsWithChildren): React.JSX.Element => <div>{children}</div>,
+  DropdownMenuSubTrigger: ({
+    children,
+    ...rest
+  }: PropsWithChildren<Record<string, unknown>>): React.JSX.Element => (
+    <div {...rest}>{children}</div>
+  ),
+  DropdownMenuSubContent: ({ children }: PropsWithChildren): React.JSX.Element => (
+    <div data-testid="dd-subcontent">{children}</div>
+  ),
+  DropdownMenuSeparator: (): React.JSX.Element => <hr />,
+  DropdownMenuItem: ({
+    children,
+    disabled,
+    onSelect,
+    ...rest
+  }: PropsWithChildren<{
+    disabled?: boolean
+    onSelect?: (event: { preventDefault: () => void }) => void
+    [key: string]: unknown
+  }>): React.JSX.Element => (
+    <button
+      type="button"
+      disabled={disabled}
+      onClick={() => {
+        onSelect?.({ preventDefault: () => undefined })
+      }}
+      {...rest}
+    >
+      {children}
+    </button>
+  )
+}))
+
+vi.mock('@/stores/specialist-store', () => ({
+  useSpecialistStore: vi.fn()
+}))
+
+vi.mock('@/stores/settings-store', () => ({
+  useSettingsStore: vi.fn()
+}))
+
+vi.mock('@/lib/utils', () => ({
+  cn: (...args: unknown[]) => args.filter(Boolean).join(' ')
+}))
+
+// window.api stub for the catalog-change subscription.
+Object.defineProperty(globalThis, 'window', {
+  writable: true,
+  value: {
+    ...globalThis.window,
+    api: {
+      specialist: {
+        onCatalogChanged: vi.fn(() => vi.fn())
+      }
+    }
+  }
+})
+
+const makeSpecialist = (
+  id: string,
+  name: string,
+  enabled = true
+): SpecialistListItem & { kind: 'custom' } => ({
+  kind: 'custom',
+  id,
+  name,
+  description: '',
+  systemPrompt: 'You are...',
+  enabled,
+  capabilityMode: 'full',
+  fullAccess: { excludedSkillIds: [], excludedConnectorIds: [], connectorTools: [] },
+  selectedCapabilities: { skillIds: [], connectorIds: [], connectorTools: [] },
+  revision: 1
+})
+
+const mockStore = (
+  items: SpecialistListItem[],
+  overrides: { isLoaded?: boolean; load?: () => Promise<void> } = {}
+): void => {
+  // eslint-disable-next-line @typescript-eslint/no-explicit-any
+  ;(useSpecialistStore as any).mockImplementation(
+    (
+      selector: (s: {
+        items: SpecialistListItem[]
+        isLoaded: boolean
+        load: () => Promise<void>
+      }) => unknown
+    ) =>
+      selector({
+        items,
+        isLoaded: overrides.isLoaded ?? true,
+        load: overrides.load ?? vi.fn().mockResolvedValue(undefined)
+      })
+  )
+  // eslint-disable-next-line @typescript-eslint/no-explicit-any
+  ;(useSettingsStore as any).mockImplementation(
+    (selector: (s: { openSettingsToPanel: (panel: string) => void }) => unknown) =>
+      selector({ openSettingsToPanel: vi.fn() })
+  )
+}
+
+let container: HTMLDivElement
+let root: Root
+
+beforeEach(() => {
+  container = document.createElement('div')
+  document.body.appendChild(container)
+  root = createRoot(container)
+})
+
+afterEach(() => {
+  act(() => root.unmount())
+  container.remove()
+  vi.clearAllMocks()
+})
+
+const renderSubmenu = (props: React.ComponentProps<typeof SpecialistSubmenu>): void => {
+  act(() => {
+    root.render(<SpecialistSubmenu {...props} />)
+  })
+}
+
+describe('SpecialistSubmenu — trigger', () => {
+  it('renders a submenu trigger', () => {
+    mockStore([])
+    renderSubmenu({ selectedId: undefined, onChange: vi.fn() })
+    expect(container.querySelector('[data-testid="specialist-submenu-trigger"]')).toBeTruthy()
+  })
+
+  it('shows "None" in the capsule when nothing is selected', () => {
+    mockStore([])
+    renderSubmenu({ selectedId: undefined, onChange: vi.fn() })
+    const trigger = container.querySelector('[data-testid="specialist-submenu-trigger"]')!
+    expect(trigger.textContent).toContain('None')
+  })
+
+  it('shows the specialist name in the capsule when one is selected', () => {
+    const sp = makeSpecialist('uuid-1', 'RNA-seq Reviewer')
+    mockStore([sp])
+    renderSubmenu({ selectedId: 'uuid-1', onChange: vi.fn() })
+    const trigger = container.querySelector('[data-testid="specialist-submenu-trigger"]')!
+    expect(trigger.textContent).toContain('RNA-seq Reviewer')
+  })
+
+  it('shows "Unavailable" in the capsule when unavailable prop is true', () => {
+    mockStore([])
+    renderSubmenu({ selectedId: 'stale-id', onChange: vi.fn(), unavailable: true })
+    const trigger = container.querySelector('[data-testid="specialist-submenu-trigger"]')!
+    expect(trigger.textContent).toContain('Unavailable')
+  })
+
+  it('keeps a bound session specialist visible but disables the trigger and hides options', () => {
+    const sp = makeSpecialist('uuid-1', 'RNA-seq Reviewer')
+    mockStore([sp])
+    renderSubmenu({ selectedId: 'uuid-1', onChange: vi.fn(), readOnly: true })
+    const trigger = container.querySelector<HTMLElement>(
+      '[data-testid="specialist-submenu-trigger"]'
+    )!
+    expect(trigger.textContent).toContain('RNA-seq Reviewer')
+    expect(trigger.hasAttribute('disabled')).toBe(true)
+    // No mutable submenu content is offered for a bound session.
+    expect(container.querySelector('[data-testid="dd-subcontent"]')).toBeNull()
+    expect(container.querySelector('[data-testid="specialist-option-none"]')).toBeNull()
+  })
+})
+
+describe('SpecialistSubmenu — submenu contents', () => {
+  it('includes None option', () => {
+    mockStore([makeSpecialist('uuid-1', 'RNA-seq Reviewer')])
+    renderSubmenu({ selectedId: undefined, onChange: vi.fn() })
+    expect(
+      container.querySelector('[data-testid="specialist-option-none"]') ??
+        document.body.querySelector('[data-testid="specialist-option-none"]')
+    ).toBeTruthy()
+  })
+
+  it('lists enabled specialists', () => {
+    const sp = makeSpecialist('uuid-1', 'RNA-seq Reviewer')
+    mockStore([sp])
+    renderSubmenu({ selectedId: undefined, onChange: vi.fn() })
+    expect(container.querySelector('[data-testid="specialist-option-uuid-1"]')).toBeTruthy()
+  })
+
+  it('does NOT list disabled specialists', () => {
+    const disabled = makeSpecialist('uuid-disabled', 'Disabled Bot', false)
+    mockStore([disabled])
+    renderSubmenu({ selectedId: undefined, onChange: vi.fn() })
+    expect(container.querySelector('[data-testid="specialist-option-uuid-disabled"]')).toBeNull()
+  })
+
+  it('does NOT list Reviewer entry', () => {
+    const items: SpecialistListItem[] = [{ kind: 'reviewer', id: 'reviewer' }]
+    mockStore(items)
+    renderSubmenu({ selectedId: undefined, onChange: vi.fn() })
+    expect(container.querySelector('[data-testid="specialist-option-reviewer"]')).toBeNull()
+  })
+
+  it('includes Create new… option', () => {
+    mockStore([])
+    renderSubmenu({ selectedId: undefined, onChange: vi.fn() })
+    expect(container.querySelector('[data-testid="specialist-option-create"]')).toBeTruthy()
+  })
+})
+
+describe('SpecialistSubmenu — selection', () => {
+  it('calls onChange with undefined when None is selected', () => {
+    const sp = makeSpecialist('uuid-1', 'RNA-seq Reviewer')
+    const onChange = vi.fn()
+    mockStore([sp])
+    renderSubmenu({ selectedId: 'uuid-1', onChange })
+    act(() => {
+      container.querySelector<HTMLButtonElement>('[data-testid="specialist-option-none"]')?.click()
+    })
+    expect(onChange).toHaveBeenCalledWith(undefined)
+  })
+
+  it('calls onChange with specialist id when specialist is selected', () => {
+    const sp = makeSpecialist('uuid-1', 'RNA-seq Reviewer')
+    const onChange = vi.fn()
+    mockStore([sp])
+    renderSubmenu({ selectedId: undefined, onChange })
+    act(() => {
+      container
+        .querySelector<HTMLButtonElement>('[data-testid="specialist-option-uuid-1"]')
+        ?.click()
+    })
+    expect(onChange).toHaveBeenCalledWith('uuid-1')
+  })
+
+  it('opens settings to specialists panel when Create new… is clicked', () => {
+    const openSettingsToPanel = vi.fn()
+    // eslint-disable-next-line @typescript-eslint/no-explicit-any
+    ;(useSpecialistStore as any).mockImplementation(
+      (
+        selector: (s: {
+          items: SpecialistListItem[]
+          isLoaded: boolean
+          load: () => Promise<void>
+        }) => unknown
+      ) => selector({ items: [], isLoaded: true, load: vi.fn().mockResolvedValue(undefined) })
+    )
+    // eslint-disable-next-line @typescript-eslint/no-explicit-any
+    ;(useSettingsStore as any).mockImplementation(
+      (selector: (s: { openSettingsToPanel: (panel: string) => void }) => unknown) =>
+        selector({ openSettingsToPanel })
+    )
+    renderSubmenu({ selectedId: undefined, onChange: vi.fn() })
+    act(() => {
+      container
+        .querySelector<HTMLButtonElement>('[data-testid="specialist-option-create"]')
+        ?.click()
+    })
+    expect(openSettingsToPanel).toHaveBeenCalledWith('specialists')
+  })
+})
+
+// ---------------------------------------------------------------------------
+// Tests: unavailable-session switching behavior (issue 07)
+// ---------------------------------------------------------------------------
+
+describe('SpecialistSubmenu — unavailable bound specialist', () => {
+  it('shows the unavailable bound specialist struck-through and not selectable', () => {
+    // Simulates a catalog that has the specialist as disabled (after setEnabled(false)).
+    const disabledSp = makeSpecialist('uuid-disabled', 'DEBUGGER', false)
+    mockStore([disabledSp])
+    renderSubmenu({ selectedId: 'uuid-disabled', onChange: vi.fn(), unavailable: true })
+    // The unavailable item is rendered as a non-interactive div (not a button).
+    const item = container.querySelector('[data-testid="specialist-option-uuid-disabled"]')
+    expect(item).toBeTruthy()
+    expect(item?.tagName).not.toBe('BUTTON')
+    expect(item?.textContent).toContain('DEBUGGER')
+    expect(item?.textContent).toContain('Unavailable')
+    // Should have line-through class.
+    expect(item?.innerHTML).toContain('line-through')
+  })
+
+  it('still shows enabled specialists alongside the unavailable one', () => {
+    const disabledSp = makeSpecialist('uuid-disabled', 'DEBUGGER', false)
+    const enabledSp = makeSpecialist('uuid-other', 'RESEARCHER', true)
+    mockStore([disabledSp, enabledSp])
+    renderSubmenu({ selectedId: 'uuid-disabled', onChange: vi.fn(), unavailable: true })
+    expect(container.querySelector('[data-testid="specialist-option-uuid-disabled"]')).toBeTruthy()
+    expect(container.querySelector('[data-testid="specialist-option-uuid-other"]')).toBeTruthy()
+  })
+
+  it('does NOT render an unavailable item for a session with no current specialist', () => {
+    // A different disabled specialist should not appear for a session that never had it bound.
+    const disabledSp = makeSpecialist('uuid-other', 'OTHER', false)
+    mockStore([disabledSp])
+    // selectedId is undefined and unavailable is false — no bound specialist.
+    renderSubmenu({ selectedId: undefined, onChange: vi.fn(), unavailable: false })
+    expect(container.querySelector('[data-testid="specialist-option-uuid-other"]')).toBeNull()
+  })
+
+  it('does NOT render the unavailable item if the specialist was already removed from catalog', () => {
+    // UUID not in the catalog at all (e.g. deleted, not just disabled).
+    mockStore([]) // empty catalog
+    renderSubmenu({ selectedId: 'uuid-gone', onChange: vi.fn(), unavailable: true })
+    // The unavailable item can only appear when the profile is in the store.
+    // When it's fully gone the item is absent — the banner/capsule still says Unavailable.
+    const item = container.querySelector('[data-testid="specialist-option-uuid-gone"]')
+    expect(item).toBeNull()
+    // But the trigger should still show "Unavailable" in the capsule.
+    const trigger = container.querySelector('[data-testid="specialist-submenu-trigger"]')!
+    expect(trigger.textContent).toContain('Unavailable')
+  })
+})

--- a/src/renderer/src/pages/workspace/SpecialistSubmenu.tsx
+++ b/src/renderer/src/pages/workspace/SpecialistSubmenu.tsx
@@ -1,0 +1,225 @@
+// SpecialistSubmenu — composer menu submenu for selecting a Personal Specialist.
+// Renders as a DropdownMenuSub inside ComposerAgentControlsMenu: hover the trigger
+// (icon + "Specialist" + current-value capsule) and None / enabled Personal
+// Specialists / "Create new…" expand to the side. Never shows Reviewer or disabled
+// specialists (except the currently-bound unavailable one, shown struck-through).
+
+import { Check, ChevronRight, UserRound } from 'lucide-react'
+import { useEffect } from 'react'
+
+import {
+  DropdownMenuSub,
+  DropdownMenuSubContent,
+  DropdownMenuSubTrigger,
+  DropdownMenuItem,
+  DropdownMenuSeparator
+} from '@/components/ui/dropdown-menu'
+import { cn } from '@/lib/utils'
+import { useSettingsStore } from '@/stores/settings-store'
+import { useSpecialistStore } from '@/stores/specialist-store'
+import type { SpecialistProfileView } from '../../../../shared/specialist'
+
+type SpecialistSubmenuProps = {
+  // Undefined means None (no specialist selected).
+  selectedId: string | undefined
+  onChange: (specialistId: string | undefined) => void
+  // Shows an "unavailable" capsule when the selected specialist is disabled/deleted.
+  unavailable?: boolean
+  // A bound session shows its identity in the trigger without a mutable submenu.
+  readOnly?: boolean
+}
+
+// Short label for the trigger capsule: truncated name when selected, "None" or
+// "Unavailable" otherwise. Kept compact so the trigger never wraps.
+const capsuleLabel = (
+  selected: SpecialistProfileView | undefined,
+  unavailable: boolean
+): string => {
+  if (unavailable) return 'Unavailable'
+  if (selected) return selected.name
+  return 'None'
+}
+
+const SpecialistSubmenu = ({
+  selectedId,
+  onChange,
+  unavailable = false,
+  readOnly = false
+}: SpecialistSubmenuProps): React.JSX.Element => {
+  const items = useSpecialistStore((state) => state.items)
+  const isLoaded = useSpecialistStore((state) => state.isLoaded)
+  const load = useSpecialistStore((state) => state.load)
+  const openSettingsToPanel = useSettingsStore((state) => state.openSettingsToPanel)
+
+  // Lazy-load on mount. This submenu only mounts when the parent menu opens
+  // (DropdownMenuContent mounts its children on open), so this is open-time load.
+  useEffect(() => {
+    if (!isLoaded) {
+      void load()
+    }
+  }, [isLoaded, load])
+
+  // Keep the list fresh when the specialist catalog changes elsewhere.
+  useEffect(() => {
+    const remove = window.api.specialist.onCatalogChanged(() => {
+      void load()
+    })
+    return remove
+  }, [load])
+
+  const enabledSpecialists = items.filter(
+    (item): item is { kind: 'custom' } & SpecialistProfileView =>
+      item.kind === 'custom' && item.enabled
+  )
+
+  const selected = enabledSpecialists.find((s) => s.id === selectedId)
+  const isNone = selectedId === undefined
+
+  const label = capsuleLabel(selected, unavailable)
+  const showValue = Boolean(selectedId) || unavailable
+
+  // When the selected specialist is unavailable, keep it visible in the list as struck-through so
+  // the user understands which profile is bound. Only applies to the currently-bound unavailable
+  // profile; other disabled profiles stay out of the picker as normal.
+  const unavailableItem =
+    unavailable && selectedId
+      ? items.find((item) => item.kind === 'custom' && item.id === selectedId)
+      : undefined
+  const unavailableProfile = unavailableItem?.kind === 'custom' ? unavailableItem : undefined
+
+  return (
+    <DropdownMenuSub>
+      <DropdownMenuSubTrigger
+        disabled={readOnly}
+        className="items-center gap-2 px-2 py-1.5"
+        data-testid="specialist-submenu-trigger"
+      >
+        <UserRound
+          className={cn(
+            'size-4 shrink-0 text-text-200',
+            unavailable && 'text-amber-600 dark:text-amber-400'
+          )}
+          strokeWidth={2}
+          aria-hidden="true"
+        />
+        <span className="min-w-0 flex-1">
+          <span className="block text-[13px] font-medium leading-5">Specialist</span>
+          {!showValue ? (
+            <span className="block text-[11px] leading-4 text-text-300">
+              Bind a personal specialist to this conversation.
+            </span>
+          ) : null}
+        </span>
+        {/* Value capsule mirrors the permission-mode capsule: current selection on the right. */}
+        <span
+          className={cn(
+            'flex shrink-0 items-center gap-1 whitespace-nowrap rounded-full px-2 py-0.5 text-[11px] font-medium leading-4',
+            unavailable
+              ? 'bg-amber-500/10 text-amber-600 dark:text-amber-400'
+              : showValue
+                ? 'bg-bg-200 text-text-100'
+                : 'text-text-300'
+          )}
+        >
+          <span className="max-w-[120px] truncate">{label}</span>
+          {!readOnly ? (
+            <ChevronRight
+              className="size-3 shrink-0 opacity-60"
+              strokeWidth={2}
+              aria-hidden="true"
+            />
+          ) : null}
+        </span>
+      </DropdownMenuSubTrigger>
+
+      {!readOnly ? (
+        <DropdownMenuSubContent className="w-56 p-1">
+          {/* None option */}
+          <DropdownMenuItem
+            onSelect={() => onChange(undefined)}
+            className="items-center gap-2 px-2 py-1.5"
+            data-testid="specialist-option-none"
+          >
+            <span
+              className="flex size-5 shrink-0 items-center justify-center rounded bg-bg-300 text-[11px] text-text-300"
+              aria-hidden="true"
+            >
+              —
+            </span>
+            <span className="min-w-0 flex-1 truncate text-[13px]">None</span>
+            {isNone && !unavailable ? (
+              <Check className="size-4 shrink-0 text-primary" strokeWidth={2} aria-hidden="true" />
+            ) : null}
+          </DropdownMenuItem>
+
+          {/* Enabled Personal Specialists (plus the unavailable bound profile if any) */}
+          {isLoaded && (enabledSpecialists.length > 0 || unavailableProfile) ? (
+            <>
+              <DropdownMenuSeparator />
+              {/* Unavailable bound specialist: struck-through/dimmed, not selectable.
+                  Only the currently-bound unavailable profile appears here; other disabled
+                  profiles are excluded from the picker as normal. */}
+              {unavailableProfile ? (
+                <div
+                  className="flex cursor-not-allowed items-center gap-2 rounded-sm px-2 py-1.5 opacity-35"
+                  data-testid={`specialist-option-${unavailableProfile.id}`}
+                  aria-disabled="true"
+                >
+                  <span
+                    className="flex size-5 shrink-0 items-center justify-center rounded bg-bg-300 text-[11px] font-medium"
+                    aria-hidden="true"
+                  >
+                    {unavailableProfile.name.slice(0, 1).toUpperCase()}
+                  </span>
+                  <span className="min-w-0 flex-1 truncate text-[13px] line-through">
+                    {unavailableProfile.name}
+                  </span>
+                  <span className="text-[10px] text-amber-500">Unavailable</span>
+                </div>
+              ) : null}
+              {enabledSpecialists.map((specialist) => {
+                const isSelected = specialist.id === selectedId
+                return (
+                  <DropdownMenuItem
+                    key={specialist.id}
+                    onSelect={() => onChange(specialist.id)}
+                    className="items-center gap-2 px-2 py-1.5"
+                    data-testid={`specialist-option-${specialist.id}`}
+                  >
+                    <span
+                      className="flex size-5 shrink-0 items-center justify-center rounded bg-bg-300 text-[11px] font-medium"
+                      aria-hidden="true"
+                    >
+                      {specialist.name.slice(0, 1).toUpperCase()}
+                    </span>
+                    <span className="min-w-0 flex-1 truncate text-[13px]">{specialist.name}</span>
+                    {isSelected ? (
+                      <Check
+                        className="size-4 shrink-0 text-primary"
+                        strokeWidth={2}
+                        aria-hidden="true"
+                      />
+                    ) : null}
+                  </DropdownMenuItem>
+                )
+              })}
+            </>
+          ) : null}
+
+          <DropdownMenuSeparator />
+
+          {/* Create new entry point */}
+          <DropdownMenuItem
+            onSelect={() => openSettingsToPanel('specialists')}
+            className="items-center gap-2 px-2 py-1.5 text-[13px] text-text-200"
+            data-testid="specialist-option-create"
+          >
+            Create new…
+          </DropdownMenuItem>
+        </DropdownMenuSubContent>
+      ) : null}
+    </DropdownMenuSub>
+  )
+}
+
+export { SpecialistSubmenu }

--- a/src/renderer/src/pages/workspace/WorkspacePage.specialist-barrier.test.tsx
+++ b/src/renderer/src/pages/workspace/WorkspacePage.specialist-barrier.test.tsx
@@ -1,0 +1,542 @@
+// @vitest-environment jsdom
+// Renderer-side tests for the specialist reconfigure barrier in WorkspacePage.
+// Covers: fail-closed send gate (both holes), Retry re-invoking the barrier,
+// double-send draft-restore prevention, and badge/chip display correctness.
+import { act } from 'react'
+import { createRoot, type Root } from 'react-dom/client'
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest'
+import type * as React from 'react'
+
+import { useNavigationStore } from '@/stores/navigation-store'
+import {
+  createInitialPreviewWorkbenchState,
+  usePreviewWorkbenchStore
+} from '@/stores/preview-workbench-store'
+import { useProjectStore } from '@/stores/project-store'
+import {
+  createInitialSessionState,
+  useSessionStore,
+  type ChatSession
+} from '@/stores/session-store'
+import { useSpecialistStore } from '@/stores/specialist-store'
+
+import { type ComposerDoc } from './composer/composer-doc'
+import type { SpecialistListItem } from '../../../../shared/specialist'
+
+;(globalThis as { IS_REACT_ACT_ENVIRONMENT?: boolean }).IS_REACT_ACT_ENVIRONMENT = true
+
+// Capture all props WorkspacePage passes to ConversationPanel.
+let conversationProps: Record<string, unknown>
+
+const runtime = vi.hoisted(() => ({
+  promptInFlightSessionIds: [] as string[],
+  nativeContextCompactionSessionIds: [] as string[],
+  sendMessage: vi.fn().mockResolvedValue({ sessionId: 'sess-a', messageId: 'msg-1' }),
+  compactContext: vi.fn(),
+  cancelRun: vi.fn(),
+  deleteRuntimeSession: vi.fn(),
+  respondToPermission: vi.fn()
+}))
+
+vi.mock('@/components/ui/resizable', () => ({
+  ResizablePanelGroup: ({ children }: { children: React.ReactNode }): React.JSX.Element => (
+    <div>{children}</div>
+  ),
+  ResizableHandle: (): React.JSX.Element => <div data-testid="resize-handle" />
+}))
+
+vi.mock('@/lib/acp/useWorkspaceAgentRuntime', () => ({
+  useWorkspaceAgentRuntime: () => ({
+    actionError: null,
+    pendingPermissions: [],
+    promptInFlightSessionIds: runtime.promptInFlightSessionIds,
+    nativeContextCompactionSessionIds: runtime.nativeContextCompactionSessionIds,
+    sendMessage: runtime.sendMessage,
+    compactContext: runtime.compactContext,
+    cancelRun: runtime.cancelRun,
+    deleteRuntimeSession: runtime.deleteRuntimeSession,
+    respondToPermission: runtime.respondToPermission
+  })
+}))
+
+vi.mock('./WorkspaceSidebar', () => ({
+  WorkspaceSidebar: (): React.JSX.Element => <aside />
+}))
+
+vi.mock('./ConversationPanel', () => ({
+  ConversationPanel: (props: Record<string, unknown>): React.JSX.Element => {
+    conversationProps = props
+    return <section data-testid="conversation" />
+  }
+}))
+
+vi.mock('./PreviewPanel', () => ({
+  PreviewPanel: (): React.JSX.Element => <div data-testid="preview-panel" />
+}))
+
+vi.mock('./RenameSessionDialog', () => ({
+  RenameSessionDialog: (): React.JSX.Element => <div />
+}))
+
+vi.mock('./DeleteSessionDialog', () => ({
+  DeleteSessionDialog: (): React.JSX.Element => <div />
+}))
+
+const { WorkspacePage } = await import('./WorkspacePage')
+
+const makeSpecialist = (
+  id: string,
+  name: string,
+  enabled = true
+): SpecialistListItem & { kind: 'custom' } => ({
+  kind: 'custom',
+  id,
+  name,
+  description: '',
+  systemPrompt: 'You are...',
+  enabled,
+  capabilityMode: 'full',
+  fullAccess: { excludedSkillIds: [], excludedConnectorIds: [], connectorTools: [] },
+  selectedCapabilities: { skillIds: [], connectorIds: [], connectorTools: [] },
+  revision: 1
+})
+
+const createSession = (overrides: Partial<ChatSession> = {}): ChatSession => {
+  const now = Date.now()
+  return {
+    id: 'sess-a',
+    projectId: 'proj-1',
+    title: 'sess-a',
+    cwd: '/workspace/proj-1',
+    status: 'idle',
+    messages: [],
+    createdAt: now,
+    updatedAt: now,
+    ...overrides
+  }
+}
+
+const textDoc = (text: string): ComposerDoc => ({ nodes: [{ type: 'text', text }] })
+
+let container: HTMLDivElement
+let root: Root
+
+const apiStub = (specialistOverrides?: Record<string, unknown>): typeof window.api =>
+  ({
+    notebook: {
+      onAvailable: vi.fn(() => vi.fn()),
+      getReference: vi.fn(() => Promise.resolve(null))
+    },
+    preview: {
+      load: vi.fn(() => Promise.resolve(undefined)),
+      save: vi.fn(() => Promise.resolve())
+    },
+    uploads: { deleteUpload: vi.fn() },
+    reviewer: {
+      onUpdated: vi.fn(() => vi.fn()),
+      onSuppressNextAutoReview: vi.fn(() => vi.fn()),
+      onFixLoopStart: vi.fn(() => vi.fn()),
+      onFixLoopEnd: vi.fn(() => vi.fn()),
+      abortFixLoop: vi.fn(() => Promise.resolve())
+    },
+    compute: { enabledHostsSet: vi.fn(() => Promise.resolve()) },
+    specialist: {
+      onCatalogChanged: vi.fn(() => vi.fn()),
+      setSessionSpecialist: vi.fn(() => Promise.resolve({ contextReset: false })),
+      ...specialistOverrides
+    }
+  }) as never
+
+const renderPage = async (r: Root): Promise<void> => {
+  await act(async () => {
+    r.render(
+      <WorkspacePage
+        isSessionPersistenceHydrated={true}
+        isSessionPersistenceReady={true}
+        canDeleteConversations={true}
+      />
+    )
+  })
+}
+
+const setupBase = (): void => {
+  usePreviewWorkbenchStore.setState(createInitialPreviewWorkbenchState())
+  useProjectStore.setState({ projects: [] })
+  useNavigationStore.setState({ view: 'workspace', activeProjectId: 'proj-1' })
+  vi.clearAllMocks()
+  runtime.promptInFlightSessionIds = []
+  runtime.nativeContextCompactionSessionIds = []
+  runtime.sendMessage.mockResolvedValue({ sessionId: 'sess-a', messageId: 'msg-1' })
+}
+
+beforeEach(() => {
+  container = document.createElement('div')
+  document.body.appendChild(container)
+  root = createRoot(container)
+})
+
+afterEach(async () => {
+  await act(async () => {
+    root.unmount()
+  })
+  container.remove()
+})
+
+// ---------------------------------------------------------------------------
+// Finding 2 — fail-closed send gate
+// ---------------------------------------------------------------------------
+
+describe('WorkspacePage fail-closed send gate', () => {
+  it('blocks send when the bound specialist is missing from a loaded catalog', async () => {
+    setupBase()
+    useSessionStore.setState({
+      ...createInitialSessionState(),
+      sessions: [createSession({ specialistId: 'spec-missing' })],
+      selectedSessionId: 'sess-a'
+    })
+    useSpecialistStore.setState({ items: [], isLoaded: true, load: vi.fn() })
+    window.api = apiStub()
+
+    await renderPage(root)
+    await act(async () => {
+      ;(conversationProps.onDraftDocChange as (doc: ComposerDoc) => void)(textDoc('hello'))
+    })
+
+    // Catalog is loaded and the bound specialist is not in it — sendMessage must NOT be called.
+    await act(async () => {
+      ;(conversationProps.onSendMessage as (ids: string[]) => void)([])
+    })
+    expect(runtime.sendMessage).not.toHaveBeenCalled()
+  })
+
+  it('allows send when the bound specialist is present and enabled', async () => {
+    setupBase()
+    useSessionStore.setState({
+      ...createInitialSessionState(),
+      sessions: [createSession({ specialistId: 'spec-a' })],
+      selectedSessionId: 'sess-a'
+    })
+    useSpecialistStore.setState({
+      items: [makeSpecialist('spec-a', 'Debugger')],
+      isLoaded: true,
+      load: vi.fn()
+    })
+    window.api = apiStub()
+
+    await renderPage(root)
+    await act(async () => {
+      ;(conversationProps.onDraftDocChange as (doc: ComposerDoc) => void)(textDoc('hello'))
+    })
+
+    expect(conversationProps.canSendMessage).toBe(true)
+  })
+
+  it('blocks send and triggers load when the catalog has not yet loaded (hole B)', async () => {
+    setupBase()
+    const loadMock = vi.fn()
+    useSessionStore.setState({
+      ...createInitialSessionState(),
+      sessions: [createSession({ specialistId: 'spec-a' })],
+      selectedSessionId: 'sess-a'
+    })
+    // isLoaded=false simulates a fresh workspace where the submenu was never opened.
+    useSpecialistStore.setState({
+      items: [],
+      isLoaded: false,
+      load: loadMock
+    })
+    window.api = apiStub()
+
+    await renderPage(root)
+    await act(async () => {
+      ;(conversationProps.onDraftDocChange as (doc: ComposerDoc) => void)(textDoc('hello'))
+    })
+
+    // canSendMessage is based on rendered state; the gate fires inside sendCurrentMessage.
+    // We call onSendMessage to exercise the path and verify load is triggered.
+    await act(async () => {
+      ;(conversationProps.onSendMessage as (ids: string[]) => void)([])
+    })
+
+    expect(runtime.sendMessage).not.toHaveBeenCalled()
+    expect(loadMock).toHaveBeenCalled()
+  })
+
+  it('allows send when there is a pending switch even though the effective specialist is unavailable (hole A)', async () => {
+    setupBase()
+    useSessionStore.setState({
+      ...createInitialSessionState(),
+      sessions: [createSession({ specialistId: 'spec-missing', status: 'running' })],
+      selectedSessionId: 'sess-a'
+    })
+    useSpecialistStore.setState({
+      items: [makeSpecialist('spec-b', 'Researcher')],
+      isLoaded: true,
+      load: vi.fn()
+    })
+    window.api = apiStub()
+
+    await renderPage(root)
+
+    // Pick a new specialist while running — sets the pending state.
+    await act(async () => {
+      ;(conversationProps.onSpecialistChange as (id: string | undefined) => void)('spec-b')
+    })
+
+    // Session finishes its run → idle. User types and sends.
+    await act(async () => {
+      useSessionStore.getState().finishRun('sess-a')
+    })
+    await act(async () => {
+      ;(conversationProps.onDraftDocChange as (doc: ComposerDoc) => void)(textDoc('hello'))
+    })
+    await act(async () => {
+      ;(conversationProps.onSendMessage as (ids: string[]) => void)([])
+    })
+
+    // The barrier should have been invoked with the new specialist.
+    expect(window.api.specialist.setSessionSpecialist).toHaveBeenCalledWith({
+      sessionId: 'sess-a',
+      specialistId: 'spec-b'
+    })
+  })
+})
+
+// ---------------------------------------------------------------------------
+// Finding 1 — Retry re-invokes the barrier
+// ---------------------------------------------------------------------------
+
+describe('WorkspacePage Retry recovery action', () => {
+  it('re-runs the barrier on Retry and completes the send on success', async () => {
+    setupBase()
+    // First call: reject to show the banner. Second call: resolve to succeed.
+    const setSessionSpecialist = vi
+      .fn()
+      .mockRejectedValueOnce(new Error('session reset failed'))
+      .mockResolvedValueOnce({ contextReset: false })
+
+    useSessionStore.setState({
+      ...createInitialSessionState(),
+      sessions: [createSession({ specialistId: 'spec-a', status: 'running' })],
+      selectedSessionId: 'sess-a'
+    })
+    useSpecialistStore.setState({
+      items: [makeSpecialist('spec-b', 'Researcher')],
+      isLoaded: true,
+      load: vi.fn()
+    })
+    window.api = apiStub({ setSessionSpecialist })
+
+    await renderPage(root)
+
+    // While the session is running, pick a new specialist — this sets the pending state.
+    await act(async () => {
+      ;(conversationProps.onSpecialistChange as (id: string | undefined) => void)('spec-b')
+    })
+
+    // Session finishes its run → idle. User types and sends.
+    await act(async () => {
+      useSessionStore.getState().finishRun('sess-a')
+    })
+    await act(async () => {
+      ;(conversationProps.onDraftDocChange as (doc: ComposerDoc) => void)(textDoc('retry test'))
+    })
+
+    // First send: barrier fails → banner shown, send not dispatched.
+    await act(async () => {
+      ;(conversationProps.onSendMessage as (ids: string[]) => void)([])
+    })
+    expect(runtime.sendMessage).not.toHaveBeenCalled()
+    expect(conversationProps.reconfigureError).toBeTruthy()
+
+    // Retry: barrier succeeds → send dispatched.
+    await act(async () => {
+      ;(conversationProps.onReconfigureRetry as () => void)()
+    })
+
+    expect(setSessionSpecialist).toHaveBeenCalledTimes(2)
+    expect(runtime.sendMessage).toHaveBeenCalledOnce()
+    expect(conversationProps.reconfigureError).toBeNull()
+  })
+})
+
+// ---------------------------------------------------------------------------
+// Finding 3 — double-send does not restore the just-sent draft
+// ---------------------------------------------------------------------------
+
+describe('WorkspacePage double-send race prevention', () => {
+  it('blocks a second send while the barrier is in flight', async () => {
+    setupBase()
+    let resolveSwitch!: (v: { contextReset: boolean }) => void
+    const switchPromise = new Promise<{ contextReset: boolean }>((res) => {
+      resolveSwitch = res
+    })
+    const setSessionSpecialist = vi.fn(() => switchPromise)
+
+    useSessionStore.setState({
+      ...createInitialSessionState(),
+      sessions: [createSession({ specialistId: 'spec-a', status: 'running' })],
+      selectedSessionId: 'sess-a'
+    })
+    useSpecialistStore.setState({
+      items: [makeSpecialist('spec-b', 'Researcher')],
+      isLoaded: true,
+      load: vi.fn()
+    })
+    window.api = apiStub({ setSessionSpecialist })
+
+    await renderPage(root)
+
+    // Set pending while running, then finish the run.
+    await act(async () => {
+      ;(conversationProps.onSpecialistChange as (id: string | undefined) => void)('spec-b')
+    })
+    await act(async () => {
+      useSessionStore.getState().finishRun('sess-a')
+    })
+    await act(async () => {
+      ;(conversationProps.onDraftDocChange as (doc: ComposerDoc) => void)(textDoc('first send'))
+    })
+
+    // Fire two sends before the barrier resolves.
+    act(() => {
+      ;(conversationProps.onSendMessage as (ids: string[]) => void)([])
+    })
+    act(() => {
+      ;(conversationProps.onSendMessage as (ids: string[]) => void)([])
+    })
+
+    // Resolve the barrier and let the async work settle.
+    await act(async () => {
+      resolveSwitch({ contextReset: false })
+    })
+
+    // Only one sendMessage call — the second was blocked by the in-flight guard.
+    expect(runtime.sendMessage).toHaveBeenCalledOnce()
+  })
+})
+
+// ---------------------------------------------------------------------------
+// Finding 5 — badge shows the effective specialist, chip shows pending
+// ---------------------------------------------------------------------------
+
+describe('WorkspacePage specialist badge vs pending chip', () => {
+  it('badge shows the effective specialist while a pending switch is in progress', async () => {
+    setupBase()
+    useSessionStore.setState({
+      ...createInitialSessionState(),
+      sessions: [
+        createSession({
+          specialistId: 'spec-a',
+          status: 'running'
+        })
+      ],
+      selectedSessionId: 'sess-a'
+    })
+    useSpecialistStore.setState({
+      items: [makeSpecialist('spec-a', 'Debugger'), makeSpecialist('spec-b', 'Researcher')],
+      isLoaded: true,
+      load: vi.fn()
+    })
+    window.api = apiStub()
+
+    await renderPage(root)
+
+    // Pick a different specialist while the session is running.
+    await act(async () => {
+      ;(conversationProps.onSpecialistChange as (id: string | undefined) => void)('spec-b')
+    })
+
+    // The badge (specialistId) shows the currently-effective specialist (spec-a).
+    expect(conversationProps.specialistId).toBe('spec-a')
+    // The pending-switch chip should be shown.
+    expect(conversationProps.specialistHasPendingSwitch).toBe(true)
+  })
+
+  it('badge shows effective and chip is hidden when there is no pending switch', async () => {
+    setupBase()
+    useSessionStore.setState({
+      ...createInitialSessionState(),
+      sessions: [createSession({ specialistId: 'spec-a' })],
+      selectedSessionId: 'sess-a'
+    })
+    useSpecialistStore.setState({
+      items: [makeSpecialist('spec-a', 'Debugger')],
+      isLoaded: true,
+      load: vi.fn()
+    })
+    window.api = apiStub()
+
+    await renderPage(root)
+
+    expect(conversationProps.specialistId).toBe('spec-a')
+    expect(conversationProps.specialistHasPendingSwitch).toBe(false)
+  })
+})
+
+// ---------------------------------------------------------------------------
+// specialistUnavailable computation
+// ---------------------------------------------------------------------------
+
+describe('WorkspacePage specialistUnavailable computation', () => {
+  it('marks unavailable when bound specialist is not in the loaded catalog', async () => {
+    setupBase()
+    useSessionStore.setState({
+      ...createInitialSessionState(),
+      sessions: [createSession({ specialistId: 'spec-gone' })],
+      selectedSessionId: 'sess-a'
+    })
+    useSpecialistStore.setState({
+      items: [makeSpecialist('spec-other', 'Other')],
+      isLoaded: true,
+      load: vi.fn()
+    })
+    window.api = apiStub()
+
+    await renderPage(root)
+
+    expect(conversationProps.specialistUnavailable).toBe(true)
+  })
+
+  it('marks NOT unavailable when catalog is not yet loaded', async () => {
+    setupBase()
+    useSessionStore.setState({
+      ...createInitialSessionState(),
+      sessions: [createSession({ specialistId: 'spec-a' })],
+      selectedSessionId: 'sess-a'
+    })
+    useSpecialistStore.setState({ items: [], isLoaded: false, load: vi.fn() })
+    window.api = apiStub()
+
+    await renderPage(root)
+
+    // While catalog is loading we cannot tell if the specialist is unavailable —
+    // the guard should not show the unavailable state to avoid false positives.
+    expect(conversationProps.specialistUnavailable).toBe(false)
+  })
+
+  it('does not mark unavailable when a pending switch overrides the effective specialist', async () => {
+    setupBase()
+    useSessionStore.setState({
+      ...createInitialSessionState(),
+      sessions: [createSession({ specialistId: 'spec-gone', status: 'running' })],
+      selectedSessionId: 'sess-a'
+    })
+    useSpecialistStore.setState({
+      items: [makeSpecialist('spec-b', 'Researcher')],
+      isLoaded: true,
+      load: vi.fn()
+    })
+    window.api = apiStub()
+
+    await renderPage(root)
+
+    // While running, pick an available specialist — sets pending, overrides unavailability.
+    await act(async () => {
+      ;(conversationProps.onSpecialistChange as (id: string | undefined) => void)('spec-b')
+    })
+
+    // The unavailable badge should not show because there is a pending switch.
+    expect(conversationProps.specialistUnavailable).toBe(false)
+  })
+})

--- a/src/renderer/src/pages/workspace/WorkspacePage.tsx
+++ b/src/renderer/src/pages/workspace/WorkspacePage.tsx
@@ -21,6 +21,7 @@ import {
 } from '@/stores/preview-workbench-store'
 import type { ChatSession } from '@/stores/session-store'
 import { useSessionStore } from '@/stores/session-store'
+import { useSpecialistStore } from '@/stores/specialist-store'
 import { selectProjectSessionReviews, useReviewStore } from '@/stores/review-store'
 import {
   assembleReviewRunRequest,
@@ -117,7 +118,10 @@ const WorkspacePage = ({
     state.projects.find((project) => project.id === scopedProjectId)
   )
 
-  // Session data lives in zustand while draft/new-conversation state stays local to the chat surface.
+  // Specialist catalog for new-conversation draft validation.
+  const specialistItems = useSpecialistStore((state) => state.items)
+  const specialistCatalogLoaded = useSpecialistStore((state) => state.isLoaded)
+  const loadSpecialists = useSpecialistStore((state) => state.load)
   const allSessions = useSessionStore((state) => state.sessions)
   const selectedSessionId = useSessionStore((state) => state.selectedSessionId)
   const clearSelection = useSessionStore((state) => state.clearSelection)
@@ -125,6 +129,10 @@ const WorkspacePage = ({
   const togglePinned = useSessionStore((state) => state.togglePinned)
   const setAutoReviewEnabled = useSessionStore((state) => state.setAutoReviewEnabled)
   const setEnabledComputeHosts = useSessionStore((state) => state.setEnabledComputeHosts)
+  const setSessionSpecialistId = useSessionStore((state) => state.setSessionSpecialistId)
+  const markSpecialistSwitchResetRequired = useSessionStore(
+    (state) => state.markSpecialistSwitchResetRequired
+  )
   const setFixLoopActive = useSessionStore((state) => state.setFixLoopActive)
   // Only sessions belonging to the active project are shown in this workspace.
   const sessions = useMemo(
@@ -178,6 +186,43 @@ const WorkspacePage = ({
   const [newConversationEnabledComputeHosts, setNewConversationEnabledComputeHosts] = useState<
     string[]
   >([])
+  // Draft specialist selection for a not-yet-created conversation. Stored in memory only (not
+  // persisted across restarts). Reset when clicking New; restored when switching back to the draft.
+  // On first send, the UUID is forwarded to createSession; the main process resolves the latest Profile.
+  const [newConversationSpecialistId, setNewConversationSpecialistId] = useState<
+    string | undefined
+  >(undefined)
+  // Keep availability derived from the current catalog, rather than caching it at click time: a profile
+  // can be disabled or deleted while a new-conversation draft is open.
+  const newConversationSpecialistUnavailable =
+    specialistCatalogLoaded &&
+    newConversationSpecialistId !== undefined &&
+    !specialistItems.some(
+      (item) => item.kind === 'custom' && item.enabled && item.id === newConversationSpecialistId
+    )
+
+  // Per-session pending specialist selection for existing conversations.
+  // Key: sessionId. Value: the pending UUID (or undefined to clear binding).
+  // The pending value is the user's last selection; it takes effect on the next send via reconfigure
+  // barrier. Multiple switches before send only keep the last one (last-write-wins).
+  const [pendingSessionSpecialist, setPendingSessionSpecialist] = useState<
+    Record<string, string | undefined>
+  >({})
+
+  // Reconfigure failure state: set when a pre-send dispose/resume fails.
+  // Keeps the draft intact, shows the recovery banner above the composer.
+  const [reconfigureError, setReconfigureError] = useState<{
+    sessionId: string
+    specialistName: string
+    message: string
+  } | null>(null)
+  // Per-session set of session IDs currently running the reconfigure barrier (async send in flight).
+  // The Set is reactive (drives canSendMessage) so a second Enter press disables send after the first
+  // barrier starts. The ref mirrors it for synchronous reads inside the event handler itself.
+  const [barrierInFlightSessions, setBarrierInFlightSessions] = useState<ReadonlySet<string>>(
+    new Set()
+  )
+  const barrierInFlightRef = useRef<Set<string>>(new Set())
   // Unsent composer state (rich doc + staged attachments) is kept per session (and per new conversation)
   // so switching away and back restores it. The active key's state is live; this map holds inactive keys.
   const composerDraftsRef = useRef<
@@ -338,7 +383,10 @@ const WorkspacePage = ({
     !activeSession?.conversationGraphSyncBlocked &&
     // Auto-recovery drops the session to idle while it resets context and replays the transcript; block
     // sends in that window so a manual prompt can't race the recovery resend into the same session.
-    !activeSession?.compacting
+    !activeSession?.compacting &&
+    // Block while the reconfigure barrier is running (async, between Enter and sendMessage). This
+    // prevents a second Enter press from racing the first one through the same pending-switch barrier.
+    !barrierInFlightSessions.has(activeSession?.id ?? '')
   // Re-editing a sent prompt is allowed under the same settled-run conditions as sending, so the
   // resent prompt can never overlap an in-flight turn, permission wait, fix loop, or compaction.
   const canEditMessage =
@@ -710,6 +758,7 @@ const WorkspacePage = ({
     setNewConversationAutoReviewEnabled(false)
     setNewConversationEnabledComputeHosts([])
     useNavigationStore.getState().recordUserNavigation()
+    setNewConversationSpecialistId(undefined)
     clearSelection()
   }
 
@@ -883,14 +932,45 @@ const WorkspacePage = ({
 
   // Sends the current draft only after hydration so restored selection cannot overwrite intent.
   // ConversationPanel owns preventDefault and passes the skills picked as inline chips.
+  // For existing sessions with a pending specialist switch, the reconfigure barrier runs first:
+  // dispose + resume the Claude ACP session with the new specialist identity. On failure, the
+  // draft is preserved, no user turn is created, and a recovery banner is shown (fail-closed —
+  // never silently fall back to Main Agent).
   const sendCurrentMessage = (forcedSkillIds: string[]): void => {
     if (!canSendMessage) return
+    // Secondary synchronous guard: blocks a second Enter press that arrives before the state update
+    // from the first barrier start triggers a re-render and disables canSendMessage.
+    if (activeSession && barrierInFlightRef.current.has(activeSession.id)) return
     if (
       supportsImageInput !== true &&
       attachments.some((attachment) => attachment.mimeType?.startsWith('image/'))
     ) {
       setAttachmentError('The selected model is not configured for image input.')
       return
+    }
+    // Block send if the draft specialist is unavailable (disabled/deleted/corrupt).
+    if (!activeSession && newConversationSpecialistUnavailable) {
+      return
+    }
+    // Block send for existing sessions when the bound specialist is unavailable (fail-closed).
+    // Hole A fix: use Object.hasOwn to distinguish "no pending entry" from "pending entry whose
+    // value is None (undefined)" — a falsy check would skip the guard for any pending switch.
+    // Hole B fix: treat an unloaded catalog as blocking (kick off the load so the next attempt
+    // succeeds). Gating on specialistCatalogLoaded=true would skip the guard before catalog
+    // resolves; the submenu only loads on open, so isLoaded is plausibly false on a fresh workspace.
+    if (activeSession?.specialistId !== undefined) {
+      if (!specialistCatalogLoaded) {
+        void loadSpecialists()
+        return
+      }
+      if (
+        !Object.hasOwn(pendingSessionSpecialist, activeSession.id) &&
+        !specialistItems.some(
+          (item) => item.kind === 'custom' && item.enabled && item.id === activeSession.specialistId
+        )
+      ) {
+        return
+      }
     }
 
     const doc = draftDoc
@@ -900,54 +980,143 @@ const WorkspacePage = ({
     const wasNewConversation = !activeSession
     const draftAutoReviewEnabled = newConversationAutoReviewEnabled
     const draftEnabledComputeHosts = newConversationEnabledComputeHosts
+    // Capture the final specialist selection (last change wins before first send).
+    const draftSpecialistId = wasNewConversation ? newConversationSpecialistId : undefined
+    // Capture pending specialist for existing sessions (last change wins).
+    const pendingSpecialistId = activeSession
+      ? pendingSessionSpecialist[activeSession.id]
+      : undefined
+    const hasPendingSwitch = activeSession !== undefined && pendingSpecialistId !== undefined
 
-    // Optimistically clear composer state; failed sends restore both doc and attachments below. Staged
-    // files are consumed (moved into the session dir) by the runtime, so they are not deleted here.
+    // Dispatches the final send after draft/attachment state has been cleared.
+    // Shared by the normal send path and the Retry recovery action so the logic stays in sync.
+    const dispatchSend = (sessionId: string | undefined): void => {
+      void sendMessage({
+        sessionId,
+        text: docToText(doc),
+        attachments: attachmentsForSend,
+        // Existing files the user referenced via `@`; the runtime attaches each as a content block.
+        referencedArtifacts: docToArtifactRefs(doc),
+        // Persist the draft's structural segments so the sent bubble renders styled mention pills.
+        parts: doc.nodes,
+        cwd: activeSession?.cwd,
+        projectId: activeSession?.projectId ?? scopedProjectId,
+        projectName: activeSession?.projectId ?? scopedProjectId,
+        permissionProfile: activePermissionProfile,
+        forcedSkillIds,
+        // New-conversation only: the UUID is forwarded to createSession; main process reads latest Profile.
+        specialistId: draftSpecialistId
+      }).then((result) => {
+        if (!result) {
+          setDraftDoc(doc)
+          setAttachments(attachmentsForSend)
+          return
+        }
+
+        // Carry the composer's auto-review choice onto the freshly created session. bindPendingSession
+        // preserves the field, so stamping the (pending) session id here survives the durable-id swap.
+        if (wasNewConversation && draftAutoReviewEnabled) {
+          setAutoReviewEnabled(result.sessionId, true)
+        }
+        // Carry the draft compute host selection onto the newly created session.
+        if (wasNewConversation && draftEnabledComputeHosts.length > 0) {
+          setEnabledComputeHosts(result.sessionId, draftEnabledComputeHosts)
+          void window.api.compute
+            .enabledHostsSet(result.sessionId, draftEnabledComputeHosts)
+            .catch((err: unknown) => {
+              console.warn('Failed to sync draft compute hosts to registry for new session', err)
+            })
+        }
+        setNewConversationAutoReviewEnabled(false)
+        setNewConversationEnabledComputeHosts([])
+        setNewConversationSpecialistId(undefined)
+      })
+    }
+
+    // Runs the reconfigure barrier then dispatches the send on success. Extracted so that both the
+    // initial send path and the Retry recovery action can invoke the same ordered sequence.
+    const runBarrierAndSend = async (sessionId: string, specialistId: string): Promise<void> => {
+      // Mark the barrier as in-flight synchronously (ref) and reactively (state). The ref allows
+      // the sendCurrentMessage guard to block a second call before the state re-render fires;
+      // the state drives canSendMessage so the Send button also disables on the next render.
+      barrierInFlightRef.current.add(sessionId)
+      setBarrierInFlightSessions((prev) => new Set(prev).add(sessionId))
+      try {
+        // Apply the pending binding to main process (validates the UUID is still available, then
+        // hot-switches the live agent session). contextReset signals the agent session was replaced
+        // (Claude bakes identity into the session at creation) so history must be replayed below.
+        const switchResult = await window.api?.specialist?.setSessionSpecialist?.({
+          sessionId,
+          specialistId
+        })
+        if (switchResult?.contextReset) {
+          markSpecialistSwitchResetRequired(sessionId)
+        }
+      } catch (err: unknown) {
+        // Reconfigure failed — preserve draft (pendingSessionSpecialist is intentionally left set
+        // so Retry has the specialist to re-attempt), do not send, show the recovery banner.
+        const pendingProfile = specialistItems.find(
+          (item) => item.kind === 'custom' && item.id === specialistId
+        )
+        const name =
+          pendingProfile?.kind === 'custom' ? pendingProfile.name : 'the selected specialist'
+        setReconfigureError({
+          sessionId,
+          specialistName: name,
+          message: err instanceof Error ? err.message : String(err)
+        })
+        barrierInFlightRef.current.delete(sessionId)
+        setBarrierInFlightSessions((prev) => {
+          const next = new Set(prev)
+          next.delete(sessionId)
+          return next
+        })
+        return
+      }
+
+      // Reconfigure succeeded: update the session's persisted specialist binding,
+      // clear the pending state, and proceed to send.
+      // Updating the session store's specialistId here ensures the next sendMessage
+      // call (which reads currentSession.specialistId for resumeSession) uses the
+      // new UUID — triggering the ACP dispose+resume that re-injects the new identity.
+      setSessionSpecialistId(sessionId, specialistId)
+      setPendingSessionSpecialist((prev) => {
+        const next = { ...prev }
+        delete next[sessionId]
+        return next
+      })
+      setDraftDoc(emptyDoc)
+      delete composerDraftsRef.current[sessionId]
+      setAttachments([])
+      setAttachmentError(null)
+      setReconfigureError(null)
+
+      barrierInFlightRef.current.delete(sessionId)
+      setBarrierInFlightSessions((prev) => {
+        const next = new Set(prev)
+        next.delete(sessionId)
+        return next
+      })
+      dispatchSend(sessionId)
+    }
+
+    // If there is a pending specialist switch for an existing session, run the reconfigure barrier
+    // BEFORE appending the user turn. The barrier is strictly ordered: reconfigure must succeed
+    // before any message is sent. On failure, the draft is restored, no user turn is created, and
+    // the recovery banner is shown.
+    if (hasPendingSwitch) {
+      void runBarrierAndSend(activeSession.id, pendingSpecialistId)
+      return
+    }
+
+    // No pending switch: proceed with the normal send path.
     setDraftDoc(emptyDoc)
     // Drop the stored draft for this key so a sent message never lingers as a restorable draft.
     delete composerDraftsRef.current[selectedSessionId ?? NEW_CONVERSATION_DRAFT_KEY]
     setAttachments([])
     setAttachmentError(null)
 
-    // The bridge creates the runtime session if this is the first message. New sessions are stamped
-    // with the active project (both as the durable projectId and the MCP storage projectName).
-    void sendMessage({
-      sessionId: activeSession?.id,
-      text: docToText(doc),
-      attachments: attachmentsForSend,
-      // Existing files the user referenced via `@`; the runtime attaches each as a content block.
-      referencedArtifacts: docToArtifactRefs(doc),
-      // Persist the draft's structural segments so the sent bubble renders styled mention pills.
-      parts: doc.nodes,
-      cwd: activeSession?.cwd,
-      projectId: activeSession?.projectId ?? scopedProjectId,
-      projectName: activeSession?.projectId ?? scopedProjectId,
-      permissionProfile: activePermissionProfile,
-      forcedSkillIds
-    }).then((result) => {
-      if (!result) {
-        setDraftDoc(doc)
-        setAttachments(attachmentsForSend)
-        return
-      }
-
-      // Carry the composer's auto-review choice onto the freshly created session. bindPendingSession
-      // preserves the field, so stamping the (pending) session id here survives the durable-id swap.
-      if (wasNewConversation && draftAutoReviewEnabled) {
-        setAutoReviewEnabled(result.sessionId, true)
-      }
-      // Carry the draft compute host selection onto the newly created session.
-      if (wasNewConversation && draftEnabledComputeHosts.length > 0) {
-        setEnabledComputeHosts(result.sessionId, draftEnabledComputeHosts)
-        void window.api.compute
-          .enabledHostsSet(result.sessionId, draftEnabledComputeHosts)
-          .catch((err: unknown) => {
-            console.warn('Failed to sync draft compute hosts to registry for new session', err)
-          })
-      }
-      setNewConversationAutoReviewEnabled(false)
-      setNewConversationEnabledComputeHosts([])
-    })
+    dispatchSend(activeSession?.id)
   }
 
   // Opens the rename dialog with the current title prefilled.
@@ -1157,6 +1326,65 @@ const WorkspacePage = ({
     upsertAndActivatePreviewItem(createProjectFilesPreviewItem())
   }
 
+  // Handles specialist selection for the new-conversation draft. Availability is derived from the
+  // catalog above so a later disable/delete is reflected before the next send.
+  const handleNewConversationSpecialistChange = (specialistId: string | undefined): void => {
+    setNewConversationSpecialistId(specialistId)
+  }
+
+  // Handles specialist selection for an existing conversation.
+  // For idle sessions: immediately write the binding via IPC (no reconfigure yet — lazy).
+  // For running sessions: record as pending; the chip appears; binding takes effect next send.
+  const handleExistingSessionSpecialistChange = (specialistId: string | undefined): void => {
+    if (!activeSession) return
+    const sessionId = activeSession.id
+    const isRunning =
+      activeSession.status === 'running' || activeSession.status === 'waiting-permission'
+
+    if (isRunning) {
+      // Pending switch: will be applied at next send via reconfigure barrier.
+      setPendingSessionSpecialist((prev) => ({ ...prev, [sessionId]: specialistId }))
+    } else {
+      // Idle: apply immediately (write to main process binding store + persist UUID).
+      const previousSpecialistId = activeSession.specialistId
+      // Optimistically update the session store so the specialist chip reflects the new selection
+      // right away and the persistence bridge writes the new UUID. Reverted on IPC failure so a
+      // rejected switch (e.g. specialist disabled between render and click) leaves the UI consistent.
+      setSessionSpecialistId(sessionId, specialistId)
+      setPendingSessionSpecialist((prev) => {
+        const next = { ...prev }
+        delete next[sessionId]
+        return next
+      })
+      void window.api?.specialist
+        ?.setSessionSpecialist?.({ sessionId, specialistId })
+        ?.then((result) => {
+          // The agent session was replaced on the main side; replay history on the next send so the
+          // new specialist keeps conversation continuity.
+          if (result?.contextReset) markSpecialistSwitchResetRequired(sessionId)
+        })
+        ?.catch((err: unknown) => {
+          setSessionSpecialistId(sessionId, previousSpecialistId)
+          console.warn('setSessionSpecialist failed', err)
+        })
+    }
+    // Clear any prior reconfigure error when the user picks a new specialist.
+    if (reconfigureError?.sessionId === sessionId) {
+      setReconfigureError(null)
+    }
+  }
+
+  // Subscribe to specialist catalog changes so unavailability state stays fresh.
+  useEffect(() => {
+    // Guard: window.api.specialist may be absent in test/headless environments.
+    if (!window.api?.specialist) return
+    void loadSpecialists()
+    const remove = window.api.specialist.onCatalogChanged(() => {
+      void loadSpecialists()
+    })
+    return remove
+  }, [loadSpecialists])
+
   return (
     <main className="h-screen overflow-hidden bg-bg-10 p-[10px] text-[13px] leading-normal text-text-000">
       <div className="flex h-full gap-2">
@@ -1229,6 +1457,79 @@ const WorkspacePage = ({
             canEditMessage={canEditMessage}
             onSendEditedMessage={sendEditedMessage}
             onOpenJobList={(sessionId) => setJobListModal({ open: true, sessionId })}
+            specialistId={
+              // For existing sessions: badge shows the currently-effective specialist (session
+              // binding). A pending switch is signalled by the chip, not by overriding the badge.
+              activeSession ? activeSession.specialistId : newConversationSpecialistId
+            }
+            specialistUnavailable={
+              activeSession
+                ? specialistCatalogLoaded &&
+                  activeSession.specialistId !== undefined &&
+                  // A pending switch overrides: the new selection is checked for availability.
+                  !Object.hasOwn(pendingSessionSpecialist, activeSession.id) &&
+                  !specialistItems.some(
+                    (item) =>
+                      item.kind === 'custom' &&
+                      item.enabled &&
+                      item.id === activeSession.specialistId
+                  )
+                : newConversationSpecialistUnavailable
+            }
+            specialistHasPendingSwitch={
+              activeSession !== undefined &&
+              pendingSessionSpecialist[activeSession.id] !== undefined &&
+              (activeSession.status === 'running' || activeSession.status === 'waiting-permission')
+            }
+            reconfigureError={
+              reconfigureError?.sessionId === activeSession?.id ? reconfigureError : null
+            }
+            onReconfigureRetry={() => {
+              // Re-run the full barrier: clears the banner first, then re-attempts the switch
+              // and, on success, dispatches the send — identical to the original send path.
+              if (!reconfigureError || !activeSession) return
+              const pendingId = pendingSessionSpecialist[reconfigureError.sessionId]
+              if (pendingId === undefined) {
+                setReconfigureError(null)
+                return
+              }
+              setReconfigureError(null)
+              sendCurrentMessage(docToSkillIds(draftDoc))
+            }}
+            onReconfigureChooseOther={() => {
+              // Clear the failed pending selection so the picker reflects the currently-effective
+              // specialist. The user can then pick a new one from the menu and send again.
+              // No mechanism exists to programmatically open the picker, so we note it here.
+              if (activeSession && reconfigureError) {
+                setPendingSessionSpecialist((prev) => {
+                  const next = { ...prev }
+                  delete next[activeSession.id]
+                  return next
+                })
+                setReconfigureError(null)
+              }
+            }}
+            onReconfigureUseNone={() => {
+              if (activeSession && reconfigureError) {
+                setPendingSessionSpecialist((prev) => {
+                  const next = { ...prev }
+                  delete next[activeSession.id]
+                  return next
+                })
+                setReconfigureError(null)
+                void window.api?.specialist
+                  ?.setSessionSpecialist?.({ sessionId: activeSession.id, specialistId: undefined })
+                  ?.then((result) => {
+                    if (result?.contextReset) markSpecialistSwitchResetRequired(activeSession.id)
+                  })
+                  ?.catch((err: unknown) => console.warn('setSessionSpecialist (none) failed', err))
+              }
+            }}
+            onSpecialistChange={
+              activeSession
+                ? handleExistingSessionSpecialistChange
+                : handleNewConversationSpecialistChange
+            }
           />
 
           <ResizableHandle

--- a/src/renderer/src/pages/workspace/composer/ComposerEditor.tsx
+++ b/src/renderer/src/pages/workspace/composer/ComposerEditor.tsx
@@ -35,6 +35,8 @@ type ComposerEditorProps = {
   placeholder: string
   className?: string
   ariaLabel: string
+  // Undefined preserves Main Agent behavior; an empty array intentionally hides every Skill.
+  allowedSkillIds?: readonly string[]
 }
 
 // Structural equality over doc nodes; used to decide whether the incoming prop diverges from what
@@ -121,7 +123,8 @@ export const ComposerEditor = ({
   disabled = false,
   placeholder,
   className,
-  ariaLabel
+  ariaLabel,
+  allowedSkillIds
 }: ComposerEditorProps): React.JSX.Element => {
   const editorRef = useRef<HTMLDivElement>(null)
   // Tracks IME composition so Enter never submits mid-composition.
@@ -247,6 +250,7 @@ export const ComposerEditor = ({
       {mention.active ? (
         <SkillMentionPopup
           query={mention.query}
+          allowedSkillIds={allowedSkillIds}
           onSelect={handleSelectSkill}
           onClose={mention.cancel}
         />

--- a/src/renderer/src/pages/workspace/composer/SkillMentionPopup.render.test.tsx
+++ b/src/renderer/src/pages/workspace/composer/SkillMentionPopup.render.test.tsx
@@ -62,6 +62,25 @@ const pressKey = (key: string): void => {
 }
 
 describe('SkillMentionPopup', () => {
+  it('hides Skills outside a bound Specialist scope but leaves Main unfiltered', () => {
+    act(() => {
+      root.render(
+        <SkillMentionPopup
+          query=""
+          allowedSkillIds={['lit']}
+          onSelect={vi.fn()}
+          onClose={vi.fn()}
+        />
+      )
+    })
+    expect(options()).toHaveLength(1)
+    expect(options()[0]?.textContent).toContain('Literature Review')
+    act(() => {
+      root.render(<SkillMentionPopup query="" onSelect={vi.fn()} onClose={vi.fn()} />)
+    })
+    expect(options()).toHaveLength(3)
+  })
+
   it('filters by name or description and renders name, badge, and description', () => {
     act(() => {
       root.render(<SkillMentionPopup query="lit" onSelect={vi.fn()} onClose={vi.fn()} />)

--- a/src/renderer/src/pages/workspace/composer/SkillMentionPopup.tsx
+++ b/src/renderer/src/pages/workspace/composer/SkillMentionPopup.tsx
@@ -18,6 +18,7 @@ const TIER_DESCRIPTION = 0
 // editor, so this listens for navigation keys on document while mounted rather than owning focus.
 type SkillMentionPopupProps = {
   query: string
+  allowedSkillIds?: readonly string[]
   onSelect: (skill: SkillView) => void
   onClose: () => void
 }
@@ -31,6 +32,7 @@ const SOURCE_LABELS: Record<SkillSource, string> = {
 
 export const SkillMentionPopup = ({
   query,
+  allowedSkillIds,
   onSelect,
   onClose
 }: SkillMentionPopupProps): React.JSX.Element | null => {
@@ -50,11 +52,13 @@ export const SkillMentionPopup = ({
   // Empty query shows every skill in its original order.
   const matches = useMemo<SkillMatch[]>(() => {
     const needle = query.trim()
-    if (needle.length === 0) return skills.map((skill) => ({ skill, positions: [] }))
+    const allowed = allowedSkillIds ? new Set(allowedSkillIds) : undefined
+    const visibleSkills = allowed ? skills.filter((skill) => allowed.has(skill.id)) : skills
+    if (needle.length === 0) return visibleSkills.map((skill) => ({ skill, positions: [] }))
 
     const descNeedle = needle.toLowerCase()
     return (
-      skills
+      visibleSkills
         .map((skill) => {
           const nameMatch = fuzzyScore(needle, skill.name)
           if (nameMatch) {
@@ -75,7 +79,7 @@ export const SkillMentionPopup = ({
         .sort((a, b) => b.tier - a.tier || b.score - a.score)
         .map(({ skill, positions }) => ({ skill, positions }))
     )
-  }, [skills, query])
+  }, [skills, query, allowedSkillIds])
 
   const [activeIndex, setActiveIndex] = useState(0)
 

--- a/src/renderer/src/stores/session-store.test.ts
+++ b/src/renderer/src/stores/session-store.test.ts
@@ -2058,4 +2058,15 @@ describe('truncateSessionFromMessage', () => {
       status: 'error'
     })
   })
+
+  it('marks and clears the specialist switch reset flag', () => {
+    seedSession()
+    expect(useSessionStore.getState().sessions[0].specialistSwitchResetRequired).toBeUndefined()
+
+    useSessionStore.getState().markSpecialistSwitchResetRequired('session-1')
+    expect(useSessionStore.getState().sessions[0].specialistSwitchResetRequired).toBe(true)
+
+    useSessionStore.getState().clearSpecialistSwitchResetRequired('session-1')
+    expect(useSessionStore.getState().sessions[0].specialistSwitchResetRequired).toBeUndefined()
+  })
 })

--- a/src/renderer/src/stores/session-store.ts
+++ b/src/renderer/src/stores/session-store.ts
@@ -101,6 +101,10 @@ export type ChatSession = Omit<
   // Transient: the durable active Branch changed while the Agent/Notebook still hold the previous
   // Branch's volatile state. The next continuation must rebuild both contexts before prompting.
   branchContextResetRequired?: boolean
+  // Transient: a specialist switch replaced the live agent session (Claude bakes identity into the
+  // session at creation). The next continuation must replay conversation history so the new
+  // specialist retains continuity, without resetting the notebook kernel (unlike a Branch switch).
+  specialistSwitchResetRequired?: boolean
   // Transient aggregate of Reviewer, Notebook, Upload-finalization, and deletion activity that lives
   // outside this store. The workspace projects those operation gates here so direct store callers
   // cannot bypass disabled revision controls.
@@ -127,6 +131,8 @@ type AppendUserMessageInput = {
   agentBackendId?: PersistedChatSession['agentBackendId']
   agentModel?: string
   isPending?: boolean
+  // Immutable Specialist UUID; written once on session creation and never changed after.
+  specialistId?: string
 }
 
 type AppendPendingUserMessageInput = {
@@ -139,6 +145,8 @@ type AppendPendingUserMessageInput = {
   agentFrameworkId?: PersistedChatSession['agentFrameworkId']
   agentBackendId?: PersistedChatSession['agentBackendId']
   agentModel?: string
+  // Immutable Specialist UUID forwarded from the new-conversation draft picker.
+  specialistId?: string
 }
 
 type BindPendingSessionInput = {
@@ -253,6 +261,8 @@ type SessionStore = SessionStoreData & {
   activateMessageBranch: (sessionId: string, branchId: string) => void
   setBranchSwitchBlocked: (sessionId: string, blocked: boolean) => void
   clearBranchContextReset: (sessionId: string) => void
+  markSpecialistSwitchResetRequired: (sessionId: string) => void
+  clearSpecialistSwitchResetRequired: (sessionId: string) => void
   upsertToolActivity: (input: UpsertToolActivityInput) => void
   beginActivityGroup: (sessionId: string, groupId: string, title: string) => void
   completeActivityGroup: (sessionId: string) => void
@@ -263,6 +273,9 @@ type SessionStore = SessionStoreData & {
   setAutoReviewEnabled: (sessionId: string, enabled: boolean) => void
   // Sets the per-session enabled compute hosts (single-select, stored as array for extensibility).
   setEnabledComputeHosts: (sessionId: string, providerIds: string[]) => void
+  // Updates the persisted specialist UUID for an existing session after reconfigure succeeds.
+  // Passing undefined clears the binding (Main Agent). Persistence only stores the UUID.
+  setSessionSpecialistId: (sessionId: string, specialistId: string | undefined) => void
   // Toggles whether a conversation is pinned to the top section of the sidebar.
   togglePinned: (sessionId: string) => void
   // Sets or clears the per-session fix loop active flag. When true, the composer send button is
@@ -314,6 +327,7 @@ const stripTransientSessionState = (session: ChatSession): PersistedChatSession 
     compacting,
     agentStatus,
     branchContextResetRequired,
+    specialistSwitchResetRequired,
     branchSwitchBlocked,
     conversationGraphSyncBlocked,
     messages,
@@ -326,6 +340,7 @@ const stripTransientSessionState = (session: ChatSession): PersistedChatSession 
   void compacting
   void agentStatus
   void branchContextResetRequired
+  void specialistSwitchResetRequired
   void branchSwitchBlocked
   void conversationGraphSyncBlocked
 
@@ -385,6 +400,7 @@ const withTransientSessionState = (
     compacting: source.compacting,
     agentStatus: source.agentStatus,
     branchContextResetRequired: source.branchContextResetRequired,
+    specialistSwitchResetRequired: source.specialistSwitchResetRequired,
     branchSwitchBlocked: source.branchSwitchBlocked,
     conversationGraphSyncBlocked: source.conversationGraphSyncBlocked
   }
@@ -844,7 +860,8 @@ export const useSessionStore = create<SessionStore>((set, get) => ({
     agentFrameworkId,
     agentBackendId,
     agentModel,
-    isPending
+    isPending,
+    specialistId
   }) => {
     const trimmedContent = content.trim()
     const normalizedAgentBackendId = agentBackendId?.trim() || undefined
@@ -921,6 +938,8 @@ export const useSessionStore = create<SessionStore>((set, get) => ({
         agentFrameworkId,
         agentBackendId: normalizedAgentBackendId,
         agentModel: normalizedAgentModel,
+        // Specialist UUID written once at creation; never changed after bind.
+        ...(specialistId ? { specialistId } : {}),
         messages: [userMessage],
         activeRun,
         createdAt: now,
@@ -954,7 +973,8 @@ export const useSessionStore = create<SessionStore>((set, get) => ({
     permissionProfile,
     agentFrameworkId,
     agentBackendId,
-    agentModel
+    agentModel,
+    specialistId
   }) => {
     return get().appendUserMessage({
       sessionId: createPendingSessionId(),
@@ -967,6 +987,7 @@ export const useSessionStore = create<SessionStore>((set, get) => ({
       agentFrameworkId,
       agentBackendId,
       agentModel,
+      specialistId,
       isPending: true
     })
   },
@@ -2120,6 +2141,27 @@ export const useSessionStore = create<SessionStore>((set, get) => ({
     }))
   },
 
+  // Marks that a specialist switch replaced the live agent session; the next send replays history
+  // into the fresh session so the new specialist keeps conversation continuity. Distinct from
+  // branchContextResetRequired because it must NOT shut down the notebook kernel.
+  markSpecialistSwitchResetRequired: (sessionId) => {
+    set((state) => ({
+      sessions: state.sessions.map((session) =>
+        session.id === sessionId ? { ...session, specialistSwitchResetRequired: true } : session
+      )
+    }))
+  },
+
+  clearSpecialistSwitchResetRequired: (sessionId) => {
+    set((state) => ({
+      sessions: state.sessions.map((session) =>
+        session.id === sessionId
+          ? { ...session, specialistSwitchResetRequired: undefined }
+          : session
+      )
+    }))
+  },
+
   // Marks a session as blocked on a user permission decision.
   setPermissionPending: (sessionId) => {
     set((state) => ({
@@ -2187,6 +2229,22 @@ export const useSessionStore = create<SessionStore>((set, get) => ({
           ? {
               ...session,
               enabledComputeHosts: providerIds.length > 0 ? providerIds : undefined,
+              updatedAt: Date.now()
+            }
+          : session
+      )
+    }))
+  },
+
+  // Updates the persisted specialist UUID for an existing session (called after reconfigure succeeds).
+  // Passing undefined clears the binding (Main Agent). Session persistence stores only the UUID.
+  setSessionSpecialistId: (sessionId, specialistId) => {
+    set((state) => ({
+      sessions: state.sessions.map((session) =>
+        session.id === sessionId
+          ? {
+              ...session,
+              specialistId: specialistId ?? undefined,
               updatedAt: Date.now()
             }
           : session

--- a/src/renderer/src/stores/specialist-store.ts
+++ b/src/renderer/src/stores/specialist-store.ts
@@ -1,0 +1,65 @@
+import { create } from 'zustand'
+import type {
+  SpecialistListItem,
+  SpecialistProfileView,
+  CreateSpecialistInput,
+  UpdateSpecialistInput
+} from '../../../shared/specialist'
+
+type SpecialistStoreData = {
+  items: SpecialistListItem[]
+  isLoaded: boolean
+}
+
+type SpecialistStoreActions = {
+  load: () => Promise<void>
+  create: (input: CreateSpecialistInput) => Promise<SpecialistProfileView>
+  update: (input: UpdateSpecialistInput) => Promise<SpecialistProfileView>
+  setEnabled: (id: string, enabled: boolean) => Promise<void>
+  delete: (id: string, expectedRevision: number) => Promise<void>
+  duplicate: (id: string) => Promise<CreateSpecialistInput>
+}
+
+type SpecialistStore = SpecialistStoreData & SpecialistStoreActions
+
+const useSpecialistStore = create<SpecialistStore>((set) => ({
+  items: [],
+  isLoaded: false,
+
+  load: async () => {
+    const items = await window.api.specialist.list()
+    set({ items, isLoaded: true })
+  },
+
+  create: async (input: CreateSpecialistInput) => {
+    const view = await window.api.specialist.create(input)
+    // Reload the full list so Reviewer and ordering stay consistent.
+    const items = await window.api.specialist.list()
+    set({ items })
+    return view
+  },
+
+  update: async (input: UpdateSpecialistInput) => {
+    const view = await window.api.specialist.update(input)
+    // Reload the full list so Reviewer and ordering stay consistent.
+    const items = await window.api.specialist.list()
+    set({ items })
+    return view
+  },
+
+  setEnabled: async (id: string, enabled: boolean) => {
+    await window.api.specialist.setEnabled({ id, enabled })
+    const items = await window.api.specialist.list()
+    set({ items })
+  },
+
+  delete: async (id: string, expectedRevision: number) => {
+    await window.api.specialist.delete({ id, expectedRevision })
+    const items = await window.api.specialist.list()
+    set({ items })
+  },
+
+  duplicate: async (id: string) => window.api.specialist.duplicate({ id })
+}))
+
+export { useSpecialistStore }

--- a/src/shared/acp.ts
+++ b/src/shared/acp.ts
@@ -275,6 +275,10 @@ export type AcpCreateSessionRequest = {
   // Scopes generated artifacts / notebooks to a project's storage subtree. Defaults per runtime.
   projectName?: string
   permissionProfile?: PermissionProfileId
+  // Immutable Specialist UUID to bind on first turn. Main process resolves the latest Profile at
+  // session-creation time — the renderer MUST NOT send systemPrompt or capability data, only the
+  // stable UUID. Absent or undefined means no specialist; use Main Agent.
+  specialistId?: string
 }
 
 export type AcpCreateSessionResponse = {
@@ -295,6 +299,8 @@ export type AcpResumeSessionRequest = {
   permissionProfile?: PermissionProfileId
   previousFrameworkId?: AgentFrameworkId
   previousBackendId?: string
+  // Durable session binding, supplied on restore so session/resume reissues the Specialist whitelist.
+  specialistId?: string
 }
 
 export type AcpCompactSessionRequest = {

--- a/src/shared/session-persistence.ts
+++ b/src/shared/session-persistence.ts
@@ -163,6 +163,10 @@ export type PersistedChatSession = {
   // Pins the conversation to a dedicated section at the top of the sidebar. Absent (older files) or
   // non-true restores as unpinned; only an explicit true keeps it pinned across restarts.
   pinned?: boolean
+  // Immutable Specialist UUID bound at session creation. Absent means no specialist binding (Main
+  // Agent). Written once when the session is created and never changed; the Profile is resolved
+  // fresh from ProfileService before every turn via the UUID.
+  specialistId?: string
   messages: PersistedChatMessage[]
   // Session JSON v2 authority. Flat messages/activities remain an active-Branch compatibility view.
   conversationGraph?: PersistedConversationGraph
@@ -1101,6 +1105,10 @@ const sanitizeSession = (
   if (activities.length > 0) sanitized.activities = activities
   if (activityGroups.length > 0) sanitized.activityGroups = activityGroups
   if (enabledComputeHosts.length > 0) sanitized.enabledComputeHosts = enabledComputeHosts
+  // Specialist UUID: accept any non-empty string. The main process validates it against ProfileService
+  // at send time; the sanitizer only ensures the value is safe to re-persist.
+  const specialistId = asString(session.specialistId)
+  if (specialistId) sanitized.specialistId = specialistId
 
   // Normalize interrupted runtime state before constructing a graph for legacy sessions. Otherwise
   // the compatibility message list becomes an error while the newly-created canonical graph retains

--- a/src/shared/settings.ts
+++ b/src/shared/settings.ts
@@ -1086,6 +1086,9 @@ export type CustomServerView = {
   description?: string
   transport: CustomServerTransport
   enabled: boolean
+  // Physical availability is independent of Main's enabled toggle. An invalid persisted server may
+  // remain visible to a Specialist but can never be selected or dispatched.
+  availability?: 'unavailable' | 'unauthenticated'
   // Display-only config summary (the command that runs, its args, or the remote URL). env/headers
   // are intentionally omitted — they may hold secrets and stay write-only from the UI.
   command?: string

--- a/src/shared/specialist.test.ts
+++ b/src/shared/specialist.test.ts
@@ -1,0 +1,201 @@
+import { describe, expect, it } from 'vitest'
+import {
+  validateSpecialistName,
+  validateSpecialistDescription,
+  validateCreateSpecialistInput,
+  validateUpdateSpecialistInput,
+  SPECIALIST_DESCRIPTION_MAX_LENGTH,
+  emptyFullAccessConfig,
+  emptySelectedConfig,
+  resolveEffectiveSpecialistSkills,
+  filterSpecialistConnectorSkills
+} from './specialist'
+
+describe('validateSpecialistName', () => {
+  it('accepts normal names', () => {
+    expect(validateSpecialistName('RNA-seq Reviewer', [])).toBeUndefined()
+    expect(validateSpecialistName('AB', [])).toBeUndefined()
+    expect(validateSpecialistName('My Bot 2', [])).toBeUndefined()
+  })
+
+  it('rejects empty / whitespace-only name', () => {
+    expect(validateSpecialistName('', [])).toBeTruthy()
+    expect(validateSpecialistName('   ', [])).toBeTruthy()
+  })
+
+  it('rejects names over 80 chars', () => {
+    expect(validateSpecialistName('A'.repeat(81), [])).toBeTruthy()
+  })
+
+  it('accepts exactly 80 chars', () => {
+    expect(validateSpecialistName('A'.repeat(80), [])).toBeUndefined()
+  })
+
+  it('allows lowercase and spaces (human-readable)', () => {
+    expect(validateSpecialistName('rna-seq reviewer', [])).toBeUndefined()
+  })
+
+  it('rejects duplicate name via existingNames fallback', () => {
+    expect(validateSpecialistName('My Bot', ['My Bot'])).toBeTruthy()
+  })
+
+  it('rejects duplicate name via existingIds map', () => {
+    const map = new Map([['My Bot', 'id-1']])
+    expect(validateSpecialistName('My Bot', [], undefined, map)).toBeTruthy()
+  })
+
+  it('allows same name for self when editing (currentId matches)', () => {
+    const map = new Map([['My Bot', 'id-1']])
+    expect(validateSpecialistName('My Bot', [], 'id-1', map)).toBeUndefined()
+  })
+})
+
+describe('validateCreateSpecialistInput', () => {
+  it('returns empty array for valid input', () => {
+    expect(validateCreateSpecialistInput({ name: 'RNA Reviewer' }, [])).toHaveLength(0)
+  })
+
+  it('returns name error when empty', () => {
+    const errors = validateCreateSpecialistInput({ name: '' }, [])
+    expect(errors.some((e) => e.field === 'name')).toBe(true)
+  })
+
+  it('returns name error when name is duplicate', () => {
+    const map = new Map([['My Bot', 'id-1']])
+    const errors = validateCreateSpecialistInput({ name: 'My Bot' }, [], map)
+    expect(errors.some((e) => e.field === 'name')).toBe(true)
+  })
+})
+
+describe('validateSpecialistDescription', () => {
+  it('accepts an empty description (optional field)', () => {
+    expect(validateSpecialistDescription('')).toBeUndefined()
+  })
+
+  it('accepts a description at exactly the max length', () => {
+    expect(
+      validateSpecialistDescription('a'.repeat(SPECIALIST_DESCRIPTION_MAX_LENGTH))
+    ).toBeUndefined()
+  })
+
+  it('rejects a description over the max length', () => {
+    expect(validateSpecialistDescription('a'.repeat(SPECIALIST_DESCRIPTION_MAX_LENGTH + 1))).toBe(
+      `Description must be ${SPECIALIST_DESCRIPTION_MAX_LENGTH} characters or fewer.`
+    )
+  })
+})
+
+describe('description validation in create/update inputs', () => {
+  it('surfaces a description error on create when too long', () => {
+    const errors = validateCreateSpecialistInput(
+      { name: 'Bot', description: 'a'.repeat(SPECIALIST_DESCRIPTION_MAX_LENGTH + 1) },
+      []
+    )
+    expect(errors.some((e) => e.field === 'description')).toBe(true)
+  })
+
+  it('surfaces a description error on update when too long', () => {
+    const errors = validateUpdateSpecialistInput(
+      { id: 'x', revision: 1, description: 'a'.repeat(SPECIALIST_DESCRIPTION_MAX_LENGTH + 1) },
+      []
+    )
+    expect(errors.some((e) => e.field === 'description')).toBe(true)
+  })
+})
+
+describe('empty config helpers', () => {
+  it('emptyFullAccessConfig returns correct shape', () => {
+    const cfg = emptyFullAccessConfig()
+    expect(cfg.excludedSkillIds).toEqual([])
+    expect(cfg.excludedConnectorIds).toEqual([])
+    expect(cfg.connectorTools).toEqual([])
+  })
+
+  it('emptySelectedConfig returns correct shape', () => {
+    const cfg = emptySelectedConfig()
+    expect(cfg.skillIds).toEqual([])
+    expect(cfg.connectorIds).toEqual([])
+    expect(cfg.connectorTools).toEqual([])
+  })
+})
+
+describe('resolveEffectiveSpecialistSkills', () => {
+  const catalog = [
+    { id: 'disabled-in-main', frameworkName: 'Disabled In Main' },
+    { id: 'future-skill', frameworkName: 'Future Skill' }
+  ]
+  const base = {
+    capabilityMode: 'full' as const,
+    fullAccess: emptyFullAccessConfig(),
+    selectedCapabilities: emptySelectedConfig()
+  }
+
+  it('full access includes current and newly discovered catalog entries, minus exclusions', () => {
+    expect(resolveEffectiveSpecialistSkills(base, catalog)).toMatchObject({
+      kind: 'specialist',
+      skillIds: ['disabled-in-main', 'future-skill']
+    })
+    expect(
+      resolveEffectiveSpecialistSkills(
+        { ...base, fullAccess: { ...emptyFullAccessConfig(), excludedSkillIds: ['future-skill'] } },
+        catalog
+      )
+    ).toMatchObject({ skillIds: ['disabled-in-main'] })
+  })
+
+  it('selected access retains explicit inclusions and reports only missing inclusions', () => {
+    expect(
+      resolveEffectiveSpecialistSkills(
+        {
+          ...base,
+          capabilityMode: 'selected',
+          selectedCapabilities: { ...emptySelectedConfig(), skillIds: ['disabled-in-main', 'gone'] }
+        },
+        catalog
+      )
+    ).toEqual({
+      kind: 'specialist',
+      skillIds: ['disabled-in-main'],
+      frameworkNames: ['Disabled In Main'],
+      missingSkillIds: ['gone']
+    })
+  })
+
+  it('keeps Main unscoped', () => {
+    expect(resolveEffectiveSpecialistSkills(undefined, catalog)).toEqual({ kind: 'main' })
+  })
+})
+
+describe('filterSpecialistConnectorSkills', () => {
+  const provisioned = ['mcp-chemistry', 'mcp-literature', 'mcp-pubmed']
+
+  it('selected mode keeps only connectorIds', () => {
+    const specialist = {
+      capabilityMode: 'selected' as const,
+      fullAccess: emptyFullAccessConfig(),
+      selectedCapabilities: { ...emptySelectedConfig(), connectorIds: ['chemistry'] }
+    }
+    expect(filterSpecialistConnectorSkills(provisioned, specialist)).toEqual(['mcp-chemistry'])
+  })
+
+  it('full mode keeps all provisioned except excludedConnectorIds', () => {
+    const specialist = {
+      capabilityMode: 'full' as const,
+      fullAccess: { ...emptyFullAccessConfig(), excludedConnectorIds: ['literature'] },
+      selectedCapabilities: emptySelectedConfig()
+    }
+    expect(filterSpecialistConnectorSkills(provisioned, specialist)).toEqual([
+      'mcp-chemistry',
+      'mcp-pubmed'
+    ])
+  })
+
+  it('returns empty when no connector is allowed', () => {
+    const specialist = {
+      capabilityMode: 'selected' as const,
+      fullAccess: emptyFullAccessConfig(),
+      selectedCapabilities: { ...emptySelectedConfig(), connectorIds: ['nonexistent'] }
+    }
+    expect(filterSpecialistConnectorSkills(provisioned, specialist)).toEqual([])
+  })
+})

--- a/src/shared/specialist.ts
+++ b/src/shared/specialist.ts
@@ -1,0 +1,363 @@
+// Shared types and validation for Personal Specialist Profiles.
+// All mutation rules live here so Settings, SDK, and runtime share one contract.
+
+// IPC channel names shared between main, preload, and renderer.
+export const SPECIALIST_IPC = {
+  LIST: 'specialist:list',
+  CREATE: 'specialist:create',
+  UPDATE: 'specialist:update',
+  SET_ENABLED: 'specialist:set-enabled',
+  DELETE: 'specialist:delete',
+  DUPLICATE: 'specialist:duplicate',
+  CATALOG_CHANGED: 'specialist:catalog-changed',
+  // Session switching (issue 07): per-session mutable binding.
+  SET_SESSION_SPECIALIST: 'specialist:set-session-specialist',
+  RESOLVE_SESSION_SPECIALIST: 'specialist:resolve-session-specialist'
+} as const
+
+// Session switching request types — resolution type is declared after SpecialistProfileView below.
+export type SetSessionSpecialistRequest = {
+  sessionId: string
+  // undefined clears the binding (reverts to Main Agent).
+  specialistId: string | undefined
+}
+
+// Response for SET_SESSION_SPECIALIST. `contextReset` is true when the live agent session was
+// replaced so the new specialist identity could take effect (Claude bakes identity into session
+// _meta at creation, so a switch requires a fresh session). When true, the renderer must replay the
+// conversation history into the next prompt so the new specialist retains continuity.
+export type SetSessionSpecialistResponse = {
+  contextReset: boolean
+}
+
+export type ResolveSessionSpecialistRequest = {
+  sessionId: string
+}
+
+// The capability scope mode for a specialist.
+export type SpecialistCapabilityMode = 'full' | 'selected'
+
+// Per-connector tool-level rules. Uses bare method names (no connector prefix).
+export type ConnectorToolRule = {
+  connectorId: string
+  includedMethods?: string[]
+  excludedMethods?: string[]
+  includeToolsPattern?: string
+  excludeToolsPattern?: string
+}
+
+// Full access mode config: default-include-all, explicit exclusions only.
+export type SpecialistFullAccessConfig = {
+  excludedSkillIds: string[]
+  excludedConnectorIds: string[]
+  connectorTools: ConnectorToolRule[]
+}
+
+// Selected capabilities mode config: default-exclude-all, explicit inclusions only.
+export type SpecialistSelectedConfig = {
+  skillIds: string[]
+  connectorIds: string[]
+  connectorTools: ConnectorToolRule[]
+}
+
+// A Skill catalog entry deliberately uses the durable app id for policy and the framework-facing
+// name only at the transport boundary. Main Agent enablement is not represented here: Specialists
+// own their capability policy independently of the Main Agent's disabled-skill preference.
+export type SpecialistSkillCatalogEntry = {
+  id: string
+  frameworkName: string
+  displayName?: string
+}
+
+export type EffectiveSpecialistSkills =
+  | { kind: 'main' }
+  | { kind: 'unavailable'; reason: string }
+  | {
+      kind: 'specialist'
+      skillIds: string[]
+      frameworkNames: string[]
+      missingSkillIds: string[]
+    }
+
+// Resolve against the live catalog; callers must not snapshot catalog contents into a profile or
+// session. Full access includes future entries by construction, while selected is an explicit list.
+export const resolveEffectiveSpecialistSkills = (
+  specialist:
+    | Pick<SpecialistProfileView, 'capabilityMode' | 'fullAccess' | 'selectedCapabilities'>
+    | undefined,
+  catalog: SpecialistSkillCatalogEntry[]
+): EffectiveSpecialistSkills => {
+  if (specialist === undefined) return { kind: 'main' }
+  const byId = new Map(catalog.map((skill) => [skill.id, skill]))
+  const requestedIds =
+    specialist.capabilityMode === 'full'
+      ? catalog
+          .filter((skill) => !specialist.fullAccess.excludedSkillIds.includes(skill.id))
+          .map((skill) => skill.id)
+      : specialist.selectedCapabilities.skillIds
+
+  const skillIds: string[] = []
+  const frameworkNames: string[] = []
+  const missingSkillIds: string[] = []
+  for (const id of requestedIds) {
+    const skill = byId.get(id)
+    if (!skill) {
+      // Exclusions are valid durable references too, but a missing exclusion has no local effect.
+      if (specialist.capabilityMode === 'selected') missingSkillIds.push(id)
+      continue
+    }
+    if (skillIds.includes(id)) continue
+    skillIds.push(id)
+    frameworkNames.push(skill.frameworkName)
+  }
+  return { kind: 'specialist', skillIds, frameworkNames, missingSkillIds }
+}
+
+// Filters provisioned `mcp-<id>` connector skill names down to those the specialist is allowed to
+// discover. "selected" mode keeps only connectorIds; "full" mode keeps everything except
+// excludedConnectorIds. This makes a restrictive skill whitelist (Claude's options.skills) match the
+// specialist's connector capability scope, so the agent discovers only the connectors it can call.
+// The per-call ConnectorService gate enforces the same config at execution time.
+export const filterSpecialistConnectorSkills = (
+  connectorSkillNames: string[],
+  specialist: Pick<SpecialistProfileView, 'capabilityMode' | 'fullAccess' | 'selectedCapabilities'>
+): string[] => {
+  const isAllowed =
+    specialist.capabilityMode === 'full'
+      ? (connectorId: string) => !specialist.fullAccess.excludedConnectorIds.includes(connectorId)
+      : (connectorId: string) => specialist.selectedCapabilities.connectorIds.includes(connectorId)
+  return connectorSkillNames.filter((skillName) => {
+    const connectorId = skillName.replace(/^mcp-/, '')
+    return isAllowed(connectorId)
+  })
+}
+
+// Renderer-safe view of one specialist profile (no secret fields).
+export type SpecialistProfileView = {
+  id: string
+  name: string // immutable-reference-safe public UPPER_SNAKE identifier
+  displayName?: string
+  description: string
+  systemPrompt: string
+  iconKey?: string
+  colorKey?: string
+  enabled: boolean
+  capabilityMode: SpecialistCapabilityMode
+  fullAccess: SpecialistFullAccessConfig
+  selectedCapabilities: SpecialistSelectedConfig
+  revision: number
+}
+
+// The built-in Reviewer entry shown in the list (read-only, never a real profile).
+export type ReviewerEntry = {
+  kind: 'reviewer'
+  id: 'reviewer'
+}
+
+// Union for the list — either a real profile or the reviewer placeholder.
+export type SpecialistListItem = ({ kind: 'custom' } & SpecialistProfileView) | ReviewerEntry
+
+// Resolution of a session's specialist binding at send time (requires SpecialistProfileView above).
+// 'main'        — no binding, main agent is used.
+// 'bound'       — a valid enabled profile was found.
+// 'unavailable' — the bound UUID is unknown, disabled, or corrupt (send must be blocked).
+export type SessionSpecialistResolution =
+  | { kind: 'main' }
+  | { kind: 'bound'; profile: SpecialistProfileView }
+  | { kind: 'unavailable'; reason: string }
+
+// Input for creating a new specialist.
+export type CreateSpecialistInput = {
+  name: string
+  displayName?: string
+  description?: string
+  systemPrompt?: string
+  iconKey?: string
+  colorKey?: string
+  capabilityMode?: SpecialistCapabilityMode
+  fullAccess?: SpecialistFullAccessConfig
+  selectedCapabilities?: SpecialistSelectedConfig
+}
+
+// Input for updating an existing specialist. Both capability configurations are
+// deliberately independent of the active mode: switching modes must never throw
+// away the other mode's connector (or skill) selection. `revision` enables
+// optimistic concurrency (must match the stored record).
+export type UpdateSpecialistInput = {
+  id: string
+  revision: number
+  name?: string
+  displayName?: string
+  description?: string
+  systemPrompt?: string
+  iconKey?: string
+  colorKey?: string
+  capabilityMode?: SpecialistCapabilityMode
+  fullAccess?: SpecialistFullAccessConfig
+  selectedCapabilities?: SpecialistSelectedConfig
+}
+
+// Request / response types for IPC.
+export type CreateSpecialistRequest = CreateSpecialistInput
+export type UpdateSpecialistRequest = UpdateSpecialistInput
+
+export type SetSpecialistEnabledRequest = {
+  id: string
+  enabled: boolean
+}
+
+export type DeleteSpecialistRequest = { id: string; expectedRevision?: number }
+export type DuplicateSpecialistRequest = { id: string }
+
+// Validation error for a single field.
+export type SpecialistFieldError = {
+  field: 'name' | 'description' | 'systemPrompt'
+  message: string
+}
+
+// ---------------------------------------------------------------------------
+// Field length limits
+// ---------------------------------------------------------------------------
+
+// Hard caps shared by validation, the UI counters, and the maxLength attrs so
+// the three never drift apart.
+export const SPECIALIST_NAME_MAX_LENGTH = 80
+export const SPECIALIST_DISPLAY_NAME_MAX_LENGTH = 80
+export const SPECIALIST_DESCRIPTION_MAX_LENGTH = 200
+
+// ---------------------------------------------------------------------------
+// Name validation
+// ---------------------------------------------------------------------------
+
+// Legacy editor validation remains permissive; lifecycle/SDK mutations use the
+// strict public-name validator below.
+// Returns an error message string, or undefined when the name is valid.
+export const validateSpecialistName = (
+  name: string,
+  existingNames: string[],
+  currentId?: string, // pass for edit: skip self-collision
+  existingIds?: Map<string, string> // name -> id for duplicate detection
+): string | undefined => {
+  if (!name.trim()) return 'Name is required.'
+  if (name.trim().length > SPECIALIST_NAME_MAX_LENGTH) {
+    return `Name must be ${SPECIALIST_NAME_MAX_LENGTH} characters or fewer.`
+  }
+
+  // Duplicate check: skip self when editing.
+  const collision = existingIds?.get(name)
+  if (collision !== undefined && collision !== currentId) {
+    return 'Name is already in use.'
+  }
+  // Fallback when existingIds not provided.
+  if (!existingIds && existingNames.includes(name)) {
+    return 'Name is already in use.'
+  }
+
+  return undefined
+}
+
+// Validates the public-facing name. Allows letters, digits, spaces, hyphens, and underscores;
+// minimum 2 non-whitespace characters after trimming; maximum 80 to match the field maxLength.
+export const validateSpecialistPublicName = (name: string): string | undefined => {
+  const trimmed = name.trim()
+  if (trimmed.length < 2) return 'Name must be at least 2 characters.'
+  if (trimmed.length > 80) return 'Name must be 80 characters or fewer.'
+  if (!/^[\p{L}0-9 _-]+$/u.test(trimmed))
+    return 'Name may only contain letters, digits, spaces, hyphens, and underscores.'
+  return undefined
+}
+
+export const validateSpecialistDisplayName = (displayName: string): string | undefined => {
+  if (!displayName.trim()) return 'Display name is required.'
+  if (displayName.length > SPECIALIST_DISPLAY_NAME_MAX_LENGTH) {
+    return `Display name must be ${SPECIALIST_DISPLAY_NAME_MAX_LENGTH} characters or fewer.`
+  }
+  return undefined
+}
+
+// ---------------------------------------------------------------------------
+// Description validation
+// ---------------------------------------------------------------------------
+
+// Validate a candidate description. Empty is allowed (the field is optional).
+// Returns an error message string, or undefined when the description is valid.
+export const validateSpecialistDescription = (description: string): string | undefined => {
+  if (description.length > SPECIALIST_DESCRIPTION_MAX_LENGTH) {
+    return `Description must be ${SPECIALIST_DESCRIPTION_MAX_LENGTH} characters or fewer.`
+  }
+  return undefined
+}
+
+// Validate all fields for a CreateSpecialistInput.
+// Returns an array of field errors (empty = valid).
+export const validateCreateSpecialistInput = (
+  input: CreateSpecialistInput,
+  existingNames: string[],
+  existingIds?: Map<string, string>
+): SpecialistFieldError[] => {
+  const errors: SpecialistFieldError[] = []
+
+  const nameError = validateSpecialistName(input.name, existingNames, undefined, existingIds)
+  if (nameError) errors.push({ field: 'name', message: nameError })
+
+  // Apply public-name format rules when a displayName is sent (i.e. via the editor
+  // which always sends displayName). This ensures the error surfaces on the field,
+  // not after a round-trip to main.
+  if (input.displayName !== undefined) {
+    const publicNameError = validateSpecialistPublicName(input.name)
+    if (publicNameError) errors.push({ field: 'name', message: publicNameError })
+  }
+
+  if (input.description !== undefined) {
+    const descriptionError = validateSpecialistDescription(input.description)
+    if (descriptionError) errors.push({ field: 'description', message: descriptionError })
+  }
+
+  return errors
+}
+
+// Validate the provided (partial) fields for an UpdateSpecialistInput.
+// Only fields that are present are validated. Name uniqueness skips the
+// specialist's own id (`input.id`) so self-rename is allowed.
+export const validateUpdateSpecialistInput = (
+  input: UpdateSpecialistInput,
+  existingNames: string[],
+  existingIds?: Map<string, string>
+): SpecialistFieldError[] => {
+  const errors: SpecialistFieldError[] = []
+
+  if (input.name !== undefined) {
+    const nameError = validateSpecialistName(input.name, existingNames, input.id, existingIds)
+    if (nameError) errors.push({ field: 'name', message: nameError })
+
+    // Apply same public-name format rules when displayName is present, keeping
+    // create and update symmetric.
+    if (input.displayName !== undefined) {
+      const publicNameError = validateSpecialistPublicName(input.name)
+      if (publicNameError) errors.push({ field: 'name', message: publicNameError })
+    }
+  }
+
+  if (input.description !== undefined) {
+    const descriptionError = validateSpecialistDescription(input.description)
+    if (descriptionError) errors.push({ field: 'description', message: descriptionError })
+  }
+
+  return errors
+}
+
+// ---------------------------------------------------------------------------
+// Empty config helpers
+// ---------------------------------------------------------------------------
+
+export const emptyFullAccessConfig = (): SpecialistFullAccessConfig => ({
+  excludedSkillIds: [],
+  excludedConnectorIds: [],
+  connectorTools: []
+})
+
+export const emptySelectedConfig = (): SpecialistSelectedConfig => ({
+  skillIds: [],
+  connectorIds: [],
+  connectorTools: []
+})


### PR DESCRIPTION
## Problem

Every conversation runs as the generic Main Agent with the full skill/connector catalog. There is no way to define a reusable agent identity (name, avatar, system-prompt persona) and scope what it can do per conversation, so users repeatedly re-explain context and cannot enforce a narrower capability surface for a given task.

## Proposed change

Introduce **Personal Specialists** — user-defined agent profiles with scoped capabilities and consistent identity, bound per conversation.

- **Profile service & storage**: a main-process `ProfileService` over an atomic settings repository (`specialists.json`), with a central validator, optimistic-concurrency revision checks, and a one-way `displayName ?? name` migration. Shared schema/types live in `src/shared/specialist.ts`.
- **IPC & preload surface**: specialist CRUD + `SET_SESSION_SPECIALIST` / `RESOLVE_SESSION_SPECIALIST` channels; `SPECIALIST_IPC` defined in `shared/` (preload is `sandbox:true`, so it cannot import from `src/main/`).
- **Settings UI**: `SpecialistsPanel` list (inline category tabs with counts, click-to-edit) and `SpecialistEditor` (avatar/icon/color, name, description with live counters, capabilities, revision-conflict banner with Reload).
- **Identity from the first turn**: the chosen specialist UUID rides the create-session request; the main process resolves the live profile (never trusts a renderer snapshot) and fails closed if it is disabled/deleted/corrupt.
  - **Claude Code**: identity via a `claude_code` preset append + a restrictive `skills` whitelist.
  - **Codex / OpenCode**: identity re-applied as a per-turn prompt prefix (no native per-session skill whitelist exists yet — see non-goals).
- **Session binding & hot-switching**: `SessionBindingService` resolves the bound profile against the live catalog (`main`, `bound`, or `unavailable`). Existing sessions can switch specialists mid-conversation; running switches are deferred behind a **reconfigure barrier** that fails closed (draft preserved, no user turn on failure), with a "Switches after this response" chip and a Retry / Choose another / Use None failure banner.
- **Capabilities UI**: a single *Full access* option (default) or a symmetric Skills/Connectors whitelist (tabbed, searchable native dropdown). Persisted-but-unavailable IDs stay visible and removable.
- **Connector gating**: provisioned `mcp-*` connector skills are exposed in the specialist whitelist so Claude discovers connector tools; the per-call `ConnectorService` gate re-enforces the same config at execution time, and `sessionId` is forwarded in `host.mcp` so the gate no longer rejects agent calls with `missing_session`.
- **Unified agent controls menu**: the standalone specialist picker and the SSH host list fold into hover submenus (`DropdownMenuSub`) inside the composer's agent-controls menu.

```mermaid
flowchart LR
  subgraph Renderer
    P["Specialist picker<br/>draft UUID"] --> CS["createSession<br/>specialistId"]
  end
  CS --> RT["AcpRuntime.createSession"]
  RT --> RES["ProfileService.resolve<br/>main / bound / unavailable"]
  RES -- unavailable --> FAIL["fail closed:<br/>block session create"]
  RES -- ok --> ID["identity append/prefix<br/>+ skill whitelist"]
  ID --> CC["Claude: preset append + skills"]
  ID --> CX["Codex/OpenCode: per-turn prefix"]
  RT --> SB["SessionBindingService<br/>bound specialistId"]
  SB --> SWITCH["hot-switch +<br/>reconfigure barrier"]
```

## Scope and non-goals

- **In scope**: profile CRUD, per-session binding, first-turn + mid-conversation identity, capability whitelisting for Claude, settings + workspace UI.
- **Non-goals**:
  - A native per-session skill whitelist for Codex/OpenCode — they currently receive the allowed-skill list as runtime guidance only, **not a security boundary**. Follow up when either runtime exposes a supported per-session capability API.
  - No SQLite/Prisma schema changes.
  - Connector execution enforcement is reused from the existing `ConnectorService` gate, not reimplemented.

## Acceptance criteria and validation

- `npm run typecheck` (node + web) — pass
- `npm run lint` — 0 errors (only pre-existing warnings in untouched files)
- `npm run test` (`vitest run`) — **8453 passed / 0 failed / 145 skipped** (rebased onto `main` incl. #505)
- New modules are unit-tested: `specialist/{repository,service,session-binding,identity,ipc}`, `specialist-identity-injection`, `shared/specialist`, plus renderer tests for `SpecialistEditor`, `SpecialistsPanel`, `SpecialistSubmenu`, and `WorkspacePage` send/reconfigure barrier.

## Review focus

- **Integration with recent `main`** (this branch is rebased onto current `main`, including #505):
  - `agent-framework/claude-code.ts` — main's built-in web tools (`tools: claude_code` preset, #513) are kept **alongside** the specialist `skills` whitelist.
  - `acp/runtime.ts` — specialist identity resolution and `extraAppends` are added, while `createSession` breadcrumb logs keep main's `diagnosticContext()` whitelist invariant.
  - `WorkspacePage.tsx` — main's `recordUserNavigation()` (#505) and `selectProjectSessionReviews` are preserved alongside the specialist store wiring and `setNewConversationSpecialistId`.
- **Fail-closed semantics** for both first-turn resolution and the running-switch reconfigure barrier (draft preserved on failure, no partial user turn).
- `SPECIALIST_IPC` placement in `shared/` (required for the sandboxed preload).
