### PR TITLE
perf(permissions): avoid full session reconciliation

### DIFF
--- a/src/main/ipc.ts
+++ b/src/main/ipc.ts
@@ -78,6 +78,7 @@ import { registerReviewerIpcHandlers } from './reviewer/ipc'
 import {
   createDefaultReviewRepository,
   createDefaultSessionRepository,
+  loadSessionMetadataAfterProjectRecovery,
   loadSessionsAfterProjectRecovery,
   registerSessionPersistenceIpcHandlers
 } from './session-persistence/ipc'
@@ -941,7 +942,13 @@ const registerIpcHandlers = async ({
         return projectRepository.list()
       }
     },
-    sessions: sessionPersistenceBackend,
+    sessions: {
+      metadataSnapshot: () =>
+        loadSessionMetadataAfterProjectRecovery(
+          projectDeletionCoordinator,
+          sessionPersistenceCoordinator
+        )
+    },
     connectors: {
       get: async () => ({
         ...(await settingsService.getConnectors()),

--- a/src/main/permission-grants/ipc.test.ts
+++ b/src/main/permission-grants/ipc.test.ts
@@ -18,6 +18,38 @@ import { registerPermissionGrantIpcHandlers } from './ipc'
 beforeEach(() => handlers.clear())
 
 describe('permission grant IPC', () => {
+  it('projects Session-scoped grants from cached metadata without loading Session storage', async () => {
+    const loadAll = vi.fn().mockRejectedValue(new Error('full Session load must not run'))
+    const metadataSnapshot = vi.fn().mockResolvedValue({
+      sessions: [{ id: 'session-1', projectId: 'project-1', title: 'Cached session' }],
+      isComplete: true
+    })
+    const sessions = { metadataSnapshot, loadAll }
+    const registry = {
+      list: vi.fn().mockResolvedValue([
+        {
+          id: 'grant-1',
+          revision: 1,
+          capability: { kind: 'file_operation', key: 'file:read' },
+          scope: { kind: 'session', projectId: 'project-1', sessionId: 'session-1' }
+        }
+      ]),
+      subscribe: vi.fn(() => () => undefined)
+    } as unknown as PermissionGrantRegistry
+    registerPermissionGrantIpcHandlers({
+      registry,
+      projects: { list: vi.fn().mockResolvedValue([]) },
+      sessions
+    })
+
+    await expect(handlers.get('permissions:list')?.(undefined)).resolves.toMatchObject({
+      incompleteStores: [],
+      grants: [{ scopeLabel: 'Session: Cached session' }]
+    })
+    expect(metadataSnapshot).toHaveBeenCalledOnce()
+    expect(loadAll).not.toHaveBeenCalled()
+  })
+
   it('registers list, revision-aware revoke, restore, and change notification', async () => {
     let listener: (() => void) | undefined
     const registry = {
@@ -38,7 +70,7 @@ describe('permission grant IPC', () => {
     const controller = registerPermissionGrantIpcHandlers({
       registry,
       projects: { list: vi.fn().mockResolvedValue([]) },
-      sessions: { loadAll: vi.fn().mockResolvedValue({ sessions: [], manifest: {} }) },
+      sessions: { metadataSnapshot: vi.fn().mockResolvedValue({ sessions: [], isComplete: true }) },
       broadcast
     })
 
@@ -79,7 +111,7 @@ describe('permission grant IPC', () => {
     registerPermissionGrantIpcHandlers({
       registry,
       projects: { list: vi.fn().mockResolvedValue([]) },
-      sessions: { loadAll: vi.fn().mockResolvedValue({ sessions: [], manifest: {} }) }
+      sessions: { metadataSnapshot: vi.fn().mockResolvedValue({ sessions: [], isComplete: true }) }
     })
 
     await expect(handlers.get('permissions:revoke')?.(undefined, { grants: [] })).rejects.toThrow(
@@ -107,10 +139,8 @@ describe('permission grant IPC', () => {
       registry,
       projects: { list: vi.fn().mockRejectedValue(new Error('project store unavailable')) },
       sessions: {
-        loadAll: vi.fn().mockResolvedValue({
-          sessions: [],
-          manifest: {},
-          diagnostics: { isComplete: false, warnings: [] }
+        metadataSnapshot: vi.fn(() => {
+          throw new Error('Session metadata unavailable')
         })
       },
       connectors: { get: vi.fn().mockRejectedValue(new Error('settings unavailable')) },

--- a/src/main/permission-grants/ipc.ts
+++ b/src/main/permission-grants/ipc.ts
@@ -9,9 +9,9 @@ import type {
   PermissionGrantsChangedEvent
 } from '../../shared/permission-grants'
 import type { Project } from '../../shared/projects'
-import type { LoadAllSessionsResult } from '../../shared/session-persistence'
 import { ipcMainHandle } from '../ipc-handler-registry'
 import { broadcastToRenderers } from '../renderer-broadcast'
+import type { SessionMetadataSnapshot } from '../session-persistence/coordinator'
 import {
   projectPermissionGrantMutation,
   projectPermissionGrantSnapshot,
@@ -22,7 +22,7 @@ import type { PermissionGrantRegistry } from './registry'
 type PermissionGrantIpcOptions = {
   registry: PermissionGrantRegistry
   projects: { list(): Promise<Project[]> }
-  sessions: { loadAll(): Promise<LoadAllSessionsResult> }
+  sessions: { metadataSnapshot(): Promise<SessionMetadataSnapshot> }
   connectors?: { get(): Promise<ConnectorPolicySnapshot | undefined> }
   broadcast?: (channel: string, payload: PermissionGrantsChangedEvent) => void
 }
@@ -59,19 +59,19 @@ const registerPermissionGrantIpcHandlers = (
   }> => {
     const [projectsResult, sessionsResult, connectorPolicyResult] = await Promise.allSettled([
       options.projects.list(),
-      options.sessions.loadAll(),
+      Promise.resolve().then(() => options.sessions.metadataSnapshot()),
       options.connectors?.get()
     ])
     const projects = projectsResult.status === 'fulfilled' ? projectsResult.value : []
-    const sessions: LoadAllSessionsResult =
+    const sessions: SessionMetadataSnapshot =
       sessionsResult.status === 'fulfilled'
         ? sessionsResult.value
-        : { sessions: [], manifest: { version: 1 } }
+        : { sessions: [], isComplete: false }
     const connectorPolicy =
       connectorPolicyResult.status === 'fulfilled' ? connectorPolicyResult.value : undefined
     const incompleteStores: PermissionGrantSnapshot['incompleteStores'] = []
     if (projectsResult.status === 'rejected') incompleteStores.push('projects')
-    if (sessionsResult.status === 'rejected' || sessions.diagnostics?.isComplete === false) {
+    if (sessionsResult.status === 'rejected' || !sessions.isComplete) {
       incompleteStores.push('sessions')
     }
     if (connectorPolicyResult.status === 'rejected') incompleteStores.push('connector_policy')

--- a/src/main/session-persistence/coordinator.test.ts
+++ b/src/main/session-persistence/coordinator.test.ts
@@ -140,6 +140,179 @@ const createProjectReconciliationSnapshot = (): ArtifactProjectReconciliationSna
   ({}) as ArtifactProjectReconciliationSnapshot
 
 describe('SessionPersistenceCoordinator', () => {
+  it('exposes Session metadata from the latest complete load without reading storage again', async () => {
+    const session = createSession({ title: 'Cached session' })
+    const loadAllWithDiagnostics = vi.fn().mockResolvedValue({
+      result: { sessions: [session], manifest: { version: 1 as const } },
+      isComplete: true
+    })
+    const coordinator = new SessionPersistenceCoordinator(
+      createSessionRepository({ loadAllWithDiagnostics }),
+      createFileIndex()
+    )
+
+    await coordinator.loadAll()
+
+    await expect(coordinator.sessionMetadataSnapshot()).resolves.toEqual({
+      sessions: [{ id: 'session-1', projectId: 'project-1', title: 'Cached session' }],
+      isComplete: true
+    })
+    expect(loadAllWithDiagnostics).toHaveBeenCalledOnce()
+  })
+
+  it('updates cached Session metadata after a durable save', async () => {
+    const session = createSession({ title: 'Original title' })
+    const coordinator = new SessionPersistenceCoordinator(
+      createSessionRepository({
+        loadAllWithDiagnostics: vi.fn().mockResolvedValue({
+          result: { sessions: [session], manifest: { version: 1 as const } },
+          isComplete: true
+        })
+      }),
+      createFileIndex()
+    )
+
+    await coordinator.loadAll()
+    await coordinator.saveSession(createSession({ title: 'Renamed session' }))
+
+    await expect(coordinator.sessionMetadataSnapshot()).resolves.toEqual({
+      sessions: [{ id: 'session-1', projectId: 'project-1', title: 'Renamed session' }],
+      isComplete: true
+    })
+  })
+
+  it('waits for an in-flight save before returning Session metadata', async () => {
+    const saveGate = createDeferred<void>()
+    const repository = createSessionRepository({
+      saveSession: vi.fn(() => saveGate.promise)
+    })
+    const coordinator = new SessionPersistenceCoordinator(repository, createFileIndex())
+
+    const save = coordinator.saveSession(createSession({ title: 'Renamed session' }))
+    await vi.waitFor(() => expect(repository.saveSession).toHaveBeenCalledOnce())
+    const snapshot = Promise.resolve(coordinator.sessionMetadataSnapshot())
+
+    saveGate.resolve()
+    await save
+
+    await expect(snapshot).resolves.toEqual({
+      sessions: [{ id: 'session-1', projectId: 'project-1', title: 'Renamed session' }],
+      isComplete: false
+    })
+  })
+
+  it('marks saved Session metadata incomplete when the derived file index update fails', async () => {
+    const session = createSession({ title: 'Original title' })
+    const repository = createSessionRepository({
+      loadAllWithDiagnostics: vi.fn().mockResolvedValue({
+        result: { sessions: [session], manifest: { version: 1 as const } },
+        isComplete: true
+      })
+    })
+    const syncSession = vi
+      .fn()
+      .mockResolvedValueOnce([])
+      .mockRejectedValueOnce(new Error('index unavailable'))
+    const coordinator = new SessionPersistenceCoordinator(
+      repository,
+      createFileIndex({ syncSession })
+    )
+
+    await coordinator.loadAll()
+    await expect(
+      coordinator.saveSession(createSession({ title: 'Durable renamed session' }))
+    ).rejects.toThrow('index unavailable')
+
+    expect(repository.saveSession).toHaveBeenCalled()
+    await expect(coordinator.sessionMetadataSnapshot()).resolves.toEqual({
+      sessions: [{ id: 'session-1', projectId: 'project-1', title: 'Durable renamed session' }],
+      isComplete: false
+    })
+  })
+
+  it('removes cached Session metadata after durable deletion', async () => {
+    const session = createSession()
+    const loadAllWithDiagnostics = vi
+      .fn()
+      .mockResolvedValueOnce({
+        result: { sessions: [session], manifest: { version: 1 as const } },
+        isComplete: true
+      })
+      .mockResolvedValueOnce({
+        result: { sessions: [], manifest: { version: 1 as const } },
+        isComplete: true
+      })
+    const coordinator = new SessionPersistenceCoordinator(
+      createSessionRepository({
+        loadAllWithDiagnostics,
+        loadSessionWithDiagnostics: vi.fn().mockResolvedValue({ status: 'found', session })
+      }),
+      createFileIndex()
+    )
+
+    await coordinator.loadAll()
+    await coordinator.deleteSession('project-1', 'session-1')
+
+    await expect(coordinator.sessionMetadataSnapshot()).resolves.toEqual({
+      sessions: [],
+      isComplete: true
+    })
+  })
+
+  it('removes only the deleted Project from cached Session metadata', async () => {
+    const deletedSession = createSession()
+    const survivingSession = createSession({ id: 'session-2', projectId: 'project-2' })
+    const coordinator = new SessionPersistenceCoordinator(
+      createSessionRepository({
+        loadAllWithDiagnostics: vi.fn().mockResolvedValue({
+          result: {
+            sessions: [deletedSession, survivingSession],
+            manifest: { version: 1 as const }
+          },
+          isComplete: true
+        }),
+        loadProjectWithDiagnostics: vi.fn().mockResolvedValue({
+          sessions: [deletedSession],
+          isComplete: true
+        })
+      }),
+      createFileIndex()
+    )
+
+    await coordinator.loadAll()
+    await coordinator.deleteProjectSessions('project-1')
+
+    await expect(coordinator.sessionMetadataSnapshot()).resolves.toEqual({
+      sessions: [{ id: 'session-2', projectId: 'project-2', title: 'Session' }],
+      isComplete: true
+    })
+  })
+
+  it('marks cached Session metadata incomplete until a complete authority scan succeeds', async () => {
+    const session = createSession()
+    const coordinator = new SessionPersistenceCoordinator(
+      createSessionRepository({
+        loadAllWithDiagnostics: vi.fn().mockResolvedValue({
+          result: { sessions: [session], manifest: { version: 1 as const } },
+          isComplete: false
+        })
+      }),
+      createFileIndex()
+    )
+
+    await expect(coordinator.sessionMetadataSnapshot()).resolves.toEqual({
+      sessions: [],
+      isComplete: false
+    })
+
+    await coordinator.loadAll()
+
+    await expect(coordinator.sessionMetadataSnapshot()).resolves.toEqual({
+      sessions: [{ id: 'session-1', projectId: 'project-1', title: 'Session' }],
+      isComplete: false
+    })
+  })
+
   it('serializes a pending save before deletion and rejects saves after the tombstone', async () => {
     const order: string[] = []
     const saveGate = createDeferred<void>()
@@ -1890,6 +2063,10 @@ describe('SessionPersistenceCoordinator', () => {
         isComplete: false,
         failure: 'startup-reconciliation-failed'
       }
+    })
+    await expect(coordinator.sessionMetadataSnapshot()).resolves.toEqual({
+      sessions: [{ id: 'session-1', projectId: 'project-1', title: 'Session' }],
+      isComplete: false
     })
     expect(markReconciliationIncomplete).toHaveBeenCalledOnce()
   })

--- a/src/main/session-persistence/coordinator.ts
+++ b/src/main/session-persistence/coordinator.ts
@@ -29,6 +29,13 @@ import {
 type ProjectSessionDeletionResult =
   { status: 'completed' } | { status: 'orphan-retained'; reason: 'missing-upload-authority' }
 
+type SessionMetadata = Readonly<Pick<PersistedChatSession, 'id' | 'projectId' | 'title'>>
+
+type SessionMetadataSnapshot = Readonly<{
+  sessions: readonly SessionMetadata[]
+  isComplete: boolean
+}>
+
 type SessionMutationRepository = {
   loadAllWithDiagnostics(options?: { mode?: 'repair' | 'read-only' }): Promise<{
     result: LoadAllSessionsResult
@@ -322,6 +329,8 @@ class SessionPersistenceCoordinator {
   private readonly deletedSessions = new Set<string>()
   private readonly deletedProjects = new Set<string>()
   private readonly validatedBindingTopologies = new Map<string, string>()
+  private sessionMetadata = new Map<string, SessionMetadata>()
+  private isSessionMetadataComplete = false
   private destructiveStartupWindowOpen = true
   private sessionDeletionHandlers: SessionDeletionHandlers | undefined
 
@@ -341,6 +350,44 @@ class SessionPersistenceCoordinator {
     this.sessionDeletionHandlers = handlers
   }
 
+  sessionMetadataSnapshot(): Promise<SessionMetadataSnapshot> {
+    return this.enqueue(async () => ({
+      sessions: [...this.sessionMetadata.values()],
+      isComplete: this.isSessionMetadataComplete
+    }))
+  }
+
+  private replaceSessionMetadata(
+    sessions: readonly PersistedChatSession[],
+    isComplete: boolean
+  ): void {
+    this.sessionMetadata = new Map(
+      sessions.map((session) => [
+        session.id,
+        { id: session.id, projectId: session.projectId, title: session.title }
+      ])
+    )
+    this.isSessionMetadataComplete = isComplete
+  }
+
+  private upsertSessionMetadata(session: PersistedChatSession): void {
+    this.sessionMetadata.set(session.id, {
+      id: session.id,
+      projectId: session.projectId,
+      title: session.title
+    })
+  }
+
+  private removeSessionMetadata(sessionId: string): void {
+    this.sessionMetadata.delete(sessionId)
+  }
+
+  private removeProjectSessionMetadata(projectId: string): void {
+    for (const [sessionId, metadata] of this.sessionMetadata) {
+      if (metadata.projectId === projectId) this.sessionMetadata.delete(sessionId)
+    }
+  }
+
   /**
    * Reads the Session authority without running recovery or derived-state reconciliation. This is
    * the degraded path used when an earlier startup prerequisite failed: healthy transcripts remain
@@ -354,6 +401,7 @@ class SessionPersistenceCoordinator {
       this.destructiveStartupWindowOpen = false
       this.fileIndex.markReconciliationIncomplete()
       const scan = await this.repository.loadAllWithDiagnostics({ mode: 'read-only' })
+      this.replaceSessionMetadata(scan.result.sessions, false)
 
       return {
         ...scan.result,
@@ -379,6 +427,7 @@ class SessionPersistenceCoordinator {
       const mayRunDestructiveStartupCleanup = this.destructiveStartupWindowOpen
       this.destructiveStartupWindowOpen = false
       const scan = await this.repository.loadAllWithDiagnostics()
+      this.replaceSessionMetadata(scan.result.sessions, scan.isComplete)
       scan.result.diagnostics = {
         isComplete: scan.isComplete,
         warnings: scan.warnings ?? [],
@@ -496,6 +545,7 @@ class SessionPersistenceCoordinator {
           await this.fileIndex.syncSession(session)
         }
       } catch (error) {
+        this.isSessionMetadataComplete = false
         this.fileIndex.markReconciliationIncomplete()
         console.error('[session-persistence] startup reconciliation failed', error)
         // Keep chat hydration available while Files remains explicitly incomplete and retryable.
@@ -567,6 +617,7 @@ class SessionPersistenceCoordinator {
         if (bindingValidation.status === 'conflict') throw bindingValidation.error
       }
       await this.repository.saveSession(durableSession)
+      this.upsertSessionMetadata(durableSession)
       // Cache only confirmed topology. A transient validation failure keeps the old fingerprint so
       // the next autosave retries the narrow lookup instead of silently treating it as acknowledged.
       if (bindingValidation.status === 'valid') {
@@ -577,6 +628,7 @@ class SessionPersistenceCoordinator {
       try {
         changedSources = await this.fileIndex.syncSession(durableSession)
       } catch (error) {
+        this.isSessionMetadataComplete = false
         // The JSON is already durable. Tell open Files views to surface the incomplete projection,
         // then preserve the rejection so the normal persistence retry path remains active.
         this.notifyFilesChanged({
@@ -770,6 +822,7 @@ class SessionPersistenceCoordinator {
         // The marked directory rename is the sole authoritative commit. Derived index deletion runs
         // afterward so any failure is replayable from the durable Project intent and tombstone.
         await this.repository.deleteProjectSessions(projectId)
+        this.removeProjectSessionMetadata(projectId)
         for (const sessionId of deletedSessionIds) {
           this.validatedBindingTopologies.delete(sessionKey(projectId, sessionId))
         }
@@ -914,6 +967,7 @@ class SessionPersistenceCoordinator {
         }
         await this.repository.deleteSession(projectId, sessionId)
         jsonDeleted = true
+        this.removeSessionMetadata(sessionId)
         this.validatedBindingTopologies.delete(key)
         await this.provenance?.completeSessionDeletion(receipt)
       } catch (error) {
@@ -944,6 +998,7 @@ class SessionPersistenceCoordinator {
       try {
         const scan = await this.repository.loadAllWithDiagnostics()
         if (scan.isComplete) {
+          this.replaceSessionMetadata(scan.result.sessions, true)
           // The deleted session may have owned a canonical row referenced by a surviving legacy
           // session. Retry the project's revision ledgers after the owner is durably gone.
           for (const session of scan.result.sessions) {
@@ -957,9 +1012,11 @@ class SessionPersistenceCoordinator {
           // and any other stale ledgers that no longer have authoritative JSON.
           await this.fileIndex.reconcileActiveSessions(scan.result.sessions)
         } else {
+          this.isSessionMetadataComplete = false
           this.fileIndex.markReconciliationIncomplete()
         }
       } catch {
+        this.isSessionMetadataComplete = false
         this.fileIndex.markReconciliationIncomplete()
       }
 
@@ -1021,6 +1078,8 @@ export type {
   ProjectSessionDeletionResult,
   SessionDeletionHandlers,
   SessionFileIndex,
+  SessionMetadata,
+  SessionMetadataSnapshot,
   SessionMutationRepository,
   SessionProvenancePersistence
 }

--- a/src/main/session-persistence/ipc.test.ts
+++ b/src/main/session-persistence/ipc.test.ts
@@ -22,6 +22,7 @@ vi.mock('../lifecycle-broadcast', () => ({
 
 import {
   createSessionPersistenceHandlers,
+  loadSessionMetadataAfterProjectRecovery,
   loadSessionsAfterProjectRecovery,
   registerSessionPersistenceIpcHandlers,
   type SessionPersistenceBackend
@@ -53,6 +54,43 @@ const createMockReviewRepository = (): ReviewRepository =>
   }) as unknown as ReviewRepository
 
 describe('session persistence IPC handlers', () => {
+  it('reads cached Session metadata only after Project deletion recovery', async () => {
+    const order: string[] = []
+    const projectRecovery = {
+      recoverPendingDeletions: vi.fn(async () => {
+        order.push('recovery')
+      })
+    }
+    const snapshot = {
+      sessions: [{ id: 'session-1', projectId: 'project-a', title: 'Session' }],
+      isComplete: true
+    }
+    const sessionLoader = {
+      sessionMetadataSnapshot: vi.fn(async () => {
+        order.push('snapshot')
+        return snapshot
+      })
+    }
+
+    await expect(
+      loadSessionMetadataAfterProjectRecovery(projectRecovery, sessionLoader)
+    ).resolves.toBe(snapshot)
+    expect(order).toEqual(['recovery', 'snapshot'])
+  })
+
+  it('does not expose cached Session metadata when Project deletion recovery fails', async () => {
+    const failure = new Error('Project deletion recovery failed')
+    const projectRecovery = {
+      recoverPendingDeletions: vi.fn().mockRejectedValue(failure)
+    }
+    const sessionLoader = { sessionMetadataSnapshot: vi.fn() }
+
+    await expect(
+      loadSessionMetadataAfterProjectRecovery(projectRecovery, sessionLoader)
+    ).rejects.toBe(failure)
+    expect(sessionLoader.sessionMetadataSnapshot).not.toHaveBeenCalled()
+  })
+
   it('hydrates a read-only Session snapshot when Project deletion recovery fails', async () => {
     const failure = new Error('Project deletion journal is locked')
     const consoleError = vi.spyOn(console, 'error').mockImplementation(() => undefined)

--- a/src/main/session-persistence/ipc.ts
+++ b/src/main/session-persistence/ipc.ts
@@ -14,6 +14,7 @@ import { SessionRepository } from './repository'
 import { ReviewRepository } from '../reviewer/repository'
 import { getProjectDbClient } from '../projects/prisma-client'
 import { withDataRootWrite } from '../storage/migration-state'
+import type { SessionMetadataSnapshot } from './coordinator'
 
 type SessionPersistenceBackend = {
   loadAll: () => Promise<LoadAllSessionsResult>
@@ -44,6 +45,10 @@ type SessionStartupLoader = {
   loadAllReadOnly: () => Promise<LoadAllSessionsResult>
 }
 
+type SessionMetadataLoader = {
+  sessionMetadataSnapshot: () => Promise<SessionMetadataSnapshot>
+}
+
 const withProjectDeletionRecoveryStatus = (
   result: LoadAllSessionsResult,
   isProjectDeletionRecoveryComplete: boolean
@@ -56,6 +61,16 @@ const withProjectDeletionRecoveryStatus = (
     isProjectDeletionRecoveryComplete
   }
 })
+
+// Cached metadata must not overtake queued Project deletion work. Let recovery failures reject so
+// Permissions reports the Session store as incomplete instead of publishing stale navigation labels.
+const loadSessionMetadataAfterProjectRecovery = async (
+  projectRecovery: ProjectDeletionRecoveryBackend,
+  sessionLoader: SessionMetadataLoader
+): Promise<SessionMetadataSnapshot> => {
+  await projectRecovery.recoverPendingDeletions()
+  return sessionLoader.sessionMetadataSnapshot()
+}
 
 // Project deletion recovery is a prerequisite for mutating startup reconciliation. If it fails,
 // expose only the coordinator's explicit read-only snapshot so healthy transcripts remain navigable
@@ -142,6 +157,7 @@ export {
   createDefaultReviewRepository,
   createDefaultSessionRepository,
   createSessionPersistenceHandlers,
+  loadSessionMetadataAfterProjectRecovery,
   loadSessionsAfterProjectRecovery,
   registerSessionPersistenceIpcHandlers
 }


### PR DESCRIPTION
## Problem

Opening **Settings > Permissions** called the Session persistence `loadAll()` path solely to resolve Session-scoped grant labels. That path scans durable Session JSON and may run startup recovery and file-index reconciliation, so the page latency grows with storage work that the permission projection does not need.

## Proposed change

Keep a process-local Session metadata snapshot (`id`, `projectId`, and `title`) inside `SessionPersistenceCoordinator` and have the permission IPC projection read that snapshot instead of invoking `loadAll()`.

The snapshot is refreshed by authoritative loads, updated after durable saves, and pruned after durable Session or Project deletion. Partial scans, snapshot failures, and startup reconciliation failures preserve readable labels while marking Session metadata incomplete.

```mermaid
flowchart LR
    JSON["Session JSON (authority)"] -->|"existing load/save/delete"| Coordinator["SessionPersistenceCoordinator"]
    Coordinator -->|"in-memory id/projectId/title snapshot"| PermissionIPC["permissions:list projection"]
    PermissionIPC --> Panel["Settings > Permissions"]
    PermissionIPC -. "does not call" .-> Reconciliation["Session load/recovery/index reconciliation"]
```

## Scope and non-goals

- No renderer or interaction changes.
- No database schema, table, row, migration, or persisted Session JSON changes.
- No changes to permission grant storage or data relationships.
- The snapshot is process-local and is rebuilt through the existing Session hydration path.
- Full Session loading and reconciliation remain authoritative for startup/recovery; this change only removes them from permission label projection.

## Acceptance criteria and validation

All listed checks ran after the last material edit.

- Permissions resolves Session-scoped labels from cached metadata without calling full Session storage
  → `npm test -- --run src/main/permission-grants/ipc.test.ts src/main/session-persistence/coordinator.test.ts`
  → 2 files passed, 78 tests passed.
- Snapshot stays fresh across load/save/Session delete/Project delete and preserves incomplete/error degradation
  → same targeted command
  → 78/78 passed, including startup reconciliation failure coverage.
- Node and renderer types remain valid
  → `npm run typecheck`
  → passed.
- Repository lint gate
  → `npm run lint`
  → passed with 0 errors (23 pre-existing warnings outside this change).
- Full regression suite
  → `npm test`
  → 600 files passed, 8,996 tests passed; 11 files / 140 tests skipped by existing suite configuration.
- Independent Standards and Spec reviews of the final commit
  → both completed with no remaining findings.

## Review focus

- Whether snapshot updates occur only after the corresponding durable authority mutation.
- Whether incomplete metadata remains fail-visible without hiding or preventing individual grant revocation.
- Whether any Session mutation path can leave a stale title or deleted Session in the projection.

Uncovered risk: validation structurally proves the expensive `loadAll()` path is not invoked, but does not include an end-to-end wall-clock benchmark with a very large on-disk Session catalog.
