### PR TITLE
fix(notebook): ignore stale executor callbacks

### DIFF
--- a/src/main/notebook/runtime-service.test.ts
+++ b/src/main/notebook/runtime-service.test.ts
@@ -6,7 +6,11 @@ import { tmpdir } from 'node:os'
 import { dirname, join } from 'node:path'
 import { afterEach, beforeAll, describe, expect, it, vi } from 'vitest'
 
-import type { NotebookExecutionRequest, NotebookExecutionResult } from './runtime-service'
+import type {
+  NotebookExecutionRequest,
+  NotebookExecutionResult,
+  NotebookExecutorLifecycleCallbacks
+} from './runtime-service'
 import {
   NotebookRuntimeService,
   buildShellEnv,
@@ -94,6 +98,47 @@ const verifiedPackageMutationTracker = (): Pick<
   markPackageMutationDirty: vi.fn().mockResolvedValue(undefined),
   refreshAfterPackageMutation: vi.fn().mockResolvedValue({ result: 'success' })
 })
+
+const lifecycleCallbackHarness = (
+  root: string,
+  options: {
+    inPlaceRestart?: boolean
+    repository?: NotebookRunRepository
+    shutdown?: () => Promise<{ reaped: boolean }>
+  } = {}
+): {
+  service: NotebookRuntimeService
+  lifecycles: NotebookExecutorLifecycleCallbacks[]
+  changedSessions: string[]
+} => {
+  const lifecycles: NotebookExecutorLifecycleCallbacks[] = []
+  const changedSessions: string[] = []
+  const service = new NotebookRuntimeService({
+    configRoot: root,
+    dataRoot: root,
+    projectName: 'default-project',
+    repository: options.repository ?? new NotebookRunRepository(root),
+    callbacks: {
+      onNotebookChanged: (event) => changedSessions.push(event.sessionId)
+    },
+    executorFactory: (_sessionId, lifecycle) => {
+      lifecycles.push(lifecycle)
+      return {
+        execute: async (request): Promise<NotebookExecutionResult> => ({
+          status: 'completed',
+          stdout: '',
+          stderr: '',
+          traceback: '',
+          cwdAfter: request.cwd,
+          outputs: []
+        }),
+        shutdown: options.shutdown ?? (async () => ({ reaped: true })),
+        restart: options.inPlaceRestart ? async () => undefined : undefined
+      }
+    }
+  })
+  return { service, lifecycles, changedSessions }
+}
 
 describe('resolveShellInvocation', () => {
   it('uses a POSIX sh command on Unix platforms', () => {
@@ -1995,6 +2040,25 @@ describe('notebook runtime service', () => {
     expect(settled.kernelStatus).toBe('idle')
   })
 
+  it('keeps the executor callback current across an in-place restart', async () => {
+    const root = await createStorageRoot()
+    const { service, lifecycles, changedSessions } = lifecycleCallbackHarness(root, {
+      inPlaceRestart: true
+    })
+
+    await service.execute({ sessionId: 'session-1', workspaceCwd: root, code: '1' })
+    await service.restart({ sessionId: 'session-1', workspaceCwd: root })
+    const changedCountBefore = changedSessions.length
+
+    expect(lifecycles).toHaveLength(1)
+    await lifecycles[0].onIdleShutdown('python', DEFAULT_PY_ENV)
+
+    expect((await service.state({ sessionId: 'session-1', workspaceCwd: root })).kernelStatus).toBe(
+      'terminated'
+    )
+    expect(changedSessions).toHaveLength(changedCountBefore + 1)
+  })
+
   it('idle-shutdown reports a terminated kernel status and notifies listeners', async () => {
     const root = await createStorageRoot()
     const changedSessions: string[] = []
@@ -2034,6 +2098,190 @@ describe('notebook runtime service', () => {
     const state = await service.state({ sessionId: 'session-1', workspaceCwd: root })
     expect(state.kernelStatus).toBe('terminated')
     expect(changedSessions).toContain('session-1')
+  })
+
+  it('ignores an idle-shutdown callback from a session replaced under the same id', async () => {
+    const root = await createStorageRoot()
+    const { service, lifecycles, changedSessions } = lifecycleCallbackHarness(root)
+
+    await service.execute({ sessionId: 'session-1', workspaceCwd: root, code: '1' })
+    await service.shutdown({ sessionId: 'session-1', workspaceCwd: root })
+    const replacement = await service.state({ sessionId: 'session-1', workspaceCwd: root })
+    const runJsonBefore = await readFile(replacement.runJsonPath, 'utf8')
+    const changedCountBefore = changedSessions.length
+
+    expect(lifecycles).toHaveLength(2)
+    await lifecycles[0].onIdleShutdown('python', DEFAULT_PY_ENV)
+
+    expect(await readFile(replacement.runJsonPath, 'utf8')).toBe(runJsonBefore)
+    expect((await service.state({ sessionId: 'session-1', workspaceCwd: root })).kernelStatus).toBe(
+      'idle'
+    )
+    expect(changedSessions).toHaveLength(changedCountBefore)
+  })
+
+  it.each(['idle', 'terminated'] as const)(
+    'ignores an old %s callback after shutdown and before same-id recreation',
+    async (callback) => {
+      const root = await createStorageRoot()
+      const { service, lifecycles, changedSessions } = lifecycleCallbackHarness(root)
+
+      const current = await service.state({
+        sessionId: 'session-1',
+        workspaceCwd: root
+      })
+      await service.shutdown({ sessionId: 'session-1', workspaceCwd: root })
+      const runJsonBefore = await readFile(current.runJsonPath, 'utf8')
+      const changedCountBefore = changedSessions.length
+
+      expect(lifecycles).toHaveLength(1)
+      if (callback === 'idle') {
+        await lifecycles[0].onIdleShutdown('python', DEFAULT_PY_ENV)
+      } else {
+        await lifecycles[0].onTerminated('python', DEFAULT_PY_ENV)
+      }
+
+      expect(await readFile(current.runJsonPath, 'utf8')).toBe(runJsonBefore)
+      expect(changedSessions).toHaveLength(changedCountBefore)
+
+      const replacement = await service.state({ sessionId: 'session-1', workspaceCwd: root })
+      expect(replacement.kernelStatus).toBe('idle')
+      expect(lifecycles).toHaveLength(2)
+    }
+  )
+
+  it('applies only the current terminated callback after executor replacement', async () => {
+    const root = await createStorageRoot()
+    const { service, lifecycles, changedSessions } = lifecycleCallbackHarness(root)
+
+    await service.execute({ sessionId: 'session-1', workspaceCwd: root, code: '1' })
+    await service.restart({ sessionId: 'session-1', workspaceCwd: root })
+    const restarted = await service.state({ sessionId: 'session-1', workspaceCwd: root })
+    const runJsonBefore = await readFile(restarted.runJsonPath, 'utf8')
+    const environmentsBefore = restarted.environments
+    const changedCountBefore = changedSessions.length
+
+    expect(lifecycles).toHaveLength(2)
+    await lifecycles[0].onTerminated('python', 'analysis')
+    expect(
+      (await service.state({ sessionId: 'session-1', workspaceCwd: root })).environments
+    ).toEqual(environmentsBefore)
+    expect(await readFile(restarted.runJsonPath, 'utf8')).toBe(runJsonBefore)
+    expect(changedSessions).toHaveLength(changedCountBefore)
+
+    await lifecycles[1].onTerminated('python', 'analysis')
+    expect(
+      (await service.state({ sessionId: 'session-1', workspaceCwd: root })).environments
+    ).toEqual([
+      ...environmentsBefore,
+      {
+        processKey: 'python:analysis',
+        kind: 'python',
+        environment: 'analysis',
+        status: 'terminated',
+        restartRecommended: false
+      }
+    ])
+    expect(await readFile(restarted.runJsonPath, 'utf8')).toBe(runJsonBefore)
+    expect(changedSessions).toHaveLength(changedCountBefore + 1)
+  })
+
+  it.each([
+    { operation: 'session shutdown', callback: 'idle' },
+    { operation: 'executor replacement', callback: 'terminated' }
+  ] as const)(
+    'drops the old $callback callback once $operation teardown begins',
+    async ({ operation, callback }) => {
+      const root = await createStorageRoot()
+      let releaseShutdown!: () => void
+      const shutdownGate = new Promise<void>((resolve) => {
+        releaseShutdown = resolve
+      })
+      const shutdownExecutor = vi.fn(async () => {
+        await shutdownGate
+        return { reaped: true }
+      })
+      const { service, lifecycles, changedSessions } = lifecycleCallbackHarness(root, {
+        shutdown: shutdownExecutor
+      })
+
+      await service.execute({ sessionId: 'session-1', workspaceCwd: root, code: '1' })
+      const beforeTeardown = await service.state({ sessionId: 'session-1', workspaceCwd: root })
+      const teardown =
+        operation === 'session shutdown'
+          ? service.shutdown({ sessionId: 'session-1', workspaceCwd: root })
+          : service.restart({ sessionId: 'session-1', workspaceCwd: root })
+      await vi.waitFor(() => expect(shutdownExecutor).toHaveBeenCalledTimes(1))
+
+      const duringTeardown =
+        operation === 'executor replacement'
+          ? await service.state({ sessionId: 'session-1', workspaceCwd: root })
+          : beforeTeardown
+      const runJsonBefore = await readFile(duringTeardown.runJsonPath, 'utf8')
+      const environmentsBefore = duringTeardown.environments
+      const changedCountBefore = changedSessions.length
+
+      if (callback === 'idle') {
+        await lifecycles[0].onIdleShutdown('python', DEFAULT_PY_ENV)
+      } else {
+        await lifecycles[0].onTerminated('python', 'analysis')
+      }
+
+      try {
+        expect(await readFile(duringTeardown.runJsonPath, 'utf8')).toBe(runJsonBefore)
+        if (operation === 'executor replacement') {
+          expect(
+            (await service.state({ sessionId: 'session-1', workspaceCwd: root })).environments
+          ).toEqual(environmentsBefore)
+        }
+        expect(changedSessions).toHaveLength(changedCountBefore)
+      } finally {
+        releaseShutdown()
+        await teardown
+      }
+      if (operation === 'session shutdown') {
+        await service.state({ sessionId: 'session-1', workspaceCwd: root })
+      }
+      expect(lifecycles).toHaveLength(2)
+    }
+  )
+
+  it('drains a callback that already owns persistence before session teardown', async () => {
+    const root = await createStorageRoot()
+    const repository = new NotebookRunRepository(root)
+    const shutdownExecutor = vi.fn(async () => ({ reaped: true }))
+    const { service, lifecycles, changedSessions } = lifecycleCallbackHarness(root, {
+      repository,
+      shutdown: shutdownExecutor
+    })
+    await service.execute({ sessionId: 'session-1', workspaceCwd: root, code: '1' })
+
+    let releasePersistence!: () => void
+    const persistenceGate = new Promise<void>((resolve) => {
+      releasePersistence = resolve
+    })
+    const updateKernelStatus = repository.updateKernelStatus.bind(repository)
+    const updateSpy = vi
+      .spyOn(repository, 'updateKernelStatus')
+      .mockImplementation(async (request) => {
+        await persistenceGate
+        return updateKernelStatus(request)
+      })
+    const changedCountBefore = changedSessions.length
+
+    const callback = lifecycles[0].onIdleShutdown('python', DEFAULT_PY_ENV)
+    await vi.waitFor(() => expect(updateSpy).toHaveBeenCalledTimes(1))
+    const teardown = service.shutdown({ sessionId: 'session-1', workspaceCwd: root })
+
+    await new Promise((resolve) => setTimeout(resolve, 20))
+    expect(shutdownExecutor).not.toHaveBeenCalled()
+
+    releasePersistence()
+    await callback
+    await teardown
+
+    expect(shutdownExecutor).toHaveBeenCalledTimes(1)
+    expect(changedSessions).toHaveLength(changedCountBefore + 1)
   })
 
   it('clears a stale terminated status once a run completes on the transparently respawned kernel', async () => {

--- a/src/main/notebook/runtime-service.ts
+++ b/src/main/notebook/runtime-service.ts
@@ -106,6 +106,8 @@ import { EnvironmentLeaseManager, type EnvironmentLeaseMode } from './environmen
 import { NotebookRecoveryCoordinator } from './recovery-coordinator'
 import {
   NotebookSessionAggregate,
+  type NotebookSessionExecutorGeneration,
+  type NotebookSessionOwnedExecutor,
   type NotebookSessionExecutionRequest,
   type NotebookSessionExecutionResult,
   type NotebookSessionExecutor,
@@ -237,6 +239,11 @@ type InspectPackagesResult = PackageInspectionResult & {
 
 type NotebookExecutor = NotebookSessionExecutor
 
+type NotebookExecutorLifecycleCallbacks = {
+  onIdleShutdown: (kind?: KernelProcessKind, env?: string) => Promise<void>
+  onTerminated: (kind: KernelProcessKind, env?: string) => Promise<void>
+}
+
 type NotebookRuntimeServiceCallbacks = {
   onNotebookAvailable?: (event: NotebookSessionReference) => void
   onNotebookChanged?: (event: NotebookSessionReference) => void
@@ -278,7 +285,10 @@ type NotebookRuntimeServiceOptions = {
   dataRoot: string
   projectName: string
   repository?: NotebookRunRepository
-  executorFactory?: (sessionId: string) => NotebookExecutor
+  executorFactory?: (
+    sessionId: string,
+    lifecycle: NotebookExecutorLifecycleCallbacks
+  ) => NotebookExecutor
   callbacks?: NotebookRuntimeServiceCallbacks
   // Resolves the connector RPC connection to inject into the kernel spawn env. Usually set after
   // construction via setMcpRpcConnectionResolver, since the RPC server is constructed with this
@@ -3256,6 +3266,7 @@ class NotebookRuntimeService {
         document = await this.repository.reconcileInterruptedRuns(projectName, request.sessionId)
       }
       // Runtime session roots come from run.json normalization so UI, MCP, and Python agree.
+      const ownedExecutor = this.createExecutor(request.sessionId, projectName)
       const session: RuntimeSession = new NotebookSessionAggregate({
         sessionId: request.sessionId,
         projectName,
@@ -3269,7 +3280,8 @@ class NotebookRuntimeService {
         runtimeRoot: document.kernel.runtimeRoot,
         runJsonPath: getNotebookRunJsonPath(this.options.dataRoot, projectName, request.sessionId),
         executionCount: document.runs.length,
-        executor: this.createExecutor(request.sessionId, projectName)
+        executor: ownedExecutor.executor,
+        executorGeneration: ownedExecutor.generation
       })
 
       try {
@@ -3298,19 +3310,30 @@ class NotebookRuntimeService {
   // shutdown proc (kernel-executor.ts's own idle timer) surfaces as a 'terminated' kernel status; this
   // branch is not exercised by unit tests (see resolveDefaultExecutorOptions for the tested,
   // spawn-free portion).
-  private createExecutor(sessionId: string, projectName: string): NotebookExecutor {
-    if (this.options.executorFactory) return this.options.executorFactory(sessionId)
+  private createExecutor(sessionId: string, projectName: string): NotebookSessionOwnedExecutor {
+    const generation = Symbol(`notebook-executor:${sessionId}`)
+    const lifecycle: NotebookExecutorLifecycleCallbacks = {
+      onIdleShutdown: (kind, env) =>
+        this.handleKernelIdleShutdown(sessionId, projectName, kind, env, generation),
+      onTerminated: (kind, env) =>
+        this.handleKernelTerminated(sessionId, projectName, kind, env, generation)
+    }
 
-    return new NotebookKernelExecutor({
+    if (this.options.executorFactory) {
+      return { executor: this.options.executorFactory(sessionId, lifecycle), generation }
+    }
+
+    const executor = new NotebookKernelExecutor({
       ...resolveDefaultExecutorOptions(),
       platform: this.options.platform,
       onIdleShutdown: (kind, env) => {
-        void this.handleKernelIdleShutdown(sessionId, projectName, kind, env)
+        void lifecycle.onIdleShutdown(kind, env)
       },
       onTerminated: (kind, env) => {
-        void this.handleKernelTerminated(sessionId, projectName, kind, env)
+        void lifecycle.onTerminated(kind, env)
       }
     })
+    return { executor, generation }
   }
 
   // Persists 'terminated' for a proc the executor dropped after its idle window, then notifies the
@@ -3322,15 +3345,27 @@ class NotebookRuntimeService {
     sessionId: string,
     projectName: string,
     kind?: KernelProcessKind,
-    env?: string
+    env?: string,
+    generation?: NotebookSessionExecutorGeneration
   ): Promise<void> {
     const session = this.sessions.get(sessionId)
     const processKey = kernelProcessKey(kind, env)
     if (session) {
+      if (generation) {
+        await session.runExecutorLifecycleCallback(generation, async () => {
+          await this.persistKernelStatus(session, 'terminated', processKey)
+          this.notifyNotebookChanged(session)
+        })
+        return
+      }
       await this.persistKernelStatus(session, 'terminated', processKey)
       this.notifyNotebookChanged(session)
       return
     }
+    // Executor-owned callbacks are valid only while their Aggregate generation is published. Once
+    // teardown removes that owner, do not fall through to the legacy rehydration path and rewrite the
+    // durable state a same-ID successor will load.
+    if (generation) return
     // No live session (rehydrated after relaunch): still persist the default env's run.json status.
     if (!persistsToRunJson(processKey)) return
     try {
@@ -3348,16 +3383,26 @@ class NotebookRuntimeService {
     sessionId: string,
     projectName: string,
     kind: KernelProcessKind,
-    env?: string
+    env?: string,
+    generation?: NotebookSessionExecutorGeneration
   ): Promise<void> {
     const session = this.sessions.get(sessionId)
     const processKey = kernelProcessKey(kind, env)
     if (session) {
+      if (generation) {
+        await session.runExecutorLifecycleCallback(generation, async () => {
+          session.markKernelTerminated(processKey)
+          await this.persistKernelStatus(session, 'terminated', processKey)
+          this.notifyNotebookChanged(session)
+        })
+        return
+      }
       session.markKernelTerminated(processKey)
       await this.persistKernelStatus(session, 'terminated', processKey)
       this.notifyNotebookChanged(session)
       return
     }
+    if (generation) return
     if (!persistsToRunJson(processKey)) return
     try {
       await this.repository.updateKernelStatus({ projectName, sessionId, status: 'terminated' })
@@ -3666,6 +3711,7 @@ export type {
   InspectPackagesRequest,
   InspectPackagesResult,
   NotebookExecutor,
+  NotebookExecutorLifecycleCallbacks,
   NotebookEnvironmentManager,
   NotebookRuntimeServiceCallbacks,
   NotebookRuntimeServiceOptions

--- a/src/main/notebook/session-aggregate.test.ts
+++ b/src/main/notebook/session-aggregate.test.ts
@@ -20,6 +20,7 @@ describe('NotebookSessionAggregate', () => {
       runtimeRoot: '/runtime',
       runJsonPath: '/workspace/run.json',
       executionCount: 0,
+      executorGeneration: Symbol('executor-1'),
       executor: {
         execute: async () => ({
           status: 'completed',
@@ -65,6 +66,7 @@ describe('NotebookSessionAggregate', () => {
       runtimeRoot: '/runtime',
       runJsonPath: '/workspace/run.json',
       executionCount: 0,
+      executorGeneration: Symbol('executor-1'),
       executor: {
         execute: async () => ({
           status: 'completed',

--- a/src/main/notebook/session-aggregate.ts
+++ b/src/main/notebook/session-aggregate.ts
@@ -67,6 +67,16 @@ export type NotebookSessionExecutor<
   terminate?: (kind: 'python' | 'r' | 'repl', env: string) => Promise<void>
 }
 
+export type NotebookSessionExecutorGeneration = symbol
+
+export type NotebookSessionOwnedExecutor<
+  Request = NotebookSessionExecutionRequest,
+  Result = NotebookSessionExecutionResult
+> = {
+  executor: NotebookSessionExecutor<Request, Result>
+  generation: NotebookSessionExecutorGeneration
+}
+
 export type NotebookSessionMcpRpcConnection = {
   endpoint: string
   token: string
@@ -86,6 +96,7 @@ export type NotebookSessionAggregateInit<
   runJsonPath: string
   executionCount: number
   executor: NotebookSessionExecutor<Request, Result>
+  executorGeneration: NotebookSessionExecutorGeneration
 }
 
 export type NotebookSessionSnapshot = Readonly<{
@@ -139,6 +150,12 @@ export class NotebookSessionAggregate<
   private activeRunIdValue: string | undefined
   private executionCountValue: number
   private executorValue: NotebookSessionExecutor<Request, Result>
+  private executorGenerationValue: NotebookSessionExecutorGeneration
+  private executorGenerationActive = true
+  // Serializes lifecycle callback commits with executor teardown. Teardown synchronously closes
+  // admission, then drains the callbacks that already proved ownership before replacing/removing the
+  // executor, so their persistence cannot land on a successor.
+  private executorLifecycleQueue: Promise<void> = Promise.resolve()
   private readonly executionQueues = new Map<string, Promise<unknown>>()
   private controlQueue: Promise<unknown> = Promise.resolve()
   private mcpRpcConnection: NotebookSessionMcpRpcConnection | undefined
@@ -158,6 +175,7 @@ export class NotebookSessionAggregate<
     this.runJsonPath = init.runJsonPath
     this.executionCountValue = init.executionCount
     this.executorValue = init.executor
+    this.executorGenerationValue = init.executorGeneration
   }
 
   get cwd(): string {
@@ -344,23 +362,53 @@ export class NotebookSessionAggregate<
     return this.executorValue.execute(request)
   }
 
+  ownsExecutorGeneration(generation: NotebookSessionExecutorGeneration): boolean {
+    return this.executorGenerationActive && this.executorGenerationValue === generation
+  }
+
+  // Commits one executor-owned callback only while its generation still owns this Aggregate. A stale
+  // callback still joins the queue, but resolves as a no-op before it can mutate, persist, or notify.
+  runExecutorLifecycleCallback<T>(
+    generation: NotebookSessionExecutorGeneration,
+    callback: () => Promise<T>
+  ): Promise<T | undefined> {
+    const run = this.executorLifecycleQueue.then(() => {
+      if (!this.ownsExecutorGeneration(generation)) return undefined
+      return callback()
+    })
+    this.executorLifecycleQueue = run.then(
+      () => undefined,
+      () => undefined
+    )
+    return run
+  }
+
   terminateExecutor(kind: 'python' | 'r' | 'repl', env: string): Promise<void> {
     return this.executorValue.terminate?.(kind, env) ?? Promise.resolve()
   }
 
   async restartExecutor(
-    replacement: () => NotebookSessionExecutor<Request, Result>
+    replacement: () => NotebookSessionOwnedExecutor<Request, Result>
   ): Promise<void> {
     if (this.executorValue.restart) {
       await this.executorValue.restart()
       return
     }
+    this.executorGenerationActive = false
+    const lifecycleDrain = this.executorLifecycleQueue
+    await lifecycleDrain
     await this.executorValue.shutdown()
-    this.executorValue = replacement()
+    const next = replacement()
+    this.executorValue = next.executor
+    this.executorGenerationValue = next.generation
+    this.executorGenerationActive = true
   }
 
   shutdownExecutor(): Promise<{ reaped: boolean }> {
-    return this.executorValue.shutdown()
+    const executor = this.executorValue
+    this.executorGenerationActive = false
+    const lifecycleDrain = this.executorLifecycleQueue
+    return lifecycleDrain.then(() => executor.shutdown())
   }
 
   async resolveMcpRpcConnection(


### PR DESCRIPTION
## Problem

Notebook executor callbacks can arrive after their executor or same-ID Session Aggregate has been replaced. The callback previously resolved ownership from the current registry state, so an old executor could persist `run.json`, mutate a replacement Aggregate, or emit `onNotebookChanged` for a generation it no longer owned. A teardown/recreate gap could also fall through to the legacy no-live-session persistence path.

## Proposed change

Bind lifecycle callbacks to the originating Aggregate and executor generation, and close callback admission synchronously before teardown or replacement.

```mermaid
flowchart LR
  Executor["Executor callback"] --> Token["Aggregate + executor generation"]
  Token --> Gate{"Still current?"}
  Gate -->|yes| Queue["Lifecycle queue"]
  Queue --> Persist["Update Aggregate + run.json + notification"]
  Gate -->|no| Drop["Ignore stale callback"]
  Teardown["Teardown / replacement"] --> Close["Close admission synchronously"]
  Close --> Drain["Drain already-admitted persistence"]
  Drain --> Replace["Publish successor"]
```

- Generated callbacks must still match the live Session Aggregate and executor generation before any mutation, persistence, or notification.
- Teardown and executor replacement synchronously reject later callbacks, then drain already-admitted persistence before releasing the old owner.
- A generated callback received while no live Session exists is stale and is ignored; generation-less legacy rehydration keeps its existing behavior.
- In-place restart preserves the executor generation because the executor instance remains the owner.

## Scope and non-goals

- Covers default and named environments, idle-shutdown and terminated callbacks, executor replacement, overlapping teardown, and same-ID recreation gaps.
- No IPC, Electron/Web/CLI/local-RPC payload, schema, Session relationship, UI, Specialist, Permission, Compute, or Issue #458 orchestration change.
- No change to normal current-generation execution or persistence semantics.

## Acceptance criteria and validation

All checks below ran after the final material edit and an independent fixed-SHA closure review confirmed the evidence mapping with 0 actionable findings.

| Behavior | Project-owned check | Final result |
| --- | --- | --- |
| Old callbacks cannot mutate/persist/notify after teardown, replacement, or same-ID recreation | `npm test -- --run src/main/notebook/runtime-service.test.ts src/main/notebook/session-aggregate.test.ts` | 174 passed, 9 skipped |
| Generated no-live-session callbacks are rejected while legacy generation-less rehydration remains | Same focused command, including idle and terminated gap regressions | passed |
| Node and renderer types remain compatible | `npm run typecheck` | passed |
| Repository lint | `npm run lint` | 0 errors; 23 unrelated baseline warnings |
| Repository regression suite | `npm test` | 649 files passed, 15 skipped; 9,591 tests passed, 184 skipped |
| Patch hygiene | `git diff --check` | passed |

## Review focus

Please focus on synchronous admission closure, draining already-admitted callback persistence before owner replacement, and the distinction between generated stale callbacks and generation-less legacy rehydration.

Remaining risk: real `NotebookKernelExecutor` timer/shutdown timing is represented by deterministic injected-lifecycle tests rather than a non-skipped external E2E. Queue draining intentionally allows teardown to wait for already-admitted repository persistence so it cannot write across generations.

Merge by squash only after all required CI and AI review checks pass.
