### PR TITLE
refactor(acp): extract snapshot and context owners

### DIFF
--- a/src/main/acp/context-usage-tracker.test.ts
+++ b/src/main/acp/context-usage-tracker.test.ts
@@ -675,4 +675,74 @@ describe('ContextUsageTracker', () => {
       estimated: true
     })
   })
+
+  it('owns provider reconciliation without exposing mutable usage collections', () => {
+    const tracker = new ContextUsageTracker(wordCounter)
+    tracker.beginSession('s1', { frameworkId: 'opencode', model: 'deepseek-v4' })
+    tracker.appendText('s1', 'messages', 'one two three')
+    tracker.reconcileProviderUsage('s1', { used: 8, size: 64_000 }, 128_000)
+
+    const snapshot = tracker.usageSnapshot()
+    expect(snapshot.s1).toMatchObject({
+      used: 8,
+      size: 128_000,
+      breakdown: { status: 'reconciled', estimatedTokens: 3, difference: 5 }
+    })
+
+    snapshot.s1.used = 999
+    snapshot.s1.breakdown?.categories.splice(0)
+
+    expect(tracker.usageSnapshot().s1).toMatchObject({
+      used: 8,
+      breakdown: {
+        categories: [
+          { key: 'messages', tokens: 3, estimated: true },
+          { key: 'other', tokens: 5, estimated: false }
+        ]
+      }
+    })
+  })
+
+  it('restores the last provider reading when a preflight estimate receives no fresh update', () => {
+    const tracker = new ContextUsageTracker(wordCounter)
+    tracker.beginSession('s1', { frameworkId: 'opencode', model: 'deepseek-v4' })
+    tracker.appendText('s1', 'messages', 'committed history')
+    tracker.reconcileProviderUsage('s1', { used: 20, size: 128_000 })
+    const checkpoint = tracker.checkpointSession('s1')
+
+    tracker.appendPromptContent('s1', 'new prompt')
+    expect(tracker.refreshUsage('s1', 'preflight', 128_000)).toBe(true)
+    expect(tracker.usage('s1')?.breakdown?.status).toBe('preflight')
+
+    expect(tracker.restorePreflightUsage('s1', checkpoint)).toBe(true)
+    expect(tracker.usageSnapshot().s1).toMatchObject({
+      used: 20,
+      size: 128_000,
+      breakdown: { status: 'reconciled' }
+    })
+  })
+
+  it('keeps only a fresh provider reading after context compaction', () => {
+    const tracker = new ContextUsageTracker(wordCounter)
+    const input = { frameworkId: 'claude-code' as const, model: 'claude-sonnet-4-5' }
+    tracker.beginSession('stale', input)
+    tracker.reconcileProviderUsage('stale', { used: 100, size: 200_000 })
+    const staleCheckpoint = tracker.checkpointSession('stale')
+
+    tracker.resetAfterCompaction('stale', input, staleCheckpoint, 200_000)
+    expect(tracker.usageSnapshot().stale).toBeUndefined()
+
+    tracker.beginSession('fresh', input)
+    tracker.appendText('fresh', 'messages', 'compacted conversation')
+    tracker.reconcileProviderUsage('fresh', { used: 100, size: 200_000 })
+    const freshCheckpoint = tracker.checkpointSession('fresh')
+    tracker.reconcileProviderUsage('fresh', { used: 12, size: 200_000 })
+    tracker.resetAfterCompaction('fresh', input, freshCheckpoint, 200_000)
+
+    expect(tracker.usageSnapshot().fresh).toMatchObject({
+      used: 12,
+      size: 200_000,
+      breakdown: { status: 'reconciled' }
+    })
+  })
 })

