### PR TITLE
fix(windows-renderer): recover from renderer crashes

### DIFF
--- a/src/main/crash-diagnostics.test.ts
+++ b/src/main/crash-diagnostics.test.ts
@@ -1,0 +1,73 @@
+import { describe, expect, it, vi } from 'vitest'
+
+import { installChildProcessGoneLogging, startLocalCrashReporting } from './crash-diagnostics'
+
+describe('startLocalCrashReporting', () => {
+  it('starts Windows Crashpad with uploads and compression disabled', () => {
+    const start = vi.fn()
+
+    const status = startLocalCrashReporting({
+      platform: 'win32',
+      productName: 'Open Science',
+      companyName: 'aipoch',
+      appVersion: '0.9.1',
+      start
+    })
+
+    expect(status).toEqual({ enabled: true, uploadsEnabled: false })
+    expect(start).toHaveBeenCalledWith({
+      productName: 'Open Science',
+      companyName: 'aipoch',
+      uploadToServer: false,
+      compress: false,
+      extra: { appVersion: '0.9.1' }
+    })
+  })
+
+  it('does not start Crashpad outside Windows', () => {
+    const start = vi.fn()
+
+    const status = startLocalCrashReporting({
+      platform: 'darwin',
+      productName: 'Open Science',
+      companyName: 'aipoch',
+      appVersion: '0.9.1',
+      start
+    })
+
+    expect(status).toEqual({ enabled: false })
+    expect(start).not.toHaveBeenCalled()
+  })
+})
+
+describe('installChildProcessGoneLogging', () => {
+  it('logs only privacy-safe child-process exit metadata', () => {
+    type Register = Parameters<typeof installChildProcessGoneLogging>[0]
+    type Listener = Parameters<Register>[0]
+    let listener: Listener | undefined
+    const log = { error: vi.fn() }
+
+    installChildProcessGoneLogging((registeredListener) => {
+      listener = registeredListener
+    }, log)
+
+    const details = {
+      type: 'GPU',
+      reason: 'crashed',
+      exitCode: -36861,
+      serviceName: 'gpu-process',
+      name: 'GPU Process',
+      commandLine: '--user-data-dir=C:\\Users\\private',
+      url: 'https://private.example'
+    } as const
+    listener!({} as Parameters<Listener>[0], details)
+
+    expect(log.error).toHaveBeenCalledWith('child process gone', {
+      type: 'GPU',
+      reason: 'crashed',
+      exitCode: -36861,
+      serviceName: 'gpu-process',
+      name: 'GPU Process'
+    })
+  })
+})

--- a/src/main/crash-diagnostics.ts
+++ b/src/main/crash-diagnostics.ts
@@ -1,0 +1,66 @@
+import type { Details as ChildProcessGoneDetails, Event as ElectronEvent } from 'electron'
+
+type LocalCrashReporterStartOptions = {
+  productName: string
+  companyName: string
+  uploadToServer: false
+  compress: false
+  extra: { appVersion: string }
+}
+
+type LocalCrashReportingStatus = { enabled: true; uploadsEnabled: false } | { enabled: false }
+
+type StartLocalCrashReportingOptions = {
+  platform: NodeJS.Platform
+  productName: string
+  companyName: string
+  appVersion: string
+  start: (options: LocalCrashReporterStartOptions) => void
+}
+
+type ChildProcessGoneListener = (event: ElectronEvent, details: ChildProcessGoneDetails) => void
+
+type DiagnosticLogger = {
+  error: (message: string, metadata: Record<string, unknown>) => void
+}
+
+// Starts local-only Crashpad before a Windows renderer can be created. Other platforms keep their
+// existing crash-reporting behavior and never call Electron's crashReporter.start().
+const startLocalCrashReporting = ({
+  platform,
+  productName,
+  companyName,
+  appVersion,
+  start
+}: StartLocalCrashReportingOptions): LocalCrashReportingStatus => {
+  if (platform !== 'win32') return { enabled: false }
+
+  start({
+    productName,
+    companyName,
+    uploadToServer: false,
+    compress: false,
+    extra: { appVersion }
+  })
+
+  return { enabled: true, uploadsEnabled: false }
+}
+
+// Binds app-level GPU/utility diagnostics while deliberately projecting only lifecycle vocabulary
+// and numeric exit metadata; command lines, URLs, and filesystem paths never reach main.log.
+const installChildProcessGoneLogging = (
+  register: (listener: ChildProcessGoneListener) => void,
+  log: DiagnosticLogger
+): void => {
+  register((_event, details) => {
+    log.error('child process gone', {
+      type: details.type,
+      reason: details.reason,
+      exitCode: details.exitCode,
+      serviceName: details.serviceName,
+      name: details.name
+    })
+  })
+}
+
+export { installChildProcessGoneLogging, startLocalCrashReporting }

--- a/src/main/index.ts
+++ b/src/main/index.ts
@@ -10,6 +10,7 @@ import {
   SKILL_IMPORT_MCP_SERVER_ARG
 } from './mcp-server-args'
 import { withApplicationRuntimeShutdown } from './application-runtime'
+import { installChildProcessGoneLogging, startLocalCrashReporting } from './crash-diagnostics'
 
 const APP_NAME = 'Open Science'
 const APP_USER_MODEL_ID = 'com.aipoch.open-science'
