### PR TITLE
refactor(acp): extract session interaction ownership

### DIFF
--- a/src/main/acp/runtime.test.ts
+++ b/src/main/acp/runtime.test.ts
@@ -11602,6 +11602,148 @@ describe('ACP runtime session management', () => {
     }
   )
 
+  it('publishes a prompt terminal event exactly once when its callback throws', async () => {
+    const process = new FakeAgentProcess()
+    startFakeAgent(process, ['s1'])
+    const runtime = new AcpRuntime({
+      appVersion: '0.1.0',
+      defaultCwd: '/workspace',
+      spawnAgent: () => asAgentProcess(process),
+      callbacks: {
+        onEvent: (event) => {
+          if (event.kind === 'stop') throw new Error('stop callback failed')
+        }
+      }
+    })
+
+    await runtime.createSession({ cwd: '/workspace' })
+    await expect(runtime.sendPrompt({ sessionId: 's1', text: 'hi' })).rejects.toThrow(
+      'stop callback failed'
+    )
+
+    expect(
+      runtime
+        .getSnapshot()
+        .events.filter((event) => event.kind === 'stop' || event.kind === 'error')
+        .map((event) => event.kind)
+    ).toEqual(['stop'])
+  })
+
+  it.each(['connection close', 'context reset'] as const)(
+    'keeps an observed OpenCode stop authoritative through %s during usage collection',
+    async (disruption) => {
+      const process = new FakeAgentProcess()
+      const replacementStarted = createDeferred()
+      const releaseReplacement = createDeferred<PromptResponse>()
+      let runtime!: AcpRuntime
+      const fakeAgent = startFakeAgent(process, ['s1', 's2'], {
+        onPrompt: ({ text }) => {
+          if (!text.includes('replacement prompt')) return undefined
+          replacementStarted.resolve()
+          return releaseReplacement.promise
+        }
+      })
+      const finalUsageStarted = createDeferred()
+      const releaseFinalUsage = createDeferred()
+      let usageFetchCount = 0
+      const opencodeUsageFetch = vi.fn(async () => {
+        usageFetchCount += 1
+        if (usageFetchCount === 2) {
+          finalUsageStarted.resolve()
+          await releaseFinalUsage.promise
+        }
+        return new Response(JSON.stringify([]), {
+          headers: { 'content-type': 'application/json' }
+        })
+      })
+      const framework = { ...opencodeFramework, spawn: () => asAgentProcess(process) }
+      const now = vi.spyOn(Date, 'now').mockReturnValue(1000)
+      try {
+        runtime = new AcpRuntime({
+          appVersion: '0.1.0',
+          defaultCwd: '/workspace',
+          resolveBackend: () => ({
+            framework,
+            executablePath: '/bin/opencode',
+            env: {},
+            opencodeUsageApi: {
+              baseUrl: 'http://127.0.0.1:4242',
+              authorization: 'Basic test'
+            }
+          }),
+          framework,
+          opencodeUsageFetch
+        })
+
+        await runtime.createSession({ cwd: '/workspace' })
+        now.mockReturnValue(1234)
+        const prompt = runtime.sendPrompt({
+          sessionId: 's1',
+          text: 'hi',
+          suppressUserMessage: true,
+          provenanceContext: { promptMessageId: 'terminal-race-prompt' }
+        })
+        await finalUsageStarted.promise
+
+        if (disruption === 'connection close') {
+          process.stdout.end()
+          await vi.waitFor(() => expect(runtime.getSnapshot().status).toBe('closed'))
+        } else {
+          const reset = runtime.resetSessionContext({ sessionId: 's1', cwd: '/workspace' })
+          await vi.waitFor(() => expect(fakeAgent.newSessions).toHaveLength(2))
+          await reset
+        }
+
+        const replacement =
+          disruption === 'context reset'
+            ? runtime.sendPrompt({ sessionId: 's1', text: 'replacement prompt' })
+            : undefined
+        if (replacement) {
+          await vi.waitFor(() =>
+            expect(runtime.getSnapshot().promptInFlightSessionIds).toContain('s1')
+          )
+          handleSessionUpdate(runtime, {
+            sessionId: 's2',
+            update: { sessionUpdate: 'usage_update', used: 95, size: 100 }
+          })
+        }
+
+        now.mockReturnValue(5678)
+        releaseFinalUsage.resolve()
+        await vi.waitFor(() =>
+          expect(
+            runtime
+              .getSnapshot()
+              .events.some(
+                (event) => event.promptMessageId === 'terminal-race-prompt' && event.kind === 'stop'
+              )
+          ).toBe(true)
+        )
+        await prompt
+
+        expect(
+          runtime
+            .getSnapshot()
+            .events.filter(
+              (event) =>
+                event.promptMessageId === 'terminal-race-prompt' &&
+                (event.kind === 'stop' || event.kind === 'error')
+            )
+            .map((event) => ({ kind: event.kind, timestamp: event.timestamp }))
+        ).toEqual([{ kind: 'stop', timestamp: 1234 }])
+
+        if (replacement) {
+          await replacementStarted.promise
+          expect(fakeAgent.prompts.some((sent) => sent.text === '/compact')).toBe(false)
+          releaseReplacement.resolve({ stopReason: 'end_turn' })
+          await replacement
+        }
+      } finally {
+        now.mockRestore()
+      }
+    }
+  )
+
   it('uses the latest Claude model request instead of accumulating the agent turn', async () => {
     const process = new FakeAgentProcess()
     const firstUsageSent = createDeferred()

--- a/src/main/acp/runtime.test.ts
+++ b/src/main/acp/runtime.test.ts
@@ -2927,6 +2927,16 @@ describe('ACP runtime session management', () => {
     const first = await runtime.createSession({ cwd: '/workspace' })
     const second = await runtime.createSession({ cwd: '/workspace' })
 
+    // Claim compaction first to retain the public snapshot's historical grouping: prompt sessions
+    // precede compaction sessions regardless of the cross-kind claim order.
+    const compacting = runtime.compactSession({ sessionId: second.sessionId })
+    await vi.waitFor(() =>
+      expect(agent.prompts).toContainEqual({ sessionId: 'remote-session-2', text: '/compact' })
+    )
+    await expect(
+      runtime.sendPrompt({ sessionId: second.sessionId, text: 'blocked prompt' })
+    ).rejects.toThrow(/already running/)
+
     const prompting = runtime.sendPrompt({ sessionId: first.sessionId, text: 'first prompt' })
     await vi.waitFor(() =>
       expect(agent.prompts).toContainEqual({
@@ -2937,14 +2947,6 @@ describe('ACP runtime session management', () => {
     await expect(runtime.compactSession({ sessionId: first.sessionId })).rejects.toThrow(
       /already running/
     )
-
-    const compacting = runtime.compactSession({ sessionId: second.sessionId })
-    await vi.waitFor(() =>
-      expect(agent.prompts).toContainEqual({ sessionId: 'remote-session-2', text: '/compact' })
-    )
-    await expect(
-      runtime.sendPrompt({ sessionId: second.sessionId, text: 'blocked prompt' })
-    ).rejects.toThrow(/already running/)
     expect(runtime.getSnapshot().promptInFlightSessionIds).toEqual([
       first.sessionId,
       second.sessionId
@@ -3058,31 +3060,72 @@ describe('ACP runtime session management', () => {
   })
 
   it('keeps overflow-recovery compaction locked while the failed prompt finishes unwinding', async () => {
+    const root = await createTemporaryRoot()
+    const repository = new ArtifactRepository(root)
+    const releaseFailedCleanup = createDeferred()
+    vi.spyOn(repository, 'listPendingRunFiles').mockImplementation(async () => {
+      await releaseFailedCleanup.promise
+      return []
+    })
     const process = new FakeAgentProcess()
     const compactTurn = createDeferred<PromptResponse>()
     const retryTurn = createDeferred<PromptResponse>()
+    const overflowObserved = createDeferred()
+    let cancelTimer:
+      | {
+          active: boolean
+          fire: () => void
+        }
+      | undefined
     const agent = startFakeAgent(process, ['remote-session-1'], {
-      onPrompt: ({ text }) =>
-        text === '/compact'
-          ? compactTurn.promise
-          : text === 'retry after overflow'
-            ? retryTurn.promise
-            : undefined
+      onPrompt: ({ text }) => {
+        if (text === '/compact') return compactTurn.promise
+        if (text === 'retry after overflow') return retryTurn.promise
+        throw acp.RequestError.internalError({ errorKind: 'request_too_large' }, 'Internal error')
+      }
     })
     const runtime = new AcpRuntime({
       appVersion: '0.1.0',
       defaultCwd: '/workspace',
       spawnAgent: () => asAgentProcess(process),
       framework: claudeCodeFramework,
-      cancelTimeoutMs: 5
+      cancelTimeoutMs: 5,
+      setTimer: (callback) => {
+        const timer = {
+          active: true,
+          fire: (): void => {
+            if (timer.active) callback()
+          }
+        }
+        cancelTimer = timer
+        return timer as unknown as ReturnType<typeof setTimeout>
+      },
+      clearTimer: (handle) => {
+        const timer = handle as unknown as { active: boolean }
+        timer.active = false
+      },
+      artifacts: {
+        configRoot: root,
+        dataRoot: root,
+        projectName: 'default-project',
+        mcpEntryPath: '/app/out/main/index.js',
+        repository
+      },
+      callbacks: {
+        onEvent: (event) => {
+          if (event.kind === 'error' && event.recoverable === 'context-overflow') {
+            overflowObserved.resolve()
+          }
+        }
+      }
     })
     const session = await runtime.createSession({ cwd: '/workspace' })
-    const internals = runtime as unknown as {
-      promptInFlightSessionIds: Set<string>
-    }
-    // Mirrors the short window after a failed prompt emitted its overflow event but before its
-    // artifact/finally cleanup released the normal turn lock.
-    internals.promptInFlightSessionIds.add(session.sessionId)
+    const failedPrompt = runtime.sendPrompt({
+      sessionId: session.sessionId,
+      text: 'oversized prompt'
+    })
+    void failedPrompt.catch(() => undefined)
+    await overflowObserved.promise
 
     await expect(runtime.compactSession({ sessionId: session.sessionId })).rejects.toThrow(
       /already running/
@@ -3095,7 +3138,6 @@ describe('ACP runtime session management', () => {
 
     // Ownership moved away from the failed prompt, but native compaction still keeps the session
     // unavailable to another user turn until the framework control turn stops.
-    expect(internals.promptInFlightSessionIds.has(session.sessionId)).toBe(false)
     expect(runtime.getSnapshot().promptInFlightSessionIds).toEqual([session.sessionId])
     await runtime.cancelPrompt({ sessionId: session.sessionId })
     expect(agent.cancelledSessions).toEqual([session.sessionId])
@@ -3103,10 +3145,19 @@ describe('ACP runtime session management', () => {
     compactTurn.resolve({ stopReason: 'end_turn' })
     await compacting
     expect(runtime.getSnapshot().promptInFlightSessionIds).toEqual([])
+    expect(cancelTimer?.active).toBe(false)
     const retry = runtime.sendPrompt({ sessionId: session.sessionId, text: 'retry after overflow' })
     await vi.waitFor(() => expect(agent.prompts.at(-1)?.text).toBe('retry after overflow'))
-    await new Promise((resolve) => setTimeout(resolve, 20))
+
+    cancelTimer?.fire()
     expect(runtime.getSnapshot().status).toBe('connected')
+
+    // The failed prompt can finish cleanup only after the retry owns the same stable App Session.
+    // Its stale finally must not clear the replacement interaction.
+    releaseFailedCleanup.resolve()
+    await expect(failedPrompt).rejects.toThrow()
+    expect(runtime.getSnapshot().promptInFlightSessionIds).toEqual([session.sessionId])
+
     retryTurn.resolve({ stopReason: 'end_turn' })
     await expect(retry).resolves.toMatchObject({ stopReason: 'end_turn' })
   })
@@ -3437,10 +3488,12 @@ describe('ACP runtime session management', () => {
         return gateB.promise
       }
     })
+    const events: AcpRuntimeEvent[] = []
     const runtime = new AcpRuntime({
       appVersion: '0.1.0',
       defaultCwd: '/workspace',
       spawnAgent: () => asAgentProcess(process),
+      callbacks: { onEvent: (event) => events.push(event) },
       artifacts: {
         configRoot: root,
         dataRoot: root,
@@ -3453,7 +3506,11 @@ describe('ACP runtime session management', () => {
     const session = await runtime.createSession({ cwd: '/workspace' })
     // The lock is claimed synchronously at turn start, so no polling is needed to observe it.
     const failedTurn = runtime
-      .sendPrompt({ sessionId: session.sessionId, text: 'oversized turn' })
+      .sendPrompt({
+        sessionId: session.sessionId,
+        text: 'oversized turn',
+        provenanceContext: { promptMessageId: 'old-prompt-message' }
+      })
       .catch(() => undefined)
     expect(runtime.getSnapshot().promptInFlightSessionIds).toContain(session.sessionId)
 
@@ -3465,7 +3522,11 @@ describe('ACP runtime session management', () => {
     // The replay turn re-claims the lock for the same app session id while the abandoned turn's finally is
     // still parked in listPendingRunFiles.
     const replayTurn = runtime
-      .sendPrompt({ sessionId: session.sessionId, text: 'replayed turn' })
+      .sendPrompt({
+        sessionId: session.sessionId,
+        text: 'replayed turn',
+        provenanceContext: { promptMessageId: 'replacement-prompt-message' }
+      })
       .catch(() => undefined)
     expect(runtime.getSnapshot().promptInFlightSessionIds).toContain(session.sessionId)
 
@@ -3480,6 +3541,14 @@ describe('ACP runtime session management', () => {
     gateA.resolve()
     gateB.resolve()
     await replayTurn
+    expect(
+      events
+        .filter((event) => event.kind === 'error' || event.kind === 'stop')
+        .map((event) => ({
+          kind: event.kind,
+          promptMessageId: event.promptMessageId
+        }))
+    ).toEqual([{ kind: 'stop', promptMessageId: 'replacement-prompt-message' }])
   })
 
   it('sends PDFs as extracted text, never as an inlined base64 file', async () => {
@@ -16764,6 +16833,53 @@ describe('Specialist Skill scoping', () => {
       })
     ).rejects.toThrow('not available to the active specialist')
     expect(agent.prompts).toHaveLength(0)
+  })
+
+  it('invalidates a Specialist preflight when context reset replaces the provider session', async () => {
+    const process = new FakeAgentProcess()
+    const agent = startFakeAgent(process, ['specialist-session-1', 'specialist-session-2'])
+    const promptPreflightEntered = createDeferred()
+    const releasePromptPreflight = createDeferred()
+    let resolutionCount = 0
+    const runtime = new AcpRuntime({
+      appVersion: '0.1.0',
+      defaultCwd: '/workspace',
+      spawnAgent: () => asAgentProcess(process),
+      framework: claudeCodeFramework,
+      resolveSpecialistIdentity: async () => ({ append: 'Specialist identity', prefix: '' }),
+      resolveSpecialistSkills: async () => {
+        resolutionCount += 1
+        if (resolutionCount === 2) {
+          promptPreflightEntered.resolve()
+          await releasePromptPreflight.promise
+        }
+        return {
+          kind: 'specialist' as const,
+          skillIds: ['allowed'],
+          frameworkNames: ['Allowed Skill'],
+          missingSkillIds: []
+        }
+      }
+    })
+
+    const session = await runtime.createSession({ cwd: '/workspace', specialistId: 'sp-1' })
+    const stalePrompt = runtime.sendPrompt({ sessionId: session.sessionId, text: 'stale prompt' })
+    void stalePrompt.catch(() => undefined)
+    await promptPreflightEntered.promise
+
+    await runtime.resetSessionContext({ sessionId: session.sessionId, cwd: '/workspace' })
+    releasePromptPreflight.resolve()
+
+    await expect(stalePrompt).rejects.toThrow(/superseded/)
+    expect(agent.prompts).toEqual([])
+
+    await runtime.sendPrompt({ sessionId: session.sessionId, text: 'replacement prompt' })
+    expect(agent.prompts).toEqual([
+      {
+        sessionId: 'specialist-session-2',
+        text: expect.stringContaining('replacement prompt')
+      }
+    ])
   })
 
   it('allows a forced mcp-* connector Skill when the active specialist grants that connector', async () => {

--- a/src/main/acp/runtime.test.ts
+++ b/src/main/acp/runtime.test.ts
@@ -2903,6 +2903,59 @@ describe('ACP runtime session management', () => {
     ).toEqual([])
   })
 
+  it('serializes prompts and compaction per session without blocking another session', async () => {
+    const process = new FakeAgentProcess()
+    const firstPromptGate = createDeferred<PromptResponse>()
+    const secondCompactionGate = createDeferred<PromptResponse>()
+    const agent = startFakeAgent(process, ['remote-session-1', 'remote-session-2'], {
+      onPrompt: ({ sessionId, text }) => {
+        if (sessionId === 'remote-session-1' && text === 'first prompt') {
+          return firstPromptGate.promise
+        }
+        if (sessionId === 'remote-session-2' && text === '/compact') {
+          return secondCompactionGate.promise
+        }
+        return undefined
+      }
+    })
+    const runtime = new AcpRuntime({
+      appVersion: '0.1.0',
+      defaultCwd: '/workspace',
+      spawnAgent: () => asAgentProcess(process),
+      framework: claudeCodeFramework
+    })
+    const first = await runtime.createSession({ cwd: '/workspace' })
+    const second = await runtime.createSession({ cwd: '/workspace' })
+
+    const prompting = runtime.sendPrompt({ sessionId: first.sessionId, text: 'first prompt' })
+    await vi.waitFor(() =>
+      expect(agent.prompts).toContainEqual({
+        sessionId: 'remote-session-1',
+        text: 'first prompt'
+      })
+    )
+    await expect(runtime.compactSession({ sessionId: first.sessionId })).rejects.toThrow(
+      /already running/
+    )
+
+    const compacting = runtime.compactSession({ sessionId: second.sessionId })
+    await vi.waitFor(() =>
+      expect(agent.prompts).toContainEqual({ sessionId: 'remote-session-2', text: '/compact' })
+    )
+    await expect(
+      runtime.sendPrompt({ sessionId: second.sessionId, text: 'blocked prompt' })
+    ).rejects.toThrow(/already running/)
+    expect(runtime.getSnapshot().promptInFlightSessionIds).toEqual([
+      first.sessionId,
+      second.sessionId
+    ])
+
+    firstPromptGate.resolve({ stopReason: 'end_turn' })
+    secondCompactionGate.resolve({ stopReason: 'end_turn' })
+    await expect(Promise.all([prompting, compacting])).resolves.toHaveLength(2)
+    expect(runtime.getSnapshot().promptInFlightSessionIds).toEqual([])
+  })
+
   it('drops estimated pre-compaction categories when no fresh usage update arrives', async () => {
     const process = new FakeAgentProcess()
     startFakeAgent(process, ['remote-session-1'])

--- a/src/main/acp/runtime.ts
+++ b/src/main/acp/runtime.ts
@@ -30,6 +30,7 @@ import type {
   AcpResumeSessionRequest,
   AcpRevokePermissionGrantRequest,
   AcpContextUsage,
+  AcpTurnTokenUsage,
   AcpSetPermissionProfileRequest,
   AcpStateSnapshot
 } from '../../shared/acp'
@@ -543,10 +544,6 @@ class AcpRuntime {
   // Forced skill state belongs to this runtime generation. It is passed explicitly into backend
   // provisioning so concurrent old/new generations cannot overwrite a SettingsService singleton.
   private readonly turnForcedSkillIds = new Set<string>()
-  private readonly claudeTurnCountsBySession = new Map<
-    string,
-    { promptTurn: number; count: number }
-  >()
   // The newest user-owned request is retained while a completion handoff may replace the agent
   // session. A Claude continuation reuses this trusted task/provenance context without asking the
   // renderer to manufacture a second user message.
@@ -2948,7 +2945,6 @@ class AcpRuntime {
       entry.aggregate.setPermissionProfile(undefined)
     }
     this.promptContentOwner.clear()
-    this.claudeTurnCountsBySession.clear()
     this.codexSkillActivity.clear()
     runCleanup('MCP HTTP routes', () => this.sessionCapabilities.clearHttpRoutes())
     this.sessionRegistry.select(undefined)
@@ -3319,7 +3315,6 @@ class AcpRuntime {
     const promptEventIdentity = promptInteraction.promptMessageId
       ? { promptMessageId: promptInteraction.promptMessageId }
       : {}
-    this.claudeTurnCountsBySession.delete(request.sessionId)
     try {
       this.callbacks.onPromptStarted?.(request.sessionId, skillImportTurnToken, promptAttemptId)
     } catch (error) {
@@ -3338,6 +3333,35 @@ class AcpRuntime {
     let revokeReferencedUploadGrant: (() => void) | undefined
     let contextUsageCheckpoint: ReturnType<ContextUsageTracker['checkpointSession']> | undefined
     let contextUsageEstimateCommitted = false
+    let observedPromptStop:
+      | {
+          response: PromptResponse
+          turnUsage?: AcpTurnTokenUsage
+          modelTurnCount?: number
+        }
+      | undefined
+    const publishObservedPromptStop = (): boolean => {
+      if (!observedPromptStop) return false
+      const terminal = this.sessionInteractions.settle(promptInteraction, {
+        ...(observedPromptStop.turnUsage ? { turnUsage: observedPromptStop.turnUsage } : {}),
+        ...(observedPromptStop.modelTurnCount === undefined
+          ? {}
+          : { modelTurnCount: observedPromptStop.modelTurnCount })
+      })
+      if (!terminal) return false
+      this.pushEvent({
+        kind: 'stop',
+        level: 'info',
+        sessionId: request.sessionId,
+        ...promptEventIdentity,
+        timestamp: terminal.timestamp,
+        title: 'Prompt stopped',
+        text: observedPromptStop.response.stopReason,
+        turnUsage: terminal.turnUsage,
+        raw: observedPromptStop.response
+      })
+      return true
+    }
 
     try {
       // Create a fresh run context before prompting so MCP writes can be attributed to this turn.
@@ -3362,23 +3386,19 @@ class AcpRuntime {
         })
       }
       const finishCancelledBeforePrompt = async (): Promise<PromptResponse> => {
+        const response: PromptResponse = { stopReason: 'cancelled' }
+        observedPromptStop = { response }
+        if (!this.sessionInteractions.captureTerminal(promptInteraction, 'cancelled')) {
+          return response
+        }
         emitUserMessage()
         await this.emitArtifactRunEvent(request.sessionId, artifactRun)
         artifactEmitted = true
-        const response: PromptResponse = { stopReason: 'cancelled' }
         log.info('prompt stopped', {
           sessionId: request.sessionId,
           stopReason: response.stopReason
         })
-        this.pushEvent({
-          kind: 'stop',
-          level: 'info',
-          sessionId: request.sessionId,
-          ...promptEventIdentity,
-          title: 'Prompt stopped',
-          text: response.stopReason,
-          raw: response
-        })
+        publishObservedPromptStop()
         return response
       }
       if (
@@ -3554,6 +3574,27 @@ class AcpRuntime {
         }
 
         if (message.kind === 'stop') {
+          const codexTurnCount = message.response._meta?.[ACP_MODEL_TURN_COUNT_META_KEY]
+          const reportedTurnCount =
+            promptFramework === 'codex' &&
+            Number.isSafeInteger(codexTurnCount) &&
+            (codexTurnCount as number) > 0
+              ? (codexTurnCount as number)
+              : undefined
+          observedPromptStop = {
+            response: message.response,
+            turnUsage:
+              promptFramework === 'codex'
+                ? (toCodexTurnTokenUsage(message.response._meta?.[ACP_TURN_TOKEN_USAGE_META_KEY]) ??
+                  toCodexTurnTokenUsage(message.response.usage))
+                : toAcpTurnTokenUsage(message.response.usage),
+            ...(reportedTurnCount === undefined ? {} : { modelTurnCount: reportedTurnCount })
+          }
+          // Freeze provider-terminal time before artifact work and provider-specific usage fetching.
+          // The outcome remains authoritative through close/reset while usage facts are finalized.
+          if (!this.sessionInteractions.captureTerminal(promptInteraction, 'stop')) {
+            return message.response
+          }
           contextUsageEstimateCommitted = true
           this.recordCodexPromptResponseContextUsage(
             request.sessionId,
@@ -3589,39 +3630,13 @@ class AcpRuntime {
                   )
                 )
               : undefined
-          // Codex ACP exposes only the latest request in PromptResponse.usage. Prefer the managed
-          // adapter's app-owned whole-turn total, but retain the standard usage as a compatibility
-          // fallback so a bridge response never loses token accounting entirely when metadata is absent.
-          const reportedTurnUsage =
-            promptFramework === 'codex'
-              ? (toCodexTurnTokenUsage(message.response._meta?.[ACP_TURN_TOKEN_USAGE_META_KEY]) ??
-                toCodexTurnTokenUsage(message.response.usage))
-              : (opencodeTurnUsage ?? toAcpTurnTokenUsage(message.response.usage))
-          const claudeTurnCount = this.claudeTurnCountsBySession.get(request.sessionId)
-          const codexTurnCount = message.response._meta?.[ACP_MODEL_TURN_COUNT_META_KEY]
-          const reportedTurnCount =
-            promptFramework === 'claude-code' && claudeTurnCount?.promptTurn === promptTurn
-              ? claudeTurnCount.count
-              : promptFramework === 'codex' &&
-                  Number.isSafeInteger(codexTurnCount) &&
-                  (codexTurnCount as number) > 0
-                ? (codexTurnCount as number)
-                : undefined
-          const turnUsage =
-            reportedTurnUsage && reportedTurnCount !== undefined
-              ? { ...reportedTurnUsage, turnCount: reportedTurnCount }
-              : reportedTurnUsage
-          this.pushEvent({
-            kind: 'stop',
-            level: 'info',
-            sessionId: request.sessionId,
-            ...promptEventIdentity,
-            title: 'Prompt stopped',
-            text: message.stopReason,
-            turnUsage,
-            raw: message.response
-          })
-          if (this.shouldAutoCompactContext(request.sessionId)) {
+          if (opencodeTurnUsage) observedPromptStop.turnUsage = opencodeTurnUsage
+          publishObservedPromptStop()
+          if (
+            this.sessionInteractions.current(request.sessionId) === promptInteraction &&
+            this.activeSessionFor(request.sessionId) === activeSession &&
+            this.shouldAutoCompactContext(request.sessionId)
+          ) {
             try {
               await this.performNativeContextCompaction(
                 activeSession,
@@ -3645,25 +3660,24 @@ class AcpRuntime {
         this.handleSessionUpdate(message.notification, request.sessionId)
       }
     } catch (error) {
-      if (this.sessionInteractions.current(request.sessionId) !== promptInteraction) {
-        // Connection teardown releases every interaction before the provider rejection reaches this
-        // catch. Preserve the existing terminal failure event for an interrupted visible prompt, but
-        // skip all turn-owned state rollback; reset/replacement stays silent and cannot target its
-        // successor's prompt identity.
-        if (this.snapshotOwner.status === 'closed') {
-          log.error('prompt failed', { sessionId: request.sessionId, ...errorLogFields(error) })
-          this.pushEvent({
-            kind: 'error',
-            level: 'error',
-            providerError: isProviderPromptError(error),
+      if (observedPromptStop) {
+        // Provider stop/cancellation already won the outcome race. App-side finalization failure,
+        // reset, or connection teardown cannot rewrite it as a prompt failure.
+        if (publishObservedPromptStop()) {
+          log.warn('prompt terminal finalization failed', {
             sessionId: request.sessionId,
-            ...promptEventIdentity,
-            title: ACP_PROMPT_FAILED_EVENT_TITLE,
-            text: describePromptError(error, { model: this.pendingSessionModel })
+            ...errorLogFields(error)
           })
         }
         throw error
       }
+      if (this.sessionInteractions.current(request.sessionId) !== promptInteraction) {
+        // Reset/replacement is silent. Unexpected connection teardown settles and publishes every
+        // visible prompt in handleConnectionClosed before releasing its interaction scope.
+        throw error
+      }
+      // A fresh provider failure captures its terminal outcome before rollback work can add latency.
+      if (!this.sessionInteractions.captureTerminal(promptInteraction, 'error')) throw error
       if (
         contextUsageCheckpoint &&
         !contextUsageEstimateCommitted &&
@@ -3705,6 +3719,8 @@ class AcpRuntime {
         isMediaOverflowError(acpErrorKind(error))
           ? 'context-overflow'
           : undefined
+      const terminal = this.sessionInteractions.settle(promptInteraction, {})
+      if (!terminal) throw error
       this.pushEvent({
         kind: 'error',
         level: 'error',
@@ -3715,6 +3731,7 @@ class AcpRuntime {
         providerError: isProviderPromptError(error),
         sessionId: request.sessionId,
         ...promptEventIdentity,
+        timestamp: terminal.timestamp,
         title: ACP_PROMPT_FAILED_EVENT_TITLE,
         text
       })
@@ -3751,7 +3768,6 @@ class AcpRuntime {
         this.sessionInteractions.current(request.sessionId) === promptInteraction
       if (ownsInteraction) {
         this.permissionContext.clearCorrelationsForSession(request.sessionId)
-        this.claudeTurnCountsBySession.delete(request.sessionId)
         if (this.contextUsageUpdatedPromptTurnsBySession.get(request.sessionId) === promptTurn) {
           this.contextUsageUpdatedPromptTurnsBySession.delete(request.sessionId)
         }
@@ -3874,7 +3890,6 @@ class AcpRuntime {
     this.handoffPromptRequests.delete(request.sessionId)
     this.handoffUserTasks.delete(request.sessionId)
     this.pendingClaudeCodeHandoffAppends.delete(request.sessionId)
-    this.claudeTurnCountsBySession.delete(request.sessionId)
     this.contextUsageTracker.deleteSession(request.sessionId)
     this.contextUsageUpdatedPromptTurnsBySession.delete(request.sessionId)
 
@@ -4124,16 +4139,7 @@ class AcpRuntime {
     const appSessionId = this.sessionRegistry.resolveAppSessionId(params.sessionId)
     const promptInteraction = this.currentPromptInteraction(appSessionId)
     if (!promptInteraction) return
-    const promptTurn = promptInteraction.sequence
-
-    const current = this.claudeTurnCountsBySession.get(appSessionId)
-    const count =
-      current?.promptTurn === promptTurn
-        ? current.count + (message.num_turns as number)
-        : (message.num_turns as number)
-    if (!Number.isSafeInteger(count)) return
-
-    this.claudeTurnCountsBySession.set(appSessionId, { promptTurn, count })
+    this.sessionInteractions.observeModelTurns(promptInteraction, message.num_turns as number)
   }
 
   // Looks up the workspace root bound to a session for filesystem operations.
@@ -4862,6 +4868,7 @@ class AcpRuntime {
   // Clears local state after the protocol connection closes unexpectedly.
   private handleConnectionClosed(): void {
     const teardownGeneration = this.connectionGeneration
+    const interruptedPrompts = this.sessionInteractions.settleActivePrompts()
     this.invalidatePendingSessionStartups()
     const orphanedProcess = this.agentProcess
     if (orphanedProcess) {
@@ -4879,7 +4886,6 @@ class AcpRuntime {
     this.handoffPromptRequests.clear()
     this.handoffUserTasks.clear()
     this.pendingClaudeCodeHandoffAppends.clear()
-    this.claudeTurnCountsBySession.clear()
     this.codexSkillActivity.clear()
     this.contextUsageTracker.clear()
     this.contextUsageUpdatedPromptTurnsBySession.clear()
@@ -4900,6 +4906,22 @@ class AcpRuntime {
     try {
       this.setStatus('closed')
     } finally {
+      for (const { scope, terminal } of interruptedPrompts) {
+        try {
+          this.pushEvent({
+            kind: 'error',
+            level: 'error',
+            providerError: false,
+            sessionId: scope.sessionId,
+            ...(scope.promptMessageId ? { promptMessageId: scope.promptMessageId } : {}),
+            timestamp: terminal.timestamp,
+            title: ACP_PROMPT_FAILED_EVENT_TITLE,
+            text: 'ACP connection closed'
+          })
+        } catch (error) {
+          safeLogError('connection-close prompt event failed', errorLogFields(error))
+        }
+      }
       // An unexpected close satisfies any pending reconnect, but retirement remains terminal. Re-run
       // its evaluator now and again when outstanding operation/activity leases drain.
       this.maybeApplyPendingProviderReconnect()

--- a/src/main/acp/runtime.ts
+++ b/src/main/acp/runtime.ts
@@ -525,8 +525,7 @@ class AcpRuntime {
   // App-owned MCP construction, routing aliases, and bearer lease ownership are kept behind one
   // explicit role policy. Connection/process lifetime remains with this runtime.
   private readonly sessionCapabilities: AcpSessionCapabilityOwner
-  private readonly sessionInteractions = new AcpSessionInteractionOwner()
-  private readonly cancelledPromptTurnsBySession = new Map<string, number>()
+  private readonly sessionInteractions: AcpSessionInteractionOwner
   // Ephemeral Reviewer identity, isolation, permission, and resource state lives behind one owner.
   private readonly reviewerSessions: ReviewerSessionOwner
   // A startup that begins while a reconnect barrier is already armed must not block the reconnect it
@@ -601,14 +600,10 @@ class AcpRuntime {
   private pendingProviderConfiguration: ResolvedAgentBackend['providerConfiguration']
   private opencodeUsageApi: ResolvedAgentBackend['opencodeUsageApi']
   private responsesBridgeLease: ResolvedAgentBackend['responsesBridgeLease']
-  private readonly skillSelectorAbortControllers = new Map<string, AbortController>()
-  private readonly pendingPromptCancellations = new Map<string, Promise<void>>()
   // Bounded resume network timeout + injectable timers (defaults to real setTimeout/clearTimeout).
   private readonly resumeTimeoutMs: number
-  private readonly cancelTimeoutMs: number
   private readonly setTimer: (fn: () => void, ms: number) => ReturnType<typeof setTimeout>
   private readonly clearTimer: (handle: ReturnType<typeof setTimeout>) => void
-  private readonly cancelTimers = new Map<string, ReturnType<typeof setTimeout>>()
   private readonly artifactOptions: AcpRuntimeArtifactOptions | undefined
   private readonly notebookOptions: AcpRuntimeNotebookOptions | undefined
   private readonly skillImportOptions: AcpRuntimeSkillImportOptions | undefined
@@ -626,10 +621,14 @@ class AcpRuntime {
     this.framework = options.framework ?? claudeCodeFramework
     this.mcpHttpHost = options.mcpHttpHost
     this.resumeTimeoutMs = options.resumeTimeoutMs ?? 30_000
-    this.cancelTimeoutMs = options.cancelTimeoutMs ?? 5_000
     this.contextUsageTracker = options.contextUsageTracker ?? new ContextUsageTracker()
     this.setTimer = options.setTimer ?? ((fn, ms) => setTimeout(fn, ms))
     this.clearTimer = options.clearTimer ?? ((handle) => clearTimeout(handle))
+    this.sessionInteractions = new AcpSessionInteractionOwner({
+      cancelTimeoutMs: options.cancelTimeoutMs,
+      setTimer: this.setTimer,
+      clearTimer: this.clearTimer
+    })
     this.artifactOptions = options.artifacts
     this.notebookOptions = options.notebook
     this.skillImportOptions = options.skillImport
@@ -1974,9 +1973,6 @@ class AcpRuntime {
         request.reason ?? 'manual'
       )
     } finally {
-      const cancelTimer = this.cancelTimers.get(request.sessionId)
-      if (cancelTimer) this.clearTimer(cancelTimer)
-      this.cancelTimers.delete(request.sessionId)
       this.sessionInteractions.release(compactionInteraction)
       this.emitState()
     }
@@ -2928,10 +2924,6 @@ class AcpRuntime {
       }
     }
 
-    for (const timer of this.cancelTimers.values()) this.clearTimer(timer)
-    this.cancelTimers.clear()
-    for (const controller of this.skillSelectorAbortControllers.values()) controller.abort()
-    this.skillSelectorAbortControllers.clear()
     runCleanup('permission-context', () => this.permissionContext.dispose())
     runCleanup('reviewer-state', () => this.reviewerSessions.clear())
     this.sessionInteractions.supersedeAll()
@@ -2958,7 +2950,6 @@ class AcpRuntime {
     this.promptContentOwner.clear()
     this.claudeTurnCountsBySession.clear()
     this.codexSkillActivity.clear()
-    this.cancelledPromptTurnsBySession.clear()
     runCleanup('MCP HTTP routes', () => this.sessionCapabilities.clearHttpRoutes())
     this.sessionRegistry.select(undefined)
     this.supportsSessionClose = false
@@ -3329,7 +3320,6 @@ class AcpRuntime {
       ? { promptMessageId: promptInteraction.promptMessageId }
       : {}
     this.claudeTurnCountsBySession.delete(request.sessionId)
-    this.cancelledPromptTurnsBySession.delete(request.sessionId)
     try {
       this.callbacks.onPromptStarted?.(request.sessionId, skillImportTurnToken, promptAttemptId)
     } catch (error) {
@@ -3391,14 +3381,11 @@ class AcpRuntime {
         })
         return response
       }
-      const turnWasCancelled = (): boolean =>
-        this.cancelledPromptTurnsBySession.get(request.sessionId) === promptTurn
-      const awaitPendingCancellation = async (): Promise<void> => {
-        await this.pendingPromptCancellations.get(request.sessionId)
+      if (
+        (await this.sessionInteractions.cancellationCheckpoint(promptInteraction)) === 'cancelled'
+      ) {
+        return finishCancelledBeforePrompt()
       }
-
-      await awaitPendingCancellation()
-      if (turnWasCancelled()) return finishCancelledBeforePrompt()
 
       // Prepend a short steering nudge naming the picked skills. It goes only into the content sent to
       // the agent; the user-facing message event keeps the original text (which already shows /Name).
@@ -3421,30 +3408,23 @@ class AcpRuntime {
         [sessionSpecialistPrefix, frameworkPromptPrefix]
           .filter((segment): segment is string => Boolean(segment))
           .join('\n\n') || undefined
-      const selectorAbortController =
+      const selectorSignal =
         this.framework.id === 'codex' &&
         forced.length === 0 &&
         this.responsesBridgeLease?.selectSkills
-          ? new AbortController()
+          ? promptInteraction.signal
           : undefined
-      if (selectorAbortController) {
-        this.skillSelectorAbortControllers.set(request.sessionId, selectorAbortController)
+      const codexSkillInputs = await this.resolveCodexSkillInputs(
+        forced,
+        request.text,
+        selectorSignal,
+        currentSpecialistSkills
+      )
+      if (
+        (await this.sessionInteractions.cancellationCheckpoint(promptInteraction)) === 'cancelled'
+      ) {
+        return finishCancelledBeforePrompt()
       }
-      let codexSkillInputs: Array<{ name: string; path: string }>
-      try {
-        codexSkillInputs = await this.resolveCodexSkillInputs(
-          forced,
-          request.text,
-          selectorAbortController?.signal,
-          currentSpecialistSkills
-        )
-      } finally {
-        if (this.skillSelectorAbortControllers.get(request.sessionId) === selectorAbortController) {
-          this.skillSelectorAbortControllers.delete(request.sessionId)
-        }
-      }
-      await awaitPendingCancellation()
-      if (turnWasCancelled()) return finishCancelledBeforePrompt()
       const promptRequestText = request.continuation
         ? this.buildSpecialistHandoffContinuationText(request)
         : request.text
@@ -3531,8 +3511,11 @@ class AcpRuntime {
               this.options.opencodeUsageFetch
             )
           : undefined
-      await awaitPendingCancellation()
-      if (turnWasCancelled()) return finishCancelledBeforePrompt()
+      if (
+        (await this.sessionInteractions.cancellationCheckpoint(promptInteraction)) === 'cancelled'
+      ) {
+        return finishCancelledBeforePrompt()
+      }
 
       // Start the prompt and race it against routed updates from the active session queue.
       const promptFailure = new Promise<never>((_, reject) => {
@@ -3662,7 +3645,25 @@ class AcpRuntime {
         this.handleSessionUpdate(message.notification, request.sessionId)
       }
     } catch (error) {
-      if (this.sessionInteractions.current(request.sessionId) !== promptInteraction) throw error
+      if (this.sessionInteractions.current(request.sessionId) !== promptInteraction) {
+        // Connection teardown releases every interaction before the provider rejection reaches this
+        // catch. Preserve the existing terminal failure event for an interrupted visible prompt, but
+        // skip all turn-owned state rollback; reset/replacement stays silent and cannot target its
+        // successor's prompt identity.
+        if (this.snapshotOwner.status === 'closed') {
+          log.error('prompt failed', { sessionId: request.sessionId, ...errorLogFields(error) })
+          this.pushEvent({
+            kind: 'error',
+            level: 'error',
+            providerError: isProviderPromptError(error),
+            sessionId: request.sessionId,
+            ...promptEventIdentity,
+            title: ACP_PROMPT_FAILED_EVENT_TITLE,
+            text: describePromptError(error, { model: this.pendingSessionModel })
+          })
+        }
+        throw error
+      }
       if (
         contextUsageCheckpoint &&
         !contextUsageEstimateCommitted &&
@@ -3749,9 +3750,6 @@ class AcpRuntime {
       const ownsInteraction =
         this.sessionInteractions.current(request.sessionId) === promptInteraction
       if (ownsInteraction) {
-        const cancelTimer = this.cancelTimers.get(request.sessionId)
-        if (cancelTimer) this.clearTimer(cancelTimer)
-        this.cancelTimers.delete(request.sessionId)
         this.permissionContext.clearCorrelationsForSession(request.sessionId)
         this.claudeTurnCountsBySession.delete(request.sessionId)
         if (this.contextUsageUpdatedPromptTurnsBySession.get(request.sessionId) === promptTurn) {
@@ -3788,24 +3786,27 @@ class AcpRuntime {
 
   // Requests cancellation without clearing in-flight state before the agent stops.
   async cancelPrompt(request: AcpCancelPromptRequest): Promise<AcpStateSnapshot> {
+    const connection = this.connection
     const activeSession = this.activeSessionFor(request.sessionId)
 
-    if (this.connection && activeSession) {
-      // Publish the cancellation attempt before the first await so a selector completing concurrently
-      // waits for the protocol outcome instead of submitting a prompt in the gap. Abort the compatibility
-      // request immediately; its own timeout is only a backstop and must not delay cancellation.
-      let settleCancellation!: () => void
-      const pendingCancellation = new Promise<void>((resolve) => {
-        settleCancellation = resolve
-      })
-      this.pendingPromptCancellations.set(request.sessionId, pendingCancellation)
-      this.skillSelectorAbortControllers.get(request.sessionId)?.abort()
-      const priorTimer = this.cancelTimers.get(request.sessionId)
-      if (priorTimer) this.clearTimer(priorTimer)
-      this.cancelTimers.set(
-        request.sessionId,
-        this.setTimer(() => {
-          if (!this.hasSessionInteractionInFlight(request.sessionId)) return
+    if (connection && activeSession) {
+      await this.sessionInteractions.cancelPrompt({
+        sessionId: request.sessionId,
+        notify: () =>
+          connection.agent.notify(acp.methods.agent.session.cancel, {
+            sessionId: activeSession.sessionId
+          }),
+        onAccepted: () => {
+          this.cancelPermissionFlowForSession(request.sessionId)
+          this.pushEvent({
+            kind: 'system',
+            level: 'warning',
+            sessionId: request.sessionId,
+            title: 'Prompt cancellation requested'
+          })
+          this.emitState()
+        },
+        onTimeout: () => {
           this.pushEvent({
             kind: 'error',
             level: 'error',
@@ -3814,31 +3815,8 @@ class AcpRuntime {
             text: 'The agent did not stop, so its process was stopped and will restart on the next prompt.'
           })
           void this.disconnect()
-        }, this.cancelTimeoutMs)
-      )
-      try {
-        await this.connection.agent.notify(acp.methods.agent.session.cancel, {
-          sessionId: activeSession.sessionId
-        })
-      } catch (error) {
-        const timer = this.cancelTimers.get(request.sessionId)
-        if (timer) this.clearTimer(timer)
-        this.cancelTimers.delete(request.sessionId)
-        throw error
-      } finally {
-        settleCancellation()
-        if (this.pendingPromptCancellations.get(request.sessionId) === pendingCancellation) {
-          this.pendingPromptCancellations.delete(request.sessionId)
         }
-      }
-      this.cancelPermissionFlowForSession(request.sessionId)
-      this.pushEvent({
-        kind: 'system',
-        level: 'warning',
-        sessionId: request.sessionId,
-        title: 'Prompt cancellation requested'
       })
-      this.emitState()
     }
 
     return this.getSnapshot()
@@ -3888,11 +3866,6 @@ class AcpRuntime {
     // A disconnect detaches the provider but deliberately keeps framework/backend affinity, so deleting
     // a session that was never re-adopted must remove its remaining Aggregate as well.
     this.permissionContext.clearSession(request.sessionId)
-    const cancelTimer = this.cancelTimers.get(request.sessionId)
-    if (cancelTimer) this.clearTimer(cancelTimer)
-    this.cancelTimers.delete(request.sessionId)
-    this.skillSelectorAbortControllers.get(request.sessionId)?.abort()
-    this.skillSelectorAbortControllers.delete(request.sessionId)
     this.sessionInteractions.supersedeCurrent(request.sessionId)
     // Drop this session's MCP routes, aliases, and bearer ownership (idempotent for detached deletes).
     this.sessionCapabilities.revokeSession(request.sessionId)
@@ -3902,7 +3875,6 @@ class AcpRuntime {
     this.handoffUserTasks.delete(request.sessionId)
     this.pendingClaudeCodeHandoffAppends.delete(request.sessionId)
     this.claudeTurnCountsBySession.delete(request.sessionId)
-    this.cancelledPromptTurnsBySession.delete(request.sessionId)
     this.contextUsageTracker.deleteSession(request.sessionId)
     this.contextUsageUpdatedPromptTurnsBySession.delete(request.sessionId)
 
@@ -4431,7 +4403,8 @@ class AcpRuntime {
       (promptTurn === undefined
         ? this.activeSessionFor(appSessionId) !== undefined
         : this.currentPromptInteraction(appSessionId)?.sequence !== promptTurn ||
-          this.cancelledPromptTurnsBySession.get(appSessionId) === promptTurn)
+          (promptInteraction !== undefined &&
+            this.sessionInteractions.isCancellationAccepted(promptInteraction)))
     const restoreContext = {
       sessionId: appSessionId,
       framework,
@@ -4526,10 +4499,6 @@ class AcpRuntime {
   }
 
   private cancelPermissionFlowForSession(sessionId: string): void {
-    const promptInteraction = this.currentPromptInteraction(sessionId)
-    if (promptInteraction) {
-      this.cancelledPromptTurnsBySession.set(sessionId, promptInteraction.sequence)
-    }
     this.permissionContext.cancelForSession(sessionId)
   }
 
@@ -4899,10 +4868,6 @@ class AcpRuntime {
       this.expectedProcessExits.add(orphanedProcess)
       void terminateProcessTree(orphanedProcess, undefined, log)
     }
-    for (const timer of this.cancelTimers.values()) this.clearTimer(timer)
-    this.cancelTimers.clear()
-    for (const controller of this.skillSelectorAbortControllers.values()) controller.abort()
-    this.skillSelectorAbortControllers.clear()
     this.permissionContext.dispose()
     this.reviewerSessions.clear()
     this.sessionCapabilities.dispose(this.activeSessionIds())
@@ -4916,7 +4881,6 @@ class AcpRuntime {
     this.pendingClaudeCodeHandoffAppends.clear()
     this.claudeTurnCountsBySession.clear()
     this.codexSkillActivity.clear()
-    this.cancelledPromptTurnsBySession.clear()
     this.contextUsageTracker.clear()
     this.contextUsageUpdatedPromptTurnsBySession.clear()
     this.sessionCapabilities.clearHttpRoutes()

--- a/src/main/acp/runtime.ts
+++ b/src/main/acp/runtime.ts
@@ -121,6 +121,10 @@ import {
 } from './session-capability-owner'
 import { ArtifactTurnOwner, type ArtifactTurnHandle } from './artifact-turn-owner'
 import { AcpPromptContentOwner } from './prompt-content-owner'
+import {
+  AcpSessionInteractionOwner,
+  type AcpPromptSessionInteractionScope
+} from './session-interaction-owner'
 import type { AcpSessionAggregateAttachInput } from './session-aggregate'
 import {
   AcpSessionRegistry,
@@ -521,6 +525,7 @@ class AcpRuntime {
   // App-owned MCP construction, routing aliases, and bearer lease ownership are kept behind one
   // explicit role policy. Connection/process lifetime remains with this runtime.
   private readonly sessionCapabilities: AcpSessionCapabilityOwner
+  private readonly sessionInteractions = new AcpSessionInteractionOwner()
   private readonly cancelledPromptTurnsBySession = new Map<string, number>()
   // Ephemeral Reviewer identity, isolation, permission, and resource state lives behind one owner.
   private readonly reviewerSessions: ReviewerSessionOwner
@@ -528,10 +533,6 @@ class AcpRuntime {
   // is waiting for. Once it reaches the replacement connection, renewal adds its token here so any
   // later reconnect waits for publication or rollback.
   private readonly pendingSessionStartupBlockers = new Set<symbol>()
-  private readonly promptInFlightSessionIds = new Set<string>()
-  // Framework control turns use a separate lock so an overflowed prompt's late `finally` can release
-  // only its own prompt lock without making an in-progress native compaction look idle.
-  private readonly contextCompactionInFlightSessionIds = new Set<string>()
   // Public operations acquire this lease synchronously, before backend resolution, skill checks, or
   // session handshakes can await. Retirement cannot remove a generation while one of those preflight
   // phases is still capable of spawning or attaching a process/session.
@@ -543,18 +544,9 @@ class AcpRuntime {
   // Forced skill state belongs to this runtime generation. It is passed explicitly into backend
   // provisioning so concurrent old/new generations cannot overwrite a SettingsService singleton.
   private readonly turnForcedSkillIds = new Set<string>()
-  // Monotonic per-turn token and the token of the turn that currently owns each app session id. When an
-  // overflow-recovery replay reuses a session id, its start bumps the token; the abandoned turn's finally
-  // then sees a newer owner and leaves the replay's shared state (lock, artifact run) untouched.
-  private promptTurnSequence = 0
   private readonly claudeTurnCountsBySession = new Map<
     string,
     { promptTurn: number; count: number }
-  >()
-  private readonly currentPromptTurnBySession = new Map<string, number>()
-  private readonly currentPromptIdentityBySession = new Map<
-    string,
-    { promptTurn: number; promptMessageId: string }
   >()
   // The newest user-owned request is retained while a completion handoff may replace the agent
   // session. A Claude continuation reuses this trusted task/provenance context without asking the
@@ -624,7 +616,6 @@ class AcpRuntime {
   private readonly artifactRunRegistry: ArtifactRunRegistry | undefined
   private readonly artifactTurns: ArtifactTurnOwner | undefined
   private readonly promptContentOwner: AcpPromptContentOwner
-  private readonly skillImportTurnTokens = new Map<string, string>()
 
   // Wires runtime dependencies and forwards permission prompts into the event stream.
   constructor(private readonly options: AcpRuntimeOptions) {
@@ -943,16 +934,22 @@ class AcpRuntime {
   }
 
   private getInFlightSessionIds(): string[] {
-    return Array.from(
-      new Set([...this.promptInFlightSessionIds, ...this.contextCompactionInFlightSessionIds])
-    )
+    const interactions = this.sessionInteractions.snapshot()
+    return [
+      ...interactions.filter(({ kind }) => kind === 'prompt'),
+      ...interactions.filter(({ kind }) => kind === 'compaction')
+    ].map(({ sessionId }) => sessionId)
   }
 
   private hasSessionInteractionInFlight(sessionId: string): boolean {
-    return (
-      this.promptInFlightSessionIds.has(sessionId) ||
-      this.contextCompactionInFlightSessionIds.has(sessionId)
-    )
+    return this.sessionInteractions.current(sessionId) !== undefined
+  }
+
+  private currentPromptInteraction(
+    sessionId: string
+  ): AcpPromptSessionInteractionScope | undefined {
+    const interaction = this.sessionInteractions.current(sessionId)
+    return interaction?.kind === 'prompt' ? interaction : undefined
   }
 
   // Run ids of turns currently in flight, from live in-memory state (not the persisted current-run
@@ -1855,11 +1852,9 @@ class AcpRuntime {
     this.contextUsageUpdatedPromptTurnsBySession.delete(request.sessionId)
     this.sessionRegistry.lookup(request.sessionId)?.aggregate.clearAppliedModel()
 
-    // Release the failed turn's in-flight lock now. Its own `finally` clears it too, but that runs only
-    // after async artifact cleanup, so the recovery resend that follows this reset would otherwise race
-    // it and be rejected with "An ACP prompt is already running for this session".
-    this.promptInFlightSessionIds.delete(request.sessionId)
-    this.contextCompactionInFlightSessionIds.delete(request.sessionId)
+    // Release the failed interaction now. Its own `finally` may run only after async artifact cleanup;
+    // the generation-guarded owner prevents that stale cleanup from clearing the recovery resend.
+    this.sessionInteractions.supersedeCurrent(request.sessionId)
 
     return this.adoptFreshSession(
       connection,
@@ -1950,13 +1945,11 @@ class AcpRuntime {
   ): Promise<PromptResponse> {
     const session = this.activeSessionFor(request.sessionId)
     if (!session) throw new Error(`ACP session not found: ${request.sessionId}`)
-    if (this.contextCompactionInFlightSessionIds.has(request.sessionId)) {
+    const currentInteraction = this.sessionInteractions.current(request.sessionId)
+    if (currentInteraction?.kind === 'compaction') {
       throw new Error('Context compaction is already running for this session')
     }
-    if (
-      this.promptInFlightSessionIds.has(request.sessionId) &&
-      request.reason !== 'overflow-recovery'
-    ) {
+    if (currentInteraction && request.reason !== 'overflow-recovery') {
       throw new Error('An ACP prompt is already running for this session')
     }
 
@@ -1964,11 +1957,14 @@ class AcpRuntime {
     // turn may still be doing artifact cleanup, but it no longer owns the agent session. Transfer its
     // public lock to the control turn now so the retry can start immediately after compaction, while the
     // dedicated compaction lock below keeps unrelated sends blocked during `/compact` itself.
-    if (request.reason === 'overflow-recovery') {
-      this.promptInFlightSessionIds.delete(request.sessionId)
+    if (request.reason === 'overflow-recovery' && currentInteraction) {
+      this.sessionInteractions.supersede(currentInteraction)
     }
 
-    this.contextCompactionInFlightSessionIds.add(request.sessionId)
+    const compactionInteraction = this.sessionInteractions.claim({
+      sessionId: request.sessionId,
+      kind: 'compaction'
+    })
     this.emitState()
 
     try {
@@ -1981,7 +1977,7 @@ class AcpRuntime {
       const cancelTimer = this.cancelTimers.get(request.sessionId)
       if (cancelTimer) this.clearTimer(cancelTimer)
       this.cancelTimers.delete(request.sessionId)
-      this.contextCompactionInFlightSessionIds.delete(request.sessionId)
+      this.sessionInteractions.release(compactionInteraction)
       this.emitState()
     }
   }
@@ -2866,8 +2862,7 @@ class AcpRuntime {
 
   private hasBlockingActivity(): boolean {
     return (
-      this.promptInFlightSessionIds.size > 0 ||
-      this.contextCompactionInFlightSessionIds.size > 0 ||
+      this.sessionInteractions.snapshot().length > 0 ||
       this.reviewerSessions.hasActiveSessions() ||
       this.pendingSessionStartupBlockers.size > 0 ||
       this.activityLeaseCount > 0
@@ -2939,8 +2934,7 @@ class AcpRuntime {
     this.skillSelectorAbortControllers.clear()
     runCleanup('permission-context', () => this.permissionContext.dispose())
     runCleanup('reviewer-state', () => this.reviewerSessions.clear())
-    this.promptInFlightSessionIds.clear()
-    this.contextCompactionInFlightSessionIds.clear()
+    this.sessionInteractions.supersedeAll()
     // Context usage belongs to this live agent-context generation. Invalidate it before teardown,
     // including when a later session.dispose throws. A reconnect may resume the native context or
     // replay history into a fresh one; only that generation's own usage_update can repopulate it.
@@ -2962,12 +2956,9 @@ class AcpRuntime {
       entry.aggregate.setPermissionProfile(undefined)
     }
     this.promptContentOwner.clear()
-    this.currentPromptTurnBySession.clear()
-    this.currentPromptIdentityBySession.clear()
     this.claudeTurnCountsBySession.clear()
     this.codexSkillActivity.clear()
     this.cancelledPromptTurnsBySession.clear()
-    this.skillImportTurnTokens.clear()
     runCleanup('MCP HTTP routes', () => this.sessionCapabilities.clearHttpRoutes())
     this.sessionRegistry.select(undefined)
     this.supportsSessionClose = false
@@ -3200,19 +3191,34 @@ class AcpRuntime {
       throw new Error('An ACP prompt is already running for this session')
     }
 
+    // Reserve this attempt before Specialist/skill authorization can yield. A newer preflight may
+    // supersede the reservation without publishing an in-flight turn, preserving the existing
+    // last-admitted-preflight behavior while preventing a stale attempt from using a replaced session.
+    let promptReservation = this.sessionInteractions.reservePrompt({
+      sessionId: request.sessionId,
+      kind: 'prompt',
+      promptMessageId: request.provenanceContext?.promptMessageId,
+      turnToken: request.continuation?.originatingTurnToken
+    })
+
     // A chip can survive a catalog/profile edit in the renderer. Re-resolve immediately before
     // dispatch so it cannot be used to escape the active Specialist scope.
-    // Avoid yielding for ordinary (non-Specialist) sessions. The prompt lock below is intentionally
-    // claimed in the caller's synchronous turn so a context reset cannot race a just-dispatched prompt
-    // before it has registered ownership. Specialist sessions still await their authoritative scope
-    // resolution before dispatch, preserving the fail-closed validation path.
-    const currentSpecialistSkills =
-      this.sessionRegistry.lookup(request.sessionId)?.aggregate.snapshot().specialistId &&
-      this.options.resolveSpecialistSkills
-        ? await this.resolveCurrentSpecialistSkills(request.sessionId)
-        : undefined
+    // Ordinary sessions continue without yielding. Specialist sessions await their authoritative scope,
+    // but the reservation is invalidated by reset/replacement before a stale attempt can be activated.
+    let currentSpecialistSkills: EffectiveSpecialistSkills | undefined
+    try {
+      currentSpecialistSkills =
+        this.sessionRegistry.lookup(request.sessionId)?.aggregate.snapshot().specialistId &&
+        this.options.resolveSpecialistSkills
+          ? await this.resolveCurrentSpecialistSkills(request.sessionId)
+          : undefined
+    } catch (error) {
+      this.sessionInteractions.release(promptReservation)
+      throw error
+    }
     if (currentSpecialistSkills && currentSpecialistSkills.kind !== 'main') {
       if (currentSpecialistSkills.kind === 'unavailable') {
+        this.sessionInteractions.release(promptReservation)
         throw new Error(currentSpecialistSkills.reason)
       }
       const rejected = (request.forcedSkillIds ?? []).find(
@@ -3224,6 +3230,7 @@ class AcpRuntime {
           !(id.startsWith('mcp-') && currentSpecialistSkills.frameworkNames.includes(id))
       )
       if (rejected) {
+        this.sessionInteractions.release(promptReservation)
         throw new Error(`Skill "${rejected}" is not available to the active specialist.`)
       }
     }
@@ -3276,40 +3283,52 @@ class AcpRuntime {
             throw new Error(`ACP session not found after force-load: ${request.sessionId}`)
           }
           activeSession = reloaded
+          // disconnect() invalidates every scope belonging to the old provider generation. Reserve the
+          // resumed stable App Session again before this same authorized attempt can continue.
+          promptReservation = this.sessionInteractions.reservePrompt({
+            sessionId: request.sessionId,
+            kind: 'prompt',
+            promptMessageId: request.provenanceContext?.promptMessageId,
+            turnToken: request.continuation?.originatingTurnToken
+          })
         }
       }
     } catch (error) {
       if (didForceReload) this.turnForcedSkillIds.clear()
+      this.sessionInteractions.release(promptReservation)
       throw error
     }
 
-    // Another prompt can claim this session while the force-load check above is awaiting. Re-acquire
-    // the turn lock before publishing its token so a delayed attempt cannot overwrite a newer turn's
-    // lifecycle state.
+    // Another prompt can claim this session while authorization preflight is awaiting. Activate only
+    // the newest reservation so a delayed attempt cannot overwrite a newer turn's lifecycle state.
     if (this.hasSessionInteractionInFlight(request.sessionId)) {
+      this.sessionInteractions.release(promptReservation)
       throw new Error('An ACP prompt is already running for this session')
     }
 
-    this.sessionRegistry.select(request.sessionId)
-    this.handoffPromptRequests.set(request.sessionId, request)
-    if (!request.suppressUserMessage) this.rememberHandoffUserTask(request.sessionId, request)
-    // Claim ownership of this session's shared turn state so a superseded turn's later finally can tell it
-    // no longer owns the lock/artifact run (see the guarded cleanup in this turn's finally).
-    const promptTurn = ++this.promptTurnSequence
-    const skillImportTurnToken = request.continuation?.originatingTurnToken ?? randomUUID()
-    this.promptInFlightSessionIds.add(request.sessionId)
-    this.currentPromptTurnBySession.set(request.sessionId, promptTurn)
-    const promptMessageId = request.provenanceContext?.promptMessageId
-    if (promptMessageId) {
-      this.currentPromptIdentityBySession.set(request.sessionId, {
-        promptTurn,
-        promptMessageId
-      })
-    } else {
-      this.currentPromptIdentityBySession.delete(request.sessionId)
+    const refreshedActiveSession = this.activeSessionFor(request.sessionId)
+    if (!refreshedActiveSession) {
+      this.sessionInteractions.release(promptReservation)
+      throw new Error(`ACP session not found: ${request.sessionId}`)
     }
+    activeSession = refreshedActiveSession
+
+    let promptInteraction: AcpPromptSessionInteractionScope
+    try {
+      promptInteraction = this.sessionInteractions.activatePrompt(promptReservation)
+      this.sessionRegistry.select(request.sessionId)
+      this.handoffPromptRequests.set(request.sessionId, request)
+      if (!request.suppressUserMessage) this.rememberHandoffUserTask(request.sessionId, request)
+    } catch (error) {
+      this.sessionInteractions.release(promptReservation)
+      throw error
+    }
+    const promptTurn = promptInteraction.sequence
+    const skillImportTurnToken = promptInteraction.turnToken
+    const promptEventIdentity = promptInteraction.promptMessageId
+      ? { promptMessageId: promptInteraction.promptMessageId }
+      : {}
     this.claudeTurnCountsBySession.delete(request.sessionId)
-    this.skillImportTurnTokens.set(request.sessionId, skillImportTurnToken)
     this.cancelledPromptTurnsBySession.delete(request.sessionId)
     try {
       this.callbacks.onPromptStarted?.(request.sessionId, skillImportTurnToken, promptAttemptId)
@@ -3347,6 +3366,7 @@ class AcpRuntime {
           kind: 'message',
           level: 'info',
           sessionId: request.sessionId,
+          ...promptEventIdentity,
           role: 'user',
           text: request.text
         })
@@ -3364,6 +3384,7 @@ class AcpRuntime {
           kind: 'stop',
           level: 'info',
           sessionId: request.sessionId,
+          ...promptEventIdentity,
           title: 'Prompt stopped',
           text: response.stopReason,
           raw: response
@@ -3448,7 +3469,7 @@ class AcpRuntime {
         references: request.referencedArtifacts ?? [],
         codexSkillInputs,
         skillImportEnabled: this.sessionCapabilities.isSkillImportEnabled(),
-        skillImportTurnToken: this.skillImportTurnTokens.get(request.sessionId),
+        skillImportTurnToken,
         onSkillImportAttachmentEligible: this.callbacks.onSkillImportAttachmentEligible
           ? (attachmentUri) => {
               try {
@@ -3521,6 +3542,14 @@ class AcpRuntime {
 
       for (;;) {
         const message = await Promise.race([activeSession.nextUpdate(), promptFailure])
+
+        // A reset/replacement may supersede this provider turn while a queued update or terminal
+        // response is still draining. Settle the abandoned promise, but never project its state or
+        // terminal facts into the replacement interaction.
+        if (this.sessionInteractions.current(request.sessionId) !== promptInteraction) {
+          if (message.kind === 'stop') return message.response
+          continue
+        }
 
         if (!providerPromptAccepted) {
           providerPromptAccepted = true
@@ -3603,6 +3632,7 @@ class AcpRuntime {
             kind: 'stop',
             level: 'info',
             sessionId: request.sessionId,
+            ...promptEventIdentity,
             title: 'Prompt stopped',
             text: message.stopReason,
             turnUsage,
@@ -3625,11 +3655,6 @@ class AcpRuntime {
           return message.response
         }
 
-        // A reset can adopt a fresh agent session under the same app id while this abandoned prompt
-        // is still unwinding. Ignore any update already queued by that old prompt generation; otherwise
-        // a late usage_update can repopulate the context measurement we deliberately invalidated.
-        if (this.currentPromptTurnBySession.get(request.sessionId) !== promptTurn) continue
-
         // Route the update under the app-facing id so a session adopted onto a new agent (after a
         // provider switch) still streams into the same conversation the renderer is watching. (No
         // per-update log line here: it fires once per streamed chunk and floods the console for no
@@ -3637,6 +3662,7 @@ class AcpRuntime {
         this.handleSessionUpdate(message.notification, request.sessionId)
       }
     } catch (error) {
+      if (this.sessionInteractions.current(request.sessionId) !== promptInteraction) throw error
       if (
         contextUsageCheckpoint &&
         !contextUsageEstimateCommitted &&
@@ -3687,6 +3713,7 @@ class AcpRuntime {
         // worth a GitHub issue. Determined structurally from the agent's signals, not the message text.
         providerError: isProviderPromptError(error),
         sessionId: request.sessionId,
+        ...promptEventIdentity,
         title: ACP_PROMPT_FAILED_EVENT_TITLE,
         text
       })
@@ -3712,29 +3739,27 @@ class AcpRuntime {
           kind: 'error',
           level: 'error',
           sessionId: request.sessionId,
+          ...promptEventIdentity,
           title: 'Artifact cleanup failed',
           text: errorMessage(error)
         })
       }
       // ArtifactTurnOwner clears only the handle that still owns this Session. A superseded turn's
       // delayed finally therefore cannot erase the replacement turn's handoff or active-run state.
-      if (this.currentPromptTurnBySession.get(request.sessionId) === promptTurn) {
+      const ownsInteraction =
+        this.sessionInteractions.current(request.sessionId) === promptInteraction
+      if (ownsInteraction) {
         const cancelTimer = this.cancelTimers.get(request.sessionId)
         if (cancelTimer) this.clearTimer(cancelTimer)
         this.cancelTimers.delete(request.sessionId)
         this.permissionContext.clearCorrelationsForSession(request.sessionId)
         this.claudeTurnCountsBySession.delete(request.sessionId)
-        this.currentPromptTurnBySession.delete(request.sessionId)
-        if (this.currentPromptIdentityBySession.get(request.sessionId)?.promptTurn === promptTurn) {
-          this.currentPromptIdentityBySession.delete(request.sessionId)
-        }
         if (this.contextUsageUpdatedPromptTurnsBySession.get(request.sessionId) === promptTurn) {
           this.contextUsageUpdatedPromptTurnsBySession.delete(request.sessionId)
         }
-        this.promptInFlightSessionIds.delete(request.sessionId)
-        if (this.skillImportTurnTokens.get(request.sessionId) === skillImportTurnToken) {
-          this.skillImportTurnTokens.delete(request.sessionId)
-        }
+      }
+      this.sessionInteractions.release(promptInteraction)
+      if (ownsInteraction) {
         try {
           this.callbacks.onPromptEnded?.(request.sessionId, skillImportTurnToken)
         } catch (error) {
@@ -3868,12 +3893,11 @@ class AcpRuntime {
     this.cancelTimers.delete(request.sessionId)
     this.skillSelectorAbortControllers.get(request.sessionId)?.abort()
     this.skillSelectorAbortControllers.delete(request.sessionId)
+    this.sessionInteractions.supersedeCurrent(request.sessionId)
     // Drop this session's MCP routes, aliases, and bearer ownership (idempotent for detached deletes).
     this.sessionCapabilities.revokeSession(request.sessionId)
     const removal = deletion.finish(target)
     this.promptContentOwner.resetSession(request.sessionId)
-    this.currentPromptTurnBySession.delete(request.sessionId)
-    this.currentPromptIdentityBySession.delete(request.sessionId)
     this.handoffPromptRequests.delete(request.sessionId)
     this.handoffUserTasks.delete(request.sessionId)
     this.pendingClaudeCodeHandoffAppends.delete(request.sessionId)
@@ -3881,9 +3905,6 @@ class AcpRuntime {
     this.cancelledPromptTurnsBySession.delete(request.sessionId)
     this.contextUsageTracker.deleteSession(request.sessionId)
     this.contextUsageUpdatedPromptTurnsBySession.delete(request.sessionId)
-    this.skillImportTurnTokens.delete(request.sessionId)
-    this.promptInFlightSessionIds.delete(request.sessionId)
-    this.contextCompactionInFlightSessionIds.delete(request.sessionId)
 
     // Only announce a deletion and shift the current session when something was actually attached; a
     // detached cleanup (post-switch) must not emit a spurious event or move the current selection.
@@ -4129,8 +4150,9 @@ class AcpRuntime {
     if (!Number.isSafeInteger(message.num_turns) || (message.num_turns as number) <= 0) return
 
     const appSessionId = this.sessionRegistry.resolveAppSessionId(params.sessionId)
-    const promptTurn = this.currentPromptTurnBySession.get(appSessionId)
-    if (promptTurn === undefined) return
+    const promptInteraction = this.currentPromptInteraction(appSessionId)
+    if (!promptInteraction) return
+    const promptTurn = promptInteraction.sequence
 
     const current = this.claudeTurnCountsBySession.get(appSessionId)
     const count =
@@ -4400,14 +4422,15 @@ class AcpRuntime {
     const reviewerContext = this.reviewerSessions.contextFor(params.sessionId)
     const mcpServerNames =
       reviewerContext?.mcpServerNames ?? this.sessionCapabilities.mcpServerNamesFor(appSessionId)
-    const promptTurn = this.currentPromptTurnBySession.get(appSessionId)
+    const promptInteraction = this.currentPromptInteraction(appSessionId)
+    const promptTurn = promptInteraction?.sequence
     const aggregateSnapshot = this.sessionRegistry.lookup(appSessionId)?.aggregate.snapshot()
     const framework = reviewerContext?.frameworkId ?? aggregateSnapshot?.frameworkId
     const isPermissionContextCancelled = (): boolean =>
       framework === 'opencode' &&
       (promptTurn === undefined
         ? this.activeSessionFor(appSessionId) !== undefined
-        : this.currentPromptTurnBySession.get(appSessionId) !== promptTurn ||
+        : this.currentPromptInteraction(appSessionId)?.sequence !== promptTurn ||
           this.cancelledPromptTurnsBySession.get(appSessionId) === promptTurn)
     const restoreContext = {
       sessionId: appSessionId,
@@ -4503,8 +4526,10 @@ class AcpRuntime {
   }
 
   private cancelPermissionFlowForSession(sessionId: string): void {
-    const promptTurn = this.currentPromptTurnBySession.get(sessionId)
-    if (promptTurn !== undefined) this.cancelledPromptTurnsBySession.set(sessionId, promptTurn)
+    const promptInteraction = this.currentPromptInteraction(sessionId)
+    if (promptInteraction) {
+      this.cancelledPromptTurnsBySession.set(sessionId, promptInteraction.sequence)
+    }
     this.permissionContext.cancelForSession(sessionId)
   }
 
@@ -4519,7 +4544,7 @@ class AcpRuntime {
     if (
       this.framework.id !== 'codex' ||
       this.pendingProviderReconnect ||
-      this.currentPromptTurnBySession.get(sessionId) !== promptTurn
+      this.currentPromptInteraction(sessionId)?.sequence !== promptTurn
     ) {
       return
     }
@@ -4690,9 +4715,12 @@ class AcpRuntime {
         routed.update.sessionUpdate === 'tool_call' ||
         routed.update.sessionUpdate === 'tool_call_update'
       ) {
-        const promptTurn = this.currentPromptTurnBySession.get(routed.sessionId)
-        if (promptTurn !== undefined) {
-          this.contextUsageUpdatedPromptTurnsBySession.set(routed.sessionId, promptTurn)
+        const promptInteraction = this.currentPromptInteraction(routed.sessionId)
+        if (promptInteraction) {
+          this.contextUsageUpdatedPromptTurnsBySession.set(
+            routed.sessionId,
+            promptInteraction.sequence
+          )
         }
       }
     }
@@ -4883,8 +4911,6 @@ class AcpRuntime {
       else entry.aggregate.detachConnection()
     }
     this.promptContentOwner.clear()
-    this.currentPromptTurnBySession.clear()
-    this.currentPromptIdentityBySession.clear()
     this.handoffPromptRequests.clear()
     this.handoffUserTasks.clear()
     this.pendingClaudeCodeHandoffAppends.clear()
@@ -4899,8 +4925,7 @@ class AcpRuntime {
     this.supportsSessionDelete = false
     this.connection = undefined
     this.agentProcess = undefined
-    this.promptInFlightSessionIds.clear()
-    this.contextCompactionInFlightSessionIds.clear()
+    this.sessionInteractions.supersedeAll()
     // The connection is already gone, so any ensureConnected caller waiting on
     // the reconnect barrier must unblock now — it will fall through to connect()
     // and pick up the new backend from resolveBackend. A fresh spawn re-provisions
@@ -4927,12 +4952,12 @@ class AcpRuntime {
   private pushEvent(
     event: Omit<AcpRuntimeEvent, 'id' | 'timestamp'> & Partial<AcpRuntimeEvent>
   ): void {
-    const currentPromptIdentity = event.sessionId
-      ? this.currentPromptIdentityBySession.get(event.sessionId)
+    const currentPromptMessageId = event.sessionId
+      ? this.currentPromptInteraction(event.sessionId)?.promptMessageId
       : undefined
     const scopedEvent =
-      currentPromptIdentity && !event.promptMessageId
-        ? { ...event, promptMessageId: currentPromptIdentity.promptMessageId }
+      currentPromptMessageId && !event.promptMessageId
+        ? { ...event, promptMessageId: currentPromptMessageId }
         : event
     const runtimeEvent = this.snapshotOwner.appendEvent(scopedEvent)
     this.callbacks.onEvent?.(runtimeEvent)

--- a/src/main/acp/session-interaction-owner.test.ts
+++ b/src/main/acp/session-interaction-owner.test.ts
@@ -18,6 +18,118 @@ const createDeferred = <T>(): {
 }
 
 describe('AcpSessionInteractionOwner', () => {
+  it('keeps model-turn observations on the current prompt generation', () => {
+    const owner = new AcpSessionInteractionOwner()
+    const first = owner.claim({ sessionId: 'session-1', kind: 'prompt' })
+
+    owner.observeModelTurns(first, 2)
+    owner.observeModelTurns(first, 0)
+    owner.observeModelTurns(first, -1)
+    owner.observeModelTurns(first, 1.5)
+    expect(owner.captureTerminal(first, 'stop')).toBe(true)
+    expect(
+      owner.settle(first, {
+        turnUsage: { inputTokens: 1, cacheTokens: 0, outputTokens: 1 }
+      })?.turnUsage?.turnCount
+    ).toBe(2)
+
+    owner.release(first)
+    const replacement = owner.claim({ sessionId: 'session-1', kind: 'prompt' })
+    owner.observeModelTurns(first, 100)
+    owner.observeModelTurns(replacement, 1)
+
+    expect(owner.captureTerminal(replacement, 'stop')).toBe(true)
+    expect(
+      owner.settle(replacement, {
+        turnUsage: { inputTokens: 1, cacheTokens: 0, outputTokens: 1 }
+      })?.turnUsage?.turnCount
+    ).toBe(1)
+    owner.release(replacement)
+  })
+
+  it('captures one immutable terminal timestamp and settles only once', () => {
+    let currentTime = 1234
+    const now = vi.fn(() => currentTime)
+    const owner = new AcpSessionInteractionOwner({ now })
+    const scope = owner.claim({ sessionId: 'session-1', kind: 'prompt' })
+
+    owner.observeModelTurns(scope, 2)
+    owner.observeModelTurns(scope, 3)
+    expect(owner.captureTerminal(scope, 'stop')).toBe(true)
+    currentTime = 5678
+    owner.release(scope)
+    expect(owner.captureTerminal(scope, 'stop')).toBe(true)
+    expect(owner.captureTerminal(scope, 'error')).toBe(false)
+    const terminal = owner.settle(scope, {
+      turnUsage: { inputTokens: 11, cacheTokens: 2, outputTokens: 4 }
+    })
+
+    expect(terminal).toEqual({
+      timestamp: 1234,
+      turnUsage: { inputTokens: 11, cacheTokens: 2, outputTokens: 4, turnCount: 5 }
+    })
+    expect(Object.isFrozen(terminal)).toBe(true)
+    expect(Object.isFrozen(terminal?.turnUsage)).toBe(true)
+    expect(
+      owner.settle(scope, {
+        turnUsage: { inputTokens: 99, cacheTokens: 0, outputTokens: 0 },
+        modelTurnCount: 99
+      })
+    ).toBeUndefined()
+    expect(owner.captureTerminal(scope, 'stop')).toBe(false)
+    expect(now).toHaveBeenCalledOnce()
+  })
+
+  it('uses an explicit model count only when terminal usage exists', () => {
+    const owner = new AcpSessionInteractionOwner({ now: () => 7 })
+    const withoutUsage = owner.claim({ sessionId: 'session-1', kind: 'prompt' })
+
+    expect(owner.captureTerminal(withoutUsage, 'stop')).toBe(true)
+    expect(owner.settle(withoutUsage, { modelTurnCount: 2 })).toEqual({ timestamp: 7 })
+    owner.release(withoutUsage)
+
+    const withUsage = owner.claim({ sessionId: 'session-1', kind: 'prompt' })
+    expect(owner.captureTerminal(withUsage, 'stop')).toBe(true)
+    expect(
+      owner.settle(withUsage, {
+        turnUsage: { inputTokens: 5, cacheTokens: 1, outputTokens: 2 },
+        modelTurnCount: 4
+      })
+    ).toEqual({
+      timestamp: 7,
+      turnUsage: { inputTokens: 5, cacheTokens: 1, outputTokens: 2, turnCount: 4 }
+    })
+  })
+
+  it('rejects stale terminal settlement', () => {
+    const owner = new AcpSessionInteractionOwner()
+    const superseded = owner.claim({ sessionId: 'session-1', kind: 'prompt' })
+    owner.supersede(superseded)
+    const replacement = owner.claim({ sessionId: 'session-1', kind: 'prompt' })
+
+    expect(owner.settle(superseded, {})).toBeUndefined()
+    owner.release(replacement)
+  })
+
+  it('settles every active prompt once while leaving compaction alone', () => {
+    const owner = new AcpSessionInteractionOwner({ now: () => 9 })
+    const first = owner.claim({ sessionId: 'session-1', kind: 'prompt' })
+    const second = owner.claim({ sessionId: 'session-2', kind: 'prompt' })
+    const compaction = owner.claim({ sessionId: 'session-3', kind: 'compaction' })
+
+    expect(owner.settleActivePrompts()).toEqual([
+      { scope: first, terminal: { timestamp: 9 } },
+      { scope: second, terminal: { timestamp: 9 } }
+    ])
+    expect(owner.settleActivePrompts()).toEqual([])
+    expect(owner.current('session-3')).toBe(compaction)
+
+    owner.supersedeAll()
+    expect(first.signal.aborted).toBe(true)
+    expect(second.signal.aborted).toBe(true)
+    expect(compaction.signal.aborted).toBe(true)
+  })
+
   it('publishes cancellation before notify settles and keeps the interaction active', async () => {
     const owner = new AcpSessionInteractionOwner()
     const scope = owner.claim({ sessionId: 'session-1', kind: 'prompt' })

--- a/src/main/acp/session-interaction-owner.test.ts
+++ b/src/main/acp/session-interaction-owner.test.ts
@@ -18,6 +18,137 @@ const createDeferred = <T>(): {
 }
 
 describe('AcpSessionInteractionOwner', () => {
+  it('publishes cancellation before notify settles and keeps the interaction active', async () => {
+    const owner = new AcpSessionInteractionOwner()
+    const scope = owner.claim({ sessionId: 'session-1', kind: 'prompt' })
+    const releaseNotify = createDeferred<void>()
+    const onAccepted = vi.fn()
+    const cancelling = owner.cancelPrompt({
+      sessionId: 'session-1',
+      notify: () => releaseNotify.promise,
+      onAccepted,
+      onTimeout: vi.fn()
+    })
+    let checkpointSettled = false
+    const checkpoint = owner.cancellationCheckpoint(scope).then((status) => {
+      checkpointSettled = true
+      return status
+    })
+
+    expect(scope.signal.aborted).toBe(true)
+    expect(owner.current('session-1')).toBe(scope)
+    await Promise.resolve()
+    expect(checkpointSettled).toBe(false)
+    expect(onAccepted).not.toHaveBeenCalled()
+
+    releaseNotify.resolve()
+    await cancelling
+    await expect(checkpoint).resolves.toBe('cancelled')
+    expect(owner.isCancellationAccepted(scope)).toBe(true)
+    expect(onAccepted).toHaveBeenCalledOnce()
+    expect(owner.current('session-1')).toBe(scope)
+  })
+
+  it('keeps cancellation inactive and clears its timer when notify fails', async () => {
+    const clearTimer = vi.fn()
+    const owner = new AcpSessionInteractionOwner({
+      cancelTimeoutMs: 1,
+      setTimer: () => 1 as unknown as ReturnType<typeof setTimeout>,
+      clearTimer
+    })
+    const scope = owner.claim({ sessionId: 'session-1', kind: 'prompt' })
+    const onAccepted = vi.fn()
+
+    await expect(
+      owner.cancelPrompt({
+        sessionId: 'session-1',
+        notify: async () => {
+          throw new Error('cancel write failed')
+        },
+        onAccepted,
+        onTimeout: vi.fn()
+      })
+    ).rejects.toThrow('cancel write failed')
+
+    await expect(owner.cancellationCheckpoint(scope)).resolves.toBe('active')
+    expect(owner.isCancellationAccepted(scope)).toBe(false)
+    expect(onAccepted).not.toHaveBeenCalled()
+    expect(clearTimer).toHaveBeenCalledOnce()
+  })
+
+  it('scopes cancellation timeouts to the captured interaction generation', async () => {
+    type TestTimer = { active: boolean; fire: () => void }
+    const timers: TestTimer[] = []
+    const owner = new AcpSessionInteractionOwner({
+      cancelTimeoutMs: 1,
+      setTimer: (callback) => {
+        const timer: TestTimer = {
+          active: true,
+          fire: () => {
+            if (timer.active) callback()
+          }
+        }
+        timers.push(timer)
+        return timer as unknown as ReturnType<typeof setTimeout>
+      },
+      clearTimer: (handle) => {
+        const timer = handle as unknown as TestTimer
+        timer.active = false
+      }
+    })
+    const onTimeout = vi.fn()
+    const first = owner.claim({ sessionId: 'session-1', kind: 'prompt' })
+
+    await owner.cancelPrompt({
+      sessionId: 'session-1',
+      notify: async () => undefined,
+      onAccepted: vi.fn(),
+      onTimeout
+    })
+    expect(timers[0].active).toBe(true)
+    owner.release(first)
+    expect(timers[0].active).toBe(false)
+
+    const replacement = owner.claim({ sessionId: 'session-1', kind: 'prompt' })
+    timers[0].fire()
+    expect(onTimeout).not.toHaveBeenCalled()
+
+    await owner.cancelPrompt({
+      sessionId: 'session-1',
+      notify: async () => undefined,
+      onAccepted: vi.fn(),
+      onTimeout
+    })
+    timers[1].fire()
+    expect(onTimeout).toHaveBeenCalledOnce()
+    owner.release(replacement)
+  })
+
+  it('does not let a cancellation without an active interaction time out a later turn', async () => {
+    let fireTimeout: (() => void) | undefined
+    const owner = new AcpSessionInteractionOwner({
+      cancelTimeoutMs: 1,
+      setTimer: (callback) => {
+        fireTimeout = callback
+        return 1 as unknown as ReturnType<typeof setTimeout>
+      }
+    })
+    const onTimeout = vi.fn()
+
+    await owner.cancelPrompt({
+      sessionId: 'session-1',
+      notify: async () => undefined,
+      onAccepted: vi.fn(),
+      onTimeout
+    })
+    const scope = owner.claim({ sessionId: 'session-1', kind: 'prompt' })
+    fireTimeout?.()
+
+    expect(onTimeout).not.toHaveBeenCalled()
+    expect(owner.current('session-1')).toBe(scope)
+    owner.release(scope)
+  })
+
   it('keeps a synchronous prompt reservation private until activation', () => {
     const owner = new AcpSessionInteractionOwner()
     const active = owner.claim({ sessionId: 'session-1', kind: 'compaction' })

--- a/src/main/acp/session-interaction-owner.test.ts
+++ b/src/main/acp/session-interaction-owner.test.ts
@@ -1,0 +1,215 @@
+import { describe, expect, it, vi } from 'vitest'
+
+import {
+  AcpSessionInteractionOwner,
+  type AcpPromptSessionInteractionScope
+} from './session-interaction-owner'
+
+const createDeferred = <T>() => {
+  let resolve!: (value: T | PromiseLike<T>) => void
+  const promise = new Promise<T>((resolvePromise) => {
+    resolve = resolvePromise
+  })
+
+  return { promise, resolve }
+}
+
+describe('AcpSessionInteractionOwner', () => {
+  it('claims a session before work reaches its first await and rejects overlapping work', async () => {
+    const owner = new AcpSessionInteractionOwner()
+    const release = createDeferred<void>()
+    const firstWork = vi.fn(async () => {
+      await release.promise
+      return 'first-result'
+    })
+    const overlappingWork = vi.fn(async () => 'overlapping-result')
+
+    const first = owner.run({ sessionId: 'session-1', kind: 'prompt' }, firstWork)
+    const overlapping = owner.run({ sessionId: 'session-1', kind: 'prompt' }, overlappingWork)
+
+    expect(firstWork).toHaveBeenCalledOnce()
+    expect(overlappingWork).not.toHaveBeenCalled()
+    await expect(overlapping).rejects.toThrow(/already running/)
+
+    release.resolve()
+    await expect(first).resolves.toBe('first-result')
+  })
+
+  it('allows interactions for different sessions to run concurrently', async () => {
+    const owner = new AcpSessionInteractionOwner()
+    const bothStarted = createDeferred<void>()
+    let started = 0
+    const work = async (result: string) => {
+      started += 1
+      if (started === 2) {
+        bothStarted.resolve()
+      }
+      await bothStarted.promise
+      return result
+    }
+
+    await expect(
+      Promise.all([
+        owner.run({ sessionId: 'session-1', kind: 'prompt' }, () => work('first-result')),
+        owner.run({ sessionId: 'session-2', kind: 'compaction' }, () => work('second-result'))
+      ])
+    ).resolves.toEqual(['first-result', 'second-result'])
+  })
+
+  it('passes immutable request facts and a fresh monotonic identity to each run', async () => {
+    const owner = new AcpSessionInteractionOwner()
+    const scopes: AcpPromptSessionInteractionScope[] = []
+
+    await owner.run(
+      {
+        sessionId: 'session-1',
+        kind: 'prompt',
+        promptMessageId: 'prompt-message-1'
+      },
+      async (scope) => {
+        const turnToken = scope.turnToken
+        await Promise.resolve()
+
+        expect(scope).toMatchObject({
+          sessionId: 'session-1',
+          kind: 'prompt',
+          promptMessageId: 'prompt-message-1'
+        })
+        expect(scope.signal).toBeInstanceOf(AbortSignal)
+        expect(scope.signal.aborted).toBe(false)
+        expect(scope.turnToken).toBe(turnToken)
+        expect(Object.isFrozen(scope)).toBe(true)
+        scopes.push(scope)
+      }
+    )
+    let compactionSequence = 0
+    await owner.run({ sessionId: 'session-1', kind: 'compaction' }, async (scope) => {
+      compactionSequence = scope.sequence
+      expect('promptMessageId' in scope).toBe(false)
+      expect('turnToken' in scope).toBe(false)
+    })
+
+    expect(compactionSequence).toBe(scopes[0].sequence + 1)
+  })
+
+  it('retains a continuation turn token and exposes only the current scope', async () => {
+    const owner = new AcpSessionInteractionOwner()
+    const release = createDeferred<void>()
+    let scope!: AcpPromptSessionInteractionScope
+    const interaction = owner.run(
+      {
+        sessionId: 'session-1',
+        kind: 'prompt',
+        turnToken: 'originating-turn-token'
+      },
+      async (activeScope) => {
+        scope = activeScope
+        await release.promise
+      }
+    )
+
+    expect(scope.turnToken).toBe('originating-turn-token')
+    expect(owner.current('session-1')).toBe(scope)
+
+    release.resolve()
+    await interaction
+
+    expect(owner.current('session-1')).toBeUndefined()
+  })
+
+  it('does not let a superseded interaction clear its replacement when it settles', async () => {
+    const owner = new AcpSessionInteractionOwner()
+    const releaseSuperseded = createDeferred<void>()
+    const releaseReplacement = createDeferred<void>()
+    let supersededScope!: AcpPromptSessionInteractionScope
+    let replacementScope!: AcpPromptSessionInteractionScope
+    const superseded = owner.run({ sessionId: 'session-1', kind: 'prompt' }, async (scope) => {
+      supersededScope = scope
+      await releaseSuperseded.promise
+      return 'superseded-result'
+    })
+
+    expect(supersededScope.signal.aborted).toBe(false)
+    owner.supersede(supersededScope)
+    expect(supersededScope.signal.aborted).toBe(true)
+    expect(owner.current('session-1')).toBeUndefined()
+    const replacement = owner.run({ sessionId: 'session-1', kind: 'prompt' }, async (scope) => {
+      replacementScope = scope
+      await releaseReplacement.promise
+      return 'replacement-result'
+    })
+    expect(replacementScope.signal.aborted).toBe(false)
+
+    owner.supersede(supersededScope)
+    expect(owner.current('session-1')).toBe(replacementScope)
+    expect(replacementScope.signal.aborted).toBe(false)
+
+    releaseSuperseded.resolve()
+    await expect(superseded).resolves.toBe('superseded-result')
+
+    const overlappingWork = vi.fn(async () => 'overlapping-result')
+    await expect(
+      owner.run({ sessionId: 'session-1', kind: 'prompt' }, overlappingWork)
+    ).rejects.toThrow(/already running/)
+    expect(overlappingWork).not.toHaveBeenCalled()
+
+    releaseReplacement.resolve()
+    await expect(replacement).resolves.toBe('replacement-result')
+    await expect(
+      owner.run({ sessionId: 'session-1', kind: 'prompt' }, async () => 'next-result')
+    ).resolves.toBe('next-result')
+  })
+
+  it.each([
+    [
+      'synchronous throw',
+      () => {
+        throw new Error('work failed')
+      }
+    ],
+    [
+      'asynchronous rejection',
+      async () => {
+        await Promise.resolve()
+        throw new Error('work failed')
+      }
+    ]
+  ])('releases a session after a work %s', async (_name, work) => {
+    const owner = new AcpSessionInteractionOwner()
+
+    await expect(
+      owner.run({ sessionId: 'session-1', kind: 'prompt' }, work)
+    ).rejects.toThrow('work failed')
+    await expect(
+      owner.run({ sessionId: 'session-1', kind: 'prompt' }, async () => 'next-result')
+    ).resolves.toBe('next-result')
+  })
+
+  it('returns a frozen detached snapshot of active session ids and kinds', async () => {
+    const owner = new AcpSessionInteractionOwner()
+    const releasePrompt = createDeferred<void>()
+    const releaseCompaction = createDeferred<void>()
+    const prompt = owner.run({ sessionId: 'session-1', kind: 'prompt' }, async () => {
+      await releasePrompt.promise
+    })
+    const compaction = owner.run({ sessionId: 'session-2', kind: 'compaction' }, async () => {
+      await releaseCompaction.promise
+    })
+
+    const snapshot = owner.snapshot()
+    expect(snapshot).toEqual([
+      { sessionId: 'session-1', kind: 'prompt' },
+      { sessionId: 'session-2', kind: 'compaction' }
+    ])
+    expect(Object.isFrozen(snapshot)).toBe(true)
+    expect(snapshot.every(Object.isFrozen)).toBe(true)
+
+    releasePrompt.resolve()
+    await prompt
+    expect(owner.snapshot()).toEqual([{ sessionId: 'session-2', kind: 'compaction' }])
+    expect(snapshot).toHaveLength(2)
+
+    releaseCompaction.resolve()
+    await compaction
+  })
+})

--- a/src/main/acp/session-interaction-owner.test.ts
+++ b/src/main/acp/session-interaction-owner.test.ts
@@ -15,6 +15,31 @@ const createDeferred = <T>() => {
 }
 
 describe('AcpSessionInteractionOwner', () => {
+  it('supports explicit claim and release while run uses the same lifecycle', async () => {
+    const owner = new AcpSessionInteractionOwner()
+    const first = owner.claim({ sessionId: 'session-1', kind: 'prompt' })
+
+    expect(owner.current('session-1')).toBe(first)
+    expect(() => owner.claim({ sessionId: 'session-1', kind: 'compaction' })).toThrow(
+      /already running/
+    )
+
+    owner.release(first)
+    const replacement = owner.claim({ sessionId: 'session-1', kind: 'compaction' })
+    owner.release(first)
+    expect(owner.current('session-1')).toBe(replacement)
+    owner.release(replacement)
+
+    const claim = vi.spyOn(owner, 'claim')
+    const release = vi.spyOn(owner, 'release')
+    await expect(
+      owner.run({ sessionId: 'session-2', kind: 'prompt' }, async () => 'run-result')
+    ).resolves.toBe('run-result')
+    expect(claim).toHaveBeenCalledOnce()
+    expect(release).toHaveBeenCalledOnce()
+    expect(release).toHaveBeenCalledWith(claim.mock.results[0].value)
+  })
+
   it('claims a session before work reaches its first await and rejects overlapping work', async () => {
     const owner = new AcpSessionInteractionOwner()
     const release = createDeferred<void>()
@@ -158,6 +183,30 @@ describe('AcpSessionInteractionOwner', () => {
     await expect(
       owner.run({ sessionId: 'session-1', kind: 'prompt' }, async () => 'next-result')
     ).resolves.toBe('next-result')
+  })
+
+  it('authoritatively supersedes the current session or every active session', () => {
+    const owner = new AcpSessionInteractionOwner()
+    const first = owner.claim({ sessionId: 'session-1', kind: 'prompt' })
+    const other = owner.claim({ sessionId: 'session-2', kind: 'compaction' })
+
+    owner.supersedeCurrent('missing-session')
+    expect(first.signal.aborted).toBe(false)
+    expect(other.signal.aborted).toBe(false)
+
+    owner.supersedeCurrent('session-1')
+    expect(first.signal.aborted).toBe(true)
+    expect(owner.current('session-1')).toBeUndefined()
+
+    const replacement = owner.claim({ sessionId: 'session-1', kind: 'prompt' })
+    owner.supersede(first)
+    expect(owner.current('session-1')).toBe(replacement)
+    expect(replacement.signal.aborted).toBe(false)
+
+    owner.supersedeAll()
+    expect(replacement.signal.aborted).toBe(true)
+    expect(other.signal.aborted).toBe(true)
+    expect(owner.snapshot()).toEqual([])
   })
 
   it.each([

--- a/src/main/acp/session-interaction-owner.test.ts
+++ b/src/main/acp/session-interaction-owner.test.ts
@@ -5,7 +5,10 @@ import {
   type AcpPromptSessionInteractionScope
 } from './session-interaction-owner'
 
-const createDeferred = <T>() => {
+const createDeferred = <T>(): {
+  promise: Promise<T>
+  resolve: (value: T | PromiseLike<T>) => void
+} => {
   let resolve!: (value: T | PromiseLike<T>) => void
   const promise = new Promise<T>((resolvePromise) => {
     resolve = resolvePromise
@@ -15,6 +18,78 @@ const createDeferred = <T>() => {
 }
 
 describe('AcpSessionInteractionOwner', () => {
+  it('keeps a synchronous prompt reservation private until activation', () => {
+    const owner = new AcpSessionInteractionOwner()
+    const active = owner.claim({ sessionId: 'session-1', kind: 'compaction' })
+
+    expect(() => owner.reservePrompt({ sessionId: 'session-1', kind: 'prompt' })).toThrow(
+      /already running/
+    )
+    owner.release(active)
+
+    const reservation = owner.reservePrompt({
+      sessionId: 'session-1',
+      kind: 'prompt',
+      promptMessageId: 'prompt-message-1'
+    })
+    expect(reservation.signal.aborted).toBe(false)
+    expect(owner.current('session-1')).toBeUndefined()
+    expect(owner.snapshot()).toEqual([])
+
+    expect(owner.activatePrompt(reservation)).toBe(reservation)
+    expect(owner.current('session-1')).toBe(reservation)
+    owner.release(reservation)
+  })
+
+  it('lets a newer reservation replace an older pending scope without stale interference', () => {
+    const owner = new AcpSessionInteractionOwner()
+    const first = owner.reservePrompt({ sessionId: 'session-1', kind: 'prompt' })
+    const replacement = owner.reservePrompt({ sessionId: 'session-1', kind: 'prompt' })
+
+    expect(first.signal.aborted).toBe(true)
+    expect(replacement.signal.aborted).toBe(false)
+    expect(() => owner.activatePrompt(first)).toThrow(/superseded/)
+    owner.release(first)
+
+    expect(owner.activatePrompt(replacement)).toBe(replacement)
+    owner.release(first)
+    expect(owner.current('session-1')).toBe(replacement)
+    owner.release(replacement)
+  })
+
+  it('releases an abandoned preflight reservation without leaking ownership', () => {
+    const owner = new AcpSessionInteractionOwner()
+    const abandoned = owner.reservePrompt({ sessionId: 'session-1', kind: 'prompt' })
+
+    owner.release(abandoned)
+    expect(() => owner.activatePrompt(abandoned)).toThrow(/superseded/)
+
+    const next = owner.reservePrompt({ sessionId: 'session-1', kind: 'prompt' })
+    expect(owner.activatePrompt(next)).toBe(next)
+    owner.release(next)
+  })
+
+  it('supersedes pending and active ownership for one session or all sessions', () => {
+    const owner = new AcpSessionInteractionOwner()
+    const pendingReset = owner.reservePrompt({ sessionId: 'session-1', kind: 'prompt' })
+    const activeReset = owner.claim({ sessionId: 'session-1', kind: 'compaction' })
+
+    owner.supersedeCurrent('session-1')
+    expect(pendingReset.signal.aborted).toBe(true)
+    expect(activeReset.signal.aborted).toBe(true)
+    expect(owner.current('session-1')).toBeUndefined()
+    expect(() => owner.activatePrompt(pendingReset)).toThrow(/superseded/)
+
+    const pendingAll = owner.reservePrompt({ sessionId: 'session-2', kind: 'prompt' })
+    const activeAll = owner.claim({ sessionId: 'session-3', kind: 'compaction' })
+    owner.supersedeAll()
+
+    expect(pendingAll.signal.aborted).toBe(true)
+    expect(activeAll.signal.aborted).toBe(true)
+    expect(owner.snapshot()).toEqual([])
+    expect(() => owner.activatePrompt(pendingAll)).toThrow(/superseded/)
+  })
+
   it('supports explicit claim and release while run uses the same lifecycle', async () => {
     const owner = new AcpSessionInteractionOwner()
     const first = owner.claim({ sessionId: 'session-1', kind: 'prompt' })
@@ -64,7 +139,7 @@ describe('AcpSessionInteractionOwner', () => {
     const owner = new AcpSessionInteractionOwner()
     const bothStarted = createDeferred<void>()
     let started = 0
-    const work = async (result: string) => {
+    const work = async (result: string): Promise<string> => {
       started += 1
       if (started === 2) {
         bothStarted.resolve()
@@ -226,9 +301,9 @@ describe('AcpSessionInteractionOwner', () => {
   ])('releases a session after a work %s', async (_name, work) => {
     const owner = new AcpSessionInteractionOwner()
 
-    await expect(
-      owner.run({ sessionId: 'session-1', kind: 'prompt' }, work)
-    ).rejects.toThrow('work failed')
+    await expect(owner.run({ sessionId: 'session-1', kind: 'prompt' }, work)).rejects.toThrow(
+      'work failed'
+    )
     await expect(
       owner.run({ sessionId: 'session-1', kind: 'prompt' }, async () => 'next-result')
     ).resolves.toBe('next-result')

--- a/src/main/acp/session-interaction-owner.ts
+++ b/src/main/acp/session-interaction-owner.ts
@@ -1,5 +1,7 @@
 import { randomUUID } from 'node:crypto'
 
+import type { AcpTurnTokenUsage } from '../../shared/acp'
+
 export type AcpSessionInteractionKind = 'prompt' | 'compaction'
 
 export interface AcpPromptSessionInteractionRequest {
@@ -58,12 +60,33 @@ export interface AcpSessionInteractionOwnerOptions {
   readonly cancelTimeoutMs?: number
   readonly setTimer?: (fn: () => void, ms: number) => ReturnType<typeof setTimeout>
   readonly clearTimer?: (handle: ReturnType<typeof setTimeout>) => void
+  readonly now?: () => number
+}
+
+type AcpSessionInteractionTerminalKind = 'stop' | 'cancelled' | 'error'
+
+interface AcpSessionInteractionTerminalInput {
+  readonly turnUsage?: AcpTurnTokenUsage
+  readonly modelTurnCount?: number
+}
+
+interface AcpSessionInteractionTerminalFacts {
+  readonly timestamp: number
+  readonly turnUsage?: Readonly<AcpTurnTokenUsage>
 }
 
 interface ActiveSessionInteraction {
   readonly scope: AcpSessionInteractionScope
   readonly abortController: AbortController
   cancelled: boolean
+  modelTurnCount: number
+}
+
+interface TerminalSettlement {
+  readonly kind: AcpSessionInteractionTerminalKind
+  readonly timestamp: number
+  readonly modelTurnCount: number
+  settled: boolean
 }
 
 interface CancellationAttempt {
@@ -81,15 +104,21 @@ export class AcpSessionInteractionOwner {
   private readonly pendingPromptReservations = new Map<string, ActiveSessionInteraction>()
   private readonly pendingCancellations = new Map<string, CancellationAttempt>()
   private readonly cancellationTimers = new Map<string, CancellationTimer>()
+  private readonly terminalSettlements = new WeakMap<
+    AcpPromptSessionInteractionScope,
+    TerminalSettlement
+  >()
   private readonly cancelTimeoutMs: number
   private readonly setTimer: (fn: () => void, ms: number) => ReturnType<typeof setTimeout>
   private readonly clearTimer: (handle: ReturnType<typeof setTimeout>) => void
+  private readonly now: () => number
   private sequence = 0
 
   constructor(options: AcpSessionInteractionOwnerOptions = {}) {
     this.cancelTimeoutMs = options.cancelTimeoutMs ?? 5_000
     this.setTimer = options.setTimer ?? ((fn, ms) => setTimeout(fn, ms))
     this.clearTimer = options.clearTimer ?? ((handle) => clearTimeout(handle))
+    this.now = options.now ?? Date.now
   }
 
   current(sessionId: string): AcpSessionInteractionScope | undefined {
@@ -105,6 +134,81 @@ export class AcpSessionInteractionOwner {
         })
       )
     )
+  }
+
+  observeModelTurns(scope: AcpPromptSessionInteractionScope, delta: number): void {
+    if (!Number.isSafeInteger(delta) || delta <= 0) return
+    const active = this.activeInteractions.get(scope.sessionId)
+    if (active?.scope !== scope) return
+    const count = active.modelTurnCount + delta
+    if (Number.isSafeInteger(count)) active.modelTurnCount = count
+  }
+
+  // Freezes the provider-terminal observation time before provider-specific usage collection or
+  // artifact publication can add latency. Repeated capture is allowed until one outcome settles.
+  captureTerminal(
+    scope: AcpPromptSessionInteractionScope,
+    kind: AcpSessionInteractionTerminalKind
+  ): boolean {
+    const terminal = this.terminalSettlements.get(scope)
+    if (terminal) return terminal.kind === kind && !terminal.settled
+
+    const active = this.activeInteractions.get(scope.sessionId)
+    if (active?.scope !== scope) return false
+    this.terminalSettlements.set(scope, {
+      kind,
+      timestamp: this.now(),
+      modelTurnCount: active.modelTurnCount,
+      settled: false
+    })
+    return true
+  }
+
+  settle(
+    scope: AcpPromptSessionInteractionScope,
+    input: AcpSessionInteractionTerminalInput
+  ): AcpSessionInteractionTerminalFacts | undefined {
+    const terminal = this.terminalSettlements.get(scope)
+    if (!terminal || terminal.settled) return undefined
+    terminal.settled = true
+
+    const requestedModelTurnCount = input.modelTurnCount ?? terminal.modelTurnCount
+    const modelTurnCount =
+      Number.isSafeInteger(requestedModelTurnCount) && requestedModelTurnCount > 0
+        ? requestedModelTurnCount
+        : undefined
+    const turnUsage = input.turnUsage
+      ? Object.freeze({
+          ...input.turnUsage,
+          ...(modelTurnCount === undefined ? {} : { turnCount: modelTurnCount })
+        })
+      : undefined
+    return Object.freeze({
+      timestamp: terminal.timestamp,
+      ...(turnUsage ? { turnUsage } : {})
+    })
+  }
+
+  // Unexpected protocol closure has no provider response to route through sendPrompt. Settle every
+  // visible prompt here so teardown can publish one owner-timestamped failure per App Session.
+  settleActivePrompts(): ReadonlyArray<{
+    readonly scope: AcpPromptSessionInteractionScope
+    readonly terminal: AcpSessionInteractionTerminalFacts
+  }> {
+    const settled: Array<{
+      scope: AcpPromptSessionInteractionScope
+      terminal: AcpSessionInteractionTerminalFacts
+    }> = []
+    for (const active of this.activeInteractions.values()) {
+      if (active.scope.kind !== 'prompt') continue
+      // A provider stop/cancellation already observed by sendPrompt owns the outcome even if
+      // connection teardown releases its public activity lock before usage finalization completes.
+      if (this.terminalSettlements.has(active.scope)) continue
+      if (!this.captureTerminal(active.scope, 'error')) continue
+      const terminal = this.settle(active.scope, {})
+      if (terminal) settled.push({ scope: active.scope, terminal })
+    }
+    return settled
   }
 
   isCancellationAccepted(scope: AcpSessionInteractionScope): boolean {
@@ -210,7 +314,8 @@ export class AcpSessionInteractionOwner {
     this.pendingPromptReservations.set(request.sessionId, {
       scope,
       abortController,
-      cancelled: false
+      cancelled: false,
+      modelTurnCount: 0
     })
 
     return scope
@@ -252,7 +357,12 @@ export class AcpSessionInteractionOwner {
           }
         : { ...base, kind: request.kind }
     )
-    this.activeInteractions.set(request.sessionId, { scope, abortController, cancelled: false })
+    this.activeInteractions.set(request.sessionId, {
+      scope,
+      abortController,
+      cancelled: false,
+      modelTurnCount: 0
+    })
 
     return scope as ScopeFor<Request>
   }

--- a/src/main/acp/session-interaction-owner.ts
+++ b/src/main/acp/session-interaction-owner.ts
@@ -80,13 +80,21 @@ export class AcpSessionInteractionOwner {
     if (active?.scope !== scope) return
 
     active.abortController.abort()
-    this.activeInteractions.delete(scope.sessionId)
+    this.release(scope)
   }
 
-  async run<T, Request extends AcpSessionInteractionRequest>(
-    request: Request,
-    work: (scope: ScopeFor<Request>) => Promise<T>
-  ): Promise<T> {
+  supersedeCurrent(sessionId: string): void {
+    const scope = this.current(sessionId)
+    if (scope) this.supersede(scope)
+  }
+
+  supersedeAll(): void {
+    for (const { scope } of Array.from(this.activeInteractions.values())) {
+      this.supersede(scope)
+    }
+  }
+
+  claim<Request extends AcpSessionInteractionRequest>(request: Request): ScopeFor<Request> {
     if (this.activeInteractions.has(request.sessionId)) {
       throw new Error('An ACP interaction is already running for this session')
     }
@@ -107,15 +115,27 @@ export class AcpSessionInteractionOwner {
           }
         : { ...base, kind: request.kind }
     )
-    const active = { scope, abortController }
-    this.activeInteractions.set(request.sessionId, active)
+    this.activeInteractions.set(request.sessionId, { scope, abortController })
+
+    return scope as ScopeFor<Request>
+  }
+
+  release(scope: AcpSessionInteractionScope): void {
+    if (this.activeInteractions.get(scope.sessionId)?.scope === scope) {
+      this.activeInteractions.delete(scope.sessionId)
+    }
+  }
+
+  async run<T, Request extends AcpSessionInteractionRequest>(
+    request: Request,
+    work: (scope: ScopeFor<Request>) => Promise<T>
+  ): Promise<T> {
+    const scope = this.claim(request)
 
     try {
-      return await work(scope as ScopeFor<Request>)
+      return await work(scope)
     } finally {
-      if (this.activeInteractions.get(request.sessionId) === active) {
-        this.activeInteractions.delete(request.sessionId)
-      }
+      this.release(scope)
     }
   }
 }

--- a/src/main/acp/session-interaction-owner.ts
+++ b/src/main/acp/session-interaction-owner.ts
@@ -15,8 +15,7 @@ export interface AcpCompactionSessionInteractionRequest {
 }
 
 export type AcpSessionInteractionRequest =
-  | AcpPromptSessionInteractionRequest
-  | AcpCompactionSessionInteractionRequest
+  AcpPromptSessionInteractionRequest | AcpCompactionSessionInteractionRequest
 
 interface AcpSessionInteractionScopeBase {
   readonly sessionId: string
@@ -35,8 +34,7 @@ export interface AcpCompactionSessionInteractionScope extends AcpSessionInteract
 }
 
 export type AcpSessionInteractionScope =
-  | AcpPromptSessionInteractionScope
-  | AcpCompactionSessionInteractionScope
+  AcpPromptSessionInteractionScope | AcpCompactionSessionInteractionScope
 
 type ScopeFor<Request extends AcpSessionInteractionRequest> = Request extends {
   readonly kind: 'prompt'
@@ -56,6 +54,7 @@ interface ActiveSessionInteraction {
 
 export class AcpSessionInteractionOwner {
   private readonly activeInteractions = new Map<string, ActiveSessionInteraction>()
+  private readonly pendingPromptReservations = new Map<string, ActiveSessionInteraction>()
   private sequence = 0
 
   current(sessionId: string): AcpSessionInteractionScope | undefined {
@@ -77,21 +76,61 @@ export class AcpSessionInteractionOwner {
   // later cleanup remains guarded by scope identity and cannot clear a replacement interaction.
   supersede(scope: AcpSessionInteractionScope): void {
     const active = this.activeInteractions.get(scope.sessionId)
-    if (active?.scope !== scope) return
+    const pending = this.pendingPromptReservations.get(scope.sessionId)
+    const owned = active?.scope === scope ? active : pending?.scope === scope ? pending : undefined
+    if (!owned) return
 
-    active.abortController.abort()
+    owned.abortController.abort()
     this.release(scope)
   }
 
   supersedeCurrent(sessionId: string): void {
-    const scope = this.current(sessionId)
-    if (scope) this.supersede(scope)
+    const activeScope = this.activeInteractions.get(sessionId)?.scope
+    const pendingScope = this.pendingPromptReservations.get(sessionId)?.scope
+    if (activeScope) this.supersede(activeScope)
+    if (pendingScope) this.supersede(pendingScope)
   }
 
   supersedeAll(): void {
-    for (const { scope } of Array.from(this.activeInteractions.values())) {
+    const owned = [...this.activeInteractions.values(), ...this.pendingPromptReservations.values()]
+    for (const { scope } of owned) {
       this.supersede(scope)
     }
+  }
+
+  reservePrompt(request: AcpPromptSessionInteractionRequest): AcpPromptSessionInteractionScope {
+    if (this.activeInteractions.has(request.sessionId)) {
+      throw new Error('An ACP interaction is already running for this session')
+    }
+
+    const abortController = new AbortController()
+    const scope: AcpPromptSessionInteractionScope = Object.freeze({
+      sessionId: request.sessionId,
+      kind: 'prompt',
+      promptMessageId: request.promptMessageId,
+      turnToken: request.turnToken ?? randomUUID(),
+      sequence: ++this.sequence,
+      signal: abortController.signal
+    })
+    this.pendingPromptReservations.get(request.sessionId)?.abortController.abort()
+    this.pendingPromptReservations.set(request.sessionId, { scope, abortController })
+
+    return scope
+  }
+
+  activatePrompt(scope: AcpPromptSessionInteractionScope): AcpPromptSessionInteractionScope {
+    if (this.activeInteractions.has(scope.sessionId)) {
+      throw new Error('An ACP interaction is already running for this session')
+    }
+
+    const pending = this.pendingPromptReservations.get(scope.sessionId)
+    if (pending?.scope !== scope) {
+      throw new Error('ACP prompt reservation was superseded')
+    }
+
+    this.pendingPromptReservations.delete(scope.sessionId)
+    this.activeInteractions.set(scope.sessionId, pending)
+    return scope
   }
 
   claim<Request extends AcpSessionInteractionRequest>(request: Request): ScopeFor<Request> {
@@ -123,6 +162,11 @@ export class AcpSessionInteractionOwner {
   release(scope: AcpSessionInteractionScope): void {
     if (this.activeInteractions.get(scope.sessionId)?.scope === scope) {
       this.activeInteractions.delete(scope.sessionId)
+      return
+    }
+
+    if (this.pendingPromptReservations.get(scope.sessionId)?.scope === scope) {
+      this.pendingPromptReservations.delete(scope.sessionId)
     }
   }
 

--- a/src/main/acp/session-interaction-owner.ts
+++ b/src/main/acp/session-interaction-owner.ts
@@ -1,0 +1,121 @@
+import { randomUUID } from 'node:crypto'
+
+export type AcpSessionInteractionKind = 'prompt' | 'compaction'
+
+export interface AcpPromptSessionInteractionRequest {
+  readonly sessionId: string
+  readonly kind: 'prompt'
+  readonly promptMessageId?: string
+  readonly turnToken?: string
+}
+
+export interface AcpCompactionSessionInteractionRequest {
+  readonly sessionId: string
+  readonly kind: 'compaction'
+}
+
+export type AcpSessionInteractionRequest =
+  | AcpPromptSessionInteractionRequest
+  | AcpCompactionSessionInteractionRequest
+
+interface AcpSessionInteractionScopeBase {
+  readonly sessionId: string
+  readonly sequence: number
+  readonly signal: AbortSignal
+}
+
+export interface AcpPromptSessionInteractionScope extends AcpSessionInteractionScopeBase {
+  readonly kind: 'prompt'
+  readonly promptMessageId?: string
+  readonly turnToken: string
+}
+
+export interface AcpCompactionSessionInteractionScope extends AcpSessionInteractionScopeBase {
+  readonly kind: 'compaction'
+}
+
+export type AcpSessionInteractionScope =
+  | AcpPromptSessionInteractionScope
+  | AcpCompactionSessionInteractionScope
+
+type ScopeFor<Request extends AcpSessionInteractionRequest> = Request extends {
+  readonly kind: 'prompt'
+}
+  ? AcpPromptSessionInteractionScope
+  : AcpCompactionSessionInteractionScope
+
+export interface AcpSessionInteractionSnapshotEntry {
+  readonly sessionId: string
+  readonly kind: AcpSessionInteractionKind
+}
+
+interface ActiveSessionInteraction {
+  readonly scope: AcpSessionInteractionScope
+  readonly abortController: AbortController
+}
+
+export class AcpSessionInteractionOwner {
+  private readonly activeInteractions = new Map<string, ActiveSessionInteraction>()
+  private sequence = 0
+
+  current(sessionId: string): AcpSessionInteractionScope | undefined {
+    return this.activeInteractions.get(sessionId)?.scope
+  }
+
+  snapshot(): readonly AcpSessionInteractionSnapshotEntry[] {
+    return Object.freeze(
+      Array.from(this.activeInteractions.values(), ({ scope }) =>
+        Object.freeze({
+          sessionId: scope.sessionId,
+          kind: scope.kind
+        })
+      )
+    )
+  }
+
+  // Signals the displaced work and releases the slot immediately. The work may still unwind, so every
+  // later cleanup remains guarded by scope identity and cannot clear a replacement interaction.
+  supersede(scope: AcpSessionInteractionScope): void {
+    const active = this.activeInteractions.get(scope.sessionId)
+    if (active?.scope !== scope) return
+
+    active.abortController.abort()
+    this.activeInteractions.delete(scope.sessionId)
+  }
+
+  async run<T, Request extends AcpSessionInteractionRequest>(
+    request: Request,
+    work: (scope: ScopeFor<Request>) => Promise<T>
+  ): Promise<T> {
+    if (this.activeInteractions.has(request.sessionId)) {
+      throw new Error('An ACP interaction is already running for this session')
+    }
+
+    const abortController = new AbortController()
+    const base = {
+      sessionId: request.sessionId,
+      sequence: ++this.sequence,
+      signal: abortController.signal
+    }
+    const scope: AcpSessionInteractionScope = Object.freeze(
+      request.kind === 'prompt'
+        ? {
+            ...base,
+            kind: request.kind,
+            promptMessageId: request.promptMessageId,
+            turnToken: request.turnToken ?? randomUUID()
+          }
+        : { ...base, kind: request.kind }
+    )
+    const active = { scope, abortController }
+    this.activeInteractions.set(request.sessionId, active)
+
+    try {
+      return await work(scope as ScopeFor<Request>)
+    } finally {
+      if (this.activeInteractions.get(request.sessionId) === active) {
+        this.activeInteractions.delete(request.sessionId)
+      }
+    }
+  }
+}

--- a/src/main/acp/session-interaction-owner.ts
+++ b/src/main/acp/session-interaction-owner.ts
@@ -47,15 +47,50 @@ export interface AcpSessionInteractionSnapshotEntry {
   readonly kind: AcpSessionInteractionKind
 }
 
+export interface AcpSessionInteractionCancellationRequest {
+  readonly sessionId: string
+  readonly notify: () => Promise<void>
+  readonly onAccepted: () => void
+  readonly onTimeout: () => void
+}
+
+export interface AcpSessionInteractionOwnerOptions {
+  readonly cancelTimeoutMs?: number
+  readonly setTimer?: (fn: () => void, ms: number) => ReturnType<typeof setTimeout>
+  readonly clearTimer?: (handle: ReturnType<typeof setTimeout>) => void
+}
+
 interface ActiveSessionInteraction {
   readonly scope: AcpSessionInteractionScope
   readonly abortController: AbortController
+  cancelled: boolean
+}
+
+interface CancellationAttempt {
+  readonly promise: Promise<void>
+  readonly settle: () => void
+}
+
+interface CancellationTimer {
+  readonly scope: AcpSessionInteractionScope | undefined
+  handle?: ReturnType<typeof setTimeout>
 }
 
 export class AcpSessionInteractionOwner {
   private readonly activeInteractions = new Map<string, ActiveSessionInteraction>()
   private readonly pendingPromptReservations = new Map<string, ActiveSessionInteraction>()
+  private readonly pendingCancellations = new Map<string, CancellationAttempt>()
+  private readonly cancellationTimers = new Map<string, CancellationTimer>()
+  private readonly cancelTimeoutMs: number
+  private readonly setTimer: (fn: () => void, ms: number) => ReturnType<typeof setTimeout>
+  private readonly clearTimer: (handle: ReturnType<typeof setTimeout>) => void
   private sequence = 0
+
+  constructor(options: AcpSessionInteractionOwnerOptions = {}) {
+    this.cancelTimeoutMs = options.cancelTimeoutMs ?? 5_000
+    this.setTimer = options.setTimer ?? ((fn, ms) => setTimeout(fn, ms))
+    this.clearTimer = options.clearTimer ?? ((handle) => clearTimeout(handle))
+  }
 
   current(sessionId: string): AcpSessionInteractionScope | undefined {
     return this.activeInteractions.get(sessionId)?.scope
@@ -70,6 +105,62 @@ export class AcpSessionInteractionOwner {
         })
       )
     )
+  }
+
+  isCancellationAccepted(scope: AcpSessionInteractionScope): boolean {
+    const active = this.activeInteractions.get(scope.sessionId)
+    return active?.scope === scope && active.cancelled
+  }
+
+  async cancellationCheckpoint(scope: AcpSessionInteractionScope): Promise<'active' | 'cancelled'> {
+    for (;;) {
+      const attempt = this.pendingCancellations.get(scope.sessionId)
+      if (!attempt) return this.isCancellationAccepted(scope) ? 'cancelled' : 'active'
+      await attempt.promise
+    }
+  }
+
+  async cancelPrompt(request: AcpSessionInteractionCancellationRequest): Promise<void> {
+    let settle!: () => void
+    const attempt: CancellationAttempt = {
+      promise: new Promise<void>((resolve) => {
+        settle = resolve
+      }),
+      settle: () => settle()
+    }
+    this.pendingCancellations.set(request.sessionId, attempt)
+
+    const active = this.activeInteractions.get(request.sessionId)
+    const scope = active?.scope
+    active?.abortController.abort()
+    this.clearCancellationTimer(request.sessionId)
+
+    const timer: CancellationTimer = { scope }
+    timer.handle = this.setTimer(() => {
+      if (this.cancellationTimers.get(request.sessionId) !== timer) return
+      this.cancellationTimers.delete(request.sessionId)
+      if (scope && this.current(request.sessionId) === scope) request.onTimeout()
+    }, this.cancelTimeoutMs)
+    this.cancellationTimers.set(request.sessionId, timer)
+
+    let accepted = false
+    try {
+      await request.notify()
+      if (active && this.activeInteractions.get(request.sessionId) === active) {
+        active.cancelled = true
+      }
+      accepted = true
+    } catch (error) {
+      this.clearCancellationTimer(request.sessionId, timer)
+      throw error
+    } finally {
+      attempt.settle()
+      if (this.pendingCancellations.get(request.sessionId) === attempt) {
+        this.pendingCancellations.delete(request.sessionId)
+      }
+    }
+
+    if (accepted) request.onAccepted()
   }
 
   // Signals the displaced work and releases the slot immediately. The work may still unwind, so every
@@ -96,6 +187,9 @@ export class AcpSessionInteractionOwner {
     for (const { scope } of owned) {
       this.supersede(scope)
     }
+    for (const sessionId of Array.from(this.cancellationTimers.keys())) {
+      this.clearCancellationTimer(sessionId)
+    }
   }
 
   reservePrompt(request: AcpPromptSessionInteractionRequest): AcpPromptSessionInteractionScope {
@@ -113,7 +207,11 @@ export class AcpSessionInteractionOwner {
       signal: abortController.signal
     })
     this.pendingPromptReservations.get(request.sessionId)?.abortController.abort()
-    this.pendingPromptReservations.set(request.sessionId, { scope, abortController })
+    this.pendingPromptReservations.set(request.sessionId, {
+      scope,
+      abortController,
+      cancelled: false
+    })
 
     return scope
   }
@@ -154,13 +252,17 @@ export class AcpSessionInteractionOwner {
           }
         : { ...base, kind: request.kind }
     )
-    this.activeInteractions.set(request.sessionId, { scope, abortController })
+    this.activeInteractions.set(request.sessionId, { scope, abortController, cancelled: false })
 
     return scope as ScopeFor<Request>
   }
 
   release(scope: AcpSessionInteractionScope): void {
     if (this.activeInteractions.get(scope.sessionId)?.scope === scope) {
+      const timer = this.cancellationTimers.get(scope.sessionId)
+      if (!timer?.scope || timer.scope === scope) {
+        this.clearCancellationTimer(scope.sessionId, timer)
+      }
       this.activeInteractions.delete(scope.sessionId)
       return
     }
@@ -168,6 +270,13 @@ export class AcpSessionInteractionOwner {
     if (this.pendingPromptReservations.get(scope.sessionId)?.scope === scope) {
       this.pendingPromptReservations.delete(scope.sessionId)
     }
+  }
+
+  private clearCancellationTimer(sessionId: string, expected?: CancellationTimer): void {
+    const timer = this.cancellationTimers.get(sessionId)
+    if (!timer || (expected && timer !== expected)) return
+    if (timer.handle !== undefined) this.clearTimer(timer.handle)
+    this.cancellationTimers.delete(sessionId)
   }
 
   async run<T, Request extends AcpSessionInteractionRequest>(


### PR DESCRIPTION
## Problem

`AcpRuntime` owned prompt admission, compaction exclusion, cancellation, turn identity, model-turn accounting, and terminal publication through separate mutable collections. Their cleanup paths could drift across reset, reconnect, provider adoption, and delayed async finalization.

## Proposed change

- Add `AcpSessionInteractionOwner` as the single owner of prompt reservations, active prompt/compaction generations, cancellation state, and public in-flight projection.
- Move prompt admission and cancellation lifecycle out of `AcpRuntime`, while keeping Provider RPC notifications, Permission side effects, and event publication in the runtime.
- Capture prompt terminal outcome/time once, finalize immutable usage facts once, and preserve an observed stop across context reset or unexpected connection close without retaining the public activity lock.
- Move Claude model-turn accumulation into the interaction generation and retain Codex/OpenCode usage parsing in their existing Provider-specific runtime paths.
- Guard automatic compaction by both interaction generation and the attached Provider session so a replaced turn cannot compact using its successor's usage.

```mermaid
flowchart LR
  P["Provider stop / error / cancellation"] --> C["Interaction owner captures outcome + timestamp"]
  C --> A["Runtime finalizes artifacts and Provider-specific usage"]
  A --> S["Owner settles immutable facts exactly once"]
  S --> E["Runtime publishes terminal event"]
  R["Reset / close"] --> L["Release active interaction lock"]
  L --> D{"Outcome already captured?"}
  D -->|yes| A
  D -->|no| F["Settle one connection failure"]
```

## Scope and non-goals

- No renderer, IPC, persistence, data-model, or public API change.
- Electron, Web, CLI, and Task paths continue through the existing runtime contracts.
- Existing Specialist, Permission, and Compute capability asymmetry is unchanged.
- No orchestration state or interface from #458 is introduced; the new owner is limited to one session interaction lifecycle.
- `docs/internal/` planning material remains ignored and is not part of this PR.

Related: #458

## Acceptance criteria and validation

All listed checks ran after the final material edit.

- Prompt admission, generation replacement, cancellation, terminal exactly-once, timestamp, usage/count, close/reset races, and auto-compaction ownership -> `npm test -- --run src/main/acp/session-interaction-owner.test.ts src/main/acp/runtime.test.ts` -> 2 files passed, 398 tests passed.
- Node and renderer contract compatibility -> `npm run typecheck` -> passed.
- Repository lint -> `npm run lint` -> passed with 0 errors; 19 pre-existing warnings outside the changed files.
- Repository regression suite -> `npm test -- --run` -> 675 files passed, 15 skipped; 9,927 tests passed, 184 skipped.
- Patch integrity -> `git diff --check origin/main...HEAD` -> passed.
- Independent spec and standards reviews -> 0 Hard findings.

Uncovered risk: deterministic in-memory ACP tests exercise the close/reset races, but real external Provider process timing is not covered by a separate end-to-end journey. No UI journey was added because the IPC and renderer contracts are unchanged.

## Review focus

- Whether `AcpSessionInteractionOwner` is the correct ownership boundary without absorbing Provider parsing or Permission policy.
- The capture -> settle-once protocol and detached terminal completion during reset/close.
- The interaction-generation plus Provider-attachment guard around automatic compaction.
