### PR TITLE
refactor(settings): extract agent runtime management

### DIFF
--- a/src/main/settings/agent-runtime-manager.test.ts
+++ b/src/main/settings/agent-runtime-manager.test.ts
@@ -1,0 +1,493 @@
+import { chmod, mkdir, mkdtemp, readFile, rm, writeFile } from 'node:fs/promises'
+import { tmpdir } from 'node:os'
+import { dirname, join } from 'node:path'
+
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest'
+
+import type { ClaudeInstallEvent } from '../../shared/settings'
+import type { ConnectorSettingsModule } from './connector-settings'
+import type { ClaudeDetectDeps } from './claude-detect'
+import type { CodexDetectDeps } from './codex-detect'
+import type { OpencodeDetectDeps } from './opencode-detect'
+import type { ProviderPreflightAccess } from './agent-runtime-manager'
+import type { SkillCatalogModule } from './skill-catalog'
+
+vi.mock('electron', () => ({
+  safeStorage: {
+    isEncryptionAvailable: () => true,
+    encryptString: (plaintext: string) => Buffer.from(`cipher:${plaintext}`, 'utf8'),
+    decryptString: (buffer: Buffer) => buffer.toString('utf8').slice('cipher:'.length)
+  },
+  app: { getPath: () => '/home', getAppPath: () => '/no-such-app-root', isPackaged: false }
+}))
+
+const { AgentRuntimeManager } = await import('./agent-runtime-manager')
+const { SettingsRepository } = await import('./repository')
+const { getAppClaudeConfigDir } = await import('./provider-env')
+const { managedClaudeDir } = await import('./managed-claude')
+const { managedOpencodeDir } = await import('./managed-opencode')
+
+type Repository = InstanceType<typeof SettingsRepository>
+type ManagerOptions = ConstructorParameters<typeof AgentRuntimeManager>[0]
+
+type RuntimeInventory = {
+  claude: Map<string, string | undefined>
+  opencode: Map<string, string | undefined>
+  codexAdapter: Map<string, string | undefined>
+  codexNative: Map<string, string | undefined>
+}
+
+const createInventory = (): RuntimeInventory => ({
+  claude: new Map(),
+  opencode: new Map(),
+  codexAdapter: new Map(),
+  codexNative: new Map()
+})
+
+const createClaudeDeps = (inventory: RuntimeInventory): ClaudeDetectDeps => ({
+  env: {},
+  homePath: '/home',
+  platform: 'linux',
+  isExecutable: (path) => Promise.resolve(inventory.claude.has(path)),
+  getVersion: (path) => Promise.resolve(inventory.claude.get(path)),
+  resolveNpmBinDirs: () => Promise.resolve([])
+})
+
+const createOpencodeDeps = (inventory: RuntimeInventory): OpencodeDetectDeps => ({
+  env: {},
+  homePath: '/home',
+  platform: 'linux',
+  isExecutable: (path) => Promise.resolve(inventory.opencode.has(path)),
+  getVersion: (path) => Promise.resolve(inventory.opencode.get(path)),
+  resolveNpmBinDirs: () => Promise.resolve([])
+})
+
+const createCodexDeps = (
+  inventory: RuntimeInventory,
+  managedAdapterPath: string,
+  managedCodexPath: string
+): CodexDetectDeps => ({
+  env: {},
+  homePath: '/home',
+  platform: 'linux',
+  isRunnable: (path) => Promise.resolve(inventory.codexAdapter.has(path)),
+  getAdapterVersion: (path) => Promise.resolve(inventory.codexAdapter.get(path)),
+  getCodexVersion: (path) => Promise.resolve(inventory.codexNative.get(path)),
+  smokeInitialize: () => Promise.resolve(true),
+  resolveNpmBinDirs: () => Promise.resolve([]),
+  managedAdapterPath,
+  managedCodexPath
+})
+
+describe('AgentRuntimeManager', () => {
+  let storageRoot: string
+  let repository: Repository
+  let inventory: RuntimeInventory
+  let managedAdapterPath: string
+  let managedCodexPath: string
+  let provisionClaudeConfig: ReturnType<typeof vi.fn>
+  let manager: InstanceType<typeof AgentRuntimeManager>
+
+  const createManager = (
+    overrides: Partial<ManagerOptions> = {}
+  ): InstanceType<typeof AgentRuntimeManager> => {
+    provisionClaudeConfig = vi.fn().mockResolvedValue(undefined)
+    const skills = {
+      materializeSkills: vi.fn().mockResolvedValue(undefined),
+      provisionClaudeConfig
+    } as unknown as SkillCatalogModule
+    const connectors = {
+      getConnectors: vi.fn().mockResolvedValue(undefined),
+      enabledConnectorIds: vi.fn().mockReturnValue([])
+    } as unknown as ConnectorSettingsModule
+
+    return new AgentRuntimeManager({
+      repository,
+      storageRoot,
+      userClaudeDir: join(storageRoot, 'user-claude'),
+      skills,
+      connectors,
+      allocateSettingsIdSequence: vi.fn().mockReturnValue(1),
+      detectDeps: createClaudeDeps(inventory),
+      opencodeDetectDeps: createOpencodeDeps(inventory),
+      codexDetectDeps: createCodexDeps(inventory, managedAdapterPath, managedCodexPath),
+      allocateOpenCodeUsagePort: () => Promise.resolve(42_424),
+      installManagedClaudeImpl: async ({ installId }) => ({
+        result: { installId, ok: false, error: 'not configured' }
+      }),
+      installManagedOpencodeImpl: async ({ installId }) => ({
+        result: { installId, ok: false, error: 'not configured' }
+      }),
+      installManagedCodexImpl: async ({ installId }) => ({
+        result: { installId, ok: false, error: 'not configured' }
+      }),
+      resolveCodexProxyEnvironment: () => Promise.resolve(undefined),
+      ...overrides
+    })
+  }
+
+  beforeEach(async () => {
+    storageRoot = await mkdtemp(join(tmpdir(), 'open-science-runtime-manager-'))
+    repository = new SettingsRepository(storageRoot)
+    inventory = createInventory()
+    managedAdapterPath = join(storageRoot, 'codex-managed', 'adapter', 'dist', 'index.js')
+    managedCodexPath = join(storageRoot, 'codex-managed', 'codex', 'bin', 'codex')
+    manager = createManager()
+  })
+
+  afterEach(async () => {
+    vi.restoreAllMocks()
+    await rm(storageRoot, { recursive: true, force: true })
+  })
+
+  it('persists successful detection for all three runtime storage shapes', async () => {
+    const claudePath = join(storageRoot, 'detected', 'claude')
+    const opencodePath = join(storageRoot, 'detected', 'opencode')
+    inventory.claude.set(claudePath, '2.1.0')
+    inventory.opencode.set(opencodePath, '1.19.0')
+    inventory.codexAdapter.set(managedAdapterPath, 'codex-acp 1.1.4')
+    inventory.codexNative.set(managedCodexPath, 'codex-cli 0.144.6')
+    manager = createManager({
+      detectDeps: { ...createClaudeDeps(inventory), env: { PATH: dirname(claudePath) } },
+      opencodeDetectDeps: {
+        ...createOpencodeDeps(inventory),
+        env: { PATH: dirname(opencodePath) }
+      }
+    })
+
+    await manager.detectClaude()
+    await manager.detectOpencode()
+    await manager.detectCodex()
+
+    expect(await repository.getSettings()).toMatchObject({
+      claude: { resolvedPath: claudePath, version: '2.1.0' },
+      opencodePath,
+      opencodeVersion: '1.19.0',
+      codex: {
+        resolvedPath: managedAdapterPath,
+        version: '1.1.4',
+        nativePath: managedCodexPath,
+        nativeVersion: '0.144.6'
+      }
+    })
+  })
+
+  it('preserves cached runtime records when live detection misses but their paths still exist', async () => {
+    const claudePath = join(storageRoot, 'cached', 'claude')
+    const opencodePath = join(storageRoot, 'cached', 'opencode')
+    await mkdir(dirname(claudePath), { recursive: true })
+    for (const path of [claudePath, opencodePath, managedAdapterPath]) {
+      await mkdir(dirname(path), { recursive: true })
+      await writeFile(path, '#!/bin/sh\n')
+      await chmod(path, 0o755)
+    }
+    await repository.setClaudeInfo({ resolvedPath: claudePath, version: 'cached-claude' })
+    await repository.setOpencodeInfo(opencodePath, 'cached-opencode')
+    await repository.setCodexInfo({
+      resolvedPath: managedAdapterPath,
+      version: 'cached-adapter',
+      nativePath: managedCodexPath,
+      nativeVersion: 'cached-native'
+    })
+
+    await manager.detectClaude()
+    await manager.detectOpencode()
+    await manager.detectCodex()
+
+    expect(await repository.getSettings()).toMatchObject({
+      claude: { resolvedPath: claudePath, version: 'cached-claude' },
+      opencodePath,
+      opencodeVersion: 'cached-opencode',
+      codex: { resolvedPath: managedAdapterPath, version: 'cached-adapter' }
+    })
+  })
+
+  it('computes selected-runtime preflight through the narrow provider access interface', async () => {
+    const opencodePath = join(storageRoot, 'bin', 'opencode')
+    inventory.opencode.set(opencodePath, '1.19.0')
+    await repository.setOpencodeInfo(opencodePath, '1.19.0')
+    await repository.setAgentFramework('opencode')
+    await repository.upsertProvider({
+      id: 'provider-a',
+      type: 'custom',
+      name: 'Provider A',
+      model: 'model-a',
+      apiEndpoints: ['openai'],
+      keyRef: 'encrypted-key',
+      lastValidatedAt: 10
+    })
+    await repository.setActiveProvider('provider-a', 'model-a')
+    const providers: ProviderPreflightAccess = {
+      resolveProviderApiEndpoints: vi.fn().mockReturnValue(['openai']),
+      resolveActiveModel: vi.fn().mockReturnValue('model-a'),
+      isProviderKeyUsable: vi.fn().mockResolvedValue(true)
+    }
+
+    const result = await manager.getPreflight(providers)
+    const storedProvider = (await repository.getSettings()).providers[0]
+
+    expect(result).toMatchObject({
+      agentFrameworkId: 'opencode',
+      opencodeReady: true,
+      activeProviderReady: true,
+      agentReady: true
+    })
+    expect(providers.resolveProviderApiEndpoints).toHaveBeenCalledWith(storedProvider, 'model-a')
+    expect(providers.isProviderKeyUsable).toHaveBeenCalledWith(storedProvider)
+  })
+
+  it('uses the shared allocator and forwards the same event sink through managed installs', async () => {
+    vi.spyOn(Date, 'now').mockReturnValue(123)
+    const allocateSettingsIdSequence = vi
+      .fn<() => number>()
+      .mockReturnValueOnce(11)
+      .mockReturnValueOnce(12)
+      .mockReturnValueOnce(13)
+    const onEvent = vi.fn<(event: ClaudeInstallEvent) => void>()
+    const installManagedClaudeImpl: NonNullable<ManagerOptions['installManagedClaudeImpl']> = vi.fn(
+      async (options) => {
+        options.onEvent({
+          kind: 'log',
+          installId: options.installId,
+          stream: 'system',
+          chunk: 'claude\n'
+        })
+        return {
+          result: { installId: options.installId, ok: true },
+          resolvedPath: join(storageRoot, 'installed', 'claude'),
+          version: '2.1.0'
+        }
+      }
+    )
+    const installManagedOpencodeImpl: NonNullable<ManagerOptions['installManagedOpencodeImpl']> =
+      vi.fn(async (options) => {
+        options.onEvent({
+          kind: 'log',
+          installId: options.installId,
+          stream: 'system',
+          chunk: 'opencode\n'
+        })
+        return {
+          result: { installId: options.installId, ok: true },
+          resolvedPath: join(storageRoot, 'installed', 'opencode'),
+          version: '1.19.0'
+        }
+      })
+    const installManagedCodexImpl: NonNullable<ManagerOptions['installManagedCodexImpl']> = vi.fn(
+      async (options) => {
+        options.onEvent({
+          kind: 'log',
+          installId: options.installId,
+          stream: 'system',
+          chunk: 'codex\n'
+        })
+        return {
+          result: { installId: options.installId, ok: true },
+          adapterPath: managedAdapterPath,
+          adapterVersion: '1.1.4',
+          codexPath: managedCodexPath,
+          codexVersion: '0.144.6'
+        }
+      }
+    )
+    const claudePath = join(storageRoot, 'installed', 'claude')
+    inventory.claude.set(claudePath, '2.1.0')
+    manager = createManager({
+      allocateSettingsIdSequence,
+      installManagedClaudeImpl,
+      installManagedOpencodeImpl,
+      installManagedCodexImpl
+    })
+
+    const results = await Promise.all([
+      manager.installClaude({ source: 'managed' }, onEvent),
+      manager.installOpencode({ source: 'managed' }, onEvent),
+      manager.installCodex({ source: 'managed' }, onEvent)
+    ])
+
+    expect(results.map((result) => result.installId)).toEqual([
+      'install-123-11',
+      'install-opencode-123-12',
+      'install-codex-123-13'
+    ])
+    expect(allocateSettingsIdSequence).toHaveBeenCalledTimes(3)
+    for (const installer of [
+      installManagedClaudeImpl,
+      installManagedOpencodeImpl,
+      installManagedCodexImpl
+    ]) {
+      expect(installer).toHaveBeenCalledWith(expect.objectContaining({ onEvent }))
+    }
+    expect(onEvent.mock.calls.map(([event]) => event.installId)).toEqual([
+      'install-123-11',
+      'install-opencode-123-12',
+      'install-codex-123-13'
+    ])
+  })
+
+  it('fails a managed Claude install whose installed executable cannot report a version', async () => {
+    vi.spyOn(Date, 'now').mockReturnValue(321)
+    const installedPath = join(storageRoot, 'installed', 'claude')
+    const onEvent = vi.fn<(event: ClaudeInstallEvent) => void>()
+    manager = createManager({
+      installManagedClaudeImpl: async ({ installId }) => ({
+        result: { installId, ok: true },
+        resolvedPath: installedPath,
+        version: 'claimed-version'
+      })
+    })
+
+    const result = await manager.installClaude({ source: 'managed' }, onEvent)
+
+    expect(result).toEqual({
+      installId: 'install-321-1',
+      ok: false,
+      error:
+        'The installed Claude runtime could not report its version. It may be incompatible or incomplete. Delete it and install again.'
+    })
+    expect((await repository.getSettings()).claude).toBeUndefined()
+    expect(onEvent).toHaveBeenCalledWith({
+      kind: 'log',
+      installId: 'install-321-1',
+      stream: 'system',
+      chunk:
+        'The installed Claude runtime could not report its version. It may be incompatible or incomplete. Delete it and install again.\n'
+    })
+  })
+
+  it('guards unmanaged uninstall and selects the first actually runnable fallback', async () => {
+    const unmanagedClaude = join(storageRoot, 'external', 'claude')
+    await repository.setClaudeInfo({ resolvedPath: unmanagedClaude, version: '2.1.0' })
+
+    await expect(manager.uninstallClaude()).resolves.toEqual({ activeBackendAffected: false })
+    expect((await repository.getSettings()).claude?.resolvedPath).toBe(unmanagedClaude)
+
+    const opencodePath = join(managedOpencodeDir(storageRoot), 'opencode')
+    await mkdir(dirname(opencodePath), { recursive: true })
+    await writeFile(opencodePath, '#!/bin/sh\n')
+    await chmod(opencodePath, 0o755)
+    await repository.setOpencodeInfo(opencodePath, '1.19.0')
+    await repository.setCodexInfo({
+      resolvedPath: managedAdapterPath,
+      version: '1.1.4',
+      nativePath: managedCodexPath,
+      nativeVersion: '0.144.6'
+    })
+    await repository.setAgentFramework('opencode')
+    inventory.codexAdapter.set(managedAdapterPath, 'codex-acp 1.1.4')
+    // The stored Claude path exists as a candidate but cannot report a version, so it is not ready.
+    inventory.claude.set(unmanagedClaude, undefined)
+
+    await expect(manager.uninstallOpencode()).resolves.toEqual({ activeBackendAffected: true })
+
+    expect(await repository.getSettings()).toMatchObject({
+      agentFrameworkId: 'codex',
+      claude: { resolvedPath: unmanagedClaude },
+      codex: { resolvedPath: managedAdapterPath }
+    })
+    expect((await repository.getSettings()).opencodePath).toBeUndefined()
+  })
+
+  it('provisions the runtime and preserves the shared versus isolated Claude probe contracts', async () => {
+    const executeClaudeProbe = vi.fn().mockResolvedValue(undefined)
+    manager = createManager({ executeClaudeProbe })
+    const executablePath = join(storageRoot, 'bin', 'claude')
+    await repository.setClaudeInfo({ resolvedPath: executablePath, version: '2.1.0' })
+    const settings = await repository.getSettings()
+
+    await expect(
+      manager.runClaudeSubscriptionProbe(
+        { type: 'claude-shared', model: 'claude-sonnet' },
+        settings
+      )
+    ).resolves.toEqual({ ok: true, category: 'ok' })
+    await expect(
+      manager.runClaudeSubscriptionProbe(
+        { type: 'claude-isolated', model: 'claude-sonnet', key: 'setup-token' },
+        settings
+      )
+    ).resolves.toEqual({ ok: true, category: 'ok' })
+
+    const configDir = getAppClaudeConfigDir(storageRoot)
+    expect(provisionClaudeConfig).toHaveBeenCalledTimes(2)
+    expect(executeClaudeProbe).toHaveBeenNthCalledWith(
+      1,
+      executablePath,
+      expect.objectContaining({ CLAUDE_CONFIG_DIR: join(storageRoot, 'user-claude') }),
+      ['--settings', join(configDir, 'settings.json'), '--plugin-dir', configDir]
+    )
+    expect(executeClaudeProbe).toHaveBeenNthCalledWith(
+      2,
+      executablePath,
+      expect.objectContaining({
+        CLAUDE_CONFIG_DIR: configDir,
+        CLAUDE_CODE_OAUTH_TOKEN: 'setup-token'
+      })
+    )
+  })
+
+  it.each([
+    {
+      name: 'timeout',
+      error: Object.assign(new Error('timed out'), { killed: true }),
+      result: {
+        ok: false,
+        category: 'timeout',
+        message: 'Claude token validation timed out. Try again.'
+      }
+    },
+    {
+      name: 'authentication rejection',
+      error: Object.assign(new Error('request failed'), { stderr: 'HTTP 401 unauthorized' }),
+      result: {
+        ok: false,
+        category: 'auth',
+        message:
+          'Claude rejected the setup token. Run `claude setup-token` again and paste a new token.'
+      }
+    },
+    {
+      name: 'network failure',
+      error: Object.assign(new Error('fetch failed'), { code: 'ENETUNREACH' }),
+      result: {
+        ok: false,
+        category: 'network',
+        message:
+          'Claude could not reach Anthropic while validating the token. Check your network and try again.'
+      }
+    }
+  ])(
+    'classifies an isolated Claude $name without mutating provider state',
+    async ({ error, result }) => {
+      manager = createManager({ executeClaudeProbe: vi.fn().mockRejectedValue(error) })
+      await repository.setClaudeInfo({ resolvedPath: '/bin/claude', version: '2.1.0' })
+
+      await expect(
+        manager.runClaudeSubscriptionProbe(
+          { type: 'claude-isolated', key: 'setup-token' },
+          await repository.getSettings()
+        )
+      ).resolves.toEqual(result)
+      expect((await repository.getSettings()).providers).toEqual([])
+    }
+  )
+
+  it('uses the managed Claude directory shape expected by the uninstall ownership guard', () => {
+    expect(
+      manager.isManagedRuntimePath('claude-code', join(managedClaudeDir(storageRoot), 'claude'))
+    ).toBe(true)
+    expect(
+      manager.isManagedRuntimePath('claude-code', join(storageRoot, 'external', 'claude'))
+    ).toBe(false)
+  })
+
+  it('owns materialization of framework-generated runtime config files', async () => {
+    const configPath = join(storageRoot, 'runtime-config', 'agent.json')
+
+    await manager.materializeAgentConfigFiles([
+      { path: configPath, content: '{"runtime":"managed"}\n' }
+    ])
+
+    await expect(readFile(configPath, 'utf8')).resolves.toBe('{"runtime":"managed"}\n')
+  })
+})

