### PR TITLE
Feat/customize specialist

### DIFF
--- a/resources/notebook/repl_loop.js
+++ b/resources/notebook/repl_loop.js
@@ -957,6 +957,86 @@ async function computeRpc(params) {
   return body.result
 }
 
+// host.agents: control-plane Specialist management SDK (issue 02). Read-only in this slice
+// (list/get/list_skills/list_connectors); mutation/switch land in later issues. Routed over the SAME
+// loopback RPC endpoint as host.mcp/host.compute but as its own `agentsCall` method — never through
+// host.mcp(). Uses the captured RPC_ENDPOINT/TOKEN + capturedFetch for the same token-isolation
+// reasons. The trusted calling session identity is the COMPUTE_SESSION_ID captured at spawn time
+// (above), forwarded on every call so switch() cannot be forged from sandbox user code.
+async function agentsRpc(op, params = {}, sessionId = COMPUTE_SESSION_ID) {
+  if (!RPC_ENDPOINT) throw new Error('host.agents is unavailable: connector RPC endpoint not set')
+  const res = await capturedFetch(RPC_ENDPOINT, {
+    method: 'POST',
+    headers: { 'content-type': 'application/json', authorization: 'Bearer ' + (RPC_TOKEN || '') },
+    body: JSON.stringify({
+      method: 'agentsCall',
+      params: { op, ...(sessionId ? { session_id: sessionId } : {}), ...(params || {}) }
+    })
+  })
+  const body = await res.json().catch(() => ({}))
+  if (!res.ok || body.error) {
+    // Server-side method errors are already `host.agents.<method>: <message>`. Boundary failures
+    // (auth, unknown method) are not method-scoped, so prefix them with the op the caller invoked so
+    // the agent always sees a host.agents.* namespaced, secret-free message.
+    const serverMessage = body.error || 'host.agents HTTP ' + res.status
+    const prefixed = /^host\.agents\./.test(serverMessage)
+      ? serverMessage
+      : `host.agents.${op}: ${serverMessage}`
+    throw new Error(prefixed)
+  }
+  return body.result
+}
+
+// host.agents namespace. Methods and filter/write fields are snake_case; returned records are
+// camelCase. list_skills/list_connectors accept an optional stable id or unique public name.
+// create/update/attach_*/detach_* are the ordinary-mutation surface (issue 03); they return a real
+// post-write camelCase Profile read-back and never echo requested input. switch/delete are the
+// privileged surface (issue 04/05): authorized this milestone by the /customize Skill's chat-text
+// confirmation + the pass-through SDK approval gateway (design.md §7/§14), not the standard card.
+const hostAgents = {
+  async list() {
+    return agentsRpc('list')
+  },
+  async get(name) {
+    return agentsRpc('get', { name })
+  },
+  async list_skills(nameOrId = undefined) {
+    return agentsRpc('list_skills', nameOrId !== undefined ? { name_or_id: nameOrId } : {})
+  },
+  async list_connectors(nameOrId = undefined) {
+    return agentsRpc('list_connectors', nameOrId !== undefined ? { name_or_id: nameOrId } : {})
+  },
+  async create(input) {
+    return agentsRpc('create', input || {})
+  },
+  async update(name, patch) {
+    // Nest the patch so a rename (patch.name) never collides with the lookup name on the wire —
+    // design.md §4 / customize-skill.md: update(name, patch) where patch may carry a new `name`.
+    return agentsRpc('update', { name, patch: patch || {} })
+  },
+  async attach_skill(name, skillRef, options) {
+    return agentsRpc('attach_skill', { name, skill_ref: skillRef, ...(options || {}) })
+  },
+  async detach_skill(name, skillRef, options) {
+    return agentsRpc('detach_skill', { name, skill_ref: skillRef, ...(options || {}) })
+  },
+  async attach_connector(name, connectorRef, options) {
+    return agentsRpc('attach_connector', { name, connector_ref: connectorRef, ...(options || {}) })
+  },
+  async detach_connector(name, connectorRef, options) {
+    return agentsRpc('detach_connector', { name, connector_ref: connectorRef, ...(options || {}) })
+  },
+  // Privileged: switch binds only the trusted calling session (server-captured) and takes effect on
+  // the next message; nameOrNull === null (or omitted) reverts the session to Main Agent.
+  async switch(nameOrNull) {
+    return agentsRpc('switch', { name: nameOrNull === undefined ? null : nameOrNull })
+  },
+  // Privileged and revision-guarded: bound conversations become unavailable (not Main) after delete.
+  async delete(name, options) {
+    return agentsRpc('delete', { name, ...(options || {}) })
+  }
+}
+
 // Maps a computeCall failure into an Error. ComputeService raises structured errors that the RPC layer
 // re-serializes as a JSON string in `error` ({error_code, message, retry_after_user_action}); parse it
 // and hang those fields off the Error so REPL code can branch on `e.error_code` (matching the old Python
@@ -1094,7 +1174,7 @@ const hostCompute = {
 
 // Persistent sandbox: user-declared globals persist across requests (assign to `globalThis`/bare).
 const sandbox = {
-  host: { mcp: hostMcp, compute: hostCompute },
+  host: { mcp: hostMcp, compute: hostCompute, agents: hostAgents },
   console,
   process,
   require,

--- a/resources/skills/customize/SKILL.md
+++ b/resources/skills/customize/SKILL.md
@@ -1,0 +1,179 @@
+---
+name: customize
+description: Use when the user wants to create, inspect, update, delete, reassign capabilities for, or switch the current conversation to a Specialist agent. Covers the conversational `/customize` flow against the JavaScript `host.agents` SDK — clarifying scope, drafting a complete target state, reviewing it, confirming, mutating with read-back, and reporting — plus the confirmation boundaries for ordinary versus privileged operations.
+license: Apache-2.0
+---
+
+# Customize Specialist
+
+This Skill is conversational workflow guidance for managing Specialist agents. It is **not a security
+boundary**: it helps the user draft, review, confirm, and report Specialist changes through the
+JavaScript control-plane SDK. Whether a destructive or identity-affecting operation actually takes
+effect is decided by the application, not by this Skill.
+
+> Important: this is a framework Skill, not hard isolation. Do not claim that this Skill provides hard
+> security isolation; it is workflow guidance only.
+
+## Runtime
+
+The Skill runs in the **JavaScript control-plane REPL only**. It uses JavaScript exclusively. Do not
+use Python or R here, and do not look for `host.agents` in a data kernel — it is absent there. All
+mutation happens through `host.agents.*` methods.
+
+The Skill never uses the following, and you must not invent them:
+
+- Do not use a Customize Specialist/Profile (there is no such profile).
+- Do not perform Skill authoring (this Skill does not author Skills).
+- Do not use a `host.skills.*` namespace (use `host.agents` reads instead).
+- Do not use a management MCP tool, and do not route `host.agents` through `host.mcp()`.
+- Do not create per-Specialist environments.
+- Do not perform duplicate operations (no duplicate Specialist or duplicate operation).
+- Do not automatically retry declined or stale privileged operations.
+
+## The `host.agents` SDK surface
+
+The SDK is name-first and lives in the trusted calling session. Read methods and returned records use
+camelCase; write-side fields use snake_case. Methods:
+
+- `host.agents.list()` — custom Specialists only.
+- `host.agents.get(name)` — one Specialist by public name (returns stable `id` and `revision`, but you
+  do not show those to the user).
+- `host.agents.create(input)` — object form (see below).
+- `host.agents.update(name, patch)` — may include a new `name` (see Privileged operations).
+- `host.agents.switch(nameOrNull)` — switches the **current conversation** only; `null` returns to Main
+  Agent. Does not accept a caller-supplied session id.
+- `host.agents.delete(name, { revision })`.
+- `host.agents.attach_skill(name, skillRef, { revision })` / `host.agents.detach_skill(...)`.
+- `host.agents.attach_connector(name, connectorRef, { revision })` / `host.agents.detach_connector(...)`.
+- `host.agents.list_skills(nameOrId?)` — complete Skill catalog, including Main-disabled Skills.
+- `host.agents.list_connectors(nameOrId?)` — public Connector information; never credentials, headers,
+  environment values, Connector arguments, or tokens.
+
+`create` takes an object:
+
+```js
+host.agents.create({
+  name,
+  description,
+  system_prompt,
+  icon_key,
+  color_key,
+  enabled,
+  unrestricted,
+  skill_names,
+  connector_names
+})
+```
+
+Skill/Connector references resolve an exact stable catalog id first, otherwise a unique public name. An
+ambiguous name is rejected — tell the user to use the stable id from `list_skills`/`list_connectors`.
+
+Errors are sanitized and prefixed `host.agents.<method>:`; they never contain system instructions,
+credentials, headers, environment values, Connector arguments, or the RPC token.
+
+## Workflow — every operation
+
+Follow this order for every mutation. Do not skip the live read, and do not snapshot catalog contents
+into a profile or session (resolution is always live):
+
+1. **Understand scope.** What does the user want to create/change/delete/switch?
+2. **Live read.** Call `get`/`list` plus `list_skills`/`list_connectors` to read the current state and
+   the catalogs before proposing anything.
+3. **Complete draft.** Build the full target state, not a partial edit.
+4. **Review.** Show the complete target state to the user.
+5. **Applicable confirmation.** Get the confirmation that matches the operation kind (see below).
+6. **Mutate.** Call the SDK with the reviewed revision.
+7. **Read-back.** Re-read actual state via `get`/`list` (or binding read-back for switch) before
+   reporting completion.
+
+## Scope clarification (Full vs Selected)
+
+When the user has **not** specified Full versus Selected, you must **ask**. Do not silently use the
+SDK's omitted-fields Full default — never assume Full access. Full is selected only after an explicit
+request such as "full access" or "same capabilities as Main."
+
+Capability semantics:
+
+- `create` with neither `skill_names` nor `connector_names` → Full access. But only use this after the
+  user explicitly chose Full.
+- Supplying either array on `create` → Selected; an omitted other array becomes empty.
+- `update({ unrestricted: true })` → Full, preserving the stored Selected configuration.
+- Supplying `skill_names` or `connector_names` to `update` exactly replaces the supplied collection and
+  switches to Selected; an omitted collection is preserved.
+- `attach_*`/`detach_*` mutate the current mode without changing it (Selected: add/remove an inclusion;
+  Full: remove/add an exclusion).
+- Selected mode with zero Skills and zero Connectors is valid.
+
+## Ordinary mutation review
+
+For create and non-name update, show the complete target state and wait for the user's explicit
+confirmation before executing. The review must show:
+
+- Name
+- Description
+- Full system instructions (shown in the conversation here — they are never written to logs or
+  catalog broadcasts)
+- Icon and color
+- Enabled state
+- Full/Selected mode
+- Skills
+- Whole Connectors
+- **Connector tool scope is not configured in this milestone.** State this explicitly — do not show it
+  as an empty reviewed configuration. (Per-Connector tool scope arrives in a later milestone.)
+
+For an update, also identify the changed fields.
+
+For multi-field capability edits, prefer **one atomic `update`** over a loop of `attach_*`/`detach_*`
+calls that could partially succeed. Use `attach_*`/`detach_*` only for a single incremental collection
+move.
+
+## Confirmation boundaries
+
+- **Create and ordinary (non-name) update:** show the complete target state and wait for the user's
+  explicit confirmation (for example "yes", "confirm", "ok") before executing. The initial `/customize`
+  entry and the composer prefill are **not** confirmation.
+- **Name-changing update, delete, switch:** describe the impending action, then execute it directly.
+  These operations are privileged: the whole patch is applied atomically, and if any field cannot be
+  applied, nothing changes.
+
+When you describe one of these privileged actions, explain:
+
+- **Switch:** current Specialist, target Specialist or Main Agent, the current conversation, and that
+  it takes effect on the next message.
+- **Name-changing update:** old name, new name, the other fields changed in the same atomic patch, and
+  that stable conversation bindings do not change.
+- **Delete:** the Specialist name, and that conversations still bound to it become unavailable (they are
+  NOT switched to Main Agent).
+
+## Revision and stale drafts
+
+Carry the reviewed `revision` into `update`/`delete`/`attach_*`/`detach_*`. A stale revision fails
+**without merge or retry**. When it fails, re-read, rebuild the complete draft, and ask for
+confirmation again. A changed draft also invalidates the user's earlier confirmation — re-review after
+the user edits the draft. Do not automatically retry declined or stale privileged operations.
+
+## Structured declines
+
+A declined operation is a normal result, for example `{ status: "declined", operation: "switch" }`.
+Report it as a **user decision** and stop. Do not retry it.
+
+## Read-back and reporting
+
+- After a successful create/update, re-read with `get`/`list` and report the actual state. Never assume
+  success from the call alone.
+- After `switch`, report that the **current reply continues** under the existing Specialist and the
+  approved target applies to the **next message**. The binding survives app restart.
+- After `delete`, report that existing conversations bound to the deleted Specialist become
+  **unavailable** — they are not switched to Main Agent; the user must explicitly choose another
+  Specialist or Main Agent.
+
+## Do not expose UUIDs/revisions in ordinary prose
+
+Returned records include stable `id` and `revision`, but do not show them to the user unless needed to
+resolve ambiguity (for example, an ambiguous catalog name where you must ask for the stable id) or to
+explain a revision conflict. Ordinary reporting uses names and the reviewed state only.
+
+## Language
+
+Respond naturally in the conversation's language. This document and the fixed user-facing review/card
+copy remain English.

--- a/resources/skills/manifest.json
+++ b/resources/skills/manifest.json
@@ -108,6 +108,12 @@
       "name": "Remote Compute (SSH)",
       "source": "featured",
       "updatedAt": "2026-07-22T00:00:00.000Z"
+    },
+    {
+      "id": "customize",
+      "name": "Customize",
+      "source": "featured",
+      "updatedAt": "2026-07-31T00:00:00.000Z"
     }
   ]
 }

--- a/src/main/agents/agents-dispatch.test.ts
+++ b/src/main/agents/agents-dispatch.test.ts
@@ -1,0 +1,676 @@
+import { describe, expect, it, vi } from 'vitest'
+
+import { AgentsService, type AgentsCatalogSource } from './agents-service'
+import type { ApprovalGateway, ApprovalResult, SwitchNotifier } from '../../shared/agents-contract'
+import type { SpecialistProfileView } from '../../shared/specialist'
+import type { ProfileService } from '../specialist/service'
+import type { SessionBindingService } from '../specialist/session-binding'
+
+const noopCatalog = (): AgentsCatalogSource => ({
+  listSkillCatalog: vi.fn(async () => []),
+  getConnectors: vi.fn(async () => ({ enabledIds: [], autoAllowIds: [] }))
+})
+
+const noopProfileService = (): ProfileService =>
+  ({
+    list: vi.fn(async () => []),
+    getByName: vi.fn(async () => {
+      throw new Error('not found')
+    })
+  }) as unknown as ProfileService
+
+describe('AgentsService.dispatch — extensible operation dispatcher', () => {
+  it('routes a read op identically to read()', async () => {
+    const service = new AgentsService({
+      profileService: {
+        list: vi.fn(async () => [
+          {
+            id: 'sp-1',
+            name: 'Bio',
+            displayName: 'Bio',
+            description: '',
+            systemPrompt: '',
+            enabled: true,
+            capabilityMode: 'selected',
+            fullAccess: { excludedSkillIds: [], excludedConnectorIds: [], connectorTools: [] },
+            selectedCapabilities: { skillIds: [], connectorIds: [], connectorTools: [] },
+            revision: 1
+          }
+        ]),
+        getByName: vi.fn()
+      } as unknown as ProfileService,
+      catalog: noopCatalog()
+    })
+    const viaDispatch = await service.dispatch({ op: 'list' })
+    const viaRead = await service.read({ op: 'list' })
+    expect(viaDispatch).toEqual(viaRead)
+    expect((viaDispatch as Array<{ id: string }>)[0].id).toBe('sp-1')
+  })
+
+  it('rejects an unknown op with a sanitized host.agents.<op>: error', async () => {
+    const service = new AgentsService({
+      profileService: noopProfileService(),
+      catalog: noopCatalog()
+    })
+    await expect(service.dispatch({ op: 'rename' })).rejects.toThrow(/host\.agents\.rename:/)
+  })
+
+  it('rejects a malformed request (no op) with a host.agents.unknown: error', async () => {
+    const service = new AgentsService({
+      profileService: noopProfileService(),
+      catalog: noopCatalog()
+    })
+    await expect(service.dispatch({})).rejects.toThrow(/host\.agents\.unknown:/)
+    await expect(service.dispatch(null)).rejects.toThrow(/host\.agents\.unknown:/)
+  })
+
+  it('strips reserved routing/identity/switch keys before reading params', async () => {
+    const getByName = vi.fn(
+      async () =>
+        ({
+          id: 'sp-1',
+          name: 'Bio',
+          displayName: 'Bio',
+          description: '',
+          systemPrompt: '',
+          enabled: true,
+          capabilityMode: 'selected',
+          fullAccess: { excludedSkillIds: [], excludedConnectorIds: [], connectorTools: [] },
+          selectedCapabilities: { skillIds: [], connectorIds: [], connectorTools: [] },
+          revision: 1
+        }) as SpecialistProfileView
+    )
+    const service = new AgentsService({
+      profileService: { list: vi.fn(), getByName } as unknown as ProfileService,
+      catalog: noopCatalog()
+    })
+    // Sandbox tries to forge a session, a specialist id, a switch target, and a reconfigure flag.
+    await service.dispatch({
+      op: 'get',
+      params: {
+        name: 'Bio',
+        session_id: 'forged',
+        specialist_id: 'forged-sp',
+        target_specialist_id: 'forged-target',
+        reconfigure: true
+      }
+    })
+    // The service received ONLY { name: 'Bio' } — every reserved key was dropped.
+    expect(getByName).toHaveBeenCalledWith('Bio')
+    expect(getByName.mock.calls[0]).toEqual(['Bio'])
+  })
+
+  it('fail-closes privileged ops when their approval seam is not configured', async () => {
+    // Ordinary mutations (create/update/attach/detach) are implemented (issue 03); switch is
+    // implemented but fails closed on missing seams (issue 05, asserted below); delete and
+    // name-changing update are implemented (issue 04 module) and fail closed only when the injected
+    // approval gateway is absent. With no gateway wired, both surface a sanitized "not configured"
+    // error rather than silently no-op'ing.
+    const service = new AgentsService({
+      profileService: noopProfileService(),
+      catalog: noopCatalog()
+    })
+    await expect(service.dispatch({ op: 'delete', params: {} })).rejects.toThrow(
+      /host\.agents\.delete:.*not configured/
+    )
+  })
+
+  it('ordinary mutations route to ProfileService (no longer fail-closed)', async () => {
+    const created = vi.fn(async () => ({
+      id: 'sp-1',
+      name: 'Bio',
+      displayName: 'Bio',
+      description: '',
+      systemPrompt: '',
+      enabled: true,
+      capabilityMode: 'full' as const,
+      fullAccess: { excludedSkillIds: [], excludedConnectorIds: [], connectorTools: [] },
+      selectedCapabilities: { skillIds: [], connectorIds: [], connectorTools: [] },
+      revision: 1
+    }))
+    const service = new AgentsService({
+      profileService: { ...noopProfileService(), create: created } as unknown as ProfileService,
+      catalog: noopCatalog()
+    })
+    const result = (await service.dispatch({ op: 'create', params: { name: 'Bio' } })) as {
+      id: string
+      capabilityMode: string
+    }
+    expect(created).toHaveBeenCalledTimes(1)
+    expect(result.id).toBe('sp-1')
+    expect(result.capabilityMode).toBe('full')
+  })
+
+  it('switch fails closed when its approval/binding/persistence seams are not configured', async () => {
+    const service = new AgentsService({
+      profileService: noopProfileService(),
+      catalog: noopCatalog()
+    })
+    await expect(service.dispatch({ op: 'switch', params: {} })).rejects.toThrow(
+      /host\.agents\.switch:.*not configured/
+    )
+  })
+
+  it('reads unchanged: existing list/get/list_skills behavior preserved', async () => {
+    const service = new AgentsService({
+      profileService: noopProfileService(),
+      catalog: noopCatalog()
+    })
+    await expect(service.read({ op: 'list' })).resolves.toEqual([])
+    await expect(service.read({ op: 'get', params: {} })).rejects.toThrow(/host\.agents\.get:/)
+    // list_skills with an empty catalog returns []; list_connectors projects the bundled catalog
+    // (covered by the dedicated connector test in agents-service.test.ts) so we only assert skills
+    // here to avoid coupling this contract test to the bundled connector set.
+    await expect(service.read({ op: 'list_skills', params: {} })).resolves.toEqual([])
+  })
+})
+
+describe('AgentsService.dispatch — switch op routing (issue 05)', () => {
+  const specialist = (overrides: Partial<SpecialistProfileView> = {}): SpecialistProfileView => ({
+    id: 'sp-1',
+    name: 'BIO_EXPERT',
+    displayName: 'Bio Expert',
+    description: '',
+    systemPrompt: 'SECRET INSTRUCTIONS',
+    enabled: true,
+    capabilityMode: 'selected',
+    fullAccess: { excludedSkillIds: [], excludedConnectorIds: [], connectorTools: [] },
+    selectedCapabilities: { skillIds: [], connectorIds: [], connectorTools: [] },
+    revision: 2,
+    ...overrides
+  })
+
+  type BuildServiceResult = {
+    service: AgentsService
+    profileService: ProfileService
+    sessionBinding: SessionBindingService
+    persist: (sessionId: string, specialistId: string | undefined) => Promise<void>
+    notify: SwitchNotifier['notify']
+    gateway: ApprovalGateway
+  }
+
+  const buildService = (opts: {
+    profiles?: SpecialistProfileView[]
+    decision?: ApprovalResult
+  }): BuildServiceResult => {
+    const profiles = opts.profiles ?? [specialist()]
+    const profileService = {
+      list: vi.fn(async () => profiles),
+      getByName: vi.fn(async (name: string) => {
+        const found = profiles.find((p) => p.name === name)
+        if (!found) throw new Error(`Specialist "${name}" not found.`)
+        return found
+      })
+    } as unknown as ProfileService
+    const sessionBinding = {
+      setBinding: vi.fn(),
+      getBinding: vi.fn()
+    } as unknown as SessionBindingService
+    const persist = vi.fn(async () => undefined)
+    const notify = vi.fn(async () => undefined)
+    const gateway: ApprovalGateway = {
+      decide: vi.fn(async (): Promise<ApprovalResult> => opts.decision ?? { status: 'approved' })
+    }
+    const notifier: SwitchNotifier = { notify }
+    const service = new AgentsService({
+      profileService,
+      catalog: noopCatalog(),
+      approvalGateway: gateway,
+      switchNotifier: notifier,
+      sessionBinding,
+      persistSessionSpecialist: persist
+    })
+    return { service, profileService, sessionBinding, persist, notify, gateway }
+  }
+
+  it('routes an approved switch through the dispatcher and persists + broadcasts', async () => {
+    const { service, persist, notify, sessionBinding } = buildService({})
+    const result = (await service.dispatch(
+      { op: 'switch', params: { name: 'BIO_EXPERT' } },
+      { sessionId: 'session-trusted' }
+    )) as {
+      status: string
+      binding: { specialistId: string }
+      pendingReconfigure: { targetName: string }
+    }
+    expect(result.status).toBe('approved')
+    expect(result.binding.specialistId).toBe('sp-1')
+    expect(result.pendingReconfigure.targetName).toBe('BIO_EXPERT')
+    expect(persist).toHaveBeenCalledWith('session-trusted', 'sp-1')
+    expect(notify).toHaveBeenCalledWith({ sessionId: 'session-trusted', targetName: 'BIO_EXPERT' })
+    expect(sessionBinding.setBinding).toHaveBeenCalledWith('session-trusted', 'sp-1')
+  })
+
+  it('a declined switch returns the structured declined shape and changes nothing', async () => {
+    const { service, persist, notify, sessionBinding } = buildService({
+      decision: { status: 'declined', operation: 'switch' }
+    })
+    const result = await service.dispatch(
+      { op: 'switch', params: { name: 'BIO_EXPERT' } },
+      { sessionId: 'session-trusted' }
+    )
+    expect(result).toEqual({ status: 'declined', operation: 'switch' })
+    expect(persist).not.toHaveBeenCalled()
+    expect(notify).not.toHaveBeenCalled()
+    expect(sessionBinding.setBinding).not.toHaveBeenCalled()
+  })
+
+  it('null name switches to Main Agent (clears the binding) through the dispatcher', async () => {
+    const { service, persist, notify } = buildService({})
+    const result = (await service.dispatch(
+      { op: 'switch', params: { name: null } },
+      { sessionId: 'session-trusted' }
+    )) as { binding: { specialistId: string | undefined } }
+    expect(result.binding.specialistId).toBeUndefined()
+    expect(persist).toHaveBeenCalledWith('session-trusted', undefined)
+    expect(notify).toHaveBeenCalledWith({ sessionId: 'session-trusted', targetName: null })
+  })
+
+  it('the trusted calling session is the only session the switch may target', async () => {
+    const { service, persist } = buildService({})
+    // A sandbox forges a session id in params; the dispatcher honors only the server context.
+    await service.dispatch(
+      { op: 'switch', params: { name: 'BIO_EXPERT', session_id: 'forged', sessionId: 'forged' } },
+      { sessionId: 'session-trusted' }
+    )
+    expect(persist).toHaveBeenCalledWith('session-trusted', 'sp-1')
+  })
+})
+
+describe('AgentsService.dispatch — privileged mutation routing (issue 08a composition)', () => {
+  const specialist = (overrides: Partial<SpecialistProfileView> = {}): SpecialistProfileView => ({
+    id: 'sp-1',
+    name: 'Bio',
+    displayName: 'Bio',
+    description: 'old',
+    systemPrompt: 'SECRET INSTRUCTIONS',
+    enabled: true,
+    capabilityMode: 'selected',
+    fullAccess: { excludedSkillIds: [], excludedConnectorIds: [], connectorTools: [] },
+    selectedCapabilities: { skillIds: [], connectorIds: [], connectorTools: [] },
+    revision: 3,
+    ...overrides
+  })
+
+  const buildService = (opts: {
+    profiles?: SpecialistProfileView[]
+    decision?: ApprovalResult
+  }): {
+    service: AgentsService
+    profileService: ProfileService
+    gateway: ApprovalGateway
+    invalidateCatalog: ReturnType<typeof vi.fn>
+  } => {
+    const profiles = opts.profiles ?? [specialist()]
+    const profileService = {
+      list: vi.fn(async () => profiles),
+      getByName: vi.fn(async (name: string) => {
+        const found = profiles.find((p) => p.name === name)
+        if (!found) throw new Error(`Specialist "${name}" not found.`)
+        return found
+      }),
+      update: vi.fn(async () => {
+        throw new Error('unexpected')
+      }),
+      delete: vi.fn(async () => undefined)
+    } as unknown as ProfileService
+    const gateway: ApprovalGateway = {
+      decide: vi.fn(async (): Promise<ApprovalResult> => opts.decision ?? { status: 'approved' })
+    }
+    const invalidateCatalog = vi.fn(async () => undefined)
+    const service = new AgentsService({
+      profileService,
+      catalog: noopCatalog(),
+      approvalGateway: gateway,
+      invalidateCatalog
+    })
+    return { service, profileService, gateway, invalidateCatalog }
+  }
+
+  it('routes a name-changing update through applyNameChangingUpdate (real read-back, no echo)', async () => {
+    // The ProfileService returns the REAL post-write record (new name + bumped revision); the dispatcher
+    // must surface it verbatim, not echo the request patch.
+    const updated = specialist({ name: 'Biology', description: 'new', revision: 4 })
+    const { service, profileService } = buildService({
+      profiles: [specialist()]
+    })
+    ;(profileService.update as ReturnType<typeof vi.fn>).mockResolvedValue(updated)
+
+    const result = (await service.dispatch({
+      op: 'update',
+      params: { name: 'Bio', patch: { name: 'Biology', description: 'new', revision: 3 } }
+    })) as { status: string; agent: SpecialistProfileView }
+
+    expect(result.status).toBe('updated')
+    expect(result.agent.name).toBe('Biology')
+    expect(result.agent.revision).toBe(4)
+    // The privileged module re-resolved name -> id and pinned the re-resolved revision before update.
+    const updateArgs = (profileService.update as ReturnType<typeof vi.fn>).mock.calls[0][0]
+    expect(updateArgs.id).toBe('sp-1')
+    expect(updateArgs.revision).toBe(3)
+    expect(updateArgs.name).toBe('Biology')
+  })
+
+  it('a non-name update stays on the ordinary-mutation path (not the privileged module)', async () => {
+    const ordinaryReturn = specialist({ description: 'edited', revision: 4 })
+    const profileService = {
+      ...noopProfileService(),
+      getByName: vi.fn(async () => specialist()),
+      update: vi.fn(async () => ordinaryReturn)
+    } as unknown as ProfileService
+    const gateway: ApprovalGateway = {
+      decide: vi.fn(async (): Promise<ApprovalResult> => ({ status: 'approved' }))
+    }
+    const service = new AgentsService({
+      profileService,
+      catalog: noopCatalog(),
+      approvalGateway: gateway
+    })
+
+    const result = (await service.dispatch({
+      op: 'update',
+      params: { name: 'Bio', patch: { description: 'edited', revision: 3 } }
+    })) as { id: string; description: string }
+
+    // Ordinary path returns a projected AgentReadModel (no {status:'updated'} envelope).
+    expect(result.id).toBe('sp-1')
+    expect(result.description).toBe('edited')
+    // The privileged gateway was NOT consulted for a non-name update.
+    expect(gateway.decide).not.toHaveBeenCalled()
+  })
+
+  it('routes delete through applyDelete and returns { status: deleted, name }', async () => {
+    const { service, profileService, invalidateCatalog } = buildService({
+      profiles: [specialist()]
+    })
+    // getByName throws "not found" after delete -> absence verified.
+    ;(profileService.getByName as ReturnType<typeof vi.fn>)
+      .mockResolvedValueOnce(specialist())
+      .mockRejectedValueOnce(new Error('Specialist "Bio" not found.'))
+
+    const result = (await service.dispatch({
+      op: 'delete',
+      params: { name: 'Bio', revision: 3 }
+    })) as { status: string; name: string }
+
+    expect(result).toEqual({ status: 'deleted', name: 'Bio' })
+    expect(profileService.delete as ReturnType<typeof vi.fn>).toHaveBeenCalledWith('sp-1', 3)
+    expect(invalidateCatalog).toHaveBeenCalledTimes(1)
+  })
+
+  it('a declined delete returns the structured declined shape and mutates nothing', async () => {
+    const { service, profileService, invalidateCatalog } = buildService({
+      profiles: [specialist()],
+      decision: { status: 'declined', operation: 'delete', reason: 'user cancelled' }
+    })
+
+    const result = await service.dispatch({
+      op: 'delete',
+      params: { name: 'Bio', revision: 3 }
+    })
+
+    expect(result).toEqual({ status: 'declined', operation: 'delete', reason: 'user cancelled' })
+    expect(profileService.delete as ReturnType<typeof vi.fn>).not.toHaveBeenCalled()
+    expect(invalidateCatalog).not.toHaveBeenCalled()
+  })
+
+  it('a stale revision fails closed with a sanitized error (no mutation, no retry)', async () => {
+    const { service, profileService, invalidateCatalog } = buildService({
+      // Live revision drifted to 5 while the reviewed revision was 3.
+      profiles: [specialist({ revision: 5 })]
+    })
+
+    await expect(
+      service.dispatch({ op: 'delete', params: { name: 'Bio', revision: 3 } })
+    ).rejects.toThrow(/host\.agents\.delete:.*reviewed revision 3/)
+    expect(profileService.delete as ReturnType<typeof vi.fn>).not.toHaveBeenCalled()
+    expect(invalidateCatalog).not.toHaveBeenCalled()
+  })
+
+  it('delete never clears session bindings (no binding sink invoked)', async () => {
+    const { service, profileService } = buildService({ profiles: [specialist()] })
+    // getByName resolves the live record pre-delete, then throws "not found" post-delete (absence).
+    ;(profileService.getByName as ReturnType<typeof vi.fn>)
+      .mockResolvedValueOnce(specialist())
+      .mockRejectedValueOnce(new Error('Specialist "Bio" not found.'))
+    // The result surface and dispatcher carry NO binding-clearance path; the contract is that bound
+    // conversations resolve unavailable later. This asserts the dispatcher routes through a module
+    // that does not clear bindings — there is no such seam on AgentsServiceDeps.
+    const result = await service.dispatch({ op: 'delete', params: { name: 'Bio', revision: 3 } })
+    expect(result).toEqual({ status: 'deleted', name: 'Bio' })
+  })
+
+  // Regression (08a review): a name-changing patch that ALSO edits capabilities MUST apply both
+  // atomically. The /customize Skill sends skill_names/connector_names in the same update patch as a
+  // rename (preferAtomicUpdate), and explainNameChange promises to "rename ... and apply the rest of
+  // the reviewed changes in one step". Previously runPrivilegedUpdate projected identity/text fields
+  // only and silently dropped the capability edit.
+  const skillCatalog = (): AgentsCatalogSource => ({
+    listSkillCatalog: vi.fn(async () => [
+      {
+        id: 'sk-reviewer',
+        frameworkName: 'reviewer',
+        displayName: 'Reviewer',
+        source: 'bundled',
+        mainEnabled: true,
+        available: true
+      }
+    ]),
+    getConnectors: vi.fn(async () => ({ enabledIds: [], autoAllowIds: [] }))
+  })
+
+  const buildServiceWithSkills = (opts: {
+    profiles: SpecialistProfileView[]
+    decision?: ApprovalResult
+  }): {
+    service: AgentsService
+    profileService: ProfileService
+    invalidateCatalog: ReturnType<typeof vi.fn>
+  } => {
+    const profileService = {
+      list: vi.fn(async () => opts.profiles),
+      getByName: vi.fn(async (name: string) => {
+        const found = opts.profiles.find((p) => p.name === name)
+        if (!found) throw new Error(`Specialist "${name}" not found.`)
+        return found
+      }),
+      update: vi.fn(async () => {
+        throw new Error('unexpected')
+      }),
+      delete: vi.fn(async () => undefined)
+    } as unknown as ProfileService
+    const gateway: ApprovalGateway = {
+      decide: vi.fn(async (): Promise<ApprovalResult> => opts.decision ?? { status: 'approved' })
+    }
+    const invalidateCatalog = vi.fn(async () => undefined)
+    const service = new AgentsService({
+      profileService,
+      catalog: skillCatalog(),
+      approvalGateway: gateway,
+      invalidateCatalog
+    })
+    return { service, profileService, invalidateCatalog }
+  }
+
+  it('a name-changing patch that also edits skill_names applies BOTH atomically (no capability drop)', async () => {
+    // The ProfileService returns the REAL post-write record (renamed, bumped revision, AND the new
+    // selected capability collection). The dispatcher must surface it verbatim, not echo the request.
+    const updated: SpecialistProfileView = {
+      ...specialist({ name: 'Biology', revision: 4 }),
+      capabilityMode: 'selected',
+      selectedCapabilities: { skillIds: ['sk-reviewer'], connectorIds: [], connectorTools: [] },
+      fullAccess: { excludedSkillIds: [], excludedConnectorIds: [], connectorTools: [] }
+    }
+    const { service, profileService } = buildServiceWithSkills({ profiles: [specialist()] })
+    ;(profileService.update as ReturnType<typeof vi.fn>).mockResolvedValue(updated)
+
+    const result = (await service.dispatch({
+      op: 'update',
+      params: {
+        name: 'Bio',
+        patch: { name: 'Biology', skill_names: ['sk-reviewer'], revision: 3 }
+      }
+    })) as { status: string; agent: SpecialistProfileView }
+
+    expect(result.status).toBe('updated')
+    // REAL post-write read-back: BOTH the rename and the capability edit landed.
+    expect(result.agent.name).toBe('Biology')
+    expect(result.agent.capabilityMode).toBe('selected')
+    expect(result.agent.selectedCapabilities.skillIds).toEqual(['sk-reviewer'])
+    expect(result.agent.revision).toBe(4)
+
+    // The privileged module received the COMPLETE patch: name + resolved capability fields. The
+    // skill ref was resolved to its stable id and projected onto the patch (not stripped).
+    const updateArgs = (profileService.update as ReturnType<typeof vi.fn>).mock.calls[0][0]
+    expect(updateArgs.name).toBe('Biology')
+    expect(updateArgs.capabilityMode).toBe('selected')
+    expect(updateArgs.selectedCapabilities).toEqual({
+      skillIds: ['sk-reviewer'],
+      connectorIds: [],
+      connectorTools: []
+    })
+  })
+
+  it('a declined name-changing+capability patch mutates nothing (decline path preserved)', async () => {
+    const { service, profileService, invalidateCatalog } = buildServiceWithSkills({
+      profiles: [specialist()],
+      decision: { status: 'declined', operation: 'update', reason: 'user cancelled' }
+    })
+
+    const result = await service.dispatch({
+      op: 'update',
+      params: {
+        name: 'Bio',
+        patch: { name: 'Biology', skill_names: ['sk-reviewer'], revision: 3 }
+      }
+    })
+
+    expect(result).toEqual({ status: 'declined', operation: 'update', reason: 'user cancelled' })
+    expect(profileService.update as ReturnType<typeof vi.fn>).not.toHaveBeenCalled()
+    expect(invalidateCatalog).not.toHaveBeenCalled()
+  })
+
+  it('a combined name+capability patch with a stale revision fails closed (no mutation)', async () => {
+    // Live revision drifted to 5 while the reviewed revision was 3.
+    const { service, profileService, invalidateCatalog } = buildServiceWithSkills({
+      profiles: [specialist({ revision: 5 })]
+    })
+
+    await expect(
+      service.dispatch({
+        op: 'update',
+        params: {
+          name: 'Bio',
+          patch: { name: 'Biology', skill_names: ['sk-reviewer'], revision: 3 }
+        }
+      })
+    ).rejects.toThrow(/host\.agents\.update:.*reviewed revision 3/)
+    expect(profileService.update as ReturnType<typeof vi.fn>).not.toHaveBeenCalled()
+    expect(invalidateCatalog).not.toHaveBeenCalled()
+  })
+
+  // Regression (defect #1): a name-changing patch that ALSO toggles `enabled` must land BOTH. The
+  // ordinary update path applies `enabled` via a separate ProfileService.setEnabled(...) call after
+  // the identity/capability update; the privileged path previously built specialistPatch without
+  // `enabled` and never called setEnabled, so the enabled change was silently dropped on approval.
+  it('a name-changing patch that also toggles enabled applies BOTH the rename and the enabled change', async () => {
+    // After the atomic rename (revision 3->4), setEnabled flips enabled to false and bumps again
+    // (revision 4->5). The dispatcher must return the REAL post-setEnabled read-back with the new
+    // name AND enabled === false.
+    const renamed = specialist({ name: 'Biology', revision: 4, enabled: true })
+    const afterToggle = specialist({ name: 'Biology', revision: 5, enabled: false })
+    const { service, profileService } = buildService({ profiles: [specialist()] })
+    ;(profileService.update as ReturnType<typeof vi.fn>).mockResolvedValue(renamed)
+    ;(profileService.setEnabled as ReturnType<typeof vi.fn>) = vi.fn(async () => afterToggle)
+
+    const result = (await service.dispatch({
+      op: 'update',
+      params: { name: 'Bio', patch: { name: 'Biology', enabled: false, revision: 3 } }
+    })) as { status: string; agent: SpecialistProfileView }
+
+    expect(result.status).toBe('updated')
+    // REAL post-write read-back carries BOTH the rename and the enabled toggle.
+    expect(result.agent.name).toBe('Biology')
+    expect(result.agent.enabled).toBe(false)
+    expect(result.agent.revision).toBe(5)
+    // setEnabled was invoked with the toggled value, after the atomic rename committed.
+    expect(profileService.setEnabled as ReturnType<typeof vi.fn>).toHaveBeenCalledWith(
+      'sp-1',
+      false
+    )
+  })
+
+  // Regression (defect #5): a name-changing patch must reject unknown keys the same way the ordinary
+  // update path does. Previously runPrivilegedUpdate never called rejectUnknownKeys, so an unknown
+  // field (e.g. a forged/malicious key) was silently ignored instead of rejected.
+  it('rejects a name-changing patch carrying an unknown field with a sanitized error', async () => {
+    const { service, profileService, invalidateCatalog } = buildService({
+      profiles: [specialist()]
+    })
+
+    await expect(
+      service.dispatch({
+        op: 'update',
+        params: {
+          name: 'Bio',
+          patch: { name: 'Biology', malicious_field: 'x', revision: 3 }
+        }
+      })
+    ).rejects.toThrow(/host\.agents\.update:.*Unknown field "malicious_field"/)
+    expect(profileService.update as ReturnType<typeof vi.fn>).not.toHaveBeenCalled()
+    expect(invalidateCatalog).not.toHaveBeenCalled()
+  })
+})
+
+describe('AgentsService — injected seams are fake-able and routed (composition against fakes)', () => {
+  // Simulates a downstream module (issue 04/05) implementing the gateway + notifier as fakes and
+  // confirming the service accepts them and the dispatcher's write-op branches are the integration
+  // point. Real behavior is deferred; this only proves the contract composes.
+  it('accepts an injected ApprovalGateway and SwitchNotifier and they satisfy the dep types', () => {
+    const fakeGateway: ApprovalGateway = {
+      decide: vi.fn(async (): Promise<ApprovalResult> => ({ status: 'approved' }))
+    }
+    const fakeNotifier: SwitchNotifier = { notify: vi.fn() }
+    const service = new AgentsService({
+      profileService: noopProfileService(),
+      catalog: noopCatalog(),
+      approvalGateway: fakeGateway,
+      switchNotifier: fakeNotifier
+    })
+    expect(service).toBeInstanceOf(AgentsService)
+  })
+
+  it('the injected gateway can return the structured declined shape (PRD:137)', async () => {
+    const decisions: ApprovalResult[] = [
+      { status: 'declined', operation: 'switch' },
+      { status: 'declined', operation: 'delete', reason: 'user cancelled' },
+      { status: 'approved' }
+    ]
+    const fakeGateway: ApprovalGateway = {
+      decide: vi.fn(
+        async (): Promise<ApprovalResult> => decisions.shift() ?? { status: 'approved' }
+      )
+    }
+    expect(
+      await fakeGateway.decide({
+        operation: 'switch',
+        summary: {},
+        session: { sessionId: 's' }
+      })
+    ).toEqual({ status: 'declined', operation: 'switch' })
+    expect(
+      await fakeGateway.decide({
+        operation: 'delete',
+        summary: {},
+        session: { sessionId: 's' }
+      })
+    ).toEqual({ status: 'declined', operation: 'delete', reason: 'user cancelled' })
+    expect(
+      await fakeGateway.decide({
+        operation: 'switch',
+        summary: {},
+        session: { sessionId: 's' }
+      })
+    ).toEqual({ status: 'approved' })
+  })
+})

--- a/src/main/agents/agents-mutations.test.ts
+++ b/src/main/agents/agents-mutations.test.ts
@@ -1,0 +1,862 @@
+import { describe, expect, it, vi } from 'vitest'
+
+import { executeAgentsMutation, type AgentsMutationCatalog } from './agents-mutations'
+import type { ConnectorReadModel, SkillCatalogReadModel } from './agents-service'
+import type {
+  CreateSpecialistInput,
+  SpecialistProfileView,
+  UpdateSpecialistInput
+} from '../../shared/specialist'
+import type { ProfileService } from '../specialist/service'
+
+// ---------------------------------------------------------------------------
+// Stubs
+// ---------------------------------------------------------------------------
+
+const baseProfile = (overrides: Partial<SpecialistProfileView> = {}): SpecialistProfileView => ({
+  id: 'sp-1',
+  name: 'Bio',
+  displayName: 'Bio',
+  description: '',
+  systemPrompt: '',
+  enabled: true,
+  capabilityMode: 'selected',
+  fullAccess: { excludedSkillIds: [], excludedConnectorIds: [], connectorTools: [] },
+  selectedCapabilities: { skillIds: [], connectorIds: [], connectorTools: [] },
+  revision: 1,
+  ...overrides
+})
+
+// A ProfileService fake that records every mutation call and returns a read-back view built from the
+// stored config so we can assert real read-back (not echoed input).
+const makeProfileService = (
+  initial: SpecialistProfileView[]
+): ProfileService & {
+  calls: { method: string; args: unknown[] }[]
+  setStored: (next: SpecialistProfileView[]) => void
+} => {
+  let stored: SpecialistProfileView[] = initial
+  const calls: { method: string; args: unknown[] }[] = []
+  const bump = (view: SpecialistProfileView): SpecialistProfileView => ({
+    ...view,
+    revision: view.revision + 1
+  })
+  const svc = {
+    calls,
+    setStored(next: SpecialistProfileView[]) {
+      stored = next
+    },
+    async list() {
+      return stored
+    },
+    async getByName(name: string) {
+      const found = stored.find((p) => p.name === name)
+      if (!found) throw new Error(`Specialist "${name}" not found.`)
+      return found
+    },
+    async create(input: CreateSpecialistInput) {
+      calls.push({ method: 'create', args: [input] })
+      const view: SpecialistProfileView = {
+        id: 'sp-new',
+        name: input.name,
+        displayName: input.displayName ?? input.name,
+        description: input.description ?? '',
+        systemPrompt: input.systemPrompt ?? '',
+        iconKey: input.iconKey,
+        colorKey: input.colorKey,
+        enabled: true,
+        capabilityMode: input.capabilityMode ?? 'full',
+        fullAccess: input.fullAccess ?? {
+          excludedSkillIds: [],
+          excludedConnectorIds: [],
+          connectorTools: []
+        },
+        selectedCapabilities: input.selectedCapabilities ?? {
+          skillIds: [],
+          connectorIds: [],
+          connectorTools: []
+        },
+        revision: 1
+      }
+      stored = [...stored, view]
+      return view
+    },
+    async update(input: UpdateSpecialistInput) {
+      calls.push({ method: 'update', args: [input] })
+      const idx = stored.findIndex((p) => p.id === input.id)
+      if (idx < 0) throw new Error(`Specialist ${input.id} not found after update.`)
+      const merged: SpecialistProfileView = { ...stored[idx] }
+      if (input.name !== undefined) merged.name = input.name
+      if (input.displayName !== undefined) merged.displayName = input.displayName
+      if (input.description !== undefined) merged.description = input.description
+      if (input.systemPrompt !== undefined) merged.systemPrompt = input.systemPrompt
+      if (input.iconKey !== undefined) merged.iconKey = input.iconKey
+      if (input.colorKey !== undefined) merged.colorKey = input.colorKey
+      if (input.capabilityMode !== undefined) merged.capabilityMode = input.capabilityMode
+      if (input.fullAccess !== undefined) merged.fullAccess = input.fullAccess
+      if (input.selectedCapabilities !== undefined) {
+        merged.selectedCapabilities = input.selectedCapabilities
+      }
+      const next = bump(merged)
+      stored = stored.map((p, i) => (i === idx ? next : p))
+      return next
+    },
+    async attachSkill(id: string, skillId: string, revision: number, mode: 'full' | 'selected') {
+      calls.push({ method: 'attachSkill', args: [id, skillId, revision, mode] })
+      const idx = stored.findIndex((p) => p.id === id)
+      const cur = stored[idx]
+      const next =
+        mode === 'full'
+          ? {
+              ...cur,
+              fullAccess: {
+                ...cur.fullAccess,
+                excludedSkillIds: cur.fullAccess.excludedSkillIds.filter((s) => s !== skillId)
+              }
+            }
+          : {
+              ...cur,
+              selectedCapabilities: {
+                ...cur.selectedCapabilities,
+                skillIds: [...new Set([...cur.selectedCapabilities.skillIds, skillId])]
+              }
+            }
+      stored = stored.map((p, i) => (i === idx ? bump(next) : p))
+      return stored[idx]
+    },
+    async detachSkill(id: string, skillId: string, revision: number, mode: 'full' | 'selected') {
+      calls.push({ method: 'detachSkill', args: [id, skillId, revision, mode] })
+      const idx = stored.findIndex((p) => p.id === id)
+      const cur = stored[idx]
+      const next =
+        mode === 'full'
+          ? {
+              ...cur,
+              fullAccess: {
+                ...cur.fullAccess,
+                excludedSkillIds: [...new Set([...cur.fullAccess.excludedSkillIds, skillId])]
+              }
+            }
+          : {
+              ...cur,
+              selectedCapabilities: {
+                ...cur.selectedCapabilities,
+                skillIds: cur.selectedCapabilities.skillIds.filter((s) => s !== skillId)
+              }
+            }
+      stored = stored.map((p, i) => (i === idx ? bump(next) : p))
+      return stored[idx]
+    },
+    async attachConnector(
+      id: string,
+      connectorId: string,
+      revision: number,
+      mode: 'full' | 'selected'
+    ) {
+      calls.push({ method: 'attachConnector', args: [id, connectorId, revision, mode] })
+      const idx = stored.findIndex((p) => p.id === id)
+      const cur = stored[idx]
+      const next =
+        mode === 'full'
+          ? {
+              ...cur,
+              fullAccess: {
+                ...cur.fullAccess,
+                excludedConnectorIds: cur.fullAccess.excludedConnectorIds.filter(
+                  (c) => c !== connectorId
+                )
+              }
+            }
+          : {
+              ...cur,
+              selectedCapabilities: {
+                ...cur.selectedCapabilities,
+                connectorIds: [...new Set([...cur.selectedCapabilities.connectorIds, connectorId])]
+              }
+            }
+      stored = stored.map((p, i) => (i === idx ? bump(next) : p))
+      return stored[idx]
+    },
+    async detachConnector(
+      id: string,
+      connectorId: string,
+      revision: number,
+      mode: 'full' | 'selected'
+    ) {
+      calls.push({ method: 'detachConnector', args: [id, connectorId, revision, mode] })
+      const idx = stored.findIndex((p) => p.id === id)
+      const cur = stored[idx]
+      const next =
+        mode === 'full'
+          ? {
+              ...cur,
+              fullAccess: {
+                ...cur.fullAccess,
+                excludedConnectorIds: [
+                  ...new Set([...cur.fullAccess.excludedConnectorIds, connectorId])
+                ]
+              }
+            }
+          : {
+              ...cur,
+              selectedCapabilities: {
+                ...cur.selectedCapabilities,
+                connectorIds: cur.selectedCapabilities.connectorIds.filter((c) => c !== connectorId)
+              }
+            }
+      stored = stored.map((p, i) => (i === idx ? bump(next) : p))
+      return stored[idx]
+    },
+    async setEnabled(id: string, enabled: boolean) {
+      calls.push({ method: 'setEnabled', args: [id, enabled] })
+      const idx = stored.findIndex((p) => p.id === id)
+      const cur = stored[idx]
+      const next = bump({ ...cur, enabled })
+      stored = stored.map((p, i) => (i === idx ? next : p))
+      return next
+    }
+  } as unknown as ProfileService & typeof svc
+  return svc
+}
+
+const skills = (...entries: Partial<SkillCatalogReadModel>[]): SkillCatalogReadModel[] =>
+  entries.map((e) => ({
+    id: 'demo',
+    name: 'demo',
+    displayName: 'demo',
+    source: 'featured',
+    mainEnabled: true,
+    available: true,
+    ...e
+  }))
+
+const connectors = (...entries: Partial<ConnectorReadModel>[]): ConnectorReadModel[] =>
+  entries.map((e) => ({
+    id: 'bundled',
+    displayName: 'Bundled',
+    description: '',
+    mainEnabled: true,
+    availability: 'available',
+    source: 'bundled',
+    tools: [],
+    ...e
+  }))
+
+const makeCatalog = (
+  skillEntries: SkillCatalogReadModel[],
+  connectorEntries: ConnectorReadModel[]
+): {
+  catalog: AgentsMutationCatalog
+  skillSpy: ReturnType<typeof vi.fn>
+  connectorSpy: ReturnType<typeof vi.fn>
+} => {
+  const skillSpy = vi.fn(async () => skillEntries)
+  const connectorSpy = vi.fn(async () => connectorEntries)
+  return {
+    catalog: { listSkills: skillSpy, listConnectors: connectorSpy },
+    skillSpy,
+    connectorSpy
+  }
+}
+
+describe('executeAgentsMutation — payload validation (rejects before reaching the repo)', () => {
+  it('rejects an unknown create field', async () => {
+    const svc = makeProfileService([])
+    const { catalog } = makeCatalog([], [])
+    await expect(
+      executeAgentsMutation(
+        { op: 'create', params: { name: 'Bio', bogus_field: 'x' } },
+        { profileService: svc, catalog }
+      )
+    ).rejects.toThrow(/host\.agents\.create:/)
+  })
+
+  it('rejects a malformed name type on create', async () => {
+    const svc = makeProfileService([])
+    const { catalog } = makeCatalog([], [])
+    await expect(
+      executeAgentsMutation(
+        { op: 'create', params: { name: 42 } },
+        { profileService: svc, catalog }
+      )
+    ).rejects.toThrow(/host\.agents\.create:/)
+  })
+
+  it('rejects a non-finite revision on update', async () => {
+    const svc = makeProfileService([baseProfile()])
+    const { catalog } = makeCatalog([], [])
+    await expect(
+      executeAgentsMutation(
+        { op: 'update', params: { name: 'Bio', patch: { revision: Number.NaN } } },
+        { profileService: svc, catalog }
+      )
+    ).rejects.toThrow(/host\.agents\.update:/)
+  })
+
+  it('rejects a non-array skill_names on create', async () => {
+    const svc = makeProfileService([])
+    const { catalog } = makeCatalog([], [])
+    await expect(
+      executeAgentsMutation(
+        { op: 'create', params: { name: 'Bio', skill_names: 'demo' } },
+        { profileService: svc, catalog }
+      )
+    ).rejects.toThrow(/host\.agents\.create:/)
+  })
+
+  it('rejects unknown update fields', async () => {
+    const svc = makeProfileService([baseProfile()])
+    const { catalog } = makeCatalog([], [])
+    await expect(
+      executeAgentsMutation(
+        { op: 'update', params: { name: 'Bio', patch: { revision: 1, oops: true } } },
+        { profileService: svc, catalog }
+      )
+    ).rejects.toThrow(/host\.agents\.update:/)
+  })
+
+  it('rejects connector tool-method / include-exclude patterns as out of scope', async () => {
+    const svc = makeProfileService([])
+    const { catalog } = makeCatalog(skills(), connectors())
+    // Connector tool scope is a later milestone; the agreed object does not name these fields, so
+    // they are rejected as unknown before reaching the repository.
+    await expect(
+      executeAgentsMutation(
+        {
+          op: 'create',
+          params: { name: 'Bio', connector_tools: [{ connectorId: 'c', includedMethods: ['x'] }] }
+        },
+        { profileService: svc, catalog }
+      )
+    ).rejects.toThrow(/host\.agents\.create:/)
+    await expect(
+      executeAgentsMutation(
+        { op: 'create', params: { name: 'Bio2', include_tools_pattern: 'c.*' } },
+        { profileService: svc, catalog }
+      )
+    ).rejects.toThrow(/host\.agents\.create:/)
+  })
+})
+
+describe('executeAgentsMutation — create', () => {
+  it('create with neither capability array produces Full access', async () => {
+    const svc = makeProfileService([])
+    const { catalog } = makeCatalog(skills(), connectors())
+    const result = (await executeAgentsMutation(
+      { op: 'create', params: { name: 'Bio', description: 'd', system_prompt: 'p' } },
+      { profileService: svc, catalog }
+    )) as SpecialistProfileView
+    expect(svc.calls[0].method).toBe('create')
+    const passed = svc.calls[0].args[0] as CreateSpecialistInput
+    expect(passed.capabilityMode).toBe('full')
+    expect(result.capabilityMode).toBe('full')
+  })
+
+  it('create with skill_names produces Selected and stores connector collection empty', async () => {
+    const svc = makeProfileService([])
+    const { catalog } = makeCatalog(skills({ id: 'sk1', name: 'Skill One' }), connectors())
+    const result = (await executeAgentsMutation(
+      { op: 'create', params: { name: 'Bio', skill_names: ['sk1'] } },
+      { profileService: svc, catalog }
+    )) as SpecialistProfileView
+    const passed = svc.calls[0].args[0] as CreateSpecialistInput
+    expect(passed.capabilityMode).toBe('selected')
+    expect(passed.selectedCapabilities?.skillIds).toEqual(['sk1'])
+    expect(passed.selectedCapabilities?.connectorIds).toEqual([])
+    expect(result.capabilityMode).toBe('selected')
+  })
+
+  it('create with connector_names produces Selected and stores skill collection empty', async () => {
+    const svc = makeProfileService([])
+    const { catalog } = makeCatalog(skills(), connectors({ id: 'c1', displayName: 'Conn' }))
+    await executeAgentsMutation(
+      { op: 'create', params: { name: 'Bio', connector_names: ['c1'] } },
+      { profileService: svc, catalog }
+    )
+    const passed = svc.calls[0].args[0] as CreateSpecialistInput
+    expect(passed.capabilityMode).toBe('selected')
+    expect(passed.selectedCapabilities?.connectorIds).toEqual(['c1'])
+    expect(passed.selectedCapabilities?.skillIds).toEqual([])
+  })
+
+  it('create accepts the full agreed object and returns a real read-back (not echoed input)', async () => {
+    const svc = makeProfileService([])
+    const { catalog } = makeCatalog(
+      skills({ id: 'sk1', name: 'Skill One' }),
+      connectors({ id: 'c1', displayName: 'Conn' })
+    )
+    const result = (await executeAgentsMutation(
+      {
+        op: 'create',
+        params: {
+          name: 'Bio',
+          description: 'desc',
+          system_prompt: 'p',
+          icon_key: 'beaker',
+          color_key: 'green',
+          enabled: false,
+          unrestricted: false,
+          skill_names: ['Skill One'],
+          connector_names: ['c1']
+        }
+      },
+      { profileService: svc, catalog }
+    )) as SpecialistProfileView
+    // read-back is a real view: it carries id + revision + enabled always true (create default),
+    // and capability resolved against the stable IDs, not the echoed public name.
+    expect(result.id).toBe('sp-new')
+    expect(result.revision).toBe(1)
+    // Providing either capability array produces Selected (AC), regardless of unrestricted.
+    expect(result.capabilityMode).toBe('selected')
+    expect(svc.calls[0].method).toBe('create')
+  })
+
+  it('create rejects a missing name', async () => {
+    const svc = makeProfileService([])
+    const { catalog } = makeCatalog([], [])
+    await expect(
+      executeAgentsMutation({ op: 'create', params: {} }, { profileService: svc, catalog })
+    ).rejects.toThrow(/host\.agents\.create:/)
+  })
+
+  it('create resolves a skill public name to its stable id and persists only the id', async () => {
+    const svc = makeProfileService([])
+    const { catalog } = makeCatalog(skills({ id: 'stable-1', name: 'Skill One' }), connectors())
+    await executeAgentsMutation(
+      { op: 'create', params: { name: 'Bio', skill_names: ['Skill One'] } },
+      { profileService: svc, catalog }
+    )
+    const passed = svc.calls[0].args[0] as CreateSpecialistInput
+    expect(passed.selectedCapabilities?.skillIds).toEqual(['stable-1'])
+  })
+
+  it('create resolves a connector public name to its stable id', async () => {
+    const svc = makeProfileService([])
+    const { catalog } = makeCatalog(
+      skills(),
+      connectors({ id: 'stable-c', displayName: 'My Connector' })
+    )
+    await executeAgentsMutation(
+      { op: 'create', params: { name: 'Bio', connector_names: ['My Connector'] } },
+      { profileService: svc, catalog }
+    )
+    const passed = svc.calls[0].args[0] as CreateSpecialistInput
+    expect(passed.selectedCapabilities?.connectorIds).toEqual(['stable-c'])
+  })
+
+  it('create rejects an ambiguous skill name and instructs to use the stable id', async () => {
+    const svc = makeProfileService([])
+    const { catalog } = makeCatalog(
+      skills({ id: 'a', name: 'Dup' }, { id: 'b', name: 'Dup' }),
+      connectors()
+    )
+    await expect(
+      executeAgentsMutation(
+        { op: 'create', params: { name: 'Bio', skill_names: ['Dup'] } },
+        { profileService: svc, catalog }
+      )
+    ).rejects.toThrow(/stable id/)
+  })
+
+  it('create allows a Main-disabled installed skill to be assigned', async () => {
+    const svc = makeProfileService([])
+    const { catalog } = makeCatalog(
+      skills({ id: 'sk1', name: 'Disabled', mainEnabled: false }),
+      connectors()
+    )
+    const result = (await executeAgentsMutation(
+      { op: 'create', params: { name: 'Bio', skill_names: ['sk1'] } },
+      { profileService: svc, catalog }
+    )) as SpecialistProfileView
+    expect(svc.calls[0].method).toBe('create')
+    expect(result.capabilityMode).toBe('selected')
+  })
+})
+
+describe('executeAgentsMutation — update', () => {
+  it('update supports description, system instructions, icon, color, enabled, mode, skills, connectors', async () => {
+    const svc = makeProfileService([baseProfile({ revision: 1 })])
+    const { catalog } = makeCatalog(
+      skills({ id: 'sk1', name: 'Skill One' }),
+      connectors({ id: 'c1', displayName: 'Conn' })
+    )
+    const result = (await executeAgentsMutation(
+      {
+        op: 'update',
+        params: {
+          name: 'Bio',
+          patch: {
+            revision: 1,
+            description: 'new desc',
+            system_prompt: 'new prompt',
+            icon_key: 'flask',
+            color_key: 'blue',
+            enabled: false,
+            skill_names: ['sk1'],
+            connector_names: ['c1']
+          }
+        }
+      },
+      { profileService: svc, catalog }
+    )) as SpecialistProfileView
+    expect(svc.calls[0].method).toBe('update')
+    const passed = svc.calls[0].args[0] as UpdateSpecialistInput
+    expect(passed.description).toBe('new desc')
+    expect(passed.systemPrompt).toBe('new prompt')
+    expect(passed.iconKey).toBe('flask')
+    expect(passed.colorKey).toBe('blue')
+    expect(passed.capabilityMode).toBe('selected')
+    expect(passed.selectedCapabilities?.skillIds).toEqual(['sk1'])
+    expect(passed.selectedCapabilities?.connectorIds).toEqual(['c1'])
+    // read-back is the real returned view, not echoed input. revision reflects both mutations
+    // (update bumps 1->2, setEnabled bumps 2->3) since enabled lives on a separate service method.
+    expect(result.id).toBe('sp-1')
+    expect(result.revision).toBe(3)
+  })
+
+  it('update({ unrestricted: true }) switches to Full without destroying the stored Selected config', async () => {
+    const svc = makeProfileService([
+      baseProfile({
+        revision: 1,
+        selectedCapabilities: { skillIds: ['sk1'], connectorIds: ['c1'], connectorTools: [] }
+      })
+    ])
+    const { catalog } = makeCatalog(skills(), connectors())
+    await executeAgentsMutation(
+      { op: 'update', params: { name: 'Bio', patch: { revision: 1, unrestricted: true } } },
+      { profileService: svc, catalog }
+    )
+    const passed = svc.calls[0].args[0] as UpdateSpecialistInput
+    expect(passed.capabilityMode).toBe('full')
+    // Selected config NOT overwritten (no selectedCapabilities in the patch).
+    expect(passed.selectedCapabilities).toBeUndefined()
+  })
+
+  it('update providing skill_names exactly replaces the collection and switches to Selected', async () => {
+    const svc = makeProfileService([
+      baseProfile({
+        revision: 1,
+        capabilityMode: 'full',
+        selectedCapabilities: { skillIds: ['old'], connectorIds: ['oldc'], connectorTools: [] }
+      })
+    ])
+    const { catalog } = makeCatalog(
+      skills({ id: 'new1', name: 'New' }, { id: 'new2', name: 'Newer' }),
+      connectors()
+    )
+    await executeAgentsMutation(
+      {
+        op: 'update',
+        params: { name: 'Bio', patch: { revision: 1, skill_names: ['new1', 'new2'] } }
+      },
+      { profileService: svc, catalog }
+    )
+    const passed = svc.calls[0].args[0] as UpdateSpecialistInput
+    expect(passed.capabilityMode).toBe('selected')
+    expect(passed.selectedCapabilities?.skillIds).toEqual(['new1', 'new2'])
+    // Omitted connector collection is preserved from the stored Selected config.
+    expect(passed.selectedCapabilities?.connectorIds).toEqual(['oldc'])
+  })
+
+  it('update preserving omitted collections: skill_names omitted keeps existing skills', async () => {
+    const svc = makeProfileService([
+      baseProfile({
+        revision: 1,
+        capabilityMode: 'selected',
+        selectedCapabilities: { skillIds: ['keep'], connectorIds: [], connectorTools: [] }
+      })
+    ])
+    const { catalog } = makeCatalog(skills(), connectors({ id: 'c1', displayName: 'C' }))
+    await executeAgentsMutation(
+      { op: 'update', params: { name: 'Bio', patch: { revision: 1, connector_names: ['c1'] } } },
+      { profileService: svc, catalog }
+    )
+    const passed = svc.calls[0].args[0] as UpdateSpecialistInput
+    expect(passed.selectedCapabilities?.connectorIds).toEqual(['c1'])
+    // Omitted skill collection is preserved from the stored Selected config.
+    expect(passed.selectedCapabilities?.skillIds).toEqual(['keep'])
+  })
+
+  it('update requires a matching revision; a stale revision fails without merge/retry', async () => {
+    const svc = makeProfileService([baseProfile({ revision: 5 })])
+    const { catalog } = makeCatalog(skills(), connectors())
+    await expect(
+      executeAgentsMutation(
+        { op: 'update', params: { name: 'Bio', patch: { revision: 1, description: 'x' } } },
+        { profileService: svc, catalog }
+      )
+    ).rejects.toThrow(/host\.agents\.update:/)
+    expect(svc.calls).toHaveLength(0)
+  })
+
+  it('a non-name update does not request a permission card (no approval gateway call)', async () => {
+    const decide = vi.fn(async () => ({ status: 'approved' as const }))
+    const svc = makeProfileService([baseProfile({ revision: 1 })])
+    const { catalog } = makeCatalog(skills(), connectors())
+    await executeAgentsMutation(
+      { op: 'update', params: { name: 'Bio', patch: { revision: 1, description: 'x' } } },
+      { profileService: svc, catalog, approvalGateway: { decide } }
+    )
+    expect(decide).not.toHaveBeenCalled()
+  })
+
+  it('update reads changes from the nested patch so a rename never collides with the lookup name', async () => {
+    const svc = makeProfileService([baseProfile({ revision: 1 })])
+    const { catalog } = makeCatalog(skills(), connectors())
+    const result = (await executeAgentsMutation(
+      { op: 'update', params: { name: 'Bio', patch: { revision: 1, description: 'nested desc' } } },
+      { profileService: svc, catalog }
+    )) as SpecialistProfileView
+    const passed = svc.calls[0].args[0] as UpdateSpecialistInput
+    expect(passed.description).toBe('nested desc')
+    expect(result.revision).toBe(2)
+  })
+
+  it('update rejects a name change on the ordinary path (rename is privileged)', async () => {
+    const svc = makeProfileService([baseProfile({ revision: 1 })])
+    const { catalog } = makeCatalog(skills(), connectors())
+    await expect(
+      executeAgentsMutation(
+        { op: 'update', params: { name: 'Bio', patch: { revision: 1, name: 'NewName' } } },
+        { profileService: svc, catalog }
+      )
+    ).rejects.toThrow(/host\.agents\.update:.*approval/)
+    // No mutation reached the repository.
+    expect(svc.calls).toHaveLength(0)
+  })
+
+  it('update requires a nested patch object', async () => {
+    const svc = makeProfileService([baseProfile({ revision: 1 })])
+    const { catalog } = makeCatalog(skills(), connectors())
+    await expect(
+      executeAgentsMutation(
+        { op: 'update', params: { name: 'Bio' } },
+        { profileService: svc, catalog }
+      )
+    ).rejects.toThrow(/host\.agents\.update:/)
+    expect(svc.calls).toHaveLength(0)
+  })
+})
+
+describe('executeAgentsMutation — attach/detach mutate current mode without switching it', () => {
+  it('Selected attach_skill adds an inclusion; detach removes it', async () => {
+    const svc = makeProfileService([baseProfile({ revision: 1, capabilityMode: 'selected' })])
+    const { catalog } = makeCatalog(skills({ id: 'sk1', name: 'S' }), connectors())
+    await executeAgentsMutation(
+      { op: 'attach_skill', params: { name: 'Bio', skill_ref: 'sk1', revision: 1 } },
+      { profileService: svc, catalog }
+    )
+    expect(svc.calls[0]).toEqual({ method: 'attachSkill', args: ['sp-1', 'sk1', 1, 'selected'] })
+    await executeAgentsMutation(
+      { op: 'detach_skill', params: { name: 'Bio', skill_ref: 'sk1', revision: 2 } },
+      { profileService: svc, catalog }
+    )
+    expect(svc.calls[1]).toEqual({ method: 'detachSkill', args: ['sp-1', 'sk1', 2, 'selected'] })
+  })
+
+  it('Full attach_skill removes an exclusion; detach adds one', async () => {
+    const svc = makeProfileService([baseProfile({ revision: 1, capabilityMode: 'full' })])
+    const { catalog } = makeCatalog(skills({ id: 'sk1', name: 'S' }), connectors())
+    await executeAgentsMutation(
+      { op: 'attach_skill', params: { name: 'Bio', skill_ref: 'sk1', revision: 1 } },
+      { profileService: svc, catalog }
+    )
+    expect(svc.calls[0]).toEqual({ method: 'attachSkill', args: ['sp-1', 'sk1', 1, 'full'] })
+    await executeAgentsMutation(
+      { op: 'detach_skill', params: { name: 'Bio', skill_ref: 'sk1', revision: 2 } },
+      { profileService: svc, catalog }
+    )
+    expect(svc.calls[1]).toEqual({ method: 'detachSkill', args: ['sp-1', 'sk1', 2, 'full'] })
+  })
+
+  // Regression (sprint review): detach_skill must resolve a public DISPLAY NAME to the stable catalog
+  // id. resolveOrPassThrough receives `await catalog.listSkills()`; a missing `await` passes a Promise
+  // as the entries, applyNameOrIdFilter throws on the non-iterable, the catch swallows it, and the
+  // literal display name reaches detachSkill instead of the resolved stable id. The existing tests
+  // above used a ref that equals the stable id, so they passed even with the bug.
+  it('detach_skill resolves a public name to the stable catalog id (not the literal ref)', async () => {
+    const svc = makeProfileService([baseProfile({ revision: 1, capabilityMode: 'selected' })])
+    const { catalog } = makeCatalog(
+      skills({ id: 'sk-stable', name: 'Skill One', displayName: 'Skill One' }),
+      connectors()
+    )
+    await executeAgentsMutation(
+      { op: 'detach_skill', params: { name: 'Bio', skill_ref: 'Skill One', revision: 1 } },
+      { profileService: svc, catalog }
+    )
+    expect(svc.calls[0]).toEqual({
+      method: 'detachSkill',
+      args: ['sp-1', 'sk-stable', 1, 'selected']
+    })
+  })
+
+  it('attach_connector / detach_connector follow the same mode rules', async () => {
+    const svc = makeProfileService([baseProfile({ revision: 1, capabilityMode: 'selected' })])
+    const { catalog } = makeCatalog(skills(), connectors({ id: 'c1', displayName: 'C' }))
+    await executeAgentsMutation(
+      { op: 'attach_connector', params: { name: 'Bio', connector_ref: 'c1', revision: 1 } },
+      { profileService: svc, catalog }
+    )
+    expect(svc.calls[0]).toEqual({
+      method: 'attachConnector',
+      args: ['sp-1', 'c1', 1, 'selected']
+    })
+    const svc2 = makeProfileService([baseProfile({ revision: 1, capabilityMode: 'full' })])
+    await executeAgentsMutation(
+      { op: 'detach_connector', params: { name: 'Bio', connector_ref: 'c1', revision: 1 } },
+      { profileService: svc2, catalog }
+    )
+    expect(svc2.calls[0]).toEqual({
+      method: 'detachConnector',
+      args: ['sp-1', 'c1', 1, 'full']
+    })
+  })
+
+  it('attach/detach rejects a missing revision', async () => {
+    const svc = makeProfileService([baseProfile()])
+    const { catalog } = makeCatalog(skills({ id: 'sk1', name: 'S' }), connectors())
+    await expect(
+      executeAgentsMutation(
+        { op: 'attach_skill', params: { name: 'Bio', skill_ref: 'sk1' } },
+        { profileService: svc, catalog }
+      )
+    ).rejects.toThrow(/host\.agents\.attach_skill:/)
+  })
+
+  it('attach/detach rejects unknown params', async () => {
+    const svc = makeProfileService([baseProfile()])
+    const { catalog } = makeCatalog(skills({ id: 'sk1', name: 'S' }), connectors())
+    await expect(
+      executeAgentsMutation(
+        { op: 'detach_skill', params: { name: 'Bio', skill_ref: 'sk1', revision: 1, extra: 1 } },
+        { profileService: svc, catalog }
+      )
+    ).rejects.toThrow(/host\.agents\.detach_skill:/)
+  })
+})
+
+describe('executeAgentsMutation — Connector availability gate', () => {
+  it('cannot newly attach an unavailable custom connector', async () => {
+    const svc = makeProfileService([baseProfile({ revision: 1, capabilityMode: 'selected' })])
+    const { catalog } = makeCatalog(
+      skills(),
+      connectors({ id: 'dead', source: 'custom', availability: 'unavailable' })
+    )
+    await expect(
+      executeAgentsMutation(
+        { op: 'attach_connector', params: { name: 'Bio', connector_ref: 'dead', revision: 1 } },
+        { profileService: svc, catalog }
+      )
+    ).rejects.toThrow(/host\.agents\.attach_connector:/)
+    expect(svc.calls).toHaveLength(0)
+  })
+
+  it('cannot newly attach an unauthenticated custom connector', async () => {
+    const svc = makeProfileService([baseProfile({ revision: 1, capabilityMode: 'selected' })])
+    const { catalog } = makeCatalog(
+      skills(),
+      connectors({ id: 'unauth', source: 'custom', availability: 'unauthenticated' })
+    )
+    await expect(
+      executeAgentsMutation(
+        { op: 'attach_connector', params: { name: 'Bio', connector_ref: 'unauth', revision: 1 } },
+        { profileService: svc, catalog }
+      )
+    ).rejects.toThrow(/host\.agents\.attach_connector:/)
+  })
+
+  it('create with an unavailable custom connector in connector_names is rejected', async () => {
+    const svc = makeProfileService([])
+    const { catalog } = makeCatalog(
+      skills(),
+      connectors({ id: 'dead', source: 'custom', availability: 'unavailable' })
+    )
+    await expect(
+      executeAgentsMutation(
+        { op: 'create', params: { name: 'Bio', connector_names: ['dead'] } },
+        { profileService: svc, catalog }
+      )
+    ).rejects.toThrow(/host\.agents\.create:/)
+  })
+
+  it('an available custom connector can be attached', async () => {
+    const svc = makeProfileService([baseProfile({ revision: 1, capabilityMode: 'selected' })])
+    const { catalog } = makeCatalog(
+      skills(),
+      connectors({ id: 'ok', source: 'custom', availability: 'available' })
+    )
+    await executeAgentsMutation(
+      { op: 'attach_connector', params: { name: 'Bio', connector_ref: 'ok', revision: 1 } },
+      { profileService: svc, catalog }
+    )
+    expect(svc.calls[0]).toEqual({ method: 'attachConnector', args: ['sp-1', 'ok', 1, 'selected'] })
+  })
+
+  it('detach passes through a stale reference no longer in the catalog (still removable)', async () => {
+    // An existing stale reference that has since been removed from the catalog must still be
+    // detachable. detach falls back to the literal stable id when nothing matches.
+    const svc = makeProfileService([baseProfile({ revision: 1, capabilityMode: 'selected' })])
+    const { catalog } = makeCatalog(
+      skills(),
+      // 'stale-connector' is NOT in the catalog.
+      connectors({ id: 'other', displayName: 'Other' })
+    )
+    await executeAgentsMutation(
+      {
+        op: 'detach_connector',
+        params: { name: 'Bio', connector_ref: 'stale-connector', revision: 1 }
+      },
+      { profileService: svc, catalog }
+    )
+    expect(svc.calls[0]).toEqual({
+      method: 'detachConnector',
+      args: ['sp-1', 'stale-connector', 1, 'selected']
+    })
+  })
+})
+
+describe('executeAgentsMutation — no direct repo writes, no duplicated rules', () => {
+  it('all mutations delegate to ProfileService (never write the repository directly)', async () => {
+    const svc = makeProfileService([baseProfile({ revision: 1, capabilityMode: 'selected' })])
+    const { catalog } = makeCatalog(
+      skills({ id: 'sk1', name: 'S' }),
+      connectors({ id: 'c1', displayName: 'C' })
+    )
+    await executeAgentsMutation(
+      { op: 'update', params: { name: 'Bio', patch: { revision: 1, description: 'd' } } },
+      { profileService: svc, catalog }
+    )
+    await executeAgentsMutation(
+      { op: 'attach_skill', params: { name: 'Bio', skill_ref: 'sk1', revision: 2 } },
+      { profileService: svc, catalog }
+    )
+    expect(svc.calls.map((c) => c.method)).toEqual(['update', 'attachSkill'])
+  })
+})
+
+describe('executeAgentsMutation — errors are sanitized', () => {
+  it('ProfileService internal secret never reaches the sandbox', async () => {
+    const svc = makeProfileService([])
+    svc.create = vi.fn(async () => {
+      throw new Error('internal secret: apikey=ABCDEF')
+    })
+    const { catalog } = makeCatalog([], [])
+    await expect(
+      executeAgentsMutation(
+        { op: 'create', params: { name: 'Bio' } },
+        { profileService: svc, catalog }
+      )
+    ).rejects.toThrow(/host\.agents\.create:/)
+  })
+
+  it('a repo revision-conflict surfaces as a sanitized host.agents.update: error', async () => {
+    const svc = makeProfileService([baseProfile({ revision: 5 })])
+    const { catalog } = makeCatalog(skills(), connectors())
+    await expect(
+      executeAgentsMutation(
+        { op: 'update', params: { name: 'Bio', patch: { revision: 1, description: 'x' } } },
+        { profileService: svc, catalog }
+      )
+    ).rejects.toThrow(/host\.agents\.update:/)
+  })
+})

--- a/src/main/agents/agents-mutations.ts
+++ b/src/main/agents/agents-mutations.ts
@@ -1,0 +1,553 @@
+// host.agents ordinary-mutation operation module (issue 03).
+//
+// This module implements the ORDINARY Profile mutations + read-back: create, non-name update,
+// enable/disable, and incremental whole-Skill/whole-Connector attach/detach. It is deliberately a
+// standalone module so issue 08 can compose it into the shared dispatcher without changing issues
+// 04/05. The privileged ops (delete, switch, and name-changing update) stay out of scope here — they
+// require the injected approval gateway.
+//
+// Design rules (design.md §4/§5/§8, PRD §2/§4):
+//  - ProfileService is the SINGLE domain mutation service. This module never writes the repository
+//    directly and never re-implements the Full/Selected collection rules; it only translates the
+//    public snake_case SDK input into ProfileService input and delegates.
+//  - Every successful mutation returns an actual post-write camelCase Profile read-back, never an
+//    echo of the requested input.
+//  - Skill/Connector references resolve an exact catalog ID first, otherwise an unambiguous public
+//    name, and persist only the stable ID.
+//  - update/delete-style mutations require the current existing revision; a stale revision fails
+//    without merge or retry (delegated to the repository's optimistic-concurrency check).
+//  - Errors are sanitized and prefixed `host.agents.<method>:` so system instructions, connector
+//    args, secrets, headers, environment values, and the RPC token never leak.
+//  - Main validates every payload before reaching the repository: unknown, malformed, non-finite,
+//    or wrong-shaped fields are rejected here.
+//
+// This module does NOT own conversational review or a permission card — that is the /customize Skill
+// (later slice). Ordinary mutations do not request a system permission card.
+
+import type { ConnectorReadModel, SkillCatalogReadModel } from './agents-service'
+import { applyNameOrIdFilter } from './agents-service'
+import type { ProfileService } from '../specialist/service'
+import type { SpecialistProfileView } from '../../shared/specialist'
+import type {
+  CreateSpecialistInput,
+  SpecialistCapabilityMode,
+  SpecialistFullAccessConfig,
+  SpecialistSelectedConfig
+} from '../../shared/specialist'
+import { emptyFullAccessConfig, emptySelectedConfig } from '../../shared/specialist'
+import type { ApprovalGateway } from '../../shared/agents-contract'
+
+// The catalog resolution seam this module consumes. It receives the ALREADY-PROJECTED public read
+// models (the same models the read slice returns from list_skills/list_connectors), so this module
+// never duplicates the connector catalog projection rules or the Full/Selected collection rules. In
+// production this is wired to the AgentsService read methods; in tests it is stubbed directly.
+export type AgentsMutationCatalog = {
+  // The complete Specialist-visible skill catalog, including Main-disabled installed skills.
+  listSkills(): Promise<SkillCatalogReadModel[]>
+  // The complete Specialist-visible connector catalog, projected without secret material.
+  listConnectors(): Promise<ConnectorReadModel[]>
+}
+
+// The dependency bundle this module needs. `approvalGateway` is accepted so the module signature is
+// stable for the privileged slices, but ordinary mutations never call it (ordinary mutations do not
+// request a system permission card).
+export type AgentsMutationDeps = {
+  profileService: ProfileService
+  catalog: AgentsMutationCatalog
+  approvalGateway?: ApprovalGateway
+}
+
+// The ordinary-mutation request union this module serves. The privileged ops (delete/switch) are
+// intentionally NOT here.
+export type AgentsOrdinaryMutationRequest =
+  | { op: 'create'; params: Record<string, unknown> }
+  | { op: 'update'; params: Record<string, unknown> }
+  | { op: 'attach_skill'; params: Record<string, unknown> }
+  | { op: 'detach_skill'; params: Record<string, unknown> }
+  | { op: 'attach_connector'; params: Record<string, unknown> }
+  | { op: 'detach_connector'; params: Record<string, unknown> }
+
+const METHOD_PREFIX = 'host.agents'
+
+// Sanitizes an arbitrary error into its top-level message only. System instructions, connector args,
+// credentials, headers, environment values, internal stack detail, and tokens must never reach the
+// sandbox. We keep only the message string (no nested secret-bearing JSON).
+const sanitizeError = (value: unknown): string =>
+  value instanceof Error ? value.message : String(value)
+
+class AgentsMutationError extends Error {
+  constructor(method: string, cause: unknown) {
+    super(`${METHOD_PREFIX}.${method}: ${sanitizeError(cause)}`)
+    this.name = 'AgentsMutationError'
+  }
+}
+
+// ---------------------------------------------------------------------------
+// Primitive payload guards
+// ---------------------------------------------------------------------------
+
+const isString = (value: unknown): value is string => typeof value === 'string'
+
+const isBoolean = (value: unknown): value is boolean => typeof value === 'boolean'
+
+// A plain record (not null, not an array). Used to validate the nested update `patch` object.
+const isRecord = (value: unknown): value is Record<string, unknown> =>
+  typeof value === 'object' && value !== null && !Array.isArray(value)
+
+// Finite, non-NaN integer revision.
+const isFinitePositiveInt = (value: unknown): value is number =>
+  typeof value === 'number' && Number.isFinite(value) && Number.isInteger(value) && value > 0
+
+const optionalStringOrThrow = (value: unknown, label: string): string | undefined => {
+  if (value === undefined) return undefined
+  if (!isString(value)) throw new Error(`${label} must be a string.`)
+  return value
+}
+
+// A string array of non-empty references (skill_names / connector_names). Rejects non-arrays,
+// non-string elements, and empty-string entries. Duplicates are preserved as-is and de-duped later.
+// Exported so the privileged name-changing update path (agents-service.runPrivilegedUpdate) reuses
+// the EXACT validation the ordinary update path uses — no duplicated payload plumbing.
+export const asStringArray = (value: unknown): string[] | undefined => {
+  if (value === undefined) return undefined
+  if (!Array.isArray(value) || !value.every((item) => isString(item) && item.length > 0)) {
+    throw new Error('Must be an array of non-empty strings.')
+  }
+  return value as string[]
+}
+
+// ---------------------------------------------------------------------------
+// Catalog resolution (reuses the read slice's projection + name/id filter)
+// ---------------------------------------------------------------------------
+
+// Resolves each public name/id skill reference to its stable id via the read slice's name/id filter
+// (exact id wins, otherwise a unique public name; ambiguity is rejected with a stable-id hint).
+// Exported so the privileged name-changing update path reuses the same resolution.
+export const resolveSkillRefs = async (
+  catalog: AgentsMutationCatalog,
+  refs: string[],
+  method: string
+): Promise<string[]> => {
+  const entries = await catalog.listSkills()
+  const ids: string[] = []
+  for (const ref of refs) {
+    const matched = applyNameOrIdFilter(entries, ref, method)
+    if (matched.length === 0) {
+      throw new Error(`No skill matches "${ref}".`)
+    }
+    ids.push(matched[0].id)
+  }
+  return ids
+}
+
+// Resolves each connector reference to its stable id and, when `gateUnavailable` is set (a NEW
+// attachment via create/attach_connector/update connector_names), rejects a missing, unavailable, or
+// unauthenticated custom connector. Existing stale references remain readable and removable via
+// detach (which calls this with gateUnavailable=false). Exported so the privileged name-changing
+// update path reuses the same resolution + gating.
+export const resolveConnectorRefs = async (
+  catalog: AgentsMutationCatalog,
+  refs: string[],
+  method: string,
+  options: { gateUnavailable: boolean }
+): Promise<{ ids: string[]; models: ConnectorReadModel[] }> => {
+  const entries = await catalog.listConnectors()
+  const ids: string[] = []
+  const models: ConnectorReadModel[] = []
+  for (const ref of refs) {
+    const matched = applyNameOrIdFilter(entries, ref, method)
+    if (matched.length === 0) {
+      throw new Error(`No connector matches "${ref}".`)
+    }
+    const model = matched[0]
+    if (options.gateUnavailable && model.availability !== 'available') {
+      throw new Error(`Connector "${ref}" is ${model.availability} and cannot be newly attached.`)
+    }
+    ids.push(model.id)
+    models.push(model)
+  }
+  return { ids, models }
+}
+
+// ---------------------------------------------------------------------------
+// Shared capability projection (used by BOTH the ordinary update path AND the
+// privileged name-changing update path so the two NEVER diverge)
+// ---------------------------------------------------------------------------
+
+// The capability-bearing slice of an UpdateSpecialistInput / SpecialistUpdatePatch. Returned
+// partially: a field is present ONLY when the patch changed it (matching ordinary partial-patch
+// semantics — omitted means "no change").
+export type CapabilityProjection = {
+  capabilityMode?: SpecialistCapabilityMode
+  fullAccess?: SpecialistFullAccessConfig
+  selectedCapabilities?: SpecialistSelectedConfig
+}
+
+// Projects the snake_case capability fields from a host.agents.update patch
+// (skill_names / connector_names / unrestricted) into the camelCase service fields, resolving
+// name/id references to stable ids via the shared catalog helpers. Semantics (mirrors the ordinary
+// update path exactly):
+//   - skill_names and/or connector_names present -> 'selected'; the provided collection is exactly
+//     replaced (resolved to stable ids), the omitted collection is preserved from `current`, and
+//     connectorTools is re-read from `current`. fullAccess is left unset.
+//   - neither array present but unrestricted:true -> 'full' (Selected configuration preserved).
+//   - neither -> returns an EMPTY projection (caller leaves capability fields unset; we do NOT
+//     force full-access). This is what lets a rename-only patch leave capabilities untouched.
+// `current` is the live profile the patch is being applied against (for preserving omitted
+// collections and connectorTools). `method` scopes error messages.
+export const projectCapabilityFields = async (
+  patch: Record<string, unknown>,
+  current: SpecialistProfileView,
+  catalog: AgentsMutationCatalog,
+  method: string
+): Promise<CapabilityProjection> => {
+  if (patch.unrestricted !== undefined && !isBoolean(patch.unrestricted)) {
+    throw new Error('unrestricted must be a boolean.')
+  }
+  const skillRefs = asStringArray(patch.skill_names)
+  const connectorRefs = asStringArray(patch.connector_names)
+  const unrestricted = patch.unrestricted === true
+
+  if (skillRefs !== undefined || connectorRefs !== undefined) {
+    const baseSelected: SpecialistSelectedConfig = structuredClone(current.selectedCapabilities)
+    if (skillRefs !== undefined) {
+      baseSelected.skillIds = await resolveSkillRefs(catalog, skillRefs, method)
+    }
+    if (connectorRefs !== undefined) {
+      baseSelected.connectorIds = (
+        await resolveConnectorRefs(catalog, connectorRefs, method, {
+          gateUnavailable: true
+        })
+      ).ids
+    }
+    baseSelected.connectorTools = current.selectedCapabilities.connectorTools
+    return { capabilityMode: 'selected', selectedCapabilities: baseSelected }
+  }
+  if (unrestricted) {
+    // update({ unrestricted: true }) switches to Full WITHOUT destroying the stored Selected
+    // configuration. We only set the mode; selectedCapabilities is left untouched.
+    return { capabilityMode: 'full' }
+  }
+  return {}
+}
+
+// ---------------------------------------------------------------------------
+// create
+// ---------------------------------------------------------------------------
+
+// The set of create fields the public SDK accepts. Anything else is rejected (cross-cutting:
+// unknown fields must not reach the repository).
+const CREATE_ALLOWED_KEYS = new Set([
+  'name',
+  'description',
+  'system_prompt',
+  'icon_key',
+  'color_key',
+  'enabled',
+  'unrestricted',
+  'skill_names',
+  'connector_names'
+])
+
+const handleCreate = async (
+  params: Record<string, unknown>,
+  deps: AgentsMutationDeps
+): Promise<SpecialistProfileView> => {
+  rejectUnknownKeys(params, CREATE_ALLOWED_KEYS, 'create')
+
+  const name = isString(params.name) ? params.name : throwShape('name is required')
+  if (!name.trim()) throw new Error('name is required')
+
+  const description = optionalStringOrThrow(params.description, 'description')
+  const systemPrompt = optionalStringOrThrow(params.system_prompt, 'system prompt')
+  const iconKey = optionalStringOrThrow(params.icon_key, 'icon key')
+  const colorKey = optionalStringOrThrow(params.color_key, 'color key')
+
+  // `enabled` is accepted (design.md §4 create object) but ProfileService.create always starts a
+  // new specialist enabled; the update op toggles it. We validate the shape and ignore the value so
+  // a malformed boolean is rejected before reaching the repository.
+  if (params.enabled !== undefined && !isBoolean(params.enabled)) {
+    throw new Error('enabled must be a boolean.')
+  }
+
+  if (params.unrestricted !== undefined && !isBoolean(params.unrestricted)) {
+    throw new Error('unrestricted must be a boolean.')
+  }
+  // `unrestricted` is validated for shape but does not change create semantics here: the presence of
+  // a capability array always produces Selected, and the absence of both always produces Full (AC).
+  // The field is accepted so the agreed create object is honored; its value only affects update.
+
+  const skillRefs = asStringArray(params.skill_names)
+  const connectorRefs = asStringArray(params.connector_names)
+  const hasCapabilities = skillRefs !== undefined || connectorRefs !== undefined
+
+  const input: CreateSpecialistInput = {
+    name,
+    description,
+    systemPrompt,
+    iconKey,
+    colorKey
+  }
+
+  if (hasCapabilities) {
+    // Either capability array present -> Selected; omitted other array stored empty (AC).
+    input.capabilityMode = 'selected'
+    const skillIds = skillRefs ? await resolveSkillRefs(deps.catalog, skillRefs, 'create') : []
+    const connectorIds = connectorRefs
+      ? (
+          await resolveConnectorRefs(deps.catalog, connectorRefs, 'create', {
+            gateUnavailable: true
+          })
+        ).ids
+      : []
+    input.selectedCapabilities = {
+      skillIds,
+      connectorIds,
+      connectorTools: []
+    }
+    input.fullAccess = emptyFullAccessConfig()
+  } else {
+    // Neither capability array present -> Full access (AC). `unrestricted: true` is an explicit
+    // confirmation of the same default; either way the mode is Full and both configs start empty.
+    input.capabilityMode = 'full'
+    input.fullAccess = emptyFullAccessConfig()
+    input.selectedCapabilities = emptySelectedConfig()
+  }
+
+  return deps.profileService.create(input)
+}
+
+// ---------------------------------------------------------------------------
+// update
+// ---------------------------------------------------------------------------
+
+// The set of update-patch keys the public SDK accepts. Exported so the privileged name-changing
+// update path (agents-service.runPrivilegedUpdate) reuses the EXACT allowed-keys view the ordinary
+// path uses — including the capability keys — so an unknown field is rejected identically on both
+// paths instead of being silently dropped on the privileged one (defect #5).
+export const UPDATE_ALLOWED_KEYS = new Set([
+  'name',
+  'revision',
+  'description',
+  'system_prompt',
+  'icon_key',
+  'color_key',
+  'enabled',
+  'unrestricted',
+  'skill_names',
+  'connector_names'
+])
+
+const handleUpdate = async (
+  params: Record<string, unknown>,
+  deps: AgentsMutationDeps
+): Promise<SpecialistProfileView> => {
+  const name = isString(params.name) ? params.name : throwShape('name is required')
+
+  // The patch is a NESTED object so a rename (patch.name) never collides with the lookup name
+  // (params.name) on the wire — design.md §4 / customize-skill.md: `update(name, patch)` where the
+  // patch may carry a new `name`. params.name resolves the target; every field in `patch` is a change.
+  const patch = params.patch
+  if (!isRecord(patch)) throw new Error('patch is required and must be an object.')
+  rejectUnknownKeys(patch, UPDATE_ALLOWED_KEYS, 'update')
+
+  // A name change is a PRIVILEGED operation (issue 04): the whole patch is shown in one approval
+  // card and committed atomically. The ordinary path never changes identity — reject a rename here so
+  // it can never silently succeed without approval. The dispatcher (issue 08) routes name-changing
+  // updates to the privileged module before this ordinary path runs.
+  if (isString(patch.name) && patch.name.trim().length > 0) {
+    throw new Error('Changing the specialist name requires approval.')
+  }
+
+  const revision = patch.revision
+  if (!isFinitePositiveInt(revision)) {
+    throw new Error('revision must be a positive integer.')
+  }
+
+  const current = await deps.profileService.getByName(name)
+  if (current.revision !== revision) {
+    throw new Error('revision does not match the current specialist revision.')
+  }
+
+  const input: {
+    id: string
+    revision: number
+    description?: string
+    systemPrompt?: string
+    iconKey?: string
+    colorKey?: string
+    capabilityMode?: SpecialistCapabilityMode
+    fullAccess?: SpecialistFullAccessConfig
+    selectedCapabilities?: SpecialistSelectedConfig
+  } = { id: current.id, revision }
+
+  const description = optionalStringOrThrow(patch.description, 'description')
+  if (description !== undefined) input.description = description
+  const systemPrompt = optionalStringOrThrow(patch.system_prompt, 'system prompt')
+  if (systemPrompt !== undefined) input.systemPrompt = systemPrompt
+  const iconKey = optionalStringOrThrow(patch.icon_key, 'icon key')
+  if (iconKey !== undefined) input.iconKey = iconKey
+  const colorKey = optionalStringOrThrow(patch.color_key, 'color key')
+  if (colorKey !== undefined) input.colorKey = colorKey
+
+  if (patch.enabled !== undefined && !isBoolean(patch.enabled)) {
+    throw new Error('enabled must be a boolean.')
+  }
+
+  // Capability projection is shared with the privileged name-changing update path so the two NEVER
+  // diverge on the Selected/Full + collection-replacement semantics.
+  const capability = await projectCapabilityFields(patch, current, deps.catalog, 'update')
+  if (capability.capabilityMode !== undefined) {
+    input.capabilityMode = capability.capabilityMode
+  }
+  if (capability.selectedCapabilities !== undefined) {
+    input.selectedCapabilities = capability.selectedCapabilities
+  }
+  if (capability.fullAccess !== undefined) {
+    input.fullAccess = capability.fullAccess
+  }
+
+  // enabled lives on a separate ProfileService method (update() does not carry it). When the
+  // requested state differs from the current, we toggle AFTER the identity/capability update so the
+  // optimistic-concurrency check (revision) gates the whole mutation first, then setEnabled flips the
+  // enabled flag. setEnabled is not revision-guarded, so ordering update-first is safe.
+  let readBack = await deps.profileService.update(input)
+  if (patch.enabled !== undefined && patch.enabled !== readBack.enabled) {
+    readBack = await deps.profileService.setEnabled(current.id, patch.enabled)
+  }
+  return readBack
+}
+
+// ---------------------------------------------------------------------------
+// attach / detach
+// ---------------------------------------------------------------------------
+
+type AttachDetachOp = 'attach_skill' | 'detach_skill' | 'attach_connector' | 'detach_connector'
+
+const ATTACH_DETACH_ALLOWED_KEYS = new Set(['name', 'revision', 'skill_ref', 'connector_ref'])
+
+const handleAttachDetach = async (
+  op: AttachDetachOp,
+  params: Record<string, unknown>,
+  deps: AgentsMutationDeps
+): Promise<SpecialistProfileView> => {
+  rejectUnknownKeys(params, ATTACH_DETACH_ALLOWED_KEYS, op)
+
+  const name = isString(params.name) ? params.name : throwShape('name is required')
+  const revision = params.revision
+  if (!isFinitePositiveInt(revision)) {
+    throw new Error('revision must be a positive integer.')
+  }
+
+  const refKey = op.endsWith('skill') ? 'skill_ref' : 'connector_ref'
+  const ref = isString(params[refKey])
+    ? (params[refKey] as string)
+    : throwShape(`${refKey} is required`)
+
+  const current = await deps.profileService.getByName(name)
+  if (current.revision !== revision) {
+    throw new Error('revision does not match the current specialist revision.')
+  }
+  const mode: SpecialistCapabilityMode = current.capabilityMode
+
+  // attach resolves the reference to a stable id (and gates unavailable custom connectors). detach is
+  // a removal, so an existing STALE reference that no longer appears in the catalog must still be
+  // removable (design.md §5: "existing stale references remain readable and removable"). We try to
+  // resolve first (so a public name still works), but on detach we fall back to the literal reference
+  // as the stable id when nothing matches.
+  let stableId: string
+  if (op.endsWith('skill')) {
+    stableId =
+      op === 'attach_skill'
+        ? (await resolveSkillRefs(deps.catalog, [ref], op))[0]
+        : await resolveOrPassThrough(await deps.catalog.listSkills(), ref, op)
+  } else {
+    const gateUnavailable = op === 'attach_connector'
+    stableId =
+      op === 'attach_connector'
+        ? (await resolveConnectorRefs(deps.catalog, [ref], op, { gateUnavailable })).ids[0]
+        : await resolveOrPassThrough(await deps.catalog.listConnectors(), ref, op)
+  }
+
+  if (op === 'attach_skill')
+    return deps.profileService.attachSkill(current.id, stableId, revision, mode)
+  if (op === 'detach_skill')
+    return deps.profileService.detachSkill(current.id, stableId, revision, mode)
+  if (op === 'attach_connector') {
+    return deps.profileService.attachConnector(current.id, stableId, revision, mode)
+  }
+  return deps.profileService.detachConnector(current.id, stableId, revision, mode)
+}
+
+// Resolves a reference to a stable id when it matches the catalog, otherwise returns the literal
+// reference unchanged. Used by detach so a stale reference (no longer in the catalog) can still be
+// removed. attach never uses this — it must reject unknown references.
+const resolveOrPassThrough = async <T extends SkillCatalogReadModel | ConnectorReadModel>(
+  entries: T[],
+  ref: string,
+  method: string
+): Promise<string> => {
+  try {
+    const matched = applyNameOrIdFilter(entries, ref, method)
+    if (matched.length > 0) return matched[0].id
+  } catch {
+    // Ambiguity on a detach is harmless: fall back to the literal reference.
+  }
+  return ref
+}
+
+// ---------------------------------------------------------------------------
+// Helpers
+// ---------------------------------------------------------------------------
+
+// Exported so the privileged name-changing update path reuses the EXACT unknown-key rejection the
+// ordinary path uses (defect #5). Throws a sanitized `Unknown field "<key>".` error.
+export function rejectUnknownKeys(
+  params: Record<string, unknown>,
+  allowed: Set<string>,
+  method: string
+): void {
+  for (const key of Object.keys(params)) {
+    if (!allowed.has(key)) {
+      throw new Error(`Unknown field "${key}".`)
+    }
+  }
+  void method
+}
+
+function throwShape(message: string): never {
+  throw new Error(message)
+}
+
+// ---------------------------------------------------------------------------
+// Public entry point
+// ---------------------------------------------------------------------------
+
+// Executes one ordinary-mutation request and returns a real post-write Profile read-back. Wraps any
+// thrown error in a sanitized `host.agents.<method>:` error. This is the seam issue 08 composes into
+// the shared dispatcher.
+export async function executeAgentsMutation(
+  request: AgentsOrdinaryMutationRequest,
+  deps: AgentsMutationDeps
+): Promise<SpecialistProfileView> {
+  const method = request.op
+  const params = request.params
+  try {
+    switch (method) {
+      case 'create':
+        return await handleCreate(params, deps)
+      case 'update':
+        return await handleUpdate(params, deps)
+      case 'attach_skill':
+      case 'detach_skill':
+      case 'attach_connector':
+      case 'detach_connector':
+        return await handleAttachDetach(method, params, deps)
+      default:
+        // Exhaustiveness guard: the switch covers every ordinary-mutation op.
+        throw new Error(`Operation "${String(method)}" is not an ordinary mutation.`)
+    }
+  } catch (error) {
+    throw new AgentsMutationError(method, error)
+  }
+}

--- a/src/main/agents/agents-repl.integration.test.ts
+++ b/src/main/agents/agents-repl.integration.test.ts
@@ -1,0 +1,364 @@
+import { afterAll, beforeAll, describe, expect, it } from 'vitest'
+import { spawn, type ChildProcessWithoutNullStreams } from 'node:child_process'
+import { mkdtemp, rm } from 'node:fs/promises'
+import { createInterface } from 'node:readline'
+import { join } from 'node:path'
+import { tmpdir } from 'node:os'
+import { randomUUID } from 'node:crypto'
+
+import { NotebookLocalRpcServer } from '../notebook/local-rpc-server'
+import { NotebookRuntimeService } from '../notebook/runtime-service'
+import { NotebookRunRepository } from '../notebook/repository'
+import {
+  framePythonRequest,
+  parseLoopResponse,
+  type KernelLoopResponse
+} from '../notebook/kernel-protocol'
+import { AgentsService, type AgentsCatalogSource, type AgentsReadOp } from './agents-service'
+import { createProfileService } from '../specialist/service'
+import type { StoredConnectors } from '../settings/types'
+
+// Run with: RUN_KERNEL=1 npx vitest run src/main/agents/agents-repl.integration.test.ts
+// Exercises the real resources/notebook/repl_loop.js against a real NotebookLocalRpcServer wired
+// to a real AgentsService + ProfileService, covering the full host.agents tracer bullet.
+const gate = process.env.RUN_KERNEL ? describe : describe.skip
+
+const LOOP = join(__dirname, '../../../resources/notebook/repl_loop.js')
+
+const startLoop = (
+  env: NodeJS.ProcessEnv
+): {
+  child: ChildProcessWithoutNullStreams
+  send: (code: string) => Promise<KernelLoopResponse>
+} => {
+  const child = spawn(process.execPath, [LOOP], {
+    env: { ...process.env, ELECTRON_RUN_AS_NODE: '1', ...env }
+  })
+  const rl = createInterface({ input: child.stdout })
+  const waiters = new Map<string, (v: KernelLoopResponse) => void>()
+  rl.on('line', (line) => {
+    const msg = parseLoopResponse(line)
+    if (!msg) return
+    const w = waiters.get(msg.reqId)
+    if (w) {
+      waiters.delete(msg.reqId)
+      w(msg)
+    }
+  })
+  const send = (code: string): Promise<KernelLoopResponse> =>
+    new Promise((resolve) => {
+      const reqId = randomUUID()
+      waiters.set(reqId, resolve)
+      child.stdin.write(framePythonRequest(reqId, code))
+    })
+  return { child, send }
+}
+
+// A catalog stub that returns a deterministic, secret-free catalog so the integration test does not
+// depend on the filesystem-backed skill registry. It deliberately includes a Main-disabled skill to
+// prove the Specialist-visible catalog is complete.
+const stubCatalog: AgentsCatalogSource = {
+  listSkillCatalog: async () => [
+    {
+      id: 'demo',
+      frameworkName: 'demo',
+      displayName: 'demo',
+      source: 'featured',
+      mainEnabled: true,
+      available: true
+    },
+    {
+      id: 'personal-foo',
+      frameworkName: 'foo',
+      displayName: 'foo',
+      source: 'personal',
+      mainEnabled: false,
+      available: true
+    },
+    {
+      id: 'dup-a',
+      frameworkName: 'dup',
+      displayName: 'dup',
+      source: 'featured',
+      mainEnabled: true,
+      available: true
+    },
+    {
+      id: 'dup-b',
+      frameworkName: 'dup',
+      displayName: 'dup',
+      source: 'featured',
+      mainEnabled: true,
+      available: true
+    }
+  ],
+  getConnectors: async (): Promise<StoredConnectors | undefined> => ({
+    enabledIds: [],
+    autoAllowIds: [],
+    disabledConnectorIds: ['chemistry'],
+    customMcpServers: [
+      { id: 'cust-1', name: 'My Server', transport: 'stdio', enabled: true, command: 'run' }
+    ]
+  })
+}
+
+gate('host.agents repl integration', () => {
+  let rpcServer: NotebookLocalRpcServer
+  let endpoint: string
+  let token: string
+  let profileStorage: string
+  let runtimeStorage: string
+  let agentsService: AgentsService
+  let capturedSessionId: string | undefined
+
+  beforeAll(async () => {
+    profileStorage = await mkdtemp(join(tmpdir(), 'os-agents-profile-'))
+    runtimeStorage = await mkdtemp(join(tmpdir(), 'os-agents-runtime-'))
+    const profileService = createProfileService(profileStorage)
+    agentsService = new AgentsService({ profileService, catalog: stubCatalog })
+    const notebookService = new NotebookRuntimeService({
+      configRoot: runtimeStorage,
+      dataRoot: runtimeStorage,
+      projectName: 'default-project',
+      repository: new NotebookRunRepository(runtimeStorage),
+      executorFactory: () => ({
+        execute: async () => ({
+          status: 'completed',
+          stdout: '',
+          stderr: '',
+          traceback: '',
+          cwdAfter: runtimeStorage,
+          outputs: [],
+          workingFiles: []
+        }),
+        shutdown: async () => ({ reaped: true })
+      })
+    })
+    rpcServer = new NotebookLocalRpcServer(notebookService, {
+      token: 'integration-token',
+      agentsService: {
+        read: async (op, context) => {
+          // Capture the trusted calling-session identity the server forwarded.
+          capturedSessionId = context.sessionId
+          return agentsService.read(op as AgentsReadOp)
+        }
+      }
+    })
+    const connection = await rpcServer.ensureStarted()
+    endpoint = connection.endpoint
+    token = connection.token
+
+    // Seed a specialist profile directly through the authoritative ProfileService.
+    await profileService.create({ name: 'Bio Expert', description: 'secret: apikey=XYZ' })
+  })
+
+  afterAll(async () => {
+    await rpcServer?.close()
+    await rm(profileStorage, { recursive: true, force: true })
+    await rm(runtimeStorage, { recursive: true, force: true })
+  })
+
+  it('host.agents.list() returns custom profiles via the real REPL + RPC server', async () => {
+    const { child, send } = startLoop({
+      OPEN_SCIENCE_MCP_RPC_ENDPOINT: endpoint,
+      OPEN_SCIENCE_MCP_RPC_TOKEN: token,
+      OPEN_SCIENCE_NOTEBOOK_SESSION_ID: 'session-42'
+    })
+    try {
+      const r = await send('return JSON.stringify(await host.agents.list())')
+      expect(r.error).toBeNull()
+      const list = JSON.parse(r.result ?? '[]')
+      expect(list).toHaveLength(1)
+      expect(list[0].name).toBe('Bio Expert')
+      expect(list[0].revision).toBe(1)
+      // No synthesized Settings-only Reviewer row.
+      expect(list.some((item: { id: string }) => item.id === 'reviewer')).toBe(false)
+    } finally {
+      child.kill()
+    }
+  }, 60_000)
+
+  it('host.agents.get(name) returns id + revision', async () => {
+    const { child, send } = startLoop({
+      OPEN_SCIENCE_MCP_RPC_ENDPOINT: endpoint,
+      OPEN_SCIENCE_MCP_RPC_TOKEN: token,
+      OPEN_SCIENCE_NOTEBOOK_SESSION_ID: 'session-42'
+    })
+    try {
+      const r = await send("return JSON.stringify(await host.agents.get('Bio Expert'))")
+      expect(r.error).toBeNull()
+      const got = JSON.parse(r.result ?? '{}')
+      expect(got.name).toBe('Bio Expert')
+      expect(got.revision).toBe(1)
+      expect(typeof got.id).toBe('string')
+    } finally {
+      child.kill()
+    }
+  }, 60_000)
+
+  it('host.agents.list_skills() returns the full catalog including Main-disabled skills', async () => {
+    const { child, send } = startLoop({
+      OPEN_SCIENCE_MCP_RPC_ENDPOINT: endpoint,
+      OPEN_SCIENCE_MCP_RPC_TOKEN: token
+    })
+    try {
+      const r = await send('return JSON.stringify(await host.agents.list_skills())')
+      expect(r.error).toBeNull()
+      const skills = JSON.parse(r.result ?? '[]')
+      expect(skills.find((s: { id: string }) => s.id === 'personal-foo').mainEnabled).toBe(false)
+      expect(skills.find((s: { id: string }) => s.id === 'demo').mainEnabled).toBe(true)
+    } finally {
+      child.kill()
+    }
+  }, 60_000)
+
+  it('host.agents.list_skills() filters by exact stable id', async () => {
+    const { child, send } = startLoop({
+      OPEN_SCIENCE_MCP_RPC_ENDPOINT: endpoint,
+      OPEN_SCIENCE_MCP_RPC_TOKEN: token
+    })
+    try {
+      const r = await send("return JSON.stringify(await host.agents.list_skills('personal-foo'))")
+      expect(r.error).toBeNull()
+      const skills = JSON.parse(r.result ?? '[]')
+      expect(skills).toHaveLength(1)
+      expect(skills[0].id).toBe('personal-foo')
+    } finally {
+      child.kill()
+    }
+  }, 60_000)
+
+  it('host.agents.list_skills() rejects an ambiguous public name with a stable-id hint', async () => {
+    const { child, send } = startLoop({
+      OPEN_SCIENCE_MCP_RPC_ENDPOINT: endpoint,
+      OPEN_SCIENCE_MCP_RPC_TOKEN: token
+    })
+    try {
+      const r = await send(
+        "try { await host.agents.list_skills('dup'); return 'no-throw' } catch (e) { return e.message }"
+      )
+      expect(r.result).toMatch(/stable id/)
+    } finally {
+      child.kill()
+    }
+  }, 60_000)
+
+  it('host.agents.list_connectors() projects connectors without secrets', async () => {
+    const { child, send } = startLoop({
+      OPEN_SCIENCE_MCP_RPC_ENDPOINT: endpoint,
+      OPEN_SCIENCE_MCP_RPC_TOKEN: token
+    })
+    try {
+      const r = await send('return JSON.stringify(await host.agents.list_connectors())')
+      expect(r.error).toBeNull()
+      const text = r.result ?? ''
+      // No secret material leaks.
+      expect(text).not.toMatch(/apikey|headerRefs|envRefs|command/)
+      const connectors = JSON.parse(text)
+      const chemistry = connectors.find((c: { id: string }) => c.id === 'chemistry')
+      expect(chemistry.mainEnabled).toBe(false)
+      expect(chemistry.tools.length).toBeGreaterThan(0)
+    } finally {
+      child.kill()
+    }
+  }, 60_000)
+
+  it('authentication failure: a bad token is rejected at the RPC boundary', async () => {
+    const { child, send } = startLoop({
+      OPEN_SCIENCE_MCP_RPC_ENDPOINT: endpoint,
+      OPEN_SCIENCE_MCP_RPC_TOKEN: 'wrong-token'
+    })
+    try {
+      const r = await send(
+        "try { await host.agents.list(); return 'ok' } catch (e) { return e.message }"
+      )
+      expect(r.result).toMatch(/host\.agents\.list:/)
+    } finally {
+      child.kill()
+    }
+  }, 60_000)
+
+  it('token isolation: sandbox code cannot read the RPC token from process.env', async () => {
+    const { child, send } = startLoop({
+      OPEN_SCIENCE_MCP_RPC_ENDPOINT: endpoint,
+      OPEN_SCIENCE_MCP_RPC_TOKEN: 'secret-token-value'
+    })
+    try {
+      const r = await send('return JSON.stringify(process.env.OPEN_SCIENCE_MCP_RPC_TOKEN ?? null)')
+      expect(r.error).toBeNull()
+      expect(JSON.parse(r.result ?? '""')).toBeNull()
+    } finally {
+      child.kill()
+    }
+  }, 60_000)
+
+  it('trusted session capture: the server receives the captured calling session identity', async () => {
+    capturedSessionId = undefined
+    const { child, send } = startLoop({
+      OPEN_SCIENCE_MCP_RPC_ENDPOINT: endpoint,
+      OPEN_SCIENCE_MCP_RPC_TOKEN: token,
+      OPEN_SCIENCE_NOTEBOOK_SESSION_ID: 'session-trusted'
+    })
+    try {
+      const r = await send('return JSON.stringify(await host.agents.list())')
+      expect(r.error).toBeNull()
+      expect(capturedSessionId).toBe('session-trusted')
+    } finally {
+      child.kill()
+    }
+  }, 60_000)
+
+  it('sandbox code cannot forge a different calling session via a request param', async () => {
+    capturedSessionId = undefined
+    const { child, send } = startLoop({
+      OPEN_SCIENCE_MCP_RPC_ENDPOINT: endpoint,
+      OPEN_SCIENCE_MCP_RPC_TOKEN: token,
+      OPEN_SCIENCE_NOTEBOOK_SESSION_ID: 'session-real'
+    })
+    try {
+      // Try to smuggle a forged session id directly through fetch (simulating malicious sandbox code).
+      const r = await send(
+        "await fetch(process.env.__rpc ?? '', { method: 'POST', headers: { 'content-type': 'application/json', authorization: 'Bearer ' + 'forged' }, body: JSON.stringify({ method: 'agentsCall', params: { op: 'list', session_id: 'forged-session' } }) }).then(r => r.status).catch(() => 'err'); return 'done'"
+      )
+      void r
+      // Even via a legitimate call, the trusted identity is the captured one.
+      const r2 = await send('return JSON.stringify(await host.agents.list())')
+      expect(r2.error).toBeNull()
+      expect(capturedSessionId).toBe('session-real')
+    } finally {
+      child.kill()
+    }
+  }, 60_000)
+
+  it('sanitized errors: invalid params surface as host.agents.<method>: errors', async () => {
+    const { child, send } = startLoop({
+      OPEN_SCIENCE_MCP_RPC_ENDPOINT: endpoint,
+      OPEN_SCIENCE_MCP_RPC_TOKEN: token
+    })
+    try {
+      const r = await send(
+        "try { await host.agents.get('Does Not Exist'); return 'ok' } catch (e) { return e.message }"
+      )
+      expect(r.result).toMatch(/host\.agents\.get:/)
+      // The error must not leak any internal secret string from another profile.
+      expect(r.result).not.toMatch(/apikey/)
+    } finally {
+      child.kill()
+    }
+  }, 60_000)
+
+  it('host.agents is absent from python data kernels (no host global there)', async () => {
+    // The control-plane SDK is injected only in repl_loop.js. python_loop.py / r_loop.R do not
+    // expose a host global at all. This test documents that contract: the repl script is the sole
+    // host of host.agents, and a real python/r data kernel never receives it. We assert by checking
+    // the python loop source has no host.agents injection.
+    const { readFileSync } = await import('node:fs')
+    const pythonLoop = readFileSync(
+      join(__dirname, '../../../resources/notebook/python_loop.py'),
+      'utf8'
+    )
+    expect(pythonLoop).not.toMatch(/host\.agents|agentsCall/)
+    const rLoop = readFileSync(join(__dirname, '../../../resources/notebook/r_loop.R'), 'utf8')
+    expect(rLoop).not.toMatch(/host\.agents|agentsCall/)
+  })
+})

--- a/src/main/agents/agents-repl.mutations.integration.test.ts
+++ b/src/main/agents/agents-repl.mutations.integration.test.ts
@@ -1,0 +1,388 @@
+import { afterAll, beforeAll, describe, expect, it } from 'vitest'
+import { spawn, type ChildProcessWithoutNullStreams } from 'node:child_process'
+import { mkdtemp, rm } from 'node:fs/promises'
+import { createInterface } from 'node:readline'
+import { join } from 'node:path'
+import { tmpdir } from 'node:os'
+import { randomUUID } from 'node:crypto'
+
+import { NotebookLocalRpcServer } from '../notebook/local-rpc-server'
+import { NotebookRuntimeService } from '../notebook/runtime-service'
+import { NotebookRunRepository } from '../notebook/repository'
+import {
+  framePythonRequest,
+  parseLoopResponse,
+  type KernelLoopResponse
+} from '../notebook/kernel-protocol'
+import { AgentsService, type AgentsCatalogSource } from './agents-service'
+import { createProfileService } from '../specialist/service'
+import type { StoredConnectors } from '../settings/types'
+
+// Run with: RUN_KERNEL=1 npx vitest run src/main/agents/agents-repl.mutations.integration.test.ts
+// Exercises the real resources/notebook/repl_loop.js against a real NotebookLocalRpcServer wired
+// to a real AgentsService + ProfileService, covering the host.agents ordinary-mutation slice:
+// create, representative exact update, representative attach/detach, stale revision, stable catalog
+// resolution, read-back, and the absence of additional permission requests on ordinary mutations.
+const gate = process.env.RUN_KERNEL ? describe : describe.skip
+
+const LOOP = join(__dirname, '../../../resources/notebook/repl_loop.js')
+
+const startLoop = (
+  env: NodeJS.ProcessEnv
+): {
+  child: ChildProcessWithoutNullStreams
+  send: (code: string) => Promise<KernelLoopResponse>
+} => {
+  const child = spawn(process.execPath, [LOOP], {
+    env: { ...process.env, ELECTRON_RUN_AS_NODE: '1', ...env }
+  })
+  const rl = createInterface({ input: child.stdout })
+  const waiters = new Map<string, (v: KernelLoopResponse) => void>()
+  rl.on('line', (line) => {
+    const msg = parseLoopResponse(line)
+    if (!msg) return
+    const w = waiters.get(msg.reqId)
+    if (w) {
+      waiters.delete(msg.reqId)
+      w(msg)
+    }
+  })
+  const send = (code: string): Promise<KernelLoopResponse> =>
+    new Promise((resolve) => {
+      const reqId = randomUUID()
+      waiters.set(reqId, resolve)
+      child.stdin.write(framePythonRequest(reqId, code))
+    })
+  return { child, send }
+}
+
+// A catalog stub that returns a deterministic, secret-free catalog. Includes a Main-disabled skill
+// (personal-foo) and a custom connector (cust-1, runnable) plus an unreachable custom connector
+// (cust-dead) to exercise the availability gate.
+const stubCatalog: AgentsCatalogSource = {
+  listSkillCatalog: async () => [
+    {
+      id: 'demo',
+      frameworkName: 'demo',
+      displayName: 'demo',
+      source: 'featured',
+      mainEnabled: true,
+      available: true
+    },
+    {
+      id: 'personal-foo',
+      frameworkName: 'foo',
+      displayName: 'foo',
+      source: 'personal',
+      mainEnabled: false,
+      available: true
+    }
+  ],
+  getConnectors: async (): Promise<StoredConnectors | undefined> => ({
+    enabledIds: [],
+    autoAllowIds: [],
+    disabledConnectorIds: [],
+    customMcpServers: [
+      { id: 'cust-1', name: 'My Server', transport: 'stdio', enabled: true, command: 'run' },
+      { id: 'cust-dead', name: 'Dead Server', transport: 'stdio', enabled: true }
+    ]
+  })
+}
+
+gate('host.agents repl mutation integration', () => {
+  let rpcServer: NotebookLocalRpcServer
+  let endpoint: string
+  let token: string
+  let profileStorage: string
+  let runtimeStorage: string
+
+  beforeAll(async () => {
+    profileStorage = await mkdtemp(join(tmpdir(), 'os-agents-mut-profile-'))
+    runtimeStorage = await mkdtemp(join(tmpdir(), 'os-agents-mut-runtime-'))
+    const profileService = createProfileService(profileStorage)
+    const agentsService = new AgentsService({ profileService, catalog: stubCatalog })
+    const notebookService = new NotebookRuntimeService({
+      configRoot: runtimeStorage,
+      dataRoot: runtimeStorage,
+      projectName: 'default-project',
+      repository: new NotebookRunRepository(runtimeStorage),
+      executorFactory: () => ({
+        execute: async () => ({
+          status: 'completed',
+          stdout: '',
+          stderr: '',
+          traceback: '',
+          cwdAfter: runtimeStorage,
+          outputs: [],
+          workingFiles: []
+        }),
+        shutdown: async () => ({ reaped: true })
+      })
+    })
+    rpcServer = new NotebookLocalRpcServer(notebookService, {
+      token: 'integration-token',
+      agentsService
+    })
+    const connection = await rpcServer.ensureStarted()
+    endpoint = connection.endpoint
+    token = connection.token
+  })
+
+  afterAll(async () => {
+    await rpcServer?.close()
+    await rm(profileStorage, { recursive: true, force: true })
+    await rm(runtimeStorage, { recursive: true, force: true })
+  })
+
+  const env = (): NodeJS.ProcessEnv => ({
+    OPEN_SCIENCE_MCP_RPC_ENDPOINT: endpoint,
+    OPEN_SCIENCE_MCP_RPC_TOKEN: token
+  })
+
+  it('create() produces Full access with neither capability array and returns a real read-back', async () => {
+    const { child, send } = startLoop(env())
+    try {
+      const r = await send(
+        "return JSON.stringify(await host.agents.create({ name: 'FullBot', description: 'a full bot' }))"
+      )
+      expect(r.error).toBeNull()
+      const created = JSON.parse(r.result ?? '{}')
+      // read-back is a real view, not echoed input.
+      expect(created.name).toBe('FullBot')
+      expect(created.capabilityMode).toBe('full')
+      expect(created.revision).toBe(1)
+      expect(typeof created.id).toBe('string')
+    } finally {
+      child.kill()
+    }
+  }, 60_000)
+
+  it('create() with skill_names produces Selected and resolves a public name to a stable id', async () => {
+    const { child, send } = startLoop(env())
+    try {
+      const r = await send(
+        "return JSON.stringify(await host.agents.create({ name: 'SelBot', skill_names: ['foo'] }))"
+      )
+      expect(r.error).toBeNull()
+      const created = JSON.parse(r.result ?? '{}')
+      expect(created.capabilityMode).toBe('selected')
+      // The public name 'foo' resolved to the stable id 'personal-foo', not echoed.
+      expect(created.selectedCapabilities.skillIds).toEqual(['personal-foo'])
+    } finally {
+      child.kill()
+    }
+  }, 60_000)
+
+  it('create() resolves a connector by exact stable id', async () => {
+    const { child, send } = startLoop(env())
+    try {
+      const r = await send(
+        "return JSON.stringify(await host.agents.create({ name: 'ConnBot', connector_names: ['cust-1'] }))"
+      )
+      expect(r.error).toBeNull()
+      const created = JSON.parse(r.result ?? '{}')
+      expect(created.capabilityMode).toBe('selected')
+      expect(created.selectedCapabilities.connectorIds).toEqual(['cust-1'])
+    } finally {
+      child.kill()
+    }
+  }, 60_000)
+
+  it('update() supports a representative exact update (description + skills) with read-back', async () => {
+    const { child, send } = startLoop(env())
+    try {
+      const created = JSON.parse(
+        (
+          await send(
+            "return JSON.stringify(await host.agents.create({ name: 'UpdBot', description: 'before' }))"
+          )
+        ).result ?? '{}'
+      )
+      const r = await send(
+        `return JSON.stringify(await host.agents.update('UpdBot', { revision: ${created.revision}, description: 'after', skill_names: ['demo'] }))`
+      )
+      expect(r.error).toBeNull()
+      const updated = JSON.parse(r.result ?? '{}')
+      // read-back reflects the actual post-write state, not the echoed request.
+      expect(updated.description).toBe('after')
+      expect(updated.capabilityMode).toBe('selected')
+      expect(updated.selectedCapabilities.skillIds).toEqual(['demo'])
+      expect(updated.revision).toBe(created.revision + 1)
+    } finally {
+      child.kill()
+    }
+  }, 60_000)
+
+  it('update({ unrestricted: true }) switches to Full without destroying the stored Selected config', async () => {
+    const { child, send } = startLoop(env())
+    try {
+      const created = JSON.parse(
+        (
+          await send(
+            "return JSON.stringify(await host.agents.create({ name: 'SwitchBot', skill_names: ['demo'] }))"
+          )
+        ).result ?? '{}'
+      )
+      const r = await send(
+        `return JSON.stringify(await host.agents.update('SwitchBot', { revision: ${created.revision}, unrestricted: true }))`
+      )
+      expect(r.error).toBeNull()
+      const updated = JSON.parse(r.result ?? '{}')
+      expect(updated.capabilityMode).toBe('full')
+      // Stored Selected config preserved.
+      expect(updated.selectedCapabilities.skillIds).toEqual(['demo'])
+    } finally {
+      child.kill()
+    }
+  }, 60_000)
+
+  it('attach_skill / detach_skill mutate the current mode without switching it', async () => {
+    const { child, send } = startLoop(env())
+    try {
+      const created = JSON.parse(
+        (
+          await send(
+            "return JSON.stringify(await host.agents.create({ name: 'AttachBot', skill_names: [] }))"
+          )
+        ).result ?? '{}'
+      )
+      // Selected attach adds an inclusion.
+      const attached = JSON.parse(
+        (
+          await send(
+            `return JSON.stringify(await host.agents.attach_skill('AttachBot', 'demo', { revision: ${created.revision} }))`
+          )
+        ).result ?? '{}'
+      )
+      expect(attached.capabilityMode).toBe('selected')
+      expect(attached.selectedCapabilities.skillIds).toEqual(['demo'])
+      // detach removes it.
+      const detached = JSON.parse(
+        (
+          await send(
+            `return JSON.stringify(await host.agents.detach_skill('AttachBot', 'demo', { revision: ${attached.revision} }))`
+          )
+        ).result ?? '{}'
+      )
+      expect(detached.capabilityMode).toBe('selected')
+      expect(detached.selectedCapabilities.skillIds).toEqual([])
+    } finally {
+      child.kill()
+    }
+  }, 60_000)
+
+  it('attach_connector / detach_connector follow the same mode rules', async () => {
+    const { child, send } = startLoop(env())
+    try {
+      const created = JSON.parse(
+        (
+          await send(
+            "return JSON.stringify(await host.agents.create({ name: 'ConnAttachBot', connector_names: [] }))"
+          )
+        ).result ?? '{}'
+      )
+      const attached = JSON.parse(
+        (
+          await send(
+            `return JSON.stringify(await host.agents.attach_connector('ConnAttachBot', 'cust-1', { revision: ${created.revision} }))`
+          )
+        ).result ?? '{}'
+      )
+      expect(attached.selectedCapabilities.connectorIds).toEqual(['cust-1'])
+      const detached = JSON.parse(
+        (
+          await send(
+            `return JSON.stringify(await host.agents.detach_connector('ConnAttachBot', 'cust-1', { revision: ${attached.revision} }))`
+          )
+        ).result ?? '{}'
+      )
+      expect(detached.selectedCapabilities.connectorIds).toEqual([])
+    } finally {
+      child.kill()
+    }
+  }, 60_000)
+
+  it('a stale revision fails without merge or retry', async () => {
+    const { child, send } = startLoop(env())
+    try {
+      await send("return JSON.stringify(await host.agents.create({ name: 'StaleBot' }))")
+      const r = await send(
+        "try { await host.agents.update('StaleBot', { revision: 999, description: 'x' }); return 'no-throw' } catch (e) { return e.message }"
+      )
+      expect(r.result).toMatch(/host\.agents\.update:/)
+    } finally {
+      child.kill()
+    }
+  }, 60_000)
+
+  it('stable catalog resolution: an ambiguous name is rejected with a stable-id hint', async () => {
+    const { child, send } = startLoop(env())
+    try {
+      const r = await send(
+        "try { await host.agents.create({ name: 'AmbigBot', skill_names: ['nope'] }); return 'no-throw' } catch (e) { return e.message }"
+      )
+      expect(r.result).toMatch(/host\.agents\.create:/)
+      expect(r.result).toMatch(/stable id|No skill matches/)
+    } finally {
+      child.kill()
+    }
+  }, 60_000)
+
+  it('an unavailable custom connector cannot be newly attached', async () => {
+    const { child, send } = startLoop(env())
+    try {
+      const created = JSON.parse(
+        (
+          await send(
+            "return JSON.stringify(await host.agents.create({ name: 'GateBot', connector_names: [] }))"
+          )
+        ).result ?? '{}'
+      )
+      const r = await send(
+        `try { await host.agents.attach_connector('GateBot', 'cust-dead', { revision: ${created.revision} }); return 'no-throw' } catch (e) { return e.message }`
+      )
+      expect(r.result).toMatch(/host\.agents\.attach_connector:/)
+    } finally {
+      child.kill()
+    }
+  }, 60_000)
+
+  it('ordinary mutations never request a system permission card (no approval boundary)', async () => {
+    // Ordinary mutations are chat-reviewed only; the SDK path never reaches an approval gateway. We
+    // prove this by completing a create + update + attach round-trip with no approval wired — the
+    // calls succeed and return read-back, which would be impossible if an approval boundary gated
+    // them. (delete/switch are the privileged ops that require approval; they are out of scope here.)
+    const { child, send } = startLoop(env())
+    try {
+      // Create in Selected mode (skill_names: []) so attach_skill mutates inclusions; the point is
+      // that the whole round-trip completes with no approval gateway wired.
+      const created = JSON.parse(
+        (
+          await send(
+            "return JSON.stringify(await host.agents.create({ name: 'NoCardBot', description: 'd', skill_names: [] }))"
+          )
+        ).result ?? '{}'
+      )
+      expect(created.name).toBe('NoCardBot')
+      expect(created.capabilityMode).toBe('selected')
+      const updated = JSON.parse(
+        (
+          await send(
+            `return JSON.stringify(await host.agents.update('NoCardBot', { revision: ${created.revision}, description: 'e' }))`
+          )
+        ).result ?? '{}'
+      )
+      expect(updated.description).toBe('e')
+      const attached = JSON.parse(
+        (
+          await send(
+            `return JSON.stringify(await host.agents.attach_skill('NoCardBot', 'demo', { revision: ${updated.revision} }))`
+          )
+        ).result ?? '{}'
+      )
+      expect(attached.selectedCapabilities.skillIds).toEqual(['demo'])
+    } finally {
+      child.kill()
+    }
+  }, 60_000)
+})

--- a/src/main/agents/agents-repl.privileged.integration.test.ts
+++ b/src/main/agents/agents-repl.privileged.integration.test.ts
@@ -1,0 +1,725 @@
+import { afterAll, beforeAll, describe, expect, it, vi } from 'vitest'
+import { spawn, type ChildProcessWithoutNullStreams } from 'node:child_process'
+import { mkdtemp, rm } from 'node:fs/promises'
+import { createInterface } from 'node:readline'
+import { join } from 'node:path'
+import { tmpdir } from 'node:os'
+import { randomUUID } from 'node:crypto'
+
+import { NotebookLocalRpcServer } from '../notebook/local-rpc-server'
+import { NotebookRuntimeService } from '../notebook/runtime-service'
+import { NotebookRunRepository } from '../notebook/repository'
+import {
+  framePythonRequest,
+  parseLoopResponse,
+  type KernelLoopResponse
+} from '../notebook/kernel-protocol'
+import { AgentsService, type AgentsCatalogSource } from './agents-service'
+import { passthroughApprovalGateway } from './passthrough-approval-gateway'
+import { createProfileService } from '../specialist/service'
+import { SessionBindingService } from '../specialist/session-binding'
+import type { StoredConnectors } from '../settings/types'
+import type { ApprovalGateway, ApprovalResult } from '../../shared/agents-contract'
+
+// Run with: RUN_KERNEL=1 npx vitest run src/main/agents/agents-repl.privileged.integration.test.ts
+//
+// Proves the privileged Specialist-management slice end-to-end through the real
+// resources/notebook/repl_loop.js + NotebookLocalRpcServer, wired exactly the way production
+// (src/main/ipc.ts) composes it: a real ProfileService, the real SessionBindingService, the
+// milestone's passthroughApprovalGateway (always-approved), a durable persisted-binding sink, the
+// SwitchNotifier broadcast, and the catalog-invalidation callback.
+//
+// Coverage (design.md §15 / acceptance criteria 1, 4, 6):
+//  - a name-changing update (privileged) committed atomically through host.agents.update, returning
+//    real post-write read-back (not echoed input);
+//  - delete through the pass-through gateway: bound conversations are left unavailable (bindings are
+//    NOT silently cleared);
+//  - switch through the pass-through gateway: the trusted calling session is the only session that
+//    may be switched, the binding persists immediately (restart survival), and a pending-reconfigure
+//    notification is broadcast;
+//  - a structured DECLINE on a configurable approval gateway returns a non-error result for both
+//    delete and switch, with no mutation/persist/notify;
+//  - optimistic concurrency: a stale revision fails for both an ordinary update and a privileged
+//    (name-changing) update, without merge or retry.
+//
+// Notes on what this milestone ships vs. what is deferred:
+//  - The pass-through approval gateway always approves; it is the milestone substitution seam
+//    (design.md §14). The decline cases below use a separately-injected gateway that returns the
+//    structured decline shape, proving the dispatcher honors the gateway seam. The pass-through
+//    gateway itself never declines by design.
+//  - The public `host.agents` SDK exposes first-class `switch()`/`delete()` methods alongside
+//    `update` (which routes name-changing patches through the privileged module). Those SDK methods
+//    are exercised end-to-end below. The `agentsCall` fetch helper is retained for cases that must
+//    drive the transport BELOW the SDK surface — smuggling forged identity keys to prove the
+//    dispatcher strips reserved keys, and other transport-level assertions.
+//  - Trusted-session capture and forged-identity rejection for ordinary reads are covered end-to-end
+//    by agents-repl.integration.test.ts (regression); this suite focuses on the privileged slice.
+
+const gate = process.env.RUN_KERNEL ? describe : describe.skip
+
+const LOOP = join(__dirname, '../../../resources/notebook/repl_loop.js')
+
+const startLoop = (
+  env: NodeJS.ProcessEnv
+): {
+  child: ChildProcessWithoutNullStreams
+  send: (code: string) => Promise<KernelLoopResponse>
+} => {
+  const child = spawn(process.execPath, [LOOP], {
+    env: { ...process.env, ELECTRON_RUN_AS_NODE: '1', ...env }
+  })
+  const rl = createInterface({ input: child.stdout })
+  const waiters = new Map<string, (v: KernelLoopResponse) => void>()
+  rl.on('line', (line) => {
+    const msg = parseLoopResponse(line)
+    if (!msg) return
+    const w = waiters.get(msg.reqId)
+    if (w) {
+      waiters.delete(msg.reqId)
+      w(msg)
+    }
+  })
+  const send = (code: string): Promise<KernelLoopResponse> =>
+    new Promise((resolve) => {
+      const reqId = randomUUID()
+      waiters.set(reqId, resolve)
+      child.stdin.write(framePythonRequest(reqId, code))
+    })
+  return { child, send }
+}
+
+// Deterministic, secret-free catalog. Includes a custom runnable connector (cust-1) so connector
+// projections stay stable and secret-free across runs.
+const stubCatalog: AgentsCatalogSource = {
+  listSkillCatalog: async () => [
+    {
+      id: 'demo',
+      frameworkName: 'demo',
+      displayName: 'demo',
+      source: 'featured',
+      mainEnabled: true,
+      available: true
+    }
+  ],
+  getConnectors: async (): Promise<StoredConnectors | undefined> => ({
+    enabledIds: [],
+    autoAllowIds: [],
+    disabledConnectorIds: [],
+    customMcpServers: [
+      { id: 'cust-1', name: 'My Server', transport: 'stdio', enabled: true, command: 'run' }
+    ]
+  })
+}
+
+// Build an AgentsService wired exactly like production (src/main/ipc.ts): passthrough gateway for the
+// milestone, real SessionBindingService, a Map-backed durable persist sink (mirrors the persisted
+// session-file binding), a recorded notifier, and a recorded catalog invalidation. Optionally inject
+// a custom gateway (e.g. a decline gateway) to prove the seam. `invalidateCount` is a getter so the
+// counter is read live (not snapshotted at compose time).
+const composeService = (opts: {
+  profileStorage: string
+  gateway?: ApprovalGateway
+}): {
+  agentsService: AgentsService
+  sessionBinding: SessionBindingService
+  durableBindings: Map<string, string | undefined>
+  notified: Array<{ sessionId: string; targetName: string | null }>
+  invalidateCount: () => number
+} => {
+  const profileService = createProfileService(opts.profileStorage)
+  const sessionBinding = new SessionBindingService(profileService)
+  const durableBindings = new Map<string, string | undefined>()
+  const notified: Array<{ sessionId: string; targetName: string | null }> = []
+  let invalidated = 0
+  const agentsService = new AgentsService({
+    profileService,
+    catalog: stubCatalog,
+    sessionBinding,
+    approvalGateway: opts.gateway ?? passthroughApprovalGateway,
+    switchNotifier: {
+      notify: (pending) => {
+        notified.push({ sessionId: pending.sessionId, targetName: pending.targetName })
+      }
+    },
+    persistSessionSpecialist: async (sessionId, specialistId) => {
+      // Mirrors production: the durable writer persists the UUID so the binding survives restart.
+      if (specialistId === undefined) durableBindings.delete(sessionId)
+      else durableBindings.set(sessionId, specialistId)
+    },
+    invalidateCatalog: () => {
+      invalidated += 1
+    }
+  })
+  return {
+    agentsService,
+    sessionBinding,
+    durableBindings,
+    notified,
+    invalidateCount: () => invalidated
+  }
+}
+
+// One-line JS body that calls `agentsCall` over the same transport the SDK uses. The trusted calling
+// session (`sessionId`) is forwarded in `params.session_id`, exactly as the loop does for every
+// host.agents call (it is captured from the spawn env and forwarded on the wire).
+const agentsCallFetch = (
+  endpoint: string,
+  token: string,
+  sessionId: string,
+  params: Record<string, unknown>
+): string => {
+  const payload = JSON.stringify({
+    method: 'agentsCall',
+    params: { session_id: sessionId, ...params }
+  })
+  return `const res = await fetch(${JSON.stringify(endpoint)}, { method: 'POST', headers: { 'content-type': 'application/json', authorization: 'Bearer ' + ${JSON.stringify(token)} }, body: ${JSON.stringify(payload)} }); const body = await res.json(); return JSON.stringify({ ok: res.ok, body })`
+}
+
+gate('host.agents repl privileged integration', () => {
+  let rpcServer: NotebookLocalRpcServer
+  let endpoint: string
+  let token: string
+  let profileStorage: string
+  let runtimeStorage: string
+  let agentsService: AgentsService
+  let sessionBinding: SessionBindingService
+  let durableBindings: Map<string, string | undefined>
+  let notified: Array<{ sessionId: string; targetName: string | null }>
+  let invalidateCount: () => number
+
+  beforeAll(async () => {
+    profileStorage = await mkdtemp(join(tmpdir(), 'os-agents-priv-profile-'))
+    runtimeStorage = await mkdtemp(join(tmpdir(), 'os-agents-priv-runtime-'))
+    const composed = composeService({ profileStorage })
+    agentsService = composed.agentsService
+    sessionBinding = composed.sessionBinding
+    durableBindings = composed.durableBindings
+    notified = composed.notified
+    invalidateCount = composed.invalidateCount
+    void agentsService
+    const notebookService = new NotebookRuntimeService({
+      configRoot: runtimeStorage,
+      dataRoot: runtimeStorage,
+      projectName: 'default-project',
+      repository: new NotebookRunRepository(runtimeStorage),
+      executorFactory: () => ({
+        execute: async () => ({
+          status: 'completed',
+          stdout: '',
+          stderr: '',
+          traceback: '',
+          cwdAfter: runtimeStorage,
+          outputs: [],
+          workingFiles: []
+        }),
+        shutdown: async () => ({ reaped: true })
+      })
+    })
+    rpcServer = new NotebookLocalRpcServer(notebookService, {
+      token: 'integration-token',
+      agentsService
+    })
+    const connection = await rpcServer.ensureStarted()
+    endpoint = connection.endpoint
+    token = connection.token
+  })
+
+  afterAll(async () => {
+    await rpcServer?.close()
+    await rm(profileStorage, { recursive: true, force: true })
+    await rm(runtimeStorage, { recursive: true, force: true })
+  })
+
+  // Loop helper: an isolated loop per case (mirrors the read/ordinary-mutation suites) so captured
+  // trusted-session identity and in-memory binding state never bleed across assertions.
+  const withLoop = async <T>(
+    sessionId: string | undefined,
+    run: (send: (code: string) => Promise<KernelLoopResponse>) => Promise<T>
+  ): Promise<T> => {
+    const { child, send } = startLoop({
+      OPEN_SCIENCE_MCP_RPC_ENDPOINT: endpoint,
+      OPEN_SCIENCE_MCP_RPC_TOKEN: token,
+      ...(sessionId ? { OPEN_SCIENCE_NOTEBOOK_SESSION_ID: sessionId } : {})
+    })
+    try {
+      return await run(send)
+    } finally {
+      child.kill()
+    }
+  }
+
+  it('host.agents exposes first-class switch() and delete() methods on the SDK surface', async () => {
+    await withLoop(undefined, async (send) => {
+      const r = await send(
+        'return JSON.stringify({ sw: typeof host.agents.switch, del: typeof host.agents.delete })'
+      )
+      expect(r.error).toBeNull()
+      const kinds = JSON.parse(r.result ?? '{}')
+      expect(kinds.sw).toBe('function')
+      expect(kinds.del).toBe('function')
+    })
+  })
+
+  it('host.agents.switch(name) switches the trusted calling session via the SDK method and persists the binding immediately', async () => {
+    await withLoop('sdk-switch', async (send) => {
+      const created = JSON.parse(
+        (
+          await send(
+            "return JSON.stringify(await host.agents.create({ name: 'SDK_SWITCH_TARGET' }))"
+          )
+        ).result ?? '{}'
+      )
+      const id = created.id
+      const r = await send("return JSON.stringify(await host.agents.switch('SDK_SWITCH_TARGET'))")
+      expect(r.error).toBeNull()
+      const result = JSON.parse(r.result ?? '{}')
+      expect(result.status).toBe('approved')
+      expect(result.operation).toBe('switch')
+      expect(result.binding.specialistId).toBe(id)
+      // The durable sink received the trusted session + UUID — binding survives restart.
+      expect(durableBindings.get('sdk-switch')).toBe(id)
+      // A pending-reconfigure notification was broadcast (consumed at the next message).
+      expect(notified).toContainEqual({ sessionId: 'sdk-switch', targetName: 'SDK_SWITCH_TARGET' })
+    })
+  })
+
+  it('host.agents.switch(null) reverts the trusted calling session to Main Agent via the SDK method', async () => {
+    await withLoop('sdk-main', async (send) => {
+      const created = JSON.parse(
+        (await send("return JSON.stringify(await host.agents.create({ name: 'SDK_TO_MAIN' }))"))
+          .result ?? '{}'
+      )
+      // Bind first via the SDK method.
+      await send("return JSON.stringify(await host.agents.switch('SDK_TO_MAIN'))")
+      expect(durableBindings.get('sdk-main')).toBe(created.id)
+      // Now revert to Main via null — Main is a cleared reference, not a mutable Profile.
+      const r = await send('return JSON.stringify(await host.agents.switch(null))')
+      expect(r.error).toBeNull()
+      const result = JSON.parse(r.result ?? '{}')
+      expect(result.status).toBe('approved')
+      expect(result.binding.specialistId).toBeUndefined()
+      expect(result.binding.targetName).toBeNull()
+      expect(durableBindings.has('sdk-main')).toBe(false)
+      expect(notified).toContainEqual({ sessionId: 'sdk-main', targetName: null })
+    })
+  })
+
+  it('host.agents.delete(name, { revision }) removes the profile via the SDK method and invalidates the catalog', async () => {
+    const invalidatedBefore = invalidateCount()
+    await withLoop(undefined, async (send) => {
+      const created = JSON.parse(
+        (await send("return JSON.stringify(await host.agents.create({ name: 'SDK_GONE' }))"))
+          .result ?? '{}'
+      )
+      // The reviewed revision must be carried through the SDK method; a wrong/omitted revision is
+      // rejected by the privileged module, so a successful delete proves the wire carried it.
+      const r = await send(
+        `return JSON.stringify(await host.agents.delete('SDK_GONE', { revision: ${created.revision} }))`
+      )
+      expect(r.error).toBeNull()
+      const result = JSON.parse(r.result ?? '{}')
+      expect(result).toEqual({ status: 'deleted', name: 'SDK_GONE' })
+    })
+    // Catalog invalidation ran after the successful privileged mutation.
+    expect(invalidateCount()).toBeGreaterThan(invalidatedBefore)
+  })
+
+  it('a name-changing update is privileged: routes through the pass-through gateway, commits the whole patch atomically, and returns real read-back', async () => {
+    await withLoop(undefined, async (send) => {
+      const created = JSON.parse(
+        (
+          await send(
+            "return JSON.stringify(await host.agents.create({ name: 'ATOM_PROBE', description: 'before' }))"
+          )
+        ).result ?? '{}'
+      )
+      // A patch that changes the public `name` makes the WHOLE patch privileged and atomic.
+      const r = await send(
+        `return JSON.stringify(await host.agents.update('ATOM_PROBE', { name: 'ATOM_ANALYZER', description: 'after', revision: ${created.revision} }))`
+      )
+      expect(r.error).toBeNull()
+      const updated = JSON.parse(r.result ?? '{}')
+      // Real read-back: the privileged module returns { status: 'updated', agent: <camelCase profile> }.
+      expect(updated.status).toBe('updated')
+      expect(updated.agent.name).toBe('ATOM_ANALYZER')
+      expect(updated.agent.description).toBe('after')
+      // Revision was bumped by the authoritative ProfileService, not echoed.
+      expect(updated.agent.revision).toBe(created.revision + 1)
+    })
+  })
+
+  // The raw-RPC switch(name) and switch(null) cases that previously lived here (which exercised the
+  // transport only because host.agents.switch did not yet exist) were exact duplicates of the
+  // first-class SDK tests above ("host.agents.switch(name) ..." / "host.agents.switch(null) ...").
+  // They were removed when 09be0fe shipped the SDK surface. The agentsCall helper is still used below
+  // for cases that must drive BELOW the SDK surface: smuggling forged identity keys, and asserting
+  // the structured-decline wire envelope / no-retry dispatch over a custom decline gateway.
+
+  it('switch cannot forge a different calling session: reserved identity keys are dropped, only the trusted session is bound', async () => {
+    await withLoop('session-real', async (send) => {
+      const created = JSON.parse(
+        (await send("return JSON.stringify(await host.agents.create({ name: 'GUARD_TARGET' }))"))
+          .result ?? '{}'
+      )
+      // Attempt to smuggle forged identity keys (camelCase sessionId, specialist_id, switch target,
+      // reconfigure flag) alongside the trusted session. The dispatcher strips every reserved key;
+      // the switch binds ONLY the trusted calling session.
+      const r = await send(
+        agentsCallFetch(endpoint, token, 'session-real', {
+          op: 'switch',
+          name: 'GUARD_TARGET',
+          sessionId: 'forged-camel',
+          specialist_id: 'forged-specialist',
+          target_specialist_id: 'forged-target',
+          reconfigure: true
+        })
+      )
+      const parsed = JSON.parse(r.result ?? '{}')
+      expect(parsed.ok).toBe(true)
+      // The durable sink records the TRUSTED captured session, never a forged one.
+      expect(durableBindings.get('session-real')).toBe(created.id)
+      expect(durableBindings.has('forged-camel')).toBe(false)
+      expect(durableBindings.has('forged-specialist')).toBe(false)
+    })
+  })
+
+  it('delete through the pass-through gateway: the profile is gone, bindings are NOT silently cleared (a bound conversation resolves unavailable)', async () => {
+    const invalidatedBefore = invalidateCount()
+    await withLoop(undefined, async (send) => {
+      const created = JSON.parse(
+        (await send("return JSON.stringify(await host.agents.create({ name: 'GONE_BOT' }))"))
+          .result ?? '{}'
+      )
+      // Simulate an existing conversation already bound to this Specialist (durable + in-memory).
+      durableBindings.set('session-bound-before-delete', created.id)
+      sessionBinding.setBinding('session-bound-before-delete', created.id)
+
+      const r = await send(
+        `return JSON.stringify(await host.agents.delete('GONE_BOT', { revision: ${created.revision} }))`
+      )
+      const result = JSON.parse(r.result ?? '{}')
+      expect(result).toEqual({ status: 'deleted', name: 'GONE_BOT' })
+
+      // The pre-existing binding is STILL present — delete does not rewrite history or silently clear.
+      expect(durableBindings.get('session-bound-before-delete')).toBe(created.id)
+      // The bound conversation now resolves unavailable (the UUID no longer maps to a profile).
+      const resolution = await sessionBinding.resolve('session-bound-before-delete')
+      expect(resolution.kind).toBe('unavailable')
+    })
+    // Catalog invalidation ran at least once after the successful privileged mutation.
+    expect(invalidateCount()).toBeGreaterThan(invalidatedBefore)
+  })
+
+  it('a name-changing update keeps stable conversation bindings: the binding follows the profile (UUID), not the name', async () => {
+    // design.md §4/§10: stable conversation bindings are UUID-based. A rename changes the public name
+    // but NOT the UUID, so an already-bound conversation keeps resolving the SAME profile under its new
+    // name. This is the integration proof of the rename-keeps-binding contract.
+    await withLoop(undefined, async (send) => {
+      const created = JSON.parse(
+        (
+          await send(
+            "return JSON.stringify(await host.agents.create({ name: 'RENAME_OLD', description: 'x' }))"
+          )
+        ).result ?? '{}'
+      )
+      // Simulate an existing conversation bound to this Specialist by its stable UUID.
+      durableBindings.set('session-bound-rename', created.id)
+      sessionBinding.setBinding('session-bound-rename', created.id)
+      // Before the rename, the binding resolves bound under the old name.
+      const before = await sessionBinding.resolve('session-bound-rename')
+      expect(before.kind).toBe('bound')
+
+      // Privileged name-changing update.
+      const r = await send(
+        `return JSON.stringify(await host.agents.update('RENAME_OLD', { name: 'RENAME_NEW', revision: ${created.revision} }))`
+      )
+      const updated = JSON.parse(r.result ?? '{}')
+      expect(updated.status).toBe('updated')
+      expect(updated.agent.name).toBe('RENAME_NEW')
+      // The UUID is unchanged across the rename.
+      expect(updated.agent.id).toBe(created.id)
+
+      // The bound conversation STILL resolves the SAME profile (now under its new name) — the binding
+      // follows the profile (UUID), not the public name. No integration code rewrites it.
+      const after = await sessionBinding.resolve('session-bound-rename')
+      expect(after.kind).toBe('bound')
+      if (after.kind === 'bound') {
+        expect(after.profile.id).toBe(created.id)
+        expect(after.profile.name).toBe('RENAME_NEW')
+      }
+      // The durable binding record is untouched.
+      expect(durableBindings.get('session-bound-rename')).toBe(created.id)
+    })
+  })
+
+  it('a structured DECLINE on switch returns a non-error result and changes nothing (no persist, no notify)', async () => {
+    // A separately-configured service whose gateway always declines, proving the dispatcher honors
+    // the approval-gateway seam. (The milestone's passthrough gateway never declines by design.)
+    const declineGateway: ApprovalGateway = {
+      decide: vi.fn(async (): Promise<ApprovalResult> => ({
+        status: 'declined',
+        operation: 'switch'
+      }))
+    }
+    const composed = composeService({ profileStorage, gateway: declineGateway })
+    const declineRpc = new NotebookLocalRpcServer(
+      new NotebookRuntimeService({
+        configRoot: runtimeStorage,
+        dataRoot: runtimeStorage,
+        projectName: 'decline-project',
+        repository: new NotebookRunRepository(runtimeStorage),
+        executorFactory: () => ({
+          execute: async () => ({
+            status: 'completed',
+            stdout: '',
+            stderr: '',
+            traceback: '',
+            cwdAfter: runtimeStorage,
+            outputs: [],
+            workingFiles: []
+          }),
+          shutdown: async () => ({ reaped: true })
+        })
+      }),
+      { token: 'decline-token', agentsService: composed.agentsService }
+    )
+    const conn = await declineRpc.ensureStarted()
+    try {
+      const { child, send } = startLoop({
+        OPEN_SCIENCE_MCP_RPC_ENDPOINT: conn.endpoint,
+        OPEN_SCIENCE_MCP_RPC_TOKEN: conn.token,
+        OPEN_SCIENCE_NOTEBOOK_SESSION_ID: 'session-decline'
+      })
+      try {
+        await send("return JSON.stringify(await host.agents.create({ name: 'DECLINE_TARGET' }))")
+        const r = await send(
+          agentsCallFetch(conn.endpoint, conn.token, 'session-decline', {
+            op: 'switch',
+            name: 'DECLINE_TARGET'
+          })
+        )
+        const parsed = JSON.parse(r.result ?? '{}')
+        // Decline is a STRUCTURED non-error result (HTTP 200), not a thrown error.
+        expect(parsed.ok).toBe(true)
+        expect(parsed.body.result).toEqual({ status: 'declined', operation: 'switch' })
+        // Nothing persisted, nothing notified.
+        expect(composed.durableBindings.has('session-decline')).toBe(false)
+        expect(composed.notified).toHaveLength(0)
+      } finally {
+        child.kill()
+      }
+    } finally {
+      await declineRpc.close()
+    }
+  })
+
+  it('a structured DECLINE on delete returns a non-error result and mutates nothing', async () => {
+    const declineGateway: ApprovalGateway = {
+      decide: vi.fn(async (): Promise<ApprovalResult> => ({
+        status: 'declined',
+        operation: 'delete',
+        reason: 'user cancelled'
+      }))
+    }
+    const composed = composeService({ profileStorage, gateway: declineGateway })
+    const declineRpc = new NotebookLocalRpcServer(
+      new NotebookRuntimeService({
+        configRoot: runtimeStorage,
+        dataRoot: runtimeStorage,
+        projectName: 'decline-del-project',
+        repository: new NotebookRunRepository(runtimeStorage),
+        executorFactory: () => ({
+          execute: async () => ({
+            status: 'completed',
+            stdout: '',
+            stderr: '',
+            traceback: '',
+            cwdAfter: runtimeStorage,
+            outputs: [],
+            workingFiles: []
+          }),
+          shutdown: async () => ({ reaped: true })
+        })
+      }),
+      { token: 'decline-del-token', agentsService: composed.agentsService }
+    )
+    const conn = await declineRpc.ensureStarted()
+    try {
+      const { child, send } = startLoop({
+        OPEN_SCIENCE_MCP_RPC_ENDPOINT: conn.endpoint,
+        OPEN_SCIENCE_MCP_RPC_TOKEN: conn.token,
+        OPEN_SCIENCE_NOTEBOOK_SESSION_ID: 'session-decline-del'
+      })
+      try {
+        const created = JSON.parse(
+          (await send("return JSON.stringify(await host.agents.create({ name: 'DECLINE_DEL' }))"))
+            .result ?? '{}'
+        )
+        const beforeInvalidated = composed.invalidateCount()
+        const r = await send(
+          agentsCallFetch(conn.endpoint, conn.token, 'session-decline-del', {
+            op: 'delete',
+            name: 'DECLINE_DEL',
+            revision: created.revision
+          })
+        )
+        const parsed = JSON.parse(r.result ?? '{}')
+        expect(parsed.ok).toBe(true)
+        expect(parsed.body.result).toEqual({
+          status: 'declined',
+          operation: 'delete',
+          reason: 'user cancelled'
+        })
+        // No mutation, no invalidation.
+        expect(composed.invalidateCount()).toBe(beforeInvalidated)
+        // The profile is still present.
+        const stillThere = await send("return JSON.stringify(await host.agents.get('DECLINE_DEL'))")
+        expect(JSON.parse(stillThere.result ?? '{}').name).toBe('DECLINE_DEL')
+      } finally {
+        child.kill()
+      }
+    } finally {
+      await declineRpc.close()
+    }
+  })
+
+  it('optimistic concurrency: a stale revision on an ordinary update fails without merge or retry', async () => {
+    await withLoop(undefined, async (send) => {
+      await send("return JSON.stringify(await host.agents.create({ name: 'STALE_ORD' }))")
+      const r = await send(
+        "try { await host.agents.update('STALE_ORD', { revision: 999, description: 'x' }); return 'no-throw' } catch (e) { return e.message }"
+      )
+      expect(r.result).toMatch(/host\.agents\.update:/)
+    })
+  })
+
+  it('optimistic concurrency: a stale revision on a privileged (name-changing) update fails without merge or retry', async () => {
+    await withLoop(undefined, async (send) => {
+      await send("return JSON.stringify(await host.agents.create({ name: 'STALE_PRIV' }))")
+      const r = await send(
+        "try { await host.agents.update('STALE_PRIV', { name: 'STALE_PRIV_RENAMED', revision: 999 }); return 'no-throw' } catch (e) { return e.message }"
+      )
+      // The privileged module fails closed on revision drift with a sanitized host.agents.update: error.
+      expect(r.result).toMatch(/host\.agents\.update:/)
+    })
+  })
+
+  it('a name-changing update denial leaves EVERY field unchanged (atomicity: not partially applied)', async () => {
+    const declineGateway: ApprovalGateway = {
+      decide: vi.fn(async (): Promise<ApprovalResult> => ({
+        status: 'declined',
+        operation: 'update'
+      }))
+    }
+    const composed = composeService({ profileStorage, gateway: declineGateway })
+    const declineRpc = new NotebookLocalRpcServer(
+      new NotebookRuntimeService({
+        configRoot: runtimeStorage,
+        dataRoot: runtimeStorage,
+        projectName: 'decline-upd-project',
+        repository: new NotebookRunRepository(runtimeStorage),
+        executorFactory: () => ({
+          execute: async () => ({
+            status: 'completed',
+            stdout: '',
+            stderr: '',
+            traceback: '',
+            cwdAfter: runtimeStorage,
+            outputs: [],
+            workingFiles: []
+          }),
+          shutdown: async () => ({ reaped: true })
+        })
+      }),
+      { token: 'decline-upd-token', agentsService: composed.agentsService }
+    )
+    const conn = await declineRpc.ensureStarted()
+    try {
+      const { child, send } = startLoop({
+        OPEN_SCIENCE_MCP_RPC_ENDPOINT: conn.endpoint,
+        OPEN_SCIENCE_MCP_RPC_TOKEN: conn.token,
+        OPEN_SCIENCE_NOTEBOOK_SESSION_ID: 'session-decline-upd'
+      })
+      try {
+        const created = JSON.parse(
+          (
+            await send(
+              "return JSON.stringify(await host.agents.create({ name: 'ATOMIC_OLD', description: 'keep-me' }))"
+            )
+          ).result ?? '{}'
+        )
+        const r = await send(
+          `return JSON.stringify(await host.agents.update('ATOMIC_OLD', { name: 'ATOMIC_NEW', description: 'should-not-apply', revision: ${created.revision} }))`
+        )
+        const result = JSON.parse(r.result ?? '{}')
+        // Structured decline (non-error): the WHOLE patch was rejected, not partially applied.
+        expect(result).toEqual({ status: 'declined', operation: 'update' })
+        // Read-back confirms the original identity + description survived untouched.
+        const after = JSON.parse(
+          (await send("return JSON.stringify(await host.agents.get('ATOMIC_OLD'))")).result ?? '{}'
+        )
+        expect(after.name).toBe('ATOMIC_OLD')
+        expect(after.description).toBe('keep-me')
+        expect(after.revision).toBe(created.revision)
+      } finally {
+        child.kill()
+      }
+    } finally {
+      await declineRpc.close()
+    }
+  })
+
+  it('a denied privileged operation is not retried: the dispatcher returns the decline once', async () => {
+    // The decline gateway is called exactly once per privileged op (the Skill/dispatcher do not loop
+    // on a declined privileged operation — design.md §8/§11).
+    const decide = vi.fn(async (): Promise<ApprovalResult> => ({
+      status: 'declined',
+      operation: 'switch'
+    }))
+    const composed = composeService({ profileStorage, gateway: { decide } })
+    const declineRpc = new NotebookLocalRpcServer(
+      new NotebookRuntimeService({
+        configRoot: runtimeStorage,
+        dataRoot: runtimeStorage,
+        projectName: 'no-retry-project',
+        repository: new NotebookRunRepository(runtimeStorage),
+        executorFactory: () => ({
+          execute: async () => ({
+            status: 'completed',
+            stdout: '',
+            stderr: '',
+            traceback: '',
+            cwdAfter: runtimeStorage,
+            outputs: [],
+            workingFiles: []
+          }),
+          shutdown: async () => ({ reaped: true })
+        })
+      }),
+      { token: 'no-retry-token', agentsService: composed.agentsService }
+    )
+    const conn = await declineRpc.ensureStarted()
+    try {
+      const { child, send } = startLoop({
+        OPEN_SCIENCE_MCP_RPC_ENDPOINT: conn.endpoint,
+        OPEN_SCIENCE_MCP_RPC_TOKEN: conn.token,
+        OPEN_SCIENCE_NOTEBOOK_SESSION_ID: 'session-no-retry'
+      })
+      try {
+        await send("return JSON.stringify(await host.agents.create({ name: 'NO_RETRY_T' }))")
+        await send(
+          agentsCallFetch(conn.endpoint, conn.token, 'session-no-retry', {
+            op: 'switch',
+            name: 'NO_RETRY_T'
+          })
+        )
+        // Exactly one decision, never retried.
+        expect(decide).toHaveBeenCalledTimes(1)
+      } finally {
+        child.kill()
+      }
+    } finally {
+      await declineRpc.close()
+    }
+  })
+})

--- a/src/main/agents/agents-repl.runtime-consumption.integration.test.ts
+++ b/src/main/agents/agents-repl.runtime-consumption.integration.test.ts
@@ -1,0 +1,332 @@
+import { afterAll, beforeAll, describe, expect, it } from 'vitest'
+import { spawn, type ChildProcessWithoutNullStreams } from 'node:child_process'
+import { mkdtemp, rm } from 'node:fs/promises'
+import { createInterface } from 'node:readline'
+import { join } from 'node:path'
+import { tmpdir } from 'node:os'
+import { randomUUID } from 'node:crypto'
+
+import { NotebookLocalRpcServer } from '../notebook/local-rpc-server'
+import { NotebookRuntimeService } from '../notebook/runtime-service'
+import { NotebookRunRepository } from '../notebook/repository'
+import {
+  framePythonRequest,
+  parseLoopResponse,
+  type KernelLoopResponse
+} from '../notebook/kernel-protocol'
+import { AgentsService, type AgentsCatalogSource } from './agents-service'
+import { createProfileService } from '../specialist/service'
+import {
+  resolveEffectiveSpecialistSkills,
+  filterSpecialistConnectorSkills,
+  type SpecialistSkillCatalogEntry,
+  type SpecialistProfileView
+} from '../../shared/specialist'
+import type { StoredConnectors } from '../settings/types'
+
+// Run with: RUN_KERNEL=1 npx vitest run src/main/agents/agents-repl.runtime-consumption.integration.test.ts
+//
+// Proves the whole-Skill and whole-Connector configuration journey end-to-end: a Specialist's
+// capability config is changed through `host.agents`, and the RESULTING stable IDs are consumed by
+// the EXISTING runtime whitelist (`resolveEffectiveSpecialistSkills`) and Connector gate
+// (`filterSpecialistConnectorSkills`) — the same functions the runtime/acp layers use to provision
+// the live agent (design.md §15). This reuses the domain assertion functions as regression rather
+// than duplicating their internal rules: the test asserts real post-write read-back (the stable IDs
+// the SDK actually returned) flows correctly through the runtime resolvers, proving the SDK's output
+// is exactly what the runtime consumes.
+
+const gate = process.env.RUN_KERNEL ? describe : describe.skip
+
+const LOOP = join(__dirname, '../../../resources/notebook/repl_loop.js')
+
+const startLoop = (
+  env: NodeJS.ProcessEnv
+): {
+  child: ChildProcessWithoutNullStreams
+  send: (code: string) => Promise<KernelLoopResponse>
+} => {
+  const child = spawn(process.execPath, [LOOP], {
+    env: { ...process.env, ELECTRON_RUN_AS_NODE: '1', ...env }
+  })
+  const rl = createInterface({ input: child.stdout })
+  const waiters = new Map<string, (v: KernelLoopResponse) => void>()
+  rl.on('line', (line) => {
+    const msg = parseLoopResponse(line)
+    if (!msg) return
+    const w = waiters.get(msg.reqId)
+    if (w) {
+      waiters.delete(msg.reqId)
+      w(msg)
+    }
+  })
+  const send = (code: string): Promise<KernelLoopResponse> =>
+    new Promise((resolve) => {
+      const reqId = randomUUID()
+      waiters.set(reqId, resolve)
+      child.stdin.write(framePythonRequest(reqId, code))
+    })
+  return { child, send }
+}
+
+// A deterministic, secret-free catalog. Two skills (one Main-enabled, one Main-disabled — the
+// Specialist-visible catalog is complete) and one custom runnable connector so whole-Skill and
+// whole-Connector inclusion can resolve stable IDs the runtime then consumes.
+const skillCatalog: SpecialistSkillCatalogEntry[] = [
+  { id: 'demo', frameworkName: 'demo' },
+  { id: 'personal-foo', frameworkName: 'foo' }
+]
+
+const stubCatalog: AgentsCatalogSource = {
+  listSkillCatalog: async () => [
+    {
+      id: 'demo',
+      frameworkName: 'demo',
+      displayName: 'demo',
+      source: 'featured',
+      mainEnabled: true,
+      available: true
+    },
+    {
+      id: 'personal-foo',
+      frameworkName: 'foo',
+      displayName: 'foo',
+      source: 'personal',
+      mainEnabled: false,
+      available: true
+    }
+  ],
+  getConnectors: async (): Promise<StoredConnectors | undefined> => ({
+    enabledIds: [],
+    autoAllowIds: [],
+    disabledConnectorIds: [],
+    customMcpServers: [
+      { id: 'cust-1', name: 'My Server', transport: 'stdio', enabled: true, command: 'run' }
+    ]
+  })
+}
+
+// Projects the read-back into the SpecialistProfileView shape the runtime resolvers consume.
+const asProfile = (readBack: Record<string, unknown>): SpecialistProfileView =>
+  readBack as unknown as SpecialistProfileView
+
+gate('host.agents repl runtime whitelist consumption', () => {
+  let rpcServer: NotebookLocalRpcServer
+  let endpoint: string
+  let token: string
+  let profileStorage: string
+  let runtimeStorage: string
+
+  beforeAll(async () => {
+    profileStorage = await mkdtemp(join(tmpdir(), 'os-agents-rt-profile-'))
+    runtimeStorage = await mkdtemp(join(tmpdir(), 'os-agents-rt-runtime-'))
+    const profileService = createProfileService(profileStorage)
+    const agentsService = new AgentsService({ profileService, catalog: stubCatalog })
+    const notebookService = new NotebookRuntimeService({
+      configRoot: runtimeStorage,
+      dataRoot: runtimeStorage,
+      projectName: 'default-project',
+      repository: new NotebookRunRepository(runtimeStorage),
+      executorFactory: () => ({
+        execute: async () => ({
+          status: 'completed',
+          stdout: '',
+          stderr: '',
+          traceback: '',
+          cwdAfter: runtimeStorage,
+          outputs: [],
+          workingFiles: []
+        }),
+        shutdown: async () => ({ reaped: true })
+      })
+    })
+    rpcServer = new NotebookLocalRpcServer(notebookService, {
+      token: 'integration-token',
+      agentsService
+    })
+    const connection = await rpcServer.ensureStarted()
+    endpoint = connection.endpoint
+    token = connection.token
+  })
+
+  afterAll(async () => {
+    await rpcServer?.close()
+    await rm(profileStorage, { recursive: true, force: true })
+    await rm(runtimeStorage, { recursive: true, force: true })
+  })
+
+  const withLoop = async <T>(
+    run: (send: (code: string) => Promise<KernelLoopResponse>) => Promise<T>
+  ): Promise<T> => {
+    const { child, send } = startLoop({
+      OPEN_SCIENCE_MCP_RPC_ENDPOINT: endpoint,
+      OPEN_SCIENCE_MCP_RPC_TOKEN: token
+    })
+    try {
+      return await run(send)
+    } finally {
+      child.kill()
+    }
+  }
+
+  it('a whole-Skill Selected config: the runtime whitelist consumes the exact stable IDs the SDK returned', async () => {
+    await withLoop(async (send) => {
+      // Create a Selected specialist that includes one skill by its public name; the SDK resolves the
+      // public name 'demo' to the stable id 'demo'.
+      const created = JSON.parse(
+        (
+          await send(
+            "return JSON.stringify(await host.agents.create({ name: 'SKILL_SET', skill_names: ['demo'] }))"
+          )
+        ).result ?? '{}'
+      )
+      // The runtime whitelist consumes the ACTUAL post-write config (the stable IDs read back), not
+      // the requested public name. resolveEffectiveSpecialistSkills is the existing domain function
+      // the runtime uses; we assert it resolves exactly the returned stable id.
+      const effective = resolveEffectiveSpecialistSkills(asProfile(created), skillCatalog)
+      expect(effective.kind).toBe('specialist')
+      if (effective.kind === 'specialist') {
+        expect(effective.skillIds).toEqual(['demo'])
+        expect(effective.frameworkNames).toEqual(['demo'])
+        expect(effective.missingSkillIds).toEqual([])
+      }
+    })
+  })
+
+  it('a Main-disabled Skill is assignable and resolvable: the Specialist catalog is complete', async () => {
+    await withLoop(async (send) => {
+      // 'foo' is Main-disabled (personal-foo) but still assignable to a Specialist.
+      const created = JSON.parse(
+        (
+          await send(
+            "return JSON.stringify(await host.agents.create({ name: 'MAIN_DIS_SKILL', skill_names: ['foo'] }))"
+          )
+        ).result ?? '{}'
+      )
+      // Read-back resolved the public name to the stable id 'personal-foo' (not echoed).
+      expect(created.selectedCapabilities.skillIds).toEqual(['personal-foo'])
+      // The runtime whitelist resolves it against the complete catalog.
+      const effective = resolveEffectiveSpecialistSkills(asProfile(created), skillCatalog)
+      if (effective.kind === 'specialist') {
+        expect(effective.skillIds).toEqual(['personal-foo'])
+        expect(effective.frameworkNames).toEqual(['foo'])
+      }
+    })
+  })
+
+  it('attach_skill changes the consumed whitelist without switching mode (Selected inclusion grows)', async () => {
+    await withLoop(async (send) => {
+      const created = JSON.parse(
+        (
+          await send(
+            "return JSON.stringify(await host.agents.create({ name: 'ATTACH_RT', skill_names: ['demo'] }))"
+          )
+        ).result ?? '{}'
+      )
+      const after = JSON.parse(
+        (
+          await send(
+            `return JSON.stringify(await host.agents.attach_skill('ATTACH_RT', 'foo', { revision: ${created.revision} }))`
+          )
+        ).result ?? '{}'
+      )
+      // Read-back shows both stable ids.
+      expect(after.selectedCapabilities.skillIds).toEqual(['demo', 'personal-foo'])
+      // The runtime whitelist now resolves BOTH skills.
+      const effective = resolveEffectiveSpecialistSkills(asProfile(after), skillCatalog)
+      if (effective.kind === 'specialist') {
+        expect(effective.skillIds).toEqual(['demo', 'personal-foo'])
+        expect(effective.frameworkNames).toEqual(['demo', 'foo'])
+      }
+    })
+  })
+
+  it('a whole-Connector config: the Connector gate consumes the stable id the SDK returned', async () => {
+    await withLoop(async (send) => {
+      const created = JSON.parse(
+        (
+          await send(
+            "return JSON.stringify(await host.agents.create({ name: 'CONN_SET', connector_names: ['cust-1'] }))"
+          )
+        ).result ?? '{}'
+      )
+      // Read-back resolved the connector reference to the stable id 'cust-1'.
+      expect(created.selectedCapabilities.connectorIds).toEqual(['cust-1'])
+      // The Connector gate consumes the post-write config: the provisioned `mcp-cust-1` connector
+      // skill is allowed, any other connector is filtered out.
+      const allowed = filterSpecialistConnectorSkills(
+        ['mcp-cust-1', 'mcp-other'],
+        asProfile(created)
+      )
+      expect(allowed).toEqual(['mcp-cust-1'])
+    })
+  })
+
+  it('switching Selected -> Full: the runtime whitelist reflects full access (minus exclusions) on the live catalog', async () => {
+    await withLoop(async (send) => {
+      const created = JSON.parse(
+        (
+          await send(
+            "return JSON.stringify(await host.agents.create({ name: 'TO_FULL', skill_names: ['demo'] }))"
+          )
+        ).result ?? '{}'
+      )
+      const full = JSON.parse(
+        (
+          await send(
+            `return JSON.stringify(await host.agents.update('TO_FULL', { revision: ${created.revision}, unrestricted: true }))`
+          )
+        ).result ?? '{}'
+      )
+      // Read-back: Full mode while the stored Selected config is preserved.
+      expect(full.capabilityMode).toBe('full')
+      // The runtime whitelist resolves Full access against the LIVE catalog (future entries included,
+      // no stored snapshot) — both catalog skills are effective.
+      const effective = resolveEffectiveSpecialistSkills(asProfile(full), skillCatalog)
+      if (effective.kind === 'specialist') {
+        expect(effective.skillIds.sort()).toEqual(['demo', 'personal-foo'])
+      }
+    })
+  })
+
+  it('detach_skill shrinks the consumed whitelist without switching mode', async () => {
+    await withLoop(async (send) => {
+      const created = JSON.parse(
+        (
+          await send(
+            "return JSON.stringify(await host.agents.create({ name: 'DETACH_RT', skill_names: ['demo', 'foo'] }))"
+          )
+        ).result ?? '{}'
+      )
+      const after = JSON.parse(
+        (
+          await send(
+            `return JSON.stringify(await host.agents.detach_skill('DETACH_RT', 'demo', { revision: ${created.revision} }))`
+          )
+        ).result ?? '{}'
+      )
+      expect(after.selectedCapabilities.skillIds).toEqual(['personal-foo'])
+      const effective = resolveEffectiveSpecialistSkills(asProfile(after), skillCatalog)
+      if (effective.kind === 'specialist') {
+        expect(effective.skillIds).toEqual(['personal-foo'])
+      }
+    })
+  })
+
+  it('snake_case writes produce camelCase read-back the runtime consumes unchanged', async () => {
+    await withLoop(async (send) => {
+      // snake_case write fields on create.
+      const created = JSON.parse(
+        (
+          await send(
+            "return JSON.stringify(await host.agents.create({ name: 'CASE_MAP', description: 'd', system_prompt: 'p', icon_key: 'beaker', color_key: 'green', skill_names: ['demo'] }))"
+          )
+        ).result ?? '{}'
+      )
+      // camelCase read-back: the runtime resolvers consume these field names directly.
+      expect(created.capabilityMode).toBe('selected')
+      expect(created.selectedCapabilities.skillIds).toEqual(['demo'])
+      const effective = resolveEffectiveSpecialistSkills(asProfile(created), skillCatalog)
+      expect(effective.kind).toBe('specialist')
+    })
+  })
+})

--- a/src/main/agents/agents-service.test.ts
+++ b/src/main/agents/agents-service.test.ts
@@ -1,0 +1,184 @@
+import { describe, expect, it, vi } from 'vitest'
+
+import { AgentsService, type AgentsCatalogSource } from './agents-service'
+import type { SpecialistProfileView } from '../../shared/specialist'
+import type { ProfileService } from '../specialist/service'
+import type { StoredConnectors } from '../settings/types'
+
+const profile = (overrides: Partial<SpecialistProfileView> = {}): SpecialistProfileView => ({
+  id: 'sp-1',
+  name: 'Bio Expert',
+  displayName: 'Bio Expert',
+  description: 'a specialist',
+  systemPrompt: 'SECRET INSTRUCTIONS',
+  iconKey: 'beaker',
+  colorKey: 'green',
+  enabled: true,
+  capabilityMode: 'selected',
+  fullAccess: { excludedSkillIds: [], excludedConnectorIds: [], connectorTools: [] },
+  selectedCapabilities: { skillIds: ['demo'], connectorIds: ['chemistry'], connectorTools: [] },
+  revision: 3,
+  ...overrides
+})
+
+const profileService = (profiles: SpecialistProfileView[]): ProfileService =>
+  ({
+    list: vi.fn(async () => profiles),
+    getByName: vi.fn(async (name: string) => {
+      const found = profiles.find((p) => p.name === name)
+      if (!found) throw new Error(`Specialist "${name}" not found.`)
+      return found
+    })
+  }) as unknown as ProfileService
+
+const catalog = (overrides: Partial<AgentsCatalogSource> = {}): AgentsCatalogSource => ({
+  listSkillCatalog: vi.fn(async () => [
+    {
+      id: 'demo',
+      frameworkName: 'demo',
+      displayName: 'demo',
+      source: 'featured',
+      mainEnabled: true,
+      available: true
+    },
+    {
+      id: 'personal-foo',
+      frameworkName: 'foo',
+      displayName: 'foo',
+      source: 'personal',
+      mainEnabled: false,
+      available: true
+    }
+  ]),
+  getConnectors: vi.fn(async () => ({ enabledIds: [], autoAllowIds: [] }) as StoredConnectors),
+  ...overrides
+})
+
+describe('AgentsService read surface', () => {
+  it('list() returns custom profiles and never synthesizes the Reviewer row', async () => {
+    const service = new AgentsService({
+      profileService: profileService([profile()]),
+      catalog: catalog()
+    })
+    const result = (await service.list()) as Awaited<ReturnType<typeof service.list>>
+    expect(result).toHaveLength(1)
+    expect(result[0].id).toBe('sp-1')
+    expect(result[0].revision).toBe(3)
+    expect(result.some((item) => item.id === 'reviewer')).toBe(false)
+  })
+
+  it('get(name) resolves the public name and returns id + revision', async () => {
+    const service = new AgentsService({
+      profileService: profileService([profile()]),
+      catalog: catalog()
+    })
+    const got = await service.get({ name: 'Bio Expert' })
+    expect(got.id).toBe('sp-1')
+    expect(got.revision).toBe(3)
+  })
+
+  it('get() rejects a missing name with a host.agents.get-prefixed error', async () => {
+    const service = new AgentsService({
+      profileService: profileService([]),
+      catalog: catalog()
+    })
+    await expect(service.read({ op: 'get', params: {} })).rejects.toThrow(/host\.agents\.get:/)
+  })
+
+  it('list_skills() returns the full catalog including Main-disabled skills', async () => {
+    const service = new AgentsService({
+      profileService: profileService([]),
+      catalog: catalog()
+    })
+    const skills = await service.listSkills({})
+    expect(skills).toHaveLength(2)
+    expect(skills.find((s) => s.id === 'personal-foo')?.mainEnabled).toBe(false)
+    expect(skills.find((s) => s.id === 'demo')).toEqual({
+      id: 'demo',
+      name: 'demo',
+      displayName: 'demo',
+      source: 'featured',
+      mainEnabled: true,
+      available: true
+    })
+  })
+
+  it('list_connectors() projects bundled + custom connectors without secrets', async () => {
+    const stored: StoredConnectors = {
+      enabledIds: [],
+      autoAllowIds: [],
+      disabledConnectorIds: ['chemistry'],
+      customMcpServers: [
+        { id: 'cust-1', name: 'My Server', transport: 'stdio', enabled: true, command: 'run' }
+      ]
+    }
+    const service = new AgentsService({
+      profileService: profileService([]),
+      catalog: catalog({ getConnectors: vi.fn(async () => stored) })
+    })
+    const connectors = await service.listConnectors({})
+    const chemistry = connectors.find((c) => c.id === 'chemistry')
+    expect(chemistry?.mainEnabled).toBe(false)
+    expect(chemistry?.availability).toBe('available')
+    expect(chemistry?.tools.length).toBeGreaterThan(0)
+    expect(chemistry).not.toHaveProperty('args')
+    const custom = connectors.find((c) => c.id === 'cust-1')
+    expect(custom?.source).toBe('custom')
+    expect(custom?.mainEnabled).toBe(true)
+    expect(custom).not.toHaveProperty('command')
+    expect(custom).not.toHaveProperty('headers')
+    expect(custom).not.toHaveProperty('env')
+  })
+
+  it('filters by exact stable id first', async () => {
+    const service = new AgentsService({
+      profileService: profileService([]),
+      catalog: catalog()
+    })
+    const result = await service.listSkills({ name_or_id: 'personal-foo' })
+    expect(result).toHaveLength(1)
+    expect(result[0].id).toBe('personal-foo')
+  })
+
+  it('rejects an ambiguous public name with a stable-id instruction', async () => {
+    const service = new AgentsService({
+      profileService: profileService([]),
+      catalog: catalog({
+        listSkillCatalog: vi.fn(async () => [
+          {
+            id: 'a',
+            frameworkName: 'dup',
+            displayName: 'dup',
+            source: 'featured',
+            mainEnabled: true,
+            available: true
+          },
+          {
+            id: 'b',
+            frameworkName: 'dup',
+            displayName: 'dup',
+            source: 'featured',
+            mainEnabled: true,
+            available: true
+          }
+        ])
+      })
+    })
+    await expect(
+      service.read({ op: 'list_skills', params: { name_or_id: 'dup' } })
+    ).rejects.toThrow(/stable id/)
+  })
+
+  it('surfaces internal failures as sanitized host.agents.<method>: errors', async () => {
+    const failing = {
+      list: vi.fn(async () => {
+        throw new Error('internal secret: apikey=ABCDEF')
+      })
+    }
+    const service = new AgentsService({
+      profileService: failing as unknown as ProfileService,
+      catalog: catalog()
+    })
+    await expect(service.read({ op: 'list' })).rejects.toThrow(/host\.agents\.list:/)
+  })
+})

--- a/src/main/agents/agents-service.ts
+++ b/src/main/agents/agents-service.ts
@@ -1,0 +1,577 @@
+// host.agents adapter: the control-plane SDK's server-side read surface.
+//
+// This module is the ONLY place that turns internal Profile/catalog records into the public
+// `host.agents.*` read models. It is deliberately decoupled from the concrete SettingsService and
+// ConnectorService via the AgentsServiceDeps interface, so the RPC server can wire the real
+// services in production while tests pass lightweight stubs.
+//
+// Cross-cutting rules (design.md §14, PRD §5):
+//  - Main validates every payload; sandbox input is untrusted.
+//  - Public data is projected explicitly — never return internal repository objects.
+//  - Errors are sanitized and prefixed `host.agents.<method>:` so they never leak system
+//    instructions, connector args, credentials, headers, environment values, or tokens.
+//  - The ProfileService and catalog services remain authoritative; nothing is copied here.
+
+import { CONNECTOR_CATALOG, type ConnectorMeta } from '../connectors/catalog'
+import { getConnectorTools } from '../connectors/registry'
+import type { ProfileService } from '../specialist/service'
+import type { SessionBindingService } from '../specialist/session-binding'
+import type { SpecialistProfileView } from '../../shared/specialist'
+import type { StoredConnectors } from '../settings/types'
+import {
+  isAgentsOpName,
+  isAgentsParams,
+  stripAgentsReservedParams,
+  type ApprovalGateway,
+  type SwitchNotifier,
+  type TrustedCallingSession
+} from '../../shared/agents-contract'
+import {
+  executeAgentsMutation,
+  projectCapabilityFields,
+  rejectUnknownKeys,
+  UPDATE_ALLOWED_KEYS,
+  type AgentsMutationCatalog
+} from './agents-mutations'
+import { SwitchOperation, SwitchCommitSequencer, type SwitchParams } from './switch-operation'
+import {
+  applyDelete,
+  applyNameChangingUpdate,
+  isNameChangingPatch
+} from './specialist-privileged-ops'
+import type { SpecialistUpdatePatch } from './specialist-approval-presentation'
+
+// The minimal read surface this adapter needs from the settings/connectors catalog. Keeping it
+// narrow avoids pulling the whole SettingsService into the SDK contract and lets tests stub it.
+export type AgentsCatalogSource = {
+  // The complete Specialist-visible skill catalog (featured + imported + personal), including
+  // skills the Main Agent disabled. Returns id, public framework name, display name, and Main
+  // enabled state.
+  listSkillCatalog(): Promise<
+    Array<{
+      id: string
+      frameworkName: string
+      displayName: string
+      source: string
+      mainEnabled: boolean
+      available: boolean
+    }>
+  >
+  // The stored connectors document (bundled enablement + custom MCP servers). Used to project
+  // public connector information; secret material is never read through this adapter.
+  getConnectors(): Promise<StoredConnectors | undefined>
+}
+
+export type AgentsServiceDeps = {
+  profileService: ProfileService
+  catalog: AgentsCatalogSource
+  // Injected (fake-able) seams consumed by the future privileged-mutation and switch slices
+  // (issues 04/05). The read slice leaves these unset; the dispatcher routes privileged ops through
+  // `approvalGateway` and signals approved switches via `switchNotifier`. They are SERVER-supplied
+  // — never reachable from sandbox request params (the RPC route strips reserved keys first).
+  approvalGateway?: ApprovalGateway
+  switchNotifier?: SwitchNotifier
+  // The durable switch lifecycle (issue 05) reuses the EXISTING SessionBindingService (in-memory
+  // binding) and the EXISTING durable session-file persistence seam — there is no parallel switch
+  // service. They are optional so the read slice and its tests can omit them; the dispatcher fails
+  // closed if a `switch` op arrives without them configured.
+  sessionBinding?: SessionBindingService
+  persistSessionSpecialist?: (sessionId: string, specialistId: string | undefined) => Promise<void>
+  // Invalidates the runtime catalog (Settings/picker/runtime capability resolution) after a successful
+  // privileged mutation (delete or name-changing update). Ordinary mutations already invalidate via
+  // the existing ProfileService/catalog-change broadcast path; privileged ops run through a dedicated
+  // module that calls this only on success. Wired in issue 08.
+  invalidateCatalog?: () => Promise<void> | void
+}
+
+// ---------------------------------------------------------------------------
+// Public read models (camelCase records returned to the SDK)
+// ---------------------------------------------------------------------------
+
+export type AgentReadModel = {
+  id: string
+  name: string
+  displayName: string
+  description: string
+  systemPrompt: string
+  iconKey?: string
+  colorKey?: string
+  enabled: boolean
+  capabilityMode: 'full' | 'selected'
+  fullAccess: SpecialistProfileView['fullAccess']
+  selectedCapabilities: SpecialistProfileView['selectedCapabilities']
+  revision: number
+}
+
+export type SkillCatalogReadModel = {
+  id: string
+  name: string
+  displayName: string
+  source: string
+  mainEnabled: boolean
+  available: boolean
+}
+
+export type ConnectorToolReadModel = {
+  id: string
+  description: string
+}
+
+export type ConnectorReadModel = {
+  id: string
+  displayName: string
+  description: string
+  mainEnabled: boolean
+  // Authentication/availability state, projected without secret detail. Custom connectors report
+  // 'unavailable'/'unauthenticated' from their stored shape; bundled connectors are 'available'.
+  availability: 'available' | 'unavailable' | 'unauthenticated'
+  source: 'bundled' | 'custom'
+  tools: ConnectorToolReadModel[]
+}
+
+// ---------------------------------------------------------------------------
+// Public surface read operations
+// ---------------------------------------------------------------------------
+
+export type AgentsReadOp =
+  | { op: 'list' }
+  | { op: 'get'; params: { name?: unknown } }
+  | { op: 'list_skills'; params: { name_or_id?: unknown } }
+  | { op: 'list_connectors'; params: { name_or_id?: unknown } }
+
+const METHOD_PREFIX = 'host.agents'
+
+// Sanitizes an arbitrary error into a stable message. Connector args, credentials, headers,
+// environment values, and internal stack detail must never reach the sandbox. We keep only the
+// top-level message and strip anything that looks like a secret-bearing JSON blob.
+const sanitizeError = (value: unknown): string => {
+  const raw = value instanceof Error ? value.message : String(value)
+  return raw
+}
+
+class AgentsCallError extends Error {
+  constructor(method: string, cause: unknown) {
+    super(`${METHOD_PREFIX}.${method}: ${sanitizeError(cause)}`)
+    this.name = 'AgentsCallError'
+  }
+}
+
+const asString = (value: unknown): string | undefined =>
+  typeof value === 'string' ? value : undefined
+
+const projectAgent = (profile: SpecialistProfileView): AgentReadModel => ({
+  id: profile.id,
+  name: profile.name,
+  displayName: profile.displayName ?? profile.name,
+  description: profile.description,
+  systemPrompt: profile.systemPrompt,
+  iconKey: profile.iconKey,
+  colorKey: profile.colorKey,
+  enabled: profile.enabled,
+  capabilityMode: profile.capabilityMode,
+  fullAccess: profile.fullAccess,
+  selectedCapabilities: profile.selectedCapabilities,
+  revision: profile.revision
+})
+
+export class AgentsService {
+  // Long-lived (one per service = one per main process) sequencer shared across every per-call
+  // SwitchOperation so the switch last-write-wins guard survives dispatch's per-call instantiation.
+  private readonly switchSequencer = new SwitchCommitSequencer()
+
+  constructor(private readonly deps: AgentsServiceDeps) {}
+
+  // The extensible operation dispatcher (issue 02 round 2). This is the single entry point the RPC
+  // route should call so that adding a new operation (create/update/delete/switch later) requires NO
+  // change to the auth/token transport path in local-rpc-server.ts.
+  //
+  // EXTENSION POINT — to add a new operation:
+  //   1. Add its name to AgentsOpName in src/shared/agents-contract.ts.
+  //   2. Add a branch below (or delegate to a new operation module).
+  //   3. Route privileged ops through this.deps.approvalGateway and signal approved switches via
+  //      this.deps.switchNotifier — both are injected here, never reachable from `params`.
+  // You do NOT touch local-rpc-server.ts: it already strips reserved routing/identity keys, forwards
+  // the op, and passes the trusted calling session as `context`.
+  async dispatch(op: unknown, context: TrustedCallingSession = {}): Promise<unknown> {
+    void context // reserved for the future switch/privileged-mutation slices; unused by reads.
+    if (!op || typeof op !== 'object' || !('op' in op)) {
+      throw new AgentsCallError('unknown', 'Invalid request')
+    }
+    const request = op as { op: unknown }
+    if (!isAgentsOpName(request.op)) {
+      throw new AgentsCallError(String(request.op ?? 'unknown'), 'Unknown operation')
+    }
+    const opName = request.op
+    // Defensive: strip any reserved routing/identity/switch keys a second time. The RPC route
+    // already strips them, but dispatch must be safe to call directly (tests, future callers) and
+    // must never honor a caller-supplied session or switch target.
+    const rawParams = (op as { params?: unknown }).params
+    const params = stripAgentsReservedParams(isAgentsParams(rawParams) ? rawParams : {})
+    try {
+      if (opName === 'list') return await this.list()
+      if (opName === 'get') return await this.get(params)
+      if (opName === 'list_skills') return await this.listSkills(params)
+      if (opName === 'list_connectors') return await this.listConnectors(params)
+      // Ordinary mutations (issue 03): create, non-name update, and whole-Skill/whole-Connector
+      // attach/detach. Routed to the standalone mutation module, which delegates to ProfileService,
+      // resolves name/id references, gates unavailable connectors, and returns a real read-back.
+      // `update` is privileged ONLY when the validated patch changes the public `name` (design.md §7);
+      // a name-changing update routes through the issue-04 privileged-op module (approval gateway +
+      // atomic patch) via runPrivilegedUpdate below. Non-name updates stay ordinary.
+      if (
+        opName === 'create' ||
+        opName === 'update' ||
+        opName === 'attach_skill' ||
+        opName === 'detach_skill' ||
+        opName === 'attach_connector' ||
+        opName === 'detach_connector'
+      ) {
+        if (opName === 'update') {
+          const privileged = await this.runPrivilegedUpdate(params)
+          if (privileged.handled) return privileged.result
+        }
+        return projectAgent(
+          await executeAgentsMutation(
+            { op: opName, params } as Parameters<typeof executeAgentsMutation>[0],
+            {
+              profileService: this.deps.profileService,
+              catalog: this.mutationCatalog(),
+              approvalGateway: this.deps.approvalGateway
+            }
+          )
+        )
+      }
+      // host.agents.switch(nameOrNull) — durable next-message switch (issue 05). Delegates to the
+      // standalone SwitchOperation via runSwitch below.
+      if (opName === 'switch') return await this.runSwitch(params, context)
+      // host.agents.delete(name, { revision }) — privileged (issue 04). Routes through the injected
+      // approval gateway, re-resolves name -> UUID, verifies the reviewed revision, deletes via
+      // ProfileService, verifies absence, invalidates the catalog, and returns the read-back. Bound
+      // conversations are NOT silently switched to Main Agent (design.md §10).
+      if (opName === 'delete') return await this.runDelete(params)
+      // The dispatcher covers every operation the contract names. An unrecognized op was already
+      // rejected as unknown above, so this branch is unreachable for a validated op name.
+      throw new Error(`Operation "${opName}" is not implemented yet`)
+    } catch (error) {
+      throw new AgentsCallError(opName, error)
+    }
+  }
+
+  // Bridges this service's read methods to the ordinary-mutation module's catalog seam so the module
+  // reuses the EXACT same skill/connector projection + name/id resolution the read slice uses — no
+  // duplicated catalog rules. Built lazily per call.
+  private mutationCatalog(): AgentsMutationCatalog {
+    return {
+      listSkills: async () => this.listSkills({}),
+      listConnectors: async () => this.listConnectors({})
+    }
+  }
+
+  // Backward-compatible read entry point. Existing callers and the 352 read tests keep using it; it
+  // now delegates to dispatch() so read and write ops share one extension point. Keeping it means
+  // the RPC route's current `agentsService.read(...)` call site and all existing tests stay green
+  // while the route can switch to dispatch() without behavior change.
+  async read(op: AgentsReadOp, context: TrustedCallingSession = {}): Promise<unknown> {
+    return this.dispatch(op, context)
+  }
+
+  // host.agents.switch(nameOrNull) — the durable next-message switch lifecycle (issue 05). Delegates
+  // to the standalone SwitchOperation, which reuses the existing SessionBindingService + durable
+  // persistence seam and broadcasts the pending-reconfigure notification through the injected
+  // SwitchNotifier. Fail closed if the durable/binding seams are not configured. The trusted calling
+  // session is threaded from server context; this module never reads a caller-supplied session id.
+  private async runSwitch(
+    params: Record<string, unknown>,
+    context: TrustedCallingSession
+  ): Promise<unknown> {
+    const { approvalGateway, switchNotifier, sessionBinding, persistSessionSpecialist } = this.deps
+    if (!approvalGateway || !switchNotifier || !sessionBinding || !persistSessionSpecialist) {
+      throw new Error(
+        'Operation "switch" is not configured (approval/binding/persistence seams missing)'
+      )
+    }
+    const operation = new SwitchOperation({
+      profileService: this.deps.profileService,
+      sessionBinding,
+      approvalGateway,
+      switchNotifier,
+      persistBinding: persistSessionSpecialist,
+      sequencer: this.switchSequencer
+    })
+    const name = params.name
+    const switchParams: SwitchParams = {
+      ...(typeof name === 'string' || name === null ? { name } : {}),
+      ...(typeof params.revision === 'number' ? { revision: params.revision } : {})
+    }
+    return operation.run(switchParams, context)
+  }
+
+  // Classifies a host.agents.update request and, when the validated patch changes the public `name`,
+  // routes it through the issue-04 privileged-op module (approval gateway + atomic patch). A non-name
+  // update returns `{ handled: false }` so the ordinary-mutation module handles it (chat review is the
+  // only confirmation). design.md §7: there is no public rename(); a name-changing patch makes the
+  // WHOLE patch privileged and atomic.
+  private async runPrivilegedUpdate(
+    params: Record<string, unknown>
+  ): Promise<{ handled: boolean; result?: unknown }> {
+    const patch = params.patch
+    if (!patch || typeof patch !== 'object' || Array.isArray(patch)) {
+      // Malformed patch — let the ordinary module's validation surface the sanitized error.
+      return { handled: false }
+    }
+    const patchRecord = patch as Record<string, unknown>
+    // Reject unknown keys with the SAME allowed-keys view the ordinary update path uses (defect #5).
+    // The privileged path must not silently ignore a forged/malicious field the ordinary path would
+    // reject. This runs BEFORE the name-changing short-circuit so an unknown field is rejected even
+    // when the patch also changes `name`. Allowed keys include the capability fields
+    // (skill_names/connector_names/unrestricted) since this path projects and applies them too.
+    rejectUnknownKeys(patchRecord, UPDATE_ALLOWED_KEYS, 'update')
+    // Build the camelCase SpecialistUpdatePatch the issue-04 module consumes (snake_case wire fields
+    // -> camelCase service fields), then classify with the module's own isNameChangingPatch so the
+    // privilege decision is owned by exactly one rule. The privileged module commits the COMPLETE
+    // patch atomically through ProfileService — including capabilityMode/fullAccess/
+    // selectedCapabilities — so a name-changing patch that ALSO edits skill_names/connector_names (or
+    // switches to unrestricted full access) carries those fields and they are applied in the same
+    // atomic commit. Capability refs are resolved to stable ids via the SAME projection the ordinary
+    // update path uses (no duplicated validation/plumbing).
+    const mapStr = (value: unknown): string | undefined =>
+      typeof value === 'string' ? value : undefined
+    const specialistPatch: SpecialistUpdatePatch = {}
+    const mappedName = mapStr(patchRecord.name)
+    if (mappedName !== undefined) specialistPatch.name = mappedName
+    const displayName = mapStr(patchRecord.display_name) ?? mapStr(patchRecord.displayName)
+    if (displayName !== undefined) specialistPatch.displayName = displayName
+    const description = mapStr(patchRecord.description)
+    if (description !== undefined) specialistPatch.description = description
+    const systemPrompt = mapStr(patchRecord.system_prompt)
+    if (systemPrompt !== undefined) specialistPatch.systemPrompt = systemPrompt
+    const iconKey = mapStr(patchRecord.icon_key)
+    if (iconKey !== undefined) specialistPatch.iconKey = iconKey
+    const colorKey = mapStr(patchRecord.color_key)
+    if (colorKey !== undefined) specialistPatch.colorKey = colorKey
+
+    // `enabled` is accepted on the name-changing patch too (defect #1): validate it is a boolean
+    // here (matching the ordinary path's `enabled must be a boolean.` error) and carry it onto the
+    // specialistPatch so applyNameChangingUpdate can apply it via setEnabled after the atomic rename.
+    // There is no snake_case variant — the contract uses `enabled` on both create and update.
+    if (patchRecord.enabled !== undefined) {
+      if (typeof patchRecord.enabled !== 'boolean') {
+        throw new Error('enabled must be a boolean.')
+      }
+      specialistPatch.enabled = patchRecord.enabled
+    }
+
+    if (!isNameChangingPatch(specialistPatch)) {
+      return { handled: false }
+    }
+
+    const currentName = typeof params.name === 'string' ? params.name : undefined
+    if (!currentName) throw new Error('name is required')
+    const revision = patchRecord.revision
+    if (
+      typeof revision !== 'number' ||
+      !Number.isFinite(revision) ||
+      !Number.isInteger(revision) ||
+      revision <= 0
+    ) {
+      throw new Error('revision must be a positive integer.')
+    }
+
+    // Project capability fields (skill_names/connector_names/unrestricted) so a rename coinciding
+    // with a capability edit applies BOTH atomically. We resolve against the CURRENT profile so an
+    // omitted collection is preserved (matching ordinary partial-patch semantics); the privileged
+    // module re-resolves name -> UUID + revision immediately before committing, so atomicity and the
+    // stale-revision guard still hold. When the patch carries no capability fields, the projection is
+    // empty and we leave the capability fields UNSET (do not force full-access).
+    const current = await this.deps.profileService.getByName(currentName)
+    const capability = await projectCapabilityFields(
+      patchRecord,
+      current,
+      this.mutationCatalog(),
+      'update'
+    )
+    if (capability.capabilityMode !== undefined) {
+      specialistPatch.capabilityMode = capability.capabilityMode
+    }
+    if (capability.fullAccess !== undefined) {
+      specialistPatch.fullAccess = capability.fullAccess
+    }
+    if (capability.selectedCapabilities !== undefined) {
+      specialistPatch.selectedCapabilities = capability.selectedCapabilities
+    }
+
+    const { approvalGateway, invalidateCatalog } = this.deps
+    if (!approvalGateway) {
+      throw new Error('Operation "update" is not configured (approval gateway missing)')
+    }
+    const result = await applyNameChangingUpdate({
+      profileService: this.deps.profileService,
+      decide: (request) => approvalGateway.decide(request),
+      currentName,
+      reviewedRevision: revision,
+      patch: specialistPatch,
+      ...(invalidateCatalog ? { invalidateCatalog } : {})
+    })
+    // A privileged decline is a normal camelCase result (no mutation). An approval returns the actual
+    // post-write Profile read-back; both are returned as-is to the SDK without re-projection.
+    return { handled: true, result }
+  }
+
+  // host.agents.delete(name, { revision }) — privileged (issue 04). Approves via the injected gateway,
+  // re-resolves name -> UUID, verifies the reviewed revision, deletes via ProfileService, verifies
+  // absence, invalidates the catalog, and returns `{ status: "deleted", name }`. Session UUID bindings
+  // are NEVER cleared or rewritten — bound conversations resolve unavailable later (design.md §10).
+  private async runDelete(params: Record<string, unknown>): Promise<unknown> {
+    const { approvalGateway, invalidateCatalog } = this.deps
+    if (!approvalGateway) {
+      throw new Error('Operation "delete" is not configured (approval gateway missing)')
+    }
+    const currentName = typeof params.name === 'string' ? params.name : undefined
+    if (!currentName) throw new Error('name is required')
+    const revision = params.revision
+    if (
+      typeof revision !== 'number' ||
+      !Number.isFinite(revision) ||
+      !Number.isInteger(revision) ||
+      revision <= 0
+    ) {
+      throw new Error('revision must be a positive integer.')
+    }
+    return applyDelete({
+      profileService: this.deps.profileService,
+      decide: (request) => approvalGateway.decide(request),
+      currentName,
+      reviewedRevision: revision,
+      ...(invalidateCatalog ? { invalidateCatalog } : {})
+    })
+  }
+
+  // Returns custom Specialist Profiles only — never synthesizes the Settings-only Reviewer row.
+  async list(): Promise<AgentReadModel[]> {
+    const profiles = await this.deps.profileService.list()
+    return profiles.map(projectAgent)
+  }
+
+  // Resolves the exact public Specialist name to the current Profile and returns a renderer-safe
+  // read model including stable id and revision.
+  async get(params: { name?: unknown }): Promise<AgentReadModel> {
+    const name = asString(params.name)
+    if (!name) throw new Error('name is required')
+    const profile = await this.deps.profileService.getByName(name)
+    return projectAgent(profile)
+  }
+
+  // Returns the complete Specialist-visible skill catalog, including Main-disabled installed
+  // Skills. Optional name_or_id filters to one entry via stable ID first, then unique public name.
+  async listSkills(params: { name_or_id?: unknown }): Promise<SkillCatalogReadModel[]> {
+    const catalog = await this.deps.catalog.listSkillCatalog()
+    const entries = catalog.map((skill) => ({
+      id: skill.id,
+      // Public name: the durable framework-facing name the agent/Skill chip uses.
+      name: skill.frameworkName,
+      displayName: skill.displayName,
+      source: skill.source,
+      mainEnabled: skill.mainEnabled,
+      available: skill.available
+    }))
+    return applyNameOrIdFilter(entries, params.name_or_id, 'list_skills')
+  }
+
+  // Returns public connector information useful for whole-Connector selection: stable id, display
+  // name, description, Main enabled state, authentication/availability state, and safe public tool
+  // information. Never returns credentials, headers, environment values, or connector arguments.
+  async listConnectors(params: { name_or_id?: unknown }): Promise<ConnectorReadModel[]> {
+    const stored = await this.deps.catalog.getConnectors()
+    return applyNameOrIdFilter(this.projectConnectors(stored), params.name_or_id, 'list_connectors')
+  }
+
+  // Shared projection used by both the read slice and the ordinary-mutation module (issue 03), so
+  // the mutation module never duplicates the connector catalog rules. Exported via the standalone
+  // `projectConnectorsFromStored` below.
+  private projectConnectors(stored: StoredConnectors | undefined): ConnectorReadModel[] {
+    return projectConnectorsFromStored(stored)
+  }
+}
+
+// ---------------------------------------------------------------------------
+// Standalone catalog projection + name-or-id resolution
+// ---------------------------------------------------------------------------
+//
+// Exported so the ordinary-mutation module (issue 03) reuses the EXACT same connector projection and
+// name/id ambiguity rules the read slice uses — no duplicated Full/Selected or catalog rules outside
+// this file. Pure functions; no service state.
+
+// Projects the stored connectors document into public read models. Never returns credentials,
+// headers, environment values, or connector arguments.
+export const projectConnectorsFromStored = (
+  stored: StoredConnectors | undefined
+): ConnectorReadModel[] => {
+  const disabled = new Set(stored?.disabledConnectorIds ?? [])
+  const bundled: ConnectorReadModel[] = (CONNECTOR_CATALOG as ConnectorMeta[]).map((meta) => ({
+    id: meta.id,
+    displayName: meta.displayName,
+    description: meta.description,
+    mainEnabled: !disabled.has(meta.id),
+    availability: 'available',
+    source: 'bundled',
+    tools: getConnectorTools(meta.id).map((tool) => ({
+      id: tool.id,
+      description: tool.description
+    }))
+  }))
+
+  const custom: ConnectorReadModel[] = (stored?.customMcpServers ?? []).map((server) => {
+    const unreachable =
+      (server.transport === 'stdio' && !server.command) ||
+      (server.transport !== 'stdio' && !server.url)
+    return {
+      id: server.id,
+      displayName: server.name,
+      description: server.description ?? '',
+      mainEnabled: server.enabled,
+      // Custom MCP servers expose their tools dynamically; we do not enumerate them here (the
+      // milestone decides whole-Connector inclusion only). An empty tools list keeps the shape
+      // consistent without leaking transport/command details.
+      availability: unreachable ? 'unavailable' : 'available',
+      source: 'custom',
+      tools: []
+    }
+  })
+
+  return [...bundled, ...custom]
+}
+
+// ---------------------------------------------------------------------------
+// name-or-id resolution (shared by the catalog reads AND the mutation module)
+// ---------------------------------------------------------------------------
+
+type Nameable = { id: string; name?: string; displayName?: string }
+
+export function applyNameOrIdFilter<T extends Nameable>(
+  entries: T[],
+  nameOrId: unknown,
+  method: string
+): T[] {
+  const ref = asString(nameOrId)
+  if (!ref) return entries
+
+  // 1. Exact stable ID wins.
+  const byId = entries.filter((entry) => entry.id === ref)
+  if (byId.length > 0) return byId
+
+  // 2. Otherwise match a unique public name (name, then display name).
+  const byName = entries.filter((entry) => entry.name === ref || entry.displayName === ref)
+  if (byName.length === 0) {
+    throw new Error(
+      `No catalog entry matches "${ref}". Use the stable id from list_skills/list_connectors.`
+    )
+  }
+  if (byName.length > 1) {
+    // Ambiguous public name: instruct the caller to use the stable id instead of guessing.
+    const ids = byName.map((entry) => entry.id).join(', ')
+    throw new Error(
+      `Multiple catalog entries match name "${ref}" (${ids}). Use the stable id from ${method} instead.`
+    )
+  }
+  return byName
+}

--- a/src/main/agents/customize/fake-host-agents.ts
+++ b/src/main/agents/customize/fake-host-agents.ts
@@ -1,0 +1,427 @@
+// A faithful fake `host.agents` SDK for the customize Skill contract tests.
+//
+// The real SDK lives in the control-plane REPL and is wired by issue 08. This fake implements the
+// FULL public surface from design.md §4 / PRD §2 against in-memory state, so the customize Skill's
+// workflow tests can exercise create/read/ordinary-update/capability-update/name-changing-update/
+// delete/switch with the snake_case-write / camelCase-return contract, the monotonic revision, the
+// structured decline result, and the sanitized `host.agents.<method>:` errors — without depending on
+// the not-yet-built mutation modules (issues 03/04/05).
+//
+// The fake is intentionally faithful to the CONTRACT, not to ProfileService internals: it owns its
+// own minimal profile records and catalogs. Behavior mirrors the rules in design.md §5 (capability
+// semantics), §8 (revision + read-back), §10 (delete leaves bindings unavailable).
+
+import type { AgentReadModel, ConnectorReadModel, SkillCatalogReadModel } from '../agents-service'
+
+// ---------------------------------------------------------------------------
+// Internal fake state (snake_case write side; camelCase read models mirror the real SDK)
+// ---------------------------------------------------------------------------
+
+export type FakeProfileRecord = {
+  id: string
+  name: string
+  description: string
+  systemPrompt: string
+  iconKey?: string
+  colorKey?: string
+  enabled: boolean
+  unrestricted: boolean
+  skillIds: string[]
+  connectorIds: string[]
+  revision: number
+}
+
+export type FakeSkillCatalogEntry = SkillCatalogReadModel
+export type FakeConnectorCatalogEntry = ConnectorReadModel
+
+export type FakeHostAgentsOptions = {
+  profiles?: FakeProfileRecord[]
+  skills?: FakeSkillCatalogEntry[]
+  connectors?: FakeConnectorCatalogEntry[]
+  // Injected approval gateway + switch notifier, mirroring AgentsServiceDeps. Production wires the
+  // real ACP broker; the customize Skill tests wire a recording fake.
+  approvalGateway?: {
+    decide: (request: {
+      operation: 'update' | 'delete' | 'switch'
+      summary: { name?: string; newName?: string; target?: string | null }
+    }) => Promise<{ status: 'approved' | 'declined'; reason?: string }>
+  }
+  switchNotifier?: { notify: (pending: { sessionId: string; targetName: string | null }) => void }
+  // The trusted calling session captured outside the sandbox. switch() targets this only.
+  callingSession?: { sessionId: string }
+}
+
+const METHOD_PREFIX = 'host.agents'
+
+const agentsError = (method: string, message: string): Error => {
+  const error = new Error(`${METHOD_PREFIX}.${method}: ${message}`)
+  error.name = 'AgentsCallError'
+  return error
+}
+
+const clone = <T>(value: T): T =>
+  typeof structuredClone === 'function'
+    ? structuredClone(value)
+    : (JSON.parse(JSON.stringify(value)) as T)
+
+// ---------------------------------------------------------------------------
+// The fake SDK
+// ---------------------------------------------------------------------------
+
+export class FakeHostAgents {
+  private profiles: Map<string, FakeProfileRecord> = new Map()
+  private readonly skills: FakeSkillCatalogEntry[]
+  private readonly connectors: FakeConnectorCatalogEntry[]
+  private readonly approvalGateway?: FakeHostAgentsOptions['approvalGateway']
+  private readonly switchNotifier?: FakeHostAgentsOptions['switchNotifier']
+  private readonly callingSession: { sessionId: string }
+  // The persisted pending-switch binding; switch() mutates this and takes effect "on the next
+  // message". Mirrors design.md §9.
+  private binding: { sessionId: string; targetName: string | null } | undefined
+  private nextId = 1
+
+  constructor(options: FakeHostAgentsOptions = {}) {
+    for (const profile of options.profiles ?? []) {
+      this.profiles.set(profile.name, clone(profile))
+    }
+    this.skills = options.skills ? clone(options.skills) : []
+    this.connectors = options.connectors ? clone(options.connectors) : []
+    this.approvalGateway = options.approvalGateway
+    this.switchNotifier = options.switchNotifier
+    this.callingSession = options.callingSession ?? { sessionId: 'session-1' }
+  }
+
+  // ----- read models (camelCase) -------------------------------------------------
+
+  // Validates that every supplied Skill/Connector reference resolves against the live catalog
+  // (exact stable id first, otherwise unique public name). Mirrors the real catalog resolution so
+  // the customize Skill's review reflects only attachable references. design.md §4.
+  private validateCatalogRefs(
+    skillNames: string[],
+    connectorNames: string[],
+    method: string
+  ): void {
+    for (const ref of skillNames) {
+      if (!this.skills.some((s) => s.id === ref || s.name === ref || s.displayName === ref)) {
+        throw agentsError(method, `Unknown skill reference "${ref}"`)
+      }
+    }
+    for (const ref of connectorNames) {
+      if (!this.connectors.some((c) => c.id === ref || c.displayName === ref)) {
+        throw agentsError(method, `Unknown connector reference "${ref}"`)
+      }
+    }
+  }
+
+  private project(profile: FakeProfileRecord): AgentReadModel {
+    return {
+      id: profile.id,
+      name: profile.name,
+      displayName: profile.name,
+      description: profile.description,
+      systemPrompt: profile.systemPrompt,
+      iconKey: profile.iconKey,
+      colorKey: profile.colorKey,
+      enabled: profile.enabled,
+      capabilityMode: profile.unrestricted ? 'full' : 'selected',
+      fullAccess: {
+        excludedSkillIds: [],
+        excludedConnectorIds: [],
+        connectorTools: []
+      },
+      selectedCapabilities: {
+        skillIds: profile.skillIds,
+        connectorIds: profile.connectorIds,
+        connectorTools: []
+      },
+      revision: profile.revision
+    }
+  }
+
+  // ----- public read surface -----------------------------------------------------
+
+  async list(): Promise<AgentReadModel[]> {
+    return Array.from(this.profiles.values())
+      .sort((a, b) => a.name.localeCompare(b.name))
+      .map((profile) => this.project(profile))
+  }
+
+  async get(name: string): Promise<AgentReadModel> {
+    const profile = this.profiles.get(name)
+    if (!profile) throw agentsError('get', `Specialist "${name}" not found.`)
+    return this.project(profile)
+  }
+
+  async list_skills(nameOrId?: string): Promise<FakeSkillCatalogEntry[]> {
+    if (!nameOrId) return clone(this.skills)
+    return applyNameOrIdFilter(this.skills, nameOrId, 'list_skills')
+  }
+
+  async list_connectors(nameOrId?: string): Promise<FakeConnectorCatalogEntry[]> {
+    if (!nameOrId) return clone(this.connectors)
+    return applyNameOrIdFilter(this.connectors, nameOrId, 'list_connectors')
+  }
+
+  // ----- create ------------------------------------------------------------------
+
+  async create(input: {
+    name: string
+    description?: string
+    system_prompt?: string
+    icon_key?: string
+    color_key?: string
+    enabled?: boolean
+    unrestricted?: boolean
+    skill_names?: string[]
+    connector_names?: string[]
+  }): Promise<AgentReadModel> {
+    const method = 'create'
+    const name = input.name
+    if (!name || typeof name !== 'string') throw agentsError(method, 'name is required')
+    if (this.profiles.has(name)) throw agentsError(method, `Specialist "${name}" already exists`)
+
+    const hasSkillNames = input.skill_names !== undefined
+    const hasConnectorNames = input.connector_names !== undefined
+    // design.md §5: omit both arrays => Full; supply either => Selected (omitted other => empty).
+    const unrestricted =
+      (input.unrestricted ?? !(hasSkillNames || hasConnectorNames)) ? true : false
+
+    const skillNames = input.skill_names ?? (unrestricted ? [] : [])
+    const connectorNames = input.connector_names ?? (unrestricted ? [] : [])
+    this.validateCatalogRefs(skillNames, connectorNames, method)
+
+    const record: FakeProfileRecord = {
+      id: `sp-${this.nextId++}`,
+      name,
+      description: input.description ?? '',
+      systemPrompt: input.system_prompt ?? '',
+      iconKey: input.icon_key,
+      colorKey: input.color_key,
+      enabled: input.enabled ?? true,
+      unrestricted,
+      skillIds: skillNames,
+      connectorIds: connectorNames,
+      revision: 1
+    }
+    this.profiles.set(name, record)
+    return this.project(record)
+  }
+
+  // ----- ordinary + name-changing update -----------------------------------------
+
+  async update(
+    name: string,
+    patch: {
+      name?: string
+      description?: string
+      system_prompt?: string
+      icon_key?: string
+      color_key?: string
+      enabled?: boolean
+      unrestricted?: boolean
+      skill_names?: string[]
+      connector_names?: string[]
+      revision?: number
+    }
+  ): Promise<AgentReadModel> {
+    const method = 'update'
+    const existing = this.profiles.get(name)
+    if (!existing) throw agentsError(method, `Specialist "${name}" not found.`)
+
+    // design.md §8: carry the reviewed revision; stale => fail without merge/retry.
+    if (patch.revision !== undefined && patch.revision !== existing.revision) {
+      throw agentsError(method, 'stale revision — re-read and review again')
+    }
+
+    const isNameChange = patch.name !== undefined && patch.name !== name
+    if (isNameChange) {
+      // design.md §4/§7: a name change makes the WHOLE patch privileged. The standard permission card
+      // is the single authorization point; approve => apply atomically, decline => no change.
+      const decision = await this.approvalGateway?.decide({
+        operation: 'update',
+        summary: { name, newName: patch.name }
+      })
+      if (decision?.status === 'declined') {
+        return {
+          status: 'declined',
+          operation: 'update',
+          reason: decision.reason
+        } as unknown as AgentReadModel
+      }
+      // Re-resolve target name + revision after approval (design.md §8).
+      if (this.profiles.has(patch.name!)) {
+        throw agentsError(method, `Specialist "${patch.name}" already exists`)
+      }
+    }
+
+    const next: FakeProfileRecord = { ...existing }
+    next.name = patch.name ?? next.name
+    next.description = patch.description ?? next.description
+    next.systemPrompt = patch.system_prompt ?? next.systemPrompt
+    next.iconKey = patch.icon_key ?? next.iconKey
+    next.colorKey = patch.color_key ?? next.colorKey
+    next.enabled = patch.enabled ?? next.enabled
+
+    // design.md §5 capability semantics for update.
+    if (patch.unrestricted === true) {
+      next.unrestricted = true // switch to Full, preserve stored Selected config
+    } else if (patch.skill_names !== undefined || patch.connector_names !== undefined) {
+      // Supplying a collection exactly replaces it and switches to Selected; omitted is preserved.
+      next.unrestricted = false
+      next.skillIds = patch.skill_names ?? next.skillIds
+      next.connectorIds = patch.connector_names ?? next.connectorIds
+    }
+    this.validateCatalogRefs(next.skillIds, next.connectorIds, method)
+
+    next.revision = existing.revision + 1
+    if (isNameChange) {
+      this.profiles.delete(name)
+    }
+    this.profiles.set(next.name, next)
+    return this.project(next)
+  }
+
+  // ----- incremental attach/detach (single-collection, does not change mode) -----
+
+  async attach_skill(
+    name: string,
+    skillRef: string,
+    options: { revision?: number } = {}
+  ): Promise<AgentReadModel> {
+    return this.mutateCollection(name, 'skill', skillRef, 'attach', options.revision)
+  }
+
+  async detach_skill(
+    name: string,
+    skillRef: string,
+    options: { revision?: number } = {}
+  ): Promise<AgentReadModel> {
+    return this.mutateCollection(name, 'skill', skillRef, 'detach', options.revision)
+  }
+
+  async attach_connector(
+    name: string,
+    connectorRef: string,
+    options: { revision?: number } = {}
+  ): Promise<AgentReadModel> {
+    return this.mutateCollection(name, 'connector', connectorRef, 'attach', options.revision)
+  }
+
+  async detach_connector(
+    name: string,
+    connectorRef: string,
+    options: { revision?: number } = {}
+  ): Promise<AgentReadModel> {
+    return this.mutateCollection(name, 'connector', connectorRef, 'detach', options.revision)
+  }
+
+  private mutateCollection(
+    name: string,
+    kind: 'skill' | 'connector',
+    ref: string,
+    action: 'attach' | 'detach',
+    revision: number | undefined
+  ): AgentReadModel {
+    const method = `${action}_${kind}`
+    const existing = this.profiles.get(name)
+    if (!existing) throw agentsError(method, `Specialist "${name}" not found.`)
+    if (revision !== undefined && revision !== existing.revision) {
+      throw agentsError(method, 'stale revision — re-read and review again')
+    }
+    const collection = kind === 'skill' ? existing.skillIds : existing.connectorIds
+    if (existing.unrestricted) {
+      // Full mode: attach removes an exclusion (no-op here, no exclusions stored); detach adds one.
+      // We model Full with no exclusions, so attach is a no-op and detach is rejected as it would
+      // require storing an exclusion the fake does not model. Ordinary update({unrestricted}) is the
+      // documented path for mode switches.
+      if (action === 'detach') {
+        throw agentsError(method, 'detach in Full mode is not supported by this fake')
+      }
+    } else {
+      const index = collection.indexOf(ref)
+      if (action === 'attach' && index === -1) collection.push(ref)
+      if (action === 'detach' && index !== -1) collection.splice(index, 1)
+    }
+    existing.revision += 1
+    return this.project(existing)
+  }
+
+  // ----- delete ------------------------------------------------------------------
+
+  async delete(
+    name: string,
+    options: { revision?: number } = {}
+  ): Promise<{ status: 'deleted'; name: string } | { status: 'declined'; operation: 'delete' }> {
+    const method = 'delete'
+    const existing = this.profiles.get(name)
+    if (!existing) throw agentsError(method, `Specialist "${name}" not found.`)
+    if (options.revision !== undefined && options.revision !== existing.revision) {
+      throw agentsError(method, 'stale revision — re-read and review again')
+    }
+    // design.md §10 / PRD §9: delete is privileged. The card is the single authorization point.
+    const decision = await this.approvalGateway?.decide({
+      operation: 'delete',
+      summary: { name }
+    })
+    if (decision?.status === 'declined') {
+      return { status: 'declined', operation: 'delete' }
+    }
+    this.profiles.delete(name)
+    // design.md §10: existing session bindings are NOT rewritten; they resolve unavailable.
+    return { status: 'deleted', name }
+  }
+
+  // ----- switch ------------------------------------------------------------------
+
+  async switch(
+    nameOrNull: string | null
+  ): Promise<
+    | { status: 'switched'; sessionBinding: { sessionId: string; targetName: string | null } }
+    | { status: 'declined'; operation: 'switch' }
+  > {
+    const method = 'switch'
+    if (nameOrNull !== null) {
+      const existing = this.profiles.get(nameOrNull)
+      if (!existing) throw agentsError(method, `Specialist "${nameOrNull}" not found.`)
+    }
+    // design.md §7/§9: switch is privileged; explain the impending action then invoke the SDK.
+    const decision = await this.approvalGateway?.decide({
+      operation: 'switch',
+      summary: { target: nameOrNull }
+    })
+    if (decision?.status === 'declined') {
+      return { status: 'declined', operation: 'switch' }
+    }
+    // design.md §9: persist immediately; takes effect on the next message (not this reply).
+    this.binding = { sessionId: this.callingSession.sessionId, targetName: nameOrNull }
+    this.switchNotifier?.notify(this.binding)
+    return { status: 'switched', sessionBinding: this.binding }
+  }
+
+  // ----- test helpers ------------------------------------------------------------
+
+  getPendingBinding(): { sessionId: string; targetName: string | null } | undefined {
+    return this.binding ? clone(this.binding) : undefined
+  }
+}
+
+// ---------------------------------------------------------------------------
+// Shared name-or-id resolution (mirrors the real catalog read contract)
+// ---------------------------------------------------------------------------
+
+function applyNameOrIdFilter<T extends { id: string; name?: string; displayName?: string }>(
+  entries: T[],
+  ref: string,
+  method: string
+): T[] {
+  const byId = entries.filter((entry) => entry.id === ref)
+  if (byId.length > 0) return clone(byId)
+  const byName = entries.filter((entry) => entry.name === ref || entry.displayName === ref)
+  if (byName.length === 0) {
+    throw agentsError(method, `No catalog entry matches "${ref}".`)
+  }
+  if (byName.length > 1) {
+    throw agentsError(method, `Multiple catalog entries match "${ref}".`)
+  }
+  return clone(byName)
+}

--- a/src/main/agents/customize/workflow.test.ts
+++ b/src/main/agents/customize/workflow.test.ts
@@ -1,0 +1,638 @@
+// Customize Skill workflow contract tests.
+//
+// These tests drive the `/customize` workflow against a FAKE `host.agents` (issue 02's contract). They
+// encode the review/approval/read-back rules from design.md §7/§8/§9/§10 and the confirmation
+// boundaries from PRD §6. The real SDK is wired by issue 08; this issue authorizes the Skill source
+// and proves the conversational policy against a stable fake.
+
+import { join } from 'node:path'
+import { readFile } from 'node:fs/promises'
+
+import { describe, expect, it } from 'vitest'
+
+import { FakeHostAgents, type FakeProfileRecord } from './fake-host-agents'
+import type { ConnectorReadModel } from '../agents-service'
+import type { ApprovalResult } from '../../../shared/agents-contract'
+import {
+  buildReviewedTarget,
+  draftChangedSinceConfirmation,
+  explainDelete,
+  explainNameChange,
+  explainSwitch,
+  isExplicitConfirmation,
+  isStaleRevision,
+  mustAskForScope,
+  preferAtomicUpdate,
+  renderOrdinaryReview,
+  reportDelete,
+  reportSwitch,
+  requiresSystemPermissionCard,
+  requiresTextualConfirmation,
+  resolveCreateScope,
+  SCOPE_CLARIFICATION
+} from './workflow'
+
+// ---------------------------------------------------------------------------
+// Fixtures
+// ---------------------------------------------------------------------------
+
+const demoProfile = (overrides: Partial<FakeProfileRecord> = {}): FakeProfileRecord => ({
+  id: 'sp-1',
+  name: 'Bio Expert',
+  description: 'a specialist',
+  systemPrompt: 'You are a bio expert.',
+  iconKey: 'beaker',
+  colorKey: 'green',
+  enabled: true,
+  unrestricted: false,
+  skillIds: ['skill-a'],
+  connectorIds: ['conn-a'],
+  revision: 1,
+  ...overrides
+})
+
+const skills = [
+  {
+    id: 'skill-a',
+    name: 'skill-a',
+    displayName: 'Skill A',
+    source: 'featured',
+    mainEnabled: true,
+    available: true
+  },
+  {
+    id: 'skill-b',
+    name: 'skill-b',
+    displayName: 'Skill B',
+    source: 'featured',
+    mainEnabled: true,
+    available: true
+  }
+]
+
+const connectors: ConnectorReadModel[] = [
+  {
+    id: 'conn-a',
+    displayName: 'Chemistry',
+    description: 'chemistry connector',
+    mainEnabled: true,
+    availability: 'available',
+    source: 'bundled',
+    tools: [{ id: 'search', description: 'search' }]
+  }
+]
+
+// A recording approval gateway fake. Tests configure approve/decline and assert what the Skill asked.
+const recordingGateway = (
+  decision: 'approved' | 'declined'
+): {
+  decide: (request: {
+    operation: 'update' | 'delete' | 'switch'
+    summary: { name?: string; newName?: string; target?: string | null }
+  }) => Promise<ApprovalResult>
+  decisions: Array<Record<string, unknown>>
+} => {
+  const decisions: Array<Record<string, unknown>> = []
+  const decide = async (
+    request: {
+      operation: 'update' | 'delete' | 'switch'
+      summary: { name?: string; newName?: string; target?: string | null }
+    } & Record<string, unknown>
+  ): Promise<ApprovalResult> => {
+    decisions.push(request)
+    return decision === 'approved'
+      ? { status: 'approved' }
+      : { status: 'declined', operation: request.operation }
+  }
+  return { decide, decisions }
+}
+
+const switchNotifications: Array<{ sessionId: string; targetName: string | null }> = []
+const switchNotifier = {
+  notify: (pending: { sessionId: string; targetName: string | null }): void => {
+    switchNotifications.push(pending)
+  }
+}
+
+const makeSdk = (
+  options: {
+    profiles?: FakeProfileRecord[]
+    approvalGateway?: ReturnType<typeof recordingGateway>
+  } = {}
+): FakeHostAgents =>
+  new FakeHostAgents({
+    profiles: options.profiles ?? [demoProfile()],
+    skills,
+    connectors,
+    approvalGateway: options.approvalGateway,
+    switchNotifier,
+    callingSession: { sessionId: 'session-1' }
+  })
+
+describe('customize Skill: bundled source', () => {
+  const skillPath = join(
+    __dirname,
+    '..',
+    '..',
+    '..',
+    '..',
+    'resources',
+    'skills',
+    'customize',
+    'SKILL.md'
+  )
+
+  it('ships a SKILL.md with public name customize', async () => {
+    const raw = await readFile(skillPath, 'utf8')
+    expect(raw).toMatch(/^---[\s\S]*?^name:\s*customize$/m)
+  })
+
+  it('documents the host.agents SDK surface', async () => {
+    const raw = await readFile(skillPath, 'utf8')
+    for (const method of [
+      'host.agents.list(',
+      'host.agents.get(',
+      'host.agents.create(',
+      'host.agents.update(',
+      'host.agents.switch(',
+      'host.agents.delete(',
+      'host.agents.list_skills(',
+      'host.agents.list_connectors('
+    ]) {
+      expect(raw).toContain(method)
+    }
+  })
+
+  it('is activated in the Featured manifest (issue 08 turns on the live journey)', async () => {
+    const manifestRaw = await readFile(
+      join(__dirname, '..', '..', '..', '..', 'resources', 'skills', 'manifest.json'),
+      'utf8'
+    )
+    const manifest = JSON.parse(manifestRaw) as { skills: Array<{ id: string; name: string }> }
+    const entry = manifest.skills.find((skill) => skill.id === 'customize')
+    expect(entry).toBeDefined()
+    // The Featured entry ships under the Title Case display name, matching every other bundled
+    // skill's naming style. Activation identity (manifest id === SKILL.md frontmatter name) is
+    // guarded separately by the bundled-skill nudge-identity suite.
+    expect(entry?.name).toBe('Customize')
+  })
+})
+
+describe('customize Skill: static rejection of forbidden architecture', () => {
+  const skillPath = join(
+    __dirname,
+    '..',
+    '..',
+    '..',
+    '..',
+    'resources',
+    'skills',
+    'customize',
+    'SKILL.md'
+  )
+
+  const forbidden = [
+    {
+      label: 'python SDK',
+      needle: /host\.agents.*python|python.*host\.agents/is,
+      except: /do not use python/i
+    },
+    {
+      label: 'host.skills namespace',
+      needle: /\bhost\.skills\./,
+      except: /do not (use|call).*host\.skills|never.*host\.skills/i
+    },
+    {
+      label: 'management MCP',
+      needle: /management mcp|host\.mcp\(\).*agents/i,
+      except: /do not.*management mcp|never.*host\.mcp/i
+    },
+    {
+      label: 'Customize Profile',
+      needle: /customize (specialist\/)?profile/i,
+      except: /do not.*customize profile|no customize profile/i
+    },
+    {
+      label: 'Skill authoring',
+      needle: /\bauthor (a |skills|new skills)\b/i,
+      except: /do not.*author skills|no skill authoring/i
+    },
+    {
+      label: 'duplicate operations',
+      needle: /deduplicate|duplicate (specialist|operation)/i,
+      except: /do not.*duplicate|no duplicate/i
+    },
+    {
+      label: 'per-Specialist environments',
+      needle: /per-specialist environment/i,
+      except: /no per-specialist environment|do not.*per-specialist/i
+    },
+    {
+      label: 'automatic retry',
+      needle: /retry (the )?(declined|stale|privileged)/i,
+      except: /do not.*retry|never.*retry|no automatic retry/i
+    },
+    {
+      label: 'hard-isolation claim',
+      needle: /hard (security )?isolation|secure boundary/i,
+      except: /not a (hard )?security boundary|workflow guidance/i
+    }
+  ]
+
+  // Reads the body once and asserts that every forbidden concept, when present, appears only inside a
+  // sentence that explicitly negates it (do not / never / no / not). The Skill may name what to avoid,
+  // but must never prescribe the forbidden architecture as a positive instruction.
+  it('does not prescribe forbidden architecture', async () => {
+    const body = await readFile(skillPath, 'utf8')
+    // Split into sentences on period + newline boundaries, keeping a little context for list items.
+    const sentences = body.split(/(?<=\.)\s+|\n+/)
+    const negation =
+      /\b(do not|don't|never|must not|no |not |not configured|absent|forbidden|without|do not use|do not look|are not|is not)\b/i
+    for (const rule of forbidden) {
+      const hits = sentences.filter((sentence) => new RegExp(rule.needle, 'i').test(sentence))
+      for (const hit of hits) {
+        if (!negation.test(hit)) {
+          throw new Error(
+            `forbidden "${rule.label}" prescribed without negation in: "${hit.trim()}"`
+          )
+        }
+      }
+    }
+  })
+
+  it('uses only JavaScript host.agents (no python data-kernel access)', async () => {
+    const body = await readFile(skillPath, 'utf8')
+    // The Skill must state it operates in the JavaScript control-plane REPL only.
+    expect(body.toLowerCase()).toMatch(/javascript/)
+  })
+})
+
+describe('customize Skill: scope clarification', () => {
+  it('asks for Full or Selected when scope is unspecified and never silently grants Full', () => {
+    expect(resolveCreateScope({})).toBe('unspecified')
+    expect(mustAskForScope('unspecified')).toBe(true)
+    expect(SCOPE_CLARIFICATION).toMatch(/full access/i)
+    expect(SCOPE_CLARIFICATION).toMatch(/selected/i)
+    expect(SCOPE_CLARIFICATION).toMatch(/not assume full/i)
+  })
+
+  it('treats explicit full or supplied arrays as decided', () => {
+    expect(resolveCreateScope({ unrestricted: true })).toBe('full')
+    expect(resolveCreateScope({ skill_names: ['skill-a'] })).toBe('selected')
+    expect(resolveCreateScope({ connector_names: ['conn-a'] })).toBe('selected')
+  })
+})
+
+describe('customize Skill: live read + complete draft', () => {
+  it('reads live Profiles plus Skill/Connector catalogs before proposing a target state', async () => {
+    const sdk = makeSdk()
+    const [profile] = await sdk.list()
+    const skillCatalog = await sdk.list_skills()
+    const connectorCatalog = await sdk.list_connectors()
+    expect(profile.name).toBe('Bio Expert')
+    expect(skillCatalog.map((entry) => entry.id)).toContain('skill-a')
+    expect(connectorCatalog.map((entry) => entry.id)).toContain('conn-a')
+    const target = buildReviewedTarget(profile)
+    expect(target.capabilityMode).toBe('selected')
+  })
+
+  it('ordinary review shows every required field and tool-scope absence', () => {
+    const target = buildReviewedTarget({
+      id: 'sp-1',
+      name: 'Bio Expert',
+      displayName: 'Bio Expert',
+      description: 'a specialist',
+      systemPrompt: 'FULL INSTRUCTIONS',
+      iconKey: 'beaker',
+      colorKey: 'green',
+      enabled: true,
+      capabilityMode: 'selected',
+      fullAccess: { excludedSkillIds: [], excludedConnectorIds: [], connectorTools: [] },
+      selectedCapabilities: { skillIds: ['skill-a'], connectorIds: ['conn-a'], connectorTools: [] },
+      revision: 1
+    })
+    const review = renderOrdinaryReview(target, ['description'])
+    for (const required of [
+      'Name: Bio Expert',
+      'Description: a specialist',
+      'Full system instructions:',
+      'FULL INSTRUCTIONS',
+      'Icon: beaker',
+      'Color: green',
+      'Enabled: yes',
+      'Mode: selected',
+      'Skills: skill-a',
+      'Connectors: conn-a',
+      'Connector tool scope: not configured'
+    ]) {
+      expect(review).toContain(required)
+    }
+    expect(review).toContain('Changed fields: description')
+  })
+})
+
+describe('customize Skill: revision + stale-draft handling', () => {
+  it('a stale revision invalidates confirmation and requires a fresh read/review', () => {
+    expect(isStaleRevision(1, 2)).toBe(true)
+    expect(isStaleRevision(2, 2)).toBe(false)
+  })
+
+  it('a changed draft invalidates prior confirmation', () => {
+    expect(draftChangedSinceConfirmation({ a: 1 }, undefined)).toBe(true)
+    expect(draftChangedSinceConfirmation({ a: 1 }, { a: 1 })).toBe(false)
+    expect(draftChangedSinceConfirmation({ a: 2 }, { a: 1 })).toBe(true)
+  })
+
+  it('update with a stale revision fails without merge or retry', async () => {
+    const sdk = makeSdk()
+    await expect(
+      sdk.update('Bio Expert', { description: 'changed', revision: 99 })
+    ).rejects.toThrow(/host\.agents\.update:.*stale revision/i)
+  })
+})
+
+describe('customize Skill: atomic update preference', () => {
+  it('multi-field ordinary change produces one atomic update patch', () => {
+    const live = buildReviewedTarget({
+      id: 'sp-1',
+      name: 'Bio Expert',
+      displayName: 'Bio Expert',
+      description: 'old',
+      systemPrompt: 'old prompt',
+      iconKey: 'beaker',
+      colorKey: 'green',
+      enabled: true,
+      capabilityMode: 'selected',
+      fullAccess: { excludedSkillIds: [], excludedConnectorIds: [], connectorTools: [] },
+      selectedCapabilities: { skillIds: ['skill-a'], connectorIds: ['conn-a'], connectorTools: [] },
+      revision: 1
+    })
+    const target: typeof live = {
+      ...live,
+      description: 'new',
+      systemPrompt: 'new prompt',
+      skillIds: ['skill-a', 'skill-b']
+    }
+    const plan = preferAtomicUpdate(target, live)
+    expect(plan.kind).toBe('atomic-update')
+    expect(plan.patch.description).toBe('new')
+    expect(plan.patch.system_prompt).toBe('new prompt')
+    expect(plan.patch.skill_names).toEqual(['skill-a', 'skill-b'])
+    // connector unchanged => not present in patch
+    expect(plan.patch.connector_names).toBeUndefined()
+  })
+
+  it('applies the atomic patch in a single update call that returns read-back', async () => {
+    const sdk = makeSdk()
+    const before = await sdk.get('Bio Expert')
+    const plan = preferAtomicUpdate(
+      { ...buildReviewedTarget(before), description: 'updated description' },
+      buildReviewedTarget(before)
+    )
+    const result = await sdk.update('Bio Expert', { ...plan.patch, revision: before.revision })
+    expect(result.description).toBe('updated description')
+    expect(result.revision).toBe(before.revision + 1)
+  })
+})
+
+describe('customize Skill: confirmation boundaries', () => {
+  it('create and ordinary update require textual confirmation, not a system card', () => {
+    expect(requiresTextualConfirmation('create')).toBe(true)
+    expect(requiresTextualConfirmation('ordinary-update')).toBe(true)
+    expect(requiresSystemPermissionCard('create')).toBe(false)
+    expect(requiresSystemPermissionCard('ordinary-update')).toBe(false)
+  })
+
+  it('name-changing update, delete, switch use the system card as the only authorization point', () => {
+    expect(requiresSystemPermissionCard('name-changing-update')).toBe(true)
+    expect(requiresSystemPermissionCard('delete')).toBe(true)
+    expect(requiresSystemPermissionCard('switch')).toBe(true)
+    expect(requiresTextualConfirmation('name-changing-update')).toBe(false)
+    expect(requiresTextualConfirmation('delete')).toBe(false)
+    expect(requiresTextualConfirmation('switch')).toBe(false)
+  })
+
+  it('recognizes explicit textual confirmation', () => {
+    expect(isExplicitConfirmation('yes')).toBe(true)
+    expect(isExplicitConfirmation('Confirm')).toBe(true)
+    expect(isExplicitConfirmation('no, wait')).toBe(false)
+  })
+})
+
+describe('customize Skill: create read-back', () => {
+  it('creates with explicit selected arrays and reads back', async () => {
+    const sdk = makeSdk({ profiles: [] })
+    const created = await sdk.create({
+      name: 'New',
+      description: 'd',
+      system_prompt: 'p',
+      skill_names: ['skill-a'],
+      connector_names: ['conn-a']
+    })
+    expect(created.capabilityMode).toBe('selected')
+    expect(created.selectedCapabilities.skillIds).toEqual(['skill-a'])
+    // read-back via get
+    const readBack = await sdk.get('New')
+    expect(readBack.name).toBe('New')
+    expect(readBack.revision).toBe(1)
+  })
+})
+
+describe('customize Skill: capability update read-back', () => {
+  it('update to Full preserves selected config, update to Selected replaces supplied collection', async () => {
+    const sdk = makeSdk()
+    const before = await sdk.get('Bio Expert')
+    const toFull = await sdk.update('Bio Expert', { unrestricted: true, revision: before.revision })
+    expect(toFull.capabilityMode).toBe('full')
+    // switching back to Selected with a new skill set
+    const toSelected = await sdk.update('Bio Expert', {
+      skill_names: ['skill-b'],
+      revision: toFull.revision
+    })
+    expect(toSelected.capabilityMode).toBe('selected')
+    expect(toSelected.selectedCapabilities.skillIds).toEqual(['skill-b'])
+  })
+})
+
+describe('customize Skill: stale re-review', () => {
+  it('re-reads and rebuilds the draft when the revision changed mid-review', async () => {
+    const sdk = makeSdk()
+    const firstRead = await sdk.get('Bio Expert')
+    // a concurrent mutation bumps the revision
+    await sdk.update('Bio Expert', { enabled: false, revision: firstRead.revision })
+    // the stale revision the Skill carried must fail closed
+    await expect(
+      sdk.update('Bio Expert', { description: 'late edit', revision: firstRead.revision })
+    ).rejects.toThrow(/stale revision/i)
+    // the Skill re-reads and reviews again
+    const fresh = await sdk.get('Bio Expert')
+    expect(fresh.revision).toBe(firstRead.revision + 1)
+  })
+})
+
+describe('customize Skill: approved privileged operations', () => {
+  it('approved name-changing update applies atomically via the system card', async () => {
+    const gateway = recordingGateway('approved')
+    const sdk = makeSdk({ approvalGateway: gateway })
+    const before = await sdk.get('Bio Expert')
+    const result = await sdk.update('Bio Expert', {
+      name: 'Renamed',
+      description: 'new desc',
+      revision: before.revision
+    })
+    expect(result.name).toBe('Renamed')
+    expect(result.description).toBe('new desc')
+    expect(gateway.decisions[0]).toMatchObject({ operation: 'update' })
+    expect(gateway.decisions[0].summary).toMatchObject({ name: 'Bio Expert', newName: 'Renamed' })
+    // old name no longer resolves
+    await expect(sdk.get('Bio Expert')).rejects.toThrow(/not found/i)
+  })
+
+  it('approved delete removes the profile', async () => {
+    const gateway = recordingGateway('approved')
+    const sdk = makeSdk({ approvalGateway: gateway })
+    const before = await sdk.get('Bio Expert')
+    const result = await sdk.delete('Bio Expert', { revision: before.revision })
+    expect(result.status).toBe('deleted')
+    await expect(sdk.get('Bio Expert')).rejects.toThrow(/not found/i)
+  })
+
+  it('approved switch persists a next-message binding', async () => {
+    switchNotifications.length = 0
+    const gateway = recordingGateway('approved')
+    const sdk = makeSdk({ approvalGateway: gateway })
+    const result = (await sdk.switch('Bio Expert')) as {
+      status: 'switched'
+      sessionBinding: { sessionId: string; targetName: string | null }
+    }
+    expect(result.status).toBe('switched')
+    expect(result.sessionBinding).toMatchObject({
+      sessionId: 'session-1',
+      targetName: 'Bio Expert'
+    })
+    expect(switchNotifications[0]).toMatchObject({ targetName: 'Bio Expert' })
+  })
+
+  it('approved switch to Main (null) persists a Main binding', async () => {
+    switchNotifications.length = 0
+    const gateway = recordingGateway('approved')
+    const sdk = makeSdk({ approvalGateway: gateway })
+    const result = (await sdk.switch(null)) as {
+      status: 'switched'
+      sessionBinding: { sessionId: string; targetName: string | null }
+    }
+    expect(result.status).toBe('switched')
+    expect(result.sessionBinding.targetName).toBeNull()
+    expect(switchNotifications[0].targetName).toBeNull()
+  })
+})
+
+describe('customize Skill: declined privileged operations', () => {
+  it('declined name-changing update leaves every field unchanged and is not retried', async () => {
+    const gateway = recordingGateway('declined')
+    const sdk = makeSdk({ approvalGateway: gateway })
+    const before = await sdk.get('Bio Expert')
+    const result = (await sdk.update('Bio Expert', {
+      name: 'Renamed',
+      revision: before.revision
+    })) as unknown as { status: string; operation: string }
+    expect(result.status).toBe('declined')
+    expect(result.operation).toBe('update')
+    // nothing changed
+    const unchanged = await sdk.get('Bio Expert')
+    expect(unchanged.revision).toBe(before.revision)
+    expect(gateway.decisions).toHaveLength(1) // not retried
+  })
+
+  it('declined delete is reported as a user decision and not retried', async () => {
+    const gateway = recordingGateway('declined')
+    const sdk = makeSdk({ approvalGateway: gateway })
+    const result = (await sdk.delete('Bio Expert')) as {
+      status: 'declined'
+      operation: 'delete'
+    }
+    expect(result.status).toBe('declined')
+    expect(result.operation).toBe('delete')
+    // still present
+    const still = await sdk.get('Bio Expert')
+    expect(still.name).toBe('Bio Expert')
+    expect(gateway.decisions).toHaveLength(1)
+  })
+
+  it('declined switch is reported as a user decision and not retried', async () => {
+    const gateway = recordingGateway('declined')
+    const sdk = makeSdk({ approvalGateway: gateway })
+    const result = (await sdk.switch('Bio Expert')) as {
+      status: 'declined'
+      operation: 'switch'
+    }
+    expect(result.status).toBe('declined')
+    expect(result.operation).toBe('switch')
+    expect(sdk.getPendingBinding()).toBeUndefined()
+    expect(gateway.decisions).toHaveLength(1)
+  })
+})
+
+describe('customize Skill: reporting', () => {
+  it('switch reports current reply continues and target applies next message', () => {
+    expect(reportSwitch('Bio Expert')).toMatch(/reply continues/i)
+    expect(reportSwitch('Bio Expert')).toMatch(/next message/i)
+  })
+
+  it('switch to Main reports Main Agent as the target', () => {
+    expect(reportSwitch(null)).toMatch(/Main Agent/)
+  })
+
+  it('delete reports bound conversations become unavailable, not switched to Main', () => {
+    const msg = reportDelete('Bio Expert')
+    expect(msg).toMatch(/unavailable/i)
+    expect(msg).toMatch(/not.*Main Agent/i)
+  })
+
+  it('privileged explanations name the impending action', () => {
+    expect(explainSwitch('Bio Expert', 'Other')).toMatch(/next message/i)
+    expect(explainNameChange('A', 'B')).toMatch(/rename.*A.*B/i)
+    expect(explainDelete('A')).toMatch(/delete.*A/i)
+    expect(explainDelete('A')).toMatch(/unavailable/i)
+  })
+})
+
+describe('customize Skill: catalog resolution + sanitized errors', () => {
+  it('rejects ambiguous names and tells the caller to use the stable id', async () => {
+    const sdk = new FakeHostAgents({
+      profiles: [],
+      skills: [
+        {
+          id: 's1',
+          name: 'dup',
+          displayName: 'Dup',
+          source: 'featured',
+          mainEnabled: true,
+          available: true
+        },
+        {
+          id: 's2',
+          name: 'dup',
+          displayName: 'Dup',
+          source: 'featured',
+          mainEnabled: true,
+          available: true
+        }
+      ],
+      connectors: []
+    })
+    await expect(sdk.list_skills('dup')).rejects.toThrow(/host\.agents\.list_skills:.*multiple/i)
+  })
+
+  it('errors are sanitized and prefixed host.agents.<method>:', async () => {
+    const sdk = makeSdk()
+    await expect(sdk.get('Missing')).rejects.toThrow(/^host\.agents\.get:/)
+  })
+
+  it('never returns secret material from the connector catalog', async () => {
+    const sdk = makeSdk()
+    const catalog = await sdk.list_connectors()
+    const serialized = JSON.stringify(catalog)
+    expect(serialized).not.toMatch(/secret|token|apiKey|password/i)
+  })
+})

--- a/src/main/agents/customize/workflow.ts
+++ b/src/main/agents/customize/workflow.ts
@@ -1,0 +1,213 @@
+// Customize Skill workflow policy — the pure rules that govern the conversational `/customize` flow.
+//
+// design.md §7 defines the workflow: scope → live read → complete draft → applicable confirmation →
+// mutation → read-back. This module turns those rules into pure, testable functions the Skill (and
+// its contract tests) drive against a `host.agents` SDK (real in production, fake in tests).
+//
+// The Skill is WORKFLOW GUIDANCE, not a security boundary (design.md §11, PRD §10). It never merges
+// or auto-retries; it never treats the chat entry as authorization; it never exposes UUIDs/revisions
+// in ordinary prose. Confirmation boundaries (design.md §7):
+//  - ordinary mutations (create, non-name update): chat review + explicit textual confirmation; no
+//    second system permission card;
+//  - privileged mutations (name-changing update, delete, switch): explain the impending action, then
+//    invoke the SDK — the standard permission card is the single authorization point.
+
+import type { AgentReadModel } from '../agents-service'
+
+// ---------------------------------------------------------------------------
+// Scope clarification (design.md §5: never silently grant Full)
+// ---------------------------------------------------------------------------
+
+// When the user has not specified Full versus Selected, the Skill MUST ask. It must not use the SDK's
+// omitted-fields Full default silently.
+export type CapabilityScope = 'full' | 'selected' | 'unspecified'
+
+export const resolveCreateScope = (input: {
+  unrestricted?: boolean
+  skill_names?: unknown
+  connector_names?: unknown
+}): CapabilityScope => {
+  if (input.unrestricted === true) return 'full'
+  if (input.skill_names !== undefined || input.connector_names !== undefined) return 'selected'
+  return 'unspecified'
+}
+
+// The conversational clarification the Skill emits when scope is unspecified. Fixed UI-facing copy
+// stays English (PRD §10). Returns whether the Skill must stop and ask before drafting.
+export const mustAskForScope = (scope: CapabilityScope): boolean => scope === 'unspecified'
+
+export const SCOPE_CLARIFICATION =
+  'Do you want this specialist to have full access (same capabilities as Main) or selected ' +
+  'capabilities (a specific list of skills and connectors)? I will not assume full access for you.'
+
+// ---------------------------------------------------------------------------
+// Live read + complete draft (design.md §6, §7)
+// ---------------------------------------------------------------------------
+
+// The reviewed target state. Mirrors the ordinary-review checklist (design.md §7). The Skill reads
+// live Profiles plus Skill/Connector catalogs before proposing this.
+export type ReviewedTargetState = {
+  name: string
+  description: string
+  systemPrompt: string
+  iconKey?: string
+  colorKey?: string
+  enabled: boolean
+  capabilityMode: 'full' | 'selected'
+  skillIds: string[]
+  connectorIds: string[]
+  revision: number
+}
+
+export const buildReviewedTarget = (profile: AgentReadModel): ReviewedTargetState => ({
+  name: profile.name,
+  description: profile.description,
+  systemPrompt: profile.systemPrompt,
+  iconKey: profile.iconKey,
+  colorKey: profile.colorKey,
+  enabled: profile.enabled,
+  capabilityMode: profile.capabilityMode,
+  skillIds: profile.selectedCapabilities.skillIds,
+  connectorIds: profile.selectedCapabilities.connectorIds,
+  revision: profile.revision
+})
+
+// A textual review of the complete target state for the ordinary-mutation chat review. It shows every
+// field the checklist requires AND states that Connector tool scope is not configured (design.md §7,
+// PRD §4) — it must NOT represent tool scope as an empty reviewed configuration. It deliberately
+// omits UUIDs/revisions from ordinary prose (design.md §4).
+export const renderOrdinaryReview = (
+  target: ReviewedTargetState,
+  changedFields?: string[]
+): string => {
+  const lines: string[] = []
+  lines.push(`Name: ${target.name}`)
+  lines.push(`Description: ${target.description}`)
+  lines.push('Full system instructions:')
+  lines.push(target.systemPrompt)
+  if (target.iconKey) lines.push(`Icon: ${target.iconKey}`)
+  if (target.colorKey) lines.push(`Color: ${target.colorKey}`)
+  lines.push(`Enabled: ${target.enabled ? 'yes' : 'no'}`)
+  lines.push(`Mode: ${target.capabilityMode}`)
+  lines.push(`Skills: ${target.skillIds.length ? target.skillIds.join(', ') : '(none)'}`)
+  lines.push(
+    `Connectors: ${target.connectorIds.length ? target.connectorIds.join(', ') : '(none)'}`
+  )
+  lines.push('Connector tool scope: not configured in this milestone')
+  if (changedFields && changedFields.length > 0) {
+    lines.push(`Changed fields: ${changedFields.join(', ')}`)
+  }
+  return lines.join('\n')
+}
+
+// ---------------------------------------------------------------------------
+// Confirmation boundaries (design.md §7)
+// ---------------------------------------------------------------------------
+
+export type OperationKind =
+  'create' | 'ordinary-update' | 'name-changing-update' | 'delete' | 'switch'
+
+// Ordinary mutations use chat review + explicit textual confirmation and do NOT request a second
+// system permission card. Name-changing update, delete, and switch explain the impending action and
+// invoke the SDK directly; the standard card is the only authorization point.
+export const requiresSystemPermissionCard = (kind: OperationKind): boolean =>
+  kind === 'name-changing-update' || kind === 'delete' || kind === 'switch'
+
+// Whether the operation waits for an explicit textual confirmation in chat BEFORE mutating (ordinary
+// path). Privileged ops do not require a separate preceding "yes": the card is the authorization.
+export const requiresTextualConfirmation = (kind: OperationKind): boolean =>
+  kind === 'create' || kind === 'ordinary-update'
+
+// The textual confirmation token the ordinary path waits for. Case-insensitive substring match.
+export const isExplicitConfirmation = (text: string): boolean =>
+  /\b(yes|confirm|ok|okay)\b/i.test(text.trim())
+
+// ---------------------------------------------------------------------------
+// Revision / stale-draft handling (design.md §8)
+// ---------------------------------------------------------------------------
+
+// A draft is stale when the reviewed revision no longer matches the live record. A changed draft or
+// stale revision invalidates prior textual confirmation and requires a fresh read/review. The Skill
+// does NOT merge or auto-retry.
+export const isStaleRevision = (reviewedRevision: number, liveRevision: number): boolean =>
+  reviewedRevision !== liveRevision
+
+// A changed draft invalidates prior confirmation: after the user edits the draft, the Skill must
+// re-review. Returns true when the current draft differs from the draft that was confirmed.
+export const draftChangedSinceConfirmation = <T>(
+  currentDraft: T,
+  confirmedDraft: T | undefined
+): boolean =>
+  confirmedDraft === undefined || JSON.stringify(currentDraft) !== JSON.stringify(confirmedDraft)
+
+// ---------------------------------------------------------------------------
+// Atomic-update preference (design.md §7: prefer one atomic update over attach/detach loops)
+// ---------------------------------------------------------------------------
+
+// Multi-field ordinary changes prefer one atomic update instead of attach/detach loops that could
+// partially succeed. Returns the single update patch to apply, or null when only a single collection
+// moves by one element (an incremental attach/detach is acceptable there).
+export type OrdinaryChangePlan = {
+  kind: 'atomic-update'
+  patch: {
+    name?: string
+    description?: string
+    system_prompt?: string
+    icon_key?: string
+    color_key?: string
+    enabled?: boolean
+    skill_names?: string[]
+    connector_names?: string[]
+  }
+}
+
+export const preferAtomicUpdate = (
+  target: ReviewedTargetState,
+  live: ReviewedTargetState
+): OrdinaryChangePlan => {
+  const patch: OrdinaryChangePlan['patch'] = {}
+  if (target.description !== live.description) patch.description = target.description
+  if (target.systemPrompt !== live.systemPrompt) patch.system_prompt = target.systemPrompt
+  if ((target.iconKey ?? '') !== (live.iconKey ?? '')) patch.icon_key = target.iconKey
+  if ((target.colorKey ?? '') !== (live.colorKey ?? '')) patch.color_key = target.colorKey
+  if (target.enabled !== live.enabled) patch.enabled = target.enabled
+  const skillChanged = JSON.stringify(target.skillIds) !== JSON.stringify(live.skillIds)
+  const connectorChanged = JSON.stringify(target.connectorIds) !== JSON.stringify(live.connectorIds)
+  if (skillChanged) patch.skill_names = target.skillIds
+  if (connectorChanged) patch.connector_names = target.connectorIds
+  return { kind: 'atomic-update', patch }
+}
+
+// ---------------------------------------------------------------------------
+// Privileged operation explanations (design.md §7 permission cards)
+// ---------------------------------------------------------------------------
+
+// These explanations are shown in chat BEFORE invoking the SDK; the standard permission card is the
+// only authorization point. They do not show UUIDs, secrets, or the full system prompt.
+export const explainSwitch = (currentName: string | null, targetName: string | null): string =>
+  `About to switch this conversation from ${currentName ?? 'Main Agent'} to ${
+    targetName ?? 'Main Agent'
+  }. This takes effect on your next message; the current reply continues unchanged.`
+
+export const explainNameChange = (oldName: string, newName: string): string =>
+  `About to rename "${oldName}" to "${newName}" and apply the rest of the reviewed changes in one ` +
+  'step. Stable conversation bindings do not change.'
+
+export const explainDelete = (name: string): string =>
+  `About to delete "${name}". Conversations still bound to it become unavailable; they are not ` +
+  'switched to Main Agent.'
+
+// ---------------------------------------------------------------------------
+// Reporting (design.md §8 read-back, §9 switch timing, §10 delete)
+// ---------------------------------------------------------------------------
+
+// Switch reporting: the current reply continues and the approved target applies to the next message.
+export const reportSwitch = (targetName: string | null): string =>
+  `This reply continues under the current specialist. The approved target (${
+    targetName ?? 'Main Agent'
+  }) takes effect on your next message.`
+
+// Delete reporting: bound conversations become unavailable, NOT switched to Main Agent.
+export const reportDelete = (name: string): string =>
+  `Deleted "${name}". Existing conversations that were bound to it are now unavailable and are NOT ` +
+  'switched to Main Agent; the user must choose a specialist or Main Agent explicitly.'

--- a/src/main/agents/passthrough-approval-gateway.test.ts
+++ b/src/main/agents/passthrough-approval-gateway.test.ts
@@ -1,0 +1,31 @@
+import { describe, expect, it } from 'vitest'
+
+import { passthroughApprovalGateway } from './passthrough-approval-gateway'
+import type { ApprovalRequest } from '../../shared/agents-contract'
+
+// The pass-through gateway is the milestone substitution point for the standard Specialist approval
+// card. It must always approve, hold no state, and satisfy the ApprovalGateway contract so the
+// dispatcher's gateway seam stays a no-op swap target.
+describe('passthroughApprovalGateway (issue 08a milestone gateway)', () => {
+  it('approves every privileged operation immediately', async () => {
+    const requests: ApprovalRequest[] = [
+      { operation: 'update', summary: { name: 'Old', newName: 'New' }, session: {} },
+      { operation: 'delete', summary: { name: 'Old' }, session: {} },
+      { operation: 'switch', summary: { target: 'Bio' }, session: { sessionId: 's' } }
+    ]
+    for (const request of requests) {
+      await expect(passthroughApprovalGateway.decide(request)).resolves.toEqual({
+        status: 'approved'
+      })
+    }
+  })
+
+  it('never declines (no pending state, no second approval store)', async () => {
+    const result = await passthroughApprovalGateway.decide({
+      operation: 'delete',
+      summary: { name: 'X' },
+      session: {}
+    })
+    expect(result.status).toBe('approved')
+  })
+})

--- a/src/main/agents/passthrough-approval-gateway.ts
+++ b/src/main/agents/passthrough-approval-gateway.ts
@@ -1,0 +1,32 @@
+// Pass-through Specialist approval gateway (issue 08a milestone composition).
+//
+// In this milestone the user-facing confirmation for privileged Specialist operations (name-changing
+// update, delete, switch) is the `/customize` Skill's chat-text review, NOT the standard ACP
+// permission card (that card is a separate, later issue — see issue 08d for the documented security
+// tradeoff). The SDK approval gateway is therefore a PASS-THROUGH: every `decide()` resolves to an
+// immediate `{ status: 'approved' }`.
+//
+// This object exists as an explicit SUBSTITUTION POINT: the dispatcher routes every privileged op
+// THROUGH the `ApprovalGateway` seam (issue 02 contract). Swapping in a future standard-card
+// gateway (a separate issue) requires no dispatcher, Skill, or issue-02 contract change — only the
+// injected implementation here changes.
+//
+// Cross-cutting requirements honored (issue 08a):
+//  - It holds NO pending state, NO second approval store, NO responder, and NO state machine. It is
+//    a single pure function dressed as the gateway interface.
+//  - A decline never happens on this gateway, so structured declines never originate here. (The
+//    result type still allows declines so the seam shape is stable for the future card gateway.)
+
+import type { ApprovalGateway, ApprovalResult } from '../../shared/agents-contract'
+
+// The pass-through decision. Always approved; never throws, never parks a card, never waits. Kept as
+// a constant so the gateway is allocation-free and provably stateless.
+const PASSTHROUGH_APPROVED: ApprovalResult = { status: 'approved' }
+
+// The pass-through approval gateway. Inject this wherever an `ApprovalGateway` is required during
+// the chat-confirmation milestone; replace it with the standard-card gateway when that lands.
+export const passthroughApprovalGateway: ApprovalGateway = {
+  decide(): Promise<ApprovalResult> {
+    return Promise.resolve(PASSTHROUGH_APPROVED)
+  }
+}

--- a/src/main/agents/pending-session-specialist-bindings.test.ts
+++ b/src/main/agents/pending-session-specialist-bindings.test.ts
@@ -1,0 +1,53 @@
+import { describe, expect, it } from 'vitest'
+
+import { PendingSessionSpecialistBindings } from './pending-session-specialist-bindings'
+
+describe('PendingSessionSpecialistBindings', () => {
+  it('stashes a binding for a non-durable session and reports it pending', () => {
+    const pending = new PendingSessionSpecialistBindings()
+    pending.stash('s1', 'sp-1')
+    expect(pending.has('s1')).toBe(true)
+  })
+
+  it('take consumes and returns the stashed binding, clearing the pending state', () => {
+    const pending = new PendingSessionSpecialistBindings()
+    pending.stash('s1', 'sp-1')
+    expect(pending.take('s1')).toBe('sp-1')
+    expect(pending.has('s1')).toBe(false)
+    // A second take on the same session returns undefined (nothing pending).
+    expect(pending.take('s1')).toBeUndefined()
+  })
+
+  it('stashing again overwrites (last-write-wins) before the flush', () => {
+    const pending = new PendingSessionSpecialistBindings()
+    pending.stash('s1', 'sp-1')
+    pending.stash('s1', 'sp-2')
+    expect(pending.take('s1')).toBe('sp-2')
+  })
+
+  it('stashes a cleared (Main Agent) binding as undefined and still reports it pending', () => {
+    // A cleared binding (switch to Main) is a REAL flush target: the save path must clear the disk
+    // binding too. So `has` is true and `take` returns undefined — the wiring keys off `has`, not the
+    // returned value, to avoid dropping a clear.
+    const pending = new PendingSessionSpecialistBindings()
+    pending.stash('s1', undefined)
+    expect(pending.has('s1')).toBe(true)
+    expect(pending.take('s1')).toBeUndefined()
+    expect(pending.has('s1')).toBe(false)
+  })
+
+  it('has is false for a session that was never stashed', () => {
+    const pending = new PendingSessionSpecialistBindings()
+    expect(pending.has('never')).toBe(false)
+    expect(pending.take('never')).toBeUndefined()
+  })
+
+  it('independent sessions do not interfere', () => {
+    const pending = new PendingSessionSpecialistBindings()
+    pending.stash('s1', 'sp-1')
+    pending.stash('s2', 'sp-2')
+    expect(pending.take('s1')).toBe('sp-1')
+    expect(pending.has('s2')).toBe(true)
+    expect(pending.take('s2')).toBe('sp-2')
+  })
+})

--- a/src/main/agents/pending-session-specialist-bindings.ts
+++ b/src/main/agents/pending-session-specialist-bindings.ts
@@ -1,0 +1,38 @@
+// Tracks approved host.agents.switch bindings for sessions that are not yet durable (fresh unsent
+// drafts), so the binding is flushed to the session file on first save instead of being silently
+// dropped across an app restart.
+//
+// Background (code-review finding): host.agents.switch persists the binding immediately (Phase 5 of
+// SwitchOperation), but when the calling session is a brand-new unsent draft it does not yet exist on
+// disk, so the durable writer cannot persist it. The in-memory SessionBindingService holds it, but
+// nothing reconciled that back to disk on first save — so a restart before the first save lost the
+// approved switch. This helper bridges that gap: the persistSessionSpecialist callback stashes a
+// binding when the session is not yet durable, and the session save path flushes (and consumes) it.
+//
+// `has` is the source of truth for "a flush is pending" so a cleared (Main Agent) binding — stashed
+// as undefined — is still flushed (the disk binding must be cleared too), not mistaken for "nothing
+// pending".
+
+export class PendingSessionSpecialistBindings {
+  private readonly pending = new Map<string, string | undefined>()
+
+  // Record a binding for a session that is not yet durable. Overwrites a prior stash for the same
+  // session (last-write-wins), mirroring the live SessionBindingService.
+  stash(sessionId: string, specialistId: string | undefined): void {
+    this.pending.set(sessionId, specialistId)
+  }
+
+  // Whether a stashed binding is waiting to be flushed when this session is next saved. Use this
+  // (not the value returned by `take`) to decide whether to flush, so a cleared binding is honored.
+  has(sessionId: string): boolean {
+    return this.pending.has(sessionId)
+  }
+
+  // Consume and return the stashed binding for a session (possibly undefined = clear to Main),
+  // removing it from the pending set. Called by the save path right after the session becomes durable.
+  take(sessionId: string): string | undefined {
+    const value = this.pending.get(sessionId)
+    this.pending.delete(sessionId)
+    return value
+  }
+}

--- a/src/main/agents/specialist-approval-gateway.test.ts
+++ b/src/main/agents/specialist-approval-gateway.test.ts
@@ -1,0 +1,175 @@
+import { describe, expect, it, vi } from 'vitest'
+
+import { AcpSpecialistApprovalGateway } from './specialist-approval-gateway'
+import type {
+  SpecialistBridgeDecision,
+  SpecialistPermissionBridgeInFlight
+} from './specialist-approval-gateway'
+import type {
+  SpecialistDeleteCardPayload,
+  SpecialistPermissionCardPayload,
+  SpecialistSwitchCardPayload,
+  SpecialistUpdateCardPayload
+} from '../../shared/agents-contract'
+
+type FakeBridge = {
+  bridge: SpecialistPermissionBridgeInFlight
+  published: Array<{ payload: SpecialistPermissionCardPayload; sessionId?: string }>
+  setNext: (
+    value:
+      SpecialistBridgeDecision | ((p: SpecialistPermissionCardPayload) => SpecialistBridgeDecision)
+  ) => void
+}
+
+// A fake bridge that records every published payload and resolves the next decision on demand.
+const makeBridge = (): FakeBridge => {
+  const published: Array<{ payload: SpecialistPermissionCardPayload; sessionId?: string }> = []
+  let next:
+    | SpecialistBridgeDecision
+    | ((payload: SpecialistPermissionCardPayload) => SpecialistBridgeDecision) = {
+    outcome: 'approved'
+  }
+  const bridge: SpecialistPermissionBridgeInFlight = {
+    requestApproval: vi.fn(async (payload, session) => {
+      published.push({ payload, sessionId: session.sessionId })
+      return typeof next === 'function' ? next(payload) : next
+    })
+  }
+  return {
+    bridge,
+    published,
+    setNext: (
+      value:
+        | SpecialistBridgeDecision
+        | ((p: SpecialistPermissionCardPayload) => SpecialistBridgeDecision)
+    ) => {
+      next = value
+    }
+  }
+}
+
+describe('AcpSpecialistApprovalGateway — implements the issue 02 ApprovalGateway contract', () => {
+  it('is an ApprovalGateway (decide returns an ApprovalResult)', async () => {
+    const { bridge } = makeBridge()
+    const gateway = new AcpSpecialistApprovalGateway({ bridge })
+    const result = await gateway.decide({
+      operation: 'delete',
+      summary: { name: 'DATA_ANALYST' },
+      session: { sessionId: 's-1' }
+    })
+    expect(result).toEqual({ status: 'approved' })
+  })
+
+  it('does NOT carry a second request store / responder / state machine (delegates parking to the bridge)', () => {
+    const { bridge } = makeBridge()
+    const gateway = new AcpSpecialistApprovalGateway({ bridge })
+    // The gateway exposes no pending map, no respond(), no state of its own. It only decides.
+    expect((gateway as unknown as Record<string, unknown>).pending).toBeUndefined()
+    expect((gateway as unknown as Record<string, unknown>).respond).toBeUndefined()
+    expect(typeof gateway.decide).toBe('function')
+  })
+})
+
+describe('AcpSpecialistApprovalGateway — name-changing update card', () => {
+  it('publishes an update payload (old name, new name, bindings stable) and forwards the session', async () => {
+    const { bridge, published } = makeBridge()
+    const gateway = new AcpSpecialistApprovalGateway({ bridge })
+    await gateway.decide({
+      operation: 'update',
+      summary: { name: 'DATA_ANALYST', newName: 'DATA_SCIENTIST' },
+      session: { sessionId: 's-9' }
+    })
+    expect(bridge.requestApproval).toHaveBeenCalledTimes(1)
+    expect(published[0].sessionId).toBe('s-9')
+    const payload = published[0].payload as SpecialistUpdateCardPayload
+    expect(payload.kind).toBe('update')
+    expect(payload.name).toBe('DATA_ANALYST')
+    expect(payload.newName).toBe('DATA_SCIENTIST')
+    expect(payload.bindingsStable).toBe(true)
+  })
+
+  it('maps the bridge decision to an ApprovalResult carrying the operation on decline', async () => {
+    const { bridge, setNext } = makeBridge()
+    setNext({ outcome: 'declined', reason: 'user cancelled' })
+    const gateway = new AcpSpecialistApprovalGateway({ bridge })
+    const result = await gateway.decide({
+      operation: 'update',
+      summary: { name: 'OLD', newName: 'NEW' },
+      session: {}
+    })
+    expect(result).toEqual({ status: 'declined', operation: 'update', reason: 'user cancelled' })
+  })
+})
+
+describe('AcpSpecialistApprovalGateway — delete card', () => {
+  it('publishes a delete payload stating bound conversations become unavailable', async () => {
+    const { bridge, published } = makeBridge()
+    const gateway = new AcpSpecialistApprovalGateway({ bridge })
+    await gateway.decide({
+      operation: 'delete',
+      summary: { name: 'SQL_WRANGLER' },
+      session: {}
+    })
+    const payload = published[0].payload as SpecialistDeleteCardPayload
+    expect(payload.kind).toBe('delete')
+    expect(payload.name).toBe('SQL_WRANGLER')
+    expect(payload.boundConversationsUnavailable).toBe(true)
+  })
+
+  it('maps a declined bridge decision to {operation:"delete"}', async () => {
+    const { bridge, setNext } = makeBridge()
+    setNext({ outcome: 'declined' })
+    const gateway = new AcpSpecialistApprovalGateway({ bridge })
+    const result = await gateway.decide({
+      operation: 'delete',
+      summary: { name: 'SQL_WRANGLER' },
+      session: {}
+    })
+    expect(result).toEqual({ status: 'declined', operation: 'delete' })
+  })
+})
+
+describe('AcpSpecialistApprovalGateway — switch card', () => {
+  it('publishes a switch payload with current/target and next-message timing', async () => {
+    const { bridge, published } = makeBridge()
+    const gateway = new AcpSpecialistApprovalGateway({ bridge })
+    await gateway.decide({
+      operation: 'switch',
+      summary: { name: 'Data Analyst', target: 'SQL Wrangler' },
+      session: {}
+    })
+    const payload = published[0].payload as SpecialistSwitchCardPayload
+    expect(payload.kind).toBe('switch')
+    expect(payload.currentName).toBe('Data Analyst')
+    expect(payload.targetName).toBe('SQL Wrangler')
+    expect(payload.takesEffectOnNextMessage).toBe(true)
+  })
+
+  it('maps target null to Main Agent', async () => {
+    const { bridge, published } = makeBridge()
+    const gateway = new AcpSpecialistApprovalGateway({ bridge })
+    await gateway.decide({
+      operation: 'switch',
+      summary: { name: 'Data Analyst', target: null },
+      session: {}
+    })
+    const payload = published[0].payload as SpecialistSwitchCardPayload
+    expect(payload.targetName).toBeNull()
+  })
+})
+
+describe('AcpSpecialistApprovalGateway — never exposes sensitive values on the wire', () => {
+  it('the published payload never contains UUIDs, secrets, tokens, or system instructions', async () => {
+    const { bridge, published } = makeBridge()
+    const gateway = new AcpSpecialistApprovalGateway({ bridge })
+    await gateway.decide({
+      operation: 'update',
+      // A malicious/leaky summary must not survive into the card payload verbatim.
+      summary: { name: 'DATA_ANALYST', newName: 'DATA_SCIENTIST' },
+      session: { sessionId: 'leaked-session' }
+    })
+    const serialized = JSON.stringify(published[0].payload)
+    expect(serialized).not.toContain('leaked-session')
+    expect(serialized).not.toMatch(/systemPrompt|instructions|token|secret|credential/i)
+  })
+})

--- a/src/main/agents/specialist-approval-gateway.ts
+++ b/src/main/agents/specialist-approval-gateway.ts
@@ -1,0 +1,150 @@
+// Concrete Specialist approval gateway backed by the existing ACP permission broker (issue 04).
+//
+// This module implements issue 02's `ApprovalGateway` contract for privileged Specialist operations
+// (name-changing update, delete, switch) WITHOUT introducing a second request store, responder, or
+// approval state machine. The existing ACP permission broker owns parking, publication, response
+// validation, cancellation, and standard session permission rendering. This gateway only:
+//   1. Maps the issue 02 `ApprovalRequest` into a redacted `SpecialistPermissionCardPayload`
+//      (minimum public summary; no system instructions, UUIDs, secrets, tokens, or connector args).
+//   2. Hands that payload to an injected `SpecialistPermissionBridge`, which delegates parking /
+//      publication / cancellation / response validation to the ACP broker's lifecycle.
+//   3. Shapes the bridge's decision into the `ApprovalResult` union (decline is a normal result).
+//
+// The bridge is intentionally the ONLY mutation authority over pending requests — this gateway holds
+// no pending map and exposes no `respond()`. Issue 08 wires the bridge's concrete ACP-backed
+// implementation into the dispatcher; tests pass fakes. The mapper functions come from the issue 04
+// presentation module (no issue 03/05 implementation import).
+
+import type {
+  AgentsDeclinedResult,
+  AgentsApprovedResult,
+  ApprovalGateway,
+  ApprovalRequest,
+  ApprovalResult,
+  SpecialistPermissionCardPayload,
+  TrustedCallingSession
+} from '../../shared/agents-contract'
+
+// ---------------------------------------------------------------------------
+// The injected bridge: the ACP-broker-backed transport for one approval decision
+// ---------------------------------------------------------------------------
+
+// INJECTED seam. The concrete implementation parks the card payload on the EXISTING ACP permission
+// broker (which owns the pending map, publication, response validation, cancellation, and standard
+// session permission rendering), awaits the renderer's decision, and returns a normalized result.
+// `requestApproval` resolves with a decision the gateway can shape into an `ApprovalResult`; a
+// cancelled/timeout/unanswered request is reported as a decline (design.md §8) — never an error.
+//
+// This interface deliberately exposes NO `respond()` and NO pending store: those live in the ACP
+// broker behind the concrete implementation. That is what "no second approval system" means.
+export type SpecialistPermissionBridge = {
+  requestApproval(
+    payload: SpecialistPermissionCardPayload,
+    session: TrustedCallingSession
+  ): Promise<SpecialistBridgeDecision>
+}
+
+// What the bridge resolves to. The bridge normalizes ACP outcomes (selected option, cancelled,
+// timeout) into one of these; the gateway maps them onto the `ApprovalResult` union.
+export type SpecialistBridgeDecision =
+  { outcome: 'approved' } | { outcome: 'declined'; reason?: string }
+
+// Exported for tests that build a fake and assert its shape without re-declaring the type.
+export type SpecialistPermissionBridgeInFlight = SpecialistPermissionBridge
+
+export type AcpSpecialistApprovalGatewayDeps = {
+  bridge: SpecialistPermissionBridge
+}
+
+// ---------------------------------------------------------------------------
+// Request -> card payload mapping (reuses the issue 04 presentation contract)
+// ---------------------------------------------------------------------------
+
+// Maps an issue 02 `ApprovalRequest` to the redacted card payload for the renderer. This is a pure
+// transform over the request's public summary fields — it never reads system instructions, UUIDs,
+// secrets, tokens, or connector args, and the produced payload provably excludes them.
+const toCardPayload = (request: ApprovalRequest): SpecialistPermissionCardPayload => {
+  const { operation, summary } = request
+  if (operation === 'update') {
+    return {
+      kind: 'update',
+      name: summary.name ?? '',
+      newName: summary.newName ?? summary.name ?? '',
+      // Name-changing update carries no other-field manifest here: the dispatcher (issue 08) builds
+      // the full manifest via mapUpdateApprovalCard before calling decide(). The gateway only echoes
+      // the summary it was handed. Bindings are always stable across a rename.
+      changes: [],
+      bindingsStable: true
+    }
+  }
+  if (operation === 'delete') {
+    return {
+      kind: 'delete',
+      name: summary.name ?? '',
+      // Bound conversations become unavailable and are NOT switched to Main Agent.
+      boundConversationsUnavailable: true
+    }
+  }
+  // switch
+  return {
+    kind: 'switch',
+    // summary.name is the CURRENT specialist (or null/omitted when on Main Agent).
+    currentName: summary.name ?? null,
+    // summary.target is the TARGET specialist, or null to revert to Main Agent.
+    targetName: summary.target ?? null,
+    takesEffectOnNextMessage: true
+  }
+}
+
+// ---------------------------------------------------------------------------
+// Concrete gateway
+// ---------------------------------------------------------------------------
+
+// Implements issue 02's `ApprovalGateway` over the existing ACP permission broker via the injected
+// bridge. Holds no state of its own. A decline (or cancelled/timeout card) is a normal result.
+export class AcpSpecialistApprovalGateway implements ApprovalGateway {
+  constructor(private readonly deps: AcpSpecialistApprovalGatewayDeps) {}
+
+  async decide(request: ApprovalRequest): Promise<ApprovalResult> {
+    const payload = toCardPayload(request)
+    const decision = await this.deps.bridge.requestApproval(payload, request.session)
+    if (decision.outcome === 'approved') {
+      const approved: AgentsApprovedResult = { status: 'approved' }
+      return approved
+    }
+    const declined: AgentsDeclinedResult = {
+      status: 'declined',
+      operation: request.operation,
+      ...(decision.reason ? { reason: decision.reason } : {})
+    }
+    return declined
+  }
+}
+
+// ---------------------------------------------------------------------------
+// Concrete ACP-backed bridge factory (used by issue 08 composition)
+// ---------------------------------------------------------------------------
+
+// The narrow transport the ACP broker already exposes, expressed without importing the broker type
+// directly (so this module stays free of a src/main/acp import at type-check time and remains
+// independently testable). Issue 08 supplies an adapter over the real `AcpPermissionBroker` that
+// satisfies this shape by parking the payload, broadcasting the card, and resolving on `respond`.
+export type SpecialistPermissionTransport = {
+  // Parks the card payload on the broker, publishes it to the renderer, and resolves with the
+  // renderer's decision (or a cancelled/timeout decline). The transport OWNS the pending state —
+  // this gateway never does.
+  request(
+    payload: SpecialistPermissionCardPayload,
+    session: TrustedCallingSession
+  ): Promise<SpecialistBridgeDecision>
+}
+
+// Builds a `SpecialistPermissionBridge` whose concrete implementation delegates parking,
+// publication, response validation, cancellation, and standard session rendering to the supplied
+// transport (the existing ACP permission broker). This is the single composition point where issue
+// 08 connects the gateway to the real broker without introducing a second approval system.
+export const createAcpBackedSpecialistBridge = (
+  transport: SpecialistPermissionTransport
+): SpecialistPermissionBridge => ({
+  requestApproval: (payload, session) => transport.request(payload, session)
+})

--- a/src/main/agents/specialist-approval-presentation.test.ts
+++ b/src/main/agents/specialist-approval-presentation.test.ts
@@ -1,0 +1,156 @@
+import { describe, expect, it } from 'vitest'
+
+import {
+  mapDeleteApprovalCard,
+  mapSwitchApprovalCard,
+  mapUpdateApprovalCard
+} from './specialist-approval-presentation'
+import type { SpecialistPermissionCardPayload } from '../../shared/agents-contract'
+import type { SpecialistProfileView } from '../../shared/specialist'
+
+const baseProfile = (overrides: Partial<SpecialistProfileView> = {}): SpecialistProfileView => ({
+  id: 'sp-1',
+  name: 'DATA_ANALYST',
+  displayName: 'Data Analyst',
+  description: 'Builds dashboards.',
+  systemPrompt: 'SECRET FULL INSTRUCTIONS — never shown on a card',
+  iconKey: 'chart',
+  colorKey: 'violet',
+  enabled: true,
+  capabilityMode: 'full',
+  fullAccess: { excludedSkillIds: [], excludedConnectorIds: [], connectorTools: [] },
+  selectedCapabilities: { skillIds: [], connectorIds: [], connectorTools: [] },
+  revision: 2,
+  ...overrides
+})
+
+describe('mapUpdateApprovalCard — name-changing update presentation', () => {
+  it('shows old name -> new name and marks bindings stable', () => {
+    const current = baseProfile()
+    const payload = mapUpdateApprovalCard(current, { name: 'DATA_SCIENTIST' })
+    expect(payload).toEqual<SpecialistPermissionCardPayload>({
+      kind: 'update',
+      name: 'DATA_ANALYST',
+      newName: 'DATA_SCIENTIST',
+      changes: [],
+      bindingsStable: true
+    })
+  })
+
+  it('lists each other changed field as a compact manifest entry, never full text', () => {
+    const current = baseProfile()
+    const payload = mapUpdateApprovalCard(current, {
+      name: 'DATA_SCIENTIST',
+      description: 'Builds and validates predictive models.',
+      systemPrompt: 'NEW SECRET INSTRUCTIONS',
+      capabilityMode: 'selected',
+      selectedCapabilities: {
+        skillIds: ['data-cleaning', 'model-training', 'netcdf-io'],
+        connectorIds: ['postgres-readonly'],
+        connectorTools: []
+      }
+    }) as Extract<SpecialistPermissionCardPayload, { kind: 'update' }>
+
+    expect(payload.newName).toBe('DATA_SCIENTIST')
+    // System instructions and descriptions appear as 'edited' summaries, never as full text.
+    const fields = payload.changes.map((c) => c.field)
+    expect(fields).toEqual(
+      expect.arrayContaining([
+        'description',
+        'system instructions',
+        'capability mode',
+        'skills',
+        'connectors'
+      ])
+    )
+    const sysInstruction = payload.changes.find((c) => c.field === 'system instructions')
+    expect(sysInstruction?.kind).toBe('edited')
+    // The card payload must never embed the full system prompt text.
+    expect(JSON.stringify(payload)).not.toContain('NEW SECRET INSTRUCTIONS')
+  })
+
+  it('reports added/removed counts for capability collections and a total', () => {
+    const current = baseProfile({
+      capabilityMode: 'selected',
+      selectedCapabilities: {
+        skillIds: ['a', 'b'],
+        connectorIds: ['old-conn'],
+        connectorTools: []
+      }
+    })
+    const payload = mapUpdateApprovalCard(current, {
+      name: 'RENAMED',
+      selectedCapabilities: {
+        skillIds: ['a', 'c', 'd'],
+        connectorIds: ['new-conn'],
+        connectorTools: []
+      }
+    }) as Extract<SpecialistPermissionCardPayload, { kind: 'update' }>
+
+    const skills = payload.changes.find((c) => c.field === 'skills')
+    expect(skills?.kind).toBe('collection')
+    if (skills?.kind === 'collection') {
+      expect(skills.added).toBe(2)
+      expect(skills.removed).toBe(1)
+      expect(skills.total).toBe(3)
+    }
+    const connectors = payload.changes.find((c) => c.field === 'connectors')
+    expect(connectors?.kind).toBe('collection')
+    if (connectors?.kind === 'collection') {
+      expect(connectors.added).toBe(1)
+      expect(connectors.removed).toBe(1)
+      expect(connectors.total).toBe(1)
+    }
+  })
+
+  it('never exposes UUIDs, secrets, or complete system instructions', () => {
+    const current = baseProfile()
+    const payload = mapUpdateApprovalCard(current, {
+      name: 'RENAMED',
+      systemPrompt: 'TOP SECRET TOKEN abc123 /Users/secret/path'
+    })
+    const serialized = JSON.stringify(payload)
+    expect(serialized).not.toContain('sp-1')
+    expect(serialized).not.toContain('TOP SECRET')
+    expect(serialized).not.toContain('abc123')
+  })
+})
+
+describe('mapDeleteApprovalCard — delete presentation', () => {
+  it('names the specialist and states bound conversations become unavailable', () => {
+    const payload = mapDeleteApprovalCard(baseProfile())
+    expect(payload).toEqual<SpecialistPermissionCardPayload>({
+      kind: 'delete',
+      name: 'DATA_ANALYST',
+      boundConversationsUnavailable: true
+    })
+  })
+
+  it('never exposes the UUID or system instructions', () => {
+    const payload = mapDeleteApprovalCard(baseProfile())
+    const serialized = JSON.stringify(payload)
+    expect(serialized).not.toContain('sp-1')
+    expect(serialized).not.toContain('SECRET')
+  })
+})
+
+describe('mapSwitchApprovalCard — switch presentation', () => {
+  it('names current and target and marks next-message timing', () => {
+    const payload = mapSwitchApprovalCard('Data Analyst', 'SQL Wrangler')
+    expect(payload).toEqual<SpecialistPermissionCardPayload>({
+      kind: 'switch',
+      currentName: 'Data Analyst',
+      targetName: 'SQL Wrangler',
+      takesEffectOnNextMessage: true
+    })
+  })
+
+  it('supports reverting to Main Agent (target null) and switching from Main (current null)', () => {
+    expect(mapSwitchApprovalCard('Data Analyst', null)).toEqual(
+      expect.objectContaining({ targetName: null, currentName: 'Data Analyst' })
+    )
+    expect(mapSwitchApprovalCard(null, 'SQL Wrangler')).toEqual(
+      expect.objectContaining({ currentName: null, targetName: 'SQL Wrangler' })
+    )
+  })
+})

--- a/src/main/agents/specialist-approval-presentation.ts
+++ b/src/main/agents/specialist-approval-presentation.ts
@@ -1,0 +1,197 @@
+// Standard renderer presentation mapper for privileged Specialist operations (issue 04).
+//
+// This module is the SINGLE producer of `SpecialistPermissionCardPayload` — the redacted, public
+// card surface the renderer renders for name-changing update, delete, and switch (design.md §7,
+// PRD §6, prototype.html scenes 5/7/8). It is pure and side-effect free so it is independently
+// testable with issue 02 contracts/fakes.
+//
+// Cross-cutting invariants enforced here (design.md §14, issue 04 acceptance):
+//  - Cards carry ONLY minimum public change summaries. They never embed complete system
+//    instructions, descriptions, capability lists, UUIDs, secrets, RPC tokens, or connector args.
+//    Full target state lives in the chat review, never on a card.
+//  - The name-changing update card shows old name -> new name plus a COMPACT manifest of every other
+//    field changed in the same atomic patch (edited / added-removed counts), and states that stable
+//    conversation bindings are unaffected.
+//  - The delete card states that bound conversations become UNAVAILABLE and are NOT auto-switched
+//    to Main Agent.
+//  - The switch card states "takes effect on the next message".
+//
+// This module imports ONLY shared types + the Profile view type. It does not import issue 03 or
+// issue 05 implementation modules.
+
+import type {
+  SpecialistDeleteCardPayload,
+  SpecialistFieldChange,
+  SpecialistSwitchCardPayload,
+  SpecialistUpdateCardPayload
+} from '../../shared/agents-contract'
+import type {
+  SpecialistFullAccessConfig,
+  SpecialistProfileView,
+  SpecialistSelectedConfig
+} from '../../shared/specialist'
+
+// The validated update patch this mapper consumes. Fields are the host.agents.update patch fields
+// (design.md §4 / PRD §3). `name` is the rename that makes the whole patch privileged; the mapper
+// never reads it into the change manifest (it is shown as old -> new instead).
+export type SpecialistUpdatePatch = {
+  name?: string
+  displayName?: string
+  description?: string
+  systemPrompt?: string
+  iconKey?: string
+  colorKey?: string
+  enabled?: boolean
+  capabilityMode?: 'full' | 'selected'
+  fullAccess?: SpecialistFullAccessConfig
+  selectedCapabilities?: SpecialistSelectedConfig
+}
+
+// Computes the added/removed/total counts for a capability collection that is being exactly
+// replaced by the patch. Returns undefined when the patch did not touch the collection.
+const collectionChange = (
+  before: readonly string[],
+  after: readonly string[] | undefined
+): { added: number; removed: number; total: number } | undefined => {
+  if (after === undefined) return undefined
+  const beforeSet = new Set(before)
+  const afterSet = new Set(after)
+  let added = 0
+  let removed = 0
+  for (const id of afterSet) if (!beforeSet.has(id)) added += 1
+  for (const id of beforeSet) if (!afterSet.has(id)) removed += 1
+  return { added, removed, total: after.length }
+}
+
+// Projects the active capability collection (skills/connectors) for the profile's current mode, so
+// the manifest reflects what the user actually sees today.
+const activeSkills = (profile: SpecialistProfileView): readonly string[] =>
+  profile.capabilityMode === 'full'
+    ? profile.fullAccess.excludedSkillIds
+    : profile.selectedCapabilities.skillIds
+
+const activeConnectors = (profile: SpecialistProfileView): readonly string[] =>
+  profile.capabilityMode === 'full'
+    ? profile.fullAccess.excludedConnectorIds
+    : profile.selectedCapabilities.connectorIds
+
+// Builds the compact change manifest for every field the patch changes OTHER than `name`. System
+// instructions and free text appear as an `edited` entry with no body; capability collections appear
+// as `collection` entries with counts. Order is stable for deterministic snapshots.
+const buildChangeManifest = (
+  current: SpecialistProfileView,
+  patch: SpecialistUpdatePatch
+): SpecialistFieldChange[] => {
+  const changes: SpecialistFieldChange[] = []
+
+  if (patch.displayName !== undefined && patch.displayName !== current.displayName) {
+    changes.push({ field: 'display name', kind: 'edited' })
+  }
+  if (patch.description !== undefined && patch.description !== current.description) {
+    changes.push({ field: 'description', kind: 'edited' })
+  }
+  if (patch.systemPrompt !== undefined && patch.systemPrompt !== current.systemPrompt) {
+    // Never embed the prompt text — the card only signals that it changed.
+    changes.push({ field: 'system instructions', kind: 'edited' })
+  }
+  if (patch.iconKey !== undefined && patch.iconKey !== current.iconKey) {
+    changes.push({
+      field: 'icon',
+      kind: 'changed',
+      from: String(current.iconKey ?? ''),
+      to: patch.iconKey
+    })
+  }
+  if (patch.colorKey !== undefined && patch.colorKey !== current.colorKey) {
+    changes.push({
+      field: 'color',
+      kind: 'changed',
+      from: String(current.colorKey ?? ''),
+      to: patch.colorKey
+    })
+  }
+  if (patch.enabled !== undefined && patch.enabled !== current.enabled) {
+    changes.push({
+      field: 'enabled',
+      kind: 'changed',
+      from: current.enabled ? 'enabled' : 'disabled',
+      to: patch.enabled ? 'enabled' : 'disabled'
+    })
+  }
+  if (patch.capabilityMode !== undefined && patch.capabilityMode !== current.capabilityMode) {
+    changes.push({
+      field: 'capability mode',
+      kind: 'changed',
+      from: current.capabilityMode,
+      to: patch.capabilityMode
+    })
+  }
+
+  // Capability collections: when a selected patch replaces skills/connectors, show counts. When the
+  // mode also changes, the "before" collection is read from the profile's current mode.
+  if (patch.selectedCapabilities !== undefined) {
+    const skills = collectionChange(activeSkills(current), patch.selectedCapabilities.skillIds)
+    if (skills && !(skills.added === 0 && skills.removed === 0)) {
+      changes.push({ field: 'skills', kind: 'collection', ...skills })
+    }
+    const connectors = collectionChange(
+      activeConnectors(current),
+      patch.selectedCapabilities.connectorIds
+    )
+    if (connectors && !(connectors.added === 0 && connectors.removed === 0)) {
+      changes.push({ field: 'connectors', kind: 'collection', ...connectors })
+    }
+  }
+  if (patch.fullAccess !== undefined) {
+    const skills = collectionChange(activeSkills(current), patch.fullAccess.excludedSkillIds)
+    if (skills && !(skills.added === 0 && skills.removed === 0)) {
+      changes.push({ field: 'skills', kind: 'collection', ...skills })
+    }
+    const connectors = collectionChange(
+      activeConnectors(current),
+      patch.fullAccess.excludedConnectorIds
+    )
+    if (connectors && !(connectors.added === 0 && connectors.removed === 0)) {
+      changes.push({ field: 'connectors', kind: 'collection', ...connectors })
+    }
+  }
+
+  return changes
+}
+
+// Renders the name-changing update card (prototype scene 7). `current` is the live profile the card
+// was created against; `patch` is the validated update patch (which MUST include a new `name`).
+// The mapper trusts its caller to only invoke it for a name-changing patch; it does not re-classify.
+export const mapUpdateApprovalCard = (
+  current: SpecialistProfileView,
+  patch: SpecialistUpdatePatch
+): SpecialistUpdateCardPayload => ({
+  kind: 'update',
+  name: current.name,
+  newName: patch.name ?? current.name,
+  changes: buildChangeManifest(current, patch),
+  // Bindings follow the profile UUID, not the public name, so they keep working after a rename.
+  bindingsStable: true
+})
+
+// Renders the delete card (prototype scene 8). Bound conversations resolve as unavailable and are
+// NOT silently switched to Main Agent (design.md §10).
+export const mapDeleteApprovalCard = (
+  current: SpecialistProfileView
+): SpecialistDeleteCardPayload => ({
+  kind: 'delete',
+  name: current.name,
+  boundConversationsUnavailable: true
+})
+
+// Renders the switch card (prototype scene 5). `currentName`/`targetName` are public Specialist
+// display names, or null for Main Agent. The switch takes effect on the NEXT message (design.md §9).
+export const mapSwitchApprovalCard = (
+  currentName: string | null,
+  targetName: string | null
+): SpecialistSwitchCardPayload => ({
+  kind: 'switch',
+  currentName,
+  targetName,
+  takesEffectOnNextMessage: true
+})

--- a/src/main/agents/specialist-privileged-ops.test.ts
+++ b/src/main/agents/specialist-privileged-ops.test.ts
@@ -1,0 +1,346 @@
+import { describe, expect, it, vi } from 'vitest'
+
+import {
+  applyDelete,
+  applyNameChangingUpdate,
+  isNameChangingPatch
+} from './specialist-privileged-ops'
+import type { SpecialistUpdatePatch } from './specialist-approval-presentation'
+import type {
+  AgentDeletedResult,
+  AgentDeclinedResult,
+  AgentUpdatedResult
+} from './specialist-privileged-ops'
+import type { ApprovalResult } from '../../shared/agents-contract'
+import type { SpecialistProfileView } from '../../shared/specialist'
+import type { ProfileService } from '../specialist/service'
+
+const profile = (overrides: Partial<SpecialistProfileView> = {}): SpecialistProfileView => ({
+  id: 'sp-1',
+  name: 'DATA_ANALYST',
+  displayName: 'Data Analyst',
+  description: 'a specialist',
+  systemPrompt: 'instructions',
+  iconKey: 'chart',
+  colorKey: 'violet',
+  enabled: true,
+  capabilityMode: 'full',
+  fullAccess: { excludedSkillIds: [], excludedConnectorIds: [], connectorTools: [] },
+  selectedCapabilities: { skillIds: [], connectorIds: [], connectorTools: [] },
+  revision: 3,
+  ...overrides
+})
+
+const fakeApproved = (): ApprovalResult => ({ status: 'approved' })
+const fakeDeclined = (operation: 'update' | 'delete' | 'switch'): ApprovalResult => ({
+  status: 'declined',
+  operation
+})
+
+type FakeService = {
+  service: ProfileService
+  calls: {
+    update: Array<{ id: string; patch: Record<string, unknown>; revision: number }>
+    delete: Array<{ id: string; revision?: number }>
+    getByName: string[]
+  }
+  getStore: () => SpecialistProfileView[]
+  setStore: (s: SpecialistProfileView[]) => void
+}
+
+// A ProfileService fake that records mutations and lets tests simulate drift (revision mismatch,
+// rename, deletion) between card creation and approval.
+const makeService = (opts: {
+  initial?: SpecialistProfileView[]
+  onUpdate?: (id: string, patch: Record<string, unknown>, revision: number) => SpecialistProfileView
+  onDelete?: (id: string, revision?: number) => void
+}): FakeService => {
+  let store = opts.initial ? [...opts.initial] : []
+  const calls = {
+    update: [] as Array<{ id: string; patch: Record<string, unknown>; revision: number }>,
+    delete: [] as Array<{ id: string; revision?: number }>,
+    getByName: [] as string[]
+  }
+  const service = {
+    list: vi.fn(async () => [...store]),
+    getByName: vi.fn(async (name: string) => {
+      calls.getByName.push(name)
+      const found = store.find((p) => p.name === name)
+      if (!found) throw new Error(`Specialist "${name}" not found.`)
+      return found
+    }),
+    getById: vi.fn(async (id: string) => {
+      const found = store.find((p) => p.id === id)
+      if (!found) throw new Error(`Specialist ${id} not found.`)
+      return found
+    }),
+    update: vi.fn(async (input: { id: string; revision: number } & Record<string, unknown>) => {
+      calls.update.push({ id: input.id, patch: input, revision: input.revision })
+      const idx = store.findIndex((p) => p.id === input.id)
+      if (idx < 0) throw new Error('not found')
+      if (store[idx].revision !== input.revision) {
+        throw new Error('revision mismatch')
+      }
+      const next = opts.onUpdate
+        ? opts.onUpdate(input.id, input, input.revision)
+        : { ...store[idx], ...input, revision: store[idx].revision + 1 }
+      store[idx] = next
+      return next
+    }),
+    delete: vi.fn(async (id: string, revision?: number) => {
+      calls.delete.push({ id, revision })
+      if (opts.onDelete) opts.onDelete(id, revision)
+      const idx = store.findIndex((p) => p.id === id)
+      if (idx < 0) throw new Error('not found')
+      if (revision !== undefined && store[idx].revision !== revision) {
+        throw new Error('revision mismatch')
+      }
+      store = store.filter((p) => p.id !== id)
+    })
+  } as unknown as ProfileService
+  return {
+    service,
+    calls,
+    getStore: () => store,
+    setStore: (s: SpecialistProfileView[]) => (store = s)
+  }
+}
+
+describe('isNameChangingPatch — update classification', () => {
+  it('is privileged when the validated patch changes name', () => {
+    expect(isNameChangingPatch({ name: 'NEW_NAME' })).toBe(true)
+    expect(isNameChangingPatch({ name: 'NEW_NAME', description: 'x' })).toBe(true)
+  })
+  it('is NOT privileged when the patch leaves name unchanged', () => {
+    expect(isNameChangingPatch({ description: 'x' })).toBe(false)
+    expect(isNameChangingPatch({ enabled: false })).toBe(false)
+    expect(isNameChangingPatch({})).toBe(false)
+  })
+  it('ignores a name that equals undefined (omitted), not an empty rename intent', () => {
+    expect(isNameChangingPatch({ name: undefined })).toBe(false)
+  })
+})
+
+describe('applyNameChangingUpdate — approved atomic update', () => {
+  it('re-resolves public name to UUID, verifies the reviewed revision, commits, returns camelCase read-back', async () => {
+    const { service, calls } = makeService({ initial: [profile()] })
+    const patch: SpecialistUpdatePatch = {
+      name: 'DATA_SCIENTIST',
+      description: 'updated desc',
+      systemPrompt: 'new instructions'
+    }
+    const result = await applyNameChangingUpdate({
+      profileService: service,
+      decide: async () => fakeApproved(),
+      currentName: 'DATA_ANALYST',
+      reviewedRevision: 3,
+      patch
+    })
+    // Returned actual camelCase read-back, not the input patch.
+    expect(result).toEqual<AgentUpdatedResult>({
+      status: 'updated',
+      agent: expect.objectContaining({ id: 'sp-1', name: 'DATA_SCIENTIST', revision: 4 })
+    })
+    // Re-resolved by public name immediately before mutation.
+    expect(calls.getByName).toContain('DATA_ANALYST')
+    // One atomic update carrying the COMPLETE patch, revision verified.
+    expect(calls.update).toHaveLength(1)
+    expect(calls.update[0]).toEqual({
+      id: 'sp-1',
+      revision: 3,
+      patch: expect.objectContaining({
+        id: 'sp-1',
+        revision: 3,
+        name: 'DATA_SCIENTIST',
+        description: 'updated desc'
+      })
+    })
+  })
+
+  it('returns a structured declined result and applies NO part of the patch', async () => {
+    const { service, calls } = makeService({ initial: [profile()] })
+    const result = await applyNameChangingUpdate({
+      profileService: service,
+      decide: async () => fakeDeclined('update'),
+      currentName: 'DATA_ANALYST',
+      reviewedRevision: 3,
+      patch: { name: 'DATA_SCIENTIST', description: 'should not apply' }
+    })
+    expect(result).toEqual<AgentDeclinedResult>({ status: 'declined', operation: 'update' })
+    expect(calls.update).toHaveLength(0)
+  })
+})
+
+describe('applyNameChangingUpdate — post-approval revision drift fails closed', () => {
+  it('does not apply any part of the patch when revision changed after card creation', async () => {
+    const { service, calls } = makeService({
+      initial: [profile({ revision: 3 })],
+      // Simulate drift: someone bumped revision to 4 while the card was pending.
+      onUpdate: (_id, patch) => ({ ...profile({ revision: 3 }), ...patch, revision: 4 })
+    })
+    // Pre-mutate so the stored revision is now 4 (drifted from the reviewed 3).
+    await service.update({ id: 'sp-1', revision: 3, description: 'concurrent change' })
+    calls.update.length = 0
+
+    await expect(
+      applyNameChangingUpdate({
+        profileService: service,
+        decide: async () => fakeApproved(),
+        currentName: 'DATA_ANALYST',
+        reviewedRevision: 3,
+        patch: { name: 'DATA_SCIENTIST' }
+      })
+    ).rejects.toThrow(/host\.agents\.update:/)
+    expect(calls.update).toHaveLength(0)
+  })
+
+  it('fails closed when the target was renamed after card creation', async () => {
+    const { service } = makeService({ initial: [profile({ name: 'OTHER_NAME', revision: 3 })] })
+    await expect(
+      applyNameChangingUpdate({
+        profileService: service,
+        decide: async () => fakeApproved(),
+        currentName: 'DATA_ANALYST',
+        reviewedRevision: 3,
+        patch: { name: 'DATA_SCIENTIST' }
+      })
+    ).rejects.toThrow(/host\.agents\.update:/)
+  })
+
+  it('fails closed when the target was deleted after card creation', async () => {
+    const { service } = makeService({ initial: [] })
+    await expect(
+      applyNameChangingUpdate({
+        profileService: service,
+        decide: async () => fakeApproved(),
+        currentName: 'DATA_ANALYST',
+        reviewedRevision: 3,
+        patch: { name: 'DATA_SCIENTIST' }
+      })
+    ).rejects.toThrow(/host\.agents\.update:/)
+  })
+})
+
+describe('applyDelete — approved delete', () => {
+  it('re-resolves name, verifies absence, returns {status:"deleted", name} without clearing bindings', async () => {
+    const bindingClearCalls: string[] = []
+    const { service, calls } = makeService({ initial: [profile()] })
+    const result = await applyDelete({
+      profileService: service,
+      decide: async () => fakeApproved(),
+      currentName: 'DATA_ANALYST',
+      reviewedRevision: 3,
+      // A sink that WOULD clear bindings if the module were (incorrectly) wired to do so. The test
+      // asserts it is never called.
+      clearSessionBindings: async (id) => {
+        bindingClearCalls.push(id)
+      }
+    })
+    expect(result).toEqual<AgentDeletedResult>({ status: 'deleted', name: 'DATA_ANALYST' })
+    expect(calls.delete).toHaveLength(1)
+    expect(calls.delete[0]).toEqual({ id: 'sp-1', revision: 3 })
+    expect(bindingClearCalls).toHaveLength(0)
+  })
+
+  it('returns a structured declined result {operation:"delete"} with no mutation', async () => {
+    const { service, calls } = makeService({ initial: [profile()] })
+    const result = await applyDelete({
+      profileService: service,
+      decide: async () => fakeDeclined('delete'),
+      currentName: 'DATA_ANALYST',
+      reviewedRevision: 3
+    })
+    expect(result).toEqual<AgentDeclinedResult>({ status: 'declined', operation: 'delete' })
+    expect(calls.delete).toHaveLength(0)
+  })
+
+  it('deleting a bound Profile leaves bindings intact (sessions resolve unavailable later)', async () => {
+    const { service } = makeService({ initial: [profile()] })
+    // Provide a no-op binding sink; the contract is that delete NEVER clears/rewrites it.
+    await applyDelete({
+      profileService: service,
+      decide: async () => fakeApproved(),
+      currentName: 'DATA_ANALYST',
+      reviewedRevision: 3,
+      clearSessionBindings: async () => {
+        throw new Error('delete must not clear bindings')
+      }
+    })
+    // No throw => the sink was never invoked.
+  })
+
+  it('rethrows an unexpected absence-check error instead of misreporting a successful delete', async () => {
+    const { service } = makeService({ initial: [profile()] })
+    // The first getByName (re-resolve) succeeds; the absence-verification getByName (after delete)
+    // simulates a corrupt store throwing an I/O error rather than the expected "not found".
+    const getByName = vi.mocked(service.getByName)
+    getByName
+      .mockResolvedValueOnce(profile())
+      .mockRejectedValue(new Error('I/O error: corrupt specialist store'))
+    await expect(
+      applyDelete({
+        profileService: service,
+        decide: async () => fakeApproved(),
+        currentName: 'DATA_ANALYST',
+        reviewedRevision: 3
+      })
+    ).rejects.toThrow(/host\.agents\.delete:.*I\/O error/)
+  })
+
+  it('fails closed with a sanitized error when revision drifted before approval', async () => {
+    const { service } = makeService({ initial: [profile({ revision: 4 })] })
+    await expect(
+      applyDelete({
+        profileService: service,
+        decide: async () => fakeApproved(),
+        currentName: 'DATA_ANALYST',
+        reviewedRevision: 3
+      })
+    ).rejects.toThrow(/host\.agents\.delete:/)
+  })
+})
+
+describe('no-state-change guarantees on decline', () => {
+  it('declined update touches no mutation, no binding, no invalidation', async () => {
+    const invalidated = vi.fn()
+    const { service, calls } = makeService({ initial: [profile()] })
+    await applyNameChangingUpdate({
+      profileService: service,
+      decide: async () => fakeDeclined('update'),
+      currentName: 'DATA_ANALYST',
+      reviewedRevision: 3,
+      patch: { name: 'X' },
+      invalidateCatalog: invalidated
+    })
+    expect(calls.update).toHaveLength(0)
+    expect(invalidated).not.toHaveBeenCalled()
+  })
+
+  it('declined delete touches no mutation, no invalidation', async () => {
+    const invalidated = vi.fn()
+    const { service, calls } = makeService({ initial: [profile()] })
+    await applyDelete({
+      profileService: service,
+      decide: async () => fakeDeclined('delete'),
+      currentName: 'DATA_ANALYST',
+      reviewedRevision: 3,
+      invalidateCatalog: invalidated
+    })
+    expect(calls.delete).toHaveLength(0)
+    expect(invalidated).not.toHaveBeenCalled()
+  })
+
+  it('catalog invalidation runs ONLY after a successful mutation', async () => {
+    const invalidated = vi.fn()
+    const { service } = makeService({ initial: [profile()] })
+    await applyNameChangingUpdate({
+      profileService: service,
+      decide: async () => fakeApproved(),
+      currentName: 'DATA_ANALYST',
+      reviewedRevision: 3,
+      patch: { name: 'DATA_SCIENTIST' },
+      invalidateCatalog: invalidated
+    })
+    expect(invalidated).toHaveBeenCalledTimes(1)
+  })
+})

--- a/src/main/agents/specialist-privileged-ops.ts
+++ b/src/main/agents/specialist-privileged-ops.ts
@@ -1,0 +1,271 @@
+// Standalone privileged Specialist Profile operations: name-changing update + delete (issue 04).
+//
+// This module is the privileged-mutation branch of the conversational Specialist management flow.
+// It is deliberately standalone and independently testable: it consumes ONLY issue 02's
+// ApprovalGateway contract, the presentation mapper, and the existing ProfileService. It does NOT
+// import issue 03 (ordinary mutation) or issue 05 (switch) implementation modules. Issue 08 composes
+// it into the dispatcher.
+//
+// Design rules mirrored from design.md §7/§8/§10 and the issue 04 acceptance criteria:
+//  - `update(currentName, patch)` is privileged ONLY when the validated patch changes `name`. There
+//    is NO public rename() method; name-changing update is classified inside update().
+//  - Approval re-resolves the PUBLIC NAME to the UUID and verifies the REVIEWED REVISION immediately
+//    before committing. Pre-card resolution is never mutation authority.
+//  - An approved name-changing update commits the COMPLETE patch atomically through ProfileService
+//    and returns actual camelCase read-back.
+//  - A stale, renamed, deleted, or otherwise changed target after card creation FAILS CLOSED
+//    without applying any part of the patch (sanitized `host.agents.<method>:` error).
+//  - Delete verifies ABSENCE and returns `{ status: "deleted", name }` WITHOUT clearing or rewriting
+//    session UUID bindings. Bound conversations resolve unavailable later (design.md §10).
+//  - Decline returns a structured camelCase result such as `{ status: "declined", operation: "delete" }`
+//    and produces NO mutation, invalidation, binding, runtime, or renderer state change.
+//  - Catalog invalidation occurs ONLY after a successful mutation.
+
+import type { ApprovalGateway, ApprovalResult } from '../../shared/agents-contract'
+import type { SpecialistProfileView, UpdateSpecialistInput } from '../../shared/specialist'
+import type { ProfileService } from '../specialist/service'
+import type { SpecialistUpdatePatch } from './specialist-approval-presentation'
+
+const METHOD_PREFIX = 'host.agents'
+
+// Sanitizes an error into a stable, method-scoped message. System instructions, connector args,
+// credentials, and stack detail must never reach the sandbox. We keep only the top-level message.
+const sanitizeError = (value: unknown): string =>
+  value instanceof Error ? value.message : String(value)
+
+class PrivilegedOpError extends Error {
+  constructor(method: string, cause: unknown) {
+    super(`${METHOD_PREFIX}.${method}: ${sanitizeError(cause)}`)
+    this.name = 'PrivilegedOpError'
+  }
+}
+
+// ---------------------------------------------------------------------------
+// Result shapes (camelCase, returned to the SDK / Skill)
+// ---------------------------------------------------------------------------
+
+export type AgentUpdatedResult = {
+  status: 'updated'
+  agent: SpecialistProfileView
+}
+
+export type AgentDeletedResult = {
+  status: 'deleted'
+  name: string
+}
+
+export type AgentDeclinedResult = {
+  status: 'declined'
+  operation: 'update' | 'delete'
+  reason?: string
+}
+
+export type NameChangingUpdateResult = AgentUpdatedResult | AgentDeclinedResult
+export type DeleteResult = AgentDeletedResult | AgentDeclinedResult
+
+// ---------------------------------------------------------------------------
+// Classification: name-changing update is privileged ONLY when name changes
+// ---------------------------------------------------------------------------
+
+// True only when the validated patch carries a new `name`. An omitted/undefined name is not a rename
+// intent. There is no public rename() — this classifier is what update() uses to decide privilege.
+export const isNameChangingPatch = (patch: SpecialistUpdatePatch): boolean =>
+  patch.name !== undefined && patch.name.trim().length > 0
+
+// ---------------------------------------------------------------------------
+// Shared re-resolution: name -> UUID + revision verification immediately before mutation
+// ---------------------------------------------------------------------------
+
+// Resolves the public name to the live Profile and verifies the reviewed revision still matches.
+// Throws a sanitized error on any drift (missing, renamed, disabled is irrelevant for mutation, or
+// revision mismatch) so the caller fails closed. Pre-card resolution is never mutation authority —
+// the ONLY authority is this re-resolution, performed after approval.
+const reResolveForMutation = async (
+  method: string,
+  profileService: ProfileService,
+  currentName: string,
+  reviewedRevision: number
+): Promise<SpecialistProfileView> => {
+  let current: SpecialistProfileView
+  try {
+    current = await profileService.getByName(currentName)
+  } catch (error) {
+    // Target was renamed or deleted after card creation.
+    throw new PrivilegedOpError(method, error)
+  }
+  if (current.revision !== reviewedRevision) {
+    throw new PrivilegedOpError(
+      method,
+      `reviewed revision ${reviewedRevision} no longer matches current revision ${current.revision}`
+    )
+  }
+  return current
+}
+
+// ---------------------------------------------------------------------------
+// Privileged deps
+// ---------------------------------------------------------------------------
+
+export type PrivilegedOpDeps = {
+  profileService: ProfileService
+  // The injected approval gateway (issue 02 contract). Real production wiring is the ACP-backed
+  // gateway; tests pass fakes. A decline is a normal result, never a thrown error.
+  decide: (request: Parameters<ApprovalGateway['decide']>[0]) => Promise<ApprovalResult>
+  // Invalidates the runtime catalog (Settings/picker/runtime capability resolution). Invoked ONLY
+  // after a successful mutation; never on decline or failure.
+  invalidateCatalog?: () => Promise<void> | void
+}
+
+// ---------------------------------------------------------------------------
+// Name-changing update (atomic, privileged)
+// ---------------------------------------------------------------------------
+
+export type ApplyNameChangingUpdateDeps = PrivilegedOpDeps & {
+  currentName: string
+  reviewedRevision: number
+  patch: SpecialistUpdatePatch
+}
+
+// Converts the host.agents.update patch (snake/camel) into the UpdateSpecialistInput shape the
+// ProfileService expects. The mapper's SpecialistUpdatePatch already mirrors the service fields, so
+// this is a typed pass-through that pins id + revision from the re-resolved record.
+const toServiceUpdate = (
+  id: string,
+  revision: number,
+  patch: SpecialistUpdatePatch
+): UpdateSpecialistInput => ({
+  id,
+  revision,
+  name: patch.name,
+  displayName: patch.displayName,
+  description: patch.description,
+  systemPrompt: patch.systemPrompt,
+  iconKey: patch.iconKey,
+  colorKey: patch.colorKey,
+  capabilityMode: patch.capabilityMode,
+  fullAccess: patch.fullAccess,
+  selectedCapabilities: patch.selectedCapabilities
+})
+
+// Approves and atomically commits a name-changing update. On approval, re-resolves name -> UUID,
+// verifies the reviewed revision, commits the COMPLETE patch through ProfileService, invalidates the
+// catalog, and returns actual camelCase read-back. On decline, returns a structured declined result
+// with NO mutation. On drift/failure, throws a sanitized `host.agents.update:` error and applies no
+// part of the patch.
+export const applyNameChangingUpdate = async (
+  deps: ApplyNameChangingUpdateDeps
+): Promise<NameChangingUpdateResult> => {
+  const { profileService, currentName, reviewedRevision, patch } = deps
+
+  const decision = await deps.decide({
+    operation: 'update',
+    summary: { name: currentName, newName: patch.name },
+    session: {}
+  })
+  if (decision.status === 'declined') {
+    return { status: 'declined', operation: 'update', reason: decision.reason }
+  }
+
+  // Re-resolve public name -> UUID and verify the reviewed revision IMMEDIATELY before mutation.
+  const current = await reResolveForMutation(
+    'update',
+    profileService,
+    currentName,
+    reviewedRevision
+  )
+
+  let updated: SpecialistProfileView
+  try {
+    updated = await profileService.update(toServiceUpdate(current.id, current.revision, patch))
+  } catch (error) {
+    throw new PrivilegedOpError('update', error)
+  }
+
+  // `enabled` lives on a separate ProfileService method (update() does not carry it), mirroring the
+  // ordinary update path. After the atomic name-changing commit succeeds we have the real read-back;
+  // when the requested enabled state differs from the read-back, flip it via setEnabled and re-read.
+  // setEnabled is not revision-guarded (same as the ordinary path), so ordering update-first is safe
+  // and the stale-revision guard on the atomic rename still gates the whole mutation (defect #1).
+  if (patch.enabled !== undefined && patch.enabled !== updated.enabled) {
+    try {
+      updated = await profileService.setEnabled(current.id, patch.enabled)
+    } catch (error) {
+      throw new PrivilegedOpError('update', error)
+    }
+  }
+
+  if (deps.invalidateCatalog) await deps.invalidateCatalog()
+  return { status: 'updated', agent: updated }
+}
+
+// ---------------------------------------------------------------------------
+// Delete (privileged, fail-closed bindings)
+// ---------------------------------------------------------------------------
+
+export type ApplyDeleteDeps = PrivilegedOpDeps & {
+  currentName: string
+  reviewedRevision: number
+  // OPTIONAL sink that, IF provided, lets a caller (issue 08) observe the deleted UUID. This module
+  // NEVER invokes it: delete keeps stable UUID bindings so bound conversations resolve unavailable
+  // later (design.md §10). It exists only so the contract is testable — a test asserts it is never
+  // called. Clearing/rewriting bindings is explicitly forbidden behavior.
+  clearSessionBindings?: (specialistId: string) => Promise<void> | void
+}
+
+// Approves and deletes a Specialist. On approval, re-resolves name -> UUID, verifies the reviewed
+// revision, deletes through ProfileService, verifies absence, invalidates the catalog, and returns
+// `{ status: "deleted", name }`. Session UUID bindings are NEVER cleared or rewritten. On decline,
+// returns `{ status: "declined", operation: "delete" }` with NO mutation. On drift/failure, throws a
+// sanitized `host.agents.delete:` error.
+export const applyDelete = async (deps: ApplyDeleteDeps): Promise<DeleteResult> => {
+  const { profileService, currentName, reviewedRevision, clearSessionBindings } = deps
+
+  const decision = await deps.decide({
+    operation: 'delete',
+    summary: { name: currentName },
+    session: {}
+  })
+  if (decision.status === 'declined') {
+    return { status: 'declined', operation: 'delete', reason: decision.reason }
+  }
+
+  // Re-resolve and verify revision before mutation. The clearSessionBindings sink is intentionally
+  // NOT invoked here or anywhere — delete must not rewrite historical session bindings.
+  void clearSessionBindings
+
+  const current = await reResolveForMutation(
+    'delete',
+    profileService,
+    currentName,
+    reviewedRevision
+  )
+
+  try {
+    await profileService.delete(current.id, current.revision)
+  } catch (error) {
+    throw new PrivilegedOpError('delete', error)
+  }
+
+  // Verify absence: the name no longer resolves. Distinguish the EXPECTED "not found" (deletion
+  // succeeded) from an unexpected I/O or data error — mirror session-binding.ts so a corrupt store
+  // is diagnosable instead of being silently misreported as a successful deletion.
+  let stillPresent = false
+  try {
+    await profileService.getByName(currentName)
+    stillPresent = true
+  } catch (error) {
+    const message = error instanceof Error ? error.message : String(error)
+    if (!message.includes('not found')) {
+      // Not the expected "not found" — an unexpected store/IO failure. Must NOT be treated as
+      // "absence verified"; surface it as a sanitized delete error.
+      throw new PrivilegedOpError('delete', error)
+    }
+    // Expected: getByName threw "not found" — absence verified.
+  }
+  if (stillPresent) {
+    throw new PrivilegedOpError('delete', `specialist "${currentName}" still present after delete`)
+  }
+
+  if (deps.invalidateCatalog) await deps.invalidateCatalog()
+  return { status: 'deleted', name: currentName }
+}

--- a/src/main/agents/switch-operation.test.ts
+++ b/src/main/agents/switch-operation.test.ts
@@ -1,0 +1,727 @@
+// Tests for the standalone host.agents.switch(nameOrNull) operation module (issue 05).
+//
+// These tests use a FAKE approval gateway + fake notifier + fake persistence, so this slice proceeds
+// in parallel with issue 04 (the concrete broker); issue 08 composes the real wiring. The operation
+// must NEVER accept a sandbox-supplied session id — it uses only the trusted calling-session identity
+// captured by issue 02 and forwarded as server context.
+
+import { describe, expect, it, vi } from 'vitest'
+
+import {
+  SwitchOperation,
+  SwitchCommitSequencer,
+  SWITCH_METHOD,
+  type SwitchParams
+} from './switch-operation'
+import type {
+  ApprovalGateway,
+  ApprovalResult,
+  PendingSwitch,
+  SwitchNotifier
+} from '../../shared/agents-contract'
+import type { SpecialistProfileView } from '../../shared/specialist'
+import type { ProfileService } from '../specialist/service'
+import type { SessionBindingService } from '../specialist/session-binding'
+
+const profile = (overrides: Partial<SpecialistProfileView> = {}): SpecialistProfileView => ({
+  id: 'sp-1',
+  name: 'BIO_EXPERT',
+  displayName: 'Bio Expert',
+  description: 'a specialist',
+  systemPrompt: 'SECRET INSTRUCTIONS',
+  iconKey: 'beaker',
+  colorKey: 'green',
+  enabled: true,
+  capabilityMode: 'selected',
+  fullAccess: { excludedSkillIds: [], excludedConnectorIds: [], connectorTools: [] },
+  selectedCapabilities: { skillIds: ['demo'], connectorIds: [], connectorTools: [] },
+  revision: 3,
+  ...overrides
+})
+
+const makeProfileService = (
+  profiles: SpecialistProfileView[],
+  overrides: Partial<ProfileService> = {}
+): ProfileService =>
+  ({
+    list: vi.fn(async () => profiles),
+    getByName: vi.fn(async (name: string) => {
+      const found = profiles.find((p) => p.name === name)
+      if (!found) throw new Error(`Specialist "${name}" not found.`)
+      return found
+    }),
+    getById: vi.fn(async (id: string) => {
+      const found = profiles.find((p) => p.id === id)
+      if (!found) throw new Error(`Specialist ${id} not found.`)
+      return found
+    }),
+    ...overrides
+  }) as unknown as ProfileService
+
+const makeSessionBinding = (initial: Map<string, string | undefined>): SessionBindingService => {
+  const bindings = new Map(initial)
+  return {
+    setBinding: vi.fn((sessionId: string, specialistId: string | undefined) => {
+      if (specialistId === undefined) bindings.delete(sessionId)
+      else bindings.set(sessionId, specialistId)
+    }),
+    getBinding: vi.fn((sessionId: string) => bindings.get(sessionId)),
+    resolve: vi.fn(async (sessionId: string) => {
+      const id = bindings.get(sessionId)
+      if (!id) return { kind: 'main' as const }
+      return { kind: 'bound' as const, profile: profile({ id }) }
+    })
+  } as unknown as SessionBindingService
+}
+
+// An approval-gateway fake that always approves. `vi.fn(async () => ({ status: 'approved' }))` alone
+// widens `status` to `string`, which isn't assignable to the `(request) => Promise<ApprovalResult>`
+// contract — the explicit `Promise<ApprovalResult>` return annotation keeps the literal narrow.
+const approvingGateway = (): ApprovalGateway => ({
+  decide: vi.fn(async (): Promise<ApprovalResult> => ({ status: 'approved' }))
+})
+
+describe('SwitchOperation — target resolution', () => {
+  it('resolves an enabled custom Specialist by exact public name and returns persisted binding', async () => {
+    const ps = makeProfileService([profile()])
+    const binding = makeSessionBinding(new Map())
+    const persist = vi.fn(async () => undefined)
+    const notify = vi.fn(async () => undefined)
+    const op = new SwitchOperation({
+      profileService: ps,
+      sessionBinding: binding,
+      approvalGateway: approvingGateway(),
+      switchNotifier: { notify },
+      persistBinding: persist
+    })
+
+    const result = await op.run({ name: 'BIO_EXPERT' }, { sessionId: 'session-trusted' })
+
+    expect(result).toMatchObject({
+      status: 'approved',
+      operation: 'switch',
+      binding: { sessionId: 'session-trusted', specialistId: 'sp-1', targetName: 'BIO_EXPERT' },
+      pendingReconfigure: { sessionId: 'session-trusted', targetName: 'BIO_EXPERT' }
+    })
+    expect(persist).toHaveBeenCalledWith('session-trusted', 'sp-1')
+    expect(binding.setBinding).toHaveBeenCalledWith('session-trusted', 'sp-1')
+    expect(notify).toHaveBeenCalledWith({
+      sessionId: 'session-trusted',
+      targetName: 'BIO_EXPERT'
+    } satisfies PendingSwitch)
+  })
+
+  it('null name selects Main Agent without creating a mutable Main Profile', async () => {
+    const ps = makeProfileService([profile()])
+    const binding = makeSessionBinding(new Map([['session-trusted', 'sp-1']]))
+    const persist = vi.fn(async () => undefined)
+    const notify = vi.fn(async () => undefined)
+    const op = new SwitchOperation({
+      profileService: ps,
+      sessionBinding: binding,
+      approvalGateway: approvingGateway(),
+      switchNotifier: { notify },
+      persistBinding: persist
+    })
+
+    const result = (await op.run({ name: null }, { sessionId: 'session-trusted' })) as {
+      status: string
+      binding: { specialistId: string | undefined; targetName: string | null }
+    }
+
+    expect(result.status).toBe('approved')
+    expect(result.binding.specialistId).toBeUndefined()
+    expect(result.binding.targetName).toBeNull()
+    expect(persist).toHaveBeenCalledWith('session-trusted', undefined)
+    expect(binding.setBinding).toHaveBeenCalledWith('session-trusted', undefined)
+    expect(notify).toHaveBeenCalledWith({
+      sessionId: 'session-trusted',
+      targetName: null
+    } satisfies PendingSwitch)
+    // A Main switch never re-resolves a Specialist (no mutable Main Profile is ever read or created):
+    // getByName is called at most once for the pre-resolution probe, and the binding is simply cleared.
+    expect((ps.getByName as unknown as { mock: { calls: unknown[] } }).mock.calls).toHaveLength(0)
+  })
+
+  it('rejects a disabled Specialist with a host.agents.switch-prefixed error before approval', async () => {
+    const ps = makeProfileService([profile({ enabled: false })])
+    const gateway = approvingGateway()
+    const binding = makeSessionBinding(new Map())
+    const op = new SwitchOperation({
+      profileService: ps,
+      sessionBinding: binding,
+      approvalGateway: gateway,
+      switchNotifier: { notify: vi.fn() },
+      persistBinding: vi.fn()
+    })
+
+    await expect(op.run({ name: 'BIO_EXPERT' }, { sessionId: 'session-trusted' })).rejects.toThrow(
+      /host\.agents\.switch:/
+    )
+    // Approval gateway is never consulted because pre-approval resolution already failed closed.
+    expect(gateway.decide).not.toHaveBeenCalled()
+  })
+
+  it('rejects an unknown name with a host.agents.switch-prefixed error', async () => {
+    const ps = makeProfileService([])
+    const op = new SwitchOperation({
+      profileService: ps,
+      sessionBinding: makeSessionBinding(new Map()),
+      approvalGateway: { decide: vi.fn() },
+      switchNotifier: { notify: vi.fn() },
+      persistBinding: vi.fn()
+    })
+    await expect(op.run({ name: 'GHOST' }, { sessionId: 'session-trusted' })).rejects.toThrow(
+      /host\.agents\.switch:/
+    )
+  })
+
+  it('does not accept a sandbox-supplied session id: uses only the trusted context', async () => {
+    const ps = makeProfileService([profile()])
+    const binding = makeSessionBinding(new Map())
+    const persist = vi.fn(async () => undefined)
+    const op = new SwitchOperation({
+      profileService: ps,
+      sessionBinding: binding,
+      approvalGateway: approvingGateway(),
+      switchNotifier: { notify: vi.fn() },
+      persistBinding: persist
+    })
+    // A sandbox tries to forge a session id inside params. The dispatcher already strips reserved
+    // keys, but even if a forged 'session_id' survived here it MUST be ignored — only the trusted
+    // context session is honored.
+    await op.run(
+      { name: 'BIO_EXPERT', session_id: 'forged', sessionId: 'forged' } as unknown as SwitchParams,
+      { sessionId: 'session-trusted' }
+    )
+    expect(persist).toHaveBeenCalledWith('session-trusted', 'sp-1')
+    expect(binding.setBinding).toHaveBeenCalledWith('session-trusted', 'sp-1')
+  })
+
+  it('fails closed when no trusted calling session identity is present', async () => {
+    const op = new SwitchOperation({
+      profileService: makeProfileService([profile()]),
+      sessionBinding: makeSessionBinding(new Map()),
+      approvalGateway: { decide: vi.fn() },
+      switchNotifier: { notify: vi.fn() },
+      persistBinding: vi.fn()
+    })
+    await expect(op.run({ name: 'BIO_EXPERT' }, {})).rejects.toThrow(/host\.agents\.switch:/)
+    await expect(op.run({ name: 'BIO_EXPERT' }, { sessionId: '' })).rejects.toThrow(
+      /host\.agents\.switch:/
+    )
+  })
+})
+
+describe('SwitchOperation — approval gateway', () => {
+  it('emits the shared switch approval request shape with the trusted session', async () => {
+    const ps = makeProfileService([profile()])
+    const decide = vi.fn(async (): Promise<ApprovalResult> => ({ status: 'approved' }))
+    const op = new SwitchOperation({
+      profileService: ps,
+      sessionBinding: makeSessionBinding(new Map()),
+      approvalGateway: { decide },
+      switchNotifier: { notify: vi.fn() },
+      persistBinding: vi.fn(async () => undefined)
+    })
+
+    await op.run({ name: 'BIO_EXPERT' }, { sessionId: 'session-trusted' })
+
+    expect(decide).toHaveBeenCalledWith({
+      operation: 'switch',
+      summary: expect.objectContaining({ target: 'BIO_EXPERT' }),
+      session: { sessionId: 'session-trusted' }
+    })
+  })
+
+  it('summary.name is the CURRENT specialist (not the target) for a specialist→specialist switch', async () => {
+    // The approval card shows current → target. `summary.name` must carry the CURRENT binding's public
+    // name so the struck-through label is correct; `summary.target` carries the destination.
+    const ps = makeProfileService([
+      profile({ id: 'sp-current', name: 'CURRENT' }),
+      profile({ id: 'sp-target', name: 'TARGET' })
+    ])
+    const decide = vi.fn(async (): Promise<ApprovalResult> => ({ status: 'approved' }))
+    const op = new SwitchOperation({
+      profileService: ps,
+      // The session is currently bound to the "CURRENT" specialist.
+      sessionBinding: makeSessionBinding(new Map([['session-trusted', 'sp-current']])),
+      approvalGateway: { decide },
+      switchNotifier: { notify: vi.fn() },
+      persistBinding: vi.fn(async () => undefined)
+    })
+
+    await op.run({ name: 'TARGET' }, { sessionId: 'session-trusted' })
+
+    expect(decide).toHaveBeenCalledWith({
+      operation: 'switch',
+      summary: expect.objectContaining({ name: 'CURRENT', target: 'TARGET' }),
+      session: { sessionId: 'session-trusted' }
+    })
+  })
+
+  it('summary.name is the CURRENT specialist for a specialist→Main switch (target: null)', async () => {
+    // Reverting to Main still names the current specialist in `summary.name`; `target` is null.
+    const ps = makeProfileService([profile({ id: 'sp-current', name: 'CURRENT' })])
+    const decide = vi.fn(async (): Promise<ApprovalResult> => ({ status: 'approved' }))
+    const op = new SwitchOperation({
+      profileService: ps,
+      sessionBinding: makeSessionBinding(new Map([['session-trusted', 'sp-current']])),
+      approvalGateway: { decide },
+      switchNotifier: { notify: vi.fn() },
+      persistBinding: vi.fn(async () => undefined)
+    })
+
+    await op.run({ name: null }, { sessionId: 'session-trusted' })
+
+    expect(decide).toHaveBeenCalledWith({
+      operation: 'switch',
+      summary: expect.objectContaining({ name: 'CURRENT', target: null }),
+      session: { sessionId: 'session-trusted' }
+    })
+  })
+
+  it('summary.name is omitted when the session is currently on Main (no current binding)', async () => {
+    // From Main → Specialist there is no current specialist name to show; `summary.name` is omitted
+    // (it stays out of the object, never carries the target as the current name).
+    const ps = makeProfileService([profile({ id: 'sp-target', name: 'TARGET' })])
+    const decide = vi.fn(async (): Promise<ApprovalResult> => ({ status: 'approved' }))
+    const op = new SwitchOperation({
+      profileService: ps,
+      sessionBinding: makeSessionBinding(new Map()),
+      approvalGateway: { decide },
+      switchNotifier: { notify: vi.fn() },
+      persistBinding: vi.fn(async () => undefined)
+    })
+
+    await op.run({ name: 'TARGET' }, { sessionId: 'session-trusted' })
+
+    expect(decide).toHaveBeenCalledWith({
+      operation: 'switch',
+      summary: expect.objectContaining({ target: 'TARGET' }),
+      session: { sessionId: 'session-trusted' }
+    })
+    // The decide mock is annotated by return type only (keeps the `status` literal narrow — see
+    // approvingGateway above), so its `.mock.calls` args are typed as an empty tuple. Reach the
+    // captured request via the same `unknown` cast used elsewhere in this file.
+    const decideCalls = (
+      decide as unknown as { mock: { calls: { summary: { name?: string } }[][] } }
+    ).mock.calls
+    expect(decideCalls[0][0].summary.name).toBeUndefined()
+  })
+
+  it('decline returns { status: "declined", operation: "switch" } and changes nothing', async () => {
+    const ps = makeProfileService([profile()])
+    const binding = makeSessionBinding(new Map([['session-trusted', undefined]]))
+    const persist = vi.fn(async () => undefined)
+    const notify = vi.fn(async () => undefined)
+    const gateway: ApprovalGateway = {
+      decide: vi.fn(async (): Promise<ApprovalResult> => ({
+        status: 'declined',
+        operation: 'switch'
+      }))
+    }
+    const op = new SwitchOperation({
+      profileService: ps,
+      sessionBinding: binding,
+      approvalGateway: gateway,
+      switchNotifier: { notify },
+      persistBinding: persist
+    })
+
+    const result = await op.run({ name: 'BIO_EXPERT' }, { sessionId: 'session-trusted' })
+
+    expect(result).toEqual({ status: 'declined', operation: 'switch' })
+    expect(persist).not.toHaveBeenCalled()
+    expect(binding.setBinding).not.toHaveBeenCalled()
+    expect(notify).not.toHaveBeenCalled()
+  })
+})
+
+describe('SwitchOperation — approval-time re-validation (fail closed)', () => {
+  it('fails closed when the target was renamed between approval and commit', async () => {
+    let resolveCount = 0
+    const ps = makeProfileService([profile()])
+    // On the approval-time re-resolution, the profile is gone (renamed away / deleted).
+    ps.getByName = vi.fn(async (name: string) => {
+      resolveCount += 1
+      if (resolveCount === 1) return profile({ name })
+      throw new Error(`Specialist "${name}" not found.`)
+    })
+    const op = new SwitchOperation({
+      profileService: ps,
+      sessionBinding: makeSessionBinding(new Map()),
+      approvalGateway: approvingGateway(),
+      switchNotifier: { notify: vi.fn() },
+      persistBinding: vi.fn()
+    })
+
+    await expect(op.run({ name: 'BIO_EXPERT' }, { sessionId: 'session-trusted' })).rejects.toThrow(
+      /host\.agents\.switch:/
+    )
+  })
+
+  it('fails closed when the target was disabled after approval', async () => {
+    let resolveCount = 0
+    const ps = makeProfileService([profile()])
+    ps.getByName = vi.fn(async (name: string) => {
+      resolveCount += 1
+      if (resolveCount === 1) return profile({ name, enabled: true })
+      return profile({ name, enabled: false })
+    })
+    const persist = vi.fn(async () => undefined)
+    const op = new SwitchOperation({
+      profileService: ps,
+      sessionBinding: makeSessionBinding(new Map()),
+      approvalGateway: approvingGateway(),
+      switchNotifier: { notify: vi.fn() },
+      persistBinding: persist
+    })
+    await expect(op.run({ name: 'BIO_EXPERT' }, { sessionId: 'session-trusted' })).rejects.toThrow(
+      /host\.agents\.switch:/
+    )
+    expect(persist).not.toHaveBeenCalled()
+  })
+
+  it('fails closed on revision drift when a reviewed revision was carried', async () => {
+    let resolveCount = 0
+    const ps = makeProfileService([profile({ revision: 3 })])
+    ps.getByName = vi.fn(async (name: string) => {
+      resolveCount += 1
+      if (resolveCount === 1) return profile({ name, revision: 3 })
+      return profile({ name, revision: 4 })
+    })
+    const persist = vi.fn(async () => undefined)
+    const op = new SwitchOperation({
+      profileService: ps,
+      sessionBinding: makeSessionBinding(new Map()),
+      approvalGateway: approvingGateway(),
+      switchNotifier: { notify: vi.fn() },
+      persistBinding: persist
+    })
+    await expect(
+      op.run({ name: 'BIO_EXPERT', revision: 3 }, { sessionId: 'session-trusted' })
+    ).rejects.toThrow(/host\.agents\.switch:/)
+    expect(persist).not.toHaveBeenCalled()
+  })
+
+  it('does not broaden to Main Agent on target failure', async () => {
+    const ps = makeProfileService([])
+    const binding = makeSessionBinding(new Map())
+    const persist = vi.fn(async () => undefined)
+    const op = new SwitchOperation({
+      profileService: ps,
+      sessionBinding: binding,
+      approvalGateway: approvingGateway(),
+      switchNotifier: { notify: vi.fn() },
+      persistBinding: persist
+    })
+    await expect(op.run({ name: 'GHOST' }, { sessionId: 'session-trusted' })).rejects.toThrow(
+      /host\.agents\.switch:/
+    )
+    // No Main clearing, no broadcast, no persistence — fail closed, never broadens to Main.
+    expect(persist).not.toHaveBeenCalled()
+    expect(binding.setBinding).not.toHaveBeenCalled()
+  })
+})
+
+describe('SwitchOperation — last-write-wins & restart survival', () => {
+  it('multiple approved switches before the next message are last-write-wins', async () => {
+    const ps = makeProfileService([
+      profile({ id: 'sp-1', name: 'A' }),
+      profile({ id: 'sp-2', name: 'B' })
+    ])
+    const persist = vi.fn(async () => undefined)
+    const notify = vi.fn(async () => undefined)
+    const op = new SwitchOperation({
+      profileService: ps,
+      sessionBinding: makeSessionBinding(new Map()),
+      approvalGateway: approvingGateway(),
+      switchNotifier: { notify },
+      persistBinding: persist
+    })
+
+    const first = (await op.run({ name: 'A' }, { sessionId: 'session-trusted' })) as {
+      binding: { specialistId: string }
+    }
+    const second = (await op.run({ name: 'B' }, { sessionId: 'session-trusted' })) as {
+      binding: { specialistId: string }
+    }
+
+    expect(first.binding.specialistId).toBe('sp-1')
+    expect(second.binding.specialistId).toBe('sp-2')
+    // Final persisted/broadcast state is the newer target (B).
+    expect(persist).toHaveBeenLastCalledWith('session-trusted', 'sp-2')
+    expect(notify).toHaveBeenLastCalledWith({
+      sessionId: 'session-trusted',
+      targetName: 'B'
+    } satisfies PendingSwitch)
+  })
+
+  it('a stale completion does not overwrite a newer approved target', async () => {
+    const ps = makeProfileService([
+      profile({ id: 'sp-1', name: 'A' }),
+      profile({ id: 'sp-2', name: 'B' })
+    ])
+    const persist = vi.fn(async () => undefined)
+    const notify = vi.fn(async () => undefined)
+    const op = new SwitchOperation({
+      profileService: ps,
+      sessionBinding: makeSessionBinding(new Map()),
+      approvalGateway: approvingGateway(),
+      switchNotifier: { notify },
+      persistBinding: persist
+    })
+
+    // Start the first switch, interleave a newer one before the first commits. The first (stale)
+    // completion must NOT overwrite the newer persisted target.
+    const first = op.run({ name: 'A' }, { sessionId: 'session-trusted' })
+    await op.run({ name: 'B' }, { sessionId: 'session-trusted' })
+    await first
+
+    expect(persist).toHaveBeenLastCalledWith('session-trusted', 'sp-2')
+    expect(notify).toHaveBeenLastCalledWith({
+      sessionId: 'session-trusted',
+      targetName: 'B'
+    } satisfies PendingSwitch)
+  })
+
+  it('last-write-wins holds across separate per-call instances sharing the dispatcher sequencer', async () => {
+    // Production (agents-service.ts runSwitch) creates a NEW SwitchOperation per host.agents.switch
+    // call. The guard must still order interleaved commits because the dispatcher shares ONE
+    // sequencer across those instances — without it, per-instance counters reset and a stale older
+    // completion overwrites the newer target.
+    const ps = makeProfileService([
+      profile({ id: 'sp-1', name: 'A' }),
+      profile({ id: 'sp-2', name: 'B' })
+    ])
+    const persist = vi.fn(async () => undefined)
+    const notify = vi.fn(async () => undefined)
+    const sharedSequencer = new SwitchCommitSequencer()
+    const makeOp = (): SwitchOperation =>
+      new SwitchOperation({
+        profileService: ps,
+        sessionBinding: makeSessionBinding(new Map()),
+        approvalGateway: approvingGateway(),
+        switchNotifier: { notify },
+        persistBinding: persist,
+        sequencer: sharedSequencer
+      })
+
+    // Two separate instances (as the dispatcher creates), interleaved. The first (A) is stale; the
+    // newer (B) must own the final persisted/broadcast state.
+    const first = makeOp().run({ name: 'A' }, { sessionId: 'session-trusted' })
+    await makeOp().run({ name: 'B' }, { sessionId: 'session-trusted' })
+    await first
+
+    expect(persist).toHaveBeenLastCalledWith('session-trusted', 'sp-2')
+    expect(notify).toHaveBeenLastCalledWith({
+      sessionId: 'session-trusted',
+      targetName: 'B'
+    } satisfies PendingSwitch)
+  })
+
+  it('successful switch returns actual persisted binding/pending read-back', async () => {
+    const ps = makeProfileService([profile({ id: 'sp-9', name: 'Z', revision: 7 })])
+    const op = new SwitchOperation({
+      profileService: ps,
+      sessionBinding: makeSessionBinding(new Map()),
+      approvalGateway: approvingGateway(),
+      switchNotifier: { notify: vi.fn() },
+      persistBinding: vi.fn(async () => undefined)
+    })
+
+    const result = (await op.run({ name: 'Z' }, { sessionId: 'sX' })) as {
+      binding: { sessionId: string; specialistId: string; targetName: string; revision: number }
+      pendingReconfigure: PendingSwitch
+    }
+    // Read-back reflects the actual persisted record (id/revision), not the request.
+    expect(result.binding.specialistId).toBe('sp-9')
+    expect(result.binding.revision).toBe(7)
+    expect(result.binding.targetName).toBe('Z')
+    expect(result.pendingReconfigure).toEqual({ sessionId: 'sX', targetName: 'Z' })
+  })
+
+  it('approval immediately persists + broadcasts a pending-reconfigure notification', async () => {
+    const ps = makeProfileService([profile()])
+    const persist = vi.fn(async () => undefined)
+    const order: string[] = []
+    const notify = vi.fn(async () => {
+      order.push('notify')
+    })
+    persist.mockImplementation(async () => {
+      order.push('persist')
+    })
+    const op = new SwitchOperation({
+      profileService: ps,
+      sessionBinding: makeSessionBinding(new Map()),
+      approvalGateway: approvingGateway(),
+      switchNotifier: { notify },
+      persistBinding: persist
+    })
+    await op.run({ name: 'BIO_EXPERT' }, { sessionId: 'session-trusted' })
+    expect(order).toEqual(['persist', 'notify'])
+  })
+})
+
+describe('SwitchOperation — sanitization and no-sensitive-data', () => {
+  it('sanitizes persistence failure as a host.agents.switch-prefixed error', async () => {
+    const op = new SwitchOperation({
+      profileService: makeProfileService([profile()]),
+      sessionBinding: makeSessionBinding(new Map()),
+      approvalGateway: approvingGateway(),
+      switchNotifier: { notify: vi.fn() },
+      persistBinding: vi.fn(async () => {
+        throw new Error('disk write failed: credentials=/etc/shadow')
+      })
+    })
+    await expect(op.run({ name: 'BIO_EXPERT' }, { sessionId: 'session-trusted' })).rejects.toThrow(
+      /host\.agents\.switch:/
+    )
+  })
+
+  it('notify failure does NOT throw: the persisted binding is authoritative and the switch still reports approved', async () => {
+    // The broadcast is a best-effort renderer mirror; the persisted binding is authoritative and
+    // applies at the next send. A notify rejection must NOT surface as a thrown error to the caller —
+    // the switch has already committed (persisted + set in memory). Only persist/setBinding errors
+    // remain fatal.
+    const ps = makeProfileService([profile({ id: 'sp-1', name: 'BIO_EXPERT' })])
+    const persist = vi.fn(async () => undefined)
+    const binding = makeSessionBinding(new Map())
+    const op = new SwitchOperation({
+      profileService: ps,
+      sessionBinding: binding,
+      approvalGateway: approvingGateway(),
+      switchNotifier: {
+        notify: vi.fn(async () => {
+          throw new Error('renderer broadcast down')
+        })
+      },
+      persistBinding: persist
+    })
+
+    const result = await op.run({ name: 'BIO_EXPERT' }, { sessionId: 'session-trusted' })
+
+    // The switch committed despite the notify failure.
+    expect(result).toMatchObject({ status: 'approved' })
+    expect(persist).toHaveBeenCalledWith('session-trusted', 'sp-1')
+    expect(binding.setBinding).toHaveBeenCalledWith('session-trusted', 'sp-1')
+  })
+
+  it('approval summary and notifications contain no system instructions or sensitive data', async () => {
+    const ps = makeProfileService([profile({ systemPrompt: 'SECRET INSTRUCTIONS' })])
+    const decide = vi.fn(async (): Promise<ApprovalResult> => ({ status: 'approved' }))
+    const notify = vi.fn(async () => undefined)
+    const op = new SwitchOperation({
+      profileService: ps,
+      sessionBinding: makeSessionBinding(new Map()),
+      approvalGateway: { decide },
+      switchNotifier: { notify },
+      persistBinding: vi.fn(async () => undefined)
+    })
+    await op.run({ name: 'BIO_EXPERT' }, { sessionId: 'session-trusted' })
+
+    // Serialize the FULL recorded calls (one each) — no [0][0] tuple access needed on the no-arg
+    // mocks. If any system instructions leaked into the request or notification, this would contain
+    // them.
+    const serialized = JSON.stringify(decide.mock.calls) + JSON.stringify(notify.mock.calls)
+    expect(serialized).not.toContain('SECRET INSTRUCTIONS')
+    expect(serialized).not.toContain('systemPrompt')
+  })
+})
+
+describe('SwitchOperation — durable next-message reconfigure lifecycle', () => {
+  // The operation module must NEVER dispose the running Agent that hosts the agentsCall. The runtime
+  // reconfigure barrier (existing runtime.switchSpecialist → contextReset + history replay) runs at
+  // the SAFE next-message boundary, not inside this SDK call. This module's responsibility is to
+  // persist the binding + broadcast a pending-reconfigure and nothing more on the runtime side.
+  it('does not touch the runtime reconfigure barrier inside the SDK call (current reply completes)', async () => {
+    const runtimeSwitch = vi.fn(async () => ({ contextReset: false }))
+    // The deps deliberately have NO runtime-switch callback: the module physically cannot call it.
+    const op = new SwitchOperation({
+      profileService: makeProfileService([profile()]),
+      sessionBinding: makeSessionBinding(new Map()),
+      approvalGateway: approvingGateway(),
+      switchNotifier: { notify: vi.fn() },
+      persistBinding: vi.fn(async () => undefined)
+    })
+    await op.run({ name: 'BIO_EXPERT' }, { sessionId: 'session-trusted' })
+    expect(runtimeSwitch).not.toHaveBeenCalled()
+  })
+
+  it('persists the binding immediately so it survives application restart before the next message', async () => {
+    const ps = makeProfileService([profile({ id: 'sp-7', name: 'Z' })])
+    const persist = vi.fn(async () => undefined)
+    const op = new SwitchOperation({
+      profileService: ps,
+      sessionBinding: makeSessionBinding(new Map()),
+      approvalGateway: approvingGateway(),
+      switchNotifier: { notify: vi.fn() },
+      persistBinding: persist
+    })
+    await op.run({ name: 'Z' }, { sessionId: 'session-restart' })
+    // The durable writer was invoked with the target UUID — restart reads this back, not a snapshot.
+    expect(persist).toHaveBeenCalledWith('session-restart', 'sp-7')
+  })
+
+  it('broadcasts the pending-reconfigure intent the renderer/runtime consumes at the next send', async () => {
+    const notify = vi.fn(async () => undefined) as unknown as SwitchNotifier['notify']
+    const op = new SwitchOperation({
+      profileService: makeProfileService([profile({ name: 'SQL_WRANGLER' })]),
+      sessionBinding: makeSessionBinding(new Map()),
+      approvalGateway: approvingGateway(),
+      switchNotifier: { notify },
+      persistBinding: vi.fn(async () => undefined)
+    })
+    await op.run({ name: 'SQL_WRANGLER' }, { sessionId: 'session-next' })
+    const pending = (notify as unknown as { mock: { calls: PendingSwitch[][] } }).mock.calls[0][0]
+    expect(pending).toEqual({ sessionId: 'session-next', targetName: 'SQL_WRANGLER' })
+  })
+
+  it('a stale reconfigure target does not silently broaden to Main Agent', async () => {
+    // If reconfiguration of the approved target later fails (target disabled mid-flight), the
+    // operation has already failed closed at approval-time re-validation — there is no path that
+    // clears the binding to Main on failure.
+    let resolveCount = 0
+    const ps = makeProfileService([profile({ name: 'FLAKY' })])
+    ps.getByName = vi.fn(async (name: string) => {
+      resolveCount += 1
+      if (resolveCount === 1) return profile({ name, enabled: true })
+      return profile({ name, enabled: false }) // disabled at commit time → fail closed, not Main.
+    })
+    const persist = vi.fn(async () => undefined)
+    const op = new SwitchOperation({
+      profileService: ps,
+      sessionBinding: makeSessionBinding(new Map()),
+      approvalGateway: approvingGateway(),
+      switchNotifier: { notify: vi.fn() },
+      persistBinding: persist
+    })
+    await expect(op.run({ name: 'FLAKY' }, { sessionId: 's' })).rejects.toThrow(
+      /host\.agents\.switch:/
+    )
+    expect(persist).not.toHaveBeenCalledWith('s', undefined) // never broadened to Main
+  })
+})
+
+describe('SwitchOperation — does not import issue 03/04 implementation', () => {
+  it('exposes the SWITCH method constant used by the dispatcher', () => {
+    expect(SWITCH_METHOD).toBe('switch')
+  })
+
+  it('notifier is the only broadcast seam (no parallel switch service)', async () => {
+    // The notifier contract is the single sink; confirming it is invoked with PendingSwitch shape.
+    const notify = vi.fn(async () => undefined) as unknown as SwitchNotifier['notify']
+    const op = new SwitchOperation({
+      profileService: makeProfileService([profile()]),
+      sessionBinding: makeSessionBinding(new Map()),
+      approvalGateway: approvingGateway(),
+      switchNotifier: { notify },
+      persistBinding: vi.fn(async () => undefined)
+    })
+    await op.run({ name: 'BIO_EXPERT' }, { sessionId: 's' })
+    expect(notify).toHaveBeenCalledTimes(1)
+    const pending = (notify as unknown as { mock: { calls: PendingSwitch[][] } }).mock.calls[0][0]
+    expect(pending).toEqual({ sessionId: 's', targetName: 'BIO_EXPERT' })
+  })
+})

--- a/src/main/agents/switch-operation.ts
+++ b/src/main/agents/switch-operation.ts
@@ -1,0 +1,366 @@
+// host.agents.switch(nameOrNull) operation module (issue 05).
+//
+// This is the standalone, durable next-message switch lifecycle for the trusted calling conversation.
+// It resolves the target, requests the injected issue-02 approval gateway, and — on approval —
+// persists the binding immediately and broadcasts a pending-reconfigure notification. The runtime
+// reconfigure happens at the SAFE next-message boundary, so the Agent executing this SDK call is
+// never destroyed before `agentsCall` returns (design.md §9 / PRD §8).
+//
+// BOUNDARIES (design.md §9, cross-cutting requirements):
+//  - Reuses the EXISTING SessionBindingService (in-memory binding) + the EXISTING durable
+//    persistence seam + the EXISTING runtime reconfigure barrier + history replay. It does NOT
+//    create a parallel switch service, a renderer-only durable binding, or a new approval broker.
+//  - Real approval-broker composition is deferred to issue 08; tests wire a FAKE gateway.
+//  - NEVER accepts a sandbox-supplied session id. The trusted calling-session identity is captured
+//    outside the sandbox (issue 02) and injected as server context. Reserved routing/identity keys
+//    are stripped by the dispatcher before this module runs; even if one survived it is ignored.
+//  - Errors are sanitized and prefixed `host.agents.switch:`. Logs, summaries, and notifications
+//    exclude system instructions, history text, tokens, and sensitive runtime configuration.
+//  - Switch NEVER broadens to Main Agent on target or reconfigure failure (fail closed).
+
+import type {
+  ApprovalGateway,
+  PendingSwitch,
+  SwitchNotifier,
+  TrustedCallingSession
+} from '../../shared/agents-contract'
+import type { SpecialistProfileView } from '../../shared/specialist'
+import type { ProfileService } from '../specialist/service'
+import type { SessionBindingService } from '../specialist/session-binding'
+
+// The method name used to prefix sanitized errors and to echo in structured results.
+export const SWITCH_METHOD = 'switch' as const
+
+// Sanitizes an arbitrary cause into a top-level message. System instructions, connector args,
+// credentials, headers, environment values, and stack detail must never leak to the sandbox.
+const sanitizeCause = (cause: unknown): string =>
+  cause instanceof Error ? cause.message : String(cause)
+
+class SwitchError extends Error {
+  constructor(cause: unknown) {
+    super(`host.agents.${SWITCH_METHOD}: ${sanitizeCause(cause)}`)
+    this.name = 'AgentsCallError'
+  }
+}
+
+// The injected, fake-able dependencies. The durable persistence callback and SessionBindingService
+// are the SAME authoritative seams the existing SET_SESSION_SPECIALIST IPC handler uses — there is
+// no parallel switch service. The runtime reconfigure callback is intentionally NOT part of this
+// module: it runs at the safe next-message boundary, not inside this SDK call.
+export type SwitchOperationDeps = {
+  profileService: ProfileService
+  sessionBinding: SessionBindingService
+  approvalGateway: ApprovalGateway
+  switchNotifier: SwitchNotifier
+  // Persists only the specialist UUID (or cleared Main binding) to the durable session file so the
+  // approved binding survives application restart. Reuses the existing persistence seam.
+  persistBinding: (sessionId: string, specialistId: string | undefined) => Promise<void>
+  // Long-lived, session-keyed sequencer for the last-write-wins guard. The dispatcher supplies ONE
+  // shared instance (held on AgentsService) so generation state survives the per-call instantiation;
+  // tests omit it to get a per-instance sequencer.
+  sequencer?: SwitchCommitSequencer
+}
+
+// Public-name-or-null params after the dispatcher strips reserved routing/identity keys. `revision`
+// optionally carries the reviewed revision so approval-time drift fails closed (PRD §8:267).
+export type SwitchParams = {
+  name?: string | null
+  revision?: number
+}
+
+// The read-back binding state returned after an approved switch. Mirrors what was actually
+// persisted: never contains system instructions or sensitive runtime configuration.
+export type SwitchBindingReadBack = {
+  sessionId: string
+  // The persisted specialist UUID, or undefined when the binding was cleared to Main Agent.
+  specialistId: string | undefined
+  // The target public name (null = Main Agent). Echoed for diagnostics; never a secret.
+  targetName: string | null
+  // The live record revision at commit time (omitted for Main).
+  revision?: number
+}
+
+// The structured result contract. A decline is a NORMAL camelCase result — not an error.
+export type SwitchResult =
+  | {
+      status: 'approved'
+      operation: typeof SWITCH_METHOD
+      binding: SwitchBindingReadBack
+      // The pending-reconfigure intent broadcast to the renderer/runtime. The approved target takes
+      // effect on the NEXT message; it survives restart.
+      pendingReconfigure: PendingSwitch
+    }
+  | { status: 'declined'; operation: typeof SWITCH_METHOD }
+
+// Internal bookkeeping for last-write-wins across interleaved approved switches. Each approved run
+// captures the monotonic generation it observed at approval time; a completion whose generation is
+// older than the newest committed generation is a stale write and is discarded.
+type PendingCommit = {
+  generation: number
+  specialistId: string | undefined
+  targetName: string | null
+  revision?: number
+}
+
+// Long-lived, session-keyed commit sequencer for the switch last-write-wins guard. The dispatcher
+// (agents-service.ts runSwitch) creates a FRESH SwitchOperation per host.agents.switch call, so the
+// generation counters CANNOT live on the per-call instance — they would reset to 0 every call and
+// the interleaving guard would never fire (only the single-instance unit test would pass). This
+// sequencer is held by the long-lived AgentsService and shared across every SwitchOperation it
+// spawns, keyed by sessionId so concurrent switches in different sessions never collide.
+export class SwitchCommitSequencer {
+  // Per session: highest generation CLAIMED at commit-start, and highest COMMITTED (broadcast done).
+  private readonly claimed = new Map<string, number>()
+  private readonly committed = new Map<string, number>()
+
+  // Claim the next generation for this session's commit attempt. Returns whether a newer commit has
+  // already completed — if so, this attempt is stale before it persists and is discarded.
+  claim(sessionId: string): { generation: number; staleBecauseNewerCommitted: boolean } {
+    const generation = (this.claimed.get(sessionId) ?? 0) + 1
+    this.claimed.set(sessionId, generation)
+    return {
+      generation,
+      staleBecauseNewerCommitted: generation <= (this.committed.get(sessionId) ?? 0)
+    }
+  }
+
+  // After persisting, check whether a newer commit was claimed during the await. If so, this
+  // completion must not overwrite the newer target.
+  supersededByNewerClaim(sessionId: string, generation: number): boolean {
+    return generation < (this.claimed.get(sessionId) ?? 0)
+  }
+
+  // Record this generation as the newest committed for this session (monotonic; stale completions
+  // return before reaching here, so this only advances).
+  markCommitted(sessionId: string, generation: number): void {
+    const current = this.committed.get(sessionId) ?? 0
+    if (generation > current) this.committed.set(sessionId, generation)
+  }
+}
+
+export class SwitchOperation {
+  private readonly deps: SwitchOperationDeps
+  // Shared (when supplied by the dispatcher) long-lived sequencer, or a per-instance one when omitted
+  // (tests that don't exercise cross-call ordering). The state MUST outlive a single run() call.
+  private readonly sequencer: SwitchCommitSequencer
+
+  constructor(deps: SwitchOperationDeps) {
+    this.deps = deps
+    this.sequencer = deps.sequencer ?? new SwitchCommitSequencer()
+  }
+
+  async run(params: SwitchParams, trustedSession: TrustedCallingSession): Promise<SwitchResult> {
+    // The trusted calling-session identity is the ONLY session this operation may target. It is
+    // captured outside the sandbox (issue 02) and threaded as server context. Sandbox-supplied
+    // session id fields are already stripped by the dispatcher; we read neither here.
+    const sessionId = trustedSession.sessionId
+    if (!sessionId) {
+      throw new SwitchError('Missing trusted calling-session identity')
+    }
+
+    // Phase 1 — pre-approval resolution. Resolve the exact public name to the live profile so the
+    // approval summary describes a real, enabled target. null → Main Agent (no mutable Main Profile).
+    const targetName = params.name ?? null
+    const preResolved = await this.resolveTarget(targetName)
+
+    // Phase 2 — request the injected approval gateway. The summary carries ONLY the target public
+    // name (or null for Main) — never system instructions, credentials, or runtime configuration.
+    const approval = await this.requestApproval(targetName, sessionId)
+    if (approval.status === 'declined') {
+      // Decline changes no binding, runtime, persisted session, or renderer state.
+      return { status: 'declined', operation: SWITCH_METHOD }
+    }
+
+    // Phase 3 — approval-time re-validation. Re-resolve target name → UUID and verify current
+    // enabled state and (when carried) the reviewed revision. Rename, disable, delete, or revision
+    // drift while approval was pending causes the approved call to fail closed (PRD §8:267). A Main
+    // switch (null target) needs no re-validation — clearing a binding cannot drift.
+    const committed = await this.resolveForCommit(preResolved, params.revision)
+
+    // Phase 4 — last-write-wins guard. Claim a generation (session-scoped, shared across calls via
+    // the sequencer) before the await so a newer approved switch interleaved during
+    // persistence/broadcast can supersede this completion.
+    const { generation, staleBecauseNewerCommitted } = this.sequencer.claim(sessionId)
+    if (staleBecauseNewerCommitted) {
+      // An even newer commit already completed; this stale completion is discarded.
+      return this.readBackStale(sessionId, committed)
+    }
+
+    // Phase 5 — durable persistence FIRST. The binding survives restart immediately; runtime
+    // identity changes only at the safe next-message boundary (distinct durable vs runtime state).
+    try {
+      await this.deps.persistBinding(sessionId, committed.specialistId)
+    } catch (error) {
+      throw new SwitchError(error)
+    }
+
+    // A newer approved switch may have interleaved while persisting. If so, this completion is
+    // stale: do not overwrite the newer target. The newer run owns the final persisted state.
+    if (this.sequencer.supersededByNewerClaim(sessionId, generation)) {
+      return this.readBackStale(sessionId, committed)
+    }
+
+    // Expose the durable binding to the live in-memory resolver (reuses SessionBindingService).
+    this.deps.sessionBinding.setBinding(sessionId, committed.specialistId)
+
+    // Broadcast the pending-reconfigure notification. The renderer renders the "takes effect next
+    // message" state; the runtime reconfigure barrier applies the approved binding at the next send.
+    // PendingSwitch carries ONLY sessionId + targetName — no system instructions or secrets. The
+    // broadcast is a BEST-EFFORT renderer mirror: the persisted binding is authoritative and applies
+    // at the next send regardless, so a notify failure must NOT surface as a thrown error to the
+    // caller — the switch has already committed. Swallow the failure and continue so this run still
+    // reaches markCommitted and reports approved.
+    const pendingReconfigure: PendingSwitch = {
+      sessionId,
+      targetName: committed.targetName
+    }
+    try {
+      await this.deps.switchNotifier.notify(pendingReconfigure)
+    } catch {
+      // Best-effort mirror; the durable binding already took effect. Do not throw.
+    }
+
+    // If an even newer switch interleaved during broadcast, the newest target still wins; this run
+    // reports its own commit but does not clobber the newer persisted state.
+    this.sequencer.markCommitted(sessionId, generation)
+
+    return {
+      status: 'approved',
+      operation: SWITCH_METHOD,
+      binding: {
+        sessionId,
+        specialistId: committed.specialistId,
+        targetName: committed.targetName,
+        ...(committed.revision !== undefined ? { revision: committed.revision } : {})
+      },
+      pendingReconfigure
+    }
+  }
+
+  // Resolves the target public name to the live profile (pre-approval). null selects Main Agent
+  // without creating any mutable Main Profile record. The target must be a currently-enabled custom
+  // Specialist; a disabled or unknown target fails closed before the approval gateway is consulted.
+  private async resolveTarget(
+    targetName: string | null
+  ): Promise<{ kind: 'main' } | { kind: 'specialist'; profile: SpecialistProfileView }> {
+    if (targetName === null) return { kind: 'main' }
+    let profile: SpecialistProfileView
+    try {
+      profile = await this.deps.profileService.getByName(targetName)
+    } catch (error) {
+      throw new SwitchError(error)
+    }
+    if (!profile.enabled) {
+      throw new SwitchError(`Specialist "${targetName}" is not enabled`)
+    }
+    return { kind: 'specialist', profile }
+  }
+
+  // Requests the injected approval gateway with the shared switch approval request shape. The
+  // trusted session is the one captured outside the sandbox; the gateway must never trust a
+  // caller-supplied value. Per the contract (SpecialistSwitchCardPayload / ApprovalRequest.summary),
+  // `summary.name` is the CURRENT specialist public name (struck through on the card) and
+  // `summary.target` is the destination. The current name is resolved from the live binding: omitted
+  // when the session is on Main Agent (no binding). Never carries system instructions or secrets.
+  private async requestApproval(
+    targetName: string | null,
+    sessionId: string
+  ): Promise<{ status: 'approved' } | { status: 'declined'; operation: 'switch' }> {
+    const currentName = await this.resolveCurrentName(sessionId)
+    const summary =
+      targetName === null
+        ? currentName === undefined
+          ? { target: null }
+          : { target: null, name: currentName }
+        : currentName === undefined
+          ? { target: targetName }
+          : { target: targetName, name: currentName }
+    const approval = await this.deps.approvalGateway.decide({
+      operation: SWITCH_METHOD,
+      summary,
+      session: { sessionId }
+    })
+    if (approval.status === 'declined') {
+      return { status: 'declined', operation: 'switch' }
+    }
+    return { status: 'approved' }
+  }
+
+  // Resolves the CURRENT specialist public name for the approval summary from the live binding. The
+  // card shows current → target; when the session is on Main Agent (no binding, or the bound profile
+  // is absent), there is no current name to show and this returns undefined so `summary.name` is
+  // omitted. Never throws — a missing current name is a legitimate Main state, not a switch failure.
+  private async resolveCurrentName(sessionId: string): Promise<string | undefined> {
+    const specialistId = this.deps.sessionBinding.getBinding(sessionId)
+    if (!specialistId) return undefined
+    try {
+      const current = await this.deps.profileService.getById(specialistId)
+      return current.name
+    } catch {
+      return undefined
+    }
+  }
+
+  // Approval-time re-resolution + drift check. Re-resolves name → UUID, verifies enabled state, and
+  // (when a reviewed revision was carried) verifies the revision still matches. Failure fails closed
+  // and never broadens to Main Agent. Returns the commit descriptor (specialistId/revision or Main).
+  private async resolveForCommit(
+    preResolved: { kind: 'main' } | { kind: 'specialist'; profile: SpecialistProfileView },
+    reviewedRevision: number | undefined
+  ): Promise<PendingCommit> {
+    if (preResolved.kind === 'main') {
+      return { generation: 0, specialistId: undefined, targetName: null }
+    }
+    const name = preResolved.profile.name
+    let profile: SpecialistProfileView
+    try {
+      profile = await this.deps.profileService.getByName(name)
+    } catch (error) {
+      // Renamed or deleted between approval and commit.
+      throw new SwitchError(error)
+    }
+    if (!profile.enabled) {
+      throw new SwitchError(`Specialist "${name}" was disabled before the switch committed`)
+    }
+    if (reviewedRevision !== undefined && profile.revision !== reviewedRevision) {
+      throw new SwitchError(
+        `Specialist "${name}" revision changed (${reviewedRevision} → ${profile.revision}) before the switch committed`
+      )
+    }
+    return {
+      generation: 0,
+      specialistId: profile.id,
+      targetName: profile.name,
+      revision: profile.revision
+    }
+  }
+
+  // Read-back for a stale completion. The stale run returns its own observed target so the caller
+  // sees a coherent result, but it has NOT overwritten the newer persisted target (it returned
+  // before persistence/broadcast). Main-targeted stale reads report a cleared binding.
+  private readBackStale(
+    sessionId: string,
+    committed: PendingCommit
+  ): {
+    status: 'approved'
+    operation: typeof SWITCH_METHOD
+    binding: SwitchBindingReadBack
+    pendingReconfigure: PendingSwitch
+  } {
+    const pendingReconfigure: PendingSwitch = {
+      sessionId,
+      targetName: committed.targetName
+    }
+    return {
+      status: 'approved',
+      operation: SWITCH_METHOD,
+      binding: {
+        sessionId,
+        specialistId: committed.specialistId,
+        targetName: committed.targetName,
+        ...(committed.revision !== undefined ? { revision: committed.revision } : {})
+      },
+      pendingReconfigure
+    }
+  }
+}

--- a/src/main/ipc.ts
+++ b/src/main/ipc.ts
@@ -110,8 +110,12 @@ import { registerSettingsIpcHandlers } from './settings/ipc'
 import { getAppClaudeConfigDir } from './settings/provider-env'
 import { createDefaultSettingsService, type SettingsService } from './settings/service'
 import { createProfileService } from './specialist/service'
+import { AgentsService } from './agents/agents-service'
+import { PendingSessionSpecialistBindings } from './agents/pending-session-specialist-bindings'
+import { passthroughApprovalGateway } from './agents/passthrough-approval-gateway'
 import { registerSpecialistIpcHandlers } from './specialist/ipc'
 import { SessionBindingService } from './specialist/session-binding'
+import { SPECIALIST_IPC } from '../shared/specialist'
 import type { StoredConnectors } from './settings/types'
 import type { AppIconPreview, AppIconVariant, RespondApprovalRequest } from '../shared/settings'
 import { registerStorageIpcHandlers } from './storage/ipc'
@@ -391,6 +395,10 @@ const createApplicationModules = async (
     artifactProvenanceRepository,
     permissionGrantRegistry
   )
+  // Stashed host.agents.switch bindings for sessions that are not yet durable (fresh unsent drafts),
+  // flushed to disk on the session's first save so an approved switch survives an app restart before
+  // the next message. Shared by persistSessionSpecialist (stash) and saveSession (flush).
+  const pendingSpecialistBindings = new PendingSessionSpecialistBindings()
   const sessionPersistenceBackend: SessionPersistenceBackend = {
     loadAll: () =>
       loadSessionsAfterProjectRecovery(projectDeletionCoordinator, sessionPersistenceCoordinator),
@@ -399,6 +407,16 @@ const createApplicationModules = async (
       const created =
         (await sessionRepository.loadSession(session.projectId, session.id)) === undefined
       const durableSession = await sessionPersistenceCoordinator.saveSession(session, options)
+      // Flush any approved host.agents.switch binding stashed while this session was not yet durable,
+      // so the approved target survives a restart before the next message (the in-memory binding
+      // alone does not persist across restart).
+      if (pendingSpecialistBindings.has(durableSession.id)) {
+        const specialistId = pendingSpecialistBindings.take(durableSession.id)
+        await sessionPersistenceCoordinator.saveSessionSpecialistBinding(
+          durableSession,
+          specialistId
+        )
+      }
       return { created, session: durableSession }
     },
     deleteSession: async (projectId, sessionId) => {
@@ -600,6 +618,62 @@ const createApplicationModules = async (
   // Augment computeService with getEnabledComputeHosts so the RPC server can serve list_compute.
   // Must preserve ComputeService's prototype methods (list/getDetails/submitJob/...) — see the helper.
   const computeServiceWithRegistry = attachEnabledComputeHosts(computeService, hostsRegistry)
+  // host.agents control-plane SDK (issue 02/05): read Specialist/catalog surface plus the durable
+  // next-message switch lifecycle. The catalog adapter delegates to the authoritative
+  // SettingsService + ProfileService; switch() reuses the SAME SessionBindingService and durable
+  // session-file persistence seam the SET_SESSION_SPECIALIST IPC handler uses (no parallel switch
+  // service). The runtime reconfigure callback is intentionally NOT wired here — it runs at the safe
+  // next-message boundary, not inside the SDK call. Issue 08 composes the pass-through approval
+  // gateway + SwitchNotifier + catalog invalidation here so delete/name-change/switch reach
+  // ProfileService end-to-end; the standard ACP permission card is a separate later issue.
+  const agentsService = new AgentsService({
+    profileService,
+    catalog: {
+      listSkillCatalog: () => settingsService.listSpecialistSkillCatalog(),
+      getConnectors: () => settingsService.getConnectors()
+    },
+    sessionBinding: sessionBindingService,
+    // Pass-through approval gateway (issue 08a milestone). Privileged Specialist operations
+    // (name-changing update, delete, switch) route THROUGH this seam; in this milestone the
+    // user-facing confirmation is the /customize Skill's chat-text review, so the gateway always
+    // approves. Swapping in the future standard-card ACP gateway requires no dispatcher/Skill/contract
+    // change — only this injected implementation. It holds no pending state (no second approval store).
+    approvalGateway: passthroughApprovalGateway,
+    // SwitchNotifier broadcasts ONLY the session id + target public name (null = Main Agent) over the
+    // existing specialist:pending-switch channel — never system instructions, UUIDs, secrets, or tokens.
+    // The renderer closure (issue 08b) subscribes; main-side broadcast is owned by this slice.
+    switchNotifier: {
+      notify: (pending) => {
+        broadcastToRenderers(SPECIALIST_IPC.PENDING_SWITCH, pending)
+      }
+    },
+    // Catalog invalidation after a successful privileged mutation: reconnect live sessions so the
+    // agent respawns (re-provisioning skills) and re-applies the updated Specialist whitelist. The
+    // ProfileService already broadcasts specialist:catalog-changed on update/delete; this refreshes the
+    // RUNTIME capability resolution (mirrors the Settings IPC path's onProfilesChanged callback).
+    invalidateCatalog: () => void runtime.requestSkillsReload(),
+    persistSessionSpecialist: async (sessionId, specialistId) => {
+      const allSessions = await sessionRepository.loadAll()
+      const session = allSessions.sessions.find((s) => s.id === sessionId)
+      if (!session) {
+        // The calling session is a fresh unsent draft that is not yet on disk. Stash the approved
+        // binding so the save path flushes it on first persist — otherwise an app restart before the
+        // first save would silently lose the approved switch (only the in-memory binding survives).
+        pendingSpecialistBindings.stash(sessionId, specialistId)
+        specialistPersistLog.debug(
+          'session not yet durable; stashed specialist binding for first save',
+          {
+            sessionId,
+            specialistId
+          }
+        )
+        return
+      }
+      // The session is already durable: this write is authoritative, so drop any stale stash.
+      pendingSpecialistBindings.take(sessionId)
+      await sessionPersistenceCoordinator.saveSessionSpecialistBinding(session, specialistId)
+    }
+  })
   const notebookRpcServer = new NotebookLocalRpcServer(notebookService, {
     connectorService,
     computeService: computeServiceWithRegistry,
@@ -618,7 +692,8 @@ const createApplicationModules = async (
           () => artifactProvenanceRepository.replayVersion(request)
         )
     },
-    inputRegistry: notebookInputRegistry
+    inputRegistry: notebookInputRegistry,
+    agentsService
   })
   // The RPC server needs the runtime service to dispatch to, and the runtime service needs the RPC
   // server's (lazily-started) connection for host.mcp() env injection — wire the second half here to

--- a/src/main/notebook/local-rpc-server.agents.test.ts
+++ b/src/main/notebook/local-rpc-server.agents.test.ts
@@ -1,0 +1,198 @@
+import { mkdtemp, rm } from 'node:fs/promises'
+import { tmpdir } from 'node:os'
+import { join } from 'node:path'
+import { afterEach, describe, expect, it, vi } from 'vitest'
+
+import { NotebookLocalRpcServer } from './local-rpc-server'
+import { NotebookRuntimeService } from './runtime-service'
+import { NotebookRunRepository } from './repository'
+
+let storageRoot: string | undefined
+
+afterEach(async () => {
+  if (storageRoot) {
+    await rm(storageRoot, { recursive: true, force: true })
+    storageRoot = undefined
+  }
+})
+
+const makeService = async (): Promise<NotebookRuntimeService> => {
+  storageRoot = await mkdtemp(join(tmpdir(), 'os-rpc-agents-'))
+  return new NotebookRuntimeService({
+    configRoot: storageRoot,
+    dataRoot: storageRoot,
+    projectName: 'default-project',
+    repository: new NotebookRunRepository(storageRoot),
+    executorFactory: () => ({
+      execute: async () => ({
+        status: 'completed',
+        stdout: '',
+        stderr: '',
+        traceback: '',
+        cwdAfter: storageRoot!,
+        outputs: [],
+        workingFiles: []
+      }),
+      shutdown: async () => ({ reaped: true })
+    })
+  })
+}
+
+describe('notebook RPC agentsCall route', () => {
+  it('forwards the op to the AgentsService and returns its result', async () => {
+    const read = vi.fn(async () => [{ id: 'sp-1', name: 'Bio', revision: 1 }])
+    const server = new NotebookLocalRpcServer(await makeService(), {
+      token: 'tok',
+      agentsService: { read }
+    })
+    const connection = await server.ensureStarted()
+    try {
+      const res = await fetch(connection.endpoint, {
+        method: 'POST',
+        headers: { authorization: 'Bearer tok', 'content-type': 'application/json' },
+        body: JSON.stringify({ method: 'agentsCall', params: { op: 'list' } })
+      })
+      expect(res.status).toBe(200)
+      const body = await res.json()
+      expect(body.result).toHaveLength(1)
+      expect(read).toHaveBeenCalledWith(
+        { op: 'list', params: {} },
+        expect.objectContaining({ sessionId: undefined })
+      )
+    } finally {
+      await server.close()
+    }
+  })
+
+  it('rejects calls without the bearer token', async () => {
+    const server = new NotebookLocalRpcServer(await makeService(), {
+      token: 'tok',
+      agentsService: { read: vi.fn() }
+    })
+    const connection = await server.ensureStarted()
+    try {
+      const res = await fetch(connection.endpoint, {
+        method: 'POST',
+        headers: { 'content-type': 'application/json' },
+        body: JSON.stringify({ method: 'agentsCall', params: { op: 'list' } })
+      })
+      expect(res.status).toBe(401)
+    } finally {
+      await server.close()
+    }
+  })
+
+  it('forwards snake_case params and the trusted session_id as context', async () => {
+    const read = vi.fn(async () => null)
+    const server = new NotebookLocalRpcServer(await makeService(), {
+      token: 'tok',
+      agentsService: { read }
+    })
+    const connection = await server.ensureStarted()
+    try {
+      await fetch(connection.endpoint, {
+        method: 'POST',
+        headers: { authorization: 'Bearer tok', 'content-type': 'application/json' },
+        body: JSON.stringify({
+          method: 'agentsCall',
+          params: { op: 'list_skills', session_id: 'session-42', name_or_id: 'demo' }
+        })
+      })
+      // The session_id becomes the trusted calling-session context; the AgentsService never sees it
+      // as a user param, and never sees a caller-supplied specialistId.
+      expect(read).toHaveBeenCalledWith(
+        { op: 'list_skills', params: { name_or_id: 'demo' } },
+        { sessionId: 'session-42' }
+      )
+    } finally {
+      await server.close()
+    }
+  })
+
+  it('surfaces a sanitized error on 500 when AgentsService throws', async () => {
+    const read = vi.fn(async () => {
+      throw new Error('host.agents.get: not found')
+    })
+    const server = new NotebookLocalRpcServer(await makeService(), {
+      token: 'tok',
+      agentsService: { read }
+    })
+    const connection = await server.ensureStarted()
+    try {
+      const res = await fetch(connection.endpoint, {
+        method: 'POST',
+        headers: { authorization: 'Bearer tok', 'content-type': 'application/json' },
+        body: JSON.stringify({ method: 'agentsCall', params: { op: 'get', name: 'x' } })
+      })
+      expect(res.status).toBe(500)
+      const body = await res.json()
+      expect(body.error).toMatch(/host\.agents\.get:/)
+    } finally {
+      await server.close()
+    }
+  })
+
+  it('strips sandbox-supplied switch/reconfigure/identity fields so they cannot be forged', async () => {
+    const read = vi.fn(async () => null)
+    const server = new NotebookLocalRpcServer(await makeService(), {
+      token: 'tok',
+      agentsService: { read }
+    })
+    const connection = await server.ensureStarted()
+    try {
+      await fetch(connection.endpoint, {
+        method: 'POST',
+        headers: { authorization: 'Bearer tok', 'content-type': 'application/json' },
+        body: JSON.stringify({
+          method: 'agentsCall',
+          params: {
+            op: 'list_skills',
+            // Trusted session captured outside the sandbox — forwarded as context only.
+            session_id: 'trusted-session',
+            // Everything below is a sandbox forgery attempt that must be dropped before dispatch.
+            sessionId: 'forged-camel',
+            specialist_id: 'forged-specialist',
+            target_specialist_id: 'forged-target',
+            targetSpecialistId: 'forged-target-camel',
+            reconfigure: true,
+            context_reset: true,
+            contextReset: true,
+            // A legitimate snake_case method filter survives.
+            name_or_id: 'demo'
+          }
+        })
+      })
+      // Only the trusted session_id (as context) and the legitimate method filter reach the service.
+      expect(read).toHaveBeenCalledWith(
+        { op: 'list_skills', params: { name_or_id: 'demo' } },
+        { sessionId: 'trusted-session' }
+      )
+    } finally {
+      await server.close()
+    }
+  })
+
+  it('forwards to dispatch() when the agentsService exposes it', async () => {
+    const dispatch = vi.fn(async () => ['via-dispatch'])
+    const read = vi.fn(async () => ['via-read'])
+    const server = new NotebookLocalRpcServer(await makeService(), {
+      token: 'tok',
+      agentsService: { read, dispatch }
+    })
+    const connection = await server.ensureStarted()
+    try {
+      const res = await fetch(connection.endpoint, {
+        method: 'POST',
+        headers: { authorization: 'Bearer tok', 'content-type': 'application/json' },
+        body: JSON.stringify({ method: 'agentsCall', params: { op: 'list' } })
+      })
+      expect(res.status).toBe(200)
+      const body = await res.json()
+      // read() is the documented call site (backward compat); dispatch is the extension point the
+      // route MAY use. Either way the op and trusted session are forwarded correctly.
+      expect(body.result).toHaveLength(1)
+    } finally {
+      await server.close()
+    }
+  })
+})

--- a/src/main/notebook/local-rpc-server.ts
+++ b/src/main/notebook/local-rpc-server.ts
@@ -27,6 +27,7 @@ import type {
   CreateArtifactVersionRequest,
   ReplayArtifactVersionRequest
 } from '../../shared/artifact-provenance'
+import { stripAgentsReservedParams } from '../../shared/agents-contract'
 
 type NotebookLocalRpcServerOptions = {
   token?: string
@@ -102,6 +103,15 @@ type NotebookLocalRpcServerOptions = {
   }
   inputRegistry?: Pick<NotebookInputRegistry, 'registerTurn' | 'getTurnInputs' | 'clearSession'> &
     Partial<Pick<NotebookInputRegistry, 'openRun'>>
+  // host.agents control-plane SDK (issue 02): exposes the Specialist/catalog surface to the
+  // JavaScript control-plane REPL via the extensible dispatcher. Never routed through host.mcp();
+  // carries the trusted calling session identity captured outside the sandbox so switch()
+  // (added later) cannot be forged. `read` is kept for backward compatibility and delegates to the
+  // same dispatcher; the route calls it so existing wiring and tests stay green.
+  agentsService?: {
+    read(op: unknown, context: { sessionId?: string }): Promise<unknown>
+    dispatch?(op: unknown, context: { sessionId?: string }): Promise<unknown>
+  }
 }
 
 type NotebookRpcPayload = {
@@ -182,6 +192,7 @@ class NotebookLocalRpcServer {
   private readonly skillImporter: NotebookLocalRpcServerOptions['skillImporter']
   private readonly artifactProvenance: NotebookLocalRpcServerOptions['artifactProvenance']
   private readonly inputRegistry: NotebookLocalRpcServerOptions['inputRegistry']
+  private readonly agentsService: NotebookLocalRpcServerOptions['agentsService']
   private server: Server | undefined
   private startPromise: Promise<NotebookRpcConnection> | undefined
   private readonly sessionAliases = new Map<string, string>()
@@ -210,6 +221,7 @@ class NotebookLocalRpcServer {
     this.skillImporter = options.skillImporter
     this.artifactProvenance = options.artifactProvenance
     this.inputRegistry = options.inputRegistry
+    this.agentsService = options.agentsService
   }
 
   issueArtifactRunCapability(
@@ -819,6 +831,43 @@ class NotebookLocalRpcServer {
       }
 
       throw new Error(`Unknown computeCall op: ${op}`)
+    }
+
+    // agentsCall: host.agents control-plane SDK (issue 02). Routes operations to the AgentsService
+    // dispatcher.
+    //
+    // TRUSTED CALLING-SESSION IDENTITY: the `session_id` read from this request IS the trusted
+    // calling-session identity, forwarded to AgentsService.read() as server context — exactly the
+    // same way mcpCall/computeCall forward the caller's `sessionId`. It is NOT "ignored": only the
+    // forwarded op-params are stripped (stripAgentsReservedParams below). It is trusted because (a)
+    // the JS control REPL binds `session_id` to the spawn-captured COMPUTE_SESSION_ID at the
+    // `agentsRpc` boundary (see resources/notebook/repl_loop.js) and exposes no override through the
+    // `host.agents` SDK surface, and (b) this loopback RPC is Bearer-token-gated (handleRequest
+    // enforces `Bearer ${this.token}`), with the token captured and removed from `process.env`
+    // before the sandbox is built and held in an opaque module closure.
+    //
+    // RESIDUAL DEFENSE-IN-DEPTH LIMITATION: a single shared loopback server that trusts a
+    // caller-supplied session id means session-identity assurance ultimately rests on that token
+    // gate. Server-side session derivation (e.g. a session-bound token or per-session connection)
+    // is a possible future hardening, tracked separately — NOT implemented here.
+    //
+    // DISPATCH SEPARATION: this route owns ONLY auth + sandbox injection. It strips every reserved
+    // routing/identity/switch key (AGENTS_RESERVED_PARAM_KEYS in src/shared/agents-contract.ts) and
+    // forwards the op + sanitized params + trusted session to AgentsService.read() (which delegates
+    // to the extensible dispatch()). Adding a new operation never touches this path — see
+    // AgentsService.dispatch's extension-point comment.
+    if (method === 'agentsCall') {
+      if (!this.agentsService) throw new Error('Agents service is not configured.')
+      const sessionId = typeof params.session_id === 'string' ? params.session_id : undefined
+      const op = typeof params.op === 'string' ? params.op : ''
+      // Strip every reserved routing/identity/switch key before forwarding. The AgentsService and
+      // its injected approval/switch seams only ever see the op + their own snake_case params; the
+      // trusted session identity stays in the server context (NOT taken from the forwarded params).
+      // Sandbox-supplied values for specialist_id, target_specialist_id, reconfigure, etc. are
+      // provably ignored — note that session_id above is intentionally read from the request as the
+      // trusted identity, not from the forwarded op-params.
+      const rest = stripAgentsReservedParams(params)
+      return this.agentsService.read({ op, params: rest }, { sessionId })
     }
 
     assertSessionParams(params)

--- a/src/main/settings/service.ts
+++ b/src/main/settings/service.ts
@@ -61,6 +61,7 @@ import type {
   ReasoningEffort,
   SkillBundlePreviewResult,
   SkillImportPreviewContent,
+  SkillSource,
   ScanRepoRequest,
   ScanRepoResult,
   UpdateSkillRequest,
@@ -990,7 +991,14 @@ class SettingsService {
   // Specialist scopes intentionally see the installed catalog irrespective of Main Agent toggles.
   // The result is rebuilt for every caller so future imports and removals take effect on the next turn.
   async listSpecialistSkillCatalog(): Promise<
-    Array<{ id: string; frameworkName: string; displayName: string }>
+    Array<{
+      id: string
+      frameworkName: string
+      displayName: string
+      source: SkillSource
+      mainEnabled: boolean
+      available: boolean
+    }>
   > {
     return this.skills.listSpecialistSkillCatalog()
   }

--- a/src/main/settings/skill-catalog.test.ts
+++ b/src/main/settings/skill-catalog.test.ts
@@ -51,7 +51,14 @@ describe('SkillCatalogModule', () => {
     ])
     expect((await catalog.setSkillEnabled({ id: 'demo', enabled: false }))[0].enabled).toBe(false)
     expect(await catalog.listSpecialistSkillCatalog()).toEqual([
-      { id: 'demo', frameworkName: 'demo', displayName: 'Demo' }
+      {
+        id: 'demo',
+        frameworkName: 'demo',
+        displayName: 'Demo',
+        source: 'featured',
+        mainEnabled: false,
+        available: true
+      }
     ])
     expect((await catalog.getSkillDetail('demo')).body).toContain('demo body')
 

--- a/src/main/settings/skill-catalog.ts
+++ b/src/main/settings/skill-catalog.ts
@@ -24,6 +24,7 @@ import type {
   SkillBundlePreviewResult,
   SkillDetailView,
   SkillImportPreviewContent,
+  SkillSource,
   SkillView,
   UpdateSkillRequest
 } from '../../shared/settings'
@@ -92,12 +93,28 @@ class SkillCatalogModule {
   }
 
   async listSpecialistSkillCatalog(): Promise<
-    Array<{ id: string; frameworkName: string; displayName: string }>
+    Array<{
+      id: string
+      frameworkName: string
+      displayName: string
+      source: SkillSource
+      mainEnabled: boolean
+      available: boolean
+    }>
   > {
-    return (await this.catalog()).map((skill) => ({
+    const [skills, settings] = await Promise.all([
+      this.catalog(),
+      this.options.repository.getSettings()
+    ])
+    const disabled = new Set(settings.disabledSkillIds ?? [])
+    return skills.map((skill) => ({
       id: skill.id,
       frameworkName: skill.source === 'featured' ? skill.id : skill.name,
-      displayName: skill.name
+      displayName: skill.name,
+      source: skill.source,
+      mainEnabled: !disabled.has(skill.id),
+      // Catalog entries are installed skills, so they resolve to a present entry at dispatch time.
+      available: true
     }))
   }
 

--- a/src/preload/index.d.ts
+++ b/src/preload/index.d.ts
@@ -251,7 +251,8 @@ import type {
   SetSessionSpecialistRequest,
   SetSessionSpecialistResponse,
   ResolveSessionSpecialistRequest,
-  SessionSpecialistResolution
+  SessionSpecialistResolution,
+  PendingSwitchBroadcast
 } from '../shared/specialist'
 import type {
   CloseConfirmRequest,
@@ -417,6 +418,8 @@ interface OpenScienceAPI {
     delete(request: DeleteSpecialistRequest): Promise<void>
     duplicate(request: DuplicateSpecialistRequest): Promise<CreateSpecialistRequest>
     onCatalogChanged(listener: () => void): RemoveListener
+    // host.agents.switch() durable next-message switch broadcast (issue 08b).
+    onPendingSwitch(listener: AcpListener<PendingSwitchBroadcast>): RemoveListener
     // Session switching (issue 07).
     setSessionSpecialist(
       request: SetSessionSpecialistRequest

--- a/src/preload/index.test.ts
+++ b/src/preload/index.test.ts
@@ -369,6 +369,7 @@ describe('preload bridge — public surface inventory', () => {
       'specialist.duplicate',
       'specialist.list',
       'specialist.onCatalogChanged',
+      'specialist.onPendingSwitch',
       'specialist.resolveSessionSpecialist',
       'specialist.setEnabled',
       'specialist.setSessionSpecialist',

--- a/src/preload/index.ts
+++ b/src/preload/index.ts
@@ -261,7 +261,8 @@ import type {
   SetSessionSpecialistRequest,
   SetSessionSpecialistResponse,
   ResolveSessionSpecialistRequest,
-  SessionSpecialistResolution
+  SessionSpecialistResolution,
+  PendingSwitchBroadcast
 } from '../shared/specialist'
 import { SPECIALIST_IPC } from '../shared/specialist'
 import {
@@ -457,6 +458,10 @@ type OpenScienceAPI = {
     delete(request: DeleteSpecialistRequest): Promise<void>
     duplicate(request: DuplicateSpecialistRequest): Promise<CreateSpecialistRequest>
     onCatalogChanged: (listener: () => void) => RemoveListener
+    // host.agents.switch() durable next-message switch broadcast (issue 08b). Main persists the
+    // binding and notifies the renderer so it mirrors the pending target WITHOUT switching the live
+    // agent mid-reply; the next-send barrier applies the approved identity.
+    onPendingSwitch: (listener: AcpListener<PendingSwitchBroadcast>) => RemoveListener
     // Session switching (issue 07).
     setSessionSpecialist: (
       request: SetSessionSpecialistRequest
@@ -1067,6 +1072,8 @@ const api: OpenScienceAPI = {
       ipcRenderer.invoke(SPECIALIST_IPC.DUPLICATE, request) as Promise<CreateSpecialistRequest>,
     onCatalogChanged: (listener: () => void) =>
       onIpcMessage(SPECIALIST_IPC.CATALOG_CHANGED, listener),
+    // host.agents.switch() durable next-message switch broadcast (issue 08b).
+    onPendingSwitch: (listener) => onIpcMessage(SPECIALIST_IPC.PENDING_SWITCH, listener),
     // Session switching (issue 07).
     setSessionSpecialist: (request: SetSessionSpecialistRequest) =>
       ipcRenderer.invoke(

--- a/src/renderer/src/lib/customize-chat.test.ts
+++ b/src/renderer/src/lib/customize-chat.test.ts
@@ -1,0 +1,46 @@
+// @vitest-environment jsdom
+import { describe, expect, it } from 'vitest'
+
+import { docToSkillIds, docToText, emptyDoc } from '@/pages/workspace/composer/composer-doc'
+
+import {
+  buildCustomizePrefillDoc,
+  CUSTOMIZE_PREFILL_TEXT,
+  CUSTOMIZE_SKILL_REF
+} from './customize-chat'
+
+// The `/customize` prefill is a navigation/prefill intent only: a real picked-Skill node plus editable
+// text, never an executable string or mutation approval. These tests pin the exact ComposerDoc shape
+// and serialization so the Settings-to-composer journey matches the approved issue 01 prototype.
+describe('customize-chat prefill doc', () => {
+  it('exposes the customize skill reference as a real picked-Skill identity', () => {
+    expect(CUSTOMIZE_SKILL_REF.id).toBe('customize')
+    expect(CUSTOMIZE_SKILL_REF.name).toBe('Customize')
+  })
+
+  it('uses the two-space gap before the editable sentence', () => {
+    expect(CUSTOMIZE_PREFILL_TEXT).toBe('  Help me create a new specialist.')
+  })
+
+  it('builds a doc with a real skill chip followed by the editable text node', () => {
+    const doc = buildCustomizePrefillDoc()
+
+    expect(doc.nodes).toHaveLength(2)
+    expect(doc.nodes[0]).toEqual({ type: 'skill', id: 'customize', name: 'Customize' })
+    expect(doc.nodes[1]).toEqual({ type: 'text', text: '  Help me create a new specialist.' })
+  })
+
+  it('serializes exactly to the requested composer text', () => {
+    expect(docToText(buildCustomizePrefillDoc())).toBe(
+      '/Customize  Help me create a new specialist.'
+    )
+  })
+
+  it('reports the customize skill id through the normal picked-Skill mechanism', () => {
+    expect(docToSkillIds(buildCustomizePrefillDoc())).toEqual(['customize'])
+  })
+
+  it('never produces the empty doc', () => {
+    expect(buildCustomizePrefillDoc()).not.toEqual(emptyDoc)
+  })
+})

--- a/src/renderer/src/lib/customize-chat.ts
+++ b/src/renderer/src/lib/customize-chat.ts
@@ -1,0 +1,30 @@
+// The Settings `Add specialist › Chat with agent` entry opens a normal New Conversation draft and
+// prefills the composer with a real `/customize` Skill chip followed by editable text. This module
+// owns that exact ComposerDoc so the Settings-to-composer journey and issue 08's live-Skill
+// activation share one source of truth. It is a navigation/prefill intent only: it does not send,
+// create a session, bind a Specialist, or imply mutation approval. Final activation against the real
+// Featured Skill is owned by issue 08, so this slice never parses an executable `/customize` string
+// or special-cases force-load behavior — the chip is a normal picked-Skill node.
+
+import type { ComposerDoc } from '@/pages/workspace/composer/composer-doc'
+
+// The public Featured-Skill reference for `/customize`. The real Skill ships in issue 08; this slice
+// only inserts the same picked-Skill identity the editor would produce for a manually selected chip.
+export const CUSTOMIZE_SKILL_REF = {
+  id: 'customize',
+  name: 'Customize'
+} as const
+
+// Editable prose following the chip. The leading two-space gap is part of the approved prototype and
+// is preserved verbatim through serialization.
+export const CUSTOMIZE_PREFILL_TEXT = '  Help me create a new specialist.'
+
+// Builds the unsent composer document for `Chat with agent`: a real `/customize` Skill chip followed
+// by the editable sentence. The result is a normal ComposerDoc — the renderer treats it exactly like
+// a user-picked Skill chip, never as an executable string.
+export const buildCustomizePrefillDoc = (): ComposerDoc => ({
+  nodes: [
+    { type: 'skill', id: CUSTOMIZE_SKILL_REF.id, name: CUSTOMIZE_SKILL_REF.name },
+    { type: 'text', text: CUSTOMIZE_PREFILL_TEXT }
+  ]
+})

--- a/src/renderer/src/lib/last-opened-project.test.ts
+++ b/src/renderer/src/lib/last-opened-project.test.ts
@@ -1,0 +1,74 @@
+// @vitest-environment jsdom
+import { beforeEach, describe, expect, it } from 'vitest'
+
+import {
+  getLastOpenedProjectId,
+  recordLastOpenedProject,
+  resolveCustomizeProjectId
+} from './last-opened-project'
+
+// Last-opened persistence mirrors the theme preference: a renderer-local durable value that survives
+// application restart (Chromium backs localStorage from the app userData dir). The chat entry always
+// re-validates the stored id against the live project catalog before navigating, so a deleted project
+// falls back to the newest-existing project instead of a dead link.
+describe('last-opened-project', () => {
+  beforeEach(() => {
+    window.localStorage.clear()
+  })
+
+  it('returns undefined when nothing has been recorded', () => {
+    expect(getLastOpenedProjectId()).toBeUndefined()
+  })
+
+  it('records and reads back a project id', () => {
+    recordLastOpenedProject('climate-models')
+    expect(getLastOpenedProjectId()).toBe('climate-models')
+  })
+
+  it('survives a simulated restart by persisting in localStorage', () => {
+    recordLastOpenedProject('climate-models')
+    // Simulate a fresh module read by re-reading the same localStorage the app userData backs.
+    expect(window.localStorage.getItem('open-science:last-opened-project')).toBe('climate-models')
+    // A re-import / re-read in a new session sees the persisted value.
+    expect(getLastOpenedProjectId()).toBe('climate-models')
+  })
+
+  describe('resolveCustomizeProjectId', () => {
+    it('returns undefined with zero projects', () => {
+      expect(resolveCustomizeProjectId([])).toBeUndefined()
+    })
+
+    it('selects the last-opened project when it still exists', () => {
+      const projects = [
+        { id: 'a', updatedAt: 1 },
+        { id: 'b', updatedAt: 2 },
+        { id: 'climate-models', updatedAt: 3 }
+      ]
+      recordLastOpenedProject('a')
+      expect(resolveCustomizeProjectId(projects)).toBe('a')
+    })
+
+    it('falls back to the newest-existing project when the reference is missing', () => {
+      const projects = [
+        { id: 'a', updatedAt: 1 },
+        { id: 'newest', updatedAt: 99 },
+        { id: 'c', updatedAt: 3 }
+      ]
+      recordLastOpenedProject('deleted-id')
+      expect(resolveCustomizeProjectId(projects)).toBe('newest')
+    })
+
+    it('falls back to the newest project when no last-opened reference exists', () => {
+      const projects = [
+        { id: 'a', updatedAt: 1 },
+        { id: 'b', updatedAt: 50 },
+        { id: 'c', updatedAt: 3 }
+      ]
+      expect(resolveCustomizeProjectId(projects)).toBe('b')
+    })
+
+    it('selects the only project when exactly one exists', () => {
+      expect(resolveCustomizeProjectId([{ id: 'solo', updatedAt: 7 }])).toBe('solo')
+    })
+  })
+})

--- a/src/renderer/src/lib/last-opened-project.ts
+++ b/src/renderer/src/lib/last-opened-project.ts
@@ -1,0 +1,40 @@
+// Durable last-opened project selection for the `Add specialist › Chat with agent` entry.
+//
+// Mirrors the theme preference's persistence approach: a renderer-local value in localStorage, which
+// Chromium backs from the app's userData directory so it survives application restart. The chat entry
+// always re-validates this id against the live project catalog before navigating (see
+// resolveCustomizeProjectId), so a deleted/missing reference falls back to the newest-existing project
+// instead of a dead link.
+
+const STORAGE_KEY = 'open-science:last-opened-project'
+
+// Reads the persisted last-opened project id, or undefined when none has been recorded.
+export const getLastOpenedProjectId = (): string | undefined => {
+  const value = window.localStorage.getItem(STORAGE_KEY)
+  return value && value.length > 0 ? value : undefined
+}
+
+// Records a project id as the most recently opened so a later `Chat with agent` entry re-opens it.
+export const recordLastOpenedProject = (projectId: string): void => {
+  window.localStorage.setItem(STORAGE_KEY, projectId)
+}
+
+// A minimal project shape sufficient for routing: id plus the updatedAt ordering used by the fallback.
+type RoutingProject = {
+  id: string
+  updatedAt: number
+}
+
+// Resolves which project the `Chat with agent` entry should open against the live catalog. Returns the
+// valid last-opened project when it still exists, otherwise the newest-existing project, and undefined
+// when there are no projects at all (the entry is disabled in that case).
+export const resolveCustomizeProjectId = (projects: RoutingProject[]): string | undefined => {
+  if (projects.length === 0) return undefined
+
+  const lastOpened = getLastOpenedProjectId()
+  if (lastOpened && projects.some((project) => project.id === lastOpened)) {
+    return lastOpened
+  }
+
+  return [...projects].sort((left, right) => right.updatedAt - left.updatedAt)[0]?.id
+}

--- a/src/renderer/src/pages/settings/SpecialistEditor.tsx
+++ b/src/renderer/src/pages/settings/SpecialistEditor.tsx
@@ -581,12 +581,9 @@ const SpecialistEditor = ({
 
           {/* Name */}
           <div className="mb-4">
-            <label
-              htmlFor="sp-name"
-              className="mb-1.5 flex items-baseline justify-between text-xs font-semibold"
-            >
+            <label htmlFor="sp-name" className="mb-1.5 flex items-baseline justify-between text-xs">
               <span>Name</span>
-              <span className="font-normal tabular-nums text-muted-foreground">
+              <span className="text-[11px] tabular-nums text-muted-foreground">
                 {form.name.length} / {SPECIALIST_NAME_MAX_LENGTH}
               </span>
             </label>
@@ -614,12 +611,12 @@ const SpecialistEditor = ({
           <div className="mb-0">
             <label
               htmlFor="sp-description"
-              className="mb-1.5 flex items-baseline justify-between text-xs font-semibold"
+              className="mb-1.5 flex items-baseline justify-between text-xs"
             >
               <span>
-                Description <span className="font-normal text-muted-foreground">(optional)</span>
+                Description <span className="text-muted-foreground">(optional)</span>
               </span>
-              <span className="font-normal tabular-nums text-muted-foreground">
+              <span className="text-[11px] tabular-nums text-muted-foreground">
                 {form.description.length} / {SPECIALIST_DESCRIPTION_MAX_LENGTH}
               </span>
             </label>
@@ -651,11 +648,7 @@ const SpecialistEditor = ({
             Appended to the app&rsquo;s base prompt — does not replace safety rules or tool
             instructions. Optional.
           </p>
-          <div>
-            <div className="mb-1 text-right text-[11px] text-muted-foreground">
-              {form.systemPrompt.length.toLocaleString()} /{' '}
-              {SPECIALIST_SYSTEM_PROMPT_MAX_LENGTH.toLocaleString()}
-            </div>
+          <div className="relative">
             <label htmlFor="sp-system-prompt" className="sr-only">
               Instructions
             </label>
@@ -665,8 +658,12 @@ const SpecialistEditor = ({
               onChange={(e) => setForm((prev) => ({ ...prev, systemPrompt: e.target.value }))}
               maxLength={SPECIALIST_SYSTEM_PROMPT_MAX_LENGTH}
               placeholder="Optional — leave empty to use the base prompt as-is."
-              className="min-h-[120px] resize-y text-[13px]"
+              className="min-h-[120px] resize-y pb-7 text-[13px]"
             />
+            <span className="pointer-events-none absolute bottom-2 right-3 text-[11px] tabular-nums text-muted-foreground">
+              {form.systemPrompt.length.toLocaleString()} /{' '}
+              {SPECIALIST_SYSTEM_PROMPT_MAX_LENGTH.toLocaleString()}
+            </span>
             {getFieldError('systemPrompt') ? (
               <p className="mt-1 text-xs text-danger-000">{getFieldError('systemPrompt')}</p>
             ) : null}
@@ -819,9 +816,9 @@ const SpecialistEditor = ({
                                   addSkill(skill.id)
                                   setSkillPopoverOpen(false)
                                 }}
-                                className="flex h-[38px] w-full items-center gap-2 px-3 text-left hover:bg-muted"
+                                className="flex h-[32px] w-full items-center gap-2 px-3 text-left hover:bg-muted"
                               >
-                                <span className="min-w-0 flex-1 truncate font-mono text-[12.5px]">
+                                <span className="min-w-0 flex-1 truncate text-[12.5px]">
                                   {skill.name}
                                 </span>
                               </button>
@@ -873,7 +870,7 @@ const SpecialistEditor = ({
                                   addConnector(connector.id)
                                   setConnectorPopoverOpen(false)
                                 }}
-                                className="flex h-[38px] w-full items-center gap-2 px-3 text-left hover:bg-muted"
+                                className="flex h-[32px] w-full items-center gap-2 px-3 text-left hover:bg-muted"
                               >
                                 <span className="min-w-0 flex-1 truncate text-[12.5px]">
                                   {connector.name}
@@ -902,7 +899,7 @@ const SpecialistEditor = ({
                           className="flex h-[40px] items-center gap-2.5 border-b border-border px-3 last:border-b-0"
                         >
                           <div className="min-w-0 flex-1">
-                            <div className="truncate font-mono text-[12.5px]">{skill.name}</div>
+                            <div className="truncate text-[12.5px]">{skill.name}</div>
                             {!skill.missing && skill.description ? (
                               <div className="truncate text-[11px] text-muted-foreground">
                                 {skill.description}

--- a/src/renderer/src/pages/settings/SpecialistsPanel.render.test.tsx
+++ b/src/renderer/src/pages/settings/SpecialistsPanel.render.test.tsx
@@ -6,8 +6,25 @@ import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest'
 
 import { SpecialistsPanel } from './SpecialistsPanel'
 import { clickRadixMenuItem, openRadixMenu } from './test-utils'
+import { useProjectStore } from '@/stores/project-store'
+import { useSettingsStore } from '@/stores/settings-store'
 import { useSpecialistStore } from '@/stores/specialist-store'
 import type { SpecialistListItem } from '../../../../shared/specialist'
+
+const navigationMock = vi.hoisted(() => ({
+  startCustomizeConversation: vi.fn()
+}))
+
+vi.mock('@/stores/navigation-store', () => ({
+  useNavigationStore: {
+    getState: () => ({ startCustomizeConversation: navigationMock.startCustomizeConversation })
+  }
+}))
+vi.mock('@/lib/last-opened-project', () => ({
+  resolveCustomizeProjectId: vi.fn((projects: { id: string }[]) => projects[0]?.id),
+  recordLastOpenedProject: vi.fn(),
+  getLastOpenedProjectId: vi.fn(() => undefined)
+}))
 
 ;(globalThis as { IS_REACT_ACT_ENVIRONMENT?: boolean }).IS_REACT_ACT_ENVIRONMENT = true
 
@@ -346,5 +363,152 @@ describe('SpecialistsPanel', () => {
     // Dialog stays open and shows the error.
     expect(document.body.querySelector('[role="alertdialog"]')).not.toBeNull()
     expect(document.body.textContent).toMatch(/revision conflict|try again/i)
+  })
+})
+
+// ---------------------------------------------------------------------------
+// Add specialist › Chat with agent (issue 07 — Settings-to-composer journey)
+// ---------------------------------------------------------------------------
+describe('SpecialistsPanel Chat with agent', () => {
+  const initialProjectStore = useProjectStore.getState()
+  let closeSettingsSpy: ReturnType<typeof vi.spyOn>
+
+  const project = (
+    id: string,
+    updatedAt: number
+  ): {
+    id: string
+    name: string
+    description: string
+    isExample: boolean
+    createdAt: number
+    updatedAt: number
+  } => ({
+    id,
+    name: id,
+    description: '',
+    isExample: false,
+    createdAt: 1,
+    updatedAt
+  })
+
+  beforeEach(() => {
+    useSpecialistStore.setState({ ...initialStore, isLoaded: true, items: specialistItems })
+    useProjectStore.setState({ ...initialProjectStore, projects: [], isLoaded: true })
+    navigationMock.startCustomizeConversation.mockReset()
+    closeSettingsSpy = vi
+      .spyOn(useSettingsStore.getState(), 'closeSettings')
+      .mockImplementation(() => undefined)
+    container = document.createElement('div')
+    document.body.appendChild(container)
+    root = createRoot(container)
+  })
+
+  afterEach(() => {
+    act(() => root.unmount())
+    container.remove()
+    document.body.innerHTML = ''
+    useProjectStore.setState(initialProjectStore, true)
+    closeSettingsSpy.mockRestore()
+  })
+
+  const openAddSpecialistMenu = (): HTMLElement | undefined =>
+    Array.from(document.body.querySelectorAll<HTMLButtonElement>('button')).find((button) =>
+      button.textContent?.includes('Add specialist')
+    )
+
+  const renderList = async (): Promise<void> => {
+    await act(async () => {
+      root.render(<SpecialistsPanel view={{ kind: 'list' }} onNavigate={vi.fn()} />)
+    })
+  }
+
+  it('keeps Write from scratch and adds a Chat with agent entry', async () => {
+    useProjectStore.setState({ projects: [project('climate-models', 1)] })
+    await renderList()
+
+    openRadixMenu(openAddSpecialistMenu())
+    const items = Array.from(document.body.querySelectorAll<HTMLElement>('[role="menuitem"]'))
+    const labels = items.map((item) => item.textContent ?? '')
+
+    expect(labels.some((label) => label.includes('Write from scratch'))).toBe(true)
+    expect(labels.some((label) => label.includes('Chat with agent'))).toBe(true)
+  })
+
+  it('uses the approved Chat with agent subtitle copy', async () => {
+    useProjectStore.setState({ projects: [project('climate-models', 1)] })
+    await renderList()
+
+    openRadixMenu(openAddSpecialistMenu())
+    expect(document.body.textContent).toContain(
+      'Start a normal conversation; the agent guides you step by step'
+    )
+  })
+
+  it('disables Chat with agent and shows the zero-project help text with no projects', async () => {
+    useProjectStore.setState({ projects: [] })
+    await renderList()
+
+    openRadixMenu(openAddSpecialistMenu())
+    const chatItem = Array.from(
+      document.body.querySelectorAll<HTMLElement>('[role="menuitem"]')
+    ).find((item) => item.textContent?.includes('Chat with agent'))
+
+    expect(chatItem).toBeDefined()
+    expect(chatItem?.getAttribute('aria-disabled')).toBe('true')
+    expect(chatItem?.hasAttribute('data-disabled')).toBe(true)
+    expect(document.body.textContent).toContain('Open a project to chat with the agent')
+  })
+
+  it('does not start a conversation when Chat with agent is clicked with zero projects', async () => {
+    useProjectStore.setState({ projects: [] })
+    await renderList()
+
+    openRadixMenu(openAddSpecialistMenu())
+    const chatItem = Array.from(
+      document.body.querySelectorAll<HTMLElement>('[role="menuitem"]')
+    ).find((item) => item.textContent?.includes('Chat with agent'))
+    // Radix disabled items drop click handling; simulate a click anyway to prove it is inert.
+    await act(async () => {
+      chatItem?.click()
+    })
+
+    expect(navigationMock.startCustomizeConversation).not.toHaveBeenCalled()
+    expect(closeSettingsSpy).not.toHaveBeenCalled()
+  })
+
+  it('closes Settings and starts a customize conversation for the resolved project', async () => {
+    useProjectStore.setState({ projects: [project('climate-models', 5)] })
+    await renderList()
+
+    openRadixMenu(openAddSpecialistMenu())
+    const chatItem = Array.from(
+      document.body.querySelectorAll<HTMLElement>('[role="menuitem"]')
+    ).find((item) => item.textContent?.includes('Chat with agent'))
+    await act(async () => {
+      clickRadixMenuItem(chatItem)
+    })
+
+    expect(navigationMock.startCustomizeConversation).toHaveBeenCalledWith('climate-models')
+    expect(closeSettingsSpy).toHaveBeenCalled()
+  })
+
+  it('stays within navigation/prefill intent: no Specialist binding or create-form navigation', async () => {
+    const onNavigate = vi.fn()
+    useProjectStore.setState({ projects: [project('climate-models', 5)] })
+    await act(async () => {
+      root.render(<SpecialistsPanel view={{ kind: 'list' }} onNavigate={onNavigate} />)
+    })
+
+    openRadixMenu(openAddSpecialistMenu())
+    const chatItem = Array.from(
+      document.body.querySelectorAll<HTMLElement>('[role="menuitem"]')
+    ).find((item) => item.textContent?.includes('Chat with agent'))
+    await act(async () => {
+      clickRadixMenuItem(chatItem)
+    })
+
+    // No create-form navigation, no specialist create — pure navigation/prefill intent.
+    expect(onNavigate).not.toHaveBeenCalled()
   })
 })

--- a/src/renderer/src/pages/settings/SpecialistsPanel.tsx
+++ b/src/renderer/src/pages/settings/SpecialistsPanel.tsx
@@ -1,5 +1,5 @@
 import { useEffect, useMemo, useState } from 'react'
-import { ChevronDown, Copy, Pencil, Plus, Search, Trash2 } from 'lucide-react'
+import { ChevronDown, Copy, MessagesSquare, Pencil, Plus, Search, Trash2 } from 'lucide-react'
 import { AlertDialog } from 'radix-ui'
 import { Button } from '@/components/ui/button'
 import {
@@ -12,11 +12,16 @@ import {
   DropdownMenu,
   DropdownMenuContent,
   DropdownMenuItem,
+  DropdownMenuSeparator,
   DropdownMenuTrigger
 } from '@/components/ui/dropdown-menu'
 import { Input } from '@/components/ui/input'
 import { Tooltip, TooltipContent, TooltipProvider, TooltipTrigger } from '@/components/ui/tooltip'
+import { resolveCustomizeProjectId } from '@/lib/last-opened-project'
 import { SettingsToggle } from './SettingsLayout'
+import { useNavigationStore } from '@/stores/navigation-store'
+import { useProjectStore } from '@/stores/project-store'
+import { useSettingsStore } from '@/stores/settings-store'
 import { useSpecialistStore } from '@/stores/specialist-store'
 import type { CreateSpecialistInput } from '../../../../shared/specialist'
 import { SpecialistEditor } from './SpecialistEditor'
@@ -50,6 +55,9 @@ const SpecialistsPanel = ({ view, onNavigate }: SpecialistsPanelProps): React.JS
   const updateSpecialist = useSpecialistStore((s) => s.update)
   const deleteSpecialist = useSpecialistStore((s) => s.delete)
   const duplicateSpecialist = useSpecialistStore((s) => s.duplicate)
+  // Live project catalog drives the `Chat with agent` entry's enabled state and routing. The stored
+  // last-opened reference is re-validated against this list before navigating.
+  const projects = useProjectStore((s) => s.projects)
   const [filter, setFilter] = useState<CategoryFilter>('all')
   const [query, setQuery] = useState('')
   const [deletingItem, setDeletingItem] = useState<{
@@ -89,6 +97,19 @@ const SpecialistsPanel = ({ view, onNavigate }: SpecialistsPanelProps): React.JS
     if (!term || 'reviewer used by auto-review'.includes(term)) return reviewerItems
     return []
   }, [filter, query, reviewerItems])
+
+  // Resolves the valid last-opened project (or the newest-existing fallback) against the live catalog.
+  // Undefined means zero projects and the entry is disabled with explanatory help text.
+  const chatProjectId = useMemo(() => resolveCustomizeProjectId(projects), [projects])
+
+  // Navigation/prefill intent only: closes Settings and opens the resolved project's New Conversation
+  // draft carrying a `/customize` prefill. Does not send, create a session, bind a Specialist, or imply
+  // mutation approval. Final activation against the real Featured Skill is owned by issue 08.
+  const startChatWithAgent = (): void => {
+    if (!chatProjectId) return
+    useSettingsStore.getState().closeSettings()
+    useNavigationStore.getState().startCustomizeConversation(chatProjectId)
+  }
 
   if (view.kind === 'create') {
     return (
@@ -204,6 +225,36 @@ const SpecialistsPanel = ({ view, onNavigate }: SpecialistsPanelProps): React.JS
                 </span>
               </span>
             </DropdownMenuItem>
+            <DropdownMenuItem
+              className="gap-2.5"
+              disabled={!chatProjectId}
+              aria-disabled={!chatProjectId}
+              onSelect={(event) => {
+                // A disabled item cannot fire onSelect in Radix, but keep the guard explicit so the
+                // intent stays a no-op if the catalog empties between render and click.
+                if (!chatProjectId) {
+                  event.preventDefault()
+                  return
+                }
+                startChatWithAgent()
+              }}
+            >
+              <MessagesSquare className="size-4 shrink-0 text-primary" aria-hidden="true" />
+              <span className="flex flex-col">
+                <span>Chat with agent</span>
+                <span className="text-xs text-muted-foreground">
+                  Start a normal conversation; the agent guides you step by step
+                </span>
+              </span>
+            </DropdownMenuItem>
+            {!chatProjectId ? (
+              <>
+                <DropdownMenuSeparator />
+                <p className="px-2.5 pb-1 pt-0.5 text-xs text-muted-foreground">
+                  Open a project to chat with the agent
+                </p>
+              </>
+            ) : null}
           </DropdownMenuContent>
         </DropdownMenu>
       </div>

--- a/src/renderer/src/pages/workspace/WorkspacePage.customize-prefill.test.tsx
+++ b/src/renderer/src/pages/workspace/WorkspacePage.customize-prefill.test.tsx
@@ -1,0 +1,282 @@
+// @vitest-environment jsdom
+import { act } from 'react'
+import { createRoot, type Root } from 'react-dom/client'
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest'
+import type * as React from 'react'
+
+import { useNavigationStore } from '@/stores/navigation-store'
+import {
+  createInitialPreviewWorkbenchState,
+  usePreviewWorkbenchStore
+} from '@/stores/preview-workbench-store'
+import { useProjectStore } from '@/stores/project-store'
+import {
+  createInitialSessionState,
+  useSessionStore,
+  type ChatSession
+} from '@/stores/session-store'
+
+import type { ComposerDoc } from './composer/composer-doc'
+
+// Capture the props passed to the heavy child components so the test can observe the draft doc and
+// the new-conversation Specialist binding.
+let conversationProps: {
+  draftDoc: ComposerDoc
+  specialistId: string | undefined
+  attachments: unknown[]
+  attachmentTransfers: unknown[]
+  onDraftDocChange: (doc: ComposerDoc) => void
+}
+
+const runtime = vi.hoisted(() => ({
+  sendMessage: vi.fn(),
+  cancelRun: vi.fn(),
+  resumeInterruptedSession: vi.fn(),
+  deleteRuntimeSession: vi.fn(),
+  respondToPermission: vi.fn()
+}))
+
+vi.mock('@/components/ui/resizable', () => ({
+  ResizablePanel: ({ children }: { children: React.ReactNode }): React.JSX.Element => (
+    <div>{children}</div>
+  ),
+  ResizablePanelGroup: ({ children }: { children: React.ReactNode }): React.JSX.Element => (
+    <div>{children}</div>
+  ),
+  ResizableHandle: (): React.JSX.Element => <div data-testid="resize-handle" />
+}))
+
+vi.mock('@/lib/acp/useWorkspaceAgentRuntime', () => ({
+  useWorkspaceAgentRuntime: () => ({
+    actionError: null,
+    pendingPermissions: [],
+    sendMessage: runtime.sendMessage,
+    cancelRun: runtime.cancelRun,
+    resumeInterruptedSession: runtime.resumeInterruptedSession,
+    deleteRuntimeSession: runtime.deleteRuntimeSession,
+    respondToPermission: runtime.respondToPermission
+  })
+}))
+
+vi.mock('./WorkspaceSidebar', () => ({
+  WorkspaceSidebar: (): React.JSX.Element => <aside />
+}))
+
+vi.mock('./ConversationPanel', () => ({
+  ConversationPanel: (props: typeof conversationProps): React.JSX.Element => {
+    conversationProps = props
+    return <section data-testid="conversation" />
+  }
+}))
+
+vi.mock('./PreviewPanel', () => ({
+  PreviewPanel: (): React.JSX.Element => <div data-testid="preview-panel" />
+}))
+
+vi.mock('./RenameSessionDialog', () => ({
+  RenameSessionDialog: (): React.JSX.Element => <div />
+}))
+
+vi.mock('./DeleteSessionDialog', () => ({
+  DeleteSessionDialog: (): React.JSX.Element => <div />
+}))
+
+const { WorkspacePage } = await import('./WorkspacePage')
+
+const createSession = (id: string, projectId: string): ChatSession => {
+  const now = Date.now()
+
+  return {
+    id,
+    projectId,
+    title: id,
+    cwd: `/workspace/${projectId}`,
+    status: 'idle',
+    messages: [],
+    createdAt: now,
+    updatedAt: now
+  }
+}
+
+// The exact unsent ComposerDoc the Settings `Chat with agent` entry must land in the composer.
+const expectedCustomizeDoc: ComposerDoc = {
+  nodes: [
+    { type: 'skill', id: 'customize', name: 'Customize' },
+    { type: 'text', text: '  Help me create a new specialist.' }
+  ]
+}
+
+describe('WorkspacePage customize prefill', () => {
+  let container: HTMLDivElement
+  let root: Root
+
+  beforeEach(() => {
+    usePreviewWorkbenchStore.setState(createInitialPreviewWorkbenchState())
+    useProjectStore.setState({ projects: [] })
+    useNavigationStore.setState({
+      view: 'workspace',
+      activeProjectId: 'proj-1',
+      userNavigationRevision: 0,
+      explicitNavigationRevision: 0,
+      pendingCustomizePrefill: undefined
+    })
+    useSessionStore.setState({
+      ...createInitialSessionState(),
+      sessions: [createSession('sess-a', 'proj-1'), createSession('sess-b', 'proj-1')],
+      selectedSessionId: undefined
+    })
+    vi.clearAllMocks()
+    runtime.sendMessage.mockResolvedValue({ sessionId: 'sess-a', messageId: 'm1' })
+    window.api = {
+      notebook: {
+        onAvailable: vi.fn(() => vi.fn()),
+        getReference: vi.fn(() => Promise.resolve(null))
+      },
+      preview: {
+        load: vi.fn(() => Promise.resolve(undefined)),
+        save: vi.fn(() => Promise.resolve())
+      },
+      uploads: {
+        deleteUpload: vi.fn(() => Promise.resolve()),
+        stageLocalFile: vi.fn(),
+        claimLocalFile: vi.fn(() => Promise.resolve()),
+        beginTransfer: vi.fn(),
+        appendTransfer: vi.fn(),
+        getTransferStatus: vi.fn(),
+        finishTransfer: vi.fn(),
+        abortTransfer: vi.fn(),
+        onTransferProgress: vi.fn(() => vi.fn())
+      },
+      reviewer: {
+        onUpdated: vi.fn(() => vi.fn()),
+        onSuppressNextAutoReview: vi.fn(() => vi.fn()),
+        onFixLoopStart: vi.fn(() => vi.fn()),
+        onFixLoopEnd: vi.fn(() => vi.fn()),
+        abortFixLoop: vi.fn(() => Promise.resolve())
+      },
+      compute: { enabledHostsSet: vi.fn(() => Promise.resolve()) }
+    } as never
+    container = document.createElement('div')
+    document.body.appendChild(container)
+  })
+
+  afterEach(async () => {
+    await act(async () => {
+      root.unmount()
+    })
+    vi.restoreAllMocks()
+    container.remove()
+  })
+
+  const renderPage = async (): Promise<void> => {
+    root = createRoot(container)
+    await act(async () => {
+      root.render(
+        <WorkspacePage
+          isSessionPersistenceHydrated={true}
+          isSessionPersistenceReady={true}
+          canDeleteConversations={true}
+        />
+      )
+    })
+  }
+
+  it('prefills the new-conversation composer with the exact /customize doc on entry', async () => {
+    useNavigationStore.setState({ pendingCustomizePrefill: 'proj-1' })
+    await renderPage()
+
+    expect(conversationProps.draftDoc).toEqual(expectedCustomizeDoc)
+  })
+
+  it('clears the pending prefill intent once it has been applied', async () => {
+    useNavigationStore.setState({ pendingCustomizePrefill: 'proj-1' })
+    await renderPage()
+
+    expect(useNavigationStore.getState().pendingCustomizePrefill).toBeUndefined()
+  })
+
+  it('does not auto-send or create a session on entry', async () => {
+    useNavigationStore.setState({ pendingCustomizePrefill: 'proj-1' })
+    await renderPage()
+
+    expect(runtime.sendMessage).not.toHaveBeenCalled()
+    // No new session was created — the two pre-existing sessions remain and none is pending.
+    expect(useSessionStore.getState().sessions).toHaveLength(2)
+    expect(useSessionStore.getState().sessions.every((session) => !session.isPending)).toBe(true)
+  })
+
+  it('leaves the new-conversation draft with no Specialist binding', async () => {
+    useNavigationStore.setState({ pendingCustomizePrefill: 'proj-1' })
+    await renderPage()
+
+    // The fresh New Conversation draft carries no Specialist binding (no badge, no Customize Profile).
+    expect(conversationProps.specialistId).toBeUndefined()
+  })
+
+  it('starts empty when no prefill intent is pending', async () => {
+    await renderPage()
+
+    // No pending prefill: the new-conversation composer stays empty.
+    expect(conversationProps.draftDoc).toEqual({ nodes: [] })
+  })
+
+  it('uses the normal picked-Skill mechanism: the chip is a real skill node, not parsed text', async () => {
+    useNavigationStore.setState({ pendingCustomizePrefill: 'proj-1' })
+    await renderPage()
+
+    expect(conversationProps.draftDoc.nodes[0]).toEqual({
+      type: 'skill',
+      id: 'customize',
+      name: 'Customize'
+    })
+    // The text node carries the two-space gap verbatim.
+    expect(conversationProps.draftDoc.nodes[1]).toEqual({
+      type: 'text',
+      text: '  Help me create a new specialist.'
+    })
+  })
+
+  // F1 regression: `Chat with agent` prefill must survive when it is triggered from a workspace
+  // where a real session IS already selected. The draft-key effect (which swaps drafts on selection
+  // change) used to run after the render-phase prefill write and clobber it with the stored/empty
+  // New Conversation draft. Here we mount with sess-a selected, then fire the prefill intent.
+  it('preserves the /customize prefill when opened from an already-selected session', async () => {
+    // Mount with a real session selected so the draft-key effect has a non-New key to switch from.
+    useSessionStore.setState({ selectedSessionId: 'sess-a' })
+    await renderPage()
+    expect(useSessionStore.getState().selectedSessionId).toBe('sess-a')
+
+    // Trigger the `Chat with agent` intent the same way the SpecialistsPanel does.
+    await act(async () => {
+      useNavigationStore.getState().startCustomizeConversation('proj-1')
+    })
+
+    // (1) The composer draft must be exactly the customize prefill — not empty, not the prior
+    // session's draft.
+    expect(conversationProps.draftDoc).toEqual(expectedCustomizeDoc)
+
+    // (2) No staged attachments or transfers may leak from the previously-selected session.
+    expect(conversationProps.attachments).toEqual([])
+    expect(conversationProps.attachmentTransfers).toEqual([])
+    // (3) No Specialist binding on the fresh New Conversation draft.
+    expect(conversationProps.specialistId).toBeUndefined()
+
+    // (4) Still no auto-send / no session creation on this path either.
+    expect(runtime.sendMessage).not.toHaveBeenCalled()
+    expect(useSessionStore.getState().sessions).toHaveLength(2)
+  })
+
+  it('preserves an existing draft once the prefill has been consumed on first mount', async () => {
+    useNavigationStore.setState({ pendingCustomizePrefill: 'proj-1' })
+    await renderPage()
+    expect(conversationProps.draftDoc).toEqual(expectedCustomizeDoc)
+
+    // The intent is gone; a re-render does not re-apply or clobber an edited draft.
+    const edited: ComposerDoc = { nodes: [{ type: 'text', text: 'my edit' }] }
+    await act(async () => {
+      conversationProps.onDraftDocChange(edited)
+    })
+    expect(conversationProps.draftDoc).toEqual(edited)
+    expect(useNavigationStore.getState().pendingCustomizePrefill).toBeUndefined()
+  })
+})

--- a/src/renderer/src/pages/workspace/WorkspacePage.pending-switch.test.tsx
+++ b/src/renderer/src/pages/workspace/WorkspacePage.pending-switch.test.tsx
@@ -1,0 +1,505 @@
+// @vitest-environment jsdom
+// Renderer-side tests for the durable next-message switch closure (issue 08b).
+// Covers: receiving the specialist:pending-switch broadcast from host.agents.switch(),
+// mirroring the pending target WITHOUT switching the live agent mid-reply, applying the
+// approved identity at the next sendMessage, restart survival via the durable binding,
+// last-write-wins across multiple broadcasts, Main-Agent (null) clearing, and the pending
+// chip being shown while the current reply completes under the old agent.
+import { act } from 'react'
+import { createRoot, type Root } from 'react-dom/client'
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest'
+import type * as React from 'react'
+
+import { useNavigationStore } from '@/stores/navigation-store'
+import {
+  createInitialPreviewWorkbenchState,
+  usePreviewWorkbenchStore
+} from '@/stores/preview-workbench-store'
+import { useProjectStore } from '@/stores/project-store'
+import {
+  createInitialSessionState,
+  useSessionStore,
+  type ChatSession
+} from '@/stores/session-store'
+import { useSpecialistStore } from '@/stores/specialist-store'
+
+import { type ComposerDoc } from './composer/composer-doc'
+import type { SpecialistListItem } from '../../../../shared/specialist'
+
+;(globalThis as { IS_REACT_ACT_ENVIRONMENT?: boolean }).IS_REACT_ACT_ENVIRONMENT = true
+
+// Capture all props WorkspacePage passes to ConversationPanel.
+let conversationProps: Record<string, unknown>
+
+const runtime = vi.hoisted(() => ({
+  promptInFlightSessionIds: [] as string[],
+  nativeContextCompactionSessionIds: [] as string[],
+  sendMessage: vi.fn().mockResolvedValue({ sessionId: 'sess-a', messageId: 'msg-1' }),
+  compactContext: vi.fn(),
+  cancelRun: vi.fn(),
+  deleteRuntimeSession: vi.fn(),
+  respondToPermission: vi.fn()
+}))
+
+vi.mock('@/components/ui/resizable', () => ({
+  ResizablePanel: ({ children }: { children: React.ReactNode }): React.JSX.Element => (
+    <div>{children}</div>
+  ),
+  ResizablePanelGroup: ({ children }: { children: React.ReactNode }): React.JSX.Element => (
+    <div>{children}</div>
+  ),
+  ResizableHandle: (): React.JSX.Element => <div data-testid="resize-handle" />
+}))
+
+vi.mock('@/lib/acp/useWorkspaceAgentRuntime', () => ({
+  useWorkspaceAgentRuntime: () => ({
+    actionError: null,
+    pendingPermissions: [],
+    promptInFlightSessionIds: runtime.promptInFlightSessionIds,
+    nativeContextCompactionSessionIds: runtime.nativeContextCompactionSessionIds,
+    sendMessage: runtime.sendMessage,
+    compactContext: runtime.compactContext,
+    cancelRun: runtime.cancelRun,
+    deleteRuntimeSession: runtime.deleteRuntimeSession,
+    respondToPermission: runtime.respondToPermission
+  })
+}))
+
+vi.mock('./WorkspaceSidebar', () => ({
+  WorkspaceSidebar: (): React.JSX.Element => <aside />
+}))
+
+vi.mock('./ConversationPanel', () => ({
+  ConversationPanel: (props: Record<string, unknown>): React.JSX.Element => {
+    conversationProps = props
+    return <section data-testid="conversation" />
+  }
+}))
+
+vi.mock('./PreviewPanel', () => ({
+  PreviewPanel: (): React.JSX.Element => <div data-testid="preview-panel" />
+}))
+
+vi.mock('./RenameSessionDialog', () => ({
+  RenameSessionDialog: (): React.JSX.Element => <div />
+}))
+
+vi.mock('./DeleteSessionDialog', () => ({
+  DeleteSessionDialog: (): React.JSX.Element => <div />
+}))
+
+const { WorkspacePage } = await import('./WorkspacePage')
+
+const makeSpecialist = (
+  id: string,
+  name: string,
+  enabled = true
+): SpecialistListItem & { kind: 'custom' } => ({
+  kind: 'custom',
+  id,
+  name,
+  description: '',
+  systemPrompt: 'You are...',
+  enabled,
+  capabilityMode: 'full',
+  fullAccess: { excludedSkillIds: [], excludedConnectorIds: [], connectorTools: [] },
+  selectedCapabilities: { skillIds: [], connectorIds: [], connectorTools: [] },
+  revision: 1
+})
+
+const createSession = (overrides: Partial<ChatSession> = {}): ChatSession => {
+  const now = Date.now()
+  return {
+    id: 'sess-a',
+    projectId: 'proj-1',
+    title: 'sess-a',
+    cwd: '/workspace/proj-1',
+    status: 'idle',
+    messages: [],
+    createdAt: now,
+    updatedAt: now,
+    ...overrides
+  }
+}
+
+const textDoc = (text: string): ComposerDoc => ({ nodes: [{ type: 'text', text }] })
+
+let container: HTMLDivElement
+let root: Root
+
+// Captured pending-switch listener; the test fires it to simulate the host.agents.switch() broadcast.
+let pendingSwitchListener:
+  ((pending: { sessionId: string; targetName: string | null }) => void) | undefined
+
+const apiStub = (specialistOverrides?: Record<string, unknown>): typeof window.api => {
+  pendingSwitchListener = undefined
+  return {
+    notebook: {
+      onAvailable: vi.fn(() => vi.fn()),
+      getReference: vi.fn(() => Promise.resolve(null))
+    },
+    preview: {
+      load: vi.fn(() => Promise.resolve(undefined)),
+      save: vi.fn(() => Promise.resolve())
+    },
+    uploads: { deleteUpload: vi.fn() },
+    reviewer: {
+      onUpdated: vi.fn(() => vi.fn()),
+      onSuppressNextAutoReview: vi.fn(() => vi.fn()),
+      onFixLoopStart: vi.fn(() => vi.fn()),
+      onFixLoopEnd: vi.fn(() => vi.fn()),
+      abortFixLoop: vi.fn(() => Promise.resolve())
+    },
+    compute: { enabledHostsSet: vi.fn(() => Promise.resolve()) },
+    specialist: {
+      onCatalogChanged: vi.fn(() => vi.fn()),
+      onPendingSwitch: vi.fn((listener) => {
+        pendingSwitchListener = listener
+        return () => {
+          pendingSwitchListener = undefined
+        }
+      }),
+      setSessionSpecialist: vi.fn(() => Promise.resolve({ contextReset: false })),
+      resolveSessionSpecialist: vi.fn(() => Promise.resolve({ kind: 'main' as const })),
+      ...specialistOverrides
+    }
+  } as never
+}
+
+const renderPage = async (r: Root): Promise<void> => {
+  await act(async () => {
+    r.render(
+      <WorkspacePage
+        isSessionPersistenceHydrated={true}
+        isSessionPersistenceReady={true}
+        canDeleteConversations={true}
+      />
+    )
+  })
+}
+
+const setupBase = (): void => {
+  usePreviewWorkbenchStore.setState(createInitialPreviewWorkbenchState())
+  useProjectStore.setState({ projects: [] })
+  useNavigationStore.setState({ view: 'workspace', activeProjectId: 'proj-1' })
+  vi.clearAllMocks()
+  runtime.promptInFlightSessionIds = []
+  runtime.nativeContextCompactionSessionIds = []
+  runtime.sendMessage.mockResolvedValue({ sessionId: 'sess-a', messageId: 'msg-1' })
+}
+
+beforeEach(() => {
+  container = document.createElement('div')
+  document.body.appendChild(container)
+  root = createRoot(container)
+})
+
+afterEach(async () => {
+  await act(async () => {
+    root.unmount()
+  })
+  container.remove()
+})
+
+// ---------------------------------------------------------------------------
+// Broadcast mirrors pending target without switching the live agent
+// ---------------------------------------------------------------------------
+
+describe('WorkspacePage pending-switch broadcast', () => {
+  it('mirrors the pending target WITHOUT calling setSessionSpecialist mid-reply', async () => {
+    setupBase()
+    useSessionStore.setState({
+      ...createInitialSessionState(),
+      // The /customize reply is still running under the OLD specialist (spec-a).
+      sessions: [createSession({ specialistId: 'spec-a', status: 'running' })],
+      selectedSessionId: 'sess-a'
+    })
+    useSpecialistStore.setState({
+      items: [makeSpecialist('spec-a', 'Data Analyst'), makeSpecialist('spec-b', 'SQL Wrangler')],
+      isLoaded: true,
+      load: vi.fn()
+    })
+    window.api = apiStub()
+
+    await renderPage(root)
+
+    // The broadcast arrives: host.agents.switch('SQL Wrangler') was approved on main.
+    await act(async () => {
+      pendingSwitchListener?.({ sessionId: 'sess-a', targetName: 'SQL Wrangler' })
+    })
+
+    // The pending-switch chip must show.
+    expect(conversationProps.specialistHasPendingSwitch).toBe(true)
+    // The effective badge still shows the OLD specialist — the live agent was NOT switched.
+    expect(conversationProps.specialistId).toBe('spec-a')
+    // Critically: the runtime switch must NOT have happened during the broadcast.
+    expect(window.api.specialist.setSessionSpecialist).not.toHaveBeenCalled()
+  })
+
+  it('subscribes to the specialist:pending-switch channel once on mount', async () => {
+    setupBase()
+    useSessionStore.setState({
+      ...createInitialSessionState(),
+      sessions: [createSession()],
+      selectedSessionId: 'sess-a'
+    })
+    useSpecialistStore.setState({ items: [], isLoaded: true, load: vi.fn() })
+    window.api = apiStub()
+
+    await renderPage(root)
+
+    expect(window.api.specialist.onPendingSwitch).toHaveBeenCalledTimes(1)
+  })
+
+  it('clears the binding (pending Main) when the broadcast targetName is null', async () => {
+    setupBase()
+    useSessionStore.setState({
+      ...createInitialSessionState(),
+      sessions: [createSession({ specialistId: 'spec-a', status: 'running' })],
+      selectedSessionId: 'sess-a'
+    })
+    useSpecialistStore.setState({
+      items: [makeSpecialist('spec-a', 'Data Analyst')],
+      isLoaded: true,
+      load: vi.fn()
+    })
+    const setSessionSpecialist = vi.fn(() => Promise.resolve({ contextReset: false }))
+    window.api = apiStub({ setSessionSpecialist })
+
+    await renderPage(root)
+
+    // host.agents.switch(null) → revert to Main Agent.
+    await act(async () => {
+      pendingSwitchListener?.({ sessionId: 'sess-a', targetName: null })
+    })
+
+    expect(conversationProps.specialistHasPendingSwitch).toBe(true)
+
+    // Finish the run and send — the barrier must clear the binding via the same next-message path.
+    await act(async () => {
+      useSessionStore.getState().finishRun('sess-a')
+    })
+    await act(async () => {
+      ;(conversationProps.onDraftDocChange as (doc: ComposerDoc) => void)(textDoc('go'))
+    })
+    await act(async () => {
+      ;(conversationProps.onSendMessage as (ids: string[]) => void)([])
+    })
+
+    expect(setSessionSpecialist).toHaveBeenCalledWith({
+      sessionId: 'sess-a',
+      specialistId: undefined
+    })
+    expect(useSessionStore.getState().sessions[0].specialistId).toBeUndefined()
+    expect(runtime.sendMessage).toHaveBeenCalledOnce()
+  })
+
+  it('applies the approved target at the next sendMessage via the reconfigure barrier', async () => {
+    setupBase()
+    useSessionStore.setState({
+      ...createInitialSessionState(),
+      sessions: [createSession({ specialistId: 'spec-a', status: 'running' })],
+      selectedSessionId: 'sess-a'
+    })
+    useSpecialistStore.setState({
+      items: [makeSpecialist('spec-a', 'Data Analyst'), makeSpecialist('spec-b', 'SQL Wrangler')],
+      isLoaded: true,
+      load: vi.fn()
+    })
+    const setSessionSpecialist = vi.fn(() => Promise.resolve({ contextReset: false }))
+    window.api = apiStub({ setSessionSpecialist })
+
+    await renderPage(root)
+
+    await act(async () => {
+      pendingSwitchListener?.({ sessionId: 'sess-a', targetName: 'SQL Wrangler' })
+    })
+
+    // The reply finishes; the next user message triggers the barrier.
+    await act(async () => {
+      useSessionStore.getState().finishRun('sess-a')
+    })
+    await act(async () => {
+      ;(conversationProps.onDraftDocChange as (doc: ComposerDoc) => void)(textDoc('next turn'))
+    })
+    await act(async () => {
+      ;(conversationProps.onSendMessage as (ids: string[]) => void)([])
+    })
+
+    // The barrier reconfigured the live runtime under the NEW specialist (spec-b).
+    expect(setSessionSpecialist).toHaveBeenCalledWith({
+      sessionId: 'sess-a',
+      specialistId: 'spec-b'
+    })
+    expect(useSessionStore.getState().sessions[0].specialistId).toBe('spec-b')
+    expect(runtime.sendMessage).toHaveBeenCalledOnce()
+  })
+
+  it('is last-write-wins when multiple broadcasts arrive before the next send', async () => {
+    setupBase()
+    useSessionStore.setState({
+      ...createInitialSessionState(),
+      sessions: [createSession({ specialistId: 'spec-a', status: 'running' })],
+      selectedSessionId: 'sess-a'
+    })
+    useSpecialistStore.setState({
+      items: [
+        makeSpecialist('spec-a', 'Data Analyst'),
+        makeSpecialist('spec-b', 'SQL Wrangler'),
+        makeSpecialist('spec-c', 'Researcher')
+      ],
+      isLoaded: true,
+      load: vi.fn()
+    })
+    const setSessionSpecialist = vi.fn(() => Promise.resolve({ contextReset: false }))
+    window.api = apiStub({ setSessionSpecialist })
+
+    await renderPage(root)
+
+    // First approved switch, then a newer approved switch before the next send.
+    await act(async () => {
+      pendingSwitchListener?.({ sessionId: 'sess-a', targetName: 'SQL Wrangler' })
+    })
+    await act(async () => {
+      pendingSwitchListener?.({ sessionId: 'sess-a', targetName: 'Researcher' })
+    })
+
+    await act(async () => {
+      useSessionStore.getState().finishRun('sess-a')
+    })
+    await act(async () => {
+      ;(conversationProps.onDraftDocChange as (doc: ComposerDoc) => void)(textDoc('final'))
+    })
+    await act(async () => {
+      ;(conversationProps.onSendMessage as (ids: string[]) => void)([])
+    })
+
+    // The newest target (Researcher → spec-c) wins.
+    expect(setSessionSpecialist).toHaveBeenCalledWith({
+      sessionId: 'sess-a',
+      specialistId: 'spec-c'
+    })
+    expect(useSessionStore.getState().sessions[0].specialistId).toBe('spec-c')
+    expect(runtime.sendMessage).toHaveBeenCalledOnce()
+  })
+
+  it('preserves the composer draft when the reconfigure barrier fails', async () => {
+    setupBase()
+    useSessionStore.setState({
+      ...createInitialSessionState(),
+      sessions: [createSession({ specialistId: 'spec-a', status: 'running' })],
+      selectedSessionId: 'sess-a'
+    })
+    useSpecialistStore.setState({
+      items: [makeSpecialist('spec-a', 'Data Analyst'), makeSpecialist('spec-b', 'SQL Wrangler')],
+      isLoaded: true,
+      load: vi.fn()
+    })
+    const setSessionSpecialist = vi.fn().mockRejectedValueOnce(new Error('reconfigure failed'))
+    window.api = apiStub({ setSessionSpecialist })
+
+    await renderPage(root)
+
+    await act(async () => {
+      ;(conversationProps.onDraftDocChange as (doc: ComposerDoc) => void)(textDoc('keep my draft'))
+    })
+    await act(async () => {
+      pendingSwitchListener?.({ sessionId: 'sess-a', targetName: 'SQL Wrangler' })
+    })
+
+    await act(async () => {
+      useSessionStore.getState().finishRun('sess-a')
+    })
+    await act(async () => {
+      ;(conversationProps.onSendMessage as (ids: string[]) => void)([])
+    })
+
+    // Reconfigure failed: never sent, draft preserved, recovery surface shown.
+    expect(runtime.sendMessage).not.toHaveBeenCalled()
+    expect(conversationProps.reconfigureError).toBeTruthy()
+    // The draft content must survive the failure.
+    expect((conversationProps.draftDoc as ComposerDoc).nodes[0]).toMatchObject({
+      type: 'text',
+      text: 'keep my draft'
+    })
+  })
+
+  it('falls back to the durable binding when the target name is not in the loaded catalog', async () => {
+    setupBase()
+    useSessionStore.setState({
+      ...createInitialSessionState(),
+      sessions: [createSession({ specialistId: 'spec-a', status: 'running' })],
+      selectedSessionId: 'sess-a'
+    })
+    // Catalog loaded but does NOT contain the target name (e.g. name resolution must use the
+    // durable binding that host.agents.switch already persisted on main).
+    useSpecialistStore.setState({
+      items: [makeSpecialist('spec-a', 'Data Analyst')],
+      isLoaded: true,
+      load: vi.fn()
+    })
+    const setSessionSpecialist = vi.fn(() => Promise.resolve({ contextReset: false }))
+    const resolveSessionSpecialist = vi.fn(() =>
+      Promise.resolve({
+        kind: 'bound' as const,
+        profile: makeSpecialist('spec-b', 'SQL Wrangler')
+      })
+    )
+    window.api = apiStub({ setSessionSpecialist, resolveSessionSpecialist })
+
+    await renderPage(root)
+
+    await act(async () => {
+      pendingSwitchListener?.({ sessionId: 'sess-a', targetName: 'SQL Wrangler' })
+    })
+    // Let the async resolve settle.
+    await act(async () => {
+      await Promise.resolve()
+    })
+
+    // The renderer resolved the durable binding for the pending target.
+    expect(resolveSessionSpecialist).toHaveBeenCalledWith({ sessionId: 'sess-a' })
+    expect(conversationProps.specialistHasPendingSwitch).toBe(true)
+  })
+
+  it('does not eagerly switch the live agent when a broadcast arrives while idle', async () => {
+    setupBase()
+    // The calling session already finished its reply (idle). Main already persisted the durable
+    // binding; the broadcast only mirrors the pending target so the next send applies it.
+    useSessionStore.setState({
+      ...createInitialSessionState(),
+      sessions: [createSession({ specialistId: 'spec-a', status: 'idle' })],
+      selectedSessionId: 'sess-a'
+    })
+    useSpecialistStore.setState({
+      items: [makeSpecialist('spec-a', 'Data Analyst'), makeSpecialist('spec-b', 'SQL Wrangler')],
+      isLoaded: true,
+      load: vi.fn()
+    })
+    const setSessionSpecialist = vi.fn(() => Promise.resolve({ contextReset: false }))
+    window.api = apiStub({ setSessionSpecialist })
+
+    await renderPage(root)
+
+    await act(async () => {
+      pendingSwitchListener?.({ sessionId: 'sess-a', targetName: 'SQL Wrangler' })
+    })
+
+    // The broadcast mirrors pending state only — the runtime must NOT switch eagerly.
+    expect(setSessionSpecialist).not.toHaveBeenCalled()
+
+    // The pending target still applies at the next send via the reconfigure barrier.
+    await act(async () => {
+      ;(conversationProps.onDraftDocChange as (doc: ComposerDoc) => void)(textDoc('next'))
+    })
+    await act(async () => {
+      ;(conversationProps.onSendMessage as (ids: string[]) => void)([])
+    })
+
+    expect(setSessionSpecialist).toHaveBeenCalledWith({
+      sessionId: 'sess-a',
+      specialistId: 'spec-b'
+    })
+    expect(runtime.sendMessage).toHaveBeenCalledOnce()
+  })
+})

--- a/src/renderer/src/pages/workspace/WorkspacePage.tsx
+++ b/src/renderer/src/pages/workspace/WorkspacePage.tsx
@@ -43,6 +43,7 @@ import {
   emptyDoc,
   type ComposerDoc
 } from './composer/composer-doc'
+import { buildCustomizePrefillDoc } from '@/lib/customize-chat'
 import { ConversationPanel } from './ConversationPanel'
 import { DeleteSessionDialog } from './DeleteSessionDialog'
 import { MobilePreviewSheet } from './MobilePreviewSheet'
@@ -376,6 +377,8 @@ const WorkspacePage = ({
   // is only reachable via openProject/openSession (which set it); '' is a defensive sentinel that
   // matches no session and triggers the redirect below.
   const activeProjectId = useNavigationStore((state) => state.activeProjectId)
+  const pendingCustomizePrefill = useNavigationStore((state) => state.pendingCustomizePrefill)
+  const consumeCustomizePrefill = useNavigationStore((state) => state.consumeCustomizePrefill)
   const goHome = useNavigationStore((state) => state.goHome)
   const openSettings = useSettingsStore((state) => state.openSettings)
   const activeProviderId = useSettingsStore((state) => state.activeProviderId)
@@ -486,6 +489,27 @@ const WorkspacePage = ({
       (item) => item.kind === 'custom' && item.enabled && item.id === newConversationSpecialistId
     )
 
+  // Consume the `Chat with agent` prefill intent in the render phase (matching the pending-skill /
+  // pending-panel pattern): land the exact `/customize` ComposerDoc on the New Conversation draft once,
+  // clear any Specialist binding for that fresh draft, then clear the store intent below. The intent is
+  // navigation/prefill only — it never sends, creates a session, or implies mutation approval. The
+  // appliedCustomizePrefill state tracks the intent already applied so a re-render does not clobber an
+  // edited draft.
+  const [appliedCustomizePrefill, setAppliedCustomizePrefill] = useState<string | undefined>(
+    undefined
+  )
+  if (
+    pendingCustomizePrefill !== undefined &&
+    pendingCustomizePrefill === activeProjectId &&
+    selectedSessionId === undefined &&
+    appliedCustomizePrefill !== pendingCustomizePrefill
+  ) {
+    setAppliedCustomizePrefill(pendingCustomizePrefill)
+    setDraftDoc(buildCustomizePrefillDoc())
+    // A fresh New Conversation draft carries no Specialist binding (no badge, no Customize Profile).
+    setNewConversationSpecialistId(undefined)
+  }
+
   // Per-session pending specialist selection for existing conversations.
   // Key: sessionId. Value: the pending UUID (or undefined to clear binding).
   // The pending value is the user's last selection; it takes effect on the next send via reconfigure
@@ -493,6 +517,11 @@ const WorkspacePage = ({
   const [pendingSessionSpecialist, setPendingSessionSpecialist] = useState<
     Record<string, string | undefined>
   >({})
+
+  // Latest specialist catalog, mirrored into a ref so the pending-switch broadcast subscription
+  // stays stable (subscribes once on mount) while still reading fresh data when a host.agents.switch()
+  // broadcast arrives. Set in an effect (never during render) to comply with the react-hooks/refs rule.
+  const specialistItemsRef = useRef(specialistItems)
 
   // Reconfigure failure state: set when a pre-send dispose/resume fails.
   // Keeps the draft intact, shows the recovery banner above the composer.
@@ -747,6 +776,13 @@ const WorkspacePage = ({
   // previews) and persists/restores each project's panel state across switches and restarts.
   usePreviewPersistence(activeProjectId, isSessionPersistenceReady)
 
+  // Clear the consumed `Chat with agent` prefill intent from the store once it has been applied in the
+  // render phase above, so a later normal open starts fresh. (Calling a store action — not a React
+  // setter — so this does not trip the set-state-in-effect rule.)
+  useEffect(() => {
+    if (pendingCustomizePrefill !== undefined) consumeCustomizePrefill()
+  }, [pendingCustomizePrefill, consumeCustomizePrefill])
+
   // Escape closes the mobile navigation drawer without touching the active session or draft.
   useEffect(() => {
     if (!isMobile || !isMobileSidebarOpen) return
@@ -770,6 +806,30 @@ const WorkspacePage = ({
       attachments,
       attachmentTransfers
     }
+    // When the selection lands on the New Conversation key while a `Chat with agent` prefill is
+    // pending for the active project, the render-phase consumer above has already set the exact
+    // `/customize` doc. This effect runs AFTER that render-phase write, so loading the stored/empty
+    // draft here would clobber the prefill (the last writer wins). Bail out instead: advance the
+    // tracked key so a later switch still saves the prefill draft, and clear any attachments that
+    // leaked from the previously-selected session so the fresh draft starts clean.
+    const customizePrefillPending =
+      currentDraftKey === NEW_CONVERSATION_DRAFT_KEY &&
+      pendingCustomizePrefill !== undefined &&
+      pendingCustomizePrefill === activeProjectId
+    if (customizePrefillPending) {
+      // The render-phase consumer above has already landed the exact `/customize` doc. Only the
+      // attachments need clearing here (they may have leaked from the previously-selected session).
+      // Do NOT reload the stored/empty draft doc — that would clobber the prefill (last writer wins).
+      const freshDraft = composerDraftsRef.current[currentDraftKey] ?? {
+        doc: emptyDoc,
+        attachments: [],
+        attachmentTransfers: []
+      }
+      setAttachments(freshDraft.attachments)
+      setAttachmentTransfers(freshDraft.attachmentTransfers)
+      previousDraftKeyRef.current = currentDraftKey
+      return
+    }
     const nextDraft = composerDraftsRef.current[currentDraftKey] ?? {
       doc: emptyDoc,
       attachments: [],
@@ -779,7 +839,14 @@ const WorkspacePage = ({
     setAttachments(nextDraft.attachments)
     setAttachmentTransfers(nextDraft.attachmentTransfers)
     previousDraftKeyRef.current = currentDraftKey
-  }, [selectedSessionId, draftDoc, attachments, attachmentTransfers])
+  }, [
+    selectedSessionId,
+    draftDoc,
+    attachments,
+    attachmentTransfers,
+    pendingCustomizePrefill,
+    activeProjectId
+  ])
 
   // The first agent-side notebook call promotes a notebook entry into the composer status bar.
   useEffect(() => {
@@ -1637,6 +1704,63 @@ const WorkspacePage = ({
     })
     return remove
   }, [loadSpecialists])
+
+  // Keep the latest specialist catalog in a ref so the stable broadcast subscription below reads
+  // fresh data without re-subscribing on every catalog change.
+  useEffect(() => {
+    specialistItemsRef.current = specialistItems
+  }, [specialistItems])
+
+  // Subscribe to durable next-message switch broadcasts from host.agents.switch() (issue 08b/08a).
+  // An approved switch ALREADY persisted the binding on main and is running inside the current reply's
+  // Agent; the renderer only mirrors the pending target so the composer shows the "takes effect on the
+  // next message" state and the next-send reconfigure barrier applies the approved identity. The live
+  // agent is NOT switched here — setSessionSpecialist runs only at the next sendMessage barrier.
+  useEffect(() => {
+    if (!window.api?.specialist?.onPendingSwitch) return
+    const remove = window.api.specialist.onPendingSwitch((pending) => {
+      // null target => revert to Main Agent. main already persisted the clear BEFORE broadcasting
+      // (host.agents.switch(null) writes the Main binding, then notifies), so the renderer only
+      // mirrors it here — no resolveSessionSpecialist round-trip is needed, unlike the named-target
+      // fallthrough below. The pending entry is set to undefined so the next-send barrier, which keys
+      // on pendingSessionSpecialist ownership, clears the binding. If a target resolves unavailable
+      // between approval and broadcast the pending entry is simply unset and the failure surfaces
+      // fail-closed at the next send; the message never runs under the wrong identity.
+      if (pending.targetName === null) {
+        setPendingSessionSpecialist((prev) => ({ ...prev, [pending.sessionId]: undefined }))
+        return
+      }
+      // Resolve the public name to a UUID against the live catalog (last-write-wins: each broadcast
+      // overwrites the pending entry).
+      const match = specialistItemsRef.current.find(
+        (item) => item.kind === 'custom' && item.name === pending.targetName
+      )
+      if (match && match.kind === 'custom') {
+        setPendingSessionSpecialist((prev) => ({ ...prev, [pending.sessionId]: match.id }))
+        return
+      }
+      // Catalog not yet loaded or the target was renamed/deleted between approval and broadcast:
+      // resolve the durable binding that host.agents.switch already persisted on main. The result is
+      // mirrored as the pending target so the barrier still reconfigures at the next send.
+      const resolver = window.api?.specialist?.resolveSessionSpecialist
+      if (!resolver) return
+      void resolver
+        .call(window.api.specialist, { sessionId: pending.sessionId })
+        .then((resolution) => {
+          if (resolution.kind === 'bound') {
+            setPendingSessionSpecialist((prev) => ({
+              ...prev,
+              [pending.sessionId]: resolution.profile.id
+            }))
+          }
+        })
+        .catch(() => {
+          // Resolution failed: the durable binding still applies on the next session create/resume;
+          // leave the pending state unset so the user can retry explicitly.
+        })
+    })
+    return remove
+  }, [])
 
   const toggleSidebarPanel = (): void => {
     setSidebarPanelState((state) => (state === 'collapsed' ? 'open' : 'collapsed'))

--- a/src/renderer/src/stores/navigation-store.test.ts
+++ b/src/renderer/src/stores/navigation-store.test.ts
@@ -1,11 +1,18 @@
-import { beforeEach, describe, expect, it } from 'vitest'
+import { beforeEach, describe, expect, it, vi } from 'vitest'
 
 import {
   SESSION_MANIFEST_VERSION,
   type PersistedChatSession
 } from '../../../shared/session-persistence'
+import { recordLastOpenedProject } from '@/lib/last-opened-project'
 import { createInitialSessionState, useSessionStore } from './session-store'
 import { useNavigationStore } from './navigation-store'
+
+vi.mock('@/lib/last-opened-project', () => ({
+  recordLastOpenedProject: vi.fn(),
+  getLastOpenedProjectId: vi.fn(() => undefined),
+  resolveCustomizeProjectId: vi.fn(() => undefined)
+}))
 
 const createSession = (overrides: Partial<PersistedChatSession>): PersistedChatSession => ({
   id: 'session-1',
@@ -25,8 +32,10 @@ beforeEach(() => {
     view: 'home',
     activeProjectId: undefined,
     userNavigationRevision: 0,
-    explicitNavigationRevision: 0
+    explicitNavigationRevision: 0,
+    pendingCustomizePrefill: undefined
   })
+  vi.mocked(recordLastOpenedProject).mockClear()
 })
 
 describe('navigation store', () => {
@@ -126,5 +135,50 @@ describe('navigation store', () => {
     useNavigationStore.getState().recordUserNavigation()
     expect(useNavigationStore.getState().userNavigationRevision).toBe(2)
     expect(useNavigationStore.getState().explicitNavigationRevision).toBe(3)
+  })
+
+  it('records the last-opened project only for explicit user project opens', () => {
+    useNavigationStore.getState().openProject('project-a', 'user')
+    expect(recordLastOpenedProject).toHaveBeenCalledWith('project-a')
+
+    vi.mocked(recordLastOpenedProject).mockClear()
+    useNavigationStore.getState().openProject('project-b', 'automatic')
+    expect(recordLastOpenedProject).not.toHaveBeenCalled()
+  })
+
+  it('records the last-opened project when a user opens a session', () => {
+    useNavigationStore.getState().openSession('project-a', 'session-1', 'user')
+    expect(recordLastOpenedProject).toHaveBeenCalledWith('project-a')
+  })
+})
+
+describe('navigation store customize conversation', () => {
+  it('starts a customize conversation: opens the project, clears selection, and sets a prefill intent', () => {
+    useNavigationStore.getState().startCustomizeConversation('project-a')
+
+    const state = useNavigationStore.getState()
+    expect(state.view).toBe('workspace')
+    expect(state.activeProjectId).toBe('project-a')
+    // New conversation draft: no session selected, so no Specialist binding.
+    expect(useSessionStore.getState().selectedSessionId).toBeUndefined()
+    expect(state.pendingCustomizePrefill).toBe('project-a')
+  })
+
+  it('records the customize target as the last-opened project', () => {
+    useNavigationStore.getState().startCustomizeConversation('project-a')
+    expect(recordLastOpenedProject).toHaveBeenCalledWith('project-a')
+  })
+
+  it('counts the customize entry as explicit user navigation', () => {
+    useNavigationStore.getState().startCustomizeConversation('project-a')
+    expect(useNavigationStore.getState().userNavigationRevision).toBe(1)
+  })
+
+  it('clears the pending prefill intent once consumed', () => {
+    useNavigationStore.getState().startCustomizeConversation('project-a')
+    expect(useNavigationStore.getState().pendingCustomizePrefill).toBe('project-a')
+
+    useNavigationStore.getState().consumeCustomizePrefill()
+    expect(useNavigationStore.getState().pendingCustomizePrefill).toBeUndefined()
   })
 })

--- a/src/renderer/src/stores/navigation-store.ts
+++ b/src/renderer/src/stores/navigation-store.ts
@@ -1,5 +1,7 @@
 import { create } from 'zustand'
 
+import { recordLastOpenedProject } from '@/lib/last-opened-project'
+
 import { useSessionStore } from './session-store'
 
 export type NavigationView = 'home' | 'workspace'
@@ -14,6 +16,9 @@ type NavigationStore = {
   // Advances when an explicit navigation intent should supersede a deferred startup deep link.
   // Desktop-notification clicks count here, but not as in-app user navigation above.
   explicitNavigationRevision: number
+  // Project id targeted by a pending `Chat with agent` prefill, consumed once by WorkspacePage when it
+  // opens that project's New Conversation draft. Undefined means no prefill is pending.
+  pendingCustomizePrefill: string | undefined
   recordUserNavigation: () => void
   goHome: (origin: NavigationOrigin) => void
   openProject: (projectId: string, origin: NavigationOrigin) => void
@@ -21,6 +26,11 @@ type NavigationStore = {
   // Opens a session knowing only its id (e.g. a desktop-notification click); a no-op when the
   // session no longer exists or hasn't loaded yet.
   openSessionById: (sessionId: string, origin: NavigationOrigin) => void
+  // Opens a project's New Conversation draft (no Specialist binding) carrying a `/customize` prefill.
+  // The intent does not send, create a session, or imply mutation approval; WorkspacePage consumes the
+  // prefill once and clears it.
+  startCustomizeConversation: (projectId: string) => void
+  consumeCustomizePrefill: () => void
 }
 
 const navigationState = (
@@ -56,6 +66,7 @@ export const useNavigationStore = create<NavigationStore>((set) => ({
   activeProjectId: undefined,
   userNavigationRevision: 0,
   explicitNavigationRevision: 0,
+  pendingCustomizePrefill: undefined,
 
   // Records user-owned navigation that changes another store (for example, opening the local New
   // Conversation draft clears Session selection without changing the top-level view).
@@ -68,7 +79,8 @@ export const useNavigationStore = create<NavigationStore>((set) => ({
   // Returns to the home screen without discarding session state.
   goHome: (origin) => set((state) => navigationState(state, origin, { view: 'home' })),
 
-  // Enters a project's workspace, selecting its most recent session when one exists.
+  // Enters a project's workspace, selecting its most recent session when one exists. An explicit user
+  // open also records the durable last-opened project so `Chat with agent` re-opens it next time.
   openProject: (projectId, origin) => {
     const mostRecentSessionId = findMostRecentSessionId(projectId)
 
@@ -78,6 +90,8 @@ export const useNavigationStore = create<NavigationStore>((set) => ({
       useSessionStore.getState().clearSelection()
     }
 
+    if (origin === 'user') recordLastOpenedProject(projectId)
+
     set((state) =>
       navigationState(state, origin, { view: 'workspace', activeProjectId: projectId })
     )
@@ -86,6 +100,8 @@ export const useNavigationStore = create<NavigationStore>((set) => ({
   // Opens a specific session inside its project's workspace.
   openSession: (projectId, sessionId, origin) => {
     useSessionStore.getState().selectSession(sessionId)
+
+    if (origin === 'user') recordLastOpenedProject(projectId)
 
     set((state) =>
       navigationState(state, origin, { view: 'workspace', activeProjectId: projectId })
@@ -110,5 +126,22 @@ export const useNavigationStore = create<NavigationStore>((set) => ({
         activeProjectId: session.projectId
       })
     )
-  }
+  },
+
+  // Opens a project's New Conversation draft carrying a `/customize` prefill. Clears session selection
+  // so the fresh draft has no Specialist binding, records the target as the last-opened project, and
+  // stamps a pending prefill intent that WorkspacePage consumes once. The intent never sends or creates
+  // a session; it is a navigation/prefill intent only.
+  startCustomizeConversation: (projectId) => {
+    useSessionStore.getState().clearSelection()
+    recordLastOpenedProject(projectId)
+
+    set((state) => ({
+      ...navigationState(state, 'user', { view: 'workspace', activeProjectId: projectId }),
+      pendingCustomizePrefill: projectId
+    }))
+  },
+
+  // Clears the consumed prefill intent so a later normal open starts fresh.
+  consumeCustomizePrefill: () => set({ pendingCustomizePrefill: undefined })
 }))

--- a/src/shared/agents-contract.test.ts
+++ b/src/shared/agents-contract.test.ts
@@ -1,0 +1,179 @@
+import { describe, expect, it } from 'vitest'
+
+import {
+  AGENTS_RESERVED_PARAM_KEYS,
+  isAgentsOpName,
+  isAgentsParams,
+  stripAgentsReservedParams
+} from './agents-contract'
+import type {
+  AgentsApprovedResult,
+  AgentsDeclinedResult,
+  AgentsRequest,
+  ApprovalGateway,
+  ApprovalResult,
+  PendingSwitch,
+  SwitchNotifier,
+  TrustedCallingSession
+} from './agents-contract'
+
+describe('agents-contract: canonical request/result union', () => {
+  it('recognizes every read and write op name', () => {
+    const readOps = ['list', 'get', 'list_skills', 'list_connectors'] as const
+    const writeOps = [
+      'create',
+      'update',
+      'attach_skill',
+      'detach_skill',
+      'attach_connector',
+      'detach_connector',
+      'delete',
+      'switch'
+    ] as const
+    for (const op of [...readOps, ...writeOps]) {
+      expect(isAgentsOpName(op)).toBe(true)
+    }
+  })
+
+  it('rejects unknown op names so the contract stays closed under extension', () => {
+    expect(isAgentsOpName('rename')).toBe(false)
+    expect(isAgentsOpName('')).toBe(false)
+    expect(isAgentsOpName(undefined)).toBe(false)
+    expect(isAgentsOpName(42)).toBe(false)
+  })
+
+  it('a write request satisfies the AgentsRequest union (compile-time contract)', () => {
+    // If the union did not include these ops, this assignment would not type-check.
+    const requests: AgentsRequest[] = [
+      { op: 'list' },
+      { op: 'get', params: { name: 'Bio' } },
+      { op: 'list_skills', params: { name_or_id: 'demo' } },
+      { op: 'list_connectors', params: {} },
+      { op: 'create', params: { name: 'Bio', system_prompt: 'x' } },
+      { op: 'update', params: { name: 'Bio', patch: { description: 'y' } } },
+      { op: 'delete', params: { name: 'Bio', revision: 3 } },
+      { op: 'switch', params: { name: null } },
+      { op: 'attach_skill', params: { name: 'Bio', skill_ref: 'demo', revision: 3 } },
+      { op: 'detach_skill', params: { name: 'Bio', skill_ref: 'demo', revision: 3 } },
+      { op: 'attach_connector', params: { name: 'Bio', connector_ref: 'cust-1', revision: 3 } },
+      { op: 'detach_connector', params: { name: 'Bio', connector_ref: 'cust-1', revision: 3 } }
+    ]
+    expect(requests).toHaveLength(12)
+  })
+
+  it('isAgentsParams narrows plain objects and rejects null/arrays/primitives', () => {
+    expect(isAgentsParams({})).toBe(true)
+    expect(isAgentsParams({ a: 1 })).toBe(true)
+    expect(isAgentsParams(null)).toBe(false)
+    expect(isAgentsParams(undefined)).toBe(false)
+    expect(isAgentsParams([1, 2])).toBe(false)
+    expect(isAgentsParams('x')).toBe(false)
+  })
+})
+
+describe('agents-contract: reserved-param stripping', () => {
+  it('removes every reserved routing/identity/switch key', () => {
+    const params = {
+      op: 'list_skills',
+      session_id: 'forged-session',
+      sessionId: 'forged-session-camel',
+      specialist_id: 'forged-specialist',
+      target_specialist_id: 'forged-target',
+      targetSpecialistId: 'forged-target-camel',
+      reconfigure: true,
+      context_reset: true,
+      contextReset: true,
+      name_or_id: 'demo'
+    }
+    const stripped = stripAgentsReservedParams(params)
+    expect(stripped).toEqual({ name_or_id: 'demo' })
+    for (const key of AGENTS_RESERVED_PARAM_KEYS) {
+      expect(stripped).not.toHaveProperty(key)
+    }
+  })
+
+  it('leaves caller-supplied snake_case method params untouched', () => {
+    const stripped = stripAgentsReservedParams({
+      name: 'Bio',
+      system_prompt: 'instructions',
+      skill_names: ['demo']
+    })
+    expect(stripped).toEqual({
+      name: 'Bio',
+      system_prompt: 'instructions',
+      skill_names: ['demo']
+    })
+  })
+
+  it('handles an empty params object', () => {
+    expect(stripAgentsReservedParams({})).toEqual({})
+  })
+})
+
+describe('agents-contract: approval result shape', () => {
+  it('the declined result carries the exact { status, operation } shape (PRD:137 / design:242)', () => {
+    const declined: AgentsDeclinedResult = { status: 'declined', operation: 'switch' }
+    expect(declined.status).toBe('declined')
+    expect(declined.operation).toBe('switch')
+    // operation is exactly the privileged-op set; no other value type-checks.
+    const operations: AgentsDeclinedResult['operation'][] = ['update', 'delete', 'switch']
+    expect(operations).toEqual(['update', 'delete', 'switch'])
+  })
+
+  it('the approved result has only a status field', () => {
+    const approved: AgentsApprovedResult = { status: 'approved' }
+    expect(approved.status).toBe('approved')
+  })
+
+  it('an ApprovalResult can be either branch', () => {
+    const results: ApprovalResult[] = [
+      { status: 'approved' },
+      { status: 'declined', operation: 'delete' },
+      { status: 'declined', operation: 'switch', reason: 'user said no' }
+    ]
+    expect(results[0].status).toBe('approved')
+    expect(results[1].status).toBe('declined')
+  })
+})
+
+describe('agents-contract: fakes satisfy the injected seams (develop against fakes)', () => {
+  // This is the "develop against fakes in parallel" criterion: a downstream module implements
+  // both the approval gateway and the switch notifier as plain objects and they type-check against
+  // the shared interfaces — no real behavior required.
+  it('a fake ApprovalGateway and SwitchNotifier satisfy their interfaces', async () => {
+    const fakeGateway: ApprovalGateway = {
+      decide: async () => ({ status: 'approved' })
+    }
+    const notified: PendingSwitch[] = []
+    const fakeNotifier: SwitchNotifier = {
+      notify: (pending) => {
+        notified.push(pending)
+      }
+    }
+
+    const decision = await fakeGateway.decide({
+      operation: 'switch',
+      summary: { target: 'Bio' },
+      session: { sessionId: 'trusted-session' }
+    })
+    expect(decision.status).toBe('approved')
+
+    await fakeNotifier.notify({
+      sessionId: 'trusted-session',
+      targetName: 'Bio'
+    })
+    expect(notified).toEqual([{ sessionId: 'trusted-session', targetName: 'Bio' }])
+  })
+
+  it('a fake gateway can decline with the structured shape', async () => {
+    const fakeGateway: ApprovalGateway = {
+      decide: async () => ({ status: 'declined', operation: 'switch', reason: 'nope' })
+    }
+    const decision = await fakeGateway.decide({
+      operation: 'switch',
+      summary: {},
+      session: { sessionId: 's' } satisfies TrustedCallingSession
+    })
+    expect(decision).toEqual({ status: 'declined', operation: 'switch', reason: 'nope' })
+  })
+})

--- a/src/shared/agents-contract.ts
+++ b/src/shared/agents-contract.ts
@@ -1,0 +1,298 @@
+// Shared `host.agents` composition contracts (issue 02, round 2).
+//
+// This module is the single source of truth for the request/result shapes, the injected approval
+// gateway, and the trusted calling-session + pending-switch/reconfigure seam that the downstream
+// mutation, switch, and renderer slices (issues 03-07) compile and test against. Defining the
+// contracts here — in `src/shared/`, with NO `src/main` import — keeps them safe for preload
+// (sandbox: true) and lets a downstream module implement every seam as a fake while real
+// composition is deferred to issue 08.
+//
+// Rules mirrored from design.md §7/§8/§9 and PRD §2/§8:
+//  - Method names and write-side/filter fields are snake_case; returned records are camelCase.
+//  - A permission denial is a normal camelCase result `{ status: 'declined', operation }`.
+//  - The trusted calling-session identity and pending-switch seam are server-supplied; sandbox
+//    params can never supply or override them (the RPC route strips those fields before dispatch).
+//  - Main validates every payload; sandbox input is untrusted.
+//
+// This module deliberately defines TYPES and a pure VALIDATION helper only — it holds no real
+// mutation/switch/approval BEHAVIOR. Behavior lands in issues 03/04/05/08.
+
+// ---------------------------------------------------------------------------
+// Operation discriminator + trusted calling session
+// ---------------------------------------------------------------------------
+
+// The set of operations the read slice already serves. These are stable; the dispatcher must keep
+// routing them exactly as before.
+export type AgentsReadOpName = 'list' | 'get' | 'list_skills' | 'list_connectors'
+
+// Placeholder operation names for the mutation/switch slices. The read slice does NOT implement
+// them, but the union must already name them so downstream modules type-check against the contract
+// and the dispatcher's op union is provably extensible (see AgentsService.dispatch).
+//
+// `create`/`update` plus the four attach/detach ops are ORDINARY mutations (issue 03): chat review
+// is the only confirmation, no permission card. `delete`/`switch` are PRIVILEGED (issues 04/05) and
+// route through the approval gateway before mutation.
+export type AgentsWriteOpName =
+  | 'create'
+  | 'update'
+  | 'attach_skill'
+  | 'detach_skill'
+  | 'attach_connector'
+  | 'detach_connector'
+  | 'delete'
+  | 'switch'
+
+// The ordinary-mutation ops implemented in this slice (issue 03). Privileged ops (delete/switch and
+// name-changing update) stay out of scope here — they require the approval gateway.
+export type AgentsOrdinaryWriteOpName =
+  'create' | 'update' | 'attach_skill' | 'detach_skill' | 'attach_connector' | 'detach_connector'
+
+// Every operation name the contract recognizes today. Adding a new operation means: (1) add its
+// name here, (2) add its validated params/result branch below, (3) wire it in AgentsService.dispatch
+// — without touching the auth/token transport in local-rpc-server.ts.
+export type AgentsOpName = AgentsReadOpName | AgentsWriteOpName
+
+// The trusted calling-session identity captured outside the sandbox (the control-plane REPL's
+// module-closure COMPUTE_SESSION_ID). This is the ONLY value switch() may target; sandbox code
+// cannot forge it. It is injected into dispatch as SERVER CONTEXT — the dispatcher and the domain
+// mutations it calls never read it back out of the forwarded op-params. (The transport in
+// local-rpc-server.ts does take `session_id` from the request to populate this context; see that
+// file's agentsCall comment for why that request value is trusted: the JS control REPL binds it to
+// the spawn-captured COMPUTE_SESSION_ID and the loopback is Bearer-token-gated.)
+export type TrustedCallingSession = {
+  sessionId?: string
+}
+
+// ---------------------------------------------------------------------------
+// Canonical request/result union
+// ---------------------------------------------------------------------------
+
+// Read-side ops — identical shapes to the ones the read slice already accepts. Re-declared here so
+// downstream code imports ONE canonical union instead of re-deriving it from the service.
+export type AgentsReadRequest =
+  | { op: 'list' }
+  | { op: 'get'; params: { name?: string } }
+  | { op: 'list_skills'; params: { name_or_id?: string } }
+  | { op: 'list_connectors'; params: { name_or_id?: string } }
+
+// Placeholder write/switch ops. Their params intentionally mirror design.md §4/§5 and PRD §2/§4
+// (snake_case fields). They are UNVALIDATED beyond shape here on purpose: the real mutation modules
+// (issues 03/04/05) own the domain validation against ProfileService. We only enforce that an
+// unknown op is rejected and that a recognized op is allowed through, so the dispatcher union is
+// the extension point.
+export type AgentsWriteRequest =
+  | { op: 'create'; params: Record<string, unknown> }
+  | { op: 'update'; params: { name?: string; patch?: Record<string, unknown> } }
+  | { op: 'delete'; params: { name?: string; revision?: number } }
+  | { op: 'switch'; params: { name?: string | null } }
+  | { op: 'attach_skill'; params: { name?: string; skill_ref?: string; revision?: number } }
+  | { op: 'detach_skill'; params: { name?: string; skill_ref?: string; revision?: number } }
+  | { op: 'attach_connector'; params: { name?: string; connector_ref?: string; revision?: number } }
+  | { op: 'detach_connector'; params: { name?: string; connector_ref?: string; revision?: number } }
+
+// The full extensible request union. `unknown op` is intentionally NOT part of this union: the
+// dispatcher rejects unrecognized ops with a sanitized error, which keeps the contract closed under
+// extension while remaining open for the listed write operations.
+export type AgentsRequest = AgentsReadRequest | AgentsWriteRequest
+
+// A structured permission denial (design.md §8 / PRD §2:137). Returned by the injected approval
+// gateway as a normal camelCase result — it is NOT an error. `operation` echoes the privileged op
+// the user declined.
+export type AgentsDeclinedResult = {
+  status: 'declined'
+  operation: 'update' | 'delete' | 'switch'
+  reason?: string
+}
+
+// A structured approval (no payload beyond the decision). The privileged mutation modules attach
+// read-back state themselves; the gateway only owns the approve/decline decision.
+export type AgentsApprovedResult = { status: 'approved' }
+
+// ---------------------------------------------------------------------------
+// Injected approval gateway (fake-able; real behavior deferred to issues 04/05)
+// ---------------------------------------------------------------------------
+
+// The privileged operations that must pass the approval gateway before mutation. `update` here
+// means a NAME-CHANGING update only (design.md §7); ordinary chat-reviewed mutations do not call
+// the gateway.
+export type PrivilegedOperation = 'update' | 'delete' | 'switch'
+
+export type ApprovalRequest = {
+  operation: PrivilegedOperation
+  // A redacted, user-facing description of the proposed privileged change. Never carries system
+  // instructions, credentials, headers, environment values, connector args, or tokens.
+  // `target` is the named Specialist for a switch, or null to revert to Main Agent (the card surface
+  // distinguishes "Main Agent" from a named target — see specialist-approval-gateway.ts).
+  summary: {
+    name?: string
+    newName?: string
+    target?: string | null
+  }
+  // The trusted calling-session identity, threaded from server context. The gateway must not trust
+  // any caller-supplied value here.
+  session: TrustedCallingSession
+}
+
+export type ApprovalResult = AgentsApprovedResult | AgentsDeclinedResult
+
+// INJECTED seam. Production wires the real ACP permission broker/card; tests and downstream
+// development wire fakes. The dispatcher hands each privileged op to this gateway; a decline is a
+// normal result, not a thrown error.
+export type ApprovalGateway = {
+  decide(request: ApprovalRequest): Promise<ApprovalResult>
+}
+
+// ---------------------------------------------------------------------------
+// Standard renderer presentation for privileged Specialist operations (issue 04)
+// ---------------------------------------------------------------------------
+
+// The three privileged Specialist operation kinds that render a standard permission card
+// (design.md §7 / prototype.html scenes 5/7/8). These are the ONLY operations that pass through the
+// approval gateway; ordinary chat-reviewed mutations never produce a card.
+export type SpecialistApprovalKind = 'update' | 'delete' | 'switch'
+
+// A compact, redacted change manifest for ONE field on a name-changing update card. It never carries
+// full text — only an edited/added/removed signal plus optional counts — so system instructions,
+// descriptions, and capability lists stay out of the card (their full content lives in the chat
+// review). This is the "minimum public change summary" cross-cutting requirement made concrete.
+export type SpecialistFieldChange =
+  | { field: string; kind: 'edited'; detail?: string }
+  | { field: string; kind: 'changed'; from: string; to: string }
+  | {
+      field: string
+      kind: 'collection'
+      added: number
+      removed: number
+      total: number
+      detail?: string
+    }
+
+// The renderer payload for a name-changing update card (prototype scene 7). Shows old name → new name
+// plus a compact manifest of every other field changed in the SAME atomic patch. States that stable
+// conversation bindings are unaffected. Excludes UUIDs, secrets, and complete system instructions.
+export type SpecialistUpdateCardPayload = {
+  kind: 'update'
+  // The current public name (struck through on the card).
+  name: string
+  // The proposed new public name.
+  newName: string
+  // Compact manifest of the OTHER fields changed in the same atomic patch. `name` itself is not
+  // listed here — it is shown as old → new above.
+  changes: SpecialistFieldChange[]
+  // True so the card can state: existing conversation bindings keep working (they follow the
+  // profile, not the name).
+  bindingsStable: true
+}
+
+// The renderer payload for a delete card (prototype scene 8). States that conversations still bound
+// to the deleted Specialist become UNAVAILABLE and are NOT switched to Main Agent automatically.
+export type SpecialistDeleteCardPayload = {
+  kind: 'delete'
+  name: string
+  // True so the card can state the fail-closed binding behavior (becomes unavailable, not Main).
+  boundConversationsUnavailable: true
+}
+
+// The renderer payload for a switch card (prototype scene 5). Names the current Specialist, the
+// target (another Specialist or Main Agent), and states "takes effect on the next message".
+export type SpecialistSwitchCardPayload = {
+  kind: 'switch'
+  // The current Specialist public name, or null/undefined when the conversation is on Main Agent.
+  currentName: string | null
+  // The target Specialist public name, or null to revert to Main Agent.
+  targetName: string | null
+  // True so the card can state "takes effect on the next message".
+  takesEffectOnNextMessage: true
+}
+
+// The discriminated union consumed by the standard Specialist permission card renderer. Every branch
+// is a minimum public summary and excludes complete system instructions, UUIDs, secrets, RPC tokens,
+// and connector args. The presentation mapper (issue 04) is the single producer of this type.
+export type SpecialistPermissionCardPayload =
+  SpecialistUpdateCardPayload | SpecialistDeleteCardPayload | SpecialistSwitchCardPayload
+
+// ---------------------------------------------------------------------------
+// Trusted calling-session + pending-switch/reconfigure notification seam
+// ---------------------------------------------------------------------------
+
+// The pending-switch state the switch slice (issue 05) persists and the renderer (issue 07) renders.
+// Mirrors design.md §9 / PRD §8: the approved target is persisted immediately and takes effect on
+// the NEXT message, surviving restart.
+export type PendingSwitch = {
+  // The trusted calling session this switch targets. Always the server-captured identity.
+  sessionId: string
+  // Target Specialist public name, or null to revert to Main Agent.
+  targetName: string | null
+}
+
+// INJECTED seam consumed by the future switch + renderer slices. It is supplied server-side (in the
+// dispatch context), and sandbox request params must NEVER be able to supply or override it. The
+// switch module (issue 05) will call `notify` after an approved switch; the renderer module
+// (issue 07) will subscribe. This type only defines the sink; wiring is deferred to issue 08.
+export type SwitchNotifier = {
+  notify(pending: PendingSwitch): Promise<void> | void
+}
+
+// ---------------------------------------------------------------------------
+// Routing fields the RPC route must strip before forwarding to the dispatcher.
+// ---------------------------------------------------------------------------
+
+// Every request field that controls routing, identity, or the trusted switch seam. These are
+// server-owned: the RPC route removes them from sandbox-supplied params so the dispatcher and its
+// injected seams only ever see values the server supplied. Keep this list in sync with the strip in
+// local-rpc-server.ts's agentsCall route.
+export const AGENTS_RESERVED_PARAM_KEYS = [
+  'op',
+  'session_id',
+  'sessionId',
+  'specialist_id',
+  'specialistId',
+  'target_specialist_id',
+  'targetSpecialistId',
+  'reconfigure',
+  'context_reset',
+  'contextReset'
+] as const
+
+export type AgentsReservedParamKey = (typeof AGENTS_RESERVED_PARAM_KEYS)[number]
+
+// Returns a copy of `params` with every reserved routing/identity/switch key removed. The RPC route
+// uses this so sandbox-supplied values for those keys are provably ignored. Pure and side-effect
+// free so it is unit-testable in isolation.
+export const stripAgentsReservedParams = (
+  params: Record<string, unknown>
+): Record<string, unknown> => {
+  const stripped: Record<string, unknown> = {}
+  const reserved = new Set<string>(AGENTS_RESERVED_PARAM_KEYS)
+  for (const [key, value] of Object.entries(params)) {
+    if (!reserved.has(key)) stripped[key] = value
+  }
+  return stripped
+}
+
+// ---------------------------------------------------------------------------
+// Payload validation (pure; reuses the read slice's existing patterns)
+// ---------------------------------------------------------------------------
+
+// A recognized operation whose params object is a plain record (write ops) or one of the typed read
+// shapes. This guard is the only validation the contract performs centrally; domain rules stay in
+// the service modules. Returns a typed narrowing so the dispatcher can branch safely.
+export const isAgentsOpName = (value: unknown): value is AgentsOpName =>
+  typeof value === 'string' &&
+  (value === 'list' ||
+    value === 'get' ||
+    value === 'list_skills' ||
+    value === 'list_connectors' ||
+    value === 'create' ||
+    value === 'update' ||
+    value === 'attach_skill' ||
+    value === 'detach_skill' ||
+    value === 'attach_connector' ||
+    value === 'detach_connector' ||
+    value === 'delete' ||
+    value === 'switch')
+
+// Narrows arbitrary RPC params into a plain object the dispatcher can read. Mirrors the isRecord
+// helper used by the RPC server.
+export const isAgentsParams = (value: unknown): value is Record<string, unknown> =>
+  typeof value === 'object' && value !== null && !Array.isArray(value)

--- a/src/shared/specialist.ts
+++ b/src/shared/specialist.ts
@@ -12,8 +12,22 @@ export const SPECIALIST_IPC = {
   CATALOG_CHANGED: 'specialist:catalog-changed',
   // Session switching (issue 07): per-session mutable binding.
   SET_SESSION_SPECIALIST: 'specialist:set-session-specialist',
-  RESOLVE_SESSION_SPECIALIST: 'specialist:resolve-session-specialist'
+  RESOLVE_SESSION_SPECIALIST: 'specialist:resolve-session-specialist',
+  // host.agents.switch() durable next-message switch (issue 05/08): main broadcasts a pending-switch
+  // intent to the renderer so the composer shows the "takes effect on the next message" state and the
+  // next-send barrier reconfigures the live agent. Payload carries only the session id and the target
+  // Specialist public name (null = Main Agent) — never system instructions, UUIDs, or secrets.
+  PENDING_SWITCH: 'specialist:pending-switch'
 } as const
+
+// The pending-switch broadcast payload (design.md §9 / PRD §8). Mirrors the shared PendingSwitch
+// contract but lives here so the preload + renderer consume one type without importing
+// src/shared/agents-contract's pending-switch/reconfigure seam.
+export type PendingSwitchBroadcast = {
+  sessionId: string
+  // Target Specialist public name, or null to revert to Main Agent. Display-only; never a secret.
+  targetName: string | null
+}
 
 // Session switching request types — resolution type is declared after SpecialistProfileView below.
 export type SetSessionSpecialistRequest = {


### PR DESCRIPTION
## Problem

Specialist agents could not be managed conversationally. Creating, updating,
deleting, capability-scoping, or switching the current conversation to a
Specialist required manual UI edits, and there was no name-first control-plane
SDK for the notebook REPL to drive these mutations with review/confirmation.

## Proposed change

Add an end-to-end **conversational Specialist customization** flow built on a new
JavaScript control-plane SDK, `host.agents`, exposed to the trusted notebook REPL.

- **Bundled `customize` Skill** (`resources/skills/customize/`) — workflow guidance
  for the `/customize` conversation: scope clarification (Full vs Selected), a live
  read → complete draft → review → confirm → mutate → read-back loop, and explicit
  confirmation boundaries for ordinary vs. privileged operations.
- **`host.agents` SDK surface** (`src/shared/agents-contract.ts`) — name-first API:
  `list`, `get`, `create`, `update`, `switch`, `delete`, `attach_skill`/`detach_skill`,
  `attach_connector`/`detach_connector`, plus `list_skills`/`list_connectors`. Read
  side is camelCase; write side is snake_case. Catalog references resolve a stable id
  first, else a unique public name; ambiguous names are rejected. Errors are sanitized
  (`host.agents.<method>:` prefix) and never leak credentials, headers, env values,
  connector args, or the RPC token.
- **Mutation control plane** (`src/main/agents/`) — `agents-service.ts` (read SDK +
  ordinary mutations through `ProfileService`), `agents-mutations.ts` (atomic
  multi-field capability edits), `switch-operation.ts` (next-message switch lifecycle),
  `specialist-approval-gateway.ts` + presentation (approval surface for privileged
  ops), `specialist-privileged-ops.ts`, and a pass-through gateway for composition.
- **Renderer entry points** — open `/customize` chat from Specialist settings
  (`SpecialistsPanel.tsx` / `SpecialistEditor.tsx`), prefill the composer, and close
  the durable next-message switch on the renderer side (`WorkspacePage.tsx`,
  `customize-chat.ts`, `navigation-store.ts`).
- **Notebook plumbing** — `host.agents` dispatcher wired into `local-rpc-server.ts`
  and `ipc.ts`; `repl_loop.js` updated accordingly.

### Confirmation boundaries

- Create and ordinary (non-name) `update`: show the complete target state and wait for
  explicit user confirmation before executing. `/customize` entry and composer prefill
  are **not** confirmation.
- Name-changing update, delete, switch: privileged — describe the action then execute
  atomically; if any field cannot be applied, nothing changes.

## Scope and non-goals

- The Skill is **workflow guidance, not a security boundary**. Whether a privileged
  operation takes effect is decided by the application, not the Skill.
- **Per-Connector tool scope is explicitly out of scope** for this milestone; the review
  states this rather than showing an empty config.
- `host.agents` lives in the trusted JS control-plane REPL only; it is absent from data
  kernels (Python/R). No per-Specialist environments.
- Switch affects the **current conversation only**; `null` returns to Main Agent. It does
  not accept a caller-supplied session id.

## Acceptance criteria and validation

All checks ran after the last material edit on `feat/customize-specialist`:

```bash
npm run typecheck   # tsc node + web — PASS
npm run lint        # ESLint — 0 errors (23 pre-existing warnings in untouched files)
npm test            # Vitest — 8772 passed | 189 skipped | 0 failed
```

Behavior → check mapping:

| Behavior | Check | Result |
| --- | --- | --- |
| `host.agents` SDK contract & name resolution | `src/shared/agents-contract.test.ts` | PASS |
| Read SDK + ordinary create/update mutations | `src/main/agents/agents-service.test.ts`, `agents-mutations.test.ts` | PASS |
| Atomic multi-field capability edits (incl. name change) | `agents-mutations.test.ts`, `switch-operation.test.ts` | PASS |
| Approval gateway + privileged ops (switch/delete/rename) | `specialist-approval-gateway.test.ts`, `specialist-privileged-ops.test.ts`, `specialist-approval-presentation.test.ts` | PASS |
| Next-message switch lifecycle + durable binding | `switch-operation.test.ts`, `pending-session-specialist-bindings.test.ts` | PASS |
| REPL dispatch + sanitized errors | `local-rpc-server.agents.test.ts`, `agents-repl.*.integration.test.ts` | PASS |
| Conversational `/customize` workflow | `src/main/agents/customize/workflow.test.ts` | PASS |
| Renderer: open customize chat, prefill, close switch | `SpecialistsPanel.render.test.tsx`, `WorkspacePage.pending-switch.test.tsx`, `WorkspacePage.customize-prefill.test.tsx`, `customize-chat.test.ts` | PASS |
