### PR TITLE
refactor(notebook): extract recovery coordination

### DIFF
--- a/src/main/ipc.ts
+++ b/src/main/ipc.ts
@@ -428,9 +428,7 @@ const createApplicationModules = async (
         capability: notebook,
         disposeTimeoutMs: QUIT_SHUTDOWN_BUDGET_MS,
         rollback: () =>
-          backendTeardownOwnedByCoordinator
-            ? undefined
-            : notebook.shutdownAll().then(() => undefined)
+          backendTeardownOwnedByCoordinator ? undefined : notebook.dispose().then(() => undefined)
       }
     }
   )

--- a/src/main/lifecycle-shutdown.test.ts
+++ b/src/main/lifecycle-shutdown.test.ts
@@ -13,7 +13,10 @@ const makeDeps = (overrides: Partial<BackendShutdownDeps> = {}): BackendShutdown
     shutdownForQuit: vi.fn(async () => ({ reaped: true })),
     shutdownForUpdateGate: vi.fn(async () => ({ reaped: true }))
   },
-  notebook: { shutdownAll: vi.fn(async () => ({ reaped: true })) },
+  notebook: {
+    shutdownAll: vi.fn(async () => ({ reaped: true })),
+    dispose: vi.fn(async () => ({ reaped: true }))
+  },
   log: { error: vi.fn() },
   ...overrides
 })
