### PR TITLE
feat(deepseek): add native Responses API support for deepseek-v4-flash

### DIFF
--- a/src/main/settings/service.test.ts
+++ b/src/main/settings/service.test.ts
@@ -2594,7 +2594,9 @@ describe('SettingsService: preflight & spawn config', () => {
       ...storedProvider,
       lastValidatedAt: Date.now()
     })
-    await service.setActiveProvider(provider.id, 'deepseek-v4-flash')
+    // deepseek-v4-pro does not yet support the native Responses API, so it drives the Chat Completions
+    // bridge (the test's whole purpose). deepseek-v4-flash would route to native Responses instead.
+    await service.setActiveProvider(provider.id, 'deepseek-v4-pro')
     await repository.setReasoningEffort('low')
 
     vi.stubEnv('OPEN_SCIENCE_AGENT_FRAMEWORK', 'codex')
@@ -3272,6 +3274,27 @@ describe('SettingsService: official vendors', () => {
     expect(body).toMatchObject({
       stream: true,
       tools: [{ type: 'function', function: { name: 'open_science_bridge_probe' } }]
+    })
+  })
+
+  it('probes DeepSeek flash through the native Responses route under Codex', async () => {
+    const service = createService()
+    await repository.setAgentFramework('codex')
+    const fetchMock = vi.fn().mockResolvedValue(validNativeCompatibilityToolCallResponse())
+    vi.stubGlobal('fetch', fetchMock)
+
+    const result = await service.validateProvider({
+      draft: { type: 'official', vendorId: 'deepseek', key: 'sk-ds', model: 'deepseek-v4-flash' }
+    })
+
+    expect(result).toMatchObject({ ok: true, category: 'ok' })
+    // deepseek-v4-flash supports the native Responses API, so the probe must hit /v1/responses with
+    // the namespace compatibility contract instead of the Chat Completions bridge.
+    expect(fetchMock.mock.calls[0][0]).toBe('https://api.deepseek.com/v1/responses')
+    expect(JSON.parse(String(fetchMock.mock.calls[0][1]?.body))).toMatchObject({
+      model: 'deepseek-v4-flash',
+      stream: true,
+      tools: [{ type: 'function', name: 'open_science__bridge_probe' }]
     })
   })
 

