### PR TITLE
style(settings): tighten sidebar and align detection actions

### DIFF
--- a/docs/design.md
+++ b/docs/design.md
@@ -424,7 +424,7 @@ Workspace-only tokens without a shadcn counterpart, plus shadow tokens. For shar
 ### Sidebar
 
 - Sidebar root: `bg-sidebar text-sidebar-foreground`.
-- Expanded width should follow content density; the settings dialog left navigation is approximately `208px`.
+- Expanded width should follow content density; the settings dialog left navigation is approximately `192px`.
 - Collapsed state keeps a `size-8` icon rail and provides `Tooltip` for every icon item.
 - Item: `h-8 rounded-lg px-2 text-sm text-muted-foreground hover:bg-sidebar-accent hover:text-sidebar-accent-foreground`.
 - Active item: `bg-sidebar-accent text-sidebar-accent-foreground font-medium`.
@@ -552,7 +552,7 @@ Workspace-only tokens without a shadcn counterpart, plus shadow tokens. For shar
 
 - Use a large `Dialog`; the restored panel is `h-[min(688px,calc(100vh-2rem))] w-[min(960px,calc(100vw-2rem))] rounded-xl border border-border bg-card shadow-dialog`. Maximize uses `inset-4`, filling the viewport with a stable 16px margin and never shrinking the restored panel.
 - Settings consumes the global semantic palette: background `#FAFAF8`, card/popover `#FFFFFF`, muted/secondary `#ECECEA`, border/input `#DEDEDA`, foreground `#202321`, and muted foreground `#646762`. Do not scope token overrides to the dialog or use `body:has(...)`; Radix portals inherit these root tokens directly.
-- Left navigation: `w-52 shrink-0 border-r border-border bg-background p-3`, organized into labeled groups (for example Capabilities and Workspace). Each group has a `text-xs font-medium text-muted-foreground` heading over its rows.
+- Left navigation: `w-48 shrink-0 border-r border-border bg-background p-3`, organized into labeled groups (for example Capabilities and Workspace). Each group has a `text-xs font-medium text-muted-foreground` heading over its rows.
 - Nav item: `h-8 w-full rounded-lg px-2 text-sm gap-2 hover:bg-muted`, with a `size-4` leading icon (`text-muted-foreground`) and a truncating label.
 - Active: `bg-muted text-foreground font-medium`; the neutral selection keeps deep green reserved for primary actions, focus, links, enabled switches, and success.
 - Content header: `h-12 border-b border-border px-3`, a space-between row. Left cluster: back / forward `size-7` icon buttons (`ArrowLeft` / `ArrowRight`, `disabled:opacity-40`), a `h-4 w-px bg-border` divider, then either a breadcrumb or a plain `h2 text-sm font-semibold` title. Right cluster: a maximize / restore `size-7` toggle (`Maximize2` / `Minimize2`) and a `size-7` close (`X`); both use `hover:bg-muted hover:text-foreground`.

