### PR TITLE
fix(acp): recover incompatible Claude session resumes

### DIFF
--- a/src/main/acp/runtime.test.ts
+++ b/src/main/acp/runtime.test.ts
@@ -7227,6 +7227,32 @@ describe('ACP runtime session management', () => {
     )
   })
 
+  it('adopts a fresh Claude session instead of resuming an OpenCode session id', async () => {
+    const process = new FakeAgentProcess()
+    const fakeAgent = startFakeAgent(process, ['claude-session-replacement'], {
+      resumeInternalErrorDetails:
+        'Claude Code returned an error result: Error: --resume requires a valid session ID or session title when used with --print. Usage: claude -p --resume <session-id|title>. Provided value "ses_03fed93d1ffe1uw7XFraUNPhun" is not a UUID and does not match any session title.'
+    })
+    const runtime = new AcpRuntime({
+      appVersion: '0.1.0',
+      defaultCwd: '/workspace',
+      spawnAgent: () => asAgentProcess(process)
+    })
+
+    await expect(
+      runtime.resumeSession({
+        sessionId: 'ses_03fed93d1ffe1uw7XFraUNPhun',
+        cwd: '/workspace'
+      })
+    ).resolves.toMatchObject({
+      sessionId: 'ses_03fed93d1ffe1uw7XFraUNPhun',
+      frameworkId: 'claude-code',
+      contextReset: true
+    })
+    expect(fakeAgent.resumedSessions).toEqual([])
+    expect(fakeAgent.newSessions).toHaveLength(1)
+  })
+
   it.each([
     '019fb8c8-6c66-7f22-9653-17b5b287dbbb',
     'urn:uuid:019fb8c8-6c66-7f22-9653-17b5b287dbbb'

--- a/src/main/acp/runtime.test.ts
+++ b/src/main/acp/runtime.test.ts
@@ -165,8 +165,7 @@ const startFakeAgent = (
     // When true, the resume handler rejects with the ACP "Resource not found" (-32002) — the signal a
     // replaced agent (e.g. after a provider switch) gives for a session id it does not hold.
     resumeNotFound?: boolean
-    // When true, the resume handler rejects with a generic "Internal error" (-32603) — what some
-    // agents return instead of a clean not-found after their process was replaced by an app restart.
+    // When true, the resume handler rejects with a detail-free generic "Internal error" (-32603).
     resumeInternalError?: boolean
     // A plain handler error is serialized by the ACP SDK as -32603 with the original message in
     // data.details. This mirrors agents that do not translate their resume failure to resourceNotFound.

--- a/src/main/acp/runtime.ts
+++ b/src/main/acp/runtime.ts
@@ -520,6 +520,8 @@ const isUnresumableSessionErrorKind = (errorKind: unknown): boolean =>
 const isCodexProtocolSessionId = (sessionId: string): boolean =>
   /^(?:urn:uuid:)?[0-9a-f]{8}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{12}$/i.test(sessionId)
 
+const isOpenCodeProtocolSessionId = (sessionId: string): boolean => sessionId.startsWith('ses_')
+
 // Legacy agents may expose only an English diagnostic. Keep this fallback deliberately narrow: a
 // false positive silently resets agent-side context, while a false negative leaves the real error
 // visible and can be fixed by teaching the backend to emit a machine-readable errorKind.
@@ -2023,6 +2025,17 @@ class AcpRuntime {
     // and let the caller replay the visible transcript under the stable app id.
     if (this.framework.id === 'codex' && !isCodexProtocolSessionId(request.sessionId)) {
       log.info('skipping invalid Codex session resume; adopting a fresh session', {
+        sessionId: request.sessionId
+      })
+      return this.adoptFreshSession(connection, request, sessionCwd, projectName)
+    }
+
+    // Persisted sessions created before framework provenance was recorded may restore without a
+    // previousFrameworkId. OpenCode ids use the `ses_...` namespace, which Claude Code rejects before
+    // it can return a resumable session-not-found result. Avoid the guaranteed failing request and
+    // preserve the app-facing conversation by adopting a fresh Claude session for transcript replay.
+    if (this.framework.id === 'claude-code' && isOpenCodeProtocolSessionId(request.sessionId)) {
+      log.info('skipping OpenCode session id for Claude resume; adopting a fresh session', {
         sessionId: request.sessionId
       })
       return this.adoptFreshSession(connection, request, sessionCwd, projectName)

--- a/src/renderer/src/lib/acp/useWorkspaceAgentRuntime.test.ts
+++ b/src/renderer/src/lib/acp/useWorkspaceAgentRuntime.test.ts
@@ -212,14 +212,28 @@ describe('workspace agent runtime event processing', () => {
 })
 
 describe('resume failure classification', () => {
-  it('replaces an opaque ACP Internal error with actionable recovery guidance', () => {
+  it('classifies an opaque ACP Internal error as unknown without guessing a cause', () => {
     const message = getResumeFailureMessage(
       new Error("Error invoking remote method 'acp:resume-session': RequestError: Internal error")
     )
 
-    expect(message).toBe(
-      'The agent could not restore this conversation. Try Resume again; if it still fails, switch back to the original agent or start a new conversation.'
+    expect(message).toBe('Agent session resume failed: Unknown error')
+  })
+
+  it('classifies a bare Internal error as unknown when IPC drops the custom error name', () => {
+    const message = getResumeFailureMessage(
+      new Error("Error invoking remote method 'acp:resume-session': Error: Internal error")
     )
+
+    expect(message).toBe('Agent session resume failed: Unknown error')
+  })
+
+  it('classifies an empty downstream failure at the Electron IPC seam as unknown', () => {
+    const message = getResumeFailureMessage(
+      new Error("Error invoking remote method 'acp:resume-session': Error")
+    )
+
+    expect(message).toBe('Agent session resume failed: Unknown error')
   })
 
   it('keeps a specific RequestError cause visible', () => {

--- a/src/renderer/src/lib/acp/useWorkspaceAgentRuntime.test.ts
+++ b/src/renderer/src/lib/acp/useWorkspaceAgentRuntime.test.ts
@@ -928,6 +928,29 @@ describe('workspace agent message sending', () => {
     })
   })
 
+  it('uses a generic creation error when IPC supplies no downstream detail', async () => {
+    const runtime = {
+      state: createSnapshot(),
+      createSession: vi
+        .fn()
+        .mockRejectedValue(new Error("Error invoking remote method 'acp:create-session': Error")),
+      resumeSession: vi.fn(),
+      resetSessionContext: vi.fn(),
+      sendPrompt: vi.fn()
+    }
+
+    await sendWorkspaceMessage(runtime, {
+      text: 'Start a new analysis',
+      cwd: '/workspace/project',
+      agentFrameworkId: 'codex'
+    })
+    await flushRuntimeTasks()
+
+    expect(useSessionStore.getState().sessions[0]?.error).toBe(
+      'Agent session could not be created.'
+    )
+  })
+
   it('unwraps an IPC-wrapped config failure at session start and marks it non-reportable', async () => {
     // resolveActiveAgentBackend throws app-authored setup guidance at spawn time; it crosses IPC wrapped
     // as "Error invoking remote method '…': Error: <msg>". The createSession path must unwrap it so the

--- a/src/renderer/src/lib/acp/useWorkspaceAgentRuntime.test.ts
+++ b/src/renderer/src/lib/acp/useWorkspaceAgentRuntime.test.ts
@@ -212,6 +212,28 @@ describe('workspace agent runtime event processing', () => {
 })
 
 describe('resume failure classification', () => {
+  it('replaces an opaque ACP Internal error with actionable recovery guidance', () => {
+    const message = getResumeFailureMessage(
+      new Error("Error invoking remote method 'acp:resume-session': RequestError: Internal error")
+    )
+
+    expect(message).toBe(
+      'The agent could not restore this conversation. Try Resume again; if it still fails, switch back to the original agent or start a new conversation.'
+    )
+  })
+
+  it('keeps a specific RequestError cause visible', () => {
+    const message = getResumeFailureMessage(
+      new Error(
+        "Error invoking remote method 'acp:resume-session': RequestError: Internal error while loading provider configuration"
+      )
+    )
+
+    expect(message).toBe(
+      'Agent session resume failed: RequestError: Internal error while loading provider configuration'
+    )
+  })
+
   it('rewrites a genuine model↔framework incompatibility into the actionable settings message', () => {
     // Verbatim error thrown by settings/service.ts when the active provider cannot drive the framework.
     const message = getResumeFailureMessage(

--- a/src/renderer/src/lib/acp/useWorkspaceAgentRuntime.test.ts
+++ b/src/renderer/src/lib/acp/useWorkspaceAgentRuntime.test.ts
@@ -798,7 +798,12 @@ describe('workspace agent message sending', () => {
       agentModel: 'model-used-by-run'
     })
 
-    expect(runtime.createSession).toHaveBeenCalledWith('/workspace/project', undefined, 'ask', undefined)
+    expect(runtime.createSession).toHaveBeenCalledWith(
+      '/workspace/project',
+      undefined,
+      'ask',
+      undefined
+    )
     expect(runtime.sendPrompt).not.toHaveBeenCalled()
     expect(useSessionStore.getState().sessions[0]).toMatchObject({
       id: sent?.sessionId,
@@ -1233,8 +1238,20 @@ describe('workspace agent message sending', () => {
       projectName: 'project-1'
     })
 
-    expect(runtime.createSession).toHaveBeenNthCalledWith(1, undefined, 'project-1', 'ask', undefined)
-    expect(runtime.createSession).toHaveBeenNthCalledWith(2, undefined, 'project-1', 'ask', undefined)
+    expect(runtime.createSession).toHaveBeenNthCalledWith(
+      1,
+      undefined,
+      'project-1',
+      'ask',
+      undefined
+    )
+    expect(runtime.createSession).toHaveBeenNthCalledWith(
+      2,
+      undefined,
+      'project-1',
+      'ask',
+      undefined
+    )
   })
 
   it('does not submit another prompt for a session that already owns a run', async () => {

--- a/src/renderer/src/lib/acp/useWorkspaceAgentRuntime.ts
+++ b/src/renderer/src/lib/acp/useWorkspaceAgentRuntime.ts
@@ -156,7 +156,7 @@ const RESUME_UNKNOWN_ERROR_MESSAGE = 'Agent session resume failed: Unknown error
 const getCreateSessionFailureMessage = (error: unknown): string => {
   const message = error instanceof Error ? error.message : String(error)
 
-  return unwrapIpcErrorDetail(message) || message.trim() || 'Agent session could not be created.'
+  return unwrapIpcErrorDetail(message) || 'Agent session could not be created.'
 }
 
 // Turns a resume failure into an actionable message. Each branch matches one distinct cause thrown

--- a/src/renderer/src/lib/acp/useWorkspaceAgentRuntime.ts
+++ b/src/renderer/src/lib/acp/useWorkspaceAgentRuntime.ts
@@ -138,16 +138,15 @@ type WorkspaceRuntimeEventProcessor = {
 const sessionSendPreparationsInFlight = new Set<string>()
 
 // Strips the Electron IPC wrapper ("Error invoking remote method '…': Error: <cause>") and any
-// leading "Error:" so the underlying agent message can be shown to the user on its own. Used by both
-// the resume and createSession failure paths, since either crosses IPC and arrives wrapped.
+// leading "Error:" (or a lone "Error" type label) so the underlying agent message can be shown to the
+// user on its own. Used by both resume and createSession failure paths, since either arrives wrapped.
 const unwrapIpcErrorDetail = (message: string): string =>
   message
     .replace(/^Error invoking remote method '[^']*':\s*/i, '')
-    .replace(/^Error:\s*/i, '')
+    .replace(/^Error(?::\s*|$)/i, '')
     .trim()
 
-const RESUME_INTERNAL_ERROR_MESSAGE =
-  'The agent could not restore this conversation. Try Resume again; if it still fails, switch back to the original agent or start a new conversation.'
+const RESUME_UNKNOWN_ERROR_MESSAGE = 'Agent session resume failed: Unknown error'
 
 // Turns a createSession (conversation-start) failure into the message persisted on the session. The
 // error crosses IPC wrapped, so it is unwrapped first — this keeps the app-authored setup guidance
@@ -196,14 +195,14 @@ const getResumeFailureMessage = (error: unknown): string => {
 
   const detail = unwrapIpcErrorDetail(message)
 
-  // Electron preserves the custom RequestError name/message but drops its structured `data.details`
-  // while crossing IPC. Do not expose that opaque implementation label as if it were actionable;
-  // keep specific non-Internal errors visible below so unexpected failures remain diagnosable.
-  if (detail === 'RequestError: Internal error') {
-    return RESUME_INTERNAL_ERROR_MESSAGE
+  // Electron can preserve only the custom RequestError name/message while dropping structured
+  // `data.details` across IPC. A bare Internal error supplies no evidence for a network, session, or
+  // provider diagnosis, so classify it as unknown. Specific downstream causes stay visible below.
+  if (detail === 'RequestError: Internal error' || detail === 'Internal error') {
+    return RESUME_UNKNOWN_ERROR_MESSAGE
   }
 
-  return detail ? `Agent session resume failed: ${detail}` : 'Agent session resume failed'
+  return detail ? `Agent session resume failed: ${detail}` : RESUME_UNKNOWN_ERROR_MESSAGE
 }
 
 // Keeps attachment-finalization failures displayable without assuming Error instances.

--- a/src/renderer/src/lib/acp/useWorkspaceAgentRuntime.ts
+++ b/src/renderer/src/lib/acp/useWorkspaceAgentRuntime.ts
@@ -146,6 +146,9 @@ const unwrapIpcErrorDetail = (message: string): string =>
     .replace(/^Error:\s*/i, '')
     .trim()
 
+const RESUME_INTERNAL_ERROR_MESSAGE =
+  'The agent could not restore this conversation. Try Resume again; if it still fails, switch back to the original agent or start a new conversation.'
+
 // Turns a createSession (conversation-start) failure into the message persisted on the session. The
 // error crosses IPC wrapped, so it is unwrapped first — this keeps the app-authored setup guidance
 // (settings/service.ts: model-incompat, no provider, Codex bridge, missing Claude executable) matching
@@ -192,6 +195,13 @@ const getResumeFailureMessage = (error: unknown): string => {
   }
 
   const detail = unwrapIpcErrorDetail(message)
+
+  // Electron preserves the custom RequestError name/message but drops its structured `data.details`
+  // while crossing IPC. Do not expose that opaque implementation label as if it were actionable;
+  // keep specific non-Internal errors visible below so unexpected failures remain diagnosable.
+  if (detail === 'RequestError: Internal error') {
+    return RESUME_INTERNAL_ERROR_MESSAGE
+  }
 
   return detail ? `Agent session resume failed: ${detail}` : 'Agent session resume failed'
 }

--- a/src/renderer/src/pages/workspace/WorkspaceMessageItem.tsx
+++ b/src/renderer/src/pages/workspace/WorkspaceMessageItem.tsx
@@ -62,6 +62,9 @@ type WorkspaceMessageItemProps = {
   onSendEditedMessage?: (messageId: string, doc: ComposerDoc) => void
   // Prompt send time for an Agent response; paired with its completion time for elapsed duration.
   turnStartedAt?: number
+  // A tool-calling turn can contain several assistant fragments; only its final fragment owns the
+  // whole-turn completion/elapsed/usage footer. Other transcript surfaces default to showing it.
+  showAssistantFooter?: boolean
   // Number of user turns after this message; drives the destructive-resend warning threshold.
   subsequentTurns?: number
   revisionNavigation?: {
@@ -661,6 +664,7 @@ const WorkspaceMessageItem = ({
   contentPaddingClassName,
   onSendEditedMessage,
   turnStartedAt,
+  showAssistantFooter = true,
   subsequentTurns = 0,
   revisionNavigation,
   artifacts = [],
@@ -894,7 +898,8 @@ const WorkspaceMessageItem = ({
             ) : null}
             <MessageImageList images={message.images ?? []} />
             <MessageArtifactList onPreviewArtifact={onPreviewArtifact} artifacts={artifacts} />
-            {terminalDate || (terminalTimestamp !== undefined && hasTurnUsage) ? (
+            {showAssistantFooter &&
+            (terminalDate || (terminalTimestamp !== undefined && hasTurnUsage)) ? (
               <div
                 data-slot="assistant-message-footer"
                 className="mt-3 flex items-center gap-x-3 whitespace-nowrap text-[11px] leading-4 text-text-000/70 tabular-nums"

--- a/src/renderer/src/pages/workspace/WorkspaceMessageScroller.render.test.tsx
+++ b/src/renderer/src/pages/workspace/WorkspaceMessageScroller.render.test.tsx
@@ -297,6 +297,76 @@ describe('WorkspaceMessageScroller loading render', () => {
     expect(html).not.toContain('Input</dt>')
   })
 
+  it('renders completion metadata once after the final assistant message fragment in a tool turn', async () => {
+    const html = await renderScroller(
+      createSession({
+        status: 'idle',
+        messages: [
+          createMessage({ id: 'prompt-1', createdAt: 1710000000000, sortIndex: 1 }),
+          createMessage({
+            id: 'reply-1',
+            role: 'agent',
+            content: 'I loaded the skill.',
+            responseToMessageId: 'prompt-1',
+            createdAt: 1710000030000,
+            completedAt: 1710000125000,
+            sortIndex: 2
+          }),
+          createMessage({
+            id: 'reply-2',
+            role: 'agent',
+            content: 'I found the baseline count.',
+            responseToMessageId: 'prompt-1',
+            createdAt: 1710000060000,
+            completedAt: 1710000125000,
+            sortIndex: 4
+          }),
+          createMessage({
+            id: 'reply-3',
+            role: 'agent',
+            content: 'Here is the final answer.',
+            responseToMessageId: 'prompt-1',
+            createdAt: 1710000090000,
+            completedAt: 1710000125000,
+            sortIndex: 6
+          })
+        ],
+        activities: [
+          createActivity({
+            id: 'activity-1',
+            title: 'First tool action',
+            sortIndex: 3,
+            createdAt: 1710000045000,
+            updatedAt: 1710000045000
+          }),
+          createActivity({
+            id: 'activity-2',
+            title: 'Second tool action',
+            sortIndex: 5,
+            createdAt: 1710000075000,
+            updatedAt: 1710000075000
+          })
+        ]
+      })
+    )
+
+    const timelineContent = [
+      'I loaded the skill.',
+      'data-message-id="activity-group-activity-1"',
+      'I found the baseline count.',
+      'data-message-id="activity-group-activity-2"',
+      'Here is the final answer.'
+    ]
+    const timelinePositions = timelineContent.map((content) => html.indexOf(content))
+
+    expect(timelinePositions.every((position) => position >= 0)).toBe(true)
+    expect(timelinePositions).toEqual([...timelinePositions].sort((left, right) => left - right))
+    expect(html.match(/data-slot="assistant-message-footer"/g)).toHaveLength(1)
+    expect(html.indexOf('data-slot="assistant-message-footer"')).toBeGreaterThan(
+      html.indexOf('Here is the final answer.')
+    )
+  })
+
   it('keeps the loading row during permission waits and hides it without an active run', async () => {
     const runningSession = createSession({
       activeRun: {

--- a/src/renderer/src/pages/workspace/WorkspaceMessageScroller.tsx
+++ b/src/renderer/src/pages/workspace/WorkspaceMessageScroller.tsx
@@ -273,6 +273,30 @@ const WorkspaceMessageScrollerImpl = ({
       ),
     [activeSession, handoffEvents]
   )
+  // Assistant text can be split into several messages around tool calls. All fragments share the
+  // prompt they respond to, but only the last visible fragment in that turn owns whole-turn metadata.
+  // Legacy unlinked messages remain independent so older transcripts do not lose their timestamps.
+  const assistantFooterMessageIds = useMemo(() => {
+    const footerIds = new Set<string>()
+    const footerIdByPromptMessageId = new Map<string, string>()
+
+    for (const item of conversationItems) {
+      if (item.type !== 'message' || item.message.role !== 'agent') continue
+
+      const promptMessageId = item.message.responseToMessageId
+      if (!promptMessageId) {
+        footerIds.add(item.message.id)
+        continue
+      }
+
+      const previousFooterId = footerIdByPromptMessageId.get(promptMessageId)
+      if (previousFooterId) footerIds.delete(previousFooterId)
+      footerIdByPromptMessageId.set(promptMessageId, item.message.id)
+      footerIds.add(item.message.id)
+    }
+
+    return footerIds
+  }, [conversationItems])
   const showAgentLoadingMessage = shouldShowAgentLoadingMessage(activeSession)
   const messageCreatedAtById = new Map(
     activeSession?.messages.map((message) => [message.id, message.createdAt]) ?? []
@@ -575,6 +599,9 @@ const WorkspaceMessageScrollerImpl = ({
                       turnStartedAt: item.message.responseToMessageId
                         ? messageCreatedAtById.get(item.message.responseToMessageId)
                         : undefined,
+                      showAssistantFooter:
+                        item.message.role !== 'agent' ||
+                        assistantFooterMessageIds.has(item.message.id),
                       subsequentTurns: subsequentTurnCountByMessageId.get(item.message.id) ?? 0,
                       revisionNavigation:
                         revisionIndex >= 0 && revisions.length > 1


### PR DESCRIPTION
## Problem

Switching an existing ACP session from Codex or OpenCode to Claude Code could forward the app-facing session ID to Claude's `--resume` flag even though it is not a Claude UUID or title. The adapter then surfaced a generic `Internal error`, and the renderer could further misclassify opaque downstream failures as network errors.

Tool-calling runs can also split one assistant response into several visible message fragments, causing whole-turn completion time, elapsed time, and usage metadata to appear more than once.

## Proposed change

- Detect backend-incompatible Claude resumes before calling `session/resume` and adopt a fresh Claude backend session under the existing app-facing session ID.
- Preserve `contextReset: true` so callers know the backend context was restarted.
- Prefer actionable downstream resume details, classify network errors only when supported by evidence, and fall back to `Unknown error` for genuinely opaque failures.
- Render whole-turn completion, elapsed, and usage metadata only on the final visible assistant fragment for a prompt.

## Scope and non-goals

- No database schema, persisted session format, or data-relationship changes.
- Cross-framework adoption intentionally starts a fresh provider context while preserving the Open Science session identity and transcript.
- Historical unlinked assistant messages retain their existing footer behavior.
- This PR does not change backend switching policy or add automatic transcript replay into the fresh provider context.

## Acceptance criteria and validation

All checks below ran after the final rebase conflict resolution:

- Incompatible Claude resume adoption, downstream error projection, and final-fragment footer behavior -> `npm test -- src/main/acp/runtime.test.ts src/renderer/src/lib/acp/useWorkspaceAgentRuntime.test.ts src/renderer/src/pages/workspace/WorkspaceMessageScroller.render.test.tsx` -> 408 passed.
- Type safety across main and renderer -> `npm run typecheck` -> passed.
- Repository lint gate -> `npm run lint` -> passed with 0 errors and 23 pre-existing warnings.
- Full regression suite -> `npm test` -> 9,608 passed, 184 skipped.

Uncovered risk: live compatibility still depends on provider adapters continuing to expose stable backend-session identity metadata; the runtime retains the defensive fresh-session fallback when that identity is incompatible.

## Review focus

- The boundary between app-facing session IDs and provider-native backend IDs.
- Error classification when downstream ACP responses include details versus no actionable information.
- Footer ownership when an assistant response is split around tool activity.
