### PR TITLE
test(acp): use platform-native resume cwd assertion

### DIFF
--- a/src/main/acp/runtime.test.ts
+++ b/src/main/acp/runtime.test.ts
@@ -6966,7 +6966,7 @@ describe('ACP runtime session management', () => {
     expect(fakeAgent.resumedSessions).toEqual([
       expect.objectContaining({
         sessionId,
-        cwd: '/workspace'
+        cwd: resolve('/workspace')
       })
     ])
     expect(fakeAgent.newSessions).toEqual([])


### PR DESCRIPTION
## Problem

The Codex session-resume test compared the normalized ACP working directory against the POSIX literal `/workspace`. On Windows, Node resolves that path to a drive-qualified native path such as `D:\workspace`, causing the post-merge Windows full-test job to fail.

Failing job: https://github.com/aipoch/open-science/actions/runs/30679508834/job/91313571615

## Proposed change

Resolve the expected test path with `node:path.resolve` before comparing the captured resume request.

## Scope and non-goals

- Changes only `src/main/acp/runtime.test.ts`.
- Does not change ACP runtime behavior.
- Does not change the Windows Path Portability or other GitHub Actions workflows.

## Acceptance criteria and validation

- Platform-native ACP resume cwd assertion -> `npm test -- src/main/acp/runtime.test.ts -t 'resumes a valid Codex protocol session id'` -> passed (2 passed).
- Type safety -> `npm run typecheck` -> passed.
- Lint -> `npm run lint` -> passed with existing repository warnings only.
- Full regression suite -> `npm test` -> passed (602 files passed, 11 skipped; 9,027 tests passed, 140 skipped).

All listed checks ran after the final material edit. The full suite required local loopback access; its initial sandboxed run failed with `listen EPERM`, and the same command passed when rerun with loopback access.

## Review focus

Confirm that the expectation now mirrors the runtime's existing `resolve(...)` behavior without weakening the session-id assertions.

## Uncovered risk

The targeted test was validated on macOS locally. Native Windows confirmation remains dependent on GitHub Actions.
