### PR TITLE
feat(workspace): show completed turn runtime icons

### DIFF
--- a/src/renderer/src/pages/settings/AgentPanel.tsx
+++ b/src/renderer/src/pages/settings/AgentPanel.tsx
@@ -1,12 +1,5 @@
 import { useCallback, useEffect, useRef, useState } from 'react'
 import { RefreshCw, TriangleAlert } from 'lucide-react'
-
-// Import the bare Mono/Color components straight from their modules: each icon's entry point
-// eagerly attaches its Avatar/Combine companions, which drag in @lobehub/ui (antd-style + an
-// emoji-mart JSON import vitest can't parse). The Mono/Color components are self-contained.
-import ClaudeColor from '@lobehub/icons/es/Claude/components/Color'
-import Codex from '@lobehub/icons/es/Codex/components/Mono'
-import OpenCode from '@lobehub/icons/es/OpenCode/components/Mono'
 import { ExternalTextLink } from '@/components/ExternalTextLink'
 import { Button } from '@/components/ui/button'
 import { selectAnyInstalling, useSettingsStore } from '@/stores/settings-store'
@@ -23,6 +16,7 @@ import {
 } from '../../../../shared/settings'
 import { AgentFrameworkCard } from './AgentFrameworkCard'
 import { ModelFrameworkCompatibilityAlert } from './ModelFrameworkCompatibilityAlert'
+import { AgentFrameworkIcon } from './provider-icons'
 import { RepairFrameworkDialog } from './RepairFrameworkDialog'
 import { SettingsSection } from './SettingsLayout'
 import { SwitchFrameworkDialog } from './SwitchFrameworkDialog'
