### PR TITLE
refactor(acp): extract prompt content owner

### DIFF
--- a/src/main/acp/prompt-content-owner.test.ts
+++ b/src/main/acp/prompt-content-owner.test.ts
@@ -1,0 +1,296 @@
+import type { ContentBlock } from '@agentclientprotocol/sdk'
+import { mkdtemp, rm } from 'node:fs/promises'
+import { tmpdir } from 'node:os'
+import { join } from 'node:path'
+import { afterEach, describe, expect, it, vi } from 'vitest'
+
+import type { UploadedAttachment } from '../../shared/uploads'
+import { UploadRepository } from '../uploads/repository'
+import { stageUploadFixtures } from '../uploads/repository.test-utils'
+import { createManagedFileReferenceResolver } from './file-reference-resolver'
+import { AcpPromptContentOwner } from './prompt-content-owner'
+
+const roots: string[] = []
+
+const createRoot = async (): Promise<string> => {
+  const root = await mkdtemp(join(tmpdir(), 'acp-prompt-content-owner-'))
+  roots.push(root)
+  return root
+}
+
+const contentBlocks = (content: string | ContentBlock[]): ContentBlock[] => {
+  expect(Array.isArray(content)).toBe(true)
+  return content as ContentBlock[]
+}
+
+afterEach(async () => {
+  await Promise.all(roots.splice(0).map((root) => rm(root, { recursive: true, force: true })))
+})
+
+describe('AcpPromptContentOwner', () => {
+  it('keeps the text fast path isolated from ambient resolvers and defensively owns Codex metadata', async () => {
+    const resolver = createManagedFileReferenceResolver({})
+    const resolveReference = vi.spyOn(resolver, 'resolve')
+    const owner = new AcpPromptContentOwner({
+      fileReferenceResolver: resolver,
+      inlineImageBudgetBytes: 1_024
+    })
+    const onSkillImportAttachmentEligible = vi.fn()
+
+    const plain = await owner.prepare({
+      appSessionId: 'session-1',
+      projectId: 'default-project',
+      text: '  plain text is preserved  ',
+      historyImages: [],
+      historyUploads: [],
+      currentUploads: [],
+      references: [],
+      codexSkillInputs: [],
+      skillImportEnabled: false,
+      skillImportTurnToken: undefined,
+      onSkillImportAttachmentEligible
+    })
+
+    expect(plain).toEqual({ content: '  plain text is preserved  ' })
+    expect(resolveReference).not.toHaveBeenCalled()
+    expect(onSkillImportAttachmentEligible).not.toHaveBeenCalled()
+
+    const codexSkillInputs = [{ name: 'research', path: '/skills/research/SKILL.md' }]
+    const withCodexMetadata = await owner.prepare({
+      appSessionId: 'session-1',
+      projectId: 'default-project',
+      text: 'use the selected Skill',
+      historyImages: [],
+      historyUploads: [],
+      currentUploads: [],
+      references: [],
+      codexSkillInputs,
+      skillImportEnabled: false,
+      skillImportTurnToken: undefined,
+      onSkillImportAttachmentEligible
+    })
+
+    codexSkillInputs[0].name = 'mutated-after-prepare'
+    codexSkillInputs.push({ name: 'late', path: '/skills/late/SKILL.md' })
+    expect(withCodexMetadata).toEqual({
+      content: [
+        {
+          type: 'text',
+          text: 'use the selected Skill',
+          _meta: {
+            'open-science/skill-inputs': [{ name: 'research', path: '/skills/research/SKILL.md' }]
+          }
+        }
+      ]
+    })
+    expect(resolveReference).not.toHaveBeenCalled()
+  })
+
+  it('preserves combined block order and returns the exact registered turn inputs', async () => {
+    const root = await createRoot()
+    const uploads = new UploadRepository(root)
+    const [referencePending] = await stageUploadFixtures(uploads, {
+      files: [
+        {
+          name: 'referenced.txt',
+          mimeType: 'text/plain',
+          content: Buffer.from('referenced body').toString('base64')
+        }
+      ]
+    })
+    const [referencedUpload] = await uploads.finalizePendingSessionUploads(
+      'source-session',
+      [referencePending],
+      'default-project'
+    )
+    const [historyUpload] = await stageUploadFixtures(uploads, {
+      files: [
+        {
+          name: 'history.txt',
+          mimeType: 'text/plain',
+          content: Buffer.from('history body').toString('base64')
+        }
+      ]
+    })
+    const [currentUpload] = await stageUploadFixtures(uploads, {
+      files: [
+        {
+          name: 'current.txt',
+          mimeType: 'text/plain',
+          content: Buffer.from('current body').toString('base64')
+        }
+      ]
+    })
+    const reference = {
+      id: referencedUpload.id,
+      name: referencedUpload.originalName,
+      path: referencedUpload.path,
+      source: 'upload' as const,
+      mimeType: referencedUpload.mimeType
+    }
+    const owner = new AcpPromptContentOwner({
+      uploadRepository: uploads,
+      fileReferenceResolver: createManagedFileReferenceResolver({ uploads }),
+      inlineImageBudgetBytes: 1_024
+    })
+
+    const result = await owner.prepare({
+      appSessionId: 'target-session',
+      projectId: 'default-project',
+      text: 'combined prompt',
+      historyImages: [
+        {
+          mimeType: 'image/png',
+          data: Buffer.from('history-image').toString('base64'),
+          byteLength: Buffer.byteLength('history-image')
+        }
+      ],
+      historyUploads: [historyUpload],
+      currentUploads: [currentUpload],
+      references: [reference],
+      codexSkillInputs: [],
+      skillImportEnabled: false,
+      skillImportTurnToken: undefined,
+      onSkillImportAttachmentEligible: vi.fn()
+    })
+
+    const blocks = contentBlocks(result.content)
+    expect(blocks.map((block) => block.type)).toEqual([
+      'text',
+      'image',
+      'resource',
+      'resource',
+      'resource'
+    ])
+    expect(blocks[0]).toEqual({ type: 'text', text: 'combined prompt' })
+    expect(blocks[1]).toMatchObject({ type: 'image', mimeType: 'image/png' })
+    expect(blocks[2]).toMatchObject({
+      type: 'resource',
+      resource: { text: 'history body' }
+    })
+    expect(blocks[3]).toMatchObject({
+      type: 'resource',
+      resource: { text: 'current body' }
+    })
+    expect(blocks[4]).toMatchObject({
+      type: 'resource',
+      resource: { text: 'referenced body' }
+    })
+    expect(result.turnInputs?.uploads.map((upload) => upload.originalName)).toEqual([
+      'history.txt',
+      'current.txt'
+    ])
+    expect(result.turnInputs?.references).toEqual([reference])
+  })
+
+  it('owns cumulative image budget per Session and releases it on resetSession and clear', async () => {
+    const root = await createRoot()
+    const uploads = new UploadRepository(root)
+    const owner = new AcpPromptContentOwner({
+      uploadRepository: uploads,
+      fileReferenceResolver: createManagedFileReferenceResolver({ uploads }),
+      inlineImageBudgetBytes: 15
+    })
+    const stageImage = async (name: string): Promise<UploadedAttachment> => {
+      const [image] = await stageUploadFixtures(uploads, {
+        files: [
+          {
+            name,
+            mimeType: 'image/png',
+            content: Buffer.from('png-bytes').toString('base64')
+          }
+        ]
+      })
+      return image
+    }
+    const prepareImage = async (name: string): ReturnType<AcpPromptContentOwner['prepare']> =>
+      owner.prepare({
+        appSessionId: 'session-1',
+        projectId: 'default-project',
+        text: name,
+        historyImages: [],
+        historyUploads: [],
+        currentUploads: [await stageImage(name)],
+        references: [],
+        codexSkillInputs: [],
+        skillImportEnabled: false,
+        skillImportTurnToken: undefined,
+        onSkillImportAttachmentEligible: vi.fn()
+      })
+
+    const first = await prepareImage('first.png')
+    const overBudget = await prepareImage('over-budget.png')
+    expect(contentBlocks(first.content).at(-1)?.type).toBe('image')
+    expect(contentBlocks(overBudget.content).at(-1)?.type).toBe('resource_link')
+
+    owner.resetSession('session-1')
+    const afterReset = await prepareImage('after-reset.png')
+    expect(contentBlocks(afterReset.content).at(-1)?.type).toBe('image')
+
+    owner.clear()
+    const afterClear = await prepareImage('after-clear.png')
+    expect(contentBlocks(afterClear.content).at(-1)?.type).toBe('image')
+  })
+
+  it('keeps already-processed image bytes charged when a later reference rejects', async () => {
+    const root = await createRoot()
+    const uploads = new UploadRepository(root)
+    const owner = new AcpPromptContentOwner({
+      uploadRepository: uploads,
+      fileReferenceResolver: createManagedFileReferenceResolver({ uploads }),
+      inlineImageBudgetBytes: 15
+    })
+    const stageImage = async (name: string): Promise<UploadedAttachment> => {
+      const [image] = await stageUploadFixtures(uploads, {
+        files: [
+          {
+            name,
+            mimeType: 'image/png',
+            content: Buffer.from('png-bytes').toString('base64')
+          }
+        ]
+      })
+      return image
+    }
+
+    await expect(
+      owner.prepare({
+        appSessionId: 'session-1',
+        projectId: 'default-project',
+        text: 'fails after image processing',
+        historyImages: [],
+        historyUploads: [],
+        currentUploads: [await stageImage('charged.png')],
+        references: [
+          {
+            id: 'linked-1',
+            name: 'unavailable.txt',
+            source: 'linked-folder',
+            rootId: 'unconfigured-root',
+            relativePath: 'unavailable.txt'
+          }
+        ],
+        codexSkillInputs: [],
+        skillImportEnabled: false,
+        skillImportTurnToken: undefined,
+        onSkillImportAttachmentEligible: vi.fn()
+      })
+    ).rejects.toThrow(/not configured/i)
+
+    const afterFailure = await owner.prepare({
+      appSessionId: 'session-1',
+      projectId: 'default-project',
+      text: 'next image',
+      historyImages: [],
+      historyUploads: [],
+      currentUploads: [await stageImage('after-failure.png')],
+      references: [],
+      codexSkillInputs: [],
+      skillImportEnabled: false,
+      skillImportTurnToken: undefined,
+      onSkillImportAttachmentEligible: vi.fn()
+    })
+
+    expect(contentBlocks(afterFailure.content).at(-1)?.type).toBe('resource_link')
+  })
+})

