### PR TITLE
refactor(main): centralize runtime wiring

### DIFF
--- a/src/main/acp/ipc.ts
+++ b/src/main/acp/ipc.ts
@@ -36,7 +36,10 @@ import {
 } from '../notifications/task-notifications'
 import { NotebookLocalRpcServer } from '../notebook/local-rpc-server'
 import { NotebookRunRepository } from '../notebook/repository'
-import { NotebookRuntimeService } from '../notebook/runtime-service'
+import {
+  NotebookRuntimeService,
+  type NotebookRuntimeServiceOptions
+} from '../notebook/runtime-service'
 import { resolveConfigRoot, resolveDataRoot } from '../storage-root'
 import type { SettingsService } from '../settings/service'
 import type { UploadRepository } from '../uploads/repository'
@@ -384,7 +387,14 @@ const registerAcpIpcHandlers = (options: AcpIpcOptions): AcpRuntimeCoordinator =
 }
 
 // Creates the shared notebook runtime used by both renderer IPC and agent MCP calls.
-const createDefaultNotebookRuntimeService = (): NotebookRuntimeService => {
+type DefaultNotebookRuntimeServiceDeps = Pick<
+  NotebookRuntimeServiceOptions,
+  'getPackageMirror' | 'getRuntimeEnablement' | 'getManualInterpreters'
+>
+
+const createDefaultNotebookRuntimeService = (
+  deps: DefaultNotebookRuntimeServiceDeps = {}
+): NotebookRuntimeService => {
   const dataRoot = resolveDataRoot()
   const artifactRepository = new ArtifactRepository(dataRoot)
 
@@ -393,8 +403,8 @@ const createDefaultNotebookRuntimeService = (): NotebookRuntimeService => {
     dataRoot,
     projectName: DEFAULT_ARTIFACT_PROJECT_NAME,
     repository: new NotebookRunRepository(dataRoot),
-    // Region default for manage_packages when no mirror is configured; the configured override is
-    // wired in main/ipc.ts via setPackageMirrorResolver once the settings service is constructed.
+    ...deps,
+    // Region default for manage_packages when no mirror is configured.
     locale: app.getLocale(),
     appVersion: app.getVersion(),
     resolveArtifactPath: (request) =>

--- a/src/main/compute/compute-service.ts
+++ b/src/main/compute/compute-service.ts
@@ -7,6 +7,7 @@ import { tmpdir } from 'node:os'
 import type {
   ComputeCallError,
   ComputeHost,
+  ComputeJob,
   DetailsAuthor,
   ExecResult,
   JobResult,
@@ -1300,7 +1301,7 @@ export class ComputeService {
         scpRunner: this.scpRunner,
         hostRepository: this.repository,
         jobRepository: this.jobRepository,
-        onJobUpdated: this.onJobUpdated
+        onJobUpdated: this.handleJobUpdated
       })
     }
 
@@ -1470,16 +1471,13 @@ export class ComputeService {
     return status
   }
 
-  // Internal callback wrapper: when a job transitions to a terminal state, notify ConcurrencyManager
-  // to trigger auto-dispatch of queued jobs. This is called by the JobPoller via onJobUpdated.
-  // Exposed as a method so the JobPoller (or IPC layer) can wire it in production.
-  notifyJobCompleted(job: import('../../shared/compute').ComputeJob): void {
-    const terminalStates = new Set(['success', 'failed', 'timeout', 'error'])
-    if (terminalStates.has(job.status) && this.concurrencyManager) {
-      // Fire-and-forget: ConcurrencyManager.onJobCompleted() is async but we don't await it here
-      // to keep the onJobUpdated callback synchronous (matches the existing pattern).
-      void this.concurrencyManager.onJobCompleted()
-    }
+  // Stable producer-facing sink for every persisted job update, regardless of whether the dispatcher
+  // or poller observed it. ConcurrencyManager owns the combined broadcast-and-drain policy when
+  // queueing is enabled; otherwise this preserves the observer-only behavior used by lightweight
+  // service configurations.
+  handleJobUpdated = (job: ComputeJob): void => {
+    if (this.concurrencyManager) this.concurrencyManager.handleJobUpdated(job)
+    else this.onJobUpdated?.(job)
   }
 }
 

--- a/src/main/compute/concurrency-integration.test.ts
+++ b/src/main/compute/concurrency-integration.test.ts
@@ -4,7 +4,7 @@
 import { mkdtemp, rm } from 'node:fs/promises'
 import { tmpdir } from 'node:os'
 import { join } from 'node:path'
-import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest'
+import { afterEach, beforeEach, describe, expect, it, vi, type Mock } from 'vitest'
 
 import { createProjectDbClient, ensureProjectSchema } from '../projects/prisma-client'
 import { ComputeHostRepository } from './repository'
@@ -58,7 +58,7 @@ describe('ConcurrencyManager integration with ComputeService', () => {
   let jobRepo: ComputeJobRepository
   let service: ComputeService
   let concurrencyManager: ConcurrencyManager
-  let onJobUpdatedSpy: ReturnType<typeof vi.fn>
+  let onJobUpdatedSpy: Mock<(job: ComputeJob) => void>
 
   beforeEach(async () => {
     storageRoot = await mkdtemp(join(tmpdir(), 'concurrency-int-'))
@@ -82,9 +82,8 @@ describe('ConcurrencyManager integration with ComputeService', () => {
       // Don't immediately transition to running in the mock - let the test control this
     })
 
-    concurrencyManager = new ConcurrencyManager(jobRepo, hostRepo, mockDispatch)
-
     onJobUpdatedSpy = vi.fn()
+    concurrencyManager = new ConcurrencyManager(jobRepo, hostRepo, mockDispatch, onJobUpdatedSpy)
 
     service = new ComputeService(
       makeFakeRunner(),
@@ -93,7 +92,7 @@ describe('ConcurrencyManager integration with ComputeService', () => {
       makeFakeScp(),
       undefined,
       jobRepo,
-      onJobUpdatedSpy as unknown as (job: ComputeJob) => void,
+      undefined,
       undefined,
       storageRoot,
       concurrencyManager
@@ -262,13 +261,14 @@ describe('ConcurrencyManager integration with ComputeService', () => {
       exitCode: 0
     })
 
-    // Trigger onJobCompleted
+    // Route the poller-observed update through the same authoritative sink used by dispatch.
     const job1 = await jobRepo.get(result1.job_id)
-    service.notifyJobCompleted(job1!)
+    service.handleJobUpdated(job1!)
 
     // Wait for async dispatch to complete
     await new Promise((resolve) => setTimeout(resolve, 200))
 
+    expect(onJobUpdatedSpy).toHaveBeenCalledWith(job1)
     // Second job should now be submitted
     const job2Updated = await jobRepo.get(result2.job_id)
     expect(job2Updated?.status).toBe('submitted')
@@ -324,7 +324,7 @@ describe('ConcurrencyManager integration with ComputeService', () => {
     })
 
     const job1 = await jobRepo.get(result1.job_id)
-    service.notifyJobCompleted(job1!)
+    service.handleJobUpdated(job1!)
 
     await new Promise((resolve) => setTimeout(resolve, 200))
 
@@ -408,7 +408,7 @@ describe('ConcurrencyManager integration with ComputeService', () => {
     })
 
     const job1 = await jobRepo.get(result1.job_id)
-    service.notifyJobCompleted(job1!)
+    service.handleJobUpdated(job1!)
 
     await new Promise((resolve) => setTimeout(resolve, 200))
 
@@ -457,7 +457,7 @@ describe('ConcurrencyManager integration with ComputeService', () => {
       })
 
       const job1 = await jobRepo.get(result1.job_id)
-      service.notifyJobCompleted(job1!)
+      service.handleJobUpdated(job1!)
 
       await new Promise((resolve) => setTimeout(resolve, 200))
 

--- a/src/main/compute/concurrency-manager.test.ts
+++ b/src/main/compute/concurrency-manager.test.ts
@@ -1,4 +1,4 @@
-import { describe, it, expect, beforeEach, vi } from 'vitest'
+import { describe, it, expect, beforeEach, vi, type Mock } from 'vitest'
 import { ConcurrencyManager } from './concurrency-manager'
 import type { ComputeJobRepository } from './job-repository'
 import type { ComputeHostRepository } from './repository'
@@ -33,20 +33,24 @@ const createMockHostRepo = (): ComputeHostRepository =>
     delete: vi.fn()
   }) as unknown as ComputeHostRepository
 
-const createMockDispatchJob = (): ((jobId: string) => Promise<void>) =>
-  vi.fn(() => Promise.resolve())
+const createMockDispatchJob = (): ((
+  jobId: string,
+  onJobUpdated: (job: ComputeJob) => void
+) => Promise<void>) => vi.fn(() => Promise.resolve())
 
 describe('ConcurrencyManager', () => {
   let jobRepo: ComputeJobRepository
   let hostRepo: ComputeHostRepository
   let dispatchJob: ReturnType<typeof createMockDispatchJob>
+  let onJobUpdated: Mock<(job: ComputeJob) => void>
   let manager: ConcurrencyManager
 
   beforeEach(() => {
     jobRepo = createMockJobRepo()
     hostRepo = createMockHostRepo()
     dispatchJob = createMockDispatchJob()
-    manager = new ConcurrencyManager(jobRepo, hostRepo, dispatchJob)
+    onJobUpdated = vi.fn()
+    manager = new ConcurrencyManager(jobRepo, hostRepo, dispatchJob, onJobUpdated)
   })
 
   describe('setSessionLimit', () => {
@@ -263,7 +267,7 @@ describe('ConcurrencyManager', () => {
 
       // Should dispatch job-1 first (earlier createdAt)
       expect(jobRepo.update).toHaveBeenCalledWith('job-1', { status: 'submitted' })
-      expect(dispatchJob).toHaveBeenCalledWith('job-1')
+      expect(dispatchJob).toHaveBeenCalledWith('job-1', expect.any(Function))
     })
 
     it('re-checks both session limit and provider ceiling', async () => {
@@ -291,7 +295,7 @@ describe('ConcurrencyManager', () => {
       expect(jobRepo.countActiveBySession).toHaveBeenCalledWith('session-1')
       expect(jobRepo.countActiveByProvider).toHaveBeenCalledWith('ssh:cluster-a')
       expect(jobRepo.update).toHaveBeenCalledWith('job-1', { status: 'submitted' })
-      expect(dispatchJob).toHaveBeenCalledWith('job-1')
+      expect(dispatchJob).toHaveBeenCalledWith('job-1', expect.any(Function))
     })
 
     it('skips jobs that still violate session limit', async () => {
@@ -374,8 +378,8 @@ describe('ConcurrencyManager', () => {
 
       expect(jobRepo.update).toHaveBeenCalledTimes(2)
       expect(dispatchJob).toHaveBeenCalledTimes(2)
-      expect(dispatchJob).toHaveBeenNthCalledWith(1, 'job-1')
-      expect(dispatchJob).toHaveBeenNthCalledWith(2, 'job-2')
+      expect(dispatchJob).toHaveBeenNthCalledWith(1, 'job-1', expect.any(Function))
+      expect(dispatchJob).toHaveBeenNthCalledWith(2, 'job-2', expect.any(Function))
     })
   })
 
@@ -510,7 +514,10 @@ describe('ConcurrencyManager', () => {
       vi.mocked(hostRepo.get).mockResolvedValue({
         concurrencyLimit: 10
       } as ComputeHost)
-      vi.mocked(jobRepo.update).mockResolvedValue({} as ComputeJob)
+      const failedJob = { ...queuedJobs[0], status: 'error' as const }
+      vi.mocked(jobRepo.update)
+        .mockResolvedValueOnce({ ...queuedJobs[0], status: 'submitted' } as ComputeJob)
+        .mockResolvedValueOnce(failedJob)
 
       // Simulate dispatchJob failure
       vi.mocked(dispatchJob).mockRejectedValueOnce(new Error('SSH connection failed'))
@@ -525,6 +532,7 @@ describe('ConcurrencyManager', () => {
         errorCode: 'dispatch_failed',
         finishedAt: expect.any(Date)
       })
+      expect(onJobUpdated).toHaveBeenCalledWith(failedJob)
     })
 
     it('continues processing next queued job after dispatch failure', async () => {
@@ -569,7 +577,7 @@ describe('ConcurrencyManager', () => {
 
       // Second job should still be dispatched
       expect(jobRepo.update).toHaveBeenCalledWith('job-2', { status: 'submitted' })
-      expect(dispatchJob).toHaveBeenCalledWith('job-2')
+      expect(dispatchJob).toHaveBeenCalledWith('job-2', expect.any(Function))
     })
 
     it('prevents concurrent tryDispatchNext execution', async () => {

--- a/src/main/compute/concurrency-manager.ts
+++ b/src/main/compute/concurrency-manager.ts
@@ -1,5 +1,6 @@
 import type { ComputeJobRepository } from './job-repository'
 import type { ComputeHostRepository } from './repository'
+import type { ComputeJob } from '../../shared/compute'
 
 export type SessionStatus = {
   session_limit: number | null
@@ -13,6 +14,14 @@ const DEFAULT_PROVIDER_CEILING = 10
 
 // Global queue limit (max queued jobs across all sessions).
 const GLOBAL_QUEUE_LIMIT = 100
+const TERMINAL_JOB_STATUSES: ReadonlySet<ComputeJob['status']> = new Set([
+  'success',
+  'failed',
+  'timeout',
+  'error'
+])
+
+type DispatchQueuedJob = (jobId: string, onJobUpdated: (job: ComputeJob) => void) => Promise<void>
 
 // Enforces session-level and provider-level concurrency limits for compute jobs.
 // Stores session limits in memory, decides whether jobs should queue or dispatch,
@@ -34,8 +43,17 @@ export class ConcurrencyManager {
   constructor(
     private readonly jobRepository: ComputeJobRepository,
     private readonly hostRepository: ComputeHostRepository,
-    private readonly dispatchJob: (jobId: string) => Promise<void>
+    private readonly dispatchJob: DispatchQueuedJob,
+    private readonly publishJobUpdated: (job: ComputeJob) => void = () => undefined
   ) {}
+
+  // Owns the complete update policy used by ComputeService: publish every persisted projection, then
+  // free and refill queue capacity for terminal states. Dispatcher and poller both receive this bound
+  // handler, and the manager's own fallback persistence uses it below.
+  handleJobUpdated = (job: ComputeJob): void => {
+    this.publishJobUpdated(job)
+    if (TERMINAL_JOB_STATUSES.has(job.status)) void this.onJobCompleted()
+  }
 
   // Set session-level concurrency limit (stored in memory, not persisted).
   setSessionLimit(sessionId: string, limit: number): void {
@@ -189,14 +207,15 @@ export class ConcurrencyManager {
         if (!reserved) continue // limits hit — leave queued for a future completion
 
         try {
-          await this.dispatchJob(job.job_id)
+          await this.dispatchJob(job.job_id, this.handleJobUpdated)
         } catch {
           // If dispatch fails, mark job as error and continue to next queued job.
-          await this.jobRepository.update(job.job_id, {
+          const updated = await this.jobRepository.update(job.job_id, {
             status: 'error',
             errorCode: 'dispatch_failed',
             finishedAt: new Date()
           })
+          this.handleJobUpdated(updated)
         }
       }
     } finally {

--- a/src/main/compute/ipc.ts
+++ b/src/main/compute/ipc.ts
@@ -264,54 +264,44 @@ const createComputeHandlers = (
   // jobs when a slot frees up. It is wired here (not in ComputeService) because it needs a
   // dispatchJob closure carrying the same runner/scp/repository deps the dispatcher uses. Only built
   // for the production path — tests inject their own service and drive the manager directly.
-  let service: ComputeService
-  if (injectedService) {
-    service = injectedService
-  } else {
-    const sshRunner = new SystemSshRunner()
-    const scpRunner = new SystemScpRunner()
+  const service =
+    injectedService ??
+    (() => {
+      const sshRunner = new SystemSshRunner()
+      const scpRunner = new SystemScpRunner()
 
-    // Terminal transitions must both broadcast to the renderer AND wake the ConcurrencyManager so
-    // the next queued job dispatches. The dispatcher (submitted→running/error) flows through this
-    // hook, so an error during dispatch drains the queue too.
-    //
-    // DRAIN CONTRACT (two sites, keep in sync): this hook covers dispatcher-observed transitions.
-    // Poller-observed terminal transitions (success/failed/timeout of a running job) are drained
-    // separately in src/main/ipc.ts, which composes the broadcaster with
-    // computeService.notifyJobCompleted(). The two paths cover disjoint transitions — do not remove
-    // either without moving its responsibility to the other, or queued jobs stop dispatching.
-    let concurrencyManager: ConcurrencyManager | undefined
-    const TERMINAL = new Set(['success', 'failed', 'timeout', 'error'])
-    const onJobUpdatedWithDrain = (job: ComputeJob): void => {
-      onJobUpdated?.(job)
-      if (TERMINAL.has(job.status)) void concurrencyManager?.onJobCompleted()
-    }
+      // ConcurrencyManager owns the complete publish-and-drain policy. It hands that same bound
+      // sink to queued dispatches, while ComputeService delegates direct dispatch and poller updates
+      // to it. This keeps one contract without a construction-order callback box.
+      const concurrencyManager = jobRepository
+        ? new ConcurrencyManager(
+            jobRepository,
+            repository,
+            (queuedJobId, handleJobUpdated) =>
+              dispatchJob(queuedJobId, {
+                runner: sshRunner,
+                scpRunner,
+                hostRepository: repository,
+                jobRepository,
+                onJobUpdated: handleJobUpdated
+              }),
+            onJobUpdated
+          )
+        : undefined
 
-    if (jobRepository) {
-      concurrencyManager = new ConcurrencyManager(jobRepository, repository, (queuedJobId) =>
-        dispatchJob(queuedJobId, {
-          runner: sshRunner,
-          scpRunner,
-          hostRepository: repository,
-          jobRepository,
-          onJobUpdated: onJobUpdatedWithDrain
-        })
+      return new ComputeService(
+        sshRunner,
+        repository,
+        broker,
+        scpRunner,
+        undefined,
+        jobRepository,
+        undefined,
+        artifactResolver,
+        storageRoot,
+        concurrencyManager
       )
-    }
-
-    service = new ComputeService(
-      sshRunner,
-      repository,
-      broker,
-      scpRunner,
-      undefined,
-      jobRepository,
-      onJobUpdatedWithDrain,
-      artifactResolver,
-      storageRoot,
-      concurrencyManager
-    )
-  }
+    })()
 
   return {
     list: () => repository.list(),

--- a/src/main/compute/job-runtime.test.ts
+++ b/src/main/compute/job-runtime.test.ts
@@ -1,0 +1,59 @@
+import { describe, expect, it, vi } from 'vitest'
+
+import type { ComputeJob } from '../../shared/compute'
+import type { JobPollerDeps } from './job-poller'
+import type { ComputeJobRepository } from './job-repository'
+import type { ComputeHostRepository } from './repository'
+import type { ScpRunner } from './scp-runner'
+import type { SshRunner } from './ssh-runner'
+import { createComputeJobRuntime } from './job-runtime'
+
+describe('createComputeJobRuntime', () => {
+  it('routes poller updates through the service-owned broadcast and drain seam', async () => {
+    const handleJobUpdated = vi.fn()
+    const start = vi.fn()
+    const stop = vi.fn()
+    const runner = {} as SshRunner
+    const scpRunner = {} as ScpRunner
+    const hostRepository = {} as ComputeHostRepository
+    const jobRepository = {} as ComputeJobRepository
+    const broadcast = vi.fn()
+    const harvest = vi.fn(async () => undefined)
+    let wiredPollerDeps: JobPollerDeps | undefined
+    const createPoller = vi.fn((deps: JobPollerDeps) => {
+      wiredPollerDeps = deps
+      return { start, stop }
+    })
+    const runtime = createComputeJobRuntime(
+      {
+        computeService: { handleJobUpdated },
+        hostRepository,
+        jobRepository,
+        storageRoot: '/data'
+      },
+      { runner, scpRunner, broadcast, harvest, createPoller }
+    )
+    const pollerDeps = wiredPollerDeps
+    expect(pollerDeps).toBeDefined()
+    const job = {
+      job_id: 'job-1',
+      provider_id: 'ssh:cluster',
+      status: 'success'
+    } as ComputeJob
+
+    pollerDeps?.onJobUpdated?.(job)
+    await pollerDeps?.harvestFn?.(job)
+    runtime.start()
+
+    expect(handleJobUpdated).toHaveBeenCalledWith(job)
+    expect(harvest).toHaveBeenCalledWith(job, {
+      sshRunner: runner,
+      scpRunner,
+      hostRepository,
+      jobRepository,
+      storageRoot: '/data',
+      broadcast
+    })
+    expect(start).toHaveBeenCalledTimes(1)
+  })
+})

--- a/src/main/compute/job-runtime.ts
+++ b/src/main/compute/job-runtime.ts
@@ -1,0 +1,59 @@
+import { broadcastJobUpdated } from './ipc'
+import { harvestJob } from './harvest-engine'
+import { JobPoller, type JobPollerDeps } from './job-poller'
+import type { ComputeJobRepository } from './job-repository'
+import type { ComputeHostRepository } from './repository'
+import type { ComputeService } from './compute-service'
+import { SystemScpRunner, type ScpRunner } from './scp-runner'
+import { SystemSshRunner, type SshRunner } from './ssh-runner'
+
+type ComputeJobRuntime = Pick<JobPoller, 'start' | 'stop'>
+
+type ComputeJobRuntimeDeps = {
+  computeService: Pick<ComputeService, 'handleJobUpdated'>
+  hostRepository: ComputeHostRepository
+  jobRepository: ComputeJobRepository
+  storageRoot: string
+}
+
+type ComputeJobRuntimeAdapters = {
+  runner?: SshRunner
+  scpRunner?: ScpRunner
+  broadcast?: typeof broadcastJobUpdated
+  harvest?: typeof harvestJob
+  createPoller?: (deps: JobPollerDeps) => ComputeJobRuntime
+}
+
+// Owns the production poller's complete job-update contract. Main-process startup supplies only the
+// long-lived compute handles; every update is routed through ComputeService, while notifications and
+// harvesting retain their dedicated projections.
+export const createComputeJobRuntime = (
+  deps: ComputeJobRuntimeDeps,
+  adapters: ComputeJobRuntimeAdapters = {}
+): ComputeJobRuntime => {
+  const runner = adapters.runner ?? new SystemSshRunner()
+  const scpRunner = adapters.scpRunner ?? new SystemScpRunner()
+  const broadcast = adapters.broadcast ?? broadcastJobUpdated
+  const harvest = adapters.harvest ?? harvestJob
+  const pollerDeps: JobPollerDeps = {
+    runner,
+    hostRepository: deps.hostRepository,
+    jobRepository: deps.jobRepository,
+    onJobUpdated: deps.computeService.handleJobUpdated,
+    broadcast,
+    storageRoot: deps.storageRoot,
+    harvestFn: (job) =>
+      harvest(job, {
+        sshRunner: runner,
+        scpRunner,
+        hostRepository: deps.hostRepository,
+        jobRepository: deps.jobRepository,
+        storageRoot: deps.storageRoot,
+        broadcast
+      })
+  }
+
+  return adapters.createPoller?.(pollerDeps) ?? new JobPoller(pollerDeps)
+}
+
+export type { ComputeJobRuntime, ComputeJobRuntimeAdapters, ComputeJobRuntimeDeps }

--- a/src/main/ipc.ts
+++ b/src/main/ipc.ts
@@ -10,16 +10,9 @@ import { createDefaultArtifactRepository, registerArtifactIpcHandlers } from './
 import { ArtifactProvenanceRepository } from './artifacts/provenance-repository'
 import { ProvenanceMessageSnapshotRepository } from './artifacts/provenance-message-snapshot'
 import { ArtifactRunRegistry } from './artifacts/run-registry'
-import {
-  registerComputeIpcHandlers,
-  createJobUpdatedBroadcaster,
-  broadcastJobUpdated
-} from './compute/ipc'
+import { registerComputeIpcHandlers } from './compute/ipc'
 import { attachEnabledComputeHosts } from './compute/enabled-hosts-registry'
-import { JobPoller } from './compute/job-poller'
-import { SystemSshRunner } from './compute/ssh-runner'
-import { SystemScpRunner } from './compute/scp-runner'
-import { harvestJob } from './compute/harvest-engine'
+import { createComputeJobRuntime } from './compute/job-runtime'
 import { waitForInitialConnectorRefresh, wireConnectorReload } from './connector-reload'
 import { ApprovalBroker } from './connectors/approval-broker'
 import { toCustomMcpConfig, selectEnabledCustomServers } from './connectors/custom-mcp-bootstrap'
@@ -121,6 +114,7 @@ import {
   samePath
 } from './storage-root'
 import { registerUpdateIpcHandlers } from './update/ipc'
+import { createUpdateStrategy } from './update/create-strategy'
 import { startUpdateScheduler } from './update/scheduler'
 import { createDefaultUploadRepository, registerUploadIpcHandlers } from './uploads/ipc'
 import { broadcastToRenderers } from './renderer-broadcast'
@@ -374,7 +368,11 @@ const registerIpcHandlers = async ({
       return sessionPersistenceCoordinator.saveManifest(request)
     }
   }
-  const notebookService = createDefaultNotebookRuntimeService()
+  const notebookService = createDefaultNotebookRuntimeService({
+    getPackageMirror: () => settingsService.getPackageMirror(),
+    getRuntimeEnablement: (language) => settingsService.getRuntimeEnablement(language),
+    getManualInterpreters: (language) => settingsService.getManualInterpreters(language)
+  })
 
   // Read fresh on every call so a future connectors-settings mutation (Plan 2 UI) only needs to call
   // refreshConnectorSkillDocs again to take effect, without reconstructing the connector service.
@@ -517,37 +515,11 @@ const registerIpcHandlers = async ({
   // (inside ComputeService) uses the same hook, so submitted→running/error transitions broadcast too.
   // Phase 3b: harvestFn drives automatic harvest on terminal transitions; broadcast + storageRoot
   // wire the compute_done notification emitter for all three terminal outcomes (issue 06).
-  const sshRunner = new SystemSshRunner()
-  const scpRunner = new SystemScpRunner()
-  // Poller-observed terminal transitions (success/failed/timeout of originally-submitted jobs) must
-  // both broadcast to the renderer AND wake the ConcurrencyManager so the next queued job dispatches
-  // when a slot frees. Compose the broadcaster with computeService.notifyJobCompleted (a no-op for
-  // non-terminal states and when no ConcurrencyManager is wired).
-  //
-  // DRAIN CONTRACT (two sites, keep in sync): this covers poller-observed completions. Dispatcher-
-  // observed transitions (submitted→running/error) are drained inside registerComputeIpcHandlers via
-  // onJobUpdatedWithDrain (src/main/compute/ipc.ts). Dropping the notifyJobCompleted call below would
-  // silently stop queued jobs from dispatching on completion — with no test failure at this seam.
-  const broadcastJobUpdatedHook = createJobUpdatedBroadcaster(hostRepository, dataRoot)
-  const jobPoller = new JobPoller({
-    runner: sshRunner,
+  const jobPoller = createComputeJobRuntime({
+    computeService,
     hostRepository,
     jobRepository,
-    onJobUpdated: (job) => {
-      broadcastJobUpdatedHook(job)
-      computeService.notifyJobCompleted(job)
-    },
-    broadcast: broadcastJobUpdated,
-    storageRoot: dataRoot,
-    harvestFn: (job) =>
-      harvestJob(job, {
-        sshRunner,
-        scpRunner,
-        hostRepository,
-        jobRepository,
-        storageRoot: dataRoot,
-        broadcast: broadcastJobUpdated
-      })
+    storageRoot: dataRoot
   })
   jobPoller.start()
   // Augment computeService with getEnabledComputeHosts so the RPC server can serve list_compute.
@@ -579,21 +551,6 @@ const registerIpcHandlers = async ({
   notebookService.setMcpRpcConnectionResolver(({ sessionId, projectId }) =>
     notebookRpcServer.issueControlConnection(sessionId, projectId)
   )
-  // Same construction-order constraint as the RPC connection above: the runtime service is created
-  // before the settings service, so the package-mirror lookup is wired in after the fact.
-  notebookService.setPackageMirrorResolver(() => settingsService.getPackageMirror())
-  // v4 per-language enablement (which discovered runtimes the agent may bind). Same construction-order
-  // reason as above; unwired -> the provenance defaults keep the enable gate closed for BYO envs.
-  notebookService.setRuntimeEnablementResolver((language) =>
-    settingsService.getRuntimeEnablement(language)
-  )
-  // Fold the manually-added interpreter catalog into the service's discovery too, so an interpreter
-  // added via "Add interpreter…" (not on PATH) is bindable by the agent and survives a restart instead
-  // of resolving to 'missing'. Same construction-order reason as the resolvers above.
-  notebookService.setManualInterpretersResolver((language) =>
-    settingsService.getManualInterpreters(language)
-  )
-
   // The renderer's approval card responds here; the broker resolves the held connector call.
   ipcMainHandle('connectors:approval-respond', (_event, request: RespondApprovalRequest) => {
     approvalBroker.respond(request.id, request.decision)
@@ -653,8 +610,6 @@ const registerIpcHandlers = async ({
   registerCliInstallIpcHandlers()
   registerWindowIpcHandlers()
   registerWindowFindIpcHandlers()
-  const updateService = registerUpdateIpcHandlers()
-  startUpdateScheduler(updateService)
   // ACP identity resolution and the Specialist settings IPC must use the same service instance.
   // Creating it only for settings leaves create-session unable to resolve a selected UUID.
   const runtime = registerAcpIpcHandlers({
@@ -687,19 +642,21 @@ const registerIpcHandlers = async ({
   runtimeRef.current = runtime
   permissionGrantRegistry.subscribe(() => runtime.notifyPermissionGrantsChanged())
   // Single shared teardown owner for both the before-quit handler (index.ts) and the pre-update-install
-  // gate. Built here because it needs the runtime, which does not exist when update IPC is registered
-  // above — so the gate is injected via a late-bound closure rather than at strategy construction.
+  // gate. Update handling is deliberately constructed below, after this dependency is complete.
   const shutdownCoordinator = new BackendShutdownCoordinator({
     runtime,
     notebook: notebookService,
     log: createLogger('shutdown')
   })
-  // Reap the agent + kernel trees before an in-place install so the NSIS uninstall step never hits files
-  // still locked by a background child. Non-latching, so a refused (degraded) install leaves the app
-  // usable. No-op on the manifest fallback strategy, which does not implement setInstallGate.
-  updateService.setInstallGate?.(() =>
-    shutdownCoordinator.runForUpdateGate(UPDATE_SHUTDOWN_BUDGET_MS)
+  // Construct update handling only after its backend-shutdown gate exists. The in-place strategy owns
+  // this immutable dependency from construction; the manifest fallback ignores it because it does not
+  // quit the running app to install.
+  const updateService = registerUpdateIpcHandlers(
+    createUpdateStrategy(process.platform, {
+      installGate: () => shutdownCoordinator.runForUpdateGate(UPDATE_SHUTDOWN_BUDGET_MS)
+    })
   )
+  startUpdateScheduler(updateService)
   // Spawn-config changes rotate the coordinator's runtime for future sessions. Existing sessions retain
   // their owning runtime, so a framework/provider switch cannot interrupt an in-flight turn.
   let invalidatePermissionProjection = (): void => {

--- a/src/main/notebook/runtime-service.test.ts
+++ b/src/main/notebook/runtime-service.test.ts
@@ -6115,14 +6115,14 @@ describe('v4 runtime bindings & agent tools', () => {
     expect(removed).toEqual(['my-analysis'])
   })
 
-  // End-to-end wiring of setManualInterpretersResolver: a Settings-added interpreter is folded into the
+  // End-to-end constructor wiring of getManualInterpreters: a Settings-added interpreter is folded into the
   // service's REAL default discovery (NOT an injected discoverRuntimes), so it becomes discoverable,
   // enable-able, and bindable — and survives a restart (a fresh service with the same resolver still
   // resolves it active, not 'missing'). Exercises the actual manualInterpretersResolver seam with a real
   // executable interpreter so the version probe + runnability classification run for real. POSIX-only:
   // it relies on a chmod-executable shell shim, which Windows can't run as `<path> --version`.
   it.skipIf(process.platform === 'win32')(
-    'discovers, binds, and (across a restart) keeps a manual interpreter added via setManualInterpretersResolver',
+    'discovers, binds, and (across a restart) keeps a constructor-injected manual interpreter',
     async () => {
       // Real discovery is exercised (no injected discoverRuntimes): it enumerates PATH + conda roots and
       // probes every real interpreter's `--version`, and it runs on each list/bind/execute/restart call —
@@ -6159,6 +6159,7 @@ describe('v4 runtime bindings & agent tools', () => {
           projectName: 'default-project',
           repository: new NotebookRunRepository(root),
           getRuntimeEnablement: async () => enablement,
+          getManualInterpreters: resolver,
           executorFactory: () => ({
             execute: async (request): Promise<NotebookExecutionResult> => {
               executions.push(request)
@@ -6175,7 +6176,6 @@ describe('v4 runtime bindings & agent tools', () => {
             terminate: async () => undefined
           })
         })
-        service.setManualInterpretersResolver(resolver)
         return service
       }
 

--- a/src/main/notebook/runtime-service.ts
+++ b/src/main/notebook/runtime-service.ts
@@ -346,16 +346,17 @@ type NotebookRuntimeServiceOptions = {
   // construction via setMcpRpcConnectionResolver, since the RPC server is constructed with this
   // service as a dependency (constructing them in the other order would cycle).
   getMcpRpcConnection?: (binding: McpRpcConnectionBinding) => Promise<McpRpcConnection>
-  // Resolves the user-configured package mirror (settings). Usually set after construction via
-  // setPackageMirrorResolver, mirroring getMcpRpcConnection above — kept optional/async so a
-  // synchronous test double works just as well as the real (disk-backed) settings service.
+  // Resolves the user-configured package mirror (settings). Optional/async so a synchronous test
+  // double works just as well as the real disk-backed settings service.
   getPackageMirror?: () => PackageMirror | undefined | Promise<PackageMirror | undefined>
   // Resolves the v4 per-language enablement (enabled/install-authorized maps) used to gate which
-  // discovered runtimes the agent may bind. Usually wired after construction via
-  // setRuntimeEnablementResolver (settings service). Undefined / returning undefined -> the provenance
-  // defaults (app-managed enabled; user-own disabled), so an unwired resolver can never enable a BYO
-  // env — the enable gate holds by default (defense-in-depth).
+  // discovered runtimes the agent may bind. Undefined / returning undefined -> the provenance defaults
+  // (app-managed enabled; user-own disabled), so an omitted resolver can never enable a BYO env — the
+  // enable gate holds by default (defense-in-depth).
   getRuntimeEnablement?: (language: NotebookLanguage) => Promise<RuntimeEnablement | undefined>
+  // Resolves Settings-added interpreters that are not discoverable from PATH/conda roots. Injected at
+  // construction so production cannot briefly expose a different catalog during startup.
+  getManualInterpreters?: (language: NotebookLanguage) => Promise<string[]>
   // Discovers the interpreters available for a language (app-managed + user-own). Injectable so tests
   // don't spawn real interpreters; production defaults to environment-discovery over the runtime root.
   discoverRuntimes?: (language: NotebookLanguage) => Promise<DiscoveredInterpreter[]>
@@ -1069,14 +1070,14 @@ class NotebookRuntimeService {
   private runSequence = 0
   private mcpRpcConnectionResolver:
     ((binding: McpRpcConnectionBinding) => Promise<McpRpcConnection>) | undefined
-  private packageMirrorResolver:
+  private readonly packageMirrorResolver:
     (() => PackageMirror | undefined | Promise<PackageMirror | undefined>) | undefined
-  private runtimeEnablementResolver:
+  private readonly runtimeEnablementResolver:
     ((language: NotebookLanguage) => Promise<RuntimeEnablement | undefined>) | undefined
   // Manually-added interpreter paths (Settings catalog) folded into discovery so a picked interpreter
   // that is NOT on PATH / in a conda root is still discovered here — and therefore bindable and not
-  // reported 'missing' after a restart. Wired post-construction like the enablement resolver.
-  private manualInterpretersResolver:
+  // reported 'missing' after a restart. Fixed at construction with the other Settings dependencies.
+  private readonly manualInterpretersResolver:
     ((language: NotebookLanguage) => Promise<string[]>) | undefined
   // Resolves when startup crash-recovery has finished; awaited by materialize/install so their prefix
   // work never races recovery's cleanup. Undefined until recoverInterruptedOperations is kicked off.
@@ -1151,6 +1152,7 @@ class NotebookRuntimeService {
     this.mcpRpcConnectionResolver = options.getMcpRpcConnection
     this.packageMirrorResolver = options.getPackageMirror
     this.runtimeEnablementResolver = options.getRuntimeEnablement
+    this.manualInterpretersResolver = options.getManualInterpreters
     this.runtimeDiscoveryImpl =
       options.discoverRuntimes ??
       (async (language) => {
@@ -1668,29 +1670,6 @@ class NotebookRuntimeService {
     resolver: (binding: McpRpcConnectionBinding) => Promise<McpRpcConnection>
   ): void {
     this.mcpRpcConnectionResolver = resolver
-  }
-
-  // Wires the package-mirror lookup after construction (typically the settings service, constructed
-  // alongside/after this one in main/ipc.ts), mirroring setMcpRpcConnectionResolver above.
-  setPackageMirrorResolver(
-    resolver: () => PackageMirror | undefined | Promise<PackageMirror | undefined>
-  ): void {
-    this.packageMirrorResolver = resolver
-  }
-
-  // Wires the per-language enablement lookup after construction (settings service), mirroring the
-  // resolvers above. Absent -> the provenance defaults, so a BYO env is never enabled until this is
-  // wired AND the user turns it on — the enable gate holds by default.
-  setRuntimeEnablementResolver(
-    resolver: (language: NotebookLanguage) => Promise<RuntimeEnablement | undefined>
-  ): void {
-    this.runtimeEnablementResolver = resolver
-  }
-
-  // Wires the manual-interpreter catalog lookup after construction, so the service's discovery folds in
-  // Settings-added interpreters (same set the Settings survey sees). Absent -> only PATH/conda/app envs.
-  setManualInterpretersResolver(resolver: (language: NotebookLanguage) => Promise<string[]>): void {
-    this.manualInterpretersResolver = resolver
   }
 
   // Starts an exclusive agent/user write stream into a cell and locks notebook editing.

--- a/src/main/update/create-strategy.test.ts
+++ b/src/main/update/create-strategy.test.ts
@@ -1,6 +1,7 @@
 import { beforeEach, describe, expect, it, vi } from 'vitest'
 
 const spawnSync = vi.hoisted(() => vi.fn())
+const quitAndInstall = vi.hoisted(() => vi.fn())
 
 vi.mock('node:child_process', () => ({ spawnSync }))
 
@@ -16,7 +17,12 @@ vi.mock('electron', () => ({
   BrowserWindow: { getAllWindows: () => [] }
 }))
 vi.mock('electron-updater', () => ({
-  autoUpdater: { on: () => {}, autoDownload: true, autoInstallOnAppQuit: true }
+  autoUpdater: {
+    on: () => {},
+    autoDownload: true,
+    autoInstallOnAppQuit: true,
+    quitAndInstall
+  }
 }))
 
 import { createUpdateStrategy } from './create-strategy'
@@ -26,6 +32,7 @@ import { UpdateService } from './service'
 describe('createUpdateStrategy', () => {
   beforeEach(() => {
     spawnSync.mockReset()
+    quitAndInstall.mockReset()
     spawnSync.mockReturnValue({
       status: 0,
       stdout: '',
@@ -39,6 +46,16 @@ describe('createUpdateStrategy', () => {
 
   it('uses ElectronUpdaterStrategy on linux', () => {
     expect(createUpdateStrategy('linux')).toBeInstanceOf(ElectronUpdaterStrategy)
+  })
+
+  it('constructs the in-place strategy with its install gate', async () => {
+    const installGate = vi.fn(async () => ({ completed: true, reaped: true }))
+    const strategy = createUpdateStrategy('win32', { installGate })
+
+    await strategy.apply()
+
+    expect(installGate).toHaveBeenCalledTimes(1)
+    expect(quitAndInstall).toHaveBeenCalledWith(true, true)
   })
 
   it('uses ElectronUpdaterStrategy on darwin for a packaged stable build', () => {

--- a/src/main/update/create-strategy.ts
+++ b/src/main/update/create-strategy.ts
@@ -5,13 +5,16 @@ import { app } from 'electron'
 
 import { ElectronUpdaterStrategy } from './electron-updater-strategy'
 import { UpdateService } from './service'
-import type { UpdateStrategy } from './strategy'
+import type { InstallGate, UpdateStrategy } from './strategy'
 
 export type CreateStrategyOptions = {
   // Whether this is a packaged (installed) build. Defaults to app.isPackaged; injectable for tests.
   isPackaged?: boolean
   // Running app version. Defaults to app.getVersion(); injectable for tests.
   version?: string
+  // Immutable pre-install backend shutdown gate for in-place strategies. The manual installer flow
+  // ignores it because applying there does not quit or replace the running app.
+  installGate?: InstallGate
 }
 
 const OFFICIAL_MAC_BUNDLE_ID = 'com.aipoch.open-science'
@@ -50,12 +53,15 @@ export const createUpdateStrategy = (
   platform: NodeJS.Platform = process.platform,
   opts: CreateStrategyOptions = {}
 ): UpdateStrategy => {
-  if (platform === 'win32' || platform === 'linux') return new ElectronUpdaterStrategy()
+  const createInPlaceStrategy = (): ElectronUpdaterStrategy =>
+    new ElectronUpdaterStrategy(opts.installGate ? { installGate: opts.installGate } : {})
+
+  if (platform === 'win32' || platform === 'linux') return createInPlaceStrategy()
 
   const isPackaged = opts.isPackaged ?? app?.isPackaged ?? false
   const version = opts.version ?? app?.getVersion?.() ?? '0.0.0'
   if (platform === 'darwin' && macCanAutoUpdate(isPackaged, version)) {
-    return new ElectronUpdaterStrategy()
+    return createInPlaceStrategy()
   }
   return new UpdateService()
 }

--- a/src/main/update/electron-updater-strategy.test.ts
+++ b/src/main/update/electron-updater-strategy.test.ts
@@ -273,9 +273,9 @@ describe('ElectronUpdaterStrategy', () => {
     const strategy = new ElectronUpdaterStrategy({
       updater,
       currentVersion: '0.2.0',
-      broadcast: vi.fn()
+      broadcast: vi.fn(),
+      installGate: gate
     })
-    strategy.setInstallGate(gate)
 
     await strategy.apply()
 

--- a/src/main/update/electron-updater-strategy.ts
+++ b/src/main/update/electron-updater-strategy.ts
@@ -43,7 +43,7 @@ export type ElectronUpdaterDeps = {
   // Injectable for tests; defaults to the public stable manifest.
   fetchImpl?: typeof fetch
   manifestUrl?: string
-  // Pre-install backend-shutdown gate; usually injected later via setInstallGate once the runtime exists.
+  // Pre-install backend-shutdown gate, fixed when the strategy is constructed.
   installGate?: InstallGate
   // Diagnostics sink for the apply path; defaults to a no-op so unit tests stay quiet.
   log?: UpdaterLogger
@@ -174,8 +174,8 @@ export class ElectronUpdaterStrategy implements UpdateStrategy {
   // In-flight manifest notes fetch for the current update, awaited by check() so the returned
   // status reflects the hydrated notes.
   private notesHydration?: Promise<void>
-  // Pre-install backend-shutdown gate, injected once the runtime exists (see ipc.ts).
-  private installGate?: InstallGate
+  // Pre-install backend-shutdown gate, owned immutably for the strategy lifetime.
+  private readonly installGate?: InstallGate
 
   constructor(deps: ElectronUpdaterDeps = {}) {
     this.updater = deps.updater ?? (autoUpdater as unknown as MinimalAutoUpdater)
@@ -207,10 +207,6 @@ export class ElectronUpdaterStrategy implements UpdateStrategy {
     this.updater.autoDownload = false
     this.updater.autoInstallOnAppQuit = false
     this.subscribe()
-  }
-
-  setInstallGate(gate: InstallGate): void {
-    this.installGate = gate
   }
 
   private subscribe(): void {

--- a/src/main/update/strategy.ts
+++ b/src/main/update/strategy.ts
@@ -5,9 +5,9 @@ import type { UpdateStatus } from '../../shared/update'
 // ShutdownOutcome so the coordinator satisfies it without coupling update code to that module.
 export type InstallReadiness = { completed: boolean; reaped: boolean }
 
-// Runs backend teardown before an in-place install and reports whether it is safe to proceed. Injected
-// after the runtime exists; the in-place (NSIS/Squirrel) strategy awaits it before quitAndInstall so it
-// never triggers the installer's uninstall step while a background process still holds app files open.
+// Runs backend teardown before an in-place install and reports whether it is safe to proceed. The
+// in-place strategy receives it at construction and awaits it before quitAndInstall, so the installer
+// never starts while a background process still holds app files open.
 export type InstallGate = () => Promise<InstallReadiness>
 
 // The platform-agnostic update contract the IPC layer and scheduler drive. Two implementations exist:
@@ -23,7 +23,4 @@ export interface UpdateStrategy {
   cancel(): Promise<UpdateStatus>
   // Applies a ready update: open the installer (mac) or quitAndInstall (win/linux).
   apply(): Promise<UpdateStatus>
-  // Optional: inject the pre-install backend-shutdown gate. Only the in-place strategy uses it; the
-  // manifest fallback (which opens an installer without quitting the running app) leaves it unset.
-  setInstallGate?(gate: InstallGate): void
 }


### PR DESCRIPTION
## Problem

The main-process composition root had two manually synchronized compute job drain contracts: dispatcher-observed terminal updates and poller-observed terminal updates each had to broadcast and wake the queued-job drain separately. It also completed several stable dependencies after construction through late-bound setters, making startup order part of the runtime contract.

## Proposed change

- Route dispatcher, queued-dispatch fallback, and poller job updates through one publish-and-terminal-drain policy owned by `ConcurrencyManager`, exposed to producers through `ComputeService.handleJobUpdated`.
- Extract production poller construction into `createComputeJobRuntime` so the complete update, notification, and harvest wiring is tested as one module.
- Constructor-inject notebook package-mirror, runtime-enablement, and manual-interpreter resolvers.
- Constructor-inject the updater install gate and create update IPC only after the shutdown coordinator exists.
- Keep the notebook MCP RPC resolver late-bound because that dependency is a genuine service/server cycle.

```mermaid
flowchart LR
  D["Direct dispatcher"] --> S["ComputeService.handleJobUpdated"]
  P["Job poller"] --> S
  S --> C["ConcurrencyManager.handleJobUpdated"]
  Q["Queued dispatcher"] --> C
  F["Queued dispatch fallback"] --> C
  C --> B["Renderer broadcast"]
  C --> T{"Terminal status?"}
  T -->|yes| R["Drain eligible queued jobs"]
  T -->|no| N["No queue action"]
```

## Scope and non-goals

This is a main-process architecture refactor. It does not change persisted data, the data model, data relationships, IPC payloads, or renderer/user interaction. It does not remove phased initialization that represents a real dependency cycle, including the notebook MCP RPC connection resolver.

## Acceptance criteria and validation

All listed checks ran after the last material production edit. Independent Spec and Standards reviews found no actionable issues in the final commit.

- Unified compute update policy, including queued-dispatch rejection broadcast/drain -> `npm test -- --run src/main/compute/job-runtime.test.ts src/main/compute/concurrency-manager.test.ts src/main/compute/concurrency-integration.test.ts src/main/compute/ipc.test.ts src/main/notebook/runtime-service.test.ts src/main/update/create-strategy.test.ts src/main/update/electron-updater-strategy.test.ts src/main/update/ipc.test.ts` -> 8 files passed, 275 tests passed.
- Notebook constructor injection and updater gate construction -> the same targeted command -> relevant runtime/update tests passed within the 275-test result.
- Cross-module regression -> `npm test` -> 593 files passed, 11 skipped; 8,908 tests passed, 140 skipped.
- Type safety -> `npm run typecheck` -> passed.
- Repository standards -> `npm run lint` -> 0 errors; 23 pre-existing warnings in unchanged files.
- Changed-file formatting -> Prettier check over all 16 changed files -> passed.

Uncovered risk: validation did not boot the full production `registerIpcHandlers` composition root in a packaged Electron application. Constructor/module contracts are covered, and the complete repository test suite passes, but real packaged startup and in-place updater behavior remain outside automated coverage.

## Review focus

- Confirm `ConcurrencyManager` is the correct owner of the combined publish-and-terminal-drain policy.
- Confirm the remaining notebook MCP RPC setter is an intentional cycle boundary.
- Confirm delaying update IPC/scheduler construction until the shutdown coordinator exists has no startup-order assumptions outside this diff.
