### PR TITLE
test(electron-e2e): add Windows window coverage

### DIFF
--- a/.github/workflows/pr-check.yml
+++ b/.github/workflows/pr-check.yml
@@ -143,13 +143,23 @@ jobs:
         if: matrix.os == 'macos-14'
         run: npm audit --audit-level=high || true
 
-  # Exercise the real desktop boundary independently from the Vitest matrix. This job runs in
-  # parallel with verify and launches BrowserWindow -> preload -> renderer -> IPC against isolated
-  # storage, so a UI failure does not wait behind the three-platform unit-test matrix.
+  # Exercise the real desktop boundary independently from the Vitest matrix. macOS and Windows run
+  # in parallel and launch BrowserWindow -> preload -> renderer -> IPC against isolated storage, so
+  # one platform's UI failure does not wait behind the other platform or the unit-test matrix.
   electron_e2e:
-    name: Electron UI E2E (macOS)
-    runs-on: macos-14
+    name: Electron UI E2E (${{ matrix.label }})
+    runs-on: ${{ matrix.os }}
     timeout-minutes: 15
+    strategy:
+      fail-fast: false
+      matrix:
+        include:
+          - os: macos-14
+            label: macOS
+            artifact-suffix: macos
+          - os: windows-latest
+            label: Windows
+            artifact-suffix: windows
 
     steps:
       - name: Checkout
@@ -174,19 +184,29 @@ jobs:
         if: failure()
         uses: actions/upload-artifact@v7
         with:
-          name: electron-ui-e2e-failure
+          name: electron-ui-e2e-${{ matrix.artifact-suffix }}-failure
           path: |
             playwright-report/
             test-results/
           retention-days: 5
           if-no-files-found: warn
 
-  # Accessibility runs independently so axe findings are attributable and do not wait behind the
-  # UI journey. It scans the production renderer inside a real Electron BrowserWindow.
+  # Accessibility runs independently on macOS and Windows so axe findings are attributable to the
+  # platform-specific renderer and do not wait behind UI journeys.
   electron_accessibility:
-    name: Electron Accessibility (macOS)
-    runs-on: macos-14
+    name: Electron Accessibility (${{ matrix.label }})
+    runs-on: ${{ matrix.os }}
     timeout-minutes: 15
+    strategy:
+      fail-fast: false
+      matrix:
+        include:
+          - os: macos-14
+            label: macOS
+            artifact-suffix: macos
+          - os: windows-latest
+            label: Windows
+            artifact-suffix: windows
 
     steps:
       - name: Checkout
@@ -211,7 +231,7 @@ jobs:
         if: failure()
         uses: actions/upload-artifact@v7
         with:
-          name: electron-accessibility-failure
+          name: electron-accessibility-${{ matrix.artifact-suffix }}-failure
           path: |
             playwright-report/
             test-results/

--- a/e2e/electron-foundation.spec.ts
+++ b/e2e/electron-foundation.spec.ts
@@ -12,6 +12,13 @@ const createProject = async (page: Page, name: string): Promise<void> => {
   await dialog.getByRole('button', { name: 'Create project' }).click()
   await expect(page.getByRole('heading', { name: 'New conversation' })).toBeVisible()
 }
