### PR TITLE
refactor(tasks): extract headless task runner

### DIFF
--- a/src/main/tasks/task-runner.test.ts
+++ b/src/main/tasks/task-runner.test.ts
@@ -768,4 +768,53 @@ describe('TaskRunner', () => {
       ]
     })
   })
+
+  it('releases its runtime-event subscription when disposed', () => {
+    let unsubscribeCount = 0
+    const runner = createRunner({
+      runtimeEvents: {
+        subscribe: () => () => {
+          unsubscribeCount += 1
+        }
+      }
+    })
+
+    runner.dispose()
+
+    expect(unsubscribeCount).toBe(1)
+  })
+
+  it('retains at most 200 terminal runs while preserving current snapshots', async () => {
+    let idCounter = 0
+    let sessionCounter = 0
+    let time = 0
+    const runner = createRunner({
+      agent: {
+        listAttachedSessionIds: async () => [],
+        createSession: async () => ({ sessionId: `session-${++sessionCounter}` }),
+        resumeSession: async (request) => ({ sessionId: request.sessionId }),
+        setPermissionProfile: async () => undefined,
+        sendPrompt: async () => undefined
+      },
+      createId: () => `id-${++idCounter}`,
+      now: () => ++time
+    })
+    let firstRunId = ''
+    let latestRunId = ''
+
+    for (let index = 0; index < 201; index += 1) {
+      const started = await runner.startRun({
+        project: project.id,
+        prompt: `Research request ${index}`
+      })
+      if (index === 0) firstRunId = started.id
+      latestRunId = started.id
+      await runner.waitForRun(started.id)
+    }
+
+    expect(() => runner.getRun(firstRunId)).toThrow(
+      expect.objectContaining({ code: 'run_not_found' })
+    )
+    expect(runner.getRun(latestRunId)).toMatchObject({ status: 'completed' })
+  })
 })

--- a/src/main/tasks/task-runner.test.ts
+++ b/src/main/tasks/task-runner.test.ts
@@ -1,0 +1,169 @@
+import { describe, expect, it } from 'vitest'
+
+import type { Project } from '../../shared/projects'
+import type { PersistedChatSession } from '../../shared/session-persistence'
+import {
+  TaskRunner,
+  type TaskPreviewResourcePort,
+  type TaskProjectPort,
+  type TaskRunnerDependencies,
+  type TaskSessionPort
+} from './task-runner'
+
+const project: Project = {
+  id: 'project-1',
+  name: 'systematic-review',
+  description: '',
+  isExample: false,
+  createdAt: 1,
+  updatedAt: 1
+}
+
+const session: PersistedChatSession = {
+  id: 'session-1',
+  projectId: project.id,
+  title: 'Review session',
+  cwd: '/workspace/review',
+  status: 'idle',
+  messages: [],
+  createdAt: 1,
+  updatedAt: 2
+}
+
+const createRunner = (overrides: Partial<TaskRunnerDependencies> = {}): TaskRunner =>
+  new TaskRunner({
+    projects: {
+      list: async () => [project],
+      create: async (request) => ({ ...project, ...request })
+    },
+    sessions: { list: async () => [], save: async () => undefined },
+    previewResources: {
+      acquire: async () => ({ id: 'resource-1', url: 'preview://resource-1', size: 0 }),
+      release: async () => undefined
+    },
+    agent: {
+      listAttachedSessionIds: async () => [],
+      createSession: async () => ({ sessionId: 'session-created' }),
+      resumeSession: async (request) => ({ sessionId: request.sessionId }),
+      setPermissionProfile: async () => undefined,
+      sendPrompt: async () => undefined
+    },
+    artifacts: {
+      finalizeRun: async () => ({ ok: true, artifacts: [] })
+    },
+    runtimeEvents: { subscribe: () => () => undefined },
+    createId: () => 'generated-id',
+    now: () => 1,
+    ...overrides
+  })
+
+describe('TaskRunner', () => {
+  it('lists projects through its public interface', async () => {
+    const projects: TaskProjectPort = {
+      list: async () => [project],
+      create: async (request) => ({ ...project, ...request })
+    }
+    const runner = createRunner({ projects })
+
+    await expect(runner.listProjects()).resolves.toEqual([project])
+  })
+
+  it('rejects an empty project name before creating a project', async () => {
+    let created = false
+    const projects: TaskProjectPort = {
+      list: async () => [project],
+      create: async (request) => {
+        created = true
+        return { ...project, ...request }
+      }
+    }
+    const runner = createRunner({ projects })
+
+    await expect(runner.createProject({ name: '   ' })).rejects.toMatchObject({
+      code: 'invalid_request',
+      message: 'Project name is required.'
+    })
+    expect(created).toBe(false)
+  })
+
+  it('lists session snapshots for a project name', async () => {
+    const projects: TaskProjectPort = {
+      list: async () => [project],
+      create: async (request) => ({ ...project, ...request })
+    }
+    const sessions: TaskSessionPort = {
+      list: async () => [session],
+      save: async () => undefined
+    }
+    const runner = createRunner({ projects, sessions })
+
+    await expect(runner.listSessions(project.name)).resolves.toEqual([
+      expect.objectContaining({ id: session.id, projectId: project.id, title: session.title })
+    ])
+  })
+
+  it('returns a durable session snapshot and its artifacts', async () => {
+    const artifactSession: PersistedChatSession = {
+      ...session,
+      artifacts: [
+        {
+          id: 'artifact-1',
+          kind: 'managed-file',
+          path: '/artifacts/report.md',
+          name: 'report.md',
+          mimeType: 'text/markdown',
+          size: 12
+        }
+      ]
+    }
+    const runner = createRunner({
+      sessions: { list: async () => [artifactSession], save: async () => undefined }
+    })
+
+    await expect(runner.getSession(session.id)).resolves.toMatchObject({
+      id: session.id,
+      artifactCount: 1
+    })
+    await expect(runner.listArtifacts(session.id)).resolves.toEqual(artifactSession.artifacts)
+  })
+
+  it('acquires and releases a persisted artifact through the preview-resource port', async () => {
+    const artifactSession: PersistedChatSession = {
+      ...session,
+      artifacts: [
+        {
+          id: 'artifact-1',
+          kind: 'managed-file',
+          path: '/artifacts/report.md',
+          name: 'report.md',
+          mimeType: 'text/markdown',
+          size: 12
+        }
+      ]
+    }
+    const released: string[] = []
+    const previewResources: TaskPreviewResourcePort = {
+      acquire: async () => ({
+        id: 'resource-1',
+        url: 'open-science-preview://resource-1/report.md',
+        size: 12,
+        mimeType: 'text/markdown'
+      }),
+      release: async (resourceId) => {
+        released.push(resourceId)
+      }
+    }
+    const runner = createRunner({
+      sessions: { list: async () => [artifactSession], save: async () => undefined },
+      previewResources
+    })
+
+    await expect(runner.acquireArtifact('artifact-1')).resolves.toMatchObject({
+      resourceId: 'resource-1',
+      name: 'report.md',
+      mimeType: 'text/markdown'
+    })
+    await runner.releaseArtifact('resource-1')
+    expect(released).toEqual(['resource-1'])
+  })
+})

--- a/src/main/tasks/task-runner.test.ts
+++ b/src/main/tasks/task-runner.test.ts
@@ -1,5 +1,7 @@
 import { describe, expect, it } from 'vitest'
 
