### PR TITLE
ci(pr-gate): prepare trusted runner bundle execution

### DIFF
--- a/scripts/ci/change-impact.json
+++ b/scripts/ci/change-impact.json
@@ -24,6 +24,38 @@
     "e2e_accessibility_windows",
     "e2e_visual_macos"
   ],
+  "bundleOrder": [
+    "policy",
+    "static",
+    "unit",
+    "coverage_macos",
+    "windows_core",
+    "macos_e2e",
+    "windows_e2e"
+  ],
+  "laneBundles": {
+    "policy": "policy",
+    "docs": "static",
+    "format": "static",
+    "lint": "static",
+    "typecheck_node": "static",
+    "typecheck_web": "static",
+    "interface_contracts": "static",
+    "cli_sdk": "static",
+    "unit_linux": "unit",
+    "coverage_macos": "coverage_macos",
+    "windows_runtime": "windows_core",
+    "windows_path": "windows_core",
+    "unit_renderer": "unit",
+    "build": "macos_e2e",
+    "e2e_functional_macos": "macos_e2e",
+    "e2e_functional_windows": "windows_e2e",
+    "e2e_workspace_macos": "macos_e2e",
+    "e2e_workspace_windows": "windows_e2e",
+    "e2e_accessibility_macos": "macos_e2e",
+    "e2e_accessibility_windows": "windows_e2e",
+    "e2e_visual_macos": "macos_e2e"
+  },
   "rules": [
     {
       "id": "global_gate_input",

--- a/scripts/ci/classify-pr-changes.mjs
+++ b/scripts/ci/classify-pr-changes.mjs
@@ -104,11 +104,24 @@ export function classifyChanges(changes, manifest = defaultManifest) {
     }
   }
 
+  const selectedLanes = manifest.laneOrder.filter((lane) => lanes.has(lane))
+  const selectedBundles = new Set()
+  const declaredBundles = new Set(manifest.bundleOrder)
+  for (const lane of selectedLanes) {
+    const bundle = manifest.laneBundles[lane]
+    if (!bundle) throw new Error(`Missing execution bundle for selected lane: ${lane}`)
+    if (!declaredBundles.has(bundle)) {
+      throw new Error(`Unknown execution bundle for selected lane ${lane}: ${bundle}`)
+    }
+    selectedBundles.add(bundle)
+  }
+
   return {
     schemaVersion: manifest.schemaVersion,
     mode,
     roots: [...roots].sort(),
-    lanes: manifest.laneOrder.filter((lane) => lanes.has(lane)),
+    lanes: selectedLanes,
+    bundles: manifest.bundleOrder.filter((bundle) => selectedBundles.has(bundle)),
     reasonChains: [...reasonChains].sort()
   }
 }
