### PR TITLE
fix(notebook): preserve control RPC capability across ACP cleanup

### DIFF
--- a/src/main/notebook/host-mcp.integration.test.ts
+++ b/src/main/notebook/host-mcp.integration.test.ts
@@ -47,7 +47,7 @@ const baseRequest = (
 })
 
 gate('repl kernel host.mcp', () => {
-  it('uses a session-bound control capability to reach the real connector route', async () => {
+  it('keeps the persistent control capability across ACP session cleanup', async () => {
     const rpcServer = new NotebookLocalRpcServer({ execute: async () => ({}) } as never, {
       connectorService: {
         call: async (server, method, args, context) => ({ server, method, args, context })
@@ -57,26 +57,31 @@ gate('repl kernel host.mcp', () => {
     const exec = makeExecutor()
 
     try {
-      const result = await exec.execute(
-        baseRequest({
-          code: `
+      const request = baseRequest({
+        code: `
             const result = await host.mcp('pubmed', 'search_articles', { query: 'tumor immunology' })
             console.log(JSON.stringify(result))
           `,
-          mcpRpcEndpoint: connection.endpoint,
-          mcpRpcToken: connection.token,
-          sessionId: 'session-42',
-          projectName: 'project-1'
-        })
-      )
-
-      expect(result.status).toBe('completed')
-      expect(JSON.parse(result.stdout.trim())).toEqual({
-        server: 'pubmed',
-        method: 'search_articles',
-        args: { query: 'tumor immunology' },
-        context: { sessionId: 'session-42', projectId: 'project-1', origin: 'agent' }
+        mcpRpcEndpoint: connection.endpoint,
+        mcpRpcToken: connection.token,
+        sessionId: 'session-42',
+        projectName: 'project-1'
       })
+      const first = await exec.execute(request)
+
+      rpcServer.releaseSessionCapabilities('session-42')
+
+      const second = await exec.execute(request)
+
+      for (const result of [first, second]) {
+        expect(result.status).toBe('completed')
+        expect(JSON.parse(result.stdout.trim())).toEqual({
+          server: 'pubmed',
+          method: 'search_articles',
+          args: { query: 'tumor immunology' },
+          context: { sessionId: 'session-42', projectId: 'project-1', origin: 'agent' }
+        })
+      }
     } finally {
       await exec.shutdown()
       connection.release()

--- a/src/main/notebook/local-rpc-server.ts
+++ b/src/main/notebook/local-rpc-server.ts
@@ -366,18 +366,13 @@ class NotebookLocalRpcServer {
     }
   }
 
-  // Revokes every bearer capability owned by one app session, including capabilities issued under
-  // the pre-start alias used before ACP returns the final session id. Control-plane capabilities are
-  // discovered by their binding rather than sessionRpcTokens because they intentionally do not rotate
-  // the Agent-facing token.
+  // Releases ACP-owned session state without revoking the persistent control-plane capability. The
+  // Notebook RuntimeSession owns that capability and revokes it through connection.release().
   releaseSessionCapabilities(sessionId: string): void {
     const ownedSessionIds = this.resolveSessionCapabilityOwners(sessionId)
 
-    for (const [token, binding] of this.sessionRpcCapabilities) {
-      if (ownedSessionIds.has(binding.sessionId)) this.sessionRpcCapabilities.delete(token)
-    }
+    this.revokeAgentSessionCapabilities(sessionId)
     for (const ownedSessionId of ownedSessionIds) {
-      this.sessionRpcTokens.delete(ownedSessionId)
       this.sessionSpecialists.delete(ownedSessionId)
     }
     for (const [aliasSessionId, targetSessionId] of this.sessionAliases) {


### PR DESCRIPTION
## Problem

ACP session cleanup revoked every session-bound Notebook RPC capability, including the private control-plane capability captured by a persistent REPL. The live REPL then reused a stale token, so later `host.mcp()` calls failed locally with `Invalid notebook RPC token.` before reaching the connector.

## Proposed change

- Reuse the existing Agent-facing capability revocation seam during ACP cleanup.
- Keep persistent control capabilities owned by the Notebook session and released through `connection.release()` during Notebook teardown.
- Add a real persistent-REPL regression proving `host.mcp()` succeeds before and after ACP cleanup.

## Scope and non-goals

This changes only the internal capability lifecycle. It does not change the data model, data relationships, UI behavior, token injection protocol, or add retry/token-refresh machinery.

## Acceptance criteria and validation

All commands ran after the final material edit:

- Persistent control capability survives ACP cleanup -> `RUN_KERNEL=1 npm test -- src/main/notebook/local-rpc-server.test.ts src/main/notebook/host-mcp.integration.test.ts` -> 43/43 passed.
- Node contracts remain valid -> `npm run typecheck:node` -> passed.
- Full type contracts remain valid -> `npm run typecheck` -> passed.
- Lint remains clean -> `npm run lint` -> 0 errors, 19 baseline warnings.
- Repository regression suite remains green -> `npm test` -> 9,754 passed, 184 skipped.

Independent review found no actionable issues. Low residual risk: Notebook teardown revocation is covered compositionally across runtime, registry, and RPC-server suites rather than by one end-to-end shutdown test wired to a real local RPC server.

## Review focus

Please verify that ACP cleanup still revokes Agent-facing capabilities and routing metadata while control-plane capability ownership remains exclusively with the Notebook session lifecycle.