### PR TITLE
refactor(acp): extract reviewer session owner

### DIFF
--- a/src/main/acp/reviewer-session-owner.ts
+++ b/src/main/acp/reviewer-session-owner.ts
@@ -1,0 +1,548 @@
+import * as acp from '@agentclientprotocol/sdk'
+import type {
+  ActiveSession,
+  ClientConnection,
+  McpServer,
+  RequestPermissionRequest,
+  RequestPermissionResponse
+} from '@agentclientprotocol/sdk'
+import { rmSync } from 'node:fs'
+import { mkdtemp } from 'node:fs/promises'
+import { tmpdir } from 'node:os'
+import { join } from 'node:path'
+
+import { REVIEWER_MCP_SERVER_NAME, REVIEWER_MCP_TOOLS } from '../../shared/reviewer'
+import type { AgentFrameworkId } from '../../shared/settings'
+import type { AgentFramework } from '../agent-framework'
+import { createLogger, diagnosticErrorFields } from '../logger'
+import { canonicalAppMcpServerName } from '../agent-framework/app-mcp-names'
+import { extractProviderToolName } from './runtime-events'
+
+const log = createLogger('acp')
+
+const REVIEWER_SESSION_ROLE = 'reviewer' as const
+
+const REVIEWER_MCP_OPENCODE_TOOL_NAMES = new Set(
+  Object.values(REVIEWER_MCP_TOOLS).map((toolName) => `${REVIEWER_MCP_SERVER_NAME}_${toolName}`)
+)
+const REVIEWER_MCP_LEAF_TOOL_NAMES = new Set<string>(Object.values(REVIEWER_MCP_TOOLS))
+const REVIEWER_MCP_SERVER_NAME_SANITIZED = REVIEWER_MCP_SERVER_NAME.replace(/[^a-zA-Z0-9]/g, '_')
+const REVIEWER_MCP_CLAUDE_TOOL_NAMES = new Set(
+  Object.values(REVIEWER_MCP_TOOLS).flatMap((toolName) =>
+    [REVIEWER_MCP_SERVER_NAME, REVIEWER_MCP_SERVER_NAME_SANITIZED].map(
+      (serverName) => `mcp__${serverName}__${toolName}`
+    )
+  )
+)
+const REVIEWER_MCP_PROVIDER_TOOL_NAMES = new Set([
+  ...REVIEWER_MCP_OPENCODE_TOOL_NAMES,
+  ...REVIEWER_MCP_CLAUDE_TOOL_NAMES
+])
+
+const errorMessage = (error: unknown): string => {
+  try {
+    const raw = error instanceof Error ? (error as { message?: unknown }).message : error
+    return typeof raw === 'string' ? raw : String(raw)
+  } catch {
+    return 'unknown error'
+  }
+}
+
+const safeLogError = (message: string, data?: unknown): void => {
+  try {
+    log.error(message, data)
+  } catch {
+    /* logging must never mask the real error */
+  }
+}
+
+export type ReviewerSessionRole = typeof REVIEWER_SESSION_ROLE
+
+export type ReviewerSessionRequest = {
+  cwd: string
+  mcpServers: McpServer[]
+  systemPromptAppend?: string
+}
+
+export type ReviewerSessionResult = {
+  session: ActiveSession
+  promptPrefix?: string
+  role: ReviewerSessionRole
+}
+
+export type ReviewerSessionDisposition = {
+  rejectedToolCalls: number
+  // Undefined for frameworks/providers that do not traverse the Responses bridge.
+  reviewerBridgeScoped: boolean | undefined
+}
+
+export type ReviewerSessionSnapshot = {
+  lifecycle: 'pending' | 'active'
+  role: ReviewerSessionRole
+  sessionId: string
+}
+
+export type ReviewerSessionContext = {
+  frameworkId: AgentFrameworkId
+  mcpServerNames: readonly string[]
+  role: ReviewerSessionRole
+}
+
+type ReviewerSessionIdentityReservation = {
+  generation: number
+  sessionId: string
+  token: symbol
+}
+
+type ReviewerSessionIdentityReservationResult =
+  | { reservation: ReviewerSessionIdentityReservation; collision?: never }
+  | { reservation?: never; collision: Error }
+
+type ActiveReviewerSessionOwner = ReviewerSessionContext & {
+  cwd: string
+  session: ActiveSession
+  sessionId: string
+  token: symbol
+}
+
+type ReviewerSessionCreationContext = {
+  connection: ClientConnection
+  framework: AgentFramework
+  sessionOptions: Record<string, unknown> | undefined
+  startupGeneration: number
+}
+
+export type ReviewerSessionOwnerDependencies = {
+  addStartupBlocker: (token: symbol) => void
+  clearPermissionCorrelations: (sessionId: string) => void
+  currentStartupGeneration: () => number
+  isPrimarySessionIdClaimed: (sessionId: string) => boolean
+  onActiveSessionReleased: () => void
+  registerBridgeSession: (sessionId: string) => void
+  removeStartupBlocker: (token: symbol) => void
+  unregisterBridgeSession: (sessionId: string) => boolean | undefined
+}
+
+// Owns every ephemeral Reviewer identity and resource. Primary session state remains in AcpRuntime;
+// the two owners collaborate only through the narrow collision and startup-blocker ports above.
+export class ReviewerSessionOwner {
+  private readonly activeById = new Map<string, ActiveReviewerSessionOwner>()
+  private readonly activeBySession = new WeakMap<ActiveSession, ActiveReviewerSessionOwner>()
+  private readonly pendingIds = new Map<string, symbol>()
+  private readonly rejectedToolCalls = new Map<string, number>()
+
+  constructor(private readonly dependencies: ReviewerSessionOwnerDependencies) {}
+
+  async create(
+    request: ReviewerSessionRequest,
+    prepare: () => Promise<ReviewerSessionCreationContext>
+  ): Promise<ReviewerSessionResult> {
+    const mcpServerNames = this.validateRequest(request)
+    const { connection, framework, sessionOptions, startupGeneration } = await prepare()
+    const reviewerCwd = await mkdtemp(join(tmpdir(), 'open-science-reviewer-'))
+    const setup = framework.buildSessionSetup({
+      systemPromptAppends: request.systemPromptAppend ? [request.systemPromptAppend] : [],
+      sessionOptions
+    })
+    const reviewerMeta: Record<string, unknown> = {
+      ...(setup.meta ?? {}),
+      // claude-agent-acp honors this legacy switch. Codex is independently restricted by the
+      // Responses bridge and the strict permission decision below.
+      disableBuiltInTools: true
+    }
+    if (framework.id === 'claude-code') {
+      const claudeCode =
+        typeof reviewerMeta.claudeCode === 'object' && reviewerMeta.claudeCode !== null
+          ? (reviewerMeta.claudeCode as Record<string, unknown>)
+          : {}
+      const claudeOptions =
+        typeof claudeCode.options === 'object' && claudeCode.options !== null
+          ? (claudeCode.options as Record<string, unknown>)
+          : {}
+      reviewerMeta.claudeCode = {
+        ...claudeCode,
+        options: { ...claudeOptions, tools: [] }
+      }
+    }
+
+    try {
+      const session = await connection.agent
+        .buildSession({
+          cwd: reviewerCwd,
+          mcpServers: request.mcpServers,
+          _meta: reviewerMeta
+        })
+        .start()
+      const reservationResult = this.reserveIdentity(session.sessionId, startupGeneration)
+      if (reservationResult.collision) {
+        this.disposeSessionAfterFailure(session, 'reviewer collision session disposal failed')
+        throw reservationResult.collision
+      }
+      const reservation = reservationResult.reservation
+      let identityActivated = false
+
+      try {
+        const permission = framework.mapPermissionProfile('ask', session.modes)
+        if (permission.modeId && permission.modeId !== session.modes?.currentModeId) {
+          await connection.agent.request(acp.methods.agent.session.setMode, {
+            sessionId: session.sessionId,
+            modeId: permission.modeId
+          })
+        }
+
+        this.activateIdentity(reservation, session, reviewerCwd, framework.id, mcpServerNames)
+        identityActivated = true
+        this.dependencies.registerBridgeSession(session.sessionId)
+
+        return { session, promptPrefix: setup.promptPrefix, role: REVIEWER_SESSION_ROLE }
+      } catch (error) {
+        let startupError = error
+        if (!identityActivated) {
+          try {
+            this.assertIdentityReservation(reservation)
+          } catch (supersededError) {
+            startupError = supersededError
+          }
+        }
+        this.releaseIdentityReservation(reservation)
+        const activeOwner = this.activeById.get(session.sessionId)
+        if (identityActivated && activeOwner?.session === session) {
+          this.activeById.delete(session.sessionId)
+          this.activeBySession.delete(session)
+          this.rejectedToolCalls.delete(session.sessionId)
+          try {
+            this.dependencies.unregisterBridgeSession(session.sessionId)
+          } catch (cleanupError) {
+            safeLogError('reviewer bridge registration rollback failed', {
+              ...diagnosticErrorFields(cleanupError),
+              sessionId: session.sessionId
+            })
+          }
+        }
+        this.disposeSessionAfterFailure(session, 'reviewer startup session disposal failed')
+        throw startupError
+      }
+    } catch (error) {
+      this.removeDirectory(reviewerCwd)
+      throw error
+    }
+  }
+
+  contextFor(sessionId: string): ReviewerSessionContext | undefined {
+    const owner = this.activeById.get(sessionId)
+    if (!owner) return undefined
+    return {
+      frameworkId: owner.frameworkId,
+      mcpServerNames: owner.mcpServerNames,
+      role: owner.role
+    }
+  }
+
+  snapshot(): ReviewerSessionSnapshot[] {
+    const active = [...this.activeById.keys()].map((sessionId): ReviewerSessionSnapshot => ({
+      lifecycle: 'active',
+      role: REVIEWER_SESSION_ROLE,
+      sessionId
+    }))
+    const pending = [...this.pendingIds.keys()]
+      .filter((sessionId) => !this.activeById.has(sessionId))
+      .map((sessionId): ReviewerSessionSnapshot => ({
+        lifecycle: 'pending',
+        role: REVIEWER_SESSION_ROLE,
+        sessionId
+      }))
+    return [...active, ...pending]
+  }
+
+  hasActiveSessions(): boolean {
+    return this.activeById.size > 0
+  }
+
+  hasActiveSessionId(sessionId: string): boolean {
+    return this.activeById.has(sessionId)
+  }
+
+  hasPendingSessionId(sessionId: string): boolean {
+    return this.pendingIds.has(sessionId)
+  }
+
+  resolvePermission(params: RequestPermissionRequest): RequestPermissionResponse | undefined {
+    const context = this.contextFor(params.sessionId)
+    if (!context) return undefined
+    const toolName = extractProviderToolName(params.toolCall)
+    const reportedTitle = params.toolCall.title
+    const opencodeToolName =
+      toolName == null &&
+      context.frameworkId === 'opencode' &&
+      typeof reportedTitle === 'string' &&
+      REVIEWER_MCP_OPENCODE_TOOL_NAMES.has(reportedTitle)
+        ? reportedTitle
+        : undefined
+    const codexToolName =
+      context.frameworkId === 'codex' &&
+      toolName != null &&
+      REVIEWER_MCP_LEAF_TOOL_NAMES.has(toolName) &&
+      reportedTitle === `mcp.${REVIEWER_MCP_SERVER_NAME}.${toolName}`
+        ? toolName
+        : undefined
+    const claudeToolName =
+      toolName == null &&
+      context.frameworkId === 'claude-code' &&
+      typeof reportedTitle === 'string' &&
+      REVIEWER_MCP_CLAUDE_TOOL_NAMES.has(reportedTitle)
+        ? reportedTitle
+        : undefined
+    const isReviewerMcp =
+      context.mcpServerNames.length === 1 &&
+      context.mcpServerNames[0] === REVIEWER_MCP_SERVER_NAME &&
+      ((toolName != null && REVIEWER_MCP_PROVIDER_TOOL_NAMES.has(toolName)) ||
+        opencodeToolName != null ||
+        codexToolName != null ||
+        claudeToolName != null)
+
+    if (!isReviewerMcp) {
+      const rejectOption =
+        params.options.find((option) => option.kind === 'reject_once') ??
+        params.options.find((option) => option.kind === 'reject_always')
+      this.rejectedToolCalls.set(
+        params.sessionId,
+        (this.rejectedToolCalls.get(params.sessionId) ?? 0) + 1
+      )
+      log.warn('rejecting non-reviewer tool requested by background reviewer', {
+        sessionId: params.sessionId,
+        tool: toolName ?? params.toolCall.kind,
+        toolCallId: params.toolCall?.toolCallId
+      })
+      return rejectOption
+        ? { outcome: { outcome: 'selected', optionId: rejectOption.optionId } }
+        : { outcome: { outcome: 'cancelled' } }
+    }
+
+    const allowOption =
+      params.options.find((option) => option.kind === 'allow_once') ??
+      params.options.find((option) => option.kind === 'allow_always')
+    if (!allowOption) {
+      log.warn('reviewer MCP permission request had no allow option; cancelling', {
+        sessionId: params.sessionId,
+        toolCallId: params.toolCall?.toolCallId
+      })
+      return { outcome: { outcome: 'cancelled' } }
+    }
+    log.debug('approving scope-bounded reviewer MCP tool call', {
+      sessionId: params.sessionId,
+      toolCallId: params.toolCall?.toolCallId,
+      optionId: allowOption.optionId
+    })
+    return { outcome: { outcome: 'selected', optionId: allowOption.optionId } }
+  }
+
+  dispose(session: ActiveSession): ReviewerSessionDisposition {
+    const cleanupFailures: unknown[] = []
+    const runCleanup = <Result>(stage: string, cleanup: () => Result): Result | undefined => {
+      try {
+        return cleanup()
+      } catch (cleanupError) {
+        cleanupFailures.push(cleanupError)
+        safeLogError('reviewer session cleanup failed', {
+          ...diagnosticErrorFields(cleanupError),
+          sessionId: session.sessionId,
+          stage
+        })
+        return undefined
+      }
+    }
+
+    const owner = this.activeBySession.get(session)
+    this.activeBySession.delete(session)
+    const ownsActiveIdentity =
+      owner !== undefined && this.activeById.get(owner.sessionId)?.token === owner.token
+    const rejectedToolCalls = ownsActiveIdentity
+      ? (this.rejectedToolCalls.get(owner.sessionId) ?? 0)
+      : 0
+    let reviewerBridgeScoped: boolean | undefined
+    if (ownsActiveIdentity && owner) {
+      this.activeById.delete(owner.sessionId)
+      reviewerBridgeScoped = runCleanup('bridge', () =>
+        this.unregisterBridgeSession(owner.sessionId)
+      )
+      runCleanup('permission-correlations', () =>
+        this.dependencies.clearPermissionCorrelations(owner.sessionId)
+      )
+      this.rejectedToolCalls.delete(owner.sessionId)
+    }
+
+    let disposeFailed = false
+    let disposeFailure: unknown
+    try {
+      session.dispose()
+    } catch (error) {
+      disposeFailed = true
+      disposeFailure = error
+    }
+
+    if (owner) this.removeDirectory(owner.cwd)
+    if (ownsActiveIdentity) {
+      runCleanup('reconnect-retirement', () => this.dependencies.onActiveSessionReleased())
+    }
+
+    if (disposeFailed) throw disposeFailure
+    if (cleanupFailures.length > 0) throw cleanupFailures[0]
+    return { rejectedToolCalls, reviewerBridgeScoped }
+  }
+
+  rejectedToolCallCount(sessionId: string): number {
+    return this.rejectedToolCalls.get(sessionId) ?? 0
+  }
+
+  invalidatePending(): void {
+    for (const token of this.pendingIds.values()) this.dependencies.removeStartupBlocker(token)
+    this.pendingIds.clear()
+  }
+
+  clear(): void {
+    this.invalidatePending()
+    for (const [sessionId, owner] of this.activeById) {
+      try {
+        this.unregisterBridgeSession(sessionId)
+      } catch (error) {
+        safeLogError('reviewer bridge cleanup after connection close failed', {
+          ...diagnosticErrorFields(error),
+          sessionId
+        })
+      }
+      this.removeDirectory(owner.cwd)
+      try {
+        this.dependencies.clearPermissionCorrelations(sessionId)
+      } catch (error) {
+        safeLogError('reviewer permission cleanup after connection close failed', {
+          ...diagnosticErrorFields(error),
+          sessionId
+        })
+      }
+      this.activeBySession.delete(owner.session)
+    }
+    this.activeById.clear()
+    this.rejectedToolCalls.clear()
+  }
+
+  private validateRequest(request: ReviewerSessionRequest): string[] {
+    const mcpServerNames = request.mcpServers
+      .map((server) => (server as { name?: unknown }).name)
+      .filter((name): name is string => typeof name === 'string')
+      .map(canonicalAppMcpServerName)
+    const reviewerMcp = request.mcpServers[0]
+    const reviewerMcpHttp =
+      reviewerMcp && 'type' in reviewerMcp && reviewerMcp.type === 'http' ? reviewerMcp : undefined
+    let reviewerMcpUrl: URL | undefined
+    try {
+      reviewerMcpUrl = reviewerMcpHttp ? new URL(reviewerMcpHttp.url) : undefined
+    } catch {
+      reviewerMcpUrl = undefined
+    }
+    if (
+      request.mcpServers.length !== 1 ||
+      mcpServerNames.length !== 1 ||
+      mcpServerNames[0] !== REVIEWER_MCP_SERVER_NAME ||
+      !reviewerMcpHttp ||
+      reviewerMcpUrl?.protocol !== 'http:' ||
+      reviewerMcpUrl.hostname !== '127.0.0.1'
+    ) {
+      throw new Error(
+        `Reviewer sessions require exactly one loopback HTTP ${REVIEWER_MCP_SERVER_NAME} MCP server.`
+      )
+    }
+    return mcpServerNames
+  }
+
+  private reserveIdentity(
+    sessionId: string,
+    generation: number
+  ): ReviewerSessionIdentityReservationResult {
+    if (generation !== this.dependencies.currentStartupGeneration()) {
+      return { collision: new Error('ACP session startup was superseded.') }
+    }
+    if (
+      this.dependencies.isPrimarySessionIdClaimed(sessionId) ||
+      this.activeById.has(sessionId) ||
+      this.pendingIds.has(sessionId)
+    ) {
+      return { collision: new Error(`Reviewer session id collision: ${sessionId}`) }
+    }
+    const reservation = {
+      generation,
+      sessionId,
+      token: Symbol('reviewer-session-identity')
+    } satisfies ReviewerSessionIdentityReservation
+    this.pendingIds.set(sessionId, reservation.token)
+    this.dependencies.addStartupBlocker(reservation.token)
+    return { reservation }
+  }
+
+  private activateIdentity(
+    reservation: ReviewerSessionIdentityReservation,
+    session: ActiveSession,
+    cwd: string,
+    frameworkId: AgentFrameworkId,
+    mcpServerNames: readonly string[]
+  ): void {
+    this.assertIdentityReservation(reservation)
+    this.pendingIds.delete(reservation.sessionId)
+    this.dependencies.removeStartupBlocker(reservation.token)
+    const owner = {
+      cwd,
+      frameworkId,
+      mcpServerNames,
+      role: REVIEWER_SESSION_ROLE,
+      session,
+      sessionId: reservation.sessionId,
+      token: reservation.token
+    } satisfies ActiveReviewerSessionOwner
+    this.activeById.set(reservation.sessionId, owner)
+    this.activeBySession.set(session, owner)
+    this.rejectedToolCalls.delete(reservation.sessionId)
+  }
+
+  private assertIdentityReservation(reservation: ReviewerSessionIdentityReservation): void {
+    if (
+      reservation.generation !== this.dependencies.currentStartupGeneration() ||
+      this.pendingIds.get(reservation.sessionId) !== reservation.token
+    ) {
+      throw new Error('ACP session startup was superseded.')
+    }
+  }
+
+  private releaseIdentityReservation(reservation: ReviewerSessionIdentityReservation): void {
+    this.dependencies.removeStartupBlocker(reservation.token)
+    if (this.pendingIds.get(reservation.sessionId) === reservation.token) {
+      this.pendingIds.delete(reservation.sessionId)
+    }
+  }
+
+  private unregisterBridgeSession(sessionId: string): boolean | undefined {
+    const scoped = this.dependencies.unregisterBridgeSession(sessionId)
+    if (scoped === false) log.error('reviewer bridge request was never scoped', { sessionId })
+    return scoped
+  }
+
+  private disposeSessionAfterFailure(session: ActiveSession, logMessage: string): void {
+    try {
+      session.dispose()
+    } catch (cleanupError) {
+      safeLogError(logMessage, {
+        ...diagnosticErrorFields(cleanupError),
+        sessionId: session.sessionId
+      })
+    }
+  }
+
+  private removeDirectory(reviewerCwd: string): void {
+    try {
+      rmSync(reviewerCwd, { recursive: true, force: true })
+    } catch (error) {
+      log.warn('failed to remove temporary reviewer directory', {
+        reviewerCwd,
+        error: errorMessage(error)
+      })
+    }
+  }
+}

