### PR TITLE
test(settings): make proxy bypass fixture cross-platform

### DIFF
--- a/src/main/settings/backend-resolver.test.ts
+++ b/src/main/settings/backend-resolver.test.ts
@@ -516,8 +516,7 @@ describe('AgentBackendResolver bridge predicates', () => {
 
   it('bypasses loopback without disabling inherited proxies for native Responses compatibility', async () => {
     vi.stubEnv('HTTPS_PROXY', 'http://proxy.example.test:3128')
-    vi.stubEnv('NO_PROXY', 'metadata.example.test')
-    vi.stubEnv('no_proxy', 'existing.internal')
+    vi.stubEnv('NO_PROXY', 'metadata.example.test,existing.internal')
     try {
       const harness = makeHarness({
         targetOverride: () => ({ needsNativeResponsesCompatibility: true })


### PR DESCRIPTION
## Summary

- Keep the backend resolver proxy-bypass fixture valid on Windows by supplying both inherited bypass hosts through one `NO_PROXY` value.
- Avoid relying on case-only environment-variable aliases coexisting in `process.env`.
- Fixes the advisory Windows failure in https://github.com/aipoch/open-science/actions/runs/30737509763/job/91468895891.

## Validation

All checks ran after the final material edit.

- Proxy-bypass fixture -> `npm test -- src/main/settings/backend-resolver.test.ts -t "bypasses loopback without disabling inherited proxies for native Responses compatibility"` -> passed (1 test).
- Type safety -> `npm run typecheck` -> passed.
- Lint compliance -> `npm run lint` -> passed with 0 errors (19 existing warnings).
- Regression suite -> `npm test` -> passed (670 files, 9,754 tests; 15 files and 184 tests skipped).

## Risk

The Windows environment-variable alias behavior cannot be reproduced directly on macOS; the advisory Windows workflow provides the platform-specific verification.

## Review focus

Confirm the fixture still covers preservation of both inherited bypass hosts without requiring distinct `NO_PROXY` and `no_proxy` process keys.