+import type { AcpRuntimeEvent } from '../../shared/acp'
+import { ARTIFACT_OWNERSHIP_PERSISTENCE_RACE } from '../../shared/artifacts'
 import type { Project } from '../../shared/projects'
 import type { PersistedChatSession } from '../../shared/session-persistence'
 import {
@@ -165,5 +167,605 @@ describe('TaskRunner', () => {
     })
     await runner.releaseArtifact('resource-1')
     expect(released).toEqual(['resource-1'])
+  })
+
+  it('rejects malformed run requests before crossing a port', async () => {
+    let listedProjects = false
+    const runner = createRunner({
+      projects: {
+        list: async () => {
+          listedProjects = true
+          return [project]
+        },
+        create: async (request) => ({ ...project, ...request })
+      }
+    })
+
+    await expect(runner.startRun(null as never)).rejects.toMatchObject({
+      code: 'invalid_request',
+      message: 'Run request must be an object.'
+    })
+    await expect(
+      runner.startRun({
+        project: project.id,
+        prompt: 'Research',
+        permissionProfile: 'unsafe' as never
+      })
+    ).rejects.toMatchObject({ code: 'invalid_request' })
+    expect(listedProjects).toBe(false)
+  })
+
+  it('runs a prompt in a new durable session and returns the assistant output', async () => {
+    let emitEvent: ((event: AcpRuntimeEvent) => void) | undefined
+    const savedSessions: PersistedChatSession[] = []
+    const ids = ['user-message-1', 'run-1', 'assistant-message-1']
+    const runner = createRunner({
+      sessions: {
+        list: async () => [],
+        save: async (saved) => {
+          savedSessions.push(structuredClone(saved))
+        }
+      },
+      agent: {
+        listAttachedSessionIds: async () => [],
+        createSession: async () => ({
+          sessionId: 'session-1',
+          cwd: '/workspace/session-1',
+          frameworkId: 'codex',
+          backendId: 'codex:shared'
+        }),
+        resumeSession: async (request) => ({ sessionId: request.sessionId }),
+        setPermissionProfile: async () => undefined,
+        sendPrompt: async () => {
+          emitEvent?.({
+            id: 'event-1',
+            timestamp: 10,
+            kind: 'message',
+            level: 'info',
+            sessionId: 'session-1',
+            role: 'assistant',
+            text: 'Research complete.'
+          })
+          emitEvent?.({
+            id: 'event-2',
+            timestamp: 11,
+            kind: 'stop',
+            level: 'info',
+            sessionId: 'session-1',
+            text: 'end_turn',
+            turnUsage: { inputTokens: 31, cacheTokens: 15, outputTokens: 14 }
+          })
+        }
+      },
+      runtimeEvents: {
+        subscribe: (listener) => {
+          emitEvent = listener
+          return () => undefined
+        }
+      },
+      createId: () => ids.shift() ?? 'generated-id',
+      now: () => 100
+    })
+
+    const started = await runner.startRun({
+      project: project.name,
+      prompt: 'Review these papers.',
+      permissionProfile: 'auto'
+    })
+    expect(started).toMatchObject({
+      id: 'run-1',
+      sessionId: 'session-1',
+      projectId: project.id,
+      status: 'running'
+    })
+
+    await expect(runner.waitForRun('run-1')).resolves.toMatchObject({
+      status: 'completed',
+      output: 'Research complete.'
+    })
+    expect(savedSessions.at(-1)).toMatchObject({
+      id: 'session-1',
+      projectId: project.id,
+      status: 'idle',
+      permissionProfile: 'auto',
+      messages: [
+        { id: 'user-message-1', role: 'user', content: 'Review these papers.' },
+        {
+          id: 'assistant-message-1',
+          role: 'agent',
+          content: 'Research complete.',
+          turnUsage: { inputTokens: 31, cacheTokens: 15, outputTokens: 14 }
+        }
+      ]
+    })
+  })
+
+  it('rejects overlapping runs for the same durable session', async () => {
+    let finishPrompt: (() => void) | undefined
+    const promptGate = new Promise<void>((resolve) => {
+      finishPrompt = resolve
+    })
+    const existing: PersistedChatSession = {
+      ...session,
+      id: 'session-busy',
+      cwd: '/workspace/session-busy'
+    }
+    const ids = ['first-user', 'first-run', 'second-user', 'second-run', 'assistant-message']
+    const runner = createRunner({
+      sessions: { list: async () => [existing], save: async () => undefined },
+      agent: {
+        listAttachedSessionIds: async () => [existing.id],
+        createSession: async () => ({ sessionId: 'unused' }),
+        resumeSession: async (request) => ({ sessionId: request.sessionId }),
+        setPermissionProfile: async () => undefined,
+        sendPrompt: async () => promptGate
+      },
+      createId: () => ids.shift() ?? 'generated-id'
+    })
+
+    const first = await runner.startRun({
+      project: project.id,
+      sessionId: existing.id,
+      prompt: 'First prompt'
+    })
+
+    try {
+      await expect(
+        runner.startRun({
+          project: project.id,
+          sessionId: existing.id,
+          prompt: 'Overlapping prompt'
+        })
+      ).rejects.toMatchObject({
+        code: 'session_busy',
+        message: `Session already has an active run: ${existing.id}`
+      })
+    } finally {
+      finishPrompt?.()
+      await runner.waitForRun(first.id)
+    }
+  })
+
+  it('resumes a detached session without duplicating the new prompt in history replay', async () => {
+    const existing: PersistedChatSession = {
+      ...session,
+      messages: [
+        {
+          id: 'old-user',
+          role: 'user',
+          content: 'Initial question',
+          status: 'complete',
+          eventIds: [],
+          createdAt: 1,
+          updatedAt: 1
+        },
+        {
+          id: 'old-agent',
+          role: 'agent',
+          content: 'Initial answer',
+          status: 'complete',
+          eventIds: [],
+          createdAt: 2,
+          updatedAt: 2
+        }
+      ]
+    }
+    const resumeRequests: Parameters<TaskRunnerDependencies['agent']['resumeSession']>[0][] = []
+    const prompts: Parameters<TaskRunnerDependencies['agent']['sendPrompt']>[0][] = []
+    const ids = ['new-user', 'run-2', 'new-agent']
+    const runner = createRunner({
+      sessions: { list: async () => [existing], save: async () => undefined },
+      agent: {
+        listAttachedSessionIds: async () => [],
+        createSession: async () => ({ sessionId: 'unused' }),
+        resumeSession: async (request) => {
+          resumeRequests.push(request)
+          return { sessionId: existing.id, cwd: existing.cwd, contextReset: true }
+        },
+        setPermissionProfile: async () => undefined,
+        sendPrompt: async (request) => {
+          prompts.push(request)
+        }
+      },
+      createId: () => ids.shift() ?? 'generated-id'
+    })
+
+    const started = await runner.startRun({
+      project: project.id,
+      sessionId: existing.id,
+      prompt: 'Follow-up question',
+      permissionProfile: 'auto'
+    })
+    await runner.waitForRun(started.id)
+
+    expect(resumeRequests).toEqual([
+      expect.objectContaining({ sessionId: existing.id, permissionProfile: 'auto' })
+    ])
+    expect(prompts).toEqual([
+      {
+        sessionId: existing.id,
+        text: 'Follow-up question',
+        historyPreamble:
+          'Previous conversation:\n\nUser: Initial question\n\nAssistant: Initial answer'
+      }
+    ])
+  })
+
+  it('provides transcript fallback for skill-triggered reconnects', async () => {
+    const existing: PersistedChatSession = {
+      ...session,
+      messages: [
+        {
+          id: 'prior-user',
+          role: 'user',
+          content: 'Prior question',
+          status: 'complete',
+          eventIds: [],
+          createdAt: 1,
+          updatedAt: 1
+        },
+        {
+          id: 'prior-agent',
+          role: 'agent',
+          content: 'Prior answer',
+          status: 'complete',
+          eventIds: [],
+          createdAt: 2,
+          updatedAt: 2
+        }
+      ]
+    }
+    const prompts: Parameters<TaskRunnerDependencies['agent']['sendPrompt']>[0][] = []
+    const ids = ['skill-user', 'skill-run', 'skill-agent']
+    const runner = createRunner({
+      sessions: { list: async () => [existing], save: async () => undefined },
+      agent: {
+        listAttachedSessionIds: async () => [existing.id],
+        createSession: async () => ({ sessionId: 'unused' }),
+        resumeSession: async (request) => ({ sessionId: request.sessionId }),
+        setPermissionProfile: async () => undefined,
+        sendPrompt: async (request) => {
+          prompts.push(request)
+        }
+      },
+      createId: () => ids.shift() ?? 'generated-id'
+    })
+
+    const started = await runner.startRun({
+      project: project.id,
+      sessionId: existing.id,
+      prompt: 'Use the selected skill.',
+      skillIds: ['literature-review']
+    })
+    await runner.waitForRun(started.id)
+
+    expect(prompts).toEqual([
+      {
+        sessionId: existing.id,
+        text: 'Use the selected skill.',
+        forcedSkillIds: ['literature-review'],
+        resumeFallback: {
+          historyPreamble:
+            'Previous conversation:\n\nUser: Prior question\n\nAssistant: Prior answer'
+        }
+      }
+    ])
+  })
+
+  it('marks artifact-only completions when turn usage is unavailable', async () => {
+    let emitEvent: ((event: AcpRuntimeEvent) => void) | undefined
+    const savedSessions: PersistedChatSession[] = []
+    const ids = ['artifact-user', 'artifact-run', 'artifact-agent']
+    const runner = createRunner({
+      sessions: {
+        list: async () => [],
+        save: async (saved) => {
+          savedSessions.push(structuredClone(saved))
+        }
+      },
+      agent: {
+        listAttachedSessionIds: async () => [],
+        createSession: async () => ({ sessionId: 'session-artifact', cwd: '/workspace/artifact' }),
+        resumeSession: async (request) => ({ sessionId: request.sessionId }),
+        setPermissionProfile: async () => undefined,
+        sendPrompt: async () => {
+          emitEvent?.({
+            id: 'artifact-event',
+            timestamp: 10,
+            kind: 'artifact',
+            level: 'info',
+            sessionId: 'session-artifact',
+            artifactClaimId: 'artifact-claim',
+            artifacts: []
+          })
+          emitEvent?.({
+            id: 'artifact-stop',
+            timestamp: 11,
+            kind: 'stop',
+            level: 'info',
+            sessionId: 'session-artifact',
+            text: 'end_turn'
+          })
+        }
+      },
+      artifacts: {
+        finalizeRun: async () => ({
+          ok: true,
+          artifacts: [
+            {
+              id: 'artifact-file',
+              projectName: project.id,
+              sessionId: 'session-artifact',
+              messageId: 'artifact-agent',
+              name: 'result.txt',
+              path: '/artifacts/result.txt',
+              fileUrl: 'open-science-preview://artifact-file/result.txt',
+              mimeType: 'text/plain',
+              size: 6,
+              mtimeMs: 11
+            }
+          ]
+        })
+      },
+      runtimeEvents: {
+        subscribe: (listener) => {
+          emitEvent = listener
+          return () => undefined
+        }
+      },
+      createId: () => ids.shift() ?? 'generated-id'
+    })
+
+    const started = await runner.startRun({ project: project.id, prompt: 'Create a file.' })
+    const completed = await runner.waitForRun(started.id)
+
+    expect(completed).toMatchObject({
+      status: 'completed',
+      artifacts: [{ id: 'artifact-file', name: 'result.txt' }]
+    })
+    expect(savedSessions.at(-1)?.messages.at(-1)).toMatchObject({
+      id: 'artifact-agent',
+      role: 'agent',
+      content: '',
+      turnUsageUnavailable: true,
+      artifactIds: ['artifact-file']
+    })
+  })
+
+  it('settles a run as failed when final session persistence fails', async () => {
+    let emitEvent: ((event: AcpRuntimeEvent) => void) | undefined
+    let saveCount = 0
+    const ids = ['save-user', 'save-run', 'save-agent']
+    const runner = createRunner({
+      sessions: {
+        list: async () => [],
+        save: async () => {
+          saveCount += 1
+          if (saveCount === 2) throw new Error('Session storage is unavailable')
+        }
+      },
+      agent: {
+        listAttachedSessionIds: async () => [],
+        createSession: async () => ({ sessionId: 'session-save', cwd: '/workspace/save' }),
+        resumeSession: async (request) => ({ sessionId: request.sessionId }),
+        setPermissionProfile: async () => undefined,
+        sendPrompt: async () => {
+          emitEvent?.({
+            id: 'save-event',
+            timestamp: 10,
+            kind: 'message',
+            level: 'info',
+            sessionId: 'session-save',
+            role: 'assistant',
+            text: 'Unsaved answer'
+          })
+        }
+      },
+      runtimeEvents: {
+        subscribe: (listener) => {
+          emitEvent = listener
+          return () => undefined
+        }
+      },
+      createId: () => ids.shift() ?? 'generated-id',
+      now: () => 100
+    })
+
+    const started = await runner.startRun({ project: project.id, prompt: 'Produce an answer.' })
+
+    await expect(runner.waitForRun(started.id)).resolves.toMatchObject({
+      status: 'failed',
+      error: 'Session storage is unavailable',
+      output: 'Unsaved answer',
+      completedAt: 100
+    })
+    expect(saveCount).toBe(3)
+  })
+
+  it('preserves finalized artifacts when a later claim fails after an ownership retry', async () => {
+    let emitEvent: ((event: AcpRuntimeEvent) => void) | undefined
+    let finalizeAttempts = 0
+    const savedSessions: PersistedChatSession[] = []
+    const ids = ['partial-user', 'partial-run', 'partial-agent']
+    const runner = createRunner({
+      sessions: {
+        list: async () => [],
+        save: async (saved) => {
+          savedSessions.push(structuredClone(saved))
+        }
+      },
+      agent: {
+        listAttachedSessionIds: async () => [],
+        createSession: async () => ({ sessionId: 'session-partial', cwd: '/workspace/partial' }),
+        resumeSession: async (request) => ({ sessionId: request.sessionId }),
+        setPermissionProfile: async () => undefined,
+        sendPrompt: async () => {
+          emitEvent?.({
+            id: 'artifact-first',
+            timestamp: 10,
+            kind: 'artifact',
+            level: 'info',
+            sessionId: 'session-partial',
+            artifactClaimId: 'claim-1',
+            artifacts: []
+          })
+          emitEvent?.({
+            id: 'artifact-second',
+            timestamp: 11,
+            kind: 'artifact',
+            level: 'info',
+            sessionId: 'session-partial',
+            artifactClaimId: 'claim-2',
+            artifacts: []
+          })
+          emitEvent?.({
+            id: 'provider-error',
+            timestamp: 12,
+            kind: 'error',
+            level: 'error',
+            sessionId: 'session-partial',
+            text: 'Provider rejected the request.'
+          })
+          throw new Error('raw provider failure')
+        }
+      },
+      artifacts: {
+        finalizeRun: async (request) => {
+          finalizeAttempts += 1
+          if (request.claimId === 'claim-1' && finalizeAttempts === 1) {
+            return {
+              ok: false,
+              code: ARTIFACT_OWNERSHIP_PERSISTENCE_RACE,
+              message: 'The durable projection has not caught up yet.'
+            }
+          }
+          if (request.claimId === 'claim-2') {
+            throw new Error('compatibility publication failed')
+          }
+          return {
+            ok: true,
+            artifacts: [
+              {
+                id: 'artifact-partial',
+                projectName: project.id,
+                sessionId: 'session-partial',
+                messageId: 'partial-agent',
+                name: 'partial-report.md',
+                path: '/artifacts/partial-report.md',
+                fileUrl: 'open-science-preview://artifact-partial/partial-report.md',
+                mimeType: 'text/markdown',
+                size: 10,
+                mtimeMs: 12
+              }
+            ]
+          }
+        }
+      },
+      runtimeEvents: {
+        subscribe: (listener) => {
+          emitEvent = listener
+          return () => undefined
+        }
+      },
+      createId: () => ids.shift() ?? 'generated-id'
+    })
+
+    const started = await runner.startRun({ project: project.id, prompt: 'Create a report.' })
+    const failed = await runner.waitForRun(started.id)
+
+    expect(failed).toMatchObject({
+      status: 'failed',
+      error: 'Provider rejected the request.',
+      artifacts: [{ id: 'artifact-partial', name: 'partial-report.md' }]
+    })
+    expect(finalizeAttempts).toBe(3)
+    expect(savedSessions.at(-1)).toMatchObject({
+      status: 'error',
+      error: 'Provider rejected the request.',
+      artifacts: [{ id: 'artifact-partial', name: 'partial-report.md' }]
+    })
+  })
+
+  it('persists terminal tool activity and provider failure reportability', async () => {
+    let emitEvent: ((event: AcpRuntimeEvent) => void) | undefined
+    const savedSessions: PersistedChatSession[] = []
+    const ids = ['tool-user', 'tool-run', 'tool-agent']
+    const runner = createRunner({
+      sessions: {
+        list: async () => [],
+        save: async (saved) => {
+          savedSessions.push(structuredClone(saved))
+        }
+      },
+      agent: {
+        listAttachedSessionIds: async () => [],
+        createSession: async () => ({ sessionId: 'session-tool', cwd: '/workspace/tool' }),
+        resumeSession: async (request) => ({ sessionId: request.sessionId }),
+        setPermissionProfile: async () => undefined,
+        sendPrompt: async () => {
+          emitEvent?.({
+            id: 'tool-start',
+            timestamp: 10,
+            kind: 'tool',
+            level: 'info',
+            sessionId: 'session-tool',
+            toolCallId: 'tool-call-1',
+            title: 'Run analysis',
+            status: 'in_progress',
+            providerToolName: 'shell'
+          })
+          emitEvent?.({
+            id: 'tool-complete',
+            timestamp: 11,
+            kind: 'tool',
+            level: 'info',
+            sessionId: 'session-tool',
+            toolCallId: 'tool-call-1',
+            status: 'completed',
+            terminalOutput: 'done\n',
+            terminalExitCode: 0
+          })
+          emitEvent?.({
+            id: 'provider-error',
+            timestamp: 12,
+            kind: 'error',
+            level: 'error',
+            sessionId: 'session-tool',
+            text: 'Provider quota exceeded.',
+            providerError: true
+          })
+          throw new Error('opaque provider error')
+        }
+      },
+      runtimeEvents: {
+        subscribe: (listener) => {
+          emitEvent = listener
+          return () => undefined
+        }
+      },
+      createId: () => ids.shift() ?? 'generated-id',
+      now: () => 100
+    })
+
+    const started = await runner.startRun({ project: project.id, prompt: 'Run analysis.' })
+    await expect(runner.waitForRun(started.id)).resolves.toMatchObject({
+      status: 'failed',
+      error: 'Provider quota exceeded.'
+    })
+    expect(savedSessions.at(-1)).toMatchObject({
+      status: 'error',
+      error: 'Provider quota exceeded.',
+      errorReportable: false,
+      activities: [
+        {
+          id: 'tool-call-1',
+          title: 'Run analysis',
+          status: 'completed',
+          eventIds: ['tool-start', 'tool-complete'],
+          terminalOutput: 'done\n',
+          terminalExitCode: 0
+        }
+      ]
+    })
   })
 })

