### PR TITLE
refactor(main): introduce caller context and client leases

### DIFF
--- a/src/main/caller-context.test.ts
+++ b/src/main/caller-context.test.ts
@@ -1,0 +1,103 @@
+import { describe, expect, it, vi } from 'vitest'
+
+import {
+  ClientLeaseRegistry,
+  canSatisfyHumanApproval,
+  createCallerContext,
+  createElectronCallerContext,
+  createTaskCallerContext,
+  createWebCallerContext,
+  hasCallerAuthority
+} from './caller-context'
+
+describe('caller context', () => {
+  it('preserves current lifecycle client ids across Electron, Web, and Task surfaces', () => {
+    expect(createElectronCallerContext(7)).toMatchObject({
+      clientId: '7',
+      lifecycleClientId: 'electron:7',
+      leaseId: 'electron:7',
+      surface: 'electron',
+      location: 'local',
+      principalKind: 'human',
+      actionOrigin: 'human'
+    })
+    expect(createWebCallerContext('browser-1')).toMatchObject({
+      clientId: 'browser-1',
+      lifecycleClientId: 'web:browser-1',
+      leaseId: 'browser-1',
+      surface: 'web',
+      location: 'local',
+      principalKind: 'human',
+      actionOrigin: 'human'
+    })
+    expect(createTaskCallerContext()).toMatchObject({
+      clientId: 'headless-task-api',
+      lifecycleClientId: 'web:headless-task-api',
+      leaseId: 'headless-task-api',
+      surface: 'task',
+      location: 'local',
+      principalKind: 'automation',
+      actionOrigin: 'automation'
+    })
+  })
+
+  it('keeps remote authority narrow and tied to authorization freshness', () => {
+    let current = true
+    const context = createWebCallerContext('browser-1', {
+      location: 'remote',
+      authorities: ['manage-remote-pairing'],
+      isAuthorizationCurrent: () => current
+    })
+
+    expect(hasCallerAuthority(context, 'manage-remote-pairing')).toBe(true)
+    current = false
+    expect(hasCallerAuthority(context, 'manage-remote-pairing')).toBe(false)
+  })
+
+  it('never treats an agent-originated action as a human approval', () => {
+    const context = createCallerContext({
+      clientId: 'coordinator-host',
+      lifecycleClientId: 'web:coordinator-host',
+      leaseId: 'coordinator-host',
+      surface: 'web',
+      location: 'local',
+      principalKind: 'human',
+      actionOrigin: 'agent-session'
+    })
+
+    expect(canSatisfyHumanApproval(context)).toBe(false)
+  })
+})
+
+describe('ClientLeaseRegistry', () => {
+  it('releases client-scoped resources once after the final connection closes', () => {
+    const releaseClient = vi.fn()
+    const registry = new ClientLeaseRegistry(releaseClient)
+    const first = registry.acquire('browser-1')
+    const second = registry.acquire('browser-1')
+
+    first.release()
+    first.release()
+    expect(releaseClient).not.toHaveBeenCalled()
+
+    second.release()
+    second.release()
+    expect(releaseClient).toHaveBeenCalledOnce()
+    expect(releaseClient).toHaveBeenCalledWith('browser-1')
+  })
+
+  it('disposes each active client once and makes outstanding leases inert', () => {
+    const releaseClient = vi.fn()
+    const registry = new ClientLeaseRegistry(releaseClient)
+    const first = registry.acquire('browser-1')
+    registry.acquire('browser-1')
+    const other = registry.acquire('browser-2')
+
+    registry.dispose()
+    registry.dispose()
+    first.release()
+    other.release()
+
+    expect(releaseClient.mock.calls).toEqual([['browser-1'], ['browser-2']])
+  })
+})

--- a/src/main/caller-context.test.ts
+++ b/src/main/caller-context.test.ts
@@ -80,10 +80,13 @@ describe('caller context', () => {
   })
 
   it('fails closed when a synthetic negative sender omits its adapter context', () => {
-    const context = callerContextForEvent({ sender: { id: -1 } })
+    const context = callerContextForEvent({
+      sender: { id: -1, lifecycleClientId: 'web:legacy-browser' }
+    })
 
     expect(context.surface).toBe('web')
     expect(context.principalKind).toBe('automation')
+    expect(context.lifecycleClientId).toBe('web:legacy-browser')
     expect(canSatisfyHumanApproval(context)).toBe(false)
   })
 })

--- a/src/main/caller-context.test.ts
+++ b/src/main/caller-context.test.ts
@@ -2,6 +2,7 @@ import { describe, expect, it, vi } from 'vitest'
 
 import {
   ClientLeaseRegistry,
+  callerContextForEvent,
   canSatisfyHumanApproval,
   createCallerContext,
   createElectronCallerContext,
@@ -65,6 +66,24 @@ describe('caller context', () => {
       actionOrigin: 'agent-session'
     })
 
+    expect(canSatisfyHumanApproval(context)).toBe(false)
+  })
+
+  it('derives one stable Electron context and accepts an adapter-owned Web context', () => {
+    const sender = { id: 7 }
+    const first = callerContextForEvent({ sender })
+    expect(callerContextForEvent({ sender })).toBe(first)
+    expect(first.lifecycleClientId).toBe('electron:7')
+
+    const web = createWebCallerContext('browser-1')
+    expect(callerContextForEvent({ sender: { id: -1, callerContext: web } })).toBe(web)
+  })
+
+  it('fails closed when a synthetic negative sender omits its adapter context', () => {
+    const context = callerContextForEvent({ sender: { id: -1 } })
+
+    expect(context.surface).toBe('web')
+    expect(context.principalKind).toBe('automation')
     expect(canSatisfyHumanApproval(context)).toBe(false)
   })
 })

--- a/src/main/caller-context.ts
+++ b/src/main/caller-context.ts
@@ -92,6 +92,7 @@ type CallerEvent = {
   sender: {
     id: number
     callerContext?: CallerContext
+    lifecycleClientId?: string
   }
 }
 
