### PR TITLE
refactor(settings): extract connector settings ownership

### DIFF
--- a/src/main/settings/connector-settings.test.ts
+++ b/src/main/settings/connector-settings.test.ts
@@ -1,0 +1,390 @@
+import { describe, it, expect, beforeEach, vi } from 'vitest'
+import { mkdtemp, readFile, rm } from 'node:fs/promises'
+import { tmpdir } from 'node:os'
+import { join } from 'node:path'
+
+const keychain = vi.hoisted(() => ({ available: true }))
+
+// Reversible fake safeStorage so secrets can be encrypted without an OS keychain.
+vi.mock('electron', () => ({
+  safeStorage: {
+    isEncryptionAvailable: () => keychain.available,
+    encryptString: (plaintext: string) => {
+      if (!keychain.available) throw new Error('Encryption is unavailable')
+      return Buffer.from(`cipher:${plaintext}`, 'utf8')
+    },
+    decryptString: (buffer: Buffer) => {
+      if (!keychain.available) throw new Error('Encryption is unavailable')
+      return buffer.toString('utf8').slice('cipher:'.length)
+    }
+  },
+  app: { getPath: () => '/home', getAppPath: () => '/home/no-such-app-root', isPackaged: false }
+}))
+
+const { ConnectorSettingsModule } = await import('./connector-settings')
+const { SettingsRepository } = await import('./repository')
+const { ALL_CONNECTOR_IDS } = await import('../connectors/registry')
+
+// Exercises the durable Connector owner against a real on-disk repository.
+describe('ConnectorSettingsModule', () => {
+  let dir: string
+  let service: InstanceType<typeof ConnectorSettingsModule>
+  let repository: InstanceType<typeof SettingsRepository>
+
+  beforeEach(async () => {
+    keychain.available = true
+    dir = await mkdtemp(join(tmpdir(), 'osci-svc-connectors-'))
+    repository = new SettingsRepository(dir)
+    service = new ConnectorSettingsModule(repository)
+    return async () => {
+      await rm(dir, { recursive: true, force: true })
+    }
+  })
+
+  it('lists every bundled connector, all enabled and not auto-allowed by default', async () => {
+    const snapshot = await service.listConnectors()
+
+    expect(snapshot.connectors).toHaveLength(ALL_CONNECTOR_IDS.length)
+    expect(snapshot.connectors.every((c) => c.enabled)).toBe(true)
+    expect(snapshot.connectors.every((c) => !c.autoAllow)).toBe(true)
+    expect(snapshot.customServers).toEqual([])
+    expect(snapshot.ncbi).toEqual({ contactEmail: undefined, hasApiKey: false })
+  })
+
+  it('disables and re-enables one connector', async () => {
+    let snapshot = await service.setConnectorEnabled({ id: 'chemistry', enabled: false })
+    expect(snapshot.connectors.find((c) => c.id === 'chemistry')?.enabled).toBe(false)
+    // Others stay enabled.
+    expect(snapshot.connectors.find((c) => c.id === 'pubmed')?.enabled).toBe(true)
+
+    snapshot = await service.setConnectorEnabled({ id: 'chemistry', enabled: true })
+    expect(snapshot.connectors.find((c) => c.id === 'chemistry')?.enabled).toBe(true)
+  })
+
+  it('toggles connector auto-allow (skip approvals)', async () => {
+    const snapshot = await service.setConnectorAutoAllow({ id: 'biomart', autoAllow: true })
+    expect(snapshot.connectors.find((c) => c.id === 'biomart')?.autoAllow).toBe(true)
+  })
+
+  it('returns connector detail with tools defaulting to allow', async () => {
+    const detail = await service.getConnectorDetail('chemistry')
+
+    expect(detail.id).toBe('chemistry')
+    expect(detail.tools.length).toBeGreaterThan(0)
+    expect(detail.tools.every((t) => t.permission === 'allow')).toBe(true)
+    expect(detail.tools[0].id).toBe(`chemistry/${detail.tools[0].method}`)
+  })
+
+  it('cycles a tool through block, ask, and back to allow', async () => {
+    const first = await service.getConnectorDetail('chemistry')
+    const toolId = first.tools[0].id
+
+    const blocked = await service.setToolPermission({ toolId, permission: 'block' })
+    expect(blocked.tools.find((t) => t.id === toolId)?.permission).toBe('block')
+
+    const asked = await service.setToolPermission({ toolId, permission: 'ask' })
+    expect(asked.tools.find((t) => t.id === toolId)?.permission).toBe('ask')
+
+    const allowed = await service.setToolPermission({ toolId, permission: 'allow' })
+    expect(allowed.tools.find((t) => t.id === toolId)?.permission).toBe('allow')
+  })
+
+  it('never keeps a tool in both ask and blocked sets', async () => {
+    const first = await service.getConnectorDetail('chemistry')
+    const toolId = first.tools[0].id
+
+    await service.setToolPermission({ toolId, permission: 'ask' })
+    await service.setToolPermission({ toolId, permission: 'block' })
+    const c = await service.getConnectors()
+    expect(c?.askToolIds ?? []).not.toContain(toolId)
+    expect(c?.blockedToolIds ?? []).toContain(toolId)
+  })
+
+  it('treats block as stronger than ask when reading inconsistent stored policy', async () => {
+    const first = await service.getConnectorDetail('chemistry')
+    const toolId = first.tools[0].id
+    await repository.setToolPolicy(toolId, true, false)
+    await repository.setToolBlocked(toolId, true)
+
+    const detail = await service.getConnectorDetail('chemistry')
+
+    expect(detail.tools.find((tool) => tool.id === toolId)?.permission).toBe('block')
+  })
+
+  it('stores contact email and reports hasApiKey without exposing the key', async () => {
+    const snapshot = await service.setNcbiCredentials({
+      contactEmail: 'me@lab.org',
+      apiKey: 'secret-key'
+    })
+
+    expect(snapshot.ncbi.contactEmail).toBe('me@lab.org')
+    expect(snapshot.ncbi.hasApiKey).toBe(true)
+    // The raw key never appears in the renderer snapshot.
+    expect(JSON.stringify(snapshot)).not.toContain('secret-key')
+  })
+
+  it('preserves an omitted NCBI key and clears an explicit empty key', async () => {
+    await service.setNcbiCredentials({ contactEmail: 'first@lab.org', apiKey: 'secret-key' })
+
+    let snapshot = await service.setNcbiCredentials({ contactEmail: 'second@lab.org' })
+    expect(snapshot.ncbi).toEqual({ contactEmail: 'second@lab.org', hasApiKey: true })
+
+    snapshot = await service.setNcbiCredentials({ contactEmail: 'second@lab.org', apiKey: '' })
+    expect(snapshot.ncbi).toEqual({ contactEmail: 'second@lab.org', hasApiKey: false })
+  })
+
+  it('throws for an unknown connector id', async () => {
+    await expect(service.getConnectorDetail('nope')).rejects.toThrow(/Unknown connector/)
+  })
+
+  it('adds, toggles, and removes a local (stdio) custom server', async () => {
+    let snapshot = await service.addCustomServer({
+      name: 'my-mem',
+      transport: 'stdio',
+      command: 'npx',
+      args: ['-y', '@modelcontextprotocol/server-memory'],
+      description: 'Memory server'
+    })
+    expect(snapshot.customServers).toHaveLength(1)
+    const added = snapshot.customServers[0]
+    expect(added).toMatchObject({
+      name: 'my-mem',
+      transport: 'stdio',
+      command: 'npx',
+      enabled: true,
+      description: 'Memory server'
+    })
+    expect(added.id).toBeTruthy()
+
+    snapshot = await service.setCustomServerEnabled({ id: added.id, enabled: false })
+    expect(snapshot.customServers[0].enabled).toBe(false)
+
+    snapshot = await service.removeCustomServer({ id: added.id })
+    expect(snapshot.customServers).toEqual([])
+  })
+
+  it('adds a remote (streamable_http) custom server with a url', async () => {
+    const snapshot = await service.addCustomServer({
+      name: 'remote-x',
+      transport: 'streamable_http',
+      url: 'https://example.com/mcp',
+      headers: { Authorization: 'Bearer t' }
+    })
+    expect(snapshot.customServers[0]).toMatchObject({
+      name: 'remote-x',
+      transport: 'streamable_http',
+      url: 'https://example.com/mcp'
+    })
+  })
+
+  it('rejects an invalid custom server (stdio without a command)', async () => {
+    await expect(service.addCustomServer({ name: 'bad', transport: 'stdio' })).rejects.toThrow(
+      /Invalid custom connector/
+    )
+  })
+
+  it('does not expose custom-server env or header secrets in the view', async () => {
+    const snapshot = await service.addCustomServer({
+      name: 'secretful',
+      transport: 'stdio',
+      command: 'run',
+      env: { TOKEN: 'super-secret' }
+    })
+    expect(JSON.stringify(snapshot)).not.toContain('super-secret')
+    const storedJson = await readFile(join(dir, 'settings.json'), 'utf8')
+    expect(storedJson).not.toContain('super-secret')
+    expect(storedJson).toContain('envRefs')
+    expect(storedJson).toContain('enc:')
+  })
+
+  it('migrates legacy plaintext custom-server secrets when secure storage is available', async () => {
+    await repository.addCustomServer({
+      id: 'legacy',
+      name: 'legacy',
+      transport: 'streamable_http',
+      enabled: true,
+      url: 'https://example.test/mcp',
+      env: { TOKEN: 'legacy-env-secret' },
+      headers: { Authorization: 'legacy-header-secret' }
+    })
+
+    const server = (await service.getConnectors())?.customMcpServers?.[0]
+    expect(server?.env).toEqual({ TOKEN: 'legacy-env-secret' })
+    expect(server?.headers).toEqual({ Authorization: 'legacy-header-secret' })
+
+    const storedJson = await readFile(join(dir, 'settings.json'), 'utf8')
+    expect(storedJson).not.toContain('legacy-env-secret')
+    expect(storedJson).not.toContain('legacy-header-secret')
+    expect(storedJson).toContain('envRefs')
+    expect(storedJson).toContain('headerRefs')
+  })
+
+  it('keeps legacy secrets readable but rejects new secret writes without secure storage', async () => {
+    await repository.addCustomServer({
+      id: 'legacy',
+      name: 'legacy',
+      transport: 'stdio',
+      enabled: true,
+      command: 'old-command',
+      env: { TOKEN: 'keep-me' }
+    })
+    keychain.available = false
+
+    expect((await service.getConnectors())?.customMcpServers?.[0]?.env).toEqual({
+      TOKEN: 'keep-me'
+    })
+    await service.updateCustomServer({
+      id: 'legacy',
+      transport: 'stdio',
+      command: 'new-command'
+    })
+    await expect(
+      service.addCustomServer({
+        name: 'new-secret',
+        transport: 'stdio',
+        command: 'run',
+        env: { TOKEN: 'must-not-persist' }
+      })
+    ).rejects.toThrow(/secure credential storage is unavailable/i)
+
+    const storedJson = await readFile(join(dir, 'settings.json'), 'utf8')
+    expect(storedJson).toContain('keep-me')
+    expect(storedJson).toContain('new-command')
+    expect(storedJson).not.toContain('must-not-persist')
+  })
+
+  it('edits a custom server, keeping its name and preserving omitted env', async () => {
+    const added = await service.addCustomServer({
+      name: 'my-mem',
+      transport: 'stdio',
+      command: 'npx',
+      args: ['-y', 'old'],
+      env: { TOKEN: 'keep-me' }
+    })
+    const id = added.customServers[0].id
+
+    // Change command/args but omit env — the stored secret env must be preserved.
+    const updated = await service.updateCustomServer({
+      id,
+      transport: 'stdio',
+      command: 'node',
+      args: ['server.js']
+    })
+    const view = updated.customServers.find((s) => s.id === id)
+    expect(view?.name).toBe('my-mem') // name is immutable
+    expect(view?.command).toBe('node')
+    expect(view?.args).toEqual(['server.js'])
+
+    const stored = (await service.getConnectors())?.customMcpServers?.find((s) => s.id === id)
+    expect(stored?.env).toEqual({ TOKEN: 'keep-me' })
+  })
+
+  it('invalidates remembered authority before persisting a security-sensitive server edit', async () => {
+    const added = await service.addCustomServer({
+      name: 'mutable-endpoint',
+      transport: 'stdio',
+      command: 'old-command',
+      args: ['serve']
+    })
+    const id = added.customServers[0].id
+    const commit = vi.fn()
+    const rollback = vi.fn()
+    const invalidate = vi.fn(async (serverId: string) => {
+      const stored = (await service.getConnectors())?.customMcpServers?.find(
+        (server) => server.id === serverId
+      )
+      expect(stored?.command).toBe('old-command')
+      return { commit, rollback }
+    })
+
+    await service.updateCustomServer(
+      {
+        id,
+        transport: 'streamable_http',
+        url: 'https://new.example/mcp',
+        headers: { Authorization: 'Bearer replacement' }
+      },
+      invalidate
+    )
+
+    expect(invalidate).toHaveBeenCalledOnce()
+    expect(invalidate).toHaveBeenCalledWith(id)
+    expect(commit).toHaveBeenCalledOnce()
+    expect(commit.mock.calls[0]?.[0]).toMatchObject({ id, url: 'https://new.example/mcp' })
+    expect(rollback).not.toHaveBeenCalled()
+    const stored = (await service.getConnectors())?.customMcpServers?.find(
+      (server) => server.id === id
+    )
+    expect(stored?.transport).toBe('streamable_http')
+    expect(stored?.url).toBe('https://new.example/mcp')
+  })
+
+  it('keeps grants for display-only edits and fails closed when invalidation fails', async () => {
+    const added = await service.addCustomServer({
+      name: 'stable-endpoint',
+      description: 'Before',
+      transport: 'stdio',
+      command: 'stable-command'
+    })
+    const id = added.customServers[0].id
+    const invalidate = vi.fn().mockResolvedValue(undefined)
+
+    await service.updateCustomServer(
+      {
+        id,
+        description: 'After',
+        transport: 'stdio',
+        command: 'stable-command'
+      },
+      invalidate
+    )
+    expect(invalidate).not.toHaveBeenCalled()
+
+    invalidate.mockRejectedValueOnce(new Error('grant cleanup failed'))
+    await expect(
+      service.updateCustomServer(
+        {
+          id,
+          description: 'After',
+          transport: 'stdio',
+          command: 'replacement-command'
+        },
+        invalidate
+      )
+    ).rejects.toThrow('grant cleanup failed')
+
+    const stored = (await service.getConnectors())?.customMcpServers?.find(
+      (server) => server.id === id
+    )
+    expect(stored?.description).toBe('After')
+    expect(stored?.command).toBe('stable-command')
+  })
+
+  it('rolls back the custom-server security barrier when persistence fails', async () => {
+    const added = await service.addCustomServer({
+      name: 'rollback-endpoint',
+      transport: 'stdio',
+      command: 'old-command'
+    })
+    const id = added.customServers[0].id
+    const commit = vi.fn()
+    const rollback = vi.fn()
+    vi.spyOn(repository, 'updateCustomServer').mockRejectedValueOnce(new Error('write failed'))
+
+    await expect(
+      service.updateCustomServer({ id, transport: 'stdio', command: 'new-command' }, async () => ({
+        commit,
+        rollback
+      }))
+    ).rejects.toThrow('write failed')
+
+    expect(commit).not.toHaveBeenCalled()
+    expect(rollback).toHaveBeenCalledOnce()
+  })
+
+  it('rejects editing an unknown custom server', async () => {
+    await expect(
+      service.updateCustomServer({ id: 'nope', transport: 'stdio', command: 'x' })
+    ).rejects.toThrow(/Unknown custom connector/)
+  })
+})