@@ -329,7 +323,7 @@ const AgentPanel = ({
       key: 'claude',
       frameworkId: 'claude-code',
       name: 'Claude Agent',
-      icon: <ClaudeColor size={24} />,
+      icon: <AgentFrameworkIcon frameworkId="claude-code" size={24} />,
       description: "Anthropic's agentic coding tool for the terminal.",
       ready: preflight.claudeReady,
       version: claude.version,
@@ -353,7 +347,7 @@ const AgentPanel = ({
       key: 'opencode',
       frameworkId: 'opencode',
       name: 'OpenCode',
-      icon: <OpenCode size={24} className="text-foreground" />,
+      icon: <AgentFrameworkIcon frameworkId="opencode" size={24} />,
       description: 'Open-source coding agent for the terminal.',
       ready: preflight.opencodeReady,
       version: opencode.version,
@@ -377,7 +371,7 @@ const AgentPanel = ({
       key: 'codex',
       frameworkId: 'codex',
       name: 'Codex',
-      icon: <Codex size={24} className="text-foreground" />,
+      icon: <AgentFrameworkIcon frameworkId="codex" size={24} />,
       description: "OpenAI's coding agent, connected through the Codex ACP adapter.",
       ready: preflight.codexReady,
       version: codex.version,

--- a/src/renderer/src/pages/settings/provider-icons.tsx
+++ b/src/renderer/src/pages/settings/provider-icons.tsx
@@ -1,5 +1,10 @@
 import { CirclePlus, Sparkles } from 'lucide-react'
 
+// Import the bare icon components so this shared renderer stays free of @lobehub/ui.
+import ClaudeColor from '@lobehub/icons/es/Claude/components/Color'
+import Codex from '@lobehub/icons/es/Codex/components/Mono'
+import OpenCode from '@lobehub/icons/es/OpenCode/components/Mono'
+
 import { cn } from '@/lib/utils'
 import anthropicLogo from '@/assets/provider-icons/anthropic.svg'
 import claudeLogo from '@/assets/provider-icons/claude.svg'
@@ -15,6 +20,24 @@ import xiaomimimoLogo from '@/assets/provider-icons/xiaomimimo.svg'
 import sensenovaLogo from '@/assets/provider-icons/sensenova.svg'
 import volcengineLogo from '@/assets/provider-icons/volcengine.svg'
 import type { OfficialVendorId } from '../../../../shared/provider-registry'
+import type { AgentFrameworkId } from '../../../../shared/settings'
+
+// The same framework marks are used by Settings cards and completed-message metadata.
+export const AgentFrameworkIcon = ({
+  frameworkId,
+  size = 20,
+  className
+}: {
+  frameworkId: AgentFrameworkId
+  size?: number
+  className?: string
+}): React.JSX.Element => {
+  if (frameworkId === 'claude-code') return <ClaudeColor size={size} className={className} />
+  if (frameworkId === 'opencode') {
+    return <OpenCode size={size} className={cn('text-foreground', className)} />
+  }
+  return <Codex size={size} className={cn('text-foreground', className)} />
+}
 
 // Official vendor brand marks, bundled as assets. Both Kimi providers (the general Moonshot platform
 // and Kimi For Coding) share the one Kimi mark, both GLM providers (pay-as-you-go Zhipu and the GLM

--- a/src/renderer/src/pages/workspace/WorkspaceMessageItem.mentions.test.tsx
+++ b/src/renderer/src/pages/workspace/WorkspaceMessageItem.mentions.test.tsx
@@ -451,6 +451,8 @@ describe('WorkspaceMessageItem turn token usage', () => {
     const details = document.body.querySelector('[data-slot="turn-runtime-details"]')
     expect(details?.textContent).toContain('Agent: Codex')
     expect(details?.textContent).toContain('Model: gpt-test')
+    expect(details?.querySelector('[data-slot="turn-runtime-agent-detail-icon"]')).not.toBeNull()
+    expect(details?.querySelector('[data-slot="turn-runtime-model-detail-icon"]')).not.toBeNull()
 
     await act(async () => {
       useSettingsStore.setState({

--- a/src/renderer/src/pages/workspace/WorkspaceMessageItem.mentions.test.tsx
+++ b/src/renderer/src/pages/workspace/WorkspaceMessageItem.mentions.test.tsx
@@ -4,6 +4,7 @@ import { createRoot, type Root } from 'react-dom/client'
 import type { JSX, PropsWithChildren } from 'react'
 import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest'
 
+import { createInitialSettingsState, useSettingsStore } from '@/stores/settings-store'
 import type { ChatMessage } from '@/stores/session-store'
 
 import { WorkspaceMessageItem } from './WorkspaceMessageItem'
@@ -38,6 +39,7 @@ const createMessage = (overrides: Partial<ChatMessage>): ChatMessage => ({
 const noop = (): void => {}
 
 beforeEach(() => {
+  useSettingsStore.setState(createInitialSettingsState())
   container = document.createElement('div')
   document.body.appendChild(container)
   root = createRoot(container)
@@ -79,7 +81,8 @@ const clickButton = (label: string): void => {
 const renderMessageItem = async (
   message: ChatMessage,
   artifacts?: React.ComponentProps<typeof WorkspaceMessageItem>['artifacts'],
-  turnStartedAt?: number
+  turnStartedAt?: number,
+  runtimeIdentity?: React.ComponentProps<typeof WorkspaceMessageItem>['runtimeIdentity']
 ): Promise<void> => {
   await act(async () => {
     root.render(
@@ -91,6 +94,7 @@ const renderMessageItem = async (
         onOpenSkillMention={noop}
         onPreviewMentionArtifact={noop}
         turnStartedAt={turnStartedAt}
+        runtimeIdentity={runtimeIdentity}
       />
     )
   })
@@ -387,6 +391,63 @@ describe('WorkspaceMessageItem turn token usage', () => {
     expect(
       usagePopover?.querySelector('[data-slot="turn-token-usage-total"]')?.className
     ).toContain('border-t')
+  })
+
+  it('resolves the completed turn framework and model provider icons from stored runtime codes', async () => {
+    useSettingsStore.setState({
+      agentFrameworks: [
+        {
+          id: 'codex',
+          displayName: 'Codex',
+          supportedApiTypes: ['responses'],
+          supportsSkills: true
+        }
+      ],
+      providers: [
+        {
+          id: 'provider-openai',
+          type: 'official',
+          name: 'OpenAI',
+          vendorId: 'openai',
+          models: ['gpt-test'],
+          supportsImageInput: true,
+          hasKey: true,
+          needsKey: false
+        }
+      ]
+    })
+    await renderMessageItem(
+      createMessage({
+        role: 'agent',
+        content: 'Done',
+        completedAt: 1710000125000
+      }),
+      undefined,
+      undefined,
+      {
+        frameworkId: 'codex',
+        backendId: 'codex:provider-openai',
+        model: 'gpt-test'
+      }
+    )
+
+    const usageTrigger = container.querySelector<HTMLButtonElement>(
+      '[data-slot="turn-token-usage"] button'
+    )
+    await act(async () => {
+      usageTrigger?.dispatchEvent(new MouseEvent('pointerover', { bubbles: true }))
+      await Promise.resolve()
+    })
+
+    const frameworkIcon = document.body.querySelector('[data-slot="turn-runtime-framework"]')
+    const modelIcon = document.body.querySelector('[data-slot="turn-runtime-model"]')
+    expect(frameworkIcon?.getAttribute('aria-label')).toBe('Agent framework: Codex')
+    expect(frameworkIcon?.getAttribute('title')).toBe('Agent framework: Codex')
+    expect(modelIcon?.getAttribute('aria-label')).toBe('Model provider: OpenAI; model: gpt-test')
+    expect(modelIcon?.getAttribute('title')).toBe('Model provider: OpenAI; model: gpt-test')
+    expect(
+      decodeURIComponent(modelIcon?.querySelector('img')?.getAttribute('src') ?? '')
+    ).toContain('<title>OpenAI</title>')
   })
 
   it('splits cache reads and writes when the agent reports both categories', async () => {

--- a/src/renderer/src/pages/workspace/WorkspaceMessageItem.mentions.test.tsx
+++ b/src/renderer/src/pages/workspace/WorkspaceMessageItem.mentions.test.tsx
@@ -338,6 +338,7 @@ describe('WorkspaceMessageItem turn token usage', () => {
     expect(separator).toBeNull()
     expect(usage?.textContent).toBe('Usage')
     expect(usageTrigger?.getAttribute('aria-label')).toBe('Token usage for this response')
+    expect(usageTrigger?.querySelector('[data-slot="turn-token-usage-icon"]')).not.toBeNull()
     expect(usageTrigger?.className).toContain('border-dashed')
     expect(usageTrigger?.className).toContain('focus-visible:ring-[3px]')
     expect(usageTrigger?.className).toContain('focus-visible:ring-ring/50')

--- a/src/renderer/src/pages/workspace/WorkspaceMessageItem.mentions.test.tsx
+++ b/src/renderer/src/pages/workspace/WorkspaceMessageItem.mentions.test.tsx
@@ -451,6 +451,22 @@ describe('WorkspaceMessageItem turn token usage', () => {
     const details = document.body.querySelector('[data-slot="turn-runtime-details"]')
     expect(details?.textContent).toContain('Agent: Codex')
     expect(details?.textContent).toContain('Model: gpt-test')
+
+    await act(async () => {
+      useSettingsStore.setState({
+        agentFrameworks: [
+          {
+            id: 'codex',
+            displayName: 'Codex CLI',
+            supportedApiTypes: ['responses'],
+            supportsSkills: true
+          }
+        ]
+      })
+      await Promise.resolve()
+    })
+
+    expect(details?.textContent).toContain('Agent: Codex CLI')
   })
 
   it('omits historical runtime metadata that no longer resolves to displayable values', async () => {

--- a/src/renderer/src/pages/workspace/WorkspaceMessageItem.mentions.test.tsx
+++ b/src/renderer/src/pages/workspace/WorkspaceMessageItem.mentions.test.tsx
@@ -448,6 +448,30 @@ describe('WorkspaceMessageItem turn token usage', () => {
     expect(
       decodeURIComponent(modelIcon?.querySelector('img')?.getAttribute('src') ?? '')
     ).toContain('<title>OpenAI</title>')
+    const details = document.body.querySelector('[data-slot="turn-runtime-details"]')
+    expect(details?.textContent).toContain('Agent: Codex')
+    expect(details?.textContent).toContain('Model: gpt-test')
+  })
+
+  it('omits historical runtime metadata that no longer resolves to displayable values', async () => {
+    useSettingsStore.setState({ agentFrameworks: [], providers: [] })
+    await renderMessageItem(
+      createMessage({ role: 'agent', content: 'Legacy answer', completedAt: 1710000125000 }),
+      undefined,
+      undefined,
+      { frameworkId: 'codex', backendId: 'codex:deleted-provider' }
+    )
+
+    const usageTrigger = container.querySelector<HTMLButtonElement>(
+      '[data-slot="turn-token-usage"] button'
+    )
+    await act(async () => {
+      usageTrigger?.dispatchEvent(new MouseEvent('pointerover', { bubbles: true }))
+      await Promise.resolve()
+    })
+
+    expect(document.body.querySelector('[data-slot="turn-runtime-icons"]')).toBeNull()
+    expect(document.body.querySelector('[data-slot="turn-runtime-details"]')).toBeNull()
   })
 
   it('splits cache reads and writes when the agent reports both categories', async () => {

--- a/src/renderer/src/pages/workspace/WorkspaceMessageItem.tsx
+++ b/src/renderer/src/pages/workspace/WorkspaceMessageItem.tsx
@@ -3,6 +3,7 @@ import { MessageScrollerItem } from '@/components/ui/message-scroller'
 import { Popover, PopoverAnchor, PopoverContent } from '@/components/ui/popover'
 import { Tooltip, TooltipContent, TooltipProvider, TooltipTrigger } from '@/components/ui/tooltip'
 import { cn, formatByteSize } from '@/lib/utils'
+import { useSettingsStore } from '@/stores/settings-store'
 import type { ChatMessage, ChatSession } from '@/stores/session-store'
 import { Collapsible } from 'radix-ui'
 import {
@@ -18,13 +19,20 @@ import { useEffect, useId, useRef, useState, type FocusEvent } from 'react'
 import type { ArtifactPreviewResult } from '../../../../shared/artifacts'
 import type { ProvenanceMessagePart } from '../../../../shared/artifact-provenance'
 import type { AcpTurnTokenUsage } from '../../../../shared/acp'
+import type { PersistedRuntimeSegment } from '../../../../shared/conversation-graph'
 import type { MessagePart } from '../../../../shared/session-persistence'
+import {
+  isClaudeSubscriptionProviderId,
+  isCodexSubscriptionProviderId
+} from '../../../../shared/settings'
 import { getUploadedAttachmentName } from '../../../../shared/uploads'
 
 import { ArtifactPreview } from './artifact-preview'
 import { ComposerEditor } from './composer/ComposerEditor'
 import { EditMessageConfirmDialog } from './EditMessageConfirmDialog'
 import { ExtensionPreservingFileName } from './ExtensionPreservingFileName'
+import { providerKindKey } from '../settings/provider-form-value'
+import { AgentFrameworkIcon, ProviderKindIcon } from '../settings/provider-icons'
 import {
   docFromMessageParts,
   docFromText,
@@ -40,11 +48,13 @@ import {
 import { FILE_MISSING_TAG, isUnavailableFileError } from './previews/preview-errors'
 import { useNearViewport } from './previews/useNearViewport'
 import { useUnavailablePreviewProbe } from './previews/useUnavailablePreviewProbe'
+import { resolveSessionProviderId } from './error-report'
 
 type MessageArtifact = NonNullable<ChatSession['artifacts']>[number]
 type MessageUploadAttachment = NonNullable<ChatMessage['uploads']>[number]
 type MessageImage = NonNullable<ChatMessage['images']>[number]
 type ArtifactMentionPart = Extract<MessagePart, { type: 'artifact' }>
+type MessageRuntimeIdentity = Pick<PersistedRuntimeSegment, 'frameworkId' | 'backendId' | 'model'>
 type WorkspaceMessageItemProps = {
   message: ChatMessage
   onPreviewArtifact: (artifact: MessageArtifact) => void
@@ -62,6 +72,8 @@ type WorkspaceMessageItemProps = {
   onSendEditedMessage?: (messageId: string, doc: ComposerDoc) => void
   // Prompt send time for an Agent response; paired with its completion time for elapsed duration.
   turnStartedAt?: number
+  // Per-turn runtime codes come from the Conversation Graph; names and icons resolve from Settings.
+  runtimeIdentity?: MessageRuntimeIdentity
   // A tool-calling turn can contain several assistant fragments; only its final fragment owns the
   // whole-turn completion/elapsed/usage footer. Other transcript surfaces default to showing it.
   showAssistantFooter?: boolean
@@ -128,7 +140,55 @@ type TurnTokenUsageEntry = readonly [
   markerClassName: string
 ]
 
-const TurnTokenUsage = ({ usage }: { usage?: AcpTurnTokenUsage }): React.JSX.Element => {
+const TurnRuntimeIcons = ({ runtime }: { runtime: MessageRuntimeIdentity }): React.JSX.Element => {
+  const frameworks = useSettingsStore((state) => state.agentFrameworks)
+  const providers = useSettingsStore((state) => state.providers)
+  const frameworkName =
+    frameworks.find((framework) => framework.id === runtime.frameworkId)?.displayName ??
+    runtime.frameworkId
+  const providerId = resolveSessionProviderId(runtime.backendId)
+  const provider = providers.find((candidate) => candidate.id === providerId)
+  const kindKey = provider
+    ? providerKindKey(provider.type, provider.vendorId)
+    : isCodexSubscriptionProviderId(providerId ?? '')
+      ? 'codex-subscription'
+      : isClaudeSubscriptionProviderId(providerId ?? '')
+        ? 'claude-subscription'
+        : ''
+  const frameworkLabel = `Agent framework: ${frameworkName}`
+  const modelLabel = `Model provider: ${provider?.name ?? providerId ?? 'Unknown'}${runtime.model ? `; model: ${runtime.model}` : ''}`
+
+  return (
+    <div data-slot="turn-runtime-icons" className="flex items-center gap-1">
+      <span
+        data-slot="turn-runtime-framework"
+        role="img"
+        aria-label={frameworkLabel}
+        title={frameworkLabel}
+        className="inline-flex size-5 items-center justify-center rounded-full border border-border bg-background"
+      >
+        <AgentFrameworkIcon frameworkId={runtime.frameworkId} size={12} />
+      </span>
+      <span
+        data-slot="turn-runtime-model"
+        role="img"
+        aria-label={modelLabel}
+        title={modelLabel}
+        className="inline-flex size-5 items-center justify-center rounded-full border border-border bg-background"
+      >
+        <ProviderKindIcon kindKey={kindKey} className="size-3" />
+      </span>
+    </div>
+  )
+}
+
+const TurnTokenUsage = ({
+  usage,
+  runtimeIdentity
+}: {
+  usage?: AcpTurnTokenUsage
+  runtimeIdentity?: MessageRuntimeIdentity
+}): React.JSX.Element => {
   const [open, setOpen] = useState(false)
   const contentId = useId()
   const triggerRef = useRef<HTMLButtonElement | null>(null)
@@ -239,8 +299,11 @@ const TurnTokenUsage = ({ usage }: { usage?: AcpTurnTokenUsage }): React.JSX.Ele
           if (openedFromPointerRef.current) event.preventDefault()
         }}
       >
-        <div className="flex items-baseline justify-between gap-3">
-          <div className="text-[13px] font-medium">Usage</div>
+        <div className="flex items-center justify-between gap-3">
+          <div className="flex items-center gap-1.5">
+            <div className="text-[13px] font-medium">Usage</div>
+            {runtimeIdentity ? <TurnRuntimeIcons runtime={runtimeIdentity} /> : null}
+          </div>
           {usage?.turnCount ? (
             <div
               data-slot="turn-token-usage-turn-count"
@@ -664,6 +727,7 @@ const WorkspaceMessageItem = ({
   contentPaddingClassName,
   onSendEditedMessage,
   turnStartedAt,
+  runtimeIdentity,
   showAssistantFooter = true,
   subsequentTurns = 0,
   revisionNavigation,
@@ -673,6 +737,7 @@ const WorkspaceMessageItem = ({
   const isUserMessage = message.role === 'user'
   const uploads = message.uploads ?? []
   const hasTurnUsage = Boolean(message.turnUsage || message.turnUsageUnavailable)
+  const showTurnUsage = hasTurnUsage || (message.status === 'complete' && Boolean(runtimeIdentity))
   const terminalTimestamp =
     message.status === 'complete'
       ? message.completedAt
@@ -899,7 +964,7 @@ const WorkspaceMessageItem = ({
             <MessageImageList images={message.images ?? []} />
             <MessageArtifactList onPreviewArtifact={onPreviewArtifact} artifacts={artifacts} />
             {showAssistantFooter &&
-            (terminalDate || (terminalTimestamp !== undefined && hasTurnUsage)) ? (
+            (terminalDate || (terminalTimestamp !== undefined && showTurnUsage)) ? (
               <div
                 data-slot="assistant-message-footer"
                 className="mt-3 flex items-center gap-x-3 whitespace-nowrap text-[11px] leading-4 text-text-000/70 tabular-nums"
@@ -915,7 +980,9 @@ const WorkspaceMessageItem = ({
                     </span>
                   </span>
                 ) : null}
-                {hasTurnUsage ? <TurnTokenUsage usage={message.turnUsage} /> : null}
+                {showTurnUsage ? (
+                  <TurnTokenUsage usage={message.turnUsage} runtimeIdentity={runtimeIdentity} />
+                ) : null}
               </div>
             ) : null}
           </div>

--- a/src/renderer/src/pages/workspace/WorkspaceMessageItem.tsx
+++ b/src/renderer/src/pages/workspace/WorkspaceMessageItem.tsx
@@ -10,6 +10,7 @@ import {
   Check,
   ChevronLeft,
   ChevronRight,
+  CircleGauge,
   Copy,
   FileText,
   Image as ImageIcon,
@@ -228,7 +229,7 @@ const TurnTokenUsage = ({
             aria-haspopup="dialog"
             aria-expanded={open}
             aria-controls={open ? contentId : undefined}
-            className="touch-manipulation border-b border-dashed border-current pb-px leading-none transition-colors duration-150 motion-reduce:transition-none hover:text-text-100 focus-visible:outline-none focus-visible:ring-[3px] focus-visible:ring-ring/50"
+            className="inline-flex touch-manipulation items-center gap-1 border-b border-dashed border-current pb-px leading-none transition-colors duration-150 motion-reduce:transition-none hover:text-text-100 focus-visible:outline-none focus-visible:ring-[3px] focus-visible:ring-ring/50"
             onPointerEnter={() => {
               openedFromPointerRef.current = true
               keepOpen()
@@ -247,6 +248,12 @@ const TurnTokenUsage = ({
               setOpen(true)
             }}
           >
+            <CircleGauge
+              data-slot="turn-token-usage-icon"
+              className="size-3 shrink-0"
+              strokeWidth={2}
+              aria-hidden="true"
+            />
             Usage
           </button>
         </span>

--- a/src/renderer/src/pages/workspace/WorkspaceMessageItem.tsx
+++ b/src/renderer/src/pages/workspace/WorkspaceMessageItem.tsx
@@ -358,10 +358,30 @@ const TurnTokenUsage = ({
             data-slot="turn-runtime-details"
             className="mt-2 space-y-0.5 border-t border-border pt-2 text-[11px] leading-4 text-muted-foreground"
           >
-            {frameworkName ? <div className="truncate">Agent: {frameworkName}</div> : null}
+            {frameworkName && runtimeIdentity?.frameworkId ? (
+              <div className="flex min-w-0 items-center gap-1.5">
+                <span
+                  data-slot="turn-runtime-agent-detail-icon"
+                  aria-hidden="true"
+                  className="flex size-3 shrink-0 items-center justify-center"
+                >
+                  <AgentFrameworkIcon frameworkId={runtimeIdentity.frameworkId} size={10} />
+                </span>
+                <span className="truncate">Agent: {frameworkName}</span>
+              </div>
+            ) : null}
             {model ? (
-              <div className="truncate" title={model}>
-                Model: {model}
+              <div className="flex min-w-0 items-center gap-1.5" title={model}>
+                {provider && kindKey ? (
+                  <span
+                    data-slot="turn-runtime-model-detail-icon"
+                    aria-hidden="true"
+                    className="flex size-3 shrink-0 items-center justify-center"
+                  >
+                    <ProviderKindIcon kindKey={kindKey} className="size-2.5" />
+                  </span>
+                ) : null}
+                <span className="truncate">Model: {model}</span>
               </div>
             ) : null}
           </div>

--- a/src/renderer/src/pages/workspace/WorkspaceMessageItem.tsx
+++ b/src/renderer/src/pages/workspace/WorkspaceMessageItem.tsx
@@ -50,7 +50,9 @@ type MessageArtifact = NonNullable<ChatSession['artifacts']>[number]
 type MessageUploadAttachment = NonNullable<ChatMessage['uploads']>[number]
 type MessageImage = NonNullable<ChatMessage['images']>[number]
 type ArtifactMentionPart = Extract<MessagePart, { type: 'artifact' }>
-type MessageRuntimeIdentity = Pick<PersistedRuntimeSegment, 'frameworkId' | 'backendId' | 'model'>
+type MessageRuntimeIdentity = Partial<
+  Pick<PersistedRuntimeSegment, 'frameworkId' | 'backendId' | 'model'>
+>
 type WorkspaceMessageItemProps = {
   message: ChatMessage
   onPreviewArtifact: (artifact: MessageArtifact) => void
@@ -144,12 +146,17 @@ const TurnTokenUsage = ({
   runtimeIdentity?: MessageRuntimeIdentity
 }): React.JSX.Element => {
   const [open, setOpen] = useState(false)
-  const settings = open && runtimeIdentity ? useSettingsStore.getState() : undefined
-  const frameworkName = settings?.agentFrameworks.find(
+  const frameworks = useSettingsStore((state) =>
+    open && runtimeIdentity ? state.agentFrameworks : undefined
+  )
+  const providers = useSettingsStore((state) =>
+    open && runtimeIdentity ? state.providers : undefined
+  )
+  const frameworkName = frameworks?.find(
     (framework) => framework.id === runtimeIdentity?.frameworkId
   )?.displayName
   const providerId = resolveSessionProviderId(runtimeIdentity?.backendId)
-  const provider = settings?.providers.find((candidate) => candidate.id === providerId)
+  const provider = providers?.find((candidate) => candidate.id === providerId)
   const kindKey = provider ? providerKindKey(provider.type, provider.vendorId) : undefined
   const model = runtimeIdentity?.model?.trim()
   const contentId = useId()
@@ -266,7 +273,7 @@ const TurnTokenUsage = ({
             <div className="text-[13px] font-medium">Usage</div>
             {frameworkName || provider ? (
               <div data-slot="turn-runtime-icons" className="flex items-center gap-1">
-                {frameworkName && runtimeIdentity ? (
+                {frameworkName && runtimeIdentity?.frameworkId ? (
                   <span
                     data-slot="turn-runtime-framework"
                     role="img"

--- a/src/renderer/src/pages/workspace/WorkspaceMessageItem.tsx
+++ b/src/renderer/src/pages/workspace/WorkspaceMessageItem.tsx
@@ -21,10 +21,6 @@ import type { ProvenanceMessagePart } from '../../../../shared/artifact-provenan
 import type { AcpTurnTokenUsage } from '../../../../shared/acp'
 import type { PersistedRuntimeSegment } from '../../../../shared/conversation-graph'
 import type { MessagePart } from '../../../../shared/session-persistence'
-import {
-  isClaudeSubscriptionProviderId,
-  isCodexSubscriptionProviderId
-} from '../../../../shared/settings'
 import { getUploadedAttachmentName } from '../../../../shared/uploads'
 
 import { ArtifactPreview } from './artifact-preview'
@@ -140,48 +136,6 @@ type TurnTokenUsageEntry = readonly [
   markerClassName: string
 ]
 
-const TurnRuntimeIcons = ({ runtime }: { runtime: MessageRuntimeIdentity }): React.JSX.Element => {
-  const frameworks = useSettingsStore((state) => state.agentFrameworks)
-  const providers = useSettingsStore((state) => state.providers)
-  const frameworkName =
-    frameworks.find((framework) => framework.id === runtime.frameworkId)?.displayName ??
-    runtime.frameworkId
-  const providerId = resolveSessionProviderId(runtime.backendId)
-  const provider = providers.find((candidate) => candidate.id === providerId)
-  const kindKey = provider
-    ? providerKindKey(provider.type, provider.vendorId)
-    : isCodexSubscriptionProviderId(providerId ?? '')
-      ? 'codex-subscription'
-      : isClaudeSubscriptionProviderId(providerId ?? '')
-        ? 'claude-subscription'
-        : ''
-  const frameworkLabel = `Agent framework: ${frameworkName}`
-  const modelLabel = `Model provider: ${provider?.name ?? providerId ?? 'Unknown'}${runtime.model ? `; model: ${runtime.model}` : ''}`
-
-  return (
-    <div data-slot="turn-runtime-icons" className="flex items-center gap-1">
-      <span
-        data-slot="turn-runtime-framework"
-        role="img"
-        aria-label={frameworkLabel}
-        title={frameworkLabel}
-        className="inline-flex size-5 items-center justify-center rounded-full border border-border bg-background"
-      >
-        <AgentFrameworkIcon frameworkId={runtime.frameworkId} size={12} />
-      </span>
-      <span
-        data-slot="turn-runtime-model"
-        role="img"
-        aria-label={modelLabel}
-        title={modelLabel}
-        className="inline-flex size-5 items-center justify-center rounded-full border border-border bg-background"
-      >
-        <ProviderKindIcon kindKey={kindKey} className="size-3" />
-      </span>
-    </div>
-  )
-}
-
 const TurnTokenUsage = ({
   usage,
   runtimeIdentity
@@ -190,6 +144,14 @@ const TurnTokenUsage = ({
   runtimeIdentity?: MessageRuntimeIdentity
 }): React.JSX.Element => {
   const [open, setOpen] = useState(false)
+  const settings = open && runtimeIdentity ? useSettingsStore.getState() : undefined
+  const frameworkName = settings?.agentFrameworks.find(
+    (framework) => framework.id === runtimeIdentity?.frameworkId
+  )?.displayName
+  const providerId = resolveSessionProviderId(runtimeIdentity?.backendId)
+  const provider = settings?.providers.find((candidate) => candidate.id === providerId)
+  const kindKey = provider ? providerKindKey(provider.type, provider.vendorId) : undefined
+  const model = runtimeIdentity?.model?.trim()
   const contentId = useId()
   const triggerRef = useRef<HTMLButtonElement | null>(null)
   const contentRef = useRef<HTMLDivElement | null>(null)
@@ -302,7 +264,32 @@ const TurnTokenUsage = ({
         <div className="flex items-center justify-between gap-3">
           <div className="flex items-center gap-1.5">
             <div className="text-[13px] font-medium">Usage</div>
-            {runtimeIdentity ? <TurnRuntimeIcons runtime={runtimeIdentity} /> : null}
+            {frameworkName || provider ? (
+              <div data-slot="turn-runtime-icons" className="flex items-center gap-1">
+                {frameworkName && runtimeIdentity ? (
+                  <span
+                    data-slot="turn-runtime-framework"
+                    role="img"
+                    aria-label={`Agent framework: ${frameworkName}`}
+                    title={`Agent framework: ${frameworkName}`}
+                    className="inline-flex size-5 items-center justify-center rounded-full border border-border bg-background"
+                  >
+                    <AgentFrameworkIcon frameworkId={runtimeIdentity.frameworkId} size={12} />
+                  </span>
+                ) : null}
+                {provider && kindKey ? (
+                  <span
+                    data-slot="turn-runtime-model"
+                    role="img"
+                    aria-label={`Model provider: ${provider.name}${model ? `; model: ${model}` : ''}`}
+                    title={`Model provider: ${provider.name}${model ? `; model: ${model}` : ''}`}
+                    className="inline-flex size-5 items-center justify-center rounded-full border border-border bg-background"
+                  >
+                    <ProviderKindIcon kindKey={kindKey} className="size-3" />
+                  </span>
+                ) : null}
+              </div>
+            ) : null}
           </div>
           {usage?.turnCount ? (
             <div
@@ -359,6 +346,19 @@ const TurnTokenUsage = ({
             {safeTotalTokens !== undefined ? tokenCountFormatter.format(safeTotalTokens) : '—'}
           </span>
         </div>
+        {frameworkName || model ? (
+          <div
+            data-slot="turn-runtime-details"
+            className="mt-2 space-y-0.5 border-t border-border pt-2 text-[11px] leading-4 text-muted-foreground"
+          >
+            {frameworkName ? <div className="truncate">Agent: {frameworkName}</div> : null}
+            {model ? (
+              <div className="truncate" title={model}>
+                Model: {model}
+              </div>
+            ) : null}
+          </div>
+        ) : null}
       </PopoverContent>
     </Popover>
   )

--- a/src/renderer/src/pages/workspace/WorkspaceMessageScroller.render.test.tsx
+++ b/src/renderer/src/pages/workspace/WorkspaceMessageScroller.render.test.tsx
@@ -3,6 +3,7 @@ import type { JSX, PropsWithChildren } from 'react'
 import type { ChatMessage, ChatSession, ToolActivity } from '@/stores/session-store'
 import type { UploadedAttachment } from '../../../../shared/uploads'
 import type { JobSummary } from '../../../../shared/compute'
+import { createLinearConversationGraph } from '../../../../shared/conversation-graph'
 import type {
   HandoffLifecycleEvent,
   HandoffLifecycleEventSource
@@ -295,6 +296,32 @@ describe('WorkspaceMessageScroller loading render', () => {
     expect(html).toContain('Elapsed 2m 5s')
     expect(html).toContain('>Usage</button>')
     expect(html).not.toContain('Input</dt>')
+  })
+
+  it('does not expose the fallback framework from a synthesized legacy graph', async () => {
+    const messages = [
+      createMessage({ id: 'prompt-1' }),
+      createMessage({
+        id: 'reply-1',
+        role: 'agent',
+        content: 'Legacy answer',
+        completedAt: 1710000001000
+      })
+    ]
+    const html = await renderScroller(
+      createSession({
+        status: 'idle',
+        messages,
+        conversationGraph: createLinearConversationGraph({
+          sessionId: 'session-1',
+          messages,
+          createdAt: 1710000000000,
+          updatedAt: 1710000001000
+        })
+      })
+    )
+
+    expect(html).not.toContain('>Usage</button>')
   })
 
   it('renders completion metadata once after the final assistant message fragment in a tool turn', async () => {

--- a/src/renderer/src/pages/workspace/WorkspaceMessageScroller.tsx
+++ b/src/renderer/src/pages/workspace/WorkspaceMessageScroller.tsx
@@ -561,6 +561,11 @@ const WorkspaceMessageScrollerImpl = ({
                     const messageNode = graph?.messages.find(
                       (message) => message.id === item.message.id
                     )
+                    const runtimeIdentity = messageNode?.runtimeSegmentId
+                      ? graph?.runtimeSegments.find(
+                          (segment) => segment.id === messageNode.runtimeSegmentId
+                        )
+                      : undefined
                     const revisionRootMessageId = messageNode?.revisionRootMessageId
                     const revisions = revisionRootMessageId
                       ? (graph?.messages
@@ -599,6 +604,7 @@ const WorkspaceMessageScrollerImpl = ({
                       turnStartedAt: item.message.responseToMessageId
                         ? messageCreatedAtById.get(item.message.responseToMessageId)
                         : undefined,
+                      runtimeIdentity,
                       showAssistantFooter:
                         item.message.role !== 'agent' ||
                         assistantFooterMessageIds.has(item.message.id),

--- a/src/renderer/src/pages/workspace/WorkspaceMessageScroller.tsx
+++ b/src/renderer/src/pages/workspace/WorkspaceMessageScroller.tsx
@@ -561,11 +561,24 @@ const WorkspaceMessageScrollerImpl = ({
                     const messageNode = graph?.messages.find(
                       (message) => message.id === item.message.id
                     )
-                    const runtimeIdentity = messageNode?.runtimeSegmentId
+                    const runtimeSegment = messageNode?.runtimeSegmentId
                       ? graph?.runtimeSegments.find(
                           (segment) => segment.id === messageNode.runtimeSegmentId
                         )
                       : undefined
+                    // Legacy sessions synthesize this segment with a fallback framework. Keep only
+                    // the session-level values that were actually persisted.
+                    const synthesizedLegacyRuntime =
+                      runtimeSegment?.id === `runtime-segment-${activeSession?.id}` &&
+                      !activeSession?.agentFrameworkId
+                    const runtimeIdentity = synthesizedLegacyRuntime
+                      ? activeSession?.agentBackendId || activeSession?.agentModel
+                        ? {
+                            backendId: activeSession.agentBackendId,
+                            model: activeSession.agentModel
+                          }
+                        : undefined
+                      : runtimeSegment
                     const revisionRootMessageId = messageNode?.revisionRootMessageId
                     const revisions = revisionRootMessageId
                       ? (graph?.messages

--- a/src/renderer/src/pages/workspace/error-report.ts
+++ b/src/renderer/src/pages/workspace/error-report.ts
@@ -100,6 +100,18 @@ const normalizeSessionProviderId = (providerId: string | undefined): string | un
     : providerId
 }
 
+// Agent backend ids encode the framework and provider as "{frameworkId}:{providerId}". Split only
+// the first colon because provider ids may contain their own namespace (for example "ssh:box").
+export const resolveSessionProviderId = (
+  agentBackendId: string | undefined
+): string | undefined => {
+  if (!agentBackendId) return undefined
+  const colonIndex = agentBackendId.indexOf(':')
+  return normalizeSessionProviderId(
+    colonIndex === -1 ? undefined : agentBackendId.slice(colonIndex + 1)
+  )
+}
+
 // Resolves the framework name and provider from the session's own stored identifiers. backendId is
 // encoded as "${frameworkId}:${providerId}" (see service.ts) — we split on the first colon because
 // provider ids can themselves contain colons (e.g. "ssh:alias"). Codex subscription sessions retain
@@ -116,11 +128,7 @@ export const resolveSessionSubject = (
 
   if (!subject.agentBackendId) return { frameworkName, model: subject.model }
 
-  // backendId format: "{frameworkId}:{providerId}" — split on first colon only.
-  const colonIdx = subject.agentBackendId.indexOf(':')
-  const providerId = normalizeSessionProviderId(
-    colonIdx !== -1 ? subject.agentBackendId.slice(colonIdx + 1) : undefined
-  )
+  const providerId = resolveSessionProviderId(subject.agentBackendId)
 
   const provider = providerId ? providers.find((p) => p.id === providerId) : undefined
   const providerName = provider?.name


### PR DESCRIPTION
## Problem

Completed-message footers do not identify the ACP framework or model that produced a turn, and icons alone are not explicit enough when reviewing historical messages.

## Proposed change

- Resolve each completed message through its existing Conversation Graph runtime segment.
- Reuse the Settings framework and provider icons beside Usage in the token popover.
- Add muted Agent and Model lines at the bottom of the popover, following the Context window diagnostics style.
- Render each label or icon only when its current display value can be resolved; incomplete or deleted historical metadata stays hidden.
- Keep persisted data unchanged: sessions continue to store only framework/backend/model identifiers.

## Scope and non-goals

- No persistence schema, IPC, ACP runtime, dependency, or settings data-model changes.
- No Unknown placeholder or raw internal identifier is exposed for incomplete historical records.

## Acceptance criteria and validation

All checks ran after the final material edit.

- Runtime labels and missing historical values -> npm test -- src/renderer/src/pages/workspace/WorkspaceMessageItem.mentions.test.tsx -> 20 tests passed.
- Renderer and shared type contracts -> npm run typecheck -> passed.
- Repository lint -> npm run lint -> passed with 19 pre-existing warnings and 0 errors; changed files report no warnings.
- Regression suite -> npm test -> passed.

Uncovered risk: no new pixel-level visual-regression snapshot was added; the interaction tests verify the popover content, icon source, accessible hover labels, and omission behavior.

## Review focus

Please confirm that resolving runtime identity from message.runtimeSegmentId preserves historical attribution when Settings change, and that the muted Agent and Model lines provide enough clarity without making the completed-message footer noisier.