### PR TITLE
fix(agents): harden notebook control-plane operations

### DIFF
--- a/resources/notebook/repl_loop.js
+++ b/resources/notebook/repl_loop.js
@@ -961,16 +961,16 @@ async function computeRpc(params) {
 // (list/get/list_skills/list_connectors); mutation/switch land in later issues. Routed over the SAME
 // loopback RPC endpoint as host.mcp/host.compute but as its own `agentsCall` method — never through
 // host.mcp(). Uses the captured RPC_ENDPOINT/TOKEN + capturedFetch for the same token-isolation
-// reasons. The trusted calling session identity is the COMPUTE_SESSION_ID captured at spawn time
-// (above), forwarded on every call so switch() cannot be forged from sandbox user code.
-async function agentsRpc(op, params = {}, sessionId = COMPUTE_SESSION_ID) {
+// reasons. The trusted calling session identity is derived by the server from the session-bound
+// capability; it is never accepted from sandbox-controlled request params.
+async function agentsRpc(op, params = {}) {
   if (!RPC_ENDPOINT) throw new Error('host.agents is unavailable: connector RPC endpoint not set')
   const res = await capturedFetch(RPC_ENDPOINT, {
     method: 'POST',
     headers: { 'content-type': 'application/json', authorization: 'Bearer ' + (RPC_TOKEN || '') },
     body: JSON.stringify({
       method: 'agentsCall',
-      params: { op, ...(sessionId ? { session_id: sessionId } : {}), ...(params || {}) }
+      params: { op, ...(params || {}) }
     })
   })
   const body = await res.json().catch(() => ({}))

--- a/src/main/agents/agents-dispatch.test.ts
+++ b/src/main/agents/agents-dispatch.test.ts
@@ -569,19 +569,13 @@ describe('AgentsService.dispatch — privileged mutation routing (issue 08a comp
     expect(invalidateCatalog).not.toHaveBeenCalled()
   })
 
-  // Regression (defect #1): a name-changing patch that ALSO toggles `enabled` must land BOTH. The
-  // ordinary update path applies `enabled` via a separate ProfileService.setEnabled(...) call after
-  // the identity/capability update; the privileged path previously built specialistPatch without
-  // `enabled` and never called setEnabled, so the enabled change was silently dropped on approval.
+  // Regression (defect #1): a name-changing patch that ALSO toggles `enabled` must land BOTH in one
+  // revision-guarded ProfileService.update call. Splitting this across update + setEnabled allows a
+  // partial rename when the second write fails and bypasses optimistic concurrency for the toggle.
   it('a name-changing patch that also toggles enabled applies BOTH the rename and the enabled change', async () => {
-    // After the atomic rename (revision 3->4), setEnabled flips enabled to false and bumps again
-    // (revision 4->5). The dispatcher must return the REAL post-setEnabled read-back with the new
-    // name AND enabled === false.
-    const renamed = specialist({ name: 'Biology', revision: 4, enabled: true })
-    const afterToggle = specialist({ name: 'Biology', revision: 5, enabled: false })
+    const updated = specialist({ name: 'Biology', revision: 4, enabled: false })
     const { service, profileService } = buildService({ profiles: [specialist()] })
-    ;(profileService.update as ReturnType<typeof vi.fn>).mockResolvedValue(renamed)
-    ;(profileService.setEnabled as ReturnType<typeof vi.fn>) = vi.fn(async () => afterToggle)
+    ;(profileService.update as ReturnType<typeof vi.fn>).mockResolvedValue(updated)
 
     const result = (await service.dispatch({
       op: 'update',
@@ -592,11 +586,9 @@ describe('AgentsService.dispatch — privileged mutation routing (issue 08a comp
     // REAL post-write read-back carries BOTH the rename and the enabled toggle.
     expect(result.agent.name).toBe('Biology')
     expect(result.agent.enabled).toBe(false)
-    expect(result.agent.revision).toBe(5)
-    // setEnabled was invoked with the toggled value, after the atomic rename committed.
-    expect(profileService.setEnabled as ReturnType<typeof vi.fn>).toHaveBeenCalledWith(
-      'sp-1',
-      false
+    expect(result.agent.revision).toBe(4)
+    expect(profileService.update as ReturnType<typeof vi.fn>).toHaveBeenCalledWith(
+      expect.objectContaining({ id: 'sp-1', name: 'Biology', enabled: false, revision: 3 })
     )
   })
 

--- a/src/main/agents/agents-error.ts
+++ b/src/main/agents/agents-error.ts
@@ -1,0 +1,15 @@
+const INTERNAL_AGENTS_ERROR_MESSAGE = 'Internal operation failed.'
+
+// Marks messages that were constructed by the host.agents modules and are safe to return to the
+// control-plane REPL. Unknown dependency errors are never trusted merely because they have a message.
+export class AgentsSafeError extends Error {}
+
+export const agentsPublicError = (message: string): AgentsSafeError => new AgentsSafeError(message)
+
+export const sanitizeAgentsError = (cause: unknown): string =>
+  cause instanceof AgentsSafeError ? cause.message : INTERNAL_AGENTS_ERROR_MESSAGE
+
+export const formatAgentsError = (method: string, cause: unknown): string => {
+  const message = sanitizeAgentsError(cause)
+  return message.startsWith('host.agents.') ? message : `host.agents.${method}: ${message}`
+}

--- a/src/main/agents/agents-mutations.test.ts
+++ b/src/main/agents/agents-mutations.test.ts
@@ -505,13 +505,14 @@ describe('executeAgentsMutation — update', () => {
     expect(passed.systemPrompt).toBe('new prompt')
     expect(passed.iconKey).toBe('flask')
     expect(passed.colorKey).toBe('blue')
+    expect(passed.enabled).toBe(false)
     expect(passed.capabilityMode).toBe('selected')
     expect(passed.selectedCapabilities?.skillIds).toEqual(['sk1'])
     expect(passed.selectedCapabilities?.connectorIds).toEqual(['c1'])
-    // read-back is the real returned view, not echoed input. revision reflects both mutations
-    // (update bumps 1->2, setEnabled bumps 2->3) since enabled lives on a separate service method.
+    // The complete patch, including enabled, is one revision-guarded atomic update.
     expect(result.id).toBe('sp-1')
-    expect(result.revision).toBe(3)
+    expect(result.revision).toBe(2)
+    expect(svc.calls.map((call) => call.method)).toEqual(['update'])
   })
 
   it('update({ unrestricted: true }) switches to Full without destroying the stored Selected config', async () => {
@@ -846,7 +847,7 @@ describe('executeAgentsMutation — errors are sanitized', () => {
         { op: 'create', params: { name: 'Bio' } },
         { profileService: svc, catalog }
       )
-    ).rejects.toThrow(/host\.agents\.create:/)
+    ).rejects.toThrow('host.agents.create: Internal operation failed.')
   })
 
   it('a repo revision-conflict surfaces as a sanitized host.agents.update: error', async () => {

--- a/src/main/agents/agents-mutations.ts
+++ b/src/main/agents/agents-mutations.ts
@@ -32,10 +32,12 @@ import type {
   CreateSpecialistInput,
   SpecialistCapabilityMode,
   SpecialistFullAccessConfig,
-  SpecialistSelectedConfig
+  SpecialistSelectedConfig,
+  UpdateSpecialistInput
 } from '../../shared/specialist'
 import { emptyFullAccessConfig, emptySelectedConfig } from '../../shared/specialist'
 import type { ApprovalGateway } from '../../shared/agents-contract'
+import { AgentsSafeError, agentsPublicError, formatAgentsError } from './agents-error'
 
 // The catalog resolution seam this module consumes. It receives the ALREADY-PROJECTED public read
 // models (the same models the read slice returns from list_skills/list_connectors), so this module
@@ -67,17 +69,9 @@ export type AgentsOrdinaryMutationRequest =
   | { op: 'attach_connector'; params: Record<string, unknown> }
   | { op: 'detach_connector'; params: Record<string, unknown> }
 
-const METHOD_PREFIX = 'host.agents'
-
-// Sanitizes an arbitrary error into its top-level message only. System instructions, connector args,
-// credentials, headers, environment values, internal stack detail, and tokens must never reach the
-// sandbox. We keep only the message string (no nested secret-bearing JSON).
-const sanitizeError = (value: unknown): string =>
-  value instanceof Error ? value.message : String(value)
-
-class AgentsMutationError extends Error {
+class AgentsMutationError extends AgentsSafeError {
   constructor(method: string, cause: unknown) {
-    super(`${METHOD_PREFIX}.${method}: ${sanitizeError(cause)}`)
+    super(formatAgentsError(method, cause))
     this.name = 'AgentsMutationError'
   }
 }
@@ -100,7 +94,7 @@ const isFinitePositiveInt = (value: unknown): value is number =>
 
 const optionalStringOrThrow = (value: unknown, label: string): string | undefined => {
   if (value === undefined) return undefined
-  if (!isString(value)) throw new Error(`${label} must be a string.`)
+  if (!isString(value)) throw agentsPublicError(`${label} must be a string.`)
   return value
 }
 
@@ -111,7 +105,7 @@ const optionalStringOrThrow = (value: unknown, label: string): string | undefine
 export const asStringArray = (value: unknown): string[] | undefined => {
   if (value === undefined) return undefined
   if (!Array.isArray(value) || !value.every((item) => isString(item) && item.length > 0)) {
-    throw new Error('Must be an array of non-empty strings.')
+    throw agentsPublicError('Must be an array of non-empty strings.')
   }
   return value as string[]
 }
@@ -133,7 +127,7 @@ export const resolveSkillRefs = async (
   for (const ref of refs) {
     const matched = applyNameOrIdFilter(entries, ref, method)
     if (matched.length === 0) {
-      throw new Error(`No skill matches "${ref}".`)
+      throw agentsPublicError(`No skill matches "${ref}".`)
     }
     ids.push(matched[0].id)
   }
@@ -157,11 +151,13 @@ export const resolveConnectorRefs = async (
   for (const ref of refs) {
     const matched = applyNameOrIdFilter(entries, ref, method)
     if (matched.length === 0) {
-      throw new Error(`No connector matches "${ref}".`)
+      throw agentsPublicError(`No connector matches "${ref}".`)
     }
     const model = matched[0]
     if (options.gateUnavailable && model.availability !== 'available') {
-      throw new Error(`Connector "${ref}" is ${model.availability} and cannot be newly attached.`)
+      throw agentsPublicError(
+        `Connector "${ref}" is ${model.availability} and cannot be newly attached.`
+      )
     }
     ids.push(model.id)
     models.push(model)
@@ -202,7 +198,7 @@ export const projectCapabilityFields = async (
   method: string
 ): Promise<CapabilityProjection> => {
   if (patch.unrestricted !== undefined && !isBoolean(patch.unrestricted)) {
-    throw new Error('unrestricted must be a boolean.')
+    throw agentsPublicError('unrestricted must be a boolean.')
   }
   const skillRefs = asStringArray(patch.skill_names)
   const connectorRefs = asStringArray(patch.connector_names)
@@ -256,7 +252,7 @@ const handleCreate = async (
   rejectUnknownKeys(params, CREATE_ALLOWED_KEYS, 'create')
 
   const name = isString(params.name) ? params.name : throwShape('name is required')
-  if (!name.trim()) throw new Error('name is required')
+  if (!name.trim()) throw agentsPublicError('name is required')
 
   const description = optionalStringOrThrow(params.description, 'description')
   const systemPrompt = optionalStringOrThrow(params.system_prompt, 'system prompt')
@@ -267,11 +263,11 @@ const handleCreate = async (
   // new specialist enabled; the update op toggles it. We validate the shape and ignore the value so
   // a malformed boolean is rejected before reaching the repository.
   if (params.enabled !== undefined && !isBoolean(params.enabled)) {
-    throw new Error('enabled must be a boolean.')
+    throw agentsPublicError('enabled must be a boolean.')
   }
 
   if (params.unrestricted !== undefined && !isBoolean(params.unrestricted)) {
-    throw new Error('unrestricted must be a boolean.')
+    throw agentsPublicError('unrestricted must be a boolean.')
   }
   // `unrestricted` is validated for shape but does not change create semantics here: the presence of
   // a capability array always produces Selected, and the absence of both always produces Full (AC).
@@ -348,7 +344,7 @@ const handleUpdate = async (
   // (params.name) on the wire — design.md §4 / customize-skill.md: `update(name, patch)` where the
   // patch may carry a new `name`. params.name resolves the target; every field in `patch` is a change.
   const patch = params.patch
-  if (!isRecord(patch)) throw new Error('patch is required and must be an object.')
+  if (!isRecord(patch)) throw agentsPublicError('patch is required and must be an object.')
   rejectUnknownKeys(patch, UPDATE_ALLOWED_KEYS, 'update')
 
   // A name change is a PRIVILEGED operation (issue 04): the whole patch is shown in one approval
@@ -356,30 +352,20 @@ const handleUpdate = async (
   // it can never silently succeed without approval. The dispatcher (issue 08) routes name-changing
   // updates to the privileged module before this ordinary path runs.
   if (isString(patch.name) && patch.name.trim().length > 0) {
-    throw new Error('Changing the specialist name requires approval.')
+    throw agentsPublicError('Changing the specialist name requires approval.')
   }
 
   const revision = patch.revision
   if (!isFinitePositiveInt(revision)) {
-    throw new Error('revision must be a positive integer.')
+    throw agentsPublicError('revision must be a positive integer.')
   }
 
   const current = await deps.profileService.getByName(name)
   if (current.revision !== revision) {
-    throw new Error('revision does not match the current specialist revision.')
+    throw agentsPublicError('revision does not match the current specialist revision.')
   }
 
-  const input: {
-    id: string
-    revision: number
-    description?: string
-    systemPrompt?: string
-    iconKey?: string
-    colorKey?: string
-    capabilityMode?: SpecialistCapabilityMode
-    fullAccess?: SpecialistFullAccessConfig
-    selectedCapabilities?: SpecialistSelectedConfig
-  } = { id: current.id, revision }
+  const input: UpdateSpecialistInput = { id: current.id, revision }
 
   const description = optionalStringOrThrow(patch.description, 'description')
   if (description !== undefined) input.description = description
@@ -391,8 +377,9 @@ const handleUpdate = async (
   if (colorKey !== undefined) input.colorKey = colorKey
 
   if (patch.enabled !== undefined && !isBoolean(patch.enabled)) {
-    throw new Error('enabled must be a boolean.')
+    throw agentsPublicError('enabled must be a boolean.')
   }
+  if (patch.enabled !== undefined) input.enabled = patch.enabled
 
   // Capability projection is shared with the privileged name-changing update path so the two NEVER
   // diverge on the Selected/Full + collection-replacement semantics.
@@ -407,15 +394,8 @@ const handleUpdate = async (
     input.fullAccess = capability.fullAccess
   }
 
-  // enabled lives on a separate ProfileService method (update() does not carry it). When the
-  // requested state differs from the current, we toggle AFTER the identity/capability update so the
-  // optimistic-concurrency check (revision) gates the whole mutation first, then setEnabled flips the
-  // enabled flag. setEnabled is not revision-guarded, so ordering update-first is safe.
-  let readBack = await deps.profileService.update(input)
-  if (patch.enabled !== undefined && patch.enabled !== readBack.enabled) {
-    readBack = await deps.profileService.setEnabled(current.id, patch.enabled)
-  }
-  return readBack
+  // One revision-guarded service update commits the complete patch atomically, including enabled.
+  return deps.profileService.update(input)
 }
 
 // ---------------------------------------------------------------------------
@@ -436,7 +416,7 @@ const handleAttachDetach = async (
   const name = isString(params.name) ? params.name : throwShape('name is required')
   const revision = params.revision
   if (!isFinitePositiveInt(revision)) {
-    throw new Error('revision must be a positive integer.')
+    throw agentsPublicError('revision must be a positive integer.')
   }
 
   const refKey = op.endsWith('skill') ? 'skill_ref' : 'connector_ref'
@@ -446,7 +426,7 @@ const handleAttachDetach = async (
 
   const current = await deps.profileService.getByName(name)
   if (current.revision !== revision) {
-    throw new Error('revision does not match the current specialist revision.')
+    throw agentsPublicError('revision does not match the current specialist revision.')
   }
   const mode: SpecialistCapabilityMode = current.capabilityMode
 
@@ -509,14 +489,14 @@ export function rejectUnknownKeys(
 ): void {
   for (const key of Object.keys(params)) {
     if (!allowed.has(key)) {
-      throw new Error(`Unknown field "${key}".`)
+      throw agentsPublicError(`Unknown field "${key}".`)
     }
   }
   void method
 }
 
 function throwShape(message: string): never {
-  throw new Error(message)
+  throw agentsPublicError(message)
 }
 
 // ---------------------------------------------------------------------------
@@ -545,7 +525,7 @@ export async function executeAgentsMutation(
         return await handleAttachDetach(method, params, deps)
       default:
         // Exhaustiveness guard: the switch covers every ordinary-mutation op.
-        throw new Error(`Operation "${String(method)}" is not an ordinary mutation.`)
+        throw agentsPublicError(`Operation "${String(method)}" is not an ordinary mutation.`)
     }
   } catch (error) {
     throw new AgentsMutationError(method, error)

--- a/src/main/agents/agents-repl.integration.test.ts
+++ b/src/main/agents/agents-repl.integration.test.ts
@@ -106,6 +106,7 @@ gate('host.agents repl integration', () => {
   let rpcServer: NotebookLocalRpcServer
   let endpoint: string
   let token: string
+  let releaseConnection: (() => void) | undefined
   let profileStorage: string
   let runtimeStorage: string
   let agentsService: AgentsService
@@ -144,15 +145,17 @@ gate('host.agents repl integration', () => {
         }
       }
     })
-    const connection = await rpcServer.ensureStarted()
+    const connection = await rpcServer.issueControlConnection('session-control', 'default-project')
     endpoint = connection.endpoint
     token = connection.token
+    releaseConnection = connection.release
 
     // Seed a specialist profile directly through the authoritative ProfileService.
     await profileService.create({ name: 'Bio Expert', description: 'secret: apikey=XYZ' })
   })
 
   afterAll(async () => {
+    releaseConnection?.()
     await rpcServer?.close()
     await rm(profileStorage, { recursive: true, force: true })
     await rm(runtimeStorage, { recursive: true, force: true })
@@ -292,7 +295,7 @@ gate('host.agents repl integration', () => {
     }
   }, 60_000)
 
-  it('trusted session capture: the server receives the captured calling session identity', async () => {
+  it('the server derives calling-session identity from the control capability', async () => {
     capturedSessionId = undefined
     const { child, send } = startLoop({
       OPEN_SCIENCE_MCP_RPC_ENDPOINT: endpoint,
@@ -302,7 +305,7 @@ gate('host.agents repl integration', () => {
     try {
       const r = await send('return JSON.stringify(await host.agents.list())')
       expect(r.error).toBeNull()
-      expect(capturedSessionId).toBe('session-trusted')
+      expect(capturedSessionId).toBe('session-control')
     } finally {
       child.kill()
     }
@@ -321,10 +324,10 @@ gate('host.agents repl integration', () => {
         "await fetch(process.env.__rpc ?? '', { method: 'POST', headers: { 'content-type': 'application/json', authorization: 'Bearer ' + 'forged' }, body: JSON.stringify({ method: 'agentsCall', params: { op: 'list', session_id: 'forged-session' } }) }).then(r => r.status).catch(() => 'err'); return 'done'"
       )
       void r
-      // Even via a legitimate call, the trusted identity is the captured one.
+      // Even via a legitimate call, the trusted identity is the capability-bound one.
       const r2 = await send('return JSON.stringify(await host.agents.list())')
       expect(r2.error).toBeNull()
-      expect(capturedSessionId).toBe('session-real')
+      expect(capturedSessionId).toBe('session-control')
     } finally {
       child.kill()
     }

--- a/src/main/agents/agents-repl.mutations.integration.test.ts
+++ b/src/main/agents/agents-repl.mutations.integration.test.ts
@@ -93,6 +93,7 @@ gate('host.agents repl mutation integration', () => {
   let rpcServer: NotebookLocalRpcServer
   let endpoint: string
   let token: string
+  let releaseConnection: (() => void) | undefined
   let profileStorage: string
   let runtimeStorage: string
 
@@ -123,12 +124,17 @@ gate('host.agents repl mutation integration', () => {
       token: 'integration-token',
       agentsService
     })
-    const connection = await rpcServer.ensureStarted()
+    const connection = await rpcServer.issueControlConnection(
+      'session-mutations',
+      'default-project'
+    )
     endpoint = connection.endpoint
     token = connection.token
+    releaseConnection = connection.release
   })
 
   afterAll(async () => {
+    releaseConnection?.()
     await rpcServer?.close()
     await rm(profileStorage, { recursive: true, force: true })
     await rm(runtimeStorage, { recursive: true, force: true })

--- a/src/main/agents/agents-repl.privileged.integration.test.ts
+++ b/src/main/agents/agents-repl.privileged.integration.test.ts
@@ -159,9 +159,8 @@ const composeService = (opts: {
   }
 }
 
-// One-line JS body that calls `agentsCall` over the same transport the SDK uses. The trusted calling
-// session (`sessionId`) is forwarded in `params.session_id`, exactly as the loop does for every
-// host.agents call (it is captured from the spawn env and forwarded on the wire).
+// One-line JS body that calls `agentsCall` over the same transport the SDK uses. `sessionId` is an
+// intentionally untrusted legacy field: the server must ignore it and use the capability binding.
 const agentsCallFetch = (
   endpoint: string,
   token: string,
@@ -177,8 +176,6 @@ const agentsCallFetch = (
 
 gate('host.agents repl privileged integration', () => {
   let rpcServer: NotebookLocalRpcServer
-  let endpoint: string
-  let token: string
   let profileStorage: string
   let runtimeStorage: string
   let agentsService: AgentsService
@@ -219,9 +216,7 @@ gate('host.agents repl privileged integration', () => {
       token: 'integration-token',
       agentsService
     })
-    const connection = await rpcServer.ensureStarted()
-    endpoint = connection.endpoint
-    token = connection.token
+    await rpcServer.ensureStarted()
   })
 
   afterAll(async () => {
@@ -234,17 +229,25 @@ gate('host.agents repl privileged integration', () => {
   // trusted-session identity and in-memory binding state never bleed across assertions.
   const withLoop = async <T>(
     sessionId: string | undefined,
-    run: (send: (code: string) => Promise<KernelLoopResponse>) => Promise<T>
+    run: (
+      send: (code: string) => Promise<KernelLoopResponse>,
+      connection: { endpoint: string; token: string }
+    ) => Promise<T>
   ): Promise<T> => {
+    const connection = await rpcServer.issueControlConnection(
+      sessionId ?? 'session-control',
+      'default-project'
+    )
     const { child, send } = startLoop({
-      OPEN_SCIENCE_MCP_RPC_ENDPOINT: endpoint,
-      OPEN_SCIENCE_MCP_RPC_TOKEN: token,
+      OPEN_SCIENCE_MCP_RPC_ENDPOINT: connection.endpoint,
+      OPEN_SCIENCE_MCP_RPC_TOKEN: connection.token,
       ...(sessionId ? { OPEN_SCIENCE_NOTEBOOK_SESSION_ID: sessionId } : {})
     })
     try {
-      return await run(send)
+      return await run(send, connection)
     } finally {
       child.kill()
+      connection.release()
     }
   }
 
@@ -356,7 +359,7 @@ gate('host.agents repl privileged integration', () => {
   // the structured-decline wire envelope / no-retry dispatch over a custom decline gateway.
 
   it('switch cannot forge a different calling session: reserved identity keys are dropped, only the trusted session is bound', async () => {
-    await withLoop('session-real', async (send) => {
+    await withLoop('session-real', async (send, connection) => {
       const created = JSON.parse(
         (await send("return JSON.stringify(await host.agents.create({ name: 'GUARD_TARGET' }))"))
           .result ?? '{}'
@@ -365,7 +368,7 @@ gate('host.agents repl privileged integration', () => {
       // reconfigure flag) alongside the trusted session. The dispatcher strips every reserved key;
       // the switch binds ONLY the trusted calling session.
       const r = await send(
-        agentsCallFetch(endpoint, token, 'session-real', {
+        agentsCallFetch(connection.endpoint, connection.token, 'forged-session', {
           op: 'switch',
           name: 'GUARD_TARGET',
           sessionId: 'forged-camel',
@@ -483,7 +486,7 @@ gate('host.agents repl privileged integration', () => {
       }),
       { token: 'decline-token', agentsService: composed.agentsService }
     )
-    const conn = await declineRpc.ensureStarted()
+    const conn = await declineRpc.issueControlConnection('session-decline', 'decline-project')
     try {
       const { child, send } = startLoop({
         OPEN_SCIENCE_MCP_RPC_ENDPOINT: conn.endpoint,
@@ -509,6 +512,7 @@ gate('host.agents repl privileged integration', () => {
         child.kill()
       }
     } finally {
+      conn.release()
       await declineRpc.close()
     }
   })
@@ -543,7 +547,10 @@ gate('host.agents repl privileged integration', () => {
       }),
       { token: 'decline-del-token', agentsService: composed.agentsService }
     )
-    const conn = await declineRpc.ensureStarted()
+    const conn = await declineRpc.issueControlConnection(
+      'session-decline-del',
+      'decline-del-project'
+    )
     try {
       const { child, send } = startLoop({
         OPEN_SCIENCE_MCP_RPC_ENDPOINT: conn.endpoint,
@@ -579,6 +586,7 @@ gate('host.agents repl privileged integration', () => {
         child.kill()
       }
     } finally {
+      conn.release()
       await declineRpc.close()
     }
   })
@@ -633,7 +641,10 @@ gate('host.agents repl privileged integration', () => {
       }),
       { token: 'decline-upd-token', agentsService: composed.agentsService }
     )
-    const conn = await declineRpc.ensureStarted()
+    const conn = await declineRpc.issueControlConnection(
+      'session-decline-upd',
+      'decline-upd-project'
+    )
     try {
       const { child, send } = startLoop({
         OPEN_SCIENCE_MCP_RPC_ENDPOINT: conn.endpoint,
@@ -665,6 +676,7 @@ gate('host.agents repl privileged integration', () => {
         child.kill()
       }
     } finally {
+      conn.release()
       await declineRpc.close()
     }
   })
@@ -698,7 +710,7 @@ gate('host.agents repl privileged integration', () => {
       }),
       { token: 'no-retry-token', agentsService: composed.agentsService }
     )
-    const conn = await declineRpc.ensureStarted()
+    const conn = await declineRpc.issueControlConnection('session-no-retry', 'no-retry-project')
     try {
       const { child, send } = startLoop({
         OPEN_SCIENCE_MCP_RPC_ENDPOINT: conn.endpoint,
@@ -719,6 +731,7 @@ gate('host.agents repl privileged integration', () => {
         child.kill()
       }
     } finally {
+      conn.release()
       await declineRpc.close()
     }
   })

--- a/src/main/agents/agents-repl.runtime-consumption.integration.test.ts
+++ b/src/main/agents/agents-repl.runtime-consumption.integration.test.ts
@@ -113,6 +113,7 @@ gate('host.agents repl runtime whitelist consumption', () => {
   let rpcServer: NotebookLocalRpcServer
   let endpoint: string
   let token: string
+  let releaseConnection: (() => void) | undefined
   let profileStorage: string
   let runtimeStorage: string
 
@@ -143,12 +144,14 @@ gate('host.agents repl runtime whitelist consumption', () => {
       token: 'integration-token',
       agentsService
     })
-    const connection = await rpcServer.ensureStarted()
+    const connection = await rpcServer.issueControlConnection('session-runtime', 'default-project')
     endpoint = connection.endpoint
     token = connection.token
+    releaseConnection = connection.release
   })
 
   afterAll(async () => {
+    releaseConnection?.()
     await rpcServer?.close()
     await rm(profileStorage, { recursive: true, force: true })
     await rm(runtimeStorage, { recursive: true, force: true })

--- a/src/main/agents/agents-service.test.ts
+++ b/src/main/agents/agents-service.test.ts
@@ -179,6 +179,8 @@ describe('AgentsService read surface', () => {
       profileService: failing as unknown as ProfileService,
       catalog: catalog()
     })
-    await expect(service.read({ op: 'list' })).rejects.toThrow(/host\.agents\.list:/)
+    await expect(service.read({ op: 'list' })).rejects.toThrow(
+      'host.agents.list: Internal operation failed.'
+    )
   })
 })

--- a/src/main/agents/agents-service.ts
+++ b/src/main/agents/agents-service.ts
@@ -40,6 +40,7 @@ import {
   isNameChangingPatch
 } from './specialist-privileged-ops'
 import type { SpecialistUpdatePatch } from './specialist-approval-presentation'
+import { AgentsSafeError, agentsPublicError, formatAgentsError } from './agents-error'
 
 // The minimal read surface this adapter needs from the settings/connectors catalog. Keeping it
 // narrow avoids pulling the whole SettingsService into the SDK contract and lets tests stub it.
@@ -139,19 +140,9 @@ export type AgentsReadOp =
   | { op: 'list_skills'; params: { name_or_id?: unknown } }
   | { op: 'list_connectors'; params: { name_or_id?: unknown } }
 
-const METHOD_PREFIX = 'host.agents'
-
-// Sanitizes an arbitrary error into a stable message. Connector args, credentials, headers,
-// environment values, and internal stack detail must never reach the sandbox. We keep only the
-// top-level message and strip anything that looks like a secret-bearing JSON blob.
-const sanitizeError = (value: unknown): string => {
-  const raw = value instanceof Error ? value.message : String(value)
-  return raw
-}
-
-class AgentsCallError extends Error {
+class AgentsCallError extends AgentsSafeError {
   constructor(method: string, cause: unknown) {
-    super(`${METHOD_PREFIX}.${method}: ${sanitizeError(cause)}`)
+    super(formatAgentsError(method, cause))
     this.name = 'AgentsCallError'
   }
 }
@@ -251,7 +242,7 @@ export class AgentsService {
       if (opName === 'delete') return await this.runDelete(params)
       // The dispatcher covers every operation the contract names. An unrecognized op was already
       // rejected as unknown above, so this branch is unreachable for a validated op name.
-      throw new Error(`Operation "${opName}" is not implemented yet`)
+      throw agentsPublicError(`Operation "${opName}" is not implemented yet`)
     } catch (error) {
       throw new AgentsCallError(opName, error)
     }
@@ -286,7 +277,7 @@ export class AgentsService {
   ): Promise<unknown> {
     const { approvalGateway, switchNotifier, sessionBinding, persistSessionSpecialist } = this.deps
     if (!approvalGateway || !switchNotifier || !sessionBinding || !persistSessionSpecialist) {
-      throw new Error(
+      throw agentsPublicError(
         'Operation "switch" is not configured (approval/binding/persistence seams missing)'
       )
     }
@@ -352,11 +343,11 @@ export class AgentsService {
 
     // `enabled` is accepted on the name-changing patch too (defect #1): validate it is a boolean
     // here (matching the ordinary path's `enabled must be a boolean.` error) and carry it onto the
-    // specialistPatch so applyNameChangingUpdate can apply it via setEnabled after the atomic rename.
-    // There is no snake_case variant — the contract uses `enabled` on both create and update.
+    // complete atomic ProfileService.update patch. There is no snake_case variant — the contract
+    // uses `enabled` on both create and update.
     if (patchRecord.enabled !== undefined) {
       if (typeof patchRecord.enabled !== 'boolean') {
-        throw new Error('enabled must be a boolean.')
+        throw agentsPublicError('enabled must be a boolean.')
       }
       specialistPatch.enabled = patchRecord.enabled
     }
@@ -366,7 +357,7 @@ export class AgentsService {
     }
 
     const currentName = typeof params.name === 'string' ? params.name : undefined
-    if (!currentName) throw new Error('name is required')
+    if (!currentName) throw agentsPublicError('name is required')
     const revision = patchRecord.revision
     if (
       typeof revision !== 'number' ||
@@ -374,7 +365,7 @@ export class AgentsService {
       !Number.isInteger(revision) ||
       revision <= 0
     ) {
-      throw new Error('revision must be a positive integer.')
+      throw agentsPublicError('revision must be a positive integer.')
     }
 
     // Project capability fields (skill_names/connector_names/unrestricted) so a rename coinciding
@@ -402,7 +393,7 @@ export class AgentsService {
 
     const { approvalGateway, invalidateCatalog } = this.deps
     if (!approvalGateway) {
-      throw new Error('Operation "update" is not configured (approval gateway missing)')
+      throw agentsPublicError('Operation "update" is not configured (approval gateway missing)')
     }
     const result = await applyNameChangingUpdate({
       profileService: this.deps.profileService,
@@ -424,10 +415,10 @@ export class AgentsService {
   private async runDelete(params: Record<string, unknown>): Promise<unknown> {
     const { approvalGateway, invalidateCatalog } = this.deps
     if (!approvalGateway) {
-      throw new Error('Operation "delete" is not configured (approval gateway missing)')
+      throw agentsPublicError('Operation "delete" is not configured (approval gateway missing)')
     }
     const currentName = typeof params.name === 'string' ? params.name : undefined
-    if (!currentName) throw new Error('name is required')
+    if (!currentName) throw agentsPublicError('name is required')
     const revision = params.revision
     if (
       typeof revision !== 'number' ||
@@ -435,7 +426,7 @@ export class AgentsService {
       !Number.isInteger(revision) ||
       revision <= 0
     ) {
-      throw new Error('revision must be a positive integer.')
+      throw agentsPublicError('revision must be a positive integer.')
     }
     return applyDelete({
       profileService: this.deps.profileService,
@@ -456,7 +447,7 @@ export class AgentsService {
   // read model including stable id and revision.
   async get(params: { name?: unknown }): Promise<AgentReadModel> {
     const name = asString(params.name)
-    if (!name) throw new Error('name is required')
+    if (!name) throw agentsPublicError('name is required')
     const profile = await this.deps.profileService.getByName(name)
     return projectAgent(profile)
   }
@@ -562,14 +553,14 @@ export function applyNameOrIdFilter<T extends Nameable>(
   // 2. Otherwise match a unique public name (name, then display name).
   const byName = entries.filter((entry) => entry.name === ref || entry.displayName === ref)
   if (byName.length === 0) {
-    throw new Error(
+    throw agentsPublicError(
       `No catalog entry matches "${ref}". Use the stable id from list_skills/list_connectors.`
     )
   }
   if (byName.length > 1) {
     // Ambiguous public name: instruct the caller to use the stable id instead of guessing.
     const ids = byName.map((entry) => entry.id).join(', ')
-    throw new Error(
+    throw agentsPublicError(
       `Multiple catalog entries match name "${ref}" (${ids}). Use the stable id from ${method} instead.`
     )
   }

--- a/src/main/agents/specialist-privileged-ops.test.ts
+++ b/src/main/agents/specialist-privileged-ops.test.ts
@@ -127,7 +127,8 @@ describe('applyNameChangingUpdate — approved atomic update', () => {
     const patch: SpecialistUpdatePatch = {
       name: 'DATA_SCIENTIST',
       description: 'updated desc',
-      systemPrompt: 'new instructions'
+      systemPrompt: 'new instructions',
+      enabled: false
     }
     const result = await applyNameChangingUpdate({
       profileService: service,
@@ -139,7 +140,12 @@ describe('applyNameChangingUpdate — approved atomic update', () => {
     // Returned actual camelCase read-back, not the input patch.
     expect(result).toEqual<AgentUpdatedResult>({
       status: 'updated',
-      agent: expect.objectContaining({ id: 'sp-1', name: 'DATA_SCIENTIST', revision: 4 })
+      agent: expect.objectContaining({
+        id: 'sp-1',
+        name: 'DATA_SCIENTIST',
+        enabled: false,
+        revision: 4
+      })
     })
     // Re-resolved by public name immediately before mutation.
     expect(calls.getByName).toContain('DATA_ANALYST')
@@ -152,7 +158,8 @@ describe('applyNameChangingUpdate — approved atomic update', () => {
         id: 'sp-1',
         revision: 3,
         name: 'DATA_SCIENTIST',
-        description: 'updated desc'
+        description: 'updated desc',
+        enabled: false
       })
     })
   })
@@ -284,7 +291,7 @@ describe('applyDelete — approved delete', () => {
         currentName: 'DATA_ANALYST',
         reviewedRevision: 3
       })
-    ).rejects.toThrow(/host\.agents\.delete:.*I\/O error/)
+    ).rejects.toThrow('host.agents.delete: Internal operation failed.')
   })
 
   it('fails closed with a sanitized error when revision drifted before approval', async () => {

--- a/src/main/agents/specialist-privileged-ops.ts
+++ b/src/main/agents/specialist-privileged-ops.ts
@@ -25,17 +25,11 @@ import type { ApprovalGateway, ApprovalResult } from '../../shared/agents-contra
 import type { SpecialistProfileView, UpdateSpecialistInput } from '../../shared/specialist'
 import type { ProfileService } from '../specialist/service'
 import type { SpecialistUpdatePatch } from './specialist-approval-presentation'
+import { AgentsSafeError, agentsPublicError, formatAgentsError } from './agents-error'
 
-const METHOD_PREFIX = 'host.agents'
-
-// Sanitizes an error into a stable, method-scoped message. System instructions, connector args,
-// credentials, and stack detail must never reach the sandbox. We keep only the top-level message.
-const sanitizeError = (value: unknown): string =>
-  value instanceof Error ? value.message : String(value)
-
-class PrivilegedOpError extends Error {
+class PrivilegedOpError extends AgentsSafeError {
   constructor(method: string, cause: unknown) {
-    super(`${METHOD_PREFIX}.${method}: ${sanitizeError(cause)}`)
+    super(formatAgentsError(method, cause))
     this.name = 'PrivilegedOpError'
   }
 }
@@ -96,7 +90,9 @@ const reResolveForMutation = async (
   if (current.revision !== reviewedRevision) {
     throw new PrivilegedOpError(
       method,
-      `reviewed revision ${reviewedRevision} no longer matches current revision ${current.revision}`
+      agentsPublicError(
+        `reviewed revision ${reviewedRevision} no longer matches current revision ${current.revision}`
+      )
     )
   }
   return current
@@ -142,6 +138,7 @@ const toServiceUpdate = (
   systemPrompt: patch.systemPrompt,
   iconKey: patch.iconKey,
   colorKey: patch.colorKey,
+  enabled: patch.enabled,
   capabilityMode: patch.capabilityMode,
   fullAccess: patch.fullAccess,
   selectedCapabilities: patch.selectedCapabilities
@@ -179,19 +176,6 @@ export const applyNameChangingUpdate = async (
     updated = await profileService.update(toServiceUpdate(current.id, current.revision, patch))
   } catch (error) {
     throw new PrivilegedOpError('update', error)
-  }
-
-  // `enabled` lives on a separate ProfileService method (update() does not carry it), mirroring the
-  // ordinary update path. After the atomic name-changing commit succeeds we have the real read-back;
-  // when the requested enabled state differs from the read-back, flip it via setEnabled and re-read.
-  // setEnabled is not revision-guarded (same as the ordinary path), so ordering update-first is safe
-  // and the stale-revision guard on the atomic rename still gates the whole mutation (defect #1).
-  if (patch.enabled !== undefined && patch.enabled !== updated.enabled) {
-    try {
-      updated = await profileService.setEnabled(current.id, patch.enabled)
-    } catch (error) {
-      throw new PrivilegedOpError('update', error)
-    }
   }
 
   if (deps.invalidateCatalog) await deps.invalidateCatalog()
@@ -263,7 +247,10 @@ export const applyDelete = async (deps: ApplyDeleteDeps): Promise<DeleteResult> 
     // Expected: getByName threw "not found" — absence verified.
   }
   if (stillPresent) {
-    throw new PrivilegedOpError('delete', `specialist "${currentName}" still present after delete`)
+    throw new PrivilegedOpError(
+      'delete',
+      agentsPublicError(`specialist "${currentName}" still present after delete`)
+    )
   }
 
   if (deps.invalidateCatalog) await deps.invalidateCatalog()

--- a/src/main/agents/switch-operation.test.ts
+++ b/src/main/agents/switch-operation.test.ts
@@ -357,7 +357,7 @@ describe('SwitchOperation — approval-time re-validation (fail closed)', () => 
     })
 
     await expect(op.run({ name: 'BIO_EXPERT' }, { sessionId: 'session-trusted' })).rejects.toThrow(
-      /host\.agents\.switch:/
+      'host.agents.switch: Internal operation failed.'
     )
   })
 
@@ -521,6 +521,55 @@ describe('SwitchOperation — last-write-wins & restart survival', () => {
     } satisfies PendingSwitch)
   })
 
+  it('serializes durable commits per session so an older slow write cannot land last', async () => {
+    const ps = makeProfileService([
+      profile({ id: 'sp-1', name: 'A' }),
+      profile({ id: 'sp-2', name: 'B' })
+    ])
+    const sharedSequencer = new SwitchCommitSequencer()
+    const binding = makeSessionBinding(new Map())
+    const writes: string[] = []
+    let releaseFirst!: () => void
+    let markFirstEntered!: () => void
+    const firstEntered = new Promise<void>((resolve) => (markFirstEntered = resolve))
+    const firstBlocked = new Promise<void>((resolve) => (releaseFirst = resolve))
+    const persist = vi.fn(async (_sessionId: string, specialistId: string | undefined) => {
+      if (specialistId === 'sp-1') {
+        markFirstEntered()
+        await firstBlocked
+      }
+      writes.push(specialistId ?? 'main')
+    })
+    const notify = vi.fn(async () => undefined)
+    const makeOp = (): SwitchOperation =>
+      new SwitchOperation({
+        profileService: ps,
+        sessionBinding: binding,
+        approvalGateway: approvingGateway(),
+        switchNotifier: { notify },
+        persistBinding: persist,
+        sequencer: sharedSequencer
+      })
+
+    const first = makeOp().run({ name: 'A' }, { sessionId: 'session-trusted' })
+    await firstEntered
+    const second = makeOp().run({ name: 'B' }, { sessionId: 'session-trusted' })
+    await new Promise((resolve) => setTimeout(resolve, 0))
+
+    // B must wait for A's entire durable commit. Otherwise A can finish after B and become the
+    // durable value despite being the older request.
+    expect(persist).toHaveBeenCalledTimes(1)
+    releaseFirst()
+    await Promise.all([first, second])
+
+    expect(writes).toEqual(['sp-1', 'sp-2'])
+    expect(binding.setBinding).toHaveBeenLastCalledWith('session-trusted', 'sp-2')
+    expect(notify).toHaveBeenLastCalledWith({
+      sessionId: 'session-trusted',
+      targetName: 'B'
+    } satisfies PendingSwitch)
+  })
+
   it('successful switch returns actual persisted binding/pending read-back', async () => {
     const ps = makeProfileService([profile({ id: 'sp-9', name: 'Z', revision: 7 })])
     const op = new SwitchOperation({
@@ -576,7 +625,7 @@ describe('SwitchOperation — sanitization and no-sensitive-data', () => {
       })
     })
     await expect(op.run({ name: 'BIO_EXPERT' }, { sessionId: 'session-trusted' })).rejects.toThrow(
-      /host\.agents\.switch:/
+      'host.agents.switch: Internal operation failed.'
     )
   })
 

--- a/src/main/agents/switch-operation.ts
+++ b/src/main/agents/switch-operation.ts
@@ -27,19 +27,15 @@ import type {
 import type { SpecialistProfileView } from '../../shared/specialist'
 import type { ProfileService } from '../specialist/service'
 import type { SessionBindingService } from '../specialist/session-binding'
+import { AgentsSafeError, agentsPublicError, formatAgentsError } from './agents-error'
 
 // The method name used to prefix sanitized errors and to echo in structured results.
 export const SWITCH_METHOD = 'switch' as const
 
-// Sanitizes an arbitrary cause into a top-level message. System instructions, connector args,
-// credentials, headers, environment values, and stack detail must never leak to the sandbox.
-const sanitizeCause = (cause: unknown): string =>
-  cause instanceof Error ? cause.message : String(cause)
-
-class SwitchError extends Error {
+class SwitchError extends AgentsSafeError {
   constructor(cause: unknown) {
-    super(`host.agents.${SWITCH_METHOD}: ${sanitizeCause(cause)}`)
-    this.name = 'AgentsCallError'
+    super(formatAgentsError(SWITCH_METHOD, cause))
+    this.name = 'SwitchError'
   }
 }
 
@@ -56,8 +52,8 @@ export type SwitchOperationDeps = {
   // approved binding survives application restart. Reuses the existing persistence seam.
   persistBinding: (sessionId: string, specialistId: string | undefined) => Promise<void>
   // Long-lived, session-keyed sequencer for the last-write-wins guard. The dispatcher supplies ONE
-  // shared instance (held on AgentsService) so generation state survives the per-call instantiation;
-  // tests omit it to get a per-instance sequencer.
+  // shared instance (held on AgentsService) so the commit queue survives per-call instantiation;
+  // tests omit it to get a per-instance queue.
   sequencer?: SwitchCommitSequencer
 }
 
@@ -92,49 +88,31 @@ export type SwitchResult =
     }
   | { status: 'declined'; operation: typeof SWITCH_METHOD }
 
-// Internal bookkeeping for last-write-wins across interleaved approved switches. Each approved run
-// captures the monotonic generation it observed at approval time; a completion whose generation is
-// older than the newest committed generation is a stale write and is discarded.
-type PendingCommit = {
-  generation: number
+type SwitchCommit = {
   specialistId: string | undefined
   targetName: string | null
   revision?: number
 }
 
-// Long-lived, session-keyed commit sequencer for the switch last-write-wins guard. The dispatcher
-// (agents-service.ts runSwitch) creates a FRESH SwitchOperation per host.agents.switch call, so the
-// generation counters CANNOT live on the per-call instance — they would reset to 0 every call and
-// the interleaving guard would never fire (only the single-instance unit test would pass). This
-// sequencer is held by the long-lived AgentsService and shared across every SwitchOperation it
-// spawns, keyed by sessionId so concurrent switches in different sessions never collide.
+// Long-lived, session-keyed exclusive commit queue. The dispatcher creates a fresh SwitchOperation
+// per call, so the queue lives on AgentsService and is shared by those instances. Serializing the
+// complete durable commit prevents an older slow persistence call from landing after a newer one;
+// different sessions retain independent queues.
 export class SwitchCommitSequencer {
-  // Per session: highest generation CLAIMED at commit-start, and highest COMMITTED (broadcast done).
-  private readonly claimed = new Map<string, number>()
-  private readonly committed = new Map<string, number>()
+  private readonly tails = new Map<string, Promise<void>>()
 
-  // Claim the next generation for this session's commit attempt. Returns whether a newer commit has
-  // already completed — if so, this attempt is stale before it persists and is discarded.
-  claim(sessionId: string): { generation: number; staleBecauseNewerCommitted: boolean } {
-    const generation = (this.claimed.get(sessionId) ?? 0) + 1
-    this.claimed.set(sessionId, generation)
-    return {
-      generation,
-      staleBecauseNewerCommitted: generation <= (this.committed.get(sessionId) ?? 0)
-    }
-  }
-
-  // After persisting, check whether a newer commit was claimed during the await. If so, this
-  // completion must not overwrite the newer target.
-  supersededByNewerClaim(sessionId: string, generation: number): boolean {
-    return generation < (this.claimed.get(sessionId) ?? 0)
-  }
-
-  // Record this generation as the newest committed for this session (monotonic; stale completions
-  // return before reaching here, so this only advances).
-  markCommitted(sessionId: string, generation: number): void {
-    const current = this.committed.get(sessionId) ?? 0
-    if (generation > current) this.committed.set(sessionId, generation)
+  enqueue<T>(sessionId: string, commit: () => Promise<T>): Promise<T> {
+    const previous = this.tails.get(sessionId) ?? Promise.resolve()
+    const result = previous.then(commit)
+    const tail = result.then(
+      () => undefined,
+      () => undefined
+    )
+    this.tails.set(sessionId, tail)
+    void tail.finally(() => {
+      if (this.tails.get(sessionId) === tail) this.tails.delete(sessionId)
+    })
+    return result
   }
 }
 
@@ -155,7 +133,7 @@ export class SwitchOperation {
     // session id fields are already stripped by the dispatcher; we read neither here.
     const sessionId = trustedSession.sessionId
     if (!sessionId) {
-      throw new SwitchError('Missing trusted calling-session identity')
+      throw new SwitchError(agentsPublicError('Missing trusted calling-session identity'))
     }
 
     // Phase 1 — pre-approval resolution. Resolve the exact public name to the live profile so the
@@ -171,70 +149,43 @@ export class SwitchOperation {
       return { status: 'declined', operation: SWITCH_METHOD }
     }
 
-    // Phase 3 — approval-time re-validation. Re-resolve target name → UUID and verify current
-    // enabled state and (when carried) the reviewed revision. Rename, disable, delete, or revision
-    // drift while approval was pending causes the approved call to fail closed (PRD §8:267). A Main
-    // switch (null target) needs no re-validation — clearing a binding cannot drift.
-    const committed = await this.resolveForCommit(preResolved, params.revision)
+    return this.sequencer.enqueue(sessionId, async () => {
+      // Revalidate inside the exclusive commit queue so drift is checked immediately before the
+      // mutation, including time spent waiting behind an earlier commit for this session.
+      const committed = await this.resolveForCommit(preResolved, params.revision)
 
-    // Phase 4 — last-write-wins guard. Claim a generation (session-scoped, shared across calls via
-    // the sequencer) before the await so a newer approved switch interleaved during
-    // persistence/broadcast can supersede this completion.
-    const { generation, staleBecauseNewerCommitted } = this.sequencer.claim(sessionId)
-    if (staleBecauseNewerCommitted) {
-      // An even newer commit already completed; this stale completion is discarded.
-      return this.readBackStale(sessionId, committed)
-    }
+      // Durable persistence comes first. The runtime identity changes only at the safe next-message
+      // boundary, after the approved binding has survived application restart.
+      try {
+        await this.deps.persistBinding(sessionId, committed.specialistId)
+      } catch (error) {
+        throw new SwitchError(error)
+      }
 
-    // Phase 5 — durable persistence FIRST. The binding survives restart immediately; runtime
-    // identity changes only at the safe next-message boundary (distinct durable vs runtime state).
-    try {
-      await this.deps.persistBinding(sessionId, committed.specialistId)
-    } catch (error) {
-      throw new SwitchError(error)
-    }
+      this.deps.sessionBinding.setBinding(sessionId, committed.specialistId)
 
-    // A newer approved switch may have interleaved while persisting. If so, this completion is
-    // stale: do not overwrite the newer target. The newer run owns the final persisted state.
-    if (this.sequencer.supersededByNewerClaim(sessionId, generation)) {
-      return this.readBackStale(sessionId, committed)
-    }
-
-    // Expose the durable binding to the live in-memory resolver (reuses SessionBindingService).
-    this.deps.sessionBinding.setBinding(sessionId, committed.specialistId)
-
-    // Broadcast the pending-reconfigure notification. The renderer renders the "takes effect next
-    // message" state; the runtime reconfigure barrier applies the approved binding at the next send.
-    // PendingSwitch carries ONLY sessionId + targetName — no system instructions or secrets. The
-    // broadcast is a BEST-EFFORT renderer mirror: the persisted binding is authoritative and applies
-    // at the next send regardless, so a notify failure must NOT surface as a thrown error to the
-    // caller — the switch has already committed. Swallow the failure and continue so this run still
-    // reaches markCommitted and reports approved.
-    const pendingReconfigure: PendingSwitch = {
-      sessionId,
-      targetName: committed.targetName
-    }
-    try {
-      await this.deps.switchNotifier.notify(pendingReconfigure)
-    } catch {
-      // Best-effort mirror; the durable binding already took effect. Do not throw.
-    }
-
-    // If an even newer switch interleaved during broadcast, the newest target still wins; this run
-    // reports its own commit but does not clobber the newer persisted state.
-    this.sequencer.markCommitted(sessionId, generation)
-
-    return {
-      status: 'approved',
-      operation: SWITCH_METHOD,
-      binding: {
+      const pendingReconfigure: PendingSwitch = {
         sessionId,
-        specialistId: committed.specialistId,
-        targetName: committed.targetName,
-        ...(committed.revision !== undefined ? { revision: committed.revision } : {})
-      },
-      pendingReconfigure
-    }
+        targetName: committed.targetName
+      }
+      try {
+        await this.deps.switchNotifier.notify(pendingReconfigure)
+      } catch {
+        // Best-effort mirror; the durable binding already took effect. Do not throw.
+      }
+
+      return {
+        status: 'approved' as const,
+        operation: SWITCH_METHOD,
+        binding: {
+          sessionId,
+          specialistId: committed.specialistId,
+          targetName: committed.targetName,
+          ...(committed.revision !== undefined ? { revision: committed.revision } : {})
+        },
+        pendingReconfigure
+      }
+    })
   }
 
   // Resolves the target public name to the live profile (pre-approval). null selects Main Agent
@@ -251,7 +202,7 @@ export class SwitchOperation {
       throw new SwitchError(error)
     }
     if (!profile.enabled) {
-      throw new SwitchError(`Specialist "${targetName}" is not enabled`)
+      throw new SwitchError(agentsPublicError(`Specialist "${targetName}" is not enabled`))
     }
     return { kind: 'specialist', profile }
   }
@@ -307,9 +258,9 @@ export class SwitchOperation {
   private async resolveForCommit(
     preResolved: { kind: 'main' } | { kind: 'specialist'; profile: SpecialistProfileView },
     reviewedRevision: number | undefined
-  ): Promise<PendingCommit> {
+  ): Promise<SwitchCommit> {
     if (preResolved.kind === 'main') {
-      return { generation: 0, specialistId: undefined, targetName: null }
+      return { specialistId: undefined, targetName: null }
     }
     const name = preResolved.profile.name
     let profile: SpecialistProfileView
@@ -320,47 +271,21 @@ export class SwitchOperation {
       throw new SwitchError(error)
     }
     if (!profile.enabled) {
-      throw new SwitchError(`Specialist "${name}" was disabled before the switch committed`)
+      throw new SwitchError(
+        agentsPublicError(`Specialist "${name}" was disabled before the switch committed`)
+      )
     }
     if (reviewedRevision !== undefined && profile.revision !== reviewedRevision) {
       throw new SwitchError(
-        `Specialist "${name}" revision changed (${reviewedRevision} → ${profile.revision}) before the switch committed`
+        agentsPublicError(
+          `Specialist "${name}" revision changed (${reviewedRevision} → ${profile.revision}) before the switch committed`
+        )
       )
     }
     return {
-      generation: 0,
       specialistId: profile.id,
       targetName: profile.name,
       revision: profile.revision
-    }
-  }
-
-  // Read-back for a stale completion. The stale run returns its own observed target so the caller
-  // sees a coherent result, but it has NOT overwritten the newer persisted target (it returned
-  // before persistence/broadcast). Main-targeted stale reads report a cleared binding.
-  private readBackStale(
-    sessionId: string,
-    committed: PendingCommit
-  ): {
-    status: 'approved'
-    operation: typeof SWITCH_METHOD
-    binding: SwitchBindingReadBack
-    pendingReconfigure: PendingSwitch
-  } {
-    const pendingReconfigure: PendingSwitch = {
-      sessionId,
-      targetName: committed.targetName
-    }
-    return {
-      status: 'approved',
-      operation: SWITCH_METHOD,
-      binding: {
-        sessionId,
-        specialistId: committed.specialistId,
-        targetName: committed.targetName,
-        ...(committed.revision !== undefined ? { revision: committed.revision } : {})
-      },
-      pendingReconfigure
     }
   }
 }

--- a/src/main/notebook/local-rpc-server.agents.test.ts
+++ b/src/main/notebook/local-rpc-server.agents.test.ts
@@ -39,26 +39,93 @@ const makeService = async (): Promise<NotebookRuntimeService> => {
 }
 
 describe('notebook RPC agentsCall route', () => {
-  it('forwards the op to the AgentsService and returns its result', async () => {
+  it('forwards agentsCall through the control-plane capability used by the REPL', async () => {
     const read = vi.fn(async () => [{ id: 'sp-1', name: 'Bio', revision: 1 }])
     const server = new NotebookLocalRpcServer(await makeService(), {
-      token: 'tok',
+      agentsService: { read }
+    })
+    const connection = await server.issueControlConnection('session-42', 'project-1')
+    try {
+      const res = await fetch(connection.endpoint, {
+        method: 'POST',
+        headers: {
+          authorization: `Bearer ${connection.token}`,
+          'content-type': 'application/json'
+        },
+        body: JSON.stringify({
+          method: 'agentsCall',
+          params: { op: 'list', session_id: 'session-42' }
+        })
+      })
+
+      expect(res.status).toBe(200)
+      await expect(res.json()).resolves.toEqual({
+        result: [{ id: 'sp-1', name: 'Bio', revision: 1 }]
+      })
+      expect(read).toHaveBeenCalledWith({ op: 'list', params: {} }, { sessionId: 'session-42' })
+    } finally {
+      connection.release()
+      await server.close()
+    }
+  })
+
+  it('derives the trusted session from the control capability instead of request params', async () => {
+    const read = vi.fn(async () => null)
+    const server = new NotebookLocalRpcServer(await makeService(), {
+      agentsService: { read }
+    })
+    const connection = await server.issueControlConnection('session-bound', 'project-bound')
+    try {
+      const res = await fetch(connection.endpoint, {
+        method: 'POST',
+        headers: {
+          authorization: `Bearer ${connection.token}`,
+          'content-type': 'application/json'
+        },
+        body: JSON.stringify({
+          method: 'agentsCall',
+          params: {
+            op: 'list_skills',
+            session_id: 'session-forged',
+            project_id: 'project-forged',
+            name_or_id: 'demo'
+          }
+        })
+      })
+
+      expect(res.status).toBe(200)
+      expect(read).toHaveBeenCalledWith(
+        { op: 'list_skills', params: { name_or_id: 'demo' } },
+        { sessionId: 'session-bound' }
+      )
+    } finally {
+      connection.release()
+      await server.close()
+    }
+  })
+
+  it('rejects agentsCall made with the server-wide bootstrap token', async () => {
+    const read = vi.fn(async () => null)
+    const server = new NotebookLocalRpcServer(await makeService(), {
+      token: 'bootstrap-token',
       agentsService: { read }
     })
     const connection = await server.ensureStarted()
     try {
       const res = await fetch(connection.endpoint, {
         method: 'POST',
-        headers: { authorization: 'Bearer tok', 'content-type': 'application/json' },
+        headers: {
+          authorization: 'Bearer bootstrap-token',
+          'content-type': 'application/json'
+        },
         body: JSON.stringify({ method: 'agentsCall', params: { op: 'list' } })
       })
-      expect(res.status).toBe(200)
-      const body = await res.json()
-      expect(body.result).toHaveLength(1)
-      expect(read).toHaveBeenCalledWith(
-        { op: 'list', params: {} },
-        expect.objectContaining({ sessionId: undefined })
-      )
+
+      expect(res.status).toBe(401)
+      await expect(res.json()).resolves.toEqual({
+        error: 'A session-bound notebook RPC token is required.'
+      })
+      expect(read).not.toHaveBeenCalled()
     } finally {
       await server.close()
     }
@@ -82,75 +149,50 @@ describe('notebook RPC agentsCall route', () => {
     }
   })
 
-  it('forwards snake_case params and the trusted session_id as context', async () => {
-    const read = vi.fn(async () => null)
-    const server = new NotebookLocalRpcServer(await makeService(), {
-      token: 'tok',
-      agentsService: { read }
-    })
-    const connection = await server.ensureStarted()
-    try {
-      await fetch(connection.endpoint, {
-        method: 'POST',
-        headers: { authorization: 'Bearer tok', 'content-type': 'application/json' },
-        body: JSON.stringify({
-          method: 'agentsCall',
-          params: { op: 'list_skills', session_id: 'session-42', name_or_id: 'demo' }
-        })
-      })
-      // The session_id becomes the trusted calling-session context; the AgentsService never sees it
-      // as a user param, and never sees a caller-supplied specialistId.
-      expect(read).toHaveBeenCalledWith(
-        { op: 'list_skills', params: { name_or_id: 'demo' } },
-        { sessionId: 'session-42' }
-      )
-    } finally {
-      await server.close()
-    }
-  })
-
   it('surfaces a sanitized error on 500 when AgentsService throws', async () => {
     const read = vi.fn(async () => {
       throw new Error('host.agents.get: not found')
     })
-    const server = new NotebookLocalRpcServer(await makeService(), {
-      token: 'tok',
-      agentsService: { read }
-    })
-    const connection = await server.ensureStarted()
+    const server = new NotebookLocalRpcServer(await makeService(), { agentsService: { read } })
+    const connection = await server.issueControlConnection('session-error', 'project-1')
     try {
       const res = await fetch(connection.endpoint, {
         method: 'POST',
-        headers: { authorization: 'Bearer tok', 'content-type': 'application/json' },
+        headers: {
+          authorization: `Bearer ${connection.token}`,
+          'content-type': 'application/json'
+        },
         body: JSON.stringify({ method: 'agentsCall', params: { op: 'get', name: 'x' } })
       })
       expect(res.status).toBe(500)
       const body = await res.json()
       expect(body.error).toMatch(/host\.agents\.get:/)
     } finally {
+      connection.release()
       await server.close()
     }
   })
 
   it('strips sandbox-supplied switch/reconfigure/identity fields so they cannot be forged', async () => {
     const read = vi.fn(async () => null)
-    const server = new NotebookLocalRpcServer(await makeService(), {
-      token: 'tok',
-      agentsService: { read }
-    })
-    const connection = await server.ensureStarted()
+    const server = new NotebookLocalRpcServer(await makeService(), { agentsService: { read } })
+    const connection = await server.issueControlConnection('trusted-session', 'project-1')
     try {
       await fetch(connection.endpoint, {
         method: 'POST',
-        headers: { authorization: 'Bearer tok', 'content-type': 'application/json' },
+        headers: {
+          authorization: `Bearer ${connection.token}`,
+          'content-type': 'application/json'
+        },
         body: JSON.stringify({
           method: 'agentsCall',
           params: {
             op: 'list_skills',
-            // Trusted session captured outside the sandbox — forwarded as context only.
-            session_id: 'trusted-session',
             // Everything below is a sandbox forgery attempt that must be dropped before dispatch.
+            session_id: 'forged-snake',
             sessionId: 'forged-camel',
+            project_id: 'forged-project-snake',
+            projectId: 'forged-project-camel',
             specialist_id: 'forged-specialist',
             target_specialist_id: 'forged-target',
             targetSpecialistId: 'forged-target-camel',
@@ -162,12 +204,13 @@ describe('notebook RPC agentsCall route', () => {
           }
         })
       })
-      // Only the trusted session_id (as context) and the legitimate method filter reach the service.
+      // Only the capability-bound session (as context) and legitimate method filter reach the service.
       expect(read).toHaveBeenCalledWith(
         { op: 'list_skills', params: { name_or_id: 'demo' } },
         { sessionId: 'trusted-session' }
       )
     } finally {
+      connection.release()
       await server.close()
     }
   })
@@ -176,14 +219,16 @@ describe('notebook RPC agentsCall route', () => {
     const dispatch = vi.fn(async () => ['via-dispatch'])
     const read = vi.fn(async () => ['via-read'])
     const server = new NotebookLocalRpcServer(await makeService(), {
-      token: 'tok',
       agentsService: { read, dispatch }
     })
-    const connection = await server.ensureStarted()
+    const connection = await server.issueControlConnection('session-dispatch', 'project-1')
     try {
       const res = await fetch(connection.endpoint, {
         method: 'POST',
-        headers: { authorization: 'Bearer tok', 'content-type': 'application/json' },
+        headers: {
+          authorization: `Bearer ${connection.token}`,
+          'content-type': 'application/json'
+        },
         body: JSON.stringify({ method: 'agentsCall', params: { op: 'list' } })
       })
       expect(res.status).toBe(200)
@@ -192,6 +237,7 @@ describe('notebook RPC agentsCall route', () => {
       // route MAY use. Either way the op and trusted session are forwarded correctly.
       expect(body.result).toHaveLength(1)
     } finally {
+      connection.release()
       await server.close()
     }
   })

--- a/src/main/notebook/local-rpc-server.ts
+++ b/src/main/notebook/local-rpc-server.ts
@@ -149,7 +149,7 @@ const ARTIFACT_RPC_METHODS = new Set<ArtifactRpcMethod>([
 // Capabilities are revoked when the turn ends. This upper bound only limits abandoned tokens, so
 // it must comfortably exceed long notebook executions that remain inside one active turn.
 const DEFAULT_ARTIFACT_RPC_CAPABILITY_TTL_MS = 2 * 60 * 60 * 1_000
-const CONTROL_RPC_METHODS = new Set(['mcpCall', 'computeCall'])
+const CONTROL_RPC_METHODS = new Set(['mcpCall', 'computeCall', 'agentsCall'])
 
 const isArtifactRpcMethod = (method: string): method is ArtifactRpcMethod =>
   ARTIFACT_RPC_METHODS.has(method as ArtifactRpcMethod)
@@ -561,7 +561,7 @@ class NotebookLocalRpcServer {
           if (authorization !== `Bearer ${this.token}`) {
             throw new RpcHttpError(401, 'Invalid notebook RPC token.')
           }
-          if (method === 'mcpCall' || method === 'computeCall') {
+          if (method === 'mcpCall' || method === 'computeCall' || method === 'agentsCall') {
             throw new RpcHttpError(401, 'A session-bound notebook RPC token is required.')
           }
         }
@@ -836,20 +836,10 @@ class NotebookLocalRpcServer {
     // agentsCall: host.agents control-plane SDK (issue 02). Routes operations to the AgentsService
     // dispatcher.
     //
-    // TRUSTED CALLING-SESSION IDENTITY: the `session_id` read from this request IS the trusted
-    // calling-session identity, forwarded to AgentsService.read() as server context — exactly the
-    // same way mcpCall/computeCall forward the caller's `sessionId`. It is NOT "ignored": only the
-    // forwarded op-params are stripped (stripAgentsReservedParams below). It is trusted because (a)
-    // the JS control REPL binds `session_id` to the spawn-captured COMPUTE_SESSION_ID at the
-    // `agentsRpc` boundary (see resources/notebook/repl_loop.js) and exposes no override through the
-    // `host.agents` SDK surface, and (b) this loopback RPC is Bearer-token-gated (handleRequest
-    // enforces `Bearer ${this.token}`), with the token captured and removed from `process.env`
-    // before the sandbox is built and held in an opaque module closure.
-    //
-    // RESIDUAL DEFENSE-IN-DEPTH LIMITATION: a single shared loopback server that trusts a
-    // caller-supplied session id means session-identity assurance ultimately rests on that token
-    // gate. Server-side session derivation (e.g. a session-bound token or per-session connection)
-    // is a possible future hardening, tracked separately — NOT implemented here.
+    // TRUSTED CALLING-SESSION IDENTITY: handleRequest derives `sessionId` from the per-session
+    // control capability and overwrites any request-body value before dispatch. The snake_case
+    // `session_id` field is reserved and stripped below, so sandbox code cannot target another
+    // conversation even if it forges raw agentsCall params.
     //
     // DISPATCH SEPARATION: this route owns ONLY auth + sandbox injection. It strips every reserved
     // routing/identity/switch key (AGENTS_RESERVED_PARAM_KEYS in src/shared/agents-contract.ts) and
@@ -858,14 +848,14 @@ class NotebookLocalRpcServer {
     // AgentsService.dispatch's extension-point comment.
     if (method === 'agentsCall') {
       if (!this.agentsService) throw new Error('Agents service is not configured.')
-      const sessionId = typeof params.session_id === 'string' ? params.session_id : undefined
+      const sessionId = typeof params.sessionId === 'string' ? params.sessionId : undefined
       const op = typeof params.op === 'string' ? params.op : ''
       // Strip every reserved routing/identity/switch key before forwarding. The AgentsService and
       // its injected approval/switch seams only ever see the op + their own snake_case params; the
       // trusted session identity stays in the server context (NOT taken from the forwarded params).
       // Sandbox-supplied values for specialist_id, target_specialist_id, reconfigure, etc. are
-      // provably ignored — note that session_id above is intentionally read from the request as the
-      // trusted identity, not from the forwarded op-params.
+      // provably ignored. The trusted session identity comes from the capability-bound camelCase
+      // field injected by handleRequest, not from sandbox-supplied snake_case params.
       const rest = stripAgentsReservedParams(params)
       return this.agentsService.read({ op, params: rest }, { sessionId })
     }

--- a/src/main/specialist/service.test.ts
+++ b/src/main/specialist/service.test.ts
@@ -167,6 +167,30 @@ describe('ProfileService.setEnabled', () => {
 })
 
 describe('ProfileService.update', () => {
+  it('atomically persists enabled with other fields and bumps revision once', async () => {
+    const created = await service.create({ name: 'My Bot' })
+    const updated = await service.update({
+      id: created.id,
+      revision: created.revision,
+      name: 'My Disabled Bot',
+      enabled: false
+    })
+
+    expect(updated).toMatchObject({
+      id: created.id,
+      name: 'My Disabled Bot',
+      enabled: false,
+      revision: created.revision + 1
+    })
+
+    const restarted = new ProfileService(new SpecialistRepository(tmpDir))
+    await expect(restarted.getById(created.id)).resolves.toMatchObject({
+      name: 'My Disabled Bot',
+      enabled: false,
+      revision: created.revision + 1
+    })
+  })
+
   it('updates identity fields and bumps revision', async () => {
     const created = await service.create({ name: 'RNA-seq Reviewer' })
     const updated = await service.update({

--- a/src/main/specialist/service.ts
+++ b/src/main/specialist/service.ts
@@ -237,6 +237,9 @@ export class ProfileService {
     if (input.name !== undefined && typeof input.name !== 'string') {
       throw new Error('Name must be a string.')
     }
+    if (input.enabled !== undefined && typeof input.enabled !== 'boolean') {
+      throw new Error('Enabled must be a boolean.')
+    }
     assertOptionalIdentityFieldShapes(input)
     assertCapabilityConfigShape(input)
 
@@ -256,6 +259,7 @@ export class ProfileService {
     if (input.systemPrompt !== undefined) patch.systemPrompt = input.systemPrompt
     if (input.iconKey !== undefined) patch.iconKey = input.iconKey
     if (input.colorKey !== undefined) patch.colorKey = input.colorKey
+    if (input.enabled !== undefined) patch.enabled = input.enabled
     if (input.capabilityMode !== undefined) patch.capabilityMode = input.capabilityMode
     if (input.fullAccess !== undefined) patch.fullAccess = input.fullAccess
     if (input.selectedCapabilities !== undefined) {

--- a/src/shared/agents-contract.ts
+++ b/src/shared/agents-contract.ts
@@ -52,13 +52,10 @@ export type AgentsOrdinaryWriteOpName =
 // — without touching the auth/token transport in local-rpc-server.ts.
 export type AgentsOpName = AgentsReadOpName | AgentsWriteOpName
 
-// The trusted calling-session identity captured outside the sandbox (the control-plane REPL's
-// module-closure COMPUTE_SESSION_ID). This is the ONLY value switch() may target; sandbox code
-// cannot forge it. It is injected into dispatch as SERVER CONTEXT — the dispatcher and the domain
-// mutations it calls never read it back out of the forwarded op-params. (The transport in
-// local-rpc-server.ts does take `session_id` from the request to populate this context; see that
-// file's agentsCall comment for why that request value is trusted: the JS control REPL binds it to
-// the spawn-captured COMPUTE_SESSION_ID and the loopback is Bearer-token-gated.)
+// The trusted calling-session identity derived from the control-plane REPL's session-bound RPC
+// capability. This is the ONLY value switch() may target; sandbox code cannot forge it. It is
+// injected into dispatch as SERVER CONTEXT — the dispatcher and the domain mutations it calls never
+// read it back out of forwarded op-params.
 export type TrustedCallingSession = {
   sessionId?: string
 }
@@ -245,6 +242,8 @@ export const AGENTS_RESERVED_PARAM_KEYS = [
   'op',
   'session_id',
   'sessionId',
+  'project_id',
+  'projectId',
   'specialist_id',
   'specialistId',
   'target_specialist_id',

--- a/src/shared/specialist.ts
+++ b/src/shared/specialist.ts
@@ -206,6 +206,7 @@ export type UpdateSpecialistInput = {
   systemPrompt?: string
   iconKey?: string
   colorKey?: string
+  enabled?: boolean
   capabilityMode?: SpecialistCapabilityMode
   fullAccess?: SpecialistFullAccessConfig
   selectedCapabilities?: SpecialistSelectedConfig


### PR DESCRIPTION
## Problem

The production Notebook control-plane capability omitted `agentsCall`, so `host.agents.*` calls from the real REPL failed with HTTP 403 even though bootstrap-token tests passed. The Specialist work merged in #546 also left several hardening gaps: request-body session identity was trusted, dependency errors could leak secrets, combined `enabled` updates were split across two writes, and overlapping switches could persist an older slow write last.

## Proposed change

- Allow `agentsCall` only on session-bound control capabilities and reject it on the server-wide bootstrap token.
- Derive the trusted session/project identity from the capability and strip all body-supplied identity fields; the REPL no longer sends a session id.
- Return only explicitly branded public `host.agents` errors and replace unknown dependency failures with `Internal operation failed.`
- Commit `enabled` in the same revision-guarded `ProfileService.update` as identity and capability changes.
- Serialize the complete switch commit per session (`revalidate -> persist -> live binding -> notify`) so durable last-write-wins holds across concurrent per-call instances.
- Move the real REPL integration suites to session-bound control tokens.

## Scope and non-goals

This PR fixes the production 403 and hardens the reachable Specialist control plane from #546. It does not change renderer behavior, profile schemas beyond accepting `enabled` in the existing update input, or the runtime next-message reconfiguration boundary.

The existing production pass-through approval gateway remains unchanged. Replacing it with ACP human confirmation requires a cohesive application-owned broker request path, trusted-session propagation, preload/renderer card wiring, and runtime composition. A partial gateway swap would either hang, misroute, or disable privileged operations, so that feature-sized gap remains explicit follow-up work.

## Acceptance criteria and validation

All listed checks ran after the last material code edit.

| Expected behavior | Evidence | Result |
| --- | --- | --- |
| Production-style control capability can call `agentsCall`; bootstrap token cannot | `local-rpc-server.agents.test.ts` | Pass |
| Forged snake/camel session and project fields cannot replace capability identity | RPC unit tests plus `RUN_KERNEL=1` REPL integration suites | 44/44 pass |
| Secret-bearing dependency errors are redacted across read, mutation, switch, and privileged paths | Focused agents/service tests | 148/148 pass in final review |
| Combined rename/capability/`enabled` updates are one durable revision bump | service, mutation, privileged, and dispatch tests | Pass |
| A slow older switch cannot land after a newer switch in the same session | cross-instance switch concurrency test | Pass |
| Node and renderer types are valid | `npm run typecheck` | Pass |
| Repository lint has no errors | `npm run lint` | Pass (0 errors; 23 pre-existing warnings outside this diff) |
| Full regression suite passes | `npm test` | 9,351 passed; 184 skipped |
| Patch is whitespace-clean | `git diff --check` | Pass |

## Review focus

- Capability ownership in `NotebookLocalRpcServer.handleRequest` and the `agentsCall` route.
- The safe/public error boundary in `agents-error.ts`.
- Atomic update projection through `ProfileService.update`.
- Per-session queue cleanup and commit ordering in `SwitchCommitSequencer`.

Related: #546.
