### PR TITLE
fix(agent-usage): aggregate complete prompt token usage

### DIFF
--- a/src/main/acp/opencode-turn-usage.test.ts
+++ b/src/main/acp/opencode-turn-usage.test.ts
@@ -1,0 +1,93 @@
+import { describe, expect, it, vi } from 'vitest'
+
+import { fetchOpenCodeUsageSnapshot, sumOpenCodeTurnUsage } from './opencode-turn-usage'
+
+const api = {
+  baseUrl: 'http://127.0.0.1:4242',
+  authorization: 'Basic secret'
+}
+
+describe('OpenCode turn usage', () => {
+  it('fetches authenticated assistant usage from the session message API', async () => {
+    const fetchImpl = vi.fn(
+      async () =>
+        new Response(
+          JSON.stringify([
+            { info: { id: 'user-1', role: 'user' } },
+            {
+              info: {
+                id: 'assistant-1',
+                role: 'assistant',
+                tokens: { input: 10, output: 4, cache: { read: 3, write: 2 } }
+              }
+            }
+          ])
+        )
+    )
+
+    const snapshot = await fetchOpenCodeUsageSnapshot(
+      api,
+      'session/with spaces',
+      '/workspace with spaces',
+      fetchImpl
+    )
+
+    expect(fetchImpl).toHaveBeenCalledWith(
+      new URL(
+        'http://127.0.0.1:4242/session/session%2Fwith%20spaces/message?directory=%2Fworkspace+with+spaces'
+      ),
+      expect.objectContaining({ headers: { authorization: 'Basic secret' } })
+    )
+    expect(snapshot?.assistantMessageIds).toEqual(new Set(['assistant-1']))
+    expect(snapshot?.usageByMessageId.get('assistant-1')).toEqual({
+      inputTokens: 10,
+      cacheTokens: 5,
+      outputTokens: 4
+    })
+  })
+
+  it('sums only assistant messages created after the turn baseline', () => {
+    const before = {
+      assistantMessageIds: new Set(['old']),
+      usageByMessageId: new Map([['old', { inputTokens: 99, cacheTokens: 9, outputTokens: 9 }]])
+    }
+    const after = {
+      assistantMessageIds: new Set(['old', 'step-1', 'step-2']),
+      usageByMessageId: new Map([
+        ['old', { inputTokens: 99, cacheTokens: 9, outputTokens: 9 }],
+        ['step-1', { inputTokens: 12, cacheTokens: 3, outputTokens: 2 }],
+        ['step-2', { inputTokens: 19, cacheTokens: 5, outputTokens: 3 }]
+      ])
+    }
+
+    expect(sumOpenCodeTurnUsage(before, after)).toEqual({
+      inputTokens: 31,
+      cacheTokens: 8,
+      outputTokens: 5
+    })
+  })
+
+  it('fails closed instead of publishing a partial sum', () => {
+    expect(
+      sumOpenCodeTurnUsage(
+        { assistantMessageIds: new Set(), usageByMessageId: new Map() },
+        {
+          assistantMessageIds: new Set(['complete', 'missing']),
+          usageByMessageId: new Map([
+            ['complete', { inputTokens: 12, cacheTokens: 3, outputTokens: 2 }]
+          ])
+        }
+      )
+    ).toBeUndefined()
+  })
+
+  it('treats an unavailable local API as an absent snapshot', async () => {
+    const fetchImpl = vi.fn(async () => {
+      throw new Error('connection closed')
+    })
+
+    await expect(
+      fetchOpenCodeUsageSnapshot(api, 'session-1', '/workspace', fetchImpl)
+    ).resolves.toBeUndefined()
+  })
+})

