### PR TITLE
fix(windows-tests): make portability checks deterministic

### DIFF
--- a/.github/workflows/pr-check.yml
+++ b/.github/workflows/pr-check.yml
@@ -86,6 +86,8 @@ jobs:
           src/main/windows.test.ts
           src/main/windows-icon-assets.test.ts
           src/main/windows-powershell.test.ts
+          src/main/file-save.test.ts
+          src/main/specialist/repository.test.ts
           src/main/notebook/micromamba-cache-powershell.test.ts
           src/main/notebook/micromamba-cache-acl.integration.test.ts
 

--- a/scripts/pr-check-workflow.test.ts
+++ b/scripts/pr-check-workflow.test.ts
@@ -43,6 +43,8 @@ describe('PR Check platform test coverage', () => {
       'src/main/windows.test.ts',
       'src/main/windows-icon-assets.test.ts',
       'src/main/windows-powershell.test.ts',
+      'src/main/file-save.test.ts',
+      'src/main/specialist/repository.test.ts',
       'src/main/notebook/micromamba-cache-powershell.test.ts',
       'src/main/notebook/micromamba-cache-acl.integration.test.ts'
     ]) {

--- a/src/main/file-save.test.ts
+++ b/src/main/file-save.test.ts
@@ -6,11 +6,12 @@ import { join } from 'node:path'
 const downloadsPath = join('/Users/example', 'Downloads')
 
 const handlers = new Map<string, (event: unknown, payload?: unknown) => unknown>()
+const getAppPath = vi.hoisted(() => vi.fn())
 const showSaveDialog = vi.hoisted(() => vi.fn())
 const showOpenDialog = vi.hoisted(() => vi.fn())
 
 vi.mock('electron', () => ({
-  app: { getPath: vi.fn(() => '/Users/example/Downloads') },
+  app: { getPath: getAppPath },
   BrowserWindow: { fromWebContents: vi.fn(() => null) },
   dialog: { showOpenDialog, showSaveDialog },
   ipcMain: {
@@ -25,6 +26,8 @@ const { registerFileSaveHandlers } = await import('./file-save')
 describe('file save IPC handlers', () => {
   beforeEach(() => {
     handlers.clear()
+    getAppPath.mockReset()
+    getAppPath.mockReturnValue(downloadsPath)
     showOpenDialog.mockReset()
     showSaveDialog.mockReset()
   })

--- a/src/main/specialist/repository.test.ts
+++ b/src/main/specialist/repository.test.ts
@@ -1,6 +1,6 @@
 import { tmpdir } from 'node:os'
 import { join } from 'node:path'
-import { mkdir, rm, writeFile, chmod } from 'node:fs/promises'
+import { mkdir, rm, writeFile } from 'node:fs/promises'
 import { randomUUID } from 'node:crypto'
 import { describe, it, expect, beforeEach, afterEach } from 'vitest'
 
@@ -110,17 +110,12 @@ describe('SpecialistRepository.getAll', () => {
   })
 
   it('throws on non-ENOENT filesystem error instead of returning empty', async () => {
-    // Create the file then make it unreadable to trigger EACCES.
-    // Skip on CI environments that run as root (root ignores chmod 000).
+    // A directory at the expected file path makes readFile fail across supported platforms
+    // without relying on POSIX permission bits, which Windows does not enforce.
     const filePath = join(tmpDir, 'specialists.json')
-    await writeFile(filePath, '{}', 'utf8')
-    await chmod(filePath, 0o000)
+    await mkdir(filePath)
     const repo = new SpecialistRepository(tmpDir)
-    try {
-      await expect(repo.getAll()).rejects.toThrow()
-    } finally {
-      await chmod(filePath, 0o644)
-    }
+    await expect(repo.getAll()).rejects.toThrow()
   })
 })
 


### PR DESCRIPTION
## Problem

The advisory Windows full-suite job exposed two deterministic portability failures after merge:

- The file-save test compared a platform-native path with a POSIX-only Electron mock value.
- The specialist repository test used `chmod(000)` to simulate a read failure, which does not make files unreadable on Windows.

Because neither suite was part of the blocking Windows PR gate, the regressions were only visible after landing on `main`.

## Proposed change

- Make the Electron Downloads mock return the same platform-native fixture used by assertions.
- Trigger a real cross-platform non-`ENOENT` read failure by placing a directory at `specialists.json`.
- Add both suites to the blocking Windows PR gate and extend the workflow contract test.

## Scope and non-goals

- Test and CI configuration only.
- No production behavior, architecture, data model, data relationships, or user interaction changes.
- The advisory full-suite `continue-on-error` policy is unchanged.

## Acceptance criteria and validation

All checks below ran after the final material edit:

- Windows download-path fixture -> `npm test -- scripts/pr-check-workflow.test.ts src/main/file-save.test.ts src/main/specialist/repository.test.ts` -> 3 files / 63 tests passed.
- Cross-platform non-`ENOENT` fixture -> the same targeted command -> passed.
- Windows PR gate coverage -> the same targeted command -> workflow contract passed.
- Type safety -> `npm run typecheck` -> passed.
- Lint -> `npm run lint` -> passed with 0 errors (23 pre-existing warnings).
- Full regression suite -> `npm test` -> 572 files / 8,577 tests passed; 11 files / 139 tests skipped.
- Independent Standards and Spec reviews -> no findings.

Uncovered risk: local verification ran on macOS. This PR's blocking Windows job provides the final native-Windows proof.

## Review focus

- Whether using a directory at `specialists.json` is the preferred cross-platform real-filesystem failure.
- Whether both suites belong in the focused blocking Windows gate.

Related failure: https://github.com/aipoch/open-science/actions/runs/30597238900/job/91052181555