--- a/src/renderer/src/pages/settings/AgentPanel.tsx
+++ b/src/renderer/src/pages/settings/AgentPanel.tsx
@@ -519,6 +519,7 @@ const AgentPanel = ({
         title={title}
         aria-label={title}
         description={description}
+        actionClassName="ml-auto"
         action={
           <Button
             type="button"

--- a/src/renderer/src/pages/settings/RuntimesPanel.render.test.tsx
+++ b/src/renderer/src/pages/settings/RuntimesPanel.render.test.tsx
@@ -143,7 +143,9 @@ describe('RuntimesPanel', () => {
     const section = container.querySelector('section[aria-label="Custom runtime title"]')
     expect(section?.querySelector('h3')?.textContent).toBe('Custom runtime title')
     expect(section?.textContent).toContain('Custom runtime description')
-    expect(section?.querySelector('button')?.textContent).toContain('Recheck')
+    const recheck = section?.querySelector<HTMLButtonElement>('button')
+    expect(recheck?.textContent).toContain('Recheck')
+    expect(recheck?.parentElement?.className).toContain('ml-auto')
   })
 
   it('renders a card per detected env with version and interpreter path', async () => {

--- a/src/renderer/src/pages/settings/RuntimesPanel.tsx
+++ b/src/renderer/src/pages/settings/RuntimesPanel.tsx
@@ -351,6 +351,7 @@ const RuntimesPanel = ({ title, description }: RuntimesPanelProps): React.JSX.El
         description={description}
         aria-label={title}
         contentClassName="space-y-5"
+        actionClassName="ml-auto"
         action={
           <Button
             type="button"

--- a/src/renderer/src/pages/settings/SettingsPage.render.test.tsx
+++ b/src/renderer/src/pages/settings/SettingsPage.render.test.tsx
@@ -249,6 +249,8 @@ describe('SettingsPage layout', () => {
     const nav = document.body.querySelector('nav[aria-label="Settings"]')
     expect(nav).not.toBeNull()
     expect(nav?.className).toContain('bg-background')
+    expect(nav?.className).toContain('md:w-48')
+    expect(nav?.className).toContain('w-[min(86vw,320px)]')
     expect(nav?.nextElementSibling?.className).toContain('bg-card')
     expect(nav?.textContent).toContain('Capabilities')
     expect(nav?.textContent).toContain('Workspace')

--- a/src/renderer/src/pages/settings/SettingsPage.render.test.tsx
+++ b/src/renderer/src/pages/settings/SettingsPage.render.test.tsx
@@ -2264,6 +2264,7 @@ describe('SettingsPage Codex framework', () => {
       (button) => button.textContent?.trim() === 'Re-detect'
     )
     expect(redetect).toBeDefined()
+    expect(redetect?.parentElement?.className).toContain('ml-auto')
     await act(async () => redetect?.click())
 
     expect(detectClaude).toHaveBeenCalledTimes(1)

--- a/src/renderer/src/pages/settings/SettingsPage.tsx
+++ b/src/renderer/src/pages/settings/SettingsPage.tsx
@@ -646,7 +646,7 @@ const SettingsPage = ({ open, onClose, onOpenSession }: SettingsPageProps): Reac
             aria-hidden={isMobile && !isMobileNavOpen ? true : undefined}
             inert={isMobile && !isMobileNavOpen ? true : undefined}
             className={cn(
-              'fixed inset-y-0 left-0 z-[70] flex w-[min(86vw,320px)] shrink-0 flex-col gap-4 border-r border-border bg-background p-3 transition-transform duration-200 ease-out md:static md:z-auto md:w-52 md:translate-x-0',
+              'fixed inset-y-0 left-0 z-[70] flex w-[min(86vw,320px)] shrink-0 flex-col gap-4 border-r border-border bg-background p-3 transition-transform duration-200 ease-out md:static md:z-auto md:w-48 md:translate-x-0',
               isMobileNavOpen ? 'translate-x-0' : '-translate-x-full'
             )}
           >


### PR DESCRIPTION
## Problem

The Settings sidebar uses more horizontal space than needed on desktop. When the Agent and Runtimes section descriptions consume the available header width, their detection actions wrap beneath the copy and remain left-aligned instead of sitting at the far right.

## Proposed change

- Reduce the desktop Settings sidebar width from 208px to 192px while preserving the existing mobile width.
- Right-align the Agent **Re-detect** and Runtimes **Recheck** actions, including when either action wraps below its section description.
- Update the Settings design documentation and add focused layout-contract assertions for the affected behavior.

## Scope and non-goals

This is limited to Settings navigation width and the two detection-action wrappers. It does not change detection behavior, runtime state, responsive breakpoints, or other Settings section actions.

## Acceptance criteria and validation

All listed checks ran after the final material edit:

- Desktop sidebar is 192px and mobile width remains unchanged -> `npm test -- src/renderer/src/pages/settings/SettingsPage.render.test.tsx` -> passed as part of 51/51 Settings tests.
- Agent **Re-detect** and Runtimes **Recheck** remain right-aligned when wrapped -> `npm test -- src/renderer/src/pages/settings/SettingsPage.render.test.tsx src/renderer/src/pages/settings/RuntimesPanel.render.test.tsx` -> 66/66 tests passed.
- Type safety -> `npm run typecheck` -> passed (node and web).
- Lint -> `npm run lint` -> passed with 0 errors and 23 pre-existing warnings.
- Full regression suite -> `npm test` -> 600 test files and 8,989 tests passed; 11 files and 140 tests skipped.
- Independent standards and specification reviews -> no findings.

Uncovered risk: automated tests assert Tailwind class contracts rather than pixel geometry, so perceived width and viewport-level wrapping still rely on visual verification.

## Review focus

Please verify the 192px desktop sidebar feels appropriately compact and that the Agent and Runtimes detection actions sit at the far right at the target Settings dialog width.
