### PR TITLE
refactor(acp): extract artifact turn owner

### DIFF
--- a/src/main/acp/artifact-turn-owner.test.ts
+++ b/src/main/acp/artifact-turn-owner.test.ts
@@ -1,4 +1,4 @@
-import { mkdtemp, readFile, rm, writeFile } from 'node:fs/promises'
+import { mkdir, mkdtemp, readFile, rm, writeFile } from 'node:fs/promises'
 import { tmpdir } from 'node:os'
 import { join } from 'node:path'
 
@@ -325,10 +325,20 @@ describe('ArtifactTurnOwner', () => {
   it('clears active ownership even when capability revocation fails', async () => {
     const dataRoot = await createRoot()
     const notebookContexts: unknown[] = []
+    const writeStarted = createDeferred()
+    const releaseWrite = createDeferred()
     const owner = new ArtifactTurnOwner({
       dataRoot,
       repository: new ArtifactRepository(dataRoot),
       runRegistry: new ArtifactRunRegistry(),
+      provenance: {
+        listRunVersions: async () => [],
+        writeAppGeneratedVersion: async () => {
+          writeStarted.resolve()
+          await releaseWrite.promise
+          return artifactVersion()
+        }
+      },
       issueRpcCapability: () => 'capability-1',
       revokeRpcCapability: async () => {
         throw new Error('revoke failed')
@@ -343,17 +353,231 @@ describe('ArtifactTurnOwner', () => {
       projectId: 'project-1',
       agentName: 'Codex'
     })
+    const acceptedWrite = owner.writeForActiveTurn('session-1', {
+      filename: 'accepted.txt',
+      content: 'accepted'
+    })
+    await writeStarted.promise
     const currentRunFile = getArtifactCurrentRunFilePath(
       dataRoot,
       'project-1',
       'artifact-session-1'
     )
 
-    await expect(owner.dispose(turn)).rejects.toThrow('revoke failed')
+    const disposal = owner.dispose(turn)
+    let disposalSettled = false
+    void disposal.then(
+      () => {
+        disposalSettled = true
+      },
+      () => {
+        disposalSettled = true
+      }
+    )
+    await Promise.resolve()
+    expect(disposalSettled).toBe(false)
 
+    releaseWrite.resolve()
+    await acceptedWrite
+    await expect(disposal).rejects.toThrow('revoke failed')
+
+    expect(disposalSettled).toBe(true)
     expect(owner.activeRunIds()).toEqual([])
     await expect(readFile(currentRunFile, 'utf8')).resolves.toBe('{}\n')
     expect(notebookContexts.at(-1)).toBeUndefined()
+  })
+
+  it('clears a stale turn handoff when its replacement uses a different storage Session', async () => {
+    const dataRoot = await createRoot()
+    const owner = new ArtifactTurnOwner({
+      dataRoot,
+      repository: new ArtifactRepository(dataRoot),
+      runRegistry: new ArtifactRunRegistry()
+    })
+    const first = await owner.open({
+      appSessionId: 'session-1',
+      artifactStorageSessionId: 'artifact-session-provisional',
+      projectId: 'project-1',
+      agentName: 'Codex'
+    })
+    const replacement = await owner.open({
+      appSessionId: 'session-1',
+      artifactStorageSessionId: 'session-1',
+      projectId: 'project-1',
+      agentName: 'Codex'
+    })
+    const firstHandoff = getArtifactCurrentRunFilePath(
+      dataRoot,
+      'project-1',
+      'artifact-session-provisional'
+    )
+    const replacementHandoff = getArtifactCurrentRunFilePath(dataRoot, 'project-1', 'session-1')
+
+    await owner.dispose(first)
+
+    await expect(readFile(firstHandoff, 'utf8')).resolves.toBe('{}\n')
+    await expect(readFile(replacementHandoff, 'utf8')).resolves.toContain('artifact-run-')
+    expect(owner.activeRunIds()).toHaveLength(1)
+    await owner.dispose(replacement)
+  })
+
+  it('retries failed claim preparation without duplicating a successful claim', async () => {
+    const dataRoot = await createRoot()
+    const repository = new ArtifactRepository(dataRoot)
+    const runRegistry = new ArtifactRunRegistry()
+    const register = vi.spyOn(runRegistry, 'register')
+    const listRunVersions = vi
+      .fn()
+      .mockRejectedValueOnce(new Error('temporary list failure'))
+      .mockResolvedValue([artifactVersion()])
+    const owner = new ArtifactTurnOwner({
+      dataRoot,
+      repository,
+      runRegistry,
+      provenance: {
+        listRunVersions,
+        writeAppGeneratedVersion: async () => artifactVersion()
+      }
+    })
+    const turn = await owner.open({
+      appSessionId: 'session-1',
+      artifactStorageSessionId: 'artifact-session-1',
+      projectId: 'project-1',
+      agentName: 'Codex'
+    })
+
+    await expect(owner.finalize(turn)).rejects.toThrow('temporary list failure')
+    await expect(owner.finalize(turn)).resolves.toMatchObject({
+      artifactClaimId: expect.stringMatching(/^artifact-claim-/)
+    })
+
+    expect(listRunVersions).toHaveBeenCalledTimes(2)
+    expect(register).toHaveBeenCalledOnce()
+    await owner.dispose(turn)
+  })
+
+  it('serializes finalization with disposal and never reopens a disposed turn', async () => {
+    const dataRoot = await createRoot()
+    const listStarted = createDeferred()
+    const releaseList = createDeferred()
+    const owner = new ArtifactTurnOwner({
+      dataRoot,
+      repository: new ArtifactRepository(dataRoot),
+      runRegistry: new ArtifactRunRegistry(),
+      provenance: {
+        listRunVersions: async () => {
+          listStarted.resolve()
+          await releaseList.promise
+          return [artifactVersion()]
+        },
+        writeAppGeneratedVersion: async () => artifactVersion()
+      }
+    })
+    const turn = await owner.open({
+      appSessionId: 'session-1',
+      artifactStorageSessionId: 'artifact-session-1',
+      projectId: 'project-1',
+      agentName: 'Codex'
+    })
+    const finalization = owner.finalize(turn)
+    await listStarted.promise
+    const disposal = owner.dispose(turn)
+    let disposalSettled = false
+    void disposal.then(() => {
+      disposalSettled = true
+    })
+
+    await Promise.resolve()
+    expect(disposalSettled).toBe(false)
+    releaseList.resolve()
+    const publication = await finalization
+    await disposal
+
+    expect(owner.snapshot(turn).phase).toBe('disposed')
+    await expect(owner.finalize(turn)).resolves.toBe(publication)
+    expect(owner.snapshot(turn).phase).toBe('disposed')
+
+    const disposedWithoutFinalization = await owner.open({
+      appSessionId: 'session-2',
+      artifactStorageSessionId: 'artifact-session-2',
+      projectId: 'project-1',
+      agentName: 'Codex'
+    })
+    await owner.dispose(disposedWithoutFinalization)
+    await expect(owner.finalize(disposedWithoutFinalization)).rejects.toThrow(/disposed/i)
+  })
+
+  it('clears a written handoff when Notebook provenance setup fails', async () => {
+    const dataRoot = await createRoot()
+    const contexts: unknown[] = []
+    const revoked: string[] = []
+    const owner = new ArtifactTurnOwner({
+      dataRoot,
+      repository: new ArtifactRepository(dataRoot),
+      runRegistry: new ArtifactRunRegistry(),
+      issueRpcCapability: () => 'capability-1',
+      revokeRpcCapability: (token) => {
+        revoked.push(token)
+        throw new Error('cleanup revoke failed')
+      },
+      notebook: {
+        setArtifactProvenanceContext: (_sessionId, context) => {
+          contexts.push(context)
+          if (context) throw new Error('Notebook context failed')
+        }
+      }
+    })
+    const currentRunFile = getArtifactCurrentRunFilePath(
+      dataRoot,
+      'project-1',
+      'artifact-session-1'
+    )
+
+    await expect(
+      owner.open({
+        appSessionId: 'session-1',
+        artifactStorageSessionId: 'artifact-session-1',
+        projectId: 'project-1',
+        agentName: 'Codex'
+      })
+    ).rejects.toThrow('Notebook context failed')
+
+    await expect(readFile(currentRunFile, 'utf8')).resolves.toBe('{}\n')
+    expect(contexts.at(-1)).toBeUndefined()
+    expect(revoked).toEqual(['capability-1'])
+    expect(owner.activeRunIds()).toEqual([])
+  })
+
+  it('clears Notebook context and ownership when handoff cleanup fails', async () => {
+    const dataRoot = await createRoot()
+    const contexts: unknown[] = []
+    const owner = new ArtifactTurnOwner({
+      dataRoot,
+      repository: new ArtifactRepository(dataRoot),
+      runRegistry: new ArtifactRunRegistry(),
+      notebook: {
+        setArtifactProvenanceContext: (_sessionId, context) => contexts.push(context)
+      }
+    })
+    const turn = await owner.open({
+      appSessionId: 'session-1',
+      artifactStorageSessionId: 'artifact-session-1',
+      projectId: 'project-1',
+      agentName: 'Codex'
+    })
+    const currentRunFile = getArtifactCurrentRunFilePath(
+      dataRoot,
+      'project-1',
+      'artifact-session-1'
+    )
+    await rm(currentRunFile)
+    await mkdir(currentRunFile)
+
+    await expect(owner.dispose(turn)).rejects.toThrow()
+
+    expect(contexts.at(-1)).toBeUndefined()
+    expect(owner.activeRunIds()).toEqual([])
+    expect(owner.snapshot(turn).phase).toBe('disposed')
   })
 
   it('revokes a capability and publishes no active state when opening the handoff fails', async () => {

--- a/src/main/acp/artifact-turn-owner.test.ts
+++ b/src/main/acp/artifact-turn-owner.test.ts
@@ -1,0 +1,395 @@
+import { mkdtemp, readFile, rm, writeFile } from 'node:fs/promises'
+import { tmpdir } from 'node:os'
+import { join } from 'node:path'
+
+import { afterEach, describe, expect, it, vi } from 'vitest'
+
+import type { ArtifactFile } from '../../shared/artifacts'
+import { ArtifactRepository, getArtifactCurrentRunFilePath } from '../artifacts/repository'
+import { ArtifactRunRegistry } from '../artifacts/run-registry'
+import { ArtifactTurnOwner } from './artifact-turn-owner'
+
+const roots: string[] = []
+
+const createRoot = async (): Promise<string> => {
+  const root = await mkdtemp(join(tmpdir(), 'artifact-turn-owner-'))
+  roots.push(root)
+  return root
+}
+
+const createDeferred = <T = void>(): {
+  promise: Promise<T>
+  resolve: (value: T) => void
+  reject: (reason?: unknown) => void
+} => {
+  let resolve!: (value: T) => void
+  let reject!: (reason?: unknown) => void
+  const promise = new Promise<T>((resolvePromise, rejectPromise) => {
+    resolve = resolvePromise
+    reject = rejectPromise
+  })
+  return { promise, resolve, reject }
+}
+
+const artifactVersion = (overrides: Partial<ArtifactFile> = {}): ArtifactFile => ({
+  id: 'version-1',
+  name: 'result.txt',
+  path: '/managed/result.txt',
+  fileUrl: 'file:///managed/result.txt',
+  mimeType: 'text/plain',
+  size: 6,
+  mtimeMs: 1,
+  projectName: 'project-1',
+  sessionId: 'artifact-session-1',
+  runId: 'artifact-run-1',
+  versionId: 'version-1',
+  ...overrides
+})
+
+afterEach(async () => {
+  await Promise.all(roots.splice(0).map((root) => rm(root, { recursive: true, force: true })))
+})
+
+describe('ArtifactTurnOwner', () => {
+  it('opens a turn-scoped handoff without exposing its capability or local path in snapshots', async () => {
+    const dataRoot = await createRoot()
+    const issuedBindings: unknown[] = []
+    const notebookContexts: unknown[] = []
+    const owner = new ArtifactTurnOwner({
+      dataRoot,
+      repository: new ArtifactRepository(dataRoot),
+      runRegistry: new ArtifactRunRegistry(),
+      runtimeInstanceId: 'runtime-1',
+      now: () => 123,
+      issueRpcCapability: (binding) => {
+        issuedBindings.push(binding)
+        return 'secret-capability'
+      },
+      notebook: {
+        setArtifactProvenanceContext: (_sessionId, context) => notebookContexts.push(context)
+      }
+    })
+
+    const turn = await owner.open({
+      appSessionId: 'session-1',
+      artifactStorageSessionId: 'artifact-session-1',
+      projectId: 'project-1',
+      agentName: 'Claude Code',
+      provenanceContext: {
+        rootFrameId: 'root-1',
+        agentFrameId: 'agent-1',
+        messageBranchId: 'branch-1',
+        messageBranchAncestry: ['branch-parent'],
+        messageAncestry: ['message-parent', 'prompt-1'],
+        runtimeSegmentId: 'segment-1',
+        promptMessageId: 'prompt-1'
+      }
+    })
+
+    expect(owner.activeRunIds()).toEqual(['artifact-run-123-1'])
+    expect(owner.promptMessageIdFor('session-1')).toBe('prompt-1')
+    expect(issuedBindings).toEqual([
+      expect.objectContaining({
+        projectId: 'project-1',
+        appSessionId: 'session-1',
+        artifactStorageSessionId: 'artifact-session-1',
+        artifactRunId: 'artifact-run-123-1',
+        notebookSessionId: 'session-1',
+        allowedMethods: ['artifactCreateVersion', 'artifactReplayVersion']
+      })
+    ])
+    expect(notebookContexts).toEqual([
+      {
+        rootFrameId: 'root-1',
+        agentFrameId: 'agent-1',
+        messageBranchId: 'branch-1',
+        runtimeSegmentId: 'segment-1',
+        promptMessageId: 'prompt-1'
+      }
+    ])
+
+    const currentRunFile = getArtifactCurrentRunFilePath(
+      dataRoot,
+      'project-1',
+      'artifact-session-1'
+    )
+    const handoff = JSON.parse(await readFile(currentRunFile, 'utf8')) as Record<string, unknown>
+    expect(handoff).toMatchObject({
+      artifactRunId: 'artifact-run-123-1',
+      rpcCapabilityToken: 'secret-capability',
+      notebookSessionId: 'session-1',
+      notebookDataDir: join(dataRoot, 'notebooks', 'project-1', 'session-1', 'data'),
+      notebookSessionRoot: join(dataRoot, 'notebooks', 'project-1', 'session-1')
+    })
+
+    const snapshot = owner.snapshot(turn)
+    expect(snapshot).toEqual({
+      appSessionId: 'session-1',
+      runId: 'artifact-run-123-1',
+      phase: 'open',
+      outstandingWrites: 0
+    })
+    expect(snapshot).not.toHaveProperty('rpcCapabilityToken')
+    expect(snapshot).not.toHaveProperty('currentRunFile')
+    expect(JSON.stringify(snapshot)).not.toContain('secret-capability')
+    expect(JSON.stringify(snapshot)).not.toContain(dataRoot)
+  })
+
+  it('keeps app-side writes scoped to the active Session turn and fails closed otherwise', async () => {
+    const dataRoot = await createRoot()
+    const repository = new ArtifactRepository(dataRoot)
+    const owner = new ArtifactTurnOwner({
+      dataRoot,
+      repository,
+      runRegistry: new ArtifactRunRegistry(),
+      now: () => 456
+    })
+
+    await owner.open({
+      appSessionId: 'session-1',
+      artifactStorageSessionId: 'artifact-session-1',
+      projectId: 'project-1',
+      agentName: 'Codex'
+    })
+    await owner.open({
+      appSessionId: 'session-2',
+      artifactStorageSessionId: 'artifact-session-2',
+      projectId: 'project-1',
+      agentName: 'Codex'
+    })
+
+    const first = await owner.writeForActiveTurn('session-1', {
+      filename: 'first.txt',
+      content: 'first'
+    })
+    const second = await owner.writeForActiveTurn('session-2', {
+      filename: 'second.txt',
+      content: 'second'
+    })
+
+    expect(first.sessionId).toBe('artifact-session-1')
+    expect(second.sessionId).toBe('artifact-session-2')
+    expect(first.runId).not.toBe(second.runId)
+    await expect(
+      owner.writeForActiveTurn('unknown-session', { filename: 'x.txt', content: 'x' })
+    ).rejects.toThrow(/No active assistant turn/i)
+  })
+
+  it('seals synchronously, drains accepted app and RPC writes, and prepares one claim exactly once', async () => {
+    const dataRoot = await createRoot()
+    const repository = new ArtifactRepository(dataRoot)
+    const releaseWrite = createDeferred()
+    const releaseRpc = createDeferred()
+    const writeStarted = createDeferred()
+    const listedVersion = artifactVersion()
+    const listRunVersions = vi.fn(async () => [listedVersion])
+    const writeAppGeneratedVersion = vi.fn(async () => {
+      writeStarted.resolve()
+      await releaseWrite.promise
+      return listedVersion
+    })
+    const prepareRunFinalization = vi.spyOn(repository, 'prepareRunFinalization')
+    const runRegistry = new ArtifactRunRegistry()
+    const register = vi.spyOn(runRegistry, 'register')
+    const revokeRpcCapability = vi.fn(async () => releaseRpc.promise)
+    const owner = new ArtifactTurnOwner({
+      dataRoot,
+      repository,
+      runRegistry,
+      provenance: { listRunVersions, writeAppGeneratedVersion },
+      issueRpcCapability: () => 'capability-1',
+      revokeRpcCapability,
+      now: () => 789
+    })
+    const turn = await owner.open({
+      appSessionId: 'session-1',
+      artifactStorageSessionId: 'artifact-session-1',
+      projectId: 'project-1',
+      agentName: 'OpenCode'
+    })
+    const acceptedWrite = owner.writeForActiveTurn('session-1', {
+      filename: 'result.txt',
+      content: 'result'
+    })
+    await writeStarted.promise
+
+    const firstFinalization = owner.finalize(turn)
+    const repeatedFinalization = owner.finalize(turn)
+    expect(firstFinalization).toBe(repeatedFinalization)
+    await expect(
+      owner.writeForActiveTurn('session-1', { filename: 'late.txt', content: 'late' })
+    ).rejects.toThrow(/No active assistant turn/i)
+    expect(listRunVersions).not.toHaveBeenCalled()
+
+    releaseRpc.resolve()
+    await Promise.resolve()
+    expect(listRunVersions).not.toHaveBeenCalled()
+    releaseWrite.resolve()
+    await acceptedWrite
+
+    const publication = await firstFinalization
+    expect(publication).toMatchObject({
+      appSessionId: 'session-1',
+      artifactStorageSessionId: 'artifact-session-1',
+      runId: 'artifact-run-789-1',
+      artifactClaimId: expect.stringMatching(/^artifact-claim-/),
+      artifacts: [listedVersion]
+    })
+    expect(revokeRpcCapability).toHaveBeenCalledOnce()
+    expect(listRunVersions).toHaveBeenCalledOnce()
+    expect(prepareRunFinalization).toHaveBeenCalledOnce()
+    expect(register).toHaveBeenCalledOnce()
+    await expect(owner.finalize(turn)).resolves.toBe(publication)
+  })
+
+  it('caches an empty terminal result without creating a claim', async () => {
+    const dataRoot = await createRoot()
+    const repository = new ArtifactRepository(dataRoot)
+    const listPendingRunFiles = vi.spyOn(repository, 'listPendingRunFiles')
+    const runRegistry = new ArtifactRunRegistry()
+    const register = vi.spyOn(runRegistry, 'register')
+    const owner = new ArtifactTurnOwner({
+      dataRoot,
+      repository,
+      runRegistry,
+      now: () => 900
+    })
+    const turn = await owner.open({
+      appSessionId: 'session-1',
+      artifactStorageSessionId: 'artifact-session-1',
+      projectId: 'project-1',
+      agentName: 'Claude Code'
+    })
+
+    await expect(owner.finalize(turn)).resolves.toBeUndefined()
+    await expect(owner.finalize(turn)).resolves.toBeUndefined()
+    expect(listPendingRunFiles).toHaveBeenCalledOnce()
+    expect(register).not.toHaveBeenCalled()
+    expect(owner.snapshot(turn)).toEqual({
+      appSessionId: 'session-1',
+      runId: 'artifact-run-900-1',
+      phase: 'finalized',
+      outstandingWrites: 0,
+      terminalResult: { kind: 'empty' }
+    })
+  })
+
+  it('does not let stale cleanup erase a replacement turn owned by the same Session', async () => {
+    const dataRoot = await createRoot()
+    const notebookContexts: Array<{ sessionId: string; context: unknown }> = []
+    const revoked: string[] = []
+    let capabilitySequence = 0
+    let now = 1_000
+    const owner = new ArtifactTurnOwner({
+      dataRoot,
+      repository: new ArtifactRepository(dataRoot),
+      runRegistry: new ArtifactRunRegistry(),
+      now: () => now,
+      issueRpcCapability: () => `capability-${++capabilitySequence}`,
+      revokeRpcCapability: (token) => {
+        revoked.push(token)
+      },
+      notebook: {
+        setArtifactProvenanceContext: (sessionId, context) => {
+          notebookContexts.push({ sessionId, context })
+        }
+      }
+    })
+    const first = await owner.open({
+      appSessionId: 'session-1',
+      artifactStorageSessionId: 'session-1',
+      projectId: 'project-1',
+      agentName: 'Codex'
+    })
+    now = 1_001
+    const replacement = await owner.open({
+      appSessionId: 'session-1',
+      artifactStorageSessionId: 'session-1',
+      projectId: 'project-1',
+      agentName: 'Codex'
+    })
+
+    await owner.dispose(first)
+    const currentRunFile = getArtifactCurrentRunFilePath(dataRoot, 'project-1', 'session-1')
+    await expect(readFile(currentRunFile, 'utf8')).resolves.toContain('artifact-run-1001-2')
+    expect(owner.activeRunIds()).toEqual(['artifact-run-1001-2'])
+    expect(notebookContexts.at(-1)?.context).not.toBeUndefined()
+
+    await owner.dispose(replacement)
+    await expect(readFile(currentRunFile, 'utf8')).resolves.toBe('{}\n')
+    expect(owner.activeRunIds()).toEqual([])
+    expect(notebookContexts.at(-1)).toEqual({ sessionId: 'session-1', context: undefined })
+    expect(revoked).toEqual(['capability-1', 'capability-2'])
+  })
+
+  it('clears active ownership even when capability revocation fails', async () => {
+    const dataRoot = await createRoot()
+    const notebookContexts: unknown[] = []
+    const owner = new ArtifactTurnOwner({
+      dataRoot,
+      repository: new ArtifactRepository(dataRoot),
+      runRegistry: new ArtifactRunRegistry(),
+      issueRpcCapability: () => 'capability-1',
+      revokeRpcCapability: async () => {
+        throw new Error('revoke failed')
+      },
+      notebook: {
+        setArtifactProvenanceContext: (_sessionId, context) => notebookContexts.push(context)
+      }
+    })
+    const turn = await owner.open({
+      appSessionId: 'session-1',
+      artifactStorageSessionId: 'artifact-session-1',
+      projectId: 'project-1',
+      agentName: 'Codex'
+    })
+    const currentRunFile = getArtifactCurrentRunFilePath(
+      dataRoot,
+      'project-1',
+      'artifact-session-1'
+    )
+
+    await expect(owner.dispose(turn)).rejects.toThrow('revoke failed')
+
+    expect(owner.activeRunIds()).toEqual([])
+    await expect(readFile(currentRunFile, 'utf8')).resolves.toBe('{}\n')
+    expect(notebookContexts.at(-1)).toBeUndefined()
+  })
+
+  it('revokes a capability and publishes no active state when opening the handoff fails', async () => {
+    const dataRoot = await createRoot()
+    const blockedRoot = join(dataRoot, 'blocked')
+    const repository = new ArtifactRepository(blockedRoot)
+    const revoked: string[] = []
+    await repository.writePendingFile({
+      projectName: 'seed',
+      sessionId: 'seed',
+      runId: 'seed',
+      filename: 'seed.txt',
+      source: { kind: 'inline', content: 'seed', encoding: 'utf8' }
+    })
+    // A file at the configured data root makes the current-run mkdir fail.
+    const fileRoot = join(dataRoot, 'root-file')
+    await writeFile(fileRoot, 'blocked')
+    const failingOwner = new ArtifactTurnOwner({
+      dataRoot: fileRoot,
+      repository,
+      runRegistry: new ArtifactRunRegistry(),
+      issueRpcCapability: () => 'failed-open-capability',
+      revokeRpcCapability: (token) => {
+        revoked.push(token)
+      }
+    })
+
+    await expect(
+      failingOwner.open({
+        appSessionId: 'session-1',
+        artifactStorageSessionId: 'artifact-session-1',
+        projectId: 'project-1',
+        agentName: 'Codex'
+      })
+    ).rejects.toThrow()
+    expect(failingOwner.activeRunIds()).toEqual([])
+    expect(revoked).toEqual(['failed-open-capability'])
+  })
+})

--- a/src/main/acp/artifact-turn-owner.test.ts
+++ b/src/main/acp/artifact-turn-owner.test.ts
@@ -322,6 +322,51 @@ describe('ArtifactTurnOwner', () => {
     expect(revoked).toEqual(['capability-1', 'capability-2'])
   })
 
+  it('serializes stale cleanup with a replacement opening the same handoff', async () => {
+    const dataRoot = await createRoot()
+    const cleanupWriteStarted = createDeferred()
+    const releaseCleanupWrite = createDeferred()
+    let writeCount = 0
+    const owner = new ArtifactTurnOwner({
+      dataRoot,
+      repository: new ArtifactRepository(dataRoot),
+      runRegistry: new ArtifactRunRegistry(),
+      writeHandoffFile: async (filePath, content) => {
+        writeCount += 1
+        if (writeCount === 2) {
+          cleanupWriteStarted.resolve()
+          await releaseCleanupWrite.promise
+        }
+        await writeFile(filePath, content, 'utf8')
+      }
+    })
+    const first = await owner.open({
+      appSessionId: 'session-1',
+      artifactStorageSessionId: 'session-1',
+      projectId: 'project-1',
+      agentName: 'Codex'
+    })
+
+    const staleDisposal = owner.dispose(first)
+    await cleanupWriteStarted.promise
+    const replacementOpening = owner.open({
+      appSessionId: 'session-1',
+      artifactStorageSessionId: 'session-1',
+      projectId: 'project-1',
+      agentName: 'Codex'
+    })
+    await Promise.resolve()
+    expect(writeCount).toBe(2)
+
+    releaseCleanupWrite.resolve()
+    await staleDisposal
+    const replacement = await replacementOpening
+    const currentRunFile = getArtifactCurrentRunFilePath(dataRoot, 'project-1', 'session-1')
+    await expect(readFile(currentRunFile, 'utf8')).resolves.toContain('artifact-run-')
+    expect(owner.activeRunIds()).toHaveLength(1)
+    await owner.dispose(replacement)
+  })
+
   it('clears active ownership even when capability revocation fails', async () => {
     const dataRoot = await createRoot()
     const notebookContexts: unknown[] = []

--- a/src/main/acp/artifact-turn-owner.ts
+++ b/src/main/acp/artifact-turn-owner.ts
@@ -144,6 +144,7 @@ class ArtifactTurnOwner {
   async open(request: OpenArtifactTurnRequest): Promise<ArtifactTurnHandle> {
     const turn = this.createTurn(request)
     const runContext = this.createRunContext(turn)
+    let handoffWritten = false
 
     turn.rpcCapabilityToken = this.options.issueRpcCapability?.({
       projectId: turn.projectId,
@@ -166,6 +167,7 @@ class ArtifactTurnOwner {
     try {
       await mkdir(dirname(turn.currentRunFile), { recursive: true })
       await writeFile(turn.currentRunFile, `${JSON.stringify(runContext)}\n`, 'utf8')
+      handoffWritten = true
       this.options.notebook?.setArtifactProvenanceContext?.(turn.appSessionId, {
         rootFrameId: turn.rootFrameId,
         agentFrameId: turn.agentFrameId,
@@ -175,7 +177,23 @@ class ArtifactTurnOwner {
       })
     } catch (error) {
       if (turn.rpcCapabilityToken) {
-        await this.options.revokeRpcCapability?.(turn.rpcCapabilityToken)
+        try {
+          await this.options.revokeRpcCapability?.(turn.rpcCapabilityToken)
+        } catch {
+          // Preserve the activation failure while still attempting every remaining cleanup stage.
+        }
+      }
+      if (handoffWritten) {
+        try {
+          await writeFile(turn.currentRunFile, `${JSON.stringify({})}\n`, 'utf8')
+        } catch {
+          // The original activation failure remains the caller-visible error.
+        }
+        try {
+          this.options.notebook?.setArtifactProvenanceContext?.(turn.appSessionId, undefined)
+        } catch {
+          // The original activation failure remains the caller-visible error.
+        }
       }
       throw error
     }
@@ -205,10 +223,7 @@ class ArtifactTurnOwner {
     }
   }
 
-  writeForActiveTurn(
-    sessionId: string,
-    input: ArtifactTurnWriteInput
-  ): Promise<ArtifactFile> {
+  writeForActiveTurn(sessionId: string, input: ArtifactTurnWriteInput): Promise<ArtifactFile> {
     const turn = sessionId ? this.activeTurnsBySession.get(sessionId) : undefined
     if (!turn || turn.phase !== 'open') {
       return Promise.reject(new Error('No active assistant turn to attach a generated file to.'))
@@ -251,20 +266,34 @@ class ArtifactTurnOwner {
 
   finalize(handle: ArtifactTurnHandle): Promise<ArtifactTurnPublication | undefined> {
     const turn = this.resolve(handle)
-    turn.finalizationPromise ??= this.finalizeTurn(turn)
+    if (turn.disposalPromise && !turn.finalizationPromise) {
+      return Promise.reject(new Error('Artifact turn is already disposing or disposed.'))
+    }
+    if (!turn.finalizationPromise) {
+      const finalization = this.finalizeTurn(turn)
+      turn.finalizationPromise = finalization
+      void finalization.catch(() => {
+        // Claim preparation can fail transiently. Preserve the runtime's existing finally retry while
+        // keeping a concurrent disposal terminal and non-reopenable.
+        if (turn.finalizationPromise === finalization && !turn.disposalPromise) {
+          turn.finalizationPromise = undefined
+        }
+      })
+    }
     return turn.finalizationPromise
   }
 
   dispose(handle: ArtifactTurnHandle): Promise<void> {
     const turn = this.resolve(handle)
-    turn.disposalPromise ??= this.disposeTurn(turn)
+    turn.disposalPromise ??= this.disposeAfterFinalization(turn)
     return turn.disposalPromise
   }
 
   private createTurn(request: OpenArtifactTurnRequest): ArtifactTurn {
     this.sequence += 1
     const runId = `artifact-run-${this.now()}-${this.sequence}`
-    const rootFrameId = request.provenanceContext?.rootFrameId ?? `root-frame-${request.appSessionId}`
+    const rootFrameId =
+      request.provenanceContext?.rootFrameId ?? `root-frame-${request.appSessionId}`
     const messageBranchId =
       request.provenanceContext?.messageBranchId ?? `message-branch-${request.appSessionId}`
     const promptMessageId = request.provenanceContext?.promptMessageId ?? `prompt-${runId}`
@@ -297,8 +326,7 @@ class ArtifactTurnOwner {
       messageBranchAncestry,
       messageAncestry,
       runtimeSegmentId:
-        request.provenanceContext?.runtimeSegmentId ??
-        `runtime-segment-${this.runtimeInstanceId}`,
+        request.provenanceContext?.runtimeSegmentId ?? `runtime-segment-${this.runtimeInstanceId}`,
       promptMessageId,
       agentName: request.agentName,
       phase: 'open',
@@ -347,8 +375,11 @@ class ArtifactTurnOwner {
         )
       : Promise.resolve()
     turn.writeDrainPromise = (async () => {
-      await rpcDrain
-      await Promise.allSettled([...turn.inFlightAppWrites])
+      const [rpcResult] = await Promise.allSettled([
+        rpcDrain,
+        Promise.allSettled([...turn.inFlightAppWrites])
+      ])
+      if (rpcResult.status === 'rejected') throw rpcResult.reason
     })()
     return turn.writeDrainPromise
   }
@@ -364,7 +395,9 @@ class ArtifactTurnOwner {
         appSessionId: turn.appSessionId,
         artifactRunId: turn.runId
       })
-      artifactVersionIds = artifacts.map((artifact) => artifact.versionId).filter(Boolean) as string[]
+      artifactVersionIds = artifacts
+        .map((artifact) => artifact.versionId)
+        .filter(Boolean) as string[]
     } else {
       artifacts = await this.options.repository.listPendingRunFiles({
         projectName: turn.projectId,
@@ -421,28 +454,48 @@ class ArtifactTurnOwner {
     return publication
   }
 
+  private async disposeAfterFinalization(turn: ArtifactTurn): Promise<void> {
+    if (turn.finalizationPromise) {
+      try {
+        await turn.finalizationPromise
+      } catch {
+        // Disposal must still clear every ephemeral resource after failed claim preparation.
+      }
+    }
+    await this.disposeTurn(turn)
+  }
+
   private async disposeTurn(turn: ArtifactTurn): Promise<void> {
-    let hasDrainError = false
-    let drainError: unknown
+    const cleanupErrors: unknown[] = []
     try {
       await this.closeWrites(turn)
     } catch (error) {
-      hasDrainError = true
-      drainError = error
+      cleanupErrors.push(error)
     }
-    const ownsActiveTurn = this.activeTurnsBySession.get(turn.appSessionId) === turn
+
+    const activeTurn = this.activeTurnsBySession.get(turn.appSessionId)
+    const ownsActiveTurn = activeTurn === turn
+    const ownsDistinctHandoff = activeTurn?.currentRunFile !== turn.currentRunFile
+    try {
+      if (ownsActiveTurn || ownsDistinctHandoff) {
+        await writeFile(turn.currentRunFile, `${JSON.stringify({})}\n`, 'utf8')
+      }
+    } catch (error) {
+      cleanupErrors.push(error)
+    }
     try {
       if (ownsActiveTurn) {
-        await writeFile(turn.currentRunFile, `${JSON.stringify({})}\n`, 'utf8')
         this.options.notebook?.setArtifactProvenanceContext?.(turn.appSessionId, undefined)
       }
+    } catch (error) {
+      cleanupErrors.push(error)
     } finally {
       if (this.activeTurnsBySession.get(turn.appSessionId) === turn) {
         this.activeTurnsBySession.delete(turn.appSessionId)
       }
       turn.phase = 'disposed'
     }
-    if (hasDrainError) throw drainError
+    if (cleanupErrors.length > 0) throw cleanupErrors[0]
   }
 
   private resolve(handle: ArtifactTurnHandle): ArtifactTurn {

--- a/src/main/acp/artifact-turn-owner.ts
+++ b/src/main/acp/artifact-turn-owner.ts
@@ -1,0 +1,463 @@
+import { randomUUID } from 'node:crypto'
+import { mkdir, writeFile } from 'node:fs/promises'
+import { dirname } from 'node:path'
+
+import type { ArtifactFile } from '../../shared/artifacts'
+import type { ArtifactRpcCapabilityBinding } from '../../shared/artifact-provenance'
+import { getNotebookDataRoot, getNotebookSessionRoot } from '../notebook/repository'
+import type { ArtifactRunContext } from '../artifacts/mcp-server'
+import { ArtifactRepository, getArtifactCurrentRunFilePath } from '../artifacts/repository'
+import { ArtifactRunRegistry } from '../artifacts/run-registry'
+
+const artifactTurnHandleKey = Symbol('artifact-turn-handle')
+
+type ArtifactTurnHandle = {
+  readonly [artifactTurnHandleKey]: symbol
+}
+
+type ArtifactTurnProvenanceContext = {
+  rootFrameId?: string
+  agentFrameId?: string
+  messageBranchId?: string
+  messageBranchAncestry?: string[]
+  messageAncestry?: string[]
+  runtimeSegmentId?: string
+  promptMessageId?: string
+}
+
+type OpenArtifactTurnRequest = {
+  appSessionId: string
+  artifactStorageSessionId: string
+  projectId: string
+  agentName: string
+  provenanceContext?: ArtifactTurnProvenanceContext
+}
+
+type ArtifactTurnWriteInput = {
+  filename: string
+  content: string
+  mimeType?: string
+}
+
+type ArtifactTurnPublication = {
+  appSessionId: string
+  artifactStorageSessionId: string
+  runId: string
+  promptMessageId: string
+  artifactClaimId: string
+  artifacts: ArtifactFile[]
+}
+
+type ArtifactTurnSnapshot = {
+  appSessionId: string
+  runId: string
+  phase: 'open' | 'sealing' | 'finalized' | 'disposed'
+  outstandingWrites: number
+  terminalResult?: { kind: 'empty' } | { kind: 'publication'; artifactCount: number }
+}
+
+type ArtifactTurnProvenance = {
+  listRunVersions: (request: {
+    projectId: string
+    appSessionId: string
+    artifactRunId: string
+  }) => Promise<ArtifactFile[]>
+  writeAppGeneratedVersion: (request: {
+    projectId: string
+    appSessionId: string
+    artifactStorageSessionId: string
+    artifactRunId: string
+    rootFrameId: string
+    agentFrameId: string
+    messageBranchId: string
+    messageBranchAncestry: string[]
+    messageAncestry: string[]
+    runtimeSegmentId: string
+    promptMessageId: string
+    agentName: string
+    filename: string
+    content: string
+    contentType?: string
+  }) => Promise<ArtifactFile>
+}
+
+type ArtifactTurnOwnerOptions = {
+  dataRoot: string
+  repository: ArtifactRepository
+  runRegistry: ArtifactRunRegistry
+  runtimeInstanceId?: string
+  now?: () => number
+  issueRpcCapability?: (binding: ArtifactRpcCapabilityBinding) => string
+  revokeRpcCapability?: (token: string) => Promise<void> | void
+  provenance?: ArtifactTurnProvenance
+  notebook?: {
+    setArtifactProvenanceContext?: (
+      sessionId: string,
+      context:
+        | {
+            rootFrameId: string
+            agentFrameId: string
+            messageBranchId: string
+            runtimeSegmentId: string
+            promptMessageId: string
+          }
+        | undefined
+    ) => void
+  }
+}
+
+type ArtifactTurn = {
+  appSessionId: string
+  artifactStorageSessionId: string
+  projectId: string
+  runId: string
+  currentRunFile: string
+  rootFrameId: string
+  agentFrameId: string
+  messageBranchId: string
+  messageBranchAncestry: string[]
+  messageAncestry: string[]
+  runtimeSegmentId: string
+  promptMessageId: string
+  agentName: string
+  rpcCapabilityToken?: string
+  phase: 'open' | 'sealing' | 'finalized' | 'disposed'
+  inFlightAppWrites: Set<Promise<ArtifactFile>>
+  writeDrainPromise?: Promise<void>
+  finalizationPromise?: Promise<ArtifactTurnPublication | undefined>
+  disposalPromise?: Promise<void>
+  terminalResult?: { kind: 'empty' } | { kind: 'publication'; artifactCount: number }
+}
+
+class ArtifactTurnOwner {
+  private readonly activeTurnsBySession = new Map<string, ArtifactTurn>()
+  private readonly turnsByHandle = new WeakMap<ArtifactTurnHandle, ArtifactTurn>()
+  private readonly runtimeInstanceId: string
+  private readonly now: () => number
+  private sequence = 0
+
+  constructor(private readonly options: ArtifactTurnOwnerOptions) {
+    this.runtimeInstanceId = options.runtimeInstanceId ?? randomUUID()
+    this.now = options.now ?? Date.now
+  }
+
+  async open(request: OpenArtifactTurnRequest): Promise<ArtifactTurnHandle> {
+    const turn = this.createTurn(request)
+    const runContext = this.createRunContext(turn)
+
+    turn.rpcCapabilityToken = this.options.issueRpcCapability?.({
+      projectId: turn.projectId,
+      appSessionId: turn.appSessionId,
+      artifactStorageSessionId: turn.artifactStorageSessionId,
+      artifactRunId: turn.runId,
+      rootFrameId: turn.rootFrameId,
+      agentFrameId: turn.agentFrameId,
+      messageBranchId: turn.messageBranchId,
+      messageBranchAncestry: turn.messageBranchAncestry,
+      messageAncestry: turn.messageAncestry,
+      runtimeSegmentId: turn.runtimeSegmentId,
+      promptMessageId: turn.promptMessageId,
+      agentName: turn.agentName,
+      ...(this.options.notebook ? { notebookSessionId: turn.appSessionId } : {}),
+      allowedMethods: ['artifactCreateVersion', 'artifactReplayVersion']
+    })
+    if (turn.rpcCapabilityToken) runContext.rpcCapabilityToken = turn.rpcCapabilityToken
+
+    try {
+      await mkdir(dirname(turn.currentRunFile), { recursive: true })
+      await writeFile(turn.currentRunFile, `${JSON.stringify(runContext)}\n`, 'utf8')
+      this.options.notebook?.setArtifactProvenanceContext?.(turn.appSessionId, {
+        rootFrameId: turn.rootFrameId,
+        agentFrameId: turn.agentFrameId,
+        messageBranchId: turn.messageBranchId,
+        runtimeSegmentId: turn.runtimeSegmentId,
+        promptMessageId: turn.promptMessageId
+      })
+    } catch (error) {
+      if (turn.rpcCapabilityToken) {
+        await this.options.revokeRpcCapability?.(turn.rpcCapabilityToken)
+      }
+      throw error
+    }
+
+    this.activeTurnsBySession.set(turn.appSessionId, turn)
+    const handle: ArtifactTurnHandle = { [artifactTurnHandleKey]: Symbol(turn.runId) }
+    this.turnsByHandle.set(handle, turn)
+    return handle
+  }
+
+  activeRunIds(): string[] {
+    return Array.from(this.activeTurnsBySession.values(), (turn) => turn.runId)
+  }
+
+  promptMessageIdFor(sessionId: string): string | undefined {
+    return this.activeTurnsBySession.get(sessionId)?.promptMessageId
+  }
+
+  snapshot(handle: ArtifactTurnHandle): ArtifactTurnSnapshot {
+    const turn = this.resolve(handle)
+    return {
+      appSessionId: turn.appSessionId,
+      runId: turn.runId,
+      phase: turn.phase,
+      outstandingWrites: turn.inFlightAppWrites.size,
+      ...(turn.terminalResult ? { terminalResult: turn.terminalResult } : {})
+    }
+  }
+
+  writeForActiveTurn(
+    sessionId: string,
+    input: ArtifactTurnWriteInput
+  ): Promise<ArtifactFile> {
+    const turn = sessionId ? this.activeTurnsBySession.get(sessionId) : undefined
+    if (!turn || turn.phase !== 'open') {
+      return Promise.reject(new Error('No active assistant turn to attach a generated file to.'))
+    }
+
+    const write = this.options.provenance
+      ? this.options.provenance.writeAppGeneratedVersion({
+          projectId: turn.projectId,
+          appSessionId: turn.appSessionId,
+          artifactStorageSessionId: turn.artifactStorageSessionId,
+          artifactRunId: turn.runId,
+          rootFrameId: turn.rootFrameId,
+          agentFrameId: turn.agentFrameId,
+          messageBranchId: turn.messageBranchId,
+          messageBranchAncestry: turn.messageBranchAncestry,
+          messageAncestry: turn.messageAncestry,
+          runtimeSegmentId: turn.runtimeSegmentId,
+          promptMessageId: turn.promptMessageId,
+          agentName: turn.agentName,
+          filename: input.filename,
+          content: input.content,
+          contentType: input.mimeType
+        })
+      : this.options.repository.writePendingFile({
+          projectName: turn.projectId,
+          sessionId: turn.artifactStorageSessionId,
+          runId: turn.runId,
+          filename: input.filename,
+          mimeType: input.mimeType,
+          source: { kind: 'inline', content: input.content, encoding: 'utf8' }
+        })
+
+    turn.inFlightAppWrites.add(write)
+    void write.then(
+      () => turn.inFlightAppWrites.delete(write),
+      () => turn.inFlightAppWrites.delete(write)
+    )
+    return write
+  }
+
+  finalize(handle: ArtifactTurnHandle): Promise<ArtifactTurnPublication | undefined> {
+    const turn = this.resolve(handle)
+    turn.finalizationPromise ??= this.finalizeTurn(turn)
+    return turn.finalizationPromise
+  }
+
+  dispose(handle: ArtifactTurnHandle): Promise<void> {
+    const turn = this.resolve(handle)
+    turn.disposalPromise ??= this.disposeTurn(turn)
+    return turn.disposalPromise
+  }
+
+  private createTurn(request: OpenArtifactTurnRequest): ArtifactTurn {
+    this.sequence += 1
+    const runId = `artifact-run-${this.now()}-${this.sequence}`
+    const rootFrameId = request.provenanceContext?.rootFrameId ?? `root-frame-${request.appSessionId}`
+    const messageBranchId =
+      request.provenanceContext?.messageBranchId ?? `message-branch-${request.appSessionId}`
+    const promptMessageId = request.provenanceContext?.promptMessageId ?? `prompt-${runId}`
+    const messageBranchAncestry = [
+      ...(request.provenanceContext?.messageBranchAncestry ?? []).filter(
+        (branchId) => branchId !== messageBranchId
+      ),
+      messageBranchId
+    ]
+    const messageAncestry = [
+      ...(request.provenanceContext?.messageAncestry ?? []).filter(
+        (messageId) => messageId !== promptMessageId
+      ),
+      promptMessageId
+    ]
+
+    return {
+      appSessionId: request.appSessionId,
+      artifactStorageSessionId: request.artifactStorageSessionId,
+      projectId: request.projectId,
+      runId,
+      currentRunFile: getArtifactCurrentRunFilePath(
+        this.options.dataRoot,
+        request.projectId,
+        request.artifactStorageSessionId
+      ),
+      rootFrameId,
+      agentFrameId: request.provenanceContext?.agentFrameId ?? rootFrameId,
+      messageBranchId,
+      messageBranchAncestry,
+      messageAncestry,
+      runtimeSegmentId:
+        request.provenanceContext?.runtimeSegmentId ??
+        `runtime-segment-${this.runtimeInstanceId}`,
+      promptMessageId,
+      agentName: request.agentName,
+      phase: 'open',
+      inFlightAppWrites: new Set()
+    }
+  }
+
+  private createRunContext(turn: ArtifactTurn): ArtifactRunContext {
+    const base = {
+      artifactRunId: turn.runId,
+      appSessionId: turn.appSessionId,
+      rootFrameId: turn.rootFrameId,
+      agentFrameId: turn.agentFrameId,
+      messageBranchId: turn.messageBranchId,
+      messageBranchAncestry: turn.messageBranchAncestry,
+      messageAncestry: turn.messageAncestry,
+      runtimeSegmentId: turn.runtimeSegmentId,
+      promptMessageId: turn.promptMessageId,
+      agentName: turn.agentName
+    }
+    return this.options.notebook
+      ? {
+          ...base,
+          notebookSessionId: turn.appSessionId,
+          notebookDataDir: getNotebookDataRoot(
+            this.options.dataRoot,
+            turn.projectId,
+            turn.appSessionId
+          ),
+          notebookSessionRoot: getNotebookSessionRoot(
+            this.options.dataRoot,
+            turn.projectId,
+            turn.appSessionId
+          )
+        }
+      : base
+  }
+
+  private closeWrites(turn: ArtifactTurn): Promise<void> {
+    if (turn.writeDrainPromise) return turn.writeDrainPromise
+
+    turn.phase = 'sealing'
+    const rpcDrain = turn.rpcCapabilityToken
+      ? Promise.resolve().then(() =>
+          this.options.revokeRpcCapability?.(turn.rpcCapabilityToken as string)
+        )
+      : Promise.resolve()
+    turn.writeDrainPromise = (async () => {
+      await rpcDrain
+      await Promise.allSettled([...turn.inFlightAppWrites])
+    })()
+    return turn.writeDrainPromise
+  }
+
+  private async finalizeTurn(turn: ArtifactTurn): Promise<ArtifactTurnPublication | undefined> {
+    await this.closeWrites(turn)
+
+    let artifacts: ArtifactFile[]
+    let artifactVersionIds: string[] | undefined
+    if (this.options.provenance) {
+      artifacts = await this.options.provenance.listRunVersions({
+        projectId: turn.projectId,
+        appSessionId: turn.appSessionId,
+        artifactRunId: turn.runId
+      })
+      artifactVersionIds = artifacts.map((artifact) => artifact.versionId).filter(Boolean) as string[]
+    } else {
+      artifacts = await this.options.repository.listPendingRunFiles({
+        projectName: turn.projectId,
+        sessionId: turn.artifactStorageSessionId,
+        runId: turn.runId
+      })
+    }
+
+    if (artifacts.length === 0) {
+      turn.phase = 'finalized'
+      turn.terminalResult = { kind: 'empty' }
+      return undefined
+    }
+
+    await this.options.repository.prepareRunFinalization({
+      projectName: turn.projectId,
+      sourceSessionId: turn.artifactStorageSessionId,
+      sessionId: turn.appSessionId,
+      runId: turn.runId,
+      ...(artifactVersionIds ? { artifactVersionIds } : {}),
+      provenanceContext: {
+        rootFrameId: turn.rootFrameId,
+        agentFrameId: turn.agentFrameId,
+        messageBranchId: turn.messageBranchId,
+        runtimeSegmentId: turn.runtimeSegmentId,
+        promptMessageId: turn.promptMessageId
+      }
+    })
+
+    const artifactClaimId = this.options.runRegistry.register({
+      projectName: turn.projectId,
+      artifactSessionId: turn.artifactStorageSessionId,
+      sessionId: turn.appSessionId,
+      runId: turn.runId,
+      artifactVersionIds,
+      rootFrameId: turn.rootFrameId,
+      agentFrameId: turn.agentFrameId,
+      messageBranchId: turn.messageBranchId,
+      messageBranchAncestry: turn.messageBranchAncestry,
+      messageAncestry: turn.messageAncestry,
+      runtimeSegmentId: turn.runtimeSegmentId,
+      promptMessageId: turn.promptMessageId
+    })
+    const publication = {
+      appSessionId: turn.appSessionId,
+      artifactStorageSessionId: turn.artifactStorageSessionId,
+      runId: turn.runId,
+      promptMessageId: turn.promptMessageId,
+      artifactClaimId,
+      artifacts
+    }
+    turn.phase = 'finalized'
+    turn.terminalResult = { kind: 'publication', artifactCount: artifacts.length }
+    return publication
+  }
+
+  private async disposeTurn(turn: ArtifactTurn): Promise<void> {
+    let hasDrainError = false
+    let drainError: unknown
+    try {
+      await this.closeWrites(turn)
+    } catch (error) {
+      hasDrainError = true
+      drainError = error
+    }
+    const ownsActiveTurn = this.activeTurnsBySession.get(turn.appSessionId) === turn
+    try {
+      if (ownsActiveTurn) {
+        await writeFile(turn.currentRunFile, `${JSON.stringify({})}\n`, 'utf8')
+        this.options.notebook?.setArtifactProvenanceContext?.(turn.appSessionId, undefined)
+      }
+    } finally {
+      if (this.activeTurnsBySession.get(turn.appSessionId) === turn) {
+        this.activeTurnsBySession.delete(turn.appSessionId)
+      }
+      turn.phase = 'disposed'
+    }
+    if (hasDrainError) throw drainError
+  }
+
+  private resolve(handle: ArtifactTurnHandle): ArtifactTurn {
+    const turn = this.turnsByHandle.get(handle)
+    if (!turn) throw new Error('Unknown Artifact turn handle')
+    return turn
+  }
+}
+
+export { ArtifactTurnOwner }
+export type {
+  ArtifactTurnHandle,
+  ArtifactTurnOwnerOptions,
+  ArtifactTurnPublication,
+  ArtifactTurnSnapshot,
+  ArtifactTurnWriteInput,
+  OpenArtifactTurnRequest
+}

--- a/src/main/acp/artifact-turn-owner.ts
+++ b/src/main/acp/artifact-turn-owner.ts
@@ -90,6 +90,7 @@ type ArtifactTurnOwnerOptions = {
   issueRpcCapability?: (binding: ArtifactRpcCapabilityBinding) => string
   revokeRpcCapability?: (token: string) => Promise<void> | void
   provenance?: ArtifactTurnProvenance
+  writeHandoffFile?: (filePath: string, content: string) => Promise<void>
   notebook?: {
     setArtifactProvenanceContext?: (
       sessionId: string,
@@ -131,6 +132,7 @@ type ArtifactTurn = {
 
 class ArtifactTurnOwner {
   private readonly activeTurnsBySession = new Map<string, ArtifactTurn>()
+  private readonly sessionHandoffQueues = new Map<string, Promise<void>>()
   private readonly turnsByHandle = new WeakMap<ArtifactTurnHandle, ArtifactTurn>()
   private readonly runtimeInstanceId: string
   private readonly now: () => number
@@ -144,64 +146,66 @@ class ArtifactTurnOwner {
   async open(request: OpenArtifactTurnRequest): Promise<ArtifactTurnHandle> {
     const turn = this.createTurn(request)
     const runContext = this.createRunContext(turn)
-    let handoffWritten = false
+    return this.withSessionHandoffLock(turn.appSessionId, async () => {
+      let handoffWritten = false
 
-    turn.rpcCapabilityToken = this.options.issueRpcCapability?.({
-      projectId: turn.projectId,
-      appSessionId: turn.appSessionId,
-      artifactStorageSessionId: turn.artifactStorageSessionId,
-      artifactRunId: turn.runId,
-      rootFrameId: turn.rootFrameId,
-      agentFrameId: turn.agentFrameId,
-      messageBranchId: turn.messageBranchId,
-      messageBranchAncestry: turn.messageBranchAncestry,
-      messageAncestry: turn.messageAncestry,
-      runtimeSegmentId: turn.runtimeSegmentId,
-      promptMessageId: turn.promptMessageId,
-      agentName: turn.agentName,
-      ...(this.options.notebook ? { notebookSessionId: turn.appSessionId } : {}),
-      allowedMethods: ['artifactCreateVersion', 'artifactReplayVersion']
-    })
-    if (turn.rpcCapabilityToken) runContext.rpcCapabilityToken = turn.rpcCapabilityToken
-
-    try {
-      await mkdir(dirname(turn.currentRunFile), { recursive: true })
-      await writeFile(turn.currentRunFile, `${JSON.stringify(runContext)}\n`, 'utf8')
-      handoffWritten = true
-      this.options.notebook?.setArtifactProvenanceContext?.(turn.appSessionId, {
+      turn.rpcCapabilityToken = this.options.issueRpcCapability?.({
+        projectId: turn.projectId,
+        appSessionId: turn.appSessionId,
+        artifactStorageSessionId: turn.artifactStorageSessionId,
+        artifactRunId: turn.runId,
         rootFrameId: turn.rootFrameId,
         agentFrameId: turn.agentFrameId,
         messageBranchId: turn.messageBranchId,
+        messageBranchAncestry: turn.messageBranchAncestry,
+        messageAncestry: turn.messageAncestry,
         runtimeSegmentId: turn.runtimeSegmentId,
-        promptMessageId: turn.promptMessageId
+        promptMessageId: turn.promptMessageId,
+        agentName: turn.agentName,
+        ...(this.options.notebook ? { notebookSessionId: turn.appSessionId } : {}),
+        allowedMethods: ['artifactCreateVersion', 'artifactReplayVersion']
       })
-    } catch (error) {
-      if (turn.rpcCapabilityToken) {
-        try {
-          await this.options.revokeRpcCapability?.(turn.rpcCapabilityToken)
-        } catch {
-          // Preserve the activation failure while still attempting every remaining cleanup stage.
-        }
-      }
-      if (handoffWritten) {
-        try {
-          await writeFile(turn.currentRunFile, `${JSON.stringify({})}\n`, 'utf8')
-        } catch {
-          // The original activation failure remains the caller-visible error.
-        }
-        try {
-          this.options.notebook?.setArtifactProvenanceContext?.(turn.appSessionId, undefined)
-        } catch {
-          // The original activation failure remains the caller-visible error.
-        }
-      }
-      throw error
-    }
+      if (turn.rpcCapabilityToken) runContext.rpcCapabilityToken = turn.rpcCapabilityToken
 
-    this.activeTurnsBySession.set(turn.appSessionId, turn)
-    const handle: ArtifactTurnHandle = { [artifactTurnHandleKey]: Symbol(turn.runId) }
-    this.turnsByHandle.set(handle, turn)
-    return handle
+      try {
+        await mkdir(dirname(turn.currentRunFile), { recursive: true })
+        await this.writeHandoffFile(turn.currentRunFile, runContext)
+        handoffWritten = true
+        this.options.notebook?.setArtifactProvenanceContext?.(turn.appSessionId, {
+          rootFrameId: turn.rootFrameId,
+          agentFrameId: turn.agentFrameId,
+          messageBranchId: turn.messageBranchId,
+          runtimeSegmentId: turn.runtimeSegmentId,
+          promptMessageId: turn.promptMessageId
+        })
+      } catch (error) {
+        if (turn.rpcCapabilityToken) {
+          try {
+            await this.options.revokeRpcCapability?.(turn.rpcCapabilityToken)
+          } catch {
+            // Preserve the activation failure while still attempting every remaining cleanup stage.
+          }
+        }
+        if (handoffWritten) {
+          try {
+            await this.writeHandoffFile(turn.currentRunFile, {})
+          } catch {
+            // The original activation failure remains the caller-visible error.
+          }
+          try {
+            this.options.notebook?.setArtifactProvenanceContext?.(turn.appSessionId, undefined)
+          } catch {
+            // The original activation failure remains the caller-visible error.
+          }
+        }
+        throw error
+      }
+
+      this.activeTurnsBySession.set(turn.appSessionId, turn)
+      const handle: ArtifactTurnHandle = { [artifactTurnHandleKey]: Symbol(turn.runId) }
+      this.turnsByHandle.set(handle, turn)
+      return handle
+    })
   }
 
   activeRunIds(): string[] {
@@ -473,29 +477,54 @@ class ArtifactTurnOwner {
       cleanupErrors.push(error)
     }
 
-    const activeTurn = this.activeTurnsBySession.get(turn.appSessionId)
-    const ownsActiveTurn = activeTurn === turn
-    const ownsDistinctHandoff = activeTurn?.currentRunFile !== turn.currentRunFile
-    try {
-      if (ownsActiveTurn || ownsDistinctHandoff) {
-        await writeFile(turn.currentRunFile, `${JSON.stringify({})}\n`, 'utf8')
+    await this.withSessionHandoffLock(turn.appSessionId, async () => {
+      const activeTurn = this.activeTurnsBySession.get(turn.appSessionId)
+      const ownsActiveTurn = activeTurn === turn
+      const ownsDistinctHandoff = activeTurn?.currentRunFile !== turn.currentRunFile
+      try {
+        if (ownsActiveTurn || ownsDistinctHandoff) {
+          await this.writeHandoffFile(turn.currentRunFile, {})
+        }
+      } catch (error) {
+        cleanupErrors.push(error)
       }
-    } catch (error) {
-      cleanupErrors.push(error)
-    }
-    try {
-      if (ownsActiveTurn) {
-        this.options.notebook?.setArtifactProvenanceContext?.(turn.appSessionId, undefined)
+      try {
+        if (ownsActiveTurn) {
+          this.options.notebook?.setArtifactProvenanceContext?.(turn.appSessionId, undefined)
+        }
+      } catch (error) {
+        cleanupErrors.push(error)
+      } finally {
+        if (this.activeTurnsBySession.get(turn.appSessionId) === turn) {
+          this.activeTurnsBySession.delete(turn.appSessionId)
+        }
+        turn.phase = 'disposed'
       }
-    } catch (error) {
-      cleanupErrors.push(error)
-    } finally {
-      if (this.activeTurnsBySession.get(turn.appSessionId) === turn) {
-        this.activeTurnsBySession.delete(turn.appSessionId)
-      }
-      turn.phase = 'disposed'
-    }
+    })
     if (cleanupErrors.length > 0) throw cleanupErrors[0]
+  }
+
+  private writeHandoffFile(filePath: string, value: ArtifactRunContext | object): Promise<void> {
+    const content = `${JSON.stringify(value)}\n`
+    return this.options.writeHandoffFile
+      ? this.options.writeHandoffFile(filePath, content)
+      : writeFile(filePath, content, 'utf8')
+  }
+
+  private withSessionHandoffLock<T>(sessionId: string, operation: () => Promise<T>): Promise<T> {
+    const previous = this.sessionHandoffQueues.get(sessionId) ?? Promise.resolve()
+    const current = previous.then(operation)
+    const tail = current.then(
+      () => undefined,
+      () => undefined
+    )
+    this.sessionHandoffQueues.set(sessionId, tail)
+    void tail.then(() => {
+      if (this.sessionHandoffQueues.get(sessionId) === tail) {
+        this.sessionHandoffQueues.delete(sessionId)
+      }
+    })
+    return current
   }
 
   private resolve(handle: ArtifactTurnHandle): ArtifactTurn {

--- a/src/main/acp/runtime.test.ts
+++ b/src/main/acp/runtime.test.ts
@@ -13044,6 +13044,64 @@ describe('ACP runtime session management', () => {
     )
   })
 
+  it.each([
+    { outcome: 'success' as const, promptError: undefined },
+    { outcome: 'failure' as const, promptError: new Error('agent failed after opening the run') }
+  ])(
+    'exposes an active artifact run only while its current-run handoff is live after $outcome',
+    async ({ promptError }) => {
+      const storageRoot = await createTemporaryRoot()
+      const process = new FakeAgentProcess()
+      let currentRunFile = ''
+      let activeRunIds: string[] = []
+      let handoffRunId: string | undefined
+      let runtime!: AcpRuntime
+      const fakeAgent = startFakeAgent(process, ['remote-session-1'], {
+        onPrompt: async () => {
+          const handoff = JSON.parse(await readFile(currentRunFile, 'utf8')) as {
+            artifactRunId?: string
+          }
+          handoffRunId = handoff.artifactRunId
+          activeRunIds = runtime.getActiveArtifactRunIds()
+          if (promptError) throw promptError
+        }
+      })
+      runtime = new AcpRuntime({
+        appVersion: '0.1.0',
+        defaultCwd: '/workspace',
+        spawnAgent: () => asAgentProcess(process),
+        artifacts: {
+          configRoot: storageRoot,
+          dataRoot: storageRoot,
+          projectName: 'default-project',
+          mcpEntryPath: '/app/out/main/index.js',
+          repository: new ArtifactRepository(storageRoot)
+        }
+      })
+
+      const session = await runtime.createSession({ cwd: '/workspace' })
+      currentRunFile = getEnvValue(
+        fakeAgent.newSessions[0].mcpServers[0],
+        'OPEN_SCIENCE_ARTIFACT_CURRENT_RUN_FILE'
+      )
+      const prompt = runtime.sendPrompt({ sessionId: session.sessionId, text: 'make a file' })
+
+      if (promptError) {
+        await expect(prompt).rejects.toMatchObject({
+          code: -32603,
+          data: { details: promptError.message }
+        })
+      } else {
+        await expect(prompt).resolves.toBeDefined()
+      }
+
+      expect(handoffRunId).toMatch(/^artifact-run-/)
+      expect(activeRunIds).toEqual([handoffRunId])
+      expect(runtime.getActiveArtifactRunIds()).toEqual([])
+      await expect(readFile(currentRunFile, 'utf8')).resolves.toBe(`${JSON.stringify({})}\n`)
+    }
+  )
+
   it('emits an artifact event with pending files before a prompt stops', async () => {
     const storageRoot = await createTemporaryRoot()
     const repository = new ArtifactRepository(storageRoot)

--- a/src/main/acp/runtime.test.ts
+++ b/src/main/acp/runtime.test.ts
@@ -13044,6 +13044,71 @@ describe('ACP runtime session management', () => {
     )
   })
 
+  it('retries transient Artifact claim preparation in the prompt failure cleanup', async () => {
+    const storageRoot = await createTemporaryRoot()
+    const repository = new ArtifactRepository(storageRoot)
+    const generatedArtifact = {
+      id: 'version-1',
+      artifactId: 'artifact-1',
+      versionId: 'version-1',
+      versionNumber: 1,
+      checksum: 'a'.repeat(64),
+      createdAt: '2026-08-02T00:00:00.000Z',
+      projectName: 'project-1',
+      sessionId: 'artifact-session-1',
+      runId: 'artifact-run-1',
+      name: 'result.txt',
+      path: '/managed/result.txt',
+      fileUrl: 'file:///managed/result.txt',
+      mimeType: 'text/plain',
+      size: 6,
+      mtimeMs: 1
+    }
+    let listAttempts = 0
+    const listRunVersions = vi.fn(async () => {
+      listAttempts += 1
+      if (listAttempts === 1) throw new Error('temporary Artifact list failure')
+      return [generatedArtifact]
+    })
+    const artifactEvents: AcpRuntimeEvent[] = []
+    const process = new FakeAgentProcess()
+    startFakeAgent(process, ['remote-session-1'])
+    const runtime = new AcpRuntime({
+      appVersion: '0.1.0',
+      defaultCwd: '/workspace',
+      spawnAgent: () => asAgentProcess(process),
+      artifacts: {
+        configRoot: storageRoot,
+        dataRoot: storageRoot,
+        projectName: 'project-1',
+        mcpEntryPath: '/app/out/main/index.js',
+        repository,
+        provenance: {
+          listRunVersions,
+          writeAppGeneratedVersion: async () => generatedArtifact
+        }
+      },
+      callbacks: {
+        onEvent: (event) => {
+          if (event.kind === 'artifact') artifactEvents.push(event)
+        }
+      }
+    })
+    const session = await runtime.createSession({ cwd: '/workspace', projectName: 'project-1' })
+
+    await expect(
+      runtime.sendPrompt({ sessionId: session.sessionId, text: 'prepare an Artifact claim' })
+    ).rejects.toThrow('temporary Artifact list failure')
+
+    expect(listRunVersions).toHaveBeenCalledTimes(2)
+    expect(artifactEvents).toHaveLength(1)
+    const claim = resolveArtifactRunClaim(runtime, artifactEvents[0].artifactClaimId!)
+    expect(claim.artifactVersionIds).toEqual(['version-1'])
+    await expect(
+      repository.findRunFinalizationMarker('project-1', claim.runId)
+    ).resolves.toMatchObject({ artifactVersionIds: ['version-1'] })
+  })
+
   it.each([
     { outcome: 'success' as const, promptError: undefined },
     { outcome: 'failure' as const, promptError: new Error('agent failed after opening the run') }
@@ -13055,7 +13120,6 @@ describe('ACP runtime session management', () => {
       let currentRunFile = ''
       let activeRunIds: string[] = []
       let handoffRunId: string | undefined
-      let runtime!: AcpRuntime
       const fakeAgent = startFakeAgent(process, ['remote-session-1'], {
         onPrompt: async () => {
           const handoff = JSON.parse(await readFile(currentRunFile, 'utf8')) as {
@@ -13066,7 +13130,7 @@ describe('ACP runtime session management', () => {
           if (promptError) throw promptError
         }
       })
-      runtime = new AcpRuntime({
+      const runtime = new AcpRuntime({
         appVersion: '0.1.0',
         defaultCwd: '/workspace',
         spawnAgent: () => asAgentProcess(process),

--- a/src/main/acp/runtime.ts
+++ b/src/main/acp/runtime.ts
@@ -748,8 +748,7 @@ class AcpRuntime {
             ...(options.notebook
               ? {
                   notebook: {
-                    setArtifactProvenanceContext:
-                      options.notebook.setArtifactProvenanceContext
+                    setArtifactProvenanceContext: options.notebook.setArtifactProvenanceContext
                   }
                 }
               : {})

--- a/src/main/acp/runtime.ts
+++ b/src/main/acp/runtime.ts
@@ -12,8 +12,8 @@ import type {
 } from '@agentclientprotocol/sdk'
 import type { ChildProcessWithoutNullStreams } from 'node:child_process'
 import { randomUUID } from 'node:crypto'
-import { mkdir, readFile, stat, writeFile } from 'node:fs/promises'
-import { dirname, join, resolve } from 'node:path'
+import { readFile, stat } from 'node:fs/promises'
+import { join, resolve } from 'node:path'
 import { Readable, Writable } from 'node:stream'
 import { pathToFileURL } from 'node:url'
 
@@ -94,9 +94,8 @@ import { ConversationPermissionGrantStore } from './permission-broker'
 import { isMcpToolName } from './permission-policy'
 import { AcpPermissionContext, HUMAN_PERMISSION_ACTION_ORIGIN } from './permission-context'
 import { applyCurrentModeUpdate } from './permission-profile-controller'
-import { type ArtifactRunContext } from '../artifacts/mcp-server'
 import { AgentMcpHttpHost } from './mcp-http-host'
-import { ArtifactRepository, getArtifactCurrentRunFilePath } from '../artifacts/repository'
+import { ArtifactRepository } from '../artifacts/repository'
 import { ArtifactRunRegistry } from '../artifacts/run-registry'
 import { NOTEBOOK_SYSTEM_PROMPT_APPEND, type NotebookRpcConnection } from '../notebook/mcp-server'
 import {
@@ -104,7 +103,6 @@ import {
   type SkillImportRpcConnection
 } from '../skills/mcp-server'
 import { isImportableSkillArchivePath } from '../skills/skill-archive-sniffer'
-import { getNotebookDataRoot, getNotebookSessionRoot } from '../notebook/repository'
 import { codexStorageDir, codexSubscriptionStorageDir } from '../agent-framework/codex'
 import { getAppClaudeConfigDir } from '../settings/provider-env'
 import type { ResponsesBridgeSkillCandidate } from '../settings/responses-bridge'
@@ -139,6 +137,7 @@ import {
   CURRENT_PRIMARY_SESSION_CAPABILITY_POLICY,
   type SessionCapabilityRoutingIds
 } from './session-capability-owner'
+import { ArtifactTurnOwner, type ArtifactTurnHandle } from './artifact-turn-owner'
 import {
   buildImageContentData,
   canInlineImageInSession,
@@ -284,25 +283,6 @@ type AcpRuntimeArtifactOptions = {
 
 type AcpRuntimeUploadOptions = {
   repository: UploadRepository
-}
-
-type ActiveArtifactRun = {
-  appSessionId: string
-  runId: string
-  artifactSessionId: string
-  currentRunFile: string
-  rootFrameId: string
-  agentFrameId: string
-  messageBranchId: string
-  messageBranchAncestry: string[]
-  messageAncestry: string[]
-  runtimeSegmentId: string
-  promptMessageId: string
-  agentName: string
-  rpcCapabilityToken?: string
-  writesClosed: boolean
-  inFlightAppWrites: Set<Promise<unknown>>
-  writeDrainPromise?: Promise<void>
 }
 
 type AcpRuntimeNotebookOptions = {
@@ -722,16 +702,10 @@ class AcpRuntime {
   private readonly skillImportOptions: AcpRuntimeSkillImportOptions | undefined
   private readonly artifactRepository: ArtifactRepository | undefined
   private readonly artifactRunRegistry: ArtifactRunRegistry | undefined
+  private readonly artifactTurns: ArtifactTurnOwner | undefined
   private readonly uploadRepository: UploadRepository | undefined
   private readonly fileReferenceResolver: FileReferenceResolver
   private readonly skillImportTurnTokens = new Map<string, string>()
-  private artifactRunSequence = 0
-  private readonly runtimeInstanceId = randomUUID()
-  // The in-flight artifact run keyed by app session id, so app-side tools (e.g. molecule preview)
-  // attach a generated file to the run of the session that triggered the call. Parallel sessions each
-  // keep their own entry — a single global field would let one session's turn capture another's write.
-  // An entry is set while that session's prompt is active and cleared in the prompt's finally.
-  private readonly activeArtifactRuns = new Map<string, ActiveArtifactRun>()
 
   // Wires runtime dependencies and forwards permission prompts into the event stream.
   constructor(private readonly options: AcpRuntimeOptions) {
@@ -762,6 +736,25 @@ class AcpRuntime {
     this.artifactRunRegistry = options.artifacts
       ? (options.artifacts.runRegistry ?? new ArtifactRunRegistry())
       : undefined
+    this.artifactTurns =
+      options.artifacts && this.artifactRepository && this.artifactRunRegistry
+        ? new ArtifactTurnOwner({
+            dataRoot: options.artifacts.dataRoot,
+            repository: this.artifactRepository,
+            runRegistry: this.artifactRunRegistry,
+            issueRpcCapability: options.artifacts.issueRpcCapability,
+            revokeRpcCapability: options.artifacts.revokeRpcCapability,
+            provenance: options.artifacts.provenance,
+            ...(options.notebook
+              ? {
+                  notebook: {
+                    setArtifactProvenanceContext:
+                      options.notebook.setArtifactProvenanceContext
+                  }
+                }
+              : {})
+          })
+        : undefined
     this.uploadRepository = options.uploads?.repository
     this.fileReferenceResolver = createManagedFileReferenceResolver({
       uploads: this.uploadRepository,
@@ -986,7 +979,7 @@ class AcpRuntime {
   // handoff, which survives a crash). The artifact orphan scan uses this to exclude files a running
   // turn is still writing, while a crashed run — absent here — correctly surfaces as orphaned.
   getActiveArtifactRunIds(): string[] {
-    return Array.from(this.activeArtifactRuns.values(), (run) => run.runId)
+    return this.artifactTurns?.activeRunIds() ?? []
   }
 
   // Resolves an application profile against per-session ACP capabilities and applies the real Agent
@@ -3342,7 +3335,7 @@ class AcpRuntime {
       sessionId: request.sessionId,
       textLength: request.text?.length ?? 0
     })
-    let artifactRun: ActiveArtifactRun | undefined
+    let artifactRun: ArtifactTurnHandle | undefined
     let artifactEmitted = false
     let skillActivityInputs: Array<{ name: string; path: string }> = []
     let skillActivitiesStarted = false
@@ -3354,11 +3347,6 @@ class AcpRuntime {
     try {
       // Create a fresh run context before prompting so MCP writes can be attributed to this turn.
       artifactRun = await this.activateArtifactRun(request.sessionId, request.provenanceContext)
-      if (artifactRun) {
-        this.activeArtifactRuns.set(request.sessionId, artifactRun)
-      } else {
-        this.activeArtifactRuns.delete(request.sessionId)
-      }
       let userMessageEmitted = false
       const emitUserMessage = (): void => {
         if (
@@ -3703,14 +3691,8 @@ class AcpRuntime {
           text: errorMessage(error)
         })
       }
-      // Only clear shared turn state if a newer turn hasn't taken over this app session id. An
-      // overflow-recovery replay reuses the id: after resetSessionContext releases this (failed) turn's
-      // lock and the renderer starts the replay, this stale finally must not delete the replay's in-flight
-      // lock (which would reopen same-session sends and misreport prompt-in-flight) or clear its active
-      // artifact run. Identity/token comparisons scope each clear to the turn that still owns the state.
-      if (artifactRun && this.activeArtifactRuns.get(request.sessionId) === artifactRun) {
-        this.activeArtifactRuns.delete(request.sessionId)
-      }
+      // ArtifactTurnOwner clears only the handle that still owns this Session. A superseded turn's
+      // delayed finally therefore cannot erase the replacement turn's handoff or active-run state.
       if (this.currentPromptTurnBySession.get(request.sessionId) === promptTurn) {
         const cancelTimer = this.cancelTimers.get(request.sessionId)
         if (cancelTimer) this.clearTimer(cancelTimer)
@@ -4164,7 +4146,7 @@ class AcpRuntime {
         appSessionId: sessionId,
         promptMessageId:
           request.provenanceContext?.promptMessageId ??
-          this.activeArtifactRuns.get(sessionId)?.promptMessageId ??
+          this.artifactTurns?.promptMessageIdFor(sessionId) ??
           `prompt-unbound-${sessionId}`,
         uploads: finalizedPromptUploads,
         references: referencedArtifacts
@@ -4744,172 +4726,26 @@ class AcpRuntime {
     )
   }
 
-  // Resolves the per-session handoff file that tells the MCP process which run is active.
-  private getArtifactCurrentRunFile(artifactSessionId: string, projectName: string): string {
-    if (!this.artifactOptions) {
-      throw new Error('Artifact storage is not configured.')
-    }
-
-    return getArtifactCurrentRunFilePath(
-      this.artifactOptions.dataRoot,
-      projectName,
-      artifactSessionId
-    )
-  }
-
   // Marks a new assistant turn as the active artifact run before the model can call the MCP tool.
   private async activateArtifactRun(
     sessionId: string,
     provenanceContext: AcpPromptRequest['provenanceContext']
-  ): Promise<ActiveArtifactRun | undefined> {
-    if (!this.artifactOptions || !this.artifactRepository) return undefined
+  ): Promise<ArtifactTurnHandle | undefined> {
+    if (!this.artifactTurns) return undefined
 
-    this.artifactRunSequence += 1
-    const artifactSessionId = this.sessionCapabilities.artifactRoutingIdFor(sessionId) ?? sessionId
-    const projectName = this.resolveSessionProjectName(sessionId)
-    const currentRunFile = this.getArtifactCurrentRunFile(artifactSessionId, projectName)
-    const runId = `artifact-run-${Date.now()}-${this.artifactRunSequence}`
-    const rootFrameId = provenanceContext?.rootFrameId ?? `root-frame-${sessionId}`
-    const messageBranchId = provenanceContext?.messageBranchId ?? `message-branch-${sessionId}`
-    const promptMessageId = provenanceContext?.promptMessageId ?? `prompt-${runId}`
-    // Imported/restored graphs may provide ancestor-only paths, while some legacy paths already
-    // include the active leaf. Canonicalize only the runtime-owned leaf: preserve every ancestor and
-    // keep repository validation strict for duplicates or unrelated ids elsewhere in the proof.
-    const messageBranchAncestry = [
-      ...(provenanceContext?.messageBranchAncestry ?? []).filter(
-        (branchId) => branchId !== messageBranchId
-      ),
-      messageBranchId
-    ]
-    const messageAncestry = [
-      ...(provenanceContext?.messageAncestry ?? []).filter(
-        (messageId) => messageId !== promptMessageId
-      ),
-      promptMessageId
-    ]
-    const artifactRun: ActiveArtifactRun = {
+    return this.artifactTurns.open({
       appSessionId: sessionId,
-      runId,
-      artifactSessionId,
-      currentRunFile,
-      rootFrameId,
-      agentFrameId: provenanceContext?.agentFrameId ?? rootFrameId,
-      messageBranchId,
-      messageBranchAncestry,
-      messageAncestry,
-      runtimeSegmentId:
-        provenanceContext?.runtimeSegmentId ?? `runtime-segment-${this.runtimeInstanceId}`,
-      promptMessageId,
+      artifactStorageSessionId:
+        this.sessionCapabilities.artifactRoutingIdFor(sessionId) ?? sessionId,
+      projectId: this.resolveSessionProjectName(sessionId),
       agentName: this.framework.displayName,
-      writesClosed: false,
-      inFlightAppWrites: new Set()
-    }
-    // Notebook kernels are keyed by the FINAL ACP session id (the notebook RPC layer rewrites the
-    // pre-start alias to it before touching disk). This handoff runs per turn with that final id, so
-    // it — not the session-creation env, which only had the alias — is the correct place to pin the
-    // kernel's data dir + session root for relative/bare artifact imports.
-    const runContext: ArtifactRunContext =
-      this.notebookOptions && this.artifactOptions
-        ? {
-            artifactRunId: artifactRun.runId,
-            appSessionId: sessionId,
-            rootFrameId: artifactRun.rootFrameId,
-            agentFrameId: artifactRun.agentFrameId,
-            messageBranchId: artifactRun.messageBranchId,
-            messageBranchAncestry: artifactRun.messageBranchAncestry,
-            messageAncestry: artifactRun.messageAncestry,
-            runtimeSegmentId: artifactRun.runtimeSegmentId,
-            promptMessageId: artifactRun.promptMessageId,
-            agentName: artifactRun.agentName,
-            notebookSessionId: sessionId,
-            notebookDataDir: getNotebookDataRoot(
-              this.artifactOptions.dataRoot,
-              projectName,
-              sessionId
-            ),
-            notebookSessionRoot: getNotebookSessionRoot(
-              this.artifactOptions.dataRoot,
-              projectName,
-              sessionId
-            )
-          }
-        : {
-            artifactRunId: artifactRun.runId,
-            appSessionId: sessionId,
-            rootFrameId: artifactRun.rootFrameId,
-            agentFrameId: artifactRun.agentFrameId,
-            messageBranchId: artifactRun.messageBranchId,
-            messageBranchAncestry: artifactRun.messageBranchAncestry,
-            messageAncestry: artifactRun.messageAncestry,
-            runtimeSegmentId: artifactRun.runtimeSegmentId,
-            promptMessageId: artifactRun.promptMessageId,
-            agentName: artifactRun.agentName
-          }
-
-    artifactRun.rpcCapabilityToken = this.artifactOptions.issueRpcCapability?.({
-      projectId: projectName,
-      appSessionId: sessionId,
-      artifactStorageSessionId: artifactSessionId,
-      artifactRunId: artifactRun.runId,
-      rootFrameId: artifactRun.rootFrameId,
-      agentFrameId: artifactRun.agentFrameId,
-      messageBranchId: artifactRun.messageBranchId,
-      messageBranchAncestry: artifactRun.messageBranchAncestry,
-      messageAncestry: artifactRun.messageAncestry,
-      runtimeSegmentId: artifactRun.runtimeSegmentId,
-      promptMessageId: artifactRun.promptMessageId,
-      agentName: artifactRun.agentName,
-      ...(this.notebookOptions ? { notebookSessionId: sessionId } : {}),
-      allowedMethods: ['artifactCreateVersion', 'artifactReplayVersion']
+      provenanceContext
     })
-    if (artifactRun.rpcCapabilityToken) {
-      runContext.rpcCapabilityToken = artifactRun.rpcCapabilityToken
-    }
-
-    try {
-      await mkdir(dirname(currentRunFile), { recursive: true })
-      await writeFile(currentRunFile, `${JSON.stringify(runContext)}\n`, 'utf8')
-      this.notebookOptions?.setArtifactProvenanceContext?.(sessionId, {
-        rootFrameId: artifactRun.rootFrameId,
-        agentFrameId: artifactRun.agentFrameId,
-        messageBranchId: artifactRun.messageBranchId,
-        runtimeSegmentId: artifactRun.runtimeSegmentId,
-        promptMessageId: artifactRun.promptMessageId
-      })
-
-      return artifactRun
-    } catch (error) {
-      if (artifactRun.rpcCapabilityToken) {
-        await this.artifactOptions.revokeRpcCapability?.(artifactRun.rpcCapabilityToken)
-      }
-      throw error
-    }
-  }
-
-  // Seals both Artifact write entrances synchronously, then drains operations that already crossed
-  // either entrance. Every emit/cleanup path shares this promise so repeated teardown cannot observe
-  // a partially drained run or bypass an earlier revoke.
-  private closeArtifactRunWrites(artifactRun: ActiveArtifactRun): Promise<void> {
-    if (artifactRun.writeDrainPromise) return artifactRun.writeDrainPromise
-
-    artifactRun.writesClosed = true
-    const rpcDrain = artifactRun.rpcCapabilityToken
-      ? Promise.resolve(this.artifactOptions?.revokeRpcCapability?.(artifactRun.rpcCapabilityToken))
-      : Promise.resolve()
-    artifactRun.writeDrainPromise = (async () => {
-      await rpcDrain
-      await Promise.allSettled([...artifactRun.inFlightAppWrites])
-    })()
-    return artifactRun.writeDrainPromise
   }
 
   // Clears the handoff file after the prompt so late MCP writes cannot attach to a completed turn.
-  private async clearArtifactRun(artifactRun: ActiveArtifactRun | undefined): Promise<void> {
-    if (!artifactRun) return
-
-    await this.closeArtifactRunWrites(artifactRun)
-    await writeFile(artifactRun.currentRunFile, `${JSON.stringify({})}\n`, 'utf8')
-    this.notebookOptions?.setArtifactProvenanceContext?.(artifactRun.appSessionId, undefined)
+  private async clearArtifactRun(artifactRun: ArtifactTurnHandle | undefined): Promise<void> {
+    if (artifactRun) await this.artifactTurns?.dispose(artifactRun)
   }
 
   // Writes an inline file into the in-flight turn's pending artifact run so it attaches to the resulting
@@ -4923,127 +4759,31 @@ class AcpRuntime {
       mimeType?: string
     }
   ): Promise<ArtifactFile> {
-    // Attribute the write to the run of the session that triggered it, resolved from the caller's
-    // session id — never a global "current" run, so a parallel session's in-flight turn cannot capture
-    // this file. Fail closed when the session has no active run.
-    const run = sessionId ? this.activeArtifactRuns.get(sessionId) : undefined
-    if (!run || run.writesClosed || !this.artifactRepository) {
+    if (!this.artifactTurns) {
       throw new Error('No active assistant turn to attach a generated file to.')
     }
-
-    const projectName = this.resolveSessionProjectName(sessionId)
-    const provenance = this.artifactOptions?.provenance
-    const write = provenance
-      ? provenance.writeAppGeneratedVersion({
-          projectId: projectName,
-          appSessionId: sessionId,
-          artifactStorageSessionId: run.artifactSessionId,
-          artifactRunId: run.runId,
-          rootFrameId: run.rootFrameId,
-          agentFrameId: run.agentFrameId,
-          messageBranchId: run.messageBranchId,
-          messageBranchAncestry: run.messageBranchAncestry,
-          messageAncestry: run.messageAncestry,
-          runtimeSegmentId: run.runtimeSegmentId,
-          promptMessageId: run.promptMessageId,
-          agentName: run.agentName,
-          filename: input.filename,
-          content: input.content,
-          contentType: input.mimeType
-        })
-      : this.artifactRepository.writePendingFile({
-          projectName,
-          sessionId: run.artifactSessionId,
-          runId: run.runId,
-          filename: input.filename,
-          mimeType: input.mimeType,
-          source: { kind: 'inline', content: input.content, encoding: 'utf8' }
-        })
-    run.inFlightAppWrites.add(write)
-    void write.then(
-      () => run.inFlightAppWrites.delete(write),
-      () => run.inFlightAppWrites.delete(write)
-    )
-    return write
+    return this.artifactTurns.writeForActiveTurn(sessionId, input)
   }
 
   // Publishes pending files as a claim event; the renderer later supplies the final message id.
   private async emitArtifactRunEvent(
     sessionId: string,
-    artifactRun: ActiveArtifactRun | undefined
+    artifactRun: ArtifactTurnHandle | undefined
   ): Promise<void> {
-    if (!artifactRun) return
-    await this.closeArtifactRunWrites(artifactRun)
-
-    if (!this.artifactOptions || !this.artifactRepository || !this.artifactRunRegistry) {
-      return
-    }
-
-    const sessionProjectName = this.resolveSessionProjectName(sessionId)
-    let artifacts: ArtifactFile[]
-    let artifactVersionIds: string[] | undefined
-    if (this.artifactOptions.provenance) {
-      const versions = await this.artifactOptions.provenance.listRunVersions({
-        projectId: sessionProjectName,
-        appSessionId: sessionId,
-        artifactRunId: artifactRun.runId
-      })
-      artifacts = versions
-      artifactVersionIds = versions.map((version) => version.versionId)
-    } else {
-      artifacts = await this.artifactRepository.listPendingRunFiles({
-        projectName: sessionProjectName,
-        sessionId: artifactRun.artifactSessionId,
-        runId: artifactRun.runId
-      })
-    }
-
-    if (artifacts.length === 0) return
-
-    // Commit the runtime's decision to publish this completed run before exposing an in-memory claim.
-    // If the process exits before the renderer supplies its terminal message id, startup recovery can
-    // still prove this handoff against the durable conversation graph. A run that crashes mid-turn
-    // never reaches this point and therefore cannot be mistaken for a completed handoff.
-    await this.artifactRepository.prepareRunFinalization({
-      projectName: sessionProjectName,
-      sourceSessionId: artifactRun.artifactSessionId,
-      sessionId,
-      runId: artifactRun.runId,
-      ...(artifactVersionIds ? { artifactVersionIds } : {}),
-      provenanceContext: {
-        rootFrameId: artifactRun.rootFrameId,
-        agentFrameId: artifactRun.agentFrameId,
-        messageBranchId: artifactRun.messageBranchId,
-        runtimeSegmentId: artifactRun.runtimeSegmentId,
-        promptMessageId: artifactRun.promptMessageId
-      }
-    })
-
-    const artifactClaimId = this.artifactRunRegistry.register({
-      projectName: sessionProjectName,
-      artifactSessionId: artifactRun.artifactSessionId,
-      sessionId,
-      runId: artifactRun.runId,
-      artifactVersionIds,
-      rootFrameId: artifactRun.rootFrameId,
-      agentFrameId: artifactRun.agentFrameId,
-      messageBranchId: artifactRun.messageBranchId,
-      messageBranchAncestry: artifactRun.messageBranchAncestry,
-      messageAncestry: artifactRun.messageAncestry,
-      runtimeSegmentId: artifactRun.runtimeSegmentId,
-      promptMessageId: artifactRun.promptMessageId
-    })
+    if (!artifactRun || !this.artifactTurns) return
+    const publication = await this.artifactTurns.finalize(artifactRun)
+    if (!publication) return
 
     this.pushEvent({
       kind: 'artifact',
       level: 'info',
       sessionId,
       title: 'Generated files',
-      runId: artifactRun.runId,
-      promptMessageId: artifactRun.promptMessageId,
-      artifactSessionId: artifactRun.artifactSessionId,
-      artifactClaimId,
-      artifacts
+      runId: publication.runId,
+      promptMessageId: publication.promptMessageId,
+      artifactSessionId: publication.artifactStorageSessionId,
+      artifactClaimId: publication.artifactClaimId,
+      artifacts: publication.artifacts
     })
   }
 


### PR DESCRIPTION
## Problem

ACP runtime still owned active Artifact run identity, current-run handoff files, app/RPC write admission and drain, provenance claim preparation, and stale-turn cleanup. These mutable responsibilities made prompt failure and replacement-turn races difficult to enforce locally and kept the runtime growing.

## Proposed change

Extract a main-process-internal `ArtifactTurnOwner` and leave `AcpRuntime` as the prompt-admission and event-publication façade.

```mermaid
flowchart LR
  Prompt["AcpRuntime prompt lifecycle"] -->|open / finalize / dispose| Owner["ArtifactTurnOwner"]
  AppWrite["App-side Artifact write"] -->|Session-scoped write| Owner
  RpcWrite["Run-scoped RPC capability"] -->|revoke + drain| Owner
  Owner --> Handoff["current-run handoff + Notebook provenance context"]
  Owner --> Claim["durable preparation + in-memory claim"]
  Claim -->|immutable publication result| Prompt
  Prompt --> Event["existing Artifact event before stop"]
  Event --> Finalize["existing renderer / IPC Version finalization"]
```

The owner now enforces:

- one active turn per app Session with opaque handles and immutable safe snapshots;
- synchronous write sealing followed by drain of accepted app and RPC writes;
- cached successful claim preparation with retry after transient preparation failure;
- serialized finalization/disposal and best-effort total cleanup;
- per-Session serialization of handoff open/cleanup, including stale provisional-to-stable Session replacement;
- exactly-once capability revocation and claim registration on successful terminal paths.

`AcpRuntime` delegates these responsibilities while preserving public methods and Artifact event ordering.

## Scope and non-goals

In scope:

- ACP Artifact-turn in-memory ownership and lifecycle;
- current-run handoff and Notebook provenance-context switching;
- run-scoped RPC capability issue/revoke and accepted-write drain;
- claim preparation and publication result ownership;
- characterization, failure, retry, and deterministic race tests.

Out of scope:

- Artifact schema, storage layout, final Version finalization, IPC channels, or event payload/order;
- prompt admission, Session registry, connection lifecycle, or A4 capability routing ownership;
- Electron/Web/CLI/Task surface changes;
- Specialist, Permission, or Compute behavior/parity changes;
- Issue #458 parent-child Sessions, delegation, budgets, orchestration persistence, or cross-Session Artifact handoff.

No data model, data relationship, migration, public API, or user-interaction change is introduced.

## Acceptance criteria and validation

All commands below ran after the last material edit at exact head `ec41c4a`.

- Artifact turn open/write/seal/drain/finalize/dispose, transient retry, total cleanup, and replacement races -> `npm test -- --run src/main/acp/artifact-turn-owner.test.ts src/main/acp/runtime.test.ts` -> 2 files, 376 tests passed.
- Artifact/Notebook/IPC/recovery integration -> `npm test -- --run src/main/acp/artifact-turn-owner.test.ts src/main/acp/runtime.test.ts src/main/acp/runtime-coordinator.test.ts src/main/notebook/local-rpc-server.test.ts src/main/artifacts/repository.test.ts src/main/artifacts/ipc.test.ts src/main/session-persistence/artifact-finalization-recovery.integration.test.ts` -> 7 files, 532 tests passed.
- Electron/Web/CLI/Task/IPC compatibility -> `npm test -- --run src/preload/index.test.ts src/shared/web-rpc-contract.test.ts src/main/web-service/http-server.test.ts src/main/web-service/task-api.test.ts src/main/tasks/task-runner.test.ts packages/open-science/client.test.ts packages/open-science/cli.test.ts src/renderer/src/lib/acp/workspace-events.test.ts` -> 8 files, 170 tests passed.
- Node/Web type contracts -> `npm run typecheck` -> passed.
- Repository lint -> `npm run lint` -> 0 errors; 19 pre-existing warnings outside this diff.
- Complete regression suite -> `npm test -- --run` -> 671 files passed / 15 skipped; 9,860 tests passed / 184 skipped.

Independent fixed-point Standards, Spec/compatibility, and deep-module reviews all inspected `c6d6ee4...ec41c4a`; all reported 0 remaining P0-P2 findings. Review findings around revoke failure, total cleanup, transient retry, terminal serialization, distinct handoff cleanup, and overlapping replacement open were fixed and covered by regression tests before the final reviews.

Uncovered risk: local validation ran on macOS. The deterministic handoff writer test covers the ordering race without relying on filesystem scheduling; repository CI remains responsible for Windows-specific filesystem and E2E behavior.

## Review focus

- Verify that `ArtifactTurnOwner` is the sole owner of active run state, handoff mutation, write drain, terminal claim preparation, and stale cleanup.
- Verify that `AcpRuntime` still owns prompt admission and publishes the unchanged Artifact event before stop.
- Verify that final Artifact Version finalization remains in the existing renderer/IPC persistence path.
- Verify that A4 is consulted only through `artifactRoutingIdFor(sessionId)` and no MCP transport/HTTP-host state moved into A5.
- Verify that raw cross-Session paths remain denied while existing explicit same-Project Artifact Version references remain unchanged.

Related: #458 (forward-compatibility boundary only; this PR does not implement it).