@@ -106,9 +107,9 @@ const callerContextForEvent = (event: CallerEvent): CallerContext => {
     event.sender.id > 0
       ? createElectronCallerContext(event.sender.id)
       : createCallerContext({
-          clientId: String(event.sender.id),
-          lifecycleClientId: `electron:${event.sender.id}`,
-          leaseId: `electron:${event.sender.id}`,
+          clientId: event.sender.lifecycleClientId?.replace(/^web:/, '') ?? String(event.sender.id),
+          lifecycleClientId: event.sender.lifecycleClientId ?? `electron:${event.sender.id}`,
+          leaseId: event.sender.lifecycleClientId?.replace(/^web:/, '') ?? String(event.sender.id),
           surface: 'web',
           location: 'remote',
           principalKind: 'automation',

--- a/src/main/caller-context.ts
+++ b/src/main/caller-context.ts
@@ -28,6 +28,10 @@ type CreateWebCallerContextOptions = Partial<
   isAuthorizationCurrent?: () => boolean
 }
 
+type CreateTaskCallerContextOptions = Partial<Pick<CallerContext, 'location'>> & {
+  isAuthorizationCurrent?: () => boolean
+}
+
 const alwaysCurrent = (): boolean => true
 
 const createCallerContext = (input: CreateCallerContextInput): CallerContext =>
@@ -64,15 +68,16 @@ const createWebCallerContext = (
     isAuthorizationCurrent: options.isAuthorizationCurrent
   })
 
-const createTaskCallerContext = (): CallerContext =>
+const createTaskCallerContext = (options: CreateTaskCallerContextOptions = {}): CallerContext =>
   createCallerContext({
     clientId: 'headless-task-api',
     lifecycleClientId: 'web:headless-task-api',
     leaseId: 'headless-task-api',
     surface: 'task',
-    location: 'local',
+    location: options.location ?? 'local',
     principalKind: 'automation',
-    actionOrigin: 'automation'
+    actionOrigin: 'automation',
+    isAuthorizationCurrent: options.isAuthorizationCurrent
   })
 
 const hasCallerAuthority = (context: CallerContext, authority: CallerAuthority): boolean =>

--- a/src/main/caller-context.ts
+++ b/src/main/caller-context.ts
@@ -1,0 +1,142 @@
+export type CallerSurface = 'electron' | 'web' | 'task'
+export type CallerLocation = 'local' | 'remote'
+export type CallerPrincipalKind = 'human' | 'automation' | 'agent-session'
+export type CallerActionOrigin = 'human' | 'automation' | 'agent-session'
+export type CallerAuthority = 'manage-remote-pairing'
+
+export type CallerContext = Readonly<{
+  clientId: string
+  lifecycleClientId: string
+  leaseId: string
+  surface: CallerSurface
+  location: CallerLocation
+  principalKind: CallerPrincipalKind
+  actionOrigin: CallerActionOrigin
+  authorities: readonly CallerAuthority[]
+  isAuthorizationCurrent: () => boolean
+}>
+
+type CreateCallerContextInput = Omit<CallerContext, 'authorities' | 'isAuthorizationCurrent'> & {
+  authorities?: readonly CallerAuthority[]
+  isAuthorizationCurrent?: () => boolean
+}
+
+type CreateWebCallerContextOptions = Partial<
+  Pick<CallerContext, 'location' | 'principalKind' | 'actionOrigin'>
+> & {
+  authorities?: readonly CallerAuthority[]
+  isAuthorizationCurrent?: () => boolean
+}
+
+const alwaysCurrent = (): boolean => true
+
+const createCallerContext = (input: CreateCallerContextInput): CallerContext =>
+  Object.freeze({
+    ...input,
+    authorities: Object.freeze([...new Set(input.authorities ?? [])]),
+    isAuthorizationCurrent: input.isAuthorizationCurrent ?? alwaysCurrent
+  })
+
+const createElectronCallerContext = (senderId: number): CallerContext =>
+  createCallerContext({
+    clientId: String(senderId),
+    lifecycleClientId: `electron:${senderId}`,
+    leaseId: `electron:${senderId}`,
+    surface: 'electron',
+    location: 'local',
+    principalKind: 'human',
+    actionOrigin: 'human'
+  })
+
+const createWebCallerContext = (
+  clientId: string,
+  options: CreateWebCallerContextOptions = {}
+): CallerContext =>
+  createCallerContext({
+    clientId,
+    lifecycleClientId: `web:${clientId}`,
+    leaseId: clientId,
+    surface: 'web',
+    location: options.location ?? 'local',
+    principalKind: options.principalKind ?? 'human',
+    actionOrigin: options.actionOrigin ?? 'human',
+    authorities: options.authorities,
+    isAuthorizationCurrent: options.isAuthorizationCurrent
+  })
+
+const createTaskCallerContext = (): CallerContext =>
+  createCallerContext({
+    clientId: 'headless-task-api',
+    lifecycleClientId: 'web:headless-task-api',
+    leaseId: 'headless-task-api',
+    surface: 'task',
+    location: 'local',
+    principalKind: 'automation',
+    actionOrigin: 'automation'
+  })
+
+const hasCallerAuthority = (context: CallerContext, authority: CallerAuthority): boolean =>
+  context.isAuthorizationCurrent() && context.authorities.includes(authority)
+
+const canSatisfyHumanApproval = (context: CallerContext): boolean =>
+  context.isAuthorizationCurrent() &&
+  context.principalKind === 'human' &&
+  context.actionOrigin === 'human'
+
+export type ClientLease = Readonly<{
+  clientId: string
+  release: () => void
+}>
+
+export class ClientLeaseRegistry {
+  private readonly leasesByClient = new Map<string, Set<symbol>>()
+  private disposed = false
+
+  constructor(private readonly releaseClient: (clientId: string) => void) {}
+
+  acquire(clientId: string): ClientLease {
+    if (this.disposed) throw new Error('Client lease registry is disposed.')
+    const token = Symbol(clientId)
+    const leases = this.leasesByClient.get(clientId) ?? new Set<symbol>()
+    leases.add(token)
+    this.leasesByClient.set(clientId, leases)
+    let released = false
+
+    return Object.freeze({
+      clientId,
+      release: () => {
+        if (released) return
+        released = true
+        const active = this.leasesByClient.get(clientId)
+        if (!active?.delete(token) || active.size > 0) return
+        this.leasesByClient.delete(clientId)
+        this.releaseClient(clientId)
+      }
+    })
+  }
+
+  dispose(): void {
+    if (this.disposed) return
+    this.disposed = true
+    const clientIds = [...this.leasesByClient.keys()]
+    this.leasesByClient.clear()
+    const failures: unknown[] = []
+    for (const clientId of clientIds) {
+      try {
+        this.releaseClient(clientId)
+      } catch (error) {
+        failures.push(error)
+      }
+    }
+    if (failures.length > 0) throw new AggregateError(failures, 'Client lease cleanup failed.')
+  }
+}
+
+export {
+  canSatisfyHumanApproval,
+  createCallerContext,
+  createElectronCallerContext,
+  createTaskCallerContext,
+  createWebCallerContext,
+  hasCallerAuthority
+}

--- a/src/main/caller-context.ts
+++ b/src/main/caller-context.ts
@@ -88,6 +88,36 @@ export type ClientLease = Readonly<{
   release: () => void
 }>
 
+type CallerEvent = {
+  sender: {
+    id: number
+    callerContext?: CallerContext
+  }
+}
+
+const nativeCallerContexts = new WeakMap<object, CallerContext>()
+
+const callerContextForEvent = (event: CallerEvent): CallerContext => {
+  if (event.sender.callerContext) return event.sender.callerContext
+  const sender = event.sender as object
+  const existing = nativeCallerContexts.get(sender)
+  if (existing) return existing
+  const context =
+    event.sender.id > 0
+      ? createElectronCallerContext(event.sender.id)
+      : createCallerContext({
+          clientId: String(event.sender.id),
+          lifecycleClientId: `electron:${event.sender.id}`,
+          leaseId: `electron:${event.sender.id}`,
+          surface: 'web',
+          location: 'remote',
+          principalKind: 'automation',
+          actionOrigin: 'automation'
+        })
+  nativeCallerContexts.set(sender, context)
+  return context
+}
+
 export class ClientLeaseRegistry {
   private readonly leasesByClient = new Map<string, Set<symbol>>()
   private disposed = false
@@ -133,6 +163,7 @@ export class ClientLeaseRegistry {
 }
 
 export {
+  callerContextForEvent,
   canSatisfyHumanApproval,
   createCallerContext,
   createElectronCallerContext,

--- a/src/main/ipc-handler-registry.test.ts
+++ b/src/main/ipc-handler-registry.test.ts
@@ -95,6 +95,41 @@ describe('createIpcHandlerRegistry', () => {
     ).resolves.toBe(false)
   })
 
+  it('does not leak authority between concurrent calls from the same Web client', async () => {
+    const registry = createIpcHandlerRegistry({ handle: vi.fn() } as never)
+    let resumeFirst!: () => void
+    const firstPaused = new Promise<void>((resolve) => {
+      resumeFirst = resolve
+    })
+    registry.ipcMainHandle(
+      'remote-access:get-snapshot',
+      async (event: unknown, request: { pause?: boolean }) => {
+        if (request.pause) await firstPaused
+        return (
+          event as { sender: { callerContext: { authorities: readonly string[] } } }
+        ).sender.callerContext.authorities.includes('manage-remote-pairing')
+      }
+    )
+
+    const trusted = registry.webRpc.invoke(
+      'remote-access:get-snapshot',
+      createWebCallerContext('browser-1', {
+        location: 'remote',
+        authorities: ['manage-remote-pairing']
+      }),
+      [{ pause: true }]
+    )
+    await expect(
+      registry.webRpc.invoke(
+        'remote-access:get-snapshot',
+        createWebCallerContext('browser-1', { location: 'remote' }),
+        [{}]
+      )
+    ).resolves.toBe(false)
+    resumeFirst()
+    await expect(trusted).resolves.toBe(true)
+  })
+
   it('rejects a caller whose authorization became stale before dispatch', async () => {
     const registry = createIpcHandlerRegistry({ handle: vi.fn() } as never)
     const handler = vi.fn()

--- a/src/main/ipc-handler-registry.test.ts
+++ b/src/main/ipc-handler-registry.test.ts
@@ -1,5 +1,6 @@
 import { describe, expect, it, vi } from 'vitest'
 
+import { createWebCallerContext } from './caller-context'
 import { createIpcHandlerRegistry } from './ipc-handler-registry'
 
 describe('createIpcHandlerRegistry', () => {
@@ -16,11 +17,11 @@ describe('createIpcHandlerRegistry', () => {
     expect([...nativeHandlers.keys()]).toEqual(['projects:list', 'test:unsafe'])
     expect(registry.webRpc.channels()).toEqual(['projects:list'])
     await expect(
-      registry.webRpc.invoke('projects:list', 'client-a', [{ page: 1 }])
+      registry.webRpc.invoke('projects:list', createWebCallerContext('client-a'), [{ page: 1 }])
     ).resolves.toEqual({ request: { page: 1 } })
-    await expect(registry.webRpc.invoke('test:unsafe', 'client-a', [])).rejects.toThrow(
-      'Unknown Web RPC channel'
-    )
+    await expect(
+      registry.webRpc.invoke('test:unsafe', createWebCallerContext('client-a'), [])
+    ).rejects.toThrow('Unknown Web RPC channel')
   })
 
   it('uses stable lifecycle senders and releases them without patching ipcMain.handle', async () => {
@@ -41,11 +42,19 @@ describe('createIpcHandlerRegistry', () => {
       return { senderId: sender.id, lifecycleClientId: sender.lifecycleClientId }
     })
 
-    const first = (await registry.webRpc.invoke('projects:list', 'browser-1', [])) as {
+    const first = (await registry.webRpc.invoke(
+      'projects:list',
+      createWebCallerContext('browser-1'),
+      []
+    )) as {
       senderId: number
       lifecycleClientId: string
     }
-    const second = (await registry.webRpc.invoke('projects:list', 'browser-1', [])) as typeof first
+    const second = (await registry.webRpc.invoke(
+      'projects:list',
+      createWebCallerContext('browser-1'),
+      []
+    )) as typeof first
     expect(second.senderId).toBe(first.senderId)
     expect(first.lifecycleClientId).toBe('web:browser-1')
 
@@ -54,7 +63,7 @@ describe('createIpcHandlerRegistry', () => {
 
     const reconnected = (await registry.webRpc.invoke(
       'projects:list',
-      'browser-1',
+      createWebCallerContext('browser-1'),
       []
     )) as typeof first
     expect(reconnected.senderId).not.toBe(first.senderId)
@@ -65,20 +74,39 @@ describe('createIpcHandlerRegistry', () => {
 
   it('scopes remote pairing authority to the current Web RPC invocation', async () => {
     const registry = createIpcHandlerRegistry({ handle: vi.fn() } as never)
-    registry.ipcMainHandle(
-      'remote-access:get-snapshot',
-      (event: unknown) =>
-        (event as { sender: { canManageRemotePairing?: boolean } }).sender
-          .canManageRemotePairing === true
+    registry.ipcMainHandle('remote-access:get-snapshot', (event: unknown) =>
+      (
+        event as { sender: { callerContext: { authorities: readonly string[] } } }
+      ).sender.callerContext.authorities.includes('manage-remote-pairing')
     )
 
     await expect(
-      registry.webRpc.invoke('remote-access:get-snapshot', 'browser-1', [], {
-        canManageRemotePairing: true
-      })
+      registry.webRpc.invoke(
+        'remote-access:get-snapshot',
+        createWebCallerContext('browser-1', {
+          location: 'remote',
+          authorities: ['manage-remote-pairing']
+        }),
+        []
+      )
     ).resolves.toBe(true)
     await expect(
-      registry.webRpc.invoke('remote-access:get-snapshot', 'browser-1', [])
+      registry.webRpc.invoke('remote-access:get-snapshot', createWebCallerContext('browser-1'), [])
     ).resolves.toBe(false)
+  })
+
+  it('rejects a caller whose authorization became stale before dispatch', async () => {
+    const registry = createIpcHandlerRegistry({ handle: vi.fn() } as never)
+    const handler = vi.fn()
+    registry.ipcMainHandle('projects:list', handler)
+    const context = createWebCallerContext('browser-1', {
+      location: 'remote',
+      isAuthorizationCurrent: () => false
+    })
+
+    await expect(registry.webRpc.invoke('projects:list', context, [])).rejects.toThrow(
+      'authorization is no longer current'
+    )
+    expect(handler).not.toHaveBeenCalled()
   })
 })

--- a/src/main/ipc-handler-registry.ts
+++ b/src/main/ipc-handler-registry.ts
@@ -3,7 +3,7 @@ import { EventEmitter } from 'node:events'
 import { ipcMain, type IpcMain, type IpcMainInvokeEvent } from 'electron'
 
 import { isWebRpcChannel } from '../shared/web-rpc-contract'
-import type { CallerContext } from './caller-context'
+import { callerContextForEvent, hasCallerAuthority, type CallerContext } from './caller-context'
 
 type IpcHandler = Parameters<IpcMain['handle']>[1]
 
@@ -107,8 +107,7 @@ const createIpcHandlerRegistry = (target: Pick<IpcMain, 'handle'>): IpcHandlerRe
 }
 
 const isRemotePairingManagerSender = (event: IpcMainInvokeEvent): boolean =>
-  event.sender.id < 0 &&
-  (event.sender as unknown as { canManageRemotePairing?: boolean }).canManageRemotePairing === true
+  hasCallerAuthority(callerContextForEvent(event), 'manage-remote-pairing')
 
 const defaultRegistry = createIpcHandlerRegistry(ipcMain)
 

--- a/src/main/ipc-handler-registry.ts
+++ b/src/main/ipc-handler-registry.ts
@@ -3,33 +3,48 @@ import { EventEmitter } from 'node:events'
 import { ipcMain, type IpcMain, type IpcMainInvokeEvent } from 'electron'
 
 import { isWebRpcChannel } from '../shared/web-rpc-contract'
+import type { CallerContext } from './caller-context'
 
 type IpcHandler = Parameters<IpcMain['handle']>[1]
 
-class WebIpcSender extends EventEmitter {
+class WebIpcSender {
   readonly id: number
   readonly lifecycleClientId: string
-  canManageRemotePairing = false
+  readonly callerContext: CallerContext
 
-  constructor(id: number, clientId: string) {
-    super()
+  constructor(
+    id: number,
+    callerContext: CallerContext,
+    private readonly lifecycle: EventEmitter
+  ) {
     this.id = id
-    this.lifecycleClientId = `web:${clientId}`
+    this.lifecycleClientId = callerContext.lifecycleClientId
+    this.callerContext = callerContext
   }
 
-  destroy(): void {
-    this.emit('destroyed')
-    this.removeAllListeners()
+  once(event: string, listener: (...args: unknown[]) => void): this {
+    this.lifecycle.once(event, listener)
+    return this
+  }
+
+  on(event: string, listener: (...args: unknown[]) => void): this {
+    this.lifecycle.on(event, listener)
+    return this
+  }
+
+  off(event: string, listener: (...args: unknown[]) => void): this {
+    this.lifecycle.off(event, listener)
+    return this
+  }
+
+  removeListener(event: string, listener: (...args: unknown[]) => void): this {
+    this.lifecycle.removeListener(event, listener)
+    return this
   }
 }
 
 export type WebRpcRouter = {
-  invoke: (
-    channel: string,
-    clientId: string,
-    args: unknown[],
-    context?: { canManageRemotePairing?: boolean }
-  ) => Promise<unknown>
+  invoke: (channel: string, callerContext: CallerContext, args: unknown[]) => Promise<unknown>
   releaseClient: (clientId: string) => void
   dispose: () => void
   channels: () => string[]
@@ -42,15 +57,24 @@ type IpcHandlerRegistry = {
 
 const createIpcHandlerRegistry = (target: Pick<IpcMain, 'handle'>): IpcHandlerRegistry => {
   const webHandlers = new Map<string, IpcHandler>()
-  const senders = new Map<string, WebIpcSender>()
+  const clients = new Map<string, { id: number; lifecycle: EventEmitter }>()
   let nextSenderId = -1
 
-  const senderFor = (clientId: string): WebIpcSender => {
-    const existing = senders.get(clientId)
-    if (existing) return existing
-    const sender = new WebIpcSender(nextSenderId--, clientId)
-    senders.set(clientId, sender)
-    return sender
+  const senderFor = (callerContext: CallerContext): WebIpcSender => {
+    let client = clients.get(callerContext.clientId)
+    if (!client) {
+      client = { id: nextSenderId--, lifecycle: new EventEmitter() }
+      clients.set(callerContext.clientId, client)
+    }
+    return new WebIpcSender(client.id, callerContext, client.lifecycle)
+  }
+
+  const destroyClient = (clientId: string): void => {
+    const client = clients.get(clientId)
+    if (!client) return
+    clients.delete(clientId)
+    client.lifecycle.emit('destroyed')
+    client.lifecycle.removeAllListeners()
   }
 
   const ipcMainHandle: IpcMain['handle'] = (channel, listener) => {
@@ -61,22 +85,20 @@ const createIpcHandlerRegistry = (target: Pick<IpcMain, 'handle'>): IpcHandlerRe
   return {
     ipcMainHandle,
     webRpc: {
-      invoke: async (channel, clientId, args, context = {}) => {
+      invoke: async (channel, callerContext, args) => {
         if (!isWebRpcChannel(channel)) throw new Error(`Unknown Web RPC channel: ${channel}`)
         const handler = webHandlers.get(channel)
         if (!handler) throw new Error(`Unregistered Web RPC channel: ${channel}`)
-        const sender = senderFor(clientId)
-        sender.canManageRemotePairing = context.canManageRemotePairing === true
+        if (!callerContext.isAuthorizationCurrent()) {
+          throw new Error('Caller authorization is no longer current.')
+        }
+        const sender = senderFor(callerContext)
         const event = { sender } as unknown as IpcMainInvokeEvent
         return handler(event, ...args)
       },
-      releaseClient: (clientId) => {
-        senders.get(clientId)?.destroy()
-        senders.delete(clientId)
-      },
+      releaseClient: destroyClient,
       dispose: () => {
-        for (const sender of senders.values()) sender.destroy()
-        senders.clear()
+        for (const clientId of [...clients.keys()]) destroyClient(clientId)
         webHandlers.clear()
       },
       channels: () => [...webHandlers.keys()].sort()

--- a/src/main/lifecycle-broadcast.ts
+++ b/src/main/lifecycle-broadcast.ts
@@ -21,7 +21,7 @@ const broadcastLifecycleEvent = <Payload>(channel: string, payload: Payload): vo
 }
 
 const getLifecycleClientId = (event: {
-  sender: { id: number; callerContext?: CallerContext }
+  sender: { id: number; callerContext?: CallerContext; lifecycleClientId?: string }
 }): string => callerContextForEvent(event).lifecycleClientId
 
 const registerLifecycleIpcHandlers = (): void => {

--- a/src/main/lifecycle-broadcast.ts
+++ b/src/main/lifecycle-broadcast.ts
@@ -1,6 +1,7 @@
 import { ipcMainHandle } from './ipc-handler-registry'
 
 import { LIFECYCLE_CHANNELS } from '../shared/lifecycle-events'
+import { callerContextForEvent, type CallerContext } from './caller-context'
 import { createLogger } from './logger'
 import { broadcastToRenderers } from './renderer-broadcast'
 
@@ -20,8 +21,8 @@ const broadcastLifecycleEvent = <Payload>(channel: string, payload: Payload): vo
 }
 
 const getLifecycleClientId = (event: {
-  sender: { id: number; lifecycleClientId?: string }
-}): string => event.sender.lifecycleClientId ?? `electron:${event.sender.id}`
+  sender: { id: number; callerContext?: CallerContext }
+}): string => callerContextForEvent(event).lifecycleClientId
 
 const registerLifecycleIpcHandlers = (): void => {
   ipcMainHandle(LIFECYCLE_CHANNELS.clientId, (event) => getLifecycleClientId(event))

--- a/src/main/remote-access/ipc.test.ts
+++ b/src/main/remote-access/ipc.test.ts
@@ -10,12 +10,21 @@ import {
   requireDesktopSender,
   requirePairingManager
 } from './ipc'
-import { createWebCallerContext } from '../caller-context'
+import { createElectronCallerContext, createWebCallerContext } from '../caller-context'
 import { webRpc } from '../ipc-handler-registry'
 
 const eventWithSenderId = (id: number, remotePairingManager = false): IpcMainInvokeEvent =>
   ({
-    sender: { id, canManageRemotePairing: remotePairingManager }
+    sender: {
+      id,
+      callerContext:
+        id > 0
+          ? createElectronCallerContext(id)
+          : createWebCallerContext(`browser-${Math.abs(id)}`, {
+              location: 'remote',
+              authorities: remotePairingManager ? ['manage-remote-pairing'] : []
+            })
+    }
   }) as unknown as IpcMainInvokeEvent
 
 describe('remote access IPC authorization', () => {

--- a/src/main/remote-access/ipc.test.ts
+++ b/src/main/remote-access/ipc.test.ts
@@ -10,6 +10,7 @@ import {
   requireDesktopSender,
   requirePairingManager
 } from './ipc'
+import { createWebCallerContext } from '../caller-context'
 import { webRpc } from '../ipc-handler-registry'
 
 const eventWithSenderId = (id: number, remotePairingManager = false): IpcMainInvokeEvent =>
@@ -33,9 +34,9 @@ describe('remote access IPC authorization', () => {
         'remote-access:set-mode'
       ])
     )
-    await expect(webRpc.invoke('remote-access:get-snapshot', 'browser-1', [])).resolves.toEqual({
-      mode: 'off'
-    })
+    await expect(
+      webRpc.invoke('remote-access:get-snapshot', createWebCallerContext('browser-1'), [])
+    ).resolves.toEqual({ mode: 'off' })
     expect(snapshot).toHaveBeenCalledWith(false, false)
   })
 

--- a/src/main/remote-access/ipc.ts
+++ b/src/main/remote-access/ipc.ts
@@ -6,10 +6,12 @@ import type {
   RevokeRemoteBrowserRequest,
   SetRemoteAccessModeRequest
 } from '../../shared/remote-access'
+import { callerContextForEvent } from '../caller-context'
 import { ipcMainHandle, isRemotePairingManagerSender } from '../ipc-handler-registry'
 import { RemoteAccessService } from './service'
 
-const isDesktopSender = (event: IpcMainInvokeEvent): boolean => event.sender.id > 0
+const isDesktopSender = (event: IpcMainInvokeEvent): boolean =>
+  callerContextForEvent(event).surface === 'electron'
 
 const requireDesktopSender = (event: IpcMainInvokeEvent): void => {
   if (!isDesktopSender(event)) {

--- a/src/main/web-service/http-server.test.ts
+++ b/src/main/web-service/http-server.test.ts
@@ -174,7 +174,11 @@ describe('startWebHttpServer', () => {
     const socket = new WebSocket(`ws://127.0.0.1:${server.port}/events?client=test-client`, {
       headers: { cookie, origin: base }
     })
+    const secondSocket = new WebSocket(`ws://127.0.0.1:${server.port}/events?client=test-client`, {
+      headers: { cookie, origin: base }
+    })
     await new Promise<void>((resolve) => socket.once('open', resolve))
+    await new Promise<void>((resolve) => secondSocket.once('open', resolve))
     const message = new Promise<string>((resolve) =>
       socket.once('message', (data) => resolve(data.toString()))
     )
@@ -187,7 +191,14 @@ describe('startWebHttpServer', () => {
     const socketClosed = new Promise<void>((resolve) => socket.once('close', () => resolve()))
     socket.close()
     await socketClosed
+    expect(rpc.releaseClient).not.toHaveBeenCalled()
+    const secondSocketClosed = new Promise<void>((resolve) =>
+      secondSocket.once('close', () => resolve())
+    )
+    secondSocket.close()
+    await secondSocketClosed
     await vi.waitFor(() => expect(rpc.releaseClient).toHaveBeenCalledWith('test-client'))
+    expect(rpc.releaseClient).toHaveBeenCalledTimes(1)
 
     await new Promise<void>((resolve, reject) => {
       const unauthenticatedSocket = new WebSocket(`ws://127.0.0.1:${server.port}/api/v1/events`)

--- a/src/main/web-service/http-server.test.ts
+++ b/src/main/web-service/http-server.test.ts
@@ -33,6 +33,8 @@ const accessOnlyExternalAccess = (): ExternalWebAccessAuthorization => ({
   kind: 'authorized' as const,
   isCurrent: () => true
 })
+const runWithCallerContext = <Result>(_context: CallerContext, operation: () => Result): Result =>
+  operation()
 
 afterEach(async () => {
   await Promise.all(servers.splice(0).map((server) => server.close()))
@@ -434,7 +436,16 @@ describe('startWebHttpServer', () => {
       releaseClient: vi.fn(),
       dispose: vi.fn()
     }
+    const taskContexts: CallerContext[] = []
+    const runWithCapturedCallerContext = <Result>(
+      context: CallerContext,
+      operation: () => Result
+    ): Result => {
+      taskContexts.push(context)
+      return operation()
+    }
     const tasks = {
+      runWithCallerContext: runWithCapturedCallerContext,
       listProjects: vi.fn(),
       createProject: vi.fn(),
       listSessions: vi.fn(),
@@ -522,6 +533,14 @@ describe('startWebHttpServer', () => {
       )
     ).toBe(401)
     expect(tasks.startRun).not.toHaveBeenCalled()
+    const taskContext = taskContexts[0]
+    expect(taskContext).toMatchObject({
+      surface: 'task',
+      location: 'remote',
+      principalKind: 'automation',
+      actionOrigin: 'automation'
+    })
+    expect(taskContext?.isAuthorizationCurrent()).toBe(false)
   })
 
   it('keeps host-management RPC local while preserving the local Web client', async () => {
@@ -870,7 +889,16 @@ describe('startWebHttpServer', () => {
     const staticRoot = await mkdtemp(join(tmpdir(), 'open-science-web-static-'))
     roots.push(staticRoot)
     await writeFile(join(staticRoot, 'index.html'), '<!doctype html>')
+    const taskContexts: CallerContext[] = []
+    const runWithCapturedCallerContext = <Result>(
+      context: CallerContext,
+      operation: () => Result
+    ): Result => {
+      taskContexts.push(context)
+      return operation()
+    }
     const tasks = {
+      runWithCallerContext: runWithCapturedCallerContext,
       listProjects: vi.fn().mockResolvedValue([{ id: 'project-1', name: 'Research' }]),
       createProject: vi.fn().mockResolvedValue({ id: 'project-2', name: 'Created' }),
       listSessions: vi.fn().mockResolvedValue([{ id: 'session/1', title: 'Review' }]),
@@ -927,6 +955,12 @@ describe('startWebHttpServer', () => {
     expect(projects.headers.get('content-type')).toBe('application/json; charset=utf-8')
     expect(projects.headers.get('cache-control')).toBe('no-store')
     expect(await projects.json()).toEqual({ data: [{ id: 'project-1', name: 'Research' }] })
+    expect(taskContexts[0]).toMatchObject({
+      surface: 'task',
+      location: 'local',
+      principalKind: 'automation',
+      actionOrigin: 'automation'
+    })
 
     const created = await fetch(`${base}/api/v1/projects`, {
       method: 'POST',
@@ -1042,6 +1076,7 @@ describe('startWebHttpServer', () => {
       })
     )
     const tasks = {
+      runWithCallerContext,
       listProjects: vi.fn(),
       createProject: vi.fn(),
       listSessions: vi.fn(),
@@ -1107,6 +1142,7 @@ describe('startWebHttpServer', () => {
       )
     )
     const tasks = {
+      runWithCallerContext,
       listProjects: vi.fn(),
       createProject: vi.fn(),
       listSessions: vi.fn(),

--- a/src/main/web-service/http-server.test.ts
+++ b/src/main/web-service/http-server.test.ts
@@ -294,6 +294,49 @@ describe('startWebHttpServer', () => {
     expect(rpc.invoke).not.toHaveBeenCalled()
   })
 
+  it('releases each active client once when the server closes', async () => {
+    const staticRoot = await mkdtemp(join(tmpdir(), 'open-science-web-static-'))
+    roots.push(staticRoot)
+    await writeFile(join(staticRoot, 'index.html'), '<!doctype html>')
+    const releaseClient = vi.fn()
+    const server = await startWebHttpServer({
+      host: '127.0.0.1',
+      port: 0,
+      token: 'test-token',
+      staticRoot,
+      rpc: {
+        channels: () => [],
+        invoke: vi.fn(),
+        releaseClient,
+        dispose: vi.fn()
+      },
+      bootstrap: {
+        appName: 'Open Science',
+        appVersion: '0.0.0',
+        configRoot: '/fake/root',
+        platform: 'test',
+        versions: { electron: '1', chrome: '1', node: '1' }
+      }
+    })
+    servers.push(server)
+    const firstSocket = new WebSocket(
+      `ws://127.0.0.1:${server.port}/events?token=test-token&client=test-client`
+    )
+    const secondSocket = new WebSocket(
+      `ws://127.0.0.1:${server.port}/events?token=test-token&client=test-client`
+    )
+    await Promise.all([
+      new Promise<void>((resolve) => firstSocket.once('open', resolve)),
+      new Promise<void>((resolve) => secondSocket.once('open', resolve))
+    ])
+
+    await server.close()
+    servers.splice(servers.indexOf(server), 1)
+
+    expect(releaseClient).toHaveBeenCalledTimes(1)
+    expect(releaseClient).toHaveBeenCalledWith('test-client')
+  })
+
   it('passes pairing authority only for trusted-browser Web RPC calls', async () => {
     const staticRoot = await mkdtemp(join(tmpdir(), 'open-science-web-static-'))
     roots.push(staticRoot)

--- a/src/main/web-service/http-server.test.ts
+++ b/src/main/web-service/http-server.test.ts
@@ -13,6 +13,7 @@ vi.mock('electron', () => ({
 }))
 
 import { WEB_RPC_PROTOCOL_VERSION } from '../../shared/web-rpc-contract'
+import type { CallerContext } from '../caller-context'
 import { broadcastToRenderers } from '../renderer-broadcast'
 import {
   REMOTE_LOCAL_ONLY_RPC_CHANNELS,
@@ -54,7 +55,9 @@ describe('startWebHttpServer', () => {
         'settings:list-agent-home-skills',
         'settings:import-agent-home-skills'
       ],
-      invoke: vi.fn(async (_channel: string, _client: string, args: unknown[]) => args[0]),
+      invoke: vi.fn(
+        async (_channel: string, _callerContext: CallerContext, args: unknown[]) => args[0]
+      ),
       releaseClient: vi.fn(),
       dispose: vi.fn()
     }
@@ -114,9 +117,17 @@ describe('startWebHttpServer', () => {
       ok: true,
       result: { value: 1 }
     })
-    expect(rpc.invoke).toHaveBeenCalledWith('projects:list', 'test-client', [{ value: 1 }], {
-      canManageRemotePairing: false
-    })
+    expect(rpc.invoke).toHaveBeenCalledWith(
+      'projects:list',
+      expect.objectContaining({
+        clientId: 'test-client',
+        lifecycleClientId: 'web:test-client',
+        location: 'local',
+        actionOrigin: 'human',
+        authorities: []
+      }),
+      [{ value: 1 }]
+    )
 
     const binary = Uint8Array.from([0, 1, 127, 128, 255])
     const encodedBinary = Buffer.from(binary).toString('base64')
@@ -316,9 +327,15 @@ describe('startWebHttpServer', () => {
     )
 
     expect(response.status).toBe(200)
-    expect(rpc.invoke).toHaveBeenCalledWith('remote-access:get-snapshot', 'trusted-phone', [], {
-      canManageRemotePairing: true
-    })
+    expect(rpc.invoke).toHaveBeenCalledWith(
+      'remote-access:get-snapshot',
+      expect.objectContaining({
+        clientId: 'trusted-phone',
+        location: 'remote',
+        authorities: ['manage-remote-pairing']
+      }),
+      []
+    )
 
     authorizeHttp.mockResolvedValueOnce(accessOnlyExternalAccess())
     const oneTimeResponse = await fetch(
@@ -336,9 +353,12 @@ describe('startWebHttpServer', () => {
     expect(oneTimeResponse.status).toBe(200)
     expect(rpc.invoke).toHaveBeenLastCalledWith(
       'remote-access:get-snapshot',
-      'one-time-phone',
-      [],
-      { canManageRemotePairing: false }
+      expect.objectContaining({
+        clientId: 'one-time-phone',
+        location: 'remote',
+        authorities: []
+      }),
+      []
     )
   })
 

--- a/src/main/web-service/http-server.ts
+++ b/src/main/web-service/http-server.ts
@@ -10,7 +10,12 @@ import { gzip } from 'node:zlib'
 import { net } from 'electron'
 import { WebSocket, WebSocketServer } from 'ws'
 
-import { ClientLeaseRegistry, createWebCallerContext } from '../caller-context'
+import {
+  ClientLeaseRegistry,
+  createTaskCallerContext,
+  createWebCallerContext,
+  type CallerContext
+} from '../caller-context'
 import type { WebRpcRouter } from '../ipc-handler-registry'
 import { addRendererBroadcastSink } from '../renderer-broadcast'
 import {
@@ -115,6 +120,7 @@ type WebServerOptions = {
     | 'listArtifacts'
     | 'acquireArtifact'
     | 'releaseArtifact'
+    | 'runWithCallerContext'
   >
   onShutdownRequest?: () => void
   bootstrap: {
@@ -334,75 +340,77 @@ const handleTaskApiRequest = async (
   response: ServerResponse,
   url: URL,
   tasks: NonNullable<WebServerOptions['tasks']>,
+  callerContext: CallerContext,
   externalAuthorization?: ExternalWebAccessAuthorization
-): Promise<boolean> => {
-  try {
-    if (url.pathname === '/api/v1/projects' && request.method === 'GET') {
-      assertExternalAuthorizationCurrent(externalAuthorization)
-      json(response, 200, { data: await tasks.listProjects() })
-      return true
-    }
-    if (url.pathname === '/api/v1/projects' && request.method === 'POST') {
-      const body = (await readJsonBody(request)) as { name?: string; description?: string }
-      assertExternalAuthorizationCurrent(externalAuthorization)
-      json(response, 201, {
-        data: await tasks.createProject({ name: body.name ?? '', description: body.description })
-      })
-      return true
-    }
-    if (url.pathname === '/api/v1/sessions' && request.method === 'GET') {
-      assertExternalAuthorizationCurrent(externalAuthorization)
-      json(response, 200, {
-        data: await tasks.listSessions(url.searchParams.get('project') ?? undefined)
-      })
-      return true
-    }
-    if (url.pathname === '/api/v1/runs' && request.method === 'POST') {
-      const body = (await readJsonBody(request)) as StartTaskRunRequest
-      assertExternalAuthorizationCurrent(externalAuthorization)
-      json(response, 202, { data: await tasks.startRun(body) })
-      return true
-    }
-
-    const runMatch = url.pathname.match(/^\/api\/v1\/runs\/([^/]+)$/)
-    if (runMatch && request.method === 'GET') {
-      assertExternalAuthorizationCurrent(externalAuthorization)
-      json(response, 200, { data: tasks.getRun(decodeURIComponent(runMatch[1])) })
-      return true
-    }
-    const sessionArtifactsMatch = url.pathname.match(/^\/api\/v1\/sessions\/([^/]+)\/artifacts$/)
-    if (sessionArtifactsMatch && request.method === 'GET') {
-      assertExternalAuthorizationCurrent(externalAuthorization)
-      json(response, 200, {
-        data: await tasks.listArtifacts(decodeURIComponent(sessionArtifactsMatch[1]))
-      })
-      return true
-    }
-    const sessionMatch = url.pathname.match(/^\/api\/v1\/sessions\/([^/]+)$/)
-    if (sessionMatch && request.method === 'GET') {
-      assertExternalAuthorizationCurrent(externalAuthorization)
-      json(response, 200, { data: await tasks.getSession(decodeURIComponent(sessionMatch[1])) })
-      return true
-    }
-    const artifactMatch = url.pathname.match(/^\/api\/v1\/artifacts\/([^/]+)\/content$/)
-    if (artifactMatch && (request.method === 'GET' || request.method === 'HEAD')) {
-      assertExternalAuthorizationCurrent(externalAuthorization)
-      const artifact = await tasks.acquireArtifact(decodeURIComponent(artifactMatch[1]))
-      try {
-        await streamPreviewResource(request, response, artifact.url, {
-          'content-disposition': `attachment; filename*=UTF-8''${encodeURIComponent(artifact.name)}`
-        })
-      } finally {
-        await tasks.releaseArtifact(artifact.resourceId)
+): Promise<boolean> =>
+  tasks.runWithCallerContext(callerContext, async () => {
+    try {
+      if (url.pathname === '/api/v1/projects' && request.method === 'GET') {
+        assertExternalAuthorizationCurrent(externalAuthorization)
+        json(response, 200, { data: await tasks.listProjects() })
+        return true
       }
+      if (url.pathname === '/api/v1/projects' && request.method === 'POST') {
+        const body = (await readJsonBody(request)) as { name?: string; description?: string }
+        assertExternalAuthorizationCurrent(externalAuthorization)
+        json(response, 201, {
+          data: await tasks.createProject({ name: body.name ?? '', description: body.description })
+        })
+        return true
+      }
+      if (url.pathname === '/api/v1/sessions' && request.method === 'GET') {
+        assertExternalAuthorizationCurrent(externalAuthorization)
+        json(response, 200, {
+          data: await tasks.listSessions(url.searchParams.get('project') ?? undefined)
+        })
+        return true
+      }
+      if (url.pathname === '/api/v1/runs' && request.method === 'POST') {
+        const body = (await readJsonBody(request)) as StartTaskRunRequest
+        assertExternalAuthorizationCurrent(externalAuthorization)
+        json(response, 202, { data: await tasks.startRun(body) })
+        return true
+      }
+
+      const runMatch = url.pathname.match(/^\/api\/v1\/runs\/([^/]+)$/)
+      if (runMatch && request.method === 'GET') {
+        assertExternalAuthorizationCurrent(externalAuthorization)
+        json(response, 200, { data: tasks.getRun(decodeURIComponent(runMatch[1])) })
+        return true
+      }
+      const sessionArtifactsMatch = url.pathname.match(/^\/api\/v1\/sessions\/([^/]+)\/artifacts$/)
+      if (sessionArtifactsMatch && request.method === 'GET') {
+        assertExternalAuthorizationCurrent(externalAuthorization)
+        json(response, 200, {
+          data: await tasks.listArtifacts(decodeURIComponent(sessionArtifactsMatch[1]))
+        })
+        return true
+      }
+      const sessionMatch = url.pathname.match(/^\/api\/v1\/sessions\/([^/]+)$/)
+      if (sessionMatch && request.method === 'GET') {
+        assertExternalAuthorizationCurrent(externalAuthorization)
+        json(response, 200, { data: await tasks.getSession(decodeURIComponent(sessionMatch[1])) })
+        return true
+      }
+      const artifactMatch = url.pathname.match(/^\/api\/v1\/artifacts\/([^/]+)\/content$/)
+      if (artifactMatch && (request.method === 'GET' || request.method === 'HEAD')) {
+        assertExternalAuthorizationCurrent(externalAuthorization)
+        const artifact = await tasks.acquireArtifact(decodeURIComponent(artifactMatch[1]))
+        try {
+          await streamPreviewResource(request, response, artifact.url, {
+            'content-disposition': `attachment; filename*=UTF-8''${encodeURIComponent(artifact.name)}`
+          })
+        } finally {
+          await tasks.releaseArtifact(artifact.resourceId)
+        }
+        return true
+      }
+    } catch (error) {
+      taskError(response, error)
       return true
     }
-  } catch (error) {
-    taskError(response, error)
-    return true
-  }
-  return false
-}
+    return false
+  })
 
 const serveStatic = async (
   request: IncomingMessage,
@@ -519,7 +527,21 @@ const startWebHttpServer = async (options: WebServerOptions): Promise<RunningWeb
       if (
         url.pathname.startsWith('/api/v1/') &&
         options.tasks &&
-        (await handleTaskApiRequest(request, response, url, options.tasks, externalAuthorization))
+        (await handleTaskApiRequest(
+          request,
+          response,
+          url,
+          options.tasks,
+          createTaskCallerContext({
+            ...(externalAuthorization
+              ? {
+                  location: 'remote' as const,
+                  isAuthorizationCurrent: externalAuthorization.isCurrent
+                }
+              : {})
+          }),
+          externalAuthorization
+        ))
       ) {
         return
       }

--- a/src/main/web-service/http-server.ts
+++ b/src/main/web-service/http-server.ts
@@ -10,6 +10,7 @@ import { gzip } from 'node:zlib'
 import { net } from 'electron'
 import { WebSocket, WebSocketServer } from 'ws'
 
+import { ClientLeaseRegistry, createWebCallerContext } from '../caller-context'
 import type { WebRpcRouter } from '../ipc-handler-registry'
 import { addRendererBroadcastSink } from '../renderer-broadcast'
 import {
@@ -453,7 +454,7 @@ const startWebHttpServer = async (options: WebServerOptions): Promise<RunningWeb
   const sockets = new Set<WebSocket>()
   const externalSockets = new Map<WebSocket, string | undefined>()
   const publicEventSockets = new Set<WebSocket>()
-  const clientConnections = new Map<string, number>()
+  const clientLeases = new ClientLeaseRegistry(options.rpc.releaseClient)
   const wsServer = new WebSocketServer({ noServer: true })
 
   const server = createServer(async (request, response) => {
@@ -461,7 +462,6 @@ const startWebHttpServer = async (options: WebServerOptions): Promise<RunningWeb
       const url = new URL(request.url ?? '/', `http://${request.headers.host ?? '127.0.0.1'}`)
       const auth = authenticateRequest(request, url, options.token)
       let authorized = auth.ok
-      let canManageRemotePairing = false
       let externalAuthorization: ExternalWebAccessAuthorization | undefined
       if (!authorized && options.externalAccess) {
         const decision = await options.externalAccess.authorizeHttp(request, response, url)
@@ -469,7 +469,6 @@ const startWebHttpServer = async (options: WebServerOptions): Promise<RunningWeb
         authorized = typeof decision === 'object'
         if (typeof decision === 'object') {
           externalAuthorization = decision
-          canManageRemotePairing = decision.kind === 'authorized-pairing-manager'
         }
       }
       if (!authorized) {
@@ -583,11 +582,21 @@ const startWebHttpServer = async (options: WebServerOptions): Promise<RunningWeb
           return
         }
         const clientId = String(request.headers['x-open-science-client'] ?? 'web')
+        const callerContext = createWebCallerContext(clientId, {
+          ...(externalAuthorization
+            ? {
+                location: 'remote' as const,
+                authorities:
+                  externalAuthorization.kind === 'authorized-pairing-manager'
+                    ? (['manage-remote-pairing'] as const)
+                    : [],
+                isAuthorizationCurrent: externalAuthorization.isCurrent
+              }
+            : {})
+        })
         try {
           assertExternalAuthorizationCurrent(externalAuthorization)
-          const result = await options.rpc.invoke(channel, clientId, parsed.data.args, {
-            canManageRemotePairing
-          })
+          const result = await options.rpc.invoke(channel, callerContext, parsed.data.args)
           json(response, 200, {
             protocolVersion: WEB_RPC_PROTOCOL_VERSION,
             ok: true,
@@ -662,20 +671,14 @@ const startWebHttpServer = async (options: WebServerOptions): Promise<RunningWeb
   wsServer.on('connection', (socket, request) => {
     const url = new URL(request.url ?? '/', `http://${request.headers.host ?? '127.0.0.1'}`)
     const clientId = url.searchParams.get('client') ?? 'web'
+    const lease = clientLeases.acquire(clientId)
     sockets.add(socket)
     if (url.pathname === '/api/v1/events') publicEventSockets.add(socket)
-    clientConnections.set(clientId, (clientConnections.get(clientId) ?? 0) + 1)
     socket.on('close', () => {
       sockets.delete(socket)
       externalSockets.delete(socket)
       publicEventSockets.delete(socket)
-      const remaining = (clientConnections.get(clientId) ?? 1) - 1
-      if (remaining <= 0) {
-        clientConnections.delete(clientId)
-        options.rpc.releaseClient(clientId)
-      } else {
-        clientConnections.set(clientId, remaining)
-      }
+      lease.release()
     })
   })
 
@@ -728,6 +731,7 @@ const startWebHttpServer = async (options: WebServerOptions): Promise<RunningWeb
       for (const socket of sockets) socket.close()
       wsServer.close()
       await new Promise<void>((resolveClose) => server.close(() => resolveClose()))
+      clientLeases.dispose()
     }
   }
 }

--- a/src/main/web-service/task-api.test.ts
+++ b/src/main/web-service/task-api.test.ts
@@ -14,6 +14,15 @@ const project = {
   updatedAt: 1
 }
 
+const taskCallerContext = (): ReturnType<typeof expect.objectContaining> =>
+  expect.objectContaining({
+    clientId: 'headless-task-api',
+    lifecycleClientId: 'web:headless-task-api',
+    surface: 'task',
+    principalKind: 'automation',
+    actionOrigin: 'automation'
+  })
+
 describe('HeadlessTaskApi', () => {
   it('supports project, session, and artifact queries through the public interface', async () => {
     const session: PersistedChatSession = {
@@ -36,7 +45,7 @@ describe('HeadlessTaskApi', () => {
       createdAt: 1,
       updatedAt: 2
     }
-    const invoke = vi.fn(async (channel: string, _clientId: string, args: unknown[]) => {
+    const invoke = vi.fn(async (channel: string, _callerContext: unknown, args: unknown[]) => {
       if (channel === 'projects:list') return [project]
       if (channel === 'projects:create') {
         return { ...project, ...(args[0] as object), id: 'project-created' }
@@ -72,14 +81,14 @@ describe('HeadlessTaskApi', () => {
     })
     await api.releaseArtifact('resource-query')
 
-    expect(invoke).toHaveBeenCalledWith('preview-resources:acquire', expect.any(String), [
+    expect(invoke).toHaveBeenCalledWith('preview-resources:acquire', taskCallerContext(), [
       {
         source: 'artifact',
         path: '/artifacts/query.csv',
         mimeType: 'text/csv'
       }
     ])
-    expect(invoke).toHaveBeenCalledWith('preview-resources:release', expect.any(String), [
+    expect(invoke).toHaveBeenCalledWith('preview-resources:release', taskCallerContext(), [
       { resourceId: 'resource-query' }
     ])
   })
@@ -155,7 +164,7 @@ describe('HeadlessTaskApi', () => {
   it('runs a prompt in a new durable session and returns the assistant output', async () => {
     let emitEvent: ((event: AcpRuntimeEvent) => void) | undefined
     const savedSessions: PersistedChatSession[] = []
-    const invoke = vi.fn(async (channel: string, _clientId: string, args: unknown[]) => {
+    const invoke = vi.fn(async (channel: string, _callerContext: unknown, args: unknown[]) => {
       if (channel === 'projects:list') return [project]
       if (channel === 'sessions:load-all') return { sessions: [], manifest: { version: 1 } }
       if (channel === 'acp:create-session') {
@@ -241,7 +250,7 @@ describe('HeadlessTaskApi', () => {
         }
       ]
     })
-    expect(invoke).toHaveBeenCalledWith('acp:send-prompt', expect.any(String), [
+    expect(invoke).toHaveBeenCalledWith('acp:send-prompt', taskCallerContext(), [
       { sessionId: 'session-1', text: 'Review these papers.' }
     ])
   })
@@ -249,7 +258,7 @@ describe('HeadlessTaskApi', () => {
   it('marks artifact-only headless completions when turn usage is unavailable', async () => {
     let emitEvent: ((event: AcpRuntimeEvent) => void) | undefined
     const savedSessions: PersistedChatSession[] = []
-    const invoke = vi.fn(async (channel: string, _clientId: string, args: unknown[]) => {
+    const invoke = vi.fn(async (channel: string, _callerContext: unknown, args: unknown[]) => {
       if (channel === 'projects:list') return [project]
       if (channel === 'sessions:load-all') return { sessions: [], manifest: { version: 1 } }
       if (channel === 'acp:create-session') {
@@ -457,10 +466,10 @@ describe('HeadlessTaskApi', () => {
     })
     await api.waitForRun('run-2')
 
-    expect(invoke).toHaveBeenCalledWith('acp:resume-session', expect.any(String), [
+    expect(invoke).toHaveBeenCalledWith('acp:resume-session', taskCallerContext(), [
       expect.objectContaining({ sessionId: existing.id, permissionProfile: 'auto' })
     ])
-    expect(invoke).toHaveBeenCalledWith('acp:send-prompt', expect.any(String), [
+    expect(invoke).toHaveBeenCalledWith('acp:send-prompt', taskCallerContext(), [
       {
         sessionId: existing.id,
         text: 'Follow-up question',
@@ -527,7 +536,7 @@ describe('HeadlessTaskApi', () => {
     })
     await api.waitForRun('skill-run')
 
-    expect(invoke).toHaveBeenCalledWith('acp:send-prompt', expect.any(String), [
+    expect(invoke).toHaveBeenCalledWith('acp:send-prompt', taskCallerContext(), [
       {
         sessionId: existing.id,
         text: 'Use the selected skill.',
@@ -544,7 +553,7 @@ describe('HeadlessTaskApi', () => {
     let emitEvent: ((event: AcpRuntimeEvent) => void) | undefined
     let finalizeAttempts = 0
     const savedSessions: PersistedChatSession[] = []
-    const invoke = vi.fn(async (channel: string, _clientId: string, args: unknown[]) => {
+    const invoke = vi.fn(async (channel: string, _callerContext: unknown, args: unknown[]) => {
       if (channel === 'projects:list') return [project]
       if (channel === 'sessions:load-all') return { sessions: [], manifest: { version: 1 } }
       if (channel === 'acp:create-session') {

--- a/src/main/web-service/task-api.test.ts
+++ b/src/main/web-service/task-api.test.ts
@@ -3,6 +3,7 @@ import { describe, expect, it, vi } from 'vitest'
 import type { AcpRuntimeEvent } from '../../shared/acp'
 import { ARTIFACT_OWNERSHIP_PERSISTENCE_RACE } from '../../shared/artifacts'
 import type { PersistedChatSession } from '../../shared/session-persistence'
+import { createTaskCallerContext, type CallerContext } from '../caller-context'
 import { HeadlessTaskApi } from './task-api'
 
 const project = {
@@ -91,6 +92,53 @@ describe('HeadlessTaskApi', () => {
     expect(invoke).toHaveBeenCalledWith('preview-resources:release', taskCallerContext(), [
       { resourceId: 'resource-query' }
     ])
+  })
+
+  it('keeps the request caller context across asynchronous run RPC', async () => {
+    let finishPrompt: (() => void) | undefined
+    const promptGate = new Promise<void>((resolve) => {
+      finishPrompt = resolve
+    })
+    const invoke = vi.fn(
+      async (channel: string, _callerContext: CallerContext, _args: unknown[]) => {
+        void _callerContext
+        void _args
+        if (channel === 'projects:list') return [project]
+        if (channel === 'sessions:load-all') return { sessions: [], manifest: { version: 1 } }
+        if (channel === 'acp:create-session') {
+          return { sessionId: 'session-context', cwd: '/workspace/context' }
+        }
+        if (channel === 'acp:send-prompt') return promptGate
+        if (channel === 'sessions:save-session') return undefined
+        if (channel === 'preview-resources:release') return undefined
+        throw new Error(`Unexpected RPC channel: ${channel}`)
+      }
+    )
+    const api = new HeadlessTaskApi({ invoke })
+    let authorizationCurrent = true
+    const context = createTaskCallerContext({
+      location: 'remote',
+      isAuthorizationCurrent: () => authorizationCurrent
+    })
+
+    const run = await api.runWithCallerContext(context, () =>
+      api.startRun({ project: project.id, prompt: 'Research with remote context.' })
+    )
+    authorizationCurrent = false
+    finishPrompt?.()
+    await api.waitForRun(run.id)
+
+    expect(invoke).toHaveBeenCalled()
+    expect(invoke.mock.calls.every(([, callerContext]) => callerContext === context)).toBe(true)
+    expect(context.isAuthorizationCurrent()).toBe(false)
+
+    await api.runWithCallerContext(context, () => api.releaseArtifact('resource-context'))
+    expect(invoke).toHaveBeenLastCalledWith(
+      'preview-resources:release',
+      expect.objectContaining({ location: 'local', actionOrigin: 'automation' }),
+      [{ resourceId: 'resource-context' }]
+    )
+    expect(invoke.mock.calls.at(-1)?.[1].isAuthorizationCurrent()).toBe(true)
   })
 
   it('rejects malformed public run requests before invoking internal RPC', async () => {

--- a/src/main/web-service/task-api.ts
+++ b/src/main/web-service/task-api.ts
@@ -1,4 +1,5 @@
 import { randomUUID } from 'node:crypto'
+import { AsyncLocalStorage } from 'node:async_hooks'
 
 import {
   getAcpRuntimeEventImage,
@@ -136,6 +137,7 @@ const summarizeSession = (session: PersistedChatSession): TaskSessionSummary => 
 
 class HeadlessTaskApi {
   private readonly dependencies: TaskApiDependencies
+  private readonly callerContexts = new AsyncLocalStorage<CallerContext>()
   private readonly runs = new Map<string, MutableTaskRun>()
   private readonly activeRunBySession = new Map<string, string>()
   private readonly unsubscribeEvents: () => void
@@ -154,6 +156,10 @@ class HeadlessTaskApi {
 
   dispose(): void {
     this.unsubscribeEvents()
+  }
+
+  runWithCallerContext<Result>(context: CallerContext, operation: () => Result): Result {
+    return this.callerContexts.run(context, operation)
   }
 
   async listProjects(): Promise<Project[]> {
@@ -298,7 +304,9 @@ class HeadlessTaskApi {
   }
 
   async releaseArtifact(resourceId: string): Promise<void> {
-    await this.invoke('preview-resources:release', { resourceId })
+    // Capability cleanup must remain available if the request authorization is revoked while the
+    // response stream is still draining. It grants no new access and only releases an acquired id.
+    await this.rpc.invoke('preview-resources:release', TASK_CALLER_CONTEXT, [{ resourceId }])
   }
 
   private reserveSession(sessionId: string, runId: string): void {
@@ -672,7 +680,7 @@ class HeadlessTaskApi {
   }
 
   private invoke(channel: string, ...args: unknown[]): Promise<unknown> {
-    return this.rpc.invoke(channel, TASK_CALLER_CONTEXT, args)
+    return this.rpc.invoke(channel, this.callerContexts.getStore() ?? TASK_CALLER_CONTEXT, args)
   }
 }
 

--- a/src/main/web-service/task-api.ts
+++ b/src/main/web-service/task-api.ts
@@ -28,12 +28,13 @@ import type {
   TaskRun,
   TaskSessionSummary
 } from '../../shared/task-api'
+import { createTaskCallerContext, type CallerContext } from '../caller-context'
 
-const TASK_API_CLIENT_ID = 'headless-task-api'
+const TASK_CALLER_CONTEXT = createTaskCallerContext()
 const MAX_RETAINED_RUNS = 200
 
 type TaskRpc = {
-  invoke(channel: string, clientId: string, args: unknown[]): Promise<unknown>
+  invoke(channel: string, callerContext: CallerContext, args: unknown[]): Promise<unknown>
 }
 
 type TaskApiDependencies = {
@@ -671,7 +672,7 @@ class HeadlessTaskApi {
   }
 
   private invoke(channel: string, ...args: unknown[]): Promise<unknown> {
-    return this.rpc.invoke(channel, TASK_API_CLIENT_ID, args)
+    return this.rpc.invoke(channel, TASK_CALLER_CONTEXT, args)
   }
 }
 


### PR DESCRIPTION
## Problem

Electron IPC, Web RPC, and the headless Task API inferred caller identity and authority from mutable synthetic sender state. Concurrent Web calls could share authority state, WebSocket cleanup was count-based outside an owner, and future provider-neutral orchestration (#458) had no explicit action-origin boundary.

## Proposed change

- Add an immutable `CallerContext` for Electron, Web, and Task surfaces, separating principal identity, action origin, location, authority, lifecycle identity, and authorization freshness.
- Give `ClientLeaseRegistry` ownership of per-client connection leases and final cleanup.
- Derive Web contexts from the authenticated HTTP request and keep authority isolated per invocation.
- Preserve request-level Task context across detached async runs while using a no-authority automation context only for idempotent capability cleanup.
- Keep native and legacy lifecycle client IDs compatible.

```mermaid
flowchart LR
  E["Electron IPC"] --> C["Immutable CallerContext"]
  W["Authenticated Web request"] --> C
  T["Task / CLI API"] --> C
  C --> R["IPC handler registry"]
  W --> L["ClientLeaseRegistry"]
  L --> X["Cleanup after final lease / shutdown"]
```

## Scope and non-goals

- No renderer UI or user-interaction changes.
- No database, schema, data-relation, shared IPC payload, or Web RPC payload changes.
- Specialist, Permission, and Compute policy/behavior remain unchanged.
- Connector runtime, ACP policy, and grant persistence are not refactored here.
- Related to #458 only as a forward-compatible action-origin seam; this PR does not implement provider-neutral orchestration or delegation ceilings.

## Acceptance criteria and validation

All listed checks ran after the last material edit.

- Caller identity, action origin, authority freshness, and fail-closed synthetic fallback -> `npm test -- --run src/main/caller-context.test.ts src/main/ipc-handler-registry.test.ts` -> pass.
- Electron/Web lifecycle ID compatibility and pairing-manager boundary -> `npm test -- --run src/main/lifecycle-broadcast.test.ts src/main/remote-access/ipc.test.ts` -> pass.
- Concurrent Web authority isolation, multi-connection final cleanup, and shutdown cleanup -> `npm test -- --run src/main/ipc-handler-registry.test.ts src/main/web-service/http-server.test.ts` -> pass.
- Local/remote Task context propagation across detached async RPC and safe capability cleanup -> `npm test -- --run src/main/web-service/task-api.test.ts src/main/web-service/http-server.test.ts` -> pass.
- Type safety -> `npm run typecheck` -> pass.
- Lint -> `npm run lint -- --no-cache` -> pass with 0 errors and 23 pre-existing warnings.
- Full regression suite -> `npm test` -> 610 files / 9,083 tests passed; 11 files / 140 tests skipped.
- Independent Standards review -> 0 hard findings, 0 judgement calls.
- Independent Spec review -> 0 findings.

## Review focus

- The fail-closed compatibility shim for legacy synthetic negative senders.
- Request-scoped authorization freshness for remote Web and Task calls.
- Exactly-once client cleanup after final connection and server shutdown.
- The narrow cleanup exception: it has no authorities and can only release an already acquired preview capability.

Uncovered risk: no real remote reverse-proxy/provider E2E was run; authentication generation, concurrency, transport, and cleanup are covered with HTTP/WebSocket integration tests and the full suite.
