### PR TITLE
refactor(settings): introduce capability foundations

### DIFF
--- a/src/main/settings/capabilities.test.ts
+++ b/src/main/settings/capabilities.test.ts
@@ -1,0 +1,42 @@
+import { mkdtemp, readFile, rm } from 'node:fs/promises'
+import { tmpdir } from 'node:os'
+import { join } from 'node:path'
+
+import { afterEach, describe, expect, it } from 'vitest'
+
+import { SETTINGS_FILE_VERSION } from '../../shared/settings'
+import { NotebookRuntimeSettingsModule } from './notebook-runtime-settings'
+import { SettingsPreferencesModule } from './preferences'
+import { SettingsRepository } from './repository'
+
+const roots: string[] = []
+
+afterEach(async () => {
+  await Promise.all(roots.splice(0).map((root) => rm(root, { recursive: true, force: true })))
+})
+
+describe('Settings capabilities', () => {
+  it('share one repository writer without changing the stored document shape', async () => {
+    const root = await mkdtemp(join(tmpdir(), 'settings-capabilities-'))
+    roots.push(root)
+    const repository = new SettingsRepository(root)
+    const preferences = new SettingsPreferencesModule(repository)
+    const notebook = new NotebookRuntimeSettingsModule(repository)
+
+    await Promise.all([
+      preferences.setNotificationsEnabled(false),
+      preferences.setClosePreference('minimize'),
+      notebook.setRuntimeSelection('python', { source: 'managed' }),
+      notebook.setPackageMirror({ pypiIndex: 'https://pypi.example/simple' })
+    ])
+
+    expect(JSON.parse(await readFile(join(root, 'settings.json'), 'utf8'))).toEqual({
+      version: SETTINGS_FILE_VERSION,
+      providers: [],
+      notificationsEnabled: false,
+      closePreference: 'minimize',
+      notebookRuntimes: { python: { source: 'managed' } },
+      packageMirror: { pypiIndex: 'https://pypi.example/simple' }
+    })
+  })
+})

--- a/src/main/settings/capabilities.ts
+++ b/src/main/settings/capabilities.ts
@@ -1,0 +1,78 @@
+import type { PackageMirror } from '../../shared/mirror'
+import type { NotebookLanguage } from '../../shared/notebook'
+import type { RuntimeEnablement, RuntimeSelection } from '../../shared/notebook-runtime'
+import type {
+  AppIconVariant,
+  ReasoningEffort,
+  SetPackageMirrorRequest
+} from '../../shared/settings'
+import type { CloseActionPreference } from '../../shared/window-controls'
+
+// A narrow, detached view of app preferences. The capability never exposes the mutable persisted
+// Settings document; callers receive scalar values whose defaults have already been resolved.
+export type SettingsPreferencesSnapshot = {
+  onboardingCompletedAt?: number
+  pathsNormalizedAt?: number
+  legacyDataMovePromptDismissedAt?: number
+  dataRoot?: string
+  reasoningEffort: ReasoningEffort
+  notificationsEnabled: boolean
+  conversationSkillImportEnabled: boolean
+  closePreference?: CloseActionPreference
+  appIconVariant: AppIconVariant
+}
+
+export interface SettingsPreferences {
+  getSnapshot(): Promise<SettingsPreferencesSnapshot>
+  markOnboardingComplete(): Promise<SettingsPreferencesSnapshot>
+  markPathsNormalized(): Promise<SettingsPreferencesSnapshot>
+  setDataRoot(path: string): Promise<SettingsPreferencesSnapshot>
+  dismissLegacyDataMovePrompt(): Promise<SettingsPreferencesSnapshot>
+  setReasoningEffort(effort: ReasoningEffort): Promise<SettingsPreferencesSnapshot>
+  setNotificationsEnabled(enabled: boolean): Promise<SettingsPreferencesSnapshot>
+  setConversationSkillImportEnabled(enabled: boolean): Promise<SettingsPreferencesSnapshot>
+  setClosePreference(
+    preference: CloseActionPreference | undefined
+  ): Promise<SettingsPreferencesSnapshot>
+  setAppIconVariant(variant: AppIconVariant): Promise<SettingsPreferencesSnapshot>
+}
+
+// One language's complete persisted Notebook policy, projected as detached values. Package mirrors
+// are process-global, while runtime selection, enablement, and manual interpreters are per-language.
+export type NotebookRuntimeSettingsSnapshot = {
+  language: NotebookLanguage
+  runtimeSelection?: RuntimeSelection
+  runtimeEnablement: RuntimeEnablement
+  manualInterpreters: string[]
+  packageMirror: PackageMirror
+}
+
+export interface NotebookRuntimeSettings {
+  getSnapshot(language: NotebookLanguage): Promise<NotebookRuntimeSettingsSnapshot>
+  setRuntimeSelection(
+    language: NotebookLanguage,
+    selection: RuntimeSelection | null
+  ): Promise<NotebookRuntimeSettingsSnapshot>
+  setEnvironmentEnabled(
+    language: NotebookLanguage,
+    envId: string,
+    enabled: boolean
+  ): Promise<NotebookRuntimeSettingsSnapshot>
+  setInstallAuthorized(
+    language: NotebookLanguage,
+    envId: string,
+    authorized: boolean
+  ): Promise<NotebookRuntimeSettingsSnapshot>
+  addManualInterpreter(
+    language: NotebookLanguage,
+    path: string
+  ): Promise<NotebookRuntimeSettingsSnapshot>
+  removeManualInterpreter(
+    language: NotebookLanguage,
+    path: string
+  ): Promise<NotebookRuntimeSettingsSnapshot>
+  setPackageMirror(
+    request: SetPackageMirrorRequest,
+    language?: NotebookLanguage
+  ): Promise<NotebookRuntimeSettingsSnapshot>
+}

