### PR TITLE
fix(windows): stabilize advisory full test

### DIFF
--- a/.github/workflows/windows-full-test.yml
+++ b/.github/workflows/windows-full-test.yml
@@ -51,6 +51,6 @@ jobs:
       - name: Test complete suite shard
         # SQLite-heavy integration suites contend heavily for Windows disk I/O when Vitest uses
         # every available core, and hosted-runner disk latency occasionally exceeds the default
-        # per-test/hook budgets. Keep files serial and use bounded 30-second budgets; the 25-minute
+        # per-test/hook budgets. Keep files serial and use bounded 60-second budgets; the 25-minute
         # job timeout remains the backstop for a real hang.
-        run: npm test -- --shard=${{ matrix.shard }}/2 --maxWorkers=1 --testTimeout=30000 --hookTimeout=30000
+        run: npm test -- --shard=${{ matrix.shard }}/2 --maxWorkers=1 --testTimeout=60000 --hookTimeout=60000

--- a/scripts/windows-release-workflows.test.ts
+++ b/scripts/windows-release-workflows.test.ts
@@ -55,7 +55,7 @@ describe('post-merge Windows validation', () => {
     })
     expect(job.strategy?.matrix?.shard).toEqual([1, 2])
     expect(findStep(job, 'Test complete suite shard').run).toBe(
-      'npm test -- --shard=${{ matrix.shard }}/2 --maxWorkers=1 --testTimeout=30000 --hookTimeout=30000'
+      'npm test -- --shard=${{ matrix.shard }}/2 --maxWorkers=1 --testTimeout=60000 --hookTimeout=60000'
     )
   })
 

--- a/src/main/session-persistence/conversation-export.test.ts
+++ b/src/main/session-persistence/conversation-export.test.ts
@@ -1,3 +1,5 @@
+import { join } from 'node:path'
+
 import { beforeEach, describe, expect, it, vi } from 'vitest'
 
 import type { PersistedChatSession } from '../../shared/session-persistence'
@@ -98,7 +100,7 @@ describe('conversation export service', () => {
     expect(showSaveDialog).toHaveBeenCalledWith(
       undefined,
       expect.objectContaining({
-        defaultPath: '/downloads/Export test.md',
+        defaultPath: join('/downloads', 'Export test.md'),
         filters: [{ name: 'Markdown', extensions: ['md'] }]
       })
     )
@@ -119,14 +121,16 @@ describe('conversation export service', () => {
       format: 'pdf'
     })
 
-    expect(createTempDirectory).toHaveBeenCalledWith('/tmp/open-science-conversation-export-')
+    expect(createTempDirectory).toHaveBeenCalledWith(
+      join('/tmp', 'open-science-conversation-export-')
+    )
     expect(writeExportFile).toHaveBeenNthCalledWith(
       1,
-      '/tmp/open-science-conversation-export-test/conversation.html',
+      join('/tmp/open-science-conversation-export-test', 'conversation.html'),
       expect.stringContaining('<!doctype html>')
     )
     expect(loadFile).toHaveBeenCalledWith(
-      '/tmp/open-science-conversation-export-test/conversation.html'
+      join('/tmp/open-science-conversation-export-test', 'conversation.html')
     )
     expect(executeJavaScript).toHaveBeenCalledOnce()
     expect(printToPDF).toHaveBeenCalledWith(


### PR DESCRIPTION
## Problem

The advisory Windows full-test shard repeatedly fails after conversation export tests were added because their expectations hard-code POSIX separators while production derives paths with `node:path.join`. The same shard also intermittently exceeds the 30-second per-test budget in different SQLite-heavy provenance tests on hosted Windows runners.

Observed run: https://github.com/aipoch/open-science/actions/runs/30613502034/job/91101365565

## Proposed change

- Build derived conversation-export path expectations with platform-native `join(...)`.
- Increase the advisory Windows per-test and hook budgets from 30 seconds to a bounded 60 seconds.
- Keep files serialized and retain the 25-minute job timeout as the hang backstop.
- Update the workflow contract test for the new command.

## Scope and non-goals

- No production application behavior changes.
- No changes to nightly/release packaging or blocking gates.
- The Windows full suite remains advisory via `continue-on-error`.

## Acceptance criteria and validation

The listed local checks ran after the final material edit:

- Platform-native conversation-export expectations and workflow command contract → `npm test -- src/main/session-persistence/conversation-export.test.ts scripts/windows-release-workflows.test.ts` → 2 files, 11 tests passed.
- SQLite-heavy provenance coverage with the proposed budgets → `npm test -- src/main/artifacts/provenance-repository.test.ts --maxWorkers=1 --testTimeout=60000 --hookTimeout=60000` → 1 file, 28 tests passed.
- Repository lint → `npm run lint` → passed with 0 errors and 23 pre-existing warnings.
- Independent final-diff review → no standards or scope findings.

Local `npm run typecheck` could not complete because the shared checkout lacks already-declared `fflate` and `tiff` packages. Local `npm test` was also blocked by the sandbox denying loopback listeners (`listen EPERM 127.0.0.1`). Online validation closed those environment-specific gaps:

- PR Verify → Ubuntu, macOS, and Windows all passed.
- Manually dispatched `Windows Full Test (Advisory)` → shard 1 and shard 2 both passed: https://github.com/aipoch/open-science/actions/runs/30622743880

## Review focus

- Whether 60 seconds is the right bounded allowance for hosted Windows SQLite/disk latency.
- Whether all values transformed by production `path.join` are represented by platform-native expectations.