--- a/src/main/acp/prompt-content-owner.ts
+++ b/src/main/acp/prompt-content-owner.ts
@@ -1,0 +1,464 @@
+import type { ContentBlock } from '@agentclientprotocol/sdk'
+import { readFile, stat } from 'node:fs/promises'
+import { pathToFileURL } from 'node:url'
+
+import type { AcpMessageImage } from '../../shared/acp'
+import type { FileReference } from '../../shared/artifacts'
+import type { UploadedAttachment } from '../../shared/uploads'
+import { readBoundedManagedFilePreview } from '../managed-file-preview'
+import {
+  buildImageContentData,
+  canInlineImageInSession,
+  consumeInlineImageBudget,
+  extractPdfText,
+  ImageContentError,
+  MAX_AUTO_EXTRACT_PDF_BYTES,
+  MAX_AUTO_PROCESS_IMAGE_BYTES,
+  MAX_SESSION_INLINE_IMAGE_BYTES,
+  type InlineImageBudget
+} from '../uploads/attachment-media'
+import type { UploadRepository } from '../uploads/repository'
+import { isImportableSkillArchivePath } from '../skills/skill-archive-sniffer'
+import {
+  ATTACHMENT_PREVIEW_BYTES,
+  MAX_EMBEDDED_TEXT_UPLOAD_BYTES,
+  buildDatasetAttachmentNotice,
+  buildDeferredMediaNotice,
+  buildOversizedAttachmentNotice,
+  imageAttachmentMimeType,
+  isDatasetAttachment,
+  isTabularAttachment,
+  isTextLikeAttachment,
+  mimeEssence
+} from './attachment-content'
+import type { FileReferenceResolver } from './file-reference-resolver'
+
+type CodexSkillInput = {
+  name: string
+  path: string
+}
+
+type AcpPromptContentOwnerOptions = {
+  uploadRepository?: UploadRepository
+  fileReferenceResolver: FileReferenceResolver
+  inlineImageBudgetBytes?: number
+}
+
+type PrepareAcpPromptContentInput = {
+  appSessionId: string
+  projectId: string
+  text: string
+  historyImages: ReadonlyArray<AcpMessageImage>
+  historyUploads: ReadonlyArray<UploadedAttachment>
+  currentUploads: ReadonlyArray<UploadedAttachment>
+  references: ReadonlyArray<FileReference>
+  codexSkillInputs: ReadonlyArray<CodexSkillInput>
+  skillImportEnabled: boolean
+  skillImportTurnToken?: string
+  onSkillImportAttachmentEligible?: (attachmentUri: string) => void
+}
+
+type AcpPromptTurnInputs = {
+  uploads: UploadedAttachment[]
+  references: FileReference[]
+}
+
+type PreparedAcpPromptContent = {
+  content: string | ContentBlock[]
+  turnInputs?: AcpPromptTurnInputs
+}
+
+type ResolvedPromptFile = {
+  absolutePath: string
+  uri: string
+  name: string
+  mimeType?: string
+  size: number
+  allowSkillImportReference: boolean
+}
+
+const errorMessage = (error: unknown): string => {
+  try {
+    const raw = error instanceof Error ? (error as { message?: unknown }).message : error
+
+    return typeof raw === 'string' ? raw : String(raw)
+  } catch {
+    return 'unknown error'
+  }
+}
+
+// Owns provider-ready prompt content and the media budget associated with each provider context.
+// Session/turn admission, authorization leases, Notebook registration, and provider dispatch remain
+// with the runtime; every piece of content resolved here is supplied explicitly by the caller.
+class AcpPromptContentOwner {
+  private readonly sessionInlineImageBytes = new Map<string, number>()
+  private readonly inlineImageBudgetBytes: number
+
+  constructor(private readonly options: AcpPromptContentOwnerOptions) {
+    this.inlineImageBudgetBytes = options.inlineImageBudgetBytes ?? MAX_SESSION_INLINE_IMAGE_BYTES
+  }
+
+  async prepare(input: PrepareAcpPromptContentInput): Promise<PreparedAcpPromptContent> {
+    const attachments = [...input.historyUploads, ...input.currentUploads]
+    let finalizedPromptUploads: UploadedAttachment[] = []
+
+    let content: string | ContentBlock[]
+    if (
+      attachments.length === 0 &&
+      input.references.length === 0 &&
+      input.historyImages.length === 0
+    ) {
+      content = input.text
+    } else {
+      const contentBlocks: ContentBlock[] = input.text.trim()
+        ? [{ type: 'text', text: input.text }]
+        : []
+      let imageBudget: InlineImageBudget = { imageCount: 0, base64Bytes: 0 }
+      const appendBlock = (block: ContentBlock, overflowFallback?: ContentBlock): void => {
+        if (block.type === 'image') {
+          try {
+            imageBudget = consumeInlineImageBudget(imageBudget, {
+              data: block.data,
+              mimeType: block.mimeType
+            })
+          } catch (error) {
+            if (
+              error instanceof ImageContentError &&
+              error.code === 'IMAGE_TOTAL_BUDGET_EXCEEDED'
+            ) {
+              if (overflowFallback) contentBlocks.push(overflowFallback)
+              return
+            }
+            throw error
+          }
+        }
+        contentBlocks.push(block)
+      }
+
+      for (const image of input.historyImages) {
+        appendBlock({ type: 'image', data: image.data, mimeType: image.mimeType })
+      }
+      if (input.historyImages.length > 0) {
+        this.sessionInlineImageBytes.set(input.appSessionId, imageBudget.base64Bytes)
+      }
+
+      // Staged uploads own the durable Session id here, so finalize before turning them into blocks.
+      if (attachments.length > 0) {
+        if (!this.options.uploadRepository) throw new Error('Upload storage is not configured.')
+
+        finalizedPromptUploads = await this.options.uploadRepository.finalizePendingSessionUploads(
+          input.appSessionId,
+          attachments,
+          input.projectId
+        )
+
+        // Preserve the existing order: history uploads, current uploads, then explicit references.
+        for (const attachment of finalizedPromptUploads) {
+          const blocks = await this.createAttachmentContentBlocks(input, attachment)
+          for (const block of blocks) {
+            appendBlock(
+              block,
+              this.imageOverflowResourceLink(block, attachment.originalName, attachment.size)
+            )
+          }
+        }
+      }
+
+      for (const reference of input.references) {
+        const blocks = await this.createReferencedArtifactContentBlocks(input, reference)
+        for (const block of blocks) {
+          appendBlock(block, this.imageOverflowResourceLink(block, reference.name))
+        }
+      }
+
+      content = contentBlocks
+    }
+
+    const preparedContent = this.attachCodexSkillInputs(content, input.codexSkillInputs)
+    const hasTurnInputs = finalizedPromptUploads.length > 0 || input.references.length > 0
+
+    return {
+      content: preparedContent,
+      ...(hasTurnInputs
+        ? {
+            turnInputs: {
+              uploads: finalizedPromptUploads,
+              references: [...input.references]
+            }
+          }
+        : {})
+    }
+  }
+
+  resetSession(sessionId: string): void {
+    this.sessionInlineImageBytes.delete(sessionId)
+  }
+
+  clear(): void {
+    this.sessionInlineImageBytes.clear()
+  }
+
+  private attachCodexSkillInputs(
+    content: string | ContentBlock[],
+    descriptors: ReadonlyArray<CodexSkillInput>
+  ): string | ContentBlock[] {
+    if (descriptors.length === 0) return content
+
+    const skillInputs = descriptors.map((descriptor) => ({ ...descriptor }))
+    const metadata = { 'open-science/skill-inputs': skillInputs }
+    if (typeof content === 'string') {
+      return [{ type: 'text', text: content, _meta: metadata }]
+    }
+
+    const blocks = [...content]
+    const textIndex = blocks.findIndex((block) => block.type === 'text')
+    if (textIndex < 0) {
+      blocks.unshift({ type: 'text', text: '', _meta: metadata })
+      return blocks
+    }
+
+    const textBlock = blocks[textIndex]
+    if (textBlock.type === 'text') {
+      blocks[textIndex] = {
+        ...textBlock,
+        _meta: { ...(textBlock._meta ?? {}), ...metadata }
+      }
+    }
+    return blocks
+  }
+
+  private async createAttachmentContentBlocks(
+    input: PrepareAcpPromptContentInput,
+    attachment: UploadedAttachment
+  ): Promise<ContentBlock[]> {
+    if (!this.options.uploadRepository) throw new Error('Upload storage is not configured.')
+
+    const filePath = await this.options.uploadRepository.resolveManagedUploadPath(
+      { path: attachment.path },
+      { projectId: input.projectId, sessionId: input.appSessionId }
+    )
+    const { size } = await stat(filePath)
+
+    return this.buildFileContentBlocks(input, {
+      absolutePath: filePath,
+      uri: pathToFileURL(filePath).href,
+      name: attachment.originalName || attachment.name,
+      mimeType: attachment.mimeType,
+      size,
+      allowSkillImportReference: true
+    })
+  }
+
+  private async createReferencedArtifactContentBlocks(
+    input: PrepareAcpPromptContentInput,
+    reference: FileReference
+  ): Promise<ContentBlock[]> {
+    const resolvedReference = await this.options.fileReferenceResolver.resolve(
+      { sessionId: input.appSessionId, projectId: input.projectId },
+      reference
+    )
+
+    return this.buildFileContentBlocks(input, resolvedReference)
+  }
+
+  private async buildFileContentBlocks(
+    input: PrepareAcpPromptContentInput,
+    descriptor: ResolvedPromptFile
+  ): Promise<ContentBlock[]> {
+    const { absolutePath, uri, name, mimeType, size, allowSkillImportReference } = descriptor
+
+    const attachmentTextReference = (
+      tag: 'attached_skill_package' | 'attached_local_archive',
+      skillImportEligible: boolean,
+      turnToken?: string
+    ): ContentBlock => ({
+      type: 'text',
+      text: [
+        `<${tag}>`,
+        JSON.stringify({
+          name,
+          uri,
+          mimeType,
+          size,
+          skillImportEligible,
+          ...(turnToken ? { skillImportTurnToken: turnToken } : {})
+        }),
+        `</${tag}>`
+      ].join('\n')
+    })
+
+    if (
+      input.skillImportEnabled &&
+      allowSkillImportReference &&
+      (await this.isSkillPackageFile(name, absolutePath))
+    ) {
+      const turnToken = input.skillImportTurnToken
+      if (turnToken) {
+        try {
+          input.onSkillImportAttachmentEligible?.(uri)
+        } catch {
+          // Eligibility notification is observational and must not abort prompt preparation.
+        }
+        return [attachmentTextReference('attached_skill_package', true, turnToken)]
+      }
+    }
+
+    const normalizedName = name.toLowerCase()
+    const normalizedMimeType = mimeEssence(mimeType)
+    if (
+      normalizedName.endsWith('.zip') ||
+      normalizedName.endsWith('.skill') ||
+      normalizedMimeType === 'application/zip' ||
+      normalizedMimeType === 'application/x-zip-compressed'
+    ) {
+      return [attachmentTextReference('attached_local_archive', false)]
+    }
+
+    const imageMimeType = imageAttachmentMimeType(name, mimeType)
+    if (imageMimeType) {
+      if (size > MAX_AUTO_PROCESS_IMAGE_BYTES) {
+        return [
+          {
+            type: 'text',
+            text: buildDeferredMediaNotice({ name, size, kind: 'image' })
+          },
+          { type: 'resource_link', uri, name, title: name, mimeType: imageMimeType, size }
+        ]
+      }
+      const { data, mimeType: outMimeType } = await buildImageContentData(
+        absolutePath,
+        imageMimeType,
+        size
+      )
+
+      const alreadyInlined = this.sessionInlineImageBytes.get(input.appSessionId) ?? 0
+      if (!canInlineImageInSession(alreadyInlined, data.length, this.inlineImageBudgetBytes)) {
+        return [{ type: 'resource_link', uri, name, title: name, mimeType: imageMimeType, size }]
+      }
+
+      // Charge before the request-level append. Existing behavior retains this charge even if a later
+      // reference fails or the request image budget rejects this block.
+      this.sessionInlineImageBytes.set(input.appSessionId, alreadyInlined + data.length)
+      return [{ type: 'image', data, mimeType: outMimeType, uri }]
+    }
+
+    if (this.isPdfFile(name, mimeType)) {
+      if (size > MAX_AUTO_EXTRACT_PDF_BYTES) {
+        return [
+          {
+            type: 'text',
+            text: buildDeferredMediaNotice({ name, size, kind: 'PDF' })
+          },
+          { type: 'resource_link', uri, name, title: name, mimeType: 'application/pdf', size }
+        ]
+      }
+      return [await this.createPdfContentBlock(name, absolutePath, uri)]
+    }
+
+    if (isTextLikeAttachment(name, mimeType)) {
+      if (size <= MAX_EMBEDDED_TEXT_UPLOAD_BYTES) {
+        return [
+          {
+            type: 'resource',
+            resource: { uri, mimeType, text: await readFile(absolutePath, 'utf8') }
+          }
+        ]
+      }
+
+      const preview = await readBoundedManagedFilePreview(
+        absolutePath,
+        { path: absolutePath, maxBytes: ATTACHMENT_PREVIEW_BYTES, encoding: 'utf8' },
+        'Attachment preview requires UTF-8 encoding.'
+      )
+
+      return [
+        {
+          type: 'text',
+          text: buildOversizedAttachmentNotice({
+            name,
+            size,
+            preview: preview.content,
+            truncated: preview.truncated,
+            tabular: isTabularAttachment(name, mimeType)
+          })
+        },
+        { type: 'resource_link', uri, name, title: name, mimeType, size }
+      ]
+    }
+
+    if (isDatasetAttachment(name, mimeType)) {
+      return [
+        { type: 'text', text: buildDatasetAttachmentNotice({ name, size }) },
+        { type: 'resource_link', uri, name, title: name, mimeType, size }
+      ]
+    }
+
+    return [{ type: 'resource_link', uri, name, title: name, mimeType, size }]
+  }
+
+  private imageOverflowResourceLink(
+    block: ContentBlock,
+    name: string,
+    size?: number
+  ): ContentBlock | undefined {
+    if (block.type !== 'image' || !block.uri) return undefined
+
+    return {
+      type: 'resource_link',
+      uri: block.uri,
+      name,
+      title: name,
+      mimeType: block.mimeType,
+      size
+    }
+  }
+
+  private isPdfFile(name: string, mimeType?: string): boolean {
+    if (mimeType === 'application/pdf') return true
+    return name.toLowerCase().endsWith('.pdf')
+  }
+
+  private async isSkillPackageFile(name: string, filePath: string): Promise<boolean> {
+    const normalizedName = name.toLowerCase()
+    if (!normalizedName.endsWith('.skill') && !normalizedName.endsWith('.zip')) return false
+    return isImportableSkillArchivePath(filePath)
+  }
+
+  private async createPdfContentBlock(
+    name: string,
+    filePath: string,
+    uri: string
+  ): Promise<ContentBlock> {
+    const toResource = (text: string): ContentBlock => ({
+      type: 'resource',
+      resource: { uri, mimeType: 'text/plain', text }
+    })
+
+    try {
+      const { text, pageCount, truncated } = await extractPdfText(filePath)
+      if (!text) {
+        return toResource(
+          `[No selectable text could be extracted from "${name}" (${pageCount} page(s)). It may be a scanned or image-only PDF.]`
+        )
+      }
+
+      const header = `[PDF text extracted from "${name}" — ${pageCount} page(s)${
+        truncated ? ', truncated' : ''
+      }]`
+      return toResource(`${header}\n\n${text}`)
+    } catch (error) {
+      return toResource(
+        `[Failed to extract text from "${name}": ${errorMessage(error)}. The PDF was not sent to avoid exceeding the request size limit.]`
+      )
+    }
+  }
+}
+
+export { AcpPromptContentOwner }
+export type {
+  AcpPromptContentOwnerOptions,
+  AcpPromptTurnInputs,
+  CodexSkillInput,
+  PrepareAcpPromptContentInput,
+  PreparedAcpPromptContent
+}