--- a/src/main/acp/opencode-turn-usage.ts
+++ b/src/main/acp/opencode-turn-usage.ts
@@ -1,0 +1,111 @@
+import type { AcpTurnTokenUsage } from '../../shared/acp'
+import type { ResolvedAgentBackend } from '../agent-framework'
+
+export type OpenCodeUsageSnapshot = {
+  assistantMessageIds: Set<string>
+  usageByMessageId: Map<string, AcpTurnTokenUsage>
+}
+
+type OpenCodeMessageInfo = {
+  id?: unknown
+  role?: unknown
+  tokens?: unknown
+}
+
+const tokenCount = (value: unknown): number | undefined =>
+  typeof value === 'number' && Number.isSafeInteger(value) && value >= 0 ? value : undefined
+
+const messageUsage = (value: unknown): AcpTurnTokenUsage | undefined => {
+  if (typeof value !== 'object' || value === null || Array.isArray(value)) return undefined
+  const tokens = value as {
+    input?: unknown
+    output?: unknown
+    cache?: { read?: unknown; write?: unknown }
+  }
+  const inputTokens = tokenCount(tokens.input)
+  const outputTokens = tokenCount(tokens.output)
+  const cachedReadTokens = tokenCount(tokens.cache?.read ?? 0)
+  const cachedWriteTokens = tokenCount(tokens.cache?.write ?? 0)
+  if (
+    inputTokens === undefined ||
+    outputTokens === undefined ||
+    cachedReadTokens === undefined ||
+    cachedWriteTokens === undefined
+  ) {
+    return undefined
+  }
+
+  const cacheTokens = cachedReadTokens + cachedWriteTokens
+  return Number.isSafeInteger(cacheTokens) ? { inputTokens, cacheTokens, outputTokens } : undefined
+}
+
+export const fetchOpenCodeUsageSnapshot = async (
+  api: NonNullable<ResolvedAgentBackend['opencodeUsageApi']>,
+  sessionId: string,
+  cwd: string,
+  fetchImpl: typeof fetch = fetch
+): Promise<OpenCodeUsageSnapshot | undefined> => {
+  try {
+    const url = new URL(
+      `/session/${encodeURIComponent(sessionId)}/message`,
+      api.baseUrl.endsWith('/') ? api.baseUrl : `${api.baseUrl}/`
+    )
+    url.searchParams.set('directory', cwd)
+    const response = await fetchImpl(url, {
+      headers: { authorization: api.authorization },
+      signal: AbortSignal.timeout(2_000)
+    })
+    if (!response.ok) return undefined
+
+    const messages = (await response.json()) as unknown
+    if (!Array.isArray(messages)) return undefined
+
+    const assistantMessageIds = new Set<string>()
+    const usageByMessageId = new Map<string, AcpTurnTokenUsage>()
+    for (const message of messages) {
+      if (typeof message !== 'object' || message === null || Array.isArray(message)) continue
+      const info = (message as { info?: OpenCodeMessageInfo }).info
+      if (!info || info.role !== 'assistant' || typeof info.id !== 'string') continue
+      assistantMessageIds.add(info.id)
+      const usage = messageUsage(info.tokens)
+      if (usage) usageByMessageId.set(info.id, usage)
+    }
+
+    return { assistantMessageIds, usageByMessageId }
+  } catch {
+    return undefined
+  }
+}
+
+export const sumOpenCodeTurnUsage = (
+  before: OpenCodeUsageSnapshot | undefined,
+  after: OpenCodeUsageSnapshot | undefined
+): AcpTurnTokenUsage | undefined => {
+  if (!before || !after) return undefined
+
+  const newMessageIds = [...after.assistantMessageIds].filter(
+    (messageId) => !before.assistantMessageIds.has(messageId)
+  )
+  if (newMessageIds.length === 0) return undefined
+
+  let inputTokens = 0
+  let cacheTokens = 0
+  let outputTokens = 0
+  for (const messageId of newMessageIds) {
+    const usage = after.usageByMessageId.get(messageId)
+    // Never publish a partial sum when OpenCode changes or omits one new assistant record.
+    if (!usage) return undefined
+    inputTokens += usage.inputTokens
+    cacheTokens += usage.cacheTokens
+    outputTokens += usage.outputTokens
+    if (
+      !Number.isSafeInteger(inputTokens) ||
+      !Number.isSafeInteger(cacheTokens) ||
+      !Number.isSafeInteger(outputTokens)
+    ) {
+      return undefined
+    }
+  }
+
+  return { inputTokens, cacheTokens, outputTokens }
+}

--- a/src/main/acp/runtime.test.ts
+++ b/src/main/acp/runtime.test.ts
@@ -7789,7 +7789,7 @@ describe('ACP runtime session management', () => {
     })
   })
 
