### PR TITLE
fix(conversations): harden conversation exports

### DIFF
--- a/src/main/ipc.ts
+++ b/src/main/ipc.ts
@@ -888,7 +888,14 @@ const registerIpcHandlers = async ({
   registerSessionPersistenceIpcHandlers(sessionPersistenceBackend, reviewRepository)
   registerConversationExportIpcHandler(
     createConversationExportService({
-      loadSession: (projectId, sessionId) => sessionRepository.loadSession(projectId, sessionId)
+      loadSession: (projectId, sessionId) => sessionRepository.loadSession(projectId, sessionId),
+      isSessionActive: (projectId, sessionId) =>
+        runtime
+          .getActivePromptSessions()
+          .some(
+            (activeSession) =>
+              activeSession.projectName === projectId && activeSession.sessionId === sessionId
+          )
     })
   )
   registerProjectFilesIpcHandlers(

--- a/src/main/session-persistence/conversation-export.test.ts
+++ b/src/main/session-persistence/conversation-export.test.ts
@@ -45,6 +45,7 @@ const session: PersistedChatSession = {
 
 describe('conversation export service', () => {
   const loadSession = vi.fn()
+  const isSessionActive = vi.fn()
   const showSaveDialog = vi.fn()
   const writeExportFile = vi.fn()
   const createTempDirectory = vi.fn()
@@ -62,6 +63,7 @@ describe('conversation export service', () => {
   beforeEach(() => {
     vi.clearAllMocks()
     loadSession.mockResolvedValue(session)
+    isSessionActive.mockReturnValue(false)
     showSaveDialog.mockResolvedValue({ canceled: false, filePath: '/downloads/export.md' })
     writeExportFile.mockResolvedValue(undefined)
     createTempDirectory.mockResolvedValue('/tmp/open-science-conversation-export-test')
@@ -74,6 +76,7 @@ describe('conversation export service', () => {
   const createService = (): ReturnType<typeof createConversationExportService> =>
     createConversationExportService({
       loadSession,
+      isSessionActive,
       showSaveDialog,
       writeFile: writeExportFile,
       createTempDirectory,
@@ -177,6 +180,22 @@ describe('conversation export service', () => {
     ).resolves.toEqual({ saved: false })
     expect(createPrintWindow).not.toHaveBeenCalled()
     expect(writeExportFile).not.toHaveBeenCalled()
+  })
+
+  it('rejects a live prompt after its durable status was normalized on load', async () => {
+    loadSession.mockResolvedValue({ ...session, status: 'error' })
+    isSessionActive.mockReturnValue(true)
+
+    await expect(
+      createService().exportConversation({
+        projectId: 'project-1',
+        sessionId: 'session-1',
+        format: 'markdown'
+      })
+    ).rejects.toThrow('finish before exporting')
+
+    expect(isSessionActive).toHaveBeenCalledWith('project-1', 'session-1')
+    expect(showSaveDialog).not.toHaveBeenCalled()
   })
 
   it('rejects missing, empty, active and malformed conversations', async () => {

--- a/src/main/session-persistence/conversation-export.ts
+++ b/src/main/session-persistence/conversation-export.ts
@@ -23,6 +23,7 @@ type ConversationExportPrintWindow = {
 
 type ConversationExportDependencies = {
   loadSession(projectId: string, sessionId: string): Promise<PersistedChatSession | undefined>
+  isSessionActive(projectId: string, sessionId: string): boolean
   showSaveDialog(
     parentWindow: Electron.BrowserWindow | undefined,
     options: SaveDialogOptions
@@ -35,6 +36,16 @@ type ConversationExportDependencies = {
   getTempPath(): string
   now(): number
 }
+
+type ConversationExportRequiredDependencies = Pick<
+  ConversationExportDependencies,
+  'loadSession' | 'isSessionActive'
+>
+
+type ConversationExportDefaultDependencies = Omit<
+  ConversationExportDependencies,
+  keyof ConversationExportRequiredDependencies
+>
 
 type ConversationExportService = {
   exportConversation(
@@ -71,7 +82,7 @@ const createDefaultPrintWindow = (): ConversationExportPrintWindow =>
     }
   })
 
-const defaultDependencies: Omit<ConversationExportDependencies, 'loadSession'> = {
+const defaultDependencies: ConversationExportDefaultDependencies = {
   showSaveDialog: (parentWindow, options) =>
     parentWindow ? dialog.showSaveDialog(parentWindow, options) : dialog.showSaveDialog(options),
   writeFile,
@@ -84,8 +95,8 @@ const defaultDependencies: Omit<ConversationExportDependencies, 'loadSession'> =
 }
 
 const createConversationExportService = (
-  dependencies: Pick<ConversationExportDependencies, 'loadSession'> &
-    Partial<Omit<ConversationExportDependencies, 'loadSession'>>
+  dependencies: ConversationExportRequiredDependencies &
+    Partial<ConversationExportDefaultDependencies>
 ): ConversationExportService => {
   const deps: ConversationExportDependencies = { ...defaultDependencies, ...dependencies }
 
@@ -94,7 +105,11 @@ const createConversationExportService = (
       const request = assertExportConversationRequest(rawRequest)
       const session = await deps.loadSession(request.projectId, request.sessionId)
       if (!session) throw new Error('Conversation not found.')
-      if (session.status === 'running' || session.status === 'waiting-permission') {
+      if (
+        deps.isSessionActive(request.projectId, request.sessionId) ||
+        session.status === 'running' ||
+        session.status === 'waiting-permission'
+      ) {
         throw new Error('Wait for the conversation to finish before exporting it.')
       }
       if (session.messages.length === 0) throw new Error('Conversation has no messages to export.')

--- a/src/shared/conversation-export.test.ts
+++ b/src/shared/conversation-export.test.ts
@@ -142,6 +142,16 @@ describe('conversation export projection', () => {
     )
   })
 
+  it('replaces headless task automatic titles with the complete prompt-derived title', () => {
+    const session = createSession()
+    const prompt =
+      'Generate a reproducible analysis of the longitudinal dataset and summarize every validation step.'
+    session.messages[0].content = prompt
+    session.title = `${prompt.replace(/\s+/g, ' ').slice(0, 57)}...`
+
+    expect(createConversationExportDocument(session, 1_710_000_003_000).title).toBe(prompt)
+  })
+
   it('keeps the complete prompt-derived document title beyond the filename limit', () => {
     const session = createSession()
     const prompt = `😀${'x'.repeat(300)}`

--- a/src/shared/conversation-export.test.ts
+++ b/src/shared/conversation-export.test.ts
@@ -70,7 +70,10 @@ describe('conversation export projection', () => {
         '<think>\nfirst\n</think>\n\n# Result\n\n**kept**\n<think>second</think>'
       )
     ).toBe('# Result\n\n**kept**')
-    expect(sanitizeExportMarkdown('before <think>unfinished')).toBe('before <think>unfinished')
+  })
+
+  it('removes an unterminated provider think block through the end of the response', () => {
+    expect(sanitizeExportMarkdown('before <think>unfinished private reasoning')).toBe('before')
   })
 
   it('projects only user-facing active messages and attachment names', () => {
@@ -135,11 +138,11 @@ describe('conversation export projection', () => {
     session.title = `${prompt.replace(/\s+/g, ' ').slice(0, 48)}...`
 
     expect(createConversationExportDocument(session, 1_710_000_003_000).title).toBe(
-      'Create a detailed reproducible research note comparing three open-science data management approaches.'
+      'Create a detailed reproducible research note comparing three open-science data management approaches. Include: - tables - code'
     )
   })
 
-  it('marks prompt-derived title truncation and preserves complete Unicode characters', () => {
+  it('keeps the complete prompt-derived document title beyond the filename limit', () => {
     const session = createSession()
     const prompt = `😀${'x'.repeat(300)}`
     session.messages[0].content = prompt
@@ -147,10 +150,7 @@ describe('conversation export projection', () => {
 
     const title = createConversationExportDocument(session, 1_710_000_003_000).title
 
-    expect(Array.from(title)).toHaveLength(243)
-    expect(title.startsWith('😀')).toBe(true)
-    expect(title.endsWith('...')).toBe(true)
-    expect(title).not.toContain('\uFFFD')
+    expect(title).toBe(prompt)
   })
 
   it('preserves manually assigned titles even when they end in an ellipsis', () => {

--- a/src/shared/conversation-export.ts
+++ b/src/shared/conversation-export.ts
@@ -46,7 +46,9 @@ export type ConversationExportDocument = {
 
 const THINK_BLOCK_PATTERN = /<think\b[^>]*>[\s\S]*?(?:<\/think\s*>|$)/gi
 const UNSAFE_FILENAME_CHARACTERS = /[<>:"/\\|?*]+/g
-const LEGACY_AUTO_TITLE_MAX_LENGTH = 48
+const RENDERER_AUTO_TITLE_PREFIX_LENGTH = 48
+const HEADLESS_AUTO_TITLE_MAX_LENGTH = 60
+const HEADLESS_AUTO_TITLE_PREFIX_LENGTH = 57
 const EXPORT_FILENAME_MAX_BYTES = 240
 
 const escapeHtml = (value: string): string =>
@@ -59,11 +61,15 @@ const escapeHtml = (value: string): string =>
 
 const normalizeInlineText = (value: string): string => value.replace(/\s+/g, ' ').trim()
 
-const createLegacyAutoTitle = (content: string): string => {
+const isKnownTruncatedAutoTitle = (title: string, content: string): boolean => {
   const normalizedTitle = normalizeInlineText(content)
-  return normalizedTitle.length > LEGACY_AUTO_TITLE_MAX_LENGTH
-    ? `${normalizedTitle.slice(0, LEGACY_AUTO_TITLE_MAX_LENGTH)}...`
-    : normalizedTitle
+
+  return (
+    (normalizedTitle.length > RENDERER_AUTO_TITLE_PREFIX_LENGTH &&
+      title === `${normalizedTitle.slice(0, RENDERER_AUTO_TITLE_PREFIX_LENGTH)}...`) ||
+    (normalizedTitle.length > HEADLESS_AUTO_TITLE_MAX_LENGTH &&
+      title === `${normalizedTitle.slice(0, HEADLESS_AUTO_TITLE_PREFIX_LENGTH)}...`)
+  )
 }
 
 const deriveTitleFromPrompt = (content: string): string => {
@@ -77,11 +83,7 @@ const resolveConversationExportTitle = (session: PersistedChatSession): string =
   const firstUserMessage = session.messages.find((message) => message.role === 'user')
   const prompt = firstUserMessage?.content ?? ''
 
-  if (
-    prompt &&
-    storedTitle === createLegacyAutoTitle(prompt) &&
-    normalizeInlineText(prompt).length > LEGACY_AUTO_TITLE_MAX_LENGTH
-  ) {
+  if (prompt && isKnownTruncatedAutoTitle(storedTitle, prompt)) {
     return deriveTitleFromPrompt(prompt) || storedTitle
   }
 

--- a/src/shared/conversation-export.ts
+++ b/src/shared/conversation-export.ts
@@ -44,10 +44,9 @@ export type ConversationExportDocument = {
   messages: ConversationExportMessage[]
 }
 
-const THINK_BLOCK_PATTERN = /<think\b[^>]*>[\s\S]*?<\/think\s*>/gi
+const THINK_BLOCK_PATTERN = /<think\b[^>]*>[\s\S]*?(?:<\/think\s*>|$)/gi
 const UNSAFE_FILENAME_CHARACTERS = /[<>:"/\\|?*]+/g
 const LEGACY_AUTO_TITLE_MAX_LENGTH = 48
-const EXPORT_TITLE_MAX_LENGTH = 240
 const EXPORT_FILENAME_MAX_BYTES = 240
 
 const escapeHtml = (value: string): string =>
@@ -60,12 +59,6 @@ const escapeHtml = (value: string): string =>
 
 const normalizeInlineText = (value: string): string => value.replace(/\s+/g, ' ').trim()
 
-const truncateText = (value: string, maxLength: number): string => {
-  const characters = Array.from(value)
-  if (characters.length <= maxLength) return value
-  return `${characters.slice(0, maxLength).join('').trimEnd()}...`
-}
-
 const createLegacyAutoTitle = (content: string): string => {
   const normalizedTitle = normalizeInlineText(content)
   return normalizedTitle.length > LEGACY_AUTO_TITLE_MAX_LENGTH
@@ -74,15 +67,9 @@ const createLegacyAutoTitle = (content: string): string => {
 }
 
 const deriveTitleFromPrompt = (content: string): string => {
-  const firstLine =
-    content
-      .split(/\r?\n/)
-      .map((line) => line.trim())
-      .find(Boolean) ?? ''
-  const normalizedLine = normalizeInlineText(firstLine).replace(/^#{1,6}\s+/, '')
-  const sentence = normalizedLine.match(/^(.+?[.!?。！？])(?:\s|$)/)?.[1] ?? normalizedLine
+  const normalizedPrompt = normalizeInlineText(content).replace(/^#{1,6}\s+/, '')
 
-  return truncateText(sentence, EXPORT_TITLE_MAX_LENGTH).trim()
+  return normalizedPrompt.trim()
 }
 
 const resolveConversationExportTitle = (session: PersistedChatSession): string => {


### PR DESCRIPTION
## Problem

Follow-up review of #531 identified three implementation gaps:

- Durable session loading normalizes interrupted `running` and `waiting-permission` states to `error`, so the export guard did not observe the authoritative live state in production.
- An assistant response ending with an unterminated `<think>` block could expose partial private reasoning.
- Prompt-derived document titles kept only the first line/sentence and were truncated at 240 characters, even though truncation belongs at the filename boundary.

## Proposed change

- Require the export service to consult the ACP runtime's live in-flight prompt set, while retaining the durable-status guard as a secondary defense.
- Remove unterminated assistant `<think>` content through the end of the response.
- Derive document titles from the complete whitespace-normalized first user prompt and keep the existing 240-byte limit only in filename sanitization.
- Recognize both renderer and Headless Task API truncated automatic-title formats.
- Add regression coverage for all three review findings.

## Scope and non-goals

This PR only hardens the conversation-export path introduced by #531. It does not change the export UI, Markdown/PDF layouts, or session persistence recovery semantics.

## Acceptance criteria and validation

All commands below ran after the last material source edit:

- Live active-session exclusion after durable status normalization -> `npm test -- src/main/session-persistence/conversation-export.test.ts` -> passed (8/8).
- Unterminated reasoning removal and complete prompt-derived titles -> `npm test -- src/shared/conversation-export.test.ts` -> passed (13/13).
- Combined focused behavior -> `npm test -- src/shared/conversation-export.test.ts src/main/session-persistence/conversation-export.test.ts` -> passed (21/21).
- Type safety -> `npm run typecheck` -> passed.
- Lint -> `npm run lint` -> passed with 0 errors (23 existing warnings outside the changed files).
- Full regression suite -> `npm test` -> passed (8,605 passed; 139 skipped).
- Formatting -> `npx prettier --check src/shared/conversation-export.ts src/shared/conversation-export.test.ts src/main/session-persistence/conversation-export.ts src/main/session-persistence/conversation-export.test.ts src/main/ipc.ts` -> passed.
- Patch hygiene -> `git diff --check` -> passed.

Independent reviewer confirmation of this final evidence mapping is still pending, so this PR remains a draft.

## Review focus

- The live-state mapping uses `projectName` from the ACP runtime as the project id, matching the runtime/storage boundary's existing convention.
- The reasoning sanitizer intentionally removes from an unmatched assistant `<think>` opener through end-of-response.
- Full prompt text is retained in document metadata/headings; only the filesystem-safe filename is byte-limited.

## Uncovered risks

The Electron Save As dialog and rendered PDF output were not exercised manually; existing automated Markdown/PDF service and rendering tests cover those paths.
