### PR TITLE
fix(storage): migrate immutable Environment manifests only

### DIFF
--- a/src/main/storage/migration-service.test.ts
+++ b/src/main/storage/migration-service.test.ts
@@ -19,7 +19,7 @@ import {
   discardStagedCopy,
   MIGRATED_DIRS,
   PROJECT_DATABASE_FILE,
-  RUNTIME_PROVENANCE_DIR,
+  RUNTIME_ENVIRONMENT_MANIFESTS_DIR,
   runDataRootMigration,
   validateNewDataRoot
 } from './migration-service'
@@ -489,7 +489,7 @@ describe('runDataRootMigration (copy phase)', () => {
       expect.objectContaining({
         from: currentDataRoot,
         to: target,
-        dirs: [...MIGRATED_DIRS, RUNTIME_PROVENANCE_DIR]
+        dirs: [...MIGRATED_DIRS, RUNTIME_ENVIRONMENT_MANIFESTS_DIR]
       })
     )
     // runtime/ is excluded from the moved set (non-relocatable; rebuilt on demand).
@@ -550,11 +550,11 @@ describe('runDataRootMigration (copy phase)', () => {
     expect(deps.setDataRoot).not.toHaveBeenCalled()
   })
 
-  it('refuses to stage a migration when the frozen source has unresolved provenance state', async () => {
+  it('refuses to stage a migration when the frozen source has unresolved durable provenance', async () => {
     const deps = fakeDeps()
     const copyAndVerify = vi.fn(async (): Promise<MigrationResult> => ({ ok: true }))
     const validateProvenanceState = vi.fn(async () => {
-      throw new Error('unfinished Environment operation')
+      throw new Error('unfinished Artifact staging')
     })
 
     const result = await runDataRootMigration(
@@ -571,10 +571,64 @@ describe('runDataRootMigration (copy phase)', () => {
 
     expect(result).toEqual({
       ok: false,
-      error: 'Could not verify provenance data: unfinished Environment operation'
+      error: 'Could not verify provenance data: unfinished Artifact staging'
     })
     expect(validateProvenanceState).toHaveBeenCalledWith(currentDataRoot)
     expect(copyAndVerify).not.toHaveBeenCalled()
+  })
+
+  it('moves immutable Environment manifests without relocating dirty runtime cache state', async () => {
+    const deps = fakeDeps()
+    const environmentKey = '6781bee2cc7128dad60abe39756695758edd2dc2f9b42bb53db430253a7d8b43'
+    const inventoryTarget = join(
+      currentDataRoot,
+      'runtime',
+      'provenance',
+      'environment-inventory',
+      environmentKey
+    )
+    await mkdir(join(inventoryTarget, 'operations'), { recursive: true })
+    await writeFile(
+      join(inventoryTarget, 'binding.json'),
+      JSON.stringify({
+        schemaVersion: 1,
+        generation: 1,
+        state: 'dirty',
+        dirtyOperationId: 'operation-interrupted',
+        dirtyReason: 'recovery',
+        operationLog: []
+      })
+    )
+    await writeFile(join(inventoryTarget, 'operations', 'operation-interrupted.json'), '{}')
+
+    const manifestName = `${'a'.repeat(64)}.json`
+    const sourceManifest = join(currentDataRoot, RUNTIME_ENVIRONMENT_MANIFESTS_DIR, manifestName)
+    await mkdir(join(currentDataRoot, RUNTIME_ENVIRONMENT_MANIFESTS_DIR), { recursive: true })
+    await writeFile(sourceManifest, '{"schemaVersion":1}\n')
+
+    const target = dataRootFor(emptyParent)
+    const destinationInventory = join(
+      target,
+      'runtime',
+      'provenance',
+      'environment-inventory',
+      'stale-environment'
+    )
+    await mkdir(destinationInventory, { recursive: true })
+    await writeFile(join(destinationInventory, 'binding.json'), '{"state":"dirty"}\n')
+    const destinationRuntimeSentinel = join(target, 'runtime', 'cache-sentinel')
+    await writeFile(destinationRuntimeSentinel, 'keep')
+
+    const result = await runDataRootMigration(
+      { currentDataRoot, runtime: deps.runtime, notebook: deps.notebook },
+      emptyParent,
+      runOpts()
+    )
+
+    expect(result).toEqual({ ok: true })
+    expect(existsSync(join(target, RUNTIME_ENVIRONMENT_MANIFESTS_DIR, manifestName))).toBe(true)
+    expect(existsSync(join(target, 'runtime', 'provenance', 'environment-inventory'))).toBe(false)
+    expect(existsSync(destinationRuntimeSentinel)).toBe(true)
   })
 
   it("stamps a 'copying' marker before the copy and promotes it to 'verified' on success", async () => {
@@ -1004,7 +1058,7 @@ describe('runtime preservation + old-runtime cleanup', () => {
     // The (relocatable) pkgs cache is copied alongside the user data so envs rebuild offline there.
     expect(copyAndVerify).toHaveBeenCalledWith(
       expect.objectContaining({
-        dirs: [...MIGRATED_DIRS, RUNTIME_PROVENANCE_DIR, join('runtime', 'pkgs')]
+        dirs: [...MIGRATED_DIRS, RUNTIME_ENVIRONMENT_MANIFESTS_DIR, join('runtime', 'pkgs')]
       })
     )
   })
@@ -1028,7 +1082,7 @@ describe('runtime preservation + old-runtime cleanup', () => {
 
     expect(copyAndVerify).toHaveBeenCalledWith(
       expect.objectContaining({
-        dirs: [...MIGRATED_DIRS, RUNTIME_PROVENANCE_DIR]
+        dirs: [...MIGRATED_DIRS, RUNTIME_ENVIRONMENT_MANIFESTS_DIR]
       })
     )
   })
@@ -1055,7 +1109,7 @@ describe('runtime preservation + old-runtime cleanup', () => {
     expect(result).toEqual({ ok: true })
     expect(copyAndVerify).toHaveBeenCalledWith(
       expect.objectContaining({
-        dirs: [...MIGRATED_DIRS, RUNTIME_PROVENANCE_DIR]
+        dirs: [...MIGRATED_DIRS, RUNTIME_ENVIRONMENT_MANIFESTS_DIR]
       })
     )
   })

--- a/src/main/storage/migration-service.test.ts
+++ b/src/main/storage/migration-service.test.ts
@@ -31,6 +31,7 @@ import {
   type MigrationMarker
 } from './migration-marker'
 import { withDataRootWrite } from './migration-state'
+import { operationJournalPath, RuntimeOperationJournal } from '../notebook/operation-journal'
 
 // Writes a verified staging marker for `<parent>/OpenScience`, as a completed copy phase would have.
 const seedVerifiedMarker = async (
@@ -574,6 +575,34 @@ describe('runDataRootMigration (copy phase)', () => {
       error: 'Could not verify provenance data: unfinished Artifact staging'
     })
     expect(validateProvenanceState).toHaveBeenCalledWith(currentDataRoot)
+    expect(copyAndVerify).not.toHaveBeenCalled()
+  })
+
+  it('refuses to copy while the source runtime recovery journal has a pending operation', async () => {
+    const deps = fakeDeps()
+    const runtimeRoot = join(currentDataRoot, 'runtime')
+    const journal = RuntimeOperationJournal.forPath(operationJournalPath(runtimeRoot))
+    await journal.begin({
+      operationId: 'operation-installing',
+      kind: 'install',
+      runtimeId: 'default-python',
+      phase: 'install-python',
+      startedAt: Date.now(),
+      targetPath: join(runtimeRoot, 'envs', 'default-python')
+    })
+    const copyAndVerify = vi.fn(async (): Promise<MigrationResult> => ({ ok: true }))
+
+    const result = await runDataRootMigration(
+      { currentDataRoot, runtime: deps.runtime, notebook: deps.notebook, copyAndVerify },
+      emptyParent,
+      runOpts()
+    )
+
+    expect(result).toEqual({
+      ok: false,
+      error:
+        'Could not verify provenance data: Unfinished Runtime operation blocks migration: operation-installing'
+    })
     expect(copyAndVerify).not.toHaveBeenCalled()
   })
 

--- a/src/main/storage/migration-service.ts
+++ b/src/main/storage/migration-service.ts
@@ -270,15 +270,22 @@ export const validateNewDataRoot = async (
 export type MigrationOutcome =
   MigrationResult | { ok: false; error: string; switchoverFailed: true }
 
-// runtime/ is not copied wholesale (env prefixes bake absolute paths), but its pkgs cache IS
-// relocatable inert data — copied so the envs can be rebuilt offline at the new root from their
-// exported locks. Nested path is intentional: copyAndVerify mirrors `from/<dir>` → `to/<dir>`.
+// runtime/ is not copied wholesale (env prefixes and mutable inventory-cache keys bake absolute
+// paths), but its pkgs cache IS relocatable inert data — copied so envs can be rebuilt offline at the
+// new root from their exported locks. Immutable Environment manifests are copied separately because
+// Notebook and Artifact provenance reference them by checksum. Nested paths are intentional:
+// copyAndVerify mirrors `from/<dir>` → `to/<dir>`.
 const RUNTIME_PKGS_DIR = join('runtime', 'pkgs')
-export const RUNTIME_PROVENANCE_DIR = join('runtime', 'provenance')
+export const RUNTIME_ENVIRONMENT_MANIFESTS_DIR = join(
+  'runtime',
+  'provenance',
+  'environment-manifests'
+)
+const RUNTIME_ENVIRONMENT_INVENTORY_DIR = join('runtime', 'provenance', 'environment-inventory')
 // The SQLite authority stays under the fixed config root. Keep the filename exported for migration
 // validation/tests, but never put it in the relocatable data-root copy/delete set.
 export const PROJECT_DATABASE_FILE = 'open-science.db'
-const BASE_MIGRATION_DIRS = [...MIGRATED_DIRS, RUNTIME_PROVENANCE_DIR]
+const BASE_MIGRATION_DIRS = [...MIGRATED_DIRS, RUNTIME_ENVIRONMENT_MANIFESTS_DIR]
 
 const defaultValidateProvenanceState = (dataRoot: string): Promise<void> =>
   validateProvenanceMigrationState(dataRoot, resolveConfigRoot())
@@ -366,6 +373,10 @@ export const runDataRootMigration = async (
   }
   try {
     await mkdir(target, { recursive: true })
+    // A runtime-only destination is a valid move target and may be residue from an earlier location.
+    // Drop only its path-keyed mutable Environment cache before staging; keep relocatable packages,
+    // exported locks, and every other rebuildable runtime file intact.
+    await rm(join(target, RUNTIME_ENVIRONMENT_INVENTORY_DIR), { recursive: true, force: true })
     await writeMigrationMarker(target, marker)
   } catch (err) {
     console.error('[migration-service] failed to initialize staging dir', err)
@@ -521,7 +532,7 @@ export const commitDataRootSwitch = async (
   }
 
   const migratedDirs = marker.migratedDirs ?? [...MIGRATED_DIRS]
-  const requiredPaths = [RUNTIME_PROVENANCE_DIR].filter((path) =>
+  const requiredPaths = [RUNTIME_ENVIRONMENT_MANIFESTS_DIR].filter((path) =>
     existsSync(join(deps.currentDataRoot, path))
   )
   if (requiredPaths.some((path) => !migratedDirs.includes(path))) {

--- a/src/main/storage/provenance-migration-validation.test.ts
+++ b/src/main/storage/provenance-migration-validation.test.ts
@@ -19,7 +19,7 @@ afterEach(async () => {
 })
 
 describe('validateProvenanceMigrationState', () => {
-  it('refuses a dirty Environment binding or unfinished operation', async () => {
+  it('accepts dirty Environment cache state because relocation rebuilds the runtime', async () => {
     const target = join(root, 'runtime', 'provenance', 'environment-inventory', 'environment-key')
     await mkdir(join(target, 'operations'), { recursive: true })
     await writeFile(
@@ -35,12 +35,30 @@ describe('validateProvenanceMigrationState', () => {
     )
     await writeFile(join(target, 'operations', 'operation-1.json'), '{}')
 
-    await expect(validateProvenanceMigrationState(root)).rejects.toThrow(
-      /unfinished Environment operation/i
-    )
+    await expect(validateProvenanceMigrationState(root)).resolves.toBeUndefined()
   })
 
-  it('refuses malformed Environment operation-log truncation metadata', async () => {
+  it.each(['operation-orphaned.json', 'operation-orphaned.json.123.tmp'])(
+    'accepts a clean Environment binding with an unbound operation file: %s',
+    async (operationFilename) => {
+      const target = join(root, 'runtime', 'provenance', 'environment-inventory', 'environment-key')
+      await mkdir(join(target, 'operations'), { recursive: true })
+      await writeFile(
+        join(target, 'binding.json'),
+        JSON.stringify({
+          schemaVersion: 1,
+          generation: 1,
+          state: 'clean',
+          operationLog: []
+        })
+      )
+      await writeFile(join(target, 'operations', operationFilename), '{}')
+
+      await expect(validateProvenanceMigrationState(root)).resolves.toBeUndefined()
+    }
+  )
+
+  it('ignores malformed Environment cache metadata that relocation does not preserve', async () => {
     const target = join(root, 'runtime', 'provenance', 'environment-inventory', 'environment-key')
     await mkdir(target, { recursive: true })
     await writeFile(
@@ -54,9 +72,7 @@ describe('validateProvenanceMigrationState', () => {
       })
     )
 
-    await expect(validateProvenanceMigrationState(root)).rejects.toThrow(
-      /invalid Environment binding/i
-    )
+    await expect(validateProvenanceMigrationState(root)).resolves.toBeUndefined()
   })
 
   it('refuses an Artifact staging directory that has not reached an immutable lifecycle state', async () => {

--- a/src/main/storage/provenance-migration-validation.test.ts
+++ b/src/main/storage/provenance-migration-validation.test.ts
@@ -5,6 +5,7 @@ import { join } from 'node:path'
 import { afterEach, beforeEach, describe, expect, it } from 'vitest'
 
 import { validateProvenanceMigrationState } from './provenance-migration-validation'
+import { operationJournalPath, RuntimeOperationJournal } from '../notebook/operation-journal'
 import { createProjectDbClient, ensureProjectSchema } from '../projects/prisma-client'
 
 let root: string
@@ -73,6 +74,33 @@ describe('validateProvenanceMigrationState', () => {
     )
 
     await expect(validateProvenanceMigrationState(root)).resolves.toBeUndefined()
+  })
+
+  it('refuses a pending runtime operation from the authoritative recovery journal', async () => {
+    const runtimeRoot = join(root, 'runtime')
+    const journal = RuntimeOperationJournal.forPath(operationJournalPath(runtimeRoot))
+    await journal.begin({
+      operationId: 'operation-installing',
+      kind: 'install',
+      runtimeId: 'default-python',
+      phase: 'install-python',
+      startedAt: Date.now(),
+      targetPath: join(runtimeRoot, 'envs', 'default-python')
+    })
+
+    await expect(validateProvenanceMigrationState(root)).rejects.toThrow(
+      /unfinished Runtime operation blocks migration: operation-installing/i
+    )
+  })
+
+  it('refuses a corrupt runtime operation journal instead of treating it as empty', async () => {
+    const runtimeRoot = join(root, 'runtime')
+    await mkdir(runtimeRoot, { recursive: true })
+    await writeFile(operationJournalPath(runtimeRoot), '{ not valid json')
+
+    await expect(validateProvenanceMigrationState(root)).rejects.toThrow(
+      /Runtime operation journal is corrupt/i
+    )
   })
 
   it('refuses an Artifact staging directory that has not reached an immutable lifecycle state', async () => {

--- a/src/main/storage/provenance-migration-validation.ts
+++ b/src/main/storage/provenance-migration-validation.ts
@@ -3,10 +3,11 @@ import { createReadStream, type Dirent } from 'node:fs'
 import { readFile, readdir, stat } from 'node:fs/promises'
 import { isAbsolute, join, relative, resolve, sep } from 'node:path'
 
-import { createProjectDbClient } from '../projects/prisma-client'
 import { validateConversationGraph } from '../../shared/conversation-graph'
 import { NOTEBOOK_RUN_FILE } from '../../shared/notebook'
 import { normalizeSessionFile } from '../../shared/session-persistence'
+import { operationJournalPath, RuntimeOperationJournal } from '../notebook/operation-journal'
+import { createProjectDbClient } from '../projects/prisma-client'
 
 const SHA256_PATTERN = /^[a-f0-9]{64}$/
 const storageKey = (...segments: string[]): string => segments.join('/')
@@ -80,6 +81,26 @@ const recordValue = (value: unknown): Record<string, unknown> | undefined =>
   value && typeof value === 'object' && !Array.isArray(value)
     ? (value as Record<string, unknown>)
     : undefined
+
+// Runtime operation journals are the authoritative crash-recovery record for prefix mutations. Unlike
+// the path-keyed Environment inventory cache below, a pending record may identify a still-running child
+// or a prefix that startup recovery has deliberately kept blocked. Migration must fail closed here:
+// switching roots would orphan that journal, and a preserved runtime bundle lets commit delete the old
+// runtime after switchover.
+const assertNoRuntimeOperations = async (root: string): Promise<void> => {
+  const runtimeRoot = join(root, 'runtime')
+  const journal = RuntimeOperationJournal.forPath(operationJournalPath(runtimeRoot))
+  const state = await journal.readState()
+  if (state === 'corrupt') {
+    throw new Error(
+      'Runtime operation journal is corrupt; repair or reset the affected runtime before moving data.'
+    )
+  }
+  const pending = state.records[0]
+  if (pending) {
+    throw new Error(`Unfinished Runtime operation blocks migration: ${pending.operationId}`)
+  }
+}
 
 // Environment bindings, inventories, and pending-operation records are mutable runtime caches keyed
 // by the interpreter command (including its absolute data-root path). A relocation rebuilds the
@@ -531,6 +552,7 @@ export const validateProvenanceMigrationState = async (
   dataRoot: string,
   authorityRoot: string = dataRoot
 ): Promise<void> => {
+  await assertNoRuntimeOperations(dataRoot)
   await validateSessionGraphs(authorityRoot)
   await validateSqliteStore(dataRoot, authorityRoot)
   const manifests = await collectEnvironmentManifests(dataRoot)

--- a/src/main/storage/provenance-migration-validation.ts
+++ b/src/main/storage/provenance-migration-validation.ts
@@ -5,10 +5,7 @@ import { isAbsolute, join, relative, resolve, sep } from 'node:path'
 
 import { createProjectDbClient } from '../projects/prisma-client'
 import { validateConversationGraph } from '../../shared/conversation-graph'
-import {
-  isNotebookEnvironmentOperationLogTruncation,
-  NOTEBOOK_RUN_FILE
-} from '../../shared/notebook'
+import { NOTEBOOK_RUN_FILE } from '../../shared/notebook'
 import { normalizeSessionFile } from '../../shared/session-persistence'
 
 const SHA256_PATTERN = /^[a-f0-9]{64}$/
@@ -84,53 +81,18 @@ const recordValue = (value: unknown): Record<string, unknown> | undefined =>
     ? (value as Record<string, unknown>)
     : undefined
 
-const validateEnvironmentState = async (root: string): Promise<Set<string>> => {
-  const provenanceRoot = join(root, 'runtime', 'provenance')
-  const manifestDirectory = join(provenanceRoot, 'environment-manifests')
+// Environment bindings, inventories, and pending-operation records are mutable runtime caches keyed
+// by the interpreter command (including its absolute data-root path). A relocation rebuilds the
+// runtime under a different path, so those records cannot be reused and are intentionally not copied.
+// Only immutable manifests are migration evidence; collect their identities here so every Notebook
+// reference below can still be proven against the bytes that the migration preserves.
+const collectEnvironmentManifests = async (root: string): Promise<Set<string>> => {
+  const manifestDirectory = join(root, 'runtime', 'provenance', 'environment-manifests')
   const manifestChecksums = new Set<string>()
   for (const entry of await readEntries(manifestDirectory)) {
     if (!entry.isFile() || !entry.name.endsWith('.json')) continue
     const checksum = entry.name.slice(0, -'.json'.length)
     if (SHA256_PATTERN.test(checksum)) manifestChecksums.add(checksum)
-  }
-
-  const inventoryRoot = join(provenanceRoot, 'environment-inventory')
-  for (const target of await readEntries(inventoryRoot)) {
-    if (!target.isDirectory()) continue
-    const targetDirectory = join(inventoryRoot, target.name)
-    const operationEntries = (await readEntries(join(targetDirectory, 'operations'))).filter(
-      (entry) => entry.isFile()
-    )
-    let binding: Record<string, unknown> | undefined
-    try {
-      binding = await readRecord(join(targetDirectory, 'binding.json'))
-    } catch (error) {
-      if (!(
-        typeof error === 'object' &&
-        error !== null &&
-        'code' in error &&
-        (error as { code?: unknown }).code === 'ENOENT'
-      )) {
-        throw error
-      }
-    }
-    if (
-      operationEntries.length > 0 ||
-      binding?.state === 'dirty' ||
-      typeof binding?.dirtyOperationId === 'string' ||
-      typeof binding?.dirtyReason === 'string'
-    ) {
-      throw new Error(`Unfinished Environment operation blocks migration: ${target.name}`)
-    }
-    if (binding && (binding.schemaVersion !== 1 || !Array.isArray(binding.operationLog))) {
-      throw new Error(`Invalid Environment binding blocks migration: ${target.name}`)
-    }
-    if (
-      binding?.operationLogTruncation !== undefined &&
-      !isNotebookEnvironmentOperationLogTruncation(binding.operationLogTruncation)
-    ) {
-      throw new Error(`Invalid Environment binding blocks migration: ${target.name}`)
-    }
   }
   return manifestChecksums
 }
@@ -562,15 +524,16 @@ const validateSqliteStore = async (dataRoot: string, authorityRoot: string): Pro
   }
 }
 
-// Migration validates domain state in addition to byte-for-byte copy inventories. It refuses open
-// mutations and checks immutable evidence before either root can become authoritative.
+// Migration validates durable domain evidence in addition to byte-for-byte copy inventories. Mutable
+// Environment caches are rebuilt with the relocated runtime; immutable evidence must validate before
+// either root can become authoritative.
 export const validateProvenanceMigrationState = async (
   dataRoot: string,
   authorityRoot: string = dataRoot
 ): Promise<void> => {
   await validateSessionGraphs(authorityRoot)
   await validateSqliteStore(dataRoot, authorityRoot)
-  const manifests = await validateEnvironmentState(dataRoot)
+  const manifests = await collectEnvironmentManifests(dataRoot)
   await validateReferencedEnvironmentManifests(dataRoot, manifests)
   await validateArtifactVersions(dataRoot)
   await assertNoUploadStaging(dataRoot)


### PR DESCRIPTION
## Problem

On Windows, a data-root move can fail during provenance validation with:

`Could not verify provenance data: Unfinished Environment operation blocks migration: 6781bee2cc7128dad60abe39756695758edd2dc2f9b42bb53db430253a7d8b43`

The migration validator treated the Environment inventory binding and pending-operation records as durable provenance. That inventory is a mutable cache keyed by the interpreter command, which embeds the managed runtime's absolute data-root path. It cannot be reused after relocation, and stale `.json` / `.tmp` operation files or a dirty binding could therefore permanently block an otherwise recoverable move.

## Proposed change

- Preserve and validate only checksum-addressed immutable Environment manifests during migration.
- Exclude the path-keyed Environment inventory cache from the provenance copy set and migration preflight.
- Fail closed when the authoritative runtime operation journal is corrupt or contains a pending operation.
- Remove only a pre-existing destination Environment inventory cache before staging, while preserving other destination runtime data.
- Keep notebook/artifact manifest-reference validation and the existing Artifact, Upload, session, and SQLite safety checks intact.

## Scope and non-goals

- This does not relax immutable Artifact or Upload provenance validation.
- This does not migrate managed environment prefixes; they are rebuilt under the relocated data root.
- This does not delete unrelated destination runtime files.

## Acceptance criteria and validation

| Behavior | Evidence |
| --- | --- |
| The reported Environment key no longer blocks a move because of a dirty/orphaned mutable cache | Storage focused tests cover dirty bindings plus orphan `.json` and `.tmp` operation records |
| Immutable Environment manifests remain available after migration | Migration integration test verifies the manifest is copied |
| Stale destination inventory is not retained while unrelated runtime data survives | Integration test seeds both states and verifies exact cleanup scope |
| Pending or corrupt runtime recovery state still blocks migration | Validator tests plus a migration-level pre-copy regression test |
| Artifact staging remains blocked | Provenance validation regression test |
| Type and repository-wide behavior remain valid | Typecheck, lint, and full test suite |

Checks run after rebasing onto the latest `origin/main`:

- `rtk npm test -- --run src/main/storage/provenance-migration-validation.test.ts src/main/storage/migration-service.test.ts`: 83 passed
- `rtk npm run typecheck`: passed
- `rtk npm run lint`: 0 errors, 23 pre-existing warnings
- `rtk npm test`: 591 files passed, 11 skipped; 8,882 tests passed, 140 skipped; 0 failed
- `rtk git diff --check origin/main...HEAD`: passed

## Independent review

Standards and spec reviews completed with no remaining findings. The first spec review identified that an existing destination inventory could survive a move; the implementation now removes that exact cache before staging, and re-review confirmed the issue is resolved.

## Review focus

Please focus on the mutable-cache versus immutable-manifest boundary, the authoritative runtime-journal safety gate, and the scope of destination cache cleanup.

## Remaining risk

The regression is modeled with cross-platform filesystem integration tests, including the exact reported target key, but has not yet been exercised through a packaged Windows UI migration.
