### PR TITLE
fix(codex): bypass proxies for local Responses bridge

### DIFF
--- a/src/main/acp/ipc.test.ts
+++ b/src/main/acp/ipc.test.ts
@@ -93,14 +93,21 @@ const {
   }
 })
 
-// Spy on the file logger so the create-session failure path can be asserted (routes to main.log, not a
-// bare console.error). errorLogFields stays real so the assertion also covers its output shape.
-const { errorLogSpy } = vi.hoisted(() => ({ errorLogSpy: vi.fn() }))
+// Spy on the file logger so session lifecycle diagnostics can be asserted (routes to main.log, not a
+// bare console). errorLogFields stays real so the create-session assertion also covers its output.
+const { errorLogSpy, infoLogSpy } = vi.hoisted(() => ({
+  errorLogSpy: vi.fn(),
+  infoLogSpy: vi.fn()
+}))
 vi.mock('../logger', async (importOriginal) => {
   const actual = await importOriginal<typeof import('../logger')>()
   return {
     ...actual,
-    createLogger: (scope: string) => ({ ...actual.createLogger(scope), error: errorLogSpy })
+    createLogger: (scope: string) => ({
+      ...actual.createLogger(scope),
+      error: errorLogSpy,
+      info: infoLogSpy
+    })
   }
 })
 
@@ -183,6 +190,7 @@ afterEach(() => {
   sendPrompt.mockReset()
   sendPrompt.mockResolvedValue(undefined)
   errorLogSpy.mockClear()
+  infoLogSpy.mockClear()
   AcpRuntimeMock.mockClear()
 })
 
@@ -588,6 +596,114 @@ describe('registerAcpIpcHandlers — reset-session-context bridge', () => {
     // The distinct resume channel must not be driven by the reset call.
     expect(resumeSession).not.toHaveBeenCalled()
     expect(result).toEqual({ sessionId: 's-1', cwd: '/workspace', contextReset: true })
+  })
+})
+
+describe('registerAcpIpcHandlers — resume-session diagnostics', () => {
+  it('logs a privacy-safe correlated lifecycle on success', async () => {
+    registerWithFakes()
+    const request: AcpResumeSessionRequest = {
+      sessionId: 'private-session-id',
+      cwd: '/Users/alice/private-project',
+      projectName: 'private-project'
+    }
+    resumeSession.mockResolvedValueOnce({
+      sessionId: request.sessionId,
+      cwd: request.cwd,
+      frameworkId: 'codex',
+      backendId: 'private-backend-id',
+      contextReset: true
+    })
+
+    await handlers.get('acp:resume-session')?.({}, request)
+
+    const started = infoLogSpy.mock.calls.find(
+      ([message]) => message === 'acp:resume-session started'
+    )
+    const completed = infoLogSpy.mock.calls.find(
+      ([message]) => message === 'acp:resume-session completed'
+    )
+    expect(started?.[1]).toMatchObject({
+      operationId: expect.any(String),
+      sessionHash: expect.stringMatching(/^[a-f0-9]{12}$/)
+    })
+    expect(completed?.[1]).toMatchObject({
+      operationId: started?.[1]?.operationId,
+      sessionHash: started?.[1]?.sessionHash,
+      frameworkId: 'codex',
+      contextReset: true,
+      durationMs: expect.any(Number)
+    })
+    const serialized = JSON.stringify(infoLogSpy.mock.calls)
+    expect(serialized).not.toContain(request.sessionId)
+    expect(serialized).not.toContain(request.cwd)
+    expect(serialized).not.toContain(request.projectName)
+    expect(serialized).not.toContain('private-backend-id')
+  })
+
+  it('classifies a failure without logging private error details', async () => {
+    registerWithFakes()
+    const request: AcpResumeSessionRequest = {
+      sessionId: 'private-session-id',
+      cwd: '/Users/alice/private-project'
+    }
+    const failure = Object.assign(
+      new Error('private provider detail at https://secret.example.test'),
+      {
+        name: 'RequestError',
+        code: -32603,
+        data: {
+          errorKind: 'session_not_found',
+          service: 'session',
+          details: 'private upstream details'
+        }
+      }
+    )
+    resumeSession.mockRejectedValueOnce(failure)
+
+    await expect(handlers.get('acp:resume-session')?.({}, request)).rejects.toBe(failure)
+
+    const started = infoLogSpy.mock.calls.find(
+      ([message]) => message === 'acp:resume-session started'
+    )
+    const failed = errorLogSpy.mock.calls.find(
+      ([message]) => message === 'acp:resume-session failed'
+    )
+    expect(failed?.[1]).toMatchObject({
+      operationId: started?.[1]?.operationId,
+      sessionHash: started?.[1]?.sessionHash,
+      errorCategory: 'request',
+      rpcCode: -32603,
+      errorKind: 'session_not_found',
+      service: 'session',
+      durationMs: expect.any(Number)
+    })
+    const serialized = JSON.stringify([infoLogSpy.mock.calls, errorLogSpy.mock.calls])
+    expect(serialized).not.toContain(request.sessionId)
+    expect(serialized).not.toContain(request.cwd)
+    expect(serialized).not.toContain('secret.example.test')
+    expect(serialized).not.toContain('private upstream details')
+  })
+
+  it('buckets an unknown numeric RPC code instead of copying it into the log', async () => {
+    registerWithFakes()
+    const privateCode = 987_654_321
+    resumeSession.mockRejectedValueOnce(
+      Object.assign(new Error('private detail'), { code: privateCode })
+    )
+
+    await expect(
+      handlers.get('acp:resume-session')?.(
+        {},
+        { sessionId: 'private-session-id', cwd: '/private/workspace' }
+      )
+    ).rejects.toThrow('private detail')
+
+    const failed = errorLogSpy.mock.calls.find(
+      ([message]) => message === 'acp:resume-session failed'
+    )
+    expect(failed?.[1]).toMatchObject({ errorCategory: 'request', rpcCode: 'other' })
+    expect(JSON.stringify(failed)).not.toContain(String(privateCode))
   })
 })
 