--- a/src/main/tasks/task-runner.ts
+++ b/src/main/tasks/task-runner.ts
@@ -1,0 +1,186 @@
+import type {
+  AcpCreateSessionRequest,
+  AcpCreateSessionResponse,
+  AcpPromptRequest,
+  AcpResumeSessionRequest,
+  AcpRuntimeEvent,
+  AcpSetPermissionProfileRequest
+} from '../../shared/acp'
+import type {
+  FinalizeRunArtifactsRequest,
+  FinalizeRunArtifactsResult
+} from '../../shared/artifacts'
+import type { Project } from '../../shared/projects'
+import type { PersistedArtifact, PersistedChatSession } from '../../shared/session-persistence'
+import type {
+  AcquiredTaskArtifact,
+  TaskApiErrorCode,
+  TaskSessionSummary
+} from '../../shared/task-api'
+
+type CreateTaskProjectRequest = {
+  name: string
+  description?: string
+}
+
+type TaskProjectPort = {
+  list(): Promise<Project[]>
+  create(request: CreateTaskProjectRequest): Promise<Project>
+}
+
+type TaskSessionPort = {
+  list(): Promise<PersistedChatSession[]>
+  save(session: PersistedChatSession): Promise<void>
+}
+
+type TaskPreviewResourcePort = {
+  acquire(request: {
+    source: 'artifact'
+    path: string
+    mimeType?: string
+  }): Promise<{ id: string; url: string; size: number; mimeType?: string }>
+  release(resourceId: string): Promise<void>
+}
+
+type TaskAgentPort = {
+  listAttachedSessionIds(): Promise<string[]>
+  createSession(request: AcpCreateSessionRequest): Promise<AcpCreateSessionResponse>
+  resumeSession(request: AcpResumeSessionRequest): Promise<AcpCreateSessionResponse>
+  setPermissionProfile(request: AcpSetPermissionProfileRequest): Promise<void>
+  sendPrompt(request: AcpPromptRequest): Promise<void>
+}
+
+type TaskArtifactPort = {
+  finalizeRun(request: FinalizeRunArtifactsRequest): Promise<FinalizeRunArtifactsResult>
+}
+
+type TaskRuntimeEventPort = {
+  subscribe(listener: (event: AcpRuntimeEvent) => void): () => void
+}
+
+type TaskRunnerDependencies = {
+  projects: TaskProjectPort
+  sessions: TaskSessionPort
+  previewResources: TaskPreviewResourcePort
+  agent: TaskAgentPort
+  artifacts: TaskArtifactPort
+  runtimeEvents: TaskRuntimeEventPort
+  createId: () => string
+  now: () => number
+}
+
+const summarizeSession = (session: PersistedChatSession): TaskSessionSummary => ({
+  id: session.id,
+  projectId: session.projectId,
+  title: session.title,
+  status: session.status,
+  permissionProfile: session.permissionProfile,
+  createdAt: session.createdAt,
+  updatedAt: session.updatedAt,
+  output: [...session.messages].reverse().find((message) => message.role === 'agent')?.content,
+  error: session.error,
+  artifactCount: session.artifacts?.length ?? 0
+})
+
+class TaskRunnerError extends Error {
+  constructor(
+    readonly code: TaskApiErrorCode,
+    message: string
+  ) {
+    super(message)
+    this.name = 'TaskRunnerError'
+  }
+}
+
+class TaskRunner {
+  constructor(private readonly dependencies: TaskRunnerDependencies) {}
+
+  listProjects(): Promise<Project[]> {
+    return this.dependencies.projects.list()
+  }
+
+  async createProject(request: CreateTaskProjectRequest): Promise<Project> {
+    if (!request || typeof request.name !== 'string' || !request.name.trim()) {
+      throw new TaskRunnerError('invalid_request', 'Project name is required.')
+    }
+    if (request.description !== undefined && typeof request.description !== 'string') {
+      throw new TaskRunnerError('invalid_request', 'Project description must be a string.')
+    }
+    return this.dependencies.projects.create(request)
+  }
+
+  async listSessions(project?: string): Promise<TaskSessionSummary[]> {
+    const sessions = await this.dependencies.sessions.list()
+    if (!project) return sessions.map(summarizeSession)
+    const resolved = await this.resolveProject(project)
+    return sessions.filter((session) => session.projectId === resolved.id).map(summarizeSession)
+  }
+
+  async getSession(sessionId: string): Promise<TaskSessionSummary> {
+    return summarizeSession(await this.findSession(sessionId))
+  }
+
+  async listArtifacts(sessionId: string): Promise<PersistedArtifact[]> {
+    return [...((await this.findSession(sessionId)).artifacts ?? [])]
+  }
+
+  async acquireArtifact(artifactId: string): Promise<AcquiredTaskArtifact> {
+    const sessions = await this.dependencies.sessions.list()
+    const artifact = sessions
+      .flatMap((session) => session.artifacts ?? [])
+      .find((candidate) => candidate.id === artifactId)
+    if (!artifact) {
+      throw new TaskRunnerError('artifact_not_found', `Artifact not found: ${artifactId}`)
+    }
+    const resource = await this.dependencies.previewResources.acquire({
+      source: 'artifact',
+      path: artifact.path,
+      mimeType: artifact.mimeType
+    })
+    return {
+      resourceId: resource.id,
+      url: resource.url,
+      name: artifact.name ?? artifact.path.split(/[\\/]/).at(-1) ?? artifact.id,
+      mimeType: resource.mimeType ?? artifact.mimeType,
+      size: resource.size
+    }
+  }
+
+  async releaseArtifact(resourceId: string): Promise<void> {
+    await this.dependencies.previewResources.release(resourceId)
+  }
+
+  private async resolveProject(identifier: string): Promise<Project> {
+    const normalized = typeof identifier === 'string' ? identifier.trim() : ''
+    if (!normalized) throw new TaskRunnerError('invalid_request', 'Project is required.')
+    const projects = await this.listProjects()
+    const byId = projects.find((project) => project.id === normalized)
+    if (byId) return byId
+    const byName = projects.filter((project) => project.name === normalized)
+    if (byName.length === 1) return byName[0]
+    if (byName.length > 1) {
+      throw new TaskRunnerError('project_ambiguous', `Project name is ambiguous: ${normalized}`)
+    }
+    throw new TaskRunnerError('project_not_found', `Project not found: ${normalized}`)
+  }
+
+  private async findSession(sessionId: string): Promise<PersistedChatSession> {
+    const session = (await this.dependencies.sessions.list()).find(
+      (candidate) => candidate.id === sessionId
+    )
+    if (!session) throw new TaskRunnerError('session_not_found', `Session not found: ${sessionId}`)
+    return session
+  }
+}
+
+export { TaskRunner, TaskRunnerError }
+export type {
+  CreateTaskProjectRequest,
+  TaskAgentPort,
+  TaskArtifactPort,
+  TaskProjectPort,
+  TaskPreviewResourcePort,
+  TaskRunnerDependencies,
+  TaskRuntimeEventPort,
+  TaskSessionPort
+}

--- a/src/main/tasks/task-runner.ts
+++ b/src/main/tasks/task-runner.ts
@@ -6,15 +6,27 @@ import type {
   AcpRuntimeEvent,
   AcpSetPermissionProfileRequest
 } from '../../shared/acp'
+import { getAcpRuntimeEventImage, getAcpRuntimeEventText } from '../../shared/acp'
 import type {
+  ArtifactFile,
   FinalizeRunArtifactsRequest,
   FinalizeRunArtifactsResult
 } from '../../shared/artifacts'
+import { ARTIFACT_OWNERSHIP_PERSISTENCE_RACE } from '../../shared/artifacts'
+import { DEFAULT_PERMISSION_PROFILE } from '../../shared/permission-profiles'
 import type { Project } from '../../shared/projects'
-import type { PersistedArtifact, PersistedChatSession } from '../../shared/session-persistence'
+import type {
+  PersistedArtifact,
+  PersistedChatMessage,
+  PersistedChatSession,
+  PersistedMessageImage,
+  PersistedToolActivity
+} from '../../shared/session-persistence'
 import type {
   AcquiredTaskArtifact,
+  StartTaskRunRequest,
   TaskApiErrorCode,
+  TaskRun,
   TaskSessionSummary
 } from '../../shared/task-api'
 
@@ -69,6 +81,76 @@ type TaskRunnerDependencies = {
   now: () => number
 }
 
