### PR TITLE
fix(runtime): roll back Electron adapter installation

### DIFF
--- a/src/main/acp/ipc.ts
+++ b/src/main/acp/ipc.ts
@@ -5,7 +5,11 @@ import { join } from 'node:path'
 
 import { app } from 'electron'
 
-import { ipcMainHandle } from '../ipc-handler-registry'
+import {
+  createIpcHandlerInstallationScope,
+  ipcMainHandle,
+  type IpcHandlerInstallation
+} from '../ipc-handler-registry'
 
 import type {
   AcpCancelPromptRequest,
@@ -301,8 +305,7 @@ const createAcpRuntime = ({
   )
 }
 
-// Installs the renderer-callable Electron adapter over an already-constructed ACP coordinator.
-const installAcpIpcHandlers = (
+const registerAcpIpcHandlerSet = (
   runtime: AcpRuntimeCoordinator,
   taskNotifications?: TaskNotificationService
 ): void => {
@@ -379,9 +382,22 @@ const installAcpIpcHandlers = (
   ipcMainHandle('acp:revoke-permission-grant', (_event, request: AcpRevokePermissionGrantRequest) =>
     runtime.revokePermissionGrant(request)
   )
+}
 
-  // Kill the agent child on quit so it never outlives the app as an orphaned process.
-  installAgentShutdownGuard(app, runtime)
+// Installs the renderer-callable Electron adapter over an already-constructed ACP coordinator.
+const installAcpIpcHandlers = (
+  runtime: AcpRuntimeCoordinator,
+  taskNotifications?: TaskNotificationService
+): IpcHandlerInstallation => {
+  const scope = createIpcHandlerInstallationScope()
+  try {
+    registerAcpIpcHandlerSet(runtime, taskNotifications)
+    // Kill the agent child on quit so it never outlives the app as an orphaned process.
+    return scope.complete(installAgentShutdownGuard(app, runtime))
+  } catch (error) {
+    scope.rollback()
+    throw error
+  }
 }
 
 // Compatibility wrapper for isolated callers; application composition uses the two-phase seam above.

--- a/src/main/acp/shutdown-guard.test.ts
+++ b/src/main/acp/shutdown-guard.test.ts
@@ -7,6 +7,7 @@ import { installAgentShutdownGuard } from './shutdown-guard'
 // Captures registered app event handlers so the will-quit teardown can be invoked without Electron.
 const createFakeApp = (): {
   on: App['on']
+  off: App['off']
   emit: (event: string) => void
 } => {
   const handlers = new Map<string, () => void>()
@@ -15,6 +16,9 @@ const createFakeApp = (): {
     on: ((event: string, handler: () => void) => {
       handlers.set(event, handler)
     }) as App['on'],
+    off: ((event: string, handler: () => void) => {
+      if (handlers.get(event) === handler) handlers.delete(event)
+    }) as App['off'],
     emit: (event: string) => handlers.get(event)?.()
   }
 }

--- a/src/main/acp/shutdown-guard.ts
+++ b/src/main/acp/shutdown-guard.ts
@@ -8,10 +8,12 @@ import type { AcpRuntime } from './runtime'
 // asking the user to keep waiting — does not tear the agent down early. The runtime shutdown is
 // synchronous because Electron does not await quit-event handlers.
 export const installAgentShutdownGuard = (
-  app: Pick<App, 'on'>,
+  app: Pick<App, 'on' | 'off'>,
   runtime: Pick<AcpRuntime, 'shutdown'>
-): void => {
-  app.on('will-quit', () => {
+): (() => void) => {
+  const shutdown = (): void => {
     runtime.shutdown()
-  })
+  }
+  app.on('will-quit', shutdown)
+  return () => app.off('will-quit', shutdown)
 }

--- a/src/main/application-runtime.test.ts
+++ b/src/main/application-runtime.test.ts
@@ -220,6 +220,11 @@ describe('application runtime composition', () => {
       (adapters) => {
         expect(adapters).toBe(adapterInterfaces)
         order.push('install')
+        return {
+          uninstall: () => {
+            order.push('uninstall')
+          }
+        }
       }
     )
 
@@ -227,7 +232,7 @@ describe('application runtime composition', () => {
     expect(order).toEqual(['start', 'created', 'install'])
 
     await runtime.dispose()
-    expect(order).toEqual(['start', 'created', 'install', 'dispose'])
+    expect(order).toEqual(['start', 'created', 'install', 'uninstall', 'dispose'])
   })
 })
 

--- a/src/main/application-runtime.ts
+++ b/src/main/application-runtime.ts
@@ -224,11 +224,19 @@ export const composeApplicationRuntimeWithAdapters = async <Interfaces extends o
   createModules: (
     modules: ApplicationModuleBuilder
   ) => Awaitable<Interfaces & { electronAdapters: Adapters }>,
-  installAdapters: (adapters: Adapters) => Awaitable<void>
+  installAdapters: (adapters: Adapters) => Awaitable<void | { uninstall(): Awaitable<void> }>
 ): Promise<ApplicationRuntime<Interfaces>> =>
   composeApplicationRuntime(async (modules) => {
     const built = await createModules(modules)
-    await installAdapters(built.electronAdapters)
+    const installation = await installAdapters(built.electronAdapters)
+    if (installation) {
+      await modules.add(installation, (installed) => ({
+        name: 'electron-runtime-adapters',
+        capability: undefined,
+        rollback: () => installed.uninstall(),
+        dispose: () => installed.uninstall()
+      }))
+    }
     const { electronAdapters: _electronAdapters, ...interfaces } = built
     void _electronAdapters
     return interfaces as Interfaces

--- a/src/main/compute/ipc.ts
+++ b/src/main/compute/ipc.ts
@@ -4,7 +4,11 @@ import { join } from 'node:path'
 
 import { BrowserWindow, shell } from 'electron'
 
-import { ipcMainHandle } from '../ipc-handler-registry'
+import {
+  createIpcHandlerInstallationScope,
+  ipcMainHandle,
+  type IpcHandlerInstallation
+} from '../ipc-handler-registry'
 
 import type {
   ComputeApprovalDecision,
@@ -472,11 +476,12 @@ const createComputeIpcModule = (
   }
 }
 
-// Installs only the renderer-callable Electron adapter over an already-constructed Compute module.
-const installComputeIpcHandlers = ({
+type ComputeIpcAdapter = Pick<ComputeIpcModule, 'handlers' | 'enabledComputeHostsRegistry'>
+
+const registerComputeIpcHandlerSet = ({
   handlers,
   enabledComputeHostsRegistry
-}: Pick<ComputeIpcModule, 'handlers' | 'enabledComputeHostsRegistry'>): void => {
+}: ComputeIpcAdapter): void => {
   ipcMainHandle('compute:list', () => handlers.list())
   ipcMainHandle('compute:get', (_event, providerId: string) => handlers.get(providerId))
   ipcMainHandle('compute:create', (_event, request: CreateComputeHostRequest) =>
@@ -574,6 +579,18 @@ const installComputeIpcHandlers = ({
       enabledComputeHostsRegistry.set(sessionId, providerIds)
     }
   )
+}
+
+// Installs only the renderer-callable Electron adapter over an already-constructed Compute module.
+const installComputeIpcHandlers = (module: ComputeIpcAdapter): IpcHandlerInstallation => {
+  const scope = createIpcHandlerInstallationScope()
+  try {
+    registerComputeIpcHandlerSet(module)
+    return scope.complete()
+  } catch (error) {
+    scope.rollback()
+    throw error
+  }
 }
 
 // Compatibility wrapper for isolated callers; application composition uses the two-phase seam above.

--- a/src/main/ipc-handler-registry.test.ts
+++ b/src/main/ipc-handler-registry.test.ts
@@ -144,4 +144,33 @@ describe('createIpcHandlerRegistry', () => {
     )
     expect(handler).not.toHaveBeenCalled()
   })
+
+  it('uninstalls only the handlers registered by a completed installation scope', () => {
+    const removeHandler = vi.fn()
+    const registry = createIpcHandlerRegistry({ handle: vi.fn(), removeHandler } as never)
+    registry.ipcMainHandle('projects:list', vi.fn())
+
+    const scope = registry.createInstallationScope()
+    registry.ipcMainHandle('test:scoped', vi.fn())
+    const cleanup = vi.fn()
+    const installation = scope.complete(cleanup)
+
+    installation.uninstall()
+    installation.uninstall()
+
+    expect(cleanup).toHaveBeenCalledOnce()
+    expect(removeHandler).toHaveBeenCalledOnce()
+    expect(removeHandler).toHaveBeenCalledWith('test:scoped')
+  })
+
+  it('rolls back handlers registered before an installation failure', () => {
+    const removeHandler = vi.fn()
+    const registry = createIpcHandlerRegistry({ handle: vi.fn(), removeHandler } as never)
+    const scope = registry.createInstallationScope()
+    registry.ipcMainHandle('test:partial', vi.fn())
+
+    scope.rollback()
+
+    expect(removeHandler).toHaveBeenCalledWith('test:partial')
+  })
 })

--- a/src/main/ipc-handler-registry.ts
+++ b/src/main/ipc-handler-registry.ts
@@ -7,6 +7,15 @@ import { callerContextForEvent, hasCallerAuthority, type CallerContext } from '.
 
 type IpcHandler = Parameters<IpcMain['handle']>[1]
 
+type IpcHandlerInstallation = {
+  uninstall(): void
+}
+
+type IpcHandlerInstallationScope = {
+  complete(cleanup?: () => void): IpcHandlerInstallation
+  rollback(): void
+}
+
 class WebIpcSender {
   readonly id: number
   readonly lifecycleClientId: string
@@ -53,10 +62,14 @@ export type WebRpcRouter = {
 type IpcHandlerRegistry = {
   ipcMainHandle: IpcMain['handle']
   webRpc: WebRpcRouter
+  createInstallationScope(): IpcHandlerInstallationScope
 }
 
-const createIpcHandlerRegistry = (target: Pick<IpcMain, 'handle'>): IpcHandlerRegistry => {
+const createIpcHandlerRegistry = (
+  target: Pick<IpcMain, 'handle'> & Partial<Pick<IpcMain, 'removeHandler'>>
+): IpcHandlerRegistry => {
   const webHandlers = new Map<string, IpcHandler>()
+  const registeredChannels = new Set<string>()
   const clients = new Map<string, { id: number; lifecycle: EventEmitter }>()
   let nextSenderId = -1
 
@@ -79,11 +92,50 @@ const createIpcHandlerRegistry = (target: Pick<IpcMain, 'handle'>): IpcHandlerRe
 
   const ipcMainHandle: IpcMain['handle'] = (channel, listener) => {
     target.handle(channel, listener)
+    registeredChannels.add(channel)
     if (isWebRpcChannel(channel)) webHandlers.set(channel, listener)
+  }
+
+  const removeChannels = (channels: Iterable<string>): void => {
+    for (const channel of channels) {
+      target.removeHandler?.(channel)
+      registeredChannels.delete(channel)
+      webHandlers.delete(channel)
+    }
   }
 
   return {
     ipcMainHandle,
+    createInstallationScope: () => {
+      const before = new Set(registeredChannels)
+      let settled = false
+      const addedChannels = (): string[] =>
+        [...registeredChannels].filter((channel) => !before.has(channel))
+      return {
+        complete: (cleanup) => {
+          if (settled) throw new Error('IPC handler installation scope is already settled.')
+          settled = true
+          const channels = addedChannels()
+          let uninstalled = false
+          return {
+            uninstall: () => {
+              if (uninstalled) return
+              uninstalled = true
+              try {
+                cleanup?.()
+              } finally {
+                removeChannels(channels)
+              }
+            }
+          }
+        },
+        rollback: () => {
+          if (settled) return
+          settled = true
+          removeChannels(addedChannels())
+        }
+      }
+    },
     webRpc: {
       invoke: async (channel, callerContext, args) => {
         if (!isWebRpcChannel(channel)) throw new Error(`Unknown Web RPC channel: ${channel}`)
@@ -113,5 +165,14 @@ const defaultRegistry = createIpcHandlerRegistry(ipcMain)
 
 const ipcMainHandle = defaultRegistry.ipcMainHandle
 const webRpc = defaultRegistry.webRpc
+const createIpcHandlerInstallationScope = (): IpcHandlerInstallationScope =>
+  defaultRegistry.createInstallationScope()
 
-export { createIpcHandlerRegistry, ipcMainHandle, isRemotePairingManagerSender, webRpc }
+export {
+  createIpcHandlerInstallationScope,
+  createIpcHandlerRegistry,
+  ipcMainHandle,
+  isRemotePairingManagerSender,
+  webRpc
+}
+export type { IpcHandlerInstallation, IpcHandlerInstallationScope }

--- a/src/main/ipc.ts
+++ b/src/main/ipc.ts
@@ -3,7 +3,7 @@ import { randomUUID } from 'node:crypto'
 
 import { app, BrowserWindow, net, Notification, protocol, webContents } from 'electron'
 
-import { ipcMainHandle } from './ipc-handler-registry'
+import { createIpcHandlerInstallationScope, ipcMainHandle } from './ipc-handler-registry'
 import {
   APPLICATION_MODULE_DISPOSAL_BUDGET_MS,
   composeApplicationRuntimeWithAdapters,
@@ -234,11 +234,20 @@ const createApplicationModules = async (
   const beforeAcpAdapters: NamedElectronSurfaceAdapter[] = []
   const afterAcpAdapters: NamedElectronSurfaceAdapter[] = []
   let surfaceAdapters = beforeComputeAdapters
-  const declareElectronAdapter = (
-    name: string,
-    install: NamedElectronSurfaceAdapter['install']
-  ): void => {
-    surfaceAdapters.push({ name, install })
+  const declareElectronAdapter = (name: string, install: () => void | (() => void)): void => {
+    surfaceAdapters.push({
+      name,
+      install: () => {
+        const scope = createIpcHandlerInstallationScope()
+        try {
+          const cleanup = install()
+          return scope.complete(typeof cleanup === 'function' ? cleanup : undefined)
+        } catch (error) {
+          scope.rollback()
+          throw error
+        }
+      }
+    })
   }
   // One settings service backs both the settings IPC and the ACP spawn config (single source of truth).
   const settingsService = await modules.add(undefined, () => ({
@@ -955,7 +964,7 @@ const createApplicationModules = async (
   )
   declareElectronAdapter('managed-preview', () => {
     registerManagedPreviewIpcHandlers(previewResources)
-    registerManagedPreviewProtocol(previewResources)
+    return registerManagedPreviewProtocol(previewResources)
   })
   declareElectronAdapter('office-preview-runtime', () =>
     registerOfficePreviewRuntimeProtocol(

--- a/src/main/office-preview/office-preview-runtime-protocol.test.ts
+++ b/src/main/office-preview/office-preview-runtime-protocol.test.ts
@@ -181,18 +181,21 @@ describe('Office preview runtime protocol', () => {
   })
 
   it('registers only the dedicated runtime scheme', async () => {
-    const targetProtocol = { handle: vi.fn() }
+    const targetProtocol = { handle: vi.fn(), unhandle: vi.fn() }
     const options = {
       runtimeHtmlPath: '/app/renderer/office-preview.html',
       fetchRuntime: vi.fn()
     }
 
-    const result = runtimeProtocol.registerOfficePreviewRuntimeProtocol(options, targetProtocol)
+    const unregister = runtimeProtocol.registerOfficePreviewRuntimeProtocol(options, targetProtocol)
 
     expect(targetProtocol.handle).toHaveBeenCalledWith(
       runtimeProtocol.OFFICE_PREVIEW_RUNTIME_SCHEME,
       expect.any(Function)
     )
-    expect(result).toBeUndefined()
+    unregister()
+    expect(targetProtocol.unhandle).toHaveBeenCalledWith(
+      runtimeProtocol.OFFICE_PREVIEW_RUNTIME_SCHEME
+    )
   })
 })

--- a/src/main/office-preview/office-preview-runtime-protocol.ts
+++ b/src/main/office-preview/office-preview-runtime-protocol.ts
@@ -55,6 +55,7 @@ type OfficePreviewRuntimeProtocolOptions = {
 
 type OfficePreviewRuntimeProtocolRegistrar = {
   handle: (scheme: string, handler: (request: Request) => Promise<Response>) => void
+  unhandle: (scheme: string) => void
 }
 
 const createOfficePreviewRuntimeUrl = (sessionId: string): string => {
@@ -151,11 +152,12 @@ const createOfficePreviewRuntimeProtocolHandler = (
 const registerOfficePreviewRuntimeProtocol = (
   options: OfficePreviewRuntimeProtocolOptions,
   targetProtocol: OfficePreviewRuntimeProtocolRegistrar
-): void => {
+): (() => void) => {
   targetProtocol.handle(
     OFFICE_PREVIEW_RUNTIME_SCHEME,
     createOfficePreviewRuntimeProtocolHandler(options)
   )
+  return () => targetProtocol.unhandle(OFFICE_PREVIEW_RUNTIME_SCHEME)
 }
 
 export {

--- a/src/main/runtime-electron-wiring.test.ts
+++ b/src/main/runtime-electron-wiring.test.ts
@@ -8,9 +8,11 @@ const { installAcpIpcHandlers, installComputeIpcHandlers, order } = vi.hoisted((
     order,
     installAcpIpcHandlers: vi.fn(() => {
       order.push('acp')
+      return { uninstall: vi.fn() }
     }),
     installComputeIpcHandlers: vi.fn(() => {
       order.push('compute')
+      return { uninstall: vi.fn() }
     })
   }
 })
@@ -39,6 +41,7 @@ describe('production Electron runtime wiring', () => {
           name: 'notifications',
           install: () => {
             order.push('notifications')
+            return { uninstall: vi.fn() }
           }
         }
       ],
@@ -47,6 +50,7 @@ describe('production Electron runtime wiring', () => {
           name: 'connectors',
           install: () => {
             order.push('connectors')
+            return { uninstall: vi.fn() }
           }
         }
       ],
@@ -56,6 +60,7 @@ describe('production Electron runtime wiring', () => {
           name: 'settings',
           install: () => {
             order.push('settings')
+            return { uninstall: vi.fn() }
           }
         }
       ]
@@ -64,5 +69,45 @@ describe('production Electron runtime wiring', () => {
     expect(installComputeIpcHandlers).toHaveBeenCalledWith(compute)
     expect(installAcpIpcHandlers).toHaveBeenCalledWith(runtime, taskNotifications)
     expect(order).toEqual(['notifications', 'compute', 'connectors', 'acp', 'settings'])
+  })
+
+  it('rolls back every installed adapter in reverse order when a later install fails', async () => {
+    const rollbackOrder: string[] = []
+    const compute = { handlers: {}, enabledComputeHostsRegistry: {} } as never
+    const runtime = {} as never
+    const taskNotifications = {} as never
+    installComputeIpcHandlers.mockReturnValueOnce({
+      uninstall: vi.fn(() => {
+        rollbackOrder.push('compute')
+      })
+    })
+
+    await expect(
+      installElectronRuntimeAdapters({
+        compute,
+        beforeCompute: [
+          {
+            name: 'first',
+            install: () => ({
+              uninstall: () => {
+                rollbackOrder.push('first')
+              }
+            })
+          }
+        ],
+        beforeAcp: [
+          {
+            name: 'failing',
+            install: () => {
+              throw new Error('adapter install failed')
+            }
+          }
+        ],
+        acp: { runtime, taskNotifications },
+        afterAcp: []
+      })
+    ).rejects.toThrow('adapter install failed')
+
+    expect(rollbackOrder).toEqual(['compute', 'first'])
   })
 })

--- a/src/main/runtime-electron-wiring.ts
+++ b/src/main/runtime-electron-wiring.ts
@@ -3,9 +3,15 @@ import type { AcpRuntimeCoordinator } from './acp/runtime-coordinator'
 import { installComputeIpcHandlers, type ComputeIpcModule } from './compute/ipc'
 import type { TaskNotificationService } from './notifications/task-notifications'
 
+type Awaitable<T> = T | Promise<T>
+
+export type InstalledElectronSurfaceAdapter = {
+  uninstall(): Awaitable<void>
+}
+
 export type NamedElectronSurfaceAdapter = {
   readonly name: string
-  install(): void | Promise<void>
+  install(): Awaitable<InstalledElectronSurfaceAdapter>
 }
 
 export type ElectronRuntimeAdapterInterfaces = {
@@ -27,10 +33,46 @@ export const installElectronRuntimeAdapters = async ({
   beforeAcp,
   acp,
   afterAcp
-}: ElectronRuntimeAdapterInterfaces): Promise<void> => {
-  for (const surface of beforeCompute) await surface.install()
-  installComputeIpcHandlers(compute)
-  for (const surface of beforeAcp) await surface.install()
-  installAcpIpcHandlers(acp.runtime, acp.taskNotifications)
-  for (const surface of afterAcp) await surface.install()
+}: ElectronRuntimeAdapterInterfaces): Promise<InstalledElectronSurfaceAdapter> => {
+  const installed: Array<{ name: string; installation: InstalledElectronSurfaceAdapter }> = []
+  const install = async (
+    name: string,
+    operation: () => Awaitable<InstalledElectronSurfaceAdapter>
+  ): Promise<void> => {
+    installed.push({ name, installation: await operation() })
+  }
+  const uninstall = async (): Promise<void> => {
+    const failures: unknown[] = []
+    for (const { installation } of [...installed].reverse()) {
+      try {
+        await installation.uninstall()
+      } catch (error) {
+        failures.push(error)
+      }
+    }
+    installed.length = 0
+    if (failures.length > 0) {
+      throw new AggregateError(failures, 'Electron runtime adapter uninstall failed.')
+    }
+  }
+
+  try {
+    for (const surface of beforeCompute) await install(surface.name, () => surface.install())
+    await install('compute', () => installComputeIpcHandlers(compute))
+    for (const surface of beforeAcp) await install(surface.name, () => surface.install())
+    await install('acp', () => installAcpIpcHandlers(acp.runtime, acp.taskNotifications))
+    for (const surface of afterAcp) await install(surface.name, () => surface.install())
+  } catch (error) {
+    try {
+      await uninstall()
+    } catch (rollbackError) {
+      throw new AggregateError(
+        [error, rollbackError],
+        'Electron runtime adapter installation and rollback failed.'
+      )
+    }
+    throw error
+  }
+
+  return { uninstall }
 }


### PR DESCRIPTION
## Problem

Electron surface adapters exposed only `install()`. If a later adapter failed, already-installed IPC handlers, shutdown hooks, or custom protocols remained registered because composition had no uninstall contract or reverse rollback.

## Proposed change

- Make adapter installation return an installed handle with `uninstall()`.
- Track installed adapters and uninstall them in reverse order on later installation failure and normal application disposal.
- Add scoped IPC registration so partially installed handler groups roll back their channels.
- Return cleanup handles from ACP, compute, shutdown-guard, Managed Preview, and Office Preview registration paths, including protocol `unhandle()`.
- Aggregate rollback failures without losing the original installation error.

## Scope and non-goals

- Changes the internal Electron adapter lifecycle contract and composition ownership.
- No persisted data, public renderer API, user interaction, or Specialist changes.

## Acceptance criteria and validation

- Later install failure rolls back prior adapters in reverse order: covered by `src/main/runtime-electron-wiring.test.ts`.
- Normal application disposal owns and invokes adapter cleanup: covered by `src/main/application-runtime.test.ts`.
- Partial IPC registration rolls back registered channels: covered by `src/main/ipc-handler-registry.test.ts` and handler-group tests.
- Managed and Office Preview protocols unregister through `unhandle()`: covered by their protocol tests.
- `npm run typecheck`: passed.
- `npm run lint`: passed with 0 errors and the existing 23 warnings.
- `npm test`: 630 files passed, 15 skipped; 9,358 tests passed, 184 skipped.

## Review focus

- Reverse-order ownership during failed install and normal disposal.
- Idempotence and error aggregation of uninstall paths.
- Completeness of IPC and custom-protocol cleanup coverage.
