### PR TITLE
fix(compute): unify SSH Compute Skill materialization

### DIFF
--- a/resources/skills/manifest.json
+++ b/resources/skills/manifest.json
@@ -107,7 +107,7 @@
       "id": "remote-compute-ssh",
       "name": "Remote Compute (SSH)",
       "source": "featured",
-      "updatedAt": "2026-07-22T00:00:00.000Z"
+      "updatedAt": "2026-08-02T00:00:00.000Z"
     },
     {
       "id": "customize",

--- a/resources/skills/remote-compute-ssh/SKILL.md
+++ b/resources/skills/remote-compute-ssh/SKILL.md
@@ -15,9 +15,13 @@ the sandbox workspace); calling it from a python/r cell will fail with `host.com
 
 ## Registered hosts
 
+<!-- open-science:compute-hosts:start -->
+
 Run `await host.compute.list()` to see all registered hosts.
+<!-- open-science:compute-hosts:end -->
 
 Each host entry shows:
+
 - Display name
 - Provider ID (e.g., `ssh:biowulf`, `ssh:192.168.1.100`)
 - Shape (e.g., `direct_ssh`, `slurm`, `pbs`)
@@ -49,8 +53,8 @@ const c = host.compute.create('ssh:<alias>')
 
 // Run a short remote command (throws on approval_denied / host_unreachable / timeout)
 const result = await c.call_command('<shell command>', '<one-line intent for the approval card>', {
-  login_shell: true,   // default: true — runs login profiles, then readable ~/.bashrc, before this command
-  timeout_seconds: 60  // optional — the host applies its own default (60s) when omitted
+  login_shell: true, // default: true — runs login profiles, then readable ~/.bashrc, before this command
+  timeout_seconds: 60 // optional — the host applies its own default (60s) when omitted
 })
 // result → { exit_code, stdout, stderr, truncated }
 
@@ -58,13 +62,16 @@ const result = await c.call_command('<shell command>', '<one-line intent for the
 const info = await host.compute.details('ssh:<alias>', { mode: 'read' })
 
 // Append a note to the host knowledge doc (agent writes; 32 KB cap enforced)
-await host.compute.details('ssh:<alias>', { mode: 'append', text: '\n## Note\nlearned X on <date>' })
+await host.compute.details('ssh:<alias>', {
+  mode: 'append',
+  text: '\n## Note\nlearned X on <date>'
+})
 
 // Replace the entire host knowledge doc (old_text must match the current doc exactly)
 await host.compute.details('ssh:<alias>', {
   mode: 'replace',
   text: '<new full doc>',
-  old_text: info.doc   // from the read above
+  old_text: info.doc // from the read above
 })
 ```
 
@@ -88,29 +95,29 @@ const activeHosts = await host.compute.list_compute()
 // Submit a non-blocking job — returns immediately after the user approves
 const c = host.compute.create('ssh:<alias>')
 const job = await c.submit_job(
-  '<one-line intent for the approval card>',  // shown in the approval card
-  '<shell command>',                           // command to run remotely
+  '<one-line intent for the approval card>', // shown in the approval card
+  '<shell command>', // command to run remotely
   {
-    timeout_seconds: 3600,  // optional; default 24 h, max 7 days
+    timeout_seconds: 3600, // optional; default 24 h, max 7 days
     inputs: [
-      { src: 'in.dat', dst_filename: 'in.dat' },          // stage a workspace file
-      { remote_path: 'ssh:<alias>/<abs_path>' }            // link a remote file (no transfer)
+      { src: 'in.dat', dst_filename: 'in.dat' }, // stage a workspace file
+      { remote_path: 'ssh:<alias>/<abs_path>' } // link a remote file (no transfer)
     ],
     outputs: [
-      '*.result',                                           // featured (default visibility)
-      { glob: '*.json', visibility: 'featured' },          // explicitly featured
-      { glob: '*.log',  visibility: 'hidden' },            // hidden (diagnostic, not shown in card)
-      { glob: 'checkpoints/**', residency: 'remote' }      // leave on remote — recorded in left_on_remote
+      '*.result', // featured (default visibility)
+      { glob: '*.json', visibility: 'featured' }, // explicitly featured
+      { glob: '*.log', visibility: 'hidden' }, // hidden (diagnostic, not shown in card)
+      { glob: 'checkpoints/**', residency: 'remote' } // leave on remote — recorded in left_on_remote
     ],
     harvest: {
-      exclude: ['work/**'],      // never harvest these paths
-      max_file_mb: 100,          // single-file cap (default 100 MB)
-      max_total_mb: 500          // total-harvest cap (default 500 MB)
+      exclude: ['work/**'], // never harvest these paths
+      max_file_mb: 100, // single-file cap (default 100 MB)
+      max_total_mb: 500 // total-harvest cap (default 500 MB)
     }
   }
 )
 // job → { job_id, provider_id, status: 'submitted', remote_workdir }