--- a/src/main/settings/agent-runtime-manager.ts
+++ b/src/main/settings/agent-runtime-manager.ts
@@ -25,7 +25,9 @@ import {
   getAgentFramework,
   type AgentFrameworkId
 } from '../agent-framework'
+import type { AgentConfigFile } from '../agent-framework/types'
 import { syncConnectorSkillDocs } from '../connectors/provision'
+import { writeAgentConfigFiles } from './agent-config-files'
 import { createDefaultDetectDeps, detectClaude, type ClaudeDetectDeps } from './claude-detect'
 import {
   createDefaultDetectDeps as createOpencodeDetectDeps,
@@ -594,6 +596,10 @@ export class AgentRuntimeManager {
       join(configRoot, 'skills'),
       this.connectors.enabledConnectorIds(connectors)
     )
+  }
+
+  async materializeAgentConfigFiles(files: AgentConfigFile[] | undefined): Promise<void> {
+    await writeAgentConfigFiles(files)
   }
 
   async provisionClaudeRuntimeConfig(

--- a/src/main/settings/agent-runtime-manager.ts
+++ b/src/main/settings/agent-runtime-manager.ts
@@ -1,0 +1,923 @@
+import { execFile } from 'node:child_process'
+import { constants } from 'node:fs'
+import { access } from 'node:fs/promises'
+import { dirname, join } from 'node:path'
+import { createServer } from 'node:net'
+import { promisify } from 'node:util'
+
+import type {
+  ClaudeDetectResult,
+  ClaudeInstallEvent,
+  ClaudeInstallResult,
+  EnvironmentCheckResult,
+  InstallClaudeRequest,
+  InstallCodexRequest,
+  InstallOpencodeRequest,
+  Preflight,
+  ValidateProviderResult
+} from '../../shared/settings'
+import { isProviderUsableByFramework } from '../../shared/settings'
+import { isModelBridgeSupported } from '../../shared/provider-registry'
+import { CLAUDE_EXECUTABLE_MISSING_MESSAGE } from '../../shared/run-error-classification'
+import { buildAgentSpawnEnv } from '../acp/agent-process'
+import {
+  DEFAULT_AGENT_FRAMEWORK_ID,
+  getAgentFramework,
+  type AgentFrameworkId
+} from '../agent-framework'
+import { syncConnectorSkillDocs } from '../connectors/provision'
+import { createDefaultDetectDeps, detectClaude, type ClaudeDetectDeps } from './claude-detect'
+import {
+  createDefaultDetectDeps as createOpencodeDetectDeps,
+  detectOpencode,
+  type OpencodeDetectDeps
+} from './opencode-detect'
+import {
+  detectCodex,
+  parseVersion as parseCodexVersion,
+  runAcpInitializeSmoke,
+  type CodexDetectDeps
+} from './codex-detect'
+import { detectNpmAvailable, runInstallWithFallback, type InstallTarget } from './claude-install'
+import { OPENCODE_INSTALL_TARGET } from './opencode-install'
+import {
+  DEFAULT_REGISTRIES,
+  installManagedClaude,
+  isManagedClaudePath,
+  managedClaudeDir,
+  uninstallManagedClaude,
+  type InstallManagedClaudeOptions,
+  type ManagedInstallOutcome
+} from './managed-claude'
+import {
+  installManagedOpencode,
+  isManagedOpencodePath,
+  managedOpencodeDir,
+  uninstallManagedOpencode,
+  type InstallManagedOpencodeOptions
+} from './managed-opencode'
+import {
+  ensureManagedCodexContextUsage,
+  installManagedCodex,
+  managedCodexAdapterEntry,
+  managedCodexBinary,
+  uninstallManagedCodex,
+  type InstallManagedCodexOptions,
+  type ManagedCodexInstallOutcome
+} from './managed-codex'
+import { runEnvironmentCheck } from './environment-check'
+import { computePreflight } from './preflight'
+import { isEncryptionAvailable } from './crypto'
+import { augmentedPathEnv } from './shell-path'
+import { buildProviderEnv, getAppClaudeConfigDir, type ResolvedProvider } from './provider-env'
+import { resolveSystemProxyEnvironment, type SystemProxyEnvironment } from './system-proxy'
+import type { ProviderAccountsModule } from './provider-accounts'
+import type { SettingsRepository } from './repository'
+import type { SkillCatalogModule } from './skill-catalog'
+import type { ConnectorSettingsModule } from './connector-settings'
+import type { StoredCodexInfo, StoredSettings } from './types'
+
+const execFileAsync = promisify(execFile)
+const CLAUDE_PROBE_TIMEOUT_MS = 20_000
+const CODEX_INSTALL_TARGET: InstallTarget = {
+  npmPackage: '@agentclientprotocol/codex-acp',
+  // Codex exposes no supported shell installer; InstallCodexRequest cannot select this branch.
+  scriptUnix: ''
+}
+
+const isManagedCodexPath = (adapterPath: string, storageRoot: string): boolean =>
+  adapterPath === managedCodexAdapterEntry(storageRoot)
+
+export type ExecuteClaudeProbe = (
+  executablePath: string,
+  env: NodeJS.ProcessEnv,
+  runtimeArgs?: string[]
+) => Promise<void>
+
+const executeClaudeProbe: ExecuteClaudeProbe = async (executablePath, env, runtimeArgs = []) => {
+  await execFileAsync(executablePath, [...runtimeArgs, '-p', 'ok'], {
+    env,
+    timeout: CLAUDE_PROBE_TIMEOUT_MS,
+    // On Windows the detected claude is a `claude.cmd` shim, which execFile cannot launch without a
+    // shell. Keep the probe on the same platform-specific path as the pre-extraction implementation.
+    shell: process.platform === 'win32',
+    windowsHide: true
+  })
+}
+
+const runCodexAdapterVersion = async (
+  adapterPath: string,
+  fallback: (path: string) => Promise<string | undefined>
+): Promise<string | undefined> => {
+  if (!/\.[cm]?js$/i.test(adapterPath)) return fallback(adapterPath)
+
+  try {
+    const { stdout } = await execFileAsync(process.execPath, [adapterPath, '--version'], {
+      env: { ...process.env, ELECTRON_RUN_AS_NODE: '1', NO_BROWSER: '1' },
+      timeout: 5_000,
+      windowsHide: true
+    })
+    return stdout
+  } catch {
+    return undefined
+  }
+}
+
+const allocateLoopbackPort = async (): Promise<number> => {
+  const server = createServer()
+  try {
+    await new Promise<void>((resolve, reject) => {
+      server.once('error', reject)
+      server.listen(0, '127.0.0.1', resolve)
+    })
+    const address = server.address()
+    if (!address || typeof address === 'string') {
+      throw new Error('Could not reserve an OpenCode usage API port.')
+    }
+    return address.port
+  } finally {
+    if (server.listening) {
+      await new Promise<void>((resolve, reject) =>
+        server.close((error) => (error ? reject(error) : resolve()))
+      )
+    }
+  }
+}
+
+const isTimeoutError = (error: unknown): boolean => {
+  if (typeof error !== 'object' || error === null) return false
+
+  const candidate = error as { killed?: boolean; signal?: string; code?: string }
+  return (
+    candidate.killed === true || candidate.signal === 'SIGTERM' || candidate.code === 'ETIMEDOUT'
+  )
+}
+
+const classifyClaudeProbeFailure = (error: unknown): 'auth' | 'network' | 'unknown' => {
+  if (typeof error !== 'object' || error === null) return 'unknown'
+
+  const candidate = error as {
+    code?: string | number
+    message?: string
+    stderr?: unknown
+    stdout?: unknown
+  }
+  if (candidate.code === 'ENOENT' || candidate.code === 'EACCES') return 'unknown'
+
+  const detail = [candidate.message, candidate.stderr, candidate.stdout]
+    .filter((value): value is string => typeof value === 'string')
+    .join(' ')
+  if (
+    /\b(?:401|403)\b|unauthori[sz]ed|not authenticated|not logged in|authentication failed|invalid api key|api key.*invalid|please run \/login|oauth.*(?:invalid|expired|reject)|(?:invalid|expired|rejected).*token|token.*(?:invalid|expired|rejected)/i.test(
+      detail
+    )
+  ) {
+    return 'auth'
+  }
+  if (
+    /\b(?:ECONNREFUSED|ECONNRESET|ENETUNREACH|EHOSTUNREACH|EAI_AGAIN)\b|network|fetch failed|getaddrinfo/i.test(
+      detail
+    )
+  ) {
+    return 'network'
+  }
+
+  return 'unknown'
+}
+
+export type ProviderPreflightAccess = Pick<
+  ProviderAccountsModule,
+  'isProviderKeyUsable' | 'resolveActiveModel' | 'resolveProviderApiEndpoints'
+>
+
+export type RuntimeUninstallResult = {
+  activeBackendAffected: boolean
+}
+
+export type AgentRuntimeManagerOptions = {
+  repository: SettingsRepository
+  storageRoot: string
+  userClaudeDir: string
+  skills: SkillCatalogModule
+  connectors: ConnectorSettingsModule
+  allocateSettingsIdSequence: () => number
+  detectDeps?: ClaudeDetectDeps
+  opencodeDetectDeps?: OpencodeDetectDeps
+  codexDetectDeps?: CodexDetectDeps
+  allocateOpenCodeUsagePort?: () => Promise<number>
+  executeClaudeProbe?: ExecuteClaudeProbe
+  installManagedClaudeImpl?: (
+    options: InstallManagedClaudeOptions
+  ) => Promise<ManagedInstallOutcome>
+  installManagedOpencodeImpl?: (
+    options: InstallManagedOpencodeOptions
+  ) => Promise<ManagedInstallOutcome>
+  installManagedCodexImpl?: (
+    options: InstallManagedCodexOptions
+  ) => Promise<ManagedCodexInstallOutcome>
+  resolveCodexProxyEnvironment?: () => Promise<SystemProxyEnvironment | undefined>
+}
+
+// Owns host runtime discovery, installation, executable preparation, and runtime-specific filesystem
+// provisioning. Durable records remain serialized by SettingsRepository; live ACP generations and
+// reconnect decisions remain outside this module.
+export class AgentRuntimeManager {
+  private readonly repository: SettingsRepository
+  private readonly storageRoot: string
+  private readonly userClaudeDir: string
+  private readonly skills: SkillCatalogModule
+  private readonly connectors: ConnectorSettingsModule
+  private readonly allocateSettingsIdSequence: () => number
+  private readonly detectDeps: ClaudeDetectDeps
+  private readonly opencodeDetectDeps: OpencodeDetectDeps
+  private readonly codexDetectDeps: CodexDetectDeps
+  private readonly allocateOpenCodeUsagePort: () => Promise<number>
+  private readonly executeClaudeProbe: ExecuteClaudeProbe
+  private readonly installManagedClaudeImpl: (
+    options: InstallManagedClaudeOptions
+  ) => Promise<ManagedInstallOutcome>
+  private readonly installManagedOpencodeImpl: (
+    options: InstallManagedOpencodeOptions
+  ) => Promise<ManagedInstallOutcome>
+  private readonly installManagedCodexImpl: (
+    options: InstallManagedCodexOptions
+  ) => Promise<ManagedCodexInstallOutcome>
+  private readonly resolveProxyEnvironment: () => Promise<SystemProxyEnvironment | undefined>
+
+  constructor(options: AgentRuntimeManagerOptions) {
+    this.repository = options.repository
+    this.storageRoot = options.storageRoot
+    this.userClaudeDir = options.userClaudeDir
+    this.skills = options.skills
+    this.connectors = options.connectors
+    this.allocateSettingsIdSequence = options.allocateSettingsIdSequence
+
+    const baseDetectDeps = options.detectDeps ?? createDefaultDetectDeps()
+    this.detectDeps = {
+      ...baseDetectDeps,
+      extraDirs: [...(baseDetectDeps.extraDirs ?? []), managedClaudeDir(this.storageRoot)]
+    }
+
+    const baseOpencodeDetectDeps = options.opencodeDetectDeps ?? createOpencodeDetectDeps()
+    this.opencodeDetectDeps = {
+      ...baseOpencodeDetectDeps,
+      extraDirs: [...(baseOpencodeDetectDeps.extraDirs ?? []), managedOpencodeDir(this.storageRoot)]
+    }
+
+    const managedAdapterPath = managedCodexAdapterEntry(this.storageRoot)
+    const managedNativePath = managedCodexBinary(this.storageRoot)
+    this.codexDetectDeps = options.codexDetectDeps ?? {
+      env: baseOpencodeDetectDeps.env,
+      homePath: baseOpencodeDetectDeps.homePath,
+      platform: baseOpencodeDetectDeps.platform,
+      isRunnable: baseOpencodeDetectDeps.isExecutable,
+      getAdapterVersion: (path) => runCodexAdapterVersion(path, baseOpencodeDetectDeps.getVersion),
+      getCodexVersion: baseOpencodeDetectDeps.getVersion,
+      smokeInitialize: runAcpInitializeSmoke(baseOpencodeDetectDeps.platform),
+      resolveNpmBinDirs: baseOpencodeDetectDeps.resolveNpmBinDirs,
+      extraDirs: [dirname(managedAdapterPath)],
+      managedAdapterPath,
+      managedCodexPath: managedNativePath
+    }
+
+    this.allocateOpenCodeUsagePort = options.allocateOpenCodeUsagePort ?? allocateLoopbackPort
+    this.executeClaudeProbe = options.executeClaudeProbe ?? executeClaudeProbe
+    this.installManagedClaudeImpl = options.installManagedClaudeImpl ?? installManagedClaude
+    this.installManagedOpencodeImpl = options.installManagedOpencodeImpl ?? installManagedOpencode
+    this.installManagedCodexImpl = options.installManagedCodexImpl ?? installManagedCodex
+    this.resolveProxyEnvironment =
+      options.resolveCodexProxyEnvironment ?? resolveSystemProxyEnvironment
+  }
+
+  async getPreflight(providers: ProviderPreflightAccess): Promise<Preflight> {
+    const settings = await this.repository.getSettings()
+    const claudePathExists = settings.claude?.resolvedPath
+      ? (await this.detectDeps.getVersion(settings.claude.resolvedPath)) !== undefined
+      : false
+    const opencodePathExists = settings.opencodePath
+      ? (await this.opencodeDetectDeps.getVersion(settings.opencodePath)) !== undefined
+      : false
+    const codexPathExists = (await this.probeCodexRuntime(settings.codex)) !== undefined
+
+    const agentFrameworkId = settings.agentFrameworkId ?? DEFAULT_AGENT_FRAMEWORK_ID
+    const framework = getAgentFramework(agentFrameworkId)
+    const activeProvider = settings.activeProviderId
+      ? settings.providers.find((provider) => provider.id === settings.activeProviderId)
+      : undefined
+    const activeEndpoints = activeProvider
+      ? providers.resolveProviderApiEndpoints(activeProvider, activeProvider.model)
+      : undefined
+    const activeProviderCompatible = activeProvider
+      ? isProviderUsableByFramework(
+          { apiEndpoints: activeEndpoints, type: activeProvider.type },
+          framework
+        ) &&
+        (framework.id !== 'codex' ||
+          isModelBridgeSupported(
+            activeProvider,
+            providers.resolveActiveModel(activeProvider, settings.activeModel)
+          ))
+      : false
+    const activeProviderKeyUsable =
+      activeProvider && activeProvider.lastValidatedAt !== undefined
+        ? await providers.isProviderKeyUsable(activeProvider)
+        : false
+
+    return computePreflight({
+      settings,
+      claudePathExists,
+      opencodePathExists,
+      codexPathExists,
+      agentFrameworkId,
+      isProviderKeyUsable: (provider) =>
+        provider.id === activeProvider?.id && activeProviderKeyUsable,
+      activeProviderCompatible
+    })
+  }
+
+  async checkEnvironment(): Promise<EnvironmentCheckResult> {
+    const settings = await this.repository.getSettings()
+    const agentFrameworkId = settings.agentFrameworkId ?? DEFAULT_AGENT_FRAMEWORK_ID
+    const [claudeRuntime, opencodeRuntime, codexRuntime] = await Promise.all([
+      this.resolveClaudeRuntime(settings),
+      this.resolveOpencodeRuntime(settings),
+      this.resolveCodexRuntime(settings)
+    ])
+
+    return runEnvironmentCheck({
+      storageRoot: this.storageRoot,
+      agentFrameworkId,
+      frameworks: [
+        {
+          id: 'claude-code',
+          label: getAgentFramework('claude-code').displayName,
+          runtime: claudeRuntime
+        },
+        {
+          id: 'opencode',
+          label: getAgentFramework('opencode').displayName,
+          runtime: opencodeRuntime
+        },
+        {
+          id: 'codex',
+          label: getAgentFramework('codex').displayName,
+          runtime: codexRuntime
+        }
+      ],
+      encryptionAvailable: isEncryptionAvailable()
+    })
+  }
+
+  async detectClaude(): Promise<ClaudeDetectResult> {
+    const result = await detectClaude(this.detectDeps)
+
+    if (result.found && result.path) {
+      await this.repository.setClaudeInfo({ resolvedPath: result.path, version: result.version })
+    } else {
+      const cached = (await this.repository.getSettings()).claude
+      if (cached?.resolvedPath && !(await this.pathExists(cached.resolvedPath))) {
+        await this.repository.setClaudeInfo({})
+      }
+    }
+
+    return result
+  }
+
+  async detectOpencode(): Promise<void> {
+    const detected = await detectOpencode(this.opencodeDetectDeps)
+
+    if (detected) {
+      await this.repository.setOpencodeInfo(detected.resolvedPath, detected.version)
+    } else {
+      const cached = (await this.repository.getSettings()).opencodePath
+      if (cached && !(await this.pathExists(cached))) await this.repository.clearOpencodeInfo()
+    }
+  }
+
+  async detectCodex(): Promise<void> {
+    const detected = await detectCodex(this.codexDetectDeps)
+
+    if (detected) {
+      await this.repository.setCodexInfo({
+        resolvedPath: detected.adapterPath,
+        version: detected.adapterVersion,
+        nativePath: detected.nativeCodexPath,
+        nativeVersion: detected.nativeCodexVersion
+      })
+    } else {
+      const cached = (await this.repository.getSettings()).codex?.resolvedPath
+      if (cached && !(await this.pathExists(cached))) await this.repository.clearCodexInfo()
+    }
+  }
+
+  async installClaude(
+    request: InstallClaudeRequest,
+    onEvent: (event: ClaudeInstallEvent) => void
+  ): Promise<ClaudeInstallResult> {
+    const installId = `install-${Date.now()}-${this.allocateSettingsIdSequence()}`
+
+    if (request.source === 'managed') {
+      const registries =
+        request.managedRegistry === 'npmmirror'
+          ? [DEFAULT_REGISTRIES[1], DEFAULT_REGISTRIES[0]]
+          : DEFAULT_REGISTRIES
+      const outcome = await this.installManagedClaudeImpl({
+        installId,
+        onEvent,
+        dataRoot: this.storageRoot,
+        registries
+      })
+
+      if (outcome.result.ok && outcome.resolvedPath) {
+        const installedVersion = await this.detectDeps.getVersion(outcome.resolvedPath)
+        if (!installedVersion) {
+          const error =
+            'The installed Claude runtime could not report its version. It may be incompatible or incomplete. Delete it and install again.'
+          onEvent({ kind: 'log', installId, stream: 'system', chunk: `${error}\n` })
+          return { installId, ok: false, error }
+        }
+
+        await this.repository.setClaudeInfo({
+          resolvedPath: outcome.resolvedPath,
+          version: outcome.version
+        })
+      }
+
+      return outcome.result
+    }
+
+    const result = await runInstallWithFallback({ source: request.source, installId, onEvent })
+    if (result.ok) await this.detectClaude()
+    return result
+  }
+
+  async installOpencode(
+    request: InstallOpencodeRequest,
+    onEvent: (event: ClaudeInstallEvent) => void
+  ): Promise<ClaudeInstallResult> {
+    const installId = `install-opencode-${Date.now()}-${this.allocateSettingsIdSequence()}`
+
+    if (request.source === 'managed') {
+      const outcome = await this.installManagedOpencodeImpl({
+        installId,
+        onEvent,
+        dataRoot: this.storageRoot
+      })
+      if (outcome.result.ok && outcome.resolvedPath) {
+        await this.repository.setOpencodeInfo(outcome.resolvedPath, outcome.version)
+      }
+      return outcome.result
+    }
+
+    const result = await runInstallWithFallback({
+      source: request.source,
+      installId,
+      onEvent,
+      installTarget: OPENCODE_INSTALL_TARGET
+    })
+    if (result.ok) await this.detectOpencode()
+    return result
+  }
+
+  async installCodex(
+    request: InstallCodexRequest,
+    onEvent: (event: ClaudeInstallEvent) => void
+  ): Promise<ClaudeInstallResult> {
+    const installId = `install-codex-${Date.now()}-${this.allocateSettingsIdSequence()}`
+
+    if (request.source === 'managed') {
+      const outcome = await this.installManagedCodexImpl({
+        installId,
+        onEvent,
+        dataRoot: this.storageRoot
+      })
+      if (
+        outcome.result.ok &&
+        outcome.adapterPath &&
+        outcome.adapterVersion &&
+        outcome.codexPath &&
+        outcome.codexVersion
+      ) {
+        await this.repository.setCodexInfo({
+          resolvedPath: outcome.adapterPath,
+          version: outcome.adapterVersion,
+          nativePath: outcome.codexPath,
+          nativeVersion: outcome.codexVersion
+        })
+      }
+      return outcome.result
+    }
+
+    const result = await runInstallWithFallback({
+      source: request.source,
+      installId,
+      onEvent,
+      installTarget: CODEX_INSTALL_TARGET
+    })
+    if (result.ok) await this.detectCodex()
+    return result
+  }
+
+  async uninstallClaude(): Promise<RuntimeUninstallResult> {
+    const settings = await this.repository.getSettings()
+    const resolvedPath = settings.claude?.resolvedPath
+    const wasActive = (settings.agentFrameworkId ?? DEFAULT_AGENT_FRAMEWORK_ID) === 'claude-code'
+
+    if (!resolvedPath || !isManagedClaudePath(resolvedPath, this.storageRoot)) {
+      return { activeBackendAffected: false }
+    }
+
+    await uninstallManagedClaude(this.storageRoot)
+    await this.detectClaude()
+    await this.autoSwitchAwayFrom('claude-code')
+    return { activeBackendAffected: wasActive }
+  }
+
+  async uninstallOpencode(): Promise<RuntimeUninstallResult> {
+    const settings = await this.repository.getSettings()
+    const resolvedPath = settings.opencodePath
+    const wasActive = (settings.agentFrameworkId ?? DEFAULT_AGENT_FRAMEWORK_ID) === 'opencode'
+
+    if (!resolvedPath || !isManagedOpencodePath(resolvedPath, this.storageRoot)) {
+      return { activeBackendAffected: false }
+    }
+
+    await uninstallManagedOpencode(this.storageRoot)
+    await this.detectOpencode()
+    await this.autoSwitchAwayFrom('opencode')
+    return { activeBackendAffected: wasActive }
+  }
+
+  async uninstallCodex(): Promise<RuntimeUninstallResult> {
+    const settings = await this.repository.getSettings()
+    const resolvedPath = settings.codex?.resolvedPath
+    const wasActive = (settings.agentFrameworkId ?? DEFAULT_AGENT_FRAMEWORK_ID) === 'codex'
+
+    if (!resolvedPath || !isManagedCodexPath(resolvedPath, this.storageRoot)) {
+      return { activeBackendAffected: false }
+    }
+
+    await uninstallManagedCodex(this.storageRoot)
+    await this.repository.clearCodexInfo()
+    await this.detectCodex()
+    await this.autoSwitchAwayFrom('codex')
+    return { activeBackendAffected: wasActive }
+  }
+
+  isManagedRuntimePath(frameworkId: AgentFrameworkId, path: string): boolean {
+    if (frameworkId === 'claude-code') return isManagedClaudePath(path, this.storageRoot)
+    if (frameworkId === 'opencode') return isManagedOpencodePath(path, this.storageRoot)
+    return isManagedCodexPath(path, this.storageRoot)
+  }
+
+  async isNpmAvailable(): Promise<boolean> {
+    const { available } = await detectNpmAvailable()
+    return available
+  }
+
+  async reserveOpenCodeUsagePort(): Promise<number> {
+    return this.allocateOpenCodeUsagePort()
+  }
+
+  async resolveCodexProxyEnvironment(): Promise<SystemProxyEnvironment | undefined> {
+    return this.resolveProxyEnvironment()
+  }
+
+  async materializeAgentSkills(
+    settings: StoredSettings,
+    configRoot: string,
+    forcedSkillIds: ReadonlySet<string>
+  ): Promise<void> {
+    await this.skills.materializeSkills(configRoot, settings.disabledSkillIds ?? [], forcedSkillIds)
+    const connectors = await this.connectors.getConnectors()
+    await syncConnectorSkillDocs(
+      join(configRoot, 'skills'),
+      this.connectors.enabledConnectorIds(connectors)
+    )
+  }
+
+  async provisionClaudeRuntimeConfig(
+    settings: StoredSettings,
+    forcedSkillIds: ReadonlySet<string> = new Set()
+  ): Promise<string> {
+    const configDir = getAppClaudeConfigDir(this.storageRoot)
+    const disabledSkillIds = (settings.disabledSkillIds ?? []).filter(
+      (id) => !forcedSkillIds.has(id)
+    )
+    await this.skills.provisionClaudeConfig(configDir, disabledSkillIds)
+    const connectors = await this.connectors.getConnectors()
+    await syncConnectorSkillDocs(
+      join(configDir, 'skills'),
+      this.connectors.enabledConnectorIds(connectors)
+    )
+    return configDir
+  }
+
+  async resolveClaudeExecutable(storedPath: string | undefined): Promise<string> {
+    if (storedPath && (await this.pathExists(storedPath))) return storedPath
+
+    const detected = await detectClaude(this.detectDeps)
+    if (detected.found && detected.path) return detected.path
+    throw new Error(CLAUDE_EXECUTABLE_MISSING_MESSAGE)
+  }
+
+  async resolveOpencodeExecutable(storedPath: string | undefined): Promise<string> {
+    if (storedPath && (await this.pathExists(storedPath))) return storedPath
+
+    const detected = await detectOpencode(this.opencodeDetectDeps)
+    if (!detected) {
+      throw new Error(
+        'opencode executable not found. Install opencode or set its path in settings.'
+      )
+    }
+    return detected.resolvedPath
+  }
+
+  async resolveCodexExecutable(
+    storedPath: string | undefined,
+    nativePath: string | undefined
+  ): Promise<string> {
+    void storedPath
+    if (!nativePath) {
+      throw new Error('Codex native executable not found. Re-detect or install Codex in settings.')
+    }
+    const adapterPath =
+      this.codexDetectDeps.managedAdapterPath ?? managedCodexAdapterEntry(this.storageRoot)
+    if (!(await this.pathExists(adapterPath))) {
+      throw new Error('Open Science Codex ACP adapter not found. Install Codex in settings.')
+    }
+
+    await ensureManagedCodexContextUsage(adapterPath)
+    return adapterPath
+  }
+
+  async probeCodexNativeVersion(nativePath: string | undefined): Promise<string | undefined> {
+    if (!nativePath) return undefined
+    const output = await this.codexDetectDeps.getCodexVersion(nativePath).catch(() => undefined)
+    return output ? parseCodexVersion(output) : undefined
+  }
+
+  async runClaudeSubscriptionProbe(
+    provider: ResolvedProvider,
+    settings: StoredSettings
+  ): Promise<ValidateProviderResult> {
+    const executablePath = settings.claude?.resolvedPath
+    if (!executablePath) {
+      return {
+        ok: false,
+        category: 'unknown',
+        message: 'Claude executable is not configured. Complete Claude detection in settings first.'
+      }
+    }
+
+    const appConfigDir = await this.provisionClaudeRuntimeConfig(settings)
+    const envOverrides = buildProviderEnv(provider, {
+      storageRoot: this.storageRoot,
+      claudeExecutablePath: executablePath,
+      userClaudeConfigDir: this.userClaudeDir
+    })
+    const env = buildAgentSpawnEnv(augmentedPathEnv(process.env), envOverrides, executablePath)
+
+    try {
+      if (provider.type === 'claude-shared') {
+        await this.executeClaudeProbe(executablePath, env, [
+          '--settings',
+          join(appConfigDir, 'settings.json'),
+          '--plugin-dir',
+          appConfigDir
+        ])
+      } else {
+        await this.executeClaudeProbe(executablePath, env)
+      }
+      return { ok: true, category: 'ok' }
+    } catch (error) {
+      if (isTimeoutError(error)) {
+        return {
+          ok: false,
+          category: 'timeout',
+          message:
+            provider.type === 'claude-shared'
+              ? 'Claude shared-profile validation timed out. Try again.'
+              : 'Claude token validation timed out. Try again.'
+        }
+      }
+
+      const category = classifyClaudeProbeFailure(error)
+      const messages =
+        provider.type === 'claude-shared'
+          ? {
+              auth: 'Claude rejected the shared profile. Sign in again and retry.',
+              network:
+                'Claude could not reach Anthropic while validating the shared profile. Check your network and try again.',
+              unknown:
+                'Claude could not run the shared-profile validation probe. Re-detect Claude and try again.'
+            }
+          : {
+              auth: 'Claude rejected the setup token. Run `claude setup-token` again and paste a new token.',
+              network:
+                'Claude could not reach Anthropic while validating the token. Check your network and try again.',
+              unknown:
+                'Claude could not run the token validation probe. Re-detect Claude and try again.'
+            }
+      return { ok: false, category, message: messages[category] }
+    }
+  }
+
+  private async resolveClaudeRuntime(settings: StoredSettings): Promise<ClaudeDetectResult> {
+    const cached = settings.claude
+    if (cached?.resolvedPath) {
+      const version = await this.detectDeps.getVersion(cached.resolvedPath)
+      if (version) {
+        if (version !== cached.version) {
+          await this.repository.setClaudeInfo({ resolvedPath: cached.resolvedPath, version })
+        }
+        return { found: true, path: cached.resolvedPath, version }
+      }
+    }
+    return this.detectClaude()
+  }
+
+  private async resolveOpencodeRuntime(settings: StoredSettings): Promise<ClaudeDetectResult> {
+    const cachedPath = settings.opencodePath
+    if (cachedPath) {
+      const version = await this.opencodeDetectDeps.getVersion(cachedPath)
+      if (version) {
+        if (version !== settings.opencodeVersion) {
+          await this.repository.setOpencodeInfo(cachedPath, version)
+        }
+        return { found: true, path: cachedPath, version }
+      }
+    }
+
+    const detected = await detectOpencode(this.opencodeDetectDeps)
+    if (detected) {
+      await this.repository.setOpencodeInfo(detected.resolvedPath, detected.version)
+      return { found: true, path: detected.resolvedPath, version: detected.version }
+    }
+    if (cachedPath && !(await this.pathExists(cachedPath)))
+      await this.repository.clearOpencodeInfo()
+    return { found: false }
+  }
+
+  private async resolveCodexRuntime(settings: StoredSettings): Promise<ClaudeDetectResult> {
+    const cached = settings.codex
+    const cachedVersions = await this.probeCodexRuntime(cached)
+    if (cached?.resolvedPath && cachedVersions) {
+      await this.repository.setCodexInfo({ ...cached, ...cachedVersions })
+      let nativeCliFound = !!cached.nativePath
+      let nativeCliPath = cached.nativePath
+      let nativeCliVersion = cachedVersions.nativeVersion
+
+      if (!cached.nativePath) {
+        nativeCliFound = true
+        const { detectNativeCodex } = await import('./codex-detect')
+        const nativeCodex = await detectNativeCodex(this.codexDetectDeps)
+        if (nativeCodex) {
+          nativeCliPath = nativeCodex.path
+          nativeCliVersion = nativeCodex.version
+        }
+      }
+
+      return {
+        found: true,
+        path: cached.resolvedPath,
+        version: cachedVersions.version,
+        codexComponents: {
+          adapterFound: true,
+          adapterPath: cached.resolvedPath,
+          adapterVersion: cachedVersions.version,
+          nativeCliFound,
+          nativeCliPath,
+          nativeCliVersion
+        }
+      }
+    }
+
+    const detected = await detectCodex(this.codexDetectDeps)
+    if (detected) {
+      await this.repository.setCodexInfo({
+        resolvedPath: detected.adapterPath,
+        version: detected.adapterVersion,
+        nativePath: detected.nativeCodexPath,
+        nativeVersion: detected.nativeCodexVersion
+      })
+      let nativeCliFound = !!detected.nativeCodexPath
+      let nativeCliPath = detected.nativeCodexPath
+      let nativeCliVersion = detected.nativeCodexVersion
+
+      if (!detected.nativeCodexPath) {
+        nativeCliFound = true
+        const { detectNativeCodex } = await import('./codex-detect')
+        const nativeCodex = await detectNativeCodex(this.codexDetectDeps)
+        if (nativeCodex) {
+          nativeCliPath = nativeCodex.path
+          nativeCliVersion = nativeCodex.version
+        }
+      }
+
+      return {
+        found: true,
+        path: detected.adapterPath,
+        version: detected.adapterVersion,
+        codexComponents: {
+          adapterFound: true,
+          adapterPath: detected.adapterPath,
+          adapterVersion: detected.adapterVersion,
+          nativeCliFound,
+          nativeCliPath,
+          nativeCliVersion
+        }
+      }
+    }
+
+    if (cached?.resolvedPath && !(await this.pathExists(cached.resolvedPath))) {
+      await this.repository.clearCodexInfo()
+    }
+
+    const { detectCodexComponents } = await import('./codex-detect')
+    const components = await detectCodexComponents(this.codexDetectDeps)
+    let diagnostic: string | undefined
+    if (components.nativeCliFound && !components.adapterFound) {
+      diagnostic = `Native Codex ${components.nativeCliVersion} is installed at ${components.nativeCliPath}, but the Codex ACP adapter required by Open Science is missing.`
+    } else if (!components.nativeCliFound && components.adapterFound) {
+      diagnostic =
+        components.adapterFailureReason === 'smoke-test-failed'
+          ? `Codex ACP adapter ${components.adapterVersion} is installed at ${components.adapterPath}, but it failed to initialize (native Codex CLI may be missing or incompatible).`
+          : `Codex ACP adapter is installed at ${components.adapterPath}, but version detection failed.`
+    } else if (components.nativeCliFound && components.adapterFound) {
+      if (components.adapterFailureReason === 'smoke-test-failed') {
+        diagnostic = `Both native Codex ${components.nativeCliVersion} and ACP adapter ${components.adapterVersion} are installed, but the adapter failed to initialize with the native CLI.`
+      } else if (components.adapterFailureReason === 'version-probe-failed') {
+        diagnostic = `Native Codex ${components.nativeCliVersion} is installed, and an ACP adapter exists at ${components.adapterPath}, but the adapter's version could not be determined.`
+      }
+    }
+
+    return {
+      found: false,
+      diagnostic,
+      codexComponents: {
+        nativeCliFound: components.nativeCliFound,
+        nativeCliPath: components.nativeCliPath,
+        nativeCliVersion: components.nativeCliVersion,
+        adapterFound: components.adapterFound,
+        adapterPath: components.adapterPath,
+        adapterVersion: components.adapterVersion,
+        adapterFailureReason: components.adapterFailureReason
+      }
+    }
+  }
+
+  private async probeCodexRuntime(
+    codex: StoredCodexInfo | undefined
+  ): Promise<Pick<StoredCodexInfo, 'version' | 'nativeVersion'> | undefined> {
+    if (!codex?.resolvedPath) return undefined
+    const controlledAdapterPath =
+      this.codexDetectDeps.managedAdapterPath ?? managedCodexAdapterEntry(this.storageRoot)
+    if (codex.resolvedPath !== controlledAdapterPath) return undefined
+
+    const adapterOutput = await this.codexDetectDeps.getAdapterVersion(codex.resolvedPath)
+    const version = adapterOutput ? parseCodexVersion(adapterOutput) : undefined
+    if (!version || !codex.nativePath) return undefined
+    const nativeOutput = await this.codexDetectDeps.getCodexVersion(codex.nativePath)
+    const nativeVersion = nativeOutput ? parseCodexVersion(nativeOutput) : undefined
+    return nativeVersion ? { version, nativeVersion } : undefined
+  }
+
+  private async autoSwitchAwayFrom(uninstalled: AgentFrameworkId): Promise<void> {
+    const settings = await this.repository.getSettings()
+    const active = settings.agentFrameworkId ?? DEFAULT_AGENT_FRAMEWORK_ID
+    if (active !== uninstalled) return
+
+    const candidates: AgentFrameworkId[] = ['claude-code', 'opencode', 'codex']
+    for (const candidate of candidates) {
+      if (candidate === uninstalled) continue
+      const path =
+        candidate === 'claude-code'
+          ? settings.claude?.resolvedPath
+          : candidate === 'opencode'
+            ? settings.opencodePath
+            : settings.codex?.resolvedPath
+      if (!path) continue
+
+      const version =
+        candidate === 'claude-code'
+          ? await this.detectDeps.getVersion(path)
+          : candidate === 'opencode'
+            ? await this.opencodeDetectDeps.getVersion(path)
+            : await this.codexDetectDeps.getAdapterVersion(path)
+      if (version) {
+        await this.repository.setAgentFramework(candidate)
+        return
+      }
+    }
+  }
+
+  private async pathExists(path: string): Promise<boolean> {
+    try {
+      await access(path, constants.X_OK)
+      return true
+    } catch {
+      return false
+    }
+  }
+}

--- a/src/main/settings/service.ts
+++ b/src/main/settings/service.ts
@@ -1,11 +1,6 @@
-import { execFile } from 'node:child_process'
-import { access } from 'node:fs/promises'
-import { constants } from 'node:fs'
 import { homedir } from 'node:os'
-import { dirname, join } from 'node:path'
+import { join } from 'node:path'
 import { randomUUID } from 'node:crypto'
-import { createServer } from 'node:net'
-import { promisify } from 'node:util'
 
 import { z } from 'zod'
 
@@ -74,7 +69,6 @@ import type { PackageMirror } from '../../shared/mirror'
 import {
   buildActiveModelIncompatibleMessage,
   CODEX_BRIDGE_UNSUPPORTED_MESSAGE,
-  CLAUDE_EXECUTABLE_MISSING_MESSAGE,
   NO_ACTIVE_PROVIDER_MESSAGE
 } from '../../shared/run-error-classification'
 import type { NotebookLanguage } from '../../shared/notebook'
@@ -87,7 +81,6 @@ import {
   type ResolvedReasoningEffort
 } from '../../shared/reasoning-effort'
 import { resolveStorageRoot } from '../storage-root'
-import { buildAgentSpawnEnv } from '../acp/agent-process'
 import {
   DEFAULT_AGENT_FRAMEWORK_ID,
   getAgentFramework,
@@ -95,63 +88,21 @@ import {
   type AgentFrameworkId,
   type ResolvedAgentBackend
 } from '../agent-framework'
-import { createDefaultDetectDeps, detectClaude, type ClaudeDetectDeps } from './claude-detect'
-import {
-  createDefaultDetectDeps as createOpencodeDetectDeps,
-  detectOpencode,
-  type OpencodeDetectDeps
-} from './opencode-detect'
-import {
-  detectCodex,
-  parseVersion as parseCodexVersion,
-  runAcpInitializeSmoke,
-  type CodexDetectDeps
-} from './codex-detect'
+import type { ClaudeDetectDeps } from './claude-detect'
+import type { OpencodeDetectDeps } from './opencode-detect'
+import type { CodexDetectDeps } from './codex-detect'
 import { openAiCompletionsBase } from './base-url'
-import {
-  installManagedOpencode,
-  isManagedOpencodePath,
-  managedOpencodeDir,
-  uninstallManagedOpencode,
-  type InstallManagedOpencodeOptions
-} from './managed-opencode'
+import type { InstallManagedOpencodeOptions } from './managed-opencode'
 import { opencodeConfigDir } from '../agent-framework/opencode'
 import {
   codexStorageDir,
   codexSubscriptionStorageDir,
   normalizeResponsesBaseUrl
 } from '../agent-framework/codex'
-import { detectNpmAvailable, runInstallWithFallback, type InstallTarget } from './claude-install'
-import { OPENCODE_INSTALL_TARGET } from './opencode-install'
-import {
-  ensureManagedCodexContextUsage,
-  installManagedCodex,
-  managedCodexAdapterEntry,
-  managedCodexBinary,
-  uninstallManagedCodex,
-  type InstallManagedCodexOptions,
-  type ManagedCodexInstallOutcome
-} from './managed-codex'
-import { runEnvironmentCheck } from './environment-check'
-import { writeAgentConfigFiles } from './agent-config-files'
-import {
-  DEFAULT_REGISTRIES,
-  installManagedClaude,
-  isManagedClaudePath,
-  managedClaudeDir,
-  uninstallManagedClaude,
-  type InstallManagedClaudeOptions,
-  type ManagedInstallOutcome
-} from './managed-claude'
+import type { InstallManagedCodexOptions, ManagedCodexInstallOutcome } from './managed-codex'
+import type { InstallManagedClaudeOptions, ManagedInstallOutcome } from './managed-claude'
 import { isEncryptionAvailable } from './crypto'
-import { augmentedPathEnv } from './shell-path'
-import { computePreflight } from './preflight'
-import {
-  buildProviderEnv,
-  getAppClaudeConfigDir,
-  getUserClaudeConfigDir,
-  type ResolvedProvider
-} from './provider-env'
+import { buildProviderEnv, getUserClaudeConfigDir, type ResolvedProvider } from './provider-env'
 import {
   ResponsesBridge,
   type ResponsesBridgeConnection,
@@ -168,9 +119,9 @@ import {
   ProviderAccountsModule,
   requiresNativeResponsesCompatibility
 } from './provider-accounts'
+import { AgentRuntimeManager, type ExecuteClaudeProbe } from './agent-runtime-manager'
 import { CONNECTOR_CATALOG } from '../connectors/catalog'
 import { renderConnectorInstructions } from '../connectors/skill-doc'
-import { syncConnectorSkillDocs } from '../connectors/provision'
 import { SkillRegistry } from '../skills/registry'
 import { UserSkillRepository } from '../skills/user-skill-repository'
 import { requestSkillImportToolSchema } from '../skills/mcp-server'
@@ -187,10 +138,10 @@ import {
   BEGIN_ACTIVITY_GROUP_TOOL_NAME
 } from '../../shared/activity-groups'
 import { REVIEWER_BRIDGE_NAMESPACED_TOOLS } from '../reviewer/bridge-tools'
-import type { StoredConnectors, StoredCodexInfo, StoredSettings } from './types'
+import type { StoredConnectors, StoredSettings } from './types'
 import { ensureCodexAuthHome, type CodexAuthControllerPort } from './codex-auth'
 
-import { resolveSystemProxyEnvironment, type SystemProxyEnvironment } from './system-proxy'
+import type { SystemProxyEnvironment } from './system-proxy'
 import { type ClaudeIsolatedAuthControllerPort } from './claude-isolated-auth'
 import { type ClaudeSharedAuthControllerPort } from './claude-shared-auth'
 
@@ -214,37 +165,6 @@ type NativeResponsesCompatibilityEntry = {
 
 type LeasedResponsesBridgeConnection = ResponsesBridgeConnection & {
   lease: NonNullable<ResolvedAgentBackend['responsesBridgeLease']>
-}
-
-const allocateLoopbackPort = async (): Promise<number> => {
-  const server = createServer()
-  try {
-    await new Promise<void>((resolve, reject) => {
-      server.once('error', reject)
-      server.listen(0, '127.0.0.1', resolve)
-    })
-    const address = server.address()
-    if (!address || typeof address === 'string') {
-      throw new Error('Could not reserve an OpenCode usage API port.')
-    }
-    return address.port
-  } finally {
-    if (server.listening) {
-      await new Promise<void>((resolve, reject) =>
-        server.close((error) => (error ? reject(error) : resolve()))
-      )
-    }
-  }
-}
-
-const execFileAsync = promisify(execFile)
-
-// Hard ceiling for a Claude credential probe so a stuck process can never hang the wizard.
-const CLAUDE_PROBE_TIMEOUT_MS = 20_000
-const CODEX_INSTALL_TARGET: InstallTarget = {
-  npmPackage: '@agentclientprotocol/codex-acp',
-  // Codex exposes no supported shell installer; InstallCodexRequest cannot select this branch.
-  scriptUnix: ''
 }
 
 // Codex exposes local MCP tools as namespaced Responses functions. Chat Completions has no namespace
@@ -310,87 +230,6 @@ const CODEX_BRIDGE_SKILL_IMPORT_TOOLS: ResponsesBridgeNamespacedTool[] = [
     }) as ResponsesBridgeNamespacedTool['parameters']
   }
 ]
-const isManagedCodexPath = (adapterPath: string, storageRoot: string): boolean =>
-  adapterPath === managedCodexAdapterEntry(storageRoot)
-
-type ExecuteClaudeProbe = (
-  executablePath: string,
-  env: NodeJS.ProcessEnv,
-  runtimeArgs?: string[]
-) => Promise<void>
-
-const executeClaudeProbe: ExecuteClaudeProbe = async (executablePath, env, runtimeArgs = []) => {
-  await execFileAsync(executablePath, [...runtimeArgs, '-p', 'ok'], {
-    env,
-    timeout: CLAUDE_PROBE_TIMEOUT_MS,
-    // On Windows the detected claude is a `claude.cmd` shim, which execFile can't launch without a
-    // shell (spawn EINVAL); route the probe through the shell there.
-    shell: process.platform === 'win32',
-    windowsHide: true
-  })
-}
-
-const runCodexAdapterVersion = async (
-  adapterPath: string,
-  fallback: (path: string) => Promise<string | undefined>
-): Promise<string | undefined> => {
-  if (!/\.[cm]?js$/i.test(adapterPath)) return fallback(adapterPath)
-
-  try {
-    const { stdout } = await execFileAsync(process.execPath, [adapterPath, '--version'], {
-      env: { ...process.env, ELECTRON_RUN_AS_NODE: '1', NO_BROWSER: '1' },
-      timeout: 5_000,
-      windowsHide: true
-    })
-    return stdout
-  } catch {
-    return undefined
-  }
-}
-
-// Detects a child-process timeout (SIGTERM kill or ETIMEDOUT) so the probe can report it distinctly.
-const isTimeoutError = (error: unknown): boolean => {
-  if (typeof error !== 'object' || error === null) return false
-
-  const candidate = error as { killed?: boolean; signal?: string; code?: string }
-
-  return (
-    candidate.killed === true || candidate.signal === 'SIGTERM' || candidate.code === 'ETIMEDOUT'
-  )
-}
-
-const classifyClaudeProbeFailure = (error: unknown): 'auth' | 'network' | 'unknown' => {
-  if (typeof error !== 'object' || error === null) return 'unknown'
-
-  const candidate = error as {
-    code?: string | number
-    message?: string
-    stderr?: unknown
-    stdout?: unknown
-  }
-  if (candidate.code === 'ENOENT' || candidate.code === 'EACCES') return 'unknown'
-
-  const detail = [candidate.message, candidate.stderr, candidate.stdout]
-    .filter((value): value is string => typeof value === 'string')
-    .join(' ')
-  if (
-    /\b(?:401|403)\b|unauthori[sz]ed|not authenticated|not logged in|authentication failed|invalid api key|api key.*invalid|please run \/login|oauth.*(?:invalid|expired|reject)|(?:invalid|expired|rejected).*token|token.*(?:invalid|expired|rejected)/i.test(
-      detail
-    )
-  ) {
-    return 'auth'
-  }
-  if (
-    /\b(?:ECONNREFUSED|ECONNRESET|ENETUNREACH|EHOSTUNREACH|EAI_AGAIN)\b|network|fetch failed|getaddrinfo/i.test(
-      detail
-    )
-  ) {
-    return 'network'
-  }
-
-  return 'unknown'
-}
-
 // A spawn configuration the ACP runtime reads at connect time so the active provider's credentials
 // are always current.
 export type AgentSpawnConfig = {
@@ -466,23 +305,9 @@ class SettingsService {
   private readonly skills: SkillCatalogModule
   private readonly connectors: ConnectorSettingsModule
   private readonly providers: ProviderAccountsModule
+  private readonly runtimeManager: AgentRuntimeManager
   private readonly storageRoot: string
-  private readonly detectDeps: ClaudeDetectDeps
-  private readonly opencodeDetectDeps: OpencodeDetectDeps
-  private readonly allocateOpenCodeUsagePort: () => Promise<number>
-  private readonly codexDetectDeps: CodexDetectDeps
   private readonly userClaudeDir: string
-  private readonly executeClaudeProbe: ExecuteClaudeProbe
-  private readonly installManagedClaudeImpl: (
-    options: InstallManagedClaudeOptions
-  ) => Promise<ManagedInstallOutcome>
-  private readonly installManagedOpencodeImpl: (
-    options: InstallManagedOpencodeOptions
-  ) => Promise<ManagedInstallOutcome>
-  private readonly installManagedCodexImpl: (
-    options: InstallManagedCodexOptions
-  ) => Promise<ManagedCodexInstallOutcome>
-  private readonly resolveCodexProxyEnvironment: () => Promise<SystemProxyEnvironment | undefined>
   // A bridge owns mutable per-runtime state (reasoning override, reviewer scopes, and reasoning
   // replay). Track each backend generation separately so an overlapping reconnect cannot mutate the
   // bridge still serving the retiring generation.
@@ -501,36 +326,6 @@ class SettingsService {
     this.preferences = new SettingsPreferencesModule(this.repository)
     this.notebookRuntimeSettings = new NotebookRuntimeSettingsModule(this.repository)
     this.connectors = new ConnectorSettingsModule(this.repository)
-    // Probe the app-managed install dir too, so a managed Claude is re-detected even if the cached
-    // path is ever cleared (e.g. a manual re-detect).
-    const baseDetectDeps = options.detectDeps ?? createDefaultDetectDeps()
-    this.detectDeps = {
-      ...baseDetectDeps,
-      extraDirs: [...(baseDetectDeps.extraDirs ?? []), managedClaudeDir(this.storageRoot)]
-    }
-    // Same rationale for opencode: probe the app-managed dir so a managed opencode is re-detected
-    // (its bare `which/where` PATH lookup would otherwise never see the app-owned install dir).
-    const baseOpencodeDetectDeps = options.opencodeDetectDeps ?? createOpencodeDetectDeps()
-    this.opencodeDetectDeps = {
-      ...baseOpencodeDetectDeps,
-      extraDirs: [...(baseOpencodeDetectDeps.extraDirs ?? []), managedOpencodeDir(this.storageRoot)]
-    }
-    this.allocateOpenCodeUsagePort = options.allocateOpenCodeUsagePort ?? allocateLoopbackPort
-    const managedAdapterPath = managedCodexAdapterEntry(this.storageRoot)
-    const managedNativePath = managedCodexBinary(this.storageRoot)
-    this.codexDetectDeps = options.codexDetectDeps ?? {
-      env: baseOpencodeDetectDeps.env,
-      homePath: baseOpencodeDetectDeps.homePath,
-      platform: baseOpencodeDetectDeps.platform,
-      isRunnable: baseOpencodeDetectDeps.isExecutable,
-      getAdapterVersion: (path) => runCodexAdapterVersion(path, baseOpencodeDetectDeps.getVersion),
-      getCodexVersion: baseOpencodeDetectDeps.getVersion,
-      smokeInitialize: runAcpInitializeSmoke(baseOpencodeDetectDeps.platform),
-      resolveNpmBinDirs: baseOpencodeDetectDeps.resolveNpmBinDirs,
-      extraDirs: [dirname(managedAdapterPath)],
-      managedAdapterPath,
-      managedCodexPath: managedNativePath
-    }
     this.userClaudeDir = options.userClaudeDir ?? getUserClaudeConfigDir()
     const userCodexDir = options.userCodexDir ?? join(homedir(), '.codex')
     this.skills = new SkillCatalogModule({
@@ -542,23 +337,35 @@ class SettingsService {
       skillRegistry: options.skillRegistry ?? new SkillRegistry(),
       userSkills: options.userSkills ?? new UserSkillRepository(this.storageRoot)
     })
-    this.executeClaudeProbe = options.executeClaudeProbe ?? executeClaudeProbe
-    this.installManagedClaudeImpl = options.installManagedClaudeImpl ?? installManagedClaude
-    this.installManagedOpencodeImpl = options.installManagedOpencodeImpl ?? installManagedOpencode
-    this.installManagedCodexImpl = options.installManagedCodexImpl ?? installManagedCodex
-    this.resolveCodexProxyEnvironment =
-      options.resolveCodexProxyEnvironment ?? resolveSystemProxyEnvironment
+    const allocateSettingsIdSequence = (): number => this.nextSettingsIdSequence()
+    this.runtimeManager = new AgentRuntimeManager({
+      repository: this.repository,
+      storageRoot: this.storageRoot,
+      userClaudeDir: this.userClaudeDir,
+      skills: this.skills,
+      connectors: this.connectors,
+      allocateSettingsIdSequence,
+      detectDeps: options.detectDeps,
+      opencodeDetectDeps: options.opencodeDetectDeps,
+      codexDetectDeps: options.codexDetectDeps,
+      allocateOpenCodeUsagePort: options.allocateOpenCodeUsagePort,
+      executeClaudeProbe: options.executeClaudeProbe,
+      installManagedClaudeImpl: options.installManagedClaudeImpl,
+      installManagedOpencodeImpl: options.installManagedOpencodeImpl,
+      installManagedCodexImpl: options.installManagedCodexImpl,
+      resolveCodexProxyEnvironment: options.resolveCodexProxyEnvironment
+    })
     this.providers = new ProviderAccountsModule({
       repository: this.repository,
       storageRoot: this.storageRoot,
       userClaudeDir: this.userClaudeDir,
       userCodexDir,
-      allocateSettingsIdSequence: () => this.nextSettingsIdSequence(),
+      allocateSettingsIdSequence,
       resolveCodexExecutable: (adapterPath, nativePath) =>
-        this.resolveCodexExecutable(adapterPath, nativePath),
-      resolveCodexProxyEnvironment: this.resolveCodexProxyEnvironment,
+        this.runtimeManager.resolveCodexExecutable(adapterPath, nativePath),
+      resolveCodexProxyEnvironment: () => this.runtimeManager.resolveCodexProxyEnvironment(),
       runClaudeSubscriptionProbe: (provider, settings) =>
-        this.runClaudeSubscriptionProbe(provider, settings),
+        this.runtimeManager.runClaudeSubscriptionProbe(provider, settings),
       codexAuth: options.codexAuth,
       claudeIsolatedAuth: options.claudeIsolatedAuth,
       claudeSharedAuth: options.claudeSharedAuth
@@ -585,13 +392,13 @@ class SettingsService {
         nativeVersion: settings.codex?.nativeVersion
       },
       claudeManaged: settings.claude?.resolvedPath
-        ? isManagedClaudePath(settings.claude.resolvedPath, this.storageRoot)
+        ? this.runtimeManager.isManagedRuntimePath('claude-code', settings.claude.resolvedPath)
         : false,
       opencodeManaged: settings.opencodePath
-        ? isManagedOpencodePath(settings.opencodePath, this.storageRoot)
+        ? this.runtimeManager.isManagedRuntimePath('opencode', settings.opencodePath)
         : false,
       codexManaged: settings.codex?.resolvedPath
-        ? isManagedCodexPath(settings.codex.resolvedPath, this.storageRoot)
+        ? this.runtimeManager.isManagedRuntimePath('codex', settings.codex.resolvedPath)
         : false,
       activeProviderId: settings.activeProviderId,
       claudeSubscriptionProviderId: settings.claudeSubscriptionProviderId,
@@ -776,39 +583,12 @@ class SettingsService {
   // Detects the opencode executable and persists its path, mirroring detectClaude. Returns the refreshed
   // snapshot so the settings card reflects the result.
   async detectOpencode(): Promise<SettingsSnapshot> {
-    const detected = await detectOpencode(this.opencodeDetectDeps)
-
-    if (detected) {
-      await this.repository.setOpencodeInfo(detected.resolvedPath, detected.version)
-    } else {
-      // Live probe found nothing. Only forget the stored record when its binary is actually gone from
-      // disk (a real uninstall) — a transient probe miss (e.g. a slow --version, a GUI PATH gap) must
-      // not wipe a still-installed opencode.
-      const cached = (await this.repository.getSettings()).opencodePath
-
-      if (cached && !(await this.pathExists(cached))) {
-        await this.repository.clearOpencodeInfo()
-      }
-    }
-
+    await this.runtimeManager.detectOpencode()
     return this.getSettingsView()
   }
 
   async detectCodex(): Promise<SettingsSnapshot> {
-    const detected = await detectCodex(this.codexDetectDeps)
-
-    if (detected) {
-      await this.repository.setCodexInfo({
-        resolvedPath: detected.adapterPath,
-        version: detected.adapterVersion,
-        nativePath: detected.nativeCodexPath,
-        nativeVersion: detected.nativeCodexVersion
-      })
-    } else {
-      const cached = (await this.repository.getSettings()).codex?.resolvedPath
-      if (cached && !(await this.pathExists(cached))) await this.repository.clearCodexInfo()
-    }
-
+    await this.runtimeManager.detectCodex()
     return this.getSettingsView()
   }
 
@@ -973,324 +753,19 @@ class SettingsService {
   }
   // Computes the two startup gates, re-checking the claude path each call as the design requires.
   async getPreflight(): Promise<Preflight> {
-    const settings = await this.repository.getSettings()
-    // Validate each recorded runtime exactly as the authoritative env check does — by invoking
-    // `--version`, not mere X_OK — so a corrupt-but-executable binary cannot pass preflight and get
-    // auto-selected as "ready" only to be rejected later by the env gate that actually runs it.
-    const claudePathExists = settings.claude?.resolvedPath
-      ? (await this.detectDeps.getVersion(settings.claude.resolvedPath)) !== undefined
-      : false
-    const opencodePathExists = settings.opencodePath
-      ? (await this.opencodeDetectDeps.getVersion(settings.opencodePath)) !== undefined
-      : false
-    const codexPathExists = (await this.probeCodexRuntime(settings.codex)) !== undefined
-
-    const agentFrameworkId = settings.agentFrameworkId ?? DEFAULT_AGENT_FRAMEWORK_ID
-    const framework = getAgentFramework(agentFrameworkId)
-    const activeProvider = settings.activeProviderId
-      ? settings.providers.find((provider) => provider.id === settings.activeProviderId)
-      : undefined
-    // Resolve compatibility here where the vendor registry is available (official endpoints + the
-    // static bridge-support marks) and pass the boolean into the pure preflight computation.
-    const activeEndpoints = activeProvider
-      ? this.providers.resolveProviderApiEndpoints(activeProvider, activeProvider.model)
-      : undefined
-    const activeProviderCompatible = activeProvider
-      ? isProviderUsableByFramework(
-          { apiEndpoints: activeEndpoints, type: activeProvider.type },
-          framework
-        ) &&
-        (framework.id !== 'codex' ||
-          isModelBridgeSupported(
-            activeProvider,
-            this.providers.resolveActiveModel(activeProvider, settings.activeModel)
-          ))
-      : false
-    const activeProviderKeyUsable =
-      activeProvider && activeProvider.lastValidatedAt !== undefined
-        ? await this.providers.isProviderKeyUsable(activeProvider)
-        : false
-
-    return computePreflight({
-      settings,
-      claudePathExists,
-      opencodePathExists,
-      codexPathExists,
-      agentFrameworkId,
-      isProviderKeyUsable: (provider) =>
-        provider.id === activeProvider?.id && activeProviderKeyUsable,
-      activeProviderCompatible
-    })
+    return this.runtimeManager.getPreflight(this.providers)
   }
 
   // Re-runs the complete host inspection on every app launch, for the SELECTED framework's runtime, so
   // a runtime installed outside Open Science between launches is picked up and onboarding can be
   // completed with Claude or OpenCode alone.
   async checkEnvironment(): Promise<EnvironmentCheckResult> {
-    const settings = await this.repository.getSettings()
-    const agentFrameworkId = settings.agentFrameworkId ?? DEFAULT_AGENT_FRAMEWORK_ID
-
-    // Detect every framework's runtime so onboarding can show them side by side; only the selected
-    // one's readiness gates Continue (enforced inside runEnvironmentCheck).
-    const [claudeRuntime, opencodeRuntime, codexRuntime] = await Promise.all([
-      this.resolveClaudeRuntime(settings),
-      this.resolveOpencodeRuntime(settings),
-      this.resolveCodexRuntime(settings)
-    ])
-
-    return runEnvironmentCheck({
-      storageRoot: this.storageRoot,
-      agentFrameworkId,
-      frameworks: [
-        {
-          id: 'claude-code',
-          label: getAgentFramework('claude-code').displayName,
-          runtime: claudeRuntime
-        },
-        {
-          id: 'opencode',
-          label: getAgentFramework('opencode').displayName,
-          runtime: opencodeRuntime
-        },
-        {
-          id: 'codex',
-          label: getAgentFramework('codex').displayName,
-          runtime: codexRuntime
-        }
-      ],
-      encryptionAvailable: this.isEncryptionAvailable()
-    })
-  }
-
-  // Resolves the Claude runtime for the environment check. Prefers a previously recorded runtime that
-  // still runs over this launch's re-detection, keeping a healthy app-managed/manual executable from
-  // being replaced by a PATH entry discovered later; the `--version` probe (not mere file existence)
-  // is the usability signal, so a stale-but-present path is never reported healthy.
-  private async resolveClaudeRuntime(settings: StoredSettings): Promise<ClaudeDetectResult> {
-    const cached = settings.claude
-
-    if (cached?.resolvedPath) {
-      const version = await this.detectDeps.getVersion(cached.resolvedPath)
-
-      if (version) {
-        // Keep the stored version in sync when an in-place update changed it under the same path.
-        if (version !== cached.version) {
-          await this.repository.setClaudeInfo({ resolvedPath: cached.resolvedPath, version })
-        }
-
-        return { found: true, path: cached.resolvedPath, version }
-      }
-    }
-
-    // No healthy recorded runtime: full detection, which persists what it finds.
-    return this.detectClaude()
-  }
-
-  // Same recorded-runtime-first logic for OpenCode, mapped into the shared detect-result shape.
-  private async resolveOpencodeRuntime(settings: StoredSettings): Promise<ClaudeDetectResult> {
-    const cachedPath = settings.opencodePath
-
-    if (cachedPath) {
-      const version = await this.opencodeDetectDeps.getVersion(cachedPath)
-
-      if (version) {
-        if (version !== settings.opencodeVersion) {
-          await this.repository.setOpencodeInfo(cachedPath, version)
-        }
-
-        return { found: true, path: cachedPath, version }
-      }
-    }
-
-    // Probe once (not twice): detect, then persist a hit or clear a truly-gone record — same rule as
-    // detectOpencode — so the card/gates stay accurate without running the full PATH/version probe again.
-    const detected = await detectOpencode(this.opencodeDetectDeps)
-
-    if (detected) {
-      await this.repository.setOpencodeInfo(detected.resolvedPath, detected.version)
-
-      return { found: true, path: detected.resolvedPath, version: detected.version }
-    }
-
-    if (cachedPath && !(await this.pathExists(cachedPath))) {
-      await this.repository.clearOpencodeInfo()
-    }
-
-    return { found: false }
-  }
-
-  private async resolveCodexRuntime(settings: StoredSettings): Promise<ClaudeDetectResult> {
-    const cached = settings.codex
-
-    const cachedVersions = await this.probeCodexRuntime(cached)
-    if (cached?.resolvedPath && cachedVersions) {
-      await this.repository.setCodexInfo({ ...cached, ...cachedVersions })
-
-      // Build codexComponents even for successful detection so onboarding shows separate rows.
-      let nativeCliFound = !!cached.nativePath
-      let nativeCliPath = cached.nativePath
-      let nativeCliVersion = cachedVersions.nativeVersion
-
-      if (!cached.nativePath) {
-        // A non-managed adapter only gets cached after passing the full smoke test, so a working
-        // native CLI exists. Trust that (mirroring the fresh-detect branch) rather than letting a
-        // narrow probe miss it and block Continue. The probe just enriches the path/version.
-        nativeCliFound = true
-        const { detectNativeCodex } = await import('./codex-detect')
-        const nativeCodex = await detectNativeCodex(this.codexDetectDeps)
-        if (nativeCodex) {
-          nativeCliPath = nativeCodex.path
-          nativeCliVersion = nativeCodex.version
-        }
-      }
-
-      const codexComponents: ClaudeDetectResult['codexComponents'] = {
-        adapterFound: true,
-        adapterPath: cached.resolvedPath,
-        adapterVersion: cachedVersions.version,
-        nativeCliFound,
-        nativeCliPath,
-        nativeCliVersion
-      }
-
-      return {
-        found: true,
-        path: cached.resolvedPath,
-        version: cachedVersions.version,
-        codexComponents
-      }
-    }
-
-    const detected = await detectCodex(this.codexDetectDeps)
-    if (detected) {
-      await this.repository.setCodexInfo({
-        resolvedPath: detected.adapterPath,
-        version: detected.adapterVersion,
-        nativePath: detected.nativeCodexPath,
-        nativeVersion: detected.nativeCodexVersion
-      })
-
-      // The controlled adapter is paired with an explicit native executable. Legacy generic
-      // detection can still omit it, so retain the independent display probe for that shape.
-      let nativeCliFound = !!detected.nativeCodexPath
-      let nativeCliPath = detected.nativeCodexPath
-      let nativeCliVersion = detected.nativeCodexVersion
-
-      if (!detected.nativeCodexPath) {
-        // Non-managed adapter passed the ACP smoke test, which proves a working native CLI exists
-        // (the handshake spawns a real session). Trust that: mark native as found even if the
-        // independent probe below can't pinpoint the exact path, so a successful pairing never
-        // blocks Continue. The probe only enriches the display with a concrete path/version.
-        nativeCliFound = true
-        const { detectNativeCodex } = await import('./codex-detect')
-        const nativeCodex = await detectNativeCodex(this.codexDetectDeps)
-        if (nativeCodex) {
-          nativeCliPath = nativeCodex.path
-          nativeCliVersion = nativeCodex.version
-        }
-      }
-
-      const codexComponents: ClaudeDetectResult['codexComponents'] = {
-        adapterFound: true,
-        adapterPath: detected.adapterPath,
-        adapterVersion: detected.adapterVersion,
-        nativeCliFound,
-        nativeCliPath,
-        nativeCliVersion
-      }
-
-      return {
-        found: true,
-        path: detected.adapterPath,
-        version: detected.adapterVersion,
-        codexComponents
-      }
-    }
-
-    // Full detection failed. Perform detailed component-level detection to provide accurate
-    // diagnostic information distinguishing "adapter missing" from "native Codex missing" from
-    // "both present but incompatible".
-    if (cached?.resolvedPath && !(await this.pathExists(cached.resolvedPath))) {
-      await this.repository.clearCodexInfo()
-    }
-
-    const { detectCodexComponents } = await import('./codex-detect')
-    const components = await detectCodexComponents(this.codexDetectDeps)
-
-    // Build diagnostic message based on what was found
-    let diagnostic: string | undefined
-    if (components.nativeCliFound && !components.adapterFound) {
-      diagnostic = `Native Codex ${components.nativeCliVersion} is installed at ${components.nativeCliPath}, but the Codex ACP adapter required by Open Science is missing.`
-    } else if (!components.nativeCliFound && components.adapterFound) {
-      if (components.adapterFailureReason === 'smoke-test-failed') {
-        diagnostic = `Codex ACP adapter ${components.adapterVersion} is installed at ${components.adapterPath}, but it failed to initialize (native Codex CLI may be missing or incompatible).`
-      } else {
-        diagnostic = `Codex ACP adapter is installed at ${components.adapterPath}, but version detection failed.`
-      }
-    } else if (components.nativeCliFound && components.adapterFound) {
-      if (components.adapterFailureReason === 'smoke-test-failed') {
-        diagnostic = `Both native Codex ${components.nativeCliVersion} and ACP adapter ${components.adapterVersion} are installed, but the adapter failed to initialize with the native CLI.`
-      } else if (components.adapterFailureReason === 'version-probe-failed') {
-        diagnostic = `Native Codex ${components.nativeCliVersion} is installed, and an ACP adapter exists at ${components.adapterPath}, but the adapter's version could not be determined.`
-      }
-    }
-
-    return {
-      found: false,
-      diagnostic,
-      codexComponents: {
-        nativeCliFound: components.nativeCliFound,
-        nativeCliPath: components.nativeCliPath,
-        nativeCliVersion: components.nativeCliVersion,
-        adapterFound: components.adapterFound,
-        adapterPath: components.adapterPath,
-        adapterVersion: components.adapterVersion,
-        adapterFailureReason: components.adapterFailureReason
-      }
-    }
-  }
-
-  private async probeCodexRuntime(
-    codex: StoredCodexInfo | undefined
-  ): Promise<Pick<StoredCodexInfo, 'version' | 'nativeVersion'> | undefined> {
-    if (!codex?.resolvedPath) return undefined
-
-    const controlledAdapterPath =
-      this.codexDetectDeps.managedAdapterPath ?? managedCodexAdapterEntry(this.storageRoot)
-    // A cached global adapter is legacy detection data, not an eligible runtime. Force a fresh
-    // controlled-pair detection so its native executable can be retained while the adapter is
-    // replaced with the app-owned one.
-    if (codex.resolvedPath !== controlledAdapterPath) return undefined
-
-    const adapterOutput = await this.codexDetectDeps.getAdapterVersion(codex.resolvedPath)
-    const version = adapterOutput ? parseCodexVersion(adapterOutput) : undefined
-    if (!version) return undefined
-
-    if (!codex.nativePath) return undefined
-
-    const nativeOutput = await this.codexDetectDeps.getCodexVersion(codex.nativePath)
-    const nativeVersion = nativeOutput ? parseCodexVersion(nativeOutput) : undefined
-    return nativeVersion ? { version, nativeVersion } : undefined
+    return this.runtimeManager.checkEnvironment()
   }
 
   // Detects claude and persists the resolved path/version for later spawns.
   async detectClaude(): Promise<ClaudeDetectResult> {
-    const result = await detectClaude(this.detectDeps)
-
-    if (result.found && result.path) {
-      await this.repository.setClaudeInfo({ resolvedPath: result.path, version: result.version })
-    } else {
-      // Live probe missed it. A GUI launch can have a narrower PATH than the installing shell, so only
-      // forget the cached record when the stored binary is actually gone from disk (a real uninstall) —
-      // mirroring checkEnvironment's cached-path resilience so the status surfaces cannot disagree.
-      const cached = (await this.repository.getSettings()).claude
-
-      if (cached?.resolvedPath && !(await this.pathExists(cached.resolvedPath))) {
-        await this.repository.setClaudeInfo({})
-      }
-    }
-
-    return result
+    return this.runtimeManager.detectClaude()
   }
 
   private nextSettingsIdSequence(): number {
@@ -1306,46 +781,7 @@ class SettingsService {
     request: InstallClaudeRequest,
     onEvent: (event: ClaudeInstallEvent) => void
   ): Promise<ClaudeInstallResult> {
-    const installId = `install-${Date.now()}-${this.nextSettingsIdSequence()}`
-
-    if (request.source === 'managed') {
-      const registries =
-        request.managedRegistry === 'npmmirror'
-          ? [DEFAULT_REGISTRIES[1], DEFAULT_REGISTRIES[0]]
-          : DEFAULT_REGISTRIES
-      const outcome = await this.installManagedClaudeImpl({
-        installId,
-        onEvent,
-        dataRoot: this.storageRoot,
-        registries
-      })
-
-      if (outcome.result.ok && outcome.resolvedPath) {
-        const installedVersion = await this.detectDeps.getVersion(outcome.resolvedPath)
-
-        if (!installedVersion) {
-          const error =
-            'The installed Claude runtime could not report its version. It may be incompatible or incomplete. Delete it and install again.'
-          onEvent({ kind: 'log', installId, stream: 'system', chunk: `${error}\n` })
-          return { installId, ok: false, error }
-        }
-
-        await this.repository.setClaudeInfo({
-          resolvedPath: outcome.resolvedPath,
-          version: outcome.version
-        })
-      }
-
-      return outcome.result
-    }
-
-    const result = await runInstallWithFallback({ source: request.source, installId, onEvent })
-
-    if (result.ok) {
-      await this.detectClaude()
-    }
-
-    return result
+    return this.runtimeManager.installClaude(request, onEvent)
   }
 
   // Installs OpenCode from the requested source (app-managed download is the first recommendation, like
@@ -1355,76 +791,14 @@ class SettingsService {
     request: InstallOpencodeRequest,
     onEvent: (event: ClaudeInstallEvent) => void
   ): Promise<ClaudeInstallResult> {
-    const installId = `install-opencode-${Date.now()}-${this.nextSettingsIdSequence()}`
-
-    if (request.source === 'managed') {
-      const outcome = await this.installManagedOpencodeImpl({
-        installId,
-        onEvent,
-        dataRoot: this.storageRoot
-      })
-
-      if (outcome.result.ok && outcome.resolvedPath) {
-        await this.repository.setOpencodeInfo(outcome.resolvedPath, outcome.version)
-      }
-
-      return outcome.result
-    }
-
-    const result = await runInstallWithFallback({
-      source: request.source,
-      installId,
-      onEvent,
-      installTarget: OPENCODE_INSTALL_TARGET
-    })
-
-    if (result.ok) {
-      await this.detectOpencode()
-    }
-
-    return result
+    return this.runtimeManager.installOpencode(request, onEvent)
   }
 
   async installCodex(
     request: InstallCodexRequest,
     onEvent: (event: ClaudeInstallEvent) => void
   ): Promise<ClaudeInstallResult> {
-    const installId = `install-codex-${Date.now()}-${this.nextSettingsIdSequence()}`
-
-    if (request.source === 'managed') {
-      const outcome = await this.installManagedCodexImpl({
-        installId,
-        onEvent,
-        dataRoot: this.storageRoot
-      })
-
-      if (
-        outcome.result.ok &&
-        outcome.adapterPath &&
-        outcome.adapterVersion &&
-        outcome.codexPath &&
-        outcome.codexVersion
-      ) {
-        await this.repository.setCodexInfo({
-          resolvedPath: outcome.adapterPath,
-          version: outcome.adapterVersion,
-          nativePath: outcome.codexPath,
-          nativeVersion: outcome.codexVersion
-        })
-      }
-
-      return outcome.result
-    }
-
-    const result = await runInstallWithFallback({
-      source: request.source,
-      installId,
-      onEvent,
-      installTarget: CODEX_INSTALL_TARGET
-    })
-    if (result.ok) await this.detectCodex()
-
-    return result
+    return this.runtimeManager.installCodex(request, onEvent)
   }
 
   // Uninstalls the app-managed Claude runtime. Only an install we own (a binary inside the app's data
@@ -1434,21 +808,8 @@ class SettingsService {
   // framework, so the IPC layer can reconnect the agent for that case alone — uninstalling the inactive
   // runtime leaves the live agent untouched and needs no reconnect.
   async uninstallClaude(): Promise<UninstallResult> {
-    const settings = await this.repository.getSettings()
-    const resolvedPath = settings.claude?.resolvedPath
-    const wasActive = (settings.agentFrameworkId ?? DEFAULT_AGENT_FRAMEWORK_ID) === 'claude-code'
-
-    if (!resolvedPath || !isManagedClaudePath(resolvedPath, this.storageRoot)) {
-      return { snapshot: await this.getSettingsView(), activeBackendAffected: false }
-    }
-
-    await uninstallManagedClaude(this.storageRoot)
-    // Re-detect resolves what remains: clears the stored path when nothing is left on disk, or adopts a
-    // still-present PATH install if one also exists.
-    await this.detectClaude()
-    await this.autoSwitchAwayFrom('claude-code')
-
-    return { snapshot: await this.getSettingsView(), activeBackendAffected: wasActive }
+    const { activeBackendAffected } = await this.runtimeManager.uninstallClaude()
+    return { snapshot: await this.getSettingsView(), activeBackendAffected }
   }
 
   // Uninstalls the app-managed OpenCode runtime, mirroring uninstallClaude (guard, delete, re-detect,
@@ -1456,76 +817,13 @@ class SettingsService {
   // removed; a PATH/npm opencode is left untouched. `activeBackendAffected` is true only when OpenCode
   // was active.
   async uninstallOpencode(): Promise<UninstallResult> {
-    const settings = await this.repository.getSettings()
-    const resolvedPath = settings.opencodePath
-    const wasActive = (settings.agentFrameworkId ?? DEFAULT_AGENT_FRAMEWORK_ID) === 'opencode'
-
-    if (!resolvedPath || !isManagedOpencodePath(resolvedPath, this.storageRoot)) {
-      return { snapshot: await this.getSettingsView(), activeBackendAffected: false }
-    }
-
-    await uninstallManagedOpencode(this.storageRoot)
-    await this.detectOpencode()
-    await this.autoSwitchAwayFrom('opencode')
-
-    return { snapshot: await this.getSettingsView(), activeBackendAffected: wasActive }
+    const { activeBackendAffected } = await this.runtimeManager.uninstallOpencode()
+    return { snapshot: await this.getSettingsView(), activeBackendAffected }
   }
 
   async uninstallCodex(): Promise<UninstallResult> {
-    const settings = await this.repository.getSettings()
-    const resolvedPath = settings.codex?.resolvedPath
-    const wasActive = (settings.agentFrameworkId ?? DEFAULT_AGENT_FRAMEWORK_ID) === 'codex'
-
-    // Exact app-owned adapter entry is the authority: never delete a PATH/npm global installation.
-    if (!resolvedPath || !isManagedCodexPath(resolvedPath, this.storageRoot)) {
-      return { snapshot: await this.getSettingsView(), activeBackendAffected: false }
-    }
-
-    await uninstallManagedCodex(this.storageRoot)
-    await this.repository.clearCodexInfo()
-    await this.detectCodex()
-    await this.autoSwitchAwayFrom('codex')
-
-    return { snapshot: await this.getSettingsView(), activeBackendAffected: wasActive }
-  }
-
-  // After a framework's runtime is uninstalled, if it was the active backend and the other framework
-  // has a *ready* runtime, switch the active framework to it so sessions keep a working agent. Readiness
-  // means the binary reports `--version`, matching the preflight gate's rule — not merely that a file
-  // exists on disk. An existing-but-broken runtime (can't run, e.g. a corrupt binary) is treated as not
-  // ready, so the selection is left as-is and the preflight gate reports the active framework as not
-  // ready rather than silently parking the user on an unusable agent. No reconnect happens here; the
-  // caller refreshes it.
-  private async autoSwitchAwayFrom(uninstalled: AgentFrameworkId): Promise<void> {
-    const settings = await this.repository.getSettings()
-    const active = settings.agentFrameworkId ?? DEFAULT_AGENT_FRAMEWORK_ID
-
-    if (active !== uninstalled) return
-
-    const candidates: AgentFrameworkId[] = ['claude-code', 'opencode', 'codex']
-
-    for (const candidate of candidates) {
-      if (candidate === uninstalled) continue
-
-      const path =
-        candidate === 'claude-code'
-          ? settings.claude?.resolvedPath
-          : candidate === 'opencode'
-            ? settings.opencodePath
-            : settings.codex?.resolvedPath
-      if (!path) continue
-
-      const version =
-        candidate === 'claude-code'
-          ? await this.detectDeps.getVersion(path)
-          : candidate === 'opencode'
-            ? await this.opencodeDetectDeps.getVersion(path)
-            : await this.codexDetectDeps.getAdapterVersion(path)
-      if (version) {
-        await this.repository.setAgentFramework(candidate)
-        return
-      }
-    }
+    const { activeBackendAffected } = await this.runtimeManager.uninstallCodex()
+    return { snapshot: await this.getSettingsView(), activeBackendAffected }
   }
 
   // Records that first-run onboarding finished so later launches skip the wizard.
@@ -1640,47 +938,6 @@ class SettingsService {
     return this.connectors.getConnectors()
   }
 
-  // Materializes the enabled skill set into opencode's isolated config dir (same skills/<name>/SKILL.md
-  // layout Claude uses), so opencode's native skill tool discovers them. A turn-forced skill overrides
-  // its disabled state, mirroring the Claude provisioning path.
-  private async materializeAgentSkills(
-    settings: StoredSettings,
-    configRoot: string,
-    forcedSkillIds: ReadonlySet<string>
-  ): Promise<void> {
-    await this.skills.materializeSkills(configRoot, settings.disabledSkillIds ?? [], forcedSkillIds)
-
-    // Connector skill docs (which instruct the agent to reach a service ONLY via `host.mcp` from the
-    // notebook kernel) are otherwise synced only into the Claude config dir. Non-Claude frameworks
-    // (Codex, opencode) read skills from their own home, so without this they never get connector
-    // guidance and fall back to ad-hoc calls (e.g. curl). Materialize them into this framework's dir too.
-    const connectors = await this.getConnectors()
-    await syncConnectorSkillDocs(
-      join(configRoot, 'skills'),
-      this.connectors.enabledConnectorIds(connectors)
-    )
-  }
-
-  private async provisionClaudeRuntimeConfig(
-    settings: StoredSettings,
-    forcedSkillIds: ReadonlySet<string> = new Set()
-  ): Promise<string> {
-    const configDir = getAppClaudeConfigDir(this.storageRoot)
-    const disabledSkillIds = (settings.disabledSkillIds ?? []).filter(
-      (id) => !forcedSkillIds.has(id)
-    )
-
-    await this.skills.provisionClaudeConfig(configDir, disabledSkillIds)
-
-    const connectors = await this.getConnectors()
-    await syncConnectorSkillDocs(
-      join(configDir, 'skills'),
-      this.connectors.enabledConnectorIds(connectors)
-    )
-
-    return configDir
-  }
-
   // Lists every bundled connector with enabled / auto-allow state, plus shared NCBI credential state.
   async listConnectors(): Promise<ConnectorsSnapshot> {
     return this.connectors.listConnectors()
@@ -1746,9 +1003,7 @@ class SettingsService {
 
   // Reports whether npm is on PATH so the installer UI can default to/enable the npm source.
   async isNpmAvailable(): Promise<boolean> {
-    const { available } = await detectNpmAvailable()
-
-    return available
+    return this.runtimeManager.isNpmAvailable()
   }
 
   // Returns the bookmark folders for a provider. Used by the remote file browser Go-to dropdown.
@@ -1778,19 +1033,9 @@ class SettingsService {
     forcedSkillIds: ReadonlySet<string>,
     resolvedSelection?: { model?: string }
   ): Promise<AgentSpawnConfig> {
-    let executablePath = settings.claude?.resolvedPath
-
-    // Trust the stored path only if it still exists. A user who uninstalled Claude leaves a stale path
-    // behind; spawning it launches a ghost that dies immediately (surfacing as write EPIPE), so fall
-    // back to a live detect and, if that also finds nothing, fail with a clear, actionable message.
-    if (!executablePath || !(await this.pathExists(executablePath))) {
-      const detected = await detectClaude(this.detectDeps)
-      executablePath = detected.found ? detected.path : undefined
-    }
-
-    if (!executablePath) {
-      throw new Error(CLAUDE_EXECUTABLE_MISSING_MESSAGE)
-    }
+    const executablePath = await this.runtimeManager.resolveClaudeExecutable(
+      settings.claude?.resolvedPath
+    )
 
     const activeProvider = settings.activeProviderId
       ? settings.providers.find((provider) => provider.id === settings.activeProviderId)
@@ -1806,7 +1051,10 @@ class SettingsService {
 
     // Provision the app-owned runtime bundle. Shared auth reads credentials from ~/.claude while the
     // ACP session injects this bundle as a local plugin plus highest-priority settings layer.
-    const appConfigDir = await this.provisionClaudeRuntimeConfig(settings, forcedSkillIds)
+    const appConfigDir = await this.runtimeManager.provisionClaudeRuntimeConfig(
+      settings,
+      forcedSkillIds
+    )
 
     const provider = this.providers.resolveProvider(
       activeProvider,
@@ -1972,17 +1220,17 @@ class SettingsService {
 
     const executablePath =
       framework.id === 'codex'
-        ? await this.resolveCodexExecutable(
+        ? await this.runtimeManager.resolveCodexExecutable(
             settings.codex?.resolvedPath,
             settings.codex?.nativePath
           )
-        : await this.resolveOpencodeExecutable(settings.opencodePath)
+        : await this.runtimeManager.resolveOpencodeExecutable(settings.opencodePath)
     // Model metadata is a compatibility contract with the native Codex binary that is about to
     // start. Probe that exact executable now instead of trusting a cached version from detection;
     // a missing or stale cache must only make us choose the conservative generated catalog.
     const codexNativeVersion =
       framework.id === 'codex'
-        ? await this.probeCodexNativeVersion(settings.codex?.nativePath)
+        ? await this.runtimeManager.probeCodexNativeVersion(settings.codex?.nativePath)
         : undefined
     const provider = this.providers.resolveProvider(activeProvider, effectiveModel)
     if (framework.id === 'codex' && isCodexSubscriptionProvider(provider.type)) {
@@ -2003,7 +1251,7 @@ class SettingsService {
           ? codexSubscriptionStorageDir(this.storageRoot)
           : codexStorageDir(this.storageRoot)
         : opencodeConfigDir(this.storageRoot)
-    await this.materializeAgentSkills(settings, skillsRoot, forcedSkillIds)
+    await this.runtimeManager.materializeAgentSkills(settings, skillsRoot, forcedSkillIds)
     // Chat-only providers require protocol translation. Non-OpenAI native Responses providers keep
     // their protocol, but use a narrow compatibility proxy because Codex emits namespace tools while
     // several compatible APIs accept only flat function names. Official OpenAI and subscriptions
@@ -2036,13 +1284,17 @@ class SettingsService {
         // materialized as on-demand `mcp-*` skills above, avoiding a full catalog in every request.
         instructions: connectorInstructions
       })
-      await writeAgentConfigFiles(modelConfig.configFiles)
+      await this.runtimeManager.materializeAgentConfigFiles(modelConfig.configFiles)
       const opencodeUsagePort =
-        framework.id === 'opencode' ? await this.allocateOpenCodeUsagePort() : undefined
+        framework.id === 'opencode'
+          ? await this.runtimeManager.reserveOpenCodeUsagePort()
+          : undefined
       const opencodeUsagePassword = opencodeUsagePort === undefined ? undefined : randomUUID()
       const usesCodexSystemProxy =
         framework.id === 'codex' && isCodexSubscriptionProvider(provider.type)
-      const proxyEnv = usesCodexSystemProxy ? await this.resolveCodexProxyEnvironment() : undefined
+      const proxyEnv = usesCodexSystemProxy
+        ? await this.runtimeManager.resolveCodexProxyEnvironment()
+        : undefined
 
       // Protocol-driven frameworks apply an explicit model through the ACP session configOption. A Codex
       // subscription with no explicit selection leaves this undefined so Codex uses the account default.
@@ -2210,55 +1462,6 @@ class SettingsService {
     }
   }
 
-  // Locates the opencode binary: an explicitly stored path wins, else a best-effort PATH lookup.
-  private async resolveOpencodeExecutable(storedPath: string | undefined): Promise<string> {
-    // Trust the stored path only if it still exists. A user who uninstalled opencode leaves a stale
-    // path behind; spawning it launches a ghost that dies immediately (surfacing as write EPIPE), so
-    // fall back to a live detect and, if that also finds nothing, fail with a clear, actionable message.
-    if (storedPath && (await this.pathExists(storedPath))) return storedPath
-
-    const detected = await detectOpencode(this.opencodeDetectDeps)
-
-    if (!detected) {
-      throw new Error(
-        'opencode executable not found. Install opencode or set its path in settings.'
-      )
-    }
-
-    return detected.resolvedPath
-  }
-
-  private async resolveCodexExecutable(
-    storedPath: string | undefined,
-    nativePath: string | undefined
-  ): Promise<string> {
-    // `storedPath` can contain a legacy/global codex-acp path. It remains useful as migration
-    // evidence only; runtime and authentication must always cross the app-controlled adapter where
-    // Open Science applies its pinned ACP extensions. A global installation may supply CODEX_PATH,
-    // never the adapter process itself.
-    void storedPath
-    if (!nativePath) {
-      throw new Error('Codex native executable not found. Re-detect or install Codex in settings.')
-    }
-    const adapterPath =
-      this.codexDetectDeps.managedAdapterPath ?? managedCodexAdapterEntry(this.storageRoot)
-    if (!(await this.pathExists(adapterPath))) {
-      throw new Error('Open Science Codex ACP adapter not found. Install Codex in settings.')
-    }
-
-    await ensureManagedCodexContextUsage(adapterPath)
-    return adapterPath
-  }
-
-  private async probeCodexNativeVersion(
-    nativePath: string | undefined
-  ): Promise<string | undefined> {
-    if (!nativePath) return undefined
-
-    const output = await this.codexDetectDeps.getCodexVersion(nativePath).catch(() => undefined)
-    return output ? parseCodexVersion(output) : undefined
-  }
-
   private resolveReasoningEffortFromSettings(
     settings: StoredSettings,
     intent: ReasoningEffort
@@ -2276,85 +1479,6 @@ class SettingsService {
     )
 
     return resolveReasoningEffortValue(intent, profile)
-  }
-
-  private async runClaudeSubscriptionProbe(
-    provider: ResolvedProvider,
-    settings: StoredSettings
-  ): Promise<ValidateProviderResult> {
-    const executablePath = settings.claude?.resolvedPath
-
-    if (!executablePath) {
-      return {
-        ok: false,
-        category: 'unknown',
-        message: 'Claude executable is not configured. Complete Claude detection in settings first.'
-      }
-    }
-
-    const appConfigDir = await this.provisionClaudeRuntimeConfig(settings)
-    const envOverrides = buildProviderEnv(provider, {
-      storageRoot: this.storageRoot,
-      claudeExecutablePath: executablePath,
-      userClaudeConfigDir: this.userClaudeDir
-    })
-    const env = buildAgentSpawnEnv(augmentedPathEnv(process.env), envOverrides, executablePath)
-
-    try {
-      if (provider.type === 'claude-shared') {
-        await this.executeClaudeProbe(executablePath, env, [
-          '--settings',
-          join(appConfigDir, 'settings.json'),
-          '--plugin-dir',
-          appConfigDir
-        ])
-      } else {
-        await this.executeClaudeProbe(executablePath, env)
-      }
-
-      return { ok: true, category: 'ok' }
-    } catch (error) {
-      if (isTimeoutError(error)) {
-        return {
-          ok: false,
-          category: 'timeout',
-          message:
-            provider.type === 'claude-shared'
-              ? 'Claude shared-profile validation timed out. Try again.'
-              : 'Claude token validation timed out. Try again.'
-        }
-      }
-
-      const category = classifyClaudeProbeFailure(error)
-      const messages =
-        provider.type === 'claude-shared'
-          ? {
-              auth: 'Claude rejected the shared profile. Sign in again and retry.',
-              network:
-                'Claude could not reach Anthropic while validating the shared profile. Check your network and try again.',
-              unknown:
-                'Claude could not run the shared-profile validation probe. Re-detect Claude and try again.'
-            }
-          : {
-              auth: 'Claude rejected the setup token. Run `claude setup-token` again and paste a new token.',
-              network:
-                'Claude could not reach Anthropic while validating the token. Check your network and try again.',
-              unknown:
-                'Claude could not run the token validation probe. Re-detect Claude and try again.'
-            }
-
-      return { ok: false, category, message: messages[category] }
-    }
-  }
-
-  private async pathExists(path: string): Promise<boolean> {
-    try {
-      await access(path, constants.X_OK)
-
-      return true
-    } catch {
-      return false
-    }
   }
 }
 


### PR DESCRIPTION
## Problem

`SettingsService` still owned Claude, OpenCode, and Codex discovery, preflight/environment checks, installation, uninstall, executable preparation, runtime configuration writes, and Claude subscription probes. That mixed host runtime filesystem/process state with Provider ownership and backend composition, leaving the façade at 2,365 lines after #583.

## Proposed change

Extract `AgentRuntimeManager` as the single owner of host runtime lifecycle behavior while preserving every `SettingsService` public signature and result shape.

```mermaid
flowchart LR
  Transports["Electron / local Web / remote Web / CLI"] --> Facade["SettingsService façade"]
  Facade --> Providers["ProviderAccountsModule"]
  Facade --> Runtime["AgentRuntimeManager"]
  Runtime --> Repository["SettingsRepository"]
  Runtime --> Host["Runtime filesystem and processes"]
  Facade --> Backend["Backend composition and bridge leases (S5b)"]
```

The provider owner and runtime owner receive the same façade-owned ID allocator callback, preserving the historical provider/install suffix sequence. Runtime config contents and immutable backend choices remain composed by `SettingsService`; their filesystem materialization now goes through the runtime owner.

## Scope and non-goals

- Move runtime detection, preflight/environment inspection, install/uninstall, executable resolution, managed-path checks, runtime skill/Connector materialization, config writes, system proxy lookup, OpenCode port allocation, and Claude subscription probing.
- Keep Provider mutation/auth/cache state in `ProviderAccountsModule`.
- Keep reconnect decisions in the existing IPC workflow and bridge/proxy leases in `SettingsService` for S5b.
- Do not change stored data, public IPC/Web/CLI contracts, renderer behavior, install UX, or install/detect concurrency.
- Preserve current capability asymmetry: Electron and local Web retain runtime management; remote Web remains denied for local mutations; CLI/Task gains no management API.
- Preserve Specialist, Permission, and Compute behavior. This does not add Issue #458 orchestration data, events, or interfaces.

## Acceptance criteria and validation

All listed checks ran after the last material edit and after rebasing onto `origin/main` at `122a300`.

- Runtime ownership and exact detection/install/uninstall/probe behavior -> `npm test -- --run src/main/settings/agent-runtime-manager.test.ts` -> 1 file, 12 tests passed.
- Electron/Web/CLI/IPC/ACP compatibility -> focused 9-file smoke suite -> 395 tests passed; final full suite below also covers these surfaces.
- Shared Provider/install allocator ordering -> `src/main/settings/service.providers.test.ts` in the full suite -> passed.
- Type contracts -> `npm run typecheck` -> passed (node + web).
- Lint -> `npm run lint` -> passed with 0 errors; 23 existing warnings outside this change remain.
- Web transport map -> `npm run check:web-api-map` -> passed.
- Repository behavior -> `npm test` -> 635 files passed / 15 skipped; 9,384 tests passed / 184 skipped.
- Independent Standards and Spec reviews -> 0 findings after the runtime-config ownership correction.

## Review focus

- Runtime filesystem/process behavior has one owner and does not cache `StoredSettings`.
- ProviderAccounts remains the only Provider state owner; its preflight access is passed at call time without a construction cycle.
- Provider and install IDs still share one allocator and retain prefix/timestamp/suffix ordering.
- Managed uninstall remains app-owned-only and returns `activeBackendAffected` without reconnecting directly.
- Cached runtime hardening, Codex controlled adapter/native semantics, forced Specialist skills, Connector docs, and cross-surface capability asymmetry remain exact.

## Residual risk

Existing install/detect concurrency and fallback asymmetries are intentionally unchanged. `AgentRuntimeManager` is still a substantial owner (929 lines), but its cohesive filesystem/process lifecycle is separated from S5b's immutable backend resolution and bridge leases.

Related to #458. Follows #583.
