### PR TITLE
fix(notebook): close environment leases on disposal

### DIFF
--- a/src/main/notebook/runtime-service.test.ts
+++ b/src/main/notebook/runtime-service.test.ts
@@ -6052,6 +6052,36 @@ describe('v4 runtime bindings & agent tools', () => {
     await expect(disposal).resolves.toEqual({ reaped: true })
   })
 
+  it('closes environment leases before terminal disposal can release queued operations', async () => {
+    const root = await createStorageRoot()
+    const service = new NotebookRuntimeService({
+      configRoot: root,
+      dataRoot: root,
+      projectName: 'default-project',
+      repository: new NotebookRunRepository(root)
+    })
+    const leaseManager = (
+      service as unknown as {
+        environmentLeases: {
+          acquire: (
+            environment: string,
+            mode: 'shared' | 'exclusive'
+          ) => { granted: Promise<{ release(): boolean }> }
+          snapshot: () => { disposed: boolean }
+        }
+      }
+    ).environmentLeases
+    const held = await leaseManager.acquire('default', 'exclusive').granted
+    const queued = leaseManager.acquire('default', 'exclusive').granted
+
+    const disposal = service.dispose()
+
+    await expect(queued).rejects.toThrow(/disposed/)
+    expect(leaseManager.snapshot().disposed).toBe(true)
+    expect(held.release()).toBe(false)
+    await expect(disposal).resolves.toEqual({ reaped: true })
+  })
+
   it('waits for recovery disposal before propagating a kernel teardown failure', async () => {
     const root = await createStorageRoot()
     let releaseRecovery: (() => void) | undefined

--- a/src/main/notebook/runtime-service.ts
+++ b/src/main/notebook/runtime-service.ts
@@ -3378,6 +3378,10 @@ class NotebookRuntimeService {
   // shutdownAll(), this is terminal: quit/relaunch and module disposal use it, while update and data-root
   // migration gates retain the reusable shutdown contract so a refused/cancelled flow can resume work.
   async dispose(): Promise<{ reaped: boolean }> {
+    // Close the terminal admission boundary before any asynchronous teardown starts. Existing holders
+    // are released and queued acquisitions reject, so no package/environment operation can begin after
+    // application disposal has crossed this point.
+    this.environmentLeases.dispose()
     // Mark recovery disposed first, but do not let slow startup filesystem reconciliation consume the
     // quit budget before kernel teardown even starts. Await both so non-quit module disposal still leaves
     // no recovery work behind once this terminal operation resolves.


### PR DESCRIPTION
## Problem

Notebook runtime terminal disposal did not close its environment lease coordinator. A queued lease acquisition could therefore complete after the runtime crossed its disposal boundary, while releases from already-held leases could still mutate shutdown state.

## Proposed change

- Dispose the environment lease coordinator synchronously when terminal runtime disposal begins.
- Add a regression test covering both a queued acquisition and a previously acquired lease.

## Scope and non-goals

- Limited to Notebook environment-lease lifecycle behavior.
- No persisted data, renderer UI, or Specialist changes.

## Acceptance criteria and validation

- Queued acquisition rejects after `dispose()`, held release returns `false`, and runtime disposal completes: covered by `src/main/notebook/runtime-service.test.ts`.
- `npm run typecheck`: passed.
- `npm run lint`: passed with 0 errors and the existing 23 warnings.
- `npm test`: 630 files passed, 15 skipped; 9,356 tests passed, 184 skipped.

## Review focus

- Whether the lease coordinator closes at the terminal boundary before asynchronous teardown can yield.
- Whether the regression test captures both queued and held-lease behavior.

Related: #577
