### PR TITLE
refactor(main): introduce typed application event hub

### DIFF
--- a/src/main/acp/ipc.ts
+++ b/src/main/acp/ipc.ts
@@ -106,10 +106,8 @@ type AcpIpcOptions = AcpIpcArtifacts & {
   profileService?: ProfileService
 }
 
-// Sends one runtime payload to every currently open renderer window.
-const broadcast = <Payload>(channel: string, payload: Payload): void => {
-  broadcastToRenderers(channel, payload)
-}
+// Sends one runtime payload through the typed application-event compatibility facade.
+const broadcast = broadcastToRenderers
 
 // Gives every new conversation an isolated working directory under the relocatable data root.
 // Persisted sessions keep this returned path as their cwd, so resumes return to the same workspace.

--- a/src/main/application-event-flow.test.ts
+++ b/src/main/application-event-flow.test.ts
@@ -1,0 +1,99 @@
+import { beforeEach, describe, expect, it, vi } from 'vitest'
+
+const windows: Array<{
+  isDestroyed: () => boolean
+  webContents: { send: ReturnType<typeof vi.fn> }
+}> = []
+
+vi.mock('electron', () => ({
+  BrowserWindow: { getAllWindows: () => windows }
+}))
+
+import type { AcpRuntimeEvent } from '../shared/acp'
+import { ApplicationEventHub } from './application-events'
+import { broadcastToRenderers, installRendererBroadcastEventHub } from './renderer-broadcast'
+import {
+  projectPublicTaskEvent,
+  projectTaskRuntimeEvent,
+  projectWebRendererEvent
+} from './web-service/application-event-projections'
+
+beforeEach(() => {
+  windows.length = 0
+})
+
+describe('application event flow', () => {
+  it('delivers terminal stop and failure events once in Electron, Task, and Web order', () => {
+    const order: string[] = []
+    const payloads: AcpRuntimeEvent[] = [
+      {
+        id: 'stop-1',
+        timestamp: 100,
+        kind: 'stop',
+        level: 'info',
+        sessionId: 'session-1',
+        turnUsage: {
+          inputTokens: 12,
+          cacheTokens: 7,
+          cachedReadTokens: 5,
+          cachedWriteTokens: 2,
+          outputTokens: 4,
+          turnCount: 3
+        }
+      },
+      {
+        id: 'failure-1',
+        timestamp: 101,
+        kind: 'error',
+        level: 'error',
+        sessionId: 'session-1',
+        text: 'provider failed',
+        providerError: true
+      }
+    ]
+    windows.push({
+      isDestroyed: () => false,
+      webContents: {
+        send: vi.fn((_channel, payload: AcpRuntimeEvent) => {
+          order.push(`electron:${payload.kind}`)
+        })
+      }
+    })
+    const hub = new ApplicationEventHub()
+    const uninstall = installRendererBroadcastEventHub(hub)
+    const removeTask = hub.subscribe((event) => {
+      const projection = projectTaskRuntimeEvent(event)
+      if (projection) order.push(`task:${projection.kind}`)
+    })
+    const removeWeb = hub.subscribe((event) => {
+      const rendererProjection = projectWebRendererEvent(event)
+      if (rendererProjection) {
+        order.push(`web:${(rendererProjection.payload as AcpRuntimeEvent).kind}`)
+      }
+      const publicProjection = projectPublicTaskEvent(event)
+      if (publicProjection?.type === 'run.event') {
+        order.push(`public:${publicProjection.data.kind}`)
+      }
+    })
+
+    for (const payload of payloads) broadcastToRenderers('acp:event', payload)
+
+    expect(order).toEqual([
+      'electron:stop',
+      'task:stop',
+      'web:stop',
+      'public:stop',
+      'electron:error',
+      'task:error',
+      'web:error',
+      'public:error'
+    ])
+    expect(windows[0].webContents.send).toHaveBeenNthCalledWith(1, 'acp:event', payloads[0])
+    expect(windows[0].webContents.send).toHaveBeenNthCalledWith(2, 'acp:event', payloads[1])
+
+    removeWeb()
+    removeTask()
+    uninstall()
+    hub.dispose()
+  })
+})

--- a/src/main/application-events.test.ts
+++ b/src/main/application-events.test.ts
@@ -1,0 +1,78 @@
+import { describe, expect, expectTypeOf, it, vi } from 'vitest'
+
+import type { AcpRuntimeEvent } from '../shared/acp'
+import {
+  ApplicationEventHub,
+  type ApplicationEvent,
+  type ApplicationEventMap
+} from './application-events'
+
+describe('ApplicationEventHub', () => {
+  it('binds known channels to their payload types', () => {
+    expectTypeOf<ApplicationEventMap['acp:event']>().toEqualTypeOf<AcpRuntimeEvent>()
+    expectTypeOf<ApplicationEvent<'specialist:catalog-changed'>>().toEqualTypeOf<
+      Readonly<{ channel: 'specialist:catalog-changed'; payload: undefined }>
+    >()
+  })
+
+  it('publishes one immutable event to subscribers in registration order', () => {
+    const hub = new ApplicationEventHub()
+    const deliveries: string[] = []
+    const first = vi.fn((event: ApplicationEvent) => {
+      deliveries.push(`first:${event.channel}`)
+      expect(Object.isFrozen(event)).toBe(true)
+    })
+    const second = vi.fn((event: ApplicationEvent) => deliveries.push(`second:${event.channel}`))
+    hub.subscribe(first)
+    hub.subscribe(second)
+
+    const event: AcpRuntimeEvent = {
+      id: 'event-1',
+      timestamp: 10,
+      kind: 'stop',
+      level: 'info',
+      sessionId: 'session-1'
+    }
+    hub.publish('acp:event', event)
+
+    expect(deliveries).toEqual(['first:acp:event', 'second:acp:event'])
+    expect(first).toHaveBeenCalledWith({ channel: 'acp:event', payload: event })
+    expect(second).toHaveBeenCalledWith({ channel: 'acp:event', payload: event })
+  })
+
+  it('preserves live Set cancellation and failure propagation semantics', () => {
+    const hub = new ApplicationEventHub()
+    const skipped = vi.fn()
+    const removeSkipped = hub.subscribe(skipped)
+    const failure = new Error('listener failed')
+    const afterFailure = vi.fn()
+    hub.subscribe(() => {
+      removeSkipped()
+      throw failure
+    })
+    hub.subscribe(afterFailure)
+
+    // Move the cancelling listener before the listener it removes while keeping the test explicit.
+    removeSkipped()
+    hub.subscribe(skipped)
+
+    expect(() => hub.publish('specialist:catalog-changed', undefined)).toThrow(failure)
+    expect(skipped).not.toHaveBeenCalled()
+    expect(afterFailure).not.toHaveBeenCalled()
+  })
+
+  it('clears subscriptions and ignores late work after disposal', () => {
+    const hub = new ApplicationEventHub()
+    const listener = vi.fn()
+    const unsubscribe = hub.subscribe(listener)
+
+    hub.dispose()
+    hub.dispose()
+    unsubscribe()
+    hub.publish('specialist:catalog-changed', undefined)
+    hub.subscribe(listener)
+    hub.publish('specialist:catalog-changed', undefined)
+
+    expect(listener).not.toHaveBeenCalled()
+  })
+})

