### PR TITLE
feat(session-artifacts): add selective artifact downloads

### DIFF
--- a/docs/design.md
+++ b/docs/design.md
@@ -394,6 +394,7 @@ Workspace-only tokens without a shadcn counterpart, plus shadow tokens. For shar
 - Overlay: `fixed inset-0 bg-black/50`, using Radix state animations for open and close; compact workspace dialogs use `bg-black/25 backdrop-blur-[2px]`.
 - Delete confirmation copy must include the session name and state that session artifacts remain in the project.
 - Rename dialog input uses `h-9 rounded-lg border-border-200 bg-bg-000 text-sm text-text-000 placeholder:text-text-100` and a subtle `ring-border-200/25` focus ring.
+- Session Artifact download dialog: use a scrollable `Dialog` up to `640px` wide and `80svh` high, with a compact header, an artifact checklist, and a persistent footer. Repair an incomplete Project Files index before treating the list as authoritative. Select every Artifact by default; show the selected/total count, file type, and size; disable download when none are selected; and keep failed items selected after a partial batch download.
 
 ### DropdownMenu / Popover / Select
 
@@ -405,7 +406,8 @@ Workspace-only tokens without a shadcn counterpart, plus shadow tokens. For shar
 - Session action menu content: `z-modal min-w-[9rem] rounded-xl border-[0.5px] border-border-200 bg-bg-000 p-1.5 shadow-menu`.
 - Session action trigger uses `MoreVertical`, opacity reveal on row hover/focus/menu-open, and an `aria-label` that includes the session title.
 - Session action items: `flex w-full cursor-pointer items-center gap-2 rounded-lg px-2 py-1.5 text-left text-sm text-text-100 data-[highlighted]:bg-bg-200 data-[highlighted]:text-text-000`.
-- Destructive session item: `text-danger-000 data-[highlighted]:bg-danger-900`; the menu includes only `Rename…` and `Delete`.
+- Destructive session item: `text-danger-000 data-[highlighted]:bg-danger-900`.
+- Group the Session action menu as: `Pin`/`Unpin` and `Rename…`; separator; `Download all artifacts` and `View notebook`; separator; destructive `Delete`.
 - Select trigger: `h-8 rounded-lg border border-border bg-card px-2.5`; hover and `data-state=open` use `bg-muted`, and keyboard focus uses the shared 3px ring.
 - Select content uses the same overscroll containment, surface, border, radius, and shadow as DropdownMenu. Options are `min-h-8 rounded-lg`; keyboard highlight uses `bg-muted text-foreground`.
 - Menus do not use a page scrim.
@@ -579,44 +581,44 @@ Workspace-only tokens without a shadcn counterpart, plus shadow tokens. For shar
 
 ## Clickable Area Guidelines
 
-| Area              | Clickable part                       | shadcn pattern                                                                           |
-| ----------------- | ------------------------------------ | ---------------------------------------------------------------------------------------- |
-| Home              | Account menu                         | `Button ghost icon` + `DropdownMenu`                                                     |
-| Home              | Main create button                   | `Button default` or `Button outline size=sm`                                             |
-| Home              | List row                             | `button` / `Link` + `hover:bg-accent`                                                    |
-| Home              | Row actions                          | `Button ghost icon` + opacity reveal                                                     |
-| Dialog            | Close                                | `DialogClose` or `Button ghost icon`                                                     |
-| Dialog            | Cancel / confirm                     | `DialogFooter` + `Button secondary/default`                                              |
-| Settings          | Left navigation                      | `Button ghost` or `TabsTrigger`; active uses `bg-muted`                                  |
-| Settings          | Back / forward                       | `size-7` icon `button` (`ArrowLeft` / `ArrowRight`), `disabled:opacity-40`               |
-| Settings          | Breadcrumb root                      | Text `button` (`text-muted-foreground hover:text-foreground`)                            |
-| Settings          | Maximize / restore                   | `size-7` icon `button` (`Maximize2` / `Minimize2`)                                       |
-| Settings          | Close                                | `size-7` icon `button` (`X`)                                                             |
-| Settings          | Select field                         | `Select`                                                                                 |
-| Skills            | Add skill                            | Neutral `DropdownMenu` trigger (`border border-border bg-card`) + `Plus` / `ChevronDown` |
-| Skills            | Group header                         | Full-width collapse `button` + rotating `ChevronDown`                                    |
-| Skills            | Skill row                            | Flex-1 `button` → detail; hover reveals no extra chrome                                  |
-| Skills            | Edit / delete                        | `SettingsIconAction` (`Button ghost icon-sm` + `Tooltip`)                                |
-| Skills            | Enable toggle                        | Shared shadcn `Switch`                                                                   |
-| Skills            | Import selected                      | Neutral `button` (`border border-border bg-card`), not primary                           |
-| Sidebar           | Back / collapse                      | `Sidebar` + `Button ghost icon`                                                          |
-| Sidebar           | Navigation row                       | `SidebarMenuButton`                                                                      |
-| Workspace sidebar | New conversation                     | `button` + `hover:bg-bg-300 cursor-pointer`                                              |
-| Workspace sidebar | Session row                          | Nested `button`; wrapper owns hover/active only                                          |
-| Workspace sidebar | Session actions                      | Icon `button` + opacity reveal + `DropdownMenu`                                          |
-| Workspace sidebar | Settings                             | Icon `button` + `hover:bg-bg-300 cursor-pointer`                                         |
-| Activity stream   | Tool row                             | `Button ghost`-style row, hover `bg-foreground/[0.04]`                                   |
-| Activity stream   | Link / reference                     | `text-primary hover:underline`                                                           |
-| Activity stream   | Output card                          | `Card` or button card                                                                    |
-| Composer          | Add / options / send                 | `Button ghost icon`                                                                      |
-| Composer          | Text field                           | `Textarea` or contenteditable shell, preserving shadcn focus ring                        |
-| Session menu      | Rename / delete                      | `DropdownMenu.Item`; destructive delete uses `text-danger-000`                           |
-| Workspace dialogs | Rename / delete confirm              | `RenameSessionDialog` uses `bg-text-000`; `DeleteSessionDialog` uses `bg-danger-000`     |
-| Viewer            | Tab                                  | `TabsTrigger`                                                                            |
-| Viewer            | More / fullscreen / download / close | `Button ghost icon` + `Tooltip`                                                          |
-| File library      | Search                               | `Input` / `CommandInput`                                                                 |
-| File library      | Grid/list switch                     | `ToggleGroup type="single"`; hover `bg-muted`, selected `bg-bg-400`                      |
-| File library      | File card / file row                 | `Card` / button row + neutral hover `bg-bg-100` / `bg-bg-200`                            |
+| Area              | Clickable part                                       | shadcn pattern                                                                           |
+| ----------------- | ---------------------------------------------------- | ---------------------------------------------------------------------------------------- |
+| Home              | Account menu                                         | `Button ghost icon` + `DropdownMenu`                                                     |
+| Home              | Main create button                                   | `Button default` or `Button outline size=sm`                                             |
+| Home              | List row                                             | `button` / `Link` + `hover:bg-accent`                                                    |
+| Home              | Row actions                                          | `Button ghost icon` + opacity reveal                                                     |
+| Dialog            | Close                                                | `DialogClose` or `Button ghost icon`                                                     |
+| Dialog            | Cancel / confirm                                     | `DialogFooter` + `Button secondary/default`                                              |
+| Settings          | Left navigation                                      | `Button ghost` or `TabsTrigger`; active uses `bg-muted`                                  |
+| Settings          | Back / forward                                       | `size-7` icon `button` (`ArrowLeft` / `ArrowRight`), `disabled:opacity-40`               |
+| Settings          | Breadcrumb root                                      | Text `button` (`text-muted-foreground hover:text-foreground`)                            |
+| Settings          | Maximize / restore                                   | `size-7` icon `button` (`Maximize2` / `Minimize2`)                                       |
+| Settings          | Close                                                | `size-7` icon `button` (`X`)                                                             |
+| Settings          | Select field                                         | `Select`                                                                                 |
+| Skills            | Add skill                                            | Neutral `DropdownMenu` trigger (`border border-border bg-card`) + `Plus` / `ChevronDown` |
+| Skills            | Group header                                         | Full-width collapse `button` + rotating `ChevronDown`                                    |
+| Skills            | Skill row                                            | Flex-1 `button` → detail; hover reveals no extra chrome                                  |
+| Skills            | Edit / delete                                        | `SettingsIconAction` (`Button ghost icon-sm` + `Tooltip`)                                |
+| Skills            | Enable toggle                                        | Shared shadcn `Switch`                                                                   |
+| Skills            | Import selected                                      | Neutral `button` (`border border-border bg-card`), not primary                           |
+| Sidebar           | Back / collapse                                      | `Sidebar` + `Button ghost icon`                                                          |
+| Sidebar           | Navigation row                                       | `SidebarMenuButton`                                                                      |
+| Workspace sidebar | New conversation                                     | `button` + `hover:bg-bg-300 cursor-pointer`                                              |
+| Workspace sidebar | Session row                                          | Nested `button`; wrapper owns hover/active only                                          |
+| Workspace sidebar | Session actions                                      | Icon `button` + opacity reveal + `DropdownMenu`                                          |
+| Workspace sidebar | Settings                                             | Icon `button` + `hover:bg-bg-300 cursor-pointer`                                         |
+| Activity stream   | Tool row                                             | `Button ghost`-style row, hover `bg-foreground/[0.04]`                                   |
+| Activity stream   | Link / reference                                     | `text-primary hover:underline`                                                           |
+| Activity stream   | Output card                                          | `Card` or button card                                                                    |
+| Composer          | Add / options / send                                 | `Button ghost icon`                                                                      |
+| Composer          | Text field                                           | `Textarea` or contenteditable shell, preserving shadcn focus ring                        |
+| Session menu      | Pin / rename / Artifact download / notebook / delete | `DropdownMenu.Item`; destructive delete uses `text-danger-000`                           |
+| Workspace dialogs | Rename / delete / Artifact download                  | Compact dialog chrome; download uses a scrollable checklist and persistent footer        |
+| Viewer            | Tab                                                  | `TabsTrigger`                                                                            |
+| Viewer            | More / fullscreen / download / close                 | `Button ghost icon` + `Tooltip`                                                          |
+| File library      | Search                                               | `Input` / `CommandInput`                                                                 |
+| File library      | Grid/list switch                                     | `ToggleGroup type="single"`; hover `bg-muted`, selected `bg-bg-400`                      |
+| File library      | File card / file row                                 | `Card` / button row + neutral hover `bg-bg-100` / `bg-bg-200`                            |
 
 ## Language Guidelines
 

--- a/src/main/file-save.test.ts
+++ b/src/main/file-save.test.ts
@@ -1,5 +1,5 @@
 import { beforeEach, describe, expect, it, vi } from 'vitest'
-import { mkdtemp, readFile, rename, rm, writeFile } from 'node:fs/promises'
+import { mkdir, mkdtemp, readFile, rename, rm, writeFile } from 'node:fs/promises'
 import { tmpdir } from 'node:os'
 import { join } from 'node:path'
 