--- a/src/main/acp/ipc.ts
+++ b/src/main/acp/ipc.ts
@@ -1,4 +1,4 @@
-import { randomUUID } from 'node:crypto'
+import { createHmac, randomBytes, randomUUID } from 'node:crypto'
 import { mkdir, rm } from 'node:fs/promises'
 import { homedir } from 'node:os'
 import { join } from 'node:path'
@@ -51,7 +51,7 @@ import type { PermissionGrantRegistry } from '../permission-grants/registry'
 import { projectRegistrySessionGrants } from './permission-broker'
 import { broadcastToRenderers } from '../renderer-broadcast'
 import { withDataRootWrite } from '../storage/migration-state'
-import { createLogger, errorLogFields } from '../logger'
+import { createLogger, diagnosticErrorFields, errorLogFields } from '../logger'
 import type { ProfileService } from '../specialist/service'
 import {
   buildSpecialistIdentityAppend,
@@ -63,6 +63,71 @@ import {
 } from '../../shared/specialist'
 
 const log = createLogger('acp')
+const resumeLogHashKey = randomBytes(32)
+const SAFE_RESUME_RPC_CODES = new Set([-32700, -32600, -32601, -32602, -32603, -32002])
+const SAFE_RESUME_ERROR_KINDS = new Set([
+  'resource_not_found',
+  'not_found',
+  'session_not_found',
+  'conversation_not_found',
+  'session_missing',
+  'conversation_missing',
+  'session_resume_failed',
+  'conversation_restore_failed'
+])
+const SAFE_RESUME_SERVICES = new Set(['session', 'provider', 'mcp', 'transport'])
+
+const safeRead = (value: object, key: string): unknown => {
+  try {
+    return (value as Record<string, unknown>)[key]
+  } catch {
+    return undefined
+  }
+}
+
+const normalizedDiagnosticToken = (value: unknown): string | undefined => {
+  if (typeof value !== 'string') return undefined
+  const normalized = value
+    .trim()
+    .toLowerCase()
+    .replace(/[^a-z0-9]+/g, '_')
+    .replace(/^_|_$/g, '')
+  return normalized || undefined
+}
+
+const resumeSessionHash = (sessionId: string): string =>
+  createHmac('sha256', resumeLogHashKey).update(sessionId).digest('hex').slice(0, 12)
+
+const resumeErrorDiagnosticFields = (error: unknown): Record<string, unknown> => {
+  const fields: Record<string, unknown> = diagnosticErrorFields(error)
+  if (typeof error !== 'object' || error === null) return fields
+
+  const code = safeRead(error, 'code')
+  if (typeof code === 'number' && Number.isFinite(code)) {
+    fields.rpcCode = SAFE_RESUME_RPC_CODES.has(code) ? code : 'other'
+  }
+
+  const data = safeRead(error, 'data')
+  if (typeof data !== 'object' || data === null) return fields
+
+  const errorKind = normalizedDiagnosticToken(safeRead(data, 'errorKind'))
+  if (errorKind) fields.errorKind = SAFE_RESUME_ERROR_KINDS.has(errorKind) ? errorKind : 'other'
+  const service = normalizedDiagnosticToken(safeRead(data, 'service'))
+  if (service) fields.service = SAFE_RESUME_SERVICES.has(service) ? service : 'other'
+  return fields
+}
+
+const logResumeDiagnostic = (
+  level: 'info' | 'error',
+  message: string,
+  data: Record<string, unknown>
+): void => {
+  try {
+    log[level](message, data)
+  } catch {
+    // Diagnostics must never change the Resume result observed by the renderer.
+  }
+}
 
 type AcpIpcArtifacts = {
   repository: ArtifactRepository
@@ -338,9 +403,32 @@ const registerAcpIpcHandlerSet = (
       throw error
     }
   })
