### PR TITLE
fix(notebook): serialize session registry lifecycle

### DIFF
--- a/src/main/notebook/runtime-service.test.ts
+++ b/src/main/notebook/runtime-service.test.ts
@@ -6093,6 +6093,52 @@ describe('v4 runtime bindings & agent tools', () => {
     await service.shutdownAll()
   })
 
+  it('shares one aggregate initialization across concurrent public session reads', async () => {
+    const root = await createStorageRoot()
+    const repository = new NotebookRunRepository(root)
+    const loadOrCreate = repository.loadOrCreate.bind(repository)
+    let releaseFirstLoad!: () => void
+    const firstLoadGate = new Promise<void>((resolve) => {
+      releaseFirstLoad = resolve
+    })
+    let gateFirstLoad = true
+    const loadSpy = vi.spyOn(repository, 'loadOrCreate').mockImplementation(async (request) => {
+      if (gateFirstLoad) {
+        gateFirstLoad = false
+        await firstLoadGate
+      }
+      return loadOrCreate(request)
+    })
+    const executorFactory = vi.fn(() => ({
+      execute: async (request: NotebookExecutionRequest): Promise<NotebookExecutionResult> => ({
+        status: 'completed',
+        stdout: request.code,
+        stderr: '',
+        traceback: '',
+        cwdAfter: request.cwd,
+        outputs: []
+      }),
+      shutdown: async () => ({ reaped: true })
+    }))
+    const service = new NotebookRuntimeService({
+      configRoot: root,
+      dataRoot: root,
+      projectName: 'default-project',
+      repository,
+      executorFactory
+    })
+    const request = { sessionId: 's', workspaceCwd: root }
+
+    const first = service.state(request)
+    const second = service.state(request)
+
+    await vi.waitFor(() => expect(loadSpy).toHaveBeenCalledTimes(1))
+    expect(executorFactory).not.toHaveBeenCalled()
+    releaseFirstLoad()
+    await expect(Promise.all([first, second])).resolves.toHaveLength(2)
+    expect(executorFactory).toHaveBeenCalledTimes(1)
+  })
+
   it('remains usable after temporary shutdowns for update and migration gates', async () => {
     const root = await createStorageRoot()
     const executions: string[] = []
@@ -6174,6 +6220,7 @@ describe('v4 runtime bindings & agent tools', () => {
     })
 
     const disposal = service.dispose()
+    expect(service.dispose()).toBe(disposal)
     let disposed = false
     void disposal.then(() => {
       disposed = true
@@ -6266,6 +6313,38 @@ describe('v4 runtime bindings & agent tools', () => {
     expect(disposed).toBe(false)
     releaseRecovery?.()
     await expect(disposal).rejects.toBe(shutdownError)
+  })
+
+  it('reports kernel and recovery disposal failures together in deterministic order', async () => {
+    const root = await createStorageRoot()
+    const shutdownError = new Error('kernel teardown failed')
+    const recoveryError = new Error('recovery disposal failed')
+    const service = new NotebookRuntimeService({
+      configRoot: root,
+      dataRoot: root,
+      projectName: 'default-project',
+      repository: new NotebookRunRepository(root),
+      executorFactory: () => ({
+        execute: async (request): Promise<NotebookExecutionResult> => ({
+          status: 'completed',
+          stdout: request.code,
+          stderr: '',
+          traceback: '',
+          cwdAfter: request.cwd,
+          outputs: []
+        }),
+        shutdown: vi.fn(async () => Promise.reject(shutdownError))
+      })
+    })
+    await service.state({ sessionId: 's', workspaceCwd: root })
+    Object.defineProperty(service, 'recoveryCoordinator', {
+      value: { dispose: vi.fn(async () => Promise.reject(recoveryError)) }
+    })
+
+    const failure = await service.dispose().catch((error: unknown) => error)
+
+    expect(failure).toBeInstanceOf(AggregateError)
+    expect((failure as AggregateError).errors).toEqual([shutdownError, recoveryError])
   })
 
   it('describeRuntimeUsage counts bound sessions by kernel state for the disable warning (WS11)', async () => {

--- a/src/main/notebook/runtime-service.ts
+++ b/src/main/notebook/runtime-service.ts
@@ -3219,7 +3219,10 @@ class NotebookRuntimeService {
           .map((result) => result.reason)
         if (failures.length === 1) throw failures[0]
         if (failures.length > 1) {
-          throw new AggregateError(failures, 'Multiple notebook runtime resources failed to dispose.')
+          throw new AggregateError(
+            failures,
+            'Multiple notebook runtime resources failed to dispose.'
+          )
         }
         return (shutdownResult as PromiseFulfilledResult<{ reaped: boolean }>).value
       }

--- a/src/main/notebook/runtime-service.ts
+++ b/src/main/notebook/runtime-service.ts
@@ -113,6 +113,7 @@ import {
   type NotebookSessionResolvedInterpreter,
   type NotebookSessionRuntimeBinding
 } from './session-aggregate'
+import { NotebookSessionRegistry } from './session-registry'
 import { getAppClaudeConfigDir } from '../settings/provider-env'
 import { terminateProcessTree } from '../process-tree'
 import { createLogger, getLogFilePath } from '../logger'
@@ -869,7 +870,7 @@ const resolveDefaultExecutorOptions = (): NotebookKernelExecutorOptions => {
 // Coordinates notebook cells, shared interpreters, persisted run history, and UI notifications.
 class NotebookRuntimeService {
   private readonly repository: NotebookRunRepository
-  private readonly sessions = new Map<string, RuntimeSession>()
+  private readonly sessions: NotebookSessionRegistry<RuntimeSession>
   private readonly announcedAgentSessionIds = new Set<string>()
   // Owns per-environment shared run and exclusive mutation leases. The runtime decides which paths
   // require which mode; acquisition, queueing, cancellation, and release stay inside the manager.
@@ -920,9 +921,15 @@ class NotebookRuntimeService {
   private environmentManager: NotebookEnvironmentManager | undefined
   private defaultEnvProvisioner: DefaultEnvProvisioner | undefined
   private defaultEnvProgress: (progress: ProvisionProgress) => void = () => undefined
+  private disposalPromise: Promise<{ reaped: boolean }> | undefined
 
   constructor(private readonly options: NotebookRuntimeServiceOptions) {
     this.repository = options.repository ?? new NotebookRunRepository(options.dataRoot)
+    this.sessions = new NotebookSessionRegistry({
+      beforeTeardown: async () => {
+        await Promise.all(Array.from(this.revocationDrains)).catch(() => undefined)
+      }
+    })
     this.recoveryCoordinator = new NotebookRecoveryCoordinator(getRuntimeRoot(options.dataRoot))
     this.mcpRpcConnectionResolver = options.getMcpRpcConnection
     this.packageMirrorResolver = options.getPackageMirror
@@ -3015,14 +3022,7 @@ class NotebookRuntimeService {
   }
 
   async shutdownSession(sessionId: string): Promise<{ sessionId: string; status: 'shutdown' }> {
-    const session = this.sessions.get(sessionId)
-
-    if (session) {
-      await session.shutdownExecutor()
-      session.releaseMcpRpcConnection()
-      this.sessions.delete(sessionId)
-    }
-
+    await this.sessions.remove(sessionId)
     return { sessionId, status: 'shutdown' }
   }
 
@@ -3193,21 +3193,16 @@ class NotebookRuntimeService {
   // Shuts down every live interpreter, used by app-level cleanup paths. Returns { reaped }: true only
   // when every kernel tree was cleanly reaped, so the update-install gate can refuse to trigger the
   // NSIS uninstall while a kernel may still hold file handles under the install dir.
-  async shutdownAll(): Promise<{ reaped: boolean }> {
-    // Let any in-flight disable drain-and-close settle first, so a revocation teardown never races the
-    // shutdown (and tests don't leak a dangling background drain).
-    await Promise.all(Array.from(this.revocationDrains)).catch(() => undefined)
-    const sessions = Array.from(this.sessions.values())
-    const results = await Promise.all(sessions.map((session) => session.shutdownExecutor()))
-    for (const session of sessions) session.releaseMcpRpcConnection()
-    this.sessions.clear()
-    return { reaped: results.every((result) => result.reaped) }
+  shutdownAll(): Promise<{ reaped: boolean }> {
+    return this.sessions.shutdownAll()
   }
 
   // Permanently closes process-owned recovery work before the final kernel teardown. Unlike
   // shutdownAll(), this is terminal: quit/relaunch and module disposal use it, while update and data-root
   // migration gates retain the reusable shutdown contract so a refused/cancelled flow can resume work.
-  async dispose(): Promise<{ reaped: boolean }> {
+  dispose(): Promise<{ reaped: boolean }> {
+    if (this.disposalPromise) return this.disposalPromise
+
     // Close the terminal admission boundary before any asynchronous teardown starts. Existing holders
     // are released and queued acquisitions reject, so no package/environment operation can begin after
     // application disposal has crossed this point.
@@ -3216,11 +3211,21 @@ class NotebookRuntimeService {
     // quit budget before kernel teardown even starts. Await both so non-quit module disposal still leaves
     // no recovery work behind once this terminal operation resolves.
     const recoveryDisposal = this.recoveryCoordinator.dispose()
-    const shutdown = this.shutdownAll()
-    const [shutdownResult, recoveryResult] = await Promise.allSettled([shutdown, recoveryDisposal])
-    if (recoveryResult.status === 'rejected') throw recoveryResult.reason
-    if (shutdownResult.status === 'rejected') throw shutdownResult.reason
-    return shutdownResult.value
+    const shutdown = this.sessions.dispose()
+    const disposal = Promise.allSettled([shutdown, recoveryDisposal]).then(
+      ([shutdownResult, recoveryResult]) => {
+        const failures = [shutdownResult, recoveryResult]
+          .filter((result): result is PromiseRejectedResult => result.status === 'rejected')
+          .map((result) => result.reason)
+        if (failures.length === 1) throw failures[0]
+        if (failures.length > 1) {
+          throw new AggregateError(failures, 'Multiple notebook runtime resources failed to dispose.')
+        }
+        return (shutdownResult as PromiseFulfilledResult<{ reaped: boolean }>).value
+      }
+    )
+    this.disposalPromise = disposal
+    return disposal
   }
 
   // Lists sessions with a cell mid-execution, for the pre-migration active-session warning.
@@ -3233,50 +3238,56 @@ class NotebookRuntimeService {
   // Creates or returns the runtime session bound to an ACP/chat session id.
   private async ensureSession(request: NotebookSessionRequest): Promise<RuntimeSession> {
     const projectName = request.projectName ?? this.options.projectName
-    const existing = this.sessions.get(request.sessionId)
+    return this.sessions.getOrCreate(request.sessionId, async () => {
+      let document = await this.repository.loadOrCreate({
+        projectName,
+        sessionId: request.sessionId,
+        workspaceCwd: request.workspaceCwd
+      })
+      // Crash recovery (WS12): the FIRST time this process loads a session, any run still marked
+      // 'running'/'queued' was in flight when a previous process died — its kernel is gone. Reconcile it
+      // to 'interrupted' so history is truthful and the UI/agent see it ended. Only reconcile when such a
+      // stale run exists (avoids rewriting a clean doc), and only here at session creation (never in
+      // state()/loadOrCreate), so a run that is genuinely live in THIS process is never mislabeled.
+      if (document.runs.some((run) => run.status === 'running' || run.status === 'queued')) {
+        document = await this.repository.reconcileInterruptedRuns(projectName, request.sessionId)
+      }
+      // Runtime session roots come from run.json normalization so UI, MCP, and Python agree.
+      const session: RuntimeSession = new NotebookSessionAggregate({
+        sessionId: request.sessionId,
+        projectName,
+        // Start the interpreter in the session's writable data dir (like a Jupyter notebook's cwd), not
+        // the outer workspace. Relative writes — e.g. plt.savefig("plot.png") — then land in a directory
+        // that is inside the artifact import roots, so the agent never has to guess an absolute path.
+        // dataRoot lives under notebookSessionRoot (an allowed import root) and is created before this.
+        cwd: document.dataRoot,
+        notebookSessionRoot: document.notebookSessionRoot,
+        dataRoot: document.dataRoot,
+        runtimeRoot: document.kernel.runtimeRoot,
+        runJsonPath: getNotebookRunJsonPath(this.options.dataRoot, projectName, request.sessionId),
+        executionCount: document.runs.length,
+        executor: this.createExecutor(request.sessionId, projectName)
+      })
 
-    if (existing) {
-      return existing
-    }
-
-    let document = await this.repository.loadOrCreate({
-      projectName,
-      sessionId: request.sessionId,
-      workspaceCwd: request.workspaceCwd
+      try {
+        // Rehydrate + revalidate any persisted runtime bindings (WS1-rest/WS12): a still-usable binding
+        // is restored active; one whose runtime is now disabled/missing is kept as unavailable (no
+        // silent fallback). Publish only after this initialization completes so same-ID callers cannot
+        // observe a partially hydrated aggregate.
+        await this.reloadPersistedBindings(session, document.runtimeBindings)
+        return session
+      } catch (error) {
+        // Initialization failures stay retryable. Best-effort cleanup must not replace the repository /
+        // binding error that callers already observe.
+        await session.shutdownExecutor().catch(() => undefined)
+        try {
+          session.releaseMcpRpcConnection()
+        } catch {
+          // Preserve the initialization failure.
+        }
+        throw error
+      }
     })
-    // Crash recovery (WS12): the FIRST time this process loads a session, any run still marked
-    // 'running'/'queued' was in flight when a previous process died — its kernel is gone. Reconcile it
-    // to 'interrupted' so history is truthful and the UI/agent see it ended. Only reconcile when such a
-    // stale run exists (avoids rewriting a clean doc), and only here at session creation (never in
-    // state()/loadOrCreate), so a run that is genuinely live in THIS process is never mislabeled.
-    if (document.runs.some((run) => run.status === 'running' || run.status === 'queued')) {
-      document = await this.repository.reconcileInterruptedRuns(projectName, request.sessionId)
-    }
-    // Runtime session roots come from run.json normalization so UI, MCP, and Python agree.
-    const session: RuntimeSession = new NotebookSessionAggregate({
-      sessionId: request.sessionId,
-      projectName,
-      // Start the interpreter in the session's writable data dir (like a Jupyter notebook's cwd), not
-      // the outer workspace. Relative writes — e.g. plt.savefig("plot.png") — then land in a directory
-      // that is inside the artifact import roots, so the agent never has to guess an absolute path.
-      // dataRoot lives under notebookSessionRoot (an allowed import root) and is created before this.
-      cwd: document.dataRoot,
-      notebookSessionRoot: document.notebookSessionRoot,
-      dataRoot: document.dataRoot,
-      runtimeRoot: document.kernel.runtimeRoot,
-      runJsonPath: getNotebookRunJsonPath(this.options.dataRoot, projectName, request.sessionId),
-      executionCount: document.runs.length,
-      executor: this.createExecutor(request.sessionId, projectName)
-    })
-
-    this.sessions.set(request.sessionId, session)
-
-    // Rehydrate + revalidate any persisted runtime bindings (WS1-rest/WS12): a still-usable binding is
-    // restored active; one whose runtime is now disabled/missing is kept as unavailable (no silent
-    // fallback). Only touches discovery when bindings were actually persisted.
-    await this.reloadPersistedBindings(session, document.runtimeBindings)
-
-    return session
   }
 
   // Builds the interpreter backend, allowing tests to inject a fake executor. The default (D-B4)

--- a/src/main/notebook/session-registry.test.ts
+++ b/src/main/notebook/session-registry.test.ts
@@ -175,6 +175,26 @@ describe('NotebookSessionRegistry', () => {
     expect(removed.releaseMcpRpcConnection).toHaveBeenCalledTimes(1)
   })
 
+  it('isolates a synchronous executor shutdown failure from other aggregates', async () => {
+    const registry = new NotebookSessionRegistry<TestSession>()
+    const teardownError = new Error('synchronous teardown failed')
+    const failed = testSession('session-1')
+    const removed = testSession('session-2')
+    vi.mocked(failed.shutdownExecutor).mockImplementationOnce(() => {
+      throw teardownError
+    })
+    await registry.getOrCreate('session-1', async () => failed)
+    await registry.getOrCreate('session-2', async () => removed)
+
+    await expect(registry.shutdownAll()).rejects.toBe(teardownError)
+
+    expect(failed.shutdownExecutor).toHaveBeenCalledTimes(1)
+    expect(removed.shutdownExecutor).toHaveBeenCalledTimes(1)
+    expect(registry.get('session-1')).toBe(failed)
+    expect(registry.get('session-2')).toBeUndefined()
+    expect(removed.releaseMcpRpcConnection).toHaveBeenCalledTimes(1)
+  })
+
   it('reports multiple shutdown failures in deterministic session-ID order', async () => {
     const registry = new NotebookSessionRegistry<TestSession>()
     const firstError = new Error('session-1 teardown failed')
@@ -192,6 +212,33 @@ describe('NotebookSessionRegistry', () => {
     expect((failure as AggregateError).errors).toEqual([firstError, secondError])
     expect(registry.get('session-1')).toBe(first)
     expect(registry.get('session-2')).toBe(second)
+  })
+
+  it('isolates reusable release failures and aggregates them with executor failures', async () => {
+    const registry = new NotebookSessionRegistry<TestSession>()
+    const executorError = new Error('session-1 executor teardown failed')
+    const releaseError = new Error('session-2 connection release failed')
+    const executorFailed = testSession('session-1')
+    const releaseFailed = testSession('session-2')
+    const removed = testSession('session-3')
+    vi.mocked(executorFailed.shutdownExecutor).mockRejectedValueOnce(executorError)
+    vi.mocked(releaseFailed.releaseMcpRpcConnection).mockImplementationOnce(() => {
+      throw releaseError
+    })
+    await registry.getOrCreate('session-1', async () => executorFailed)
+    await registry.getOrCreate('session-2', async () => releaseFailed)
+    await registry.getOrCreate('session-3', async () => removed)
+
+    const failure = await registry.shutdownAll().catch((error: unknown) => error)
+
+    expect(failure).toBeInstanceOf(AggregateError)
+    expect((failure as AggregateError).errors).toEqual([executorError, releaseError])
+    expect(executorFailed.shutdownExecutor).toHaveBeenCalledTimes(1)
+    expect(releaseFailed.releaseMcpRpcConnection).toHaveBeenCalledTimes(1)
+    expect(removed.releaseMcpRpcConnection).toHaveBeenCalledTimes(1)
+    expect(registry.get('session-1')).toBe(executorFailed)
+    expect(registry.get('session-2')).toBe(releaseFailed)
+    expect(registry.get('session-3')).toBeUndefined()
   })
 
   it('returns reaped false after releasing sessions, then reopens admission', async () => {
@@ -285,7 +332,51 @@ describe('NotebookSessionRegistry', () => {
 
     expect(failed.shutdownExecutor).toHaveBeenCalledTimes(1)
     expect(removed.shutdownExecutor).toHaveBeenCalledTimes(1)
-    expect(registry.get('session-1')).toBe(failed)
+    expect(failed.releaseMcpRpcConnection).toHaveBeenCalledTimes(1)
+    expect(removed.releaseMcpRpcConnection).toHaveBeenCalledTimes(1)
+    expect(registry.get('session-1')).toBeUndefined()
+    expect(registry.get('session-2')).toBeUndefined()
+  })
+
+  it('releases terminal resources exactly once after executor shutdown rejects', async () => {
+    const registry = new NotebookSessionRegistry<TestSession>()
+    const teardownError = new Error('terminal executor teardown failed')
+    const session = testSession('session-1')
+    vi.mocked(session.shutdownExecutor).mockRejectedValueOnce(teardownError)
+    await registry.getOrCreate('session-1', async () => session)
+
+    const disposal = registry.dispose()
+
+    await expect(disposal).rejects.toBe(teardownError)
+    expect(session.shutdownExecutor).toHaveBeenCalledTimes(1)
+    expect(session.releaseMcpRpcConnection).toHaveBeenCalledTimes(1)
+    expect(registry.get('session-1')).toBeUndefined()
+    await expect(registry.dispose()).rejects.toBe(teardownError)
+    expect(session.releaseMcpRpcConnection).toHaveBeenCalledTimes(1)
+  })
+
+  it('aggregates terminal executor and release failures after attempting every aggregate', async () => {
+    const registry = new NotebookSessionRegistry<TestSession>()
+    const executorError = new Error('session-1 terminal executor failed')
+    const releaseError = new Error('session-1 terminal release failed')
+    const failed = testSession('session-1')
+    const cleaned = testSession('session-2')
+    vi.mocked(failed.shutdownExecutor).mockRejectedValueOnce(executorError)
+    vi.mocked(failed.releaseMcpRpcConnection).mockImplementationOnce(() => {
+      throw releaseError
+    })
+    await registry.getOrCreate('session-1', async () => failed)
+    await registry.getOrCreate('session-2', async () => cleaned)
+
+    const failure = await registry.dispose().catch((error: unknown) => error)
+
+    expect(failure).toBeInstanceOf(AggregateError)
+    expect((failure as AggregateError).errors).toEqual([executorError, releaseError])
+    expect(failed.shutdownExecutor).toHaveBeenCalledTimes(1)
+    expect(cleaned.shutdownExecutor).toHaveBeenCalledTimes(1)
+    expect(failed.releaseMcpRpcConnection).toHaveBeenCalledTimes(1)
+    expect(cleaned.releaseMcpRpcConnection).toHaveBeenCalledTimes(1)
+    expect(registry.get('session-1')).toBeUndefined()
     expect(registry.get('session-2')).toBeUndefined()
   })
 
@@ -332,7 +423,27 @@ describe('NotebookSessionRegistry', () => {
     await expect(removal).rejects.toBe(teardownError)
     await expect(disposal).rejects.toBe(teardownError)
     expect(session.shutdownExecutor).toHaveBeenCalledTimes(1)
-    expect(registry.get('session-1')).toBe(session)
+    expect(session.releaseMcpRpcConnection).toHaveBeenCalledTimes(1)
+    expect(registry.get('session-1')).toBeUndefined()
+  })
+
+  it('does not repeat a release that already failed during removal before terminal disposal', async () => {
+    const registry = new NotebookSessionRegistry<TestSession>()
+    const releaseError = new Error('removal release failed')
+    const session = testSession('session-1')
+    vi.mocked(session.releaseMcpRpcConnection).mockImplementationOnce(() => {
+      throw releaseError
+    })
+    await registry.getOrCreate('session-1', async () => session)
+
+    const removal = registry.remove('session-1')
+    const disposal = registry.dispose()
+
+    await expect(removal).rejects.toBe(releaseError)
+    await expect(disposal).rejects.toBe(releaseError)
+    expect(session.shutdownExecutor).toHaveBeenCalledTimes(1)
+    expect(session.releaseMcpRpcConnection).toHaveBeenCalledTimes(1)
+    expect(registry.get('session-1')).toBeUndefined()
   })
 
   it('adopts an earlier global shutdown as terminal cleanup without retrying failures', async () => {

--- a/src/main/notebook/session-registry.test.ts
+++ b/src/main/notebook/session-registry.test.ts
@@ -8,7 +8,11 @@ type TestSession = {
   releaseMcpRpcConnection: () => void
 }
 
-const deferred = <T>() => {
+const deferred = <T>(): {
+  promise: Promise<T>
+  resolve: (value: T) => void
+  reject: (reason?: unknown) => void
+} => {
   let resolve!: (value: T) => void
   let reject!: (reason?: unknown) => void
   const promise = new Promise<T>((resolvePromise, rejectPromise) => {

--- a/src/main/notebook/session-registry.test.ts
+++ b/src/main/notebook/session-registry.test.ts
@@ -40,4 +40,73 @@ describe('NotebookSessionRegistry', () => {
     await expect(Promise.all([first, second])).resolves.toEqual([session, session])
     expect(registry.get('session-1')).toBe(session)
   })
+
+  it('allows another initialization after the first attempt rejects', async () => {
+    const registry = new NotebookSessionRegistry<TestSession>()
+    const initializationError = new Error('initialization failed')
+    const session = testSession('session-1')
+    const create = vi
+      .fn<() => Promise<TestSession>>()
+      .mockRejectedValueOnce(initializationError)
+      .mockResolvedValueOnce(session)
+
+    await expect(registry.getOrCreate('session-1', create)).rejects.toBe(initializationError)
+    await expect(registry.getOrCreate('session-1', create)).resolves.toBe(session)
+
+    expect(create).toHaveBeenCalledTimes(2)
+  })
+
+  it('initializes different session IDs without serializing them', async () => {
+    const registry = new NotebookSessionRegistry<TestSession>()
+    const firstInitialization = deferred<TestSession>()
+    const second = testSession('session-2')
+
+    const firstAdmission = registry.getOrCreate('session-1', () => firstInitialization.promise)
+    const secondAdmission = registry.getOrCreate('session-2', async () => second)
+
+    await expect(secondAdmission).resolves.toBe(second)
+    const first = testSession('session-1')
+    firstInitialization.resolve(first)
+    await expect(firstAdmission).resolves.toBe(first)
+  })
+
+  it('removes an in-flight session before admitting a fresh generation', async () => {
+    const registry = new NotebookSessionRegistry<TestSession>()
+    const initialization = deferred<TestSession>()
+    const original = testSession('session-1')
+    const replacement = testSession('session-1')
+    const createReplacement = vi.fn(async () => replacement)
+
+    const originalAdmission = registry.getOrCreate('session-1', () => initialization.promise)
+    const removal = registry.remove('session-1')
+    const replacementAdmission = registry.getOrCreate('session-1', createReplacement)
+
+    expect(createReplacement).not.toHaveBeenCalled()
+    initialization.resolve(original)
+
+    await expect(originalAdmission).resolves.toBe(original)
+    await expect(removal).resolves.toEqual({ reaped: true })
+    await expect(replacementAdmission).resolves.toBe(replacement)
+    expect(original.shutdownExecutor).toHaveBeenCalledTimes(1)
+    expect(original.releaseMcpRpcConnection).toHaveBeenCalledTimes(1)
+    expect(registry.get('session-1')).toBe(replacement)
+  })
+
+  it('restores queued admission to the old session when removal fails', async () => {
+    const registry = new NotebookSessionRegistry<TestSession>()
+    const teardownError = new Error('teardown failed')
+    const original = testSession('session-1')
+    vi.mocked(original.shutdownExecutor).mockRejectedValueOnce(teardownError)
+    await registry.getOrCreate('session-1', async () => original)
+    const createReplacement = vi.fn(async () => testSession('session-1'))
+
+    const removal = registry.remove('session-1')
+    const queuedAdmission = registry.getOrCreate('session-1', createReplacement)
+
+    await expect(removal).rejects.toBe(teardownError)
+    await expect(queuedAdmission).resolves.toBe(original)
+    expect(createReplacement).not.toHaveBeenCalled()
+    expect(original.releaseMcpRpcConnection).not.toHaveBeenCalled()
+    expect(registry.get('session-1')).toBe(original)
+  })
 })

--- a/src/main/notebook/session-registry.test.ts
+++ b/src/main/notebook/session-registry.test.ts
@@ -1,0 +1,43 @@
+import { describe, expect, it, vi } from 'vitest'
+
+import { NotebookSessionRegistry } from './session-registry'
+
+type TestSession = {
+  sessionId: string
+  shutdownExecutor: () => Promise<{ reaped: boolean }>
+  releaseMcpRpcConnection: () => void
+}
+
+const deferred = <T>() => {
+  let resolve!: (value: T) => void
+  let reject!: (reason?: unknown) => void
+  const promise = new Promise<T>((resolvePromise, rejectPromise) => {
+    resolve = resolvePromise
+    reject = rejectPromise
+  })
+  return { promise, resolve, reject }
+}
+
+const testSession = (sessionId: string): TestSession => ({
+  sessionId,
+  shutdownExecutor: vi.fn(async () => ({ reaped: true })),
+  releaseMcpRpcConnection: vi.fn()
+})
+
+describe('NotebookSessionRegistry', () => {
+  it('shares one initialization across concurrent admission for the same session ID', async () => {
+    const registry = new NotebookSessionRegistry<TestSession>()
+    const initialization = deferred<TestSession>()
+    const create = vi.fn(() => initialization.promise)
+
+    const first = registry.getOrCreate('session-1', create)
+    const second = registry.getOrCreate('session-1', create)
+
+    expect(create).toHaveBeenCalledTimes(1)
+    const session = testSession('session-1')
+    initialization.resolve(session)
+
+    await expect(Promise.all([first, second])).resolves.toEqual([session, session])
+    expect(registry.get('session-1')).toBe(session)
+  })
+})

--- a/src/main/notebook/session-registry.test.ts
+++ b/src/main/notebook/session-registry.test.ts
@@ -33,6 +33,7 @@ describe('NotebookSessionRegistry', () => {
     const first = registry.getOrCreate('session-1', create)
     const second = registry.getOrCreate('session-1', create)
 
+    await Promise.resolve()
     expect(create).toHaveBeenCalledTimes(1)
     const session = testSession('session-1')
     initialization.resolve(session)
@@ -54,6 +55,21 @@ describe('NotebookSessionRegistry', () => {
     await expect(registry.getOrCreate('session-1', create)).resolves.toBe(session)
 
     expect(create).toHaveBeenCalledTimes(2)
+  })
+
+  it('turns a synchronous initialization failure into a retryable rejection', async () => {
+    const registry = new NotebookSessionRegistry<TestSession>()
+    const initializationError = new Error('synchronous initialization failed')
+    const session = testSession('session-1')
+    const create = vi
+      .fn<() => Promise<TestSession>>()
+      .mockImplementationOnce(() => {
+        throw initializationError
+      })
+      .mockResolvedValueOnce(session)
+
+    await expect(registry.getOrCreate('session-1', create)).rejects.toBe(initializationError)
+    await expect(registry.getOrCreate('session-1', create)).resolves.toBe(session)
   })
 
   it('initializes different session IDs without serializing them', async () => {
@@ -227,5 +243,106 @@ describe('NotebookSessionRegistry', () => {
     ])
     expect(session.shutdownExecutor).toHaveBeenCalledTimes(1)
     expect(session.releaseMcpRpcConnection).toHaveBeenCalledTimes(1)
+  })
+
+  it('permanently closes admission and shares terminal disposal across callers', async () => {
+    const registry = new NotebookSessionRegistry<TestSession>()
+    const initialization = deferred<TestSession>()
+    const session = testSession('session-1')
+    vi.mocked(session.shutdownExecutor).mockResolvedValueOnce({ reaped: false })
+    const admission = registry.getOrCreate('session-1', () => initialization.promise)
+
+    const firstDisposal = registry.dispose()
+    const repeatedDisposal = registry.dispose()
+    const createAfterDispose = vi.fn(async () => testSession('session-2'))
+
+    expect(repeatedDisposal).toBe(firstDisposal)
+    await expect(registry.getOrCreate('session-2', createAfterDispose)).rejects.toThrow(/disposed/)
+    expect(createAfterDispose).not.toHaveBeenCalled()
+    initialization.resolve(session)
+
+    await expect(admission).resolves.toBe(session)
+    await expect(firstDisposal).resolves.toEqual({ reaped: false })
+    expect(session.shutdownExecutor).toHaveBeenCalledTimes(1)
+    expect(session.releaseMcpRpcConnection).toHaveBeenCalledTimes(1)
+    await expect(registry.getOrCreate('session-1', async () => session)).rejects.toThrow(/disposed/)
+  })
+
+  it('rethrows one terminal teardown error unchanged after attempting every session', async () => {
+    const registry = new NotebookSessionRegistry<TestSession>()
+    const teardownError = new Error('terminal teardown failed')
+    const failed = testSession('session-1')
+    const removed = testSession('session-2')
+    vi.mocked(failed.shutdownExecutor).mockRejectedValueOnce(teardownError)
+    await registry.getOrCreate('session-1', async () => failed)
+    await registry.getOrCreate('session-2', async () => removed)
+
+    await expect(registry.dispose()).rejects.toBe(teardownError)
+
+    expect(failed.shutdownExecutor).toHaveBeenCalledTimes(1)
+    expect(removed.shutdownExecutor).toHaveBeenCalledTimes(1)
+    expect(registry.get('session-1')).toBe(failed)
+    expect(registry.get('session-2')).toBeUndefined()
+  })
+
+  it('orders multiple terminal teardown errors by session ID', async () => {
+    const registry = new NotebookSessionRegistry<TestSession>()
+    const firstError = new Error('session-1 terminal teardown failed')
+    const secondError = new Error('session-2 terminal teardown failed')
+    const second = testSession('session-2')
+    const first = testSession('session-1')
+    vi.mocked(second.shutdownExecutor).mockRejectedValueOnce(secondError)
+    vi.mocked(first.shutdownExecutor).mockRejectedValueOnce(firstError)
+    await registry.getOrCreate('session-2', async () => second)
+    await registry.getOrCreate('session-1', async () => first)
+
+    const failure = await registry.dispose().catch((error: unknown) => error)
+
+    expect(failure).toBeInstanceOf(AggregateError)
+    expect((failure as AggregateError).errors).toEqual([firstError, secondError])
+  })
+
+  it('finishes terminal disposal when an in-flight initialization rejects', async () => {
+    const registry = new NotebookSessionRegistry<TestSession>()
+    const initialization = deferred<TestSession>()
+    const initializationError = new Error('factory failed')
+    const admission = registry.getOrCreate('session-1', () => initialization.promise)
+
+    const disposal = registry.dispose()
+    initialization.reject(initializationError)
+
+    await expect(admission).rejects.toBe(initializationError)
+    await expect(disposal).resolves.toEqual({ reaped: true })
+  })
+
+  it('includes an earlier failed removal in terminal disposal without retrying teardown', async () => {
+    const registry = new NotebookSessionRegistry<TestSession>()
+    const teardownError = new Error('removal teardown failed')
+    const session = testSession('session-1')
+    vi.mocked(session.shutdownExecutor).mockRejectedValueOnce(teardownError)
+    await registry.getOrCreate('session-1', async () => session)
+
+    const removal = registry.remove('session-1')
+    const disposal = registry.dispose()
+
+    await expect(removal).rejects.toBe(teardownError)
+    await expect(disposal).rejects.toBe(teardownError)
+    expect(session.shutdownExecutor).toHaveBeenCalledTimes(1)
+    expect(registry.get('session-1')).toBe(session)
+  })
+
+  it('adopts an earlier global shutdown as terminal cleanup without retrying failures', async () => {
+    const registry = new NotebookSessionRegistry<TestSession>()
+    const teardownError = new Error('global teardown failed')
+    const session = testSession('session-1')
+    vi.mocked(session.shutdownExecutor).mockRejectedValueOnce(teardownError)
+    await registry.getOrCreate('session-1', async () => session)
+
+    const shutdown = registry.shutdownAll()
+    const disposal = registry.dispose()
+
+    await expect(shutdown).rejects.toBe(teardownError)
+    await expect(disposal).rejects.toBe(teardownError)
+    expect(session.shutdownExecutor).toHaveBeenCalledTimes(1)
   })
 })

--- a/src/main/notebook/session-registry.test.ts
+++ b/src/main/notebook/session-registry.test.ts
@@ -109,4 +109,123 @@ describe('NotebookSessionRegistry', () => {
     expect(original.releaseMcpRpcConnection).not.toHaveBeenCalled()
     expect(registry.get('session-1')).toBe(original)
   })
+
+  it('shuts down in-flight sessions before reopening global admission', async () => {
+    const registry = new NotebookSessionRegistry<TestSession>()
+    const initialization = deferred<TestSession>()
+    const original = testSession('session-1')
+    const replacement = testSession('session-2')
+    const createReplacement = vi.fn(async () => replacement)
+
+    const originalAdmission = registry.getOrCreate('session-1', () => initialization.promise)
+    const shutdown = registry.shutdownAll()
+    const replacementAdmission = registry.getOrCreate('session-2', createReplacement)
+
+    expect(createReplacement).not.toHaveBeenCalled()
+    initialization.resolve(original)
+
+    await expect(originalAdmission).resolves.toBe(original)
+    await expect(shutdown).resolves.toEqual({ reaped: true })
+    await expect(replacementAdmission).resolves.toBe(replacement)
+    expect(original.shutdownExecutor).toHaveBeenCalledTimes(1)
+    expect(original.releaseMcpRpcConnection).toHaveBeenCalledTimes(1)
+    expect(registry.get('session-1')).toBeUndefined()
+    expect(registry.get('session-2')).toBe(replacement)
+  })
+
+  it('keeps failed sessions while removing successful sessions after best-effort shutdown', async () => {
+    const registry = new NotebookSessionRegistry<TestSession>()
+    const teardownError = new Error('session-1 teardown failed')
+    const failed = testSession('session-1')
+    const removed = testSession('session-2')
+    vi.mocked(failed.shutdownExecutor).mockRejectedValueOnce(teardownError)
+    await registry.getOrCreate('session-1', async () => failed)
+    await registry.getOrCreate('session-2', async () => removed)
+    const createReplacement = vi.fn(async () => testSession('session-1'))
+
+    const shutdown = registry.shutdownAll()
+    const queuedAdmission = registry.getOrCreate('session-1', createReplacement)
+
+    await expect(shutdown).rejects.toBe(teardownError)
+    await expect(queuedAdmission).resolves.toBe(failed)
+    expect(createReplacement).not.toHaveBeenCalled()
+    expect(registry.get('session-1')).toBe(failed)
+    expect(registry.get('session-2')).toBeUndefined()
+    expect(failed.releaseMcpRpcConnection).not.toHaveBeenCalled()
+    expect(removed.releaseMcpRpcConnection).toHaveBeenCalledTimes(1)
+  })
+
+  it('reports multiple shutdown failures in deterministic session-ID order', async () => {
+    const registry = new NotebookSessionRegistry<TestSession>()
+    const firstError = new Error('session-1 teardown failed')
+    const secondError = new Error('session-2 teardown failed')
+    const second = testSession('session-2')
+    const first = testSession('session-1')
+    vi.mocked(second.shutdownExecutor).mockRejectedValueOnce(secondError)
+    vi.mocked(first.shutdownExecutor).mockRejectedValueOnce(firstError)
+    await registry.getOrCreate('session-2', async () => second)
+    await registry.getOrCreate('session-1', async () => first)
+
+    const failure = await registry.shutdownAll().catch((error: unknown) => error)
+
+    expect(failure).toBeInstanceOf(AggregateError)
+    expect((failure as AggregateError).errors).toEqual([firstError, secondError])
+    expect(registry.get('session-1')).toBe(first)
+    expect(registry.get('session-2')).toBe(second)
+  })
+
+  it('returns reaped false after releasing sessions, then reopens admission', async () => {
+    const registry = new NotebookSessionRegistry<TestSession>()
+    const unreaped = testSession('session-1')
+    vi.mocked(unreaped.shutdownExecutor).mockResolvedValueOnce({ reaped: false })
+    await registry.getOrCreate('session-1', async () => unreaped)
+
+    await expect(registry.shutdownAll()).resolves.toEqual({ reaped: false })
+
+    const replacement = testSession('session-1')
+    await expect(registry.getOrCreate('session-1', async () => replacement)).resolves.toBe(
+      replacement
+    )
+    expect(unreaped.releaseMcpRpcConnection).toHaveBeenCalledTimes(1)
+  })
+
+  it('includes an earlier per-session removal without tearing down its aggregate twice', async () => {
+    const registry = new NotebookSessionRegistry<TestSession>()
+    const teardown = deferred<{ reaped: boolean }>()
+    const session = testSession('session-1')
+    vi.mocked(session.shutdownExecutor).mockReturnValue(teardown.promise)
+    await registry.getOrCreate('session-1', async () => session)
+
+    const removal = registry.remove('session-1')
+    const shutdown = registry.shutdownAll()
+
+    await vi.waitFor(() => expect(session.shutdownExecutor).toHaveBeenCalledTimes(1))
+    teardown.resolve({ reaped: true })
+    await expect(Promise.all([removal, shutdown])).resolves.toEqual([
+      { reaped: true },
+      { reaped: true }
+    ])
+    expect(session.shutdownExecutor).toHaveBeenCalledTimes(1)
+    expect(session.releaseMcpRpcConnection).toHaveBeenCalledTimes(1)
+  })
+
+  it('queues per-session removal behind an earlier global shutdown', async () => {
+    const registry = new NotebookSessionRegistry<TestSession>()
+    const teardown = deferred<{ reaped: boolean }>()
+    const session = testSession('session-1')
+    vi.mocked(session.shutdownExecutor).mockReturnValue(teardown.promise)
+    await registry.getOrCreate('session-1', async () => session)
+
+    const shutdown = registry.shutdownAll()
+    const removal = registry.remove('session-1')
+
+    await vi.waitFor(() => expect(session.shutdownExecutor).toHaveBeenCalledTimes(1))
+    teardown.resolve({ reaped: true })
+    await expect(Promise.all([shutdown, removal])).resolves.toEqual([
+      { reaped: true },
+      { reaped: true }
+    ])
+    expect(session.shutdownExecutor).toHaveBeenCalledTimes(1)
+    expect(session.releaseMcpRpcConnection).toHaveBeenCalledTimes(1)
+  })
 })

--- a/src/main/notebook/session-registry.ts
+++ b/src/main/notebook/session-registry.ts
@@ -1,0 +1,37 @@
+export type NotebookSessionRegistryMember = {
+  readonly sessionId: string
+  shutdownExecutor: () => Promise<{ reaped: boolean }>
+  releaseMcpRpcConnection: () => void
+}
+
+export class NotebookSessionRegistry<Session extends NotebookSessionRegistryMember> {
+  private readonly sessions = new Map<string, Session>()
+  private readonly creations = new Map<string, Promise<Session>>()
+
+  get(sessionId: string): Session | undefined {
+    return this.sessions.get(sessionId)
+  }
+
+  getOrCreate(sessionId: string, create: () => Promise<Session>): Promise<Session> {
+    const existing = this.sessions.get(sessionId)
+    if (existing) return Promise.resolve(existing)
+
+    const pending = this.creations.get(sessionId)
+    if (pending) return pending
+
+    const creation = create().then((session) => {
+      this.sessions.set(sessionId, session)
+      return session
+    })
+    this.creations.set(sessionId, creation)
+    void creation.then(
+      () => this.clearCreation(sessionId, creation),
+      () => this.clearCreation(sessionId, creation)
+    )
+    return creation
+  }
+
+  private clearCreation(sessionId: string, creation: Promise<Session>): void {
+    if (this.creations.get(sessionId) === creation) this.creations.delete(sessionId)
+  }
+}

--- a/src/main/notebook/session-registry.ts
+++ b/src/main/notebook/session-registry.ts
@@ -22,12 +22,17 @@ export class NotebookSessionRegistry<Session extends NotebookSessionRegistryMemb
   private readonly creations = new Map<string, Promise<Session>>()
   private readonly removalGates = new Map<string, AdmissionGate>()
   private readonly removals = new Map<string, Promise<{ reaped: boolean }>>()
+  private globalGate: AdmissionGate | undefined
+  private shutdownPromise: Promise<{ reaped: boolean }> | undefined
 
   get(sessionId: string): Session | undefined {
     return this.sessions.get(sessionId)
   }
 
   getOrCreate(sessionId: string, create: () => Promise<Session>): Promise<Session> {
+    const globalGate = this.globalGate
+    if (globalGate) return globalGate.promise.then(() => this.getOrCreate(sessionId, create))
+
     const gate = this.removalGates.get(sessionId)
     if (gate) return gate.promise.then(() => this.getOrCreate(sessionId, create))
 
@@ -50,6 +55,9 @@ export class NotebookSessionRegistry<Session extends NotebookSessionRegistryMemb
   }
 
   remove(sessionId: string): Promise<{ reaped: boolean }> {
+    const globalGate = this.globalGate
+    if (globalGate) return globalGate.promise.then(() => this.remove(sessionId))
+
     const existing = this.removals.get(sessionId)
     if (existing) return existing
 
@@ -62,6 +70,70 @@ export class NotebookSessionRegistry<Session extends NotebookSessionRegistryMemb
       () => this.clearRemoval(sessionId, removal)
     )
     return removal
+  }
+
+  shutdownAll(): Promise<{ reaped: boolean }> {
+    if (this.shutdownPromise) return this.shutdownPromise
+
+    const gate = admissionGate()
+    this.globalGate = gate
+    const shutdown = this.shutdownWithinGate(gate)
+    this.shutdownPromise = shutdown
+    void shutdown.then(
+      () => this.clearShutdown(shutdown),
+      () => this.clearShutdown(shutdown)
+    )
+    return shutdown
+  }
+
+  private async shutdownWithinGate(gate: AdmissionGate): Promise<{ reaped: boolean }> {
+    try {
+      const removals = Array.from(this.removals.entries()).sort(([left], [right]) =>
+        left.localeCompare(right)
+      )
+      const removalOutcomes = await Promise.allSettled(removals.map(([, removal]) => removal))
+      await Promise.allSettled(Array.from(this.creations.values()))
+      const removalIds = new Set(removals.map(([sessionId]) => sessionId))
+      const sessions = Array.from(this.sessions.entries())
+        .filter(([sessionId]) => !removalIds.has(sessionId))
+        .sort(([left], [right]) => left.localeCompare(right))
+      const outcomes = await Promise.allSettled(
+        sessions.map(([, session]) => session.shutdownExecutor())
+      )
+      const failures: Array<{ sessionId: string; reason: unknown }> = []
+      let reaped = true
+
+      removalOutcomes.forEach((outcome, index) => {
+        const [sessionId] = removals[index]
+        if (outcome.status === 'rejected') {
+          failures.push({ sessionId, reason: outcome.reason })
+          return
+        }
+        reaped &&= outcome.value.reaped
+      })
+
+      outcomes.forEach((outcome, index) => {
+        const [sessionId, session] = sessions[index]
+        if (outcome.status === 'rejected') {
+          failures.push({ sessionId, reason: outcome.reason })
+          return
+        }
+
+        reaped &&= outcome.value.reaped
+        session.releaseMcpRpcConnection()
+        if (this.sessions.get(sessionId) === session) this.sessions.delete(sessionId)
+      })
+
+      this.throwFailures(
+        failures
+          .sort((left, right) => left.sessionId.localeCompare(right.sessionId))
+          .map(({ reason }) => reason)
+      )
+      return { reaped }
+    } finally {
+      if (this.globalGate === gate) this.globalGate = undefined
+      gate.release()
+    }
   }
 
   private async removeWithinGate(
@@ -89,5 +161,16 @@ export class NotebookSessionRegistry<Session extends NotebookSessionRegistryMemb
 
   private clearRemoval(sessionId: string, removal: Promise<{ reaped: boolean }>): void {
     if (this.removals.get(sessionId) === removal) this.removals.delete(sessionId)
+  }
+
+  private clearShutdown(shutdown: Promise<{ reaped: boolean }>): void {
+    if (this.shutdownPromise === shutdown) this.shutdownPromise = undefined
+  }
+
+  private throwFailures(failures: unknown[]): void {
+    if (failures.length === 1) throw failures[0]
+    if (failures.length > 1) {
+      throw new AggregateError(failures, 'Multiple notebook sessions failed to shut down.')
+    }
   }
 }

--- a/src/main/notebook/session-registry.ts
+++ b/src/main/notebook/session-registry.ts
@@ -24,12 +24,16 @@ export class NotebookSessionRegistry<Session extends NotebookSessionRegistryMemb
   private readonly removals = new Map<string, Promise<{ reaped: boolean }>>()
   private globalGate: AdmissionGate | undefined
   private shutdownPromise: Promise<{ reaped: boolean }> | undefined
+  private terminal = false
+  private disposalPromise: Promise<{ reaped: boolean }> | undefined
 
   get(sessionId: string): Session | undefined {
     return this.sessions.get(sessionId)
   }
 
   getOrCreate(sessionId: string, create: () => Promise<Session>): Promise<Session> {
+    if (this.terminal) return Promise.reject(this.disposedError())
+
     const globalGate = this.globalGate
     if (globalGate) return globalGate.promise.then(() => this.getOrCreate(sessionId, create))
 
@@ -42,10 +46,12 @@ export class NotebookSessionRegistry<Session extends NotebookSessionRegistryMemb
     const pending = this.creations.get(sessionId)
     if (pending) return pending
 
-    const creation = create().then((session) => {
-      this.sessions.set(sessionId, session)
-      return session
-    })
+    const creation = Promise.resolve()
+      .then(create)
+      .then((session) => {
+        this.sessions.set(sessionId, session)
+        return session
+      })
     this.creations.set(sessionId, creation)
     void creation.then(
       () => this.clearCreation(sessionId, creation),
@@ -55,6 +61,8 @@ export class NotebookSessionRegistry<Session extends NotebookSessionRegistryMemb
   }
 
   remove(sessionId: string): Promise<{ reaped: boolean }> {
+    if (this.terminal) return Promise.reject(this.disposedError())
+
     const globalGate = this.globalGate
     if (globalGate) return globalGate.promise.then(() => this.remove(sessionId))
 
@@ -73,6 +81,7 @@ export class NotebookSessionRegistry<Session extends NotebookSessionRegistryMemb
   }
 
   shutdownAll(): Promise<{ reaped: boolean }> {
+    if (this.terminal) return Promise.reject(this.disposedError())
     if (this.shutdownPromise) return this.shutdownPromise
 
     const gate = admissionGate()
@@ -84,6 +93,63 @@ export class NotebookSessionRegistry<Session extends NotebookSessionRegistryMemb
       () => this.clearShutdown(shutdown)
     )
     return shutdown
+  }
+
+  dispose(): Promise<{ reaped: boolean }> {
+    if (this.disposalPromise) return this.disposalPromise
+
+    this.terminal = true
+    const disposal = this.disposePermanently()
+    this.disposalPromise = disposal
+    return disposal
+  }
+
+  private async disposePermanently(): Promise<{ reaped: boolean }> {
+    const shutdown = this.shutdownPromise
+    if (shutdown) return shutdown
+
+    const removals = Array.from(this.removals.entries()).sort(([left], [right]) =>
+      left.localeCompare(right)
+    )
+    const removalOutcomes = await Promise.allSettled(removals.map(([, removal]) => removal))
+    await Promise.allSettled(Array.from(this.creations.values()))
+    const removalIds = new Set(removals.map(([sessionId]) => sessionId))
+    const sessions = Array.from(this.sessions.entries())
+      .filter(([sessionId]) => !removalIds.has(sessionId))
+      .sort(([left], [right]) => left.localeCompare(right))
+    const outcomes = await Promise.allSettled(
+      sessions.map(([, session]) => session.shutdownExecutor())
+    )
+    const failures: Array<{ sessionId: string; reason: unknown }> = []
+    let reaped = true
+
+    removalOutcomes.forEach((outcome, index) => {
+      const [sessionId] = removals[index]
+      if (outcome.status === 'rejected') {
+        failures.push({ sessionId, reason: outcome.reason })
+        return
+      }
+      reaped &&= outcome.value.reaped
+    })
+
+    outcomes.forEach((outcome, index) => {
+      const [sessionId, session] = sessions[index]
+      if (outcome.status === 'rejected') {
+        failures.push({ sessionId, reason: outcome.reason })
+        return
+      }
+
+      reaped &&= outcome.value.reaped
+      session.releaseMcpRpcConnection()
+      if (this.sessions.get(sessionId) === session) this.sessions.delete(sessionId)
+    })
+
+    this.throwFailures(
+      failures
+        .sort((left, right) => left.sessionId.localeCompare(right.sessionId))
+        .map(({ reason }) => reason)
+    )
+    return { reaped }
   }
 
   private async shutdownWithinGate(gate: AdmissionGate): Promise<{ reaped: boolean }> {
@@ -172,5 +238,9 @@ export class NotebookSessionRegistry<Session extends NotebookSessionRegistryMemb
     if (failures.length > 1) {
       throw new AggregateError(failures, 'Multiple notebook sessions failed to shut down.')
     }
+  }
+
+  private disposedError(): Error {
+    return new Error('Notebook session registry has been disposed.')
   }
 }

--- a/src/main/notebook/session-registry.ts
+++ b/src/main/notebook/session-registry.ts
@@ -13,6 +13,12 @@ type AdmissionGate = {
   release: () => void
 }
 
+type RemovalOperation = {
+  promise: Promise<{ reaped: boolean }>
+  releaseAttempted: boolean
+  failureStage?: number
+}
+
 const admissionGate = (): AdmissionGate => {
   let release!: () => void
   const promise = new Promise<void>((resolve) => {
@@ -25,7 +31,7 @@ export class NotebookSessionRegistry<Session extends NotebookSessionRegistryMemb
   private readonly sessions = new Map<string, Session>()
   private readonly creations = new Map<string, Promise<Session>>()
   private readonly removalGates = new Map<string, AdmissionGate>()
-  private readonly removals = new Map<string, Promise<{ reaped: boolean }>>()
+  private readonly removals = new Map<string, RemovalOperation>()
   private globalGate: AdmissionGate | undefined
   private shutdownPromise: Promise<{ reaped: boolean }> | undefined
   private terminal = false
@@ -77,17 +83,21 @@ export class NotebookSessionRegistry<Session extends NotebookSessionRegistryMemb
     if (globalGate) return globalGate.promise.then(() => this.remove(sessionId))
 
     const existing = this.removals.get(sessionId)
-    if (existing) return existing
+    if (existing) return existing.promise
 
     const gate = admissionGate()
     this.removalGates.set(sessionId, gate)
-    const removal = this.removeWithinGate(sessionId, gate)
-    this.removals.set(sessionId, removal)
-    void removal.then(
-      () => this.clearRemoval(sessionId, removal),
-      () => this.clearRemoval(sessionId, removal)
+    const operation: RemovalOperation = {
+      promise: Promise.resolve({ reaped: true }),
+      releaseAttempted: false
+    }
+    operation.promise = this.removeWithinGate(sessionId, gate, operation)
+    this.removals.set(sessionId, operation)
+    void operation.promise.then(
+      () => this.clearRemoval(sessionId, operation),
+      () => this.clearRemoval(sessionId, operation)
     )
-    return removal
+    return operation.promise
   }
 
   shutdownAll(): Promise<{ reaped: boolean }> {
@@ -117,25 +127,27 @@ export class NotebookSessionRegistry<Session extends NotebookSessionRegistryMemb
   private async disposePermanently(): Promise<{ reaped: boolean }> {
     const shutdown = this.shutdownPromise
     if (shutdown) return shutdown
-    return this.teardownOwnedSessions()
+    return this.teardownOwnedSessions(true)
   }
 
   private async shutdownWithinGate(gate: AdmissionGate): Promise<{ reaped: boolean }> {
     try {
-      return await this.teardownOwnedSessions()
+      return await this.teardownOwnedSessions(false)
     } finally {
       if (this.globalGate === gate) this.globalGate = undefined
       gate.release()
     }
   }
 
-  private async teardownOwnedSessions(): Promise<{ reaped: boolean }> {
+  private async teardownOwnedSessions(terminalCleanup: boolean): Promise<{ reaped: boolean }> {
     // Global gates are acquired before per-ID gates. A teardown already owned by remove() counts
     // toward this operation, but is never retried, so colliding lifecycle calls release resources once.
     const removals = Array.from(this.removals.entries()).sort(([left], [right]) =>
       left.localeCompare(right)
     )
-    const removalOutcomes = await Promise.allSettled(removals.map(([, removal]) => removal))
+    const removalOutcomes = await Promise.allSettled(
+      removals.map(([, operation]) => operation.promise)
+    )
     await this.options.beforeTeardown?.()
     await Promise.allSettled(Array.from(this.creations.values()))
     const removalIds = new Set(removals.map(([sessionId]) => sessionId))
@@ -143,15 +155,34 @@ export class NotebookSessionRegistry<Session extends NotebookSessionRegistryMemb
       .filter(([sessionId]) => !removalIds.has(sessionId))
       .sort(([left], [right]) => left.localeCompare(right))
     const outcomes = await Promise.allSettled(
-      sessions.map(([, session]) => session.shutdownExecutor())
+      sessions.map(([, session]) => Promise.resolve().then(() => session.shutdownExecutor()))
     )
-    const failures: Array<{ sessionId: string; reason: unknown }> = []
+    const failures: Array<{ sessionId: string; stage: number; reason: unknown }> = []
     let reaped = true
+    const terminal = terminalCleanup || this.terminal
 
     removalOutcomes.forEach((outcome, index) => {
-      const [sessionId] = removals[index]
+      const [sessionId, operation] = removals[index]
       if (outcome.status === 'rejected') {
-        failures.push({ sessionId, reason: outcome.reason })
+        failures.push({
+          sessionId,
+          stage: operation.failureStage ?? 0,
+          reason: outcome.reason
+        })
+        if (terminal) {
+          const session = this.sessions.get(sessionId)
+          if (session && !operation.releaseAttempted) {
+            operation.releaseAttempted = true
+            try {
+              session.releaseMcpRpcConnection()
+            } catch (error) {
+              failures.push({ sessionId, stage: 1, reason: error })
+            }
+          }
+          if (session && this.sessions.get(sessionId) === session) {
+            this.sessions.delete(sessionId)
+          }
+        }
         return
       }
       reaped &&= outcome.value.reaped
@@ -160,18 +191,30 @@ export class NotebookSessionRegistry<Session extends NotebookSessionRegistryMemb
     outcomes.forEach((outcome, index) => {
       const [sessionId, session] = sessions[index]
       if (outcome.status === 'rejected') {
-        failures.push({ sessionId, reason: outcome.reason })
-        return
+        failures.push({ sessionId, stage: 0, reason: outcome.reason })
+      } else {
+        reaped &&= outcome.value.reaped
       }
 
-      reaped &&= outcome.value.reaped
-      session.releaseMcpRpcConnection()
-      if (this.sessions.get(sessionId) === session) this.sessions.delete(sessionId)
+      if (outcome.status === 'fulfilled' || terminal) {
+        let released = false
+        try {
+          session.releaseMcpRpcConnection()
+          released = true
+        } catch (error) {
+          failures.push({ sessionId, stage: 1, reason: error })
+        }
+        if ((released || terminal) && this.sessions.get(sessionId) === session) {
+          this.sessions.delete(sessionId)
+        }
+      }
     })
 
     this.throwFailures(
       failures
-        .sort((left, right) => left.sessionId.localeCompare(right.sessionId))
+        .sort(
+          (left, right) => left.sessionId.localeCompare(right.sessionId) || left.stage - right.stage
+        )
         .map(({ reason }) => reason)
     )
     return { reaped }
@@ -179,15 +222,28 @@ export class NotebookSessionRegistry<Session extends NotebookSessionRegistryMemb
 
   private async removeWithinGate(
     sessionId: string,
-    gate: AdmissionGate
+    gate: AdmissionGate,
+    operation: RemovalOperation
   ): Promise<{ reaped: boolean }> {
     try {
       await this.creations.get(sessionId)?.catch(() => undefined)
       const session = this.sessions.get(sessionId)
       if (!session) return { reaped: true }
 
-      const result = await session.shutdownExecutor()
-      session.releaseMcpRpcConnection()
+      let result: { reaped: boolean }
+      try {
+        result = await Promise.resolve().then(() => session.shutdownExecutor())
+      } catch (error) {
+        operation.failureStage = 0
+        throw error
+      }
+      operation.releaseAttempted = true
+      try {
+        session.releaseMcpRpcConnection()
+      } catch (error) {
+        operation.failureStage = 1
+        throw error
+      }
       if (this.sessions.get(sessionId) === session) this.sessions.delete(sessionId)
       return result
     } finally {
@@ -200,8 +256,8 @@ export class NotebookSessionRegistry<Session extends NotebookSessionRegistryMemb
     if (this.creations.get(sessionId) === creation) this.creations.delete(sessionId)
   }
 
-  private clearRemoval(sessionId: string, removal: Promise<{ reaped: boolean }>): void {
-    if (this.removals.get(sessionId) === removal) this.removals.delete(sessionId)
+  private clearRemoval(sessionId: string, operation: RemovalOperation): void {
+    if (this.removals.get(sessionId) === operation) this.removals.delete(sessionId)
   }
 
   private clearShutdown(shutdown: Promise<{ reaped: boolean }>): void {

--- a/src/main/notebook/session-registry.ts
+++ b/src/main/notebook/session-registry.ts
@@ -4,15 +4,33 @@ export type NotebookSessionRegistryMember = {
   releaseMcpRpcConnection: () => void
 }
 
+type AdmissionGate = {
+  promise: Promise<void>
+  release: () => void
+}
+
+const admissionGate = (): AdmissionGate => {
+  let release!: () => void
+  const promise = new Promise<void>((resolve) => {
+    release = resolve
+  })
+  return { promise, release }
+}
+
 export class NotebookSessionRegistry<Session extends NotebookSessionRegistryMember> {
   private readonly sessions = new Map<string, Session>()
   private readonly creations = new Map<string, Promise<Session>>()
+  private readonly removalGates = new Map<string, AdmissionGate>()
+  private readonly removals = new Map<string, Promise<{ reaped: boolean }>>()
 
   get(sessionId: string): Session | undefined {
     return this.sessions.get(sessionId)
   }
 
   getOrCreate(sessionId: string, create: () => Promise<Session>): Promise<Session> {
+    const gate = this.removalGates.get(sessionId)
+    if (gate) return gate.promise.then(() => this.getOrCreate(sessionId, create))
+
     const existing = this.sessions.get(sessionId)
     if (existing) return Promise.resolve(existing)
 
@@ -31,7 +49,45 @@ export class NotebookSessionRegistry<Session extends NotebookSessionRegistryMemb
     return creation
   }
 
+  remove(sessionId: string): Promise<{ reaped: boolean }> {
+    const existing = this.removals.get(sessionId)
+    if (existing) return existing
+
+    const gate = admissionGate()
+    this.removalGates.set(sessionId, gate)
+    const removal = this.removeWithinGate(sessionId, gate)
+    this.removals.set(sessionId, removal)
+    void removal.then(
+      () => this.clearRemoval(sessionId, removal),
+      () => this.clearRemoval(sessionId, removal)
+    )
+    return removal
+  }
+
+  private async removeWithinGate(
+    sessionId: string,
+    gate: AdmissionGate
+  ): Promise<{ reaped: boolean }> {
+    try {
+      await this.creations.get(sessionId)?.catch(() => undefined)
+      const session = this.sessions.get(sessionId)
+      if (!session) return { reaped: true }
+
+      const result = await session.shutdownExecutor()
+      session.releaseMcpRpcConnection()
+      if (this.sessions.get(sessionId) === session) this.sessions.delete(sessionId)
+      return result
+    } finally {
+      if (this.removalGates.get(sessionId) === gate) this.removalGates.delete(sessionId)
+      gate.release()
+    }
+  }
+
   private clearCreation(sessionId: string, creation: Promise<Session>): void {
     if (this.creations.get(sessionId) === creation) this.creations.delete(sessionId)
+  }
+
+  private clearRemoval(sessionId: string, removal: Promise<{ reaped: boolean }>): void {
+    if (this.removals.get(sessionId) === removal) this.removals.delete(sessionId)
   }
 }

--- a/src/main/notebook/session-registry.ts
+++ b/src/main/notebook/session-registry.ts
@@ -4,6 +4,10 @@ export type NotebookSessionRegistryMember = {
   releaseMcpRpcConnection: () => void
 }
 
+export type NotebookSessionRegistryOptions = {
+  beforeTeardown?: () => Promise<void>
+}
+
 type AdmissionGate = {
   promise: Promise<void>
   release: () => void
@@ -27,8 +31,14 @@ export class NotebookSessionRegistry<Session extends NotebookSessionRegistryMemb
   private terminal = false
   private disposalPromise: Promise<{ reaped: boolean }> | undefined
 
+  constructor(private readonly options: NotebookSessionRegistryOptions = {}) {}
+
   get(sessionId: string): Session | undefined {
     return this.sessions.get(sessionId)
+  }
+
+  values(): IterableIterator<Session> {
+    return this.sessions.values()
   }
 
   getOrCreate(sessionId: string, create: () => Promise<Session>): Promise<Session> {
@@ -107,11 +117,26 @@ export class NotebookSessionRegistry<Session extends NotebookSessionRegistryMemb
   private async disposePermanently(): Promise<{ reaped: boolean }> {
     const shutdown = this.shutdownPromise
     if (shutdown) return shutdown
+    return this.teardownOwnedSessions()
+  }
 
+  private async shutdownWithinGate(gate: AdmissionGate): Promise<{ reaped: boolean }> {
+    try {
+      return await this.teardownOwnedSessions()
+    } finally {
+      if (this.globalGate === gate) this.globalGate = undefined
+      gate.release()
+    }
+  }
+
+  private async teardownOwnedSessions(): Promise<{ reaped: boolean }> {
+    // Global gates are acquired before per-ID gates. A teardown already owned by remove() counts
+    // toward this operation, but is never retried, so colliding lifecycle calls release resources once.
     const removals = Array.from(this.removals.entries()).sort(([left], [right]) =>
       left.localeCompare(right)
     )
     const removalOutcomes = await Promise.allSettled(removals.map(([, removal]) => removal))
+    await this.options.beforeTeardown?.()
     await Promise.allSettled(Array.from(this.creations.values()))
     const removalIds = new Set(removals.map(([sessionId]) => sessionId))
     const sessions = Array.from(this.sessions.entries())
@@ -150,56 +175,6 @@ export class NotebookSessionRegistry<Session extends NotebookSessionRegistryMemb
         .map(({ reason }) => reason)
     )
     return { reaped }
-  }
-
-  private async shutdownWithinGate(gate: AdmissionGate): Promise<{ reaped: boolean }> {
-    try {
-      const removals = Array.from(this.removals.entries()).sort(([left], [right]) =>
-        left.localeCompare(right)
-      )
-      const removalOutcomes = await Promise.allSettled(removals.map(([, removal]) => removal))
-      await Promise.allSettled(Array.from(this.creations.values()))
-      const removalIds = new Set(removals.map(([sessionId]) => sessionId))
-      const sessions = Array.from(this.sessions.entries())
-        .filter(([sessionId]) => !removalIds.has(sessionId))
-        .sort(([left], [right]) => left.localeCompare(right))
-      const outcomes = await Promise.allSettled(
-        sessions.map(([, session]) => session.shutdownExecutor())
-      )
-      const failures: Array<{ sessionId: string; reason: unknown }> = []
-      let reaped = true
-
-      removalOutcomes.forEach((outcome, index) => {
-        const [sessionId] = removals[index]
-        if (outcome.status === 'rejected') {
-          failures.push({ sessionId, reason: outcome.reason })
-          return
-        }
-        reaped &&= outcome.value.reaped
-      })
-
-      outcomes.forEach((outcome, index) => {
-        const [sessionId, session] = sessions[index]
-        if (outcome.status === 'rejected') {
-          failures.push({ sessionId, reason: outcome.reason })
-          return
-        }
-
-        reaped &&= outcome.value.reaped
-        session.releaseMcpRpcConnection()
-        if (this.sessions.get(sessionId) === session) this.sessions.delete(sessionId)
-      })
-
-      this.throwFailures(
-        failures
-          .sort((left, right) => left.sessionId.localeCompare(right.sessionId))
-          .map(({ reason }) => reason)
-      )
-      return { reaped }
-    } finally {
-      if (this.globalGate === gate) this.globalGate = undefined
-      gate.release()
-    }
   }
 
   private async removeWithinGate(


### PR DESCRIPTION
## Problem

Notebook Session creation and teardown were coordinated directly by `NotebookRuntimeService`. Concurrent creation could publish after shutdown, terminal disposal could miss in-flight Sessions, and cleanup failures were not consistently isolated or reported.

## Proposed change

Introduce a deep `NotebookSessionRegistry` that owns creation admission, single-flight publication, reusable shutdown, terminal disposal, resource release, and deterministic failure aggregation. `NotebookRuntimeService` remains the existing public façade.

```mermaid
flowchart LR
  Caller["NotebookRuntimeService"] --> Registry["NotebookSessionRegistry"]
  Registry --> Global["Global admission gate"]
  Global --> PerId["Per-Session gate"]
  PerId --> Factory["Aggregate factory / hydration"]
  Factory --> Published["Published Session Aggregate"]
  Registry --> Reusable["shutdownAll: close temporarily → drain → reopen"]
  Registry --> Terminal["dispose: close permanently → drain all → remain closed"]
```

## Scope and non-goals

- Same-ID creation is single-flight; different IDs remain concurrent.
- `remove` gates one ID, waits prior creation, and retains the old Aggregate when teardown fails.
- Reusable `shutdownAll` gates creation, attempts all teardown best-effort, removes successful Sessions, retains failures, then reopens admission.
- Terminal `dispose` permanently closes admission, drains published and in-flight Sessions, attempts executor and MCP cleanup exactly once, and returns the same Promise on repeated calls.
- One failure is rethrown unchanged; multiple failures use deterministic `AggregateError`; `reaped:false` is preserved.
- Executor-generation/stale-callback behavior remains deferred to N3.3.
- No Session ID, `run.json`, schema, data relationship, UI, IPC/Web/CLI/local-RPC contract, execution/binding/cancellation policy, Specialist, Permission, Compute, or Issue #458 change.

## Acceptance criteria and validation

All checks below ran after the final material commit:

- Registry lifecycle matrix: 23/23 passed.
- Registry/Aggregate/RuntimeService focused tests: 189/189 passed.
- Electron IPC/local-RPC/kernel/storage compatibility: 13 files, 368/368 passed.
- `npm run typecheck`: passed.
- `npm run lint`: 0 errors; 23 unchanged baseline warnings.
- `npm test`: 651 files passed, 15 skipped; 9,573 tests passed, 184 skipped.
- `git diff --check`: passed.

## Review focus

Independent Standards closure found no violations or actionable judgement calls. Independent Spec closure found no remaining findings after adding synchronous teardown isolation, terminal release after executor failure, release-once coordination, and deterministic two-stage error aggregation.

The intentionally uncovered behavior is N3.3: late callbacks from a replaced executor are still keyed by Session ID and will be addressed separately. Merge by squash only after all required CI and platform checks pass.
