### PR TITLE
test(settings): make runtime fixture paths host-independent

### DIFF
--- a/src/main/settings/agent-runtime-manager.test.ts
+++ b/src/main/settings/agent-runtime-manager.test.ts
@@ -1,6 +1,6 @@
 import { chmod, mkdir, mkdtemp, readFile, rm, writeFile } from 'node:fs/promises'
 import { tmpdir } from 'node:os'
-import { dirname, join } from 'node:path'
+import { dirname, join, posix } from 'node:path'
 
 import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest'
 
@@ -141,17 +141,19 @@ describe('AgentRuntimeManager', () => {
   })
 
   it('persists successful detection for all three runtime storage shapes', async () => {
-    const claudePath = join(storageRoot, 'detected', 'claude')
-    const opencodePath = join(storageRoot, 'detected', 'opencode')
+    // The injected detector platform is Linux, so keep these virtual inventory paths POSIX on every
+    // host. Using the host path helpers makes the Windows keys disagree with the detector probes.
+    const claudePath = posix.join('/detected', 'claude')
+    const opencodePath = posix.join('/detected', 'opencode')
     inventory.claude.set(claudePath, '2.1.0')
     inventory.opencode.set(opencodePath, '1.19.0')
     inventory.codexAdapter.set(managedAdapterPath, 'codex-acp 1.1.4')
     inventory.codexNative.set(managedCodexPath, 'codex-cli 0.144.6')
     manager = createManager({
-      detectDeps: { ...createClaudeDeps(inventory), env: { PATH: dirname(claudePath) } },
+      detectDeps: { ...createClaudeDeps(inventory), env: { PATH: posix.dirname(claudePath) } },
       opencodeDetectDeps: {
         ...createOpencodeDeps(inventory),
-        env: { PATH: dirname(opencodePath) }
+        env: { PATH: posix.dirname(opencodePath) }
       }
     })
 


### PR DESCRIPTION
## Problem

The Windows full-test job failed because the AgentRuntimeManager test pinned its detector dependencies to Linux while constructing virtual executable paths with host path helpers. On Windows, the mock inventory keys therefore used different separators from the detector probes, so Claude and OpenCode were reported as missing.

## Proposed change

Use POSIX path helpers for the Linux-pinned virtual detector inventory and PATH values.

## Scope and non-goals

This changes test fixtures only. Production runtime detection and settings persistence are unchanged.

## Acceptance criteria and validation

- Host-independent Linux fixture paths -> targeted ESLint and Prettier checks -> passed after the final edit.
- Node TypeScript contracts -> npm run typecheck:node -> passed after the final edit.
- Windows runtime-manager scenario -> PR GitHub Actions -> pending.
- Local npm test was intentionally not run per request.

## Review focus

Confirm that the fixture path semantics follow the injected detector platform rather than the host running Vitest.