### PR TITLE
docs(readme): remove version-specific downgrade guidance

### DIFF
--- a/README.md
+++ b/README.md
@@ -208,21 +208,6 @@ Provider vendors, available models, and regional endpoints can evolve independen
 
 Open Science stores project data, settings, artifact versions, and provenance evidence on the local computer. API Keys are kept locally and use the operating system's secure credential storage when it is available. Logs are local and are not uploaded automatically.
 
-### Downgrading safely
-
-Installing an older Open Science application does not downgrade data that a newer version has
-already written. To prepare a compatible, isolated copy for Open Science 0.7.3, quit the app and run:
-
-```bash
-open-science rollback-to-0.7.3 --yes
-```
-
-The command preserves the newer Config Root and data without rewriting them, converts the active
-Session branches into the 0.7.3 format, and activates a separate rollback Data Root. It does not
-require a backup made before the upgrade. Install and start 0.7.3 only after the command succeeds.
-See [the CLI downgrade guide](packages/open-science/CLI.md#rollback-to-073) for retained data,
-limitations, custom paths, and recovery locations.
-
 External data flow is still possible and should be reviewed:
 
 - Model requests send the prompt and necessary context to the selected model provider.


### PR DESCRIPTION
## Problem

The general README contains Open Science 0.7.3-specific rollback instructions. This version-bound guidance is better kept in release-oriented documentation and the existing CLI downgrade guide.

## Proposed change

Remove the **Downgrading safely** section from the root README. The detailed 0.7.3 rollback documentation in `packages/open-science/CLI.md` remains unchanged.

## Scope and non-goals

- Changes only `README.md`.
- Does not change the rollback command, CLI behavior, or stored data.
- Does not relocate or rewrite the existing CLI downgrade guide.

## Acceptance criteria and validation

All listed checks ran after the final material edit.

- General README no longer contains the 0.7.3 rollback section -> `rg -n 'Downgrading safely|rollback-to-0\.7\.3' README.md` -> passed (no matches).
- Detailed rollback guidance remains available in the CLI guide -> `rg -n 'rollback-to-0\.7\.3|Rollback to 0\.7\.3|rollback-to-073' packages/open-science/CLI.md` -> passed.
- Repository type safety remains green -> `npm run typecheck` -> passed.
- Repository lint remains green -> `npm run lint` -> passed.
- Patch formatting is clean -> `git diff --check` -> passed.
- `npm test` was not run because this is a documentation-only change with no `src/` or code-logic modifications, per the repository test exception.

## Review focus

Confirm that the version-specific section should be absent from the general README and that retaining the CLI guide is sufficient.

Uncovered risk: the README was not rendered in a separate Markdown preview. Independent review remains pending while this PR is a draft.