--- a/src/main/settings/service.ts
+++ b/src/main/settings/service.ts
@@ -104,6 +104,7 @@ import {
   isModelBridgeSupported,
   isOfficialVendorId,
   isVendorModelMultimodal,
+  isVendorModelResponsesSupported,
   resolveCustomModelContextWindow,
   resolveModelContextWindow,
   resolveVendorApiEndpoints,
@@ -1685,7 +1686,7 @@ class SettingsService {
     // Resolve compatibility here where the vendor registry is available (official endpoints + the
     // static bridge-support marks) and pass the boolean into the pure preflight computation.
     const activeEndpoints = activeProvider
-      ? this.resolveProviderApiEndpoints(activeProvider)
+      ? this.resolveProviderApiEndpoints(activeProvider, activeProvider.model)
       : undefined
     const activeProviderCompatible = activeProvider
       ? isProviderUsableByFramework(
@@ -3626,7 +3627,7 @@ class SettingsService {
     if (
       !isProviderUsableByFramework(
         {
-          apiEndpoints: this.resolveProviderApiEndpoints(activeProvider),
+          apiEndpoints: this.resolveProviderApiEndpoints(activeProvider, effectiveModel),
           type: activeProvider.type
         },
         framework
@@ -3928,10 +3929,25 @@ class SettingsService {
   }
 
   // The chat APIs a provider speaks: official providers come from the registry, custom gateways from
-  // their stored/drafted endpoints, everything else defaults to Anthropic /v1/messages.
-  private resolveProviderApiEndpoints(provider: StoredProvider): ChatApiEndpoint[] {
+  // their stored/drafted endpoints, everything else defaults to Anthropic /v1/messages. For official
+  // vendors the set is model-aware: a vendor may serve the Responses protocol for a subset of its
+  // catalog (e.g. DeepSeek's deepseek-v4-flash), so 'responses' is injected only when the active model
+  // is in that subset. When no active model is supplied, the vendor default model is used so the
+  // resolved set always matches the model the session actually drives.
+  private resolveProviderApiEndpoints(
+    provider: StoredProvider,
+    activeModel?: string
+  ): ChatApiEndpoint[] {
     if (provider.type === 'official' && provider.vendorId) {
-      return resolveVendorApiEndpoints(provider.vendorId)
+      const vendorEndpoints = resolveVendorApiEndpoints(provider.vendorId)
+      const modelToCheck = activeModel ?? defaultVendorModel(provider.vendorId)
+      if (
+        !vendorEndpoints.includes('responses') &&
+        isVendorModelResponsesSupported(provider.vendorId, modelToCheck)
+      ) {
+        return [...vendorEndpoints, 'responses']
+      }
+      return vendorEndpoints
     }
 
     return provider.apiEndpoints && provider.apiEndpoints.length > 0
@@ -3951,7 +3967,7 @@ class SettingsService {
       type: provider.type,
       codexAuthMode: provider.codexAuthMode,
       name: provider.name,
-      apiEndpoints: this.resolveProviderApiEndpoints(provider),
+      apiEndpoints: this.resolveProviderApiEndpoints(provider, activeModel),
       baseUrl: provider.baseUrl,
       model: provider.model,
       contextWindow: provider.contextWindow,
@@ -4107,7 +4123,7 @@ class SettingsService {
         model,
         ...(contextWindow === undefined ? {} : { contextWindow }),
         key,
-        apiEndpoints: this.resolveProviderApiEndpoints(provider),
+        apiEndpoints: this.resolveProviderApiEndpoints(provider, model),
         supportsImageInput: this.providerSupportsImageInput(provider, modelOverride)
       }
     }
@@ -4127,7 +4143,7 @@ class SettingsService {
       model,
       ...(contextWindow === undefined ? {} : { contextWindow }),
       key,
-      apiEndpoints: this.resolveProviderApiEndpoints(provider),
+      apiEndpoints: this.resolveProviderApiEndpoints(provider, model),
       supportsImageInput: this.providerSupportsImageInput(provider, modelOverride),
       ...(provider.type === 'custom'
         ? { reasoningEffortTransport: provider.reasoningEffortTransport }
@@ -4139,15 +4155,24 @@ class SettingsService {
   // with the vendor's registry base URL + default model.
   private resolveDraft(draft: ProviderDraft): ResolvedProvider {
     if (draft.type === 'official' && isOfficialVendorId(draft.vendorId)) {
+      const draftModel = draft.model ?? defaultVendorModel(draft.vendorId)
+      const vendorEndpoints = resolveVendorApiEndpoints(draft.vendorId)
+      const draftEndpoints: ChatApiEndpoint[] =
+        !vendorEndpoints.includes('responses') &&
+        isVendorModelResponsesSupported(draft.vendorId, draftModel)
+          ? [...vendorEndpoints, 'responses']
+          : vendorEndpoints
       return {
         type: 'custom',
         vendorId: draft.vendorId,
         baseUrl: resolveVendorBaseUrl(draft.vendorId, draft.region),
         openaiBaseUrl: resolveVendorOpenAiBaseUrl(draft.vendorId, draft.region),
-        model: draft.model ?? defaultVendorModel(draft.vendorId),
+        model: draftModel,
         key: draft.key,
         // Official vendors declare their own endpoints; a custom draft carries the user's choice.
-        apiEndpoints: resolveVendorApiEndpoints(draft.vendorId)
+        // The set is model-aware so a vendor with per-model Responses support (e.g. DeepSeek flash)
+        // validates against the Responses route when the draft's model implements it.
+        apiEndpoints: draftEndpoints
       }
     }
 

--- a/src/shared/provider-registry.test.ts
+++ b/src/shared/provider-registry.test.ts
@@ -6,6 +6,7 @@ import {
   getOfficialVendor,
   isOfficialVendorId,
   isVendorModelMultimodal,
+  isVendorModelResponsesSupported,
   resolveCustomModelContextWindow,
   resolveModelContextWindow,
   resolveVendorApiEndpoints,
@@ -443,6 +444,36 @@ describe('provider registry', () => {
       expect(isVendorModelMultimodal('openrouter', 'somevendor/unknown-model')).toBe(false)
       // Kimi's list is k3-only; an unknown id is not vision-capable.
       expect(isVendorModelMultimodal('kimi', 'kimi-k9-imaginary')).toBe(false)
+    })
+  })
+
+  describe('isVendorModelResponsesSupported', () => {
+    it('returns true for every model of a vendor that declares responses in apiEndpoints', () => {
+      // xAI and MiniMax declare vendor-level 'responses', so their whole catalog supports it.
+      expect(isVendorModelResponsesSupported('xai', 'grok-4.5')).toBe(true)
+      expect(isVendorModelResponsesSupported('xai', 'grok-build-0.1')).toBe(true)
+      expect(isVendorModelResponsesSupported('minimax', 'MiniMax-M3')).toBe(true)
+      expect(isVendorModelResponsesSupported('volcengine', 'doubao-seed-2-1-pro-260628')).toBe(true)
+    })
+
+    it('returns true for DeepSeek flash only (per-model Responses support)', () => {
+      expect(isVendorModelResponsesSupported('deepseek', 'deepseek-v4-flash')).toBe(true)
+    })
+
+    it('returns false for DeepSeek models that do not yet implement Responses', () => {
+      expect(isVendorModelResponsesSupported('deepseek', 'deepseek-v4-pro')).toBe(false)
+      expect(isVendorModelResponsesSupported('deepseek', 'deepseek-v4-pro[1m]')).toBe(false)
+    })
+
+    it('returns false for vendors with no Responses support at all', () => {
+      expect(isVendorModelResponsesSupported('zhipu', 'glm-5.2')).toBe(false)
+      expect(isVendorModelResponsesSupported('kimi', 'kimi-k3')).toBe(false)
+      expect(isVendorModelResponsesSupported('anthropic', 'claude-opus-5')).toBe(false)
+    })
+
+    it('returns false for an undefined model id', () => {
+      expect(isVendorModelResponsesSupported('deepseek', undefined)).toBe(false)
+      expect(isVendorModelResponsesSupported('xai', undefined)).toBe(false)
     })
   })
 

--- a/src/shared/provider-registry.ts
+++ b/src/shared/provider-registry.ts
@@ -73,6 +73,12 @@ export type OfficialVendor = {
   // the Codex Responses->Chat bridge. Ships with the app so such models are greyed in the picker
   // rather than user-tested. Absent/empty ⇒ every listed model is bridge-compatible.
   bridgeUnsupportedModels?: readonly string[]
+  // Models that accept native Responses API (/v1/responses) requests, for vendors where only a
+  // subset of the catalog implements the Responses protocol while the vendor-level `apiEndpoints`
+  // does not include 'responses'. A vendor that declares 'responses' in `apiEndpoints` serves it
+  // for its whole catalog and must not set this field. Absent ⇒ Responses availability is purely
+  // governed by `apiEndpoints`.
+  responsesModels?: readonly string[]
   // Describes which of this vendor's models accept image input (multimodal vision). Absent ⇒ the vendor
   // has no vision models. This must cover live-fetched ids too — a vendor that refreshes its catalog can
   // surface a vision model not in the bundled `models` array — so it is a rule, not a static id list:
@@ -195,7 +201,8 @@ export const OFFICIAL_VENDORS: OfficialVendor[] = [
     // DeepSeek exposes both routes: Anthropic /v1/messages under `/anthropic`, and the OpenAI-compatible
     // route under `/v1`. The same model ids work on both, so it's safe to prefer OpenAI where the
     // framework supports it (e.g. OpenCode). openaiBaseUrl is the exact version-carrying base clients
-    // append `/chat/completions` to.
+    // append `/chat/completions` to, and the same `/v1` root serves `/v1/responses` for Responses-capable
+    // models.
     apiEndpoints: ['anthropic', 'openai'],
     baseUrl: 'https://api.deepseek.com/anthropic',
     openaiBaseUrl: 'https://api.deepseek.com/v1',
@@ -205,7 +212,10 @@ export const OFFICIAL_VENDORS: OfficialVendor[] = [
       { id: 'deepseek-v4-pro', contextWindow: 1_000_000 },
       { id: 'deepseek-v4-pro[1m]', contextWindow: 1_000_000 },
       { id: 'deepseek-v4-flash', contextWindow: 1_000_000 }
-    ]
+    ],
+    // DeepSeek serves a native Responses API for deepseek-v4-flash only; deepseek-v4-pro does not yet
+    // implement /v1/responses (planned for early August 2026), so it stays on the Chat Completions bridge.
+    responsesModels: ['deepseek-v4-flash']
     // DeepSeek's chat models are text-only, so no `multimodal` rule (image input stays disabled).
   },
   {
@@ -786,6 +796,24 @@ export const isVendorModelMultimodal = (
   if (rule.multimodalModelPattern?.test(modelId)) return true
 
   return rule.multimodalModels?.includes(modelId) ?? false
+}
+
+// Whether a specific model from an official vendor accepts native Responses API (/v1/responses)
+// requests. A vendor that declares 'responses' in `apiEndpoints` serves it for its whole catalog, so
+// every model is Responses-capable. Vendors without that declaration may still list individual models
+// in `responsesModels`; those are the only ids that gain the Responses route. Returns false for an
+// unknown/absent vendor, an empty model id, or a vendor with no Responses support at all.
+export const isVendorModelResponsesSupported = (
+  vendorId: OfficialVendorId,
+  modelId: string | undefined
+): boolean => {
+  if (!modelId) return false
+
+  const vendor = VENDORS_BY_ID.get(vendorId)
+  if (!vendor) return false
+
+  if (vendor.apiEndpoints?.includes('responses')) return true
+  return vendor.responsesModels?.includes(modelId) ?? false
 }
 
 // Custom model ids are opaque: guessing from their name is less reliable than a stable documented


### PR DESCRIPTION
## Problem

DeepSeek now serves a native Responses API (`/v1/responses`) for the `deepseek-v4-flash` model ([DeepSeek Responses API docs](https://api-docs.deepseek.com/zh-cn/guides/responses_api)). The app previously routed **all** DeepSeek models through the Codex Chat Completions bridge because the vendor-level `apiEndpoints` was `[anthropic, openai]` with no per-model mechanism.

`deepseek-v4-pro` does **not** yet support Responses (planned for early August 2026), so it must stay on the Chat bridge. This is a per-model capability the app had no way to express.

## Proposed change

Add a per-model Responses allow-list (`responsesModels`) to `OfficialVendor`, mirroring the existing `multimodal` / `bridgeUnsupportedModels` patterns. The service-layer endpoint resolution (`resolveProviderApiEndpoints`) becomes **model-aware**: it injects `responses` into the resolved endpoint set only when the active model is allow-listed.

All downstream decisions — `requiresChatCompletionsBridge`, `requiresNativeResponsesCompatibility`, validation routing, Codex config, UI compatibility — already consume the resolved endpoint set, so a single choke point flips `deepseek-v4-flash` from the Chat bridge to the native Responses compatibility proxy while `deepseek-v4-pro` stays bridged.

DeepSeek's `openaiBaseUrl` (`https://api.deepseek.com/v1`) already carries the `/v1` segment, so `normalizeResponsesBaseUrl`, `responsesUrl`, and `buildResponsesValidationRequest` all derive `/v1/responses` correctly — no URL plumbing changes.

## Scope and non-goals

**In scope:**
- New `responsesModels` field on `OfficialVendor` + `isVendorModelResponsesSupported` resolver
- Model-aware `resolveProviderApiEndpoints` in `SettingsService`
- DeepSeek entry: `responsesModels: [deepseek-v4-flash]`

**Non-goals:**
- No changes to the Chat bridge, native compatibility proxy internals, URL derivation, or Responses wire protocol
- No change for `deepseek-v4-pro` (stays on the Chat bridge until DeepSeek ships Responses support)
- No UI changes — `toProviderView` now returns the model-aware endpoint set

## Acceptance criteria and validation

| Behavior | Command | Result |
|---|---|---|
| Registry resolves flash as Responses-capable, pro as not | `npx vitest run src/shared/provider-registry.test.ts` | 50 passed |
| Service injects `responses` for flash, not pro | `npx vitest run src/main/settings/service.test.ts` | 231 passed |
| DeepSeek flash probes `/v1/responses` (native), not `/v1/chat/completions` (bridge) | covered in service.test.ts | passed |
| Type checking (node) | `npm run typecheck:node` | passed |
| Linting | `npm run lint` | 0 errors |
| Full suite | `npx vitest run` | 8774 passed (4 pre-existing tiff module failures + 1 flaky timeout, unrelated) |

All checks ran after the last material edit. The pre-existing failures (tiff/fflate missing modules, micromamba timeout) exist on `main` and are not covered by this change.

## Review focus

- The model-aware endpoint resolution is the architectural choke point — confirm the 5 call sites in `service.ts` all thread the resolved active model correctly.
- The `responsesModels` field on `OfficialVendor` is intentionally a static, ships-with-app allow-list (same contract as `bridgeUnsupportedModels`), not a runtime probe.