### PR TITLE
fix(claude-code): bypass WebFetch preflight for custom providers

### DIFF
--- a/src/main/acp/permission-broker.test.ts
+++ b/src/main/acp/permission-broker.test.ts
@@ -1111,14 +1111,22 @@ describe('ACP permission broker', () => {
     const broker = new AcpPermissionBroker((request) => emitted.push(request))
 
     const firstFetch = broker.requestPermission(
-      createToolPermissionRequest({ sessionId: 'session-1', providerToolName: 'WebFetch' })
+      createToolPermissionRequest({
+        sessionId: 'session-1',
+        providerToolName: 'WebFetch',
+        rawInput: { url: 'https://www.ncbi.nlm.nih.gov/' }
+      })
     )
     broker.respond({ requestId: emitted[0].requestId, optionId: getSessionOptionId(emitted[0]) })
     await firstFetch
 
     // The same category in a different session must still prompt.
     broker.requestPermission(
-      createToolPermissionRequest({ sessionId: 'session-2', providerToolName: 'WebFetch' })
+      createToolPermissionRequest({
+        sessionId: 'session-2',
+        providerToolName: 'WebFetch',
+        rawInput: { url: 'https://www.ncbi.nlm.nih.gov/' }
+      })
     )
     expect(emitted).toHaveLength(2)
   })
