### PR TITLE
feat(workspace): show turn token usage

### DIFF
--- a/src/main/acp/runtime.test.ts
+++ b/src/main/acp/runtime.test.ts
@@ -7431,6 +7431,13 @@ describe('ACP runtime session management', () => {
     expect(runtime.getSnapshot().contextUsageBySession).toMatchObject({
       s1: { used: 24, size: 200000 }
     })
+    expect(runtime.getSnapshot().events.find((event) => event.kind === 'stop')).toMatchObject({
+      turnUsage: {
+        inputTokens: 31,
+        cacheTokens: 15,
+        outputTokens: 14
+      }
+    })
   })
 
   it('corrects an unpatched external Codex total with its latest request usage at stop', async () => {

--- a/src/main/acp/runtime.test.ts
+++ b/src/main/acp/runtime.test.ts
@@ -7486,6 +7486,47 @@ describe('ACP runtime session management', () => {
     })
   })
 
+  it('keeps managed Codex turn totals separate from its latest context snapshot', async () => {
+    const process = new FakeAgentProcess()
+    startFakeAgent(process, ['s1'], {
+      modes: createModes(['read-only', 'agent', 'agent-full-access'], 'agent'),
+      onPrompt: () => ({
+        stopReason: 'end_turn',
+        usage: {
+          totalTokens: 27,
+          inputTokens: 19,
+          cachedReadTokens: 5,
+          outputTokens: 3
+        },
+        _meta: {
+          'open-science/turn-usage': {
+            totalTokens: 60,
+            inputTokens: 31,
+            cachedReadTokens: 8,
+            cachedWriteTokens: 7,
+            outputTokens: 14
+          }
+        }
+      })
+    })
+    const runtime = new AcpRuntime({
+      appVersion: '0.1.0',
+      defaultCwd: '/workspace',
+      spawnAgent: () => asAgentProcess(process),
+      framework: codexFramework
+    })
+
+    await runtime.createSession({ cwd: '/workspace' })
+    await runtime.sendPrompt({ sessionId: 's1', text: 'use a tool and summarize' })
+
+    expect(runtime.getSnapshot().contextUsageBySession).toMatchObject({
+      s1: { used: 24 }
+    })
+    expect(runtime.getSnapshot().events.find((event) => event.kind === 'stop')).toMatchObject({
+      turnUsage: { inputTokens: 31, cacheTokens: 15, outputTokens: 14 }
+    })
+  })
+
   it('uses OpenCode native input and cache-read context usage', async () => {
     const process = new FakeAgentProcess()
     startFakeAgent(process, ['s1'])

--- a/src/main/acp/runtime.test.ts
+++ b/src/main/acp/runtime.test.ts
@@ -7484,6 +7484,9 @@ describe('ACP runtime session management', () => {
     expect(runtime.getSnapshot().contextUsageBySession).toMatchObject({
       s1: { used: 15, size: 128000 }
     })
+    expect(
+      runtime.getSnapshot().events.find((event) => event.kind === 'stop')?.turnUsage
+    ).toBeUndefined()
   })
 
   it('keeps managed Codex turn totals separate from its latest context snapshot', async () => {

--- a/src/main/acp/runtime.ts
+++ b/src/main/acp/runtime.ts
@@ -2928,9 +2928,13 @@ class AcpRuntime {
             sessionId: request.sessionId,
             stopReason: message.stopReason
           })
+          const promptFramework = this.sessionFrameworks.get(request.sessionId) ?? this.framework.id
+          // Codex ACP exposes only the latest request in PromptResponse.usage. The managed adapter's
+          // app-owned metadata is the sole whole-turn source; other frameworks already accumulate usage.
           const turnUsage =
-            toAcpTurnTokenUsage(message.response._meta?.[ACP_TURN_TOKEN_USAGE_META_KEY]) ??
-            toAcpTurnTokenUsage(message.response.usage)
+            promptFramework === 'codex'
+              ? toAcpTurnTokenUsage(message.response._meta?.[ACP_TURN_TOKEN_USAGE_META_KEY])
+              : toAcpTurnTokenUsage(message.response.usage)
           this.pushEvent({
             kind: 'stop',
             level: 'info',

--- a/src/main/acp/runtime.ts
+++ b/src/main/acp/runtime.ts
@@ -37,7 +37,11 @@ import type {
   AcpSetPermissionProfileRequest,
   AcpStateSnapshot
 } from '../../shared/acp'
-import { getAcpRuntimeEventImage, MAX_ACP_SESSION_IMAGE_BYTES } from '../../shared/acp'
+import {
+  getAcpRuntimeEventImage,
+  MAX_ACP_SESSION_IMAGE_BYTES,
+  toAcpTurnTokenUsage
+} from '../../shared/acp'
 import { ACP_PROMPT_FAILED_EVENT_TITLE } from '../../shared/acp'
 import {
   DEFAULT_PERMISSION_PROFILE,
@@ -2929,6 +2933,7 @@ class AcpRuntime {
             sessionId: request.sessionId,
             title: 'Prompt stopped',
             text: message.stopReason,
+            turnUsage: toAcpTurnTokenUsage(message.response.usage),
             raw: message.response
           })
           if (this.shouldAutoCompactContext(request.sessionId)) {
@@ -5663,6 +5668,7 @@ class AcpRuntime {
       compactionReason: event.compactionReason,
       recoverable: event.recoverable,
       providerError: event.providerError,
+      turnUsage: event.turnUsage,
       sessionId: event.sessionId,
       messageId: event.messageId,
       role: event.role,

--- a/src/main/acp/runtime.ts
+++ b/src/main/acp/runtime.ts
@@ -38,6 +38,7 @@ import type {
   AcpStateSnapshot
 } from '../../shared/acp'
 import {
+  ACP_TURN_TOKEN_USAGE_META_KEY,
   getAcpRuntimeEventImage,
   MAX_ACP_SESSION_IMAGE_BYTES,
   toAcpTurnTokenUsage
@@ -2927,13 +2928,16 @@ class AcpRuntime {
             sessionId: request.sessionId,
             stopReason: message.stopReason
           })
+          const turnUsage =
+            toAcpTurnTokenUsage(message.response._meta?.[ACP_TURN_TOKEN_USAGE_META_KEY]) ??
+            toAcpTurnTokenUsage(message.response.usage)
           this.pushEvent({
             kind: 'stop',
             level: 'info',
             sessionId: request.sessionId,
             title: 'Prompt stopped',
             text: message.stopReason,
-            turnUsage: toAcpTurnTokenUsage(message.response.usage),
+            turnUsage,
             raw: message.response
           })
           if (this.shouldAutoCompactContext(request.sessionId)) {

--- a/src/main/settings/managed-codex.test.ts
+++ b/src/main/settings/managed-codex.test.ts
@@ -17,6 +17,8 @@ import { Readable } from 'node:stream'
 import { gzipSync } from 'node:zlib'
 import { afterEach, describe, expect, it, vi } from 'vitest'
 
+import { ACP_TURN_TOKEN_USAGE_META_KEY, toAcpTurnTokenUsage } from '../../shared/acp'
+
 const PINNED_SKILL_MAPPER_FIXTURE = [
   'function buildPromptItems(prompt) {',
   '  return prompt.map((block) => {',
@@ -1415,6 +1417,24 @@ describe('patchCodexAcpTurnUsageSource', () => {
     '  return adapter;'
   ].join('\n')
 
+  // Mirrors codex-acp 1.1.4's buildPromptUsage -> toPromptUsage output rather than using the
+  // passthrough mapper above, so this fixture covers the adapter-to-runtime cache-field contract.
+  const fixtureWithPinnedPromptUsage = fixture.replace(
+    '    buildPromptUsage(usage) { return usage; },',
+    [
+      '    buildPromptUsage(tokenCount) {',
+      '      if (tokenCount == null) return null;',
+      '      return {',
+      '        totalTokens: tokenCount.totalTokens,',
+      '        inputTokens: tokenCount.inputTokens,',
+      '        cachedReadTokens: tokenCount.cachedInputTokens,',
+      '        outputTokens: tokenCount.outputTokens,',
+      '        thoughtTokens: tokenCount.reasoningOutputTokens',
+      '      };',
+      '    },'
+    ].join('\n')
+  )
+
   const usage = (
     totalTokens: number,
     inputTokens: number,
@@ -1484,6 +1504,41 @@ describe('patchCodexAcpTurnUsageSource', () => {
     expect(response.usage).toEqual(usage(27, 19, 5, 3, 0))
     expect(response._meta?.['open-science/turn-usage']).toEqual(usage(45, 31, 8, 6, 0))
     expect(patchCodexAcpTurnUsageSource(patched)).toBe(patched)
+  })
+
+  it('preserves cached-input totals through the pinned adapter mapping and ACP normalization', () => {
+    const adapter = Function(patchCodexAcpTurnUsageSource(fixtureWithPinnedPromptUsage))() as {
+      startPrompt: () => void
+      createUsageUpdate: (params: unknown) => void
+      finishPrompt: () => { _meta?: Record<string, unknown> }
+    }
+
+    adapter.createUsageUpdate({
+      tokenUsage: {
+        last: usage(100, 70, 13, 15, 2),
+        total: usage(100, 70, 13, 15, 2)
+      }
+    })
+    adapter.startPrompt()
+    adapter.createUsageUpdate({
+      tokenUsage: {
+        last: usage(18, 12, 3, 3, 0),
+        total: usage(118, 82, 16, 18, 2)
+      }
+    })
+    adapter.createUsageUpdate({
+      tokenUsage: {
+        last: usage(27, 19, 5, 3, 0),
+        total: usage(145, 101, 21, 21, 2)
+      }
+    })
+
+    const response = adapter.finishPrompt()
+    expect(toAcpTurnTokenUsage(response._meta?.[ACP_TURN_TOKEN_USAGE_META_KEY])).toEqual({
+      inputTokens: 31,
+      cacheTokens: 8,
+      outputTokens: 6
+    })
   })
 
   it('uses the first request snapshot when a resumed session has no cumulative baseline', () => {

--- a/src/main/settings/managed-codex.test.ts
+++ b/src/main/settings/managed-codex.test.ts
@@ -123,7 +123,7 @@ vi.mock('node:fs/promises', async (importActual) => {
       const [file, data] = args
       if (fsFaults.pauseNextWrite && typeof data === 'string') {
         fsFaults.pauseNextWrite = false
-        const patchTarget = '    const lastTokenUsage = this.sessionState.lastTokenUsage;'
+        const patchTarget = '    const contextTokenUsage = this.sessionState.lastTokenUsage;'
         const targetOffset = data.indexOf(patchTarget)
         if (targetOffset !== -1) {
           await actual.writeFile(file, data.slice(0, targetOffset))
@@ -1225,7 +1225,7 @@ describe('patchCodexAcpContextUsageSource', () => {
     const patched = patchCodexAcpContextUsageSource(source)
 
     expect(patched).toContain(
-      'lastTokenUsage.inputTokens + (lastTokenUsage.cachedInputTokens ?? 0)'
+      'contextTokenUsage.inputTokens + (contextTokenUsage.cachedInputTokens ?? 0)'
     )
     expect(patched).not.toContain('lastTokenUsage?.totalTokens')
     expect(patchCodexAcpContextUsageSource(patched)).toBe(patched)
@@ -1250,7 +1250,7 @@ describe('patchCodexAcpContextUsageSource', () => {
       await ensureManagedCodexContextUsage(adapterPath)
 
       expect(await readFile(adapterPath, 'utf8')).toContain(
-        'lastTokenUsage.inputTokens + (lastTokenUsage.cachedInputTokens ?? 0)'
+        'contextTokenUsage.inputTokens + (contextTokenUsage.cachedInputTokens ?? 0)'
       )
     } finally {
       await rm(patchRoot, { recursive: true, force: true })
@@ -1306,7 +1306,7 @@ describe('patchCodexAcpContextUsageSource', () => {
         await ensureManagedCodexContextUsage(adapterPath)
 
         expect(await readFile(adapterPath, 'utf8')).toContain(
-          'lastTokenUsage.inputTokens + (lastTokenUsage.cachedInputTokens ?? 0)'
+          'contextTokenUsage.inputTokens + (contextTokenUsage.cachedInputTokens ?? 0)'
         )
       } finally {
         fsFaults.adapterReplaceFailures = 0
@@ -1352,7 +1352,7 @@ describe('patchCodexAcpContextUsageSource', () => {
 
       await expect(firstCheck).resolves.toBeUndefined()
       expect(await readFile(adapterPath, 'utf8')).toContain(
-        'lastTokenUsage.inputTokens + (lastTokenUsage.cachedInputTokens ?? 0)'
+        'contextTokenUsage.inputTokens + (contextTokenUsage.cachedInputTokens ?? 0)'
       )
     } finally {
       releaseWrite?.()
@@ -1434,7 +1434,10 @@ describe('patchCodexAcpTurnUsageSource', () => {
     const adapter = Function(patched)() as {
       startPrompt: () => void
       createUsageUpdate: (params: unknown) => void
-      finishPrompt: () => { usage: ReturnType<typeof usage> | null }
+      finishPrompt: () => {
+        usage: ReturnType<typeof usage> | null
+        _meta?: Record<string, unknown>
+      }
     }
 
     // Seed the previous completed turn so the first update is derived from cumulative totals.
@@ -1465,7 +1468,9 @@ describe('patchCodexAcpTurnUsageSource', () => {
       }
     })
 
-    expect(adapter.finishPrompt().usage).toEqual(usage(45, 31, 8, 6, 0))
+    const response = adapter.finishPrompt()
+    expect(response.usage).toEqual(usage(27, 19, 5, 3, 0))
+    expect(response._meta?.['open-science/turn-usage']).toEqual(usage(45, 31, 8, 6, 0))
     expect(patchCodexAcpTurnUsageSource(patched)).toBe(patched)
   })
 
@@ -1484,7 +1489,29 @@ describe('patchCodexAcpTurnUsageSource', () => {
       }
     })
 
-    expect(adapter.finishPrompt().usage).toEqual(usage(18, 12, 3, 3, 0))
+    const response = adapter.finishPrompt() as {
+      usage: ReturnType<typeof usage> | null
+      _meta?: Record<string, unknown>
+    }
+    expect(response.usage).toEqual(usage(18, 12, 3, 3, 0))
+    expect(response._meta?.['open-science/turn-usage']).toEqual(usage(18, 12, 3, 3, 0))
+  })
+
+  it('composes with the context-usage patch without duplicate declarations', () => {
+    const contextFixture = fixture.replace(
+      '    this.handleTokenUsageUpdated(params);\n    return null;',
+      [
+        '    this.handleTokenUsageUpdated(params);',
+        '    const used = this.sessionState.lastTokenUsage?.totalTokens;',
+        '    return used;'
+      ].join('\n')
+    )
+    const composed = patchCodexAcpTurnUsageSource(patchCodexAcpContextUsageSource(contextFixture))
+
+    expect(() => Function(composed)).not.toThrow()
+    expect(composed).toContain(
+      'contextTokenUsage.inputTokens + (contextTokenUsage.cachedInputTokens ?? 0)'
+    )
   })
 })
 

--- a/src/main/settings/managed-codex.test.ts
+++ b/src/main/settings/managed-codex.test.ts
@@ -1380,7 +1380,7 @@ describe('patchCodexAcpTurnUsageSource', () => {
   type FixtureTokenUsage = {
     totalTokens: number
     inputTokens: number
-    cachedInputTokens: number
+    cachedInputTokens?: number
     outputTokens: number
     reasoningOutputTokens: number
   }
@@ -1425,6 +1425,18 @@ describe('patchCodexAcpTurnUsageSource', () => {
     totalTokens,
     inputTokens,
     cachedInputTokens,
+    outputTokens,
+    reasoningOutputTokens
+  })
+
+  const uncachedUsage = (
+    totalTokens: number,
+    inputTokens: number,
+    outputTokens: number,
+    reasoningOutputTokens: number
+  ): FixtureTokenUsage => ({
+    totalTokens,
+    inputTokens,
     outputTokens,
     reasoningOutputTokens
   })
@@ -1495,6 +1507,67 @@ describe('patchCodexAcpTurnUsageSource', () => {
     }
     expect(response.usage).toEqual(usage(18, 12, 3, 3, 0))
     expect(response._meta?.['open-science/turn-usage']).toEqual(usage(18, 12, 3, 3, 0))
+  })
+
+  it('normalizes omitted cached-input counters without double-counting repeated updates', () => {
+    const adapter = Function(patchCodexAcpTurnUsageSource(fixture))() as {
+      startPrompt: () => void
+      createUsageUpdate: (params: unknown) => void
+      finishPrompt: () => { _meta?: Record<string, unknown> }
+    }
+
+    adapter.createUsageUpdate({
+      tokenUsage: {
+        last: uncachedUsage(100, 70, 15, 2),
+        total: uncachedUsage(100, 70, 15, 2)
+      }
+    })
+    adapter.startPrompt()
+    for (const snapshot of [
+      uncachedUsage(118, 82, 18, 2),
+      uncachedUsage(118, 82, 18, 2),
+      uncachedUsage(145, 101, 21, 2)
+    ]) {
+      adapter.createUsageUpdate({
+        tokenUsage: {
+          last:
+            snapshot.totalTokens === 118
+              ? uncachedUsage(18, 12, 3, 0)
+              : uncachedUsage(27, 19, 3, 0),
+          total: snapshot
+        }
+      })
+    }
+
+    expect(adapter.finishPrompt()._meta?.['open-science/turn-usage']).toEqual(
+      usage(45, 31, 0, 6, 0)
+    )
+  })
+
+  it('upgrades the existing turn-usage patch to normalize cached-input counters', () => {
+    const normalized = patchCodexAcpTurnUsageSource(fixture)
+    const legacy = normalized
+      .replace(
+        [
+          '    const normalizeTokenUsage = (usage) =>',
+          '      usage == null',
+          '        ? usage',
+          '        : { ...usage, cachedInputTokens: usage.cachedInputTokens ?? 0 };',
+          '    const previousTotalTokenUsage = normalizeTokenUsage(this.sessionState.totalTokenUsage);'
+        ].join('\n'),
+        '    const previousTotalTokenUsage = this.sessionState.totalTokenUsage;'
+      )
+      .replace(
+        '    const currentTotalTokenUsage = normalizeTokenUsage(this.sessionState.totalTokenUsage);',
+        '    const currentTotalTokenUsage = this.sessionState.totalTokenUsage;'
+      )
+      .replace(
+        '    const lastTokenUsage = normalizeTokenUsage(this.sessionState.lastTokenUsage);',
+        '    const lastTokenUsage = this.sessionState.lastTokenUsage;'
+      )
+
+    expect(legacy).not.toBe(normalized)
+    expect(patchCodexAcpTurnUsageSource(legacy)).toBe(normalized)
   })
 
   it('composes with the context-usage patch without duplicate declarations', () => {

--- a/src/main/settings/managed-codex.test.ts
+++ b/src/main/settings/managed-codex.test.ts
@@ -178,6 +178,7 @@ import {
   patchCodexAcpContextUsageSource,
   patchCodexAcpModelCatalogStartupSource,
   patchCodexAcpSkillInputSource,
+  patchCodexAcpTurnUsageSource,
   resolveManagedCodexPlatform,
   sanitizeManagedCodexDiagnostic,
   verifyManagedCodexPair,
@@ -1372,6 +1373,118 @@ describe('patchCodexAcpContextUsageSource', () => {
     expect(() => patchCodexAcpContextUsageSource(drifted)).toThrow(
       /context-usage patch no longer matches/
     )
+  })
+})
+
+describe('patchCodexAcpTurnUsageSource', () => {
+  type FixtureTokenUsage = {
+    totalTokens: number
+    inputTokens: number
+    cachedInputTokens: number
+    outputTokens: number
+    reasoningOutputTokens: number
+  }
+
+  const fixture = [
+    '  const sessionState = { currentTurnId: null, lastTokenUsage: null, totalTokenUsage: null };',
+    '  const activePrompt = { complete() {} };',
+    '  const adapter = {',
+    '    sessionState,',
+    '    handleTokenUsageUpdated(params) {',
+    '      this.sessionState.lastTokenUsage = params.tokenUsage.last;',
+    '      this.sessionState.totalTokenUsage = params.tokenUsage.total;',
+    '    },',
+    '  createUsageUpdate(params) {',
+    '    this.handleTokenUsageUpdated(params);',
+    '    return null;',
+    '  },',
+    '    buildPromptUsage(usage) { return usage; },',
+    '    startPrompt() {',
+    '    sessionState.currentTurnId = null;',
+    '    sessionState.lastTokenUsage = null;',
+    '    },',
+    '    commandResponse() { return { usage: this.buildPromptUsage(sessionState.lastTokenUsage), }; },',
+    '    normalResponse() { return { usage: this.buildPromptUsage(sessionState.lastTokenUsage), }; },',
+    '    cancelledResponse() { return { usage: this.buildPromptUsage(sessionState.lastTokenUsage), }; },',
+    '    finishPrompt() {',
+    '      const response = this.normalResponse();',
+    '      activePrompt.complete();',
+    '      return response;',
+    '    }',
+    '  };',
+    '  return adapter;'
+  ].join('\n')
+
+  const usage = (
+    totalTokens: number,
+    inputTokens: number,
+    cachedInputTokens: number,
+    outputTokens: number,
+    reasoningOutputTokens: number
+  ): FixtureTokenUsage => ({
+    totalTokens,
+    inputTokens,
+    cachedInputTokens,
+    outputTokens,
+    reasoningOutputTokens
+  })
+
+  it('accumulates every model request in one Codex prompt without double-counting updates', () => {
+    const patched = patchCodexAcpTurnUsageSource(fixture)
+    const adapter = Function(patched)() as {
+      startPrompt: () => void
+      createUsageUpdate: (params: unknown) => void
+      finishPrompt: () => { usage: ReturnType<typeof usage> | null }
+    }
+
+    // Seed the previous completed turn so the first update is derived from cumulative totals.
+    adapter.createUsageUpdate({
+      tokenUsage: {
+        last: usage(100, 70, 13, 15, 2),
+        total: usage(100, 70, 13, 15, 2)
+      }
+    })
+    adapter.startPrompt()
+    adapter.createUsageUpdate({
+      tokenUsage: {
+        last: usage(18, 12, 3, 3, 0),
+        total: usage(118, 82, 16, 18, 2)
+      }
+    })
+    // Codex can repeat the same cumulative snapshot; a zero delta must not add the request twice.
+    adapter.createUsageUpdate({
+      tokenUsage: {
+        last: usage(18, 12, 3, 3, 0),
+        total: usage(118, 82, 16, 18, 2)
+      }
+    })
+    adapter.createUsageUpdate({
+      tokenUsage: {
+        last: usage(27, 19, 5, 3, 0),
+        total: usage(145, 101, 21, 21, 2)
+      }
+    })
+
+    expect(adapter.finishPrompt().usage).toEqual(usage(45, 31, 8, 6, 0))
+    expect(patchCodexAcpTurnUsageSource(patched)).toBe(patched)
+  })
+
+  it('uses the first request snapshot when a resumed session has no cumulative baseline', () => {
+    const adapter = Function(patchCodexAcpTurnUsageSource(fixture))() as {
+      startPrompt: () => void
+      createUsageUpdate: (params: unknown) => void
+      finishPrompt: () => { usage: ReturnType<typeof usage> | null }
+    }
+
+    adapter.startPrompt()
+    adapter.createUsageUpdate({
+      tokenUsage: {
+        last: usage(18, 12, 3, 3, 0),
+        total: usage(10_018, 8_012, 1_003, 903, 100)
+      }
+    })
+
+    expect(adapter.finishPrompt().usage).toEqual(usage(18, 12, 3, 3, 0))
   })
 })
 

--- a/src/main/settings/managed-codex.ts
+++ b/src/main/settings/managed-codex.ts
@@ -118,6 +118,89 @@ const CODEX_ACP_CONTEXT_USAGE_REPLACEMENT = [
   '        : lastTokenUsage.inputTokens + (lastTokenUsage.cachedInputTokens ?? 0);'
 ].join('\n')
 
+const CODEX_ACP_TURN_USAGE_UPDATE_SOURCE = [
+  '  createUsageUpdate(params) {',
+  '    this.handleTokenUsageUpdated(params);'
+].join('\n')
+const CODEX_ACP_TURN_USAGE_UPDATE_REPLACEMENT = [
+  '  createUsageUpdate(params) {',
+  '    const previousTotalTokenUsage = this.sessionState.totalTokenUsage;',
+  '    this.handleTokenUsageUpdated(params);',
+  '    const currentTotalTokenUsage = this.sessionState.totalTokenUsage;',
+  '    const lastTokenUsage = this.sessionState.lastTokenUsage;',
+  '    const promptTokenUsage = this.sessionState.promptTokenUsage;',
+  '    if (',
+  '      promptTokenUsage != null &&',
+  '      currentTotalTokenUsage != null &&',
+  '      lastTokenUsage != null',
+  '    ) {',
+  '      const tokenKeys = [',
+  '        "totalTokens",',
+  '        "inputTokens",',
+  '        "cachedInputTokens",',
+  '        "outputTokens",',
+  '        "reasoningOutputTokens"',
+  '      ];',
+  '      const cumulativeDelta = previousTotalTokenUsage == null',
+  '        ? lastTokenUsage',
+  '        : {',
+  '            totalTokens: currentTotalTokenUsage.totalTokens - previousTotalTokenUsage.totalTokens,',
+  '            inputTokens: currentTotalTokenUsage.inputTokens - previousTotalTokenUsage.inputTokens,',
+  '            cachedInputTokens:',
+  '              currentTotalTokenUsage.cachedInputTokens - previousTotalTokenUsage.cachedInputTokens,',
+  '            outputTokens:',
+  '              currentTotalTokenUsage.outputTokens - previousTotalTokenUsage.outputTokens,',
+  '            reasoningOutputTokens:',
+  '              currentTotalTokenUsage.reasoningOutputTokens -',
+  '              previousTotalTokenUsage.reasoningOutputTokens',
+  '          };',
+  '      const increment = tokenKeys.every(',
+  '        (key) => Number.isSafeInteger(cumulativeDelta[key]) && cumulativeDelta[key] >= 0',
+  '      )',
+  '        ? cumulativeDelta',
+  '        : lastTokenUsage;',
+  '      const nextPromptTokenUsage = {',
+  '        totalTokens: promptTokenUsage.totalTokens + increment.totalTokens,',
+  '        inputTokens: promptTokenUsage.inputTokens + increment.inputTokens,',
+  '        cachedInputTokens: promptTokenUsage.cachedInputTokens + increment.cachedInputTokens,',
+  '        outputTokens: promptTokenUsage.outputTokens + increment.outputTokens,',
+  '        reasoningOutputTokens:',
+  '          promptTokenUsage.reasoningOutputTokens + increment.reasoningOutputTokens',
+  '      };',
+  '      if (tokenKeys.every((key) => Number.isSafeInteger(nextPromptTokenUsage[key]))) {',
+  '        this.sessionState.promptTokenUsage = nextPromptTokenUsage;',
+  '        this.sessionState.promptTokenUsageObserved = true;',
+  '      }',
+  '    }'
+].join('\n')
+
+const CODEX_ACP_TURN_USAGE_START_SOURCE = [
+  '    sessionState.currentTurnId = null;',
+  '    sessionState.lastTokenUsage = null;'
+].join('\n')
+const CODEX_ACP_TURN_USAGE_START_REPLACEMENT = [
+  CODEX_ACP_TURN_USAGE_START_SOURCE,
+  '    sessionState.promptTokenUsage = {',
+  '      totalTokens: 0,',
+  '      inputTokens: 0,',
+  '      cachedInputTokens: 0,',
+  '      outputTokens: 0,',
+  '      reasoningOutputTokens: 0',
+  '    };',
+  '    sessionState.promptTokenUsageObserved = false;'
+].join('\n')
+
+const CODEX_ACP_TURN_USAGE_RESPONSE_SOURCE =
+  'usage: this.buildPromptUsage(sessionState.lastTokenUsage),'
+const CODEX_ACP_TURN_USAGE_RESPONSE_REPLACEMENT =
+  'usage: this.buildPromptUsage(sessionState.promptTokenUsageObserved ? sessionState.promptTokenUsage : null),'
+const CODEX_ACP_TURN_USAGE_FINISH_SOURCE = '      activePrompt.complete();'
+const CODEX_ACP_TURN_USAGE_FINISH_REPLACEMENT = [
+  '      sessionState.promptTokenUsage = void 0;',
+  '      sessionState.promptTokenUsageObserved = void 0;',
+  CODEX_ACP_TURN_USAGE_FINISH_SOURCE
+].join('\n')
+
 const CODEX_ACP_SKILL_INPUT_SOURCE = [
   'function buildPromptItems(prompt) {',
   '  return prompt.map((block) => {',
@@ -243,6 +326,41 @@ export const patchCodexAcpContextUsageSource = (source: string): string => {
   return source
 }
 
+// Codex ACP 1.1.4 projects only tokenUsage.last into PromptResponse.usage, so a prompt that performs
+// tools loses every model request except the final one. Accumulate deltas from tokenUsage.total while
+// the prompt is active. Falling back to `last` for the first update keeps resumed sessions from
+// attributing their historical cumulative total to the first new response.
+export const patchCodexAcpTurnUsageSource = (source: string): string => {
+  if (
+    source.includes(CODEX_ACP_TURN_USAGE_UPDATE_REPLACEMENT) &&
+    source.includes(CODEX_ACP_TURN_USAGE_START_REPLACEMENT) &&
+    source.includes(CODEX_ACP_TURN_USAGE_RESPONSE_REPLACEMENT) &&
+    source.includes(CODEX_ACP_TURN_USAGE_FINISH_REPLACEMENT)
+  ) {
+    return source
+  }
+
+  const updateMatches = source.split(CODEX_ACP_TURN_USAGE_UPDATE_SOURCE).length - 1
+  const startMatches = source.split(CODEX_ACP_TURN_USAGE_START_SOURCE).length - 1
+  const responseMatches = source.split(CODEX_ACP_TURN_USAGE_RESPONSE_SOURCE).length - 1
+  const finishMatches = source.split(CODEX_ACP_TURN_USAGE_FINISH_SOURCE).length - 1
+
+  if (updateMatches === 1 && startMatches === 1 && responseMatches === 3 && finishMatches === 1) {
+    return source
+      .replace(CODEX_ACP_TURN_USAGE_UPDATE_SOURCE, CODEX_ACP_TURN_USAGE_UPDATE_REPLACEMENT)
+      .replace(CODEX_ACP_TURN_USAGE_START_SOURCE, CODEX_ACP_TURN_USAGE_START_REPLACEMENT)
+      .replaceAll(CODEX_ACP_TURN_USAGE_RESPONSE_SOURCE, CODEX_ACP_TURN_USAGE_RESPONSE_REPLACEMENT)
+      .replace(CODEX_ACP_TURN_USAGE_FINISH_SOURCE, CODEX_ACP_TURN_USAGE_FINISH_REPLACEMENT)
+  }
+
+  if (responseMatches > 0 || source.includes('buildPromptUsage(lastTokenUsage)')) {
+    throw new Error('Pinned Codex ACP turn-usage patch no longer matches the adapter bundle')
+  }
+
+  // Unit-test fixtures use tiny stand-in adapters rather than the pinned production bundle.
+  return source
+}
+
 // The pinned adapter normally flattens every ACP text block into a Codex text input, discarding
 // private extension metadata. Extend that exact source shape so an explicit app Skill selection
 // becomes Codex's native UserInput::Skill while preserving the original text byte-for-byte.
@@ -280,7 +398,9 @@ export const patchCodexAcpModelCatalogStartupSource = (source: string): string =
 export const ensureManagedCodexContextUsage = async (adapterPath: string): Promise<void> => {
   const source = await readFile(adapterPath, 'utf8')
   const patched = patchCodexAcpModelCatalogStartupSource(
-    patchCodexAcpSkillInputSource(patchCodexAcpContextUsageSource(source))
+    patchCodexAcpSkillInputSource(
+      patchCodexAcpTurnUsageSource(patchCodexAcpContextUsageSource(source))
+    )
   )
 
   if (patched === source) return

--- a/src/main/settings/managed-codex.ts
+++ b/src/main/settings/managed-codex.ts
@@ -130,12 +130,68 @@ const CODEX_ACP_TURN_USAGE_UPDATE_SOURCE = [
   '  createUsageUpdate(params) {',
   '    this.handleTokenUsageUpdated(params);'
 ].join('\n')
-const CODEX_ACP_TURN_USAGE_UPDATE_REPLACEMENT = [
+const CODEX_ACP_TURN_USAGE_UPDATE_LEGACY_REPLACEMENT = [
   '  createUsageUpdate(params) {',
   '    const previousTotalTokenUsage = this.sessionState.totalTokenUsage;',
   '    this.handleTokenUsageUpdated(params);',
   '    const currentTotalTokenUsage = this.sessionState.totalTokenUsage;',
   '    const lastTokenUsage = this.sessionState.lastTokenUsage;',
+  '    const promptTokenUsage = this.sessionState.promptTokenUsage;',
+  '    if (',
+  '      promptTokenUsage != null &&',
+  '      currentTotalTokenUsage != null &&',
+  '      lastTokenUsage != null',
+  '    ) {',
+  '      const tokenKeys = [',
+  '        "totalTokens",',
+  '        "inputTokens",',
+  '        "cachedInputTokens",',
+  '        "outputTokens",',
+  '        "reasoningOutputTokens"',
+  '      ];',
+  '      const cumulativeDelta = previousTotalTokenUsage == null',
+  '        ? lastTokenUsage',
+  '        : {',
+  '            totalTokens: currentTotalTokenUsage.totalTokens - previousTotalTokenUsage.totalTokens,',
+  '            inputTokens: currentTotalTokenUsage.inputTokens - previousTotalTokenUsage.inputTokens,',
+  '            cachedInputTokens:',
+  '              currentTotalTokenUsage.cachedInputTokens - previousTotalTokenUsage.cachedInputTokens,',
+  '            outputTokens:',
+  '              currentTotalTokenUsage.outputTokens - previousTotalTokenUsage.outputTokens,',
+  '            reasoningOutputTokens:',
+  '              currentTotalTokenUsage.reasoningOutputTokens -',
+  '              previousTotalTokenUsage.reasoningOutputTokens',
+  '          };',
+  '      const increment = tokenKeys.every(',
+  '        (key) => Number.isSafeInteger(cumulativeDelta[key]) && cumulativeDelta[key] >= 0',
+  '      )',
+  '        ? cumulativeDelta',
+  '        : lastTokenUsage;',
+  '      const nextPromptTokenUsage = {',
+  '        totalTokens: promptTokenUsage.totalTokens + increment.totalTokens,',
+  '        inputTokens: promptTokenUsage.inputTokens + increment.inputTokens,',
+  '        cachedInputTokens: promptTokenUsage.cachedInputTokens + increment.cachedInputTokens,',
+  '        outputTokens: promptTokenUsage.outputTokens + increment.outputTokens,',
+  '        reasoningOutputTokens:',
+  '          promptTokenUsage.reasoningOutputTokens + increment.reasoningOutputTokens',
+  '      };',
+  '      if (tokenKeys.every((key) => Number.isSafeInteger(nextPromptTokenUsage[key]))) {',
+  '        this.sessionState.promptTokenUsage = nextPromptTokenUsage;',
+  '        this.sessionState.promptTokenUsageObserved = true;',
+  '      }',
+  '    }'
+].join('\n')
+
+const CODEX_ACP_TURN_USAGE_UPDATE_REPLACEMENT = [
+  '  createUsageUpdate(params) {',
+  '    const normalizeTokenUsage = (usage) =>',
+  '      usage == null',
+  '        ? usage',
+  '        : { ...usage, cachedInputTokens: usage.cachedInputTokens ?? 0 };',
+  '    const previousTotalTokenUsage = normalizeTokenUsage(this.sessionState.totalTokenUsage);',
+  '    this.handleTokenUsageUpdated(params);',
+  '    const currentTotalTokenUsage = normalizeTokenUsage(this.sessionState.totalTokenUsage);',
+  '    const lastTokenUsage = normalizeTokenUsage(this.sessionState.lastTokenUsage);',
   '    const promptTokenUsage = this.sessionState.promptTokenUsage;',
   '    if (',
   '      promptTokenUsage != null &&',
@@ -357,10 +413,15 @@ export const patchCodexAcpContextUsageSource = (source: string): string => {
 // field for the transcript footer. Falling back to `last` for the first update keeps resumed sessions
 // from attributing their historical cumulative total to the first new response.
 export const patchCodexAcpTurnUsageSource = (source: string): string => {
-  const migratedSource = source.replaceAll(
-    CODEX_ACP_TURN_USAGE_RESPONSE_LEGACY_REPLACEMENT,
-    CODEX_ACP_TURN_USAGE_RESPONSE_REPLACEMENT
-  )
+  const migratedSource = source
+    .replace(
+      CODEX_ACP_TURN_USAGE_UPDATE_LEGACY_REPLACEMENT,
+      CODEX_ACP_TURN_USAGE_UPDATE_REPLACEMENT
+    )
+    .replaceAll(
+      CODEX_ACP_TURN_USAGE_RESPONSE_LEGACY_REPLACEMENT,
+      CODEX_ACP_TURN_USAGE_RESPONSE_REPLACEMENT
+    )
 
   if (
     migratedSource.includes(CODEX_ACP_TURN_USAGE_UPDATE_REPLACEMENT) &&

--- a/src/main/settings/managed-codex.ts
+++ b/src/main/settings/managed-codex.ts
@@ -22,6 +22,7 @@ import { pipeline } from 'node:stream/promises'
 import { createGunzip } from 'node:zlib'
 
 import type { ClaudeInstallEvent, ClaudeInstallResult } from '../../shared/settings'
+import { ACP_TURN_TOKEN_USAGE_META_KEY } from '../../shared/acp'
 import {
   DEFAULT_REGISTRIES,
   defaultFetchJson,
@@ -110,12 +111,19 @@ const codexBinaryInRoot = (root: string, platform: ManagedCodexPlatform): string
 
 const CODEX_ACP_CONTEXT_USAGE_SOURCE =
   '    const used = this.sessionState.lastTokenUsage?.totalTokens;'
-const CODEX_ACP_CONTEXT_USAGE_REPLACEMENT = [
+const CODEX_ACP_CONTEXT_USAGE_LEGACY_REPLACEMENT = [
   '    const lastTokenUsage = this.sessionState.lastTokenUsage;',
   '    const used =',
   '      lastTokenUsage == null',
   '        ? void 0',
   '        : lastTokenUsage.inputTokens + (lastTokenUsage.cachedInputTokens ?? 0);'
+].join('\n')
+const CODEX_ACP_CONTEXT_USAGE_REPLACEMENT = [
+  '    const contextTokenUsage = this.sessionState.lastTokenUsage;',
+  '    const used =',
+  '      contextTokenUsage == null',
+  '        ? void 0',
+  '        : contextTokenUsage.inputTokens + (contextTokenUsage.cachedInputTokens ?? 0);'
 ].join('\n')
 
 const CODEX_ACP_TURN_USAGE_UPDATE_SOURCE = [
@@ -192,8 +200,20 @@ const CODEX_ACP_TURN_USAGE_START_REPLACEMENT = [
 
 const CODEX_ACP_TURN_USAGE_RESPONSE_SOURCE =
   'usage: this.buildPromptUsage(sessionState.lastTokenUsage),'
-const CODEX_ACP_TURN_USAGE_RESPONSE_REPLACEMENT =
+const CODEX_ACP_TURN_USAGE_RESPONSE_LEGACY_REPLACEMENT =
   'usage: this.buildPromptUsage(sessionState.promptTokenUsageObserved ? sessionState.promptTokenUsage : null),'
+const CODEX_ACP_TURN_USAGE_RESPONSE_REPLACEMENT = [
+  'usage: this.buildPromptUsage(',
+  '  sessionState.lastTokenUsage',
+  '),',
+  '...(sessionState.promptTokenUsageObserved',
+  '  ? {',
+  '      _meta: {',
+  `        "${ACP_TURN_TOKEN_USAGE_META_KEY}": this.buildPromptUsage(sessionState.promptTokenUsage)`,
+  '      }',
+  '    }',
+  '  : {}),'
+].join('\n')
 const CODEX_ACP_TURN_USAGE_FINISH_SOURCE = '      activePrompt.complete();'
 const CODEX_ACP_TURN_USAGE_FINISH_REPLACEMENT = [
   '      sessionState.promptTokenUsage = void 0;',
@@ -308,6 +328,12 @@ const renameWithTransientLockRetry = async (source: string, destination: string)
 // during installation instead of silently restoring the wrong metric.
 export const patchCodexAcpContextUsageSource = (source: string): string => {
   if (source.includes(CODEX_ACP_CONTEXT_USAGE_REPLACEMENT)) return source
+  if (source.includes(CODEX_ACP_CONTEXT_USAGE_LEGACY_REPLACEMENT)) {
+    return source.replace(
+      CODEX_ACP_CONTEXT_USAGE_LEGACY_REPLACEMENT,
+      CODEX_ACP_CONTEXT_USAGE_REPLACEMENT
+    )
+  }
 
   const matches = source.split(CODEX_ACP_CONTEXT_USAGE_SOURCE).length - 1
 
@@ -326,39 +352,44 @@ export const patchCodexAcpContextUsageSource = (source: string): string => {
   return source
 }
 
-// Codex ACP 1.1.4 projects only tokenUsage.last into PromptResponse.usage, so a prompt that performs
-// tools loses every model request except the final one. Accumulate deltas from tokenUsage.total while
-// the prompt is active. Falling back to `last` for the first update keeps resumed sessions from
-// attributing their historical cumulative total to the first new response.
+// Codex ACP 1.1.4 projects only tokenUsage.last into PromptResponse.usage. Preserve that latest
+// request for context reconciliation while accumulating whole-turn deltas into an app-owned _meta
+// field for the transcript footer. Falling back to `last` for the first update keeps resumed sessions
+// from attributing their historical cumulative total to the first new response.
 export const patchCodexAcpTurnUsageSource = (source: string): string => {
+  const migratedSource = source.replaceAll(
+    CODEX_ACP_TURN_USAGE_RESPONSE_LEGACY_REPLACEMENT,
+    CODEX_ACP_TURN_USAGE_RESPONSE_REPLACEMENT
+  )
+
   if (
-    source.includes(CODEX_ACP_TURN_USAGE_UPDATE_REPLACEMENT) &&
-    source.includes(CODEX_ACP_TURN_USAGE_START_REPLACEMENT) &&
-    source.includes(CODEX_ACP_TURN_USAGE_RESPONSE_REPLACEMENT) &&
-    source.includes(CODEX_ACP_TURN_USAGE_FINISH_REPLACEMENT)
+    migratedSource.includes(CODEX_ACP_TURN_USAGE_UPDATE_REPLACEMENT) &&
+    migratedSource.includes(CODEX_ACP_TURN_USAGE_START_REPLACEMENT) &&
+    migratedSource.includes(CODEX_ACP_TURN_USAGE_RESPONSE_REPLACEMENT) &&
+    migratedSource.includes(CODEX_ACP_TURN_USAGE_FINISH_REPLACEMENT)
   ) {
-    return source
+    return migratedSource
   }
 
-  const updateMatches = source.split(CODEX_ACP_TURN_USAGE_UPDATE_SOURCE).length - 1
-  const startMatches = source.split(CODEX_ACP_TURN_USAGE_START_SOURCE).length - 1
-  const responseMatches = source.split(CODEX_ACP_TURN_USAGE_RESPONSE_SOURCE).length - 1
-  const finishMatches = source.split(CODEX_ACP_TURN_USAGE_FINISH_SOURCE).length - 1
+  const updateMatches = migratedSource.split(CODEX_ACP_TURN_USAGE_UPDATE_SOURCE).length - 1
+  const startMatches = migratedSource.split(CODEX_ACP_TURN_USAGE_START_SOURCE).length - 1
+  const responseMatches = migratedSource.split(CODEX_ACP_TURN_USAGE_RESPONSE_SOURCE).length - 1
+  const finishMatches = migratedSource.split(CODEX_ACP_TURN_USAGE_FINISH_SOURCE).length - 1
 
   if (updateMatches === 1 && startMatches === 1 && responseMatches === 3 && finishMatches === 1) {
-    return source
+    return migratedSource
       .replace(CODEX_ACP_TURN_USAGE_UPDATE_SOURCE, CODEX_ACP_TURN_USAGE_UPDATE_REPLACEMENT)
       .replace(CODEX_ACP_TURN_USAGE_START_SOURCE, CODEX_ACP_TURN_USAGE_START_REPLACEMENT)
       .replaceAll(CODEX_ACP_TURN_USAGE_RESPONSE_SOURCE, CODEX_ACP_TURN_USAGE_RESPONSE_REPLACEMENT)
       .replace(CODEX_ACP_TURN_USAGE_FINISH_SOURCE, CODEX_ACP_TURN_USAGE_FINISH_REPLACEMENT)
   }
 
-  if (responseMatches > 0 || source.includes('buildPromptUsage(lastTokenUsage)')) {
+  if (responseMatches > 0 || migratedSource.includes('buildPromptUsage(lastTokenUsage)')) {
     throw new Error('Pinned Codex ACP turn-usage patch no longer matches the adapter bundle')
   }
 
   // Unit-test fixtures use tiny stand-in adapters rather than the pinned production bundle.
-  return source
+  return migratedSource
 }
 
 // The pinned adapter normally flattens every ACP text block into a Codex text input, discarding

--- a/src/main/settings/service.test.ts
+++ b/src/main/settings/service.test.ts
@@ -2237,7 +2237,7 @@ describe('SettingsService: preflight & spawn config', () => {
 
     expect(backend.executablePath).toBe(adapterPath)
     expect(await readFile(adapterPath, 'utf8')).toContain(
-      'lastTokenUsage.inputTokens + (lastTokenUsage.cachedInputTokens ?? 0)'
+      'contextTokenUsage.inputTokens + (contextTokenUsage.cachedInputTokens ?? 0)'
     )
   })
 

--- a/src/main/web-service/task-api.test.ts
+++ b/src/main/web-service/task-api.test.ts
@@ -187,7 +187,8 @@ describe('HeadlessTaskApi', () => {
           kind: 'stop',
           level: 'info',
           sessionId: 'session-1',
-          text: 'end_turn'
+          text: 'end_turn',
+          turnUsage: { inputTokens: 31, cacheTokens: 15, outputTokens: 14 }
         })
         return {}
       }
@@ -232,12 +233,97 @@ describe('HeadlessTaskApi', () => {
       permissionProfile: 'auto',
       messages: [
         { id: 'user-message-1', role: 'user', content: 'Review these papers.' },
-        { role: 'agent', content: 'Research complete.', status: 'complete' }
+        {
+          role: 'agent',
+          content: 'Research complete.',
+          status: 'complete',
+          turnUsage: { inputTokens: 31, cacheTokens: 15, outputTokens: 14 }
+        }
       ]
     })
     expect(invoke).toHaveBeenCalledWith('acp:send-prompt', expect.any(String), [
       { sessionId: 'session-1', text: 'Review these papers.' }
     ])
+  })
+
+  it('marks artifact-only headless completions when turn usage is unavailable', async () => {
+    let emitEvent: ((event: AcpRuntimeEvent) => void) | undefined
+    const savedSessions: PersistedChatSession[] = []
+    const invoke = vi.fn(async (channel: string, _clientId: string, args: unknown[]) => {
+      if (channel === 'projects:list') return [project]
+      if (channel === 'sessions:load-all') return { sessions: [], manifest: { version: 1 } }
+      if (channel === 'acp:create-session') {
+        return { sessionId: 'session-artifact-only', cwd: '/workspace/session-artifact-only' }
+      }
+      if (channel === 'sessions:save-session') {
+        savedSessions.push(structuredClone(args[0]) as PersistedChatSession)
+        return undefined
+      }
+      if (channel === 'acp:send-prompt') {
+        emitEvent?.({
+          id: 'artifact-only-event',
+          timestamp: 10,
+          kind: 'artifact',
+          level: 'info',
+          sessionId: 'session-artifact-only',
+          artifactClaimId: 'artifact-only-claim',
+          artifacts: []
+        })
+        emitEvent?.({
+          id: 'artifact-only-stop',
+          timestamp: 11,
+          kind: 'stop',
+          level: 'info',
+          sessionId: 'session-artifact-only',
+          text: 'end_turn'
+        })
+        return {}
+      }
+      if (channel === 'artifacts:finalize-run') {
+        return {
+          ok: true,
+          artifacts: [
+            {
+              id: 'artifact-only-file',
+              projectName: project.id,
+              sessionId: 'session-artifact-only',
+              messageId: 'artifact-only-agent',
+              name: 'result.txt',
+              path: '/artifacts/result.txt',
+              fileUrl: 'open-science-preview://artifact-only-file/result.txt',
+              mimeType: 'text/plain',
+              size: 6,
+              mtimeMs: 11
+            }
+          ]
+        }
+      }
+      throw new Error(`Unexpected RPC channel: ${channel}`)
+    })
+    const api = new HeadlessTaskApi(
+      { invoke },
+      {
+        createId: (() => {
+          const ids = ['artifact-only-user', 'artifact-only-run', 'artifact-only-agent']
+          return () => ids.shift() ?? 'generated-id'
+        })(),
+        subscribeEvents: (listener) => {
+          emitEvent = listener
+          return () => undefined
+        }
+      }
+    )
+
+    await api.startRun({ project: project.id, prompt: 'Create a file.' })
+    await api.waitForRun('artifact-only-run')
+
+    expect(savedSessions.at(-1)?.messages.at(-1)).toMatchObject({
+      id: 'artifact-only-agent',
+      role: 'agent',
+      content: '',
+      turnUsageUnavailable: true,
+      artifactIds: ['artifact-only-file']
+    })
   })
 
   it('settles a run as failed when final session persistence fails', async () => {

--- a/src/main/web-service/task-api.ts
+++ b/src/main/web-service/task-api.ts
@@ -492,6 +492,7 @@ class HeadlessTaskApi {
     const assistantEvents = events.filter(
       (event) => event.kind === 'message' && event.role === 'assistant'
     )
+    const terminalStopEvent = [...events].reverse().find((event) => event.kind === 'stop')
     const output = assistantEvents.map((event) => getAcpRuntimeEventText(event) ?? '').join('')
     const assistantMessageId = this.dependencies.createId()
     const images = assistantEvents
@@ -508,6 +509,11 @@ class HeadlessTaskApi {
       responseToMessageId: session.activeRun?.promptMessageId,
       eventIds: assistantEvents.map((event) => event.id),
       images: images.length ? images : undefined,
+      ...(terminalStopEvent?.turnUsage
+        ? { turnUsage: terminalStopEvent.turnUsage }
+        : terminalStopEvent
+          ? { turnUsageUnavailable: true as const }
+          : {}),
       createdAt: now,
       updatedAt: now
     }

--- a/src/renderer/src/lib/acp/workspace-events.test.ts
+++ b/src/renderer/src/lib/acp/workspace-events.test.ts
@@ -983,6 +983,89 @@ describe('workspace runtime events', () => {
     })
   })
 
+  it('attaches turn usage to an artifact-only terminal response', async () => {
+    const promptMessageId = useSessionStore.getState().sessions[0].activeRun?.promptMessageId
+    const finalizeRunArtifacts = vi.fn(async ({ messageId }: { messageId: string }) => [
+      createArtifactFile({
+        id: `transport-session-1:${messageId}:result.txt`,
+        sessionId: 'transport-session-1',
+        messageId,
+        runId: undefined
+      })
+    ])
+    const saveSession = vi.fn().mockResolvedValue(undefined)
+
+    await applyWorkspaceRuntimeEvent(
+      createEvent({
+        id: 'artifact-event-only-response',
+        kind: 'artifact',
+        runId: 'artifact-run-only-response',
+        promptMessageId,
+        artifactSessionId: 'artifact-session-1',
+        artifactClaimId: 'claim-only-response',
+        artifacts: [createArtifactFile({ runId: 'artifact-run-only-response' })]
+      }),
+      { finalizeRunArtifacts, saveSession }
+    )
+
+    await applyWorkspaceRuntimeEvent(
+      createEvent({
+        id: 'stop-only-response',
+        kind: 'stop',
+        turnUsage: { inputTokens: 31, cacheTokens: 15, outputTokens: 14 }
+      })
+    )
+
+    expect(useSessionStore.getState().sessions[0].messages[1]).toMatchObject({
+      role: 'agent',
+      content: '',
+      status: 'complete',
+      artifactIds: [expect.stringContaining(':result.txt')],
+      turnUsage: { inputTokens: 31, cacheTokens: 15, outputTokens: 14 }
+    })
+    expect(saveSession).toHaveBeenLastCalledWith(
+      expect.objectContaining({
+        messages: expect.arrayContaining([
+          expect.objectContaining({
+            role: 'agent',
+            turnUsage: { inputTokens: 31, cacheTokens: 15, outputTokens: 14 }
+          })
+        ])
+      })
+    )
+  })
+
+  it('marks an artifact-only terminal response when turn usage is unavailable', async () => {
+    const promptMessageId = useSessionStore.getState().sessions[0].activeRun?.promptMessageId
+
+    await applyWorkspaceRuntimeEvent(
+      createEvent({
+        id: 'artifact-event-only-unavailable-response',
+        kind: 'artifact',
+        runId: 'artifact-run-only-unavailable-response',
+        promptMessageId,
+        artifactSessionId: 'artifact-session-1',
+        artifactClaimId: 'claim-only-unavailable-response',
+        artifacts: [createArtifactFile({ runId: 'artifact-run-only-unavailable-response' })]
+      }),
+      {
+        finalizeRunArtifacts: vi.fn().mockResolvedValue([]),
+        saveSession: vi.fn().mockResolvedValue(undefined)
+      }
+    )
+
+    await applyWorkspaceRuntimeEvent(
+      createEvent({ id: 'stop-only-unavailable-response', kind: 'stop' })
+    )
+
+    expect(useSessionStore.getState().sessions[0].messages[1]).toMatchObject({
+      role: 'agent',
+      content: '',
+      status: 'complete',
+      turnUsageUnavailable: true
+    })
+  })
+
   it('binds a restarted runtime Artifact event to the current response in a historical Session', async () => {
     const finalizeRunArtifacts = vi.fn(async ({ messageId }: { messageId: string }) => [
       createArtifactFile({

--- a/src/renderer/src/lib/acp/workspace-events.test.ts
+++ b/src/renderer/src/lib/acp/workspace-events.test.ts
@@ -204,10 +204,20 @@ describe('workspace runtime events', () => {
         text: 'Done'
       })
     )
-    await applyWorkspaceRuntimeEvent(createEvent({ id: 'event-2', kind: 'stop', text: 'end_turn' }))
+    await applyWorkspaceRuntimeEvent(
+      createEvent({
+        id: 'event-2',
+        kind: 'stop',
+        text: 'end_turn',
+        turnUsage: { inputTokens: 31, cacheTokens: 15, outputTokens: 14 }
+      })
+    )
 
     expect(useSessionStore.getState().sessions[0].status).toBe('idle')
-    expect(useSessionStore.getState().sessions[0].messages[1].status).toBe('complete')
+    expect(useSessionStore.getState().sessions[0].messages[1]).toMatchObject({
+      status: 'complete',
+      turnUsage: { inputTokens: 31, cacheTokens: 15, outputTokens: 14 }
+    })
 
     useSessionStore.getState().appendUserMessage({
       sessionId: 'transport-session-1',

--- a/src/renderer/src/lib/acp/workspace-events.test.ts
+++ b/src/renderer/src/lib/acp/workspace-events.test.ts
@@ -777,6 +777,68 @@ describe('workspace runtime events', () => {
     ])
   })
 
+  it.each([
+    {
+      label: 'reported',
+      turnUsage: { inputTokens: 31, cacheTokens: 15, outputTokens: 14 },
+      expectedUsage: {
+        turnUsage: { inputTokens: 31, cacheTokens: 15, outputTokens: 14 }
+      }
+    },
+    {
+      label: 'unavailable',
+      turnUsage: undefined,
+      expectedUsage: { turnUsageUnavailable: true }
+    }
+  ])('preserves $label usage for an artifact-only response received after stop', async (input) => {
+    const promptMessageId = useSessionStore.getState().sessions[0].activeRun?.promptMessageId
+    const saveSession = vi.fn().mockResolvedValue(undefined)
+    const finalizeRunArtifacts = vi.fn(async ({ messageId }: { messageId: string }) => [
+      createArtifactFile({
+        id: `transport-session-1:${messageId}:result.txt`,
+        sessionId: 'transport-session-1',
+        messageId,
+        runId: undefined
+      })
+    ])
+
+    await applyWorkspaceRuntimeEvent(
+      createEvent({
+        id: `stop-before-artifact-only-${input.label}`,
+        kind: 'stop',
+        turnUsage: input.turnUsage
+      })
+    )
+    expect(useSessionStore.getState().sessions[0].messages).toHaveLength(1)
+
+    await applyWorkspaceRuntimeEvent(
+      createEvent({
+        id: `artifact-only-after-stop-${input.label}`,
+        kind: 'artifact',
+        runId: `artifact-run-after-stop-${input.label}`,
+        promptMessageId,
+        artifactSessionId: 'artifact-session-1',
+        artifactClaimId: `claim-after-stop-${input.label}`,
+        artifacts: [createArtifactFile({ runId: `artifact-run-after-stop-${input.label}` })]
+      }),
+      { finalizeRunArtifacts, saveSession }
+    )
+
+    expect(useSessionStore.getState().sessions[0].messages[1]).toMatchObject({
+      role: 'agent',
+      content: '',
+      status: 'complete',
+      ...input.expectedUsage
+    })
+    expect(saveSession).toHaveBeenLastCalledWith(
+      expect.objectContaining({
+        messages: expect.arrayContaining([
+          expect.objectContaining({ role: 'agent', ...input.expectedUsage })
+        ])
+      })
+    )
+  })
+
   it('keeps Artifact persistence behind an older queued Session save', async () => {
     const promptMessageId = useSessionStore.getState().sessions[0].activeRun?.promptMessageId
     await applyWorkspaceRuntimeEvent(

--- a/src/renderer/src/lib/acp/workspace-events.test.ts
+++ b/src/renderer/src/lib/acp/workspace-events.test.ts
@@ -839,6 +839,57 @@ describe('workspace runtime events', () => {
     )
   })
 
+  it('keeps pending artifact usage isolated across consecutive prompts', async () => {
+    const firstPromptMessageId = useSessionStore.getState().sessions[0].activeRun?.promptMessageId
+    const firstTurnUsage = { inputTokens: 31, cacheTokens: 15, outputTokens: 14 }
+    const secondTurnUsage = { inputTokens: 47, cacheTokens: 9, outputTokens: 22 }
+    const saveSession = vi.fn().mockResolvedValue(undefined)
+    const finalizeRunArtifacts = vi.fn().mockResolvedValue([])
+
+    await applyWorkspaceRuntimeEvent(
+      createEvent({ id: 'first-stop-before-artifact', kind: 'stop', turnUsage: firstTurnUsage })
+    )
+    const secondPrompt = useSessionStore.getState().appendUserMessage({
+      sessionId: 'transport-session-1',
+      content: 'Create another artifact'
+    })
+    await applyWorkspaceRuntimeEvent(
+      createEvent({ id: 'second-stop-before-artifact', kind: 'stop', turnUsage: secondTurnUsage })
+    )
+
+    for (const [label, promptMessageId] of [
+      ['first', firstPromptMessageId],
+      ['second', secondPrompt?.messageId]
+    ] as const) {
+      await applyWorkspaceRuntimeEvent(
+        createEvent({
+          id: `${label}-late-artifact`,
+          kind: 'artifact',
+          runId: `${label}-artifact-run`,
+          promptMessageId,
+          artifactSessionId: 'artifact-session-1',
+          artifactClaimId: `${label}-artifact-claim`,
+          artifacts: [createArtifactFile({ runId: `${label}-artifact-run` })]
+        }),
+        { finalizeRunArtifacts, saveSession }
+      )
+    }
+
+    const messages = useSessionStore.getState().sessions[0].messages
+    expect(
+      messages.find((message) => message.responseToMessageId === firstPromptMessageId)
+    ).toMatchObject({
+      role: 'agent',
+      turnUsage: firstTurnUsage
+    })
+    expect(
+      messages.find((message) => message.responseToMessageId === secondPrompt?.messageId)
+    ).toMatchObject({
+      role: 'agent',
+      turnUsage: secondTurnUsage
+    })
+  })
+
   it('keeps Artifact persistence behind an older queued Session save', async () => {
     const promptMessageId = useSessionStore.getState().sessions[0].activeRun?.promptMessageId
     await applyWorkspaceRuntimeEvent(

--- a/src/renderer/src/lib/acp/workspace-events.ts
+++ b/src/renderer/src/lib/acp/workspace-events.ts
@@ -134,23 +134,22 @@ const saveSessionForArtifactFinalization = (
   session: PersistedChatSession
 ): Promise<PersistedChatSession> => saveSessionInOrder(session)
 
-const finalizeArtifactEvent = async (
-  event: AcpRuntimeEvent,
-  dependencies: WorkspaceRuntimeEventDependencies
-): Promise<boolean> => {
-  if (
-    event.kind !== 'artifact' ||
-    !event.sessionId ||
-    !event.runId ||
-    !event.artifactClaimId ||
-    !event.artifacts ||
-    event.artifacts.length === 0
-  ) {
-    return false
-  }
+type FinalizableArtifactEvent = AcpRuntimeEvent & {
+  kind: 'artifact'
+  sessionId: string
+  runId: string
+  artifactClaimId: string
+  artifacts: ArtifactFile[]
+}
 
-  const store = useSessionStore.getState()
-  const attached = store.attachRunArtifacts({
+const isFinalizableArtifactEvent = (event: AcpRuntimeEvent): event is FinalizableArtifactEvent =>
+  event.kind === 'artifact' &&
+  Boolean(event.sessionId && event.runId && event.artifactClaimId && event.artifacts?.length)
+
+const attachArtifactEvent = (
+  event: FinalizableArtifactEvent
+): { sessionId: string; messageId: string } | undefined =>
+  useSessionStore.getState().attachRunArtifacts({
     sessionId: event.sessionId,
     runId: event.runId,
     promptMessageId: event.promptMessageId,
@@ -158,7 +157,17 @@ const finalizeArtifactEvent = async (
     artifacts: event.artifacts
   })
 
+const finalizeArtifactEvent = async (
+  event: AcpRuntimeEvent,
+  dependencies: WorkspaceRuntimeEventDependencies
+): Promise<boolean> => {
+  if (!isFinalizableArtifactEvent(event)) return false
+
+  const attached = attachArtifactEvent(event)
+
   if (!attached) return true
+
+  const store = useSessionStore.getState()
 
   try {
     const persistLatestSession = async (): Promise<void> => {
@@ -407,6 +416,26 @@ const applyWorkspaceRuntimeEvent = async (
 
   if (event.kind === 'stop' && event.sessionId) {
     activityGroupToolCallIdsBySession.delete(event.sessionId)
+    const deferredArtifacts = deferredArtifactEventsBySession.get(event.sessionId)
+    const activeSession = store.sessions.find((session) => session.id === event.sessionId)
+    let deferredAttachmentError: unknown
+    let deferredAttachmentFailed = false
+
+    // Artifact-only turns need their terminal Agent message before finishRun chooses the owner of the
+    // usage footer. Binding is synchronous; durable finalization still happens after the run settles.
+    if (!activeSession?.conversationGraphSyncBlocked && deferredArtifacts) {
+      try {
+        for (const deferredArtifact of deferredArtifacts) {
+          if (isFinalizableArtifactEvent(deferredArtifact.event)) {
+            attachArtifactEvent(deferredArtifact.event)
+          }
+        }
+      } catch (error) {
+        deferredAttachmentError = error
+        deferredAttachmentFailed = true
+      }
+    }
+
     store.finishRun(event.sessionId, event.turnUsage)
 
     const terminalSession = useSessionStore
@@ -419,7 +448,11 @@ const applyWorkspaceRuntimeEvent = async (
       return true
     }
 
-    const deferredArtifacts = deferredArtifactEventsBySession.get(event.sessionId)
+    if (deferredAttachmentFailed) {
+      deferredArtifactEventsBySession.delete(event.sessionId)
+      throw deferredAttachmentError
+    }
+
     if (deferredArtifacts) {
       deferredArtifactEventsBySession.delete(event.sessionId)
       for (const deferredArtifact of deferredArtifacts) {

--- a/src/renderer/src/lib/acp/workspace-events.ts
+++ b/src/renderer/src/lib/acp/workspace-events.ts
@@ -1,4 +1,8 @@
-import type { AcpRuntimeEvent, AcpPermissionRequest } from '../../../../shared/acp'
+import type {
+  AcpRuntimeEvent,
+  AcpPermissionRequest,
+  AcpTurnTokenUsage
+} from '../../../../shared/acp'
 import {
   ARTIFACT_OWNERSHIP_PERSISTENCE_RACE,
   type ArtifactFile,
@@ -39,16 +43,26 @@ type DeferredArtifactEvent = {
   dependencies: WorkspaceRuntimeEventDependencies
 }
 
+type PendingArtifactTurnUsage = {
+  promptMessageId: string
+  turnUsage?: AcpTurnTokenUsage
+  turnUsageUnavailable?: true
+}
+
 // The runtime deliberately publishes generated files immediately before its stop event. Providers may
 // still have a terminal assistant chunk queued behind the tool result, so binding at the artifact event
 // can capture an intermediate message. Hold every event until stop makes the renderer's terminal
 // Message/Branch projection authoritative; one turn may publish more than one generated file claim.
 const deferredArtifactEventsBySession = new Map<string, DeferredArtifactEvent[]>()
+// Some providers reverse that order and publish an artifact-only response just after stop. Keep the
+// terminal usage scoped to its prompt until the matching Artifact creates the owning Agent message.
+const pendingArtifactTurnUsageBySession = new Map<string, PendingArtifactTurnUsage>()
 const scheduledAutoReviewsBySession = new Map<string, ReturnType<typeof setTimeout>>()
 const AUTO_REVIEW_ARTIFACT_SETTLE_DELAY_MS = 100
 
 const resetDeferredArtifactEventsForTests = (): void => {
   deferredArtifactEventsBySession.clear()
+  pendingArtifactTurnUsageBySession.clear()
   for (const timer of scheduledAutoReviewsBySession.values()) clearTimeout(timer)
   scheduledAutoReviewsBySession.clear()
 }
@@ -147,23 +161,27 @@ const isFinalizableArtifactEvent = (event: AcpRuntimeEvent): event is Finalizabl
   Boolean(event.sessionId && event.runId && event.artifactClaimId && event.artifacts?.length)
 
 const attachArtifactEvent = (
-  event: FinalizableArtifactEvent
+  event: FinalizableArtifactEvent,
+  turnUsage?: PendingArtifactTurnUsage
 ): { sessionId: string; messageId: string } | undefined =>
   useSessionStore.getState().attachRunArtifacts({
     sessionId: event.sessionId,
     runId: event.runId,
     promptMessageId: event.promptMessageId,
     eventId: event.id,
-    artifacts: event.artifacts
+    artifacts: event.artifacts,
+    turnUsage: turnUsage?.turnUsage,
+    turnUsageUnavailable: turnUsage?.turnUsageUnavailable
   })
 
 const finalizeArtifactEvent = async (
   event: AcpRuntimeEvent,
-  dependencies: WorkspaceRuntimeEventDependencies
+  dependencies: WorkspaceRuntimeEventDependencies,
+  turnUsage?: PendingArtifactTurnUsage
 ): Promise<boolean> => {
   if (!isFinalizableArtifactEvent(event)) return false
 
-  const attached = attachArtifactEvent(event)
+  const attached = attachArtifactEvent(event, turnUsage)
 
   if (!attached) return true
 
@@ -418,6 +436,7 @@ const applyWorkspaceRuntimeEvent = async (
     activityGroupToolCallIdsBySession.delete(event.sessionId)
     const deferredArtifacts = deferredArtifactEventsBySession.get(event.sessionId)
     const activeSession = store.sessions.find((session) => session.id === event.sessionId)
+    const terminalPromptMessageId = activeSession?.activeRun?.promptMessageId
     let deferredAttachmentError: unknown
     let deferredAttachmentFailed = false
 
@@ -445,12 +464,32 @@ const applyWorkspaceRuntimeEvent = async (
       // The run is visibly settled as an integrity error, but its terminal Message is not proven to
       // belong to the active Branch. Acknowledge the stop without publishing Artifact or Review data.
       deferredArtifactEventsBySession.delete(event.sessionId)
+      pendingArtifactTurnUsageBySession.delete(event.sessionId)
       return true
     }
 
     if (deferredAttachmentFailed) {
       deferredArtifactEventsBySession.delete(event.sessionId)
       throw deferredAttachmentError
+    }
+
+    const terminalResponse = terminalPromptMessageId
+      ? [...(terminalSession?.messages ?? [])]
+          .reverse()
+          .find(
+            (message) =>
+              message.role === 'agent' && message.responseToMessageId === terminalPromptMessageId
+          )
+      : undefined
+    if (terminalPromptMessageId && !terminalResponse) {
+      pendingArtifactTurnUsageBySession.set(event.sessionId, {
+        promptMessageId: terminalPromptMessageId,
+        ...(event.turnUsage
+          ? { turnUsage: event.turnUsage }
+          : { turnUsageUnavailable: true as const })
+      })
+    } else {
+      pendingArtifactTurnUsageBySession.delete(event.sessionId)
     }
 
     if (deferredArtifacts) {
@@ -504,13 +543,20 @@ const applyWorkspaceRuntimeEvent = async (
     }
 
     cancelScheduledAutoReview(event.sessionId)
-    const wasFinalized = await finalizeArtifactEvent(event, dependencies)
+    const pendingTurnUsage = pendingArtifactTurnUsageBySession.get(event.sessionId)
+    const matchingTurnUsage =
+      event.promptMessageId === pendingTurnUsage?.promptMessageId ? pendingTurnUsage : undefined
+    const wasFinalized = await finalizeArtifactEvent(event, dependencies, matchingTurnUsage)
+    if (wasFinalized && matchingTurnUsage) {
+      pendingArtifactTurnUsageBySession.delete(event.sessionId)
+    }
     if (wasFinalized) scheduleAutoReview(event.sessionId)
     return wasFinalized
   }
 
   if (event.kind === 'error' && event.sessionId) {
     activityGroupToolCallIdsBySession.delete(event.sessionId)
+    pendingArtifactTurnUsageBySession.delete(event.sessionId)
     // A recoverable request-size overflow shows the neutral "compacting" note ONLY while a recovery is
     // actually in flight — the workspace runtime flips the session to `compacting` first (its recovery
     // effect runs before this event is applied). If the session is not compacting, no recovery started

--- a/src/renderer/src/lib/acp/workspace-events.ts
+++ b/src/renderer/src/lib/acp/workspace-events.ts
@@ -44,7 +44,6 @@ type DeferredArtifactEvent = {
 }
 
 type PendingArtifactTurnUsage = {
-  promptMessageId: string
   turnUsage?: AcpTurnTokenUsage
   turnUsageUnavailable?: true
 }
@@ -56,7 +55,8 @@ type PendingArtifactTurnUsage = {
 const deferredArtifactEventsBySession = new Map<string, DeferredArtifactEvent[]>()
 // Some providers reverse that order and publish an artifact-only response just after stop. Keep the
 // terminal usage scoped to its prompt until the matching Artifact creates the owning Agent message.
-const pendingArtifactTurnUsageBySession = new Map<string, PendingArtifactTurnUsage>()
+const pendingArtifactTurnUsageBySession = new Map<string, Map<string, PendingArtifactTurnUsage>>()
+const MAX_PENDING_ARTIFACT_TURNS_PER_SESSION = 16
 const scheduledAutoReviewsBySession = new Map<string, ReturnType<typeof setTimeout>>()
 const AUTO_REVIEW_ARTIFACT_SETTLE_DELAY_MS = 100
 
@@ -482,14 +482,23 @@ const applyWorkspaceRuntimeEvent = async (
           )
       : undefined
     if (terminalPromptMessageId && !terminalResponse) {
-      pendingArtifactTurnUsageBySession.set(event.sessionId, {
-        promptMessageId: terminalPromptMessageId,
+      const pendingByPrompt =
+        pendingArtifactTurnUsageBySession.get(event.sessionId) ??
+        new Map<string, PendingArtifactTurnUsage>()
+      pendingByPrompt.set(terminalPromptMessageId, {
         ...(event.turnUsage
           ? { turnUsage: event.turnUsage }
           : { turnUsageUnavailable: true as const })
       })
-    } else {
-      pendingArtifactTurnUsageBySession.delete(event.sessionId)
+      if (pendingByPrompt.size > MAX_PENDING_ARTIFACT_TURNS_PER_SESSION) {
+        const oldestPromptMessageId = pendingByPrompt.keys().next().value
+        if (oldestPromptMessageId) pendingByPrompt.delete(oldestPromptMessageId)
+      }
+      pendingArtifactTurnUsageBySession.set(event.sessionId, pendingByPrompt)
+    } else if (terminalPromptMessageId) {
+      const pendingByPrompt = pendingArtifactTurnUsageBySession.get(event.sessionId)
+      pendingByPrompt?.delete(terminalPromptMessageId)
+      if (pendingByPrompt?.size === 0) pendingArtifactTurnUsageBySession.delete(event.sessionId)
     }
 
     if (deferredArtifacts) {
@@ -543,12 +552,14 @@ const applyWorkspaceRuntimeEvent = async (
     }
 
     cancelScheduledAutoReview(event.sessionId)
-    const pendingTurnUsage = pendingArtifactTurnUsageBySession.get(event.sessionId)
-    const matchingTurnUsage =
-      event.promptMessageId === pendingTurnUsage?.promptMessageId ? pendingTurnUsage : undefined
+    const pendingByPrompt = pendingArtifactTurnUsageBySession.get(event.sessionId)
+    const matchingTurnUsage = event.promptMessageId
+      ? pendingByPrompt?.get(event.promptMessageId)
+      : undefined
     const wasFinalized = await finalizeArtifactEvent(event, dependencies, matchingTurnUsage)
-    if (wasFinalized && matchingTurnUsage) {
-      pendingArtifactTurnUsageBySession.delete(event.sessionId)
+    if (wasFinalized && matchingTurnUsage && event.promptMessageId) {
+      pendingByPrompt?.delete(event.promptMessageId)
+      if (pendingByPrompt?.size === 0) pendingArtifactTurnUsageBySession.delete(event.sessionId)
     }
     if (wasFinalized) scheduleAutoReview(event.sessionId)
     return wasFinalized

--- a/src/renderer/src/lib/acp/workspace-events.ts
+++ b/src/renderer/src/lib/acp/workspace-events.ts
@@ -407,7 +407,7 @@ const applyWorkspaceRuntimeEvent = async (
 
   if (event.kind === 'stop' && event.sessionId) {
     activityGroupToolCallIdsBySession.delete(event.sessionId)
-    store.finishRun(event.sessionId)
+    store.finishRun(event.sessionId, event.turnUsage)
 
     const terminalSession = useSessionStore
       .getState()

--- a/src/renderer/src/pages/workspace/WorkspaceMessageItem.mentions.test.tsx
+++ b/src/renderer/src/pages/workspace/WorkspaceMessageItem.mentions.test.tsx
@@ -300,3 +300,47 @@ describe('WorkspaceMessageItem missing artifact badge', () => {
     expect(container.textContent).toContain('Missing')
   })
 })
+
+describe('WorkspaceMessageItem turn token usage', () => {
+  it('shows the completed response totals below the agent message', async () => {
+    await renderMessageItem(
+      createMessage({
+        role: 'agent',
+        content: 'Done',
+        turnUsage: { inputTokens: 12_345, cacheTokens: 678, outputTokens: 90 }
+      })
+    )
+
+    const usage = container.querySelector('[data-slot="turn-token-usage"]')
+    expect(usage?.getAttribute('aria-label')).toBe('Token usage for this response')
+    expect(usage?.textContent).toContain('Input 12,345')
+    expect(usage?.textContent).toContain('Cache 678')
+    expect(usage?.textContent).toContain('Output 90')
+  })
+
+  it('shows unavailable totals when the agent did not report usage', async () => {
+    await renderMessageItem(
+      createMessage({ role: 'agent', content: 'Done', turnUsageUnavailable: true })
+    )
+
+    const usage = container.querySelector('[data-slot="turn-token-usage"]')
+    expect(usage?.getAttribute('aria-label')).toBe('Token usage unavailable for this response')
+    expect(usage?.textContent).toContain('Input —')
+    expect(usage?.textContent).toContain('Cache —')
+    expect(usage?.textContent).toContain('Output —')
+  })
+
+  it('omits the footer from a non-final agent message in the same turn', async () => {
+    await renderMessageItem(createMessage({ role: 'agent', content: 'Intermediate update' }))
+
+    expect(container.querySelector('[data-slot="turn-token-usage"]')).toBeNull()
+  })
+
+  it('waits until an agent response completes before showing unavailable totals', async () => {
+    await renderMessageItem(
+      createMessage({ role: 'agent', content: 'Still working', status: 'streaming' })
+    )
+
+    expect(container.querySelector('[data-slot="turn-token-usage"]')).toBeNull()
+  })
+})

--- a/src/renderer/src/pages/workspace/WorkspaceMessageItem.tsx
+++ b/src/renderer/src/pages/workspace/WorkspaceMessageItem.tsx
@@ -15,6 +15,7 @@ import {
 import { useEffect, useRef, useState } from 'react'
 import type { ArtifactPreviewResult } from '../../../../shared/artifacts'
 import type { ProvenanceMessagePart } from '../../../../shared/artifact-provenance'
+import type { AcpTurnTokenUsage } from '../../../../shared/acp'
 import type { MessagePart } from '../../../../shared/session-persistence'
 import { getUploadedAttachmentName } from '../../../../shared/uploads'
 
@@ -71,6 +72,29 @@ type WorkspaceMessageItemProps = {
 }
 
 const ARTIFACT_GALLERY_VISIBLE_COUNT = 5
+const tokenCountFormatter = new Intl.NumberFormat('en-US')
+
+const TurnTokenUsage = ({ usage }: { usage?: AcpTurnTokenUsage }): React.JSX.Element => (
+  <dl
+    data-slot="turn-token-usage"
+    aria-label={
+      usage ? 'Token usage for this response' : 'Token usage unavailable for this response'
+    }
+    className="mt-3 flex flex-wrap items-center gap-x-3 gap-y-1 text-[11px] leading-4 text-text-300 tabular-nums"
+  >
+    {[
+      ['Input', usage?.inputTokens],
+      ['Cache', usage?.cacheTokens],
+      ['Output', usage?.outputTokens]
+    ].map(([label, value]) => (
+      <div key={label} className="flex items-baseline gap-1">
+        <dt>{label}</dt>{' '}
+        <dd>{typeof value === 'number' ? tokenCountFormatter.format(value) : '—'}</dd>
+      </div>
+    ))}
+  </dl>
+)
+
 const artifactCardClassName =
   'h-[82px] w-[128px] shrink-0 overflow-hidden rounded-lg border border-border-200 bg-bg-000 text-left text-text-000 shadow-none transition-colors hover:bg-bg-200 focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-border-200/60'
 const artifactPreviewClassName = 'h-[56px] w-full overflow-hidden bg-bg-200'
@@ -619,6 +643,10 @@ const WorkspaceMessageItem = ({
             ) : null}
             <MessageImageList images={message.images ?? []} />
             <MessageArtifactList onPreviewArtifact={onPreviewArtifact} artifacts={artifacts} />
+            {message.status !== 'streaming' &&
+            (message.turnUsage || message.turnUsageUnavailable) ? (
+              <TurnTokenUsage usage={message.turnUsage} />
+            ) : null}
           </div>
         )}
       </div>

--- a/src/renderer/src/stores/session-store.test.ts
+++ b/src/renderer/src/stores/session-store.test.ts
@@ -345,7 +345,11 @@ describe('session store', () => {
       content: ' complete'
     })
 
-    useSessionStore.getState().finishRun('transport-session-1')
+    useSessionStore.getState().finishRun('transport-session-1', {
+      inputTokens: 31,
+      cacheTokens: 15,
+      outputTokens: 14
+    })
 
     const session = useSessionStore.getState().sessions[0]
     const agentMessage = session.messages[1]
@@ -358,10 +362,86 @@ describe('session store', () => {
       streamId: 'assistant-message-1',
       responseToMessageId: result?.messageId,
       eventIds: ['event-1', 'event-2'],
-      status: 'complete'
+      status: 'complete',
+      turnUsage: { inputTokens: 31, cacheTokens: 15, outputTokens: 14 }
+    })
+    expect(
+      session.conversationGraph?.messages.find((message) => message.id === agentMessage.id)
+        ?.turnUsage
+    ).toEqual({ inputTokens: 31, cacheTokens: 15, outputTokens: 14 })
+    expect(toPersistedSession(session).messages[1].turnUsage).toEqual({
+      inputTokens: 31,
+      cacheTokens: 15,
+      outputTokens: 14
     })
     expect(session.status).toBe('idle')
     expect(session.activeRun).toBeUndefined()
+  })
+
+  it('attaches whole-turn usage only to the final agent message for the active prompt', () => {
+    useSessionStore.getState().appendUserMessage({
+      sessionId: 'transport-session-1',
+      content: 'Explain the analysis'
+    })
+    useSessionStore.getState().appendAgentMessageChunk({
+      sessionId: 'transport-session-1',
+      streamId: 'assistant-message-1',
+      eventId: 'event-1',
+      content: 'I will inspect the data.'
+    })
+    useSessionStore.getState().appendAgentMessageChunk({
+      sessionId: 'transport-session-1',
+      streamId: 'assistant-message-2',
+      eventId: 'event-2',
+      content: 'The analysis is complete.'
+    })
+
+    useSessionStore.getState().finishRun('transport-session-1', {
+      inputTokens: 120,
+      cacheTokens: 30,
+      outputTokens: 45
+    })
+
+    const agentMessages = useSessionStore
+      .getState()
+      .sessions[0].messages.filter((message) => message.role === 'agent')
+    expect(agentMessages[0].turnUsage).toBeUndefined()
+    expect(agentMessages[1].turnUsage).toEqual({
+      inputTokens: 120,
+      cacheTokens: 30,
+      outputTokens: 45
+    })
+  })
+
+  it('marks only the final agent message when whole-turn usage is unavailable', () => {
+    useSessionStore.getState().appendUserMessage({
+      sessionId: 'transport-session-1',
+      content: 'Explain the analysis'
+    })
+    useSessionStore.getState().appendAgentMessageChunk({
+      sessionId: 'transport-session-1',
+      streamId: 'assistant-message-1',
+      eventId: 'event-1',
+      content: 'I will inspect the data.'
+    })
+    useSessionStore.getState().appendAgentMessageChunk({
+      sessionId: 'transport-session-1',
+      streamId: 'assistant-message-2',
+      eventId: 'event-2',
+      content: 'The analysis is complete.'
+    })
+
+    useSessionStore.getState().finishRun('transport-session-1')
+
+    const session = useSessionStore.getState().sessions[0]
+    const agentMessages = session.messages.filter((message) => message.role === 'agent')
+    expect(agentMessages[0].turnUsageUnavailable).toBeUndefined()
+    expect(agentMessages[1].turnUsageUnavailable).toBe(true)
+    expect(
+      session.conversationGraph?.messages.find((message) => message.id === agentMessages[1].id)
+        ?.turnUsageUnavailable
+    ).toBe(true)
+    expect(toPersistedSession(session).messages.at(-1)?.turnUsageUnavailable).toBe(true)
   })
 
   it('merges image-only and text chunks into the same agent message', () => {

--- a/src/renderer/src/stores/session-store.ts
+++ b/src/renderer/src/stores/session-store.ts
@@ -188,6 +188,8 @@ type AttachRunArtifactsInput = {
   promptMessageId?: string
   eventId: string
   artifacts: ArtifactFile[]
+  turnUsage?: AcpTurnTokenUsage
+  turnUsageUnavailable?: true
 }
 
 type ReplaceMessageArtifactsInput = {
@@ -1283,7 +1285,15 @@ export const useSessionStore = create<SessionStore>((set, get) => ({
   },
 
   // Attaches a runtime artifact event to the best local assistant message before file finalization.
-  attachRunArtifacts: ({ sessionId, runId, promptMessageId, eventId, artifacts }) => {
+  attachRunArtifacts: ({
+    sessionId,
+    runId,
+    promptMessageId,
+    eventId,
+    artifacts,
+    turnUsage,
+    turnUsageUnavailable
+  }) => {
     if (!sessionId || !runId || !eventId || artifacts.length === 0) return undefined
 
     let result: AppendMessageResult | undefined
@@ -1392,6 +1402,11 @@ export const useSessionStore = create<SessionStore>((set, get) => ({
                   ...message,
                   eventIds: appendUniqueStrings(message.eventIds, [eventId]),
                   artifactIds: appendUniqueStrings(message.artifactIds, incomingArtifactIds),
+                  ...(turnUsage
+                    ? { turnUsage, turnUsageUnavailable: undefined }
+                    : turnUsageUnavailable
+                      ? { turnUsage: undefined, turnUsageUnavailable: true as const }
+                      : {}),
                   updatedAt: now
                 }
               : message
@@ -1415,6 +1430,11 @@ export const useSessionStore = create<SessionStore>((set, get) => ({
           responseToMessageId,
           eventIds: [eventId],
           artifactIds: incomingArtifactIds,
+          ...(turnUsage
+            ? { turnUsage }
+            : turnUsageUnavailable
+              ? { turnUsageUnavailable: true as const }
+              : {}),
           sortIndex: createSortIndex(),
           createdAt: now,
           updatedAt: now

--- a/src/renderer/src/stores/session-store.ts
+++ b/src/renderer/src/stores/session-store.ts
@@ -11,7 +11,8 @@ import { sanitizeActivityGroupTitle } from '../../../shared/activity-groups'
 import {
   MAX_ACP_SESSION_IMAGE_BYTES,
   sanitizeAcpMessageImage,
-  type AcpMessageImage
+  type AcpMessageImage,
+  type AcpTurnTokenUsage
 } from '../../../shared/acp'
 import {
   DEFAULT_PERMISSION_PROFILE,
@@ -237,7 +238,7 @@ type SessionStore = SessionStoreData & {
   ) => void
   upsertPersistedSession: (session: PersistedChatSession) => void
   applyDurableSessionProjection: (input: ApplyDurableSessionProjectionInput) => void
-  finishRun: (sessionId: string) => void
+  finishRun: (sessionId: string, turnUsage?: AcpTurnTokenUsage) => void
   // opts.reportable overrides the report-affordance decision: pass false for a model-provider failure
   // (the agent relayed an upstream LLM/HTTP error), true to force it, or omit to let the store derive it
   // from the message (an app-crafted reminder → not reportable; anything else → reportable).
@@ -737,17 +738,39 @@ const appendUniqueStrings = (
 const isArtifactFinalizationError = (error: string | undefined): boolean =>
   error?.startsWith(ARTIFACT_ERROR_PREFIX) ?? false
 
-// Marks any open streamed messages as completed when a run stops.
-const completeStreamingMessages = (messages: ChatMessage[]): ChatMessage[] =>
-  messages.map((message) =>
-    message.status === 'streaming'
-      ? {
-          ...message,
-          status: 'complete',
-          updatedAt: Date.now()
-        }
-      : message
-  )
+// Marks open streams complete and attaches whole-turn usage to the final Agent message responding to
+// the active prompt. A turn can emit multiple message ids, so only its last response owns the footer.
+const completeStreamingMessages = (
+  messages: ChatMessage[],
+  promptMessageId: string | undefined,
+  turnUsage: AcpTurnTokenUsage | undefined,
+  now: number
+): ChatMessage[] => {
+  const usageFooterMessageId = promptMessageId
+    ? [...messages]
+        .reverse()
+        .find(
+          (message) => message.role === 'agent' && message.responseToMessageId === promptMessageId
+        )?.id
+    : undefined
+
+  return messages.map((message) => {
+    const completesStream = message.status === 'streaming'
+    const ownsTurnUsageFooter = message.id === usageFooterMessageId
+    if (!completesStream && !ownsTurnUsageFooter) return message
+
+    return {
+      ...message,
+      ...(completesStream ? { status: 'complete' as const } : {}),
+      ...(ownsTurnUsageFooter
+        ? turnUsage
+          ? { turnUsage }
+          : { turnUsageUnavailable: true as const }
+        : {}),
+      updatedAt: now
+    }
+  })
+}
 
 // Marks partial streamed messages as errored when a run fails.
 const failStreamingMessages = (messages: ChatMessage[]): ChatMessage[] =>
@@ -1757,14 +1780,19 @@ export const useSessionStore = create<SessionStore>((set, get) => ({
   },
 
   // Completes the active run and any streamed messages for the session.
-  finishRun: (sessionId) => {
+  finishRun: (sessionId, turnUsage) => {
     set((state) => ({
       sessions: state.sessions.map((session) => {
         if (session.id !== sessionId) return session
 
         const keepArtifactError = isArtifactFinalizationError(session.error)
         const now = Date.now()
-        const messages = completeStreamingMessages(session.messages)
+        const messages = completeStreamingMessages(
+          session.messages,
+          session.activeRun?.promptMessageId,
+          turnUsage,
+          now
+        )
         const activities = completeOpenActivities(session.activities)
         const activityGroups = completeOpenActivityGroups(session.activityGroups, now)
         // Streaming updates intentionally stay in the lightweight flat projection. Before Branch

--- a/src/renderer/src/stores/session-store.ts
+++ b/src/renderer/src/stores/session-store.ts
@@ -1786,7 +1786,9 @@ export const useSessionStore = create<SessionStore>((set, get) => ({
         if (session.id !== sessionId) return session
 
         const keepArtifactError = isArtifactFinalizationError(session.error)
-        const now = Date.now()
+        // A deferred Artifact may have inserted the terminal message during the same millisecond.
+        // Advance its timestamp so graph synchronization accepts the completed payload as newer.
+        const now = Math.max(Date.now(), session.updatedAt + 1)
         const messages = completeStreamingMessages(
           session.messages,
           session.activeRun?.promptMessageId,

--- a/src/shared/acp.ts
+++ b/src/shared/acp.ts
@@ -144,15 +144,19 @@ export type AcpTurnTokenUsage = {
   outputTokens: number
 }
 
+// Private PromptResponse metadata used by the managed Codex adapter to keep whole-turn totals
+// separate from ACP's latest-request usage snapshot.
+export const ACP_TURN_TOKEN_USAGE_META_KEY = 'open-science/turn-usage'
+
 const asTokenCount = (value: unknown): number | undefined =>
   typeof value === 'number' && Number.isSafeInteger(value) && value >= 0 ? value : undefined
 
 // Normalizes ACP's experimental PromptResponse usage into the stable, provider-neutral projection the
 // renderer persists. Missing cache categories mean zero; malformed totals suppress the entire footer.
-export const toAcpTurnTokenUsage = (
-  usage: Usage | null | undefined
-): AcpTurnTokenUsage | undefined => {
-  if (!usage) return undefined
+export const toAcpTurnTokenUsage = (value: unknown): AcpTurnTokenUsage | undefined => {
+  if (typeof value !== 'object' || value === null || Array.isArray(value)) return undefined
+
+  const usage = value as Partial<Usage>
 
   const inputTokens = asTokenCount(usage.inputTokens)
   const outputTokens = asTokenCount(usage.outputTokens)

--- a/src/shared/acp.ts
+++ b/src/shared/acp.ts
@@ -1,4 +1,4 @@
-import type { ToolCallContent, ToolCallLocation, ToolKind } from '@agentclientprotocol/sdk'
+import type { ToolCallContent, ToolCallLocation, ToolKind, Usage } from '@agentclientprotocol/sdk'
 import type { ArtifactFile, FileReference } from './artifacts'
 import type { UploadedAttachment } from './uploads'
 import type { PermissionProfileId, SessionPermissionProfileState } from './permission-profiles'
@@ -136,6 +136,58 @@ export type AcpContextUsage = {
   breakdown?: AcpContextUsageBreakdown
 }
 
+// Provider-reported totals for one completed prompt turn. Cache reads and writes are combined for the
+// transcript because both consume the provider's cache token budget and users need one comparable sum.
+export type AcpTurnTokenUsage = {
+  inputTokens: number
+  cacheTokens: number
+  outputTokens: number
+}
+
+const asTokenCount = (value: unknown): number | undefined =>
+  typeof value === 'number' && Number.isSafeInteger(value) && value >= 0 ? value : undefined
+
+// Normalizes ACP's experimental PromptResponse usage into the stable, provider-neutral projection the
+// renderer persists. Missing cache categories mean zero; malformed totals suppress the entire footer.
+export const toAcpTurnTokenUsage = (
+  usage: Usage | null | undefined
+): AcpTurnTokenUsage | undefined => {
+  if (!usage) return undefined
+
+  const inputTokens = asTokenCount(usage.inputTokens)
+  const outputTokens = asTokenCount(usage.outputTokens)
+  const cachedReadTokens = asTokenCount(usage.cachedReadTokens ?? 0)
+  const cachedWriteTokens = asTokenCount(usage.cachedWriteTokens ?? 0)
+
+  if (
+    inputTokens === undefined ||
+    outputTokens === undefined ||
+    cachedReadTokens === undefined ||
+    cachedWriteTokens === undefined
+  ) {
+    return undefined
+  }
+
+  const cacheTokens = cachedReadTokens + cachedWriteTokens
+  if (!Number.isSafeInteger(cacheTokens)) return undefined
+
+  return { inputTokens, cacheTokens, outputTokens }
+}
+
+// Re-validates the durable projection when loading session JSON, dropping unknown or unsafe values.
+export const sanitizeAcpTurnTokenUsage = (value: unknown): AcpTurnTokenUsage | undefined => {
+  if (typeof value !== 'object' || value === null || Array.isArray(value)) return undefined
+
+  const usage = value as Record<string, unknown>
+  const inputTokens = asTokenCount(usage.inputTokens)
+  const cacheTokens = asTokenCount(usage.cacheTokens)
+  const outputTokens = asTokenCount(usage.outputTokens)
+
+  return inputTokens === undefined || cacheTokens === undefined || outputTokens === undefined
+    ? undefined
+    : { inputTokens, cacheTokens, outputTokens }
+}
+
 export type AcpRuntimeEvent = {
   id: string
   timestamp: number
@@ -144,6 +196,8 @@ export type AcpRuntimeEvent = {
   // Present only on a usage_update-derived event; the runtime records it per session and does not push
   // the event into the visible conversation.
   contextUsage?: AcpContextUsage
+  // Present on a completed prompt's stop event when the Agent reports whole-turn token totals.
+  turnUsage?: AcpTurnTokenUsage
   // Identifies who owns a native compaction lifecycle so overflow recovery can keep its retry gate
   // active until the replacement prompt takes over, even if control-turn events arrive first.
   compactionReason?: 'automatic' | 'manual' | 'overflow-recovery'

--- a/src/shared/session-persistence.test.ts
+++ b/src/shared/session-persistence.test.ts
@@ -276,6 +276,62 @@ describe('message image persistence', () => {
   })
 })
 
+describe('turn token usage persistence', () => {
+  it('round-trips valid totals and drops invalid usage fields', () => {
+    const restored = normalizeSessionFile({
+      id: 'session-1',
+      projectId: 'project-a',
+      title: 'Usage',
+      cwd: '/workspace',
+      status: 'idle',
+      messages: [
+        {
+          id: 'message-valid',
+          role: 'agent',
+          content: 'Done',
+          status: 'complete',
+          eventIds: [],
+          turnUsage: { inputTokens: 12_345, cacheTokens: 678, outputTokens: 90 },
+          createdAt: 1,
+          updatedAt: 1
+        },
+        {
+          id: 'message-invalid',
+          role: 'agent',
+          content: 'Also done',
+          status: 'complete',
+          eventIds: [],
+          turnUsage: { inputTokens: -1, cacheTokens: 2, outputTokens: 3 },
+          turnUsageUnavailable: true,
+          createdAt: 2,
+          updatedAt: 2
+        },
+        {
+          id: 'message-user',
+          role: 'user',
+          content: 'Prompt',
+          status: 'complete',
+          eventIds: [],
+          turnUsageUnavailable: true,
+          createdAt: 3,
+          updatedAt: 3
+        }
+      ],
+      createdAt: 1,
+      updatedAt: 2
+    })
+
+    expect(restored?.messages[0].turnUsage).toEqual({
+      inputTokens: 12_345,
+      cacheTokens: 678,
+      outputTokens: 90
+    })
+    expect(restored?.messages[1].turnUsage).toBeUndefined()
+    expect(restored?.messages[1].turnUsageUnavailable).toBe(true)
+    expect(restored?.messages[2].turnUsageUnavailable).toBeUndefined()
+  })
+})
+
 describe('sanitizeToolActivity', () => {
   it('keeps identity fields and known text/diff content', () => {
     const activity = sanitizeToolActivity({

--- a/src/shared/session-persistence.ts
+++ b/src/shared/session-persistence.ts
@@ -5,7 +5,9 @@ import {
   MAX_ACP_MESSAGE_IMAGE_BYTES_PER_MESSAGE,
   MAX_ACP_SESSION_IMAGE_BYTES,
   sanitizeAcpMessageImage,
-  type AcpMessageImage
+  sanitizeAcpTurnTokenUsage,
+  type AcpMessageImage,
+  type AcpTurnTokenUsage
 } from './acp'
 import {
   DEFAULT_PERMISSION_PROFILE,
@@ -87,6 +89,10 @@ export type PersistedChatMessage = {
   images?: PersistedMessageImage[]
   // Structured mention segments for the styled user bubble; optional for backward compatibility.
   parts?: MessagePart[]
+  // Whole-turn totals reported with the completed Agent response; absent for older sessions/providers.
+  turnUsage?: AcpTurnTokenUsage
+  // Marks the final Agent message for a turn whose provider did not report usable totals.
+  turnUsageUnavailable?: true
   createdAt: number
   updatedAt: number
 }
@@ -781,6 +787,9 @@ const sanitizeMessage = (
     ? message.parts.map(sanitizeMessagePart).filter((item): item is MessagePart => !!item)
     : []
   const images = sanitizeMessageImages(message.images)
+  const turnUsage = role === 'agent' ? sanitizeAcpTurnTokenUsage(message.turnUsage) : undefined
+  const turnUsageUnavailable =
+    role === 'agent' && !turnUsage && message.turnUsageUnavailable === true
 
   if (streamId) sanitized.streamId = streamId
   if (responseToMessageId) sanitized.responseToMessageId = responseToMessageId
@@ -788,6 +797,8 @@ const sanitizeMessage = (
   if (uploads.length > 0) sanitized.uploads = uploads
   if (parts.length > 0) sanitized.parts = parts
   if (images) sanitized.images = images
+  if (turnUsage) sanitized.turnUsage = turnUsage
+  if (turnUsageUnavailable) sanitized.turnUsageUnavailable = true
 
   return sanitized
 }


### PR DESCRIPTION
## Problem

Agent responses do not expose the token totals consumed by the complete response turn. This makes it impossible to inspect input, cache, and output usage from the transcript, and Codex's pinned ACP adapter currently reports only its final model request when a turn performs tools.

## Proposed change

- Normalize ACP `PromptResponse.usage` into provider-neutral `inputTokens`, `cacheTokens`, and `outputTokens` totals.
- Combine cache reads and cache writes under the displayed `Cache` total.
- Patch the app-managed Codex ACP adapter to accumulate every model request in the prompt from cumulative counter deltas, without double-counting repeated snapshots or importing resumed-session history.
- Attach the totals only to the final Agent message for the active prompt and persist them in the session JSON/conversation graph.
- Render a compact footer under that final message. When the Agent provides no valid usage, render `Input — / Cache — / Output —` instead of fabricating zeroes.

```mermaid
flowchart LR
  A["Provider token usage"] --> B["ACP prompt response"]
  A --> C["Codex per-request delta accumulator"]
  C --> B
  B --> D["Runtime stop event"]
  D --> E["Final Agent message"]
  E --> F["Session JSON and conversation graph"]
  E --> G["Input / Cache / Output footer"]
```

## Scope and non-goals

- Adds optional, backward-compatible `turnUsage` and `turnUsageUnavailable` message fields.
- No database migration and no new IPC channel.
- Does not estimate missing provider data, calculate monetary cost, or display reasoning/thought tokens.
- Intermediate Agent message IDs from the same prompt do not receive a footer; the final message owns the whole-turn total.

## Acceptance criteria and validation

- Whole-turn totals flow from ACP stop events to the final Agent message and durable session graph.
- Codex multi-request prompts sum all requests, ignore duplicate cumulative snapshots, and handle a missing resume baseline.
- Cache read and cache write tokens are combined in the `Cache` value.
- Completed responses show exact formatted totals; missing usage shows em-dash placeholders; streaming and intermediate messages show no footer.
- Old session files remain loadable and malformed usage fields are rejected.

Validation after the final material edit and rebase onto current `main`:

- `npm run typecheck` — passed.
- `npm run lint` — passed with 0 errors and 23 pre-existing warnings in unrelated files.
- `npm test` — 574 files passed, 11 skipped; 8,611 tests passed, 139 skipped.
- Focused persistence/store/UI tests — 109 passed.
- Independent Standards review — no findings.
- Independent Spec review — no findings.

## Review focus

- Codex cumulative-delta behavior in `managed-codex.ts`.
- Final-message ownership of the footer for turns with multiple Agent message IDs.
- Backward compatibility of the optional session JSON fields.
