### PR TITLE
refactor(settings): extract skill catalog ownership

### DIFF
--- a/src/main/settings/service.test.ts
+++ b/src/main/settings/service.test.ts
@@ -3819,6 +3819,43 @@ describe('SettingsService: skills', () => {
     }
   })
 
+  it('builds the Codex skill catalog from one settings snapshot', async () => {
+    const skillsRoot = join(storageRoot, 'codex', 'skills')
+    await Promise.all(
+      ['os-demo', 'mcp-pubmed'].map(async (directory) => {
+        const skillDir = join(skillsRoot, directory)
+        await mkdir(skillDir, { recursive: true })
+        await writeFile(join(skillDir, 'SKILL.md'), `# ${directory}`, 'utf8')
+      })
+    )
+    const service = new SettingsService({
+      repository,
+      storageRoot,
+      skillRegistry: new SkillRegistry(await seedBundle())
+    })
+    const empty = await repository.getSettings()
+    const getSettings = vi
+      .spyOn(repository, 'getSettings')
+      .mockResolvedValueOnce({
+        ...empty,
+        connectors: {
+          enabledIds: [],
+          autoAllowIds: [],
+          disabledConnectorIds: ['pubmed']
+        }
+      })
+      .mockResolvedValueOnce({
+        ...empty,
+        disabledSkillIds: ['demo'],
+        connectors: { enabledIds: [], autoAllowIds: [] }
+      })
+
+    const catalog = await service.codexSkillCatalog(join(storageRoot, 'codex'))
+
+    expect(catalog.map(({ name }) => name)).toEqual(['demo'])
+    expect(getSettings).toHaveBeenCalledTimes(1)
+  })
+
   it('migrates legacy shared Codex skills into the app-owned subscription home only', async () => {
     const adapterPath = join(storageRoot, 'bin', 'codex-acp')
     await mkdir(dirname(adapterPath), { recursive: true })

--- a/src/main/settings/service.ts
+++ b/src/main/settings/service.ts
@@ -2657,11 +2657,7 @@ class SettingsService {
     configRoot: string,
     forcedSkillIds: ReadonlySet<string>
   ): Promise<void> {
-    await this.skills.materializeSkills(
-      configRoot,
-      settings.disabledSkillIds ?? [],
-      forcedSkillIds
-    )
+    await this.skills.materializeSkills(configRoot, settings.disabledSkillIds ?? [], forcedSkillIds)
 
     // Connector skill docs (which instruct the agent to reach a service ONLY via `host.mcp` from the
     // notebook kernel) are otherwise synced only into the Claude config dir. Non-Claude frameworks

--- a/src/main/settings/service.ts
+++ b/src/main/settings/service.ts
@@ -200,6 +200,7 @@ import { SettingsRepository } from './repository'
 import { sanitizeCustomMcpServer } from './repository'
 import { SettingsPreferencesModule, toSettingsPreferencesSnapshot } from './preferences'
 import { NotebookRuntimeSettingsModule } from './notebook-runtime-settings'
+import { SkillCatalogModule } from './skill-catalog'
 import { CONNECTOR_CATALOG } from '../connectors/catalog'
 import { getConnectorTools } from '../connectors/registry'
 import { renderConnectorInstructions } from '../connectors/skill-doc'
@@ -562,6 +563,7 @@ class SettingsService {
   private readonly repository: SettingsRepository
   private readonly preferences: SettingsPreferencesModule
   private readonly notebookRuntimeSettings: NotebookRuntimeSettingsModule
+  private readonly skills: SkillCatalogModule
   private readonly storageRoot: string
   private readonly detectDeps: ClaudeDetectDeps
   private readonly opencodeDetectDeps: OpencodeDetectDeps
@@ -569,9 +571,6 @@ class SettingsService {
   private readonly codexDetectDeps: CodexDetectDeps
   private readonly userClaudeDir: string
   private readonly userCodexDir: string
-  private readonly userAgentsDir: string
-  private readonly skillRegistry: SkillRegistry
-  private readonly userSkills: UserSkillRepository
   private readonly executeClaudeProbe: ExecuteClaudeProbe
   private readonly installManagedClaudeImpl: (
     options: InstallManagedClaudeOptions
@@ -638,9 +637,15 @@ class SettingsService {
     }
     this.userClaudeDir = options.userClaudeDir ?? getUserClaudeConfigDir()
     this.userCodexDir = options.userCodexDir ?? join(homedir(), '.codex')
-    this.userAgentsDir = options.userAgentsDir ?? join(homedir(), '.agents')
-    this.skillRegistry = options.skillRegistry ?? new SkillRegistry()
-    this.userSkills = options.userSkills ?? new UserSkillRepository(this.storageRoot)
+    this.skills = new SkillCatalogModule({
+      repository: this.repository,
+      storageRoot: this.storageRoot,
+      userClaudeDir: this.userClaudeDir,
+      userCodexDir: this.userCodexDir,
+      userAgentsDir: options.userAgentsDir ?? join(homedir(), '.agents'),
+      skillRegistry: options.skillRegistry ?? new SkillRegistry(),
+      userSkills: options.userSkills ?? new UserSkillRepository(this.storageRoot)
+    })
     this.executeClaudeProbe = options.executeClaudeProbe ?? executeClaudeProbe
     this.installManagedClaudeImpl = options.installManagedClaudeImpl ?? installManagedClaude
     this.installManagedOpencodeImpl = options.installManagedOpencodeImpl ?? installManagedOpencode
@@ -994,22 +999,9 @@ class SettingsService {
     return this.getSettingsView()
   }
 
-  // The full skill catalog across every source: bundled (featured) + imported + personal.
-  private async skillCatalog(): Promise<BundledSkill[]> {
-    const [featured, user] = await Promise.all([this.skillRegistry.list(), this.userSkills.list()])
-
-    return [...featured, ...user]
-  }
-
-  // Lists all skills (featured + imported + personal) with enabled state from the stored disabled set.
+  // Compatibility facade: Skill state and filesystem rules live in SkillCatalogModule.
   async listSkills(): Promise<SkillView[]> {
-    const [skills, settings] = await Promise.all([
-      this.skillCatalog(),
-      this.repository.getSettings()
-    ])
-    const disabled = new Set(settings.disabledSkillIds ?? [])
-
-    return skills.map((skill) => this.toSkillView(skill, disabled))
+    return this.skills.listSkills()
   }
 
   // Specialist scopes intentionally see the installed catalog irrespective of Main Agent toggles.
@@ -1017,12 +1009,7 @@ class SettingsService {
   async listSpecialistSkillCatalog(): Promise<
     Array<{ id: string; frameworkName: string; displayName: string }>
   > {
-    const skills = await this.skillCatalog()
-    return skills.map((skill) => ({
-      id: skill.id,
-      frameworkName: skill.source === 'featured' ? skill.id : skill.name,
-      displayName: skill.name
-    }))
+    return this.skills.listSpecialistSkillCatalog()
   }
 
   // Returns the mcp-<id> skill names for connectors provisioned at the Main Agent level (enabled
@@ -1041,206 +1028,78 @@ class SettingsService {
   // Returns the subset of forced ids that are currently disabled in settings — i.e. the picks that need
   // a respawn to materialize. Enabled picks are already present and need no reconnect.
   async skillsNeedingForceLoad(forcedIds: string[]): Promise<string[]> {
-    const settings = await this.repository.getSettings()
-    const disabled = new Set(settings.disabledSkillIds ?? [])
-
-    return forcedIds.filter((id) => disabled.has(id))
+    return this.skills.skillsNeedingForceLoad(forcedIds)
   }
 
   // Resolves picker ids to the names the agent's Skill tool accepts. Bundled skills use their
   // manifest id as frontmatter name, while personal/imported ids have an app-owned source prefix and
   // must use the frontmatter name kept in the user skill catalog.
   async skillNudgeNamesForIds(ids: string[]): Promise<string[]> {
-    const skills = await this.skillCatalog()
-    const nameById = new Map(
-      skills.map((skill) => [skill.id, skill.source === 'featured' ? skill.id : skill.name])
-    )
-
-    return ids.map((id) => nameById.get(id)).filter((name): name is string => name !== undefined)
+    return this.skills.skillNudgeNamesForIds(ids)
   }
 
   async codexSkillDescriptorsForIds(
     ids: string[],
     codexHome: string | undefined
   ): Promise<Array<{ name: string; path: string }>> {
-    if (!codexHome || ids.length === 0) return []
-
-    const requestedHome = resolve(codexHome)
-    const allowedHomes = new Set([
-      resolve(codexStorageDir(this.storageRoot)),
-      resolve(codexSubscriptionStorageDir(this.storageRoot))
-    ])
-    if (!allowedHomes.has(requestedHome)) return []
-
-    const skillsRoot = join(requestedHome, 'skills')
-    const realSkillsRoot = await realpath(skillsRoot).catch(() => undefined)
-    if (!realSkillsRoot) return []
-    const rootWithSep = realSkillsRoot.endsWith(sep) ? realSkillsRoot : `${realSkillsRoot}${sep}`
-    const catalog = new Map((await this.skillCatalog()).map((skill) => [skill.id, skill] as const))
-    const descriptors: Array<{ name: string; path: string }> = []
-
-    for (const id of [...new Set(ids)]) {
-      const skill = catalog.get(id)
-      if (!skill) continue
-      const filePath = join(skillsRoot, `${OS_SKILL_PREFIX}${skill.id}`, 'SKILL.md')
-      const realFilePath = await realpath(filePath).catch(() => undefined)
-      if (!realFilePath || !realFilePath.startsWith(rootWithSep)) continue
-
-      descriptors.push({
-        name: skill.source === 'featured' ? skill.id : skill.name,
-        path: filePath
-      })
-    }
-
-    return descriptors
+    return this.skills.codexSkillDescriptorsForIds(ids, codexHome)
   }
 
   async codexSkillCatalog(
     codexHome: string | undefined
   ): Promise<Array<{ name: string; description: string; path: string }>> {
-    if (!codexHome) return []
-
-    const requestedHome = resolve(codexHome)
-    const allowedHomes = new Set([
-      resolve(codexStorageDir(this.storageRoot)),
-      resolve(codexSubscriptionStorageDir(this.storageRoot))
-    ])
-    if (!allowedHomes.has(requestedHome)) return []
-
-    const skillsRoot = join(requestedHome, 'skills')
-    const realSkillsRoot = await realpath(skillsRoot).catch(() => undefined)
-    if (!realSkillsRoot) return []
-    const rootWithSep = realSkillsRoot.endsWith(sep) ? realSkillsRoot : `${realSkillsRoot}${sep}`
-    const [skills, settings] = await Promise.all([
-      this.skillCatalog(),
-      this.repository.getSettings()
-    ])
-    const disabled = new Set(settings.disabledSkillIds ?? [])
-    const enabledSkills = skills
-      .filter((skill) => !disabled.has(skill.id))
-      .map((skill) => ({
-        directory: `${OS_SKILL_PREFIX}${skill.id}`,
-        name: skill.source === 'featured' ? skill.id : skill.name,
-        description: skill.description
-      }))
-    const enabledConnectors = this.enabledConnectorIds(settings.connectors).flatMap((id) => {
-      const connector = CONNECTOR_CATALOG.find((candidate) => candidate.id === id)
-      return connector
-        ? [
-            {
-              directory: `mcp-${id}`,
-              name: `mcp-${id}`,
-              description: connector.useWhen
-            }
-          ]
-        : []
+    return this.skills.codexSkillCatalog(codexHome, async () => {
+      const settings = await this.repository.getSettings()
+      return this.enabledConnectorIds(settings.connectors).flatMap((id) => {
+        const connector = CONNECTOR_CATALOG.find((candidate) => candidate.id === id)
+        return connector
+          ? [
+              {
+                directory: `mcp-${id}`,
+                name: `mcp-${id}`,
+                description: connector.useWhen
+              }
+            ]
+          : []
+      })
     })
-    const enabled = [...enabledSkills, ...enabledConnectors]
-    const nameCounts = new Map<string, number>()
-    for (const { name } of enabled) nameCounts.set(name, (nameCounts.get(name) ?? 0) + 1)
-
-    const catalog: Array<{ name: string; description: string; path: string }> = []
-    for (const { directory, name, description } of enabled) {
-      if (nameCounts.get(name) !== 1) continue
-      const filePath = join(skillsRoot, directory, 'SKILL.md')
-      const realFilePath = await realpath(filePath).catch(() => undefined)
-      if (!realFilePath || !realFilePath.startsWith(rootWithSep)) continue
-      catalog.push({ name, description, path: filePath })
-    }
-
-    return catalog.sort((a, b) => a.name.localeCompare(b.name))
   }
 
   // Returns one skill's view plus its SKILL.md body for the detail view (any source).
   async getSkillDetail(id: string): Promise<SkillDetailView> {
-    const [skills, settings] = await Promise.all([
-      this.skillCatalog(),
-      this.repository.getSettings()
-    ])
-    const skill = skills.find((entry) => entry.id === id)
-
-    if (!skill) {
-      throw new Error(`Unknown skill: ${id}`)
-    }
-
-    const disabled = new Set(settings.disabledSkillIds ?? [])
-    const { fields, body } = await readSkillFile(skill.sourceDir)
-    const metadata = Object.fromEntries(
-      Object.entries(fields).filter(([key]) => key !== 'name' && key !== 'description')
-    )
-    const references = await this.listSkillReferences(skill.sourceDir)
-
-    return { ...this.toSkillView(skill, disabled), body, metadata, references }
-  }
-
-  // Lists the file names directly under a skill's `references/` directory (empty when absent).
-  private async listSkillReferences(sourceDir: string): Promise<{ path: string }[]> {
-    try {
-      const entries = await readdir(join(sourceDir, 'references'), { withFileTypes: true })
-
-      return entries
-        .filter((entry) => entry.isFile())
-        .map((entry) => ({ path: entry.name }))
-        .sort((a, b) => a.path.localeCompare(b.path))
-    } catch {
-      return []
-    }
+    return this.skills.getSkillDetail(id)
   }
 
   // Toggles a skill and returns the refreshed list. The agent picks up the change on its next reconnect
   // (driven by the IPC layer's onSkillsChanged), which re-provisions the config dir.
   async setSkillEnabled(request: SetSkillEnabledRequest): Promise<SkillView[]> {
-    await this.repository.setSkillEnabled(request.id, request.enabled)
-
-    return this.listSkills()
+    return this.skills.setSkillEnabled(request)
   }
 
   // Creates a personal skill from the in-app editor, returning the refreshed list.
   async createSkill(request: CreateSkillRequest): Promise<SkillView[]> {
-    await this.userSkills.createPersonal(request, request.slug)
-
-    return this.listSkills()
+    return this.skills.createSkill(request)
   }
 
   // Updates an existing personal skill in place, returning the refreshed list.
   async updateSkill(request: UpdateSkillRequest): Promise<SkillView[]> {
-    await this.userSkills.updatePersonal(request.id, {
-      name: request.name,
-      description: request.description,
-      body: request.body,
-      metadata: request.metadata,
-      references: request.references
-    })
-
-    return this.listSkills()
+    return this.skills.updateSkill(request)
   }
 
   // Deletes a personal or imported skill, returning the refreshed list.
   async deleteSkill(request: DeleteSkillRequest): Promise<SkillView[]> {
-    await this.userSkills.delete(request.id)
-    // Drop any stale disabled entry so a re-created skill with the same id starts enabled.
-    await this.repository.setSkillEnabled(request.id, true)
-
-    return this.listSkills()
+    return this.skills.deleteSkill(request)
   }
 
   // Imports a skill from a public GitHub URL (deduplicated), returning the outcome + refreshed list.
   async importSkill(request: ImportSkillRequest): Promise<ImportSkillResult> {
-    const outcome = await this.userSkills.importFromGitHub(request.url, netFetch)
-
-    return { status: outcome.status, id: outcome.id, skills: await this.listSkills() }
+    return this.skills.importSkill(request)
   }
 
   // Imports a skill from an uploaded .zip / .skill bundle, returning the outcome + refreshed list. The
   // decode is bounded by the (larger) whole-bundle cap since one upload may carry many skills.
   async importSkillZip(request: ImportSkillZipRequest): Promise<ImportSkillResult> {
-    const zip = decodeBoundedBase64(request.dataBase64, SKILL_IMPORT_LIMITS.maxBundleBytes)
-    const outcome = await this.userSkills.importFromZip(zip, {
-      subPath: request.subPath,
-      replaceId: request.replaceId
-    })
-
-    return { status: outcome.status, id: outcome.id, skills: await this.listSkills() }
+    return this.skills.importSkillZip(request)
   }
 
   // Imports several skills from ONE uploaded bundle in a single call (the bundle is decoded and
@@ -1249,57 +1108,37 @@ class SettingsService {
   async importSkillZipBatch(
     request: ImportSkillZipBatchRequest
   ): Promise<ImportSkillZipBatchResult> {
-    const zip = decodeBoundedBase64(request.dataBase64, SKILL_IMPORT_LIMITS.maxBundleBytes)
-    const outcomes = await this.importSkillArchiveBatch(zip, request.items)
-    // Success and failure are mutually exclusive: a succeeded item carries status+id, a failed one
-    // carries only error (never a placeholder status).
-    const results: ImportSkillZipBatchResult['results'] = outcomes.map((entry) =>
-      entry.outcome
-        ? { subPath: entry.subPath, status: entry.outcome.status, id: entry.outcome.id }
-        : { subPath: entry.subPath, error: entry.error ?? 'Import failed.' }
-    )
-    return { results, skills: await this.listSkills() }
+    return this.skills.importSkillZipBatch(request)
   }
 
   // Parses an uploaded bundle for a confirm-before-import preview, without writing anything. Returns
   // the importable skills plus any the bundle contained that were skipped (too large, no SKILL.md, ...).
   async previewSkillZip(request: PreviewSkillZipRequest): Promise<SkillBundlePreviewResult> {
-    return this.previewSkillArchive(
-      decodeBoundedBase64(request.dataBase64, SKILL_IMPORT_LIMITS.maxBundleBytes)
-    )
+    return this.skills.previewSkillZip(request)
   }
 
   // Main-process callers that already own validated bytes use these archive-level methods directly;
   // renderer IPC remains base64-shaped, while conversation imports avoid a redundant encode/decode.
   async previewSkillArchive(zip: Buffer): Promise<SkillBundlePreviewResult> {
-    return this.userSkills.previewZip(zip)
+    return this.skills.previewSkillArchive(zip)
   }
 
   async importSkillArchiveBatch(
     zip: Buffer,
     items: ImportSkillZipBatchRequest['items']
   ): ReturnType<UserSkillRepository['importFromZipBatch']> {
-    return this.userSkills.importFromZipBatch(zip, items)
+    return this.skills.importSkillArchiveBatch(zip, items)
   }
 
   // Lazily loads one selected GitHub candidate. The repository's bounded helper downloads only its
   // SKILL.md; the display label is reconstructed from the public URL and contains no host paths.
   async previewGitHubSkill(request: PreviewGitHubSkillRequest): Promise<SkillImportPreviewContent> {
-    const location = parseGitHubSkillUrl(request.url)
-    if (!location) throw new Error('Not a recognizable GitHub URL.')
-    const preview = await this.userSkills.previewGitHubSkill(request.url, netFetch)
-    const suffix = location.path ? `/${location.path}` : ''
-    const revision = location.ref ? `@${location.ref}` : ''
-
-    return {
-      ...preview,
-      sourceLabel: `github.com/${location.owner}/${location.repo}${revision}${suffix}`
-    }
+    return this.skills.previewGitHubSkill(request)
   }
 
   // Scans a GitHub repo for importable skill directories (marking already-imported ones).
   async scanRepoSkills(request: ScanRepoRequest): Promise<ScanRepoResult> {
-    return { skills: await this.userSkills.scanRepo(request.repo, netFetch) }
+    return this.skills.scanRepoSkills(request)
   }
 
   // Lists user-installed skills from the framework-neutral ~/.agents/skills source plus the active
@@ -3186,12 +3025,11 @@ class SettingsService {
     configRoot: string,
     forcedSkillIds: ReadonlySet<string>
   ): Promise<void> {
-    const disabled = new Set(
-      (settings.disabledSkillIds ?? []).filter((id) => !forcedSkillIds.has(id))
+    await this.skills.materializeSkills(
+      configRoot,
+      settings.disabledSkillIds ?? [],
+      forcedSkillIds
     )
-    const enabled = (await this.skillCatalog()).filter((skill) => !disabled.has(skill.id))
-
-    await new ClaudeCodeSkillMaterializer().sync(configRoot, enabled)
 
     // Connector skill docs (which instruct the agent to reach a service ONLY via `host.mcp` from the
     // notebook kernel) are otherwise synced only into the Claude config dir. Non-Claude frameworks
@@ -3210,10 +3048,7 @@ class SettingsService {
       (id) => !forcedSkillIds.has(id)
     )
 
-    await provisionAppClaudeConfigDir(configDir, {
-      skills: await this.skillCatalog(),
-      disabledSkillIds
-    })
+    await this.skills.provisionClaudeConfig(configDir, disabledSkillIds)
 
     const connectors = await this.getConnectors()
     await syncConnectorSkillDocs(join(configDir, 'skills'), this.enabledConnectorIds(connectors))

--- a/src/main/settings/service.ts
+++ b/src/main/settings/service.ts
@@ -1031,8 +1031,7 @@ class SettingsService {
   async codexSkillCatalog(
     codexHome: string | undefined
   ): Promise<Array<{ name: string; description: string; path: string }>> {
-    return this.skills.codexSkillCatalog(codexHome, async () => {
-      const settings = await this.repository.getSettings()
+    return this.skills.codexSkillCatalog(codexHome, (settings) => {
       return this.enabledConnectorIds(settings.connectors).flatMap((id) => {
         const connector = CONNECTOR_CATALOG.find((candidate) => candidate.id === id)
         return connector

--- a/src/main/settings/service.ts
+++ b/src/main/settings/service.ts
@@ -1,8 +1,8 @@
 import { execFile } from 'node:child_process'
-import { access, readdir, realpath } from 'node:fs/promises'
+import { access } from 'node:fs/promises'
 import { constants } from 'node:fs'
 import { homedir } from 'node:os'
-import { dirname, isAbsolute, join, relative, resolve, sep } from 'node:path'
+import { dirname, join } from 'node:path'
 import { randomUUID } from 'node:crypto'
 import { createServer } from 'node:net'
 import { isDeepStrictEqual, promisify } from 'node:util'
@@ -23,8 +23,6 @@ import type {
   RemoveCustomServerRequest,
   SetCustomServerEnabledRequest,
   UpdateCustomServerRequest,
-  AgentHomeSkillRef,
-  AgentHomeSkillSource,
   AgentHomeSkillView,
   CreateSkillRequest,
   DeleteSkillRequest,
@@ -156,8 +154,6 @@ import {
   isOfficialOpenAiResponsesBase,
   normalizeResponsesBaseUrl
 } from '../agent-framework/codex'
-import { ClaudeCodeSkillMaterializer, OS_SKILL_PREFIX } from '../skills/materializer'
-import { provisionAppClaudeConfigDir } from './claude-config-provision'
 import { detectNpmAvailable, runInstallWithFallback, type InstallTarget } from './claude-install'
 import { OPENCODE_INSTALL_TARGET } from './opencode-install'
 import {
@@ -205,12 +201,9 @@ import { CONNECTOR_CATALOG } from '../connectors/catalog'
 import { getConnectorTools } from '../connectors/registry'
 import { renderConnectorInstructions } from '../connectors/skill-doc'
 import { syncConnectorSkillDocs } from '../connectors/provision'
-import { SkillRegistry, type BundledSkill } from '../skills/registry'
-import { SAFE_SLUG, UserSkillRepository } from '../skills/user-skill-repository'
-import { parseGitHubSkillUrl } from '../skills/github-import'
-import { netFetch, netFetchStandard } from '../skills/net-fetch'
-import { decodeBoundedBase64, SKILL_IMPORT_LIMITS } from '../skills/import-limits'
-import { readSkillFile } from '../skills/skill-files'
+import { SkillRegistry } from '../skills/registry'
+import { UserSkillRepository } from '../skills/user-skill-repository'
+import { netFetchStandard } from '../skills/net-fetch'
 import { requestSkillImportToolSchema } from '../skills/mcp-server'
 import {
   REQUEST_SKILL_IMPORT_TOOL_DESCRIPTION,
@@ -496,16 +489,6 @@ export type AgentSpawnConfig = {
 export type UninstallResult = {
   snapshot: SettingsSnapshot
   activeBackendAffected: boolean
-}
-
-type AgentHomeSkillDir = { source: AgentHomeSkillSource; dir: string }
-
-type DiscoveredAgentHomeSkill = {
-  skill: AgentHomeSkillView
-  realPath: string
-  aliases: AgentHomeSkillRef[]
-  fallbackAliases: AgentHomeSkillRef[]
-  matchedFallbackSlugs: Set<string>
 }
 
 export type SettingsServiceOptions = {
@@ -1141,373 +1124,22 @@ class SettingsService {
     return this.skills.scanRepoSkills(request)
   }
 
-  // Lists user-installed skills from the framework-neutral ~/.agents/skills source plus the active
-  // framework's own source (~/.claude/skills or ~/.codex/skills). Node's homedir() supplies the
-  // Windows USERPROFILE equivalent, so no platform-specific path parsing reaches the renderer.
+  // Compatibility facade for installed Skill discovery, preview, and batch import.
   async listAgentHomeSkills(): Promise<AgentHomeSkillView[]> {
-    const settings = await this.repository.getSettings()
-    const framework = settings.agentFrameworkId ?? DEFAULT_AGENT_FRAMEWORK_ID
-    const sources = this.resolveAgentHomeSkillDirs(framework)
-
-    return (await this.discoverAgentHomeSkills(sources)).map((item) => item.skill)
+    return this.skills.listAgentHomeSkills()
   }
 
-  // Resolves duplicate source rows by their real directory while retaining every source/slug alias.
-  // The aliases are internal import identities: the renderer sees one canonical row, but records
-  // created before canonicalization can still be matched without creating a duplicate.
-  private async discoverAgentHomeSkills(
-    sources: AgentHomeSkillDir[]
-  ): Promise<DiscoveredAgentHomeSkill[]> {
-    // Sources are additive, so one unreadable directory must not hide healthy results. If no source
-    // yields a usable skill, preserve a real scan error instead of presenting a false empty state.
-    const scanResults = await Promise.allSettled(
-      sources.map(async ({ source, dir }) => {
-        const skills = await this.userSkills.listAgentHomeSkills(dir, source)
-        const visible: {
-          skill: AgentHomeSkillView
-          realPath: string
-          alias: AgentHomeSkillRef
-        }[] = []
-
-        for (const skill of skills) {
-          try {
-            const realPath = await this.resolveAgentHomeSkillPath(source, skill.slug, sources)
-            visible.push({
-              realPath,
-              alias: { source, slug: skill.slug },
-              skill: {
-                source,
-                slug: skill.slug,
-                name: skill.name,
-                description: skill.description,
-                alreadyImported: skill.alreadyImported
-              }
-            })
-          } catch {
-            continue
-          }
-        }
-
-        return visible
-      })
-    )
-    const groups = scanResults.flatMap((result) =>
-      result.status === 'fulfilled' ? [result.value] : []
-    )
-    const firstFailure = scanResults.find((result) => result.status === 'rejected')
-    if (groups.every((group) => group.length === 0) && firstFailure?.status === 'rejected') {
-      throw firstFailure.reason
-    }
-
-    const unique = new Map<string, DiscoveredAgentHomeSkill>()
-    for (const item of groups.flat()) {
-      const pathKey = process.platform === 'win32' ? item.realPath.toLowerCase() : item.realPath
-      const existing = unique.get(pathKey)
-      if (existing) {
-        existing.aliases.push(item.alias)
-        existing.skill.alreadyImported ||= item.skill.alreadyImported
-      } else {
-        unique.set(pathKey, {
-          skill: item.skill,
-          realPath: item.realPath,
-          aliases: [item.alias],
-          fallbackAliases: [],
-          matchedFallbackSlugs: new Set()
-        })
-      }
-    }
-
-    const discovered = [...unique.values()]
-    try {
-      const matches = await this.userSkills.matchImportedAgentHomeSkills(
-        discovered.map((item) => ({
-          sourcePath: item.realPath,
-          canonical: { source: item.skill.source, slug: item.skill.slug },
-          aliases: item.aliases
-        }))
-      )
-      for (const [index, match] of matches.entries()) {
-        const item = discovered[index]
-        if (item) {
-          item.skill.alreadyImported = match.identityImported
-          item.fallbackAliases.push(...match.fallbackAliases)
-          if (match.identityMigrationNeeded) {
-            try {
-              await this.userSkills.importAgentHomeSkill(
-                item.realPath,
-                { source: item.skill.source, slug: item.skill.slug },
-                {
-                  aliases: item.aliases,
-                  expectedSignature: match.matchedIdentitySignature,
-                  expectedImportedIdentity: match.matchedImportedIdentity
-                }
-              )
-            } catch {
-              // Keep the row actionable when automatic metadata migration fails. A manual import
-              // retries the same atomic staging path and reports any persistent error per item.
-              item.skill.alreadyImported = false
-            }
-          }
-        }
-      }
-    } catch {
-      // Preserve readable rows when compatibility matching fails. Import reports validation errors
-      // per item instead of one malformed legacy tree hiding healthy installed choices.
-    }
-    const fallbackBySlug = new Map<
-      string,
-      { item: DiscoveredAgentHomeSkill; alias: AgentHomeSkillRef }[]
-    >()
-    for (const item of discovered) {
-      if (item.skill.alreadyImported) continue
-      for (const alias of item.fallbackAliases) {
-        const candidates = fallbackBySlug.get(alias.slug) ?? []
-        candidates.push({ item, alias })
-        fallbackBySlug.set(alias.slug, candidates)
-      }
-    }
-    // Content matching has already excluded unrelated same-slug imports. Every remaining candidate
-    // represents the same legacy bytes, so all source rows claim the fallback and stay idempotent.
-    for (const [fallbackSlug, candidates] of fallbackBySlug) {
-      for (const candidate of candidates) {
-        candidate.item.skill.alreadyImported = true
-        candidate.item.matchedFallbackSlugs.add(fallbackSlug)
-      }
-    }
-
-    return discovered
-  }
-
-  // Lazily loads one selected installed candidate through the same trusted source routing, realpath
-  // containment, and canonical top-level identity used by import. Only a tilde display label leaves
-  // main; the resolved absolute path stays private to this process.
   async previewAgentHomeSkill(
     request: PreviewAgentHomeSkillRequest
   ): Promise<SkillImportPreviewContent> {
-    const settings = await this.repository.getSettings()
-    const framework = settings.agentFrameworkId ?? DEFAULT_AGENT_FRAMEWORK_ID
-    const availableSources = this.resolveAgentHomeSkillDirs(framework)
-    const requestedSourcePath = join(
-      availableSources.find((candidate) => candidate.source === request.source)?.dir ?? '',
-      request.slug
-    )
-    const sourcePath = await this.resolveAgentHomeSkillPath(
-      request.source,
-      request.slug,
-      availableSources
-    )
-    const canonical = await this.canonicalAgentHomeSkillRef(sourcePath, availableSources)
-    if (!canonical) {
-      throw new Error('Refusing to preview installed skill outside a top-level skill directory.')
-    }
-    const sourceRoot =
-      canonical.source === 'agents'
-        ? '~/.agents/skills'
-        : canonical.source === 'claude'
-          ? '~/.claude/skills'
-          : '~/.codex/skills'
-    const sourceLabel = `${sourceRoot}/${canonical.slug}`
-
-    try {
-      const preview = await this.userSkills.previewAgentHomeSkill(sourcePath)
-      return { ...preview, sourceLabel }
-    } catch (error) {
-      const message =
-        error instanceof Error ? error.message : 'Could not preview the installed skill.'
-      const redacted = [sourcePath, requestedSourcePath].reduce((value, hostPath) => {
-        if (!hostPath) return value
-        return value
-          .split(`${hostPath}${sep}`)
-          .join(`${sourceLabel}/`)
-          .split(hostPath)
-          .join(sourceLabel)
-      }, message)
-      throw new Error(redacted)
-    }
+    return this.skills.previewAgentHomeSkill(request)
   }
 
-  // The generic source is always available. A framework-specific source is additive, not a gate on
-  // the import feature, so Settings can keep the entry visible for OpenCode and future frameworks.
-  private resolveAgentHomeSkillDirs(framework: AgentFrameworkId): AgentHomeSkillDir[] {
-    const sources: AgentHomeSkillDir[] = [
-      { source: 'agents', dir: join(this.userAgentsDir, 'skills') }
-    ]
-
-    switch (framework) {
-      case 'claude-code':
-        sources.push({ source: 'claude', dir: join(this.userClaudeDir, 'skills') })
-        break
-      case 'codex':
-        sources.push({ source: 'codex', dir: join(this.userCodexDir, 'skills') })
-        break
-      default:
-        break
-    }
-
-    return sources
-  }
-
-  // Imports a checked batch while isolating failures per item. The repository's existing directory
-  // copy and conflict logic remains authoritative; this method adds only source routing and batching.
   async importAgentHomeSkills(
     request: ImportAgentHomeSkillsRequest
   ): Promise<ImportAgentHomeSkillsResult> {
-    if (!request || !Array.isArray(request.skills)) {
-      throw new Error('Installed skills must be an array.')
-    }
-    if (request.skills.length > SKILL_IMPORT_LIMITS.maxSkillsPerBundle) {
-      throw new Error(
-        `Cannot import more than ${SKILL_IMPORT_LIMITS.maxSkillsPerBundle} installed skills at once.`
-      )
-    }
-
-    const settings = await this.repository.getSettings()
-    const framework = settings.agentFrameworkId ?? DEFAULT_AGENT_FRAMEWORK_ID
-    const availableSources = this.resolveAgentHomeSkillDirs(framework)
-    // The picker normally just completed this scan. If an unrelated source becomes unreadable
-    // between listing and importing, keep per-item isolation and simply skip compatibility aliases.
-    const discoveredSkills = await this.discoverAgentHomeSkills(availableSources).catch(
-      () => [] as DiscoveredAgentHomeSkill[]
-    )
-    const discoveredByPath = new Map(
-      discoveredSkills.map((item) => [
-        process.platform === 'win32' ? item.realPath.toLowerCase() : item.realPath,
-        item
-      ])
-    )
-    const results: ImportAgentHomeSkillsResult['results'] = []
-
-    for (const skill of request.skills) {
-      const candidate =
-        typeof skill === 'object' && skill !== null
-          ? (skill as { source?: unknown; slug?: unknown })
-          : undefined
-      const ref: Partial<AgentHomeSkillRef> = {}
-      if (
-        candidate?.source === 'agents' ||
-        candidate?.source === 'claude' ||
-        candidate?.source === 'codex'
-      ) {
-        ref.source = candidate.source
-      }
-      if (typeof candidate?.slug === 'string') ref.slug = candidate.slug
-
-      try {
-        if (!ref.source || ref.slug === undefined) {
-          throw new Error('Installed skill entries must include a valid source and slug.')
-        }
-        const validatedRef: AgentHomeSkillRef = { source: ref.source, slug: ref.slug }
-        const sourcePath = await this.resolveAgentHomeSkillPath(
-          validatedRef.source,
-          validatedRef.slug,
-          availableSources
-        )
-        const canonicalSkill = await this.canonicalAgentHomeSkillRef(sourcePath, availableSources)
-        if (!canonicalSkill) {
-          throw new Error(`Refusing to import installed skill outside a top-level skill directory.`)
-        }
-        const pathKey = process.platform === 'win32' ? sourcePath.toLowerCase() : sourcePath
-        const discovered = discoveredByPath.get(pathKey)
-        const outcome = await this.userSkills.importAgentHomeSkill(sourcePath, canonicalSkill, {
-          aliases: discovered?.aliases,
-          fallbackSlugs: discovered ? [...discovered.matchedFallbackSlugs] : undefined
-        })
-
-        results.push({ ...validatedRef, status: outcome.status, id: outcome.id })
-      } catch (error) {
-        results.push({
-          ...ref,
-          error: error instanceof Error ? error.message : 'Could not import the installed skill.'
-        })
-      }
-    }
-
-    return { results, skills: await this.listSkills() }
+    return this.skills.importAgentHomeSkills(request)
   }
-
-  // Resolves a renderer-supplied source + slug to an absolute path under an available global source,
-  // refusing unavailable framework sources and path escapes. This keeps all path authority in main.
-  // Candidate and source roots are resolved via realpath. This permits the common layout where a
-  // framework-specific skill is a symlink into ~/.agents/skills, while rejecting targets outside
-  // every source available to the active framework.
-  private async resolveAgentHomeSkillPath(
-    source: AgentHomeSkillSource,
-    slug: string,
-    availableSources: { source: AgentHomeSkillSource; dir: string }[]
-  ): Promise<string> {
-    const homeSkillsDir = availableSources.find((candidate) => candidate.source === source)?.dir
-    if (!homeSkillsDir) {
-      throw new Error(`Installed skill source "${String(source)}" is not available.`)
-    }
-    if (!SAFE_SLUG.test(slug)) {
-      throw new Error(`Refusing to import installed skill with unsafe slug: ${slug}`)
-    }
-
-    const lexicalCandidate = resolve(homeSkillsDir, slug)
-    const candidate = await realpath(lexicalCandidate).catch(() => lexicalCandidate)
-    const allowedRoots = await Promise.all(
-      availableSources.map(({ dir }) => realpath(dir).catch(() => resolve(dir)))
-    )
-    const withinAllowedRoot = allowedRoots.some((root) => {
-      const rootWithSep = root.endsWith(sep) ? root : root + sep
-
-      return candidate === root || candidate.startsWith(rootWithSep)
-    })
-
-    if (!withinAllowedRoot) {
-      throw new Error(`Refusing to import installed skill outside its source: ${slug}`)
-    }
-    if (!(await this.canonicalAgentHomeSkillRef(candidate, availableSources))) {
-      throw new Error(
-        `Refusing to import installed skill outside a top-level skill directory: ${slug}`
-      )
-    }
-
-    // Copy from the resolved directory so a safe root symlink is dereferenced once. Nested symlinks
-    // remain visible to the repository copy filter and are still rejected.
-    return candidate
-  }
-
-  // A framework directory may alias a shared skill with a root symlink. Prefer the first direct
-  // source root that owns the resolved directory (the shared Agents root is ordered first), so both
-  // the visible row and a stale/direct import request converge on one installed-skill identity.
-  private async canonicalAgentHomeSkillRef(
-    realSkillPath: string,
-    availableSources: { source: AgentHomeSkillSource; dir: string }[]
-  ): Promise<AgentHomeSkillRef | undefined> {
-    for (const source of availableSources) {
-      const realRoot = await realpath(source.dir).catch(() => resolve(source.dir))
-      const child = relative(realRoot, realSkillPath)
-      if (
-        child &&
-        !isAbsolute(child) &&
-        child !== '..' &&
-        !child.startsWith(`..${sep}`) &&
-        !child.includes(sep) &&
-        SAFE_SLUG.test(child)
-      ) {
-        return { source: source.source, slug: child }
-      }
-    }
-
-    return undefined
-  }
-
-  // Projects a catalog skill into its renderer-safe view given the disabled set.
-  private toSkillView(skill: BundledSkill, disabled: Set<string>): SkillView {
-    return {
-      id: skill.id,
-      name: skill.name,
-      description: skill.description,
-      source: skill.source,
-      updatedAt: skill.updatedAt,
-      enabled: !disabled.has(skill.id),
-      author: skill.author,
-      license: skill.license,
-      thirdParty: skill.thirdParty
-    }
-  }
-
   // Computes the two startup gates, re-checking the claude path each call as the design requires.
   async getPreflight(): Promise<Preflight> {
     const settings = await this.repository.getSettings()

--- a/src/main/settings/skill-catalog.test.ts
+++ b/src/main/settings/skill-catalog.test.ts
@@ -58,7 +58,9 @@ describe('SkillCatalogModule', () => {
     const runtimeRoot = await mkdtemp(join(tmpdir(), 'settings-skill-runtime-'))
     roots.push(runtimeRoot)
     await catalog.materializeSkills(runtimeRoot, ['demo'])
-    await expect(readFile(join(runtimeRoot, 'skills', 'os-demo', 'SKILL.md'), 'utf8')).rejects.toThrow()
+    await expect(
+      readFile(join(runtimeRoot, 'skills', 'os-demo', 'SKILL.md'), 'utf8')
+    ).rejects.toThrow()
     await catalog.materializeSkills(runtimeRoot, ['demo'], new Set(['demo']))
     await expect(
       readFile(join(runtimeRoot, 'skills', 'os-demo', 'SKILL.md'), 'utf8')
@@ -71,9 +73,9 @@ describe('SkillCatalogModule', () => {
       })
     ).resolves.toEqual([])
     expect(
-      (
-        await catalog.createSkill({ name: 'My Skill', description: 'Mine.', body: '# Mine' })
-      ).map((skill) => skill.id)
+      (await catalog.createSkill({ name: 'My Skill', description: 'Mine.', body: '# Mine' })).map(
+        (skill) => skill.id
+      )
     ).toEqual(['demo', 'personal-my-skill'])
     expect(
       (
@@ -85,9 +87,9 @@ describe('SkillCatalogModule', () => {
         })
       ).find((skill) => skill.id === 'personal-my-skill')
     ).toMatchObject({ description: 'Edited.' })
-    expect((await catalog.deleteSkill({ id: 'personal-my-skill' })).map((skill) => skill.id)).toEqual([
-      'demo'
-    ])
+    expect(
+      (await catalog.deleteSkill({ id: 'personal-my-skill' })).map((skill) => skill.id)
+    ).toEqual(['demo'])
   })
 
   it('owns active-framework agent-home discovery and batch import', async () => {
@@ -129,9 +131,7 @@ describe('SkillCatalogModule', () => {
           skills: [{ source: 'agents', slug: 'shared' }]
         })
       ).results
-    ).toEqual([
-      { source: 'agents', slug: 'shared', status: 'imported', id: 'imported-shared' }
-    ])
+    ).toEqual([{ source: 'agents', slug: 'shared', status: 'imported', id: 'imported-shared' }])
 
     const preview = await catalog.previewAgentHomeSkill({ source: 'claude', slug: 'claude-only' })
     expect(preview.sourceLabel).toBe('~/.claude/skills/claude-only')

--- a/src/main/settings/skill-catalog.test.ts
+++ b/src/main/settings/skill-catalog.test.ts
@@ -1,0 +1,73 @@
+import { mkdir, mkdtemp, rm, writeFile } from 'node:fs/promises'
+import { tmpdir } from 'node:os'
+import { join } from 'node:path'
+
+import { afterEach, describe, expect, it } from 'vitest'
+
+import { SkillRegistry } from '../skills/registry'
+import { SettingsRepository } from './repository'
+import { SkillCatalogModule } from './skill-catalog'
+
+const roots: string[] = []
+
+afterEach(async () => {
+  await Promise.all(roots.splice(0).map((root) => rm(root, { recursive: true, force: true })))
+})
+
+const createCatalog = async (): Promise<SkillCatalogModule> => {
+  const storageRoot = await mkdtemp(join(tmpdir(), 'settings-skill-catalog-'))
+  const bundleRoot = await mkdtemp(join(tmpdir(), 'settings-skill-bundle-'))
+  roots.push(storageRoot, bundleRoot)
+  await mkdir(join(bundleRoot, 'demo'), { recursive: true })
+  await writeFile(
+    join(bundleRoot, 'demo', 'SKILL.md'),
+    '---\nname: demo\ndescription: A demo skill.\n---\n\ndemo body\n'
+  )
+  await writeFile(
+    join(bundleRoot, 'manifest.json'),
+    JSON.stringify({
+      version: 1,
+      skills: [
+        { id: 'demo', name: 'Demo', source: 'featured', updatedAt: '2026-01-01T00:00:00.000Z' }
+      ]
+    })
+  )
+  return new SkillCatalogModule({
+    repository: new SettingsRepository(storageRoot),
+    storageRoot,
+    skillRegistry: new SkillRegistry(bundleRoot),
+    userClaudeDir: join(storageRoot, 'user-claude'),
+    userCodexDir: join(storageRoot, 'user-codex'),
+    userAgentsDir: join(storageRoot, 'user-agents')
+  })
+}
+
+describe('SkillCatalogModule', () => {
+  it('owns catalog projection, enablement, detail, and personal CRUD', async () => {
+    const catalog = await createCatalog()
+
+    expect(await catalog.listSkills()).toEqual([
+      expect.objectContaining({ id: 'demo', description: 'A demo skill.', enabled: true })
+    ])
+    expect((await catalog.setSkillEnabled({ id: 'demo', enabled: false }))[0].enabled).toBe(false)
+    expect((await catalog.getSkillDetail('demo')).body).toContain('demo body')
+    expect(
+      (
+        await catalog.createSkill({ name: 'My Skill', description: 'Mine.', body: '# Mine' })
+      ).map((skill) => skill.id)
+    ).toEqual(['demo', 'personal-my-skill'])
+    expect(
+      (
+        await catalog.updateSkill({
+          id: 'personal-my-skill',
+          name: 'My Skill',
+          description: 'Edited.',
+          body: '# Edited'
+        })
+      ).find((skill) => skill.id === 'personal-my-skill')
+    ).toMatchObject({ description: 'Edited.' })
+    expect((await catalog.deleteSkill({ id: 'personal-my-skill' })).map((skill) => skill.id)).toEqual([
+      'demo'
+    ])
+  })
+})

--- a/src/main/settings/skill-catalog.test.ts
+++ b/src/main/settings/skill-catalog.test.ts
@@ -1,4 +1,4 @@
-import { mkdir, mkdtemp, rm, writeFile } from 'node:fs/promises'
+import { chmod, mkdir, mkdtemp, readFile, rm, writeFile } from 'node:fs/promises'
 import { tmpdir } from 'node:os'
 import { join } from 'node:path'
 
@@ -50,7 +50,26 @@ describe('SkillCatalogModule', () => {
       expect.objectContaining({ id: 'demo', description: 'A demo skill.', enabled: true })
     ])
     expect((await catalog.setSkillEnabled({ id: 'demo', enabled: false }))[0].enabled).toBe(false)
+    expect(await catalog.listSpecialistSkillCatalog()).toEqual([
+      { id: 'demo', frameworkName: 'demo', displayName: 'Demo' }
+    ])
     expect((await catalog.getSkillDetail('demo')).body).toContain('demo body')
+
+    const runtimeRoot = await mkdtemp(join(tmpdir(), 'settings-skill-runtime-'))
+    roots.push(runtimeRoot)
+    await catalog.materializeSkills(runtimeRoot, ['demo'])
+    await expect(readFile(join(runtimeRoot, 'skills', 'os-demo', 'SKILL.md'), 'utf8')).rejects.toThrow()
+    await catalog.materializeSkills(runtimeRoot, ['demo'], new Set(['demo']))
+    await expect(
+      readFile(join(runtimeRoot, 'skills', 'os-demo', 'SKILL.md'), 'utf8')
+    ).resolves.toContain('demo body')
+    expect((await catalog.listSkills())[0].enabled).toBe(false)
+    await chmod(join(runtimeRoot, 'skills', 'os-demo'), 0o755)
+    await expect(
+      catalog.codexSkillCatalog(join(tmpdir(), 'untrusted-codex-home'), async () => {
+        throw new Error('untrusted homes must not resolve catalog extensions')
+      })
+    ).resolves.toEqual([])
     expect(
       (
         await catalog.createSkill({ name: 'My Skill', description: 'Mine.', body: '# Mine' })
@@ -112,6 +131,24 @@ describe('SkillCatalogModule', () => {
       ).results
     ).toEqual([
       { source: 'agents', slug: 'shared', status: 'imported', id: 'imported-shared' }
+    ])
+
+    const preview = await catalog.previewAgentHomeSkill({ source: 'claude', slug: 'claude-only' })
+    expect(preview.sourceLabel).toBe('~/.claude/skills/claude-only')
+    expect(JSON.stringify(preview)).not.toContain(userClaudeDir)
+
+    expect(
+      (
+        await catalog.importAgentHomeSkills({
+          skills: [{ source: 'agents', slug: '../escape' }]
+        })
+      ).results
+    ).toEqual([
+      {
+        source: 'agents',
+        slug: '../escape',
+        error: 'Refusing to import installed skill with unsafe slug: ../escape'
+      }
     ])
   })
 })

--- a/src/main/settings/skill-catalog.test.ts
+++ b/src/main/settings/skill-catalog.test.ts
@@ -70,4 +70,48 @@ describe('SkillCatalogModule', () => {
       'demo'
     ])
   })
+
+  it('owns active-framework agent-home discovery and batch import', async () => {
+    const storageRoot = await mkdtemp(join(tmpdir(), 'settings-agent-home-catalog-'))
+    const bundleRoot = await mkdtemp(join(tmpdir(), 'settings-agent-home-bundle-'))
+    const userClaudeDir = await mkdtemp(join(tmpdir(), 'settings-agent-home-claude-'))
+    const userAgentsDir = await mkdtemp(join(tmpdir(), 'settings-agent-home-agents-'))
+    roots.push(storageRoot, bundleRoot, userClaudeDir, userAgentsDir)
+    await writeFile(join(bundleRoot, 'manifest.json'), JSON.stringify({ version: 1, skills: [] }))
+    const seed = async (home: string, slug: string): Promise<void> => {
+      await mkdir(join(home, 'skills', slug), { recursive: true })
+      await writeFile(
+        join(home, 'skills', slug, 'SKILL.md'),
+        `---\nname: ${slug}\ndescription: Test ${slug}\n---\nBody\n`
+      )
+    }
+    await seed(userAgentsDir, 'shared')
+    await seed(userClaudeDir, 'claude-only')
+    const repository = new SettingsRepository(storageRoot)
+    await repository.setAgentFramework('claude-code')
+    const catalog = new SkillCatalogModule({
+      repository,
+      storageRoot,
+      userClaudeDir,
+      userAgentsDir,
+      userCodexDir: join(storageRoot, 'user-codex'),
+      skillRegistry: new SkillRegistry(bundleRoot)
+    })
+
+    expect(
+      (await catalog.listAgentHomeSkills()).map(({ source, slug }) => ({ source, slug }))
+    ).toEqual([
+      { source: 'agents', slug: 'shared' },
+      { source: 'claude', slug: 'claude-only' }
+    ])
+    expect(
+      (
+        await catalog.importAgentHomeSkills({
+          skills: [{ source: 'agents', slug: 'shared' }]
+        })
+      ).results
+    ).toEqual([
+      { source: 'agents', slug: 'shared', status: 'imported', id: 'imported-shared' }
+    ])
+  })
 })

--- a/src/main/settings/skill-catalog.ts
+++ b/src/main/settings/skill-catalog.ts
@@ -1,0 +1,331 @@
+import { readdir, realpath } from 'node:fs/promises'
+import { join, resolve, sep } from 'node:path'
+
+import type {
+  CreateSkillRequest,
+  DeleteSkillRequest,
+  ImportSkillRequest,
+  ImportSkillResult,
+  ImportSkillZipBatchRequest,
+  ImportSkillZipBatchResult,
+  ImportSkillZipRequest,
+  PreviewGitHubSkillRequest,
+  PreviewSkillZipRequest,
+  ScanRepoRequest,
+  ScanRepoResult,
+  SetSkillEnabledRequest,
+  SkillBundlePreviewResult,
+  SkillDetailView,
+  SkillImportPreviewContent,
+  SkillView,
+  UpdateSkillRequest
+} from '../../shared/settings'
+import { codexStorageDir, codexSubscriptionStorageDir } from '../agent-framework/codex'
+import { parseGitHubSkillUrl } from '../skills/github-import'
+import { decodeBoundedBase64, SKILL_IMPORT_LIMITS } from '../skills/import-limits'
+import { ClaudeCodeSkillMaterializer, OS_SKILL_PREFIX } from '../skills/materializer'
+import { netFetch } from '../skills/net-fetch'
+import { SkillRegistry, type BundledSkill } from '../skills/registry'
+import { readSkillFile } from '../skills/skill-files'
+import { UserSkillRepository } from '../skills/user-skill-repository'
+import { provisionAppClaudeConfigDir } from './claude-config-provision'
+import type { SettingsRepository } from './repository'
+
+type SkillCatalogEntry = { name: string; description: string; path: string }
+type AdditionalSkillCatalogEntry = Omit<SkillCatalogEntry, 'path'> & { directory: string }
+type AdditionalSkillCatalogEntries =
+  | readonly AdditionalSkillCatalogEntry[]
+  | (() => Promise<readonly AdditionalSkillCatalogEntry[]>)
+
+type SkillCatalogModuleOptions = {
+  repository: SettingsRepository
+  storageRoot: string
+  userClaudeDir?: string
+  userCodexDir?: string
+  userAgentsDir?: string
+  skillRegistry?: SkillRegistry
+  userSkills?: UserSkillRepository
+}
+
+// Owns the installed Skill catalog and its filesystem rules. SettingsService remains a compatibility
+// facade for existing Electron, Web, CLI, IPC, runtime, and Specialist callers.
+class SkillCatalogModule {
+  private readonly skillRegistry: SkillRegistry
+  private readonly userSkills: UserSkillRepository
+
+  constructor(private readonly options: SkillCatalogModuleOptions) {
+    this.skillRegistry = options.skillRegistry ?? new SkillRegistry()
+    this.userSkills = options.userSkills ?? new UserSkillRepository(options.storageRoot)
+  }
+
+  private async catalog(): Promise<BundledSkill[]> {
+    const [featured, user] = await Promise.all([this.skillRegistry.list(), this.userSkills.list()])
+    return [...featured, ...user]
+  }
+
+  async listSkills(): Promise<SkillView[]> {
+    const [skills, settings] = await Promise.all([
+      this.catalog(),
+      this.options.repository.getSettings()
+    ])
+    const disabled = new Set(settings.disabledSkillIds ?? [])
+    return skills.map((skill) => this.toSkillView(skill, disabled))
+  }
+
+  async listSpecialistSkillCatalog(): Promise<
+    Array<{ id: string; frameworkName: string; displayName: string }>
+  > {
+    return (await this.catalog()).map((skill) => ({
+      id: skill.id,
+      frameworkName: skill.source === 'featured' ? skill.id : skill.name,
+      displayName: skill.name
+    }))
+  }
+
+  async skillsNeedingForceLoad(ids: string[]): Promise<string[]> {
+    const disabled = new Set(
+      (await this.options.repository.getSettings()).disabledSkillIds ?? []
+    )
+    return ids.filter((id) => disabled.has(id))
+  }
+
+  async skillNudgeNamesForIds(ids: string[]): Promise<string[]> {
+    const nameById = new Map(
+      (await this.catalog()).map((skill) => [
+        skill.id,
+        skill.source === 'featured' ? skill.id : skill.name
+      ])
+    )
+    return ids.map((id) => nameById.get(id)).filter((name): name is string => name !== undefined)
+  }
+
+  async codexSkillDescriptorsForIds(
+    ids: string[],
+    codexHome: string | undefined
+  ): Promise<Array<{ name: string; path: string }>> {
+    if (!codexHome || ids.length === 0) return []
+    const skillsRoot = this.allowedCodexSkillsRoot(codexHome)
+    if (!skillsRoot) return []
+    const realRoot = await realpath(skillsRoot).catch(() => undefined)
+    if (!realRoot) return []
+    const rootWithSep = realRoot.endsWith(sep) ? realRoot : `${realRoot}${sep}`
+    const byId = new Map((await this.catalog()).map((skill) => [skill.id, skill] as const))
+    const descriptors: Array<{ name: string; path: string }> = []
+    for (const id of [...new Set(ids)]) {
+      const skill = byId.get(id)
+      if (!skill) continue
+      const filePath = join(skillsRoot, `${OS_SKILL_PREFIX}${skill.id}`, 'SKILL.md')
+      const realFile = await realpath(filePath).catch(() => undefined)
+      if (!realFile || !realFile.startsWith(rootWithSep)) continue
+      descriptors.push({
+        name: skill.source === 'featured' ? skill.id : skill.name,
+        path: filePath
+      })
+    }
+    return descriptors
+  }
+
+  async codexSkillCatalog(
+    codexHome: string | undefined,
+    additionalEntries: AdditionalSkillCatalogEntries = []
+  ): Promise<SkillCatalogEntry[]> {
+    if (!codexHome) return []
+    const skillsRoot = this.allowedCodexSkillsRoot(codexHome)
+    if (!skillsRoot) return []
+    const realRoot = await realpath(skillsRoot).catch(() => undefined)
+    if (!realRoot) return []
+    const rootWithSep = realRoot.endsWith(sep) ? realRoot : `${realRoot}${sep}`
+    const [skills, settings, extensions] = await Promise.all([
+      this.catalog(),
+      this.options.repository.getSettings(),
+      typeof additionalEntries === 'function' ? additionalEntries() : additionalEntries
+    ])
+    const disabled = new Set(settings.disabledSkillIds ?? [])
+    const enabled = [
+      ...skills
+        .filter((skill) => !disabled.has(skill.id))
+        .map((skill) => ({
+          directory: `${OS_SKILL_PREFIX}${skill.id}`,
+          name: skill.source === 'featured' ? skill.id : skill.name,
+          description: skill.description
+        })),
+      ...extensions
+    ]
+    const nameCounts = new Map<string, number>()
+    for (const item of enabled) nameCounts.set(item.name, (nameCounts.get(item.name) ?? 0) + 1)
+    const result: SkillCatalogEntry[] = []
+    for (const item of enabled) {
+      if (nameCounts.get(item.name) !== 1) continue
+      const filePath = join(skillsRoot, item.directory, 'SKILL.md')
+      const realFile = await realpath(filePath).catch(() => undefined)
+      if (!realFile || !realFile.startsWith(rootWithSep)) continue
+      result.push({ name: item.name, description: item.description, path: filePath })
+    }
+    return result.sort((a, b) => a.name.localeCompare(b.name))
+  }
+
+  async getSkillDetail(id: string): Promise<SkillDetailView> {
+    const [skills, settings] = await Promise.all([
+      this.catalog(),
+      this.options.repository.getSettings()
+    ])
+    const skill = skills.find((entry) => entry.id === id)
+    if (!skill) throw new Error(`Unknown skill: ${id}`)
+    const { fields, body } = await readSkillFile(skill.sourceDir)
+    return {
+      ...this.toSkillView(skill, new Set(settings.disabledSkillIds ?? [])),
+      body,
+      metadata: Object.fromEntries(
+        Object.entries(fields).filter(([key]) => key !== 'name' && key !== 'description')
+      ),
+      references: await this.listReferences(skill.sourceDir)
+    }
+  }
+
+  async setSkillEnabled(request: SetSkillEnabledRequest): Promise<SkillView[]> {
+    await this.options.repository.setSkillEnabled(request.id, request.enabled)
+    return this.listSkills()
+  }
+
+  async createSkill(request: CreateSkillRequest): Promise<SkillView[]> {
+    await this.userSkills.createPersonal(request, request.slug)
+    return this.listSkills()
+  }
+
+  async updateSkill(request: UpdateSkillRequest): Promise<SkillView[]> {
+    await this.userSkills.updatePersonal(request.id, {
+      name: request.name,
+      description: request.description,
+      body: request.body,
+      metadata: request.metadata,
+      references: request.references
+    })
+    return this.listSkills()
+  }
+
+  async deleteSkill(request: DeleteSkillRequest): Promise<SkillView[]> {
+    await this.userSkills.delete(request.id)
+    await this.options.repository.setSkillEnabled(request.id, true)
+    return this.listSkills()
+  }
+
+  async importSkill(request: ImportSkillRequest): Promise<ImportSkillResult> {
+    const outcome = await this.userSkills.importFromGitHub(request.url, netFetch)
+    return { ...outcome, skills: await this.listSkills() }
+  }
+
+  async importSkillZip(request: ImportSkillZipRequest): Promise<ImportSkillResult> {
+    const zip = decodeBoundedBase64(request.dataBase64, SKILL_IMPORT_LIMITS.maxBundleBytes)
+    const outcome = await this.userSkills.importFromZip(zip, {
+      subPath: request.subPath,
+      replaceId: request.replaceId
+    })
+    return { ...outcome, skills: await this.listSkills() }
+  }
+
+  async importSkillZipBatch(
+    request: ImportSkillZipBatchRequest
+  ): Promise<ImportSkillZipBatchResult> {
+    const zip = decodeBoundedBase64(request.dataBase64, SKILL_IMPORT_LIMITS.maxBundleBytes)
+    const outcomes = await this.importSkillArchiveBatch(zip, request.items)
+    return {
+      results: outcomes.map((entry) =>
+        entry.outcome
+          ? { subPath: entry.subPath, ...entry.outcome }
+          : { subPath: entry.subPath, error: entry.error ?? 'Import failed.' }
+      ),
+      skills: await this.listSkills()
+    }
+  }
+
+  async previewSkillZip(request: PreviewSkillZipRequest): Promise<SkillBundlePreviewResult> {
+    return this.previewSkillArchive(
+      decodeBoundedBase64(request.dataBase64, SKILL_IMPORT_LIMITS.maxBundleBytes)
+    )
+  }
+
+  async previewSkillArchive(zip: Buffer): Promise<SkillBundlePreviewResult> {
+    return this.userSkills.previewZip(zip)
+  }
+
+  async importSkillArchiveBatch(
+    zip: Buffer,
+    items: ImportSkillZipBatchRequest['items']
+  ): ReturnType<UserSkillRepository['importFromZipBatch']> {
+    return this.userSkills.importFromZipBatch(zip, items)
+  }
+
+  async previewGitHubSkill(
+    request: PreviewGitHubSkillRequest
+  ): Promise<SkillImportPreviewContent> {
+    const location = parseGitHubSkillUrl(request.url)
+    if (!location) throw new Error('Not a recognizable GitHub URL.')
+    const preview = await this.userSkills.previewGitHubSkill(request.url, netFetch)
+    const suffix = location.path ? `/${location.path}` : ''
+    const revision = location.ref ? `@${location.ref}` : ''
+    return {
+      ...preview,
+      sourceLabel: `github.com/${location.owner}/${location.repo}${revision}${suffix}`
+    }
+  }
+
+  async scanRepoSkills(request: ScanRepoRequest): Promise<ScanRepoResult> {
+    return { skills: await this.userSkills.scanRepo(request.repo, netFetch) }
+  }
+
+  async materializeSkills(
+    configRoot: string,
+    disabledIds: readonly string[],
+    forcedIds: ReadonlySet<string> = new Set()
+  ): Promise<void> {
+    const disabled = new Set(disabledIds.filter((id) => !forcedIds.has(id)))
+    await new ClaudeCodeSkillMaterializer().sync(
+      configRoot,
+      (await this.catalog()).filter((skill) => !disabled.has(skill.id))
+    )
+  }
+
+  async provisionClaudeConfig(configDir: string, disabledSkillIds: string[]): Promise<void> {
+    await provisionAppClaudeConfigDir(configDir, {
+      skills: await this.catalog(),
+      disabledSkillIds
+    })
+  }
+
+  private allowedCodexSkillsRoot(codexHome: string): string | undefined {
+    const requested = resolve(codexHome)
+    const allowed = new Set([
+      resolve(codexStorageDir(this.options.storageRoot)),
+      resolve(codexSubscriptionStorageDir(this.options.storageRoot))
+    ])
+    return allowed.has(requested) ? join(requested, 'skills') : undefined
+  }
+
+  private async listReferences(sourceDir: string): Promise<{ path: string }[]> {
+    try {
+      return (await readdir(join(sourceDir, 'references'), { withFileTypes: true }))
+        .filter((entry) => entry.isFile())
+        .map((entry) => ({ path: entry.name }))
+        .sort((a, b) => a.path.localeCompare(b.path))
+    } catch {
+      return []
+    }
+  }
+
+  private toSkillView(skill: BundledSkill, disabled: Set<string>): SkillView {
+    return {
+      id: skill.id,
+      name: skill.name,
+      description: skill.description,
+      source: skill.source,
+      updatedAt: skill.updatedAt,
+      enabled: !disabled.has(skill.id),
+      author: skill.author,
+      license: skill.license,
+      thirdParty: skill.thirdParty
+    }
+  }
+}
+
+export { SkillCatalogModule }
+export type { AdditionalSkillCatalogEntry, SkillCatalogModuleOptions }

--- a/src/main/settings/skill-catalog.ts
+++ b/src/main/settings/skill-catalog.ts
@@ -38,11 +38,15 @@ import { readSkillFile } from '../skills/skill-files'
 import { SAFE_SLUG, UserSkillRepository } from '../skills/user-skill-repository'
 import { provisionAppClaudeConfigDir } from './claude-config-provision'
 import type { SettingsRepository } from './repository'
+import type { StoredSettings } from './types'
 
 type SkillCatalogEntry = { name: string; description: string; path: string }
 type AdditionalSkillCatalogEntry = Omit<SkillCatalogEntry, 'path'> & { directory: string }
 type AdditionalSkillCatalogEntries =
-  readonly AdditionalSkillCatalogEntry[] | (() => Promise<readonly AdditionalSkillCatalogEntry[]>)
+  | readonly AdditionalSkillCatalogEntry[]
+  | ((
+      settings: StoredSettings
+    ) => readonly AdditionalSkillCatalogEntry[] | Promise<readonly AdditionalSkillCatalogEntry[]>)
 type AgentHomeSkillDir = { source: AgentHomeSkillSource; dir: string }
 type DiscoveredAgentHomeSkill = {
   skill: AgentHomeSkillView
@@ -148,11 +152,14 @@ class SkillCatalogModule {
     const realRoot = await realpath(skillsRoot).catch(() => undefined)
     if (!realRoot) return []
     const rootWithSep = realRoot.endsWith(sep) ? realRoot : `${realRoot}${sep}`
-    const [skills, settings, extensions] = await Promise.all([
+    const [skills, settings] = await Promise.all([
       this.catalog(),
-      this.options.repository.getSettings(),
-      typeof additionalEntries === 'function' ? additionalEntries() : additionalEntries
+      this.options.repository.getSettings()
     ])
+    const extensions =
+      typeof additionalEntries === 'function'
+        ? await additionalEntries(settings)
+        : additionalEntries
     const disabled = new Set(settings.disabledSkillIds ?? [])
     const enabled = [
       ...skills

--- a/src/main/settings/skill-catalog.ts
+++ b/src/main/settings/skill-catalog.ts
@@ -27,10 +27,7 @@ import type {
   SkillView,
   UpdateSkillRequest
 } from '../../shared/settings'
-import {
-  DEFAULT_AGENT_FRAMEWORK_ID,
-  type AgentFrameworkId
-} from '../agent-framework'
+import { DEFAULT_AGENT_FRAMEWORK_ID, type AgentFrameworkId } from '../agent-framework'
 import { codexStorageDir, codexSubscriptionStorageDir } from '../agent-framework/codex'
 import { parseGitHubSkillUrl } from '../skills/github-import'
 import { decodeBoundedBase64, SKILL_IMPORT_LIMITS } from '../skills/import-limits'
@@ -45,8 +42,7 @@ import type { SettingsRepository } from './repository'
 type SkillCatalogEntry = { name: string; description: string; path: string }
 type AdditionalSkillCatalogEntry = Omit<SkillCatalogEntry, 'path'> & { directory: string }
 type AdditionalSkillCatalogEntries =
-  | readonly AdditionalSkillCatalogEntry[]
-  | (() => Promise<readonly AdditionalSkillCatalogEntry[]>)
+  readonly AdditionalSkillCatalogEntry[] | (() => Promise<readonly AdditionalSkillCatalogEntry[]>)
 type AgentHomeSkillDir = { source: AgentHomeSkillSource; dir: string }
 type DiscoveredAgentHomeSkill = {
   skill: AgentHomeSkillView
@@ -102,9 +98,7 @@ class SkillCatalogModule {
   }
 
   async skillsNeedingForceLoad(ids: string[]): Promise<string[]> {
-    const disabled = new Set(
-      (await this.options.repository.getSettings()).disabledSkillIds ?? []
-    )
+    const disabled = new Set((await this.options.repository.getSettings()).disabledSkillIds ?? [])
     return ids.filter((id) => disabled.has(id))
   }
 
@@ -274,9 +268,7 @@ class SkillCatalogModule {
     return this.userSkills.importFromZipBatch(zip, items)
   }
 
-  async previewGitHubSkill(
-    request: PreviewGitHubSkillRequest
-  ): Promise<SkillImportPreviewContent> {
+  async previewGitHubSkill(request: PreviewGitHubSkillRequest): Promise<SkillImportPreviewContent> {
     const location = parseGitHubSkillUrl(request.url)
     if (!location) throw new Error('Not a recognizable GitHub URL.')
     const preview = await this.userSkills.previewGitHubSkill(request.url, netFetch)
@@ -518,9 +510,7 @@ class SkillCatalogModule {
         const discoveredSkill = discoveredByPath.get(pathKey)
         const outcome = await this.userSkills.importAgentHomeSkill(sourcePath, canonical, {
           aliases: discoveredSkill?.aliases,
-          fallbackSlugs: discoveredSkill
-            ? [...discoveredSkill.matchedFallbackSlugs]
-            : undefined
+          fallbackSlugs: discoveredSkill ? [...discoveredSkill.matchedFallbackSlugs] : undefined
         })
         results.push({ ...validated, ...outcome })
       } catch (error) {

--- a/src/main/settings/skill-catalog.ts
+++ b/src/main/settings/skill-catalog.ts
@@ -1,15 +1,22 @@
 import { readdir, realpath } from 'node:fs/promises'
-import { join, resolve, sep } from 'node:path'
+import { homedir } from 'node:os'
+import { isAbsolute, join, relative, resolve, sep } from 'node:path'
 
 import type {
+  AgentHomeSkillRef,
+  AgentHomeSkillSource,
+  AgentHomeSkillView,
   CreateSkillRequest,
   DeleteSkillRequest,
   ImportSkillRequest,
   ImportSkillResult,
+  ImportAgentHomeSkillsRequest,
+  ImportAgentHomeSkillsResult,
   ImportSkillZipBatchRequest,
   ImportSkillZipBatchResult,
   ImportSkillZipRequest,
   PreviewGitHubSkillRequest,
+  PreviewAgentHomeSkillRequest,
   PreviewSkillZipRequest,
   ScanRepoRequest,
   ScanRepoResult,
@@ -20,6 +27,10 @@ import type {
   SkillView,
   UpdateSkillRequest
 } from '../../shared/settings'
+import {
+  DEFAULT_AGENT_FRAMEWORK_ID,
+  type AgentFrameworkId
+} from '../agent-framework'
 import { codexStorageDir, codexSubscriptionStorageDir } from '../agent-framework/codex'
 import { parseGitHubSkillUrl } from '../skills/github-import'
 import { decodeBoundedBase64, SKILL_IMPORT_LIMITS } from '../skills/import-limits'
@@ -27,7 +38,7 @@ import { ClaudeCodeSkillMaterializer, OS_SKILL_PREFIX } from '../skills/material
 import { netFetch } from '../skills/net-fetch'
 import { SkillRegistry, type BundledSkill } from '../skills/registry'
 import { readSkillFile } from '../skills/skill-files'
-import { UserSkillRepository } from '../skills/user-skill-repository'
+import { SAFE_SLUG, UserSkillRepository } from '../skills/user-skill-repository'
 import { provisionAppClaudeConfigDir } from './claude-config-provision'
 import type { SettingsRepository } from './repository'
 
@@ -36,6 +47,14 @@ type AdditionalSkillCatalogEntry = Omit<SkillCatalogEntry, 'path'> & { directory
 type AdditionalSkillCatalogEntries =
   | readonly AdditionalSkillCatalogEntry[]
   | (() => Promise<readonly AdditionalSkillCatalogEntry[]>)
+type AgentHomeSkillDir = { source: AgentHomeSkillSource; dir: string }
+type DiscoveredAgentHomeSkill = {
+  skill: AgentHomeSkillView
+  realPath: string
+  aliases: AgentHomeSkillRef[]
+  fallbackAliases: AgentHomeSkillRef[]
+  matchedFallbackSlugs: Set<string>
+}
 
 type SkillCatalogModuleOptions = {
   repository: SettingsRepository
@@ -271,6 +290,321 @@ class SkillCatalogModule {
 
   async scanRepoSkills(request: ScanRepoRequest): Promise<ScanRepoResult> {
     return { skills: await this.userSkills.scanRepo(request.repo, netFetch) }
+  }
+
+  async listAgentHomeSkills(): Promise<AgentHomeSkillView[]> {
+    const settings = await this.options.repository.getSettings()
+    const framework = settings.agentFrameworkId ?? DEFAULT_AGENT_FRAMEWORK_ID
+    return (await this.discoverAgentHomeSkills(this.agentHomeDirs(framework))).map(
+      (item) => item.skill
+    )
+  }
+
+  private async discoverAgentHomeSkills(
+    sources: AgentHomeSkillDir[]
+  ): Promise<DiscoveredAgentHomeSkill[]> {
+    const scanResults = await Promise.allSettled(
+      sources.map(async ({ source, dir }) => {
+        const skills = await this.userSkills.listAgentHomeSkills(dir, source)
+        const visible: {
+          skill: AgentHomeSkillView
+          realPath: string
+          alias: AgentHomeSkillRef
+        }[] = []
+        for (const skill of skills) {
+          try {
+            const realPath = await this.resolveAgentHomeSkillPath(source, skill.slug, sources)
+            visible.push({
+              realPath,
+              alias: { source, slug: skill.slug },
+              skill: {
+                source,
+                slug: skill.slug,
+                name: skill.name,
+                description: skill.description,
+                alreadyImported: skill.alreadyImported
+              }
+            })
+          } catch {
+            continue
+          }
+        }
+        return visible
+      })
+    )
+    const groups = scanResults.flatMap((result) =>
+      result.status === 'fulfilled' ? [result.value] : []
+    )
+    const firstFailure = scanResults.find((result) => result.status === 'rejected')
+    if (groups.every((group) => group.length === 0) && firstFailure?.status === 'rejected') {
+      throw firstFailure.reason
+    }
+
+    const unique = new Map<string, DiscoveredAgentHomeSkill>()
+    for (const item of groups.flat()) {
+      const pathKey = process.platform === 'win32' ? item.realPath.toLowerCase() : item.realPath
+      const existing = unique.get(pathKey)
+      if (existing) {
+        existing.aliases.push(item.alias)
+        existing.skill.alreadyImported ||= item.skill.alreadyImported
+      } else {
+        unique.set(pathKey, {
+          skill: item.skill,
+          realPath: item.realPath,
+          aliases: [item.alias],
+          fallbackAliases: [],
+          matchedFallbackSlugs: new Set()
+        })
+      }
+    }
+
+    const discovered = [...unique.values()]
+    try {
+      const matches = await this.userSkills.matchImportedAgentHomeSkills(
+        discovered.map((item) => ({
+          sourcePath: item.realPath,
+          canonical: { source: item.skill.source, slug: item.skill.slug },
+          aliases: item.aliases
+        }))
+      )
+      for (const [index, match] of matches.entries()) {
+        const item = discovered[index]
+        if (!item) continue
+        item.skill.alreadyImported = match.identityImported
+        item.fallbackAliases.push(...match.fallbackAliases)
+        if (match.identityMigrationNeeded) {
+          try {
+            await this.userSkills.importAgentHomeSkill(
+              item.realPath,
+              { source: item.skill.source, slug: item.skill.slug },
+              {
+                aliases: item.aliases,
+                expectedSignature: match.matchedIdentitySignature,
+                expectedImportedIdentity: match.matchedImportedIdentity
+              }
+            )
+          } catch {
+            item.skill.alreadyImported = false
+          }
+        }
+      }
+    } catch {
+      // Keep readable rows when compatibility matching cannot inspect malformed legacy imports.
+    }
+
+    const fallbackBySlug = new Map<
+      string,
+      { item: DiscoveredAgentHomeSkill; alias: AgentHomeSkillRef }[]
+    >()
+    for (const item of discovered) {
+      if (item.skill.alreadyImported) continue
+      for (const alias of item.fallbackAliases) {
+        const candidates = fallbackBySlug.get(alias.slug) ?? []
+        candidates.push({ item, alias })
+        fallbackBySlug.set(alias.slug, candidates)
+      }
+    }
+    for (const [fallbackSlug, candidates] of fallbackBySlug) {
+      for (const candidate of candidates) {
+        candidate.item.skill.alreadyImported = true
+        candidate.item.matchedFallbackSlugs.add(fallbackSlug)
+      }
+    }
+    return discovered
+  }
+
+  async previewAgentHomeSkill(
+    request: PreviewAgentHomeSkillRequest
+  ): Promise<SkillImportPreviewContent> {
+    const settings = await this.options.repository.getSettings()
+    const framework = settings.agentFrameworkId ?? DEFAULT_AGENT_FRAMEWORK_ID
+    const availableSources = this.agentHomeDirs(framework)
+    const requestedSourcePath = join(
+      availableSources.find((candidate) => candidate.source === request.source)?.dir ?? '',
+      request.slug
+    )
+    const sourcePath = await this.resolveAgentHomeSkillPath(
+      request.source,
+      request.slug,
+      availableSources
+    )
+    const canonical = await this.canonicalAgentHomeSkillRef(sourcePath, availableSources)
+    if (!canonical) {
+      throw new Error('Refusing to preview installed skill outside a top-level skill directory.')
+    }
+    const sourceRoot =
+      canonical.source === 'agents'
+        ? '~/.agents/skills'
+        : canonical.source === 'claude'
+          ? '~/.claude/skills'
+          : '~/.codex/skills'
+    const sourceLabel = `${sourceRoot}/${canonical.slug}`
+    try {
+      return {
+        ...(await this.userSkills.previewAgentHomeSkill(sourcePath)),
+        sourceLabel
+      }
+    } catch (error) {
+      const message =
+        error instanceof Error ? error.message : 'Could not preview the installed skill.'
+      const redacted = [sourcePath, requestedSourcePath].reduce((value, hostPath) => {
+        if (!hostPath) return value
+        return value
+          .split(`${hostPath}${sep}`)
+          .join(`${sourceLabel}/`)
+          .split(hostPath)
+          .join(sourceLabel)
+      }, message)
+      throw new Error(redacted)
+    }
+  }
+
+  async importAgentHomeSkills(
+    request: ImportAgentHomeSkillsRequest
+  ): Promise<ImportAgentHomeSkillsResult> {
+    if (!request || !Array.isArray(request.skills)) {
+      throw new Error('Installed skills must be an array.')
+    }
+    if (request.skills.length > SKILL_IMPORT_LIMITS.maxSkillsPerBundle) {
+      throw new Error(
+        `Cannot import more than ${SKILL_IMPORT_LIMITS.maxSkillsPerBundle} installed skills at once.`
+      )
+    }
+
+    const settings = await this.options.repository.getSettings()
+    const framework = settings.agentFrameworkId ?? DEFAULT_AGENT_FRAMEWORK_ID
+    const availableSources = this.agentHomeDirs(framework)
+    const discovered = await this.discoverAgentHomeSkills(availableSources).catch(
+      () => [] as DiscoveredAgentHomeSkill[]
+    )
+    const discoveredByPath = new Map(
+      discovered.map((item) => [
+        process.platform === 'win32' ? item.realPath.toLowerCase() : item.realPath,
+        item
+      ])
+    )
+    const results: ImportAgentHomeSkillsResult['results'] = []
+
+    for (const skill of request.skills) {
+      const candidate =
+        typeof skill === 'object' && skill !== null
+          ? (skill as { source?: unknown; slug?: unknown })
+          : undefined
+      const ref: Partial<AgentHomeSkillRef> = {}
+      if (
+        candidate?.source === 'agents' ||
+        candidate?.source === 'claude' ||
+        candidate?.source === 'codex'
+      ) {
+        ref.source = candidate.source
+      }
+      if (typeof candidate?.slug === 'string') ref.slug = candidate.slug
+
+      try {
+        if (!ref.source || ref.slug === undefined) {
+          throw new Error('Installed skill entries must include a valid source and slug.')
+        }
+        const validated: AgentHomeSkillRef = { source: ref.source, slug: ref.slug }
+        const sourcePath = await this.resolveAgentHomeSkillPath(
+          validated.source,
+          validated.slug,
+          availableSources
+        )
+        const canonical = await this.canonicalAgentHomeSkillRef(sourcePath, availableSources)
+        if (!canonical) {
+          throw new Error('Refusing to import installed skill outside a top-level skill directory.')
+        }
+        const pathKey = process.platform === 'win32' ? sourcePath.toLowerCase() : sourcePath
+        const discoveredSkill = discoveredByPath.get(pathKey)
+        const outcome = await this.userSkills.importAgentHomeSkill(sourcePath, canonical, {
+          aliases: discoveredSkill?.aliases,
+          fallbackSlugs: discoveredSkill
+            ? [...discoveredSkill.matchedFallbackSlugs]
+            : undefined
+        })
+        results.push({ ...validated, ...outcome })
+      } catch (error) {
+        results.push({
+          ...ref,
+          error: error instanceof Error ? error.message : 'Could not import the installed skill.'
+        })
+      }
+    }
+    return { results, skills: await this.listSkills() }
+  }
+
+  private agentHomeDirs(framework: AgentFrameworkId): AgentHomeSkillDir[] {
+    const sources: AgentHomeSkillDir[] = [
+      {
+        source: 'agents',
+        dir: join(this.options.userAgentsDir ?? join(homedir(), '.agents'), 'skills')
+      }
+    ]
+    if (framework === 'claude-code') {
+      sources.push({
+        source: 'claude',
+        dir: join(this.options.userClaudeDir ?? join(homedir(), '.claude'), 'skills')
+      })
+    } else if (framework === 'codex') {
+      sources.push({
+        source: 'codex',
+        dir: join(this.options.userCodexDir ?? join(homedir(), '.codex'), 'skills')
+      })
+    }
+    return sources
+  }
+
+  private async resolveAgentHomeSkillPath(
+    source: AgentHomeSkillSource,
+    slug: string,
+    availableSources: AgentHomeSkillDir[]
+  ): Promise<string> {
+    const homeSkillsDir = availableSources.find((candidate) => candidate.source === source)?.dir
+    if (!homeSkillsDir) {
+      throw new Error(`Installed skill source "${String(source)}" is not available.`)
+    }
+    if (!SAFE_SLUG.test(slug)) {
+      throw new Error(`Refusing to import installed skill with unsafe slug: ${slug}`)
+    }
+    const lexicalCandidate = resolve(homeSkillsDir, slug)
+    const candidate = await realpath(lexicalCandidate).catch(() => lexicalCandidate)
+    const allowedRoots = await Promise.all(
+      availableSources.map(({ dir }) => realpath(dir).catch(() => resolve(dir)))
+    )
+    const withinAllowedRoot = allowedRoots.some((root) => {
+      const rootWithSep = root.endsWith(sep) ? root : root + sep
+      return candidate === root || candidate.startsWith(rootWithSep)
+    })
+    if (!withinAllowedRoot) {
+      throw new Error(`Refusing to import installed skill outside its source: ${slug}`)
+    }
+    if (!(await this.canonicalAgentHomeSkillRef(candidate, availableSources))) {
+      throw new Error(
+        `Refusing to import installed skill outside a top-level skill directory: ${slug}`
+      )
+    }
+    return candidate
+  }
+
+  private async canonicalAgentHomeSkillRef(
+    realSkillPath: string,
+    availableSources: AgentHomeSkillDir[]
+  ): Promise<AgentHomeSkillRef | undefined> {
+    for (const source of availableSources) {
+      const realRoot = await realpath(source.dir).catch(() => resolve(source.dir))
+      const child = relative(realRoot, realSkillPath)
+      if (
+        child &&
+        !isAbsolute(child) &&
+        child !== '..' &&
+        !child.startsWith(`..${sep}`) &&
+        !child.includes(sep) &&
+        SAFE_SLUG.test(child)
+      ) {
+        return { source: source.source, slug: child }
+      }
+    }
+    return undefined
   }
 
   async materializeSkills(


### PR DESCRIPTION
## Problem

`SettingsService` owns skill discovery, enablement, mutation, GitHub preview/install, and agent-home import behavior alongside unrelated provider and application settings. That makes the service difficult to navigate and lets skill-specific state continue expanding inside the facade.

## Proposed change

- Extract skill catalog operations into `SkillCatalogModule`.
- Move agent-home discovery/import and alias handling into the same focused owner.
- Keep `SettingsService` as the compatibility facade and preserve one repository settings snapshot for each composed Codex catalog.
- Add isolated characterization tests for catalog mutations, imports, aliases, forced skills, and snapshot consistency.

```mermaid
flowchart LR
  C["Electron / Web / CLI callers"] --> F["SettingsService facade"]
  F --> R["SettingsRepository: one snapshot"]
  F --> S["SkillCatalogModule"]
  R --> S
  S --> B["Built-in and additional skills"]
  S --> A["Agent-home imports"]
  S --> K["Connector-derived skills"]
```

## Scope and non-goals

- No public IPC payload, settings schema, persisted data model, data relationship, or UI interaction changes.
- Electron, Web, and CLI continue through the existing `SettingsService` surface.
- Specialist, Permission, Compute, ACP transport, and notebook runtime behavior are unchanged.
- Issue #458 remains a forward constraint only; this PR does not implement delegation/session-tree policy.
- Internal planning documents under `docs/internal` are not included.

## Acceptance criteria and validation

All checks below are from the final branch state after the last material edit:

- Skill catalog ownership, snapshot consistency, facade compatibility, and latest Responses proxy behavior -> `npm test -- --run src/main/settings/skill-catalog.test.ts src/main/settings/service.test.ts src/main/settings/service.connectors.test.ts src/main/settings/ipc.test.ts src/main/settings/capabilities.test.ts src/main/settings/native-responses-compatibility.test.ts` -> PASS (6 files, 307 tests)
- Node and Web contracts -> `npm run typecheck` -> PASS
- Repository lint -> `npm run lint -- --no-cache` -> PASS (0 errors, 23 pre-existing warnings; changed files have no warnings)
- Full regression suite -> `npm test` -> PASS (611 files, 9,087 tests; 11 files / 140 tests skipped)
- `git diff --check` -> PASS
- Independent Standards review -> 0 findings
- Independent Spec review -> 0 findings after snapshot-consistency fix

## Review focus

- Confirm `SettingsService` remains a thin compatibility facade rather than duplicating catalog ownership.
- Confirm catalog enablement and connector projections use the same persisted settings snapshot.
- Confirm filesystem/import mutations preserve existing IDs, aliases, and error behavior.

## Uncovered risk

No live external agent-home installation was exercised; discovery and import behavior are covered with isolated filesystem fixtures. No public API or UI behavior changed.