@@ -1131,7 +1139,8 @@ describe('ACP permission broker', () => {
     const secondBroker = new AcpPermissionBroker((request) => secondEmitted.push(request), store)
     const request = createToolPermissionRequest({
       sessionId: 'shared-conversation',
-      providerToolName: 'WebFetch'
+      providerToolName: 'WebFetch',
+      rawInput: { url: 'https://www.ncbi.nlm.nih.gov/' }
     })
 
     const firstPermission = firstBroker.requestPermission(request)
@@ -1146,13 +1155,85 @@ describe('ACP permission broker', () => {
     })
     expect(secondEmitted).toHaveLength(0)
     expect(secondBroker.listGrants('shared-conversation')).toEqual([
-      expect.objectContaining({ categoryKey: 'tool:WebFetch', scope: 'session' })
+      expect.objectContaining({
+        categoryKey: 'webfetch:www.ncbi.nlm.nih.gov',
+        label: 'WebFetch (www.ncbi.nlm.nih.gov)',
+        scope: 'session'
+      })
     ])
 
     secondBroker.clearSession('shared-conversation')
     expect(firstBroker.listGrants('shared-conversation')).toEqual([])
     void firstBroker.requestPermission(request)
     expect(firstEmitted).toHaveLength(2)
+  })
+
+  it('scopes WebFetch conversation grants to the approved hostname', async () => {
+    const emitted: EmittedPermissionRequest[] = []
+    const broker = new AcpPermissionBroker((request) => emitted.push(request))
+    const firstRequest = createToolPermissionRequest({
+      providerToolName: 'WebFetch',
+      rawInput: { url: 'https://www.ncbi.nlm.nih.gov/' }
+    })
+
+    const firstPermission = broker.requestPermission(firstRequest)
+    broker.respond({
+      requestId: emitted[0].requestId,
+      optionId: getSessionOptionId(emitted[0])
+    })
+    await firstPermission
+
+    await expect(
+      broker.requestPermission(
+        createToolPermissionRequest({
+          providerToolName: 'WebFetch',
+          rawInput: { url: 'https://www.ncbi.nlm.nih.gov/research/' }
+        })
+      )
+    ).resolves.toEqual({ outcome: { outcome: 'selected', optionId: 'allow-once' } })
+    expect(emitted).toHaveLength(1)
+
+    void broker.requestPermission(
+      createToolPermissionRequest({
+        providerToolName: 'WebFetch',
+        rawInput: { url: 'https://example.com/' }
+      })
+    )
+    expect(emitted).toHaveLength(2)
+  })
+
+  it('offers only one-shot approval when a WebFetch hostname cannot be verified', () => {
+    const emitted: EmittedPermissionRequest[] = []
+    const broker = new AcpPermissionBroker((request) => emitted.push(request))
+
+    void broker.requestPermission(
+      createToolPermissionRequest({ providerToolName: 'WebFetch', rawInput: { url: 'not-a-url' } })
+    )
+
+    expect(emitted[0].options).not.toContainEqual(expect.objectContaining({ scope: 'session' }))
+  })
+
+  it('scopes WebFetch grants from the adapter title when raw input is absent', async () => {
+    const emitted: EmittedPermissionRequest[] = []
+    const broker = new AcpPermissionBroker((request) => emitted.push(request))
+
+    const permission = broker.requestPermission(
+      createToolPermissionRequest({
+        title: 'Fetch https://www.ncbi.nlm.nih.gov/research/',
+        providerToolName: 'WebFetch'
+      })
+    )
+
+    broker.respond({
+      requestId: emitted[0].requestId,
+      optionId: getSessionOptionId(emitted[0])
+    })
+    await permission
+
+    expect(emitted[0].title).toBe('Fetch https://www.ncbi.nlm.nih.gov/research/')
+    expect(broker.listGrants('session-1')).toEqual([
+      expect.objectContaining({ categoryKey: 'webfetch:www.ncbi.nlm.nih.gov' })
+    ])
   })
 
   it('shares MCP grants across hyphenated and underscore-sanitized framework identities', async () => {

--- a/src/main/acp/permission-broker.ts
+++ b/src/main/acp/permission-broker.ts
@@ -199,6 +199,26 @@ const resolveNotebookPermissionContext = (
   return { runtime: resolveNotebookRuntime(tool, rawInput) }
 }
 
+// WebFetch bypasses Claude's remote hostname preflight for custom API-key providers. Force any
+// conversation-wide approval to stay on the exact hostname the user reviewed; an absent or malformed
+// URL deliberately yields no category, so the broker offers only the provider's one-shot approval.
+const resolveWebFetchHostname = (params: RequestPermissionRequest): string | undefined => {
+  if (extractProviderToolName(params.toolCall) !== 'WebFetch') return undefined
+
+  const input = recordInput(params.toolCall.rawInput)
+  const inputUrl = typeof input?.url === 'string' ? input.url.trim() : undefined
+  const titleUrl = params.toolCall.title?.match(/^Fetch\s+(https?:\/\/\S+)$/i)?.[1]
+  const candidate = inputUrl || titleUrl
+  if (!candidate) return undefined
+
+  try {
+    const url = new URL(candidate)
+    return url.protocol === 'http:' || url.protocol === 'https:' ? url.hostname : undefined
+  } catch {
+    return undefined
+  }
+}
+
 const isMcpPermission = (
   params: RequestPermissionRequest,
   mcpServerNames: readonly string[]
@@ -249,9 +269,10 @@ const projectPermissionOptions = (
 // 1. MCP tool (recognized across frameworks — Claude's mcp__ prefix or an opencode <server>_ name):
 //    keyed by tool identity, with notebook execution tools further separated by runtime.
 // 2. Native Skill tool: keyed by the stable provider capability.
-// 3. Shell/execute tool (provider tool name Bash, or execute kind): keyed by concrete command signature.
-// 4. File operations: keyed by stable operation/tool identity, independent of target path.
-// 5. Other built-ins (WebFetch/…): keyed by stable provider tool name.
+// 3. WebFetch: keyed by the exact parsed hostname; malformed/missing URLs cannot receive a grant.
+// 4. Shell/execute tool (provider tool name Bash, or execute kind): keyed by concrete command signature.
+// 5. File operations: keyed by stable operation/tool identity, independent of target path.
+// 6. Other built-ins: keyed by stable provider tool name.
 // The MCP check runs before the execute branch so an opencode MCP tool reporting kind:execute (e.g. a
 // notebook execute-cell) is grouped as its own MCP tool, not misrouted to the shared Bash category.
 const resolveCategoryKey = (
@@ -279,6 +300,11 @@ const resolveCategoryKey = (
   }
 
   if (isSkillPermission(params)) return 'skill'
+
+  if (providerToolName === 'WebFetch') {
+    const hostname = resolveWebFetchHostname(params)
+    return hostname ? `webfetch:${hostname}` : undefined
+  }
 
   if (providerToolName === 'Bash' || toolCall.kind === 'execute') {
     const command = resolveShellCommand(params)
@@ -348,6 +374,15 @@ const describeGrant = (categoryKey: string): AcpPermissionGrant => {
       categoryKey,
       kind: 'tool',
       label: 'Skill',
+      scope: 'session'
+    }
+  }
+
+  if (categoryKey.startsWith('webfetch:')) {
+    return {
+      categoryKey,
+      kind: 'tool',
+      label: `WebFetch (${categoryKey.slice('webfetch:'.length)})`,
       scope: 'session'
     }
   }

--- a/src/main/settings/claude-config-provision.ts
+++ b/src/main/settings/claude-config-provision.ts
@@ -24,8 +24,9 @@ const GUARDED_FILE_TOOLS = ['Read', 'Edit', 'Glob', 'Grep'] as const
 //
 // Tradeoff: #105 originally denied WebSearch as an exfiltration-channel hardening measure (open-web
 // reach is a path for conversation/workspace data to leave the app). Re-opening it accepts that risk
-// in exchange for the model's built-in web reach. WebFetch additionally relies on the CLI's own
-// claude.ai domain-safety preflight (enforced inside the claude binary, not here) as a backstop.
+// in exchange for the model's built-in web reach. Subscription WebFetch additionally relies on the
+// CLI's claude.ai domain-safety preflight. Custom API-key sessions cannot reach that hard-coded check,
+// so they force WebFetch through the app broker and scope conversation grants to one hostname.
 const DENIED_BUILTIN_TOOLS = [] as const
 
 // Built-in tool deny entries this module OWNS across versions — the full set it has ever written into

--- a/src/main/settings/service.test.ts
+++ b/src/main/settings/service.test.ts
@@ -3019,7 +3019,10 @@ describe('SettingsService: preflight & spawn config', () => {
       CLAUDE_CONFIG_DIR: getAppClaudeConfigDir(storageRoot)
     })
     expect(config.sessionOptions).toEqual({
-      settings: { skipWebFetchPreflight: true }
+      settings: {
+        skipWebFetchPreflight: true,
+        permissions: { ask: ['WebFetch'] }
+      }
     })
     // Custom providers always use the bearer token variable, never x-api-key.
     expect(config.envOverrides.ANTHROPIC_API_KEY).toBeUndefined()
@@ -3140,7 +3143,10 @@ describe('SettingsService: official vendors', () => {
       ANTHROPIC_MODEL: 'deepseek-v4-flash'
     })
     expect(config.sessionOptions).toEqual({
-      settings: { skipWebFetchPreflight: true }
+      settings: {
+        skipWebFetchPreflight: true,
+        permissions: { ask: ['WebFetch'] }
+      }
     })
     expect(config.contextWindow).toBe(1_000_000)
   })

--- a/src/main/settings/service.test.ts
+++ b/src/main/settings/service.test.ts
@@ -3018,8 +3018,26 @@ describe('SettingsService: preflight & spawn config', () => {
       ANTHROPIC_MODEL: 'm',
       CLAUDE_CONFIG_DIR: getAppClaudeConfigDir(storageRoot)
     })
+    expect(config.sessionOptions).toEqual({
+      settings: { skipWebFetchPreflight: true }
+    })
     // Custom providers always use the bearer token variable, never x-api-key.
     expect(config.envOverrides.ANTHROPIC_API_KEY).toBeUndefined()
+  })
+
+  it('does not inject WebFetch preflight settings into isolated Claude sessions', async () => {
+    const service = createService()
+    const { encryptKey, maskKey } = await import('./crypto.js')
+    await repository.setClaudeInfo({ resolvedPath: execPath, version: '2.1.0' })
+    await repository.upsertClaudeIsolatedProvider({
+      keyRef: encryptKey('sk-ant-isolated'),
+      keyMask: maskKey('sk-ant-isolated')
+    })
+    await service.setActiveProvider(CLAUDE_ISOLATED_PROVIDER_ID)
+
+    const config = await service.resolveActiveSpawnConfig()
+
+    expect(config.sessionOptions).toBeUndefined()
   })
 
   it('throws a clear error when no active provider is configured', async () => {
@@ -3120,6 +3138,9 @@ describe('SettingsService: official vendors', () => {
       ANTHROPIC_BASE_URL: 'https://api.deepseek.com/anthropic',
       ANTHROPIC_AUTH_TOKEN: 'sk-ds',
       ANTHROPIC_MODEL: 'deepseek-v4-flash'
+    })
+    expect(config.sessionOptions).toEqual({
+      settings: { skipWebFetchPreflight: true }
     })
     expect(config.contextWindow).toBe(1_000_000)
   })

--- a/src/main/settings/service.ts
+++ b/src/main/settings/service.ts
@@ -3515,7 +3515,14 @@ class SettingsService {
             settings: join(appConfigDir, 'settings.json'),
             plugins: [{ type: 'local', path: appConfigDir, skipMcpDiscovery: true }]
           }
-        : undefined
+        : provider.type === 'custom'
+          ? {
+              // Custom Anthropic-compatible gateways may work while Anthropic's domain preflight
+              // endpoint is unreachable. Keep this override scoped to the ACP session so neither
+              // project/user settings nor the isolated Claude runtime configuration are mutated.
+              settings: { skipWebFetchPreflight: true }
+            }
+          : undefined
 
     return {
       envOverrides,

--- a/src/main/settings/service.ts
+++ b/src/main/settings/service.ts
@@ -3520,7 +3520,12 @@ class SettingsService {
               // Custom Anthropic-compatible gateways may work while Anthropic's domain preflight
               // endpoint is unreachable. Keep this override scoped to the ACP session so neither
               // project/user settings nor the isolated Claude runtime configuration are mutated.
-              settings: { skipWebFetchPreflight: true }
+              // WebFetch remains an explicit app-brokered permission, whose conversation grants are
+              // scoped to the approved hostname rather than the whole tool.
+              settings: {
+                skipWebFetchPreflight: true,
+                permissions: { ask: ['WebFetch'] }
+              }
             }
           : undefined
 


### PR DESCRIPTION
## Problem

Claude Code's built-in WebFetch performs Anthropic's domain-safety preflight before requesting the target URL. Sessions routed through Anthropic-compatible custom providers can reach their inference gateway while that hard-coded Anthropic preflight endpoint is unavailable or rejects the custom provider credential, so WebFetch fails before fetching public sites such as NCBI.

## Proposed change

- Inject `skipWebFetchPreflight: true` through the Claude ACP session options when the resolved provider is custom.
- Force `WebFetch` through the app permission broker for those sessions and scope conversation grants to the parsed target hostname.
- Cover both manually configured Anthropic-compatible providers and official catalog providers, which resolve through the same custom gateway path.
- Keep the override in memory for the session instead of writing a project, user, or app-owned settings file.

## Scope and non-goals

- Claude shared-subscription sessions retain their existing file-backed settings and local plugin configuration.
- Claude isolated-subscription sessions receive no WebFetch preflight override.
- Missing or malformed WebFetch URLs cannot receive a conversation-wide grant; Full Access retains its existing explicit native bypass semantics.
- This PR does not add UI or modify provider validation or network proxying.
- This PR does not change project-level or global Claude settings.

## Acceptance criteria and validation

- Custom, official-catalog, and isolated provider routing: covered by `src/main/settings/service.test.ts`.
- Hostname-scoped WebFetch grants, cross-host isolation, malformed URL handling, and adapter-title fallback: covered by `src/main/acp/permission-broker.test.ts`.
- Type safety: `npm run typecheck` — passed.
- Lint: `npm run lint` — passed with 0 errors (23 warnings outside the touched files).
- Full regression suite: `npm test` — passed (572 test files passed, 11 skipped; 8,581 tests passed, 139 skipped).

All successful checks above ran after the final material source edit.

Uncovered risk: no live Claude Code WebFetch request was made in the test suite. The implementation relies on Claude Agent SDK's documented inline `settings` option and `skipWebFetchPreflight` contract, plus the existing ACP session-options and permission-broker paths. Hostname scoping is user-mediated rather than a network-layer egress boundary, and redirects are handled by Claude Code after the initial target is approved.

## Review focus

- Whether resolving official catalog providers to the custom-provider branch is the intended scope.
- Whether the hostname-scoped permission tradeoff is acceptable for custom-provider sessions.
- Whether shared and isolated Claude subscription paths remain sufficiently constrained.

Closes #521