--- a/src/main/settings/capabilities.ts
+++ b/src/main/settings/capabilities.ts
@@ -49,30 +49,22 @@ export type NotebookRuntimeSettingsSnapshot = {
 
 export interface NotebookRuntimeSettings {
   getSnapshot(language: NotebookLanguage): Promise<NotebookRuntimeSettingsSnapshot>
+  getPackageMirror(): Promise<PackageMirror>
   setRuntimeSelection(
     language: NotebookLanguage,
     selection: RuntimeSelection | null
-  ): Promise<NotebookRuntimeSettingsSnapshot>
+  ): Promise<RuntimeSelection | undefined>
   setEnvironmentEnabled(
     language: NotebookLanguage,
     envId: string,
     enabled: boolean
-  ): Promise<NotebookRuntimeSettingsSnapshot>
+  ): Promise<RuntimeEnablement>
   setInstallAuthorized(
     language: NotebookLanguage,
     envId: string,
     authorized: boolean
-  ): Promise<NotebookRuntimeSettingsSnapshot>
-  addManualInterpreter(
-    language: NotebookLanguage,
-    path: string
-  ): Promise<NotebookRuntimeSettingsSnapshot>
-  removeManualInterpreter(
-    language: NotebookLanguage,
-    path: string
-  ): Promise<NotebookRuntimeSettingsSnapshot>
-  setPackageMirror(
-    request: SetPackageMirrorRequest,
-    language?: NotebookLanguage
-  ): Promise<NotebookRuntimeSettingsSnapshot>
+  ): Promise<RuntimeEnablement>
+  addManualInterpreter(language: NotebookLanguage, path: string): Promise<string[]>
+  removeManualInterpreter(language: NotebookLanguage, path: string): Promise<string[]>
+  setPackageMirror(request: SetPackageMirrorRequest): Promise<PackageMirror>
 }

--- a/src/main/settings/notebook-runtime-settings.test.ts
+++ b/src/main/settings/notebook-runtime-settings.test.ts
@@ -1,0 +1,106 @@
+import { mkdtemp, rm } from 'node:fs/promises'
+import { tmpdir } from 'node:os'
+import { join } from 'node:path'
+
+import { afterEach, describe, expect, it } from 'vitest'
+
+import { NotebookRuntimeSettingsModule } from './notebook-runtime-settings'
+import { SettingsRepository } from './repository'
+
+const roots: string[] = []
+
+const createModule = async (): Promise<NotebookRuntimeSettingsModule> => {
+  const root = await mkdtemp(join(tmpdir(), 'notebook-runtime-settings-'))
+  roots.push(root)
+  return new NotebookRuntimeSettingsModule(new SettingsRepository(root))
+}
+
+afterEach(async () => {
+  await Promise.all(roots.splice(0).map((root) => rm(root, { recursive: true, force: true })))
+})
+
+describe('NotebookRuntimeSettingsModule', () => {
+  it('returns a detached default policy snapshot for one language', async () => {
+    const settings = await createModule()
+
+    const snapshot = await settings.getSnapshot('python')
+
+    expect(snapshot).toEqual({
+      language: 'python',
+      runtimeEnablement: { enabled: {}, installAuthorized: {} },
+      manualInterpreters: [],
+      packageMirror: {}
+    })
+  })
+
+  it('persists and clears a runtime selection through the repository policy', async () => {
+    const settings = await createModule()
+    const selection = {
+      source: 'external' as const,
+      interpreterPath: '/usr/bin/python3',
+      interpreterArgs: ['-I'],
+      appOwnedOverlay: false,
+      packageInstallAuthorized: true
+    }
+
+    await expect(settings.setRuntimeSelection('python', selection)).resolves.toEqual(selection)
+
+    const snapshot = await settings.getSnapshot('python')
+    expect(snapshot.runtimeSelection).toEqual(selection)
+    if (snapshot.runtimeSelection?.source === 'external') {
+      snapshot.runtimeSelection.interpreterArgs?.push('--mutated')
+    }
+    expect((await settings.getSnapshot('python')).runtimeSelection).toEqual(selection)
+
+    await expect(settings.setRuntimeSelection('python', null)).resolves.toBeUndefined()
+    expect((await settings.getSnapshot('python')).runtimeSelection).toBeUndefined()
+  })
+
+  it('keeps environment enablement and install authorization as separate choices', async () => {
+    const settings = await createModule()
+
+    await expect(
+      settings.setEnvironmentEnabled('python', '/usr/bin/python3', true)
+    ).resolves.toEqual({
+      enabled: { '/usr/bin/python3': true },
+      installAuthorized: {}
+    })
+    await expect(
+      settings.setInstallAuthorized('python', '/usr/bin/python3', false)
+    ).resolves.toEqual({
+      enabled: { '/usr/bin/python3': true },
+      installAuthorized: { '/usr/bin/python3': false }
+    })
+
+    const snapshot = await settings.getSnapshot('python')
+    snapshot.runtimeEnablement.enabled['/usr/bin/python3'] = false
+    expect((await settings.getSnapshot('python')).runtimeEnablement).toEqual({
+      enabled: { '/usr/bin/python3': true },
+      installAuthorized: { '/usr/bin/python3': false }
+    })
+  })
+
+  it('preserves repository normalization for manual interpreters and package mirrors', async () => {
+    const settings = await createModule()
+
+    await settings.addManualInterpreter('python', '  /opt/python/bin/python3  ')
+    await expect(
+      settings.addManualInterpreter('python', '/opt/python/bin/python3')
+    ).resolves.toEqual(['/opt/python/bin/python3'])
+    await expect(
+      settings.setPackageMirror({
+        condaChannel: ' https://mirror.example/conda ',
+        pypiIndex: ''
+      })
+    ).resolves.toEqual({ condaChannel: ' https://mirror.example/conda ' })
+
+    const snapshot = await settings.getSnapshot('python')
+    expect(snapshot.manualInterpreters).toEqual(['/opt/python/bin/python3'])
+    expect(snapshot.packageMirror).toEqual({ condaChannel: ' https://mirror.example/conda ' })
+
+    await expect(
+      settings.removeManualInterpreter('python', '/opt/python/bin/python3')
+    ).resolves.toEqual([])
+    await expect(settings.setPackageMirror({})).resolves.toEqual({})
+  })
+})

