### PR TITLE
refactor(notebook): extract environment lease manager

### DIFF
--- a/src/main/notebook/environment-lease-manager.test.ts
+++ b/src/main/notebook/environment-lease-manager.test.ts
@@ -1,0 +1,127 @@
+import { describe, expect, it } from 'vitest'
+
+import { EnvironmentLeaseManager } from './environment-lease-manager'
+
+describe('EnvironmentLeaseManager', () => {
+  it('serializes exclusive leases for the same environment', async () => {
+    const manager = new EnvironmentLeaseManager()
+    const first = await manager.acquire('analysis', 'exclusive').granted
+    const secondAcquisition = manager.acquire('analysis', 'exclusive')
+    let secondGranted = false
+    void secondAcquisition.granted.then(() => {
+      secondGranted = true
+    })
+
+    await Promise.resolve()
+    expect(secondGranted).toBe(false)
+
+    expect(first.release()).toBe(true)
+    expect(first.release()).toBe(false)
+    const second = await secondAcquisition.granted
+    expect(secondGranted).toBe(true)
+
+    second.release()
+    expect(manager.snapshot().environments).toEqual([])
+  })
+
+  it('shares an environment between runs while an exclusive waiter blocks later runs', async () => {
+    const manager = new EnvironmentLeaseManager()
+    const firstRun = await manager.acquire('analysis', 'shared').granted
+    const secondRunAcquisition = manager.acquire('analysis', 'shared')
+    let secondRunGranted = false
+    void secondRunAcquisition.granted.then(() => {
+      secondRunGranted = true
+    })
+
+    await Promise.resolve()
+    expect(secondRunGranted).toBe(true)
+    const secondRun = await secondRunAcquisition.granted
+
+    const installAcquisition = manager.acquire('analysis', 'exclusive')
+    const laterRunAcquisition = manager.acquire('analysis', 'shared')
+    let installGranted = false
+    let laterRunGranted = false
+    void installAcquisition.granted.then(() => {
+      installGranted = true
+    })
+    void laterRunAcquisition.granted.then(() => {
+      laterRunGranted = true
+    })
+
+    firstRun.release()
+    secondRun.release()
+    const install = await installAcquisition.granted
+    expect(installGranted).toBe(true)
+    expect(laterRunGranted).toBe(false)
+
+    install.release()
+    const laterRun = await laterRunAcquisition.granted
+    expect(laterRunGranted).toBe(true)
+    laterRun.release()
+  })
+
+  it('grants leases for different environments independently', async () => {
+    const manager = new EnvironmentLeaseManager()
+    const first = await manager.acquire('analysis-a', 'exclusive').granted
+
+    const second = await manager.acquire('analysis-b', 'exclusive').granted
+    expect(manager.snapshot().environments).toEqual([
+      {
+        environment: 'analysis-a',
+        holders: { shared: 0, exclusive: 1 },
+        waiters: { shared: 0, exclusive: 0 }
+      },
+      {
+        environment: 'analysis-b',
+        holders: { shared: 0, exclusive: 1 },
+        waiters: { shared: 0, exclusive: 0 }
+      }
+    ])
+
+    first.release()
+    second.release()
+  })
+
+  it('cancels only a pending acquisition and unblocks compatible waiters', async () => {
+    const manager = new EnvironmentLeaseManager()
+    const firstRun = await manager.acquire('analysis', 'shared').granted
+    const installAcquisition = manager.acquire('analysis', 'exclusive')
+    const cancelledInstall = expect(installAcquisition.granted).rejects.toThrow(/cancelled/)
+    const laterRunAcquisition = manager.acquire('analysis', 'shared')
+    let laterRunGranted = false
+    void laterRunAcquisition.granted.then(() => {
+      laterRunGranted = true
+    })
+
+    expect(installAcquisition.cancel()).toBe(true)
+    expect(installAcquisition.cancel()).toBe(false)
+    await cancelledInstall
+    await Promise.resolve()
+    expect(laterRunGranted).toBe(true)
+
+    const laterRun = await laterRunAcquisition.granted
+    expect(laterRunAcquisition.cancel()).toBe(false)
+    firstRun.release()
+    laterRun.release()
+    expect(manager.snapshot().environments).toEqual([])
+  })
+
+  it('disposes every holder and waiter without leaving reusable lease state', async () => {
+    const manager = new EnvironmentLeaseManager()
+    const holder = await manager.acquire('analysis', 'exclusive').granted
+    const pending = manager.acquire('analysis', 'shared')
+    const pendingResult = expect(pending.granted).rejects.toThrow(/disposed/)
+
+    manager.dispose()
+
+    await pendingResult
+    expect(holder.release()).toBe(false)
+    expect(pending.cancel()).toBe(false)
+    expect(manager.snapshot()).toEqual({ disposed: true, environments: [] })
+
+    const afterDispose = manager.acquire('analysis', 'exclusive')
+    await expect(afterDispose.granted).rejects.toThrow(/disposed/)
+    expect(afterDispose.cancel()).toBe(false)
+    manager.dispose()
+  })
+})

