### PR TITLE
refactor(acp): own connection resource publication

### DIFF
--- a/src/main/acp/connection-resource-owner.test.ts
+++ b/src/main/acp/connection-resource-owner.test.ts
@@ -47,6 +47,7 @@ describe('AcpConnectionResourceOwner', () => {
     })
 
     const first = owner.connect(operation)
+    expect(operation).toHaveBeenCalledOnce()
     const secondOperation = vi.fn(async (attempt: AcpConnectionResourceAttempt) =>
       attachAndPublish(attempt, 'unexpected')
     )
@@ -60,6 +61,32 @@ describe('AcpConnectionResourceOwner', () => {
     expect(secondOperation).not.toHaveBeenCalled()
     expect(secondHandle).toBe(firstHandle)
     expect(owner.connection).toBe(firstHandle.connection)
+  })
+
+  it('keeps an attached resource provisional until publication', async () => {
+    const owner = new AcpConnectionResourceOwner()
+    const attached = createDeferred()
+    const canPublish = createDeferred()
+    const pending = owner.connect(async (attempt) => {
+      attempt.attach({
+        process: process('provisional'),
+        connection: connection('provisional'),
+        framework: 'opencode',
+        bridgeLease: undefined
+      })
+      attached.resolve()
+      await canPublish.promise
+      return attempt.publish({ close: false, delete: false, resume: true })
+    })
+
+    await attached.promise
+    expect(owner.connection).toBeUndefined()
+    expect(owner.capabilities).toEqual({ close: false, delete: false, resume: false })
+
+    canPublish.resolve()
+    const handle = await pending
+    expect(owner.connection).toBe(handle.connection)
+    expect(owner.capabilities.resume).toBe(true)
   })
 
   it('prevents a superseded attempt from publishing its attached resource', async () => {
@@ -90,6 +117,7 @@ describe('AcpConnectionResourceOwner', () => {
     const owner = new AcpConnectionResourceOwner()
     const first = await owner.connect(async (attempt) => attachAndPublish(attempt, 'first'))
     const firstTeardownEpoch = owner.supersede()
+    expect(owner.connection).toBeUndefined()
     const detachedFirst = owner.detach(firstTeardownEpoch)
     expect(detachedFirst?.connection).toBe(first.connection)
     expect(owner.detach(firstTeardownEpoch)).toBeUndefined()

--- a/src/main/acp/connection-resource-owner.test.ts
+++ b/src/main/acp/connection-resource-owner.test.ts
@@ -133,6 +133,49 @@ describe('AcpConnectionResourceOwner', () => {
     expect(() => replacement.assertCurrent()).toThrow('ACP connection was superseded.')
   })
 
+  it('restores only a still-attached published resource after teardown fails', async () => {
+    const owner = new AcpConnectionResourceOwner()
+    const handle = await owner.connect(async (attempt) => attachAndPublish(attempt, 'restored'))
+    const teardownEpoch = owner.supersede()
+
+    expect(owner.connection).toBeUndefined()
+    expect(owner.restorePublished(teardownEpoch)).toBe(true)
+    expect(owner.connection).toBe(handle.connection)
+
+    const staleEpoch = teardownEpoch
+    const replacementTeardownEpoch = owner.supersede()
+    expect(owner.restorePublished(staleEpoch)).toBe(false)
+    expect(owner.detach(replacementTeardownEpoch)?.connection).toBe(handle.connection)
+    expect(owner.restorePublished(replacementTeardownEpoch)).toBe(false)
+    expect(owner.connection).toBeUndefined()
+  })
+
+  it('never promotes a provisional resource through teardown rollback', async () => {
+    const owner = new AcpConnectionResourceOwner()
+    const attached = createDeferred()
+    const canPublish = createDeferred()
+    const pending = owner.connect(async (attempt) => {
+      attempt.attach({
+        process: process('provisional'),
+        connection: connection('provisional'),
+        framework: 'codex',
+        bridgeLease: undefined
+      })
+      attached.resolve()
+      await canPublish.promise
+      return attempt.publish({ close: false, delete: false, resume: false })
+    })
+    await attached.promise
+
+    const teardownEpoch = owner.supersede()
+    expect(owner.restorePublished(teardownEpoch)).toBe(false)
+    expect(owner.connection).toBeUndefined()
+
+    canPublish.resolve()
+    await expect(pending).rejects.toThrow('ACP connection was superseded.')
+    expect(owner.detach(teardownEpoch)?.connection).toMatchObject({ id: 'provisional' })
+  })
+
   it('exposes an immutable ready handle without process or bridge release authority', async () => {
     const owner = new AcpConnectionResourceOwner()
     const handle = await owner.connect(async (attempt) => attachAndPublish(attempt, 'ready'))

--- a/src/main/acp/connection-resource-owner.test.ts
+++ b/src/main/acp/connection-resource-owner.test.ts
@@ -1,0 +1,125 @@
+import type { ClientConnection } from '@agentclientprotocol/sdk'
+import type { ChildProcessWithoutNullStreams } from 'node:child_process'
+import { describe, expect, it, vi } from 'vitest'
+
+import {
+  AcpConnectionResourceOwner,
+  type AcpConnectionResourceAttempt
+} from './connection-resource-owner'
+
+type Deferred = {
+  promise: Promise<void>
+  resolve: () => void
+}
+
+const createDeferred = (): Deferred => {
+  let resolve!: () => void
+  const promise = new Promise<void>((resolvePromise) => {
+    resolve = resolvePromise
+  })
+  return { promise, resolve }
+}
+
+const connection = (id: string): ClientConnection => ({ id }) as unknown as ClientConnection
+const process = (id: string): ChildProcessWithoutNullStreams =>
+  ({ id }) as unknown as ChildProcessWithoutNullStreams
+
+const attachAndPublish = (
+  attempt: AcpConnectionResourceAttempt,
+  id: string
+): ReturnType<AcpConnectionResourceAttempt['publish']> => {
+  attempt.attach({
+    process: process(id),
+    connection: connection(id),
+    framework: 'claude-code',
+    bridgeLease: undefined
+  })
+  return attempt.publish({ close: true, delete: false, resume: true })
+}
+
+describe('AcpConnectionResourceOwner', () => {
+  it('shares one publication attempt across concurrent connect callers', async () => {
+    const owner = new AcpConnectionResourceOwner()
+    const canPublish = createDeferred()
+    const operation = vi.fn(async (attempt: AcpConnectionResourceAttempt) => {
+      await canPublish.promise
+      return attachAndPublish(attempt, 'shared')
+    })
+
+    const first = owner.connect(operation)
+    const secondOperation = vi.fn(async (attempt: AcpConnectionResourceAttempt) =>
+      attachAndPublish(attempt, 'unexpected')
+    )
+    const second = owner.connect(secondOperation)
+
+    expect(second).toBe(first)
+    canPublish.resolve()
+    const [firstHandle, secondHandle] = await Promise.all([first, second])
+
+    expect(operation).toHaveBeenCalledOnce()
+    expect(secondOperation).not.toHaveBeenCalled()
+    expect(secondHandle).toBe(firstHandle)
+    expect(owner.connection).toBe(firstHandle.connection)
+  })
+
+  it('prevents a superseded attempt from publishing its attached resource', async () => {
+    const owner = new AcpConnectionResourceOwner()
+    const attached = createDeferred()
+    const canPublish = createDeferred()
+    const pending = owner.connect(async (attempt) => {
+      attempt.attach({
+        process: process('stale'),
+        connection: connection('stale'),
+        framework: 'codex',
+        bridgeLease: undefined
+      })
+      attached.resolve()
+      await canPublish.promise
+      return attempt.publish({ close: false, delete: false, resume: false })
+    })
+    await attached.promise
+
+    const teardownEpoch = owner.supersede()
+    canPublish.resolve()
+
+    await expect(pending).rejects.toThrow('ACP connection was superseded.')
+    expect(owner.detach(teardownEpoch)?.connection).toMatchObject({ id: 'stale' })
+  })
+
+  it('transfers each resource once and ignores a stale detach after replacement', async () => {
+    const owner = new AcpConnectionResourceOwner()
+    const first = await owner.connect(async (attempt) => attachAndPublish(attempt, 'first'))
+    const firstTeardownEpoch = owner.supersede()
+    const detachedFirst = owner.detach(firstTeardownEpoch)
+    expect(detachedFirst?.connection).toBe(first.connection)
+    expect(owner.detach(firstTeardownEpoch)).toBeUndefined()
+
+    const replacement = await owner.connect(async (attempt) =>
+      attachAndPublish(attempt, 'replacement')
+    )
+    expect(owner.detach(firstTeardownEpoch)).toBeUndefined()
+    replacement.assertCurrent()
+    expect(owner.connection).toBe(replacement.connection)
+
+    expect(owner.detach(owner.epoch)?.connection).toBe(replacement.connection)
+    expect(() => replacement.assertCurrent()).toThrow('ACP connection was superseded.')
+  })
+
+  it('exposes an immutable ready handle without process or bridge release authority', async () => {
+    const owner = new AcpConnectionResourceOwner()
+    const handle = await owner.connect(async (attempt) => attachAndPublish(attempt, 'ready'))
+
+    expect(Object.keys(handle).sort()).toEqual([
+      'assertCurrent',
+      'capabilities',
+      'connection',
+      'epoch',
+      'framework'
+    ])
+    expect(Object.isFrozen(handle)).toBe(true)
+    expect(Object.isFrozen(handle.capabilities)).toBe(true)
+    expect(handle).not.toHaveProperty('process')
+    expect(handle).not.toHaveProperty('bridgeLease')
+    expect(handle).not.toHaveProperty('release')
+  })
+})

--- a/src/main/acp/connection-resource-owner.ts
+++ b/src/main/acp/connection-resource-owner.ts
@@ -1,0 +1,178 @@
+import type { ClientConnection } from '@agentclientprotocol/sdk'
+import type { ChildProcessWithoutNullStreams } from 'node:child_process'
+
+import type { AgentFramework, ResolvedAgentBackend } from '../agent-framework'
+
+type ResponsesBridgeLease = ResolvedAgentBackend['responsesBridgeLease']
+
+export type AcpConnectionCapabilities = Readonly<{
+  close: boolean
+  delete: boolean
+  resume: boolean
+}>
+
+export type AcpAttachedConnectionResource = {
+  process: ChildProcessWithoutNullStreams
+  connection: ClientConnection
+  framework: AgentFramework['id']
+  bridgeLease: ResponsesBridgeLease
+}
+
+export type AcpDetachedConnectionResource = AcpAttachedConnectionResource & {
+  capabilities: AcpConnectionCapabilities
+}
+
+export type AcpConnectionResourceReadyHandle = Readonly<{
+  epoch: number
+  connection: ClientConnection
+  framework: AgentFramework['id']
+  capabilities: AcpConnectionCapabilities
+  assertCurrent: () => void
+}>
+
+export type AcpConnectionResourceAttempt = Readonly<{
+  epoch: number
+  attach: (resource: AcpAttachedConnectionResource) => void
+  publish: (capabilities: AcpConnectionCapabilities) => AcpConnectionResourceReadyHandle
+  assertCurrent: () => void
+  owns: (connection: ClientConnection) => boolean
+}>
+
+type CurrentResource = AcpAttachedConnectionResource & {
+  epoch: number
+  capabilities: AcpConnectionCapabilities
+}
+
+const EMPTY_CAPABILITIES: AcpConnectionCapabilities = Object.freeze({
+  close: false,
+  delete: false,
+  resume: false
+})
+
+// Owns connection publication, identity, and exclusive resource transfer. Runtime ports still perform
+// spawn/initialize and physical teardown in A9.1a1; attach/detach prevents either side from retaining a
+// second mutable owner while those effects move behind this module in A9.1a2.
+export class AcpConnectionResourceOwner {
+  private resourceEpoch = 0
+  private current: CurrentResource | undefined
+  private connectInFlight: Promise<AcpConnectionResourceReadyHandle> | undefined
+
+  get epoch(): number {
+    return this.resourceEpoch
+  }
+
+  get connection(): ClientConnection | undefined {
+    return this.current?.connection
+  }
+
+  get capabilities(): AcpConnectionCapabilities {
+    return this.current?.capabilities ?? EMPTY_CAPABILITIES
+  }
+
+  get inFlight(): Promise<AcpConnectionResourceReadyHandle> | undefined {
+    return this.connectInFlight
+  }
+
+  get bridgeSkillsAvailable(): boolean {
+    return Boolean(this.current?.bridgeLease?.selectSkills)
+  }
+
+  connect(
+    operation: (
+      attempt: AcpConnectionResourceAttempt
+    ) => Promise<AcpConnectionResourceReadyHandle>
+  ): Promise<AcpConnectionResourceReadyHandle> {
+    if (this.connectInFlight) return this.connectInFlight
+
+    const epoch = this.supersede()
+    const attempt = this.createAttempt(epoch)
+    const connect = Promise.resolve().then(() => operation(attempt))
+    this.connectInFlight = connect
+    const clear = (): void => {
+      if (this.connectInFlight === connect) this.connectInFlight = undefined
+    }
+    void connect.then(clear, clear)
+    return connect
+  }
+
+  supersede(): number {
+    this.resourceEpoch += 1
+    this.connectInFlight = undefined
+    return this.resourceEpoch
+  }
+
+  detach(expectedEpoch = this.resourceEpoch): AcpDetachedConnectionResource | undefined {
+    if (expectedEpoch !== this.resourceEpoch) return undefined
+    const resource = this.current
+    this.current = undefined
+    if (!resource) return undefined
+    return resource
+  }
+
+  assertCurrentConnection(connection: ClientConnection): void {
+    if (this.current?.connection !== connection) {
+      throw new Error('ACP session startup was superseded.')
+    }
+  }
+
+  registerBridgeReviewerSession(sessionId: string): void {
+    this.current?.bridgeLease?.registerReviewerSession(sessionId)
+  }
+
+  unregisterBridgeReviewerSession(sessionId: string): boolean | undefined {
+    return this.current?.bridgeLease?.unregisterReviewerSession(sessionId)
+  }
+
+  setBridgeReasoningEffort(
+    effort: Parameters<
+      NonNullable<NonNullable<ResponsesBridgeLease>['setReasoningEffort']>
+    >[0]
+  ): void {
+    this.current?.bridgeLease?.setReasoningEffort?.(effort)
+  }
+
+  async selectBridgeSkills(
+    text: Parameters<NonNullable<ResponsesBridgeLease>['selectSkills']>[0],
+    catalog: Parameters<NonNullable<ResponsesBridgeLease>['selectSkills']>[1],
+    signal?: Parameters<NonNullable<ResponsesBridgeLease>['selectSkills']>[2]
+  ): Promise<Awaited<ReturnType<NonNullable<ResponsesBridgeLease>['selectSkills']>> | undefined> {
+    return this.current?.bridgeLease?.selectSkills(text, catalog, signal)
+  }
+
+  private createAttempt(epoch: number): AcpConnectionResourceAttempt {
+    const assertCurrent = (): void => {
+      if (epoch !== this.resourceEpoch) throw new Error('ACP connection was superseded.')
+    }
+
+    return Object.freeze({
+      epoch,
+      assertCurrent,
+      attach: (resource) => {
+        assertCurrent()
+        if (this.current) throw new Error('ACP connection resource is already attached.')
+        this.current = { ...resource, epoch, capabilities: EMPTY_CAPABILITIES }
+      },
+      publish: (capabilities) => {
+        assertCurrent()
+        const resource = this.current
+        if (!resource || resource.epoch !== epoch) {
+          throw new Error('ACP connection resource is not attached.')
+        }
+        resource.capabilities = Object.freeze({ ...capabilities })
+        const handle: AcpConnectionResourceReadyHandle = Object.freeze({
+          epoch,
+          connection: resource.connection,
+          framework: resource.framework,
+          capabilities: resource.capabilities,
+          assertCurrent: () => {
+            assertCurrent()
+            if (this.current !== resource) throw new Error('ACP connection was superseded.')
+          }
+        })
+        return handle
+      },
+      owns: (connection) =>
+        epoch === this.resourceEpoch && this.current?.connection === connection
+    })
+  }
+}

--- a/src/main/acp/connection-resource-owner.ts
+++ b/src/main/acp/connection-resource-owner.ts
@@ -79,9 +79,7 @@ export class AcpConnectionResourceOwner {
   }
 
   connect(
-    operation: (
-      attempt: AcpConnectionResourceAttempt
-    ) => Promise<AcpConnectionResourceReadyHandle>
+    operation: (attempt: AcpConnectionResourceAttempt) => Promise<AcpConnectionResourceReadyHandle>
   ): Promise<AcpConnectionResourceReadyHandle> {
     if (this.connectInFlight) return this.connectInFlight
 
@@ -112,6 +110,15 @@ export class AcpConnectionResourceOwner {
     return this.resourceEpoch
   }
 
+  restorePublished(expectedEpoch: number): boolean {
+    // A teardown may fail before detach transfers the published resource back to Runtime. Restore only
+    // that still-owned publication into the teardown epoch; a stale caller, provisional startup, or
+    // already-detached resource must never be able to revive a connection.
+    if (expectedEpoch !== this.resourceEpoch || !this.current) return false
+    this.current.epoch = expectedEpoch
+    return true
+  }
+
   detach(expectedEpoch = this.resourceEpoch): AcpDetachedConnectionResource | undefined {
     if (expectedEpoch !== this.resourceEpoch) return undefined
     const resource = this.provisional ?? this.current
@@ -136,9 +143,7 @@ export class AcpConnectionResourceOwner {
   }
 
   setBridgeReasoningEffort(
-    effort: Parameters<
-      NonNullable<NonNullable<ResponsesBridgeLease>['setReasoningEffort']>
-    >[0]
+    effort: Parameters<NonNullable<NonNullable<ResponsesBridgeLease>['setReasoningEffort']>>[0]
   ): void {
     this.currentResource()?.bridgeLease?.setReasoningEffort?.(effort)
   }
@@ -192,8 +197,9 @@ export class AcpConnectionResourceOwner {
         return handle
       },
       owns: (connection) =>
-        epoch === this.resourceEpoch &&
-        (this.provisional?.connection === connection || this.current?.connection === connection)
+        this.currentResource()?.connection === connection ||
+        (this.provisional?.epoch === this.resourceEpoch &&
+          this.provisional.connection === connection)
     })
   }
 }

--- a/src/main/acp/connection-resource-owner.ts
+++ b/src/main/acp/connection-resource-owner.ts
@@ -54,6 +54,7 @@ const EMPTY_CAPABILITIES: AcpConnectionCapabilities = Object.freeze({
 // second mutable owner while those effects move behind this module in A9.1a2.
 export class AcpConnectionResourceOwner {
   private resourceEpoch = 0
+  private provisional: CurrentResource | undefined
   private current: CurrentResource | undefined
   private connectInFlight: Promise<AcpConnectionResourceReadyHandle> | undefined
 
@@ -62,11 +63,11 @@ export class AcpConnectionResourceOwner {
   }
 
   get connection(): ClientConnection | undefined {
-    return this.current?.connection
+    return this.currentResource()?.connection
   }
 
   get capabilities(): AcpConnectionCapabilities {
-    return this.current?.capabilities ?? EMPTY_CAPABILITIES
+    return this.currentResource()?.capabilities ?? EMPTY_CAPABILITIES
   }
 
   get inFlight(): Promise<AcpConnectionResourceReadyHandle> | undefined {
@@ -74,7 +75,7 @@ export class AcpConnectionResourceOwner {
   }
 
   get bridgeSkillsAvailable(): boolean {
-    return Boolean(this.current?.bridgeLease?.selectSkills)
+    return Boolean(this.currentResource()?.bridgeLease?.selectSkills)
   }
 
   connect(
@@ -86,12 +87,22 @@ export class AcpConnectionResourceOwner {
 
     const epoch = this.supersede()
     const attempt = this.createAttempt(epoch)
-    const connect = Promise.resolve().then(() => operation(attempt))
+    let resolveConnect!: (handle: AcpConnectionResourceReadyHandle) => void
+    let rejectConnect!: (error: unknown) => void
+    const connect = new Promise<AcpConnectionResourceReadyHandle>((resolve, reject) => {
+      resolveConnect = resolve
+      rejectConnect = reject
+    })
     this.connectInFlight = connect
     const clear = (): void => {
       if (this.connectInFlight === connect) this.connectInFlight = undefined
     }
     void connect.then(clear, clear)
+    try {
+      void operation(attempt).then(resolveConnect, rejectConnect)
+    } catch (error) {
+      rejectConnect(error)
+    }
     return connect
   }
 
@@ -103,7 +114,8 @@ export class AcpConnectionResourceOwner {
 
   detach(expectedEpoch = this.resourceEpoch): AcpDetachedConnectionResource | undefined {
     if (expectedEpoch !== this.resourceEpoch) return undefined
-    const resource = this.current
+    const resource = this.provisional ?? this.current
+    this.provisional = undefined
     this.current = undefined
     if (!resource) return undefined
     return resource
@@ -116,7 +128,7 @@ export class AcpConnectionResourceOwner {
   }
 
   registerBridgeReviewerSession(sessionId: string): void {
-    this.current?.bridgeLease?.registerReviewerSession(sessionId)
+    this.currentResource()?.bridgeLease?.registerReviewerSession(sessionId)
   }
 
   unregisterBridgeReviewerSession(sessionId: string): boolean | undefined {
@@ -128,7 +140,7 @@ export class AcpConnectionResourceOwner {
       NonNullable<NonNullable<ResponsesBridgeLease>['setReasoningEffort']>
     >[0]
   ): void {
-    this.current?.bridgeLease?.setReasoningEffort?.(effort)
+    this.currentResource()?.bridgeLease?.setReasoningEffort?.(effort)
   }
 
   async selectBridgeSkills(
@@ -136,7 +148,11 @@ export class AcpConnectionResourceOwner {
     catalog: Parameters<NonNullable<ResponsesBridgeLease>['selectSkills']>[1],
     signal?: Parameters<NonNullable<ResponsesBridgeLease>['selectSkills']>[2]
   ): Promise<Awaited<ReturnType<NonNullable<ResponsesBridgeLease>['selectSkills']>> | undefined> {
-    return this.current?.bridgeLease?.selectSkills(text, catalog, signal)
+    return this.currentResource()?.bridgeLease?.selectSkills(text, catalog, signal)
+  }
+
+  private currentResource(): CurrentResource | undefined {
+    return this.current?.epoch === this.resourceEpoch ? this.current : undefined
   }
 
   private createAttempt(epoch: number): AcpConnectionResourceAttempt {
@@ -149,15 +165,19 @@ export class AcpConnectionResourceOwner {
       assertCurrent,
       attach: (resource) => {
         assertCurrent()
-        if (this.current) throw new Error('ACP connection resource is already attached.')
-        this.current = { ...resource, epoch, capabilities: EMPTY_CAPABILITIES }
+        if (this.provisional || this.current) {
+          throw new Error('ACP connection resource is already attached.')
+        }
+        this.provisional = { ...resource, epoch, capabilities: EMPTY_CAPABILITIES }
       },
       publish: (capabilities) => {
         assertCurrent()
-        const resource = this.current
+        const resource = this.provisional
         if (!resource || resource.epoch !== epoch) {
           throw new Error('ACP connection resource is not attached.')
         }
+        this.provisional = undefined
+        this.current = resource
         resource.capabilities = Object.freeze({ ...capabilities })
         const handle: AcpConnectionResourceReadyHandle = Object.freeze({
           epoch,
@@ -172,7 +192,8 @@ export class AcpConnectionResourceOwner {
         return handle
       },
       owns: (connection) =>
-        epoch === this.resourceEpoch && this.current?.connection === connection
+        epoch === this.resourceEpoch &&
+        (this.provisional?.connection === connection || this.current?.connection === connection)
     })
   }
 }

--- a/src/main/acp/runtime.test.ts
+++ b/src/main/acp/runtime.test.ts
@@ -975,6 +975,96 @@ describe('ACP runtime migration write-gate', () => {
     ])
   })
 
+  it('publishes connected only after initialize, authentication, and provider configuration', async () => {
+    const process = new FakeAgentProcess()
+    const actions: string[] = []
+    acp
+      .agent({ name: 'connection-order-agent' })
+      .onRequest(acp.methods.agent.initialize, () => {
+        actions.push('initialize')
+        return {
+          protocolVersion: acp.PROTOCOL_VERSION,
+          agentCapabilities: { loadSession: false },
+          authMethods: []
+        }
+      })
+      .onRequest(acp.methods.agent.authenticate, () => {
+        actions.push('authenticate')
+        return {}
+      })
+      .onRequest(acp.methods.agent.providers.set, () => {
+        actions.push('configure-provider')
+        return {}
+      })
+      .connect(
+        acp.ndJsonStream(
+          Writable.toWeb(process.stdout) as WritableStream<Uint8Array>,
+          Readable.toWeb(process.stdin) as ReadableStream<Uint8Array>
+        )
+      )
+    const runtime = new AcpRuntime({
+      appVersion: '0.1.0',
+      defaultCwd: '/workspace',
+      resolveBackend: () => ({
+        framework: { ...claudeCodeFramework, spawn: () => asAgentProcess(process) },
+        executablePath: '/bin/agent',
+        env: {},
+        authentication: { methodId: 'api-key' },
+        providerConfiguration: {
+          providerId: 'custom-gateway',
+          apiType: 'openai',
+          baseUrl: 'http://127.0.0.1:1234/v1'
+        }
+      }),
+      callbacks: {
+        onEvent: (event) => {
+          if (event.title === 'Agent initialized') actions.push('initialized-event')
+        },
+        onStateChanged: (snapshot) => {
+          if (snapshot.status === 'connected') actions.push('publish-connected')
+        }
+      }
+    })
+
+    await runtime.connect({ cwd: '/workspace' })
+
+    expect(actions).toEqual([
+      'initialize',
+      'authenticate',
+      'configure-provider',
+      'initialized-event',
+      'publish-connected'
+    ])
+    await runtime.disconnect()
+  })
+
+  it('ignores a detached connection closing after its replacement is connected', async () => {
+    const oldProcess = new FakeAgentProcess()
+    const replacementProcess = new FakeAgentProcess()
+    startFakeAgent(oldProcess, ['old-session'])
+    startFakeAgent(replacementProcess, ['replacement-session'])
+    let spawnCount = 0
+    const runtime = new AcpRuntime({
+      appVersion: '0.1.0',
+      defaultCwd: '/workspace',
+      spawnAgent: () => asAgentProcess(spawnCount++ === 0 ? oldProcess : replacementProcess)
+    })
+
+    await runtime.createSession({ cwd: '/workspace' })
+    await runtime.disconnect()
+    await runtime.createSession({ cwd: '/workspace' })
+
+    oldProcess.stdout.end()
+    await new Promise((resolvePromise) => setTimeout(resolvePromise, 0))
+
+    expect(runtime.getSnapshot()).toMatchObject({
+      status: 'connected',
+      sessionIds: ['replacement-session']
+    })
+    expect(replacementProcess.killed).toBe(false)
+    await runtime.disconnect()
+  })
+
   it.each(['initialize', 'authenticate'] as const)(
     'clears one-shot connection intents when %s fails',
     async (failureStage) => {

--- a/src/main/acp/runtime.test.ts
+++ b/src/main/acp/runtime.test.ts
@@ -5311,6 +5311,64 @@ describe('ACP runtime session management', () => {
     expect(runtime.getSnapshot().sessionIds).toEqual(['remote-session-1', 'remote-session-2'])
   })
 
+  it('does not reuse a superseded connection while its replacement connect is starting', async () => {
+    const oldProcess = new FakeAgentProcess()
+    const replacementProcess = new FakeAgentProcess()
+    const oldAgent = startFakeAgent(oldProcess, ['old-session', 'wrong-old-session'])
+    const replacementAgent = startFakeAgent(replacementProcess, ['replacement-session'])
+    let spawnCount = 0
+    const runtime = new AcpRuntime({
+      appVersion: '0.1.0',
+      defaultCwd: '/workspace',
+      spawnAgent: () => asAgentProcess(spawnCount++ === 0 ? oldProcess : replacementProcess)
+    })
+    await runtime.createSession({ cwd: '/workspace' })
+
+    const reconnect = runtime.connect({ cwd: '/workspace' })
+    const successor = runtime.createSession({ cwd: '/workspace' })
+    const [, session] = await Promise.all([reconnect, successor])
+
+    expect(session.sessionId).toBe('replacement-session')
+    expect(oldAgent.newSessions).toHaveLength(1)
+    expect(replacementAgent.newSessions).toHaveLength(1)
+    expect(spawnCount).toBe(2)
+  })
+
+  it('releases a spawned resource superseded immediately before owner attach', async () => {
+    const process = new FakeAgentProcess()
+    startFakeAgent(process, [])
+    const { lease, release } = createBackendLeaseHarness()
+    const runtime = new AcpRuntime({
+      appVersion: '0.1.0',
+      defaultCwd: '/workspace',
+      resolveBackend: () => ({
+        framework: { ...claudeCodeFramework, spawn: () => asAgentProcess(process) },
+        executablePath: '/bin/agent',
+        env: {},
+        responsesBridgeLease: lease
+      })
+    })
+    const internal = runtime as unknown as {
+      createClientConnection: (
+        stream: acp.Stream
+      ) => import('@agentclientprotocol/sdk').ClientConnection
+    }
+    const createConnection = internal.createClientConnection.bind(runtime)
+    let disconnect: Promise<unknown> | undefined
+    vi.spyOn(internal, 'createClientConnection').mockImplementation((stream) => {
+      const connection = createConnection(stream)
+      disconnect = runtime.disconnect()
+      return connection
+    })
+
+    await expect(runtime.connect({ cwd: '/workspace' })).rejects.toThrow(/superseded/i)
+    await disconnect
+
+    expect(process.killed).toBe(true)
+    expect(release).toHaveBeenCalledOnce()
+    expect(runtime.getSnapshot().sessionIds).toEqual([])
+  })
+
   it('invalidates an in-flight connection when disconnect is requested before initialization finishes', async () => {
     const initializeStarted = createDeferred()
     const firstInitializeCanFinish = createDeferred()

--- a/src/main/acp/runtime.test.ts
+++ b/src/main/acp/runtime.test.ts
@@ -1066,6 +1066,37 @@ describe('ACP runtime migration write-gate', () => {
     await runtime.disconnect()
   })
 
+  it('keeps using a published connection when teardown fails before resource detach', async () => {
+    const process = new FakeAgentProcess()
+    const fakeAgent = startFakeAgent(process, ['first-session', 'successor-session'])
+    const spawnAgent = vi.fn(() => asAgentProcess(process))
+    const runtime = new AcpRuntime({
+      appVersion: '0.1.0',
+      defaultCwd: '/workspace',
+      spawnAgent
+    })
+    await runtime.createSession({ cwd: '/workspace' })
+    const internal = runtime as unknown as {
+      disconnectCurrent: (emitClosedStatus?: boolean) => Promise<AcpStateSnapshot>
+    }
+    const disconnectCurrentSpy = vi
+      .spyOn(internal, 'disconnectCurrent')
+      .mockRejectedValueOnce(new Error('disconnect failed before detach'))
+
+    try {
+      await expect(runtime.disconnect()).rejects.toThrow('disconnect failed before detach')
+      await expect(runtime.createSession({ cwd: '/workspace' })).resolves.toMatchObject({
+        sessionId: 'successor-session'
+      })
+      expect(fakeAgent.newSessions).toHaveLength(2)
+      expect(spawnAgent).toHaveBeenCalledOnce()
+      expect(process.killed).toBe(false)
+    } finally {
+      disconnectCurrentSpy.mockRestore()
+      await runtime.disconnect().catch(() => undefined)
+    }
+  })
+
   it.each(['initialize', 'authenticate'] as const)(
     'clears one-shot connection intents when %s fails',
     async (failureStage) => {

--- a/src/main/acp/runtime.test.ts
+++ b/src/main/acp/runtime.test.ts
@@ -1013,7 +1013,8 @@ describe('ACP runtime migration write-gate', () => {
         providerConfiguration: {
           providerId: 'custom-gateway',
           apiType: 'openai',
-          baseUrl: 'http://127.0.0.1:1234/v1'
+          baseUrl: 'http://127.0.0.1:1234/v1',
+          headers: {}
         }
       }),
       callbacks: {
@@ -15739,7 +15740,11 @@ describe('ACP runtime — connect failure logging', () => {
         framework: {
           ...claudeCodeFramework,
           spawn: () => {
-            ;(runtime as unknown as { connectionGeneration: number }).connectionGeneration += 1
+            ;(
+              runtime as unknown as {
+                connectionResources: { supersede: () => number }
+              }
+            ).connectionResources.supersede()
             return asAgentProcess(process)
           }
         },
@@ -16963,7 +16968,11 @@ describe('ACP runtime — failure-path robustness (errorMessage coercion + sync-
       appVersion: '0.1.0',
       defaultCwd: '/workspace',
       spawnAgent: () => {
-        ;(runtime as unknown as { connectionGeneration: number }).connectionGeneration += 1
+        ;(
+          runtime as unknown as {
+            connectionResources: { supersede: () => number }
+          }
+        ).connectionResources.supersede()
         return asAgentProcess(process)
       }
     })

--- a/src/main/acp/runtime.ts
+++ b/src/main/acp/runtime.ts
@@ -1499,7 +1499,6 @@ class AcpRuntime {
 
       throw cause
     }
-
   }
 
   // Creates a protocol session, injects artifact tooling, and uses the returned id as the app session id.
@@ -2674,6 +2673,12 @@ class AcpRuntime {
 
     try {
       return await this.disconnectCurrent(emitClosedStatus, teardownGeneration)
+    } catch (error) {
+      // disconnectCurrent transfers the resource with detach before physical teardown. If it failed
+      // earlier, the owner still holds a live published connection: restore only that exact teardown
+      // epoch so callers retain the pre-refactor recovery behavior. Once detached, rollback is a no-op.
+      this.connectionResources.restorePublished(teardownGeneration)
+      throw error
     } finally {
       try {
         await this.closeMcpHttpHost(teardownGeneration)

--- a/src/main/acp/runtime.ts
+++ b/src/main/acp/runtime.ts
@@ -1207,12 +1207,14 @@ class AcpRuntime {
     attempt: AcpConnectionResourceAttempt
   ): Promise<AcpConnectionResourceReadyHandle> {
     const generation = attempt.epoch
+    attempt.assertCurrent()
     // Resolve up front rather than reading this.cwd after the pre-connect teardown, which may still be
     // mutating runtime state.
     const cwd = resolve(request.cwd || this.options.defaultCwd)
     // Captured at function scope so the catch can clean up the spawned child on every failure path —
     // including "superseded during spawn", before it can be attached to the resource owner.
     let agentProcess: ChildProcessWithoutNullStreams | undefined
+    let unattachedConnection: ClientConnection | undefined
     let unattachedBridgeLease: ResolvedAgentBackend['responsesBridgeLease']
     let resourceAttached = false
     let connectionAuthentication: ResolvedAgentBackend['authentication']
@@ -1276,6 +1278,7 @@ class AcpRuntime {
       )
 
       const connection = this.createClientConnection(stream)
+      unattachedConnection = connection
       attempt.attach({
         process: agentProcess,
         connection,
@@ -1283,6 +1286,7 @@ class AcpRuntime {
         bridgeLease: spawned.backend.responsesBridgeLease
       })
       resourceAttached = true
+      unattachedConnection = undefined
       unattachedBridgeLease = undefined
       connection.closed.then(() => {
         if (
@@ -1370,8 +1374,17 @@ class AcpRuntime {
 
       // Before attach(), the owner cannot detach the candidate for failure cleanup. Keep that
       // pre-publication resource local and transfer-or-release it exactly once.
-      if (!resourceAttached && agentProcess && generation === this.connectionGeneration) {
+      if (!resourceAttached && agentProcess) {
         this.expectedProcessExits.add(agentProcess)
+        try {
+          unattachedConnection?.close()
+        } catch (cleanupError) {
+          safeLogError('unattached ACP connection cleanup failed', {
+            ...diagnosticErrorFields(cleanupError),
+            ...this.diagnosticContext(spawnedFramework, generation)
+          })
+        }
+        unattachedConnection = undefined
         try {
           const result = await terminateProcessTree(agentProcess, undefined, log)
           this.lastTreeKillReaped = this.lastTreeKillReaped && result.reaped

--- a/src/main/acp/runtime.ts
+++ b/src/main/acp/runtime.ts
@@ -134,6 +134,11 @@ import {
   type AcpSessionDeletion,
   type AcpSessionRegistryEntry
 } from './session-registry'
+import {
+  AcpConnectionResourceOwner,
+  type AcpConnectionResourceAttempt,
+  type AcpConnectionResourceReadyHandle
+} from './connection-resource-owner'
 
 export type AcpRuntimeCallbacks = {
   onStateChanged?: (state: AcpStateSnapshot) => void
@@ -499,14 +504,15 @@ const isUnresumableSessionError = (error: unknown): boolean => {
   )
 }
 
-// Owns the agent process, protocol connection, and all active protocol sessions.
+// ACP Session facade. Connection publication and resource identity have their own epoch owner while
+// spawn/initialize and physical teardown remain runtime ports until A9.1a2.
 class AcpRuntime {
   private readonly snapshotOwner: AcpRuntimeSnapshotOwner
   private readonly contextUsageTracker: ContextUsageTracker
   // Prompt lifecycle stays with the runtime: this marks turns that received provider-side
   // context-bearing updates so a rejected prompt rolls back only when the provider saw no turn data.
   private readonly contextUsageUpdatedPromptTurnsBySession = new Map<string, number>()
-  private agentProcess: ChildProcessWithoutNullStreams | undefined
+  private readonly connectionResources = new AcpConnectionResourceOwner()
   // Latched by shutdown() on app quit. A connect can be mid-spawn (resolveSpawnConfig is async) when
   // quit fires, so this lets the post-spawn path kill a child that was created after killAgentProcess ran.
   private shuttingDown = false
@@ -514,12 +520,6 @@ class AcpRuntime {
   // at the start of shutdownForQuit/shutdownForUpdateGate, then narrowed by each terminateProcessTree so
   // those methods can report whether the agent tree was cleanly reaped (vs a degraded taskkill fallback).
   private lastTreeKillReaped = true
-  private connection: ClientConnection | undefined
-  private connectInFlight: Promise<AcpStateSnapshot> | undefined
-  private connectionGeneration = 0
-  private supportsSessionClose = false
-  private supportsSessionDelete = false
-  private supportsSessionResume = false
   // Stable app identities, provider aliases, publication order, selection, and startup/delete
   // arbitration share one owner. The runtime retains only protocol/resource orchestration.
   private readonly sessionRegistry: AcpSessionRegistry
@@ -596,7 +596,6 @@ class AcpRuntime {
   private pendingAuthentication: ResolvedAgentBackend['authentication']
   private pendingProviderConfiguration: ResolvedAgentBackend['providerConfiguration']
   private opencodeUsageApi: ResolvedAgentBackend['opencodeUsageApi']
-  private responsesBridgeLease: ResolvedAgentBackend['responsesBridgeLease']
   // Bounded resume network timeout + injectable timers (defaults to real setTimeout/clearTimeout).
   private readonly resumeTimeoutMs: number
   private readonly setTimer: (fn: () => void, ms: number) => ReturnType<typeof setTimeout>
@@ -724,11 +723,31 @@ class AcpRuntime {
       isPrimarySessionIdClaimed: (sessionId) => this.sessionRegistry.isIdentityClaimed(sessionId),
       onActiveSessionReleased: () => this.maybeApplyPendingProviderReconnect(),
       registerBridgeSession: (sessionId) =>
-        this.responsesBridgeLease?.registerReviewerSession(sessionId),
+        this.connectionResources.registerBridgeReviewerSession(sessionId),
       removeStartupBlocker: (token) => this.pendingSessionStartupBlockers.delete(token),
       unregisterBridgeSession: (sessionId) =>
-        this.responsesBridgeLease?.unregisterReviewerSession(sessionId)
+        this.connectionResources.unregisterBridgeReviewerSession(sessionId)
     })
+  }
+
+  private get connection(): ClientConnection | undefined {
+    return this.connectionResources.connection
+  }
+
+  private get connectionGeneration(): number {
+    return this.connectionResources.epoch
+  }
+
+  private get supportsSessionClose(): boolean {
+    return this.connectionResources.capabilities.close
+  }
+
+  private get supportsSessionDelete(): boolean {
+    return this.connectionResources.capabilities.delete
+  }
+
+  private get supportsSessionResume(): boolean {
+    return this.connectionResources.capabilities.resume
   }
 
   private attachSessionAggregate(
@@ -1111,7 +1130,7 @@ class AcpRuntime {
     if (this.pendingProviderReconnect) return false
 
     this.pendingSessionEffort = effort === 'default' ? undefined : effort
-    this.responsesBridgeLease?.setReasoningEffort?.(this.pendingSessionEffort)
+    this.connectionResources.setBridgeReasoningEffort(this.pendingSessionEffort)
     const connection = this.connection
     if (!connection) return true
 
@@ -1179,34 +1198,23 @@ class AcpRuntime {
   }
 
   private async connectOperation(request: AcpConnectRequest = {}): Promise<AcpStateSnapshot> {
-    if (this.connectInFlight) {
-      return this.connectInFlight
-    }
-
-    const generation = this.nextConnectionGeneration()
-    this.invalidatePendingSessionStartups()
-    const connectPromise = this.connectFresh(request, generation)
-    this.connectInFlight = connectPromise
-
-    try {
-      return await connectPromise
-    } finally {
-      if (this.connectInFlight === connectPromise) {
-        this.connectInFlight = undefined
-      }
-    }
+    await this.connectionResources.connect((attempt) => this.connectFresh(request, attempt))
+    return this.getSnapshot()
   }
 
   private async connectFresh(
     request: AcpConnectRequest = {},
-    generation: number
-  ): Promise<AcpStateSnapshot> {
+    attempt: AcpConnectionResourceAttempt
+  ): Promise<AcpConnectionResourceReadyHandle> {
+    const generation = attempt.epoch
     // Resolve up front rather than reading this.cwd after the pre-connect teardown, which may still be
     // mutating runtime state.
     const cwd = resolve(request.cwd || this.options.defaultCwd)
     // Captured at function scope so the catch can clean up the spawned child on every failure path —
-    // including "superseded during spawn", where it is never assigned to this.agentProcess.
+    // including "superseded during spawn", before it can be attached to the resource owner.
     let agentProcess: ChildProcessWithoutNullStreams | undefined
+    let unattachedBridgeLease: ResolvedAgentBackend['responsesBridgeLease']
+    let resourceAttached = false
     let connectionAuthentication: ResolvedAgentBackend['authentication']
     let connectionProviderConfiguration: ResolvedAgentBackend['providerConfiguration']
     // The framework THIS connect spawned under, bound atomically to the spawn (spawnAgentProcess returns
@@ -1218,8 +1226,9 @@ class AcpRuntime {
     try {
       // Inside the try so a teardown throw or the generation assertion (a supersede race) also produces
       // an enriched failure record instead of propagating silently.
-      await this.disconnectCurrent(false)
-      this.assertCurrentConnectionGeneration(generation)
+      this.invalidatePendingSessionStartups()
+      await this.disconnectCurrent(false, generation)
+      attempt.assertCurrent()
 
       this.snapshotOwner.updateCwd(cwd)
       this.snapshotOwner.updateError(undefined)
@@ -1231,6 +1240,7 @@ class AcpRuntime {
       spawnedFramework = spawned.framework
       connectionAuthentication = spawned.backend.authentication
       connectionProviderConfiguration = spawned.backend.providerConfiguration
+      unattachedBridgeLease = spawned.backend.responsesBridgeLease
 
       // spawnAgentProcess resolves the provider config asynchronously, so the connection may have been
       // torn down or superseded during the spawn: a quit latched shuttingDown, or any teardown/reconnect
@@ -1247,6 +1257,8 @@ class AcpRuntime {
           this.lastTreeKillReaped = this.lastTreeKillReaped && result.reaped
         } finally {
           await spawned.backend.responsesBridgeLease?.release()
+          agentProcess = undefined
+          unattachedBridgeLease = undefined
         }
         throw new Error(
           this.shuttingDown
@@ -1256,19 +1268,25 @@ class AcpRuntime {
       }
 
       this.applyResolvedBackend(spawned.backend)
-      this.agentProcess = agentProcess
-      this.attachAgentProcessEvents(this.agentProcess, generation)
+      this.attachAgentProcessEvents(agentProcess, generation)
 
       const stream = acp.ndJsonStream(
-        Writable.toWeb(this.agentProcess.stdin) as WritableStream<Uint8Array>,
-        Readable.toWeb(this.agentProcess.stdout) as ReadableStream<Uint8Array>
+        Writable.toWeb(agentProcess.stdin) as WritableStream<Uint8Array>,
+        Readable.toWeb(agentProcess.stdout) as ReadableStream<Uint8Array>
       )
 
       const connection = this.createClientConnection(stream)
-      this.connection = connection
+      attempt.attach({
+        process: agentProcess,
+        connection,
+        framework: spawned.framework,
+        bridgeLease: spawned.backend.responsesBridgeLease
+      })
+      resourceAttached = true
+      unattachedBridgeLease = undefined
       connection.closed.then(() => {
         if (
-          this.connectionGeneration === generation &&
+          attempt.owns(connection) &&
           (this.snapshotOwner.status === 'connected' || this.snapshotOwner.status === 'connecting')
         ) {
           this.handleConnectionClosed()
@@ -1295,11 +1313,11 @@ class AcpRuntime {
           plan: {}
         }
       })
-      this.assertCurrentConnectionOwner(connection, generation)
+      attempt.assertCurrent()
       if (this.pendingAuthentication) {
         const authentication = this.pendingAuthentication
         await connection.agent.request(acp.methods.agent.authenticate, authentication)
-        this.assertCurrentConnectionOwner(connection, generation)
+        attempt.assertCurrent()
         if (this.pendingAuthentication === authentication) {
           this.pendingAuthentication = undefined
         }
@@ -1307,25 +1325,22 @@ class AcpRuntime {
       if (this.pendingProviderConfiguration) {
         const providerConfiguration = this.pendingProviderConfiguration
         await connection.agent.request(acp.methods.agent.providers.set, providerConfiguration)
-        this.assertCurrentConnectionOwner(connection, generation)
+        attempt.assertCurrent()
         if (this.pendingProviderConfiguration === providerConfiguration) {
           this.pendingProviderConfiguration = undefined
         }
       }
-      this.supportsSessionClose = Boolean(initResult.agentCapabilities?.sessionCapabilities?.close)
-      this.supportsSessionDelete = Boolean(
-        initResult.agentCapabilities?.sessionCapabilities?.delete
-      )
-      this.supportsSessionResume = Boolean(
-        initResult.agentCapabilities?.sessionCapabilities?.resume
-      )
-      this.assertCurrentConnectionOwner(connection, generation)
+      const handle = attempt.publish({
+        close: Boolean(initResult.agentCapabilities?.sessionCapabilities?.close),
+        delete: Boolean(initResult.agentCapabilities?.sessionCapabilities?.delete),
+        resume: Boolean(initResult.agentCapabilities?.sessionCapabilities?.resume)
+      })
 
       log.info('agent initialized', {
         protocolVersion: initResult.protocolVersion,
-        supportsSessionClose: this.supportsSessionClose,
-        supportsSessionDelete: this.supportsSessionDelete,
-        supportsSessionResume: this.supportsSessionResume
+        supportsSessionClose: handle.capabilities.close,
+        supportsSessionDelete: handle.capabilities.delete,
+        supportsSessionResume: handle.capabilities.resume
       })
 
       this.pushEvent({
@@ -1336,8 +1351,9 @@ class AcpRuntime {
       })
       // Event/state listeners are external and may synchronously disconnect or replace the runtime.
       // Re-check the concrete owner after callbacks return before committing the connected snapshot.
-      this.assertCurrentConnectionOwner(connection, generation)
+      handle.assertCurrent()
       this.setStatus('connected')
+      return handle
     } catch (thrown) {
       // A spawn failure arrives wrapped so it can name the framework it targeted without mutating the
       // original throwable; unwrap to the real cause (logged and re-thrown) and prefer its framework
@@ -1351,6 +1367,24 @@ class AcpRuntime {
         spawnFailure = undefined
       }
       const cause = spawnFailure ? spawnFailure.cause : thrown
+
+      // Before attach(), the owner cannot detach the candidate for failure cleanup. Keep that
+      // pre-publication resource local and transfer-or-release it exactly once.
+      if (!resourceAttached && agentProcess && generation === this.connectionGeneration) {
+        this.expectedProcessExits.add(agentProcess)
+        try {
+          const result = await terminateProcessTree(agentProcess, undefined, log)
+          this.lastTreeKillReaped = this.lastTreeKillReaped && result.reaped
+        } catch (cleanupError) {
+          safeLogError('unattached agent process cleanup failed', {
+            ...diagnosticErrorFields(cleanupError),
+            ...this.diagnosticContext(spawnedFramework, generation)
+          })
+        }
+        agentProcess = undefined
+        await this.releaseResponsesBridgeLease(unattachedBridgeLease)
+        unattachedBridgeLease = undefined
+      }
 
       // This connect owns the one-shot credential/config intent only while its generation is current.
       // Clear every unconsumed value on a same-generation failure (including initialize/auth failure),
@@ -1453,7 +1487,6 @@ class AcpRuntime {
       throw cause
     }
 
-    return this.getSnapshot()
   }
 
   // Creates a protocol session, injects artifact tooling, and uses the returned id as the app session id.
@@ -2622,10 +2655,9 @@ class AcpRuntime {
 
   // Tears down every local session route and closes the underlying agent process.
   async disconnect(emitClosedStatus = true): Promise<AcpStateSnapshot> {
-    const teardownGeneration = this.nextConnectionGeneration()
+    const teardownGeneration = this.connectionResources.supersede()
     const reconnectBarrierGeneration = this.reconnectBarrierGeneration
     this.invalidatePendingSessionStartups()
-    this.connectInFlight = undefined
 
     try {
       return await this.disconnectCurrent(emitClosedStatus, teardownGeneration)
@@ -2644,18 +2676,17 @@ class AcpRuntime {
   // reclaims the remaining connection/session state as the process exits.
   shutdown(): void {
     this.shuttingDown = true
-    this.nextConnectionGeneration()
+    const teardownGeneration = this.connectionResources.supersede()
     this.invalidatePendingSessionStartups()
-    this.connectInFlight = undefined
-    this.connection?.close()
-    this.connection = undefined
+    const resource = this.connectionResources.detach(teardownGeneration)
+    resource?.connection.close()
     this.completePendingReconnectTeardown()
-    this.killAgentProcess()
+    this.killAgentProcess(resource?.process)
     this.contextUsageTracker.clear()
     this.contextUsageUpdatedPromptTurnsBySession.clear()
     this.clearAppliedSessionModels()
     void this.closeMcpHttpHost()
-    void this.releaseResponsesBridgeLease()
+    void this.releaseResponsesBridgeLease(resource?.bridgeLease)
   }
 
   // Awaitable quit/relaunch teardown. Latches shuttingDown FIRST so a connect that is mid-spawn when
@@ -2667,7 +2698,7 @@ class AcpRuntime {
     this.lastTreeKillReaped = true
     this.shuttingDown = true
     // Capture the in-flight connect before disconnect() clears it.
-    const inFlight = this.connectInFlight
+    const inFlight = this.connectionResources.inFlight
     // Kill the currently-assigned agent tree right away. Do NOT wait on the in-flight connect first: it
     // may be stalled on ACP initialize with the child already assigned, and waiting would let
     // shutdownBackends time out and app.exit orphan it. disconnect() reaps that child's tree and closes
@@ -2694,7 +2725,7 @@ class AcpRuntime {
     this.lastTreeKillReaped = true
     // Capture the in-flight connect before disconnect() clears it. disconnect() bumps the generation, so
     // a connect still mid-spawn will self-reap on the stale-generation check regardless of this await.
-    const inFlight = this.connectInFlight
+    const inFlight = this.connectionResources.inFlight
     await this.disconnect(false)
     // Await so the mid-spawn child's kill settles before we report the reaped signal.
     if (inFlight) await inFlight.catch(() => undefined)
@@ -2782,7 +2813,22 @@ class AcpRuntime {
       // barrier-release below cannot let a blocked ensureConnected reuse the STALE connection on the
       // old backend; the re-check there will fall through to a fresh connect(). Set status directly
       // rather than via setStatus — the throw may have come from emitState itself.
-      this.connection = undefined
+      const teardownGeneration = this.connectionResources.supersede()
+      const detached = this.connectionResources.detach(teardownGeneration)
+      try {
+        detached?.connection.close()
+      } catch (closeError) {
+        safeLogError('connection close after failed deferred disconnect failed', {
+          ...diagnosticErrorFields(closeError)
+        })
+      }
+      void this.killAgentProcessTree(detached?.process)
+        .catch((cleanupError) =>
+          safeLogError('agent process cleanup after failed deferred disconnect failed', {
+            ...diagnosticErrorFields(cleanupError)
+          })
+        )
+        .then(() => this.releaseResponsesBridgeLease(detached?.bridgeLease))
       this.snapshotOwner.transitionStatus('closed')
       // Broadcast the closed status defensively so the renderer doesn't keep showing the prior
       // 'connected' state when no createSession follows to re-emit it. Guarded because emitState may
@@ -2948,27 +2994,19 @@ class AcpRuntime {
     this.codexSkillActivity.clear()
     runCleanup('MCP HTTP routes', () => this.sessionCapabilities.clearHttpRoutes())
     this.sessionRegistry.select(undefined)
-    this.supportsSessionClose = false
-    this.supportsSessionDelete = false
-    this.supportsSessionResume = false
 
     // Detach generation-owned resources before the first teardown await. A newer connect may publish
     // replacements while process/lease cleanup is still settling; the old teardown must never close or
     // release those replacements when it resumes.
-    const connection = this.connection
-    this.connection = undefined
-    runCleanup('connection', () => connection?.close())
-    const agentProcess = this.agentProcess
-    if (this.agentProcess === agentProcess) this.agentProcess = undefined
-    const responsesBridgeLease = this.responsesBridgeLease
-    if (this.responsesBridgeLease === responsesBridgeLease) this.responsesBridgeLease = undefined
+    const resource = this.connectionResources.detach(teardownGeneration)
+    runCleanup('connection', () => resource?.connection.close())
 
     try {
-      await this.killAgentProcessTree(agentProcess)
+      await this.killAgentProcessTree(resource?.process)
     } catch (error) {
       recordFailure('agent-process', error)
     }
-    await this.releaseResponsesBridgeLease(responsesBridgeLease)
+    await this.releaseResponsesBridgeLease(resource?.bridgeLease)
 
     if (emitClosedStatus && teardownGeneration === this.connectionGeneration) {
       runCleanup('closed-status', () => this.setStatus('closed'))
@@ -2982,48 +3020,27 @@ class AcpRuntime {
   // handlers stay quiet. Synchronous: used by the will-quit backstop (shutdown()), which Electron
   // cannot await. It only signals the immediate child — the awaited disconnect path below reaps the
   // whole tree.
-  private killAgentProcess(): void {
-    if (this.agentProcess) {
-      this.expectedProcessExits.add(this.agentProcess)
+  private killAgentProcess(child: ChildProcessWithoutNullStreams | undefined): void {
+    if (child) {
+      this.expectedProcessExits.add(child)
 
-      if (!this.agentProcess.killed) {
-        this.agentProcess.kill()
+      if (!child.killed) {
+        child.kill()
       }
     }
-
-    this.agentProcess = undefined
   }
 
   // Awaitable tree teardown for the async disconnect path: marks the exit expected, then hands the
   // whole process tree to terminateProcessTree so a Windows grandchild (taskkill /T) is reaped before
   // the caller (before-quit shutdownBackends) proceeds to app.exit.
   private async killAgentProcessTree(
-    child: ChildProcessWithoutNullStreams | undefined = this.agentProcess
+    child: ChildProcessWithoutNullStreams | undefined
   ): Promise<void> {
-    if (this.agentProcess === child) this.agentProcess = undefined
     if (!child) return
     this.expectedProcessExits.add(child)
     const result = await terminateProcessTree(child, undefined, log)
     // Narrow the current teardown's reaped accumulator (reset by shutdownForQuit/shutdownForUpdateGate).
     this.lastTreeKillReaped = this.lastTreeKillReaped && result.reaped
-  }
-
-  private nextConnectionGeneration(): number {
-    this.connectionGeneration += 1
-    return this.connectionGeneration
-  }
-
-  private assertCurrentConnectionGeneration(generation: number): void {
-    if (generation !== this.connectionGeneration) {
-      throw new Error('ACP connection was superseded.')
-    }
-  }
-
-  private assertCurrentConnectionOwner(connection: ClientConnection, generation: number): void {
-    this.assertCurrentConnectionGeneration(generation)
-    if (this.connection !== connection) {
-      throw new Error('ACP connection was superseded.')
-    }
   }
 
   // Creates the agent process, preferring an injected spawner (tests) and otherwise resolving the
@@ -3108,13 +3125,11 @@ class AcpRuntime {
     this.pendingAuthentication = backend.authentication
     this.pendingProviderConfiguration = backend.providerConfiguration
     this.opencodeUsageApi = backend.opencodeUsageApi
-    this.responsesBridgeLease = backend.responsesBridgeLease
   }
 
   private async releaseResponsesBridgeLease(
-    lease: ResolvedAgentBackend['responsesBridgeLease'] = this.responsesBridgeLease
+    lease: ResolvedAgentBackend['responsesBridgeLease']
   ): Promise<void> {
-    if (this.responsesBridgeLease === lease) this.responsesBridgeLease = undefined
     try {
       await lease?.release()
     } catch (error) {
@@ -3431,7 +3446,7 @@ class AcpRuntime {
       const selectorSignal =
         this.framework.id === 'codex' &&
         forced.length === 0 &&
-        this.responsesBridgeLease?.selectSkills
+        this.connectionResources.bridgeSkillsAvailable
           ? promptInteraction.signal
           : undefined
       const codexSkillInputs = await this.resolveCodexSkillInputs(
@@ -3978,7 +3993,7 @@ class AcpRuntime {
       return this.skillsHooks.descriptorsForIds(forcedSkillIds, this.codexHome)
     }
 
-    if (!this.responsesBridgeLease?.selectSkills || !this.skillsHooks?.catalogForCodexHome) {
+    if (!this.connectionResources.bridgeSkillsAvailable || !this.skillsHooks?.catalogForCodexHome) {
       return []
     }
 
@@ -4001,7 +4016,8 @@ class AcpRuntime {
     if (catalog.length === 0) return []
 
     try {
-      const selected = await this.responsesBridgeLease.selectSkills(text, catalog, signal)
+      const selected = await this.connectionResources.selectBridgeSkills(text, catalog, signal)
+      if (!selected) return []
       // Treat the selector as advisory: retain only Skills it was offered. This keeps an out-of-date
       // selector result from reintroducing a Skill or mcp-* connector from the previous specialist.
       const offeredSkills = new Set(catalog.map((skill) => `${skill.name}\u0000${skill.path}`))
@@ -4870,13 +4886,13 @@ class AcpRuntime {
     const teardownGeneration = this.connectionGeneration
     const interruptedPrompts = this.sessionInteractions.settleActivePrompts()
     this.invalidatePendingSessionStartups()
-    const orphanedProcess = this.agentProcess
-    if (orphanedProcess) {
-      this.expectedProcessExits.add(orphanedProcess)
-      void terminateProcessTree(orphanedProcess, undefined, log)
-    }
     this.permissionContext.dispose()
     this.reviewerSessions.clear()
+    const resource = this.connectionResources.detach(teardownGeneration)
+    if (resource?.process) {
+      this.expectedProcessExits.add(resource.process)
+      void terminateProcessTree(resource.process, undefined, log)
+    }
     this.sessionCapabilities.dispose(this.activeSessionIds())
     for (const entry of this.sessionRegistry.entries()) {
       if (entry.attachment) this.sessionRegistry.detach(entry.attachment, 'connection')
@@ -4891,10 +4907,6 @@ class AcpRuntime {
     this.contextUsageUpdatedPromptTurnsBySession.clear()
     this.sessionCapabilities.clearHttpRoutes()
     this.sessionRegistry.select(undefined)
-    this.supportsSessionClose = false
-    this.supportsSessionDelete = false
-    this.connection = undefined
-    this.agentProcess = undefined
     this.sessionInteractions.supersedeAll()
     // The connection is already gone, so any ensureConnected caller waiting on
     // the reconnect barrier must unblock now — it will fall through to connect()
@@ -4902,7 +4914,7 @@ class AcpRuntime {
     // skills too, so clear both pending flags to avoid a spurious later reconnect.
     this.completePendingReconnectTeardown()
     void this.closeMcpHttpHost(teardownGeneration)
-    void this.releaseResponsesBridgeLease()
+    void this.releaseResponsesBridgeLease(resource?.bridgeLease)
     try {
       this.setStatus('closed')
     } finally {


### PR DESCRIPTION
## Problem

`AcpRuntime` still owned connection identity, generation publication, concurrent connect admission, protocol capability publication, and the physical process/connection resources in one mutable cluster. Moving that entire cluster at once measured 1,137 production changed lines, so the extraction was stopped and split before commit.

## Proposed change

Add a runtime-private `AcpConnectionResourceOwner` for the first bounded slice: resource epoch, connect-in-flight deduplication, provisional/current slots, exclusive attach/publish/detach transfer, immutable ready handles, and current-epoch assertions.

```mermaid
stateDiagram-v2
  [*] --> Empty
  Empty --> Provisional: attach(resource)
  Provisional --> Published: publish(capabilities)
  Published --> Detached: supersede + detach(epoch)
  Provisional --> Detached: supersede + detach(epoch)
  Published --> Published: teardown failed before detach / conditional restore
  Detached --> [*]
```

`AcpRuntime` still performs backend resolution, spawn, ACP initialize/auth/provider configuration, process event handling, physical close/tree reap, bridge release, and shutdown. Those effects move only in A9.1a2 after this publication boundary is merged.

The implementation also closes and characterizes three publication races:

- a replacement request cannot briefly expose/reuse the superseded connection;
- a process/connection/bridge superseded immediately before owner attach is released exactly once;
- a teardown failure before detach conditionally restores only the still-owned published resource, while provisional, stale, and detached resources cannot be revived.

## Scope and non-goals

- Internal ACP state ownership only; no IPC/public API, data model/relationship, persistence, UI, or user-interaction change.
- Reconnect/skills/retirement arbitration remains A9.1b.
- Physical teardown and shutdown ownership remains A9.1a2.
- Session Registry, provider-ID adoption, Prompt, Specialist, Permission, Compute, Notebook capability, Artifact, Electron/Web/CLI/Task adapters remain unchanged.
- Related to #458 only as a forward-compatible internal seam; no orchestration state, relation, event, interface, or public provider target is introduced.

## Acceptance criteria and validation

All checks ran after the final material edit (`6f72b03`) on `origin/main@6074983`:

- Epoch, in-flight, provisional/publication, immutable handle, detach, stale, and rollback invariants -> owner + ACP runtime suites -> 387/387 passed.
- Cross-repository regression -> `npm test -- --run` -> 677 files passed, 15 skipped; 9,945 tests passed, 184 skipped.
- Node/Web type compatibility -> `npm run typecheck` -> passed.
- Repository lint -> `npm run lint` -> 0 errors; 19 existing warnings outside changed files.
- Changed-file formatting -> Prettier check -> passed.
- Patch hygiene -> `git diff --check origin/main...HEAD` -> passed.
- Independent Spec review -> 0 Hard / 0 Judgement after two reported race regressions were fixed and re-reviewed.
- Independent Standards review -> 0 Hard / 0 Judgement.

Uncovered risk: platform-specific process-tree and shutdown effects remain in `AcpRuntime` in this PR; their implementation is unchanged and will move with dedicated teardown tests in A9.1a2.

## Review focus

- No mutable process/connection/lease has two owners: attach consumes it, and detach transfers it before cleanup.
- Only a fully initialized connection becomes publicly current.
- Stale epochs cannot publish, while a failed pre-detach teardown can restore only its exact still-attached published resource.
- The compatibility façade and every transport/capability surface remain unchanged.
