### PR TITLE
fix(settings): surface preference write failures

### DIFF
--- a/src/renderer/src/pages/onboarding/AgentStep.render.test.tsx
+++ b/src/renderer/src/pages/onboarding/AgentStep.render.test.tsx
@@ -258,6 +258,42 @@ describe('AgentStep', () => {
     expect(checkEnvironment).toHaveBeenCalledOnce()
   })
 
+  it('does not refresh the old framework environment when a switch fails', async () => {
+    const setAgentFramework = vi.fn().mockRejectedValue(new Error('framework save failed'))
+    const checkEnvironment = vi.fn().mockResolvedValue(undefined)
+    useSettingsStore.setState({
+      agentFrameworkId: 'claude-code',
+      agentFrameworks: threeFrameworks,
+      claude: { resolvedPath: '/bin/claude', version: '2.1.0' },
+      codex: { resolvedPath: '/bin/codex-acp', version: '0.9.0' },
+      preflight: {
+        claudeReady: true,
+        opencodeReady: false,
+        codexReady: true,
+        agentFrameworkId: 'claude-code',
+        agentReady: true,
+        activeProviderReady: false
+      },
+      environmentCheck: environment(true),
+      setAgentFramework,
+      checkEnvironment
+    })
+
+    await renderStep()
+    await act(async () => {
+      container.querySelector<HTMLElement>('[aria-label="Use Codex"]')?.click()
+      await Promise.resolve()
+      await Promise.resolve()
+    })
+
+    expect(setAgentFramework).toHaveBeenCalledWith('codex')
+    expect(checkEnvironment).not.toHaveBeenCalled()
+    const continueButton = [...container.querySelectorAll('button')].find(
+      (button) => button.textContent === 'Continue'
+    )
+    expect(continueButton?.disabled).toBe(true)
+  })
+
   it('enables Continue only when the latest check passes for the selected framework', async () => {
     useSettingsStore.setState({
       agentFrameworks: twoFrameworks,

--- a/src/renderer/src/pages/settings/ActiveModelSelect.tsx
+++ b/src/renderer/src/pages/settings/ActiveModelSelect.tsx
@@ -67,7 +67,7 @@ const ActiveModelSelect = (): React.JSX.Element | null => {
       value={current ? `${current.providerId}${SEP}${current.model}` : undefined}
       onValueChange={(value) => {
         const [providerId, model] = value.split(SEP)
-        void setActiveProvider(providerId, model)
+        void setActiveProvider(providerId, model).catch(() => undefined)
       }}
     >
       <SelectTrigger aria-label="Active model">

--- a/src/renderer/src/pages/settings/AgentPanel.tsx
+++ b/src/renderer/src/pages/settings/AgentPanel.tsx
@@ -171,7 +171,13 @@ const AgentPanel = ({
         if (request.intentVersion !== onboardingUserIntentVersion.current) continue
 
         if (useSettingsStore.getState().agentFrameworkId !== request.target) {
-          await setAgentFramework(request.target)
+          try {
+            await setAgentFramework(request.target)
+          } catch {
+            // The store already records safe feedback. Do not inspect the still-selected old
+            // framework; continue only if a newer user intent was queued during the failed IPC.
+            continue
+          }
         }
 
         // If the user changed their mind during the IPC, immediately apply the newer queued target.
@@ -186,6 +192,9 @@ const AgentPanel = ({
 
   const queueOnboardingSwitch = useCallback(
     (target: AgentFrameworkId, intentVersion = onboardingUserIntentVersion.current): void => {
+      // Invalidate readiness immediately: until this switch is saved and checked, the previous
+      // framework's successful result must not leave onboarding's Continue gate enabled.
+      useSettingsStore.setState({ environmentCheck: undefined, environmentCheckError: undefined })
       onboardingPendingSwitch.current = { target, intentVersion }
       void drainOnboardingSwitches()
     },
@@ -219,6 +228,10 @@ const AgentPanel = ({
       await setAgentFramework(target)
       // Framework detection updates the cards; the full pass owns the Home repair alert.
       await checkEnvironment({ force: true })
+    } catch {
+      // The Settings-level alert owns the failure copy. Stopping here prevents a stale environment
+      // check and consumes the event-handler rejection after the store has recorded diagnostics.
+      return
     } finally {
       settingsSwitchInFlight.current = false
       setIsSwitching(false)

--- a/src/renderer/src/pages/settings/SettingsPage.render.test.tsx
+++ b/src/renderer/src/pages/settings/SettingsPage.render.test.tsx
@@ -212,6 +212,32 @@ const settingsSection = (title: string): HTMLElement | undefined =>
 const agentItem = (): HTMLElement | null => navButton('Agent')?.closest('li') ?? null
 
 describe('SettingsPage layout', () => {
+  it('shows and dismisses a settings write failure above the scrolling content', () => {
+    useSettingsStore.setState({
+      settingsWriteError: 'Could not save notification preference. ipc down'
+    })
+
+    act(() => {
+      root.render(<SettingsPage open onClose={vi.fn()} />)
+    })
+
+    const alert = document.body.querySelector<HTMLElement>('[data-slot="settings-write-error"]')
+    const scroll = document.body.querySelector<HTMLElement>('[data-slot="settings-content-scroll"]')
+    expect(alert?.getAttribute('role')).toBe('alert')
+    expect(alert?.textContent).toContain('Could not save notification preference. ipc down')
+    expect(alert?.className).toContain('border-danger-000/30')
+    expect(alert?.className).toContain('bg-danger-000/10')
+    expect(alert?.className).toContain('text-danger-000')
+    expect(alert?.nextElementSibling).toBe(scroll)
+
+    act(() => {
+      alert?.querySelector<HTMLButtonElement>('[aria-label="Dismiss settings error"]')?.click()
+    })
+
+    expect(useSettingsStore.getState().settingsWriteError).toBeUndefined()
+    expect(document.body.querySelector('[data-slot="settings-write-error"]')).toBeNull()
+  })
+
   it('mounts the sidebar + content with grouped nav items and a close control', () => {
     useSettingsStore.setState({
       providers: [

--- a/src/renderer/src/pages/settings/SettingsPage.render.test.tsx
+++ b/src/renderer/src/pages/settings/SettingsPage.render.test.tsx
@@ -212,9 +212,9 @@ const settingsSection = (title: string): HTMLElement | undefined =>
 const agentItem = (): HTMLElement | null => navButton('Agent')?.closest('li') ?? null
 
 describe('SettingsPage layout', () => {
-  it('shows and dismisses a settings write failure above the scrolling content', () => {
+  it('shows and dismisses a settings write failure above the scrolling content', async () => {
     useSettingsStore.setState({
-      settingsWriteError: 'Could not save notification preference. ipc down'
+      settingsWriteError: 'Could not save notification preference. Try again.'
     })
 
     act(() => {
@@ -224,14 +224,18 @@ describe('SettingsPage layout', () => {
     const alert = document.body.querySelector<HTMLElement>('[data-slot="settings-write-error"]')
     const scroll = document.body.querySelector<HTMLElement>('[data-slot="settings-content-scroll"]')
     expect(alert?.getAttribute('role')).toBe('alert')
-    expect(alert?.textContent).toContain('Could not save notification preference. ipc down')
+    expect(alert?.textContent).toContain('Could not save notification preference. Try again.')
     expect(alert?.className).toContain('border-danger-000/30')
     expect(alert?.className).toContain('bg-danger-000/10')
     expect(alert?.className).toContain('text-danger-000')
     expect(alert?.nextElementSibling).toBe(scroll)
 
+    const dismiss = alert?.querySelector<HTMLButtonElement>('[aria-label="Dismiss settings error"]')
+    await act(async () => dismiss?.focus())
+    expect(document.body.textContent).toContain('Dismiss')
+
     act(() => {
-      alert?.querySelector<HTMLButtonElement>('[aria-label="Dismiss settings error"]')?.click()
+      dismiss?.click()
     })
 
     expect(useSettingsStore.getState().settingsWriteError).toBeUndefined()

--- a/src/renderer/src/pages/settings/SettingsPage.tsx
+++ b/src/renderer/src/pages/settings/SettingsPage.tsx
@@ -1,4 +1,5 @@
 import {
+  AlertTriangle,
   ArrowLeft,
   ArrowRight,
   Cloud,
@@ -206,6 +207,8 @@ const SettingsPage = ({ open, onClose, onOpenSession }: SettingsPageProps): Reac
   const consumePendingSkill = useSettingsStore((state) => state.consumePendingSkill)
   const pendingSettingsPanel = useSettingsStore((state) => state.pendingSettingsPanel)
   const consumePendingSettingsPanel = useSettingsStore((state) => state.consumePendingSettingsPanel)
+  const settingsWriteError = useSettingsStore((state) => state.settingsWriteError)
+  const clearSettingsWriteError = useSettingsStore((state) => state.clearSettingsWriteError)
   const canImportInstalledSkills =
     typeof window.api.settings.listAgentHomeSkills === 'function' &&
     typeof window.api.settings.importAgentHomeSkills === 'function'
@@ -833,6 +836,27 @@ const SettingsPage = ({ open, onClose, onOpenSession }: SettingsPageProps): Reac
                 </div>
               </div>
             </TooltipProvider>
+
+            {settingsWriteError ? (
+              <div
+                data-slot="settings-write-error"
+                role="alert"
+                className="mx-3 mt-3 flex items-start gap-2 rounded-lg border border-danger-000/30 bg-danger-000/10 px-3 py-2 text-xs text-danger-000"
+              >
+                <AlertTriangle className="mt-0.5 size-3.5 shrink-0" aria-hidden="true" />
+                <p className="min-w-0 flex-1 break-words py-0.5">{settingsWriteError}</p>
+                <Button
+                  type="button"
+                  variant="ghost"
+                  size="icon-sm"
+                  aria-label="Dismiss settings error"
+                  className="-my-1 -mr-1 shrink-0 rounded-md text-danger-000 hover:bg-danger-000/10 hover:text-danger-000"
+                  onClick={clearSettingsWriteError}
+                >
+                  <X className="size-3.5" aria-hidden="true" />
+                </Button>
+              </div>
+            ) : null}
 
             <div data-slot="settings-content-scroll" className="min-h-0 flex-1 overflow-y-auto">
               <div className="mx-auto min-h-full w-full max-w-[880px]">

--- a/src/renderer/src/pages/settings/SettingsPage.tsx
+++ b/src/renderer/src/pages/settings/SettingsPage.tsx
@@ -835,28 +835,33 @@ const SettingsPage = ({ open, onClose, onOpenSession }: SettingsPageProps): Reac
                   </Tooltip>
                 </div>
               </div>
-            </TooltipProvider>
 
-            {settingsWriteError ? (
-              <div
-                data-slot="settings-write-error"
-                role="alert"
-                className="mx-3 mt-3 flex items-start gap-2 rounded-lg border border-danger-000/30 bg-danger-000/10 px-3 py-2 text-xs text-danger-000"
-              >
-                <AlertTriangle className="mt-0.5 size-3.5 shrink-0" aria-hidden="true" />
-                <p className="min-w-0 flex-1 break-words py-0.5">{settingsWriteError}</p>
-                <Button
-                  type="button"
-                  variant="ghost"
-                  size="icon-sm"
-                  aria-label="Dismiss settings error"
-                  className="-my-1 -mr-1 shrink-0 rounded-md text-danger-000 hover:bg-danger-000/10 hover:text-danger-000"
-                  onClick={clearSettingsWriteError}
+              {settingsWriteError ? (
+                <div
+                  data-slot="settings-write-error"
+                  role="alert"
+                  className="mx-3 mt-3 flex items-start gap-2 rounded-lg border border-danger-000/30 bg-danger-000/10 px-3 py-2 text-xs text-danger-000"
                 >
-                  <X className="size-3.5" aria-hidden="true" />
-                </Button>
-              </div>
-            ) : null}
+                  <AlertTriangle className="mt-0.5 size-3.5 shrink-0" aria-hidden="true" />
+                  <p className="min-w-0 flex-1 break-words py-0.5">{settingsWriteError}</p>
+                  <Tooltip>
+                    <TooltipTrigger asChild>
+                      <Button
+                        type="button"
+                        variant="ghost"
+                        size="icon-sm"
+                        aria-label="Dismiss settings error"
+                        className="-my-1 -mr-1 shrink-0 rounded-md text-danger-000 hover:bg-danger-000/10 hover:text-danger-000"
+                        onClick={clearSettingsWriteError}
+                      >
+                        <X className="size-3.5" aria-hidden="true" />
+                      </Button>
+                    </TooltipTrigger>
+                    <TooltipContent>Dismiss</TooltipContent>
+                  </Tooltip>
+                </div>
+              ) : null}
+            </TooltipProvider>
 
             <div data-slot="settings-content-scroll" className="min-h-0 flex-1 overflow-y-auto">
               <div className="mx-auto min-h-full w-full max-w-[880px]">

--- a/src/renderer/src/pages/workspace/ComposerModelPicker.render.test.tsx
+++ b/src/renderer/src/pages/workspace/ComposerModelPicker.render.test.tsx
@@ -201,7 +201,7 @@ describe('ComposerModelPicker', () => {
     // keyboard-unreachable), keep it unselectable, and still offer a way out to Settings. The reason
     // row now lives inside the "Model" submenu; "Open Settings" stays on the first level.
     const openSettings = vi.fn()
-    const setActiveProvider = vi.fn()
+    const setActiveProvider = vi.fn().mockResolvedValue(undefined)
     useSettingsStore.setState({
       agentFrameworkId: 'claude-code',
       agentFrameworks: [
@@ -618,7 +618,7 @@ describe('ComposerModelPicker', () => {
   })
 
   it('keeps the grouped provider catalog in the Model submenu and switches on pick', async () => {
-    const setActiveProvider = vi.fn()
+    const setActiveProvider = vi.fn().mockResolvedValue(undefined)
     useSettingsStore.setState({
       providers: [
         provider({

--- a/src/renderer/src/pages/workspace/ComposerModelPicker.tsx
+++ b/src/renderer/src/pages/workspace/ComposerModelPicker.tsx
@@ -375,7 +375,11 @@ const ComposerModelPicker = (): React.JSX.Element | null => {
                         <MenuRadioItem
                           key={`${option.providerId}:${option.model}`}
                           checked={isActive}
-                          onSelect={() => void setActiveProvider(option.providerId, option.model)}
+                          onSelect={() =>
+                            void setActiveProvider(option.providerId, option.model).catch(
+                              () => undefined
+                            )
+                          }
                           leading={
                             <ProviderKindIcon
                               kindKey={providerKindKey(option.providerType, option.vendorId)}

--- a/src/renderer/src/stores/settings-store.test.ts
+++ b/src/renderer/src/stores/settings-store.test.ts
@@ -1375,9 +1375,10 @@ describe('settings store: setAgentFramework', () => {
 
   it('keeps the previous framework and exposes a visible failure when main rejects', async () => {
     const consoleError = vi.spyOn(console, 'error').mockImplementation(() => undefined)
-    api.setAgentFramework.mockRejectedValue(new Error('ipc down'))
+    const ipcError = new Error('ipc down')
+    api.setAgentFramework.mockRejectedValue(ipcError)
 
-    await useSettingsStore.getState().setAgentFramework('opencode')
+    await expect(useSettingsStore.getState().setAgentFramework('opencode')).rejects.toBe(ipcError)
 
     expect(useSettingsStore.getState().agentFrameworkId).toBe('claude-code')
     expect(useSettingsStore.getState().settingsWriteError).toBe(

--- a/src/renderer/src/stores/settings-store.test.ts
+++ b/src/renderer/src/stores/settings-store.test.ts
@@ -1342,6 +1342,33 @@ describe('settings store: setAgentFramework', () => {
     })
   })
 
+  it('keeps the previous framework and exposes a visible failure when main rejects', async () => {
+    const consoleError = vi.spyOn(console, 'error').mockImplementation(() => undefined)
+    api.setAgentFramework.mockRejectedValue(new Error('ipc down'))
+
+    await useSettingsStore.getState().setAgentFramework('opencode')
+
+    expect(useSettingsStore.getState().agentFrameworkId).toBe('claude-code')
+    expect(useSettingsStore.getState().settingsWriteError).toBe(
+      'Could not switch agent framework. ipc down'
+    )
+    expect(consoleError).toHaveBeenCalledWith('Failed to switch agent framework', expect.any(Error))
+  })
+
+  it('does not report a saved framework as a write failure when live detection rejects', async () => {
+    const consoleError = vi.spyOn(console, 'error').mockImplementation(() => undefined)
+    api.detectOpencode.mockRejectedValue(new Error('probe down'))
+
+    await useSettingsStore.getState().setAgentFramework('opencode')
+
+    expect(useSettingsStore.getState().agentFrameworkId).toBe('opencode')
+    expect(useSettingsStore.getState().settingsWriteError).toBeUndefined()
+    expect(consoleError).toHaveBeenCalledWith(
+      'Failed to refresh agent framework status',
+      expect.any(Error)
+    )
+  })
+
   it('installs and uninstalls Codex through the shared runtime lifecycle', async () => {
     api.getSettings.mockResolvedValue({
       ...snapshot([]),
@@ -1506,10 +1533,13 @@ describe('settings store: setAgentFramework', () => {
 
 describe('settings store: setReasoningEffort', () => {
   it('forwards the level to main and caches the returned snapshot', async () => {
+    useSettingsStore.setState({ settingsWriteError: 'A previous write failed.' })
+
     await useSettingsStore.getState().setReasoningEffort('high')
 
     expect(api.setReasoningEffort).toHaveBeenCalledWith({ effort: 'high' })
     expect(useSettingsStore.getState().reasoningEffort).toBe('high')
+    expect(useSettingsStore.getState().settingsWriteError).toBeUndefined()
   })
 
   it('applies the picked level optimistically before main confirms', async () => {
@@ -1531,13 +1561,16 @@ describe('settings store: setReasoningEffort', () => {
     expect(useSettingsStore.getState().reasoningEffort).toBe('max')
   })
 
-  it('reverts to the previous level and logs when main rejects', async () => {
+  it('reverts to the previous level and exposes a visible failure when main rejects', async () => {
     const consoleError = vi.spyOn(console, 'error').mockImplementation(() => undefined)
     api.setReasoningEffort.mockRejectedValue(new Error('ipc down'))
 
     await useSettingsStore.getState().setReasoningEffort('low')
 
     expect(useSettingsStore.getState().reasoningEffort).toBe('default')
+    expect(useSettingsStore.getState().settingsWriteError).toBe(
+      'Could not save reasoning effort. ipc down'
+    )
     expect(consoleError).toHaveBeenCalledWith('Failed to set reasoning effort', expect.any(Error))
   })
 
@@ -1558,13 +1591,16 @@ describe('settings store: setNotificationsEnabled', () => {
     expect(useSettingsStore.getState().notificationsEnabled).toBe(false)
   })
 
-  it('reverts to the previous flag and logs when main rejects', async () => {
+  it('reverts to the previous flag and exposes a visible failure when main rejects', async () => {
     const consoleError = vi.spyOn(console, 'error').mockImplementation(() => undefined)
     api.setNotificationsEnabled.mockRejectedValue(new Error('ipc down'))
 
     await useSettingsStore.getState().setNotificationsEnabled(false)
 
     expect(useSettingsStore.getState().notificationsEnabled).toBe(true)
+    expect(useSettingsStore.getState().settingsWriteError).toBe(
+      'Could not save notification preference. ipc down'
+    )
     expect(consoleError).toHaveBeenCalledWith(
       'Failed to set notifications enabled',
       expect.any(Error)
@@ -1588,13 +1624,16 @@ describe('settings store: setConversationSkillImportEnabled', () => {
     expect(useSettingsStore.getState().conversationSkillImportEnabled).toBe(false)
   })
 
-  it('reverts to the previous flag and logs when main rejects', async () => {
+  it('reverts to the previous flag and exposes a visible failure when main rejects', async () => {
     const consoleError = vi.spyOn(console, 'error').mockImplementation(() => undefined)
     api.setConversationSkillImportEnabled.mockRejectedValue(new Error('ipc down'))
 
     await useSettingsStore.getState().setConversationSkillImportEnabled(false)
 
     expect(useSettingsStore.getState().conversationSkillImportEnabled).toBe(true)
+    expect(useSettingsStore.getState().settingsWriteError).toBe(
+      'Could not save conversation Skill import preference. ipc down'
+    )
     expect(consoleError).toHaveBeenCalledWith(
       'Failed to set conversation Skill import enabled',
       expect.any(Error)
@@ -1624,7 +1663,7 @@ describe('settings store: setClosePreference', () => {
     expect(useSettingsStore.getState().closePreference).toBeUndefined()
   })
 
-  it('reverts to the previous preference when main rejects', async () => {
+  it('reverts to the previous preference and exposes a visible failure when main rejects', async () => {
     const consoleError = vi.spyOn(console, 'error').mockImplementation(() => undefined)
     useSettingsStore.setState({ closePreference: 'quit' })
     api.setClosePreference.mockRejectedValue(new Error('ipc down'))
@@ -1632,6 +1671,9 @@ describe('settings store: setClosePreference', () => {
     await useSettingsStore.getState().setClosePreference(undefined)
 
     expect(useSettingsStore.getState().closePreference).toBe('quit')
+    expect(useSettingsStore.getState().settingsWriteError).toBe(
+      'Could not save window close preference. ipc down'
+    )
     expect(consoleError).toHaveBeenCalledWith('Failed to set close preference', expect.any(Error))
   })
 
@@ -1652,7 +1694,7 @@ describe('settings store: setAppIconVariant', () => {
     expect(useSettingsStore.getState().appIconVariant).toBe('dark')
   })
 
-  it('reverts to the previous variant and logs when main rejects', async () => {
+  it('reverts to the previous variant and exposes a visible failure when main rejects', async () => {
     const consoleError = vi.spyOn(console, 'error').mockImplementation(() => undefined)
     useSettingsStore.setState({ appIconVariant: 'light' })
     api.setAppIconVariant.mockRejectedValue(new Error('ipc down'))
@@ -1660,6 +1702,9 @@ describe('settings store: setAppIconVariant', () => {
     await useSettingsStore.getState().setAppIconVariant('dark')
 
     expect(useSettingsStore.getState().appIconVariant).toBe('light')
+    expect(useSettingsStore.getState().settingsWriteError).toBe(
+      'Could not save app icon preference. ipc down'
+    )
     expect(consoleError).toHaveBeenCalledWith('Failed to set app icon variant', expect.any(Error))
   })
 

--- a/src/renderer/src/stores/settings-store.test.ts
+++ b/src/renderer/src/stores/settings-store.test.ts
@@ -1671,24 +1671,51 @@ describe('settings store: setReasoningEffort', () => {
 
   it('ignores a stale failure from an older write to the same preference', async () => {
     vi.spyOn(console, 'error').mockImplementation(() => undefined)
-    let rejectOlder: (reason?: unknown) => void = () => undefined
     api.setReasoningEffort
-      .mockImplementationOnce(
-        () =>
-          new Promise<SettingsSnapshot>((_resolve, reject) => {
-            rejectOlder = reject
-          })
-      )
+      .mockRejectedValueOnce(new Error('stale failure'))
       .mockResolvedValueOnce({ ...snapshot([]), reasoningEffort: 'max' })
 
     const olderWrite = useSettingsStore.getState().setReasoningEffort('high')
-    await useSettingsStore.getState().setReasoningEffort('max')
+    const newerWrite = useSettingsStore.getState().setReasoningEffort('max')
 
-    rejectOlder(new Error('stale failure'))
-    await olderWrite
+    await Promise.all([olderWrite, newerWrite])
 
     expect(useSettingsStore.getState().reasoningEffort).toBe('max')
     expect(useSettingsStore.getState().settingsWriteError).toBeUndefined()
+  })
+
+  it('restores the confirmed value when concurrent writes to the same preference both fail', async () => {
+    vi.spyOn(console, 'error').mockImplementation(() => undefined)
+    api.setReasoningEffort
+      .mockRejectedValueOnce(new Error('older failure'))
+      .mockRejectedValueOnce(new Error('newer failure'))
+
+    const olderWrite = useSettingsStore.getState().setReasoningEffort('high')
+    const newerWrite = useSettingsStore.getState().setReasoningEffort('max')
+
+    await Promise.all([olderWrite, newerWrite])
+
+    expect(useSettingsStore.getState().reasoningEffort).toBe('default')
+    expect(useSettingsStore.getState().settingsWriteError).toBe(
+      'Could not save reasoning effort. Try again.'
+    )
+  })
+
+  it('restores the last successful value when a queued newer write fails', async () => {
+    vi.spyOn(console, 'error').mockImplementation(() => undefined)
+    api.setReasoningEffort
+      .mockResolvedValueOnce({ ...snapshot([]), reasoningEffort: 'high' })
+      .mockRejectedValueOnce(new Error('newer failure'))
+
+    const olderWrite = useSettingsStore.getState().setReasoningEffort('high')
+    const newerWrite = useSettingsStore.getState().setReasoningEffort('max')
+
+    await Promise.all([olderWrite, newerWrite])
+
+    expect(useSettingsStore.getState().reasoningEffort).toBe('high')
+    expect(useSettingsStore.getState().settingsWriteError).toBe(
+      'Could not save reasoning effort. Try again.'
+    )
   })
 
   it('reverts to the previous level and exposes a visible failure when main rejects', async () => {

--- a/src/renderer/src/stores/settings-store.test.ts
+++ b/src/renderer/src/stores/settings-store.test.ts
@@ -239,6 +239,7 @@ beforeEach(() => {
     })
   }
   ;(globalThis as { window?: unknown }).window = { api: { settings: api, acp } }
+  useSettingsStore.getState().clearSettingsWriteError()
   useSettingsStore.setState(createInitialSettingsState())
 })
 
@@ -851,6 +852,20 @@ describe('settings store: provider/model selection', () => {
     await useSettingsStore.getState().setActiveProvider('p1', '')
 
     expect(api.setActiveProvider).toHaveBeenCalledWith({ id: 'p1', model: undefined })
+  })
+
+  it('clears an existing preference write error after the active provider saves', async () => {
+    vi.spyOn(console, 'error').mockImplementation(() => undefined)
+    api.setReasoningEffort.mockRejectedValueOnce(new Error('reasoning unavailable'))
+
+    await useSettingsStore.getState().setReasoningEffort('high')
+    expect(useSettingsStore.getState().settingsWriteError).toBe(
+      'Could not save reasoning effort. Try again.'
+    )
+
+    await useSettingsStore.getState().setActiveProvider('p1', 'glm-4.7')
+
+    expect(useSettingsStore.getState().settingsWriteError).toBeUndefined()
   })
 })
 
@@ -1533,7 +1548,9 @@ describe('settings store: setAgentFramework', () => {
 
 describe('settings store: setReasoningEffort', () => {
   it('forwards the level to main and caches the returned snapshot', async () => {
-    useSettingsStore.setState({ settingsWriteError: 'A previous write failed.' })
+    vi.spyOn(console, 'error').mockImplementation(() => undefined)
+    api.setNotificationsEnabled.mockRejectedValueOnce(new Error('notifications unavailable'))
+    await useSettingsStore.getState().setNotificationsEnabled(false)
 
     await useSettingsStore.getState().setReasoningEffort('high')
 
@@ -1561,7 +1578,7 @@ describe('settings store: setReasoningEffort', () => {
     expect(useSettingsStore.getState().reasoningEffort).toBe('max')
   })
 
-  it('ignores an older write failure after a newer settings write succeeds', async () => {
+  it('surfaces an unrelated older write failure after a newer settings write succeeds', async () => {
     let rejectReasoning: (reason?: unknown) => void = () => undefined
     api.setReasoningEffort.mockImplementation(
       () =>
@@ -1576,7 +1593,9 @@ describe('settings store: setReasoningEffort', () => {
     rejectReasoning(new Error('stale failure'))
     await olderWrite
 
-    expect(useSettingsStore.getState().settingsWriteError).toBeUndefined()
+    expect(useSettingsStore.getState().settingsWriteError).toBe(
+      'Could not save reasoning effort. Try again.'
+    )
   })
 
   it('keeps a newer write failure when an older settings write succeeds later', async () => {
@@ -1599,6 +1618,61 @@ describe('settings store: setReasoningEffort', () => {
     expect(useSettingsStore.getState().settingsWriteError).toBe(
       'Could not save notification preference. Try again.'
     )
+  })
+
+  it('retains failures from concurrent writes to different preferences', async () => {
+    vi.spyOn(console, 'error').mockImplementation(() => undefined)
+    let rejectReasoning: (reason?: unknown) => void = () => undefined
+    let rejectNotifications: (reason?: unknown) => void = () => undefined
+    api.setReasoningEffort.mockImplementation(
+      () =>
+        new Promise<SettingsSnapshot>((_resolve, reject) => {
+          rejectReasoning = reject
+        })
+    )
+    api.setNotificationsEnabled.mockImplementation(
+      () =>
+        new Promise<SettingsSnapshot>((_resolve, reject) => {
+          rejectNotifications = reject
+        })
+    )
+
+    const reasoningWrite = useSettingsStore.getState().setReasoningEffort('high')
+    const notificationsWrite = useSettingsStore.getState().setNotificationsEnabled(false)
+
+    rejectNotifications(new Error('notifications unavailable'))
+    await notificationsWrite
+    rejectReasoning(new Error('reasoning unavailable'))
+    await reasoningWrite
+
+    expect(useSettingsStore.getState().settingsWriteError).toContain(
+      'Could not save notification preference. Try again.'
+    )
+    expect(useSettingsStore.getState().settingsWriteError).toContain(
+      'Could not save reasoning effort. Try again.'
+    )
+  })
+
+  it('ignores a stale failure from an older write to the same preference', async () => {
+    vi.spyOn(console, 'error').mockImplementation(() => undefined)
+    let rejectOlder: (reason?: unknown) => void = () => undefined
+    api.setReasoningEffort
+      .mockImplementationOnce(
+        () =>
+          new Promise<SettingsSnapshot>((_resolve, reject) => {
+            rejectOlder = reject
+          })
+      )
+      .mockResolvedValueOnce({ ...snapshot([]), reasoningEffort: 'max' })
+
+    const olderWrite = useSettingsStore.getState().setReasoningEffort('high')
+    await useSettingsStore.getState().setReasoningEffort('max')
+
+    rejectOlder(new Error('stale failure'))
+    await olderWrite
+
+    expect(useSettingsStore.getState().reasoningEffort).toBe('max')
+    expect(useSettingsStore.getState().settingsWriteError).toBeUndefined()
   })
 
   it('reverts to the previous level and exposes a visible failure when main rejects', async () => {

--- a/src/renderer/src/stores/settings-store.test.ts
+++ b/src/renderer/src/stores/settings-store.test.ts
@@ -867,6 +867,22 @@ describe('settings store: provider/model selection', () => {
 
     expect(useSettingsStore.getState().settingsWriteError).toBeUndefined()
   })
+
+  it('records a safe write error and preserves rejection semantics when activation fails', async () => {
+    const consoleError = vi.spyOn(console, 'error').mockImplementation(() => undefined)
+    const ipcError = new Error('/Users/example/.open-science/settings.json is unavailable')
+    api.setActiveProvider.mockRejectedValueOnce(ipcError)
+
+    await expect(useSettingsStore.getState().setActiveProvider('p1', 'glm-4.7')).rejects.toBe(
+      ipcError
+    )
+
+    expect(useSettingsStore.getState().settingsWriteError).toBe(
+      'Could not switch active provider or model. Try again.'
+    )
+    expect(useSettingsStore.getState().settingsWriteError).not.toContain('/Users/example')
+    expect(consoleError).toHaveBeenCalledWith('Failed to set active provider', ipcError)
+  })
 })
 
 describe('selectProviderModelOptions', () => {

--- a/src/renderer/src/stores/settings-store.test.ts
+++ b/src/renderer/src/stores/settings-store.test.ts
@@ -1350,7 +1350,7 @@ describe('settings store: setAgentFramework', () => {
 
     expect(useSettingsStore.getState().agentFrameworkId).toBe('claude-code')
     expect(useSettingsStore.getState().settingsWriteError).toBe(
-      'Could not switch agent framework. ipc down'
+      'Could not switch agent framework. Try again.'
     )
     expect(consoleError).toHaveBeenCalledWith('Failed to switch agent framework', expect.any(Error))
   })
@@ -1561,6 +1561,46 @@ describe('settings store: setReasoningEffort', () => {
     expect(useSettingsStore.getState().reasoningEffort).toBe('max')
   })
 
+  it('ignores an older write failure after a newer settings write succeeds', async () => {
+    let rejectReasoning: (reason?: unknown) => void = () => undefined
+    api.setReasoningEffort.mockImplementation(
+      () =>
+        new Promise<SettingsSnapshot>((_resolve, reject) => {
+          rejectReasoning = reject
+        })
+    )
+
+    const olderWrite = useSettingsStore.getState().setReasoningEffort('high')
+    await useSettingsStore.getState().setNotificationsEnabled(false)
+
+    rejectReasoning(new Error('stale failure'))
+    await olderWrite
+
+    expect(useSettingsStore.getState().settingsWriteError).toBeUndefined()
+  })
+
+  it('keeps a newer write failure when an older settings write succeeds later', async () => {
+    vi.spyOn(console, 'error').mockImplementation(() => undefined)
+    let resolveReasoning: (value: SettingsSnapshot) => void = () => undefined
+    api.setReasoningEffort.mockImplementation(
+      () =>
+        new Promise<SettingsSnapshot>((resolve) => {
+          resolveReasoning = resolve
+        })
+    )
+    api.setNotificationsEnabled.mockRejectedValue(new Error('newer failure'))
+
+    const olderWrite = useSettingsStore.getState().setReasoningEffort('high')
+    await useSettingsStore.getState().setNotificationsEnabled(false)
+
+    resolveReasoning({ ...snapshot([]), reasoningEffort: 'high' })
+    await olderWrite
+
+    expect(useSettingsStore.getState().settingsWriteError).toBe(
+      'Could not save notification preference. Try again.'
+    )
+  })
+
   it('reverts to the previous level and exposes a visible failure when main rejects', async () => {
     const consoleError = vi.spyOn(console, 'error').mockImplementation(() => undefined)
     api.setReasoningEffort.mockRejectedValue(new Error('ipc down'))
@@ -1569,7 +1609,7 @@ describe('settings store: setReasoningEffort', () => {
 
     expect(useSettingsStore.getState().reasoningEffort).toBe('default')
     expect(useSettingsStore.getState().settingsWriteError).toBe(
-      'Could not save reasoning effort. ipc down'
+      'Could not save reasoning effort. Try again.'
     )
     expect(consoleError).toHaveBeenCalledWith('Failed to set reasoning effort', expect.any(Error))
   })
@@ -1599,7 +1639,7 @@ describe('settings store: setNotificationsEnabled', () => {
 
     expect(useSettingsStore.getState().notificationsEnabled).toBe(true)
     expect(useSettingsStore.getState().settingsWriteError).toBe(
-      'Could not save notification preference. ipc down'
+      'Could not save notification preference. Try again.'
     )
     expect(consoleError).toHaveBeenCalledWith(
       'Failed to set notifications enabled',
@@ -1632,7 +1672,7 @@ describe('settings store: setConversationSkillImportEnabled', () => {
 
     expect(useSettingsStore.getState().conversationSkillImportEnabled).toBe(true)
     expect(useSettingsStore.getState().settingsWriteError).toBe(
-      'Could not save conversation Skill import preference. ipc down'
+      'Could not save conversation Skill import preference. Try again.'
     )
     expect(consoleError).toHaveBeenCalledWith(
       'Failed to set conversation Skill import enabled',
@@ -1672,7 +1712,7 @@ describe('settings store: setClosePreference', () => {
 
     expect(useSettingsStore.getState().closePreference).toBe('quit')
     expect(useSettingsStore.getState().settingsWriteError).toBe(
-      'Could not save window close preference. ipc down'
+      'Could not save window close preference. Try again.'
     )
     expect(consoleError).toHaveBeenCalledWith('Failed to set close preference', expect.any(Error))
   })
@@ -1703,7 +1743,7 @@ describe('settings store: setAppIconVariant', () => {
 
     expect(useSettingsStore.getState().appIconVariant).toBe('light')
     expect(useSettingsStore.getState().settingsWriteError).toBe(
-      'Could not save app icon preference. ipc down'
+      'Could not save app icon preference. Try again.'
     )
     expect(consoleError).toHaveBeenCalledWith('Failed to set app icon variant', expect.any(Error))
   })

--- a/src/renderer/src/stores/settings-store.ts
+++ b/src/renderer/src/stores/settings-store.ts
@@ -88,6 +88,8 @@ type SettingsStoreData = {
   isLoaded: boolean
   isLoading: boolean
   loadError: string | undefined
+  // Latest failed Settings write, shown by the dialog until dismissed or another write starts.
+  settingsWriteError: string | undefined
   settingsLoadGeneration: number
   claude: ClaudeInfo
   activeProviderId: string | undefined
@@ -229,6 +231,7 @@ type SettingsStore = SettingsStoreData & {
   setClosePreference: (preference: CloseActionPreference | undefined) => Promise<void>
   // Sets the app-icon look; main applies it live to the window and dock/taskbar.
   setAppIconVariant: (variant: AppIconVariant) => Promise<void>
+  clearSettingsWriteError: () => void
   deleteProvider: (providerId: string) => Promise<void>
   openSettings: () => void
   openSettingsToPanel: (panel: SettingsPanelId) => void
@@ -333,6 +336,7 @@ export const createInitialSettingsState = (): SettingsStoreData => ({
   isLoaded: false,
   isLoading: false,
   loadError: undefined,
+  settingsWriteError: undefined,
   settingsLoadGeneration: 0,
   claude: {},
   activeProviderId: undefined,
@@ -586,6 +590,13 @@ const SAFE_SETTINGS_LOAD_ERROR = 'Open Science could not load settings. Retry to
 // Keep raw IPC diagnostics in the developer channel while renderer state remains path-safe.
 const reportSettingsLoadError = (error: unknown): void => {
   console.warn('Settings startup loading failed', error)
+}
+
+// Keep the action-specific summary stable while preserving an actionable IPC message when one exists.
+// Raw failures remain in the console for diagnostics; non-Error payloads never leak into the UI.
+const describeSettingsWriteError = (summary: string, error: unknown): string => {
+  const detail = error instanceof Error ? error.message.trim() : ''
+  return detail ? `${summary} ${detail}` : summary
 }
 
 // Renderer cache of the main-process settings service. The main process stays the source of truth
@@ -973,12 +984,25 @@ export const useSettingsStore = create<SettingsStore>((set, get) => ({
     await get().refreshPreflight()
   },
 
-  // Switches the agent backend; main reconnects so the choice applies on the next prompt. Surfaces
-  // failures (e.g. a stale preload bundle where the IPC is missing after a renderer-only hot reload)
-  // to the console instead of silently reverting the selector.
+  // Switches the agent backend; main reconnects so the choice applies on the next prompt. A failed
+  // write leaves the previous framework selected and feeds the shared Settings error banner.
   setAgentFramework: async (id) => {
+    set({ settingsWriteError: undefined })
+
+    let snapshot: SettingsSnapshot
     try {
-      set(applySnapshot(await window.api.settings.setAgentFramework({ id })))
+      snapshot = await window.api.settings.setAgentFramework({ id })
+    } catch (error) {
+      set({
+        settingsWriteError: describeSettingsWriteError('Could not switch agent framework.', error)
+      })
+      console.error('Failed to switch agent framework', error)
+      return
+    }
+
+    set(applySnapshot(snapshot))
+
+    try {
       // Live-detect the newly-selected framework so a binary installed (or deleted) since the last
       // check is reflected right away, then refresh the readiness gate the install prompt keys off.
       if (id === 'opencode') {
@@ -990,7 +1014,9 @@ export const useSettingsStore = create<SettingsStore>((set, get) => ({
       }
       await get().refreshPreflight()
     } catch (error) {
-      console.error('Failed to switch agent framework', error)
+      // The preference is already saved. Keep the new selection and avoid relabelling a follow-up
+      // detection problem as a write failure; the next explicit/full environment check can retry.
+      console.error('Failed to refresh agent framework status', error)
     }
   },
 
@@ -999,12 +1025,15 @@ export const useSettingsStore = create<SettingsStore>((set, get) => ({
   // optimistically, reconcile from the returned snapshot, and revert if the write fails.
   setReasoningEffort: async (effort) => {
     const previous = get().reasoningEffort
-    set({ reasoningEffort: effort })
+    set({ reasoningEffort: effort, settingsWriteError: undefined })
 
     try {
       set(applySnapshot(await window.api.settings.setReasoningEffort({ effort })))
     } catch (error) {
-      set({ reasoningEffort: previous })
+      set({
+        reasoningEffort: previous,
+        settingsWriteError: describeSettingsWriteError('Could not save reasoning effort.', error)
+      })
       console.error('Failed to set reasoning effort', error)
     }
   },
@@ -1013,36 +1042,54 @@ export const useSettingsStore = create<SettingsStore>((set, get) => ({
   // reconcile from the returned snapshot, and revert if the write fails.
   setNotificationsEnabled: async (enabled) => {
     const previous = get().notificationsEnabled
-    set({ notificationsEnabled: enabled })
+    set({ notificationsEnabled: enabled, settingsWriteError: undefined })
 
     try {
       set(applySnapshot(await window.api.settings.setNotificationsEnabled({ enabled })))
     } catch (error) {
-      set({ notificationsEnabled: previous })
+      set({
+        notificationsEnabled: previous,
+        settingsWriteError: describeSettingsWriteError(
+          'Could not save notification preference.',
+          error
+        )
+      })
       console.error('Failed to set notifications enabled', error)
     }
   },
 
   setConversationSkillImportEnabled: async (enabled) => {
     const previous = get().conversationSkillImportEnabled
-    set({ conversationSkillImportEnabled: enabled })
+    set({ conversationSkillImportEnabled: enabled, settingsWriteError: undefined })
 
     try {
       set(applySnapshot(await window.api.settings.setConversationSkillImportEnabled({ enabled })))
     } catch (error) {
-      set({ conversationSkillImportEnabled: previous })
+      set({
+        conversationSkillImportEnabled: previous,
+        settingsWriteError: describeSettingsWriteError(
+          'Could not save conversation Skill import preference.',
+          error
+        )
+      })
       console.error('Failed to set conversation Skill import enabled', error)
     }
   },
 
   setClosePreference: async (preference) => {
     const previous = get().closePreference
-    set({ closePreference: preference })
+    set({ closePreference: preference, settingsWriteError: undefined })
 
     try {
       set(applySnapshot(await window.api.settings.setClosePreference({ preference })))
     } catch (error) {
-      set({ closePreference: previous })
+      set({
+        closePreference: previous,
+        settingsWriteError: describeSettingsWriteError(
+          'Could not save window close preference.',
+          error
+        )
+      })
       console.error('Failed to set close preference', error)
     }
   },
@@ -1051,15 +1098,20 @@ export const useSettingsStore = create<SettingsStore>((set, get) => ({
   // from the returned snapshot, and revert if the write fails.
   setAppIconVariant: async (variant) => {
     const previous = get().appIconVariant
-    set({ appIconVariant: variant })
+    set({ appIconVariant: variant, settingsWriteError: undefined })
 
     try {
       set(applySnapshot(await window.api.settings.setAppIconVariant({ variant })))
     } catch (error) {
-      set({ appIconVariant: previous })
+      set({
+        appIconVariant: previous,
+        settingsWriteError: describeSettingsWriteError('Could not save app icon preference.', error)
+      })
       console.error('Failed to set app icon variant', error)
     }
   },
+
+  clearSettingsWriteError: () => set({ settingsWriteError: undefined }),
 
   // Detects the opencode executable and refreshes its status card.
   detectOpencode: async () => {

--- a/src/renderer/src/stores/settings-store.ts
+++ b/src/renderer/src/stores/settings-store.ts
@@ -1139,7 +1139,7 @@ export const useSettingsStore = create<SettingsStore>((set, get) => ({
     } catch (error) {
       finishSettingsWrite(set, writeToken, SETTINGS_WRITE_ERRORS.agentFramework)
       console.error('Failed to switch agent framework', error)
-      return
+      throw error
     }
 
     if (!isCurrentSettingsWrite(writeToken)) return

--- a/src/renderer/src/stores/settings-store.ts
+++ b/src/renderer/src/stores/settings-store.ts
@@ -585,7 +585,6 @@ const resolveUpsertedProviderId = (
 }
 
 let settingsLoadPromise: Promise<boolean> | undefined
-let settingsWriteGeneration = 0
 const SAFE_SETTINGS_LOAD_ERROR = 'Open Science could not load settings. Retry to continue.'
 
 // Keep raw IPC diagnostics in the developer channel while renderer state remains path-safe.
@@ -603,19 +602,69 @@ const SETTINGS_WRITE_ERRORS = {
   appIcon: 'Could not save app icon preference. Try again.'
 } as const
 
-// Shared banner ownership follows user intent order, not network completion order. A late result from
-// an older write must never clear or replace the outcome of a newer Settings action.
-const beginSettingsWrite = (): number => {
-  settingsWriteGeneration += 1
-  return settingsWriteGeneration
+type SettingsWriteKey = keyof typeof SETTINGS_WRITE_ERRORS | 'activeProvider'
+
+type SettingsWriteToken = {
+  key: SettingsWriteKey
+  generation: number
+  failuresAtStart: ReadonlyMap<SettingsWriteKey, number>
 }
+
+type SettingsWriteFailure = {
+  id: number
+  message: string
+}
+
+const settingsWriteGenerations = new Map<SettingsWriteKey, number>()
+const settingsWriteFailures = new Map<SettingsWriteKey, SettingsWriteFailure>()
+let settingsWriteFailureId = 0
+
+const currentSettingsWriteError = (): string | undefined => {
+  const messages = [...settingsWriteFailures.values()]
+    .sort((left, right) => left.id - right.id)
+    .map((failure) => failure.message)
+
+  return messages.length > 0 ? messages.join(' ') : undefined
+}
+
+// Generations are isolated per preference: a newer write supersedes stale work for that same
+// preference without hiding a failure from a different concurrent write. The token also remembers
+// errors visible when the user started this write so a success clears only those stale errors, not a
+// different failure that arrived while the write was pending.
+const beginSettingsWrite = (key: SettingsWriteKey): SettingsWriteToken => {
+  const generation = (settingsWriteGenerations.get(key) ?? 0) + 1
+  settingsWriteGenerations.set(key, generation)
+  return {
+    key,
+    generation,
+    failuresAtStart: new Map(
+      [...settingsWriteFailures].map(([failureKey, failure]) => [failureKey, failure.id])
+    )
+  }
+}
+
+const isCurrentSettingsWrite = (token: SettingsWriteToken): boolean =>
+  settingsWriteGenerations.get(token.key) === token.generation
 
 const finishSettingsWrite = (
   set: StoreApi<SettingsStore>['setState'],
-  generation: number,
+  token: SettingsWriteToken,
   error?: string
 ): void => {
-  if (generation === settingsWriteGeneration) set({ settingsWriteError: error })
+  if (!isCurrentSettingsWrite(token)) return
+
+  if (error) {
+    settingsWriteFailureId += 1
+    settingsWriteFailures.set(token.key, { id: settingsWriteFailureId, message: error })
+  } else {
+    for (const [failureKey, failureId] of token.failuresAtStart) {
+      if (settingsWriteFailures.get(failureKey)?.id === failureId) {
+        settingsWriteFailures.delete(failureKey)
+      }
+    }
+  }
+
+  set({ settingsWriteError: currentSettingsWriteError() })
 }
 
 // Renderer cache of the main-process settings service. The main process stays the source of truth
@@ -994,32 +1043,35 @@ export const useSettingsStore = create<SettingsStore>((set, get) => ({
   // Switches the active provider/model (main drops the agent connection so the next prompt reconnects).
   // An empty model string is treated as "no specific model" so main uses the provider default.
   setActiveProvider: async (providerId, model) => {
+    const writeToken = beginSettingsWrite('activeProvider')
     const snapshot = await window.api.settings.setActiveProvider({
       id: providerId,
       model: model || undefined
     })
 
+    if (!isCurrentSettingsWrite(writeToken)) return
     set(applySnapshot(snapshot))
+    finishSettingsWrite(set, writeToken)
     await get().refreshPreflight()
   },
 
   // Switches the agent backend; main reconnects so the choice applies on the next prompt. A failed
   // write leaves the previous framework selected and feeds the shared Settings error banner.
   setAgentFramework: async (id) => {
-    const writeGeneration = beginSettingsWrite()
-    set({ settingsWriteError: undefined })
+    const writeToken = beginSettingsWrite('agentFramework')
 
     let snapshot: SettingsSnapshot
     try {
       snapshot = await window.api.settings.setAgentFramework({ id })
     } catch (error) {
-      finishSettingsWrite(set, writeGeneration, SETTINGS_WRITE_ERRORS.agentFramework)
+      finishSettingsWrite(set, writeToken, SETTINGS_WRITE_ERRORS.agentFramework)
       console.error('Failed to switch agent framework', error)
       return
     }
 
+    if (!isCurrentSettingsWrite(writeToken)) return
     set(applySnapshot(snapshot))
-    finishSettingsWrite(set, writeGeneration)
+    finishSettingsWrite(set, writeToken)
 
     try {
       // Live-detect the newly-selected framework so a binary installed (or deleted) since the last
@@ -1043,16 +1095,18 @@ export const useSettingsStore = create<SettingsStore>((set, get) => ({
   // trip includes that reconnect, which is too slow to gate the selector on — apply the pick
   // optimistically, reconcile from the returned snapshot, and revert if the write fails.
   setReasoningEffort: async (effort) => {
-    const writeGeneration = beginSettingsWrite()
+    const writeToken = beginSettingsWrite('reasoningEffort')
     const previous = get().reasoningEffort
-    set({ reasoningEffort: effort, settingsWriteError: undefined })
+    set({ reasoningEffort: effort })
 
     try {
-      set(applySnapshot(await window.api.settings.setReasoningEffort({ effort })))
-      finishSettingsWrite(set, writeGeneration)
+      const snapshot = await window.api.settings.setReasoningEffort({ effort })
+      if (!isCurrentSettingsWrite(writeToken)) return
+      set(applySnapshot(snapshot))
+      finishSettingsWrite(set, writeToken)
     } catch (error) {
-      set({ reasoningEffort: previous })
-      finishSettingsWrite(set, writeGeneration, SETTINGS_WRITE_ERRORS.reasoningEffort)
+      if (isCurrentSettingsWrite(writeToken)) set({ reasoningEffort: previous })
+      finishSettingsWrite(set, writeToken, SETTINGS_WRITE_ERRORS.reasoningEffort)
       console.error('Failed to set reasoning effort', error)
     }
   },
@@ -1060,46 +1114,52 @@ export const useSettingsStore = create<SettingsStore>((set, get) => ({
   // Toggles desktop notifications. Optimistic like the other preference setters: apply the pick,
   // reconcile from the returned snapshot, and revert if the write fails.
   setNotificationsEnabled: async (enabled) => {
-    const writeGeneration = beginSettingsWrite()
+    const writeToken = beginSettingsWrite('notifications')
     const previous = get().notificationsEnabled
-    set({ notificationsEnabled: enabled, settingsWriteError: undefined })
+    set({ notificationsEnabled: enabled })
 
     try {
-      set(applySnapshot(await window.api.settings.setNotificationsEnabled({ enabled })))
-      finishSettingsWrite(set, writeGeneration)
+      const snapshot = await window.api.settings.setNotificationsEnabled({ enabled })
+      if (!isCurrentSettingsWrite(writeToken)) return
+      set(applySnapshot(snapshot))
+      finishSettingsWrite(set, writeToken)
     } catch (error) {
-      set({ notificationsEnabled: previous })
-      finishSettingsWrite(set, writeGeneration, SETTINGS_WRITE_ERRORS.notifications)
+      if (isCurrentSettingsWrite(writeToken)) set({ notificationsEnabled: previous })
+      finishSettingsWrite(set, writeToken, SETTINGS_WRITE_ERRORS.notifications)
       console.error('Failed to set notifications enabled', error)
     }
   },
 
   setConversationSkillImportEnabled: async (enabled) => {
-    const writeGeneration = beginSettingsWrite()
+    const writeToken = beginSettingsWrite('conversationSkillImport')
     const previous = get().conversationSkillImportEnabled
-    set({ conversationSkillImportEnabled: enabled, settingsWriteError: undefined })
+    set({ conversationSkillImportEnabled: enabled })
 
     try {
-      set(applySnapshot(await window.api.settings.setConversationSkillImportEnabled({ enabled })))
-      finishSettingsWrite(set, writeGeneration)
+      const snapshot = await window.api.settings.setConversationSkillImportEnabled({ enabled })
+      if (!isCurrentSettingsWrite(writeToken)) return
+      set(applySnapshot(snapshot))
+      finishSettingsWrite(set, writeToken)
     } catch (error) {
-      set({ conversationSkillImportEnabled: previous })
-      finishSettingsWrite(set, writeGeneration, SETTINGS_WRITE_ERRORS.conversationSkillImport)
+      if (isCurrentSettingsWrite(writeToken)) set({ conversationSkillImportEnabled: previous })
+      finishSettingsWrite(set, writeToken, SETTINGS_WRITE_ERRORS.conversationSkillImport)
       console.error('Failed to set conversation Skill import enabled', error)
     }
   },
 
   setClosePreference: async (preference) => {
-    const writeGeneration = beginSettingsWrite()
+    const writeToken = beginSettingsWrite('closePreference')
     const previous = get().closePreference
-    set({ closePreference: preference, settingsWriteError: undefined })
+    set({ closePreference: preference })
 
     try {
-      set(applySnapshot(await window.api.settings.setClosePreference({ preference })))
-      finishSettingsWrite(set, writeGeneration)
+      const snapshot = await window.api.settings.setClosePreference({ preference })
+      if (!isCurrentSettingsWrite(writeToken)) return
+      set(applySnapshot(snapshot))
+      finishSettingsWrite(set, writeToken)
     } catch (error) {
-      set({ closePreference: previous })
-      finishSettingsWrite(set, writeGeneration, SETTINGS_WRITE_ERRORS.closePreference)
+      if (isCurrentSettingsWrite(writeToken)) set({ closePreference: previous })
+      finishSettingsWrite(set, writeToken, SETTINGS_WRITE_ERRORS.closePreference)
       console.error('Failed to set close preference', error)
     }
   },
@@ -1107,21 +1167,26 @@ export const useSettingsStore = create<SettingsStore>((set, get) => ({
   // Sets the app-icon look. Optimistic like the other preference setters: apply the pick, reconcile
   // from the returned snapshot, and revert if the write fails.
   setAppIconVariant: async (variant) => {
-    const writeGeneration = beginSettingsWrite()
+    const writeToken = beginSettingsWrite('appIcon')
     const previous = get().appIconVariant
-    set({ appIconVariant: variant, settingsWriteError: undefined })
+    set({ appIconVariant: variant })
 
     try {
-      set(applySnapshot(await window.api.settings.setAppIconVariant({ variant })))
-      finishSettingsWrite(set, writeGeneration)
+      const snapshot = await window.api.settings.setAppIconVariant({ variant })
+      if (!isCurrentSettingsWrite(writeToken)) return
+      set(applySnapshot(snapshot))
+      finishSettingsWrite(set, writeToken)
     } catch (error) {
-      set({ appIconVariant: previous })
-      finishSettingsWrite(set, writeGeneration, SETTINGS_WRITE_ERRORS.appIcon)
+      if (isCurrentSettingsWrite(writeToken)) set({ appIconVariant: previous })
+      finishSettingsWrite(set, writeToken, SETTINGS_WRITE_ERRORS.appIcon)
       console.error('Failed to set app icon variant', error)
     }
   },
 
-  clearSettingsWriteError: () => set({ settingsWriteError: undefined }),
+  clearSettingsWriteError: () => {
+    settingsWriteFailures.clear()
+    set({ settingsWriteError: undefined })
+  },
 
   // Detects the opencode executable and refreshes its status card.
   detectOpencode: async () => {

--- a/src/renderer/src/stores/settings-store.ts
+++ b/src/renderer/src/stores/settings-store.ts
@@ -585,6 +585,7 @@ const resolveUpsertedProviderId = (
 }
 
 let settingsLoadPromise: Promise<boolean> | undefined
+let settingsWriteGeneration = 0
 const SAFE_SETTINGS_LOAD_ERROR = 'Open Science could not load settings. Retry to continue.'
 
 // Keep raw IPC diagnostics in the developer channel while renderer state remains path-safe.
@@ -592,11 +593,29 @@ const reportSettingsLoadError = (error: unknown): void => {
   console.warn('Settings startup loading failed', error)
 }
 
-// Keep the action-specific summary stable while preserving an actionable IPC message when one exists.
-// Raw failures remain in the console for diagnostics; non-Error payloads never leak into the UI.
-const describeSettingsWriteError = (summary: string, error: unknown): string => {
-  const detail = error instanceof Error ? error.message.trim() : ''
-  return detail ? `${summary} ${detail}` : summary
+// Visible copy stays stable and path-safe; raw IPC failures remain in the console for diagnostics.
+const SETTINGS_WRITE_ERRORS = {
+  agentFramework: 'Could not switch agent framework. Try again.',
+  reasoningEffort: 'Could not save reasoning effort. Try again.',
+  notifications: 'Could not save notification preference. Try again.',
+  conversationSkillImport: 'Could not save conversation Skill import preference. Try again.',
+  closePreference: 'Could not save window close preference. Try again.',
+  appIcon: 'Could not save app icon preference. Try again.'
+} as const
+
+// Shared banner ownership follows user intent order, not network completion order. A late result from
+// an older write must never clear or replace the outcome of a newer Settings action.
+const beginSettingsWrite = (): number => {
+  settingsWriteGeneration += 1
+  return settingsWriteGeneration
+}
+
+const finishSettingsWrite = (
+  set: StoreApi<SettingsStore>['setState'],
+  generation: number,
+  error?: string
+): void => {
+  if (generation === settingsWriteGeneration) set({ settingsWriteError: error })
 }
 
 // Renderer cache of the main-process settings service. The main process stays the source of truth
@@ -987,20 +1006,20 @@ export const useSettingsStore = create<SettingsStore>((set, get) => ({
   // Switches the agent backend; main reconnects so the choice applies on the next prompt. A failed
   // write leaves the previous framework selected and feeds the shared Settings error banner.
   setAgentFramework: async (id) => {
+    const writeGeneration = beginSettingsWrite()
     set({ settingsWriteError: undefined })
 
     let snapshot: SettingsSnapshot
     try {
       snapshot = await window.api.settings.setAgentFramework({ id })
     } catch (error) {
-      set({
-        settingsWriteError: describeSettingsWriteError('Could not switch agent framework.', error)
-      })
+      finishSettingsWrite(set, writeGeneration, SETTINGS_WRITE_ERRORS.agentFramework)
       console.error('Failed to switch agent framework', error)
       return
     }
 
     set(applySnapshot(snapshot))
+    finishSettingsWrite(set, writeGeneration)
 
     try {
       // Live-detect the newly-selected framework so a binary installed (or deleted) since the last
@@ -1024,16 +1043,16 @@ export const useSettingsStore = create<SettingsStore>((set, get) => ({
   // trip includes that reconnect, which is too slow to gate the selector on — apply the pick
   // optimistically, reconcile from the returned snapshot, and revert if the write fails.
   setReasoningEffort: async (effort) => {
+    const writeGeneration = beginSettingsWrite()
     const previous = get().reasoningEffort
     set({ reasoningEffort: effort, settingsWriteError: undefined })
 
     try {
       set(applySnapshot(await window.api.settings.setReasoningEffort({ effort })))
+      finishSettingsWrite(set, writeGeneration)
     } catch (error) {
-      set({
-        reasoningEffort: previous,
-        settingsWriteError: describeSettingsWriteError('Could not save reasoning effort.', error)
-      })
+      set({ reasoningEffort: previous })
+      finishSettingsWrite(set, writeGeneration, SETTINGS_WRITE_ERRORS.reasoningEffort)
       console.error('Failed to set reasoning effort', error)
     }
   },
@@ -1041,55 +1060,46 @@ export const useSettingsStore = create<SettingsStore>((set, get) => ({
   // Toggles desktop notifications. Optimistic like the other preference setters: apply the pick,
   // reconcile from the returned snapshot, and revert if the write fails.
   setNotificationsEnabled: async (enabled) => {
+    const writeGeneration = beginSettingsWrite()
     const previous = get().notificationsEnabled
     set({ notificationsEnabled: enabled, settingsWriteError: undefined })
 
     try {
       set(applySnapshot(await window.api.settings.setNotificationsEnabled({ enabled })))
+      finishSettingsWrite(set, writeGeneration)
     } catch (error) {
-      set({
-        notificationsEnabled: previous,
-        settingsWriteError: describeSettingsWriteError(
-          'Could not save notification preference.',
-          error
-        )
-      })
+      set({ notificationsEnabled: previous })
+      finishSettingsWrite(set, writeGeneration, SETTINGS_WRITE_ERRORS.notifications)
       console.error('Failed to set notifications enabled', error)
     }
   },
 
   setConversationSkillImportEnabled: async (enabled) => {
+    const writeGeneration = beginSettingsWrite()
     const previous = get().conversationSkillImportEnabled
     set({ conversationSkillImportEnabled: enabled, settingsWriteError: undefined })
 
     try {
       set(applySnapshot(await window.api.settings.setConversationSkillImportEnabled({ enabled })))
+      finishSettingsWrite(set, writeGeneration)
     } catch (error) {
-      set({
-        conversationSkillImportEnabled: previous,
-        settingsWriteError: describeSettingsWriteError(
-          'Could not save conversation Skill import preference.',
-          error
-        )
-      })
+      set({ conversationSkillImportEnabled: previous })
+      finishSettingsWrite(set, writeGeneration, SETTINGS_WRITE_ERRORS.conversationSkillImport)
       console.error('Failed to set conversation Skill import enabled', error)
     }
   },
 
   setClosePreference: async (preference) => {
+    const writeGeneration = beginSettingsWrite()
     const previous = get().closePreference
     set({ closePreference: preference, settingsWriteError: undefined })
 
     try {
       set(applySnapshot(await window.api.settings.setClosePreference({ preference })))
+      finishSettingsWrite(set, writeGeneration)
     } catch (error) {
-      set({
-        closePreference: previous,
-        settingsWriteError: describeSettingsWriteError(
-          'Could not save window close preference.',
-          error
-        )
-      })
+      set({ closePreference: previous })
+      finishSettingsWrite(set, writeGeneration, SETTINGS_WRITE_ERRORS.closePreference)
       console.error('Failed to set close preference', error)
     }
   },
@@ -1097,16 +1107,16 @@ export const useSettingsStore = create<SettingsStore>((set, get) => ({
   // Sets the app-icon look. Optimistic like the other preference setters: apply the pick, reconcile
   // from the returned snapshot, and revert if the write fails.
   setAppIconVariant: async (variant) => {
+    const writeGeneration = beginSettingsWrite()
     const previous = get().appIconVariant
     set({ appIconVariant: variant, settingsWriteError: undefined })
 
     try {
       set(applySnapshot(await window.api.settings.setAppIconVariant({ variant })))
+      finishSettingsWrite(set, writeGeneration)
     } catch (error) {
-      set({
-        appIconVariant: previous,
-        settingsWriteError: describeSettingsWriteError('Could not save app icon preference.', error)
-      })
+      set({ appIconVariant: previous })
+      finishSettingsWrite(set, writeGeneration, SETTINGS_WRITE_ERRORS.appIcon)
       console.error('Failed to set app icon variant', error)
     }
   },

--- a/src/renderer/src/stores/settings-store.ts
+++ b/src/renderer/src/stores/settings-store.ts
@@ -594,6 +594,7 @@ const reportSettingsLoadError = (error: unknown): void => {
 
 // Visible copy stays stable and path-safe; raw IPC failures remain in the console for diagnostics.
 const SETTINGS_WRITE_ERRORS = {
+  activeProvider: 'Could not switch active provider or model. Try again.',
   agentFramework: 'Could not switch agent framework. Try again.',
   reasoningEffort: 'Could not save reasoning effort. Try again.',
   notifications: 'Could not save notification preference. Try again.',
@@ -602,7 +603,7 @@ const SETTINGS_WRITE_ERRORS = {
   appIcon: 'Could not save app icon preference. Try again.'
 } as const
 
-type SettingsWriteKey = keyof typeof SETTINGS_WRITE_ERRORS | 'activeProvider'
+type SettingsWriteKey = keyof typeof SETTINGS_WRITE_ERRORS
 
 type SettingsWriteToken = {
   key: SettingsWriteKey
@@ -1044,10 +1045,17 @@ export const useSettingsStore = create<SettingsStore>((set, get) => ({
   // An empty model string is treated as "no specific model" so main uses the provider default.
   setActiveProvider: async (providerId, model) => {
     const writeToken = beginSettingsWrite('activeProvider')
-    const snapshot = await window.api.settings.setActiveProvider({
-      id: providerId,
-      model: model || undefined
-    })
+    let snapshot: SettingsSnapshot
+    try {
+      snapshot = await window.api.settings.setActiveProvider({
+        id: providerId,
+        model: model || undefined
+      })
+    } catch (error) {
+      finishSettingsWrite(set, writeToken, SETTINGS_WRITE_ERRORS.activeProvider)
+      console.error('Failed to set active provider', error)
+      throw error
+    }
 
     if (!isCurrentSettingsWrite(writeToken)) return
     set(applySnapshot(snapshot))

--- a/src/renderer/src/stores/settings-store.ts
+++ b/src/renderer/src/stores/settings-store.ts
@@ -616,8 +616,21 @@ type SettingsWriteFailure = {
   message: string
 }
 
+type OptimisticSettingsWriteKey =
+  'reasoningEffort' | 'notifications' | 'conversationSkillImport' | 'closePreference' | 'appIcon'
+
+type OptimisticSettingsWriteState<T> = {
+  confirmedValue: T
+  pendingCount: number
+}
+
 const settingsWriteGenerations = new Map<SettingsWriteKey, number>()
 const settingsWriteFailures = new Map<SettingsWriteKey, SettingsWriteFailure>()
+const settingsWriteQueues = new Map<OptimisticSettingsWriteKey, Promise<unknown>>()
+const optimisticSettingsWriteStates = new Map<
+  OptimisticSettingsWriteKey,
+  OptimisticSettingsWriteState<unknown>
+>()
 let settingsWriteFailureId = 0
 
 const currentSettingsWriteError = (): string | undefined => {
@@ -646,6 +659,58 @@ const beginSettingsWrite = (key: SettingsWriteKey): SettingsWriteToken => {
 
 const isCurrentSettingsWrite = (token: SettingsWriteToken): boolean =>
   settingsWriteGenerations.get(token.key) === token.generation
+
+// Preserve click order for one optimistic preference while unrelated preferences still write in
+// parallel. This makes the last confirmed value deterministic even when users change one control
+// repeatedly before its previous IPC round trip finishes.
+const runOptimisticSettingsWrite = async <T>(
+  key: OptimisticSettingsWriteKey,
+  write: () => Promise<T>
+): Promise<T> => {
+  const previous = settingsWriteQueues.get(key)
+  const current = previous ? previous.catch(() => undefined).then(write) : write()
+  settingsWriteQueues.set(key, current)
+
+  try {
+    return await current
+  } finally {
+    if (settingsWriteQueues.get(key) === current) settingsWriteQueues.delete(key)
+  }
+}
+
+const beginOptimisticSettingsWrite = <T>(
+  key: OptimisticSettingsWriteKey,
+  confirmedValue: T
+): { writeToken: SettingsWriteToken; optimisticState: OptimisticSettingsWriteState<T> } => {
+  let optimisticState = optimisticSettingsWriteStates.get(key) as
+    OptimisticSettingsWriteState<T> | undefined
+
+  if (!optimisticState) {
+    optimisticState = { confirmedValue, pendingCount: 0 }
+    optimisticSettingsWriteStates.set(key, optimisticState as OptimisticSettingsWriteState<unknown>)
+  }
+  optimisticState.pendingCount += 1
+
+  return { writeToken: beginSettingsWrite(key), optimisticState }
+}
+
+const completeOptimisticSettingsWrite = <T>(
+  key: OptimisticSettingsWriteKey,
+  optimisticState: OptimisticSettingsWriteState<T>,
+  confirmedValue?: { value: T }
+): T => {
+  if (confirmedValue) optimisticState.confirmedValue = confirmedValue.value
+  optimisticState.pendingCount -= 1
+
+  if (
+    optimisticState.pendingCount === 0 &&
+    optimisticSettingsWriteStates.get(key) === optimisticState
+  ) {
+    optimisticSettingsWriteStates.delete(key)
+  }
+
+  return optimisticState.confirmedValue
+}
 
 const finishSettingsWrite = (
   set: StoreApi<SettingsStore>['setState'],
@@ -1103,17 +1168,26 @@ export const useSettingsStore = create<SettingsStore>((set, get) => ({
   // trip includes that reconnect, which is too slow to gate the selector on — apply the pick
   // optimistically, reconcile from the returned snapshot, and revert if the write fails.
   setReasoningEffort: async (effort) => {
-    const writeToken = beginSettingsWrite('reasoningEffort')
     const previous = get().reasoningEffort
+    const { writeToken, optimisticState } = beginOptimisticSettingsWrite(
+      'reasoningEffort',
+      previous
+    )
     set({ reasoningEffort: effort })
 
     try {
-      const snapshot = await window.api.settings.setReasoningEffort({ effort })
+      const snapshot = await runOptimisticSettingsWrite('reasoningEffort', () =>
+        window.api.settings.setReasoningEffort({ effort })
+      )
+      completeOptimisticSettingsWrite('reasoningEffort', optimisticState, {
+        value: snapshot.reasoningEffort
+      })
       if (!isCurrentSettingsWrite(writeToken)) return
       set(applySnapshot(snapshot))
       finishSettingsWrite(set, writeToken)
     } catch (error) {
-      if (isCurrentSettingsWrite(writeToken)) set({ reasoningEffort: previous })
+      const confirmedValue = completeOptimisticSettingsWrite('reasoningEffort', optimisticState)
+      if (isCurrentSettingsWrite(writeToken)) set({ reasoningEffort: confirmedValue })
       finishSettingsWrite(set, writeToken, SETTINGS_WRITE_ERRORS.reasoningEffort)
       console.error('Failed to set reasoning effort', error)
     }
@@ -1122,51 +1196,80 @@ export const useSettingsStore = create<SettingsStore>((set, get) => ({
   // Toggles desktop notifications. Optimistic like the other preference setters: apply the pick,
   // reconcile from the returned snapshot, and revert if the write fails.
   setNotificationsEnabled: async (enabled) => {
-    const writeToken = beginSettingsWrite('notifications')
     const previous = get().notificationsEnabled
+    const { writeToken, optimisticState } = beginOptimisticSettingsWrite('notifications', previous)
     set({ notificationsEnabled: enabled })
 
     try {
-      const snapshot = await window.api.settings.setNotificationsEnabled({ enabled })
+      const snapshot = await runOptimisticSettingsWrite('notifications', () =>
+        window.api.settings.setNotificationsEnabled({ enabled })
+      )
+      completeOptimisticSettingsWrite('notifications', optimisticState, {
+        value: snapshot.notificationsEnabled
+      })
       if (!isCurrentSettingsWrite(writeToken)) return
       set(applySnapshot(snapshot))
       finishSettingsWrite(set, writeToken)
     } catch (error) {
-      if (isCurrentSettingsWrite(writeToken)) set({ notificationsEnabled: previous })
+      const confirmedValue = completeOptimisticSettingsWrite('notifications', optimisticState)
+      if (isCurrentSettingsWrite(writeToken)) set({ notificationsEnabled: confirmedValue })
       finishSettingsWrite(set, writeToken, SETTINGS_WRITE_ERRORS.notifications)
       console.error('Failed to set notifications enabled', error)
     }
   },
 
   setConversationSkillImportEnabled: async (enabled) => {
-    const writeToken = beginSettingsWrite('conversationSkillImport')
     const previous = get().conversationSkillImportEnabled
+    const { writeToken, optimisticState } = beginOptimisticSettingsWrite(
+      'conversationSkillImport',
+      previous
+    )
     set({ conversationSkillImportEnabled: enabled })
 
     try {
-      const snapshot = await window.api.settings.setConversationSkillImportEnabled({ enabled })
+      const snapshot = await runOptimisticSettingsWrite('conversationSkillImport', () =>
+        window.api.settings.setConversationSkillImportEnabled({ enabled })
+      )
+      completeOptimisticSettingsWrite('conversationSkillImport', optimisticState, {
+        value: snapshot.conversationSkillImportEnabled
+      })
       if (!isCurrentSettingsWrite(writeToken)) return
       set(applySnapshot(snapshot))
       finishSettingsWrite(set, writeToken)
     } catch (error) {
-      if (isCurrentSettingsWrite(writeToken)) set({ conversationSkillImportEnabled: previous })
+      const confirmedValue = completeOptimisticSettingsWrite(
+        'conversationSkillImport',
+        optimisticState
+      )
+      if (isCurrentSettingsWrite(writeToken)) {
+        set({ conversationSkillImportEnabled: confirmedValue })
+      }
       finishSettingsWrite(set, writeToken, SETTINGS_WRITE_ERRORS.conversationSkillImport)
       console.error('Failed to set conversation Skill import enabled', error)
     }
   },
 
   setClosePreference: async (preference) => {
-    const writeToken = beginSettingsWrite('closePreference')
     const previous = get().closePreference
+    const { writeToken, optimisticState } = beginOptimisticSettingsWrite(
+      'closePreference',
+      previous
+    )
     set({ closePreference: preference })
 
     try {
-      const snapshot = await window.api.settings.setClosePreference({ preference })
+      const snapshot = await runOptimisticSettingsWrite('closePreference', () =>
+        window.api.settings.setClosePreference({ preference })
+      )
+      completeOptimisticSettingsWrite('closePreference', optimisticState, {
+        value: snapshot.closePreference
+      })
       if (!isCurrentSettingsWrite(writeToken)) return
       set(applySnapshot(snapshot))
       finishSettingsWrite(set, writeToken)
     } catch (error) {
-      if (isCurrentSettingsWrite(writeToken)) set({ closePreference: previous })
+      const confirmedValue = completeOptimisticSettingsWrite('closePreference', optimisticState)
+      if (isCurrentSettingsWrite(writeToken)) set({ closePreference: confirmedValue })
       finishSettingsWrite(set, writeToken, SETTINGS_WRITE_ERRORS.closePreference)
       console.error('Failed to set close preference', error)
     }
@@ -1175,17 +1278,23 @@ export const useSettingsStore = create<SettingsStore>((set, get) => ({
   // Sets the app-icon look. Optimistic like the other preference setters: apply the pick, reconcile
   // from the returned snapshot, and revert if the write fails.
   setAppIconVariant: async (variant) => {
-    const writeToken = beginSettingsWrite('appIcon')
     const previous = get().appIconVariant
+    const { writeToken, optimisticState } = beginOptimisticSettingsWrite('appIcon', previous)
     set({ appIconVariant: variant })
 
     try {
-      const snapshot = await window.api.settings.setAppIconVariant({ variant })
+      const snapshot = await runOptimisticSettingsWrite('appIcon', () =>
+        window.api.settings.setAppIconVariant({ variant })
+      )
+      completeOptimisticSettingsWrite('appIcon', optimisticState, {
+        value: snapshot.appIconVariant
+      })
       if (!isCurrentSettingsWrite(writeToken)) return
       set(applySnapshot(snapshot))
       finishSettingsWrite(set, writeToken)
     } catch (error) {
-      if (isCurrentSettingsWrite(writeToken)) set({ appIconVariant: previous })
+      const confirmedValue = completeOptimisticSettingsWrite('appIcon', optimisticState)
+      if (isCurrentSettingsWrite(writeToken)) set({ appIconVariant: confirmedValue })
       finishSettingsWrite(set, writeToken, SETTINGS_WRITE_ERRORS.appIcon)
       console.error('Failed to set app icon variant', error)
     }


### PR DESCRIPTION
## Problem

Several Settings preferences optimistically rolled back after a failed write, but the failure was only logged to the console. Users could see their selection revert without an actionable explanation.

## Proposed change

- Add transient Settings write-error state with safe, preference-specific user-facing copy while preserving raw errors in the console.
- Cover agent framework, reasoning effort, notifications, conversation Skill import, window close behavior, and app icon writes.
- Keep the existing optimistic rollback behavior where applicable.
- Show a fixed inline danger alert below the Settings header. The alert is dismissible, exposes `role="alert"`, and provides a tooltip for its icon-only dismiss action.
- Track write generations per preference: stale work for the same preference cannot overwrite the latest value, while failures from different concurrent preferences remain visible together.
- Serialize persistence for repeated optimistic writes to the same preference while keeping the UI update immediate; failures restore the last confirmed value, including all-failure and earlier-success/later-failure sequences.
- Clear only errors that were already visible when a later Settings write began and then succeeded; a different failure arriving while that write is pending remains visible.
- Include successful active-provider/model writes in the shared lifecycle so they clear an existing stale preference error.
- Record active-provider/model failures with safe copy, preserve rejection semantics for awaited callers, and explicitly consume already-recorded failures at fire-and-forget model selectors.
- Keep framework status refresh failures separate from successful framework writes to avoid false save-failure feedback.
- Preserve framework write rejection semantics. Onboarding invalidates the old readiness result before switching and stops without checking the old framework when persistence fails.

## Scope and non-goals

- No architecture, data model, data relationship, persistence format, or IPC contract changes.
- No success toast or new notification infrastructure.

## Acceptance criteria and validation

The following checks ran after the last material edit:

- Settings write failures display an actionable alert and preserve or restore the expected preference state -> focused store, Settings page, model-selector, composer, and onboarding tests -> 5 files and 184 tests passed.
- The alert is placed above the scrolling content, uses the existing danger treatment, is announced as an alert, exposes a dismiss tooltip, and clears on dismissal -> the focused test set passed.
- Node and renderer TypeScript remain valid -> `npm run typecheck` passed.
- Repository lint rules remain satisfied -> `npm run lint` completed with 0 errors and 23 pre-existing warnings; changed Settings files added no warnings.
- The complete repository suite remains green -> `npm test` -> 609 files passed, 11 skipped; 9,084 tests passed, 140 skipped.
- Patch formatting is clean -> `git diff --check origin/main...HEAD` passed.

Known scope trade-off: callers that invoke these setters while the Settings dialog is closed still do not render this banner. App-level or caller-specific feedback is intentionally deferred so this focused fix does not change onboarding or workspace interaction patterns.

## Review focus

- Whether all in-scope preference writes set safe feedback without exposing raw IPC details.
- Whether latest-write ownership matches the expected behavior for overlapping Settings writes.
- Alert placement, accessibility, dismissal, and consistency with the existing Settings design.
