### PR TITLE
test(acp): certify session adoption compatibility

### DIFF
--- a/packages/open-science/cli.test.ts
+++ b/packages/open-science/cli.test.ts
@@ -308,6 +308,59 @@ describe('task CLI', () => {
     expect(setExitCode).toHaveBeenCalledWith(1)
   })
 
+  it('keeps run --session on the stable app id for Task API calls and events', async () => {
+    const stableSessionId = 'stable-app-session'
+    const providerSessionId = 'provider-session'
+    const stableEvent = {
+      type: 'run.event',
+      data: { sessionId: stableSessionId, kind: 'tool' }
+    }
+    const client = {
+      events: async function* () {
+        yield { type: 'run.event', data: { sessionId: providerSessionId, kind: 'tool' } }
+        yield stableEvent
+      },
+      startRun: vi.fn().mockResolvedValue({
+        id: 'run-1',
+        sessionId: stableSessionId,
+        status: 'running'
+      }),
+      waitForRun: vi.fn().mockResolvedValue({
+        id: 'run-1',
+        sessionId: stableSessionId,
+        status: 'completed',
+        output: 'Done',
+        artifacts: []
+      })
+    }
+    const log = vi.fn()
+
+    await runTaskCommand(
+      parseCliArgs([
+        'run',
+        '--project',
+        'project-1',
+        '--session',
+        stableSessionId,
+        '--prompt',
+        'Continue research.',
+        '--wait',
+        '--jsonl'
+      ]),
+      { connect: vi.fn().mockResolvedValue(client), stdinIsTTY: true, log }
+    )
+
+    expect(client.startRun).toHaveBeenCalledWith({
+      project: 'project-1',
+      prompt: 'Continue research.',
+      sessionId: stableSessionId
+    })
+    expect(log.mock.calls.map(([line]) => JSON.parse(line))).toEqual([
+      stableEvent,
+      expect.objectContaining({ id: 'run-1', sessionId: stableSessionId, status: 'completed' })
+    ])
+  })
+
   it('passes the wait timeout and warns when a run needs approval', async () => {
     const events = async function* (): AsyncGenerator<{
       type: string

--- a/src/main/specialist/specialist-identity-injection.test.ts
+++ b/src/main/specialist/specialist-identity-injection.test.ts
@@ -478,6 +478,12 @@ describe('specialist hot-switch — Claude Code', () => {
         specialistId === 'sp-a'
           ? { append: buildSpecialistIdentityAppend(profileA), prefix: '' }
           : { append: buildSpecialistIdentityAppend(profileB), prefix: '' },
+      resolveSpecialistSkills: async () => ({
+        kind: 'specialist',
+        skillIds: ['allowed'],
+        frameworkNames: ['Allowed Skill'],
+        missingSkillIds: []
+      }),
       notebook: {
         projectName: 'test',
         mcpEntryPath: '/test/mcp.js',
@@ -496,6 +502,9 @@ describe('specialist hot-switch — Claude Code', () => {
     expect(fakeAgent.newSessions).toHaveLength(2)
     expect(JSON.stringify(fakeAgent.newSessions[1]._meta)).toContain('Specialist B')
     expect(JSON.stringify(fakeAgent.newSessions[1]._meta)).not.toContain('Specialist A')
+    expect(fakeAgent.newSessions[1]._meta).toMatchObject({
+      claudeCode: { options: { skills: ['Allowed Skill'] } }
+    })
     expect(registerSessionSpecialist).toHaveBeenLastCalledWith('session-claude', 'sp-b')
   })
 


### PR DESCRIPTION
## Problem

A7.2a/A7.2b moved stable application Session identity and provider-adoption arbitration behind the ACP Session Registry. The remaining compatibility gaps were at two public seams: the CLI must keep using the stable application Session ID even when provider events carry a different protocol Session ID, and a Claude replacement must continue to provision the active Specialist Skill whitelist.

## Proposed change

- Add a public CLI/Task tracer proving `run --session` sends the stable application Session ID to `startRun`, filters events for a different provider Session ID, and emits the stable terminal run.
- Extend the existing Claude Specialist replacement test to prove the fresh `session/new` metadata still contains the resolved Specialist Skill whitelist.

## Scope and non-goals

- Test-only: 62 added lines in two existing test files; no production changes.
- No persisted model, data relationship, IPC channel, HTTP route, SDK/CLI flag, event payload, UI, or error change.
- Electron, local/remote Web, Task, CLI/SDK, and IPC keep their current behavior.
- Specialist, Permission, and Compute keep their current intentionally uneven surface availability.
- No parent/child orchestration, cascade cancellation, durable relationship, method, event, or UI from issue #458.
- The Specialist prefix defect found during certification was fixed separately in #629 before this branch was rebased onto latest `main`.

Existing focused tests remain the evidence for Permission profile/grant preservation and provider tool-correlation cleanup, as allowed by the certification brief; this PR does not duplicate them.

## Acceptance criteria and validation

All listed commands ran after the last material edit.

- Stable App Session ID through CLI/Task routing and event filtering -> `npm test -- --run packages/open-science/cli.test.ts` -> 10/10 passed.
- Claude fresh replacement keeps the Specialist Skill whitelist -> `npm test -- --run src/main/specialist/specialist-identity-injection.test.ts` -> 16/16 passed.
- Type safety -> `npm run typecheck` -> passed.
- Repository lint -> `npm run lint` -> 0 errors; 19 pre-existing warnings outside the changed files.
- Full regression suite -> `npm test -- --run` -> 674 files passed, 15 skipped; 9,899 tests passed, 184 skipped.
- Patch integrity -> `git diff --check` -> passed.
- Independent final review -> Spec 0 findings; Standards 0 hard / 0 judgement findings.

Uncovered risk: the CLI tracer uses the project-owned Task client mock rather than a live HTTP/WebSocket process. Existing Task integration tests and required PR CI continue to cover transport wiring.

## Review focus

- The CLI tracer must distinguish stable application Session identity from replaceable provider protocol identity.
- The Claude assertion must cover the replacement `session/new`, not merely initial Session creation.
- Production diff must remain zero.
