### PR TITLE
ci(windows): extend path portability preflight

### DIFF
--- a/.github/workflows/windows-path-portability.yml
+++ b/.github/workflows/windows-path-portability.yml
@@ -49,6 +49,8 @@ jobs:
           src/main/notebook/runtime-paths.test.ts
           src/main/session-persistence/conversation-export.test.ts
           src/main/session-persistence/data-path-roundtrip.test.ts
+          src/main/settings/notebook-runtime-settings.test.ts
+          src/main/settings/preferences.test.ts
           src/main/settings/shell-path.test.ts
           src/main/specialist/repository.test.ts
           src/main/storage/data-path.test.ts

--- a/scripts/windows-path-portability-workflow.test.ts
+++ b/scripts/windows-path-portability-workflow.test.ts
@@ -94,6 +94,8 @@ describe('Windows path portability workflow', () => {
       'src/main/notebook/runtime-paths.test.ts',
       'src/main/session-persistence/conversation-export.test.ts',
       'src/main/session-persistence/data-path-roundtrip.test.ts',
+      'src/main/settings/notebook-runtime-settings.test.ts',
+      'src/main/settings/preferences.test.ts',
       'src/main/settings/shell-path.test.ts',
       'src/main/specialist/repository.test.ts',
       'src/main/storage/data-path.test.ts',

--- a/src/main/settings/notebook-runtime-settings.test.ts
+++ b/src/main/settings/notebook-runtime-settings.test.ts
@@ -1,6 +1,6 @@
 import { mkdtemp, rm } from 'node:fs/promises'
 import { tmpdir } from 'node:os'
-import { join } from 'node:path'
+import { join, resolve } from 'node:path'
 
 import { afterEach, describe, expect, it } from 'vitest'
 
@@ -35,9 +35,10 @@ describe('NotebookRuntimeSettingsModule', () => {
 
   it('persists and clears a runtime selection through the repository policy', async () => {
     const settings = await createModule()
+    const interpreterPath = resolve('/usr/bin/python3')
     const selection = {
       source: 'external' as const,
-      interpreterPath: '/usr/bin/python3',
+      interpreterPath,
       interpreterArgs: ['-I'],
       appOwnedOverlay: false,
       packageInstallAuthorized: true
@@ -58,35 +59,33 @@ describe('NotebookRuntimeSettingsModule', () => {
 
   it('keeps environment enablement and install authorization as separate choices', async () => {
     const settings = await createModule()
+    const interpreterPath = resolve('/usr/bin/python3')
 
-    await expect(
-      settings.setEnvironmentEnabled('python', '/usr/bin/python3', true)
-    ).resolves.toEqual({
-      enabled: { '/usr/bin/python3': true },
+    await expect(settings.setEnvironmentEnabled('python', interpreterPath, true)).resolves.toEqual({
+      enabled: { [interpreterPath]: true },
       installAuthorized: {}
     })
-    await expect(
-      settings.setInstallAuthorized('python', '/usr/bin/python3', false)
-    ).resolves.toEqual({
-      enabled: { '/usr/bin/python3': true },
-      installAuthorized: { '/usr/bin/python3': false }
+    await expect(settings.setInstallAuthorized('python', interpreterPath, false)).resolves.toEqual({
+      enabled: { [interpreterPath]: true },
+      installAuthorized: { [interpreterPath]: false }
     })
 
     const snapshot = await settings.getSnapshot('python')
-    snapshot.runtimeEnablement.enabled['/usr/bin/python3'] = false
+    snapshot.runtimeEnablement.enabled[interpreterPath] = false
     expect((await settings.getSnapshot('python')).runtimeEnablement).toEqual({
-      enabled: { '/usr/bin/python3': true },
-      installAuthorized: { '/usr/bin/python3': false }
+      enabled: { [interpreterPath]: true },
+      installAuthorized: { [interpreterPath]: false }
     })
   })
 
   it('preserves repository normalization for manual interpreters and package mirrors', async () => {
     const settings = await createModule()
+    const interpreterPath = resolve('/opt/python/bin/python3')
 
-    await settings.addManualInterpreter('python', '  /opt/python/bin/python3  ')
-    await expect(
-      settings.addManualInterpreter('python', '/opt/python/bin/python3')
-    ).resolves.toEqual(['/opt/python/bin/python3'])
+    await settings.addManualInterpreter('python', `  ${interpreterPath}  `)
+    await expect(settings.addManualInterpreter('python', interpreterPath)).resolves.toEqual([
+      interpreterPath
+    ])
     await expect(
       settings.setPackageMirror({
         condaChannel: ' https://mirror.example/conda ',
@@ -95,12 +94,10 @@ describe('NotebookRuntimeSettingsModule', () => {
     ).resolves.toEqual({ condaChannel: ' https://mirror.example/conda ' })
 
     const snapshot = await settings.getSnapshot('python')
-    expect(snapshot.manualInterpreters).toEqual(['/opt/python/bin/python3'])
+    expect(snapshot.manualInterpreters).toEqual([interpreterPath])
     expect(snapshot.packageMirror).toEqual({ condaChannel: ' https://mirror.example/conda ' })
 
-    await expect(
-      settings.removeManualInterpreter('python', '/opt/python/bin/python3')
-    ).resolves.toEqual([])
+    await expect(settings.removeManualInterpreter('python', interpreterPath)).resolves.toEqual([])
     await expect(settings.setPackageMirror({})).resolves.toEqual({})
   })
 })

--- a/src/main/settings/preferences.test.ts
+++ b/src/main/settings/preferences.test.ts
@@ -1,6 +1,6 @@
 import { mkdtemp, rm } from 'node:fs/promises'
 import { tmpdir } from 'node:os'
-import { join } from 'node:path'
+import { join, resolve } from 'node:path'
 
 import { afterEach, describe, expect, it } from 'vitest'
 
@@ -36,13 +36,14 @@ describe('SettingsPreferencesModule', () => {
 
   it('persists scalar commands with the existing defaults and one-time markers', async () => {
     const { preferences, repository } = await createModule(2_000)
+    const dataRoot = resolve('/data/open-science')
 
     await preferences.setReasoningEffort('high')
     await preferences.setNotificationsEnabled(false)
     await preferences.setConversationSkillImportEnabled(false)
     await preferences.setClosePreference('quit')
     await preferences.setAppIconVariant('dark')
-    await preferences.setDataRoot('/data/open-science')
+    await preferences.setDataRoot(dataRoot)
     await preferences.markOnboardingComplete()
     await preferences.markPathsNormalized()
     await preferences.dismissLegacyDataMovePrompt()
@@ -51,7 +52,7 @@ describe('SettingsPreferencesModule', () => {
       onboardingCompletedAt: 2_000,
       pathsNormalizedAt: 2_000,
       legacyDataMovePromptDismissedAt: 2_000,
-      dataRoot: '/data/open-science',
+      dataRoot,
       reasoningEffort: 'high',
       notificationsEnabled: false,
       conversationSkillImportEnabled: false,
@@ -65,7 +66,7 @@ describe('SettingsPreferencesModule', () => {
       onboardingCompletedAt: 2_000,
       pathsNormalizedAt: 2_000,
       legacyDataMovePromptDismissedAt: 2_000,
-      dataRoot: '/data/open-science',
+      dataRoot,
       reasoningEffort: 'high',
       notificationsEnabled: false,
       conversationSkillImportEnabled: false,


### PR DESCRIPTION
## Summary

- run preferences and notebook runtime settings tests in the blocking Windows path portability workflow
- use platform-native absolute paths in settings path fixtures
- keep the workflow contract test synchronized with the focused test list

## Testing

- npx vitest run scripts/windows-path-portability-workflow.test.ts src/main/settings/notebook-runtime-settings.test.ts src/main/settings/preferences.test.ts
- npx vitest run src/main/logger.test.ts src/main/notebook/kernel-executor.test.ts src/main/notebook/runtime-service.test.ts src/renderer/src/pages/workspace/ProjectFilesView.test.tsx --maxWorkers=1 --exclude .pnpm-store/** --exclude .worktree/**
- eslint on changed TypeScript tests
- prettier --check on changed files