--- a/src/main/settings/connector-settings.ts
+++ b/src/main/settings/connector-settings.ts
@@ -1,0 +1,341 @@
+import { randomUUID } from 'node:crypto'
+import { isDeepStrictEqual } from 'node:util'
+
+import type {
+  AddCustomServerRequest,
+  ConnectorDetailView,
+  ConnectorsSnapshot,
+  ConnectorView,
+  CustomServerView,
+  NcbiCredentialsView,
+  RemoveCustomServerRequest,
+  SetConnectorAutoAllowRequest,
+  SetConnectorEnabledRequest,
+  SetCustomServerEnabledRequest,
+  SetNcbiCredentialsRequest,
+  SetToolPermissionRequest,
+  ToolPermission,
+  UpdateCustomServerRequest
+} from '../../shared/settings'
+import { CONNECTOR_CATALOG } from '../connectors/catalog'
+import { getConnectorTools } from '../connectors/registry'
+import { encryptKey, isEncryptionAvailable, tryDecryptKey } from './crypto'
+import { sanitizeCustomMcpServer, type SettingsRepository } from './repository'
+import type { StoredConnectors, StoredCustomMcpServer } from './types'
+
+type CustomServerSecurityChangeGuard = {
+  commit(server: StoredCustomMcpServer): void
+  rollback(): void
+}
+
+// Owns durable Connector policy, secret migration/projection, and custom-server mutation. Live MCP
+// clients, approval decisions, Specialist bindings, and refresh workflows remain outside this module.
+class ConnectorSettingsModule {
+  constructor(private readonly repository: SettingsRepository) {}
+
+  // Bundled connectors are default-on. Keep this projection on the durable owner so runtime
+  // configuration, Skill provisioning, and renderer views all apply the same opt-out rule.
+  enabledConnectorIds(connectors: StoredConnectors | undefined): string[] {
+    const disabled = new Set(connectors?.disabledConnectorIds ?? [])
+
+    return CONNECTOR_CATALOG.map((meta) => meta.id).filter((id) => !disabled.has(id))
+  }
+
+  // Called from SettingsService's existing whole-settings migration path so the trigger timing and
+  // provider-before-Connector ordering stay unchanged while Connector migration has one owner.
+  async migrateLegacyNcbiKeyRef(connectors: StoredConnectors | undefined): Promise<boolean> {
+    const ref = connectors?.ncbiApiKeyRef
+    if (!ref?.startsWith('plain:')) return false
+    const key = tryDecryptKey(ref)
+    if (!key) return false
+
+    await this.repository.setNcbiCredentials(connectors?.contactEmail, encryptKey(key))
+
+    return true
+  }
+
+  // Main-process-only read used by live Connector and runtime consumers. Renderer-facing methods
+  // below project secret-free views instead of exposing decrypted env/header values.
+  async getConnectors(): Promise<StoredConnectors | undefined> {
+    const settings = await this.repository.getSettings()
+    const connectors = settings.connectors
+    if (!connectors?.customMcpServers) return connectors
+
+    const resolvedServers: StoredCustomMcpServer[] = []
+    for (const stored of connectors.customMcpServers) {
+      let secured = stored
+      // Migrate pre-encryption settings on first read. The renderer never receives resolved secrets.
+      if ((stored.env || stored.headers) && isEncryptionAvailable()) {
+        secured = {
+          ...stored,
+          ...(stored.env ? { envRefs: this.encryptSecretRecord(stored.env) } : {}),
+          ...(stored.headers ? { headerRefs: this.encryptSecretRecord(stored.headers) } : {}),
+          env: undefined,
+          headers: undefined
+        }
+        await this.repository.updateCustomServer(stored.id, secured)
+      }
+
+      resolvedServers.push({
+        ...secured,
+        env: secured.envRefs ? this.decryptSecretRecord(secured.envRefs) : secured.env,
+        headers: secured.headerRefs ? this.decryptSecretRecord(secured.headerRefs) : secured.headers
+      })
+    }
+
+    return { ...connectors, customMcpServers: resolvedServers }
+  }
+
+  async provisionedConnectorSkillNames(): Promise<string[]> {
+    const connectors = await this.getConnectors()
+    const bundled = this.enabledConnectorIds(connectors)
+    const custom = (connectors?.customMcpServers ?? [])
+      .filter((server) => server.enabled)
+      .map((server) => server.id)
+
+    return Array.from(new Set([...bundled, ...custom].map((id) => `mcp-${id}`)))
+  }
+
+  async listConnectors(): Promise<ConnectorsSnapshot> {
+    return this.connectorsSnapshot()
+  }
+
+  async getConnectorDetail(id: string): Promise<ConnectorDetailView> {
+    const meta = CONNECTOR_CATALOG.find((entry) => entry.id === id)
+
+    if (!meta) throw new Error(`Unknown connector: ${id}`)
+
+    const connectors = await this.getConnectors()
+    const view = this.toConnectorViews(connectors).find((entry) => entry.id === id)
+    const blocked = new Set(connectors?.blockedToolIds ?? [])
+    const ask = new Set(connectors?.askToolIds ?? [])
+    const tools = getConnectorTools(id).map((tool) => {
+      const toolId = `${id}/${tool.id}`
+      // Precedence: block > ask > allow (the default; tools run without a prompt unless opted in).
+      const permission: ToolPermission = blocked.has(toolId)
+        ? 'block'
+        : ask.has(toolId)
+          ? 'ask'
+          : 'allow'
+
+      return { id: toolId, method: tool.id, description: tool.description, permission }
+    })
+
+    return { ...view!, useWhen: meta.useWhen, termsUrl: meta.termsUrl, tools }
+  }
+
+  async setConnectorEnabled(request: SetConnectorEnabledRequest): Promise<ConnectorsSnapshot> {
+    await this.repository.setConnectorDisabled(request.id, !request.enabled)
+
+    return this.connectorsSnapshot()
+  }
+
+  async setConnectorAutoAllow(request: SetConnectorAutoAllowRequest): Promise<ConnectorsSnapshot> {
+    await this.repository.setConnectorAutoAllow(request.id, request.autoAllow)
+
+    return this.connectorsSnapshot()
+  }
+
+  async setToolPermission(request: SetToolPermissionRequest): Promise<ConnectorDetailView> {
+    await this.repository.setToolPolicy(
+      request.toolId,
+      request.permission === 'ask',
+      request.permission === 'block'
+    )
+    const connectorId = request.toolId.split('/')[0]
+
+    return this.getConnectorDetail(connectorId)
+  }
+
+  async setNcbiCredentials(request: SetNcbiCredentialsRequest): Promise<ConnectorsSnapshot> {
+    const existing = await this.getConnectors()
+    // An omitted apiKey leaves the stored key unchanged; an empty string clears it.
+    const apiKeyRef =
+      request.apiKey === undefined
+        ? existing?.ncbiApiKeyRef
+        : request.apiKey === ''
+          ? undefined
+          : encryptKey(request.apiKey)
+
+    await this.repository.setNcbiCredentials(request.contactEmail?.trim() || undefined, apiKeyRef)
+
+    return this.connectorsSnapshot()
+  }
+
+  async addCustomServer(request: AddCustomServerRequest): Promise<ConnectorsSnapshot> {
+    const candidate: StoredCustomMcpServer = {
+      id: randomUUID(),
+      name: request.name.trim(),
+      transport: request.transport,
+      enabled: true,
+      trustedAt: Date.now(),
+      ...(request.description?.trim() ? { description: request.description.trim() } : {}),
+      ...(request.command?.trim() ? { command: request.command.trim() } : {}),
+      ...(request.args && request.args.length > 0 ? { args: request.args } : {}),
+      ...(request.env && Object.keys(request.env).length > 0
+        ? { envRefs: this.encryptSecretRecord(request.env) }
+        : {}),
+      ...(request.url?.trim() ? { url: request.url.trim() } : {}),
+      ...(request.headers && Object.keys(request.headers).length > 0
+        ? { headerRefs: this.encryptSecretRecord(request.headers) }
+        : {})
+    }
+    const server = sanitizeCustomMcpServer(candidate)
+
+    if (!server) throw new Error('Invalid custom connector configuration')
+
+    await this.repository.addCustomServer(server)
+
+    return this.connectorsSnapshot()
+  }
+
+  async setCustomServerEnabled(
+    request: SetCustomServerEnabledRequest
+  ): Promise<ConnectorsSnapshot> {
+    await this.repository.setCustomServerEnabled(request.id, request.enabled)
+
+    return this.connectorsSnapshot()
+  }
+
+  async removeCustomServer(request: RemoveCustomServerRequest): Promise<ConnectorsSnapshot> {
+    await this.repository.removeCustomServer(request.id)
+
+    return this.connectorsSnapshot()
+  }
+
+  // Omitted env/headers retain their stored values. Security-sensitive changes acquire a guard
+  // before persistence, commit it after the durable write, and roll it back if that write fails.
+  async updateCustomServer(
+    request: UpdateCustomServerRequest,
+    beforeSecuritySensitiveUpdate?: (
+      serverId: string
+    ) => Promise<CustomServerSecurityChangeGuard | void>
+  ): Promise<ConnectorsSnapshot> {
+    const existing = (await this.getConnectors())?.customMcpServers?.find(
+      (server) => server.id === request.id
+    )
+
+    if (!existing) throw new Error(`Unknown custom connector: ${request.id}`)
+
+    const envRefs = request.env ? this.encryptSecretRecord(request.env) : existing.envRefs
+    const headerRefs = request.headers
+      ? this.encryptSecretRecord(request.headers)
+      : existing.headerRefs
+    // Preserve legacy plaintext only when the caller leaves it untouched and safeStorage is still
+    // unavailable. A later getConnectors() call migrates it as soon as encryption becomes available.
+    const legacyEnv = request.env === undefined ? existing.env : undefined
+    const legacyHeaders = request.headers === undefined ? existing.headers : undefined
+    const merged: StoredCustomMcpServer = {
+      id: existing.id,
+      name: existing.name,
+      transport: request.transport,
+      enabled: existing.enabled,
+      ...(existing.trustedAt !== undefined ? { trustedAt: existing.trustedAt } : {}),
+      ...(request.description?.trim() ? { description: request.description.trim() } : {}),
+      ...(request.command?.trim() ? { command: request.command.trim() } : {}),
+      ...(request.args && request.args.length > 0 ? { args: request.args } : {}),
+      ...(envRefs && Object.keys(envRefs).length > 0 ? { envRefs } : {}),
+      ...(legacyEnv && Object.keys(legacyEnv).length > 0 ? { env: legacyEnv } : {}),
+      ...(request.url?.trim() ? { url: request.url.trim() } : {}),
+      ...(headerRefs && Object.keys(headerRefs).length > 0 ? { headerRefs } : {}),
+      ...(legacyHeaders && Object.keys(legacyHeaders).length > 0 ? { headers: legacyHeaders } : {})
+    }
+    const server = sanitizeCustomMcpServer(merged)
+
+    if (!server) throw new Error('Invalid custom connector configuration')
+
+    const securitySensitiveConfigChanged =
+      existing.transport !== server.transport ||
+      existing.command !== server.command ||
+      !isDeepStrictEqual(existing.args ?? [], server.args ?? []) ||
+      existing.url !== server.url ||
+      request.env !== undefined ||
+      request.headers !== undefined
+
+    const securityChangeGuard = securitySensitiveConfigChanged
+      ? await beforeSecuritySensitiveUpdate?.(request.id)
+      : undefined
+
+    try {
+      await this.repository.updateCustomServer(request.id, server)
+      securityChangeGuard?.commit(server)
+    } catch (error) {
+      securityChangeGuard?.rollback()
+      throw error
+    }
+
+    return this.connectorsSnapshot()
+  }
+
+  private encryptSecretRecord(values: Record<string, string>): Record<string, string> {
+    return Object.fromEntries(
+      Object.entries(values).map(([name, value]) => [name, encryptKey(value)])
+    )
+  }
+
+  private decryptSecretRecord(
+    refs: Record<string, string> | undefined
+  ): Record<string, string> | undefined {
+    if (!refs) return undefined
+    const values = Object.entries(refs).flatMap(([name, ref]) => {
+      const value = tryDecryptKey(ref)
+      return value === undefined ? [] : [[name, value] as const]
+    })
+
+    return values.length > 0 ? Object.fromEntries(values) : undefined
+  }
+
+  private toConnectorViews(connectors: StoredConnectors | undefined): ConnectorView[] {
+    const disabled = new Set(connectors?.disabledConnectorIds ?? [])
+    const autoAllow = new Set(connectors?.autoAllowIds ?? [])
+
+    return CONNECTOR_CATALOG.map((meta) => ({
+      id: meta.id,
+      displayName: meta.displayName,
+      description: meta.description,
+      sources: meta.sources,
+      requiresNcbi: meta.requiresNcbi,
+      enabled: !disabled.has(meta.id),
+      autoAllow: autoAllow.has(meta.id),
+      group: meta.group ?? 'featured'
+    })).sort((a, b) => a.displayName.localeCompare(b.displayName))
+  }
+
+  private ncbiView(connectors: StoredConnectors | undefined): NcbiCredentialsView {
+    return { contactEmail: connectors?.contactEmail, hasApiKey: !!connectors?.ncbiApiKeyRef }
+  }
+
+  private toCustomServerViews(connectors: StoredConnectors | undefined): CustomServerView[] {
+    return (connectors?.customMcpServers ?? [])
+      .map((server) => {
+        const unavailable =
+          (server.transport === 'stdio' && !server.command) ||
+          (server.transport !== 'stdio' && !server.url)
+        return {
+          id: server.id,
+          name: server.name,
+          description: server.description,
+          transport: server.transport,
+          enabled: server.enabled,
+          command: server.command,
+          args: server.args,
+          url: server.url,
+          ...(unavailable ? { availability: 'unavailable' as const } : {})
+        }
+      })
+      .sort((a, b) => a.name.localeCompare(b.name))
+  }
+
+  private async connectorsSnapshot(): Promise<ConnectorsSnapshot> {
+    const connectors = await this.getConnectors()
+
+    return {
+      connectors: this.toConnectorViews(connectors),
+      customServers: this.toCustomServerViews(connectors),
+      ncbi: this.ncbiView(connectors)
+    }
+  }
+}
+
+export { ConnectorSettingsModule }
+export type { CustomServerSecurityChangeGuard }