--- a/src/main/settings/notebook-runtime-settings.ts
+++ b/src/main/settings/notebook-runtime-settings.ts
@@ -1,0 +1,111 @@
+import type { PackageMirror } from '../../shared/mirror'
+import type { NotebookLanguage } from '../../shared/notebook'
+import type { RuntimeEnablement, RuntimeSelection } from '../../shared/notebook-runtime'
+import type { SetPackageMirrorRequest } from '../../shared/settings'
+import type { NotebookRuntimeSettings, NotebookRuntimeSettingsSnapshot } from './capabilities'
+import type { SettingsRepository } from './repository'
+import type { StoredSettings } from './types'
+
+const cloneRuntimeSelection = (
+  selection: RuntimeSelection | undefined
+): RuntimeSelection | undefined => {
+  if (!selection) return undefined
+  if (selection.source === 'managed') return { source: 'managed' }
+
+  return {
+    ...selection,
+    ...(selection.interpreterArgs ? { interpreterArgs: [...selection.interpreterArgs] } : {})
+  }
+}
+
+const cloneRuntimeEnablement = (enablement: RuntimeEnablement | undefined): RuntimeEnablement => ({
+  enabled: { ...enablement?.enabled },
+  installAuthorized: { ...enablement?.installAuthorized }
+})
+
+const clonePackageMirror = (mirror: PackageMirror | undefined): PackageMirror => ({ ...mirror })
+
+const toNotebookRuntimeSettingsSnapshot = (
+  settings: StoredSettings,
+  language: NotebookLanguage
+): NotebookRuntimeSettingsSnapshot => ({
+  language,
+  ...(settings.notebookRuntimes?.[language]
+    ? { runtimeSelection: cloneRuntimeSelection(settings.notebookRuntimes[language]) }
+    : {}),
+  runtimeEnablement: cloneRuntimeEnablement(settings.notebookRuntimeEnablement?.[language]),
+  manualInterpreters: [...(settings.notebookManualInterpreters?.[language] ?? [])],
+  packageMirror: clonePackageMirror(settings.packageMirror)
+})
+
+class NotebookRuntimeSettingsModule implements NotebookRuntimeSettings {
+  constructor(private readonly repository: SettingsRepository) {}
+
+  async getSnapshot(language: NotebookLanguage): Promise<NotebookRuntimeSettingsSnapshot> {
+    return toNotebookRuntimeSettingsSnapshot(await this.repository.getSettings(), language)
+  }
+
+  async getPackageMirror(): Promise<PackageMirror> {
+    return clonePackageMirror((await this.repository.getSettings()).packageMirror)
+  }
+
+  async setRuntimeSelection(
+    language: NotebookLanguage,
+    selection: RuntimeSelection | null
+  ): Promise<RuntimeSelection | undefined> {
+    const settings = await this.repository.setRuntimeSelection(language, selection)
+    return cloneRuntimeSelection(settings.notebookRuntimes?.[language])
+  }
+
+  async setEnvironmentEnabled(
+    language: NotebookLanguage,
+    envId: string,
+    enabled: boolean
+  ): Promise<RuntimeEnablement> {
+    const current = (await this.getSnapshot(language)).runtimeEnablement
+    const settings = await this.repository.setRuntimeEnablement(language, {
+      enabled: { ...current.enabled, [envId]: enabled },
+      installAuthorized: { ...current.installAuthorized }
+    })
+
+    return cloneRuntimeEnablement(settings.notebookRuntimeEnablement?.[language])
+  }
+
+  async setInstallAuthorized(
+    language: NotebookLanguage,
+    envId: string,
+    authorized: boolean
+  ): Promise<RuntimeEnablement> {
+    const current = (await this.getSnapshot(language)).runtimeEnablement
+    const settings = await this.repository.setRuntimeEnablement(language, {
+      enabled: { ...current.enabled },
+      installAuthorized: { ...current.installAuthorized, [envId]: authorized }
+    })
+
+    return cloneRuntimeEnablement(settings.notebookRuntimeEnablement?.[language])
+  }
+
+  async addManualInterpreter(language: NotebookLanguage, path: string): Promise<string[]> {
+    const current = (await this.getSnapshot(language)).manualInterpreters
+    const settings = await this.repository.setManualInterpreters(language, [...current, path])
+
+    return [...(settings.notebookManualInterpreters?.[language] ?? [])]
+  }
+
+  async removeManualInterpreter(language: NotebookLanguage, path: string): Promise<string[]> {
+    const current = (await this.getSnapshot(language)).manualInterpreters
+    const settings = await this.repository.setManualInterpreters(
+      language,
+      current.filter((candidate) => candidate !== path)
+    )
+
+    return [...(settings.notebookManualInterpreters?.[language] ?? [])]
+  }
+
+  async setPackageMirror(request: SetPackageMirrorRequest): Promise<PackageMirror> {
+    const settings = await this.repository.setPackageMirror(request)
+    return clonePackageMirror(settings.packageMirror)
+  }
+}
+
+export { NotebookRuntimeSettingsModule, toNotebookRuntimeSettingsSnapshot }

