### PR TITLE
test(agents): cover sensitive runtime error redaction

### DIFF
--- a/src/main/agents/agents-service.test.ts
+++ b/src/main/agents/agents-service.test.ts
@@ -172,15 +172,25 @@ describe('AgentsService read surface', () => {
   it('surfaces internal failures as sanitized host.agents.<method>: errors', async () => {
     const failing = {
       list: vi.fn(async () => {
-        throw new Error('internal secret: apikey=ABCDEF')
+        throw new Error(
+          'request failed at /Users/alice/private/config.json with Authorization: Bearer TOP-SECRET and apiKey=ABCDEF'
+        )
       })
     }
     const service = new AgentsService({
       profileService: failing as unknown as ProfileService,
       catalog: catalog()
     })
-    await expect(service.read({ op: 'list' })).rejects.toThrow(
-      'host.agents.list: Internal operation failed.'
-    )
+    let message = ''
+    try {
+      await service.read({ op: 'list' })
+    } catch (error) {
+      message = error instanceof Error ? error.message : String(error)
+    }
+
+    expect(message).toBe('host.agents.list: Internal operation failed.')
+    expect(message).not.toContain('TOP-SECRET')
+    expect(message).not.toContain('ABCDEF')
+    expect(message).not.toContain('/Users/alice/private/config.json')
   })
 })


### PR DESCRIPTION
## Problem

The original Agents error path exposed dependency `Error.message` values to the control-plane REPL. #581 has since landed a fail-closed `AgentsSafeError` boundary that maps unknown dependency errors to a fixed public message, but its read-surface regression test did not include representative token, API-key, and filesystem-path material.

## Proposed change

- Strengthen the Agents read-surface regression test with a dependency error containing an authorization token, API key, and local path.
- Assert the exact fixed public error and explicitly verify that none of the sensitive values escape.

## Scope and non-goals

- Test coverage only; the production fix is already provided by #581.
- No production code, user interaction, data model, or Specialist changes.

## Acceptance criteria and validation

- Unknown dependency errors return exactly `host.agents.list: Internal operation failed.` and do not contain the token, API key, or path: covered by `src/main/agents/agents-service.test.ts`.
- `npm run typecheck`: passed.
- `npm run lint`: passed with 0 errors and the existing 23 warnings.
- `npm test`: 630 files passed, 15 skipped; 9,355 tests passed, 184 skipped.

## Review focus

- Whether the regression test exercises the sensitive detail called out by the original finding.
- Whether the branch remains test-only and relies on the fail-closed boundary from #581.

Related: #581