-  it('corrects an unpatched external Codex total with its latest request usage at stop', async () => {
+  it('falls back to an unpatched Codex latest request usage at stop', async () => {
     const process = new FakeAgentProcess()
     const usageSent = createDeferred()
     const finishPrompt = createDeferred()
@@ -7833,9 +7833,11 @@ describe('ACP runtime session management', () => {
     expect(runtime.getSnapshot().contextUsageBySession).toMatchObject({
       s1: { used: 15, size: 128000 }
     })
-    expect(
-      runtime.getSnapshot().events.find((event) => event.kind === 'stop')?.turnUsage
-    ).toBeUndefined()
+    expect(runtime.getSnapshot().events.find((event) => event.kind === 'stop')?.turnUsage).toEqual({
+      inputTokens: 12,
+      cacheTokens: 3,
+      outputTokens: 3
+    })
   })
 
   it('keeps managed Codex turn totals separate from its latest context snapshot', async () => {
@@ -7879,6 +7881,37 @@ describe('ACP runtime session management', () => {
     })
   })
 
+  it('keeps Codex bridge usage visible when the adapter omits whole-turn metadata', async () => {
+    const process = new FakeAgentProcess()
+    startFakeAgent(process, ['s1'], {
+      modes: createModes(['read-only', 'agent', 'agent-full-access'], 'agent'),
+      onPrompt: () => ({
+        stopReason: 'end_turn',
+        // A Responses bridge still returns standard ACP usage even when its adapter does not publish
+        // Open Science's private whole-turn metadata. The footer must not become entirely unavailable.
+        usage: {
+          totalTokens: 27,
+          inputTokens: 19,
+          cachedReadTokens: 5,
+          outputTokens: 3
+        }
+      })
+    })
+    const runtime = new AcpRuntime({
+      appVersion: '0.1.0',
+      defaultCwd: '/workspace',
+      spawnAgent: () => asAgentProcess(process),
+      framework: codexFramework
+    })
+
+    await runtime.createSession({ cwd: '/workspace' })
+    await runtime.sendPrompt({ sessionId: 's1', text: 'answer through the bridge' })
+
+    expect(runtime.getSnapshot().events.find((event) => event.kind === 'stop')).toMatchObject({
+      turnUsage: { inputTokens: 19, cacheTokens: 5, outputTokens: 3 }
+    })
+  })
+
   it('uses OpenCode native input and cache-read context usage', async () => {
     const process = new FakeAgentProcess()
     startFakeAgent(process, ['s1'])
@@ -7897,6 +7930,72 @@ describe('ACP runtime session management', () => {
 
     expect(runtime.getSnapshot().contextUsageBySession).toMatchObject({
       s1: { used: 15, size: 128000 }
+    })
+  })
+
+  it('sums every OpenCode assistant model step created by one prompt turn', async () => {
+    const process = new FakeAgentProcess()
+    startFakeAgent(process, ['s1'], {
+      onPrompt: () => ({
+        stopReason: 'end_turn',
+        // OpenCode ACP currently exposes only the final assistant record here.
+        usage: {
+          totalTokens: 27,
+          inputTokens: 19,
+          cachedReadTokens: 5,
+          outputTokens: 3
+        }
+      })
+    })
+    const messageSnapshots = [
+      [{ info: { id: 'old', role: 'assistant' } }],
+      [
+        { info: { id: 'old', role: 'assistant' } },
+        {
+          info: {
+            id: 'step-1',
+            role: 'assistant',
+            tokens: { input: 12, output: 2, reasoning: 0, cache: { read: 3, write: 0 } }
+          }
+        },
+        {
+          info: {
+            id: 'step-2',
+            role: 'assistant',
+            tokens: { input: 19, output: 3, reasoning: 0, cache: { read: 5, write: 0 } }
+          }
+        }
+      ]
+    ]
+    const opencodeUsageFetch = vi.fn(
+      async () =>
+        new Response(JSON.stringify(messageSnapshots.shift() ?? []), {
+          headers: { 'content-type': 'application/json' }
+        })
+    )
+    const framework = { ...opencodeFramework, spawn: () => asAgentProcess(process) }
+    const runtime = new AcpRuntime({
+      appVersion: '0.1.0',
+      defaultCwd: '/workspace',
+      resolveBackend: () => ({
+        framework,
+        executablePath: '/bin/opencode',
+        env: {},
+        opencodeUsageApi: {
+          baseUrl: 'http://127.0.0.1:4242',
+          authorization: 'Basic test'
+        }
+      }),
+      framework,
+      opencodeUsageFetch
+    })
+
+    await runtime.createSession({ cwd: '/workspace' })
+    await runtime.sendPrompt({ sessionId: 's1', text: 'use a tool and summarize' })
+
+    expect(opencodeUsageFetch).toHaveBeenCalledTimes(2)
+    expect(runtime.getSnapshot().events.find((event) => event.kind === 'stop')).toMatchObject({
+      turnUsage: { inputTokens: 31, cacheTokens: 8, outputTokens: 5 }
     })
   })
 

--- a/src/main/acp/runtime.ts
+++ b/src/main/acp/runtime.ts
@@ -71,6 +71,7 @@ import {
   toAcpRuntimeEvent
 } from './runtime-events'
 import { readWorkspaceTextFile, writeWorkspaceTextFile } from './filesystem'
+import { fetchOpenCodeUsageSnapshot, sumOpenCodeTurnUsage } from './opencode-turn-usage'
 import {
   matchSessionModelOption,
   resolveSessionEffortOption,
@@ -216,6 +217,8 @@ type AcpRuntimeOptions = {
   // injectable so tests can drive the degrade-to-file path with small fixtures.
   inlineImageBudgetBytes?: number
   contextUsageTracker?: ContextUsageTracker
+  // Injectable only for the authenticated OpenCode loopback usage snapshots; production uses fetch.
+  opencodeUsageFetch?: typeof fetch
   // Resolves the identity-inject text for a specialist UUID at session-creation time.
   // The main process reads the latest Profile from ProfileService; the runtime never caches it.
   // Returns undefined when the specialist is not found, disabled, or its Profile is corrupt —
@@ -877,6 +880,7 @@ class AcpRuntime {
   // initialize so the decrypted key is not retained by the runtime longer than necessary.
   private pendingAuthentication: ResolvedAgentBackend['authentication']
   private pendingProviderConfiguration: ResolvedAgentBackend['providerConfiguration']
+  private opencodeUsageApi: ResolvedAgentBackend['opencodeUsageApi']
   private responsesBridgeLease: ResolvedAgentBackend['responsesBridgeLease']
   private readonly skillSelectorAbortControllers = new Map<string, AbortController>()
   private readonly pendingPromptCancellations = new Map<string, Promise<void>>()
@@ -2672,6 +2676,7 @@ class AcpRuntime {
     this.pendingSystemPromptAppends = [...(backend.systemPromptAppends ?? [])]
     this.pendingAuthentication = backend.authentication
     this.pendingProviderConfiguration = backend.providerConfiguration
+    this.opencodeUsageApi = backend.opencodeUsageApi
     this.responsesBridgeLease = backend.responsesBridgeLease
   }
 
@@ -2954,6 +2959,19 @@ class AcpRuntime {
         skillActivitiesStarted = true
       }
 
+      const promptFramework = this.sessionFrameworks.get(request.sessionId) ?? this.framework.id
+      const opencodeUsageBefore =
+        promptFramework === 'opencode' && this.opencodeUsageApi
+          ? await fetchOpenCodeUsageSnapshot(
+              this.opencodeUsageApi,
+              activeSession.sessionId,
+              this.sessionCwds.get(request.sessionId) ?? this.cwd,
+              this.options.opencodeUsageFetch
+            )
+          : undefined
+      await awaitPendingCancellation()
+      if (turnWasCancelled()) return finishCancelledBeforePrompt()
+
       // Start the prompt and race it against routed updates from the active session queue.
       const promptFailure = new Promise<never>((_, reject) => {
         activeSession.prompt(promptContent).catch(reject)
@@ -2995,13 +3013,26 @@ class AcpRuntime {
             sessionId: request.sessionId,
             stopReason: message.stopReason
           })
-          const promptFramework = this.sessionFrameworks.get(request.sessionId) ?? this.framework.id
-          // Codex ACP exposes only the latest request in PromptResponse.usage. The managed adapter's
-          // app-owned metadata is the sole whole-turn source; other frameworks already accumulate usage.
+          const opencodeTurnUsage =
+            promptFramework === 'opencode' && this.opencodeUsageApi
+              ? sumOpenCodeTurnUsage(
+                  opencodeUsageBefore,
+                  await fetchOpenCodeUsageSnapshot(
+                    this.opencodeUsageApi,
+                    activeSession.sessionId,
+                    this.sessionCwds.get(request.sessionId) ?? this.cwd,
+                    this.options.opencodeUsageFetch
+                  )
+                )
+              : undefined
+          // Codex ACP exposes only the latest request in PromptResponse.usage. Prefer the managed
+          // adapter's app-owned whole-turn total, but retain the standard usage as a compatibility
+          // fallback so a bridge response never loses token accounting entirely when metadata is absent.
           const turnUsage =
             promptFramework === 'codex'
-              ? toAcpTurnTokenUsage(message.response._meta?.[ACP_TURN_TOKEN_USAGE_META_KEY])
-              : toAcpTurnTokenUsage(message.response.usage)
+              ? (toAcpTurnTokenUsage(message.response._meta?.[ACP_TURN_TOKEN_USAGE_META_KEY]) ??
+                toAcpTurnTokenUsage(message.response.usage))
+              : (opencodeTurnUsage ?? toAcpTurnTokenUsage(message.response.usage))
           this.pushEvent({
             kind: 'stop',
             level: 'info',

--- a/src/main/agent-framework/types.ts
+++ b/src/main/agent-framework/types.ts
@@ -212,6 +212,12 @@ export type ResolvedAgentBackend = {
   contextUsageModel?: string
   authentication?: AgentAuthentication
   providerConfiguration?: AgentProviderConfiguration
+  // Authenticated loopback API exposed by the same OpenCode ACP process. The runtime snapshots
+  // assistant messages around a prompt so it can aggregate every model step in that user turn.
+  opencodeUsageApi?: {
+    baseUrl: string
+    authorization: string
+  }
   // A bridged backend owns one reference to its local loopback bridge. Runtime teardown releases it;
   // reviewer sessions register their Codex prompt_cache_key here so routing never depends on content.
   responsesBridgeLease?: {

--- a/src/main/settings/managed-codex.test.ts
+++ b/src/main/settings/managed-codex.test.ts
@@ -1401,13 +1401,14 @@ describe('patchCodexAcpTurnUsageSource', () => {
     '    return null;',
     '  },',
     '    buildPromptUsage(usage) { return usage; },',
+    '    buildQuotaMeta() { return { quota: { remaining: 42 } }; },',
     '    startPrompt() {',
     '    sessionState.currentTurnId = null;',
     '    sessionState.lastTokenUsage = null;',
     '    },',
-    '    commandResponse() { return { usage: this.buildPromptUsage(sessionState.lastTokenUsage), }; },',
-    '    normalResponse() { return { usage: this.buildPromptUsage(sessionState.lastTokenUsage), }; },',
-    '    cancelledResponse() { return { usage: this.buildPromptUsage(sessionState.lastTokenUsage), }; },',
+    '    commandResponse() { return { usage: this.buildPromptUsage(sessionState.lastTokenUsage), _meta: this.buildQuotaMeta(sessionState), }; },',
+    '    normalResponse() { return { usage: this.buildPromptUsage(sessionState.lastTokenUsage), _meta: this.buildQuotaMeta(sessionState), }; },',
+    '    cancelledResponse() { return { usage: this.buildPromptUsage(sessionState.lastTokenUsage), _meta: this.buildQuotaMeta(sessionState), }; },',
     '    finishPrompt() {',
     '      const response = this.normalResponse();',
     '      activePrompt.complete();',
@@ -1541,6 +1542,27 @@ describe('patchCodexAcpTurnUsageSource', () => {
     })
   })
 
+  it('merges whole-turn usage with the pinned adapter quota metadata', () => {
+    const adapter = Function(patchCodexAcpTurnUsageSource(fixture))() as {
+      startPrompt: () => void
+      createUsageUpdate: (params: unknown) => void
+      finishPrompt: () => { _meta?: Record<string, unknown> }
+    }
+
+    adapter.startPrompt()
+    adapter.createUsageUpdate({
+      tokenUsage: {
+        last: usage(18, 12, 3, 3, 0),
+        total: usage(18, 12, 3, 3, 0)
+      }
+    })
+
+    expect(adapter.finishPrompt()._meta).toEqual({
+      quota: { remaining: 42 },
+      [ACP_TURN_TOKEN_USAGE_META_KEY]: usage(18, 12, 3, 3, 0)
+    })
+  })
+
   it('uses the first request snapshot when a resumed session has no cumulative baseline', () => {
     const adapter = Function(patchCodexAcpTurnUsageSource(fixture))() as {
       startPrompt: () => void
@@ -1623,6 +1645,42 @@ describe('patchCodexAcpTurnUsageSource', () => {
 
     expect(legacy).not.toBe(normalized)
     expect(patchCodexAcpTurnUsageSource(legacy)).toBe(normalized)
+  })
+
+  it('upgrades the overwritten turn-usage metadata shape in an existing managed adapter', () => {
+    const patched = patchCodexAcpTurnUsageSource(fixture)
+    const latestUsage = [
+      'usage: this.buildPromptUsage(',
+      '  sessionState.lastTokenUsage',
+      '),'
+    ].join('\n')
+    const overwrittenUsage = [
+      latestUsage,
+      '...(sessionState.promptTokenUsageObserved',
+      '  ? {',
+      '      _meta: {',
+      `        "${ACP_TURN_TOKEN_USAGE_META_KEY}": this.buildPromptUsage(sessionState.promptTokenUsage)`,
+      '      }',
+      '    }',
+      '  : {}),'
+    ].join('\n')
+    const mergedMeta = [
+      '_meta: {',
+      '  ...this.buildQuotaMeta(sessionState),',
+      '  ...(sessionState.promptTokenUsageObserved',
+      '    ? {',
+      `        "${ACP_TURN_TOKEN_USAGE_META_KEY}": this.buildPromptUsage(sessionState.promptTokenUsage)`,
+      '      }',
+      '    : {})',
+      '}'
+    ].join('\n')
+    const overwritten = patched.replaceAll(
+      `${latestUsage} ${mergedMeta}`,
+      `${overwrittenUsage} _meta: this.buildQuotaMeta(sessionState)`
+    )
+
+    expect(overwritten).not.toBe(patched)
+    expect(patchCodexAcpTurnUsageSource(overwritten)).toBe(patched)
   })
 
   it('composes with the context-usage patch without duplicate declarations', () => {

--- a/src/main/settings/managed-codex.ts
+++ b/src/main/settings/managed-codex.ts
@@ -258,7 +258,10 @@ const CODEX_ACP_TURN_USAGE_RESPONSE_SOURCE =
   'usage: this.buildPromptUsage(sessionState.lastTokenUsage),'
 const CODEX_ACP_TURN_USAGE_RESPONSE_LEGACY_REPLACEMENT =
   'usage: this.buildPromptUsage(sessionState.promptTokenUsageObserved ? sessionState.promptTokenUsage : null),'
-const CODEX_ACP_TURN_USAGE_RESPONSE_REPLACEMENT = [
+// The first turn-usage patch emitted a second `_meta` property immediately before the adapter's
+// existing quota metadata. JavaScript keeps only the latter property, so this exact shape must be
+// recognized and upgraded in already-managed installs.
+const CODEX_ACP_TURN_USAGE_RESPONSE_OVERWRITTEN_REPLACEMENT = [
   'usage: this.buildPromptUsage(',
   '  sessionState.lastTokenUsage',
   '),',
@@ -269,6 +272,22 @@ const CODEX_ACP_TURN_USAGE_RESPONSE_REPLACEMENT = [
   '      }',
   '    }',
   '  : {}),'
+].join('\n')
+const CODEX_ACP_TURN_USAGE_RESPONSE_REPLACEMENT = [
+  'usage: this.buildPromptUsage(',
+  '  sessionState.lastTokenUsage',
+  '),'
+].join('\n')
+const CODEX_ACP_TURN_USAGE_META_SOURCE = '_meta: this.buildQuotaMeta(sessionState)'
+const CODEX_ACP_TURN_USAGE_META_REPLACEMENT = [
+  '_meta: {',
+  '  ...this.buildQuotaMeta(sessionState),',
+  '  ...(sessionState.promptTokenUsageObserved',
+  '    ? {',
+  `        "${ACP_TURN_TOKEN_USAGE_META_KEY}": this.buildPromptUsage(sessionState.promptTokenUsage)`,
+  '      }',
+  '    : {})',
+  '}'
 ].join('\n')
 const CODEX_ACP_TURN_USAGE_FINISH_SOURCE = '      activePrompt.complete();'
 const CODEX_ACP_TURN_USAGE_FINISH_REPLACEMENT = [
@@ -422,11 +441,17 @@ export const patchCodexAcpTurnUsageSource = (source: string): string => {
       CODEX_ACP_TURN_USAGE_RESPONSE_LEGACY_REPLACEMENT,
       CODEX_ACP_TURN_USAGE_RESPONSE_REPLACEMENT
     )
+    .replaceAll(
+      CODEX_ACP_TURN_USAGE_RESPONSE_OVERWRITTEN_REPLACEMENT,
+      CODEX_ACP_TURN_USAGE_RESPONSE_REPLACEMENT
+    )
+    .replaceAll(CODEX_ACP_TURN_USAGE_META_SOURCE, CODEX_ACP_TURN_USAGE_META_REPLACEMENT)
 
   if (
     migratedSource.includes(CODEX_ACP_TURN_USAGE_UPDATE_REPLACEMENT) &&
     migratedSource.includes(CODEX_ACP_TURN_USAGE_START_REPLACEMENT) &&
     migratedSource.includes(CODEX_ACP_TURN_USAGE_RESPONSE_REPLACEMENT) &&
+    migratedSource.includes(CODEX_ACP_TURN_USAGE_META_REPLACEMENT) &&
     migratedSource.includes(CODEX_ACP_TURN_USAGE_FINISH_REPLACEMENT)
   ) {
     return migratedSource
@@ -435,9 +460,16 @@ export const patchCodexAcpTurnUsageSource = (source: string): string => {
   const updateMatches = migratedSource.split(CODEX_ACP_TURN_USAGE_UPDATE_SOURCE).length - 1
   const startMatches = migratedSource.split(CODEX_ACP_TURN_USAGE_START_SOURCE).length - 1
   const responseMatches = migratedSource.split(CODEX_ACP_TURN_USAGE_RESPONSE_SOURCE).length - 1
+  const metaMatches = migratedSource.split(CODEX_ACP_TURN_USAGE_META_REPLACEMENT).length - 1
   const finishMatches = migratedSource.split(CODEX_ACP_TURN_USAGE_FINISH_SOURCE).length - 1
 
-  if (updateMatches === 1 && startMatches === 1 && responseMatches === 3 && finishMatches === 1) {
+  if (
+    updateMatches === 1 &&
+    startMatches === 1 &&
+    responseMatches === 3 &&
+    metaMatches === 3 &&
+    finishMatches === 1
+  ) {
     return migratedSource
       .replace(CODEX_ACP_TURN_USAGE_UPDATE_SOURCE, CODEX_ACP_TURN_USAGE_UPDATE_REPLACEMENT)
       .replace(CODEX_ACP_TURN_USAGE_START_SOURCE, CODEX_ACP_TURN_USAGE_START_REPLACEMENT)

--- a/src/main/settings/service.test.ts
+++ b/src/main/settings/service.test.ts
@@ -133,6 +133,7 @@ const createService = (
     installManagedCodexImpl?: ManagedCodexInstallImpl
     // When set, opencode detection resolves this path/version; otherwise it finds nothing.
     opencodeDetected?: { path: string; version: string }
+    allocateOpenCodeUsagePort?: () => Promise<number>
     codexDetected?: { path: string; version: string; nativePath?: string; nativeVersion?: string }
     managedCodexAdapterPath?: string
     managedCodexNativePath?: string
@@ -191,6 +192,7 @@ const createService = (
         ),
       resolveNpmBinDirs: () => Promise.resolve([])
     },
+    allocateOpenCodeUsagePort: options.allocateOpenCodeUsagePort ?? (() => Promise.resolve(42_424)),
     codexDetectDeps: {
       env: options.codexDetected ? { PATH: dirname(options.codexDetected.path) } : {},
       homePath: '/home',
@@ -2516,6 +2518,11 @@ describe('SettingsService: preflight & spawn config', () => {
       attachment: true,
       modalities: { input: ['text', 'image'] },
       limit: { context: 1_000_000, output: 32_000 }
+    })
+    expect(backend.args).toEqual(['--port', '42424', '--hostname', '127.0.0.1'])
+    expect(backend.opencodeUsageApi).toEqual({
+      baseUrl: 'http://127.0.0.1:42424',
+      authorization: `Basic ${Buffer.from(`opencode:${backend.env.OPENCODE_SERVER_PASSWORD}`).toString('base64')}`
     })
   })
 

--- a/src/main/settings/service.ts
+++ b/src/main/settings/service.ts
@@ -4,6 +4,7 @@ import { constants } from 'node:fs'
 import { homedir } from 'node:os'
 import { dirname, isAbsolute, join, relative, resolve, sep } from 'node:path'
 import { randomUUID } from 'node:crypto'
+import { createServer } from 'node:net'
 import { isDeepStrictEqual, promisify } from 'node:util'
 
 import { z } from 'zod'
@@ -281,6 +282,27 @@ type LeasedResponsesBridgeConnection = ResponsesBridgeConnection & {
   lease: NonNullable<ResolvedAgentBackend['responsesBridgeLease']>
 }
 
+const allocateLoopbackPort = async (): Promise<number> => {
+  const server = createServer()
+  try {
+    await new Promise<void>((resolve, reject) => {
+      server.once('error', reject)
+      server.listen(0, '127.0.0.1', resolve)
+    })
+    const address = server.address()
+    if (!address || typeof address === 'string') {
+      throw new Error('Could not reserve an OpenCode usage API port.')
+    }
+    return address.port
+  } finally {
+    if (server.listening) {
+      await new Promise<void>((resolve, reject) =>
+        server.close((error) => (error ? reject(error) : resolve()))
+      )
+    }
+  }
+}
+
 const execFileAsync = promisify(execFile)
 
 // Hard ceiling for a Claude credential probe so a stuck process can never hang the wizard.
@@ -490,6 +512,9 @@ export type SettingsServiceOptions = {
   storageRoot?: string
   detectDeps?: ClaudeDetectDeps
   opencodeDetectDeps?: OpencodeDetectDeps
+  // Reserves the authenticated loopback HTTP port exposed by `opencode acp`. Injectable so settings
+  // tests do not bind real sockets.
+  allocateOpenCodeUsagePort?: () => Promise<number>
   codexDetectDeps?: CodexDetectDeps
   // The machine's own Claude config dir, used by the shared provider for auth/spawn and scanned as a
   // user skill source. Injectable so tests don't touch the real ~/.claude.
@@ -538,6 +563,7 @@ class SettingsService {
   private readonly storageRoot: string
   private readonly detectDeps: ClaudeDetectDeps
   private readonly opencodeDetectDeps: OpencodeDetectDeps
+  private readonly allocateOpenCodeUsagePort: () => Promise<number>
   private readonly codexDetectDeps: CodexDetectDeps
   private readonly userClaudeDir: string
   private readonly userCodexDir: string
@@ -590,6 +616,7 @@ class SettingsService {
       ...baseOpencodeDetectDeps,
       extraDirs: [...(baseOpencodeDetectDeps.extraDirs ?? []), managedOpencodeDir(this.storageRoot)]
     }
+    this.allocateOpenCodeUsagePort = options.allocateOpenCodeUsagePort ?? allocateLoopbackPort
     const managedAdapterPath = managedCodexAdapterEntry(this.storageRoot)
     const managedNativePath = managedCodexBinary(this.storageRoot)
     this.codexDetectDeps = options.codexDetectDeps ?? {
@@ -3759,6 +3786,9 @@ class SettingsService {
         instructions: connectorInstructions
       })
       await writeAgentConfigFiles(modelConfig.configFiles)
+      const opencodeUsagePort =
+        framework.id === 'opencode' ? await this.allocateOpenCodeUsagePort() : undefined
+      const opencodeUsagePassword = opencodeUsagePort === undefined ? undefined : randomUUID()
       const usesCodexSystemProxy =
         framework.id === 'codex' && isCodexSubscriptionProvider(provider.type)
       const proxyEnv = usesCodexSystemProxy ? await this.resolveCodexProxyEnvironment() : undefined
@@ -3772,12 +3802,22 @@ class SettingsService {
         executablePath,
         env: {
           ...(modelConfig.env ?? {}),
+          ...(opencodeUsagePassword ? { OPENCODE_SERVER_PASSWORD: opencodeUsagePassword } : {}),
           ...(proxyEnv ?? {}),
           ...(framework.id === 'codex' && settings.codex?.nativePath
             ? { CODEX_PATH: settings.codex.nativePath }
             : {})
         },
-        args: modelConfig.args,
+        args:
+          opencodeUsagePort === undefined
+            ? modelConfig.args
+            : [
+                ...(modelConfig.args ?? []),
+                '--port',
+                String(opencodeUsagePort),
+                '--hostname',
+                '127.0.0.1'
+              ],
         ...(usesCodexSystemProxy
           ? { proxyEnvironmentMode: proxyEnv === undefined ? 'inherit' : 'replace' }
           : {}),
@@ -3790,6 +3830,14 @@ class SettingsService {
         contextUsageModel: provider.model,
         authentication: modelConfig.authentication,
         providerConfiguration: modelConfig.providerConfiguration,
+        ...(opencodeUsagePort === undefined || !opencodeUsagePassword
+          ? {}
+          : {
+              opencodeUsageApi: {
+                baseUrl: `http://127.0.0.1:${opencodeUsagePort}`,
+                authorization: `Basic ${Buffer.from(`opencode:${opencodeUsagePassword}`).toString('base64')}`
+              }
+            }),
         responsesBridgeLease: responsesBridge?.lease
       }
     } catch (error) {


### PR DESCRIPTION
## Problem

Codex sessions using Responses-compatible providers could lose the whole-turn token metadata when the managed adapter added quota metadata, leaving Input/Cache/Output blank. An unpatched Codex bridge also had no fallback when the private metadata was absent. OpenCode's ACP response reports the last assistant model step, so tool-follow-up turns displayed one step's context instead of the cumulative token usage for the user turn.

## Proposed change

- Preserve the managed Codex adapter's cumulative prompt usage alongside quota metadata.
- Fall back to standard ACP response usage when Codex private whole-turn metadata is unavailable.
- Start OpenCode's authenticated loopback HTTP API on a per-backend localhost port.
- Snapshot OpenCode assistant messages before and after a prompt, then sum every new assistant model step in that turn.
- Fall back to the standard ACP response usage if the OpenCode usage API is unavailable or incomplete.

## Scope and non-goals

- Aggregation is scoped to assistant model steps created in the active ACP session during one user prompt.
- Nested OpenCode child/subagent sessions are not folded into the parent session total.
- This does not change pricing, quota, or context-window calculations.

## Acceptance criteria and validation

All listed checks ran after the last material edit.

- Codex managed adapter preserves quota metadata and exposes cumulative Input/Cache/Output -> `npm test -- --run src/main/settings/managed-codex.test.ts` -> passed.
- Codex bridge without private metadata keeps standard token usage visible -> `npm test -- --run src/main/acp/runtime.test.ts -t 'keeps Codex bridge usage visible when the adapter omits whole-turn metadata'` -> passed.
- OpenCode sums every assistant model step created by one prompt turn -> `npm test -- --run src/main/acp/opencode-turn-usage.test.ts src/main/acp/runtime.test.ts -t 'OpenCode turn usage|sums every OpenCode assistant model step created by one prompt turn'` -> passed.
- OpenCode backend provisions an authenticated localhost usage endpoint -> `npm test -- --run src/main/settings/service.test.ts -t 'declares the model image capability in the resolved OpenCode backend config'` -> passed.
- Type safety -> `npm run typecheck` -> passed.
- Lint -> `npm run lint` -> passed with pre-existing warnings only; changed files have no warnings.
- Repository test suite -> `npm test -- --maxWorkers=4` -> 592 files and 8,883 tests passed; 11 files and 140 tests skipped by configuration.
- Formatting and patch integrity -> changed-file Prettier check and `git diff --check` -> passed.
- Independent review -> Standards and Spec reviews -> no findings.

Uncovered risks: OpenCode's local message API is not part of the ACP wire contract and could change in a future OpenCode release. Failure is fail-safe: the UI falls back to the last standard ACP usage rather than becoming blank. Nested child-session model calls remain outside the parent turn total.

## Review focus

- Turn boundaries and message-ID based OpenCode aggregation.
- Lifecycle and authentication of the localhost OpenCode usage API.
- Codex metadata migration and fallback behavior.