--- a/src/main/notebook/environment-lease-manager.ts
+++ b/src/main/notebook/environment-lease-manager.ts
@@ -35,7 +35,6 @@ export class EnvironmentLeaseManager {
   private disposed = false
 
   acquire(environment: string, mode: EnvironmentLeaseMode): EnvironmentLeaseAcquisition {
-    let pending!: PendingAcquisition
     let resolveGranted!: (lease: EnvironmentLease) => void
     let rejectGranted!: (error: Error) => void
     const granted = new Promise<EnvironmentLease>((resolve, reject) => {
@@ -46,7 +45,7 @@ export class EnvironmentLeaseManager {
       granted,
       cancel: () => this.cancelPendingAcquisition(environment, pending)
     }
-    pending = { mode, acquisition, resolve: resolveGranted, reject: rejectGranted }
+    const pending = { mode, acquisition, resolve: resolveGranted, reject: rejectGranted }
 
     if (this.disposed) {
       pending.reject(new Error('Environment lease manager is disposed.'))

--- a/src/main/notebook/environment-lease-manager.ts
+++ b/src/main/notebook/environment-lease-manager.ts
@@ -1,0 +1,176 @@
+export type EnvironmentLeaseMode = 'shared' | 'exclusive'
+
+export type EnvironmentLeaseSnapshot = {
+  disposed: boolean
+  environments: Array<{
+    environment: string
+    holders: { shared: number; exclusive: number }
+    waiters: { shared: number; exclusive: number }
+  }>
+}
+
+export type EnvironmentLease = {
+  release(): boolean
+}
+
+export type EnvironmentLeaseAcquisition = {
+  readonly granted: Promise<EnvironmentLease>
+  cancel(): boolean
+}
+
+type PendingAcquisition = {
+  mode: EnvironmentLeaseMode
+  acquisition: EnvironmentLeaseAcquisition
+  resolve: (lease: EnvironmentLease) => void
+  reject: (error: Error) => void
+}
+
+type EnvironmentLeaseState = {
+  holders: Map<EnvironmentLease, EnvironmentLeaseMode>
+  waiters: PendingAcquisition[]
+}
+
+export class EnvironmentLeaseManager {
+  private readonly states = new Map<string, EnvironmentLeaseState>()
+  private disposed = false
+
+  acquire(environment: string, mode: EnvironmentLeaseMode): EnvironmentLeaseAcquisition {
+    let pending!: PendingAcquisition
+    let resolveGranted!: (lease: EnvironmentLease) => void
+    let rejectGranted!: (error: Error) => void
+    const granted = new Promise<EnvironmentLease>((resolve, reject) => {
+      resolveGranted = resolve
+      rejectGranted = reject
+    })
+    const acquisition: EnvironmentLeaseAcquisition = {
+      granted,
+      cancel: () => this.cancelPendingAcquisition(environment, pending)
+    }
+    pending = { mode, acquisition, resolve: resolveGranted, reject: rejectGranted }
+
+    if (this.disposed) {
+      pending.reject(new Error('Environment lease manager is disposed.'))
+      return acquisition
+    }
+
+    const state = this.stateFor(environment)
+    if (
+      state.waiters.length === 0 &&
+      (state.holders.size === 0 ||
+        (mode === 'shared' &&
+          Array.from(state.holders.values()).every((held) => held === 'shared')))
+    ) {
+      this.grant(environment, state, pending)
+    } else {
+      state.waiters.push(pending)
+    }
+    return acquisition
+  }
+
+  dispose(): void {
+    if (this.disposed) return
+    this.disposed = true
+
+    for (const [environment, state] of Array.from(this.states.entries())) {
+      const waiters = state.waiters.splice(0)
+      for (const waiter of waiters) {
+        waiter.reject(new Error('Environment lease manager is disposed.'))
+      }
+      for (const lease of Array.from(state.holders.keys())) lease.release()
+      this.states.delete(environment)
+    }
+  }
+
+  snapshot(): EnvironmentLeaseSnapshot {
+    return {
+      disposed: this.disposed,
+      environments: Array.from(this.states.entries())
+        .map(([environment, state]) => ({
+          environment,
+          holders: this.countModes(state.holders.values()),
+          waiters: this.countModes(state.waiters.map((waiter) => waiter.mode))
+        }))
+        .sort((left, right) => left.environment.localeCompare(right.environment))
+    }
+  }
+
+  private stateFor(environment: string): EnvironmentLeaseState {
+    let state = this.states.get(environment)
+    if (!state) {
+      state = { holders: new Map(), waiters: [] }
+      this.states.set(environment, state)
+    }
+    return state
+  }
+
+  private grant(
+    environment: string,
+    state: EnvironmentLeaseState,
+    pending: PendingAcquisition
+  ): void {
+    let released = false
+    const lease: EnvironmentLease = {
+      release: () => {
+        if (released) return false
+        released = true
+        this.release(environment, state, lease)
+        return true
+      }
+    }
+    state.holders.set(lease, pending.mode)
+    pending.resolve(lease)
+  }
+
+  private cancelPendingAcquisition(environment: string, pending: PendingAcquisition): boolean {
+    const state = this.states.get(environment)
+    const index = state?.waiters.indexOf(pending) ?? -1
+    if (!state || index < 0) return false
+    state.waiters.splice(index, 1)
+    pending.reject(new Error('Environment lease acquisition was cancelled.'))
+    this.pump(environment, state)
+    this.deleteEmptyState(environment, state)
+    return true
+  }
+
+  private release(
+    environment: string,
+    state: EnvironmentLeaseState,
+    lease: EnvironmentLease
+  ): void {
+    if (!state.holders.delete(lease)) return
+    this.pump(environment, state)
+    this.deleteEmptyState(environment, state)
+  }
+
+  private pump(environment: string, state: EnvironmentLeaseState): void {
+    if (Array.from(state.holders.values()).some((mode) => mode === 'exclusive')) return
+    if (state.holders.size > 0) {
+      while (state.waiters[0]?.mode === 'shared') {
+        this.grant(environment, state, state.waiters.shift()!)
+      }
+      return
+    }
+    const next = state.waiters.shift()
+    if (!next) return
+    this.grant(environment, state, next)
+    if (next.mode === 'exclusive') return
+    while (state.waiters[0]?.mode === 'shared') {
+      this.grant(environment, state, state.waiters.shift()!)
+    }
+  }
+
+  private deleteEmptyState(environment: string, state: EnvironmentLeaseState): void {
+    if (state.holders.size === 0 && state.waiters.length === 0) {
+      this.states.delete(environment)
+    }
+  }
+
+  private countModes(modes: Iterable<EnvironmentLeaseMode>): {
+    shared: number
+    exclusive: number
+  } {
+    const counts = { shared: 0, exclusive: 0 }
+    for (const mode of modes) counts[mode] += 1
+    return counts
+  }
+}

--- a/src/main/notebook/runtime-service.test.ts
+++ b/src/main/notebook/runtime-service.test.ts
@@ -2246,6 +2246,67 @@ describe('notebook runtime service', () => {
       await install
     })
 
+    it('serializes environment mutations that target the same environment', async () => {
+      const root = await createStorageRoot()
+      const service = new NotebookRuntimeService({
+        configRoot: root,
+        dataRoot: root,
+        projectName: 'default-project',
+        repository: new NotebookRunRepository(root)
+      })
+      const events: string[] = []
+      let releaseFirst: (() => void) | undefined
+
+      const first = service.withEnvLock('analysis', async () => {
+        events.push('first:start')
+        await new Promise<void>((resolve) => {
+          releaseFirst = resolve
+        })
+        events.push('first:end')
+      })
+      await vi.waitFor(() => expect(releaseFirst).toBeDefined())
+
+      const second = service.withEnvLock('analysis', async () => {
+        events.push('second:start')
+      })
+      await Promise.resolve()
+      expect(events).toEqual(['first:start'])
+
+      releaseFirst?.()
+      await Promise.all([first, second])
+      expect(events).toEqual(['first:start', 'first:end', 'second:start'])
+    })
+
+    it('allows environment mutations for different environments to proceed concurrently', async () => {
+      const root = await createStorageRoot()
+      const service = new NotebookRuntimeService({
+        configRoot: root,
+        dataRoot: root,
+        projectName: 'default-project',
+        repository: new NotebookRunRepository(root)
+      })
+      const events: string[] = []
+      let releaseFirst: (() => void) | undefined
+
+      const first = service.withEnvLock('analysis-a', async () => {
+        events.push('first:start')
+        await new Promise<void>((resolve) => {
+          releaseFirst = resolve
+        })
+        events.push('first:end')
+      })
+      await vi.waitFor(() => expect(releaseFirst).toBeDefined())
+
+      await service.withEnvLock('analysis-b', async () => {
+        events.push('second:start')
+      })
+      expect(events).toEqual(['first:start', 'second:start'])
+
+      releaseFirst?.()
+      await first
+      expect(events).toEqual(['first:start', 'second:start', 'first:end'])
+    })
+
     it('leaves a terminated kernel status after a run whose kernel rejected (G3)', async () => {
       const root = await createStorageRoot()
       // eslint-disable-next-line prefer-const -- forward ref: the executor closure captures svc before `service` exists

--- a/src/main/notebook/runtime-service.ts
+++ b/src/main/notebook/runtime-service.ts
@@ -109,6 +109,7 @@ import {
   readProcessStartToken
 } from './operation-recovery'
 import { isChildUnconfirmedError } from './provisioner-runtime'
+import { EnvironmentLeaseManager, type EnvironmentLeaseMode } from './environment-lease-manager'
 import { getAppClaudeConfigDir } from '../settings/provider-env'
 import { terminateProcessTree } from '../process-tree'
 import { createLogger, getLogFilePath } from '../logger'
@@ -989,78 +990,16 @@ const findCell = (session: RuntimeSession, cellId: string): NotebookCell => {
   return cell
 }
 
-// Per-ENV readers-writer lock serializing environment management against kernel runs (§5
-// "serialize package management against the target environment"). A run is a shared reader (runs on
-// the same env proceed concurrently, e.g. across
-// sessions), an install is an exclusive writer (blocks every run on that env until it finishes), so a
-// pip/conda/CRAN install can never overlap an in-flight cell on the same env. Keyed by the RESOLVED env
-// name (not language), so installs into DIFFERENT envs run concurrently while install+run on the SAME
-// env stay mutually exclusive. Held at the service instance level because installs are process-global.
-class EnvConcurrencyLock {
-  // Tail of the exclusive (install) chain per env; a live install keeps this promise unresolved.
-  private readonly writer = new Map<string, Promise<void>>()
-  // In-flight readers (runs) per env, awaited by a pending install so it never overlaps one.
-  private readonly readers = new Map<string, Set<Promise<void>>>()
-
-  private readersFor(env: string): Set<Promise<void>> {
-    let set = this.readers.get(env)
-    if (!set) {
-      set = new Set()
-      this.readers.set(env, set)
-    }
-    return set
-  }
-
-  // Shared slot for a kernel run: waits out any active install, then runs concurrently with peers.
-  async withRun<T>(env: string, fn: () => Promise<T>): Promise<T> {
-    // Re-check after each wait so a run that arrives mid-install joins only once the install clears.
-    let active = this.writer.get(env)
-    while (active) {
-      await active
-      active = this.writer.get(env)
-    }
-    // Register synchronously (no await between the writer check above and this add) so a concurrent
-    // install can never slip in and start between our check and registration.
-    const readers = this.readersFor(env)
-    let done!: () => void
-    const reader = new Promise<void>((resolve) => (done = resolve))
-    readers.add(reader)
-    try {
-      return await fn()
-    } finally {
-      readers.delete(reader)
-      done()
-    }
-  }
-
-  // Exclusive slot for an install: waits for the previous install and every in-flight run on this env
-  // to drain, then runs alone. New runs registered after this point block on `mine`.
-  async withInstall<T>(env: string, fn: () => Promise<T>): Promise<T> {
-    const prev = this.writer.get(env) ?? Promise.resolve()
-    let done!: () => void
-    const mine = new Promise<void>((resolve) => (done = resolve))
-    this.writer.set(env, mine)
-    try {
-      await prev
-      await Promise.all(Array.from(this.readersFor(env)))
-      return await fn()
-    } finally {
-      if (this.writer.get(env) === mine) this.writer.delete(env)
-      done()
-    }
-  }
-}
-
 // Coordinates notebook cells, shared interpreters, persisted run history, and UI notifications.
 class NotebookRuntimeService {
   private readonly repository: NotebookRunRepository
   private readonly sessions = new Map<string, RuntimeSession>()
   private readonly announcedAgentSessionIds = new Set<string>()
-  // Serializes environment management (installs) against kernel runs on the same language's env;
-  // shared across this service's sessions because installs are process-global (§5, G2).
-  private readonly envLock = new EnvConcurrencyLock()
+  // Owns per-environment shared run and exclusive mutation leases. The runtime decides which paths
+  // require which mode; acquisition, queueing, cancellation, and release stay inside the manager.
+  private readonly environmentLeases = new EnvironmentLeaseManager()
   // Process-global set of env process keys ('r:<env>') with a pending R-kernel restart recommendation
-  // after an install/uninstall. Shared across sessions like envLock, since installs are process-global;
+  // after an install/uninstall. Shared across sessions like environmentLeases, since installs are process-global;
   // set in managePackages, cleared when the owning session restarts. Only R populates it.
   private readonly restartRecommendedEnvs = new Set<string>()
   // In-flight background drains kicked off by revokeRuntime (disable): each drains the affected env's
@@ -1974,7 +1913,7 @@ class NotebookRuntimeService {
       session,
       runningRun,
       () =>
-        this.envLock.withRun(env, async () => {
+        this.withEnvironmentLease(env, 'shared', async () => {
           // The run may have waited behind an installer after computing interpreterResolveError above.
           // Re-read the repair gate only after the shared run lease is acquired so a transaction that
           // quarantined this env while we waited cannot release the lock and let a stale decision spawn it.
@@ -2593,7 +2532,7 @@ class NotebookRuntimeService {
       binding?.resolvedInterpreter,
       runtimeRoot
     )
-    const inspection = await this.envLock.withRun(envName, () =>
+    const inspection = await this.withEnvironmentLease(envName, 'shared', () =>
       this.environmentStateTracker.inspectPackages(target, request.packages)
     )
     return {
@@ -2859,7 +2798,7 @@ class NotebookRuntimeService {
       // env lock while it clearQuarantine()s the prefix's journal records; recording before acquiring the
       // lock let the Reset delete THIS record between our begin() and the install starting, after which
       // journal.update() no-ops and a crash would strand a sidecar with no journal record recovery scans.
-      result = await this.envLock.withInstall(envName, async () => {
+      result = await this.withEnvironmentLease(envName, 'exclusive', async () => {
         // Fail CLOSED, like the provisioner's prefix writes: if we can't record the intent (journal
         // begin — also throws on a corrupt journal), do NOT spawn the installer; a crash would otherwise
         // leave an unrecorded child recovery can't reap. The begun flag routes this to a structured
@@ -3204,7 +3143,7 @@ class NotebookRuntimeService {
         // it) — creating over a possibly-live prefix could corrupt it.
         this.assertPrefixRecoverable(envPrefix(getRuntimeRoot(this.options.dataRoot), name))
         // Serialize create against installs / other env ops on the same env (design D4 / review A).
-        return this.envLock.withInstall(name, async () => {
+        return this.withEnvironmentLease(name, 'exclusive', async () => {
           await manager.createNamedEnvironment(name, language, request.packages)
           return { environments: manager.listEnvironments() }
         })
@@ -3237,7 +3176,7 @@ class NotebookRuntimeService {
         // is still writing. Mirrors the 'create' guard; keyed by the same real prefix.
         this.assertPrefixRecoverable(envPrefix(getRuntimeRoot(this.options.dataRoot), name))
         // Serialize the rm -rf against a concurrent install into the same env (design D4 / review A).
-        return this.envLock.withInstall(name, async () => {
+        return this.withEnvironmentLease(name, 'exclusive', async () => {
           const environments = manager.removeEnvironment(name)
           this.clearRemovedManagedEnvironmentRepair(name)
           return { environments }
@@ -3474,13 +3413,26 @@ class NotebookRuntimeService {
     return this.liveUnconfirmedPrefixes.has(prefix)
   }
 
-  // Runs fn under the SAME exclusive per-env lock that package installs use (envLock.withInstall), so a
+  // Runs fn under the SAME exclusive per-env lease that package installs use, so a
   // default-env materialize/repair/upgrade in the provisioner serializes with an install into that env
   // instead of racing it on a separate lock. Injected into the provisioner as withPrefixLock (ipc.ts).
   // Keyed by env NAME, matching managePackages/named-env create/remove. The provisioner only calls this
   // from its top-level entries (never re-entrantly), so it cannot deadlock against itself.
   withEnvLock<T>(envName: string, fn: () => Promise<T>): Promise<T> {
-    return this.envLock.withInstall(envName, fn)
+    return this.withEnvironmentLease(envName, 'exclusive', fn)
+  }
+
+  private async withEnvironmentLease<T>(
+    envName: string,
+    mode: EnvironmentLeaseMode,
+    fn: () => Promise<T>
+  ): Promise<T> {
+    const lease = await this.environmentLeases.acquire(envName, mode).granted
+    try {
+      return await fn()
+    } finally {
+      lease.release()
+    }
   }
 
   private async runRecovery(): Promise<void> {


### PR DESCRIPTION
## Problem

Notebook environment concurrency and install/run exclusion were embedded in the runtime service, making lease ownership and cross-environment behavior difficult to reason about and extend safely.

## Proposed change

- Extract a per-environment `EnvironmentLeaseManager` that owns shared/exclusive acquisition, queueing, cancellation, idempotent release, disposal, and diagnostic snapshots.
- Keep `NotebookRuntimeService` as the compatibility façade and retain responsibility for choosing operation modes.
- Preserve writer preference: installs and other exclusive work do not starve behind newly arriving shared runs.

```mermaid
flowchart LR
  R["Notebook runtime façade"] -->|"run: shared"| L["Environment lease manager"]
  R -->|"install/create/remove/provision: exclusive"| L
  L -->|"grant by environment key"| E["Existing execution/package workflow"]
```

## Scope and non-goals

No IPC, preload, Web, CLI, schema, persisted-shape, data-relationship, or user-interaction changes. Specialist, Permission, Compute, recovery, package semantics, and execution semantics are unchanged. The narrow owner remains compatible with a future application-owned orchestrator discussed in #458.

## Acceptance criteria and validation

All checks below ran after the final material edit:

- Same-environment exclusion and cross-environment concurrency -> `npm test -- --run src/main/notebook/environment-lease-manager.test.ts src/main/notebook/runtime-service.test.ts` -> 2 files, 158 tests passed.
- Cancellation, disposal, writer preference, and idempotent release -> same focused command -> passed.
- Node/Web types -> `npm run typecheck` -> passed.
- Repository lint -> `npm run lint` -> passed.
- Regression suite -> `npm test` -> passed.
- Patch hygiene -> `git diff --check origin/main...HEAD` -> passed.
- Independent review -> Standards: 0 findings; Spec: 0 findings.

## Review focus

- Lease lifecycle has one owner and release cannot succeed twice.
- Runtime policy still decides whether an operation is shared or exclusive.
- Environment keys serialize only related work; unrelated environments remain concurrent.

Uncovered risk: coordination remains in-process, as before; no cross-process lease is introduced.