--- a/src/main/acp/context-usage-tracker.ts
+++ b/src/main/acp/context-usage-tracker.ts
@@ -6,6 +6,7 @@ import cl100kBase from 'js-tiktoken/ranks/cl100k_base'
 import o200kBase from 'js-tiktoken/ranks/o200k_base'
 
 import type {
+  AcpContextUsage,
   AcpContextUsageBreakdown,
   AcpContextUsageCategory,
   AcpContextUsageCategoryKey
@@ -47,6 +48,8 @@ type SessionEstimateInput = {
 
 type SessionEstimateCheckpoint = {
   state?: SessionEstimate
+  usage?: AcpContextUsage
+  usageRevision: number
 }
 
 type SessionUpdateObservation = {
@@ -312,6 +315,9 @@ const toolContentText = (content: ToolUpdate['content'], budget: ToolTextBudget)
 
 class ContextUsageTracker {
   private readonly sessions = new Map<string, SessionEstimate>()
+  private readonly usageBySession = new Map<string, AcpContextUsage>()
+  private readonly usageRevisions = new Map<string, number>()
+  private readonly updatedPromptTurnsBySession = new Map<string, number>()
 
   constructor(private readonly counter: TokenCounter = defaultTokenCounter) {}
 
@@ -354,12 +360,128 @@ class ContextUsageTracker {
 
   checkpointSession(sessionId: string): SessionEstimateCheckpoint {
     const state = this.sessions.get(sessionId)
-    return state ? { state: cloneSessionEstimate(state) } : {}
+    const usage = this.usageBySession.get(sessionId)
+    return {
+      ...(state ? { state: cloneSessionEstimate(state) } : {}),
+      ...(usage ? { usage: this.cloneUsage(usage) } : {}),
+      usageRevision: this.usageRevisions.get(sessionId) ?? 0
+    }
   }
 
   restoreSession(sessionId: string, checkpoint: SessionEstimateCheckpoint): void {
     if (checkpoint.state) this.sessions.set(sessionId, cloneSessionEstimate(checkpoint.state))
     else this.sessions.delete(sessionId)
+    if (checkpoint.usage) this.replaceUsage(sessionId, checkpoint.usage)
+    else this.deleteUsage(sessionId)
+  }
+
+  usage(sessionId: string): AcpContextUsage | undefined {
+    const usage = this.usageBySession.get(sessionId)
+    return usage ? this.cloneUsage(usage) : undefined
+  }
+
+  hasUsage(): boolean {
+    return this.usageBySession.size > 0
+  }
+
+  usageSnapshot(): Record<string, AcpContextUsage> {
+    return Object.fromEntries(
+      Array.from(this.usageBySession, ([sessionId, usage]) => [sessionId, this.cloneUsage(usage)])
+    )
+  }
+
+  reconcileProviderUsage(
+    sessionId: string,
+    usage: AcpContextUsage,
+    selectedContextWindow?: number
+  ): void {
+    const breakdown = this.compare(sessionId, usage.used, 'reconciled')
+    this.replaceUsage(sessionId, {
+      ...usage,
+      size: selectedContextWindow ?? usage.size,
+      ...(breakdown ? { breakdown } : {})
+    })
+  }
+
+  reconcileUsed(sessionId: string, used: number): boolean {
+    const current = this.usageBySession.get(sessionId)
+    if (!current || !Number.isSafeInteger(used)) return false
+    if (current.used === used && current.breakdown?.status === 'reconciled') return false
+
+    this.replaceUsage(sessionId, {
+      used,
+      ...(current.size === undefined ? {} : { size: current.size }),
+      breakdown: this.compare(sessionId, used, 'reconciled')
+    })
+    return true
+  }
+
+  refreshUsage(
+    sessionId: string,
+    status: AcpContextUsageBreakdown['status'],
+    size?: number
+  ): boolean {
+    const current = this.usageBySession.get(sessionId)
+    if (status === 'preflight') {
+      const breakdown = this.estimate(sessionId)
+      if (!breakdown) return false
+      const agentUsed = current?.breakdown?.status === 'preflight' ? current.agentUsed : current?.used
+      this.replaceUsage(sessionId, {
+        used: agentUsed ?? breakdown.estimatedTokens,
+        ...(agentUsed === undefined ? {} : { agentUsed }),
+        ...(size === undefined ? {} : { size }),
+        breakdown
+      })
+      return true
+    }
+
+    if (!current) return false
+    const breakdown = this.compare(sessionId, current.used, status)
+    if (!breakdown) return false
+    this.replaceUsage(sessionId, { ...current, breakdown })
+    return true
+  }
+
+  restorePreflightUsage(sessionId: string, checkpoint: SessionEstimateCheckpoint): boolean {
+    if (this.usageBySession.get(sessionId)?.breakdown?.status !== 'preflight') return false
+
+    if (checkpoint.usage && checkpoint.usage.breakdown?.status !== 'preflight') {
+      this.replaceUsage(sessionId, checkpoint.usage)
+    } else {
+      this.deleteUsage(sessionId)
+    }
+    return true
+  }
+
+  resetAfterCompaction(
+    sessionId: string,
+    input: SessionEstimateInput,
+    checkpoint: SessionEstimateCheckpoint,
+    size?: number
+  ): void {
+    this.resetSession(sessionId, input)
+    if ((this.usageRevisions.get(sessionId) ?? 0) === checkpoint.usageRevision) {
+      this.deleteUsage(sessionId)
+    } else {
+      this.refreshUsage(sessionId, 'reconciled', size)
+    }
+  }
+
+  markPromptTurnUpdated(sessionId: string, promptTurn: number): void {
+    this.updatedPromptTurnsBySession.set(sessionId, promptTurn)
+  }
+
+  promptTurnWasUpdated(sessionId: string, promptTurn: number): boolean {
+    return this.updatedPromptTurnsBySession.get(sessionId) === promptTurn
+  }
+
+  clearPromptTurn(sessionId: string, promptTurn?: number): void {
+    if (
+      promptTurn === undefined ||
+      this.updatedPromptTurnsBySession.get(sessionId) === promptTurn
+    ) {
+      this.updatedPromptTurnsBySession.delete(sessionId)
+    }
   }
 
   appendText(sessionId: string, category: EstimatedCategoryKey, text: string): void {
@@ -636,12 +758,42 @@ class ContextUsageTracker {
     }
   }
 
+  private cloneUsage(usage: AcpContextUsage): AcpContextUsage {
+    return {
+      ...usage,
+      ...(usage.breakdown
+        ? {
+            breakdown: {
+              ...usage.breakdown,
+              categories: usage.breakdown.categories.map((category) => ({ ...category }))
+            }
+          }
+        : {})
+    }
+  }
+
+  private replaceUsage(sessionId: string, usage: AcpContextUsage): void {
+    this.usageBySession.set(sessionId, this.cloneUsage(usage))
+    this.usageRevisions.set(sessionId, (this.usageRevisions.get(sessionId) ?? 0) + 1)
+  }
+
+  private deleteUsage(sessionId: string): void {
+    if (!this.usageBySession.delete(sessionId)) return
+    this.usageRevisions.set(sessionId, (this.usageRevisions.get(sessionId) ?? 0) + 1)
+  }
+
   deleteSession(sessionId: string): void {
     this.sessions.delete(sessionId)
+    this.deleteUsage(sessionId)
+    this.usageRevisions.delete(sessionId)
+    this.updatedPromptTurnsBySession.delete(sessionId)
   }
 
   clear(): void {
     this.sessions.clear()
+    this.usageBySession.clear()
+    this.usageRevisions.clear()
+    this.updatedPromptTurnsBySession.clear()
   }
 }
 

--- a/src/main/acp/context-usage-tracker.ts
+++ b/src/main/acp/context-usage-tracker.ts
@@ -317,7 +317,6 @@ class ContextUsageTracker {
   private readonly sessions = new Map<string, SessionEstimate>()
   private readonly usageBySession = new Map<string, AcpContextUsage>()
   private readonly usageRevisions = new Map<string, number>()
-  private readonly updatedPromptTurnsBySession = new Map<string, number>()
 
   constructor(private readonly counter: TokenCounter = defaultTokenCounter) {}
 
@@ -425,7 +424,8 @@ class ContextUsageTracker {
     if (status === 'preflight') {
       const breakdown = this.estimate(sessionId)
       if (!breakdown) return false
-      const agentUsed = current?.breakdown?.status === 'preflight' ? current.agentUsed : current?.used
+      const agentUsed =
+        current?.breakdown?.status === 'preflight' ? current.agentUsed : current?.used
       this.replaceUsage(sessionId, {
         used: agentUsed ?? breakdown.estimatedTokens,
         ...(agentUsed === undefined ? {} : { agentUsed }),
@@ -464,23 +464,6 @@ class ContextUsageTracker {
       this.deleteUsage(sessionId)
     } else {
       this.refreshUsage(sessionId, 'reconciled', size)
-    }
-  }
-
-  markPromptTurnUpdated(sessionId: string, promptTurn: number): void {
-    this.updatedPromptTurnsBySession.set(sessionId, promptTurn)
-  }
-
-  promptTurnWasUpdated(sessionId: string, promptTurn: number): boolean {
-    return this.updatedPromptTurnsBySession.get(sessionId) === promptTurn
-  }
-
-  clearPromptTurn(sessionId: string, promptTurn?: number): void {
-    if (
-      promptTurn === undefined ||
-      this.updatedPromptTurnsBySession.get(sessionId) === promptTurn
-    ) {
-      this.updatedPromptTurnsBySession.delete(sessionId)
     }
   }
 
@@ -786,14 +769,12 @@ class ContextUsageTracker {
     this.sessions.delete(sessionId)
     this.deleteUsage(sessionId)
     this.usageRevisions.delete(sessionId)
-    this.updatedPromptTurnsBySession.delete(sessionId)
   }
 
   clear(): void {
     this.sessions.clear()
     this.usageBySession.clear()
     this.usageRevisions.clear()
-    this.updatedPromptTurnsBySession.clear()
   }
 }
 

--- a/src/main/acp/runtime-snapshot-owner.ts
+++ b/src/main/acp/runtime-snapshot-owner.ts
@@ -4,6 +4,7 @@ import { getAcpRuntimeEventImage, MAX_ACP_SESSION_IMAGE_BYTES } from '../../shar
 const MAX_EVENTS = 500
 
 type RuntimeSnapshotFields = Pick<AcpStateSnapshot, 'status' | 'cwd' | 'error' | 'events'>
+type RuntimeSnapshotProjection = Omit<AcpStateSnapshot, keyof RuntimeSnapshotFields>
 type RuntimeEventInput = Omit<AcpRuntimeEvent, 'id' | 'timestamp'> & Partial<AcpRuntimeEvent>
 
 const cloneEvent = (event: AcpRuntimeEvent): AcpRuntimeEvent => structuredClone(event)
@@ -103,15 +104,16 @@ class AcpRuntimeSnapshotOwner {
     return runtimeEvent
   }
 
-  snapshot(): RuntimeSnapshotFields {
-    return {
+  snapshot(projection: RuntimeSnapshotProjection): AcpStateSnapshot {
+    return structuredClone({
       status: this.connectionStatus,
       cwd: this.workingDirectory,
       error: this.currentError,
-      events: this.retainedEvents.map(cloneEvent)
-    }
+      events: this.retainedEvents,
+      ...projection
+    })
   }
 }
 
 export { AcpRuntimeSnapshotOwner }
-export type { RuntimeEventInput, RuntimeSnapshotFields }
+export type { RuntimeEventInput, RuntimeSnapshotFields, RuntimeSnapshotProjection }

--- a/src/main/acp/runtime-snapshot-owner.ts
+++ b/src/main/acp/runtime-snapshot-owner.ts
@@ -1,0 +1,117 @@
+import type { AcpRuntimeEvent, AcpStateSnapshot } from '../../shared/acp'
+import { getAcpRuntimeEventImage, MAX_ACP_SESSION_IMAGE_BYTES } from '../../shared/acp'
+
+const MAX_EVENTS = 500
+
+type RuntimeSnapshotFields = Pick<AcpStateSnapshot, 'status' | 'cwd' | 'error' | 'events'>
+type RuntimeEventInput = Omit<AcpRuntimeEvent, 'id' | 'timestamp'> & Partial<AcpRuntimeEvent>
+
+const cloneEvent = (event: AcpRuntimeEvent): AcpRuntimeEvent => structuredClone(event)
+
+// Owns the small, runtime-wide portion of the renderer snapshot. Publishing remains the runtime's
+// responsibility: commands mutate synchronously and callers decide when callbacks must observe them.
+class AcpRuntimeSnapshotOwner {
+  private connectionStatus: AcpStateSnapshot['status'] = 'idle'
+  private workingDirectory: string
+  private currentError: string | undefined
+  private retainedEvents: AcpRuntimeEvent[] = []
+  private eventSequence = 0
+
+  constructor(cwd: string) {
+    this.workingDirectory = cwd
+  }
+
+  get status(): AcpStateSnapshot['status'] {
+    return this.connectionStatus
+  }
+
+  get cwd(): string {
+    return this.workingDirectory
+  }
+
+  get error(): string | undefined {
+    return this.currentError
+  }
+
+  transitionStatus(status: AcpStateSnapshot['status']): void {
+    this.connectionStatus = status
+  }
+
+  updateCwd(cwd: string): void {
+    this.workingDirectory = cwd
+  }
+
+  updateError(error: string | undefined): void {
+    this.currentError = error
+  }
+
+  nextEventId(): string {
+    this.eventSequence += 1
+    return `acp-event-${this.eventSequence}`
+  }
+
+  appendEvent(event: RuntimeEventInput): AcpRuntimeEvent {
+    let image = event.image
+    let raw = event.raw
+    let text = event.text
+    if (image && event.sessionId) {
+      const retainedBytes = this.retainedEvents
+        .filter((candidate) => candidate.sessionId === event.sessionId)
+        .reduce(
+          (total, candidate) => total + (getAcpRuntimeEventImage(candidate)?.byteLength ?? 0),
+          0
+        )
+      if (retainedBytes + image.byteLength > MAX_ACP_SESSION_IMAGE_BYTES) {
+        image = undefined
+        raw = undefined
+        text = 'Agent image omitted because the session image budget was reached.'
+      }
+    }
+
+    const runtimeEvent: AcpRuntimeEvent = {
+      id: event.id ?? this.nextEventId(),
+      timestamp: event.timestamp ?? Date.now(),
+      level: event.level ?? 'info',
+      kind: event.kind,
+      compactionReason: event.compactionReason,
+      recoverable: event.recoverable,
+      providerError: event.providerError,
+      turnUsage: event.turnUsage,
+      sessionId: event.sessionId,
+      messageId: event.messageId,
+      role: event.role,
+      text,
+      image,
+      title: event.title,
+      status: event.status,
+      toolCallId: event.toolCallId,
+      providerToolName: event.providerToolName,
+      toolKind: event.toolKind,
+      toolContent: event.toolContent,
+      toolLocations: event.toolLocations,
+      rawInput: event.rawInput,
+      rawOutput: event.rawOutput,
+      runId: event.runId,
+      promptMessageId: event.promptMessageId,
+      artifactSessionId: event.artifactSessionId,
+      artifactClaimId: event.artifactClaimId,
+      artifacts: event.artifacts,
+      raw
+    }
+
+    this.retainedEvents = [...this.retainedEvents, cloneEvent(runtimeEvent)].slice(-MAX_EVENTS)
+    return runtimeEvent
+  }
+
+  snapshot(): RuntimeSnapshotFields {
+    return {
+      status: this.connectionStatus,
+      cwd: this.workingDirectory,
+      error: this.currentError,
+      events: this.retainedEvents.map(cloneEvent)
+    }
+  }
+}
+
+export { AcpRuntimeSnapshotOwner }
+export type { RuntimeEventInput, RuntimeSnapshotFields }

--- a/src/main/acp/runtime.test.ts
+++ b/src/main/acp/runtime.test.ts
@@ -584,12 +584,15 @@ const agentToAppSessionMap = (runtime: AcpRuntime): Map<string, string> =>
 const sessionFrameworksMap = (runtime: AcpRuntime): Map<string, string> =>
   (runtime as unknown as { sessionFrameworks: Map<string, string> }).sessionFrameworks
 
-const contextUsageMap = (runtime: AcpRuntime): Map<string, { used: number; size: number }> =>
-  (
-    runtime as unknown as {
-      contextUsageBySession: Map<string, { used: number; size: number }>
-    }
-  ).contextUsageBySession
+const contextUsageMap = (
+  runtime: AcpRuntime
+): { set: (sessionId: string, usage: AcpContextUsage) => void } => {
+  const tracker = (runtime as unknown as { contextUsageTracker: ContextUsageTracker })
+    .contextUsageTracker
+  return {
+    set: (sessionId, usage) => tracker.reconcileProviderUsage(sessionId, usage)
+  }
+}
 
 const sessionInlineImageBytesMap = (runtime: AcpRuntime): Map<string, number> =>
   (runtime as unknown as { sessionInlineImageBytes: Map<string, number> }).sessionInlineImageBytes
@@ -7333,10 +7336,24 @@ describe('ACP runtime session management', () => {
     expect(snapshot.contextUsageBySession).toMatchObject({ s1: { used: 12, size: 128_000 } })
 
     const retainedEventIds = snapshot.events.map(({ id }) => id)
+    const retainedEventTitles = snapshot.events.map(({ title }) => title)
+    const messageRaw = snapshot.events.find(({ messageId }) => messageId === 'message-1')?.raw as {
+      update: { content: { text: string } }
+    }
+    messageRaw.update.content.text = 'mutated outside the runtime'
+    if (snapshot.events[0]) snapshot.events[0].title = 'mutated outside the runtime'
     snapshot.events.length = 0
     delete snapshot.contextUsageBySession.s1
 
     expect(runtime.getSnapshot().events.map(({ id }) => id)).toEqual(retainedEventIds)
+    expect(runtime.getSnapshot().events.map(({ title }) => title)).toEqual(retainedEventTitles)
+    expect(
+      (
+        runtime.getSnapshot().events.find(({ messageId }) => messageId === 'message-1')?.raw as {
+          update: { content: { text: string } }
+        }
+      ).update.content.text
+    ).toBe('first')
     expect(runtime.getSnapshot().contextUsageBySession).toMatchObject({
       s1: { used: 12, size: 128_000 }
     })

--- a/src/main/acp/runtime.test.ts
+++ b/src/main/acp/runtime.test.ts
@@ -7290,6 +7290,58 @@ describe('ACP runtime session management', () => {
     expect(sharedAgent.resumedSessions).toEqual([])
   })
 
+  it('returns detached snapshot collections without collapsing hidden event sequence slots', async () => {
+    const process = new FakeAgentProcess()
+    startFakeAgent(process, ['s1'])
+    const runtime = new AcpRuntime({
+      appVersion: '0.1.0',
+      defaultCwd: '/workspace',
+      spawnAgent: () => asAgentProcess(process)
+    })
+
+    await runtime.createSession({ cwd: '/workspace' })
+    const existingEventCount = runtime.getSnapshot().events.length
+    handleSessionUpdate(runtime, {
+      sessionId: 's1',
+      update: {
+        sessionUpdate: 'agent_message_chunk',
+        messageId: 'message-1',
+        content: { type: 'text', text: 'first' }
+      }
+    })
+    // Usage updates consume their normalized event id before being projected into context state. They
+    // intentionally remain absent from the visible event log, so the following message keeps the gap.
+    handleSessionUpdate(runtime, {
+      sessionId: 's1',
+      update: { sessionUpdate: 'usage_update', used: 12, size: 128_000 }
+    })
+    handleSessionUpdate(runtime, {
+      sessionId: 's1',
+      update: {
+        sessionUpdate: 'agent_message_chunk',
+        messageId: 'message-2',
+        content: { type: 'text', text: 'second' }
+      }
+    })
+
+    const snapshot = runtime.getSnapshot()
+    const messageEventIds = snapshot.events
+      .slice(existingEventCount)
+      .map(({ id }) => Number(id.replace('acp-event-', '')))
+    expect(messageEventIds).toHaveLength(2)
+    expect(messageEventIds[1] - messageEventIds[0]).toBe(2)
+    expect(snapshot.contextUsageBySession).toMatchObject({ s1: { used: 12, size: 128_000 } })
+
+    const retainedEventIds = snapshot.events.map(({ id }) => id)
+    snapshot.events.length = 0
+    delete snapshot.contextUsageBySession.s1
+
+    expect(runtime.getSnapshot().events.map(({ id }) => id)).toEqual(retainedEventIds)
+    expect(runtime.getSnapshot().contextUsageBySession).toMatchObject({
+      s1: { used: 12, size: 128_000 }
+    })
+  })
+
   it('recombines Codex uncached input and cache read for context usage', async () => {
     const process = new FakeAgentProcess()
     const usageSent = createDeferred()

--- a/src/main/acp/runtime.test.ts
+++ b/src/main/acp/runtime.test.ts
@@ -7295,14 +7295,27 @@ describe('ACP runtime session management', () => {
 
   it('returns detached snapshot collections without collapsing hidden event sequence slots', async () => {
     const process = new FakeAgentProcess()
-    startFakeAgent(process, ['s1'])
+    startPermissionProbeAgent(process, {
+      newSessionId: 's1',
+      toolCallId: 'snapshot-permission',
+      toolTitle: 'Run nested input',
+      toolKind: 'execute',
+      toolRawInput: { command: 'npm test', metadata: { source: 'provider' } },
+      modes: createModes(['read-only', 'agent'], 'agent'),
+      permissionOptions: [
+        { optionId: 'allow-once', name: 'Allow once', kind: 'allow_once' },
+        { optionId: 'reject', name: 'Reject', kind: 'reject_once' }
+      ]
+    })
     const runtime = new AcpRuntime({
       appVersion: '0.1.0',
       defaultCwd: '/workspace',
       spawnAgent: () => asAgentProcess(process)
     })
 
-    await runtime.createSession({ cwd: '/workspace' })
+    const session = await runtime.createSession({ cwd: '/workspace' })
+    const prompt = runtime.sendPrompt({ sessionId: session.sessionId, text: 'request permission' })
+    await vi.waitFor(() => expect(runtime.getSnapshot().pendingPermissions).toHaveLength(1))
     const existingEventCount = runtime.getSnapshot().events.length
     handleSessionUpdate(runtime, {
       sessionId: 's1',
@@ -7340,23 +7353,54 @@ describe('ACP runtime session management', () => {
     const messageRaw = snapshot.events.find(({ messageId }) => messageId === 'message-1')?.raw as {
       update: { content: { text: string } }
     }
+    const contextCategory = snapshot.contextUsageBySession.s1.breakdown?.categories[0]
+    const pendingPermission = snapshot.pendingPermissions[0]
+    const pendingRawInput = pendingPermission.rawInput as {
+      metadata: { source: string }
+    }
+    const permissionProfile = snapshot.permissionProfiles.s1
+    expect(contextCategory).toBeDefined()
+    const retainedContextCategoryTokens = contextCategory!.tokens
     messageRaw.update.content.text = 'mutated outside the runtime'
     if (snapshot.events[0]) snapshot.events[0].title = 'mutated outside the runtime'
+    contextCategory!.tokens = 999
+    pendingRawInput.metadata.source = 'mutated outside the runtime'
+    pendingPermission.options[0].name = 'mutated outside the runtime'
+    permissionProfile.availableModeIds[0] = 'mutated outside the runtime'
     snapshot.events.length = 0
     delete snapshot.contextUsageBySession.s1
 
-    expect(runtime.getSnapshot().events.map(({ id }) => id)).toEqual(retainedEventIds)
-    expect(runtime.getSnapshot().events.map(({ title }) => title)).toEqual(retainedEventTitles)
+    const retainedSnapshot = runtime.getSnapshot()
+    expect(retainedSnapshot.events.map(({ id }) => id)).toEqual(retainedEventIds)
+    expect(retainedSnapshot.events.map(({ title }) => title)).toEqual(retainedEventTitles)
     expect(
       (
-        runtime.getSnapshot().events.find(({ messageId }) => messageId === 'message-1')?.raw as {
+        retainedSnapshot.events.find(({ messageId }) => messageId === 'message-1')?.raw as {
           update: { content: { text: string } }
         }
       ).update.content.text
     ).toBe('first')
-    expect(runtime.getSnapshot().contextUsageBySession).toMatchObject({
+    expect(retainedSnapshot.contextUsageBySession).toMatchObject({
       s1: { used: 12, size: 128_000 }
     })
+    expect(retainedSnapshot.contextUsageBySession.s1.breakdown?.categories[0]?.tokens).toBe(
+      retainedContextCategoryTokens
+    )
+    expect(retainedSnapshot.pendingPermissions[0].rawInput).toEqual({
+      command: 'npm test',
+      metadata: { source: 'provider' }
+    })
+    expect(retainedSnapshot.pendingPermissions[0].options[0]).toMatchObject({
+      optionId: 'allow-once',
+      name: 'Allow once'
+    })
+    expect(retainedSnapshot.permissionProfiles.s1.availableModeIds).toEqual(['read-only', 'agent'])
+
+    runtime.respondToPermission({
+      requestId: retainedSnapshot.pendingPermissions[0].requestId,
+      optionId: 'reject'
+    })
+    await prompt
   })
 
   it('recombines Codex uncached input and cache read for context usage', async () => {

--- a/src/main/acp/runtime.ts
+++ b/src/main/acp/runtime.ts
@@ -728,6 +728,9 @@ const isUnresumableSessionError = (error: unknown): boolean => {
 class AcpRuntime {
   private readonly snapshotOwner: AcpRuntimeSnapshotOwner
   private readonly contextUsageTracker: ContextUsageTracker
+  // Prompt lifecycle stays with the runtime: this marks turns that received provider-side
+  // context-bearing updates so a rejected prompt rolls back only when the provider saw no turn data.
+  private readonly contextUsageUpdatedPromptTurnsBySession = new Map<string, number>()
   private agentProcess: ChildProcessWithoutNullStreams | undefined
   // Latched by shutdown() on app quit. A connect can be mid-spawn (resolveSpawnConfig is async) when
   // quit fires, so this lets the post-spawn path kill a child that was created after killAgentProcess ran.
@@ -989,10 +992,8 @@ class AcpRuntime {
   getSnapshot(): AcpStateSnapshot {
     const sessionIds = Array.from(this.sessions.keys())
     const promptInFlightSessionIds = this.getInFlightSessionIds()
-    const snapshot = this.snapshotOwner.snapshot()
 
-    return {
-      ...snapshot,
+    return this.snapshotOwner.snapshot({
       sessionId: this.currentSessionId,
       sessionIds,
       pendingPermissions: this.permissionBroker.getPendingRequests(),
@@ -1005,7 +1006,7 @@ class AcpRuntime {
         this.framework.contextCompaction.kind === 'native-command' ? sessionIds : [],
       promptInFlight: promptInFlightSessionIds.length > 0,
       promptInFlightSessionIds
-    }
+    })
   }
 
   // Lists sessions with an in-flight prompt, for the pre-migration active-session warning.
@@ -1738,6 +1739,7 @@ class AcpRuntime {
     // A context reset creates a new agent-side conversation under the same app id. Do not carry the
     // previous context size into the fresh conversation before its first usage_update arrives.
     this.contextUsageTracker.deleteSession(request.sessionId)
+    this.contextUsageUpdatedPromptTurnsBySession.delete(request.sessionId)
     this.appliedSessionModels.delete(request.sessionId)
 
     // Release the failed turn's in-flight lock now. Its own `finally` clears it too, but that runs only
@@ -2282,6 +2284,7 @@ class AcpRuntime {
     this.connection = undefined
     this.killAgentProcess()
     this.contextUsageTracker.clear()
+    this.contextUsageUpdatedPromptTurnsBySession.clear()
     this.appliedSessionModels.clear()
     void this.closeMcpHttpHost()
     void this.releaseResponsesBridgeLease()
@@ -2352,6 +2355,7 @@ class AcpRuntime {
     // replacement generation repopulate usage after reconnect/resume.
     if (this.contextUsageTracker.hasUsage()) {
       this.contextUsageTracker.clear()
+      this.contextUsageUpdatedPromptTurnsBySession.clear()
       this.appliedSessionModels.clear()
       this.emitState()
     }
@@ -2511,6 +2515,7 @@ class AcpRuntime {
       // including when a later session.dispose throws. A reconnect may resume the native context or
       // replay history into a fresh one; only that generation's own usage_update can repopulate it.
       this.contextUsageTracker.clear()
+      this.contextUsageUpdatedPromptTurnsBySession.clear()
       this.appliedSessionModels.clear()
 
       this.releaseAllNotebookSessionCapabilities()
@@ -3088,16 +3093,13 @@ class AcpRuntime {
         !this.pendingProviderReconnect
       ) {
         const partialTurnWasObserved =
-          this.contextUsageTracker.promptTurnWasUpdated(request.sessionId, promptTurn)
+          this.contextUsageUpdatedPromptTurnsBySession.get(request.sessionId) === promptTurn
         if (partialTurnWasObserved) {
           // The provider may keep a turn that already streamed context-bearing updates even when its
           // prompt request ultimately rejects. Preserve those prompt/tool/output estimates, but do not
           // leave their transient preflight reading in place without a fresh authoritative total.
           this.contextUsageTracker.finalizeAssistantOutput(request.sessionId)
-          this.restoreContextUsageBeforePromptIfPreflight(
-            request.sessionId,
-            contextUsageCheckpoint
-          )
+          this.restoreContextUsageBeforePromptIfPreflight(request.sessionId, contextUsageCheckpoint)
         } else {
           this.contextUsageTracker.restoreSession(request.sessionId, contextUsageCheckpoint)
         }
@@ -3181,7 +3183,9 @@ class AcpRuntime {
         this.claudeTurnCountsBySession.delete(request.sessionId)
         this.clearOpenCodePermissionToolContext(request.sessionId)
         this.currentPromptTurnBySession.delete(request.sessionId)
-        this.contextUsageTracker.clearPromptTurn(request.sessionId, promptTurn)
+        if (this.contextUsageUpdatedPromptTurnsBySession.get(request.sessionId) === promptTurn) {
+          this.contextUsageUpdatedPromptTurnsBySession.delete(request.sessionId)
+        }
         this.promptInFlightSessionIds.delete(request.sessionId)
         if (this.skillImportTurnTokens.get(request.sessionId) === skillImportTurnToken) {
           this.skillImportTurnTokens.delete(request.sessionId)
@@ -3335,6 +3339,7 @@ class AcpRuntime {
     this.sessionFrameworks.delete(request.sessionId)
     this.sessionBackendIds.delete(request.sessionId)
     this.contextUsageTracker.deleteSession(request.sessionId)
+    this.contextUsageUpdatedPromptTurnsBySession.delete(request.sessionId)
     this.appliedSessionModels.delete(request.sessionId)
     this.permissionProfiles.delete(request.sessionId)
     this.artifactSessionIds.delete(request.sessionId)
@@ -5624,7 +5629,7 @@ class AcpRuntime {
       ) {
         const promptTurn = this.currentPromptTurnBySession.get(routed.sessionId)
         if (promptTurn !== undefined) {
-          this.contextUsageTracker.markPromptTurnUpdated(routed.sessionId, promptTurn)
+          this.contextUsageUpdatedPromptTurnsBySession.set(routed.sessionId, promptTurn)
         }
       }
     }
@@ -5780,10 +5785,7 @@ class AcpRuntime {
         return
       }
 
-      if (
-        this.snapshotOwner.status === 'connected' ||
-        this.snapshotOwner.status === 'connecting'
-      ) {
+      if (this.snapshotOwner.status === 'connected' || this.snapshotOwner.status === 'connecting') {
         this.pushEvent({
           kind: 'system',
           level: code === 0 ? 'info' : 'warning',
@@ -5821,6 +5823,7 @@ class AcpRuntime {
     this.clearAllOpenCodePermissionToolContext()
     this.sessionProjectNames.clear()
     this.contextUsageTracker.clear()
+    this.contextUsageUpdatedPromptTurnsBySession.clear()
     this.appliedSessionModels.clear()
     this.artifactSessionIds.clear()
     this.notebookRoutingIds.clear()

--- a/src/main/acp/runtime.ts
+++ b/src/main/acp/runtime.ts
@@ -40,8 +40,6 @@ import type {
 import {
   ACP_MODEL_TURN_COUNT_META_KEY,
   ACP_TURN_TOKEN_USAGE_META_KEY,
-  getAcpRuntimeEventImage,
-  MAX_ACP_SESSION_IMAGE_BYTES,
   toAcpTurnTokenUsage
 } from '../../shared/acp'
 import { ACP_PROMPT_FAILED_EVENT_TITLE } from '../../shared/acp'
@@ -80,6 +78,7 @@ import {
   type SessionModelSelection
 } from './session-config'
 import { describePromptError, isProviderPromptError } from './prompt-error'
+import { AcpRuntimeSnapshotOwner } from './runtime-snapshot-owner'
 import {
   ATTACHMENT_PREVIEW_BYTES,
   MAX_EMBEDDED_TEXT_UPLOAD_BYTES,
@@ -498,8 +497,6 @@ const codexMcpToolIdentity = (
   }
 }
 
-// Keeps runtime snapshots bounded so long conversations do not grow renderer payloads forever.
-const MAX_EVENTS = 500
 // Bounds pending Codex MCP identities even if an agent never emits terminal tool updates.
 const MAX_CODEX_MCP_TOOL_IDENTITIES_PER_SESSION = 32
 const MAX_CLAUDE_CODE_MCP_TOOL_INPUTS_PER_SESSION = 32
@@ -729,19 +726,8 @@ const isUnresumableSessionError = (error: unknown): boolean => {
 
 // Owns the agent process, protocol connection, and all active protocol sessions.
 class AcpRuntime {
-  private status: AcpStateSnapshot['status'] = 'idle'
-  private cwd: string
-  private error: string | undefined
-  private events: AcpRuntimeEvent[] = []
-  private eventSequence = 0
-  // Latest context-window usage per app session, from ACP usage_update. Consumed by getSnapshot;
-  // entries appear once the active framework emits a usable context count.
-  private contextUsageBySession = new Map<string, AcpContextUsage>()
+  private readonly snapshotOwner: AcpRuntimeSnapshotOwner
   private readonly contextUsageTracker: ContextUsageTracker
-  // Identifies prompt turns that received provider-side context-bearing updates. A prompt rejected
-  // before its first update can be rolled back safely; once output/tool/usage events arrive, the live
-  // provider session may retain that partial turn and the estimator must retain it too.
-  private readonly contextUsageUpdatedPromptTurnsBySession = new Map<string, number>()
   private agentProcess: ChildProcessWithoutNullStreams | undefined
   // Latched by shutdown() on app quit. A connect can be mid-spawn (resolveSpawnConfig is async) when
   // quit fires, so this lets the post-spawn path kill a child that was created after killAgentProcess ran.
@@ -938,7 +924,7 @@ class AcpRuntime {
 
   // Wires runtime dependencies and forwards permission prompts into the event stream.
   constructor(private readonly options: AcpRuntimeOptions) {
-    this.cwd = resolve(options.defaultCwd)
+    this.snapshotOwner = new AcpRuntimeSnapshotOwner(resolve(options.defaultCwd))
     this.callbacks = options.callbacks ?? {}
     this.spawnAgent = options.spawnAgent
     this.skillsHooks = options.skills
@@ -996,27 +982,25 @@ class AcpRuntime {
     framework: AgentFramework['id'] = this.framework.id,
     generation = this.connectionGeneration
   ): { framework: AgentFramework['id']; generation: number; status: AcpStateSnapshot['status'] } {
-    return { framework, generation, status: this.status }
+    return { framework, generation, status: this.snapshotOwner.status }
   }
 
   // Returns an immutable renderer-facing view of connection and session state.
   getSnapshot(): AcpStateSnapshot {
     const sessionIds = Array.from(this.sessions.keys())
     const promptInFlightSessionIds = this.getInFlightSessionIds()
+    const snapshot = this.snapshotOwner.snapshot()
 
     return {
-      status: this.status,
-      cwd: this.cwd,
+      ...snapshot,
       sessionId: this.currentSessionId,
       sessionIds,
-      error: this.error,
-      events: [...this.events],
       pendingPermissions: this.permissionBroker.getPendingRequests(),
       permissionProfiles: Object.fromEntries(this.permissionProfiles),
       permissionGrants: Object.fromEntries(
         sessionIds.map((sessionId) => [sessionId, this.permissionBroker.listGrants(sessionId)])
       ),
-      contextUsageBySession: Object.fromEntries(this.contextUsageBySession),
+      contextUsageBySession: this.contextUsageTracker.usageSnapshot(),
       nativeContextCompactionSessionIds:
         this.framework.contextCompaction.kind === 'native-command' ? sessionIds : [],
       promptInFlight: promptInFlightSessionIds.length > 0,
@@ -1295,8 +1279,8 @@ class AcpRuntime {
       await this.disconnectCurrent(false)
       this.assertCurrentConnectionGeneration(generation)
 
-      this.cwd = cwd
-      this.error = undefined
+      this.snapshotOwner.updateCwd(cwd)
+      this.snapshotOwner.updateError(undefined)
       this.setStatus('connecting')
       log.info('connecting agent', this.diagnosticContext(this.framework.id, generation))
 
@@ -1340,7 +1324,7 @@ class AcpRuntime {
       this.connection.closed.then(() => {
         if (
           this.connectionGeneration === generation &&
-          (this.status === 'connected' || this.status === 'connecting')
+          (this.snapshotOwner.status === 'connected' || this.snapshotOwner.status === 'connecting')
         ) {
           this.handleConnectionClosed()
         }
@@ -1438,7 +1422,7 @@ class AcpRuntime {
             /* a throwing logger must not mask the cause */
           }
         } else {
-          this.error = errorMessage(cause)
+          this.snapshotOwner.updateError(errorMessage(cause))
           safeLogError('agent connection failed', {
             ...diagnosticErrorFields(cause),
             ...processFields
@@ -1449,7 +1433,7 @@ class AcpRuntime {
               kind: 'error',
               level: 'error',
               title: 'Connection failed',
-              text: this.error
+              text: this.snapshotOwner.error
             })
           } catch (notifyError) {
             safeLogError('agent connection failure notification failed', {
@@ -1467,7 +1451,7 @@ class AcpRuntime {
               ...processFields
             })
           }
-          this.status = 'error'
+          this.snapshotOwner.transitionStatus('error')
           try {
             this.emitState()
           } catch (notifyError) {
@@ -1510,7 +1494,7 @@ class AcpRuntime {
     let provisionalNotebookSessionId: string | undefined
     try {
       log.info('createSession: starting', this.diagnosticContext())
-      const sessionCwd = resolve(request.cwd || this.cwd || this.options.defaultCwd)
+      const sessionCwd = resolve(request.cwd || this.snapshotOwner.cwd || this.options.defaultCwd)
       const projectName = this.normalizeProjectName(request.projectName)
       log.info('createSession: ensureConnected', this.diagnosticContext())
       const connection = await this.ensureConnected(sessionCwd)
@@ -1607,7 +1591,7 @@ class AcpRuntime {
       this.notebookOptions?.registerSessionSpecialist?.(session.sessionId, request.specialistId)
       this.rememberSkillImportSession(session.sessionId, skillImportSessionId)
       this.currentSessionId = session.sessionId
-      this.cwd = sessionCwd
+      this.snapshotOwner.updateCwd(sessionCwd)
       this.pushEvent({
         kind: 'system',
         level: 'info',
@@ -1665,7 +1649,7 @@ class AcpRuntime {
     this.rememberNotebookSession(appSessionId, appSessionId)
     this.rememberSkillImportSession(appSessionId, appSessionId)
     this.currentSessionId = appSessionId
-    this.cwd = cwd
+    this.snapshotOwner.updateCwd(cwd)
   }
 
   // Reattaches a persisted protocol session after an app restart so later prompts can stream.
@@ -1677,7 +1661,7 @@ class AcpRuntime {
     request: AcpResumeSessionRequest
   ): Promise<AcpCreateSessionResponse> {
     if (request.specialistId) this.sessionSpecialistIds.set(request.sessionId, request.specialistId)
-    const sessionCwd = resolve(request.cwd || this.cwd || this.options.defaultCwd)
+    const sessionCwd = resolve(request.cwd || this.snapshotOwner.cwd || this.options.defaultCwd)
     const projectName = this.normalizeProjectName(request.projectName)
 
     // If the runtime already attached this session, only refresh routing metadata.
@@ -1694,7 +1678,7 @@ class AcpRuntime {
         )
       )
       this.currentSessionId = request.sessionId
-      this.cwd = sessionCwd
+      this.snapshotOwner.updateCwd(sessionCwd)
       this.sessionCwds.set(request.sessionId, sessionCwd)
       this.sessionProjectNames.set(request.sessionId, projectName)
       this.emitState()
@@ -1725,7 +1709,7 @@ class AcpRuntime {
   private async resetSessionContextOperation(
     request: AcpResumeSessionRequest
   ): Promise<AcpCreateSessionResponse> {
-    const sessionCwd = resolve(request.cwd || this.cwd || this.options.defaultCwd)
+    const sessionCwd = resolve(request.cwd || this.snapshotOwner.cwd || this.options.defaultCwd)
     const projectName = this.normalizeProjectName(request.projectName)
     const connection = await this.ensureConnected(sessionCwd)
 
@@ -1753,9 +1737,7 @@ class AcpRuntime {
     this.sessionInlineImageBytes.delete(request.sessionId)
     // A context reset creates a new agent-side conversation under the same app id. Do not carry the
     // previous context size into the fresh conversation before its first usage_update arrives.
-    this.contextUsageBySession.delete(request.sessionId)
     this.contextUsageTracker.deleteSession(request.sessionId)
-    this.contextUsageUpdatedPromptTurnsBySession.delete(request.sessionId)
     this.appliedSessionModels.delete(request.sessionId)
 
     // Release the failed turn's in-flight lock now. Its own `finally` clears it too, but that runs only
@@ -1882,7 +1864,7 @@ class AcpRuntime {
     const strategy = this.framework.contextCompaction
     if (strategy.kind !== 'native-command' || strategy.triggerAtPercent === undefined) return false
 
-    const usage = this.contextUsageBySession.get(sessionId)
+    const usage = this.contextUsageTracker.usage(sessionId)
     if (!usage || usage.size === undefined || usage.size <= 0 || usage.used < 0) return false
     if (usage.breakdown?.status === 'preflight') return false
 
@@ -1898,15 +1880,9 @@ class AcpRuntime {
     if (strategy.kind !== 'native-command') {
       throw new Error(`${this.framework.displayName} manages context compaction automatically.`)
     }
-    const contextUsageBeforeCompaction = this.contextUsageBySession.get(appSessionId)
     const contextUsageCheckpoint = this.contextUsageTracker.checkpointSession(appSessionId)
     const restoreContextEstimate = (): void => {
       this.contextUsageTracker.restoreSession(appSessionId, contextUsageCheckpoint)
-      if (contextUsageBeforeCompaction) {
-        this.contextUsageBySession.set(appSessionId, contextUsageBeforeCompaction)
-      } else {
-        this.contextUsageBySession.delete(appSessionId)
-      }
     }
 
     this.pushEvent({
@@ -1949,15 +1925,12 @@ class AcpRuntime {
           // Some adapters do not emit usage_update for their compaction control turn. Invalidate only
           // the unchanged pre-compaction reading; a fresh update received during the turn is a new
           // object and remains available to the context meter and auto-compaction threshold.
-          this.contextUsageTracker.resetSession(
+          this.contextUsageTracker.resetAfterCompaction(
             appSessionId,
-            this.contextUsageEstimateInput(appSessionId)
+            this.contextUsageEstimateInput(appSessionId),
+            contextUsageCheckpoint,
+            this.selectedContextWindowFor(appSessionId)
           )
-          if (this.contextUsageBySession.get(appSessionId) === contextUsageBeforeCompaction) {
-            this.contextUsageBySession.delete(appSessionId)
-          } else {
-            this.refreshEstimatedContextUsage(appSessionId, 'reconciled')
-          }
           this.sessionInlineImageBytes.delete(appSessionId)
           this.pushEvent({
             kind: 'compaction',
@@ -2149,7 +2122,7 @@ class AcpRuntime {
       this.rememberArtifactSession(request.sessionId, request.sessionId)
       this.rememberSkillImportSession(request.sessionId, request.sessionId)
       this.currentSessionId = request.sessionId
-      this.cwd = sessionCwd
+      this.snapshotOwner.updateCwd(sessionCwd)
       this.pushEvent({
         kind: 'system',
         level: 'info',
@@ -2309,7 +2282,6 @@ class AcpRuntime {
     this.connection = undefined
     this.killAgentProcess()
     this.contextUsageTracker.clear()
-    this.contextUsageUpdatedPromptTurnsBySession.clear()
     this.appliedSessionModels.clear()
     void this.closeMcpHttpHost()
     void this.releaseResponsesBridgeLease()
@@ -2378,10 +2350,8 @@ class AcpRuntime {
     // The selected backend changed even if teardown must wait for an active prompt. Its old context
     // measurement no longer describes the selected generation, so hide it immediately and let the
     // replacement generation repopulate usage after reconnect/resume.
-    if (this.contextUsageBySession.size > 0) {
-      this.contextUsageBySession.clear()
+    if (this.contextUsageTracker.hasUsage()) {
       this.contextUsageTracker.clear()
-      this.contextUsageUpdatedPromptTurnsBySession.clear()
       this.appliedSessionModels.clear()
       this.emitState()
     }
@@ -2440,7 +2410,7 @@ class AcpRuntime {
       // old backend; the re-check there will fall through to a fresh connect(). Set status directly
       // rather than via setStatus — the throw may have come from emitState itself.
       this.connection = undefined
-      this.status = 'closed'
+      this.snapshotOwner.transitionStatus('closed')
       // Broadcast the closed status defensively so the renderer doesn't keep showing the prior
       // 'connected' state when no createSession follows to re-emit it. Guarded because emitState may
       // be the very thing that threw — the barrier release below must still run.
@@ -2540,9 +2510,7 @@ class AcpRuntime {
       // Context usage belongs to this live agent-context generation. Invalidate it before teardown,
       // including when a later session.dispose throws. A reconnect may resume the native context or
       // replay history into a fresh one; only that generation's own usage_update can repopulate it.
-      this.contextUsageBySession.clear()
       this.contextUsageTracker.clear()
-      this.contextUsageUpdatedPromptTurnsBySession.clear()
       this.appliedSessionModels.clear()
 
       this.releaseAllNotebookSessionCapabilities()
@@ -2791,7 +2759,7 @@ class AcpRuntime {
 
         if (toForce.length > 0) {
           // Capture routing before disconnect clears it, so resume lands on the same conversation.
-          const sessionCwd = this.sessionCwds.get(request.sessionId) ?? this.cwd
+          const sessionCwd = this.sessionCwds.get(request.sessionId) ?? this.snapshotOwner.cwd
           const projectName = this.resolveSessionProjectName(request.sessionId)
           const permissionProfile =
             this.permissionProfiles.get(request.sessionId)?.selectedProfile ??
@@ -2858,7 +2826,6 @@ class AcpRuntime {
     let skillActivitiesFinalized = false
     let revokeReferencedUploadGrant: (() => void) | undefined
     let contextUsageCheckpoint: ReturnType<ContextUsageTracker['checkpointSession']> | undefined
-    let contextUsageBeforePrompt: AcpContextUsage | undefined
     let contextUsageEstimateCommitted = false
 
     try {
@@ -2970,7 +2937,6 @@ class AcpRuntime {
       )
 
       contextUsageCheckpoint = this.contextUsageTracker.checkpointSession(request.sessionId)
-      contextUsageBeforePrompt = this.contextUsageBySession.get(request.sessionId)
       await this.recordPromptContextEstimate(
         request.sessionId,
         promptContent,
@@ -2996,7 +2962,7 @@ class AcpRuntime {
           ? await fetchOpenCodeUsageSnapshot(
               this.opencodeUsageApi,
               activeSession.sessionId,
-              this.sessionCwds.get(request.sessionId) ?? this.cwd,
+              this.sessionCwds.get(request.sessionId) ?? this.snapshotOwner.cwd,
               this.options.opencodeUsageFetch
             )
           : undefined
@@ -3032,7 +2998,7 @@ class AcpRuntime {
           if (
             this.restoreContextUsageBeforePromptIfPreflight(
               request.sessionId,
-              contextUsageBeforePrompt
+              contextUsageCheckpoint
             )
           ) {
             this.emitState()
@@ -3051,7 +3017,7 @@ class AcpRuntime {
                   await fetchOpenCodeUsageSnapshot(
                     this.opencodeUsageApi,
                     activeSession.sessionId,
-                    this.sessionCwds.get(request.sessionId) ?? this.cwd,
+                    this.sessionCwds.get(request.sessionId) ?? this.snapshotOwner.cwd,
                     this.options.opencodeUsageFetch
                   )
                 )
@@ -3122,7 +3088,7 @@ class AcpRuntime {
         !this.pendingProviderReconnect
       ) {
         const partialTurnWasObserved =
-          this.contextUsageUpdatedPromptTurnsBySession.get(request.sessionId) === promptTurn
+          this.contextUsageTracker.promptTurnWasUpdated(request.sessionId, promptTurn)
         if (partialTurnWasObserved) {
           // The provider may keep a turn that already streamed context-bearing updates even when its
           // prompt request ultimately rejects. Preserve those prompt/tool/output estimates, but do not
@@ -3130,15 +3096,10 @@ class AcpRuntime {
           this.contextUsageTracker.finalizeAssistantOutput(request.sessionId)
           this.restoreContextUsageBeforePromptIfPreflight(
             request.sessionId,
-            contextUsageBeforePrompt
+            contextUsageCheckpoint
           )
         } else {
           this.contextUsageTracker.restoreSession(request.sessionId, contextUsageCheckpoint)
-          if (contextUsageBeforePrompt) {
-            this.contextUsageBySession.set(request.sessionId, contextUsageBeforePrompt)
-          } else {
-            this.contextUsageBySession.delete(request.sessionId)
-          }
         }
       }
       if (skillActivitiesStarted && !skillActivitiesFinalized) {
@@ -3220,9 +3181,7 @@ class AcpRuntime {
         this.claudeTurnCountsBySession.delete(request.sessionId)
         this.clearOpenCodePermissionToolContext(request.sessionId)
         this.currentPromptTurnBySession.delete(request.sessionId)
-        if (this.contextUsageUpdatedPromptTurnsBySession.get(request.sessionId) === promptTurn) {
-          this.contextUsageUpdatedPromptTurnsBySession.delete(request.sessionId)
-        }
+        this.contextUsageTracker.clearPromptTurn(request.sessionId, promptTurn)
         this.promptInFlightSessionIds.delete(request.sessionId)
         if (this.skillImportTurnTokens.get(request.sessionId) === skillImportTurnToken) {
           this.skillImportTurnTokens.delete(request.sessionId)
@@ -3375,9 +3334,7 @@ class AcpRuntime {
     this.sessionProjectNames.delete(request.sessionId)
     this.sessionFrameworks.delete(request.sessionId)
     this.sessionBackendIds.delete(request.sessionId)
-    this.contextUsageBySession.delete(request.sessionId)
     this.contextUsageTracker.deleteSession(request.sessionId)
-    this.contextUsageUpdatedPromptTurnsBySession.delete(request.sessionId)
     this.appliedSessionModels.delete(request.sessionId)
     this.permissionProfiles.delete(request.sessionId)
     this.artifactSessionIds.delete(request.sessionId)
@@ -3948,7 +3905,7 @@ class AcpRuntime {
       await this.reconnectBarrier
     }
 
-    if (this.connection && this.status === 'connected') {
+    if (this.connection && this.snapshotOwner.status === 'connected') {
       return this.connection
     }
 
@@ -5497,36 +5454,20 @@ class AcpRuntime {
     }
 
     const usage = toCodexTurnTokenUsage(response.usage)
-    const current = this.contextUsageBySession.get(sessionId)
-    if (!usage || !current) return
+    if (!usage) return
 
     const used = usage.inputTokens + usage.cacheTokens
-    if (!Number.isSafeInteger(used)) return
-    if (current.used === used && current.breakdown?.status === 'reconciled') return
-
-    this.contextUsageBySession.set(sessionId, {
-      used,
-      ...(current.size === undefined ? {} : { size: current.size }),
-      breakdown: this.contextUsageTracker.compare(sessionId, used, 'reconciled')
-    })
-    this.emitState()
+    if (this.contextUsageTracker.reconcileUsed(sessionId, used)) this.emitState()
   }
 
   private restoreContextUsageBeforePromptIfPreflight(
     sessionId: string,
-    usageBeforePrompt: AcpContextUsage | undefined
+    checkpoint: ReturnType<ContextUsageTracker['checkpointSession']>
   ): boolean {
-    if (this.contextUsageBySession.get(sessionId)?.breakdown?.status !== 'preflight') return false
-
     // Preflight is a generation-only projection. If this turn produced no authoritative update,
     // return to the last Agent reading so compaction remains available; a prior preflight reading is
     // not authoritative either, so clear it instead of carrying the transient state across turns.
-    if (usageBeforePrompt && usageBeforePrompt.breakdown?.status !== 'preflight') {
-      this.contextUsageBySession.set(sessionId, usageBeforePrompt)
-    } else {
-      this.contextUsageBySession.delete(sessionId)
-    }
-    return true
+    return this.contextUsageTracker.restorePreflightUsage(sessionId, checkpoint)
   }
 
   private contextUsageSelectionFor(sessionId?: string): {
@@ -5593,27 +5534,9 @@ class AcpRuntime {
     sessionId: string,
     status: NonNullable<AcpContextUsage['breakdown']>['status']
   ): boolean {
-    const current = this.contextUsageBySession.get(sessionId)
-    if (status === 'preflight') {
-      const breakdown = this.contextUsageTracker.estimate(sessionId)
-      const size = this.selectedContextWindowFor(sessionId) ?? current?.size
-      if (!breakdown) return false
-      const agentUsed =
-        current?.breakdown?.status === 'preflight' ? current.agentUsed : current?.used
-      this.contextUsageBySession.set(sessionId, {
-        used: agentUsed ?? breakdown.estimatedTokens,
-        ...(agentUsed === undefined ? {} : { agentUsed }),
-        ...(size === undefined ? {} : { size }),
-        breakdown
-      })
-      return true
-    }
-
-    if (!current) return false
-    const breakdown = this.contextUsageTracker.compare(sessionId, current.used, status)
-    if (!breakdown) return false
-    this.contextUsageBySession.set(sessionId, { ...current, breakdown })
-    return true
+    const selectedSize = this.selectedContextWindowFor(sessionId)
+    const size = selectedSize ?? this.contextUsageTracker.usage(sessionId)?.size
+    return this.contextUsageTracker.refreshUsage(sessionId, status, size)
   }
 
   private async recordPromptContextEstimate(
@@ -5701,7 +5624,7 @@ class AcpRuntime {
       ) {
         const promptTurn = this.currentPromptTurnBySession.get(routed.sessionId)
         if (promptTurn !== undefined) {
-          this.contextUsageUpdatedPromptTurnsBySession.set(routed.sessionId, promptTurn)
+          this.contextUsageTracker.markPromptTurnUpdated(routed.sessionId, promptTurn)
         }
       }
     }
@@ -5725,16 +5648,11 @@ class AcpRuntime {
       // must stay hidden until disconnect replaces the agent-context generation.
       if (this.pendingProviderReconnect) return
 
-      const breakdown = this.contextUsageTracker.compare(
+      this.contextUsageTracker.reconcileProviderUsage(
         routed.sessionId,
-        event.contextUsage.used,
-        'reconciled'
+        event.contextUsage,
+        this.selectedContextWindowFor(routed.sessionId)
       )
-      this.contextUsageBySession.set(routed.sessionId, {
-        ...event.contextUsage,
-        size: this.selectedContextWindowFor(routed.sessionId) ?? event.contextUsage.size,
-        ...(breakdown ? { breakdown } : {})
-      })
       this.emitState()
       return
     }
@@ -5743,7 +5661,7 @@ class AcpRuntime {
 
     if (
       !this.pendingProviderReconnect &&
-      this.contextUsageBySession.get(routed.sessionId)?.breakdown?.status !== 'reconciled'
+      this.contextUsageTracker.usage(routed.sessionId)?.breakdown?.status !== 'reconciled'
     ) {
       this.refreshEstimatedContextUsage(routed.sessionId, 'preflight')
     }
@@ -5803,7 +5721,7 @@ class AcpRuntime {
         log.warn('agent stderr', {
           text,
           framework,
-          status: this.status,
+          status: this.snapshotOwner.status,
           sessionCount: this.sessions.size
         })
       }
@@ -5837,12 +5755,12 @@ class AcpRuntime {
         return
       }
 
-      this.error = errorMessage(error)
+      this.snapshotOwner.updateError(errorMessage(error))
       this.pushEvent({
         kind: 'error',
         level: 'error',
         title: 'Agent process error',
-        text: this.error
+        text: this.snapshotOwner.error
       })
       this.setStatus('error')
     })
@@ -5852,7 +5770,7 @@ class AcpRuntime {
         code,
         signal,
         framework,
-        status: this.status,
+        status: this.snapshotOwner.status,
         expected: this.expectedProcessExits.has(agentProcess),
         sessionCount: this.sessions.size,
         pid: agentProcess.pid
@@ -5862,7 +5780,10 @@ class AcpRuntime {
         return
       }
 
-      if (this.status === 'connected' || this.status === 'connecting') {
+      if (
+        this.snapshotOwner.status === 'connected' ||
+        this.snapshotOwner.status === 'connecting'
+      ) {
         this.pushEvent({
           kind: 'system',
           level: code === 0 ? 'info' : 'warning',
@@ -5899,9 +5820,7 @@ class AcpRuntime {
     this.codexSkillActivity.clear()
     this.clearAllOpenCodePermissionToolContext()
     this.sessionProjectNames.clear()
-    this.contextUsageBySession.clear()
     this.contextUsageTracker.clear()
-    this.contextUsageUpdatedPromptTurnsBySession.clear()
     this.appliedSessionModels.clear()
     this.artifactSessionIds.clear()
     this.notebookRoutingIds.clear()
@@ -5935,7 +5854,7 @@ class AcpRuntime {
 
   // Updates connection status and broadcasts the new snapshot.
   private setStatus(status: AcpStateSnapshot['status']): void {
-    this.status = status
+    this.snapshotOwner.transitionStatus(status)
     this.emitState()
   }
 
@@ -5943,63 +5862,14 @@ class AcpRuntime {
   private pushEvent(
     event: Omit<AcpRuntimeEvent, 'id' | 'timestamp'> & Partial<AcpRuntimeEvent>
   ): void {
-    let image = event.image
-    let raw = event.raw
-    let text = event.text
-    if (image && event.sessionId) {
-      const retainedBytes = this.events
-        .filter((candidate) => candidate.sessionId === event.sessionId)
-        .reduce(
-          (total, candidate) => total + (getAcpRuntimeEventImage(candidate)?.byteLength ?? 0),
-          0
-        )
-      if (retainedBytes + image.byteLength > MAX_ACP_SESSION_IMAGE_BYTES) {
-        image = undefined
-        raw = undefined
-        text = 'Agent image omitted because the session image budget was reached.'
-      }
-    }
-
-    const runtimeEvent: AcpRuntimeEvent = {
-      id: event.id ?? this.nextEventId(),
-      timestamp: event.timestamp ?? Date.now(),
-      level: event.level ?? 'info',
-      kind: event.kind,
-      compactionReason: event.compactionReason,
-      recoverable: event.recoverable,
-      providerError: event.providerError,
-      turnUsage: event.turnUsage,
-      sessionId: event.sessionId,
-      messageId: event.messageId,
-      role: event.role,
-      text,
-      image,
-      title: event.title,
-      status: event.status,
-      toolCallId: event.toolCallId,
-      providerToolName: event.providerToolName,
-      toolKind: event.toolKind,
-      toolContent: event.toolContent,
-      toolLocations: event.toolLocations,
-      rawInput: event.rawInput,
-      rawOutput: event.rawOutput,
-      runId: event.runId,
-      promptMessageId: event.promptMessageId,
-      artifactSessionId: event.artifactSessionId,
-      artifactClaimId: event.artifactClaimId,
-      artifacts: event.artifacts,
-      raw
-    }
-
-    this.events = [...this.events, runtimeEvent].slice(-MAX_EVENTS)
+    const runtimeEvent = this.snapshotOwner.appendEvent(event)
     this.callbacks.onEvent?.(runtimeEvent)
     this.emitState()
   }
 
   // Generates monotonically increasing event ids for this runtime instance.
   private nextEventId(): string {
-    this.eventSequence += 1
-    return `acp-event-${this.eventSequence}`
+    return this.snapshotOwner.nextEventId()
   }
 
   // Broadcasts the latest runtime snapshot if a listener is registered.


### PR DESCRIPTION
## Problem

ACP runtime snapshot mutation and context-window accounting were embedded in the large runtime, mixing read-model ownership with prompt, session, permission, and connection lifecycle behavior.

## Proposed change

- Extract an ACP runtime snapshot owner for status, cwd, errors, event sequence, and immutable snapshot projection.
- Extract a context-usage tracker for provider reconciliation, local estimation, checkpoint/restore, reset, and usage projection.
- Keep prompt-turn and session lifecycle ownership in the ACP runtime; keep `turnUsage` and model turn count outside the context tracker.
- Deep-copy every nested snapshot collection, including events, context breakdowns, pending Permission requests, and Permission profiles.

```mermaid
flowchart LR
  R["ACP runtime lifecycle"] --> S["Runtime snapshot owner"]
  R --> C["Context usage tracker"]
  S --> Q["Immutable status/event/permission snapshot"]
  C --> Q
  R --> T["Prompt turnUsage and model turns remain runtime-owned"]
```

## Scope and non-goals

No prompt execution, session lifecycle, Permission policy, Specialist binding, Compute behavior, transport, IPC, Web, CLI, schema, persisted-shape, data-relationship, or user-interaction changes. These owner seams remain provider-neutral for future orchestration work such as #458 without introducing orchestration state now.

## Acceptance criteria and validation

All checks below ran after the final material edit; the branch was then rebased without conflict onto `main@1f4f164` and the focused/full checks were repeated.

- Snapshot immutability, monotonic event order, provider precedence, reset, checkpoint/restore -> `npm test -- --run src/main/acp` -> 26 files, 599 tests passed.
- Node/Web types -> `npm run typecheck` -> passed.
- Repository lint without cache -> `npm run lint -- --no-cache` -> 0 errors; 23 pre-existing warnings.
- Regression suite -> `npm test` -> 606 files passed, 11 skipped; 9,051 tests passed, 140 skipped.
- Patch hygiene -> `git diff --check origin/main...HEAD` -> passed.
- Independent review -> Standards: 0 findings; Spec: 0 findings after ownership fixes.

## Review focus

- No mutable nested snapshot data escapes the owner boundary.
- Hidden usage events retain sequence positions and provider values still take precedence over estimates.
- Prompt/session lifecycle and terminal turn accounting remain owned by the ACP runtime.

Uncovered risk: deep-copy cost for the bounded event history (up to 500 events) has not received a dedicated benchmark; the full ACP and repository suites cover correctness, not micro-performance.