-print(job.job_id)   // end the cell — kernel never blocks on compute
+print(job.job_id) // end the cell — kernel never blocks on compute
 ```
 
 **End the cell here. Do NOT write a polling loop.** The app runs the poller and harvest in the
@@ -139,14 +146,14 @@ const s = await handle.status()
 
 ### submit_job status values
 
-| status | meaning |
-|--------|---------|
-| `submitted` | accepted; background dispatch in progress |
-| `running` | remote process confirmed alive (pid recorded) |
-| `success` | exit code 0 |
-| `failed` | non-zero exit (`job_failed`) or process vanished (`process_vanished`) |
-| `timeout` | exceeded `timeout_seconds` |
-| `error` | never reached the remote host (`host_unreachable` / `dispatch_failed`) |
+| status      | meaning                                                                |
+| ----------- | ---------------------------------------------------------------------- |
+| `submitted` | accepted; background dispatch in progress                              |
+| `running`   | remote process confirmed alive (pid recorded)                          |
+| `success`   | exit code 0                                                            |
+| `failed`    | non-zero exit (`job_failed`) or process vanished (`process_vanished`)  |
+| `timeout`   | exceeded `timeout_seconds`                                             |
+| `error`     | never reached the remote host (`host_unreachable` / `dispatch_failed`) |
 
 ## Workflow: the analysis turn
 
@@ -210,14 +217,14 @@ inputs to the next job — no local round-trip:
 
 ```javascript
 // In the analysis turn — chain a left_on_remote output into the next job
-const big_output_uri = r.left_on_remote[0].uri  // e.g. 'ssh:biowulf//scratch/jobs/<id>/big.h5'
+const big_output_uri = r.left_on_remote[0].uri // e.g. 'ssh:biowulf//scratch/jobs/<id>/big.h5'
 
 const job2 = await c.submit_job(
   'process big.h5 output from job 1',
   'python process.py --input big.h5 --out summary.csv',
   {
     inputs: [
-      { remote_path: big_output_uri }  // symlinked in job workdir, no transfer
+      { remote_path: big_output_uri } // symlinked in job workdir, no transfer
     ],
     outputs: ['summary.csv']
   }
@@ -239,14 +246,14 @@ for (const seed of [0, 1, 2, 3, 4]) {
     `AlphaFold seed ${seed}`,
     `python fold.py --seed ${seed} --in input.fasta --out ranked.pdb`,
     {
-      inputs:  [{ src: 'input.fasta', dst_filename: 'input.fasta' }],
+      inputs: [{ src: 'input.fasta', dst_filename: 'input.fasta' }],
       outputs: [{ glob: '*.pdb', visibility: 'featured' }],
       timeout_seconds: 3600
     }
   )
   jobs.push(job.job_id)
 }