--- a/src/main/settings/preferences.test.ts
+++ b/src/main/settings/preferences.test.ts
@@ -1,0 +1,76 @@
+import { mkdtemp, rm } from 'node:fs/promises'
+import { tmpdir } from 'node:os'
+import { join } from 'node:path'
+
+import { afterEach, describe, expect, it } from 'vitest'
+
+import { SettingsPreferencesModule } from './preferences'
+import { SettingsRepository } from './repository'
+
+const roots: string[] = []
+
+const createModule = async (
+  now = 1_000
+): Promise<{ preferences: SettingsPreferencesModule; repository: SettingsRepository }> => {
+  const root = await mkdtemp(join(tmpdir(), 'settings-preferences-'))
+  roots.push(root)
+  const repository = new SettingsRepository(root)
+  return { preferences: new SettingsPreferencesModule(repository, () => now), repository }
+}
+
+afterEach(async () => {
+  await Promise.all(roots.splice(0).map((root) => rm(root, { recursive: true, force: true })))
+})
+
+describe('SettingsPreferencesModule', () => {
+  it('resolves preference defaults without exposing the stored document', async () => {
+    const { preferences } = await createModule()
+
+    await expect(preferences.getSnapshot()).resolves.toEqual({
+      reasoningEffort: 'default',
+      notificationsEnabled: true,
+      conversationSkillImportEnabled: true,
+      appIconVariant: 'light'
+    })
+  })
+
+  it('persists scalar commands with the existing defaults and one-time markers', async () => {
+    const { preferences, repository } = await createModule(2_000)
+
+    await preferences.setReasoningEffort('high')
+    await preferences.setNotificationsEnabled(false)
+    await preferences.setConversationSkillImportEnabled(false)
+    await preferences.setClosePreference('quit')
+    await preferences.setAppIconVariant('dark')
+    await preferences.setDataRoot('/data/open-science')
+    await preferences.markOnboardingComplete()
+    await preferences.markPathsNormalized()
+    await preferences.dismissLegacyDataMovePrompt()
+
+    await expect(preferences.getSnapshot()).resolves.toEqual({
+      onboardingCompletedAt: 2_000,
+      pathsNormalizedAt: 2_000,
+      legacyDataMovePromptDismissedAt: 2_000,
+      dataRoot: '/data/open-science',
+      reasoningEffort: 'high',
+      notificationsEnabled: false,
+      conversationSkillImportEnabled: false,
+      closePreference: 'quit',
+      appIconVariant: 'dark'
+    })
+
+    await preferences.setClosePreference(undefined)
+    await preferences.markOnboardingComplete()
+    await expect(repository.getSettings()).resolves.toMatchObject({
+      onboardingCompletedAt: 2_000,
+      pathsNormalizedAt: 2_000,
+      legacyDataMovePromptDismissedAt: 2_000,
+      dataRoot: '/data/open-science',
+      reasoningEffort: 'high',
+      notificationsEnabled: false,
+      conversationSkillImportEnabled: false,
+      appIconVariant: 'dark'
+    })
+    expect((await repository.getSettings()).closePreference).toBeUndefined()
+  })
+})

