### PR TITLE
feat(context-usage): persist usage across restarts

### DIFF
--- a/src/renderer/src/lib/acp/useWorkspaceAgentRuntime.test.ts
+++ b/src/renderer/src/lib/acp/useWorkspaceAgentRuntime.test.ts
@@ -4,6 +4,7 @@ import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest'
 
 import {
   createInitialSessionState,
+  toPersistedSession,
   useSessionStore,
   type ChatMessage
 } from '../../stores/session-store'
@@ -24,7 +25,8 @@ import {
   recoverContextOverflowWorkspaceSession,
   resendEditedWorkspaceMessage,
   resumeInterruptedWorkspaceSession,
-  sendWorkspaceMessage
+  sendWorkspaceMessage,
+  syncWorkspaceContextUsage
 } from './useWorkspaceAgentRuntime'
 
 const createEvent = (overrides: Partial<AcpRuntimeEvent>): AcpRuntimeEvent => ({
@@ -270,6 +272,39 @@ describe('resume failure classification', () => {
     expect(message).toBe(
       'Agent session resume failed: ACP protocol version is not compatible with this client'
     )
+  })
+})
+
+describe('workspace context usage persistence', () => {
+  it('keeps detached snapshots and replaces or clears attached snapshots', () => {
+    useSessionStore.setState(createInitialSessionState())
+    useSessionStore.getState().appendUserMessage({
+      sessionId: 'session-1',
+      content: 'Persist context usage',
+      cwd: '/workspace/project',
+      projectId: 'project-1'
+    })
+    const usage = { used: 24_890, size: 200_000 }
+    const updatedAt = useSessionStore.getState().sessions[0].updatedAt
+
+    syncWorkspaceContextUsage(['session-1'], { 'session-1': usage })
+    const sessionWithUsage = useSessionStore.getState().sessions[0]
+    expect(toPersistedSession(sessionWithUsage).contextUsage).toEqual(usage)
+    expect(sessionWithUsage.updatedAt).toBe(updatedAt)
+
+    syncWorkspaceContextUsage([], {})
+    expect(useSessionStore.getState().sessions[0]).toBe(sessionWithUsage)
+
+    syncWorkspaceContextUsage(['session-1'], { 'session-1': { ...usage } })
+    expect(useSessionStore.getState().sessions[0]).toBe(sessionWithUsage)
+
+    syncWorkspaceContextUsage(['session-1'], {
+      'session-1': { used: 30_000, size: 200_000 }
+    })
+    expect(useSessionStore.getState().sessions[0].contextUsage?.used).toBe(30_000)
+
+    syncWorkspaceContextUsage(['session-1'], {})
+    expect(useSessionStore.getState().sessions[0].contextUsage).toBeUndefined()
   })
 })
 

--- a/src/renderer/src/lib/acp/useWorkspaceAgentRuntime.ts
+++ b/src/renderer/src/lib/acp/useWorkspaceAgentRuntime.ts
@@ -1379,6 +1379,18 @@ const markRunningSessionsDisconnectedOnDrop = (
   }
 }
 