@@ -141,6 +154,7 @@ function escapeHtml(value) {
 export function formatPlanSummary(plan) {
   const roots = plan.roots.length === 0 ? '_none_' : plan.roots.map(escapeHtml).join(', ')
   const lanes = plan.lanes.length === 0 ? '_none_' : plan.lanes.map(escapeHtml).join(', ')
+  const bundles = plan.bundles?.length > 0 ? plan.bundles.map(escapeHtml).join(', ') : '_none_'
   const reasons =
     plan.reasonChains.length === 0
       ? '- _No changed paths_'
@@ -151,6 +165,7 @@ export function formatPlanSummary(plan) {
 - Mode: **${escapeHtml(plan.mode)}**
 - Roots: ${roots}
 - Selected lanes: ${lanes}
+- Execution bundles: ${bundles}
 
 ### Reason chains
 

--- a/scripts/ci/classify-pr-changes.test.ts
+++ b/scripts/ci/classify-pr-changes.test.ts
@@ -60,6 +60,9 @@ describe('pull request change classification', () => {
       expect(readFileSync(summary, 'utf8')).toContain(
         'src/shared/acp.ts -&gt; shared_contract -&gt; preload_adapter'
       )
+      expect(readFileSync(summary, 'utf8')).toContain(
+        'Execution bundles: policy, static, unit, coverage_macos, windows_core, macos_e2e, windows_e2e'
+      )
     } finally {
       rmSync(root, { force: true, recursive: true })
     }
@@ -124,7 +127,34 @@ describe('pull request change classification', () => {
         'e2e_visual_macos'
       ])
     )
+    expect(plan.bundles).toEqual([
+      'policy',
+      'static',
+      'unit',
+      'coverage_macos',
+      'windows_core',
+      'macos_e2e',
+      'windows_e2e'
+    ])
     expect(plan.reasonChains).toContain('src/new-runtime/capability.ts -> unknown -> full')
+  })
+
+  it('fails closed when a selected lane has no execution bundle', () => {
+    const manifest = JSON.parse(readFileSync(resolve('scripts/ci/change-impact.json'), 'utf8'))
+    delete manifest.laneBundles.policy
+
+    expect(() => classifyChanges([], manifest)).toThrow(
+      'Missing execution bundle for selected lane: policy'
+    )
+  })
+
+  it('fails closed when a selected lane references an undeclared execution bundle', () => {
+    const manifest = JSON.parse(readFileSync(resolve('scripts/ci/change-impact.json'), 'utf8'))
+    manifest.laneBundles.policy = 'undeclared'
+
+    expect(() => classifyChanges([], manifest)).toThrow(
+      'Unknown execution bundle for selected lane policy: undeclared'
+    )
   })
 
   it('keeps documentation-only changes on the stable minimal gate', () => {
@@ -135,6 +165,7 @@ describe('pull request change classification', () => {
 
     expect(plan.mode).toBe('selective')
     expect(plan.lanes).toEqual(['policy', 'docs'])
+    expect(plan.bundles).toEqual(['policy', 'static'])
     expect(plan.reasonChains).toEqual(
       expect.arrayContaining([
         'README.md -> documentation',

--- a/scripts/ci/evaluate-pr-gate.mjs
+++ b/scripts/ci/evaluate-pr-gate.mjs
@@ -1,11 +1,60 @@
 /* eslint-disable @typescript-eslint/explicit-function-return-type */
 
-import { appendFileSync } from 'node:fs'
+import { appendFileSync, readFileSync } from 'node:fs'
 import { resolve } from 'node:path'
 import { fileURLToPath } from 'node:url'
 
-export function evaluatePrGate(plan, conclusions) {
+const gateManifest = JSON.parse(
+  readFileSync(new URL('./change-impact.json', import.meta.url), 'utf8')
+)
+
+function expectedBundlesForLanes(lanes) {
+  if (!Array.isArray(lanes) || new Set(lanes).size !== lanes.length) return undefined
+
+  const selected = new Set()
+  const declaredBundles = new Set(gateManifest.bundleOrder)
+  for (const lane of lanes) {
+    if (!gateManifest.laneOrder.includes(lane)) return undefined
+    const bundle = gateManifest.laneBundles[lane]
+    if (!bundle || !declaredBundles.has(bundle)) return undefined
+    selected.add(bundle)
+  }
+  return gateManifest.bundleOrder.filter((bundle) => selected.has(bundle))
+}
+
+export function evaluatePrGate(plan, conclusions, { executionMode = 'lanes' } = {}) {
   const failures = []
+  const hasBundlePlan = Array.isArray(plan.bundles)
+  const expectedBundles = expectedBundlesForLanes(plan.lanes)
+  const hasValidBundlePlan =
+    hasBundlePlan &&
+    expectedBundles !== undefined &&
+    plan.bundles.length === expectedBundles.length &&
+    plan.bundles.every((bundle, index) => bundle === expectedBundles[index])
+  const selectedExecutions =
+    executionMode === 'bundles' ? (hasValidBundlePlan ? plan.bundles : []) : plan.lanes
+
+  if (executionMode !== 'lanes' && executionMode !== 'bundles') {
+    failures.push({
+      lane: 'preflight',
+      conclusion: 'invalid',
+      reason: `unsupported execution mode: ${executionMode}`
+    })
+  }
+
+  if (executionMode === 'bundles' && !hasBundlePlan) {
+    failures.push({
+      lane: 'preflight',
+      conclusion: 'invalid',
+      reason: 'execution bundle plan is missing'
+    })
+  } else if (executionMode === 'bundles' && !hasValidBundlePlan) {
+    failures.push({
+      lane: 'preflight',
+      conclusion: 'invalid',
+      reason: 'execution bundle plan does not match selected lanes'
+    })
+  }
 
   if (plan.schemaVersion !== 1) {
     failures.push({
@@ -22,18 +71,21 @@ export function evaluatePrGate(plan, conclusions) {
     })
   }
 
-  for (const lane of plan.lanes) {
-    const conclusion = conclusions[lane] ?? 'missing'
+  for (const execution of selectedExecutions) {
+    const conclusion = conclusions[execution] ?? 'missing'
     if (conclusion !== 'success') {
       failures.push({
-        lane,
+        lane: execution,
         conclusion,
-        reason: 'selected lane did not succeed'
+        reason:
+          executionMode === 'bundles'
+            ? 'selected execution bundle did not succeed'
+            : 'selected lane did not succeed'
       })
     }
   }
 
-  const selected = new Set(plan.lanes)
+  const selected = new Set(selectedExecutions)
   for (const [lane, conclusion] of Object.entries(conclusions)) {
     if (
       lane !== 'preflight' &&
@@ -52,7 +104,8 @@ export function evaluatePrGate(plan, conclusions) {
   return {
     ok: failures.length === 0,
     failures,
-    selectedLanes: [...plan.lanes]
+    selectedLanes: [...plan.lanes],
+    selectedBundles: executionMode === 'bundles' && hasValidBundlePlan ? [...plan.bundles] : []
   }
 }
 
@@ -66,6 +119,10 @@ function escapeHtml(value) {
 }
 
 export function formatPrGateSummary(result) {
+  const bundles =
+    result.selectedBundles.length === 0
+      ? ''
+      : `\n- Execution bundles: ${result.selectedBundles.map(escapeHtml).join(', ')}`
   const failures =
     result.failures.length === 0
       ? '- None'
@@ -80,7 +137,7 @@ export function formatPrGateSummary(result) {
 
 Result: **${result.ok ? 'pass' : 'fail'}**
 
-- Selected lanes: ${result.selectedLanes.map(escapeHtml).join(', ') || '_none_'}
+- Selected lanes: ${result.selectedLanes.map(escapeHtml).join(', ') || '_none_'}${bundles}
 
 ### Failures
 
@@ -97,7 +154,9 @@ export function runPrGateCli(environment = process.env) {
   const conclusions = Object.fromEntries(
     Object.entries(needs).map(([lane, value]) => [lane, value?.result ?? 'missing'])
   )
-  const result = evaluatePrGate(plan, conclusions)
+  const result = evaluatePrGate(plan, conclusions, {
+    executionMode: environment.PR_GATE_EXECUTION_MODE ?? 'lanes'
+  })
   const summary = formatPrGateSummary(result)
 
   if (environment.GITHUB_STEP_SUMMARY) appendFileSync(environment.GITHUB_STEP_SUMMARY, summary)

--- a/scripts/ci/evaluate-pr-gate.test.ts
+++ b/scripts/ci/evaluate-pr-gate.test.ts
@@ -8,6 +8,164 @@ import { describe, expect, it } from 'vitest'
 import { evaluatePrGate } from './evaluate-pr-gate.mjs'
 
 describe('PR Gate aggregation', () => {
+  it('accepts shared execution bundles while preserving semantic lane selection', () => {
+    const result = evaluatePrGate(
+      {
+        schemaVersion: 1,
+        mode: 'selective',
+        roots: ['documentation'],
+        lanes: ['policy', 'docs', 'format'],
+        bundles: ['policy', 'static'],
+        reasonChains: []
+      },
+      {
+        preflight: 'success',
+        policy: 'success',
+        static: 'success',
+        coverage_macos: 'skipped'
+      },
+      { executionMode: 'bundles' }
+    )
+
+    expect(result.ok).toBe(true)
+    expect(result.selectedLanes).toEqual(['policy', 'docs', 'format'])
+  })
+
+  it('fails closed when bundle execution is requested without a bundle plan', () => {
+    const result = evaluatePrGate(
+      {
+        schemaVersion: 1,
+        mode: 'selective',
+        roots: ['documentation'],
+        lanes: ['policy', 'docs'],
+        reasonChains: []
+      },
+      { preflight: 'success', policy: 'success', static: 'success' },
+      { executionMode: 'bundles' }
+    )
+
+    expect(result.ok).toBe(false)
+    expect(result.failures).toContainEqual({
+      lane: 'preflight',
+      conclusion: 'invalid',
+      reason: 'execution bundle plan is missing'
+    })
+  })
+
+  it('fails closed when the bundle plan is not an array', () => {
+    expect(() =>
+      evaluatePrGate(
+        {
+          schemaVersion: 1,
+          mode: 'selective',
+          roots: ['documentation'],
+          lanes: ['policy', 'docs'],
+          bundles: { policy: true },
+          reasonChains: []
+        },
+        { preflight: 'success', policy: 'success' },
+        { executionMode: 'bundles' }
+      )
+    ).not.toThrow()
+
+    const result = evaluatePrGate(
+      {
+        schemaVersion: 1,
+        mode: 'selective',
+        roots: ['documentation'],
+        lanes: ['policy', 'docs'],
+        bundles: { policy: true },
+        reasonChains: []
+      },
+      { preflight: 'success', policy: 'success' },
+      { executionMode: 'bundles' }
+    )
+
+    expect(result.ok).toBe(false)
+    expect(result.failures).toContainEqual({
+      lane: 'preflight',
+      conclusion: 'invalid',
+      reason: 'execution bundle plan is missing'
+    })
+  })
+
+  it.each([
+    ['empty', []],
+    ['unknown', ['policy', 'unknown']],
+    ['duplicate', ['policy', 'static', 'static']],
+    ['missing', ['policy']],
+    ['extra', ['policy', 'static', 'unit']]
+  ])('fails closed when the bundle plan is %s', (_case, bundles) => {
+    const result = evaluatePrGate(
+      {
+        schemaVersion: 1,
+        mode: 'selective',
+        roots: ['documentation'],
+        lanes: ['policy', 'docs'],
+        bundles,
+        reasonChains: []
+      },
+      { preflight: 'success', policy: 'success', static: 'success' },
+      { executionMode: 'bundles' }
+    )
+
+    expect(result.ok).toBe(false)
+    expect(result.failures).toContainEqual({
+      lane: 'preflight',
+      conclusion: 'invalid',
+      reason: 'execution bundle plan does not match selected lanes'
+    })
+  })
+
+  it('fails closed for an unsupported execution mode', () => {
+    const result = evaluatePrGate(
+      {
+        schemaVersion: 1,
+        mode: 'selective',
+        roots: [],
+        lanes: ['policy'],
+        bundles: ['policy'],
+        reasonChains: []
+      },
+      { preflight: 'success', policy: 'success' },
+      { executionMode: 'typo' }
+    )
+
+    expect(result.ok).toBe(false)
+    expect(result.failures).toContainEqual({
+      lane: 'preflight',
+      conclusion: 'invalid',
+      reason: 'unsupported execution mode: typo'
+    })
+  })
+
+  it('uses bundle execution mode through the trusted CLI interface', () => {
+    const result = spawnSync(process.execPath, [resolve('scripts/ci/evaluate-pr-gate.mjs')], {
+      encoding: 'utf8',
+      env: {
+        ...process.env,
+        PR_GATE_EXECUTION_MODE: 'bundles',
+        PR_GATE_PLAN: JSON.stringify({
+          schemaVersion: 1,
+          mode: 'selective',
+          roots: ['documentation'],
+          lanes: ['policy', 'docs'],
+          bundles: ['policy', 'static'],
+          reasonChains: []
+        }),
+        PR_GATE_NEEDS: JSON.stringify({
+          preflight: { result: 'success' },
+          policy: { result: 'success' },
+          static: { result: 'success' }
+        })
+      }
+    })
+
+    expect(result.status, result.stderr).toBe(0)
+    expect(result.stdout).toContain('Result: **pass**')
+    expect(result.stdout).toContain('Execution bundles: policy, static')
+  })
+
   it('publishes a successful aggregate result from GitHub needs JSON', () => {
     const root = mkdtempSync(join(tmpdir(), 'pr-gate-evaluator-'))
     const summary = join(root, 'summary')
@@ -24,6 +182,7 @@ describe('PR Gate aggregation', () => {
             mode: 'selective',
             roots: ['documentation'],
             lanes: ['policy', 'docs'],
+            bundles: ['policy', 'static'],
             reasonChains: ['README.md -> documentation']
           }),
           PR_GATE_NEEDS: JSON.stringify({

--- a/scripts/ci/evaluate-pr-gate.test.ts
+++ b/scripts/ci/evaluate-pr-gate.test.ts
@@ -144,6 +144,7 @@ describe('PR Gate aggregation', () => {
       encoding: 'utf8',
       env: {
         ...process.env,
+        GITHUB_STEP_SUMMARY: '',
         PR_GATE_EXECUTION_MODE: 'bundles',
         PR_GATE_PLAN: JSON.stringify({
           schemaVersion: 1,


### PR DESCRIPTION
## Problem

The shadow PR Gate preserves semantic coverage, but its 21 execution lanes create avoidable runner queue pressure. The workflow cannot safely switch to bundled jobs in the same pull request that introduces bundle planning because preflight and aggregation intentionally execute the classifier and evaluator from the exact base SHA.

## Proposed change

Prepare the trusted control plane for a later topology change:

- map every semantic lane deterministically to one of seven execution bundles: `policy`, `static`, `unit`, `coverage_macos`, `windows_core`, `macos_e2e`, and `windows_e2e`;
- publish the selected bundles as an additive field in the change-impact plan while preserving semantic lanes;
- add an opt-in bundle aggregation mode while keeping lane aggregation as the default;
- fail closed when the execution mode or bundle plan is missing, malformed, unknown, duplicated, incomplete, extra, or inconsistent with the semantic lanes.

```mermaid
flowchart LR
  A["Phase A PR"] --> B["Trusted base classifier and evaluator"]
  B --> C["Existing 21 semantic jobs"]
  C --> D["Lane-mode PR Gate"]
  D --> E["Phase A squash merge"]
  E --> F["Bundle planning becomes trusted on main"]
  F --> G["Phase B workflow PR"]
  G --> H["About 7 validation bundles plus preflight and gate"]
```

## Scope and non-goals

- The existing 23-job PR Gate workflow is deliberately unchanged in this phase.
- No product architecture, data model, data relationship, or user interaction changes are included.
- Phase B will change only the workflow execution topology after these controls are trusted from `main`.
- AI PR Review remains outside the deterministic PR Gate.

## Acceptance criteria and validation

All listed checks ran after the final material edit:

- deterministic lane-to-bundle selection and fail-closed validation -> `npm test -- --run scripts/ci` -> 7 files, 99 tests passed;
- Node and web type safety -> `npm run typecheck` -> passed;
- repository lint -> `npm run lint` -> 0 errors (23 pre-existing warnings outside this diff);
- changed-file formatting -> `npx prettier --check <changed files>` -> passed;
- full coverage regression suite -> `npm run test:coverage` -> 650 files and 9,560 tests passed; 15 files and 184 tests skipped; 87.71% statement coverage;
- independent Standards review -> no findings;
- independent Spec review -> no findings.

`CI Integrity` is expected to report `protected-gate-control-plane` for the manifest, classifier, and evaluator. This PR therefore requires an explicit maintainer ruleset bypass. The hosted PR Gate should continue to pass through the trusted base-SHA lane path.

## Review focus

- Confirm that the mapping preserves every semantic lane while reducing the future execution surface to seven bundles.
- Confirm that lane mode remains fully backward compatible until Phase B explicitly sets bundle mode.
- Confirm that malformed or inconsistent bundle plans cannot pass aggregation.

Uncovered risk: this phase does not measure the runner-queue improvement because it intentionally does not change workflow jobs. That measurement belongs to Phase B after this compatibility layer is merged.