--- a/src/main/settings/preferences.ts
+++ b/src/main/settings/preferences.ts
@@ -1,0 +1,89 @@
+import {
+  DEFAULT_APP_ICON_VARIANT,
+  DEFAULT_CONVERSATION_SKILL_IMPORT_ENABLED,
+  DEFAULT_NOTIFICATIONS_ENABLED,
+  DEFAULT_REASONING_EFFORT,
+  type AppIconVariant,
+  type ReasoningEffort
+} from '../../shared/settings'
+import type { CloseActionPreference } from '../../shared/window-controls'
+import type { SettingsPreferences, SettingsPreferencesSnapshot } from './capabilities'
+import type { SettingsRepository } from './repository'
+import type { StoredSettings } from './types'
+
+// Project only the values owned by this module. Keeping the projection here lets the compatibility
+// facade combine one repository read with its provider/runtime views without exposing StoredSettings
+// through the capability interface.
+const toSettingsPreferencesSnapshot = (settings: StoredSettings): SettingsPreferencesSnapshot => ({
+  ...(settings.onboardingCompletedAt === undefined
+    ? {}
+    : { onboardingCompletedAt: settings.onboardingCompletedAt }),
+  ...(settings.pathsNormalizedAt === undefined
+    ? {}
+    : { pathsNormalizedAt: settings.pathsNormalizedAt }),
+  ...(settings.legacyDataMovePromptDismissedAt === undefined
+    ? {}
+    : { legacyDataMovePromptDismissedAt: settings.legacyDataMovePromptDismissedAt }),
+  ...(settings.dataRoot === undefined ? {} : { dataRoot: settings.dataRoot }),
+  reasoningEffort: settings.reasoningEffort ?? DEFAULT_REASONING_EFFORT,
+  notificationsEnabled: settings.notificationsEnabled ?? DEFAULT_NOTIFICATIONS_ENABLED,
+  conversationSkillImportEnabled:
+    settings.conversationSkillImportEnabled ?? DEFAULT_CONVERSATION_SKILL_IMPORT_ENABLED,
+  ...(settings.closePreference === undefined ? {} : { closePreference: settings.closePreference }),
+  appIconVariant: settings.appIconVariant ?? DEFAULT_APP_ICON_VARIANT
+})
+
+class SettingsPreferencesModule implements SettingsPreferences {
+  constructor(
+    private readonly repository: SettingsRepository,
+    private readonly now: () => number = Date.now
+  ) {}
+
+  async getSnapshot(): Promise<SettingsPreferencesSnapshot> {
+    return toSettingsPreferencesSnapshot(await this.repository.getSettings())
+  }
+
+  async markOnboardingComplete(): Promise<SettingsPreferencesSnapshot> {
+    return toSettingsPreferencesSnapshot(await this.repository.markOnboardingComplete(this.now()))
+  }
+
+  async markPathsNormalized(): Promise<SettingsPreferencesSnapshot> {
+    return toSettingsPreferencesSnapshot(await this.repository.markPathsNormalized(this.now()))
+  }
+
+  async setDataRoot(path: string): Promise<SettingsPreferencesSnapshot> {
+    return toSettingsPreferencesSnapshot(await this.repository.setDataRoot(path))
+  }
+
+  async dismissLegacyDataMovePrompt(): Promise<SettingsPreferencesSnapshot> {
+    return toSettingsPreferencesSnapshot(
+      await this.repository.markLegacyDataMovePromptDismissed(this.now())
+    )
+  }
+
+  async setReasoningEffort(effort: ReasoningEffort): Promise<SettingsPreferencesSnapshot> {
+    return toSettingsPreferencesSnapshot(await this.repository.setReasoningEffort(effort))
+  }
+
+  async setNotificationsEnabled(enabled: boolean): Promise<SettingsPreferencesSnapshot> {
+    return toSettingsPreferencesSnapshot(await this.repository.setNotificationsEnabled(enabled))
+  }
+
+  async setConversationSkillImportEnabled(enabled: boolean): Promise<SettingsPreferencesSnapshot> {
+    return toSettingsPreferencesSnapshot(
+      await this.repository.setConversationSkillImportEnabled(enabled)
+    )
+  }
+
+  async setClosePreference(
+    preference: CloseActionPreference | undefined
+  ): Promise<SettingsPreferencesSnapshot> {
+    return toSettingsPreferencesSnapshot(await this.repository.setClosePreference(preference))
+  }
+
+  async setAppIconVariant(variant: AppIconVariant): Promise<SettingsPreferencesSnapshot> {
+    return toSettingsPreferencesSnapshot(await this.repository.setAppIconVariant(variant))
+  }
+}
+
+export { SettingsPreferencesModule, toSettingsPreferencesSnapshot }

--- a/src/main/settings/service.ts
+++ b/src/main/settings/service.ts
@@ -199,6 +199,7 @@ import { NativeResponsesCompatibilityProxy } from './native-responses-compatibil
 import { SettingsRepository } from './repository'
 import { sanitizeCustomMcpServer } from './repository'
 import { SettingsPreferencesModule, toSettingsPreferencesSnapshot } from './preferences'
+import { NotebookRuntimeSettingsModule } from './notebook-runtime-settings'
 import { CONNECTOR_CATALOG } from '../connectors/catalog'
 import { getConnectorTools } from '../connectors/registry'
 import { renderConnectorInstructions } from '../connectors/skill-doc'
