### PR TITLE
fix(acp): preserve specialist prefix after adoption

### DIFF
--- a/src/main/acp/runtime.ts
+++ b/src/main/acp/runtime.ts
@@ -2477,7 +2477,7 @@ class AcpRuntime {
       const stagedSpecialistId =
         request.specialistId ??
         this.sessionRegistry.lookup(request.sessionId)?.aggregate.snapshot().specialistId
-      const specialistAppend = await this.resolveCurrentSpecialistIdentityAppend(
+      const specialistIdentity = await this.resolveCurrentSpecialistIdentity(
         request.sessionId,
         stagedSpecialistId
       )
@@ -2487,7 +2487,9 @@ class AcpRuntime {
           cwd: sessionCwd,
           mcpServers,
           ...this.buildSessionMetaArg(
-            [specialistAppend, handoffAppend].filter((append): append is string => Boolean(append)),
+            [specialistIdentity?.append, handoffAppend].filter((append): append is string =>
+              Boolean(append)
+            ),
             await this.resolveCurrentSpecialistSkills(request.sessionId, stagedSpecialistId)
           )
         })
@@ -2525,6 +2527,11 @@ class AcpRuntime {
         modelApplication.appliedModel,
         modelApplication.configOptions
       )
+      if (specialistIdentity) {
+        aggregate.setSpecialistPrefix(specialistIdentity.prefix || undefined)
+      } else if (!stagedSpecialistId) {
+        aggregate.setSpecialistPrefix(undefined)
+      }
       if (request.specialistId) {
         aggregate.setSpecialistId(request.specialistId)
       }
@@ -4224,17 +4231,16 @@ class AcpRuntime {
     }
   }
 
-  // Resolves the session-meta identity APPEND for the session's current specialist binding. Only
-  // meaningful for Claude (append mode); returns undefined for Codex/OpenCode (prefix mode) or when
-  // no specialist is bound. Used by adoptFreshSession so a context reset re-bakes the identity.
-  private async resolveCurrentSpecialistIdentityAppend(
+  // Re-resolves the current Specialist identity when a stable app Session adopts a fresh provider
+  // Session. Claude re-bakes the append into Session metadata; Codex/OpenCode retain the prefix for
+  // subsequent prompts.
+  private async resolveCurrentSpecialistIdentity(
     sessionId: string,
     specialistId = this.sessionRegistry.lookup(sessionId)?.aggregate.snapshot().specialistId
-  ): Promise<string | undefined> {
+  ): Promise<{ append: string; prefix: string } | undefined> {
     if (!specialistId || !this.options.resolveSpecialistIdentity) return undefined
     try {
-      const identity = await this.options.resolveSpecialistIdentity(specialistId, this.framework.id)
-      return identity?.append || undefined
+      return await this.options.resolveSpecialistIdentity(specialistId, this.framework.id)
     } catch {
       return undefined
     }

--- a/src/main/specialist/specialist-identity-injection.test.ts
+++ b/src/main/specialist/specialist-identity-injection.test.ts
@@ -393,6 +393,67 @@ describe('specialist identity injection — OpenCode', () => {
   })
 })
 
