### PR TITLE
fix(test): exclude local caches from Vitest discovery

### DIFF
--- a/vitest.config.test.ts
+++ b/vitest.config.test.ts
@@ -1,0 +1,12 @@
+import { describe, expect, it } from 'vitest'
+
+import { VITEST_EXCLUDE_PATTERNS } from './vitest.config'
+
+describe('Vitest discovery boundaries', () => {
+  it.each(['**/.pnpm-store/**', '**/tmp/**', '**/.worktrees/**', '**/.worktree/**'])(
+    'excludes %s from recursive test discovery',
+    (pattern) => {
+      expect(VITEST_EXCLUDE_PATTERNS).toContain(pattern)
+    }
+  )
+})

--- a/vitest.config.ts
+++ b/vitest.config.ts
@@ -4,6 +4,16 @@ import { defineConfig, configDefaults } from 'vitest/config'
 const testRoot = resolve('.')
 const sharedInstallRoot = basename(dirname(testRoot)) === '.worktree' ? resolve('../..') : testRoot
 
+const VITEST_EXCLUDE_PATTERNS = [
+  ...configDefaults.exclude,
+  'e2e/**',
+  '**/.claude/**',
+  '**/.pnpm-store/**',
+  '**/tmp/**',
+  '**/.worktrees/**',
+  '**/.worktree/**'
+]
+
 // Mirrors the renderer alias from electron.vite.config.ts so tests that mount real component
 // trees (instead of mocking every aliased import) can resolve '@/...' without a build step.
 export default defineConfig({
@@ -38,7 +48,7 @@ export default defineConfig({
     // often stale) suites during local runs. Playwright owns e2e/; Vitest must not execute those specs
     // in its Node workers. .worktree is the project-standard root; .claude remains excluded for
     // existing local checkouts.
-    exclude: [...configDefaults.exclude, 'e2e/**', '**/.claude/**', '**/.worktree/**'],
+    exclude: VITEST_EXCLUDE_PATTERNS,
     // Lift the 5s default: the full coverage run instruments 4400+ tests across parallel workers on a
     // shared CI runner, so a fast fully-mocked test can still be CPU-starved past 5s and time out
     // spuriously. 15s absorbs that contention without masking a genuine hang (real work is far slower).
@@ -84,3 +94,5 @@ export default defineConfig({
     }
   }
 })
+
+export { VITEST_EXCLUDE_PATTERNS }


### PR DESCRIPTION
## Problem

Vitest excluded `.worktree/` only indirectly/incompletely and did not exclude repository-local `.pnpm-store/`, `tmp/`, or legacy `.worktrees/` directories. A full run could rediscover copied or cached tests and execute them more than once.

## Proposed change

- Define an exported list of repository-local discovery exclusions.
- Exclude `.pnpm-store/`, `tmp/`, `.worktrees/`, and `.worktree/` in addition to Vitest defaults and the existing E2E/Claude paths.
- Pin the four local-directory patterns with a configuration regression test.

## Scope and non-goals

- Limited to Vitest test discovery boundaries.
- No production source, data model, renderer UI, or Specialist changes.

## Acceptance criteria and validation

- All four repository-local directories are excluded: covered by `vitest.config.test.ts`.
- `npm run typecheck`: passed.
- `npm run lint`: passed with 0 errors and the existing 23 warnings.
- `npm test`: 631 files passed, 15 skipped; 9,359 tests passed, 184 skipped.

## Review focus

- Whether the patterns match nested repository-local directories without suppressing normal source tests.
- Whether the exported configuration remains aligned with Vitest defaults.
