### PR TITLE
refactor(settings): extract backend resolution

### DIFF
--- a/src/main/acp/runtime.test.ts
+++ b/src/main/acp/runtime.test.ts
@@ -28,7 +28,12 @@ import type { ModelReasoningEffort } from '../../shared/reasoning-effort'
 import { terminateProcessTree } from '../process-tree'
 import { AgentMcpHttpHost } from './mcp-http-host'
 import { SkillRegistry } from '../skills/registry'
-import { claudeCodeFramework, codexFramework, opencodeFramework } from '../agent-framework'
+import {
+  claudeCodeFramework,
+  codexFramework,
+  opencodeFramework,
+  type ResolvedAgentBackend
+} from '../agent-framework'
 import { ArtifactRepository } from '../artifacts/repository'
 import { ArtifactProvenanceRepository } from '../artifacts/provenance-repository'
 import type { ArtifactRunClaim } from '../artifacts/run-registry'
@@ -111,6 +116,22 @@ class FakeAgentProcess extends EventEmitter {
 // Narrows the fake process into the runtime's child process type.
 const asAgentProcess = (process: FakeAgentProcess): ChildProcessWithoutNullStreams =>
   process as unknown as ChildProcessWithoutNullStreams
+
+const createBackendLeaseHarness = (): {
+  release: () => Promise<void>
+  lease: NonNullable<ResolvedAgentBackend['responsesBridgeLease']>
+} => {
+  const release = vi.fn(async () => undefined)
+  return {
+    release,
+    lease: {
+      selectSkills: vi.fn(async () => []),
+      registerReviewerSession: vi.fn(),
+      unregisterReviewerSession: vi.fn(() => false),
+      release
+    }
+  }
+}
 
 // Creates a manually controlled promise for ordering async protocol steps.
 const createDeferred = <Value = void>(): {
@@ -1156,11 +1177,17 @@ describe('ACP runtime session management', () => {
 
   it('kills the agent process synchronously on shutdown so it cannot outlive the app', async () => {
     const process = new FakeAgentProcess()
+    const { lease, release } = createBackendLeaseHarness()
     startFakeAgent(process, ['shutdown-session'])
     const runtime = new AcpRuntime({
       appVersion: '0.2.0',
       defaultCwd: '/workspace',
-      spawnAgent: () => asAgentProcess(process)
+      resolveBackend: () => ({
+        framework: { ...claudeCodeFramework, spawn: () => asAgentProcess(process) },
+        executablePath: '/bin/agent',
+        env: {},
+        responsesBridgeLease: lease
+      })
     })
 
     await runtime.createSession({ cwd: '/workspace' })
@@ -1172,6 +1199,7 @@ describe('ACP runtime session management', () => {
 
     // Calling it again after the process is gone is a no-op, not a crash.
     expect(() => runtime.shutdown()).not.toThrow()
+    await vi.waitFor(() => expect(release).toHaveBeenCalledOnce())
   })
 
   it('kills a child that finishes spawning after shutdown began, so quit-during-connect cannot orphan it', async () => {
@@ -1290,6 +1318,31 @@ describe('ACP runtime session management', () => {
     await vi.waitFor(() => expect(runtime.getSnapshot().status).toBe('closed'))
     await vi.waitFor(() => expect(process.killed).toBe(true))
     expect(runtime.getSnapshot().sessionIds).toEqual([])
+  })
+
+  it('releases the backend lease exactly once after an unexpected protocol close', async () => {
+    const process = new FakeAgentProcess()
+    const { lease, release } = createBackendLeaseHarness()
+    startFakeAgent(process, ['unexpected-close-lease-session'])
+    const runtime = new AcpRuntime({
+      appVersion: '0.2.0',
+      defaultCwd: '/workspace',
+      resolveBackend: () => ({
+        framework: { ...claudeCodeFramework, spawn: () => asAgentProcess(process) },
+        executablePath: '/bin/agent',
+        env: {},
+        responsesBridgeLease: lease
+      })
+    })
+
+    await runtime.createSession({ cwd: '/workspace' })
+    process.stdout.end()
+
+    await vi.waitFor(() => expect(runtime.getSnapshot().status).toBe('closed'))
+    await vi.waitFor(() => expect(release).toHaveBeenCalledOnce())
+
+    runtime.shutdown()
+    expect(release).toHaveBeenCalledOnce()
   })
 
   it('releases notebook RPC capabilities after an unexpected protocol close', async () => {
@@ -11433,19 +11486,29 @@ describe('ACP runtime — connect failure logging', () => {
     warnLogSpy.mockClear()
     errorLogSpy.mockClear()
     const process = new FakeAgentProcess()
+    const { lease, release } = createBackendLeaseHarness()
     process.pid = 1212
     const runtime = new AcpRuntime({
       appVersion: '0.1.0',
       defaultCwd: '/workspace',
       // Bump the connection generation synchronously during spawn: the connect that captured the older
       // generation must detect the supersede after the child appears and abandon it.
-      spawnAgent: () => {
-        ;(runtime as unknown as { connectionGeneration: number }).connectionGeneration += 1
-        return asAgentProcess(process)
-      }
+      resolveBackend: () => ({
+        framework: {
+          ...claudeCodeFramework,
+          spawn: () => {
+            ;(runtime as unknown as { connectionGeneration: number }).connectionGeneration += 1
+            return asAgentProcess(process)
+          }
+        },
+        executablePath: '/bin/agent',
+        env: {},
+        responsesBridgeLease: lease
+      })
     })
 
     await expect(runtime.createSession({ cwd: '/workspace' })).rejects.toThrow(/superseded/i)
+    expect(release).toHaveBeenCalledOnce()
 
     const abandoned = warnLogSpy.mock.calls.find(
       ([message]) => message === 'agent connection abandoned (superseded or shutting down)'
@@ -11465,6 +11528,7 @@ describe('ACP runtime — connect failure logging', () => {
 
   it('labels a real-backend spawn failure with the resolved (switched) framework, not the old one', async () => {
     errorLogSpy.mockClear()
+    const { lease, release } = createBackendLeaseHarness()
     // The runtime defaults to claude-code; this reconnect resolves a *different* backend whose real
     // framework.spawn() throws. spawnAgentProcess sets this.framework to opencode before spawning, so
     // the failure must be attributed to opencode — the backend actually launched — via the spawn tag,
@@ -11480,11 +11544,13 @@ describe('ACP runtime — connect failure logging', () => {
           }
         },
         executablePath: '/bin/opencode',
-        env: {}
+        env: {},
+        responsesBridgeLease: lease
       })
     })
 
     await expect(runtime.createSession({ cwd: '/workspace' })).rejects.toThrow(/opencode ENOENT/)
+    expect(release).toHaveBeenCalledOnce()
 
     const call = errorLogSpy.mock.calls.find(([message]) => message === 'agent connection failed')
     expect(call).toBeDefined()

--- a/src/main/settings/backend-resolver.test.ts
+++ b/src/main/settings/backend-resolver.test.ts
@@ -1,0 +1,667 @@
+import { describe, expect, it, vi } from 'vitest'
+
+import { SETTINGS_FILE_VERSION } from '../../shared/settings'
+import type { AgentFrameworkId } from '../agent-framework'
+import type { ResolvedProvider } from './provider-env'
+import type { ProviderRuntimeTarget, RuntimeProviderModelSelection } from './provider-accounts'
+import type { StoredProvider, StoredSettings } from './types'
+import {
+  AgentBackendResolver,
+  type AgentBackendConnectorPort,
+  type AgentBackendProviderPort,
+  type AgentBackendResolverOptions,
+  type AgentBackendRuntimePort
+} from './backend-resolver'
+
+type ResponsesBridgeFactory = NonNullable<AgentBackendResolverOptions['createResponsesBridge']>
+type ResponsesBridgeDouble = ReturnType<ResponsesBridgeFactory>
+type NativeResponsesProxyFactory = NonNullable<
+  AgentBackendResolverOptions['createNativeResponsesProxy']
+>
+type NativeResponsesProxyDouble = ReturnType<NativeResponsesProxyFactory>
+type ResolveRuntimeTarget = AgentBackendProviderPort['resolveRuntimeTarget']
+type TargetOverride = Omit<Partial<ProviderRuntimeTarget>, 'provider'> & {
+  provider?: Partial<ResolvedProvider>
+}
+
+const makeStoredProvider = (
+  id: string,
+  model = `${id}-default`,
+  keyRef = `${id}-key-ref`
+): StoredProvider => ({
+  id,
+  type: 'custom',
+  name: id,
+  apiEndpoints: ['anthropic', 'openai', 'responses'],
+  baseUrl: 'https://gateway.example/v1',
+  model,
+  keyRef
+})
+
+const makeSettings = (overrides: Partial<StoredSettings> = {}): StoredSettings => {
+  const provider = makeStoredProvider('provider-a', 'model-a')
+  return {
+    version: SETTINGS_FILE_VERSION,
+    providers: [provider],
+    activeProviderId: provider.id,
+    activeModel: provider.model,
+    agentFrameworkId: 'claude-code',
+    reasoningEffort: 'high',
+    ...overrides
+  }
+}
+
+const effectiveModelFor = (
+  provider: StoredProvider,
+  selection: RuntimeProviderModelSelection
+): string => {
+  if (selection.kind === 'required') return selection.model
+  if (selection.kind === 'configured' && selection.requestedModel) {
+    return selection.requestedModel
+  }
+  return provider.model ?? 'provider-default-model'
+}
+
+const makeResponsesBridgeDouble = (
+  options: {
+    startError?: Error
+    closeError?: Error
+  } = {}
+): ResponsesBridgeDouble => ({
+  start: vi.fn(async () => {
+    if (options.startError) throw options.startError
+    return { baseUrl: 'http://127.0.0.1:41001/v1', token: 'bridge-token' }
+  }),
+  close: vi.fn(async () => {
+    if (options.closeError) throw options.closeError
+  }),
+  selectSkills: vi.fn(async () => []),
+  registerReviewerSession: vi.fn(),
+  unregisterReviewerSession: vi.fn(() => false),
+  setReasoningEffort: vi.fn()
+})
+
+const makeNativeResponsesProxyDouble = (
+  options: {
+    startError?: Error
+    closeError?: Error
+  } = {}
+): NativeResponsesProxyDouble => ({
+  start: vi.fn(async () => {
+    if (options.startError) throw options.startError
+    return {
+      baseUrl: 'http://127.0.0.1:41002/v1',
+      token: 'proxy-token',
+      kind: 'responses-compatibility' as const
+    }
+  }),
+  close: vi.fn(async () => {
+    if (options.closeError) throw options.closeError
+  }),
+  selectSkills: vi.fn(async () => []),
+  registerReviewerSession: vi.fn(),
+  unregisterReviewerSession: vi.fn(() => false)
+})
+
+type HarnessOptions = {
+  settings?: StoredSettings
+  frameworkOverride?: string
+  rejectRequiredModels?: ReadonlySet<string>
+  targetOverride?: (
+    provider: StoredProvider,
+    selection: RuntimeProviderModelSelection,
+    frameworkId: AgentFrameworkId
+  ) => TargetOverride
+  responsesBridgeBuilder?: (index: number) => ResponsesBridgeDouble
+  nativeResponsesProxyBuilder?: (index: number) => NativeResponsesProxyDouble
+  nextGenerationId?: () => string
+}
+
+// The inferred return preserves each Vitest mock's concrete call signature for assertions below.
+// eslint-disable-next-line @typescript-eslint/explicit-function-return-type
+const makeHarness = (options: HarnessOptions = {}) => {
+  let currentSettings = options.settings ?? makeSettings()
+  const readSettings = vi.fn(async () => currentSettings)
+  const readFrameworkOverride = vi.fn(() => options.frameworkOverride)
+  const ensureCodexSubscriptionHome = vi.fn(async () => undefined)
+  const nextGenerationId = vi.fn(options.nextGenerationId ?? (() => 'generation'))
+
+  const resolveRuntimeTarget = vi.fn(
+    (
+      storedProvider: Parameters<ResolveRuntimeTarget>[0],
+      selection: Parameters<ResolveRuntimeTarget>[1],
+      framework: Parameters<ResolveRuntimeTarget>[2]
+    ): ProviderRuntimeTarget => {
+      if (selection.kind === 'required' && options.rejectRequiredModels?.has(selection.model)) {
+        throw new Error(`required model unavailable: ${selection.model}`)
+      }
+
+      const effectiveModel = effectiveModelFor(storedProvider, selection)
+      const provider: ResolvedProvider = {
+        type: storedProvider.type,
+        baseUrl: storedProvider.baseUrl ?? 'https://gateway.example/v1',
+        openaiBaseUrl: storedProvider.baseUrl ?? 'https://gateway.example/v1',
+        model: effectiveModel,
+        contextWindow: 128_000,
+        apiEndpoints: ['anthropic', 'openai', 'responses'],
+        ...(storedProvider.keyRef ? { key: `plain:${storedProvider.keyRef}` } : {})
+      }
+      const override = options.targetOverride?.(storedProvider, selection, framework.id)
+      const { provider: providerOverride, ...targetOverride } = override ?? {}
+      return {
+        providerId: storedProvider.id,
+        providerType: storedProvider.type,
+        effectiveModel,
+        apiEndpoints: ['anthropic', 'openai', 'responses'],
+        provider: { ...provider, ...providerOverride },
+        reasoningEffortProfile: {
+          supported: true,
+          slots: ['low', 'medium', 'high', 'xhigh', 'max']
+        },
+        frameworkCompatible: true,
+        modelBridgeSupported: true,
+        needsChatResponsesBridge: false,
+        needsNativeResponsesCompatibility: false,
+        ...targetOverride
+      }
+    }
+  )
+  const resolveRuntimeReasoningEffortProfile = vi.fn(() => ({
+    supported: true as const,
+    slots: ['low', 'medium', 'high', 'xhigh', 'max'] as const
+  }))
+  const providers: AgentBackendProviderPort = {
+    resolveRuntimeTarget,
+    resolveRuntimeReasoningEffortProfile
+  }
+
+  const runtime = {
+    resolveClaudeExecutable: vi.fn(async () => '/runtime/claude'),
+    resolveOpencodeExecutable: vi.fn(async () => '/runtime/opencode'),
+    resolveCodexExecutable: vi.fn(async () => '/runtime/codex-acp'),
+    probeCodexNativeVersion: vi.fn(async () => '0.144.6'),
+    provisionClaudeRuntimeConfig: vi.fn(async () => '/storage/claude-config'),
+    materializeAgentSkills: vi.fn(async () => undefined),
+    materializeAgentConfigFiles: vi.fn(async () => undefined),
+    reserveOpenCodeUsagePort: vi.fn(async () => 42_424),
+    resolveCodexProxyEnvironment: vi.fn(async () => undefined)
+  } satisfies AgentBackendRuntimePort
+  const connectors = {
+    enabledConnectorIds: vi.fn(() => [])
+  } satisfies AgentBackendConnectorPort
+
+  const responsesBridges: ResponsesBridgeDouble[] = []
+  const createResponsesBridge = vi.fn((): ResponsesBridgeDouble => {
+    const bridge =
+      options.responsesBridgeBuilder?.(responsesBridges.length) ?? makeResponsesBridgeDouble()
+    responsesBridges.push(bridge)
+    return bridge
+  })
+  const nativeResponsesProxies: NativeResponsesProxyDouble[] = []
+  const createNativeResponsesProxy = vi.fn((): NativeResponsesProxyDouble => {
+    const proxy =
+      options.nativeResponsesProxyBuilder?.(nativeResponsesProxies.length) ??
+      makeNativeResponsesProxyDouble()
+    nativeResponsesProxies.push(proxy)
+    return proxy
+  })
+
+  const resolver = new AgentBackendResolver({
+    readSettings,
+    providers,
+    runtime,
+    connectors,
+    storageRoot: '/storage',
+    userClaudeDir: '/user/.claude',
+    readFrameworkOverride,
+    createResponsesBridge,
+    createNativeResponsesProxy,
+    ensureCodexSubscriptionHome,
+    nextGenerationId
+  })
+
+  return {
+    resolver,
+    readSettings,
+    readFrameworkOverride,
+    ensureCodexSubscriptionHome,
+    nextGenerationId,
+    resolveRuntimeTarget,
+    resolveRuntimeReasoningEffortProfile,
+    runtime,
+    connectors,
+    createResponsesBridge,
+    createNativeResponsesProxy,
+    responsesBridges,
+    nativeResponsesProxies,
+    getSettings: () => currentSettings,
+    setSettings: (settings: StoredSettings) => {
+      currentSettings = settings
+    }
+  }
+}
+
+const expectRuntimeNotStarted = (runtime: ReturnType<typeof makeHarness>['runtime']): void => {
+  expect(runtime.resolveClaudeExecutable).not.toHaveBeenCalled()
+  expect(runtime.resolveOpencodeExecutable).not.toHaveBeenCalled()
+  expect(runtime.resolveCodexExecutable).not.toHaveBeenCalled()
+  expect(runtime.probeCodexNativeVersion).not.toHaveBeenCalled()
+  expect(runtime.provisionClaudeRuntimeConfig).not.toHaveBeenCalled()
+  expect(runtime.materializeAgentSkills).not.toHaveBeenCalled()
+  expect(runtime.materializeAgentConfigFiles).not.toHaveBeenCalled()
+  expect(runtime.reserveOpenCodeUsagePort).not.toHaveBeenCalled()
+  expect(runtime.resolveCodexProxyEnvironment).not.toHaveBeenCalled()
+}
+
+describe('AgentBackendResolver construction and selection', () => {
+  it('constructs without side effects and captures a secret-free framework selection', async () => {
+    const harness = makeHarness({
+      settings: makeSettings({ agentFrameworkId: 'codex' })
+    })
+
+    expect(harness.readSettings).not.toHaveBeenCalled()
+    expect(harness.readFrameworkOverride).not.toHaveBeenCalled()
+    expect(harness.resolveRuntimeTarget).not.toHaveBeenCalled()
+    expect(harness.resolveRuntimeReasoningEffortProfile).not.toHaveBeenCalled()
+    expect(harness.connectors.enabledConnectorIds).not.toHaveBeenCalled()
+    expect(harness.createResponsesBridge).not.toHaveBeenCalled()
+    expect(harness.createNativeResponsesProxy).not.toHaveBeenCalled()
+    expect(harness.ensureCodexSubscriptionHome).not.toHaveBeenCalled()
+    expect(harness.nextGenerationId).not.toHaveBeenCalled()
+    expectRuntimeNotStarted(harness.runtime)
+
+    const selection = await harness.resolver.captureConfiguredSelection()
+
+    expect(selection).toEqual({ frameworkId: 'codex' })
+    expect(Object.keys(selection)).toEqual(['frameworkId'])
+    expect(JSON.stringify(selection)).not.toContain('key')
+    expect(harness.resolveRuntimeTarget).not.toHaveBeenCalled()
+    expect(harness.resolveRuntimeReasoningEffortProfile).not.toHaveBeenCalled()
+    expectRuntimeNotStarted(harness.runtime)
+  })
+
+  it('projects reasoning capability without resolving a secret-bearing runtime target', async () => {
+    const harness = makeHarness()
+
+    await expect(harness.resolver.resolveActiveReasoningEffort('max')).resolves.toBe('max')
+
+    expect(harness.resolveRuntimeReasoningEffortProfile).toHaveBeenCalledWith(
+      harness.getSettings().providers[0],
+      'model-a'
+    )
+    expect(harness.resolveRuntimeTarget).not.toHaveBeenCalled()
+    expectRuntimeNotStarted(harness.runtime)
+  })
+})
+
+describe('AgentBackendResolver configured and explicit targets', () => {
+  it('produces equivalent stable backends for configured and provider-default explicit targets', async () => {
+    const settings = makeSettings()
+    const harness = makeHarness({ settings })
+
+    const configured = await harness.resolver.resolveActiveBackend()
+    const explicit = await harness.resolver.resolveExplicitTarget({
+      frameworkId: 'claude-code',
+      providerId: 'provider-a',
+      model: { kind: 'provider-default' },
+      reasoningEffort: 'high'
+    })
+
+    expect(explicit).toEqual(configured)
+    expect(harness.resolveRuntimeTarget).toHaveBeenNthCalledWith(
+      1,
+      settings.providers[0],
+      { kind: 'configured', requestedModel: 'model-a' },
+      expect.objectContaining({ id: 'claude-code' })
+    )
+    expect(harness.resolveRuntimeTarget).toHaveBeenNthCalledWith(
+      2,
+      settings.providers[0],
+      { kind: 'provider-default' },
+      expect.objectContaining({ id: 'claude-code' })
+    )
+  })
+
+  it('late-binds a configured selection but keeps an explicit target fixed', async () => {
+    const providerA = makeStoredProvider('provider-a', 'model-a', 'key-a')
+    const providerB = makeStoredProvider('provider-b', 'model-b', 'key-b')
+    const harness = makeHarness({
+      settings: makeSettings({
+        providers: [providerA, providerB],
+        activeProviderId: providerA.id,
+        activeModel: providerA.model,
+        agentFrameworkId: 'codex',
+        reasoningEffort: 'high'
+      })
+    })
+    const selection = await harness.resolver.captureConfiguredSelection()
+    const rotatedProviderA = { ...providerA, keyRef: 'key-a-rotated' }
+    harness.setSettings(
+      makeSettings({
+        providers: [rotatedProviderA, providerB],
+        activeProviderId: providerB.id,
+        activeModel: 'model-b-current',
+        agentFrameworkId: 'claude-code',
+        reasoningEffort: 'low'
+      })
+    )
+
+    const lateBound = await harness.resolver.resolveSelection(selection)
+    const fixed = await harness.resolver.resolveExplicitTarget({
+      frameworkId: 'codex',
+      providerId: providerA.id,
+      model: { kind: 'required', id: 'model-a-fixed' },
+      reasoningEffort: 'max'
+    })
+
+    expect(lateBound).toMatchObject({
+      backendId: 'codex:provider-b',
+      sessionModel: 'model-b-current',
+      sessionEffort: 'low',
+      authentication: { methodId: 'api-key', _meta: { 'api-key': { apiKey: 'plain:key-b' } } }
+    })
+    expect(fixed).toMatchObject({
+      backendId: 'codex:provider-a',
+      sessionModel: 'model-a-fixed',
+      sessionEffort: 'max',
+      authentication: {
+        methodId: 'api-key',
+        _meta: { 'api-key': { apiKey: 'plain:key-a-rotated' } }
+      }
+    })
+    expect(harness.resolveRuntimeTarget).toHaveBeenNthCalledWith(
+      1,
+      providerB,
+      { kind: 'configured', requestedModel: 'model-b-current' },
+      expect.objectContaining({ id: 'codex' })
+    )
+    expect(harness.resolveRuntimeTarget).toHaveBeenNthCalledWith(
+      2,
+      rotatedProviderA,
+      { kind: 'required', model: 'model-a-fixed' },
+      expect.objectContaining({ id: 'codex' })
+    )
+  })
+
+  it('fails an unavailable required model before runtime work without mutating settings', async () => {
+    const harness = makeHarness({ rejectRequiredModels: new Set(['missing-model']) })
+    const before = structuredClone(harness.getSettings())
+
+    await expect(
+      harness.resolver.resolveExplicitTarget({
+        frameworkId: 'codex',
+        providerId: 'provider-a',
+        model: { kind: 'required', id: 'missing-model' },
+        reasoningEffort: 'high'
+      })
+    ).rejects.toThrow('required model unavailable: missing-model')
+
+    expect(harness.getSettings()).toEqual(before)
+    expect(harness.createResponsesBridge).not.toHaveBeenCalled()
+    expect(harness.createNativeResponsesProxy).not.toHaveBeenCalled()
+    expect(harness.nextGenerationId).not.toHaveBeenCalled()
+    expectRuntimeNotStarted(harness.runtime)
+  })
+
+  it('ignores the configured framework override for an explicit target', async () => {
+    const harness = makeHarness({ frameworkOverride: 'opencode' })
+
+    const backend = await harness.resolver.resolveExplicitTarget({
+      frameworkId: 'codex',
+      providerId: 'provider-a',
+      model: { kind: 'provider-default' },
+      reasoningEffort: 'high'
+    })
+
+    expect(backend.framework.id).toBe('codex')
+    expect(harness.readFrameworkOverride).not.toHaveBeenCalled()
+  })
+})
+
+describe('AgentBackendResolver runtime delegation', () => {
+  it('preserves legacy spawn-config error priority by resolving Claude before the provider', async () => {
+    const harness = makeHarness({
+      settings: makeSettings({ providers: [], activeProviderId: undefined })
+    })
+    const executableError = new Error('Claude executable is unavailable')
+    harness.runtime.resolveClaudeExecutable.mockRejectedValueOnce(executableError)
+
+    await expect(harness.resolver.resolveActiveSpawnConfig()).rejects.toBe(executableError)
+
+    expect(harness.resolveRuntimeTarget).not.toHaveBeenCalled()
+  })
+
+  it.each([
+    { frameworkId: 'claude-code' as const, executableMethod: 'resolveClaudeExecutable' as const },
+    { frameworkId: 'opencode' as const, executableMethod: 'resolveOpencodeExecutable' as const },
+    { frameworkId: 'codex' as const, executableMethod: 'resolveCodexExecutable' as const }
+  ])('delegates $frameworkId preparation through the S5a runtime port', async (testCase) => {
+    const harness = makeHarness()
+
+    const backend = await harness.resolver.resolveExplicitTarget(
+      {
+        frameworkId: testCase.frameworkId,
+        providerId: 'provider-a',
+        model: { kind: 'provider-default' },
+        reasoningEffort: 'high'
+      },
+      { forcedSkillIds: ['forced-skill'] }
+    )
+
+    expect(backend.framework.id).toBe(testCase.frameworkId)
+    expect(harness.runtime[testCase.executableMethod]).toHaveBeenCalledTimes(1)
+    if (testCase.frameworkId === 'claude-code') {
+      expect(harness.runtime.provisionClaudeRuntimeConfig).toHaveBeenCalledWith(
+        harness.getSettings(),
+        new Set(['forced-skill'])
+      )
+      expect(harness.runtime.materializeAgentSkills).not.toHaveBeenCalled()
+      expect(harness.runtime.materializeAgentConfigFiles).not.toHaveBeenCalled()
+    } else {
+      expect(harness.runtime.materializeAgentSkills).toHaveBeenCalledWith(
+        harness.getSettings(),
+        expect.any(String),
+        new Set(['forced-skill'])
+      )
+      expect(harness.runtime.materializeAgentConfigFiles).toHaveBeenCalledTimes(1)
+    }
+    expect(harness.runtime.reserveOpenCodeUsagePort).toHaveBeenCalledTimes(
+      testCase.frameworkId === 'opencode' ? 1 : 0
+    )
+    expect(harness.runtime.probeCodexNativeVersion).toHaveBeenCalledTimes(
+      testCase.frameworkId === 'codex' ? 1 : 0
+    )
+  })
+})
+
+describe('AgentBackendResolver bridge predicates', () => {
+  it.each([
+    { name: 'direct', chat: false, native: false, responseCalls: 0, nativeCalls: 0 },
+    {
+      name: 'Chat Completions bridge',
+      chat: true,
+      native: false,
+      responseCalls: 1,
+      nativeCalls: 0
+    },
+    {
+      name: 'native Responses compatibility',
+      chat: false,
+      native: true,
+      responseCalls: 0,
+      nativeCalls: 1
+    }
+  ])('honors the provider-owned $name predicate', async (testCase) => {
+    const harness = makeHarness({
+      targetOverride: () => ({
+        needsChatResponsesBridge: testCase.chat,
+        needsNativeResponsesCompatibility: testCase.native
+      })
+    })
+
+    const backend = await harness.resolver.resolveExplicitTarget({
+      frameworkId: 'codex',
+      providerId: 'provider-a',
+      model: { kind: 'provider-default' },
+      reasoningEffort: 'high'
+    })
+
+    expect(harness.createResponsesBridge).toHaveBeenCalledTimes(testCase.responseCalls)
+    expect(harness.createNativeResponsesProxy).toHaveBeenCalledTimes(testCase.nativeCalls)
+    expect(backend.responsesBridgeLease === undefined).toBe(
+      testCase.responseCalls + testCase.nativeCalls === 0
+    )
+    await backend.responsesBridgeLease?.release()
+  })
+})
+
+describe('AgentBackendResolver bridge generations', () => {
+  it('creates unique generations and releases each lease idempotently', async () => {
+    let generation = 0
+    const harness = makeHarness({
+      targetOverride: () => ({ needsChatResponsesBridge: true }),
+      nextGenerationId: () => `generation-${++generation}`
+    })
+    const target = {
+      frameworkId: 'codex' as const,
+      providerId: 'provider-a',
+      model: { kind: 'provider-default' as const },
+      reasoningEffort: 'high' as const
+    }
+
+    const first = await harness.resolver.resolveExplicitTarget(target)
+    const second = await harness.resolver.resolveExplicitTarget(target)
+    first.responsesBridgeLease?.setReasoningEffort?.('low')
+    second.responsesBridgeLease?.setReasoningEffort?.('max')
+    first.responsesBridgeLease?.registerReviewerSession('first-reviewer')
+    second.responsesBridgeLease?.registerReviewerSession('second-reviewer')
+    await first.responsesBridgeLease?.release()
+    await first.responsesBridgeLease?.release()
+    await second.responsesBridgeLease?.release()
+
+    expect(harness.nextGenerationId).toHaveBeenCalledTimes(2)
+    expect(harness.nextGenerationId).toHaveNthReturnedWith(1, 'generation-1')
+    expect(harness.nextGenerationId).toHaveNthReturnedWith(2, 'generation-2')
+    expect(harness.createResponsesBridge).toHaveBeenCalledTimes(2)
+    expect(harness.responsesBridges).toHaveLength(2)
+    expect(harness.responsesBridges[0]?.close).toHaveBeenCalledTimes(1)
+    expect(harness.responsesBridges[1]?.close).toHaveBeenCalledTimes(1)
+    expect(harness.responsesBridges[0]?.setReasoningEffort).toHaveBeenCalledWith('low')
+    expect(harness.responsesBridges[0]?.setReasoningEffort).not.toHaveBeenCalledWith('max')
+    expect(harness.responsesBridges[1]?.setReasoningEffort).toHaveBeenCalledWith('max')
+    expect(harness.responsesBridges[1]?.setReasoningEffort).not.toHaveBeenCalledWith('low')
+    expect(harness.responsesBridges[0]?.registerReviewerSession).toHaveBeenCalledWith(
+      'first-reviewer'
+    )
+    expect(harness.responsesBridges[0]?.registerReviewerSession).toHaveBeenCalledTimes(1)
+    expect(harness.responsesBridges[0]?.registerReviewerSession).not.toHaveBeenCalledWith(
+      'second-reviewer'
+    )
+    expect(harness.responsesBridges[1]?.registerReviewerSession).toHaveBeenCalledWith(
+      'second-reviewer'
+    )
+    expect(harness.responsesBridges[1]?.registerReviewerSession).toHaveBeenCalledTimes(1)
+    expect(harness.responsesBridges[1]?.registerReviewerSession).not.toHaveBeenCalledWith(
+      'first-reviewer'
+    )
+  })
+})
+
+describe('AgentBackendResolver bridge cleanup', () => {
+  it.each(['chat', 'native'] as const)(
+    'closes a half-started %s resource and preserves the start error',
+    async (protocol) => {
+      const startError = new Error(`${protocol} start failed`)
+      const closeError = new Error(`${protocol} close failed`)
+      const resource =
+        protocol === 'chat'
+          ? makeResponsesBridgeDouble({ startError, closeError })
+          : makeNativeResponsesProxyDouble({ startError, closeError })
+      const harness = makeHarness({
+        targetOverride: () => ({
+          needsChatResponsesBridge: protocol === 'chat',
+          needsNativeResponsesCompatibility: protocol === 'native'
+        }),
+        ...(protocol === 'chat'
+          ? { responsesBridgeBuilder: () => resource as ResponsesBridgeDouble }
+          : { nativeResponsesProxyBuilder: () => resource as NativeResponsesProxyDouble })
+      })
+
+      await expect(
+        harness.resolver.resolveExplicitTarget({
+          frameworkId: 'codex',
+          providerId: 'provider-a',
+          model: { kind: 'provider-default' },
+          reasoningEffort: 'high'
+        })
+      ).rejects.toBe(startError)
+
+      expect(resource.close).toHaveBeenCalledTimes(1)
+      expect(harness.runtime.materializeAgentConfigFiles).not.toHaveBeenCalled()
+    }
+  )
+
+  it.each(['chat', 'native'] as const)(
+    'releases a started %s resource when later backend preparation fails',
+    async (protocol) => {
+      const preparationError = new Error(`${protocol} preparation failed`)
+      const resource =
+        protocol === 'chat' ? makeResponsesBridgeDouble() : makeNativeResponsesProxyDouble()
+      const harness = makeHarness({
+        targetOverride: () => ({
+          needsChatResponsesBridge: protocol === 'chat',
+          needsNativeResponsesCompatibility: protocol === 'native'
+        }),
+        ...(protocol === 'chat'
+          ? { responsesBridgeBuilder: () => resource as ResponsesBridgeDouble }
+          : { nativeResponsesProxyBuilder: () => resource as NativeResponsesProxyDouble })
+      })
+      harness.runtime.materializeAgentConfigFiles.mockRejectedValueOnce(preparationError)
+
+      await expect(
+        harness.resolver.resolveExplicitTarget({
+          frameworkId: 'codex',
+          providerId: 'provider-a',
+          model: { kind: 'provider-default' },
+          reasoningEffort: 'high'
+        })
+      ).rejects.toBe(preparationError)
+
+      expect(resource.start).toHaveBeenCalledTimes(1)
+      expect(resource.close).toHaveBeenCalledTimes(1)
+    }
+  )
+
+  it.each(['chat', 'native'] as const)(
+    'preserves the existing %s cleanup rejection priority after preparation fails',
+    async (protocol) => {
+      const preparationError = new Error(`${protocol} preparation failed`)
+      const closeError = new Error(`${protocol} close failed`)
+      const resource =
+        protocol === 'chat'
+          ? makeResponsesBridgeDouble({ closeError })
+          : makeNativeResponsesProxyDouble({ closeError })
+      const harness = makeHarness({
+        targetOverride: () => ({
+          needsChatResponsesBridge: protocol === 'chat',
+          needsNativeResponsesCompatibility: protocol === 'native'
+        }),
+        ...(protocol === 'chat'
+          ? { responsesBridgeBuilder: () => resource as ResponsesBridgeDouble }
+          : { nativeResponsesProxyBuilder: () => resource as NativeResponsesProxyDouble })
+      })
+      harness.runtime.materializeAgentConfigFiles.mockRejectedValueOnce(preparationError)
+
+      await expect(
+        harness.resolver.resolveExplicitTarget({
+          frameworkId: 'codex',
+          providerId: 'provider-a',
+          model: { kind: 'provider-default' },
+          reasoningEffort: 'high'
+        })
+      ).rejects.toBe(closeError)
+
+      expect(resource.close).toHaveBeenCalledTimes(1)
+    }
+  )
+})

--- a/src/main/settings/backend-resolver.ts
+++ b/src/main/settings/backend-resolver.ts
@@ -1,0 +1,673 @@
+import { randomUUID } from 'node:crypto'
+import { join } from 'node:path'
+
+import { z } from 'zod'
+
+import type { ReasoningEffort } from '../../shared/settings'
+import {
+  CODEX_ISOLATED_PROVIDER_ID,
+  DEFAULT_CONVERSATION_SKILL_IMPORT_ENABLED,
+  DEFAULT_REASONING_EFFORT,
+  isCodexSubscriptionProvider
+} from '../../shared/settings'
+import {
+  buildActiveModelIncompatibleMessage,
+  CODEX_BRIDGE_UNSUPPORTED_MESSAGE,
+  NO_ACTIVE_PROVIDER_MESSAGE
+} from '../../shared/run-error-classification'
+import {
+  resolveReasoningEffortValue,
+  type ModelReasoningEffort,
+  type ResolvedReasoningEffort
+} from '../../shared/reasoning-effort'
+import {
+  DEFAULT_AGENT_FRAMEWORK_ID,
+  getAgentFramework,
+  type AgentFrameworkId,
+  type ResolvedAgentBackend
+} from '../agent-framework'
+import { opencodeConfigDir } from '../agent-framework/opencode'
+import {
+  codexStorageDir,
+  codexSubscriptionStorageDir,
+  normalizeResponsesBaseUrl
+} from '../agent-framework/codex'
+import { renderConnectorInstructions } from '../connectors/skill-doc'
+import { NOTEBOOK_MCP_SERVER_NAME, NOTEBOOK_RPC_TOOLS } from '../notebook/mcp-server'
+import { ARTIFACT_MCP_SERVER_NAME, writeArtifactFileToolSchema } from '../artifacts/mcp-server'
+import { beginActivityGroupToolSchema } from '../activity-groups/mcp-server'
+import {
+  ACTIVITY_GROUP_MCP_SERVER_NAME,
+  BEGIN_ACTIVITY_GROUP_TOOL_NAME
+} from '../../shared/activity-groups'
+import { REVIEWER_BRIDGE_NAMESPACED_TOOLS } from '../reviewer/bridge-tools'
+import { requestSkillImportToolSchema } from '../skills/mcp-server'
+import {
+  REQUEST_SKILL_IMPORT_TOOL_DESCRIPTION,
+  REQUEST_SKILL_IMPORT_TOOL_NAME,
+  SKILL_IMPORT_MCP_SERVER_NAME
+} from '../../shared/skill-import'
+import { openAiCompletionsBase } from './base-url'
+import { buildProviderEnv } from './provider-env'
+import {
+  ResponsesBridge,
+  type ResponsesBridgeConnection,
+  type ResponsesBridgeNamespacedTool,
+  type ResponsesBridgeTarget
+} from './responses-bridge'
+import { NativeResponsesCompatibilityProxy } from './native-responses-compatibility'
+import type { AgentRuntimeManager } from './agent-runtime-manager'
+import type { ConnectorSettingsModule } from './connector-settings'
+import {
+  CLAUDE_SHARED_DISCONNECTED_MESSAGE,
+  type ProviderAccountsModule,
+  type ProviderRuntimeTarget,
+  type RuntimeProviderModelSelection
+} from './provider-accounts'
+import { ensureCodexAuthHome } from './codex-auth'
+import type { StoredSettings } from './types'
+
+export type AgentBackendSelection = Readonly<{
+  frameworkId: AgentFrameworkId
+}>
+
+export type AgentBackendResolutionContext = {
+  forcedSkillIds?: string[]
+}
+
+export type ExplicitAgentBackendTarget = Readonly<{
+  frameworkId: AgentFrameworkId
+  providerId: string
+  model: Readonly<{ kind: 'required'; id: string }> | Readonly<{ kind: 'provider-default' }>
+  reasoningEffort: ReasoningEffort
+}>
+
+export type AgentSpawnConfig = {
+  envOverrides: Record<string, string>
+  executablePath: string
+  contextWindow?: number
+  sessionOptions?: Record<string, unknown>
+}
+
+export type AgentBackendRuntimePort = Pick<
+  AgentRuntimeManager,
+  | 'resolveClaudeExecutable'
+  | 'resolveOpencodeExecutable'
+  | 'resolveCodexExecutable'
+  | 'probeCodexNativeVersion'
+  | 'provisionClaudeRuntimeConfig'
+  | 'materializeAgentSkills'
+  | 'materializeAgentConfigFiles'
+  | 'reserveOpenCodeUsagePort'
+  | 'resolveCodexProxyEnvironment'
+>
+
+export type AgentBackendProviderPort = Pick<
+  ProviderAccountsModule,
+  'resolveRuntimeTarget' | 'resolveRuntimeReasoningEffortProfile'
+>
+
+export type AgentBackendConnectorPort = Pick<ConnectorSettingsModule, 'enabledConnectorIds'>
+
+type BridgeBasePort = Pick<
+  ResponsesBridge,
+  'start' | 'close' | 'selectSkills' | 'registerReviewerSession' | 'unregisterReviewerSession'
+>
+
+type ResponsesBridgePort = BridgeBasePort & Pick<ResponsesBridge, 'setReasoningEffort'>
+type NativeResponsesProxyPort = BridgeBasePort
+
+type NativeResponsesProxyTarget = {
+  baseUrl: string
+  key?: string
+  model?: string
+  reviewerScope: { namespacedTools: ResponsesBridgeNamespacedTool[] }
+}
+
+type ResponsesBridgeEntry = {
+  bridge: ResponsesBridgePort
+  connection: Promise<ResponsesBridgeConnection>
+}
+
+type NativeResponsesCompatibilityEntry = {
+  proxy: NativeResponsesProxyPort
+  connection: Promise<ResponsesBridgeConnection>
+}
+
+type LeasedResponsesBridgeConnection = ResponsesBridgeConnection & {
+  lease: NonNullable<ResolvedAgentBackend['responsesBridgeLease']>
+}
+
+export type AgentBackendResolverOptions = {
+  readSettings: () => Promise<StoredSettings>
+  providers: AgentBackendProviderPort
+  runtime: AgentBackendRuntimePort
+  connectors: AgentBackendConnectorPort
+  storageRoot: string
+  userClaudeDir: string
+  readFrameworkOverride?: () => string | undefined
+  createResponsesBridge?: (target: ResponsesBridgeTarget) => ResponsesBridgePort
+  createNativeResponsesProxy?: (target: NativeResponsesProxyTarget) => NativeResponsesProxyPort
+  ensureCodexSubscriptionHome?: () => Promise<void>
+  nextGenerationId?: () => string
+}
+
+// Codex exposes local MCP tools as namespaced Responses functions. Chat Completions has no namespace
+// field, so the bridge receives the app-owned notebook schemas and aliases them for the upstream.
+const CODEX_NOTEBOOK_TOOL_NAMESPACE = `mcp__${NOTEBOOK_MCP_SERVER_NAME.replace(
+  /[^a-zA-Z0-9_]/g,
+  '_'
+)}`
+const CODEX_BRIDGE_NOTEBOOK_TOOLS: ResponsesBridgeNamespacedTool[] = NOTEBOOK_RPC_TOOLS.map(
+  (tool) => ({
+    namespace: CODEX_NOTEBOOK_TOOL_NAMESPACE,
+    name: tool.name,
+    description:
+      tool.name === 'notebook_execute'
+        ? `${tool.description} For Open Science data connectors, the Python code MUST call host.mcp(server, method, arguments). Never use requests, urllib, httpx, curl, or a raw upstream API for connector data; those bypass app permissions, credentials, and rate limits. Codex MCP resource-list tools are not connector discovery.`
+        : tool.description,
+    parameters: z.toJSONSchema(z.object(tool.inputSchema), {
+      target: 'draft-7'
+    }) as ResponsesBridgeNamespacedTool['parameters']
+  })
+)
+const CODEX_ARTIFACT_TOOL_NAMESPACE = `mcp__${ARTIFACT_MCP_SERVER_NAME.replace(
+  /[^a-zA-Z0-9_]/g,
+  '_'
+)}`
+const CODEX_BRIDGE_ARTIFACT_TOOLS: ResponsesBridgeNamespacedTool[] = [
+  {
+    namespace: CODEX_ARTIFACT_TOOL_NAMESPACE,
+    name: 'write_artifact_file',
+    description:
+      'Attach a generated image, chart, report, data export, or archive to the current Open Science response. The file must already exist before using a localPath source.',
+    parameters: z.toJSONSchema(z.object(writeArtifactFileToolSchema), {
+      target: 'draft-7'
+    }) as ResponsesBridgeNamespacedTool['parameters']
+  }
+]
+const CODEX_ACTIVITY_TOOL_NAMESPACE = `mcp__${ACTIVITY_GROUP_MCP_SERVER_NAME.replace(
+  /[^a-zA-Z0-9_]/g,
+  '_'
+)}`
+const CODEX_BRIDGE_ACTIVITY_TOOLS: ResponsesBridgeNamespacedTool[] = [
+  {
+    namespace: CODEX_ACTIVITY_TOOL_NAMESPACE,
+    name: BEGIN_ACTIVITY_GROUP_TOOL_NAME,
+    description:
+      'Declare the concise purpose of the next coherent group of tool calls. Call once before the first tool in that group, not once per step.',
+    parameters: z.toJSONSchema(z.object(beginActivityGroupToolSchema), {
+      target: 'draft-7'
+    }) as ResponsesBridgeNamespacedTool['parameters']
+  }
+]
+const CODEX_SKILL_IMPORT_TOOL_NAMESPACE = `mcp__${SKILL_IMPORT_MCP_SERVER_NAME.replace(
+  /[^a-zA-Z0-9_]/g,
+  '_'
+)}`
+const CODEX_BRIDGE_SKILL_IMPORT_TOOLS: ResponsesBridgeNamespacedTool[] = [
+  {
+    namespace: CODEX_SKILL_IMPORT_TOOL_NAMESPACE,
+    name: REQUEST_SKILL_IMPORT_TOOL_NAME,
+    description: REQUEST_SKILL_IMPORT_TOOL_DESCRIPTION,
+    parameters: z.toJSONSchema(z.object(requestSkillImportToolSchema), {
+      target: 'draft-7'
+    }) as ResponsesBridgeNamespacedTool['parameters']
+  }
+]
+
+// Owns backend resolution decisions and every live bridge/proxy generation created for them. The
+// constructor is intentionally side-effect free; runtime resources start only inside resolve calls.
+export class AgentBackendResolver {
+  private readonly readSettings: () => Promise<StoredSettings>
+  private readonly providers: AgentBackendProviderPort
+  private readonly runtime: AgentBackendRuntimePort
+  private readonly connectors: AgentBackendConnectorPort
+  private readonly storageRoot: string
+  private readonly userClaudeDir: string
+  private readonly readFrameworkOverride: () => string | undefined
+  private readonly createResponsesBridge: (target: ResponsesBridgeTarget) => ResponsesBridgePort
+  private readonly createNativeResponsesProxy: (
+    target: NativeResponsesProxyTarget
+  ) => NativeResponsesProxyPort
+  private readonly ensureCodexSubscriptionHome: () => Promise<void>
+  private readonly nextGenerationId: () => string
+  private readonly responsesBridges = new Map<string, ResponsesBridgeEntry>()
+  private readonly nativeResponsesCompatibilityProxies = new Map<
+    string,
+    NativeResponsesCompatibilityEntry
+  >()
+
+  constructor(options: AgentBackendResolverOptions) {
+    this.readSettings = options.readSettings
+    this.providers = options.providers
+    this.runtime = options.runtime
+    this.connectors = options.connectors
+    this.storageRoot = options.storageRoot
+    this.userClaudeDir = options.userClaudeDir
+    this.readFrameworkOverride =
+      options.readFrameworkOverride ?? (() => process.env.OPEN_SCIENCE_AGENT_FRAMEWORK)
+    this.createResponsesBridge =
+      options.createResponsesBridge ?? ((target) => new ResponsesBridge(target))
+    this.createNativeResponsesProxy =
+      options.createNativeResponsesProxy ??
+      ((target) => new NativeResponsesCompatibilityProxy(target))
+    this.ensureCodexSubscriptionHome =
+      options.ensureCodexSubscriptionHome ??
+      (() => ensureCodexAuthHome('isolated', this.storageRoot))
+    this.nextGenerationId = options.nextGenerationId ?? randomUUID
+  }
+
+  async resolveActiveSpawnConfig(
+    context: AgentBackendResolutionContext = {}
+  ): Promise<AgentSpawnConfig> {
+    const settings = await this.readSettings()
+    const executablePath = await this.runtime.resolveClaudeExecutable(settings.claude?.resolvedPath)
+    const target = this.resolveConfiguredProviderTarget(settings, getAgentFramework('claude-code'))
+    return this.resolveClaudeSpawnConfig(
+      settings,
+      target,
+      new Set(context.forcedSkillIds ?? []),
+      executablePath
+    )
+  }
+
+  async resolveActiveBackend(
+    context: AgentBackendResolutionContext = {}
+  ): Promise<ResolvedAgentBackend> {
+    const settings = await this.readSettings()
+    const frameworkId = this.resolveConfiguredFrameworkId(settings)
+    return this.resolveBackendFromSettings(
+      settings,
+      frameworkId,
+      settings.activeProviderId,
+      { kind: 'configured', requestedModel: settings.activeModel },
+      settings.reasoningEffort ?? DEFAULT_REASONING_EFFORT,
+      context
+    )
+  }
+
+  async captureConfiguredSelection(): Promise<AgentBackendSelection> {
+    const settings = await this.readSettings()
+    return { frameworkId: this.resolveConfiguredFrameworkId(settings) }
+  }
+
+  async resolveSelection(
+    selection: AgentBackendSelection,
+    context: AgentBackendResolutionContext = {}
+  ): Promise<ResolvedAgentBackend> {
+    const settings = await this.readSettings()
+    return this.resolveBackendFromSettings(
+      settings,
+      selection.frameworkId,
+      settings.activeProviderId,
+      { kind: 'configured', requestedModel: settings.activeModel },
+      settings.reasoningEffort ?? DEFAULT_REASONING_EFFORT,
+      context
+    )
+  }
+
+  async resolveExplicitTarget(
+    target: ExplicitAgentBackendTarget,
+    context: AgentBackendResolutionContext = {}
+  ): Promise<ResolvedAgentBackend> {
+    const settings = await this.readSettings()
+    const modelSelection: RuntimeProviderModelSelection =
+      target.model.kind === 'required'
+        ? { kind: 'required', model: target.model.id }
+        : { kind: 'provider-default' }
+    return this.resolveBackendFromSettings(
+      settings,
+      target.frameworkId,
+      target.providerId,
+      modelSelection,
+      target.reasoningEffort,
+      context
+    )
+  }
+
+  async resolveActiveReasoningEffort(intent: ReasoningEffort): Promise<ResolvedReasoningEffort> {
+    const settings = await this.readSettings()
+    if (intent === DEFAULT_REASONING_EFFORT) return DEFAULT_REASONING_EFFORT
+    const activeProvider = settings.activeProviderId
+      ? settings.providers.find((candidate) => candidate.id === settings.activeProviderId)
+      : undefined
+    if (!activeProvider) return DEFAULT_REASONING_EFFORT
+
+    const profile = this.providers.resolveRuntimeReasoningEffortProfile(
+      activeProvider,
+      settings.activeModel
+    )
+    return resolveReasoningEffortValue(intent, profile)
+  }
+
+  private resolveConfiguredFrameworkId(settings: StoredSettings): AgentFrameworkId {
+    const forced = this.readFrameworkOverride()
+    return forced === 'opencode' || forced === 'claude-code' || forced === 'codex'
+      ? forced
+      : (settings.agentFrameworkId ?? DEFAULT_AGENT_FRAMEWORK_ID)
+  }
+
+  private resolveConfiguredProviderTarget(
+    settings: StoredSettings,
+    framework: ReturnType<typeof getAgentFramework>
+  ): ProviderRuntimeTarget {
+    const activeProvider = settings.activeProviderId
+      ? settings.providers.find((provider) => provider.id === settings.activeProviderId)
+      : undefined
+    if (!activeProvider) throw new Error(NO_ACTIVE_PROVIDER_MESSAGE)
+    return this.providers.resolveRuntimeTarget(
+      activeProvider,
+      { kind: 'configured', requestedModel: settings.activeModel },
+      framework
+    )
+  }
+
+  private async resolveBackendFromSettings(
+    settings: StoredSettings,
+    frameworkId: AgentFrameworkId,
+    providerId: string | undefined,
+    modelSelection: RuntimeProviderModelSelection,
+    effortIntent: ReasoningEffort,
+    context: AgentBackendResolutionContext
+  ): Promise<ResolvedAgentBackend> {
+    const framework = getAgentFramework(frameworkId)
+    const storedProvider = providerId
+      ? settings.providers.find((provider) => provider.id === providerId)
+      : undefined
+    if (!storedProvider) throw new Error(NO_ACTIVE_PROVIDER_MESSAGE)
+
+    const target = this.providers.resolveRuntimeTarget(storedProvider, modelSelection, framework)
+    if (!target.frameworkCompatible) {
+      throw new Error(buildActiveModelIncompatibleMessage(framework.displayName))
+    }
+    if (framework.id === 'codex' && !target.modelBridgeSupported) {
+      throw new Error(CODEX_BRIDGE_UNSUPPORTED_MESSAGE)
+    }
+
+    const resolvedEffort =
+      effortIntent === DEFAULT_REASONING_EFFORT
+        ? DEFAULT_REASONING_EFFORT
+        : resolveReasoningEffortValue(effortIntent, target.reasoningEffortProfile)
+    const sessionEffort: ModelReasoningEffort | undefined =
+      resolvedEffort === 'default' ? undefined : resolvedEffort
+    const supportedReasoningEfforts = target.reasoningEffortProfile.supported
+      ? [...new Set(target.reasoningEffortProfile.slots)]
+      : undefined
+    const forcedSkillIds = new Set(context.forcedSkillIds ?? [])
+
+    if (framework.id === 'claude-code') {
+      const { envOverrides, executablePath, sessionOptions, contextWindow } =
+        await this.resolveClaudeSpawnConfig(settings, target, forcedSkillIds)
+      return {
+        framework,
+        backendId: `${framework.id}:${target.providerId}`,
+        executablePath,
+        env: envOverrides,
+        sessionOptions,
+        sessionEffort,
+        contextWindow,
+        contextUsageModel: target.effectiveModel
+      }
+    }
+
+    const executablePath =
+      framework.id === 'codex'
+        ? await this.runtime.resolveCodexExecutable(
+            settings.codex?.resolvedPath,
+            settings.codex?.nativePath
+          )
+        : await this.runtime.resolveOpencodeExecutable(settings.opencodePath)
+    const codexNativeVersion =
+      framework.id === 'codex'
+        ? await this.runtime.probeCodexNativeVersion(settings.codex?.nativePath)
+        : undefined
+    const provider = target.provider
+    if (framework.id === 'codex' && isCodexSubscriptionProvider(provider.type)) {
+      await this.ensureCodexSubscriptionHome()
+    }
+    const backendProviderId =
+      framework.id === 'codex' && isCodexSubscriptionProvider(provider.type)
+        ? CODEX_ISOLATED_PROVIDER_ID
+        : target.providerId
+    const skillsRoot =
+      framework.id === 'codex'
+        ? isCodexSubscriptionProvider(provider.type)
+          ? codexSubscriptionStorageDir(this.storageRoot)
+          : codexStorageDir(this.storageRoot)
+        : opencodeConfigDir(this.storageRoot)
+    await this.runtime.materializeAgentSkills(settings, skillsRoot, forcedSkillIds)
+
+    const connectorInstructions = renderConnectorInstructions(
+      this.connectors.enabledConnectorIds(settings.connectors)
+    )
+    const responsesBridge = target.needsChatResponsesBridge
+      ? await this.ensureResponsesBridge(
+          provider,
+          sessionEffort,
+          settings.conversationSkillImportEnabled ?? DEFAULT_CONVERSATION_SKILL_IMPORT_ENABLED
+        )
+      : target.needsNativeResponsesCompatibility
+        ? await this.ensureNativeResponsesCompatibility(provider)
+        : undefined
+
+    try {
+      const modelConfig = framework.prepareModelConfig(provider, {
+        storageRoot: this.storageRoot,
+        executablePath,
+        ...(codexNativeVersion ? { nativeVersion: codexNativeVersion } : {}),
+        responsesBridge,
+        reasoningEffort: sessionEffort,
+        reasoningEfforts: supportedReasoningEfforts,
+        instructions: connectorInstructions
+      })
+      await this.runtime.materializeAgentConfigFiles(modelConfig.configFiles)
+      const opencodeUsagePort =
+        framework.id === 'opencode' ? await this.runtime.reserveOpenCodeUsagePort() : undefined
+      const opencodeUsagePassword = opencodeUsagePort === undefined ? undefined : randomUUID()
+      const usesCodexSystemProxy =
+        framework.id === 'codex' && isCodexSubscriptionProvider(provider.type)
+      const proxyEnv = usesCodexSystemProxy
+        ? await this.runtime.resolveCodexProxyEnvironment()
+        : undefined
+      const sessionModel = modelConfig.sessionModel ?? provider.model
+
+      return {
+        framework,
+        backendId: `${framework.id}:${backendProviderId}`,
+        executablePath,
+        env: {
+          ...(modelConfig.env ?? {}),
+          ...(opencodeUsagePassword ? { OPENCODE_SERVER_PASSWORD: opencodeUsagePassword } : {}),
+          ...(proxyEnv ?? {}),
+          ...(framework.id === 'codex' && settings.codex?.nativePath
+            ? { CODEX_PATH: settings.codex.nativePath }
+            : {})
+        },
+        args:
+          opencodeUsagePort === undefined
+            ? modelConfig.args
+            : [
+                ...(modelConfig.args ?? []),
+                '--port',
+                String(opencodeUsagePort),
+                '--hostname',
+                '127.0.0.1'
+              ],
+        ...(usesCodexSystemProxy
+          ? { proxyEnvironmentMode: proxyEnv === undefined ? 'inherit' : 'replace' }
+          : {}),
+        sessionModel,
+        ...(framework.id === 'codex' && isCodexSubscriptionProvider(provider.type) && sessionModel
+          ? { sessionModelRequired: true }
+          : {}),
+        sessionEffort,
+        contextWindow: provider.contextWindow,
+        contextUsageModel: provider.model,
+        authentication: modelConfig.authentication,
+        providerConfiguration: modelConfig.providerConfiguration,
+        ...(opencodeUsagePort === undefined || !opencodeUsagePassword
+          ? {}
+          : {
+              opencodeUsageApi: {
+                baseUrl: `http://127.0.0.1:${opencodeUsagePort}`,
+                authorization: `Basic ${Buffer.from(`opencode:${opencodeUsagePassword}`).toString('base64')}`
+              }
+            }),
+        responsesBridgeLease: responsesBridge?.lease
+      }
+    } catch (error) {
+      await responsesBridge?.lease.release()
+      throw error
+    }
+  }
+
+  private async resolveClaudeSpawnConfig(
+    settings: StoredSettings,
+    target: ProviderRuntimeTarget,
+    forcedSkillIds: ReadonlySet<string>,
+    resolvedExecutablePath?: string
+  ): Promise<AgentSpawnConfig> {
+    const executablePath =
+      resolvedExecutablePath ??
+      (await this.runtime.resolveClaudeExecutable(settings.claude?.resolvedPath))
+    if (target.providerType === 'claude-shared' && target.disconnectedAt !== undefined) {
+      throw new Error(CLAUDE_SHARED_DISCONNECTED_MESSAGE)
+    }
+    const appConfigDir = await this.runtime.provisionClaudeRuntimeConfig(settings, forcedSkillIds)
+    const provider = target.provider
+    const envOverrides = buildProviderEnv(provider, {
+      storageRoot: this.storageRoot,
+      claudeExecutablePath: executablePath,
+      userClaudeConfigDir: this.userClaudeDir
+    })
+    const sessionOptions =
+      target.providerType === 'claude-shared'
+        ? {
+            settings: join(appConfigDir, 'settings.json'),
+            plugins: [{ type: 'local', path: appConfigDir, skipMcpDiscovery: true }]
+          }
+        : provider.type === 'custom'
+          ? {
+              settings: {
+                skipWebFetchPreflight: true,
+                permissions: { ask: ['WebFetch'] }
+              }
+            }
+          : undefined
+
+    return {
+      envOverrides,
+      executablePath,
+      sessionOptions,
+      contextWindow: provider.contextWindow
+    }
+  }
+
+  private async ensureResponsesBridge(
+    provider: ProviderRuntimeTarget['provider'],
+    reasoningEffort: ModelReasoningEffort | undefined,
+    conversationSkillImportEnabled: boolean
+  ): Promise<LeasedResponsesBridgeConnection> {
+    const targetBaseUrl = openAiCompletionsBase(provider)
+    if (!targetBaseUrl) throw new Error('The Chat Completions provider has no base URL.')
+    const target: ResponsesBridgeTarget = {
+      baseUrl: targetBaseUrl,
+      key: provider.key,
+      vendorId: provider.vendorId,
+      reasoningEffortTransport: provider.reasoningEffortTransport,
+      model: provider.model,
+      reasoningEffort,
+      namespacedTools: [
+        ...CODEX_BRIDGE_NOTEBOOK_TOOLS,
+        ...CODEX_BRIDGE_ARTIFACT_TOOLS,
+        ...CODEX_BRIDGE_ACTIVITY_TOOLS,
+        ...(conversationSkillImportEnabled ? CODEX_BRIDGE_SKILL_IMPORT_TOOLS : [])
+      ],
+      reviewerScope: { namespacedTools: REVIEWER_BRIDGE_NAMESPACED_TOOLS }
+    }
+    const bridgeId = this.nextGenerationId()
+    const bridge = this.createResponsesBridge(target)
+    const entry = { bridge, connection: bridge.start() }
+    this.responsesBridges.set(bridgeId, entry)
+
+    let connection: ResponsesBridgeConnection
+    try {
+      connection = await entry.connection
+    } catch (error) {
+      if (this.responsesBridges.get(bridgeId) === entry) this.responsesBridges.delete(bridgeId)
+      await entry.bridge.close().catch(() => undefined)
+      throw error
+    }
+
+    let released = false
+    const leasedEntry = entry
+    return {
+      ...connection,
+      lease: {
+        selectSkills: (text, catalog, signal) =>
+          leasedEntry.bridge.selectSkills(text, catalog, signal),
+        registerReviewerSession: (promptCacheKey) =>
+          leasedEntry.bridge.registerReviewerSession(promptCacheKey),
+        unregisterReviewerSession: (promptCacheKey) =>
+          leasedEntry.bridge.unregisterReviewerSession(promptCacheKey),
+        setReasoningEffort: (effort) => leasedEntry.bridge.setReasoningEffort(effort),
+        release: async () => {
+          if (released) return
+          released = true
+          if (this.responsesBridges.get(bridgeId) !== leasedEntry) return
+          this.responsesBridges.delete(bridgeId)
+          await leasedEntry.bridge.close()
+        }
+      }
+    }
+  }
+
+  private async ensureNativeResponsesCompatibility(
+    provider: ProviderRuntimeTarget['provider']
+  ): Promise<LeasedResponsesBridgeConnection> {
+    const targetBaseUrl = normalizeResponsesBaseUrl(provider.openaiBaseUrl ?? provider.baseUrl)
+    if (!targetBaseUrl) throw new Error('The native Responses provider has no base URL.')
+    const proxyId = this.nextGenerationId()
+    const proxy = this.createNativeResponsesProxy({
+      baseUrl: targetBaseUrl,
+      key: provider.key,
+      model: provider.model,
+      reviewerScope: { namespacedTools: REVIEWER_BRIDGE_NAMESPACED_TOOLS }
+    })
+    const entry = { proxy, connection: proxy.start() }
+    this.nativeResponsesCompatibilityProxies.set(proxyId, entry)
+
+    let connection: ResponsesBridgeConnection
+    try {
+      connection = await entry.connection
+    } catch (error) {
+      if (this.nativeResponsesCompatibilityProxies.get(proxyId) === entry) {
+        this.nativeResponsesCompatibilityProxies.delete(proxyId)
+      }
+      await entry.proxy.close().catch(() => undefined)
+      throw error
+    }
+
+    let released = false
+    const leasedEntry = entry
+    return {
+      ...connection,
+      lease: {
+        selectSkills: (text, catalog, signal) =>
+          leasedEntry.proxy.selectSkills(text, catalog, signal),
+        registerReviewerSession: (promptCacheKey) =>
+          leasedEntry.proxy.registerReviewerSession(promptCacheKey),
+        unregisterReviewerSession: (promptCacheKey) =>
+          leasedEntry.proxy.unregisterReviewerSession(promptCacheKey),
+        release: async () => {
+          if (released) return
+          released = true
+          if (this.nativeResponsesCompatibilityProxies.get(proxyId) !== leasedEntry) return
+          this.nativeResponsesCompatibilityProxies.delete(proxyId)
+          await leasedEntry.proxy.close()
+        }
+      }
+    }
+  }
+}

--- a/src/main/settings/provider-accounts.test.ts
+++ b/src/main/settings/provider-accounts.test.ts
@@ -9,6 +9,7 @@ import type { ClaudeSharedAuthControllerPort, ClaudeSharedAuthStatus } from './c
 import type { ValidateProviderResult } from '../../shared/settings'
 import type { ResolvedProvider } from './provider-env'
 import type { StoredSettings } from './types'
+import { getAgentFramework } from '../agent-framework'
 
 vi.mock('electron', () => ({
   safeStorage: {
@@ -132,6 +133,79 @@ describe('ProviderAccountsModule', () => {
 
     await module.deleteProvider(stored.id)
     expect((await repository.getSettings()).providers).toEqual([])
+  })
+
+  it('projects an ephemeral runtime target without changing the stored provider selection', async () => {
+    await module.upsertProvider({
+      type: 'custom',
+      name: 'Lab gateway',
+      baseUrl: 'https://lab.example/v1',
+      model: 'lab-model',
+      key: 'secret-key',
+      apiEndpoints: ['openai']
+    })
+    const before = await repository.getSettings()
+    const stored = before.providers[0]
+
+    const target = module.resolveRuntimeTarget(
+      stored,
+      { kind: 'configured', requestedModel: 'unavailable-model' },
+      getAgentFramework('codex')
+    )
+
+    expect(target).toMatchObject({
+      providerId: stored.id,
+      effectiveModel: 'lab-model',
+      provider: { model: 'lab-model', key: 'secret-key' },
+      needsChatResponsesBridge: true
+    })
+    expect(module.resolveRuntimeReasoningEffortProfile(stored, 'lab-model')).toMatchObject({
+      supported: true
+    })
+    expect(await repository.getSettings()).toEqual(before)
+    expect(JSON.stringify(before)).not.toContain('secret-key')
+  })
+
+  it('rejects an unavailable required model instead of applying the configured fallback', async () => {
+    await module.upsertProvider({
+      type: 'custom',
+      name: 'Lab gateway',
+      baseUrl: 'https://lab.example/v1',
+      model: 'lab-model',
+      key: 'secret-key',
+      apiEndpoints: ['openai']
+    })
+    const before = await repository.getSettings()
+    const stored = before.providers[0]
+
+    expect(() =>
+      module.resolveRuntimeTarget(
+        stored,
+        { kind: 'required', model: 'unavailable-model' },
+        getAgentFramework('codex')
+      )
+    ).toThrow(
+      `The requested model "unavailable-model" is not available for provider "Lab gateway".`
+    )
+    expect(await repository.getSettings()).toEqual(before)
+  })
+
+  it('keeps an exact required model when a subscription catalog is unknown', async () => {
+    await module.upsertProvider({ type: 'claude-shared' })
+    const before = await repository.getSettings()
+    const stored = before.providers[0]
+
+    const target = module.resolveRuntimeTarget(
+      stored,
+      { kind: 'required', model: 'account-model' },
+      getAgentFramework('claude-code')
+    )
+
+    expect(target).toMatchObject({
+      effectiveModel: 'account-model',
+      provider: { model: 'account-model' }
+    })
+    expect(await repository.getSettings()).toEqual(before)
   })
 
   it('keeps only the newest validation result for one provider id', async () => {

--- a/src/main/settings/provider-accounts.ts
+++ b/src/main/settings/provider-accounts.ts
@@ -38,7 +38,12 @@ import {
   resolveVendorModelsUrl,
   resolveVendorOpenAiBaseUrl
 } from '../../shared/provider-registry'
-import { resolveProviderEffectiveModel } from '../../shared/provider-reasoning-effort'
+import {
+  resolveProviderEffectiveModel,
+  resolveProviderReasoningEffortProfile
+} from '../../shared/provider-reasoning-effort'
+import type { ReasoningEffortProfile } from '../../shared/reasoning-effort'
+import { isModelBridgeSupported } from '../../shared/provider-registry'
 import {
   DEFAULT_AGENT_FRAMEWORK_ID,
   getAgentFramework,
@@ -100,6 +105,25 @@ type ProviderAccountsModuleOptions = {
   codexAuth?: CodexAuthControllerPort
   claudeIsolatedAuth?: ClaudeIsolatedAuthControllerPort
   claudeSharedAuth?: ClaudeSharedAuthControllerPort
+}
+
+export type RuntimeProviderModelSelection =
+  | { kind: 'configured'; requestedModel?: string }
+  | { kind: 'required'; model: string }
+  | { kind: 'provider-default' }
+
+export type ProviderRuntimeTarget = {
+  providerId: string
+  providerType: StoredProvider['type']
+  disconnectedAt?: number
+  effectiveModel?: string
+  apiEndpoints: ChatApiEndpoint[]
+  provider: ResolvedProvider
+  reasoningEffortProfile: ReasoningEffortProfile
+  frameworkCompatible: boolean
+  modelBridgeSupported: boolean
+  needsChatResponsesBridge: boolean
+  needsNativeResponsesCompatibility: boolean
 }
 
 // Native Responses vendors other than OpenAI require the same namespace compatibility proxy during
@@ -1025,6 +1049,72 @@ class ProviderAccountsModule {
     return resolveProviderEffectiveModel(
       provider ? { ...provider, models: this.availableModels(provider) } : undefined,
       requested
+    )
+  }
+
+  // Produces the complete ephemeral provider input for one backend generation without mutating the
+  // active selection, refreshing catalogs, or entering an authentication lifecycle. A configured
+  // selection retains the historical fallback rules; an explicit required model must match exactly.
+  resolveRuntimeTarget(
+    storedProvider: StoredProvider,
+    selection: RuntimeProviderModelSelection,
+    framework: { id: AgentFrameworkId; supportedApiTypes: readonly ChatApiEndpoint[] }
+  ): ProviderRuntimeTarget {
+    const availableModels = this.availableModels(storedProvider)
+    if (
+      selection.kind === 'required' &&
+      availableModels.length > 0 &&
+      !availableModels.includes(selection.model)
+    ) {
+      throw new Error(
+        `The requested model "${selection.model}" is not available for provider "${storedProvider.name}".`
+      )
+    }
+
+    const effectiveModel =
+      selection.kind === 'required'
+        ? this.resolveActiveModel(storedProvider, selection.model)
+        : this.resolveActiveModel(
+            storedProvider,
+            selection.kind === 'configured' ? selection.requestedModel : undefined
+          )
+
+    if (selection.kind === 'required' && effectiveModel !== selection.model) {
+      throw new Error(
+        `The requested model "${selection.model}" is not available for provider "${storedProvider.name}".`
+      )
+    }
+
+    const apiEndpoints = this.resolveProviderApiEndpoints(storedProvider, effectiveModel)
+    const provider = this.resolveProvider(storedProvider, effectiveModel)
+
+    return {
+      providerId: storedProvider.id,
+      providerType: storedProvider.type,
+      ...(storedProvider.disconnectedAt === undefined
+        ? {}
+        : { disconnectedAt: storedProvider.disconnectedAt }),
+      effectiveModel,
+      apiEndpoints,
+      provider,
+      reasoningEffortProfile: resolveProviderReasoningEffortProfile(storedProvider, effectiveModel),
+      frameworkCompatible: isProviderUsableByFramework(
+        { apiEndpoints, type: storedProvider.type },
+        framework
+      ),
+      modelBridgeSupported: isModelBridgeSupported(storedProvider, effectiveModel),
+      needsChatResponsesBridge: requiresChatCompletionsBridge(provider, framework),
+      needsNativeResponsesCompatibility: requiresNativeResponsesCompatibility(provider, framework)
+    }
+  }
+
+  resolveRuntimeReasoningEffortProfile(
+    storedProvider: StoredProvider,
+    requestedModel?: string
+  ): ReasoningEffortProfile {
+    return resolveProviderReasoningEffortProfile(
+      storedProvider,
+      this.resolveActiveModel(storedProvider, requestedModel)
     )
   }
 

--- a/src/main/settings/service.test.ts
+++ b/src/main/settings/service.test.ts
@@ -17,8 +17,6 @@ import type {
 } from './claude-isolated-auth'
 import type { ClaudeSharedAuthControllerPort } from './claude-shared-auth'
 import type { UserSkillRepository } from '../skills/user-skill-repository'
-import type { ResponsesBridge } from './responses-bridge'
-import type { NativeResponsesCompatibilityProxy } from './native-responses-compatibility'
 import type { SystemProxyEnvironment } from './system-proxy'
 
 // Reversible fake safeStorage so provider keys can be encrypted/decrypted without an OS keychain.
@@ -2780,7 +2778,6 @@ describe('SettingsService: preflight & spawn config', () => {
 
     await service.setActiveProvider(first.id)
     const firstBackend = await service.resolveActiveAgentBackend()
-    const firstBackendPeer = await service.resolveActiveAgentBackend()
     await service.setActiveProvider(second.id)
     const secondBackend = await service.resolveActiveAgentBackend()
 
@@ -2788,26 +2785,8 @@ describe('SettingsService: preflight & spawn config', () => {
       secondBackend.providerConfiguration?.baseUrl
     )
 
-    const bridges = Array.from(
-      (
-        service as unknown as {
-          responsesBridges: Map<string, { bridge: ResponsesBridge }>
-        }
-      ).responsesBridges.values(),
-      (entry) => entry.bridge
-    )
-    const skillCatalog = [
-      { name: 'mcp-pubmed', description: 'Search PubMed.', path: '/skills/pubmed/SKILL.md' }
-    ]
-    const selectSkills = vi
-      .spyOn(bridges[0], 'selectSkills')
-      .mockResolvedValue([{ name: 'mcp-pubmed', path: '/skills/pubmed/SKILL.md' }])
-    await expect(
-      firstBackend.responsesBridgeLease?.selectSkills('search PubMed', skillCatalog)
-    ).resolves.toEqual([{ name: 'mcp-pubmed', path: '/skills/pubmed/SKILL.md' }])
-    expect(selectSkills).toHaveBeenCalledWith('search PubMed', skillCatalog, undefined)
-    bridges[0].registerReviewerSession('reviewer-one')
-    bridges[2].registerReviewerSession('reviewer-two')
+    firstBackend.responsesBridgeLease?.registerReviewerSession('reviewer-one')
+    secondBackend.responsesBridgeLease?.registerReviewerSession('reviewer-two')
 
     const send = async (backend: typeof firstBackend, promptCacheKey: string): Promise<void> => {
       const response = await localFetch(`${backend.providerConfiguration?.baseUrl}/responses`, {
@@ -2846,18 +2825,8 @@ describe('SettingsService: preflight & spawn config', () => {
       expect.arrayContaining(['mcp__open_science_reviewer__submit_findings'])
     ])
 
-    const bridgePool = (
-      service as unknown as {
-        responsesBridges: Map<string, unknown>
-      }
-    ).responsesBridges
-    expect(bridgePool.size).toBe(3)
     await firstBackend.responsesBridgeLease?.release()
-    expect(bridgePool.size).toBe(2)
-    await firstBackendPeer.responsesBridgeLease?.release()
-    expect(bridgePool.size).toBe(1)
     await secondBackend.responsesBridgeLease?.release()
-    expect(bridgePool.size).toBe(0)
   })
 
   it('closes and evicts a responses bridge whose start fails', async () => {
@@ -2893,14 +2862,13 @@ describe('SettingsService: preflight & spawn config', () => {
     await service.setActiveProvider(provider.id)
     vi.stubEnv('OPEN_SCIENCE_AGENT_FRAMEWORK', 'codex')
 
-    await expect(service.resolveActiveAgentBackend()).rejects.toBe(startError)
-
-    const bridgePool = (service as unknown as { responsesBridges: Map<string, unknown> })
-      .responsesBridges
-    expect(closeSpy).toHaveBeenCalledOnce()
-    expect(bridgePool.size).toBe(0)
-    startSpy.mockRestore()
-    closeSpy.mockRestore()
+    try {
+      await expect(service.resolveActiveAgentBackend()).rejects.toBe(startError)
+      expect(closeSpy).toHaveBeenCalledOnce()
+    } finally {
+      startSpy.mockRestore()
+      closeSpy.mockRestore()
+    }
   })
 
   it('routes a native-Responses vendor through the protocol-preserving compatibility proxy', async () => {
@@ -2972,34 +2940,7 @@ describe('SettingsService: preflight & spawn config', () => {
     expect(backend.authentication).toBeUndefined()
     expect(backend.env.CODEX_CONFIG).not.toContain('mm-secret')
 
-    const proxies = Array.from(
-      (
-        service as unknown as {
-          nativeResponsesCompatibilityProxies: Map<
-            string,
-            { proxy: NativeResponsesCompatibilityProxy }
-          >
-        }
-      ).nativeResponsesCompatibilityProxies.values(),
-      (entry) => entry.proxy
-    )
-    expect(proxies).toHaveLength(1)
-    const skillCatalog = [
-      { name: 'mcp-pubmed', description: 'Search PubMed.', path: '/skills/pubmed/SKILL.md' }
-    ]
-    const selectSkills = vi
-      .spyOn(proxies[0], 'selectSkills')
-      .mockResolvedValue([{ name: 'mcp-pubmed', path: '/skills/pubmed/SKILL.md' }])
-    await expect(
-      backend.responsesBridgeLease?.selectSkills('用 PubMed 搜索肿瘤免疫文章', skillCatalog)
-    ).resolves.toEqual([{ name: 'mcp-pubmed', path: '/skills/pubmed/SKILL.md' }])
-    expect(selectSkills).toHaveBeenCalledWith('用 PubMed 搜索肿瘤免疫文章', skillCatalog, undefined)
-
     await backend.responsesBridgeLease?.release()
-    expect(
-      (service as unknown as { nativeResponsesCompatibilityProxies: Map<string, unknown> })
-        .nativeResponsesCompatibilityProxies.size
-    ).toBe(0)
   })
 
   it('builds spawn env from the active provider with the decrypted key', async () => {
@@ -4685,85 +4626,6 @@ describe('SettingsService: reasoning effort', () => {
     expect(backend.sessionModel).toBe('claude-opus-5')
     expect(backend.sessionEffort).toBe('max')
     expect(content.model).toBe('anthropic/claude-opus-5')
-  })
-
-  it('isolates live effort changes between overlapping bridge generations', async () => {
-    const localFetch = globalThis.fetch
-    const upstreamEfforts: unknown[] = []
-    vi.stubGlobal(
-      'fetch',
-      vi.fn(async (_url: Parameters<typeof fetch>[0], init?: Parameters<typeof fetch>[1]) => {
-        const body = JSON.parse(String(init?.body)) as Record<string, unknown>
-        upstreamEfforts.push(body.reasoning_effort)
-        return new Response(
-          [
-            'data: ' +
-              JSON.stringify({
-                id: 'chat-isolated-effort',
-                model: 'model-a',
-                choices: [{ index: 0, delta: {}, finish_reason: 'stop' }]
-              }),
-            '',
-            'data: [DONE]',
-            ''
-          ].join('\n'),
-          { headers: { 'content-type': 'text/event-stream' } }
-        )
-      })
-    )
-    const service = createService()
-    const bridgeService = service as unknown as {
-      ensureResponsesBridge: (
-        provider: {
-          type: 'custom'
-          baseUrl: string
-          apiEndpoints: ['openai']
-          model: string
-          key: string
-        },
-        effort: 'low' | 'max'
-      ) => Promise<{
-        baseUrl: string
-        token: string
-        lease: {
-          setReasoningEffort: (effort: 'low' | 'high' | 'max') => void
-          release: () => Promise<void>
-        }
-      }>
-    }
-    const provider = {
-      type: 'custom' as const,
-      baseUrl: 'https://vendor.example/v1',
-      apiEndpoints: ['openai'] as ['openai'],
-      model: 'model-a',
-      key: 'key-a'
-    }
-    const first = await bridgeService.ensureResponsesBridge(provider, 'low')
-    const second = await bridgeService.ensureResponsesBridge(provider, 'max')
-    const post = async (connection: { baseUrl: string; token: string }): Promise<void> => {
-      const response = await localFetch(`${connection.baseUrl}/responses`, {
-        method: 'POST',
-        headers: {
-          authorization: `Bearer ${connection.token}`,
-          'content-type': 'application/json'
-        },
-        body: JSON.stringify({ model: 'catalog', input: 'hi', stream: true })
-      })
-      await response.text()
-    }
-
-    try {
-      await post(first)
-      await post(second)
-      second.lease.setReasoningEffort('high')
-      await post(first)
-      await post(second)
-
-      expect(upstreamEfforts).toEqual(['low', 'max', 'low', 'high'])
-    } finally {
-      await first.lease.release()
-      await second.lease.release()
-    }
   })
 
   it('surfaces sessionEffort on the Claude backend too (the early-return path)', async () => {

--- a/src/main/settings/service.ts
+++ b/src/main/settings/service.ts
@@ -1,8 +1,5 @@
 import { homedir } from 'node:os'
 import { join } from 'node:path'
-import { randomUUID } from 'node:crypto'
-
-import { z } from 'zod'
 
 import type { CloseActionPreference } from '../../shared/window-controls'
 
@@ -57,33 +54,13 @@ import type {
   ValidateProviderRequest,
   ValidateProviderResult
 } from '../../shared/settings'
-import {
-  CODEX_ISOLATED_PROVIDER_ID,
-  DEFAULT_CONVERSATION_SKILL_IMPORT_ENABLED,
-  DEFAULT_REASONING_EFFORT,
-  isCodexSubscriptionProvider,
-  isProviderUsableByFramework,
-  requiresChatCompletionsBridge
-} from '../../shared/settings'
 import type { PackageMirror } from '../../shared/mirror'
-import {
-  buildActiveModelIncompatibleMessage,
-  CODEX_BRIDGE_UNSUPPORTED_MESSAGE,
-  NO_ACTIVE_PROVIDER_MESSAGE
-} from '../../shared/run-error-classification'
 import type { NotebookLanguage } from '../../shared/notebook'
 import type { RuntimeEnablement, RuntimeSelection } from '../../shared/notebook-runtime'
-import { isModelBridgeSupported } from '../../shared/provider-registry'
-import { resolveProviderReasoningEffortProfile } from '../../shared/provider-reasoning-effort'
-import {
-  resolveReasoningEffortValue,
-  type ModelReasoningEffort,
-  type ResolvedReasoningEffort
-} from '../../shared/reasoning-effort'
+import type { ResolvedReasoningEffort } from '../../shared/reasoning-effort'
 import { resolveStorageRoot } from '../storage-root'
 import {
   DEFAULT_AGENT_FRAMEWORK_ID,
-  getAgentFramework,
   listAgentFrameworks,
   type AgentFrameworkId,
   type ResolvedAgentBackend
@@ -91,153 +68,33 @@ import {
 import type { ClaudeDetectDeps } from './claude-detect'
 import type { OpencodeDetectDeps } from './opencode-detect'
 import type { CodexDetectDeps } from './codex-detect'
-import { openAiCompletionsBase } from './base-url'
 import type { InstallManagedOpencodeOptions } from './managed-opencode'
-import { opencodeConfigDir } from '../agent-framework/opencode'
-import {
-  codexStorageDir,
-  codexSubscriptionStorageDir,
-  normalizeResponsesBaseUrl
-} from '../agent-framework/codex'
 import type { InstallManagedCodexOptions, ManagedCodexInstallOutcome } from './managed-codex'
 import type { InstallManagedClaudeOptions, ManagedInstallOutcome } from './managed-claude'
 import { isEncryptionAvailable } from './crypto'
-import { buildProviderEnv, getUserClaudeConfigDir, type ResolvedProvider } from './provider-env'
-import {
-  ResponsesBridge,
-  type ResponsesBridgeConnection,
-  type ResponsesBridgeNamespacedTool
-} from './responses-bridge'
-import { NativeResponsesCompatibilityProxy } from './native-responses-compatibility'
+import { getUserClaudeConfigDir } from './provider-env'
 import { SettingsRepository } from './repository'
 import { SettingsPreferencesModule, toSettingsPreferencesSnapshot } from './preferences'
 import { NotebookRuntimeSettingsModule } from './notebook-runtime-settings'
 import { SkillCatalogModule } from './skill-catalog'
 import { ConnectorSettingsModule, type CustomServerSecurityChangeGuard } from './connector-settings'
-import {
-  CLAUDE_SHARED_DISCONNECTED_MESSAGE,
-  ProviderAccountsModule,
-  requiresNativeResponsesCompatibility
-} from './provider-accounts'
+import { ProviderAccountsModule } from './provider-accounts'
 import { AgentRuntimeManager, type ExecuteClaudeProbe } from './agent-runtime-manager'
+import {
+  AgentBackendResolver,
+  type AgentBackendResolutionContext,
+  type AgentBackendSelection,
+  type AgentSpawnConfig
+} from './backend-resolver'
 import { CONNECTOR_CATALOG } from '../connectors/catalog'
-import { renderConnectorInstructions } from '../connectors/skill-doc'
 import { SkillRegistry } from '../skills/registry'
 import { UserSkillRepository } from '../skills/user-skill-repository'
-import { requestSkillImportToolSchema } from '../skills/mcp-server'
-import {
-  REQUEST_SKILL_IMPORT_TOOL_DESCRIPTION,
-  REQUEST_SKILL_IMPORT_TOOL_NAME,
-  SKILL_IMPORT_MCP_SERVER_NAME
-} from '../../shared/skill-import'
-import { NOTEBOOK_MCP_SERVER_NAME, NOTEBOOK_RPC_TOOLS } from '../notebook/mcp-server'
-import { ARTIFACT_MCP_SERVER_NAME, writeArtifactFileToolSchema } from '../artifacts/mcp-server'
-import { beginActivityGroupToolSchema } from '../activity-groups/mcp-server'
-import {
-  ACTIVITY_GROUP_MCP_SERVER_NAME,
-  BEGIN_ACTIVITY_GROUP_TOOL_NAME
-} from '../../shared/activity-groups'
-import { REVIEWER_BRIDGE_NAMESPACED_TOOLS } from '../reviewer/bridge-tools'
 import type { StoredConnectors, StoredSettings } from './types'
-import { ensureCodexAuthHome, type CodexAuthControllerPort } from './codex-auth'
+import type { CodexAuthControllerPort } from './codex-auth'
 
 import type { SystemProxyEnvironment } from './system-proxy'
 import { type ClaudeIsolatedAuthControllerPort } from './claude-isolated-auth'
 import { type ClaudeSharedAuthControllerPort } from './claude-shared-auth'
-
-export type AgentBackendSelection = {
-  frameworkId: AgentFrameworkId
-}
-
-export type AgentBackendResolutionContext = {
-  forcedSkillIds?: string[]
-}
-
-type ResponsesBridgeEntry = {
-  bridge: ResponsesBridge
-  connection: Promise<ResponsesBridgeConnection>
-}
-
-type NativeResponsesCompatibilityEntry = {
-  proxy: NativeResponsesCompatibilityProxy
-  connection: Promise<ResponsesBridgeConnection>
-}
-
-type LeasedResponsesBridgeConnection = ResponsesBridgeConnection & {
-  lease: NonNullable<ResolvedAgentBackend['responsesBridgeLease']>
-}
-
-// Codex exposes local MCP tools as namespaced Responses functions. Chat Completions has no namespace
-// field, so the bridge receives the app-owned notebook schemas and aliases them for the upstream.
-const CODEX_NOTEBOOK_TOOL_NAMESPACE = `mcp__${NOTEBOOK_MCP_SERVER_NAME.replace(
-  /[^a-zA-Z0-9_]/g,
-  '_'
-)}`
-const CODEX_BRIDGE_NOTEBOOK_TOOLS: ResponsesBridgeNamespacedTool[] = NOTEBOOK_RPC_TOOLS.map(
-  (tool) => ({
-    namespace: CODEX_NOTEBOOK_TOOL_NAMESPACE,
-    name: tool.name,
-    description:
-      tool.name === 'notebook_execute'
-        ? `${tool.description} For Open Science data connectors, the Python code MUST call host.mcp(server, method, arguments). Never use requests, urllib, httpx, curl, or a raw upstream API for connector data; those bypass app permissions, credentials, and rate limits. Codex MCP resource-list tools are not connector discovery.`
-        : tool.description,
-    parameters: z.toJSONSchema(z.object(tool.inputSchema), {
-      target: 'draft-7'
-    }) as ResponsesBridgeNamespacedTool['parameters']
-  })
-)
-const CODEX_ARTIFACT_TOOL_NAMESPACE = `mcp__${ARTIFACT_MCP_SERVER_NAME.replace(
-  /[^a-zA-Z0-9_]/g,
-  '_'
-)}`
-const CODEX_BRIDGE_ARTIFACT_TOOLS: ResponsesBridgeNamespacedTool[] = [
-  {
-    namespace: CODEX_ARTIFACT_TOOL_NAMESPACE,
-    name: 'write_artifact_file',
-    description:
-      'Attach a generated image, chart, report, data export, or archive to the current Open Science response. The file must already exist before using a localPath source.',
-    parameters: z.toJSONSchema(z.object(writeArtifactFileToolSchema), {
-      target: 'draft-7'
-    }) as ResponsesBridgeNamespacedTool['parameters']
-  }
-]
-const CODEX_ACTIVITY_TOOL_NAMESPACE = `mcp__${ACTIVITY_GROUP_MCP_SERVER_NAME.replace(
-  /[^a-zA-Z0-9_]/g,
-  '_'
-)}`
-const CODEX_BRIDGE_ACTIVITY_TOOLS: ResponsesBridgeNamespacedTool[] = [
-  {
-    namespace: CODEX_ACTIVITY_TOOL_NAMESPACE,
-    name: BEGIN_ACTIVITY_GROUP_TOOL_NAME,
-    description:
-      'Declare the concise purpose of the next coherent group of tool calls. Call once before the first tool in that group, not once per step.',
-    parameters: z.toJSONSchema(z.object(beginActivityGroupToolSchema), {
-      target: 'draft-7'
-    }) as ResponsesBridgeNamespacedTool['parameters']
-  }
-]
-const CODEX_SKILL_IMPORT_TOOL_NAMESPACE = `mcp__${SKILL_IMPORT_MCP_SERVER_NAME.replace(
-  /[^a-zA-Z0-9_]/g,
-  '_'
-)}`
-const CODEX_BRIDGE_SKILL_IMPORT_TOOLS: ResponsesBridgeNamespacedTool[] = [
-  {
-    namespace: CODEX_SKILL_IMPORT_TOOL_NAMESPACE,
-    name: REQUEST_SKILL_IMPORT_TOOL_NAME,
-    description: REQUEST_SKILL_IMPORT_TOOL_DESCRIPTION,
-    parameters: z.toJSONSchema(z.object(requestSkillImportToolSchema), {
-      target: 'draft-7'
-    }) as ResponsesBridgeNamespacedTool['parameters']
-  }
-]
-// A spawn configuration the ACP runtime reads at connect time so the active provider's credentials
-// are always current.
-export type AgentSpawnConfig = {
-  envOverrides: Record<string, string>
-  executablePath: string
-  contextWindow?: number
-  sessionOptions?: Record<string, unknown>
-}
 
 // Outcome of uninstalling a managed runtime. `activeBackendAffected` is true only when the removed
 // runtime backed the active framework, so the IPC layer reconnects the agent for that case alone —
@@ -306,16 +163,9 @@ class SettingsService {
   private readonly connectors: ConnectorSettingsModule
   private readonly providers: ProviderAccountsModule
   private readonly runtimeManager: AgentRuntimeManager
+  private readonly backendResolver: AgentBackendResolver
   private readonly storageRoot: string
   private readonly userClaudeDir: string
-  // A bridge owns mutable per-runtime state (reasoning override, reviewer scopes, and reasoning
-  // replay). Track each backend generation separately so an overlapping reconnect cannot mutate the
-  // bridge still serving the retiring generation.
-  private readonly responsesBridges = new Map<string, ResponsesBridgeEntry>()
-  private readonly nativeResponsesCompatibilityProxies = new Map<
-    string,
-    NativeResponsesCompatibilityEntry
-  >()
   // Provider and runtime-install IDs historically shared one monotonic suffix. Keep that observable
   // ordering while the provider owner remains responsible for formatting provider IDs.
   private settingsIdSequence = 0
@@ -369,6 +219,14 @@ class SettingsService {
       codexAuth: options.codexAuth,
       claudeIsolatedAuth: options.claudeIsolatedAuth,
       claudeSharedAuth: options.claudeSharedAuth
+    })
+    this.backendResolver = new AgentBackendResolver({
+      readSettings: () => this.repository.getSettings(),
+      providers: this.providers,
+      runtime: this.runtimeManager,
+      connectors: this.connectors,
+      storageRoot: this.storageRoot,
+      userClaudeDir: this.userClaudeDir
     })
   }
 
@@ -526,9 +384,7 @@ class SettingsService {
   // profile. This is intentionally async only because settings are read from disk; capability lookup
   // is synchronous and never performs provider discovery or a network request.
   async resolveActiveReasoningEffort(intent: ReasoningEffort): Promise<ResolvedReasoningEffort> {
-    const settings = await this.repository.getSettings()
-
-    return this.resolveReasoningEffortFromSettings(settings, intent)
+    return this.backendResolver.resolveActiveReasoningEffort(intent)
   }
 
   // Whether desktop notifications for finished/failed agent tasks are on, read fresh so the
@@ -1023,77 +879,7 @@ class SettingsService {
   async resolveActiveSpawnConfig(
     context: AgentBackendResolutionContext = {}
   ): Promise<AgentSpawnConfig> {
-    const settings = await this.repository.getSettings()
-
-    return this.resolveSpawnConfig(settings, new Set(context.forcedSkillIds ?? []))
-  }
-
-  private async resolveSpawnConfig(
-    settings: StoredSettings,
-    forcedSkillIds: ReadonlySet<string>,
-    resolvedSelection?: { model?: string }
-  ): Promise<AgentSpawnConfig> {
-    const executablePath = await this.runtimeManager.resolveClaudeExecutable(
-      settings.claude?.resolvedPath
-    )
-
-    const activeProvider = settings.activeProviderId
-      ? settings.providers.find((provider) => provider.id === settings.activeProviderId)
-      : undefined
-
-    if (!activeProvider) {
-      throw new Error(NO_ACTIVE_PROVIDER_MESSAGE)
-    }
-
-    if (activeProvider.type === 'claude-shared' && activeProvider.disconnectedAt !== undefined) {
-      throw new Error(CLAUDE_SHARED_DISCONNECTED_MESSAGE)
-    }
-
-    // Provision the app-owned runtime bundle. Shared auth reads credentials from ~/.claude while the
-    // ACP session injects this bundle as a local plugin plus highest-priority settings layer.
-    const appConfigDir = await this.runtimeManager.provisionClaudeRuntimeConfig(
-      settings,
-      forcedSkillIds
-    )
-
-    const provider = this.providers.resolveProvider(
-      activeProvider,
-      resolvedSelection
-        ? resolvedSelection.model
-        : this.providers.resolveActiveModel(activeProvider, settings.activeModel)
-    )
-    const envOverrides = buildProviderEnv(provider, {
-      storageRoot: this.storageRoot,
-      claudeExecutablePath: executablePath,
-      userClaudeConfigDir: this.userClaudeDir
-    })
-
-    const sessionOptions =
-      activeProvider.type === 'claude-shared'
-        ? {
-            settings: join(appConfigDir, 'settings.json'),
-            plugins: [{ type: 'local', path: appConfigDir, skipMcpDiscovery: true }]
-          }
-        : provider.type === 'custom'
-          ? {
-              // Custom Anthropic-compatible gateways may work while Anthropic's domain preflight
-              // endpoint is unreachable. Keep this override scoped to the ACP session so neither
-              // project/user settings nor the isolated Claude runtime configuration are mutated.
-              // V1 keeps provider-native WebFetch/WebSearch Once-only. This bypass removes Claude's
-              // remote preflight dependency but does not create Session, Project, or Global grants.
-              settings: {
-                skipWebFetchPreflight: true,
-                permissions: { ask: ['WebFetch'] }
-              }
-            }
-          : undefined
-
-    return {
-      envOverrides,
-      executablePath,
-      sessionOptions,
-      contextWindow: provider.contextWindow
-    }
+    return this.backendResolver.resolveActiveSpawnConfig(context)
   }
 
   // Resolves the active agent backend for one connect: the selected framework plus its spawn inputs.
@@ -1104,381 +890,20 @@ class SettingsService {
   async resolveActiveAgentBackend(
     context: AgentBackendResolutionContext = {}
   ): Promise<ResolvedAgentBackend> {
-    const settings = await this.repository.getSettings()
-    const forced = process.env.OPEN_SCIENCE_AGENT_FRAMEWORK
-    const frameworkId: AgentFrameworkId =
-      forced === 'opencode' || forced === 'claude-code' || forced === 'codex'
-        ? forced
-        : (settings.agentFrameworkId ?? DEFAULT_AGENT_FRAMEWORK_ID)
-
-    return this.resolveAgentBackendFromSettings(settings, frameworkId, context)
+    return this.backendResolver.resolveActiveBackend(context)
   }
 
   // Captures only non-secret backend identity. Runtime generations resolve credentials again at spawn,
   // so decrypted keys are not retained by the coordinator after AcpRuntime finishes authentication.
   async captureActiveAgentBackendSelection(): Promise<AgentBackendSelection> {
-    const settings = await this.repository.getSettings()
-    const forced = process.env.OPEN_SCIENCE_AGENT_FRAMEWORK
-    const frameworkId: AgentFrameworkId =
-      forced === 'opencode' || forced === 'claude-code' || forced === 'codex'
-        ? forced
-        : (settings.agentFrameworkId ?? DEFAULT_AGENT_FRAMEWORK_ID)
-
-    return { frameworkId }
+    return this.backendResolver.captureConfiguredSelection()
   }
 
   async resolveAgentBackend(
     selection: AgentBackendSelection,
     context: AgentBackendResolutionContext = {}
   ): Promise<ResolvedAgentBackend> {
-    const stored = await this.repository.getSettings()
-    const settings: StoredSettings = {
-      ...stored,
-      agentFrameworkId: selection.frameworkId
-    }
-
-    return this.resolveAgentBackendFromSettings(settings, selection.frameworkId, context)
-  }
-
-  private async resolveAgentBackendFromSettings(
-    settings: StoredSettings,
-    frameworkId: AgentFrameworkId,
-    context: AgentBackendResolutionContext
-  ): Promise<ResolvedAgentBackend> {
-    const forcedSkillIds = new Set(context.forcedSkillIds ?? [])
-    const framework = getAgentFramework(frameworkId)
-    // 'default' means "don't override": nothing is sent over ACP or framework config, so the agent
-    // keeps its own default effort. A concrete intent is projected through the active model profile
-    // exactly once here, then delivered through the framework config and ACP session channels. Those
-    // transports receive the same model-native value and must not independently reinterpret it.
-
-    // Enforce provider↔framework compatibility up front so an incompatible pair fails with a clear
-    // message instead of spawning an agent that can't use the credentials — e.g. OpenCode + a Local
-    // Claude provider (Claude-only login), or Claude + an OpenAI-only gateway.
-    const activeProvider = settings.activeProviderId
-      ? settings.providers.find((provider) => provider.id === settings.activeProviderId)
-      : undefined
-
-    if (!activeProvider) {
-      throw new Error(NO_ACTIVE_PROVIDER_MESSAGE)
-    }
-
-    // Resolve the model exactly once for this backend generation. The same selection drives the
-    // model profile, bridge compatibility, and the framework config so a refreshed catalog cannot
-    // make the effort belong to one model while the request is sent to another.
-    const effectiveModel = this.providers.resolveActiveModel(activeProvider, settings.activeModel)
-    const effortIntent = settings.reasoningEffort ?? DEFAULT_REASONING_EFFORT
-    const reasoningEffortProfile = resolveProviderReasoningEffortProfile(
-      activeProvider,
-      effectiveModel
-    )
-    const resolvedEffort =
-      effortIntent === DEFAULT_REASONING_EFFORT
-        ? DEFAULT_REASONING_EFFORT
-        : resolveReasoningEffortValue(effortIntent, reasoningEffortProfile)
-    const sessionEffort: ModelReasoningEffort | undefined =
-      resolvedEffort === 'default' ? undefined : resolvedEffort
-    const supportedReasoningEfforts = reasoningEffortProfile.supported
-      ? [...new Set(reasoningEffortProfile.slots)]
-      : undefined
-
-    if (
-      !isProviderUsableByFramework(
-        {
-          apiEndpoints: this.providers.resolveProviderApiEndpoints(activeProvider, effectiveModel),
-          type: activeProvider.type
-        },
-        framework
-      )
-    ) {
-      throw new Error(buildActiveModelIncompatibleMessage(framework.displayName))
-    }
-
-    const activeConnectorIds = this.connectors.enabledConnectorIds(settings.connectors)
-    const connectorInstructions = renderConnectorInstructions(activeConnectorIds)
-
-    if (framework.id === 'codex' && !isModelBridgeSupported(activeProvider, effectiveModel)) {
-      throw new Error(CODEX_BRIDGE_UNSUPPORTED_MESSAGE)
-    }
-
-    if (framework.id === 'claude-code') {
-      // Claude path: app-owned runtime provisioning + Anthropic-shaped env + local-auth handling.
-      const { envOverrides, executablePath, sessionOptions, contextWindow } =
-        await this.resolveSpawnConfig(settings, forcedSkillIds, { model: effectiveModel })
-
-      return {
-        framework,
-        backendId: `${framework.id}:${activeProvider.id}`,
-        executablePath,
-        env: envOverrides,
-        sessionOptions,
-        sessionEffort,
-        contextWindow,
-        contextUsageModel: effectiveModel
-      }
-    }
-
-    const executablePath =
-      framework.id === 'codex'
-        ? await this.runtimeManager.resolveCodexExecutable(
-            settings.codex?.resolvedPath,
-            settings.codex?.nativePath
-          )
-        : await this.runtimeManager.resolveOpencodeExecutable(settings.opencodePath)
-    // Model metadata is a compatibility contract with the native Codex binary that is about to
-    // start. Probe that exact executable now instead of trusting a cached version from detection;
-    // a missing or stale cache must only make us choose the conservative generated catalog.
-    const codexNativeVersion =
-      framework.id === 'codex'
-        ? await this.runtimeManager.probeCodexNativeVersion(settings.codex?.nativePath)
-        : undefined
-    const provider = this.providers.resolveProvider(activeProvider, effectiveModel)
-    if (framework.id === 'codex' && isCodexSubscriptionProvider(provider.type)) {
-      // Runtime resolution can be reached without opening a Settings auth session first. Enforce
-      // file-backed credentials here as well so a direct prompt never falls through to the user's
-      // global Codex keyring.
-      await ensureCodexAuthHome('isolated', this.storageRoot)
-    }
-    // `codex-shared` is accepted only as a legacy/provider-time import request. Every runtime
-    // subscription record converges on the same app-owned backend and profile boundary.
-    const backendProviderId =
-      framework.id === 'codex' && isCodexSubscriptionProvider(provider.type)
-        ? CODEX_ISOLATED_PROVIDER_ID
-        : activeProvider.id
-    const skillsRoot =
-      framework.id === 'codex'
-        ? isCodexSubscriptionProvider(provider.type)
-          ? codexSubscriptionStorageDir(this.storageRoot)
-          : codexStorageDir(this.storageRoot)
-        : opencodeConfigDir(this.storageRoot)
-    await this.runtimeManager.materializeAgentSkills(settings, skillsRoot, forcedSkillIds)
-    // Chat-only providers require protocol translation. Non-OpenAI native Responses providers keep
-    // their protocol, but use a narrow compatibility proxy because Codex emits namespace tools while
-    // several compatible APIs accept only flat function names. Official OpenAI and subscriptions
-    // already implement Codex's native wire contract and remain direct.
-    const needsChatResponsesBridge = requiresChatCompletionsBridge(provider, framework)
-    const needsNativeResponsesCompatibility = requiresNativeResponsesCompatibility(
-      provider,
-      framework
-    )
-    // A bridge may still serve a live Codex runtime from an earlier framework generation. Do not stop
-    // or retarget it merely because the newly selected framework/provider does not need one.
-    const responsesBridge = needsChatResponsesBridge
-      ? await this.ensureResponsesBridge(
-          provider,
-          sessionEffort,
-          settings.conversationSkillImportEnabled ?? DEFAULT_CONVERSATION_SKILL_IMPORT_ENABLED
-        )
-      : needsNativeResponsesCompatibility
-        ? await this.ensureNativeResponsesCompatibility(provider)
-        : undefined
-    try {
-      const modelConfig = framework.prepareModelConfig(provider, {
-        storageRoot: this.storageRoot,
-        executablePath,
-        ...(codexNativeVersion ? { nativeVersion: codexNativeVersion } : {}),
-        responsesBridge,
-        reasoningEffort: sessionEffort,
-        reasoningEfforts: supportedReasoningEfforts,
-        // Keep only connector calling conventions in OpenCode's baseline. Detailed tools are already
-        // materialized as on-demand `mcp-*` skills above, avoiding a full catalog in every request.
-        instructions: connectorInstructions
-      })
-      await this.runtimeManager.materializeAgentConfigFiles(modelConfig.configFiles)
-      const opencodeUsagePort =
-        framework.id === 'opencode'
-          ? await this.runtimeManager.reserveOpenCodeUsagePort()
-          : undefined
-      const opencodeUsagePassword = opencodeUsagePort === undefined ? undefined : randomUUID()
-      const usesCodexSystemProxy =
-        framework.id === 'codex' && isCodexSubscriptionProvider(provider.type)
-      const proxyEnv = usesCodexSystemProxy
-        ? await this.runtimeManager.resolveCodexProxyEnvironment()
-        : undefined
-
-      // Protocol-driven frameworks apply an explicit model through the ACP session configOption. A Codex
-      // subscription with no explicit selection leaves this undefined so Codex uses the account default.
-      const sessionModel = modelConfig.sessionModel ?? provider.model
-      return {
-        framework,
-        backendId: `${framework.id}:${backendProviderId}`,
-        executablePath,
-        env: {
-          ...(modelConfig.env ?? {}),
-          ...(opencodeUsagePassword ? { OPENCODE_SERVER_PASSWORD: opencodeUsagePassword } : {}),
-          ...(proxyEnv ?? {}),
-          ...(framework.id === 'codex' && settings.codex?.nativePath
-            ? { CODEX_PATH: settings.codex.nativePath }
-            : {})
-        },
-        args:
-          opencodeUsagePort === undefined
-            ? modelConfig.args
-            : [
-                ...(modelConfig.args ?? []),
-                '--port',
-                String(opencodeUsagePort),
-                '--hostname',
-                '127.0.0.1'
-              ],
-        ...(usesCodexSystemProxy
-          ? { proxyEnvironmentMode: proxyEnv === undefined ? 'inherit' : 'replace' }
-          : {}),
-        sessionModel,
-        ...(framework.id === 'codex' && isCodexSubscriptionProvider(provider.type) && sessionModel
-          ? { sessionModelRequired: true }
-          : {}),
-        sessionEffort,
-        contextWindow: provider.contextWindow,
-        contextUsageModel: provider.model,
-        authentication: modelConfig.authentication,
-        providerConfiguration: modelConfig.providerConfiguration,
-        ...(opencodeUsagePort === undefined || !opencodeUsagePassword
-          ? {}
-          : {
-              opencodeUsageApi: {
-                baseUrl: `http://127.0.0.1:${opencodeUsagePort}`,
-                authorization: `Basic ${Buffer.from(`opencode:${opencodeUsagePassword}`).toString('base64')}`
-              }
-            }),
-        responsesBridgeLease: responsesBridge?.lease
-      }
-    } catch (error) {
-      await responsesBridge?.lease.release()
-      throw error
-    }
-  }
-
-  private async ensureResponsesBridge(
-    provider: ResolvedProvider,
-    reasoningEffort: ModelReasoningEffort | undefined,
-    conversationSkillImportEnabled: boolean
-  ): Promise<LeasedResponsesBridgeConnection> {
-    // Resolve to the OpenAI base the bridge appends `/chat/completions` to: an official vendor's exact
-    // versioned base, or a custom gateway root normalized to `<root>/v1`.
-    const targetBaseUrl = openAiCompletionsBase(provider)
-    if (!targetBaseUrl) throw new Error('The Chat Completions provider has no base URL.')
-
-    const target = {
-      baseUrl: targetBaseUrl,
-      key: provider.key,
-      vendorId: provider.vendorId,
-      reasoningEffortTransport: provider.reasoningEffortTransport,
-      model: provider.model,
-      reasoningEffort,
-      namespacedTools: [
-        ...CODEX_BRIDGE_NOTEBOOK_TOOLS,
-        ...CODEX_BRIDGE_ARTIFACT_TOOLS,
-        ...CODEX_BRIDGE_ACTIVITY_TOOLS,
-        ...(conversationSkillImportEnabled ? CODEX_BRIDGE_SKILL_IMPORT_TOOLS : [])
-      ],
-      reviewerScope: {
-        namespacedTools: REVIEWER_BRIDGE_NAMESPACED_TOOLS
-      }
-    }
-    const bridgeId = randomUUID()
-    const bridge = new ResponsesBridge(target)
-    const entry = { bridge, connection: bridge.start() }
-    this.responsesBridges.set(bridgeId, entry)
-
-    let connection: ResponsesBridgeConnection
-    try {
-      connection = await entry.connection
-    } catch (error) {
-      if (this.responsesBridges.get(bridgeId) === entry) this.responsesBridges.delete(bridgeId)
-      await entry.bridge.close().catch(() => undefined)
-      throw error
-    }
-
-    let released = false
-    const leasedEntry = entry
-    return {
-      ...connection,
-      lease: {
-        selectSkills: (text, catalog, signal) =>
-          leasedEntry.bridge.selectSkills(text, catalog, signal),
-        registerReviewerSession: (promptCacheKey) =>
-          leasedEntry.bridge.registerReviewerSession(promptCacheKey),
-        unregisterReviewerSession: (promptCacheKey) =>
-          leasedEntry.bridge.unregisterReviewerSession(promptCacheKey),
-        setReasoningEffort: (effort) => leasedEntry.bridge.setReasoningEffort(effort),
-        release: async () => {
-          if (released) return
-          released = true
-          if (this.responsesBridges.get(bridgeId) !== leasedEntry) return
-          this.responsesBridges.delete(bridgeId)
-          await leasedEntry.bridge.close()
-        }
-      }
-    }
-  }
-
-  private async ensureNativeResponsesCompatibility(
-    provider: ResolvedProvider
-  ): Promise<LeasedResponsesBridgeConnection> {
-    const targetBaseUrl = normalizeResponsesBaseUrl(provider.openaiBaseUrl ?? provider.baseUrl)
-    if (!targetBaseUrl) throw new Error('The native Responses provider has no base URL.')
-
-    const proxyId = randomUUID()
-    const proxy = new NativeResponsesCompatibilityProxy({
-      baseUrl: targetBaseUrl,
-      key: provider.key,
-      model: provider.model,
-      reviewerScope: { namespacedTools: REVIEWER_BRIDGE_NAMESPACED_TOOLS }
-    })
-    const entry = { proxy, connection: proxy.start() }
-    this.nativeResponsesCompatibilityProxies.set(proxyId, entry)
-
-    let connection: ResponsesBridgeConnection
-    try {
-      connection = await entry.connection
-    } catch (error) {
-      if (this.nativeResponsesCompatibilityProxies.get(proxyId) === entry) {
-        this.nativeResponsesCompatibilityProxies.delete(proxyId)
-      }
-      await entry.proxy.close().catch(() => undefined)
-      throw error
-    }
-
-    let released = false
-    const leasedEntry = entry
-    return {
-      ...connection,
-      lease: {
-        selectSkills: (text, catalog, signal) =>
-          leasedEntry.proxy.selectSkills(text, catalog, signal),
-        registerReviewerSession: (promptCacheKey) =>
-          leasedEntry.proxy.registerReviewerSession(promptCacheKey),
-        unregisterReviewerSession: (promptCacheKey) =>
-          leasedEntry.proxy.unregisterReviewerSession(promptCacheKey),
-        release: async () => {
-          if (released) return
-          released = true
-          if (this.nativeResponsesCompatibilityProxies.get(proxyId) !== leasedEntry) return
-          this.nativeResponsesCompatibilityProxies.delete(proxyId)
-          await leasedEntry.proxy.close()
-        }
-      }
-    }
-  }
-
-  private resolveReasoningEffortFromSettings(
-    settings: StoredSettings,
-    intent: ReasoningEffort
-  ): ResolvedReasoningEffort {
-    if (intent === DEFAULT_REASONING_EFFORT) return DEFAULT_REASONING_EFFORT
-
-    const provider = settings.activeProviderId
-      ? settings.providers.find((candidate) => candidate.id === settings.activeProviderId)
-      : undefined
-    if (!provider) return DEFAULT_REASONING_EFFORT
-
-    const profile = resolveProviderReasoningEffortProfile(
-      provider,
-      this.providers.resolveActiveModel(provider, settings.activeModel)
-    )
-
-    return resolveReasoningEffortValue(intent, profile)
+    return this.backendResolver.resolveSelection(selection, context)
   }
 }
 
@@ -1487,3 +912,8 @@ const createDefaultSettingsService = (): SettingsService => new SettingsService(
 
 export { SettingsService, createDefaultSettingsService }
 export type { CustomServerSecurityChangeGuard }
+export type {
+  AgentBackendResolutionContext,
+  AgentBackendSelection,
+  AgentSpawnConfig
+} from './backend-resolver'


### PR DESCRIPTION
## Problem

`SettingsService` still owned backend selection, provider/model projection, framework preparation, and live Responses bridge/proxy generations. That mixed persistent settings orchestration with ephemeral runtime state and made the façade continue growing after runtime installation management was extracted.

## Proposed change

- Add `AgentBackendResolver` as the owner of one backend resolution flow and its live bridge/proxy generations.
- Keep `SettingsService` as the existing façade; all public method signatures and type exports remain stable.
- Let `ProviderAccountsModule` project pure runtime targets and a separate secret-free reasoning capability profile.
- Preserve configured selection as `{ frameworkId }`, with provider/model/reasoning late-bound at resolution time.
- Add an internal explicit target seam for a fixed provider/model/reasoning request. Known unavailable required models fail before runtime preparation; an unknown catalog preserves the exact requested model and never falls back.
- Add direct ownership and lifecycle coverage for bridge/proxy generations and ACP lease release.

```mermaid
flowchart LR
  F["SettingsService façade"] --> R["AgentBackendResolver"]
  R --> P["ProviderAccountsModule\nmodel and capability projection"]
  R --> M["AgentRuntimeManager\nexecutable and materialization"]
  R --> C["ConnectorSettingsModule\nenabled connector projection"]
  R --> B["Responses bridge / native proxy\ngeneration + lease ownership"]
  R --> O["ResolvedAgentBackend"]
  O --> A["AcpRuntime\nlease consumer + teardown"]
```

## Scope and non-goals

- Internal architecture/state-ownership change only; no data model, data relationship, persistence schema, or user-interaction change.
- No changes to Electron preload/IPC, Web RPC/API map, CLI/SDK, Task API, or ACP public contracts.
- Specialist, Permission, and Compute behavior and their current cross-surface capability asymmetry remain unchanged.
- No Electron adapter install/uninstall changes; the rollback boundary from #589 remains intact.
- Forward-compatible with #458 through an internal, non-secret explicit target only. This PR does not add orchestration metadata, session trees, permissions, budgets, events, persistence, or public APIs.
- Local planning documents under `docs/internal/` remain ignored and are not part of this PR.

## Acceptance criteria and validation

All checks below ran after the final material edit and independent Standards, Spec, and cross-surface reviews reported no remaining P0-P2 findings.

- Provider target projection, exact required-model semantics, secret-free capability lookup, explicit/configured selection, framework delegation, generation isolation, and cleanup -> `npm test -- --run src/main/settings/backend-resolver.test.ts src/main/settings/provider-accounts.test.ts` -> 27/27 passed.
- Settings façade, bridge/proxy integration, IPC, and ACP lease lifecycle -> focused Settings/ACP suite -> 571/571 passed.
- Node and Web type contracts -> `npm run typecheck` -> passed.
- Repository lint -> `npm run lint` -> 0 errors; 23 pre-existing warnings.
- Web transport contract -> `npm run check:web-api-map` -> passed, no generated API change.
- CLI/SDK contract -> `npm run test:cli` -> 29/29 passed.
- Full repository regression -> `npm test` -> 636 files passed, 15 skipped; 9,407 tests passed, 184 skipped.

Uncovered risk: real provider processes and external APIs are not launched by the unit suite. The resolver keeps the existing framework adapters and provider preparation code paths, while fakes and loopback integration tests cover their ownership and cleanup contracts.

## Review focus

- `AgentBackendResolver` constructor remains side-effect free; resources start only during resolution.
- Plaintext credentials exist only in ephemeral backend targets, while reasoning capability lookup remains secret-free.
- Overlapping bridge/proxy generations retain independent effort/reviewer state and release idempotently.
- Configured selections continue late-binding current settings; explicit targets remain fixed and private to the resolver.
- Existing Electron/Web/CLI/Task/ACP and Specialist/Permission/Compute contracts remain unchanged.

Relates to #458.
