### PR TITLE
fix(ci-integrity): compare revisions from merge base

### DIFF
--- a/scripts/ci/check-ci-integrity.mjs
+++ b/scripts/ci/check-ci-integrity.mjs
@@ -316,13 +316,17 @@ function textAtRevision(revision, path, cwd) {
 }
 
 export function ciIntegrityFilesFromRevisions(base, head, { cwd = process.cwd() } = {}) {
-  const diff = execFileSync('git', ['diff', '--name-status', '-z', base, head], { cwd })
+  const mergeBase = execFileSync('git', ['merge-base', base, head], {
+    cwd,
+    encoding: 'utf8'
+  }).trim()
+  const diff = execFileSync('git', ['diff', '--name-status', '-z', mergeBase, head], { cwd })
   return parseNameStatus(diff.toString('utf8'))
     .filter(({ path, previousPath }) => [path, previousPath].filter(Boolean).some(isGuardedPath))
     .map(({ path, previousPath }) => ({
       path,
       previousPath,
-      baseText: textAtRevision(base, previousPath ?? path, cwd),
+      baseText: textAtRevision(mergeBase, previousPath ?? path, cwd),
       headText: textAtRevision(head, path, cwd)
     }))
 }

--- a/scripts/ci/check-ci-integrity.test.ts
+++ b/scripts/ci/check-ci-integrity.test.ts
@@ -111,6 +111,56 @@ jobs:
     }
   })
 
+  it('ignores protected target-branch changes that are absent from a divergent PR head', () => {
+    const root = mkdtempSync(join(tmpdir(), 'ci-integrity-divergent-pr-'))
+
+    try {
+      execFileSync('git', ['init', '--quiet'], { cwd: root })
+      execFileSync('git', ['config', 'user.email', 'ci@example.com'], { cwd: root })
+      execFileSync('git', ['config', 'user.name', 'CI Test'], { cwd: root })
+      mkdirSync(join(root, '.github', 'workflows'), { recursive: true })
+      writeFileSync(
+        join(root, '.github', 'workflows', 'pr-gate.yml'),
+        'jobs:\n  gate:\n    name: PR Gate\n    steps:\n      - uses: actions/checkout@v7\n'
+      )
+      execFileSync('git', ['add', '.github/workflows/pr-gate.yml'], { cwd: root })
+      execFileSync('git', ['commit', '--quiet', '-m', 'initial gate'], { cwd: root })
+      const branchPoint = execFileSync('git', ['rev-parse', 'HEAD'], {
+        cwd: root,
+        encoding: 'utf8'
+      }).trim()
+
+      execFileSync('git', ['checkout', '--quiet', '-b', 'feature'], { cwd: root })
+      mkdirSync(join(root, 'src'), { recursive: true })
+      writeFileSync(join(root, 'src', 'feature.ts'), 'export const feature = true\n')
+      execFileSync('git', ['add', 'src/feature.ts'], { cwd: root })
+      execFileSync('git', ['commit', '--quiet', '-m', 'change product code'], { cwd: root })
+      const head = execFileSync('git', ['rev-parse', 'HEAD'], {
+        cwd: root,
+        encoding: 'utf8'
+      }).trim()
+
+      execFileSync('git', ['checkout', '--quiet', '-b', 'target', branchPoint], { cwd: root })
+      writeFileSync(
+        join(root, '.github', 'workflows', 'pr-gate.yml'),
+        'jobs:\n  gate:\n    name: PR Gate\n    steps:\n      - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1\n'
+      )
+      execFileSync('git', ['add', '.github/workflows/pr-gate.yml'], { cwd: root })
+      execFileSync('git', ['commit', '--quiet', '-m', 'harden target gate'], { cwd: root })
+      const target = execFileSync('git', ['rev-parse', 'HEAD'], {
+        cwd: root,
+        encoding: 'utf8'
+      }).trim()
+
+      const files = ciIntegrityFilesFromRevisions(target, head, { cwd: root })
+
+      expect(files).toEqual([])
+      expect(checkCiIntegrityChanges(files)).toMatchObject({ ok: true, violations: [] })
+    } finally {
+      rmSync(root, { force: true, recursive: true })
+    }
+  })
+
   it('rejects a newly introduced mutable third-party action reference', () => {
     const result = checkCiIntegrityChanges([
       {


### PR DESCRIPTION
## Problem

CI Integrity compared the current target-branch SHA directly with the PR head. When a PR branch was created before a protected CI change landed on `main`, the two-tip diff treated target-only changes as if the PR had reverted them. PR #604 only changes product source, but CI Integrity incorrectly inspected the PR Gate changes from #602 and required a maintainer bypass.

## Proposed change

Resolve the Git merge-base inside `ciIntegrityFilesFromRevisions(base, head)`, then use that revision for both the changed-file list and trusted base content. This keeps the existing CLI interface while making PR and merge-group inspection describe only changes introduced by the proposed head.

Add a divergent-history regression fixture where the target branch hardens a protected workflow after the feature branch diverges. The feature branch must not inherit that target-only workflow change as an integrity violation.

## Scope and non-goals

This changes CI policy diff semantics only. It does not modify product architecture, data models, data relationships, source behavior, or user interaction. It does not weaken protected-control-plane enforcement: genuine changes introduced after the merge-base remain blocked.

## Acceptance criteria and validation

All listed checks ran after the last material edit.

| Expected behavior | Command | Result |
| --- | --- | --- |
| A divergent PR is inspected from its merge-base | `npm test -- scripts/ci/check-ci-integrity.test.ts -t "ignores protected target-branch changes"` | Passed |
| PR #604 no longer inherits target-only CI changes | `node scripts/ci/check-ci-integrity.mjs --base 8fe24f30f0c9f50e1e6c55c8a7d2e2439d390a85 --head 3dd3289276eb7707ab256a76285b41007d1c998e` | Passed; no CI-sensitive files inspected |
| Genuine protected Gate changes remain blocked | `node scripts/ci/check-ci-integrity.mjs --base b9f9d99b87d40232695547c94bca09bd91a99fdf --head 96134f2d1b2d6e78dd46557a49f1dafb577a9434` | Expected failure; only `protected-gate-control-plane` |
| CI policy contracts remain intact | `npm exec vitest run scripts/ci` | Passed: 7 files, 104 tests |
| TypeScript remains valid | `npm run typecheck` | Passed |
| Repository lint policy remains satisfied | `npm run lint` | Passed: 0 errors, 23 existing warnings |
| Full repository behavior remains intact | `npm test` | Passed: 649 files and 9,583 tests; 15 files and 184 tests skipped |
| Changed files are formatted and whitespace-clean | `npm exec prettier -- --check scripts/ci/check-ci-integrity.mjs scripts/ci/check-ci-integrity.test.ts`; `git diff --check` | Passed |

Independent Standards and Spec reviews found no issues.

## Review focus

- Confirm both the name-status diff and base file content use the same merge-base.
- Confirm an unrelated-history failure remains fail-closed through `git merge-base`.
- Confirm merge-group behavior is unchanged when the supplied base is already an ancestor of the synthetic head.

`CI Integrity` is expected to fail on this PR because `scripts/ci/check-ci-integrity.mjs` is an established protected control-plane file. Once PR Gate and review evidence are satisfactory, this repair requires one explicit maintainer ruleset bypass.

Related: #604 and #602.
