### PR TITLE
perf(acp): reduce agent context overhead

### DIFF
--- a/src/main/acp/context-usage-static-context.test.ts
+++ b/src/main/acp/context-usage-static-context.test.ts
@@ -1,5 +1,8 @@
 import { describe, expect, it } from 'vitest'
+import { Tiktoken } from 'js-tiktoken/lite'
+import cl100kBase from 'js-tiktoken/ranks/cl100k_base'
 
+import { NOTEBOOK_SYSTEM_PROMPT_APPEND } from '../notebook/mcp-server'
 import { contextUsageMcpSections } from './context-usage-static-context'
 
 describe('contextUsageMcpSections', () => {
@@ -32,6 +35,20 @@ describe('contextUsageMcpSections', () => {
     const text = sections.map((section) => section.text).join('\n')
     expect(text).toContain('mcp.open-science-notebook.notebook_execute')
     expect(text).not.toContain('mcp__open_science_notebook__notebook_execute')
+  })
+
+  it('keeps the notebook schema plus scoped guidance within the static context budget', () => {
+    const [{ text: schema }] = contextUsageMcpSections('codex', {
+      artifacts: false,
+      notebook: true,
+      skillImport: false
+    })
+    const tokenizer = new Tiktoken(cl100kBase)
+
+    // Baseline before deduplication was about 5.2k cl100k tokens (3.6k schema + 1.6k prompt).
+    expect(
+      tokenizer.encode(`${NOTEBOOK_SYSTEM_PROMPT_APPEND}\n${schema}`).length
+    ).toBeLessThanOrEqual(3_200)
   })
 
   it('uses bridge aliases for Codex MCP tools delivered through a compatibility proxy', () => {

--- a/src/main/acp/runtime.test.ts
+++ b/src/main/acp/runtime.test.ts
@@ -12670,6 +12670,50 @@ describe('ACP runtime session management', () => {
     expect(states).not.toContain('closed')
   })
 
+  it('does not let a stale planned reconnect overwrite a newer connection status', async () => {
+    const oldProcess = new FakeAgentProcess()
+    const newProcess = new FakeAgentProcess()
+    startFakeAgent(oldProcess, ['s1'])
+    startFakeAgent(newProcess, ['s2'])
+    const teardownStarted = createDeferred()
+    const releaseTeardown = createDeferred()
+    let spawnCount = 0
+    const runtime = new AcpRuntime({
+      appVersion: '0.1.0',
+      defaultCwd: '/workspace',
+      resolveBackend: () => ({
+        framework: {
+          ...claudeCodeFramework,
+          spawn: () => asAgentProcess(spawnCount++ === 0 ? oldProcess : newProcess)
+        },
+        executablePath: '/bin/agent',
+        env: {}
+      })
+    })
+
+    await runtime.createSession({ cwd: '/workspace' })
+    vi.mocked(terminateProcessTree).mockImplementationOnce(async (child) => {
+      child?.kill()
+      teardownStarted.resolve()
+      await releaseTeardown.promise
+      return { reaped: true }
+    })
+    const reconnect = runtime.requestProviderReconnect()
+    await teardownStarted.promise
+
+    try {
+      await expect(runtime.createSession({ cwd: '/workspace' })).resolves.toMatchObject({
+        sessionId: 's2'
+      })
+      expect(runtime.getSnapshot().status).toBe('connected')
+    } finally {
+      releaseTeardown.resolve()
+      await reconnect
+    }
+
+    expect(runtime.getSnapshot().status).toBe('connected')
+  })
+
   it('passes the artifact MCP server to new and resumed sessions', async () => {
     const process = new FakeAgentProcess()
     const fakeAgent = startFakeAgent(process, ['remote-session-1'])

--- a/src/main/acp/runtime.test.ts
+++ b/src/main/acp/runtime.test.ts
@@ -4163,7 +4163,7 @@ describe('ACP runtime session management', () => {
     })
   })
 
-  it('delivers resolved connector guidance to Codex as a prompt prefix', async () => {
+  it('keeps backend-persistent Codex guidance out of the user prompt', async () => {
     const process = new FakeAgentProcess()
     const fakeAgent = startFakeAgent(process, ['codex-session'], {
       modes: {
@@ -4171,24 +4171,34 @@ describe('ACP runtime session management', () => {
         availableModes: ['read-only', 'agent', 'agent-full-access'].map((id) => ({ id, name: id }))
       }
     })
-    const connectorInstructions =
-      'Load the matching `mcp-*` skill before using a connector, then call host.mcp(...).'
+    const persistentInstructions = 'Stable Codex developer instructions.'
+    let resolvedContext: { forcedSkillIds: string[]; systemPromptAppends?: string[] } | undefined
     const runtime = new AcpRuntime({
       appVersion: '0.1.0',
       defaultCwd: '/workspace',
-      resolveBackend: () => ({
-        framework: { ...codexFramework, spawn: () => asAgentProcess(process) },
-        executablePath: '/bin/codex-acp',
-        env: {},
-        systemPromptAppends: [connectorInstructions]
-      })
+      resolveBackend: (context) => {
+        resolvedContext = context
+        return {
+          framework: { ...codexFramework, spawn: () => asAgentProcess(process) },
+          executablePath: '/bin/codex-acp',
+          env: {},
+          persistentSystemPrompt: persistentInstructions
+        }
+      }
     })
 
     const session = await runtime.createSession({ cwd: '/workspace' })
     await runtime.sendPrompt({ sessionId: session.sessionId, text: 'search PubMed' })
+    await runtime.sendPrompt({ sessionId: session.sessionId, text: 'summarize the results' })
 
-    expect(fakeAgent.prompts[0].text).toContain(connectorInstructions)
-    expect(fakeAgent.prompts[0].text).toContain('search PubMed')
+    expect(resolvedContext?.systemPromptAppends).toEqual(
+      expect.arrayContaining([expect.stringContaining('open_science_large_file_instructions')])
+    )
+    expect(fakeAgent.prompts.map(({ text }) => text)).toEqual([
+      'search PubMed',
+      'summarize the results'
+    ])
+    expect(fakeAgent.prompts.every(({ text }) => !text.includes(persistentInstructions))).toBe(true)
   })
 
   it('forwards resolved Claude session options on create and resume', async () => {
@@ -4220,23 +4230,33 @@ describe('ACP runtime session management', () => {
     })
   })
 
-  it('delivers the large-data-file guidance to opencode as a prompt prefix', async () => {
+  it('keeps backend-persistent OpenCode guidance out of the user prompt', async () => {
     const process = new FakeAgentProcess()
     const fakeAgent = startFakeAgent(process, ['oc-session'])
+    let resolvedContext: { forcedSkillIds: string[]; systemPromptAppends?: string[] } | undefined
     const runtime = new AcpRuntime({
       appVersion: '0.1.0',
       defaultCwd: '/workspace',
-      spawnAgent: () => asAgentProcess(process),
-      framework: opencodeFramework
+      resolveBackend: (context) => {
+        resolvedContext = context
+        return {
+          framework: { ...opencodeFramework, spawn: () => asAgentProcess(process) },
+          executablePath: '/bin/opencode',
+          env: {},
+          persistentSystemPrompt: 'Stable OpenCode instructions.'
+        }
+      }
     })
 
     const session = await runtime.createSession({ cwd: '/workspace' })
     await runtime.sendPrompt({ sessionId: session.sessionId, text: 'hello opencode' })
+    await runtime.sendPrompt({ sessionId: session.sessionId, text: 'continue' })
 
-    // opencode has no system-prompt preset, so the guidance rides the prompt prefix ahead of user text.
     expect(fakeAgent.newSessions[0]._meta).toBeUndefined()
-    expect(fakeAgent.prompts[0].text).toContain('open_science_large_file_instructions')
-    expect(fakeAgent.prompts[0].text).toContain('hello opencode')
+    expect(resolvedContext?.systemPromptAppends).toEqual(
+      expect.arrayContaining([expect.stringContaining('open_science_large_file_instructions')])
+    )
+    expect(fakeAgent.prompts.map(({ text }) => text)).toEqual(['hello opencode', 'continue'])
   })
 
   it('waits for session-scoped MCP capability readiness before creating the agent session', async () => {
@@ -11580,6 +11600,7 @@ describe('ACP runtime session management', () => {
     const process = new FakeAgentProcess()
     const gate = createDeferred()
     const usageSent = createDeferred()
+    const states: string[] = []
     startFakeAgent(process, ['s1'], {
       onPrompt: async ({ sessionId }) => {
         handleSessionUpdate(runtime, {
@@ -11603,7 +11624,8 @@ describe('ACP runtime session management', () => {
     const runtime = new AcpRuntime({
       appVersion: '0.1.0',
       defaultCwd: '/workspace',
-      spawnAgent: () => asAgentProcess(process)
+      spawnAgent: () => asAgentProcess(process),
+      callbacks: { onStateChanged: (snapshot) => states.push(snapshot.status) }
     })
 
     await runtime.createSession({ cwd: '/workspace' })
@@ -11629,6 +11651,8 @@ describe('ACP runtime session management', () => {
     await prompt
     await new Promise((resolve) => setTimeout(resolve, 0))
     expect(process.killed).toBe(true)
+    expect(runtime.getSnapshot().status).toBe('idle')
+    expect(states).not.toContain('closed')
     expect(runtime.getSnapshot().contextUsageBySession).toEqual({})
   })
 
@@ -12630,16 +12654,20 @@ describe('ACP runtime session management', () => {
   it('reconnects immediately when a provider switch happens with no prompt in flight', async () => {
     const process = new FakeAgentProcess()
     startFakeAgent(process, ['s1'])
+    const states: string[] = []
     const runtime = new AcpRuntime({
       appVersion: '0.1.0',
       defaultCwd: '/workspace',
-      spawnAgent: () => asAgentProcess(process)
+      spawnAgent: () => asAgentProcess(process),
+      callbacks: { onStateChanged: (snapshot) => states.push(snapshot.status) }
     })
 
     await runtime.createSession({ cwd: '/workspace' })
     await runtime.requestProviderReconnect()
 
     expect(process.killed).toBe(true)
+    expect(runtime.getSnapshot().status).toBe('idle')
+    expect(states).not.toContain('closed')
   })
 
   it('passes the artifact MCP server to new and resumed sessions', async () => {
@@ -14207,16 +14235,23 @@ describe('ACP runtime skill force-load + nudge', () => {
   it('passes turn-forced skill ids to backend resolution per runtime instance', async () => {
     const firstSpawner = createFreshAgentSpawner()
     const secondSpawner = createFreshAgentSpawner()
-    const firstContexts: Array<{ forcedSkillIds: string[] } | undefined> = []
-    const secondContexts: Array<{ forcedSkillIds: string[] } | undefined> = []
+    const firstContexts: Array<
+      { forcedSkillIds: string[]; systemPromptAppends?: string[] } | undefined
+    > = []
+    const secondContexts: Array<
+      { forcedSkillIds: string[]; systemPromptAppends?: string[] } | undefined
+    > = []
     const createRuntime = (
       spawner: ReturnType<typeof createFreshAgentSpawner>,
-      contexts: Array<{ forcedSkillIds: string[] } | undefined>
+      contexts: Array<{ forcedSkillIds: string[]; systemPromptAppends?: string[] } | undefined>
     ): AcpRuntime =>
       new AcpRuntime({
         appVersion: '0.1.0',
         defaultCwd: '/workspace',
-        resolveBackend: (context?: { forcedSkillIds: string[] }) => {
+        resolveBackend: (context?: {
+          forcedSkillIds: string[]
+          systemPromptAppends?: string[]
+        }) => {
           contexts.push(context)
           return {
             framework: { ...claudeCodeFramework, spawn: spawner.spawn },
@@ -14249,10 +14284,18 @@ describe('ACP runtime skill force-load + nudge', () => {
       })
     ])
 
-    expect(firstContexts).toContainEqual({ forcedSkillIds: ['skill-a'] })
-    expect(secondContexts).toContainEqual({ forcedSkillIds: ['skill-b'] })
-    expect(firstContexts).not.toContainEqual({ forcedSkillIds: ['skill-b'] })
-    expect(secondContexts).not.toContainEqual({ forcedSkillIds: ['skill-a'] })
+    expect(firstContexts).toEqual(
+      expect.arrayContaining([expect.objectContaining({ forcedSkillIds: ['skill-a'] })])
+    )
+    expect(secondContexts).toEqual(
+      expect.arrayContaining([expect.objectContaining({ forcedSkillIds: ['skill-b'] })])
+    )
+    expect(firstContexts).not.toEqual(
+      expect.arrayContaining([expect.objectContaining({ forcedSkillIds: ['skill-b'] })])
+    )
+    expect(secondContexts).not.toEqual(
+      expect.arrayContaining([expect.objectContaining({ forcedSkillIds: ['skill-a'] })])
+    )
   })
 
   it('respawns and nudges when a picked skill is disabled, then restores after the turn', async () => {
@@ -14287,9 +14330,10 @@ describe('ACP runtime skill force-load + nudge', () => {
       }
     ])
 
-    // After the turn the force set is cleared and a restore reconnect is scheduled (agent torn down).
+    // After the turn the force set is cleared and a planned restore reconnect tears the agent down
+    // without advertising an abnormal closed connection to the renderer.
     await new Promise((resolve) => setTimeout(resolve, 0))
-    expect(runtime.getSnapshot().status).toBe('closed')
+    expect(runtime.getSnapshot().status).toBe('idle')
   })
 
   it('nudges without any reconnect when every picked skill is already enabled', async () => {

--- a/src/main/acp/runtime.ts
+++ b/src/main/acp/runtime.ts
@@ -180,6 +180,7 @@ type AcpRuntimeOptions = {
   // inject that directly).
   resolveBackend?: (context: {
     forcedSkillIds: string[]
+    systemPromptAppends: string[]
   }) => Promise<ResolvedAgentBackend> | ResolvedAgentBackend
   artifacts?: AcpRuntimeArtifactOptions
   uploads?: AcpRuntimeUploadOptions
@@ -695,6 +696,7 @@ class AcpRuntime {
   private pendingSessionEffort: ModelReasoningEffort | undefined
   private pendingSessionOptions: Record<string, unknown> | undefined
   private pendingSystemPromptAppends: string[] = []
+  private pendingPersistentSystemPrompt: string | undefined
   // The latest configOptions each session reported — seeded from session/new and refreshed after a
   // model switch (effort rungs are model-dependent, so the original set goes stale). The live effort
   // path resolves against this, never against the possibly-outdated session/new response.
@@ -2789,7 +2791,7 @@ class AcpRuntime {
     }
 
     this.pendingProviderReconnect = false
-    await this.disconnect()
+    await this.disconnectForPlannedReconnect()
   }
 
   // If a provider reconnect was deferred while a prompt ran, apply it once nothing is in flight.
@@ -2826,7 +2828,7 @@ class AcpRuntime {
   private async disconnectForDeferredReconnect(): Promise<void> {
     const reconnectBarrierGeneration = this.reconnectBarrierGeneration
     try {
-      await this.disconnect()
+      await this.disconnectForPlannedReconnect()
     } catch (error) {
       safeLogError('deferred reconnect disconnect failed', errorLogFields(error))
       // disconnect() rejected — its synchronous teardown may have thrown before clearing the
@@ -2849,6 +2851,16 @@ class AcpRuntime {
       // this one is settling. Complete only the barrier generation this teardown was started for.
       this.completePendingReconnectTeardown(reconnectBarrierGeneration)
     }
+  }
+
+  // A provider/model change deliberately detaches the current native sessions so the next prompt can
+  // resume them on a freshly configured process. Publish `idle`, not `closed`: renderer treats a
+  // running-session transition to closed/error as an unexpected transport loss and offers Resume.
+  // The main-process turn can already be terminal while its renderer event is still queued, so even an
+  // otherwise idle reconnect must not expose that race as a false interruption.
+  private async disconnectForPlannedReconnect(): Promise<void> {
+    await this.disconnect(false)
+    this.setStatus('idle')
   }
 
   // Retirement is terminal for this runtime generation. Swallow teardown failures just like deferred
@@ -3098,7 +3110,10 @@ class AcpRuntime {
     }
 
     const backend = this.options.resolveBackend
-      ? await this.options.resolveBackend({ forcedSkillIds: [...this.turnForcedSkillIds] })
+      ? await this.options.resolveBackend({
+          forcedSkillIds: [...this.turnForcedSkillIds],
+          systemPromptAppends: await this.getBackendSystemPromptAppends()
+        })
       : undefined
 
     if (!backend) {
@@ -3151,6 +3166,7 @@ class AcpRuntime {
     this.selectedContextUsageModel = backend.contextUsageModel
     this.pendingSessionOptions = backend.sessionOptions
     this.pendingSystemPromptAppends = [...(backend.systemPromptAppends ?? [])]
+    this.pendingPersistentSystemPrompt = backend.persistentSystemPrompt
     this.pendingAuthentication = backend.authentication
     this.pendingProviderConfiguration = backend.providerConfiguration
     this.opencodeUsageApi = backend.opencodeUsageApi
@@ -3409,11 +3425,12 @@ class AcpRuntime {
       // the agent; the user-facing message event keeps the original text (which already shows /Name).
       // Framework-neutral delivery of system-prompt guidance: Claude carries appends in session _meta;
       // frameworks without a session preset carry the guidance as a prompt prefix.
+      const specialistSkillGuidance = this.specialistSkillGuidance(currentSpecialistSkills)
       const { promptPrefix: frameworkPromptPrefix } = this.framework.buildSessionSetup({
-        systemPromptAppends: this.getSystemPromptAppends(
-          this.specialistSkillGuidance(currentSpecialistSkills)
-        ),
-        turnPromptReminders: [],
+        systemPromptAppends: this.pendingPersistentSystemPrompt
+          ? []
+          : this.getSystemPromptAppends(),
+        turnPromptReminders: specialistSkillGuidance ? [specialistSkillGuidance] : [],
         sessionOptions: this.pendingSessionOptions
       })
       // For Codex/OpenCode, prepend the per-session specialist identity prefix (set at createSession).
@@ -4625,16 +4642,27 @@ class AcpRuntime {
     })
   }
 
+  private getAppSystemPromptAppends(): string[] {
+    return [
+      TURN_CONTINUITY_SYSTEM_PROMPT_APPEND,
+      LARGE_DATA_FILE_SYSTEM_PROMPT_APPEND,
+      ...(this.artifactToolingAvailable() ? [ARTIFACT_FILE_SYSTEM_PROMPT_APPEND] : []),
+      ...(this.notebookToolingAvailable() ? [NOTEBOOK_SYSTEM_PROMPT_APPEND] : []),
+      ...(this.skillImportToolingAvailable() ? [SKILL_IMPORT_SYSTEM_PROMPT_APPEND] : [])
+    ]
+  }
+
+  private async getBackendSystemPromptAppends(): Promise<string[]> {
+    await this.sessionCapabilities.refreshDynamicAvailability()
+    return this.getAppSystemPromptAppends()
+  }
+
   private getSystemPromptAppends(skillGuidance?: string): string[] {
     // Each append names MCP tools that only exist when that tooling is actually wired for this session;
     // omit it otherwise so the agent isn't told to use tools it wasn't given.
     return [
-      TURN_CONTINUITY_SYSTEM_PROMPT_APPEND,
-      LARGE_DATA_FILE_SYSTEM_PROMPT_APPEND,
+      ...this.getAppSystemPromptAppends(),
       ...this.pendingSystemPromptAppends,
-      ...(this.artifactToolingAvailable() ? [ARTIFACT_FILE_SYSTEM_PROMPT_APPEND] : []),
-      ...(this.notebookToolingAvailable() ? [NOTEBOOK_SYSTEM_PROMPT_APPEND] : []),
-      ...(this.skillImportToolingAvailable() ? [SKILL_IMPORT_SYSTEM_PROMPT_APPEND] : []),
       ...(skillGuidance ? [skillGuidance] : [])
     ]
   }
@@ -5233,9 +5261,11 @@ class AcpRuntime {
   private contextUsageEstimateInput(sessionId?: string): SessionEstimateInput {
     const { model } = this.contextUsageSelectionFor(sessionId)
     const sessionSetup = this.framework.buildSessionSetup({
-      systemPromptAppends: this.getSystemPromptAppends(),
+      systemPromptAppends: this.pendingPersistentSystemPrompt ? [] : this.getSystemPromptAppends(),
       sessionOptions: this.pendingSessionOptions
     })
+    const persistentSystemPrompt =
+      this.pendingPersistentSystemPrompt ?? sessionSetup.persistentSystemPrompt
     const persistentSections = contextUsageMcpSections(this.framework.id, {
       artifacts: this.artifactToolingAvailable(),
       notebook: this.notebookToolingAvailable(),
@@ -5246,9 +5276,7 @@ class AcpRuntime {
     return {
       frameworkId: this.framework.id,
       ...(model ? { model } : {}),
-      ...(sessionSetup.persistentSystemPrompt
-        ? { persistentSystemPrompt: [sessionSetup.persistentSystemPrompt] }
-        : {}),
+      ...(persistentSystemPrompt ? { persistentSystemPrompt: [persistentSystemPrompt] } : {}),
       ...(persistentSections.length > 0 ? { persistentSections } : {})
     }
   }

--- a/src/main/acp/runtime.ts
+++ b/src/main/acp/runtime.ts
@@ -2859,8 +2859,10 @@ class AcpRuntime {
   // The main-process turn can already be terminal while its renderer event is still queued, so even an
   // otherwise idle reconnect must not expose that race as a false interruption.
   private async disconnectForPlannedReconnect(): Promise<void> {
-    await this.disconnect(false)
-    this.setStatus('idle')
+    const disconnect = this.disconnect(false)
+    const teardownGeneration = this.connectionGeneration
+    await disconnect
+    if (teardownGeneration === this.connectionGeneration) this.setStatus('idle')
   }
 
   // Retirement is terminal for this runtime generation. Swallow teardown failures just like deferred

--- a/src/main/acp/session-capability-owner.test.ts
+++ b/src/main/acp/session-capability-owner.test.ts
@@ -31,6 +31,30 @@ const createOwner = (
   })
 
 describe('ACP session capability owner', () => {
+  it('refreshes preference-backed availability before backend guidance is projected', async () => {
+    let skillImportEnabled = false
+    const owner = createOwner({
+      skillImport: {
+        mcpEntryPath: '/app/main.js',
+        isEnabled: async () => skillImportEnabled,
+        getRpcConnection: async () => ({ endpoint: 'http://127.0.0.1:2', token: 'skill' })
+      }
+    })
+    const input = {
+      framework: opencodeFramework,
+      nativeMcpEnabled: true,
+      bridgeMcpAliasesEnabled: false,
+      policy: CURRENT_PRIMARY_SESSION_CAPABILITY_POLICY
+    }
+
+    await owner.refreshDynamicAvailability()
+    expect(owner.toolingAvailability(input).skillImport).toBe(false)
+
+    skillImportEnabled = true
+    await owner.refreshDynamicAvailability()
+    expect(owner.toolingAvailability(input).skillImport).toBe(true)
+  })
+
   it('derives the exact current primary set while reviewer and unknown capabilities fail closed', async () => {
     const owner = createOwner()
     const routingIds = owner.createRoutingIds('session-1')

--- a/src/main/acp/session-capability-owner.ts
+++ b/src/main/acp/session-capability-owner.ts
@@ -411,6 +411,14 @@ export class AcpSessionCapabilityOwner {
     return this.skillImportEnabled
   }
 
+  // Skill-import enablement is preference-backed and may change between connections. Refresh it
+  // before projecting tooling guidance into backend-native instructions, which happens before the
+  // concrete session capability set is built.
+  async refreshDynamicAvailability(): Promise<void> {
+    if (!this.options.skillImport) return
+    this.skillImportEnabled = (await this.options.skillImport.isEnabled?.()) ?? true
+  }
+
   toolingAvailability(input: {
     framework: Pick<AgentFramework, 'acceptsStdioMcp'>
     nativeMcpEnabled: boolean
@@ -492,7 +500,7 @@ export class AcpSessionCapabilityOwner {
     routingId: string
   ): Promise<SkillImportMcpEnvironment | undefined> {
     if (!this.options.skillImport || !routingId) return undefined
-    this.skillImportEnabled = (await this.options.skillImport.isEnabled?.()) ?? true
+    await this.refreshDynamicAvailability()
     if (!this.skillImportEnabled) return undefined
     const connection = await this.options.skillImport.getRpcConnection()
     return { ...connection, sessionId: routingId }

--- a/src/main/agent-framework/claude-code.test.ts
+++ b/src/main/agent-framework/claude-code.test.ts
@@ -71,20 +71,26 @@ describe('claudeCodeFramework', () => {
     expect(setup.persistentSystemPrompt).toBe(systemPrompt.append)
   })
 
-  it('keeps generic MCP tool references unchanged for Codex', () => {
+  it('keeps turn-only MCP tool references unchanged for Codex', () => {
     const append = 'Use `notebook_execute` and then `write_artifact_file`.'
 
-    expect(codexFramework.buildSessionSetup({ systemPromptAppends: [append] }).promptPrefix).toBe(
-      append
-    )
+    expect(
+      codexFramework.buildSessionSetup({
+        systemPromptAppends: [],
+        turnPromptReminders: [append]
+      }).promptPrefix
+    ).toBe(append)
   })
 
-  it('renders generic MCP tool references as OpenCode callable names', () => {
+  it('renders turn-only MCP tool references as OpenCode callable names', () => {
     const append =
       'Use `notebook_execute` from `open-science-notebook`, then `write_artifact_file`.'
 
     expect(
-      opencodeFramework.buildSessionSetup({ systemPromptAppends: [append] }).promptPrefix
+      opencodeFramework.buildSessionSetup({
+        systemPromptAppends: [],
+        turnPromptReminders: [append]
+      }).promptPrefix
     ).toBe(
       'Use `open_science_notebook_notebook_execute` from `open_science_notebook`, then `open_science_artifacts_write_artifact_file`.'
     )

--- a/src/main/agent-framework/claude-code.test.ts
+++ b/src/main/agent-framework/claude-code.test.ts
@@ -66,6 +66,9 @@ describe('claudeCodeFramework', () => {
     expect(systemPrompt.append).toContain('`mcp__open-science-notebook__inspect_packages`')
     expect(systemPrompt.append).toContain('`mcp__open-science-notebook__manage_packages`')
     expect(systemPrompt.append).toContain('`mcp__open-science-artifacts__write_artifact_file`')
+    expect(systemPrompt.append).not.toContain(
+      'open-science-artifacts.mcp__open-science-artifacts__write_artifact_file'
+    )
     expect(systemPrompt.append).not.toMatch(/`notebook_execute`/)
     expect(systemPrompt.append).not.toMatch(/`write_artifact_file`/)
     expect(setup.persistentSystemPrompt).toBe(systemPrompt.append)

--- a/src/main/agent-framework/codex.test.ts
+++ b/src/main/agent-framework/codex.test.ts
@@ -206,12 +206,14 @@ describe('codexFramework', () => {
       {
         storageRoot: '/data',
         executablePath: '/runtime/codex-acp',
-        responsesBridge: { baseUrl: 'http://127.0.0.1:43123/v1', token: 'local-token' }
+        responsesBridge: { baseUrl: 'http://127.0.0.1:43123/v1', token: 'local-token' },
+        systemPromptAppends: ['Stable bridge guidance.']
       }
     )
 
     expect(JSON.parse(config.env?.CODEX_CONFIG ?? '')).toMatchObject({
       model: CODEX_BRIDGE_MODEL,
+      developer_instructions: 'Stable bridge guidance.',
       model_context_window: 128_000,
       model_auto_compact_token_limit: 121_600,
       model_provider: 'open-science',
@@ -234,6 +236,7 @@ describe('codexFramework', () => {
       headers: { authorization: 'Bearer local-token' }
     })
     expect(config.env?.CODEX_CONFIG).not.toContain('upstream-secret')
+    expect(config.persistentSystemPrompt).toBe('Stable bridge guidance.')
   })
 
   it('drives a native-Responses vendor directly on its OpenAI /v1 base, ignoring the bridge', () => {
@@ -569,12 +572,51 @@ describe('codexFramework', () => {
     })
   })
 
-  it('delivers Open Science session guidance as a prompt prefix', () => {
+  it('delivers Open Science session guidance as persistent developer instructions', () => {
     const framework = createCodexFramework()
 
-    expect(framework.buildSessionSetup({ systemPromptAppends: ['one', 'two'] })).toEqual({
-      promptPrefix: 'one\n\ntwo'
+    const config = framework.prepareModelConfig(
+      {
+        type: 'custom',
+        apiEndpoints: ['responses'],
+        baseUrl: 'https://api.openai.com/v1',
+        model: 'gpt-5.6-sol'
+      },
+      {
+        storageRoot: '/data',
+        executablePath: '/runtime/codex-acp',
+        systemPromptAppends: ['one', 'two']
+      }
+    )
+
+    expect(JSON.parse(config.env?.CODEX_CONFIG ?? '{}').developer_instructions).toBe('one\n\ntwo')
+    expect(config.persistentSystemPrompt).toBe('one\n\ntwo')
+    expect(
+      framework.buildSessionSetup({
+        systemPromptAppends: [],
+        turnPromptReminders: ['turn-only reminder']
+      })
+    ).toEqual({
+      promptPrefix: 'turn-only reminder'
     })
+  })
+
+  it('persists app guidance for a subscription backend', () => {
+    const framework = createCodexFramework()
+    const config = framework.prepareModelConfig(
+      { type: 'codex-isolated', apiEndpoints: ['responses'], model: 'gpt-5.6-terra' },
+      {
+        storageRoot: '/data',
+        executablePath: '/runtime/codex-acp',
+        systemPromptAppends: ['Stable subscription guidance.']
+      }
+    )
+
+    expect(JSON.parse(config.env?.CODEX_CONFIG ?? '{}')).toMatchObject({
+      model: 'gpt-5.6-terra',
+      developer_instructions: 'Stable subscription guidance.'
+    })
+    expect(config.persistentSystemPrompt).toBe('Stable subscription guidance.')
   })
 
   it.each([

--- a/src/main/agent-framework/codex.ts
+++ b/src/main/agent-framework/codex.ts
@@ -369,6 +369,8 @@ export const createCodexFramework = ({
   },
 
   prepareModelConfig(provider, ctx: ModelConfigContext): AgentModelConfig {
+    const persistentSystemPrompt =
+      ctx.systemPromptAppends?.filter(Boolean).join('\n\n') || undefined
     if (isCodexSubscriptionProvider(provider.type)) {
       // Every Open Science subscription session uses the same app-owned home. `codex-shared` is
       // accepted only as a legacy Provider discriminator; it must never select the user's global
@@ -378,14 +380,19 @@ export const createCodexFramework = ({
         model: provider.model,
         reasoningEffort: ctx.reasoningEffort
       })
+      const codexConfig = {
+        ...modelOptions,
+        ...(persistentSystemPrompt ? { developer_instructions: persistentSystemPrompt } : {})
+      }
       const codexConfigJson =
-        Object.keys(modelOptions).length > 0 ? JSON.stringify(modelOptions) : undefined
+        Object.keys(codexConfig).length > 0 ? JSON.stringify(codexConfig) : undefined
       const codexHome = codexSubscriptionStorageDir(ctx.storageRoot)
       return {
         env: {
           ...isolatedCodexHomeEnv(codexHome, platform),
           ...(codexConfigJson ? { CODEX_CONFIG: codexConfigJson } : {})
-        }
+        },
+        ...(persistentSystemPrompt ? { persistentSystemPrompt } : {})
       }
     }
 
@@ -443,7 +450,8 @@ export const createCodexFramework = ({
         key: useLocalResponsesEndpoint ? undefined : provider.key,
         reasoningEffort: ctx.reasoningEffort
       }),
-      ...(modelCatalogPath ? { model_catalog_json: modelCatalogPath } : {})
+      ...(modelCatalogPath ? { model_catalog_json: modelCatalogPath } : {}),
+      ...(persistentSystemPrompt ? { developer_instructions: persistentSystemPrompt } : {})
     }
     return {
       env: {
@@ -480,14 +488,19 @@ export const createCodexFramework = ({
             } satisfies AgentProviderConfiguration
           }
         : {}),
-      ...(useChatBridge ? { sessionModel: CODEX_BRIDGE_MODEL } : {})
+      ...(useChatBridge ? { sessionModel: CODEX_BRIDGE_MODEL } : {}),
+      ...(persistentSystemPrompt ? { persistentSystemPrompt } : {})
     }
   },
 
   buildSessionSetup(ctx: SessionSetupContext): SessionSetup {
+    // Production backends pass no stable appends here because developer_instructions owns them.
+    // Keep the fallback for injected/legacy backends and ephemeral reviewer sessions.
+    const promptPrefix = [...ctx.systemPromptAppends, ...(ctx.turnPromptReminders ?? [])]
+      .filter(Boolean)
+      .join('\n\n')
     return {
-      promptPrefix:
-        ctx.systemPromptAppends.length > 0 ? ctx.systemPromptAppends.join('\n\n') : undefined
+      ...(promptPrefix ? { promptPrefix } : {})
     }
   },
 

--- a/src/main/agent-framework/opencode.test.ts
+++ b/src/main/agent-framework/opencode.test.ts
@@ -23,6 +23,36 @@ describe('opencodeFramework.prepareModelConfig', () => {
     expect(parsed.instructions).toContain(instructionsFile?.path)
   })
 
+  it('writes stable app guidance to native instructions instead of a user prompt', () => {
+    const config = opencodeFramework.prepareModelConfig(
+      { type: 'custom', baseUrl: 'https://gw/v1', model: 'm', key: 'k' },
+      {
+        storageRoot: '/data',
+        executablePath: '/bin/opencode',
+        systemPromptAppends: [
+          'Use `notebook_execute` from `open-science-notebook`.',
+          'Then call `write_artifact_file`.'
+        ]
+      }
+    )
+
+    const instructionsFile = config.configFiles?.find((file) =>
+      file.path.endsWith('open-science.md')
+    )
+    expect(instructionsFile?.content).toBe(
+      'Use `open_science_notebook_notebook_execute` from `open_science_notebook`.\n\nThen call `open_science_artifacts_write_artifact_file`.'
+    )
+    const opencodeJson = config.configFiles?.find((file) => file.path.endsWith('opencode.json'))
+    expect(JSON.parse(opencodeJson?.content ?? '{}').instructions).toContain(instructionsFile?.path)
+    expect(config.persistentSystemPrompt).toBe(instructionsFile?.content)
+    expect(
+      opencodeFramework.buildSessionSetup({
+        systemPromptAppends: [],
+        turnPromptReminders: ['turn-only reminder']
+      })
+    ).toEqual({ promptPrefix: 'turn-only reminder' })
+  })
+
   it('omits instructions when none are provided', () => {
     const config = opencodeFramework.prepareModelConfig(
       { type: 'custom', baseUrl: 'https://gw/v1', model: 'm', key: 'k' },

--- a/src/main/agent-framework/opencode.ts
+++ b/src/main/agent-framework/opencode.ts
@@ -25,7 +25,7 @@ import { renderAppMcpToolReferences } from './app-mcp-names'
 
 // opencode speaks ACP over `opencode acp` (stdio JSON-RPC). Only the shapes that differ from Claude
 // are implemented here: model config (a generated opencode.json, not ANTHROPIC_* env), system-prompt
-// delivery (a prompt prefix, since opencode has no preset), and skills (materialized into opencode's
+// delivery (generated native instructions), and skills (materialized into opencode's
 // config dir, which its native skill tool discovers). Everything else reuses the generic runtime.
 // See docs/internal/pluggable-agent-framework-feasibility.md.
 
@@ -361,13 +361,27 @@ export const opencodeFramework: AgentFramework = {
     const configPath = join(opencodeDir, 'opencode.json')
     const configFiles = [{ path: configPath, content: '' }]
 
-    // Compact connector conventions, wired via opencode's `instructions` config so the agent uses
-    // host.mcp instead of raw HTTP. Detailed schemas remain in on-demand `mcp-*` skills. Absolute path
-    // keeps the baseline independent of the session cwd.
+    // Stable app guidance belongs in OpenCode's native instructions layer, never ordinary user prompt
+    // history. Keep connector conventions separate so their independent lifecycle remains explicit;
+    // both absolute paths are backend-scoped and independent of the session cwd.
     const instructionPaths: string[] = []
+    const persistentInstructions: string[] = []
+    if (ctx.systemPromptAppends?.length) {
+      const instructions = ctx.systemPromptAppends
+        .map((append) => renderAppMcpToolReferences('opencode', append))
+        .filter(Boolean)
+        .join('\n\n')
+      if (instructions) {
+        const instructionsPath = join(opencodeDir, 'instructions', 'open-science.md')
+        instructionPaths.push(instructionsPath)
+        persistentInstructions.push(instructions)
+        configFiles.push({ path: instructionsPath, content: instructions })
+      }
+    }
     if (ctx.instructions) {
       const instructionsPath = join(opencodeDir, 'instructions', 'connectors.md')
       instructionPaths.push(instructionsPath)
+      persistentInstructions.push(ctx.instructions)
       configFiles.push({ path: instructionsPath, content: ctx.instructions })
     }
 
@@ -413,19 +427,22 @@ export const opencodeFramework: AgentFramework = {
         // Pass the decrypted key ONLY via the environment; the config references it as `{env:...}`.
         ...(provider.key ? { [OPENCODE_API_KEY_ENV]: provider.key } : {})
       },
-      configFiles
+      configFiles,
+      ...(persistentInstructions.length > 0
+        ? { persistentSystemPrompt: persistentInstructions.join('\n\n') }
+        : {})
     }
   },
 
   buildSessionSetup(ctx: SessionSetupContext): SessionSetup {
-    // No claude_code preset here; deliver appends as a prompt prefix instead of session meta.
+    // Production backends pass no stable appends here because they are already installed in native
+    // instructions. Retain the append fallback for injected/legacy backends and ephemeral reviewers.
+    const promptPrefix = [...ctx.systemPromptAppends, ...(ctx.turnPromptReminders ?? [])]
+      .map((append) => renderAppMcpToolReferences('opencode', append))
+      .filter(Boolean)
+      .join('\n\n')
     return {
-      promptPrefix:
-        ctx.systemPromptAppends.length > 0
-          ? ctx.systemPromptAppends
-              .map((append) => renderAppMcpToolReferences('opencode', append))
-              .join('\n\n')
-          : undefined
+      ...(promptPrefix ? { promptPrefix } : {})
     }
   },
 

--- a/src/main/agent-framework/types.ts
+++ b/src/main/agent-framework/types.ts
@@ -53,6 +53,10 @@ export type AgentModelConfig = {
   // Framework-specific model id used for local metadata/configuration. A bridge may keep this
   // separate from the provider's upstream model id.
   sessionModel?: string
+  // Exact stable app guidance delivered through framework-native backend configuration rather than
+  // ordinary ACP prompt content. The runtime uses this for context accounting and to avoid copying
+  // the same text into every user message.
+  persistentSystemPrompt?: string
 }
 
 // Inputs for translating a provider; paths differ per framework (Claude wants its executable + config
@@ -69,6 +73,9 @@ export type ModelConfigContext = {
   // Compact connector conventions for frameworks that need host.mcp guidance in their baseline
   // instructions. Detailed connector schemas live in on-demand `mcp-*` skills. Empty ⇒ omitted.
   instructions?: string
+  // Stable app guidance that must live at system/developer scope for the backend generation. Claude
+  // delivers the same appends through session metadata instead and may ignore this field.
+  systemPromptAppends?: string[]
   // The active model's already-resolved API effort. Undefined means don't override. Frameworks encode
   // this into their valid transport vocabulary without changing the persisted user intent.
   reasoningEffort?: ModelReasoningEffort
@@ -193,6 +200,8 @@ export type ResolvedAgentBackend = {
   // Backend-resolved guidance appended to every session. Connector conventions use this channel for
   // Claude and Codex; OpenCode keeps the same guidance in its generated instructions config.
   systemPromptAppends?: string[]
+  // Exact stable text already installed in the backend's native instructions configuration.
+  persistentSystemPrompt?: string
   // Model to apply per session via the ACP `model` configOption, for frameworks that select the model
   // over the protocol rather than via env (opencode). Undefined ⇒ the framework's env/config drives it
   // (Claude uses ANTHROPIC_MODEL). Applied best-effort: skipped when the agent advertises no match.

--- a/src/main/artifacts/mcp-server.test.ts
+++ b/src/main/artifacts/mcp-server.test.ts
@@ -530,14 +530,39 @@ describe('artifact MCP server', () => {
         version_id: 'version-1',
         version_number: 1,
         filename: 'sin.png',
-        content_type: 'image/png',
         size_bytes: 4,
-        checksum: 'a'.repeat(64),
-        producer_run_id: 'notebook-run-17',
-        environment: 'analysis-python'
+        producer_run_id: 'notebook-run-17'
       }
     })
     expect(JSON.stringify(toWriteArtifactToolResult(result))).not.toContain(root)
+    expect(JSON.stringify(toWriteArtifactToolResult(result))).not.toContain('checksum')
+    expect(JSON.stringify(toWriteArtifactToolResult(result))).not.toContain('environment')
+  })
+
+  it('returns a compact legacy artifact receipt without echoing local paths', () => {
+    const result = toWriteArtifactToolResult({
+      id: 'legacy-artifact-1',
+      projectName: 'default-project',
+      sessionId: 'session-1',
+      runId: 'artifact-run-1',
+      name: 'table.csv',
+      path: '/private/session/artifacts/table.csv',
+      fileUrl: 'file:///private/session/artifacts/table.csv',
+      mimeType: 'text/csv',
+      size: 42,
+      mtimeMs: 1,
+      producerRunId: 'notebook-run-1'
+    })
+
+    expect(result).toEqual({
+      artifact: {
+        artifact_id: 'legacy-artifact-1',
+        filename: 'table.csv',
+        size_bytes: 42,
+        producer_run_id: 'notebook-run-1'
+      }
+    })
+    expect(JSON.stringify(result)).not.toContain('/private/session')
   })
 
   it('restores the previous pending file when a durable Version RPC rejects the write', async () => {

--- a/src/main/artifacts/mcp-server.ts
+++ b/src/main/artifacts/mcp-server.ts
@@ -453,16 +453,20 @@ const toWriteArtifactToolResult = (
         version_id: artifact.versionId,
         version_number: artifact.versionNumber,
         filename: artifact.name,
-        content_type: artifact.mimeType,
         size_bytes: artifact.size,
-        checksum: artifact.checksum,
-        producer_run_id: artifact.producerRunId,
-        environment: artifact.environment
+        producer_run_id: artifact.producerRunId
       }
     }
   }
 
-  return { artifact }
+  return {
+    artifact: {
+      artifact_id: artifact.id,
+      filename: artifact.name,
+      size_bytes: artifact.size,
+      producer_run_id: artifact.producerRunId
+    }
+  }
 }
 
 // Builds the stdio MCP server exposed to the agent for managed artifact writes.

--- a/src/main/connectors/skill-doc.test.ts
+++ b/src/main/connectors/skill-doc.test.ts
@@ -23,6 +23,13 @@ describe('renderConnectorInstructions', () => {
     expect(renderConnectorInstructions([])).toBe('')
     expect(renderConnectorInstructions(['nope'])).toBe('')
   })
+
+  it('forbids connector calls until the matching skill supplies the exact method name', () => {
+    const md = renderConnectorInstructions(['pubmed'])
+
+    expect(md).toContain('Load the matching `mcp-*` skill before the first `host.mcp` call')
+    expect(md).toContain('Never guess a connector server or method name')
+  })
 })
 
 describe('renderSkillDoc', () => {

--- a/src/main/connectors/skill-doc.ts
+++ b/src/main/connectors/skill-doc.ts
@@ -104,7 +104,7 @@ export function renderConnectorInstructions(connectorIds: string[]): string {
 
   return (
     `# Open Science data connector conventions\n\n` +
-    `Detailed instructions, tool schemas, return shapes, and examples are available through the matching \`mcp-*\` skill. Load that skill before using a connector.\n\n` +
+    `Detailed instructions, exact server/method names, schemas, return shapes, and examples are available through the matching \`mcp-*\` skill. Load the matching \`mcp-*\` skill before the first \`host.mcp\` call. Never guess a connector server or method name; if the matching skill is not loaded, do not call the connector.\n\n` +
     CONVENTIONS
   )
 }

--- a/src/main/notebook/mcp-server.test.ts
+++ b/src/main/notebook/mcp-server.test.ts
@@ -1,4 +1,6 @@
 import { describe, expect, it } from 'vitest'
+import { Tiktoken } from 'js-tiktoken/lite'
+import cl100kBase from 'js-tiktoken/ranks/cl100k_base'
 import { z } from 'zod'
 
 import {
@@ -7,16 +9,21 @@ import {
   INSPECT_PACKAGES_DOC,
   MANAGE_ENVIRONMENTS_DOC,
   MANAGE_PACKAGES_DOC,
-  NOTEBOOK_MCP_OUTPUT_FIELD_LIMIT,
+  NOTEBOOK_MCP_EXECUTION_RESULT_LIMIT,
+  NOTEBOOK_MCP_STATE_RESULT_LIMIT,
   REPL_EXECUTE_DOC,
   NOTEBOOK_RPC_TOOLS,
   NOTEBOOK_SYSTEM_PROMPT_APPEND,
   callNotebookRpc,
+  compactNotebookExecutionResult,
+  compactNotebookStateResult,
   compactManagePackagesResult,
   compactRestartResult,
   createNotebookMcpServerConfig,
-  truncateNotebookRunResult
+  serializeNotebookToolResult
 } from './mcp-server'
+
+const tokenizer = new Tiktoken(cl100kBase)
 
 describe('notebook MCP server config', () => {
   it('builds an ACP stdio MCP server config scoped to the notebook runtime RPC endpoint', () => {
@@ -553,7 +560,7 @@ describe('manage_environments tool', () => {
   })
 })
 
-describe('truncateNotebookRunResult', () => {
+describe('compactNotebookExecutionResult', () => {
   const runSummary = (text: {
     stdout?: string
     stderr?: string
@@ -567,142 +574,163 @@ describe('truncateNotebookRunResult', () => {
     workingFiles: []
   })
 
-  it('returns a run summary untouched when every stream is under the limit', () => {
-    const result = runSummary({ stdout: 'small output' })
-
-    const truncated = truncateNotebookRunResult(result)
-
-    expect(truncated).toBe(result)
-    expect(truncated).not.toHaveProperty('truncated')
+  it('applies the compact projection and global budget to every execution tool', () => {
+    for (const name of ['notebook_execute', 'repl_execute', 'bash_execute']) {
+      const tool = NOTEBOOK_RPC_TOOLS.find((entry) => entry.name === name)
+      expect(tool?.mapResult).toBe(compactNotebookExecutionResult)
+      expect(tool?.resultLimitChars).toBe(NOTEBOOK_MCP_EXECUTION_RESULT_LIMIT)
+    }
   })
 
-  it('clips an oversized stream, marks it truncated, and keeps the JSON parseable', () => {
-    const oversized = 'x'.repeat(NOTEBOOK_MCP_OUTPUT_FIELD_LIMIT + 5_000)
-    const result = runSummary({ stdout: oversized })
-
-    const truncated = truncateNotebookRunResult(result) as {
-      truncated?: boolean
-      text: { stdout: string; stderr: string }
+  it('keeps diagnostic streams once and removes duplicated structured stream outputs', () => {
+    const result = {
+      ...runSummary({ stdout: 'answer\n', stderr: 'warning\n' }),
+      script: 'print("answer")',
+      roots: { dataRoot: '/private/data' },
+      outputs: [
+        { type: 'stream', name: 'stdout', text: 'answer\n' },
+        { type: 'stream', name: 'stderr', text: 'warning\n' },
+        { type: 'display', data: { 'text/plain': '42' } }
+      ]
     }
 
-    expect(truncated.truncated).toBe(true)
-    expect(truncated.text.stdout.length).toBeLessThan(oversized.length)
-    expect(truncated.text.stdout).toContain('truncated 5000 chars')
-    // Streams under the limit are left alone.
-    expect(truncated.text.stderr).toBe('')
-    // The serialized payload the agent receives is still valid JSON.
-    expect(() => JSON.parse(JSON.stringify(truncated))).not.toThrow()
-    // The original object is not mutated.
-    expect((result.text as { stdout: string }).stdout).toBe(oversized)
+    const compact = compactNotebookExecutionResult(result) as Record<string, unknown>
+
+    expect(compact).toMatchObject({ stdout: 'answer\n', stderr: 'warning\n' })
+    expect(compact).not.toHaveProperty('text')
+    expect(compact).not.toHaveProperty('script')
+    expect(compact).not.toHaveProperty('roots')
+    expect(compact.outputs).toEqual([{ type: 'display', data: { 'text/plain': '42' } }])
   })
 
-  it('clips each oversized stream independently', () => {
-    const oversized = 'y'.repeat(NOTEBOOK_MCP_OUTPUT_FIELD_LIMIT + 1)
-    const result = runSummary({ stdout: oversized, traceback: oversized })
-
-    const truncated = truncateNotebookRunResult(result) as {
-      truncated?: boolean
-      text: { stdout: string; traceback: string }
-    }
-
-    expect(truncated.truncated).toBe(true)
-    expect(truncated.text.stdout).toContain('truncated')
-    expect(truncated.text.traceback).toContain('truncated')
-  })
-
-  it('elides an image display output to a marker and marks the run truncated', () => {
+  it('elides an image display output while preserving its notebook-preview marker', () => {
     const base64 = 'A'.repeat(60_000)
     const result = {
       ...runSummary({ stdout: 'done' }),
       outputs: [{ type: 'display', data: { 'image/png': base64, 'text/plain': 'small' } }]
     }
 
-    const truncated = truncateNotebookRunResult(result) as {
-      truncated?: boolean
+    const compact = compactNotebookExecutionResult(result) as {
       outputs: { data: Record<string, string> }[]
     }
 
-    expect(truncated.truncated).toBe(true)
-    // The base64 image is replaced with a compact marker...
-    expect(truncated.outputs[0].data['image/png']).toContain('image/png')
-    expect(truncated.outputs[0].data['image/png']).toContain('omitted')
-    expect(truncated.outputs[0].data['image/png'].length).toBeLessThan(200)
-    // ...while a small text mime stays inline.
-    expect(truncated.outputs[0].data['text/plain']).toBe('small')
-    // The serialized payload the agent receives is tiny and valid JSON.
-    const serialized = JSON.stringify(truncated)
+    expect(compact.outputs[0].data['image/png']).toContain('image/png')
+    expect(compact.outputs[0].data['image/png']).toContain('omitted')
+    expect(compact.outputs[0].data['image/png'].length).toBeLessThan(200)
+    expect(compact.outputs[0].data['text/plain']).toBe('small')
+    const serialized = JSON.stringify(compact)
     expect(serialized.length).toBeLessThan(2_000)
     expect(() => JSON.parse(serialized)).not.toThrow()
-    // The original object is not mutated.
     expect(result.outputs[0].data['image/png'].length).toBe(60_000)
   })
 
-  it('elides image outputs inside a state result run history', () => {
-    const base64 = 'B'.repeat(60_000)
-    const state = {
-      kernelStatus: 'idle',
-      runs: [
-        {
-          runId: 'r1',
-          text: { stdout: '', stderr: '', traceback: '', plain: [] },
-          outputs: [{ type: 'display', data: { 'image/png': base64 } }]
-        }
-      ],
-      recentRuns: []
-    }
-
-    const truncated = truncateNotebookRunResult(state) as {
-      runs: { outputs: { data: Record<string, string> }[] }[]
-    }
-
-    expect(truncated.runs[0].outputs[0].data['image/png']).toContain('omitted')
-    expect(JSON.stringify(truncated).length).toBeLessThan(2_000)
-  })
-
-  it('clips a top-level stdout on a repl_execute/bash control result and its outputs', () => {
-    const oversized = 'z'.repeat(NOTEBOOK_MCP_OUTPUT_FIELD_LIMIT + 90_000)
-    // The control-plane result shape: stdout/stderr/traceback are top-level (no `text` object).
+  it('applies a global execution-result budget to multiple large fields', () => {
+    const oversized = Array.from({ length: 100_000 }, (_, index) => `${index % 10}`).join('')
     const result = {
       status: 'completed',
+      environment: oversized,
       stdout: oversized,
-      stderr: '',
-      traceback: '',
-      outputs: [{ type: 'stream', name: 'stdout', text: oversized }]
+      stderr: oversized,
+      traceback: oversized,
+      outputs: [
+        { type: 'stream', name: 'stdout', text: oversized },
+        { type: 'json', data: { value: oversized } }
+      ]
     }
 
-    const truncated = truncateNotebookRunResult(result) as {
-      truncated?: boolean
-      stdout: string
-      outputs: { text: string }[]
-    }
+    const serialized = serializeNotebookToolResult(
+      compactNotebookExecutionResult(result),
+      NOTEBOOK_MCP_EXECUTION_RESULT_LIMIT
+    )
 
-    expect(truncated.truncated).toBe(true)
-    expect(truncated.stdout.length).toBeLessThan(oversized.length)
-    expect(truncated.stdout).toContain('truncated')
-    // The duplicated stream output is clipped too.
-    expect(truncated.outputs[0].text.length).toBeLessThan(oversized.length)
-    // The whole serialized payload is now well under the tool-result budget.
-    expect(JSON.stringify(truncated).length).toBeLessThan(NOTEBOOK_MCP_OUTPUT_FIELD_LIMIT * 3)
-    // Original not mutated.
+    expect(serialized.length).toBeLessThanOrEqual(NOTEBOOK_MCP_EXECUTION_RESULT_LIMIT)
+    expect(tokenizer.encode(serialized).length).toBeLessThanOrEqual(4_000)
+    expect(JSON.parse(serialized)).toMatchObject({ status: 'completed', truncated: true })
     expect(result.stdout.length).toBe(oversized.length)
   })
 
-  it('clips a bash_execute result with a large stdout and no `text` object', () => {
-    const oversized = 'w'.repeat(NOTEBOOK_MCP_OUTPUT_FIELD_LIMIT + 1)
-    const result = { stdout: oversized, stderr: '', exitCode: 0 }
+  it('passes through payloads that are neither run summaries nor state', () => {
+    expect(compactNotebookExecutionResult(null)).toBeNull()
+    expect(compactNotebookExecutionResult('plain')).toBe('plain')
+  })
+})
 
-    const truncated = truncateNotebookRunResult(result) as { truncated?: boolean; stdout: string }
-
-    expect(truncated.truncated).toBe(true)
-    expect(truncated.stdout).toContain('truncated')
+describe('compactNotebookStateResult', () => {
+  it('applies the state projection and smaller global budget to notebook_state', () => {
+    const tool = NOTEBOOK_RPC_TOOLS.find((entry) => entry.name === 'notebook_state')
+    expect(tool?.mapResult).toBe(compactNotebookStateResult)
+    expect(tool?.resultLimitChars).toBe(NOTEBOOK_MCP_STATE_RESULT_LIMIT)
   })
 
-  it('passes through payloads that are neither run summaries nor state', () => {
-    const other = { cells: [], kernelStatus: 'idle' }
+  it('returns bounded recent metadata without duplicating the complete run history', () => {
+    const runs = Array.from({ length: 20 }, (_, index) => ({
+      runId: `run-${index}`,
+      cellId: `cell-${index}`,
+      kernelKind: 'python',
+      status: 'completed',
+      startedAt: index,
+      endedAt: index + 1,
+      script: 'print(1)'.repeat(10_000),
+      text: {
+        stdout: `output-${index}`.repeat(10_000),
+        stderr: '',
+        traceback: '',
+        plain: []
+      },
+      outputs: [{ type: 'stream', name: 'stdout', text: `output-${index}`.repeat(10_000) }]
+    }))
+    const state = {
+      sessionId: 'session-1',
+      kernelStatus: 'idle',
+      cwd: '/workspace',
+      dataRoot: '/workspace/data',
+      cells: [
+        { id: 'cell-19', language: 'python', code: 'x'.repeat(100_000), status: 'completed' }
+      ],
+      runs,
+      recentRuns: runs,
+      environments: [],
+      runtimeBindings: {}
+    }
 
-    expect(truncateNotebookRunResult(other)).toBe(other)
-    expect(truncateNotebookRunResult(null)).toBeNull()
-    expect(truncateNotebookRunResult('plain')).toBe('plain')
+    const compact = compactNotebookStateResult(state) as Record<string, unknown>
+    const serialized = serializeNotebookToolResult(compact, NOTEBOOK_MCP_STATE_RESULT_LIMIT)
+    const parsed = JSON.parse(serialized) as Record<string, unknown>
+
+    expect(serialized.length).toBeLessThanOrEqual(NOTEBOOK_MCP_STATE_RESULT_LIMIT)
+    expect(tokenizer.encode(serialized).length).toBeLessThanOrEqual(2_000)
+    expect(parsed).not.toHaveProperty('runs')
+    expect(parsed).toHaveProperty('runCount', 20)
+    expect((parsed.recentRuns as unknown[]).length).toBe(10)
+    expect(serialized).not.toContain('print(1)')
+    expect(serialized).not.toContain('outputs')
+    expect(serialized).not.toContain('code')
+    expect(serialized).toContain('output-19')
+  })
+
+  it('passes through non-object state results', () => {
+    expect(compactNotebookStateResult(null)).toBeNull()
+    expect(compactNotebookStateResult('plain')).toBe('plain')
+  })
+
+  it('enforces the state budget when runtime metadata is unexpectedly large', () => {
+    const state = compactNotebookStateResult({
+      sessionId: 'session-1',
+      kernelStatus: 'idle',
+      cells: [],
+      runs: [],
+      recentRuns: [],
+      runtimeBindings: { python: { runtimeId: 'x'.repeat(100_000) } }
+    })
+    const serialized = serializeNotebookToolResult(state, NOTEBOOK_MCP_STATE_RESULT_LIMIT)
+
+    expect(serialized.length).toBeLessThanOrEqual(NOTEBOOK_MCP_STATE_RESULT_LIMIT)
+    expect(tokenizer.encode(serialized).length).toBeLessThanOrEqual(2_000)
+    expect(JSON.parse(serialized)).toMatchObject({
+      sessionId: 'session-1',
+      kernelStatus: 'idle',
+      truncated: true
+    })
   })
 })
 

--- a/src/main/notebook/mcp-server.test.ts
+++ b/src/main/notebook/mcp-server.test.ts
@@ -708,6 +708,39 @@ describe('compactNotebookStateResult', () => {
     expect(serialized).toContain('output-19')
   })
 
+  it('keeps the latest successful text result available for recovery', () => {
+    const state = {
+      sessionId: 'session-1',
+      runs: [
+        {
+          runId: 'run-1',
+          status: 'completed',
+          text: { stdout: '', stderr: '', traceback: '', plain: [] },
+          outputs: [{ type: 'display', data: { 'text/plain': 'older result' } }]
+        },
+        {
+          runId: 'run-2',
+          status: 'completed',
+          text: { stdout: '', stderr: '', traceback: '', plain: [] },
+          outputs: [
+            {
+              type: 'display',
+              data: { 'text/plain': '{"total_count":42}', 'image/png': 'A'.repeat(60_000) }
+            }
+          ]
+        }
+      ]
+    }
+
+    const compact = compactNotebookStateResult(state) as {
+      recentRuns: Array<Record<string, unknown>>
+    }
+
+    expect(compact.recentRuns[0]).not.toHaveProperty('outputPreview')
+    expect(compact.recentRuns[1]).toHaveProperty('outputPreview', '{"total_count":42}')
+    expect(JSON.stringify(compact)).not.toContain('image/png')
+  })
+
   it('passes through non-object state results', () => {
     expect(compactNotebookStateResult(null)).toBeNull()
     expect(compactNotebookStateResult('plain')).toBe('plain')

--- a/src/main/notebook/mcp-server.test.ts
+++ b/src/main/notebook/mcp-server.test.ts
@@ -70,6 +70,9 @@ describe('notebook MCP server config', () => {
     )
     expect(NOTEBOOK_SYSTEM_PROMPT_APPEND).toContain('write_artifact_file')
     expect(NOTEBOOK_SYSTEM_PROMPT_APPEND).toContain('open-science-artifacts')
+    expect(NOTEBOOK_SYSTEM_PROMPT_APPEND).not.toContain(
+      '`open-science-artifacts.write_artifact_file`'
+    )
     expect(NOTEBOOK_SYSTEM_PROMPT_APPEND).toContain('"kind": "localPath"')
     expect(NOTEBOOK_SYSTEM_PROMPT_APPEND).not.toContain(
       'for binary final outputs, read base64 content'

--- a/src/main/notebook/mcp-server.ts
+++ b/src/main/notebook/mcp-server.ts
@@ -11,32 +11,13 @@ const NOTEBOOK_MCP_SERVER_NAME = 'open-science-notebook'
 const NOTEBOOK_SYSTEM_PROMPT_APPEND = [
   '<open_science_notebook_instructions>',
   'Notebook tool instructions (only applies when using open-science-notebook tools).',
-  'Use the `open-science-notebook` tools when you need to write or run Python code in the shared local notebook interpreter.',
   'Notebook preview is only for code and execution results; keep chat, explanation, and diagnosis in the chat area.',
-  'To write and run code, use the `notebook_execute` tool: it writes one Python code cell and runs it in the shared interpreter in a single step. Treat each `notebook_execute` call as one notebook cell, and use several calls for several cells. Reuse a `cellId` to overwrite and rerun that cell.',
-  'The python and r data cells run `notebook_execute` writes and have NO outbound connector (host.mcp) access. To call an MCP connector, use the `repl_execute` tool — the control-plane REPL is the only kernel with connector access (`await host.mcp(server, method, args)`). Do NOT try to call host.mcp, urllib/requests, or fetch a connector from a python/r cell; it will fail.',
-  'Hand connector results to the python/r data cells through the shared workspace channel: have `repl_execute` write files into the directory given by the `$OPEN_SCIENCE_HANDOFF_DIR` env var (read it at runtime — every kernel kind sees the same path there) and have the data cell read them back, not by pasting large data through the chat.',
-  'Read input or preprocessed data from `./data/` (split into `./data/raw` and `./data/processed`; also reachable via the `OPEN_SCIENCE_NOTEBOOK_DATA_DIR` env var or the returned `dataRoot`) instead of guessing a path.',
-  'Write intermediate or working analysis outputs into `./outputs/`; that is separate from final user-facing artifacts, which still must be saved with `write_artifact_file` before telling the user they are available.',
-  'The python/r kernel is PERSISTENT across calls: variables, imports, and definitions from one `notebook_execute` call stay available to later calls on the SAME environment. Reuse them directly — do NOT re-read a file or recompute data that is already held in a variable from an earlier call this session.',
-  'That in-memory state is lost not only on `notebook_restart` (whose result already says so) but also on closing/reopening the app — only run history and on-disk files survive. So checkpoint an expensive result you may need again (a large fetch, a slow computation, a trained model) to `./data`, `./handoff`, or `./outputs` and re-load it after a restart/reopen instead of recomputing.',
-  'After each run, inspect the returned run summary, including stdout, stderr, traceback, outputs, artifacts, workingFiles, cwdBefore, and cwdAfter.',
-  'If the result is not the expected user outcome, analyze the returned facts, modify code or environment, and run again.',
-  'If you decide a missing package, dependency, Python executable, executor, interpreter, kernel, or runtime component must be installed, place installation contents under the directory given by the `OPEN_SCIENCE_RUNTIME_DIR` env var (read it at runtime) and continue with that runtime.',
-  'Do not install runtime dependencies into the project repository, workspace, system Python, or the user existing global environment unless the user explicitly asks.',
-  'The notebook already runs inside a writable session workspace — its current working directory — so create files with plain relative paths (Python: `plt.savefig("plot.png")`, `df.to_csv("out.csv")`; R: `png("plot.png", width=800, height=500); plot(...); dev.off()`, `write.csv(df, "out.csv")`). Do NOT construct or guess absolute paths under a home directory; if you need an absolute path, read it at runtime (`os.getcwd()` / R `getwd()`, `os.path.abspath("plot.png")` / R `normalizePath("plot.png")`, or the returned `dataRoot` / env var `OPEN_SCIENCE_NOTEBOOK_DATA_DIR`).',
-  'The working directory already IS the session data dir: `os.getcwd()` / R `getwd()` equals `$OPEN_SCIENCE_NOTEBOOK_DATA_DIR`. So a relative save like `png("plot.png"); ...; dev.off()` already writes the file INTO that dir and it is captured — save it once and stop. Do NOT then copy or move it to `$OPEN_SCIENCE_NOTEBOOK_DATA_DIR` (or to an absolute rebuild of the same name): the source and destination are the identical path, and R `file.copy(src, dst, overwrite=TRUE)` (or a shell `cp`) will TRUNCATE the file to 0 bytes.',
-  'You may read user-provided existing data files in place, but do not move, overwrite, or delete original files; write derived files into the working directory.',
-  'Treat notebook MCP results as execution facts only. The notebook runtime does not classify files for you; you decide whether each generated file is an intermediate working file or a final user-facing artifact.',
-  'If a notebook run creates a final user-facing output such as a chart, image, report, PDF, HTML page, document, CSV export, or archive, save that final output through the `write_artifact_file` tool from `open-science-artifacts` before telling the user it is available. Do NOT copy a generated notebook output into the workspace with a shell command; the artifact tool performs the cross-platform copy.',
-  'Pass the file to `write_artifact_file` as `source: { "kind": "localPath", "path": "plot.png" }` — use the SAME relative filename you saved with. The artifact tool resolves a relative path (or a bare filename) against the notebook session data dir, so no absolute path is needed; do NOT rebuild an absolute path from `OPEN_SCIENCE_NOTEBOOK_DATA_DIR` or a home dir.',
-  'When `notebook_execute`, `repl_execute`, or `bash_execute` produced the file, call `write_artifact_file` with `producerRunId` set to the exact `runId` returned by the execution that created or last modified that file. Do not substitute the Artifact run ID or guess another Notebook run.',
-  'Use inline `content` only for small generated text that is already in memory.',
-  'Artifact file paths are returned in `artifacts[]`; notebook working file paths are returned in `workingFiles[]`.',
-  'The user does not need to click a button to send results back; use MCP return values and notebook state as the execution facts.',
-  'When the user asks whether a Python/R package is installed or which version is present in an app-managed runtime, or when code depends on a specific package version, use the `inspect_packages` tool. It reads distribution metadata without importing or changing packages. It does not provision a missing default runtime; use `notebook_execute` to prepare that runtime under execution approval, then retry. For a user-owned external runtime, use `notebook_execute` so running that interpreter receives execution approval. Do NOT call inspection as a mandatory preflight after a clear missing-package error.',
-  'When a run fails on a missing package, dependency, or module (ImportError / ModuleNotFoundError / "there is no package called"), install it with the `manage_packages` tool — Python vs R by language — and do NOT install packages from inside a cell (%pip, !pip, install.packages()) or with OS installers.',
-  'A named environment is a SEPARATE persistent conda environment (its own process + namespace) from the default python/r environment and from every other named environment. Create one with manage_environments, then BIND it with notebook_bind_runtime to run in it — one runtime per language per session, with no shared variables/imports across environments. Move data between environments through ./handoff/ just like between kernels.',
+  'Use `notebook_execute` for one persistent Python/R cell per call; reuse `cellId` to rerun a cell. Python/R data kernels cannot call connectors. Use `repl_execute` for `host.mcp`/`host.compute`, and exchange large data through `$OPEN_SCIENCE_HANDOFF_DIR` (`./handoff/`).',
+  'Each runtime is a separate persistent namespace. Create named runtimes with `manage_environments`, select them with the bind/switch tools, and use files to move data across runtimes. Memory is lost on restart or app reopen; run history and files survive.',
+  'The notebook already runs inside a writable session workspace. Use plain relative paths: inputs in `./data/`, intermediate results in `./outputs/`, and connector handoff in `./handoff/`. The cwd is already the session data dir; never copy a saved file onto the same path. Do not modify original user files.',
+  'Use `inspect_packages` for version checks and `manage_packages` for installs. Never install inside a cell or shell. App-managed runtime contents belong under `$OPEN_SCIENCE_RUNTIME_DIR`, never the project, workspace, system Python, or a user global environment.',
+  'MCP execution replies are bounded summaries; full output remains in the notebook preview. Inspect stdout, stderr, traceback, outputs, and workingFiles, then revise and rerun if needed. The notebook runtime does not classify files for you.',
+  'For a final user-facing file, call `open-science-artifacts.write_artifact_file` before announcing it. Use `source: { "kind": "localPath", "path": "plot.png" }` with the SAME relative filename you saved with and `producerRunId` set to the exact `runId` returned by the execution that last wrote it. Use inline content only for small text.',
   '</open_science_notebook_instructions>'
 ].join('\n')
 
@@ -110,65 +91,46 @@ const bindRuntimeToolSchema = {
 // Install contract embedded as the manage_packages description so the agent always sees it (spec §8.2).
 // Soft constraint this phase; the hard guarantee is the phase-3 network-isolation sandbox.
 const INSPECT_PACKAGES_DOC = [
-  "Inspect installed package metadata in the session's bound app-managed runtime without changing the environment or importing the packages.",
-  'Pass Python distribution names or R package names. Each result reports installed, missing, or unknown and includes the installed version when available.',
-  'Use this when the user asks which version is installed or when code depends on a specific package version. Do NOT make it a mandatory preflight after a clear missing-package error — call manage_packages directly in that recovery path.',
-  "There is NO per-call environment argument. The query uses the session's bound app-managed runtime, or the app-managed default when nothing is bound.",
-  'Inspection never provisions a missing default runtime. If the default is not ready, use notebook_execute to prepare it under notebook execution approval, then retry inspection.',
-  'A user-owned external runtime is intentionally rejected because collecting its metadata executes that interpreter. Use notebook_execute there so the execution receives notebook approval.',
-  'Installed metadata does not prove that an import/library() call will succeed; use notebook_execute when importability itself must be tested.'
+  "Read installed/missing/version metadata from the session's bound app-managed Python/R runtime without importing or changing packages.",
+  'Use for requested version checks, not as a mandatory preflight after a clear missing-package error. Use notebook_execute to test actual importability.',
+  'There is no per-call environment. A missing default is prepared by notebook_execute; an external runtime must also be inspected through notebook_execute so execution receives approval.'
 ].join('\n')
 
 const MANAGE_PACKAGES_DOC = [
-  'Install packages into the shared notebook environment through THIS tool only — it runs the install in the trusted main process, never in the kernel.',
-  'Route by language: Python packages → manage_packages(language="python"); R packages → manage_packages(language="r"). For a PyPI-only Python package pass usePip=true; pass channels only when a package needs a non-default conda channel.',
+  'Install packages in the session-bound runtime through this trusted tool only. Select with language="python" or language="r", usePip=true only for PyPI-only packages, and pass channels only when needed.',
   'conda installs resolve conda-forge + bioconda by default. A CRAN R package is installed by its plain name (e.g. "dplyr" → r-dplyr); a Bioconductor R package must be named by its bioconda package id "bioconductor-<name>" in lowercase (e.g. DESeq2 → "bioconductor-deseq2"), which is left as-is (not r- prefixed).',
-  "Installs go to the session's bound runtime (notebook_bind_runtime), or the app-managed default when nothing is bound — there is NO per-call environment argument. To install into a different named environment, bind or switch to it first with notebook_bind_runtime / notebook_switch_runtime. Installs persist across cells and sessions.",
-  'The DEFAULT environments (default-python / default-r) are ADDITIVE-ONLY: they accept only a bare package name or an exact "name==version" pin, and REFUSE uninstall, version ranges, git/URL specs, extras, and flags. If you need to remove/downgrade a package or use richer specs (ranges, git+https, wheels), create a named environment with manage_environments(action:"create") and install there.',
-  "If the default runtime is the user's OWN interpreter (BYO/external), package installs may be read-only: an install can come back refused with an actionable message — surface it to the user rather than retrying, and do not try to install another way.",
-  'Pass operation:"uninstall" to remove the listed packages (default operation is install); uninstall is only allowed on a named/created env (not the additive-only defaults), is env-scoped, and never touches system/global packages.',
-  'The result includes verified packageChanges for the packages you requested, with installed/updated/unchanged/removed state and observed before/after versions when available. Dependencies remain in provenance instead of bloating the tool result.',
-  'After a successful install you can import/library()-load the package in the SAME kernel right away — the running kernel picks up a newly-installed package on its next import (no restart needed). Only call notebook_restart if you installed a newer version of a package that was ALREADY imported/loaded this session and you need the running kernel to use the new version.',
-  'Do NOT install any other way: no apt / brew / yum, no sudo, no curl | bash, no downloading installers, no subprocess hand-rolled installs, and no in-cell %pip / !pip / install.packages() (those run in the kernel and bypass this gate).',
-  'Do NOT route around a missing package by swapping in a different library that does roughly the same thing; install the package the task actually needs.',
-  'If a package needs a system/OS dependency, stop and report the limitation to the user; do NOT try to self-install it.'
+  'There is no per-call environment: bind/switch first. Default runtimes are additive-only (bare name or exact name==version); uninstall, ranges, URLs, extras, and downgrades require a named environment. External runtimes may refuse writes; surface that result.',
+  'operation defaults to install; use operation:"uninstall" only in a named environment. The concise result reports verified requested-package changes. New packages import immediately; use notebook_restart only to reload a newer version already imported.',
+  'Never use apt, brew, sudo, curl | bash, subprocess installs, %pip, !pip, or install.packages(), and never substitute another library. Report required OS dependencies to the user instead of installing them.'
 ].join('\n')
 
 const MANAGE_ENVIRONMENTS_DOC = [
-  'Create, list, and remove named persistent python/r environments. One conda environment = one process = one persistent namespace, separate from the default-python / default-r environments and from every other named environment.',
-  'action:"create" — provision a new environment: pass language ("python" or "r") and name. It starts from a minimal base (just enough to run the loop protocol), plus any packages[] you pass. Use manage_packages afterwards to add more.',
-  'action:"list" — return the environments already provisioned (name, language, readiness, whether it is a default).',
-  'action:"remove" — delete a named environment by name. The defaults (default-python / default-r) cannot be removed. An environment with a running kernel is refused — restart or shut down its kernel first.',
-  "A named environment must be created here before it can be selected with notebook_bind_runtime / notebook_switch_runtime; notebook_execute and manage_packages then act on the session's bound runtime.",
-  'Named environments have NO outbound connector (host.mcp) access, same as the default data kernels — only repl_execute (the control-plane REPL) can call connectors.',
-  'action:"remove" only deletes environments YOU created with action:"create" (agent-created). The app-managed defaults and any app-managed versioned env are refused, and a user\'s own external interpreter is never a named environment here so it can never be removed.'
+  'Create, list, or remove named persistent Python/R environments. Each is a separate process and namespace.',
+  'action:"create" needs language and name (optional initial packages); action:"list" reports provisioned environments; action:"remove" accepts a name.',
+  'Create before bind/switch. Removal is limited to agent-created, idle named environments; defaults, app-managed versioned environments, and external interpreters cannot be removed.',
+  'Named data kernels cannot call connectors; use repl_execute and ./handoff/.'
 ].join('\n')
 
 const LIST_NOTEBOOK_RUNTIMES_DOC = [
-  "List the notebook runtimes you may run code on, per language (python / r). Returns the app-managed default environment plus any of the user's own interpreters they have ENABLED in Settings — disabled interpreters are never listed and cannot be used.",
-  'Each entry has: runtimeId (the stable id you pass to notebook_bind_runtime / notebook_switch_runtime), language, source ("managed" = app-owned, "external" = the user\'s own interpreter), label, version, runnable, and bound (whether it is this session\'s current runtime for that language).',
-  "You do NOT need to bind a runtime to run code: with no binding, notebook_execute uses the app-managed default. Bind only to run on one of the user's own listed interpreters."
+  'List enabled managed/external Python/R runtimes and their runtimeId, source, version, runnable, and bound status. Disabled runtimes are omitted.',
+  'No binding is required for the app-managed default; bind only to select another listed runtime.'
 ].join('\n')
 
 const BIND_RUNTIME_DOC = [
-  'Bind a language (python or r) to one of the runtimes from list_notebook_runtimes for the REST of this session — pass its runtimeId. This is the first-time choice for a language; there is ONE runtime per language per session.',
-  'Only enabled runtimes can be bound: a disabled or unknown runtimeId is refused (the enable gate is enforced in the trusted main process, so a guessed interpreter path cannot bypass it).',
-  'To CHANGE an already-bound language use notebook_switch_runtime instead (bind refuses re-binding a different runtime). After binding, notebook_execute for that language runs on the bound runtime automatically — do not pass a runtime per call.'
+  'Bind a language to one enabled runtimeId for the rest of this session (one runtime per language). Disabled/unknown IDs are refused.',
+  'Use switch to change an existing binding. notebook_execute then uses the binding automatically; no per-call runtime is accepted.'
 ].join('\n')
 
 const SWITCH_RUNTIME_DOC = [
-  'Switch a language (python or r) to a different runtime from list_notebook_runtimes — pass its runtimeId. This TEARS DOWN the current kernel for that language and clears its in-memory state (variables, imports), then rebinds; the other language and the control-plane REPL are unaffected.',
-  'Only enabled runtimes can be switched to (a disabled or unknown runtimeId is refused in the main process). Switching is explicit and per-session: there is never more than one runtime per language at a time, and notebook_execute keeps using the newly-bound runtime with no per-call runtime argument.'
+  'Switch a language to another enabled runtimeId. This tears down that language kernel and clears its memory; other kernels are unaffected.',
+  'The new per-session binding is used automatically by notebook_execute; disabled/unknown IDs are refused.'
 ].join('\n')
 
 // Control-plane REPL contract, embedded as the repl_execute description so the agent always sees it.
 const REPL_EXECUTE_DOC = [
-  'Run JavaScript on the persistent control-plane REPL kernel — a Node process separate from the python/r data kernels.',
-  'This is the ONLY kernel with outbound connector access: call `await host.mcp(server, method, args)` to reach MCP connectors. The python/r data kernels have none, so do connector fetches here.',
-  'Remote compute (`host.compute`: list / create / call_command / details of SSH compute hosts) is likewise available ONLY here — the python/r data kernels have no `host.compute`. Load the `remote-compute-ssh` skill for its API.',
-  'Code runs in a persistent context (globals declared in one call persist to the next). A trailing expression is echoed like a REPL — its value comes back as the result — or use `console.log(...)` / `return <expr>`. Do NOT echo a large result (many records / big JSON); it is truncated. Write large data to ./handoff/ instead.',
-  'To hand data to the python/r kernels, write files into ./handoff/ (the shared workspace channel every kernel sees) and have the data cell read them back; this tool does not itself run data-analysis code.',
-  'Distinct from notebook_execute: use notebook_execute for python/r data cells, and this tool for connector calls and control-plane orchestration.'
+  'Run JavaScript in the persistent control-plane REPL, separate from notebook_execute Python/R data kernels.',
+  'Only this kernel can call connectors (`await host.mcp(server, method, args)`) and remote compute (`host.compute`; load its skill for the API).',
+  'Globals persist and a trailing expression is returned. Do not echo large data; write it to ./handoff/ for Python/R. Use notebook_execute for analysis code.'
 ].join('\n')
 
 // Stateless shell contract, embedded as the bash_execute description so the agent always sees it.
@@ -182,7 +144,7 @@ const buildShellExecuteDoc = (platform: NodeJS.Platform = process.platform): str
     platform === 'win32' ? '$env:OPEN_SCIENCE_HANDOFF_DIR' : '$OPEN_SCIENCE_HANDOFF_DIR'
   const platformContract =
     platform === 'win32'
-      ? 'Target Windows PowerShell 5.1 syntax. PowerShell aliases such as cp/ls/mv/rm are not POSIX utilities: do not pass POSIX-only flags. `&&` is unavailable in Windows PowerShell 5.1; use `if ($?) { ... }` when the next command depends on success.'
+      ? 'Target Windows PowerShell 5.1; aliases are not POSIX utilities and `&&` is unavailable. Use `if ($?) { ... }` for dependent commands.'
       : undefined
   const exitCodeContract =
     platform === 'win32'
@@ -192,13 +154,10 @@ const buildShellExecuteDoc = (platform: NodeJS.Platform = process.platform): str
   return [
     shellDescription,
     ...(platformContract ? [platformContract] : []),
-    'Stateless: every call spawns a fresh process, so shell state (cwd changes, exported variables, background jobs, shell functions) does NOT persist between calls — write files if you need results to carry over.',
-    `Runs in the same workspace directory the python/r data kernels start in, and can read/write ./handoff/ (also at ${handoffVariable}), the same shared channel repl_execute uses to hand data to the data kernels.`,
+    `Stateless: each call is a fresh process, so cwd, variables, jobs, and functions do not persist. It starts in the data-kernel workspace and shares ./handoff/ (${handoffVariable}).`,
     exitCodeContract,
-    'Distinct from notebook_execute and repl_execute: those run on persistent python/r/control-plane kernels with state that survives across calls; this tool is for one-off command-line inspection and package CLI probes, not for anything relying on shell state persisting.',
     'Do NOT copy a generated notebook output into the workspace with this tool. For a final chart, image, report, CSV, or other user-facing file, call `write_artifact_file` with the same relative filename you saved with (it resolves against the notebook session data dir); it copies the file safely on every platform.',
-    'Do NOT use this to run analysis code: never write a python/R script to disk and execute it with `python`/`Rscript`/`node`, and never pipe code via `-e`/`-c`/a heredoc. Run python via notebook_execute (language:"python"), R via notebook_execute (language:"r"), and JavaScript via repl_execute — those kernels persist state, capture figures and outputs into the notebook, and install packages via manage_packages. A shell escape hatch bypasses all of that and its results are lost to the notebook.',
-    'To install packages use manage_packages, not `pip install` / `Rscript -e install.packages(...)` here.'
+    'Use only for one-off command inspection. Run Python/R with notebook_execute, JavaScript with repl_execute, and installs with manage_packages; never execute analysis scripts, inline code, or installers here.'
   ].join('\n')
 }
 
@@ -225,6 +184,7 @@ type NotebookRpcToolDefinition = {
   // Optional projection of the raw RPC result before it is serialized for the agent. Used to keep
   // a verbose result (e.g. restart returning the whole session state) compact and to-the-point.
   mapResult?: (raw: unknown) => unknown
+  resultLimitChars?: number
 }
 
 // Creates the ACP MCP-server declaration that launches this app bundle in notebook stdio mode.
@@ -307,143 +267,309 @@ const callNotebookRpc = async (
   return payload.result
 }
 
-// Per-stream cap for the run summary returned to the agent. The full output is always kept in
-// run.json and the notebook preview; only this agent-facing copy is bounded so a single large
-// result (e.g. a connector call dumping many records to stdout) cannot overflow the tool result.
-const NOTEBOOK_MCP_OUTPUT_FIELD_LIMIT = 8_000
+// Approximate 4k/2k-token budgets for ordinary English/JSON. The final serialized character caps are
+// deliberately conservative; full values stay in run.json and the notebook preview.
+const NOTEBOOK_MCP_EXECUTION_RESULT_LIMIT = 12_000
+const NOTEBOOK_MCP_STATE_RESULT_LIMIT = 6_000
+const NOTEBOOK_MCP_STREAM_PREVIEW_LIMIT = 2_500
+const NOTEBOOK_MCP_STATE_OUTPUT_PREVIEW_LIMIT = 600
+const MIME_INLINE_LIMIT = 768
+const MAX_EXECUTION_OUTPUTS = 6
+const MAX_EXECUTION_FILES = 10
+const MAX_STATE_CELLS = 20
+const MAX_STATE_RUNS = 10
 
-// Clips one output stream to the field limit, appending a marker that points at the full copy.
-const clipStream = (text: string): { text: string; clipped: boolean } => {
-  if (text.length <= NOTEBOOK_MCP_OUTPUT_FIELD_LIMIT) return { text, clipped: false }
+const isImageMime = (mime: string): boolean => mime.startsWith('image/')
 
-  const removed = text.length - NOTEBOOK_MCP_OUTPUT_FIELD_LIMIT
+const clipAgentText = (text: string, limit: number): { text: string; clipped: boolean } => {
+  if (text.length <= limit) return { text, clipped: false }
   return {
-    text: `${text.slice(0, NOTEBOOK_MCP_OUTPUT_FIELD_LIMIT)}\n…[truncated ${removed} chars; full output in notebook preview]`,
+    text: `${text.slice(0, limit)}\n…[${text.length - limit} chars omitted; full output in notebook preview]`,
     clipped: true
   }
 }
 
-// Bounds the agent-facing run summary by clipping oversized stdout/stderr/traceback in place. Only
-// touches values shaped like a run summary (a `text` object with string streams); every other RPC
-// payload (state/restart/shutdown) is returned untouched. Never clips the serialized JSON string,
-// which would produce invalid JSON.
-// A single inline base64 image (matplotlib/ggplot figure) or other rich payload easily overflows the
-// tool-result token budget, and the agent only needs to know the output exists — the full data lives
-// in run.json and the notebook preview. Image mimes and any oversized payload are replaced with a
-// marker; small text mimes stay inline.
-const MIME_INLINE_LIMIT = 1_024
-const isImageMime = (mime: string): boolean => mime.startsWith('image/')
+const asRecord = (value: unknown): Record<string, unknown> | undefined =>
+  typeof value === 'object' && value !== null ? (value as Record<string, unknown>) : undefined
 
-// Elides image/oversized display payloads and clips oversized stream/error text inside one run's
-// structured `outputs` array; returns whether anything was clipped.
-const elideOutputs = (outputs: unknown): { outputs: unknown; clipped: boolean } => {
-  if (!Array.isArray(outputs)) return { outputs, clipped: false }
-  let clipped = false
-  const next = outputs.map((output) => {
-    if (typeof output !== 'object' || output === null) return output
-    const record = output as Record<string, unknown>
+const pickDefined = (
+  record: Record<string, unknown>,
+  fields: readonly string[]
+): Record<string, unknown> => {
+  const picked: Record<string, unknown> = {}
+  for (const field of fields) {
+    if (record[field] !== undefined) picked[field] = record[field]
+  }
+  return picked
+}
 
-    if (record.type === 'display' && typeof record.data === 'object' && record.data !== null) {
-      const data = record.data as Record<string, unknown>
-      const nextData: Record<string, unknown> = {}
-      for (const [mime, payload] of Object.entries(data)) {
-        const asString = typeof payload === 'string' ? payload : JSON.stringify(payload)
-        if (isImageMime(mime) || asString.length > MIME_INLINE_LIMIT) {
-          nextData[mime] = `[${mime}: ${asString.length} chars omitted; shown in notebook preview]`
-          clipped = true
+const compactWorkingFiles = (value: unknown): unknown[] => {
+  if (!Array.isArray(value)) return []
+  return value.slice(0, MAX_EXECUTION_FILES).flatMap((file) => {
+    const record = asRecord(file)
+    if (!record) return []
+    return [pickDefined(record, ['relativePath', 'kind', 'size', 'createdByRunId'])]
+  })
+}
+
+const compactArtifacts = (value: unknown): unknown[] => {
+  if (!Array.isArray(value)) return []
+  return value.slice(0, MAX_EXECUTION_FILES).flatMap((artifact) => {
+    const record = asRecord(artifact)
+    if (!record) return []
+    return [
+      pickDefined(record, [
+        'artifactId',
+        'versionId',
+        'versionNumber',
+        'id',
+        'name',
+        'mimeType',
+        'size',
+        'producerRunId'
+      ])
+    ]
+  })
+}
+
+const compactExecutionOutputs = (
+  value: unknown,
+  canonicalTraceback: string
+): { outputs: unknown[]; truncated: boolean; omitted: number } => {
+  if (!Array.isArray(value)) return { outputs: [], truncated: false, omitted: 0 }
+
+  let truncated = false
+  let omitted = 0
+  const outputs: unknown[] = []
+  for (const output of value) {
+    const record = asRecord(output)
+    if (!record) continue
+
+    // stdout/stderr already have canonical top-level fields in the compact result.
+    if (record.type === 'stream') {
+      continue
+    }
+    if (outputs.length >= MAX_EXECUTION_OUTPUTS) {
+      omitted += 1
+      truncated = true
+      continue
+    }
+
+    if (record.type === 'display' && asRecord(record.data)) {
+      const data: Record<string, unknown> = {}
+      for (const [mime, payload] of Object.entries(asRecord(record.data) ?? {})) {
+        const serialized =
+          typeof payload === 'string' ? payload : (JSON.stringify(payload) ?? 'null')
+        if (isImageMime(mime) || serialized.length > MIME_INLINE_LIMIT) {
+          data[mime] = `[${mime}: ${serialized.length} chars omitted; shown in notebook preview]`
+          truncated = true
         } else {
-          nextData[mime] = payload
+          data[mime] = payload
         }
       }
-      return { ...record, data: nextData }
+      outputs.push({ type: 'display', data })
+      continue
     }
 
-    for (const field of ['text', 'traceback'] as const) {
-      const value = record[field]
-      if (typeof value !== 'string') continue
-      const { text: clippedText, clipped: didClip } = clipStream(value)
-      if (didClip) {
-        clipped = true
-        return { ...record, [field]: clippedText }
+    if (record.type === 'text' && typeof record.text === 'string') {
+      const clipped = clipAgentText(record.text, MIME_INLINE_LIMIT)
+      outputs.push({ type: 'text', text: clipped.text })
+      truncated = truncated || clipped.clipped
+      continue
+    }
+
+    if (record.type === 'json') {
+      const serialized = JSON.stringify(record.data) ?? 'null'
+      if (serialized.length > MIME_INLINE_LIMIT) {
+        outputs.push({
+          type: 'json',
+          data: `[JSON: ${serialized.length} chars omitted; shown in notebook preview]`
+        })
+        truncated = true
+      } else {
+        outputs.push({ type: 'json', data: record.data })
       }
+      continue
     }
 
-    return output
-  })
-  return { outputs: next, clipped }
+    if (record.type === 'error') {
+      const error = pickDefined(record, ['type', 'name', 'message', 'line'])
+      if (typeof record.traceback === 'string' && record.traceback !== canonicalTraceback) {
+        const clipped = clipAgentText(record.traceback, MIME_INLINE_LIMIT)
+        error.traceback = clipped.text
+        truncated = truncated || clipped.clipped
+      }
+      outputs.push(error)
+      continue
+    }
+
+    outputs.push(pickDefined(record, ['type']))
+  }
+
+  return { outputs, truncated, omitted }
 }
 
-// Clips oversized stdout/stderr/traceback and elides image/large `outputs` on one run-shaped record
-// (an execute summary, or one entry from a state result's run history).
-const truncateRunLike = (value: unknown): unknown => {
-  if (typeof value !== 'object' || value === null) return value
-  const record = value as Record<string, unknown>
-  let clippedAny = false
-  let next: Record<string, unknown> = record
-
-  const text = record.text
-  if (typeof text === 'object' && text !== null) {
-    const streams = text as Record<string, unknown>
-    const nextText: Record<string, unknown> = { ...streams }
-    let textClipped = false
-    for (const field of ['stdout', 'stderr', 'traceback'] as const) {
-      const stream = streams[field]
-      if (typeof stream !== 'string') continue
-      const { text: clippedText, clipped } = clipStream(stream)
-      nextText[field] = clippedText
-      textClipped = textClipped || clipped
-    }
-    if (textClipped) {
-      next = { ...next, text: nextText }
-      clippedAny = true
-    }
+// Projects one immediate execution result for the next model step. Code, roots, provenance, and
+// duplicated stream outputs remain durable but are not echoed into every later inference.
+const compactNotebookExecutionResult = (raw: unknown): unknown => {
+  const record = asRecord(raw)
+  if (!record) return raw
+  const text = asRecord(record.text)
+  const stream = (field: 'stdout' | 'stderr' | 'traceback'): string => {
+    const value = record[field] ?? text?.[field]
+    return typeof value === 'string' ? value : ''
   }
+  const stdout = clipAgentText(stream('stdout'), NOTEBOOK_MCP_STREAM_PREVIEW_LIMIT)
+  const stderr = clipAgentText(stream('stderr'), NOTEBOOK_MCP_STREAM_PREVIEW_LIMIT)
+  const traceback = clipAgentText(stream('traceback'), NOTEBOOK_MCP_STREAM_PREVIEW_LIMIT)
+  const compactOutputs = compactExecutionOutputs(record.outputs, stream('traceback'))
+  const workingFiles = compactWorkingFiles(record.workingFiles)
+  const artifacts = compactArtifacts(record.artifacts)
+  const filesOmitted =
+    (Array.isArray(record.workingFiles) && record.workingFiles.length > workingFiles.length) ||
+    (Array.isArray(record.artifacts) && record.artifacts.length > artifacts.length)
+  const truncated =
+    stdout.clipped ||
+    stderr.clipped ||
+    traceback.clipped ||
+    compactOutputs.truncated ||
+    filesOmitted
 
-  // Top-level streams: repl_execute/bash_execute control-plane results carry stdout/stderr/traceback
-  // on the record itself (not under `text`). A large host.mcp result dumped into stdout here would
-  // otherwise overflow the tool-result budget exactly like an untruncated run summary.
-  for (const field of ['stdout', 'stderr', 'traceback'] as const) {
-    const stream = record[field]
-    if (typeof stream !== 'string') continue
-    const { text: clippedText, clipped } = clipStream(stream)
-    if (clipped) {
-      next = { ...next, [field]: clippedText }
-      clippedAny = true
-    }
+  return {
+    ...pickDefined(record, [
+      'runId',
+      'cellId',
+      'kernelKind',
+      'status',
+      'executionCount',
+      'environment',
+      'startedAt',
+      'endedAt',
+      'exitCode'
+    ]),
+    ...(stdout.text ? { stdout: stdout.text } : {}),
+    ...(stderr.text ? { stderr: stderr.text } : {}),
+    ...(traceback.text ? { traceback: traceback.text } : {}),
+    ...(compactOutputs.outputs.length ? { outputs: compactOutputs.outputs } : {}),
+    ...(compactOutputs.omitted > 0 ? { omittedOutputCount: compactOutputs.omitted } : {}),
+    ...(workingFiles.length ? { workingFiles } : {}),
+    ...(artifacts.length ? { artifacts } : {}),
+    ...(record.cwdBefore !== record.cwdAfter && record.cwdAfter !== undefined
+      ? { cwdAfter: record.cwdAfter }
+      : {}),
+    ...(truncated
+      ? {
+          truncated: true,
+          note: 'Agent-facing result shortened; full output remains in the notebook preview.'
+        }
+      : {})
   }
-
-  const { outputs, clipped: outputsClipped } = elideOutputs(record.outputs)
-  if (outputsClipped) {
-    next = { ...next, outputs }
-    clippedAny = true
-  }
-
-  return clippedAny ? { ...next, truncated: true } : value
 }
 
-// Bounds the agent-facing result: clips oversized text streams and replaces image/large display
-// outputs with markers — on a single run summary AND on every run inside a state result's
-// `runs`/`recentRuns` history. run.json and the notebook preview keep the full data untouched.
-const truncateNotebookRunResult = (value: unknown): unknown => {
-  if (typeof value !== 'object' || value === null) return value
-  const record = value as Record<string, unknown>
+const compactStateRun = (value: unknown, includeOutputPreview: boolean): unknown => {
+  const record = asRecord(value)
+  if (!record) return value
+  const text = asRecord(record.text)
+  const output = ['traceback', 'stderr', 'stdout']
+    .map((field) => text?.[field])
+    .find((candidate) => typeof candidate === 'string' && candidate.length > 0)
+  const outputPreview =
+    includeOutputPreview && typeof output === 'string'
+      ? clipAgentText(output, NOTEBOOK_MCP_STATE_OUTPUT_PREVIEW_LIMIT).text
+      : undefined
+  const workingFiles = compactWorkingFiles(record.workingFiles)
 
-  // State result: a run-history document with runs/recentRuns arrays.
-  if (Array.isArray(record.runs) || Array.isArray(record.recentRuns)) {
-    const next = { ...record }
-    if (Array.isArray(record.runs)) next.runs = record.runs.map(truncateRunLike)
-    if (Array.isArray(record.recentRuns)) next.recentRuns = record.recentRuns.map(truncateRunLike)
-    return next
+  return {
+    ...pickDefined(record, [
+      'runId',
+      'cellId',
+      'kernelKind',
+      'status',
+      'executionCount',
+      'environment',
+      'startedAt',
+      'endedAt',
+      'interruptionReason'
+    ]),
+    ...(workingFiles.length ? { workingFiles } : {}),
+    ...(outputPreview ? { outputPreview } : {})
   }
-
-  // Single run summary (execute result).
-  return truncateRunLike(value)
 }
 
-// Serializes notebook RPC results exactly as execution facts for the agent to analyze, bounding the
-// per-stream output size so one large run cannot overflow the tool result.
-const toToolText = (value: unknown): string =>
-  JSON.stringify(truncateNotebookRunResult(value), null, 2)
+// notebook_state is a recovery/inspection summary, not a second transport for the full run.json.
+// Keep stable cell/run identities, age old output down to metadata, and include only the latest
+// run's short diagnostic preview.
+const compactNotebookStateResult = (raw: unknown): unknown => {
+  const record = asRecord(raw)
+  if (!record) return raw
+  const runs = Array.isArray(record.runs) ? record.runs : []
+  const recentSource = Array.isArray(record.recentRuns) ? record.recentRuns : runs
+  const recentRuns = recentSource.slice(-MAX_STATE_RUNS)
+  const cells = Array.isArray(record.cells)
+    ? record.cells.slice(-MAX_STATE_CELLS).flatMap((cell) => {
+        const cellRecord = asRecord(cell)
+        return cellRecord
+          ? [pickDefined(cellRecord, ['id', 'language', 'status', 'executionCount', 'latestRunId'])]
+          : []
+      })
+    : []
+
+  return {
+    ...pickDefined(record, [
+      'sessionId',
+      'cwd',
+      'dataRoot',
+      'kernelStatus',
+      'activeRunId',
+      'runtimeBindings'
+    ]),
+    cellCount: Array.isArray(record.cells) ? record.cells.length : 0,
+    ...(cells.length ? { cells } : {}),
+    runCount: runs.length || recentSource.length,
+    recentRuns: recentRuns.map((run, index) =>
+      compactStateRun(run, index === recentRuns.length - 1)
+    ),
+    ...(Array.isArray(record.environments) ? { environments: record.environments } : {}),
+    historyCompacted: true,
+    note: 'Only recent run metadata and the latest output preview are returned; full history remains in the notebook preview.'
+  }
+}
+
+// The specialized projections normally fit. This last serialization guard handles adversarial IDs,
+// JSON, or runtime metadata while keeping a valid JSON receipt with the most useful identities.
+const serializeNotebookToolResult = (value: unknown, limitChars?: number): string => {
+  const serialized = JSON.stringify(value, null, 2) ?? 'null'
+  if (limitChars === undefined || serialized.length <= limitChars) return serialized
+
+  const record = asRecord(value) ?? {}
+  const identity = pickDefined(record, ['status', 'runId', 'sessionId', 'kernelStatus', 'exitCode'])
+  for (const [key, fieldValue] of Object.entries(identity)) {
+    if (typeof fieldValue === 'string') identity[key] = clipAgentText(fieldValue, 256).text
+  }
+  const base = {
+    ...identity,
+    truncated: true,
+    note: `Agent-facing result exceeded the ${limitChars}-character budget; full output remains in the notebook preview.`
+  }
+  let low = 0
+  let high = serialized.length
+  let best = JSON.stringify(base, null, 2)
+  while (low <= high) {
+    const midpoint = Math.floor((low + high) / 2)
+    const candidate = JSON.stringify(
+      { ...base, preview: `${serialized.slice(0, midpoint)}\n…[preview truncated]` },
+      null,
+      2
+    )
+    if (candidate.length <= limitChars) {
+      best = candidate
+      low = midpoint + 1
+    } else {
+      high = midpoint - 1
+    }
+  }
+  return best
+}
 
 // Registers one MCP tool that forwards its validated input to a matching notebook RPC method.
 const registerNotebookRpcTool = (
@@ -465,7 +591,7 @@ const registerNotebookRpcTool = (
         content: [
           {
             type: 'text',
-            text: toToolText(result)
+            text: serializeNotebookToolResult(result, definition.resultLimitChars)
           }
         ]
       }
@@ -511,31 +637,39 @@ const NOTEBOOK_RPC_TOOLS: NotebookRpcToolDefinition[] = [
     name: 'notebook_execute',
     title: 'Execute notebook code',
     description:
-      'Write one code cell and run it in the shared local interpreter, returning the full run summary. Each call is one notebook cell; reuse a cellId to overwrite and rerun that cell. Keep the returned runId: if this execution creates or last modifies a final file, pass that exact value as producerRunId to write_artifact_file. Pass language: "python" (default) or "r" to select the interpreter for the cell. Do NOT pass a runtime or environment here — the cell runs in the session\'s bound runtime (see notebook_bind_runtime), or the app-managed default when nothing is bound; there is no per-call runtime switching. Each bound runtime is a SEPARATE namespace (variables/imports do NOT carry across runtimes); change it with notebook_switch_runtime, and create a named environment first with manage_environments before binding to it.',
+      'Write and run one persistent Python/R cell; reuse cellId to rerun it. The session binding selects the runtime (no per-call runtime/environment). Keep runId as producerRunId when this run last writes a final artifact.',
     method: 'execute',
-    inputSchema: executeToolSchema
+    inputSchema: executeToolSchema,
+    mapResult: compactNotebookExecutionResult,
+    resultLimitChars: NOTEBOOK_MCP_EXECUTION_RESULT_LIMIT
   },
   {
     name: 'repl_execute',
     title: 'Execute control-plane REPL code',
     description: REPL_EXECUTE_DOC,
     method: 'executeControl',
-    inputSchema: replExecuteToolSchema
+    inputSchema: replExecuteToolSchema,
+    mapResult: compactNotebookExecutionResult,
+    resultLimitChars: NOTEBOOK_MCP_EXECUTION_RESULT_LIMIT
   },
   {
     name: 'bash_execute',
     title: 'Execute a stateless shell command',
     description: BASH_EXECUTE_DOC,
     method: 'executeShell',
-    inputSchema: bashExecuteToolSchema
+    inputSchema: bashExecuteToolSchema,
+    mapResult: compactNotebookExecutionResult,
+    resultLimitChars: NOTEBOOK_MCP_EXECUTION_RESULT_LIMIT
   },
   {
     name: 'notebook_state',
     title: 'Get notebook state',
     description:
-      "Return current notebook cells, recent runs, notebookSessionRoot, dataRoot, runtimeRoot, cwd, kernel status, and the session's current python/r runtime bindings (runtimeBindings).",
+      'Return compact session state: cell identities, latest run metadata/output preview, cwd/dataRoot, kernel status, and runtime bindings. Full run history stays in the notebook preview.',
     method: 'state',
-    inputSchema: {}
+    inputSchema: {},
+    mapResult: compactNotebookStateResult,
+    resultLimitChars: NOTEBOOK_MCP_STATE_RESULT_LIMIT
   },
   {
     name: 'list_notebook_runtimes',
@@ -630,18 +764,21 @@ export {
   REPL_EXECUTE_DOC,
   BASH_EXECUTE_DOC,
   buildShellExecuteDoc,
-  NOTEBOOK_MCP_OUTPUT_FIELD_LIMIT,
+  NOTEBOOK_MCP_EXECUTION_RESULT_LIMIT,
+  NOTEBOOK_MCP_STATE_RESULT_LIMIT,
   NOTEBOOK_MCP_SERVER_ARG,
   NOTEBOOK_MCP_SERVER_NAME,
   NOTEBOOK_RPC_TOOLS,
   NOTEBOOK_SYSTEM_PROMPT_APPEND,
   callNotebookRpc,
+  compactNotebookExecutionResult,
+  compactNotebookStateResult,
   compactManagePackagesResult,
   compactRestartResult,
   createNotebookMcpEnvironmentFromProcess,
   createNotebookMcpServer,
   createNotebookMcpServerConfig,
   runNotebookMcpServer,
-  truncateNotebookRunResult
+  serializeNotebookToolResult
 }
 export type { NotebookMcpEnvironment, NotebookMcpServerConfigRequest, NotebookRpcConnection }

--- a/src/main/notebook/mcp-server.ts
+++ b/src/main/notebook/mcp-server.ts
@@ -470,9 +470,19 @@ const compactStateRun = (value: unknown, includeOutputPreview: boolean): unknown
   const record = asRecord(value)
   if (!record) return value
   const text = asRecord(record.text)
-  const output = ['traceback', 'stderr', 'stdout']
+  const diagnosticOutput = ['traceback', 'stderr', 'stdout']
     .map((field) => text?.[field])
     .find((candidate) => typeof candidate === 'string' && candidate.length > 0)
+  const displayOutput = Array.isArray(record.outputs)
+    ? record.outputs
+        .map((candidate) => {
+          const output = asRecord(candidate)
+          const data = output?.type === 'display' ? asRecord(output.data) : undefined
+          return data?.['text/plain']
+        })
+        .find((candidate) => typeof candidate === 'string' && candidate.length > 0)
+    : undefined
+  const output = diagnosticOutput ?? displayOutput
   const outputPreview =
     includeOutputPreview && typeof output === 'string'
       ? clipAgentText(output, NOTEBOOK_MCP_STATE_OUTPUT_PREVIEW_LIMIT).text

--- a/src/main/notebook/mcp-server.ts
+++ b/src/main/notebook/mcp-server.ts
@@ -17,7 +17,7 @@ const NOTEBOOK_SYSTEM_PROMPT_APPEND = [
   'The notebook already runs inside a writable session workspace. Use plain relative paths: inputs in `./data/`, intermediate results in `./outputs/`, and connector handoff in `./handoff/`. The cwd is already the session data dir; never copy a saved file onto the same path. Do not modify original user files.',
   'Use `inspect_packages` for version checks and `manage_packages` for installs. Never install inside a cell or shell. App-managed runtime contents belong under `$OPEN_SCIENCE_RUNTIME_DIR`, never the project, workspace, system Python, or a user global environment.',
   'MCP execution replies are bounded summaries; full output remains in the notebook preview. Inspect stdout, stderr, traceback, outputs, and workingFiles, then revise and rerun if needed. The notebook runtime does not classify files for you.',
-  'For a final user-facing file, call `open-science-artifacts.write_artifact_file` before announcing it. Use `source: { "kind": "localPath", "path": "plot.png" }` with the SAME relative filename you saved with and `producerRunId` set to the exact `runId` returned by the execution that last wrote it. Use inline content only for small text.',
+  'For a final user-facing file, call `write_artifact_file` from the `open-science-artifacts` server before announcing it. Use `source: { "kind": "localPath", "path": "plot.png" }` with the SAME relative filename you saved with and `producerRunId` set to the exact `runId` returned by the execution that last wrote it. Use inline content only for small text.',
   '</open_science_notebook_instructions>'
 ].join('\n')
 

--- a/src/main/settings/backend-resolver.test.ts
+++ b/src/main/settings/backend-resolver.test.ts
@@ -106,6 +106,7 @@ const makeNativeResponsesProxyDouble = (
 type HarnessOptions = {
   settings?: StoredSettings
   frameworkOverride?: string
+  connectorIds?: string[]
   rejectRequiredModels?: ReadonlySet<string>
   targetOverride?: (
     provider: StoredProvider,
@@ -187,7 +188,7 @@ const makeHarness = (options: HarnessOptions = {}) => {
     resolveCodexProxyEnvironment: vi.fn(async () => undefined)
   } satisfies AgentBackendRuntimePort
   const connectors = {
-    enabledConnectorIds: vi.fn(() => [])
+    enabledConnectorIds: vi.fn(() => options.connectorIds ?? [])
   } satisfies AgentBackendConnectorPort
 
   const responsesBridges: ResponsesBridgeDouble[] = []
@@ -475,6 +476,44 @@ describe('AgentBackendResolver runtime delegation', () => {
 })
 
 describe('AgentBackendResolver bridge predicates', () => {
+  it.each([
+    { name: 'direct Responses', chat: false, native: false, apiEndpoints: ['responses'] as const },
+    { name: 'Chat bridge', chat: true, native: false, apiEndpoints: ['openai'] as const },
+    {
+      name: 'Responses compatibility',
+      chat: false,
+      native: true,
+      apiEndpoints: ['responses'] as const
+    }
+  ])('persists skill-first connector guidance for Codex $name', async (testCase) => {
+    const harness = makeHarness({
+      connectorIds: ['pubmed'],
+      targetOverride: () => ({
+        needsChatResponsesBridge: testCase.chat,
+        needsNativeResponsesCompatibility: testCase.native,
+        provider: { apiEndpoints: [...testCase.apiEndpoints] }
+      })
+    })
+
+    const backend = await harness.resolver.resolveExplicitTarget({
+      frameworkId: 'codex',
+      providerId: 'provider-a',
+      model: { kind: 'provider-default' },
+      reasoningEffort: 'high'
+    })
+    const developerInstructions = JSON.parse(backend.env.CODEX_CONFIG ?? '{}')
+      .developer_instructions as string | undefined
+
+    expect(developerInstructions).toContain(
+      'Load the matching `mcp-*` skill before the first `host.mcp` call'
+    )
+    expect(developerInstructions).toContain('Never guess a connector server or method name')
+    expect(developerInstructions).not.toContain('search_articles')
+    expect(backend.persistentSystemPrompt).toBe(developerInstructions)
+    expect(backend.systemPromptAppends).toBeUndefined()
+    await backend.responsesBridgeLease?.release()
+  })
+
   it.each([
     { name: 'direct', chat: false, native: false, responseCalls: 0, nativeCalls: 0 },
     {

--- a/src/main/settings/backend-resolver.ts
+++ b/src/main/settings/backend-resolver.ts
@@ -69,6 +69,7 @@ export type AgentBackendSelection = Readonly<{
 
 export type AgentBackendResolutionContext = {
   forcedSkillIds?: string[]
+  systemPromptAppends?: string[]
 }
 
 export type ExplicitAgentBackendTarget = Readonly<{
@@ -376,6 +377,9 @@ export class AgentBackendResolver {
       ? [...new Set(target.reasoningEffortProfile.slots)]
       : undefined
     const forcedSkillIds = new Set(context.forcedSkillIds ?? [])
+    const connectorInstructions = renderConnectorInstructions(
+      this.connectors.enabledConnectorIds(settings.connectors)
+    )
 
     if (framework.id === 'claude-code') {
       const { envOverrides, executablePath, sessionOptions, contextWindow } =
@@ -388,7 +392,8 @@ export class AgentBackendResolver {
         sessionOptions,
         sessionEffort,
         contextWindow,
-        contextUsageModel: target.effectiveModel
+        contextUsageModel: target.effectiveModel,
+        ...(connectorInstructions ? { systemPromptAppends: [connectorInstructions] } : {})
       }
     }
 
@@ -419,9 +424,6 @@ export class AgentBackendResolver {
         : opencodeConfigDir(this.storageRoot)
     await this.runtime.materializeAgentSkills(settings, skillsRoot, forcedSkillIds)
 
-    const connectorInstructions = renderConnectorInstructions(
-      this.connectors.enabledConnectorIds(settings.connectors)
-    )
     const responsesBridge = target.needsChatResponsesBridge
       ? await this.ensureResponsesBridge(
           provider,
@@ -431,6 +433,10 @@ export class AgentBackendResolver {
       : target.needsNativeResponsesCompatibility
         ? await this.ensureNativeResponsesCompatibility(provider)
         : undefined
+    const persistentSystemPromptAppends = [
+      ...(context.systemPromptAppends ?? []),
+      ...(framework.id === 'codex' && connectorInstructions ? [connectorInstructions] : [])
+    ]
 
     try {
       const modelConfig = framework.prepareModelConfig(provider, {
@@ -440,7 +446,10 @@ export class AgentBackendResolver {
         responsesBridge,
         reasoningEffort: sessionEffort,
         reasoningEfforts: supportedReasoningEfforts,
-        instructions: connectorInstructions
+        instructions: connectorInstructions,
+        ...(persistentSystemPromptAppends.length > 0
+          ? { systemPromptAppends: persistentSystemPromptAppends }
+          : {})
       })
       await this.runtime.materializeAgentConfigFiles(modelConfig.configFiles)
       const opencodeUsagePort =
@@ -494,6 +503,7 @@ export class AgentBackendResolver {
         contextUsageModel: provider.model,
         authentication: modelConfig.authentication,
         providerConfiguration: modelConfig.providerConfiguration,
+        persistentSystemPrompt: modelConfig.persistentSystemPrompt,
         ...(opencodeUsagePort === undefined || !opencodeUsagePassword
           ? {}
           : {

--- a/src/main/settings/service.test.ts
+++ b/src/main/settings/service.test.ts
@@ -1133,7 +1133,16 @@ describe('SettingsService: providers', () => {
     ).providers[0]
     await service.setActiveProvider(provider.id)
 
-    await service.resolveActiveAgentBackend()
+    const backend = await service.resolveActiveAgentBackend({
+      systemPromptAppends: ['Stable Open Science app guidance.']
+    })
+
+    expect(backend.persistentSystemPrompt).toContain('Stable Open Science app guidance.')
+    const appInstructions = await readFile(
+      join(storageRoot, 'opencode', 'config', 'opencode', 'instructions', 'open-science.md'),
+      'utf8'
+    )
+    expect(appInstructions).toBe('Stable Open Science app guidance.')
 
     const baseline = await readFile(
       join(storageRoot, 'opencode', 'config', 'opencode', 'instructions', 'connectors.md'),
@@ -1141,7 +1150,10 @@ describe('SettingsService: providers', () => {
     )
     expect(baseline).toContain('host.mcp')
     expect(baseline).toContain('mcp-*')
+    expect(baseline).toContain('Load the matching `mcp-*` skill before the first `host.mcp` call')
+    expect(baseline).toContain('Never guess a connector server or method name')
     expect(baseline).not.toContain('pubchem_get_compounds')
+    expect(baseline).not.toContain('search_articles')
     expect(baseline).not.toContain('```json')
     expect(baseline.length).toBeLessThan(2_500)
 
@@ -2087,7 +2099,9 @@ describe('SettingsService: preflight & spawn config', () => {
     await service.setActiveProvider(provider.id)
     vi.stubEnv('OPEN_SCIENCE_AGENT_FRAMEWORK', 'codex')
 
-    const backend = await service.resolveActiveAgentBackend()
+    const backend = await service.resolveActiveAgentBackend({
+      systemPromptAppends: ['Stable Open Science developer guidance.']
+    })
     const selection = await service.captureActiveAgentBackendSelection()
 
     expect(backend.framework.id).toBe('codex')
@@ -2100,13 +2114,20 @@ describe('SettingsService: preflight & spawn config', () => {
       NO_BROWSER: '1'
     })
     expect(backend.env.CODEX_API_KEY).toBeUndefined()
+    const developerInstructions = JSON.parse(backend.env.CODEX_CONFIG ?? '{}')
+      .developer_instructions as string
+    expect(developerInstructions).toContain('Stable Open Science developer guidance.')
+    expect(developerInstructions).toContain(
+      'Load the matching `mcp-*` skill before the first `host.mcp` call'
+    )
+    expect(developerInstructions).not.toContain('search_articles')
+    expect(backend.persistentSystemPrompt).toBe(developerInstructions)
     expect(backend.authentication).toEqual({
       methodId: 'api-key',
       _meta: { 'api-key': { apiKey: 'test-key' } }
     })
-    // Codex discovers the Connector through its native Skill catalog. Supplying the connector
-    // calling convention as a global prompt lets bridged models skip progressive Skill loading and
-    // guess method names directly.
+    // Stable guidance only tells Codex to load the matching Skill; exact connector methods remain
+    // progressive content and must not be copied into the baseline.
     expect(backend.systemPromptAppends).toBeUndefined()
 
     expect(selection).toEqual({ frameworkId: 'codex' })
@@ -2436,7 +2457,15 @@ describe('SettingsService: preflight & spawn config', () => {
     expect(backend.authentication).toBeUndefined()
     expect(backend.providerConfiguration).toBeUndefined()
     expect(backend.env.CODEX_API_KEY).toBeUndefined()
-    expect(JSON.parse(backend.env.CODEX_CONFIG ?? '{}')).toEqual({ model: 'gpt-5.6-terra' })
+    const codexConfig = JSON.parse(backend.env.CODEX_CONFIG ?? '{}') as {
+      model?: string
+      developer_instructions?: string
+    }
+    expect(codexConfig.model).toBe('gpt-5.6-terra')
+    expect(codexConfig.developer_instructions).toContain(
+      'Load the matching `mcp-*` skill before the first `host.mcp` call'
+    )
+    expect(codexConfig.developer_instructions).not.toContain('search_articles')
     expect(backend.env.MODEL_PROVIDER).toBeUndefined()
     expect(backend.env.NO_BROWSER).toBeUndefined()
     expect(backend.env.CODEX_PATH).toBe('/data/codex-managed/native/codex')
@@ -2620,6 +2649,14 @@ describe('SettingsService: preflight & spawn config', () => {
     })
     expect(backend.env.CODEX_CONFIG).toContain('"wire_api":"responses"')
     expect(backend.env.CODEX_CONFIG).not.toContain('test-key')
+    const developerInstructions = JSON.parse(backend.env.CODEX_CONFIG ?? '{}')
+      .developer_instructions as string
+    expect(developerInstructions).toContain(
+      'Load the matching `mcp-*` skill before the first `host.mcp` call'
+    )
+    expect(developerInstructions).toContain('Never guess a connector server or method name')
+    expect(developerInstructions).not.toContain('search_articles')
+    expect(backend.persistentSystemPrompt).toBe(developerInstructions)
 
     const bridgeResponse = await localFetch(`${backend.providerConfiguration?.baseUrl}/responses`, {
       method: 'POST',
@@ -3635,6 +3672,7 @@ describe('SettingsService: skills', () => {
     const managedSkillFile = join(managedSkillDir, 'SKILL.md')
     try {
       const config = await service.resolveActiveSpawnConfig()
+      const backend = await service.resolveActiveAgentBackend()
 
       expect(config.envOverrides.CLAUDE_CONFIG_DIR).toBe(userClaudeDir)
       expect(config.sessionOptions).toEqual({
@@ -3660,6 +3698,9 @@ describe('SettingsService: skills', () => {
       expect(appSettings.permissions.deny).toEqual(
         expect.arrayContaining([expect.stringMatching(/^Read/)])
       )
+      expect(backend.systemPromptAppends).toEqual([
+        expect.stringContaining('Load the matching `mcp-*` skill before the first `host.mcp` call')
+      ])
     } finally {
       await chmod(managedSkillFile, 0o644).catch(() => undefined)
       await chmod(managedSkillDir, 0o755).catch(() => undefined)
@@ -4645,7 +4686,10 @@ describe('SettingsService: reasoning effort', () => {
 
     expect(backend.framework.id).toBe('claude-code')
     expect(backend.sessionEffort).toBe('low')
-    expect(backend.systemPromptAppends).toBeUndefined()
+    expect(backend.systemPromptAppends).toEqual([
+      expect.stringContaining('Load the matching `mcp-*` skill before the first `host.mcp` call')
+    ])
+    expect(backend.systemPromptAppends?.join('\n')).not.toContain('search_articles')
   })
 
   it("leaves sessionEffort undefined when the level is 'default' or unset", async () => {


### PR DESCRIPTION
## Problem

Simple ACP tasks can accumulate disproportionate input/cache traffic because stable app guidance is copied into ordinary prompt history, Notebook observations can carry duplicated or unbounded long-tail output, and agents may guess connector methods before loading the matching progressive Skill. A planned provider/model reconnect can also briefly look like an unexpected disconnect and expose a false Resume action.

## Proposed change

- Install stable Open Science guidance once in each backend's native system/developer-instruction layer for OpenCode and Codex, while preserving Claude Code session metadata delivery and fallback behavior for injected/legacy backends.
- Keep connector discovery progressive, but make the compact baseline require loading the matching `mcp-*` Skill before the first `host.mcp` call and forbid guessed server/method names across Claude Code, OpenCode, Codex Responses, and Codex bridge routes.
- Compress duplicated Notebook guidance and apply whole-result budgets to execution observations and `notebook_state`.
- Preserve ten recent Notebook run summaries, retain output preview only for the newest run, remove duplicated stream payloads, and keep full persisted output available in the Notebook UI.
- Return compact Artifact and package-management receipts when verbose provenance is not needed by the next inference.
- Treat deliberate provider/model reconnect teardown as idle rather than closed so the renderer does not present Resume for an expected process restart.
- Integrate dynamic Skill-import availability with the session capability owner introduced on current `main`.

## Scope and non-goals

- No persistent data-model or data-relationship migration.
- No removal of full Notebook run data or renderer output; only model-facing MCP projections are shortened.
- No unified capability gateway or extra describe inference.
- No live in-process model switching. The current reconnect/resume path remains the fallback; a possible adapter-owned live-switch seam is recorded only in an ignored internal design document and is not part of this PR.
- No new user workflow. The visible behavior change is limited to avoiding a false Resume action during planned reconnects.

## Acceptance criteria and validation

- Stable backend guidance is absent from repeated user prompt text and remains included in context accounting.
- Connector baselines contain skill-first routing instructions but no connector operation schema or guessed method examples.
- Notebook execution replies stay within the global result budget, `notebook_state` returns up to ten compact runs, and full data remains durable.
- Planned reconnects end in idle without emitting closed; unexpected disconnect behavior remains unchanged.
- Rebased onto `origin/main` at `c6d6ee4`.
- `npm run typecheck` — passed.
- `npm run lint` — passed with 0 errors and 19 pre-existing warnings outside this diff.
- `npm test` — passed with 670 files / 9,854 tests passing and 15 files / 184 tests skipped. The suite was run with localhost loopback enabled because HTTP/RPC tests bind `127.0.0.1`.
- `git diff origin/main...HEAD --check` — passed.

External-provider E2E token/cache measurements remain the main follow-up risk: unit coverage verifies prompt lifecycle and result bounds, but exact savings still depend on each provider's cache accounting and agent inference count.

## Review focus

- Whether native OpenCode/Codex instructions remain stable across reconnect and model configuration paths without leaking into ordinary user history.
- Whether Notebook projections preserve the execution facts needed for the immediate next inference while keeping durable/UI output intact.
- Whether planned reconnect state remains distinguishable from a genuine process or transport loss.
- Whether the session capability owner remains the sole boundary for dynamic app-tool availability after the rebase.