+
+const openProjectActions = async (page: Page, name: string): Promise<void> => {
+  const projects = page.getByRole('region', { name: 'Projects' })
+  await projects.getByRole('button', { name, exact: true }).hover()
+  await projects.getByRole('button', { name: `Open actions for ${name}` }).click()
+}
+
 test('creates a project through the desktop stack and reloads it after relaunch', async ({
   app
 }) => {
@@ -40,7 +47,7 @@ test('renames a project through the home actions and keeps the change after rela
   await createProject(page, PROJECT_NAME)
 
   await page.getByRole('button', { name: 'All projects' }).click()
-  await page.getByRole('button', { name: `Open actions for ${PROJECT_NAME}` }).click()
+  await openProjectActions(page, PROJECT_NAME)
   await page.getByRole('menuitem', { name: 'Rename…' }).click()
 
   const dialog = page.getByRole('dialog', { name: 'Edit project' })
@@ -66,7 +73,7 @@ test('deletes a project through confirmation and keeps it absent after relaunch'
   await createProject(page, PROJECT_NAME)
 
   await page.getByRole('button', { name: 'All projects' }).click()
-  await page.getByRole('button', { name: `Open actions for ${PROJECT_NAME}` }).click()
+  await openProjectActions(page, PROJECT_NAME)
   await page.getByRole('menuitem', { name: 'Delete' }).click()
 
   const dialog = page.getByRole('alertdialog', { name: 'Delete project?' })

--- a/e2e/fixtures/electron-app.ts
+++ b/e2e/fixtures/electron-app.ts
@@ -1,4 +1,5 @@
 import { test as base } from '@playwright/test'
+import { spawn } from 'node:child_process'
 import { mkdtemp, rm } from 'node:fs/promises'
 import { tmpdir } from 'node:os'
 import { join, resolve } from 'node:path'
@@ -14,6 +15,10 @@ type LaunchRoots = {
 type ElectronApp = {
   readonly page: Page
   completeOnboarding: () => Promise<Page>
+  findOverlayIsVisible: () => Promise<boolean>
+  launchSecondInstance: () => Promise<Page>
+  mainWindowState: () => Promise<{ minimized: boolean; visible: boolean }>
+  requestMainWindowClose: () => Promise<void>
   restart: () => Promise<Page>
 }
 
@@ -87,6 +92,53 @@ class ElectronAppHarness implements ElectronApp {
     return this.page
   }
 
+  async findOverlayIsVisible(): Promise<boolean> {
+    return this.runningApplication.evaluate(({ BrowserWindow }) => {
+      const mainWindow = BrowserWindow.getAllWindows()[0]
+      if (!mainWindow) return false
+
+      return mainWindow.contentView.children.some((view) => {
+        const bounds = view.getBounds()
+        return bounds.width > 0 && bounds.height > 0
+      })
+    })
+  }
+
+  async mainWindowState(): Promise<{ minimized: boolean; visible: boolean }> {
+    return this.runningApplication.evaluate(({ BrowserWindow }) => {
+      const mainWindow = BrowserWindow.getAllWindows()[0]
+      if (!mainWindow) throw new Error('Open Science main window was not found.')
+
+      return { minimized: mainWindow.isMinimized(), visible: mainWindow.isVisible() }
+    })
+  }
+
+  async launchSecondInstance(): Promise<Page> {
+    const executable = this.runningApplication.process().spawnfile
+    await new Promise<void>((resolveLaunch, rejectLaunch) => {
+      const child = spawn(executable, [`--user-data-dir=${this.roots.userDataRoot}`, APP_ROOT], {
+        cwd: APP_ROOT,
+        env: launchEnvironment(this.roots.storageRoot),
+        stdio: 'ignore',
+        windowsHide: true
+      })
+      child.once('error', rejectLaunch)
+      child.once('exit', (code, signal) => {
+        if (code === 0) resolveLaunch()
+        else rejectLaunch(new Error(`Second Electron instance exited with ${code ?? signal}.`))
+      })
+    })
+    return this.page
+  }
+
+  async requestMainWindowClose(): Promise<void> {
+    await this.runningApplication.evaluate(({ BrowserWindow }) => {
+      const mainWindow = BrowserWindow.getAllWindows()[0]
+      if (!mainWindow) throw new Error('Open Science main window was not found.')
+      mainWindow.close()
+    })
+  }
+
   async restart(): Promise<Page> {
     await this.close()
     await this.launch()
@@ -101,6 +153,11 @@ class ElectronAppHarness implements ElectronApp {
   private async launch(): Promise<void> {
     this.application = await launchOpenScience(this.roots)
     this.currentPage = await openMainWindow(this.application)
+  }
+
+  private get runningApplication(): ElectronApplication {
+    if (!this.application) throw new Error('Electron application is not running.')
+    return this.application
   }
 
   private async close(): Promise<void> {

--- a/e2e/fixtures/electron-app.ts
+++ b/e2e/fixtures/electron-app.ts
@@ -12,12 +12,15 @@ type LaunchRoots = {
   userDataRoot: string
 }
 
+type ShortcutModifier = 'alt' | 'control' | 'meta' | 'shift'
+
 type ElectronApp = {
   readonly page: Page
   completeOnboarding: () => Promise<Page>
   findOverlayIsVisible: () => Promise<boolean>
   launchSecondInstance: () => Promise<Page>
   mainWindowState: () => Promise<{ minimized: boolean; visible: boolean }>
+  pressMainWindowShortcut: (key: string, modifiers: ShortcutModifier[]) => Promise<void>
   requestMainWindowClose: () => Promise<void>
   restart: () => Promise<Page>
 }
@@ -114,13 +117,15 @@ class ElectronAppHarness implements ElectronApp {
   }
 
   async launchSecondInstance(): Promise<Page> {
-    const executable = this.runningApplication.process().spawnfile
+    const { appPath, executable } = await this.runningApplication.evaluate(({ app }) => ({
+      appPath: app.getAppPath(),
+      executable: process.execPath
+    }))
     await new Promise<void>((resolveLaunch, rejectLaunch) => {
-      const child = spawn(executable, [`--user-data-dir=${this.roots.userDataRoot}`, APP_ROOT], {
+      const child = spawn(executable, [`--user-data-dir=${this.roots.userDataRoot}`, appPath], {
         cwd: APP_ROOT,
         env: launchEnvironment(this.roots.storageRoot),
-        stdio: 'ignore',
-        windowsHide: true
+        stdio: 'ignore'
       })
       child.once('error', rejectLaunch)
       child.once('exit', (code, signal) => {
@@ -129,6 +134,28 @@ class ElectronAppHarness implements ElectronApp {
       })
     })
     return this.page
+  }
+
+  async pressMainWindowShortcut(key: string, modifiers: ShortcutModifier[]): Promise<void> {
+    await this.runningApplication.evaluate(
+      ({ BrowserWindow }, input) => {
+        const mainWindow = BrowserWindow.getAllWindows()[0]
+        if (!mainWindow) throw new Error('Open Science main window was not found.')
+
+        mainWindow.webContents.focus()
+        mainWindow.webContents.sendInputEvent({
+          type: 'keyDown',
+          keyCode: input.key,
+          modifiers: input.modifiers
+        })
+        mainWindow.webContents.sendInputEvent({
+          type: 'keyUp',
+          keyCode: input.key,
+          modifiers: input.modifiers
+        })
+      },
+      { key, modifiers }
+    )
   }
 
   async requestMainWindowClose(): Promise<void> {

--- a/e2e/visual-regression.spec.ts
+++ b/e2e/visual-regression.spec.ts
@@ -2,6 +2,8 @@ import { expect } from '@playwright/test'
 import type { Page } from 'playwright'
 import { test } from './fixtures/electron-app'
 
+test.skip(process.platform !== 'darwin', 'Visual baselines are currently macOS-only.')
+
 const prepareVisualPage = async (page: Page): Promise<void> => {
   await page.setViewportSize({ width: 1280, height: 800 })
   await page.emulateMedia({ reducedMotion: 'reduce' })

--- a/e2e/windows-window-system.spec.ts
+++ b/e2e/windows-window-system.spec.ts
@@ -1,0 +1,61 @@
+import { expect } from '@playwright/test'
+import type { Locator, Page } from 'playwright'
+import { test } from './fixtures/electron-app'
+
+const openGeneralSettings = async (page: Page): Promise<Locator> => {
+  await page.getByRole('button', { name: 'Model settings' }).click()
+  const settings = page.getByRole('dialog', { name: 'Settings' })
+  await settings
+    .getByRole('navigation', { name: 'Settings' })
+    .getByRole('button', { name: 'General', exact: true })
+    .click()
+  return settings
+}
+
+test.describe('Windows window system', () => {
+  test.skip(process.platform !== 'win32', 'Windows window behavior requires a Windows host.')
+
+  test('persists minimize-to-tray across titlebar close, relaunch, and Ctrl+W', async ({ app }) => {
+    let page = await app.completeOnboarding()
+    let settings = await openGeneralSettings(page)
+    const closeAction = settings.getByRole('combobox', { name: 'When closing the window' })
+
+    await closeAction.click()
+    await page.getByRole('option', { name: 'Minimize to tray' }).click()
+    await expect(closeAction).toContainText('Minimize to tray')
+    await settings.getByRole('button', { name: 'Close settings' }).click()
+
+    page = await app.restart()
+    settings = await openGeneralSettings(page)
+    await expect(settings.getByRole('combobox', { name: 'When closing the window' })).toContainText(
+      'Minimize to tray'
+    )
+    await settings.getByRole('button', { name: 'Close settings' }).click()
+
+    await app.requestMainWindowClose()
+    await expect.poll(() => app.mainWindowState()).toEqual({ minimized: false, visible: false })
+
+    page = await app.launchSecondInstance()
+    await expect.poll(() => app.mainWindowState()).toEqual({ minimized: false, visible: true })
+
+    await page.keyboard.press('Control+W')
+    await expect.poll(() => app.mainWindowState()).toEqual({ minimized: false, visible: false })
+
+    page = await app.launchSecondInstance()
+    await expect.poll(() => app.mainWindowState()).toEqual({ minimized: false, visible: true })
+    await expect(page.getByRole('region', { name: 'Projects' })).toBeVisible()
+  })
+
+  test('opens the whole-window find overlay with Ctrl+F in a workspace', async ({ app }) => {
+    const page = await app.completeOnboarding()
+    await page.getByRole('button', { name: 'New project' }).click()
+    const projectDialog = page.getByRole('dialog', { name: 'New project' })
+    await projectDialog.getByLabel('Name').fill('Windows find project')
+    await projectDialog.getByRole('button', { name: 'Create project' }).click()
+    await expect(page.getByRole('heading', { name: 'New conversation' })).toBeVisible()
+
+    await expect.poll(() => app.findOverlayIsVisible()).toBe(false)
+    await page.keyboard.press('Control+F')
+    await expect.poll(() => app.findOverlayIsVisible()).toBe(true)
+  })
+})

--- a/e2e/windows-window-system.spec.ts
+++ b/e2e/windows-window-system.spec.ts
@@ -38,7 +38,7 @@ test.describe('Windows window system', () => {
     page = await app.launchSecondInstance()
     await expect.poll(() => app.mainWindowState()).toEqual({ minimized: false, visible: true })
 
-    await page.keyboard.press('Control+W')
+    await app.pressMainWindowShortcut('W', ['control'])
     await expect.poll(() => app.mainWindowState()).toEqual({ minimized: false, visible: false })
 
     page = await app.launchSecondInstance()
@@ -55,7 +55,7 @@ test.describe('Windows window system', () => {
     await expect(page.getByRole('heading', { name: 'New conversation' })).toBeVisible()
 
     await expect.poll(() => app.findOverlayIsVisible()).toBe(false)
-    await page.keyboard.press('Control+F')
+    await app.pressMainWindowShortcut('F', ['control'])
     await expect.poll(() => app.findOverlayIsVisible()).toBe(true)
   })
 })

--- a/package.json
+++ b/package.json
@@ -17,7 +17,7 @@
     "test": "vitest run",
     "build:e2e": "electron-vite build",
     "test:e2e": "playwright test",
-    "test:e2e:journey": "playwright test e2e/electron-foundation.spec.ts e2e/settings-persistence.spec.ts",
+    "test:e2e:journey": "playwright test e2e/electron-foundation.spec.ts e2e/settings-persistence.spec.ts e2e/windows-window-system.spec.ts",
     "test:e2e:accessibility": "playwright test e2e/accessibility.spec.ts",
     "test:e2e:visual": "playwright test e2e/visual-regression.spec.ts",
     "test:cli": "vitest run packages/open-science",


### PR DESCRIPTION
## Problem

Electron Journey, axe, and visual checks currently protect macOS, but Windows is an official release target with platform-specific window behavior and no real BrowserWindow E2E coverage.

## Proposed change

- Run Electron Journey and axe as independent macOS/Windows matrix legs; both platforms and both suites remain parallel.
- Add a Windows journey for persisted close preference, real BrowserWindow close-to-tray behavior, production single-instance restoration, Ctrl+W, and Ctrl+F find-overlay behavior.
- Keep visual baselines macOS-only and explicitly skip them elsewhere.
- Stabilize project action journeys by hovering the row before using its hover-revealed menu.

```mermaid
flowchart LR
  V[Verify matrix] --> JM[Journey macOS]
  V --> JW[Journey Windows]
  V --> AM[axe macOS]
  V --> AW[axe Windows]
  V --> VM[Visual macOS]
  JW --> C[Close preference and titlebar close]
  C --> H[Hidden with process alive]
  H --> S[Real second instance]
  S --> R[Production lifecycle restores window]
```

## Scope and non-goals

This changes test and CI architecture only. It does not change runtime architecture, data models, data relationships, persisted schemas, or user interaction behavior. Windows visual baselines remain deferred because DPI, fonts, and native scrollbar rendering need a separate stabilization pass. Linux Electron journeys are also outside this slice.

## Acceptance criteria and validation

All listed local checks ran after the relevant final edits:

- Test fixture and TypeScript contracts -> npm run typecheck -> passed.
- Repository lint gate -> npm run lint -> passed with 23 pre-existing warnings and 0 errors.
- Production Electron build -> npm run build:e2e -> passed.
- macOS Journey, axe, and visual regression -> npm run test:e2e -> 7 passed, 2 Windows-only skipped.
- Repository Vitest suite -> npm test -> one clean run passed 610 files and 9,084 tests; a later load-contended rerun passed 9,081 tests and timed out 3 unrelated PDF/logger performance cases, which then passed 80/80 in a focused rerun.
- Windows Journey and axe -> new Windows CI matrix legs are the authoritative platform validation.
- YAML matrix shape and macOS-only visual runner -> js-yaml parse/assertion -> passed.

Uncovered risks: Windows visual rendering is intentionally not baselined; Linux Electron UI is not exercised; the E2E harness assumes the sole BrowserWindow is the main window.

## Review focus

- Reliability of the real secondary-instance restore path on windows-latest.
- Preservation of the existing macOS check names for branch protection.
- Independence and artifact naming of the new matrix legs.