+// Copies live context usage into the durable Session. Missing usage clears only attached sessions,
+// preserving the last snapshot for detached sessions while invalidating replaced runtime contexts.
+const syncWorkspaceContextUsage = (
+  sessionIds: readonly string[],
+  contextUsageBySession: Record<string, AcpContextUsage>
+): void => {
+  const { setContextUsage } = useSessionStore.getState()
+  for (const sessionId of sessionIds) {
+    setContextUsage(sessionId, contextUsageBySession[sessionId])
+  }
+}
+
 // Deletes in three ordered ownership layers: agent runtime, durable JSON/DB coordinator, then renderer
 // state. A failure in either authoritative layer leaves the session visible with an actionable error.
 const deleteWorkspaceSession = async (
@@ -1504,6 +1516,10 @@ const useWorkspaceAgentRuntime = (): {
   useEffect(() => {
     syncWorkspacePermissionState(runtime.state.pendingPermissions)
   }, [runtime.state.pendingPermissions])
+
+  useEffect(() => {
+    syncWorkspaceContextUsage(runtime.state.sessionIds, runtime.state.contextUsageBySession)
+  }, [runtime.state.sessionIds, runtime.state.contextUsageBySession])
 
   // An abnormal live drop (agent crash / gateway drop) surfaces as a transition into 'closed'/'error'
   // while a session is still running. Flag those sessions so the Resume banner appears.
@@ -1688,5 +1704,6 @@ export {
   resendEditedWorkspaceMessage,
   resumeInterruptedWorkspaceSession,
   sendWorkspaceMessage,
+  syncWorkspaceContextUsage,
   useWorkspaceAgentRuntime
 }

--- a/src/renderer/src/pages/workspace/WorkspacePage.tsx
+++ b/src/renderer/src/pages/workspace/WorkspacePage.tsx
@@ -657,7 +657,9 @@ const WorkspacePage = ({
     : undefined
   // Session grants only exist for a bound Agent session; new conversations have none yet.
   const activePermissionGrants = activeSession ? (permissionGrants?.[activeSession.id] ?? []) : []
-  const activeContextUsage = activeSession ? contextUsageBySession?.[activeSession.id] : undefined
+  const activeContextUsage = activeSession
+    ? (contextUsageBySession?.[activeSession.id] ?? activeSession.contextUsage)
+    : undefined
   const activeSessionSupportsNativeCompaction = activeSession
     ? nativeContextCompactionSessionIds?.includes(activeSession.id) === true
     : false

--- a/src/renderer/src/stores/session-store.ts
+++ b/src/renderer/src/stores/session-store.ts
@@ -11,6 +11,7 @@ import { sanitizeActivityGroupTitle } from '../../../shared/activity-groups'
 import {
   MAX_ACP_SESSION_IMAGE_BYTES,
   sanitizeAcpMessageImage,
+  type AcpContextUsage,
   type AcpMessageImage,
   type AcpTurnTokenUsage
 } from '../../../shared/acp'
@@ -280,6 +281,7 @@ type SessionStore = SessionStoreData & {
   completeActivityGroup: (sessionId: string, promptMessageId?: string) => void
   setPermissionPending: (sessionId: string) => void
   clearPermissionPending: (sessionId: string) => void
+  setContextUsage: (sessionId: string, contextUsage: AcpContextUsage | undefined) => void
   setPermissionProfile: (sessionId: string, profile: PermissionProfileId) => void
   // Persists the per-session auto-review toggle. true = on; false = off (default).
   setAutoReviewEnabled: (sessionId: string, enabled: boolean) => void
@@ -2317,6 +2319,21 @@ export const useSessionStore = create<SessionStore>((set, get) => ({
           : session
       )
     }))
+  },
+
+  setContextUsage: (sessionId, contextUsage) => {
+    set((state) => {
+      const session = state.sessions.find((candidate) => candidate.id === sessionId)
+      if (!session || JSON.stringify(session.contextUsage) === JSON.stringify(contextUsage)) {
+        return state
+      }
+
+      return {
+        sessions: state.sessions.map((candidate) =>
+          candidate.id === sessionId ? { ...candidate, contextUsage } : candidate
+        )
+      }
+    })
   },
 
   setEnabledComputeHosts: (sessionId, providerIds) => {

--- a/src/shared/acp.ts
+++ b/src/shared/acp.ts
@@ -143,6 +143,87 @@ export type AcpContextUsage = {
   breakdown?: AcpContextUsageBreakdown
 }
 
+const asTokenCount = (value: unknown): number | undefined =>
+  typeof value === 'number' && Number.isSafeInteger(value) && value >= 0 ? value : undefined
+
+const ACP_CONTEXT_USAGE_CATEGORY_KEYS = new Set<AcpContextUsageCategoryKey>([
+  'system',
+  'tools',
+  'messages',
+  'mcp',
+  'skills',
+  'other'
+])
+const ACP_CONTEXT_USAGE_TOKENIZERS = new Set<NonNullable<AcpContextUsageBreakdown['tokenizer']>>([
+  'anthropic',
+  'o200k_base',
+  'cl100k_base'
+])
+
+// Re-validates the last known context snapshot before restoring it from Session JSON.
+export const sanitizeAcpContextUsage = (value: unknown): AcpContextUsage | undefined => {
+  if (typeof value !== 'object' || value === null || Array.isArray(value)) return undefined
+
+  const usage = value as Record<string, unknown>
+  const used = asTokenCount(usage.used)
+  if (used === undefined) return undefined
+
+  const sanitized: AcpContextUsage = { used }
+  const agentUsed = asTokenCount(usage.agentUsed)
+  const size = asTokenCount(usage.size)
+  if (agentUsed !== undefined) sanitized.agentUsed = agentUsed
+  if (size !== undefined && size > 0) sanitized.size = size
+
+  if (typeof usage.breakdown !== 'object' || usage.breakdown === null) return sanitized
+  const breakdown = usage.breakdown as Record<string, unknown>
+  const estimatedTokens = asTokenCount(breakdown.estimatedTokens)
+  const difference = breakdown.difference
+  const source = breakdown.source
+  const status = breakdown.status
+  if (
+    (source !== 'estimated' && source !== 'native') ||
+    estimatedTokens === undefined ||
+    typeof difference !== 'number' ||
+    !Number.isSafeInteger(difference) ||
+    (status !== 'preflight' && status !== 'reconciled') ||
+    !Array.isArray(breakdown.categories)
+  ) {
+    return sanitized
+  }
+
+  const categories: AcpContextUsageCategory[] = []
+  const categoryKeys = new Set<AcpContextUsageCategoryKey>()
+  for (const value of breakdown.categories) {
+    if (typeof value !== 'object' || value === null || Array.isArray(value)) return sanitized
+    const category = value as Record<string, unknown>
+    const key = category.key as AcpContextUsageCategoryKey
+    const tokens = asTokenCount(category.tokens)
+    if (
+      !ACP_CONTEXT_USAGE_CATEGORY_KEYS.has(key) ||
+      categoryKeys.has(key) ||
+      tokens === undefined ||
+      typeof category.estimated !== 'boolean'
+    ) {
+      return sanitized
+    }
+    categoryKeys.add(key)
+    categories.push({ key, tokens, estimated: category.estimated })
+  }
+
+  const tokenizer = breakdown.tokenizer as AcpContextUsageBreakdown['tokenizer']
+  const model = typeof breakdown.model === 'string' && breakdown.model ? breakdown.model : undefined
+  sanitized.breakdown = {
+    source,
+    ...(tokenizer && ACP_CONTEXT_USAGE_TOKENIZERS.has(tokenizer) ? { tokenizer } : {}),
+    ...(model ? { model } : {}),
+    estimatedTokens,
+    difference,
+    status,
+    categories
+  }
+  return sanitized
+}
+
 // Provider-reported totals for one completed prompt turn. `cacheTokens` stays as the comparable
 // provider-neutral total. Read/write details are present as a pair only when the adapter reports both
 // categories separately.
@@ -161,9 +242,6 @@ export type AcpTurnTokenUsage = {
 // separate from ACP's latest-request usage snapshot.
 export const ACP_TURN_TOKEN_USAGE_META_KEY = 'open-science/turn-usage'
 export const ACP_MODEL_TURN_COUNT_META_KEY = 'open-science/model-turn-count'
-
-const asTokenCount = (value: unknown): number | undefined =>
-  typeof value === 'number' && Number.isSafeInteger(value) && value >= 0 ? value : undefined
 
 // Normalizes ACP's experimental PromptResponse usage into the stable, provider-neutral projection the
 // renderer persists. Missing cache categories mean zero; malformed totals suppress the entire footer.

--- a/src/shared/session-persistence.test.ts
+++ b/src/shared/session-persistence.test.ts
@@ -427,6 +427,56 @@ describe('turn token usage persistence', () => {
   })
 })
 
+describe('context usage persistence', () => {
+  it('round-trips a valid snapshot and drops malformed usage', () => {
+    const contextUsage = {
+      used: 29_500,
+      agentUsed: 29_500,
+      size: 168_000,
+      breakdown: {
+        source: 'estimated',
+        tokenizer: 'o200k_base',
+        model: 'gpt-5.6-sol',
+        estimatedTokens: 29_405,
+        difference: 95,
+        status: 'reconciled',
+        categories: [
+          { key: 'system', tokens: 7_200, estimated: true },
+          { key: 'other', tokens: 95, estimated: false }
+        ]
+      }
+    }
+    const restored = normalizeSessionFile({
+      ...createSessionWithActivity(undefined),
+      activities: undefined,
+      contextUsage
+    })
+    const malformed = normalizeSessionFile({
+      ...createSessionWithActivity(undefined),
+      activities: undefined,
+      contextUsage: { used: -1, size: 168_000 }
+    })
+    const unsafeBreakdown = normalizeSessionFile({
+      ...createSessionWithActivity(undefined),
+      activities: undefined,
+      contextUsage: {
+        used: 100,
+        breakdown: {
+          source: 'estimated',
+          estimatedTokens: 100,
+          difference: 0,
+          status: 'reconciled',
+          categories: [{ key: 'unknown', tokens: 100, estimated: true }]
+        }
+      }
+    })
+
+    expect(restored?.contextUsage).toEqual(contextUsage)
+    expect(malformed?.contextUsage).toBeUndefined()
+    expect(unsafeBreakdown?.contextUsage).toEqual({ used: 100 })
+  })
+})
+
 describe('sanitizeToolActivity', () => {
   it('keeps identity fields and known text/diff content', () => {
     const activity = sanitizeToolActivity({

--- a/src/shared/session-persistence.ts
+++ b/src/shared/session-persistence.ts
@@ -4,8 +4,10 @@ import {
   MAX_ACP_MESSAGE_IMAGES_PER_MESSAGE,
   MAX_ACP_MESSAGE_IMAGE_BYTES_PER_MESSAGE,
   MAX_ACP_SESSION_IMAGE_BYTES,
+  sanitizeAcpContextUsage,
   sanitizeAcpMessageImage,
   sanitizeAcpTurnTokenUsage,
+  type AcpContextUsage,
   type AcpMessageImage,
   type AcpTurnTokenUsage
 } from './acp'
@@ -178,6 +180,9 @@ export type PersistedChatSession = {
   // Agent). Written once when the session is created and never changed; the Profile is resolved
   // fresh from ProfileService before every turn via the UUID.
   specialistId?: string
+  // Last known context-window usage. A live attached runtime replaces or clears this snapshot; a
+  // detached restored Session keeps it so the indicator survives an app restart.
+  contextUsage?: AcpContextUsage
   messages: PersistedChatMessage[]
   // Session JSON v2 authority. Flat messages/activities remain an active-Branch compatibility view.
   conversationGraph?: PersistedConversationGraph
@@ -1152,6 +1157,8 @@ const sanitizeSession = (
   // at send time; the sanitizer only ensures the value is safe to re-persist.
   const specialistId = asString(session.specialistId)
   if (specialistId) sanitized.specialistId = specialistId
+  const contextUsage = sanitizeAcpContextUsage(session.contextUsage)
+  if (contextUsage) sanitized.contextUsage = contextUsage
 
   // Normalize interrupted runtime state before constructing a graph for legacy sessions. Otherwise
   // the compatibility message list becomes an error while the newly-created canonical graph retains


### PR DESCRIPTION
## Problem

Context-window usage currently lives only in the ACP runtime snapshot, so restarting Open Science removes the indicator even though the conversation Session is restored.

## Proposed change

- Persist the last known `contextUsage` as an optional, sanitized Session field.
- Mirror live usage only for attached runtime Sessions; clear it when an attached context generation is invalidated.
- Fall back to the persisted snapshot for restored, detached Sessions.
- Keep New conversation unchanged: no Session means no Context window indicator.

```mermaid
flowchart LR
  A["ACP runtime usage"] --> B["Session store contextUsage"]
  B --> C["Existing Session JSON autosave"]
  C --> D["Restart hydration"]
  D --> E["Existing Context window UI"]
```

## Scope and non-goals

No database, migration script, dependency, layout, or new user action is added. Older Session files remain valid because the field is optional.

## Acceptance criteria and validation

All checks below ran after the final material edit.

- Context usage round-trip and untrusted payload sanitization -> `npm test -- src/shared/session-persistence.test.ts src/renderer/src/lib/acp/useWorkspaceAgentRuntime.test.ts` -> passed (119 tests).
- Context Window remains hidden without usage, including New conversation -> existing `ComposerContextUsage` coverage within the full suite -> passed.
- Node and renderer types -> `npm run typecheck` equivalent (`tsc` against both project configs) -> passed.
- Repository lint -> `npm run lint` equivalent -> passed with 0 errors and 19 pre-existing warnings.
- Full regression suite -> `npm test -- --maxWorkers=4` -> passed (670 files, 9,756 tests; 184 skipped).

## Review focus

- Last-known snapshot semantics across detached versus attached runtime Sessions.
- Strict validation of restored breakdown category keys and token counts.
- No-op equality guard preventing redundant Session writes.

## Uncovered risks

The exact quit-and-relaunch Electron UI journey is not automated; persistence boundaries, hydration fallback, hidden-empty behavior, and the full unit/integration suite are covered.