### PR TITLE
ci(windows): gate path portability on pull requests

### DIFF
--- a/.github/workflows/windows-path-portability.yml
+++ b/.github/workflows/windows-path-portability.yml
@@ -1,0 +1,59 @@
+name: Windows Path Portability
+
+# Run a blocking, native-filesystem check before merge without duplicating the slow, advisory
+# Windows full suite. These contracts cover the path boundaries most likely to regress when code or
+# tests assume POSIX separators; the complete Windows suite remains a post-merge safety net.
+on:
+  pull_request:
+    branches:
+      - main
+    types: [opened, synchronize, reopened]
+    paths-ignore:
+      - '**/*.md'
+      - 'docs/**'
+      - 'LICENSE'
+      - '.gitignore'
+  workflow_dispatch:
+
+permissions:
+  contents: read
+
+concurrency:
+  group: windows-path-portability-${{ github.event.pull_request.number || github.ref }}
+  cancel-in-progress: true
+
+jobs:
+  path_portability:
+    name: Windows path portability
+    runs-on: windows-latest
+    timeout-minutes: 10
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v7
+
+      - name: Setup Node
+        uses: actions/setup-node@v7
+        with:
+          node-version: 22
+          cache: npm
+
+      - name: Install dependencies
+        run: npm ci
+
+      - name: Test Windows path portability
+        run: >-
+          npx vitest run
+          src/main/acp/workspace-path.test.ts
+          src/main/file-save.test.ts
+          src/main/notebook/run-document-data-paths.test.ts
+          src/main/notebook/runtime-paths.test.ts
+          src/main/session-persistence/conversation-export.test.ts
+          src/main/session-persistence/data-path-roundtrip.test.ts
+          src/main/settings/shell-path.test.ts
+          src/main/specialist/repository.test.ts
+          src/main/storage/data-path.test.ts
+          src/main/storage/normalize-legacy-paths.test.ts
+          src/main/storage/path-presence.test.ts
+          --maxWorkers=1
+          --testTimeout=30000
+          --hookTimeout=30000

--- a/scripts/windows-path-portability-workflow.test.ts
+++ b/scripts/windows-path-portability-workflow.test.ts
@@ -1,0 +1,112 @@
+import { readFileSync } from 'node:fs'
+import { join } from 'node:path'
+
+import { load } from 'js-yaml'
+import { describe, expect, it } from 'vitest'
+
+type WorkflowStep = {
+  name?: string
+  run?: string
+  uses?: string
+  with?: Record<string, unknown>
+}
+
+type WorkflowJob = {
+  'continue-on-error'?: boolean
+  'runs-on'?: string
+  steps?: WorkflowStep[]
+  'timeout-minutes'?: number
+}
+
+type Workflow = {
+  concurrency?: {
+    'cancel-in-progress'?: boolean
+    group?: string
+  }
+  jobs: Record<string, WorkflowJob>
+  on?: {
+    pull_request?: {
+      branches?: string[]
+      'paths-ignore'?: string[]
+      types?: string[]
+    }
+    workflow_dispatch?: unknown
+  }
+  permissions?: Record<string, string>
+}
+
+const workflow = load(
+  readFileSync(join(process.cwd(), '.github/workflows/windows-path-portability.yml'), 'utf8')
+) as Workflow
+
+const job = workflow.jobs.path_portability
+
+const getStep = (name: string): WorkflowStep => {
+  const step = job?.steps?.find((candidate) => candidate.name === name)
+  if (!step) throw new Error(`Missing Windows path portability step: ${name}`)
+  return step
+}
+
+describe('Windows path portability workflow', () => {
+  it('runs for pull requests to main and supports manual dispatch', () => {
+    expect(workflow.on?.pull_request).toMatchObject({
+      branches: ['main'],
+      types: ['opened', 'synchronize', 'reopened']
+    })
+    expect(workflow.on?.pull_request?.['paths-ignore']).toEqual([
+      '**/*.md',
+      'docs/**',
+      'LICENSE',
+      '.gitignore'
+    ])
+    expect(workflow.on).toHaveProperty('workflow_dispatch')
+  })
+
+  it('is a bounded blocking job on a real Windows filesystem', () => {
+    expect(workflow.permissions).toEqual({ contents: 'read' })
+    expect(workflow.concurrency).toEqual({
+      group: 'windows-path-portability-${{ github.event.pull_request.number || github.ref }}',
+      'cancel-in-progress': true
+    })
+    expect(job).toMatchObject({
+      'runs-on': 'windows-latest',
+      'timeout-minutes': 10
+    })
+    expect(job?.['continue-on-error']).toBeUndefined()
+  })
+
+  it('uses the locked Node toolchain', () => {
+    expect(getStep('Checkout').uses).toBe('actions/checkout@v7')
+    expect(getStep('Setup Node')).toMatchObject({
+      uses: 'actions/setup-node@v7',
+      with: { 'node-version': 22, cache: 'npm' }
+    })
+    expect(getStep('Install dependencies').run).toBe('npm ci')
+  })
+
+  it('hard-gates the focused filesystem path contracts without duplicating the full suite', () => {
+    const run = getStep('Test Windows path portability').run
+
+    for (const testFile of [
+      'src/main/acp/workspace-path.test.ts',
+      'src/main/file-save.test.ts',
+      'src/main/notebook/run-document-data-paths.test.ts',
+      'src/main/notebook/runtime-paths.test.ts',
+      'src/main/session-persistence/conversation-export.test.ts',
+      'src/main/session-persistence/data-path-roundtrip.test.ts',
+      'src/main/settings/shell-path.test.ts',
+      'src/main/specialist/repository.test.ts',
+      'src/main/storage/data-path.test.ts',
+      'src/main/storage/normalize-legacy-paths.test.ts',
+      'src/main/storage/path-presence.test.ts'
+    ]) {
+      expect(run).toContain(testFile)
+    }
+
+    expect(run).toContain('--maxWorkers=1')
+    expect(run).toContain('--testTimeout=30000')
+    expect(run).toContain('--hookTimeout=30000')
+    expect(run).not.toContain('npm test')
+    expect(run).not.toContain('--shard')
+  })
+})