--- a/src/main/application-events.ts
+++ b/src/main/application-events.ts
@@ -1,0 +1,153 @@
+import type { AcpPermissionRequest, AcpRuntimeEvent, AcpStateSnapshot } from '../shared/acp'
+import type { ComputeApprovalRequest, JobSummary } from '../shared/compute'
+import type { DownloadProgress } from '../shared/download-progress'
+import type {
+  Project,
+  ProjectDeletedEvent,
+  SessionDeletedEvent,
+  SessionUpsertEvent
+} from '../shared/lifecycle-events'
+import type { NotebookAvailableEvent, NotebookChangedEvent } from '../shared/notebook'
+import type { PermissionGrantsChangedEvent } from '../shared/permission-grants'
+import type { ProjectFilesChangedEvent } from '../shared/project-files'
+import type {
+  ReviewSessionRequest,
+  ReviewSuppressionEvent,
+  ReviewUpdateEvent
+} from '../shared/reviewer'
+import type {
+  ClaudeInstallEvent,
+  ConnectorApprovalRequest,
+  ConversationSkillImportApprovalRequest
+} from '../shared/settings'
+import type { PendingSwitchBroadcast } from '../shared/specialist'
+import type { MigrationProgress } from '../shared/storage'
+import type { UpdateStatus } from '../shared/update'
+
+// This catalog describes only events that already flow through renderer-broadcast. Window-only
+// signals and generated Web-only channels stay on their existing transports until their owner moves
+// them deliberately.
+export type ApplicationEventMap = {
+  'acp:state': AcpStateSnapshot
+  'acp:event': AcpRuntimeEvent
+  'acp:permission-request': AcpPermissionRequest
+  'notebook:available': NotebookAvailableEvent
+  'notebook:changed': NotebookChangedEvent
+  'project:created': Project
+  'project:updated': Project
+  'project:deleted': ProjectDeletedEvent
+  'session:created': SessionUpsertEvent
+  'session:updated': SessionUpsertEvent
+  'session:deleted': SessionDeletedEvent
+  'project-files:changed': ProjectFilesChangedEvent
+  'permissions:changed': PermissionGrantsChangedEvent
+  'connectors:approval-request': ConnectorApprovalRequest
+  'skills:conversation-import-request': ConversationSkillImportApprovalRequest
+  'skills:conversation-import-settled': string
+  'compute:approval-request': ComputeApprovalRequest
+  'compute:job-updated': JobSummary
+  'specialist:catalog-changed': undefined
+  'specialist:pending-switch': PendingSwitchBroadcast
+  'settings:install-log': ClaudeInstallEvent
+  'storage:migrate-progress': MigrationProgress
+  'reviewer:updated': ReviewUpdateEvent
+  'reviewer:suppress-next-auto-review': ReviewSuppressionEvent
+  'reviewer:fix-loop-start': ReviewSessionRequest
+  'reviewer:fix-loop-end': ReviewSessionRequest
+  'remote-access:changed': Record<string, never>
+  'update:status': UpdateStatus
+  'update:progress': DownloadProgress
+}
+
+export type ApplicationEventChannel = keyof ApplicationEventMap
+
+export type ApplicationEvent<Channel extends ApplicationEventChannel = ApplicationEventChannel> = {
+  [CurrentChannel in Channel]: Readonly<{
+    channel: CurrentChannel
+    payload: ApplicationEventMap[CurrentChannel]
+  }>
+}[Channel]
+
+export type ApplicationEventListener = (event: ApplicationEvent) => void
+
+export type ApplicationEventPublisher = {
+  publish<Channel extends ApplicationEventChannel>(
+    channel: Channel,
+    payload: ApplicationEventMap[Channel]
+  ): void
+}
+
+export type ApplicationEventSource = {
+  subscribe(listener: ApplicationEventListener): () => void
+}
+
+export type ApplicationEvents = ApplicationEventPublisher & ApplicationEventSource
+
+export type ApplicationEventInstaller = (events: ApplicationEvents) => () => void
+
+export type ApplicationEventModule = {
+  name: 'application-events'
+  capability: ApplicationEvents
+  start(): void
+  rollback(): void
+  dispose(): void
+}
+
+// Owns in-process publication order and subscription lifetime. It deliberately knows nothing about
+// Electron, WebSocket serialization, public allowlists, or durable state.
+export class ApplicationEventHub implements ApplicationEvents {
+  private readonly listeners = new Set<ApplicationEventListener>()
+  private disposed = false
+
+  publish<Channel extends ApplicationEventChannel>(
+    channel: Channel,
+    payload: ApplicationEventMap[Channel]
+  ): void {
+    if (this.disposed) return
+    const event = Object.freeze({ channel, payload }) as ApplicationEvent
+
+    // Iterate the live Set deliberately. The compatibility broadcaster used the same semantics:
+    // removing a not-yet-called listener skips it in the active publication, and listener failures
+    // stop later delivery and propagate to the publisher.
+    for (const listener of this.listeners) listener(event)
+  }
+
+  subscribe(listener: ApplicationEventListener): () => void {
+    if (this.disposed) return () => undefined
+    this.listeners.add(listener)
+
+    return () => {
+      this.listeners.delete(listener)
+    }
+  }
+
+  dispose(): void {
+    if (this.disposed) return
+    this.disposed = true
+    this.listeners.clear()
+  }
+}
+
+// The runtime registers this module first, so reverse disposal keeps publication and every
+// projection alive while later-owned backends emit their final shutdown events.
+export const createApplicationEventModule = (
+  install: ApplicationEventInstaller
+): ApplicationEventModule => {
+  const hub = new ApplicationEventHub()
+  let uninstall: (() => void) | undefined
+  const dispose = (): void => {
+    uninstall?.()
+    uninstall = undefined
+    hub.dispose()
+  }
+
+  return {
+    name: 'application-events',
+    capability: hub,
+    start: () => {
+      uninstall = install(hub)
+    },
+    rollback: dispose,
+    dispose
+  }
+}

--- a/src/main/application-runtime.test.ts
+++ b/src/main/application-runtime.test.ts
@@ -6,6 +6,7 @@ import {
   shutdownApplicationSurfaces,
   withApplicationRuntimeShutdown
 } from './application-runtime'
