### PR TITLE
fix(e2e): fail tests on renderer errors

### DIFF
--- a/e2e/fixtures/electron-app.ts
+++ b/e2e/fixtures/electron-app.ts
@@ -4,6 +4,7 @@ import { chmod, mkdir, mkdtemp, readdir, rm, writeFile } from 'node:fs/promises'
 import { tmpdir } from 'node:os'
 import { delimiter, join, resolve } from 'node:path'
 import { _electron as electron, type ElectronApplication, type Page } from 'playwright'
+import { RendererFailureGate } from './renderer-failure-gate'
 
 const APP_ROOT = resolve(process.cwd())
 const FAKE_AGENT_PATH = resolve(APP_ROOT, 'e2e', 'fixtures', 'fake-opencode.mjs')
@@ -100,16 +101,12 @@ const makeTreeWritable = async (root: string): Promise<void> => {
   )
 }
 
-const observeRendererFailures = (page: Page): void => {
-  page.on('console', (message) => {
-    if (message.type() === 'error') console.error(`[renderer console] ${message.text()}`)
-  })
-  page.on('pageerror', (error) => console.error('[renderer pageerror]', error))
-}
-
-const openMainWindow = async (application: ElectronApplication): Promise<Page> => {
+const openMainWindow = async (
+  application: ElectronApplication,
+  rendererFailures: RendererFailureGate
+): Promise<Page> => {
   const page = await application.firstWindow()
-  observeRendererFailures(page)
+  rendererFailures.observe(page)
   await page.waitForLoadState('domcontentloaded')
   return page
 }
@@ -118,6 +115,7 @@ class ElectronAppHarness implements ElectronApp {
   private application: ElectronApplication | undefined
   private currentPage: Page | undefined
   private fakeAgentEnabled = false
+  private readonly rendererFailures = new RendererFailureGate()
 
   private constructor(
     private readonly testRoot: string,
@@ -273,11 +271,12 @@ class ElectronAppHarness implements ElectronApp {
     await this.close().catch(() => undefined)
     await makeTreeWritable(this.testRoot)
     await rm(this.testRoot, { force: true, recursive: true })
+    this.rendererFailures.assertNoFailures()
   }
 
   private async launch(): Promise<void> {
     this.application = await launchOpenScience(this.roots, this.fakeAgentEnabled)
-    this.currentPage = await openMainWindow(this.application)
+    this.currentPage = await openMainWindow(this.application, this.rendererFailures)
   }
 
   private get runningApplication(): ElectronApplication {

--- a/e2e/fixtures/electron-app.ts
+++ b/e2e/fixtures/electron-app.ts
@@ -106,7 +106,7 @@ const openMainWindow = async (
   rendererFailures: RendererFailureGate
 ): Promise<Page> => {
   const page = await application.firstWindow()
-  rendererFailures.observe(page)
+  await rendererFailures.observe(page)
   await page.waitForLoadState('domcontentloaded')
   return page
 }

--- a/e2e/fixtures/renderer-failure-gate.ts
+++ b/e2e/fixtures/renderer-failure-gate.ts
@@ -1,0 +1,25 @@
+import type { ConsoleMessage, Page } from 'playwright'
+
+type ObservablePage = Pick<Page, 'on'>
+
+class RendererFailureGate {
+  private readonly failures: Error[] = []
+
+  observe(page: ObservablePage): void {
+    page.on('console', (message: ConsoleMessage) => {
+      if (message.type() === 'error') {
+        this.failures.push(new Error(`[renderer console] ${message.text()}`))
+      }
+    })
+    page.on('pageerror', (error: Error) => {
+      this.failures.push(new Error(`[renderer pageerror] ${error.message}`, { cause: error }))
+    })
+  }
+
+  assertNoFailures(): void {
+    if (this.failures.length === 0) return
+    throw new AggregateError(this.failures, 'Renderer emitted errors during Electron E2E.')
+  }
+}
+
+export { RendererFailureGate }

--- a/e2e/fixtures/renderer-failure-gate.ts
+++ b/e2e/fixtures/renderer-failure-gate.ts
@@ -1,24 +1,38 @@
 import type { ConsoleMessage, Page } from 'playwright'
 
-type ObservablePage = Pick<Page, 'on'>
+type ObservablePage = Pick<Page, 'consoleMessages' | 'on' | 'pageErrors'>
 
 class RendererFailureGate {
-  private readonly failures: Error[] = []
+  private readonly failures = new Map<string, Error>()
 
-  observe(page: ObservablePage): void {
-    page.on('console', (message: ConsoleMessage) => {
-      if (message.type() === 'error') {
-        this.failures.push(new Error(`[renderer console] ${message.text()}`))
-      }
-    })
-    page.on('pageerror', (error: Error) => {
-      this.failures.push(new Error(`[renderer pageerror] ${error.message}`, { cause: error }))
-    })
+  async observe(page: ObservablePage): Promise<void> {
+    const recordConsole = (message: ConsoleMessage): void => {
+      if (message.type() !== 'error') return
+      const text = message.text()
+      this.failures.set(`console:${text}`, new Error(`[renderer console] ${text}`))
+    }
+    const recordPageError = (error: Error): void => {
+      this.failures.set(
+        `pageerror:${error.message}`,
+        new Error(`[renderer pageerror] ${error.message}`, { cause: error })
+      )
+    }
+
+    // Attach live listeners first, then backfill Playwright's bounded history so errors emitted while
+    // the initial Electron window was navigating cannot escape the gate.
+    page.on('console', recordConsole)
+    page.on('pageerror', recordPageError)
+    const [consoleMessages, pageErrors] = await Promise.all([
+      page.consoleMessages(),
+      page.pageErrors()
+    ])
+    consoleMessages.forEach(recordConsole)
+    pageErrors.forEach(recordPageError)
   }
 
   assertNoFailures(): void {
-    if (this.failures.length === 0) return
-    throw new AggregateError(this.failures, 'Renderer emitted errors during Electron E2E.')
+    if (this.failures.size === 0) return
+    throw new AggregateError(this.failures.values(), 'Renderer emitted errors during Electron E2E.')
   }
 }
 

--- a/test/renderer-failure-gate.test.ts
+++ b/test/renderer-failure-gate.test.ts
@@ -1,0 +1,43 @@
+import { describe, expect, it, vi } from 'vitest'
+
+import { RendererFailureGate } from '../e2e/fixtures/renderer-failure-gate'
+
+type Listener = (...args: never[]) => void
+
+const observablePage = (): {
+  page: { on: ReturnType<typeof vi.fn> }
+  emit: (event: string, value: unknown) => void
+} => {
+  const listeners = new Map<string, Listener>()
+  return {
+    page: {
+      on: vi.fn((event: string, listener: Listener) => {
+        listeners.set(event, listener)
+      })
+    },
+    emit: (event: string, value: unknown) => listeners.get(event)?.(value as never)
+  }
+}
+
+describe('RendererFailureGate', () => {
+  it('fails on renderer console errors and page errors', () => {
+    const gate = new RendererFailureGate()
+    const observed = observablePage()
+    gate.observe(observed.page as never)
+
+    observed.emit('console', { type: () => 'error', text: () => 'broken renderer' })
+    observed.emit('pageerror', new Error('uncaught renderer failure'))
+
+    expect(() => gate.assertNoFailures()).toThrow(/Renderer emitted errors/)
+  })
+
+  it('ignores non-error console messages', () => {
+    const gate = new RendererFailureGate()
+    const observed = observablePage()
+    gate.observe(observed.page as never)
+
+    observed.emit('console', { type: () => 'warning', text: () => 'diagnostic' })
+
+    expect(() => gate.assertNoFailures()).not.toThrow()
+  })
+})

--- a/test/renderer-failure-gate.test.ts
+++ b/test/renderer-failure-gate.test.ts
@@ -5,25 +5,31 @@ import { RendererFailureGate } from '../e2e/fixtures/renderer-failure-gate'
 type Listener = (...args: never[]) => void
 
 const observablePage = (): {
-  page: { on: ReturnType<typeof vi.fn> }
+  page: {
+    consoleMessages: ReturnType<typeof vi.fn>
+    on: ReturnType<typeof vi.fn>
+    pageErrors: ReturnType<typeof vi.fn>
+  }
   emit: (event: string, value: unknown) => void
 } => {
   const listeners = new Map<string, Listener>()
   return {
     page: {
+      consoleMessages: vi.fn(async () => []),
       on: vi.fn((event: string, listener: Listener) => {
         listeners.set(event, listener)
-      })
+      }),
+      pageErrors: vi.fn(async () => [])
     },
     emit: (event: string, value: unknown) => listeners.get(event)?.(value as never)
   }
 }
 
 describe('RendererFailureGate', () => {
-  it('fails on renderer console errors and page errors', () => {
+  it('fails on renderer console errors and page errors', async () => {
     const gate = new RendererFailureGate()
     const observed = observablePage()
-    gate.observe(observed.page as never)
+    await gate.observe(observed.page as never)
 
     observed.emit('console', { type: () => 'error', text: () => 'broken renderer' })
     observed.emit('pageerror', new Error('uncaught renderer failure'))
@@ -31,13 +37,26 @@ describe('RendererFailureGate', () => {
     expect(() => gate.assertNoFailures()).toThrow(/Renderer emitted errors/)
   })
 
-  it('ignores non-error console messages', () => {
+  it('ignores non-error console messages', async () => {
     const gate = new RendererFailureGate()
     const observed = observablePage()
-    gate.observe(observed.page as never)
+    await gate.observe(observed.page as never)
 
     observed.emit('console', { type: () => 'warning', text: () => 'diagnostic' })
 
     expect(() => gate.assertNoFailures()).not.toThrow()
+  })
+
+  it('backfills renderer errors emitted before observation begins', async () => {
+    const gate = new RendererFailureGate()
+    const observed = observablePage()
+    observed.page.consoleMessages.mockResolvedValue([
+      { type: () => 'error', text: () => 'early console failure' }
+    ])
+    observed.page.pageErrors.mockResolvedValue([new Error('early page failure')])
+
+    await gate.observe(observed.page as never)
+
+    expect(() => gate.assertNoFailures()).toThrow(/Renderer emitted errors/)
   })
 })


### PR DESCRIPTION
## Problem

Electron E2E fixtures logged renderer `pageerror` events and `console.error` messages but did not fail the test. Renderer regressions could therefore leave a green E2E run.

## Proposed change

- Add a renderer failure gate that records `pageerror` and error-level console events.
- Attach the gate to every launched or restarted renderer page.
- Assert accumulated failures after application teardown so cleanup still runs.
- Keep warnings and lower console levels non-fatal.

## Scope and non-goals

- Changes only E2E failure semantics and fixture plumbing.
- No production behavior, persisted data, user interaction, or Specialist changes.

## Acceptance criteria and validation

- Error events fail with aggregated diagnostics while warnings remain allowed: covered by `test/renderer-failure-gate.test.ts`.
- `npm run typecheck`: passed.
- `npm run lint`: passed with 0 errors and the existing 23 warnings.
- `npm test`: 631 files passed, 15 skipped; 9,357 tests passed, 184 skipped.
- `npm run build:e2e`: passed.
- `npm run test:e2e`: 12 passed, 2 Windows-only tests skipped.

## Review focus

- Gate attachment across initial launch and relaunch.
- Assertion ordering relative to Electron teardown.
- Diagnostic quality when multiple renderer failures occur.
