### PR TITLE
fix(settings): filter Fetch Metadata headers from Responses proxy

### DIFF
--- a/src/main/settings/native-responses-compatibility.test.ts
+++ b/src/main/settings/native-responses-compatibility.test.ts
@@ -321,6 +321,43 @@ describe('native Responses compatibility', () => {
     }
   })
 
+  it('forwards loopback requests without browser-controlled Fetch Metadata headers', async () => {
+    const fetchImpl = vi.fn(
+      async (_url: Parameters<typeof fetch>[0], init?: Parameters<typeof fetch>[1]) => {
+        const headers = new Headers(init?.headers)
+        if (headers.has('sec-fetch-mode')) throw new Error('net::ERR_INVALID_ARGUMENT')
+
+        return new Response(JSON.stringify({ id: 'response-1', output: [] }), {
+          status: 200,
+          headers: { 'content-type': 'application/json' }
+        })
+      }
+    )
+    const proxy = new NativeResponsesCompatibilityProxy(
+      { baseUrl: 'https://api.deepseek.com/v1', model: 'deepseek-v4-flash' },
+      fetchImpl
+    )
+    const connection = await proxy.start()
+    try {
+      const response = await fetch(`${connection.baseUrl}/responses`, {
+        method: 'POST',
+        headers: {
+          authorization: `Bearer ${connection.token}`,
+          'content-type': 'application/json'
+        },
+        body: JSON.stringify({
+          model: 'deepseek-v4-flash',
+          input: 'ping'
+        })
+      })
+
+      expect(response.ok, await response.text()).toBe(true)
+      expect(fetchImpl).toHaveBeenCalledOnce()
+    } finally {
+      await proxy.close()
+    }
+  })
+
   it('forwards a near-limit multimodal request larger than 32 MiB', async () => {
     const upstreamBodies: string[] = []
     const fetchImpl = vi.fn(

--- a/src/main/settings/native-responses-compatibility.ts
+++ b/src/main/settings/native-responses-compatibility.ts
@@ -209,7 +209,16 @@ const upstreamHeaders = (
 ): Record<string, string> => {
   const headers: Record<string, string> = {}
   for (const [name, value] of Object.entries(request.headers)) {
-    if (HOP_BY_HOP_HEADERS.has(name) || name === 'authorization' || value === undefined) continue
+    // Node fetch adds Fetch Metadata headers to the loopback request. Chromium owns these headers and
+    // rejects callers that pass them explicitly to Electron net.fetch with ERR_INVALID_ARGUMENT.
+    if (
+      HOP_BY_HOP_HEADERS.has(name) ||
+      name === 'authorization' ||
+      name.startsWith('sec-fetch-') ||
+      value === undefined
+    ) {
+      continue
+    }
     headers[name] = Array.isArray(value) ? value.join(', ') : value
   }
   headers['content-type'] = 'application/json'


### PR DESCRIPTION
## Problem

Codex validation for DeepSeek `deepseek-v4-flash` correctly targets the native Responses endpoint, but the loopback Node fetch adds `sec-fetch-mode`. The compatibility proxy forwarded that browser-controlled header to Electron `net.fetch`, which rejects it with `net::ERR_INVALID_ARGUMENT` before the request reaches DeepSeek.

## Proposed change

- Strip `sec-fetch-*` Fetch Metadata headers when forwarding loopback requests upstream.
- Add a regression test that reproduces Electron's rejection at the external fetch seam and verifies the proxy completes the request after filtering.

## Scope and non-goals

- No architecture, data model, data relationship, configuration, or UI changes.
- No change to DeepSeek model routing: `deepseek-v4-flash` continues to use `/v1/responses` under Codex.
- No dependency or public interface changes.

## Acceptance criteria and validation

All checks below ran after the last material edit.

| Behavior | Command | Result |
| --- | --- | --- |
| Loopback Fetch Metadata headers no longer trigger the Electron boundary failure | `npm test -- --run src/main/settings/native-responses-compatibility.test.ts -t "forwards loopback requests without browser-controlled Fetch Metadata headers"` | Pass: 1 test |
| Native Responses compatibility and DeepSeek Codex routing remain valid | `npm test -- --run src/main/settings/native-responses-compatibility.test.ts src/main/settings/service.test.ts -t "native Responses compatibility\|probes DeepSeek flash through the native Responses route under Codex"` | Pass: 9 tests |
| TypeScript contracts remain valid | `npm run typecheck` | Pass |
| Repository lint gate | `npm run lint` | Pass: 0 errors; 23 existing warnings |
| Full unit/integration suite | `npm test` | Pass: 9,073 tests; 140 skipped |

Independent review completed with 0 Standards findings and 0 Spec findings.

## Review focus

- Confirm filtering the `sec-fetch-*` family is appropriately scoped for Electron `net.fetch`.
- Confirm required upstream headers other than browser-controlled Fetch Metadata remain forwarded.

## Uncovered risk

The suite does not use a live valid DeepSeek API key. It covers the local proxy behavior and Electron rejection contract without exercising a billed provider response.
