### PR TITLE
fix(specialist): harden validation and main-agent switching

### DIFF
--- a/src/main/specialist/service.test.ts
+++ b/src/main/specialist/service.test.ts
@@ -150,6 +150,20 @@ describe('ProfileService.setEnabled', () => {
   it('throws for unknown id', async () => {
     await expect(service.setEnabled('no-such-id', false)).rejects.toThrow()
   })
+
+  it('rejects a non-boolean enabled value without corrupting the profile', async () => {
+    const created = await service.create({ name: 'My Bot' })
+
+    await expect(service.setEnabled(created.id, 'false' as never)).rejects.toThrow(
+      /enabled must be a boolean/i
+    )
+
+    expect(await service.getById(created.id)).toMatchObject({
+      id: created.id,
+      enabled: true,
+      revision: created.revision
+    })
+  })
 })
 
 describe('ProfileService.update', () => {
@@ -229,6 +243,24 @@ describe('ProfileService.update', () => {
     expect((await service.getById(created.id)).revision).toBe(created.revision)
   })
 
+  it('rejects non-string identity fields without corrupting the stored profile', async () => {
+    const created = await service.create({ name: 'Safe Bot' })
+
+    await expect(
+      service.update({
+        id: created.id,
+        revision: created.revision,
+        systemPrompt: { injected: true }
+      } as never)
+    ).rejects.toThrow(/system prompt must be a string/i)
+
+    expect(await service.getById(created.id)).toMatchObject({
+      id: created.id,
+      name: 'Safe Bot',
+      revision: created.revision
+    })
+  })
+
   it('keeps the immutable id and supports renaming', async () => {
     const created = await service.create({ name: 'My Bot' })
     const updated = await service.update({
@@ -263,7 +295,7 @@ describe('ProfileService.update', () => {
   it('rejects a stale revision (optimistic concurrency conflict)', async () => {
     const created = await service.create({ name: 'My Bot' })
     await expect(
-      service.update({ id: created.id, revision: created.revision + 1, name: 'X' })
+      service.update({ id: created.id, revision: created.revision + 1, name: 'Valid Name' })
     ).rejects.toThrow(/revision conflict/i)
   })
 
@@ -327,6 +359,22 @@ describe('ProfileService.subscribe', () => {
 })
 
 describe('ProfileService lifecycle mutations', () => {
+  it('rejects malformed delete payloads without removing the profile', async () => {
+    const created = await service.create({ name: 'Safe Bot' })
+
+    await expect(service.delete(created.id, '1' as never)).rejects.toThrow(
+      /expected revision must be a positive integer/i
+    )
+    await expect(service.delete({ injected: true } as never)).rejects.toThrow(
+      /specialist id must be a non-empty string/i
+    )
+
+    expect(await service.getById(created.id)).toMatchObject({
+      id: created.id,
+      revision: created.revision
+    })
+  })
+
   it('keeps UUID stable across public rename and rejects a stale delete', async () => {
     const created = await service.create({ name: 'RNA Reviewer', displayName: 'RNA reviewer' })
     const renamed = await service.rename({

--- a/src/main/specialist/service.ts
+++ b/src/main/specialist/service.ts
@@ -99,11 +99,12 @@ const toView = (s: StoredSpecialist): SpecialistProfileView => ({
   revision: s.revision
 })
 
-const assertCreateInputShape = (input: CreateSpecialistInput): void => {
-  if (!input || typeof input !== 'object' || typeof input.name !== 'string') {
-    throw new Error('Name must be a string.')
-  }
-
+const assertOptionalIdentityFieldShapes = (
+  input: Pick<
+    UpdateSpecialistInput,
+    'description' | 'displayName' | 'systemPrompt' | 'iconKey' | 'colorKey'
+  >
+): void => {
   const optionalTextFields = [
     ['description', input.description],
     ['display name', input.displayName],
@@ -116,6 +117,13 @@ const assertCreateInputShape = (input: CreateSpecialistInput): void => {
       throw new Error(`${label[0].toUpperCase()}${label.slice(1)} must be a string.`)
     }
   }
+}
+
+const assertCreateInputShape = (input: CreateSpecialistInput): void => {
+  if (!input || typeof input !== 'object' || typeof input.name !== 'string') {
+    throw new Error('Name must be a string.')
+  }
+  assertOptionalIdentityFieldShapes(input)
 
   if (
     input.capabilityMode !== undefined &&
@@ -174,8 +182,8 @@ export class ProfileService {
     const existingNames = doc.specialists.map((s) => s.name)
     const existingIds = new Map(doc.specialists.map((s) => [s.name, s.id]))
 
-    // validateCreateSpecialistInput now applies the public-name format rule when
-    // displayName is present, so create and update share one symmetric rule set.
+    // Validate the required name and optional display name through the shared
+    // boundary rules before constructing the persisted record.
     const errors = validateCreateSpecialistInput(input, existingNames, existingIds)
     if (errors.length > 0) {
       throw new Error(errors.map((e) => e.message).join('; '))
@@ -207,6 +215,10 @@ export class ProfileService {
   }
 
   async setEnabled(id: string, enabled: boolean): Promise<SpecialistProfileView> {
+    if (typeof id !== 'string' || !id.trim()) {
+      throw new Error('Specialist id must be a non-empty string.')
+    }
+    if (typeof enabled !== 'boolean') throw new Error('Enabled must be a boolean.')
     const updatedDoc = await this.repo.setEnabled(id, enabled)
     this.notify()
     const found = updatedDoc.specialists.find((s) => s.id === id)
@@ -222,6 +234,10 @@ export class ProfileService {
     if (!input || typeof input.id !== 'string' || typeof input.revision !== 'number') {
       throw new Error('Update requires id and revision.')
     }
+    if (input.name !== undefined && typeof input.name !== 'string') {
+      throw new Error('Name must be a string.')
+    }
+    assertOptionalIdentityFieldShapes(input)
     assertCapabilityConfigShape(input)
 
     const doc = await this.repo.getAll()
@@ -271,6 +287,15 @@ export class ProfileService {
   }
 
   async delete(id: string, expectedRevision?: number): Promise<void> {
+    if (typeof id !== 'string' || !id.trim()) {
+      throw new Error('Specialist id must be a non-empty string.')
+    }
+    if (
+      expectedRevision !== undefined &&
+      (!Number.isInteger(expectedRevision) || expectedRevision < 1)
+    ) {
+      throw new Error('Expected revision must be a positive integer.')
+    }
     await this.repo.delete(id, expectedRevision)
     this.notify()
   }

--- a/src/renderer/src/pages/settings/SpecialistEditor.render.test.tsx
+++ b/src/renderer/src/pages/settings/SpecialistEditor.render.test.tsx
@@ -7,6 +7,7 @@ import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest'
 import { SpecialistEditor } from './SpecialistEditor'
 import { clickRadixMenuItem, openRadixMenu } from './test-utils'
 import { useSettingsStore } from '@/stores/settings-store'
+import { SPECIALIST_SYSTEM_PROMPT_MAX_LENGTH } from '../../../../shared/specialist'
 
 ;(globalThis as { IS_REACT_ACT_ENVIRONMENT?: boolean }).IS_REACT_ACT_ENVIRONMENT = true
 
@@ -396,14 +397,20 @@ describe('SpecialistEditor', () => {
     expect(document.body.querySelector('[data-specialist-icon="microscope"]')).not.toBeNull()
   })
 
-  it('caps Name and Description inputs and shows live character counters', async () => {
+  it('caps identity inputs and shows live character counters', async () => {
     await act(async () => {
       root.render(<SpecialistEditor onCancel={vi.fn()} onSave={vi.fn()} />)
     })
     expect(document.body.querySelector<HTMLInputElement>('#sp-name')!.maxLength).toBe(80)
     expect(document.body.querySelector<HTMLInputElement>('#sp-description')!.maxLength).toBe(200)
+    expect(document.body.querySelector<HTMLTextAreaElement>('#sp-system-prompt')!.maxLength).toBe(
+      SPECIALIST_SYSTEM_PROMPT_MAX_LENGTH
+    )
     expect(document.body.textContent).toContain('/ 80')
     expect(document.body.textContent).toContain('/ 200')
+    expect(document.body.textContent).toContain(
+      `/ ${SPECIALIST_SYSTEM_PROMPT_MAX_LENGTH.toLocaleString()}`
+    )
   })
 
   it('shows the saved identity bar only in edit mode', async () => {

--- a/src/renderer/src/pages/settings/SpecialistEditor.tsx
+++ b/src/renderer/src/pages/settings/SpecialistEditor.tsx
@@ -1,4 +1,5 @@
 import { useEffect, useMemo, useRef, useState, useCallback } from 'react'
+import { X } from 'lucide-react'
 import { Button } from '@/components/ui/button'
 import { Input } from '@/components/ui/input'
 import { Textarea } from '@/components/ui/textarea'
@@ -7,6 +8,7 @@ import { cn } from '@/lib/utils'
 import {
   SPECIALIST_DESCRIPTION_MAX_LENGTH,
   SPECIALIST_NAME_MAX_LENGTH,
+  SPECIALIST_SYSTEM_PROMPT_MAX_LENGTH,
   validateCreateSpecialistInput,
   type CreateSpecialistInput,
   type UpdateSpecialistInput,
@@ -16,6 +18,7 @@ import {
 import { SpecialistAvatar } from './specialist-avatar'
 import { AVATAR_COLORS, AVATAR_ICONS } from './specialist-icons'
 import { useSettingsStore } from '@/stores/settings-store'
+import { SettingsIconAction } from './SettingsLayout'
 
 type SpecialistEditorProps = {
   onCancel: () => void
@@ -649,6 +652,10 @@ const SpecialistEditor = ({
             instructions. Optional.
           </p>
           <div>
+            <div className="mb-1 text-right text-[11px] text-muted-foreground">
+              {form.systemPrompt.length.toLocaleString()} /{' '}
+              {SPECIALIST_SYSTEM_PROMPT_MAX_LENGTH.toLocaleString()}
+            </div>
             <label htmlFor="sp-system-prompt" className="sr-only">
               Instructions
             </label>
@@ -656,9 +663,13 @@ const SpecialistEditor = ({
               id="sp-system-prompt"
               value={form.systemPrompt}
               onChange={(e) => setForm((prev) => ({ ...prev, systemPrompt: e.target.value }))}
+              maxLength={SPECIALIST_SYSTEM_PROMPT_MAX_LENGTH}
               placeholder="Optional — leave empty to use the base prompt as-is."
               className="min-h-[120px] resize-y text-[13px]"
             />
+            {getFieldError('systemPrompt') ? (
+              <p className="mt-1 text-xs text-danger-000">{getFieldError('systemPrompt')}</p>
+            ) : null}
           </div>
         </section>
 
@@ -916,14 +927,12 @@ const SpecialistEditor = ({
                               ) : null}
                             </>
                           )}
-                          <button
-                            type="button"
-                            aria-label={`Remove ${skill.name}`}
+                          <SettingsIconAction
+                            label={`Remove ${skill.name}`}
+                            icon={X}
                             onClick={() => removeSkill(skill.id)}
-                            className="flex size-[22px] shrink-0 items-center justify-center rounded text-[12px] text-muted-foreground hover:bg-muted hover:text-destructive"
-                          >
-                            ✕
-                          </button>
+                            danger
+                          />
                         </div>
                       ))
                     )}
@@ -968,14 +977,12 @@ const SpecialistEditor = ({
                               Main disabled · available here
                             </span>
                           ) : null}
-                          <button
-                            type="button"
-                            aria-label={`Remove ${connector.name}`}
+                          <SettingsIconAction
+                            label={`Remove ${connector.name}`}
+                            icon={X}
                             onClick={() => removeConnector(connector.id)}
-                            className="flex size-[22px] shrink-0 items-center justify-center rounded text-[12px] text-muted-foreground hover:bg-muted hover:text-destructive"
-                          >
-                            ✕
-                          </button>
+                            danger
+                          />
                         </div>
                       ))
                     )}
@@ -1008,13 +1015,11 @@ const SpecialistEditor = ({
           <div
             role="alert"
             aria-label="Revision conflict"
-            className="mt-4 flex items-start gap-3 rounded-lg border border-amber-200 bg-amber-50 p-3 text-sm dark:border-amber-900 dark:bg-amber-950"
+            className="mt-4 flex items-start gap-3 rounded-lg border border-border bg-muted/50 p-3 text-sm"
           >
             <div className="min-w-0 flex-1">
-              <p className="font-semibold text-amber-900 dark:text-amber-100">
-                Someone else saved a newer version
-              </p>
-              <p className="mt-0.5 text-xs text-amber-700 dark:text-amber-300">
+              <p className="font-semibold text-foreground">Someone else saved a newer version</p>
+              <p className="mt-0.5 text-xs text-muted-foreground">
                 Your local edits are preserved. Reload to get the latest version (your unsaved
                 changes will be discarded), or cancel and try again.
               </p>
@@ -1026,7 +1031,7 @@ const SpecialistEditor = ({
                 variant="outline"
                 onClick={() => void handleReload()}
                 disabled={isReloading}
-                className="shrink-0 border-amber-300 text-amber-900 hover:bg-amber-100 dark:border-amber-700 dark:text-amber-100"
+                className="shrink-0"
               >
                 {isReloading ? 'Reloading…' : 'Reload'}
               </Button>

--- a/src/renderer/src/pages/settings/SpecialistsPanel.tsx
+++ b/src/renderer/src/pages/settings/SpecialistsPanel.tsx
@@ -15,6 +15,7 @@ import {
   DropdownMenuTrigger
 } from '@/components/ui/dropdown-menu'
 import { Input } from '@/components/ui/input'
+import { Tooltip, TooltipContent, TooltipProvider, TooltipTrigger } from '@/components/ui/tooltip'
 import { SettingsToggle } from './SettingsLayout'
 import { useSpecialistStore } from '@/stores/specialist-store'
 import type { CreateSpecialistInput } from '../../../../shared/specialist'
@@ -264,15 +265,24 @@ const SpecialistsPanel = ({ view, onNavigate }: SpecialistsPanelProps): React.JS
                           onToggle={() => void setEnabled(item.id, !item.enabled)}
                         />
                         <DropdownMenu>
-                          <DropdownMenuTrigger asChild>
-                            <Button
-                              variant="ghost"
-                              size="icon"
-                              aria-label={`Actions for ${item.displayName ?? item.name}`}
-                            >
-                              <ChevronDown aria-hidden="true" />
-                            </Button>
-                          </DropdownMenuTrigger>
+                          <TooltipProvider delayDuration={200}>
+                            <Tooltip>
+                              <TooltipTrigger asChild>
+                                <DropdownMenuTrigger asChild>
+                                  <Button
+                                    variant="ghost"
+                                    size="icon"
+                                    aria-label={`Actions for ${item.displayName ?? item.name}`}
+                                  >
+                                    <ChevronDown aria-hidden="true" />
+                                  </Button>
+                                </DropdownMenuTrigger>
+                              </TooltipTrigger>
+                              <TooltipContent>
+                                Actions for {item.displayName ?? item.name}
+                              </TooltipContent>
+                            </Tooltip>
+                          </TooltipProvider>
                           <DropdownMenuContent align="end">
                             <DropdownMenuItem
                               className="gap-2 text-xs"
@@ -327,7 +337,7 @@ const SpecialistsPanel = ({ view, onNavigate }: SpecialistsPanelProps): React.JS
                     className="flex min-h-14 items-center gap-2 py-2.5"
                   >
                     <span
-                      className="flex size-7 shrink-0 items-center justify-center rounded-lg bg-[#dcfce7] text-[13px]"
+                      className="flex size-7 shrink-0 items-center justify-center rounded-lg bg-primary/10 text-[13px] text-primary"
                       aria-hidden="true"
                     >
                       ✓
@@ -370,7 +380,7 @@ const SpecialistsPanel = ({ view, onNavigate }: SpecialistsPanelProps): React.JS
             {deleteError ? (
               <p
                 role="alert"
-                className="mt-3 rounded-lg border border-amber-200 bg-amber-50 px-3 py-2 text-xs text-amber-900 dark:border-amber-900 dark:bg-amber-950 dark:text-amber-100"
+                className="mt-3 rounded-lg border border-danger-000/30 bg-danger-000/10 px-3 py-2 text-xs text-danger-000"
               >
                 {deleteError}
               </p>

--- a/src/renderer/src/pages/workspace/WorkspacePage.specialist-barrier.test.tsx
+++ b/src/renderer/src/pages/workspace/WorkspacePage.specialist-barrier.test.tsx
@@ -300,6 +300,46 @@ describe('WorkspacePage fail-closed send gate', () => {
       specialistId: 'spec-b'
     })
   })
+
+  it('applies a pending switch to Main Agent before sending', async () => {
+    setupBase()
+    const setSessionSpecialist = vi.fn(() => Promise.resolve({ contextReset: false }))
+    useSessionStore.setState({
+      ...createInitialSessionState(),
+      sessions: [createSession({ specialistId: 'spec-a', status: 'running' })],
+      selectedSessionId: 'sess-a'
+    })
+    useSpecialistStore.setState({
+      items: [makeSpecialist('spec-a', 'Debugger')],
+      isLoaded: true,
+      load: vi.fn()
+    })
+    window.api = apiStub({ setSessionSpecialist })
+
+    await renderPage(root)
+
+    await act(async () => {
+      ;(conversationProps.onSpecialistChange as (id: string | undefined) => void)(undefined)
+    })
+    expect(conversationProps.specialistHasPendingSwitch).toBe(true)
+
+    await act(async () => {
+      useSessionStore.getState().finishRun('sess-a')
+    })
+    await act(async () => {
+      ;(conversationProps.onDraftDocChange as (doc: ComposerDoc) => void)(textDoc('continue'))
+    })
+    await act(async () => {
+      ;(conversationProps.onSendMessage as (ids: string[]) => void)([])
+    })
+
+    expect(setSessionSpecialist).toHaveBeenCalledWith({
+      sessionId: 'sess-a',
+      specialistId: undefined
+    })
+    expect(useSessionStore.getState().sessions[0].specialistId).toBeUndefined()
+    expect(runtime.sendMessage).toHaveBeenCalledOnce()
+  })
 })
 
 // ---------------------------------------------------------------------------
@@ -357,6 +397,69 @@ describe('WorkspacePage Retry recovery action', () => {
     expect(setSessionSpecialist).toHaveBeenCalledTimes(2)
     expect(runtime.sendMessage).toHaveBeenCalledOnce()
     expect(conversationProps.reconfigureError).toBeNull()
+  })
+
+  it('commits Main Agent to the session store only after Use None succeeds', async () => {
+    setupBase()
+    let resolveUseNone!: (value: { contextReset: boolean }) => void
+    const useNonePromise = new Promise<{ contextReset: boolean }>((resolve) => {
+      resolveUseNone = resolve
+    })
+    const setSessionSpecialist = vi
+      .fn()
+      .mockRejectedValueOnce(new Error('session reset failed'))
+      .mockReturnValueOnce(useNonePromise)
+
+    useSessionStore.setState({
+      ...createInitialSessionState(),
+      sessions: [createSession({ specialistId: 'spec-a', status: 'running' })],
+      selectedSessionId: 'sess-a'
+    })
+    useSpecialistStore.setState({
+      items: [makeSpecialist('spec-a', 'Debugger'), makeSpecialist('spec-b', 'Researcher')],
+      isLoaded: true,
+      load: vi.fn()
+    })
+    window.api = apiStub({ setSessionSpecialist })
+
+    await renderPage(root)
+    await act(async () => {
+      ;(conversationProps.onSpecialistChange as (id: string | undefined) => void)('spec-b')
+    })
+    await act(async () => {
+      useSessionStore.getState().finishRun('sess-a')
+      ;(conversationProps.onDraftDocChange as (doc: ComposerDoc) => void)(textDoc('keep me'))
+    })
+    await act(async () => {
+      ;(conversationProps.onSendMessage as (ids: string[]) => void)([])
+    })
+    expect(conversationProps.reconfigureError).toBeTruthy()
+
+    act(() => {
+      ;(conversationProps.onReconfigureUseNone as () => void)()
+    })
+    act(() => {
+      ;(conversationProps.onSendMessage as (ids: string[]) => void)([])
+      ;(conversationProps.onReconfigureUseNone as () => void)()
+      ;(conversationProps.onSpecialistChange as (id: string | undefined) => void)('spec-b')
+    })
+
+    expect(setSessionSpecialist).toHaveBeenCalledTimes(2)
+    expect(useSessionStore.getState().sessions[0].specialistId).toBe('spec-a')
+    expect(conversationProps.reconfigureError).toBeTruthy()
+    expect(runtime.sendMessage).not.toHaveBeenCalled()
+
+    await act(async () => {
+      resolveUseNone({ contextReset: false })
+    })
+
+    expect(setSessionSpecialist).toHaveBeenLastCalledWith({
+      sessionId: 'sess-a',
+      specialistId: undefined
+    })
+    expect(useSessionStore.getState().sessions[0].specialistId).toBeUndefined()
+    expect(conversationProps.reconfigureError).toBeNull()
+    expect(runtime.sendMessage).not.toHaveBeenCalled()
   })
 })
 

--- a/src/renderer/src/pages/workspace/WorkspacePage.tsx
+++ b/src/renderer/src/pages/workspace/WorkspacePage.tsx
@@ -1012,7 +1012,8 @@ const WorkspacePage = ({
     const pendingSpecialistId = activeSession
       ? pendingSessionSpecialist[activeSession.id]
       : undefined
-    const hasPendingSwitch = activeSession !== undefined && pendingSpecialistId !== undefined
+    const hasPendingSwitch =
+      activeSession !== undefined && Object.hasOwn(pendingSessionSpecialist, activeSession.id)
 
     // Dispatches the final send after draft/attachment state has been cleared.
     // Shared by the normal send path and the Retry recovery action so the logic stays in sync.
@@ -1080,7 +1081,10 @@ const WorkspacePage = ({
 
     // Runs the reconfigure barrier then dispatches the send on success. Extracted so that both the
     // initial send path and the Retry recovery action can invoke the same ordered sequence.
-    const runBarrierAndSend = async (sessionId: string, specialistId: string): Promise<void> => {
+    const runBarrierAndSend = async (
+      sessionId: string,
+      specialistId: string | undefined
+    ): Promise<void> => {
       // Mark the barrier as in-flight synchronously (ref) and reactively (state). The ref allows
       // the sendCurrentMessage guard to block a second call before the state re-render fires;
       // the state drives canSendMessage so the Send button also disables on the next render.
@@ -1104,7 +1108,11 @@ const WorkspacePage = ({
           (item) => item.kind === 'custom' && item.id === specialistId
         )
         const name =
-          pendingProfile?.kind === 'custom' ? pendingProfile.name : 'the selected specialist'
+          specialistId === undefined
+            ? 'Main Agent'
+            : pendingProfile?.kind === 'custom'
+              ? pendingProfile.name
+              : 'the selected specialist'
         setReconfigureError({
           sessionId,
           specialistName: name,
@@ -1384,6 +1392,7 @@ const WorkspacePage = ({
   const handleExistingSessionSpecialistChange = (specialistId: string | undefined): void => {
     if (!activeSession) return
     const sessionId = activeSession.id
+    if (barrierInFlightRef.current.has(sessionId)) return
     const isRunning =
       activeSession.status === 'running' || activeSession.status === 'waiting-permission'
 
@@ -1524,7 +1533,7 @@ const WorkspacePage = ({
             }
             specialistHasPendingSwitch={
               activeSession !== undefined &&
-              pendingSessionSpecialist[activeSession.id] !== undefined &&
+              Object.hasOwn(pendingSessionSpecialist, activeSession.id) &&
               (activeSession.status === 'running' || activeSession.status === 'waiting-permission')
             }
             reconfigureError={
@@ -1534,8 +1543,7 @@ const WorkspacePage = ({
               // Re-run the full barrier: clears the banner first, then re-attempts the switch
               // and, on success, dispatches the send — identical to the original send path.
               if (!reconfigureError || !activeSession) return
-              const pendingId = pendingSessionSpecialist[reconfigureError.sessionId]
-              if (pendingId === undefined) {
+              if (!Object.hasOwn(pendingSessionSpecialist, reconfigureError.sessionId)) {
                 setReconfigureError(null)
                 return
               }
@@ -1557,18 +1565,37 @@ const WorkspacePage = ({
             }}
             onReconfigureUseNone={() => {
               if (activeSession && reconfigureError) {
-                setPendingSessionSpecialist((prev) => {
-                  const next = { ...prev }
-                  delete next[activeSession.id]
-                  return next
-                })
-                setReconfigureError(null)
-                void window.api?.specialist
-                  ?.setSessionSpecialist?.({ sessionId: activeSession.id, specialistId: undefined })
+                const sessionId = activeSession.id
+                const specialistApi = window.api?.specialist
+                if (
+                  !specialistApi?.setSessionSpecialist ||
+                  barrierInFlightRef.current.has(sessionId)
+                ) {
+                  return
+                }
+                barrierInFlightRef.current.add(sessionId)
+                setBarrierInFlightSessions((prev) => new Set(prev).add(sessionId))
+                void specialistApi
+                  .setSessionSpecialist({ sessionId, specialistId: undefined })
                   ?.then((result) => {
-                    if (result?.contextReset) markSpecialistSwitchResetRequired(activeSession.id)
+                    if (result?.contextReset) markSpecialistSwitchResetRequired(sessionId)
+                    setSessionSpecialistId(sessionId, undefined)
+                    setPendingSessionSpecialist((prev) => {
+                      const next = { ...prev }
+                      delete next[sessionId]
+                      return next
+                    })
+                    setReconfigureError(null)
                   })
                   ?.catch((err: unknown) => console.warn('setSessionSpecialist (none) failed', err))
+                  ?.finally(() => {
+                    barrierInFlightRef.current.delete(sessionId)
+                    setBarrierInFlightSessions((prev) => {
+                      const next = new Set(prev)
+                      next.delete(sessionId)
+                      return next
+                    })
+                  })
               }
             }}
             onSpecialistChange={

--- a/src/shared/specialist.test.ts
+++ b/src/shared/specialist.test.ts
@@ -5,6 +5,8 @@ import {
   validateCreateSpecialistInput,
   validateUpdateSpecialistInput,
   SPECIALIST_DESCRIPTION_MAX_LENGTH,
+  SPECIALIST_DISPLAY_NAME_MAX_LENGTH,
+  SPECIALIST_SYSTEM_PROMPT_MAX_LENGTH,
   emptyFullAccessConfig,
   emptySelectedConfig,
   resolveEffectiveSpecialistSkills,
@@ -65,6 +67,36 @@ describe('validateCreateSpecialistInput', () => {
     const errors = validateCreateSpecialistInput({ name: 'My Bot' }, [], map)
     expect(errors.some((e) => e.field === 'name')).toBe(true)
   })
+
+  it('rejects invalid public names even when displayName is omitted', () => {
+    expect(
+      validateCreateSpecialistInput({ name: '<bad>' }, []).map((error) => error.message)
+    ).toContain('Name may only contain letters, digits, spaces, hyphens, and underscores.')
+    expect(
+      validateUpdateSpecialistInput({ id: 'specialist-1', revision: 1, name: '<bad>' }, []).map(
+        (error) => error.message
+      )
+    ).toContain('Name may only contain letters, digits, spaces, hyphens, and underscores.')
+  })
+
+  it('rejects blank or oversized display names on create and update', () => {
+    expect(
+      validateCreateSpecialistInput({ name: 'Bot', displayName: '   ' }, []).map(
+        (error) => error.message
+      )
+    ).toContain('Display name is required.')
+
+    expect(
+      validateUpdateSpecialistInput(
+        {
+          id: 'specialist-1',
+          revision: 1,
+          displayName: 'x'.repeat(SPECIALIST_DISPLAY_NAME_MAX_LENGTH + 1)
+        },
+        []
+      ).map((error) => error.message)
+    ).toContain(`Display name must be ${SPECIALIST_DISPLAY_NAME_MAX_LENGTH} characters or fewer.`)
+  })
 })
 
 describe('validateSpecialistDescription', () => {
@@ -100,6 +132,24 @@ describe('description validation in create/update inputs', () => {
       []
     )
     expect(errors.some((e) => e.field === 'description')).toBe(true)
+  })
+})
+
+describe('system prompt validation in create/update inputs', () => {
+  it('rejects prompts over the shared storage and runtime limit', () => {
+    const oversized = 'a'.repeat(SPECIALIST_SYSTEM_PROMPT_MAX_LENGTH + 1)
+
+    expect(
+      validateCreateSpecialistInput({ name: 'Bot', systemPrompt: oversized }, []).some(
+        (error) => error.field === 'systemPrompt'
+      )
+    ).toBe(true)
+    expect(
+      validateUpdateSpecialistInput(
+        { id: 'specialist-1', revision: 1, systemPrompt: oversized },
+        []
+      ).some((error) => error.field === 'systemPrompt')
+    ).toBe(true)
   })
 })
 

--- a/src/shared/specialist.ts
+++ b/src/shared/specialist.ts
@@ -224,6 +224,7 @@ export type SpecialistFieldError = {
 export const SPECIALIST_NAME_MAX_LENGTH = 80
 export const SPECIALIST_DISPLAY_NAME_MAX_LENGTH = 80
 export const SPECIALIST_DESCRIPTION_MAX_LENGTH = 200
+export const SPECIALIST_SYSTEM_PROMPT_MAX_LENGTH = 32_768
 
 // ---------------------------------------------------------------------------
 // Name validation
@@ -288,6 +289,13 @@ export const validateSpecialistDescription = (description: string): string | und
   return undefined
 }
 
+export const validateSpecialistSystemPrompt = (systemPrompt: string): string | undefined => {
+  if (systemPrompt.length > SPECIALIST_SYSTEM_PROMPT_MAX_LENGTH) {
+    return `System prompt must be ${SPECIALIST_SYSTEM_PROMPT_MAX_LENGTH} characters or fewer.`
+  }
+  return undefined
+}
+
 // Validate all fields for a CreateSpecialistInput.
 // Returns an array of field errors (empty = valid).
 export const validateCreateSpecialistInput = (
@@ -299,18 +307,24 @@ export const validateCreateSpecialistInput = (
 
   const nameError = validateSpecialistName(input.name, existingNames, undefined, existingIds)
   if (nameError) errors.push({ field: 'name', message: nameError })
-
-  // Apply public-name format rules when a displayName is sent (i.e. via the editor
-  // which always sends displayName). This ensures the error surfaces on the field,
-  // not after a round-trip to main.
-  if (input.displayName !== undefined) {
+  else {
     const publicNameError = validateSpecialistPublicName(input.name)
     if (publicNameError) errors.push({ field: 'name', message: publicNameError })
+  }
+
+  if (input.displayName !== undefined) {
+    const displayNameError = validateSpecialistDisplayName(input.displayName)
+    if (displayNameError) errors.push({ field: 'name', message: displayNameError })
   }
 
   if (input.description !== undefined) {
     const descriptionError = validateSpecialistDescription(input.description)
     if (descriptionError) errors.push({ field: 'description', message: descriptionError })
+  }
+
+  if (input.systemPrompt !== undefined) {
+    const systemPromptError = validateSpecialistSystemPrompt(input.systemPrompt)
+    if (systemPromptError) errors.push({ field: 'systemPrompt', message: systemPromptError })
   }
 
   return errors
@@ -329,18 +343,25 @@ export const validateUpdateSpecialistInput = (
   if (input.name !== undefined) {
     const nameError = validateSpecialistName(input.name, existingNames, input.id, existingIds)
     if (nameError) errors.push({ field: 'name', message: nameError })
-
-    // Apply same public-name format rules when displayName is present, keeping
-    // create and update symmetric.
-    if (input.displayName !== undefined) {
+    else {
       const publicNameError = validateSpecialistPublicName(input.name)
       if (publicNameError) errors.push({ field: 'name', message: publicNameError })
     }
   }
 
+  if (input.displayName !== undefined) {
+    const displayNameError = validateSpecialistDisplayName(input.displayName)
+    if (displayNameError) errors.push({ field: 'name', message: displayNameError })
+  }
+
   if (input.description !== undefined) {
     const descriptionError = validateSpecialistDescription(input.description)
     if (descriptionError) errors.push({ field: 'description', message: descriptionError })
+  }
+
+  if (input.systemPrompt !== undefined) {
+    const systemPromptError = validateSpecialistSystemPrompt(input.systemPrompt)
+    if (systemPromptError) errors.push({ field: 'systemPrompt', message: systemPromptError })
   }
 
   return errors


### PR DESCRIPTION
## Problem

Follow-up review of #530 found several non-permission hardening gaps in Specialist profile validation and renderer session switching:

- A pending selection of Main Agent was represented by `undefined`, so presence checks could mistake it for no pending switch.
- The `Use None` recovery path could update renderer state before the main-process switch succeeded and allowed concurrent send, retry, or picker actions.
- Malformed lifecycle payloads and oversized identity fields could cross the service boundary before validation.
- A few Specialist Settings controls lacked the shared tooltip/action treatment and semantic color tokens.

## Proposed change

- Treat an own-property with value `undefined` as an explicit pending Main Agent switch.
- Serialize the Main Agent recovery path with the existing per-session reconfigure barrier, committing renderer state only after main-process confirmation.
- Reject concurrent picker changes, duplicate recovery actions, and sends while that barrier is in flight.
- Centralize public/display-name, description, system-prompt, enable, and delete payload validation before persistence.
- Add a shared 32,768-character system-prompt limit with editor counter and `maxLength`.
- Use shared Settings icon actions/tooltips and semantic color tokens in Specialist Settings.

## Scope and non-goals

- No architecture, database schema, data model, or data-relationship changes.
- No permission policy, global Block/Ask behavior, or approval-flow changes; those remain with `feat/permission-management`.
- No ACP resume identity, runtime transactionality, connector gating, or custom MCP behavior changes.
- User-visible behavior changes are limited to deterministic Main Agent switching/recovery, bounded identity input, tooltips, and semantic Settings colors.

## Acceptance criteria and validation

- Main Agent pending selection and recovery serialization -> `npm test -- src/renderer/src/pages/workspace/WorkspacePage.specialist-barrier.test.tsx` -> 13/13 passed.
- Specialist service/shared validation and Settings rendering -> affected six-file test run -> 111/111 passed.
- Node and renderer type safety -> `npm run typecheck` -> passed.
- Repository lint -> `npm run lint` -> 0 errors; 23 pre-existing warnings outside this diff.
- Full regression suite after the final material edit -> `npm test -- --reporter=dot` -> 567 files and 8,539 tests passed; 11 files and 139 tests skipped; 3 existing failures remain in `spreadsheet-cache-policy.test.ts` (this branch does not modify that area).
- Patch hygiene -> `git diff --check` -> passed.
- Independent Spec and Standards reviews -> no remaining actionable findings.

Uncovered/deferred risks:

- The spreadsheet cache-policy suite has three unrelated baseline failures under the full run.
- Runtime resume identity/transactionality and connector/custom MCP hardening should be revisited after the permission-management work lands, so their shared runtime boundaries can be reviewed together.

## Review focus

- `Object.hasOwn` semantics for a pending Main Agent (`undefined`) selection.
- Per-session barrier lifecycle across Retry, Use None, send, and specialist picker actions.
- Service-boundary validation occurring before repository mutation/notification.
- Confirmation that the diff remains isolated from permission, ACP runtime, and connector implementation files.