+import { createApplicationEventModule } from './application-events'
 
 describe('application runtime composition', () => {
   it('constructs and starts each module once through declared dependencies', async () => {
@@ -233,6 +234,42 @@ describe('application runtime composition', () => {
 
     await runtime.dispose()
     expect(order).toEqual(['start', 'created', 'install', 'uninstall', 'dispose'])
+  })
+
+  it('keeps application event publication alive until later-owned backends finish disposal', async () => {
+    const order: string[] = []
+    let emitTerminalEvent = (): void => undefined
+
+    const runtime = await composeApplicationRuntime(async (modules) => {
+      const events = await modules.add((installedEvents) => {
+        emitTerminalEvent = () =>
+          installedEvents.publish('acp:event', {
+            id: 'event-1',
+            timestamp: 100,
+            kind: 'stop',
+            level: 'info',
+            sessionId: 'session-1',
+            turnUsage: { inputTokens: 3, cacheTokens: 2, outputTokens: 1 }
+          })
+        return () => order.push('uninstall:application-events')
+      }, createApplicationEventModule)
+      events.subscribe((event) => {
+        if (event.channel === 'acp:event') order.push(`event:${event.payload.kind}`)
+      })
+      await modules.add(undefined, () => ({
+        capability: undefined,
+        dispose: () => {
+          order.push('dispose:backend')
+          emitTerminalEvent()
+        }
+      }))
+      return {}
+    })
+
+    await runtime.dispose()
+    emitTerminalEvent()
+
+    expect(order).toEqual(['dispose:backend', 'event:stop', 'uninstall:application-events'])
   })
 })
 

--- a/src/main/index.ts
+++ b/src/main/index.ts
@@ -207,6 +207,7 @@ async function startElectronApp(mainEntryPath: string): Promise<void> {
       const webMode = parseWebModeOptions(process.argv)
       // Pass the concrete main entry path so ACP can launch the artifact MCP server from the same bundle.
       const {
+        applicationEvents,
         taskNotifications,
         settingsService,
         sessionDeletionCapability,
@@ -280,7 +281,8 @@ async function startElectronApp(mainEntryPath: string): Promise<void> {
       const webController = createWebServiceController({
         rpc: webRpc,
         requestQuit: () => app.quit(),
-        externalAccess: remoteAccess.webAccess
+        externalAccess: remoteAccess.webAccess,
+        applicationEvents
       })
       remoteAccess.attachWebController(webController)
       registerRemoteAccessIpcHandlers(remoteAccess)

--- a/src/main/ipc.ts
+++ b/src/main/ipc.ts
@@ -9,6 +9,7 @@ import {
   composeApplicationRuntimeWithAdapters,
   type ApplicationModuleBuilder
 } from './application-runtime'
+import { createApplicationEventModule, type ApplicationEventSource } from './application-events'
 
 import { createAcpRuntime, createDefaultNotebookRuntimeService } from './acp/ipc'
 import { createDefaultArtifactRepository, registerArtifactIpcHandlers } from './artifacts/ipc'
@@ -132,7 +133,7 @@ import { registerUpdateIpcHandlers } from './update/ipc'
 import { createUpdateStrategy } from './update/create-strategy'
 import { startUpdateScheduler } from './update/scheduler'
 import { createDefaultUploadRepository, registerUploadIpcHandlers } from './uploads/ipc'
-import { broadcastToRenderers } from './renderer-broadcast'
+import { broadcastToRenderers, installRendererBroadcastEventHub } from './renderer-broadcast'
 import {
   installElectronRuntimeAdapters,
   type ElectronRuntimeAdapterInterfaces,
@@ -156,6 +157,7 @@ type IpcRegistrationOptions = {
 }
 
 export type ApplicationRuntimeInterfaces = {
+  applicationEvents: ApplicationEventSource
   taskNotifications: Pick<
     TaskNotificationService,
     'setActivationHandler' | 'setAttentionHandlers' | 'setPendingOpenSession' | 'setUnreadHandler'
@@ -249,6 +251,10 @@ const createApplicationModules = async (
       }
     })
   }
+  const applicationEvents = await modules.add(
+    installRendererBroadcastEventHub,
+    createApplicationEventModule
+  )
   // One settings service backs both the settings IPC and the ACP spawn config (single source of truth).
   const settingsService = await modules.add(undefined, () => ({
     capability: createDefaultSettingsService()
@@ -1210,6 +1216,7 @@ const createApplicationModules = async (
   backendTeardownOwnedByCoordinator = true
 
   return {
+    applicationEvents,
     taskNotifications,
     settingsService,
     sessionDeletionCapability: sessionPersistenceCoordinator,

--- a/src/main/lifecycle-broadcast.ts
+++ b/src/main/lifecycle-broadcast.ts
@@ -3,13 +3,17 @@ import { ipcMainHandle } from './ipc-handler-registry'
 import { LIFECYCLE_CHANNELS } from '../shared/lifecycle-events'
 import { callerContextForEvent, type CallerContext } from './caller-context'
 import { createLogger } from './logger'
+import type { ApplicationEventChannel, ApplicationEventMap } from './application-events'
 import { broadcastToRenderers } from './renderer-broadcast'
 
 const log = createLogger('lifecycle-broadcast')
 
 // Lifecycle notifications keep first-party clients fresh, but a disconnected renderer must never
 // turn an already-committed repository mutation into a failed RPC.
-const broadcastLifecycleEvent = <Payload>(channel: string, payload: Payload): void => {
+const broadcastLifecycleEvent = <Channel extends ApplicationEventChannel>(
+  channel: Channel,
+  payload: ApplicationEventMap[Channel]
+): void => {
   try {
     broadcastToRenderers(channel, payload)
   } catch (error) {

--- a/src/main/notifications/electron-wiring.ts
+++ b/src/main/notifications/electron-wiring.ts
@@ -56,7 +56,10 @@ export const buildTaskNotificationShow =
 // to the wrong broadcast channel) would break notification click-to-open without TaskNotificationService
 // tests catching it.
 export type BuildConnectorApprovalBroadcastDeps = {
-  broadcastToRenderers: (channel: string, payload: ConnectorApprovalRequest) => void
+  broadcastToRenderers: (
+    channel: 'connectors:approval-request',
+    payload: ConnectorApprovalRequest
+  ) => void
   taskNotifications: Pick<TaskNotificationService, 'handleConnectorApproval'>
   onNotificationError?: (error: unknown) => void
 }
@@ -72,7 +75,10 @@ export const buildConnectorApprovalBroadcast =
   }
 
 export type BuildComputeApprovalBroadcastDeps = {
-  broadcastToRenderers: (channel: string, payload: ComputeApprovalRequest) => void
+  broadcastToRenderers: (
+    channel: 'compute:approval-request',
+    payload: ComputeApprovalRequest
+  ) => void
   taskNotifications: Pick<TaskNotificationService, 'handleComputeApproval'>
   onNotificationError?: (error: unknown) => void
 }
@@ -90,7 +96,10 @@ export const buildComputeApprovalBroadcast =
   }
 
 export type BuildSkillImportApprovalBroadcastDeps = {
-  broadcastToRenderers: (channel: string, payload: ConversationSkillImportApprovalRequest) => void
+  broadcastToRenderers: (
+    channel: 'skills:conversation-import-request',
+    payload: ConversationSkillImportApprovalRequest
+  ) => void
   taskNotifications: Pick<TaskNotificationService, 'handleSkillImportApproval'>
   onNotificationError?: (error: unknown) => void
 }

--- a/src/main/remote-access/service.ts
+++ b/src/main/remote-access/service.ts
@@ -26,7 +26,10 @@ type RemoteAccessServiceDeps = {
   enableRemoteIt?: typeof enableRemoteItServices
   ensureRemoteItLink?: typeof ensureRemoteItConnectLink
   disableRemoteItLink?: typeof disableRemoteItConnectLink
-  broadcast?: (channel: string, payload: unknown) => void
+  broadcast?: (
+    channel: typeof REMOTE_ACCESS_CHANGED_CHANNEL,
+    payload: Record<string, never>
+  ) => void
 }
 
 const isRemoteItBrowserHost = (hostname: string): boolean =>

--- a/src/main/renderer-broadcast.test.ts
+++ b/src/main/renderer-broadcast.test.ts
@@ -12,7 +12,12 @@ vi.mock('electron', () => ({
   }
 }))
 
-import { addRendererBroadcastSink, broadcastToRenderers } from './renderer-broadcast'
+import { ApplicationEventHub } from './application-events'
+import {
+  addRendererBroadcastSink,
+  broadcastToRenderers,
+  installRendererBroadcastEventHub
+} from './renderer-broadcast'
 
 beforeEach(() => {
   windows.length = 0
@@ -38,13 +43,50 @@ describe('broadcastToRenderers', () => {
     const sink = vi.fn()
     const remove = addRendererBroadcastSink(sink)
 
-    broadcastToRenderers('channel', { value: 1 })
-    expect(live.webContents.send).toHaveBeenCalledWith('channel', { value: 1 })
+    broadcastToRenderers('remote-access:changed', {})
+    expect(live.webContents.send).toHaveBeenCalledWith('remote-access:changed', {})
     expect(dead.webContents.send).not.toHaveBeenCalled()
-    expect(sink).toHaveBeenCalledWith('channel', { value: 1 })
+    expect(sink).toHaveBeenCalledWith('remote-access:changed', {})
 
     remove()
-    broadcastToRenderers('other', null)
+    broadcastToRenderers('specialist:catalog-changed', undefined)
     expect(sink).toHaveBeenCalledTimes(1)
+  })
+
+  it('projects one hub publication to Electron before external subscribers', () => {
+    const live = {
+      destroyed: false,
+      isDestroyed(): boolean {
+        return this.destroyed
+      },
+      webContents: { send: vi.fn() }
+    }
+    windows.push(live)
+    const hub = new ApplicationEventHub()
+    const order: string[] = []
+    live.webContents.send.mockImplementation(() => order.push('electron'))
+    const uninstall = installRendererBroadcastEventHub(hub)
+    const remove = addRendererBroadcastSink(() => order.push('sink'))
+
+    broadcastToRenderers('specialist:catalog-changed', undefined)
+
+    expect(order).toEqual(['electron', 'sink'])
+    remove()
+    uninstall()
+    hub.dispose()
+  })
+
+  it('keeps duplicate sink registration compatible with Set ownership', () => {
+    const sink = vi.fn()
+    const removeFirst = addRendererBroadcastSink(sink)
+    const removeSecond = addRendererBroadcastSink(sink)
+
+    broadcastToRenderers('specialist:catalog-changed', undefined)
+    expect(sink).toHaveBeenCalledOnce()
+
+    removeFirst()
+    broadcastToRenderers('specialist:catalog-changed', undefined)
+    expect(sink).toHaveBeenCalledOnce()
+    removeSecond()
   })
 })

--- a/src/main/renderer-broadcast.ts
+++ b/src/main/renderer-broadcast.ts
@@ -1,20 +1,80 @@
 import { BrowserWindow } from 'electron'
 
-export type RendererBroadcastSink = (channel: string, payload: unknown) => void
+import type {
+  ApplicationEventChannel,
+  ApplicationEventMap,
+  ApplicationEvents
+} from './application-events'
 
+export type RendererBroadcastSink = <Channel extends ApplicationEventChannel>(
+  channel: Channel,
+  payload: ApplicationEventMap[Channel]
+) => void
+
+let installedEvents: ApplicationEvents | undefined
+let removeElectronProjection: (() => void) | undefined
 const sinks = new Set<RendererBroadcastSink>()
+const sinkSubscriptions = new Map<RendererBroadcastSink, () => void>()
 
-const broadcastToRenderers = <Payload>(channel: string, payload: Payload): void => {
+const projectToElectron = <Channel extends ApplicationEventChannel>(
+  channel: Channel,
+  payload: ApplicationEventMap[Channel]
+): void => {
   for (const window of BrowserWindow.getAllWindows()) {
     if (!window.isDestroyed()) window.webContents.send(channel, payload)
   }
+}
 
+// Compatibility facade for existing publishers. Production installs the application-owned hub
+// before exposing IPC surfaces, so one publication fans out through ordered projections. The direct
+// path keeps isolated unit tests and startup-before-install behavior identical to the old broadcaster.
+const broadcastToRenderers = <Channel extends ApplicationEventChannel>(
+  channel: Channel,
+  payload: ApplicationEventMap[Channel]
+): void => {
+  if (installedEvents) {
+    installedEvents.publish(channel, payload)
+    return
+  }
+
+  projectToElectron(channel, payload)
   for (const sink of sinks) sink(channel, payload)
 }
 
+const subscribeSink = (events: ApplicationEvents, sink: RendererBroadcastSink): (() => void) =>
+  events.subscribe((event) => sink(event.channel, event.payload))
+
 const addRendererBroadcastSink = (sink: RendererBroadcastSink): (() => void) => {
-  sinks.add(sink)
-  return () => sinks.delete(sink)
+  if (!sinks.has(sink)) {
+    sinks.add(sink)
+    if (installedEvents) sinkSubscriptions.set(sink, subscribeSink(installedEvents, sink))
+  }
+
+  return () => {
+    if (!sinks.delete(sink)) return
+    sinkSubscriptions.get(sink)?.()
+    sinkSubscriptions.delete(sink)
+  }
 }
 
-export { addRendererBroadcastSink, broadcastToRenderers }
+// The composition root owns the hub; this adapter only binds the legacy publisher facade and the
+// Electron projection for one application runtime generation.
+const installRendererBroadcastEventHub = (events: ApplicationEvents): (() => void) => {
+  if (installedEvents) throw new Error('Renderer broadcast event hub is already installed.')
+  installedEvents = events
+  removeElectronProjection = events.subscribe((event) =>
+    projectToElectron(event.channel, event.payload)
+  )
+  for (const sink of sinks) sinkSubscriptions.set(sink, subscribeSink(events, sink))
+
+  return () => {
+    if (installedEvents !== events) return
+    removeElectronProjection?.()
+    removeElectronProjection = undefined
+    for (const unsubscribe of sinkSubscriptions.values()) unsubscribe()
+    sinkSubscriptions.clear()
+    installedEvents = undefined
+  }
+}
+
+export { addRendererBroadcastSink, broadcastToRenderers, installRendererBroadcastEventHub }

--- a/src/main/session-persistence/ipc.test.ts
+++ b/src/main/session-persistence/ipc.test.ts
@@ -352,4 +352,30 @@ describe('session persistence IPC handlers', () => {
     ).rejects.toBe(failure)
     expect(broadcastLifecycleEvent).not.toHaveBeenCalled()
   })
+
+  it('publishes a lifecycle event only after the durable Session transition is readable', async () => {
+    const session = createSession()
+    let durableReadable = false
+    const repository: SessionPersistenceBackend = {
+      loadAll: vi.fn().mockResolvedValue({ sessions: [], manifest: { version: 1 as const } }),
+      saveSession: vi.fn(async () => {
+        durableReadable = true
+        return { created: true, session }
+      }),
+      deleteSession: vi.fn().mockResolvedValue(undefined),
+      saveManifest: vi.fn().mockResolvedValue(undefined)
+    }
+    broadcastLifecycleEvent.mockImplementationOnce(() => {
+      expect(durableReadable).toBe(true)
+    })
+    registerSessionPersistenceIpcHandlers(repository, createMockReviewRepository())
+
+    await ipcHandlers.get('sessions:save-session')?.(
+      { sender: { id: 1, lifecycleClientId: 'electron:origin' } },
+      session
+    )
+
+    expect(repository.saveSession).toHaveBeenCalledOnce()
+    expect(broadcastLifecycleEvent).toHaveBeenCalledOnce()
+  })
 })

--- a/src/main/update/electron-updater-strategy.ts
+++ b/src/main/update/electron-updater-strategy.ts
@@ -6,7 +6,13 @@ import { APP } from '../../shared/app-config'
 import type { UpdateStatus } from '../../shared/update'
 import { fetchManifest } from './manifest'
 import type { InstallGate, UpdateStrategy } from './strategy'
+import type { ApplicationEventMap } from '../application-events'
 import { broadcastToRenderers } from '../renderer-broadcast'
+
+type UpdateBroadcast = <Channel extends 'update:status' | 'update:progress'>(
+  channel: Channel,
+  payload: ApplicationEventMap[Channel]
+) => void
 
 // Minimal logger surface so tests inject a spy without pulling electron-log.
 type UpdaterLogger = { info: (msg: string) => void; error: (msg: string, err?: unknown) => void }
@@ -35,7 +41,7 @@ export type ElectronUpdaterDeps = {
   currentVersion?: string
   platform?: NodeJS.Platform
   arch?: string
-  broadcast?: (channel: string, payload: unknown) => void
+  broadcast?: UpdateBroadcast
   // Factory for the per-download cancellation token; defaults to electron-updater's CancellationToken.
   // Injectable so tests can drive cancel() without the real class.
   createCancellationToken?: () => MinimalCancellationToken
@@ -81,9 +87,8 @@ const defaultIsRosetta = (): boolean | undefined => {
 
 // Default broadcast pushes to every live window (mirrors service.ts). Never runs in unit tests, which
 // inject their own broadcast.
-const defaultBroadcast = (channel: string, payload: unknown): void => {
+const defaultBroadcast: UpdateBroadcast = (channel, payload) =>
   broadcastToRenderers(channel, payload)
-}
 
 // Coerce electron-updater's releaseNotes (string | {note}[] | null) to a plain string for the dialog.
 const notesToString = (notes: unknown): string => {
@@ -156,7 +161,7 @@ export class ElectronUpdaterStrategy implements UpdateStrategy {
   private readonly currentVersion: string
   private readonly platform: NodeJS.Platform
   private readonly arch: string
-  private readonly broadcast: (channel: string, payload: unknown) => void
+  private readonly broadcast: UpdateBroadcast
   private readonly fetchImpl?: typeof fetch
   private readonly manifestUrl: string
   private readonly log: UpdaterLogger

--- a/src/main/update/service.ts
+++ b/src/main/update/service.ts
@@ -9,7 +9,13 @@ import { isNewer, selectDownload, type UpdateStatus } from '../../shared/update'
 import { downloadInstaller } from './downloader'
 import { fetchManifest } from './manifest'
 import type { UpdateStrategy } from './strategy'
+import type { ApplicationEventMap } from '../application-events'
 import { broadcastToRenderers } from '../renderer-broadcast'
+
+type UpdateBroadcast = <Channel extends 'update:status' | 'update:progress'>(
+  channel: Channel,
+  payload: ApplicationEventMap[Channel]
+) => void
 
 export type UpdateServiceDeps = {
   fetchImpl?: typeof fetch
@@ -17,7 +23,7 @@ export type UpdateServiceDeps = {
   arch?: string
   currentVersion?: string
   manifestUrl?: string
-  broadcast?: (channel: string, payload: unknown) => void
+  broadcast?: UpdateBroadcast
   // Resolves where to save the installer, or null if the user cancels. Injected in tests; the
   // default is platform-aware (see resolveSavePath).
   promptSavePath?: (defaultFileName: string) => Promise<string | null>
@@ -32,9 +38,8 @@ export type UpdateServiceDeps = {
 }
 
 // Default broadcast pushes to every live window, mirroring the connector approval-broker pattern.
-const defaultBroadcast = (channel: string, payload: unknown): void => {
+const defaultBroadcast: UpdateBroadcast = (channel, payload) =>
   broadcastToRenderers(channel, payload)
-}
 
 // Derive a safe on-disk installer name from the URL path only (never the query string), so a
 // query-polluted or malformed URL still yields a sane default filename.
@@ -64,7 +69,7 @@ export class UpdateService implements UpdateStrategy {
   private readonly arch: string
   private readonly currentVersion: string
   private readonly manifestUrl: string
-  private readonly broadcast: (channel: string, payload: unknown) => void
+  private readonly broadcast: UpdateBroadcast
   private readonly promptSavePath: (defaultFileName: string) => Promise<string | null>
   private readonly fileExists: (path: string) => boolean
   private readonly openPath: (path: string) => Promise<string>

--- a/src/main/web-service/application-event-projections.test.ts
+++ b/src/main/web-service/application-event-projections.test.ts
@@ -1,0 +1,79 @@
+import { describe, expect, it } from 'vitest'
+
+import type { AcpRuntimeEvent } from '../../shared/acp'
+import type { ApplicationEvent } from '../application-events'
+import {
+  projectPublicTaskEvent,
+  projectTaskRuntimeEvent,
+  projectWebRendererEvent
+} from './application-event-projections'
+
+describe('application event projections', () => {
+  it('passes terminal usage metadata through every eligible surface without recomputation', () => {
+    const payload: AcpRuntimeEvent = {
+      id: 'event-1',
+      timestamp: 1_700_000_000_000,
+      kind: 'stop',
+      level: 'info',
+      sessionId: 'session-1',
+      turnUsage: {
+        inputTokens: 12,
+        cacheTokens: 7,
+        cachedReadTokens: 5,
+        cachedWriteTokens: 2,
+        outputTokens: 4,
+        turnCount: 3
+      },
+      raw: { providerSessionId: 'non-uuid-session' }
+    }
+    const event: ApplicationEvent<'acp:event'> = { channel: 'acp:event', payload }
+
+    expect(projectTaskRuntimeEvent(event)).toBe(payload)
+    expect(projectWebRendererEvent(event)).toEqual({
+      protocolVersion: 1,
+      channel: 'acp:event',
+      payload
+    })
+    expect(projectPublicTaskEvent(event)).toEqual({ type: 'run.event', data: payload })
+  })
+
+  it('keeps Specialist events out of Web and public Task surfaces', () => {
+    const catalogChanged: ApplicationEvent<'specialist:catalog-changed'> = {
+      channel: 'specialist:catalog-changed',
+      payload: undefined
+    }
+    const pendingSwitch: ApplicationEvent<'specialist:pending-switch'> = {
+      channel: 'specialist:pending-switch',
+      payload: { sessionId: 'session-1', targetName: 'Analyst' }
+    }
+
+    for (const event of [catalogChanged, pendingSwitch]) {
+      expect(projectWebRendererEvent(event)).toBeUndefined()
+      expect(projectPublicTaskEvent(event)).toBeUndefined()
+      expect(projectTaskRuntimeEvent(event)).toBeUndefined()
+    }
+  })
+
+  it('keeps public Task events to the existing two-channel allowlist', () => {
+    const permission: ApplicationEvent<'acp:permission-request'> = {
+      channel: 'acp:permission-request',
+      payload: {
+        requestId: 'permission-1',
+        sessionId: 'session-1',
+        toolCallId: 'tool-1',
+        title: 'Run command',
+        options: []
+      }
+    }
+    const compute: ApplicationEvent<'compute:job-updated'> = {
+      channel: 'compute:job-updated',
+      payload: {} as Extract<ApplicationEvent, { channel: 'compute:job-updated' }>['payload']
+    }
+
+    expect(projectPublicTaskEvent(permission)).toEqual({
+      type: 'permission.requested',
+      data: permission.payload
+    })
+    expect(projectPublicTaskEvent(compute)).toBeUndefined()
+  })
+})

--- a/src/main/web-service/application-event-projections.ts
+++ b/src/main/web-service/application-event-projections.ts
@@ -1,0 +1,40 @@
+import { WEB_RPC_PROTOCOL_VERSION, isWebRpcEventChannel } from '../../shared/web-rpc-contract'
+import type { ApplicationEvent } from '../application-events'
+
+type WebRendererEvent = {
+  protocolVersion: typeof WEB_RPC_PROTOCOL_VERSION
+  channel: string
+  payload: unknown
+}
+
+type PublicTaskEvent =
+  | { type: 'run.event'; data: Extract<ApplicationEvent, { channel: 'acp:event' }>['payload'] }
+  | {
+      type: 'permission.requested'
+      data: Extract<ApplicationEvent, { channel: 'acp:permission-request' }>['payload']
+    }
+
+const projectWebRendererEvent = (event: ApplicationEvent): WebRendererEvent | undefined =>
+  isWebRpcEventChannel(event.channel)
+    ? {
+        protocolVersion: WEB_RPC_PROTOCOL_VERSION,
+        channel: event.channel,
+        payload: event.payload ?? null
+      }
+    : undefined
+
+const projectPublicTaskEvent = (event: ApplicationEvent): PublicTaskEvent | undefined => {
+  if (event.channel === 'acp:event') return { type: 'run.event', data: event.payload }
+  if (event.channel === 'acp:permission-request') {
+    return { type: 'permission.requested', data: event.payload }
+  }
+  return undefined
+}
+
+const projectTaskRuntimeEvent = (
+  event: ApplicationEvent
+): Extract<ApplicationEvent, { channel: 'acp:event' }>['payload'] | undefined =>
+  event.channel === 'acp:event' ? event.payload : undefined
+
+export { projectPublicTaskEvent, projectTaskRuntimeEvent, projectWebRendererEvent }
+export type { PublicTaskEvent, WebRendererEvent }

--- a/src/main/web-service/controller.test.ts
+++ b/src/main/web-service/controller.test.ts
@@ -1,5 +1,6 @@
 import { describe, expect, it, vi } from 'vitest'
 
+import { ApplicationEventHub } from '../application-events'
 import type { WebRpcRouter } from '../ipc-handler-registry'
 import { createWebServiceController, type WebServiceControllerDeps } from './index'
 
@@ -32,7 +33,11 @@ const makeController = (
   const removeState = vi.fn().mockResolvedValue(undefined)
 
   const controller = createWebServiceController(
-    { rpc: {} as WebRpcRouter, requestQuit },
+    {
+      rpc: {} as WebRpcRouter,
+      requestQuit,
+      applicationEvents: new ApplicationEventHub()
+    },
     {
       startServer,
       resolveConfigRoot: () => '/fake/root',

--- a/src/main/web-service/http-server.test.ts
+++ b/src/main/web-service/http-server.test.ts
@@ -13,8 +13,8 @@ vi.mock('electron', () => ({
 }))
 
 import { WEB_RPC_PROTOCOL_VERSION } from '../../shared/web-rpc-contract'
+import { ApplicationEventHub } from '../application-events'
 import type { CallerContext } from '../caller-context'
-import { broadcastToRenderers } from '../renderer-broadcast'
 import {
   REMOTE_LOCAL_ONLY_RPC_CHANNELS,
   startWebHttpServer,
@@ -25,6 +25,10 @@ import { TaskApiError } from './task-api'
 
 const roots: string[] = []
 const servers: RunningWebServer[] = []
+const applicationEvents = new ApplicationEventHub()
+const startTestWebHttpServer = (
+  options: Omit<Parameters<typeof startWebHttpServer>[0], 'applicationEvents'>
+): ReturnType<typeof startWebHttpServer> => startWebHttpServer({ ...options, applicationEvents })
 const authorizedExternalAccess = (): ExternalWebAccessAuthorization => ({
   kind: 'authorized-pairing-manager' as const,
   isCurrent: () => true
@@ -42,6 +46,41 @@ afterEach(async () => {
 })
 
 describe('startWebHttpServer', () => {
+  it('releases its application-event subscription when listening fails', async () => {
+    const unsubscribe = vi.fn()
+    const subscribe = vi.fn(() => unsubscribe)
+    const options = {
+      host: '127.0.0.1',
+      token: 'test-token',
+      staticRoot: '/unused',
+      applicationEvents: { subscribe },
+      rpc: {
+        channels: () => [],
+        invoke: vi.fn(async () => undefined),
+        releaseClient: vi.fn(),
+        dispose: vi.fn()
+      },
+      bootstrap: {
+        appName: 'Open Science',
+        appVersion: '0.0.0',
+        configRoot: '/fake/root',
+        platform: 'test',
+        versions: { electron: '1', chrome: '1', node: '1' }
+      }
+    }
+
+    await expect(startWebHttpServer({ ...options, port: -1 })).rejects.toThrow()
+
+    expect(subscribe).toHaveBeenCalledOnce()
+    expect(unsubscribe).toHaveBeenCalledOnce()
+
+    const retry = await startWebHttpServer({ ...options, port: 0 })
+    expect(subscribe).toHaveBeenCalledTimes(2)
+    expect(unsubscribe).toHaveBeenCalledOnce()
+    await retry.close()
+    expect(unsubscribe).toHaveBeenCalledTimes(2)
+  })
+
   it('authenticates, serves the UI, invokes RPC, and mirrors events over WebSocket', async () => {
     const staticRoot = await mkdtemp(join(tmpdir(), 'open-science-web-static-'))
     roots.push(staticRoot)
@@ -63,7 +102,7 @@ describe('startWebHttpServer', () => {
       releaseClient: vi.fn(),
       dispose: vi.fn()
     }
-    const server = await startWebHttpServer({
+    const server = await startTestWebHttpServer({
       host: '127.0.0.1',
       port: 0,
       token: 'test-token',
@@ -184,11 +223,19 @@ describe('startWebHttpServer', () => {
     const message = new Promise<string>((resolve) =>
       socket.once('message', (data) => resolve(data.toString()))
     )
-    broadcastToRenderers('project:created', { ready: true })
+    const project = {
+      id: 'project-1',
+      name: 'Test project',
+      description: '',
+      isExample: false,
+      createdAt: 1,
+      updatedAt: 1
+    }
+    applicationEvents.publish('project:created', project)
     expect(JSON.parse(await message)).toEqual({
       protocolVersion: WEB_RPC_PROTOCOL_VERSION,
       channel: 'project:created',
-      payload: { ready: true }
+      payload: project
     })
     const socketClosed = new Promise<void>((resolve) => socket.once('close', () => resolve()))
     socket.close()
@@ -219,20 +266,43 @@ describe('startWebHttpServer', () => {
     await new Promise<void>((resolve) => publicSocket.once('open', resolve))
     const publicMessages: unknown[] = []
     publicSocket.on('message', (data) => publicMessages.push(JSON.parse(data.toString())))
-    broadcastToRenderers('acp:event', { sessionId: 'session-1', kind: 'message', text: 'Hi' })
-    broadcastToRenderers('acp:permission-request', {
+    applicationEvents.publish('acp:event', {
+      id: 'event-1',
+      timestamp: 1,
+      level: 'info',
       sessionId: 'session-1',
-      requestId: 'permission-1'
+      kind: 'message',
+      text: 'Hi'
+    })
+    applicationEvents.publish('acp:permission-request', {
+      sessionId: 'session-1',
+      requestId: 'permission-1',
+      toolCallId: 'tool-1',
+      title: 'Run command',
+      options: []
     })
     await vi.waitFor(() => {
       expect(publicMessages).toEqual([
         {
           type: 'run.event',
-          data: { sessionId: 'session-1', kind: 'message', text: 'Hi' }
+          data: {
+            id: 'event-1',
+            timestamp: 1,
+            level: 'info',
+            sessionId: 'session-1',
+            kind: 'message',
+            text: 'Hi'
+          }
         },
         {
           type: 'permission.requested',
-          data: { sessionId: 'session-1', requestId: 'permission-1' }
+          data: {
+            sessionId: 'session-1',
+            requestId: 'permission-1',
+            toolCallId: 'tool-1',
+            title: 'Run command',
+            options: []
+          }
         }
       ])
     })
@@ -246,7 +316,7 @@ describe('startWebHttpServer', () => {
       releaseClient: vi.fn(),
       dispose: vi.fn()
     }
-    const server = await startWebHttpServer({
+    const server = await startTestWebHttpServer({
       host: '127.0.0.1',
       port: 0,
       token: 'test-token',
@@ -301,7 +371,7 @@ describe('startWebHttpServer', () => {
     roots.push(staticRoot)
     await writeFile(join(staticRoot, 'index.html'), '<!doctype html>')
     const releaseClient = vi.fn()
-    const server = await startWebHttpServer({
+    const server = await startTestWebHttpServer({
       host: '127.0.0.1',
       port: 0,
       token: 'test-token',
@@ -350,7 +420,7 @@ describe('startWebHttpServer', () => {
       dispose: vi.fn()
     }
     const authorizeHttp = vi.fn().mockResolvedValue(authorizedExternalAccess())
-    const server = await startWebHttpServer({
+    const server = await startTestWebHttpServer({
       host: '127.0.0.1',
       port: 0,
       token: 'local-token',
@@ -463,7 +533,7 @@ describe('startWebHttpServer', () => {
       acquireArtifact: vi.fn(),
       releaseArtifact: vi.fn()
     }
-    const server = await startWebHttpServer({
+    const server = await startTestWebHttpServer({
       host: '127.0.0.1',
       port: 0,
       token: 'local-token',
@@ -556,7 +626,7 @@ describe('startWebHttpServer', () => {
       releaseClient: vi.fn(),
       dispose: vi.fn()
     }
-    const server = await startWebHttpServer({
+    const server = await startTestWebHttpServer({
       host: '127.0.0.1',
       port: 0,
       token: 'local-token',
@@ -679,7 +749,7 @@ describe('startWebHttpServer', () => {
       releaseClient: vi.fn(),
       dispose: vi.fn()
     }
-    const server = await startWebHttpServer({
+    const server = await startTestWebHttpServer({
       host: '127.0.0.1',
       port: 0,
       token: 'local-token',
@@ -751,7 +821,7 @@ describe('startWebHttpServer', () => {
     const staticRoot = await mkdtemp(join(tmpdir(), 'open-science-web-static-'))
     roots.push(staticRoot)
     await writeFile(join(staticRoot, 'index.html'), '<!doctype html>')
-    const server = await startWebHttpServer({
+    const server = await startTestWebHttpServer({
       host: '127.0.0.1',
       port: 0,
       token: 'local-token',
@@ -811,7 +881,7 @@ describe('startWebHttpServer', () => {
     roots.push(staticRoot)
     await writeFile(join(staticRoot, 'index.html'), '<!doctype html>')
     const onShutdownRequest = vi.fn()
-    const server = await startWebHttpServer({
+    const server = await startTestWebHttpServer({
       host: '127.0.0.1',
       port: 0,
       token: 'test-token',
@@ -851,7 +921,7 @@ describe('startWebHttpServer', () => {
     roots.push(staticRoot)
     await writeFile(join(staticRoot, 'index.html'), '<!doctype html>')
     const onShutdownRequest = vi.fn()
-    const server = await startWebHttpServer({
+    const server = await startTestWebHttpServer({
       host: '127.0.0.1',
       port: 0,
       token: 'local-token',
@@ -926,7 +996,7 @@ describe('startWebHttpServer', () => {
       releaseArtifact: vi.fn(),
       dispose: vi.fn()
     }
-    const server = await startWebHttpServer({
+    const server = await startTestWebHttpServer({
       host: '127.0.0.1',
       port: 0,
       token: 'test-token',
@@ -1093,7 +1163,7 @@ describe('startWebHttpServer', () => {
       }),
       releaseArtifact: vi.fn().mockResolvedValue(undefined)
     }
-    const server = await startWebHttpServer({
+    const server = await startTestWebHttpServer({
       host: '127.0.0.1',
       port: 0,
       token: 'test-token',
@@ -1159,7 +1229,7 @@ describe('startWebHttpServer', () => {
       }),
       releaseArtifact: vi.fn().mockResolvedValue(undefined)
     }
-    const server = await startWebHttpServer({
+    const server = await startTestWebHttpServer({
       host: '127.0.0.1',
       port: 0,
       token: 'test-token',

--- a/src/main/web-service/http-server.ts
+++ b/src/main/web-service/http-server.ts
@@ -17,13 +17,13 @@ import {
   type CallerContext
 } from '../caller-context'
 import type { WebRpcRouter } from '../ipc-handler-registry'
-import { addRendererBroadcastSink } from '../renderer-broadcast'
+import type { ApplicationEventSource } from '../application-events'
 import {
   isWebRpcChannel,
-  isWebRpcEventChannel,
   WEB_RPC_PROTOCOL_VERSION,
   webRpcRequestSchema
 } from '../../shared/web-rpc-contract'
+import { projectPublicTaskEvent, projectWebRendererEvent } from './application-event-projections'
 import { authenticateRequest, persistAuthCookie } from './auth'
 import type { StartTaskRunRequest } from '../../shared/task-api'
 import { TaskApiError, type HeadlessTaskApi } from './task-api'
@@ -108,6 +108,7 @@ type WebServerOptions = {
   token: string
   staticRoot: string
   rpc: WebRpcRouter
+  applicationEvents: ApplicationEventSource
   externalAccess?: ExternalWebAccess
   tasks?: Pick<
     HeadlessTaskApi,
@@ -704,20 +705,11 @@ const startWebHttpServer = async (options: WebServerOptions): Promise<RunningWeb
     })
   })
 
-  const removeBroadcastSink = addRendererBroadcastSink((channel, payload) => {
-    const internalMessage = isWebRpcEventChannel(channel)
-      ? JSON.stringify({
-          protocolVersion: WEB_RPC_PROTOCOL_VERSION,
-          channel,
-          payload: payload ?? null
-        })
-      : undefined
-    const publicMessage =
-      channel === 'acp:event'
-        ? JSON.stringify({ type: 'run.event', data: payload })
-        : channel === 'acp:permission-request'
-          ? JSON.stringify({ type: 'permission.requested', data: payload })
-          : undefined
+  const removeBroadcastSink = options.applicationEvents.subscribe((event) => {
+    const internalProjection = projectWebRendererEvent(event)
+    const publicProjection = projectPublicTaskEvent(event)
+    const internalMessage = internalProjection ? JSON.stringify(internalProjection) : undefined
+    const publicMessage = publicProjection ? JSON.stringify(publicProjection) : undefined
     for (const socket of sockets) {
       if (socket.readyState !== WebSocket.OPEN) continue
       if (publicEventSockets.has(socket)) {
@@ -728,13 +720,19 @@ const startWebHttpServer = async (options: WebServerOptions): Promise<RunningWeb
     }
   })
 
-  await new Promise<void>((resolveListening, reject) => {
-    server.once('error', reject)
-    server.listen(options.port, options.host, () => {
-      server.off('error', reject)
-      resolveListening()
+  try {
+    await new Promise<void>((resolveListening, reject) => {
+      server.once('error', reject)
+      server.listen(options.port, options.host, () => {
+        server.off('error', reject)
+        resolveListening()
+      })
     })
-  })
+  } catch (error) {
+    removeBroadcastSink()
+    clientLeases.dispose()
+    throw error
+  }
 
   const address = server.address()
   const port = typeof address === 'object' && address ? address.port : options.port

--- a/src/main/web-service/index.ts
+++ b/src/main/web-service/index.ts
@@ -4,10 +4,11 @@ import { app } from 'electron'
 
 import type { WebRpcRouter } from '../ipc-handler-registry'
 import { createLogger } from '../logger'
-import { addRendererBroadcastSink } from '../renderer-broadcast'
+import type { ApplicationEventSource } from '../application-events'
 import { resolveConfigRoot } from '../storage-root'
 import { loadOrCreateWebToken } from './auth'
 import { startWebHttpServer, type ExternalWebAccess, type RunningWebServer } from './http-server'
+import { projectTaskRuntimeEvent } from './application-event-projections'
 import { HeadlessTaskApi } from './task-api'
 import { removeWebServiceState, writeWebServiceState, type WebServiceState } from './state-file'
 
@@ -62,8 +63,14 @@ const createWebServiceController = (
   {
     rpc,
     requestQuit,
-    externalAccess
-  }: { rpc: WebRpcRouter; requestQuit: () => void; externalAccess?: ExternalWebAccess },
+    externalAccess,
+    applicationEvents
+  }: {
+    rpc: WebRpcRouter
+    requestQuit: () => void
+    externalAccess?: ExternalWebAccess
+    applicationEvents: ApplicationEventSource
+  },
   deps: Partial<WebServiceControllerDeps> = {}
 ): WebServiceController => {
   const startServer = deps.startServer ?? startWebHttpServer
@@ -86,8 +93,9 @@ const createWebServiceController = (
     }))
   const tasks = new HeadlessTaskApi(rpc, {
     subscribeEvents: (listener) =>
-      addRendererBroadcastSink((channel, payload) => {
-        if (channel === 'acp:event') listener(payload as Parameters<typeof listener>[0])
+      applicationEvents.subscribe((event) => {
+        const runtimeEvent = projectTaskRuntimeEvent(event)
+        if (runtimeEvent) listener(runtimeEvent)
       })
   })
 
@@ -123,6 +131,7 @@ const createWebServiceController = (
       token,
       staticRoot: join(info.appPath, 'out', 'web'),
       rpc,
+      applicationEvents,
       externalAccess,
       tasks,
       // Attached: a graceful shutdown request stops only the web service (the app keeps running). A


### PR DESCRIPTION
## Problem

Application events were coupled to a global Electron broadcaster plus transport-specific sinks. Channel/payload ownership, projection allowlists, delivery order, and subscription lifetime were therefore difficult to review independently.

## Proposed change

- Add a composition-owned, synchronous application event hub with a typed 29-channel catalog.
- Keep `broadcastToRenderers` as the compatibility publisher facade until T2, while routing production publications through the hub once.
- Project the same event independently to Electron, renderer WebSocket clients, Headless Task capture, and the public Task event stream.
- Keep the event bridge alive through ACP/Notebook shutdown, then clear subscriptions at application-runtime disposal.
- Release the Web event subscription when HTTP listen fails as well as on normal close.

```mermaid
flowchart LR
  P["Existing publishers"] --> C["broadcastToRenderers compatibility facade"]
  C --> H["Typed application event hub"]
  H --> E["Electron projection"]
  H --> T["Headless Task: acp:event only"]
  H --> W["Renderer Web: generated positive allowlist"]
  H --> A["Public /api/v1/events: run + permission only"]
```

## Scope and non-goals

- No channel or payload changes; no data model, persistence schema, or user-interaction changes.
- Terminal ACP timestamp, raw payload, token categories, and optional model turn count pass through unchanged. Existing renderer/Task ownership of completion/failure time and response linkage remains unchanged.
- Specialist remains Electron-only for `catalog-changed` and `pending-switch`.
- Permission remains Electron/Web capable, with only `permission.requested` on the public Task stream.
- Compute remains available on Electron/local Web under the existing authority matrix; no Compute management is added to Task/SDK/CLI, and remote Web denials remain unchanged.
- Issue #458 remains forward-only: the catalog can be extended later, but this PR adds no orchestration state, parent-child model, protocol field, API, or speculative event.
- No event sourcing, durable replay, global state store, generated Web map change, preload contract change, or SDK type expansion.

## Acceptance criteria and validation

All listed checks ran after the final material edit.

- Typed channel/payload catalog, synchronous Set semantics, idempotent disposal, shutdown-order delivery, durable commit-before-publish, and cross-surface terminal order -> focused Vitest suites -> passed (51 tests).
- Web renderer/public Task allowlists, serialization, listen-failure cleanup, retry, and socket lifecycle -> `npm test -- --run src/main/web-service/http-server.test.ts` -> passed (15 tests).
- Electron/Web/remote/Task/SDK/CLI, ACP terminal metadata, Specialist switch, Permission, and Compute compatibility -> F0 focused suites plus final `npm test` -> passed.
- Type safety -> `npm run typecheck` -> passed.
- Web contract generation -> `npm run check:web-api-map` -> passed.
- Repository lint -> `npm run lint` -> 0 errors; 23 unchanged latest-main warnings.
- Independent Standards and Spec reviews of the final diff -> no P0-P2 findings.

## Review focus

- The hub owns only in-process ordering and subscription lifetime; durable owners still commit before publishing.
- Reverse runtime disposal keeps the bridge alive for backend terminal events and removes it only after backend shutdown.
- Electron -> Headless Task -> Web ordering, payload identity, generated Web allowlist, and the two-event public allowlist remain unchanged.
- The compatibility facade remains intentionally bounded and is not a new global state owner.

## Uncovered risk

No UI E2E suite was added because the PR does not change renderer behavior or user interaction. The legacy publisher facade remains until T2; focused compatibility tests pin its observable behavior during that transition.
