### PR TITLE
refactor(notebook): extract runtime binding ownership

### DIFF
--- a/src/main/acp/ipc.ts
+++ b/src/main/acp/ipc.ts
@@ -501,7 +501,7 @@ const registerAcpIpcHandlers = (options: AcpIpcOptions): AcpRuntimeCoordinator =
 // Creates the shared notebook runtime used by both renderer IPC and agent MCP calls.
 type DefaultNotebookRuntimeServiceDeps = Pick<
   NotebookRuntimeServiceOptions,
-  'getPackageMirror' | 'getRuntimeEnablement' | 'getManualInterpreters'
+  'getPackageMirror' | 'notebookRuntimeSettings'
 >
 
 const createDefaultNotebookRuntimeService = (

--- a/src/main/ipc.ts
+++ b/src/main/ipc.ts
@@ -109,6 +109,7 @@ import { tryDecryptKey } from './settings/crypto'
 import { registerSettingsIpcHandlers } from './settings/ipc'
 import { getAppClaudeConfigDir } from './settings/provider-env'
 import { createDefaultSettingsService } from './settings/service'
+import type { NotebookRuntimeSettings } from './settings/capabilities'
 import type { WindowSettingsCapabilities } from './settings/service-capabilities'
 import { createSettingsWorkflows } from './settings/workflows'
 import { createProfileService } from './specialist/service'
@@ -435,13 +436,28 @@ const createApplicationModules = async (
     }
   }
   let backendTeardownOwnedByCoordinator = false
