### PR TITLE
fix(workspace): use semantic runtime label icons

### DIFF
--- a/src/renderer/src/pages/workspace/WorkspaceMessageItem.mentions.test.tsx
+++ b/src/renderer/src/pages/workspace/WorkspaceMessageItem.mentions.test.tsx
@@ -452,8 +452,12 @@ describe('WorkspaceMessageItem turn token usage', () => {
     const details = document.body.querySelector('[data-slot="turn-runtime-details"]')
     expect(details?.textContent).toContain('Agent: Codex')
     expect(details?.textContent).toContain('Model: gpt-test')
-    expect(details?.querySelector('[data-slot="turn-runtime-agent-detail-icon"]')).not.toBeNull()
-    expect(details?.querySelector('[data-slot="turn-runtime-model-detail-icon"]')).not.toBeNull()
+    expect(
+      details?.querySelector('[data-slot="turn-runtime-agent-detail-icon"] .lucide-bot')
+    ).not.toBeNull()
+    expect(
+      details?.querySelector('[data-slot="turn-runtime-model-detail-icon"] .lucide-brain')
+    ).not.toBeNull()
 
     await act(async () => {
       useSettingsStore.setState({

--- a/src/renderer/src/pages/workspace/WorkspaceMessageItem.tsx
+++ b/src/renderer/src/pages/workspace/WorkspaceMessageItem.tsx
@@ -7,6 +7,8 @@ import { useSettingsStore } from '@/stores/settings-store'
 import type { ChatMessage, ChatSession } from '@/stores/session-store'
 import { Collapsible } from 'radix-ui'
 import {
+  Bot,
+  Brain,
   Check,
   ChevronLeft,
   ChevronRight,
@@ -365,29 +367,27 @@ const TurnTokenUsage = ({
             data-slot="turn-runtime-details"
             className="mt-2 space-y-0.5 border-t border-border pt-2 text-[11px] leading-4 text-muted-foreground"
           >
-            {frameworkName && runtimeIdentity?.frameworkId ? (
+            {frameworkName ? (
               <div className="flex min-w-0 items-center gap-1.5">
                 <span
                   data-slot="turn-runtime-agent-detail-icon"
                   aria-hidden="true"
                   className="flex size-3 shrink-0 items-center justify-center"
                 >
-                  <AgentFrameworkIcon frameworkId={runtimeIdentity.frameworkId} size={10} />
+                  <Bot className="size-2.5" strokeWidth={2} />
                 </span>
                 <span className="truncate">Agent: {frameworkName}</span>
               </div>
             ) : null}
             {model ? (
               <div className="flex min-w-0 items-center gap-1.5" title={model}>
-                {provider && kindKey ? (
-                  <span
-                    data-slot="turn-runtime-model-detail-icon"
-                    aria-hidden="true"
-                    className="flex size-3 shrink-0 items-center justify-center"
-                  >
-                    <ProviderKindIcon kindKey={kindKey} className="size-2.5" />
-                  </span>
-                ) : null}
+                <span
+                  data-slot="turn-runtime-model-detail-icon"
+                  aria-hidden="true"
+                  className="flex size-3 shrink-0 items-center justify-center"
+                >
+                  <Brain className="size-2.5" strokeWidth={2} />
+                </span>
                 <span className="truncate">Model: {model}</span>
               </div>
             ) : null}


### PR DESCRIPTION
## Problem

The runtime detail rows added in #613 used framework and provider brand icons. Those icons identify the concrete runtime, but the rows need semantic labels matching Settings: Bot for Agent and Brain for Model.

## Proposed change

- Reuse the Lucide Bot and Brain icons already used by Settings.
- Keep the branded framework and provider icons in the Usage header.
- Render the Brain icon whenever a Model row is available, including when its provider no longer resolves.
- Assert the exact semantic SVG icons in the existing renderer test.

## Scope and non-goals

This changes presentation only. It does not change architecture, persisted data, runtime resolution, historical visibility, or interaction behavior.

## Acceptance criteria and validation

All checks below ran after the last material edit:

- Semantic Agent and Model detail icons -> `/Users/eweno/projects/aipoch/open-science/node_modules/.bin/vitest run src/renderer/src/pages/workspace/WorkspaceMessageItem.mentions.test.tsx` -> 20 passed.
- Type safety -> `npm run typecheck` -> passed.
- Lint -> `npm run lint` -> 0 errors; 19 existing warnings outside the changed files.
- Regression suite -> `npm test` -> 669 files passed, 15 skipped; 9,764 tests passed, 184 skipped.

Uncovered risk: no screenshot regression was added; the rendered icon components and classes are covered directly by the component test.

## Review focus

Confirm the bottom detail rows use fixed Bot and Brain semantics while the Usage header retains framework and provider branding.