@@ -27,7 +30,8 @@ describe('shutdownBackends', () => {
     const deps = makeDeps()
     await shutdownBackends(deps)
     expect(deps.runtime.shutdownForQuit).toHaveBeenCalledTimes(1)
-    expect(deps.notebook.shutdownAll).toHaveBeenCalledTimes(1)
+    expect(deps.notebook.dispose).toHaveBeenCalledTimes(1)
+    expect(deps.notebook.shutdownAll).not.toHaveBeenCalled()
   })
 
   it('still runs notebook shutdown and resolves when runtime teardown rejects', async () => {
@@ -39,14 +43,17 @@ describe('shutdownBackends', () => {
       }
     })
     await expect(shutdownBackends(deps)).resolves.toBeUndefined()
-    expect(deps.notebook.shutdownAll).toHaveBeenCalledTimes(1)
+    expect(deps.notebook.dispose).toHaveBeenCalledTimes(1)
     expect(deps.log?.error).toHaveBeenCalledWith(expect.any(String), err)
   })
 
   it('resolves and logs even when notebook shutdown rejects', async () => {
     const err = new Error('notebook boom')
     const deps = makeDeps({
-      notebook: { shutdownAll: vi.fn(async () => Promise.reject(err)) }
+      notebook: {
+        shutdownAll: vi.fn(async () => ({ reaped: true })),
+        dispose: vi.fn(async () => Promise.reject(err))
+      }
     })
     await expect(shutdownBackends(deps)).resolves.toBeUndefined()
     expect(deps.runtime.shutdownForQuit).toHaveBeenCalledTimes(1)
@@ -95,7 +102,8 @@ describe('BackendShutdownCoordinator', () => {
     expect(outcome).toEqual({ completed: true, reaped: true })
     expect(deps.runtime.shutdownForQuit).toHaveBeenCalledTimes(1)
     expect(deps.runtime.shutdownForUpdateGate).not.toHaveBeenCalled()
-    expect(deps.notebook.shutdownAll).toHaveBeenCalledTimes(1)
+    expect(deps.notebook.dispose).toHaveBeenCalledTimes(1)
+    expect(deps.notebook.shutdownAll).not.toHaveBeenCalled()
   })
 
   it('runForUpdateGate uses the non-latching teardown', async () => {
@@ -112,7 +120,10 @@ describe('BackendShutdownCoordinator', () => {
 
   it('reports reaped:false when a tree kill was degraded', async () => {
     const deps = makeDeps({
-      notebook: { shutdownAll: vi.fn(async () => ({ reaped: false })) }
+      notebook: {
+        shutdownAll: vi.fn(async () => ({ reaped: false })),
+        dispose: vi.fn(async () => ({ reaped: true }))
+      }
     })
     const coordinator = new BackendShutdownCoordinator(deps)
 

--- a/src/main/lifecycle-shutdown.ts
+++ b/src/main/lifecycle-shutdown.ts
@@ -21,7 +21,7 @@ export type QuitShutdownDeps = {
     // instead of orphaning its freshly-spawned child. disconnect() alone does not set that latch.
     shutdownForQuit: () => Promise<{ reaped: boolean }>
   }
-  notebook: { shutdownAll: () => Promise<{ reaped: boolean }> }
+  notebook: { dispose: () => Promise<{ reaped: boolean }> }
   log?: ShutdownLogger
   // Upper bound for the quit-path helpers; defaults to QUIT_SHUTDOWN_BUDGET_MS.
   timeoutMs?: number
@@ -33,6 +33,10 @@ export type BackendShutdownDeps = QuitShutdownDeps & {
     // Non-latching pre-update-install teardown: reaps the agent tree but leaves the runtime usable so a
     // refused install does not wedge the app (the next prompt lazily reconnects).
     shutdownForUpdateGate: () => Promise<{ reaped: boolean }>
+  }
+  notebook: QuitShutdownDeps['notebook'] & {
+    // Reusable kernel teardown for update checks that may leave the current app running.
+    shutdownAll: () => Promise<{ reaped: boolean }>
   }
 }
 
@@ -62,7 +66,7 @@ const runBounded = async (
         log?.error('runtime shutdown failed during shutdown', runtimeResult.reason)
       }
       if (notebookResult.status === 'rejected') {
-        log?.error('notebook shutdownAll failed during shutdown', notebookResult.reason)
+        log?.error('notebook shutdown failed during shutdown', notebookResult.reason)
       }
 
       // Optional chaining keeps the never-throw invariant even if a teardown resolves a malformed value.
@@ -95,7 +99,7 @@ const runBounded = async (
 export const shutdownBackends = async (deps: QuitShutdownDeps): Promise<void> => {
   await runBounded(
     deps.runtime.shutdownForQuit(),
-    deps.notebook.shutdownAll(),
+    deps.notebook.dispose(),
     deps.timeoutMs ?? QUIT_SHUTDOWN_BUDGET_MS,
     deps.log
   )
@@ -116,7 +120,7 @@ export class BackendShutdownCoordinator {
   ): Promise<ShutdownOutcome> {
     return runBounded(
       this.deps.runtime.shutdownForQuit(),
-      this.deps.notebook.shutdownAll(),
+      this.deps.notebook.dispose(),
       budgetMs,
       this.deps.log
     )

--- a/src/main/notebook/recovery-coordinator.test.ts
+++ b/src/main/notebook/recovery-coordinator.test.ts
@@ -1,0 +1,74 @@
+import { mkdir, mkdtemp, rm, writeFile } from 'node:fs/promises'
+import { tmpdir } from 'node:os'
+import { join } from 'node:path'
+import { afterEach, describe, expect, it } from 'vitest'
+
+import { operationJournalPath } from './operation-journal'
+import { NotebookRecoveryCoordinator } from './recovery-coordinator'
+
+let root: string | undefined
+
+afterEach(async () => {
+  if (root) {
+    await rm(root, { recursive: true, force: true })
+    root = undefined
+  }
+})
+
+const createRuntimeRoot = async (): Promise<string> => {
+  root = await mkdtemp(join(tmpdir(), 'open-science-notebook-recovery-'))
+  return join(root, 'runtime')
+}
+
+describe('NotebookRecoveryCoordinator', () => {
+  it('owns blocked and live-unconfirmed recovery state in one snapshot', async () => {
+    const coordinator = new NotebookRecoveryCoordinator(await createRuntimeRoot())
+
+    coordinator.markLiveUnconfirmed('/runtime/envs/default-python', 'managed:python:default')
+
+    expect(coordinator.snapshot()).toMatchObject({
+      readiness: 'not-started',
+      blockedPrefixes: ['/runtime/envs/default-python'],
+      blockedRuntimeIds: ['managed:python:default'],
+      liveUnconfirmedPrefixes: ['/runtime/envs/default-python'],
+      liveUnconfirmedRuntimeIds: ['managed:python:default'],
+      corruptJournal: false
+    })
+  })
+
+  it('keeps a corrupt journal fail-closed while allowlisting only the reset prefix', async () => {
+    const runtimeRoot = await createRuntimeRoot()
+    await mkdir(runtimeRoot, { recursive: true })
+    await writeFile(operationJournalPath(runtimeRoot), '{ not json', 'utf8')
+    const coordinator = new NotebookRecoveryCoordinator(runtimeRoot)
+
+    await coordinator.recover()
+
+    const resetPrefix = join(runtimeRoot, 'envs', 'default-python')
+    const otherPrefix = join(runtimeRoot, 'envs', 'analysis')
+    expect(coordinator.snapshot()).toMatchObject({ readiness: 'ready', corruptJournal: true })
+    expect(coordinator.isPrefixBlocked(resetPrefix)).toBe(true)
+    expect(coordinator.isPrefixBlocked(otherPrefix)).toBe(true)
+
+    coordinator.allowCorruptReset(resetPrefix)
+
+    expect(coordinator.isPrefixBlocked(resetPrefix)).toBe(false)
+    expect(coordinator.isPrefixBlocked(otherPrefix)).toBe(true)
+  })
+
+  it('fails closed after disposal even if reset commands clear known blocks', async () => {
+    const coordinator = new NotebookRecoveryCoordinator(await createRuntimeRoot())
+    const prefix = '/runtime/envs/default-python'
+    coordinator.markLiveUnconfirmed(prefix, 'managed:python:default')
+
+    await coordinator.dispose()
+    coordinator.clearPrefixBlock(prefix)
+    coordinator.clearRuntimeBlock('managed:python:default')
+    coordinator.allowCorruptReset(prefix)
+
+    expect(coordinator.snapshot().readiness).toBe('disposed')
+    expect(coordinator.isPrefixBlocked(prefix)).toBe(true)
+    expect(coordinator.isRuntimeIdBlocked('managed:python:default')).toBe(true)
+    await expect(coordinator.recover()).rejects.toThrow(/disposed/)
+  })
+})

--- a/src/main/notebook/recovery-coordinator.ts
+++ b/src/main/notebook/recovery-coordinator.ts
@@ -8,18 +8,11 @@ import {
   removeOperationChildSync,
   RuntimeOperationJournal
 } from './operation-journal'
-import {
-  defaultOperationChildLiveness,
-  reconcileInterruptedOperations
-} from './operation-recovery'
+import { defaultOperationChildLiveness, reconcileInterruptedOperations } from './operation-recovery'
 import { addRepairRequired, managedRepairRegistryKey } from './runtime-paths'
 
 export type NotebookRecoveryReadiness =
-  | 'not-started'
-  | 'recovering'
-  | 'ready'
-  | 'failed'
-  | 'disposed'
+  'not-started' | 'recovering' | 'ready' | 'failed' | 'disposed'
 
 export type NotebookRecoverySnapshot = {
   readiness: NotebookRecoveryReadiness

--- a/src/main/notebook/recovery-coordinator.ts
+++ b/src/main/notebook/recovery-coordinator.ts
@@ -1,0 +1,244 @@
+import { existsSync } from 'node:fs'
+import { rm } from 'node:fs/promises'
+import { join } from 'node:path'
+
+import {
+  operationJournalPath,
+  readOperationChild,
+  removeOperationChildSync,
+  RuntimeOperationJournal
+} from './operation-journal'
+import {
+  defaultOperationChildLiveness,
+  reconcileInterruptedOperations
+} from './operation-recovery'
+import { addRepairRequired, managedRepairRegistryKey } from './runtime-paths'
+
+export type NotebookRecoveryReadiness =
+  | 'not-started'
+  | 'recovering'
+  | 'ready'
+  | 'failed'
+  | 'disposed'
+
+export type NotebookRecoverySnapshot = {
+  readiness: NotebookRecoveryReadiness
+  blockedPrefixes: string[]
+  blockedRuntimeIds: string[]
+  liveUnconfirmedPrefixes: string[]
+  liveUnconfirmedRuntimeIds: string[]
+  corruptJournal: boolean
+  lastFailure?: Error
+}
+
+export class NotebookRecoveryCoordinator {
+  private recoveryComplete: Promise<void> | undefined
+  private recoveryInFlight: Promise<void> | undefined
+  private readiness: NotebookRecoveryReadiness = 'not-started'
+  private lastFailure: Error | undefined
+  private readonly blockedPrefixes = new Set<string>()
+  private readonly blockedRuntimeIds = new Set<string>()
+  private readonly startupBlockedPrefixes = new Set<string>()
+  private readonly startupBlockedRuntimeIds = new Set<string>()
+  private readonly corruptResetAllowlist = new Set<string>()
+  private readonly liveUnconfirmedPrefixes = new Set<string>()
+  private readonly liveUnconfirmedRuntimeIds = new Set<string>()
+  private recoveryCorrupt = false
+  private disposed = false
+
+  constructor(private readonly runtimeRoot: string) {}
+
+  async recover(): Promise<void> {
+    if (this.disposed) throw new Error('Notebook recovery coordinator is disposed.')
+    if (this.recoveryInFlight) {
+      await this.recoveryInFlight
+      return
+    }
+
+    this.readiness = 'recovering'
+    this.lastFailure = undefined
+    const run = this.reconcile()
+    this.recoveryInFlight = run
+    this.recoveryComplete = run.then(
+      () => undefined,
+      () => undefined
+    )
+    try {
+      await run
+      if (!this.disposed) this.readiness = 'ready'
+    } catch (error) {
+      this.lastFailure = error instanceof Error ? error : new Error(String(error))
+      if (!this.disposed) this.readiness = 'failed'
+      throw error
+    } finally {
+      if (this.recoveryInFlight === run) this.recoveryInFlight = undefined
+    }
+  }
+
+  async ensureReady(): Promise<void> {
+    if (this.disposed) throw new Error('Notebook recovery coordinator is disposed.')
+    if (this.recoveryComplete) await this.recoveryComplete
+    if (
+      this.startupBlockedPrefixes.size > 0 ||
+      this.startupBlockedRuntimeIds.size > 0 ||
+      this.recoveryCorrupt
+    ) {
+      await this.recover()
+    }
+  }
+
+  async dispose(): Promise<void> {
+    if (this.disposed) return
+    this.disposed = true
+    this.readiness = 'disposed'
+    await this.recoveryInFlight?.catch(() => undefined)
+  }
+
+  snapshot(): NotebookRecoverySnapshot {
+    return {
+      readiness: this.readiness,
+      blockedPrefixes: Array.from(this.blockedPrefixes).sort(),
+      blockedRuntimeIds: Array.from(this.blockedRuntimeIds).sort(),
+      liveUnconfirmedPrefixes: Array.from(this.liveUnconfirmedPrefixes).sort(),
+      liveUnconfirmedRuntimeIds: Array.from(this.liveUnconfirmedRuntimeIds).sort(),
+      corruptJournal: this.recoveryCorrupt,
+      lastFailure: this.lastFailure
+    }
+  }
+
+  isPrefixBlocked(prefix: string): boolean {
+    if (this.disposed || this.blockedPrefixes.has(prefix)) return true
+    return this.recoveryCorrupt && !this.corruptResetAllowlist.has(prefix)
+  }
+
+  isRuntimeIdBlocked(runtimeId: string): boolean {
+    return this.disposed || this.blockedRuntimeIds.has(runtimeId)
+  }
+
+  isGloballyBlocked(): boolean {
+    return this.disposed || this.recoveryCorrupt
+  }
+
+  clearPrefixBlock(prefix: string): void {
+    this.blockedPrefixes.delete(prefix)
+    this.startupBlockedPrefixes.delete(prefix)
+  }
+
+  clearRuntimeBlock(runtimeId: string): void {
+    this.blockedRuntimeIds.delete(runtimeId)
+    this.startupBlockedRuntimeIds.delete(runtimeId)
+  }
+
+  allowCorruptReset(prefix: string): void {
+    this.corruptResetAllowlist.add(prefix)
+  }
+
+  markLiveUnconfirmed(prefix: string, runtimeId?: string): void {
+    this.blockedPrefixes.add(prefix)
+    this.liveUnconfirmedPrefixes.add(prefix)
+    if (runtimeId) {
+      this.blockedRuntimeIds.add(runtimeId)
+      this.liveUnconfirmedRuntimeIds.add(runtimeId)
+    }
+  }
+
+  markRuntimeLiveUnconfirmed(runtimeId: string): void {
+    this.blockedRuntimeIds.add(runtimeId)
+    this.liveUnconfirmedRuntimeIds.add(runtimeId)
+  }
+
+  isPrefixLiveUnconfirmed(prefix: string): boolean {
+    return this.liveUnconfirmedPrefixes.has(prefix)
+  }
+
+  private async reconcile(): Promise<void> {
+    const nextStartupBlockedPrefixes = new Set<string>()
+    const nextStartupBlockedRuntimeIds = new Set<string>()
+
+    await rm(join(this.runtimeRoot, 'packs', '.cache'), { recursive: true, force: true }).catch(
+      () => undefined
+    )
+    const journal = RuntimeOperationJournal.forPath(operationJournalPath(this.runtimeRoot))
+    if ((await journal.readState()) === 'corrupt') {
+      console.error(
+        '[notebook] operation journal is unreadable; blocking all runtime writes until recovery'
+      )
+      this.recoveryCorrupt = true
+      return
+    }
+
+    const reconciled = await reconcileInterruptedOperations(journal, {
+      operationChildLiveness: defaultOperationChildLiveness,
+      hydrateInterruptedChild: (record) => {
+        const state = readOperationChild(this.runtimeRoot, record.operationId)
+        if (state === undefined) return record
+        if (state === 'corrupt' || 'spawning' in state) {
+          return {
+            ...record,
+            childPid: undefined,
+            childStartedAt: undefined,
+            childStartToken: undefined,
+            spawnAttempted: true
+          }
+        }
+        return { ...record, ...state }
+      },
+      cleanStaging: async (record) => {
+        if (record.targetPath) await rm(record.targetPath, { recursive: true, force: true })
+      },
+      verifyOrRebuildEnv: async (record) => {
+        if (!record.targetPath || !existsSync(record.targetPath)) return
+        if (existsSync(join(record.targetPath, 'conda-meta'))) return
+        await rm(record.targetPath, { recursive: true, force: true })
+      },
+      markRepairRequired: async (record) => {
+        if (!record.runtimeId) return
+        const reason = record.repairReason ?? 'interrupted-install'
+        const language =
+          record.phase === 'install-r'
+            ? 'r'
+            : record.phase === 'install-python'
+              ? 'python'
+              : undefined
+        const alreadyScoped = /^managed:(?:python|r):/u.test(record.runtimeId)
+        const repairKey =
+          reason === 'protected-identity-change' || !record.targetPath || !language || alreadyScoped
+            ? record.runtimeId
+            : managedRepairRegistryKey(record.runtimeId, language)
+        addRepairRequired(this.runtimeRoot, repairKey, reason)
+      },
+      blockUnknownChildTarget: async (record) => {
+        if (record.kind === 'install') nextStartupBlockedRuntimeIds.add(record.runtimeId)
+        if (record.targetPath) nextStartupBlockedPrefixes.add(record.targetPath)
+      }
+    })
+
+    for (const prefix of this.startupBlockedPrefixes) {
+      if (!nextStartupBlockedPrefixes.has(prefix) && !this.liveUnconfirmedPrefixes.has(prefix)) {
+        this.blockedPrefixes.delete(prefix)
+      }
+    }
+    for (const runtimeId of this.startupBlockedRuntimeIds) {
+      if (
+        !nextStartupBlockedRuntimeIds.has(runtimeId) &&
+        !this.liveUnconfirmedRuntimeIds.has(runtimeId)
+      ) {
+        this.blockedRuntimeIds.delete(runtimeId)
+      }
+    }
+    this.startupBlockedPrefixes.clear()
+    this.startupBlockedRuntimeIds.clear()
+    for (const prefix of nextStartupBlockedPrefixes) {
+      this.startupBlockedPrefixes.add(prefix)
+      this.blockedPrefixes.add(prefix)
+    }
+    for (const runtimeId of nextStartupBlockedRuntimeIds) {
+      this.startupBlockedRuntimeIds.add(runtimeId)
+      this.blockedRuntimeIds.add(runtimeId)
+    }
+    this.recoveryCorrupt = false
+    this.corruptResetAllowlist.clear()
+
+    for (const record of reconciled) removeOperationChildSync(this.runtimeRoot, record.operationId)
+  }
+}

--- a/src/main/notebook/runtime-service.test.ts
+++ b/src/main/notebook/runtime-service.test.ts
@@ -1439,7 +1439,7 @@ describe('notebook runtime service', () => {
     })
     const readState = vi
       .spyOn(RuntimeOperationJournal.prototype, 'readState')
-      .mockImplementation(async function () {
+      .mockImplementation(async function (this: RuntimeOperationJournal) {
         await readGate
         return originalReadState.call(this)
       })

--- a/src/main/notebook/runtime-service.test.ts
+++ b/src/main/notebook/runtime-service.test.ts
@@ -6052,6 +6052,59 @@ describe('v4 runtime bindings & agent tools', () => {
     await expect(disposal).resolves.toEqual({ reaped: true })
   })
 
+  it('waits for recovery disposal before propagating a kernel teardown failure', async () => {
+    const root = await createStorageRoot()
+    let releaseRecovery: (() => void) | undefined
+    const recoveryDisposal = new Promise<void>((resolve) => {
+      releaseRecovery = resolve
+    })
+    const shutdownError = new Error('kernel teardown failed')
+    const shutdown = vi.fn(async () => Promise.reject(shutdownError))
+    const service = new NotebookRuntimeService({
+      configRoot: root,
+      dataRoot: root,
+      projectName: 'default-project',
+      repository: new NotebookRunRepository(root),
+      executorFactory: () => ({
+        execute: async (request): Promise<NotebookExecutionResult> => ({
+          status: 'completed',
+          stdout: request.code,
+          stderr: '',
+          traceback: '',
+          cwdAfter: request.cwd,
+          outputs: []
+        }),
+        shutdown
+      })
+    })
+
+    await service.execute({
+      sessionId: 's',
+      workspaceCwd: root,
+      code: 'before-quit',
+      language: 'python'
+    })
+    Object.defineProperty(service, 'recoveryCoordinator', {
+      value: { dispose: vi.fn(() => recoveryDisposal) }
+    })
+
+    const disposal = service.dispose()
+    let disposed = false
+    void disposal.then(
+      () => {
+        disposed = true
+      },
+      () => {
+        disposed = true
+      }
+    )
+
+    await vi.waitFor(() => expect(shutdown).toHaveBeenCalledTimes(1))
+    expect(disposed).toBe(false)
+    releaseRecovery?.()
+    await expect(disposal).rejects.toBe(shutdownError)
+  })
+
   it('describeRuntimeUsage counts bound sessions by kernel state for the disable warning (WS11)', async () => {
     const root = await createStorageRoot()
     const service = bindingService(root, {

--- a/src/main/notebook/runtime-service.test.ts
+++ b/src/main/notebook/runtime-service.test.ts
@@ -5960,6 +5960,51 @@ describe('v4 runtime bindings & agent tools', () => {
     await service.shutdownAll()
   })
 
+  it('remains usable after temporary shutdowns for update and migration gates', async () => {
+    const root = await createStorageRoot()
+    const executions: string[] = []
+    let shutdowns = 0
+    const service = new NotebookRuntimeService({
+      configRoot: root,
+      dataRoot: root,
+      projectName: 'default-project',
+      repository: new NotebookRunRepository(root),
+      executorFactory: () => ({
+        execute: async (request): Promise<NotebookExecutionResult> => {
+          executions.push(request.code)
+          return {
+            status: 'completed',
+            stdout: request.code,
+            stderr: '',
+            traceback: '',
+            cwdAfter: request.cwd,
+            outputs: []
+          }
+        },
+        shutdown: async () => {
+          shutdowns += 1
+          return { reaped: true }
+        }
+      })
+    })
+
+    for (const code of ['before-gate', 'after-update-gate', 'after-migration-gate']) {
+      if (executions.length > 0) await service.shutdownAll()
+
+      const result = await service.execute({
+        sessionId: 's',
+        workspaceCwd: root,
+        code,
+        language: 'python'
+      })
+
+      expect(result.status).toBe('completed')
+    }
+
+    expect(executions).toEqual(['before-gate', 'after-update-gate', 'after-migration-gate'])
+    expect(shutdowns).toBe(2)
+  })
+
   it('describeRuntimeUsage counts bound sessions by kernel state for the disable warning (WS11)', async () => {
     const root = await createStorageRoot()
     const service = bindingService(root, {

--- a/src/main/notebook/runtime-service.test.ts
+++ b/src/main/notebook/runtime-service.test.ts
@@ -6005,6 +6005,53 @@ describe('v4 runtime bindings & agent tools', () => {
     expect(shutdowns).toBe(2)
   })
 
+  it('starts kernel teardown without waiting for startup recovery to settle', async () => {
+    const root = await createStorageRoot()
+    let releaseRecovery: (() => void) | undefined
+    const recoveryDisposal = new Promise<void>((resolve) => {
+      releaseRecovery = resolve
+    })
+    const shutdown = vi.fn(async () => ({ reaped: true }))
+    const service = new NotebookRuntimeService({
+      configRoot: root,
+      dataRoot: root,
+      projectName: 'default-project',
+      repository: new NotebookRunRepository(root),
+      executorFactory: () => ({
+        execute: async (request): Promise<NotebookExecutionResult> => ({
+          status: 'completed',
+          stdout: request.code,
+          stderr: '',
+          traceback: '',
+          cwdAfter: request.cwd,
+          outputs: []
+        }),
+        shutdown
+      })
+    })
+
+    await service.execute({
+      sessionId: 's',
+      workspaceCwd: root,
+      code: 'before-quit',
+      language: 'python'
+    })
+    Object.defineProperty(service, 'recoveryCoordinator', {
+      value: { dispose: vi.fn(() => recoveryDisposal) }
+    })
+
+    const disposal = service.dispose()
+    let disposed = false
+    void disposal.then(() => {
+      disposed = true
+    })
+
+    await vi.waitFor(() => expect(shutdown).toHaveBeenCalledTimes(1))
+    expect(disposed).toBe(false)
+    releaseRecovery?.()
+    await expect(disposal).resolves.toEqual({ reaped: true })
+  })
+
   it('describeRuntimeUsage counts bound sessions by kernel state for the disable warning (WS11)', async () => {
     const root = await createStorageRoot()
     const service = bindingService(root, {

--- a/src/main/notebook/runtime-service.test.ts
+++ b/src/main/notebook/runtime-service.test.ts
@@ -1424,6 +1424,58 @@ describe('notebook runtime service', () => {
     expect(await journal.pending()).toEqual([])
   })
 
+  it('shares one startup recovery attempt across concurrent callers', async () => {
+    const root = await createStorageRoot()
+    const service = new NotebookRuntimeService({
+      configRoot: root,
+      dataRoot: root,
+      projectName: 'default-project',
+      repository: new NotebookRunRepository(root)
+    })
+    const originalReadState = RuntimeOperationJournal.prototype.readState
+    let releaseRead!: () => void
+    const readGate = new Promise<void>((resolve) => {
+      releaseRead = resolve
+    })
+    const readState = vi
+      .spyOn(RuntimeOperationJournal.prototype, 'readState')
+      .mockImplementation(async function () {
+        await readGate
+        return originalReadState.call(this)
+      })
+
+    const first = service.recoverInterruptedOperations()
+    await vi.waitFor(() => expect(readState).toHaveBeenCalledOnce())
+    const second = service.recoverInterruptedOperations()
+
+    await Promise.resolve()
+    expect(readState).toHaveBeenCalledOnce()
+
+    releaseRead()
+    await Promise.all([first, second])
+
+    // One healthy recovery reads once for the fail-closed preflight and once for reconciliation.
+    expect(readState).toHaveBeenCalledTimes(2)
+    readState.mockRestore()
+  })
+
+  it('treats a missing startup journal as ready without blocking runtimes', async () => {
+    const root = await createStorageRoot()
+    const runtimeRoot = getRuntimeRoot(root)
+    const service = new NotebookRuntimeService({
+      configRoot: root,
+      dataRoot: root,
+      projectName: 'default-project',
+      repository: new NotebookRunRepository(root)
+    })
+
+    await service.recoverInterruptedOperations()
+
+    expect(service.isPrefixRecoveryBlocked(envPrefix(runtimeRoot, DEFAULT_PY_ENV))).toBe(false)
+    expect(service.isPrefixRecoveryBlocked(envPrefix(runtimeRoot, DEFAULT_R_ENV))).toBe(false)
+    expect(existsSync(operationJournalPath(runtimeRoot))).toBe(false)
+  })
+
   it('wipes the pack download cache on startup so a restart does not resume a partial (WS13)', async () => {
     const root = await createStorageRoot()
     const runtimeRoot = join(root, 'runtime')

--- a/src/main/notebook/runtime-service.ts
+++ b/src/main/notebook/runtime-service.ts
@@ -3364,9 +3364,6 @@ class NotebookRuntimeService {
   // when every kernel tree was cleanly reaped, so the update-install gate can refuse to trigger the
   // NSIS uninstall while a kernel may still hold file handles under the install dir.
   async shutdownAll(): Promise<{ reaped: boolean }> {
-    // Recovery is process-owned work. Await any active reconciliation and permanently close its command
-    // surface before tearing down kernels, so late startup work cannot reopen a target during shutdown.
-    await this.recoveryCoordinator.dispose()
     // Let any in-flight disable drain-and-close settle first, so a revocation teardown never races the
     // shutdown (and tests don't leak a dangling background drain).
     await Promise.all(Array.from(this.revocationDrains)).catch(() => undefined)
@@ -3375,6 +3372,14 @@ class NotebookRuntimeService {
     for (const session of sessions) this.releaseMcpRpcConnection(session)
     this.sessions.clear()
     return { reaped: results.every((result) => result.reaped) }
+  }
+
+  // Permanently closes process-owned recovery work before the final kernel teardown. Unlike
+  // shutdownAll(), this is terminal: quit/relaunch and module disposal use it, while update and data-root
+  // migration gates retain the reusable shutdown contract so a refused/cancelled flow can resume work.
+  async dispose(): Promise<{ reaped: boolean }> {
+    await this.recoveryCoordinator.dispose()
+    return this.shutdownAll()
   }
 
   // Lists sessions with a cell mid-execution, for the pre-migration active-session warning.

--- a/src/main/notebook/runtime-service.ts
+++ b/src/main/notebook/runtime-service.ts
@@ -3383,8 +3383,10 @@ class NotebookRuntimeService {
     // no recovery work behind once this terminal operation resolves.
     const recoveryDisposal = this.recoveryCoordinator.dispose()
     const shutdown = this.shutdownAll()
-    const [result] = await Promise.all([shutdown, recoveryDisposal])
-    return result
+    const [shutdownResult, recoveryResult] = await Promise.allSettled([shutdown, recoveryDisposal])
+    if (recoveryResult.status === 'rejected') throw recoveryResult.reason
+    if (shutdownResult.status === 'rejected') throw shutdownResult.reason
+    return shutdownResult.value
   }
 
   // Lists sessions with a cell mid-execution, for the pre-migration active-session warning.

--- a/src/main/notebook/runtime-service.ts
+++ b/src/main/notebook/runtime-service.ts
@@ -1,7 +1,7 @@
 import { spawn, type ChildProcess } from 'node:child_process'
 import { randomUUID } from 'node:crypto'
 import { existsSync, realpathSync } from 'node:fs'
-import { readFile, realpath, rm, writeFile } from 'node:fs/promises'
+import { readFile, realpath, writeFile } from 'node:fs/promises'
 import { isAbsolute, join, relative, resolve, sep, win32 } from 'node:path'
 
 import type {
@@ -97,19 +97,15 @@ import {
 } from './environment-discovery'
 import {
   operationJournalPath,
-  readOperationChild,
   recordOperationChildSync,
   recordSpawnIntentSync,
   removeOperationChildSync,
   RuntimeOperationJournal
 } from './operation-journal'
-import {
-  reconcileInterruptedOperations,
-  defaultOperationChildLiveness,
-  readProcessStartToken
-} from './operation-recovery'
+import { readProcessStartToken } from './operation-recovery'
 import { isChildUnconfirmedError } from './provisioner-runtime'
 import { EnvironmentLeaseManager, type EnvironmentLeaseMode } from './environment-lease-manager'
+import { NotebookRecoveryCoordinator } from './recovery-coordinator'
 import { getAppClaudeConfigDir } from '../settings/provider-env'
 import { terminateProcessTree } from '../process-tree'
 import { createLogger, getLogFilePath } from '../logger'
@@ -1018,54 +1014,13 @@ class NotebookRuntimeService {
   // reported 'missing' after a restart. Fixed at construction with the other Settings dependencies.
   private readonly manualInterpretersResolver:
     ((language: NotebookLanguage) => Promise<string[]>) | undefined
-  // Resolves when startup crash-recovery has finished; awaited by materialize/install so their prefix
-  // work never races recovery's cleanup. Undefined until recoverInterruptedOperations is kicked off.
-  private recoveryComplete: Promise<void> | undefined
-  private recoveryInFlight: Promise<void> | undefined
-  // Env prefixes an interrupted op left possibly-live: recovery couldn't confirm the child process died
-  // (liveness 'unknown' — no ps / Windows / unparsable), so a survivor might STILL be writing this
-  // prefix. Any op that would write it (default materialize, package install, named-env create, UI
-  // provision/repair) must refuse while the durable journal still retains that operation — the recovery
-  // barrier resolving is not enough, since the op wasn't actually reconciled. A later guarded refresh
-  // (or restart) re-runs recovery; once the owner commits or the pid is verifiably gone, the prefix clears.
-  private readonly blockedPrefixes = new Set<string>()
-  // Runtime IDs an interrupted INSTALL left possibly-live (recovery couldn't confirm the child died).
-  // Prefix-keyed blocking doesn't fit an install: an EXTERNAL install writes the user's OWN env (not a
-  // path under runtimeRoot) and a managed named install's identity is its runtimeId, so execute() and
-  // managePackages() refuse a BOUND runtime by its runtimeId here — while managed materialize/create/
-  // remove/startup maintenance keep refusing by real prefix (blockedPrefixes). Cleared the same way:
-  // a later restart re-runs recovery and, once the pid is gone/verifiable, reconciles the journal entry.
-  private readonly blockedRuntimeIds = new Set<string>()
+  // Owns startup-recovery promises, journal reconciliation, fail-closed block decisions, Reset
+  // allowlisting, and same-process live-unconfirmed tracking. The service retains its public recovery
+  // facade so Electron, Web, CLI, and IPC adapters keep the same contract.
+  private readonly recoveryCoordinator: NotebookRecoveryCoordinator
   // Immediate in-process gate for a protected-identity failure. It is armed before kernel termination
   // and before the durable registry write, so disk-full/permission errors cannot reopen the damaged env.
   private readonly repairBlockedEnvs = new Set<string>()
-  // Subsets populated specifically by startup recovery. Unlike same-process live-unconfirmed blocks,
-  // these are refreshable: during a data-root relaunch the prior app can finish and durably remove its
-  // journal record after this process first observed it. A later recovery pass rebuilds these sets from
-  // the current journal instead of retaining a stale in-memory quarantine forever.
-  private readonly startupBlockedPrefixes = new Set<string>()
-  private readonly startupBlockedRuntimeIds = new Set<string>()
-  // GLOBAL write barrier set when the operation journal itself is corrupt/unreadable. A corrupt journal
-  // means we CANNOT enumerate what was in flight, so we can't know which prefix (if any) an orphan might
-  // still be writing — blocking only the two managed defaults (the original fix) left a possibly-live
-  // NAMED env, or an external install, free to be rm -rf'd. This flag makes every recovery-blocked check
-  // below (prefix, default-env, runtimeId) refuse EVERYTHING until an explicit Reset moves the corrupt
-  // journal aside (clearCorruptRecoveryBlock).
-  private recoveryCorrupt = false
-  // Prefixes an explicit force Reset released from recoveryCorrupt (see clearCorruptRecoveryBlock). While
-  // recoveryCorrupt is set (a corrupt journal blocks all prefixes), a prefix listed here is exempt — its
-  // env was reset and its corrupt journal moved aside, so it can rebuild while every OTHER env stays
-  // blocked. Empty on the normal path (recoveryCorrupt false makes it moot). Cleared implicitly on the
-  // next boot, which reads the now-absent journal and never sets recoveryCorrupt again.
-  private readonly corruptResetAllowlist = new Set<string>()
-  // Prefixes a write in THIS process left with a child we could not confirm stopped (an orphan MAY still
-  // be writing). A subset of blockedPrefixes, but tracked separately because a force Reset must treat it
-  // DIFFERENTLY from an ordinary recovery block: an ordinary block came from a PRIOR boot (the spawning
-  // process is gone, so Reset may delete+rebuild), whereas a live-unconfirmed prefix's orphan could still
-  // be running NOW — Reset must refuse it until a restart. Read by the provisioner via the injected
-  // isPrefixLiveUnconfirmed dep (clearQuarantine). Per-process, so it is empty after a restart.
-  private readonly liveUnconfirmedPrefixes = new Set<string>()
-  private readonly liveUnconfirmedRuntimeIds = new Set<string>()
   private readonly runtimeDiscoveryImpl: (
     language: NotebookLanguage
   ) => Promise<DiscoveredInterpreter[]>
@@ -1088,6 +1043,7 @@ class NotebookRuntimeService {
 
   constructor(private readonly options: NotebookRuntimeServiceOptions) {
     this.repository = options.repository ?? new NotebookRunRepository(options.dataRoot)
+    this.recoveryCoordinator = new NotebookRecoveryCoordinator(getRuntimeRoot(options.dataRoot))
     this.mcpRpcConnectionResolver = options.getMcpRpcConnection
     this.packageMirrorResolver = options.getPackageMirror
     this.runtimeEnablementResolver = options.getRuntimeEnablement
@@ -1775,9 +1731,9 @@ class NotebookRuntimeService {
       this.repairBlockedEnvs.has(repairBlockKey(cell.language, env, binding)) ||
       repairKeys.some((key) => isRepairRequired(repairRegistryRoot, key))
     if (
-      (binding?.runtimeId && this.blockedRuntimeIds.has(binding.runtimeId)) ||
+      (binding?.runtimeId && this.recoveryCoordinator.isRuntimeIdBlocked(binding.runtimeId)) ||
       prefixBlocked ||
-      (isExternal && this.recoveryCorrupt)
+      (isExternal && this.recoveryCoordinator.isGloballyBlocked())
     ) {
       // Recovery flagged this BOUND runtime possibly-live after an interrupted install (external or a
       // managed named env) — OR its managed prefix is recovery-blocked (per-prefix block or a not-yet-
@@ -2481,9 +2437,9 @@ class NotebookRuntimeService {
       !isExternal && this.isPrefixRecoveryBlocked(envPrefix(runtimeRoot, envName))
 
     if (
-      (binding?.runtimeId && this.blockedRuntimeIds.has(binding.runtimeId)) ||
+      (binding?.runtimeId && this.recoveryCoordinator.isRuntimeIdBlocked(binding.runtimeId)) ||
       prefixBlocked ||
-      (isExternal && this.recoveryCorrupt)
+      (isExternal && this.recoveryCoordinator.isGloballyBlocked())
     ) {
       throw new Error(
         `RUNTIME_RECOVERY_BLOCKED: the ${request.language} environment is recovering from an ` +
@@ -2739,14 +2695,15 @@ class NotebookRuntimeService {
     // Returned as a structured error (not thrown) to match managePackages' other refusals.
     const isExternal = binding?.source === 'external'
     const runtimeIdBlocked =
-      binding?.runtimeId !== undefined && this.blockedRuntimeIds.has(binding.runtimeId)
+      binding?.runtimeId !== undefined &&
+      this.recoveryCoordinator.isRuntimeIdBlocked(binding.runtimeId)
     // A managed/default install is gated by its real prefix via isPrefixRecoveryBlocked, which already
     // folds in the corrupt-journal barrier AND honours a force Reset's per-prefix allowlist — so a reset
     // (allowlisted) default env can be installed into again while other envs stay blocked. An EXTERNAL
     // install has no managed prefix to key that allowlist on, so it keeps the raw corrupt catch-all.
     const prefixBlocked =
       !isExternal && this.isPrefixRecoveryBlocked(envPrefix(runtimeRoot, envName))
-    const corruptBlockedExternal = isExternal && this.recoveryCorrupt
+    const corruptBlockedExternal = isExternal && this.recoveryCoordinator.isGloballyBlocked()
     if (runtimeIdBlocked || prefixBlocked || corruptBlockedExternal) {
       return {
         ok: false,
@@ -2994,8 +2951,7 @@ class NotebookRuntimeService {
         // (the install's identity — external or managed named) and, for a managed install, its prefix.
         // blockPrefixRecovery ALSO marks the prefix live-unconfirmed, so a force Reset this session
         // refuses to delete + rebuild it out from under the possibly-live installer (clearQuarantine).
-        this.blockedRuntimeIds.add(repairRuntimeId)
-        this.liveUnconfirmedRuntimeIds.add(repairRuntimeId)
+        this.recoveryCoordinator.markRuntimeLiveUnconfirmed(repairRuntimeId)
         if (journalTarget) this.blockPrefixRecovery(journalTarget)
       }
       throw error
@@ -3248,23 +3204,7 @@ class NotebookRuntimeService {
   // download (staging cleanup), materialize (verify/rebuild the env prefix), and install (flag
   // repair-required) paths all populate the journal, so each reconcile action below is wired to a real effect.
   async recoverInterruptedOperations(): Promise<void> {
-    if (this.recoveryInFlight) {
-      await this.recoveryInFlight
-      return
-    }
-    // Publish the in-flight recovery so new prefix-touching operations (materialize/install) can await
-    // it — otherwise an old op's cleanup/delete could race a fresh fetch/install on the same prefix.
-    const run = this.runRecovery()
-    this.recoveryInFlight = run
-    this.recoveryComplete = run.then(
-      () => undefined,
-      () => undefined
-    )
-    try {
-      await run
-    } finally {
-      if (this.recoveryInFlight === run) this.recoveryInFlight = undefined
-    }
+    await this.recoveryCoordinator.recover()
   }
 
   // Awaited by materialize/install before they touch a prefix, so startup recovery has finished
@@ -3273,18 +3213,7 @@ class NotebookRuntimeService {
   // startup env gate and UI provision/repair handlers can share the SAME barrier (they touch prefixes
   // too, not just materialize/install).
   async ensureRecovered(): Promise<void> {
-    if (this.recoveryComplete) await this.recoveryComplete
-    // A startup block is a snapshot of another process's in-flight journal. Re-read it before refusing
-    // a new write: the operation owner may have committed and removed the record after our first pass
-    // (notably while the old app drains during a data-root relaunch). Same-process unconfirmed blocks
-    // are excluded from these sets and therefore remain blocked until restart/Reset.
-    if (
-      this.startupBlockedPrefixes.size > 0 ||
-      this.startupBlockedRuntimeIds.size > 0 ||
-      this.recoveryCorrupt
-    ) {
-      await this.recoverInterruptedOperations()
-    }
+    await this.recoveryCoordinator.ensureReady()
   }
 
   // Throws if `prefix` is one recovery couldn't confirm free of a live orphan (see blockedPrefixes).
@@ -3314,21 +3243,19 @@ class NotebookRuntimeService {
   // Whether an arbitrary env prefix is recovery-blocked. Injected into the provisioner (ipc.ts) so its
   // startup restore/upgrade/repair and named create self-refuse a possibly-live prefix — the guarantee
   // the barrier alone didn't give the startup gate. Keyed by real prefix, matching blockedPrefixes.
-  // recoveryCorrupt (a corrupt journal — see runRecovery) blocks EVERY prefix, not just a specific one:
+  // A corrupt journal blocks EVERY prefix, not just a specific one:
   // an unreadable journal means we can't rule out an orphan writing an arbitrary (including named) env.
   // A force Reset can exempt ONE prefix from that global block (corruptResetAllowlist) so it rebuilds
   // while the others stay blocked; the explicit per-prefix block (blockedPrefixes) still applies to it.
   isPrefixRecoveryBlocked(prefix: string): boolean {
-    if (this.blockedPrefixes.has(prefix)) return true
-    return this.recoveryCorrupt && !this.corruptResetAllowlist.has(prefix)
+    return this.recoveryCoordinator.isPrefixBlocked(prefix)
   }
 
   // Drops the in-memory recovery block for a prefix. Called by an EXPLICIT user recovery (repair with
   // force, wired via ipc.ts) so a quarantined runtime can be reset. The provisioner also clears the
   // retained journal record + sidecar for the prefix, so the quarantine won't re-arm next startup.
   clearRecoveryBlock(prefix: string): void {
-    this.blockedPrefixes.delete(prefix)
-    this.startupBlockedPrefixes.delete(prefix)
+    this.recoveryCoordinator.clearPrefixBlock(prefix)
   }
 
   // Drops the in-memory recovery block for a runtime ID. An interrupted INSTALL blocks the bound
@@ -3336,8 +3263,7 @@ class NotebookRuntimeService {
   // sessions rejected by blockedRuntimeIds until the next restart. The provisioner's Reset collects the
   // runtimeIds of the retained install records for the reset prefix and clears them here too.
   clearRuntimeRecoveryBlock(runtimeId: string): void {
-    this.blockedRuntimeIds.delete(runtimeId)
-    this.startupBlockedRuntimeIds.delete(runtimeId)
+    this.recoveryCoordinator.clearRuntimeBlock(runtimeId)
   }
 
   // Called only after the explicit UI Runtime Reset has rebuilt and verified the managed default env.
@@ -3389,7 +3315,7 @@ class NotebookRuntimeService {
   // (which re-reads the now-absent journal and clears the barrier entirely). The user accepted the risk
   // for the prefix they explicitly reset, and only that prefix. Idempotent.
   clearCorruptRecoveryBlock(prefix: string): void {
-    this.corruptResetAllowlist.add(prefix)
+    this.recoveryCoordinator.allowCorruptReset(prefix)
   }
 
   // Records, in THIS process, that a prefix write failed with a child we could not confirm stopped — a
@@ -3398,8 +3324,7 @@ class NotebookRuntimeService {
   // it live-unconfirmed so a force Reset this session refuses to delete it out from under that orphan.
   // Injected into the provisioner as blockPrefix (ipc.ts), and called directly by the install path.
   blockPrefixRecovery(prefix: string): void {
-    this.blockedPrefixes.add(prefix)
-    this.liveUnconfirmedPrefixes.add(prefix)
+    this.recoveryCoordinator.markLiveUnconfirmed(prefix)
   }
 
   // True when a write in THIS process left `prefix` with a child that could not be confirmed stopped (see
@@ -3410,7 +3335,7 @@ class NotebookRuntimeService {
   // from the DURABLE journal/sidecar and clears the block only once the child is provably gone (pid ESRCH /
   // reused) or, for a no-PID orphan, a Linux machine-reboot proof (boot_id changed).
   isPrefixLiveUnconfirmed(prefix: string): boolean {
-    return this.liveUnconfirmedPrefixes.has(prefix)
+    return this.recoveryCoordinator.isPrefixLiveUnconfirmed(prefix)
   }
 
   // Runs fn under the SAME exclusive per-env lease that package installs use, so a
@@ -3435,163 +3360,13 @@ class NotebookRuntimeService {
     }
   }
 
-  private async runRecovery(): Promise<void> {
-    const runtimeRoot = getRuntimeRoot(this.options.dataRoot)
-    const nextStartupBlockedPrefixes = new Set<string>()
-    const nextStartupBlockedRuntimeIds = new Set<string>()
-    // Reclaim any prior-session pack-download cache FIRST — before the corrupt-journal early return
-    // below — so this housekeeping runs on every startup path, not just the healthy-journal one. It is
-    // only housekeeping: correctness of "app closes → start from scratch" is guaranteed independently by
-    // the per-session cache key (createFetchBundleAdapter), so a failure here (or skipping it) can never
-    // let a new fetch resume last session's .part — it only leaves reclaimable disk. Hence best-effort.
-    await rm(join(runtimeRoot, 'packs', '.cache'), { recursive: true, force: true }).catch(
-      () => undefined
-    )
-    const journal = RuntimeOperationJournal.forPath(operationJournalPath(runtimeRoot))
-    // Fail SAFE on a corrupt/unreadable journal: reconcileInterruptedOperations would read it as empty
-    // (nothing in flight) and open the recovery barrier, but a corrupt journal is NOT proof that no op
-    // was interrupted — an install/materialize may have been mid-write into ANY prefix (default, named,
-    // or an external install's runtimeId). We can't know which, so block EVERYTHING for this session
-    // (recoveryCorrupt — checked by every isPrefixRecoveryBlocked/isDefaultEnvRecoveryBlocked/
-    // assertPrefixRecoverable call, including named-env remove, which carries no journal record of its
-    // own and previously only checked the per-prefix set) and leave the journal untouched so a later
-    // boot — or an explicit Reset, which moves it aside — can recover.
-    if ((await journal.readState()) === 'corrupt') {
-      console.error(
-        '[notebook] operation journal is unreadable; blocking all runtime writes until recovery'
-      )
-      this.recoveryCorrupt = true
-      return
-    }
-    const reconciled = await reconcileInterruptedOperations(journal, {
-      operationChildLiveness: defaultOperationChildLiveness,
-      // Resolve the spawn lifecycle from the synchronous sidecar (see operation-journal): a recorded PID
-      // (recovering one the async journal update lost) is probed; a "spawning" intent with no PID means
-      // a child MAY be live so recovery must block (spawnAttempted); no sidecar means the op never
-      // reached the spawn stage and is safe to reconcile. Never a wall-clock guess.
-      hydrateInterruptedChild: (record) => {
-        // The synchronous sidecar is the AUTHORITATIVE record of the CURRENT spawn lifecycle: it is
-        // re-armed ({ spawning: true }) before EVERY spawn and converted to the PID on each spawn, so it
-        // always reflects the latest spawn. The journal's async childPid can be STALE — an op that
-        // spawns twice (materialize's cache-repair retry, or R's conda→CRAN) records spawn #1's PID in
-        // the journal; if it then crashed after spawn #2 started but before spawn #2's PID landed, the
-        // journal still names the (exited) first child. Trusting that would probe a dead pid, conclude
-        // 'dead', and clean the prefix while spawn #2 is still writing. So read the sidecar FIRST and let
-        // it override the journal.
-        const state = readOperationChild(runtimeRoot, record.operationId)
-        if (state === undefined) return record // no sidecar (legacy) -> fall back to the journal PID
-        // 'corrupt' (present but unreadable/invalid) or a bare spawn intent -> a child MAY be live but its
-        // PID is unknown. Block, and DROP any stale journal PID so recovery doesn't probe an earlier,
-        // already-exited child and wrongly conclude the target is free.
-        if (state === 'corrupt' || 'spawning' in state)
-          return {
-            ...record,
-            childPid: undefined,
-            childStartedAt: undefined,
-            childStartToken: undefined,
-            spawnAttempted: true
-          }
-        // Sidecar has the current PID -> probe it (overrides the journal). Its childStartToken (present
-        // only when the sidecar carried one) rides along in the spread as the authoritative identity.
-        return { ...record, ...state }
-      },
-      cleanStaging: async (record) => {
-        if (record.targetPath) await rm(record.targetPath, { recursive: true, force: true })
-      },
-      // materialize/upgrade: an interrupted create can leave the env prefix without conda-meta (a
-      // half-built dir micromamba would later refuse). Remove such an incomplete prefix so the next
-      // lazy materialize rebuilds it cleanly; a complete conda env (has conda-meta) is left intact.
-      verifyOrRebuildEnv: async (record) => {
-        if (!record.targetPath) return
-        if (!existsSync(record.targetPath)) return
-        if (existsSync(join(record.targetPath, 'conda-meta'))) return
-        await rm(record.targetPath, { recursive: true, force: true })
-      },
-      // install: an interrupted package install may be half-applied — flag the runtime repair-required
-      // so a bound session refuses it (no silent success). The flag is cleared when a fresh install of
-      // that runtime completes (managePackages), which is how the user repairs it.
-      markRepairRequired: async (record) => {
-        if (!record.runtimeId) return
-        const reason = record.repairReason ?? 'interrupted-install'
-        const language =
-          record.phase === 'install-r'
-            ? 'r'
-            : record.phase === 'install-python'
-              ? 'python'
-              : undefined
-        const alreadyScoped = /^managed:(?:python|r):/u.test(record.runtimeId)
-        const repairKey =
-          reason === 'protected-identity-change' || !record.targetPath || !language || alreadyScoped
-            ? record.runtimeId
-            : managedRepairRegistryKey(record.runtimeId, language)
-        addRepairRequired(getRuntimeRoot(this.options.dataRoot), repairKey, reason)
-      },
-      // liveness 'unknown' (couldn't confirm the child died — e.g. Windows with a recorded start time):
-      // a possibly-live orphan may still be writing this operation's env prefix. Block that PREFIX while
-      // its durable operation remains so any write to it (default materialize, package install, named-env
-      // create, UI provision/repair) refuses — rather than racing the survivor once the recovery barrier
-      // opens. Keyed by targetPath (the prefix the op writes), which materialize/
-      // upgrade/install all carry and which is exactly what the write paths check via
-      // assertPrefixRecoverable — unlike a repair-required flag, whose env/interpreter-id key does not
-      // match the materialize op's env-NAME runtimeId (so that flag never fired for the default env, and
-      // install is deliberately allowed while repair-required anyway). The journal entry is retained, so
-      // a later restart re-runs recovery and, once the pid is gone/verifiable, reconciles + unblocks.
-      //
-      // A 'download' op needs no block: each fetch stages into its own unique mkdtemp('.incoming-') dir
-      // and commits by atomic rename, so an orphaned download can't corrupt a fresh fetch (a later
-      // startup reaps the leftover). Its targetPath is that staging dir, which nothing else writes.
-      blockUnknownChildTarget: async (record) => {
-        // An INSTALL is identified by its runtimeId, not a managed prefix: an external install's target
-        // is the user's own env (no path under runtimeRoot) and a managed named install's identity is
-        // its runtimeId. Block the runtimeId so execute()/managePackages() refuse the bound runtime.
-        if (record.kind === 'install') nextStartupBlockedRuntimeIds.add(record.runtimeId)
-        // materialize/upgrade name the real managed prefix they write — block it so managed materialize/
-        // create/remove/startup maintenance refuse it. (An external install carries no targetPath, so
-        // it never wrongly blocks the app-managed default here.)
-        if (record.targetPath) nextStartupBlockedPrefixes.add(record.targetPath)
-      }
-    })
-
-    // Replace only the blocks derived from the prior recovery snapshot. Same-process unconfirmed
-    // workers remain in the live sets and can never be cleared merely because a journal file vanished.
-    for (const prefix of this.startupBlockedPrefixes) {
-      if (!nextStartupBlockedPrefixes.has(prefix) && !this.liveUnconfirmedPrefixes.has(prefix)) {
-        this.blockedPrefixes.delete(prefix)
-      }
-    }
-    for (const runtimeId of this.startupBlockedRuntimeIds) {
-      if (
-        !nextStartupBlockedRuntimeIds.has(runtimeId) &&
-        !this.liveUnconfirmedRuntimeIds.has(runtimeId)
-      ) {
-        this.blockedRuntimeIds.delete(runtimeId)
-      }
-    }
-    this.startupBlockedPrefixes.clear()
-    this.startupBlockedRuntimeIds.clear()
-    for (const prefix of nextStartupBlockedPrefixes) {
-      this.startupBlockedPrefixes.add(prefix)
-      this.blockedPrefixes.add(prefix)
-    }
-    for (const runtimeId of nextStartupBlockedRuntimeIds) {
-      this.startupBlockedRuntimeIds.add(runtimeId)
-      this.blockedRuntimeIds.add(runtimeId)
-    }
-    // A cleanly readable journal supersedes a previous corrupt snapshot. Reset allowlisting is only
-    // meaningful while the global corrupt barrier is active.
-    this.recoveryCorrupt = false
-    this.corruptResetAllowlist.clear()
-
-    // Reconciled records are cleared from the journal, so their PID sidecars are now inert — remove them
-    // so they don't accumulate. A retained (unknown-blocked) record keeps its sidecar for the next
-    // startup's liveness probe.
-    for (const record of reconciled) removeOperationChildSync(runtimeRoot, record.operationId)
-  }
-
   // Shuts down every live interpreter, used by app-level cleanup paths. Returns { reaped }: true only
   // when every kernel tree was cleanly reaped, so the update-install gate can refuse to trigger the
   // NSIS uninstall while a kernel may still hold file handles under the install dir.
   async shutdownAll(): Promise<{ reaped: boolean }> {
+    // Recovery is process-owned work. Await any active reconciliation and permanently close its command
+    // surface before tearing down kernels, so late startup work cannot reopen a target during shutdown.
+    await this.recoveryCoordinator.dispose()
     // Let any in-flight disable drain-and-close settle first, so a revocation teardown never races the
     // shutdown (and tests don't leak a dangling background drain).
     await Promise.all(Array.from(this.revocationDrains)).catch(() => undefined)

--- a/src/main/notebook/runtime-service.ts
+++ b/src/main/notebook/runtime-service.ts
@@ -3378,8 +3378,13 @@ class NotebookRuntimeService {
   // shutdownAll(), this is terminal: quit/relaunch and module disposal use it, while update and data-root
   // migration gates retain the reusable shutdown contract so a refused/cancelled flow can resume work.
   async dispose(): Promise<{ reaped: boolean }> {
-    await this.recoveryCoordinator.dispose()
-    return this.shutdownAll()
+    // Mark recovery disposed first, but do not let slow startup filesystem reconciliation consume the
+    // quit budget before kernel teardown even starts. Await both so non-quit module disposal still leaves
+    // no recovery work behind once this terminal operation resolves.
+    const recoveryDisposal = this.recoveryCoordinator.dispose()
+    const shutdown = this.shutdownAll()
+    const [result] = await Promise.all([shutdown, recoveryDisposal])
+    return result
   }
 
   // Lists sessions with a cell mid-execution, for the pre-migration active-session warning.

--- a/src/main/storage/ipc.test.ts
+++ b/src/main/storage/ipc.test.ts
@@ -71,6 +71,7 @@ const fakeDeps = (overrides: Partial<FakeDeps> = {}): FakeDeps => ({
   },
   notebook: {
     shutdownAll: vi.fn().mockResolvedValue({ reaped: true }),
+    dispose: vi.fn().mockResolvedValue({ reaped: true }),
     getActiveNotebookSessions: vi.fn().mockReturnValue([])
   },
   getActivePromptSessions: vi.fn().mockReturnValue([]),
@@ -319,7 +320,8 @@ describe('storage IPC handlers', () => {
         .fn()
         .mockReturnValue([{ projectName: 'p', sessionId: 'agent-1' }]),
       notebook: {
-        shutdownAll: vi.fn().mockResolvedValue(undefined),
+        shutdownAll: vi.fn().mockResolvedValue({ reaped: true }),
+        dispose: vi.fn().mockResolvedValue({ reaped: true }),
         getActiveNotebookSessions: vi
           .fn()
           .mockReturnValue([{ projectName: 'p', sessionId: 'nb-1' }])
@@ -339,7 +341,8 @@ describe('storage IPC handlers', () => {
     // reference drops `this` and throws "Cannot read properties of undefined (reading 'values')".
     class FakeNotebookService {
       private sessions = new Map([['nb-1', { projectName: 'p', sessionId: 'nb-1' }]])
-      shutdownAll = vi.fn().mockResolvedValue(undefined)
+      shutdownAll = vi.fn().mockResolvedValue({ reaped: true })
+      dispose = vi.fn().mockResolvedValue({ reaped: true })
       getActiveNotebookSessions(): { projectName: string; sessionId: string }[] {
         return Array.from(this.sessions.values())
       }
@@ -453,7 +456,8 @@ describe('storage IPC handlers', () => {
     })
 
     expect(deps.runtime.shutdownForQuit).toHaveBeenCalledTimes(1)
-    expect(deps.notebook.shutdownAll).toHaveBeenCalledTimes(1)
+    expect(deps.notebook.dispose).toHaveBeenCalledTimes(1)
+    expect(deps.notebook.shutdownAll).not.toHaveBeenCalled()
     expect(appRelaunch).toHaveBeenCalledTimes(1)
     expect(appExit).toHaveBeenCalledWith(0)
     expect(cleanupRuntimeCache).toHaveBeenCalledWith(join(dataRoot, 'runtime'))
@@ -473,7 +477,8 @@ describe('storage IPC handlers', () => {
     ).resolves.toEqual({ ok: true })
 
     expect(deps.runtime.shutdownForQuit).toHaveBeenCalledTimes(1)
-    expect(deps.notebook.shutdownAll).toHaveBeenCalledTimes(1)
+    expect(deps.notebook.dispose).toHaveBeenCalledTimes(1)
+    expect(deps.notebook.shutdownAll).not.toHaveBeenCalled()
     expect(appRelaunch).toHaveBeenCalledTimes(1)
     expect(appExit).toHaveBeenCalledWith(0)
   })

--- a/src/main/storage/ipc.ts
+++ b/src/main/storage/ipc.ts
@@ -43,14 +43,15 @@ import { RELOCATABLE_DATA_DIRS } from './data-directories'
 type SessionSource = { projectName: string; sessionId: string }
 
 type StorageIpcDeps = {
-  // disconnect drives the migration session-interrupt; shutdownForQuit is the awaited quit/relaunch
-  // teardown used by cleanRelaunch (via shutdownBackends).
+  // disconnect/shutdownAll drive the reusable migration session-interrupt; shutdownForQuit/dispose are
+  // the terminal teardown used by cleanRelaunch (via shutdownBackends).
   runtime: {
     disconnect: () => Promise<unknown>
     shutdownForQuit: () => Promise<{ reaped: boolean }>
   }
   notebook: {
     shutdownAll: () => Promise<{ reaped: boolean }>
+    dispose: () => Promise<{ reaped: boolean }>
     getActiveNotebookSessions: () => SessionSource[]
   }
   getActivePromptSessions: () => SessionSource[]


### PR DESCRIPTION
## Problem

`NotebookRuntimeService` owns startup recovery, interrupted-operation reconciliation, repair markers, blocked prefixes, and recovery lifecycle state alongside session, execution, package, and environment orchestration. That makes recovery state ownership difficult to reason about and lets the runtime service continue expanding.

## Proposed change

- Extract process-owned recovery state and reconciliation into `NotebookRecoveryCoordinator`.
- Preserve recovery readiness, interrupted-operation cleanup, repair-required markers, prefix blocking, and failure semantics.
- Keep temporary kernel shutdown reusable for update and migration gates.
- Add a distinct terminal `dispose()` boundary for quit, clean relaunch, and module rollback.
- Start kernel teardown immediately during terminal disposal even when startup recovery is still settling, while still waiting for both terminal paths before reporting completion or failure.
- Add characterization and real-service regression coverage for recovery and lifecycle invariants.

```mermaid
flowchart LR
  O["Notebook operations"] --> R["NotebookRuntimeService"]
  R --> C["NotebookRecoveryCoordinator"]
  C --> J["Interrupted operation journals"]
  C --> P["Repair markers and blocked prefixes"]
  U["Update / migration gate"] --> S["Reusable shutdownAll"]
  Q["Quit / relaunch / rollback"] --> D["Terminal dispose"]
  S --> R
  D --> C
  D --> R
```

## Scope and non-goals

- No public IPC payload, storage schema, persisted data model, data relationship, or UI interaction changes.
- Electron, Web, and CLI continue through the existing Notebook runtime/IPC surfaces.
- Specialist, Permission, Compute, ACP transport, and Settings behavior are unchanged.
- Issue #458 remains a forward constraint only; this PR does not implement task/session delegation policy.
- Internal planning documents under `docs/internal` are not included.

## Acceptance criteria and validation

All checks below ran on the final branch state after rebasing onto the latest `main`:

- Recovery, runtime reuse, terminal teardown, lifecycle, notebook IPC, and migration IPC -> `npm test -- --run src/main/notebook/recovery-coordinator.test.ts src/main/notebook/runtime-service.test.ts src/main/notebook/ipc.test.ts src/main/lifecycle-shutdown.test.ts src/main/storage/ipc.test.ts` -> PASS (5 files, 224 tests)
- Node and Web contracts -> `npm run typecheck` -> PASS
- Repository lint -> `npm run lint -- --no-cache` -> PASS (0 errors, 23 pre-existing warnings; changed files have no warnings)
- Full regression suite -> `npm test` -> PASS (612 files, 9,095 tests; 11 files / 140 tests skipped)
- `git diff --check` and changed-file Prettier -> PASS
- Independent Standards review -> 0 findings
- Independent Spec review -> 0 findings

## Review focus

- Confirm recovery state has one process-owned coordinator and no duplicate mutable owner remains in `NotebookRuntimeService`.
- Confirm update/migration paths use reusable `shutdownAll()` while only terminal lifecycle paths call `dispose()`.
- Confirm cleanup, repair-marker, blocked-prefix, and retry semantics remain fail-closed and idempotent.

## Uncovered risk

Recovery is exercised through filesystem/process fixtures rather than killing a real packaged Electron application mid-operation. No public API or user interaction changed.