-  ipcMainHandle('acp:resume-session', (_event, request: AcpResumeSessionRequest) =>
-    runtime.resumeSession(request)
-  )
+  ipcMainHandle('acp:resume-session', async (_event, request: AcpResumeSessionRequest) => {
+    const startedAt = Date.now()
+    const context = {
+      operationId: randomUUID(),
+      sessionHash: resumeSessionHash(request.sessionId)
+    }
+    logResumeDiagnostic('info', 'acp:resume-session started', context)
+
+    try {
+      const result = await runtime.resumeSession(request)
+      logResumeDiagnostic('info', 'acp:resume-session completed', {
+        ...context,
+        durationMs: Math.max(0, Date.now() - startedAt),
+        frameworkId: result.frameworkId,
+        contextReset: result.contextReset === true
+      })
+      return result
+    } catch (error) {
+      logResumeDiagnostic('error', 'acp:resume-session failed', {
+        ...context,
+        durationMs: Math.max(0, Date.now() - startedAt),
+        ...resumeErrorDiagnosticFields(error)
+      })
+      throw error
+    }
+  })
   ipcMainHandle('acp:reset-session-context', (_event, request: AcpResumeSessionRequest) =>
     runtime.resetSessionContext(request)
   )

--- a/src/main/settings/backend-resolver.test.ts
+++ b/src/main/settings/backend-resolver.test.ts
@@ -534,13 +534,11 @@ describe('AgentBackendResolver bridge predicates', () => {
       expect(backend.env).not.toHaveProperty('HTTPS_PROXY')
       const loopbackBypass = ['localhost', '127.0.0.1', '127.0.0.0/8', '::1', '[::1]']
       expect(backend.env.NO_PROXY?.split(',')).toEqual(
-        expect.arrayContaining(['metadata.example.test', ...loopbackBypass])
+        expect.arrayContaining(['metadata.example.test', 'existing.internal', ...loopbackBypass])
       )
-      expect(backend.env.NO_PROXY?.split(',')).not.toContain('existing.internal')
       expect(backend.env.no_proxy?.split(',')).toEqual(
-        expect.arrayContaining(['existing.internal', ...loopbackBypass])
+        expect.arrayContaining(['metadata.example.test', 'existing.internal', ...loopbackBypass])
       )
-      expect(backend.env.no_proxy?.split(',')).not.toContain('metadata.example.test')
       await backend.responsesBridgeLease?.release()
     } finally {
       vi.unstubAllEnvs()

--- a/src/main/settings/backend-resolver.test.ts
+++ b/src/main/settings/backend-resolver.test.ts
@@ -513,6 +513,39 @@ describe('AgentBackendResolver bridge predicates', () => {
     )
     await backend.responsesBridgeLease?.release()
   })
+
+  it('bypasses loopback without disabling inherited proxies for native Responses compatibility', async () => {
+    vi.stubEnv('HTTPS_PROXY', 'http://proxy.example.test:3128')
+    vi.stubEnv('NO_PROXY', 'metadata.example.test')
+    vi.stubEnv('no_proxy', 'existing.internal')
+    try {
+      const harness = makeHarness({
+        targetOverride: () => ({ needsNativeResponsesCompatibility: true })
+      })
+
+      const backend = await harness.resolver.resolveExplicitTarget({
+        frameworkId: 'codex',
+        providerId: 'provider-a',
+        model: { kind: 'provider-default' },
+        reasoningEffort: 'high'
+      })
+
+      expect(backend.proxyEnvironmentMode).toBeUndefined()
+      expect(backend.env).not.toHaveProperty('HTTPS_PROXY')
+      const loopbackBypass = ['localhost', '127.0.0.1', '127.0.0.0/8', '::1', '[::1]']
+      expect(backend.env.NO_PROXY?.split(',')).toEqual(
+        expect.arrayContaining(['metadata.example.test', ...loopbackBypass])
+      )
+      expect(backend.env.NO_PROXY?.split(',')).not.toContain('existing.internal')
+      expect(backend.env.no_proxy?.split(',')).toEqual(
+        expect.arrayContaining(['existing.internal', ...loopbackBypass])
+      )
+      expect(backend.env.no_proxy?.split(',')).not.toContain('metadata.example.test')
+      await backend.responsesBridgeLease?.release()
+    } finally {
+      vi.unstubAllEnvs()
+    }
+  })
 })
 
 describe('AgentBackendResolver bridge generations', () => {

--- a/src/main/settings/backend-resolver.ts
+++ b/src/main/settings/backend-resolver.ts
@@ -65,6 +65,7 @@ import {
   type RuntimeProviderModelSelection
 } from './provider-accounts'
 import { ensureCodexAuthHome } from './codex-auth'
+import { loopbackProxyBypassEnvironment } from './system-proxy'
 import type { StoredSettings } from './types'
 
 export type AgentBackendSelection = Readonly<{
@@ -470,6 +471,12 @@ export class AgentBackendResolver {
       const proxyEnv = usesCodexSystemProxy
         ? await this.runtime.resolveCodexProxyEnvironment()
         : undefined
+      // Only the Codex child talks to the app-owned bridge at loopback. Add a bypass override for
+      // that local hop without copying or clearing proxy variables. This leaves the main-process
+      // bridge's upstream network route untouched.
+      const loopbackProxyBypass = responsesBridge
+        ? loopbackProxyBypassEnvironment(process.env)
+        : undefined
       const sessionModel = modelConfig.sessionModel ?? provider.model
 
       return {
@@ -480,6 +487,7 @@ export class AgentBackendResolver {
           ...(modelConfig.env ?? {}),
           ...(opencodeUsagePassword ? { OPENCODE_SERVER_PASSWORD: opencodeUsagePassword } : {}),
           ...(proxyEnv ?? {}),
+          ...(loopbackProxyBypass ?? {}),
           ...(framework.id === 'codex' && settings.codex?.nativePath
             ? { CODEX_PATH: settings.codex.nativePath }
             : {})

--- a/src/main/settings/native-responses-compatibility.test.ts
+++ b/src/main/settings/native-responses-compatibility.test.ts
@@ -459,7 +459,14 @@ describe('native Responses compatibility', () => {
         body: JSON.stringify({ model: 'private-model', input: 'private prompt' })
       })
       expect(response.status).toBe(400)
-      await response.text()
+      const errorResponse = await response.json()
+      expect(errorResponse).toEqual({
+        error: {
+          type: 'invalid_request_error',
+          message: 'Native Responses compatibility request failed'
+        }
+      })
+      expect(JSON.stringify(errorResponse)).not.toContain('private-gateway.example.test')
       expect(fetchImpl).toHaveBeenCalledOnce()
 
       expect(logSpies.warn.mock.calls).toContainEqual([

--- a/src/main/settings/native-responses-compatibility.test.ts
+++ b/src/main/settings/native-responses-compatibility.test.ts
@@ -1,10 +1,26 @@
-import { describe, expect, it, vi } from 'vitest'
+import { afterEach, describe, expect, it, vi } from 'vitest'
+
+const logSpies = vi.hoisted(() => ({
+  debug: vi.fn(),
+  error: vi.fn(),
+  info: vi.fn(),
+  warn: vi.fn()
+}))
+
+vi.mock('../logger', async (importOriginal) => ({
+  ...(await importOriginal<typeof import('../logger')>()),
+  createLogger: () => logSpies
+}))
 
 import {
   NativeResponsesCompatibilityProxy,
   flattenNativeResponsesRequest,
   restoreNativeResponsesPayload
 } from './native-responses-compatibility'
+
+afterEach(() => {
+  for (const spy of Object.values(logSpies)) spy.mockClear()
+})
 
 describe('native Responses compatibility', () => {
   it('flattens namespace tools and matching history without changing plain functions', () => {
@@ -199,6 +215,9 @@ describe('native Responses compatibility', () => {
       tool_choice: { type: 'function', name: 'select_skills' },
       tools: [expect.objectContaining({ type: 'function', name: 'select_skills' })]
     })
+    const serializedLogs = JSON.stringify(Object.values(logSpies).flatMap((spy) => spy.mock.calls))
+    expect(serializedLogs).not.toContain('用 PubMed 搜索肿瘤免疫文章')
+    expect(serializedLogs).not.toContain('mcp-pubmed')
   })
 
   it('continues scanning for smaller Skills after a candidate exceeds the catalog byte budget', async () => {
@@ -353,6 +372,112 @@ describe('native Responses compatibility', () => {
 
       expect(response.ok, await response.text()).toBe(true)
       expect(fetchImpl).toHaveBeenCalledOnce()
+    } finally {
+      await proxy.close()
+    }
+  })
+
+  it('logs a privacy-safe lifecycle that distinguishes an upstream 502', async () => {
+    const privatePrompt = 'private medical prompt'
+    const privateUpstreamDetail = 'private gateway diagnostic'
+    const proxy = new NativeResponsesCompatibilityProxy(
+      {
+        baseUrl: 'https://api.deepseek.com/v1',
+        key: 'private-api-key',
+        model: 'deepseek-v4-flash'
+      },
+      vi.fn().mockResolvedValue(
+        new Response(JSON.stringify({ error: { message: privateUpstreamDetail } }), {
+          status: 502,
+          headers: { 'content-type': 'application/json' }
+        })
+      )
+    )
+    const connection = await proxy.start()
+    try {
+      const response = await fetch(`${connection.baseUrl}/responses`, {
+        method: 'POST',
+        headers: {
+          authorization: `Bearer ${connection.token}`,
+          'content-type': 'application/json'
+        },
+        body: JSON.stringify({ model: 'deepseek-v4-flash', input: privatePrompt })
+      })
+      expect(response.status).toBe(502)
+      await response.text()
+
+      const received = logSpies.info.mock.calls.find(
+        ([message]) => message === 'native Responses compatibility request'
+      )
+      const upstream = logSpies.info.mock.calls.find(
+        ([message]) => message === 'native Responses compatibility upstream response'
+      )
+      const completed = logSpies.info.mock.calls.find(
+        ([message]) => message === 'native Responses compatibility request completed'
+      )
+      expect(received?.[1]).toMatchObject({ requestId: expect.any(String) })
+      expect(upstream?.[1]).toMatchObject({
+        requestId: received?.[1]?.requestId,
+        status: 502,
+        responseType: 'json',
+        durationMs: expect.any(Number)
+      })
+      expect(completed?.[1]).toMatchObject({
+        requestId: received?.[1]?.requestId,
+        status: 502,
+        durationMs: expect.any(Number)
+      })
+      const serialized = JSON.stringify(Object.values(logSpies).flatMap((spy) => spy.mock.calls))
+      expect(serialized).not.toContain(privatePrompt)
+      expect(serialized).not.toContain(privateUpstreamDetail)
+      expect(serialized).not.toContain('private-api-key')
+      expect(serialized).not.toContain(connection.token)
+      expect(serialized).not.toContain('api.deepseek.com')
+    } finally {
+      await proxy.close()
+    }
+  })
+
+  it('classifies an upstream transport failure without logging its raw message', async () => {
+    const privateError = Object.assign(
+      new Error('fetch failed for https://private-gateway.example.test/account/alice'),
+      { code: 'ECONNRESET' }
+    )
+    const fetchImpl = vi.fn().mockRejectedValue(privateError)
+    const proxy = new NativeResponsesCompatibilityProxy(
+      { baseUrl: 'https://api.deepseek.com/v1', key: 'private-api-key' },
+      fetchImpl
+    )
+    const connection = await proxy.start()
+    try {
+      const response = await fetch(`${connection.baseUrl}/responses`, {
+        method: 'POST',
+        headers: {
+          authorization: `Bearer ${connection.token}`,
+          'content-type': 'application/json'
+        },
+        body: JSON.stringify({ model: 'private-model', input: 'private prompt' })
+      })
+      expect(response.status).toBe(400)
+      await response.text()
+      expect(fetchImpl).toHaveBeenCalledOnce()
+
+      expect(logSpies.warn.mock.calls).toContainEqual([
+        'native Responses compatibility request failed',
+        expect.objectContaining({
+          requestId: expect.any(String),
+          phase: 'upstream-fetch',
+          outcome: 'error',
+          errorCategory: 'network',
+          errorCode: 'ECONNRESET',
+          durationMs: expect.any(Number)
+        })
+      ])
+      const serialized = JSON.stringify(Object.values(logSpies).flatMap((spy) => spy.mock.calls))
+      expect(serialized).not.toContain('private-gateway.example.test')
+      expect(serialized).not.toContain('private-api-key')
+      expect(serialized).not.toContain('private-model')
+      expect(serialized).not.toContain('private prompt')
     } finally {
       await proxy.close()
     }

--- a/src/main/settings/native-responses-compatibility.ts
+++ b/src/main/settings/native-responses-compatibility.ts
@@ -468,13 +468,13 @@ export class NativeResponsesCompatibilityProxy {
     if (this.connection) return this.connection
     const token = randomBytes(24).toString('hex')
     const server = createServer((request, response) => {
-      void this.handle(request, response).catch((error: unknown) => {
+      void this.handle(request, response).catch(() => {
         if (response.destroyed || response.writableEnded) return
         if (!response.headersSent) {
           json(response, 400, {
             error: {
               type: 'invalid_request_error',
-              message: error instanceof Error ? error.message : String(error)
+              message: 'Native Responses compatibility request failed'
             }
           })
         } else {

--- a/src/main/settings/native-responses-compatibility.ts
+++ b/src/main/settings/native-responses-compatibility.ts
@@ -1,7 +1,7 @@
-import { randomBytes } from 'node:crypto'
+import { randomBytes, randomUUID } from 'node:crypto'
 import { createServer, type IncomingMessage, type Server, type ServerResponse } from 'node:http'
 
-import { createLogger } from '../logger'
+import { createLogger, diagnosticErrorFields } from '../logger'
 import type {
   ResponsesBridgeConnection,
   ResponsesBridgeNamespacedTool,
@@ -45,6 +45,41 @@ const MAX_SKILL_SELECTOR_NAME_BYTES = 128
 const MAX_SKILL_SELECTOR_DESCRIPTION_BYTES = 2 * 1024
 const MAX_SKILL_SELECTOR_CATALOG_BYTES = 256 * 1024
 const log = createLogger('native-responses-compatibility')
+const SAFE_NETWORK_ERROR_CODES = new Set([
+  'EAI_AGAIN',
+  'ECONNREFUSED',
+  'ECONNRESET',
+  'EHOSTUNREACH',
+  'ENETUNREACH',
+  'ESOCKETTIMEDOUT',
+  'ETIMEDOUT'
+])
+
+const safeRead = (value: object, key: string): unknown => {
+  try {
+    return (value as Record<string, unknown>)[key]
+  } catch {
+    return undefined
+  }
+}
+
+const safeNetworkErrorCode = (error: unknown): string | undefined => {
+  if (typeof error !== 'object' || error === null) return undefined
+  const directCode = safeRead(error, 'code')
+  if (typeof directCode === 'string' && SAFE_NETWORK_ERROR_CODES.has(directCode)) return directCode
+  const cause = safeRead(error, 'cause')
+  if (typeof cause !== 'object' || cause === null) return undefined
+  const causeCode = safeRead(cause, 'code')
+  return typeof causeCode === 'string' && SAFE_NETWORK_ERROR_CODES.has(causeCode)
+    ? causeCode
+    : undefined
+}
+
+const upstreamResponseType = (contentType: string): 'event-stream' | 'json' | 'binary' => {
+  if (contentType.includes('text/event-stream')) return 'event-stream'
+  if (contentType.includes('application/json')) return 'json'
+  return 'binary'
+}
 
 const isObject = (value: unknown): value is JsonObject =>
   typeof value === 'object' && value !== null && !Array.isArray(value)
@@ -414,7 +449,7 @@ export class NativeResponsesCompatibilityProxy {
       log.info('native Responses Skill selection completed', {
         model: this.target.model,
         catalogCount: catalog.length,
-        selectedNames: selected.map(({ name }) => name)
+        selectedCount: selected.length
       })
       return selected
     } catch {
@@ -505,6 +540,9 @@ export class NativeResponsesCompatibilityProxy {
     }
 
     const abortController = new AbortController()
+    const requestId = randomUUID()
+    const startedAt = Date.now()
+    let phase = 'read-request'
     const abortUpstream = (): void => abortController.abort()
     const abortOnRequestClose = (): void => {
       if (request.aborted || !request.complete) abortUpstream()
@@ -535,11 +573,12 @@ export class NativeResponsesCompatibilityProxy {
         : body
       const { request: upstreamRequest, aliases } = flattenNativeResponsesRequest(scopedBody)
       log.info('native Responses compatibility request', {
-        model: body.model,
+        requestId,
         namespaceToolCount: aliases.size,
         stream: body.stream === true,
         reviewerScoped
       })
+      phase = 'upstream-fetch'
       const upstream = await this.fetchImpl(responsesUrl(this.target.baseUrl), {
         method: 'POST',
         headers: upstreamHeaders(request, this.target.key),
@@ -547,18 +586,40 @@ export class NativeResponsesCompatibilityProxy {
         signal: abortController.signal
       })
       const contentType = upstream.headers.get('content-type') ?? ''
-      if (contentType.includes('text/event-stream')) {
+      const responseType = upstreamResponseType(contentType)
+      log.info('native Responses compatibility upstream response', {
+        requestId,
+        status: upstream.status,
+        responseType,
+        durationMs: Math.max(0, Date.now() - startedAt)
+      })
+      phase = 'forward-response'
+      if (responseType === 'event-stream') {
         await streamResponse(upstream, response, aliases)
-        return
-      }
-      if (contentType.includes('application/json')) {
+      } else if (responseType === 'json') {
         const payload = restoreNativeResponsesPayload(await upstream.json(), aliases)
         response.writeHead(upstream.status, copyResponseHeaders(upstream))
         response.end(JSON.stringify(payload))
-        return
+      } else {
+        response.writeHead(upstream.status, copyResponseHeaders(upstream))
+        response.end(Buffer.from(await upstream.arrayBuffer()))
       }
-      response.writeHead(upstream.status, copyResponseHeaders(upstream))
-      response.end(Buffer.from(await upstream.arrayBuffer()))
+      log.info('native Responses compatibility request completed', {
+        requestId,
+        status: upstream.status,
+        durationMs: Math.max(0, Date.now() - startedAt)
+      })
+    } catch (error) {
+      const errorCode = safeNetworkErrorCode(error)
+      log.warn('native Responses compatibility request failed', {
+        requestId,
+        phase,
+        outcome: abortController.signal.aborted ? 'aborted' : 'error',
+        durationMs: Math.max(0, Date.now() - startedAt),
+        ...diagnosticErrorFields(error),
+        ...(errorCode ? { errorCode } : {})
+      })
+      throw error
     } finally {
       request.off('aborted', abortUpstream)
       request.off('close', abortOnRequestClose)

--- a/src/main/settings/system-proxy.test.ts
+++ b/src/main/settings/system-proxy.test.ts
@@ -54,6 +54,20 @@ describe('resolveSystemProxyEnvironment', () => {
     }
   })
 
+  it.each(['NO_PROXY', 'no_proxy'] as const)(
+    'preserves inherited bypasses in both aliases when only %s is defined',
+    async (key) => {
+      const inheritedBypass = 'metadata.example.test'
+      const resolved = await resolveSystemProxyEnvironment(
+        vi.fn().mockResolvedValue('PROXY proxy.example.test:3128'),
+        { [key]: inheritedBypass }
+      )
+
+      expect(resolved?.NO_PROXY?.split(',')).toContain(inheritedBypass)
+      expect(resolved?.no_proxy?.split(',')).toContain(inheritedBypass)
+    }
+  )
+
   it('falls back to the inherited or direct network when resolution fails', async () => {
     const resolveProxy = vi.fn().mockRejectedValue(new Error('proxy resolver unavailable'))
 

--- a/src/main/settings/system-proxy.ts
+++ b/src/main/settings/system-proxy.ts
@@ -24,9 +24,9 @@ export const clearSystemProxyEnvironment = (env: NodeJS.ProcessEnv): void => {
   for (const key of SYSTEM_PROXY_ENV_KEYS) delete env[key]
 }
 
-// Imported subscription routes are intentionally restricted to loopback. Keep those local calls
-// out of a resolved corporate/system proxy while covering the common spellings understood by
-// different HTTP stacks (host, IPv4 range/CIDR, and bracketed/unbracketed IPv6).
+// App-owned local services are intentionally restricted to loopback. Keep those calls out of an
+// inherited or resolved proxy while covering the common spellings understood by different HTTP
+// stacks (host, IPv4 range/CIDR, and bracketed/unbracketed IPv6).
 const LOOPBACK_PROXY_BYPASS = [
   'localhost',
   '.localhost',
@@ -35,6 +35,20 @@ const LOOPBACK_PROXY_BYPASS = [
   '::1',
   '[::1]'
 ] as const
+
+export const loopbackProxyBypassEnvironment = (
+  sourceEnv: NodeJS.ProcessEnv = process.env
+): Pick<SystemProxyEnvironment, 'NO_PROXY' | 'no_proxy'> => {
+  const appendLoopback = (value: string | undefined): string => {
+    const bypass = (value?.split(',') ?? []).map((entry) => entry.trim()).filter(Boolean)
+    return [...new Set([...bypass, ...LOOPBACK_PROXY_BYPASS])].join(',')
+  }
+
+  return {
+    NO_PROXY: appendLoopback(sourceEnv.NO_PROXY),
+    no_proxy: appendLoopback(sourceEnv.no_proxy)
+  }
+}
 
 const proxyEnvironmentForDirective = (
   kind: string,
@@ -109,13 +123,7 @@ export const resolveSystemProxyEnvironment = async (
     const proxyEnv = parseSystemProxyRules(await resolveProxy(CODEX_PROXY_TARGET_URL))
     if (Object.keys(proxyEnv).length === 0) return {}
 
-    const bypass = [sourceEnv.NO_PROXY, sourceEnv.no_proxy]
-      .flatMap((value) => value?.split(',') ?? [])
-      .map((value) => value.trim())
-      .filter(Boolean)
-    const noProxy = [...new Set([...bypass, ...LOOPBACK_PROXY_BYPASS])].join(',')
-
-    return { ...proxyEnv, NO_PROXY: noProxy, no_proxy: noProxy }
+    return { ...proxyEnv, ...loopbackProxyBypassEnvironment(sourceEnv) }
   } catch {
     // `undefined` is distinct from the empty environment produced by an explicit DIRECT decision.
     // Callers preserve the app's inherited proxy variables only for this resolver-failure fallback.

--- a/src/main/settings/system-proxy.ts
+++ b/src/main/settings/system-proxy.ts
@@ -39,14 +39,17 @@ const LOOPBACK_PROXY_BYPASS = [
 export const loopbackProxyBypassEnvironment = (
   sourceEnv: NodeJS.ProcessEnv = process.env
 ): Pick<SystemProxyEnvironment, 'NO_PROXY' | 'no_proxy'> => {
-  const appendLoopback = (value: string | undefined): string => {
-    const bypass = (value?.split(',') ?? []).map((entry) => entry.trim()).filter(Boolean)
-    return [...new Set([...bypass, ...LOOPBACK_PROXY_BYPASS])].join(',')
-  }
+  // Some clients prefer the lowercase alias once it exists. Give both aliases the same union so
+  // adding a missing spelling cannot hide bypasses inherited through the other one.
+  const inheritedBypass = [sourceEnv.NO_PROXY, sourceEnv.no_proxy]
+    .flatMap((value) => value?.split(',') ?? [])
+    .map((entry) => entry.trim())
+    .filter(Boolean)
+  const bypass = [...new Set([...inheritedBypass, ...LOOPBACK_PROXY_BYPASS])].join(',')
 
   return {
-    NO_PROXY: appendLoopback(sourceEnv.NO_PROXY),
-    no_proxy: appendLoopback(sourceEnv.no_proxy)
+    NO_PROXY: bypass,
+    no_proxy: bypass
   }
 }
 


### PR DESCRIPTION
## Problem

Codex can inherit proxy environment variables while it is configured to call the app-owned Responses compatibility bridge on localhost. A proxy that does not bypass loopback can intercept that request and return a 502 for the local `/v1/responses` URL before the bridge sees it. The supplied screenshot and timing strongly support this path, but the existing logs did not contain enough lifecycle detail to prove where the request stopped.

The same logs also lacked lifecycle diagnostics for `acp:resume-session`, leaving same-session Resume failures or no-response behavior indistinguishable at the IPC boundary.

## Proposed change

- Append loopback hosts and ranges to both `NO_PROXY` and `no_proxy` for the Codex child process only when the local Responses bridge is active.
- Preserve all inherited HTTP/HTTPS proxy variables so the main-process request from the bridge to an overseas model API can continue through the configured proxy.
- Preserve inherited bypass entries from either proxy-bypass variable spelling in both aliases.
- Add correlated, privacy-safe lifecycle diagnostics for local Responses compatibility requests and `acp:resume-session`.
- Whitelist network errors, RPC codes, error kinds, and services; bucket unknown values as `other`.
- Return a fixed client-safe message for unexpected bridge failures instead of exposing raw exception details.

## Scope and non-goals

- This does not change OS-level routing performed by transparent proxies, TUN devices, or VPNs; those still need explicit DIRECT rules for localhost, `127.0.0.0/8`, and `::1`.
- This does not add a speculative behavioral fix for Resume. The new start/completed/failed events provide evidence for the next diagnosis, including a start event with no terminal event.
- New diagnostics do not record request or response bodies, prompts, credentials, model parameters, upstream domains, raw session IDs, workspace paths, backend IDs, tool or Skill names, raw error messages, or unrecognized error metadata.

## Acceptance criteria and validation

- [x] Local Responses bridge requests bypass inherited environment proxies.
- [x] External model API traffic retains its existing proxy route.
- [x] Inherited bypass entries from either variable spelling are preserved in both aliases.
- [x] 502 forwarding and transport failures include correlated lifecycle metadata without user content.
- [x] Unexpected bridge failures do not expose raw exception text to the local client.
- [x] Resume success, failure, and missing-terminal-event cases can be distinguished without logging raw identifiers.
- [x] Focused tests: 40 passed.
- [x] Full test suite: 649 files passed, 15 skipped; 9591 tests passed, 184 skipped.
- [x] `npm run typecheck` passed.
- [x] `npm run lint` passed with 0 errors and 23 pre-existing warnings.

## Review focus

Please focus on the boundary between the Codex child and the main-process compatibility bridge, preservation of external proxy routing and inherited bypasses, and whether every new diagnostic or error response remains privacy-safe.