### PR DESCRIPTION
## Problem

The existing pull-request gate exercises explicit Windows-only tests, while the complete Windows suite runs after merge and is advisory. Cross-platform code and tests can therefore introduce POSIX separator or path-construction assumptions without a blocking native-Windows signal.

## Proposed change

Add a dedicated **Windows Path Portability** workflow that:

- runs on pull requests to `main` and supports `workflow_dispatch`
- uses one blocking `windows-latest` job with a 10-minute timeout
- installs from the lockfile and runs 11 focused filesystem/path contract suites serially
- preserves the separate post-merge Windows full-suite workflow

Add a repository-owned YAML contract test that locks the trigger, permissions, runtime bound, toolchain, focused test selection, and non-sharded scope.

## Scope and non-goals

- CI-only: no production source or behavior changes.
- Does not modify `CONTRIBUTING.md`, release/nightly workflows, or the existing full Windows advisory workflow.
- Includes the squash-merged Windows test stabilization from `main` as branch ancestry; it does not duplicate those fixes.

## Acceptance criteria and validation

The listed local checks ran after the last material edit:

- workflow trigger/config remains blocking, bounded, dispatchable, and focused -> `npm test -- scripts/windows-path-portability-workflow.test.ts` -> **pass** (1 file, 4 tests)
- selected path contracts stay green on the current source state -> focused `npx vitest run ... --maxWorkers=1 --testTimeout=30000 --hookTimeout=30000` command from the workflow -> **pass** (11 files, 130 tests)
- workflow syntax is valid -> `actionlint .github/workflows/windows-path-portability.yml` -> **pass**
- TypeScript remains valid -> `npm run typecheck` -> **pass**
- repository lint gate remains green -> `npm run lint` -> **pass** (0 errors; 23 pre-existing warnings)
- repository suite remains green -> `npm test` -> **pass** (576 files / 8,641 tests; 11 files / 139 tests skipped)
- native-Windows path contracts run before merge -> [Windows Path Portability run 30626591030](https://github.com/aipoch/open-science/actions/runs/30626591030) -> **pass** (2m16s)
- existing cross-platform PR gate remains green -> [PR Check run 30626591009](https://github.com/aipoch/open-science/actions/runs/30626591009) -> **pass** (macOS, Ubuntu, Windows)

Uncovered risk: the curated suite will not catch path regressions outside the selected filesystem boundaries; the post-merge full Windows suite remains the broader advisory safety net.

## Review focus

Please review whether the selected path-boundary suites balance separator coverage with a fast, actionable pre-merge signal, and whether the contract test prevents drift back toward the slow full-suite design.