-print(jobs)   // end the cell — no waiting, no loop
+print(jobs) // end the cell — no waiting, no loop
 ```
 
 The app triggers one analysis turn per job completion (or a merged turn for simultaneous
@@ -304,6 +311,7 @@ try {
 ## What to record in the knowledge doc
 
 The knowledge doc is the only state that survives across sessions. Record:
+
 - Scheduler type and any known partition/account combinations that worked.
 - Environment activation commands (e.g. `module load X/<ver>`, `conda activate <env>`).
 - Verified invocations tagged `verified <date>`; user-provided info tagged `per user <date>`.

--- a/src/main/compute/ipc.test.ts
+++ b/src/main/compute/ipc.test.ts
@@ -129,6 +129,31 @@ describe('compute handlers', () => {
     expect(del).toHaveBeenCalledWith('ssh:biowulf')
   })
 
+  it('refreshes the canonical Compute Skill after host create and delete', async () => {
+    const create = vi.fn(() => Promise.resolve(sampleHost()))
+    const del = vi.fn(() => Promise.resolve())
+    const syncComputeSkill = vi.fn(() => Promise.resolve())
+    const handlers = createComputeHandlers(
+      mockRepository({ create, delete: del }),
+      undefined,
+      undefined,
+      undefined,
+      undefined,
+      undefined,
+      undefined,
+      undefined,
+      undefined,
+      undefined,
+      undefined,
+      syncComputeSkill
+    )
+
+    await handlers.create({ sshAlias: 'biowulf' })
+    await handlers.delete('ssh:biowulf')
+
+    expect(syncComputeSkill).toHaveBeenCalledTimes(2)
+  })
+
   it('sshConfigAliases uses the injected alias lister', async () => {
     const lister = vi.fn(() => Promise.resolve(['biowulf', 'lab-gpu']))
     const handlers = createComputeHandlers(mockRepository({}), lister)

--- a/src/main/compute/ipc.ts
+++ b/src/main/compute/ipc.ts
@@ -33,6 +33,9 @@ import { getProjectDbClient } from '../projects/prisma-client'
 import { createLogger, errorLogFields } from '../logger'
 import { resolveDataRoot, resolveStorageRoot } from '../storage-root'
 import { SettingsRepository } from '../settings/repository'
+import { getAppClaudeConfigDir } from '../settings/provider-env'
+import { codexStorageDir, codexSubscriptionStorageDir } from '../agent-framework/codex'
+import { opencodeConfigDir } from '../agent-framework/opencode'
 import { broadcastToRenderers } from '../renderer-broadcast'
 import type { TaskNotificationService } from '../notifications/task-notifications'
 import { buildComputeApprovalBroadcast } from '../notifications/electron-wiring'
@@ -50,6 +53,7 @@ import { getJobHarvestDir } from './harvest-engine'
 import { workspaceRelativePath } from './workspace-path'
 import type { PermissionGrantRegistry } from '../permission-grants/registry'
 import { createComputePermissionGrantAdapter } from './permission-grant-adapter'
+import { hasCanonicalComputeSkillDoc, syncComputeSkillDoc } from './skill-doc'
 
 // IPC channel names for the renderer job feed (Phase 3d, issue 05).
 export const COMPUTE_JOBS_LIST_CHANNEL = 'compute:jobs:list'
@@ -199,7 +203,8 @@ const createComputeHandlers = (
   artifactResolver?: ArtifactResolver,
   storageRoot?: string,
   taskNotifications?: Pick<TaskNotificationService, 'handleComputeApproval'>,
-  permissionGrantRegistry?: PermissionGrantRegistry
+  permissionGrantRegistry?: PermissionGrantRegistry,
+  syncComputeSkillDocument?: () => Promise<void>
 ): ComputeHandlers => {
   const permissionGrants = permissionGrantRegistry
     ? createComputePermissionGrantAdapter(permissionGrantRegistry, settingsRepository)
@@ -319,7 +324,9 @@ const createComputeHandlers = (
             await permissionGrantRegistry.prune({ kind: 'compute_provider', providerId })
           }
         }
-        return repository.create(request)
+        const host = await repository.create(request)
+        await syncComputeSkillDocument?.()
+        return host
       }),
     delete: (providerId) =>
       runHostLifecycleMutation(async () => {
@@ -336,6 +343,7 @@ const createComputeHandlers = (
         try {
           await repository.delete(providerId)
           await permissionGrantRegistry?.prune({ kind: 'compute_provider', providerId })
+          await syncComputeSkillDocument?.()
         } finally {
           broker.completeProviderInvalidation(providerId)
         }
@@ -394,6 +402,28 @@ const createDefaultComputeHostRepository = (): ComputeHostRepository =>
 
 const createDefaultComputeJobRepository = (): ComputeJobRepository =>
   new ComputeJobRepository(() => getProjectDbClient(resolveStorageRoot()))
+
+const syncCurrentComputeSkillDocuments = async (
+  storageRoot: string,
+  repository: ComputeHostRepository
+): Promise<void> => {
+  const skillsDirs = [
+    join(getAppClaudeConfigDir(storageRoot), 'skills'),
+    join(opencodeConfigDir(storageRoot), 'skills'),
+    join(codexStorageDir(storageRoot), 'skills'),
+    join(codexSubscriptionStorageDir(storageRoot), 'skills')
+  ]
+  const existing = await Promise.all(
+    skillsDirs.map((skillsDir) => hasCanonicalComputeSkillDoc(skillsDir))
+  )
+  if (!existing.some(Boolean)) return
+  const hosts = await repository.list()
+  await Promise.all(
+    skillsDirs.map((skillsDir, index) =>
+      existing[index] ? syncComputeSkillDoc(skillsDir, hosts) : undefined
+    )
+  )
+}
 
 // Broadcasts a job summary to all renderer windows. Called by the JobPoller onJobUpdated hook
 // and by the job dispatcher on status transitions (Phase 3d, design.md §9).
@@ -464,7 +494,8 @@ const createComputeIpcModule = (
     artifactResolver,
     dataRoot,
     taskNotifications,
-    permissionGrantRegistry
+    permissionGrantRegistry,
+    () => syncCurrentComputeSkillDocuments(storageRoot, repository)
   )
 
   return {

--- a/src/main/compute/skill-doc.test.ts
+++ b/src/main/compute/skill-doc.test.ts
@@ -1,0 +1,94 @@
+import { mkdir, mkdtemp, readFile, readdir, rm, writeFile } from 'node:fs/promises'
+import { tmpdir } from 'node:os'
+import { join } from 'node:path'
+
+import { afterEach, describe, expect, it } from 'vitest'
+
+import type { ComputeHost } from '../../shared/compute'
+import { COMPUTE_SKILL_DIRECTORY, syncComputeSkillDoc } from './skill-doc'
+
+const roots: string[] = []
+
+afterEach(async () => {
+  await Promise.all(roots.splice(0).map((root) => rm(root, { recursive: true, force: true })))
+})
+
+const sampleHost = (overrides: Partial<ComputeHost> = {}): ComputeHost => ({
+  id: 'host-1',
+  providerId: 'ssh:biowulf',
+  displayName: 'biowulf',
+  shape: 'scheduler_cluster',
+  sshAlias: 'biowulf',
+  sshOverrides: undefined,
+  scratchRoot: undefined,
+  scratchPinned: false,
+  concurrencyLimit: undefined,
+  probeResult: {
+    ok: true,
+    probedAt: '2026-08-01T00:00:00.000Z',
+    exitCode: 0,
+    errorTail: null
+  },
+  detailsDoc: '',
+  detailsUpdatedAt: undefined,
+  detailsUpdatedBy: undefined,
+  createdAt: 1,
+  updatedAt: 1,
+  ...overrides
+})
+
+const writeCanonicalDocument = async (skillsDir: string): Promise<void> => {
+  await mkdir(join(skillsDir, COMPUTE_SKILL_DIRECTORY), { recursive: true })
+  await writeFile(
+    join(skillsDir, COMPUTE_SKILL_DIRECTORY, 'SKILL.md'),
+    [
+      '---',
+      'name: remote-compute-ssh',
+      'description: Discover and use SSH compute hosts.',
+      '---',
+      '',
+      '## Registered hosts',
+      '',
+      '<!-- open-science:compute-hosts:start -->',
+      'Run `await host.compute.list()` to see all registered hosts.',
+      '<!-- open-science:compute-hosts:end -->',
+      '',
+      '## API reference',
+      '',
+      'Use `host.compute.create()` to bind a host.'
+    ].join('\n'),
+    'utf8'
+  )
+}
+
+describe('syncComputeSkillDoc', () => {
+  it('updates the one canonical document with the current host projection', async () => {
+    const root = await mkdtemp(join(tmpdir(), 'compute-skill-doc-'))
+    roots.push(root)
+    const skillsDir = join(root, 'skills')
+    await writeCanonicalDocument(skillsDir)
+
+    await syncComputeSkillDoc(skillsDir, [sampleHost()])
+
+    const doc = await readFile(join(skillsDir, COMPUTE_SKILL_DIRECTORY, 'SKILL.md'), 'utf8')
+    expect(doc).toContain('ssh:biowulf')
+    expect(doc).toContain('biowulf')
+    expect(doc).toContain('connected')
+    expect(doc).toContain('## API reference')
+    expect(await readdir(skillsDir)).toEqual([COMPUTE_SKILL_DIRECTORY])
+  })
+
+  it('replaces stale host data when a host is deleted', async () => {
+    const root = await mkdtemp(join(tmpdir(), 'compute-skill-doc-'))
+    roots.push(root)
+    const skillsDir = join(root, 'skills')
+    await writeCanonicalDocument(skillsDir)
+
+    await syncComputeSkillDoc(skillsDir, [sampleHost()])
+    await syncComputeSkillDoc(skillsDir, [])
+
+    const doc = await readFile(join(skillsDir, COMPUTE_SKILL_DIRECTORY, 'SKILL.md'), 'utf8')
+    expect(doc).toContain('no hosts registered yet')
+    expect(doc).not.toContain('ssh:biowulf')
+  })
+})

--- a/src/main/compute/skill-doc.ts
+++ b/src/main/compute/skill-doc.ts
@@ -1,0 +1,112 @@
+import { chmod, readFile, stat, writeFile } from 'node:fs/promises'
+import { join } from 'node:path'
+
+import type { ComputeHost } from '../../shared/compute'
+
+const COMPUTE_SKILL_ID = 'remote-compute-ssh'
+const COMPUTE_SKILL_DIRECTORY = `os-${COMPUTE_SKILL_ID}`
+const HOST_PROJECTION_START = '<!-- open-science:compute-hosts:start -->'
+const HOST_PROJECTION_END = '<!-- open-science:compute-hosts:end -->'
+
+const statusLabel = (host: ComputeHost): string =>
+  host.probeResult === undefined
+    ? 'not yet probed'
+    : host.probeResult.ok
+      ? 'connected'
+      : 'probe failed'
+
+const renderHostProjection = (hosts: readonly ComputeHost[]): string =>
+  hosts.length === 0
+    ? '  (no hosts registered yet)'
+    : hosts
+        .map(
+          (host) =>
+            `  - ${host.displayName} (provider_id: \`${host.providerId}\`, shape: ${host.shape}, status: ${statusLabel(host)})`
+        )
+        .join('\n')
+
+const projectionPattern = new RegExp(
+  `${HOST_PROJECTION_START}\\n[\\s\\S]*?${HOST_PROJECTION_END}`,
+  'm'
+)
+
+const withHostProjection = (document: string, projection: string): string => {
+  const markedProjection = `${HOST_PROJECTION_START}\n${projection}\n${HOST_PROJECTION_END}`
+  if (projectionPattern.test(document)) {
+    return document.replace(projectionPattern, markedProjection)
+  }
+
+  // Migrate a pre-marker bundled copy in place. This only changes the known Registered hosts section
+  // of the SSH Compute Skill; other bundled guidance stays byte-for-byte intact.
+  const registeredHosts = /^(## Registered hosts\n\n)[\s\S]*?(?=^## |\s*$)/m
+  if (registeredHosts.test(document)) {
+    return document.replace(registeredHosts, `$1${markedProjection}\n\n`)
+  }
+
+  return document
+}
+
+const extractHostProjection = (document: string): string | undefined => {
+  const match = projectionPattern.exec(document)
+  if (!match) return undefined
+  return match[0].slice(HOST_PROJECTION_START.length, -HOST_PROJECTION_END.length).trim()
+}
+
+// Applies the dynamic host data from an earlier canonical document to a freshly copied bundled one.
+// Generic Skill materialization therefore refreshes shipped guidance without erasing runtime state.
+const preserveComputeHostProjection = (document: string, priorDocument: string): string => {
+  const projection = extractHostProjection(priorDocument)
+  return projection === undefined ? document : withHostProjection(document, projection)
+}
+
+// Updates the application-managed canonical Skill in place. The generic materializer owns creation of
+// the os- directory; a missing document means this framework has not been provisioned yet, so there
+// is intentionally nothing to create or expose.
+const syncComputeSkillDoc = async (
+  skillsDir: string,
+  hosts: readonly ComputeHost[]
+): Promise<void> => {
+  const directory = join(skillsDir, COMPUTE_SKILL_DIRECTORY)
+  const file = join(directory, 'SKILL.md')
+  let document: string
+  try {
+    document = await readFile(file, 'utf8')
+  } catch {
+    return
+  }
+
+  const updated = withHostProjection(document, renderHostProjection(hosts))
+  if (updated === document) return
+
+  // Materialized Skills are normally read-only. Temporarily restore only this application-owned
+  // document, then restore its prior protections once the host projection is durable.
+  const [directoryMode, fileMode] = await Promise.all([
+    stat(directory)
+      .then((entry) => entry.mode & 0o777)
+      .catch(() => undefined),
+    stat(file)
+      .then((entry) => entry.mode & 0o777)
+      .catch(() => undefined)
+  ])
+  await chmod(directory, 0o755).catch(() => undefined)
+  await chmod(file, 0o644).catch(() => undefined)
+  try {
+    await writeFile(file, updated, 'utf8')
+  } finally {
+    if (fileMode !== undefined) await chmod(file, fileMode).catch(() => undefined)
+    if (directoryMode !== undefined) await chmod(directory, directoryMode).catch(() => undefined)
+  }
+}
+
+const hasCanonicalComputeSkillDoc = async (skillsDir: string): Promise<boolean> =>
+  readFile(join(skillsDir, COMPUTE_SKILL_DIRECTORY, 'SKILL.md'), 'utf8')
+    .then(() => true)
+    .catch(() => false)
+
+export {
+  COMPUTE_SKILL_DIRECTORY,
+  COMPUTE_SKILL_ID,
+  hasCanonicalComputeSkillDoc,
+  preserveComputeHostProjection,
+  syncComputeSkillDoc
+}

--- a/src/main/compute/skill-provisioning.test.ts
+++ b/src/main/compute/skill-provisioning.test.ts
@@ -1,0 +1,159 @@
+import { chmod, mkdir, mkdtemp, readFile, readdir, rm, writeFile } from 'node:fs/promises'
+import { tmpdir } from 'node:os'
+import { join } from 'node:path'
+
+import { afterEach, describe, expect, it } from 'vitest'
+
+import type { ComputeHost, CreateComputeHostRequest } from '../../shared/compute'
+import { ClaudeCodeSkillMaterializer } from '../skills/materializer'
+import type { BundledSkill } from '../skills/registry'
+import { createComputeHandlers } from './ipc'
+import type { ComputeService } from './compute-service'
+import type { ComputeHostRepository } from './repository'
+import { COMPUTE_SKILL_DIRECTORY, syncComputeSkillDoc } from './skill-doc'
+
+const roots: string[] = []
+
+afterEach(async () => {
+  for (const root of roots.splice(0)) {
+    await chmod(join(root, 'config', 'skills', COMPUTE_SKILL_DIRECTORY), 0o755).catch(
+      () => undefined
+    )
+    await chmod(join(root, 'config', 'skills', COMPUTE_SKILL_DIRECTORY, 'SKILL.md'), 0o644).catch(
+      () => undefined
+    )
+    await rm(root, { recursive: true, force: true })
+  }
+})
+
+const host = (overrides: Partial<ComputeHost> = {}): ComputeHost => ({
+  id: 'host-1',
+  providerId: 'ssh:biowulf',
+  displayName: 'biowulf',
+  shape: 'direct_ssh',
+  sshAlias: 'biowulf',
+  sshOverrides: undefined,
+  scratchRoot: undefined,
+  scratchPinned: false,
+  concurrencyLimit: undefined,
+  probeResult: undefined,
+  detailsDoc: '',
+  detailsUpdatedAt: undefined,
+  detailsUpdatedBy: undefined,
+  createdAt: 1,
+  updatedAt: 1,
+  ...overrides
+})
+
+describe('SSH Compute Skill provisioning lifecycle', () => {
+  it('keeps one canonical Skill with the current hosts through bootstrap, refresh, and host changes', async () => {
+    const root = await mkdtemp(join(tmpdir(), 'compute-skill-provisioning-'))
+    roots.push(root)
+    const configDir = join(root, 'config')
+    const skillsDir = join(configDir, 'skills')
+    const sourceDir = join(root, 'bundled-remote-compute-ssh')
+    await mkdir(sourceDir, { recursive: true })
+    await writeFile(
+      join(sourceDir, 'SKILL.md'),
+      [
+        '---',
+        'name: remote-compute-ssh',
+        'description: Discover SSH compute hosts.',
+        '---',
+        '',
+        '## Registered hosts',
+        '',
+        '<!-- open-science:compute-hosts:start -->',
+        '',
+        'Run `await host.compute.list()` to see all registered hosts.',
+        '<!-- open-science:compute-hosts:end -->',
+        '',
+        '## API reference',
+        '',
+        'Bundled SSH guidance.'
+      ].join('\n'),
+      'utf8'
+    )
+    await mkdir(join(skillsDir, 'remote-compute-ssh'), { recursive: true })
+    await writeFile(join(skillsDir, 'remote-compute-ssh', 'SKILL.md'), 'legacy duplicate')
+    await mkdir(join(skillsDir, 'user-owned-skill'), { recursive: true })
+    await writeFile(join(skillsDir, 'user-owned-skill', 'SKILL.md'), 'keep')
+
+    const bundledSkill: BundledSkill = {
+      id: 'remote-compute-ssh',
+      name: 'Remote Compute (SSH)',
+      description: 'Discover SSH compute hosts.',
+      source: 'featured',
+      updatedAt: 'v1',
+      sourceDir
+    }
+    const hosts = [host()]
+    const repository: ComputeHostRepository = {
+      list: async () => hosts,
+      get: async (providerId) => hosts.find((item) => item.providerId === providerId) ?? null,
+      create: async (request: CreateComputeHostRequest) => {
+        const created = host({
+          id: 'host-2',
+          providerId: `ssh:${request.sshAlias}`,
+          displayName: request.sshAlias,
+          sshAlias: request.sshAlias
+        })
+        hosts.push(created)
+        return created
+      },
+      delete: async (providerId) => {
+        const index = hosts.findIndex((item) => item.providerId === providerId)
+        if (index >= 0) hosts.splice(index, 1)
+      }
+    } as ComputeHostRepository
+    const materializer = new ClaudeCodeSkillMaterializer()
+    const sync = (): Promise<void> => syncComputeSkillDoc(skillsDir, hosts)
+    const handlers = createComputeHandlers(
+      repository,
+      undefined,
+      {} as ComputeService,
+      undefined,
+      undefined,
+      undefined,
+      undefined,
+      undefined,
+      undefined,
+      undefined,
+      undefined,
+      sync
+    )
+
+    await materializer.sync(configDir, [bundledSkill])
+    await sync()
+
+    expect((await readdir(skillsDir)).filter((entry) => !entry.startsWith('.'))).toEqual([
+      COMPUTE_SKILL_DIRECTORY,
+      'user-owned-skill'
+    ])
+    await expect(
+      readFile(join(skillsDir, 'remote-compute-ssh', 'SKILL.md'), 'utf8')
+    ).rejects.toThrow()
+    await expect(readFile(join(skillsDir, 'user-owned-skill', 'SKILL.md'), 'utf8')).resolves.toBe(
+      'keep'
+    )
+    let document = await readFile(join(skillsDir, COMPUTE_SKILL_DIRECTORY, 'SKILL.md'), 'utf8')
+    expect(document).toContain('name: remote-compute-ssh')
+    expect(document).toContain('ssh:biowulf')
+
+    await handlers.create({ sshAlias: 'lab-gpu' })
+    await materializer.sync(configDir, [{ ...bundledSkill, updatedAt: 'v2' }])
+
+    document = await readFile(join(skillsDir, COMPUTE_SKILL_DIRECTORY, 'SKILL.md'), 'utf8')
+    expect(document).toContain('ssh:biowulf')
+    expect(document).toContain('ssh:lab-gpu')
+    expect(document).toContain('Bundled SSH guidance.')
+
+    await handlers.delete('ssh:lab-gpu')
+    await handlers.delete('ssh:biowulf')
+
+    document = await readFile(join(skillsDir, COMPUTE_SKILL_DIRECTORY, 'SKILL.md'), 'utf8')
+    expect(document).toContain('no hosts registered yet')
+    expect(document).not.toContain('ssh:lab-gpu')
+    expect(document).not.toContain('ssh:biowulf')
+  })
+})

--- a/src/main/settings/agent-runtime-manager.test.ts
+++ b/src/main/settings/agent-runtime-manager.test.ts
@@ -426,6 +426,21 @@ describe('AgentRuntimeManager', () => {
     )
   })
 
