### PR TITLE
fix(workspace): let user messages use available width

### DIFF
--- a/src/renderer/src/pages/workspace/WorkspaceMessageItem.actions.test.tsx
+++ b/src/renderer/src/pages/workspace/WorkspaceMessageItem.actions.test.tsx
@@ -150,6 +150,13 @@ describe('WorkspaceMessageItem user message actions', () => {
     expect(transcriptRow?.classList.contains('md:px-6')).toBe(true)
   })
 
+  it('measures the user bubble against the full transcript width', async () => {
+    await renderItem(createMessage())
+
+    const bubbleRow = container.querySelector<HTMLElement>('[data-slot="user-bubble-row"]')
+    expect(bubbleRow?.classList.contains('w-full')).toBe(true)
+  })
+
   it('renders copy and edit actions next to user bubbles only', async () => {
     await renderItem(createMessage())
 

--- a/src/renderer/src/pages/workspace/WorkspaceMessageItem.tsx
+++ b/src/renderer/src/pages/workspace/WorkspaceMessageItem.tsx
@@ -785,7 +785,7 @@ const WorkspaceMessageItem = ({
             <div className="group flex flex-col items-end">
               <div
                 data-slot="user-bubble-row"
-                className="flex max-w-full items-center justify-end gap-1"
+                className="flex w-full max-w-full items-center justify-end gap-1"
               >
                 {/* Branch/copy/edit controls stay left of the bubble and never shift its sent time. */}
                 {showUserActions ? (


### PR DESCRIPTION
## Problem

When the right-hand preview column is collapsed, the conversation gains horizontal space but the right-aligned user-message row still shrink-wraps its contents. The bubble's percentage width is then measured against that narrow row, so prompts wrap before using the available transcript width.

## Proposed change

- Make the user-message bubble row span the full transcript width while preserving the existing bubble cap and right alignment.
- Add a focused regression test for the full-width row invariant.

## Scope and non-goals

- No changes to preview-panel state or resizing behavior.
- No changes to the existing user-bubble maximum width, styling, actions, or timestamps.
- No changes to assistant-message layout.

## Acceptance criteria and validation

All listed checks ran after the last material edit.

- User bubbles can measure against the available transcript width -> `npm test -- src/renderer/src/pages/workspace/WorkspaceMessageItem.actions.test.tsx` -> 14 passed.
- Renderer and main-process type safety -> `npm run typecheck` -> passed.
- Repository lint rules -> `npm run lint` -> passed with 0 errors and 23 existing warnings.
- Repository regression suite -> `npm test` -> 9,586 passed and 184 skipped across 666 files.
- Final standards/spec review -> independent two-axis review -> no hard standards violations, missing requirements, scope creep, or implementation errors.

Uncovered risk: the focused regression pins the layout invariant but does not automate an Electron pixel-width or visual assertion while collapsing the third column.

## Review focus

Please verify that making `user-bubble-row` full width resolves percentage sizing without changing the existing bubble cap or action placement.