@@ -7,11 +7,12 @@ const downloadsPath = join('/Users/example', 'Downloads')
 
 const handlers = new Map<string, (event: unknown, payload?: unknown) => unknown>()
 const showSaveDialog = vi.hoisted(() => vi.fn())
+const showOpenDialog = vi.hoisted(() => vi.fn())
 
 vi.mock('electron', () => ({
   app: { getPath: vi.fn(() => '/Users/example/Downloads') },
   BrowserWindow: { fromWebContents: vi.fn(() => null) },
-  dialog: { showSaveDialog },
+  dialog: { showOpenDialog, showSaveDialog },
   ipcMain: {
     handle: (channel: string, handler: (event: unknown, payload?: unknown) => unknown) => {
       handlers.set(channel, handler)
@@ -24,7 +25,231 @@ const { registerFileSaveHandlers } = await import('./file-save')
 describe('file save IPC handlers', () => {
   beforeEach(() => {
     handlers.clear()
+    showOpenDialog.mockReset()
     showSaveDialog.mockReset()
+  })
+
+  it('exports one selected Session Artifact through Save As', async () => {
+    const root = await mkdtemp(join(tmpdir(), 'open-science-save-session-artifact-'))
+    const sourcePath = join(root, 'managed-report.csv')
+    const destinationPath = join(root, 'downloaded-report.csv')
+    await writeFile(sourcePath, 'artifact bytes')
+    const resolveSessionArtifactFilePath = vi.fn().mockResolvedValue(sourcePath)
+    showSaveDialog.mockResolvedValue({ canceled: false, filePath: destinationPath })
+    registerFileSaveHandlers({ resolveSessionArtifactFilePath } as never)
+
+    try {
+      const result = await handlers.get('file:save-session-artifacts')!(
+        { sender: {} },
+        {
+          projectId: 'project-1',
+          sessionId: 'session-1',
+          files: [{ path: 'artifact://report', suggestedName: 'report.csv' }]
+        }
+      )
+
+      expect(resolveSessionArtifactFilePath).toHaveBeenCalledWith(
+        'project-1',
+        'session-1',
+        'artifact://report'
+      )
+      expect(showSaveDialog).toHaveBeenCalledWith(
+        expect.objectContaining({
+          defaultPath: join(downloadsPath, 'report.csv'),
+          title: 'Save artifact'
+        })
+      )
+      expect(result).toEqual({ saved: true, filePaths: [destinationPath] })
+      await expect(readFile(destinationPath, 'utf8')).resolves.toBe('artifact bytes')
+    } finally {
+      await rm(root, { recursive: true, force: true })
+    }
+  })
+
+  it('exports multiple selected Session Artifacts after choosing one destination folder', async () => {
+    const root = await mkdtemp(join(tmpdir(), 'open-science-save-session-artifacts-'))
+    const sourceA = join(root, 'managed-a.csv')
+    const sourceB = join(root, 'managed-b.png')
+    const destinationDirectory = join(root, 'downloads')
+    await writeFile(sourceA, 'artifact a')
+    await writeFile(sourceB, 'artifact b')
+    await mkdir(destinationDirectory)
+    const resolveSessionArtifactFilePath = vi
+      .fn()
+      .mockResolvedValueOnce(sourceA)
+      .mockResolvedValueOnce(sourceB)
+    showOpenDialog.mockResolvedValue({ canceled: false, filePaths: [destinationDirectory] })
+    registerFileSaveHandlers({ resolveSessionArtifactFilePath } as never)
+
+    try {
+      const result = await handlers.get('file:save-session-artifacts')!(
+        { sender: {} },
+        {
+          projectId: 'project-1',
+          sessionId: 'session-1',
+          files: [
+            { path: 'artifact://a', suggestedName: 'a.csv' },
+            { path: 'artifact://b', suggestedName: 'b.png' }
+          ]
+        }
+      )
+
+      expect(showOpenDialog).toHaveBeenCalledTimes(1)
+      expect(showOpenDialog).toHaveBeenCalledWith(
+        expect.objectContaining({
+          defaultPath: downloadsPath,
+          properties: ['openDirectory', 'createDirectory'],
+          title: 'Choose where to save artifacts'
+        })
+      )
+      expect(result).toEqual({
+        saved: true,
+        filePaths: [join(destinationDirectory, 'a.csv'), join(destinationDirectory, 'b.png')]
+      })
+      await expect(readFile(join(destinationDirectory, 'a.csv'), 'utf8')).resolves.toBe(
+        'artifact a'
+      )
+      await expect(readFile(join(destinationDirectory, 'b.png'), 'utf8')).resolves.toBe(
+        'artifact b'
+      )
+    } finally {
+      await rm(root, { recursive: true, force: true })
+    }
+  })
+
+  it('keeps existing files and selected duplicate names when exporting multiple Artifacts', async () => {
+    const root = await mkdtemp(join(tmpdir(), 'open-science-save-artifact-collisions-'))
+    const sourceA = join(root, 'managed-a.csv')
+    const sourceB = join(root, 'managed-b.csv')
+    const destinationDirectory = join(root, 'downloads')
+    await writeFile(sourceA, 'artifact a')
+    await writeFile(sourceB, 'artifact b')
+    await mkdir(destinationDirectory)
+    await writeFile(join(destinationDirectory, 'report.csv'), 'existing download')
+    const resolveSessionArtifactFilePath = vi
+      .fn()
+      .mockResolvedValueOnce(sourceA)
+      .mockResolvedValueOnce(sourceB)
+    showOpenDialog.mockResolvedValue({ canceled: false, filePaths: [destinationDirectory] })
+    registerFileSaveHandlers({ resolveSessionArtifactFilePath } as never)
+
+    try {
+      const result = await handlers.get('file:save-session-artifacts')!(
+        { sender: {} },
+        {
+          projectId: 'project-1',
+          sessionId: 'session-1',
+          files: [
+            { path: 'artifact://a', suggestedName: 'report.csv' },
+            { path: 'artifact://b', suggestedName: 'report.csv' }
+          ]
+        }
+      )
+
+      expect(result).toEqual({
+        saved: true,
+        filePaths: [
+          join(destinationDirectory, 'report (2).csv'),
+          join(destinationDirectory, 'report (3).csv')
+        ]
+      })
+      await expect(readFile(join(destinationDirectory, 'report.csv'), 'utf8')).resolves.toBe(
+        'existing download'
+      )
+      await expect(readFile(join(destinationDirectory, 'report (2).csv'), 'utf8')).resolves.toBe(
+        'artifact a'
+      )
+      await expect(readFile(join(destinationDirectory, 'report (3).csv'), 'utf8')).resolves.toBe(
+        'artifact b'
+      )
+    } finally {
+      await rm(root, { recursive: true, force: true })
+    }
+  })
+
+  it('reports one failed Artifact while keeping the other batch exports', async () => {
+    const destinationDirectory = '/downloads/session-artifacts'
+    const closeA = vi.fn().mockResolvedValue(undefined)
+    const closeB = vi.fn().mockResolvedValue(undefined)
+    const copyA = vi.fn().mockResolvedValue(undefined)
+    const copyB = vi.fn().mockRejectedValue(new Error('disk full'))
+    showOpenDialog.mockResolvedValue({ canceled: false, filePaths: [destinationDirectory] })
+    registerFileSaveHandlers({
+      resolveSessionArtifactFilePath: vi
+        .fn()
+        .mockResolvedValueOnce('/managed/a.csv')
+        .mockResolvedValueOnce('/managed/b.csv'),
+      openManagedFile: vi
+        .fn()
+        .mockResolvedValueOnce({ copyTo: copyA, close: closeA })
+        .mockResolvedValueOnce({ copyTo: copyB, close: closeB })
+    } as never)
+
+    const result = await handlers.get('file:save-session-artifacts')!(
+      { sender: {} },
+      {
+        projectId: 'project-1',
+        sessionId: 'session-1',
+        files: [
+          { path: 'artifact://a', suggestedName: 'a.csv' },
+          { path: 'artifact://b', suggestedName: 'b.csv' }
+        ]
+      }
+    )
+
+    expect(result).toEqual({
+      saved: true,
+      filePaths: [join(destinationDirectory, 'a.csv')],
+      failures: [
+        {
+          path: 'artifact://b',
+          suggestedName: 'b.csv',
+          message: 'disk full'
+        }
+      ]
+    })
+    expect(closeA).toHaveBeenCalledTimes(1)
+    expect(closeB).toHaveBeenCalledTimes(1)
+  })
+
+  it('keeps exporting valid Artifacts when one selected source no longer resolves', async () => {
+    const destinationDirectory = '/downloads/session-artifacts'
+    const copyTo = vi.fn().mockResolvedValue(undefined)
+    const close = vi.fn().mockResolvedValue(undefined)
+    showOpenDialog.mockResolvedValue({ canceled: false, filePaths: [destinationDirectory] })
+    registerFileSaveHandlers({
+      resolveSessionArtifactFilePath: vi
+        .fn()
+        .mockRejectedValueOnce(new Error('Artifact no longer exists'))
+        .mockResolvedValueOnce('/managed/b.csv'),
+      openManagedFile: vi.fn().mockResolvedValue({ copyTo, close })
+    } as never)
+
+    const result = await handlers.get('file:save-session-artifacts')!(
+      { sender: {} },
+      {
+        projectId: 'project-1',
+        sessionId: 'session-1',
+        files: [
+          { path: 'artifact://missing', suggestedName: 'missing.csv' },
+          { path: 'artifact://b', suggestedName: 'b.csv' }
+        ]
+      }
+    )
+
+    expect(result).toEqual({
+      saved: true,
+      filePaths: [join(destinationDirectory, 'b.csv')],
+      failures: [
+        {
+          path: 'artifact://missing',
+          suggestedName: 'missing.csv',
+          message: 'Artifact no longer exists'
+        }
+      ]
+    })
+    expect(copyTo).toHaveBeenCalledWith(join(destinationDirectory, 'b.csv'), { exclusive: true })
+    expect(close).toHaveBeenCalledTimes(1)
   })
 
   it('registers a managed-file save channel', () => {

--- a/src/main/file-save.ts
+++ b/src/main/file-save.ts
@@ -1,14 +1,16 @@
-import { BrowserWindow, app, dialog, ipcMain } from 'electron'
+import { BrowserWindow, app, dialog, ipcMain, type OpenDialogOptions } from 'electron'
 import { constants } from 'node:fs'
-import { open, writeFile } from 'node:fs/promises'
-import { basename, join } from 'node:path'
+import { open, rm, writeFile } from 'node:fs/promises'
+import { basename, extname, join } from 'node:path'
 import { pipeline } from 'node:stream/promises'
 
 import type {
   SaveBlobFileRequest,
   SaveBlobFileResult,
   SaveManagedFileRequest,
-  SaveManagedFileResult
+  SaveManagedFileResult,
+  SaveSessionArtifactsRequest,
+  SaveSessionArtifactsResult
 } from '../shared/file-save'
 
 type RegisterFileSaveHandlersOptions = {
@@ -16,11 +18,16 @@ type RegisterFileSaveHandlersOptions = {
     source: SaveManagedFileRequest['source'],
     request: { path: string }
   ) => Promise<string>
+  resolveSessionArtifactFilePath?: (
+    projectId: string,
+    sessionId: string,
+    path: string
+  ) => Promise<string>
   openManagedFile?: (sourcePath: string) => Promise<ManagedFileHandle>
 }
 
 type ManagedFileHandle = {
-  copyTo: (destinationPath: string) => Promise<void>
+  copyTo: (destinationPath: string, options?: { exclusive?: boolean }) => Promise<void>
   close: () => Promise<void>
 }
 
@@ -40,16 +47,39 @@ const assertSaveManagedFileRequest = (request: SaveManagedFileRequest): void => 
   }
 }
 
+const assertSaveSessionArtifactsRequest = (request: SaveSessionArtifactsRequest): void => {
+  if (
+    typeof request !== 'object' ||
+    request === null ||
+    typeof request.projectId !== 'string' ||
+    request.projectId.trim().length === 0 ||
+    typeof request.sessionId !== 'string' ||
+    request.sessionId.trim().length === 0 ||
+    !Array.isArray(request.files) ||
+    request.files.length === 0 ||
+    request.files.some(
+      (file) =>
+        typeof file !== 'object' ||
+        file === null ||
+        typeof file.path !== 'string' ||
+        file.path.trim().length === 0 ||
+        typeof file.suggestedName !== 'string'
+    )
+  ) {
+    throw new Error('Invalid Session Artifact save request.')
+  }
+}
+
 // Holds the validated source inode across Save As so a pending artifact rename cannot change identity.
 const openManagedFile = async (sourcePath: string): Promise<ManagedFileHandle> => {
   const sourceHandle = await open(sourcePath, 'r')
 
   return {
-    copyTo: async (destinationPath) => {
+    copyTo: async (destinationPath, options) => {
       // Open without truncation, then check and write through the same handle to prevent path swaps.
       const destinationHandle = await open(
         destinationPath,
-        constants.O_CREAT | constants.O_RDWR,
+        constants.O_CREAT | constants.O_RDWR | (options?.exclusive ? constants.O_EXCL : 0),
         0o666
       )
 
@@ -70,6 +100,42 @@ const openManagedFile = async (sourcePath: string): Promise<ManagedFileHandle> =
       }
     },
     close: () => sourceHandle.close()
+  }
+}
+
+const isAlreadyExistsError = (error: unknown): boolean =>
+  error instanceof Error && 'code' in error && error.code === 'EEXIST'
+
+const addFilenameCollisionSuffix = (filename: string, suffix: number): string => {
+  const extension = extname(filename)
+  const stem = basename(filename, extension)
+  return `${stem} (${suffix})${extension}`
+}
+
+const getSafeFilename = (suggestedName: string, sourcePath: string): string => {
+  const requestedBaseName = basename(suggestedName.trim())
+  return requestedBaseName && requestedBaseName !== '.' && requestedBaseName !== '..'
+    ? requestedBaseName
+    : basename(sourcePath)
+}
+
+// Atomically claims the first available filename so batch exports never overwrite existing files.
+const copyToAvailableDestination = async (
+  managedFile: ManagedFileHandle,
+  destinationDirectory: string,
+  safeName: string
+): Promise<string> => {
+  for (let suffix = 1; ; suffix += 1) {
+    const filename = suffix === 1 ? safeName : addFilenameCollisionSuffix(safeName, suffix)
+    const destinationPath = join(destinationDirectory, filename)
+    try {
+      await managedFile.copyTo(destinationPath, { exclusive: true })
+      return destinationPath
+    } catch (error) {
+      if (isAlreadyExistsError(error)) continue
+      await rm(destinationPath, { force: true }).catch(() => undefined)
+      throw error
+    }
   }
 }
 
@@ -152,6 +218,88 @@ const registerFileSaveHandlers = (options: RegisterFileSaveHandlersOptions = {})
         return { saved: true, filePath }
       } finally {
         await managedFile.close()
+      }
+    }
+  )
+
+  ipcMain.handle(
+    'file:save-session-artifacts',
+    async (event, request: SaveSessionArtifactsRequest): Promise<SaveSessionArtifactsResult> => {
+      const resolveSessionArtifactFilePath = options.resolveSessionArtifactFilePath
+      if (!resolveSessionArtifactFilePath) {
+        throw new Error('Session Artifact file resolver is not configured.')
+      }
+
+      assertSaveSessionArtifactsRequest(request)
+      const parentWindow = BrowserWindow.fromWebContents(event.sender)
+
+      if (request.files.length === 1) {
+        const [file] = request.files
+        const sourcePath = await resolveSessionArtifactFilePath(
+          request.projectId,
+          request.sessionId,
+          file.path
+        )
+        const safeName = getSafeFilename(file.suggestedName, sourcePath)
+        const dialogOptions = {
+          defaultPath: join(app.getPath('downloads'), safeName),
+          title: 'Save artifact'
+        }
+        const managedFile = await (options.openManagedFile ?? openManagedFile)(sourcePath)
+
+        try {
+          const { canceled, filePath } = parentWindow
+            ? await dialog.showSaveDialog(parentWindow, dialogOptions)
+            : await dialog.showSaveDialog(dialogOptions)
+
+          if (canceled || !filePath) return { saved: false }
+
+          await managedFile.copyTo(filePath)
+          return { saved: true, filePaths: [filePath] }
+        } finally {
+          await managedFile.close()
+        }
+      }
+
+      const directoryDialogOptions: OpenDialogOptions = {
+        defaultPath: app.getPath('downloads'),
+        properties: ['openDirectory', 'createDirectory'],
+        title: 'Choose where to save artifacts'
+      }
+      const { canceled, filePaths } = parentWindow
+        ? await dialog.showOpenDialog(parentWindow, directoryDialogOptions)
+        : await dialog.showOpenDialog(directoryDialogOptions)
+      const destinationDirectory = filePaths[0]
+      if (canceled || !destinationDirectory) return { saved: false }
+
+      const savedPaths: string[] = []
+      const failures: Array<{ path: string; suggestedName: string; message: string }> = []
+      for (const file of request.files) {
+        let managedFile: ManagedFileHandle | undefined
+        try {
+          const sourcePath = await resolveSessionArtifactFilePath(
+            request.projectId,
+            request.sessionId,
+            file.path
+          )
+          const safeName = getSafeFilename(file.suggestedName, sourcePath)
+          managedFile = await (options.openManagedFile ?? openManagedFile)(sourcePath)
+          savedPaths.push(
+            await copyToAvailableDestination(managedFile, destinationDirectory, safeName)
+          )
+        } catch (error) {
+          failures.push({
+            ...file,
+            message: error instanceof Error ? error.message : String(error)
+          })
+        } finally {
+          await managedFile?.close()
+        }
+      }
+      return {
+        saved: true,
+        filePaths: savedPaths,
+        ...(failures.length > 0 ? { failures } : {})
       }
     }
   )

--- a/src/main/ipc.ts
+++ b/src/main/ipc.ts
@@ -27,6 +27,7 @@ import { ALL_CONNECTOR_IDS } from './connectors/registry'
 import { ConnectorService } from './connectors/service'
 import { syncConnectorSkillDocs, syncCustomServerSkillDocs } from './connectors/provision'
 import { registerFileSaveHandlers } from './file-save'
+import { createSessionArtifactFileResolver } from './session-artifact-file-resolver'
 import { registerCliInstallIpcHandlers } from './cli-install/ipc'
 import { registerGithubIpcHandlers } from './github-ipc'
 import { BackendShutdownCoordinator, UPDATE_SHUTDOWN_BUDGET_MS } from './lifecycle-shutdown'
@@ -69,6 +70,7 @@ import { createProductionProvisioner, type RuntimeProvisioner } from './notebook
 import { runtimeRoot } from './notebook/runtime-paths'
 import type { NotebookEnvironmentManager } from './notebook/runtime-service'
 import { parseArtifactVersionLocator } from '../shared/artifact-provenance'
+import { DEFAULT_ARTIFACT_PROJECT_NAME } from '../shared/artifacts'
 import type { NotebookLanguage } from '../shared/notebook'
 import { OFFICE_PREVIEW_STATE_CHANNEL } from '../shared/office-preview'
 import { prepareExternalPythonRuntime } from './notebook/venv-overlay'
@@ -280,6 +282,13 @@ const registerIpcHandlers = async ({
         : notebookInputRegistry
             .resolvePreviewKey(request.path)
             .then((target) => target.absolutePath)
+  const resolveSessionArtifactFilePath = createSessionArtifactFileResolver({
+    compatibilityProjectName: DEFAULT_ARTIFACT_PROJECT_NAME,
+    resolveVersionContent: (identity) =>
+      artifactProvenanceRepository.resolveVersionContent(identity),
+    resolveLegacyArtifactPath: (projectName, sessionId, path) =>
+      artifactRepository.resolveSessionArtifactFilePath(projectName, sessionId, path)
+  })
   // One registry owns short-lived capability URLs for both managed artifact repositories.
   const previewResources = new ManagedPreviewResources({
     resolvePath: resolveManagedFilePath
@@ -579,7 +588,7 @@ const registerIpcHandlers = async ({
     }
   )
 
-  registerFileSaveHandlers({ resolveManagedFilePath })
+  registerFileSaveHandlers({ resolveManagedFilePath, resolveSessionArtifactFilePath })
   registerLogsIpcHandlers()
   registerGithubIpcHandlers()
   registerCliInstallIpcHandlers()

--- a/src/main/session-artifact-file-resolver.test.ts
+++ b/src/main/session-artifact-file-resolver.test.ts
@@ -1,0 +1,94 @@
+import { describe, expect, it, vi } from 'vitest'
+
+import { createArtifactVersionLocator } from '../shared/artifact-provenance'
+import { createSessionArtifactFileResolver } from './session-artifact-file-resolver'
+
+describe('Session Artifact file resolver', () => {
+  it('rejects an Artifact Version locator owned by a different Source Session', async () => {
+    const resolveVersionContent = vi.fn().mockResolvedValue({ path: '/managed/report.csv' })
+    const resolveLegacyArtifactPath = vi.fn().mockResolvedValue('/managed/legacy.csv')
+    const resolve = createSessionArtifactFileResolver({
+      compatibilityProjectName: 'default-project',
+      resolveVersionContent,
+      resolveLegacyArtifactPath
+    })
+    const locator = createArtifactVersionLocator({
+      projectId: 'project-1',
+      appSessionId: 'session-2',
+      artifactId: 'artifact-1',
+      versionId: 'version-1'
+    })
+
+    await expect(resolve('project-1', 'session-1', locator)).rejects.toThrow(
+      'Artifact Version belongs to a different Source Session.'
+    )
+    expect(resolveVersionContent).not.toHaveBeenCalled()
+    expect(resolveLegacyArtifactPath).not.toHaveBeenCalled()
+  })
+
+  it('resolves a matching immutable Artifact Version', async () => {
+    const resolveVersionContent = vi.fn().mockResolvedValue({ path: '/managed/report.csv' })
+    const resolveLegacyArtifactPath = vi.fn()
+    const resolve = createSessionArtifactFileResolver({
+      compatibilityProjectName: 'default-project',
+      resolveVersionContent,
+      resolveLegacyArtifactPath
+    })
+    const locator = createArtifactVersionLocator({
+      projectId: 'project-1',
+      appSessionId: 'session-1',
+      artifactId: 'artifact-1',
+      versionId: 'version-1'
+    })
+
+    await expect(resolve('project-1', 'session-1', locator)).resolves.toBe('/managed/report.csv')
+    expect(resolveVersionContent).toHaveBeenCalledWith({
+      projectId: 'project-1',
+      appSessionId: 'session-1',
+      artifactId: 'artifact-1',
+      versionId: 'version-1'
+    })
+    expect(resolveLegacyArtifactPath).not.toHaveBeenCalled()
+  })
+
+  it('delegates a legacy Artifact path to the Session-scoped repository resolver', async () => {
+    const resolveVersionContent = vi.fn()
+    const resolveLegacyArtifactPath = vi.fn().mockResolvedValue('/managed/legacy.csv')
+    const resolve = createSessionArtifactFileResolver({
+      compatibilityProjectName: 'default-project',
+      resolveVersionContent,
+      resolveLegacyArtifactPath
+    })
+
+    await expect(
+      resolve('project-1', 'session-1', '/managed/project-1/session-1/legacy.csv')
+    ).resolves.toBe('/managed/legacy.csv')
+    expect(resolveLegacyArtifactPath).toHaveBeenCalledWith(
+      'project-1',
+      'session-1',
+      '/managed/project-1/session-1/legacy.csv'
+    )
+    expect(resolveVersionContent).not.toHaveBeenCalled()
+  })
+
+  it('falls back to the compatibility Project namespace for migrated legacy Artifacts', async () => {
+    const resolveVersionContent = vi.fn()
+    const resolveLegacyArtifactPath = vi
+      .fn()
+      .mockRejectedValueOnce(new Error('outside requested Project'))
+      .mockResolvedValueOnce('/managed/default-project/session-1/legacy.csv')
+    const resolve = createSessionArtifactFileResolver({
+      compatibilityProjectName: 'default-project',
+      resolveVersionContent,
+      resolveLegacyArtifactPath
+    })
+    const path = '/managed/default-project/session-1/legacy.csv'
+
+    await expect(resolve('project-1', 'session-1', path)).resolves.toBe(path)
+    expect(resolveLegacyArtifactPath.mock.calls).toEqual([
+      ['project-1', 'session-1', path],
+      ['default-project', 'session-1', path]
+    ])
+    expect(resolveVersionContent).not.toHaveBeenCalled()
+  })
+})

--- a/src/main/session-artifact-file-resolver.ts
+++ b/src/main/session-artifact-file-resolver.ts
@@ -1,0 +1,46 @@
+import { parseArtifactVersionLocator } from '../shared/artifact-provenance'
+
+type SessionArtifactFileResolverDependencies = {
+  compatibilityProjectName: string
+  resolveVersionContent: (
+    identity: NonNullable<ReturnType<typeof parseArtifactVersionLocator>>
+  ) => Promise<{ path: string }>
+  resolveLegacyArtifactPath: (
+    projectName: string,
+    sessionId: string,
+    path: string
+  ) => Promise<string>
+}
+
+type SessionArtifactFileResolver = (
+  projectId: string,
+  sessionId: string,
+  path: string
+) => Promise<string>
+
+// Native versions carry their Project and Source Session identity. Legacy files may live under the
+// active Project namespace or the pre-migration compatibility namespace; both remain Session-bound.
+const createSessionArtifactFileResolver =
+  (dependencies: SessionArtifactFileResolverDependencies): SessionArtifactFileResolver =>
+  async (projectId, sessionId, path) => {
+    const versionIdentity = parseArtifactVersionLocator(path)
+    if (!versionIdentity) {
+      try {
+        return await dependencies.resolveLegacyArtifactPath(projectId, sessionId, path)
+      } catch (projectError) {
+        if (projectId === dependencies.compatibilityProjectName) throw projectError
+        return dependencies.resolveLegacyArtifactPath(
+          dependencies.compatibilityProjectName,
+          sessionId,
+          path
+        )
+      }
+    }
+    if (versionIdentity.projectId !== projectId || versionIdentity.appSessionId !== sessionId) {
+      throw new Error('Artifact Version belongs to a different Source Session.')
+    }
+    return dependencies.resolveVersionContent(versionIdentity).then((resolved) => resolved.path)
+  }
+
+export { createSessionArtifactFileResolver }
+export type { SessionArtifactFileResolver, SessionArtifactFileResolverDependencies }

--- a/src/main/web-service/http-server.test.ts
+++ b/src/main/web-service/http-server.test.ts
@@ -32,6 +32,7 @@ describe('startWebHttpServer', () => {
     const rpc = {
       channels: () => [
         'test:echo',
+        'file:save-session-artifacts',
         'uploads:stage-local-file',
         'settings:list-agent-home-skills',
         'settings:import-agent-home-skills'
@@ -104,6 +105,7 @@ describe('startWebHttpServer', () => {
 
     // Channels unavailable to web clients are rejected over /rpc without reaching the handler.
     for (const channel of [
+      'file:save-session-artifacts',
       'window:close',
       'uploads:stage-local-file',
       'settings:list-agent-home-skills',

--- a/src/main/web-service/http-server.ts
+++ b/src/main/web-service/http-server.ts
@@ -23,6 +23,7 @@ const MAX_RPC_BODY_BYTES = 64 * 1024 * 1024
 const WEB_UNAVAILABLE_RPC_CHANNELS = new Set([
   'file:save-blob',
   'file:save-managed',
+  'file:save-session-artifacts',
   'uploads:stage-local-file',
   'window:close',
   'settings:list-agent-home-skills',

--- a/src/preload/index.d.ts
+++ b/src/preload/index.d.ts
@@ -37,7 +37,9 @@ import type {
   SaveBlobFileRequest,
   SaveBlobFileResult,
   SaveManagedFileRequest,
-  SaveManagedFileResult
+  SaveManagedFileResult,
+  SaveSessionArtifactsRequest,
+  SaveSessionArtifactsResult
 } from '../shared/file-save'
 import type {
   ComputeApprovalDecision,
@@ -244,6 +246,7 @@ type AcpListener<Payload> = (payload: Payload) => void
 interface OpenScienceAPI {
   saveBlobFile(request: SaveBlobFileRequest): Promise<SaveBlobFileResult>
   saveManagedFile(request: SaveManagedFileRequest): Promise<SaveManagedFileResult>
+  saveSessionArtifacts(request: SaveSessionArtifactsRequest): Promise<SaveSessionArtifactsResult>
   // Host platform (process.platform), e.g. 'win32' | 'darwin' | 'linux'.
   platform: string
   getRuntimeVersions(): {

--- a/src/preload/index.test.ts
+++ b/src/preload/index.test.ts
@@ -32,6 +32,7 @@ vi.mock('electron', () => ({
 
 // The subset of the bridge these tests exercise. Args are unknown — forwarding, not shape, is asserted.
 type PreloadApi = {
+  saveSessionArtifacts: (request: unknown) => unknown
   lifecycle: {
     getClientId: () => unknown
   }
@@ -199,8 +200,19 @@ const sampleFramework = { framework: 'opencode' }
 const sampleResumeRequest = { sessionId: 's-1', cwd: '/workspace/project' }
 const sampleGitHubPreview = { url: 'https://github.com/acme/skills/tree/main/foo' }
 const sampleAgentHomePreview = { source: 'agents', slug: 'foo' }
+const sampleSessionArtifactSelection = {
+  projectId: 'p-1',
+  sessionId: 's-1',
+  files: [{ path: 'artifact://report', suggestedName: 'report.csv' }]
+}
 
 const cases: ForwardingCase[] = [
+  {
+    name: 'saveSessionArtifacts → file:save-session-artifacts',
+    invoke: (a) => a.saveSessionArtifacts(sampleSessionArtifactSelection),
+    channel: 'file:save-session-artifacts',
+    args: [sampleSessionArtifactSelection]
+  },
   {
     name: 'lifecycle.getClientId → lifecycle:client-id (no args)',
     invoke: (a) => a.lifecycle.getClientId(),

--- a/src/preload/index.ts
+++ b/src/preload/index.ts
@@ -39,7 +39,9 @@ import type {
   SaveBlobFileRequest,
   SaveBlobFileResult,
   SaveManagedFileRequest,
-  SaveManagedFileResult
+  SaveManagedFileResult,
+  SaveSessionArtifactsRequest,
+  SaveSessionArtifactsResult
 } from '../shared/file-save'
 import type {
   ComputeApprovalDecision,
@@ -279,6 +281,9 @@ const onIpcMessage = <Payload>(channel: string, listener: AcpListener<Payload>):
 type OpenScienceAPI = {
   saveBlobFile: (request: SaveBlobFileRequest) => Promise<SaveBlobFileResult>
   saveManagedFile: (request: SaveManagedFileRequest) => Promise<SaveManagedFileResult>
+  saveSessionArtifacts: (
+    request: SaveSessionArtifactsRequest
+  ) => Promise<SaveSessionArtifactsResult>
   // Host platform (process.platform), e.g. 'win32' | 'darwin' | 'linux'. Lets the renderer pick
   // platform-correct copy such as the claude install command shown in the onboarding/settings card.
   platform: string
@@ -737,6 +742,11 @@ const api: OpenScienceAPI = {
     ipcRenderer.invoke('file:save-blob', request) as Promise<SaveBlobFileResult>,
   saveManagedFile: (request) =>
     ipcRenderer.invoke('file:save-managed', request) as Promise<SaveManagedFileResult>,
+  saveSessionArtifacts: (request) =>
+    ipcRenderer.invoke(
+      'file:save-session-artifacts',
+      request
+    ) as Promise<SaveSessionArtifactsResult>,
   platform: process.platform,
   getRuntimeVersions: () => ({
     electron: process.versions.electron,

--- a/src/renderer/src/pages/workspace/DownloadSessionArtifactsDialog.interaction.test.tsx
+++ b/src/renderer/src/pages/workspace/DownloadSessionArtifactsDialog.interaction.test.tsx
@@ -1,0 +1,208 @@
+// @vitest-environment jsdom
+import { act } from 'react'
+import { createRoot, type Root } from 'react-dom/client'
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest'
+
+import type { ProjectFileItem } from '../../../../shared/project-files'
+import type { ChatSession } from '@/stores/session-store'
+import { DownloadSessionArtifactsDialog } from './DownloadSessionArtifactsDialog'
+
+;(globalThis as { IS_REACT_ACT_ENVIRONMENT?: boolean }).IS_REACT_ACT_ENVIRONMENT = true
+
+const session: ChatSession = {
+  id: 'session-1',
+  projectId: 'project-1',
+  title: 'Analysis session',
+  cwd: '/workspace',
+  status: 'idle',
+  messages: [],
+  createdAt: 1710000000000,
+  updatedAt: 1710000000000
+}
+
+const artifacts: ProjectFileItem[] = [
+  {
+    id: 'artifact-1',
+    source: 'artifact',
+    sourceFileId: 'artifact-1',
+    projectId: 'project-1',
+    sessionId: 'session-1',
+    name: 'report.csv',
+    path: 'artifact://report',
+    mimeType: 'text/csv',
+    size: 1536,
+    sortAtMs: 2
+  },
+  {
+    id: 'artifact-2',
+    source: 'artifact',
+    sourceFileId: 'artifact-2',
+    projectId: 'project-1',
+    sessionId: 'session-1',
+    name: 'figure.png',
+    path: 'artifact://figure',
+    mimeType: 'image/png',
+    size: 4096,
+    sortAtMs: 1
+  }
+]
+
+let container: HTMLElement
+let root: Root
+let listFiles: ReturnType<typeof vi.fn>
+let saveSessionArtifacts: ReturnType<typeof vi.fn>
+
+beforeEach(() => {
+  listFiles = vi.fn().mockResolvedValue({ items: artifacts, totalCount: artifacts.length })
+  saveSessionArtifacts = vi.fn().mockResolvedValue({
+    saved: true,
+    filePaths: ['/downloads/report.csv']
+  })
+  ;(window as unknown as { api: unknown }).api = {
+    projectFiles: {
+      getOverview: vi.fn().mockResolvedValue({
+        totalCount: artifacts.length,
+        uploadCount: 0,
+        artifactCount: artifacts.length,
+        artifactGroupCount: 1,
+        isIndexComplete: true
+      }),
+      listFiles,
+      repairIndex: vi.fn().mockResolvedValue(undefined)
+    },
+    saveSessionArtifacts
+  }
+  container = document.createElement('div')
+  document.body.appendChild(container)
+  root = createRoot(container)
+})
+
+afterEach(() => {
+  act(() => root.unmount())
+  container.remove()
+  vi.restoreAllMocks()
+})
+
+describe('DownloadSessionArtifactsDialog', () => {
+  it('selects every Artifact by default and downloads only the checked rows', async () => {
+    const onClose = vi.fn()
+    await act(async () => {
+      root.render(<DownloadSessionArtifactsDialog session={session} onClose={onClose} />)
+      await Promise.resolve()
+      await Promise.resolve()
+    })
+
+    expect(document.body.textContent).toContain('Download session artifacts')
+    expect(document.body.textContent).toContain('2 of 2 selected')
+    expect(document.body.textContent).toContain('report.csv')
+    expect(document.body.textContent).toContain('figure.png')
+    const checkboxes = [
+      ...document.body.querySelectorAll<HTMLInputElement>('input[type="checkbox"]')
+    ]
+    expect(checkboxes).toHaveLength(2)
+    expect(checkboxes.every((checkbox) => checkbox.checked)).toBe(true)
+
+    act(() => checkboxes[1].click())
+    expect(document.body.textContent).toContain('1 of 2 selected')
+
+    await act(async () => {
+      document.body
+        .querySelector<HTMLButtonElement>('[data-testid="download-session-artifacts-confirm"]')
+        ?.click()
+      await Promise.resolve()
+    })
+
+    expect(saveSessionArtifacts).toHaveBeenCalledWith({
+      projectId: 'project-1',
+      sessionId: 'session-1',
+      files: [{ path: 'artifact://report', suggestedName: 'report.csv' }]
+    })
+    expect(onClose).toHaveBeenCalledTimes(1)
+  })
+
+  it('preserves the selection when the same Session receives a live metadata update', async () => {
+    await act(async () => {
+      root.render(<DownloadSessionArtifactsDialog session={session} onClose={vi.fn()} />)
+      await Promise.resolve()
+      await Promise.resolve()
+    })
+    const checkboxes = [
+      ...document.body.querySelectorAll<HTMLInputElement>('input[type="checkbox"]')
+    ]
+    act(() => checkboxes[1].click())
+    expect(document.body.textContent).toContain('1 of 2 selected')
+
+    await act(async () => {
+      root.render(
+        <DownloadSessionArtifactsDialog
+          session={{ ...session, title: 'Analysis session updated', status: 'running' }}
+          onClose={vi.fn()}
+        />
+      )
+      await Promise.resolve()
+      await Promise.resolve()
+    })
+
+    expect(listFiles).toHaveBeenCalledTimes(1)
+    expect(document.body.textContent).toContain('1 of 2 selected')
+  })
+
+  it('offers Retry when the Artifact snapshot cannot be loaded', async () => {
+    listFiles
+      .mockReset()
+      .mockRejectedValueOnce(new Error('file index unavailable'))
+      .mockResolvedValueOnce({ items: artifacts, totalCount: artifacts.length })
+    await act(async () => {
+      root.render(<DownloadSessionArtifactsDialog session={session} onClose={vi.fn()} />)
+      await Promise.resolve()
+      await Promise.resolve()
+    })
+
+    expect(document.body.querySelector('[role="alert"]')?.textContent).toContain(
+      'file index unavailable'
+    )
+
+    await act(async () => {
+      const retry = [...document.body.querySelectorAll('button')].find(
+        (button) => button.textContent === 'Retry'
+      )
+      retry?.click()
+      await Promise.resolve()
+      await Promise.resolve()
+    })
+
+    expect(listFiles).toHaveBeenCalledTimes(2)
+    expect(document.body.textContent).toContain('report.csv')
+    expect(document.body.textContent).toContain('2 of 2 selected')
+  })
+
+  it('keeps only failed Artifacts selected after a partial batch export', async () => {
+    const onClose = vi.fn()
+    saveSessionArtifacts.mockResolvedValue({
+      saved: true,
+      filePaths: ['/downloads/report.csv'],
+      failures: [{ path: 'artifact://figure', suggestedName: 'figure.png', message: 'disk full' }]
+    })
+    await act(async () => {
+      root.render(<DownloadSessionArtifactsDialog session={session} onClose={onClose} />)
+      await Promise.resolve()
+      await Promise.resolve()
+    })
+
+    await act(async () => {
+      document.body
+        .querySelector<HTMLButtonElement>('[data-testid="download-session-artifacts-confirm"]')
+        ?.click()
+      await Promise.resolve()
+    })
+
+    const checkboxes = [
+      ...document.body.querySelectorAll<HTMLInputElement>('input[type="checkbox"]')
+    ]
+    expect(checkboxes.map((checkbox) => checkbox.checked)).toEqual([false, true])
+    expect(document.body.querySelector('[role="alert"]')?.textContent).toContain(
+      'Downloaded 1 of 2 artifacts. 1 failed.'
+    )
+    expect(onClose).not.toHaveBeenCalled()
+  })
+})

--- a/src/renderer/src/pages/workspace/DownloadSessionArtifactsDialog.tsx
+++ b/src/renderer/src/pages/workspace/DownloadSessionArtifactsDialog.tsx
@@ -1,0 +1,295 @@
+import { useEffect, useMemo, useState } from 'react'
+import { Archive, Download, LoaderCircle, X } from 'lucide-react'
+import { Dialog } from 'radix-ui'
+
+import { Button } from '@/components/ui/button'
+import {
+  dialogCloseButtonClassName,
+  dialogOverlayClassName,
+  dialogPanelClassName
+} from '@/components/ui/dialog-chrome'
+import { useRetainedDialogValue } from '@/components/ui/use-retained-dialog-value'
+import type { ChatSession } from '@/stores/session-store'
+import { formatBytes } from '../../../../shared/update'
+import type { ProjectFileItem } from '../../../../shared/project-files'
+import { listAllSessionArtifacts } from './session-artifact-download-data'
+
+type DownloadSessionArtifactsDialogProps = {
+  session: ChatSession | undefined
+  onClose: () => void
+}
+
+type ArtifactListStatus = 'loading' | 'ready' | 'error'
+
+type SettledArtifactList = {
+  requestKey: string
+  status: Exclude<ArtifactListStatus, 'loading'>
+  artifacts: ProjectFileItem[]
+  loadError?: string
+}
+
+const EMPTY_ARTIFACTS: ProjectFileItem[] = []
+
+const getArtifactType = (artifact: ProjectFileItem): string => {
+  const dotIndex = artifact.name.lastIndexOf('.')
+  if (dotIndex >= 0 && dotIndex < artifact.name.length - 1) {
+    return artifact.name.slice(dotIndex + 1).toLowerCase()
+  }
+  return artifact.mimeType?.split('/').at(-1) ?? 'file'
+}
+
+const getErrorMessage = (error: unknown): string =>
+  error instanceof Error ? error.message : String(error)
+
+const pluralizeArtifact = (count: number): string => `${count} artifact${count === 1 ? '' : 's'}`
+
+const DownloadSessionArtifactsDialog = ({
+  session,
+  onClose
+}: DownloadSessionArtifactsDialogProps): React.JSX.Element => {
+  const dialogSession = useRetainedDialogValue(session)
+  const [settledArtifactList, setSettledArtifactList] = useState<SettledArtifactList>()
+  const [selectedIds, setSelectedIds] = useState<Set<string>>(new Set())
+  const [downloadError, setDownloadError] = useState<string>()
+  const [isDownloading, setIsDownloading] = useState(false)
+  const [retryVersion, setRetryVersion] = useState(0)
+  const projectId = session?.projectId
+  const sessionId = session?.id
+  const requestKey =
+    projectId && sessionId ? `${projectId}\u0000${sessionId}\u0000${retryVersion}` : undefined
+  const currentArtifactList =
+    settledArtifactList?.requestKey === requestKey ? settledArtifactList : undefined
+  const artifacts = currentArtifactList?.artifacts ?? EMPTY_ARTIFACTS
+  const status: ArtifactListStatus = currentArtifactList?.status ?? 'loading'
+  const loadError = currentArtifactList?.loadError
+
+  useEffect(() => {
+    if (!projectId || !sessionId || !requestKey) return
+    let isCurrent = true
+
+    void listAllSessionArtifacts({
+      getOverview: window.api.projectFiles.getOverview,
+      listFiles: window.api.projectFiles.listFiles,
+      repairIndex: window.api.projectFiles.repairIndex,
+      projectId,
+      sessionId
+    }).then(
+      (nextArtifacts) => {
+        if (!isCurrent) return
+        setSettledArtifactList({
+          requestKey,
+          status: 'ready',
+          artifacts: nextArtifacts
+        })
+        setSelectedIds(new Set(nextArtifacts.map((artifact) => artifact.id)))
+        setDownloadError(undefined)
+      },
+      (error: unknown) => {
+        if (!isCurrent) return
+        setSettledArtifactList({
+          requestKey,
+          status: 'error',
+          artifacts: [],
+          loadError: getErrorMessage(error)
+        })
+      }
+    )
+
+    return () => {
+      isCurrent = false
+    }
+  }, [projectId, requestKey, sessionId])
+
+  const selectedArtifacts = useMemo(
+    () => artifacts.filter((artifact) => selectedIds.has(artifact.id)),
+    [artifacts, selectedIds]
+  )
+  const allSelected = artifacts.length > 0 && selectedArtifacts.length === artifacts.length
+
+  const toggleArtifact = (artifactId: string): void => {
+    setDownloadError(undefined)
+    setSelectedIds((current) => {
+      const next = new Set(current)
+      if (next.has(artifactId)) next.delete(artifactId)
+      else next.add(artifactId)
+      return next
+    })
+  }
+
+  const toggleAll = (): void => {
+    setDownloadError(undefined)
+    setSelectedIds(allSelected ? new Set() : new Set(artifacts.map((artifact) => artifact.id)))
+  }
+
+  const downloadSelected = async (): Promise<void> => {
+    if (!session || selectedArtifacts.length === 0 || isDownloading) return
+    setIsDownloading(true)
+    setDownloadError(undefined)
+    try {
+      const result = await window.api.saveSessionArtifacts({
+        projectId: session.projectId,
+        sessionId: session.id,
+        files: selectedArtifacts.map((artifact) => ({
+          path: artifact.path,
+          suggestedName: artifact.name
+        }))
+      })
+      if (!result.saved) return
+      if (result.failures?.length) {
+        const failedPaths = new Set(result.failures.map((failure) => failure.path))
+        setSelectedIds(
+          new Set(
+            artifacts
+              .filter((artifact) => failedPaths.has(artifact.path))
+              .map((artifact) => artifact.id)
+          )
+        )
+        setDownloadError(
+          `Downloaded ${result.filePaths.length} of ${selectedArtifacts.length} artifacts. ${result.failures.length} failed.`
+        )
+        return
+      }
+      onClose()
+    } catch (error) {
+      setDownloadError(getErrorMessage(error))
+    } finally {
+      setIsDownloading(false)
+    }
+  }
+
+  return (
+    <Dialog.Root
+      open={Boolean(session)}
+      onOpenChange={(open) => {
+        if (!open) onClose()
+      }}
+    >
+      <Dialog.Portal>
+        <Dialog.Overlay className={dialogOverlayClassName} />
+        <Dialog.Content
+          className={dialogPanelClassName(
+            'flex max-h-[80svh] w-[min(640px,calc(100vw-2rem))] flex-col overflow-hidden p-0'
+          )}
+        >
+          <div className="flex shrink-0 items-center justify-between gap-4 border-b border-border px-4 py-3">
+            <div className="flex min-w-0 items-center gap-2">
+              <Archive className="size-4 shrink-0 text-muted-foreground" aria-hidden="true" />
+              <div className="min-w-0">
+                <Dialog.Title className="text-sm font-semibold text-foreground">
+                  Download session artifacts
+                </Dialog.Title>
+                <Dialog.Description className="truncate text-xs text-muted-foreground">
+                  {dialogSession?.title ?? 'Session'}
+                </Dialog.Description>
+              </div>
+              {status === 'ready' ? (
+                <span className="shrink-0 text-xs tabular-nums text-muted-foreground">
+                  {selectedArtifacts.length} of {artifacts.length} selected
+                </span>
+              ) : null}
+            </div>
+            <Button
+              type="button"
+              variant="ghost"
+              size="icon-sm"
+              aria-label="Close"
+              className={dialogCloseButtonClassName}
+              onClick={onClose}
+            >
+              <X className="size-4" aria-hidden="true" />
+            </Button>
+          </div>
+
+          <div className="min-h-0 flex-1 overflow-y-auto">
+            {status === 'loading' ? (
+              <div className="flex min-h-32 items-center justify-center gap-2 text-sm text-muted-foreground">
+                <LoaderCircle className="size-4 animate-spin" aria-hidden="true" />
+                Loading artifacts…
+              </div>
+            ) : status === 'error' ? (
+              <div className="flex min-h-32 flex-col items-center justify-center gap-3 px-6 text-center">
+                <p role="alert" className="text-sm text-danger-000">
+                  {loadError ?? 'Could not load session artifacts.'}
+                </p>
+                <Button
+                  type="button"
+                  variant="outline"
+                  onClick={() => setRetryVersion((v) => v + 1)}
+                >
+                  Retry
+                </Button>
+              </div>
+            ) : artifacts.length === 0 ? (
+              <div className="flex min-h-32 items-center justify-center px-6 text-center text-sm text-muted-foreground">
+                No downloadable artifacts in this session.
+              </div>
+            ) : (
+              <div role="group" aria-label="Session artifacts">
+                {artifacts.map((artifact) => (
+                  <label
+                    key={artifact.id}
+                    className="flex cursor-pointer items-center gap-3 px-4 py-2 transition-colors hover:bg-muted"
+                  >
+                    <input
+                      type="checkbox"
+                      checked={selectedIds.has(artifact.id)}
+                      onChange={() => toggleArtifact(artifact.id)}
+                      className="size-4 cursor-pointer accent-primary"
+                    />
+                    <span className="min-w-0 flex-1 truncate text-sm text-foreground">
+                      {artifact.name}
+                    </span>
+                    <span className="shrink-0 text-xs text-muted-foreground">
+                      {getArtifactType(artifact)}
+                    </span>
+                    <span className="w-16 shrink-0 text-right text-xs tabular-nums text-muted-foreground">
+                      {formatBytes(artifact.size)}
+                    </span>
+                  </label>
+                ))}
+              </div>
+            )}
+          </div>
+
+          <div className="flex shrink-0 items-center justify-between gap-3 border-t border-border px-4 py-3">
+            <Button
+              type="button"
+              variant="ghost"
+              size="sm"
+              disabled={status !== 'ready' || artifacts.length === 0 || isDownloading}
+              onClick={toggleAll}
+            >
+              {allSelected ? 'Uncheck all' : 'Check all'}
+            </Button>
+            <div className="flex min-w-0 items-center gap-3">
+              {status === 'ready' && downloadError ? (
+                <p role="alert" className="truncate text-xs text-danger-000">
+                  {downloadError}
+                </p>
+              ) : null}
+              <Button
+                type="button"
+                size="sm"
+                data-testid="download-session-artifacts-confirm"
+                disabled={status !== 'ready' || selectedArtifacts.length === 0 || isDownloading}
+                onClick={() => void downloadSelected()}
+              >
+                {isDownloading ? (
+                  <LoaderCircle className="size-4 animate-spin" aria-hidden="true" />
+                ) : (
+                  <Download className="size-4" aria-hidden="true" />
+                )}
+                {isDownloading
+                  ? 'Downloading…'
+                  : `Download ${pluralizeArtifact(selectedArtifacts.length)}`}
+              </Button>
+            </div>
+          </div>
+        </Dialog.Content>
+      </Dialog.Portal>
+    </Dialog.Root>
+  )
+}
+
+export { DownloadSessionArtifactsDialog }
+export type { DownloadSessionArtifactsDialogProps }

--- a/src/renderer/src/pages/workspace/WorkspacePage.draft-preservation.test.tsx
+++ b/src/renderer/src/pages/workspace/WorkspacePage.draft-preservation.test.tsx
@@ -35,7 +35,12 @@ let sidebarProps: {
   canDeleteConversations: boolean
   onOpenSession: (id: string) => void
   onNewConversation: () => void
+  onDownloadArtifacts: (session: ChatSession) => void
   onDeleteSession: (session: ChatSession) => void
+}
+let downloadArtifactsDialogProps: {
+  session: ChatSession | undefined
+  onClose: () => void
 }
 let deleteDialogProps: {
   session: ChatSession | undefined
@@ -96,6 +101,15 @@ vi.mock('./RenameSessionDialog', () => ({
 vi.mock('./DeleteSessionDialog', () => ({
   DeleteSessionDialog: (props: typeof deleteDialogProps): React.JSX.Element => {
     deleteDialogProps = props
+    return <div />
+  }
+}))
+
+vi.mock('./DownloadSessionArtifactsDialog', () => ({
+  DownloadSessionArtifactsDialog: (
+    props: typeof downloadArtifactsDialogProps
+  ): React.JSX.Element => {
+    downloadArtifactsDialogProps = props
     return <div />
   }
 }))
@@ -260,6 +274,21 @@ describe('WorkspacePage draft preservation', () => {
       sidebarProps.onOpenSession(id)
     })
   }
+
+  it('opens and closes the Artifact download dialog for the selected sidebar Session', async () => {
+    await renderPage()
+    const sessionB = useSessionStore.getState().sessions.find((session) => session.id === 'sess-b')!
+
+    await act(async () => {
+      sidebarProps.onDownloadArtifacts(sessionB)
+    })
+    expect(downloadArtifactsDialogProps.session?.id).toBe('sess-b')
+
+    await act(async () => {
+      downloadArtifactsDialogProps.onClose()
+    })
+    expect(downloadArtifactsDialogProps.session).toBeUndefined()
+  })
 
   it('preserves each session doc independently when switching away and back', async () => {
     await renderPage()

--- a/src/renderer/src/pages/workspace/WorkspacePage.tsx
+++ b/src/renderer/src/pages/workspace/WorkspacePage.tsx
@@ -42,6 +42,7 @@ import {
 } from './composer/composer-doc'
 import { ConversationPanel } from './ConversationPanel'
 import { DeleteSessionDialog } from './DeleteSessionDialog'
+import { DownloadSessionArtifactsDialog } from './DownloadSessionArtifactsDialog'
 import { PreviewPanel } from './PreviewPanel'
 import { RenameSessionDialog } from './RenameSessionDialog'
 import { SessionNotebookDialog } from './SessionNotebookDialog'
@@ -273,6 +274,9 @@ const WorkspacePage = ({
   >({})
   const [sessionToRename, setSessionToRename] = useState<ChatSession | undefined>(undefined)
   const [renameDraft, setRenameDraft] = useState('')
+  const [sessionToDownloadArtifacts, setSessionToDownloadArtifacts] = useState<
+    ChatSession | undefined
+  >(undefined)
   const [sessionToDelete, setSessionToDelete] = useState<ChatSession | undefined>(undefined)
   const [sessionDeletionInProgressIds, setSessionDeletionInProgressIds] = useState<
     ReadonlySet<string>
@@ -1447,6 +1451,7 @@ const WorkspacePage = ({
           onOpenFiles={openFilesPreview}
           onOpenSession={openSession}
           onRenameSession={openRenameDialog}
+          onDownloadArtifacts={setSessionToDownloadArtifacts}
           onViewNotebook={setSessionToViewNotebook}
           onTogglePin={(session) => {
             if (isSessionPersistenceReady) togglePinned(session.id)
@@ -1613,6 +1618,11 @@ const WorkspacePage = ({
         canDelete={canDeleteConversations}
         onCancel={closeDeleteDialog}
         onConfirmDelete={confirmDeleteSession}
+      />
+
+      <DownloadSessionArtifactsDialog
+        session={sessionToDownloadArtifacts}
+        onClose={() => setSessionToDownloadArtifacts(undefined)}
       />
 
       <SessionNotebookDialog

--- a/src/renderer/src/pages/workspace/WorkspacePage.tsx
+++ b/src/renderer/src/pages/workspace/WorkspacePage.tsx
@@ -1451,6 +1451,7 @@ const WorkspacePage = ({
           onOpenFiles={openFilesPreview}
           onOpenSession={openSession}
           onRenameSession={openRenameDialog}
+          canDownloadArtifacts={typeof window.api?.saveSessionArtifacts === 'function'}
           onDownloadArtifacts={setSessionToDownloadArtifacts}
           onViewNotebook={setSessionToViewNotebook}
           onTogglePin={(session) => {

--- a/src/renderer/src/pages/workspace/WorkspaceSidebar.render.test.tsx
+++ b/src/renderer/src/pages/workspace/WorkspaceSidebar.render.test.tsx
@@ -36,6 +36,7 @@ const renderSidebar = async (sessions: ChatSession[]): Promise<string> => {
       onOpenFiles={vi.fn()}
       onOpenSession={vi.fn()}
       onRenameSession={vi.fn()}
+      onDownloadArtifacts={vi.fn()}
       onViewNotebook={vi.fn()}
       onTogglePin={vi.fn()}
       onDeleteSession={vi.fn()}
@@ -105,6 +106,7 @@ describe('WorkspaceSidebar accessible render', () => {
     ]
     const onOpenSession = vi.fn()
     const onRenameSession = vi.fn()
+    const onDownloadArtifacts = vi.fn()
     const onDeleteSession = vi.fn()
     const tree = WorkspaceSidebar({
       projectName: 'Example project',
@@ -119,6 +121,7 @@ describe('WorkspaceSidebar accessible render', () => {
       onOpenFiles: vi.fn(),
       onOpenSession,
       onRenameSession,
+      onDownloadArtifacts,
       onViewNotebook: vi.fn(),
       onTogglePin: vi.fn(),
       onDeleteSession,
@@ -132,6 +135,9 @@ describe('WorkspaceSidebar accessible render', () => {
         typeof element.props.onClick === 'function'
     )
     const renameItems = elements.filter((element) => getTextContent(element).trim() === 'Rename…')
+    const downloadItems = elements.filter(
+      (element) => getTextContent(element).trim() === 'Download all artifacts'
+    )
     const deleteItems = elements.filter((element) => getTextContent(element).trim() === 'Delete')
 
     expect(notebookButton?.props.onClick).toBeTypeOf('function')
@@ -141,6 +147,10 @@ describe('WorkspaceSidebar accessible render', () => {
     expect(renameItems[1]?.props.onSelect).toBeTypeOf('function')
     ;(renameItems[1]?.props.onSelect as () => void)()
     expect(onRenameSession).toHaveBeenCalledWith(sessions[1])
+
+    expect(downloadItems[1]?.props.onSelect).toBeTypeOf('function')
+    ;(downloadItems[1]?.props.onSelect as () => void)()
+    expect(onDownloadArtifacts).toHaveBeenCalledWith(sessions[1])
 
     expect(deleteItems[0]?.props.onSelect).toBeTypeOf('function')
     ;(deleteItems[0]?.props.onSelect as () => void)()
@@ -163,6 +173,7 @@ describe('WorkspaceSidebar accessible render', () => {
       onOpenFiles,
       onOpenSession: vi.fn(),
       onRenameSession: vi.fn(),
+      onDownloadArtifacts: vi.fn(),
       onViewNotebook: vi.fn(),
       onTogglePin: vi.fn(),
       onDeleteSession: vi.fn(),
@@ -202,6 +213,7 @@ describe('WorkspaceSidebar accessible render', () => {
       onOpenFiles: vi.fn(),
       onOpenSession: vi.fn(),
       onRenameSession: vi.fn(),
+      onDownloadArtifacts: vi.fn(),
       onTogglePin: vi.fn(),
       onDeleteSession: vi.fn(),
       onViewNotebook,
@@ -250,6 +262,7 @@ describe('WorkspaceSidebar accessible render', () => {
       onOpenFiles: vi.fn(),
       onOpenSession: vi.fn(),
       onRenameSession: vi.fn(),
+      onDownloadArtifacts: vi.fn(),
       onViewNotebook: vi.fn(),
       onTogglePin,
       onDeleteSession: vi.fn(),
@@ -286,6 +299,7 @@ describe('WorkspaceSidebar accessible render', () => {
       onOpenFiles: vi.fn(),
       onOpenSession: vi.fn(),
       onRenameSession: vi.fn(),
+      onDownloadArtifacts: vi.fn(),
       onViewNotebook: vi.fn(),
       onTogglePin: vi.fn(),
       onDeleteSession: vi.fn(),

--- a/src/renderer/src/pages/workspace/WorkspaceSidebar.render.test.tsx
+++ b/src/renderer/src/pages/workspace/WorkspaceSidebar.render.test.tsx
@@ -36,6 +36,7 @@ const renderSidebar = async (sessions: ChatSession[]): Promise<string> => {
       onOpenFiles={vi.fn()}
       onOpenSession={vi.fn()}
       onRenameSession={vi.fn()}
+      canDownloadArtifacts
       onDownloadArtifacts={vi.fn()}
       onViewNotebook={vi.fn()}
       onTogglePin={vi.fn()}
@@ -121,6 +122,7 @@ describe('WorkspaceSidebar accessible render', () => {
       onOpenFiles: vi.fn(),
       onOpenSession,
       onRenameSession,
+      canDownloadArtifacts: true,
       onDownloadArtifacts,
       onViewNotebook: vi.fn(),
       onTogglePin: vi.fn(),
@@ -173,6 +175,7 @@ describe('WorkspaceSidebar accessible render', () => {
       onOpenFiles,
       onOpenSession: vi.fn(),
       onRenameSession: vi.fn(),
+      canDownloadArtifacts: true,
       onDownloadArtifacts: vi.fn(),
       onViewNotebook: vi.fn(),
       onTogglePin: vi.fn(),
@@ -213,6 +216,7 @@ describe('WorkspaceSidebar accessible render', () => {
       onOpenFiles: vi.fn(),
       onOpenSession: vi.fn(),
       onRenameSession: vi.fn(),
+      canDownloadArtifacts: true,
       onDownloadArtifacts: vi.fn(),
       onTogglePin: vi.fn(),
       onDeleteSession: vi.fn(),
@@ -262,6 +266,7 @@ describe('WorkspaceSidebar accessible render', () => {
       onOpenFiles: vi.fn(),
       onOpenSession: vi.fn(),
       onRenameSession: vi.fn(),
+      canDownloadArtifacts: true,
       onDownloadArtifacts: vi.fn(),
       onViewNotebook: vi.fn(),
       onTogglePin,
@@ -299,6 +304,7 @@ describe('WorkspaceSidebar accessible render', () => {
       onOpenFiles: vi.fn(),
       onOpenSession: vi.fn(),
       onRenameSession: vi.fn(),
+      canDownloadArtifacts: true,
       onDownloadArtifacts: vi.fn(),
       onViewNotebook: vi.fn(),
       onTogglePin: vi.fn(),
@@ -313,5 +319,36 @@ describe('WorkspaceSidebar accessible render', () => {
     expect(pinItem?.props.disabled).toBe(true)
     expect(renameItem?.props.disabled).toBe(true)
     expect(deleteItem?.props.disabled).toBe(false)
+  })
+
+  it('hides artifact downloads when the runtime does not provide the desktop save capability', async () => {
+    const { WorkspaceSidebar } = await import('./WorkspaceSidebar')
+    const session = createSession({ id: 'session-a', title: 'Notebook review' })
+    const tree = WorkspaceSidebar({
+      projectName: 'Example project',
+      sessions: [session],
+      activeSessionId: session.id,
+      canCreateConversation: true,
+      canMutateConversations: true,
+      canDeleteConversations: true,
+      onGoHome: vi.fn(),
+      onNewConversation: vi.fn(),
+      isFilesOpen: false,
+      onOpenFiles: vi.fn(),
+      onOpenSession: vi.fn(),
+      onRenameSession: vi.fn(),
+      canDownloadArtifacts: false,
+      onDownloadArtifacts: vi.fn(),
+      onViewNotebook: vi.fn(),
+      onTogglePin: vi.fn(),
+      onDeleteSession: vi.fn(),
+      onOpenSettings: vi.fn()
+    })
+
+    const downloadItem = collectElements(tree).find(
+      (element) => getTextContent(element).trim() === 'Download all artifacts'
+    )
+
+    expect(downloadItem).toBeUndefined()
   })
 })

--- a/src/renderer/src/pages/workspace/WorkspaceSidebar.tsx
+++ b/src/renderer/src/pages/workspace/WorkspaceSidebar.tsx
@@ -1,4 +1,5 @@
 import {
+  Archive,
   BookOpen,
   ChevronLeft,
   Files,
@@ -14,6 +15,7 @@ import {
   DropdownMenu,
   DropdownMenuContent,
   DropdownMenuItem,
+  DropdownMenuSeparator,
   DropdownMenuTrigger
 } from '@/components/ui/dropdown-menu'
 
@@ -35,6 +37,7 @@ type WorkspaceSidebarProps = {
   onOpenFiles: () => void
   onOpenSession: (sessionId: string) => void
   onRenameSession: (session: ChatSession) => void
+  onDownloadArtifacts: (session: ChatSession) => void
   onViewNotebook: (session: ChatSession) => void
   onTogglePin: (session: ChatSession) => void
   onDeleteSession: (session: ChatSession) => void
@@ -83,6 +86,7 @@ const WorkspaceSidebar = ({
   onOpenFiles,
   onOpenSession,
   onRenameSession,
+  onDownloadArtifacts,
   onViewNotebook,
   onTogglePin,
   onDeleteSession,
@@ -254,6 +258,16 @@ const WorkspaceSidebar = ({
                               </span>
                               Rename…
                             </DropdownMenuItem>
+                            <DropdownMenuSeparator />
+                            <DropdownMenuItem
+                              className="gap-2"
+                              onSelect={() => onDownloadArtifacts(session)}
+                            >
+                              <span className={sessionMenuIconClassName}>
+                                <Archive className="size-4" strokeWidth={2} aria-hidden="true" />
+                              </span>
+                              Download all artifacts
+                            </DropdownMenuItem>
                             <DropdownMenuItem
                               className="gap-2"
                               onSelect={() => onViewNotebook(session)}
@@ -263,6 +277,7 @@ const WorkspaceSidebar = ({
                               </span>
                               View notebook
                             </DropdownMenuItem>
+                            <DropdownMenuSeparator />
                             {/* Delete uses the project's danger token pair for light surfaces. */}
                             <DropdownMenuItem
                               className="gap-2 text-danger-000 data-[highlighted]:bg-danger-900 data-[highlighted]:text-danger-000"

--- a/src/renderer/src/pages/workspace/WorkspaceSidebar.tsx
+++ b/src/renderer/src/pages/workspace/WorkspaceSidebar.tsx
@@ -37,6 +37,7 @@ type WorkspaceSidebarProps = {
   onOpenFiles: () => void
   onOpenSession: (sessionId: string) => void
   onRenameSession: (session: ChatSession) => void
+  canDownloadArtifacts: boolean
   onDownloadArtifacts: (session: ChatSession) => void
   onViewNotebook: (session: ChatSession) => void
   onTogglePin: (session: ChatSession) => void
@@ -86,6 +87,7 @@ const WorkspaceSidebar = ({
   onOpenFiles,
   onOpenSession,
   onRenameSession,
+  canDownloadArtifacts,
   onDownloadArtifacts,
   onViewNotebook,
   onTogglePin,
@@ -259,15 +261,17 @@ const WorkspaceSidebar = ({
                               Rename…
                             </DropdownMenuItem>
                             <DropdownMenuSeparator />
-                            <DropdownMenuItem
-                              className="gap-2"
-                              onSelect={() => onDownloadArtifacts(session)}
-                            >
-                              <span className={sessionMenuIconClassName}>
-                                <Archive className="size-4" strokeWidth={2} aria-hidden="true" />
-                              </span>
-                              Download all artifacts
-                            </DropdownMenuItem>
+                            {canDownloadArtifacts ? (
+                              <DropdownMenuItem
+                                className="gap-2"
+                                onSelect={() => onDownloadArtifacts(session)}
+                              >
+                                <span className={sessionMenuIconClassName}>
+                                  <Archive className="size-4" strokeWidth={2} aria-hidden="true" />
+                                </span>
+                                Download all artifacts
+                              </DropdownMenuItem>
+                            ) : null}
                             <DropdownMenuItem
                               className="gap-2"
                               onSelect={() => onViewNotebook(session)}

--- a/src/renderer/src/pages/workspace/session-artifact-download-data.test.ts
+++ b/src/renderer/src/pages/workspace/session-artifact-download-data.test.ts
@@ -1,0 +1,91 @@
+import { describe, expect, it, vi } from 'vitest'
+
+import type { ProjectFileItem } from '../../../../shared/project-files'
+import { listAllSessionArtifacts } from './session-artifact-download-data'
+
+const artifact = (id: string): ProjectFileItem => ({
+  id,
+  source: 'artifact',
+  sourceFileId: id,
+  projectId: 'project-1',
+  sessionId: 'session-1',
+  name: `${id}.csv`,
+  path: `artifact://${id}`,
+  size: 1024,
+  sortAtMs: 1
+})
+
+describe('Session Artifact download data', () => {
+  it('loads every page in one Source Session collection', async () => {
+    const firstPage = Array.from({ length: 100 }, (_, index) => artifact(`artifact-${index}`))
+    const finalArtifact = artifact('artifact-100')
+    const listFiles = vi
+      .fn()
+      .mockResolvedValueOnce({ items: firstPage, nextCursor: 'page-2', totalCount: 101 })
+      .mockResolvedValueOnce({ items: [finalArtifact], totalCount: 101 })
+    const getOverview = vi.fn().mockResolvedValue({
+      totalCount: 101,
+      uploadCount: 0,
+      artifactCount: 101,
+      artifactGroupCount: 1,
+      isIndexComplete: true
+    })
+    const repairIndex = vi.fn()
+
+    await expect(
+      listAllSessionArtifacts({
+        getOverview,
+        listFiles,
+        repairIndex,
+        projectId: 'project-1',
+        sessionId: 'session-1'
+      })
+    ).resolves.toEqual([...firstPage, finalArtifact])
+    expect(repairIndex).not.toHaveBeenCalled()
+    expect(listFiles).toHaveBeenNthCalledWith(1, {
+      projectId: 'project-1',
+      collection: { kind: 'sessionArtifacts', sessionId: 'session-1' },
+      limit: 100
+    })
+    expect(listFiles).toHaveBeenNthCalledWith(2, {
+      projectId: 'project-1',
+      collection: { kind: 'sessionArtifacts', sessionId: 'session-1' },
+      cursor: 'page-2',
+      limit: 100
+    })
+  })
+
+  it('repairs an incomplete Project Files index before listing Session Artifacts', async () => {
+    const getOverview = vi
+      .fn()
+      .mockResolvedValueOnce({
+        totalCount: 0,
+        uploadCount: 0,
+        artifactCount: 0,
+        artifactGroupCount: 0,
+        isIndexComplete: false
+      })
+      .mockResolvedValueOnce({
+        totalCount: 1,
+        uploadCount: 0,
+        artifactCount: 1,
+        artifactGroupCount: 1,
+        isIndexComplete: true
+      })
+    const repairIndex = vi.fn().mockResolvedValue(undefined)
+    const listFiles = vi.fn().mockResolvedValue({ items: [artifact('artifact-1')], totalCount: 1 })
+
+    await expect(
+      listAllSessionArtifacts({
+        getOverview,
+        listFiles,
+        repairIndex,
+        projectId: 'project-1',
+        sessionId: 'session-1'
+      })
+    ).resolves.toEqual([artifact('artifact-1')])
+    expect(repairIndex).toHaveBeenCalledWith({ projectId: 'project-1' })
+    expect(getOverview).toHaveBeenCalledTimes(2)
+    expect(listFiles).toHaveBeenCalledTimes(1)
+  })
+})

--- a/src/renderer/src/pages/workspace/session-artifact-download-data.ts
+++ b/src/renderer/src/pages/workspace/session-artifact-download-data.ts
@@ -1,0 +1,65 @@
+import type {
+  GetProjectFilesOverviewRequest,
+  ListProjectFilesRequest,
+  ProjectFileItem,
+  ProjectFilesOverview,
+  ProjectFilesPage
+} from '../../../../shared/project-files'
+
+type GetProjectFilesOverview = (
+  request: GetProjectFilesOverviewRequest
+) => Promise<ProjectFilesOverview>
+type ListProjectFiles = (request: ListProjectFilesRequest) => Promise<ProjectFilesPage>
+type RepairProjectFilesIndex = (request: { projectId: string }) => Promise<void>
+
+type ListAllSessionArtifactsOptions = {
+  getOverview: GetProjectFilesOverview
+  listFiles: ListProjectFiles
+  repairIndex: RepairProjectFilesIndex
+  projectId: string
+  sessionId: string
+}
+
+const SESSION_ARTIFACT_PAGE_LIMIT = 100
+
+// Hides cursor traversal from the dialog so its interface is one complete Source Session snapshot.
+const listAllSessionArtifacts = async ({
+  getOverview,
+  listFiles,
+  repairIndex,
+  projectId,
+  sessionId
+}: ListAllSessionArtifactsOptions): Promise<ProjectFileItem[]> => {
+  let overview = await getOverview({ projectId })
+  if (!overview.isIndexComplete) {
+    await repairIndex({ projectId })
+    overview = await getOverview({ projectId })
+    if (!overview.isIndexComplete) {
+      throw new Error('Some Session Artifacts could not be indexed yet.')
+    }
+  }
+
+  const artifacts: ProjectFileItem[] = []
+  let cursor: string | undefined
+
+  do {
+    const page = await listFiles({
+      projectId,
+      collection: { kind: 'sessionArtifacts', sessionId },
+      ...(cursor ? { cursor } : {}),
+      limit: SESSION_ARTIFACT_PAGE_LIMIT
+    })
+    artifacts.push(...page.items)
+    cursor = page.nextCursor
+  } while (cursor)
+
+  return artifacts
+}
+
+export { listAllSessionArtifacts }
+export type {
+  GetProjectFilesOverview,
+  ListAllSessionArtifactsOptions,
+  ListProjectFiles,
+  RepairProjectFilesIndex
+}

--- a/src/renderer/web/api-map.generated.ts
+++ b/src/renderer/web/api-map.generated.ts
@@ -100,6 +100,7 @@ export const WEB_INVOKE_CHANNELS = {
   'runtime.unregisterInterpreter': 'runtime:unregister-interpreter',
   saveBlobFile: 'file:save-blob',
   saveManagedFile: 'file:save-managed',
+  saveSessionArtifacts: 'file:save-session-artifacts',
   'sessions.deleteSession': 'sessions:delete-session',
   'sessions.loadAll': 'sessions:load-all',
   'sessions.saveManifest': 'sessions:save-manifest',

--- a/src/shared/file-save.ts
+++ b/src/shared/file-save.ts
@@ -18,9 +18,31 @@ type SaveManagedFileRequest = {
 
 type SaveManagedFileResult = SaveBlobFileResult
 
+type SaveSessionArtifactFile = {
+  path: string
+  suggestedName: string
+}
+
+type SaveSessionArtifactsRequest = {
+  projectId: string
+  sessionId: string
+  files: SaveSessionArtifactFile[]
+}
+
+type SaveSessionArtifactFailure = SaveSessionArtifactFile & {
+  message: string
+}
+
+type SaveSessionArtifactsResult =
+  { saved: false } | { saved: true; filePaths: string[]; failures?: SaveSessionArtifactFailure[] }
+
 export type {
   SaveBlobFileRequest,
   SaveBlobFileResult,
   SaveManagedFileRequest,
-  SaveManagedFileResult
+  SaveManagedFileResult,
+  SaveSessionArtifactFailure,
+  SaveSessionArtifactFile,
+  SaveSessionArtifactsRequest,
+  SaveSessionArtifactsResult
 }


### PR DESCRIPTION
## Problem

Session Artifacts can be inspected inside the workspace, but a user cannot export an entire Session collection or choose a subset of its generated files from the Session menu.

## Proposed change

- Add a Download all artifacts action to each Session menu.
- Open a selection dialog that loads every Artifact page, repairs an incomplete Project Files index before presenting the list, selects all items by default, and supports Check all and Uncheck all.
- Add a typed preload and main-process save flow. A single selection uses Save As; multiple selections use one destination folder, avoid overwriting name collisions, and report per-file failures without dropping successful downloads.
- Resolve immutable Artifact Versions within their Project and Source Session, while retaining Session-scoped compatibility for both Project and legacy default-project storage layouts.
- Update the generated web API map and workspace design guidance.

## Scope and non-goals

This PR covers Session Artifact export from the desktop Session menu. It does not export uploads, notebook inputs, Session transcripts, or a packaged Session archive. It does not change Artifact retention or deletion behavior.

## Acceptance criteria and validation

All listed checks ran after the last material edit.

- Session menu action, dialog selection, retry, partial-failure state, and Workspace wiring -> npm test -- src/renderer/src/pages/workspace/DownloadSessionArtifactsDialog.interaction.test.tsx src/renderer/src/pages/workspace/WorkspaceSidebar.render.test.tsx src/renderer/src/pages/workspace/WorkspacePage.draft-preservation.test.tsx -> passed.
- Complete pagination and incomplete-index repair -> npm test -- src/renderer/src/pages/workspace/session-artifact-download-data.test.ts -> passed.
- Single and batch saves, collision handling, partial source failures, and legacy namespace fallback -> npm test -- src/main/file-save.test.ts src/main/session-artifact-file-resolver.test.ts -> passed.
- Preload forwarding and generated web API synchronization -> npm test -- src/preload/index.test.ts src/renderer/web/api-map.generated.test.ts -> passed.
- Combined focused validation -> 124 tests passed across 8 affected test files.
- npm run typecheck -> passed.
- npm run lint -> passed with 0 errors; 23 existing warnings are outside this diff.
- npm test -> 8,542 tests passed and 139 skipped across 582 test files.

Independent Standards and Spec reviews found no remaining findings in the final state.

Uncovered risks: native save-dialog behavior is not exercised end-to-end on every supported operating system, and very large real-world Artifact batches were not performance-tested. IPC and filesystem behavior are covered with project-owned unit and interaction tests.

## Review focus

- Project and Source Session scoping for native and legacy Artifact paths.
- Partial batch behavior when a source disappears or a copy fails.
- Index-repair behavior before the dialog treats an empty list as authoritative.