--- a/src/main/settings/service.connectors.test.ts
+++ b/src/main/settings/service.connectors.test.ts
@@ -1,39 +1,28 @@
-import { describe, it, expect, beforeEach, vi } from 'vitest'
+import { beforeEach, describe, expect, it, vi } from 'vitest'
 import { mkdtemp, readFile, rm } from 'node:fs/promises'
 import { tmpdir } from 'node:os'
 import { join } from 'node:path'
 
-const keychain = vi.hoisted(() => ({ available: true }))
-
-// Reversible fake safeStorage so secrets can be encrypted without an OS keychain.
 vi.mock('electron', () => ({
   safeStorage: {
-    isEncryptionAvailable: () => keychain.available,
-    encryptString: (plaintext: string) => {
-      if (!keychain.available) throw new Error('Encryption is unavailable')
-      return Buffer.from(`cipher:${plaintext}`, 'utf8')
-    },
-    decryptString: (buffer: Buffer) => {
-      if (!keychain.available) throw new Error('Encryption is unavailable')
-      return buffer.toString('utf8').slice('cipher:'.length)
-    }
+    isEncryptionAvailable: () => true,
+    encryptString: (plaintext: string) => Buffer.from(`cipher:${plaintext}`, 'utf8'),
+    decryptString: (buffer: Buffer) => buffer.toString('utf8').slice('cipher:'.length)
   },
   app: { getPath: () => '/home', getAppPath: () => '/home/no-such-app-root', isPackaged: false }
 }))
 
 const { SettingsService } = await import('./service')
 const { SettingsRepository } = await import('./repository')
