### PR TITLE
fix(acp): harden reviewer session lifecycle

### DIFF
--- a/src/main/acp/runtime.test.ts
+++ b/src/main/acp/runtime.test.ts
@@ -6437,6 +6437,53 @@ describe('ACP runtime session management', () => {
     expect(mcpServerNamesMap(runtime).has('reviewer-session-1')).toBe(false)
   })
 
+  it('keeps setMode failure primary when reviewer startup disposal also fails', async () => {
+    errorLogSpy.mockClear()
+    const process = new FakeAgentProcess()
+    const fakeAgent = startFakeAgent(process, ['reviewer-session-1'], {
+      modes: createModes(['default'], 'unexpected-mode'),
+      rejectModeChange: true
+    })
+    const runtime = new AcpRuntime({
+      appVersion: '0.1.0',
+      defaultCwd: '/workspace',
+      spawnAgent: () => asAgentProcess(process)
+    })
+    const disposeSpy = vi
+      .spyOn(acp.ActiveSession.prototype, 'dispose')
+      .mockImplementationOnce(() => {
+        throw new Error('startup dispose failed')
+      })
+
+    try {
+      await expect(
+        runtime.buildReviewerSession({
+          cwd: '/workspace',
+          mcpServers: [
+            {
+              type: 'http',
+              name: 'open-science-reviewer',
+              url: 'http://127.0.0.1:1/mcp',
+              headers: []
+            }
+          ]
+        })
+      ).rejects.toMatchObject({
+        message: 'Internal error',
+        data: { details: 'set mode failed' }
+      })
+    } finally {
+      disposeSpy.mockRestore()
+    }
+
+    const reviewerCwd = fakeAgent.newSessions[0]?.cwd
+    await expect(stat(reviewerCwd!)).rejects.toMatchObject({ code: 'ENOENT' })
+    expect(errorLogSpy).toHaveBeenCalledWith('reviewer startup session disposal failed', {
+      errorCategory: 'error',
+      sessionId: 'reviewer-session-1'
+    })
+  })
+
   it('rejects tools from every MCP namespace except the dedicated reviewer server', async () => {
     const process = new FakeAgentProcess()
     let permissionResponse: unknown
@@ -9032,6 +9079,56 @@ describe('ACP runtime session management', () => {
       sessionId: 'reviewer-session-1'
     })
     expect(process.killed).toBe(true)
+    expect(releaseBridge).toHaveBeenCalledOnce()
+  })
+
+  it('completes reviewer cleanup before propagating a session disposal failure', async () => {
+    const process = new FakeAgentProcess()
+    const registerReviewerSession = vi.fn()
+    const unregisterReviewerSession = vi.fn(() => true)
+    const releaseBridge = vi.fn(async () => undefined)
+    const fakeAgent = startFakeAgent(process, ['reviewer-session-1'])
+    const runtime = new AcpRuntime({
+      appVersion: '0.1.0',
+      defaultCwd: '/workspace',
+      resolveBackend: () => ({
+        framework: { ...claudeCodeFramework, spawn: () => asAgentProcess(process) },
+        executablePath: '/bin/claude',
+        env: {},
+        responsesBridgeLease: {
+          selectSkills: vi.fn(async () => []),
+          registerReviewerSession,
+          unregisterReviewerSession,
+          release: releaseBridge
+        }
+      })
+    })
+    const { session } = await runtime.buildReviewerSession({
+      cwd: '/workspace',
+      mcpServers: [
+        {
+          type: 'http',
+          name: 'open-science-reviewer',
+          url: 'http://127.0.0.1:1/mcp',
+          headers: []
+        }
+      ]
+    })
+    const reviewerCwd = fakeAgent.newSessions[0]!.cwd
+
+    await runtime.requestProviderReconnect()
+    expect(process.killed).toBe(false)
+
+    vi.spyOn(session, 'dispose').mockImplementationOnce(() => {
+      throw new Error('reviewer dispose failed')
+    })
+
+    expect(() => runtime.disposeReviewerSession(session)).toThrow('reviewer dispose failed')
+
+    expect(unregisterReviewerSession).toHaveBeenCalledWith('reviewer-session-1')
+    expect(runtime.reviewerRejectedToolCallCount('reviewer-session-1')).toBe(0)
+    await expect(stat(reviewerCwd)).rejects.toMatchObject({ code: 'ENOENT' })
+    await vi.waitFor(() => expect(process.killed).toBe(true))
     expect(releaseBridge).toHaveBeenCalledOnce()
   })
 

--- a/src/main/acp/runtime.test.ts
+++ b/src/main/acp/runtime.test.ts
@@ -936,6 +936,64 @@ describe('ACP runtime migration write-gate', () => {
     ])
   })
 
+  it.each(['initialize', 'authenticate'] as const)(
+    'clears one-shot connection intents when %s fails',
+    async (failureStage) => {
+      const process = new FakeAgentProcess()
+      const providerSet = vi.fn()
+      acp
+        .agent({ name: `failing-${failureStage}-agent` })
+        .onRequest(acp.methods.agent.initialize, () => {
+          if (failureStage === 'initialize') throw new Error('initialize failed')
+          return {
+            protocolVersion: acp.PROTOCOL_VERSION,
+            agentCapabilities: { loadSession: false },
+            authMethods: []
+          }
+        })
+        .onRequest(acp.methods.agent.authenticate, () => {
+          throw new Error('authenticate failed')
+        })
+        .onRequest(acp.methods.agent.providers.set, providerSet)
+        .connect(
+          acp.ndJsonStream(
+            Writable.toWeb(process.stdout) as WritableStream<Uint8Array>,
+            Readable.toWeb(process.stdin) as ReadableStream<Uint8Array>
+          )
+        )
+
+      const runtime = new AcpRuntime({
+        appVersion: '0.1.0',
+        defaultCwd: '/workspace',
+        resolveBackend: () => ({
+          framework: { ...claudeCodeFramework, spawn: () => asAgentProcess(process) },
+          executablePath: '/bin/agent',
+          env: {},
+          authentication: {
+            methodId: 'api-key',
+            _meta: { 'api-key': { apiKey: 'test-only-key' } }
+          },
+          providerConfiguration: {
+            providerId: 'custom-gateway',
+            apiType: 'openai',
+            baseUrl: 'http://127.0.0.1:1234/v1',
+            headers: { authorization: 'Bearer test-only-token' }
+          }
+        })
+      })
+
+      await expect(runtime.connect({ cwd: '/workspace' })).rejects.toThrow()
+
+      const internal = runtime as unknown as {
+        pendingAuthentication?: unknown
+        pendingProviderConfiguration?: unknown
+      }
+      expect(internal.pendingAuthentication).toBeUndefined()
+      expect(internal.pendingProviderConfiguration).toBeUndefined()
+      expect(providerSet).not.toHaveBeenCalled()
+    }
+  )
+
   it('rejects session creation when a required subscription model is unavailable', async () => {
     const process = new FakeAgentProcess()
     startFakeAgent(process, ['subscription-session'], {
@@ -4750,6 +4808,36 @@ describe('ACP runtime session management', () => {
     })
   })
 
+  it('does not commit connected after an initialized-event callback disconnects', async () => {
+    const process = new FakeAgentProcess()
+    startFakeAgent(process, ['reentrant-disconnect-session'])
+    const statuses: string[] = []
+    let disconnect: Promise<unknown> | undefined
+    const callbacks: { disconnectRuntime?: () => Promise<unknown> } = {}
+    const runtime = new AcpRuntime({
+      appVersion: '0.1.0',
+      defaultCwd: '/workspace',
+      spawnAgent: () => asAgentProcess(process),
+      callbacks: {
+        onEvent: (event) => {
+          if (event.title === 'Agent initialized') disconnect = callbacks.disconnectRuntime?.()
+        },
+        onStateChanged: (snapshot) => statuses.push(snapshot.status)
+      }
+    })
+    callbacks.disconnectRuntime = () => runtime.disconnect()
+
+    await expect(runtime.connect({ cwd: '/workspace' })).rejects.toThrow(
+      'ACP connection was superseded.'
+    )
+    expect(disconnect).toBeDefined()
+    await disconnect
+
+    expect(runtime.getSnapshot()).toMatchObject({ status: 'closed', sessionIds: [] })
+    expect(statuses.at(-1)).toBe('closed')
+    expect(statuses).not.toContain('connected')
+  })
+
   it('rejects filesystem callbacks for unknown sessions instead of falling back to global cwd', async () => {
     const workspaceRoot = await mkdtemp(join(tmpdir(), 'open-science-acp-runtime-'))
     const filePath = join(workspaceRoot, 'notes.txt')
@@ -7457,6 +7545,74 @@ describe('ACP runtime session management', () => {
       releaseStaleMode.resolve()
       await stale.catch(() => undefined)
       disconnectCurrentSpy.mockRestore()
+      if (successor) await runtime.deleteSession({ sessionId: successor.sessionId })
+      await runtime.disconnect().catch(() => undefined)
+    }
+  })
+
+  it('does not let stale permission setup target a same-id successor connection', async () => {
+    const oldProcess = new FakeAgentProcess()
+    const newProcess = new FakeAgentProcess()
+    startFakeAgent(oldProcess, ['shared-primary'], {
+      modes: createModes(['read-only', 'agent', 'agent-full-access'], 'agent')
+    })
+    const newAgent = startFakeAgent(newProcess, ['shared-primary'], {
+      modes: createModes(['read-only', 'agent', 'agent-full-access'], 'agent')
+    })
+    let spawnCount = 0
+    const runtime = new AcpRuntime({
+      appVersion: '0.1.0',
+      defaultCwd: '/workspace',
+      resolveBackend: () => {
+        spawnCount += 1
+        return {
+          framework: {
+            ...codexFramework,
+            spawn: () => asAgentProcess(spawnCount === 1 ? oldProcess : newProcess)
+          },
+          executablePath: '/bin/codex-acp',
+          env: {}
+        }
+      }
+    })
+    const permissionSetupStarted = createDeferred()
+    const releasePermissionSetup = createDeferred()
+    const internal = runtime as unknown as {
+      configurePermissionProfile: (...args: unknown[]) => Promise<unknown>
+    }
+    const configurePermissionProfile = internal.configurePermissionProfile.bind(runtime)
+    vi.spyOn(internal, 'configurePermissionProfile').mockImplementationOnce(async (...args) => {
+      permissionSetupStarted.resolve()
+      await releasePermissionSetup.promise
+      return configurePermissionProfile(...args)
+    })
+
+    const stale = runtime.createSession({
+      cwd: '/workspace',
+      permissionProfile: 'full'
+    })
+    await permissionSetupStarted.promise
+    let successor: Awaited<ReturnType<AcpRuntime['createSession']>> | undefined
+
+    try {
+      await runtime.disconnect()
+      successor = await runtime.createSession({
+        cwd: '/workspace',
+        permissionProfile: 'ask'
+      })
+      expect(newAgent.modeChanges).toEqual([{ sessionId: 'shared-primary', modeId: 'read-only' }])
+
+      releasePermissionSetup.resolve()
+      await expect(stale).rejects.toThrow('ACP session startup was superseded.')
+      expect(newAgent.modeChanges).toEqual([{ sessionId: 'shared-primary', modeId: 'read-only' }])
+      expect(runtime.getSnapshot().permissionProfiles['shared-primary']).toMatchObject({
+        selectedProfile: 'ask',
+        effectiveProfile: 'ask',
+        currentModeId: 'read-only'
+      })
+    } finally {
+      releasePermissionSetup.resolve()
+      await stale.catch(() => undefined)
       if (successor) await runtime.deleteSession({ sessionId: successor.sessionId })
       await runtime.disconnect().catch(() => undefined)
     }
@@ -15579,6 +15735,42 @@ describe('ACP runtime — failure-path robustness (errorMessage coercion + sync-
 
     await expect(runtime.createSession({ cwd: '/workspace' })).rejects.toBe(spawnError)
   }
+
+  it('does not overwrite a reentrant failure-event disconnect with error status', async () => {
+    const spawnError = new Error('spawn failed before disconnect')
+    const statuses: string[] = []
+    let disconnect: Promise<unknown> | undefined
+    const callbacks: { disconnectRuntime?: () => Promise<unknown> } = {}
+    const runtime = new AcpRuntime({
+      appVersion: '0.1.0',
+      defaultCwd: '/workspace',
+      callbacks: {
+        onEvent: (event) => {
+          if (event.title === 'Connection failed') disconnect = callbacks.disconnectRuntime?.()
+        },
+        onStateChanged: (snapshot) => statuses.push(snapshot.status)
+      },
+      resolveBackend: () => ({
+        framework: {
+          ...claudeCodeFramework,
+          spawn: () => {
+            throw spawnError
+          }
+        },
+        executablePath: '/bin/agent',
+        env: {}
+      })
+    })
+    callbacks.disconnectRuntime = () => runtime.disconnect()
+
+    await expect(runtime.connect({ cwd: '/workspace' })).rejects.toBe(spawnError)
+    expect(disconnect).toBeDefined()
+    await disconnect
+
+    expect(runtime.getSnapshot().status).toBe('closed')
+    expect(statuses.at(-1)).toBe('closed')
+    expect(statuses).not.toContain('error')
+  })
 
   it('propagates the spawn cause even when onEvent throws synchronously', async () => {
     const spawnError = new Error('spawn failed A')

--- a/src/main/acp/runtime.test.ts
+++ b/src/main/acp/runtime.test.ts
@@ -950,10 +950,19 @@ describe('ACP runtime migration write-gate', () => {
       }),
       framework: codexFramework
     })
+    const disposeSpy = vi
+      .spyOn(acp.ActiveSession.prototype, 'dispose')
+      .mockImplementationOnce(() => {
+        throw new Error('unavailable-model disposal failed')
+      })
 
-    await expect(runtime.createSession({ cwd: '/workspace' })).rejects.toThrow(
-      'The selected model "gpt-subscription" is not available for this Codex account.'
-    )
+    try {
+      await expect(runtime.createSession({ cwd: '/workspace' })).rejects.toThrow(
+        'The selected model "gpt-subscription" is not available for this Codex account.'
+      )
+    } finally {
+      disposeSpy.mockRestore()
+    }
   })
 
   it('does not tokenize against an optional model that the Agent could not apply', async () => {
@@ -1065,10 +1074,19 @@ describe('ACP runtime migration write-gate', () => {
       }),
       framework: codexFramework
     })
+    const disposeSpy = vi
+      .spyOn(acp.ActiveSession.prototype, 'dispose')
+      .mockImplementationOnce(() => {
+        throw new Error('required-model disposal failed')
+      })
 
-    await expect(runtime.createSession({ cwd: '/workspace' })).rejects.toThrow(
-      'The selected model "gpt-subscription" could not be applied'
-    )
+    try {
+      await expect(runtime.createSession({ cwd: '/workspace' })).rejects.toThrow(
+        'The selected model "gpt-subscription" could not be applied'
+      )
+    } finally {
+      disposeSpy.mockRestore()
+    }
   })
 
   it('skips set_config_option when a required subscription model already matches currentValue', async () => {
@@ -8708,14 +8726,23 @@ describe('ACP runtime session management', () => {
       runtime as unknown as { configurePermissionProfile: () => Promise<void> },
       'configurePermissionProfile'
     ).mockRejectedValueOnce(failure)
+    const disposeSpy = vi
+      .spyOn(acp.ActiveSession.prototype, 'dispose')
+      .mockImplementationOnce(() => {
+        throw new Error('resumed-session disposal failed')
+      })
 
-    await expect(
-      runtime.resumeSession({ sessionId: 'restored-session', cwd: '/workspace' })
-    ).rejects.toBe(failure)
+    try {
+      await expect(
+        runtime.resumeSession({ sessionId: 'restored-session', cwd: '/workspace' })
+      ).rejects.toBe(failure)
 
-    expect(releaseSessionCapabilities).toHaveBeenCalledOnce()
-    expect(releaseSessionCapabilities).toHaveBeenCalledWith('restored-session')
-    expect(pendingPrimarySessionIds(runtime).size).toBe(0)
+      expect(releaseSessionCapabilities).toHaveBeenCalledOnce()
+      expect(releaseSessionCapabilities).toHaveBeenCalledWith('restored-session')
+      expect(pendingPrimarySessionIds(runtime).size).toBe(0)
+    } finally {
+      disposeSpy.mockRestore()
+    }
   })
 
   it('releases the notebook RPC capability when fresh-session adoption fails', async () => {
@@ -8741,18 +8768,27 @@ describe('ACP runtime session management', () => {
       runtime as unknown as { configurePermissionProfile: () => Promise<void> },
       'configurePermissionProfile'
     ).mockRejectedValueOnce(failure)
-
-    await expect(
-      runtime.resumeSession({
-        sessionId: 'switched-session',
-        cwd: '/workspace',
-        previousFrameworkId: 'codex'
+    const disposeSpy = vi
+      .spyOn(acp.ActiveSession.prototype, 'dispose')
+      .mockImplementationOnce(() => {
+        throw new Error('adopted-session disposal failed')
       })
-    ).rejects.toBe(failure)
 
-    expect(releaseSessionCapabilities).toHaveBeenCalledOnce()
-    expect(releaseSessionCapabilities).toHaveBeenCalledWith('switched-session')
-    expect(pendingPrimarySessionIds(runtime).size).toBe(0)
+    try {
+      await expect(
+        runtime.resumeSession({
+          sessionId: 'switched-session',
+          cwd: '/workspace',
+          previousFrameworkId: 'codex'
+        })
+      ).rejects.toBe(failure)
+
+      expect(releaseSessionCapabilities).toHaveBeenCalledOnce()
+      expect(releaseSessionCapabilities).toHaveBeenCalledWith('switched-session')
+      expect(pendingPrimarySessionIds(runtime).size).toBe(0)
+    } finally {
+      disposeSpy.mockRestore()
+    }
   })
 
   it('replaces a failed resume capability without revoking the adopted session capability', async () => {

--- a/src/main/acp/runtime.test.ts
+++ b/src/main/acp/runtime.test.ts
@@ -7956,6 +7956,100 @@ describe('ACP runtime session management', () => {
     }
   })
 
+  it('does not let an older disconnect close a successor HTTP MCP host', async () => {
+    const oldProcess = new FakeAgentProcess()
+    const newProcess = new FakeAgentProcess()
+    startFakeAgent(oldProcess, ['old-http-session'])
+    startFakeAgent(newProcess, ['new-http-session'])
+    const routes = new Set<string>()
+    const close = vi.fn(async () => {
+      routes.clear()
+    })
+    const httpHost = {
+      ensureStarted: vi.fn(async () => ({
+        endpoint: 'http://127.0.0.1:4321',
+        token: 'host-token'
+      })),
+      registerNotebook: vi.fn((routingId: string) => {
+        routes.add(routingId)
+      }),
+      urlFor: vi.fn(
+        (kind: string, routingId: string) =>
+          `http://127.0.0.1:4321/mcp/${kind}/${encodeURIComponent(routingId)}`
+      ),
+      unregister: vi.fn((routingId: string) => {
+        routes.delete(routingId)
+      }),
+      clear: vi.fn(() => routes.clear()),
+      close
+    } as unknown as AgentMcpHttpHost
+    let spawnCount = 0
+    const runtime = new AcpRuntime({
+      appVersion: '0.1.0',
+      defaultCwd: '/workspace',
+      resolveBackend: () => {
+        const process = spawnCount === 0 ? oldProcess : newProcess
+        spawnCount += 1
+        return {
+          framework: {
+            ...opencodeFramework,
+            acceptsStdioMcp: false,
+            spawn: () => asAgentProcess(process)
+          },
+          executablePath: '/bin/agent',
+          env: {}
+        }
+      },
+      mcpHttpHost: httpHost,
+      notebook: {
+        projectName: 'default-project',
+        mcpEntryPath: '/app/out/main/index.js',
+        getRpcConnection: async () => ({
+          endpoint: 'http://127.0.0.1:4567',
+          token: 'notebook-token'
+        })
+      }
+    })
+    const first = await runtime.createSession({ cwd: '/workspace' })
+    const firstRoutingId = [...routes][0]
+    expect(first.sessionId).toBe('old-http-session')
+    expect(firstRoutingId).toBeDefined()
+    const oldKillStarted = createDeferred()
+    const releaseOldKill = createDeferred()
+    vi.mocked(terminateProcessTree).mockImplementationOnce(async (child) => {
+      oldKillStarted.resolve()
+      await releaseOldKill.promise
+      child?.kill()
+      return { reaped: true }
+    })
+    const oldDisconnect = runtime.disconnect()
+    await oldKillStarted.promise
+
+    try {
+      const successor = await runtime.createSession({ cwd: '/workspace' })
+      const successorRoutingId = [...routes][0]
+      expect(successor.sessionId).toBe('new-http-session')
+      expect(successorRoutingId).toBeDefined()
+      expect(successorRoutingId).not.toBe(firstRoutingId)
+      expect(routes.size).toBe(1)
+
+      releaseOldKill.resolve()
+      await oldDisconnect
+
+      expect(close).not.toHaveBeenCalled()
+      expect(routes).toContain(successorRoutingId)
+      expect(runtime.getSnapshot()).toMatchObject({
+        status: 'connected',
+        sessionIds: ['new-http-session']
+      })
+    } finally {
+      releaseOldKill.resolve()
+      await oldDisconnect.catch(() => undefined)
+      await runtime.disconnect().catch(() => undefined)
+      expect(close).toHaveBeenCalledOnce()
+    }
+  })
+
   it('releases an armed reconnect barrier during synchronous shutdown', async () => {
     const oldProcess = new FakeAgentProcess()
     const abandonedProcess = new FakeAgentProcess()

--- a/src/main/acp/runtime.test.ts
+++ b/src/main/acp/runtime.test.ts
@@ -11871,6 +11871,167 @@ describe('ACP runtime session management', () => {
     expect(spawnCount).toBe(2)
   })
 
+  it.each([
+    {
+      operation: 'resume',
+      interruption: 'delete',
+      sessionId: '123e4567-e89b-42d3-a456-426614174000'
+    },
+    {
+      operation: 'context reset',
+      interruption: 'delete',
+      sessionId: 'stable-app-session'
+    },
+    {
+      operation: 'resume',
+      interruption: 'disconnect',
+      sessionId: '123e4567-e89b-42d3-a456-426614174000'
+    },
+    {
+      operation: 'context reset',
+      interruption: 'disconnect',
+      sessionId: 'stable-app-session'
+    }
+  ])(
+    'rejects a pending $operation after a second $interruption invalidation',
+    async ({ operation, interruption, sessionId }) => {
+      const oldProcess = new FakeAgentProcess()
+      const newProcess = new FakeAgentProcess()
+      const promptGate = createDeferred()
+      startFakeAgent(oldProcess, ['stable-app-session'], {
+        onPrompt: () => promptGate.promise
+      })
+      const newAgent = startFakeAgent(newProcess, ['unexpected-provider-session'])
+
+      let spawnCount = 0
+      const runtime = new AcpRuntime({
+        appVersion: '0.1.0',
+        defaultCwd: '/workspace',
+        resolveBackend: async () => {
+          spawnCount += 1
+          return {
+            framework: {
+              ...claudeCodeFramework,
+              spawn: () => asAgentProcess(spawnCount === 1 ? oldProcess : newProcess)
+            },
+            executablePath: '/bin/agent',
+            env: {},
+            args: []
+          }
+        }
+      })
+
+      await runtime.createSession({ cwd: '/workspace' })
+      const prompt = runtime.sendPrompt({ sessionId: 'stable-app-session', text: 'hi' })
+      await runtime.requestProviderReconnect()
+
+      const connectionReady = createDeferred()
+      const releaseEnsureConnected = createDeferred()
+      const internal = runtime as unknown as {
+        ensureConnected: (cwd: string) => Promise<unknown>
+      }
+      const ensureConnected = internal.ensureConnected.bind(runtime)
+      vi.spyOn(internal, 'ensureConnected').mockImplementationOnce(async (cwd) => {
+        const connection = await ensureConnected(cwd)
+        connectionReady.resolve()
+        await releaseEnsureConnected.promise
+        return connection
+      })
+
+      const pending =
+        operation === 'context reset'
+          ? runtime.resetSessionContext({ sessionId, cwd: '/workspace' })
+          : runtime.resumeSession({ sessionId, cwd: '/workspace' })
+
+      promptGate.resolve()
+      await prompt
+      await connectionReady.promise
+
+      if (interruption === 'delete') {
+        await runtime.deleteSession({ sessionId })
+        releaseEnsureConnected.resolve()
+      } else {
+        // Resolving the wrapper queues the startup continuation. disconnect() invalidates its
+        // generation and clears the just-returned connection synchronously before yielding.
+        releaseEnsureConnected.resolve()
+        await runtime.disconnect()
+      }
+
+      try {
+        await expect(pending).rejects.toThrow('ACP session startup was superseded.')
+        expect(newAgent.newSessions).toEqual([])
+        expect(newAgent.resumedSessions).toEqual([])
+        expect(runtime.getSnapshot().sessionIds).not.toContain(sessionId)
+      } finally {
+        promptGate.resolve()
+        releaseEnsureConnected.resolve()
+        await pending.catch(() => undefined)
+        await runtime.disconnect().catch(() => undefined)
+      }
+    }
+  )
+
+  it('blocks a same-id reset while deletion is in flight and allows retry after deletion fails', async () => {
+    const process = new FakeAgentProcess()
+    const closeStarted = createDeferred()
+    const releaseClose = createDeferred()
+    const deleteFailure = new Error('agent delete failed')
+    const fakeAgent = startFakeAgent(
+      process,
+      ['stable-app-session', 'replacement-provider-session'],
+      {
+        onClose: async () => {
+          closeStarted.resolve()
+          await releaseClose.promise
+          throw deleteFailure
+        }
+      }
+    )
+    const runtime = new AcpRuntime({
+      appVersion: '0.1.0',
+      defaultCwd: '/workspace',
+      spawnAgent: () => asAgentProcess(process)
+    })
+    await runtime.createSession({ cwd: '/workspace' })
+
+    const deleting = runtime.deleteSession({ sessionId: 'stable-app-session' })
+    await closeStarted.promise
+    const resetWhileDeleting = runtime.resetSessionContext({
+      sessionId: 'stable-app-session',
+      cwd: '/workspace'
+    })
+
+    try {
+      await expect(resetWhileDeleting).rejects.toThrow(
+        'Primary session id collision with deletion in progress: stable-app-session'
+      )
+      expect(fakeAgent.newSessions).toHaveLength(1)
+
+      releaseClose.resolve()
+      await expect(deleting).rejects.toMatchObject({
+        code: -32603,
+        data: { details: deleteFailure.message }
+      })
+
+      await expect(
+        runtime.resetSessionContext({
+          sessionId: 'stable-app-session',
+          cwd: '/workspace'
+        })
+      ).resolves.toMatchObject({
+        sessionId: 'stable-app-session',
+        contextReset: true
+      })
+      expect(fakeAgent.newSessions).toHaveLength(2)
+    } finally {
+      releaseClose.resolve()
+      await deleting.catch(() => undefined)
+      await resetWhileDeleting.catch(() => undefined)
+      await runtime.deleteSession({ sessionId: 'stable-app-session' }).catch(() => undefined)
+      await runtime.disconnect().catch(() => undefined)
+    }
+  })
+
   it('createSession proceeds immediately when an unexpected connection close resolves the barrier', async () => {
     const oldProcess = new FakeAgentProcess()
     const newProcess = new FakeAgentProcess()

--- a/src/main/acp/runtime.test.ts
+++ b/src/main/acp/runtime.test.ts
@@ -186,6 +186,7 @@ const startFakeAgent = (
     rejectModeChange?: boolean
     newSessionError?: unknown
     onNewSession?: (context: { sessionId: string; index: number }) => Promise<void> | void
+    onResumeRequest?: (context: { sessionId: string; index: number }) => Promise<void> | void
     onResume?: (sessionId: string) => Promise<void> | void
     onSetMode?: (context: { sessionId: string; modeId: string }) => Promise<void> | void
     onClose?: (sessionId: string) => Promise<void> | void
@@ -231,6 +232,7 @@ const startFakeAgent = (
   const configChanges: Array<{ sessionId: string; configId: string; value: string | boolean }> = []
   const actions: string[] = []
   let sessionIndex = 0
+  let resumeIndex = 0
 
   acp
     .agent({ name: 'test-agent' })
@@ -275,6 +277,10 @@ const startFakeAgent = (
       }
     })
     .onRequest(acp.methods.agent.session.resume, async (ctx) => {
+      const index = resumeIndex
+      resumeIndex += 1
+      await options.onResumeRequest?.({ sessionId: ctx.params.sessionId, index })
+
       if (options.resumeNotFound) {
         throw acp.RequestError.resourceNotFound(ctx.params.sessionId)
       }
@@ -4331,7 +4337,7 @@ describe('ACP runtime session management', () => {
     }
   })
 
-  it('continues partial provisional route cleanup without replacing the startup error', async () => {
+  it('cleans partial provisional routes after a framework switch without replacing the startup error', async () => {
     const root = await createTemporaryRoot()
     const startupFailure = new Error('notebook capability setup failed')
     let unregisterAttempt = 0
@@ -4376,6 +4382,7 @@ describe('ACP runtime session management', () => {
         projectName: 'default-project',
         mcpEntryPath: '/app/out/main/index.js',
         getRpcConnection: async () => {
+          setRuntimeFramework(runtime, claudeCodeFramework)
           throw startupFailure
         }
       },
@@ -7887,6 +7894,7 @@ describe('ACP runtime session management', () => {
       const staleModeStarted = createDeferred()
       const releaseStaleMode = createDeferred()
       const capabilityReleases: ReturnType<typeof vi.fn>[] = []
+      const releaseSessionCapabilities = vi.fn()
       startFakeAgent(process, ['stale-provider', 'successor-provider'], {
         modes: createModes(['read-only', 'agent', 'agent-full-access'], 'agent'),
         onSetMode: async ({ modeId }) => {
@@ -7925,6 +7933,7 @@ describe('ACP runtime session management', () => {
         notebook: {
           projectName: 'default-project',
           mcpEntryPath: '/app/out/main/index.js',
+          releaseSessionCapabilities,
           getRpcConnection: async () => {
             const release = vi.fn()
             capabilityReleases.push(release)
@@ -7991,6 +8000,7 @@ describe('ACP runtime session management', () => {
         expect(capabilityReleases).toHaveLength(2)
         expect(capabilityReleases[0]).toHaveBeenCalledOnce()
         expect(capabilityReleases[1]).not.toHaveBeenCalled()
+        expect(releaseSessionCapabilities).not.toHaveBeenCalled()
       } finally {
         releaseStaleMode.resolve()
         await staleOutcome
@@ -8000,6 +8010,63 @@ describe('ACP runtime session management', () => {
       }
     }
   )
+
+  it('does not let a superseded failed resume revoke its same-id successor capability', async () => {
+    const sessionId = '123e4567-e89b-42d3-a456-426614174000'
+    const process = new FakeAgentProcess()
+    const staleResumeStarted = createDeferred()
+    const releaseStaleResume = createDeferred()
+    const releaseSessionCapabilities = vi.fn()
+    const fakeAgent = startFakeAgent(process, [], {
+      onResumeRequest: async ({ index }) => {
+        if (index !== 0) return
+        staleResumeStarted.resolve()
+        await releaseStaleResume.promise
+        throw acp.RequestError.resourceNotFound(sessionId)
+      }
+    })
+    const runtime = new AcpRuntime({
+      appVersion: '0.1.0',
+      defaultCwd: '/workspace',
+      spawnAgent: () => asAgentProcess(process),
+      notebook: {
+        projectName: 'default-project',
+        mcpEntryPath: '/app/out/main/index.js',
+        getRpcConnection: async () => ({
+          endpoint: 'http://127.0.0.1:4567',
+          token: 'legacy-notebook-token'
+        }),
+        releaseSessionCapabilities
+      }
+    })
+    await runtime.connect({ cwd: '/workspace' })
+
+    const stale = runtime.resumeSession({ sessionId, cwd: '/workspace' })
+    const staleOutcome = stale.then(
+      (value) => ({ value, error: undefined }),
+      (error: unknown) => ({ value: undefined, error })
+    )
+    await staleResumeStarted.promise
+    ;(
+      runtime as unknown as { invalidatePendingSessionStartups: () => void }
+    ).invalidatePendingSessionStartups()
+    const successor = await runtime.resumeSession({ sessionId, cwd: '/workspace' })
+
+    try {
+      releaseStaleResume.resolve()
+      const outcome = await staleOutcome
+      expect(outcome.error).toMatchObject({ message: 'ACP session startup was superseded.' })
+      expect(successor).toMatchObject({ sessionId })
+      expect(fakeAgent.newSessions).toHaveLength(0)
+      expect(fakeAgent.resumedSessions).toHaveLength(1)
+      expect(releaseSessionCapabilities).not.toHaveBeenCalled()
+      expect(runtime.getSnapshot().sessionIds).toEqual([sessionId])
+    } finally {
+      releaseStaleResume.resolve()
+      await staleOutcome
+      await runtime.deleteSession({ sessionId })
+    }
+  })
 
   it('reserves a known resumed app id before provider attach completes', async () => {
     const sessionId = '123e4567-e89b-42d3-a456-426614174000'
@@ -14934,6 +15001,41 @@ describe('ACP runtime — session-creation and spawn diagnostics', () => {
 
     await expect(runtime.createSession({ cwd: '/workspace' })).rejects.toBe(failure)
 
+    expect(releaseSessionCapabilities).toHaveBeenCalledOnce()
+    expect(releaseSessionCapabilities).toHaveBeenCalledWith(
+      expect.stringMatching(/^notebook-session-/)
+    )
+  })
+
+  it('releases owned session metadata after its exact provisional capability fails to publish', async () => {
+    const process = new FakeAgentProcess()
+    startFakeAgent(process, ['perm-fail-session'])
+    const release = vi.fn()
+    const releaseSessionCapabilities = vi.fn()
+    const runtime = new AcpRuntime({
+      appVersion: '0.1.0',
+      defaultCwd: '/workspace',
+      spawnAgent: () => asAgentProcess(process),
+      notebook: {
+        projectName: 'default-project',
+        mcpEntryPath: '/app/out/main/index.js',
+        getRpcConnection: async () => ({
+          endpoint: 'http://127.0.0.1:4567',
+          token: 'secret-token',
+          release
+        }),
+        releaseSessionCapabilities
+      }
+    })
+    const failure = new Error('permission setup failed')
+    vi.spyOn(
+      runtime as unknown as { configurePermissionProfile: () => Promise<void> },
+      'configurePermissionProfile'
+    ).mockRejectedValueOnce(failure)
+
+    await expect(runtime.createSession({ cwd: '/workspace' })).rejects.toBe(failure)
+
+    expect(release).toHaveBeenCalledOnce()
     expect(releaseSessionCapabilities).toHaveBeenCalledOnce()
     expect(releaseSessionCapabilities).toHaveBeenCalledWith(
       expect.stringMatching(/^notebook-session-/)

--- a/src/main/acp/runtime.test.ts
+++ b/src/main/acp/runtime.test.ts
@@ -6255,6 +6255,152 @@ describe('ACP runtime session management', () => {
     expect(spawnAgent).not.toHaveBeenCalled()
   })
 
+  it('rejects a reviewer session id that collides with a primary session before authority setup', async () => {
+    const process = new FakeAgentProcess()
+    const fakeAgent = startFakeAgent(process, ['shared-session', 'shared-session'])
+    const runtime = new AcpRuntime({
+      appVersion: '0.1.0',
+      defaultCwd: '/workspace',
+      spawnAgent: () => asAgentProcess(process)
+    })
+
+    await runtime.createSession({ cwd: '/workspace' })
+
+    await expect(
+      runtime.buildReviewerSession({
+        cwd: '/workspace',
+        mcpServers: [
+          {
+            type: 'http',
+            name: 'open-science-reviewer',
+            url: 'http://127.0.0.1:1/mcp',
+            headers: []
+          }
+        ]
+      })
+    ).rejects.toThrow('Reviewer session id collision: shared-session')
+
+    const reviewerCwd = fakeAgent.newSessions[1]?.cwd
+    expect(reviewerCwd).toMatch(/open-science-reviewer-/)
+    await expect(stat(reviewerCwd!)).rejects.toMatchObject({ code: 'ENOENT' })
+    expect(fakeAgent.modeChanges).toEqual([])
+    expect(runtime.getSnapshot().sessionIds).toEqual(['shared-session'])
+  })
+
+  it('keeps the reviewer collision as primary when the duplicate session cannot dispose', async () => {
+    errorLogSpy.mockClear()
+    const process = new FakeAgentProcess()
+    const fakeAgent = startFakeAgent(process, ['shared-session', 'shared-session'])
+    const runtime = new AcpRuntime({
+      appVersion: '0.1.0',
+      defaultCwd: '/workspace',
+      spawnAgent: () => asAgentProcess(process)
+    })
+    await runtime.createSession({ cwd: '/workspace' })
+    const disposeSpy = vi
+      .spyOn(acp.ActiveSession.prototype, 'dispose')
+      .mockImplementationOnce(() => {
+        throw new Error('duplicate dispose failed')
+      })
+
+    try {
+      await expect(
+        runtime.buildReviewerSession({
+          cwd: '/workspace',
+          mcpServers: [
+            {
+              type: 'http',
+              name: 'open-science-reviewer',
+              url: 'http://127.0.0.1:1/mcp',
+              headers: []
+            }
+          ]
+        })
+      ).rejects.toThrow('Reviewer session id collision: shared-session')
+    } finally {
+      disposeSpy.mockRestore()
+    }
+
+    const reviewerCwd = fakeAgent.newSessions[1]?.cwd
+    await expect(stat(reviewerCwd!)).rejects.toMatchObject({ code: 'ENOENT' })
+    expect(errorLogSpy).toHaveBeenCalledWith('reviewer collision session disposal failed', {
+      errorCategory: 'error',
+      sessionId: 'shared-session'
+    })
+  })
+
+  it('rejects a reviewer session id that collides with a freshly adopted provider session', async () => {
+    const process = new FakeAgentProcess()
+    const fakeAgent = startFakeAgent(process, ['provider-session', 'provider-session'], {
+      resumeNotFound: true
+    })
+    const runtime = new AcpRuntime({
+      appVersion: '0.1.0',
+      defaultCwd: '/workspace',
+      spawnAgent: () => asAgentProcess(process)
+    })
+
+    await expect(
+      runtime.resumeSession({ sessionId: 'stable-app-session', cwd: '/workspace' })
+    ).resolves.toMatchObject({ sessionId: 'stable-app-session', contextReset: true })
+
+    await expect(
+      runtime.buildReviewerSession({
+        cwd: '/workspace',
+        mcpServers: [
+          {
+            type: 'http',
+            name: 'open-science-reviewer',
+            url: 'http://127.0.0.1:1/mcp',
+            headers: []
+          }
+        ]
+      })
+    ).rejects.toThrow('Reviewer session id collision: provider-session')
+
+    const reviewerCwd = fakeAgent.newSessions[1]?.cwd
+    expect(reviewerCwd).toMatch(/open-science-reviewer-/)
+    await expect(stat(reviewerCwd!)).rejects.toMatchObject({ code: 'ENOENT' })
+    expect(fakeAgent.modeChanges).toEqual([])
+    expect(runtime.getSnapshot().sessionIds).toEqual(['stable-app-session'])
+  })
+
+  it('rejects a reviewer session id that collides with an existing reviewer', async () => {
+    const process = new FakeAgentProcess()
+    const fakeAgent = startFakeAgent(process, ['reviewer-session', 'reviewer-session'])
+    const runtime = new AcpRuntime({
+      appVersion: '0.1.0',
+      defaultCwd: '/workspace',
+      spawnAgent: () => asAgentProcess(process)
+    })
+    const request = {
+      cwd: '/workspace',
+      mcpServers: [
+        {
+          type: 'http' as const,
+          name: 'open-science-reviewer',
+          url: 'http://127.0.0.1:1/mcp',
+          headers: []
+        }
+      ]
+    }
+
+    const first = await runtime.buildReviewerSession(request)
+
+    await expect(runtime.buildReviewerSession(request)).rejects.toThrow(
+      'Reviewer session id collision: reviewer-session'
+    )
+
+    const duplicateCwd = fakeAgent.newSessions[1]?.cwd
+    expect(duplicateCwd).toMatch(/open-science-reviewer-/)
+    await expect(stat(duplicateCwd!)).rejects.toMatchObject({ code: 'ENOENT' })
+    await first.session.prompt([{ type: 'text', text: 'first reviewer remains active' }])
+    expect(fakeAgent.prompts).toEqual([
+      { sessionId: 'reviewer-session', text: 'first reviewer remains active' }
+    ])
+    runtime.disposeReviewerSession(first.session)
+  })
+
   it('removes the temporary reviewer directory when session startup fails', async () => {
     const process = new FakeAgentProcess()
     const fakeAgent = startFakeAgent(process, ['reviewer-session-1'], {

--- a/src/main/acp/runtime.test.ts
+++ b/src/main/acp/runtime.test.ts
@@ -131,11 +131,13 @@ const createBackendLeaseHarness = (): {
 }
 
 // Creates a manually controlled promise for ordering async protocol steps.
-const createDeferred = <Value = void>(): {
+type Deferred<Value = void> = {
   promise: Promise<Value>
   resolve: (value: Value) => void
   reject: (error: unknown) => void
-} => {
+}
+
+const createDeferred = <Value = void>(): Deferred<Value> => {
   let resolve!: (value: Value) => void
   let reject!: (error: unknown) => void
   const promise = new Promise<Value>((promiseResolve, promiseReject) => {
@@ -420,6 +422,67 @@ const createModes = (
   availableModes: ids.map((id) => ({ id, name: id }))
 })
 
+const startPendingReviewerRace = async (
+  sessionIds: string[]
+): Promise<{
+  fakeAgent: ReturnType<typeof startFakeAgent>
+  lease: NonNullable<ResolvedAgentBackend['responsesBridgeLease']>
+  runtime: AcpRuntime
+  reviewer: ReturnType<AcpRuntime['buildReviewerSession']>
+  request: Parameters<AcpRuntime['buildReviewerSession']>[0]
+  releaseReviewerMode: Deferred
+  modeRequestCount: () => number
+}> => {
+  const process = new FakeAgentProcess()
+  const reviewerModeStarted = createDeferred()
+  const releaseReviewerMode = createDeferred()
+  let modeRequestCount = 0
+  const fakeAgent = startFakeAgent(process, sessionIds, {
+    modes: createModes(['read-only', 'agent', 'agent-full-access'], 'agent'),
+    onSetMode: async () => {
+      modeRequestCount += 1
+      if (modeRequestCount === 1) {
+        reviewerModeStarted.resolve()
+        await releaseReviewerMode.promise
+      }
+    }
+  })
+  const { lease } = createBackendLeaseHarness()
+  const runtime = new AcpRuntime({
+    appVersion: '0.1.0',
+    defaultCwd: '/workspace',
+    resolveBackend: () => ({
+      framework: { ...codexFramework, spawn: () => asAgentProcess(process) },
+      executablePath: '/bin/codex-acp',
+      env: {},
+      responsesBridgeLease: lease
+    })
+  })
+  const request = {
+    cwd: '/workspace',
+    mcpServers: [
+      {
+        type: 'http' as const,
+        name: 'open-science-reviewer',
+        url: 'http://127.0.0.1:1/mcp',
+        headers: []
+      }
+    ]
+  }
+  const reviewer = runtime.buildReviewerSession(request)
+  await reviewerModeStarted.promise
+
+  return {
+    fakeAgent,
+    lease,
+    runtime,
+    reviewer,
+    request,
+    releaseReviewerMode,
+    modeRequestCount: () => modeRequestCount
+  }
+}
+
 let temporaryRoot: string | undefined
 const temporaryDisconnections: Array<() => Promise<void>> = []
 
@@ -644,6 +707,9 @@ const handleSessionUpdate = (runtime: AcpRuntime, notification: SessionNotificat
 
 const reviewerSessionIds = (runtime: AcpRuntime): Set<string> =>
   (runtime as unknown as { reviewerSessionIds: Set<string> }).reviewerSessionIds
+
+const pendingReviewerSessionIds = (runtime: AcpRuntime): Set<string> =>
+  (runtime as unknown as { pendingReviewerSessionIds: Set<string> }).pendingReviewerSessionIds
 
 const permissionContext = (runtime: AcpRuntime): AcpPermissionContext =>
   (runtime as unknown as { permissionContext: AcpPermissionContext }).permissionContext
@@ -6255,6 +6321,123 @@ describe('ACP runtime session management', () => {
     expect(spawnAgent).not.toHaveBeenCalled()
   })
 
+  it('reserves a reviewer session id while its permission mode is still starting', async () => {
+    const {
+      fakeAgent,
+      lease,
+      runtime,
+      reviewer: first,
+      request,
+      releaseReviewerMode,
+      modeRequestCount
+    } = await startPendingReviewerRace(['shared-reviewer', 'shared-reviewer'])
+    const second = runtime.buildReviewerSession(request)
+
+    try {
+      await expect(second).rejects.toThrow('Reviewer session id collision: shared-reviewer')
+      expect(modeRequestCount()).toBe(1)
+      expect(lease.registerReviewerSession).not.toHaveBeenCalled()
+
+      const duplicateCwd = fakeAgent.newSessions[1]?.cwd
+      expect(duplicateCwd).toMatch(/open-science-reviewer-/)
+      await expect(stat(duplicateCwd!)).rejects.toMatchObject({ code: 'ENOENT' })
+
+      releaseReviewerMode.resolve()
+      const winner = await first
+      expect(lease.registerReviewerSession).toHaveBeenCalledOnce()
+      expect(lease.registerReviewerSession).toHaveBeenCalledWith('shared-reviewer')
+      await winner.session.prompt([{ type: 'text', text: 'winner keeps reviewer authority' }])
+      expect(fakeAgent.prompts).toEqual([
+        { sessionId: 'shared-reviewer', text: 'winner keeps reviewer authority' }
+      ])
+    } finally {
+      releaseReviewerMode.resolve()
+      await first.then(
+        ({ session }) => runtime.disposeReviewerSession(session),
+        () => undefined
+      )
+      await second.then(
+        ({ session }) => runtime.disposeReviewerSession(session),
+        () => undefined
+      )
+    }
+  })
+
+  it.each([
+    {
+      operation: 'new primary session',
+      agentSessionIds: ['shared-session', 'shared-session'],
+      collisionId: 'shared-session',
+      disposalFailure: 'primary collision dispose failed',
+      start: (runtime: AcpRuntime) => runtime.createSession({ cwd: '/workspace' })
+    },
+    {
+      operation: 'fresh adoption app-facing id',
+      agentSessionIds: ['stable-app-session', 'new-provider-session'],
+      collisionId: 'stable-app-session',
+      start: (runtime: AcpRuntime) =>
+        runtime.resumeSession({ sessionId: 'stable-app-session', cwd: '/workspace' })
+    },
+    {
+      operation: 'fresh adoption provider id',
+      agentSessionIds: ['reserved-provider-session', 'reserved-provider-session'],
+      collisionId: 'reserved-provider-session',
+      disposalFailure: 'adoption collision dispose failed',
+      start: (runtime: AcpRuntime) =>
+        runtime.resumeSession({ sessionId: 'stable-app-session', cwd: '/workspace' })
+    },
+    {
+      operation: 'resumed primary session',
+      agentSessionIds: ['123e4567-e89b-42d3-a456-426614174000'],
+      collisionId: '123e4567-e89b-42d3-a456-426614174000',
+      start: (runtime: AcpRuntime) =>
+        runtime.resumeSession({
+          sessionId: '123e4567-e89b-42d3-a456-426614174000',
+          cwd: '/workspace'
+        })
+    }
+  ])(
+    'rejects a pending reviewer identity collision from a $operation',
+    async ({ agentSessionIds, collisionId, disposalFailure, start }) => {
+      errorLogSpy.mockClear()
+      const { runtime, reviewer, releaseReviewerMode, modeRequestCount } =
+        await startPendingReviewerRace(agentSessionIds)
+      const disposeSpy = vi.spyOn(acp.ActiveSession.prototype, 'dispose')
+      if (disposalFailure) {
+        disposeSpy.mockImplementationOnce(() => {
+          throw new Error(disposalFailure)
+        })
+      }
+      const primary = start(runtime)
+
+      try {
+        await expect(primary).rejects.toThrow(
+          'Primary session id collision with pending reviewer: ' + collisionId
+        )
+        expect(disposeSpy).toHaveBeenCalledOnce()
+        expect(modeRequestCount()).toBe(1)
+        expect(runtime.getSnapshot().sessionIds).toEqual([])
+        if (disposalFailure) {
+          expect(errorLogSpy).toHaveBeenCalledWith('primary collision session disposal failed', {
+            errorCategory: 'error',
+            sessionId: collisionId
+          })
+        }
+      } finally {
+        disposeSpy.mockRestore()
+        await primary.then(
+          ({ sessionId }) => runtime.deleteSession({ sessionId }),
+          () => undefined
+        )
+        releaseReviewerMode.resolve()
+        await reviewer.then(
+          ({ session }) => runtime.disposeReviewerSession(session),
+          () => undefined
+        )
+      }
+    }
+  )
+
   it('rejects a reviewer session id that collides with a primary session before authority setup', async () => {
     const process = new FakeAgentProcess()
     const fakeAgent = startFakeAgent(process, ['shared-session', 'shared-session'])
@@ -6434,6 +6617,7 @@ describe('ACP runtime session management', () => {
     expect(reviewerCwd).toMatch(/open-science-reviewer-/)
     await expect(stat(reviewerCwd)).rejects.toMatchObject({ code: 'ENOENT' })
     expect(reviewerSessionIds(runtime).size).toBe(0)
+    expect(pendingReviewerSessionIds(runtime).size).toBe(0)
     expect(mcpServerNamesMap(runtime).has('reviewer-session-1')).toBe(false)
   })
 

--- a/src/main/acp/runtime.test.ts
+++ b/src/main/acp/runtime.test.ts
@@ -483,6 +483,70 @@ const startPendingReviewerRace = async (
   }
 }
 
+type StartPrimarySession = (runtime: AcpRuntime) => ReturnType<AcpRuntime['createSession']>
+
+const startPendingPrimaryRace = async (
+  sessionIds: string[],
+  startPrimary: StartPrimarySession
+): Promise<{
+  fakeAgent: ReturnType<typeof startFakeAgent>
+  lease: NonNullable<ResolvedAgentBackend['responsesBridgeLease']>
+  runtime: AcpRuntime
+  primary: ReturnType<AcpRuntime['createSession']>
+  reviewer: ReturnType<AcpRuntime['buildReviewerSession']>
+  releasePrimaryMode: Deferred
+  modeRequestCount: () => number
+}> => {
+  const process = new FakeAgentProcess()
+  const primaryModeStarted = createDeferred()
+  const releasePrimaryMode = createDeferred()
+  let modeRequestCount = 0
+  const fakeAgent = startFakeAgent(process, sessionIds, {
+    modes: createModes(['read-only', 'agent', 'agent-full-access'], 'agent'),
+    onSetMode: async () => {
+      modeRequestCount += 1
+      if (modeRequestCount === 1) {
+        primaryModeStarted.resolve()
+        await releasePrimaryMode.promise
+      }
+    }
+  })
+  const { lease } = createBackendLeaseHarness()
+  const runtime = new AcpRuntime({
+    appVersion: '0.1.0',
+    defaultCwd: '/workspace',
+    resolveBackend: () => ({
+      framework: { ...codexFramework, spawn: () => asAgentProcess(process) },
+      executablePath: '/bin/codex-acp',
+      env: {},
+      responsesBridgeLease: lease
+    })
+  })
+  const primary = startPrimary(runtime)
+  await primaryModeStarted.promise
+  const reviewer = runtime.buildReviewerSession({
+    cwd: '/workspace',
+    mcpServers: [
+      {
+        type: 'http',
+        name: 'open-science-reviewer',
+        url: 'http://127.0.0.1:1/mcp',
+        headers: []
+      }
+    ]
+  })
+
+  return {
+    fakeAgent,
+    lease,
+    runtime,
+    primary,
+    reviewer,
+    releasePrimaryMode,
+    modeRequestCount: () => modeRequestCount
+  }
+}
+
 let temporaryRoot: string | undefined
 const temporaryDisconnections: Array<() => Promise<void>> = []
 
@@ -710,6 +774,9 @@ const reviewerSessionIds = (runtime: AcpRuntime): Set<string> =>
 
 const pendingReviewerSessionIds = (runtime: AcpRuntime): Set<string> =>
   (runtime as unknown as { pendingReviewerSessionIds: Set<string> }).pendingReviewerSessionIds
+
+const pendingPrimarySessionIds = (runtime: AcpRuntime): Map<string, symbol> =>
+  (runtime as unknown as { pendingPrimarySessionIds: Map<string, symbol> }).pendingPrimarySessionIds
 
 const permissionContext = (runtime: AcpRuntime): AcpPermissionContext =>
   (runtime as unknown as { permissionContext: AcpPermissionContext }).permissionContext
@@ -6363,6 +6430,196 @@ describe('ACP runtime session management', () => {
     }
   })
 
+  it('reserves a new primary session id while its permission mode is still starting', async () => {
+    const { fakeAgent, lease, runtime, primary, reviewer, releasePrimaryMode, modeRequestCount } =
+      await startPendingPrimaryRace(['shared-session', 'shared-session'], (runtime) =>
+        runtime.createSession({ cwd: '/workspace' })
+      )
+
+    try {
+      await expect(reviewer).rejects.toThrow('Reviewer session id collision: shared-session')
+      expect(modeRequestCount()).toBe(1)
+      expect(lease.registerReviewerSession).not.toHaveBeenCalled()
+      expect([...pendingPrimarySessionIds(runtime).keys()]).toEqual(['shared-session'])
+
+      const duplicateCwd = fakeAgent.newSessions[1]?.cwd
+      expect(duplicateCwd).toMatch(/open-science-reviewer-/)
+      await expect(stat(duplicateCwd!)).rejects.toMatchObject({ code: 'ENOENT' })
+
+      releasePrimaryMode.resolve()
+      const winner = await primary
+      expect(pendingPrimarySessionIds(runtime).size).toBe(0)
+      expect(runtime.getSnapshot()).toMatchObject({
+        sessionIds: ['shared-session'],
+        permissionProfiles: {
+          'shared-session': {
+            selectedProfile: 'ask',
+            effectiveProfile: 'ask',
+            currentModeId: 'read-only'
+          }
+        }
+      })
+      await runtime.sendPrompt({
+        sessionId: winner.sessionId,
+        text: 'primary keeps normal authority'
+      })
+      expect(fakeAgent.prompts).toHaveLength(1)
+      expect(fakeAgent.prompts[0]).toMatchObject({ sessionId: 'shared-session' })
+      expect(fakeAgent.prompts[0]?.text).toContain('primary keeps normal authority')
+    } finally {
+      releasePrimaryMode.resolve()
+      await reviewer.then(
+        ({ session }) => runtime.disposeReviewerSession(session),
+        () => undefined
+      )
+      await primary.then(
+        ({ sessionId }) => runtime.deleteSession({ sessionId }),
+        () => undefined
+      )
+    }
+  })
+
+  it('reserves a resumed primary session id while its permission mode is still starting', async () => {
+    const sessionId = '123e4567-e89b-42d3-a456-426614174000'
+    const { fakeAgent, runtime, primary, reviewer, releasePrimaryMode, modeRequestCount } =
+      await startPendingPrimaryRace([sessionId], (runtime) =>
+        runtime.resumeSession({ sessionId, cwd: '/workspace' })
+      )
+
+    try {
+      await expect(reviewer).rejects.toThrow(
+        'Reviewer session id collision: 123e4567-e89b-42d3-a456-426614174000'
+      )
+      expect(modeRequestCount()).toBe(1)
+      expect([...pendingPrimarySessionIds(runtime).keys()]).toEqual([sessionId])
+
+      const duplicateCwd = fakeAgent.newSessions[0]?.cwd
+      expect(duplicateCwd).toMatch(/open-science-reviewer-/)
+      await expect(stat(duplicateCwd!)).rejects.toMatchObject({ code: 'ENOENT' })
+
+      releasePrimaryMode.resolve()
+      await expect(primary).resolves.toMatchObject({ sessionId })
+      expect(pendingPrimarySessionIds(runtime).size).toBe(0)
+      expect(runtime.getSnapshot().sessionIds).toEqual([sessionId])
+      await runtime.sendPrompt({ sessionId, text: 'resumed primary remains active' })
+      expect(fakeAgent.prompts).toHaveLength(1)
+      expect(fakeAgent.prompts[0]).toMatchObject({ sessionId })
+      expect(fakeAgent.prompts[0]?.text).toContain('resumed primary remains active')
+    } finally {
+      releasePrimaryMode.resolve()
+      await reviewer.then(
+        ({ session }) => runtime.disposeReviewerSession(session),
+        () => undefined
+      )
+      await primary.then(
+        ({ sessionId: resumedSessionId }) => runtime.deleteSession({ sessionId: resumedSessionId }),
+        () => undefined
+      )
+    }
+  })
+
+  it('reserves a fresh adoption app-facing id while its permission mode is still starting', async () => {
+    const { fakeAgent, runtime, primary, reviewer, releasePrimaryMode, modeRequestCount } =
+      await startPendingPrimaryRace(['new-provider-session', 'stable-app-session'], (runtime) =>
+        runtime.resumeSession({
+          sessionId: 'stable-app-session',
+          cwd: '/workspace'
+        })
+      )
+
+    try {
+      await expect(reviewer).rejects.toThrow('Reviewer session id collision: stable-app-session')
+      expect(modeRequestCount()).toBe(1)
+      expect([...pendingPrimarySessionIds(runtime).keys()]).toEqual([
+        'stable-app-session',
+        'new-provider-session'
+      ])
+
+      const duplicateCwd = fakeAgent.newSessions[1]?.cwd
+      expect(duplicateCwd).toMatch(/open-science-reviewer-/)
+      await expect(stat(duplicateCwd!)).rejects.toMatchObject({ code: 'ENOENT' })
+
+      releasePrimaryMode.resolve()
+      await expect(primary).resolves.toMatchObject({
+        sessionId: 'stable-app-session',
+        contextReset: true
+      })
+      expect(pendingPrimarySessionIds(runtime).size).toBe(0)
+      expect(runtime.getSnapshot().sessionIds).toEqual(['stable-app-session'])
+      await runtime.sendPrompt({
+        sessionId: 'stable-app-session',
+        text: 'adopted primary remains active'
+      })
+      expect(fakeAgent.prompts).toHaveLength(1)
+      expect(fakeAgent.prompts[0]).toMatchObject({ sessionId: 'new-provider-session' })
+      expect(fakeAgent.prompts[0]?.text).toContain('adopted primary remains active')
+    } finally {
+      releasePrimaryMode.resolve()
+      await reviewer.then(
+        ({ session }) => runtime.disposeReviewerSession(session),
+        () => undefined
+      )
+      await primary.then(
+        ({ sessionId }) => runtime.deleteSession({ sessionId }),
+        () => undefined
+      )
+    }
+  })
+
+  it('reserves a fresh adoption provider id while its permission mode is still starting', async () => {
+    const { fakeAgent, runtime, primary, reviewer, releasePrimaryMode, modeRequestCount } =
+      await startPendingPrimaryRace(
+        ['reserved-provider-session', 'reserved-provider-session'],
+        (runtime) =>
+          runtime.resumeSession({
+            sessionId: 'stable-app-session',
+            cwd: '/workspace'
+          })
+      )
+
+    try {
+      await expect(reviewer).rejects.toThrow(
+        'Reviewer session id collision: reserved-provider-session'
+      )
+      expect(modeRequestCount()).toBe(1)
+      expect([...pendingPrimarySessionIds(runtime).keys()]).toEqual([
+        'stable-app-session',
+        'reserved-provider-session'
+      ])
+
+      const duplicateCwd = fakeAgent.newSessions[1]?.cwd
+      expect(duplicateCwd).toMatch(/open-science-reviewer-/)
+      await expect(stat(duplicateCwd!)).rejects.toMatchObject({ code: 'ENOENT' })
+
+      releasePrimaryMode.resolve()
+      await expect(primary).resolves.toMatchObject({
+        sessionId: 'stable-app-session',
+        contextReset: true
+      })
+      expect(pendingPrimarySessionIds(runtime).size).toBe(0)
+      expect(runtime.getSnapshot().sessionIds).toEqual(['stable-app-session'])
+      await runtime.sendPrompt({
+        sessionId: 'stable-app-session',
+        text: 'provider-owned primary remains active'
+      })
+      expect(fakeAgent.prompts).toHaveLength(1)
+      expect(fakeAgent.prompts[0]).toMatchObject({
+        sessionId: 'reserved-provider-session'
+      })
+      expect(fakeAgent.prompts[0]?.text).toContain('provider-owned primary remains active')
+    } finally {
+      releasePrimaryMode.resolve()
+      await reviewer.then(
+        ({ session }) => runtime.disposeReviewerSession(session),
+        () => undefined
+      )
+      await primary.then(
+        ({ sessionId }) => runtime.deleteSession({ sessionId }),
+        () => undefined
+      )
+    }
+  })
+
   it.each([
     {
       operation: 'new primary session',
@@ -7154,6 +7411,7 @@ describe('ACP runtime session management', () => {
 
     expect(releaseSessionCapabilities).toHaveBeenCalledOnce()
     expect(releaseSessionCapabilities).toHaveBeenCalledWith('restored-session')
+    expect(pendingPrimarySessionIds(runtime).size).toBe(0)
   })
 
   it('releases the notebook RPC capability when fresh-session adoption fails', async () => {
@@ -7190,6 +7448,7 @@ describe('ACP runtime session management', () => {
 
     expect(releaseSessionCapabilities).toHaveBeenCalledOnce()
     expect(releaseSessionCapabilities).toHaveBeenCalledWith('switched-session')
+    expect(pendingPrimarySessionIds(runtime).size).toBe(0)
   })
 
   it('replaces a failed resume capability without revoking the adopted session capability', async () => {
@@ -12671,6 +12930,7 @@ describe('ACP runtime — session-creation and spawn diagnostics', () => {
     ).mockRejectedValueOnce(boom)
 
     await expect(runtime.createSession({ cwd: '/workspace' })).rejects.toBe(boom)
+    expect(pendingPrimarySessionIds(runtime).size).toBe(0)
 
     const call = errorLogSpy.mock.calls.find(
       ([message]) => message === 'createSession: configurePermissionProfile failed'

--- a/src/main/acp/runtime.test.ts
+++ b/src/main/acp/runtime.test.ts
@@ -8418,6 +8418,73 @@ describe('ACP runtime session management', () => {
     }
   })
 
+  it('does not let an invalidated context reset replace a same-id successor session', async () => {
+    const oldProcess = new FakeAgentProcess()
+    const newProcess = new FakeAgentProcess()
+    startFakeAgent(oldProcess, ['stable-app-session'])
+    const newAgent = startFakeAgent(newProcess, ['stale-reset-provider-session'])
+    let spawnCount = 0
+    const runtime = new AcpRuntime({
+      appVersion: '0.1.0',
+      defaultCwd: '/workspace',
+      resolveBackend: () => {
+        spawnCount += 1
+        return {
+          framework: {
+            ...claudeCodeFramework,
+            spawn: () => asAgentProcess(spawnCount === 1 ? oldProcess : newProcess)
+          },
+          executablePath: '/bin/agent',
+          env: {}
+        }
+      }
+    })
+    await runtime.createSession({ cwd: '/workspace' })
+
+    const ensureConnectedStarted = createDeferred()
+    const replacementConnection = createDeferred<unknown>()
+    const internal = runtime as unknown as {
+      connection: unknown
+      ensureConnected: (cwd: string) => Promise<unknown>
+    }
+    vi.spyOn(internal, 'ensureConnected').mockImplementationOnce(async () => {
+      ensureConnectedStarted.resolve()
+      return replacementConnection.promise
+    })
+
+    const reset = runtime.resetSessionContext({
+      sessionId: 'stable-app-session',
+      cwd: '/workspace'
+    })
+    await ensureConnectedStarted.promise
+    await runtime.disconnect()
+    const successor = await runtime.resumeSession({
+      sessionId: 'stable-app-session',
+      cwd: '/workspace'
+    })
+    replacementConnection.resolve(internal.connection)
+
+    try {
+      await expect(reset).rejects.toThrow('ACP session startup was superseded.')
+      expect(successor).toMatchObject({ sessionId: 'stable-app-session' })
+      expect(newAgent.newSessions).toHaveLength(0)
+      expect(runtime.getSnapshot().sessionIds).toEqual(['stable-app-session'])
+      await runtime.sendPrompt({
+        sessionId: 'stable-app-session',
+        text: 'successor remains active'
+      })
+      expect(newAgent.prompts.at(-1)).toMatchObject({
+        sessionId: 'stable-app-session',
+        text: expect.stringContaining('successor remains active')
+      })
+    } finally {
+      replacementConnection.resolve(internal.connection)
+      await reset.catch(() => undefined)
+      await runtime.deleteSession({ sessionId: 'stable-app-session' }).catch(() => undefined)
+      await runtime.disconnect().catch(() => undefined)
+    }
+  })
+
   it.each([
     {
       operation: 'new primary session',

--- a/src/main/acp/runtime.test.ts
+++ b/src/main/acp/runtime.test.ts
@@ -1582,6 +1582,47 @@ describe('ACP runtime session management', () => {
     promptGate.resolve()
   })
 
+  it('does not attribute a resumed session event to a prompt from a closed connection', async () => {
+    const sessionId = '123e4567-e89b-42d3-a456-426614174000'
+    const oldProcess = new FakeAgentProcess()
+    const newProcess = new FakeAgentProcess()
+    const oldPromptGate = createDeferred()
+    const oldAgent = startFakeAgent(oldProcess, [sessionId], {
+      onPrompt: () => oldPromptGate.promise
+    })
+    startFakeAgent(newProcess, [])
+    const events: AcpRuntimeEvent[] = []
+    let spawnCount = 0
+    const runtime = new AcpRuntime({
+      appVersion: '0.2.0',
+      defaultCwd: '/workspace',
+      spawnAgent: () => asAgentProcess(spawnCount++ === 0 ? oldProcess : newProcess),
+      callbacks: { onEvent: (event) => events.push(event) }
+    })
+
+    const session = await runtime.createSession({ cwd: '/workspace' })
+    const prompt = runtime
+      .sendPrompt({
+        sessionId: session.sessionId,
+        text: 'stay pending',
+        provenanceContext: { promptMessageId: 'closed-prompt-message' }
+      })
+      .catch(() => undefined)
+    await vi.waitFor(() => expect(oldAgent.prompts).toHaveLength(1))
+
+    oldProcess.stdout.end()
+    await vi.waitFor(() => expect(runtime.getSnapshot().status).toBe('closed'))
+
+    await runtime.resumeSession({ sessionId, cwd: '/workspace' })
+    const resumedEvent = events.filter((event) => event.title === 'Session resumed').at(-1)
+    expect(resumedEvent).toMatchObject({ kind: 'system', sessionId })
+    expect(resumedEvent?.promptMessageId).toBeUndefined()
+
+    oldPromptGate.resolve()
+    await prompt
+    await runtime.disconnect()
+  })
+
   it('shutdownForQuit latches shutting-down so a later connect is refused', async () => {
     const process = new FakeAgentProcess()
     startFakeAgent(process, ['quit-latch-session'])
@@ -2379,6 +2420,58 @@ describe('ACP runtime session management', () => {
     await expect(callConnector(replacementToken)).resolves.toMatchObject({ status: 200 })
     expect(connectorCall).toHaveBeenCalledOnce()
   })
+
+  it.each([true, false])(
+    'releases each Notebook capability generation exactly once across context reset and delete (replacement release: %s)',
+    async (replacementProvidesRelease) => {
+      const process = new FakeAgentProcess()
+      startFakeAgent(process, ['remote-session-1', 'remote-session-2'])
+      const capabilityReleases: Array<ReturnType<typeof vi.fn> | undefined> = []
+      const runtime = new AcpRuntime({
+        appVersion: '0.1.0',
+        defaultCwd: '/workspace',
+        spawnAgent: () => asAgentProcess(process),
+        notebook: {
+          projectName: 'default-project',
+          mcpEntryPath: '/app/out/main/index.js',
+          getRpcConnection: async () => {
+            const release =
+              capabilityReleases.length === 0 || replacementProvidesRelease ? vi.fn() : undefined
+            capabilityReleases.push(release)
+            return {
+              endpoint: 'http://127.0.0.1:4567',
+              token: `notebook-token-${capabilityReleases.length}`,
+              ...(release ? { release } : {})
+            }
+          }
+        }
+      })
+
+      try {
+        const session = await runtime.createSession({ cwd: '/workspace' })
+        expect(capabilityReleases).toHaveLength(1)
+        expect(capabilityReleases[0]).toBeDefined()
+        expect(capabilityReleases[0]).not.toHaveBeenCalled()
+
+        await runtime.resetSessionContext({ sessionId: session.sessionId, cwd: '/workspace' })
+        expect(capabilityReleases).toHaveLength(2)
+        expect(capabilityReleases[0]).toHaveBeenCalledOnce()
+        if (replacementProvidesRelease) {
+          expect(capabilityReleases[1]).not.toHaveBeenCalled()
+        } else {
+          expect(capabilityReleases[1]).toBeUndefined()
+        }
+
+        await runtime.deleteSession({ sessionId: session.sessionId })
+        expect(capabilityReleases[0]).toHaveBeenCalledOnce()
+        if (replacementProvidesRelease) {
+          expect(capabilityReleases[1]).toHaveBeenCalledOnce()
+        }
+      } finally {
+        await runtime.disconnect().catch(() => undefined)
+      }
+    }
+  )
 
   it('uses the framework native command to compact without adding command output to chat events', async () => {
     const process = new FakeAgentProcess()
@@ -4129,6 +4222,288 @@ describe('ACP runtime session management', () => {
       await httpHost.close()
     }
   })
+
+  it('cleans provisional http MCP routes when fresh adoption collides', async () => {
+    const root = await createTemporaryRoot()
+    const httpHost = {
+      ensureStarted: vi.fn(async () => ({
+        endpoint: 'http://127.0.0.1:4321',
+        token: 'host-token'
+      })),
+      registerArtifact: vi.fn(),
+      registerNotebook: vi.fn(),
+      registerSkillImport: vi.fn(),
+      urlFor: vi.fn(
+        (kind: string, routingId: string) =>
+          `http://127.0.0.1:4321/mcp/${kind}/${encodeURIComponent(routingId)}`
+      ),
+      unregister: vi.fn(),
+      clear: vi.fn(),
+      close: vi.fn(async () => undefined)
+    } as unknown as AgentMcpHttpHost
+    const process = new FakeAgentProcess()
+    const reviewerModeStarted = createDeferred()
+    const releaseReviewerMode = createDeferred()
+    const fakeAgent = startFakeAgent(
+      process,
+      ['reserved-provider-session', 'reserved-provider-session'],
+      {
+        modes: createModes(['read-only', 'agent', 'agent-full-access'], 'agent'),
+        onSetMode: async () => {
+          reviewerModeStarted.resolve()
+          await releaseReviewerMode.promise
+        }
+      }
+    )
+    const runtime = new AcpRuntime({
+      appVersion: '0.1.0',
+      defaultCwd: '/workspace',
+      resolveBackend: () => ({
+        framework: {
+          ...codexFramework,
+          acceptsStdioMcp: false,
+          spawn: () => asAgentProcess(process)
+        },
+        executablePath: '/bin/codex-acp',
+        env: {}
+      }),
+      mcpHttpHost: httpHost,
+      artifacts: {
+        configRoot: root,
+        dataRoot: root,
+        projectName: 'default-project',
+        mcpEntryPath: '/app/out/main/index.js'
+      },
+      notebook: {
+        projectName: 'default-project',
+        mcpEntryPath: '/app/out/main/index.js',
+        getRpcConnection: async () => ({ endpoint: 'http://127.0.0.1:4567', token: 'nb' })
+      },
+      skillImport: {
+        mcpEntryPath: '/app/out/main/index.js',
+        getRpcConnection: async () => ({
+          endpoint: 'http://127.0.0.1:4568',
+          token: 'skill'
+        })
+      }
+    })
+    const reviewer = runtime.buildReviewerSession({
+      cwd: '/workspace',
+      mcpServers: [
+        {
+          type: 'http',
+          name: 'open-science-reviewer',
+          url: 'http://127.0.0.1:1/mcp',
+          headers: []
+        }
+      ]
+    })
+    await reviewerModeStarted.promise
+
+    try {
+      await expect(
+        runtime.resumeSession({ sessionId: 'stable-app-session', cwd: '/workspace' })
+      ).rejects.toThrow(
+        'Primary session id collision with pending reviewer: reserved-provider-session'
+      )
+      expect(fakeAgent.newSessions).toHaveLength(2)
+      expect(httpHost.registerArtifact).toHaveBeenCalledWith(
+        'stable-app-session',
+        expect.any(Object)
+      )
+      expect(httpHost.registerNotebook).toHaveBeenCalledWith(
+        'stable-app-session',
+        expect.any(Object)
+      )
+      expect(httpHost.registerSkillImport).toHaveBeenCalledWith(
+        'stable-app-session',
+        expect.any(Object)
+      )
+      expect(httpHost.unregister).toHaveBeenCalledOnce()
+      expect(httpHost.unregister).toHaveBeenCalledWith('stable-app-session')
+    } finally {
+      releaseReviewerMode.resolve()
+      await reviewer.then(
+        ({ session }) => runtime.disposeReviewerSession(session),
+        () => undefined
+      )
+      await runtime.disconnect().catch(() => undefined)
+    }
+  })
+
+  it('continues partial provisional route cleanup without replacing the startup error', async () => {
+    const root = await createTemporaryRoot()
+    const startupFailure = new Error('notebook capability setup failed')
+    let unregisterAttempt = 0
+    const unregister = vi.fn((routingId: string) => {
+      void routingId
+      unregisterAttempt += 1
+      if (unregisterAttempt === 1) {
+        throw new Error('first provisional route cleanup failed')
+      }
+    })
+    const httpHost = {
+      ensureStarted: vi.fn(async () => ({
+        endpoint: 'http://127.0.0.1:4321',
+        token: 'host-token'
+      })),
+      registerArtifact: vi.fn(),
+      registerNotebook: vi.fn(),
+      registerSkillImport: vi.fn(),
+      urlFor: vi.fn(
+        (kind: string, routingId: string) =>
+          `http://127.0.0.1:4321/mcp/${kind}/${encodeURIComponent(routingId)}`
+      ),
+      unregister,
+      clear: vi.fn(),
+      close: vi.fn(async () => undefined)
+    } as unknown as AgentMcpHttpHost
+    const process = new FakeAgentProcess()
+    startFakeAgent(process, [])
+    const runtime = new AcpRuntime({
+      appVersion: '0.1.0',
+      defaultCwd: '/workspace',
+      spawnAgent: () => asAgentProcess(process),
+      framework: { ...opencodeFramework, acceptsStdioMcp: false },
+      mcpHttpHost: httpHost,
+      artifacts: {
+        configRoot: root,
+        dataRoot: root,
+        projectName: 'default-project',
+        mcpEntryPath: '/app/out/main/index.js'
+      },
+      notebook: {
+        projectName: 'default-project',
+        mcpEntryPath: '/app/out/main/index.js',
+        getRpcConnection: async () => {
+          throw startupFailure
+        }
+      },
+      skillImport: {
+        mcpEntryPath: '/app/out/main/index.js',
+        getRpcConnection: async () => ({
+          endpoint: 'http://127.0.0.1:4568',
+          token: 'skill'
+        })
+      }
+    })
+
+    await expect(runtime.createSession({ cwd: '/workspace' })).rejects.toBe(startupFailure)
+
+    expect(httpHost.registerArtifact).toHaveBeenCalledOnce()
+    expect(httpHost.registerNotebook).not.toHaveBeenCalled()
+    expect(httpHost.registerSkillImport).not.toHaveBeenCalled()
+    expect(unregister).toHaveBeenCalledTimes(3)
+    expect(new Set(unregister.mock.calls.map(([routingId]) => routingId)).size).toBe(3)
+  })
+
+  it.each(['notebook alias', 'skill alias', 'specialist registration', 'event', 'state'] as const)(
+    'keeps published http MCP ownership when the %s callback throws',
+    async (failingCallback) => {
+      const httpHost = {
+        ensureStarted: vi.fn(async () => ({
+          endpoint: 'http://127.0.0.1:4321',
+          token: 'host-token'
+        })),
+        registerNotebook: vi.fn(),
+        registerSkillImport: vi.fn(),
+        urlFor: vi.fn(
+          (kind: string, routingId: string) =>
+            `http://127.0.0.1:4321/mcp/${kind}/${encodeURIComponent(routingId)}`
+        ),
+        unregister: vi.fn(),
+        clear: vi.fn(),
+        close: vi.fn(async () => undefined)
+      } as unknown as AgentMcpHttpHost
+      const release = vi.fn()
+      const process = new FakeAgentProcess()
+      const fakeAgent = startFakeAgent(process, ['published-session'])
+      let observerFailurePending = true
+      const runtime = new AcpRuntime({
+        appVersion: '0.1.0',
+        defaultCwd: '/workspace',
+        spawnAgent: () => asAgentProcess(process),
+        framework: { ...opencodeFramework, acceptsStdioMcp: false },
+        mcpHttpHost: httpHost,
+        callbacks: {
+          onEvent: (event) => {
+            if (
+              observerFailurePending &&
+              failingCallback === 'event' &&
+              event.sessionId === 'published-session'
+            ) {
+              observerFailurePending = false
+              throw new Error('event callback failed')
+            }
+          },
+          onStateChanged: (snapshot) => {
+            if (
+              observerFailurePending &&
+              failingCallback === 'state' &&
+              snapshot.sessionIds.includes('published-session')
+            ) {
+              observerFailurePending = false
+              throw new Error('state callback failed')
+            }
+          }
+        },
+        notebook: {
+          projectName: 'default-project',
+          mcpEntryPath: '/app/out/main/index.js',
+          getRpcConnection: async () => ({
+            endpoint: 'http://127.0.0.1:4567',
+            token: 'notebook-token',
+            release
+          }),
+          registerSessionAlias: () => {
+            if (failingCallback === 'notebook alias') {
+              throw new Error('notebook alias callback failed')
+            }
+          },
+          registerSessionSpecialist: () => {
+            if (failingCallback === 'specialist registration') {
+              throw new Error('specialist registration callback failed')
+            }
+          }
+        },
+        skillImport: {
+          mcpEntryPath: '/app/out/main/index.js',
+          getRpcConnection: async () => ({
+            endpoint: 'http://127.0.0.1:4568',
+            token: 'skill-import-token'
+          }),
+          registerSessionAlias: () => {
+            if (failingCallback === 'skill alias') {
+              throw new Error('skill alias callback failed')
+            }
+          }
+        }
+      })
+
+      try {
+        await expect(runtime.createSession({ cwd: '/workspace' })).resolves.toMatchObject({
+          sessionId: 'published-session'
+        })
+        expect(runtime.getSnapshot().sessionIds).toEqual(['published-session'])
+        expect(httpHost.unregister).not.toHaveBeenCalled()
+        expect(release).not.toHaveBeenCalled()
+
+        await runtime.sendPrompt({ sessionId: 'published-session', text: 'still usable' })
+        expect(fakeAgent.prompts.at(-1)).toMatchObject({
+          sessionId: 'published-session',
+          text: expect.stringContaining('still usable')
+        })
+
+        await runtime.deleteSession({ sessionId: 'published-session' })
+        expect(release).toHaveBeenCalledOnce()
+      } finally {
+        if (runtime.getSnapshot().sessionIds.includes('published-session')) {
+          await runtime.deleteSession({ sessionId: 'published-session' }).catch(() => undefined)
+        }
+        await runtime.disconnect().catch(() => undefined)
+      }
+    }
+  )
 
   it('allows prompts from different sessions to run concurrently', async () => {
     const process = new FakeAgentProcess()
@@ -7511,6 +7886,7 @@ describe('ACP runtime session management', () => {
       const process = new FakeAgentProcess()
       const staleModeStarted = createDeferred()
       const releaseStaleMode = createDeferred()
+      const capabilityReleases: ReturnType<typeof vi.fn>[] = []
       startFakeAgent(process, ['stale-provider', 'successor-provider'], {
         modes: createModes(['read-only', 'agent', 'agent-full-access'], 'agent'),
         onSetMode: async ({ modeId }) => {
@@ -7524,10 +7900,41 @@ describe('ACP runtime session management', () => {
         appVersion: '0.1.0',
         defaultCwd: '/workspace',
         resolveBackend: () => ({
-          framework: { ...codexFramework, spawn: () => asAgentProcess(process) },
+          framework: {
+            ...codexFramework,
+            acceptsStdioMcp: false,
+            spawn: () => asAgentProcess(process)
+          },
           executablePath: '/bin/codex-acp',
           env: {}
         }),
+        mcpHttpHost: {
+          ensureStarted: vi.fn(async () => ({
+            endpoint: 'http://127.0.0.1:4321',
+            token: 'host-token'
+          })),
+          registerNotebook: vi.fn(),
+          urlFor: vi.fn(
+            (kind: string, routingId: string) =>
+              `http://127.0.0.1:4321/mcp/${kind}/${encodeURIComponent(routingId)}`
+          ),
+          unregister: vi.fn(),
+          clear: vi.fn(),
+          close: vi.fn(async () => undefined)
+        } as unknown as AgentMcpHttpHost,
+        notebook: {
+          projectName: 'default-project',
+          mcpEntryPath: '/app/out/main/index.js',
+          getRpcConnection: async () => {
+            const release = vi.fn()
+            capabilityReleases.push(release)
+            return {
+              endpoint: 'http://127.0.0.1:4567',
+              token: `notebook-token-${capabilityReleases.length}`,
+              release
+            }
+          }
+        },
         resolveSpecialistIdentity: async (specialistId) => ({
           append: '',
           prefix: `${specialistId} prefix`
@@ -7578,6 +7985,12 @@ describe('ACP runtime session management', () => {
         expect(sessionSpecialistIds(runtime).has(sessionId)).toBe(false)
         expect(sessionSpecialistPrefixes(runtime).has(sessionId)).toBe(false)
         expect(runtime.getSnapshot().sessionIds).toEqual([sessionId])
+        expect(
+          (runtime as unknown as { mcpHttpHost: AgentMcpHttpHost }).mcpHttpHost.unregister
+        ).not.toHaveBeenCalled()
+        expect(capabilityReleases).toHaveLength(2)
+        expect(capabilityReleases[0]).toHaveBeenCalledOnce()
+        expect(capabilityReleases[1]).not.toHaveBeenCalled()
       } finally {
         releaseStaleMode.resolve()
         await staleOutcome
@@ -8790,6 +9203,123 @@ describe('ACP runtime session management', () => {
       disposeSpy.mockRestore()
     }
   })
+
+  it.each([
+    {
+      path: 'resume event',
+      failingObserver: 'event' as const,
+      previousFrameworkId: undefined,
+      contextReset: undefined,
+      providerSessionIds: []
+    },
+    {
+      path: 'resume state',
+      failingObserver: 'state' as const,
+      previousFrameworkId: undefined,
+      contextReset: undefined,
+      providerSessionIds: []
+    },
+    {
+      path: 'fresh-adoption state',
+      failingObserver: 'state' as const,
+      previousFrameworkId: 'opencode' as const,
+      contextReset: true,
+      providerSessionIds: ['adopted-provider-session']
+    }
+  ])(
+    'keeps a published $path session usable when its observer throws',
+    async ({ failingObserver, previousFrameworkId, contextReset, providerSessionIds }) => {
+      const sessionId =
+        previousFrameworkId === undefined
+          ? '123e4567-e89b-42d3-a456-426614174000'
+          : 'stable-app-session'
+      const httpHost = {
+        ensureStarted: vi.fn(async () => ({
+          endpoint: 'http://127.0.0.1:4321',
+          token: 'host-token'
+        })),
+        registerNotebook: vi.fn(),
+        urlFor: vi.fn(
+          (kind: string, routingId: string) =>
+            `http://127.0.0.1:4321/mcp/${kind}/${encodeURIComponent(routingId)}`
+        ),
+        unregister: vi.fn(),
+        clear: vi.fn(),
+        close: vi.fn(async () => undefined)
+      } as unknown as AgentMcpHttpHost
+      const release = vi.fn()
+      const process = new FakeAgentProcess()
+      const fakeAgent = startFakeAgent(process, [...providerSessionIds], {
+        modes: createModes(['read-only', 'agent', 'agent-full-access'], 'read-only')
+      })
+      let observerFailurePending = true
+      const runtime = new AcpRuntime({
+        appVersion: '0.1.0',
+        defaultCwd: '/workspace',
+        spawnAgent: () => asAgentProcess(process),
+        framework: { ...codexFramework, acceptsStdioMcp: false },
+        mcpHttpHost: httpHost,
+        callbacks: {
+          onEvent: (event) => {
+            if (
+              observerFailurePending &&
+              failingObserver === 'event' &&
+              event.sessionId === sessionId
+            ) {
+              observerFailurePending = false
+              throw new Error('resume event callback failed')
+            }
+          },
+          onStateChanged: (snapshot) => {
+            if (
+              observerFailurePending &&
+              failingObserver === 'state' &&
+              snapshot.sessionIds.includes(sessionId)
+            ) {
+              observerFailurePending = false
+              throw new Error('session state callback failed')
+            }
+          }
+        },
+        notebook: {
+          projectName: 'default-project',
+          mcpEntryPath: '/app/out/main/index.js',
+          getRpcConnection: async () => ({
+            endpoint: 'http://127.0.0.1:4567',
+            token: 'notebook-token',
+            release
+          })
+        }
+      })
+
+      try {
+        await expect(
+          runtime.resumeSession({
+            sessionId,
+            cwd: '/workspace',
+            ...(previousFrameworkId ? { previousFrameworkId } : {})
+          })
+        ).resolves.toMatchObject({ sessionId, ...(contextReset ? { contextReset } : {}) })
+        expect(runtime.getSnapshot().sessionIds).toEqual([sessionId])
+        expect(httpHost.unregister).not.toHaveBeenCalled()
+        expect(release).not.toHaveBeenCalled()
+
+        await runtime.sendPrompt({ sessionId, text: 'still usable' })
+        expect(fakeAgent.prompts.at(-1)).toMatchObject({
+          sessionId: previousFrameworkId ? 'adopted-provider-session' : sessionId,
+          text: expect.stringContaining('still usable')
+        })
+
+        await runtime.deleteSession({ sessionId })
+        expect(release).toHaveBeenCalledOnce()
+      } finally {
+        if (runtime.getSnapshot().sessionIds.includes(sessionId)) {
+          await runtime.deleteSession({ sessionId }).catch(() => undefined)
+        }
+        await runtime.disconnect().catch(() => undefined)
+      }
+    }
+  )
 
   it('replaces a failed resume capability without revoking the adopted session capability', async () => {
     const process = new FakeAgentProcess()

--- a/src/main/acp/runtime.test.ts
+++ b/src/main/acp/runtime.test.ts
@@ -779,8 +779,9 @@ const handleSessionUpdate = (runtime: AcpRuntime, notification: SessionNotificat
 const reviewerSessionIds = (runtime: AcpRuntime): Set<string> =>
   (runtime as unknown as { reviewerSessionIds: Set<string> }).reviewerSessionIds
 
-const pendingReviewerSessionIds = (runtime: AcpRuntime): Set<string> =>
-  (runtime as unknown as { pendingReviewerSessionIds: Set<string> }).pendingReviewerSessionIds
+const pendingReviewerSessionIds = (runtime: AcpRuntime): Map<string, symbol> =>
+  (runtime as unknown as { pendingReviewerSessionIds: Map<string, symbol> })
+    .pendingReviewerSessionIds
 
 const pendingPrimarySessionIds = (runtime: AcpRuntime): Map<string, symbol> =>
   (runtime as unknown as { pendingPrimarySessionIds: Map<string, symbol> }).pendingPrimarySessionIds
@@ -6437,22 +6438,110 @@ describe('ACP runtime session management', () => {
     }
   })
 
-  it('invalidates a pending reviewer startup before a failing disconnect can strand it', async () => {
-    const process = new FakeAgentProcess()
-    const reviewerModeStarted = createDeferred()
-    const releaseReviewerMode = createDeferred()
-    let modeRequestCount = 0
-    startFakeAgent(process, ['primary-session', 'stale-reviewer'], {
-      modes: createModes(['read-only', 'agent', 'agent-full-access'], 'agent'),
-      onSetMode: async () => {
-        modeRequestCount += 1
-        if (modeRequestCount === 2) {
-          reviewerModeStarted.resolve()
-          await releaseReviewerMode.promise
+  it.each([
+    {
+      teardown: 'disconnect',
+      runTeardown: (runtime: AcpRuntime) => runtime.disconnect(),
+      canStartSuccessor: true
+    },
+    {
+      teardown: 'reconnect',
+      runTeardown: (runtime: AcpRuntime) => runtime.connect({ cwd: '/workspace' }),
+      canStartSuccessor: false
+    }
+  ])(
+    'invalidates a pending reviewer startup before a failing $teardown can strand it',
+    async ({ runTeardown, canStartSuccessor }) => {
+      const process = new FakeAgentProcess()
+      const reviewerModeStarted = createDeferred()
+      const releaseReviewerMode = createDeferred()
+      let modeRequestCount = 0
+      startFakeAgent(process, ['primary-session', 'stale-reviewer', 'stale-reviewer'], {
+        modes: createModes(['read-only', 'agent', 'agent-full-access'], 'agent'),
+        onSetMode: async () => {
+          modeRequestCount += 1
+          if (modeRequestCount === 2) {
+            reviewerModeStarted.resolve()
+            await releaseReviewerMode.promise
+          }
         }
+      })
+      const { lease } = createBackendLeaseHarness()
+      const runtime = new AcpRuntime({
+        appVersion: '0.1.0',
+        defaultCwd: '/workspace',
+        resolveBackend: () => ({
+          framework: { ...codexFramework, spawn: () => asAgentProcess(process) },
+          executablePath: '/bin/codex-acp',
+          env: {},
+          responsesBridgeLease: lease
+        })
+      })
+      const primary = await runtime.createSession({ cwd: '/workspace' })
+      const activePrimary = (
+        runtime as unknown as { sessions: Map<string, { dispose: () => void }> }
+      ).sessions.get(primary.sessionId)!
+      const disposePrimary = activePrimary.dispose.bind(activePrimary)
+      activePrimary.dispose = vi.fn(() => {
+        throw new Error('primary disconnect dispose failed')
+      })
+      const reviewerRequest: Parameters<AcpRuntime['buildReviewerSession']>[0] = {
+        cwd: '/workspace',
+        mcpServers: [
+          {
+            type: 'http',
+            name: 'open-science-reviewer',
+            url: 'http://127.0.0.1:1/mcp',
+            headers: []
+          }
+        ]
       }
+      const reviewer = runtime.buildReviewerSession(reviewerRequest)
+      await reviewerModeStarted.promise
+      let successor: Awaited<ReturnType<AcpRuntime['buildReviewerSession']>> | undefined
+
+      try {
+        expect(pendingReviewerSessionIds(runtime).has('stale-reviewer')).toBe(true)
+
+        await expect(runTeardown(runtime)).rejects.toThrow('primary disconnect dispose failed')
+
+        expect(pendingReviewerSessionIds(runtime).size).toBe(0)
+        if (canStartSuccessor) {
+          successor = await runtime.buildReviewerSession(reviewerRequest)
+          expect(reviewerSessionIds(runtime)).toEqual(new Set(['stale-reviewer']))
+        }
+
+        releaseReviewerMode.resolve()
+        await expect(reviewer).rejects.toThrow('ACP session startup was superseded.')
+        if (canStartSuccessor) {
+          expect(reviewerSessionIds(runtime)).toEqual(new Set(['stale-reviewer']))
+        } else {
+          expect(reviewerSessionIds(runtime).size).toBe(0)
+        }
+        expect(lease.registerReviewerSession).not.toHaveBeenCalled()
+      } finally {
+        releaseReviewerMode.resolve()
+        await reviewer.then(
+          ({ session }) => runtime.disposeReviewerSession(session),
+          () => undefined
+        )
+        if (successor) runtime.disposeReviewerSession(successor.session)
+        activePrimary.dispose = disposePrimary
+        await runtime.disconnect().catch(() => undefined)
+      }
+    }
+  )
+
+  it('completes unexpected-close cleanup when one reviewer bridge unregister throws', async () => {
+    const process = new FakeAgentProcess()
+    const fakeAgent = startFakeAgent(process, ['reviewer-one', 'reviewer-two'], {
+      modes: createModes(['read-only', 'agent', 'agent-full-access'], 'read-only')
     })
-    const { lease } = createBackendLeaseHarness()
+    const { lease, release } = createBackendLeaseHarness()
+    lease.unregisterReviewerSession = vi.fn((sessionId: string) => {
+      if (sessionId === 'reviewer-one') throw new Error('reviewer unregister failed')
+      return false
+    })
     const runtime = new AcpRuntime({
       appVersion: '0.1.0',
       defaultCwd: '/workspace',
@@ -6463,15 +6552,7 @@ describe('ACP runtime session management', () => {
         responsesBridgeLease: lease
       })
     })
-    const primary = await runtime.createSession({ cwd: '/workspace' })
-    const activePrimary = (
-      runtime as unknown as { sessions: Map<string, { dispose: () => void }> }
-    ).sessions.get(primary.sessionId)!
-    const disposePrimary = activePrimary.dispose.bind(activePrimary)
-    activePrimary.dispose = vi.fn(() => {
-      throw new Error('primary disconnect dispose failed')
-    })
-    const reviewer = runtime.buildReviewerSession({
+    const reviewerRequest: Parameters<AcpRuntime['buildReviewerSession']>[0] = {
       cwd: '/workspace',
       mcpServers: [
         {
@@ -6481,27 +6562,30 @@ describe('ACP runtime session management', () => {
           headers: []
         }
       ]
-    })
-    await reviewerModeStarted.promise
+    }
+    await runtime.buildReviewerSession(reviewerRequest)
+    await runtime.buildReviewerSession(reviewerRequest)
+    const reviewerCwds = fakeAgent.newSessions.map(({ cwd }) => cwd)
+    await runtime.requestProviderReconnect()
+    const handleConnectionClosed = (
+      runtime as unknown as { handleConnectionClosed: () => void }
+    ).handleConnectionClosed.bind(runtime)
 
     try {
-      expect(pendingReviewerSessionIds(runtime).has('stale-reviewer')).toBe(true)
-
-      await expect(runtime.disconnect()).rejects.toThrow('primary disconnect dispose failed')
-
-      expect(pendingReviewerSessionIds(runtime).size).toBe(0)
-      releaseReviewerMode.resolve()
-      await expect(reviewer).rejects.toThrow('ACP session startup was superseded.')
+      expect(handleConnectionClosed).not.toThrow()
+      expect(lease.unregisterReviewerSession).toHaveBeenCalledWith('reviewer-one')
+      expect(lease.unregisterReviewerSession).toHaveBeenCalledWith('reviewer-two')
       expect(reviewerSessionIds(runtime).size).toBe(0)
-      expect(lease.registerReviewerSession).not.toHaveBeenCalled()
+      expect(
+        (runtime as unknown as { reconnectBarrier?: Promise<void> }).reconnectBarrier
+      ).toBeUndefined()
+      await vi.waitFor(() => expect(release).toHaveBeenCalledOnce())
+      for (const reviewerCwd of reviewerCwds) {
+        await expect(stat(reviewerCwd)).rejects.toMatchObject({ code: 'ENOENT' })
+      }
     } finally {
-      releaseReviewerMode.resolve()
-      await reviewer.then(
-        ({ session }) => runtime.disposeReviewerSession(session),
-        () => undefined
-      )
-      activePrimary.dispose = disposePrimary
-      await runtime.disconnect().catch(() => undefined)
+      lease.unregisterReviewerSession = vi.fn(() => false)
+      if (reviewerSessionIds(runtime).size > 0) handleConnectionClosed()
     }
   })
 
@@ -6701,19 +6785,97 @@ describe('ACP runtime session management', () => {
     }
   })
 
-  it('invalidates a pending primary startup before a failing disconnect can strand it', async () => {
+  it.each([
+    {
+      teardown: 'disconnect',
+      runTeardown: (runtime: AcpRuntime) => runtime.disconnect(),
+      canStartSuccessor: true
+    },
+    {
+      teardown: 'reconnect',
+      runTeardown: (runtime: AcpRuntime) => runtime.connect({ cwd: '/workspace' }),
+      canStartSuccessor: false
+    }
+  ])(
+    'invalidates a pending primary startup before a failing $teardown can strand it',
+    async ({ runTeardown, canStartSuccessor }) => {
+      const process = new FakeAgentProcess()
+      const pendingModeStarted = createDeferred()
+      const releasePendingMode = createDeferred()
+      let modeRequestCount = 0
+      startFakeAgent(process, ['active-primary', 'stale-primary', 'stale-primary'], {
+        modes: createModes(['read-only', 'agent', 'agent-full-access'], 'agent'),
+        onSetMode: async () => {
+          modeRequestCount += 1
+          if (modeRequestCount === 2) {
+            pendingModeStarted.resolve()
+            await releasePendingMode.promise
+          }
+        }
+      })
+      const runtime = new AcpRuntime({
+        appVersion: '0.1.0',
+        defaultCwd: '/workspace',
+        resolveBackend: () => ({
+          framework: { ...codexFramework, spawn: () => asAgentProcess(process) },
+          executablePath: '/bin/codex-acp',
+          env: {}
+        })
+      })
+      const active = await runtime.createSession({ cwd: '/workspace' })
+      const activeSession = (
+        runtime as unknown as { sessions: Map<string, { dispose: () => void }> }
+      ).sessions.get(active.sessionId)!
+      const disposeActive = activeSession.dispose.bind(activeSession)
+      activeSession.dispose = vi.fn(() => {
+        throw new Error('active primary disconnect dispose failed')
+      })
+      const pending = runtime.createSession({ cwd: '/workspace' })
+      await pendingModeStarted.promise
+      let successor: Awaited<ReturnType<AcpRuntime['createSession']>> | undefined
+
+      try {
+        expect([...pendingPrimarySessionIds(runtime).keys()]).toEqual(['stale-primary'])
+
+        await expect(runTeardown(runtime)).rejects.toThrow(
+          'active primary disconnect dispose failed'
+        )
+
+        expect(pendingPrimarySessionIds(runtime).size).toBe(0)
+        if (canStartSuccessor) {
+          successor = await runtime.createSession({ cwd: '/workspace' })
+          expect(runtime.getSnapshot().sessionIds).toContain('stale-primary')
+        }
+
+        releasePendingMode.resolve()
+        await expect(pending).rejects.toThrow('ACP session startup was superseded.')
+        if (canStartSuccessor) {
+          expect(runtime.getSnapshot().sessionIds).toContain('stale-primary')
+        } else {
+          expect(runtime.getSnapshot().sessionIds).not.toContain('stale-primary')
+        }
+      } finally {
+        releasePendingMode.resolve()
+        await pending.then(
+          ({ sessionId }) => runtime.deleteSession({ sessionId }),
+          () => undefined
+        )
+        if (successor) await runtime.deleteSession({ sessionId: successor.sessionId })
+        activeSession.dispose = disposeActive
+        await runtime.disconnect().catch(() => undefined)
+      }
+    }
+  )
+
+  it('disposes a created primary session when teardown invalidates its startup', async () => {
     const process = new FakeAgentProcess()
     const pendingModeStarted = createDeferred()
     const releasePendingMode = createDeferred()
-    let modeRequestCount = 0
-    startFakeAgent(process, ['active-primary', 'stale-primary'], {
+    startFakeAgent(process, ['stale-primary'], {
       modes: createModes(['read-only', 'agent', 'agent-full-access'], 'agent'),
       onSetMode: async () => {
-        modeRequestCount += 1
-        if (modeRequestCount === 2) {
-          pendingModeStarted.resolve()
-          await releasePendingMode.promise
-        }
+        pendingModeStarted.resolve()
+        await releasePendingMode.promise
       }
     })
     const runtime = new AcpRuntime({
@@ -6725,33 +6887,33 @@ describe('ACP runtime session management', () => {
         env: {}
       })
     })
-    const active = await runtime.createSession({ cwd: '/workspace' })
-    const activeSession = (
-      runtime as unknown as { sessions: Map<string, { dispose: () => void }> }
-    ).sessions.get(active.sessionId)!
-    const disposeActive = activeSession.dispose.bind(activeSession)
-    activeSession.dispose = vi.fn(() => {
-      throw new Error('active primary disconnect dispose failed')
-    })
+    await runtime.connect({ cwd: '/workspace' })
+    const disposeSpy = vi.spyOn(acp.ActiveSession.prototype, 'dispose')
+    const disconnectCurrentSpy = vi
+      .spyOn(
+        runtime as unknown as {
+          disconnectCurrent: (emitClosedStatus?: boolean) => Promise<AcpStateSnapshot>
+        },
+        'disconnectCurrent'
+      )
+      .mockRejectedValueOnce(new Error('disconnect teardown failed'))
     const pending = runtime.createSession({ cwd: '/workspace' })
     await pendingModeStarted.promise
 
     try {
-      expect([...pendingPrimarySessionIds(runtime).keys()]).toEqual(['stale-primary'])
-
-      await expect(runtime.disconnect()).rejects.toThrow('active primary disconnect dispose failed')
-
-      expect(pendingPrimarySessionIds(runtime).size).toBe(0)
+      await expect(runtime.disconnect()).rejects.toThrow('disconnect teardown failed')
       releasePendingMode.resolve()
+
       await expect(pending).rejects.toThrow('ACP session startup was superseded.')
-      expect(runtime.getSnapshot().sessionIds).not.toContain('stale-primary')
+      expect(disposeSpy).toHaveBeenCalledOnce()
+      expect(
+        (disposeSpy.mock.instances[0] as unknown as { sessionId?: string })?.sessionId
+      ).toBe('stale-primary')
     } finally {
       releasePendingMode.resolve()
-      await pending.then(
-        ({ sessionId }) => runtime.deleteSession({ sessionId }),
-        () => undefined
-      )
-      activeSession.dispose = disposeActive
+      await pending.catch(() => undefined)
+      disconnectCurrentSpy.mockRestore()
+      disposeSpy.mockRestore()
       await runtime.disconnect().catch(() => undefined)
     }
   })
@@ -6789,6 +6951,83 @@ describe('ACP runtime session management', () => {
     releasePendingMode.resolve()
     await expect(pending).resolves.toMatchObject({ sessionId: 'pending-primary' })
     await vi.waitFor(() => expect(process.killed).toBe(true))
+  })
+
+  it('defers a provider reconnect until a pending reviewer startup activates', async () => {
+    const { lease, runtime, reviewer, releaseReviewerMode } = await startPendingReviewerRace([
+      'pending-reviewer'
+    ])
+
+    try {
+      await runtime.requestProviderReconnect()
+
+      expect(
+        (runtime as unknown as { pendingProviderReconnect: boolean }).pendingProviderReconnect
+      ).toBe(true)
+      expect(pendingReviewerSessionIds(runtime).has('pending-reviewer')).toBe(true)
+
+      releaseReviewerMode.resolve()
+      const activeReviewer = await reviewer
+      expect(reviewerSessionIds(runtime)).toEqual(new Set(['pending-reviewer']))
+      expect(lease.registerReviewerSession).toHaveBeenCalledWith('pending-reviewer')
+      expect(activeReviewer.session.sessionId).toBe('pending-reviewer')
+    } finally {
+      releaseReviewerMode.resolve()
+      await reviewer.then(
+        ({ session }) => runtime.disposeReviewerSession(session),
+        () => undefined
+      )
+    }
+  })
+
+  it('resolves an armed reconnect barrier when explicitly disconnected', async () => {
+    const oldProcess = new FakeAgentProcess()
+    const newProcess = new FakeAgentProcess()
+    startFakeAgent(oldProcess, ['active-reviewer'])
+    startFakeAgent(newProcess, ['fresh-primary'])
+    let spawnCount = 0
+    const runtime = new AcpRuntime({
+      appVersion: '0.1.0',
+      defaultCwd: '/workspace',
+      resolveBackend: () => {
+        spawnCount += 1
+        return {
+          framework: {
+            ...claudeCodeFramework,
+            spawn: () => asAgentProcess(spawnCount === 1 ? oldProcess : newProcess)
+          },
+          executablePath: '/bin/agent',
+          env: {}
+        }
+      }
+    })
+    await runtime.buildReviewerSession({
+      cwd: '/workspace',
+      mcpServers: [
+        {
+          type: 'http',
+          name: 'open-science-reviewer',
+          url: 'http://127.0.0.1:1/mcp',
+          headers: []
+        }
+      ]
+    })
+    await runtime.requestProviderReconnect()
+    expect(
+      (runtime as unknown as { reconnectBarrier?: Promise<void> }).reconnectBarrier
+    ).toBeDefined()
+
+    await runtime.disconnect()
+
+    expect(
+      (runtime as unknown as { reconnectBarrier?: Promise<void> }).reconnectBarrier
+    ).toBeUndefined()
+    expect(
+      (runtime as unknown as { pendingProviderReconnect: boolean }).pendingProviderReconnect
+    ).toBe(false)
+    await expect(runtime.createSession({ cwd: '/workspace' })).resolves.toMatchObject({
+      sessionId: 'fresh-primary'
+    })
   })
 
   it('reserves a resumed primary session id while its permission mode is still starting', async () => {
@@ -10378,6 +10617,56 @@ describe('ACP runtime session management', () => {
     expect(newAgent.resumedSessions).toEqual([
       expect.objectContaining({ sessionId: resumedSessionId })
     ])
+    expect(spawnCount).toBe(2)
+  })
+
+  it('resetSessionContext renews its published app identity after a pending reconnect', async () => {
+    const oldProcess = new FakeAgentProcess()
+    const newProcess = new FakeAgentProcess()
+    const gate = createDeferred()
+    startFakeAgent(oldProcess, ['stable-app-session'], { onPrompt: () => gate.promise })
+    const newAgent = startFakeAgent(newProcess, ['replacement-provider-session'])
+
+    let spawnCount = 0
+    const runtime = new AcpRuntime({
+      appVersion: '0.1.0',
+      defaultCwd: '/workspace',
+      resolveBackend: async () => {
+        spawnCount += 1
+        return {
+          framework: {
+            ...claudeCodeFramework,
+            spawn: () => asAgentProcess(spawnCount === 1 ? oldProcess : newProcess)
+          },
+          executablePath: '/bin/agent',
+          env: {},
+          args: []
+        }
+      }
+    })
+
+    await runtime.createSession({ cwd: '/workspace' })
+    const prompt = runtime.sendPrompt({ sessionId: 'stable-app-session', text: 'hi' })
+    await runtime.requestProviderReconnect()
+
+    const reset = runtime.resetSessionContext({
+      sessionId: 'stable-app-session',
+      cwd: '/workspace'
+    })
+    await new Promise((resolve) => setTimeout(resolve, 0))
+    expect(newAgent.newSessions).toEqual([])
+
+    gate.resolve()
+    await prompt
+
+    await expect(reset).resolves.toMatchObject({
+      sessionId: 'stable-app-session',
+      contextReset: true
+    })
+    await runtime.sendPrompt({ sessionId: 'stable-app-session', text: 'replacement turn' })
+    expect(newAgent.prompts.at(-1)).toMatchObject({
+      sessionId: 'replacement-provider-session'
+    })
     expect(spawnCount).toBe(2)
   })
 

--- a/src/main/acp/runtime.test.ts
+++ b/src/main/acp/runtime.test.ts
@@ -180,6 +180,8 @@ const startFakeAgent = (
     supportsClose?: boolean
     rejectModeChange?: boolean
     newSessionError?: unknown
+    onNewSession?: (context: { sessionId: string; index: number }) => Promise<void> | void
+    onResume?: (sessionId: string) => Promise<void> | void
     onSetMode?: (context: { sessionId: string; modeId: string }) => Promise<void> | void
     onClose?: (sessionId: string) => Promise<void> | void
     onPrompt?: (context: {
@@ -246,7 +248,7 @@ const startFakeAgent = (
       providerConfigurations.push(ctx.params)
       return {}
     })
-    .onRequest(acp.methods.agent.session.new, (ctx) => {
+    .onRequest(acp.methods.agent.session.new, async (ctx) => {
       if (options.newSessionError !== undefined) throw options.newSessionError
 
       newSessions.push({
@@ -255,8 +257,11 @@ const startFakeAgent = (
         ...(ctx.params._meta === undefined ? {} : { _meta: ctx.params._meta })
       })
       // Return deterministic ids so the tests can assert exact routing.
+      const index = sessionIndex
       const sessionId = sessionIds[sessionIndex]
       sessionIndex += 1
+
+      await options.onNewSession?.({ sessionId, index })
 
       return {
         sessionId,
@@ -264,7 +269,7 @@ const startFakeAgent = (
         ...(options.configOptions ? { configOptions: options.configOptions } : {})
       }
     })
-    .onRequest(acp.methods.agent.session.resume, (ctx) => {
+    .onRequest(acp.methods.agent.session.resume, async (ctx) => {
       if (options.resumeNotFound) {
         throw acp.RequestError.resourceNotFound(ctx.params.sessionId)
       }
@@ -294,6 +299,8 @@ const startFakeAgent = (
         mcpServers: ctx.params.mcpServers ?? [],
         ...(ctx.params._meta === undefined ? {} : { _meta: ctx.params._meta })
       })
+
+      await options.onResume?.(ctx.params.sessionId)
 
       return { modes: options.modes }
     })
@@ -6430,6 +6437,153 @@ describe('ACP runtime session management', () => {
     }
   })
 
+  it('activates reviewer routing before granting responses bridge authority', async () => {
+    const process = new FakeAgentProcess()
+    startFakeAgent(process, ['reviewer-session-1'], {
+      modes: createModes(['read-only', 'agent', 'agent-full-access'], 'read-only')
+    })
+    const routingObservedByBridge: Array<{ active: boolean; pending: boolean }> = []
+    const { lease } = createBackendLeaseHarness()
+    lease.registerReviewerSession = vi.fn((sessionId: string) => {
+      routingObservedByBridge.push({
+        active: reviewerSessionIds(runtime).has(sessionId),
+        pending: pendingReviewerSessionIds(runtime).has(sessionId)
+      })
+    })
+    const runtime = new AcpRuntime({
+      appVersion: '0.1.0',
+      defaultCwd: '/workspace',
+      resolveBackend: () => ({
+        framework: { ...codexFramework, spawn: () => asAgentProcess(process) },
+        executablePath: '/bin/codex-acp',
+        env: {},
+        responsesBridgeLease: lease
+      })
+    })
+
+    const { session } = await runtime.buildReviewerSession({
+      cwd: '/workspace',
+      mcpServers: [
+        {
+          type: 'http',
+          name: 'open-science-reviewer',
+          url: 'http://127.0.0.1:1/mcp',
+          headers: []
+        }
+      ]
+    })
+
+    expect(routingObservedByBridge).toEqual([{ active: true, pending: false }])
+    runtime.disposeReviewerSession(session)
+  })
+
+  it('rolls back reviewer activation when responses bridge registration throws', async () => {
+    const process = new FakeAgentProcess()
+    const fakeAgent = startFakeAgent(process, ['reviewer-session-1'], {
+      modes: createModes(['read-only', 'agent', 'agent-full-access'], 'read-only')
+    })
+    const { lease } = createBackendLeaseHarness()
+    lease.registerReviewerSession = vi.fn(() => {
+      throw new Error('reviewer bridge registration failed')
+    })
+    const runtime = new AcpRuntime({
+      appVersion: '0.1.0',
+      defaultCwd: '/workspace',
+      resolveBackend: () => ({
+        framework: { ...codexFramework, spawn: () => asAgentProcess(process) },
+        executablePath: '/bin/codex-acp',
+        env: {},
+        responsesBridgeLease: lease
+      })
+    })
+
+    await expect(
+      runtime.buildReviewerSession({
+        cwd: '/workspace',
+        mcpServers: [
+          {
+            type: 'http',
+            name: 'open-science-reviewer',
+            url: 'http://127.0.0.1:1/mcp',
+            headers: []
+          }
+        ]
+      })
+    ).rejects.toThrow('reviewer bridge registration failed')
+
+    expect(reviewerSessionIds(runtime).size).toBe(0)
+    expect(pendingReviewerSessionIds(runtime).size).toBe(0)
+    expect(lease.unregisterReviewerSession).toHaveBeenCalledWith('reviewer-session-1')
+    await expect(stat(fakeAgent.newSessions[0]!.cwd)).rejects.toMatchObject({ code: 'ENOENT' })
+  })
+
+  it('lets the first known create identity reservation win while another start is unresolved', async () => {
+    const process = new FakeAgentProcess()
+    const primaryStartReachedAgent = createDeferred()
+    const releasePrimaryStart = createDeferred()
+    const fakeAgent = startFakeAgent(process, ['shared-session', 'shared-session'], {
+      modes: createModes(['read-only', 'agent', 'agent-full-access'], 'read-only'),
+      onNewSession: async ({ index }) => {
+        if (index === 0) {
+          primaryStartReachedAgent.resolve()
+          await releasePrimaryStart.promise
+        }
+      }
+    })
+    const { lease } = createBackendLeaseHarness()
+    const runtime = new AcpRuntime({
+      appVersion: '0.1.0',
+      defaultCwd: '/workspace',
+      resolveBackend: () => ({
+        framework: { ...codexFramework, spawn: () => asAgentProcess(process) },
+        executablePath: '/bin/codex-acp',
+        env: {},
+        responsesBridgeLease: lease
+      })
+    })
+    await runtime.connect({ cwd: '/workspace' })
+
+    const primary = runtime.createSession({ cwd: '/workspace' })
+    await primaryStartReachedAgent.promise
+    const reviewer = runtime.buildReviewerSession({
+      cwd: '/workspace',
+      mcpServers: [
+        {
+          type: 'http',
+          name: 'open-science-reviewer',
+          url: 'http://127.0.0.1:1/mcp',
+          headers: []
+        }
+      ]
+    })
+
+    try {
+      const winner = await reviewer
+      expect(reviewerSessionIds(runtime)).toEqual(new Set(['shared-session']))
+      expect(lease.registerReviewerSession).toHaveBeenCalledWith('shared-session')
+
+      releasePrimaryStart.resolve()
+      await expect(primary).rejects.toThrow(
+        'Primary session id collision with reviewer: shared-session'
+      )
+      expect(runtime.getSnapshot().sessionIds).toEqual([])
+      await winner.session.prompt([{ type: 'text', text: 'first reservation keeps authority' }])
+      expect(fakeAgent.prompts).toEqual([
+        { sessionId: 'shared-session', text: 'first reservation keeps authority' }
+      ])
+    } finally {
+      releasePrimaryStart.resolve()
+      await reviewer.then(
+        ({ session }) => runtime.disposeReviewerSession(session),
+        () => undefined
+      )
+      await primary.then(
+        ({ sessionId }) => runtime.deleteSession({ sessionId }),
+        () => undefined
+      )
+    }
+  })
+
   it('reserves a new primary session id while its permission mode is still starting', async () => {
     const { fakeAgent, lease, runtime, primary, reviewer, releasePrimaryMode, modeRequestCount } =
       await startPendingPrimaryRace(['shared-session', 'shared-session'], (runtime) =>
@@ -6518,6 +6672,176 @@ describe('ACP runtime session management', () => {
     }
   })
 
+  it('reserves a known resumed app id before provider attach completes', async () => {
+    const sessionId = '123e4567-e89b-42d3-a456-426614174000'
+    const process = new FakeAgentProcess()
+    const resumeStarted = createDeferred()
+    const releaseResume = createDeferred()
+    const fakeAgent = startFakeAgent(process, [sessionId], {
+      modes: createModes(['read-only', 'agent', 'agent-full-access'], 'read-only'),
+      onResume: async () => {
+        resumeStarted.resolve()
+        await releaseResume.promise
+      }
+    })
+    const { lease } = createBackendLeaseHarness()
+    const runtime = new AcpRuntime({
+      appVersion: '0.1.0',
+      defaultCwd: '/workspace',
+      resolveBackend: () => ({
+        framework: { ...codexFramework, spawn: () => asAgentProcess(process) },
+        executablePath: '/bin/codex-acp',
+        env: {},
+        responsesBridgeLease: lease
+      })
+    })
+    await runtime.connect({ cwd: '/workspace' })
+
+    const primary = runtime.resumeSession({ sessionId, cwd: '/workspace' })
+    await resumeStarted.promise
+    const reviewer = runtime.buildReviewerSession({
+      cwd: '/workspace',
+      mcpServers: [
+        {
+          type: 'http',
+          name: 'open-science-reviewer',
+          url: 'http://127.0.0.1:1/mcp',
+          headers: []
+        }
+      ]
+    })
+
+    try {
+      await expect(reviewer).rejects.toThrow(`Reviewer session id collision: ${sessionId}`)
+      expect([...pendingPrimarySessionIds(runtime).keys()]).toEqual([sessionId])
+      await expect(stat(fakeAgent.newSessions[0]!.cwd)).rejects.toMatchObject({ code: 'ENOENT' })
+
+      releaseResume.resolve()
+      await expect(primary).resolves.toMatchObject({ sessionId })
+      expect(pendingPrimarySessionIds(runtime).size).toBe(0)
+    } finally {
+      releaseResume.resolve()
+      await reviewer.then(
+        ({ session }) => runtime.disposeReviewerSession(session),
+        () => undefined
+      )
+      await primary.then(
+        ({ sessionId: resumedSessionId }) => runtime.deleteSession({ sessionId: resumedSessionId }),
+        () => undefined
+      )
+    }
+  })
+
+  it('rejects a second primary owner for a pending stable app id', async () => {
+    const sessionId = '123e4567-e89b-42d3-a456-426614174000'
+    const process = new FakeAgentProcess()
+    const resumeStarted = createDeferred()
+    const releaseResume = createDeferred()
+    const fakeAgent = startFakeAgent(process, [], {
+      modes: createModes(['read-only', 'agent', 'agent-full-access'], 'read-only'),
+      onResume: async () => {
+        resumeStarted.resolve()
+        await releaseResume.promise
+      }
+    })
+    const runtime = new AcpRuntime({
+      appVersion: '0.1.0',
+      defaultCwd: '/workspace',
+      resolveBackend: () => ({
+        framework: { ...codexFramework, spawn: () => asAgentProcess(process) },
+        executablePath: '/bin/codex-acp',
+        env: {}
+      })
+    })
+    await runtime.connect({ cwd: '/workspace' })
+
+    const first = runtime.resumeSession({ sessionId, cwd: '/workspace' })
+    await resumeStarted.promise
+
+    try {
+      await expect(runtime.resumeSession({ sessionId, cwd: '/workspace' })).rejects.toThrow(
+        `Primary session id collision: ${sessionId}`
+      )
+      expect(fakeAgent.resumedSessions).toHaveLength(1)
+
+      releaseResume.resolve()
+      await expect(first).resolves.toMatchObject({ sessionId })
+    } finally {
+      releaseResume.resolve()
+      await first.then(
+        ({ sessionId: resumedSessionId }) => runtime.deleteSession({ sessionId: resumedSessionId }),
+        () => undefined
+      )
+    }
+  })
+
+  it('reserves a fresh adoption app id before the provider session starts', async () => {
+    const process = new FakeAgentProcess()
+    const adoptionStarted = createDeferred()
+    const releaseAdoption = createDeferred()
+    const fakeAgent = startFakeAgent(process, ['new-provider-session', 'stable-app-session'], {
+      modes: createModes(['read-only', 'agent', 'agent-full-access'], 'read-only'),
+      onNewSession: async ({ index }) => {
+        if (index === 0) {
+          adoptionStarted.resolve()
+          await releaseAdoption.promise
+        }
+      }
+    })
+    const { lease } = createBackendLeaseHarness()
+    const runtime = new AcpRuntime({
+      appVersion: '0.1.0',
+      defaultCwd: '/workspace',
+      resolveBackend: () => ({
+        framework: { ...codexFramework, spawn: () => asAgentProcess(process) },
+        executablePath: '/bin/codex-acp',
+        env: {},
+        responsesBridgeLease: lease
+      })
+    })
+    await runtime.connect({ cwd: '/workspace' })
+
+    const primary = runtime.resumeSession({
+      sessionId: 'stable-app-session',
+      cwd: '/workspace'
+    })
+    await adoptionStarted.promise
+    const reviewer = runtime.buildReviewerSession({
+      cwd: '/workspace',
+      mcpServers: [
+        {
+          type: 'http',
+          name: 'open-science-reviewer',
+          url: 'http://127.0.0.1:1/mcp',
+          headers: []
+        }
+      ]
+    })
+
+    try {
+      await expect(reviewer).rejects.toThrow('Reviewer session id collision: stable-app-session')
+      expect([...pendingPrimarySessionIds(runtime).keys()]).toEqual(['stable-app-session'])
+      await expect(stat(fakeAgent.newSessions[1]!.cwd)).rejects.toMatchObject({ code: 'ENOENT' })
+
+      releaseAdoption.resolve()
+      await expect(primary).resolves.toMatchObject({
+        sessionId: 'stable-app-session',
+        contextReset: true
+      })
+      expect(pendingPrimarySessionIds(runtime).size).toBe(0)
+    } finally {
+      releaseAdoption.resolve()
+      await reviewer.then(
+        ({ session }) => runtime.disposeReviewerSession(session),
+        () => undefined
+      )
+      await primary.then(
+        ({ sessionId }) => runtime.deleteSession({ sessionId }),
+        () => undefined
+      )
+    }
+  })
+
   it('reserves a fresh adoption app-facing id while its permission mode is still starting', async () => {
     const { fakeAgent, runtime, primary, reviewer, releasePrimaryMode, modeRequestCount } =
       await startPendingPrimaryRace(['new-provider-session', 'stable-app-session'], (runtime) =>
@@ -6534,6 +6858,7 @@ describe('ACP runtime session management', () => {
         'stable-app-session',
         'new-provider-session'
       ])
+      expect(new Set(pendingPrimarySessionIds(runtime).values()).size).toBe(1)
 
       const duplicateCwd = fakeAgent.newSessions[1]?.cwd
       expect(duplicateCwd).toMatch(/open-science-reviewer-/)
@@ -6586,6 +6911,7 @@ describe('ACP runtime session management', () => {
         'stable-app-session',
         'reserved-provider-session'
       ])
+      expect(new Set(pendingPrimarySessionIds(runtime).values()).size).toBe(1)
 
       const duplicateCwd = fakeAgent.newSessions[1]?.cwd
       expect(duplicateCwd).toMatch(/open-science-reviewer-/)
@@ -6620,11 +6946,88 @@ describe('ACP runtime session management', () => {
     }
   })
 
+  it('keeps the stable app id reserved while context reset starts a replacement provider session', async () => {
+    const process = new FakeAgentProcess()
+    const replacementStarted = createDeferred()
+    const releaseReplacement = createDeferred()
+    const fakeAgent = startFakeAgent(
+      process,
+      ['stable-app-session', 'replacement-provider-session', 'stable-app-session'],
+      {
+        modes: createModes(['read-only', 'agent', 'agent-full-access'], 'read-only'),
+        onNewSession: async ({ index }) => {
+          if (index === 1) {
+            replacementStarted.resolve()
+            await releaseReplacement.promise
+          }
+        }
+      }
+    )
+    const { lease } = createBackendLeaseHarness()
+    const runtime = new AcpRuntime({
+      appVersion: '0.1.0',
+      defaultCwd: '/workspace',
+      resolveBackend: () => ({
+        framework: { ...codexFramework, spawn: () => asAgentProcess(process) },
+        executablePath: '/bin/codex-acp',
+        env: {},
+        responsesBridgeLease: lease
+      })
+    })
+    await runtime.createSession({ cwd: '/workspace' })
+
+    const reset = runtime.resetSessionContext({
+      sessionId: 'stable-app-session',
+      cwd: '/workspace'
+    })
+    await replacementStarted.promise
+    const reviewer = runtime.buildReviewerSession({
+      cwd: '/workspace',
+      mcpServers: [
+        {
+          type: 'http',
+          name: 'open-science-reviewer',
+          url: 'http://127.0.0.1:1/mcp',
+          headers: []
+        }
+      ]
+    })
+
+    try {
+      await expect(reviewer).rejects.toThrow('Reviewer session id collision: stable-app-session')
+      expect([...pendingPrimarySessionIds(runtime).keys()]).toEqual(['stable-app-session'])
+      await expect(stat(fakeAgent.newSessions[2]!.cwd)).rejects.toMatchObject({ code: 'ENOENT' })
+
+      releaseReplacement.resolve()
+      await expect(reset).resolves.toMatchObject({
+        sessionId: 'stable-app-session',
+        contextReset: true
+      })
+      expect(pendingPrimarySessionIds(runtime).size).toBe(0)
+      await runtime.sendPrompt({
+        sessionId: 'stable-app-session',
+        text: 'replacement primary remains active'
+      })
+      expect(fakeAgent.prompts.at(-1)).toMatchObject({
+        sessionId: 'replacement-provider-session'
+      })
+    } finally {
+      releaseReplacement.resolve()
+      await reviewer.then(
+        ({ session }) => runtime.disposeReviewerSession(session),
+        () => undefined
+      )
+      await reset.catch(() => undefined)
+      await runtime.deleteSession({ sessionId: 'stable-app-session' }).catch(() => undefined)
+    }
+  })
+
   it.each([
     {
       operation: 'new primary session',
       agentSessionIds: ['shared-session', 'shared-session'],
       collisionId: 'shared-session',
+      expectedDisposals: 1,
       disposalFailure: 'primary collision dispose failed',
       start: (runtime: AcpRuntime) => runtime.createSession({ cwd: '/workspace' })
     },
@@ -6632,6 +7035,7 @@ describe('ACP runtime session management', () => {
       operation: 'fresh adoption app-facing id',
       agentSessionIds: ['stable-app-session', 'new-provider-session'],
       collisionId: 'stable-app-session',
+      expectedDisposals: 0,
       start: (runtime: AcpRuntime) =>
         runtime.resumeSession({ sessionId: 'stable-app-session', cwd: '/workspace' })
     },
@@ -6639,6 +7043,7 @@ describe('ACP runtime session management', () => {
       operation: 'fresh adoption provider id',
       agentSessionIds: ['reserved-provider-session', 'reserved-provider-session'],
       collisionId: 'reserved-provider-session',
+      expectedDisposals: 1,
       disposalFailure: 'adoption collision dispose failed',
       start: (runtime: AcpRuntime) =>
         runtime.resumeSession({ sessionId: 'stable-app-session', cwd: '/workspace' })
@@ -6647,6 +7052,7 @@ describe('ACP runtime session management', () => {
       operation: 'resumed primary session',
       agentSessionIds: ['123e4567-e89b-42d3-a456-426614174000'],
       collisionId: '123e4567-e89b-42d3-a456-426614174000',
+      expectedDisposals: 0,
       start: (runtime: AcpRuntime) =>
         runtime.resumeSession({
           sessionId: '123e4567-e89b-42d3-a456-426614174000',
@@ -6655,7 +7061,7 @@ describe('ACP runtime session management', () => {
     }
   ])(
     'rejects a pending reviewer identity collision from a $operation',
-    async ({ agentSessionIds, collisionId, disposalFailure, start }) => {
+    async ({ agentSessionIds, collisionId, expectedDisposals, disposalFailure, start }) => {
       errorLogSpy.mockClear()
       const { runtime, reviewer, releaseReviewerMode, modeRequestCount } =
         await startPendingReviewerRace(agentSessionIds)
@@ -6671,7 +7077,7 @@ describe('ACP runtime session management', () => {
         await expect(primary).rejects.toThrow(
           'Primary session id collision with pending reviewer: ' + collisionId
         )
-        expect(disposeSpy).toHaveBeenCalledOnce()
+        expect(disposeSpy).toHaveBeenCalledTimes(expectedDisposals)
         expect(modeRequestCount()).toBe(1)
         expect(runtime.getSnapshot().sessionIds).toEqual([])
         if (disposalFailure) {

--- a/src/main/acp/runtime.test.ts
+++ b/src/main/acp/runtime.test.ts
@@ -6437,6 +6437,74 @@ describe('ACP runtime session management', () => {
     }
   })
 
+  it('invalidates a pending reviewer startup before a failing disconnect can strand it', async () => {
+    const process = new FakeAgentProcess()
+    const reviewerModeStarted = createDeferred()
+    const releaseReviewerMode = createDeferred()
+    let modeRequestCount = 0
+    startFakeAgent(process, ['primary-session', 'stale-reviewer'], {
+      modes: createModes(['read-only', 'agent', 'agent-full-access'], 'agent'),
+      onSetMode: async () => {
+        modeRequestCount += 1
+        if (modeRequestCount === 2) {
+          reviewerModeStarted.resolve()
+          await releaseReviewerMode.promise
+        }
+      }
+    })
+    const { lease } = createBackendLeaseHarness()
+    const runtime = new AcpRuntime({
+      appVersion: '0.1.0',
+      defaultCwd: '/workspace',
+      resolveBackend: () => ({
+        framework: { ...codexFramework, spawn: () => asAgentProcess(process) },
+        executablePath: '/bin/codex-acp',
+        env: {},
+        responsesBridgeLease: lease
+      })
+    })
+    const primary = await runtime.createSession({ cwd: '/workspace' })
+    const activePrimary = (
+      runtime as unknown as { sessions: Map<string, { dispose: () => void }> }
+    ).sessions.get(primary.sessionId)!
+    const disposePrimary = activePrimary.dispose.bind(activePrimary)
+    activePrimary.dispose = vi.fn(() => {
+      throw new Error('primary disconnect dispose failed')
+    })
+    const reviewer = runtime.buildReviewerSession({
+      cwd: '/workspace',
+      mcpServers: [
+        {
+          type: 'http',
+          name: 'open-science-reviewer',
+          url: 'http://127.0.0.1:1/mcp',
+          headers: []
+        }
+      ]
+    })
+    await reviewerModeStarted.promise
+
+    try {
+      expect(pendingReviewerSessionIds(runtime).has('stale-reviewer')).toBe(true)
+
+      await expect(runtime.disconnect()).rejects.toThrow('primary disconnect dispose failed')
+
+      expect(pendingReviewerSessionIds(runtime).size).toBe(0)
+      releaseReviewerMode.resolve()
+      await expect(reviewer).rejects.toThrow('ACP session startup was superseded.')
+      expect(reviewerSessionIds(runtime).size).toBe(0)
+      expect(lease.registerReviewerSession).not.toHaveBeenCalled()
+    } finally {
+      releaseReviewerMode.resolve()
+      await reviewer.then(
+        ({ session }) => runtime.disposeReviewerSession(session),
+        () => undefined
+      )
+      activePrimary.dispose = disposePrimary
+      await runtime.disconnect().catch(() => undefined)
+    }
+  })
+
   it('activates reviewer routing before granting responses bridge authority', async () => {
     const process = new FakeAgentProcess()
     startFakeAgent(process, ['reviewer-session-1'], {
@@ -6631,6 +6699,96 @@ describe('ACP runtime session management', () => {
         () => undefined
       )
     }
+  })
+
+  it('invalidates a pending primary startup before a failing disconnect can strand it', async () => {
+    const process = new FakeAgentProcess()
+    const pendingModeStarted = createDeferred()
+    const releasePendingMode = createDeferred()
+    let modeRequestCount = 0
+    startFakeAgent(process, ['active-primary', 'stale-primary'], {
+      modes: createModes(['read-only', 'agent', 'agent-full-access'], 'agent'),
+      onSetMode: async () => {
+        modeRequestCount += 1
+        if (modeRequestCount === 2) {
+          pendingModeStarted.resolve()
+          await releasePendingMode.promise
+        }
+      }
+    })
+    const runtime = new AcpRuntime({
+      appVersion: '0.1.0',
+      defaultCwd: '/workspace',
+      resolveBackend: () => ({
+        framework: { ...codexFramework, spawn: () => asAgentProcess(process) },
+        executablePath: '/bin/codex-acp',
+        env: {}
+      })
+    })
+    const active = await runtime.createSession({ cwd: '/workspace' })
+    const activeSession = (
+      runtime as unknown as { sessions: Map<string, { dispose: () => void }> }
+    ).sessions.get(active.sessionId)!
+    const disposeActive = activeSession.dispose.bind(activeSession)
+    activeSession.dispose = vi.fn(() => {
+      throw new Error('active primary disconnect dispose failed')
+    })
+    const pending = runtime.createSession({ cwd: '/workspace' })
+    await pendingModeStarted.promise
+
+    try {
+      expect([...pendingPrimarySessionIds(runtime).keys()]).toEqual(['stale-primary'])
+
+      await expect(runtime.disconnect()).rejects.toThrow('active primary disconnect dispose failed')
+
+      expect(pendingPrimarySessionIds(runtime).size).toBe(0)
+      releasePendingMode.resolve()
+      await expect(pending).rejects.toThrow('ACP session startup was superseded.')
+      expect(runtime.getSnapshot().sessionIds).not.toContain('stale-primary')
+    } finally {
+      releasePendingMode.resolve()
+      await pending.then(
+        ({ sessionId }) => runtime.deleteSession({ sessionId }),
+        () => undefined
+      )
+      activeSession.dispose = disposeActive
+      await runtime.disconnect().catch(() => undefined)
+    }
+  })
+
+  it('defers a provider reconnect until a pending primary startup publishes', async () => {
+    const process = new FakeAgentProcess()
+    const pendingModeStarted = createDeferred()
+    const releasePendingMode = createDeferred()
+    startFakeAgent(process, ['pending-primary'], {
+      modes: createModes(['read-only', 'agent', 'agent-full-access'], 'agent'),
+      onSetMode: async () => {
+        pendingModeStarted.resolve()
+        await releasePendingMode.promise
+      }
+    })
+    const runtime = new AcpRuntime({
+      appVersion: '0.1.0',
+      defaultCwd: '/workspace',
+      resolveBackend: () => ({
+        framework: { ...codexFramework, spawn: () => asAgentProcess(process) },
+        executablePath: '/bin/codex-acp',
+        env: {}
+      })
+    })
+    const pending = runtime.createSession({ cwd: '/workspace' })
+    await pendingModeStarted.promise
+
+    await runtime.requestProviderReconnect()
+
+    expect(process.killed).toBe(false)
+    expect(
+      (runtime as unknown as { pendingProviderReconnect: boolean }).pendingProviderReconnect
+    ).toBe(true)
+
+    releasePendingMode.resolve()
+    await expect(pending).resolves.toMatchObject({ sessionId: 'pending-primary' })
+    await vi.waitFor(() => expect(process.killed).toBe(true))
   })
 
   it('reserves a resumed primary session id while its permission mode is still starting', async () => {
@@ -10176,6 +10334,50 @@ describe('ACP runtime session management', () => {
 
     // The second session must have landed on the new connection (second spawn).
     expect(result.sessionId).toBe('s2')
+    expect(spawnCount).toBe(2)
+  })
+
+  it('resumeSession renews its stable identity after waiting for a pending provider reconnect', async () => {
+    const oldProcess = new FakeAgentProcess()
+    const newProcess = new FakeAgentProcess()
+    const gate = createDeferred()
+    const resumedSessionId = '123e4567-e89b-42d3-a456-426614174000'
+    startFakeAgent(oldProcess, ['s1'], { onPrompt: () => gate.promise })
+    const newAgent = startFakeAgent(newProcess, [])
+
+    let spawnCount = 0
+    const runtime = new AcpRuntime({
+      appVersion: '0.1.0',
+      defaultCwd: '/workspace',
+      resolveBackend: async () => {
+        spawnCount += 1
+        return {
+          framework: {
+            ...claudeCodeFramework,
+            spawn: () => asAgentProcess(spawnCount === 1 ? oldProcess : newProcess)
+          },
+          executablePath: '/bin/agent',
+          env: {},
+          args: []
+        }
+      }
+    })
+
+    await runtime.createSession({ cwd: '/workspace' })
+    const prompt = runtime.sendPrompt({ sessionId: 's1', text: 'hi' })
+    await runtime.requestProviderReconnect()
+
+    const resumed = runtime.resumeSession({ sessionId: resumedSessionId, cwd: '/workspace' })
+    await new Promise((resolve) => setTimeout(resolve, 0))
+    expect(newAgent.resumedSessions).toEqual([])
+
+    gate.resolve()
+    await prompt
+
+    await expect(resumed).resolves.toMatchObject({ sessionId: resumedSessionId })
+    expect(newAgent.resumedSessions).toEqual([
+      expect.objectContaining({ sessionId: resumedSessionId })
+    ])
     expect(spawnCount).toBe(2)
   })
 

--- a/src/main/acp/runtime.test.ts
+++ b/src/main/acp/runtime.test.ts
@@ -161,6 +161,11 @@ const startFakeAgent = (
     // session/new set; defaults to echoing configOptions.
     updatedConfigOptions?: SessionConfigOption[]
     rejectSetConfigOption?: boolean
+    onSetConfigOption?: (context: {
+      sessionId: string
+      configId: string
+      value: string | boolean
+    }) => Promise<void> | void
     // When true, the resume handler rejects with the ACP "Resource not found" (-32002) — the signal a
     // replaced agent (e.g. after a provider switch) gives for a session id it does not hold.
     resumeNotFound?: boolean
@@ -317,10 +322,15 @@ const startFakeAgent = (
       })
       return pending ? pending.then(recordModeChange) : recordModeChange()
     })
-    .onRequest(acp.methods.agent.session.setConfigOption, (ctx) => {
+    .onRequest(acp.methods.agent.session.setConfigOption, async (ctx) => {
       if (options.rejectSetConfigOption) throw acp.RequestError.internalError()
 
       configChanges.push({
+        sessionId: ctx.params.sessionId,
+        configId: ctx.params.configId,
+        value: ctx.params.value
+      })
+      await options.onSetConfigOption?.({
         sessionId: ctx.params.sessionId,
         configId: ctx.params.configId,
         value: ctx.params.value
@@ -785,6 +795,16 @@ const pendingReviewerSessionIds = (runtime: AcpRuntime): Map<string, symbol> =>
 
 const pendingPrimarySessionIds = (runtime: AcpRuntime): Map<string, symbol> =>
   (runtime as unknown as { pendingPrimarySessionIds: Map<string, symbol> }).pendingPrimarySessionIds
+
+const sessionSpecialistIds = (runtime: AcpRuntime): Map<string, string> =>
+  (runtime as unknown as { sessionSpecialistIds: Map<string, string> }).sessionSpecialistIds
+
+const sessionSpecialistPrefixes = (runtime: AcpRuntime): Map<string, string> =>
+  (runtime as unknown as { sessionSpecialistPrefixes: Map<string, string> })
+    .sessionSpecialistPrefixes
+
+const appliedSessionModels = (runtime: AcpRuntime): Map<string, string> =>
+  (runtime as unknown as { appliedSessionModels: Map<string, string> }).appliedSessionModels
 
 const permissionContext = (runtime: AcpRuntime): AcpPermissionContext =>
   (runtime as unknown as { permissionContext: AcpPermissionContext }).permissionContext
@@ -6447,16 +6467,17 @@ describe('ACP runtime session management', () => {
     {
       teardown: 'reconnect',
       runTeardown: (runtime: AcpRuntime) => runtime.connect({ cwd: '/workspace' }),
-      canStartSuccessor: false
+      canStartSuccessor: true
     }
   ])(
     'invalidates a pending reviewer startup before a failing $teardown can strand it',
     async ({ runTeardown, canStartSuccessor }) => {
-      const process = new FakeAgentProcess()
+      const oldProcess = new FakeAgentProcess()
+      const newProcess = new FakeAgentProcess()
       const reviewerModeStarted = createDeferred()
       const releaseReviewerMode = createDeferred()
       let modeRequestCount = 0
-      startFakeAgent(process, ['primary-session', 'stale-reviewer', 'stale-reviewer'], {
+      startFakeAgent(oldProcess, ['primary-session', 'stale-reviewer'], {
         modes: createModes(['read-only', 'agent', 'agent-full-access'], 'agent'),
         onSetMode: async () => {
           modeRequestCount += 1
@@ -6466,16 +6487,28 @@ describe('ACP runtime session management', () => {
           }
         }
       })
-      const { lease } = createBackendLeaseHarness()
+      startFakeAgent(newProcess, ['stale-reviewer'], {
+        modes: createModes(['read-only', 'agent', 'agent-full-access'], 'agent')
+      })
+      const oldBridge = createBackendLeaseHarness()
+      const newBridge = createBackendLeaseHarness()
+      let spawnCount = 0
       const runtime = new AcpRuntime({
         appVersion: '0.1.0',
         defaultCwd: '/workspace',
-        resolveBackend: () => ({
-          framework: { ...codexFramework, spawn: () => asAgentProcess(process) },
-          executablePath: '/bin/codex-acp',
-          env: {},
-          responsesBridgeLease: lease
-        })
+        resolveBackend: () => {
+          const useOld = spawnCount === 0
+          spawnCount += 1
+          return {
+            framework: {
+              ...codexFramework,
+              spawn: () => asAgentProcess(useOld ? oldProcess : newProcess)
+            },
+            executablePath: '/bin/codex-acp',
+            env: {},
+            responsesBridgeLease: useOld ? oldBridge.lease : newBridge.lease
+          }
+        }
       })
       const primary = await runtime.createSession({ cwd: '/workspace' })
       const activePrimary = (
@@ -6497,6 +6530,10 @@ describe('ACP runtime session management', () => {
         ]
       }
       const reviewer = runtime.buildReviewerSession(reviewerRequest)
+      const reviewerOutcome = reviewer.then(
+        (value) => ({ value, error: undefined }),
+        (error: unknown) => ({ value: undefined, error })
+      )
       await reviewerModeStarted.promise
       let successor: Awaited<ReturnType<AcpRuntime['buildReviewerSession']>> | undefined
 
@@ -6512,13 +6549,19 @@ describe('ACP runtime session management', () => {
         }
 
         releaseReviewerMode.resolve()
-        await expect(reviewer).rejects.toThrow('ACP session startup was superseded.')
+        const staleOutcome = await reviewerOutcome
+        expect(staleOutcome.error).toMatchObject({
+          message: 'ACP session startup was superseded.'
+        })
         if (canStartSuccessor) {
           expect(reviewerSessionIds(runtime)).toEqual(new Set(['stale-reviewer']))
         } else {
           expect(reviewerSessionIds(runtime).size).toBe(0)
         }
-        expect(lease.registerReviewerSession).not.toHaveBeenCalled()
+        expect(oldBridge.lease.registerReviewerSession).not.toHaveBeenCalled()
+        if (canStartSuccessor) {
+          expect(newBridge.lease.registerReviewerSession).toHaveBeenCalledWith('stale-reviewer')
+        }
       } finally {
         releaseReviewerMode.resolve()
         await reviewer.then(
@@ -6531,6 +6574,67 @@ describe('ACP runtime session management', () => {
       }
     }
   )
+
+  it('keeps a successor reviewer active when an older same-id session disposes late', async () => {
+    const oldProcess = new FakeAgentProcess()
+    const newProcess = new FakeAgentProcess()
+    startFakeAgent(oldProcess, ['shared-reviewer'], {
+      modes: createModes(['read-only', 'agent', 'agent-full-access'], 'read-only')
+    })
+    const newAgent = startFakeAgent(newProcess, ['shared-reviewer'], {
+      modes: createModes(['read-only', 'agent', 'agent-full-access'], 'read-only')
+    })
+    const oldBridge = createBackendLeaseHarness()
+    const newBridge = createBackendLeaseHarness()
+    let spawnCount = 0
+    const runtime = new AcpRuntime({
+      appVersion: '0.1.0',
+      defaultCwd: '/workspace',
+      resolveBackend: () => {
+        const useOld = spawnCount === 0
+        spawnCount += 1
+        return {
+          framework: {
+            ...codexFramework,
+            spawn: () => asAgentProcess(useOld ? oldProcess : newProcess)
+          },
+          executablePath: '/bin/codex-acp',
+          env: {},
+          responsesBridgeLease: useOld ? oldBridge.lease : newBridge.lease
+        }
+      }
+    })
+    const request: Parameters<AcpRuntime['buildReviewerSession']>[0] = {
+      cwd: '/workspace',
+      mcpServers: [
+        {
+          type: 'http',
+          name: 'open-science-reviewer',
+          url: 'http://127.0.0.1:1/mcp',
+          headers: []
+        }
+      ]
+    }
+    const oldReviewer = await runtime.buildReviewerSession(request)
+    await runtime.disconnect()
+    const successor = await runtime.buildReviewerSession(request)
+    const successorCwd = newAgent.newSessions[0]!.cwd
+
+    try {
+      runtime.disposeReviewerSession(oldReviewer.session)
+
+      expect(reviewerSessionIds(runtime)).toEqual(new Set(['shared-reviewer']))
+      expect(newBridge.lease.unregisterReviewerSession).not.toHaveBeenCalled()
+      await expect(stat(successorCwd)).resolves.toBeDefined()
+      await successor.session.prompt([{ type: 'text', text: 'successor remains scoped' }])
+      expect(newAgent.prompts).toEqual([
+        { sessionId: 'shared-reviewer', text: 'successor remains scoped' }
+      ])
+    } finally {
+      runtime.disposeReviewerSession(successor.session)
+      await runtime.disconnect().catch(() => undefined)
+    }
+  })
 
   it('completes unexpected-close cleanup when one reviewer bridge unregister throws', async () => {
     const process = new FakeAgentProcess()
@@ -6565,6 +6669,9 @@ describe('ACP runtime session management', () => {
     }
     await runtime.buildReviewerSession(reviewerRequest)
     await runtime.buildReviewerSession(reviewerRequest)
+    ;(
+      runtime as unknown as { reviewerRejectedToolCalls: Map<string, number> }
+    ).reviewerRejectedToolCalls.set('reviewer-one', 2)
     const reviewerCwds = fakeAgent.newSessions.map(({ cwd }) => cwd)
     await runtime.requestProviderReconnect()
     const handleConnectionClosed = (
@@ -6576,6 +6683,10 @@ describe('ACP runtime session management', () => {
       expect(lease.unregisterReviewerSession).toHaveBeenCalledWith('reviewer-one')
       expect(lease.unregisterReviewerSession).toHaveBeenCalledWith('reviewer-two')
       expect(reviewerSessionIds(runtime).size).toBe(0)
+      expect(
+        (runtime as unknown as { reviewerRejectedToolCalls: Map<string, number> })
+          .reviewerRejectedToolCalls.size
+      ).toBe(0)
       expect(
         (runtime as unknown as { reconnectBarrier?: Promise<void> }).reconnectBarrier
       ).toBeUndefined()
@@ -6794,16 +6905,17 @@ describe('ACP runtime session management', () => {
     {
       teardown: 'reconnect',
       runTeardown: (runtime: AcpRuntime) => runtime.connect({ cwd: '/workspace' }),
-      canStartSuccessor: false
+      canStartSuccessor: true
     }
   ])(
     'invalidates a pending primary startup before a failing $teardown can strand it',
     async ({ runTeardown, canStartSuccessor }) => {
-      const process = new FakeAgentProcess()
+      const oldProcess = new FakeAgentProcess()
+      const newProcess = new FakeAgentProcess()
       const pendingModeStarted = createDeferred()
       const releasePendingMode = createDeferred()
       let modeRequestCount = 0
-      startFakeAgent(process, ['active-primary', 'stale-primary', 'stale-primary'], {
+      startFakeAgent(oldProcess, ['active-primary', 'stale-primary'], {
         modes: createModes(['read-only', 'agent', 'agent-full-access'], 'agent'),
         onSetMode: async () => {
           modeRequestCount += 1
@@ -6813,14 +6925,25 @@ describe('ACP runtime session management', () => {
           }
         }
       })
+      startFakeAgent(newProcess, ['stale-primary'], {
+        modes: createModes(['read-only', 'agent', 'agent-full-access'], 'agent')
+      })
+      let spawnCount = 0
       const runtime = new AcpRuntime({
         appVersion: '0.1.0',
         defaultCwd: '/workspace',
-        resolveBackend: () => ({
-          framework: { ...codexFramework, spawn: () => asAgentProcess(process) },
-          executablePath: '/bin/codex-acp',
-          env: {}
-        })
+        resolveBackend: () => {
+          const useOld = spawnCount === 0
+          spawnCount += 1
+          return {
+            framework: {
+              ...codexFramework,
+              spawn: () => asAgentProcess(useOld ? oldProcess : newProcess)
+            },
+            executablePath: '/bin/codex-acp',
+            env: {}
+          }
+        }
       })
       const active = await runtime.createSession({ cwd: '/workspace' })
       const activeSession = (
@@ -6831,6 +6954,10 @@ describe('ACP runtime session management', () => {
         throw new Error('active primary disconnect dispose failed')
       })
       const pending = runtime.createSession({ cwd: '/workspace' })
+      const pendingOutcome = pending.then(
+        (value) => ({ value, error: undefined }),
+        (error: unknown) => ({ value: undefined, error })
+      )
       await pendingModeStarted.promise
       let successor: Awaited<ReturnType<AcpRuntime['createSession']>> | undefined
 
@@ -6848,7 +6975,10 @@ describe('ACP runtime session management', () => {
         }
 
         releasePendingMode.resolve()
-        await expect(pending).rejects.toThrow('ACP session startup was superseded.')
+        const staleOutcome = await pendingOutcome
+        expect(staleOutcome.error).toMatchObject({
+          message: 'ACP session startup was superseded.'
+        })
         if (canStartSuccessor) {
           expect(runtime.getSnapshot().sessionIds).toContain('stale-primary')
         } else {
@@ -6866,6 +6996,139 @@ describe('ACP runtime session management', () => {
       }
     }
   )
+
+  it('does not let a stale primary startup publish specialist or permission state', async () => {
+    const process = new FakeAgentProcess()
+    const staleModeStarted = createDeferred()
+    const releaseStaleMode = createDeferred()
+    startFakeAgent(process, ['shared-primary', 'shared-primary'], {
+      modes: createModes(['read-only', 'agent', 'agent-full-access'], 'agent'),
+      onSetMode: async ({ modeId }) => {
+        if (modeId === 'agent-full-access') {
+          staleModeStarted.resolve()
+          await releaseStaleMode.promise
+        }
+      }
+    })
+    const runtime = new AcpRuntime({
+      appVersion: '0.1.0',
+      defaultCwd: '/workspace',
+      resolveBackend: () => ({
+        framework: { ...codexFramework, spawn: () => asAgentProcess(process) },
+        executablePath: '/bin/codex-acp',
+        env: {}
+      }),
+      resolveSpecialistIdentity: async (specialistId) => ({
+        append: '',
+        prefix: `${specialistId} prefix`
+      })
+    })
+    await runtime.connect({ cwd: '/workspace' })
+    const disconnectCurrentSpy = vi
+      .spyOn(
+        runtime as unknown as {
+          disconnectCurrent: (emitClosedStatus?: boolean) => Promise<AcpStateSnapshot>
+        },
+        'disconnectCurrent'
+      )
+      .mockRejectedValueOnce(new Error('disconnect teardown failed'))
+    const stale = runtime.createSession({
+      cwd: '/workspace',
+      specialistId: 'stale-specialist',
+      permissionProfile: 'full'
+    })
+    await staleModeStarted.promise
+    let successor: Awaited<ReturnType<AcpRuntime['createSession']>> | undefined
+
+    try {
+      await expect(runtime.disconnect()).rejects.toThrow('disconnect teardown failed')
+      successor = await runtime.createSession({ cwd: '/workspace', permissionProfile: 'ask' })
+
+      releaseStaleMode.resolve()
+      await expect(stale).rejects.toThrow('ACP session startup was superseded.')
+      expect(runtime.getSnapshot().permissionProfiles['shared-primary']).toMatchObject({
+        selectedProfile: 'ask',
+        effectiveProfile: 'ask',
+        currentModeId: 'read-only'
+      })
+      expect(sessionSpecialistIds(runtime).has('shared-primary')).toBe(false)
+      expect(sessionSpecialistPrefixes(runtime).has('shared-primary')).toBe(false)
+    } finally {
+      releaseStaleMode.resolve()
+      await stale.catch(() => undefined)
+      disconnectCurrentSpy.mockRestore()
+      if (successor) await runtime.deleteSession({ sessionId: successor.sessionId })
+      await runtime.disconnect().catch(() => undefined)
+    }
+  })
+
+  it('does not let a stale primary model application replace its successor projection', async () => {
+    const process = new FakeAgentProcess()
+    const staleModelStarted = createDeferred()
+    const releaseStaleModel = createDeferred()
+    const configOptions = [
+      {
+        type: 'select',
+        id: 'model',
+        name: 'Model',
+        category: 'model',
+        currentValue: 'model-default',
+        options: [
+          { value: 'model-old', name: 'Old model' },
+          { value: 'model-new', name: 'New model' }
+        ]
+      } as SessionConfigOption
+    ]
+    startFakeAgent(process, ['shared-primary', 'shared-primary'], {
+      configOptions,
+      onSetConfigOption: async ({ value }) => {
+        if (value === 'model-old') {
+          staleModelStarted.resolve()
+          await releaseStaleModel.promise
+        }
+      }
+    })
+    const runtime = new AcpRuntime({
+      appVersion: '0.1.0',
+      defaultCwd: '/workspace',
+      resolveBackend: () => ({
+        framework: { ...opencodeFramework, spawn: () => asAgentProcess(process) },
+        executablePath: '/bin/opencode-acp',
+        env: {},
+        sessionModel: 'model-old'
+      }),
+      framework: opencodeFramework
+    })
+    await runtime.connect({ cwd: '/workspace' })
+    const disconnectCurrentSpy = vi
+      .spyOn(
+        runtime as unknown as {
+          disconnectCurrent: (emitClosedStatus?: boolean) => Promise<AcpStateSnapshot>
+        },
+        'disconnectCurrent'
+      )
+      .mockRejectedValueOnce(new Error('disconnect teardown failed'))
+    const stale = runtime.createSession({ cwd: '/workspace' })
+    await staleModelStarted.promise
+    let successor: Awaited<ReturnType<AcpRuntime['createSession']>> | undefined
+
+    try {
+      await expect(runtime.disconnect()).rejects.toThrow('disconnect teardown failed')
+      ;(runtime as unknown as { pendingSessionModel?: string }).pendingSessionModel = 'model-new'
+      successor = await runtime.createSession({ cwd: '/workspace' })
+      expect(appliedSessionModels(runtime).get('shared-primary')).toBe('model-new')
+
+      releaseStaleModel.resolve()
+      await expect(stale).rejects.toThrow('ACP session startup was superseded.')
+      expect(appliedSessionModels(runtime).get('shared-primary')).toBe('model-new')
+    } finally {
+      releaseStaleModel.resolve()
+      await stale.catch(() => undefined)
+      disconnectCurrentSpy.mockRestore()
+      if (successor) await runtime.deleteSession({ sessionId: successor.sessionId })
+      await runtime.disconnect().catch(() => undefined)
+    }
+  })
 
   it('disposes a created primary session when teardown invalidates its startup', async () => {
     const process = new FakeAgentProcess()
@@ -6906,9 +7169,9 @@ describe('ACP runtime session management', () => {
 
       await expect(pending).rejects.toThrow('ACP session startup was superseded.')
       expect(disposeSpy).toHaveBeenCalledOnce()
-      expect(
-        (disposeSpy.mock.instances[0] as unknown as { sessionId?: string })?.sessionId
-      ).toBe('stale-primary')
+      expect((disposeSpy.mock.instances[0] as unknown as { sessionId?: string })?.sessionId).toBe(
+        'stale-primary'
+      )
     } finally {
       releasePendingMode.resolve()
       await pending.catch(() => undefined)
@@ -7030,6 +7293,158 @@ describe('ACP runtime session management', () => {
     })
   })
 
+  it('fully detaches the old backend when a primary dispose fails during disconnect', async () => {
+    const oldProcess = new FakeAgentProcess()
+    const newProcess = new FakeAgentProcess()
+    startFakeAgent(oldProcess, ['active-primary'])
+    startFakeAgent(newProcess, ['fresh-primary'])
+    const oldBridge = createBackendLeaseHarness()
+    const newBridge = createBackendLeaseHarness()
+    let spawnCount = 0
+    const runtime = new AcpRuntime({
+      appVersion: '0.1.0',
+      defaultCwd: '/workspace',
+      resolveBackend: () => {
+        const useOld = spawnCount === 0
+        spawnCount += 1
+        return {
+          framework: {
+            ...claudeCodeFramework,
+            spawn: () => asAgentProcess(useOld ? oldProcess : newProcess)
+          },
+          executablePath: '/bin/agent',
+          env: {},
+          responsesBridgeLease: useOld ? oldBridge.lease : newBridge.lease
+        }
+      }
+    })
+    const active = await runtime.createSession({ cwd: '/workspace' })
+    const activeSession = (
+      runtime as unknown as { sessions: Map<string, { dispose: () => void }> }
+    ).sessions.get(active.sessionId)!
+    const disposeActive = activeSession.dispose.bind(activeSession)
+    activeSession.dispose = vi.fn(() => {
+      throw new Error('active primary dispose failed')
+    })
+
+    try {
+      await expect(runtime.disconnect()).rejects.toThrow('active primary dispose failed')
+      expect(oldProcess.killed).toBe(true)
+      expect(oldBridge.release).toHaveBeenCalledOnce()
+      expect(runtime.getSnapshot().sessionIds).toEqual([])
+
+      await expect(runtime.createSession({ cwd: '/workspace' })).resolves.toMatchObject({
+        sessionId: 'fresh-primary'
+      })
+      expect(spawnCount).toBe(2)
+    } finally {
+      activeSession.dispose = disposeActive
+      await runtime.disconnect().catch(() => undefined)
+    }
+  })
+
+  it('does not let an older teardown complete a newer reconnect intent', async () => {
+    const process = new FakeAgentProcess()
+    startFakeAgent(process, [])
+    const runtime = new AcpRuntime({
+      appVersion: '0.1.0',
+      defaultCwd: '/workspace',
+      spawnAgent: () => asAgentProcess(process)
+    })
+    await runtime.connect({ cwd: '/workspace' })
+    const oldCloseStarted = createDeferred()
+    const releaseOldClose = createDeferred()
+    const closeMcpHttpHostSpy = vi
+      .spyOn(runtime as unknown as { closeMcpHttpHost: () => Promise<void> }, 'closeMcpHttpHost')
+      .mockImplementationOnce(async () => {
+        oldCloseStarted.resolve()
+        await releaseOldClose.promise
+      })
+    const oldDisconnect = runtime.disconnect()
+    await oldCloseStarted.promise
+    const releaseActivity = createDeferred()
+    const activity = runtime.withActivity({}, async () => releaseActivity.promise)
+
+    try {
+      await runtime.requestProviderReconnect()
+      expect(
+        (runtime as unknown as { pendingProviderReconnect: boolean }).pendingProviderReconnect
+      ).toBe(true)
+      expect(
+        (runtime as unknown as { reconnectBarrier?: Promise<void> }).reconnectBarrier
+      ).toBeDefined()
+
+      releaseOldClose.resolve()
+      await oldDisconnect
+      expect(
+        (runtime as unknown as { pendingProviderReconnect: boolean }).pendingProviderReconnect
+      ).toBe(true)
+      expect(
+        (runtime as unknown as { reconnectBarrier?: Promise<void> }).reconnectBarrier
+      ).toBeDefined()
+
+      releaseActivity.resolve()
+      await activity
+      await vi.waitFor(() =>
+        expect(
+          (runtime as unknown as { reconnectBarrier?: Promise<void> }).reconnectBarrier
+        ).toBeUndefined()
+      )
+    } finally {
+      releaseOldClose.resolve()
+      releaseActivity.resolve()
+      await oldDisconnect.catch(() => undefined)
+      await activity.catch(() => undefined)
+      closeMcpHttpHostSpy.mockRestore()
+      await runtime.disconnect().catch(() => undefined)
+    }
+  })
+
+  it('releases an armed reconnect barrier during synchronous shutdown', async () => {
+    const oldProcess = new FakeAgentProcess()
+    const abandonedProcess = new FakeAgentProcess()
+    startFakeAgent(oldProcess, ['active-reviewer'])
+    startFakeAgent(abandonedProcess, ['must-not-publish'])
+    let spawnCount = 0
+    const runtime = new AcpRuntime({
+      appVersion: '0.1.0',
+      defaultCwd: '/workspace',
+      resolveBackend: () => {
+        const process = spawnCount === 0 ? oldProcess : abandonedProcess
+        spawnCount += 1
+        return {
+          framework: { ...claudeCodeFramework, spawn: () => asAgentProcess(process) },
+          executablePath: '/bin/agent',
+          env: {}
+        }
+      }
+    })
+    await runtime.buildReviewerSession({
+      cwd: '/workspace',
+      mcpServers: [
+        {
+          type: 'http',
+          name: 'open-science-reviewer',
+          url: 'http://127.0.0.1:1/mcp',
+          headers: []
+        }
+      ]
+    })
+    await runtime.requestProviderReconnect()
+    const blocked = runtime.createSession({ cwd: '/workspace' })
+
+    runtime.shutdown()
+
+    await expect(blocked).rejects.toThrow('ACP runtime is shutting down.')
+    expect(
+      (runtime as unknown as { reconnectBarrier?: Promise<void> }).reconnectBarrier
+    ).toBeUndefined()
+    expect(
+      (runtime as unknown as { pendingProviderReconnect: boolean }).pendingProviderReconnect
+    ).toBe(false)
+    expect(runtime.getSnapshot().sessionIds).toEqual([])
+  })
+
   it('reserves a resumed primary session id while its permission mode is still starting', async () => {
     const sessionId = '123e4567-e89b-42d3-a456-426614174000'
     const { fakeAgent, runtime, primary, reviewer, releasePrimaryMode, modeRequestCount } =
@@ -7068,6 +7483,92 @@ describe('ACP runtime session management', () => {
       )
     }
   })
+
+  it.each([
+    { path: 'resume', previousFrameworkId: undefined, contextReset: undefined },
+    { path: 'fresh adoption', previousFrameworkId: 'opencode' as const, contextReset: true }
+  ])(
+    'does not let a stale $path overwrite its same-id successor projections',
+    async ({ previousFrameworkId, contextReset }) => {
+      const process = new FakeAgentProcess()
+      const staleModeStarted = createDeferred()
+      const releaseStaleMode = createDeferred()
+      startFakeAgent(process, ['stale-provider', 'successor-provider'], {
+        modes: createModes(['read-only', 'agent', 'agent-full-access'], 'agent'),
+        onSetMode: async ({ modeId }) => {
+          if (modeId === 'agent-full-access') {
+            staleModeStarted.resolve()
+            await releaseStaleMode.promise
+          }
+        }
+      })
+      const runtime = new AcpRuntime({
+        appVersion: '0.1.0',
+        defaultCwd: '/workspace',
+        resolveBackend: () => ({
+          framework: { ...codexFramework, spawn: () => asAgentProcess(process) },
+          executablePath: '/bin/codex-acp',
+          env: {}
+        }),
+        resolveSpecialistIdentity: async (specialistId) => ({
+          append: '',
+          prefix: `${specialistId} prefix`
+        })
+      })
+      await runtime.connect({ cwd: '/workspace' })
+      const disconnectCurrentSpy = vi
+        .spyOn(
+          runtime as unknown as {
+            disconnectCurrent: (emitClosedStatus?: boolean) => Promise<AcpStateSnapshot>
+          },
+          'disconnectCurrent'
+        )
+        .mockRejectedValueOnce(new Error('disconnect teardown failed'))
+      const sessionId = '123e4567-e89b-42d3-a456-426614174000'
+      const stale = runtime.resumeSession({
+        sessionId,
+        cwd: '/workspace',
+        permissionProfile: 'full',
+        specialistId: 'stale-specialist',
+        ...(previousFrameworkId ? { previousFrameworkId } : {})
+      })
+      const staleOutcome = stale.then(
+        (value) => ({ value, error: undefined }),
+        (error: unknown) => ({ value: undefined, error })
+      )
+      await staleModeStarted.promise
+      let successor: Awaited<ReturnType<AcpRuntime['resumeSession']>> | undefined
+
+      try {
+        await expect(runtime.disconnect()).rejects.toThrow('disconnect teardown failed')
+        successor = await runtime.resumeSession({
+          sessionId,
+          cwd: '/workspace',
+          permissionProfile: 'ask',
+          ...(previousFrameworkId ? { previousFrameworkId } : {})
+        })
+        expect(successor.contextReset).toBe(contextReset)
+
+        releaseStaleMode.resolve()
+        const outcome = await staleOutcome
+        expect(outcome.error).toMatchObject({ message: 'ACP session startup was superseded.' })
+        expect(runtime.getSnapshot().permissionProfiles[sessionId]).toMatchObject({
+          selectedProfile: 'ask',
+          effectiveProfile: 'ask',
+          currentModeId: 'read-only'
+        })
+        expect(sessionSpecialistIds(runtime).has(sessionId)).toBe(false)
+        expect(sessionSpecialistPrefixes(runtime).has(sessionId)).toBe(false)
+        expect(runtime.getSnapshot().sessionIds).toEqual([sessionId])
+      } finally {
+        releaseStaleMode.resolve()
+        await staleOutcome
+        disconnectCurrentSpy.mockRestore()
+        if (successor) await runtime.deleteSession({ sessionId })
+        await runtime.disconnect().catch(() => undefined)
+      }
+    }
+  )
 
   it('reserves a known resumed app id before provider attach completes', async () => {
     const sessionId = '123e4567-e89b-42d3-a456-426614174000'

--- a/src/main/acp/runtime.ts
+++ b/src/main/acp/runtime.ts
@@ -282,11 +282,13 @@ export type ReviewerSessionDisposition = {
 }
 
 type PrimarySessionIdentityReservation = {
+  deletionEpochs: Map<string, number>
   generation: number
   // A startup that begins without a usable connection (or behind an already-armed reconnect barrier)
   // may cross the connection setup's expected invalidation exactly once. An explicit teardown that
   // starts after a live-session reset receives no such permit and cannot adopt a later successor.
   mayRenewAfterConnectionSetup: boolean
+  released: boolean
   token: symbol
   sessionIds: Set<string>
 }
@@ -668,6 +670,12 @@ class AcpRuntime {
   // for publication. Tokens make multi-id reservations owner-aware so one concurrent startup can never
   // release another startup's identity.
   private readonly pendingPrimarySessionIds = new Map<string, symbol>()
+  // Explicit deletion must supersede any same-id reset/resume that was already waiting for connection
+  // setup. Keep a per-id epoch across disconnects so a detached delete cannot be mistaken for the
+  // reconnect teardown that removed the captured ActiveSession.
+  private readonly primarySessionDeletionEpochs = new Map<string, number>()
+  private readonly primarySessionDeletionsInFlight = new Map<string, number>()
+  private readonly primarySessionIdentityReservationCounts = new Map<string, number>()
   // A startup that begins while a reconnect barrier is already armed must not block the reconnect it
   // is waiting for. Once it reaches the replacement connection, renewal adds its token here so any
   // later reconnect waits for publication or rollback.
@@ -1529,6 +1537,7 @@ class AcpRuntime {
       const projectName = this.normalizeProjectName(request.projectName)
       log.info('createSession: ensureConnected', this.diagnosticContext())
       const connection = await this.ensureConnected(sessionCwd)
+      this.assertCurrentConnectedConnection(connection)
       const sessionStartupGeneration = this.sessionStartupGeneration
       const artifactSessionId = this.createArtifactSessionId()
       provisionalArtifactSessionId = artifactSessionId || undefined
@@ -1883,6 +1892,7 @@ class AcpRuntime {
     publishedSession: ActiveSession | undefined
   ): Promise<AcpCreateSessionResponse> {
     const connection = await this.ensureConnected(sessionCwd)
+    this.assertCurrentConnectedConnection(connection)
     const currentPublishedSession = this.sessions.get(request.sessionId)
     const reconnectReplacedPublishedSession =
       publishedSession !== undefined &&
@@ -2227,6 +2237,7 @@ class AcpRuntime {
     primaryIdentityReservation: PrimarySessionIdentityReservation
   ): Promise<AcpCreateSessionResponse> {
     const connection = await this.ensureConnected(sessionCwd)
+    this.assertCurrentConnectedConnection(connection)
     this.renewPrimarySessionIdentityReservation(primaryIdentityReservation)
     // A session created under a different framework can never be resumed by the current agent — each
     // framework keeps its own session store, so the request is guaranteed to fail and only makes the
@@ -3789,7 +3800,26 @@ class AcpRuntime {
 
   // Closes the agent-side session when supported, then removes local routing state.
   async deleteSession(request: AcpDeleteSessionRequest): Promise<AcpStateSnapshot> {
-    return this.withOperationLease(() => this.deleteSessionOperation(request))
+    this.primarySessionDeletionEpochs.set(
+      request.sessionId,
+      (this.primarySessionDeletionEpochs.get(request.sessionId) ?? 0) + 1
+    )
+    this.primarySessionDeletionsInFlight.set(
+      request.sessionId,
+      (this.primarySessionDeletionsInFlight.get(request.sessionId) ?? 0) + 1
+    )
+    try {
+      return await this.withOperationLease(() => this.deleteSessionOperation(request))
+    } finally {
+      const remainingDeletions =
+        (this.primarySessionDeletionsInFlight.get(request.sessionId) ?? 1) - 1
+      if (remainingDeletions > 0) {
+        this.primarySessionDeletionsInFlight.set(request.sessionId, remainingDeletions)
+      } else {
+        this.primarySessionDeletionsInFlight.delete(request.sessionId)
+      }
+      this.releasePrimarySessionDeletionEpochIfUnused(request.sessionId)
+    }
   }
 
   private async deleteSessionOperation(
@@ -6236,6 +6266,7 @@ class AcpRuntime {
     }
 
     const connection = await this.ensureConnected(request.cwd)
+    this.assertCurrentConnectedConnection(connection)
     const sessionStartupGeneration = this.sessionStartupGeneration
     const reviewerCwd = await mkdtemp(join(tmpdir(), 'open-science-reviewer-'))
 
@@ -6430,6 +6461,16 @@ class AcpRuntime {
     }
 
     const uniqueSessionIds = [...new Set(sessionIds)]
+    const deletionCollision = uniqueSessionIds.find((sessionId) =>
+      this.primarySessionDeletionsInFlight.has(sessionId)
+    )
+    if (deletionCollision) {
+      return {
+        collision: new Error(
+          `Primary session id collision with deletion in progress: ${deletionCollision}`
+        )
+      }
+    }
     const pendingReviewerCollision = uniqueSessionIds.find((sessionId) =>
       this.pendingReviewerSessionIds.has(sessionId)
     )
@@ -6466,10 +6507,12 @@ class AcpRuntime {
     const owner =
       reservation ??
       ({
+        deletionEpochs: new Map<string, number>(),
         generation,
         mayRenewAfterConnectionSetup: Boolean(
           this.reconnectBarrier || !this.connection || this.snapshotOwner.status !== 'connected'
         ),
+        released: false,
         token: Symbol('primary-session-identity'),
         sessionIds: new Set<string>()
       } satisfies PrimarySessionIdentityReservation)
@@ -6477,6 +6520,13 @@ class AcpRuntime {
       this.pendingSessionStartupBlockers.add(owner.token)
     }
     for (const sessionId of uniqueSessionIds) {
+      if (!owner.deletionEpochs.has(sessionId)) {
+        owner.deletionEpochs.set(sessionId, this.primarySessionDeletionEpochs.get(sessionId) ?? 0)
+        this.primarySessionIdentityReservationCounts.set(
+          sessionId,
+          (this.primarySessionIdentityReservationCounts.get(sessionId) ?? 0) + 1
+        )
+      }
       owner.sessionIds.add(sessionId)
       this.pendingPrimarySessionIds.set(sessionId, owner.token)
     }
@@ -6489,9 +6539,15 @@ class AcpRuntime {
   ): void {
     const previousGeneration = reservation.generation
     const previousMayRenewAfterConnectionSetup = reservation.mayRenewAfterConnectionSetup
+    const wasDeleted = [...reservation.sessionIds].some(
+      (sessionId) =>
+        reservation.deletionEpochs.get(sessionId) !==
+        (this.primarySessionDeletionEpochs.get(sessionId) ?? 0)
+    )
     if (
-      previousGeneration !== this.sessionStartupGeneration &&
-      !previousMayRenewAfterConnectionSetup
+      wasDeleted ||
+      (previousGeneration !== this.sessionStartupGeneration &&
+        !previousMayRenewAfterConnectionSetup)
     ) {
       throw new Error('ACP session startup was superseded.')
     }
@@ -6516,6 +6572,11 @@ class AcpRuntime {
     if (
       reservation.generation !== this.sessionStartupGeneration ||
       [...reservation.sessionIds].some(
+        (sessionId) =>
+          reservation.deletionEpochs.get(sessionId) !==
+          (this.primarySessionDeletionEpochs.get(sessionId) ?? 0)
+      ) ||
+      [...reservation.sessionIds].some(
         (sessionId) => this.pendingPrimarySessionIds.get(sessionId) !== reservation.token
       )
     ) {
@@ -6523,14 +6584,39 @@ class AcpRuntime {
     }
   }
 
+  private assertCurrentConnectedConnection(connection: ClientConnection): void {
+    if (this.connection !== connection || this.snapshotOwner.status !== 'connected') {
+      throw new Error('ACP session startup was superseded.')
+    }
+  }
+
   private releasePrimarySessionIdentityReservation(
     reservation: PrimarySessionIdentityReservation
   ): void {
+    if (reservation.released) return
+    reservation.released = true
     this.pendingSessionStartupBlockers.delete(reservation.token)
     for (const sessionId of reservation.sessionIds) {
       if (this.pendingPrimarySessionIds.get(sessionId) === reservation.token) {
         this.pendingPrimarySessionIds.delete(sessionId)
       }
+      const remainingReservations =
+        (this.primarySessionIdentityReservationCounts.get(sessionId) ?? 1) - 1
+      if (remainingReservations > 0) {
+        this.primarySessionIdentityReservationCounts.set(sessionId, remainingReservations)
+      } else {
+        this.primarySessionIdentityReservationCounts.delete(sessionId)
+      }
+      this.releasePrimarySessionDeletionEpochIfUnused(sessionId)
+    }
+  }
+
+  private releasePrimarySessionDeletionEpochIfUnused(sessionId: string): void {
+    if (
+      !this.primarySessionDeletionsInFlight.has(sessionId) &&
+      !this.primarySessionIdentityReservationCounts.has(sessionId)
+    ) {
+      this.primarySessionDeletionEpochs.delete(sessionId)
     }
   }
 

--- a/src/main/acp/runtime.ts
+++ b/src/main/acp/runtime.ts
@@ -1101,7 +1101,6 @@ class AcpRuntime {
     if (!selection) {
       log.info('no matching session model option', this.diagnosticContext())
       if (this.pendingSessionModelRequired) {
-        session.dispose()
         throw new Error(
           `The selected model "${this.pendingSessionModel}" is not available for this Codex account.`
         )
@@ -1142,7 +1141,6 @@ class AcpRuntime {
         ...this.diagnosticContext()
       })
       if (this.pendingSessionModelRequired) {
-        session.dispose()
         throw new Error(
           `The selected model "${this.pendingSessionModel}" could not be applied: ${message}`
         )
@@ -2350,7 +2348,9 @@ class AcpRuntime {
       } catch (supersededError) {
         startupError = supersededError
       }
-      session?.dispose()
+      if (session) {
+        this.disposeSessionAfterFailure(session, 'resumed startup session disposal failed')
+      }
       if (notebookCapabilityProvisional) {
         this.releaseNotebookSessionCapabilities(request.sessionId)
       }
@@ -2460,7 +2460,9 @@ class AcpRuntime {
       } catch (supersededError) {
         startupError = supersededError
       }
-      adopted?.dispose()
+      if (adopted) {
+        this.disposeSessionAfterFailure(adopted, 'adopted startup session disposal failed')
+      }
       if (notebookCapabilityProvisional) {
         this.releaseNotebookSessionCapabilities(request.sessionId)
       }

--- a/src/main/acp/runtime.ts
+++ b/src/main/acp/runtime.ts
@@ -5638,6 +5638,26 @@ class AcpRuntime {
         })
         .start()
 
+      // Reviewer ids share protocol routing with primary/adopted sessions. An agent-provided
+      // collision must fail before the reviewer receives permission authority, bridge scope, or a
+      // prompt; otherwise its strict reviewer identity could overwrite state owned by a conversation.
+      if (
+        this.sessions.has(session.sessionId) ||
+        this.agentToAppSessionId.has(session.sessionId) ||
+        this.reviewerSessionIds.has(session.sessionId)
+      ) {
+        const collision = new Error(`Reviewer session id collision: ${session.sessionId}`)
+        try {
+          session.dispose()
+        } catch (cleanupError) {
+          safeLogError('reviewer collision session disposal failed', {
+            ...diagnosticErrorFields(cleanupError),
+            sessionId: session.sessionId
+          })
+        }
+        throw collision
+      }
+
       try {
         // Apply the framework's Ask baseline before prompting. The dedicated reviewer MCP is
         // then selectively approved by resolveReviewerPermission; all other permission requests fail.

--- a/src/main/acp/runtime.ts
+++ b/src/main/acp/runtime.ts
@@ -2261,7 +2261,13 @@ class AcpRuntime {
       log.info('skipping OpenCode session id for Claude resume; adopting a fresh session', {
         sessionId: request.sessionId
       })
-      return this.adoptFreshSession(connection, request, sessionCwd, projectName)
+      return this.adoptFreshSession(
+        connection,
+        request,
+        sessionCwd,
+        projectName,
+        primaryIdentityReservation
+      )
     }
 
     // Resume is optional in ACP. A cross-framework session was handled above and can always be

--- a/src/main/acp/runtime.ts
+++ b/src/main/acp/runtime.ts
@@ -1518,6 +1518,7 @@ class AcpRuntime {
     let releaseProvisionalNotebookConnection: (() => void) | undefined
     let primaryIdentityReservation: PrimarySessionIdentityReservation | undefined
     let provisionalSession: ActiveSession | undefined
+    let provisionalHttpMcpRoutes = false
     try {
       log.info('createSession: starting', this.diagnosticContext())
       const sessionCwd = resolve(request.cwd || this.snapshotOwner.cwd || this.options.defaultCwd)
@@ -1559,6 +1560,7 @@ class AcpRuntime {
       }
 
       log.info('createSession: createMcpServers', this.diagnosticContext())
+      provisionalHttpMcpRoutes = !this.framework.acceptsStdioMcp
       const mcpServers = await this.createMcpServers({
         artifactSessionId,
         notebookSessionId,
@@ -1716,11 +1718,14 @@ class AcpRuntime {
           'primary startup session disposal failed'
         )
       }
-      this.unregisterProvisionalHttpMcpRoutes([
-        provisionalArtifactSessionId,
-        provisionalNotebookSessionId,
-        provisionalSkillImportSessionId
-      ])
+      this.unregisterProvisionalHttpMcpRoutes(
+        [
+          provisionalArtifactSessionId,
+          provisionalNotebookSessionId,
+          provisionalSkillImportSessionId
+        ],
+        provisionalHttpMcpRoutes
+      )
       this.releaseProvisionalNotebookCapability(
         provisionalNotebookSessionId,
         releaseProvisionalNotebookConnection,
@@ -2281,9 +2286,11 @@ class AcpRuntime {
     let notebookCapabilityProvisional = Boolean(this.notebookOptions)
     let releaseProvisionalNotebookConnection: (() => void) | undefined
     let session: ActiveSession | undefined
+    let provisionalHttpMcpRoutes = false
     try {
       // Resumed sessions already have stable ids, so the artifact session mirrors the runtime session
       // id.
+      provisionalHttpMcpRoutes = !this.framework.acceptsStdioMcp
       const mcpServers = await this.createMcpServers({
         artifactSessionId: request.sessionId,
         notebookSessionId: request.sessionId,
@@ -2310,6 +2317,24 @@ class AcpRuntime {
         })
       } catch (error) {
         if (!isUnresumableSessionError(error)) throw error
+
+        // The failed resume crossed a network await. If teardown replaced this startup meanwhile,
+        // release only its concrete bearer lease and stop: broad app-id cleanup or fresh adoption
+        // could otherwise revoke or overwrite the same-id successor.
+        try {
+          this.assertPrimarySessionIdentityReservation(primaryIdentityReservation)
+        } catch (supersededError) {
+          if (notebookCapabilityProvisional) {
+            this.releaseProvisionalNotebookCapability(
+              request.sessionId,
+              releaseProvisionalNotebookConnection,
+              false
+            )
+            notebookCapabilityProvisional = false
+            releaseProvisionalNotebookConnection = undefined
+          }
+          throw supersededError
+        }
 
         // The agent could not resume this session (an app restart spawned a fresh agent process that no
         // longer holds it — surfacing as -32002 not-found or a generic -32603 Internal error). Revoke
@@ -2430,7 +2455,7 @@ class AcpRuntime {
         ownsProvisionalHttpRoutes = false
       }
       if (ownsProvisionalHttpRoutes) {
-        this.unregisterProvisionalHttpMcpRoutes([request.sessionId])
+        this.unregisterProvisionalHttpMcpRoutes([request.sessionId], provisionalHttpMcpRoutes)
       }
       if (session) {
         this.disposeSessionAfterFailure(session, 'resumed startup session disposal failed')
@@ -2463,7 +2488,9 @@ class AcpRuntime {
     let notebookCapabilityProvisional = Boolean(this.notebookOptions)
     let releaseProvisionalNotebookConnection: (() => void) | undefined
     let adopted: ActiveSession | undefined
+    let provisionalHttpMcpRoutes = false
     try {
+      provisionalHttpMcpRoutes = !this.framework.acceptsStdioMcp
       const mcpServers = await this.createMcpServers({
         artifactSessionId: request.sessionId,
         notebookSessionId: request.sessionId,
@@ -2564,7 +2591,7 @@ class AcpRuntime {
         ownsProvisionalHttpRoutes = false
       }
       if (ownsProvisionalHttpRoutes) {
-        this.unregisterProvisionalHttpMcpRoutes([request.sessionId])
+        this.unregisterProvisionalHttpMcpRoutes([request.sessionId], provisionalHttpMcpRoutes)
       }
       if (adopted) {
         this.disposeSessionAfterFailure(adopted, 'adopted startup session disposal failed')
@@ -4847,8 +4874,11 @@ class AcpRuntime {
   // unregisterHttpMcpSession. Drop their direct HTTP-host registrations while the startup still owns
   // its identity. A superseded resume/adoption skips this cleanup because teardown already cleared the
   // old generation and the same routing id may now belong to its successor.
-  private unregisterProvisionalHttpMcpRoutes(routingIds: readonly (string | undefined)[]): void {
-    if (!this.mcpHttpHost || this.framework.acceptsStdioMcp) return
+  private unregisterProvisionalHttpMcpRoutes(
+    routingIds: readonly (string | undefined)[],
+    usedHttpTransport: boolean
+  ): void {
+    if (!this.mcpHttpHost || !usedHttpTransport) return
 
     for (const routingId of new Set(routingIds)) {
       if (!routingId) continue

--- a/src/main/acp/runtime.ts
+++ b/src/main/acp/runtime.ts
@@ -618,6 +618,10 @@ class AcpRuntime {
   // handled by a strict allowlist: only the scope-bounded reviewer MCP is approved; every built-in tool is
   // rejected. Each session also gets an empty temporary cwd so ungated read-only tools see no project data.
   private readonly reviewerSessionIds = new Set<string>()
+  // Session/new returns an agent-owned id before the reviewer permission baseline has finished. Reserve
+  // that identity across the async mode switch so a concurrent reviewer cannot claim the same protocol
+  // route before either session has authority.
+  private readonly pendingReviewerSessionIds = new Set<string>()
   private readonly reviewerSessionDirectories = new Map<string, string>()
   // Per reviewer session: count of tool calls the strict allowlist rejected. Lets the orchestrator
   // distinguish "reviewer never called its tools" from "the gate blocked them" when a review ends
@@ -1505,6 +1509,12 @@ class AcpRuntime {
         })
         .start()
 
+      const pendingReviewerCollision = this.pendingReviewerSessionCollisionError(session.sessionId)
+      if (pendingReviewerCollision) {
+        this.disposeSessionAfterFailure(session, 'primary collision session disposal failed')
+        throw pendingReviewerCollision
+      }
+
       // For Codex / OpenCode the specialist identity rides every prompt turn as a prefix.
       // Store it now; sendPromptTurn reads it when composing each prompt.
       if (specialistPrefix) {
@@ -2075,6 +2085,16 @@ class AcpRuntime {
         ...resumeResponse
       })
 
+      const pendingReviewerCollision = this.pendingReviewerSessionCollisionError(
+        request.sessionId,
+        session.sessionId
+      )
+      if (pendingReviewerCollision) {
+        this.disposeSessionAfterFailure(session, 'primary collision session disposal failed')
+        session = undefined
+        throw pendingReviewerCollision
+      }
+
       await this.configurePermissionProfile(
         request.sessionId,
         session,
@@ -2160,6 +2180,16 @@ class AcpRuntime {
           )
         })
         .start()
+
+      const pendingReviewerCollision = this.pendingReviewerSessionCollisionError(
+        request.sessionId,
+        adopted.sessionId
+      )
+      if (pendingReviewerCollision) {
+        this.disposeSessionAfterFailure(adopted, 'primary collision session disposal failed')
+        adopted = undefined
+        throw pendingReviewerCollision
+      }
 
       await this.configurePermissionProfile(
         request.sessionId,
@@ -5641,16 +5671,9 @@ class AcpRuntime {
       // Reviewer ids share protocol routing with primary/adopted sessions. An agent-provided
       // collision must fail before the reviewer receives permission authority, bridge scope, or a
       // prompt; otherwise its strict reviewer identity could overwrite state owned by a conversation.
-      if (
-        this.sessions.has(session.sessionId) ||
-        this.agentToAppSessionId.has(session.sessionId) ||
-        this.reviewerSessionIds.has(session.sessionId)
-      ) {
+      if (!this.reserveReviewerSessionId(session.sessionId)) {
         const collision = new Error(`Reviewer session id collision: ${session.sessionId}`)
-        this.disposeReviewerSessionAfterFailure(
-          session,
-          'reviewer collision session disposal failed'
-        )
+        this.disposeSessionAfterFailure(session, 'reviewer collision session disposal failed')
         throw collision
       }
 
@@ -5664,25 +5687,52 @@ class AcpRuntime {
             modeId: permission.modeId
           })
         }
+
+        this.responsesBridgeLease?.registerReviewerSession(session.sessionId)
+        this.reviewerSessionDirectories.set(session.sessionId, reviewerCwd)
+        this.sessionMcpServerNames.set(session.sessionId, mcpServerNames)
+        this.sessionFrameworks.set(session.sessionId, this.framework.id)
+        // No await separates release from activation: protocol routing always sees exactly one of the
+        // pending or active identities, and reviewer permission authority appears only on success.
+        this.pendingReviewerSessionIds.delete(session.sessionId)
+        this.reviewerSessionIds.add(session.sessionId)
+
+        return { session, promptPrefix: setup.promptPrefix }
       } catch (error) {
-        this.disposeReviewerSessionAfterFailure(session, 'reviewer startup session disposal failed')
+        this.pendingReviewerSessionIds.delete(session.sessionId)
+        this.disposeSessionAfterFailure(session, 'reviewer startup session disposal failed')
         throw error
       }
-
-      this.reviewerSessionIds.add(session.sessionId)
-      this.responsesBridgeLease?.registerReviewerSession(session.sessionId)
-      this.reviewerSessionDirectories.set(session.sessionId, reviewerCwd)
-      this.sessionMcpServerNames.set(session.sessionId, mcpServerNames)
-      this.sessionFrameworks.set(session.sessionId, this.framework.id)
-
-      return { session, promptPrefix: setup.promptPrefix }
     } catch (error) {
       this.removeReviewerDirectory(reviewerCwd)
       throw error
     }
   }
 
-  private disposeReviewerSessionAfterFailure(session: ActiveSession, logMessage: string): void {
+  private reserveReviewerSessionId(sessionId: string): boolean {
+    if (
+      this.sessions.has(sessionId) ||
+      this.agentToAppSessionId.has(sessionId) ||
+      this.reviewerSessionIds.has(sessionId) ||
+      this.pendingReviewerSessionIds.has(sessionId)
+    ) {
+      return false
+    }
+
+    this.pendingReviewerSessionIds.add(sessionId)
+    return true
+  }
+
+  private pendingReviewerSessionCollisionError(...sessionIds: string[]): Error | undefined {
+    const collisionId = sessionIds.find((sessionId) =>
+      this.pendingReviewerSessionIds.has(sessionId)
+    )
+    return collisionId
+      ? new Error(`Primary session id collision with pending reviewer: ${collisionId}`)
+      : undefined
+  }
+
+  private disposeSessionAfterFailure(session: ActiveSession, logMessage: string): void {
     try {
       session.dispose()
     } catch (cleanupError) {

--- a/src/main/acp/runtime.ts
+++ b/src/main/acp/runtime.ts
@@ -2728,7 +2728,7 @@ class AcpRuntime {
       return await this.disconnectCurrent(emitClosedStatus, teardownGeneration)
     } finally {
       try {
-        await this.closeMcpHttpHost()
+        await this.closeMcpHttpHost(teardownGeneration)
       } finally {
         this.completePendingReconnectTeardown(reconnectBarrierGeneration)
       }
@@ -3217,7 +3217,13 @@ class AcpRuntime {
     }
   }
 
-  private async closeMcpHttpHost(): Promise<void> {
+  private async closeMcpHttpHost(expectedGeneration?: number): Promise<void> {
+    // The host instance is shared across reconnects. An older disconnect may finish after a successor
+    // has already registered routes on it, so only the generation that initiated teardown may close it.
+    // shutdown() omits the guard because it latches the runtime terminal before calling this helper.
+    if (expectedGeneration !== undefined && expectedGeneration !== this.connectionGeneration) {
+      return
+    }
     try {
       await this.mcpHttpHost?.close()
     } catch (error) {
@@ -6151,6 +6157,7 @@ class AcpRuntime {
 
   // Clears local state after the protocol connection closes unexpectedly.
   private handleConnectionClosed(): void {
+    const teardownGeneration = this.connectionGeneration
     this.invalidatePendingSessionStartups()
     const orphanedProcess = this.agentProcess
     if (orphanedProcess) {
@@ -6198,7 +6205,7 @@ class AcpRuntime {
     // and pick up the new backend from resolveBackend. A fresh spawn re-provisions
     // skills too, so clear both pending flags to avoid a spurious later reconnect.
     this.completePendingReconnectTeardown()
-    void this.closeMcpHttpHost()
+    void this.closeMcpHttpHost(teardownGeneration)
     void this.releaseResponsesBridgeLease()
     try {
       this.setStatus('closed')

--- a/src/main/acp/runtime.ts
+++ b/src/main/acp/runtime.ts
@@ -5647,14 +5647,10 @@ class AcpRuntime {
         this.reviewerSessionIds.has(session.sessionId)
       ) {
         const collision = new Error(`Reviewer session id collision: ${session.sessionId}`)
-        try {
-          session.dispose()
-        } catch (cleanupError) {
-          safeLogError('reviewer collision session disposal failed', {
-            ...diagnosticErrorFields(cleanupError),
-            sessionId: session.sessionId
-          })
-        }
+        this.disposeReviewerSessionAfterFailure(
+          session,
+          'reviewer collision session disposal failed'
+        )
         throw collision
       }
 
@@ -5669,7 +5665,7 @@ class AcpRuntime {
           })
         }
       } catch (error) {
-        session.dispose()
+        this.disposeReviewerSessionAfterFailure(session, 'reviewer startup session disposal failed')
         throw error
       }
 
@@ -5686,6 +5682,17 @@ class AcpRuntime {
     }
   }
 
+  private disposeReviewerSessionAfterFailure(session: ActiveSession, logMessage: string): void {
+    try {
+      session.dispose()
+    } catch (cleanupError) {
+      safeLogError(logMessage, {
+        ...diagnosticErrorFields(cleanupError),
+        sessionId: session.sessionId
+      })
+    }
+  }
+
   // Disposes an ephemeral reviewer session and unregisters it from the auto-approve set. Safe to call
   // even if the session was never registered (e.g. it failed before start). Returns the gate rejection
   // count plus whether a bridged reviewer request actually hit its trusted session scope. The reads and
@@ -5693,18 +5700,52 @@ class AcpRuntime {
   disposeReviewerSession(
     session: import('@agentclientprotocol/sdk').ActiveSession
   ): ReviewerSessionDisposition {
+    const cleanupFailures: unknown[] = []
+    const runCleanup = <Result>(stage: string, cleanup: () => Result): Result | undefined => {
+      try {
+        return cleanup()
+      } catch (cleanupError) {
+        cleanupFailures.push(cleanupError)
+        safeLogError('reviewer session cleanup failed', {
+          ...diagnosticErrorFields(cleanupError),
+          sessionId: session.sessionId,
+          stage
+        })
+        return undefined
+      }
+    }
+
     const rejectedToolCalls = this.reviewerRejectedToolCalls.get(session.sessionId) ?? 0
     this.reviewerSessionIds.delete(session.sessionId)
-    const reviewerBridgeScoped = this.unregisterReviewerBridgeSession(session.sessionId)
+    const reviewerBridgeScoped = runCleanup('bridge', () =>
+      this.unregisterReviewerBridgeSession(session.sessionId)
+    )
     this.sessionMcpServerNames.delete(session.sessionId)
-    this.permissionContext.clearCorrelationsForSession(session.sessionId)
+    runCleanup('permission-correlations', () =>
+      this.permissionContext.clearCorrelationsForSession(session.sessionId)
+    )
     this.sessionFrameworks.delete(session.sessionId)
     this.reviewerRejectedToolCalls.delete(session.sessionId)
     const reviewerCwd = this.reviewerSessionDirectories.get(session.sessionId)
     this.reviewerSessionDirectories.delete(session.sessionId)
-    session.dispose()
+
+    let disposeFailed = false
+    let disposeFailure: unknown
+    try {
+      session.dispose()
+    } catch (error) {
+      disposeFailed = true
+      disposeFailure = error
+    }
+
     if (reviewerCwd) this.removeReviewerDirectory(reviewerCwd)
-    this.maybeApplyPendingProviderReconnect()
+    runCleanup('reconnect-retirement', () => this.maybeApplyPendingProviderReconnect())
+
+    // Session disposal is the primary lifecycle failure. Every authority/resource cleanup above still
+    // runs, and any secondary failure is reported without replacing the error the caller must handle.
+    if (disposeFailed) throw disposeFailure
+    if (cleanupFailures.length > 0) throw cleanupFailures[0]
+
     return { rejectedToolCalls, reviewerBridgeScoped }
   }
 

--- a/src/main/acp/runtime.ts
+++ b/src/main/acp/runtime.ts
@@ -258,6 +258,16 @@ type ReviewerSessionResult = {
   promptPrefix?: string
 }
 
+type ReviewerSessionIdentityReservation = {
+  generation: number
+  sessionId: string
+  token: symbol
+}
+
+type ReviewerSessionIdentityReservationResult =
+  | { reservation: ReviewerSessionIdentityReservation; collision?: never }
+  | { reservation?: never; collision: Error }
+
 export type ReviewerSessionDisposition = {
   rejectedToolCalls: number
   // Undefined for frameworks/providers that do not traverse the Responses bridge.
@@ -265,6 +275,7 @@ export type ReviewerSessionDisposition = {
 }
 
 type PrimarySessionIdentityReservation = {
+  generation: number
   token: symbol
   sessionIds: Set<string>
 }
@@ -603,6 +614,7 @@ class AcpRuntime {
   private connection: ClientConnection | undefined
   private connectInFlight: Promise<AcpStateSnapshot> | undefined
   private connectionGeneration = 0
+  private sessionStartupGeneration = 0
   private currentSessionId: string | undefined
   private supportsSessionClose = false
   private supportsSessionDelete = false
@@ -630,11 +642,15 @@ class AcpRuntime {
   // Session/new returns an agent-owned id before the reviewer permission baseline has finished. Reserve
   // that identity across the async mode switch so a concurrent reviewer cannot claim the same protocol
   // route before either session has authority.
-  private readonly pendingReviewerSessionIds = new Set<string>()
+  private readonly pendingReviewerSessionIds = new Map<string, symbol>()
   // A primary startup can know both its stable app id and its provider protocol id before it is ready
   // for publication. Tokens make multi-id reservations owner-aware so one concurrent startup can never
   // release another startup's identity.
   private readonly pendingPrimarySessionIds = new Map<string, symbol>()
+  // A startup that begins while a reconnect barrier is already armed must not block the reconnect it
+  // is waiting for. Once it reaches the replacement connection, renewal adds its token here so any
+  // later reconnect waits for publication or rollback.
+  private readonly pendingSessionStartupBlockers = new Set<symbol>()
   private readonly reviewerSessionDirectories = new Map<string, string>()
   // Per reviewer session: count of tool calls the strict allowlist rejected. Lets the orchestrator
   // distinguish "reviewer never called its tools" from "the gate blocked them" when a review ends
@@ -1474,6 +1490,7 @@ class AcpRuntime {
       const projectName = this.normalizeProjectName(request.projectName)
       log.info('createSession: ensureConnected', this.diagnosticContext())
       const connection = await this.ensureConnected(sessionCwd)
+      const sessionStartupGeneration = this.sessionStartupGeneration
       const artifactSessionId = this.createArtifactSessionId()
       const notebookSessionId = this.createNotebookSessionId()
       provisionalNotebookSessionId = notebookSessionId || undefined
@@ -1525,7 +1542,12 @@ class AcpRuntime {
 
       // New-session requests have no app id on their interface: the provider-returned id becomes the
       // stable app id. Reserve that first known identity synchronously before any later setup awaits.
-      const reservationResult = this.reservePrimarySessionIds(undefined, [session.sessionId])
+      const reservationResult = this.reservePrimarySessionIds(
+        undefined,
+        [session.sessionId],
+        undefined,
+        sessionStartupGeneration
+      )
       if (reservationResult.collision) {
         this.disposeSessionAfterFailure(session, 'primary collision session disposal failed')
         throw reservationResult.collision
@@ -1560,6 +1582,7 @@ class AcpRuntime {
       const updatedConfigOptions = await this.applySessionModel(session)
       await this.applySessionEffort(session, updatedConfigOptions)
 
+      this.assertPrimarySessionIdentityReservation(primaryIdentityReservation)
       this.sessions.set(session.sessionId, session)
       this.releasePrimarySessionIdentityReservation(primaryIdentityReservation)
       primaryIdentityReservation = undefined
@@ -1732,6 +1755,10 @@ class AcpRuntime {
     primaryIdentityReservation: PrimarySessionIdentityReservation
   ): Promise<AcpCreateSessionResponse> {
     const connection = await this.ensureConnected(sessionCwd)
+    this.renewPrimarySessionIdentityReservation(
+      primaryIdentityReservation,
+      this.sessions.has(request.sessionId) ? request.sessionId : undefined
+    )
 
     // Tear down the currently attached agent session (if any) before adopting a replacement, dropping
     // its reverse routing so late events from the old agent session can no longer target this app id.
@@ -2061,6 +2088,7 @@ class AcpRuntime {
     primaryIdentityReservation: PrimarySessionIdentityReservation
   ): Promise<AcpCreateSessionResponse> {
     const connection = await this.ensureConnected(sessionCwd)
+    this.renewPrimarySessionIdentityReservation(primaryIdentityReservation)
     // A session created under a different framework can never be resumed by the current agent — each
     // framework keeps its own session store, so the request is guaranteed to fail and only makes the
     // agent log a scary internal error. Skip straight to adopting a fresh session (context still
@@ -2198,6 +2226,7 @@ class AcpRuntime {
       const updatedConfigOptions = await this.applySessionModel(session)
       await this.applySessionEffort(session, updatedConfigOptions)
 
+      this.assertPrimarySessionIdentityReservation(primaryIdentityReservation)
       this.sessions.set(request.sessionId, session)
       this.releasePrimarySessionIdentityReservation(primaryIdentityReservation)
       if (updatedConfigOptions) {
@@ -2296,6 +2325,7 @@ class AcpRuntime {
 
       const updatedConfigOptions = await this.applySessionModel(adopted)
       await this.applySessionEffort(adopted, updatedConfigOptions)
+      this.assertPrimarySessionIdentityReservation(primaryIdentityReservation)
       this.adoptSession(
         request.sessionId,
         adopted,
@@ -2365,6 +2395,7 @@ class AcpRuntime {
   // Tears down every local session route and closes the underlying agent process.
   async disconnect(emitClosedStatus = true): Promise<AcpStateSnapshot> {
     this.nextConnectionGeneration()
+    this.invalidatePendingSessionStartups()
     this.connectInFlight = undefined
 
     try {
@@ -2381,6 +2412,7 @@ class AcpRuntime {
   shutdown(): void {
     this.shuttingDown = true
     this.nextConnectionGeneration()
+    this.invalidatePendingSessionStartups()
     this.connectInFlight = undefined
     this.connection?.close()
     this.connection = undefined
@@ -2578,6 +2610,7 @@ class AcpRuntime {
       this.promptInFlightSessionIds.size > 0 ||
       this.contextCompactionInFlightSessionIds.size > 0 ||
       this.reviewerSessionIds.size > 0 ||
+      this.pendingSessionStartupBlockers.size > 0 ||
       this.activityLeaseCount > 0
     )
   }
@@ -5581,6 +5614,7 @@ class AcpRuntime {
 
   // Clears local state after the protocol connection closes unexpectedly.
   private handleConnectionClosed(): void {
+    this.invalidatePendingSessionStartups()
     const orphanedProcess = this.agentProcess
     if (orphanedProcess) {
       this.expectedProcessExits.add(orphanedProcess)
@@ -5730,6 +5764,7 @@ class AcpRuntime {
     }
 
     const connection = await this.ensureConnected(request.cwd)
+    const sessionStartupGeneration = this.sessionStartupGeneration
     const reviewerCwd = await mkdtemp(join(tmpdir(), 'open-science-reviewer-'))
 
     const setup = this.framework.buildSessionSetup({
@@ -5769,11 +5804,15 @@ class AcpRuntime {
       // Reviewer ids share protocol routing with primary/adopted sessions. An agent-provided
       // collision must fail before the reviewer receives permission authority, bridge scope, or a
       // prompt; otherwise its strict reviewer identity could overwrite state owned by a conversation.
-      if (!this.reserveReviewerSessionId(session.sessionId)) {
-        const collision = new Error(`Reviewer session id collision: ${session.sessionId}`)
+      const reservationResult = this.reserveReviewerSessionId(
+        session.sessionId,
+        sessionStartupGeneration
+      )
+      if (reservationResult.collision) {
         this.disposeSessionAfterFailure(session, 'reviewer collision session disposal failed')
-        throw collision
+        throw reservationResult.collision
       }
+      const identityReservation = reservationResult.reservation
 
       try {
         // Apply the framework's Ask baseline before prompting. The dedicated reviewer MCP is
@@ -5788,8 +5827,7 @@ class AcpRuntime {
 
         // No await separates the pending -> active transition: protocol routing always sees exactly
         // one identity state. Bridge authority is granted only after the active reviewer route exists.
-        this.pendingReviewerSessionIds.delete(session.sessionId)
-        this.reviewerSessionIds.add(session.sessionId)
+        this.activateReviewerSessionIdentity(identityReservation)
         this.responsesBridgeLease?.registerReviewerSession(session.sessionId)
         this.reviewerSessionDirectories.set(session.sessionId, reviewerCwd)
         this.sessionMcpServerNames.set(session.sessionId, mcpServerNames)
@@ -5797,7 +5835,7 @@ class AcpRuntime {
 
         return { session, promptPrefix: setup.promptPrefix }
       } catch (error) {
-        this.pendingReviewerSessionIds.delete(session.sessionId)
+        this.releaseReviewerSessionIdentityReservation(identityReservation)
         if (this.reviewerSessionIds.delete(session.sessionId)) {
           try {
             this.responsesBridgeLease?.unregisterReviewerSession(session.sessionId)
@@ -5817,7 +5855,14 @@ class AcpRuntime {
     }
   }
 
-  private reserveReviewerSessionId(sessionId: string): boolean {
+  private reserveReviewerSessionId(
+    sessionId: string,
+    generation: number
+  ): ReviewerSessionIdentityReservationResult {
+    if (generation !== this.sessionStartupGeneration) {
+      return { collision: new Error('ACP session startup was superseded.') }
+    }
+
     if (
       this.sessions.has(sessionId) ||
       this.agentToAppSessionId.has(sessionId) ||
@@ -5825,18 +5870,61 @@ class AcpRuntime {
       this.pendingReviewerSessionIds.has(sessionId) ||
       this.pendingPrimarySessionIds.has(sessionId)
     ) {
-      return false
+      return { collision: new Error(`Reviewer session id collision: ${sessionId}`) }
     }
 
-    this.pendingReviewerSessionIds.add(sessionId)
-    return true
+    const reservation = {
+      generation,
+      sessionId,
+      token: Symbol('reviewer-session-identity')
+    } satisfies ReviewerSessionIdentityReservation
+    this.pendingReviewerSessionIds.set(sessionId, reservation.token)
+    this.pendingSessionStartupBlockers.add(reservation.token)
+    return { reservation }
+  }
+
+  private activateReviewerSessionIdentity(
+    reservation: ReviewerSessionIdentityReservation
+  ): void {
+    if (
+      reservation.generation !== this.sessionStartupGeneration ||
+      this.pendingReviewerSessionIds.get(reservation.sessionId) !== reservation.token
+    ) {
+      throw new Error('ACP session startup was superseded.')
+    }
+
+    this.pendingReviewerSessionIds.delete(reservation.sessionId)
+    this.pendingSessionStartupBlockers.delete(reservation.token)
+    this.reviewerSessionIds.add(reservation.sessionId)
+  }
+
+  private releaseReviewerSessionIdentityReservation(
+    reservation: ReviewerSessionIdentityReservation
+  ): void {
+    this.pendingSessionStartupBlockers.delete(reservation.token)
+    if (this.pendingReviewerSessionIds.get(reservation.sessionId) === reservation.token) {
+      this.pendingReviewerSessionIds.delete(reservation.sessionId)
+    }
+  }
+
+  private invalidatePendingSessionStartups(): void {
+    this.sessionStartupGeneration += 1
+    this.pendingReviewerSessionIds.clear()
+    this.pendingPrimarySessionIds.clear()
+    this.pendingSessionStartupBlockers.clear()
   }
 
   private reservePrimarySessionIds(
     reservation: PrimarySessionIdentityReservation | undefined,
     sessionIds: string[],
-    publishedAppSessionId?: string
+    publishedAppSessionId?: string,
+    startupGeneration = reservation?.generation ?? this.sessionStartupGeneration
   ): PrimarySessionIdentityReservationResult {
+    const generation = reservation?.generation ?? startupGeneration
+    if (generation !== this.sessionStartupGeneration) {
+      return { collision: new Error('ACP session startup was superseded.') }
+    }
+
     const uniqueSessionIds = [...new Set(sessionIds)]
     const pendingReviewerCollision = uniqueSessionIds.find((sessionId) =>
       this.pendingReviewerSessionIds.has(sessionId)
@@ -5874,9 +5962,13 @@ class AcpRuntime {
     const owner =
       reservation ??
       ({
+        generation,
         token: Symbol('primary-session-identity'),
         sessionIds: new Set<string>()
       } satisfies PrimarySessionIdentityReservation)
+    if (!reservation && !this.reconnectBarrier) {
+      this.pendingSessionStartupBlockers.add(owner.token)
+    }
     for (const sessionId of uniqueSessionIds) {
       owner.sessionIds.add(sessionId)
       this.pendingPrimarySessionIds.set(sessionId, owner.token)
@@ -5884,9 +5976,41 @@ class AcpRuntime {
     return { reservation: owner }
   }
 
+  private renewPrimarySessionIdentityReservation(
+    reservation: PrimarySessionIdentityReservation,
+    publishedAppSessionId?: string
+  ): void {
+    const previousGeneration = reservation.generation
+    reservation.generation = this.sessionStartupGeneration
+    const result = this.reservePrimarySessionIds(
+      reservation,
+      [...reservation.sessionIds],
+      publishedAppSessionId
+    )
+    if (result.collision) {
+      reservation.generation = previousGeneration
+      throw result.collision
+    }
+    this.pendingSessionStartupBlockers.add(reservation.token)
+  }
+
+  private assertPrimarySessionIdentityReservation(
+    reservation: PrimarySessionIdentityReservation
+  ): void {
+    if (
+      reservation.generation !== this.sessionStartupGeneration ||
+      [...reservation.sessionIds].some(
+        (sessionId) => this.pendingPrimarySessionIds.get(sessionId) !== reservation.token
+      )
+    ) {
+      throw new Error('ACP session startup was superseded.')
+    }
+  }
+
   private releasePrimarySessionIdentityReservation(
     reservation: PrimarySessionIdentityReservation
   ): void {
+    this.pendingSessionStartupBlockers.delete(reservation.token)
     for (const sessionId of reservation.sessionIds) {
       if (this.pendingPrimarySessionIds.get(sessionId) === reservation.token) {
         this.pendingPrimarySessionIds.delete(sessionId)

--- a/src/main/acp/runtime.ts
+++ b/src/main/acp/runtime.ts
@@ -268,6 +268,13 @@ type ReviewerSessionIdentityReservationResult =
   | { reservation: ReviewerSessionIdentityReservation; collision?: never }
   | { reservation?: never; collision: Error }
 
+type ReviewerSessionOwner = {
+  cwd: string
+  session: ActiveSession
+  sessionId: string
+  token: symbol
+}
+
 export type ReviewerSessionDisposition = {
   rejectedToolCalls: number
   // Undefined for frameworks/providers that do not traverse the Responses bridge.
@@ -283,6 +290,11 @@ type PrimarySessionIdentityReservation = {
 type PrimarySessionIdentityReservationResult =
   | { reservation: PrimarySessionIdentityReservation; collision?: never }
   | { reservation?: never; collision: Error }
+
+type SessionModelApplication = {
+  appliedModel: string | undefined
+  configOptions: SessionConfigOption[] | null | undefined
+}
 
 type AcpRuntimeArtifactOptions = {
   // Config root: where the app-owned claude config dir lives (never relocated).
@@ -639,6 +651,11 @@ class AcpRuntime {
   // handled by a strict allowlist: only the scope-bounded reviewer MCP is approved; every built-in tool is
   // rejected. Each session also gets an empty temporary cwd so ungated read-only tools see no project data.
   private readonly reviewerSessionIds = new Set<string>()
+  private readonly reviewerSessionOwners = new Map<string, ReviewerSessionOwner>()
+  private readonly reviewerSessionOwnersBySession = new WeakMap<
+    ActiveSession,
+    ReviewerSessionOwner
+  >()
   // Session/new returns an agent-owned id before the reviewer permission baseline has finished. Reserve
   // that identity across the async mode switch so a concurrent reviewer cannot claim the same protocol
   // route before either session has authority.
@@ -721,6 +738,7 @@ class AcpRuntime {
   // queued blocks until the reconnect completes rather than reusing the stale connection.
   private reconnectBarrier: Promise<void> | undefined
   private reconnectBarrierResolve: (() => void) | undefined
+  private reconnectBarrierGeneration = 0
   private expectedProcessExits = new WeakSet<ChildProcessWithoutNullStreams>()
   private readonly permissionContext: AcpPermissionContext
   private readonly callbacks: AcpRuntimeCallbacks
@@ -1034,11 +1052,10 @@ class AcpRuntime {
   // Resolves an application profile against per-session ACP capabilities and applies the real Agent
   // mode before any prompt is sent. The selected/effective projection is then shared with the UI and
   // the conservative fallback reviewer.
-  private async configurePermissionProfile(
-    appSessionId: string,
+  private async applyPermissionProfileMode(
     session: ActiveSession,
     profile: PermissionProfileId
-  ): Promise<void> {
+  ): Promise<SessionPermissionProfileState> {
     const application = this.framework.mapPermissionProfile(profile, session.modes)
 
     if (application.modeId && application.modeId !== session.modes?.currentModeId) {
@@ -1050,8 +1067,19 @@ class AcpRuntime {
       })
     }
 
-    this.permissionProfiles.set(appSessionId, application.state)
     log.info('permission profile applied', this.diagnosticContext())
+    return application.state
+  }
+
+  private async configurePermissionProfile(
+    appSessionId: string,
+    session: ActiveSession,
+    profile: PermissionProfileId,
+    commit = true
+  ): Promise<SessionPermissionProfileState> {
+    const state = await this.applyPermissionProfileMode(session, profile)
+    if (commit) this.permissionProfiles.set(appSessionId, state)
+    return state
   }
 
   // Applies the active model to a freshly built/resumed session via the ACP model configOption, for
@@ -1060,11 +1088,10 @@ class AcpRuntime {
   // exists or application fails; required selections fail visibly rather than silently running another
   // model. Returns the agent's post-application configOptions when it reports them — effort levels are
   // model-dependent, so callers resolving further options must use the set from AFTER the model switch.
-  private async applySessionModel(
-    session: ActiveSession
-  ): Promise<SessionConfigOption[] | null | undefined> {
-    this.appliedSessionModels.delete(session.sessionId)
-    if (!this.pendingSessionModel || !this.connection) return undefined
+  private async applySessionModel(session: ActiveSession): Promise<SessionModelApplication> {
+    if (!this.pendingSessionModel || !this.connection) {
+      return { appliedModel: undefined, configOptions: undefined }
+    }
 
     const configOptions = (
       session as { newSessionResponse?: { configOptions?: SessionConfigOption[] | null } }
@@ -1079,7 +1106,7 @@ class AcpRuntime {
           `The selected model "${this.pendingSessionModel}" is not available for this Codex account.`
         )
       }
-      return undefined
+      return { appliedModel: undefined, configOptions: undefined }
     }
 
     // The agent already has the desired model — typically because the framework seeded it via
@@ -1088,8 +1115,7 @@ class AcpRuntime {
     // sending the same value back stalled the first prompt of a new session for ~2 min (issue #277).
     if (selection.alreadyCurrent) {
       log.info('session model already current', this.diagnosticContext())
-      this.appliedSessionModels.set(session.sessionId, selection.value)
-      return configOptions ?? null
+      return { appliedModel: selection.value, configOptions: configOptions ?? null }
     }
 
     try {
@@ -1102,11 +1128,13 @@ class AcpRuntime {
         }
       )) as { configOptions?: SessionConfigOption[] | null }
       log.info('session model applied', this.diagnosticContext())
-      this.appliedSessionModels.set(session.sessionId, selection.value)
       // The model switch rebuilds the agent's options (effort rungs are model-dependent). The
       // caller commits the fresh set to latestSessionConfigOptions once the session is registered,
       // so the map never holds an entry for a session that failed to attach.
-      return response?.configOptions ?? configOptions
+      return {
+        appliedModel: selection.value,
+        configOptions: response?.configOptions ?? configOptions
+      }
     } catch (error) {
       const message = error instanceof Error ? error.message : String(error)
       log.warn('set session model failed', {
@@ -1119,7 +1147,7 @@ class AcpRuntime {
           `The selected model "${this.pendingSessionModel}" could not be applied: ${message}`
         )
       }
-      return undefined
+      return { appliedModel: undefined, configOptions: undefined }
     }
   }
 
@@ -1558,20 +1586,14 @@ class AcpRuntime {
       }
       primaryIdentityReservation = reservationResult.reservation
 
-      // For Codex / OpenCode the specialist identity rides every prompt turn as a prefix.
-      // Store it now; sendPromptTurn reads it when composing each prompt.
-      if (specialistPrefix) {
-        this.sessionSpecialistPrefixes.set(session.sessionId, specialistPrefix)
-      }
-      if (request.specialistId)
-        this.sessionSpecialistIds.set(session.sessionId, request.specialistId)
-
       log.info('createSession: configurePermissionProfile', this.diagnosticContext())
+      let permissionState: SessionPermissionProfileState
       try {
-        await this.configurePermissionProfile(
+        permissionState = await this.configurePermissionProfile(
           session.sessionId,
           session,
-          normalizePermissionProfile(request.permissionProfile)
+          normalizePermissionProfile(request.permissionProfile),
+          false
         )
       } catch (error) {
         safeLogError('createSession: configurePermissionProfile failed', {
@@ -1582,18 +1604,37 @@ class AcpRuntime {
       }
 
       log.info('createSession: applySessionModel', this.diagnosticContext())
-      const updatedConfigOptions = await this.applySessionModel(session)
-      await this.applySessionEffort(session, updatedConfigOptions)
+      const modelApplication = await this.applySessionModel(session)
+      await this.applySessionEffort(session, modelApplication.configOptions)
 
       this.assertPrimarySessionIdentityReservation(primaryIdentityReservation)
+      // Commit app-owned projections only after the reservation is known to still own this id. No
+      // await separates this assertion from publication, so an invalidated startup cannot overwrite a
+      // same-id successor's Specialist, Permission, or model state.
+      if (specialistPrefix) {
+        this.sessionSpecialistPrefixes.set(session.sessionId, specialistPrefix)
+      } else {
+        this.sessionSpecialistPrefixes.delete(session.sessionId)
+      }
+      if (request.specialistId) {
+        this.sessionSpecialistIds.set(session.sessionId, request.specialistId)
+      } else {
+        this.sessionSpecialistIds.delete(session.sessionId)
+      }
+      this.permissionProfiles.set(session.sessionId, permissionState)
+      this.commitAppliedSessionModel(
+        session.sessionId,
+        session.sessionId,
+        modelApplication.appliedModel
+      )
       this.sessions.set(session.sessionId, session)
       provisionalSession = undefined
       this.releasePrimarySessionIdentityReservation(primaryIdentityReservation)
       primaryIdentityReservation = undefined
       // Committed only now: the options map must never hold an entry for a session that failed to
       // attach (a throw between apply and registration would orphan it).
-      if (updatedConfigOptions) {
-        this.latestSessionConfigOptions.set(session.sessionId, updatedConfigOptions)
+      if (modelApplication.configOptions) {
+        this.latestSessionConfigOptions.set(session.sessionId, modelApplication.configOptions)
       }
       this.sessionCwds.set(session.sessionId, sessionCwd)
       this.sessionMcpServerNames.set(session.sessionId, this.mcpServerNamesOf(mcpServers))
@@ -1623,6 +1664,14 @@ class AcpRuntime {
         ...(this.backendId ? { backendId: this.backendId } : {})
       }
     } catch (error) {
+      let startupError = error
+      if (primaryIdentityReservation) {
+        try {
+          this.assertPrimarySessionIdentityReservation(primaryIdentityReservation)
+        } catch (supersededError) {
+          startupError = supersededError
+        }
+      }
       if (provisionalSession) {
         this.disposeSessionAfterFailure(
           provisionalSession,
@@ -1633,10 +1682,10 @@ class AcpRuntime {
         this.releaseNotebookSessionCapabilities(provisionalNotebookSessionId)
       }
       safeLogError('createSession: failed', {
-        ...diagnosticErrorFields(error),
+        ...diagnosticErrorFields(startupError),
         ...this.diagnosticContext()
       })
-      throw error
+      throw startupError
     } finally {
       if (primaryIdentityReservation) {
         this.releasePrimarySessionIdentityReservation(primaryIdentityReservation)
@@ -1647,18 +1696,30 @@ class AcpRuntime {
   // Registers a freshly-built agent session under an app-facing id (used when adopting a conversation
   // onto a replaced agent after a provider switch). Remaps the agent's own id so later updates and
   // permission requests relabel into the same conversation.
+  private commitAppliedSessionModel(
+    appSessionId: string,
+    providerSessionId: string,
+    appliedModel: string | undefined
+  ): void {
+    if (appliedModel) {
+      this.appliedSessionModels.set(providerSessionId, appliedModel)
+      this.appliedSessionModels.set(appSessionId, appliedModel)
+      return
+    }
+    this.appliedSessionModels.delete(providerSessionId)
+    this.appliedSessionModels.delete(appSessionId)
+  }
+
   private adoptSession(
     appSessionId: string,
     session: ActiveSession,
     cwd: string,
     projectName: string,
-    mcpServerNames: string[]
+    mcpServerNames: string[],
+    appliedModel: string | undefined
   ): void {
     this.sessions.set(appSessionId, session)
-
-    const appliedModel = this.appliedSessionModels.get(session.sessionId)
-    if (appliedModel) this.appliedSessionModels.set(appSessionId, appliedModel)
-    else this.appliedSessionModels.delete(appSessionId)
+    this.commitAppliedSessionModel(appSessionId, session.sessionId, appliedModel)
 
     if (session.sessionId !== appSessionId) {
       this.agentToAppSessionId.set(session.sessionId, appSessionId)
@@ -1684,7 +1745,6 @@ class AcpRuntime {
   private async resumeSessionOperation(
     request: AcpResumeSessionRequest
   ): Promise<AcpCreateSessionResponse> {
-    if (request.specialistId) this.sessionSpecialistIds.set(request.sessionId, request.specialistId)
     const sessionCwd = resolve(request.cwd || this.snapshotOwner.cwd || this.options.defaultCwd)
     const projectName = this.normalizeProjectName(request.projectName)
 
@@ -1692,6 +1752,9 @@ class AcpRuntime {
     const attachedSession = this.sessions.get(request.sessionId)
 
     if (attachedSession) {
+      if (request.specialistId) {
+        this.sessionSpecialistIds.set(request.sessionId, request.specialistId)
+      }
       await this.configurePermissionProfile(
         request.sessionId,
         attachedSession,
@@ -2184,7 +2247,10 @@ class AcpRuntime {
           mcpServers,
           ...this.buildSessionMetaArg(
             [],
-            await this.resolveCurrentSpecialistSkills(request.sessionId)
+            await this.resolveCurrentSpecialistSkills(
+              request.sessionId,
+              request.specialistId ?? this.sessionSpecialistIds.get(request.sessionId)
+            )
           )
         })
       } catch (error) {
@@ -2227,20 +2293,30 @@ class AcpRuntime {
         throw reservationResult.collision
       }
 
-      await this.configurePermissionProfile(
+      const permissionState = await this.configurePermissionProfile(
         request.sessionId,
         session,
-        normalizePermissionProfile(request.permissionProfile)
+        normalizePermissionProfile(request.permissionProfile),
+        false
       )
 
-      const updatedConfigOptions = await this.applySessionModel(session)
-      await this.applySessionEffort(session, updatedConfigOptions)
+      const modelApplication = await this.applySessionModel(session)
+      await this.applySessionEffort(session, modelApplication.configOptions)
 
       this.assertPrimarySessionIdentityReservation(primaryIdentityReservation)
+      if (request.specialistId) {
+        this.sessionSpecialistIds.set(request.sessionId, request.specialistId)
+      }
+      this.permissionProfiles.set(request.sessionId, permissionState)
+      this.commitAppliedSessionModel(
+        request.sessionId,
+        session.sessionId,
+        modelApplication.appliedModel
+      )
       this.sessions.set(request.sessionId, session)
       this.releasePrimarySessionIdentityReservation(primaryIdentityReservation)
-      if (updatedConfigOptions) {
-        this.latestSessionConfigOptions.set(request.sessionId, updatedConfigOptions)
+      if (modelApplication.configOptions) {
+        this.latestSessionConfigOptions.set(request.sessionId, modelApplication.configOptions)
       }
       this.sessionCwds.set(request.sessionId, sessionCwd)
       this.sessionMcpServerNames.set(request.sessionId, this.mcpServerNamesOf(mcpServers))
@@ -2268,11 +2344,17 @@ class AcpRuntime {
         ...(this.backendId ? { backendId: this.backendId } : {})
       }
     } catch (error) {
+      let startupError = error
+      try {
+        this.assertPrimarySessionIdentityReservation(primaryIdentityReservation)
+      } catch (supersededError) {
+        startupError = supersededError
+      }
       session?.dispose()
       if (notebookCapabilityProvisional) {
         this.releaseNotebookSessionCapabilities(request.sessionId)
       }
-      throw error
+      throw startupError
     }
   }
 
@@ -2303,7 +2385,12 @@ class AcpRuntime {
       // A freshly adopted session carries no prior _meta, so the specialist identity append (Claude)
       // must be re-resolved from the live binding. Without this, a context reset or specialist switch
       // would silently drop the session's specialist identity.
-      const specialistAppend = await this.resolveCurrentSpecialistIdentityAppend(request.sessionId)
+      const stagedSpecialistId =
+        request.specialistId ?? this.sessionSpecialistIds.get(request.sessionId)
+      const specialistAppend = await this.resolveCurrentSpecialistIdentityAppend(
+        request.sessionId,
+        stagedSpecialistId
+      )
       const handoffAppend = this.pendingClaudeCodeHandoffAppends.get(request.sessionId)
       adopted = await connection.agent
         .buildSession({
@@ -2311,7 +2398,7 @@ class AcpRuntime {
           mcpServers,
           ...this.buildSessionMetaArg(
             [specialistAppend, handoffAppend].filter((append): append is string => Boolean(append)),
-            await this.resolveCurrentSpecialistSkills(request.sessionId)
+            await this.resolveCurrentSpecialistSkills(request.sessionId, stagedSpecialistId)
           )
         })
         .start()
@@ -2327,28 +2414,34 @@ class AcpRuntime {
       }
       primaryIdentityReservation = reservationResult.reservation
 
-      await this.configurePermissionProfile(
+      const permissionState = await this.configurePermissionProfile(
         request.sessionId,
         adopted,
-        normalizePermissionProfile(request.permissionProfile)
+        normalizePermissionProfile(request.permissionProfile),
+        false
       )
 
-      const updatedConfigOptions = await this.applySessionModel(adopted)
-      await this.applySessionEffort(adopted, updatedConfigOptions)
+      const modelApplication = await this.applySessionModel(adopted)
+      await this.applySessionEffort(adopted, modelApplication.configOptions)
       this.assertPrimarySessionIdentityReservation(primaryIdentityReservation)
+      if (request.specialistId) {
+        this.sessionSpecialistIds.set(request.sessionId, request.specialistId)
+      }
+      this.permissionProfiles.set(request.sessionId, permissionState)
       this.adoptSession(
         request.sessionId,
         adopted,
         sessionCwd,
         projectName,
-        this.mcpServerNamesOf(mcpServers)
+        this.mcpServerNamesOf(mcpServers),
+        modelApplication.appliedModel
       )
       this.pendingClaudeCodeHandoffAppends.delete(request.sessionId)
       this.releasePrimarySessionIdentityReservation(primaryIdentityReservation)
       // Keyed by the agent session id, matching the live-effort lookup over this.sessions values:
       // an adopted session's agent id differs from the app id it is registered under.
-      if (updatedConfigOptions) {
-        this.latestSessionConfigOptions.set(adopted.sessionId, updatedConfigOptions)
+      if (modelApplication.configOptions) {
+        this.latestSessionConfigOptions.set(adopted.sessionId, modelApplication.configOptions)
       }
       this.emitState()
       notebookCapabilityProvisional = false
@@ -2361,11 +2454,17 @@ class AcpRuntime {
         contextReset: true
       }
     } catch (error) {
+      let startupError = error
+      try {
+        this.assertPrimarySessionIdentityReservation(primaryIdentityReservation)
+      } catch (supersededError) {
+        startupError = supersededError
+      }
       adopted?.dispose()
       if (notebookCapabilityProvisional) {
         this.releaseNotebookSessionCapabilities(request.sessionId)
       }
-      throw error
+      throw startupError
     }
   }
 
@@ -2404,17 +2503,18 @@ class AcpRuntime {
 
   // Tears down every local session route and closes the underlying agent process.
   async disconnect(emitClosedStatus = true): Promise<AcpStateSnapshot> {
-    this.nextConnectionGeneration()
+    const teardownGeneration = this.nextConnectionGeneration()
+    const reconnectBarrierGeneration = this.reconnectBarrierGeneration
     this.invalidatePendingSessionStartups()
     this.connectInFlight = undefined
 
     try {
-      return await this.disconnectCurrent(emitClosedStatus)
+      return await this.disconnectCurrent(emitClosedStatus, teardownGeneration)
     } finally {
       try {
         await this.closeMcpHttpHost()
       } finally {
-        this.completePendingReconnectTeardown()
+        this.completePendingReconnectTeardown(reconnectBarrierGeneration)
       }
     }
   }
@@ -2553,6 +2653,7 @@ class AcpRuntime {
   // Tears down the connection for a deferred provider/skills reconnect, always releasing the
   // reconnect barrier — even if the disconnect rejects — and never leaking an unhandled rejection.
   private async disconnectForDeferredReconnect(): Promise<void> {
+    const reconnectBarrierGeneration = this.reconnectBarrierGeneration
     try {
       await this.disconnect()
     } catch (error) {
@@ -2573,7 +2674,9 @@ class AcpRuntime {
         safeLogError('emitState after failed deferred disconnect failed', errorLogFields(emitError))
       }
     } finally {
-      this.resolveReconnectBarrier()
+      // Tests and embedders may replace disconnect(), and a newer provider intent can arrive while
+      // this one is settling. Complete only the barrier generation this teardown was started for.
+      this.completePendingReconnectTeardown(reconnectBarrierGeneration)
     }
   }
 
@@ -2587,7 +2690,6 @@ class AcpRuntime {
     } catch (error) {
       safeLogError('retired runtime disconnect failed', errorLogFields(error))
     } finally {
-      this.resolveReconnectBarrier()
       try {
         this.callbacks.onRetired?.()
       } catch (error) {
@@ -2636,6 +2738,7 @@ class AcpRuntime {
 
   // Creates the reconnect barrier promise if one is not already pending.
   private armReconnectBarrier(): void {
+    this.reconnectBarrierGeneration += 1
     if (!this.reconnectBarrier) {
       this.reconnectBarrier = new Promise<void>((resolve) => {
         this.reconnectBarrierResolve = resolve
@@ -2651,69 +2754,110 @@ class AcpRuntime {
     resolve?.()
   }
 
-  private completePendingReconnectTeardown(): void {
+  private completePendingReconnectTeardown(expectedBarrierGeneration?: number): void {
+    if (
+      expectedBarrierGeneration !== undefined &&
+      expectedBarrierGeneration !== this.reconnectBarrierGeneration
+    ) {
+      return
+    }
     this.pendingProviderReconnect = false
     this.pendingSkillsReload = false
     this.resolveReconnectBarrier()
   }
 
-  private async disconnectCurrent(emitClosedStatus = true): Promise<AcpStateSnapshot> {
-    try {
-      for (const timer of this.cancelTimers.values()) this.clearTimer(timer)
-      this.cancelTimers.clear()
-      for (const controller of this.skillSelectorAbortControllers.values()) controller.abort()
-      this.skillSelectorAbortControllers.clear()
-      this.permissionContext.dispose()
-      this.clearReviewerSessionState()
-      this.promptInFlightSessionIds.clear()
-      this.contextCompactionInFlightSessionIds.clear()
-      // Context usage belongs to this live agent-context generation. Invalidate it before teardown,
-      // including when a later session.dispose throws. A reconnect may resume the native context or
-      // replay history into a fresh one; only that generation's own usage_update can repopulate it.
-      this.contextUsageTracker.clear()
-      this.contextUsageUpdatedPromptTurnsBySession.clear()
-      this.appliedSessionModels.clear()
-
-      this.releaseAllNotebookSessionCapabilities()
-
-      for (const session of this.sessions.values()) {
-        session.dispose()
+  private async disconnectCurrent(
+    emitClosedStatus = true,
+    teardownGeneration = this.connectionGeneration
+  ): Promise<AcpStateSnapshot> {
+    let teardownFailed = false
+    let teardownFailure: unknown
+    const recordFailure = (stage: string, error: unknown): void => {
+      if (!teardownFailed) {
+        teardownFailed = true
+        teardownFailure = error
+        return
       }
-
-      this.sessions.clear()
-      this.sessionCwds.clear()
-      this.sessionInlineImageBytes.clear()
-      this.currentPromptTurnBySession.clear()
-      this.currentPromptIdentityBySession.clear()
-      this.claudeTurnCountsBySession.clear()
-      this.latestSessionConfigOptions.clear()
-      this.sessionMcpServerNames.clear()
-      this.codexSkillActivity.clear()
-      this.cancelledPromptTurnsBySession.clear()
-      this.sessionProjectNames.clear()
-      this.permissionProfiles.clear()
-      this.artifactSessionIds.clear()
-      this.notebookRoutingIds.clear()
-      this.skillImportRoutingIds.clear()
-      this.skillImportTurnTokens.clear()
-      this.mcpHttpHost?.clear()
-      this.agentToAppSessionId.clear()
-      this.currentSessionId = undefined
-      this.supportsSessionClose = false
-      this.supportsSessionDelete = false
-      this.supportsSessionResume = false
-      this.connection?.close()
-      this.connection = undefined
-
-      await this.killAgentProcessTree()
-    } finally {
-      await this.releaseResponsesBridgeLease()
+      safeLogError('secondary ACP disconnect cleanup failed', {
+        ...diagnosticErrorFields(error),
+        stage
+      })
+    }
+    const runCleanup = (stage: string, cleanup: () => void): void => {
+      try {
+        cleanup()
+      } catch (error) {
+        recordFailure(stage, error)
+      }
     }
 
-    if (emitClosedStatus) {
-      this.setStatus('closed')
+    for (const timer of this.cancelTimers.values()) this.clearTimer(timer)
+    this.cancelTimers.clear()
+    for (const controller of this.skillSelectorAbortControllers.values()) controller.abort()
+    this.skillSelectorAbortControllers.clear()
+    runCleanup('permission-context', () => this.permissionContext.dispose())
+    runCleanup('reviewer-state', () => this.clearReviewerSessionState())
+    this.promptInFlightSessionIds.clear()
+    this.contextCompactionInFlightSessionIds.clear()
+    // Context usage belongs to this live agent-context generation. Invalidate it before teardown,
+    // including when a later session.dispose throws. A reconnect may resume the native context or
+    // replay history into a fresh one; only that generation's own usage_update can repopulate it.
+    this.contextUsageTracker.clear()
+    this.contextUsageUpdatedPromptTurnsBySession.clear()
+    this.appliedSessionModels.clear()
+
+    this.releaseAllNotebookSessionCapabilities()
+
+    for (const session of this.sessions.values()) {
+      runCleanup('primary-session', () => session.dispose())
     }
 
+    this.sessions.clear()
+    this.sessionCwds.clear()
+    this.sessionInlineImageBytes.clear()
+    this.currentPromptTurnBySession.clear()
+    this.currentPromptIdentityBySession.clear()
+    this.claudeTurnCountsBySession.clear()
+    this.latestSessionConfigOptions.clear()
+    this.sessionMcpServerNames.clear()
+    this.codexSkillActivity.clear()
+    this.cancelledPromptTurnsBySession.clear()
+    this.sessionProjectNames.clear()
+    this.permissionProfiles.clear()
+    this.artifactSessionIds.clear()
+    this.notebookRoutingIds.clear()
+    this.skillImportRoutingIds.clear()
+    this.skillImportTurnTokens.clear()
+    runCleanup('MCP HTTP routes', () => this.mcpHttpHost?.clear())
+    this.agentToAppSessionId.clear()
+    this.currentSessionId = undefined
+    this.supportsSessionClose = false
+    this.supportsSessionDelete = false
+    this.supportsSessionResume = false
+
+    // Detach generation-owned resources before the first teardown await. A newer connect may publish
+    // replacements while process/lease cleanup is still settling; the old teardown must never close or
+    // release those replacements when it resumes.
+    const connection = this.connection
+    this.connection = undefined
+    runCleanup('connection', () => connection?.close())
+    const agentProcess = this.agentProcess
+    if (this.agentProcess === agentProcess) this.agentProcess = undefined
+    const responsesBridgeLease = this.responsesBridgeLease
+    if (this.responsesBridgeLease === responsesBridgeLease) this.responsesBridgeLease = undefined
+
+    try {
+      await this.killAgentProcessTree(agentProcess)
+    } catch (error) {
+      recordFailure('agent-process', error)
+    }
+    await this.releaseResponsesBridgeLease(responsesBridgeLease)
+
+    if (emitClosedStatus && teardownGeneration === this.connectionGeneration) {
+      runCleanup('closed-status', () => this.setStatus('closed'))
+    }
+
+    if (teardownFailed) throw teardownFailure
     return this.getSnapshot()
   }
 
@@ -2736,9 +2880,10 @@ class AcpRuntime {
   // Awaitable tree teardown for the async disconnect path: marks the exit expected, then hands the
   // whole process tree to terminateProcessTree so a Windows grandchild (taskkill /T) is reaped before
   // the caller (before-quit shutdownBackends) proceeds to app.exit.
-  private async killAgentProcessTree(): Promise<void> {
-    const child = this.agentProcess
-    this.agentProcess = undefined
+  private async killAgentProcessTree(
+    child: ChildProcessWithoutNullStreams | undefined = this.agentProcess
+  ): Promise<void> {
+    if (this.agentProcess === child) this.agentProcess = undefined
     if (!child) return
     this.expectedProcessExits.add(child)
     const result = await terminateProcessTree(child, undefined, log)
@@ -2838,9 +2983,10 @@ class AcpRuntime {
     this.responsesBridgeLease = backend.responsesBridgeLease
   }
 
-  private async releaseResponsesBridgeLease(): Promise<void> {
-    const lease = this.responsesBridgeLease
-    this.responsesBridgeLease = undefined
+  private async releaseResponsesBridgeLease(
+    lease: ResolvedAgentBackend['responsesBridgeLease'] = this.responsesBridgeLease
+  ): Promise<void> {
+    if (this.responsesBridgeLease === lease) this.responsesBridgeLease = undefined
     try {
       await lease?.release()
     } catch (error) {
@@ -4658,9 +4804,9 @@ class AcpRuntime {
   }
 
   private async resolveCurrentSpecialistSkills(
-    sessionId: string
+    sessionId: string,
+    specialistId = this.sessionSpecialistIds.get(sessionId)
   ): Promise<EffectiveSpecialistSkills | undefined> {
-    const specialistId = this.sessionSpecialistIds.get(sessionId)
     if (!specialistId || !this.options.resolveSpecialistSkills) return undefined
     try {
       return await this.options.resolveSpecialistSkills(specialistId)
@@ -4673,9 +4819,9 @@ class AcpRuntime {
   // meaningful for Claude (append mode); returns undefined for Codex/OpenCode (prefix mode) or when
   // no specialist is bound. Used by adoptFreshSession so a context reset re-bakes the identity.
   private async resolveCurrentSpecialistIdentityAppend(
-    sessionId: string
+    sessionId: string,
+    specialistId = this.sessionSpecialistIds.get(sessionId)
   ): Promise<string | undefined> {
-    const specialistId = this.sessionSpecialistIds.get(sessionId)
     if (!specialistId || !this.options.resolveSpecialistIdentity) return undefined
     try {
       const identity = await this.options.resolveSpecialistIdentity(specialistId, this.framework.id)
@@ -5753,7 +5899,9 @@ class AcpRuntime {
       this.sessionFrameworks.delete(sessionId)
     }
     this.reviewerSessionDirectories.clear()
+    this.reviewerSessionOwners.clear()
     this.reviewerSessionIds.clear()
+    this.reviewerRejectedToolCalls.clear()
   }
 
   private removeReviewerDirectory(reviewerCwd: string): void {
@@ -5868,7 +6016,7 @@ class AcpRuntime {
 
         // No await separates the pending -> active transition: protocol routing always sees exactly
         // one identity state. Bridge authority is granted only after the active reviewer route exists.
-        this.activateReviewerSessionIdentity(identityReservation)
+        this.activateReviewerSessionIdentity(identityReservation, session, reviewerCwd)
         identityActivated = true
         this.responsesBridgeLease?.registerReviewerSession(session.sessionId)
         this.reviewerSessionDirectories.set(session.sessionId, reviewerCwd)
@@ -5877,8 +6025,21 @@ class AcpRuntime {
 
         return { session, promptPrefix: setup.promptPrefix }
       } catch (error) {
+        let startupError = error
+        if (!identityActivated) {
+          try {
+            this.assertReviewerSessionIdentityReservation(identityReservation)
+          } catch (supersededError) {
+            startupError = supersededError
+          }
+        }
         this.releaseReviewerSessionIdentityReservation(identityReservation)
-        if (identityActivated && this.reviewerSessionIds.delete(session.sessionId)) {
+        const activeOwner = this.reviewerSessionOwners.get(session.sessionId)
+        if (identityActivated && activeOwner?.session === session) {
+          this.reviewerSessionOwners.delete(session.sessionId)
+          this.reviewerSessionOwnersBySession.delete(session)
+          this.reviewerSessionIds.delete(session.sessionId)
+          this.reviewerRejectedToolCalls.delete(session.sessionId)
           try {
             this.responsesBridgeLease?.unregisterReviewerSession(session.sessionId)
           } catch (cleanupError) {
@@ -5889,7 +6050,7 @@ class AcpRuntime {
           }
         }
         this.disposeSessionAfterFailure(session, 'reviewer startup session disposal failed')
-        throw error
+        throw startupError
       }
     } catch (error) {
       this.removeReviewerDirectory(reviewerCwd)
@@ -5925,17 +6086,36 @@ class AcpRuntime {
     return { reservation }
   }
 
-  private activateReviewerSessionIdentity(reservation: ReviewerSessionIdentityReservation): void {
+  private activateReviewerSessionIdentity(
+    reservation: ReviewerSessionIdentityReservation,
+    session: ActiveSession,
+    cwd: string
+  ): void {
+    this.assertReviewerSessionIdentityReservation(reservation)
+
+    this.pendingReviewerSessionIds.delete(reservation.sessionId)
+    this.pendingSessionStartupBlockers.delete(reservation.token)
+    const owner = {
+      cwd,
+      session,
+      sessionId: reservation.sessionId,
+      token: reservation.token
+    } satisfies ReviewerSessionOwner
+    this.reviewerSessionOwners.set(reservation.sessionId, owner)
+    this.reviewerSessionOwnersBySession.set(session, owner)
+    this.reviewerRejectedToolCalls.delete(reservation.sessionId)
+    this.reviewerSessionIds.add(reservation.sessionId)
+  }
+
+  private assertReviewerSessionIdentityReservation(
+    reservation: ReviewerSessionIdentityReservation
+  ): void {
     if (
       reservation.generation !== this.sessionStartupGeneration ||
       this.pendingReviewerSessionIds.get(reservation.sessionId) !== reservation.token
     ) {
       throw new Error('ACP session startup was superseded.')
     }
-
-    this.pendingReviewerSessionIds.delete(reservation.sessionId)
-    this.pendingSessionStartupBlockers.delete(reservation.token)
-    this.reviewerSessionIds.add(reservation.sessionId)
   }
 
   private releaseReviewerSessionIdentityReservation(
@@ -6091,19 +6271,29 @@ class AcpRuntime {
       }
     }
 
-    const rejectedToolCalls = this.reviewerRejectedToolCalls.get(session.sessionId) ?? 0
-    this.reviewerSessionIds.delete(session.sessionId)
-    const reviewerBridgeScoped = runCleanup('bridge', () =>
-      this.unregisterReviewerBridgeSession(session.sessionId)
-    )
-    this.sessionMcpServerNames.delete(session.sessionId)
-    runCleanup('permission-correlations', () =>
-      this.permissionContext.clearCorrelationsForSession(session.sessionId)
-    )
-    this.sessionFrameworks.delete(session.sessionId)
-    this.reviewerRejectedToolCalls.delete(session.sessionId)
-    const reviewerCwd = this.reviewerSessionDirectories.get(session.sessionId)
-    this.reviewerSessionDirectories.delete(session.sessionId)
+    const owner = this.reviewerSessionOwnersBySession.get(session)
+    this.reviewerSessionOwnersBySession.delete(session)
+    const ownsActiveIdentity =
+      owner !== undefined && this.reviewerSessionOwners.get(owner.sessionId)?.token === owner.token
+    const rejectedToolCalls = ownsActiveIdentity
+      ? (this.reviewerRejectedToolCalls.get(session.sessionId) ?? 0)
+      : 0
+    let reviewerBridgeScoped: boolean | undefined
+    if (ownsActiveIdentity) {
+      this.reviewerSessionOwners.delete(session.sessionId)
+      this.reviewerSessionIds.delete(session.sessionId)
+      reviewerBridgeScoped = runCleanup('bridge', () =>
+        this.unregisterReviewerBridgeSession(session.sessionId)
+      )
+      this.sessionMcpServerNames.delete(session.sessionId)
+      runCleanup('permission-correlations', () =>
+        this.permissionContext.clearCorrelationsForSession(session.sessionId)
+      )
+      this.sessionFrameworks.delete(session.sessionId)
+      this.reviewerRejectedToolCalls.delete(session.sessionId)
+      this.reviewerSessionDirectories.delete(session.sessionId)
+    }
+    const reviewerCwd = owner?.cwd
 
     let disposeFailed = false
     let disposeFailure: unknown
@@ -6115,7 +6305,9 @@ class AcpRuntime {
     }
 
     if (reviewerCwd) this.removeReviewerDirectory(reviewerCwd)
-    runCleanup('reconnect-retirement', () => this.maybeApplyPendingProviderReconnect())
+    if (ownsActiveIdentity) {
+      runCleanup('reconnect-retirement', () => this.maybeApplyPendingProviderReconnect())
+    }
 
     // Session disposal is the primary lifecycle failure. Every authority/resource cleanup above still
     // runs, and any secondary failure is reported without replacing the error the caller must handle.

--- a/src/main/acp/runtime.ts
+++ b/src/main/acp/runtime.ts
@@ -264,6 +264,15 @@ export type ReviewerSessionDisposition = {
   reviewerBridgeScoped: boolean | undefined
 }
 
+type PrimarySessionIdentityReservation = {
+  token: symbol
+  sessionIds: string[]
+}
+
+type PrimarySessionIdentityReservationResult =
+  | { reservation: PrimarySessionIdentityReservation; collision?: never }
+  | { reservation?: never; collision: Error }
+
 type AcpRuntimeArtifactOptions = {
   // Config root: where the app-owned claude config dir lives (never relocated).
   configRoot: string
@@ -622,6 +631,10 @@ class AcpRuntime {
   // that identity across the async mode switch so a concurrent reviewer cannot claim the same protocol
   // route before either session has authority.
   private readonly pendingReviewerSessionIds = new Set<string>()
+  // A primary startup can know both its stable app id and its provider protocol id before it is ready
+  // for publication. Tokens make multi-id reservations owner-aware so one concurrent startup can never
+  // release another startup's identity.
+  private readonly pendingPrimarySessionIds = new Map<string, symbol>()
   private readonly reviewerSessionDirectories = new Map<string, string>()
   // Per reviewer session: count of tool calls the strict allowlist rejected. Lets the orchestrator
   // distinguish "reviewer never called its tools" from "the gate blocked them" when a review ends
@@ -1454,6 +1467,7 @@ class AcpRuntime {
     request: AcpCreateSessionRequest = {}
   ): Promise<AcpCreateSessionResponse> {
     let provisionalNotebookSessionId: string | undefined
+    let primaryIdentityReservation: PrimarySessionIdentityReservation | undefined
     try {
       log.info('createSession: starting', this.diagnosticContext())
       const sessionCwd = resolve(request.cwd || this.snapshotOwner.cwd || this.options.defaultCwd)
@@ -1509,11 +1523,12 @@ class AcpRuntime {
         })
         .start()
 
-      const pendingReviewerCollision = this.pendingReviewerSessionCollisionError(session.sessionId)
-      if (pendingReviewerCollision) {
+      const reservationResult = this.reservePrimarySessionIds(session.sessionId)
+      if (reservationResult.collision) {
         this.disposeSessionAfterFailure(session, 'primary collision session disposal failed')
-        throw pendingReviewerCollision
+        throw reservationResult.collision
       }
+      primaryIdentityReservation = reservationResult.reservation
 
       // For Codex / OpenCode the specialist identity rides every prompt turn as a prefix.
       // Store it now; sendPromptTurn reads it when composing each prompt.
@@ -1544,6 +1559,8 @@ class AcpRuntime {
       await this.applySessionEffort(session, updatedConfigOptions)
 
       this.sessions.set(session.sessionId, session)
+      this.releasePrimarySessionIdentityReservation(primaryIdentityReservation)
+      primaryIdentityReservation = undefined
       // Committed only now: the options map must never hold an entry for a session that failed to
       // attach (a throw between apply and registration would orphan it).
       if (updatedConfigOptions) {
@@ -1585,6 +1602,10 @@ class AcpRuntime {
         ...this.diagnosticContext()
       })
       throw error
+    } finally {
+      if (primaryIdentityReservation) {
+        this.releasePrimarySessionIdentityReservation(primaryIdentityReservation)
+      }
     }
   }
 
@@ -2039,6 +2060,7 @@ class AcpRuntime {
     // later setup failure must revoke it so an unattached Agent cannot retain host.mcp/compute access.
     let notebookCapabilityProvisional = Boolean(this.notebookOptions)
     let session: ActiveSession | undefined
+    let primaryIdentityReservation: PrimarySessionIdentityReservation | undefined
     try {
       // Resumed sessions already have stable ids, so the artifact session mirrors the runtime session
       // id.
@@ -2085,15 +2107,13 @@ class AcpRuntime {
         ...resumeResponse
       })
 
-      const pendingReviewerCollision = this.pendingReviewerSessionCollisionError(
-        request.sessionId,
-        session.sessionId
-      )
-      if (pendingReviewerCollision) {
+      const reservationResult = this.reservePrimarySessionIds(request.sessionId, session.sessionId)
+      if (reservationResult.collision) {
         this.disposeSessionAfterFailure(session, 'primary collision session disposal failed')
         session = undefined
-        throw pendingReviewerCollision
+        throw reservationResult.collision
       }
+      primaryIdentityReservation = reservationResult.reservation
 
       await this.configurePermissionProfile(
         request.sessionId,
@@ -2105,6 +2125,8 @@ class AcpRuntime {
       await this.applySessionEffort(session, updatedConfigOptions)
 
       this.sessions.set(request.sessionId, session)
+      this.releasePrimarySessionIdentityReservation(primaryIdentityReservation)
+      primaryIdentityReservation = undefined
       if (updatedConfigOptions) {
         this.latestSessionConfigOptions.set(request.sessionId, updatedConfigOptions)
       }
@@ -2139,6 +2161,10 @@ class AcpRuntime {
         this.releaseNotebookSessionCapabilities(request.sessionId)
       }
       throw error
+    } finally {
+      if (primaryIdentityReservation) {
+        this.releasePrimarySessionIdentityReservation(primaryIdentityReservation)
+      }
     }
   }
 
@@ -2157,6 +2183,7 @@ class AcpRuntime {
     // partially-created Agent session.
     let notebookCapabilityProvisional = Boolean(this.notebookOptions)
     let adopted: ActiveSession | undefined
+    let primaryIdentityReservation: PrimarySessionIdentityReservation | undefined
     try {
       const mcpServers = await this.createMcpServers({
         artifactSessionId: request.sessionId,
@@ -2181,15 +2208,13 @@ class AcpRuntime {
         })
         .start()
 
-      const pendingReviewerCollision = this.pendingReviewerSessionCollisionError(
-        request.sessionId,
-        adopted.sessionId
-      )
-      if (pendingReviewerCollision) {
+      const reservationResult = this.reservePrimarySessionIds(request.sessionId, adopted.sessionId)
+      if (reservationResult.collision) {
         this.disposeSessionAfterFailure(adopted, 'primary collision session disposal failed')
         adopted = undefined
-        throw pendingReviewerCollision
+        throw reservationResult.collision
       }
+      primaryIdentityReservation = reservationResult.reservation
 
       await this.configurePermissionProfile(
         request.sessionId,
@@ -2207,6 +2232,8 @@ class AcpRuntime {
         this.mcpServerNamesOf(mcpServers)
       )
       this.pendingClaudeCodeHandoffAppends.delete(request.sessionId)
+      this.releasePrimarySessionIdentityReservation(primaryIdentityReservation)
+      primaryIdentityReservation = undefined
       // Keyed by the agent session id, matching the live-effort lookup over this.sessions values:
       // an adopted session's agent id differs from the app id it is registered under.
       if (updatedConfigOptions) {
@@ -2228,6 +2255,10 @@ class AcpRuntime {
         this.releaseNotebookSessionCapabilities(request.sessionId)
       }
       throw error
+    } finally {
+      if (primaryIdentityReservation) {
+        this.releasePrimarySessionIdentityReservation(primaryIdentityReservation)
+      }
     }
   }
 
@@ -5714,7 +5745,8 @@ class AcpRuntime {
       this.sessions.has(sessionId) ||
       this.agentToAppSessionId.has(sessionId) ||
       this.reviewerSessionIds.has(sessionId) ||
-      this.pendingReviewerSessionIds.has(sessionId)
+      this.pendingReviewerSessionIds.has(sessionId) ||
+      this.pendingPrimarySessionIds.has(sessionId)
     ) {
       return false
     }
@@ -5723,13 +5755,60 @@ class AcpRuntime {
     return true
   }
 
-  private pendingReviewerSessionCollisionError(...sessionIds: string[]): Error | undefined {
-    const collisionId = sessionIds.find((sessionId) =>
+  private reservePrimarySessionIds(
+    ...sessionIds: string[]
+  ): PrimarySessionIdentityReservationResult {
+    const uniqueSessionIds = [...new Set(sessionIds)]
+    const pendingReviewerCollision = uniqueSessionIds.find((sessionId) =>
       this.pendingReviewerSessionIds.has(sessionId)
     )
-    return collisionId
-      ? new Error(`Primary session id collision with pending reviewer: ${collisionId}`)
-      : undefined
+    if (pendingReviewerCollision) {
+      return {
+        collision: new Error(
+          `Primary session id collision with pending reviewer: ${pendingReviewerCollision}`
+        )
+      }
+    }
+
+    const activeReviewerCollision = uniqueSessionIds.find((sessionId) =>
+      this.reviewerSessionIds.has(sessionId)
+    )
+    if (activeReviewerCollision) {
+      return {
+        collision: new Error(
+          `Primary session id collision with reviewer: ${activeReviewerCollision}`
+        )
+      }
+    }
+
+    const primaryCollision = uniqueSessionIds.find(
+      (sessionId) =>
+        this.pendingPrimarySessionIds.has(sessionId) ||
+        this.sessions.has(sessionId) ||
+        this.agentToAppSessionId.has(sessionId)
+    )
+    if (primaryCollision) {
+      return { collision: new Error(`Primary session id collision: ${primaryCollision}`) }
+    }
+
+    const reservation: PrimarySessionIdentityReservation = {
+      token: Symbol('primary-session-identity'),
+      sessionIds: uniqueSessionIds
+    }
+    for (const sessionId of uniqueSessionIds) {
+      this.pendingPrimarySessionIds.set(sessionId, reservation.token)
+    }
+    return { reservation }
+  }
+
+  private releasePrimarySessionIdentityReservation(
+    reservation: PrimarySessionIdentityReservation
+  ): void {
+    for (const sessionId of reservation.sessionIds) {
+      if (this.pendingPrimarySessionIds.get(sessionId) === reservation.token) {
+        this.pendingPrimarySessionIds.delete(sessionId)
+      }
+    }
   }
 
   private disposeSessionAfterFailure(session: ActiveSession, logMessage: string): void {

--- a/src/main/acp/runtime.ts
+++ b/src/main/acp/runtime.ts
@@ -800,6 +800,9 @@ class AcpRuntime {
   // app session id -> the notebook routing id registered with the http MCP host, so it can be
   // unregistered on session delete (the artifact routing id is tracked in artifactSessionIds).
   private readonly notebookRoutingIds = new Map<string, string>()
+  // Concrete bearer releases committed with their app Session. This preserves cleanup even if an
+  // optional alias callback fails, and prevents broad same-id revocation from crossing generations.
+  private readonly notebookCapabilityReleases = new Map<string, () => void>()
   private readonly skillImportRoutingIds = new Map<string, string>()
   private readonly skillImportTurnTokens = new Map<string, string>()
   // Refreshed before every session build. Defaults on for callers/tests that predate the preference.
@@ -1509,7 +1512,10 @@ class AcpRuntime {
   private async createSessionOperation(
     request: AcpCreateSessionRequest = {}
   ): Promise<AcpCreateSessionResponse> {
+    let provisionalArtifactSessionId: string | undefined
     let provisionalNotebookSessionId: string | undefined
+    let provisionalSkillImportSessionId: string | undefined
+    let releaseProvisionalNotebookConnection: (() => void) | undefined
     let primaryIdentityReservation: PrimarySessionIdentityReservation | undefined
     let provisionalSession: ActiveSession | undefined
     try {
@@ -1520,9 +1526,11 @@ class AcpRuntime {
       const connection = await this.ensureConnected(sessionCwd)
       const sessionStartupGeneration = this.sessionStartupGeneration
       const artifactSessionId = this.createArtifactSessionId()
+      provisionalArtifactSessionId = artifactSessionId || undefined
       const notebookSessionId = this.createNotebookSessionId()
       provisionalNotebookSessionId = notebookSessionId || undefined
       const skillImportSessionId = this.createSkillImportSessionId()
+      provisionalSkillImportSessionId = skillImportSessionId || undefined
 
       // Resolve specialist identity before starting the ACP session so the identity append is
       // included in session/new. Main process reads the latest Profile — renderer only sends the UUID.
@@ -1556,7 +1564,10 @@ class AcpRuntime {
         notebookSessionId,
         skillImportSessionId,
         sessionCwd,
-        projectName
+        projectName,
+        onNotebookConnection: (connection) => {
+          releaseProvisionalNotebookConnection = connection.release
+        }
       })
       log.info('createSession: buildSession', this.diagnosticContext())
       const extraAppends = specialistAppend ? [specialistAppend] : []
@@ -1641,18 +1652,47 @@ class AcpRuntime {
       if (this.backendId) this.sessionBackendIds.set(session.sessionId, this.backendId)
       this.rememberArtifactSession(session.sessionId, artifactSessionId)
       this.rememberNotebookSession(session.sessionId, notebookSessionId)
-      this.notebookOptions?.registerSessionSpecialist?.(session.sessionId, request.specialistId)
       this.rememberSkillImportSession(session.sessionId, skillImportSessionId)
+      this.commitNotebookCapabilityRelease(session.sessionId, releaseProvisionalNotebookConnection)
+      // Route and bearer ownership is now represented by the committed app-session maps. End the
+      // provisional rollback window before invoking external observers so their failures cannot tear
+      // down a Session that has already been published.
+      provisionalArtifactSessionId = undefined
+      provisionalNotebookSessionId = undefined
+      provisionalSkillImportSessionId = undefined
+      releaseProvisionalNotebookConnection = undefined
+      try {
+        this.notebookOptions?.registerSessionSpecialist?.(session.sessionId, request.specialistId)
+      } catch (error) {
+        safeLogError('register session specialist failed', {
+          ...diagnosticErrorFields(error),
+          sessionId: session.sessionId
+        })
+      }
       this.currentSessionId = session.sessionId
       this.snapshotOwner.updateCwd(sessionCwd)
-      this.pushEvent({
-        kind: 'system',
-        level: 'info',
-        sessionId: session.sessionId,
-        title: 'Session created',
-        text: sessionCwd
-      })
-      this.emitState()
+      try {
+        this.pushEvent({
+          kind: 'system',
+          level: 'info',
+          sessionId: session.sessionId,
+          title: 'Session created',
+          text: sessionCwd
+        })
+      } catch (error) {
+        safeLogError('session created event callback failed', {
+          ...diagnosticErrorFields(error),
+          sessionId: session.sessionId
+        })
+      }
+      try {
+        this.emitState()
+      } catch (error) {
+        safeLogError('session created state callback failed', {
+          ...diagnosticErrorFields(error),
+          sessionId: session.sessionId
+        })
+      }
 
       log.info('createSession: completed successfully', this.diagnosticContext())
       return {
@@ -1676,9 +1716,16 @@ class AcpRuntime {
           'primary startup session disposal failed'
         )
       }
-      if (provisionalNotebookSessionId) {
-        this.releaseNotebookSessionCapabilities(provisionalNotebookSessionId)
-      }
+      this.unregisterProvisionalHttpMcpRoutes([
+        provisionalArtifactSessionId,
+        provisionalNotebookSessionId,
+        provisionalSkillImportSessionId
+      ])
+      this.releaseProvisionalNotebookCapability(
+        provisionalNotebookSessionId,
+        releaseProvisionalNotebookConnection,
+        true
+      )
       safeLogError('createSession: failed', {
         ...diagnosticErrorFields(startupError),
         ...this.diagnosticContext()
@@ -2226,6 +2273,7 @@ class AcpRuntime {
     // A Notebook bearer token is provisional until the resumed session is fully registered. Any
     // later setup failure must revoke it so an unattached Agent cannot retain host.mcp/compute access.
     let notebookCapabilityProvisional = Boolean(this.notebookOptions)
+    let releaseProvisionalNotebookConnection: (() => void) | undefined
     let session: ActiveSession | undefined
     try {
       // Resumed sessions already have stable ids, so the artifact session mirrors the runtime session
@@ -2235,7 +2283,10 @@ class AcpRuntime {
         notebookSessionId: request.sessionId,
         skillImportSessionId: request.sessionId,
         sessionCwd,
-        projectName
+        projectName,
+        onNotebookConnection: (connection) => {
+          releaseProvisionalNotebookConnection = connection.release
+        }
       })
       let resumeResponse
       try {
@@ -2259,8 +2310,13 @@ class AcpRuntime {
         // the token handed to that failed attempt before adopting a brand-new agent session under the
         // SAME app id; adoptFreshSession owns the replacement token's lifecycle.
         if (notebookCapabilityProvisional) {
-          this.releaseNotebookSessionCapabilities(request.sessionId)
+          this.releaseProvisionalNotebookCapability(
+            request.sessionId,
+            releaseProvisionalNotebookConnection,
+            true
+          )
           notebookCapabilityProvisional = false
+          releaseProvisionalNotebookConnection = undefined
         }
         log.info('resumed session adopted after unrecoverable resume error', {
           sessionId: request.sessionId,
@@ -2322,18 +2378,35 @@ class AcpRuntime {
       this.sessionFrameworks.set(request.sessionId, this.framework.id)
       if (this.backendId) this.sessionBackendIds.set(request.sessionId, this.backendId)
       this.rememberArtifactSession(request.sessionId, request.sessionId)
+      this.rememberNotebookSession(request.sessionId, request.sessionId)
       this.rememberSkillImportSession(request.sessionId, request.sessionId)
+      this.commitNotebookCapabilityRelease(request.sessionId, releaseProvisionalNotebookConnection)
+      notebookCapabilityProvisional = false
+      releaseProvisionalNotebookConnection = undefined
       this.currentSessionId = request.sessionId
       this.snapshotOwner.updateCwd(sessionCwd)
-      this.pushEvent({
-        kind: 'system',
-        level: 'info',
-        sessionId: request.sessionId,
-        title: 'Session resumed',
-        text: sessionCwd
-      })
-      this.emitState()
-      notebookCapabilityProvisional = false
+      try {
+        this.pushEvent({
+          kind: 'system',
+          level: 'info',
+          sessionId: request.sessionId,
+          title: 'Session resumed',
+          text: sessionCwd
+        })
+      } catch (error) {
+        safeLogError('session resumed event callback failed', {
+          ...diagnosticErrorFields(error),
+          sessionId: request.sessionId
+        })
+      }
+      try {
+        this.emitState()
+      } catch (error) {
+        safeLogError('session resumed state callback failed', {
+          ...diagnosticErrorFields(error),
+          sessionId: request.sessionId
+        })
+      }
 
       return {
         sessionId: request.sessionId,
@@ -2343,16 +2416,25 @@ class AcpRuntime {
       }
     } catch (error) {
       let startupError = error
+      let ownsProvisionalHttpRoutes = true
       try {
         this.assertPrimarySessionIdentityReservation(primaryIdentityReservation)
       } catch (supersededError) {
         startupError = supersededError
+        ownsProvisionalHttpRoutes = false
+      }
+      if (ownsProvisionalHttpRoutes) {
+        this.unregisterProvisionalHttpMcpRoutes([request.sessionId])
       }
       if (session) {
         this.disposeSessionAfterFailure(session, 'resumed startup session disposal failed')
       }
       if (notebookCapabilityProvisional) {
-        this.releaseNotebookSessionCapabilities(request.sessionId)
+        this.releaseProvisionalNotebookCapability(
+          request.sessionId,
+          releaseProvisionalNotebookConnection,
+          ownsProvisionalHttpRoutes
+        )
       }
       throw startupError
     }
@@ -2373,6 +2455,7 @@ class AcpRuntime {
     // adoptSession has registered the replacement; every earlier failure revokes it and disposes any
     // partially-created Agent session.
     let notebookCapabilityProvisional = Boolean(this.notebookOptions)
+    let releaseProvisionalNotebookConnection: (() => void) | undefined
     let adopted: ActiveSession | undefined
     try {
       const mcpServers = await this.createMcpServers({
@@ -2380,7 +2463,10 @@ class AcpRuntime {
         notebookSessionId: request.sessionId,
         skillImportSessionId: request.sessionId,
         sessionCwd,
-        projectName
+        projectName,
+        onNotebookConnection: (connection) => {
+          releaseProvisionalNotebookConnection = connection.release
+        }
       })
       // A freshly adopted session carries no prior _meta, so the specialist identity append (Claude)
       // must be re-resolved from the live binding. Without this, a context reset or specialist switch
@@ -2443,8 +2529,17 @@ class AcpRuntime {
       if (modelApplication.configOptions) {
         this.latestSessionConfigOptions.set(adopted.sessionId, modelApplication.configOptions)
       }
-      this.emitState()
+      this.commitNotebookCapabilityRelease(request.sessionId, releaseProvisionalNotebookConnection)
       notebookCapabilityProvisional = false
+      releaseProvisionalNotebookConnection = undefined
+      try {
+        this.emitState()
+      } catch (error) {
+        safeLogError('adopted session state callback failed', {
+          ...diagnosticErrorFields(error),
+          sessionId: request.sessionId
+        })
+      }
 
       return {
         sessionId: request.sessionId,
@@ -2455,16 +2550,25 @@ class AcpRuntime {
       }
     } catch (error) {
       let startupError = error
+      let ownsProvisionalHttpRoutes = true
       try {
         this.assertPrimarySessionIdentityReservation(primaryIdentityReservation)
       } catch (supersededError) {
         startupError = supersededError
+        ownsProvisionalHttpRoutes = false
+      }
+      if (ownsProvisionalHttpRoutes) {
+        this.unregisterProvisionalHttpMcpRoutes([request.sessionId])
       }
       if (adopted) {
         this.disposeSessionAfterFailure(adopted, 'adopted startup session disposal failed')
       }
       if (notebookCapabilityProvisional) {
-        this.releaseNotebookSessionCapabilities(request.sessionId)
+        this.releaseProvisionalNotebookCapability(
+          request.sessionId,
+          releaseProvisionalNotebookConnection,
+          ownsProvisionalHttpRoutes
+        )
       }
       throw startupError
     }
@@ -3712,6 +3816,7 @@ class AcpRuntime {
     this.sessionSpecialistPrefixes.delete(request.sessionId)
     this.sessionSpecialistIds.delete(request.sessionId)
 
+    this.releaseCommittedNotebookCapability(request.sessionId)
     this.releaseNotebookSessionCapabilities(request.sessionId)
 
     // Only announce a deletion and shift the current session when something was actually attached; a
@@ -4491,7 +4596,15 @@ class AcpRuntime {
 
     if (notebookSessionId === sessionId) return
 
-    this.notebookOptions.registerSessionAlias?.(notebookSessionId, sessionId)
+    try {
+      this.notebookOptions.registerSessionAlias?.(notebookSessionId, sessionId)
+    } catch (error) {
+      safeLogError('register notebook session alias failed', {
+        ...diagnosticErrorFields(error),
+        aliasSessionId: notebookSessionId,
+        sessionId
+      })
+    }
   }
 
   // Capability cleanup is best-effort and must never replace the session lifecycle error that caused
@@ -4509,8 +4622,16 @@ class AcpRuntime {
   }
 
   private releaseAllNotebookSessionCapabilities(): void {
-    const sessionIds = new Set([...this.sessions.keys(), ...this.notebookRoutingIds.keys()])
-    for (const sessionId of sessionIds) this.releaseNotebookSessionCapabilities(sessionId)
+    const sessionIds = new Set([
+      ...this.sessions.keys(),
+      ...this.notebookRoutingIds.keys(),
+      ...this.notebookCapabilityReleases.keys()
+    ])
+    for (const sessionId of sessionIds) {
+      this.releaseCommittedNotebookCapability(sessionId)
+      this.releaseNotebookSessionCapabilities(sessionId)
+    }
+    this.notebookCapabilityReleases.clear()
   }
 
   private createSkillImportSessionId(): string {
@@ -4526,7 +4647,15 @@ class AcpRuntime {
     this.skillImportRoutingIds.set(sessionId, routingSessionId)
 
     if (routingSessionId !== sessionId) {
-      this.skillImportOptions.registerSessionAlias?.(routingSessionId, sessionId)
+      try {
+        this.skillImportOptions.registerSessionAlias?.(routingSessionId, sessionId)
+      } catch (error) {
+        safeLogError('register skill import session alias failed', {
+          ...diagnosticErrorFields(error),
+          aliasSessionId: routingSessionId,
+          sessionId
+        })
+      }
     }
   }
 
@@ -4534,11 +4663,13 @@ class AcpRuntime {
   private async buildNotebookEnvironment(
     notebookSessionId: string,
     sessionCwd: string,
-    projectName: string
+    projectName: string,
+    onConnection?: (connection: NotebookRpcConnection) => void
   ): Promise<NotebookMcpEnvironment | undefined> {
     if (!this.notebookOptions || !notebookSessionId) return undefined
 
     const connection = await this.resolveNotebookRpcConnection(notebookSessionId, projectName)
+    onConnection?.(connection)
 
     return {
       endpoint: connection.endpoint,
@@ -4553,12 +4684,14 @@ class AcpRuntime {
   private async createNotebookMcpServers(
     notebookSessionId: string,
     sessionCwd: string,
-    projectName: string
+    projectName: string,
+    onConnection?: (connection: NotebookRpcConnection) => void
   ): Promise<McpServer[]> {
     const environment = await this.buildNotebookEnvironment(
       notebookSessionId,
       sessionCwd,
-      projectName
+      projectName,
+      onConnection
     )
 
     if (!environment || !this.notebookOptions) return []
@@ -4619,13 +4752,15 @@ class AcpRuntime {
     notebookSessionId,
     skillImportSessionId,
     sessionCwd,
-    projectName
+    projectName,
+    onNotebookConnection
   }: {
     artifactSessionId: string
     notebookSessionId: string
     skillImportSessionId: string
     sessionCwd: string
     projectName: string
+    onNotebookConnection?: (connection: NotebookRpcConnection) => void
   }): Promise<McpServer[]> {
     // Bridge-backed Codex receives the app-owned notebook schemas as namespaced Chat aliases while the
     // actual tool remains attached here as MCP. Codex therefore keeps ownership of dispatch, approval,
@@ -4640,7 +4775,12 @@ class AcpRuntime {
           ...(artifactEnabled
             ? await this.createArtifactMcpServers(artifactSessionId, sessionCwd, projectName)
             : []),
-          ...(await this.createNotebookMcpServers(notebookSessionId, sessionCwd, projectName)),
+          ...(await this.createNotebookMcpServers(
+            notebookSessionId,
+            sessionCwd,
+            projectName,
+            onNotebookConnection
+          )),
           ...(await this.createSkillImportMcpServers(skillImportSessionId))
         ]
       : await this.createHttpMcpServers(
@@ -4648,7 +4788,8 @@ class AcpRuntime {
           notebookSessionId,
           skillImportSessionId,
           sessionCwd,
-          projectName
+          projectName,
+          onNotebookConnection
         )
 
     if (!artifactEnabled) {
@@ -4696,6 +4837,92 @@ class AcpRuntime {
     if (skillImportRoutingId) this.mcpHttpHost.unregister(skillImportRoutingId)
   }
 
+  // Failed startups have not committed their routing ids to the app-session maps used by
+  // unregisterHttpMcpSession. Drop their direct HTTP-host registrations while the startup still owns
+  // its identity. A superseded resume/adoption skips this cleanup because teardown already cleared the
+  // old generation and the same routing id may now belong to its successor.
+  private unregisterProvisionalHttpMcpRoutes(routingIds: readonly (string | undefined)[]): void {
+    if (!this.mcpHttpHost || this.framework.acceptsStdioMcp) return
+
+    for (const routingId of new Set(routingIds)) {
+      if (!routingId) continue
+      try {
+        this.mcpHttpHost.unregister(routingId)
+      } catch (error) {
+        safeLogError('provisional http MCP route cleanup failed', {
+          ...diagnosticErrorFields(error),
+          routingId,
+          ...this.diagnosticContext()
+        })
+      }
+    }
+  }
+
+  // Prefer the concrete connection lease so a stale startup can revoke only its own bearer. Injected
+  // adapters predating leases fall back to broad app-id cleanup only while this startup still owns that
+  // identity; broad cleanup after supersession could revoke the successor's Notebook/Compute token.
+  private releaseProvisionalNotebookCapability(
+    sessionId: string | undefined,
+    release: (() => void) | undefined,
+    ownsStableIdentity: boolean
+  ): void {
+    if (release) {
+      try {
+        release()
+      } catch (error) {
+        safeLogError('provisional notebook capability cleanup failed', {
+          ...diagnosticErrorFields(error),
+          sessionId
+        })
+      }
+    }
+
+    if (sessionId && ownsStableIdentity) {
+      this.releaseNotebookSessionCapabilities(sessionId)
+    }
+  }
+
+  private commitNotebookCapabilityRelease(
+    sessionId: string,
+    release: (() => void) | undefined
+  ): void {
+    const previousRelease = this.notebookCapabilityReleases.get(sessionId)
+    if (previousRelease === release) return
+
+    // Publish the replacement ownership before retiring the previous generation. If old cleanup
+    // throws, the new Session must still retain a reachable release handle for delete/disconnect.
+    if (release) {
+      this.notebookCapabilityReleases.set(sessionId, release)
+    } else {
+      this.notebookCapabilityReleases.delete(sessionId)
+    }
+    if (!previousRelease) return
+
+    try {
+      previousRelease()
+    } catch (error) {
+      safeLogError('replaced notebook capability cleanup failed', {
+        ...diagnosticErrorFields(error),
+        sessionId
+      })
+    }
+  }
+
+  private releaseCommittedNotebookCapability(sessionId: string): void {
+    const release = this.notebookCapabilityReleases.get(sessionId)
+    this.notebookCapabilityReleases.delete(sessionId)
+    if (!release) return
+
+    try {
+      release()
+    } catch (error) {
+      safeLogError('committed notebook capability cleanup failed', {
+        ...diagnosticErrorFields(error),
+        sessionId
+      })
+    }
+  }
+
   // Serves app-owned session MCP over the local http host for frameworks that reject stdio MCP.
   // Registers each session's environment under its app-owned id and returns http McpServer configs
   // pointing at the host, authenticated with the host token. No host wired ⇒ no servers (basic turn).
@@ -4704,7 +4931,8 @@ class AcpRuntime {
     notebookSessionId: string,
     skillImportSessionId: string,
     sessionCwd: string,
-    projectName: string
+    projectName: string,
+    onNotebookConnection?: (connection: NotebookRpcConnection) => void
   ): Promise<McpServer[]> {
     if (!this.mcpHttpHost) return []
 
@@ -4731,7 +4959,8 @@ class AcpRuntime {
     const notebookEnvironment = await this.buildNotebookEnvironment(
       notebookSessionId,
       sessionCwd,
-      projectName
+      projectName,
+      onNotebookConnection
     )
 
     if (notebookEnvironment) {
@@ -5800,6 +6029,7 @@ class AcpRuntime {
     this.sessionCwds.clear()
     this.sessionInlineImageBytes.clear()
     this.currentPromptTurnBySession.clear()
+    this.currentPromptIdentityBySession.clear()
     this.handoffPromptRequests.clear()
     this.handoffUserTasks.clear()
     this.pendingClaudeCodeHandoffAppends.clear()

--- a/src/main/acp/runtime.ts
+++ b/src/main/acp/runtime.ts
@@ -1069,14 +1069,16 @@ class AcpRuntime {
   // the conservative fallback reviewer.
   private async applyPermissionProfileMode(
     session: ActiveSession,
-    profile: PermissionProfileId
+    profile: PermissionProfileId,
+    connection: ClientConnection | undefined = this.connection
   ): Promise<SessionPermissionProfileState> {
     const application = this.framework.mapPermissionProfile(profile, session.modes)
 
     if (application.modeId && application.modeId !== session.modes?.currentModeId) {
-      if (!this.connection) throw new Error('ACP connection is not available.')
+      if (!connection) throw new Error('ACP connection is not available.')
+      this.assertCurrentConnectedConnection(connection)
 
-      await this.connection.agent.request(acp.methods.agent.session.setMode, {
+      await connection.agent.request(acp.methods.agent.session.setMode, {
         sessionId: session.sessionId,
         modeId: application.modeId
       })
@@ -1090,10 +1092,17 @@ class AcpRuntime {
     appSessionId: string,
     session: ActiveSession,
     profile: PermissionProfileId,
-    commit = true
+    commit = true,
+    connection: ClientConnection | undefined = this.connection
   ): Promise<SessionPermissionProfileState> {
-    const state = await this.applyPermissionProfileMode(session, profile)
-    if (commit) this.permissionProfiles.set(appSessionId, state)
+    const state = await this.applyPermissionProfileMode(session, profile, connection)
+    if (commit) {
+      if (this.sessions.get(appSessionId) !== session) {
+        throw new Error('ACP session startup was superseded.')
+      }
+      if (connection) this.assertCurrentConnectedConnection(connection)
+      this.permissionProfiles.set(appSessionId, state)
+    }
     return state
   }
 
@@ -1103,8 +1112,11 @@ class AcpRuntime {
   // exists or application fails; required selections fail visibly rather than silently running another
   // model. Returns the agent's post-application configOptions when it reports them — effort levels are
   // model-dependent, so callers resolving further options must use the set from AFTER the model switch.
-  private async applySessionModel(session: ActiveSession): Promise<SessionModelApplication> {
-    if (!this.pendingSessionModel || !this.connection) {
+  private async applySessionModel(
+    session: ActiveSession,
+    connection: ClientConnection | undefined = this.connection
+  ): Promise<SessionModelApplication> {
+    if (!this.pendingSessionModel || !connection) {
       return { appliedModel: undefined, configOptions: undefined }
     }
 
@@ -1132,15 +1144,13 @@ class AcpRuntime {
       return { appliedModel: selection.value, configOptions: configOptions ?? null }
     }
 
+    this.assertCurrentConnectedConnection(connection)
     try {
-      const response = (await this.connection.agent.request(
-        acp.methods.agent.session.setConfigOption,
-        {
-          sessionId: session.sessionId,
-          configId: selection.configId,
-          value: selection.value
-        }
-      )) as { configOptions?: SessionConfigOption[] | null }
+      const response = (await connection.agent.request(acp.methods.agent.session.setConfigOption, {
+        sessionId: session.sessionId,
+        configId: selection.configId,
+        value: selection.value
+      })) as { configOptions?: SessionConfigOption[] | null }
       log.info('session model applied', this.diagnosticContext())
       // The model switch rebuilds the agent's options (effort rungs are model-dependent). The
       // caller commits the fresh set to latestSessionConfigOptions once the session is registered,
@@ -1173,9 +1183,10 @@ class AcpRuntime {
   // never fatal to the session.
   private async applySessionEffort(
     session: ActiveSession,
-    configOptions?: SessionConfigOption[] | null
+    configOptions?: SessionConfigOption[] | null,
+    connection: ClientConnection | undefined = this.connection
   ): Promise<void> {
-    if (!this.pendingSessionEffort || !this.connection) return
+    if (!this.pendingSessionEffort || !connection) return
 
     const effectiveOptions =
       configOptions ??
@@ -1188,7 +1199,8 @@ class AcpRuntime {
       return
     }
 
-    await this.sendSessionEffort(session, selection)
+    this.assertCurrentConnectedConnection(connection)
+    await this.sendSessionEffort(session, selection, connection)
   }
 
   // Live-applies a reasoning-effort change to every open session — the ACP equivalent of a model
@@ -1209,7 +1221,8 @@ class AcpRuntime {
 
     this.pendingSessionEffort = effort === 'default' ? undefined : effort
     this.responsesBridgeLease?.setReasoningEffort?.(this.pendingSessionEffort)
-    if (!this.connection) return true
+    const connection = this.connection
+    if (!connection) return true
 
     let allApplied = true
     let appliedToAny = false
@@ -1226,7 +1239,7 @@ class AcpRuntime {
         continue
       }
 
-      if (!(await this.sendSessionEffort(session, selection))) {
+      if (!(await this.sendSessionEffort(session, selection, connection))) {
         allApplied = false
       } else {
         appliedToAny = true
@@ -1247,10 +1260,11 @@ class AcpRuntime {
   // non-fatal.
   private async sendSessionEffort(
     session: ActiveSession,
-    selection: SessionModelSelection
+    selection: SessionModelSelection,
+    connection: ClientConnection | undefined = this.connection
   ): Promise<boolean> {
     try {
-      await this.connection?.agent.request(acp.methods.agent.session.setConfigOption, {
+      await connection?.agent.request(acp.methods.agent.session.setConfigOption, {
         sessionId: session.sessionId,
         configId: selection.configId,
         value: selection.value
@@ -1300,6 +1314,8 @@ class AcpRuntime {
     // Captured at function scope so the catch can clean up the spawned child on every failure path —
     // including "superseded during spawn", where it is never assigned to this.agentProcess.
     let agentProcess: ChildProcessWithoutNullStreams | undefined
+    let connectionAuthentication: ResolvedAgentBackend['authentication']
+    let connectionProviderConfiguration: ResolvedAgentBackend['providerConfiguration']
     // The framework THIS connect spawned under, bound atomically to the spawn (spawnAgentProcess returns
     // it alongside the process, and tags a spawn-throw with it) rather than re-read from the mutable
     // this.framework, which an overlapping reconnect can move before the failure log is written. Seeded
@@ -1320,6 +1336,8 @@ class AcpRuntime {
       const spawned = await this.spawnAgentProcess()
       agentProcess = spawned.process
       spawnedFramework = spawned.framework
+      connectionAuthentication = spawned.backend.authentication
+      connectionProviderConfiguration = spawned.backend.providerConfiguration
 
       // spawnAgentProcess resolves the provider config asynchronously, so the connection may have been
       // torn down or superseded during the spawn: a quit latched shuttingDown, or any teardown/reconnect
@@ -1353,8 +1371,9 @@ class AcpRuntime {
         Readable.toWeb(this.agentProcess.stdout) as ReadableStream<Uint8Array>
       )
 
-      this.connection = this.createClientConnection(stream)
-      this.connection.closed.then(() => {
+      const connection = this.createClientConnection(stream)
+      this.connection = connection
+      connection.closed.then(() => {
         if (
           this.connectionGeneration === generation &&
           (this.snapshotOwner.status === 'connected' || this.snapshotOwner.status === 'connecting')
@@ -1364,7 +1383,7 @@ class AcpRuntime {
       })
 
       // Initialization tells the agent which client-side services this app can handle.
-      const initResult = await this.connection.agent.request(acp.methods.agent.initialize, {
+      const initResult = await connection.agent.request(acp.methods.agent.initialize, {
         protocolVersion: acp.PROTOCOL_VERSION,
         clientInfo: {
           name: 'open-science',
@@ -1383,15 +1402,22 @@ class AcpRuntime {
           plan: {}
         }
       })
+      this.assertCurrentConnectionOwner(connection, generation)
       if (this.pendingAuthentication) {
         const authentication = this.pendingAuthentication
-        this.pendingAuthentication = undefined
-        await this.connection.agent.request(acp.methods.agent.authenticate, authentication)
+        await connection.agent.request(acp.methods.agent.authenticate, authentication)
+        this.assertCurrentConnectionOwner(connection, generation)
+        if (this.pendingAuthentication === authentication) {
+          this.pendingAuthentication = undefined
+        }
       }
       if (this.pendingProviderConfiguration) {
         const providerConfiguration = this.pendingProviderConfiguration
-        this.pendingProviderConfiguration = undefined
-        await this.connection.agent.request(acp.methods.agent.providers.set, providerConfiguration)
+        await connection.agent.request(acp.methods.agent.providers.set, providerConfiguration)
+        this.assertCurrentConnectionOwner(connection, generation)
+        if (this.pendingProviderConfiguration === providerConfiguration) {
+          this.pendingProviderConfiguration = undefined
+        }
       }
       this.supportsSessionClose = Boolean(initResult.agentCapabilities?.sessionCapabilities?.close)
       this.supportsSessionDelete = Boolean(
@@ -1400,7 +1426,7 @@ class AcpRuntime {
       this.supportsSessionResume = Boolean(
         initResult.agentCapabilities?.sessionCapabilities?.resume
       )
-      this.assertCurrentConnectionGeneration(generation)
+      this.assertCurrentConnectionOwner(connection, generation)
 
       log.info('agent initialized', {
         protocolVersion: initResult.protocolVersion,
@@ -1415,6 +1441,9 @@ class AcpRuntime {
         title: 'Agent initialized',
         text: `ACP protocol ${initResult.protocolVersion}`
       })
+      // Event/state listeners are external and may synchronously disconnect or replace the runtime.
+      // Re-check the concrete owner after callbacks return before committing the connected snapshot.
+      this.assertCurrentConnectionOwner(connection, generation)
       this.setStatus('connected')
     } catch (thrown) {
       // A spawn failure arrives wrapped so it can name the framework it targeted without mutating the
@@ -1429,6 +1458,18 @@ class AcpRuntime {
         spawnFailure = undefined
       }
       const cause = spawnFailure ? spawnFailure.cause : thrown
+
+      // This connect owns the one-shot credential/config intent only while its generation is current.
+      // Clear every unconsumed value on a same-generation failure (including initialize/auth failure),
+      // but leave a successor generation's possibly identity-equal configuration untouched.
+      if (generation === this.connectionGeneration) {
+        if (this.pendingAuthentication === connectionAuthentication) {
+          this.pendingAuthentication = undefined
+        }
+        if (this.pendingProviderConfiguration === connectionProviderConfiguration) {
+          this.pendingProviderConfiguration = undefined
+        }
+      }
 
       // The entire failure-handling body is best-effort: logging, notification sinks (pushEvent/
       // emitState), and cleanup are each isolated so that whatever throws — a hostile error value, a
@@ -1476,22 +1517,28 @@ class AcpRuntime {
           }
           // Cleanup must not mask the original failure: a throw from session.dispose(),
           // connection.close(), or a teardown hook is logged with context but never replaces `cause`.
-          try {
-            await this.disconnectCurrent(false)
-          } catch (cleanupError) {
-            safeLogError('agent connection cleanup failed', {
-              ...diagnosticErrorFields(cleanupError),
-              ...processFields
-            })
+          if (generation === this.connectionGeneration) {
+            try {
+              await this.disconnectCurrent(false, generation)
+            } catch (cleanupError) {
+              safeLogError('agent connection cleanup failed', {
+                ...diagnosticErrorFields(cleanupError),
+                ...processFields
+              })
+            }
           }
-          this.snapshotOwner.transitionStatus('error')
-          try {
-            this.emitState()
-          } catch (notifyError) {
-            safeLogError('agent connection emitState failed', {
-              ...diagnosticErrorFields(notifyError),
-              ...processFields
-            })
+          // Cleanup and external callbacks both yield or re-enter. A newer generation owns the status
+          // once either happens, so the failed connect may commit `error` only while still current.
+          if (generation === this.connectionGeneration) {
+            this.snapshotOwner.transitionStatus('error')
+            try {
+              this.emitState()
+            } catch (notifyError) {
+              safeLogError('agent connection emitState failed', {
+                ...diagnosticErrorFields(notifyError),
+                ...processFields
+              })
+            }
           }
         }
       } catch (handlingError) {
@@ -1617,7 +1664,8 @@ class AcpRuntime {
           session.sessionId,
           session,
           normalizePermissionProfile(request.permissionProfile),
-          false
+          false,
+          connection
         )
       } catch (error) {
         safeLogError('createSession: configurePermissionProfile failed', {
@@ -1628,8 +1676,8 @@ class AcpRuntime {
       }
 
       log.info('createSession: applySessionModel', this.diagnosticContext())
-      const modelApplication = await this.applySessionModel(session)
-      await this.applySessionEffort(session, modelApplication.configOptions)
+      const modelApplication = await this.applySessionModel(session, connection)
+      await this.applySessionEffort(session, modelApplication.configOptions, connection)
 
       this.assertPrimarySessionIdentityReservation(primaryIdentityReservation)
       // Commit app-owned projections only after the reservation is known to still own this id. No
@@ -2409,11 +2457,12 @@ class AcpRuntime {
         request.sessionId,
         session,
         normalizePermissionProfile(request.permissionProfile),
-        false
+        false,
+        connection
       )
 
-      const modelApplication = await this.applySessionModel(session)
-      await this.applySessionEffort(session, modelApplication.configOptions)
+      const modelApplication = await this.applySessionModel(session, connection)
+      await this.applySessionEffort(session, modelApplication.configOptions, connection)
 
       this.assertPrimarySessionIdentityReservation(primaryIdentityReservation)
       if (request.specialistId) {
@@ -2564,11 +2613,12 @@ class AcpRuntime {
         request.sessionId,
         adopted,
         normalizePermissionProfile(request.permissionProfile),
-        false
+        false,
+        connection
       )
 
-      const modelApplication = await this.applySessionModel(adopted)
-      await this.applySessionEffort(adopted, modelApplication.configOptions)
+      const modelApplication = await this.applySessionModel(adopted, connection)
+      await this.applySessionEffort(adopted, modelApplication.configOptions, connection)
       this.assertPrimarySessionIdentityReservation(primaryIdentityReservation)
       if (request.specialistId) {
         this.sessionSpecialistIds.set(request.sessionId, request.specialistId)
@@ -3064,6 +3114,13 @@ class AcpRuntime {
 
   private assertCurrentConnectionGeneration(generation: number): void {
     if (generation !== this.connectionGeneration) {
+      throw new Error('ACP connection was superseded.')
+    }
+  }
+
+  private assertCurrentConnectionOwner(connection: ClientConnection, generation: number): void {
+    this.assertCurrentConnectionGeneration(generation)
+    if (this.connection !== connection) {
       throw new Error('ACP connection was superseded.')
     }
   }

--- a/src/main/acp/runtime.ts
+++ b/src/main/acp/runtime.ts
@@ -266,7 +266,7 @@ export type ReviewerSessionDisposition = {
 
 type PrimarySessionIdentityReservation = {
   token: symbol
-  sessionIds: string[]
+  sessionIds: Set<string>
 }
 
 type PrimarySessionIdentityReservationResult =
@@ -1523,7 +1523,9 @@ class AcpRuntime {
         })
         .start()
 
-      const reservationResult = this.reservePrimarySessionIds(session.sessionId)
+      // New-session requests have no app id on their interface: the provider-returned id becomes the
+      // stable app id. Reserve that first known identity synchronously before any later setup awaits.
+      const reservationResult = this.reservePrimarySessionIds(undefined, [session.sessionId])
       if (reservationResult.collision) {
         this.disposeSessionAfterFailure(session, 'primary collision session disposal failed')
         throw reservationResult.collision
@@ -1700,6 +1702,35 @@ class AcpRuntime {
   ): Promise<AcpCreateSessionResponse> {
     const sessionCwd = resolve(request.cwd || this.snapshotOwner.cwd || this.options.defaultCwd)
     const projectName = this.normalizeProjectName(request.projectName)
+    const publishedAppSessionId = this.sessions.has(request.sessionId)
+      ? request.sessionId
+      : undefined
+    const reservationResult = this.reservePrimarySessionIds(
+      undefined,
+      [request.sessionId],
+      publishedAppSessionId
+    )
+    if (reservationResult.collision) throw reservationResult.collision
+    const reservation = reservationResult.reservation
+
+    try {
+      return await this.resetReservedSessionContextOperation(
+        request,
+        sessionCwd,
+        projectName,
+        reservation
+      )
+    } finally {
+      this.releasePrimarySessionIdentityReservation(reservation)
+    }
+  }
+
+  private async resetReservedSessionContextOperation(
+    request: AcpResumeSessionRequest,
+    sessionCwd: string,
+    projectName: string,
+    primaryIdentityReservation: PrimarySessionIdentityReservation
+  ): Promise<AcpCreateSessionResponse> {
     const connection = await this.ensureConnected(sessionCwd)
 
     // Tear down the currently attached agent session (if any) before adopting a replacement, dropping
@@ -1734,7 +1765,13 @@ class AcpRuntime {
     this.promptInFlightSessionIds.delete(request.sessionId)
     this.contextCompactionInFlightSessionIds.delete(request.sessionId)
 
-    return this.adoptFreshSession(connection, request, sessionCwd, projectName)
+    return this.adoptFreshSession(
+      connection,
+      request,
+      sessionCwd,
+      projectName,
+      primaryIdentityReservation
+    )
   }
 
   // Hot-switches the specialist bound to a live session. Updates the per-session skills and identity
@@ -2004,6 +2041,25 @@ class AcpRuntime {
     sessionCwd: string,
     projectName: string
   ): Promise<AcpCreateSessionResponse> {
+    // request.sessionId is the known stable app identity. Reserve it synchronously, before connection
+    // setup can await, then let the network path extend the same owner with the provider protocol id.
+    const reservationResult = this.reservePrimarySessionIds(undefined, [request.sessionId])
+    if (reservationResult.collision) throw reservationResult.collision
+    const reservation = reservationResult.reservation
+
+    try {
+      return await this.resumeReservedSessionNetwork(request, sessionCwd, projectName, reservation)
+    } finally {
+      this.releasePrimarySessionIdentityReservation(reservation)
+    }
+  }
+
+  private async resumeReservedSessionNetwork(
+    request: AcpResumeSessionRequest,
+    sessionCwd: string,
+    projectName: string,
+    primaryIdentityReservation: PrimarySessionIdentityReservation
+  ): Promise<AcpCreateSessionResponse> {
     const connection = await this.ensureConnected(sessionCwd)
     // A session created under a different framework can never be resumed by the current agent — each
     // framework keeps its own session store, so the request is guaranteed to fail and only makes the
@@ -2025,7 +2081,13 @@ class AcpRuntime {
         toBackend: this.backendId
       })
 
-      return this.adoptFreshSession(connection, request, sessionCwd, projectName)
+      return this.adoptFreshSession(
+        connection,
+        request,
+        sessionCwd,
+        projectName,
+        primaryIdentityReservation
+      )
     }
 
     // A conversation adopted from another framework keeps its app-facing id. After restart the
@@ -2036,7 +2098,13 @@ class AcpRuntime {
       log.info('skipping invalid Codex session resume; adopting a fresh session', {
         sessionId: request.sessionId
       })
-      return this.adoptFreshSession(connection, request, sessionCwd, projectName)
+      return this.adoptFreshSession(
+        connection,
+        request,
+        sessionCwd,
+        projectName,
+        primaryIdentityReservation
+      )
     }
 
     // Persisted sessions created before framework provenance was recorded may restore without a
@@ -2060,7 +2128,6 @@ class AcpRuntime {
     // later setup failure must revoke it so an unattached Agent cannot retain host.mcp/compute access.
     let notebookCapabilityProvisional = Boolean(this.notebookOptions)
     let session: ActiveSession | undefined
-    let primaryIdentityReservation: PrimarySessionIdentityReservation | undefined
     try {
       // Resumed sessions already have stable ids, so the artifact session mirrors the runtime session
       // id.
@@ -2098,7 +2165,13 @@ class AcpRuntime {
           ...errorLogFields(error)
         })
 
-        return await this.adoptFreshSession(connection, request, sessionCwd, projectName)
+        return await this.adoptFreshSession(
+          connection,
+          request,
+          sessionCwd,
+          projectName,
+          primaryIdentityReservation
+        )
       }
       // The SDK exposes public helpers for new sessions only. The runtime keeps this adapter
       // narrow so resume can reuse the same update routing surface as newly-created sessions.
@@ -2107,13 +2180,14 @@ class AcpRuntime {
         ...resumeResponse
       })
 
-      const reservationResult = this.reservePrimarySessionIds(request.sessionId, session.sessionId)
+      const reservationResult = this.reservePrimarySessionIds(primaryIdentityReservation, [
+        session.sessionId
+      ])
       if (reservationResult.collision) {
         this.disposeSessionAfterFailure(session, 'primary collision session disposal failed')
         session = undefined
         throw reservationResult.collision
       }
-      primaryIdentityReservation = reservationResult.reservation
 
       await this.configurePermissionProfile(
         request.sessionId,
@@ -2126,7 +2200,6 @@ class AcpRuntime {
 
       this.sessions.set(request.sessionId, session)
       this.releasePrimarySessionIdentityReservation(primaryIdentityReservation)
-      primaryIdentityReservation = undefined
       if (updatedConfigOptions) {
         this.latestSessionConfigOptions.set(request.sessionId, updatedConfigOptions)
       }
@@ -2161,10 +2234,6 @@ class AcpRuntime {
         this.releaseNotebookSessionCapabilities(request.sessionId)
       }
       throw error
-    } finally {
-      if (primaryIdentityReservation) {
-        this.releasePrimarySessionIdentityReservation(primaryIdentityReservation)
-      }
     }
   }
 
@@ -2176,14 +2245,14 @@ class AcpRuntime {
     connection: ClientConnection,
     request: AcpResumeSessionRequest,
     sessionCwd: string,
-    projectName: string
+    projectName: string,
+    primaryIdentityReservation: PrimarySessionIdentityReservation
   ): Promise<AcpCreateSessionResponse> {
     // Fresh adoption also receives a provisional Notebook bearer token. Transfer ownership only after
     // adoptSession has registered the replacement; every earlier failure revokes it and disposes any
     // partially-created Agent session.
     let notebookCapabilityProvisional = Boolean(this.notebookOptions)
     let adopted: ActiveSession | undefined
-    let primaryIdentityReservation: PrimarySessionIdentityReservation | undefined
     try {
       const mcpServers = await this.createMcpServers({
         artifactSessionId: request.sessionId,
@@ -2208,7 +2277,10 @@ class AcpRuntime {
         })
         .start()
 
-      const reservationResult = this.reservePrimarySessionIds(request.sessionId, adopted.sessionId)
+      const reservationResult = this.reservePrimarySessionIds(primaryIdentityReservation, [
+        request.sessionId,
+        adopted.sessionId
+      ])
       if (reservationResult.collision) {
         this.disposeSessionAfterFailure(adopted, 'primary collision session disposal failed')
         adopted = undefined
@@ -2233,7 +2305,6 @@ class AcpRuntime {
       )
       this.pendingClaudeCodeHandoffAppends.delete(request.sessionId)
       this.releasePrimarySessionIdentityReservation(primaryIdentityReservation)
-      primaryIdentityReservation = undefined
       // Keyed by the agent session id, matching the live-effort lookup over this.sessions values:
       // an adopted session's agent id differs from the app id it is registered under.
       if (updatedConfigOptions) {
@@ -2255,10 +2326,6 @@ class AcpRuntime {
         this.releaseNotebookSessionCapabilities(request.sessionId)
       }
       throw error
-    } finally {
-      if (primaryIdentityReservation) {
-        this.releasePrimarySessionIdentityReservation(primaryIdentityReservation)
-      }
     }
   }
 
@@ -5719,18 +5786,28 @@ class AcpRuntime {
           })
         }
 
+        // No await separates the pending -> active transition: protocol routing always sees exactly
+        // one identity state. Bridge authority is granted only after the active reviewer route exists.
+        this.pendingReviewerSessionIds.delete(session.sessionId)
+        this.reviewerSessionIds.add(session.sessionId)
         this.responsesBridgeLease?.registerReviewerSession(session.sessionId)
         this.reviewerSessionDirectories.set(session.sessionId, reviewerCwd)
         this.sessionMcpServerNames.set(session.sessionId, mcpServerNames)
         this.sessionFrameworks.set(session.sessionId, this.framework.id)
-        // No await separates release from activation: protocol routing always sees exactly one of the
-        // pending or active identities, and reviewer permission authority appears only on success.
-        this.pendingReviewerSessionIds.delete(session.sessionId)
-        this.reviewerSessionIds.add(session.sessionId)
 
         return { session, promptPrefix: setup.promptPrefix }
       } catch (error) {
         this.pendingReviewerSessionIds.delete(session.sessionId)
+        if (this.reviewerSessionIds.delete(session.sessionId)) {
+          try {
+            this.responsesBridgeLease?.unregisterReviewerSession(session.sessionId)
+          } catch (cleanupError) {
+            safeLogError('reviewer bridge registration rollback failed', {
+              ...diagnosticErrorFields(cleanupError),
+              sessionId: session.sessionId
+            })
+          }
+        }
         this.disposeSessionAfterFailure(session, 'reviewer startup session disposal failed')
         throw error
       }
@@ -5756,7 +5833,9 @@ class AcpRuntime {
   }
 
   private reservePrimarySessionIds(
-    ...sessionIds: string[]
+    reservation: PrimarySessionIdentityReservation | undefined,
+    sessionIds: string[],
+    publishedAppSessionId?: string
   ): PrimarySessionIdentityReservationResult {
     const uniqueSessionIds = [...new Set(sessionIds)]
     const pendingReviewerCollision = uniqueSessionIds.find((sessionId) =>
@@ -5783,22 +5862,26 @@ class AcpRuntime {
 
     const primaryCollision = uniqueSessionIds.find(
       (sessionId) =>
-        this.pendingPrimarySessionIds.has(sessionId) ||
-        this.sessions.has(sessionId) ||
+        (this.pendingPrimarySessionIds.has(sessionId) &&
+          this.pendingPrimarySessionIds.get(sessionId) !== reservation?.token) ||
+        (this.sessions.has(sessionId) && sessionId !== publishedAppSessionId) ||
         this.agentToAppSessionId.has(sessionId)
     )
     if (primaryCollision) {
       return { collision: new Error(`Primary session id collision: ${primaryCollision}`) }
     }
 
-    const reservation: PrimarySessionIdentityReservation = {
-      token: Symbol('primary-session-identity'),
-      sessionIds: uniqueSessionIds
-    }
+    const owner =
+      reservation ??
+      ({
+        token: Symbol('primary-session-identity'),
+        sessionIds: new Set<string>()
+      } satisfies PrimarySessionIdentityReservation)
     for (const sessionId of uniqueSessionIds) {
-      this.pendingPrimarySessionIds.set(sessionId, reservation.token)
+      owner.sessionIds.add(sessionId)
+      this.pendingPrimarySessionIds.set(sessionId, owner.token)
     }
-    return { reservation }
+    return { reservation: owner }
   }
 
   private releasePrimarySessionIdentityReservation(

--- a/src/main/acp/runtime.ts
+++ b/src/main/acp/runtime.ts
@@ -1236,6 +1236,7 @@ class AcpRuntime {
     }
 
     const generation = this.nextConnectionGeneration()
+    this.invalidatePendingSessionStartups()
     const connectPromise = this.connectFresh(request, generation)
     this.connectInFlight = connectPromise
 
@@ -1484,6 +1485,7 @@ class AcpRuntime {
   ): Promise<AcpCreateSessionResponse> {
     let provisionalNotebookSessionId: string | undefined
     let primaryIdentityReservation: PrimarySessionIdentityReservation | undefined
+    let provisionalSession: ActiveSession | undefined
     try {
       log.info('createSession: starting', this.diagnosticContext())
       const sessionCwd = resolve(request.cwd || this.snapshotOwner.cwd || this.options.defaultCwd)
@@ -1539,6 +1541,7 @@ class AcpRuntime {
           ...this.buildSessionMetaArg(extraAppends, specialistSkills)
         })
         .start()
+      provisionalSession = session
 
       // New-session requests have no app id on their interface: the provider-returned id becomes the
       // stable app id. Reserve that first known identity synchronously before any later setup awaits.
@@ -1550,6 +1553,7 @@ class AcpRuntime {
       )
       if (reservationResult.collision) {
         this.disposeSessionAfterFailure(session, 'primary collision session disposal failed')
+        provisionalSession = undefined
         throw reservationResult.collision
       }
       primaryIdentityReservation = reservationResult.reservation
@@ -1574,7 +1578,6 @@ class AcpRuntime {
           ...diagnosticErrorFields(error),
           ...this.diagnosticContext()
         })
-        session.dispose()
         throw error
       }
 
@@ -1584,6 +1587,7 @@ class AcpRuntime {
 
       this.assertPrimarySessionIdentityReservation(primaryIdentityReservation)
       this.sessions.set(session.sessionId, session)
+      provisionalSession = undefined
       this.releasePrimarySessionIdentityReservation(primaryIdentityReservation)
       primaryIdentityReservation = undefined
       // Committed only now: the options map must never hold an entry for a session that failed to
@@ -1619,6 +1623,12 @@ class AcpRuntime {
         ...(this.backendId ? { backendId: this.backendId } : {})
       }
     } catch (error) {
+      if (provisionalSession) {
+        this.disposeSessionAfterFailure(
+          provisionalSession,
+          'primary startup session disposal failed'
+        )
+      }
       if (provisionalNotebookSessionId) {
         this.releaseNotebookSessionCapabilities(provisionalNotebookSessionId)
       }
@@ -2401,7 +2411,11 @@ class AcpRuntime {
     try {
       return await this.disconnectCurrent(emitClosedStatus)
     } finally {
-      await this.closeMcpHttpHost()
+      try {
+        await this.closeMcpHttpHost()
+      } finally {
+        this.completePendingReconnectTeardown()
+      }
     }
   }
 
@@ -2416,6 +2430,7 @@ class AcpRuntime {
     this.connectInFlight = undefined
     this.connection?.close()
     this.connection = undefined
+    this.completePendingReconnectTeardown()
     this.killAgentProcess()
     this.contextUsageTracker.clear()
     this.contextUsageUpdatedPromptTurnsBySession.clear()
@@ -2634,6 +2649,12 @@ class AcpRuntime {
     this.reconnectBarrier = undefined
     this.reconnectBarrierResolve = undefined
     resolve?.()
+  }
+
+  private completePendingReconnectTeardown(): void {
+    this.pendingProviderReconnect = false
+    this.pendingSkillsReload = false
+    this.resolveReconnectBarrier()
   }
 
   private async disconnectCurrent(emitClosedStatus = true): Promise<AcpStateSnapshot> {
@@ -5659,9 +5680,7 @@ class AcpRuntime {
     // the reconnect barrier must unblock now — it will fall through to connect()
     // and pick up the new backend from resolveBackend. A fresh spawn re-provisions
     // skills too, so clear both pending flags to avoid a spurious later reconnect.
-    this.pendingProviderReconnect = false
-    this.pendingSkillsReload = false
-    this.resolveReconnectBarrier()
+    this.completePendingReconnectTeardown()
     void this.closeMcpHttpHost()
     void this.releaseResponsesBridgeLease()
     try {
@@ -5707,9 +5726,30 @@ class AcpRuntime {
 
   private clearReviewerSessionState(): void {
     for (const [sessionId, reviewerCwd] of this.reviewerSessionDirectories) {
-      this.unregisterReviewerBridgeSession(sessionId)
-      this.removeReviewerDirectory(reviewerCwd)
-      this.permissionContext.clearCorrelationsForSession(sessionId)
+      try {
+        this.unregisterReviewerBridgeSession(sessionId)
+      } catch (error) {
+        safeLogError('reviewer bridge cleanup after connection close failed', {
+          ...diagnosticErrorFields(error),
+          sessionId
+        })
+      }
+      try {
+        this.removeReviewerDirectory(reviewerCwd)
+      } catch (error) {
+        safeLogError('reviewer directory cleanup after connection close failed', {
+          ...diagnosticErrorFields(error),
+          sessionId
+        })
+      }
+      try {
+        this.permissionContext.clearCorrelationsForSession(sessionId)
+      } catch (error) {
+        safeLogError('reviewer permission cleanup after connection close failed', {
+          ...diagnosticErrorFields(error),
+          sessionId
+        })
+      }
       this.sessionFrameworks.delete(sessionId)
     }
     this.reviewerSessionDirectories.clear()
@@ -5813,6 +5853,7 @@ class AcpRuntime {
         throw reservationResult.collision
       }
       const identityReservation = reservationResult.reservation
+      let identityActivated = false
 
       try {
         // Apply the framework's Ask baseline before prompting. The dedicated reviewer MCP is
@@ -5828,6 +5869,7 @@ class AcpRuntime {
         // No await separates the pending -> active transition: protocol routing always sees exactly
         // one identity state. Bridge authority is granted only after the active reviewer route exists.
         this.activateReviewerSessionIdentity(identityReservation)
+        identityActivated = true
         this.responsesBridgeLease?.registerReviewerSession(session.sessionId)
         this.reviewerSessionDirectories.set(session.sessionId, reviewerCwd)
         this.sessionMcpServerNames.set(session.sessionId, mcpServerNames)
@@ -5836,7 +5878,7 @@ class AcpRuntime {
         return { session, promptPrefix: setup.promptPrefix }
       } catch (error) {
         this.releaseReviewerSessionIdentityReservation(identityReservation)
-        if (this.reviewerSessionIds.delete(session.sessionId)) {
+        if (identityActivated && this.reviewerSessionIds.delete(session.sessionId)) {
           try {
             this.responsesBridgeLease?.unregisterReviewerSession(session.sessionId)
           } catch (cleanupError) {
@@ -5883,9 +5925,7 @@ class AcpRuntime {
     return { reservation }
   }
 
-  private activateReviewerSessionIdentity(
-    reservation: ReviewerSessionIdentityReservation
-  ): void {
+  private activateReviewerSessionIdentity(reservation: ReviewerSessionIdentityReservation): void {
     if (
       reservation.generation !== this.sessionStartupGeneration ||
       this.pendingReviewerSessionIds.get(reservation.sessionId) !== reservation.token

--- a/src/main/acp/runtime.ts
+++ b/src/main/acp/runtime.ts
@@ -283,6 +283,10 @@ export type ReviewerSessionDisposition = {
 
 type PrimarySessionIdentityReservation = {
   generation: number
+  // A startup that begins without a usable connection (or behind an already-armed reconnect barrier)
+  // may cross the connection setup's expected invalidation exactly once. An explicit teardown that
+  // starts after a live-session reset receives no such permit and cannot adopt a later successor.
+  mayRenewAfterConnectionSetup: boolean
   token: symbol
   sessionIds: Set<string>
 }
@@ -1848,9 +1852,8 @@ class AcpRuntime {
   ): Promise<AcpCreateSessionResponse> {
     const sessionCwd = resolve(request.cwd || this.snapshotOwner.cwd || this.options.defaultCwd)
     const projectName = this.normalizeProjectName(request.projectName)
-    const publishedAppSessionId = this.sessions.has(request.sessionId)
-      ? request.sessionId
-      : undefined
+    const publishedSession = this.sessions.get(request.sessionId)
+    const publishedAppSessionId = publishedSession ? request.sessionId : undefined
     const reservationResult = this.reservePrimarySessionIds(
       undefined,
       [request.sessionId],
@@ -1864,7 +1867,8 @@ class AcpRuntime {
         request,
         sessionCwd,
         projectName,
-        reservation
+        reservation,
+        publishedSession
       )
     } finally {
       this.releasePrimarySessionIdentityReservation(reservation)
@@ -1875,12 +1879,24 @@ class AcpRuntime {
     request: AcpResumeSessionRequest,
     sessionCwd: string,
     projectName: string,
-    primaryIdentityReservation: PrimarySessionIdentityReservation
+    primaryIdentityReservation: PrimarySessionIdentityReservation,
+    publishedSession: ActiveSession | undefined
   ): Promise<AcpCreateSessionResponse> {
     const connection = await this.ensureConnected(sessionCwd)
+    const currentPublishedSession = this.sessions.get(request.sessionId)
+    const reconnectReplacedPublishedSession =
+      publishedSession !== undefined &&
+      currentPublishedSession === undefined &&
+      primaryIdentityReservation.generation !== this.sessionStartupGeneration &&
+      primaryIdentityReservation.mayRenewAfterConnectionSetup
+    if (currentPublishedSession !== publishedSession && !reconnectReplacedPublishedSession) {
+      throw new Error('ACP session startup was superseded.')
+    }
     this.renewPrimarySessionIdentityReservation(
       primaryIdentityReservation,
-      this.sessions.has(request.sessionId) ? request.sessionId : undefined
+      currentPublishedSession === publishedSession && currentPublishedSession
+        ? request.sessionId
+        : undefined
     )
 
     // Tear down the currently attached agent session (if any) before adopting a replacement, dropping
@@ -6451,6 +6467,9 @@ class AcpRuntime {
       reservation ??
       ({
         generation,
+        mayRenewAfterConnectionSetup: Boolean(
+          this.reconnectBarrier || !this.connection || this.snapshotOwner.status !== 'connected'
+        ),
         token: Symbol('primary-session-identity'),
         sessionIds: new Set<string>()
       } satisfies PrimarySessionIdentityReservation)
@@ -6469,7 +6488,15 @@ class AcpRuntime {
     publishedAppSessionId?: string
   ): void {
     const previousGeneration = reservation.generation
+    const previousMayRenewAfterConnectionSetup = reservation.mayRenewAfterConnectionSetup
+    if (
+      previousGeneration !== this.sessionStartupGeneration &&
+      !previousMayRenewAfterConnectionSetup
+    ) {
+      throw new Error('ACP session startup was superseded.')
+    }
     reservation.generation = this.sessionStartupGeneration
+    reservation.mayRenewAfterConnectionSetup = false
     const result = this.reservePrimarySessionIds(
       reservation,
       [...reservation.sessionIds],
@@ -6477,6 +6504,7 @@ class AcpRuntime {
     )
     if (result.collision) {
       reservation.generation = previousGeneration
+      reservation.mayRenewAfterConnectionSetup = previousMayRenewAfterConnectionSetup
       throw result.collision
     }
     this.pendingSessionStartupBlockers.add(reservation.token)

--- a/src/main/notebook/local-rpc-server.test.ts
+++ b/src/main/notebook/local-rpc-server.test.ts
@@ -484,6 +484,45 @@ describe('notebook local RPC server', () => {
     }
   })
 
+  it('does not revoke a replacement capability when the prior connection releases late', async () => {
+    const root = await createStorageRoot()
+    const connectorCall = vi.fn(async () => ({ ok: true }))
+    const service = new NotebookRuntimeService({
+      configRoot: root,
+      dataRoot: root,
+      projectName: 'default-project',
+      repository: new NotebookRunRepository(root)
+    })
+    const server = new NotebookLocalRpcServer(service, {
+      token: 'secret-token',
+      connectorService: { call: connectorCall }
+    })
+    const prior = await server.issueSessionConnection('stable-session', 'default-project')
+    const replacement = await server.issueSessionConnection('stable-session', 'default-project')
+
+    try {
+      expect(prior.release).toBeTypeOf('function')
+      prior.release?.()
+
+      const response = await fetch(replacement.endpoint, {
+        method: 'POST',
+        headers: {
+          authorization: `Bearer ${replacement.token}`,
+          'content-type': 'application/json'
+        },
+        body: JSON.stringify({
+          method: 'mcpCall',
+          params: { server: 'pubmed', method: 'search', args: {} }
+        })
+      })
+
+      expect(response.status).toBe(200)
+      expect(connectorCall).toHaveBeenCalledOnce()
+    } finally {
+      await server.close()
+    }
+  })
+
   it('dispatches Artifact Version creation through the authenticated main-process bridge', async () => {
     const root = await createStorageRoot()
     const service = new NotebookRuntimeService({

--- a/src/main/notebook/local-rpc-server.ts
+++ b/src/main/notebook/local-rpc-server.ts
@@ -396,7 +396,18 @@ class NotebookLocalRpcServer {
     const token = randomUUID()
     this.sessionRpcTokens.set(sessionId, token)
     this.sessionRpcCapabilities.set(token, { sessionId, projectId })
-    return { endpoint: connection.endpoint, token }
+    return {
+      endpoint: connection.endpoint,
+      token,
+      release: () => {
+        // A stale startup may release after a same-ID successor has rotated the current token. Revoke
+        // only this concrete capability and clear the owner projection only while it still points here.
+        if (this.sessionRpcTokens.get(sessionId) === token) {
+          this.sessionRpcTokens.delete(sessionId)
+        }
+        this.sessionRpcCapabilities.delete(token)
+      }
+    }
   }
 
   // Issues a dedicated capability for the persistent control-plane REPL. Unlike the Agent-facing

--- a/src/main/notebook/mcp-server.ts
+++ b/src/main/notebook/mcp-server.ts
@@ -43,6 +43,9 @@ const NOTEBOOK_SYSTEM_PROMPT_APPEND = [
 type NotebookRpcConnection = {
   endpoint: string
   token: string
+  // Optional owner-scoped cleanup for provisional startup connections. Releasing an older connection
+  // must not revoke a newer token issued under the same stable app Session id.
+  release?: () => void
 }
 
 type NotebookMcpEnvironment = NotebookRpcConnection & {

--- a/src/main/reviewer/orchestrator-prompt-prefix.test.ts
+++ b/src/main/reviewer/orchestrator-prompt-prefix.test.ts
@@ -235,6 +235,94 @@ describe('runReview — framework-neutral rubric delivery (promptPrefix)', () =>
     expect(review.checks).toEqual([])
     await client.$disconnect()
   })
+
+  it('returns an error review and stops the MCP server when reviewer disposal fails', async () => {
+    let reviewerEndpoint = ''
+    const runtime = {
+      buildReviewerSession: async (request: { mcpServers: unknown[] }) => {
+        const mcp = extractReviewerMcp(request.mcpServers)
+        reviewerEndpoint = mcp.url
+        let submitDone: Promise<void> | null = null
+        return {
+          session: {
+            sessionId: 'reviewer-session-1',
+            prompt: () => {
+              submitDone = callSubmitFindings(mcp.url, mcp.token, [
+                { status: 'pass', claim: 'Cleanup claim', evidence: 'Cleanup evidence' }
+              ])
+            },
+            nextUpdate: async () => {
+              if (submitDone) await submitDone
+              return { kind: 'stop', stopReason: 'end_turn' }
+            },
+            dispose: () => {}
+          }
+        }
+      },
+      disposeReviewerSession: () => {
+        throw new Error('reviewer dispose failed')
+      }
+    } as unknown as AcpRuntime
+    const client = createProjectDbClient(temporaryRoot!)
+    await ensureProjectSchema(client)
+    const repository = new ReviewRepository(() => Promise.resolve(client))
+
+    const review = await runReview({
+      sessionId: 'session-1',
+      turnMessageId: 'msg-2',
+      projectId: 'project-1',
+      getSession: () => makeSession(),
+      reviewRepository: repository,
+      acpRuntime: runtime,
+      artifactStorageRoot: temporaryRoot!
+    })
+
+    expect(review.lifecycle).toBe('error')
+    expect(review.errorMessage).toContain('reviewer dispose failed')
+    await expect(fetch(reviewerEndpoint)).rejects.toThrow()
+    await client.$disconnect()
+  })
+
+  it('keeps the reviewer failure primary when disposal also fails', async () => {
+    let reviewerEndpoint = ''
+    const runtime = {
+      buildReviewerSession: async (request: { mcpServers: unknown[] }) => {
+        reviewerEndpoint = extractReviewerMcp(request.mcpServers).url
+        return {
+          session: {
+            sessionId: 'reviewer-session-1',
+            prompt: () => {
+              throw new Error('reviewer prompt failed')
+            },
+            nextUpdate: async () => ({ kind: 'stop', stopReason: 'end_turn' }),
+            dispose: () => {}
+          }
+        }
+      },
+      disposeReviewerSession: () => {
+        throw new Error('reviewer dispose failed')
+      }
+    } as unknown as AcpRuntime
+    const client = createProjectDbClient(temporaryRoot!)
+    await ensureProjectSchema(client)
+    const repository = new ReviewRepository(() => Promise.resolve(client))
+
+    const review = await runReview({
+      sessionId: 'session-1',
+      turnMessageId: 'msg-2',
+      projectId: 'project-1',
+      getSession: () => makeSession(),
+      reviewRepository: repository,
+      acpRuntime: runtime,
+      artifactStorageRoot: temporaryRoot!
+    })
+
+    expect(review.lifecycle).toBe('error')
+    expect(review.errorMessage).toContain('reviewer prompt failed')
+    expect(review.errorMessage).not.toContain('reviewer dispose failed')
+    await expect(fetch(reviewerEndpoint)).rejects.toThrow()
+    await client.$disconnect()
+  })
 })
 
 // The second promptPrefix concat site lives inside the module-local runScopedReview, reachable only
@@ -340,6 +428,118 @@ describe('runScopedReview — framework-neutral rubric delivery (fix-loop re-rev
     expect(sent).toContain(scopedHead)
     expect(sent.startsWith(`${scopedPrefix}\n\n${scopedHead}`)).toBe(true)
 
+    await client.$disconnect()
+  })
+
+  it.each([
+    {
+      caseName: 'records disposal failure as the scoped error',
+      scopedPromptError: undefined,
+      expectedError: 'scoped reviewer dispose failed'
+    },
+    {
+      caseName: 'keeps an existing scoped reviewer failure primary',
+      scopedPromptError: 'scoped reviewer prompt failed',
+      expectedError: 'scoped reviewer prompt failed'
+    }
+  ])('$caseName and stops the MCP server', async ({ scopedPromptError, expectedError }) => {
+    let currentSession = makeSession()
+    let buildCall = 0
+    let disposeCall = 0
+    let scopedEndpoint = ''
+    const runtime = {
+      buildReviewerSession: async (request: { mcpServers: unknown[] }) => {
+        buildCall += 1
+        const mcp = extractReviewerMcp(request.mcpServers)
+        let submitDone: Promise<void> | null = null
+        return {
+          session: {
+            sessionId: `reviewer-${buildCall}`,
+            prompt: () => {
+              if (buildCall === 1) {
+                submitDone = callSubmitFindings(mcp.url, mcp.token, [
+                  {
+                    status: 'warn',
+                    claim: 'Result count is unverified',
+                    evidence: 'No artifact supports the result count.',
+                    locator: {
+                      blockRef: { messageId: 'msg-2', blockIndex: 0 },
+                      contentHash: 'h-msg-2'
+                    }
+                  }
+                ])
+              } else {
+                scopedEndpoint = mcp.url
+                if (scopedPromptError) throw new Error(scopedPromptError)
+              }
+            },
+            nextUpdate: async () => {
+              if (submitDone) await submitDone
+              return { kind: 'stop', stopReason: 'end_turn' }
+            },
+            dispose: () => {}
+          }
+        }
+      },
+      disposeReviewerSession: () => {
+        disposeCall += 1
+        if (disposeCall === 2) throw new Error('scoped reviewer dispose failed')
+        return { rejectedToolCalls: 0, reviewerBridgeScoped: undefined }
+      },
+      sendPrompt: async () => {
+        currentSession = {
+          ...currentSession,
+          messages: [
+            ...currentSession.messages,
+            {
+              id: 'msg-3-auditor',
+              role: 'user',
+              content: '[Auditor] verify the result count.',
+              status: 'complete',
+              eventIds: [],
+              createdAt: 3000,
+              updatedAt: 3000
+            },
+            {
+              id: 'msg-4-correction',
+              role: 'agent',
+              content: 'Verified the result count.',
+              status: 'complete',
+              eventIds: [],
+              createdAt: 4000,
+              updatedAt: 4000
+            }
+          ],
+          updatedAt: 4000
+        }
+      }
+    } as unknown as AcpRuntime
+    const client = createProjectDbClient(temporaryRoot!)
+    await ensureProjectSchema(client)
+    const repository = new ReviewRepository(() => Promise.resolve(client))
+
+    await runReview({
+      sessionId: 'session-1',
+      turnMessageId: 'msg-2',
+      projectId: 'project-1',
+      mainSessionId: 'session-1',
+      getSession: () => currentSession,
+      reviewRepository: repository,
+      acpRuntime: runtime,
+      artifactStorageRoot: temporaryRoot!,
+      fixLoopMaxRounds: 1
+    })
+
+    const reviews = await repository.getReviewsForSession('session-1')
+    expect(reviews).toEqual(
+      expect.arrayContaining([
+        expect.objectContaining({
+          lifecycle: 'error',
+          errorMessage: expectedError
+        })
+      ])
+    )
+    await expect(fetch(scopedEndpoint)).rejects.toThrow()
     await client.$disconnect()
   })
 })

--- a/src/main/reviewer/orchestrator.ts
+++ b/src/main/reviewer/orchestrator.ts
@@ -133,6 +133,55 @@ const incompleteReviewMessage = (rejectedToolCalls: number): string =>
 const REVIEWER_BRIDGE_SCOPE_ERROR =
   'Reviewer request was not constrained to the reviewer-only tool scope.'
 
+type ReviewerCleanupResult = {
+  rejectedToolCalls: number
+  reviewerBridgeScoped: boolean | undefined
+  runtimeCleanupFailed: boolean
+  runtimeCleanupError?: unknown
+}
+
+// Reviewer ACP disposal and MCP shutdown are independent cleanup operations. A throwing ACP adapter
+// must not strand the authenticated MCP server; callers decide whether the disposal error is primary
+// or secondary to an earlier reviewer failure after both cleanup attempts have completed.
+const cleanupReviewerResources = async (
+  acpRuntime: ReviewerAcpRuntime,
+  reviewerSession: ActiveSession | undefined,
+  mcpServer: ReviewerMcpServer | undefined
+): Promise<ReviewerCleanupResult> => {
+  let rejectedToolCalls = 0
+  let reviewerBridgeScoped: boolean | undefined
+  let runtimeCleanupFailed = false
+  let runtimeCleanupError: unknown
+
+  if (reviewerSession) {
+    try {
+      const disposition = acpRuntime.disposeReviewerSession(reviewerSession)
+      rejectedToolCalls = disposition.rejectedToolCalls
+      reviewerBridgeScoped = disposition.reviewerBridgeScoped
+    } catch (error) {
+      runtimeCleanupFailed = true
+      runtimeCleanupError = error
+    }
+  }
+
+  try {
+    await mcpServer?.stop()
+  } catch (error) {
+    // MCP stop was historically best-effort. Keep that contract while reporting the failure; a
+    // runtime cleanup error, when present, remains the cleanup error returned to orchestration.
+    log.error('reviewer MCP server cleanup failed', {
+      error: error instanceof Error ? error.message : String(error)
+    })
+  }
+
+  return {
+    rejectedToolCalls,
+    reviewerBridgeScoped,
+    runtimeCleanupFailed,
+    ...(runtimeCleanupError === undefined ? {} : { runtimeCleanupError })
+  }
+}
+
 // Streaming content deltas are emitted one-per-chunk as the reviewer writes its message/thinking, so
 // their count tracks how much it *says*, not how much it *does*. Counting them toward the loop cap
 // made a normally-verbose review trip the guard mid-stream before it could call submit_findings. Only
@@ -814,6 +863,8 @@ const runScopedReview = async (options: {
   let checksSubmitted = false
   let rejectedToolCalls = 0
   let reviewerBridgeScoped: boolean | undefined
+  let reviewerSessionFailed = false
+  let reviewerSessionError: unknown
   const capturedLog: ReviewerLogEntry[] = []
 
   try {
@@ -860,7 +911,33 @@ const runScopedReview = async (options: {
       { onUpdate: (entry) => capturedLog.push(entry) }
     )
   } catch (error) {
-    const errorMsg = error instanceof Error ? error.message : String(error)
+    reviewerSessionFailed = true
+    reviewerSessionError = error
+  } finally {
+    const cleanup = await cleanupReviewerResources(acpRuntime, reviewerSession, mcpServer)
+    rejectedToolCalls = cleanup.rejectedToolCalls
+    reviewerBridgeScoped = cleanup.reviewerBridgeScoped
+    if (cleanup.runtimeCleanupFailed) {
+      if (reviewerSessionFailed) {
+        log.error('scoped re-review session cleanup also failed', {
+          reviewId: review.id,
+          error:
+            cleanup.runtimeCleanupError instanceof Error
+              ? cleanup.runtimeCleanupError.message
+              : String(cleanup.runtimeCleanupError)
+        })
+      } else {
+        reviewerSessionFailed = true
+        reviewerSessionError = cleanup.runtimeCleanupError
+      }
+    }
+  }
+
+  if (reviewerSessionFailed) {
+    const errorMsg =
+      reviewerSessionError instanceof Error
+        ? reviewerSessionError.message
+        : String(reviewerSessionError)
     log.error('scoped re-review session failed', { reviewId: review.id, error: errorMsg })
 
     review = await runReviewMutation(runSessionMutation, () =>
@@ -873,14 +950,6 @@ const runScopedReview = async (options: {
     const errorWithChecks: ReviewWithChecks = { ...review, checks: [] }
     onReviewUpdate?.(errorWithChecks)
     return { review: errorWithChecks, submittedChecks: [] }
-  } finally {
-    // dispose returns the gate's rejection count and clears it atomically — no ordering hazard.
-    if (reviewerSession) {
-      const disposition = acpRuntime.disposeReviewerSession(reviewerSession)
-      rejectedToolCalls = disposition.rejectedToolCalls
-      reviewerBridgeScoped = disposition.reviewerBridgeScoped
-    }
-    await mcpServer?.stop().catch(() => undefined)
   }
 
   if (reviewerBridgeScoped === false) {
@@ -1035,6 +1104,8 @@ const runReviewWithSession = async (
   let checksSubmitted = false
   let rejectedToolCalls = 0
   let reviewerBridgeScoped: boolean | undefined
+  let reviewerSessionFailed = false
+  let reviewerSessionError: unknown
   const capturedLog: ReviewerLogEntry[] = []
 
   try {
@@ -1096,7 +1167,33 @@ const runReviewWithSession = async (
     )
     log.info('reviewer session stopped', { reviewId: review.id, stopReason })
   } catch (error) {
-    const errorMsg = error instanceof Error ? error.message : String(error)
+    reviewerSessionFailed = true
+    reviewerSessionError = error
+  } finally {
+    const cleanup = await cleanupReviewerResources(acpRuntime, reviewerSession, mcpServer)
+    rejectedToolCalls = cleanup.rejectedToolCalls
+    reviewerBridgeScoped = cleanup.reviewerBridgeScoped
+    if (cleanup.runtimeCleanupFailed) {
+      if (reviewerSessionFailed) {
+        log.error('reviewer session cleanup also failed', {
+          reviewId: review.id,
+          error:
+            cleanup.runtimeCleanupError instanceof Error
+              ? cleanup.runtimeCleanupError.message
+              : String(cleanup.runtimeCleanupError)
+        })
+      } else {
+        reviewerSessionFailed = true
+        reviewerSessionError = cleanup.runtimeCleanupError
+      }
+    }
+  }
+
+  if (reviewerSessionFailed) {
+    const errorMsg =
+      reviewerSessionError instanceof Error
+        ? reviewerSessionError.message
+        : String(reviewerSessionError)
     log.error('reviewer session failed', { reviewId: review.id, error: errorMsg })
 
     review = await runReviewMutation(runSessionMutation, () =>
@@ -1110,16 +1207,6 @@ const runReviewWithSession = async (
     onReviewUpdate?.(errorWithFindings)
 
     return errorWithFindings
-  } finally {
-    // Always dispose the reviewer session and shut down the servers. dispose returns the gate's
-    // rejection count and clears it atomically, so an incomplete review reports the real cause with
-    // no capture-before-dispose ordering to get wrong.
-    if (reviewerSession) {
-      const disposition = acpRuntime.disposeReviewerSession(reviewerSession)
-      rejectedToolCalls = disposition.rejectedToolCalls
-      reviewerBridgeScoped = disposition.reviewerBridgeScoped
-    }
-    await mcpServer?.stop().catch(() => undefined)
   }
 
   if (reviewerBridgeScoped === false) {


### PR DESCRIPTION
## Problem

Reviewer Session IDs were registered only after asynchronous startup. A Reviewer could alias an active or in-flight Primary Session, temporarily narrow Primary permissions/tools, and delete shared metadata during disposal. Reviewer or Primary teardown failures could also leave stale startup continuations, bridge authority, reconnect barriers, or backend resources alive across a replacement connection.

## Proposed change

Harden ACP session identity and teardown ownership without changing normal Reviewer behavior or public contracts.

```mermaid
flowchart LR
  Primary["Primary create / resume / adoption"] --> PPending["Owner-token Primary reservation"]
  PPending --> PSetup["Stage Specialist / Permission / model projections"]
  PSetup --> PCommit["Assert owner + publish atomically"]

  Reviewer["Reviewer start"] --> RPending["Owner-token Reviewer reservation"]
  RPending --> RActive["Promote ActiveSession owner"]
  RActive --> Bridge["Register Reviewer bridge authority"]

  Teardown["Disconnect / reconnect / close"] --> Fence["Invalidate startup generation"]
  Fence --> Detach["Detach old connection / process / lease"]
  Detach --> Cleanup["Best-effort cleanup; preserve first error"]
```

- Known stable Primary app IDs are reserved before the first network/setup await. Provider protocol IDs extend the same owner token synchronously when they become known.
- Pending identities grant no Reviewer, Permission, bridge, or capability authority. Specialist, Permission, and applied-model projections remain local until the owner token is revalidated and the Session is published.
- Active Reviewer ownership includes the concrete `ActiveSession`, so a late dispose from an old same-ID Reviewer cannot remove its successor's route, bridge scope, metadata, or temporary directory.
- Disconnect detaches generation-owned connection/process/bridge resources before asynchronous cleanup, continues after individual disposal failures, and rethrows the first lifecycle error after cleanup.
- Reconnect completion is generation-owned, so an older teardown cannot clear a newer provider/skills request or barrier.
- HTTP MCP routes and Notebook bearer capabilities stay provisional until the app Session is published. Failure cleanup unregisters every provisional route independently and releases the exact bearer generation, so a stale same-ID teardown cannot revoke its successor.
- A resume failure revalidates its Primary reservation before any broad cleanup or fresh adoption. Superseded attempts release only their concrete bearer lease; current owners also clean session-wide metadata and `onSessionReleased`. Provisional HTTP cleanup uses the transport mode captured by that startup rather than the later mutable framework.
- Context reset captures the concrete published `ActiveSession` before its first await. Only a startup that began without a usable connection (or behind an already-armed reconnect barrier) receives a one-shot reservation renewal across expected connection setup; an explicit teardown invalidates an older reset instead of letting it replace a same-ID successor.
- Every caller revalidates the concrete connection returned by `ensureConnected` before using it. Per-session deletion epochs supersede older reset/resume reservations, an in-flight deletion rejects later same-ID startups, and owner refcounts retain each epoch until every stale continuation has unwound.
- Connection bootstrap and per-session Permission/model/effort setup stay bound to one captured protocol connection. Initialize/auth/provider requests, event callbacks, cleanup, and the final status commit are generation-fenced; a stale setup cannot target or overwrite a same-ID successor connection.
- One-shot authentication/provider configuration is cleared after successful consumption or a same-generation bootstrap failure, while a superseded attempt cannot erase the successor generation's intent even when the resolver reuses the same object.
- Shared HTTP MCP host shutdown is generation-owned. A delayed disconnect or unexpected-close cleanup cannot close routes registered by a replacement connection; the newest disconnect still closes the host exactly once.
- Alias, Specialist, event, and state callbacks run outside the publication rollback boundary; callback failures are logged without destroying a Session that is already usable.

## Scope and non-goals

- Reject collisions with active Primary IDs, fresh-adoption Provider IDs, active Reviewers, and pending Primary/Reviewer identities.
- Preserve Codex non-UUID fresh adoption, context reset, stable app ID/provider ID mapping, transcript replay, and resource cleanup semantics.
- Preserve latest-main Specialist immediate handoff appends/prompt identity and Compute Skill materialization/control-capability semantics.
- Preserve the collision or original startup/disposal error as primary; secondary cleanup failures are logged without replacing it.
- Preserve Electron/local Web/remote Web Reviewer APIs and existing normal flows.
- No CLI/Task Reviewer API, IPC/Web payload/event, schema, Session relationship, UI, Specialist capability, Permission allowlist, Compute policy, or Issue #458 orchestration change.

## Validation

- ACP/Reviewer/Immediate-handoff/Notebook cross-point focused suites: 430/430 passed.
- `npm run typecheck`: passed.
- `npm run lint`: passed with 0 errors; 19 pre-existing warnings remain outside this diff.
- Final-head `npm test -- --run`: 669 files passed, 15 skipped; 9,837 tests passed, 184 skipped.
- `git diff --check`: passed.
- Latest-main rebase: base `a842397`, head `cd63636`, 16 commits, ahead/behind `16/0`.
- Fixed-SHA Spec review for `a842397..cd63636` reports P0/P1/P2/P3 = 0/0/0/0. Standards reports P0/P1/P2 = 0/0/0 and three non-blocking P3 notes: prerequisite diff size, lifecycle-test discoverability, and a missing direct Notebook durable-binding combination test.

Coverage includes Reviewer/Primary same-ID races; create/resume/context-reset/fresh-adoption app/provider reservations; invalidated context reset racing a same-ID successor; reset/resume across delete, failed delete, and a second disconnect after connection setup; public connect, disconnect, shutdown, deferred reconnect, and unexpected close; same-ID successor permission setup; reentrant initialized/failure event disconnects; initialize/authentication intent failure cleanup; stale HTTP host close racing a successor route; real disposal failure followed by a fresh backend/bridge; stale Reviewer disposal after replacement; staged Specialist/Permission/model projection commits; partial/throwing HTTP route cleanup; published-session observer/alias failures; exact Notebook capability release; and disposal failure preserving required-model/startup errors while reservations are revoked.

## Review focus

Please focus on generation ownership at teardown boundaries, concrete ActiveSession ownership for Reviewer disposal and context reset, the one-shot connection-setup renewal permit, captured connection ownership through bootstrap/session setup, and the no-await assertion-to-publication sections for Primary create/resume/adoption.

Real external ACP providers were not run; provider boundaries use the project's existing fakes. Merge by squash only after all required CI and AI review checks pass.