--- a/src/main/acp/runtime.test.ts
+++ b/src/main/acp/runtime.test.ts
@@ -2007,6 +2007,49 @@ describe('ACP runtime session management', () => {
     )
   })
 
+  it('keeps a text-only prompt free of omitted ambient context', async () => {
+    const root = await createTemporaryRoot()
+    const ambientSecret = 'AMBIENT_FILE_MUST_NOT_ENTER_PROMPT'
+    await writeFile(join(root, 'ambient-secret.txt'), ambientSecret, 'utf8')
+    const uploadRepository = new UploadRepository(root)
+    const finalizeUploads = vi.spyOn(uploadRepository, 'finalizePendingSessionUploads')
+    const resolveManagedUpload = vi.spyOn(uploadRepository, 'resolveManagedUploadPath')
+    const resolveSessionUpload = vi.spyOn(uploadRepository, 'resolveSessionUploadPath')
+    const registerTurnInputs = vi.fn(async () => undefined)
+    const process = new FakeAgentProcess()
+    const receivedPrompts: ContentBlock[][] = []
+    startFakeAgent(process, ['remote-session-1'], {
+      onPrompt: ({ prompt }) => {
+        receivedPrompts.push(prompt)
+      }
+    })
+    const runtime = new AcpRuntime({
+      appVersion: '0.1.0',
+      defaultCwd: root,
+      spawnAgent: () => asAgentProcess(process),
+      uploads: { repository: uploadRepository },
+      notebook: {
+        projectName: 'default-project',
+        mcpEntryPath: '/app/out/main/index.js',
+        getRpcConnection: async () => ({ endpoint: 'http://127.0.0.1:1/notebook', token: 'nb' }),
+        registerTurnInputs
+      }
+    })
+
+    const session = await runtime.createSession({ cwd: root })
+    finalizeUploads.mockClear()
+    resolveManagedUpload.mockClear()
+    resolveSessionUpload.mockClear()
+    await runtime.sendPrompt({ sessionId: session.sessionId, text: 'summarize without context' })
+
+    expect(receivedPrompts).toEqual([[{ type: 'text', text: 'summarize without context' }]])
+    expect(JSON.stringify(receivedPrompts)).not.toContain(ambientSecret)
+    expect(finalizeUploads).not.toHaveBeenCalled()
+    expect(resolveManagedUpload).not.toHaveBeenCalled()
+    expect(resolveSessionUpload).not.toHaveBeenCalled()
+    expect(registerTurnInputs).not.toHaveBeenCalled()
+  })
+
   it('sends staged uploads as ACP prompt content blocks', async () => {
     const root = await createTemporaryRoot()
     const uploadRepository = new UploadRepository(root)
@@ -2069,6 +2112,84 @@ describe('ACP runtime session management', () => {
     await expect(
       readFile(join(root, 'uploads', 'default-project', 'remote-session-1', 'notes.txt'), 'utf8')
     ).resolves.toBe('hello from upload')
+  })
+
+  it('preserves prompt content order across replay images, uploads, and references', async () => {
+    const root = await createTemporaryRoot()
+    const uploadRepository = new UploadRepository(root)
+    const [historyUpload, currentUpload, mentionedUpload] = await stageUploadFixtures(
+      uploadRepository,
+      {
+        files: [
+          {
+            name: 'history.txt',
+            mimeType: 'text/plain',
+            content: Buffer.from('history upload').toString('base64')
+          },
+          {
+            name: 'current.txt',
+            mimeType: 'text/plain',
+            content: Buffer.from('current upload').toString('base64')
+          },
+          {
+            name: 'mentioned.txt',
+            mimeType: 'text/plain',
+            content: Buffer.from('mentioned upload').toString('base64')
+          }
+        ]
+      }
+    )
+    const [mentionedReference] = await uploadRepository.finalizePendingSessionUploads(
+      'remote-session-1',
+      [mentionedUpload]
+    )
+    const process = new FakeAgentProcess()
+    const receivedPrompts: ContentBlock[][] = []
+    startFakeAgent(process, ['remote-session-1'], {
+      onPrompt: ({ prompt }) => {
+        receivedPrompts.push(prompt)
+      }
+    })
+    const runtime = new AcpRuntime({
+      appVersion: '0.1.0',
+      defaultCwd: '/workspace',
+      spawnAgent: () => asAgentProcess(process),
+      uploads: { repository: uploadRepository }
+    })
+    const historyImageData = Buffer.from('history-image').toString('base64')
+
+    const session = await runtime.createSession({ cwd: '/workspace' })
+    await runtime.sendPrompt({
+      sessionId: session.sessionId,
+      text: 'inspect all context',
+      historyImages: [
+        {
+          mimeType: 'image/png',
+          data: historyImageData,
+          byteLength: Buffer.byteLength('history-image')
+        }
+      ],
+      historyAttachments: [historyUpload],
+      attachments: [currentUpload],
+      referencedArtifacts: [
+        {
+          id: mentionedReference.id,
+          name: mentionedReference.originalName,
+          path: mentionedReference.path,
+          source: 'upload',
+          mimeType: mentionedReference.mimeType
+        }
+      ]
+    })
+
+    expect(receivedPrompts).toHaveLength(1)
+    expect(receivedPrompts[0]).toMatchObject([
+      { type: 'text', text: 'inspect all context' },
+      { type: 'image', mimeType: 'image/png', data: historyImageData },
+      { type: 'resource', resource: { text: 'history upload' } },
+      { type: 'resource', resource: { text: 'current upload' } },
+      { type: 'resource', resource: { text: 'mentioned upload' } }
+    ])
   })
 
   it('keeps ordinary ZIPs on provider-safe references and marks only Skill packages eligible', async () => {
@@ -2367,6 +2488,68 @@ describe('ACP runtime session management', () => {
     })
     // The raw image bytes must not be inlined anywhere in the degraded turn.
     expect(JSON.stringify(receivedPrompts[1])).not.toContain(
+      Buffer.from('png-bytes').toString('base64')
+    )
+  })
+
+  it('keeps image bytes charged when later prompt content preparation fails', async () => {
+    const root = await createTemporaryRoot()
+    const uploadRepository = new UploadRepository(root)
+    const process = new FakeAgentProcess()
+    const receivedPrompts: ContentBlock[][] = []
+    startFakeAgent(process, ['remote-session-1'], {
+      onPrompt: ({ prompt }) => {
+        receivedPrompts.push(prompt)
+      }
+    })
+    const runtime = new AcpRuntime({
+      appVersion: '0.1.0',
+      defaultCwd: '/workspace',
+      spawnAgent: () => asAgentProcess(process),
+      uploads: { repository: uploadRepository },
+      inlineImageBudgetBytes: 15
+    })
+    const stageImage = (name: string): Promise<UploadedAttachment[]> =>
+      stageUploadFixtures(uploadRepository, {
+        files: [
+          { name, mimeType: 'image/png', content: Buffer.from('png-bytes').toString('base64') }
+        ]
+      })
+
+    const session = await runtime.createSession({ cwd: '/workspace' })
+    await expect(
+      runtime.sendPrompt({
+        sessionId: session.sessionId,
+        text: 'first image then invalid reference',
+        attachments: await stageImage('first.png'),
+        referencedArtifacts: [
+          {
+            id: 'missing-artifact',
+            name: 'missing.txt',
+            path: '/not-configured/missing.txt',
+            source: 'artifact',
+            mimeType: 'text/plain'
+          }
+        ]
+      })
+    ).rejects.toThrow('File reference source is not configured: artifact')
+    expect(receivedPrompts).toHaveLength(0)
+
+    await runtime.sendPrompt({
+      sessionId: session.sessionId,
+      text: 'second image',
+      attachments: await stageImage('second.png')
+    })
+
+    expect(receivedPrompts).toHaveLength(1)
+    expect(receivedPrompts[0][1]).toMatchObject({
+      type: 'resource_link',
+      name: 'second.png',
+      title: 'second.png',
+      mimeType: 'image/png',
+      uri: expect.stringContaining('second.png')
+    })
+    expect(JSON.stringify(receivedPrompts[0])).not.toContain(
       Buffer.from('png-bytes').toString('base64')
     )
   })

--- a/src/main/acp/runtime.test.ts
+++ b/src/main/acp/runtime.test.ts
@@ -777,8 +777,14 @@ const contextUsageMap = (
   }
 }
 
-const sessionInlineImageBytesMap = (runtime: AcpRuntime): Map<string, number> =>
-  (runtime as unknown as { sessionInlineImageBytes: Map<string, number> }).sessionInlineImageBytes
+const promptContentLifecycle = (
+  runtime: AcpRuntime
+): { resetSession: (sessionId: string) => void } =>
+  (
+    runtime as unknown as {
+      promptContentOwner: { resetSession: (sessionId: string) => void }
+    }
+  ).promptContentOwner
 
 const resolveArtifactRunClaim = (runtime: AcpRuntime, claimId: string): ArtifactRunClaim =>
   (
@@ -2817,13 +2823,14 @@ describe('ACP runtime session management', () => {
     })
 
     const session = await runtime.createSession({ cwd: '/workspace' })
-    sessionInlineImageBytesMap(runtime).set(session.sessionId, 2048)
+    const resetPromptContent = vi.spyOn(promptContentLifecycle(runtime), 'resetSession')
     contextUsageMap(runtime).set(session.sessionId, { used: 180_000, size: 200_000 })
     expect(runtime.getSnapshot().nativeContextCompactionSessionIds).toEqual([session.sessionId])
     await runtime.compactSession({ sessionId: session.sessionId })
 
     expect(agent.prompts).toEqual([{ sessionId: 'remote-session-1', text: '/compact' }])
-    expect(sessionInlineImageBytesMap(runtime).has(session.sessionId)).toBe(false)
+    expect(resetPromptContent).toHaveBeenCalledOnce()
+    expect(resetPromptContent).toHaveBeenCalledWith(session.sessionId)
     expect(runtime.getSnapshot().contextUsageBySession).toEqual({})
     expect(
       runtime
@@ -2880,13 +2887,13 @@ describe('ACP runtime session management', () => {
     })
 
     const session = await runtime.createSession({ cwd: '/workspace' })
-    sessionInlineImageBytesMap(runtime).set(session.sessionId, 2048)
+    const resetPromptContent = vi.spyOn(promptContentLifecycle(runtime), 'resetSession')
 
     await expect(runtime.compactSession({ sessionId: session.sessionId })).resolves.toMatchObject({
       stopReason: 'cancelled'
     })
 
-    expect(sessionInlineImageBytesMap(runtime).get(session.sessionId)).toBe(2048)
+    expect(resetPromptContent).not.toHaveBeenCalled()
     expect(
       runtime
         .getSnapshot()
@@ -2917,13 +2924,13 @@ describe('ACP runtime session management', () => {
     })
 
     const session = await runtime.createSession({ cwd: '/workspace' })
-    sessionInlineImageBytesMap(runtime).set(session.sessionId, 2048)
+    const resetPromptContent = vi.spyOn(promptContentLifecycle(runtime), 'resetSession')
 
     await expect(runtime.compactSession({ sessionId: session.sessionId })).rejects.toThrow(
       'Compacting failed: media_unstrippable'
     )
 
-    expect(sessionInlineImageBytesMap(runtime).get(session.sessionId)).toBe(2048)
+    expect(resetPromptContent).not.toHaveBeenCalled()
     expect(runtime.getSnapshot().events).toContainEqual(
       expect.objectContaining({
         kind: 'compaction',

--- a/src/main/acp/runtime.ts
+++ b/src/main/acp/runtime.ts
@@ -12,10 +12,9 @@ import type {
 } from '@agentclientprotocol/sdk'
 import type { ChildProcessWithoutNullStreams } from 'node:child_process'
 import { randomUUID } from 'node:crypto'
-import { readFile, stat } from 'node:fs/promises'
+import { readFile } from 'node:fs/promises'
 import { join, resolve } from 'node:path'
 import { Readable, Writable } from 'node:stream'
-import { pathToFileURL } from 'node:url'
 
 import type {
   AcpCancelPromptRequest,
@@ -77,19 +76,6 @@ import {
 } from './session-config'
 import { describePromptError, isProviderPromptError } from './prompt-error'
 import { AcpRuntimeSnapshotOwner } from './runtime-snapshot-owner'
-import {
-  ATTACHMENT_PREVIEW_BYTES,
-  MAX_EMBEDDED_TEXT_UPLOAD_BYTES,
-  buildDatasetAttachmentNotice,
-  buildDeferredMediaNotice,
-  buildOversizedAttachmentNotice,
-  imageAttachmentMimeType,
-  isDatasetAttachment,
-  isTabularAttachment,
-  isTextLikeAttachment,
-  mimeEssence
-} from './attachment-content'
-import { readBoundedManagedFilePreview } from '../managed-file-preview'
 import { ConversationPermissionGrantStore } from './permission-broker'
 import { isMcpToolName } from './permission-policy'
 import { AcpPermissionContext, HUMAN_PERMISSION_ACTION_ORIGIN } from './permission-context'
@@ -102,7 +88,6 @@ import {
   SKILL_IMPORT_SYSTEM_PROMPT_APPEND,
   type SkillImportRpcConnection
 } from '../skills/mcp-server'
-import { isImportableSkillArchivePath } from '../skills/skill-archive-sniffer'
 import { codexStorageDir, codexSubscriptionStorageDir } from '../agent-framework/codex'
 import { getAppClaudeConfigDir } from '../settings/provider-env'
 import type { ResponsesBridgeSkillCandidate } from '../settings/responses-bridge'
@@ -116,10 +101,7 @@ import {
   type SessionUpdateObservation
 } from './context-usage-tracker'
 import { contextUsageMcpSections } from './context-usage-static-context'
-import {
-  createManagedFileReferenceResolver,
-  type FileReferenceResolver
-} from './file-reference-resolver'
+import { createManagedFileReferenceResolver } from './file-reference-resolver'
 import type { UploadRepository } from '../uploads/repository'
 import { DEFAULT_UPLOAD_PROJECT_NAME, type UploadedAttachment } from '../../shared/uploads'
 import type { ArtifactFile, FileReference } from '../../shared/artifacts'
@@ -138,17 +120,7 @@ import {
   type SessionCapabilityRoutingIds
 } from './session-capability-owner'
 import { ArtifactTurnOwner, type ArtifactTurnHandle } from './artifact-turn-owner'
-import {
-  buildImageContentData,
-  canInlineImageInSession,
-  consumeInlineImageBudget,
-  extractPdfText,
-  ImageContentError,
-  MAX_AUTO_EXTRACT_PDF_BYTES,
-  MAX_AUTO_PROCESS_IMAGE_BYTES,
-  MAX_SESSION_INLINE_IMAGE_BYTES,
-  type InlineImageBudget
-} from '../uploads/attachment-media'
+import { AcpPromptContentOwner } from './prompt-content-owner'
 
 export type AcpRuntimeCallbacks = {
   onStateChanged?: (state: AcpStateSnapshot) => void
@@ -554,12 +526,6 @@ class AcpRuntime {
   private supportsSessionResume = false
   private readonly sessions = new Map<string, ActiveSession>()
   private readonly sessionCwds = new Map<string, string>()
-  // Running total of base64 image bytes this session has inlined. The agent replays full history each
-  // turn, so this accumulates; once it nears the request ceiling further images degrade to file links
-  // (see canInlineImageInSession) so a long conversation can never overflow the request or break
-  // compaction with `media_unstrippable`. Cleared after successful native compaction, on session
-  // delete, and on disconnect.
-  private readonly sessionInlineImageBytes = new Map<string, number>()
   // App-owned MCP construction, routing aliases, and bearer lease ownership are kept behind one
   // explicit role policy. Connection/process lifetime remains with this runtime.
   private readonly sessionCapabilities: AcpSessionCapabilityOwner
@@ -693,7 +659,6 @@ class AcpRuntime {
   // Bounded resume network timeout + injectable timers (defaults to real setTimeout/clearTimeout).
   private readonly resumeTimeoutMs: number
   private readonly cancelTimeoutMs: number
-  private readonly inlineImageBudgetBytes: number
   private readonly setTimer: (fn: () => void, ms: number) => ReturnType<typeof setTimeout>
   private readonly clearTimer: (handle: ReturnType<typeof setTimeout>) => void
   private readonly cancelTimers = new Map<string, ReturnType<typeof setTimeout>>()
@@ -703,8 +668,7 @@ class AcpRuntime {
   private readonly artifactRepository: ArtifactRepository | undefined
   private readonly artifactRunRegistry: ArtifactRunRegistry | undefined
   private readonly artifactTurns: ArtifactTurnOwner | undefined
-  private readonly uploadRepository: UploadRepository | undefined
-  private readonly fileReferenceResolver: FileReferenceResolver
+  private readonly promptContentOwner: AcpPromptContentOwner
   private readonly skillImportTurnTokens = new Map<string, string>()
 
   // Wires runtime dependencies and forwards permission prompts into the event stream.
@@ -717,7 +681,6 @@ class AcpRuntime {
     this.mcpHttpHost = options.mcpHttpHost
     this.resumeTimeoutMs = options.resumeTimeoutMs ?? 30_000
     this.cancelTimeoutMs = options.cancelTimeoutMs ?? 5_000
-    this.inlineImageBudgetBytes = options.inlineImageBudgetBytes ?? MAX_SESSION_INLINE_IMAGE_BYTES
     this.contextUsageTracker = options.contextUsageTracker ?? new ContextUsageTracker()
     this.setTimer = options.setTimer ?? ((fn, ms) => setTimeout(fn, ms))
     this.clearTimer = options.clearTimer ?? ((handle) => clearTimeout(handle))
@@ -754,11 +717,16 @@ class AcpRuntime {
               : {})
           })
         : undefined
-    this.uploadRepository = options.uploads?.repository
-    this.fileReferenceResolver = createManagedFileReferenceResolver({
-      uploads: this.uploadRepository,
+    const uploadRepository = options.uploads?.repository
+    const fileReferenceResolver = createManagedFileReferenceResolver({
+      uploads: uploadRepository,
       artifacts: this.artifactRepository,
       artifactVersions: options.artifacts?.provenance
+    })
+    this.promptContentOwner = new AcpPromptContentOwner({
+      uploadRepository,
+      fileReferenceResolver,
+      inlineImageBudgetBytes: options.inlineImageBudgetBytes
     })
     this.permissionContext = new AcpPermissionContext({
       emitPermissionRequest: (request) => {
@@ -1884,7 +1852,7 @@ class AcpRuntime {
     }
 
     // The fresh agent session holds no history, so the accumulated media is gone; start its budget clean.
-    this.sessionInlineImageBytes.delete(request.sessionId)
+    this.promptContentOwner.resetSession(request.sessionId)
     // A context reset creates a new agent-side conversation under the same app id. Do not carry the
     // previous context size into the fresh conversation before its first usage_update arrives.
     this.contextUsageTracker.deleteSession(request.sessionId)
@@ -2094,7 +2062,7 @@ class AcpRuntime {
             contextUsageCheckpoint,
             this.selectedContextWindowFor(appSessionId)
           )
-          this.sessionInlineImageBytes.delete(appSessionId)
+          this.promptContentOwner.resetSession(appSessionId)
           this.pushEvent({
             kind: 'compaction',
             compactionReason: reason,
@@ -2977,7 +2945,7 @@ class AcpRuntime {
 
     this.sessions.clear()
     this.sessionCwds.clear()
-    this.sessionInlineImageBytes.clear()
+    this.promptContentOwner.clear()
     this.currentPromptTurnBySession.clear()
     this.currentPromptIdentityBySession.clear()
     this.claudeTurnCountsBySession.clear()
@@ -3447,13 +3415,45 @@ class AcpRuntime {
         request.sessionId,
         request.referencedArtifacts ?? []
       )
-      const promptContent = this.attachCodexSkillInputs(
-        await this.createPromptContent(request.sessionId, {
-          ...request,
-          text: promptText
-        }),
-        codexSkillInputs
-      )
+      const projectId = this.resolveSessionProjectName(request.sessionId)
+      const preparedPrompt = await this.promptContentOwner.prepare({
+        appSessionId: request.sessionId,
+        projectId,
+        text: promptText,
+        historyImages: request.historyImages ?? [],
+        historyUploads: request.historyAttachments ?? [],
+        currentUploads: request.attachments ?? [],
+        references: request.referencedArtifacts ?? [],
+        codexSkillInputs,
+        skillImportEnabled: this.sessionCapabilities.isSkillImportEnabled(),
+        skillImportTurnToken: this.skillImportTurnTokens.get(request.sessionId),
+        onSkillImportAttachmentEligible: this.callbacks.onSkillImportAttachmentEligible
+          ? (attachmentUri) => {
+              try {
+                this.callbacks.onSkillImportAttachmentEligible?.(
+                  request.sessionId,
+                  skillImportTurnToken,
+                  attachmentUri
+                )
+              } catch (error) {
+                safeLogError('skill import attachment callback failed', errorLogFields(error))
+              }
+            }
+          : undefined
+      })
+      if (this.notebookOptions?.registerTurnInputs && preparedPrompt.turnInputs) {
+        await this.notebookOptions.registerTurnInputs({
+          projectId,
+          appSessionId: request.sessionId,
+          promptMessageId:
+            request.provenanceContext?.promptMessageId ??
+            this.artifactTurns?.promptMessageIdFor(request.sessionId) ??
+            `prompt-unbound-${request.sessionId}`,
+          uploads: preparedPrompt.turnInputs.uploads,
+          references: preparedPrompt.turnInputs.references
+        })
+      }
+      const promptContent = preparedPrompt.content
 
       contextUsageCheckpoint = this.contextUsageTracker.checkpointSession(request.sessionId)
       await this.recordPromptContextEstimate(
@@ -3864,7 +3864,7 @@ class AcpRuntime {
     this.sessionCapabilities.revokeSession(request.sessionId)
     this.sessions.delete(request.sessionId)
     this.sessionCwds.delete(request.sessionId)
-    this.sessionInlineImageBytes.delete(request.sessionId)
+    this.promptContentOwner.resetSession(request.sessionId)
     this.currentPromptTurnBySession.delete(request.sessionId)
     this.currentPromptIdentityBySession.delete(request.sessionId)
     this.handoffPromptRequests.delete(request.sessionId)
@@ -4009,34 +4009,6 @@ class AcpRuntime {
     }
   }
 
-  private attachCodexSkillInputs(
-    content: string | ContentBlock[],
-    descriptors: Array<{ name: string; path: string }>
-  ): string | ContentBlock[] {
-    if (descriptors.length === 0) return content
-
-    const metadata = { 'open-science/skill-inputs': descriptors }
-    if (typeof content === 'string') {
-      return [{ type: 'text', text: content, _meta: metadata }]
-    }
-
-    const blocks = [...content]
-    const textIndex = blocks.findIndex((block) => block.type === 'text')
-    if (textIndex < 0) {
-      blocks.unshift({ type: 'text', text: '', _meta: metadata })
-      return blocks
-    }
-
-    const textBlock = blocks[textIndex]
-    if (textBlock.type === 'text') {
-      blocks[textIndex] = {
-        ...textBlock,
-        _meta: { ...(textBlock._meta ?? {}), ...metadata }
-      }
-    }
-    return blocks
-  }
-
   // Native UserInput::Skill entries are consumed inside Codex and may not emit a filesystem read
   // lifecycle over ACP. Project the same compact activity explicitly so selected and auto-routed
   // Skills remain visible without sending their path or document to renderer state or persistence.
@@ -4057,102 +4029,6 @@ class AcpRuntime {
         status
       })
     }
-  }
-
-  // Turns the renderer prompt plus upload references into the ACP prompt payload.
-  private async createPromptContent(
-    sessionId: string,
-    request: AcpPromptRequest
-  ): Promise<string | ContentBlock[]> {
-    const attachments = [...(request.historyAttachments ?? []), ...(request.attachments ?? [])]
-    const referencedArtifacts = request.referencedArtifacts ?? []
-    let finalizedPromptUploads: UploadedAttachment[] = []
-
-    if (
-      attachments.length === 0 &&
-      referencedArtifacts.length === 0 &&
-      (request.historyImages?.length ?? 0) === 0
-    )
-      return request.text
-
-    const contentBlocks: ContentBlock[] = request.text.trim()
-      ? [{ type: 'text', text: request.text }]
-      : []
-    let imageBudget: InlineImageBudget = { imageCount: 0, base64Bytes: 0 }
-    const appendBlock = (block: ContentBlock, overflowFallback?: ContentBlock): void => {
-      if (block.type === 'image') {
-        try {
-          imageBudget = consumeInlineImageBudget(imageBudget, {
-            data: block.data,
-            mimeType: block.mimeType
-          })
-        } catch (error) {
-          if (error instanceof ImageContentError && error.code === 'IMAGE_TOTAL_BUDGET_EXCEEDED') {
-            if (overflowFallback) contentBlocks.push(overflowFallback)
-            return
-          }
-          throw error
-        }
-      }
-      contentBlocks.push(block)
-    }
-    for (const image of request.historyImages ?? []) {
-      appendBlock({ type: 'image', data: image.data, mimeType: image.mimeType })
-    }
-    if ((request.historyImages?.length ?? 0) > 0) {
-      this.sessionInlineImageBytes.set(sessionId, imageBudget.base64Bytes)
-    }
-
-    // Staged uploads own the durable session id here, so finalize before turning them into blocks.
-    if (attachments.length > 0) {
-      if (!this.uploadRepository) throw new Error('Upload storage is not configured.')
-
-      const finalizedAttachments = await this.uploadRepository.finalizePendingSessionUploads(
-        sessionId,
-        attachments,
-        this.resolveSessionProjectName(sessionId)
-      )
-      finalizedPromptUploads = finalizedAttachments
-
-      // Keep the user's text first, then append files in the same order they were added. A file may
-      // expand to several blocks (an oversized text file becomes a preview notice + a resource link);
-      // route each through appendBlock so image blocks still honor the per-request inline budget.
-      for (const attachment of finalizedAttachments) {
-        const blocks = await this.createAttachmentContentBlock(sessionId, attachment)
-        for (const block of blocks) {
-          appendBlock(
-            block,
-            this.imageOverflowResourceLink(block, attachment.originalName, attachment.size)
-          )
-        }
-      }
-    }
-
-    // `@`-mentioned artifacts reuse the same per-type block builder as uploads, in mention order.
-    for (const reference of referencedArtifacts) {
-      const blocks = await this.createReferencedArtifactContentBlock(sessionId, reference)
-      for (const block of blocks) {
-        appendBlock(block, this.imageOverflowResourceLink(block, reference.name))
-      }
-    }
-
-    if (
-      this.notebookOptions?.registerTurnInputs &&
-      (finalizedPromptUploads.length > 0 || referencedArtifacts.length > 0)
-    ) {
-      await this.notebookOptions.registerTurnInputs({
-        projectId: this.resolveSessionProjectName(sessionId),
-        appSessionId: sessionId,
-        promptMessageId:
-          request.provenanceContext?.promptMessageId ??
-          this.artifactTurns?.promptMessageIdFor(sessionId) ??
-          `prompt-unbound-${sessionId}`,
-        uploads: finalizedPromptUploads,
-        references: referencedArtifacts
-      })
-    }
-
-    return contentBlocks
   }
 
   // Converts the user's explicit `@` selections into a turn-scoped capability for Skill import.
@@ -4176,289 +4052,6 @@ class AcpRuntime {
     })
 
     return authorize(this.resolveSessionProjectName(sessionId), sessionId, paths)
-  }
-
-  private imageOverflowResourceLink(
-    block: ContentBlock,
-    name: string,
-    size?: number
-  ): ContentBlock | undefined {
-    if (block.type !== 'image' || !block.uri) return undefined
-
-    return {
-      type: 'resource_link',
-      uri: block.uri,
-      name,
-      title: name,
-      mimeType: block.mimeType,
-      size
-    }
-  }
-
-  // Converts one managed upload into the richest ACP content block that is safe for its type.
-  private async createAttachmentContentBlock(
-    sessionId: string,
-    attachment: UploadedAttachment
-  ): Promise<ContentBlock[]> {
-    if (!this.uploadRepository) throw new Error('Upload storage is not configured.')
-
-    const filePath = await this.uploadRepository.resolveManagedUploadPath(
-      { path: attachment.path },
-      { projectId: this.resolveSessionProjectName(sessionId), sessionId }
-    )
-    const { size } = await stat(filePath)
-
-    return this.buildFileContentBlock({
-      sessionId,
-      absolutePath: filePath,
-      uri: pathToFileURL(filePath).href,
-      name: attachment.originalName || attachment.name,
-      mimeType: attachment.mimeType,
-      size,
-      allowSkillImportReference: true
-    })
-  }
-
-  // Converts one `@`-mentioned artifact into the same content block an equivalent upload produces.
-  private async createReferencedArtifactContentBlock(
-    sessionId: string,
-    reference: FileReference
-  ): Promise<ContentBlock[]> {
-    const resolvedReference = await this.fileReferenceResolver.resolve(
-      { sessionId, projectId: this.resolveSessionProjectName(sessionId) },
-      reference
-    )
-
-    return this.buildFileContentBlock({
-      sessionId,
-      absolutePath: resolvedReference.absolutePath,
-      uri: resolvedReference.uri,
-      name: resolvedReference.name,
-      mimeType: resolvedReference.mimeType,
-      size: resolvedReference.size,
-      // The import tool currently owns only session uploads. Artifact-store paths remain ordinary
-      // references so the prompt never advertises a URI that main will reject at the trust boundary.
-      allowSkillImportReference: resolvedReference.allowSkillImportReference
-    })
-  }
-
-  // Builds the richest ACP content block that is safe for a resolved file, shared by uploads and
-  // `@`-mentioned artifacts so both reach the agent through identical per-type logic.
-  private async buildFileContentBlock(descriptor: {
-    sessionId: string
-    absolutePath: string
-    uri: string
-    name: string
-    mimeType?: string
-    size: number
-    allowSkillImportReference: boolean
-  }): Promise<ContentBlock[]> {
-    const { sessionId, absolutePath, uri, name, mimeType, size, allowSkillImportReference } =
-      descriptor
-
-    // ACP providers such as OpenCode reject ZIP uploads before the prompt reaches the agent
-    // (`file part media type application/zip functionality not supported`). Keep all ZIPs off that
-    // file-part path, but mark only importer-owned, manifest-confirmed archives as Skill packages so an
-    // ordinary ZIP remains inspectable without advertising request_skill_import.
-    const attachmentTextReference = (
-      tag: 'attached_skill_package' | 'attached_local_archive',
-      skillImportEligible: boolean,
-      turnToken?: string
-    ): ContentBlock => ({
-      type: 'text',
-      text: [
-        `<${tag}>`,
-        JSON.stringify({
-          name,
-          uri,
-          mimeType,
-          size,
-          skillImportEligible,
-          ...(turnToken ? { skillImportTurnToken: turnToken } : {})
-        }),
-        `</${tag}>`
-      ].join('\n')
-    })
-    if (
-      this.sessionCapabilities.isSkillImportEnabled() &&
-      allowSkillImportReference &&
-      (await this.isSkillPackageFile(name, absolutePath))
-    ) {
-      const turnToken = this.skillImportTurnTokens.get(sessionId)
-      if (turnToken) {
-        try {
-          this.callbacks.onSkillImportAttachmentEligible?.(sessionId, turnToken, uri)
-        } catch (error) {
-          safeLogError('skill import attachment callback failed', errorLogFields(error))
-        }
-        return [attachmentTextReference('attached_skill_package', true, turnToken)]
-      }
-    }
-
-    const normalizedName = name.toLowerCase()
-    const normalizedMimeType = mimeEssence(mimeType)
-    if (
-      normalizedName.endsWith('.zip') ||
-      normalizedName.endsWith('.skill') ||
-      normalizedMimeType === 'application/zip' ||
-      normalizedMimeType === 'application/x-zip-compressed'
-    ) {
-      return [attachmentTextReference('attached_local_archive', false)]
-    }
-
-    // Images are embedded as base64 so vision-capable agents receive the actual pixels.
-    // Large images are downscaled/re-encoded first so one file cannot overflow the request. Detection
-    // falls back to the file extension so a `.png` with a missing/generic MIME (some drag/drop and paste
-    // sources omit it) is still inlined as pixels instead of degrading to a bare file link.
-    const imageMimeType = imageAttachmentMimeType(name, mimeType)
-
-    if (imageMimeType) {
-      if (size > MAX_AUTO_PROCESS_IMAGE_BYTES) {
-        return [
-          {
-            type: 'text',
-            text: buildDeferredMediaNotice({ name, size, kind: 'image' })
-          },
-          { type: 'resource_link', uri, name, title: name, mimeType: imageMimeType, size }
-        ]
-      }
-      const { data, mimeType: outMimeType } = await buildImageContentData(
-        absolutePath,
-        imageMimeType,
-        size
-      )
-
-      // Inlined images accumulate over a conversation's replayed history. Once this session's running
-      // total nears the request ceiling, degrade further images to a file reference (like large binary
-      // uploads) instead of base64, so the conversation never overflows the request or breaks
-      // compaction with `media_unstrippable`. The file stays reachable to the agent via its uri.
-      const alreadyInlined = this.sessionInlineImageBytes.get(sessionId) ?? 0
-
-      if (!canInlineImageInSession(alreadyInlined, data.length, this.inlineImageBudgetBytes)) {
-        return [{ type: 'resource_link', uri, name, title: name, mimeType: imageMimeType, size }]
-      }
-
-      this.sessionInlineImageBytes.set(sessionId, alreadyInlined + data.length)
-
-      return [{ type: 'image', data, mimeType: outMimeType, uri }]
-    }
-
-    // PDFs are never inlined as base64 (a 20MB file overflows the 32MB request limit); instead we
-    // extract selectable text so the model reads readable content. Page images are a future option.
-    if (this.isPdfFile(name, mimeType)) {
-      if (size > MAX_AUTO_EXTRACT_PDF_BYTES) {
-        return [
-          {
-            type: 'text',
-            text: buildDeferredMediaNotice({ name, size, kind: 'PDF' })
-          },
-          { type: 'resource_link', uri, name, title: name, mimeType: 'application/pdf', size }
-        ]
-      }
-      return [await this.createPdfContentBlock(name, absolutePath, uri)]
-    }
-
-    if (isTextLikeAttachment(name, mimeType)) {
-      // Small text-like files are embedded for direct reading.
-      if (size <= MAX_EMBEDDED_TEXT_UPLOAD_BYTES) {
-        return [
-          {
-            type: 'resource',
-            resource: { uri, mimeType, text: await readFile(absolutePath, 'utf8') }
-          }
-        ]
-      }
-
-      // Oversized text/tabular files are never inlined — a full read is the main request-size overflow
-      // source. Send a bounded preview (structure + a few rows) plus a link so the agent reads only what
-      // it needs instead of loading the whole file into context.
-      const preview = await readBoundedManagedFilePreview(
-        absolutePath,
-        { path: absolutePath, maxBytes: ATTACHMENT_PREVIEW_BYTES, encoding: 'utf8' },
-        'Attachment preview requires UTF-8 encoding.'
-      )
-
-      return [
-        {
-          type: 'text',
-          text: buildOversizedAttachmentNotice({
-            name,
-            size,
-            preview: preview.content,
-            truncated: preview.truncated,
-            tabular: isTabularAttachment(name, mimeType)
-          })
-        },
-        { type: 'resource_link', uri, name, title: name, mimeType, size }
-      ]
-    }
-
-    if (isDatasetAttachment(name, mimeType)) {
-      return [
-        { type: 'text', text: buildDatasetAttachmentNotice({ name, size }) },
-        { type: 'resource_link', uri, name, title: name, mimeType, size }
-      ]
-    }
-
-    // Binary and large files are passed as resource links so agents can decide how to fetch them.
-    return [
-      {
-        type: 'resource_link',
-        uri,
-        name,
-        title: name,
-        mimeType,
-        size
-      }
-    ]
-  }
-
-  // Recognizes PDFs by MIME type or extension since the renderer does not always send a MIME type.
-  private isPdfFile(name: string, mimeType?: string): boolean {
-    if (mimeType === 'application/pdf') return true
-
-    return name.toLowerCase().endsWith('.pdf')
-  }
-
-  private async isSkillPackageFile(name: string, filePath: string): Promise<boolean> {
-    const normalizedName = name.toLowerCase()
-
-    if (!normalizedName.endsWith('.skill') && !normalizedName.endsWith('.zip')) return false
-
-    return isImportableSkillArchivePath(filePath)
-  }
-
-  // Turns a PDF into a text resource block, degrading to an explanatory note when extraction fails
-  // or yields nothing (e.g. scanned/image-only PDFs) rather than ever inlining the raw file.
-  private async createPdfContentBlock(
-    name: string,
-    filePath: string,
-    uri: string
-  ): Promise<ContentBlock> {
-    const toResource = (text: string): ContentBlock => ({
-      type: 'resource',
-      resource: { uri, mimeType: 'text/plain', text }
-    })
-
-    try {
-      const { text, pageCount, truncated } = await extractPdfText(filePath)
-
-      if (!text) {
-        return toResource(
-          `[No selectable text could be extracted from "${name}" (${pageCount} page(s)). It may be a scanned or image-only PDF.]`
-        )
-      }
-
-      const header = `[PDF text extracted from "${name}" — ${pageCount} page(s)${
-        truncated ? ', truncated' : ''
-      }]`
-
-      return toResource(`${header}\n\n${text}`)
-    } catch (error) {
-      return toResource(
-        `[Failed to extract text from "${name}": ${errorMessage(error)}. The PDF was not sent to avoid exceeding the request size limit.]`
-      )
-    }
   }
 
   // Lazily initializes the process connection before session creation.
@@ -5280,7 +4873,7 @@ class AcpRuntime {
     this.sessionCapabilities.dispose(this.sessions.keys())
     this.sessions.clear()
     this.sessionCwds.clear()
-    this.sessionInlineImageBytes.clear()
+    this.promptContentOwner.clear()
     this.currentPromptTurnBySession.clear()
     this.currentPromptIdentityBySession.clear()
     this.handoffPromptRequests.clear()


### PR DESCRIPTION
## Problem

ACP prompt preparation still mixed attachment/reference resolution, Skill metadata, file classification, and the provider-context image budget into the runtime that owns Session and turn dispatch.

## Proposed change

Introduce `AcpPromptContentOwner`, which accepts an explicit typed input snapshot and returns provider-ready content plus the finalized Upload/reference provenance needed by Notebook registration. It also owns the per-Session cumulative inline-image budget and exposes only `resetSession`/`clear` lifecycle operations.

```mermaid
flowchart LR
  Runtime["ACP runtime: admission, grant, turn"] -->|typed explicit inputs| Content["AcpPromptContentOwner"]
  Content --> Uploads["Upload repository"]
  Content --> References["File reference resolver"]
  Content -->|provider content + turn inputs| Runtime
  Runtime --> Notebook["Notebook registration"]
  Runtime --> Usage["ContextUsage accounting"]
  Runtime --> Provider["ACP provider dispatch"]
```

The runtime keeps Specialist admission, forced/automatic Skill selection, referenced-upload authorization and revocation, Notebook registration, context accounting, activity events, and provider dispatch.

## Scope and non-goals

In scope:

- Preserve text, replay-image, history/current Upload, and explicit reference order.
- Preserve all image/PDF/text/dataset/archive classification, truncation, denial, and budget behavior.
- Preserve Codex Skill metadata and Skill-import eligibility callback behavior.
- Move cumulative provider-context image-budget ownership and its existing reset/clear calls behind the owner.

Out of scope:

- No shared ACP request, IPC, preload, Web, CLI, SDK, Task, persistence, schema, data-relationship, or UI change.
- No Specialist, Permission, or Compute parity change; current surface asymmetry remains.
- No issue #458 child Session, inherited context, orchestration state, or cross-Session authority.

## Acceptance criteria and validation

All commands below ran against exact head `6763946737faf5c3ffb03d9157cf48316c20d0bf` after the last material edit.

- Explicit content preparation and lifecycle ownership -> `npm test -- --run src/main/acp/prompt-content-owner.test.ts src/main/acp/runtime.test.ts` -> 2 files, 370 passed.
- Attachment/reference/media/archive behavior -> `npm test -- --run src/main/acp/attachment-content.test.ts src/main/acp/file-reference-resolver.test.ts src/main/uploads/attachment-media.test.ts src/main/skills/skill-archive-sniffer.test.ts` -> 4 files, 74 passed.
- Electron/Web/CLI/Task/IPC compatibility -> focused 9-file surface matrix -> 9 files, 199 passed.
- Node and renderer types -> `npm run typecheck` -> passed.
- Repository lint -> `npm run lint` -> passed.
- Full regression suite -> `npm test -- --run` -> 672 files passed / 15 skipped; 9,867 tests passed / 184 skipped.
- Patch hygiene -> `git diff --check origin/main...HEAD` -> passed.
- Independent exact-head Standards, Spec, and deep-module reviews -> no P0/P1/P2 findings.

The focused runtime suite requires local loopback listeners; it passed in the normal unsandboxed test environment. Remaining risk is limited to provider implementations outside the repository test harness mutating ACP content blocks; the owner defensively copies Skill descriptors and preserves the existing wire shapes.

## Review focus

- The owner must consume only explicit inputs and must not discover transcript, workspace, kernel, or Session-store context.
- Image-budget mutation timing intentionally remains unchanged, including retaining charges when a later reference fails.
- Referenced-upload grants must continue to span the full provider turn and revoke in runtime `finally` paths.
- Notebook registration must remain after resolution and before context estimation/provider dispatch.
- Future issue #458 context builders may produce typed inputs but must not weaken managed reference authorization.

Related: #458
