### PR TITLE
fix(projects): report project deletion failures

### DIFF
--- a/src/renderer/src/pages/home/DeleteProjectDialog.tsx
+++ b/src/renderer/src/pages/home/DeleteProjectDialog.tsx
@@ -19,6 +19,8 @@ type DeleteProjectDialogProps = {
   sessionCount: number
   hasCompleteSessionCatalog: boolean
   canDelete: boolean
+  isDeleting: boolean
+  error: string | undefined
   onCancel: () => void
   onConfirmDelete: () => void
 }
@@ -26,12 +28,14 @@ type DeleteProjectDialogProps = {
 const deleteDialogConfirmButtonClassName =
   'border-transparent bg-danger-000 text-white hover:bg-danger-000/90 hover:text-white'
 
-// Destructive deletion requires confirmation; the project's sessions are removed with it, artifacts stay.
+// Destructive deletion requires confirmation and reports the app-managed data removed with the Project.
 const DeleteProjectDialog = ({
   project,
   sessionCount,
   hasCompleteSessionCatalog,
   canDelete,
+  isDeleting,
+  error,
   onCancel,
   onConfirmDelete
 }: DeleteProjectDialogProps): React.JSX.Element => {
@@ -46,7 +50,7 @@ const DeleteProjectDialog = ({
     <AlertDialog.Root
       open={Boolean(project)}
       onOpenChange={(open) => {
-        if (!open) onCancel()
+        if (!open && !isDeleting) onCancel()
       }}
     >
       <AlertDialog.Portal>
@@ -64,7 +68,9 @@ const DeleteProjectDialog = ({
                     ? ` and its ${dialogSessionCount} ${dialogSessionCount === 1 ? 'session' : 'sessions'}`
                     : ''
                   : ' and all of its saved conversations, including any that could not be loaded during recovery'}
-                . Generated artifacts remain on disk. This action cannot be undone.
+                . Generated artifacts and uploaded files stored by Open Science will also be
+                deleted. Files in the project&apos;s working folder are not deleted. This action
+                cannot be undone.
               </AlertDialog.Description>
             </div>
             <Button
@@ -73,27 +79,32 @@ const DeleteProjectDialog = ({
               size="icon-sm"
               aria-label="Close"
               className={dialogCloseButtonClassName}
+              disabled={isDeleting}
               onClick={onCancel}
             >
               <X className="size-4" aria-hidden="true" />
             </Button>
           </div>
+          {error ? (
+            <p className="mt-4 text-sm text-danger-000" role="alert">
+              {error}
+            </p>
+          ) : null}
           <div className={dialogFooterClassName}>
             <AlertDialog.Cancel asChild>
-              <Button type="button" variant="outline">
+              <Button type="button" variant="outline" disabled={isDeleting}>
                 Cancel
               </Button>
             </AlertDialog.Cancel>
-            <AlertDialog.Action asChild>
-              <Button
-                type="button"
-                className={deleteDialogConfirmButtonClassName}
-                disabled={!canDelete}
-                onClick={onConfirmDelete}
-              >
-                Delete
-              </Button>
-            </AlertDialog.Action>
+            {/* Async confirmation owns dialog closure so a failed deletion remains visible. */}
+            <Button
+              type="button"
+              className={deleteDialogConfirmButtonClassName}
+              disabled={!canDelete || isDeleting}
+              onClick={onConfirmDelete}
+            >
+              {isDeleting ? 'Deleting…' : 'Delete'}
+            </Button>
           </div>
         </AlertDialog.Content>
       </AlertDialog.Portal>

--- a/src/renderer/src/pages/home/HomePage.persistence.test.tsx
+++ b/src/renderer/src/pages/home/HomePage.persistence.test.tsx
@@ -19,23 +19,32 @@ vi.mock('./DeleteProjectDialog', () => ({
     project,
     canDelete,
     hasCompleteSessionCatalog,
+    isDeleting,
+    error,
     onConfirmDelete
   }: {
     project: Project | undefined
     canDelete: boolean
     hasCompleteSessionCatalog: boolean
+    isDeleting: boolean
+    error: string | undefined
     onConfirmDelete: () => void
   }) => (
-    <button
-      type="button"
-      data-testid="confirm-project-delete"
-      data-can-delete={String(canDelete)}
-      data-has-project={String(Boolean(project))}
-      data-has-complete-session-catalog={String(hasCompleteSessionCatalog)}
-      onClick={onConfirmDelete}
-    >
-      Confirm delete
-    </button>
+    <>
+      <button
+        type="button"
+        data-testid="confirm-project-delete"
+        data-can-delete={String(canDelete)}
+        data-has-project={String(Boolean(project))}
+        data-has-complete-session-catalog={String(hasCompleteSessionCatalog)}
+        data-is-deleting={String(isDeleting)}
+        disabled={isDeleting}
+        onClick={onConfirmDelete}
+      >
+        Confirm delete
+      </button>
+      {error ? <p role="alert">{error}</p> : null}
+    </>
   )
 }))
 vi.mock('radix-ui', () => ({
@@ -174,5 +183,36 @@ describe('HomePage persistence recovery', () => {
       container.querySelector<HTMLButtonElement>('[data-testid="confirm-project-delete"]')?.dataset
         .hasCompleteSessionCatalog
     ).toBe('false')
+  })
+
+  it('keeps the confirmation open, explains a durable deletion failure, and allows retry', async () => {
+    deleteProject.mockRejectedValueOnce(new Error('Project storage is unavailable.'))
+
+    await act(async () => root.render(<HomePage canDeleteProjects hasCompleteSessionCatalog />))
+
+    const deleteAction = [...container.querySelectorAll<HTMLButtonElement>('button')].find(
+      (button) => button.textContent?.trim() === 'Delete'
+    )
+    await act(async () => deleteAction?.click())
+    await act(async () =>
+      container.querySelector<HTMLButtonElement>('[data-testid="confirm-project-delete"]')?.click()
+    )
+
+    const confirm = container.querySelector<HTMLButtonElement>(
+      '[data-testid="confirm-project-delete"]'
+    )
+    expect(confirm?.dataset.hasProject).toBe('true')
+    expect(confirm?.dataset.isDeleting).toBe('false')
+    expect(container.querySelector('[role="alert"]')?.textContent).toBe(
+      'Project storage is unavailable.'
+    )
+    expect(useProjectStore.getState().projects).toContainEqual(project)
+
+    deleteProject.mockResolvedValueOnce(undefined)
+    await act(async () => confirm?.click())
+
+    expect(deleteProject).toHaveBeenCalledTimes(2)
+    expect(confirm?.dataset.hasProject).toBe('false')
+    expect(container.querySelector('[role="alert"]')).toBeNull()
   })
 })

--- a/src/renderer/src/pages/home/HomePage.tsx
+++ b/src/renderer/src/pages/home/HomePage.tsx
@@ -103,6 +103,8 @@ const HomePage = ({
   const [isSubmitting, setIsSubmitting] = useState(false)
   const [formError, setFormError] = useState<string | undefined>(undefined)
   const [projectToDelete, setProjectToDelete] = useState<Project | undefined>(undefined)
+  const [isDeletingProject, setIsDeletingProject] = useState(false)
+  const [deleteProjectError, setDeleteProjectError] = useState<string | undefined>(undefined)
 
   // Non-pending sessions only; pending ones have no durable project yet.
   const persistedSessions = useMemo(
@@ -160,7 +162,15 @@ const HomePage = ({
   const openDeleteDialog = (project: Project): void => {
     if (!canDeleteProjects) return
 
+    setDeleteProjectError(undefined)
     setProjectToDelete(project)
+  }
+
+  const closeDeleteDialog = (): void => {
+    if (isDeletingProject) return
+
+    setProjectToDelete(undefined)
+    setDeleteProjectError(undefined)
   }
 
   const closeFormDialog = (): void => {
@@ -206,7 +216,7 @@ const HomePage = ({
 
   // Main coordinates durable project/session/index cleanup; renderer state changes only after it succeeds.
   const confirmDeleteProject = (): void => {
-    if (!canDeleteProjects || !projectToDelete) return
+    if (!canDeleteProjects || !projectToDelete || isDeletingProject) return
 
     const projectId = projectToDelete.id
 
@@ -214,14 +224,23 @@ const HomePage = ({
     // the navigation revision before the async mutation so deferred startup intents cannot reopen a
     // conversation after the post-delete view has settled.
     useNavigationStore.getState().recordUserNavigation()
-    setProjectToDelete(undefined)
+    setIsDeletingProject(true)
+    setDeleteProjectError(undefined)
 
     void deleteProject(projectId)
       .then(() => {
         useSessionStore.getState().removeSessionsForProject(projectId)
+        setProjectToDelete(undefined)
       })
-      .catch(() => {
-        // Durable deletion failed; leave the project and in-memory sessions untouched.
+      .catch((error: unknown) => {
+        // Durable deletion failed; keep the target and in-memory sessions visible so the user can
+        // inspect the failure and retry or cancel explicitly.
+        setDeleteProjectError(
+          error instanceof Error ? error.message : 'Could not delete the project. Please try again.'
+        )
+      })
+      .finally(() => {
+        setIsDeletingProject(false)
       })
   }
 
@@ -442,7 +461,9 @@ const HomePage = ({
         sessionCount={deleteTargetSessionCount}
         hasCompleteSessionCatalog={hasCompleteSessionCatalog}
         canDelete={canDeleteProjects}
-        onCancel={() => setProjectToDelete(undefined)}
+        isDeleting={isDeletingProject}
+        error={deleteProjectError}
+        onCancel={closeDeleteDialog}
         onConfirmDelete={confirmDeleteProject}
       />
     </main>

--- a/src/renderer/src/pages/home/home-dialogs.render.test.tsx
+++ b/src/renderer/src/pages/home/home-dialogs.render.test.tsx
@@ -1,4 +1,5 @@
 import { Children, isValidElement, type ReactElement, type ReactNode } from 'react'
+import { AlertDialog } from 'radix-ui'
 import { describe, expect, it, vi } from 'vitest'
 
 import type { Project } from '../../../../shared/projects'
@@ -123,10 +124,13 @@ describe('home dialogs shared chrome', () => {
       sessionCount: 2,
       hasCompleteSessionCatalog: true,
       canDelete: true,
+      isDeleting: false,
+      error: undefined,
       onCancel,
       onConfirmDelete
     })
     const elements = collectElements(tree)
+    const text = getTextContent(tree)
     const deleteButton = elements.find(
       (element) => getTextContent(element).trim() === 'Delete' && element.props.onClick
     )
@@ -135,6 +139,12 @@ describe('home dialogs shared chrome', () => {
       interceptsOutsideClick: false
     })
     expect(deleteButton?.props.className).toContain('bg-danger-000')
+    expect(elements.some((element) => element.type === AlertDialog.Action)).toBe(false)
+    expect(text).toContain(
+      'Generated artifacts and uploaded files stored by Open Science will also be deleted.'
+    )
+    expect(text).toContain("Files in the project's working folder are not deleted.")
+    expect(text).not.toContain('Generated artifacts remain on disk')
   })
 
   it('warns about unreadable conversations without showing an incomplete session count', async () => {
@@ -145,6 +155,8 @@ describe('home dialogs shared chrome', () => {
       sessionCount: 1,
       hasCompleteSessionCatalog: false,
       canDelete: true,
+      isDeleting: false,
+      error: undefined,
       onCancel: vi.fn(),
       onConfirmDelete: vi.fn()
     })
@@ -154,5 +166,54 @@ describe('home dialogs shared chrome', () => {
       'all of its saved conversations, including any that could not be loaded during recovery'
     )
     expect(text).not.toContain('its 1 session')
+  })
+
+  it('renders a durable deletion failure as an inline alert', async () => {
+    const { DeleteProjectDialog } = await import('./DeleteProjectDialog')
+
+    const tree = DeleteProjectDialog({
+      project: createProject(),
+      sessionCount: 0,
+      hasCompleteSessionCatalog: true,
+      canDelete: true,
+      isDeleting: false,
+      error: 'Project storage is unavailable.',
+      onCancel: vi.fn(),
+      onConfirmDelete: vi.fn()
+    })
+    const alert = collectElements(tree).find((element) => element.props.role === 'alert')
+
+    expect(alert).toBeDefined()
+    expect(getTextContent(alert)).toBe('Project storage is unavailable.')
+  })
+
+  it('locks every dismissal and confirmation control while deletion is pending', async () => {
+    const { DeleteProjectDialog } = await import('./DeleteProjectDialog')
+
+    const tree = DeleteProjectDialog({
+      project: createProject(),
+      sessionCount: 0,
+      hasCompleteSessionCatalog: true,
+      canDelete: true,
+      isDeleting: true,
+      error: undefined,
+      onCancel: vi.fn(),
+      onConfirmDelete: vi.fn()
+    })
+    const elements = collectElements(tree)
+    const closeButton = elements.find((element) => element.props['aria-label'] === 'Close')
+    const cancelButton = elements.find(
+      (element) =>
+        getTextContent(element).trim() === 'Cancel' && element.props.variant === 'outline'
+    )
+    const deleteButton = elements.find(
+      (element) =>
+        getTextContent(element).trim() === 'Deleting…' &&
+        String(element.props.className).includes('bg-danger-000')
+    )
+
+    expect(closeButton?.props.disabled).toBe(true)
+    expect(cancelButton?.props.disabled).toBe(true)
+    expect(deleteButton?.props.disabled).toBe(true)
   })
 })


### PR DESCRIPTION
## Problem

Project deletion is a terminal cleanup boundary for Open Science-managed Artifact and Upload bytes, but the confirmation dialog said generated artifacts would remain on disk. The renderer also closed the dialog before durable deletion settled and swallowed any rejection, leaving users with no indication that deletion had failed.

## Proposed change

- State that Open Science-managed generated artifacts and uploads are deleted while files in the project's working folder are left alone.
- Keep the controlled AlertDialog open until durable deletion succeeds instead of using Radix Action's automatic close behavior.
- Disable close, cancel, and duplicate confirmation while deletion is in flight and show `Deleting…`.
- Surface deletion failures as an inline alert, preserve the project and sessions, and allow an explicit retry or cancel.
- Add regression coverage for storage copy, pending controls, failure visibility, retry, and success closure.

## Scope and non-goals

- Does not change `ProjectDeletionCoordinator`, its crash-recovery protocol, or the set/order of data it deletes.
- Does not delete files from conversation working directories.
- Does not add a new global notification system; feedback remains local to the destructive confirmation.

## Acceptance criteria and validation

All checks below ran after the final material edit.

- Project deletion copy matches terminal managed-byte cleanup -> `npm test -- src/renderer/src/pages/home/HomePage.persistence.test.tsx src/renderer/src/pages/home/home-dialogs.render.test.tsx src/main/projects/deletion-coordinator.test.ts` -> PASS (3 files, 29 tests).
- Failed deletion stays visible, reports the error, preserves state, permits retry, and closes only after success -> same targeted command -> PASS.
- Type safety -> `npm run typecheck` -> PASS.
- Repository lint -> `npm run lint` -> PASS with 0 errors and 23 existing warnings in untouched files.
- Integration regressions -> `npm test` -> PASS (574 files / 8,608 tests; 11 files / 139 tests skipped).

Independent Standards and Spec reviews reported 0 findings and confirmed this behavior-to-check mapping.

Uncovered risk: focused tests use a mocked dialog plus component-structure assertions rather than a packaged-browser Radix interaction, and do not directly exercise physical Artifact/Upload byte removal or cwd preservation. Those storage behaviors are unchanged and remain covered by the lower-layer/full suite.

## Review focus

- Whether the managed-storage versus working-folder wording is clear enough for a destructive action.
- Whether keeping the AlertDialog controlled through the async operation avoids every premature-dismissal path.
