### PR TITLE
fix(acp): wait for Claude MCP servers before session start

### DIFF
--- a/patches/@agentclientprotocol+claude-agent-acp+0.60.0.patch
+++ b/patches/@agentclientprotocol+claude-agent-acp+0.60.0.patch
@@ -1,7 +1,80 @@
+diff --git a/node_modules/@agentclientprotocol/claude-agent-acp/dist/acp-agent.d.ts b/node_modules/@agentclientprotocol/claude-agent-acp/dist/acp-agent.d.ts
+index f247a7e..1288e59 100644
+--- a/node_modules/@agentclientprotocol/claude-agent-acp/dist/acp-agent.d.ts
++++ b/node_modules/@agentclientprotocol/claude-agent-acp/dist/acp-agent.d.ts
+@@ -13,6 +13,7 @@ export interface Logger {
+     log: (...args: any[]) => void;
+     error: (...args: any[]) => void;
+ }
++export declare function waitForMcpServers(query: Pick<Query, "mcpServerStatus" | "close">, serverNames: string[], timeoutMs?: number): Promise<void>;
+ type AccumulatedUsage = {
+     inputTokens: number;
+     outputTokens: number;
 diff --git a/node_modules/@agentclientprotocol/claude-agent-acp/dist/acp-agent.js b/node_modules/@agentclientprotocol/claude-agent-acp/dist/acp-agent.js
+index 361d032..1e98b3f 100644
 --- a/node_modules/@agentclientprotocol/claude-agent-acp/dist/acp-agent.js
 +++ b/node_modules/@agentclientprotocol/claude-agent-acp/dist/acp-agent.js
-@@ -2353,7 +2353,7 @@ export class ClaudeAgent {
+@@ -438,6 +438,59 @@ class ClientConnection {
+         return this.ctx.notify(method, params);
+     }
+ }
++// Claude snapshots the available tool set when a model request starts. Wait for every MCP server
++// supplied by the ACP client before returning session/new so the first prompt cannot race startup.
++const MCP_STARTUP_TIMEOUT_MS = 10000;
++const MCP_STATUS_POLL_INTERVAL_MS = 50;
++const delay = (milliseconds) => new Promise((resolve) => setTimeout(resolve, milliseconds));
++const withTimeout = (promise, milliseconds, timeoutError) => new Promise((resolve, reject) => {
++    const timer = setTimeout(() => reject(timeoutError()), milliseconds);
++    promise.then((value) => {
++        clearTimeout(timer);
++        resolve(value);
++    }, (error) => {
++        clearTimeout(timer);
++        reject(error);
++    });
++});
++export async function waitForMcpServers(query, serverNames, timeoutMs = MCP_STARTUP_TIMEOUT_MS) {
++    if (serverNames.length === 0) {
++        return;
++    }
++    const pending = new Set(serverNames);
++    const deadline = Date.now() + timeoutMs;
++    while (pending.size > 0) {
++        const remainingMs = deadline - Date.now();
++        if (remainingMs <= 0) {
++            query.close();
++            throw new Error(`Timed out waiting for MCP servers: ${[...pending].join(", ")}`);
++        }
++        let statuses;
++        try {
++            statuses = await withTimeout(query.mcpServerStatus(), remainingMs, () => new Error(`Timed out waiting for MCP servers: ${[...pending].join(", ")}`));
++        }
++        catch (error) {
++            query.close();
++            throw error;
++        }
++        for (const status of statuses) {
++            if (!pending.has(status.name)) {
++                continue;
++            }
++            if (status.status === "connected") {
++                pending.delete(status.name);
++                continue;
++            }
++            if (status.status === "failed" || status.status === "needs-auth" || status.status === "disabled") {
++                query.close();
++                throw new Error(`MCP server ${status.name} is ${status.status}${status.error ? `: ${status.error}` : ""}`);
++            }
++        }
++        if (pending.size > 0) {
++            await delay(Math.min(MCP_STATUS_POLL_INTERVAL_MS, Math.max(0, deadline - Date.now())));
++        }
++    }
++}
+ export class ClaudeAcpAgent {
+     sessions;
+     client;
+@@ -2353,7 +2406,7 @@ export class ClaudeAcpAgent {
                                      cache_creation_input_tokens: usage.cache_creation_input_tokens ?? prev.cache_creation_input_tokens,
                                  };
                              }
@@ -10,7 +83,7 @@ diff --git a/node_modules/@agentclientprotocol/claude-agent-acp/dist/acp-agent.j
                              if (nextUsage !== lastAssistantTotalUsage) {
                                  lastAssistantTotalUsage = nextUsage;
                                  await sendUpdate({
-@@ -2465,7 +2465,7 @@ export class ClaudeAgent {
+@@ -2465,7 +2518,7 @@ export class ClaudeAcpAgent {
                          // aligned with what the user's current selection is producing.
                          if (message.type === "assistant" && message.parent_tool_use_id === null) {
                              lastAssistantUsage = snapshotFromUsage(message.message.usage);
@@ -19,7 +92,15 @@ diff --git a/node_modules/@agentclientprotocol/claude-agent-acp/dist/acp-agent.j
                              if (message.message.model && message.message.model !== "<synthetic>") {
                                  lastAssistantModel = message.message.model;
                              }
-@@ -4282,15 +4282,10 @@ function sessionUsage(session) {
+@@ -4067,6 +4120,7 @@ export class ClaudeAcpAgent {
+         let initializationResult;
+         try {
+             initializationResult = await q.initializationResult();
++            await waitForMcpServers(q, Object.keys(mcpServers));
+         }
+         catch (error) {
+             if (creationOpts.resume &&
+@@ -4282,15 +4336,10 @@ function sessionUsage(session) {
              session.accumulatedUsage.cachedWriteTokens,
      };
  }
@@ -39,7 +120,7 @@ diff --git a/node_modules/@agentclientprotocol/claude-agent-acp/dist/acp-agent.j
  }
  /**
   * Build the `data` payload attached to a `RequestError.internalError` when we
-@@ -4307,7 +4302,7 @@ function errorKindData(errorKind) {
+@@ -4307,7 +4356,7 @@ function errorKindData(errorKind) {
  }
  /** Project a nullable API usage object into our non-null snapshot shape.
   *  Both SDK message_start and assistant message `usage` have `number | null`

--- a/src/main/acp/claude-agent-acp-patch.test.ts
+++ b/src/main/acp/claude-agent-acp-patch.test.ts
@@ -1,0 +1,79 @@
+import type { McpServerStatus, Query } from '@anthropic-ai/claude-agent-sdk'
+import { describe, expect, it, vi } from 'vitest'
+
+import { waitForMcpServers } from '@agentclientprotocol/claude-agent-acp/dist/acp-agent.js'
+
+type McpStatusQuery = Pick<Query, 'mcpServerStatus' | 'close'>
+
+const queryWithStatus = (mcpServerStatus: McpStatusQuery['mcpServerStatus']): McpStatusQuery => ({
+  mcpServerStatus,
+  close: vi.fn()
+})
+
+const status = (
+  name: string,
+  state: McpServerStatus['status'],
+  error?: string
+): McpServerStatus => ({ name, status: state, ...(error ? { error } : {}) })
+
+describe('claude-agent-acp MCP readiness patch', () => {
+  it('waits until every configured MCP server is connected', async () => {
+    const mcpServerStatus = vi
+      .fn<McpStatusQuery['mcpServerStatus']>()
+      .mockResolvedValueOnce([
+        status('open-science-activity', 'connected'),
+        status('open-science-notebook', 'pending')
+      ])
+      .mockResolvedValueOnce([
+        status('open-science-activity', 'connected'),
+        status('open-science-notebook', 'connected')
+      ])
+
+    const query = queryWithStatus(mcpServerStatus)
+
+    await waitForMcpServers(query, ['open-science-activity', 'open-science-notebook'], 500)
+
+    expect(mcpServerStatus).toHaveBeenCalledTimes(2)
+    expect(query.close).not.toHaveBeenCalled()
+  })
+
+  it('ignores MCP servers that were not configured by the ACP client', async () => {
+    const mcpServerStatus = vi
+      .fn<McpStatusQuery['mcpServerStatus']>()
+      .mockResolvedValue([
+        status('open-science-notebook', 'connected'),
+        status('user-project-server', 'failed', 'not installed')
+      ])
+
+    const query = queryWithStatus(mcpServerStatus)
+
+    await expect(waitForMcpServers(query, ['open-science-notebook'], 100)).resolves.toBeUndefined()
+    expect(query.close).not.toHaveBeenCalled()
+  })
+
+  it('reports a configured MCP server startup failure', async () => {
+    const mcpServerStatus = vi
+      .fn<McpStatusQuery['mcpServerStatus']>()
+      .mockResolvedValue([status('open-science-notebook', 'failed', 'process exited')])
+
+    const query = queryWithStatus(mcpServerStatus)
+
+    await expect(waitForMcpServers(query, ['open-science-notebook'], 100)).rejects.toThrow(
+      'MCP server open-science-notebook is failed: process exited'
+    )
+    expect(query.close).toHaveBeenCalledOnce()
+  })
+
+  it('times out when MCP status does not respond', async () => {
+    const mcpServerStatus = vi
+      .fn<McpStatusQuery['mcpServerStatus']>()
+      .mockReturnValue(new Promise<McpServerStatus[]>(() => undefined))
+
+    const query = queryWithStatus(mcpServerStatus)
+
+    await expect(waitForMcpServers(query, ['open-science-notebook'], 5)).rejects.toThrow(
+      'Timed out waiting for MCP servers: open-science-notebook'
+    )
+    expect(query.close).toHaveBeenCalledOnce()
+  })
+})


### PR DESCRIPTION
## Problem

Closes #522.

A new Claude Code session can accept the first user prompt before its configured stdio MCP servers finish registering. Claude snapshots the available tool set when the model request starts and does not refresh that snapshot when an MCP server connects later, so otherwise-valid Open Science tools fail with `No such tool available`.

A deterministic local reproduction used Claude Code 2.1.207 with a generic delayed stdio MCP server. Delays up to 1 second succeeded, while delays from 2 seconds onward failed before this change. The same failure reproduced with Claude Code 2.1.215 and 2.1.219, ruling out the Open Science notebook implementation, hyphenated names, provider response latency, and a newer-CLI fix.

## Proposed change

Patch `claude-agent-acp` at its session-creation boundary to:

- poll `mcpServerStatus()` for only the MCP servers supplied by the ACP client;
- return `session/new` only after every configured server is connected;
- fail explicitly after 10 seconds or on `failed`, `needs-auth`, or `disabled` terminal states;
- close the Claude query when readiness fails so no background process is leaked.

Add focused regression tests for multiple-server readiness, unrelated-server isolation, terminal failure, timeout, and query cleanup.

## Scope / non-goals

- No architecture, MCP transport, data model, data relationship, or UI changes.
- The only user-visible change is that new Claude sessions may wait briefly for MCP readiness; startup failures now surface during session creation instead of as a later missing-tool error.
- This does not change project/user MCP servers that were not supplied by the ACP client.
- This does not upgrade or fork the upstream adapter; it extends the repository's existing `patch-package` patch for version 0.60.0.

## Acceptance / validation

| Behavior | Check | Result |
| --- | --- | --- |
| First prompt waits for all configured MCP servers | `claude-agent-acp-patch.test.ts` pending-to-connected case | Pass |
| Unrelated user/project MCP failures do not block the app session | focused unrelated-server case | Pass |
| Failed or stalled configured servers fail explicitly and close the query | focused failure and timeout cases | Pass |
| Original first-turn race no longer returns `No such tool available` | real Claude Code 2.1.207 harness with 3s and 8s delayed stdio MCP startup | Pass; tool invoked |
| Node and renderer types remain valid | `npm run typecheck` | Pass |
| Repository lint remains valid | `npm run lint` plus focused ESLint | Pass; no errors, no warnings in the new test |
| Full repository behavior remains valid | `npm test` with localhost binding allowed | 593 files passed; 8,910 tests passed; 11 files / 140 tests skipped by suite configuration |
| Patch has no whitespace errors | `git diff origin/main...HEAD --check` | Pass |

The first sandboxed full-test attempt failed because localhost binding was denied with `listen EPERM 127.0.0.1`; rerunning the identical suite with localhost access passed completely.

## Review focus

- Is the 10-second readiness deadline appropriate for supported Windows environments?
- Are `failed`, `needs-auth`, and `disabled` the right terminal states for ACP-supplied app MCP servers?
- Is extending the existing adapter patch preferable to carrying this wait in a broader Open Science runtime layer?