-const { ALL_CONNECTOR_IDS } = await import('../connectors/registry')
 
-// Exercises the connector surface of SettingsService against a real on-disk repository.
-describe('SettingsService connectors', () => {
+// Keeps the public SettingsService connector facade and its legacy migration trigger characterized.
+describe('SettingsService connector facade', () => {
   let dir: string
   let service: InstanceType<typeof SettingsService>
   let repository: InstanceType<typeof SettingsRepository>
 
   beforeEach(async () => {
-    keychain.available = true
-    dir = await mkdtemp(join(tmpdir(), 'osci-svc-connectors-'))
+    dir = await mkdtemp(join(tmpdir(), 'osci-svc-connectors-facade-'))
     repository = new SettingsRepository(dir)
     service = new SettingsService({ repository })
     return async () => {
@@ -41,329 +30,26 @@ describe('SettingsService connectors', () => {
     }
   })
 
-  it('lists every bundled connector, all enabled and not auto-allowed by default', async () => {
-    const snapshot = await service.listConnectors()
-
-    expect(snapshot.connectors).toHaveLength(ALL_CONNECTOR_IDS.length)
-    expect(snapshot.connectors.every((c) => c.enabled)).toBe(true)
-    expect(snapshot.connectors.every((c) => !c.autoAllow)).toBe(true)
-    expect(snapshot.customServers).toEqual([])
-    expect(snapshot.ncbi).toEqual({ contactEmail: undefined, hasApiKey: false })
-  })
-
-  it('disables and re-enables one connector', async () => {
-    let snapshot = await service.setConnectorEnabled({ id: 'chemistry', enabled: false })
-    expect(snapshot.connectors.find((c) => c.id === 'chemistry')?.enabled).toBe(false)
-    // Others stay enabled.
-    expect(snapshot.connectors.find((c) => c.id === 'pubmed')?.enabled).toBe(true)
-
-    snapshot = await service.setConnectorEnabled({ id: 'chemistry', enabled: true })
-    expect(snapshot.connectors.find((c) => c.id === 'chemistry')?.enabled).toBe(true)
-  })
-
-  it('toggles connector auto-allow (skip approvals)', async () => {
-    const snapshot = await service.setConnectorAutoAllow({ id: 'biomart', autoAllow: true })
-    expect(snapshot.connectors.find((c) => c.id === 'biomart')?.autoAllow).toBe(true)
-  })
-
-  it('returns connector detail with tools defaulting to allow', async () => {
-    const detail = await service.getConnectorDetail('chemistry')
-
-    expect(detail.id).toBe('chemistry')
-    expect(detail.tools.length).toBeGreaterThan(0)
-    expect(detail.tools.every((t) => t.permission === 'allow')).toBe(true)
-    expect(detail.tools[0].id).toBe(`chemistry/${detail.tools[0].method}`)
-  })
-
-  it('cycles a tool through block, ask, and back to allow', async () => {
-    const first = await service.getConnectorDetail('chemistry')
-    const toolId = first.tools[0].id
-
-    const blocked = await service.setToolPermission({ toolId, permission: 'block' })
-    expect(blocked.tools.find((t) => t.id === toolId)?.permission).toBe('block')
-
-    const asked = await service.setToolPermission({ toolId, permission: 'ask' })
-    expect(asked.tools.find((t) => t.id === toolId)?.permission).toBe('ask')
-
-    const allowed = await service.setToolPermission({ toolId, permission: 'allow' })
-    expect(allowed.tools.find((t) => t.id === toolId)?.permission).toBe('allow')
-  })
-
-  it('never keeps a tool in both ask and blocked sets', async () => {
-    const first = await service.getConnectorDetail('chemistry')
-    const toolId = first.tools[0].id
-
-    await service.setToolPermission({ toolId, permission: 'ask' })
-    await service.setToolPermission({ toolId, permission: 'block' })
-    const c = await service.getConnectors()
-    expect(c?.askToolIds ?? []).not.toContain(toolId)
-    expect(c?.blockedToolIds ?? []).toContain(toolId)
-  })
-
-  it('stores contact email and reports hasApiKey without exposing the key', async () => {
+  it('delegates Connector mutations and secret-free projections', async () => {
     const snapshot = await service.setNcbiCredentials({
       contactEmail: 'me@lab.org',
       apiKey: 'secret-key'
     })
 
-    expect(snapshot.ncbi.contactEmail).toBe('me@lab.org')
-    expect(snapshot.ncbi.hasApiKey).toBe(true)
-    // The raw key never appears in the renderer snapshot.
+    expect(snapshot.ncbi).toEqual({ contactEmail: 'me@lab.org', hasApiKey: true })
     expect(JSON.stringify(snapshot)).not.toContain('secret-key')
+    expect((await service.getConnectors())?.ncbiApiKeyRef).toMatch(/^enc:/)
   })
 
-  it('throws for an unknown connector id', async () => {
-    await expect(service.getConnectorDetail('nope')).rejects.toThrow(/Unknown connector/)
-  })
+  it('migrates a legacy NCBI key only through the existing whole-settings read path', async () => {
+    await repository.setNcbiCredentials('me@lab.org', 'plain:legacy-key')
 
-  it('adds, toggles, and removes a local (stdio) custom server', async () => {
-    let snapshot = await service.addCustomServer({
-      name: 'my-mem',
-      transport: 'stdio',
-      command: 'npx',
-      args: ['-y', '@modelcontextprotocol/server-memory'],
-      description: 'Memory server'
-    })
-    expect(snapshot.customServers).toHaveLength(1)
-    const added = snapshot.customServers[0]
-    expect(added).toMatchObject({
-      name: 'my-mem',
-      transport: 'stdio',
-      command: 'npx',
-      enabled: true,
-      description: 'Memory server'
-    })
-    expect(added.id).toBeTruthy()
+    await service.getConnectors()
+    expect(await readFile(join(dir, 'settings.json'), 'utf8')).toContain('plain:legacy-key')
 
-    snapshot = await service.setCustomServerEnabled({ id: added.id, enabled: false })
-    expect(snapshot.customServers[0].enabled).toBe(false)
-
-    snapshot = await service.removeCustomServer({ id: added.id })
-    expect(snapshot.customServers).toEqual([])
-  })
-
-  it('adds a remote (streamable_http) custom server with a url', async () => {
-    const snapshot = await service.addCustomServer({
-      name: 'remote-x',
-      transport: 'streamable_http',
-      url: 'https://example.com/mcp',
-      headers: { Authorization: 'Bearer t' }
-    })
-    expect(snapshot.customServers[0]).toMatchObject({
-      name: 'remote-x',
-      transport: 'streamable_http',
-      url: 'https://example.com/mcp'
-    })
-  })
-
-  it('rejects an invalid custom server (stdio without a command)', async () => {
-    await expect(service.addCustomServer({ name: 'bad', transport: 'stdio' })).rejects.toThrow(
-      /Invalid custom connector/
-    )
-  })
-
-  it('does not expose custom-server env or header secrets in the view', async () => {
-    const snapshot = await service.addCustomServer({
-      name: 'secretful',
-      transport: 'stdio',
-      command: 'run',
-      env: { TOKEN: 'super-secret' }
-    })
-    expect(JSON.stringify(snapshot)).not.toContain('super-secret')
-    const storedJson = await readFile(join(dir, 'settings.json'), 'utf8')
-    expect(storedJson).not.toContain('super-secret')
-    expect(storedJson).toContain('envRefs')
-    expect(storedJson).toContain('enc:')
-  })
-
-  it('migrates legacy plaintext custom-server secrets when secure storage is available', async () => {
-    await repository.addCustomServer({
-      id: 'legacy',
-      name: 'legacy',
-      transport: 'streamable_http',
-      enabled: true,
-      url: 'https://example.test/mcp',
-      env: { TOKEN: 'legacy-env-secret' },
-      headers: { Authorization: 'legacy-header-secret' }
-    })
-
-    const server = (await service.getConnectors())?.customMcpServers?.[0]
-    expect(server?.env).toEqual({ TOKEN: 'legacy-env-secret' })
-    expect(server?.headers).toEqual({ Authorization: 'legacy-header-secret' })
-
-    const storedJson = await readFile(join(dir, 'settings.json'), 'utf8')
-    expect(storedJson).not.toContain('legacy-env-secret')
-    expect(storedJson).not.toContain('legacy-header-secret')
-    expect(storedJson).toContain('envRefs')
-    expect(storedJson).toContain('headerRefs')
-  })
-
-  it('keeps legacy secrets readable but rejects new secret writes without secure storage', async () => {
-    await repository.addCustomServer({
-      id: 'legacy',
-      name: 'legacy',
-      transport: 'stdio',
-      enabled: true,
-      command: 'old-command',
-      env: { TOKEN: 'keep-me' }
-    })
-    keychain.available = false
-
-    expect((await service.getConnectors())?.customMcpServers?.[0]?.env).toEqual({
-      TOKEN: 'keep-me'
-    })
-    await service.updateCustomServer({
-      id: 'legacy',
-      transport: 'stdio',
-      command: 'new-command'
-    })
-    await expect(
-      service.addCustomServer({
-        name: 'new-secret',
-        transport: 'stdio',
-        command: 'run',
-        env: { TOKEN: 'must-not-persist' }
-      })
-    ).rejects.toThrow(/secure credential storage is unavailable/i)
-
-    const storedJson = await readFile(join(dir, 'settings.json'), 'utf8')
-    expect(storedJson).toContain('keep-me')
-    expect(storedJson).toContain('new-command')
-    expect(storedJson).not.toContain('must-not-persist')
-  })
-
-  it('edits a custom server, keeping its name and preserving omitted env', async () => {
-    const added = await service.addCustomServer({
-      name: 'my-mem',
-      transport: 'stdio',
-      command: 'npx',
-      args: ['-y', 'old'],
-      env: { TOKEN: 'keep-me' }
-    })
-    const id = added.customServers[0].id
-
-    // Change command/args but omit env — the stored secret env must be preserved.
-    const updated = await service.updateCustomServer({
-      id,
-      transport: 'stdio',
-      command: 'node',
-      args: ['server.js']
-    })
-    const view = updated.customServers.find((s) => s.id === id)
-    expect(view?.name).toBe('my-mem') // name is immutable
-    expect(view?.command).toBe('node')
-    expect(view?.args).toEqual(['server.js'])
-
-    const stored = (await service.getConnectors())?.customMcpServers?.find((s) => s.id === id)
-    expect(stored?.env).toEqual({ TOKEN: 'keep-me' })
-  })
-
-  it('invalidates remembered authority before persisting a security-sensitive server edit', async () => {
-    const added = await service.addCustomServer({
-      name: 'mutable-endpoint',
-      transport: 'stdio',
-      command: 'old-command',
-      args: ['serve']
-    })
-    const id = added.customServers[0].id
-    const commit = vi.fn()
-    const rollback = vi.fn()
-    const invalidate = vi.fn(async (serverId: string) => {
-      const stored = (await service.getConnectors())?.customMcpServers?.find(
-        (server) => server.id === serverId
-      )
-      expect(stored?.command).toBe('old-command')
-      return { commit, rollback }
-    })
-
-    await service.updateCustomServer(
-      {
-        id,
-        transport: 'streamable_http',
-        url: 'https://new.example/mcp',
-        headers: { Authorization: 'Bearer replacement' }
-      },
-      invalidate
-    )
-
-    expect(invalidate).toHaveBeenCalledOnce()
-    expect(invalidate).toHaveBeenCalledWith(id)
-    expect(commit).toHaveBeenCalledOnce()
-    expect(commit.mock.calls[0]?.[0]).toMatchObject({ id, url: 'https://new.example/mcp' })
-    expect(rollback).not.toHaveBeenCalled()
-    const stored = (await service.getConnectors())?.customMcpServers?.find(
-      (server) => server.id === id
-    )
-    expect(stored?.transport).toBe('streamable_http')
-    expect(stored?.url).toBe('https://new.example/mcp')
-  })
-
-  it('keeps grants for display-only edits and fails closed when invalidation fails', async () => {
-    const added = await service.addCustomServer({
-      name: 'stable-endpoint',
-      description: 'Before',
-      transport: 'stdio',
-      command: 'stable-command'
-    })
-    const id = added.customServers[0].id
-    const invalidate = vi.fn().mockResolvedValue(undefined)
-
-    await service.updateCustomServer(
-      {
-        id,
-        description: 'After',
-        transport: 'stdio',
-        command: 'stable-command'
-      },
-      invalidate
-    )
-    expect(invalidate).not.toHaveBeenCalled()
-
-    invalidate.mockRejectedValueOnce(new Error('grant cleanup failed'))
-    await expect(
-      service.updateCustomServer(
-        {
-          id,
-          description: 'After',
-          transport: 'stdio',
-          command: 'replacement-command'
-        },
-        invalidate
-      )
-    ).rejects.toThrow('grant cleanup failed')
-
-    const stored = (await service.getConnectors())?.customMcpServers?.find(
-      (server) => server.id === id
-    )
-    expect(stored?.description).toBe('After')
-    expect(stored?.command).toBe('stable-command')
-  })
-
-  it('rolls back the custom-server security barrier when persistence fails', async () => {
-    const added = await service.addCustomServer({
-      name: 'rollback-endpoint',
-      transport: 'stdio',
-      command: 'old-command'
-    })
-    const id = added.customServers[0].id
-    const commit = vi.fn()
-    const rollback = vi.fn()
-    vi.spyOn(repository, 'updateCustomServer').mockRejectedValueOnce(new Error('write failed'))
-
-    await expect(
-      service.updateCustomServer({ id, transport: 'stdio', command: 'new-command' }, async () => ({
-        commit,
-        rollback
-      }))
-    ).rejects.toThrow('write failed')
-
-    expect(commit).not.toHaveBeenCalled()
-    expect(rollback).toHaveBeenCalledOnce()
-  })
-
-  it('rejects editing an unknown custom server', async () => {
-    await expect(
-      service.updateCustomServer({ id: 'nope', transport: 'stdio', command: 'x' })
-    ).rejects.toThrow(/Unknown custom connector/)
+    await service.getSettingsView()
+    const stored = await readFile(join(dir, 'settings.json'), 'utf8')
+    expect(stored).not.toContain('plain:legacy-key')
+    expect(stored).toContain('enc:')
   })
 })

--- a/src/main/settings/service.ts
+++ b/src/main/settings/service.ts
@@ -17,8 +17,6 @@ import type {
   ClaudeInstallResult,
   ConnectorDetailView,
   ConnectorsSnapshot,
-  ConnectorView,
-  CustomServerView,
   AddCustomServerRequest,
   RemoveCustomServerRequest,
   SetCustomServerEnabledRequest,
@@ -33,7 +31,6 @@ import type {
   InstallCodexRequest,
   InstallOpencodeRequest,
   ChatApiEndpoint,
-  NcbiCredentialsView,
   Preflight,
   ProviderDraft,
   ProviderView,
@@ -49,7 +46,6 @@ import type {
   AppIconVariant,
   SkillDetailView,
   SkillView,
-  ToolPermission,
   ImportSkillRequest,
   ImportSkillResult,
   ImportSkillZipRequest,
@@ -194,12 +190,11 @@ import {
 } from './responses-bridge'
 import { NativeResponsesCompatibilityProxy } from './native-responses-compatibility'
 import { SettingsRepository } from './repository'
-import { sanitizeCustomMcpServer } from './repository'
 import { SettingsPreferencesModule, toSettingsPreferencesSnapshot } from './preferences'
 import { NotebookRuntimeSettingsModule } from './notebook-runtime-settings'
 import { SkillCatalogModule } from './skill-catalog'
+import { ConnectorSettingsModule, type CustomServerSecurityChangeGuard } from './connector-settings'
 import { CONNECTOR_CATALOG } from '../connectors/catalog'
-import { getConnectorTools } from '../connectors/registry'
 import { renderConnectorInstructions } from '../connectors/skill-doc'
 import { syncConnectorSkillDocs } from '../connectors/provision'
 import { SkillRegistry } from '../skills/registry'
@@ -219,13 +214,7 @@ import {
   BEGIN_ACTIVITY_GROUP_TOOL_NAME
 } from '../../shared/activity-groups'
 import { REVIEWER_BRIDGE_NAMESPACED_TOOLS } from '../reviewer/bridge-tools'
-import type {
-  StoredConnectors,
-  StoredCodexInfo,
-  StoredCustomMcpServer,
-  StoredProvider,
-  StoredSettings
-} from './types'
+import type { StoredConnectors, StoredCodexInfo, StoredProvider, StoredSettings } from './types'
 import { classifyStatus, validateProvider } from './validate'
 import {
   clearAppOwnedCodexAuthentication,
@@ -249,11 +238,6 @@ import {
   type ClaudeSharedAuthControllerPort,
   type ClaudeSharedAuthStatus
 } from './claude-shared-auth'
-
-type CustomServerSecurityChangeGuard = {
-  commit(server: StoredCustomMcpServer): void
-  rollback(): void
-}
 
 export type AgentBackendSelection = {
   frameworkId: AgentFrameworkId
@@ -548,6 +532,7 @@ class SettingsService {
   private readonly preferences: SettingsPreferencesModule
   private readonly notebookRuntimeSettings: NotebookRuntimeSettingsModule
   private readonly skills: SkillCatalogModule
+  private readonly connectors: ConnectorSettingsModule
   private readonly storageRoot: string
   private readonly detectDeps: ClaudeDetectDeps
   private readonly opencodeDetectDeps: OpencodeDetectDeps
@@ -589,6 +574,7 @@ class SettingsService {
     this.repository = options.repository ?? new SettingsRepository(this.storageRoot)
     this.preferences = new SettingsPreferencesModule(this.repository)
     this.notebookRuntimeSettings = new NotebookRuntimeSettingsModule(this.repository)
+    this.connectors = new ConnectorSettingsModule(this.repository)
     // Probe the app-managed install dir too, so a managed Claude is re-detected even if the cached
     // path is ever cleared (e.g. a manual re-detect).
     const baseDetectDeps = options.detectDeps ?? createDefaultDetectDeps()
@@ -859,14 +845,7 @@ class SettingsService {
       changed = true
     }
 
-    const ncbiRef = settings.connectors?.ncbiApiKeyRef
-    if (ncbiRef?.startsWith('plain:')) {
-      const key = tryDecryptKey(ncbiRef)
-      if (key) {
-        await this.repository.setNcbiCredentials(settings.connectors?.contactEmail, encryptKey(key))
-        changed = true
-      }
-    }
+    changed = (await this.connectors.migrateLegacyNcbiKeyRef(settings.connectors)) || changed
 
     return changed ? this.repository.getSettings() : settings
   }
@@ -1008,12 +987,7 @@ class SettingsService {
   // skill whitelist so the agent can discover connector tools; the per-call ConnectorService gate
   // still enforces the specialist's own connector access config.
   async provisionedConnectorSkillNames(): Promise<string[]> {
-    const connectors = await this.getConnectors()
-    const bundled = this.enabledConnectorIds(connectors)
-    const custom = (connectors?.customMcpServers ?? [])
-      .filter((server) => server.enabled)
-      .map((server) => server.id)
-    return Array.from(new Set([...bundled, ...custom].map((id) => `mcp-${id}`)))
+    return this.connectors.provisionedConnectorSkillNames()
   }
 
   // Returns the subset of forced ids that are currently disabled in settings — i.e. the picks that need
@@ -1040,7 +1014,7 @@ class SettingsService {
     codexHome: string | undefined
   ): Promise<Array<{ name: string; description: string; path: string }>> {
     return this.skills.codexSkillCatalog(codexHome, (settings) => {
-      return this.enabledConnectorIds(settings.connectors).flatMap((id) => {
+      return this.connectors.enabledConnectorIds(settings.connectors).flatMap((id) => {
         const connector = CONNECTOR_CATALOG.find((candidate) => candidate.id === id)
         return connector
           ? [
@@ -2610,50 +2584,7 @@ class SettingsService {
   // Reads the connector enablement/config block, read fresh so callers see the latest saved state.
   // Undefined when no connector has ever been configured.
   async getConnectors(): Promise<StoredConnectors | undefined> {
-    const settings = await this.repository.getSettings()
-    const connectors = settings.connectors
-    if (!connectors?.customMcpServers) return connectors
-
-    const resolvedServers: StoredCustomMcpServer[] = []
-    for (const stored of connectors.customMcpServers) {
-      let secured = stored
-      // Migrate pre-encryption settings on first read. The renderer never receives the resolved secrets.
-      if ((stored.env || stored.headers) && isEncryptionAvailable()) {
-        secured = {
-          ...stored,
-          ...(stored.env ? { envRefs: this.encryptSecretRecord(stored.env) } : {}),
-          ...(stored.headers ? { headerRefs: this.encryptSecretRecord(stored.headers) } : {}),
-          env: undefined,
-          headers: undefined
-        }
-        await this.repository.updateCustomServer(stored.id, secured)
-      }
-
-      resolvedServers.push({
-        ...secured,
-        env: secured.envRefs ? this.decryptSecretRecord(secured.envRefs) : secured.env,
-        headers: secured.headerRefs ? this.decryptSecretRecord(secured.headerRefs) : secured.headers
-      })
-    }
-
-    return { ...connectors, customMcpServers: resolvedServers }
-  }
-
-  private encryptSecretRecord(values: Record<string, string>): Record<string, string> {
-    return Object.fromEntries(
-      Object.entries(values).map(([name, value]) => [name, encryptKey(value)])
-    )
-  }
-
-  private decryptSecretRecord(
-    refs: Record<string, string> | undefined
-  ): Record<string, string> | undefined {
-    if (!refs) return undefined
-    const values = Object.entries(refs).flatMap(([name, ref]) => {
-      const value = tryDecryptKey(ref)
-      return value === undefined ? [] : [[name, value] as const]
-    })
-    return values.length > 0 ? Object.fromEntries(values) : undefined
+    return this.connectors.getConnectors()
   }
 
   // Materializes the enabled skill set into opencode's isolated config dir (same skills/<name>/SKILL.md
@@ -2671,7 +2602,10 @@ class SettingsService {
     // (Codex, opencode) read skills from their own home, so without this they never get connector
     // guidance and fall back to ad-hoc calls (e.g. curl). Materialize them into this framework's dir too.
     const connectors = await this.getConnectors()
-    await syncConnectorSkillDocs(join(configRoot, 'skills'), this.enabledConnectorIds(connectors))
+    await syncConnectorSkillDocs(
+      join(configRoot, 'skills'),
+      this.connectors.enabledConnectorIds(connectors)
+    )
   }
 
   private async provisionClaudeRuntimeConfig(
@@ -2686,186 +2620,61 @@ class SettingsService {
     await this.skills.provisionClaudeConfig(configDir, disabledSkillIds)
 
     const connectors = await this.getConnectors()
-    await syncConnectorSkillDocs(join(configDir, 'skills'), this.enabledConnectorIds(connectors))
+    await syncConnectorSkillDocs(
+      join(configDir, 'skills'),
+      this.connectors.enabledConnectorIds(connectors)
+    )
 
     return configDir
   }
 
-  // Bundled connectors the user hasn't turned off (default-on), for skill and baseline delivery.
-  private enabledConnectorIds(connectors: StoredConnectors | undefined): string[] {
-    const disabled = new Set(connectors?.disabledConnectorIds ?? [])
-
-    return CONNECTOR_CATALOG.map((meta) => meta.id).filter((id) => !disabled.has(id))
-  }
-
-  // Projects the bundled catalog into renderer views, applying the stored opt-out / auto-allow sets.
-  private toConnectorViews(connectors: StoredConnectors | undefined): ConnectorView[] {
-    const disabled = new Set(connectors?.disabledConnectorIds ?? [])
-    const autoAllow = new Set(connectors?.autoAllowIds ?? [])
-
-    return CONNECTOR_CATALOG.map((meta) => ({
-      id: meta.id,
-      displayName: meta.displayName,
-      description: meta.description,
-      sources: meta.sources,
-      requiresNcbi: meta.requiresNcbi,
-      enabled: !disabled.has(meta.id),
-      autoAllow: autoAllow.has(meta.id),
-      group: meta.group ?? 'featured'
-    })).sort((a, b) => a.displayName.localeCompare(b.displayName))
-  }
-
-  private ncbiView(connectors: StoredConnectors | undefined): NcbiCredentialsView {
-    return { contactEmail: connectors?.contactEmail, hasApiKey: !!connectors?.ncbiApiKeyRef }
-  }
-
-  // Projects stored custom MCP servers into renderer views (no secret env/header values).
-  private toCustomServerViews(connectors: StoredConnectors | undefined): CustomServerView[] {
-    return (connectors?.customMcpServers ?? [])
-      .map((s) => {
-        const unavailable =
-          (s.transport === 'stdio' && !s.command) || (s.transport !== 'stdio' && !s.url)
-        return {
-          id: s.id,
-          name: s.name,
-          description: s.description,
-          transport: s.transport,
-          enabled: s.enabled,
-          command: s.command,
-          args: s.args,
-          url: s.url,
-          ...(unavailable ? { availability: 'unavailable' as const } : {})
-        }
-      })
-      .sort((a, b) => a.name.localeCompare(b.name))
-  }
-
-  private async connectorsSnapshot(): Promise<ConnectorsSnapshot> {
-    const connectors = await this.getConnectors()
-
-    return {
-      connectors: this.toConnectorViews(connectors),
-      customServers: this.toCustomServerViews(connectors),
-      ncbi: this.ncbiView(connectors)
-    }
-  }
-
   // Lists every bundled connector with enabled / auto-allow state, plus shared NCBI credential state.
   async listConnectors(): Promise<ConnectorsSnapshot> {
-    return this.connectorsSnapshot()
+    return this.connectors.listConnectors()
   }
 
   // Returns one connector's view plus its tools (with per-tool permission) and metadata.
   async getConnectorDetail(id: string): Promise<ConnectorDetailView> {
-    const meta = CONNECTOR_CATALOG.find((entry) => entry.id === id)
-
-    if (!meta) throw new Error(`Unknown connector: ${id}`)
-
-    const connectors = await this.getConnectors()
-    const view = this.toConnectorViews(connectors).find((entry) => entry.id === id)
-    const blocked = new Set(connectors?.blockedToolIds ?? [])
-    const ask = new Set(connectors?.askToolIds ?? [])
-    const tools = getConnectorTools(id).map((tool) => {
-      const toolId = `${id}/${tool.id}`
-      // Precedence: block > ask > allow (the default; tools run without a prompt unless opted in).
-      const permission: ToolPermission = blocked.has(toolId)
-        ? 'block'
-        : ask.has(toolId)
-          ? 'ask'
-          : 'allow'
-
-      return { id: toolId, method: tool.id, description: tool.description, permission }
-    })
-
-    return { ...view!, useWhen: meta.useWhen, termsUrl: meta.termsUrl, tools }
+    return this.connectors.getConnectorDetail(id)
   }
 
   // Enables/disables one bundled connector and returns the refreshed snapshot.
   async setConnectorEnabled(request: SetConnectorEnabledRequest): Promise<ConnectorsSnapshot> {
-    await this.repository.setConnectorDisabled(request.id, !request.enabled)
-
-    return this.connectorsSnapshot()
+    return this.connectors.setConnectorEnabled(request)
   }
 
   // Toggles "skip approvals" for one connector (autoAllowIds) and returns the refreshed snapshot.
   async setConnectorAutoAllow(request: SetConnectorAutoAllowRequest): Promise<ConnectorsSnapshot> {
-    await this.repository.setConnectorAutoAllow(request.id, request.autoAllow)
-
-    return this.connectorsSnapshot()
+    return this.connectors.setConnectorAutoAllow(request)
   }
 
   // Sets one tool's policy (allow = run without a prompt [default], ask = require approval when no
   // remembered Broker grant applies, block = denied) and returns the refreshed detail.
   async setToolPermission(request: SetToolPermissionRequest): Promise<ConnectorDetailView> {
-    await this.repository.setToolPolicy(
-      request.toolId,
-      request.permission === 'ask',
-      request.permission === 'block'
-    )
-    const connectorId = request.toolId.split('/')[0]
-
-    return this.getConnectorDetail(connectorId)
+    return this.connectors.setToolPermission(request)
   }
 
   // Sets or clears the shared contact email and NCBI API key (encrypted at rest), returning state.
   async setNcbiCredentials(request: SetNcbiCredentialsRequest): Promise<ConnectorsSnapshot> {
-    const existing = await this.getConnectors()
-    // An omitted apiKey leaves the stored key unchanged; an empty string clears it.
-    const apiKeyRef =
-      request.apiKey === undefined
-        ? existing?.ncbiApiKeyRef
-        : request.apiKey === ''
-          ? undefined
-          : encryptKey(request.apiKey)
-
-    await this.repository.setNcbiCredentials(request.contactEmail?.trim() || undefined, apiKeyRef)
-
-    return this.connectorsSnapshot()
+    return this.connectors.setNcbiCredentials(request)
   }
 
   // Adds a user-provided custom MCP server (add-time trust is the caller's responsibility). The
   // config is sanitized to enforce per-transport requirements before it is persisted.
   async addCustomServer(request: AddCustomServerRequest): Promise<ConnectorsSnapshot> {
-    const candidate: StoredCustomMcpServer = {
-      id: randomUUID(),
-      name: request.name.trim(),
-      transport: request.transport,
-      enabled: true,
-      trustedAt: Date.now(),
-      ...(request.description?.trim() ? { description: request.description.trim() } : {}),
-      ...(request.command?.trim() ? { command: request.command.trim() } : {}),
-      ...(request.args && request.args.length > 0 ? { args: request.args } : {}),
-      ...(request.env && Object.keys(request.env).length > 0
-        ? { envRefs: this.encryptSecretRecord(request.env) }
-        : {}),
-      ...(request.url?.trim() ? { url: request.url.trim() } : {}),
-      ...(request.headers && Object.keys(request.headers).length > 0
-        ? { headerRefs: this.encryptSecretRecord(request.headers) }
-        : {})
-    }
-    const server = sanitizeCustomMcpServer(candidate)
-
-    if (!server) throw new Error('Invalid custom connector configuration')
-
-    await this.repository.addCustomServer(server)
-
-    return this.connectorsSnapshot()
+    return this.connectors.addCustomServer(request)
   }
 
   // Enables/disables one custom MCP server and returns the refreshed snapshot.
   async setCustomServerEnabled(
     request: SetCustomServerEnabledRequest
   ): Promise<ConnectorsSnapshot> {
-    await this.repository.setCustomServerEnabled(request.id, request.enabled)
-
-    return this.connectorsSnapshot()
+    return this.connectors.setCustomServerEnabled(request)
   }
 
   // Removes one custom MCP server and returns the refreshed snapshot.
   async removeCustomServer(request: RemoveCustomServerRequest): Promise<ConnectorsSnapshot> {
-    await this.repository.removeCustomServer(request.id)
-
-    return this.connectorsSnapshot()
+    return this.connectors.removeCustomServer(request)
   }
 
   // Edits an existing custom MCP server, keeping its immutable identity (id, name, enabled, trust).
@@ -2879,60 +2688,7 @@ class SettingsService {
       serverId: string
     ) => Promise<CustomServerSecurityChangeGuard | void>
   ): Promise<ConnectorsSnapshot> {
-    const existing = (await this.getConnectors())?.customMcpServers?.find(
-      (s) => s.id === request.id
-    )
-
-    if (!existing) throw new Error(`Unknown custom connector: ${request.id}`)
-
-    const envRefs = request.env ? this.encryptSecretRecord(request.env) : existing.envRefs
-    const headerRefs = request.headers
-      ? this.encryptSecretRecord(request.headers)
-      : existing.headerRefs
-    // Preserve legacy plaintext only when the caller leaves it untouched and safeStorage is still
-    // unavailable. A later getConnectors() call migrates it as soon as encryption becomes available.
-    const legacyEnv = request.env === undefined ? existing.env : undefined
-    const legacyHeaders = request.headers === undefined ? existing.headers : undefined
-    const merged: StoredCustomMcpServer = {
-      id: existing.id,
-      name: existing.name,
-      transport: request.transport,
-      enabled: existing.enabled,
-      ...(existing.trustedAt !== undefined ? { trustedAt: existing.trustedAt } : {}),
-      ...(request.description?.trim() ? { description: request.description.trim() } : {}),
-      ...(request.command?.trim() ? { command: request.command.trim() } : {}),
-      ...(request.args && request.args.length > 0 ? { args: request.args } : {}),
-      ...(envRefs && Object.keys(envRefs).length > 0 ? { envRefs } : {}),
-      ...(legacyEnv && Object.keys(legacyEnv).length > 0 ? { env: legacyEnv } : {}),
-      ...(request.url?.trim() ? { url: request.url.trim() } : {}),
-      ...(headerRefs && Object.keys(headerRefs).length > 0 ? { headerRefs } : {}),
-      ...(legacyHeaders && Object.keys(legacyHeaders).length > 0 ? { headers: legacyHeaders } : {})
-    }
-    const server = sanitizeCustomMcpServer(merged)
-
-    if (!server) throw new Error('Invalid custom connector configuration')
-
-    const securitySensitiveConfigChanged =
-      existing.transport !== server.transport ||
-      existing.command !== server.command ||
-      !isDeepStrictEqual(existing.args ?? [], server.args ?? []) ||
-      existing.url !== server.url ||
-      request.env !== undefined ||
-      request.headers !== undefined
-
-    const securityChangeGuard = securitySensitiveConfigChanged
-      ? await beforeSecuritySensitiveUpdate?.(request.id)
-      : undefined
-
-    try {
-      await this.repository.updateCustomServer(request.id, server)
-      securityChangeGuard?.commit(server)
-    } catch (error) {
-      securityChangeGuard?.rollback()
-      throw error
-    }
-
-    return this.connectorsSnapshot()
+    return this.connectors.updateCustomServer(request, beforeSecuritySensitiveUpdate)
   }
 
   // Reports whether npm is on PATH so the installer UI can default to/enable the npm source.
@@ -3137,8 +2893,8 @@ class SettingsService {
       throw new Error(buildActiveModelIncompatibleMessage(framework.displayName))
     }
 
-    const enabledConnectorIds = this.enabledConnectorIds(settings.connectors)
-    const connectorInstructions = renderConnectorInstructions(enabledConnectorIds)
+    const activeConnectorIds = this.connectors.enabledConnectorIds(settings.connectors)
+    const connectorInstructions = renderConnectorInstructions(activeConnectorIds)
 
     if (framework.id === 'codex' && !isModelBridgeSupported(activeProvider, effectiveModel)) {
       throw new Error(CODEX_BRIDGE_UNSUPPORTED_MESSAGE)


### PR DESCRIPTION
## Problem

`SettingsService` owns Connector persistence, secret handling, renderer projections, and custom-server mutation alongside unrelated settings domains. This obscures the durable state owner and keeps the service growing.

## Proposed change

- Add `ConnectorSettingsModule` as the owner of durable Connector policy, NCBI/custom-server secret migration and projection, and custom-server mutations.
- Keep every existing `SettingsService` Connector method as a compatibility facade.
- Move the comprehensive behavior suite to the new owner and retain focused facade/migration characterization.

```mermaid
flowchart LR
  Clients["Electron / Web / runtime / host.agents"] --> Facade["SettingsService facade"]
  Facade --> Owner["ConnectorSettingsModule"]
  Owner --> Repo["SettingsRepository"]
  Live["ConnectorService / Permission / Specialist"] --> Facade
```

## Scope and non-goals

- No settings schema, stored data relationship, IPC channel, generated Web API, UI, or user-interaction change.
- Live MCP lifecycle remains in `ConnectorService`; approvals/grants remain in Permission; Specialist and `host.agents` semantics remain unchanged; Compute is untouched.
- Electron, local/remote Web, and CLI/Task retain their current capability asymmetry. This PR does not add cross-surface features.
- Related to #458 only as a forward-compatible ownership seam. It adds no orchestration state, child permission ceiling, or public interface.

## Acceptance criteria and validation

All listed checks ran after the last material edit.

- Connector defaults, policy precedence, NCBI preserve/clear, secret-safe views, custom-server mutation and security guard transaction -> `npm test -- --run src/main/settings/connector-settings.test.ts` -> passed.
- `SettingsService` facade compatibility and legacy NCBI migration trigger timing -> `npm test -- --run src/main/settings/service.connectors.test.ts` -> passed.
- Settings/Connector/Agents/IPC/preload/Web contract compatibility -> focused 14-file regression suite -> 449 passed, 12 skipped.
- Node and Web type contracts -> `npm run typecheck` -> passed.
- Repository lint -> `npm run lint` -> passed with 0 errors (23 existing warnings outside this diff).
- Full regression suite -> `npm test` -> 630 files passed, 15 skipped; 9,352 tests passed, 184 skipped.
- Generated Web transport contract -> `npm run check:web-api-map` -> passed.
- Independent Standards review -> 0 findings.
- Independent Spec review -> 0 findings.

Uncovered risk: no manual Electron/Web UI journey was run because this change does not modify UI or transport wiring; existing skipped tests remain skipped by their own environment gates.

## Review focus

- Does the new owner stop at durable settings and avoid absorbing live Connector/Permission/Specialist state?
- Are decrypted custom-server secrets still main-process-only while renderer and `host.agents` projections remain secret-free?
- Is custom-server security invalidation still ordered guard -> durable write -> commit, with rollback on write failure?
