### PR TITLE
fix(permissions): keep Undo stack above window bottom

### DIFF
--- a/src/renderer/src/components/PermissionUndoSnackbar.test.tsx
+++ b/src/renderer/src/components/PermissionUndoSnackbar.test.tsx
@@ -77,6 +77,17 @@ describe('PermissionUndoSnackbar', () => {
     expect(container.querySelector('[data-testid="permission-undo-snackbar"]')).toBeNull()
   })
 
+  it('keeps the Undo stack above the window bottom after Settings has closed', async () => {
+    await act(async () => root.render(<PermissionUndoSnackbar />))
+
+    const stack = container.querySelector<HTMLElement>('[data-testid="permission-undo-stack"]')
+
+    expect(stack?.className).toContain('bottom-[max(1.5rem,env(safe-area-inset-bottom))]')
+    expect(stack?.className).toContain('max-h-[min(70svh,32rem)]')
+    expect(stack?.className).toContain('overflow-y-auto')
+    expect(stack?.querySelector('[data-slot="scroll-area-viewport"]')).toBeNull()
+  })
+
   it('pauses automatic dismissal while the snackbar is hovered', async () => {
     await act(async () => root.render(<PermissionUndoSnackbar />))
     const snackbar = container.querySelector<HTMLElement>(
@@ -121,9 +132,6 @@ describe('PermissionUndoSnackbar', () => {
     expect(container.textContent).toContain('Revoked Shell')
     expect(container.textContent).toContain('Revoked Connector')
     expect(container.textContent).not.toContain('queued')
-    expect(
-      container.querySelector('[data-testid="permission-undo-stack"]')?.getAttribute('data-slot')
-    ).toBe('scroll-area')
 
     const fourthUndo = container.querySelector<HTMLButtonElement>(
       '[data-undo-token="undo-4"] button:not([aria-label])'

--- a/src/renderer/src/components/PermissionUndoSnackbar.tsx
+++ b/src/renderer/src/components/PermissionUndoSnackbar.tsx
@@ -2,7 +2,6 @@ import { KeyRound, LoaderCircle, RotateCcw, X } from 'lucide-react'
 import { useEffect, useMemo, useState } from 'react'
 
 import { Button } from '@/components/ui/button'
-import { ScrollArea } from '@/components/ui/scroll-area'
 import { Tooltip, TooltipContent, TooltipProvider, TooltipTrigger } from '@/components/ui/tooltip'
 import { usePermissionGrantsStore } from '@/stores/permission-grants-store'
 import type { PermissionUndo } from '@/stores/permission-grants-store'
@@ -105,11 +104,13 @@ const PermissionUndoSnackbar = (): React.JSX.Element | null => {
   )
   if (items.length === 0) return null
 
+  // The shared ScrollArea viewport is full-height and requires a definite root height. This stack
+  // must instead size to its receipts so its bottom anchor cannot lay them out below the viewport.
   return (
-    <ScrollArea
+    <div
       aria-live="polite"
       data-testid="permission-undo-stack"
-      className="pointer-events-auto z-toast fixed bottom-[max(1.5rem,env(safe-area-inset-bottom))] left-1/2 max-h-[min(70svh,32rem)] -translate-x-1/2 overscroll-contain"
+      className="pointer-events-auto z-toast fixed bottom-[max(1.5rem,env(safe-area-inset-bottom))] left-1/2 max-h-[min(70svh,32rem)] -translate-x-1/2 overflow-y-auto overscroll-contain"
     >
       <div className="flex flex-col items-center gap-2 p-1 pr-3">
         {items.map((item) => (
@@ -122,7 +123,7 @@ const PermissionUndoSnackbar = (): React.JSX.Element | null => {
           />
         ))}
       </div>
-    </ScrollArea>
+    </div>
   )
 }
 


### PR DESCRIPTION
## Problem

On Windows, closing the permission surface could leave the Undo snackbar below the visible window. The fixed stack used the shared Radix ScrollArea with a full-height viewport, but its root only had a maximum height. Without a definite parent height, the bottom-anchored content could be laid out past the viewport.

## Proposed change

- Replace the full-height Radix viewport with a content-sized native overflow container.
- Preserve the existing bottom safe-area offset, maximum stack height, overscroll behavior, and per-receipt interactions.
- Add a regression test that locks down the intrinsic-height scroll structure after Settings closes.

## Scope and non-goals

This change only affects the permission Undo stack layout. It does not change grant revocation, restoration, expiry, queueing, or other shared ScrollArea consumers.

## Acceptance criteria and validation

The checks below ran against the final material implementation:

- Undo remains bottom-anchored and scrolls within the visible viewport -> `npm test -- src/renderer/src/components/PermissionUndoSnackbar.test.tsx` -> passed, 6/6 tests.
- Changed files satisfy ESLint/Prettier rules -> `npx --no-install eslint src/renderer/src/components/PermissionUndoSnackbar.tsx src/renderer/src/components/PermissionUndoSnackbar.test.tsx` -> passed.
- Patch has no whitespace errors -> `git diff --check` -> passed.
- Repository lint -> `npm run lint` -> passed with 0 errors; unrelated baseline warnings remain.
- Repository typecheck -> `npm run typecheck` -> blocked because this worktree does not have the lockfile dependencies `fflate` and `tiff` installed.
- Full test suite -> `npm test` -> not completed in the restricted sandbox; localhost-listening tests failed with `EPERM` and the runner was terminated after five minutes.

Uncovered risk: the structural regression is deterministic, but the final layout has not been visually exercised on a Windows Electron runtime.

## Review focus

Please verify that the content-sized overflow container keeps single and queued Undo receipts above the bottom edge without changing restore, dismiss, expiry, or modal interaction behavior.