+type MutableTaskRun = TaskRun & {
+  events: AcpRuntimeEvent[]
+  completion: Promise<void>
+}
+
+type CompletedTaskSession = {
+  session: PersistedChatSession
+  output: string
+  artifacts: ArtifactFile[]
+}
+
+class PartialTaskCompletionError extends Error {
+  constructor(
+    readonly completion: CompletedTaskSession,
+    readonly failure: unknown
+  ) {
+    super(failure instanceof Error ? failure.message : String(failure))
+    this.name = 'PartialTaskCompletionError'
+  }
+}
+
+const MAX_RETAINED_RUNS = 200
+
+const cloneRun = (run: MutableTaskRun): TaskRun => ({
+  id: run.id,
+  sessionId: run.sessionId,
+  projectId: run.projectId,
+  status: run.status,
+  startedAt: run.startedAt,
+  completedAt: run.completedAt,
+  output: run.output,
+  error: run.error,
+  artifacts: [...run.artifacts]
+})
+
+const createTitle = (prompt: string): string => {
+  const normalized = prompt.trim().replace(/\s+/g, ' ')
+  return normalized.length <= 60 ? normalized : `${normalized.slice(0, 57)}...`
+}
+
+const createUserMessage = (id: string, content: string, now: number): PersistedChatMessage => ({
+  id,
+  role: 'user',
+  content,
+  status: 'complete',
+  eventIds: [],
+  createdAt: now,
+  updatedAt: now
+})
+
+const toPersistedArtifact = (artifact: ArtifactFile): PersistedArtifact => ({
+  id: artifact.id,
+  kind: 'managed-file',
+  path: artifact.path,
+  fileUrl: artifact.fileUrl,
+  name: artifact.name,
+  mimeType: artifact.mimeType,
+  size: artifact.size,
+  mtimeMs: artifact.mtimeMs
+})
+
+const createHistoryPreamble = (session: PersistedChatSession): string | undefined => {
+  if (session.messages.length === 0) return undefined
+  const transcript = session.messages
+    .filter((message) => message.content.trim())
+    .map((message) => `${message.role === 'user' ? 'User' : 'Assistant'}: ${message.content}`)
+    .join('\n\n')
+  return transcript ? `Previous conversation:\n\n${transcript}` : undefined
+}
+
 const summarizeSession = (session: PersistedChatSession): TaskSessionSummary => ({
   id: session.id,
   projectId: session.projectId,
@@ -93,7 +175,19 @@ class TaskRunnerError extends Error {
 }
 
 class TaskRunner {
-  constructor(private readonly dependencies: TaskRunnerDependencies) {}
+  private readonly runs = new Map<string, MutableTaskRun>()
+  private readonly activeRunBySession = new Map<string, string>()
+  private readonly unsubscribeEvents: () => void
+
+  constructor(private readonly dependencies: TaskRunnerDependencies) {
+    this.unsubscribeEvents = dependencies.runtimeEvents.subscribe((event) =>
+      this.captureEvent(event)
+    )
+  }
+
+  dispose(): void {
+    this.unsubscribeEvents()
+  }
 
   listProjects(): Promise<Project[]> {
     return this.dependencies.projects.list()
@@ -148,6 +242,429 @@ class TaskRunner {
 
   async releaseArtifact(resourceId: string): Promise<void> {
     await this.dependencies.previewResources.release(resourceId)
+  }
+
+  async startRun(request: StartTaskRunRequest): Promise<TaskRun> {
+    if (!request || typeof request !== 'object') {
+      throw new TaskRunnerError('invalid_request', 'Run request must be an object.')
+    }
+    if (typeof request.project !== 'string' || !request.project.trim()) {
+      throw new TaskRunnerError('invalid_request', 'Project is required.')
+    }
+    if (request.sessionId !== undefined && typeof request.sessionId !== 'string') {
+      throw new TaskRunnerError('invalid_request', 'Session id must be a string.')
+    }
+    if (
+      request.permissionProfile !== undefined &&
+      !['ask', 'auto', 'full'].includes(request.permissionProfile)
+    ) {
+      throw new TaskRunnerError('invalid_request', 'Approval profile must be ask, auto, or full.')
+    }
+    if (
+      request.skillIds !== undefined &&
+      (!Array.isArray(request.skillIds) ||
+        request.skillIds.some((skillId) => typeof skillId !== 'string' || !skillId.trim()))
+    ) {
+      throw new TaskRunnerError('invalid_request', 'Skill ids must be non-empty strings.')
+    }
+    const prompt = typeof request.prompt === 'string' ? request.prompt.trim() : ''
+    if (!prompt) throw new TaskRunnerError('invalid_request', 'Prompt is required.')
+
+    const project = await this.resolveProject(request.project)
+    const sessions = await this.dependencies.sessions.list()
+    const existing = request.sessionId
+      ? sessions.find((session) => session.id === request.sessionId)
+      : undefined
+    if (request.sessionId && !existing) {
+      throw new TaskRunnerError('session_not_found', `Session not found: ${request.sessionId}`)
+    }
+    if (existing && existing.projectId !== project.id) {
+      throw new TaskRunnerError(
+        'invalid_request',
+        `Session ${existing.id} does not belong to project ${project.id}.`
+      )
+    }
+
+    const userMessageId = this.dependencies.createId()
+    const runId = this.dependencies.createId()
+    if (existing) this.reserveSession(existing.id, runId)
+    let prepared: Awaited<ReturnType<TaskRunner['prepareSession']>>
+    try {
+      prepared = await this.prepareSession(project, existing, request, prompt, userMessageId)
+      this.reserveSession(prepared.session.id, runId)
+    } catch (error) {
+      if (existing) this.releaseSession(existing.id, runId)
+      throw error
+    }
+    const session = prepared.session
+    const run = {
+      id: runId,
+      sessionId: session.id,
+      projectId: project.id,
+      status: 'running' as const,
+      startedAt: this.dependencies.now(),
+      artifacts: [],
+      events: [],
+      completion: Promise.resolve()
+    } satisfies MutableTaskRun
+
+    this.pruneRuns()
+    this.runs.set(runId, run)
+    run.completion = this.executeRun(
+      run,
+      session,
+      request,
+      prompt,
+      prepared.historyPreamble,
+      prepared.resumeFallback
+    ).finally(() => this.releaseSession(session.id, runId))
+    return cloneRun(run)
+  }
+
+  getRun(runId: string): TaskRun {
+    const run = this.runs.get(runId)
+    if (!run) throw new TaskRunnerError('run_not_found', `Run not found: ${runId}`)
+    return cloneRun(run)
+  }
+
+  async waitForRun(runId: string): Promise<TaskRun> {
+    const run = this.runs.get(runId)
+    if (!run) throw new TaskRunnerError('run_not_found', `Run not found: ${runId}`)
+    await run.completion
+    return cloneRun(run)
+  }
+
+  private reserveSession(sessionId: string, runId: string): void {
+    const activeRunId = this.activeRunBySession.get(sessionId)
+    if (activeRunId && activeRunId !== runId) {
+      throw new TaskRunnerError('session_busy', `Session already has an active run: ${sessionId}`)
+    }
+    this.activeRunBySession.set(sessionId, runId)
+  }
+
+  private releaseSession(sessionId: string, runId: string): void {
+    if (this.activeRunBySession.get(sessionId) === runId) {
+      this.activeRunBySession.delete(sessionId)
+    }
+  }
+
+  private async prepareSession(
+    project: Project,
+    existing: PersistedChatSession | undefined,
+    request: StartTaskRunRequest,
+    prompt: string,
+    userMessageId: string
+  ): Promise<{
+    session: PersistedChatSession
+    historyPreamble?: string
+    resumeFallback?: AcpPromptRequest['resumeFallback']
+  }> {
+    const now = this.dependencies.now()
+    const permissionProfile =
+      request.permissionProfile ?? existing?.permissionProfile ?? DEFAULT_PERMISSION_PROFILE
+    let sessionInfo: AcpCreateSessionResponse
+
+    if (existing) {
+      const attachedSessionIds = await this.dependencies.agent.listAttachedSessionIds()
+      if (attachedSessionIds.includes(existing.id)) {
+        if (request.permissionProfile && request.permissionProfile !== existing.permissionProfile) {
+          await this.dependencies.agent.setPermissionProfile({
+            sessionId: existing.id,
+            profile: request.permissionProfile
+          })
+        }
+        sessionInfo = {
+          sessionId: existing.id,
+          cwd: existing.cwd,
+          frameworkId: existing.agentFrameworkId,
+          backendId: existing.agentBackendId
+        }
+      } else {
+        sessionInfo = await this.dependencies.agent.resumeSession({
+          sessionId: existing.id,
+          cwd: existing.cwd,
+          projectName: project.id,
+          permissionProfile,
+          previousFrameworkId: existing.agentFrameworkId,
+          previousBackendId: existing.agentBackendId
+        })
+      }
+    } else {
+      sessionInfo = await this.dependencies.agent.createSession({
+        projectName: project.id,
+        permissionProfile
+      })
+    }
+
+    const userMessage = createUserMessage(userMessageId, prompt, now)
+    const session: PersistedChatSession = existing
+      ? {
+          ...existing,
+          cwd: sessionInfo.cwd ?? existing.cwd,
+          status: 'running',
+          permissionProfile,
+          agentFrameworkId: sessionInfo.frameworkId ?? existing.agentFrameworkId,
+          agentBackendId: sessionInfo.backendId ?? existing.agentBackendId,
+          messages: [...existing.messages, userMessage],
+          activeRun: { promptMessageId: userMessageId, startedAt: now },
+          error: undefined,
+          updatedAt: now
+        }
+      : {
+          id: sessionInfo.sessionId,
+          projectId: project.id,
+          title: createTitle(prompt),
+          cwd: sessionInfo.cwd ?? '',
+          status: 'running',
+          permissionProfile,
+          agentFrameworkId: sessionInfo.frameworkId,
+          agentBackendId: sessionInfo.backendId,
+          messages: [userMessage],
+          activeRun: { promptMessageId: userMessageId, startedAt: now },
+          createdAt: now,
+          updatedAt: now
+        }
+
+    await this.dependencies.sessions.save(session)
+    const previousHistoryPreamble = existing ? createHistoryPreamble(existing) : undefined
+    return {
+      session,
+      historyPreamble: sessionInfo.contextReset ? previousHistoryPreamble : undefined,
+      resumeFallback:
+        request.skillIds?.length && previousHistoryPreamble
+          ? { historyPreamble: previousHistoryPreamble }
+          : undefined
+    }
+  }
+
+  private async executeRun(
+    run: MutableTaskRun,
+    session: PersistedChatSession,
+    request: StartTaskRunRequest,
+    prompt: string,
+    historyPreamble?: string,
+    resumeFallback?: AcpPromptRequest['resumeFallback']
+  ): Promise<void> {
+    let promptError: unknown
+    try {
+      await this.dependencies.agent.sendPrompt({
+        sessionId: session.id,
+        text: prompt,
+        ...(request.skillIds?.length ? { forcedSkillIds: request.skillIds } : {}),
+        ...(historyPreamble ? { historyPreamble } : {}),
+        ...(resumeFallback ? { resumeFallback } : {})
+      })
+    } catch (error) {
+      promptError = error
+    }
+
+    let completed: CompletedTaskSession | undefined
+    let completionError: unknown
+    try {
+      completed = await this.completeSession(session, run.events)
+    } catch (error) {
+      if (error instanceof PartialTaskCompletionError) {
+        completed = error.completion
+        completionError = error.failure
+      } else {
+        completionError = error
+      }
+    }
+
+    const failure = completionError ?? promptError
+    if (failure) {
+      await this.failRun(run, session, completed, failure)
+      return
+    }
+
+    try {
+      await this.dependencies.sessions.save(completed!.session)
+    } catch (error) {
+      await this.failRun(run, session, completed, error)
+      return
+    }
+    run.status = 'completed'
+    run.output = completed!.output
+    run.artifacts = completed!.artifacts
+    run.completedAt = this.dependencies.now()
+  }
+
+  private async failRun(
+    run: MutableTaskRun,
+    session: PersistedChatSession,
+    completed: CompletedTaskSession | undefined,
+    failure: unknown
+  ): Promise<void> {
+    const runtimeError = [...run.events]
+      .reverse()
+      .find((event) => event.kind === 'error' && event.text?.trim())
+    const message =
+      runtimeError?.text?.trim() || (failure instanceof Error ? failure.message : String(failure))
+    const failed: PersistedChatSession = {
+      ...(completed?.session ?? session),
+      status: 'error',
+      activeRun: undefined,
+      error: message,
+      ...(runtimeError?.providerError ? { errorReportable: false } : {}),
+      updatedAt: this.dependencies.now()
+    }
+    run.status = 'failed'
+    run.error = message
+    run.output = completed?.output
+    run.artifacts = completed?.artifacts ?? []
+    run.completedAt = this.dependencies.now()
+    await this.dependencies.sessions.save(failed).catch(() => undefined)
+  }
+
+  private async completeSession(
+    session: PersistedChatSession,
+    events: AcpRuntimeEvent[]
+  ): Promise<CompletedTaskSession> {
+    const now = this.dependencies.now()
+    const assistantEvents = events.filter(
+      (event) => event.kind === 'message' && event.role === 'assistant'
+    )
+    const terminalStopEvent = [...events].reverse().find((event) => event.kind === 'stop')
+    const output = assistantEvents.map((event) => getAcpRuntimeEventText(event) ?? '').join('')
+    const images = assistantEvents
+      .map((event) => {
+        const image = getAcpRuntimeEventImage(event)
+        return image ? ({ id: event.id, ...image } satisfies PersistedMessageImage) : undefined
+      })
+      .filter((image): image is PersistedMessageImage => Boolean(image))
+    const assistantMessageId = this.dependencies.createId()
+    const assistantMessage: PersistedChatMessage = {
+      id: assistantMessageId,
+      role: 'agent',
+      content: output,
+      status: 'complete',
+      responseToMessageId: session.activeRun?.promptMessageId,
+      eventIds: assistantEvents.map((event) => event.id),
+      images: images.length ? images : undefined,
+      ...(terminalStopEvent?.turnUsage
+        ? { turnUsage: terminalStopEvent.turnUsage }
+        : terminalStopEvent
+          ? { turnUsageUnavailable: true as const }
+          : {}),
+      createdAt: now,
+      updatedAt: now
+    }
+    const activities = this.createActivities(events, now)
+    const finalizedArtifacts: ArtifactFile[] = []
+    const buildCompletion = (): CompletedTaskSession => {
+      const uniqueArtifacts = [
+        ...new Map(finalizedArtifacts.map((artifact) => [artifact.id, artifact])).values()
+      ]
+      const persistedArtifacts = uniqueArtifacts.map(toPersistedArtifact)
+      const linkedAssistantMessage: PersistedChatMessage = {
+        ...assistantMessage,
+        artifactIds: uniqueArtifacts.length
+          ? uniqueArtifacts.map((artifact) => artifact.id)
+          : undefined
+      }
+      const hasAssistantMessage = Boolean(output || images.length || persistedArtifacts.length)
+
+      return {
+        output,
+        artifacts: uniqueArtifacts,
+        session: {
+          ...session,
+          status: 'idle',
+          activeRun: undefined,
+          messages: hasAssistantMessage
+            ? [...session.messages, linkedAssistantMessage]
+            : session.messages,
+          activities: [...(session.activities ?? []), ...activities],
+          artifacts: [...(session.artifacts ?? []), ...persistedArtifacts],
+          filesRevision:
+            persistedArtifacts.length > 0
+              ? (session.filesRevision ?? 0) + 1
+              : session.filesRevision,
+          updatedAt: now
+        }
+      }
+    }
+    let ownershipSessionPersisted = false
+    for (const event of events) {
+      if (event.kind !== 'artifact' || !event.artifactClaimId) continue
+      try {
+        const request = {
+          claimId: event.artifactClaimId,
+          messageId: assistantMessageId
+        }
+        let result = await this.dependencies.artifacts.finalizeRun(request)
+        if (!result.ok) {
+          if (result.code !== ARTIFACT_OWNERSHIP_PERSISTENCE_RACE) {
+            throw new Error(result.message)
+          }
+          if (!ownershipSessionPersisted) {
+            await this.dependencies.sessions.save({
+              ...session,
+              messages: [...session.messages, assistantMessage],
+              activities: [...(session.activities ?? []), ...activities],
+              updatedAt: now
+            })
+            ownershipSessionPersisted = true
+          }
+          result = await this.dependencies.artifacts.finalizeRun(request)
+          if (!result.ok) throw new Error(result.message)
+        }
+        finalizedArtifacts.push(...result.artifacts)
+      } catch (error) {
+        throw new PartialTaskCompletionError(buildCompletion(), error)
+      }
+    }
+    return buildCompletion()
+  }
+
+  private createActivities(events: AcpRuntimeEvent[], now: number): PersistedToolActivity[] {
+    const activities = new Map<string, PersistedToolActivity>()
+    for (const event of events) {
+      if (event.kind !== 'tool' || !event.toolCallId) continue
+      const existing = activities.get(event.toolCallId)
+      activities.set(event.toolCallId, {
+        id: event.toolCallId,
+        kind: 'tool',
+        title: event.title?.trim() || existing?.title || 'Tool call',
+        status:
+          event.status === 'failed'
+            ? 'failed'
+            : event.status === 'completed'
+              ? 'completed'
+              : 'in_progress',
+        sortIndex: existing?.sortIndex ?? now + activities.size,
+        eventIds: [...(existing?.eventIds ?? []), event.id],
+        providerToolName: event.providerToolName ?? existing?.providerToolName,
+        toolKind: event.toolKind ?? existing?.toolKind,
+        toolContent: event.toolContent ?? existing?.toolContent,
+        toolLocations: event.toolLocations ?? existing?.toolLocations,
+        rawInput: event.rawInput ?? existing?.rawInput,
+        rawOutput: event.rawOutput ?? existing?.rawOutput,
+        terminalOutput: event.terminalOutput ?? existing?.terminalOutput,
+        terminalExitCode: event.terminalExitCode ?? existing?.terminalExitCode,
+        createdAt: existing?.createdAt ?? now,
+        updatedAt: now
+      })
+    }
+    return [...activities.values()]
+  }
+
+  private captureEvent(event: AcpRuntimeEvent): void {
+    if (!event.sessionId) return
+    for (const run of this.runs.values()) {
+      if (run.status === 'running' && run.sessionId === event.sessionId) run.events.push(event)
+    }
+  }
+
+  private pruneRuns(): void {
+    if (this.runs.size < MAX_RETAINED_RUNS) return
+    const completed = [...this.runs.values()]
+      .filter((run) => run.status !== 'running')
+      .sort((left, right) => left.startedAt - right.startedAt)
+    for (const run of completed) {
+      this.runs.delete(run.id)
+      if (this.runs.size < MAX_RETAINED_RUNS) return
+    }
   }
 
   private async resolveProject(identifier: string): Promise<Project> {

--- a/src/main/tasks/task-runner.ts
+++ b/src/main/tasks/task-runner.ts
@@ -690,7 +690,7 @@ class TaskRunner {
   }
 }
 
-export { TaskRunner, TaskRunnerError }
+export { TaskRunner, TaskRunnerError, summarizeSession }
 export type {
   CreateTaskProjectRequest,
   TaskAgentPort,

--- a/src/main/web-service/task-api.test.ts
+++ b/src/main/web-service/task-api.test.ts
@@ -1,7 +1,6 @@
 import { describe, expect, it, vi } from 'vitest'
 
 import type { AcpRuntimeEvent } from '../../shared/acp'
-import { ARTIFACT_OWNERSHIP_PERSISTENCE_RACE } from '../../shared/artifacts'
 import type { PersistedChatSession } from '../../shared/session-persistence'
 import { createTaskCallerContext, type CallerContext } from '../caller-context'
 import { HeadlessTaskApi } from './task-api'
@@ -24,8 +23,8 @@ const taskCallerContext = (): ReturnType<typeof expect.objectContaining> =>
     actionOrigin: 'automation'
   })
 
-describe('HeadlessTaskApi', () => {
-  it('supports project, session, and artifact queries through the public interface', async () => {
+describe('HeadlessTaskApi adapter', () => {
+  it('maps public query and artifact commands to the compatibility façade', async () => {
     const session: PersistedChatSession = {
       id: 'session-query',
       projectId: project.id,
@@ -94,26 +93,135 @@ describe('HeadlessTaskApi', () => {
     ])
   })
 
-  it('keeps the request caller context across asynchronous run RPC', async () => {
+  it('maps attached-session and artifact-finalization ports to façade channels', async () => {
+    let emitEvent: ((event: AcpRuntimeEvent) => void) | undefined
+    const existing: PersistedChatSession = {
+      id: 'session-attached',
+      projectId: project.id,
+      title: 'Attached session',
+      cwd: '/workspace/attached',
+      status: 'idle',
+      permissionProfile: 'ask',
+      messages: [],
+      createdAt: 1,
+      updatedAt: 1
+    }
+    const invoke = vi.fn(async (channel: string, callerContext: CallerContext, args: unknown[]) => {
+      void callerContext
+      if (channel === 'projects:list') return [project]
+      if (channel === 'sessions:load-all') return { sessions: [existing], manifest: { version: 1 } }
+      if (channel === 'acp:get-state') return { sessionIds: [existing.id] }
+      if (channel === 'acp:set-permission-profile') return undefined
+      if (channel === 'sessions:save-session') return undefined
+      if (channel === 'acp:send-prompt') {
+        emitEvent?.({
+          id: 'artifact-event',
+          timestamp: 10,
+          kind: 'artifact',
+          level: 'info',
+          sessionId: existing.id,
+          artifactClaimId: 'artifact-claim',
+          artifacts: []
+        })
+        return undefined
+      }
+      if (channel === 'artifacts:finalize-run') return { ok: true, artifacts: [] }
+      throw new Error(`Unexpected RPC channel: ${channel} ${JSON.stringify(args)}`)
+    })
+    const ids = ['attached-user', 'attached-run', 'attached-agent']
+    const api = new HeadlessTaskApi(
+      { invoke },
+      {
+        createId: () => ids.shift() ?? 'generated-id',
+        subscribeEvents: (listener) => {
+          emitEvent = listener
+          return () => undefined
+        }
+      }
+    )
+
+    const run = await api.startRun({
+      project: project.id,
+      sessionId: existing.id,
+      prompt: 'Continue research.',
+      permissionProfile: 'auto'
+    })
+    await api.waitForRun(run.id)
+
+    expect(invoke).toHaveBeenCalledWith('acp:get-state', taskCallerContext(), [])
+    expect(invoke).toHaveBeenCalledWith('acp:set-permission-profile', taskCallerContext(), [
+      { sessionId: existing.id, profile: 'auto' }
+    ])
+    expect(invoke).toHaveBeenCalledWith('artifacts:finalize-run', taskCallerContext(), [
+      { claimId: 'artifact-claim', messageId: 'attached-agent' }
+    ])
+  })
+
+  it('maps detached-session resume to the façade with its durable Agent binding', async () => {
+    const existing: PersistedChatSession = {
+      id: 'session-detached',
+      projectId: project.id,
+      title: 'Detached session',
+      cwd: '/workspace/detached',
+      status: 'idle',
+      permissionProfile: 'ask',
+      agentFrameworkId: 'codex',
+      agentBackendId: 'codex:shared',
+      messages: [],
+      createdAt: 1,
+      updatedAt: 1
+    }
+    const invoke = vi.fn(async (channel: string, callerContext: CallerContext, args: unknown[]) => {
+      void callerContext
+      if (channel === 'projects:list') return [project]
+      if (channel === 'sessions:load-all') return { sessions: [existing], manifest: { version: 1 } }
+      if (channel === 'acp:get-state') return { sessionIds: [] }
+      if (channel === 'acp:resume-session') {
+        return { sessionId: existing.id, cwd: existing.cwd }
+      }
+      if (channel === 'sessions:save-session' || channel === 'acp:send-prompt') return undefined
+      throw new Error(`Unexpected RPC channel: ${channel} ${JSON.stringify(args)}`)
+    })
+    const ids = ['detached-user', 'detached-run', 'detached-agent']
+    const api = new HeadlessTaskApi({ invoke }, { createId: () => ids.shift() ?? 'generated-id' })
+
+    const run = await api.startRun({
+      project: project.id,
+      sessionId: existing.id,
+      prompt: 'Resume research.'
+    })
+    await api.waitForRun(run.id)
+
+    expect(invoke).toHaveBeenCalledWith('acp:resume-session', taskCallerContext(), [
+      {
+        sessionId: existing.id,
+        cwd: existing.cwd,
+        projectName: project.id,
+        permissionProfile: 'ask',
+        previousFrameworkId: 'codex',
+        previousBackendId: 'codex:shared'
+      }
+    ])
+  })
+
+  it('keeps the captured request caller across asynchronous run façade calls', async () => {
     let finishPrompt: (() => void) | undefined
     const promptGate = new Promise<void>((resolve) => {
       finishPrompt = resolve
     })
-    const invoke = vi.fn(
-      async (channel: string, _callerContext: CallerContext, _args: unknown[]) => {
-        void _callerContext
-        void _args
-        if (channel === 'projects:list') return [project]
-        if (channel === 'sessions:load-all') return { sessions: [], manifest: { version: 1 } }
-        if (channel === 'acp:create-session') {
-          return { sessionId: 'session-context', cwd: '/workspace/context' }
-        }
-        if (channel === 'acp:send-prompt') return promptGate
-        if (channel === 'sessions:save-session') return undefined
-        if (channel === 'preview-resources:release') return undefined
-        throw new Error(`Unexpected RPC channel: ${channel}`)
+    const invoke = vi.fn(async (channel: string, callerContext: CallerContext, args: unknown[]) => {
+      void callerContext
+      void args
+      if (channel === 'projects:list') return [project]
+      if (channel === 'sessions:load-all') return { sessions: [], manifest: { version: 1 } }
+      if (channel === 'acp:create-session') {
+        return { sessionId: 'session-context', cwd: '/workspace/context' }
       }
-    )
+      if (channel === 'acp:send-prompt') return promptGate
+      if (channel === 'sessions:save-session') return undefined
+      if (channel === 'preview-resources:release') return undefined
+      throw new Error(`Unexpected RPC channel: ${channel}`)
+    })
     const api = new HeadlessTaskApi({ invoke })
     let authorizationCurrent = true
     const context = createTaskCallerContext({
@@ -139,587 +247,5 @@ describe('HeadlessTaskApi', () => {
       [{ resourceId: 'resource-context' }]
     )
     expect(invoke.mock.calls.at(-1)?.[1].isAuthorizationCurrent()).toBe(true)
-  })
-
-  it('rejects malformed public run requests before invoking internal RPC', async () => {
-    const invoke = vi.fn()
-    const api = new HeadlessTaskApi({ invoke })
-
-    await expect(api.startRun(null as never)).rejects.toMatchObject({
-      code: 'invalid_request',
-      message: 'Run request must be an object.'
-    })
-    await expect(
-      api.startRun({
-        project: project.id,
-        prompt: 'Research',
-        permissionProfile: 'unsafe' as never
-      })
-    ).rejects.toMatchObject({ code: 'invalid_request' })
-    expect(invoke).not.toHaveBeenCalled()
-  })
-
-  it('rejects overlapping runs for the same durable session', async () => {
-    let finishPrompt: (() => void) | undefined
-    const promptGate = new Promise<void>((resolve) => {
-      finishPrompt = resolve
-    })
-    const existing: PersistedChatSession = {
-      id: 'session-busy',
-      projectId: project.id,
-      title: 'Busy session',
-      cwd: '/workspace/session-busy',
-      status: 'idle',
-      messages: [],
-      createdAt: 1,
-      updatedAt: 1
-    }
-    const invoke = vi.fn(async (channel: string) => {
-      if (channel === 'projects:list') return [project]
-      if (channel === 'sessions:load-all') {
-        return { sessions: [existing], manifest: { version: 1 } }
-      }
-      if (channel === 'acp:get-state') return { sessionIds: [existing.id] }
-      if (channel === 'sessions:save-session') return undefined
-      if (channel === 'acp:send-prompt') return promptGate
-      throw new Error(`Unexpected RPC channel: ${channel}`)
-    })
-    const api = new HeadlessTaskApi({ invoke })
-
-    const first = await api.startRun({
-      project: project.id,
-      sessionId: existing.id,
-      prompt: 'First prompt'
-    })
-
-    try {
-      await expect(
-        api.startRun({
-          project: project.id,
-          sessionId: existing.id,
-          prompt: 'Overlapping prompt'
-        })
-      ).rejects.toMatchObject({
-        code: 'session_busy',
-        message: `Session already has an active run: ${existing.id}`
-      })
-    } finally {
-      finishPrompt?.()
-      await api.waitForRun(first.id)
-    }
-  })
-
-  it('runs a prompt in a new durable session and returns the assistant output', async () => {
-    let emitEvent: ((event: AcpRuntimeEvent) => void) | undefined
-    const savedSessions: PersistedChatSession[] = []
-    const invoke = vi.fn(async (channel: string, _callerContext: unknown, args: unknown[]) => {
-      if (channel === 'projects:list') return [project]
-      if (channel === 'sessions:load-all') return { sessions: [], manifest: { version: 1 } }
-      if (channel === 'acp:create-session') {
-        return {
-          sessionId: 'session-1',
-          cwd: '/workspace/session-1',
-          frameworkId: 'codex',
-          backendId: 'codex:shared'
-        }
-      }
-      if (channel === 'sessions:save-session') {
-        savedSessions.push(structuredClone(args[0]) as PersistedChatSession)
-        return undefined
-      }
-      if (channel === 'acp:send-prompt') {
-        emitEvent?.({
-          id: 'event-1',
-          timestamp: 10,
-          kind: 'message',
-          level: 'info',
-          sessionId: 'session-1',
-          messageId: 'assistant-1',
-          role: 'assistant',
-          text: 'Research complete.'
-        })
-        emitEvent?.({
-          id: 'event-2',
-          timestamp: 11,
-          kind: 'stop',
-          level: 'info',
-          sessionId: 'session-1',
-          text: 'end_turn',
-          turnUsage: { inputTokens: 31, cacheTokens: 15, outputTokens: 14 }
-        })
-        return {}
-      }
-      throw new Error(`Unexpected RPC channel: ${channel}`)
-    })
-    const api = new HeadlessTaskApi(
-      { invoke },
-      {
-        createId: (() => {
-          const ids = ['user-message-1', 'run-1']
-          return () => ids.shift() ?? 'generated-id'
-        })(),
-        now: () => 100,
-        subscribeEvents: (listener) => {
-          emitEvent = listener
-          return () => undefined
-        }
-      }
-    )
-
-    const started = await api.startRun({
-      project: 'systematic-review',
-      prompt: 'Review these papers.',
-      permissionProfile: 'auto'
-    })
-    expect(started).toMatchObject({
-      id: 'run-1',
-      sessionId: 'session-1',
-      projectId: 'project-1',
-      status: 'running'
-    })
-
-    const completed = await api.waitForRun('run-1')
-    expect(completed).toMatchObject({
-      status: 'completed',
-      output: 'Research complete.'
-    })
-    expect(savedSessions.at(-1)).toMatchObject({
-      id: 'session-1',
-      projectId: 'project-1',
-      status: 'idle',
-      permissionProfile: 'auto',
-      messages: [
-        { id: 'user-message-1', role: 'user', content: 'Review these papers.' },
-        {
-          role: 'agent',
-          content: 'Research complete.',
-          status: 'complete',
-          turnUsage: { inputTokens: 31, cacheTokens: 15, outputTokens: 14 }
-        }
-      ]
-    })
-    expect(invoke).toHaveBeenCalledWith('acp:send-prompt', taskCallerContext(), [
-      { sessionId: 'session-1', text: 'Review these papers.' }
-    ])
-  })
-
-  it('marks artifact-only headless completions when turn usage is unavailable', async () => {
-    let emitEvent: ((event: AcpRuntimeEvent) => void) | undefined
-    const savedSessions: PersistedChatSession[] = []
-    const invoke = vi.fn(async (channel: string, _callerContext: unknown, args: unknown[]) => {
-      if (channel === 'projects:list') return [project]
-      if (channel === 'sessions:load-all') return { sessions: [], manifest: { version: 1 } }
-      if (channel === 'acp:create-session') {
-        return { sessionId: 'session-artifact-only', cwd: '/workspace/session-artifact-only' }
-      }
-      if (channel === 'sessions:save-session') {
-        savedSessions.push(structuredClone(args[0]) as PersistedChatSession)
-        return undefined
-      }
-      if (channel === 'acp:send-prompt') {
-        emitEvent?.({
-          id: 'artifact-only-event',
-          timestamp: 10,
-          kind: 'artifact',
-          level: 'info',
-          sessionId: 'session-artifact-only',
-          artifactClaimId: 'artifact-only-claim',
-          artifacts: []
-        })
-        emitEvent?.({
-          id: 'artifact-only-stop',
-          timestamp: 11,
-          kind: 'stop',
-          level: 'info',
-          sessionId: 'session-artifact-only',
-          text: 'end_turn'
-        })
-        return {}
-      }
-      if (channel === 'artifacts:finalize-run') {
-        return {
-          ok: true,
-          artifacts: [
-            {
-              id: 'artifact-only-file',
-              projectName: project.id,
-              sessionId: 'session-artifact-only',
-              messageId: 'artifact-only-agent',
-              name: 'result.txt',
-              path: '/artifacts/result.txt',
-              fileUrl: 'open-science-preview://artifact-only-file/result.txt',
-              mimeType: 'text/plain',
-              size: 6,
-              mtimeMs: 11
-            }
-          ]
-        }
-      }
-      throw new Error(`Unexpected RPC channel: ${channel}`)
-    })
-    const api = new HeadlessTaskApi(
-      { invoke },
-      {
-        createId: (() => {
-          const ids = ['artifact-only-user', 'artifact-only-run', 'artifact-only-agent']
-          return () => ids.shift() ?? 'generated-id'
-        })(),
-        subscribeEvents: (listener) => {
-          emitEvent = listener
-          return () => undefined
-        }
-      }
-    )
-
-    await api.startRun({ project: project.id, prompt: 'Create a file.' })
-    await api.waitForRun('artifact-only-run')
-
-    expect(savedSessions.at(-1)?.messages.at(-1)).toMatchObject({
-      id: 'artifact-only-agent',
-      role: 'agent',
-      content: '',
-      turnUsageUnavailable: true,
-      artifactIds: ['artifact-only-file']
-    })
-  })
-
-  it('settles a run as failed when final session persistence fails', async () => {
-    let emitEvent: ((event: AcpRuntimeEvent) => void) | undefined
-    let saveCount = 0
-    const invoke = vi.fn(async (channel: string) => {
-      if (channel === 'projects:list') return [project]
-      if (channel === 'sessions:load-all') return { sessions: [], manifest: { version: 1 } }
-      if (channel === 'acp:create-session') {
-        return { sessionId: 'session-save-failure', cwd: '/workspace/session-save-failure' }
-      }
-      if (channel === 'sessions:save-session') {
-        saveCount += 1
-        if (saveCount === 2) throw new Error('Session storage is unavailable')
-        return undefined
-      }
-      if (channel === 'acp:send-prompt') {
-        emitEvent?.({
-          id: 'event-save-failure',
-          timestamp: 10,
-          kind: 'message',
-          level: 'info',
-          sessionId: 'session-save-failure',
-          role: 'assistant',
-          text: 'Unsaved answer'
-        })
-        return {}
-      }
-      throw new Error(`Unexpected RPC channel: ${channel}`)
-    })
-    const api = new HeadlessTaskApi(
-      { invoke },
-      {
-        createId: (() => {
-          const ids = ['user-save-failure', 'run-save-failure', 'agent-save-failure']
-          return () => ids.shift() ?? 'generated-id'
-        })(),
-        now: () => 100,
-        subscribeEvents: (listener) => {
-          emitEvent = listener
-          return () => undefined
-        }
-      }
-    )
-
-    await api.startRun({ project: project.id, prompt: 'Produce an answer.' })
-    await expect(api.waitForRun('run-save-failure')).resolves.toMatchObject({
-      status: 'failed',
-      error: 'Session storage is unavailable',
-      output: 'Unsaved answer',
-      completedAt: 100
-    })
-    expect(saveCount).toBe(3)
-  })
-
-  it('resumes a durable session without duplicating the new prompt in history replay', async () => {
-    let emitEvent: ((event: AcpRuntimeEvent) => void) | undefined
-    const existing: PersistedChatSession = {
-      id: 'session-1',
-      projectId: project.id,
-      title: 'Prior work',
-      cwd: '/workspace/session-1',
-      status: 'idle',
-      permissionProfile: 'ask',
-      messages: [
-        {
-          id: 'old-user',
-          role: 'user',
-          content: 'Initial question',
-          status: 'complete',
-          eventIds: [],
-          createdAt: 1,
-          updatedAt: 1
-        },
-        {
-          id: 'old-agent',
-          role: 'agent',
-          content: 'Initial answer',
-          status: 'complete',
-          eventIds: [],
-          createdAt: 2,
-          updatedAt: 2
-        }
-      ],
-      createdAt: 1,
-      updatedAt: 2
-    }
-    const invoke = vi.fn(async (channel: string) => {
-      if (channel === 'projects:list') return [project]
-      if (channel === 'sessions:load-all') {
-        return { sessions: [existing], manifest: { version: 1 } }
-      }
-      if (channel === 'acp:get-state') return { sessionIds: [] }
-      if (channel === 'acp:resume-session') {
-        return { sessionId: existing.id, cwd: existing.cwd, contextReset: true }
-      }
-      if (channel === 'sessions:save-session') return undefined
-      if (channel === 'acp:send-prompt') {
-        emitEvent?.({
-          id: 'event-1',
-          timestamp: 10,
-          kind: 'message',
-          level: 'info',
-          sessionId: existing.id,
-          role: 'assistant',
-          text: 'Follow-up answer'
-        })
-        return {}
-      }
-      throw new Error(`Unexpected RPC channel: ${channel}`)
-    })
-    const api = new HeadlessTaskApi(
-      { invoke },
-      {
-        createId: (() => {
-          const ids = ['new-user', 'run-2', 'new-agent']
-          return () => ids.shift() ?? 'generated-id'
-        })(),
-        subscribeEvents: (listener) => {
-          emitEvent = listener
-          return () => undefined
-        }
-      }
-    )
-
-    await api.startRun({
-      project: project.id,
-      sessionId: existing.id,
-      prompt: 'Follow-up question',
-      permissionProfile: 'auto'
-    })
-    await api.waitForRun('run-2')
-
-    expect(invoke).toHaveBeenCalledWith('acp:resume-session', taskCallerContext(), [
-      expect.objectContaining({ sessionId: existing.id, permissionProfile: 'auto' })
-    ])
-    expect(invoke).toHaveBeenCalledWith('acp:send-prompt', taskCallerContext(), [
-      {
-        sessionId: existing.id,
-        text: 'Follow-up question',
-        historyPreamble:
-          'Previous conversation:\n\nUser: Initial question\n\nAssistant: Initial answer'
-      }
-    ])
-  })
-
-  it('provides transcript fallback for skill-triggered reconnects', async () => {
-    const existing: PersistedChatSession = {
-      id: 'session-skill-reload',
-      projectId: project.id,
-      title: 'Skill reload session',
-      cwd: '/workspace/session-skill-reload',
-      status: 'idle',
-      messages: [
-        {
-          id: 'prior-user',
-          role: 'user',
-          content: 'Prior question',
-          status: 'complete',
-          eventIds: [],
-          createdAt: 1,
-          updatedAt: 1
-        },
-        {
-          id: 'prior-agent',
-          role: 'agent',
-          content: 'Prior answer',
-          status: 'complete',
-          eventIds: [],
-          createdAt: 2,
-          updatedAt: 2
-        }
-      ],
-      createdAt: 1,
-      updatedAt: 2
-    }
-    const invoke = vi.fn(async (channel: string) => {
-      if (channel === 'projects:list') return [project]
-      if (channel === 'sessions:load-all') {
-        return { sessions: [existing], manifest: { version: 1 } }
-      }
-      if (channel === 'acp:get-state') return { sessionIds: [existing.id] }
-      if (channel === 'sessions:save-session' || channel === 'acp:send-prompt') return {}
-      throw new Error(`Unexpected RPC channel: ${channel}`)
-    })
-    const api = new HeadlessTaskApi(
-      { invoke },
-      {
-        createId: (() => {
-          const ids = ['skill-user', 'skill-run', 'skill-agent']
-          return () => ids.shift() ?? 'generated-id'
-        })()
-      }
-    )
-
-    await api.startRun({
-      project: project.id,
-      sessionId: existing.id,
-      prompt: 'Use the selected skill.',
-      skillIds: ['literature-review']
-    })
-    await api.waitForRun('skill-run')
-
-    expect(invoke).toHaveBeenCalledWith('acp:send-prompt', taskCallerContext(), [
-      {
-        sessionId: existing.id,
-        text: 'Use the selected skill.',
-        forcedSkillIds: ['literature-review'],
-        resumeFallback: {
-          historyPreamble:
-            'Previous conversation:\n\nUser: Prior question\n\nAssistant: Prior answer'
-        }
-      }
-    ])
-  })
-
-  it('preserves finalized artifacts when a later claim fails after an ownership retry', async () => {
-    let emitEvent: ((event: AcpRuntimeEvent) => void) | undefined
-    let finalizeAttempts = 0
-    const savedSessions: PersistedChatSession[] = []
-    const invoke = vi.fn(async (channel: string, _callerContext: unknown, args: unknown[]) => {
-      if (channel === 'projects:list') return [project]
-      if (channel === 'sessions:load-all') return { sessions: [], manifest: { version: 1 } }
-      if (channel === 'acp:create-session') {
-        return { sessionId: 'session-failed', cwd: '/workspace/session-failed' }
-      }
-      if (channel === 'sessions:save-session') {
-        savedSessions.push(structuredClone(args[0]) as PersistedChatSession)
-        return undefined
-      }
-      if (channel === 'acp:send-prompt') {
-        emitEvent?.({
-          id: 'artifact-event',
-          timestamp: 10,
-          kind: 'artifact',
-          level: 'info',
-          sessionId: 'session-failed',
-          artifactClaimId: 'claim-1',
-          artifacts: []
-        })
-        emitEvent?.({
-          id: 'artifact-event-later',
-          timestamp: 11,
-          kind: 'artifact',
-          level: 'info',
-          sessionId: 'session-failed',
-          artifactClaimId: 'claim-2',
-          artifacts: []
-        })
-        emitEvent?.({
-          id: 'error-event',
-          timestamp: 12,
-          kind: 'error',
-          level: 'error',
-          sessionId: 'session-failed',
-          text: 'Provider rejected the request.'
-        })
-        throw new Error('raw provider failure')
-      }
-      if (channel === 'artifacts:finalize-run') {
-        finalizeAttempts += 1
-        const request = args[0] as { claimId: string }
-        if (request.claimId === 'claim-1' && finalizeAttempts === 1) {
-          return {
-            ok: false,
-            code: ARTIFACT_OWNERSHIP_PERSISTENCE_RACE,
-            message: 'The durable projection has not caught up yet.'
-          }
-        }
-        if (request.claimId === 'claim-2') {
-          throw new Error('compatibility publication failed')
-        }
-        return {
-          ok: true,
-          artifacts: [
-            {
-              id: 'artifact-1',
-              projectName: project.id,
-              sessionId: 'session-failed',
-              messageId: 'agent-message',
-              name: 'partial-report.md',
-              path: '/artifacts/partial-report.md',
-              fileUrl: 'open-science-preview://artifact-1/partial-report.md',
-              mimeType: 'text/markdown',
-              size: 10,
-              mtimeMs: 12
-            }
-          ]
-        }
-      }
-      throw new Error(`Unexpected RPC channel: ${channel}`)
-    })
-    const api = new HeadlessTaskApi(
-      { invoke },
-      {
-        createId: (() => {
-          const ids = ['user-message', 'run-failed', 'agent-message']
-          return () => ids.shift() ?? 'generated-id'
-        })(),
-        subscribeEvents: (listener) => {
-          emitEvent = listener
-          return () => undefined
-        }
-      }
-    )
-
-    await api.startRun({ project: project.id, prompt: 'Create a report.' })
-    const failed = await api.waitForRun('run-failed')
-
-    expect(failed).toMatchObject({
-      status: 'failed',
-      error: 'Provider rejected the request.',
-      artifacts: [{ id: 'artifact-1', name: 'partial-report.md' }]
-    })
-    expect(finalizeAttempts).toBe(3)
-    expect(
-      invoke.mock.calls
-        .map(([channel]) => channel)
-        .filter((channel) => ['sessions:save-session', 'artifacts:finalize-run'].includes(channel))
-    ).toEqual([
-      'sessions:save-session',
-      'artifacts:finalize-run',
-      'sessions:save-session',
-      'artifacts:finalize-run',
-      'artifacts:finalize-run',
-      'sessions:save-session'
-    ])
-    expect(savedSessions[1]).toMatchObject({
-      status: 'running',
-      messages: [
-        { id: 'user-message', role: 'user' },
-        { id: 'agent-message', role: 'agent', status: 'complete' }
-      ]
-    })
-    expect(savedSessions[1].messages.at(-1)?.artifactIds).toBeUndefined()
-    expect(savedSessions.at(-1)).toMatchObject({
-      status: 'error',
-      error: 'Provider rejected the request.',
-      artifacts: [{ id: 'artifact-1', name: 'partial-report.md' }]
-    })
   })
 })

--- a/src/main/web-service/task-api.ts
+++ b/src/main/web-service/task-api.ts
@@ -51,11 +51,12 @@ class HeadlessTaskApi {
     dependencies: Partial<TaskApiDependencies> = {}
   ) {
     const subscribeEvents = dependencies.subscribeEvents ?? (() => () => undefined)
+    // Compatibility removal target: A6/T2 replace these façade channel mappings with direct owner
+    // adapters while TaskRunner keeps the same narrow ports.
     this.runner = new TaskRunner({
       projects: {
         list: () => this.invoke('projects:list') as Promise<Project[]>,
-        create: (request) =>
-          this.invoke('projects:create', request) as Promise<Project>
+        create: (request) => this.invoke('projects:create', request) as Promise<Project>
       },
       sessions: {
         list: async () => {

--- a/src/main/web-service/task-api.ts
+++ b/src/main/web-service/task-api.ts
@@ -1,38 +1,36 @@
-import { randomUUID } from 'node:crypto'
 import { AsyncLocalStorage } from 'node:async_hooks'
+import { randomUUID } from 'node:crypto'
 
-import {
-  getAcpRuntimeEventImage,
-  getAcpRuntimeEventText,
-  type AcpCreateSessionResponse,
-  type AcpPromptRequest,
-  type AcpRuntimeEvent
-} from '../../shared/acp'
-import {
-  ARTIFACT_OWNERSHIP_PERSISTENCE_RACE,
-  type ArtifactFile,
-  type FinalizeRunArtifactsResult
-} from '../../shared/artifacts'
-import { DEFAULT_PERMISSION_PROFILE } from '../../shared/permission-profiles'
-import type { Project } from '../../shared/projects'
 import type {
-  PersistedArtifact,
-  PersistedChatMessage,
-  PersistedChatSession,
-  PersistedMessageImage,
-  PersistedToolActivity
-} from '../../shared/session-persistence'
+  AcpCreateSessionRequest,
+  AcpCreateSessionResponse,
+  AcpPromptRequest,
+  AcpResumeSessionRequest,
+  AcpRuntimeEvent,
+  AcpSetPermissionProfileRequest
+} from '../../shared/acp'
+import type {
+  FinalizeRunArtifactsRequest,
+  FinalizeRunArtifactsResult
+} from '../../shared/artifacts'
+import type { Project } from '../../shared/projects'
+import type { PersistedArtifact, PersistedChatSession } from '../../shared/session-persistence'
 import type {
   AcquiredTaskArtifact,
   StartTaskRunRequest,
-  TaskApiErrorCode,
   TaskRun,
   TaskSessionSummary
 } from '../../shared/task-api'
 import { createTaskCallerContext, type CallerContext } from '../caller-context'
+import {
+  TaskRunner,
+  TaskRunnerError,
+  summarizeSession,
+  type CreateTaskProjectRequest,
+  type TaskRunnerDependencies
+} from '../tasks/task-runner'
 
 const TASK_CALLER_CONTEXT = createTaskCallerContext()
-const MAX_RETAINED_RUNS = 200
 
 type TaskRpc = {
   invoke(channel: string, callerContext: CallerContext, args: unknown[]): Promise<unknown>
@@ -44,639 +42,118 @@ type TaskApiDependencies = {
   subscribeEvents: (listener: (event: AcpRuntimeEvent) => void) => () => void
 }
 
-type MutableTaskRun = TaskRun & {
-  events: AcpRuntimeEvent[]
-  completion: Promise<void>
-}
-
-type CompletedTaskSession = {
-  session: PersistedChatSession
-  output: string
-  artifacts: ArtifactFile[]
-}
-
-class PartialTaskCompletionError extends Error {
-  constructor(
-    readonly completion: CompletedTaskSession,
-    readonly failure: unknown
-  ) {
-    super(failure instanceof Error ? failure.message : String(failure))
-    this.name = 'PartialTaskCompletionError'
-  }
-}
-
-class TaskApiError extends Error {
-  constructor(
-    readonly code: TaskApiErrorCode,
-    message: string
-  ) {
-    super(message)
-    this.name = 'TaskApiError'
-  }
-}
-
-const cloneRun = (run: MutableTaskRun): TaskRun => ({
-  id: run.id,
-  sessionId: run.sessionId,
-  projectId: run.projectId,
-  status: run.status,
-  startedAt: run.startedAt,
-  completedAt: run.completedAt,
-  output: run.output,
-  error: run.error,
-  artifacts: [...run.artifacts]
-})
-
-const createTitle = (prompt: string): string => {
-  const normalized = prompt.trim().replace(/\s+/g, ' ')
-  return normalized.length <= 60 ? normalized : `${normalized.slice(0, 57)}...`
-}
-
-const toPersistedArtifact = (artifact: ArtifactFile): PersistedArtifact => ({
-  id: artifact.id,
-  kind: 'managed-file',
-  path: artifact.path,
-  fileUrl: artifact.fileUrl,
-  name: artifact.name,
-  mimeType: artifact.mimeType,
-  size: artifact.size,
-  mtimeMs: artifact.mtimeMs
-})
-
-const createUserMessage = (id: string, content: string, now: number): PersistedChatMessage => ({
-  id,
-  role: 'user',
-  content,
-  status: 'complete',
-  eventIds: [],
-  createdAt: now,
-  updatedAt: now
-})
-
-const createHistoryPreamble = (session: PersistedChatSession): string | undefined => {
-  if (session.messages.length === 0) return undefined
-  const transcript = session.messages
-    .filter((message) => message.content.trim())
-    .map((message) => `${message.role === 'user' ? 'User' : 'Assistant'}: ${message.content}`)
-    .join('\n\n')
-  return transcript ? `Previous conversation:\n\n${transcript}` : undefined
-}
-
-const summarizeSession = (session: PersistedChatSession): TaskSessionSummary => ({
-  id: session.id,
-  projectId: session.projectId,
-  title: session.title,
-  status: session.status,
-  permissionProfile: session.permissionProfile,
-  createdAt: session.createdAt,
-  updatedAt: session.updatedAt,
-  output: [...session.messages].reverse().find((message) => message.role === 'agent')?.content,
-  error: session.error,
-  artifactCount: session.artifacts?.length ?? 0
-})
-
 class HeadlessTaskApi {
-  private readonly dependencies: TaskApiDependencies
   private readonly callerContexts = new AsyncLocalStorage<CallerContext>()
-  private readonly runs = new Map<string, MutableTaskRun>()
-  private readonly activeRunBySession = new Map<string, string>()
-  private readonly unsubscribeEvents: () => void
+  private readonly runner: TaskRunner
 
   constructor(
     private readonly rpc: TaskRpc,
     dependencies: Partial<TaskApiDependencies> = {}
   ) {
-    this.dependencies = {
+    const subscribeEvents = dependencies.subscribeEvents ?? (() => () => undefined)
+    this.runner = new TaskRunner({
+      projects: {
+        list: () => this.invoke('projects:list') as Promise<Project[]>,
+        create: (request) =>
+          this.invoke('projects:create', request) as Promise<Project>
+      },
+      sessions: {
+        list: async () => {
+          const result = (await this.invoke('sessions:load-all')) as {
+            sessions: PersistedChatSession[]
+          }
+          return result.sessions
+        },
+        save: async (session) => {
+          await this.invoke('sessions:save-session', session)
+        }
+      },
+      agent: {
+        listAttachedSessionIds: async () => {
+          const state = (await this.invoke('acp:get-state')) as { sessionIds?: string[] }
+          return state.sessionIds ?? []
+        },
+        createSession: (request: AcpCreateSessionRequest) =>
+          this.invoke('acp:create-session', request) as Promise<AcpCreateSessionResponse>,
+        resumeSession: (request: AcpResumeSessionRequest) =>
+          this.invoke('acp:resume-session', request) as Promise<AcpCreateSessionResponse>,
+        setPermissionProfile: async (request: AcpSetPermissionProfileRequest) => {
+          await this.invoke('acp:set-permission-profile', request)
+        },
+        sendPrompt: async (request: AcpPromptRequest) => {
+          await this.invoke('acp:send-prompt', request)
+        }
+      },
+      artifacts: {
+        finalizeRun: (request: FinalizeRunArtifactsRequest) =>
+          this.invoke('artifacts:finalize-run', request) as Promise<FinalizeRunArtifactsResult>
+      },
+      previewResources: {
+        acquire: (request) =>
+          this.invoke('preview-resources:acquire', request) as Promise<{
+            id: string
+            url: string
+            size: number
+            mimeType?: string
+          }>,
+        // Capability cleanup must remain available if request authorization is revoked while a
+        // response stream drains. The fixed local automation context grants no new access.
+        release: async (resourceId) => {
+          await this.rpc.invoke('preview-resources:release', TASK_CALLER_CONTEXT, [{ resourceId }])
+        }
+      },
+      runtimeEvents: { subscribe: subscribeEvents },
       createId: dependencies.createId ?? randomUUID,
-      now: dependencies.now ?? Date.now,
-      subscribeEvents: dependencies.subscribeEvents ?? (() => () => undefined)
-    }
-    this.unsubscribeEvents = this.dependencies.subscribeEvents((event) => this.captureEvent(event))
+      now: dependencies.now ?? Date.now
+    } satisfies TaskRunnerDependencies)
   }
 
   dispose(): void {
-    this.unsubscribeEvents()
+    this.runner.dispose()
   }
 
   runWithCallerContext<Result>(context: CallerContext, operation: () => Result): Result {
     return this.callerContexts.run(context, operation)
   }
 
-  async listProjects(): Promise<Project[]> {
-    return (await this.invoke('projects:list')) as Project[]
+  listProjects(): Promise<Project[]> {
+    return this.runner.listProjects()
   }
 
-  async createProject(request: { name: string; description?: string }): Promise<Project> {
-    if (!request || typeof request.name !== 'string' || !request.name.trim()) {
-      throw new TaskApiError('invalid_request', 'Project name is required.')
-    }
-    if (request.description !== undefined && typeof request.description !== 'string') {
-      throw new TaskApiError('invalid_request', 'Project description must be a string.')
-    }
-    return (await this.invoke('projects:create', request)) as Project
+  createProject(request: CreateTaskProjectRequest): Promise<Project> {
+    return this.runner.createProject(request)
   }
 
-  async listSessions(project?: string): Promise<TaskSessionSummary[]> {
-    const sessions = await this.loadSessions()
-    if (!project) return sessions.map(summarizeSession)
-    const resolved = await this.resolveProject(project)
-    return sessions.filter((session) => session.projectId === resolved.id).map(summarizeSession)
+  listSessions(project?: string): Promise<TaskSessionSummary[]> {
+    return this.runner.listSessions(project)
   }
 
-  async getSession(sessionId: string): Promise<TaskSessionSummary> {
-    return summarizeSession(await this.findSession(sessionId))
+  getSession(sessionId: string): Promise<TaskSessionSummary> {
+    return this.runner.getSession(sessionId)
   }
 
-  async startRun(request: StartTaskRunRequest): Promise<TaskRun> {
-    if (!request || typeof request !== 'object') {
-      throw new TaskApiError('invalid_request', 'Run request must be an object.')
-    }
-    if (typeof request.project !== 'string' || !request.project.trim()) {
-      throw new TaskApiError('invalid_request', 'Project is required.')
-    }
-    if (request.sessionId !== undefined && typeof request.sessionId !== 'string') {
-      throw new TaskApiError('invalid_request', 'Session id must be a string.')
-    }
-    if (
-      request.permissionProfile !== undefined &&
-      !['ask', 'auto', 'full'].includes(request.permissionProfile)
-    ) {
-      throw new TaskApiError('invalid_request', 'Approval profile must be ask, auto, or full.')
-    }
-    if (
-      request.skillIds !== undefined &&
-      (!Array.isArray(request.skillIds) ||
-        request.skillIds.some((skillId) => typeof skillId !== 'string' || !skillId.trim()))
-    ) {
-      throw new TaskApiError('invalid_request', 'Skill ids must be non-empty strings.')
-    }
-    const prompt = typeof request.prompt === 'string' ? request.prompt.trim() : ''
-    if (!prompt) throw new TaskApiError('invalid_request', 'Prompt is required.')
-
-    const project = await this.resolveProject(request.project)
-    const sessions = await this.loadSessions()
-    const existing = request.sessionId
-      ? sessions.find((session) => session.id === request.sessionId)
-      : undefined
-    if (request.sessionId && !existing) {
-      throw new TaskApiError('session_not_found', `Session not found: ${request.sessionId}`)
-    }
-    if (existing && existing.projectId !== project.id) {
-      throw new TaskApiError(
-        'invalid_request',
-        `Session ${existing.id} does not belong to project ${project.id}.`
-      )
-    }
-
-    const userMessageId = this.dependencies.createId()
-    const runId = this.dependencies.createId()
-    if (existing) this.reserveSession(existing.id, runId)
-    let prepared: Awaited<ReturnType<HeadlessTaskApi['prepareSession']>>
-    try {
-      prepared = await this.prepareSession(project, existing, request, prompt, userMessageId)
-      this.reserveSession(prepared.session.id, runId)
-    } catch (error) {
-      if (existing) this.releaseSession(existing.id, runId)
-      throw error
-    }
-    const session = prepared.session
-    const run = {
-      id: runId,
-      sessionId: session.id,
-      projectId: project.id,
-      status: 'running' as const,
-      startedAt: this.dependencies.now(),
-      artifacts: [],
-      events: [],
-      completion: Promise.resolve()
-    } satisfies MutableTaskRun
-
-    this.pruneRuns()
-    this.runs.set(runId, run)
-    run.completion = this.executeRun(
-      run,
-      session,
-      request,
-      prompt,
-      prepared.historyPreamble,
-      prepared.resumeFallback
-    ).finally(() => this.releaseSession(session.id, runId))
-    return cloneRun(run)
+  startRun(request: StartTaskRunRequest): Promise<TaskRun> {
+    return this.runner.startRun(request)
   }
 
   getRun(runId: string): TaskRun {
-    const run = this.runs.get(runId)
-    if (!run) throw new TaskApiError('run_not_found', `Run not found: ${runId}`)
-    return cloneRun(run)
+    return this.runner.getRun(runId)
   }
 
-  async waitForRun(runId: string): Promise<TaskRun> {
-    const run = this.runs.get(runId)
-    if (!run) throw new TaskApiError('run_not_found', `Run not found: ${runId}`)
-    await run.completion
-    return cloneRun(run)
+  waitForRun(runId: string): Promise<TaskRun> {
+    return this.runner.waitForRun(runId)
   }
 
-  async listArtifacts(sessionId: string): Promise<PersistedArtifact[]> {
-    return [...((await this.findSession(sessionId)).artifacts ?? [])]
+  listArtifacts(sessionId: string): Promise<PersistedArtifact[]> {
+    return this.runner.listArtifacts(sessionId)
   }
 
-  async acquireArtifact(artifactId: string): Promise<AcquiredTaskArtifact> {
-    const sessions = await this.loadSessions()
-    const artifact = sessions
-      .flatMap((session) => session.artifacts ?? [])
-      .find((candidate) => candidate.id === artifactId)
-    if (!artifact) {
-      throw new TaskApiError('artifact_not_found', `Artifact not found: ${artifactId}`)
-    }
-    const resource = (await this.invoke('preview-resources:acquire', {
-      source: 'artifact',
-      path: artifact.path,
-      mimeType: artifact.mimeType
-    })) as { id: string; url: string; size: number; mimeType?: string }
-    return {
-      resourceId: resource.id,
-      url: resource.url,
-      name: artifact.name ?? artifact.path.split(/[\\/]/).at(-1) ?? artifact.id,
-      mimeType: resource.mimeType ?? artifact.mimeType,
-      size: resource.size
-    }
+  acquireArtifact(artifactId: string): Promise<AcquiredTaskArtifact> {
+    return this.runner.acquireArtifact(artifactId)
   }
 
-  async releaseArtifact(resourceId: string): Promise<void> {
-    // Capability cleanup must remain available if the request authorization is revoked while the
-    // response stream is still draining. It grants no new access and only releases an acquired id.
-    await this.rpc.invoke('preview-resources:release', TASK_CALLER_CONTEXT, [{ resourceId }])
-  }
-
-  private reserveSession(sessionId: string, runId: string): void {
-    const activeRunId = this.activeRunBySession.get(sessionId)
-    if (activeRunId && activeRunId !== runId) {
-      throw new TaskApiError('session_busy', `Session already has an active run: ${sessionId}`)
-    }
-    this.activeRunBySession.set(sessionId, runId)
-  }
-
-  private releaseSession(sessionId: string, runId: string): void {
-    if (this.activeRunBySession.get(sessionId) === runId) {
-      this.activeRunBySession.delete(sessionId)
-    }
-  }
-
-  private async prepareSession(
-    project: Project,
-    existing: PersistedChatSession | undefined,
-    request: StartTaskRunRequest,
-    prompt: string,
-    userMessageId: string
-  ): Promise<{
-    session: PersistedChatSession
-    historyPreamble?: string
-    resumeFallback?: AcpPromptRequest['resumeFallback']
-  }> {
-    const now = this.dependencies.now()
-    const permissionProfile =
-      request.permissionProfile ?? existing?.permissionProfile ?? DEFAULT_PERMISSION_PROFILE
-    let sessionInfo: AcpCreateSessionResponse
-
-    if (existing) {
-      const state = (await this.invoke('acp:get-state')) as { sessionIds?: string[] }
-      if (state.sessionIds?.includes(existing.id)) {
-        if (request.permissionProfile && request.permissionProfile !== existing.permissionProfile) {
-          await this.invoke('acp:set-permission-profile', {
-            sessionId: existing.id,
-            profile: request.permissionProfile
-          })
-        }
-        sessionInfo = {
-          sessionId: existing.id,
-          cwd: existing.cwd,
-          frameworkId: existing.agentFrameworkId,
-          backendId: existing.agentBackendId
-        }
-      } else {
-        sessionInfo = (await this.invoke('acp:resume-session', {
-          sessionId: existing.id,
-          cwd: existing.cwd,
-          projectName: project.id,
-          permissionProfile,
-          previousFrameworkId: existing.agentFrameworkId,
-          previousBackendId: existing.agentBackendId
-        })) as AcpCreateSessionResponse
-      }
-    } else {
-      sessionInfo = (await this.invoke('acp:create-session', {
-        projectName: project.id,
-        permissionProfile
-      })) as AcpCreateSessionResponse
-    }
-
-    const userMessage = createUserMessage(userMessageId, prompt, now)
-    const session: PersistedChatSession = existing
-      ? {
-          ...existing,
-          cwd: sessionInfo.cwd ?? existing.cwd,
-          status: 'running',
-          permissionProfile,
-          agentFrameworkId: sessionInfo.frameworkId ?? existing.agentFrameworkId,
-          agentBackendId: sessionInfo.backendId ?? existing.agentBackendId,
-          messages: [...existing.messages, userMessage],
-          activeRun: { promptMessageId: userMessageId, startedAt: now },
-          error: undefined,
-          updatedAt: now
-        }
-      : {
-          id: sessionInfo.sessionId,
-          projectId: project.id,
-          title: createTitle(prompt),
-          cwd: sessionInfo.cwd ?? '',
-          status: 'running',
-          permissionProfile,
-          agentFrameworkId: sessionInfo.frameworkId,
-          agentBackendId: sessionInfo.backendId,
-          messages: [userMessage],
-          activeRun: { promptMessageId: userMessageId, startedAt: now },
-          createdAt: now,
-          updatedAt: now
-        }
-
-    await this.invoke('sessions:save-session', session)
-    const previousHistoryPreamble = existing ? createHistoryPreamble(existing) : undefined
-    return {
-      session,
-      historyPreamble: sessionInfo.contextReset ? previousHistoryPreamble : undefined,
-      resumeFallback:
-        request.skillIds?.length && previousHistoryPreamble
-          ? { historyPreamble: previousHistoryPreamble }
-          : undefined
-    }
-  }
-
-  private async executeRun(
-    run: MutableTaskRun,
-    session: PersistedChatSession,
-    request: StartTaskRunRequest,
-    prompt: string,
-    historyPreamble?: string,
-    resumeFallback?: AcpPromptRequest['resumeFallback']
-  ): Promise<void> {
-    let promptError: unknown
-    try {
-      await this.invoke('acp:send-prompt', {
-        sessionId: session.id,
-        text: prompt,
-        ...(request.skillIds?.length ? { forcedSkillIds: request.skillIds } : {}),
-        ...(historyPreamble ? { historyPreamble } : {}),
-        ...(resumeFallback ? { resumeFallback } : {})
-      })
-    } catch (error) {
-      promptError = error
-    }
-
-    let completed: Awaited<ReturnType<HeadlessTaskApi['completeSession']>> | undefined
-    let completionError: unknown
-    try {
-      completed = await this.completeSession(session, run.events)
-    } catch (error) {
-      if (error instanceof PartialTaskCompletionError) {
-        completed = error.completion
-        completionError = error.failure
-      } else {
-        completionError = error
-      }
-    }
-
-    const failure = completionError ?? promptError
-    if (failure) {
-      await this.failRun(run, session, completed, failure)
-      return
-    }
-
-    try {
-      await this.invoke('sessions:save-session', completed!.session)
-    } catch (error) {
-      await this.failRun(run, session, completed, error)
-      return
-    }
-    run.status = 'completed'
-    run.output = completed!.output
-    run.artifacts = completed!.artifacts
-    run.completedAt = this.dependencies.now()
-  }
-
-  private async failRun(
-    run: MutableTaskRun,
-    session: PersistedChatSession,
-    completed: Awaited<ReturnType<HeadlessTaskApi['completeSession']>> | undefined,
-    failure: unknown
-  ): Promise<void> {
-    const runtimeError = [...run.events]
-      .reverse()
-      .find((event) => event.kind === 'error' && event.text?.trim())
-    const message =
-      runtimeError?.text?.trim() || (failure instanceof Error ? failure.message : String(failure))
-    const failed: PersistedChatSession = {
-      ...(completed?.session ?? session),
-      status: 'error',
-      activeRun: undefined,
-      error: message,
-      // A model-provider failure (tagged on the error event at the ACP layer) is not a reportable bug;
-      // persist that so a reloaded headless session hides the report button, matching the desktop path.
-      ...(runtimeError?.providerError ? { errorReportable: false } : {}),
-      updatedAt: this.dependencies.now()
-    }
-    run.status = 'failed'
-    run.error = message
-    run.output = completed?.output
-    run.artifacts = completed?.artifacts ?? []
-    run.completedAt = this.dependencies.now()
-    await this.invoke('sessions:save-session', failed).catch(() => undefined)
-  }
-
-  private async completeSession(
-    session: PersistedChatSession,
-    events: AcpRuntimeEvent[]
-  ): Promise<CompletedTaskSession> {
-    const now = this.dependencies.now()
-    const assistantEvents = events.filter(
-      (event) => event.kind === 'message' && event.role === 'assistant'
-    )
-    const terminalStopEvent = [...events].reverse().find((event) => event.kind === 'stop')
-    const output = assistantEvents.map((event) => getAcpRuntimeEventText(event) ?? '').join('')
-    const assistantMessageId = this.dependencies.createId()
-    const images = assistantEvents
-      .map((event) => {
-        const image = getAcpRuntimeEventImage(event)
-        return image ? ({ id: event.id, ...image } satisfies PersistedMessageImage) : undefined
-      })
-      .filter((image): image is PersistedMessageImage => Boolean(image))
-    const assistantMessage: PersistedChatMessage = {
-      id: assistantMessageId,
-      role: 'agent',
-      content: output,
-      status: 'complete',
-      responseToMessageId: session.activeRun?.promptMessageId,
-      eventIds: assistantEvents.map((event) => event.id),
-      images: images.length ? images : undefined,
-      ...(terminalStopEvent?.turnUsage
-        ? { turnUsage: terminalStopEvent.turnUsage }
-        : terminalStopEvent
-          ? { turnUsageUnavailable: true as const }
-          : {}),
-      createdAt: now,
-      updatedAt: now
-    }
-    const activities = this.createActivities(events, now)
-    const finalizedArtifacts: ArtifactFile[] = []
-    const buildCompletion = (): CompletedTaskSession => {
-      const uniqueArtifacts = [
-        ...new Map(finalizedArtifacts.map((artifact) => [artifact.id, artifact])).values()
-      ]
-      const persistedArtifacts = uniqueArtifacts.map(toPersistedArtifact)
-      const linkedAssistantMessage: PersistedChatMessage = {
-        ...assistantMessage,
-        artifactIds: uniqueArtifacts.length
-          ? uniqueArtifacts.map((artifact) => artifact.id)
-          : undefined
-      }
-      const hasAssistantMessage = Boolean(output || images.length || persistedArtifacts.length)
-
-      return {
-        output,
-        artifacts: uniqueArtifacts,
-        session: {
-          ...session,
-          status: 'idle',
-          activeRun: undefined,
-          messages: hasAssistantMessage
-            ? [...session.messages, linkedAssistantMessage]
-            : session.messages,
-          activities: [...(session.activities ?? []), ...activities],
-          artifacts: [...(session.artifacts ?? []), ...persistedArtifacts],
-          filesRevision:
-            persistedArtifacts.length > 0
-              ? (session.filesRevision ?? 0) + 1
-              : session.filesRevision,
-          updatedAt: now
-        }
-      }
-    }
-    let ownershipSessionPersisted = false
-    for (const event of events) {
-      if (event.kind !== 'artifact' || !event.artifactClaimId) continue
-      try {
-        const request = {
-          claimId: event.artifactClaimId,
-          messageId: assistantMessageId
-        }
-        let result = (await this.invoke(
-          'artifacts:finalize-run',
-          request
-        )) as FinalizeRunArtifactsResult
-        if (!result.ok) {
-          if (result.code !== ARTIFACT_OWNERSHIP_PERSISTENCE_RACE) {
-            throw new Error(result.message)
-          }
-          if (!ownershipSessionPersisted) {
-            await this.invoke('sessions:save-session', {
-              ...session,
-              messages: [...session.messages, assistantMessage],
-              activities: [...(session.activities ?? []), ...activities],
-              updatedAt: now
-            })
-            ownershipSessionPersisted = true
-          }
-          result = (await this.invoke(
-            'artifacts:finalize-run',
-            request
-          )) as FinalizeRunArtifactsResult
-          if (!result.ok) {
-            throw new Error(result.message)
-          }
-        }
-        finalizedArtifacts.push(...result.artifacts)
-      } catch (error) {
-        throw new PartialTaskCompletionError(buildCompletion(), error)
-      }
-    }
-    return buildCompletion()
-  }
-
-  private createActivities(events: AcpRuntimeEvent[], now: number): PersistedToolActivity[] {
-    const activities = new Map<string, PersistedToolActivity>()
-    for (const event of events) {
-      if (event.kind !== 'tool' || !event.toolCallId) continue
-      const existing = activities.get(event.toolCallId)
-      activities.set(event.toolCallId, {
-        id: event.toolCallId,
-        kind: 'tool',
-        title: event.title?.trim() || existing?.title || 'Tool call',
-        status:
-          event.status === 'failed'
-            ? 'failed'
-            : event.status === 'completed'
-              ? 'completed'
-              : 'in_progress',
-        sortIndex: existing?.sortIndex ?? now + activities.size,
-        eventIds: [...(existing?.eventIds ?? []), event.id],
-        providerToolName: event.providerToolName ?? existing?.providerToolName,
-        toolKind: event.toolKind ?? existing?.toolKind,
-        toolContent: event.toolContent ?? existing?.toolContent,
-        toolLocations: event.toolLocations ?? existing?.toolLocations,
-        rawInput: event.rawInput ?? existing?.rawInput,
-        rawOutput: event.rawOutput ?? existing?.rawOutput,
-        terminalOutput: event.terminalOutput ?? existing?.terminalOutput,
-        terminalExitCode: event.terminalExitCode ?? existing?.terminalExitCode,
-        createdAt: existing?.createdAt ?? now,
-        updatedAt: now
-      })
-    }
-    return [...activities.values()]
-  }
-
-  private captureEvent(event: AcpRuntimeEvent): void {
-    if (!event.sessionId) return
-    for (const run of this.runs.values()) {
-      if (run.status === 'running' && run.sessionId === event.sessionId) run.events.push(event)
-    }
-  }
-
-  private pruneRuns(): void {
-    if (this.runs.size < MAX_RETAINED_RUNS) return
-    const completed = [...this.runs.values()]
-      .filter((run) => run.status !== 'running')
-      .sort((left, right) => left.startedAt - right.startedAt)
-    for (const run of completed) {
-      this.runs.delete(run.id)
-      if (this.runs.size < MAX_RETAINED_RUNS) return
-    }
-  }
-
-  private async resolveProject(identifier: string): Promise<Project> {
-    const normalized = typeof identifier === 'string' ? identifier.trim() : ''
-    if (!normalized) throw new TaskApiError('invalid_request', 'Project is required.')
-    const projects = await this.listProjects()
-    const byId = projects.find((project) => project.id === normalized)
-    if (byId) return byId
-    const byName = projects.filter((project) => project.name === normalized)
-    if (byName.length === 1) return byName[0]
-    if (byName.length > 1) {
-      throw new TaskApiError('project_ambiguous', `Project name is ambiguous: ${normalized}`)
-    }
-    throw new TaskApiError('project_not_found', `Project not found: ${normalized}`)
-  }
-
-  private async findSession(sessionId: string): Promise<PersistedChatSession> {
-    const session = (await this.loadSessions()).find((candidate) => candidate.id === sessionId)
-    if (!session) throw new TaskApiError('session_not_found', `Session not found: ${sessionId}`)
-    return session
-  }
-
-  private async loadSessions(): Promise<PersistedChatSession[]> {
-    const result = (await this.invoke('sessions:load-all')) as {
-      sessions: PersistedChatSession[]
-    }
-    return result.sessions
+  releaseArtifact(resourceId: string): Promise<void> {
+    return this.runner.releaseArtifact(resourceId)
   }
 
   private invoke(channel: string, ...args: unknown[]): Promise<unknown> {
@@ -684,5 +161,5 @@ class HeadlessTaskApi {
   }
 }
 
-export { HeadlessTaskApi, TaskApiError, summarizeSession }
+export { HeadlessTaskApi, TaskRunnerError as TaskApiError, summarizeSession }
 export type { TaskApiDependencies, TaskRpc }


### PR DESCRIPTION
## Problem

Task automation orchestration lived in the public Web transport adapter. That coupled HTTP compatibility, ACP/session lifecycle, artifacts, previews, and runtime-event handling in one module, making ownership unclear and the adapter difficult to change safely.

## Proposed change

Extract a headless `TaskRunner` that owns task run and artifact orchestration behind narrow project, session, agent, artifact, preview, and event ports. Keep `task-api.ts` as a compatibility adapter for the existing public HTTP surface.

```mermaid
flowchart LR
  HTTP["HTTP routes"] --> Adapter["Task HTTP compatibility adapter"]
  Adapter --> Runner["TaskRunner"]
  Events["F3 runtime events"] --> Runner
  Runner --> Ports["Narrow capability ports"]
  Ports --> Facade["Temporary IPC / WebRPC facade"]
  Runner --> PublicEvents["Existing public task-event projection"]
```

The temporary facade remains an explicit A6/T2 removal target; the new task module does not depend on IPC registries, routers, channel names, or generic invoke contracts.

## Scope and compatibility

- Preserve existing routes, request/response bodies, status codes, task events, CLI behavior, SDK behavior, and persisted schemas.
- Preserve controller-scoped lifecycle and the current SDK/CLI wait timeout; do not add a task-internal timeout.
- Preserve Electron/Web/CLI IPC compatibility and the existing Specialist, Permission, and Compute capability asymmetry.
- Keep Issue #458 forward-compatible without adding orchestration state or public APIs.
- No data-model, data-relation, or user-interaction changes.

## Acceptance and verification

- TaskRunner and adapter tests: 20 passed.
- SDK/CLI compatibility tests: 16 passed.
- HTTP compatibility tests: 15 passed.
- F3/controller lifecycle tests: 12 passed.
- Architecture search: no IPC router/registry imports, channel strings, or generic invoke dependencies in the task module.
- `npm run typecheck`: passed.
- `npm run lint`: 0 errors; 23 pre-existing warnings.
- `npm test`: 642 files passed, 15 skipped; 9,456 tests passed, 184 skipped.

## Review

Independent Standards and Spec reviews found no remaining actionable issues after adding adapter-mapping certification and the explicit A6/T2 removal note. CI and platform E2E remain the final merge gate. Merge by squash after all required checks pass.
