### PR TITLE
refactor(acp): extract session arbitration

### DIFF
--- a/src/main/acp/runtime.test.ts
+++ b/src/main/acp/runtime.test.ts
@@ -838,9 +838,6 @@ const pendingReviewerSessionIds = (runtime: AcpRuntime): Map<string, symbol> =>
       .map(({ sessionId }) => [sessionId, Symbol.for(sessionId)])
   )
 
-const pendingPrimarySessionIds = (runtime: AcpRuntime): Map<string, symbol> =>
-  (runtime as unknown as { pendingPrimarySessionIds: Map<string, symbol> }).pendingPrimarySessionIds
-
 const contextUsageSelectionForTest = (
   runtime: AcpRuntime,
   sessionId: string
@@ -7780,15 +7777,12 @@ describe('ACP runtime session management', () => {
       await expect(reviewer).rejects.toThrow('Reviewer session id collision: shared-session')
       expect(modeRequestCount()).toBe(1)
       expect(lease.registerReviewerSession).not.toHaveBeenCalled()
-      expect([...pendingPrimarySessionIds(runtime).keys()]).toEqual(['shared-session'])
-
       const duplicateCwd = fakeAgent.newSessions[1]?.cwd
       expect(duplicateCwd).toMatch(/open-science-reviewer-/)
       await expect(stat(duplicateCwd!)).rejects.toMatchObject({ code: 'ENOENT' })
 
       releasePrimaryMode.resolve()
       const winner = await primary
-      expect(pendingPrimarySessionIds(runtime).size).toBe(0)
       expect(runtime.getSnapshot()).toMatchObject({
         sessionIds: ['shared-session'],
         permissionProfiles: {
@@ -7883,13 +7877,10 @@ describe('ACP runtime session management', () => {
       let successor: Awaited<ReturnType<AcpRuntime['createSession']>> | undefined
 
       try {
-        expect([...pendingPrimarySessionIds(runtime).keys()]).toEqual(['stale-primary'])
-
         await expect(runTeardown(runtime)).rejects.toThrow(
           'active primary disconnect dispose failed'
         )
 
-        expect(pendingPrimarySessionIds(runtime).size).toBe(0)
         if (canStartSuccessor) {
           successor = await runtime.createSession({ cwd: '/workspace' })
           expect(runtime.getSnapshot().sessionIds).toContain('stale-primary')
@@ -8539,15 +8530,12 @@ describe('ACP runtime session management', () => {
         'Reviewer session id collision: 123e4567-e89b-42d3-a456-426614174000'
       )
       expect(modeRequestCount()).toBe(1)
-      expect([...pendingPrimarySessionIds(runtime).keys()]).toEqual([sessionId])
-
       const duplicateCwd = fakeAgent.newSessions[0]?.cwd
       expect(duplicateCwd).toMatch(/open-science-reviewer-/)
       await expect(stat(duplicateCwd!)).rejects.toMatchObject({ code: 'ENOENT' })
 
       releasePrimaryMode.resolve()
       await expect(primary).resolves.toMatchObject({ sessionId })
-      expect(pendingPrimarySessionIds(runtime).size).toBe(0)
       expect(runtime.getSnapshot().sessionIds).toEqual([sessionId])
       await runtime.sendPrompt({ sessionId, text: 'resumed primary remains active' })
       expect(fakeAgent.prompts).toHaveLength(1)
@@ -8792,12 +8780,10 @@ describe('ACP runtime session management', () => {
 
     try {
       await expect(reviewer).rejects.toThrow(`Reviewer session id collision: ${sessionId}`)
-      expect([...pendingPrimarySessionIds(runtime).keys()]).toEqual([sessionId])
       await expect(stat(fakeAgent.newSessions[0]!.cwd)).rejects.toMatchObject({ code: 'ENOENT' })
 
       releaseResume.resolve()
       await expect(primary).resolves.toMatchObject({ sessionId })
-      expect(pendingPrimarySessionIds(runtime).size).toBe(0)
     } finally {
       releaseResume.resolve()
       await reviewer.then(
@@ -8899,7 +8885,6 @@ describe('ACP runtime session management', () => {
 
     try {
       await expect(reviewer).rejects.toThrow('Reviewer session id collision: stable-app-session')
-      expect([...pendingPrimarySessionIds(runtime).keys()]).toEqual(['stable-app-session'])
       await expect(stat(fakeAgent.newSessions[1]!.cwd)).rejects.toMatchObject({ code: 'ENOENT' })
 
       releaseAdoption.resolve()
@@ -8907,7 +8892,6 @@ describe('ACP runtime session management', () => {
         sessionId: 'stable-app-session',
         contextReset: true
       })
-      expect(pendingPrimarySessionIds(runtime).size).toBe(0)
     } finally {
       releaseAdoption.resolve()
       await reviewer.then(
@@ -8933,12 +8917,6 @@ describe('ACP runtime session management', () => {
     try {
       await expect(reviewer).rejects.toThrow('Reviewer session id collision: stable-app-session')
       expect(modeRequestCount()).toBe(1)
-      expect([...pendingPrimarySessionIds(runtime).keys()]).toEqual([
-        'stable-app-session',
-        'new-provider-session'
-      ])
-      expect(new Set(pendingPrimarySessionIds(runtime).values()).size).toBe(1)
-
       const duplicateCwd = fakeAgent.newSessions[1]?.cwd
       expect(duplicateCwd).toMatch(/open-science-reviewer-/)
       await expect(stat(duplicateCwd!)).rejects.toMatchObject({ code: 'ENOENT' })
@@ -8948,7 +8926,6 @@ describe('ACP runtime session management', () => {
         sessionId: 'stable-app-session',
         contextReset: true
       })
-      expect(pendingPrimarySessionIds(runtime).size).toBe(0)
       expect(runtime.getSnapshot().sessionIds).toEqual(['stable-app-session'])
       await runtime.sendPrompt({
         sessionId: 'stable-app-session',
@@ -8986,12 +8963,6 @@ describe('ACP runtime session management', () => {
         'Reviewer session id collision: reserved-provider-session'
       )
       expect(modeRequestCount()).toBe(1)
-      expect([...pendingPrimarySessionIds(runtime).keys()]).toEqual([
-        'stable-app-session',
-        'reserved-provider-session'
-      ])
-      expect(new Set(pendingPrimarySessionIds(runtime).values()).size).toBe(1)
-
       const duplicateCwd = fakeAgent.newSessions[1]?.cwd
       expect(duplicateCwd).toMatch(/open-science-reviewer-/)
       await expect(stat(duplicateCwd!)).rejects.toMatchObject({ code: 'ENOENT' })
@@ -9001,7 +8972,6 @@ describe('ACP runtime session management', () => {
         sessionId: 'stable-app-session',
         contextReset: true
       })
-      expect(pendingPrimarySessionIds(runtime).size).toBe(0)
       expect(runtime.getSnapshot().sessionIds).toEqual(['stable-app-session'])
       await runtime.sendPrompt({
         sessionId: 'stable-app-session',
@@ -9074,7 +9044,6 @@ describe('ACP runtime session management', () => {
 
     try {
       await expect(reviewer).rejects.toThrow('Reviewer session id collision: stable-app-session')
-      expect([...pendingPrimarySessionIds(runtime).keys()]).toEqual(['stable-app-session'])
       await expect(stat(fakeAgent.newSessions[2]!.cwd)).rejects.toMatchObject({ code: 'ENOENT' })
 
       releaseReplacement.resolve()
@@ -9082,7 +9051,6 @@ describe('ACP runtime session management', () => {
         sessionId: 'stable-app-session',
         contextReset: true
       })
-      expect(pendingPrimarySessionIds(runtime).size).toBe(0)
       await runtime.sendPrompt({
         sessionId: 'stable-app-session',
         text: 'replacement primary remains active'
@@ -9803,10 +9771,8 @@ describe('ACP runtime session management', () => {
     ).rejects.toThrow(/not found/)
   })
 
-  it('releases an adopted provider id for reuse when the app session is deleted', async () => {
+  it('allows a deleted adopted provider id to be reused by a new session', async () => {
     const process = new FakeAgentProcess()
-    // Resume rejects, so the runtime adopts a fresh agent session (adopted-session-1) under the
-    // app-facing id (switched-session), registering the reverse mapping used to relabel agent events.
     const fakeAgent = startFakeAgent(process, ['adopted-session-1', 'adopted-session-1'], {
       resumeNotFound: true
     })
@@ -9819,15 +9785,16 @@ describe('ACP runtime session management', () => {
     await runtime.resumeSession({ sessionId: 'switched-session', cwd: '/workspace' })
     await runtime.deleteSession({ sessionId: 'switched-session' })
 
-    // A new provider session may reuse the deleted underlying id without colliding with a stale alias.
     const reused = await runtime.createSession({ cwd: '/workspace' })
     expect(reused.sessionId).toBe('adopted-session-1')
+    expect(runtime.getSnapshot().sessionIds).toEqual(['adopted-session-1'])
 
     await runtime.sendPrompt({ sessionId: reused.sessionId, text: 'reuse provider identity' })
     expect(fakeAgent.prompts.at(-1)).toEqual({
       sessionId: 'adopted-session-1',
       text: 'reuse provider identity'
     })
+
     await runtime.deleteSession({ sessionId: reused.sessionId })
   })
 
@@ -9985,7 +9952,13 @@ describe('ACP runtime session management', () => {
 
       expect(releaseSessionCapabilities).toHaveBeenCalledOnce()
       expect(releaseSessionCapabilities).toHaveBeenCalledWith('restored-session')
-      expect(pendingPrimarySessionIds(runtime).size).toBe(0)
+
+      const recovered = await runtime.resumeSession({
+        sessionId: 'restored-session',
+        cwd: '/workspace'
+      })
+      expect(recovered.sessionId).toBe('restored-session')
+      await runtime.deleteSession({ sessionId: recovered.sessionId })
     } finally {
       disposeSpy.mockRestore()
     }
@@ -9993,7 +9966,7 @@ describe('ACP runtime session management', () => {
 
   it('releases the notebook RPC capability when fresh-session adoption fails', async () => {
     const process = new FakeAgentProcess()
-    startFakeAgent(process, ['adopted-session'])
+    startFakeAgent(process, ['adopted-session', 'adopted-session'])
     const releaseSessionCapabilities = vi.fn()
     const runtime = new AcpRuntime({
       appVersion: '0.1.0',
@@ -10031,7 +10004,14 @@ describe('ACP runtime session management', () => {
 
       expect(releaseSessionCapabilities).toHaveBeenCalledOnce()
       expect(releaseSessionCapabilities).toHaveBeenCalledWith('switched-session')
-      expect(pendingPrimarySessionIds(runtime).size).toBe(0)
+
+      const recovered = await runtime.resumeSession({
+        sessionId: 'switched-session',
+        cwd: '/workspace',
+        previousFrameworkId: 'codex'
+      })
+      expect(recovered).toMatchObject({ sessionId: 'switched-session', contextReset: true })
+      await runtime.deleteSession({ sessionId: recovered.sessionId })
     } finally {
       disposeSpy.mockRestore()
     }
@@ -16064,7 +16044,7 @@ describe('ACP runtime — session-creation and spawn diagnostics', () => {
   it('logs a safe category when permission-profile setup throws', async () => {
     errorLogSpy.mockClear()
     const process = new FakeAgentProcess()
-    startFakeAgent(process, ['perm-fail-session'])
+    startFakeAgent(process, ['perm-fail-session', 'perm-fail-session'])
     const runtime = new AcpRuntime({
       appVersion: '0.1.0',
       defaultCwd: '/workspace',
@@ -16078,8 +16058,6 @@ describe('ACP runtime — session-creation and spawn diagnostics', () => {
     ).mockRejectedValueOnce(boom)
 
     await expect(runtime.createSession({ cwd: '/workspace' })).rejects.toBe(boom)
-    expect(pendingPrimarySessionIds(runtime).size).toBe(0)
-
     const call = errorLogSpy.mock.calls.find(
       ([message]) => message === 'createSession: configurePermissionProfile failed'
     )
@@ -16090,6 +16068,10 @@ describe('ACP runtime — session-creation and spawn diagnostics', () => {
       generation: 1,
       status: 'connected'
     })
+
+    const recovered = await runtime.createSession({ cwd: '/workspace' })
+    expect(recovered.sessionId).toBe('perm-fail-session')
+    await runtime.deleteSession({ sessionId: recovered.sessionId })
   })
 
   it('releases the provisional notebook RPC capability when session creation fails', async () => {

--- a/src/main/acp/runtime.ts
+++ b/src/main/acp/runtime.ts
@@ -121,8 +121,14 @@ import {
 } from './session-capability-owner'
 import { ArtifactTurnOwner, type ArtifactTurnHandle } from './artifact-turn-owner'
 import { AcpPromptContentOwner } from './prompt-content-owner'
-import type { AcpSessionAggregate, AcpSessionAggregateAttachInput } from './session-aggregate'
-import { AcpSessionRegistry } from './session-registry'
+import type { AcpSessionAggregateAttachInput } from './session-aggregate'
+import {
+  AcpSessionRegistry,
+  type AcpPrimarySessionIdentityReservation,
+  type AcpPrimarySessionIdentityReservationResult,
+  type AcpSessionDeletion,
+  type AcpSessionRegistryEntry
+} from './session-registry'
 
 export type AcpRuntimeCallbacks = {
   onStateChanged?: (state: AcpStateSnapshot) => void
@@ -209,22 +215,6 @@ type AcpRuntimeSkillsOptions = {
   // Chat Completions compatibility selector receives name + description; paths remain local.
   catalogForCodexHome?: (codexHome: string | undefined) => Promise<ResponsesBridgeSkillCandidate[]>
 }
-
-type PrimarySessionIdentityReservation = {
-  deletionEpochs: Map<string, number>
-  generation: number
-  // A startup that begins without a usable connection (or behind an already-armed reconnect barrier)
-  // may cross the connection setup's expected invalidation exactly once. An explicit teardown that
-  // starts after a live-session reset receives no such permit and cannot adopt a later successor.
-  mayRenewAfterConnectionSetup: boolean
-  released: boolean
-  token: symbol
-  sessionIds: Set<string>
-}
-
-type PrimarySessionIdentityReservationResult =
-  | { reservation: PrimarySessionIdentityReservation; collision?: never }
-  | { reservation?: never; collision: Error }
 
 type SessionModelApplication = {
   appliedModel: string | undefined
@@ -522,29 +512,18 @@ class AcpRuntime {
   private connection: ClientConnection | undefined
   private connectInFlight: Promise<AcpStateSnapshot> | undefined
   private connectionGeneration = 0
-  private sessionStartupGeneration = 0
   private supportsSessionClose = false
   private supportsSessionDelete = false
   private supportsSessionResume = false
-  // Stable app identities, provider aliases, publication order, and current selection share one owner.
-  private readonly sessionRegistry = new AcpSessionRegistry()
+  // Stable app identities, provider aliases, publication order, selection, and startup/delete
+  // arbitration share one owner. The runtime retains only protocol/resource orchestration.
+  private readonly sessionRegistry: AcpSessionRegistry
   // App-owned MCP construction, routing aliases, and bearer lease ownership are kept behind one
   // explicit role policy. Connection/process lifetime remains with this runtime.
   private readonly sessionCapabilities: AcpSessionCapabilityOwner
   private readonly cancelledPromptTurnsBySession = new Map<string, number>()
   // Ephemeral Reviewer identity, isolation, permission, and resource state lives behind one owner.
-  // Primary identity arbitration remains here and collaborates through narrow collision ports.
   private readonly reviewerSessions: ReviewerSessionOwner
-  // A primary startup can know both its stable app id and its provider protocol id before it is ready
-  // for publication. Tokens make multi-id reservations owner-aware so one concurrent startup can never
-  // release another startup's identity.
-  private readonly pendingPrimarySessionIds = new Map<string, symbol>()
-  // Explicit deletion must supersede any same-id reset/resume that was already waiting for connection
-  // setup. Keep a per-id epoch across disconnects so a detached delete cannot be mistaken for the
-  // reconnect teardown that removed the captured ActiveSession.
-  private readonly primarySessionDeletionEpochs = new Map<string, number>()
-  private readonly primarySessionDeletionsInFlight = new Map<string, number>()
-  private readonly primarySessionIdentityReservationCounts = new Map<string, number>()
   // A startup that begins while a reconnect barrier is already armed must not block the reconnect it
   // is waiting for. Once it reaches the replacement connection, renewal adds its token here so any
   // later reconnect waits for publication or rollback.
@@ -704,6 +683,26 @@ class AcpRuntime {
       fileReferenceResolver,
       inlineImageBudgetBytes: options.inlineImageBudgetBytes
     })
+    this.sessionRegistry = new AcpSessionRegistry({
+      addStartupBlocker: (token) => this.pendingSessionStartupBlockers.add(token),
+      foreignIdentityCollision: (sessionIds) => {
+        const pendingReviewerCollision = sessionIds.find((sessionId) =>
+          this.reviewerSessions.hasPendingSessionId(sessionId)
+        )
+        if (pendingReviewerCollision) {
+          return new Error(
+            `Primary session id collision with pending reviewer: ${pendingReviewerCollision}`
+          )
+        }
+        const activeReviewerCollision = sessionIds.find((sessionId) =>
+          this.reviewerSessions.hasActiveSessionId(sessionId)
+        )
+        return activeReviewerCollision
+          ? new Error(`Primary session id collision with reviewer: ${activeReviewerCollision}`)
+          : undefined
+      },
+      removeStartupBlocker: (token) => this.pendingSessionStartupBlockers.delete(token)
+    })
     this.permissionContext = new AcpPermissionContext({
       emitPermissionRequest: (request) => {
         // Relabel to the app-facing id when this session was adopted onto a replaced agent.
@@ -734,11 +733,8 @@ class AcpRuntime {
       addStartupBlocker: (token) => this.pendingSessionStartupBlockers.add(token),
       clearPermissionCorrelations: (sessionId) =>
         this.permissionContext.clearCorrelationsForSession(sessionId),
-      currentStartupGeneration: () => this.sessionStartupGeneration,
-      isPrimarySessionIdClaimed: (sessionId) =>
-        this.activeSessionFor(sessionId) !== undefined ||
-        this.sessionRegistry.hasProviderAlias(sessionId) ||
-        this.pendingPrimarySessionIds.has(sessionId),
+      currentStartupGeneration: () => this.sessionRegistry.startupGeneration,
+      isPrimarySessionIdClaimed: (sessionId) => this.sessionRegistry.isIdentityClaimed(sessionId),
       onActiveSessionReleased: () => this.maybeApplyPendingProviderReconnect(),
       registerBridgeSession: (sessionId) =>
         this.responsesBridgeLease?.registerReviewerSession(sessionId),
@@ -748,15 +744,12 @@ class AcpRuntime {
     })
   }
 
-  private getOrCreateSessionAggregate(appSessionId: string): AcpSessionAggregate {
-    return this.sessionRegistry.ensureAffinity(appSessionId).aggregate
-  }
-
   private attachSessionAggregate(
+    reservation: AcpPrimarySessionIdentityReservation,
     appSessionId: string,
     input: AcpSessionAggregateAttachInput
-  ): void {
-    this.sessionRegistry.publish(appSessionId, input)
+  ): AcpSessionRegistryEntry {
+    return this.sessionRegistry.publish(reservation, appSessionId, input)
   }
 
   private activeSessionFor(appSessionId: string): ActiveSession | undefined {
@@ -764,11 +757,11 @@ class AcpRuntime {
   }
 
   private activeSessionEntries(): Array<readonly [string, ActiveSession]> {
-    const entries: Array<readonly [string, ActiveSession]> = []
-    for (const { appSessionId, attachment } of this.sessionRegistry.entries(true)) {
-      if (attachment) entries.push([appSessionId, attachment.session])
-    }
-    return entries
+    return this.sessionRegistry
+      .entries(true)
+      .flatMap(({ appSessionId, attachment }) =>
+        attachment ? [[appSessionId, attachment.session] as const] : []
+      )
   }
 
   private activeSessionIds(): string[] {
@@ -1006,7 +999,7 @@ class AcpRuntime {
         throw new Error('ACP session startup was superseded.')
       }
       if (connection) this.assertCurrentConnectedConnection(connection)
-      this.getOrCreateSessionAggregate(appSessionId).setPermissionProfile(state)
+      this.sessionRegistry.lookup(appSessionId)?.aggregate.setPermissionProfile(state)
     }
     return state
   }
@@ -1480,7 +1473,7 @@ class AcpRuntime {
   ): Promise<AcpCreateSessionResponse> {
     let provisionalRoutingIds: SessionCapabilityRoutingIds | undefined
     let releaseProvisionalNotebookConnection: (() => void) | undefined
-    let primaryIdentityReservation: PrimarySessionIdentityReservation | undefined
+    let primaryIdentityReservation: AcpPrimarySessionIdentityReservation | undefined
     let provisionalSession: ActiveSession | undefined
     let provisionalHttpMcpRoutes = false
     try {
@@ -1490,7 +1483,7 @@ class AcpRuntime {
       log.info('createSession: ensureConnected', this.diagnosticContext())
       const connection = await this.ensureConnected(sessionCwd)
       this.assertCurrentConnectedConnection(connection)
-      const sessionStartupGeneration = this.sessionStartupGeneration
+      const sessionStartupGeneration = this.sessionRegistry.startupGeneration
       const routingIds = this.sessionCapabilities.createRoutingIds()
       provisionalRoutingIds = routingIds
 
@@ -1587,7 +1580,20 @@ class AcpRuntime {
       // Commit app-owned projections only after the reservation is known to still own this id. No
       // await separates this assertion from publication, so an invalidated startup cannot overwrite a
       // same-id successor's Specialist, Permission, or model state.
-      const aggregate = this.getOrCreateSessionAggregate(session.sessionId)
+      const { aggregate } = this.attachSessionAggregate(
+        primaryIdentityReservation,
+        session.sessionId,
+        {
+          session,
+          cwd: sessionCwd,
+          projectName,
+          frameworkId: this.framework.id,
+          backendId: this.backendId,
+          permissionProfile: permissionState,
+          appliedModel: modelApplication.appliedModel,
+          configOptions: modelApplication.configOptions
+        }
+      )
       if (specialistPrefix) {
         aggregate.setSpecialistPrefix(specialistPrefix)
       } else {
@@ -1598,16 +1604,6 @@ class AcpRuntime {
       } else {
         aggregate.setSpecialistId(undefined)
       }
-      this.attachSessionAggregate(session.sessionId, {
-        session,
-        cwd: sessionCwd,
-        projectName,
-        frameworkId: this.framework.id,
-        backendId: this.backendId,
-        permissionProfile: permissionState,
-        appliedModel: modelApplication.appliedModel,
-        configOptions: modelApplication.configOptions
-      })
       provisionalSession = undefined
       this.releasePrimarySessionIdentityReservation(primaryIdentityReservation)
       primaryIdentityReservation = undefined
@@ -1630,7 +1626,6 @@ class AcpRuntime {
           sessionId: session.sessionId
         })
       }
-      this.sessionRegistry.select(session.sessionId)
       this.snapshotOwner.updateCwd(sessionCwd)
       try {
         this.pushEvent({
@@ -1706,6 +1701,7 @@ class AcpRuntime {
   // onto a replaced agent after a provider switch). Remaps the agent's own id so later updates and
   // permission requests relabel into the same conversation.
   private adoptSession(
+    primaryIdentityReservation: AcpPrimarySessionIdentityReservation,
     appSessionId: string,
     session: ActiveSession,
     cwd: string,
@@ -1713,8 +1709,8 @@ class AcpRuntime {
     permissionProfile: SessionPermissionProfileState,
     appliedModel: string | undefined,
     configOptions: SessionConfigOption[] | null | undefined
-  ): void {
-    this.attachSessionAggregate(appSessionId, {
+  ): AcpSessionRegistryEntry {
+    const entry = this.attachSessionAggregate(primaryIdentityReservation, appSessionId, {
       session,
       cwd,
       projectName,
@@ -1725,8 +1721,8 @@ class AcpRuntime {
       configOptions
     })
 
-    this.sessionRegistry.select(appSessionId)
     this.snapshotOwner.updateCwd(cwd)
+    return entry
   }
 
   // Reattaches a persisted protocol session after an app restart so later prompts can stream.
@@ -1744,7 +1740,8 @@ class AcpRuntime {
     const attachedSession = this.activeSessionFor(request.sessionId)
 
     if (attachedSession) {
-      const aggregate = this.getOrCreateSessionAggregate(request.sessionId)
+      const aggregate = this.sessionRegistry.lookup(request.sessionId)?.aggregate
+      if (!aggregate) throw new Error(`ACP session is not registered: ${request.sessionId}`)
       if (request.specialistId) {
         aggregate.setSpecialistId(request.specialistId)
       }
@@ -1817,26 +1814,23 @@ class AcpRuntime {
     request: AcpResumeSessionRequest,
     sessionCwd: string,
     projectName: string,
-    primaryIdentityReservation: PrimarySessionIdentityReservation,
+    primaryIdentityReservation: AcpPrimarySessionIdentityReservation,
     publishedSession: ActiveSession | undefined
   ): Promise<AcpCreateSessionResponse> {
     const connection = await this.ensureConnected(sessionCwd)
     this.assertCurrentConnectedConnection(connection)
     const currentPublishedSession = this.activeSessionFor(request.sessionId)
-    const reconnectReplacedPublishedSession =
-      publishedSession !== undefined &&
-      currentPublishedSession === undefined &&
-      primaryIdentityReservation.generation !== this.sessionStartupGeneration &&
-      primaryIdentityReservation.mayRenewAfterConnectionSetup
-    if (currentPublishedSession !== publishedSession && !reconnectReplacedPublishedSession) {
-      throw new Error('ACP session startup was superseded.')
-    }
-    this.renewPrimarySessionIdentityReservation(
+    const crossedGeneration = this.renewPrimarySessionIdentityReservation(
       primaryIdentityReservation,
       currentPublishedSession === publishedSession && currentPublishedSession
         ? request.sessionId
         : undefined
     )
+    const reconnectReplacedPublishedSession =
+      publishedSession !== undefined && currentPublishedSession === undefined && crossedGeneration
+    if (currentPublishedSession !== publishedSession && !reconnectReplacedPublishedSession) {
+      throw new Error('ACP session startup was superseded.')
+    }
 
     // Tear down the currently attached agent session (if any) before adopting a replacement, dropping
     // its reverse routing so late events from the old agent session can no longer target this app id.
@@ -1904,7 +1898,7 @@ class AcpRuntime {
     }
 
     // Skills map drives per-turn skill resolution for every framework.
-    const aggregate = this.getOrCreateSessionAggregate(sessionId)
+    const { aggregate } = this.sessionRegistry.ensureAffinity(sessionId)
     aggregate.setSpecialistId(specialistId)
 
     // Per-turn identity prefix (Codex / OpenCode). Claude uses a session _meta append instead, which
@@ -2159,7 +2153,7 @@ class AcpRuntime {
     request: AcpResumeSessionRequest,
     sessionCwd: string,
     projectName: string,
-    primaryIdentityReservation: PrimarySessionIdentityReservation
+    primaryIdentityReservation: AcpPrimarySessionIdentityReservation
   ): Promise<AcpCreateSessionResponse> {
     const connection = await this.ensureConnected(sessionCwd)
     this.assertCurrentConnectedConnection(connection)
@@ -2350,20 +2344,23 @@ class AcpRuntime {
       await this.applySessionEffort(session, modelApplication.configOptions, connection)
 
       this.assertPrimarySessionIdentityReservation(primaryIdentityReservation)
-      const aggregate = this.getOrCreateSessionAggregate(request.sessionId)
+      const { aggregate } = this.attachSessionAggregate(
+        primaryIdentityReservation,
+        request.sessionId,
+        {
+          session,
+          cwd: sessionCwd,
+          projectName,
+          frameworkId: this.framework.id,
+          backendId: this.backendId,
+          permissionProfile: permissionState,
+          appliedModel: modelApplication.appliedModel,
+          configOptions: modelApplication.configOptions
+        }
+      )
       if (request.specialistId) {
         aggregate.setSpecialistId(request.specialistId)
       }
-      this.attachSessionAggregate(request.sessionId, {
-        session,
-        cwd: sessionCwd,
-        projectName,
-        frameworkId: this.framework.id,
-        backendId: this.backendId,
-        permissionProfile: permissionState,
-        appliedModel: modelApplication.appliedModel,
-        configOptions: modelApplication.configOptions
-      })
       this.releasePrimarySessionIdentityReservation(primaryIdentityReservation)
       this.sessionCapabilities.commit({
         appSessionId: request.sessionId,
@@ -2373,7 +2370,6 @@ class AcpRuntime {
       })
       notebookCapabilityProvisional = false
       releaseProvisionalNotebookConnection = undefined
-      this.sessionRegistry.select(request.sessionId)
       this.snapshotOwner.updateCwd(sessionCwd)
       try {
         this.pushEvent({
@@ -2450,7 +2446,7 @@ class AcpRuntime {
     request: AcpResumeSessionRequest,
     sessionCwd: string,
     projectName: string,
-    primaryIdentityReservation: PrimarySessionIdentityReservation
+    primaryIdentityReservation: AcpPrimarySessionIdentityReservation
   ): Promise<AcpCreateSessionResponse> {
     // Fresh adoption also receives a provisional Notebook bearer token. Transfer ownership only after
     // adoptSession has registered the replacement; every earlier failure revokes it and disposes any
@@ -2519,11 +2515,8 @@ class AcpRuntime {
       const modelApplication = await this.applySessionModel(adopted, connection)
       await this.applySessionEffort(adopted, modelApplication.configOptions, connection)
       this.assertPrimarySessionIdentityReservation(primaryIdentityReservation)
-      const aggregate = this.getOrCreateSessionAggregate(request.sessionId)
-      if (request.specialistId) {
-        aggregate.setSpecialistId(request.specialistId)
-      }
-      this.adoptSession(
+      const { aggregate } = this.adoptSession(
+        primaryIdentityReservation,
         request.sessionId,
         adopted,
         sessionCwd,
@@ -2532,6 +2525,9 @@ class AcpRuntime {
         modelApplication.appliedModel,
         modelApplication.configOptions
       )
+      if (request.specialistId) {
+        aggregate.setSpecialistId(request.specialistId)
+      }
       this.pendingClaudeCodeHandoffAppends.delete(request.sessionId)
       this.releasePrimarySessionIdentityReservation(primaryIdentityReservation)
       this.sessionCapabilities.commit({
@@ -3818,30 +3814,17 @@ class AcpRuntime {
 
   // Closes the agent-side session when supported, then removes local routing state.
   async deleteSession(request: AcpDeleteSessionRequest): Promise<AcpStateSnapshot> {
-    this.primarySessionDeletionEpochs.set(
-      request.sessionId,
-      (this.primarySessionDeletionEpochs.get(request.sessionId) ?? 0) + 1
-    )
-    this.primarySessionDeletionsInFlight.set(
-      request.sessionId,
-      (this.primarySessionDeletionsInFlight.get(request.sessionId) ?? 0) + 1
-    )
+    const deletion = this.sessionRegistry.beginDelete(request.sessionId)
     try {
-      return await this.withOperationLease(() => this.deleteSessionOperation(request))
+      return await this.withOperationLease(() => this.deleteSessionOperation(request, deletion))
     } finally {
-      const remainingDeletions =
-        (this.primarySessionDeletionsInFlight.get(request.sessionId) ?? 1) - 1
-      if (remainingDeletions > 0) {
-        this.primarySessionDeletionsInFlight.set(request.sessionId, remainingDeletions)
-      } else {
-        this.primarySessionDeletionsInFlight.delete(request.sessionId)
-      }
-      this.releasePrimarySessionDeletionEpochIfUnused(request.sessionId)
+      deletion.finish()
     }
   }
 
   private async deleteSessionOperation(
-    request: AcpDeleteSessionRequest
+    request: AcpDeleteSessionRequest,
+    deletion: AcpSessionDeletion
   ): Promise<AcpStateSnapshot> {
     const target = this.sessionRegistry.lookup(request.sessionId)
     const session = target?.attachment?.session
@@ -3880,7 +3863,7 @@ class AcpRuntime {
     this.skillSelectorAbortControllers.delete(request.sessionId)
     // Drop this session's MCP routes, aliases, and bearer ownership (idempotent for detached deletes).
     this.sessionCapabilities.revokeSession(request.sessionId)
-    if (target) this.sessionRegistry.remove(target)
+    const removal = deletion.finish(target)
     this.promptContentOwner.resetSession(request.sessionId)
     this.currentPromptTurnBySession.delete(request.sessionId)
     this.currentPromptIdentityBySession.delete(request.sessionId)
@@ -3895,9 +3878,9 @@ class AcpRuntime {
     this.promptInFlightSessionIds.delete(request.sessionId)
     this.contextCompactionInFlightSessionIds.delete(request.sessionId)
 
-    // Only announce a deletion when something was actually attached; detached cleanup after a switch
-    // must not emit a spurious event or move the current selection.
-    if (session) {
+    // Only announce a deletion and shift the current session when something was actually attached; a
+    // detached cleanup (post-switch) must not emit a spurious event or move the current selection.
+    if (removal.wasActive) {
       this.pushEvent({
         kind: 'system',
         level: 'info',
@@ -4973,152 +4956,46 @@ class AcpRuntime {
           connection,
           framework: this.framework,
           sessionOptions: this.pendingSessionOptions,
-          startupGeneration: this.sessionStartupGeneration
+          startupGeneration: this.sessionRegistry.startupGeneration
         }
       })
     )
   }
 
   private invalidatePendingSessionStartups(): void {
-    this.sessionStartupGeneration += 1
+    this.sessionRegistry.invalidatePending()
     this.reviewerSessions.invalidatePending()
-    this.pendingPrimarySessionIds.clear()
-    this.pendingSessionStartupBlockers.clear()
   }
 
   private reservePrimarySessionIds(
-    reservation: PrimarySessionIdentityReservation | undefined,
+    reservation: AcpPrimarySessionIdentityReservation | undefined,
     sessionIds: string[],
     publishedAppSessionId?: string,
-    startupGeneration = reservation?.generation ?? this.sessionStartupGeneration
-  ): PrimarySessionIdentityReservationResult {
-    const generation = reservation?.generation ?? startupGeneration
-    if (generation !== this.sessionStartupGeneration) {
-      return { collision: new Error('ACP session startup was superseded.') }
-    }
-
-    const uniqueSessionIds = [...new Set(sessionIds)]
-    const deletionCollision = uniqueSessionIds.find((sessionId) =>
-      this.primarySessionDeletionsInFlight.has(sessionId)
-    )
-    if (deletionCollision) {
-      return {
-        collision: new Error(
-          `Primary session id collision with deletion in progress: ${deletionCollision}`
-        )
-      }
-    }
-    const pendingReviewerCollision = uniqueSessionIds.find((sessionId) =>
-      this.reviewerSessions.hasPendingSessionId(sessionId)
-    )
-    if (pendingReviewerCollision) {
-      return {
-        collision: new Error(
-          `Primary session id collision with pending reviewer: ${pendingReviewerCollision}`
-        )
-      }
-    }
-
-    const activeReviewerCollision = uniqueSessionIds.find((sessionId) =>
-      this.reviewerSessions.hasActiveSessionId(sessionId)
-    )
-    if (activeReviewerCollision) {
-      return {
-        collision: new Error(
-          `Primary session id collision with reviewer: ${activeReviewerCollision}`
-        )
-      }
-    }
-
-    const primaryCollision = uniqueSessionIds.find(
-      (sessionId) =>
-        (this.pendingPrimarySessionIds.has(sessionId) &&
-          this.pendingPrimarySessionIds.get(sessionId) !== reservation?.token) ||
-        (this.activeSessionFor(sessionId) !== undefined && sessionId !== publishedAppSessionId) ||
-        this.sessionRegistry.hasProviderAlias(sessionId)
-    )
-    if (primaryCollision) {
-      return { collision: new Error(`Primary session id collision: ${primaryCollision}`) }
-    }
-
-    const owner =
-      reservation ??
-      ({
-        deletionEpochs: new Map<string, number>(),
-        generation,
-        mayRenewAfterConnectionSetup: Boolean(
-          this.reconnectBarrier || !this.connection || this.snapshotOwner.status !== 'connected'
-        ),
-        released: false,
-        token: Symbol('primary-session-identity'),
-        sessionIds: new Set<string>()
-      } satisfies PrimarySessionIdentityReservation)
-    if (!reservation && !this.reconnectBarrier) {
-      this.pendingSessionStartupBlockers.add(owner.token)
-    }
-    for (const sessionId of uniqueSessionIds) {
-      if (!owner.deletionEpochs.has(sessionId)) {
-        owner.deletionEpochs.set(sessionId, this.primarySessionDeletionEpochs.get(sessionId) ?? 0)
-        this.primarySessionIdentityReservationCounts.set(
-          sessionId,
-          (this.primarySessionIdentityReservationCounts.get(sessionId) ?? 0) + 1
-        )
-      }
-      owner.sessionIds.add(sessionId)
-      this.pendingPrimarySessionIds.set(sessionId, owner.token)
-    }
-    return { reservation: owner }
+    startupGeneration = this.sessionRegistry.startupGeneration
+  ): AcpPrimarySessionIdentityReservationResult {
+    return this.sessionRegistry.reserve({
+      reservation,
+      sessionIds,
+      publishedAppSessionId,
+      startupGeneration,
+      mayRenewAfterConnectionSetup: Boolean(
+        this.reconnectBarrier || !this.connection || this.snapshotOwner.status !== 'connected'
+      ),
+      blockStartup: !this.reconnectBarrier
+    })
   }
 
   private renewPrimarySessionIdentityReservation(
-    reservation: PrimarySessionIdentityReservation,
+    reservation: AcpPrimarySessionIdentityReservation,
     publishedAppSessionId?: string
-  ): void {
-    const previousGeneration = reservation.generation
-    const previousMayRenewAfterConnectionSetup = reservation.mayRenewAfterConnectionSetup
-    const wasDeleted = [...reservation.sessionIds].some(
-      (sessionId) =>
-        reservation.deletionEpochs.get(sessionId) !==
-        (this.primarySessionDeletionEpochs.get(sessionId) ?? 0)
-    )
-    if (
-      wasDeleted ||
-      (previousGeneration !== this.sessionStartupGeneration &&
-        !previousMayRenewAfterConnectionSetup)
-    ) {
-      throw new Error('ACP session startup was superseded.')
-    }
-    reservation.generation = this.sessionStartupGeneration
-    reservation.mayRenewAfterConnectionSetup = false
-    const result = this.reservePrimarySessionIds(
-      reservation,
-      [...reservation.sessionIds],
-      publishedAppSessionId
-    )
-    if (result.collision) {
-      reservation.generation = previousGeneration
-      reservation.mayRenewAfterConnectionSetup = previousMayRenewAfterConnectionSetup
-      throw result.collision
-    }
-    this.pendingSessionStartupBlockers.add(reservation.token)
+  ): boolean {
+    return reservation.renew(publishedAppSessionId)
   }
 
   private assertPrimarySessionIdentityReservation(
-    reservation: PrimarySessionIdentityReservation
+    reservation: AcpPrimarySessionIdentityReservation
   ): void {
-    if (
-      reservation.generation !== this.sessionStartupGeneration ||
-      [...reservation.sessionIds].some(
-        (sessionId) =>
-          reservation.deletionEpochs.get(sessionId) !==
-          (this.primarySessionDeletionEpochs.get(sessionId) ?? 0)
-      ) ||
-      [...reservation.sessionIds].some(
-        (sessionId) => this.pendingPrimarySessionIds.get(sessionId) !== reservation.token
-      )
-    ) {
-      throw new Error('ACP session startup was superseded.')
-    }
+    reservation.assertCurrent()
   }
 
   private assertCurrentConnectedConnection(connection: ClientConnection): void {
@@ -5128,33 +5005,9 @@ class AcpRuntime {
   }
 
   private releasePrimarySessionIdentityReservation(
-    reservation: PrimarySessionIdentityReservation
+    reservation: AcpPrimarySessionIdentityReservation
   ): void {
-    if (reservation.released) return
-    reservation.released = true
-    this.pendingSessionStartupBlockers.delete(reservation.token)
-    for (const sessionId of reservation.sessionIds) {
-      if (this.pendingPrimarySessionIds.get(sessionId) === reservation.token) {
-        this.pendingPrimarySessionIds.delete(sessionId)
-      }
-      const remainingReservations =
-        (this.primarySessionIdentityReservationCounts.get(sessionId) ?? 1) - 1
-      if (remainingReservations > 0) {
-        this.primarySessionIdentityReservationCounts.set(sessionId, remainingReservations)
-      } else {
-        this.primarySessionIdentityReservationCounts.delete(sessionId)
-      }
-      this.releasePrimarySessionDeletionEpochIfUnused(sessionId)
-    }
-  }
-
-  private releasePrimarySessionDeletionEpochIfUnused(sessionId: string): void {
-    if (
-      !this.primarySessionDeletionsInFlight.has(sessionId) &&
-      !this.primarySessionIdentityReservationCounts.has(sessionId)
-    ) {
-      this.primarySessionDeletionEpochs.delete(sessionId)
-    }
+    reservation.release()
   }
 
   private disposeSessionAfterFailure(session: ActiveSession, logMessage: string): void {

--- a/src/main/acp/session-registry.test.ts
+++ b/src/main/acp/session-registry.test.ts
@@ -1,8 +1,12 @@
 import type { ActiveSession } from '@agentclientprotocol/sdk'
-import { describe, expect, it } from 'vitest'
+import { describe, expect, it, vi } from 'vitest'
 
 import type { SessionPermissionProfileState } from '../../shared/permission-profiles'
-import { AcpSessionRegistry, type AcpSessionRegistryEntry } from './session-registry'
+import {
+  AcpSessionRegistry,
+  type AcpPrimarySessionIdentityReservation,
+  type AcpSessionRegistryEntry
+} from './session-registry'
 
 const providerSession = (sessionId: string): ActiveSession =>
   ({ sessionId }) as unknown as ActiveSession
@@ -15,35 +19,52 @@ const permissionProfile = (): SessionPermissionProfileState => ({
   fullAccessAvailable: false
 })
 
+const reserve = (
+  registry: AcpSessionRegistry,
+  sessionIds: string[],
+  publishedAppSessionId?: string
+): AcpPrimarySessionIdentityReservation => {
+  const result = registry.reserve({ sessionIds, publishedAppSessionId })
+  if (result.collision) throw result.collision
+  return result.reservation
+}
+
 const publish = (
   registry: AcpSessionRegistry,
   appSessionId: string,
-  providerSessionId: string
-): AcpSessionRegistryEntry =>
-  registry.publish(appSessionId, {
+  providerSessionId: string,
+  publishedAppSessionId?: string
+): AcpSessionRegistryEntry => {
+  const reservation = reserve(
+    registry,
+    [...new Set([appSessionId, providerSessionId])],
+    publishedAppSessionId
+  )
+  const publication = registry.publish(reservation, appSessionId, {
     session: providerSession(providerSessionId),
     cwd: '/workspace',
     projectName: 'project-1',
     frameworkId: 'claude-code',
-    permissionProfile: permissionProfile(),
-    appliedModel: 'model-a'
+    permissionProfile: permissionProfile()
   })
+  reservation.release()
+  return publication
+}
 
 describe('ACP session registry', () => {
-  it('owns stable identity, aliases, selection, and publication order', () => {
+  it('publishes stable identities, current selection, and active ordering atomically', () => {
     const registry = new AcpSessionRegistry()
     const firstA = publish(registry, 'app-a', 'provider-a')
     publish(registry, 'app-b', 'provider-b')
 
     expect(registry.currentSessionId).toBe('app-b')
     expect(registry.resolveAppSessionId('provider-a')).toBe('app-a')
-    expect(registry.hasProviderAlias('provider-a')).toBe(true)
     expect(registry.entries(true).map(({ appSessionId }) => appSessionId)).toEqual([
       'app-a',
       'app-b'
     ])
 
-    const replacement = publish(registry, 'app-a', 'provider-a-2')
+    const replacement = publish(registry, 'app-a', 'provider-a-2', 'app-a')
     expect(registry.detach(firstA.attachment!, 'provider')).toBe(false)
     expect(registry.entries(true).map(({ appSessionId }) => appSessionId)).toEqual([
       'app-a',
@@ -57,6 +78,7 @@ describe('ACP session registry', () => {
       providerSessionId: undefined,
       frameworkId: 'claude-code'
     })
+    expect(registry.entries().map(({ appSessionId }) => appSessionId)).toEqual(['app-a', 'app-b'])
     expect(registry.currentSessionId).toBe('app-a')
 
     publish(registry, 'app-a', 'provider-a-3')
@@ -64,62 +86,226 @@ describe('ACP session registry', () => {
       'app-b',
       'app-a'
     ])
+    expect(registry.currentSessionId).toBe('app-a')
   })
 
-  it('keeps pure affinity without claiming a provider identity and clears applied models', () => {
-    const registry = new AcpSessionRegistry()
-    const affinity = registry.ensureAffinity('app-a')
-
-    affinity.aggregate.setSpecialistId('specialist-a')
-    expect(registry.hasProviderAlias('app-a')).toBe(false)
-    expect(registry.entries(true)).toEqual([])
-
-    publish(registry, 'app-a', 'provider-a')
-    registry.clearAppliedModels()
-    expect(registry.lookup('app-a')?.aggregate.snapshot()).toMatchObject({
-      specialistId: 'specialist-a',
-      appliedModel: undefined
+  it('reserves primary identities through an opaque blocker-owning handle', () => {
+    const blockers = new Set<symbol>()
+    const foreignCollision = new Error(
+      'Primary session id collision with pending reviewer: reviewer-pending'
+    )
+    const foreignIdentityCollision = vi.fn((sessionIds: readonly string[]) =>
+      sessionIds.includes('reviewer-pending') ? foreignCollision : undefined
+    )
+    const registry = new AcpSessionRegistry({
+      addStartupBlocker: (token) => blockers.add(token),
+      removeStartupBlocker: (token) => blockers.delete(token),
+      foreignIdentityCollision
     })
+
+    const reservation = reserve(registry, ['app-a'])
+    expect(blockers).toHaveLength(1)
+    expect(registry.isIdentityClaimed('app-a')).toBe(true)
+    expect(() => reservation.assertCurrent()).not.toThrow()
+
+    expect(registry.reserve({ sessionIds: ['app-a'] }).collision?.message).toBe(
+      'Primary session id collision: app-a'
+    )
+    expect(registry.reserve({ sessionIds: ['reviewer-pending'] }).collision).toBe(foreignCollision)
+    expect(foreignIdentityCollision).toHaveBeenCalledWith(['reviewer-pending'])
+
+    const extended = registry.reserve({ reservation, sessionIds: ['provider-a'] })
+    expect(extended.reservation).toBe(reservation)
+    expect(registry.isIdentityClaimed('provider-a')).toBe(true)
+    expect(registry.reserve({ sessionIds: ['provider-a'] }).collision?.message).toBe(
+      'Primary session id collision: provider-a'
+    )
+
+    reservation.release()
+    reservation.release()
+    expect(blockers).toHaveLength(0)
+    expect(registry.isIdentityClaimed('app-a')).toBe(false)
+    expect(registry.isIdentityClaimed('provider-a')).toBe(false)
+    expect(registry.reserve({ sessionIds: ['app-a'] }).collision).toBeUndefined()
   })
 
-  it('detaches connection state and removes only the captured generation', () => {
-    const registry = new AcpSessionRegistry()
-    const stale = publish(registry, 'app-a', 'provider-a')
-    const replacement = publish(registry, 'app-a', 'provider-a-2')
+  it('delegates global reviewer priority ahead of primary collisions', () => {
+    const pendingReviewer = new Error(
+      'Primary session id collision with pending reviewer: reviewer-pending'
+    )
+    const activeReviewer = new Error('Primary session id collision with reviewer: reviewer-active')
+    const foreignIdentityCollision = vi.fn((sessionIds: readonly string[]) => {
+      if (sessionIds.includes('reviewer-pending')) return pendingReviewer
+      if (sessionIds.includes('reviewer-active')) return activeReviewer
+      return undefined
+    })
+    const registry = new AcpSessionRegistry({ foreignIdentityCollision })
+    const primary = reserve(registry, ['primary-session'])
 
-    expect(registry.remove(stale).removed).toBe(false)
-    expect(registry.detach(replacement.attachment!, 'connection')).toBe(true)
+    const collision = registry.reserve({
+      sessionIds: ['primary-session', 'reviewer-active', 'reviewer-pending']
+    }).collision
+
+    expect(collision).toBe(pendingReviewer)
+    expect(foreignIdentityCollision).toHaveBeenLastCalledWith([
+      'primary-session',
+      'reviewer-active',
+      'reviewer-pending'
+    ])
+    primary.release()
+  })
+
+  it('allows one connection-authorized reservation renewal across startup invalidation', () => {
+    const blockers = new Set<symbol>()
+    const registry = new AcpSessionRegistry({
+      addStartupBlocker: (token) => blockers.add(token),
+      removeStartupBlocker: (token) => blockers.delete(token)
+    })
+    const result = registry.reserve({
+      sessionIds: ['app-a'],
+      mayRenewAfterConnectionSetup: true,
+      blockStartup: false
+    })
+    if (result.collision) throw result.collision
+
+    expect(blockers).toHaveLength(0)
+    registry.invalidatePending()
+    expect(() => result.reservation.assertCurrent()).toThrow('ACP session startup was superseded.')
+
+    expect(result.reservation.renew()).toBe(true)
+    expect(blockers).toHaveLength(1)
+    expect(() => result.reservation.assertCurrent()).not.toThrow()
+
+    registry.invalidatePending()
+    expect(() => result.reservation.renew()).toThrow('ACP session startup was superseded.')
+    result.reservation.release()
+    expect(blockers).toHaveLength(0)
+
+    const sameGeneration = reserve(registry, ['same-generation'])
+    expect(sameGeneration.renew()).toBe(false)
+    sameGeneration.release()
+  })
+
+  it('serializes deletion against reservations and removes only the captured generation', () => {
+    let blockForeign = false
+    const foreignIdentityCollision = vi.fn((sessionIds: readonly string[]) =>
+      blockForeign && sessionIds.includes('app-c') ? new Error('foreign collision') : undefined
+    )
+    const registry = new AcpSessionRegistry({ foreignIdentityCollision })
+    publish(registry, 'app-a', 'provider-a')
+    publish(registry, 'app-b', 'provider-b')
+
+    const staleStartup = reserve(registry, ['app-c'])
+    blockForeign = true
+    foreignIdentityCollision.mockClear()
+    const emptyDeletion = registry.beginDelete('app-c')
+    expect(registry.reserve({ sessionIds: ['app-c'] }).collision?.message).toBe(
+      'Primary session id collision with deletion in progress: app-c'
+    )
+    expect(foreignIdentityCollision).not.toHaveBeenCalled()
+    expect(() => staleStartup.assertCurrent()).toThrow('ACP session startup was superseded.')
+    expect(emptyDeletion.finish()).toMatchObject({ removed: false, wasActive: false })
+    staleStartup.release()
+
+    const activeTarget = registry.lookup('app-b')!
+    const activeDeletion = registry.beginDelete('app-b')
+    expect(registry.detach(activeTarget.attachment!, 'provider')).toBe(true)
+    expect(activeDeletion.finish(activeTarget)).toMatchObject({
+      removed: true,
+      wasActive: true,
+      currentSessionId: 'app-a'
+    })
+    expect(registry.lookup('app-b')).toBeUndefined()
+    expect(registry.resolveAppSessionId('provider-b')).toBe('provider-b')
+
+    const detached = registry.lookup('app-a')!
+    expect(registry.detach(detached.attachment!, 'provider')).toBe(true)
+    const detachedDeletion = registry.beginDelete('app-a')
+    expect(detachedDeletion.finish(registry.lookup('app-a'))).toMatchObject({
+      removed: true,
+      wasActive: false,
+      currentSessionId: 'app-a'
+    })
+
+    const oldEntry = publish(registry, 'app-d', 'provider-d')
+    expect(registry.detach(oldEntry.attachment!, 'provider')).toBe(true)
+    publish(registry, 'app-d', 'provider-d-2')
+    const staleDeletion = registry.beginDelete('app-d')
+    expect(staleDeletion.finish(oldEntry)).toMatchObject({ removed: false })
+    expect(registry.lookup('app-d')?.attachment?.providerSessionId).toBe('provider-d-2')
+  })
+
+  it('selects an already-published app session without changing publication order', () => {
+    const registry = new AcpSessionRegistry()
+    publish(registry, 'app-a', 'provider-a')
+    publish(registry, 'app-b', 'provider-b')
+
+    registry.select('app-a')
+
+    expect(registry.currentSessionId).toBe('app-a')
+    expect(registry.entries(true).map(({ appSessionId }) => appSessionId)).toEqual([
+      'app-a',
+      'app-b'
+    ])
+  })
+
+  it('retains detached affinity without claiming a primary identity', () => {
+    const registry = new AcpSessionRegistry()
+
+    registry.ensureAffinity('app-a').aggregate.setSpecialistId('specialist-1')
+
+    expect(registry.lookup('app-a')?.aggregate.snapshot().specialistId).toBe('specialist-1')
+    expect(registry.entries(true)).toEqual([])
+    expect(registry.isIdentityClaimed('app-a')).toBe(false)
+  })
+
+  it('clears applied models without detaching active sessions', () => {
+    const registry = new AcpSessionRegistry()
+    const entry = publish(registry, 'app-a', 'provider-a')
+    entry.aggregate.attach({
+      session: entry.attachment!.session,
+      cwd: '/workspace',
+      projectName: 'project-1',
+      frameworkId: 'claude-code',
+      permissionProfile: permissionProfile(),
+      appliedModel: 'model-1'
+    })
+
+    registry.clearAppliedModels()
+
+    expect(registry.lookup('app-a')?.aggregate.snapshot().appliedModel).toBeUndefined()
+    expect(registry.lookup('app-a')?.attachment?.session).toBe(entry.attachment?.session)
+  })
+
+  it('detaches connection state while retaining detached affinity', () => {
+    const registry = new AcpSessionRegistry()
+    const entry = publish(registry, 'app-a', 'provider-a')
+    entry.aggregate.attach({
+      session: entry.attachment!.session,
+      cwd: '/workspace',
+      projectName: 'project-1',
+      frameworkId: 'codex',
+      backendId: 'backend-1',
+      permissionProfile: permissionProfile(),
+      appliedModel: 'model-1'
+    })
+    entry.aggregate.setSpecialistId('specialist-1')
+    entry.aggregate.setSpecialistPrefix('Use the selected specialist.')
+
+    expect(registry.detach(entry.attachment!, 'connection')).toBe(true)
+
     expect(registry.currentSessionId).toBeUndefined()
+    expect(registry.entries(true)).toEqual([])
     expect(registry.lookup('app-a')?.aggregate.snapshot()).toMatchObject({
+      providerSessionId: undefined,
       cwd: undefined,
       projectName: undefined,
-      providerSessionId: undefined
-    })
-
-    const republished = publish(registry, 'app-a', 'provider-a-3')
-    publish(registry, 'app-b', 'provider-b')
-    registry.select('app-a')
-    expect(registry.remove(republished)).toMatchObject({
-      removed: true,
-      wasActive: true,
-      currentSessionId: 'app-b'
-    })
-    expect(registry.lookup('app-a')).toBeUndefined()
-    expect(registry.resolveAppSessionId('provider-a-3')).toBe('provider-a-3')
-
-    const detached = publish(registry, 'app-c', 'provider-c')
-    registry.detach(detached.attachment!, 'provider')
-    const detachedTarget = registry.lookup('app-c')!
-    expect(registry.remove(detachedTarget)).toMatchObject({ removed: true, wasActive: false })
-    expect(registry.lookup('app-c')).toBeUndefined()
-
-    const capturedActive = publish(registry, 'app-d', 'provider-d')
-    registry.select('app-d')
-    expect(registry.detach(capturedActive.attachment!, 'provider')).toBe(true)
-    expect(registry.remove(capturedActive)).toMatchObject({
-      removed: true,
-      wasActive: true,
-      currentSessionId: 'app-b'
+      frameworkId: 'codex',
+      backendId: 'backend-1',
+      permissionProfile: permissionProfile(),
+      specialistId: 'specialist-1',
+      specialistPrefix: 'Use the selected specialist.',
+      appliedModel: undefined
     })
   })
 })

--- a/src/main/acp/session-registry.ts
+++ b/src/main/acp/session-registry.ts
@@ -2,55 +2,91 @@ import type { ActiveSession } from '@agentclientprotocol/sdk'
 
 import { AcpSessionAggregate, type AcpSessionAggregateAttachInput } from './session-aggregate'
 
+type RegistryOptions = {
+  addStartupBlocker?: (token: symbol) => void
+  removeStartupBlocker?: (token: symbol) => void
+  foreignIdentityCollision?: (sessionIds: readonly string[]) => Error | undefined
+}
 type AcpSessionAttachment = Readonly<{
   appSessionId: string
   providerSessionId: string
   generation: number
   session: ActiveSession
 }>
-
 type SessionRecord = {
   aggregate: AcpSessionAggregate
   generation: number
   attachment?: AcpSessionAttachment
 }
-
 type AcpSessionRegistryEntry = Readonly<SessionRecord & { appSessionId: string }>
-
-type AcpSessionRemoval = Readonly<{
-  removed: boolean
-  wasActive: boolean
-  currentSessionId?: string
+type AcpPrimarySessionIdentityReservation = Readonly<{
+  assertCurrent: () => void
+  renew: (publishedAppSessionId?: string) => boolean
+  release: () => void
 }>
-
+type ReservationRequest = {
+  sessionIds: readonly string[]
+  reservation?: AcpPrimarySessionIdentityReservation
+  publishedAppSessionId?: string
+  startupGeneration?: number
+  mayRenewAfterConnectionSetup?: boolean
+  blockStartup?: boolean
+}
+type AcpPrimarySessionIdentityReservationResult =
+  | { reservation: AcpPrimarySessionIdentityReservation; collision?: never }
+  | { reservation?: never; collision: Error }
+type Removal = Readonly<{ removed: boolean; wasActive: boolean; currentSessionId?: string }>
+type AcpSessionDeletion = Readonly<{
+  finish: (target?: AcpSessionRegistryEntry) => Removal
+}>
+type IdentityEpoch = { value: number; deletions: number; reservations: number }
+type ReservationState = {
+  blocked: boolean
+  deletionEpochs: Map<string, number>
+  generation: number
+  mayRenewAfterConnectionSetup: boolean
+  token: symbol
+  sessionIds: Set<string>
+}
 const registryEntry = (appSessionId: string, record: SessionRecord): AcpSessionRegistryEntry => ({
   appSessionId,
   ...record
 })
-
+const supersededError = (): Error => new Error('ACP session startup was superseded.')
 class AcpSessionRegistry {
   private readonly records = new Map<string, SessionRecord>()
   private readonly providerAliases = new Map<string, { appSessionId: string; generation: number }>()
+  private readonly pendingPrimarySessionIds = new Map<string, symbol>()
+  private readonly reservationStates = new Map<
+    AcpPrimarySessionIdentityReservation,
+    ReservationState
+  >()
+  private readonly identityEpochs = new Map<string, IdentityEpoch>()
   private nextAttachmentGeneration = 0
+  private startupGenerationValue = 0
   private currentSessionIdValue: string | undefined
-
+  constructor(private readonly options: RegistryOptions = {}) {}
+  get startupGeneration(): number {
+    return this.startupGenerationValue
+  }
   get currentSessionId(): string | undefined {
     return this.currentSessionIdValue
   }
-
   lookup(appSessionId: string): AcpSessionRegistryEntry | undefined {
     const record = this.records.get(appSessionId)
     return record ? registryEntry(appSessionId, record) : undefined
   }
-
   resolveAppSessionId(providerSessionId: string): string {
     return this.providerAliases.get(providerSessionId)?.appSessionId ?? providerSessionId
   }
-
-  hasProviderAlias(providerSessionId: string): boolean {
-    return this.providerAliases.has(providerSessionId)
+  isIdentityClaimed(sessionId: string): boolean {
+    const record = this.records.get(sessionId)
+    return Boolean(
+      record?.attachment ||
+      this.providerAliases.has(sessionId) ||
+      this.pendingPrimarySessionIds.has(sessionId)
+    )
   }
-
   entries(activeOnly = false): AcpSessionRegistryEntry[] {
     const entries: AcpSessionRegistryEntry[] = []
     for (const [appSessionId, record] of this.records) {
@@ -58,7 +94,6 @@ class AcpSessionRegistry {
     }
     return entries
   }
-
   ensureAffinity(appSessionId: string): AcpSessionRegistryEntry {
     const existing = this.records.get(appSessionId)
     if (existing) return registryEntry(appSessionId, existing)
@@ -66,16 +101,74 @@ class AcpSessionRegistry {
     this.records.set(appSessionId, record)
     return registryEntry(appSessionId, record)
   }
-
   select(appSessionId: string | undefined): void {
     this.currentSessionIdValue = appSessionId
   }
-
   clearAppliedModels(): void {
     for (const record of this.records.values()) record.aggregate.clearAppliedModel()
   }
-
-  publish(appSessionId: string, input: AcpSessionAggregateAttachInput): AcpSessionRegistryEntry {
+  reserve(request: ReservationRequest): AcpPrimarySessionIdentityReservationResult {
+    const state = request.reservation ? this.reservationStates.get(request.reservation) : undefined
+    const generation = state?.generation ?? request.startupGeneration ?? this.startupGenerationValue
+    if ((request.reservation && !state) || generation !== this.startupGenerationValue) {
+      return { collision: supersededError() }
+    }
+    const sessionIds = [...new Set(request.sessionIds)]
+    const deleting = sessionIds.find((id) => (this.identityEpochs.get(id)?.deletions ?? 0) > 0)
+    if (deleting) {
+      return {
+        collision: new Error(`Primary session id collision with deletion in progress: ${deleting}`)
+      }
+    }
+    const foreignCollision = this.options.foreignIdentityCollision?.(sessionIds)
+    if (foreignCollision) return { collision: foreignCollision }
+    const primaryCollision = sessionIds.find((sessionId) => {
+      const pendingOwner = this.pendingPrimarySessionIds.get(sessionId)
+      return (
+        (pendingOwner !== undefined && pendingOwner !== state?.token) ||
+        (this.records.get(sessionId)?.attachment !== undefined &&
+          sessionId !== request.publishedAppSessionId) ||
+        this.providerAliases.has(sessionId)
+      )
+    })
+    if (primaryCollision) {
+      return { collision: new Error(`Primary session id collision: ${primaryCollision}`) }
+    }
+    const reservation = request.reservation ?? this.createReservation()
+    const owner =
+      state ??
+      ({
+        blocked: request.blockStartup !== false,
+        deletionEpochs: new Map(),
+        generation,
+        mayRenewAfterConnectionSetup: request.mayRenewAfterConnectionSetup ?? false,
+        token: Symbol('primary-session-identity'),
+        sessionIds: new Set()
+      } satisfies ReservationState)
+    if (!state) {
+      this.reservationStates.set(reservation, owner)
+      if (owner.blocked) this.options.addStartupBlocker?.(owner.token)
+    }
+    for (const sessionId of sessionIds) {
+      if (!owner.deletionEpochs.has(sessionId)) {
+        const epoch = this.epoch(sessionId)
+        owner.deletionEpochs.set(sessionId, epoch.value)
+        epoch.reservations += 1
+      }
+      owner.sessionIds.add(sessionId)
+      this.pendingPrimarySessionIds.set(sessionId, owner.token)
+    }
+    return { reservation }
+  }
+  publish(
+    reservation: AcpPrimarySessionIdentityReservation,
+    appSessionId: string,
+    input: AcpSessionAggregateAttachInput
+  ): AcpSessionRegistryEntry {
+    const state = this.assertReservation(reservation)
+    if (!state.sessionIds.has(appSessionId) || !state.sessionIds.has(input.session.sessionId)) {
+      throw supersededError()
+    }
     const record = this.records.get(appSessionId) ?? {
       aggregate: new AcpSessionAggregate(appSessionId),
       generation: 0
@@ -101,7 +194,6 @@ class AcpSessionRegistry {
     this.currentSessionIdValue = appSessionId
     return registryEntry(appSessionId, record)
   }
-
   detach(attachment: AcpSessionAttachment, mode: 'provider' | 'connection'): boolean {
     const record = this.records.get(attachment.appSessionId)
     if (!record?.attachment || record.attachment.generation !== attachment.generation) return false
@@ -116,21 +208,113 @@ class AcpSessionRegistry {
     }
     return true
   }
-
-  remove(target: AcpSessionRegistryEntry): AcpSessionRemoval {
-    const record = this.records.get(target.appSessionId)
-    const matches = record?.generation === target.generation
-    const wasActive = Boolean(matches && target.attachment)
-    if (matches && record) {
-      if (record.attachment) this.deleteAlias(record.attachment)
-      this.records.delete(target.appSessionId)
-      if (wasActive && this.currentSessionIdValue === target.appSessionId) {
-        this.currentSessionIdValue = this.entries(true)[0]?.appSessionId
+  beginDelete(appSessionId: string): AcpSessionDeletion {
+    const startingGeneration = this.records.get(appSessionId)?.generation
+    const wasActiveAtStart = this.records.get(appSessionId)?.attachment !== undefined
+    const epoch = this.epoch(appSessionId)
+    epoch.value += 1
+    epoch.deletions += 1
+    let result: Removal | undefined
+    return Object.freeze({
+      finish: (target) => {
+        if (result) return result
+        const record = this.records.get(appSessionId)
+        const matches =
+          target?.appSessionId === appSessionId &&
+          target.generation === startingGeneration &&
+          target.generation === record?.generation
+        const wasActive = Boolean(matches && wasActiveAtStart)
+        if (matches && record) {
+          if (record.attachment) this.deleteAlias(record.attachment)
+          this.records.delete(appSessionId)
+          if (wasActive && this.currentSessionIdValue === appSessionId) {
+            this.currentSessionIdValue = this.entries(true)[0]?.appSessionId
+          }
+        }
+        this.releaseEpoch(appSessionId, 'deletions')
+        result = {
+          removed: Boolean(matches),
+          wasActive,
+          currentSessionId: this.currentSessionIdValue
+        }
+        return result
       }
-    }
-    return { removed: Boolean(matches), wasActive, currentSessionId: this.currentSessionIdValue }
+    })
   }
-
+  invalidatePending(): void {
+    this.startupGenerationValue += 1
+    this.pendingPrimarySessionIds.clear()
+    for (const state of this.reservationStates.values()) this.removeBlocker(state)
+  }
+  private createReservation(): AcpPrimarySessionIdentityReservation {
+    const reservation: AcpPrimarySessionIdentityReservation = {
+      assertCurrent: () => this.assertReservation(reservation),
+      renew: (publishedAppSessionId) => this.renewReservation(reservation, publishedAppSessionId),
+      release: () => this.releaseReservation(reservation)
+    }
+    return Object.freeze(reservation)
+  }
+  private assertReservation(reservation: AcpPrimarySessionIdentityReservation): ReservationState {
+    const state = this.reservationStates.get(reservation)
+    if (
+      !state ||
+      state.generation !== this.startupGenerationValue ||
+      this.reservationWasDeleted(state) ||
+      [...state.sessionIds].some(
+        (sessionId) => this.pendingPrimarySessionIds.get(sessionId) !== state.token
+      )
+    ) {
+      throw supersededError()
+    }
+    return state
+  }
+  private renewReservation(
+    reservation: AcpPrimarySessionIdentityReservation,
+    publishedAppSessionId?: string
+  ): boolean {
+    const state = this.reservationStates.get(reservation)
+    if (!state) throw supersededError()
+    const previousGeneration = state.generation
+    const crossedGeneration = previousGeneration !== this.startupGenerationValue
+    const previousPermit = state.mayRenewAfterConnectionSetup
+    if (this.reservationWasDeleted(state) || (crossedGeneration && !previousPermit)) {
+      throw supersededError()
+    }
+    state.generation = this.startupGenerationValue
+    state.mayRenewAfterConnectionSetup = false
+    const result = this.reserve({
+      reservation,
+      sessionIds: [...state.sessionIds],
+      publishedAppSessionId
+    })
+    if (result.collision) {
+      state.generation = previousGeneration
+      state.mayRenewAfterConnectionSetup = previousPermit
+      throw result.collision
+    }
+    if (!state.blocked) {
+      state.blocked = true
+      this.options.addStartupBlocker?.(state.token)
+    }
+    return crossedGeneration
+  }
+  private releaseReservation(reservation: AcpPrimarySessionIdentityReservation): void {
+    const state = this.reservationStates.get(reservation)
+    if (!state) return
+    this.removeBlocker(state)
+    for (const sessionId of state.sessionIds) {
+      if (this.pendingPrimarySessionIds.get(sessionId) === state.token) {
+        this.pendingPrimarySessionIds.delete(sessionId)
+      }
+      this.releaseEpoch(sessionId, 'reservations')
+    }
+    this.reservationStates.delete(reservation)
+  }
+  private removeBlocker(state: ReservationState): void {
+    if (!state.blocked) return
+    state.blocked = false
+    this.options.removeStartupBlocker?.(state.token)
+  }
   private deleteAlias(attachment: AcpSessionAttachment): void {
     if (
       this.providerAliases.get(attachment.providerSessionId)?.generation === attachment.generation
@@ -138,7 +322,30 @@ class AcpSessionRegistry {
       this.providerAliases.delete(attachment.providerSessionId)
     }
   }
+  private reservationWasDeleted(state: ReservationState): boolean {
+    return [...state.deletionEpochs].some(
+      ([id, value]) => value !== (this.identityEpochs.get(id)?.value ?? 0)
+    )
+  }
+  private epoch(sessionId: string): IdentityEpoch {
+    const existing = this.identityEpochs.get(sessionId)
+    if (existing) return existing
+    const created = { value: 0, deletions: 0, reservations: 0 }
+    this.identityEpochs.set(sessionId, created)
+    return created
+  }
+  private releaseEpoch(sessionId: string, owner: 'deletions' | 'reservations'): void {
+    const epoch = this.identityEpochs.get(sessionId)
+    if (!epoch) return
+    epoch[owner] -= 1
+    if (epoch.deletions === 0 && epoch.reservations === 0) this.identityEpochs.delete(sessionId)
+  }
 }
-
 export { AcpSessionRegistry }
-export type { AcpSessionAttachment, AcpSessionRegistryEntry, AcpSessionRemoval }
+export type {
+  AcpPrimarySessionIdentityReservation,
+  AcpPrimarySessionIdentityReservationResult,
+  AcpSessionAttachment,
+  AcpSessionDeletion,
+  AcpSessionRegistryEntry
+}


### PR DESCRIPTION
## Problem

`AcpRuntime` still owned Primary session identity reservations, startup invalidation, reconnect renewal, and deletion epochs alongside Provider workflows. Those maps formed one ABA-sensitive state machine, but their ownership was split from the `AcpSessionRegistry` that already owns stable app IDs, Provider aliases, publication order, and attachment generations.

## Proposed change

- Move startup generation, pending Primary identities, reservation counts, and deletion epochs into `AcpSessionRegistry`.
- Expose opaque Reservation (`assertCurrent`, `renew`, `release`) and Deletion (`finish`) handles instead of Registry-internal maps.
- Make reservation-verified publication atomic with Registry attachment state.
- Preserve the global collision order: stale generation, deletion in progress, pending Reviewer, active Reviewer, then Primary pending/active/alias.
- Replace runtime tests that inspected a private Primary map with public retry, prompt, delete, and cleanup outcomes.

```mermaid
flowchart LR
  Runtime["AcpRuntime: Provider workflows and resource disposal"] -->|"reserve / publish / beginDelete"| Registry["AcpSessionRegistry: identity arbitration"]
  Reviewer["ReviewerSessionOwner"] -->|"foreign collision callback"| Registry
  Registry -->|"add / remove blocker callback"| Blockers["Runtime-owned shared startup blocker set"]
  Registry --> Aggregate["Session aggregate and attachment generation"]
```

## Scope and non-goals

- No IPC, preload, shared contract, persistence schema, data relationship, or UI interaction changes.
- Electron, Web, CLI/Task behavior and their current capability asymmetry remain unchanged.
- Specialist, Permission, Compute, Reviewer, Provider handshake, Codex fresh adoption, `contextReset`, transcript replay, and Provider session disposal remain in their existing owners.
- This keeps the forward-compatible boundary evaluated for #458; it does not introduce orchestration state, relationships, or public APIs for that issue.
- Production gross churn is 674 lines (`runtime.ts` 395 + `session-registry.ts` 279): 24 above the 650 target and below the 800 hard stop. Reservation and deletion intentionally remain together because they serialize through one `identityEpochs` ABA owner; splitting again would create a temporary dual owner.
- `session-registry.ts` is 351 lines and the lifecycle surface is 12 operations.

## Acceptance criteria and validation

All commands below ran after the final material edit at head `38b2d091cc57abb79dbce728408cb6e5a39b8284`.

| Behavior | Project-owned check | Final result |
| --- | --- | --- |
| Multi-ID reservation, Reviewer priority, single renewal, deletion fencing, captured-generation removal, and idempotent terminal release | `npm test -- --run src/main/acp/session-registry.test.ts src/main/acp/runtime.test.ts` | 2 files; 379/379 passed |
| Same-ID retry after resume, fresh-adoption, and Permission setup failures; adopted Provider ID cleanup | public lifecycle cases in `src/main/acp/runtime.test.ts` | included above and in full suite |
| Node and Web type boundaries | `npm run typecheck` | passed |
| Repository lint | `npm run lint` | 0 errors; 19 pre-existing warnings outside changed files |
| Repository regression suite | `npm test -- --run` | 674 files passed, 15 skipped; 9896 tests passed, 184 skipped |
| Final specification and repository-standards review | independent two-axis review of final working tree | 0 Spec findings; 0 Standards findings |

Uncovered risk: no new end-to-end UI journey or real external Provider process test was added. This PR does not change renderer/preload/IPC surfaces or Provider protocol/resource ownership; the full repository suite covers their existing integration contracts.

## Review focus

- The collision priority and single authorized reconnect renewal in `AcpSessionRegistry.reserve`.
- Deletion beginning before the runtime operation lease and `finish` preserving captured-generation/current-session semantics.
- Reservation release never removing another owner's identity or shared startup blocker.
- Runtime retaining Provider disposal and failure cleanup without leaking Specialist, Permission, Compute, or Reviewer state into the Registry.