+  const notebookRuntimeSettings: Pick<NotebookRuntimeSettings, 'getSnapshot'> = {
+    getSnapshot: async (language) => {
+      const [runtimeSelection, runtimeEnablement, manualInterpreters, packageMirror] =
+        await Promise.all([
+          settingsService.getRuntimeSelection(language),
+          settingsService.getRuntimeEnablement(language),
+          settingsService.getManualInterpreters(language),
+          settingsService.getPackageMirror()
+        ])
+      return {
+        language,
+        runtimeSelection,
+        runtimeEnablement,
+        manualInterpreters,
+        packageMirror
+      }
+    }
+  }
   const notebookService = await modules.add(
     {
       getPackageMirror: () => settingsService.getPackageMirror(),
-      getRuntimeEnablement: (language: NotebookLanguage) =>
-        settingsService.getRuntimeEnablement(language),
-      getManualInterpreters: (language: NotebookLanguage) =>
-        settingsService.getManualInterpreters(language)
+      notebookRuntimeSettings
     },
     (settings) => {
       const notebook = createDefaultNotebookRuntimeService(settings)

--- a/src/main/notebook/runtime-binding.ts
+++ b/src/main/notebook/runtime-binding.ts
@@ -1,0 +1,447 @@
+import type { NotebookLanguage } from '../../shared/notebook'
+import {
+  isEnvEnabled,
+  type DiscoveredInterpreter,
+  type NotebookRuntimeBinding,
+  type NotebookRuntimeBindings,
+  type NotebookRuntimeListing,
+  type RuntimeBindingUnavailableReason
+} from '../../shared/notebook-runtime'
+import type { NotebookRuntimeSettings } from '../settings/capabilities'
+import {
+  defaultDiscoveryDeps,
+  discoverInterpreters,
+  rscriptFor,
+  windowsCondaPrefixForR
+} from './environment-discovery'
+import { getRuntimeRoot, type NotebookRunRepository } from './repository'
+import {
+  DEFAULT_PY_ENV,
+  DEFAULT_R_ENV,
+  isRepairRequired,
+  managedRepairRegistryKey
+} from './runtime-paths'
+import type { NotebookSessionAggregate, NotebookSessionRuntimeBinding } from './session-aggregate'
+
+type RuntimeBindingSession = Pick<
+  NotebookSessionAggregate,
+  'runtimeBinding' | 'setRuntimeBinding'
+> & {
+  readonly projectName: string
+  readonly sessionId: string
+}
+
+type RuntimeBindingRepository = Pick<NotebookRunRepository, 'setRuntimeBindings'>
+
+type NotebookRuntimeBindingOwnerOptions = {
+  dataRoot: string
+  repository: RuntimeBindingRepository
+  runtimeSettings: Pick<NotebookRuntimeSettings, 'getSnapshot'>
+  discoverRuntimes?: (language: NotebookLanguage) => Promise<DiscoveredInterpreter[]>
+  platform?: NodeJS.Platform
+}
+
+type AdmissionGate = {
+  promise: Promise<void>
+  release: () => void
+}
+
+const admissionGate = (): AdmissionGate => {
+  let release!: () => void
+  const promise = new Promise<void>((resolve) => {
+    release = resolve
+  })
+  return { promise, release }
+}
+
+const defaultEnvironment = (language: NotebookLanguage): string =>
+  language === 'r' ? DEFAULT_R_ENV : DEFAULT_PY_ENV
+
+/** Owns Notebook runtime discovery, selection, binding transitions, and durable wire snapshots. */
+export class NotebookRuntimeBindingOwner {
+  private activeWrites = 0
+  private readonly activeWritesBySession = new Map<string, number>()
+  private globalWriteGate: AdmissionGate | undefined
+  private readonly sessionWriteGates = new Map<string, AdmissionGate>()
+  private readonly allWriteDrainWaiters = new Set<() => void>()
+  private readonly sessionWriteDrainWaiters = new Map<string, Set<() => void>>()
+
+  constructor(private readonly options: NotebookRuntimeBindingOwnerOptions) {}
+
+  /**
+   * Admits one complete binding write, including session creation and durable persistence. The lease
+   * is session-scoped so unrelated notebook sessions retain their existing independent lifecycle.
+   */
+  runWrite<T>(sessionId: string, operation: () => Promise<T>): Promise<T> {
+    return this.runWrites([sessionId], operation)
+  }
+
+  runWrites<T>(sessionIds: Iterable<string>, operation: () => Promise<T>): Promise<T> {
+    const admittedSessionIds = Array.from(new Set(sessionIds)).sort()
+    return this.runWritesWhenAdmitted(admittedSessionIds, operation)
+  }
+
+  private runWritesWhenAdmitted<T>(sessionIds: string[], operation: () => Promise<T>): Promise<T> {
+    const blockedBy = this.writeAdmissionGate(sessionIds)
+    if (blockedBy) {
+      return blockedBy.promise.then(() => this.runWritesWhenAdmitted(sessionIds, operation))
+    }
+    this.acquireWrites(sessionIds)
+
+    let result: Promise<T>
+    try {
+      // Start the operation synchronously with admission. In particular, ensureSession() must enter
+      // the registry before a same-tick global teardown can close registry creation admission.
+      result = operation()
+    } catch (error) {
+      for (const sessionId of sessionIds) this.releaseWrite(sessionId)
+      return Promise.reject(error)
+    }
+    return result.finally(() => {
+      for (const sessionId of sessionIds) this.releaseWrite(sessionId)
+    })
+  }
+
+  /** Closes all binding writes while every session generation is torn down. */
+  async withGlobalTeardown<T>(teardown: () => Promise<T>): Promise<T> {
+    while (this.globalWriteGate) await this.globalWriteGate.promise
+    const gate = admissionGate()
+    this.globalWriteGate = gate
+    try {
+      return await teardown()
+    } finally {
+      if (this.globalWriteGate === gate) this.globalWriteGate = undefined
+      gate.release()
+    }
+  }
+
+  /** Closes only one session's binding writes while that generation is removed. */
+  async withSessionTeardown<T>(sessionId: string, teardown: () => Promise<T>): Promise<T> {
+    while (true) {
+      const globalGate = this.globalWriteGate
+      if (globalGate) {
+        await globalGate.promise
+        continue
+      }
+      const existing = this.sessionWriteGates.get(sessionId)
+      if (existing) {
+        await existing.promise
+        continue
+      }
+      break
+    }
+
+    const gate = admissionGate()
+    this.sessionWriteGates.set(sessionId, gate)
+    try {
+      return await teardown()
+    } finally {
+      if (this.sessionWriteGates.get(sessionId) === gate) {
+        this.sessionWriteGates.delete(sessionId)
+      }
+      gate.release()
+    }
+  }
+
+  waitForWrites(sessionId?: string): Promise<void> {
+    if (sessionId === undefined) {
+      if (this.activeWrites === 0) return Promise.resolve()
+      return new Promise<void>((resolve) => this.allWriteDrainWaiters.add(resolve))
+    }
+    if (!this.activeWritesBySession.has(sessionId)) return Promise.resolve()
+    const waiters = this.sessionWriteDrainWaiters.get(sessionId) ?? new Set<() => void>()
+    this.sessionWriteDrainWaiters.set(sessionId, waiters)
+    return new Promise<void>((resolve) => waiters.add(resolve))
+  }
+
+  async list(session: RuntimeBindingSession): Promise<{
+    runtimes: NotebookRuntimeListing[]
+    bindings: NotebookRuntimeBindings
+  }> {
+    const runtimes: NotebookRuntimeListing[] = []
+    for (const language of ['python', 'r'] as const) {
+      const bound = session.runtimeBinding(language)
+      for (const env of await this.listEnabledInterpreters(language)) {
+        const binding = this.toInternalBinding(env)
+        runtimes.push({
+          language: binding.language,
+          runtimeId: binding.runtimeId,
+          source: binding.source,
+          provenance: binding.provenance,
+          interpreterPath: binding.interpreterPath,
+          label: binding.label,
+          version: binding.version,
+          runnable: env.runnable,
+          detail: env.detail,
+          bound: bound?.runtimeId === binding.runtimeId
+        })
+      }
+    }
+    return { runtimes, bindings: this.snapshot(session) }
+  }
+
+  async bind(
+    session: RuntimeBindingSession,
+    language: NotebookLanguage,
+    runtimeId: string
+  ): Promise<{ bound: NotebookRuntimeBinding; bindings: NotebookRuntimeBindings }> {
+    const binding = await this.resolveEnabledRuntime(language, runtimeId)
+    const existing = session.runtimeBinding(language)
+    if (existing && existing.runtimeId !== binding.runtimeId) {
+      throw new Error(
+        `A ${language} runtime is already bound for this session. Use ` +
+          'notebook_switch_runtime to change it (it tears down the current kernel first).'
+      )
+    }
+    session.setRuntimeBinding(language, binding)
+    await this.persist(session)
+    return { bound: this.toWireBinding(binding), bindings: this.snapshot(session) }
+  }
+
+  async switch(
+    session: RuntimeBindingSession,
+    language: NotebookLanguage,
+    runtimeId: string,
+    beforeReplace: () => Promise<void>
+  ): Promise<{ bound: NotebookRuntimeBinding; bindings: NotebookRuntimeBindings }> {
+    const binding = await this.resolveEnabledRuntime(language, runtimeId)
+    await beforeReplace()
+    session.setRuntimeBinding(language, binding)
+    await this.persist(session)
+    return { bound: this.toWireBinding(binding), bindings: this.snapshot(session) }
+  }
+
+  async revoke<Context>(
+    session: RuntimeBindingSession,
+    language: NotebookLanguage,
+    runtimeId: string,
+    beforeRevoke: (binding: NotebookSessionRuntimeBinding) => Context
+  ): Promise<Context | undefined> {
+    const binding = session.runtimeBinding(language)
+    if (!binding || binding.runtimeId !== runtimeId || binding.status === 'unavailable') {
+      return undefined
+    }
+    const context = beforeRevoke(binding)
+    const unavailable: NotebookSessionRuntimeBinding = {
+      ...binding,
+      status: 'unavailable',
+      reason: 'disabled'
+    }
+    session.setRuntimeBinding(language, unavailable)
+    await this.persist(session)
+    return context
+  }
+
+  markUnavailable(
+    session: RuntimeBindingSession,
+    language: NotebookLanguage,
+    reason: RuntimeBindingUnavailableReason
+  ): boolean {
+    const binding = session.runtimeBinding(language)
+    if (!binding) return false
+    session.setRuntimeBinding(language, { ...binding, status: 'unavailable', reason })
+    return true
+  }
+
+  markAvailable(session: RuntimeBindingSession, language: NotebookLanguage): boolean {
+    const binding = session.runtimeBinding(language)
+    if (!binding || binding.status === 'active') return false
+    session.setRuntimeBinding(language, { ...binding, status: 'active', reason: undefined })
+    return true
+  }
+
+  snapshot(session: RuntimeBindingSession): NotebookRuntimeBindings {
+    const python = session.runtimeBinding('python')
+    const r = session.runtimeBinding('r')
+    return {
+      python: python ? this.toWireBinding(python) : undefined,
+      r: r ? this.toWireBinding(r) : undefined
+    }
+  }
+
+  async persist(session: RuntimeBindingSession): Promise<void> {
+    try {
+      await this.options.repository.setRuntimeBindings(
+        session.projectName,
+        session.sessionId,
+        this.snapshot(session)
+      )
+    } catch (error) {
+      console.error('[notebook] Failed to persist runtime bindings', error)
+    }
+  }
+
+  async reload(
+    session: RuntimeBindingSession,
+    persisted: NotebookRuntimeBindings | undefined
+  ): Promise<void> {
+    if (!persisted) return
+    for (const language of ['python', 'r'] as const) {
+      const wire = persisted[language]
+      if (!wire) continue
+      try {
+        session.setRuntimeBinding(
+          language,
+          await this.resolveEnabledRuntime(language, wire.runtimeId)
+        )
+      } catch {
+        const settings = await this.runtimeSettingsSnapshot(language)
+        const discovered = await this.discover(language, settings?.manualInterpreters ?? [])
+        const stillDetected = discovered.some((env) => env.envId === wire.runtimeId)
+        session.setRuntimeBinding(language, {
+          language,
+          runtimeId: wire.runtimeId,
+          source: wire.source,
+          provenance: wire.provenance,
+          interpreterPath: wire.interpreterPath,
+          label: wire.label,
+          version: wire.version,
+          status: 'unavailable',
+          reason: stillDetected ? 'disabled' : 'missing'
+        })
+      }
+    }
+  }
+
+  private async discover(
+    language: NotebookLanguage,
+    manualInterpreters: string[]
+  ): Promise<DiscoveredInterpreter[]> {
+    try {
+      const injected = this.options.discoverRuntimes
+      return injected
+        ? await injected(language)
+        : discoverInterpreters(
+            language,
+            defaultDiscoveryDeps(getRuntimeRoot(this.options.dataRoot), () => manualInterpreters)
+          )
+    } catch {
+      return []
+    }
+  }
+
+  private async listEnabledInterpreters(
+    language: NotebookLanguage
+  ): Promise<DiscoveredInterpreter[]> {
+    const settings = await this.runtimeSettingsSnapshot(language)
+    const discovered = await this.discover(language, settings?.manualInterpreters ?? [])
+    return discovered.filter((env) => isEnvEnabled(env, settings?.runtimeEnablement))
+  }
+
+  private async resolveEnabledRuntime(
+    language: NotebookLanguage,
+    runtimeId: string
+  ): Promise<NotebookSessionRuntimeBinding> {
+    const enabled = await this.listEnabledInterpreters(language)
+    const match = enabled.find((env) => env.envId === runtimeId)
+    if (!match) {
+      throw new Error(
+        `"${runtimeId}" is not an enabled ${language} runtime. Use list_notebook_runtimes to see the ` +
+          'available runtimes, or enable it in Settings → Runtimes first (disabled and unknown ' +
+          'runtimes are refused).'
+      )
+    }
+    const binding = this.toInternalBinding(match)
+    const repairKey =
+      binding.source === 'external'
+        ? binding.runtimeId
+        : (binding.envName ?? defaultEnvironment(language))
+    const runtimeRoot = getRuntimeRoot(this.options.dataRoot)
+    const repairRequired =
+      isRepairRequired(runtimeRoot, repairKey) ||
+      (binding.source === 'managed' &&
+        isRepairRequired(runtimeRoot, managedRepairRegistryKey(repairKey, language))) ||
+      (binding.source === 'managed' && isRepairRequired(runtimeRoot, binding.runtimeId))
+    return repairRequired
+      ? { ...binding, status: 'unavailable', reason: 'repair-required' }
+      : binding
+  }
+
+  private toInternalBinding(env: DiscoveredInterpreter): NotebookSessionRuntimeBinding {
+    const source = env.provenance === 'user-own' ? 'external' : 'managed'
+    const externalRCondaPrefix =
+      source === 'external' && env.language === 'r'
+        ? windowsCondaPrefixForR(env.interpreterPath, this.options.platform ?? process.platform)
+        : undefined
+    return {
+      language: env.language,
+      runtimeId: env.envId,
+      source,
+      provenance: env.provenance,
+      interpreterPath: env.interpreterPath,
+      label: env.label,
+      version: env.version,
+      status: 'active',
+      resolvedInterpreter:
+        source === 'external'
+          ? {
+              command: env.language === 'r' ? rscriptFor(env.interpreterPath) : env.interpreterPath,
+              ...(externalRCondaPrefix ? { condaPrefix: externalRCondaPrefix } : {})
+            }
+          : undefined,
+      envName: source === 'managed' ? (env.condaEnv ?? defaultEnvironment(env.language)) : undefined
+    }
+  }
+
+  private toWireBinding(binding: NotebookSessionRuntimeBinding): NotebookRuntimeBinding {
+    return {
+      language: binding.language,
+      runtimeId: binding.runtimeId,
+      source: binding.source,
+      provenance: binding.provenance,
+      interpreterPath: binding.interpreterPath,
+      label: binding.label,
+      version: binding.version,
+      status: binding.status ?? 'active',
+      reason: binding.reason
+    }
+  }
+
+  private async runtimeSettingsSnapshot(
+    language: NotebookLanguage
+  ): Promise<Awaited<ReturnType<NotebookRuntimeSettings['getSnapshot']>> | undefined> {
+    try {
+      return await this.options.runtimeSettings.getSnapshot(language)
+    } catch {
+      return undefined
+    }
+  }
+
+  private writeAdmissionGate(sessionIds: string[]): AdmissionGate | undefined {
+    return (
+      this.globalWriteGate ??
+      sessionIds
+        .map((sessionId) => this.sessionWriteGates.get(sessionId))
+        .find((gate): gate is AdmissionGate => gate !== undefined)
+    )
+  }
+
+  private acquireWrites(sessionIds: string[]): void {
+    for (const sessionId of sessionIds) {
+      this.activeWrites += 1
+      this.activeWritesBySession.set(
+        sessionId,
+        (this.activeWritesBySession.get(sessionId) ?? 0) + 1
+      )
+    }
+  }
+
+  private releaseWrite(sessionId: string): void {
+    this.activeWrites -= 1
+    const remaining = (this.activeWritesBySession.get(sessionId) ?? 1) - 1
+    if (remaining === 0) {
+      this.activeWritesBySession.delete(sessionId)
+      const waiters = this.sessionWriteDrainWaiters.get(sessionId)
+      if (waiters) {
+        this.sessionWriteDrainWaiters.delete(sessionId)
+        for (const resolve of waiters) resolve()
+      }
+    } else {
+      this.activeWritesBySession.set(sessionId, remaining)
+    }
+    if (this.activeWrites === 0) {
+      for (const resolve of this.allWriteDrainWaiters) resolve()
+      this.allWriteDrainWaiters.clear()
+    }
+  }
+}

--- a/src/main/notebook/runtime-service.test.ts
+++ b/src/main/notebook/runtime-service.test.ts
@@ -4769,6 +4769,8 @@ describe('v4 runtime bindings & agent tools', () => {
       executions?: NotebookExecutionRequest[]
       terminations?: string[]
       platform?: NodeJS.Platform
+      repository?: NotebookRunRepository
+      discoverRuntimes?: (language: 'python' | 'r') => Promise<DiscoveredInterpreter[]>
       installPackagesImpl?: (
         request: InstallRequestForTest,
         deps?: Partial<InstallDepsForTest>
@@ -4779,12 +4781,21 @@ describe('v4 runtime bindings & agent tools', () => {
       configRoot: root,
       dataRoot: root,
       projectName: 'default-project',
-      repository: new NotebookRunRepository(root),
-      discoverRuntimes: async (language) =>
-        (options.discovered ?? [managedPy, userPyA, userPyB]).filter(
-          (env) => env.language === language
-        ),
-      getRuntimeEnablement: async () => options.enablement,
+      repository: options.repository ?? new NotebookRunRepository(root),
+      discoverRuntimes:
+        options.discoverRuntimes ??
+        (async (language) =>
+          (options.discovered ?? [managedPy, userPyA, userPyB]).filter(
+            (env) => env.language === language
+          )),
+      notebookRuntimeSettings: {
+        getSnapshot: async (language) => ({
+          language,
+          runtimeEnablement: options.enablement ?? { enabled: {}, installAuthorized: {} },
+          manualInterpreters: [],
+          packageMirror: {}
+        })
+      },
       platform: options.platform,
       installPackagesImpl: options.installPackagesImpl,
       // A fake installer must have a fake inventory refresh too. Mixing the fake installer with a
@@ -4993,6 +5004,311 @@ describe('v4 runtime bindings & agent tools', () => {
     // Subsequent runs use the newly-bound interpreter.
     await service.execute({ sessionId: 's', workspaceCwd: root, code: '2', language: 'python' })
     expect(executions.at(-1)?.resolvedInterpreter?.command).toBe(userPyB.interpreterPath)
+  })
+
+  it('preserves a switched and revoked binding across a replacement session generation', async () => {
+    const root = await createStorageRoot()
+    const discovered = [managedPy, userPyA, userPyB]
+    const enablement: RuntimeEnablement = {
+      enabled: { [userPyA.envId]: true, [userPyB.envId]: true },
+      installAuthorized: {}
+    }
+    const service = bindingService(root, { discovered, enablement })
+
+    await service.bindRuntime({
+      sessionId: 's',
+      workspaceCwd: root,
+      language: 'python',
+      runtimeId: userPyA.envId
+    })
+    await service.switchRuntime({
+      sessionId: 's',
+      workspaceCwd: root,
+      language: 'python',
+      runtimeId: userPyB.envId
+    })
+
+    const persistedAfterSwitch = await new NotebookRunRepository(root).findExisting(
+      'default-project',
+      's'
+    )
+    expect(persistedAfterSwitch?.runtimeBindings).toEqual({
+      python: {
+        language: 'python',
+        runtimeId: userPyB.envId,
+        source: 'external',
+        provenance: 'user-own',
+        interpreterPath: userPyB.interpreterPath,
+        label: userPyB.label,
+        version: userPyB.version,
+        status: 'active'
+      }
+    })
+
+    enablement.enabled[userPyB.envId] = false
+    await service.revokeRuntime('python', userPyB.envId)
+    await service.shutdownAll()
+
+    const reloaded = await service.state({ sessionId: 's', workspaceCwd: root })
+    expect(reloaded.runtimeBindings).toEqual({
+      python: {
+        language: 'python',
+        runtimeId: userPyB.envId,
+        source: 'external',
+        provenance: 'user-own',
+        interpreterPath: userPyB.interpreterPath,
+        label: userPyB.label,
+        version: userPyB.version,
+        status: 'unavailable',
+        reason: 'disabled'
+      },
+      r: undefined
+    })
+  })
+
+  it('finishes a binding persistence commit before replacing the session generation', async () => {
+    const root = await createStorageRoot()
+    const repository = new NotebookRunRepository(root)
+    const persistRuntimeBindings = repository.setRuntimeBindings.bind(repository)
+    let releasePersistence!: () => void
+    const persistenceGate = new Promise<void>((resolve) => {
+      releasePersistence = resolve
+    })
+    let markPersistenceStarted!: () => void
+    const persistenceStarted = new Promise<void>((resolve) => {
+      markPersistenceStarted = resolve
+    })
+    vi.spyOn(repository, 'setRuntimeBindings').mockImplementation(async (...args) => {
+      markPersistenceStarted()
+      await persistenceGate
+      return persistRuntimeBindings(...args)
+    })
+    const service = new NotebookRuntimeService({
+      configRoot: root,
+      dataRoot: root,
+      projectName: 'default-project',
+      repository,
+      discoverRuntimes: async (language) => (language === 'python' ? [userPyA] : []),
+      notebookRuntimeSettings: {
+        getSnapshot: async (language) => ({
+          language,
+          runtimeEnablement: {
+            enabled: { [userPyA.envId]: true },
+            installAuthorized: {}
+          },
+          manualInterpreters: [],
+          packageMirror: {}
+        })
+      },
+      executorFactory: () => ({
+        execute: async (request): Promise<NotebookExecutionResult> => ({
+          status: 'completed',
+          stdout: '',
+          stderr: '',
+          traceback: '',
+          cwdAfter: request.cwd,
+          outputs: []
+        }),
+        shutdown: async () => ({ reaped: true })
+      })
+    })
+    const request = { sessionId: 's', workspaceCwd: root }
+    await service.state(request)
+
+    const bind = service.bindRuntime({
+      ...request,
+      language: 'python',
+      runtimeId: userPyA.envId
+    })
+    await persistenceStarted
+
+    let shutdownSettled = false
+    let replacementSettled = false
+    const shutdown = service.shutdownAll().then((result) => {
+      shutdownSettled = true
+      return result
+    })
+    const replacement = service.state(request).then((state) => {
+      replacementSettled = true
+      return state
+    })
+
+    await new Promise<void>((resolve) => setImmediate(resolve))
+    const shutdownSettledBeforeCommit = shutdownSettled
+    const replacementSettledBeforeCommit = replacementSettled
+    releasePersistence()
+
+    await expect(bind).resolves.toEqual(
+      expect.objectContaining({ bound: expect.objectContaining({ runtimeId: userPyA.envId }) })
+    )
+    await expect(shutdown).resolves.toEqual({ reaped: true })
+    await expect(replacement).resolves.toEqual(
+      expect.objectContaining({
+        runtimeBindings: expect.objectContaining({
+          python: expect.objectContaining({ runtimeId: userPyA.envId })
+        })
+      })
+    )
+    expect(shutdownSettledBeforeCommit).toBe(false)
+    expect(replacementSettledBeforeCommit).toBe(false)
+  })
+
+  it.each(['shutdown', 'dispose'] as const)(
+    'starts fresh-session binding creation before an immediate %s teardown',
+    async (teardown) => {
+      const root = await createStorageRoot()
+      const service = bindingService(root, {
+        discovered: [userPyA],
+        enablement: { enabled: { [userPyA.envId]: true }, installAuthorized: {} }
+      })
+
+      const bind = service.bindRuntime({
+        sessionId: 'fresh',
+        workspaceCwd: root,
+        language: 'python',
+        runtimeId: userPyA.envId
+      })
+      const close = teardown === 'shutdown' ? service.shutdownAll() : service.dispose()
+      let timeout: ReturnType<typeof setTimeout> | undefined
+      const outcome = await Promise.race([
+        Promise.all([bind, close]).then(
+          () => 'completed' as const,
+          () => 'rejected' as const
+        ),
+        new Promise<'timed-out'>((resolve) => {
+          timeout = setTimeout(() => resolve('timed-out'), 250)
+        })
+      ])
+      if (timeout) clearTimeout(timeout)
+
+      expect(outcome).toBe('completed')
+    }
+  )
+
+  it('does not let another session runtime listing delay a session shutdown', async () => {
+    const root = await createStorageRoot()
+    let releaseDiscovery!: () => void
+    const discoveryGate = new Promise<void>((resolve) => {
+      releaseDiscovery = resolve
+    })
+    let markDiscoveryStarted!: () => void
+    const discoveryStarted = new Promise<void>((resolve) => {
+      markDiscoveryStarted = resolve
+    })
+    const service = bindingService(root, {
+      discoverRuntimes: async (language) => {
+        if (language !== 'python') return []
+        markDiscoveryStarted()
+        await discoveryGate
+        return [managedPy]
+      }
+    })
+    await service.state({ sessionId: 'a', workspaceCwd: root })
+
+    const listing = service.listRuntimes({ sessionId: 'b', workspaceCwd: root })
+    await discoveryStarted
+    let shutdownSettled = false
+    const shutdown = service.shutdownSession('a').then((result) => {
+      shutdownSettled = true
+      return result
+    })
+
+    await new Promise<void>((resolve) => setImmediate(resolve))
+    const shutdownSettledBeforeDiscovery = shutdownSettled
+    releaseDiscovery()
+
+    await expect(shutdown).resolves.toEqual({ sessionId: 'a', status: 'shutdown' })
+    await expect(listing).resolves.toEqual(expect.objectContaining({ runtimes: expect.any(Array) }))
+    expect(shutdownSettledBeforeDiscovery).toBe(true)
+  })
+
+  it('does not let another session binding write delay a session shutdown', async () => {
+    const root = await createStorageRoot()
+    const repository = new NotebookRunRepository(root)
+    const persistRuntimeBindings = repository.setRuntimeBindings.bind(repository)
+    let releasePersistence!: () => void
+    const persistenceGate = new Promise<void>((resolve) => {
+      releasePersistence = resolve
+    })
+    let markPersistenceStarted!: () => void
+    const persistenceStarted = new Promise<void>((resolve) => {
+      markPersistenceStarted = resolve
+    })
+    vi.spyOn(repository, 'setRuntimeBindings').mockImplementation(async (...args) => {
+      if (args[1] === 'b') {
+        markPersistenceStarted()
+        await persistenceGate
+      }
+      return persistRuntimeBindings(...args)
+    })
+    const service = bindingService(root, {
+      repository,
+      discovered: [userPyA],
+      enablement: { enabled: { [userPyA.envId]: true }, installAuthorized: {} }
+    })
+    await Promise.all([
+      service.state({ sessionId: 'a', workspaceCwd: root }),
+      service.state({ sessionId: 'b', workspaceCwd: root })
+    ])
+
+    const bind = service.bindRuntime({
+      sessionId: 'b',
+      workspaceCwd: root,
+      language: 'python',
+      runtimeId: userPyA.envId
+    })
+    await persistenceStarted
+    let shutdownSettled = false
+    const shutdown = service.shutdownSession('a').then((result) => {
+      shutdownSettled = true
+      return result
+    })
+
+    await new Promise<void>((resolve) => setImmediate(resolve))
+    const shutdownSettledBeforeCommit = shutdownSettled
+    releasePersistence()
+
+    await expect(shutdown).resolves.toEqual({ sessionId: 'a', status: 'shutdown' })
+    await expect(bind).resolves.toEqual(
+      expect.objectContaining({ bound: expect.objectContaining({ runtimeId: userPyA.envId }) })
+    )
+    expect(shutdownSettledBeforeCommit).toBe(true)
+  })
+
+  it('does not let read-only runtime discovery delay terminal disposal', async () => {
+    const root = await createStorageRoot()
+    let releaseDiscovery!: () => void
+    const discoveryGate = new Promise<void>((resolve) => {
+      releaseDiscovery = resolve
+    })
+    let markDiscoveryStarted!: () => void
+    const discoveryStarted = new Promise<void>((resolve) => {
+      markDiscoveryStarted = resolve
+    })
+    const service = bindingService(root, {
+      discoverRuntimes: async (language) => {
+        if (language !== 'python') return []
+        markDiscoveryStarted()
+        await discoveryGate
+        return [managedPy]
+      }
+    })
+
+    const listing = service.listRuntimes({ sessionId: 'b', workspaceCwd: root })
+    await discoveryStarted
+    let disposalSettled = false
+    const disposal = service.dispose().then((result) => {
+      disposalSettled = true
+      return result
+    })
+
+    await new Promise<void>((resolve) => setImmediate(resolve))
+    const disposalSettledBeforeDiscovery = disposalSettled
+    releaseDiscovery()
+
+    await expect(disposal).resolves.toEqual({ reaped: true })
+    await expect(listing).resolves.toEqual(expect.objectContaining({ runtimes: expect.any(Array) }))
+    expect(disposalSettledBeforeDiscovery).toBe(true)
   })
 
   it('refuses switching to a disabled runtime', async () => {
@@ -7063,11 +7379,11 @@ describe('v4 runtime bindings & agent tools', () => {
     expect(removed).toEqual(['my-analysis'])
   })
 
-  // End-to-end constructor wiring of getManualInterpreters: a Settings-added interpreter is folded into the
-  // service's REAL default discovery (NOT an injected discoverRuntimes), so it becomes discoverable,
-  // enable-able, and bindable — and survives a restart (a fresh service with the same resolver still
-  // resolves it active, not 'missing'). Exercises the actual manualInterpretersResolver seam with a real
-  // executable interpreter so the version probe + runnability classification run for real. POSIX-only:
+  // End-to-end constructor wiring of NotebookRuntimeSettings: a Settings-added interpreter is folded
+  // into the service's REAL default discovery (NOT an injected discoverRuntimes), so it becomes
+  // discoverable, enable-able, and bindable — and survives a restart (a fresh service with the same
+  // capability still resolves it active, not 'missing'). Uses a real executable interpreter so the
+  // version probe + runnability classification run for real. POSIX-only:
   // it relies on a chmod-executable shell shim, which Windows can't run as `<path> --version`.
   it.skipIf(process.platform === 'win32')(
     'discovers, binds, and (across a restart) keeps a constructor-injected manual interpreter',
@@ -7106,8 +7422,14 @@ describe('v4 runtime bindings & agent tools', () => {
           dataRoot: root,
           projectName: 'default-project',
           repository: new NotebookRunRepository(root),
-          getRuntimeEnablement: async () => enablement,
-          getManualInterpreters: resolver,
+          notebookRuntimeSettings: {
+            getSnapshot: async (language) => ({
+              language,
+              runtimeEnablement: enablement,
+              manualInterpreters: await resolver(language),
+              packageMirror: {}
+            })
+          },
           executorFactory: () => ({
             execute: async (request): Promise<NotebookExecutionResult> => {
               executions.push(request)

--- a/src/main/notebook/runtime-service.ts
+++ b/src/main/notebook/runtime-service.ts
@@ -86,13 +86,7 @@ import type {
   RuntimeEnablement,
   RuntimeUsage
 } from '../../shared/notebook-runtime'
-import { isEnvEnabled } from '../../shared/notebook-runtime'
-import {
-  discoverInterpreters,
-  defaultDiscoveryDeps,
-  rscriptFor,
-  windowsCondaPrefixForR
-} from './environment-discovery'
+import type { NotebookRuntimeSettings } from '../settings/capabilities'
 import {
   operationJournalPath,
   recordOperationChildSync,
@@ -128,6 +122,7 @@ import {
   type PackageMutationVerification
 } from './environment-state-tracker'
 import { startWorkingFileObservation } from './working-file-observer'
+import { NotebookRuntimeBindingOwner } from './runtime-binding'
 import {
   boundedRuntimeDiagnostic,
   redactRuntimeDiagnosticValue,
@@ -322,6 +317,10 @@ type NotebookRuntimeServiceOptions = {
   // Resolves the user-configured package mirror (settings). Optional/async so a synchronous test
   // double works just as well as the real disk-backed settings service.
   getPackageMirror?: () => PackageMirror | undefined | Promise<PackageMirror | undefined>
+  // Stable, detached Settings capability used by runtime discovery and binding policy. Production
+  // injects this named capability; the raw resolvers below remain compatibility seams for isolated
+  // callers and tests that predate the Settings capability split.
+  notebookRuntimeSettings?: Pick<NotebookRuntimeSettings, 'getSnapshot'>
   // Resolves the v4 per-language enablement (enabled/install-authorized maps) used to gate which
   // discovered runtimes the agent may bind. Undefined / returning undefined -> the provenance defaults
   // (app-managed enabled; user-own disabled), so an omitted resolver can never enable a BYO env — the
@@ -926,11 +925,7 @@ class NotebookRuntimeService {
     (() => PackageMirror | undefined | Promise<PackageMirror | undefined>) | undefined
   private readonly runtimeEnablementResolver:
     ((language: NotebookLanguage) => Promise<RuntimeEnablement | undefined>) | undefined
-  // Manually-added interpreter paths (Settings catalog) folded into discovery so a picked interpreter
-  // that is NOT on PATH / in a conda root is still discovered here — and therefore bindable and not
-  // reported 'missing' after a restart. Fixed at construction with the other Settings dependencies.
-  private readonly manualInterpretersResolver:
-    ((language: NotebookLanguage) => Promise<string[]>) | undefined
+  private readonly runtimeBindingOwner: NotebookRuntimeBindingOwner
   // Owns startup-recovery promises, journal reconciliation, fail-closed block decisions, Reset
   // allowlisting, and same-process live-unconfirmed tracking. The service retains its public recovery
   // facade so Electron, Web, CLI, and IPC adapters keep the same contract.
@@ -938,9 +933,6 @@ class NotebookRuntimeService {
   // Immediate in-process gate for a protected-identity failure. It is armed before kernel termination
   // and before the durable registry write, so disk-full/permission errors cannot reopen the damaged env.
   private readonly repairBlockedEnvs = new Set<string>()
-  private readonly runtimeDiscoveryImpl: (
-    language: NotebookLanguage
-  ) => Promise<DiscoveredInterpreter[]>
   private readonly installPackagesImpl: (
     request: InstallRequest,
     deps?: Partial<InstallDeps>
@@ -964,26 +956,25 @@ class NotebookRuntimeService {
     this.sessions = new NotebookSessionRegistry({
       beforeTeardown: async () => {
         await Promise.all(Array.from(this.revocationDrains)).catch(() => undefined)
+        await this.runtimeBindingOwner.waitForWrites()
       }
     })
     this.recoveryCoordinator = new NotebookRecoveryCoordinator(getRuntimeRoot(options.dataRoot))
     this.mcpRpcConnectionResolver = options.getMcpRpcConnection
     this.packageMirrorResolver = options.getPackageMirror
-    this.runtimeEnablementResolver = options.getRuntimeEnablement
-    this.manualInterpretersResolver = options.getManualInterpreters
-    this.runtimeDiscoveryImpl =
-      options.discoverRuntimes ??
-      (async (language) => {
-        // Resolve the manual catalog for this language (async), then hand discovery a sync getter for
-        // it — mirroring runtime-ipc, so the service and the Settings survey discover the same set.
-        const manual = this.manualInterpretersResolver
-          ? await this.manualInterpretersResolver(language).catch(() => [])
-          : []
-        return discoverInterpreters(
-          language,
-          defaultDiscoveryDeps(getRuntimeRoot(this.options.dataRoot), () => manual)
-        )
-      })
+    this.runtimeEnablementResolver = options.notebookRuntimeSettings
+      ? async (language) =>
+          (await options.notebookRuntimeSettings?.getSnapshot(language))?.runtimeEnablement
+      : options.getRuntimeEnablement
+    const runtimeSettings =
+      options.notebookRuntimeSettings ?? this.legacyRuntimeSettingsCapability(options)
+    this.runtimeBindingOwner = new NotebookRuntimeBindingOwner({
+      dataRoot: options.dataRoot,
+      repository: this.repository,
+      runtimeSettings,
+      discoverRuntimes: options.discoverRuntimes,
+      platform: options.platform
+    })
     this.installPackagesImpl = options.installPackagesImpl ?? installPackagesDefault
     this.runtimeLogger =
       options.logger ?? (getLogFilePath() ? createLogger('notebook:runtime') : undefined)
@@ -995,6 +986,37 @@ class NotebookRuntimeService {
         logger: this.runtimeLogger
       })
     this.environmentManager = options.environmentManager
+  }
+
+  private legacyRuntimeSettingsCapability(
+    options: NotebookRuntimeServiceOptions
+  ): Pick<NotebookRuntimeSettings, 'getSnapshot'> {
+    return {
+      getSnapshot: async (language) => {
+        const [runtimeEnablement, manualInterpreters] = await Promise.all([
+          options.getRuntimeEnablement?.(language).catch(() => undefined),
+          options.getManualInterpreters?.(language).catch(() => [])
+        ])
+        return {
+          language,
+          runtimeEnablement: runtimeEnablement ?? { enabled: {}, installAuthorized: {} },
+          manualInterpreters: manualInterpreters ?? [],
+          packageMirror: {}
+        }
+      }
+    }
+  }
+
+  private async resolveRuntimeEnablement(
+    language: NotebookLanguage
+  ): Promise<RuntimeEnablement | undefined> {
+    const resolver = this.runtimeEnablementResolver
+    if (!resolver) return undefined
+    try {
+      return await resolver(language)
+    } catch {
+      return undefined
+    }
   }
 
   // Wires the provisioner-backed environment manager after construction (the provisioner is built in
@@ -1135,110 +1157,6 @@ class NotebookRuntimeService {
     }
   }
 
-  // Discovers a language's interpreters (best-effort; a discovery failure yields an empty list so the
-  // tools degrade to "only the app-managed default is available" rather than throwing at the agent).
-  private async runtimeDiscovery(language: NotebookLanguage): Promise<DiscoveredInterpreter[]> {
-    try {
-      return await this.runtimeDiscoveryImpl(language)
-    } catch {
-      return []
-    }
-  }
-
-  // The persisted enablement for a language; undefined (unwired or a read failure) -> isEnvEnabled
-  // falls back to the provenance defaults, keeping the enable gate closed for BYO envs.
-  private async resolveRuntimeEnablement(
-    language: NotebookLanguage
-  ): Promise<RuntimeEnablement | undefined> {
-    if (!this.runtimeEnablementResolver) return undefined
-    try {
-      return await this.runtimeEnablementResolver(language)
-    } catch {
-      return undefined
-    }
-  }
-
-  // Projects a discovered interpreter into the wire binding. An app-managed env is 'managed' (the
-  // executor keeps its managed-prefix lookup); everything else is 'external' (run its interpreter).
-  private toInternalBinding(env: DiscoveredInterpreter): InternalRuntimeBinding {
-    // A conda env WE own (app-managed default OR an agent-created named env) is 'managed': the executor
-    // resolves it by env NAME (managed-prefix lookup + conda activation). Only the USER'S OWN
-    // interpreter is 'external' — run its binary directly.
-    const source = env.provenance === 'user-own' ? 'external' : 'managed'
-    const externalRCondaPrefix =
-      source === 'external' && env.language === 'r'
-        ? windowsCondaPrefixForR(env.interpreterPath, this.options.platform ?? process.platform)
-        : undefined
-    return {
-      language: env.language,
-      runtimeId: env.envId,
-      source,
-      provenance: env.provenance,
-      interpreterPath: env.interpreterPath,
-      label: env.label,
-      version: env.version,
-      status: 'active',
-      // Managed runs in its conda env by NAME (default-python, or the agent-created env's condaEnv);
-      // external runs the user's own interpreter directly. External R must launch via Rscript (the R
-      // kernel loop needs Rscript, not the R binary), matching the managed path's rScriptBin.
-      resolvedInterpreter:
-        source === 'external'
-          ? {
-              command: env.language === 'r' ? rscriptFor(env.interpreterPath) : env.interpreterPath,
-              ...(externalRCondaPrefix ? { condaPrefix: externalRCondaPrefix } : {})
-            }
-          : undefined,
-      envName:
-        source === 'managed' ? (env.condaEnv ?? this.defaultEnvNameFor(env.language)) : undefined
-    }
-  }
-
-  // The ENABLED interpreters for a language: app-managed + user-enabled external, never disabled.
-  private async listEnabledInterpreters(
-    language: NotebookLanguage
-  ): Promise<DiscoveredInterpreter[]> {
-    const [discovered, enablement] = await Promise.all([
-      this.runtimeDiscovery(language),
-      this.resolveRuntimeEnablement(language)
-    ])
-    return discovered.filter((env) => isEnvEnabled(env, enablement))
-  }
-
-  // Resolves a runtimeId to an ENABLED runtime for a language, refusing in the MAIN process when it is
-  // disabled or unknown — a guessed interpreter path can never bypass the Settings enable gate.
-  private async resolveEnabledRuntime(
-    language: NotebookLanguage,
-    runtimeId: string
-  ): Promise<InternalRuntimeBinding> {
-    const enabled = await this.listEnabledInterpreters(language)
-    const match = enabled.find((env) => env.envId === runtimeId)
-    if (!match) {
-      throw new Error(
-        `"${runtimeId}" is not an enabled ${language} runtime. Use list_notebook_runtimes to see the ` +
-          'available runtimes, or enable it in Settings → Runtimes first (disabled and unknown ' +
-          'runtimes are refused).'
-      )
-    }
-    const binding = this.toInternalBinding(match)
-    // An interrupted install left this runtime possibly half-applied (crash recovery flagged it): mark
-    // the binding repair-required so execution refuses rather than silently trusting it. A completed
-    // re-install of this runtime clears the flag (see managePackages).
-    const repairKey =
-      binding.source === 'external'
-        ? binding.runtimeId
-        : (binding.envName ?? this.defaultEnvNameFor(language))
-    const runtimeRoot = getRuntimeRoot(this.options.dataRoot)
-    const repairRequired =
-      isRepairRequired(runtimeRoot, repairKey) ||
-      (binding.source === 'managed' &&
-        isRepairRequired(runtimeRoot, managedRepairRegistryKey(repairKey, language))) ||
-      (binding.source === 'managed' && isRepairRequired(runtimeRoot, binding.runtimeId))
-    if (repairRequired) {
-      return { ...binding, status: 'unavailable', reason: 'repair-required' }
-    }
-    return binding
-  }
-
   // list_notebook_runtimes: the enabled runtimes for both languages, each flagged with whether it is
   // this session's current binding. Never returns a disabled runtime.
   async listRuntimes(request: NotebookSessionRequest): Promise<{
@@ -1246,26 +1164,7 @@ class NotebookRuntimeService {
     bindings: NotebookRuntimeBindings
   }> {
     const session = await this.ensureSession(request)
-    const runtimes: NotebookRuntimeListing[] = []
-    for (const language of ['python', 'r'] as const) {
-      const bound = session.runtimeBinding(language)
-      for (const env of await this.listEnabledInterpreters(language)) {
-        const binding = this.toInternalBinding(env)
-        runtimes.push({
-          language: binding.language,
-          runtimeId: binding.runtimeId,
-          source: binding.source,
-          provenance: binding.provenance,
-          interpreterPath: binding.interpreterPath,
-          label: binding.label,
-          version: binding.version,
-          runnable: env.runnable,
-          detail: env.detail,
-          bound: bound?.runtimeId === binding.runtimeId
-        })
-      }
-    }
-    return { runtimes, bindings: this.buildRuntimeBindings(session) }
+    return this.runtimeBindingOwner.list(session)
   }
 
   // notebook_bind_runtime: the FIRST binding of a language for the session. Refuses a disabled/unknown
@@ -1273,18 +1172,10 @@ class NotebookRuntimeService {
   async bindRuntime(
     request: NotebookSessionRequest & { language: NotebookLanguage; runtimeId: string }
   ): Promise<{ bound: NotebookRuntimeBinding; bindings: NotebookRuntimeBindings }> {
-    const session = await this.ensureSession(request)
-    const binding = await this.resolveEnabledRuntime(request.language, request.runtimeId)
-    const existing = session.runtimeBinding(request.language)
-    if (existing && existing.runtimeId !== binding.runtimeId) {
-      throw new Error(
-        `A ${request.language} runtime is already bound for this session. Use ` +
-          'notebook_switch_runtime to change it (it tears down the current kernel first).'
-      )
-    }
-    session.setRuntimeBinding(request.language, binding)
-    await this.persistRuntimeBindings(session)
-    return { bound: this.toWireBinding(binding), bindings: this.buildRuntimeBindings(session) }
+    return this.runtimeBindingOwner.runWrite(request.sessionId, async () => {
+      const session = await this.ensureSession(request)
+      return this.runtimeBindingOwner.bind(session, request.language, request.runtimeId)
+    })
   }
 
   // notebook_switch_runtime: an EXPLICIT switch — tear down the old kernel + clear that language's
@@ -1292,19 +1183,24 @@ class NotebookRuntimeService {
   async switchRuntime(
     request: NotebookSessionRequest & { language: NotebookLanguage; runtimeId: string }
   ): Promise<{ bound: NotebookRuntimeBinding; bindings: NotebookRuntimeBindings }> {
-    const session = await this.ensureSession(request)
-    const binding = await this.resolveEnabledRuntime(request.language, request.runtimeId)
-    // PHYSICALLY tear down the CURRENT runtime's kernel for this language BEFORE rebinding, so the new
-    // runtime starts fresh and two same-language interpreters never coexist. Resolve the OLD env first
-    // (from the outgoing binding), kill its kernel process via the executor, then clear its state.
-    const oldEnv = this.resolveRunEnv(session, request.language)
-    const kind = request.language === 'r' ? 'r' : 'python'
-    await session.terminateExecutor(kind, oldEnv)
-    this.tearDownLanguageBinding(session, request.language, oldEnv)
-    session.setRuntimeBinding(request.language, binding)
-    await this.persistRuntimeBindings(session)
-    this.notifyNotebookChanged(session)
-    return { bound: this.toWireBinding(binding), bindings: this.buildRuntimeBindings(session) }
+    return this.runtimeBindingOwner.runWrite(request.sessionId, async () => {
+      const session = await this.ensureSession(request)
+      const result = await this.runtimeBindingOwner.switch(
+        session,
+        request.language,
+        request.runtimeId,
+        async () => {
+          // PHYSICALLY tear down the CURRENT runtime's kernel for this language BEFORE rebinding, so the
+          // new runtime starts fresh and two same-language interpreters never coexist.
+          const oldEnv = this.resolveRunEnv(session, request.language)
+          const kind = request.language === 'r' ? 'r' : 'python'
+          await session.terminateExecutor(kind, oldEnv)
+          this.tearDownLanguageBinding(session, request.language, oldEnv)
+        }
+      )
+      this.notifyNotebookChanged(session)
+      return result
+    })
   }
 
   // WS11: how many live sessions are bound to a runtime, split by kernel state, so Settings can warn
@@ -1335,43 +1231,54 @@ class NotebookRuntimeService {
     runtimeId: string,
     options: { force?: boolean } = {}
   ): Promise<void> {
-    for (const session of this.sessions.values()) {
+    const targetSessions = Array.from(this.sessions.values()).filter((session) => {
       const binding = session.runtimeBinding(language)
-      if (binding && binding.runtimeId === runtimeId && binding.status !== 'unavailable') {
-        // 1. Block new leases NOW: an unavailable binding makes further execute/install reject.
-        const env = this.resolveRunEnv(session, language)
-        const processKey = dataProcessKey(language, env)
-        session.setRuntimeBinding(language, {
-          ...binding,
-          status: 'unavailable',
-          reason: 'disabled'
-        })
-        await this.persistRuntimeBindings(session)
-        this.notifyNotebookChanged(session)
+      return binding?.runtimeId === runtimeId && binding.status !== 'unavailable'
+    })
+    await this.runtimeBindingOwner.runWrites(
+      targetSessions.map((session) => session.sessionId),
+      async () => {
+        for (const session of targetSessions) {
+          if (this.sessions.get(session.sessionId) !== session) continue
+          const revocation = await this.runtimeBindingOwner.revoke(
+            session,
+            language,
+            runtimeId,
+            () => {
+              const env = this.resolveRunEnv(session, language)
+              return { env, processKey: dataProcessKey(language, env) }
+            }
+          )
+          if (!revocation) continue
 
-        if (options.force) {
-          // FORCE-STOP ("stop running work and disable"): abort a running cell now — flag its process
-          // key so the killed run records 'cancelled' (not 'failed'), then physically terminate the
-          // kernel and clear its state. Only flag when a cell is actually running, so the one-shot flag
-          // can't leak onto a later run of an idle/dormant kernel.
-          const kind = language === 'r' ? 'r' : 'python'
-          if (session.kernelStatus(processKey) === 'running') {
-            session.markForceStopped(processKey)
-          }
-          await session.terminateExecutor(kind, env)
-          this.tearDownLanguageBinding(session, language, env)
+          // 1. Block new leases NOW: an unavailable binding makes further execute/install reject.
+          const { env, processKey } = revocation
           this.notifyNotebookChanged(session)
-          continue
-        }
 
-        // 2. Default (drain): close in the BACKGROUND so the disable toggle doesn't block on a
-        //    long-running cell — let the in-flight run finish, then tear the kernel down. Tracked so
-        //    shutdown awaits it.
-        const drain = this.drainAndCloseRuntime(session, language, env)
-        this.revocationDrains.add(drain)
-        void drain.finally(() => this.revocationDrains.delete(drain))
+          if (options.force) {
+            // FORCE-STOP ("stop running work and disable"): abort a running cell now — flag its process
+            // key so the killed run records 'cancelled' (not 'failed'), then physically terminate the
+            // kernel and clear its state. Only flag when a cell is actually running, so the one-shot flag
+            // can't leak onto a later run of an idle/dormant kernel.
+            const kind = language === 'r' ? 'r' : 'python'
+            if (session.kernelStatus(processKey) === 'running') {
+              session.markForceStopped(processKey)
+            }
+            await session.terminateExecutor(kind, env)
+            this.tearDownLanguageBinding(session, language, env)
+            this.notifyNotebookChanged(session)
+            continue
+          }
+
+          // 2. Default (drain): close in the BACKGROUND so the disable toggle doesn't block on a
+          //    long-running cell — let the in-flight run finish, then tear the kernel down. Tracked so
+          //    shutdown awaits it.
+          const drain = this.drainAndCloseRuntime(session, language, env)
+          this.revocationDrains.add(drain)
+          void drain.finally(() => this.revocationDrains.delete(drain))
+        }
       }
-    }
+    )
   }
 
   // Drain-and-close for a revoked (disabled) runtime: wait out the in-flight run on this env (never a
@@ -1393,81 +1300,6 @@ class NotebookRuntimeService {
       this.notifyNotebookChanged(session)
     } catch (error) {
       console.error('[notebook] Failed to drain/close a revoked runtime', error)
-    }
-  }
-
-  // Drops the wire-only fields of an internal binding (never leaks the interpreter override shape).
-  private toWireBinding(binding: InternalRuntimeBinding): NotebookRuntimeBinding {
-    return {
-      language: binding.language,
-      runtimeId: binding.runtimeId,
-      source: binding.source,
-      provenance: binding.provenance,
-      interpreterPath: binding.interpreterPath,
-      label: binding.label,
-      version: binding.version,
-      status: binding.status ?? 'active',
-      reason: binding.reason
-    }
-  }
-
-  // The session's current per-language bindings in wire shape (for notebook_state / the tools).
-  private buildRuntimeBindings(session: RuntimeSession): NotebookRuntimeBindings {
-    const python = session.runtimeBinding('python')
-    const r = session.runtimeBinding('r')
-    return {
-      python: python ? this.toWireBinding(python) : undefined,
-      r: r ? this.toWireBinding(r) : undefined
-    }
-  }
-
-  // Persists the session's bindings so they survive a restart (best-effort; a persistence failure must
-  // not fail the bind/switch/revoke operation itself). Reloaded + revalidated by reloadPersistedBindings.
-  private async persistRuntimeBindings(session: RuntimeSession): Promise<void> {
-    try {
-      await this.repository.setRuntimeBindings(
-        session.projectName,
-        session.sessionId,
-        this.buildRuntimeBindings(session)
-      )
-    } catch (error) {
-      console.error('[notebook] Failed to persist runtime bindings', error)
-    }
-  }
-
-  // On session (re)load, rehydrate persisted bindings and REVALIDATE each against current discovery +
-  // enablement: a binding that still resolves to an enabled+runnable runtime is restored active (its
-  // kernel is terminated after a restart — memory is gone, but the binding stands); one that no longer
-  // resolves is kept as unavailable (NO silent fallback) so the next execute rejects and the agent
-  // switches — 'disabled' when the runtime is still detected but turned off, 'missing' when it is gone.
-  private async reloadPersistedBindings(
-    session: RuntimeSession,
-    persisted: NotebookRuntimeBindings | undefined
-  ): Promise<void> {
-    if (!persisted) return
-    for (const language of ['python', 'r'] as const) {
-      const wire = persisted[language]
-      if (!wire) continue
-      try {
-        session.setRuntimeBinding(
-          language,
-          await this.resolveEnabledRuntime(language, wire.runtimeId)
-        )
-      } catch {
-        const discovered = await this.runtimeDiscovery(language)
-        const stillDetected = discovered.some((env) => env.envId === wire.runtimeId)
-        session.setRuntimeBinding(language, {
-          language,
-          runtimeId: wire.runtimeId,
-          source: wire.source,
-          provenance: wire.provenance,
-          interpreterPath: wire.interpreterPath,
-          label: wire.label,
-          version: wire.version,
-          status: 'unavailable',
-          reason: stillDetected ? 'disabled' : 'missing'
-        })
-      }
     }
   }
 
@@ -2192,7 +2024,7 @@ class NotebookRuntimeService {
       recentRuns: document.runs.slice(-20).map((run) => this.toPublicRunRecord(run)),
       environments: this.buildEnvironmentStatuses(session),
       // v4 session runtime bindings (notebook_state surfaces the current python/r bindings).
-      runtimeBindings: this.buildRuntimeBindings(session)
+      runtimeBindings: this.runtimeBindingOwner.snapshot(session)
     }
   }
 
@@ -3121,7 +2953,10 @@ class NotebookRuntimeService {
   }
 
   async shutdownSession(sessionId: string): Promise<{ sessionId: string; status: 'shutdown' }> {
-    await this.sessions.remove(sessionId)
+    await this.runtimeBindingOwner.withSessionTeardown(sessionId, async () => {
+      await this.runtimeBindingOwner.waitForWrites(sessionId)
+      await this.sessions.remove(sessionId)
+    })
     return { sessionId, status: 'shutdown' }
   }
 
@@ -3293,7 +3128,7 @@ class NotebookRuntimeService {
   // when every kernel tree was cleanly reaped, so the update-install gate can refuse to trigger the
   // NSIS uninstall while a kernel may still hold file handles under the install dir.
   shutdownAll(): Promise<{ reaped: boolean }> {
-    return this.sessions.shutdownAll()
+    return this.runtimeBindingOwner.withGlobalTeardown(() => this.sessions.shutdownAll())
   }
 
   // Permanently closes process-owned recovery work before the final kernel teardown. Unlike
@@ -3310,7 +3145,7 @@ class NotebookRuntimeService {
     // quit budget before kernel teardown even starts. Await both so non-quit module disposal still leaves
     // no recovery work behind once this terminal operation resolves.
     const recoveryDisposal = this.recoveryCoordinator.dispose()
-    const shutdown = this.sessions.dispose()
+    const shutdown = this.runtimeBindingOwner.withGlobalTeardown(() => this.sessions.dispose())
     const disposal = Promise.allSettled([shutdown, recoveryDisposal]).then(
       ([shutdownResult, recoveryResult]) => {
         const failures = [shutdownResult, recoveryResult]
@@ -3378,7 +3213,7 @@ class NotebookRuntimeService {
         // is restored active; one whose runtime is now disabled/missing is kept as unavailable (no
         // silent fallback). Publish only after this initialization completes so same-ID callers cannot
         // observe a partially hydrated aggregate.
-        await this.reloadPersistedBindings(session, document.runtimeBindings)
+        await this.runtimeBindingOwner.reload(session, document.runtimeBindings)
         return session
       } catch (error) {
         // Initialization failures stay retryable. Best-effort cleanup must not replace the repository /
@@ -3663,31 +3498,43 @@ class NotebookRuntimeService {
     managedRepair: boolean,
     crossLanguageRepair = false
   ): Promise<void> {
-    const changedSessions: RuntimeSession[] = []
-    for (const session of this.sessions.values()) {
-      let changed = false
-      for (const [language, binding] of session.runtimeBindingEntries()) {
+    const targetSessions = Array.from(this.sessions.values()).filter((session) =>
+      Array.from(session.runtimeBindingEntries()).some(([language, binding]) => {
         const targetMatches =
           binding.source === 'external'
             ? !managedRepair && language === repairedLanguage && binding.runtimeId === runtimeId
             : managedRepair &&
               (crossLanguageRepair || language === repairedLanguage) &&
               this.resolveRunEnv(session, language) === envName
-        if (targetMatches && binding.reason === 'repair-required') {
-          session.setRuntimeBinding(language, {
-            ...binding,
-            status: 'active',
-            reason: undefined
-          })
-          changed = true
+        return targetMatches && binding.reason === 'repair-required'
+      })
+    )
+    await this.runtimeBindingOwner.runWrites(
+      targetSessions.map((session) => session.sessionId),
+      async () => {
+        const changedSessions: RuntimeSession[] = []
+        for (const session of targetSessions) {
+          if (this.sessions.get(session.sessionId) !== session) continue
+          let changed = false
+          for (const [language, binding] of session.runtimeBindingEntries()) {
+            const targetMatches =
+              binding.source === 'external'
+                ? !managedRepair && language === repairedLanguage && binding.runtimeId === runtimeId
+                : managedRepair &&
+                  (crossLanguageRepair || language === repairedLanguage) &&
+                  this.resolveRunEnv(session, language) === envName
+            if (targetMatches && binding.reason === 'repair-required') {
+              changed = this.runtimeBindingOwner.markAvailable(session, language) || changed
+            }
+          }
+          if (changed) changedSessions.push(session)
+        }
+        for (const session of changedSessions) {
+          await this.runtimeBindingOwner.persist(session)
+          this.notifyNotebookChanged(session)
         }
       }
-      if (changed) changedSessions.push(session)
-    }
-    for (const session of changedSessions) {
-      await this.persistRuntimeBindings(session)
-      this.notifyNotebookChanged(session)
-    }
+    )
   }
 
   // A protected interpreter identity changed after an installer transaction despite the approved
@@ -3701,54 +3548,71 @@ class NotebookRuntimeService {
     runtimeRoot: string,
     managedRuntime: boolean
   ): Promise<void> {
-    const affectedBindings = new Set<RuntimeSession>()
     const affectedLanguages: readonly NotebookLanguage[] = managedRuntime
       ? ['python', 'r']
       : [language]
-    if (managedRuntime) {
-      for (const affectedLanguage of affectedLanguages) {
-        this.repairBlockedEnvs.add(dataProcessKey(affectedLanguage, envName))
-      }
-    } else {
-      this.repairBlockedEnvs.add(externalRepairBlockKey(language, runtimeId))
-    }
-    try {
-      for (const session of this.sessions.values()) {
-        for (const affectedLanguage of affectedLanguages) {
-          const binding = session.runtimeBinding(affectedLanguage)
-          const sessionEnv = this.resolveRunEnv(session, affectedLanguage)
-          const targetMatches = managedRuntime
-            ? binding?.source !== 'external' && sessionEnv === envName
-            : binding?.source === 'external' && binding.runtimeId === runtimeId
-          if (!targetMatches) continue
-
-          if (binding) {
-            session.setRuntimeBinding(affectedLanguage, {
-              ...binding,
-              status: 'unavailable',
-              reason: 'repair-required'
-            })
-            affectedBindings.add(session)
+    const targetSessions = Array.from(this.sessions.values()).filter((session) =>
+      affectedLanguages.some((affectedLanguage) => {
+        const binding = session.runtimeBinding(affectedLanguage)
+        const sessionEnv = this.resolveRunEnv(session, affectedLanguage)
+        return managedRuntime
+          ? binding?.source !== 'external' && sessionEnv === envName
+          : binding?.source === 'external' && binding.runtimeId === runtimeId
+      })
+    )
+    await this.runtimeBindingOwner.runWrites(
+      targetSessions.map((session) => session.sessionId),
+      async () => {
+        const affectedBindings = new Set<RuntimeSession>()
+        if (managedRuntime) {
+          for (const affectedLanguage of affectedLanguages) {
+            this.repairBlockedEnvs.add(dataProcessKey(affectedLanguage, envName))
           }
-          const kind = affectedLanguage === 'r' ? 'r' : 'python'
-          await session.terminateExecutor(kind, sessionEnv)
-          this.tearDownLanguageBinding(session, affectedLanguage, sessionEnv)
-          this.notifyNotebookChanged(session)
+        } else {
+          this.repairBlockedEnvs.add(externalRepairBlockKey(language, runtimeId))
+        }
+        try {
+          for (const session of targetSessions) {
+            if (this.sessions.get(session.sessionId) !== session) continue
+            for (const affectedLanguage of affectedLanguages) {
+              const binding = session.runtimeBinding(affectedLanguage)
+              const sessionEnv = this.resolveRunEnv(session, affectedLanguage)
+              const targetMatches = managedRuntime
+                ? binding?.source !== 'external' && sessionEnv === envName
+                : binding?.source === 'external' && binding.runtimeId === runtimeId
+              if (!targetMatches) continue
+
+              if (
+                binding &&
+                this.runtimeBindingOwner.markUnavailable(
+                  session,
+                  affectedLanguage,
+                  'repair-required'
+                )
+              ) {
+                affectedBindings.add(session)
+              }
+              const kind = affectedLanguage === 'r' ? 'r' : 'python'
+              await session.terminateExecutor(kind, sessionEnv)
+              this.tearDownLanguageBinding(session, affectedLanguage, sessionEnv)
+              this.notifyNotebookChanged(session)
+            }
+          }
+
+          // The operation journal stays live until both the durable repair registry and the binding state
+          // are committed. A tagged failure makes the caller retain journal + sidecar evidence for startup
+          // recovery, while the process-local gate above continues blocking execution immediately.
+          addRepairRequired(runtimeRoot, runtimeId, 'protected-identity-change')
+          for (const session of affectedBindings) await this.runtimeBindingOwner.persist(session)
+        } catch (error) {
+          throw new Error(
+            `${REPAIR_QUARANTINE_FAILED}: could not durably quarantine the runtime after its protected ` +
+              `interpreter changed. ${error instanceof Error ? error.message : String(error)}`,
+            { cause: error }
+          )
         }
       }
-
-      // The operation journal stays live until both the durable repair registry and the binding state
-      // are committed. A tagged failure makes the caller retain journal + sidecar evidence for startup
-      // recovery, while the process-local gate above continues blocking execution immediately.
-      addRepairRequired(runtimeRoot, runtimeId, 'protected-identity-change')
-      for (const session of affectedBindings) await this.persistRuntimeBindings(session)
-    } catch (error) {
-      throw new Error(
-        `${REPAIR_QUARANTINE_FAILED}: could not durably quarantine the runtime after its protected ` +
-          `interpreter changed. ${error instanceof Error ? error.message : String(error)}`,
-        { cause: error }
-      )
-    }
+    )
   }
 
   // Adds notebook roots and kernel metadata to the run returned to MCP callers.


### PR DESCRIPTION
## Problem

Notebook runtime discovery, Settings enablement, binding transitions, revocation, and persisted binding reload were mixed into `NotebookRuntimeService` alongside execution and provisioning. That blurred state ownership and made the runtime service continue growing.

## Proposed change

- Add `NotebookRuntimeBindingOwner` as the owner of runtime discovery, selection, bind/switch/revoke transitions, snapshots, reload, and durable binding persistence.
- Consume a narrow `NotebookRuntimeSettings.getSnapshot` capability from main-process composition instead of coupling the binding state machine to the broad Settings service.
- Keep execution, provisioning, kernel teardown, notifications, and package/environment policy in `NotebookRuntimeService`.
- Serialize binding writes with session-scoped leases. A same-session teardown waits through the durable commit before publishing a successor generation, while unrelated sessions and read-only runtime discovery remain independent.

```mermaid
flowchart LR
  Surfaces["Electron / Web / CLI / Task adapters"] --> Service["NotebookRuntimeService"]
  Service --> Binding["NotebookRuntimeBindingOwner"]
  Binding --> Settings["NotebookRuntimeSettings snapshot capability"]
  Binding --> Repository["NotebookRunRepository runtimeBindings"]
  Service --> Execution["Execution / provisioning / kernel lifecycle"]
```

## Scope and non-goals

- No change to the persisted `runtimeBindings` shape or data relationships.
- No change to IPC or local RPC methods, payloads, errors, or authorization.
- No change to Electron, local/remote Web, CLI, or Task capability availability.
- No change to Specialist, Permission, or Compute behavior.
- No transfer of execution or provisioning ownership into the binding module.
- This remains forward-compatible with #458 but does not add orchestration data, public APIs, or UI for it.
- `docs/internal/` planning material remains ignored and is not part of this PR.

## Acceptance criteria and validation

All listed checks ran after the final material edit and rebase onto `4edb5e80a054794996d3fab9468bc8a53b1a60de`.

- Binding discovery, bind/switch/revoke/reload, generation replacement, per-session isolation, and immediate shutdown/dispose races -> `npm test -- --run src/main/notebook/runtime-service.test.ts src/main/notebook/runtime-ipc.test.ts src/main/acp/ipc.test.ts src/main/notebook/local-rpc-server.test.ts src/main/notebook/local-rpc-server.agents.test.ts` -> **255 passed**.
- Node and renderer type safety -> `npm run typecheck` -> **passed**.
- Repository lint -> `npm run lint` -> **passed with 0 errors**; 19 pre-existing warnings remain outside the changed files.
- Full regression suite -> `npm test` -> **9,761 passed, 184 skipped across 670 passed and 15 skipped files**.
- Patch integrity -> `git diff --check origin/main...HEAD` -> **passed**.
- Independent Standards and Spec reviews of exact head `2eed2bedbdb0f88e817c4ef7e78985fa46540582` -> **P0/P1/P2/P3 all 0**.

Uncovered risk: the concurrency coverage is deterministic and in-process; it does not simulate an operating-system crash during the repository's existing atomic file replacement. No UI E2E suite was run because this PR does not change renderer behavior or UI surfaces.

## Review focus

- Whether the new module boundary is deep enough: binding state and persistence belong to the owner, while execution/provisioning remain in the service.
- Whether write admission covers the full `ensureSession` -> transition -> durable commit interval without blocking unrelated sessions or read-only discovery.
- Whether the narrow Settings capability remains internal composition and leaves every transport contract unchanged.

Merge with squash only; keep the PR title as the Conventional Commit squash subject.