@@ -560,6 +561,7 @@ export type SettingsServiceOptions = {
 class SettingsService {
   private readonly repository: SettingsRepository
   private readonly preferences: SettingsPreferencesModule
+  private readonly notebookRuntimeSettings: NotebookRuntimeSettingsModule
   private readonly storageRoot: string
   private readonly detectDeps: ClaudeDetectDeps
   private readonly opencodeDetectDeps: OpencodeDetectDeps
@@ -603,6 +605,7 @@ class SettingsService {
     this.storageRoot = options.storageRoot ?? resolveStorageRoot()
     this.repository = options.repository ?? new SettingsRepository(this.storageRoot)
     this.preferences = new SettingsPreferencesModule(this.repository)
+    this.notebookRuntimeSettings = new NotebookRuntimeSettingsModule(this.repository)
     // Probe the app-managed install dir too, so a managed Claude is re-detected even if the cached
     // path is ever cleared (e.g. a manual re-detect).
     const baseDetectDeps = options.detectDeps ?? createDefaultDetectDeps()
@@ -786,13 +789,13 @@ class SettingsService {
   // Reads the package-mirror configuration, read fresh so callers see the latest saved state.
   // Empty object means public hosts (no override configured).
   async getPackageMirror(): Promise<PackageMirror> {
-    return (await this.repository.getSettings()).packageMirror ?? {}
+    return this.notebookRuntimeSettings.getPackageMirror()
   }
 
   // The persisted notebook runtime selection for a language (managed vs the user's own interpreter),
   // read fresh. undefined means "not chosen" -> the notebook runtime resolves to the managed default.
   async getRuntimeSelection(language: NotebookLanguage): Promise<RuntimeSelection | undefined> {
-    return (await this.repository.getSettings()).notebookRuntimes?.[language]
+    return (await this.notebookRuntimeSettings.getSnapshot(language)).runtimeSelection
   }
 
   // Sets (or clears, when `selection` is null) the persisted runtime choice for a language, returning
@@ -802,18 +805,14 @@ class SettingsService {
     language: NotebookLanguage,
     selection: RuntimeSelection | null
   ): Promise<RuntimeSelection | undefined> {
-    const settings = await this.repository.setRuntimeSelection(language, selection)
-
-    return settings.notebookRuntimes?.[language]
+    return this.notebookRuntimeSettings.setRuntimeSelection(language, selection)
   }
 
   // The persisted v4 environment enablement for a language, read fresh. Always returns a concrete
   // RuntimeEnablement (empty maps when nothing is stored) so callers can index it and apply the
   // provenance default (isEnvEnabled) without a null check.
   async getRuntimeEnablement(language: NotebookLanguage): Promise<RuntimeEnablement> {
-    const stored = (await this.repository.getSettings()).notebookRuntimeEnablement?.[language]
-
-    return { enabled: { ...stored?.enabled }, installAuthorized: { ...stored?.installAuthorized } }
+    return (await this.notebookRuntimeSettings.getSnapshot(language)).runtimeEnablement
   }
 
   // Sets one env's explicit enabled override (keyed by envId) for a language, read-modify-write over
@@ -824,14 +823,7 @@ class SettingsService {
     envId: string,
     enabled: boolean
   ): Promise<RuntimeEnablement> {
-    const current = await this.getRuntimeEnablement(language)
-    const next: RuntimeEnablement = {
-      enabled: { ...current.enabled, [envId]: enabled },
-      installAuthorized: { ...current.installAuthorized }
-    }
-    const settings = await this.repository.setRuntimeEnablement(language, next)
-
-    return settings.notebookRuntimeEnablement?.[language] ?? { enabled: {}, installAuthorized: {} }
+    return this.notebookRuntimeSettings.setEnvironmentEnabled(language, envId, enabled)
   }
 
   // Sets one env's high-risk package-install authorization (keyed by envId) for a language, returning
@@ -842,44 +834,28 @@ class SettingsService {
     envId: string,
     authorized: boolean
   ): Promise<RuntimeEnablement> {
-    const current = await this.getRuntimeEnablement(language)
-    const next: RuntimeEnablement = {
-      enabled: { ...current.enabled },
-      installAuthorized: { ...current.installAuthorized, [envId]: authorized }
-    }
-    const settings = await this.repository.setRuntimeEnablement(language, next)
-
-    return settings.notebookRuntimeEnablement?.[language] ?? { enabled: {}, installAuthorized: {} }
+    return this.notebookRuntimeSettings.setInstallAuthorized(language, envId, authorized)
   }
 
   // The manual-interpreter catalog for a language (paths added via "Add interpreter…"), for merging
   // into environment discovery. Empty array when none.
   async getManualInterpreters(language: NotebookLanguage): Promise<string[]> {
-    return (await this.repository.getSettings()).notebookManualInterpreters?.[language] ?? []
+    return (await this.notebookRuntimeSettings.getSnapshot(language)).manualInterpreters
   }
 
   // Adds an interpreter path to a language's manual catalog (idempotent), returning the refreshed list.
   async addManualInterpreter(language: NotebookLanguage, path: string): Promise<string[]> {
-    const current = await this.getManualInterpreters(language)
-    const settings = await this.repository.setManualInterpreters(language, [...current, path])
-    return settings.notebookManualInterpreters?.[language] ?? []
+    return this.notebookRuntimeSettings.addManualInterpreter(language, path)
   }
 
   // Removes an interpreter path from a language's manual catalog, returning the refreshed list.
   async removeManualInterpreter(language: NotebookLanguage, path: string): Promise<string[]> {
-    const current = await this.getManualInterpreters(language)
-    const settings = await this.repository.setManualInterpreters(
-      language,
-      current.filter((p) => p !== path)
-    )
-    return settings.notebookManualInterpreters?.[language] ?? []
+    return this.notebookRuntimeSettings.removeManualInterpreter(language, path)
   }
 
   // Sets (or clears) the package-mirror configuration and returns the sanitized, persisted value.
   async setPackageMirror(request: SetPackageMirrorRequest): Promise<PackageMirror> {
-    const settings = await this.repository.setPackageMirror(request)
-
-    return settings.packageMirror ?? {}
+    return this.notebookRuntimeSettings.setPackageMirror(request)
   }
 
   private async migrateLegacyKeyRefs(settings: StoredSettings): Promise<StoredSettings> {

--- a/src/main/settings/service.ts
+++ b/src/main/settings/service.ts
@@ -77,9 +77,7 @@ import {
   claudeIsolatedProviderIdentity,
   claudeSharedProviderIdentity,
   codexSubscriptionProviderIdentity,
-  DEFAULT_APP_ICON_VARIANT,
   DEFAULT_CONVERSATION_SKILL_IMPORT_ENABLED,
-  DEFAULT_NOTIFICATIONS_ENABLED,
   DEFAULT_REASONING_EFFORT,
   isClaudeSubscriptionProvider,
   isClaudeSubscriptionProviderId,
@@ -200,6 +198,7 @@ import {
 import { NativeResponsesCompatibilityProxy } from './native-responses-compatibility'
 import { SettingsRepository } from './repository'
 import { sanitizeCustomMcpServer } from './repository'
+import { SettingsPreferencesModule, toSettingsPreferencesSnapshot } from './preferences'
 import { CONNECTOR_CATALOG } from '../connectors/catalog'
 import { getConnectorTools } from '../connectors/registry'
 import { renderConnectorInstructions } from '../connectors/skill-doc'
@@ -560,6 +559,7 @@ export type SettingsServiceOptions = {
 // transiently; nothing that leaves this object (views, spawn config aside) carries plaintext.
 class SettingsService {
   private readonly repository: SettingsRepository
+  private readonly preferences: SettingsPreferencesModule
   private readonly storageRoot: string
   private readonly detectDeps: ClaudeDetectDeps
   private readonly opencodeDetectDeps: OpencodeDetectDeps
@@ -602,6 +602,7 @@ class SettingsService {
   constructor(options: SettingsServiceOptions = {}) {
     this.storageRoot = options.storageRoot ?? resolveStorageRoot()
     this.repository = options.repository ?? new SettingsRepository(this.storageRoot)
+    this.preferences = new SettingsPreferencesModule(this.repository)
     // Probe the app-managed install dir too, so a managed Claude is re-detected even if the cached
     // path is ever cleared (e.g. a manual re-detect).
     const baseDetectDeps = options.detectDeps ?? createDefaultDetectDeps()
@@ -737,6 +738,7 @@ class SettingsService {
   // Returns the renderer-safe (masked) snapshot of settings.
   async getSettingsView(): Promise<SettingsSnapshot> {
     const settings = await this.migrateLegacyKeyRefs(await this.repository.getSettings())
+    const preferences = toSettingsPreferencesSnapshot(settings)
 
     return {
       claude: settings.claude ?? {},
@@ -764,14 +766,13 @@ class SettingsService {
           provider.id === settings.activeProviderId ? settings.activeModel : undefined
         )
       ),
-      onboardingCompletedAt: settings.onboardingCompletedAt,
+      onboardingCompletedAt: preferences.onboardingCompletedAt,
       packageMirror: settings.packageMirror,
-      reasoningEffort: settings.reasoningEffort ?? DEFAULT_REASONING_EFFORT,
-      notificationsEnabled: settings.notificationsEnabled ?? DEFAULT_NOTIFICATIONS_ENABLED,
-      conversationSkillImportEnabled:
-        settings.conversationSkillImportEnabled ?? DEFAULT_CONVERSATION_SKILL_IMPORT_ENABLED,
-      closePreference: settings.closePreference,
-      appIconVariant: settings.appIconVariant ?? DEFAULT_APP_ICON_VARIANT,
+      reasoningEffort: preferences.reasoningEffort,
+      notificationsEnabled: preferences.notificationsEnabled,
+      conversationSkillImportEnabled: preferences.conversationSkillImportEnabled,
+      closePreference: preferences.closePreference,
+      appIconVariant: preferences.appIconVariant,
       agentFrameworkId: settings.agentFrameworkId ?? DEFAULT_AGENT_FRAMEWORK_ID,
       agentFrameworks: listAgentFrameworks().map((framework) => ({
         id: framework.id,
@@ -915,7 +916,7 @@ class SettingsService {
   // Sets the reasoning-effort preference. Where the framework supports it the caller applies the
   // level live over ACP (otherwise it reconnects); the persisted value drives the next spawn.
   async setReasoningEffort(effort: ReasoningEffort): Promise<SettingsSnapshot> {
-    await this.repository.setReasoningEffort(effort)
+    await this.preferences.setReasoningEffort(effort)
 
     return this.getSettingsView()
   }
@@ -932,14 +933,12 @@ class SettingsService {
   // Whether desktop notifications for finished/failed agent tasks are on, read fresh so the
   // notification path sees a toggle change immediately (no restart, no cached copy to go stale).
   async getNotificationsEnabled(): Promise<boolean> {
-    return (
-      (await this.repository.getSettings()).notificationsEnabled ?? DEFAULT_NOTIFICATIONS_ENABLED
-    )
+    return (await this.preferences.getSnapshot()).notificationsEnabled
   }
 
   // Sets the desktop-notification preference and returns the refreshed snapshot for the renderer.
   async setNotificationsEnabled(enabled: boolean): Promise<SettingsSnapshot> {
-    await this.repository.setNotificationsEnabled(enabled)
+    await this.preferences.setNotificationsEnabled(enabled)
 
     return this.getSettingsView()
   }
@@ -947,38 +946,35 @@ class SettingsService {
   // Read fresh for every agent-session MCP build so disabling the feature removes the server and its
   // prompt guidance after the settings-triggered reconnect without restarting the app.
   async getConversationSkillImportEnabled(): Promise<boolean> {
-    return (
-      (await this.repository.getSettings()).conversationSkillImportEnabled ??
-      DEFAULT_CONVERSATION_SKILL_IMPORT_ENABLED
-    )
+    return (await this.preferences.getSnapshot()).conversationSkillImportEnabled
   }
 
   async setConversationSkillImportEnabled(enabled: boolean): Promise<SettingsSnapshot> {
-    await this.repository.setConversationSkillImportEnabled(enabled)
+    await this.preferences.setConversationSkillImportEnabled(enabled)
 
     return this.getSettingsView()
   }
 
   async getClosePreference(): Promise<CloseActionPreference | undefined> {
-    return (await this.repository.getSettings()).closePreference
+    return (await this.preferences.getSnapshot()).closePreference
   }
 
   async setClosePreference(
     preference: CloseActionPreference | undefined
   ): Promise<SettingsSnapshot> {
-    await this.repository.setClosePreference(preference)
+    await this.preferences.setClosePreference(preference)
 
     return this.getSettingsView()
   }
 
   // The selected app-icon look, read fresh so the startup apply reflects the latest saved choice.
   async getAppIconVariant(): Promise<AppIconVariant> {
-    return (await this.repository.getSettings()).appIconVariant ?? DEFAULT_APP_ICON_VARIANT
+    return (await this.preferences.getSnapshot()).appIconVariant
   }
 
   // Persists the app-icon look; the caller applies it live to the window and dock/taskbar.
   async setAppIconVariant(variant: AppIconVariant): Promise<SettingsSnapshot> {
-    await this.repository.setAppIconVariant(variant)
+    await this.preferences.setAppIconVariant(variant)
 
     return this.getSettingsView()
   }
@@ -2254,7 +2250,7 @@ class SettingsService {
 
   // Records that first-run onboarding finished so later launches skip the wizard.
   async markOnboardingComplete(): Promise<SettingsSnapshot> {
-    await this.repository.markOnboardingComplete(Date.now())
+    await this.preferences.markOnboardingComplete()
 
     return this.getSettingsView()
   }
@@ -2263,19 +2259,19 @@ class SettingsService {
   // launches skip it. The caller is responsible for only invoking this after the pass actually
   // completed without throwing (see normalizeLegacyDataPaths).
   async markPathsNormalized(): Promise<void> {
-    await this.repository.markPathsNormalized(Date.now())
+    await this.preferences.markPathsNormalized()
   }
 
   // Persists the new data-root path after a successful migration (see storage/migration-service.ts).
   // The caller is responsible for only invoking this once the move itself has succeeded.
   async setDataRoot(path: string): Promise<void> {
-    await this.repository.setDataRoot(path)
+    await this.preferences.setDataRoot(path)
   }
 
   // Records that the user has answered the one-time legacy-data-move prompt (moved, relocated, or
   // declined), so it is never shown again. Idempotent-once at the repository layer.
   async dismissLegacyDataMovePrompt(): Promise<void> {
-    await this.repository.markLegacyDataMovePromptDismissed(Date.now())
+    await this.preferences.dismissLegacyDataMovePrompt()
   }
 
   // Encrypts any new key, recomputes its mask, and inserts/updates the provider record.


### PR DESCRIPTION
## Problem

`SettingsService` owned persistence, scalar preferences, Notebook runtime policy, onboarding markers, notification settings, and other unrelated state behind one broad interface. That made the service difficult to evolve and encouraged consumers to depend on more settings behavior than they need.

## Proposed change

- Introduce narrow Preferences and Notebook runtime settings capabilities with immutable snapshots.
- Extract their behavior into focused modules while keeping `SettingsService` as a compatibility façade.
- Share the existing `SettingsRepository` so the persistence queue remains the single writer and the stored shape remains unchanged.

```mermaid
flowchart LR
  C["Existing callers"] --> F["SettingsService compatibility façade"]
  F --> P["Preferences capability"]
  F --> N["Notebook runtime settings capability"]
  P --> R["One SettingsRepository / write queue"]
  N --> R
```

## Scope and non-goals

No schema, stored-shape, data-relationship, IPC, preload, Web, CLI, or user-interaction changes. Specialist, Permission, and Compute behavior is untouched. The narrower capability seams support a future application-owned orchestrator such as #458 without exposing the complete Settings service.

## Acceptance criteria and validation

All checks below ran after the final material edit:

- Capability isolation and façade compatibility -> `npm test -- --run src/main/settings/capabilities.test.ts src/main/settings/preferences.test.ts src/main/settings/notebook-runtime-settings.test.ts` -> 3 files, 7 tests passed.
- Settings/Notebook regression set -> focused suite -> 7 files, 335 tests passed.
- Electron/Web/CLI compatibility contracts -> F0 contract suite -> 10 files, 473 tests passed.
- Node/Web types -> `npm run typecheck` -> passed.
- Repository lint -> `npm run lint` -> 0 errors; 23 pre-existing warnings.
- Regression suite -> `npm test` -> 606 files passed, 11 skipped; 9,047 tests passed, 140 skipped.
- Patch hygiene -> `git diff --check origin/main...HEAD` -> passed.
- Independent review -> Standards: 0 findings; Spec: 0 findings.

## Review focus

- `SettingsService` method signatures and observable behavior remain compatible.
- Both capability modules use the same repository and persistence queue.
- Callers can depend on a narrow interface without gaining a settings service locator.

Uncovered risk: this PR establishes capability seams but intentionally does not migrate every caller away from the compatibility façade.