@@ -58,7 +59,7 @@ if (shouldRunArtifactMcpServer) {
 // Boots the Electron app only in normal UI mode, keeping artifact MCP mode free of Electron imports.
 async function startElectronApp(mainEntryPath: string): Promise<void> {
   const [
-    { app, BrowserWindow, nativeImage, protocol },
+    { app, BrowserWindow, crashReporter, nativeImage, protocol },
     { electronApp },
     { default: icon },
     { default: iconDark },
@@ -102,6 +103,18 @@ async function startElectronApp(mainEntryPath: string): Promise<void> {
     acquireSingleInstanceLock: (opts) => acquireSingleInstanceLock(opts),
     quit: () => app.quit(),
     prepare: async () => {
+      // Start Windows Crashpad after the single-instance lock but before any BrowserWindow can create
+      // a renderer. Upload stays disabled: dumps remain local for explicit support collection. Without
+      // this initialization the affected Windows renderer failures surface only as
+      // Crashpad_NotConnectedToHandler, which masks the native crash that caused the white window.
+      const crashReporting = startLocalCrashReporting({
+        platform: process.platform,
+        productName: APP_NAME,
+        companyName: 'aipoch',
+        appVersion: app.getVersion(),
+        start: (options) => crashReporter.start(options)
+      })
+
       const [
         { registerIpcHandlers },
         { createMainWindow },
@@ -174,8 +187,16 @@ async function startElectronApp(mainEntryPath: string): Promise<void> {
         electron: process.versions.electron,
         node: process.versions.node,
         execPath: process.execPath,
-        logFile: getLogFilePath()
+        logFile: getLogFilePath(),
+        crashReporting: crashReporting.enabled
+          ? { ...crashReporting, dumpsDirectory: app.getPath('crashDumps') }
+          : crashReporting
       })
+
+      // Renderer exits are logged by each BrowserWindow. This complementary app-level event catches
+      // GPU and utility-process failures, which can also leave a window blank but are otherwise absent
+      // from main.log. Keep only Electron lifecycle vocabulary and numeric exit metadata.
+      installChildProcessGoneLogging((listener) => app.on('child-process-gone', listener), log)
 
       // Capture otherwise-silent crashes so a hang or unexpected exit leaves a trail in the log file.
       process.on('uncaughtException', (error) => log.error('uncaughtException', error))

--- a/src/main/windows.test.ts
+++ b/src/main/windows.test.ts
@@ -11,11 +11,13 @@ import {
 } from '../shared/window-controls'
 
 // Hoisted so the electron mock and the test body share the same spies.
-const { openExternalMock, ipcMainOnMock, ipcMainRemoveListenerMock } = vi.hoisted(() => ({
-  openExternalMock: vi.fn(),
-  ipcMainOnMock: vi.fn(),
-  ipcMainRemoveListenerMock: vi.fn()
-}))
+const { openExternalMock, ipcMainOnMock, ipcMainRemoveListenerMock, showMessageBoxMock } =
+  vi.hoisted(() => ({
+    openExternalMock: vi.fn(),
+    ipcMainOnMock: vi.fn(),
+    ipcMainRemoveListenerMock: vi.fn(),
+    showMessageBoxMock: vi.fn()
+  }))
 
 const { windowLogSpies } = vi.hoisted(() => ({
   windowLogSpies: {
@@ -61,6 +63,8 @@ let lastWindow: FakeBrowserWindow | undefined
 
 class FakeBrowserWindow {
   closeMock = vi.fn()
+  destroyMock = vi.fn()
+  loadFileMock = vi.fn(() => Promise.resolve())
   sendMock = vi.fn()
   webContentsHandlers = new Map<string, WebContentsHandler>()
   handlers = new Map<string, Array<(event: CloseEvent) => void>>()
@@ -99,6 +103,11 @@ class FakeBrowserWindow {
     if (!event.defaultPrevented) this.destroyed = true
   }
 
+  destroy(): void {
+    this.destroyMock()
+    this.destroyed = true
+  }
+
   show(): void {
     this.hidden = false
   }
@@ -117,7 +126,7 @@ class FakeBrowserWindow {
   }
 
   loadFile(): Promise<void> {
-    return Promise.resolve()
+    return this.loadFileMock()
   }
 }
 
@@ -132,6 +141,7 @@ vi.mock('electron', () => ({
     }
   },
   WebContentsView: class {},
+  dialog: { showMessageBox: showMessageBoxMock },
   ipcMain: { on: ipcMainOnMock, removeListener: ipcMainRemoveListenerMock },
   shell: { openExternal: openExternalMock }
 }))
@@ -276,6 +286,8 @@ describe('close chord interception', () => {
     windowLogSpies.info.mockClear()
     windowLogSpies.warn.mockClear()
     windowLogSpies.error.mockClear()
+    showMessageBoxMock.mockReset()
+    showMessageBoxMock.mockResolvedValue({ response: 0 })
   })
 
   // Fires an ipcMain handshake signal that main registered via ipcMain.on, spoofing the sender as this
@@ -523,6 +535,109 @@ describe('close chord interception', () => {
       exitCode: 139,
       wasUnresponsive: false
     })
+  })
+
+  it('records a main-frame load failure without logging its URL', () => {
+    createMainWindow()
+    const window = currentWindow!
+
+    fireWebContentsEvent(
+      window,
+      'did-fail-load',
+      {},
+      -105,
+      'NAME_NOT_RESOLVED',
+      'file:///private/session-content/index.html',
+      true
+    )
+
+    expect(windowLogSpies.error).toHaveBeenCalledWith('renderer document failed to load', {
+      errorCode: -105,
+      errorDescription: 'NAME_NOT_RESOLVED'
+    })
+    expect(JSON.stringify(windowLogSpies.error.mock.calls)).not.toContain('session-content')
+  })
+
+  it('records a preload failure without logging its path or error text', () => {
+    createMainWindow()
+    const window = currentWindow!
+
+    fireWebContentsEvent(
+      window,
+      'preload-error',
+      {},
+      'C:\\Users\\person\\private-preload.js',
+      new Error('secret from local data')
+    )
+
+    expect(windowLogSpies.error).toHaveBeenCalledWith('renderer preload failed', {
+      errorName: 'Error'
+    })
+    expect(JSON.stringify(windowLogSpies.error.mock.calls)).not.toContain('private-preload')
+    expect(JSON.stringify(windowLogSpies.error.mock.calls)).not.toContain('secret from local data')
+  })
+
+  it('reloads the safe renderer entry after an unexpected renderer exit', () => {
+    createMainWindow()
+    const window = currentWindow!
+    expect(window.loadFileMock).toHaveBeenCalledTimes(1)
+
+    fireWebContentsEvent(window, 'render-process-gone', {}, { reason: 'crashed', exitCode: 139 })
+
+    expect(window.loadFileMock).toHaveBeenCalledTimes(2)
+    expect(windowLogSpies.warn).toHaveBeenCalledWith('reloading renderer after process exit', {
+      reason: 'crashed',
+      automaticRecoveryAttempt: 1
+    })
+  })
+
+  it.each(['clean-exit', 'killed'])('does not reload after an intentional %s', (reason) => {
+    createMainWindow()
+    const window = currentWindow!
+
+    fireWebContentsEvent(window, 'render-process-gone', {}, { reason, exitCode: 0 })
+
+    expect(window.loadFileMock).toHaveBeenCalledTimes(1)
+    expect(showMessageBoxMock).not.toHaveBeenCalled()
+  })
+
+  it('stops automatic reloads and asks before retrying a renderer crash loop', async () => {
+    createMainWindow()
+    const window = currentWindow!
+
+    for (let attempt = 0; attempt < 3; attempt += 1) {
+      fireWebContentsEvent(window, 'render-process-gone', {}, { reason: 'crashed', exitCode: 139 })
+    }
+
+    expect(window.loadFileMock).toHaveBeenCalledTimes(3)
+    expect(showMessageBoxMock).toHaveBeenCalledTimes(1)
+    expect(showMessageBoxMock).toHaveBeenCalledWith(
+      window,
+      expect.objectContaining({
+        type: 'error',
+        buttons: ['Reload', 'Close window'],
+        defaultId: 0,
+        cancelId: 1
+      })
+    )
+    await vi.waitFor(() => expect(window.loadFileMock).toHaveBeenCalledTimes(4))
+  })
+
+  it('destroys the blank window when the user closes a renderer crash-loop prompt', async () => {
+    showMessageBoxMock.mockResolvedValueOnce({ response: 1 })
+    createMainWindow({
+      classifyClose: () => 'hide',
+      resolveCloseAction: vi.fn(),
+      requestQuit: vi.fn()
+    })
+    const window = currentWindow!
+
+    for (let attempt = 0; attempt < 3; attempt += 1) {
+      fireWebContentsEvent(window, 'render-process-gone', {}, { reason: 'oom', exitCode: 5 })
+    }
+
+    await vi.waitFor(() => expect(window.destroyMock).toHaveBeenCalledTimes(1))
+    expect(window.hidden).toBe(false)
   })
 
   it('records the known hang duration when an unresponsive renderer terminates', () => {

--- a/src/main/windows.ts
+++ b/src/main/windows.ts
@@ -1,6 +1,7 @@
 import {
   app,
   BrowserWindow,
+  dialog,
   ipcMain,
   shell,
   WebContentsView,
@@ -36,6 +37,15 @@ const icon = process.platform === 'win32' ? iconWindows : iconPng
 // same way in dev (project root) and packaged (asar root) via app.getAppPath().
 const findOverlayEntry = join(app.getAppPath(), 'resources/find-overlay/index.html')
 const log = createLogger('window')
+const RENDERER_RECOVERY_WINDOW_MS = 60_000
+const MAX_AUTOMATIC_RENDERER_RECOVERIES = 2
+const RECOVERABLE_RENDERER_EXIT_REASONS = new Set([
+  'abnormal-exit',
+  'crashed',
+  'oom',
+  'launch-failed',
+  'integrity-failure'
+])
 
 const loadRenderer = (window: BrowserWindow): void => {
   if (is.dev && process.env['ELECTRON_RENDERER_URL']) {
@@ -115,6 +125,8 @@ const createMainWindow = (opts?: MainWindowCloseOptions): BrowserWindow => {
   let windowFindListenerReady = false
   let rendererResponsive = true
   let rendererUnresponsiveAt: number | undefined
+  let rendererRecoveryTimes: number[] = []
+  let rendererRecoveryDialogOpen = false
   const clearRendererHangState = (): void => {
     rendererResponsive = true
     rendererUnresponsiveAt = undefined
@@ -161,6 +173,18 @@ const createMainWindow = (opts?: MainWindowCloseOptions): BrowserWindow => {
       findOverlay.close()
     }
   })
+  // Keep renderer bootstrap failures diagnosable without persisting the failed URL, preload path, or
+  // error message (all of which can contain local paths or Session-derived data).
+  window.webContents.on(
+    'did-fail-load',
+    (_event, errorCode, errorDescription, _validatedURL, isMainFrame) => {
+      if (!isMainFrame) return
+      log.error('renderer document failed to load', { errorCode, errorDescription })
+    }
+  )
+  window.webContents.on('preload-error', (_event, _preloadPath, error) => {
+    log.error('renderer preload failed', { errorName: error.name })
+  })
   // Persist only fixed Electron lifecycle vocabulary and numeric timing/exit metadata. Current URLs,
   // Session content, renderer console output, process arguments, and local paths stay out of main.log.
   window.webContents.on('render-process-gone', (_event, details) => {
@@ -177,6 +201,61 @@ const createMainWindow = (opts?: MainWindowCloseOptions): BrowserWindow => {
     windowFindListenerReady = false
     clearRendererHangState()
     findOverlay.close()
+
+    if (!RECOVERABLE_RENDERER_EXIT_REASONS.has(details.reason) || window.isDestroyed()) return
+
+    const now = Date.now()
+    rendererRecoveryTimes = rendererRecoveryTimes.filter(
+      (recoveryAt) => now - recoveryAt < RENDERER_RECOVERY_WINDOW_MS
+    )
+    if (rendererRecoveryTimes.length < MAX_AUTOMATIC_RENDERER_RECOVERIES) {
+      rendererRecoveryTimes.push(now)
+      log.warn('reloading renderer after process exit', {
+        reason: details.reason,
+        automaticRecoveryAttempt: rendererRecoveryTimes.length
+      })
+      loadRenderer(window)
+      return
+    }
+
+    if (rendererRecoveryDialogOpen) return
+    rendererRecoveryDialogOpen = true
+    log.error('renderer automatic recovery paused after repeated exits', {
+      reason: details.reason,
+      automaticRecoveries: rendererRecoveryTimes.length,
+      recoveryWindowMs: RENDERER_RECOVERY_WINDOW_MS
+    })
+    void dialog
+      .showMessageBox(window, {
+        type: 'error',
+        buttons: ['Reload', 'Close window'],
+        defaultId: 0,
+        cancelId: 1,
+        title: 'Open Science',
+        message: 'The app window stopped responding repeatedly.',
+        detail:
+          'Automatic recovery has been paused. Reloading returns this window to the home screen; background work may still be running.'
+      })
+      .then(
+        ({ response }) => {
+          rendererRecoveryDialogOpen = false
+          if (window.isDestroyed()) return
+          if (response === 0) {
+            rendererRecoveryTimes = []
+            log.warn('reloading renderer after user confirmation')
+            loadRenderer(window)
+            return
+          }
+          // Bypass the normal Windows close-to-tray interception: the user explicitly chose to close
+          // this unrecoverable blank window, not leave it hidden and alive in the tray.
+          window.destroy()
+        },
+        () => {
+          rendererRecoveryDialogOpen = false
+          log.error('renderer recovery dialog failed')
+          if (!window.isDestroyed()) window.destroy()
+        }
+      )
   })
   window.webContents.on('unresponsive', () => {
     if (rendererResponsive) {

--- a/src/renderer/src/pages/workspace/ConversationPanel.tsx
+++ b/src/renderer/src/pages/workspace/ConversationPanel.tsx
@@ -61,6 +61,7 @@ import { ReportErrorDialog } from './ReportErrorDialog'
 import { SessionInterruptedBanner } from './SessionInterruptedBanner'
 import { ExtensionPreservingFileName } from './ExtensionPreservingFileName'
 import { WorkspaceMessageScroller } from './WorkspaceMessageScroller'
+import { WorkspaceMessageEditStateProvider } from './workspace-message-edit-state'
 
 const composerInteractiveTransitionClassName = 'transition-colors duration-200 ease-out'
 
@@ -346,11 +347,12 @@ const ConversationPanel = ({
           </button>
         </header>
 
-        <WorkspaceMessageScroller
-          activeSession={activeSession}
-          canEditMessage={canEditMessage}
-          onSendEditedMessage={onSendEditedMessage}
-        />
+        <WorkspaceMessageEditStateProvider canEditMessage={canEditMessage}>
+          <WorkspaceMessageScroller
+            activeSession={activeSession}
+            onSendEditedMessage={onSendEditedMessage}
+          />
+        </WorkspaceMessageEditStateProvider>
 
         <div className="relative shrink-0">
           <div

--- a/src/renderer/src/pages/workspace/WorkspaceMessageScroller.interaction.test.tsx
+++ b/src/renderer/src/pages/workspace/WorkspaceMessageScroller.interaction.test.tsx
@@ -1,12 +1,18 @@
 // @vitest-environment jsdom
-import { act } from 'react'
+import { act, useCallback, useEffect } from 'react'
 import { createRoot, type Root } from 'react-dom/client'
 import type { PropsWithChildren } from 'react'
-import type { ChatMessage, ChatSession } from '@/stores/session-store'
-import { createInitialReviewState, useReviewStore } from '@/stores/review-store'
+import { useSessionStore, type ChatMessage, type ChatSession } from '@/stores/session-store'
+import {
+  createInitialReviewState,
+  selectProjectSessionReviews,
+  useReviewStore
+} from '@/stores/review-store'
 import { createUploadVersionReference, type UploadedAttachment } from '../../../../shared/uploads'
 import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest'
 import type { ReviewWithChecks } from '../../../../shared/reviewer'
+
+import type { ComposerDoc } from './composer/composer-doc'
 
 // pdfjs-dist references DOMMatrix at module load, which jsdom does not provide. This suite exercises
 // click/scroll behavior, not PDF rendering, so stub the library to keep the import graph loadable.
@@ -27,8 +33,13 @@ vi.mock('pdfjs-dist', () => {
   }
 })
 
+const { agentMarkdownRenderMock } = vi.hoisted(() => ({ agentMarkdownRenderMock: vi.fn() }))
+
 vi.mock('@/components/streamdown/AgentMarkdown', () => ({
-  AgentMarkdown: ({ content }: { content: string }) => <div>{content}</div>
+  AgentMarkdown: ({ content }: { content: string }) => {
+    agentMarkdownRenderMock(content)
+    return <div>{content}</div>
+  }
 }))
 
 vi.mock('@/components/ui/message-scroller', () => {
@@ -154,6 +165,7 @@ describe('WorkspaceMessageScroller artifact click behavior', () => {
 
   it('updates the visible message-branch review card when a running review completes', async () => {
     const { WorkspaceMessageScroller } = await import('./WorkspaceMessageScroller')
+    const { WorkspaceMessageEditStateProvider } = await import('./workspace-message-edit-state')
     const runningReview: ReviewWithChecks = {
       id: 'review-1',
       projectId: 'default',
@@ -187,18 +199,51 @@ describe('WorkspaceMessageScroller artifact click behavior', () => {
         })
       ]
     })
+    useSessionStore.setState({ sessions: [session], selectedSessionId: session.id })
+
+    const resendEditedMessage = vi.fn()
+    const ReviewLifecycleParent = (): React.JSX.Element => {
+      // Mirrors WorkspacePage: composer controls subscribe to the Session review lifecycle while the
+      // transcript sits below that reactive parent.
+      const isReviewing = useReviewStore((state) =>
+        selectProjectSessionReviews(state.reviewsBySession, session.projectId, session.id).some(
+          (review) => review.lifecycle === 'running'
+        )
+      )
+      const activeSession = useSessionStore((state) =>
+        state.sessions.find((candidate) => candidate.id === session.id)
+      )
+      const activeSessionId = activeSession?.id
+      // Mirrors WorkspacePage: the edit handler is scoped to the durable session identity rather than
+      // the ChatSession object, whose transient operation gates can change during reviewer updates.
+      const onSendEditedMessage = useCallback(
+        (messageId: string, doc: ComposerDoc) => {
+          if (activeSessionId) resendEditedMessage(activeSessionId, messageId, doc)
+        },
+        [activeSessionId]
+      )
+      useEffect(() => {
+        useSessionStore.getState().setBranchSwitchBlocked(session.id, isReviewing)
+      }, [isReviewing])
+      return (
+        <div data-reviewing={isReviewing ? 'true' : 'false'}>
+          <WorkspaceMessageEditStateProvider canEditMessage={!isReviewing}>
+            <WorkspaceMessageScroller
+              activeSession={activeSession}
+              onSendEditedMessage={onSendEditedMessage}
+            />
+          </WorkspaceMessageEditStateProvider>
+        </div>
+      )
+    }
 
     root = createRoot(container)
     await act(async () => {
-      root.render(
-        <WorkspaceMessageScroller
-          activeSession={session}
-          canEditMessage={false}
-          onSendEditedMessage={vi.fn()}
-        />
-      )
+      root.render(<ReviewLifecycleParent />)
     })
     expect(container.textContent).toContain('Reviewing…')
+    expect(container.querySelector('[data-reviewing="true"]')).not.toBeNull()
+    agentMarkdownRenderMock.mockClear()
 
     await act(async () => {
       useReviewStore.getState().handleReviewUpdate({
@@ -216,6 +261,10 @@ describe('WorkspaceMessageScroller artifact click behavior', () => {
     ).toBe('complete')
     expect(container.textContent).toContain('No issues found')
     expect(container.textContent).not.toContain('Reviewing…')
+    expect(container.querySelector('[data-reviewing="false"]')).not.toBeNull()
+    // Reviewer pushes should update only the card. Re-rendering the complete rich transcript here made
+    // large 0.9 sessions repeatedly rebuild every Markdown tree at end_turn on Windows.
+    expect(agentMarkdownRenderMock).not.toHaveBeenCalled()
   })
 
   it('upserts and activates the clicked artifact in the preview store, scoped to the active session', async () => {
@@ -249,11 +298,7 @@ describe('WorkspaceMessageScroller artifact click behavior', () => {
     root = createRoot(container)
     await act(async () => {
       root.render(
-        <WorkspaceMessageScroller
-          activeSession={session}
-          canEditMessage={false}
-          onSendEditedMessage={vi.fn()}
-        />
+        <WorkspaceMessageScroller activeSession={session} onSendEditedMessage={vi.fn()} />
       )
     })
 
@@ -289,7 +334,6 @@ describe('WorkspaceMessageScroller artifact click behavior', () => {
       root.render(
         <WorkspaceMessageScroller
           activeSession={createSession({ status: 'idle' })}
-          canEditMessage={false}
           onSendEditedMessage={vi.fn()}
         />
       )
@@ -331,11 +375,7 @@ describe('WorkspaceMessageScroller artifact click behavior', () => {
     root = createRoot(container)
     await act(async () => {
       root.render(
-        <WorkspaceMessageScroller
-          activeSession={session}
-          canEditMessage={false}
-          onSendEditedMessage={vi.fn()}
-        />
+        <WorkspaceMessageScroller activeSession={session} onSendEditedMessage={vi.fn()} />
       )
     })
 
@@ -368,11 +408,7 @@ describe('WorkspaceMessageScroller artifact click behavior', () => {
     root = createRoot(container)
     await act(async () => {
       root.render(
-        <WorkspaceMessageScroller
-          activeSession={session}
-          canEditMessage={false}
-          onSendEditedMessage={vi.fn()}
-        />
+        <WorkspaceMessageScroller activeSession={session} onSendEditedMessage={vi.fn()} />
       )
     })
 
@@ -431,11 +467,7 @@ describe('WorkspaceMessageScroller artifact click behavior', () => {
     root = createRoot(container)
     await act(async () => {
       root.render(
-        <WorkspaceMessageScroller
-          activeSession={session}
-          canEditMessage={false}
-          onSendEditedMessage={vi.fn()}
-        />
+        <WorkspaceMessageScroller activeSession={session} onSendEditedMessage={vi.fn()} />
       )
     })
 
@@ -498,11 +530,7 @@ describe('WorkspaceMessageScroller artifact click behavior', () => {
     root = createRoot(container)
     await act(async () => {
       root.render(
-        <WorkspaceMessageScroller
-          activeSession={session}
-          canEditMessage={false}
-          onSendEditedMessage={vi.fn()}
-        />
+        <WorkspaceMessageScroller activeSession={session} onSendEditedMessage={vi.fn()} />
       )
     })
     expect(window.api.artifacts.readPreview).not.toHaveBeenCalled()

--- a/src/renderer/src/pages/workspace/WorkspaceMessageScroller.render.test.tsx
+++ b/src/renderer/src/pages/workspace/WorkspaceMessageScroller.render.test.tsx
@@ -168,11 +168,7 @@ const renderScroller = async (session: ChatSession): Promise<string> => {
   const { WorkspaceMessageScroller } = await import('./WorkspaceMessageScroller')
 
   return renderToStaticMarkup(
-    <WorkspaceMessageScroller
-      activeSession={session}
-      canEditMessage={false}
-      onSendEditedMessage={vi.fn()}
-    />
+    <WorkspaceMessageScroller activeSession={session} onSendEditedMessage={vi.fn()} />
   )
 }
 

--- a/src/renderer/src/pages/workspace/WorkspaceMessageScroller.tsx
+++ b/src/renderer/src/pages/workspace/WorkspaceMessageScroller.tsx
@@ -12,7 +12,7 @@ import {
 import { selectProjectSessionReviews, useReviewStore } from '@/stores/review-store'
 import { useSettingsStore } from '@/stores/settings-store'
 import { useSessionStore, type ChatSession } from '@/stores/session-store'
-import { useCallback, useEffect, useMemo, useRef, useState } from 'react'
+import { memo, useCallback, useEffect, useMemo, useRef, useState, type ComponentProps } from 'react'
 
 import { shouldShowAgentLoadingMessage } from './agent-loading-message'
 import {
@@ -31,6 +31,7 @@ import { WorkspaceActivityGroup } from './WorkspaceActivityGroup'
 import { WorkspaceAgentLoadingRow } from './WorkspaceAgentLoadingRow'
 import { WorkspaceMessageItem } from './WorkspaceMessageItem'
 import type { ArtifactMentionPart } from './WorkspaceMessageItem'
+import { useWorkspaceMessageEditState } from './workspace-message-edit-state-context'
 import { createConversationItems } from './workspace-conversation-items'
 import { groupConversationItems } from './workspace-tool-activity-groups'
 import type { ActivityExpansionOverrides } from './workspace-tool-activity-groups'
@@ -40,8 +41,6 @@ import type { ComposerDoc } from './composer/composer-doc'
 
 type WorkspaceMessageScrollerProps = {
   activeSession: ChatSession | undefined
-  // Gates inline editing of sent user prompts; the handler forks at the edited message and resends.
-  canEditMessage: boolean
   onSendEditedMessage: (messageId: string, doc: ComposerDoc) => void
 }
 
@@ -125,10 +124,57 @@ const openSessionReviewer = (sessionId: string, intent: GoToTranscriptIntent): v
   )
 }
 
+type WorkspaceMessageReviewProps = {
+  projectId: string | undefined
+  sessionId: string
+  turnMessageId: string
+  onGoToTranscript: (intent: GoToTranscriptIntent) => void
+  onRerun: (review: ReviewWithChecks) => Promise<boolean>
+}
+
+// Keep reviewer updates local to their card. Subscribing the transcript parent to the whole Session
+// review array made every reviewer push rebuild every rich Markdown message in large conversations.
+const WorkspaceMessageReview = ({
+  projectId,
+  sessionId,
+  turnMessageId,
+  onGoToTranscript,
+  onRerun
+}: WorkspaceMessageReviewProps): React.JSX.Element | null => {
+  const review = useReviewStore((state) =>
+    selectProjectSessionReviews(state.reviewsBySession, projectId, sessionId).find(
+      (candidate) => candidate.turnMessageId === turnMessageId
+    )
+  )
+
+  if (!review) return null
+  return (
+    <div className="px-4 pb-1 md:px-6">
+      <div className="mx-auto w-full max-w-[56rem]">
+        {/* Only "Go to transcript" navigates to the reviewer page; the card itself does not. */}
+        <ReviewerCard review={review} onGoToTranscript={onGoToTranscript} onRerun={onRerun} />
+      </div>
+    </div>
+  )
+}
+
+type EditableWorkspaceMessageItemProps = Omit<
+  ComponentProps<typeof WorkspaceMessageItem>,
+  'canEditMessage'
+>
+
+// Only user-message edit controls subscribe to review-sensitive edit availability. Agent rows remain
+// outside this context subscription, so a reviewer lifecycle transition cannot rebuild rich output.
+const EditableWorkspaceMessageItem = (
+  props: EditableWorkspaceMessageItemProps
+): React.JSX.Element => {
+  const canEditMessage = useWorkspaceMessageEditState()
+  return <WorkspaceMessageItem {...props} canEditMessage={canEditMessage} />
+}
+
 // Owns transcript scrolling and session-scoped expansion state for activity groups.
-const WorkspaceMessageScroller = ({
+const WorkspaceMessageScrollerImpl = ({
   activeSession,
-  canEditMessage,
   onSendEditedMessage
 }: WorkspaceMessageScrollerProps): React.JSX.Element => {
   const currentSessionId = activeSession?.id
@@ -139,9 +185,6 @@ const WorkspaceMessageScroller = ({
     const stop = window.api?.window?.announceWindowFindReady?.()
     return () => stop?.()
   }, [])
-  const currentSessionReviews = useReviewStore((state) =>
-    selectProjectSessionReviews(state.reviewsBySession, currentProjectId, currentSessionId)
-  )
   const loadReviewsForSession = useReviewStore((state) => state.loadReviewsForSession)
 
   // Job store for binding and CompletedJobCard rendering
@@ -473,14 +516,6 @@ const WorkspaceMessageScroller = ({
                       activeSession && item.message.role !== 'user'
                         ? getMessageArtifacts(activeSession, item.message)
                         : []
-                    // Look up any review for this agent message (its id is the turnMessageId).
-                    const review =
-                      currentSessionId && item.message.role === 'agent'
-                        ? currentSessionReviews.find(
-                            (candidate) => candidate.turnMessageId === item.message.id
-                          )
-                        : undefined
-
                     // Jobs pre-assigned to this slot: each job appears in exactly one slot.
                     const jobsBeforeMessage = jobSlotsByItemIndex.get(itemIndex) ?? []
                     const graph = activeSession?.conversationGraph
@@ -515,6 +550,28 @@ const WorkspaceMessageScroller = ({
                               )
                         : undefined
                     }
+                    const messageItemProps: EditableWorkspaceMessageItemProps = {
+                      message: item.message,
+                      onPreviewArtifact,
+                      onPreviewUploadAttachment,
+                      onOpenSkillMention,
+                      onPreviewMentionArtifact,
+                      onSendEditedMessage,
+                      turnStartedAt: item.message.responseToMessageId
+                        ? messageCreatedAtById.get(item.message.responseToMessageId)
+                        : undefined,
+                      subsequentTurns: subsequentTurnCountByMessageId.get(item.message.id) ?? 0,
+                      revisionNavigation:
+                        revisionIndex >= 0 && revisions.length > 1
+                          ? {
+                              index: revisionIndex,
+                              total: revisions.length,
+                              onPrevious: activateRevision(revisionIndex - 1),
+                              onNext: activateRevision(revisionIndex + 1)
+                            }
+                          : undefined,
+                      artifacts
+                    }
 
                     return (
                       <div key={item.id}>
@@ -532,43 +589,19 @@ const WorkspaceMessageScroller = ({
                             </div>
                           </MessageScrollerItem>
                         ))}
-                        <WorkspaceMessageItem
-                          message={item.message}
-                          onPreviewArtifact={onPreviewArtifact}
-                          onPreviewUploadAttachment={onPreviewUploadAttachment}
-                          onOpenSkillMention={onOpenSkillMention}
-                          onPreviewMentionArtifact={onPreviewMentionArtifact}
-                          canEditMessage={canEditMessage}
-                          onSendEditedMessage={onSendEditedMessage}
-                          turnStartedAt={
-                            item.message.responseToMessageId
-                              ? messageCreatedAtById.get(item.message.responseToMessageId)
-                              : undefined
-                          }
-                          subsequentTurns={subsequentTurnCountByMessageId.get(item.message.id) ?? 0}
-                          revisionNavigation={
-                            revisionIndex >= 0 && revisions.length > 1
-                              ? {
-                                  index: revisionIndex,
-                                  total: revisions.length,
-                                  onPrevious: activateRevision(revisionIndex - 1),
-                                  onNext: activateRevision(revisionIndex + 1)
-                                }
-                              : undefined
-                          }
-                          artifacts={artifacts}
-                        />
-                        {review ? (
-                          <div className="px-4 pb-1 md:px-6">
-                            <div className="mx-auto w-full max-w-[56rem]">
-                              {/* Only "Go to transcript" navigates to the reviewer page; the card itself does not. */}
-                              <ReviewerCard
-                                review={review}
-                                onGoToTranscript={handleGoToTranscript}
-                                onRerun={handleRerunReview}
-                              />
-                            </div>
-                          </div>
+                        {item.message.role === 'user' ? (
+                          <EditableWorkspaceMessageItem {...messageItemProps} />
+                        ) : (
+                          <WorkspaceMessageItem {...messageItemProps} canEditMessage={false} />
+                        )}
+                        {currentSessionId && item.message.role === 'agent' ? (
+                          <WorkspaceMessageReview
+                            projectId={currentProjectId}
+                            sessionId={currentSessionId}
+                            turnMessageId={item.message.id}
+                            onGoToTranscript={handleGoToTranscript}
+                            onRerun={handleRerunReview}
+                          />
                         ) : null}
                       </div>
                     )
@@ -638,5 +671,42 @@ const WorkspaceMessageScroller = ({
     </>
   )
 }
+
+// Composer controls above the transcript react to reviewer lifecycle changes. Keep those parent
+// renders from rebuilding an unchanged transcript; review cards maintain their own scoped subscription.
+const areSessionsEqualForTranscript = (
+  previous: ChatSession | undefined,
+  next: ChatSession | undefined
+): boolean => {
+  if (Object.is(previous, next)) return true
+  if (!previous || !next) return false
+
+  // WorkspacePage mirrors reviewer activity into this transient operation gate. It changes the
+  // ChatSession object identity but is not rendered by the transcript, so compare every other field.
+  const previousKeys = Object.keys(previous).filter(
+    (key) => key !== 'branchSwitchBlocked'
+  ) as Array<keyof ChatSession>
+  const nextKeys = Object.keys(next).filter((key) => key !== 'branchSwitchBlocked') as Array<
+    keyof ChatSession
+  >
+
+  return (
+    previousKeys.length === nextKeys.length &&
+    previousKeys.every((key) => Object.is(previous[key], next[key]))
+  )
+}
+
+const areWorkspaceMessageScrollerPropsEqual = (
+  previous: WorkspaceMessageScrollerProps,
+  next: WorkspaceMessageScrollerProps
+): boolean =>
+  previous.onSendEditedMessage === next.onSendEditedMessage &&
+  areSessionsEqualForTranscript(previous.activeSession, next.activeSession)
+
+const WorkspaceMessageScroller = memo(
+  WorkspaceMessageScrollerImpl,
+  areWorkspaceMessageScrollerPropsEqual
+)
+WorkspaceMessageScroller.displayName = 'WorkspaceMessageScroller'
 
 export { WorkspaceMessageScroller }

--- a/src/renderer/src/pages/workspace/WorkspacePage.edit-message.test.tsx
+++ b/src/renderer/src/pages/workspace/WorkspacePage.edit-message.test.tsx
@@ -263,4 +263,17 @@ describe('WorkspacePage inline edit resend', () => {
     })
     expect(conversationProps.canEditMessage).toBe(true)
   })
+
+  it('keeps the resend handler stable when only the branch-switch operation gate changes', async () => {
+    await renderPage()
+
+    const initialHandler = conversationProps.onSendEditedMessage
+
+    await act(async () => {
+      useSessionStore.getState().setBranchSwitchBlocked('sess-a', true)
+    })
+
+    expect(conversationProps.canEditMessage).toBe(true)
+    expect(conversationProps.onSendEditedMessage).toBe(initialHandler)
+  })
 })

--- a/src/renderer/src/pages/workspace/WorkspacePage.tsx
+++ b/src/renderer/src/pages/workspace/WorkspacePage.tsx
@@ -735,6 +735,10 @@ const WorkspacePage = ({
     !activeSession?.conversationGraphSyncBlocked &&
     !activeSession?.compacting &&
     !sessionDeletionInProgressIds.has(activeSession?.id ?? '')
+  const canEditMessageRef = useRef(canEditMessage)
+  useLayoutEffect(() => {
+    canEditMessageRef.current = canEditMessage
+  }, [canEditMessage])
   useEffect(() => {
     const sessionId = activeSession?.id
     if (!sessionId) return
@@ -1188,16 +1192,19 @@ const WorkspacePage = ({
   // Resends an inline-edited prompt: the conversation is truncated at the edited message, the agent
   // context resets, and the kept turns replay as a preamble on the resent prompt. The gate mirrors
   // canEditMessage so a resend never overlaps an in-flight turn.
-  const sendEditedMessage = (messageId: string, doc: ComposerDoc): void => {
-    if (!canEditMessage || docIsEmpty(doc) || !activeSession) return
+  const sendEditedMessage = useCallback(
+    (messageId: string, doc: ComposerDoc): void => {
+      if (!canEditMessageRef.current || docIsEmpty(doc) || !activeSessionId) return
 
-    void resendEditedMessage(activeSession.id, messageId, {
-      text: docToText(doc),
-      parts: doc.nodes,
-      forcedSkillIds: docToSkillIds(doc),
-      referencedArtifacts: docToArtifactRefs(doc)
-    })
-  }
+      void resendEditedMessage(activeSessionId, messageId, {
+        text: docToText(doc),
+        parts: doc.nodes,
+        forcedSkillIds: docToSkillIds(doc),
+        referencedArtifacts: docToArtifactRefs(doc)
+      })
+    },
+    [activeSessionId, resendEditedMessage]
+  )
 
   // Sends the current draft only after hydration so restored selection cannot overwrite intent.
   // ConversationPanel owns preventDefault and passes the skills picked as inline chips.

--- a/src/renderer/src/pages/workspace/workspace-message-edit-state-context.ts
+++ b/src/renderer/src/pages/workspace/workspace-message-edit-state-context.ts
@@ -1,0 +1,7 @@
+import { createContext, useContext } from 'react'
+
+const WorkspaceMessageEditStateContext = createContext(false)
+
+const useWorkspaceMessageEditState = (): boolean => useContext(WorkspaceMessageEditStateContext)
+
+export { WorkspaceMessageEditStateContext, useWorkspaceMessageEditState }

--- a/src/renderer/src/pages/workspace/workspace-message-edit-state.tsx
+++ b/src/renderer/src/pages/workspace/workspace-message-edit-state.tsx
@@ -1,0 +1,21 @@
+import type { ReactNode } from 'react'
+
+import { WorkspaceMessageEditStateContext } from './workspace-message-edit-state-context'
+
+type WorkspaceMessageEditStateProviderProps = {
+  canEditMessage: boolean
+  children: ReactNode
+}
+
+// Editing availability changes with reviewer lifecycle, but only sent user messages need that signal.
+// Keeping it in a narrow context lets those controls update without invalidating the transcript parent.
+const WorkspaceMessageEditStateProvider = ({
+  canEditMessage,
+  children
+}: WorkspaceMessageEditStateProviderProps): React.JSX.Element => (
+  <WorkspaceMessageEditStateContext.Provider value={canEditMessage}>
+    {children}
+  </WorkspaceMessageEditStateContext.Provider>
+)
+
+export { WorkspaceMessageEditStateProvider }


### PR DESCRIPTION
## Problem

Windows users on the 0.9 line can finish a review in a large session and be left with a blank `BrowserWindow`. The supplied `main.log` records repeated renderer exits (`reason: crashed`, `exitCode: -36861`) concentrated around review completion, but the app neither recovered the renderer nor initialized local Crashpad early enough to preserve useful native crash evidence.

The 0.9 review-status refresh also allowed reviewer lifecycle changes to rebuild the parent transcript, including every rich Markdown tree in long sessions.

## Proposed change

- Localize reviewer and edit-state subscriptions so review lifecycle and `branchSwitchBlocked` changes do not rebuild unchanged agent rich text.
- Keep the edited-message callback stable for transient changes to the active session object.
- Recover an unexpectedly exited renderer with at most two automatic reloads per 60 seconds; on the next crash, show a native Reload/Close prompt instead of looping.
- Start Windows-only local Crashpad before a renderer is created, with upload and compression disabled.
- Add privacy-safe diagnostics for renderer load/preload failures and GPU/utility child-process exits without logging content, URLs, command lines, or failed paths.

## Scope and non-goals

- This mitigates the identified 0.9 transcript rebuild pressure and prevents an unexpected renderer exit from remaining as a white window.
- It does not claim the exact native Chromium crash is proven without a Windows `.dmp` file.
- It does not upload crash dumps or virtualize the complete transcript.

## Acceptance criteria and validation

All checks below ran after the last material edit.

- Reviewer lifecycle plus the real `branchSwitchBlocked` store update leaves agent Markdown and the edited-message callback stable -> `npm test -- src/renderer/src/pages/workspace/WorkspaceMessageScroller.interaction.test.tsx src/renderer/src/pages/workspace/WorkspacePage.edit-message.test.tsx` -> 2 files, 11 tests passed.
- Windows renderer recovery, Crashpad platform gating, upload-disabled configuration, and privacy-safe child-process projection -> `npm test -- src/main/crash-diagnostics.test.ts src/main/windows.test.ts src/renderer/src/pages/workspace/WorkspaceMessageScroller.interaction.test.tsx` -> 3 files, 56 tests passed.
- Type safety -> `npm run typecheck` -> passed.
- Lint -> `npm run lint` -> 0 errors; 23 pre-existing warnings.
- Full regression suite -> `npm test` -> 650 files passed, 15 skipped; 9,594 tests passed, 184 skipped.
- Production bundles -> `npm run build` -> passed.
- Independent review -> Standards: no findings; Spec: no high/medium findings.

Uncovered risk: `main.log` records the Crashpad directory and crash time but not a dump filename/ID. If the directory contains multiple dumps, support must correlate the local file by modification time. Dumps remain local and may contain process memory; users must explicitly choose to provide one.

## Review focus

- The recovery-loop limit and intentional-exit exclusions in `windows.ts`.
- The transcript memo boundary across reviewer, edit-state, and session operation-gate updates.
- Windows-only Crashpad startup and the privacy boundary of diagnostic log metadata.