+describe('specialist identity injection — fresh provider adoption', () => {
+  it.each([
+    {
+      path: 'Codex non-UUID adoption',
+      framework: codexFramework,
+      previousFrameworkId: 'codex' as const,
+      appSessionId: 'ses_0458258b7ffeH2DeqPYBPk6fh2',
+      providerSessionId: '019fb8c8-6c66-7f22-9653-17b5b287dbbb',
+      modes: CODEX_MODES
+    },
+    {
+      path: 'OpenCode cross-framework adoption',
+      framework: opencodeFramework,
+      previousFrameworkId: 'claude-code' as const,
+      appSessionId: 'stable-app-session',
+      providerSessionId: 'provider-session',
+      modes: undefined
+    }
+  ])(
+    'keeps the Specialist prefix after $path',
+    async ({ framework, previousFrameworkId, appSessionId, providerSessionId, modes }) => {
+      const process = new FakeAgentProcess()
+      const fakeAgent = startFakeAgentWithModes(process, [providerSessionId], modes)
+      const profile = makeProfile()
+      const runtime = new AcpRuntime({
+        appVersion: '0.1.0',
+        defaultCwd: '/workspace',
+        resolveBackend: () => ({
+          framework: { ...framework, spawn: () => asAgentProcess(process) },
+          executablePath: '/bin/agent-acp',
+          env: {}
+        }),
+        framework,
+        resolveSpecialistIdentity: async (specialistId, frameworkId) => {
+          expect(specialistId).toBe(profile.id)
+          expect(frameworkId).toBe(framework.id)
+          return { append: '', prefix: buildSpecialistIdentityPrefix(profile) }
+        }
+      })
+
+      const resumed = await runtime.resumeSession({
+        sessionId: appSessionId,
+        cwd: '/workspace',
+        previousFrameworkId,
+        specialistId: profile.id
+      })
+      expect(resumed).toMatchObject({ sessionId: appSessionId, contextReset: true })
+
+      await runtime.sendPrompt({
+        sessionId: appSessionId,
+        text: 'Continue the analysis',
+        historyPreamble: 'PRIOR CONTEXT: the last result was incomplete.'
+      })
+
+      expect(fakeAgent.prompts[0]).toMatchObject({ sessionId: providerSessionId })
+      expect(fakeAgent.prompts[0].text).toContain('PRIOR CONTEXT: the last result was incomplete.')
+      expect(fakeAgent.prompts[0].text).toContain(SPECIALIST_IDENTITY_TAG)
+    }
+  )
+})
+
 // ---------------------------------------------------------------------------
 // Tests: Hot-switching specialist on a live session
 // ---------------------------------------------------------------------------


### PR DESCRIPTION
## Problem

When a stable app Session adopted a fresh Codex or OpenCode provider Session, the runtime re-resolved the current Specialist but retained only Claude's session-meta append. The prefix used by Codex/OpenCode prompts was not restored to the Session Aggregate, so the next prompt could silently lose the user's selected Specialist identity after a Codex non-UUID or cross-framework adoption.

## Proposed change

- Re-resolve the complete Specialist identity during fresh provider adoption.
- Continue passing `append` into Claude Session metadata.
- Restore `prefix` to the stable app Session Aggregate for Codex/OpenCode prompts.
- Add public lifecycle coverage for Codex non-UUID and OpenCode cross-framework adoption, including stable app ID, replacement provider ID, `contextReset`, history replay, and Specialist identity.

## Scope and non-goals

- This is a behavior correction: Codex/OpenCode fresh adoption now preserves the already-selected Specialist identity.
- No architecture ownership, public request/response type, IPC, preload, Web/CLI/Task surface, persistence model, data relationship, or UI change.
- Permission and Compute behavior are unchanged.
- No issue #458 orchestration state, relationship, method, event, or UI is introduced.
- Resolver failure keeps the existing best-effort behavior: same-runtime adoption retains an existing prefix; a fresh runtime cannot reconstruct identity when resolution fails; Claude continues omitting an unresolved append.

## Acceptance criteria and validation

All checks ran after the final material edit at head `5c5725c593c0aadd6fbc6645a587522d4a39501f`.

| Behavior | Project-owned check | Final result |
| --- | --- | --- |
| Codex non-UUID and OpenCode cross-framework fresh adoption preserve stable app ID, route to the new provider ID, request replay, and retain Specialist identity | `npm test -- --run src/main/specialist/specialist-identity-injection.test.ts` | 1 file; 16/16 passed |
| Node and Web type boundaries | `npm run typecheck` | passed |
| Repository lint | `npm run lint` | 0 errors; 19 pre-existing warnings outside changed files |
| Repository regression suite | `npm test -- --run` | 674 files passed, 15 skipped; 9898 tests passed, 184 skipped |
| Final specification and repository-standards review | independent two-axis review of the final diff | 0 Spec findings; 0 Standards findings |

TDD evidence: the new Codex case initially had 14 passing tests and one failure solely because the adopted prompt lacked `[open-science:specialist-identity]`; after the fix, both Codex and OpenCode cases pass.

Uncovered risk: resolver failure behavior is unchanged but is not newly locked by an adoption-specific test. This PR deliberately does not change that fallback policy.

## Review focus

- Claude still consumes only `identity.append` in Session metadata.
- Codex/OpenCode consume `identity.prefix` from the same stable app Session Aggregate used by later prompts.
- Identity resolution failure does not turn fresh adoption into a new failure mode.