--- a/src/main/acp/reviewer-session-owner.ts
+++ b/src/main/acp/reviewer-session-owner.ts
@@ -56,6 +56,14 @@ const safeLogError = (message: string, data?: unknown): void => {
   }
 }
 
+const safeLogWarn = (message: string, data?: unknown): void => {
+  try {
+    log.warn(message, data)
+  } catch {
+    /* logging must never interrupt lifecycle cleanup */
+  }
+}
+
 export type ReviewerSessionRole = typeof REVIEWER_SESSION_ROLE
 
 export type ReviewerSessionRequest = {
@@ -539,7 +547,7 @@ export class ReviewerSessionOwner {
     try {
       rmSync(reviewerCwd, { recursive: true, force: true })
     } catch (error) {
-      log.warn('failed to remove temporary reviewer directory', {
+      safeLogWarn('failed to remove temporary reviewer directory', {
         reviewerCwd,
         error: errorMessage(error)
       })

--- a/src/main/acp/runtime-activity.test.ts
+++ b/src/main/acp/runtime-activity.test.ts
@@ -21,7 +21,7 @@ const createActivityMock = (): Pick<
     // inspect it. Read it once to keep @typescript-eslint/no-unused-vars happy without changing
     // the contract shape.
     void req
-    return { session: { sessionId: 'reviewer-1' } } as Awaited<
+    return { role: 'reviewer', session: { sessionId: 'reviewer-1' } } as Awaited<
       ReturnType<AcpRuntime['buildReviewerSession']>
     >
   }),
@@ -102,6 +102,7 @@ describe('AcpRuntimeActivity', () => {
     })
 
     expect(result.built.session.sessionId).toBe('reviewer-1')
+    expect(result.built.role).toBe('reviewer')
     expect(result.sent.stopReason).toBe('end_turn')
     expect(mock.buildReviewerSession).toHaveBeenCalledOnce()
     expect(mock.sendPrompt).toHaveBeenCalledOnce()

--- a/src/main/acp/runtime.test.ts
+++ b/src/main/acp/runtime.test.ts
@@ -800,7 +800,6 @@ type ReviewerOwnerProbe = {
         role: 'reviewer'
       }
     | undefined
-  rejectedToolCalls: Map<string, number>
   snapshot: () => Array<{
     lifecycle: 'pending' | 'active'
     role: 'reviewer'
@@ -7266,7 +7265,6 @@ describe('ACP runtime session management', () => {
     }
     await runtime.buildReviewerSession(reviewerRequest)
     await runtime.buildReviewerSession(reviewerRequest)
-    reviewerOwnerProbe(runtime).rejectedToolCalls.set('reviewer-one', 2)
     const reviewerCwds = fakeAgent.newSessions.map(({ cwd }) => cwd)
     await runtime.requestProviderReconnect()
     const handleConnectionClosed = (
@@ -7278,7 +7276,6 @@ describe('ACP runtime session management', () => {
       expect(lease.unregisterReviewerSession).toHaveBeenCalledWith('reviewer-one')
       expect(lease.unregisterReviewerSession).toHaveBeenCalledWith('reviewer-two')
       expect(reviewerSessionIds(runtime).size).toBe(0)
-      expect(reviewerOwnerProbe(runtime).rejectedToolCalls.size).toBe(0)
       expect(
         (runtime as unknown as { reconnectBarrier?: Promise<void> }).reconnectBarrier
       ).toBeUndefined()

--- a/src/main/acp/runtime.test.ts
+++ b/src/main/acp/runtime.test.ts
@@ -792,12 +792,40 @@ const handleSessionUpdate = (runtime: AcpRuntime, notification: SessionNotificat
     }
   ).handleSessionUpdate(notification)
 
+type ReviewerOwnerProbe = {
+  contextFor: (sessionId: string) =>
+    | {
+        frameworkId: string
+        mcpServerNames: readonly string[]
+        role: 'reviewer'
+      }
+    | undefined
+  rejectedToolCalls: Map<string, number>
+  snapshot: () => Array<{
+    lifecycle: 'pending' | 'active'
+    role: 'reviewer'
+    sessionId: string
+  }>
+}
+
+const reviewerOwnerProbe = (runtime: AcpRuntime): ReviewerOwnerProbe =>
+  (runtime as unknown as { reviewerSessions: ReviewerOwnerProbe }).reviewerSessions
+
 const reviewerSessionIds = (runtime: AcpRuntime): Set<string> =>
-  (runtime as unknown as { reviewerSessionIds: Set<string> }).reviewerSessionIds
+  new Set(
+    reviewerOwnerProbe(runtime)
+      .snapshot()
+      .filter(({ lifecycle }) => lifecycle === 'active')
+      .map(({ sessionId }) => sessionId)
+  )
 
 const pendingReviewerSessionIds = (runtime: AcpRuntime): Map<string, symbol> =>
-  (runtime as unknown as { pendingReviewerSessionIds: Map<string, symbol> })
-    .pendingReviewerSessionIds
+  new Map(
+    reviewerOwnerProbe(runtime)
+      .snapshot()
+      .filter(({ lifecycle }) => lifecycle === 'pending')
+      .map(({ sessionId }) => [sessionId, Symbol.for(sessionId)])
+  )
 
 const pendingPrimarySessionIds = (runtime: AcpRuntime): Map<string, symbol> =>
   (runtime as unknown as { pendingPrimarySessionIds: Map<string, symbol> }).pendingPrimarySessionIds
@@ -6535,7 +6563,7 @@ describe('ACP runtime session management', () => {
     expect(mcpServerNamesMap(runtime).get('switched-session')).toEqual(['open-science-artifacts'])
   })
 
-  it('registers a reviewer session MCP names for auditing and clears them on dispose', async () => {
+  it('returns an explicit reviewer role while preserving MCP audit routing', async () => {
     infoLogSpy.mockClear()
     const process = new FakeAgentProcess()
     startPermissionProbeAgent(process, {
@@ -6552,7 +6580,7 @@ describe('ACP runtime session management', () => {
 
     // The reviewer session records its MCP server name so its (auto-approved) tool calls still audit
     // with the correct isMcp classification.
-    const { session } = await runtime.buildReviewerSession({
+    const built = await runtime.buildReviewerSession({
       cwd: '/workspace',
       mcpServers: [
         {
@@ -6563,19 +6591,100 @@ describe('ACP runtime session management', () => {
         }
       ]
     })
+    const { session } = built
+    expect(built.role).toBe('reviewer')
     expect(session.sessionId).toBe('reviewer-session-1')
-    expect(mcpServerNamesMap(runtime).has('reviewer-session-1')).toBe(true)
-    expect(sessionFrameworksMap(runtime).get('reviewer-session-1')).toBe('claude-code')
+    expect(reviewerOwnerProbe(runtime).contextFor('reviewer-session-1')).toEqual({
+      frameworkId: 'claude-code',
+      mcpServerNames: ['open-science-reviewer'],
+      role: 'reviewer'
+    })
+    expect(mcpServerNamesMap(runtime).has('reviewer-session-1')).toBe(false)
+    expect(sessionFrameworksMap(runtime).has('reviewer-session-1')).toBe(false)
 
     // Drive a tool-call permission request through the reviewer session (auto-approved by the runtime).
     await session.prompt([{ type: 'text', text: 'review this turn' }])
 
     expect(auditedIsMcp('reviewer-mcp')).toBe(true)
 
-    // Disposing the reviewer session unregisters its MCP names.
+    // Disposing the reviewer session clears only the owner-private invocation context.
     runtime.disposeReviewerSession(session)
+    expect(reviewerOwnerProbe(runtime).contextFor('reviewer-session-1')).toBeUndefined()
     expect(mcpServerNamesMap(runtime).has('reviewer-session-1')).toBe(false)
     expect(sessionFrameworksMap(runtime).has('reviewer-session-1')).toBe(false)
+  })
+
+  it('keeps reviewer ownership out of public primary state and capability hooks', async () => {
+    const process = new FakeAgentProcess()
+    startFakeAgent(process, ['primary-session', 'reviewer-session'])
+    const resolveSpecialistIdentity = vi.fn(async () => ({ append: '', prefix: '' }))
+    const resolveSpecialistSkills = vi.fn(async () => ({
+      kind: 'specialist' as const,
+      skillIds: [],
+      frameworkNames: [],
+      missingSkillIds: []
+    }))
+    const registerSessionSpecialist = vi.fn()
+    const onPermissionRequest = vi.fn()
+    const runtime = new AcpRuntime({
+      appVersion: '0.1.0',
+      defaultCwd: '/workspace',
+      spawnAgent: () => asAgentProcess(process),
+      resolveSpecialistIdentity,
+      resolveSpecialistSkills,
+      notebook: {
+        projectName: 'default-project',
+        mcpEntryPath: '/app/out/main/index.js',
+        getRpcConnection: async () => ({
+          endpoint: 'http://127.0.0.1:4567',
+          token: 'notebook-token'
+        }),
+        registerSessionSpecialist
+      },
+      callbacks: { onPermissionRequest }
+    })
+    await runtime.createSession({ cwd: '/workspace' })
+    resolveSpecialistIdentity.mockClear()
+    resolveSpecialistSkills.mockClear()
+    registerSessionSpecialist.mockClear()
+
+    const primaryProjection = (): object => {
+      const snapshot = runtime.getSnapshot()
+      return {
+        sessionId: snapshot.sessionId,
+        sessionIds: snapshot.sessionIds,
+        pendingPermissions: snapshot.pendingPermissions,
+        permissionProfiles: snapshot.permissionProfiles,
+        permissionGrants: snapshot.permissionGrants,
+        contextUsageBySession: snapshot.contextUsageBySession
+      }
+    }
+    const before = primaryProjection()
+    const built = await runtime.buildReviewerSession({
+      cwd: '/workspace',
+      mcpServers: [
+        {
+          type: 'http',
+          name: 'open-science-reviewer',
+          url: 'http://127.0.0.1:1/mcp',
+          headers: []
+        }
+      ]
+    })
+
+    expect(primaryProjection()).toEqual(before)
+    expect(reviewerOwnerProbe(runtime).snapshot()).toEqual([
+      { lifecycle: 'active', role: 'reviewer', sessionId: 'reviewer-session' }
+    ])
+    expect(reviewerOwnerProbe(runtime).snapshot()[0]).not.toHaveProperty('cwd')
+    expect(resolveSpecialistIdentity).not.toHaveBeenCalled()
+    expect(resolveSpecialistSkills).not.toHaveBeenCalled()
+    expect(registerSessionSpecialist).not.toHaveBeenCalled()
+    expect(onPermissionRequest).not.toHaveBeenCalled()
+
+    runtime.disposeReviewerSession(built.session)
+    expect(primaryProjection()).toEqual(before)
+    await runtime.disconnect()
   })
 
   it.each([
@@ -7157,9 +7266,7 @@ describe('ACP runtime session management', () => {
     }
     await runtime.buildReviewerSession(reviewerRequest)
     await runtime.buildReviewerSession(reviewerRequest)
-    ;(
-      runtime as unknown as { reviewerRejectedToolCalls: Map<string, number> }
-    ).reviewerRejectedToolCalls.set('reviewer-one', 2)
+    reviewerOwnerProbe(runtime).rejectedToolCalls.set('reviewer-one', 2)
     const reviewerCwds = fakeAgent.newSessions.map(({ cwd }) => cwd)
     await runtime.requestProviderReconnect()
     const handleConnectionClosed = (
@@ -7171,10 +7278,7 @@ describe('ACP runtime session management', () => {
       expect(lease.unregisterReviewerSession).toHaveBeenCalledWith('reviewer-one')
       expect(lease.unregisterReviewerSession).toHaveBeenCalledWith('reviewer-two')
       expect(reviewerSessionIds(runtime).size).toBe(0)
-      expect(
-        (runtime as unknown as { reviewerRejectedToolCalls: Map<string, number> })
-          .reviewerRejectedToolCalls.size
-      ).toBe(0)
+      expect(reviewerOwnerProbe(runtime).rejectedToolCalls.size).toBe(0)
       expect(
         (runtime as unknown as { reconnectBarrier?: Promise<void> }).reconnectBarrier
       ).toBeUndefined()

--- a/src/main/acp/runtime.ts
+++ b/src/main/acp/runtime.ts
@@ -13,9 +13,7 @@ import type {
 } from '@agentclientprotocol/sdk'
 import type { ChildProcessWithoutNullStreams } from 'node:child_process'
 import { randomUUID } from 'node:crypto'
-import { rmSync } from 'node:fs'
-import { mkdir, mkdtemp, readFile, stat, writeFile } from 'node:fs/promises'
-import { tmpdir } from 'node:os'
+import { mkdir, readFile, stat, writeFile } from 'node:fs/promises'
 import { dirname, join, resolve } from 'node:path'
 import { Readable, Writable } from 'node:stream'
 import { pathToFileURL } from 'node:url'
@@ -149,7 +147,12 @@ import type { ArtifactFile, FileReference } from '../../shared/artifacts'
 import type { ArtifactRpcCapabilityBinding } from '../../shared/artifact-provenance'
 import { isMediaOverflowError } from '../../shared/media-overflow'
 import type { AcpRuntimeActivity, AcpRuntimeActivityOptions } from './runtime-activity'
-import { REVIEWER_MCP_SERVER_NAME, REVIEWER_MCP_TOOLS } from '../../shared/reviewer'
+import {
+  ReviewerSessionOwner,
+  type ReviewerSessionDisposition,
+  type ReviewerSessionRequest,
+  type ReviewerSessionResult
+} from './reviewer-session-owner'
 import {
   buildImageContentData,
   canInlineImageInSession,
@@ -245,40 +248,6 @@ type AcpRuntimeSkillsOptions = {
   // Lists only enabled, materialized app-owned Skills from the active isolated Codex home. The
   // Chat Completions compatibility selector receives name + description; paths remain local.
   catalogForCodexHome?: (codexHome: string | undefined) => Promise<ResponsesBridgeSkillCandidate[]>
-}
-
-type ReviewerSessionRequest = {
-  cwd: string
-  mcpServers: McpServer[]
-  systemPromptAppend?: string
-}
-
-type ReviewerSessionResult = {
-  session: import('@agentclientprotocol/sdk').ActiveSession
-  promptPrefix?: string
-}
-
-type ReviewerSessionIdentityReservation = {
-  generation: number
-  sessionId: string
-  token: symbol
-}
-
-type ReviewerSessionIdentityReservationResult =
-  | { reservation: ReviewerSessionIdentityReservation; collision?: never }
-  | { reservation?: never; collision: Error }
-
-type ReviewerSessionOwner = {
-  cwd: string
-  session: ActiveSession
-  sessionId: string
-  token: symbol
-}
-
-export type ReviewerSessionDisposition = {
-  rejectedToolCalls: number
-  // Undefined for frameworks/providers that do not traverse the Responses bridge.
-  reviewerBridgeScoped: boolean | undefined
 }
 
 type PrimarySessionIdentityReservation = {
@@ -486,26 +455,6 @@ class SpawnFailure {
 
 const log = createLogger('acp')
 
-const REVIEWER_MCP_OPENCODE_TOOL_NAMES = new Set(
-  Object.values(REVIEWER_MCP_TOOLS).map((toolName) => `${REVIEWER_MCP_SERVER_NAME}_${toolName}`)
-)
-const REVIEWER_MCP_LEAF_TOOL_NAMES = new Set<string>(Object.values(REVIEWER_MCP_TOOLS))
-// claude-code namespaces MCP tools as mcp__<server>__<tool>. Depending on the provider path, the
-// server segment either preserves hyphens or replaces them with underscores. Match both exact forms:
-// the tool call title can be the only identity available to a permission request.
-const REVIEWER_MCP_SERVER_NAME_SANITIZED = REVIEWER_MCP_SERVER_NAME.replace(/[^a-zA-Z0-9]/g, '_')
-const REVIEWER_MCP_CLAUDE_TOOL_NAMES = new Set(
-  Object.values(REVIEWER_MCP_TOOLS).flatMap((toolName) =>
-    [REVIEWER_MCP_SERVER_NAME, REVIEWER_MCP_SERVER_NAME_SANITIZED].map(
-      (serverName) => `mcp__${serverName}__${toolName}`
-    )
-  )
-)
-const REVIEWER_MCP_PROVIDER_TOOL_NAMES = new Set([
-  ...REVIEWER_MCP_OPENCODE_TOOL_NAMES,
-  ...REVIEWER_MCP_CLAUDE_TOOL_NAMES
-])
-
 // Logs an error without ever throwing back into the caller. Used on failure paths where a throwing
 // logger (or a hostile payload) must never mask the original error being handled/re-thrown.
 const safeLogError = (message: string, data?: unknown): void => {
@@ -652,20 +601,9 @@ class AcpRuntime {
   // than hardcoded so it can't drift from what createMcpServers wires up.
   private readonly sessionMcpServerNames = new Map<string, string[]>()
   private readonly cancelledPromptTurnsBySession = new Map<string, number>()
-  // Ephemeral background reviewer sessions (built via buildReviewerSession). They are deliberately kept
-  // out of `this.sessions` — not tracked in the snapshot, not user-facing. Their permission requests are
-  // handled by a strict allowlist: only the scope-bounded reviewer MCP is approved; every built-in tool is
-  // rejected. Each session also gets an empty temporary cwd so ungated read-only tools see no project data.
-  private readonly reviewerSessionIds = new Set<string>()
-  private readonly reviewerSessionOwners = new Map<string, ReviewerSessionOwner>()
-  private readonly reviewerSessionOwnersBySession = new WeakMap<
-    ActiveSession,
-    ReviewerSessionOwner
-  >()
-  // Session/new returns an agent-owned id before the reviewer permission baseline has finished. Reserve
-  // that identity across the async mode switch so a concurrent reviewer cannot claim the same protocol
-  // route before either session has authority.
-  private readonly pendingReviewerSessionIds = new Map<string, symbol>()
+  // Ephemeral Reviewer identity, isolation, permission, and resource state lives behind one owner.
+  // Primary session registries remain here and collaborate through narrow collision/blocker ports.
+  private readonly reviewerSessions: ReviewerSessionOwner
   // A primary startup can know both its stable app id and its provider protocol id before it is ready
   // for publication. Tokens make multi-id reservations owner-aware so one concurrent startup can never
   // release another startup's identity.
@@ -680,11 +618,6 @@ class AcpRuntime {
   // is waiting for. Once it reaches the replacement connection, renewal adds its token here so any
   // later reconnect waits for publication or rollback.
   private readonly pendingSessionStartupBlockers = new Set<symbol>()
-  private readonly reviewerSessionDirectories = new Map<string, string>()
-  // Per reviewer session: count of tool calls the strict allowlist rejected. Lets the orchestrator
-  // distinguish "reviewer never called its tools" from "the gate blocked them" when a review ends
-  // without submit_findings, so the reported cause is accurate instead of misleading.
-  private readonly reviewerRejectedToolCalls = new Map<string, number>()
   // A replaced agent's own session id -> the app-facing id it was adopted under (after a provider
   // switch), so agent-origin events/permissions relabel into the conversation the renderer tracks.
   private readonly agentToAppSessionId = new Map<string, string>()
@@ -884,6 +817,22 @@ class AcpRuntime {
       onOpenCodeWaitTimeout: ({ sessionId, toolCallId, waitMs }) => {
         log.warn('OpenCode permission context wait timed out', { sessionId, toolCallId, waitMs })
       }
+    })
+    this.reviewerSessions = new ReviewerSessionOwner({
+      addStartupBlocker: (token) => this.pendingSessionStartupBlockers.add(token),
+      clearPermissionCorrelations: (sessionId) =>
+        this.permissionContext.clearCorrelationsForSession(sessionId),
+      currentStartupGeneration: () => this.sessionStartupGeneration,
+      isPrimarySessionIdClaimed: (sessionId) =>
+        this.sessions.has(sessionId) ||
+        this.agentToAppSessionId.has(sessionId) ||
+        this.pendingPrimarySessionIds.has(sessionId),
+      onActiveSessionReleased: () => this.maybeApplyPendingProviderReconnect(),
+      registerBridgeSession: (sessionId) =>
+        this.responsesBridgeLease?.registerReviewerSession(sessionId),
+      removeStartupBlocker: (token) => this.pendingSessionStartupBlockers.delete(token),
+      unregisterBridgeSession: (sessionId) =>
+        this.responsesBridgeLease?.unregisterReviewerSession(sessionId)
     })
   }
 
@@ -2942,7 +2891,7 @@ class AcpRuntime {
     return (
       this.promptInFlightSessionIds.size > 0 ||
       this.contextCompactionInFlightSessionIds.size > 0 ||
-      this.reviewerSessionIds.size > 0 ||
+      this.reviewerSessions.hasActiveSessions() ||
       this.pendingSessionStartupBlockers.size > 0 ||
       this.activityLeaseCount > 0
     )
@@ -3012,7 +2961,7 @@ class AcpRuntime {
     for (const controller of this.skillSelectorAbortControllers.values()) controller.abort()
     this.skillSelectorAbortControllers.clear()
     runCleanup('permission-context', () => this.permissionContext.dispose())
-    runCleanup('reviewer-state', () => this.clearReviewerSessionState())
+    runCleanup('reviewer-state', () => this.reviewerSessions.clear())
     this.promptInFlightSessionIds.clear()
     this.contextCompactionInFlightSessionIds.clear()
     // Context usage belongs to this live agent-context generation. Invalidate it before teardown,
@@ -5600,9 +5549,11 @@ class AcpRuntime {
     // tool identity (name/kind) and whether it looks like MCP — never the title (a WebFetch title is the
     // full URL with query params, i.e. user data).
     const appSessionId = this.agentToAppSessionId.get(params.sessionId) ?? params.sessionId
-    const mcpServerNames = this.sessionMcpServerNames.get(appSessionId) ?? []
+    const reviewerContext = this.reviewerSessions.contextFor(params.sessionId)
+    const mcpServerNames =
+      reviewerContext?.mcpServerNames ?? this.sessionMcpServerNames.get(appSessionId) ?? []
     const promptTurn = this.currentPromptTurnBySession.get(appSessionId)
-    const framework = this.sessionFrameworks.get(appSessionId)
+    const framework = reviewerContext?.frameworkId ?? this.sessionFrameworks.get(appSessionId)
     const isPermissionContextCancelled = (): boolean =>
       framework === 'opencode' &&
       (promptTurn === undefined
@@ -5642,12 +5593,10 @@ class AcpRuntime {
       // Background reviewer sessions run unattended and are intentionally absent from `this.sessions`.
       // Approve only their dedicated, scope-bounded MCP. Bash, filesystem, network, other MCP servers,
       // and unknown tools are rejected without involving the renderer.
-      if (this.reviewerSessionIds.has(params.sessionId)) {
-        return this.resolveReviewerPermission(
-          normalizedParams,
-          mcpServerNames,
-          this.sessionFrameworks.get(params.sessionId)
-        )
+      if (reviewerContext) {
+        const response = this.reviewerSessions.resolvePermission(normalizedParams)
+        if (response) return response
+        throw new Error(`Unknown ACP reviewer session: ${params.sessionId}`)
       }
 
       if (!this.sessions.has(appSessionId)) {
@@ -5694,11 +5643,13 @@ class AcpRuntime {
   // place where a preceding tool_call can reliably enrich a later sparse permission request.
   private observePermissionToolContext(notification: SessionNotification): void {
     const sessionId = this.agentToAppSessionId.get(notification.sessionId) ?? notification.sessionId
-    const framework = this.sessionFrameworks.get(sessionId)
+    const reviewerContext = this.reviewerSessions.contextFor(notification.sessionId)
+    const framework = reviewerContext?.frameworkId ?? this.sessionFrameworks.get(sessionId)
     this.permissionContext.observeToolCall(notification, {
       sessionId,
       framework,
-      mcpServerNames: this.sessionMcpServerNames.get(sessionId) ?? []
+      mcpServerNames:
+        reviewerContext?.mcpServerNames ?? this.sessionMcpServerNames.get(sessionId) ?? []
     })
   }
 
@@ -5706,100 +5657,6 @@ class AcpRuntime {
     const promptTurn = this.currentPromptTurnBySession.get(sessionId)
     if (promptTurn !== undefined) this.cancelledPromptTurnsBySession.set(sessionId, promptTurn)
     this.permissionContext.cancelForSession(sessionId)
-  }
-
-  // Returns the leaf reviewer tool name when a claude-code MCP *title* matches the reviewer. The
-  // identity must come from the title (the same field the generic MCP classifier trusts), never the
-  // toolCallId: a tool call id is an opaque, agent-chosen string, so matching it would let a Bash call
-  // carrying a reviewer-shaped id (e.g. mcp__open_science_reviewer__read_turn_0) slip past the gate.
-  // claude-code emits the exact mcp__<server>__<tool> form as the title with no numeric suffix, so an
-  // exact set membership check across its preserved and sanitized server-name forms is sufficient.
-  private matchReviewerClaudeToolName(title: string | null | undefined): string | undefined {
-    if (typeof title !== 'string') return undefined
-    return REVIEWER_MCP_CLAUDE_TOOL_NAMES.has(title) ? title : undefined
-  }
-
-  // Grants only the dedicated reviewer MCP. The old implementation selected the first available option
-  // for every reviewer request, which effectively approved Bash/network/filesystem tools. A denied call
-  // uses a one-shot reject when offered and otherwise cancels; it never falls through to an allow option.
-  private resolveReviewerPermission(
-    params: RequestPermissionRequest,
-    mcpServerNames: readonly string[],
-    frameworkId: string | undefined
-  ): RequestPermissionResponse {
-    const toolName = extractProviderToolName(params.toolCall)
-    const reportedTitle = params.toolCall.title
-    const opencodeToolName =
-      toolName == null &&
-      frameworkId === 'opencode' &&
-      typeof reportedTitle === 'string' &&
-      REVIEWER_MCP_OPENCODE_TOOL_NAMES.has(reportedTitle)
-        ? reportedTitle
-        : undefined
-    const codexToolName =
-      frameworkId === 'codex' &&
-      toolName != null &&
-      REVIEWER_MCP_LEAF_TOOL_NAMES.has(toolName) &&
-      reportedTitle === `mcp.${REVIEWER_MCP_SERVER_NAME}.${toolName}`
-        ? toolName
-        : undefined
-    // claude-code (and the OpenAI-compatible providers routed through it) emit reviewer MCP calls with
-    // no provider _meta tool name; the sanitized mcp__<server>__<tool> identity rides in the tool call
-    // title. Recognize it there — the same field the generic MCP classifier trusts — so the strict
-    // allowlist does not reject the reviewer's own tools. The toolCallId is deliberately not consulted:
-    // it is agent-controlled, so trusting it would let a Bash call with a reviewer-shaped id slip past.
-    const claudeToolName =
-      toolName == null && frameworkId === 'claude-code'
-        ? this.matchReviewerClaudeToolName(reportedTitle)
-        : undefined
-    const isReviewerMcp =
-      mcpServerNames.length === 1 &&
-      mcpServerNames[0] === REVIEWER_MCP_SERVER_NAME &&
-      ((toolName != null && REVIEWER_MCP_PROVIDER_TOOL_NAMES.has(toolName)) ||
-        opencodeToolName != null ||
-        codexToolName != null ||
-        claudeToolName != null)
-
-    if (!isReviewerMcp) {
-      const rejectOption =
-        params.options.find((option) => option.kind === 'reject_once') ??
-        params.options.find((option) => option.kind === 'reject_always')
-
-      this.reviewerRejectedToolCalls.set(
-        params.sessionId,
-        (this.reviewerRejectedToolCalls.get(params.sessionId) ?? 0) + 1
-      )
-
-      log.warn('rejecting non-reviewer tool requested by background reviewer', {
-        sessionId: params.sessionId,
-        tool: toolName ?? params.toolCall.kind,
-        toolCallId: params.toolCall?.toolCallId
-      })
-
-      return rejectOption
-        ? { outcome: { outcome: 'selected', optionId: rejectOption.optionId } }
-        : { outcome: { outcome: 'cancelled' } }
-    }
-
-    const allowOption =
-      params.options.find((option) => option.kind === 'allow_once') ??
-      params.options.find((option) => option.kind === 'allow_always')
-
-    if (!allowOption) {
-      log.warn('reviewer MCP permission request had no allow option; cancelling', {
-        sessionId: params.sessionId,
-        toolCallId: params.toolCall?.toolCallId
-      })
-      return { outcome: { outcome: 'cancelled' } }
-    }
-
-    log.debug('approving scope-bounded reviewer MCP tool call', {
-      sessionId: params.sessionId,
-      toolCallId: params.toolCall?.toolCallId,
-      optionId: allowOption.optionId
-    })
-
-    return { outcome: { outcome: 'selected', optionId: allowOption.optionId } }
   }
 
   // App-managed codex-acp emits the exact per-request numerator during generation. Codex's pinned
@@ -6169,7 +6026,7 @@ class AcpRuntime {
     for (const controller of this.skillSelectorAbortControllers.values()) controller.abort()
     this.skillSelectorAbortControllers.clear()
     this.permissionContext.dispose()
-    this.clearReviewerSessionState()
+    this.reviewerSessions.clear()
     this.releaseAllNotebookSessionCapabilities()
     this.sessions.clear()
     this.sessionCwds.clear()
@@ -6248,267 +6105,28 @@ class AcpRuntime {
     this.callbacks.onStateChanged?.(this.getSnapshot())
   }
 
-  private clearReviewerSessionState(): void {
-    for (const [sessionId, reviewerCwd] of this.reviewerSessionDirectories) {
-      try {
-        this.unregisterReviewerBridgeSession(sessionId)
-      } catch (error) {
-        safeLogError('reviewer bridge cleanup after connection close failed', {
-          ...diagnosticErrorFields(error),
-          sessionId
-        })
-      }
-      try {
-        this.removeReviewerDirectory(reviewerCwd)
-      } catch (error) {
-        safeLogError('reviewer directory cleanup after connection close failed', {
-          ...diagnosticErrorFields(error),
-          sessionId
-        })
-      }
-      try {
-        this.permissionContext.clearCorrelationsForSession(sessionId)
-      } catch (error) {
-        safeLogError('reviewer permission cleanup after connection close failed', {
-          ...diagnosticErrorFields(error),
-          sessionId
-        })
-      }
-      this.sessionFrameworks.delete(sessionId)
-    }
-    this.reviewerSessionDirectories.clear()
-    this.reviewerSessionOwners.clear()
-    this.reviewerSessionIds.clear()
-    this.reviewerRejectedToolCalls.clear()
-  }
-
-  private removeReviewerDirectory(reviewerCwd: string): void {
-    try {
-      rmSync(reviewerCwd, { recursive: true, force: true })
-    } catch (error) {
-      log.warn('failed to remove temporary reviewer directory', {
-        reviewerCwd,
-        error: errorMessage(error)
-      })
-    }
-  }
-
   // Creates an ephemeral reviewer ACP session using the existing agent connection. The reviewer
   // session is isolated from main agent sessions: it is not tracked in this.sessions, does not
   // appear in the snapshot, and callers are responsible for disposing it. This allows background
   // review to run in parallel with the main session without affecting the main state machine.
   async buildReviewerSession(request: ReviewerSessionRequest): Promise<ReviewerSessionResult> {
-    return this.withOperationLease(() => this.buildReviewerSessionOperation(request))
-  }
-
-  private async buildReviewerSessionOperation(
-    request: ReviewerSessionRequest
-  ): Promise<ReviewerSessionResult> {
-    // Used only to establish/reuse the shared agent connection. The reviewer session itself runs in an
-    // app-created empty temporary directory so built-in read tools cannot see the audited workspace.
-    const mcpServerNames = this.mcpServerNamesOf(request.mcpServers)
-    const reviewerMcp = request.mcpServers[0]
-    const reviewerMcpHttp =
-      reviewerMcp && 'type' in reviewerMcp && reviewerMcp.type === 'http' ? reviewerMcp : undefined
-    let reviewerMcpUrl: URL | undefined
-    try {
-      reviewerMcpUrl = reviewerMcpHttp ? new URL(reviewerMcpHttp.url) : undefined
-    } catch {
-      reviewerMcpUrl = undefined
-    }
-    if (
-      request.mcpServers.length !== 1 ||
-      mcpServerNames.length !== 1 ||
-      mcpServerNames[0] !== REVIEWER_MCP_SERVER_NAME ||
-      !reviewerMcpHttp ||
-      reviewerMcpUrl?.protocol !== 'http:' ||
-      reviewerMcpUrl.hostname !== '127.0.0.1'
-    ) {
-      throw new Error(
-        `Reviewer sessions require exactly one loopback HTTP ${REVIEWER_MCP_SERVER_NAME} MCP server.`
-      )
-    }
-
-    const connection = await this.ensureConnected(request.cwd)
-    this.assertCurrentConnectedConnection(connection)
-    const sessionStartupGeneration = this.sessionStartupGeneration
-    const reviewerCwd = await mkdtemp(join(tmpdir(), 'open-science-reviewer-'))
-
-    const setup = this.framework.buildSessionSetup({
-      systemPromptAppends: request.systemPromptAppend ? [request.systemPromptAppend] : [],
-      sessionOptions: this.pendingSessionOptions
-    })
-    const reviewerMeta: Record<string, unknown> = {
-      ...(setup.meta ?? {}),
-      // claude-agent-acp honors this legacy switch. codex-acp currently ignores it, so bridged
-      // Codex turns are independently restricted to reviewer MCP schemas at the bridge boundary.
-      disableBuiltInTools: true
-    }
-    if (this.framework.id === 'claude-code') {
-      const claudeCode =
-        typeof reviewerMeta.claudeCode === 'object' && reviewerMeta.claudeCode !== null
-          ? (reviewerMeta.claudeCode as Record<string, unknown>)
-          : {}
-      const claudeOptions =
-        typeof claudeCode.options === 'object' && claudeCode.options !== null
-          ? (claudeCode.options as Record<string, unknown>)
-          : {}
-      reviewerMeta.claudeCode = {
-        ...claudeCode,
-        options: { ...claudeOptions, tools: [] }
-      }
-    }
-
-    try {
-      const session = await connection.agent
-        .buildSession({
-          cwd: reviewerCwd,
-          mcpServers: request.mcpServers,
-          _meta: reviewerMeta
-        })
-        .start()
-
-      // Reviewer ids share protocol routing with primary/adopted sessions. An agent-provided
-      // collision must fail before the reviewer receives permission authority, bridge scope, or a
-      // prompt; otherwise its strict reviewer identity could overwrite state owned by a conversation.
-      const reservationResult = this.reserveReviewerSessionId(
-        session.sessionId,
-        sessionStartupGeneration
-      )
-      if (reservationResult.collision) {
-        this.disposeSessionAfterFailure(session, 'reviewer collision session disposal failed')
-        throw reservationResult.collision
-      }
-      const identityReservation = reservationResult.reservation
-      let identityActivated = false
-
-      try {
-        // Apply the framework's Ask baseline before prompting. The dedicated reviewer MCP is
-        // then selectively approved by resolveReviewerPermission; all other permission requests fail.
-        const permission = this.framework.mapPermissionProfile('ask', session.modes)
-        if (permission.modeId && permission.modeId !== session.modes?.currentModeId) {
-          await connection.agent.request(acp.methods.agent.session.setMode, {
-            sessionId: session.sessionId,
-            modeId: permission.modeId
-          })
+    return this.withOperationLease(() =>
+      this.reviewerSessions.create(request, async () => {
+        const connection = await this.ensureConnected(request.cwd)
+        this.assertCurrentConnectedConnection(connection)
+        return {
+          connection,
+          framework: this.framework,
+          sessionOptions: this.pendingSessionOptions,
+          startupGeneration: this.sessionStartupGeneration
         }
-
-        // No await separates the pending -> active transition: protocol routing always sees exactly
-        // one identity state. Bridge authority is granted only after the active reviewer route exists.
-        this.activateReviewerSessionIdentity(identityReservation, session, reviewerCwd)
-        identityActivated = true
-        this.responsesBridgeLease?.registerReviewerSession(session.sessionId)
-        this.reviewerSessionDirectories.set(session.sessionId, reviewerCwd)
-        this.sessionMcpServerNames.set(session.sessionId, mcpServerNames)
-        this.sessionFrameworks.set(session.sessionId, this.framework.id)
-
-        return { session, promptPrefix: setup.promptPrefix }
-      } catch (error) {
-        let startupError = error
-        if (!identityActivated) {
-          try {
-            this.assertReviewerSessionIdentityReservation(identityReservation)
-          } catch (supersededError) {
-            startupError = supersededError
-          }
-        }
-        this.releaseReviewerSessionIdentityReservation(identityReservation)
-        const activeOwner = this.reviewerSessionOwners.get(session.sessionId)
-        if (identityActivated && activeOwner?.session === session) {
-          this.reviewerSessionOwners.delete(session.sessionId)
-          this.reviewerSessionOwnersBySession.delete(session)
-          this.reviewerSessionIds.delete(session.sessionId)
-          this.reviewerRejectedToolCalls.delete(session.sessionId)
-          try {
-            this.responsesBridgeLease?.unregisterReviewerSession(session.sessionId)
-          } catch (cleanupError) {
-            safeLogError('reviewer bridge registration rollback failed', {
-              ...diagnosticErrorFields(cleanupError),
-              sessionId: session.sessionId
-            })
-          }
-        }
-        this.disposeSessionAfterFailure(session, 'reviewer startup session disposal failed')
-        throw startupError
-      }
-    } catch (error) {
-      this.removeReviewerDirectory(reviewerCwd)
-      throw error
-    }
-  }
-
-  private reserveReviewerSessionId(
-    sessionId: string,
-    generation: number
-  ): ReviewerSessionIdentityReservationResult {
-    if (generation !== this.sessionStartupGeneration) {
-      return { collision: new Error('ACP session startup was superseded.') }
-    }
-
-    if (
-      this.sessions.has(sessionId) ||
-      this.agentToAppSessionId.has(sessionId) ||
-      this.reviewerSessionIds.has(sessionId) ||
-      this.pendingReviewerSessionIds.has(sessionId) ||
-      this.pendingPrimarySessionIds.has(sessionId)
-    ) {
-      return { collision: new Error(`Reviewer session id collision: ${sessionId}`) }
-    }
-
-    const reservation = {
-      generation,
-      sessionId,
-      token: Symbol('reviewer-session-identity')
-    } satisfies ReviewerSessionIdentityReservation
-    this.pendingReviewerSessionIds.set(sessionId, reservation.token)
-    this.pendingSessionStartupBlockers.add(reservation.token)
-    return { reservation }
-  }
-
-  private activateReviewerSessionIdentity(
-    reservation: ReviewerSessionIdentityReservation,
-    session: ActiveSession,
-    cwd: string
-  ): void {
-    this.assertReviewerSessionIdentityReservation(reservation)
-
-    this.pendingReviewerSessionIds.delete(reservation.sessionId)
-    this.pendingSessionStartupBlockers.delete(reservation.token)
-    const owner = {
-      cwd,
-      session,
-      sessionId: reservation.sessionId,
-      token: reservation.token
-    } satisfies ReviewerSessionOwner
-    this.reviewerSessionOwners.set(reservation.sessionId, owner)
-    this.reviewerSessionOwnersBySession.set(session, owner)
-    this.reviewerRejectedToolCalls.delete(reservation.sessionId)
-    this.reviewerSessionIds.add(reservation.sessionId)
-  }
-
-  private assertReviewerSessionIdentityReservation(
-    reservation: ReviewerSessionIdentityReservation
-  ): void {
-    if (
-      reservation.generation !== this.sessionStartupGeneration ||
-      this.pendingReviewerSessionIds.get(reservation.sessionId) !== reservation.token
-    ) {
-      throw new Error('ACP session startup was superseded.')
-    }
-  }
-
-  private releaseReviewerSessionIdentityReservation(
-    reservation: ReviewerSessionIdentityReservation
-  ): void {
-    this.pendingSessionStartupBlockers.delete(reservation.token)
-    if (this.pendingReviewerSessionIds.get(reservation.sessionId) === reservation.token) {
-      this.pendingReviewerSessionIds.delete(reservation.sessionId)
-    }
+      })
+    )
   }
 
   private invalidatePendingSessionStartups(): void {
     this.sessionStartupGeneration += 1
-    this.pendingReviewerSessionIds.clear()
+    this.reviewerSessions.invalidatePending()
     this.pendingPrimarySessionIds.clear()
     this.pendingSessionStartupBlockers.clear()
   }
@@ -6536,7 +6154,7 @@ class AcpRuntime {
       }
     }
     const pendingReviewerCollision = uniqueSessionIds.find((sessionId) =>
-      this.pendingReviewerSessionIds.has(sessionId)
+      this.reviewerSessions.hasPendingSessionId(sessionId)
     )
     if (pendingReviewerCollision) {
       return {
@@ -6547,7 +6165,7 @@ class AcpRuntime {
     }
 
     const activeReviewerCollision = uniqueSessionIds.find((sessionId) =>
-      this.reviewerSessionIds.has(sessionId)
+      this.reviewerSessions.hasActiveSessionId(sessionId)
     )
     if (activeReviewerCollision) {
       return {
@@ -6702,80 +6320,15 @@ class AcpRuntime {
   disposeReviewerSession(
     session: import('@agentclientprotocol/sdk').ActiveSession
   ): ReviewerSessionDisposition {
-    const cleanupFailures: unknown[] = []
-    const runCleanup = <Result>(stage: string, cleanup: () => Result): Result | undefined => {
-      try {
-        return cleanup()
-      } catch (cleanupError) {
-        cleanupFailures.push(cleanupError)
-        safeLogError('reviewer session cleanup failed', {
-          ...diagnosticErrorFields(cleanupError),
-          sessionId: session.sessionId,
-          stage
-        })
-        return undefined
-      }
-    }
-
-    const owner = this.reviewerSessionOwnersBySession.get(session)
-    this.reviewerSessionOwnersBySession.delete(session)
-    const ownsActiveIdentity =
-      owner !== undefined && this.reviewerSessionOwners.get(owner.sessionId)?.token === owner.token
-    const rejectedToolCalls = ownsActiveIdentity
-      ? (this.reviewerRejectedToolCalls.get(session.sessionId) ?? 0)
-      : 0
-    let reviewerBridgeScoped: boolean | undefined
-    if (ownsActiveIdentity) {
-      this.reviewerSessionOwners.delete(session.sessionId)
-      this.reviewerSessionIds.delete(session.sessionId)
-      reviewerBridgeScoped = runCleanup('bridge', () =>
-        this.unregisterReviewerBridgeSession(session.sessionId)
-      )
-      this.sessionMcpServerNames.delete(session.sessionId)
-      runCleanup('permission-correlations', () =>
-        this.permissionContext.clearCorrelationsForSession(session.sessionId)
-      )
-      this.sessionFrameworks.delete(session.sessionId)
-      this.reviewerRejectedToolCalls.delete(session.sessionId)
-      this.reviewerSessionDirectories.delete(session.sessionId)
-    }
-    const reviewerCwd = owner?.cwd
-
-    let disposeFailed = false
-    let disposeFailure: unknown
-    try {
-      session.dispose()
-    } catch (error) {
-      disposeFailed = true
-      disposeFailure = error
-    }
-
-    if (reviewerCwd) this.removeReviewerDirectory(reviewerCwd)
-    if (ownsActiveIdentity) {
-      runCleanup('reconnect-retirement', () => this.maybeApplyPendingProviderReconnect())
-    }
-
-    // Session disposal is the primary lifecycle failure. Every authority/resource cleanup above still
-    // runs, and any secondary failure is reported without replacing the error the caller must handle.
-    if (disposeFailed) throw disposeFailure
-    if (cleanupFailures.length > 0) throw cleanupFailures[0]
-
-    return { rejectedToolCalls, reviewerBridgeScoped }
-  }
-
-  private unregisterReviewerBridgeSession(sessionId: string): boolean | undefined {
-    const scoped = this.responsesBridgeLease?.unregisterReviewerSession(sessionId)
-    if (scoped === false) {
-      log.error('reviewer bridge request was never scoped', { sessionId })
-    }
-    return scoped
+    return this.reviewerSessions.dispose(session)
   }
 
   // Returns how many permission requests the strict reviewer gate rejected for a given reviewer
   // session. Non-zero means the session was active but the gate blocked its tool calls.
   reviewerRejectedToolCallCount(sessionId: string): number {
-    return this.reviewerRejectedToolCalls.get(sessionId) ?? 0
+    return this.reviewerSessions.rejectedToolCallCount(sessionId)
   }
 }
 
 export { AcpRuntime }
+export type { ReviewerSessionDisposition } from './reviewer-session-owner'


### PR DESCRIPTION
## Problem

Ephemeral Reviewer identity, permission routing, temporary isolation, bridge authority, and disposal were owned directly by the already-large ACP runtime. That mixed Reviewer lifecycle state with Primary session state and made the A3.0 safety invariants harder to review as one unit.

## Proposed change

- Add a main-process `ReviewerSessionOwner` that owns pending and active Reviewer identities, concrete ActiveSession ownership, temporary cwd resources, strict Reviewer MCP permission decisions, rejection counts, bridge registration, and disposal/connection-close cleanup.
- Keep `AcpRuntime` as the unchanged facade for Reviewer orchestration while it supplies narrow Primary collision and reconnect-blocker ports.
- Expose an internal ephemeral `role: reviewer` result and owner-private diagnostic snapshot for future capability decisions.
- Stop storing Reviewer framework and MCP routing metadata in the ordinary Primary session maps.

```mermaid
flowchart LR
  Orchestrator[Reviewer orchestrator] --> Runtime[AcpRuntime facade]
  Runtime --> Owner[ReviewerSessionOwner]
  Owner --> ACP[ACP ActiveSession]
  Owner --> Gate[Strict Reviewer permission gate]
  Owner --> Bridge[Responses bridge scope]
  Runtime -. read-only collision port .-> Primary[Primary session registry]
```

## Scope and non-goals

- No persisted role, Session relationship, database, conversation graph, IPC, Web RPC, preload, CLI, Task API, or UI change.
- Reviewer remains available through the existing Electron, local Web, and remote Web flows; CLI and Task gain no Reviewer management API.
- Specialist, ordinary Permission profiles/grants, and Compute availability remain unchanged.
- Related to #458 only as a forward-compatible leaf Reviewer seam. This does not implement delegation, child Sessions, orchestration state, budgets, permission ceilings, tools, or events.

## Acceptance criteria and validation

All listed checks ran after the final material edit on head `177b0fb`.

- Reviewer identity, isolation, strict permission, collision, generation, late-dispose, reconnect, retirement, and cleanup behavior -> `npm test -- --run src/main/acp/runtime.test.ts` -> 359 passed.
- Internal Reviewer role and narrow activity facade -> `npm test -- --run src/main/acp/runtime-activity.test.ts` -> 5 passed.
- Reviewer orchestration plus Electron/Web/remote/Task/CLI compatibility -> targeted 10-file Vitest matrix -> 118 passed.
- Repository behavior -> `npm test -- --run` -> 669 files passed, 15 skipped; 9,838 tests passed, 184 skipped.
- Node and Web contracts -> `npm run typecheck` -> passed.
- Repository style -> `npm run lint` -> 0 errors; 19 pre-existing warnings outside this diff.
- Independent Spec and Standards re-review -> P0/P1/P2 = 0/0/0.

The remaining uncovered risk is the exact operating-system failure combination where recursive temp-directory removal and logging both fail simultaneously. The cleanup helper is now total and independently reviewed, while existing tests cover the surrounding best-effort cleanup behavior.

## Review focus

- Pending-to-active identity transition remains generation/token fenced with no await before authority registration.
- An old same-ID ActiveSession cannot remove a successor owner or bridge scope.
- Reviewer permission remains fail-closed for every tool except the exact dedicated Reviewer MCP methods across Claude Code, OpenCode, and Codex.
- Owner-private role/snapshot data never enters `AcpStateSnapshot`, persistence, or shared wire types.
- Connection-close and explicit dispose remain distinct cleanup paths, and primary Session disposal errors retain precedence.
