### PR TITLE
refactor(main): separate application runtime composition

### DIFF
--- a/src/main/acp/ipc.test.ts
+++ b/src/main/acp/ipc.test.ts
@@ -112,7 +112,8 @@ vi.mock('../storage-root', () => ({
   resolveDataRoot: () => '/tmp/data'
 }))
 
-const { registerAcpIpcHandlers } = await import('./ipc')
+const { createAcpRuntime, installAcpIpcHandlers, registerAcpIpcHandlers } = await import('./ipc')
+type AcpTestOptions = Parameters<typeof registerAcpIpcHandlers>[0]
 
 // Minimal options — createRuntime just forwards them into the mocked AcpRuntime constructor.
 const registerWithFakes = (overrides?: {
@@ -128,7 +129,7 @@ const registerWithFakes = (overrides?: {
   profileService?: { getById: (id: string) => Promise<unknown> }
   specialistSkillCatalog?: Array<{ id: string; frameworkName: string; displayName: string }>
   provisionedConnectorSkillNames?: string[]
-}): void => {
+}): AcpTestOptions => {
   const taskNotifications =
     overrides?.taskNotifications ??
     ({ trackPrompt: vi.fn(), untrackPrompt: vi.fn() } as unknown as {
@@ -163,6 +164,7 @@ const registerWithFakes = (overrides?: {
   }
 
   registerAcpIpcHandlers(options)
+  return options as AcpTestOptions
 }
 
 afterEach(() => {
@@ -182,6 +184,22 @@ afterEach(() => {
   sendPrompt.mockResolvedValue(undefined)
   errorLogSpy.mockClear()
   AcpRuntimeMock.mockClear()
+})
+
+describe('ACP module transport seam', () => {
+  it('constructs the coordinator before installing Electron handlers', () => {
+    const options = registerWithFakes()
+    handlers.clear()
+
+    const runtime = createAcpRuntime(options)
+
+    expect(handlers.size).toBe(0)
+
+    installAcpIpcHandlers(runtime, options.taskNotifications)
+
+    expect(handlers.has('acp:get-state')).toBe(true)
+    expect(handlers.has('acp:respond-permission')).toBe(true)
+  })
 })
 
 describe('registerAcpIpcHandlers — Specialist identity resolver', () => {

--- a/src/main/acp/ipc.ts
+++ b/src/main/acp/ipc.ts
@@ -118,7 +118,7 @@ const createManagedSessionWorkspace = async (): Promise<string> => {
 
 // Creates the runtime coordinator used by all ACP IPC handlers and artifact claims. Each child runtime
 // captures one framework generation so sessions on different frameworks can remain live concurrently.
-const createRuntime = ({
+const createAcpRuntime = ({
   mcpEntryPath,
   repository,
   runRegistry,
@@ -301,11 +301,11 @@ const createRuntime = ({
   )
 }
 
-// Registers renderer-callable runtime commands on Electron IPC and returns the coordinator used by
-// settings, storage, reviewer, and shutdown integrations.
-const registerAcpIpcHandlers = (options: AcpIpcOptions): AcpRuntimeCoordinator => {
-  const runtime = createRuntime(options)
-
+// Installs the renderer-callable Electron adapter over an already-constructed ACP coordinator.
+const installAcpIpcHandlers = (
+  runtime: AcpRuntimeCoordinator,
+  taskNotifications?: TaskNotificationService
+): void => {
   ipcMainHandle('acp:get-state', () => runtime.getSnapshot())
   ipcMainHandle('acp:connect', (_event, request: AcpConnectRequest) => runtime.connect(request))
   ipcMainHandle('acp:disconnect', () => runtime.disconnect())
@@ -351,12 +351,12 @@ const registerAcpIpcHandlers = (options: AcpIpcOptions): AcpRuntimeCoordinator =
     // Remember the prompt's first line so a completion/failure notification can name the task.
     // If the runtime rejects before the turn starts (unknown session, another prompt in flight),
     // revert so a still-running turn keeps its own prompt's name.
-    const tracked = options.taskNotifications?.trackPrompt(request)
+    const tracked = taskNotifications?.trackPrompt(request)
 
     try {
       await runtime.sendPrompt(request)
     } catch (error) {
-      if (tracked) options.taskNotifications?.untrackPrompt(request.sessionId, tracked)
+      if (tracked) taskNotifications?.untrackPrompt(request.sessionId, tracked)
       throw error
     }
 
@@ -382,7 +382,12 @@ const registerAcpIpcHandlers = (options: AcpIpcOptions): AcpRuntimeCoordinator =
 
   // Kill the agent child on quit so it never outlives the app as an orphaned process.
   installAgentShutdownGuard(app, runtime)
+}
 
+// Compatibility wrapper for isolated callers; application composition uses the two-phase seam above.
+const registerAcpIpcHandlers = (options: AcpIpcOptions): AcpRuntimeCoordinator => {
+  const runtime = createAcpRuntime(options)
+  installAcpIpcHandlers(runtime, options.taskNotifications)
   return runtime
 }
 
@@ -420,4 +425,10 @@ const createDefaultNotebookRuntimeService = (
   })
 }
 
-export { createDefaultNotebookRuntimeService, registerAcpIpcHandlers }
+export {
+  createAcpRuntime,
+  createDefaultNotebookRuntimeService,
+  installAcpIpcHandlers,
+  registerAcpIpcHandlers
+}
+export type { AcpIpcOptions }

--- a/src/main/application-runtime.test.ts
+++ b/src/main/application-runtime.test.ts
@@ -1,6 +1,6 @@
 import { describe, expect, it, vi } from 'vitest'
 
-import { composeApplicationRuntime } from './application-runtime'
+import { composeApplicationRuntime, shutdownApplicationSurfaces } from './application-runtime'
 
 describe('application runtime composition', () => {
   it('constructs and starts each module once through declared dependencies', async () => {
@@ -98,6 +98,21 @@ describe('application runtime composition', () => {
     expect(dispose).toHaveBeenCalledOnce()
   })
 
+  it('uses rollback ownership only for failed composition', async () => {
+    const rollback = vi.fn()
+    const dispose = vi.fn()
+
+    await expect(
+      composeApplicationRuntime(async (modules) => {
+        await modules.add({}, () => ({ capability: {}, rollback, dispose }))
+        throw new Error('construction failed')
+      })
+    ).rejects.toThrow('construction failed')
+
+    expect(rollback).toHaveBeenCalledOnce()
+    expect(dispose).not.toHaveBeenCalled()
+  })
+
   it('attempts every disposer in reverse order when cleanup reports failures', async () => {
     const events: string[] = []
     const firstFailure = new Error('first disposal failed')
@@ -127,5 +142,48 @@ describe('application runtime composition', () => {
     })
     await expect(runtime.dispose()).rejects.toBe(disposalError)
     expect(events).toEqual(['dispose:second', 'dispose:first'])
+  })
+})
+
+describe('application surface shutdown', () => {
+  it('keeps one ordered quit path from the composed backend through web surfaces', async () => {
+    const order: string[] = []
+
+    await shutdownApplicationSurfaces({
+      disposeApplicationRuntime: () => {
+        order.push('application-runtime')
+      },
+      shutdownRemoteAccess: () => {
+        order.push('remote-access')
+      },
+      closeWebController: () => {
+        order.push('web-controller')
+      },
+      disposeWebRpc: () => {
+        order.push('web-rpc')
+      }
+    })
+
+    expect(order).toEqual(['application-runtime', 'remote-access', 'web-controller', 'web-rpc'])
+  })
+
+  it('continues closing surfaces when application runtime disposal rejects', async () => {
+    const failure = new Error('backend shutdown failed')
+    const shutdownRemoteAccess = vi.fn()
+    const closeWebController = vi.fn()
+    const disposeWebRpc = vi.fn()
+
+    await expect(
+      shutdownApplicationSurfaces({
+        disposeApplicationRuntime: () => Promise.reject(failure),
+        shutdownRemoteAccess,
+        closeWebController,
+        disposeWebRpc
+      })
+    ).rejects.toBe(failure)
+
+    expect(shutdownRemoteAccess).toHaveBeenCalledOnce()
+    expect(closeWebController).toHaveBeenCalledOnce()
+    expect(disposeWebRpc).toHaveBeenCalledOnce()
   })
 })

--- a/src/main/application-runtime.test.ts
+++ b/src/main/application-runtime.test.ts
@@ -1,6 +1,10 @@
 import { describe, expect, it, vi } from 'vitest'
 
-import { composeApplicationRuntime, shutdownApplicationSurfaces } from './application-runtime'
+import {
+  composeApplicationRuntime,
+  shutdownApplicationSurfaces,
+  withApplicationRuntimeShutdown
+} from './application-runtime'
 
 describe('application runtime composition', () => {
   it('constructs and starts each module once through declared dependencies', async () => {
@@ -149,21 +153,32 @@ describe('application surface shutdown', () => {
   it('keeps one ordered quit path from the composed backend through web surfaces', async () => {
     const order: string[] = []
 
-    await shutdownApplicationSurfaces({
-      disposeApplicationRuntime: () => {
-        order.push('application-runtime')
-      },
-      shutdownRemoteAccess: () => {
-        order.push('remote-access')
-      },
-      closeWebController: () => {
-        order.push('web-controller')
-      },
-      disposeWebRpc: () => {
-        order.push('web-rpc')
+    const lifecycle = withApplicationRuntimeShutdown(
+      { marker: 'electron-lifecycle' },
+      {
+        disposeApplicationRuntime: () => {
+          order.push('application-runtime')
+        },
+        remoteAccess: {
+          shutdown: () => {
+            order.push('remote-access')
+          }
+        },
+        webController: {
+          close: () => {
+            order.push('web-controller')
+          }
+        },
+        webRpc: {
+          dispose: () => {
+            order.push('web-rpc')
+          }
+        }
       }
-    })
+    )
+    await lifecycle.shutdownBackends()
 
+    expect(lifecycle.marker).toBe('electron-lifecycle')
     expect(order).toEqual(['application-runtime', 'remote-access', 'web-controller', 'web-rpc'])
   })
 

--- a/src/main/application-runtime.test.ts
+++ b/src/main/application-runtime.test.ts
@@ -1,0 +1,108 @@
+import { describe, expect, it, vi } from 'vitest'
+
+import { composeApplicationRuntime } from './application-runtime'
+
+describe('application runtime composition', () => {
+  it('constructs and starts each module once through declared dependencies', async () => {
+    const events: string[] = []
+
+    const runtime = await composeApplicationRuntime(async (modules) => {
+      const settings = await modules.add({ initialValue: 'managed' }, ({ initialValue }) => ({
+        capability: { read: () => initialValue },
+        start: () => {
+          events.push('start:settings')
+        },
+        dispose: () => {
+          events.push('dispose:settings')
+        }
+      }))
+      const synthetic = await modules.add(
+        { readSetting: settings.read },
+        ({ readSetting }) => ({
+          capability: { describe: () => `synthetic:${readSetting()}` },
+          start: () => {
+            events.push('start:synthetic')
+          },
+          dispose: () => {
+            events.push('dispose:synthetic')
+          }
+        })
+      )
+
+      return { settings, synthetic }
+    })
+
+    expect(runtime.interfaces.settings.read()).toBe('managed')
+    expect(runtime.interfaces.synthetic.describe()).toBe('synthetic:managed')
+    expect(events).toEqual(['start:settings', 'start:synthetic'])
+
+    await runtime.dispose()
+    await runtime.dispose()
+
+    expect(events).toEqual([
+      'start:settings',
+      'start:synthetic',
+      'dispose:synthetic',
+      'dispose:settings'
+    ])
+  })
+
+  it('disposes already-created modules in reverse order after partial construction failure', async () => {
+    const events: string[] = []
+    const failure = new Error('synthetic construction failed')
+
+    await expect(
+      composeApplicationRuntime(async (modules) => {
+        await modules.add({}, () => ({
+          capability: { name: 'first' },
+          start: () => {
+            events.push('start:first')
+          },
+          dispose: () => {
+            events.push('dispose:first')
+          }
+        }))
+        await modules.add({}, () => ({
+          capability: { name: 'second' },
+          start: () => {
+            events.push('start:second')
+          },
+          dispose: () => {
+            events.push('dispose:second')
+          }
+        }))
+        await modules.add({}, () => {
+          throw failure
+        })
+        return {}
+      })
+    ).rejects.toBe(failure)
+
+    expect(events).toEqual([
+      'start:first',
+      'start:second',
+      'dispose:second',
+      'dispose:first'
+    ])
+  })
+
+  it('releases a module whose startup fails before propagating the error', async () => {
+    const dispose = vi.fn()
+    const failure = new Error('start failed')
+
+    await expect(
+      composeApplicationRuntime(async (modules) => {
+        await modules.add({}, () => ({
+          capability: {},
+          start: () => {
+            throw failure
+          },
+          dispose
+        }))
+        return {}
+      })
+    ).rejects.toBe(failure)
+
+    expect(dispose).toHaveBeenCalledOnce()
+  })
+})

--- a/src/main/application-runtime.test.ts
+++ b/src/main/application-runtime.test.ts
@@ -16,18 +16,15 @@ describe('application runtime composition', () => {
           events.push('dispose:settings')
         }
       }))
-      const synthetic = await modules.add(
-        { readSetting: settings.read },
-        ({ readSetting }) => ({
-          capability: { describe: () => `synthetic:${readSetting()}` },
-          start: () => {
-            events.push('start:synthetic')
-          },
-          dispose: () => {
-            events.push('dispose:synthetic')
-          }
-        })
-      )
+      const synthetic = await modules.add({ readSetting: settings.read }, ({ readSetting }) => ({
+        capability: { describe: () => `synthetic:${readSetting()}` },
+        start: () => {
+          events.push('start:synthetic')
+        },
+        dispose: () => {
+          events.push('dispose:synthetic')
+        }
+      }))
 
       return { settings, synthetic }
     })
@@ -78,12 +75,7 @@ describe('application runtime composition', () => {
       })
     ).rejects.toBe(failure)
 
-    expect(events).toEqual([
-      'start:first',
-      'start:second',
-      'dispose:second',
-      'dispose:first'
-    ])
+    expect(events).toEqual(['start:first', 'start:second', 'dispose:second', 'dispose:first'])
   })
 
   it('releases a module whose startup fails before propagating the error', async () => {
@@ -104,5 +96,36 @@ describe('application runtime composition', () => {
     ).rejects.toBe(failure)
 
     expect(dispose).toHaveBeenCalledOnce()
+  })
+
+  it('attempts every disposer in reverse order when cleanup reports failures', async () => {
+    const events: string[] = []
+    const firstFailure = new Error('first disposal failed')
+    const secondFailure = new Error('second disposal failed')
+
+    const runtime = await composeApplicationRuntime(async (modules) => {
+      await modules.add({}, () => ({
+        capability: {},
+        dispose: () => {
+          events.push('dispose:first')
+          throw firstFailure
+        }
+      }))
+      await modules.add({}, () => ({
+        capability: {},
+        dispose: () => {
+          events.push('dispose:second')
+          throw secondFailure
+        }
+      }))
+      return {}
+    })
+
+    const disposalError = await runtime.dispose().catch((error: unknown) => error)
+    expect(disposalError).toMatchObject({
+      errors: [secondFailure, firstFailure]
+    })
+    await expect(runtime.dispose()).rejects.toBe(disposalError)
+    expect(events).toEqual(['dispose:second', 'dispose:first'])
   })
 })

--- a/src/main/application-runtime.test.ts
+++ b/src/main/application-runtime.test.ts
@@ -147,6 +147,55 @@ describe('application runtime composition', () => {
     await expect(runtime.dispose()).rejects.toBe(disposalError)
     expect(events).toEqual(['dispose:second', 'dispose:first'])
   })
+
+  it('bounds a hung module, reports its name, and continues reverse disposal', async () => {
+    vi.useFakeTimers()
+    const events: string[] = []
+    let rejectLate: ((error: Error) => void) | undefined
+
+    try {
+      const runtime = await composeApplicationRuntime(async (modules) => {
+        await modules.add({}, () => ({
+          name: 'settings',
+          capability: {},
+          dispose: () => {
+            events.push('dispose:settings')
+          }
+        }))
+        await modules.add({}, () => ({
+          name: 'mcp-client-manager',
+          capability: {},
+          disposeTimeoutMs: 25,
+          dispose: () =>
+            new Promise<void>((_resolve, reject) => {
+              rejectLate = reject
+            })
+        }))
+        return {}
+      })
+
+      const disposal = runtime.dispose().catch((error: unknown) => error)
+      await vi.advanceTimersByTimeAsync(25)
+
+      const error = await disposal
+      expect(error).toMatchObject({
+        errors: [
+          expect.objectContaining({
+            name: 'ApplicationModuleDisposalTimeoutError',
+            moduleName: 'mcp-client-manager',
+            timeoutMs: 25
+          })
+        ]
+      })
+      expect(events).toEqual(['dispose:settings'])
+
+      // A timed-out disposer remains observed: a later transport rejection must not become unhandled.
+      rejectLate?.(new Error('late MCP close failure'))
+      await Promise.resolve()
+    } finally {
+      vi.useRealTimers()
+    }
+  })
 })
 
 describe('application surface shutdown', () => {
@@ -182,21 +231,27 @@ describe('application surface shutdown', () => {
     expect(order).toEqual(['application-runtime', 'remote-access', 'web-controller', 'web-rpc'])
   })
 
-  it('continues closing surfaces when application runtime disposal rejects', async () => {
+  it('diagnoses runtime failure and continues closing surfaces without rejecting lifecycle', async () => {
     const failure = new Error('backend shutdown failed')
     const shutdownRemoteAccess = vi.fn()
     const closeWebController = vi.fn()
     const disposeWebRpc = vi.fn()
+    const log = { error: vi.fn() }
 
     await expect(
       shutdownApplicationSurfaces({
         disposeApplicationRuntime: () => Promise.reject(failure),
         shutdownRemoteAccess,
         closeWebController,
-        disposeWebRpc
+        disposeWebRpc,
+        log
       })
-    ).rejects.toBe(failure)
+    ).resolves.toBeUndefined()
 
+    expect(log.error).toHaveBeenCalledWith(
+      'application runtime disposal failed during application shutdown',
+      failure
+    )
     expect(shutdownRemoteAccess).toHaveBeenCalledOnce()
     expect(closeWebController).toHaveBeenCalledOnce()
     expect(disposeWebRpc).toHaveBeenCalledOnce()

--- a/src/main/application-runtime.test.ts
+++ b/src/main/application-runtime.test.ts
@@ -2,6 +2,7 @@ import { describe, expect, it, vi } from 'vitest'
 
 import {
   composeApplicationRuntime,
+  composeApplicationRuntimeWithAdapters,
   shutdownApplicationSurfaces,
   withApplicationRuntimeShutdown
 } from './application-runtime'
@@ -196,6 +197,38 @@ describe('application runtime composition', () => {
       vi.useRealTimers()
     }
   })
+
+  it('installs adapters from the completed production composition before exposing interfaces', async () => {
+    const order: string[] = []
+    const adapterInterfaces = { compute: {}, acp: {} }
+
+    const runtime = await composeApplicationRuntimeWithAdapters(
+      async (modules) => {
+        const capability = await modules.add({}, () => ({
+          name: 'runtime',
+          capability: { ready: true },
+          start: () => {
+            order.push('start')
+          },
+          dispose: () => {
+            order.push('dispose')
+          }
+        }))
+        order.push('created')
+        return { capability, electronAdapters: adapterInterfaces }
+      },
+      (adapters) => {
+        expect(adapters).toBe(adapterInterfaces)
+        order.push('install')
+      }
+    )
+
+    expect(runtime.interfaces).toEqual({ capability: { ready: true } })
+    expect(order).toEqual(['start', 'created', 'install'])
+
+    await runtime.dispose()
+    expect(order).toEqual(['start', 'created', 'install', 'dispose'])
+  })
 })
 
 describe('application surface shutdown', () => {
@@ -249,7 +282,7 @@ describe('application surface shutdown', () => {
     ).resolves.toBeUndefined()
 
     expect(log.error).toHaveBeenCalledWith(
-      'application runtime disposal failed during application shutdown',
+      'application runtime disposal failed during application shutdown: Error: backend shutdown failed',
       failure
     )
     expect(shutdownRemoteAccess).toHaveBeenCalledOnce()

--- a/src/main/application-runtime.ts
+++ b/src/main/application-runtime.ts
@@ -1,0 +1,93 @@
+type Awaitable<T> = T | Promise<T>
+
+export type ApplicationModule<Capability> = {
+  capability: Capability
+  start?: () => Awaitable<void>
+  dispose?: () => Awaitable<void>
+}
+
+export type ApplicationModuleFactory<Dependencies, Capability> = (
+  dependencies: Dependencies
+) => Awaitable<ApplicationModule<Capability>>
+
+export type ApplicationModuleBuilder = {
+  add<Dependencies, Capability>(
+    dependencies: Dependencies,
+    factory: ApplicationModuleFactory<Dependencies, Capability>
+  ): Promise<Capability>
+}
+
+export type ApplicationRuntime<Interfaces> = {
+  readonly interfaces: Interfaces
+  dispose(): Promise<void>
+}
+
+type OwnedModule = Pick<ApplicationModule<unknown>, 'dispose'>
+
+class RuntimeModuleBuilder implements ApplicationModuleBuilder {
+  private readonly modules: OwnedModule[] = []
+  private disposePromise: Promise<void> | undefined
+  private acceptingModules = true
+
+  async add<Dependencies, Capability>(
+    dependencies: Dependencies,
+    factory: ApplicationModuleFactory<Dependencies, Capability>
+  ): Promise<Capability> {
+    if (!this.acceptingModules) {
+      throw new Error('Application runtime composition is already complete.')
+    }
+
+    const module = await factory(dependencies)
+    this.modules.push(module)
+    await module.start?.()
+    return module.capability
+  }
+
+  complete(): void {
+    this.acceptingModules = false
+  }
+
+  dispose(): Promise<void> {
+    this.acceptingModules = false
+    this.disposePromise ??= this.disposeModules()
+    return this.disposePromise
+  }
+
+  private async disposeModules(): Promise<void> {
+    const failures: unknown[] = []
+    for (const module of [...this.modules].reverse()) {
+      try {
+        await module.dispose?.()
+      } catch (error) {
+        failures.push(error)
+      }
+    }
+    if (failures.length > 0) {
+      throw new AggregateError(failures, 'Application runtime disposal failed.')
+    }
+  }
+}
+
+export const composeApplicationRuntime = async <Interfaces>(
+  build: (modules: ApplicationModuleBuilder) => Awaitable<Interfaces>
+): Promise<ApplicationRuntime<Interfaces>> => {
+  const modules = new RuntimeModuleBuilder()
+  try {
+    const interfaces = await build(modules)
+    modules.complete()
+    return {
+      interfaces,
+      dispose: () => modules.dispose()
+    }
+  } catch (error) {
+    try {
+      await modules.dispose()
+    } catch (disposeError) {
+      throw new AggregateError(
+        [error, disposeError],
+        'Application runtime construction and disposal failed.'
+      )
+    }
+    throw error
+  }
+}

--- a/src/main/application-runtime.ts
+++ b/src/main/application-runtime.ts
@@ -32,6 +32,13 @@ export type ApplicationSurfaceShutdown = {
   disposeWebRpc(): Awaitable<void>
 }
 
+export type ApplicationLifecycleShutdownDependencies = {
+  disposeApplicationRuntime: ApplicationSurfaceShutdown['disposeApplicationRuntime']
+  remoteAccess: { shutdown(): Awaitable<void> }
+  webController: { close(): Awaitable<void> }
+  webRpc: { dispose(): Awaitable<void> }
+}
+
 // Preserves the desktop quit order while guaranteeing that a failed surface cannot strand a later
 // one. Backend shutdown is owned by the application runtime and remains bounded by its coordinator.
 export const shutdownApplicationSurfaces = async ({
@@ -54,6 +61,31 @@ export const shutdownApplicationSurfaces = async ({
     }
   }
 }
+
+// Builds the exact callback passed to the Electron lifecycle. Requiring the application disposer here
+// prevents index wiring from falling back to surface-only cleanup and orphaning backend ownership.
+export const createApplicationLifecycleShutdown = ({
+  disposeApplicationRuntime,
+  remoteAccess,
+  webController,
+  webRpc
+}: ApplicationLifecycleShutdownDependencies): (() => Promise<void>) => {
+  return () =>
+    shutdownApplicationSurfaces({
+      disposeApplicationRuntime,
+      shutdownRemoteAccess: () => remoteAccess.shutdown(),
+      closeWebController: () => webController.close(),
+      disposeWebRpc: () => webRpc.dispose()
+    })
+}
+
+export const withApplicationRuntimeShutdown = <Options extends object>(
+  options: Options,
+  dependencies: ApplicationLifecycleShutdownDependencies
+): NoInfer<Options> & { shutdownBackends: () => Promise<void> } => ({
+  ...options,
+  shutdownBackends: createApplicationLifecycleShutdown(dependencies)
+})
 
 type OwnedModule = Pick<ApplicationModule<unknown>, 'dispose' | 'rollback'>
 

--- a/src/main/application-runtime.ts
+++ b/src/main/application-runtime.ts
@@ -64,11 +64,22 @@ export const shutdownApplicationSurfaces = async ({
   disposeWebRpc,
   log
 }: ApplicationSurfaceShutdown): Promise<void> => {
+  const flattenErrors = (error: unknown): unknown[] =>
+    error instanceof AggregateError ? error.errors.flatMap(flattenErrors) : [error]
+  const describeError = (error: unknown): string =>
+    error instanceof Error ? `${error.name}: ${error.message}` : String(error)
   const dispose = async (name: string, operation: () => Awaitable<void>): Promise<void> => {
     try {
       await operation()
     } catch (error) {
-      log?.error(`${name} disposal failed during application shutdown`, error)
+      for (const cause of flattenErrors(error)) {
+        // Put the cause summary in the top-level message: the production logger intentionally serializes
+        // an Error as name/message/stack and does not retain AggregateError.errors or custom properties.
+        log?.error(
+          `${name} disposal failed during application shutdown: ${describeError(cause)}`,
+          cause
+        )
+      }
     }
   }
 
@@ -208,3 +219,17 @@ export const composeApplicationRuntime = async <Interfaces>(
     throw error
   }
 }
+
+export const composeApplicationRuntimeWithAdapters = async <Interfaces extends object, Adapters>(
+  createModules: (
+    modules: ApplicationModuleBuilder
+  ) => Awaitable<Interfaces & { electronAdapters: Adapters }>,
+  installAdapters: (adapters: Adapters) => Awaitable<void>
+): Promise<ApplicationRuntime<Interfaces>> =>
+  composeApplicationRuntime(async (modules) => {
+    const built = await createModules(modules)
+    await installAdapters(built.electronAdapters)
+    const { electronAdapters: _electronAdapters, ...interfaces } = built
+    void _electronAdapters
+    return interfaces as Interfaces
+  })

--- a/src/main/application-runtime.ts
+++ b/src/main/application-runtime.ts
@@ -3,6 +3,9 @@ type Awaitable<T> = T | Promise<T>
 export type ApplicationModule<Capability> = {
   capability: Capability
   start?: () => Awaitable<void>
+  // Releases a partially-constructed module before runtime ownership has been fully established.
+  // When omitted, normal disposal is also safe for rollback.
+  rollback?: () => Awaitable<void>
   dispose?: () => Awaitable<void>
 }
 
@@ -22,7 +25,37 @@ export type ApplicationRuntime<Interfaces> = {
   dispose(): Promise<void>
 }
 
-type OwnedModule = Pick<ApplicationModule<unknown>, 'dispose'>
+export type ApplicationSurfaceShutdown = {
+  disposeApplicationRuntime(): Awaitable<void>
+  shutdownRemoteAccess(): Awaitable<void>
+  closeWebController(): Awaitable<void>
+  disposeWebRpc(): Awaitable<void>
+}
+
+// Preserves the desktop quit order while guaranteeing that a failed surface cannot strand a later
+// one. Backend shutdown is owned by the application runtime and remains bounded by its coordinator.
+export const shutdownApplicationSurfaces = async ({
+  disposeApplicationRuntime,
+  shutdownRemoteAccess,
+  closeWebController,
+  disposeWebRpc
+}: ApplicationSurfaceShutdown): Promise<void> => {
+  try {
+    await disposeApplicationRuntime()
+  } finally {
+    try {
+      await shutdownRemoteAccess()
+    } finally {
+      try {
+        await closeWebController()
+      } finally {
+        await disposeWebRpc()
+      }
+    }
+  }
+}
+
+type OwnedModule = Pick<ApplicationModule<unknown>, 'dispose' | 'rollback'>
 
 class RuntimeModuleBuilder implements ApplicationModuleBuilder {
   private readonly modules: OwnedModule[] = []
@@ -47,17 +80,17 @@ class RuntimeModuleBuilder implements ApplicationModuleBuilder {
     this.acceptingModules = false
   }
 
-  dispose(): Promise<void> {
+  dispose(mode: 'runtime' | 'rollback' = 'runtime'): Promise<void> {
     this.acceptingModules = false
-    this.disposePromise ??= this.disposeModules()
+    this.disposePromise ??= this.disposeModules(mode)
     return this.disposePromise
   }
 
-  private async disposeModules(): Promise<void> {
+  private async disposeModules(mode: 'runtime' | 'rollback'): Promise<void> {
     const failures: unknown[] = []
     for (const module of [...this.modules].reverse()) {
       try {
-        await module.dispose?.()
+        await (mode === 'rollback' ? (module.rollback ?? module.dispose)?.() : module.dispose?.())
       } catch (error) {
         failures.push(error)
       }
@@ -81,7 +114,7 @@ export const composeApplicationRuntime = async <Interfaces>(
     }
   } catch (error) {
     try {
-      await modules.dispose()
+      await modules.dispose('rollback')
     } catch (disposeError) {
       throw new AggregateError(
         [error, disposeError],

--- a/src/main/application-runtime.ts
+++ b/src/main/application-runtime.ts
@@ -1,12 +1,26 @@
 type Awaitable<T> = T | Promise<T>
 
+export const APPLICATION_MODULE_DISPOSAL_BUDGET_MS = 1000
+
+export class ApplicationModuleDisposalTimeoutError extends Error {
+  constructor(
+    readonly moduleName: string,
+    readonly timeoutMs: number
+  ) {
+    super(`Application runtime module "${moduleName}" disposal exceeded ${timeoutMs}ms.`)
+    this.name = 'ApplicationModuleDisposalTimeoutError'
+  }
+}
+
 export type ApplicationModule<Capability> = {
+  name?: string
   capability: Capability
   start?: () => Awaitable<void>
   // Releases a partially-constructed module before runtime ownership has been fully established.
   // When omitted, normal disposal is also safe for rollback.
   rollback?: () => Awaitable<void>
   dispose?: () => Awaitable<void>
+  disposeTimeoutMs?: number
 }
 
 export type ApplicationModuleFactory<Dependencies, Capability> = (
@@ -30,6 +44,7 @@ export type ApplicationSurfaceShutdown = {
   shutdownRemoteAccess(): Awaitable<void>
   closeWebController(): Awaitable<void>
   disposeWebRpc(): Awaitable<void>
+  log?: { error(message: string, error: unknown): void }
 }
 
 export type ApplicationLifecycleShutdownDependencies = {
@@ -37,6 +52,7 @@ export type ApplicationLifecycleShutdownDependencies = {
   remoteAccess: { shutdown(): Awaitable<void> }
   webController: { close(): Awaitable<void> }
   webRpc: { dispose(): Awaitable<void> }
+  log?: ApplicationSurfaceShutdown['log']
 }
 
 // Preserves the desktop quit order while guaranteeing that a failed surface cannot strand a later
@@ -45,21 +61,21 @@ export const shutdownApplicationSurfaces = async ({
   disposeApplicationRuntime,
   shutdownRemoteAccess,
   closeWebController,
-  disposeWebRpc
+  disposeWebRpc,
+  log
 }: ApplicationSurfaceShutdown): Promise<void> => {
-  try {
-    await disposeApplicationRuntime()
-  } finally {
+  const dispose = async (name: string, operation: () => Awaitable<void>): Promise<void> => {
     try {
-      await shutdownRemoteAccess()
-    } finally {
-      try {
-        await closeWebController()
-      } finally {
-        await disposeWebRpc()
-      }
+      await operation()
+    } catch (error) {
+      log?.error(`${name} disposal failed during application shutdown`, error)
     }
   }
+
+  await dispose('application runtime', disposeApplicationRuntime)
+  await dispose('remote access', shutdownRemoteAccess)
+  await dispose('web controller', closeWebController)
+  await dispose('web RPC', disposeWebRpc)
 }
 
 // Builds the exact callback passed to the Electron lifecycle. Requiring the application disposer here
@@ -68,14 +84,16 @@ export const createApplicationLifecycleShutdown = ({
   disposeApplicationRuntime,
   remoteAccess,
   webController,
-  webRpc
+  webRpc,
+  log
 }: ApplicationLifecycleShutdownDependencies): (() => Promise<void>) => {
   return () =>
     shutdownApplicationSurfaces({
       disposeApplicationRuntime,
       shutdownRemoteAccess: () => remoteAccess.shutdown(),
       closeWebController: () => webController.close(),
-      disposeWebRpc: () => webRpc.dispose()
+      disposeWebRpc: () => webRpc.dispose(),
+      log
     })
 }
 
@@ -87,7 +105,10 @@ export const withApplicationRuntimeShutdown = <Options extends object>(
   shutdownBackends: createApplicationLifecycleShutdown(dependencies)
 })
 
-type OwnedModule = Pick<ApplicationModule<unknown>, 'dispose' | 'rollback'>
+type OwnedModule = Pick<
+  ApplicationModule<unknown>,
+  'name' | 'dispose' | 'rollback' | 'disposeTimeoutMs'
+>
 
 class RuntimeModuleBuilder implements ApplicationModuleBuilder {
   private readonly modules: OwnedModule[] = []
@@ -120,9 +141,16 @@ class RuntimeModuleBuilder implements ApplicationModuleBuilder {
 
   private async disposeModules(mode: 'runtime' | 'rollback'): Promise<void> {
     const failures: unknown[] = []
-    for (const module of [...this.modules].reverse()) {
+    for (const [index, module] of [...this.modules].reverse().entries()) {
       try {
-        await (mode === 'rollback' ? (module.rollback ?? module.dispose)?.() : module.dispose?.())
+        const dispose = mode === 'rollback' ? (module.rollback ?? module.dispose) : module.dispose
+        if (dispose) {
+          await this.disposeModule(
+            module.name ?? `module-${this.modules.length - index}`,
+            dispose,
+            module.disposeTimeoutMs ?? APPLICATION_MODULE_DISPOSAL_BUDGET_MS
+          )
+        }
       } catch (error) {
         failures.push(error)
       }
@@ -130,6 +158,30 @@ class RuntimeModuleBuilder implements ApplicationModuleBuilder {
     if (failures.length > 0) {
       throw new AggregateError(failures, 'Application runtime disposal failed.')
     }
+  }
+
+  private async disposeModule(
+    moduleName: string,
+    dispose: () => Awaitable<void>,
+    timeoutMs: number
+  ): Promise<void> {
+    const observed = Promise.resolve()
+      .then(dispose)
+      .then(
+        () => ({ status: 'fulfilled' as const }),
+        (reason: unknown) => ({ status: 'rejected' as const, reason })
+      )
+    let timer: ReturnType<typeof setTimeout> | undefined
+    const timeout = new Promise<{ status: 'timeout' }>((resolve) => {
+      timer = setTimeout(() => resolve({ status: 'timeout' }), timeoutMs)
+      timer.unref?.()
+    })
+    const outcome = await Promise.race([observed, timeout])
+    if (timer) clearTimeout(timer)
+    if (outcome.status === 'timeout') {
+      throw new ApplicationModuleDisposalTimeoutError(moduleName, timeoutMs)
+    }
+    if (outcome.status === 'rejected') throw outcome.reason
   }
 }
 

--- a/src/main/compute/ipc.test.ts
+++ b/src/main/compute/ipc.test.ts
@@ -14,7 +14,9 @@ import {
   COMPUTE_JOBS_LIST_CHANNEL,
   broadcastJobUpdated,
   createComputeHandlers,
+  createComputeIpcModule,
   createJobUpdatedBroadcaster,
+  installComputeIpcHandlers,
   registerComputeIpcHandlers,
   toJobSummary
 } from './ipc'
@@ -1181,6 +1183,17 @@ describe('registerComputeIpcHandlers', () => {
     for (const channel of expected) {
       expect(handlers.has(channel)).toBe(true)
     }
+  })
+
+  it('keeps Compute construction separate from Electron adapter installation', () => {
+    const module = createComputeIpcModule(mockRepository({}), mockJobRepo({}))
+
+    expect(handlers.size).toBe(0)
+
+    installComputeIpcHandlers(module)
+
+    expect(handlers.has('compute:list')).toBe(true)
+    expect(module.computeService).toBeDefined()
   })
 
   it('round-trips the enabled-hosts registry through get/set IPC channels', async () => {

--- a/src/main/compute/ipc.ts
+++ b/src/main/compute/ipc.ts
@@ -416,8 +416,17 @@ export const createJobUpdatedBroadcaster =
       })
   }
 
-// Registers the renderer-callable compute host commands.
-const registerComputeIpcHandlers = (
+type ComputeIpcModule = {
+  handlers: ComputeHandlers
+  computeService: ComputeService
+  jobRepository: ComputeJobRepository
+  hostRepository: ComputeHostRepository
+  enabledComputeHostsRegistry: EnabledComputeHostsRegistry
+}
+
+// Constructs the shared Compute module without installing an Electron transport. Keeping this seam
+// explicit lets application composition start the Job runtime before any renderer adapter exists.
+const createComputeIpcModule = (
   repository = createDefaultComputeHostRepository(),
   jobRepository = createDefaultComputeJobRepository(),
   // Resolves artifact-store paths for job input staging. Optional: when omitted, artifact inputs
@@ -429,12 +438,7 @@ const registerComputeIpcHandlers = (
   injectedService?: ComputeService,
   taskNotifications?: Pick<TaskNotificationService, 'handleComputeApproval'>,
   permissionGrantRegistry?: PermissionGrantRegistry
-): {
-  computeService: ComputeService
-  jobRepository: ComputeJobRepository
-  hostRepository: ComputeHostRepository
-  enabledComputeHostsRegistry: EnabledComputeHostsRegistry
-} => {
+): ComputeIpcModule => {
   const storageRoot = resolveStorageRoot()
   const dataRoot = resolveDataRoot()
 
@@ -459,6 +463,20 @@ const registerComputeIpcHandlers = (
     permissionGrantRegistry
   )
 
+  return {
+    handlers,
+    computeService: handlers.computeService,
+    jobRepository,
+    hostRepository: repository,
+    enabledComputeHostsRegistry
+  }
+}
+
+// Installs only the renderer-callable Electron adapter over an already-constructed Compute module.
+const installComputeIpcHandlers = ({
+  handlers,
+  enabledComputeHostsRegistry
+}: Pick<ComputeIpcModule, 'handlers' | 'enabledComputeHostsRegistry'>): void => {
   ipcMainHandle('compute:list', () => handlers.list())
   ipcMainHandle('compute:get', (_event, providerId: string) => handlers.get(providerId))
   ipcMainHandle('compute:create', (_event, request: CreateComputeHostRequest) =>
@@ -556,20 +574,41 @@ const registerComputeIpcHandlers = (
       enabledComputeHostsRegistry.set(sessionId, providerIds)
     }
   )
+}
 
-  return {
-    computeService: handlers.computeService,
+// Compatibility wrapper for isolated callers; application composition uses the two-phase seam above.
+const registerComputeIpcHandlers = (
+  repository = createDefaultComputeHostRepository(),
+  jobRepository = createDefaultComputeJobRepository(),
+  artifactResolver?: ArtifactResolver,
+  injectedService?: ComputeService,
+  taskNotifications?: Pick<TaskNotificationService, 'handleComputeApproval'>,
+  permissionGrantRegistry?: PermissionGrantRegistry
+): Omit<ComputeIpcModule, 'handlers'> => {
+  const module = createComputeIpcModule(
+    repository,
     jobRepository,
-    hostRepository: repository,
-    enabledComputeHostsRegistry
+    artifactResolver,
+    injectedService,
+    taskNotifications,
+    permissionGrantRegistry
+  )
+  installComputeIpcHandlers(module)
+  return {
+    computeService: module.computeService,
+    jobRepository: module.jobRepository,
+    hostRepository: module.hostRepository,
+    enabledComputeHostsRegistry: module.enabledComputeHostsRegistry
   }
 }
 
 export {
   createComputeHandlers,
+  createComputeIpcModule,
   createDefaultComputeHostRepository,
   createDefaultComputeJobRepository,
+  installComputeIpcHandlers,
   registerComputeIpcHandlers,
   enabledComputeHostsRegistry
 }
-export type { ComputeHandlers }
+export type { ComputeHandlers, ComputeIpcModule }

--- a/src/main/index.ts
+++ b/src/main/index.ts
@@ -9,7 +9,7 @@ import {
   NOTEBOOK_MCP_SERVER_ARG,
   SKILL_IMPORT_MCP_SERVER_ARG
 } from './mcp-server-args'
-import { shutdownApplicationSurfaces } from './application-runtime'
+import { withApplicationRuntimeShutdown } from './application-runtime'
 
 const APP_NAME = 'Open Science'
 const APP_USER_MODEL_ID = 'com.aipoch.open-science'
@@ -330,47 +330,50 @@ async function startElectronApp(mainEntryPath: string): Promise<void> {
     // is bound with the live backend handles; the agent teardown latches shutting-down and awaits the
     // process tree so a Windows taskkill /T completes before app.exit.
     installAppLifecycle: (ctx) => {
-      const { showMainWindow, getMainWindow, isMainWindowHidden } = ctx.installAppLifecycle({
-        app,
-        createMainWindow: ctx.createMainWindow,
-        createTray: (handlers) => {
-          const webPort = ctx.webController.runningPort()
-          const headlessWeb = ctx.webMode.headless && webPort !== undefined
-          return ctx.createAppTray({
-            iconPath: trayIconPath,
-            templateIconPath: process.platform === 'darwin' ? trayMacTemplate : undefined,
-            ...handlers,
-            ...(headlessWeb
-              ? {
-                  headless: true,
-                  onOpenWeb: async () => {
-                    const { shell } = await import('electron')
-                    await shell.openExternal(await ctx.buildAuthenticatedWebUrl(webPort))
-                  },
-                  onCopyWebUrl: async () => {
-                    const { clipboard } = await import('electron')
-                    clipboard.writeText(await ctx.buildAuthenticatedWebUrl(webPort))
-                  }
-                }
-              : {})
-          })
-        },
-        // Application composition owns the one bounded ACP/Notebook shutdown. Remaining surfaces close
-        // afterward in their established order, even when an earlier disposer rejects.
-        shutdownBackends: () =>
-          shutdownApplicationSurfaces({
+      const { showMainWindow, getMainWindow, isMainWindowHidden } = ctx.installAppLifecycle(
+        withApplicationRuntimeShutdown(
+          {
+            app,
+            createMainWindow: ctx.createMainWindow,
+            createTray: (handlers) => {
+              const webPort = ctx.webController.runningPort()
+              const headlessWeb = ctx.webMode.headless && webPort !== undefined
+              return ctx.createAppTray({
+                iconPath: trayIconPath,
+                templateIconPath: process.platform === 'darwin' ? trayMacTemplate : undefined,
+                ...handlers,
+                ...(headlessWeb
+                  ? {
+                      headless: true,
+                      onOpenWeb: async () => {
+                        const { shell } = await import('electron')
+                        await shell.openExternal(await ctx.buildAuthenticatedWebUrl(webPort))
+                      },
+                      onCopyWebUrl: async () => {
+                        const { clipboard } = await import('electron')
+                        clipboard.writeText(await ctx.buildAuthenticatedWebUrl(webPort))
+                      }
+                    }
+                  : {})
+              })
+            },
+            isMigrationInProgress: ctx.isMigrationInProgress,
+            quit: () => app.quit(),
+            countWindows: () => BrowserWindow.getAllWindows().length,
+            createInitialWindow: !ctx.webMode.headless,
+            detectActiveSessions: ctx.detectActiveSessions,
+            createConfirmClose: ctx.createConfirmClose
+          },
+          {
+            // Application composition owns the one bounded ACP/Notebook shutdown. Remaining surfaces
+            // close afterward in their established order, even when an earlier disposer rejects.
             disposeApplicationRuntime: ctx.disposeApplicationRuntime,
-            shutdownRemoteAccess: () => ctx.remoteAccess.shutdown(),
-            closeWebController: () => ctx.webController.close(),
-            disposeWebRpc: () => ctx.webRpc.dispose()
-          }),
-        isMigrationInProgress: ctx.isMigrationInProgress,
-        quit: () => app.quit(),
-        countWindows: () => BrowserWindow.getAllWindows().length,
-        createInitialWindow: !ctx.webMode.headless,
-        detectActiveSessions: ctx.detectActiveSessions,
-        createConfirmClose: ctx.createConfirmClose
-      })
+            remoteAccess: ctx.remoteAccess,
+            webController: ctx.webController,
+            webRpc: ctx.webRpc
+          }
+        )
+      )
 
       // Window lifecycle now exists: expose it to the restored controller, reapply any Windows
       // overlay to the first window, then attach completion/focus/window-recreation events.

--- a/src/main/index.ts
+++ b/src/main/index.ts
@@ -209,7 +209,7 @@ async function startElectronApp(mainEntryPath: string): Promise<void> {
       const {
         taskNotifications,
         settingsService,
-        sessionPersistenceCoordinator,
+        sessionDeletionCapability,
         detectActiveSessions,
         dispose: disposeApplicationRuntime
       } = await registerIpcHandlers({
@@ -257,7 +257,7 @@ async function startElectronApp(mainEntryPath: string): Promise<void> {
         headless: webMode.headless,
         unreadController: unreadTaskController,
         unreadTaskRepository,
-        sessionPersistenceCoordinator
+        sessionPersistenceCoordinator: sessionDeletionCapability
       })
       visibilityProbeBox.current = registerUnreadTaskIpc({
         getMainWindow: () => mainWindowGetterBox.current?.(),
@@ -370,7 +370,8 @@ async function startElectronApp(mainEntryPath: string): Promise<void> {
             disposeApplicationRuntime: ctx.disposeApplicationRuntime,
             remoteAccess: ctx.remoteAccess,
             webController: ctx.webController,
-            webRpc: ctx.webRpc
+            webRpc: ctx.webRpc,
+            log: ctx.log
           }
         )
       )

--- a/src/main/index.ts
+++ b/src/main/index.ts
@@ -112,7 +112,6 @@ async function startElectronApp(mainEntryPath: string): Promise<void> {
         { webRpc },
         { parseWebModeOptions, createWebServiceController, buildAuthenticatedWebUrl },
         { routeSecondInstance },
-        { detectActiveSessions: computeActiveSessions },
         { createElectronCloseConfirm },
         { installWindowShortcuts },
         { createAppIconController, buildAppIconPreviews },
@@ -136,7 +135,6 @@ async function startElectronApp(mainEntryPath: string): Promise<void> {
         import('./ipc-handler-registry'),
         import('./web-service'),
         import('./second-instance-router'),
-        import('./storage/detect-active'),
         import('./window-close-confirm'),
         import('./window-shortcuts'),
         import('./app-icon'),
@@ -208,12 +206,12 @@ async function startElectronApp(mainEntryPath: string): Promise<void> {
       const webMode = parseWebModeOptions(process.argv)
       // Pass the concrete main entry path so ACP can launch the artifact MCP server from the same bundle.
       const {
-        runtime,
-        notebook,
         shutdownCoordinator,
         taskNotifications,
         settingsService,
-        sessionPersistenceCoordinator
+        sessionPersistenceCoordinator,
+        detectActiveSessions,
+        dispose: disposeApplicationRuntime
       } = await registerIpcHandlers({
         mainEntryPath,
         headless: webMode.headless,
@@ -305,8 +303,8 @@ async function startElectronApp(mainEntryPath: string): Promise<void> {
         unreadTaskController,
         mainWindowGetterBox,
         settingsService,
-        // Running-work snapshot + confirm coordinator, bound here where runtime/notebook are in scope.
-        detectActiveSessions: () => computeActiveSessions({ runtime, notebook }),
+        disposeApplicationRuntime,
+        detectActiveSessions,
         createConfirmClose: (getWindow: () => InstanceType<typeof BrowserWindow> | undefined) =>
           createElectronCloseConfirm(getWindow, {
             get: () => settingsService.getClosePreference(),
@@ -368,6 +366,7 @@ async function startElectronApp(mainEntryPath: string): Promise<void> {
             await ctx.remoteAccess.shutdown()
             await ctx.webController.close()
             ctx.webRpc.dispose()
+            await ctx.disposeApplicationRuntime()
           }
         },
         isMigrationInProgress: ctx.isMigrationInProgress,

--- a/src/main/index.ts
+++ b/src/main/index.ts
@@ -9,6 +9,7 @@ import {
   NOTEBOOK_MCP_SERVER_ARG,
   SKILL_IMPORT_MCP_SERVER_ARG
 } from './mcp-server-args'
+import { shutdownApplicationSurfaces } from './application-runtime'
 
 const APP_NAME = 'Open Science'
 const APP_USER_MODEL_ID = 'com.aipoch.open-science'
@@ -206,7 +207,6 @@ async function startElectronApp(mainEntryPath: string): Promise<void> {
       const webMode = parseWebModeOptions(process.argv)
       // Pass the concrete main entry path so ACP can launch the artifact MCP server from the same bundle.
       const {
-        shutdownCoordinator,
         taskNotifications,
         settingsService,
         sessionPersistenceCoordinator,
@@ -298,7 +298,6 @@ async function startElectronApp(mainEntryPath: string): Promise<void> {
         createAppTray,
         buildAuthenticatedWebUrl,
         routeSecondInstance,
-        shutdownCoordinator,
         taskNotifications,
         unreadTaskController,
         mainWindowGetterBox,
@@ -356,19 +355,15 @@ async function startElectronApp(mainEntryPath: string): Promise<void> {
               : {})
           })
         },
-        // Latching quit teardown via the shared coordinator (the same one the update gate uses). The
-        // coordinator awaits the agent + kernel process trees so a Windows taskkill /T completes before
-        // app.exit; runForQuit bounds it so a stuck backend can't hang quit.
-        shutdownBackends: async () => {
-          try {
-            await ctx.shutdownCoordinator.runForQuit()
-          } finally {
-            await ctx.remoteAccess.shutdown()
-            await ctx.webController.close()
-            ctx.webRpc.dispose()
-            await ctx.disposeApplicationRuntime()
-          }
-        },
+        // Application composition owns the one bounded ACP/Notebook shutdown. Remaining surfaces close
+        // afterward in their established order, even when an earlier disposer rejects.
+        shutdownBackends: () =>
+          shutdownApplicationSurfaces({
+            disposeApplicationRuntime: ctx.disposeApplicationRuntime,
+            shutdownRemoteAccess: () => ctx.remoteAccess.shutdown(),
+            closeWebController: () => ctx.webController.close(),
+            disposeWebRpc: () => ctx.webRpc.dispose()
+          }),
         isMigrationInProgress: ctx.isMigrationInProgress,
         quit: () => app.quit(),
         countWindows: () => BrowserWindow.getAllWindows().length,

--- a/src/main/ipc.ts
+++ b/src/main/ipc.ts
@@ -6,16 +6,12 @@ import { app, BrowserWindow, net, Notification, protocol, webContents } from 'el
 import { ipcMainHandle } from './ipc-handler-registry'
 import { composeApplicationRuntime, type ApplicationModuleBuilder } from './application-runtime'
 
-import {
-  createAcpRuntime,
-  createDefaultNotebookRuntimeService,
-  installAcpIpcHandlers
-} from './acp/ipc'
+import { createAcpRuntime, createDefaultNotebookRuntimeService } from './acp/ipc'
 import { createDefaultArtifactRepository, registerArtifactIpcHandlers } from './artifacts/ipc'
 import { ArtifactProvenanceRepository } from './artifacts/provenance-repository'
 import { ProvenanceMessageSnapshotRepository } from './artifacts/provenance-message-snapshot'
 import { ArtifactRunRegistry } from './artifacts/run-registry'
-import { createComputeIpcModule, installComputeIpcHandlers } from './compute/ipc'
+import { createComputeIpcModule } from './compute/ipc'
 import { attachEnabledComputeHosts } from './compute/enabled-hosts-registry'
 import { createComputeJobRuntime } from './compute/job-runtime'
 import { waitForInitialConnectorRefresh, wireConnectorReload } from './connector-reload'
@@ -125,6 +121,11 @@ import { createUpdateStrategy } from './update/create-strategy'
 import { startUpdateScheduler } from './update/scheduler'
 import { createDefaultUploadRepository, registerUploadIpcHandlers } from './uploads/ipc'
 import { broadcastToRenderers } from './renderer-broadcast'
+import {
+  installElectronRuntimeAdapters,
+  type ElectronRuntimeAdapterInterfaces,
+  type NamedElectronSurfaceAdapter
+} from './runtime-electron-wiring'
 import { ConversationSkillImporter, SkillImportApprovalBroker } from './skills/conversation-import'
 import type { ConversationSkillImportApprovalResponse } from '../shared/settings'
 
@@ -155,13 +156,8 @@ type ApplicationRuntimeInterfaces = {
   detectActiveSessions: () => ReturnType<typeof detectActiveSessions>
 }
 
-type NamedElectronAdapter = {
-  readonly name: string
-  install(): void | Promise<void>
-}
-
 type ApplicationModuleInterfaces = ApplicationRuntimeInterfaces & {
-  readonly electronAdapters: readonly NamedElectronAdapter[]
+  readonly electronAdapters: ElectronRuntimeAdapterInterfaces
 }
 
 type IpcRegistration = ApplicationRuntimeInterfaces & {
@@ -222,9 +218,15 @@ const createApplicationModules = async (
   }: IpcRegistrationOptions,
   modules: ApplicationModuleBuilder
 ): Promise<ApplicationModuleInterfaces> => {
-  const electronAdapters: NamedElectronAdapter[] = []
-  const declareElectronAdapter = (name: string, install: NamedElectronAdapter['install']): void => {
-    electronAdapters.push({ name, install })
+  const beforeComputeAdapters: NamedElectronSurfaceAdapter[] = []
+  const beforeAcpAdapters: NamedElectronSurfaceAdapter[] = []
+  const afterAcpAdapters: NamedElectronSurfaceAdapter[] = []
+  let surfaceAdapters = beforeComputeAdapters
+  const declareElectronAdapter = (
+    name: string,
+    install: NamedElectronSurfaceAdapter['install']
+  ): void => {
+    surfaceAdapters.push({ name, install })
   }
   // One settings service backs both the settings IPC and the ACP spawn config (single source of truth).
   const settingsService = await modules.add(undefined, () => ({
@@ -561,13 +563,13 @@ const createApplicationModules = async (
     taskNotifications,
     permissionGrantRegistry
   )
+  surfaceAdapters = beforeAcpAdapters
   const {
     computeService,
     jobRepository,
     hostRepository,
     enabledComputeHostsRegistry: hostsRegistry
   } = computeIpcModule
-  declareElectronAdapter('compute', () => installComputeIpcHandlers(computeIpcModule))
   const dataRoot = resolveDataRoot()
   // Start the JobPoller wired to the shared broadcaster so every state/tail change is pushed to all
   // renderer windows via 'compute:job-updated' (Phase 3d, design.md §9 + §15.3). The dispatcher
@@ -718,7 +720,7 @@ const createApplicationModules = async (
       }
     }
   )
-  declareElectronAdapter('acp', () => installAcpIpcHandlers(runtime, taskNotifications))
+  surfaceAdapters = afterAcpAdapters
   runtimeRef.current = runtime
   permissionGrantRegistry.subscribe(() => runtime.notifyPermissionGrantsChanged())
   // Single shared teardown owner for both the before-quit handler (index.ts) and the pre-update-install
@@ -1113,7 +1115,13 @@ const createApplicationModules = async (
     settingsService,
     sessionPersistenceCoordinator,
     detectActiveSessions: () => detectActiveSessions({ runtime, notebook: notebookService }),
-    electronAdapters
+    electronAdapters: {
+      beforeCompute: beforeComputeAdapters,
+      compute: computeIpcModule,
+      beforeAcp: beforeAcpAdapters,
+      acp: { runtime, taskNotifications },
+      afterAcp: afterAcpAdapters
+    }
   }
 }
 
@@ -1122,7 +1130,7 @@ const createApplicationModules = async (
 const installElectronAdapters = async (
   interfaces: Pick<ApplicationModuleInterfaces, 'electronAdapters'>
 ): Promise<void> => {
-  for (const adapter of interfaces.electronAdapters) await adapter.install()
+  await installElectronRuntimeAdapters(interfaces.electronAdapters)
 }
 
 const registerIpcHandlers = async (options: IpcRegistrationOptions): Promise<IpcRegistration> => {

--- a/src/main/ipc.ts
+++ b/src/main/ipc.ts
@@ -4,6 +4,7 @@ import { randomUUID } from 'node:crypto'
 import { app, BrowserWindow, net, Notification, protocol, webContents } from 'electron'
 
 import { ipcMainHandle } from './ipc-handler-registry'
+import { composeApplicationRuntime, type ApplicationModuleBuilder } from './application-runtime'
 
 import { createDefaultNotebookRuntimeService, registerAcpIpcHandlers } from './acp/ipc'
 import { createDefaultArtifactRepository, registerArtifactIpcHandlers } from './artifacts/ipc'
@@ -107,6 +108,7 @@ import type { StoredConnectors } from './settings/types'
 import type { AppIconPreview, AppIconVariant, RespondApprovalRequest } from '../shared/settings'
 import { registerStorageIpcHandlers } from './storage/ipc'
 import { normalizeLegacyDataPaths } from './storage/normalize-legacy-paths'
+import { detectActiveSessions } from './storage/detect-active'
 import {
   computeDefaultDataRoot,
   initDataRoot,
@@ -134,6 +136,27 @@ type IpcRegistrationOptions = {
   onAppIconVariantChanged?: (variant: AppIconVariant) => void
   // Renders the built-in icon variants to preview data URLs for the Appearance picker.
   listAppIconPreviews?: () => AppIconPreview[]
+}
+
+type ApplicationRuntimeInterfaces = {
+  shutdownCoordinator: BackendShutdownCoordinator
+  taskNotifications: Pick<
+    TaskNotificationService,
+    | 'setActivationHandler'
+    | 'setAttentionHandlers'
+    | 'setPendingOpenSession'
+    | 'setUnreadHandler'
+  >
+  settingsService: Pick<
+    SettingsService,
+    'getAppIconVariant' | 'getClosePreference' | 'setClosePreference'
+  >
+  sessionPersistenceCoordinator: SessionPersistenceCoordinator
+  detectActiveSessions: () => ReturnType<typeof detectActiveSessions>
+}
+
+type IpcRegistration = ApplicationRuntimeInterfaces & {
+  dispose: () => Promise<void>
 }
 
 // Builds a short, human-readable preview of a connector call's arguments for the approval card.
@@ -182,21 +205,19 @@ const refreshConnectorSkillDocs = async (
 // Registers every main-process IPC surface used by the renderer. Async because the notebook-env gate
 // needs the configured package mirror, read from disk; callers await this before creating the main
 // window so every IPC channel (incl. notebook-env) is registered before the renderer can call it.
-const registerIpcHandlers = async ({
-  mainEntryPath,
-  headless = false,
-  onAppIconVariantChanged,
-  listAppIconPreviews
-}: IpcRegistrationOptions): Promise<{
-  runtime: ReturnType<typeof registerAcpIpcHandlers>
-  notebook: ReturnType<typeof createDefaultNotebookRuntimeService>
-  shutdownCoordinator: BackendShutdownCoordinator
-  taskNotifications: TaskNotificationService
-  settingsService: SettingsService
-  sessionPersistenceCoordinator: SessionPersistenceCoordinator
-}> => {
+const installElectronAdapters = async (
+  {
+    mainEntryPath,
+    headless = false,
+    onAppIconVariantChanged,
+    listAppIconPreviews
+  }: IpcRegistrationOptions,
+  modules: ApplicationModuleBuilder
+): Promise<ApplicationRuntimeInterfaces> => {
   // One settings service backs both the settings IPC and the ACP spawn config (single source of truth).
-  const settingsService = createDefaultSettingsService()
+  const settingsService = await modules.add(undefined, () => ({
+    capability: createDefaultSettingsService()
+  }))
   const storedSettings = await settingsService.getStoredSettings()
   // Prime the data-root cache from settings before any data repository is constructed below. A change
   // to this value only takes effect after a restart, so reading it once here is sufficient.
@@ -369,11 +390,22 @@ const registerIpcHandlers = async ({
       return sessionPersistenceCoordinator.saveManifest(request)
     }
   }
-  const notebookService = createDefaultNotebookRuntimeService({
-    getPackageMirror: () => settingsService.getPackageMirror(),
-    getRuntimeEnablement: (language) => settingsService.getRuntimeEnablement(language),
-    getManualInterpreters: (language) => settingsService.getManualInterpreters(language)
-  })
+  const notebookService = await modules.add(
+    {
+      getPackageMirror: () => settingsService.getPackageMirror(),
+      getRuntimeEnablement: (language: NotebookLanguage) =>
+        settingsService.getRuntimeEnablement(language),
+      getManualInterpreters: (language: NotebookLanguage) =>
+        settingsService.getManualInterpreters(language)
+    },
+    (settings) => {
+      const notebook = createDefaultNotebookRuntimeService(settings)
+      return {
+        capability: notebook,
+        dispose: () => notebook.shutdownAll().then(() => undefined)
+      }
+    }
+  )
 
   // Read fresh on every call so a future connectors-settings mutation (Plan 2 UI) only needs to call
   // refreshConnectorSkillDocs again to take effect, without reconstructing the connector service.
@@ -424,7 +456,13 @@ const registerIpcHandlers = async ({
   // One MCP client manager backs both dispatch (ConnectorService.call → custom server) and skill-doc
   // generation (listTools) for user-added custom MCP servers (stdio + remote). It lazily connects per
   // server, so constructing it here does not spawn anything until a custom server is actually used.
-  const mcpClientManager = new McpClientManager()
+  const mcpClientManager = await modules.add(undefined, () => {
+    const manager = new McpClientManager()
+    return {
+      capability: manager,
+      dispose: () => manager.closeAll()
+    }
+  })
   // Bridges un-trusted connector calls to the renderer approval card. A tool call that isn't
   // pre-allowed or skip-approved is held here until the user decides (or it auto-denies on timeout).
   const approvalBroker = new ApprovalBroker({
@@ -516,13 +554,17 @@ const registerIpcHandlers = async ({
   // (inside ComputeService) uses the same hook, so submitted→running/error transitions broadcast too.
   // Phase 3b: harvestFn drives automatic harvest on terminal transitions; broadcast + storageRoot
   // wire the compute_done notification emitter for all three terminal outcomes (issue 06).
-  const jobPoller = createComputeJobRuntime({
-    computeService,
-    hostRepository,
-    jobRepository,
-    storageRoot: dataRoot
-  })
-  jobPoller.start()
+  await modules.add(
+    { computeService, hostRepository, jobRepository, storageRoot: dataRoot },
+    (dependencies) => {
+      const jobPoller = createComputeJobRuntime(dependencies)
+      return {
+        capability: undefined,
+        start: () => jobPoller.start(),
+        dispose: () => jobPoller.stop()
+      }
+    }
+  )
   // Augment computeService with getEnabledComputeHosts so the RPC server can serve list_compute.
   // Must preserve ComputeService's prototype methods (list/getDetails/submitJob/...) — see the helper.
   const computeServiceWithRegistry = attachEnabledComputeHosts(computeService, hostsRegistry)
@@ -613,33 +655,42 @@ const registerIpcHandlers = async ({
   registerWindowFindIpcHandlers()
   // ACP identity resolution and the Specialist settings IPC must use the same service instance.
   // Creating it only for settings leaves create-session unable to resolve a selected UUID.
-  const runtime = registerAcpIpcHandlers({
-    mcpEntryPath: mainEntryPath,
-    repository: artifactRepository,
-    runRegistry: artifactRunRegistry,
-    provenanceRepository: artifactProvenanceRepository,
-    uploadRepository,
-    notebookRpcServer,
-    authorizeSkillImportReferencedUploads: (projectId, sessionId, paths) =>
-      conversationSkillImporter.authorizeReferencedUploads(projectId, sessionId, paths),
-    settingsService,
-    permissionGrantRegistry,
-    taskNotifications,
-    onSessionTurnStarted: (sessionId, turnToken) =>
-      skillImportApprovalBroker.beginSessionTurn(sessionId, turnToken),
-    onSessionTurnEnded: (sessionId, turnToken) =>
-      skillImportApprovalBroker.endSessionTurn(sessionId, turnToken),
-    onSkillImportAttachmentEligible: (sessionId, turnToken, attachmentUri) =>
-      skillImportApprovalBroker.allowSessionTurnAttachment(sessionId, turnToken, attachmentUri),
-    onSessionCancellationRequested: (sessionId) =>
-      skillImportApprovalBroker.cancelSession(sessionId),
-    onSessionUnavailable: (sessionId) => skillImportApprovalBroker.cancelSession(sessionId),
-    onAllSessionsCancellationRequested: () => skillImportApprovalBroker.cancelAll(),
-    beforeSessionDelete: (sessionId) =>
-      notebookService.shutdownSession(sessionId).then(() => undefined),
-    initializationBarrier: initialConnectorSkillsReady,
-    profileService
-  })
+  const runtime = await modules.add(
+    {
+      mcpEntryPath: mainEntryPath,
+      repository: artifactRepository,
+      runRegistry: artifactRunRegistry,
+      provenanceRepository: artifactProvenanceRepository,
+      uploadRepository,
+      notebookRpcServer,
+      authorizeSkillImportReferencedUploads: (projectId, sessionId, paths) =>
+        conversationSkillImporter.authorizeReferencedUploads(projectId, sessionId, paths),
+      settingsService,
+      permissionGrantRegistry,
+      taskNotifications,
+      onSessionTurnStarted: (sessionId, turnToken) =>
+        skillImportApprovalBroker.beginSessionTurn(sessionId, turnToken),
+      onSessionTurnEnded: (sessionId, turnToken) =>
+        skillImportApprovalBroker.endSessionTurn(sessionId, turnToken),
+      onSkillImportAttachmentEligible: (sessionId, turnToken, attachmentUri) =>
+        skillImportApprovalBroker.allowSessionTurnAttachment(sessionId, turnToken, attachmentUri),
+      onSessionCancellationRequested: (sessionId) =>
+        skillImportApprovalBroker.cancelSession(sessionId),
+      onSessionUnavailable: (sessionId) => skillImportApprovalBroker.cancelSession(sessionId),
+      onAllSessionsCancellationRequested: () => skillImportApprovalBroker.cancelAll(),
+      beforeSessionDelete: (sessionId) =>
+        notebookService.shutdownSession(sessionId).then(() => undefined),
+      initializationBarrier: initialConnectorSkillsReady,
+      profileService
+    },
+    (options) => {
+      const runtime = registerAcpIpcHandlers(options)
+      return {
+        capability: runtime,
+        dispose: () => runtime.shutdownForQuit().then(() => undefined)
+      }
+    }
+  )
   runtimeRef.current = runtime
   permissionGrantRegistry.subscribe(() => runtime.notifyPermissionGrantsChanged())
   // Single shared teardown owner for both the before-quit handler (index.ts) and the pre-update-install
@@ -652,12 +703,24 @@ const registerIpcHandlers = async ({
   // Construct update handling only after its backend-shutdown gate exists. The in-place strategy owns
   // this immutable dependency from construction; the manifest fallback ignores it because it does not
   // quit the running app to install.
-  const updateService = registerUpdateIpcHandlers(
-    createUpdateStrategy(process.platform, {
-      installGate: () => shutdownCoordinator.runForUpdateGate(UPDATE_SHUTDOWN_BUDGET_MS)
-    })
+  await modules.add(
+    { shutdownCoordinator, platform: process.platform },
+    ({ shutdownCoordinator: coordinator, platform }) => {
+      const service = registerUpdateIpcHandlers(
+        createUpdateStrategy(platform, {
+          installGate: () => coordinator.runForUpdateGate(UPDATE_SHUTDOWN_BUDGET_MS)
+        })
+      )
+      let stopScheduler: (() => void) | undefined
+      return {
+        capability: service,
+        start: () => {
+          stopScheduler = startUpdateScheduler(service)
+        },
+        dispose: () => stopScheduler?.()
+      }
+    }
   )
-  startUpdateScheduler(updateService)
   // Spawn-config changes rotate the coordinator's runtime for future sessions. Existing sessions retain
   // their owning runtime, so a framework/provider switch cannot interrupt an in-flight turn.
   let invalidatePermissionProjection = (): void => {
@@ -980,12 +1043,21 @@ const registerIpcHandlers = async ({
   // Return the long-lived backend handles so the app lifecycle (before-quit) can shut them down
   // cleanly on quit — the agent process tree and every notebook kernel.
   return {
-    runtime,
-    notebook: notebookService,
     shutdownCoordinator,
     taskNotifications,
     settingsService,
-    sessionPersistenceCoordinator
+    sessionPersistenceCoordinator,
+    detectActiveSessions: () => detectActiveSessions({ runtime, notebook: notebookService })
+  }
+}
+
+const registerIpcHandlers = async (options: IpcRegistrationOptions): Promise<IpcRegistration> => {
+  const applicationRuntime = await composeApplicationRuntime((modules) =>
+    installElectronAdapters(options, modules)
+  )
+  return {
+    ...applicationRuntime.interfaces,
+    dispose: applicationRuntime.dispose
   }
 }
 

--- a/src/main/ipc.ts
+++ b/src/main/ipc.ts
@@ -4,7 +4,11 @@ import { randomUUID } from 'node:crypto'
 import { app, BrowserWindow, net, Notification, protocol, webContents } from 'electron'
 
 import { ipcMainHandle } from './ipc-handler-registry'
-import { composeApplicationRuntime, type ApplicationModuleBuilder } from './application-runtime'
+import {
+  APPLICATION_MODULE_DISPOSAL_BUDGET_MS,
+  composeApplicationRuntime,
+  type ApplicationModuleBuilder
+} from './application-runtime'
 
 import { createAcpRuntime, createDefaultNotebookRuntimeService } from './acp/ipc'
 import { createDefaultArtifactRepository, registerArtifactIpcHandlers } from './artifacts/ipc'
@@ -26,7 +30,11 @@ import { registerFileSaveHandlers } from './file-save'
 import { createSessionArtifactFileResolver } from './session-artifact-file-resolver'
 import { registerCliInstallIpcHandlers } from './cli-install/ipc'
 import { registerGithubIpcHandlers } from './github-ipc'
-import { BackendShutdownCoordinator, UPDATE_SHUTDOWN_BUDGET_MS } from './lifecycle-shutdown'
+import {
+  BackendShutdownCoordinator,
+  QUIT_SHUTDOWN_BUDGET_MS,
+  UPDATE_SHUTDOWN_BUDGET_MS
+} from './lifecycle-shutdown'
 import { registerLifecycleIpcHandlers } from './lifecycle-broadcast'
 import { registerLogsIpcHandlers } from './logs-ipc'
 import { registerWindowIpcHandlers } from './window-ipc'
@@ -143,7 +151,7 @@ type IpcRegistrationOptions = {
   listAppIconPreviews?: () => AppIconPreview[]
 }
 
-type ApplicationRuntimeInterfaces = {
+export type ApplicationRuntimeInterfaces = {
   taskNotifications: Pick<
     TaskNotificationService,
     'setActivationHandler' | 'setAttentionHandlers' | 'setPendingOpenSession' | 'setUnreadHandler'
@@ -152,7 +160,7 @@ type ApplicationRuntimeInterfaces = {
     SettingsService,
     'getAppIconVariant' | 'getClosePreference' | 'setClosePreference'
   >
-  sessionPersistenceCoordinator: SessionPersistenceCoordinator
+  sessionDeletionCapability: Pick<SessionPersistenceCoordinator, 'setSessionDeletionHandlers'>
   detectActiveSessions: () => ReturnType<typeof detectActiveSessions>
 }
 
@@ -416,7 +424,9 @@ const createApplicationModules = async (
     (settings) => {
       const notebook = createDefaultNotebookRuntimeService(settings)
       return {
+        name: 'notebook-runtime',
         capability: notebook,
+        disposeTimeoutMs: QUIT_SHUTDOWN_BUDGET_MS,
         rollback: () =>
           backendTeardownOwnedByCoordinator
             ? undefined
@@ -479,6 +489,7 @@ const createApplicationModules = async (
   const mcpClientManager = await modules.add(undefined, () => {
     const manager = new McpClientManager()
     return {
+      name: 'mcp-client-manager',
       capability: manager,
       dispose: () => manager.closeAll()
     }
@@ -581,6 +592,7 @@ const createApplicationModules = async (
     (dependencies) => {
       const jobPoller = createComputeJobRuntime(dependencies)
       return {
+        name: 'compute-job-runtime',
         capability: undefined,
         start: () => jobPoller.start(),
         dispose: () => jobPoller.stop()
@@ -712,7 +724,9 @@ const createApplicationModules = async (
     (options) => {
       const runtime = createAcpRuntime(options)
       return {
+        name: 'acp-runtime',
         capability: runtime,
+        disposeTimeoutMs: QUIT_SHUTDOWN_BUDGET_MS,
         rollback: () =>
           backendTeardownOwnedByCoordinator
             ? undefined
@@ -738,6 +752,7 @@ const createApplicationModules = async (
   })
   let stopUpdateScheduler: (() => void) | undefined
   await modules.add(undefined, () => ({
+    name: 'update-scheduler',
     capability: undefined,
     dispose: () => stopUpdateScheduler?.()
   }))
@@ -1105,7 +1120,9 @@ const createApplicationModules = async (
   // The shared coordinator is the sole normal owner of ACP + Notebook teardown. Register it last so
   // reverse disposal executes the existing bounded backend shutdown before supporting modules stop.
   await modules.add({ shutdownCoordinator }, ({ shutdownCoordinator: coordinator }) => ({
+    name: 'backend-shutdown-coordinator',
     capability: undefined,
+    disposeTimeoutMs: QUIT_SHUTDOWN_BUDGET_MS + APPLICATION_MODULE_DISPOSAL_BUDGET_MS,
     dispose: () => coordinator.runForQuit().then(() => undefined)
   }))
   backendTeardownOwnedByCoordinator = true
@@ -1113,7 +1130,7 @@ const createApplicationModules = async (
   return {
     taskNotifications,
     settingsService,
-    sessionPersistenceCoordinator,
+    sessionDeletionCapability: sessionPersistenceCoordinator,
     detectActiveSessions: () => detectActiveSessions({ runtime, notebook: notebookService }),
     electronAdapters: {
       beforeCompute: beforeComputeAdapters,

--- a/src/main/ipc.ts
+++ b/src/main/ipc.ts
@@ -6,12 +6,16 @@ import { app, BrowserWindow, net, Notification, protocol, webContents } from 'el
 import { ipcMainHandle } from './ipc-handler-registry'
 import { composeApplicationRuntime, type ApplicationModuleBuilder } from './application-runtime'
 
-import { createDefaultNotebookRuntimeService, registerAcpIpcHandlers } from './acp/ipc'
+import {
+  createAcpRuntime,
+  createDefaultNotebookRuntimeService,
+  installAcpIpcHandlers
+} from './acp/ipc'
 import { createDefaultArtifactRepository, registerArtifactIpcHandlers } from './artifacts/ipc'
 import { ArtifactProvenanceRepository } from './artifacts/provenance-repository'
 import { ProvenanceMessageSnapshotRepository } from './artifacts/provenance-message-snapshot'
 import { ArtifactRunRegistry } from './artifacts/run-registry'
-import { registerComputeIpcHandlers } from './compute/ipc'
+import { createComputeIpcModule, installComputeIpcHandlers } from './compute/ipc'
 import { attachEnabledComputeHosts } from './compute/enabled-hosts-registry'
 import { createComputeJobRuntime } from './compute/job-runtime'
 import { waitForInitialConnectorRefresh, wireConnectorReload } from './connector-reload'
@@ -139,13 +143,9 @@ type IpcRegistrationOptions = {
 }
 
 type ApplicationRuntimeInterfaces = {
-  shutdownCoordinator: BackendShutdownCoordinator
   taskNotifications: Pick<
     TaskNotificationService,
-    | 'setActivationHandler'
-    | 'setAttentionHandlers'
-    | 'setPendingOpenSession'
-    | 'setUnreadHandler'
+    'setActivationHandler' | 'setAttentionHandlers' | 'setPendingOpenSession' | 'setUnreadHandler'
   >
   settingsService: Pick<
     SettingsService,
@@ -153,6 +153,15 @@ type ApplicationRuntimeInterfaces = {
   >
   sessionPersistenceCoordinator: SessionPersistenceCoordinator
   detectActiveSessions: () => ReturnType<typeof detectActiveSessions>
+}
+
+type NamedElectronAdapter = {
+  readonly name: string
+  install(): void | Promise<void>
+}
+
+type ApplicationModuleInterfaces = ApplicationRuntimeInterfaces & {
+  readonly electronAdapters: readonly NamedElectronAdapter[]
 }
 
 type IpcRegistration = ApplicationRuntimeInterfaces & {
@@ -202,10 +211,9 @@ const refreshConnectorSkillDocs = async (
   }
 }
 
-// Registers every main-process IPC surface used by the renderer. Async because the notebook-env gate
-// needs the configured package mirror, read from disk; callers await this before creating the main
-// window so every IPC channel (incl. notebook-env) is registered before the renderer can call it.
-const installElectronAdapters = async (
+// Constructs application-owned modules and their narrow Electron adapter interfaces. The factory does
+// not register a channel or protocol; transport installation happens only after construction succeeds.
+const createApplicationModules = async (
   {
     mainEntryPath,
     headless = false,
@@ -213,7 +221,11 @@ const installElectronAdapters = async (
     listAppIconPreviews
   }: IpcRegistrationOptions,
   modules: ApplicationModuleBuilder
-): Promise<ApplicationRuntimeInterfaces> => {
+): Promise<ApplicationModuleInterfaces> => {
+  const electronAdapters: NamedElectronAdapter[] = []
+  const declareElectronAdapter = (name: string, install: NamedElectronAdapter['install']): void => {
+    electronAdapters.push({ name, install })
+  }
   // One settings service backs both the settings IPC and the ACP spawn config (single source of truth).
   const settingsService = await modules.add(undefined, () => ({
     capability: createDefaultSettingsService()
@@ -325,7 +337,7 @@ const installElectronAdapters = async (
   // Permission scope validation starts before the ACP coordinator is constructed. Keep the late-bound
   // reference here so a first-turn Session grant can recognize its live owner before the renderer's
   // asynchronous session persistence finishes.
-  const runtimeRef: { current: ReturnType<typeof registerAcpIpcHandlers> | undefined } = {
+  const runtimeRef: { current: ReturnType<typeof createAcpRuntime> | undefined } = {
     current: undefined
   }
 
@@ -390,6 +402,7 @@ const installElectronAdapters = async (
       return sessionPersistenceCoordinator.saveManifest(request)
     }
   }
+  let backendTeardownOwnedByCoordinator = false
   const notebookService = await modules.add(
     {
       getPackageMirror: () => settingsService.getPackageMirror(),
@@ -402,7 +415,10 @@ const installElectronAdapters = async (
       const notebook = createDefaultNotebookRuntimeService(settings)
       return {
         capability: notebook,
-        dispose: () => notebook.shutdownAll().then(() => undefined)
+        rollback: () =>
+          backendTeardownOwnedByCoordinator
+            ? undefined
+            : notebook.shutdownAll().then(() => undefined)
       }
     }
   )
@@ -445,14 +461,16 @@ const installElectronAdapters = async (
   // The renderer peeks once sessions are hydrated, then conditionally consumes the same target.
   // This lets partial recovery open an already-loaded conversation while retaining an omitted one
   // for retry, without an older IPC round trip clearing a newer click target.
-  ipcMainHandle('notifications:peek-pending-open-session', () =>
-    taskNotifications.peekPendingOpenSession()
-  )
-  ipcMainHandle('notifications:take-pending-open-session', (_event, expectedToken: unknown) =>
-    typeof expectedToken === 'number' && Number.isSafeInteger(expectedToken) && expectedToken > 0
-      ? taskNotifications.takePendingOpenSession(expectedToken)
-      : null
-  )
+  declareElectronAdapter('task-notifications', () => {
+    ipcMainHandle('notifications:peek-pending-open-session', () =>
+      taskNotifications.peekPendingOpenSession()
+    )
+    ipcMainHandle('notifications:take-pending-open-session', (_event, expectedToken: unknown) =>
+      typeof expectedToken === 'number' && Number.isSafeInteger(expectedToken) && expectedToken > 0
+        ? taskNotifications.takePendingOpenSession(expectedToken)
+        : null
+    )
+  })
   // One MCP client manager backs both dispatch (ConnectorService.call → custom server) and skill-doc
   // generation (listTools) for user-added custom MCP servers (stdio + remote). It lazily connects per
   // server, so constructing it here does not spawn anything until a custom server is actually used.
@@ -535,12 +553,7 @@ const installElectronAdapters = async (
   const computeArtifactResolver = {
     resolveArtifactPath: (path: string) => artifactRepository.resolveManagedFilePath({ path })
   }
-  const {
-    computeService,
-    jobRepository,
-    hostRepository,
-    enabledComputeHostsRegistry: hostsRegistry
-  } = registerComputeIpcHandlers(
+  const computeIpcModule = createComputeIpcModule(
     undefined,
     undefined,
     computeArtifactResolver,
@@ -548,6 +561,13 @@ const installElectronAdapters = async (
     taskNotifications,
     permissionGrantRegistry
   )
+  const {
+    computeService,
+    jobRepository,
+    hostRepository,
+    enabledComputeHostsRegistry: hostsRegistry
+  } = computeIpcModule
+  declareElectronAdapter('compute', () => installComputeIpcHandlers(computeIpcModule))
   const dataRoot = resolveDataRoot()
   // Start the JobPoller wired to the shared broadcaster so every state/tail change is pushed to all
   // renderer windows via 'compute:job-updated' (Phase 3d, design.md §9 + §15.3). The dispatcher
@@ -595,17 +615,19 @@ const installElectronAdapters = async (
     notebookRpcServer.issueControlConnection(sessionId, projectId)
   )
   // The renderer's approval card responds here; the broker resolves the held connector call.
-  ipcMainHandle('connectors:approval-respond', (_event, request: RespondApprovalRequest) => {
-    approvalBroker.respond(request.id, request.decision)
-  })
-  ipcMainHandle(
-    'skills:conversation-import-respond',
-    (_event, response: ConversationSkillImportApprovalResponse) => {
-      skillImportApprovalBroker.respond(response)
-    }
-  )
-  ipcMainHandle('skills:conversation-import-replay-pending', () => {
-    skillImportApprovalBroker.replayPending()
+  declareElectronAdapter('connector-approvals', () => {
+    ipcMainHandle('connectors:approval-respond', (_event, request: RespondApprovalRequest) => {
+      approvalBroker.respond(request.id, request.decision)
+    })
+    ipcMainHandle(
+      'skills:conversation-import-respond',
+      (_event, response: ConversationSkillImportApprovalResponse) => {
+        skillImportApprovalBroker.respond(response)
+      }
+    )
+    ipcMainHandle('skills:conversation-import-replay-pending', () => {
+      skillImportApprovalBroker.replayPending()
+    })
   })
 
   const initialConnectorSkillsReady = waitForInitialConnectorRefresh(
@@ -647,12 +669,14 @@ const installElectronAdapters = async (
       )
     )
 
-  registerFileSaveHandlers({ resolveManagedFilePath, resolveSessionArtifactFilePath })
-  registerLogsIpcHandlers()
-  registerGithubIpcHandlers()
-  registerCliInstallIpcHandlers()
-  registerWindowIpcHandlers()
-  registerWindowFindIpcHandlers()
+  declareElectronAdapter('desktop-utilities', () => {
+    registerFileSaveHandlers({ resolveManagedFilePath, resolveSessionArtifactFilePath })
+    registerLogsIpcHandlers()
+    registerGithubIpcHandlers()
+    registerCliInstallIpcHandlers()
+    registerWindowIpcHandlers()
+    registerWindowFindIpcHandlers()
+  })
   // ACP identity resolution and the Specialist settings IPC must use the same service instance.
   // Creating it only for settings leaves create-session unable to resolve a selected UUID.
   const runtime = await modules.add(
@@ -684,13 +708,17 @@ const installElectronAdapters = async (
       profileService
     },
     (options) => {
-      const runtime = registerAcpIpcHandlers(options)
+      const runtime = createAcpRuntime(options)
       return {
         capability: runtime,
-        dispose: () => runtime.shutdownForQuit().then(() => undefined)
+        rollback: () =>
+          backendTeardownOwnedByCoordinator
+            ? undefined
+            : runtime.shutdownForQuit().then(() => undefined)
       }
     }
   )
+  declareElectronAdapter('acp', () => installAcpIpcHandlers(runtime, taskNotifications))
   runtimeRef.current = runtime
   permissionGrantRegistry.subscribe(() => runtime.notifyPermissionGrantsChanged())
   // Single shared teardown owner for both the before-quit handler (index.ts) and the pre-update-install
@@ -703,72 +731,68 @@ const installElectronAdapters = async (
   // Construct update handling only after its backend-shutdown gate exists. The in-place strategy owns
   // this immutable dependency from construction; the manifest fallback ignores it because it does not
   // quit the running app to install.
-  await modules.add(
-    { shutdownCoordinator, platform: process.platform },
-    ({ shutdownCoordinator: coordinator, platform }) => {
-      const service = registerUpdateIpcHandlers(
-        createUpdateStrategy(platform, {
-          installGate: () => coordinator.runForUpdateGate(UPDATE_SHUTDOWN_BUDGET_MS)
-        })
-      )
-      let stopScheduler: (() => void) | undefined
-      return {
-        capability: service,
-        start: () => {
-          stopScheduler = startUpdateScheduler(service)
-        },
-        dispose: () => stopScheduler?.()
-      }
-    }
-  )
+  const updateStrategy = createUpdateStrategy(process.platform, {
+    installGate: () => shutdownCoordinator.runForUpdateGate(UPDATE_SHUTDOWN_BUDGET_MS)
+  })
+  let stopUpdateScheduler: (() => void) | undefined
+  await modules.add(undefined, () => ({
+    capability: undefined,
+    dispose: () => stopUpdateScheduler?.()
+  }))
+  declareElectronAdapter('update', () => {
+    const updateService = registerUpdateIpcHandlers(updateStrategy)
+    stopUpdateScheduler = startUpdateScheduler(updateService)
+  })
   // Spawn-config changes rotate the coordinator's runtime for future sessions. Existing sessions retain
   // their owning runtime, so a framework/provider switch cannot interrupt an in-flight turn.
   let invalidatePermissionProjection = (): void => {
     broadcastToRenderers('permissions:changed', { revision: Date.now() })
   }
-  registerSettingsIpcHandlers({
-    service: settingsService,
-    onActiveProviderChanged: () => void runtime.requestProviderReconnect(),
-    onAgentFrameworkChanged: () => void runtime.requestAgentFrameworkSwitch(),
-    onReasoningEffortChanged: (effort) => runtime.applyReasoningEffortChange(effort),
-    onSkillsChanged: () => void runtime.requestSkillsReload(),
-    // Re-sync bundled + custom skill docs and refresh the in-memory snapshot the connector
-    // service reads, then request a skills reload. The reload respawns the agent on next idle so a
-    // non-Claude framework (Codex, opencode) — whose connector docs are materialized into its own
-    // home at spawn — picks up the change too, not just the Claude config dir.
-    onConnectorsChanged: () => {
-      // Connector policy shadows or reactivates grants without mutating them. Republish the shared
-      // projection immediately so both Settings surfaces describe the same effective decision.
-      invalidatePermissionProjection()
-      void wireConnectorReload(
-        () =>
-          refreshConnectorSkillDocs(
-            settingsService,
-            resolveStorageRoot(),
-            mcpClientManager,
-            (connectors) => {
-              connectorsSnapshot = connectors
-            }
-          ),
-        () => void runtime.requestSkillsReload()
-      )
-    },
-    onCustomServerRemoved: (serverId) =>
-      permissionGrantRegistry.prune({ kind: 'mcp_server', serverId }).then(() => undefined),
-    onCustomServerSecurityChanged: async (serverId) => {
-      const guard = connectorService.beginCustomServerSecurityChange(serverId)
-      try {
-        await permissionGrantRegistry.prune({ kind: 'mcp_server', serverId })
-        return guard
-      } catch (error) {
-        guard.rollback()
-        throw error
-      }
-    },
-    onAppIconVariantChanged,
-    listAppIconPreviews
-  })
-  registerNotebookIpcHandlers(notebookService)
+  declareElectronAdapter('settings', () =>
+    registerSettingsIpcHandlers({
+      service: settingsService,
+      onActiveProviderChanged: () => void runtime.requestProviderReconnect(),
+      onAgentFrameworkChanged: () => void runtime.requestAgentFrameworkSwitch(),
+      onReasoningEffortChanged: (effort) => runtime.applyReasoningEffortChange(effort),
+      onSkillsChanged: () => void runtime.requestSkillsReload(),
+      // Re-sync bundled + custom skill docs and refresh the in-memory snapshot the connector
+      // service reads, then request a skills reload. The reload respawns the agent on next idle so a
+      // non-Claude framework (Codex, opencode) — whose connector docs are materialized into its own
+      // home at spawn — picks up the change too, not just the Claude config dir.
+      onConnectorsChanged: () => {
+        // Connector policy shadows or reactivates grants without mutating them. Republish the shared
+        // projection immediately so both Settings surfaces describe the same effective decision.
+        invalidatePermissionProjection()
+        void wireConnectorReload(
+          () =>
+            refreshConnectorSkillDocs(
+              settingsService,
+              resolveStorageRoot(),
+              mcpClientManager,
+              (connectors) => {
+                connectorsSnapshot = connectors
+              }
+            ),
+          () => void runtime.requestSkillsReload()
+        )
+      },
+      onCustomServerRemoved: (serverId) =>
+        permissionGrantRegistry.prune({ kind: 'mcp_server', serverId }).then(() => undefined),
+      onCustomServerSecurityChanged: async (serverId) => {
+        const guard = connectorService.beginCustomServerSecurityChange(serverId)
+        try {
+          await permissionGrantRegistry.prune({ kind: 'mcp_server', serverId })
+          return guard
+        } catch (error) {
+          guard.rollback()
+          throw error
+        }
+      },
+      onAppIconVariantChanged,
+      listAppIconPreviews
+    })
+  )
+  declareElectronAdapter('notebook', () => registerNotebookIpcHandlers(notebookService))
   // Wire session deletion to the binding store so stale in-memory bindings do not accumulate.
   // The renderer calls sessions:delete-session (via sessionPersistenceBackend) and acp:delete-session
   // separately; both paths should clear the binding. Override the backend deleteSession callback here
@@ -781,74 +805,82 @@ const installElectronAdapters = async (
     sessionBindingService.clearSession(sessionId)
   }
   const specialistPersistLog = createLogger('specialist:persist')
-  registerSpecialistIpcHandlers(
-    profileService,
-    sessionBindingService,
-    // Persist only the specialist UUID to the durable session file — never a profile snapshot.
-    // Read the current session file, patch specialistId, and save so the binding survives restarts.
-    // Reading all sessions to locate the target is intentional: sessionId alone is not sufficient to
-    // open the file (it lives under sessions/<projectId>/<sessionId>.json), and this operation is
-    // infrequent enough that the scan cost is acceptable.
-    async (sessionId, specialistId) => {
-      const allSessions = await sessionRepository.loadAll()
-      const session = allSessions.sessions.find((s) => s.id === sessionId)
-      if (!session) {
-        // The session has not yet been persisted (created but not saved). The specialistId will be
-        // written when the renderer calls sessions:save-session for the first time.
-        specialistPersistLog.debug(
-          'session not yet durable; specialistId will be written on first save',
-          {
-            sessionId,
-            specialistId
-          }
-        )
-        return
-      }
-      await sessionPersistenceCoordinator.saveSessionSpecialistBinding(session, specialistId)
-    },
-    // Apply the switch to the live agent runtime. `runtime` is assigned above (registerAcpIpcHandlers),
-    // but the closure is invoked per-request so a late-bound reference is unnecessary.
-    (sessionId, specialistId) => runtime.switchSpecialist(sessionId, specialistId),
-    // A specialist capability edit (skills/connectors/enabled) must reach live sessions on the next
-    // turn: reconnect so the agent respawns (re-provisioning skills) and resumes with the updated
-    // specialist whitelist in the session _meta.
-    () => void runtime.requestSkillsReload()
+  declareElectronAdapter('specialist', () =>
+    registerSpecialistIpcHandlers(
+      profileService,
+      sessionBindingService,
+      // Persist only the specialist UUID to the durable session file — never a profile snapshot.
+      // Read the current session file, patch specialistId, and save so the binding survives restarts.
+      // Reading all sessions to locate the target is intentional: sessionId alone is not sufficient to
+      // open the file (it lives under sessions/<projectId>/<sessionId>.json), and this operation is
+      // infrequent enough that the scan cost is acceptable.
+      async (sessionId, specialistId) => {
+        const allSessions = await sessionRepository.loadAll()
+        const session = allSessions.sessions.find((s) => s.id === sessionId)
+        if (!session) {
+          // The session has not yet been persisted (created but not saved). The specialistId will be
+          // written when the renderer calls sessions:save-session for the first time.
+          specialistPersistLog.debug(
+            'session not yet durable; specialistId will be written on first save',
+            {
+              sessionId,
+              specialistId
+            }
+          )
+          return
+        }
+        await sessionPersistenceCoordinator.saveSessionSpecialistBinding(session, specialistId)
+      },
+      // Apply the switch to the live agent runtime. `runtime` is assigned above (registerAcpIpcHandlers),
+      // but the closure is invoked per-request so a late-bound reference is unnecessary.
+      (sessionId, specialistId) => runtime.switchSpecialist(sessionId, specialistId),
+      // A specialist capability edit (skills/connectors/enabled) must reach live sessions on the next
+      // turn: reconnect so the agent respawns (re-provisioning skills) and resumes with the updated
+      // specialist whitelist in the session _meta.
+      () => void runtime.requestSkillsReload()
+    )
   )
   // Runtime selection UI (Settings/Onboarding): survey managed+external per language, persist the
   // choice, and pick an interpreter file. The runtime root MUST match the executor/service's
   // (getRuntimeRoot(<dataRoot>)); read lazily so a data-root switch is reflected without re-register.
-  registerRuntimeIpcHandlers({
-    settingsService,
-    runtimeRoot: () => getRuntimeRoot(resolveDataRoot()),
-    // WS10: revoke a disabled runtime from any live session bound to it (mark binding unavailable).
-    onRuntimeDisabled: (language, envId, force) =>
-      notebookService.revokeRuntime(language, envId, { force }),
-    // WS11: live-session usage of a runtime, for the disable-impact warning.
-    describeRuntimeUsage: (language, envId) =>
-      notebookService.describeRuntimeUsage(language, envId),
-    prepareExternalPython: async (selection, root) => {
-      const configuredMirror = await settingsService.getPackageMirror()
-      const mirror = await effectiveMirrorAsync(configuredMirror, app.getLocale())
-      await prepareExternalPythonRuntime(selection, root, {
-        pypiIndex: mirror.pypiIndex,
-        caBundle: mirror.caBundle
-      })
-    }
-  })
-  registerManagedPreviewIpcHandlers(previewResources)
-  registerManagedPreviewProtocol(previewResources)
-  registerOfficePreviewRuntimeProtocol(
-    {
-      runtimeHtmlPath: join(__dirname, '../renderer/office-preview.html'),
-      devServerUrl: process.env['ELECTRON_RENDERER_URL'],
-      fetchRuntime: (targetUrl, request) =>
-        net.fetch(targetUrl, {
-          // Runtime assets are public application files. Forwarding custom-protocol headers or its
-          // abort signal makes Chromium treat the local fetch as a cross-site renderer request.
-          method: request.method
+  declareElectronAdapter('notebook-runtime', () =>
+    registerRuntimeIpcHandlers({
+      settingsService,
+      runtimeRoot: () => getRuntimeRoot(resolveDataRoot()),
+      // WS10: revoke a disabled runtime from any live session bound to it (mark binding unavailable).
+      onRuntimeDisabled: (language, envId, force) =>
+        notebookService.revokeRuntime(language, envId, { force }),
+      // WS11: live-session usage of a runtime, for the disable-impact warning.
+      describeRuntimeUsage: (language, envId) =>
+        notebookService.describeRuntimeUsage(language, envId),
+      prepareExternalPython: async (selection, root) => {
+        const configuredMirror = await settingsService.getPackageMirror()
+        const mirror = await effectiveMirrorAsync(configuredMirror, app.getLocale())
+        await prepareExternalPythonRuntime(selection, root, {
+          pypiIndex: mirror.pypiIndex,
+          caBundle: mirror.caBundle
         })
-    },
-    protocol
+      }
+    })
+  )
+  declareElectronAdapter('managed-preview', () => {
+    registerManagedPreviewIpcHandlers(previewResources)
+    registerManagedPreviewProtocol(previewResources)
+  })
+  declareElectronAdapter('office-preview-runtime', () =>
+    registerOfficePreviewRuntimeProtocol(
+      {
+        runtimeHtmlPath: join(__dirname, '../renderer/office-preview.html'),
+        devServerUrl: process.env['ELECTRON_RENDERER_URL'],
+        fetchRuntime: (targetUrl, request) =>
+          net.fetch(targetUrl, {
+            // Runtime assets are public application files. Forwarding custom-protocol headers or its
+            // abort signal makes Chromium treat the local fetch as a cross-site renderer request.
+            method: request.method
+          })
+      },
+      protocol
+    )
   )
   const officePreviewSupervisor = new OfficePreviewSupervisor({
     inspectResource: ({ source, path }) => previewResources.inspect({ source, path }),
@@ -866,7 +898,9 @@ const installElectronAdapters = async (
     publishState: (ownerId, state) =>
       webContents.fromId(ownerId)?.send(OFFICE_PREVIEW_STATE_CHANNEL, state)
   })
-  registerOfficePreviewIpcHandlers(officePreviewSupervisor)
+  declareElectronAdapter('office-preview', () =>
+    registerOfficePreviewIpcHandlers(officePreviewSupervisor)
+  )
 
   // Resolve the shared conda base under the app data root (relocatable, where the runtime install
   // lives) and start the env readiness gate. The conda channel comes from the effective package mirror
@@ -944,12 +978,14 @@ const installElectronAdapters = async (
 
   // Always register the handlers (serialized is undefined when the provisioner could not be built). The
   // recovery barrier is threaded in so the startup gate and UI provision/repair await recovery first.
-  registerNotebookEnvIpcHandlers(
-    serialized,
-    provisioningRoot,
-    waitForRecovery,
-    assertProvisionAllowed,
-    (language) => notebookService.completeRuntimeRepair(language)
+  declareElectronAdapter('notebook-environment', () =>
+    registerNotebookEnvIpcHandlers(
+      serialized,
+      provisioningRoot,
+      waitForRecovery,
+      assertProvisionAllowed,
+      (language) => notebookService.completeRuntimeRepair(language)
+    )
   )
   if (provisioner && serialized) {
     // Back the notebook service's manage_environments tool with the same provisioner that owns the env
@@ -963,98 +999,138 @@ const installElectronAdapters = async (
   }
 
   // Registered after the acp/notebook handlers exist: migration needs to interrupt both runtimes.
-  registerStorageIpcHandlers({
-    runtime,
-    notebook: notebookService,
-    getActivePromptSessions: () => runtime.getActivePromptSessions(),
-    settingsService
-  })
-  registerArtifactIpcHandlers(
-    artifactRepository,
-    artifactRunRegistry,
-    () => (runtimeRef.current ? runtimeRef.current.getActiveArtifactRunIds() : []),
-    artifactProvenanceRepository,
-    (projectId, sessionId, mutation) =>
-      sessionPersistenceCoordinator.runSessionMutation(projectId, sessionId, mutation)
-  )
-  registerUploadIpcHandlers(uploadRepository, {
-    withSessionMutation: (projectId, sessionId, mutation) =>
-      sessionPersistenceCoordinator.runSessionMutation(projectId, sessionId, mutation)
-  })
-  ipcMainHandle('notebook:read-input-preview', (_event, request) =>
-    notebookInputRegistry.readPreview(request)
-  )
-  registerSessionPersistenceIpcHandlers(sessionPersistenceBackend, reviewRepository)
-  registerConversationExportIpcHandler(
-    createConversationExportService({
-      loadSession: (projectId, sessionId) => sessionRepository.loadSession(projectId, sessionId),
-      isSessionActive: (projectId, sessionId) =>
-        runtime
-          .getActivePromptSessions()
-          .some(
-            (activeSession) =>
-              activeSession.projectName === projectId && activeSession.sessionId === sessionId
-          )
+  declareElectronAdapter('storage', () =>
+    registerStorageIpcHandlers({
+      runtime,
+      notebook: notebookService,
+      getActivePromptSessions: () => runtime.getActivePromptSessions(),
+      settingsService
     })
   )
-  const permissionGrantIpc = registerPermissionGrantIpcHandlers({
-    registry: permissionGrantRegistry,
-    projects: {
-      list: async () => {
-        await projectDeletionCoordinator.recoverPendingDeletions()
-        return projectRepository.list()
-      }
-    },
-    sessions: {
-      metadataSnapshot: () =>
-        loadSessionMetadataAfterProjectRecovery(
-          projectDeletionCoordinator,
-          sessionPersistenceCoordinator
-        )
-    },
-    connectors: {
-      get: async () => ({
-        ...(await settingsService.getConnectors()),
-        bundledConnectorIds: ALL_CONNECTOR_IDS
-      })
-    }
-  })
-  invalidatePermissionProjection = permissionGrantIpc.invalidateProjection
-  registerProjectFilesIpcHandlers(
-    projectFilesRepository,
-    sessionPersistenceCoordinator,
-    projectDeletionCoordinator
+  declareElectronAdapter('artifacts', () =>
+    registerArtifactIpcHandlers(
+      artifactRepository,
+      artifactRunRegistry,
+      () => (runtimeRef.current ? runtimeRef.current.getActiveArtifactRunIds() : []),
+      artifactProvenanceRepository,
+      (projectId, sessionId, mutation) =>
+        sessionPersistenceCoordinator.runSessionMutation(projectId, sessionId, mutation)
+    )
   )
-  registerProjectIpcHandlers(projectRepository, previewStateRepository, projectDeletionCoordinator)
-  registerLifecycleIpcHandlers()
+  declareElectronAdapter('uploads', () =>
+    registerUploadIpcHandlers(uploadRepository, {
+      withSessionMutation: (projectId, sessionId, mutation) =>
+        sessionPersistenceCoordinator.runSessionMutation(projectId, sessionId, mutation)
+    })
+  )
+  declareElectronAdapter('notebook-input-preview', () => {
+    ipcMainHandle('notebook:read-input-preview', (_event, request) =>
+      notebookInputRegistry.readPreview(request)
+    )
+  })
+  declareElectronAdapter('session-persistence', () =>
+    registerSessionPersistenceIpcHandlers(sessionPersistenceBackend, reviewRepository)
+  )
+  declareElectronAdapter('conversation-export', () =>
+    registerConversationExportIpcHandler(
+      createConversationExportService({
+        loadSession: (projectId, sessionId) => sessionRepository.loadSession(projectId, sessionId),
+        isSessionActive: (projectId, sessionId) =>
+          runtime
+            .getActivePromptSessions()
+            .some(
+              (activeSession) =>
+                activeSession.projectName === projectId && activeSession.sessionId === sessionId
+            )
+      })
+    )
+  )
+  declareElectronAdapter('permission-grants', () => {
+    const permissionGrantIpc = registerPermissionGrantIpcHandlers({
+      registry: permissionGrantRegistry,
+      projects: {
+        list: async () => {
+          await projectDeletionCoordinator.recoverPendingDeletions()
+          return projectRepository.list()
+        }
+      },
+      sessions: {
+        metadataSnapshot: () =>
+          loadSessionMetadataAfterProjectRecovery(
+            projectDeletionCoordinator,
+            sessionPersistenceCoordinator
+          )
+      },
+      connectors: {
+        get: async () => ({
+          ...(await settingsService.getConnectors()),
+          bundledConnectorIds: ALL_CONNECTOR_IDS
+        })
+      }
+    })
+    invalidatePermissionProjection = permissionGrantIpc.invalidateProjection
+  })
+  declareElectronAdapter('project-files', () =>
+    registerProjectFilesIpcHandlers(
+      projectFilesRepository,
+      sessionPersistenceCoordinator,
+      projectDeletionCoordinator
+    )
+  )
+  declareElectronAdapter('projects', () =>
+    registerProjectIpcHandlers(
+      projectRepository,
+      previewStateRepository,
+      projectDeletionCoordinator
+    )
+  )
+  declareElectronAdapter('lifecycle', () => registerLifecycleIpcHandlers())
   // Compute IPC handlers are registered earlier (before the notebook RPC server) so computeService
   // can be injected into the RPC server for the computeCall route. See above.
   // Wire the reviewer backend into the app lifecycle: installs ipcMainHandle('reviewer:run', ...)
   // and 'reviewer:get-for-session' so the renderer's fire-and-forget reviewer calls resolve to
   // real handlers instead of no-ops. Passing the already-constructed AcpRuntime so the reviewer
   // can spawn sessions under the same agent connection.
-  registerReviewerIpcHandlers({
-    acpRuntime: runtime,
-    artifactProvenanceRepository,
-    withSessionMutation: (projectId, sessionId, mutation) =>
-      sessionPersistenceCoordinator.runSessionMutation(projectId, sessionId, mutation)
+  declareElectronAdapter('reviewer', () => {
+    registerReviewerIpcHandlers({
+      acpRuntime: runtime,
+      artifactProvenanceRepository,
+      withSessionMutation: (projectId, sessionId, mutation) =>
+        sessionPersistenceCoordinator.runSessionMutation(projectId, sessionId, mutation)
+    })
   })
 
-  // Return the long-lived backend handles so the app lifecycle (before-quit) can shut them down
-  // cleanly on quit — the agent process tree and every notebook kernel.
+  // The shared coordinator is the sole normal owner of ACP + Notebook teardown. Register it last so
+  // reverse disposal executes the existing bounded backend shutdown before supporting modules stop.
+  await modules.add({ shutdownCoordinator }, ({ shutdownCoordinator: coordinator }) => ({
+    capability: undefined,
+    dispose: () => coordinator.runForQuit().then(() => undefined)
+  }))
+  backendTeardownOwnedByCoordinator = true
+
   return {
-    shutdownCoordinator,
     taskNotifications,
     settingsService,
     sessionPersistenceCoordinator,
-    detectActiveSessions: () => detectActiveSessions({ runtime, notebook: notebookService })
+    detectActiveSessions: () => detectActiveSessions({ runtime, notebook: notebookService }),
+    electronAdapters
   }
 }
 
+// Installs transports only after every named application module has been constructed successfully.
+// Future application-only modules (including an orchestrator) do not need an Electron adapter entry.
+const installElectronAdapters = async (
+  interfaces: Pick<ApplicationModuleInterfaces, 'electronAdapters'>
+): Promise<void> => {
+  for (const adapter of interfaces.electronAdapters) await adapter.install()
+}
+
 const registerIpcHandlers = async (options: IpcRegistrationOptions): Promise<IpcRegistration> => {
-  const applicationRuntime = await composeApplicationRuntime((modules) =>
-    installElectronAdapters(options, modules)
-  )
+  const applicationRuntime = await composeApplicationRuntime(async (modules) => {
+    const { electronAdapters, ...interfaces } = await createApplicationModules(options, modules)
+    await installElectronAdapters({ electronAdapters })
+    return interfaces
+  })
   return {
     ...applicationRuntime.interfaces,
     dispose: applicationRuntime.dispose

--- a/src/main/ipc.ts
+++ b/src/main/ipc.ts
@@ -6,7 +6,7 @@ import { app, BrowserWindow, net, Notification, protocol, webContents } from 'el
 import { ipcMainHandle } from './ipc-handler-registry'
 import {
   APPLICATION_MODULE_DISPOSAL_BUDGET_MS,
-  composeApplicationRuntime,
+  composeApplicationRuntimeWithAdapters,
   type ApplicationModuleBuilder
 } from './application-runtime'
 
@@ -1142,20 +1142,11 @@ const createApplicationModules = async (
   }
 }
 
-// Installs transports only after every named application module has been constructed successfully.
-// Future application-only modules (including an orchestrator) do not need an Electron adapter entry.
-const installElectronAdapters = async (
-  interfaces: Pick<ApplicationModuleInterfaces, 'electronAdapters'>
-): Promise<void> => {
-  await installElectronRuntimeAdapters(interfaces.electronAdapters)
-}
-
 const registerIpcHandlers = async (options: IpcRegistrationOptions): Promise<IpcRegistration> => {
-  const applicationRuntime = await composeApplicationRuntime(async (modules) => {
-    const { electronAdapters, ...interfaces } = await createApplicationModules(options, modules)
-    await installElectronAdapters({ electronAdapters })
-    return interfaces
-  })
+  const applicationRuntime = await composeApplicationRuntimeWithAdapters(
+    (modules) => createApplicationModules(options, modules),
+    installElectronRuntimeAdapters
+  )
   return {
     ...applicationRuntime.interfaces,
     dispose: applicationRuntime.dispose

--- a/src/main/logger.test.ts
+++ b/src/main/logger.test.ts
@@ -1,4 +1,4 @@
-import { mkdtemp, readdir, rm } from 'node:fs/promises'
+import { mkdtemp, readFile, readdir, rm } from 'node:fs/promises'
 import { tmpdir } from 'node:os'
 import { join } from 'node:path'
 
@@ -12,6 +12,10 @@ import {
   formatLine,
   initLogger
 } from './logger'
+import {
+  ApplicationModuleDisposalTimeoutError,
+  shutdownApplicationSurfaces
+} from './application-runtime'
 
 let logDir: string | undefined
 
@@ -930,6 +934,40 @@ describe('logger: errorLogFields', () => {
     expect(fixed.data.error).toBe('x')
     expect(typeof fixed.data.stack).toBe('string')
     expect(fixed.data.framework).toBe('claude-code')
+  })
+})
+
+describe('logger: application shutdown diagnostics', () => {
+  it('persists every aggregate cause with the timed-out module name and budget', async () => {
+    logDir = await mkdtemp(join(tmpdir(), 'os-logger-shutdown-'))
+    initLogger({ logDir, fileName: 'main.log', mirrorToConsole: false })
+    const log = createLogger('shutdown')
+
+    await shutdownApplicationSurfaces({
+      disposeApplicationRuntime: () =>
+        Promise.reject(
+          new AggregateError([
+            new ApplicationModuleDisposalTimeoutError('mcp-client-manager', 1000),
+            new Error('compute poller stop failed')
+          ])
+        ),
+      shutdownRemoteAccess: () => undefined,
+      closeWebController: () => undefined,
+      disposeWebRpc: () => undefined,
+      log
+    })
+    await flushLogs()
+
+    const records = (await readFile(join(logDir, 'main.log'), 'utf8'))
+      .trim()
+      .split('\n')
+      .map((line) => JSON.parse(line) as { msg: string })
+
+    expect(records.map((record) => record.msg)).toEqual([
+      expect.stringContaining('mcp-client-manager'),
+      expect.stringContaining('compute poller stop failed')
+    ])
+    expect(records[0].msg).toContain('1000ms')
   })
 })
 

--- a/src/main/runtime-electron-wiring.test.ts
+++ b/src/main/runtime-electron-wiring.test.ts
@@ -1,0 +1,60 @@
+import { describe, expect, it, vi } from 'vitest'
+
+const { installAcpIpcHandlers, installComputeIpcHandlers, order } = vi.hoisted(() => {
+  const order: string[] = []
+  return {
+    order,
+    installAcpIpcHandlers: vi.fn(() => {
+      order.push('acp')
+    }),
+    installComputeIpcHandlers: vi.fn(() => {
+      order.push('compute')
+    })
+  }
+})
+
+vi.mock('./acp/ipc', () => ({ installAcpIpcHandlers }))
+vi.mock('./compute/ipc', () => ({ installComputeIpcHandlers }))
+
+import { installElectronRuntimeAdapters } from './runtime-electron-wiring'
+
+describe('production Electron runtime wiring', () => {
+  it('installs the constructed Compute and ACP modules before remaining surfaces', async () => {
+    const compute = { handlers: {}, enabledComputeHostsRegistry: {} } as never
+    const runtime = {} as never
+    const taskNotifications = {} as never
+
+    await installElectronRuntimeAdapters({
+      compute,
+      beforeCompute: [
+        {
+          name: 'notifications',
+          install: () => {
+            order.push('notifications')
+          }
+        }
+      ],
+      beforeAcp: [
+        {
+          name: 'connectors',
+          install: () => {
+            order.push('connectors')
+          }
+        }
+      ],
+      acp: { runtime, taskNotifications },
+      afterAcp: [
+        {
+          name: 'settings',
+          install: () => {
+            order.push('settings')
+          }
+        }
+      ]
+    })
+
+    expect(installComputeIpcHandlers).toHaveBeenCalledWith(compute)
+    expect(installAcpIpcHandlers).toHaveBeenCalledWith(runtime, taskNotifications)
+    expect(order).toEqual(['notifications', 'compute', 'connectors', 'acp', 'settings'])
+  })
+})

--- a/src/main/runtime-electron-wiring.test.ts
+++ b/src/main/runtime-electron-wiring.test.ts
@@ -1,4 +1,6 @@
-import { describe, expect, it, vi } from 'vitest'
+import { describe, expect, expectTypeOf, it, vi } from 'vitest'
+
+import type { ApplicationRuntimeInterfaces } from './ipc'
 
 const { installAcpIpcHandlers, installComputeIpcHandlers, order } = vi.hoisted(() => {
   const order: string[] = []
@@ -19,6 +21,12 @@ vi.mock('./compute/ipc', () => ({ installComputeIpcHandlers }))
 import { installElectronRuntimeAdapters } from './runtime-electron-wiring'
 
 describe('production Electron runtime wiring', () => {
+  it('exports only the named Session deletion capability to application startup', () => {
+    expectTypeOf<
+      keyof ApplicationRuntimeInterfaces['sessionDeletionCapability']
+    >().toEqualTypeOf<'setSessionDeletionHandlers'>()
+  })
+
   it('installs the constructed Compute and ACP modules before remaining surfaces', async () => {
     const compute = { handlers: {}, enabledComputeHostsRegistry: {} } as never
     const runtime = {} as never

--- a/src/main/runtime-electron-wiring.ts
+++ b/src/main/runtime-electron-wiring.ts
@@ -1,0 +1,36 @@
+import { installAcpIpcHandlers } from './acp/ipc'
+import type { AcpRuntimeCoordinator } from './acp/runtime-coordinator'
+import { installComputeIpcHandlers, type ComputeIpcModule } from './compute/ipc'
+import type { TaskNotificationService } from './notifications/task-notifications'
+
+export type NamedElectronSurfaceAdapter = {
+  readonly name: string
+  install(): void | Promise<void>
+}
+
+export type ElectronRuntimeAdapterInterfaces = {
+  readonly beforeCompute: readonly NamedElectronSurfaceAdapter[]
+  readonly compute: Pick<ComputeIpcModule, 'handlers' | 'enabledComputeHostsRegistry'>
+  readonly beforeAcp: readonly NamedElectronSurfaceAdapter[]
+  readonly acp: {
+    runtime: AcpRuntimeCoordinator
+    taskNotifications: TaskNotificationService
+  }
+  readonly afterAcp: readonly NamedElectronSurfaceAdapter[]
+}
+
+// Production transport wiring for application-owned runtimes. Compute and ACP are required named
+// interfaces rather than optional entries in a generic list, so composition cannot silently omit one.
+export const installElectronRuntimeAdapters = async ({
+  beforeCompute,
+  compute,
+  beforeAcp,
+  acp,
+  afterAcp
+}: ElectronRuntimeAdapterInterfaces): Promise<void> => {
+  for (const surface of beforeCompute) await surface.install()
+  installComputeIpcHandlers(compute)
+  for (const surface of beforeAcp) await surface.install()
+  installAcpIpcHandlers(acp.runtime, acp.taskNotifications)
+  for (const surface of afterAcp) await surface.install()
+}


### PR DESCRIPTION
## Problem

The Electron main process constructs runtime owners, registers transport adapters, and coordinates shutdown across a large `ipc.ts`/`index.ts` surface. This blurs state ownership, makes partial construction rollback difficult to reason about, and gives future application-owned orchestration from #458 no stable composition seam.

## Proposed change

- Introduce an application runtime composition root that constructs owned modules before installing Electron adapters.
- Expose narrow runtime interfaces for adapter installation and session-deletion callbacks instead of leaking broad service objects.
- Keep ACP and Compute runtime construction separate from their IPC registration while preserving the same instances across both phases.
- Centralize reverse-order rollback and shutdown with per-module deadlines, late-rejection observation, and production-visible diagnostics.
- Route production Electron wiring through the new composition seam and add focused regression coverage.

```mermaid
flowchart LR
  Entry["Electron main entry"] --> Compose["Application runtime composition"]
  Compose --> Owners["Owned runtime modules"]
  Owners --> ACP["ACP runtime"]
  Owners --> Compute["Compute runtime"]
  Owners --> Notebook["Notebook runtime"]
  Owners --> Settings["Settings / permissions / specialists"]
  Compose --> Interfaces["Narrow runtime interfaces"]
  Interfaces --> Adapters["Electron IPC adapters"]
  Adapters --> Renderer["Electron / Web surfaces"]
  Interfaces --> Headless["CLI / headless callers"]
  Compose --> Shutdown["Bounded reverse-order disposal"]
```

## Scope and non-goals

- Preserves existing Specialist, Permission, Compute, ACP, and Notebook behavior.
- Preserves Electron, Web, CLI/headless, and IPC compatibility; this PR changes internal construction and ownership, not public contracts.
- Does not change database schemas, persisted data relationships, shared IPC payloads, or user interaction.
- Does not implement #458. It adds an application-owned composition boundary so a later provider-neutral `OrchestratorService` can compose ACP runtimes without embedding lifecycle ownership in an IPC adapter.
- Does not move `docs/internal` planning files into Git.

This is the largest Wave 1 PR: 11 files with approximately 1,626 changed lines. Most of the diff is IPC adapter extraction/re-registration and regression tests. The review order below is intended to keep it tractable.

## Acceptance criteria and validation

All listed checks ran after the last material edit.

| Behavior | Project-owned check | Final result |
| --- | --- | --- |
| Runtime construction, partial rollback, reverse disposal, deadlines, and late failures | `rtk npm test -- --run src/main/application-runtime.test.ts src/main/logger.test.ts src/main/runtime-electron-wiring.test.ts src/main/app-lifecycle.test.ts` | 4 files / 104 tests passed |
| Shutdown diagnostics survive the production logger file sink | same focused command (`logger.test.ts`) | passed; module name and `1000ms` budget reach the sink |
| Production composition creates owners, installs adapters, exposes interfaces, and disposes in order | same focused command (`runtime-electron-wiring.test.ts`) | passed |
| Node and renderer type compatibility | `npm run typecheck` | passed |
| Repository lint gate | `npm run lint -- --no-cache` | 0 errors; 23 pre-existing warnings |
| Full regression suite | `npm test` | 608 files passed, 11 skipped; 9,065 tests passed, 140 skipped |
| Final independent Standards and Spec review | two-axis review against `origin/main` plus 5 focused files / 145 tests | Hard 0 / Judgement 0 / Nit 0; tests passed |

Uncovered risk: tests use project-owned fakes around Electron boundaries rather than launching every production surface end to end. CI portability, E2E, CodeQL, and automated review remain required before merge.

## Review focus

1. `application-runtime.ts`: module ownership, rollback, deadline budgets, and aggregate diagnostics.
2. `runtime-electron-wiring.ts` plus `index.ts`: production create/install/expose/dispose order.
3. `acp/ipc.ts` and `compute/ipc.ts`: construction is separate from adapter registration while instance identity is preserved.
4. `ipc.ts`: existing handler behavior is retained behind runtime interfaces.
5. Tests: compatibility evidence and diagnostic behavior.

Related: #458