+  it('synchronizes the Compute host projection after each Skill provisioning path', async () => {
+    const syncComputeSkillDocument = vi.fn().mockResolvedValue(undefined)
+    manager = createManager({ syncComputeSkillDocument })
+    const settings = await repository.getSettings()
+    const agentRoot = join(storageRoot, 'codex')
+
+    await manager.materializeAgentSkills(settings, agentRoot, new Set())
+    await manager.provisionClaudeRuntimeConfig(settings)
+
+    expect(syncComputeSkillDocument).toHaveBeenCalledWith(join(agentRoot, 'skills'))
+    expect(syncComputeSkillDocument).toHaveBeenCalledWith(
+      join(getAppClaudeConfigDir(storageRoot), 'skills')
+    )
+  })
+
   it.each([
     {
       name: 'timeout',

--- a/src/main/settings/agent-runtime-manager.ts
+++ b/src/main/settings/agent-runtime-manager.ts
@@ -27,6 +27,9 @@ import {
 } from '../agent-framework'
 import type { AgentConfigFile } from '../agent-framework/types'
 import { syncConnectorSkillDocs } from '../connectors/provision'
+import { ComputeHostRepository } from '../compute/repository'
+import { getProjectDbClient } from '../projects/prisma-client'
+import { hasCanonicalComputeSkillDoc, syncComputeSkillDoc } from '../compute/skill-doc'
 import { writeAgentConfigFiles } from './agent-config-files'
 import { createDefaultDetectDeps, detectClaude, type ClaudeDetectDeps } from './claude-detect'
 import {
@@ -218,6 +221,7 @@ export type AgentRuntimeManagerOptions = {
     options: InstallManagedCodexOptions
   ) => Promise<ManagedCodexInstallOutcome>
   resolveCodexProxyEnvironment?: () => Promise<SystemProxyEnvironment | undefined>
+  syncComputeSkillDocument?: (skillsDir: string) => Promise<void>
 }
 
 // Owns host runtime discovery, installation, executable preparation, and runtime-specific filesystem
@@ -245,6 +249,7 @@ export class AgentRuntimeManager {
     options: InstallManagedCodexOptions
   ) => Promise<ManagedCodexInstallOutcome>
   private readonly resolveProxyEnvironment: () => Promise<SystemProxyEnvironment | undefined>
+  private readonly syncComputeSkillDocument: (skillsDir: string) => Promise<void>
 
   constructor(options: AgentRuntimeManagerOptions) {
     this.repository = options.repository
@@ -289,6 +294,15 @@ export class AgentRuntimeManager {
     this.installManagedCodexImpl = options.installManagedCodexImpl ?? installManagedCodex
     this.resolveProxyEnvironment =
       options.resolveCodexProxyEnvironment ?? resolveSystemProxyEnvironment
+    this.syncComputeSkillDocument =
+      options.syncComputeSkillDocument ??
+      (async (skillsDir) => {
+        if (!(await hasCanonicalComputeSkillDoc(skillsDir))) return
+        const hosts = await new ComputeHostRepository(() =>
+          getProjectDbClient(this.storageRoot)
+        ).list()
+        await syncComputeSkillDoc(skillsDir, hosts)
+      })
   }
 
   async getPreflight(providers: ProviderPreflightAccess): Promise<Preflight> {
@@ -596,6 +610,7 @@ export class AgentRuntimeManager {
       join(configRoot, 'skills'),
       this.connectors.enabledConnectorIds(connectors)
     )
+    await this.syncComputeSkillDocument(join(configRoot, 'skills'))
   }
 
   async materializeAgentConfigFiles(files: AgentConfigFile[] | undefined): Promise<void> {
@@ -616,6 +631,7 @@ export class AgentRuntimeManager {
       join(configDir, 'skills'),
       this.connectors.enabledConnectorIds(connectors)
     )
+    await this.syncComputeSkillDocument(join(configDir, 'skills'))
     return configDir
   }
 

--- a/src/main/skills/materializer.test.ts
+++ b/src/main/skills/materializer.test.ts
@@ -13,6 +13,7 @@ import { join } from 'node:path'
 
 import { describe, expect, it } from 'vitest'
 
+import { COMPUTE_SKILL_DIRECTORY, syncComputeSkillDoc } from '../compute/skill-doc'
 import type { BundledSkill } from './registry'
 import { ClaudeCodeSkillMaterializer } from './materializer'
 
@@ -149,6 +150,82 @@ describe('ClaudeCodeSkillMaterializer', () => {
     await materializer.sync(configDir, [])
 
     expect(await listSkillDirs(configDir)).toEqual([])
+  })
+
+  it('preserves the current Compute host projection across a generic skill refresh', async () => {
+    const configDir = await skillsDir()
+    const sourceDir = await mkdtemp(join(tmpdir(), 'src-remote-compute-ssh-'))
+    await writeFile(
+      join(sourceDir, 'SKILL.md'),
+      [
+        '---',
+        'name: remote-compute-ssh',
+        'description: Discover SSH compute hosts.',
+        '---',
+        '',
+        '## Registered hosts',
+        '',
+        '<!-- open-science:compute-hosts:start -->',
+        'Run `await host.compute.list()` to see all registered hosts.',
+        '<!-- open-science:compute-hosts:end -->',
+        '',
+        '## API reference',
+        '',
+        'Bundled SSH guidance.'
+      ].join('\n'),
+      'utf8'
+    )
+    const computeSkill: BundledSkill = {
+      id: 'remote-compute-ssh',
+      name: 'Remote Compute (SSH)',
+      description: 'Discover SSH compute hosts.',
+      source: 'featured',
+      updatedAt: 'v1',
+      sourceDir
+    }
+    const materializer = new ClaudeCodeSkillMaterializer()
+
+    await materializer.sync(configDir, [computeSkill])
+    await syncComputeSkillDoc(join(configDir, 'skills'), [
+      {
+        id: 'host-1',
+        providerId: 'ssh:biowulf',
+        displayName: 'biowulf',
+        shape: 'direct_ssh',
+        sshAlias: 'biowulf',
+        sshOverrides: undefined,
+        scratchRoot: undefined,
+        scratchPinned: false,
+        concurrencyLimit: undefined,
+        probeResult: undefined,
+        detailsDoc: '',
+        detailsUpdatedAt: undefined,
+        detailsUpdatedBy: undefined,
+        createdAt: 1,
+        updatedAt: 1
+      }
+    ])
+
+    await materializer.sync(configDir, [{ ...computeSkill, updatedAt: 'v2' }])
+
+    const doc = await readFile(
+      join(configDir, 'skills', COMPUTE_SKILL_DIRECTORY, 'SKILL.md'),
+      'utf8'
+    )
+    expect(doc).toContain('ssh:biowulf')
+    expect(doc).toContain('Bundled SSH guidance.')
+  })
+
+  it('removes only the known legacy bare Compute Skill directory', async () => {
+    const configDir = await skillsDir()
+    await mkdir(join(configDir, 'skills', 'remote-compute-ssh'), { recursive: true })
+    await writeFile(join(configDir, 'skills', 'remote-compute-ssh', 'SKILL.md'), 'legacy')
+    await mkdir(join(configDir, 'skills', 'user-owned-skill'), { recursive: true })
+    await writeFile(join(configDir, 'skills', 'user-owned-skill', 'SKILL.md'), 'user-owned')
+
+    await new ClaudeCodeSkillMaterializer().sync(configDir, [])
+
+    expect(await listSkillDirs(configDir)).toEqual(['user-owned-skill'])
   })
 
   it.skipIf(process.platform === 'win32')(

--- a/src/main/skills/materializer.ts
+++ b/src/main/skills/materializer.ts
@@ -2,6 +2,7 @@ import { chmod, cp, lstat, mkdir, readFile, readdir, rm, writeFile } from 'node:
 import { join } from 'node:path'
 
 import { createLogger } from '../logger'
+import { COMPUTE_SKILL_ID, preserveComputeHostProjection } from '../compute/skill-doc'
 import type { BundledSkill } from './registry'
 
 const log = createLogger('skills')
@@ -109,6 +110,15 @@ class ClaudeCodeSkillMaterializer implements SkillMaterializer {
     const skillsDir = join(configDir, 'skills')
     await mkdir(skillsDir, { recursive: true })
 
+    // Before this Skill became application-managed it was materialized in the bare public-name
+    // directory. That exact directory is now the only known obsolete duplicate; never inspect or
+    // remove any other unprefixed directory because those can be user-owned Skills.
+    const legacyComputeDir = join(skillsDir, COMPUTE_SKILL_ID)
+    await chmodTree(legacyComputeDir, 'writable')
+    await rm(legacyComputeDir, { recursive: true, force: true }).catch((error) =>
+      log.warn('failed to remove legacy Compute Skill directory', { error })
+    )
+
     const wanted = new Map(enabled.map((skill) => [`${OS_SKILL_PREFIX}${skill.id}`, skill]))
 
     let existing: string[] = []
@@ -144,6 +154,10 @@ class ClaudeCodeSkillMaterializer implements SkillMaterializer {
 
       const target = join(skillsDir, name)
       try {
+        const priorComputeDocument =
+          skill.id === COMPUTE_SKILL_ID
+            ? await readFile(join(target, 'SKILL.md'), 'utf8').catch(() => undefined)
+            : undefined
         // Restore write bits before removal in case a prior sync left the dir read-only.
         await chmodTree(target, 'writable')
         await rm(target, { recursive: true, force: true })
@@ -157,6 +171,14 @@ class ClaudeCodeSkillMaterializer implements SkillMaterializer {
             return true
           }
         })
+        if (priorComputeDocument !== undefined) {
+          const current = await readFile(join(target, 'SKILL.md'), 'utf8')
+          await writeFile(
+            join(target, 'SKILL.md'),
+            preserveComputeHostProjection(current, priorComputeDocument),
+            'utf8'
+          )
+        }
         // Skills whose model tooling needs a compute backend this app lacks get an up-front notice so
         // the agent reports cleanly instead of failing through the model commands. Done before the
         // read-only chmod, which would otherwise block the rewrite.


### PR DESCRIPTION
## Problem

SSH Compute was materialized both as the bundled `os-remote-compute-ssh` Skill and as a bare `remote-compute-ssh` runtime document. The two documents could diverge, and generic Skill refreshes could overwrite the live host projection.

## Proposed change

Use `os-remote-compute-ssh/SKILL.md` as the sole canonical document. Preserve its host projection during generic materialization, synchronize it before agent discovery and after Compute host mutations, and remove only the known bare legacy directory.

## Scope and non-goals

This change only affects SSH Compute Skill provisioning. It does not alter Specialist switching, connector filtering, host persistence, SSH APIs, or Settings UI behavior.

## Acceptance criteria and validation

- Bootstrap, generic refresh ordering, host create/delete, legacy cleanup, and filesystem discovery -> `npm test -- src/main/compute/skill-provisioning.test.ts src/main/compute/skill-doc.test.ts src/main/skills/materializer.test.ts src/main/compute/ipc.test.ts src/main/settings/agent-runtime-manager.test.ts` -> passed (80 tests).
- TypeScript validation -> `npm run typecheck` -> passed.
- Lint validation -> `npm run lint` -> passed.
- Full suite -> `npm test` -> attempted after the final material edit; blocked by the worktree/Vite filesystem restriction denying access to the parent-repository `pdfjs-dist` worker import. This fails unrelated renderer preview tests before they initialize.

## Review focus

Please verify the canonical-path ownership boundary, preservation of dynamic host data across a bundled Skill refresh, and the narrow legacy-directory cleanup.