### PR TITLE
perf(agent-context): reduce skill and notebook payloads

### DIFF
--- a/src/main/connectors/custom-skill-doc.test.ts
+++ b/src/main/connectors/custom-skill-doc.test.ts
@@ -30,10 +30,10 @@ describe('renderCustomSkillDoc', () => {
     expect(md).not.toContain('name: mcp-myserver')
     expect(md).toContain('source: connector')
     expect(md).toMatch(/description: ".*Use when.*"/)
-    expect(md).toContain('## When to Use')
+    expect(md.match(/Use when/g)).toHaveLength(1)
     expect(md).toContain('search')
     expect(md).toContain('fetch')
-    expect(md).toContain('"type": "object"')
+    expect(md).toContain('"type":"object"')
     // Runtime routing still uses the display name (the key McpClientManager registers under).
     // No-arg tools render without a third argument (a literal ... would reach the bridge as Ellipsis).
     expect(md).toContain('host.mcp("myserver", "search")')

--- a/src/main/connectors/descriptors/chembl.ts
+++ b/src/main/connectors/descriptors/chembl.ts
@@ -769,7 +769,7 @@ export const CHEMBL_TOOLS: ToolDescriptor[] = [
     returns:
       '`{ count, total (distinct parents, or filtered count when a post-filter is set), truncated, indication_query: { term, match_field, only_approved }, total_indication_rows, drugs: [ { molecule_chembl_id, pref_name, molecule_type, max_phase, first_approval, oral, parenteral, therapeutic_flag, black_box_warning (0/1), topical (0/1), withdrawn_flag, molecule_properties, molecule_structures, molecule_synonyms, best_phase_for_ind, efo_terms: [str], indication_rows: [drugind_id], warning_summary: [ { warning_type, warning_class, warning_country, warning_year } ], ... } ] }`.',
     example:
-      'const result = await host.mcp("chembl", "drug_search", {"indication": "hypertension", "only_approved": True, "limit": 10})',
+      'const result = await host.mcp("chembl", "drug_search", {"indication": "hypertension", "only_approved": true, "limit": 10})',
     run: async (ctx, a) => {
       const limit = clampLimit(a.limit)
       // Post-filters need the full parent set joined; otherwise bound the join to the first page.

--- a/src/main/connectors/descriptors/chemistry.ts
+++ b/src/main/connectors/descriptors/chemistry.ts
@@ -244,7 +244,7 @@ export const CHEMISTRY_TOOLS: ToolDescriptor[] = [
     returns:
       '`{ "n_requested": int, "duplicates": [int], "records": [ {...} ], "not_found": [int] }` — one record per distinct CID (repeats disclosed in `duplicates`, first-occurrence order). Each record carries CID, MolecularFormula, MolecularWeight, SMILES (isomeric), ConnectivitySMILES, InChI, InChIKey, IUPACName, XLogP, ExactMass, TPSA, Charge, HBondDonorCount, HBondAcceptorCount, RotatableBondCount, HeavyAtomCount — plus `synonyms`/`n_synonyms_total`/`synonyms_truncated` when `include_synonyms`. CIDs the API does not know appear in `not_found`.',
     example:
-      'const result = await host.mcp("chemistry", "pubchem_get_compounds", {"cids": [2244, 2519], "include_synonyms": False})',
+      'const result = await host.mcp("chemistry", "pubchem_get_compounds", {"cids": [2244, 2519], "include_synonyms": false})',
     run: async (ctx, a) => {
       const raw = ([] as unknown[]).concat(a.cids as never).map((c) => Number(c))
       if (!raw.length) throw new Error('cids must be non-empty')
@@ -342,7 +342,7 @@ export const CHEMISTRY_TOOLS: ToolDescriptor[] = [
     returns:
       '`{ "cid": int, "active_only": bool, "n_rows_total": int, "truncated": bool, "rows": [ {...} ] }` — each row maps the upstream columns: AID, SID, CID, "Activity Outcome" (Active/Inactive/Unspecified/Inconclusive), "Target Accession", "Target GeneID", "Activity Value [uM]", "Activity Name", "Assay Name", "Assay Type", "PubMed ID". Filtering by `active_only` happens BEFORE the cap, so `n_rows_total` is the true (filtered) count. `rows` is `[]` for compounds with no assay data (not an error).',
     example:
-      'const result = await host.mcp("chemistry", "pubchem_get_bioassay_summary", {"cid": 2244, "active_only": True})',
+      'const result = await host.mcp("chemistry", "pubchem_get_bioassay_summary", {"cid": 2244, "active_only": true})',
     run: async (ctx, a) => {
       const cid = Number(a.cid)
       const maxRows = Number(a.max_rows ?? 100)

--- a/src/main/connectors/descriptors/clinical-trials.ts
+++ b/src/main/connectors/descriptors/clinical-trials.ts
@@ -547,7 +547,7 @@ export const CLINICAL_TRIALS_TOOLS: ToolDescriptor[] = [
     returns:
       '`{ count, total (only when count_total, else null), next_page_token, items: [ { nct_id, title, status, phase (array|null), conditions, interventions, sponsor, enrollment, start_date, primary_completion_date, locations_count, study_type } ] }`.',
     example:
-      'const result = await host.mcp("clinical_trials", "search_trials", {"condition": "lung cancer", "status": ["RECRUITING"], "phase": ["PHASE3"], "count_total": True, "page_size": 10})',
+      'const result = await host.mcp("clinical_trials", "search_trials", {"condition": "lung cancer", "status": ["RECRUITING"], "phase": ["PHASE3"], "count_total": true, "page_size": 10})',
     run: async (ctx, a) => {
       const countTotal = Boolean(a.count_total)
       const page = await fetchPage(
@@ -609,7 +609,7 @@ export const CLINICAL_TRIALS_TOOLS: ToolDescriptor[] = [
     returns:
       'Same shape as search_trials: `{ count, total, next_page_token, items: [ trial summaries ] }`.',
     example:
-      'const result = await host.mcp("clinical_trials", "search_by_sponsor", {"sponsor_name": "Pfizer", "phase": ["PHASE3"], "count_total": True})',
+      'const result = await host.mcp("clinical_trials", "search_by_sponsor", {"sponsor_name": "Pfizer", "phase": ["PHASE3"], "count_total": true})',
     run: async (ctx, a) => {
       const countTotal = Boolean(a.count_total)
       const page = await fetchPage(

--- a/src/main/connectors/descriptors/literature-openalex.ts
+++ b/src/main/connectors/descriptors/literature-openalex.ts
@@ -462,7 +462,7 @@ export const OPENALEX_LITERATURE_TOOLS: ToolDescriptor[] = [
     returns:
       '{query, filters (applied filter object), venue_resolved? , sort, api_total (meta.count), n_records_returned, records_truncated (api_total > returned), records[]} — each record the lean work shape.',
     example:
-      'const result = await host.mcp("literature", "openalex_search_works", {"query": "CRISPR base editing", "year_from": 2020, "open_access_only": True, "sort": "cited_by_count", "max_records": 25})',
+      'const result = await host.mcp("literature", "openalex_search_works", {"query": "CRISPR base editing", "year_from": 2020, "open_access_only": true, "sort": "cited_by_count", "max_records": 25})',
     run: async (ctx, a) => {
       const query = a.query != null && String(a.query).trim() !== '' ? String(a.query) : null
       const sort = String(a.sort ?? 'relevance')

--- a/src/main/connectors/descriptors/omics-archives.ts
+++ b/src/main/connectors/descriptors/omics-archives.ts
@@ -1333,7 +1333,7 @@ export const OMICS_ARCHIVES_TOOLS: ToolDescriptor[] = [
     returns:
       '`{ "n_requested": int, "records": [ { "accession", "title", "description", "study_status", "release_year", "submission_year", "organisms": [{organism,organism_part}], "organism_names": [str], "assays": [{assay_number,measurement,technology,platform,filename}], "assay_count", "technologies": [str], "factors": [str], "descriptors": [str], "sample_count", "protocols": [{name,description}], "sample_table"? } ], "not_found": [str] }` — records sorted by numeric accession.',
     example:
-      'const result = await host.mcp("omics_archives", "metabolights_get_studies", {"accessions": ["MTBLS1"], "include_samples": False})',
+      'const result = await host.mcp("omics_archives", "metabolights_get_studies", {"accessions": ["MTBLS1"], "include_samples": false})',
     run: async (ctx, a) => {
       const unique = sortMtbls(asArr(a.accessions).map(String))
       const includeSamples = Boolean(a.include_samples)
@@ -1507,7 +1507,7 @@ export const OMICS_ARCHIVES_TOOLS: ToolDescriptor[] = [
     returns:
       '`{ "studies": [ { "accession", "secondary_accession", "bioproject", "study_name", "biome_lineages": [str], "samples_count", "centre_name", "data_origination", "is_private", "last_update", "analyses_total"?, "analyses_by_pipeline_version"?, "analyses_by_experiment_type"? } ], "missing": [str], "analyses"?: {acc: [record]} }` — studies sorted by accession.',
     example:
-      'const result = await host.mcp("omics_archives", "mgnify_get_studies", {"accessions": ["MGYS00000410"], "include_analyses": False})',
+      'const result = await host.mcp("omics_archives", "mgnify_get_studies", {"accessions": ["MGYS00000410"], "include_analyses": false})',
     run: async (ctx, a) => {
       const includeAnalyses = Boolean(a.include_analyses)
       const unique = [...new Set(asArr(a.accessions).map(String))].sort()

--- a/src/main/connectors/descriptors/protein-annotation.ts
+++ b/src/main/connectors/descriptors/protein-annotation.ts
@@ -911,7 +911,7 @@ export const PROTEIN_ANNOTATION_TOOLS: ToolDescriptor[] = [
     returns:
       '`{ "count": int, "results": [ { "accession": str, "name": str, "source_database": str, "length": int, "tax_id": int, "organism": str } ] | null }` — `results` is null in count_only mode; otherwise sorted by accession.',
     example:
-      'const result = await host.mcp("protein_annotation", "get_pfam_family_proteins", {"pfam_accession": "PF00069", "count_only": True})',
+      'const result = await host.mcp("protein_annotation", "get_pfam_family_proteins", {"pfam_accession": "PF00069", "count_only": true})',
     run: async (ctx, a) => {
       const acc = String(a.pfam_accession).trim().toUpperCase()
       const db = a.reviewed_only ? 'reviewed' : 'uniprot'

--- a/src/main/connectors/descriptors/structures-complexportal.ts
+++ b/src/main/connectors/descriptors/structures-complexportal.ts
@@ -285,7 +285,7 @@ export const STRUCTURES_COMPLEXPORTAL_TOOLS: ToolDescriptor[] = [
     returns:
       '{query_accession, solr_query, total_reported, total_retrieved, complexes:[{complex_ac, name, species_name, taxid, predicted_complex, interactors:[{identifier, name, interactor_type, stoichiometry_raw}]}]}. complexes are sorted by CPX accession (numeric); total_reported == total_retrieved is enforced or the call throws.',
     example:
-      'const result = await host.mcp("structures", "complexportal_search_by_participant", {"accession": "P69905", "participants_only": True})',
+      'const result = await host.mcp("structures", "complexportal_search_by_participant", {"accession": "P69905", "participants_only": true})',
     run: async (ctx: ToolContext, a: Record<string, unknown>): Promise<unknown> => {
       const accession = String(a.accession).trim()
       const participantsOnly = a.participants_only !== false

--- a/src/main/connectors/descriptors/structures-intact.ts
+++ b/src/main/connectors/descriptors/structures-intact.ts
@@ -448,7 +448,7 @@ export const STRUCTURES_INTACT_TOOLS: ToolDescriptor[] = [
     returns:
       "`{ interaction_ac, short_label, type: {name, mi}, detection_method: {name, mi}, host_organism, negative, publication: {pubmed_id, title, journal, publication_date, authors}, xrefs: [{database, database_mi, identifier, qualifier}], annotations: [{topic, topic_mi, description}], parameters, confidences, participants?: [{participant_ac, short_label, identifier, identifier_database, description, type, species, taxid, biological_role, experimental_role, detection_methods}], n_participants? }`. Unknown AC -> `{ interaction_ac, error: 'not_found' }`.",
     example:
-      'const result = await host.mcp("structures", "intact_get_interaction_details", {"interaction_ac": "EBI-15635490", "include_participants": True})',
+      'const result = await host.mcp("structures", "intact_get_interaction_details", {"interaction_ac": "EBI-15635490", "include_participants": true})',
     run: async (ctx, a): Promise<Record<string, unknown>> => {
       const interactionAc = String(a.interaction_ac)
       const includeParticipants = a.include_participants !== false

--- a/src/main/connectors/descriptors/structures-pdb.ts
+++ b/src/main/connectors/descriptors/structures-pdb.ts
@@ -501,7 +501,7 @@ export const STRUCTURES_PDB_TOOLS: ToolDescriptor[] = [
     returns:
       '{pdb_id, n_polymer_entities (entry total when entity_ids=null, else null), polymer_entity_ids, truncated, records:[{rcsb_id, entity_id, description, polymer_type, sequence_length, source_organisms, uniprot_ids, reference_sequence_identifiers, uniprot_aligned_regions, sequence?}], not_found:[...], sequences_omitted?}.',
     example:
-      'const result = await host.mcp("structures", "pdb_get_entities", {"pdb_id": "1TUP", "include_sequences": True})',
+      'const result = await host.mcp("structures", "pdb_get_entities", {"pdb_id": "1TUP", "include_sequences": true})',
     run: async (ctx, a) => {
       const pdbId = asStr(a.pdb_id).toUpperCase()
       const includeSequences = a.include_sequences === true

--- a/src/main/connectors/skill-doc.test.ts
+++ b/src/main/connectors/skill-doc.test.ts
@@ -1,5 +1,10 @@
 import { describe, it, expect } from 'vitest'
+import { Tiktoken } from 'js-tiktoken/lite'
+import cl100kBase from 'js-tiktoken/ranks/cl100k_base'
 import { renderConnectorInstructions, renderSkillDoc, renderCustomSkillDoc } from './skill-doc'
+import { CONNECTOR_CATALOG } from './catalog'
+
+const tokenizer = new Tiktoken(cl100kBase)
 
 describe('renderConnectorInstructions', () => {
   it('keeps only shared host.mcp conventions in opencode baseline instructions', () => {
@@ -33,25 +38,26 @@ describe('renderConnectorInstructions', () => {
 })
 
 describe('renderSkillDoc', () => {
-  it('renders frontmatter, conventions, and each tool', () => {
+  it('renders a compact self-contained catalog without repeating the shared conventions', () => {
     const md = renderSkillDoc('chemistry')
     expect(md).toContain('name: mcp-chemistry')
     expect(md).toContain('source: connector')
     expect(md).toContain('host.mcp(')
     expect(md).toContain('pubchem_get_compounds')
     expect(md).toContain('rate-limited') // rate warning present
+    expect(md).not.toContain('Do NOT reimplement these calls with raw HTTP')
   })
   it('uses the trigger-style useWhen as the frontmatter description for auto-discovery', () => {
     const md = renderSkillDoc('chemistry')
     // The frontmatter description is what Claude Code matches a plain user question against.
     const frontmatter = md.slice(0, md.indexOf('---', 3))
     expect(frontmatter).toMatch(/description: ".*Use when.*"/)
-    expect(md).toContain('## When to Use')
+    expect(md.match(/Use when/g)).toHaveLength(1)
   })
   it('throws for an unknown connector', () => {
     expect(() => renderSkillDoc('nope')).toThrow()
   })
-  it('renders a tool-authored example as a single realistic call, with no per-tool prose', () => {
+  it('renders a tool-authored example as a single compact realistic call', () => {
     // The example carries only realistic args (better than schema placeholders). General guidance
     // (reuse across cells, return shape) lives once in the shared conventions template — it must NOT
     // be duplicated into each tool's example.
@@ -60,13 +66,10 @@ describe('renderSkillDoc', () => {
       md.indexOf('### search_articles'),
       md.indexOf('### get_article_metadata')
     )
-    const code = block
-      .slice(block.indexOf('```js\n') + '```js\n'.length, block.lastIndexOf('```'))
-      .trim()
-    expect(code).toBe(
+    expect(block).toContain(
       'const result = await host.mcp("pubmed", "search_articles", {"query": "CRISPR gene editing", "max_results": 10})'
     )
-    expect(code).not.toContain('#') // no per-tool comment/prose
+    expect(block).not.toContain('```')
   })
   it('does not hardcode a processing/display method in the doc', () => {
     // Requirement: the skill doc states facts (shape lives in Returns, result is a Python value) but
@@ -123,12 +126,26 @@ describe('renderSkillDoc', () => {
     expect(md).toMatch(/never re-(issue|call)/i)
   })
   it('gives custom MCP servers the same reuse guidance', () => {
-    // renderCustomSkillDoc shares the CONVENTIONS block, so the fix must reach custom servers too.
+    // Custom servers do not always receive the bundled connector baseline, so their compact Skill
+    // still carries the minimum persistence rule without copying the full shared conventions.
     const md = renderCustomSkillDoc(
       { id: 'acme-id', name: 'acme', description: 'Use when you need acme tools.' },
       [{ name: 'do_thing', inputSchema: { type: 'object', properties: { q: { type: 'string' } } } }]
     )
     expect(md).toContain('persistent')
     expect(md).toMatch(/instead of running the call again/)
+  })
+
+  it('keeps the PubMed Skill under a 2.3k-token on-demand budget', () => {
+    const md = renderSkillDoc('pubmed')
+
+    expect(tokenizer.encode(md).length).toBeLessThan(2_300)
+  })
+
+  it('keeps every authored connector example valid for the JavaScript REPL', () => {
+    for (const connector of CONNECTOR_CATALOG) {
+      const md = renderSkillDoc(connector.id)
+      expect(md, connector.id).not.toMatch(/host\.mcp\([^\n]*\b(?:True|False|None)\b/)
+    }
   })
 })

--- a/src/main/connectors/skill-doc.test.ts
+++ b/src/main/connectors/skill-doc.test.ts
@@ -134,6 +134,8 @@ describe('renderSkillDoc', () => {
     )
     expect(md).toContain('persistent')
     expect(md).toMatch(/instead of running the call again/)
+    expect(md).toContain('Do not bypass `host.mcp` with raw HTTP')
+    expect(md).toContain('approval')
   })
 
   it('keeps the PubMed Skill under a 2.3k-token on-demand budget', () => {

--- a/src/main/connectors/skill-doc.ts
+++ b/src/main/connectors/skill-doc.ts
@@ -10,6 +10,11 @@ const CONVENTIONS = [
   'To use a result in a python or r cell, have the REPL write it to `./handoff/<name>.json` (the shared `$OPEN_SCIENCE_HANDOFF_DIR`), then read that file from the data cell — not through the model context.'
 ].join('\n')
 
+// A Skill may be loaded outside the bundled-connector baseline (notably for custom MCP servers), so
+// keep the minimum calling and reuse contract local without copying the full shared policy block.
+const SKILL_CONVENTIONS =
+  'Use from `repl_execute` as `const result = await host.mcp(server, method, {...})`. Results are native JavaScript in a persistent REPL; save reusable values on `globalThis` instead of running the call again, and never re-issue the same upstream call.'
+
 // Placeholder value for one JSON-Schema field in a call example: an enum's first choice or the field's
 // own default when present, otherwise a type-keyed stand-in. Rendered as a JSON literal.
 function sampleValue(spec: { type?: unknown; default?: unknown; enum?: unknown }): string {
@@ -57,17 +62,23 @@ function exampleArgs(schema: unknown): string | undefined {
   return entries.length ? `{${entries.join(', ')}}` : undefined
 }
 
+const inlineCode = (value: string): string => {
+  const longestFence = Math.max(0, ...(value.match(/`+/g) ?? []).map((match) => match.length))
+  const fence = '`'.repeat(longestFence + 1)
+  return `${fence}${value}${fence}`
+}
+
 // Renders one tool's usage example as a copyable repl_execute (JS) cell. Prefers the descriptor's
 // hand-authored `example` (a single `await host.mcp(...)` call with realistic args); otherwise builds a
 // bare call from the schema. A tool with no concrete args renders as `await host.mcp(server, method)`
 // (no third argument) — passing a literal `...` there would reach the bridge and raise, so it's omitted.
 function renderExample(server: string, tool: string, schema: unknown, example?: string): string {
-  if (example) return `Example:\n\n\`\`\`js\n${example}\n\`\`\`\n`
+  if (example) return `**Example:** ${inlineCode(example)}\n`
   const args = exampleArgs(schema)
   const call = args
     ? `host.mcp("${server}", "${tool}", ${args})`
     : `host.mcp("${server}", "${tool}")`
-  return `Example:\n\n\`\`\`js\nconst result = await ${call}\n\`\`\`\n`
+  return `**Example:** ${inlineCode(`const result = await ${call}`)}\n`
 }
 
 // Renders one connector's tools as a searchable skill document (frontmatter + conventions + methods).
@@ -81,14 +92,14 @@ export function renderSkillDoc(connectorId: string): string {
   const methods = tools
     .map(
       (t) =>
-        `### ${t.id}\n\n${t.description}\n\n\`\`\`json\n${JSON.stringify(t.input, null, 2)}\n\`\`\`\n\n` +
+        `### ${t.id}\n\n${t.description}\n\n**Input:** ${inlineCode(JSON.stringify(t.input))}\n\n` +
         (t.returns ? `**Returns:** ${t.returns}\n\n` : '') +
         renderExample(connectorId, t.id, t.input, t.example)
     )
     .join('\n')
   return (
-    `${header}\n## When to Use\n\n${meta.useWhen}\n\n` +
-    `> This connector is rate-limited at the upstream API.\n\n${CONVENTIONS}\n\n## Tools\n\n${methods}`
+    `${header}\n> This connector is rate-limited at the upstream API.\n\n` +
+    `${SKILL_CONVENTIONS}\n\n## Tools\n\n${methods}`
   )
 }
 
@@ -130,12 +141,12 @@ export function renderCustomSkillDoc(
   const methods = tools
     .map(
       (t) =>
-        `### ${t.name}\n\n${t.description ?? ''}\n\n\`\`\`json\n${JSON.stringify(t.inputSchema ?? {}, null, 2)}\n\`\`\`\n\n` +
+        `### ${t.name}\n\n${t.description ?? ''}\n\n**Input:** ${inlineCode(JSON.stringify(t.inputSchema ?? {}))}\n\n` +
         renderExample(server.name, t.name, t.inputSchema)
     )
     .join('\n')
   return (
-    `${header}\n## When to Use\n\n${useWhen}\n\n` +
-    `> This connector is rate-limited at the upstream API.\n\n${CONVENTIONS}\n\n## Tools\n\n${methods}`
+    `${header}\n> This connector is rate-limited at the upstream API.\n\n` +
+    `${SKILL_CONVENTIONS}\n\n## Tools\n\n${methods}`
   )
 }

--- a/src/main/connectors/skill-doc.ts
+++ b/src/main/connectors/skill-doc.ts
@@ -15,6 +15,10 @@ const CONVENTIONS = [
 const SKILL_CONVENTIONS =
   'Use from `repl_execute` as `const result = await host.mcp(server, method, {...})`. Results are native JavaScript in a persistent REPL; save reusable values on `globalThis` instead of running the call again, and never re-issue the same upstream call.'
 
+const CUSTOM_SKILL_CONVENTIONS =
+  `${SKILL_CONVENTIONS} Do not bypass \`host.mcp\` with raw HTTP or calls from Python/R: ` +
+  'the host path enforces approval, tool policy, credentials, and rate limits.'
+
 // Placeholder value for one JSON-Schema field in a call example: an enum's first choice or the field's
 // own default when present, otherwise a type-keyed stand-in. Rendered as a JSON literal.
 function sampleValue(spec: { type?: unknown; default?: unknown; enum?: unknown }): string {
@@ -147,6 +151,6 @@ export function renderCustomSkillDoc(
     .join('\n')
   return (
     `${header}\n> This connector is rate-limited at the upstream API.\n\n` +
-    `${SKILL_CONVENTIONS}\n\n## Tools\n\n${methods}`
+    `${CUSTOM_SKILL_CONVENTIONS}\n\n## Tools\n\n${methods}`
   )
 }

--- a/src/main/notebook/mcp-server.test.ts
+++ b/src/main/notebook/mcp-server.test.ts
@@ -448,6 +448,8 @@ describe('inspect_packages tool', () => {
     expect(compact).toHaveProperty('omittedPackageCount', 30)
     expect(JSON.stringify(compact)).not.toContain('evidenceSources')
     expect(JSON.stringify(compact)).not.toContain('libraryRank')
+    expect(JSON.stringify(compact)).not.toContain('full output in notebook preview')
+    expect(JSON.stringify(compact)).toContain('omitted from this tool response')
     expect(JSON.stringify(compact).length).toBeLessThanOrEqual(NOTEBOOK_MCP_CONTROL_RESULT_LIMIT)
   })
 })
@@ -533,34 +535,38 @@ describe('notebook control tool results', () => {
     }
   })
 
-  it('lists selectable runtimes without interpreter paths or duplicate full bindings', () => {
-    const compact = compactListRuntimesResult({
-      runtimes: [
-        {
+  it('pages selectable runtimes without making omitted runtime IDs undiscoverable', () => {
+    const compact = compactListRuntimesResult(
+      {
+        runtimes: Array.from({ length: 45 }, (_, index) => ({
           language: 'python',
-          runtimeId: 'managed-python',
+          runtimeId: `managed-python-${index}`,
           source: 'managed',
           provenance: 'app-managed',
           interpreterPath: '/private/runtime/bin/python',
-          label: 'Managed Python',
+          label: `Managed Python ${index}`,
           version: '3.13',
           runnable: true,
           bound: true
+        })),
+        bindings: {
+          python: {
+            language: 'python',
+            runtimeId: 'managed-python',
+            source: 'managed',
+            provenance: 'app-managed',
+            interpreterPath: '/private/runtime/bin/python',
+            label: 'Managed Python'
+          }
         }
-      ],
-      bindings: {
-        python: {
-          language: 'python',
-          runtimeId: 'managed-python',
-          source: 'managed',
-          provenance: 'app-managed',
-          interpreterPath: '/private/runtime/bin/python',
-          label: 'Managed Python'
-        }
-      }
-    })
+      },
+      { offset: 40, limit: 5 }
+    ) as Record<string, unknown>
 
-    expect(compact).toMatchObject({ runtimeCount: 1 })
+    expect(compact).toMatchObject({ runtimeCount: 45, offset: 40 })
+    expect(compact.runtimes).toHaveLength(5)
+    expect(compact).not.toHaveProperty('nextOffset')
+    expect(JSON.stringify(compact)).toContain('managed-python-44')
     expect(JSON.stringify(compact)).not.toContain('interpreterPath')
     expect(JSON.stringify(compact)).not.toContain('/private/runtime')
   })
@@ -595,8 +601,8 @@ describe('notebook control tool results', () => {
       sessionId: 'session-1',
       status: 'shutdown'
     })
-    expect(
-      compactManageEnvironmentsResult({
+    const environments = compactManageEnvironmentsResult(
+      {
         environments: Array.from({ length: 40 }, (_, index) => ({
           name: `env-${index}`,
           language: 'python',
@@ -605,8 +611,13 @@ describe('notebook control tool results', () => {
           sizeBytes: 10,
           internalPath: `/private/env-${index}`
         }))
-      })
-    ).toMatchObject({ environmentCount: 40, omittedEnvironmentCount: 10 })
+      },
+      { offset: 30, limit: 10 }
+    ) as Record<string, unknown>
+    expect(environments).toMatchObject({ environmentCount: 40, offset: 30 })
+    expect(environments.environments).toHaveLength(10)
+    expect(environments).not.toHaveProperty('nextOffset')
+    expect(JSON.stringify(environments)).toContain('env-39')
   })
 })
 
@@ -617,7 +628,7 @@ describe('manage_environments tool', () => {
     expect(tool).toBeDefined()
     expect(tool?.method).toBe('manageEnvironments')
     expect(Object.keys(tool?.inputSchema ?? {})).toEqual(
-      expect.arrayContaining(['action', 'language', 'name', 'packages'])
+      expect.arrayContaining(['action', 'language', 'name', 'packages', 'offset', 'limit'])
     )
   })
 

--- a/src/main/notebook/mcp-server.test.ts
+++ b/src/main/notebook/mcp-server.test.ts
@@ -9,6 +9,7 @@ import {
   INSPECT_PACKAGES_DOC,
   MANAGE_ENVIRONMENTS_DOC,
   MANAGE_PACKAGES_DOC,
+  NOTEBOOK_MCP_CONTROL_RESULT_LIMIT,
   NOTEBOOK_MCP_EXECUTION_RESULT_LIMIT,
   NOTEBOOK_MCP_STATE_RESULT_LIMIT,
   REPL_EXECUTE_DOC,
@@ -18,6 +19,11 @@ import {
   compactNotebookExecutionResult,
   compactNotebookStateResult,
   compactManagePackagesResult,
+  compactInspectPackagesResult,
+  compactListRuntimesResult,
+  compactManageEnvironmentsResult,
+  compactRuntimeBindingResult,
+  compactShutdownResult,
   compactRestartResult,
   createNotebookMcpServerConfig,
   serializeNotebookToolResult
@@ -413,6 +419,37 @@ describe('inspect_packages tool', () => {
       packages: ['dplyr']
     })
   })
+
+  it('returns only actionable package status fields with a bounded item count', () => {
+    const packages = Array.from({ length: 80 }, (_, index) => ({
+      requested: `pkg-${index}`,
+      name: `pkg-${index}`,
+      status: 'installed',
+      version: '1.0.0',
+      versionStatus: 'known',
+      ecosystem: 'python',
+      evidenceSources: ['python-importlib-metadata'],
+      libraryRank: index
+    }))
+
+    const compact = compactInspectPackagesResult({
+      language: 'python',
+      environmentName: 'default-python',
+      runtimeSource: 'managed',
+      runtimeId: '/private/runtime/python',
+      runtimeLabel: 'Managed Python',
+      inventory: { capturedAt: 'now', source: 'full-scan', validation: 'full-scan' },
+      packages,
+      warnings: ['x'.repeat(10_000)]
+    }) as Record<string, unknown>
+
+    expect(compact).not.toHaveProperty('runtimeId')
+    expect(compact.packages as unknown[]).toHaveLength(50)
+    expect(compact).toHaveProperty('omittedPackageCount', 30)
+    expect(JSON.stringify(compact)).not.toContain('evidenceSources')
+    expect(JSON.stringify(compact)).not.toContain('libraryRank')
+    expect(JSON.stringify(compact).length).toBeLessThanOrEqual(NOTEBOOK_MCP_CONTROL_RESULT_LIMIT)
+  })
 })
 
 describe('compactManagePackagesResult', () => {
@@ -454,7 +491,6 @@ describe('compactManagePackagesResult', () => {
       ok: true,
       needsRestart: true,
       method: 'conda',
-      prefix: '/runtime/envs/default-r',
       fallbackUsed: false,
       packageChanges: [
         {
@@ -486,6 +522,91 @@ describe('compactManagePackagesResult', () => {
     })
     expect(compactManagePackagesResult(null)).toBeNull()
     expect(compactManagePackagesResult('x')).toBe('x')
+  })
+})
+
+describe('notebook control tool results', () => {
+  it('gives every notebook tool a purpose-specific projection and a global result budget', () => {
+    for (const tool of NOTEBOOK_RPC_TOOLS) {
+      expect(tool.mapResult, tool.name).toBeTypeOf('function')
+      expect(tool.resultLimitChars, tool.name).toBeGreaterThan(0)
+    }
+  })
+
+  it('lists selectable runtimes without interpreter paths or duplicate full bindings', () => {
+    const compact = compactListRuntimesResult({
+      runtimes: [
+        {
+          language: 'python',
+          runtimeId: 'managed-python',
+          source: 'managed',
+          provenance: 'app-managed',
+          interpreterPath: '/private/runtime/bin/python',
+          label: 'Managed Python',
+          version: '3.13',
+          runnable: true,
+          bound: true
+        }
+      ],
+      bindings: {
+        python: {
+          language: 'python',
+          runtimeId: 'managed-python',
+          source: 'managed',
+          provenance: 'app-managed',
+          interpreterPath: '/private/runtime/bin/python',
+          label: 'Managed Python'
+        }
+      }
+    })
+
+    expect(compact).toMatchObject({ runtimeCount: 1 })
+    expect(JSON.stringify(compact)).not.toContain('interpreterPath')
+    expect(JSON.stringify(compact)).not.toContain('/private/runtime')
+  })
+
+  it('projects bind, shutdown, and environment receipts to their next-step fields', () => {
+    expect(
+      compactRuntimeBindingResult({
+        bound: {
+          language: 'r',
+          runtimeId: 'managed-r',
+          source: 'managed',
+          provenance: 'app-managed',
+          interpreterPath: '/private/runtime/bin/R',
+          label: 'Managed R',
+          status: 'active'
+        },
+        bindings: { r: { interpreterPath: '/private/runtime/bin/R' } }
+      })
+    ).toEqual({
+      bound: {
+        language: 'r',
+        runtimeId: 'managed-r',
+        source: 'managed',
+        provenance: 'app-managed',
+        label: 'Managed R',
+        status: 'active'
+      }
+    })
+    expect(
+      compactShutdownResult({ sessionId: 'session-1', status: 'shutdown', cells: [] })
+    ).toEqual({
+      sessionId: 'session-1',
+      status: 'shutdown'
+    })
+    expect(
+      compactManageEnvironmentsResult({
+        environments: Array.from({ length: 40 }, (_, index) => ({
+          name: `env-${index}`,
+          language: 'python',
+          ready: true,
+          isDefault: false,
+          sizeBytes: 10,
+          internalPath: `/private/env-${index}`
+        }))
+      })
+    ).toMatchObject({ environmentCount: 40, omittedEnvironmentCount: 10 })
   })
 })
 

--- a/src/main/notebook/mcp-server.ts
+++ b/src/main/notebook/mcp-server.ts
@@ -271,6 +271,7 @@ const callNotebookRpc = async (
 // deliberately conservative; full values stay in run.json and the notebook preview.
 const NOTEBOOK_MCP_EXECUTION_RESULT_LIMIT = 12_000
 const NOTEBOOK_MCP_STATE_RESULT_LIMIT = 6_000
+const NOTEBOOK_MCP_CONTROL_RESULT_LIMIT = 8_000
 const NOTEBOOK_MCP_STREAM_PREVIEW_LIMIT = 2_500
 const NOTEBOOK_MCP_STATE_OUTPUT_PREVIEW_LIMIT = 600
 const MIME_INLINE_LIMIT = 768
@@ -278,6 +279,9 @@ const MAX_EXECUTION_OUTPUTS = 6
 const MAX_EXECUTION_FILES = 10
 const MAX_STATE_CELLS = 20
 const MAX_STATE_RUNS = 10
+const MAX_RUNTIME_RESULTS = 40
+const MAX_PACKAGE_RESULTS = 50
+const MAX_ENVIRONMENT_RESULTS = 30
 
 const isImageMime = (mime: string): boolean => mime.startsWith('image/')
 
@@ -301,6 +305,33 @@ const pickDefined = (
     if (record[field] !== undefined) picked[field] = record[field]
   }
   return picked
+}
+
+const compactRuntimeBinding = (value: unknown): Record<string, unknown> | undefined => {
+  const record = asRecord(value)
+  return record
+    ? pickDefined(record, [
+        'language',
+        'runtimeId',
+        'source',
+        'provenance',
+        'label',
+        'version',
+        'status',
+        'reason'
+      ])
+    : undefined
+}
+
+const compactRuntimeBindings = (value: unknown): Record<string, unknown> | undefined => {
+  const record = asRecord(value)
+  if (!record) return undefined
+  const bindings: Record<string, unknown> = {}
+  for (const language of ['python', 'r']) {
+    const binding = compactRuntimeBinding(record[language])
+    if (binding) bindings[language] = binding
+  }
+  return Object.keys(bindings).length > 0 ? bindings : undefined
 }
 
 const compactWorkingFiles = (value: unknown): unknown[] => {
@@ -524,22 +555,34 @@ const compactNotebookStateResult = (raw: unknown): unknown => {
       })
     : []
 
+  const runtimeBindings = compactRuntimeBindings(record.runtimeBindings)
+  const environments = Array.isArray(record.environments)
+    ? record.environments.slice(0, MAX_ENVIRONMENT_RESULTS).flatMap((environment) => {
+        const item = asRecord(environment)
+        return item
+          ? [
+              pickDefined(item, [
+                'processKey',
+                'kind',
+                'environment',
+                'status',
+                'restartRecommended'
+              ])
+            ]
+          : []
+      })
+    : []
+
   return {
-    ...pickDefined(record, [
-      'sessionId',
-      'cwd',
-      'dataRoot',
-      'kernelStatus',
-      'activeRunId',
-      'runtimeBindings'
-    ]),
+    ...pickDefined(record, ['sessionId', 'cwd', 'dataRoot', 'kernelStatus', 'activeRunId']),
+    ...(runtimeBindings ? { runtimeBindings } : {}),
     cellCount: Array.isArray(record.cells) ? record.cells.length : 0,
     ...(cells.length ? { cells } : {}),
     runCount: runs.length || recentSource.length,
     recentRuns: recentRuns.map((run, index) =>
       compactStateRun(run, index === recentRuns.length - 1)
     ),
-    ...(Array.isArray(record.environments) ? { environments: record.environments } : {}),
+    ...(environments.length ? { environments } : {}),
     historyCompacted: true,
     note: 'Only recent run metadata and the latest output preview are returned; full history remains in the notebook preview.'
   }
@@ -559,7 +602,7 @@ const serializeNotebookToolResult = (value: unknown, limitChars?: number): strin
   const base = {
     ...identity,
     truncated: true,
-    note: `Agent-facing result exceeded the ${limitChars}-character budget; full output remains in the notebook preview.`
+    note: `Agent-facing result exceeded the ${limitChars}-character budget; additional details were omitted from this tool response.`
   }
   let low = 0
   let high = serialized.length
@@ -624,20 +667,149 @@ const compactRestartResult = (raw: unknown): unknown => {
   }
 }
 
+const compactListRuntimesResult = (raw: unknown): unknown => {
+  const record = asRecord(raw)
+  if (!record) return raw
+  const source = Array.isArray(record.runtimes) ? record.runtimes : []
+  const runtimes = source.slice(0, MAX_RUNTIME_RESULTS).flatMap((runtime) => {
+    const item = asRecord(runtime)
+    return item
+      ? [
+          pickDefined(item, [
+            'language',
+            'runtimeId',
+            'source',
+            'provenance',
+            'label',
+            'version',
+            'runnable',
+            'bound',
+            'status',
+            'reason',
+            'detail'
+          ])
+        ]
+      : []
+  })
+  const bindings = compactRuntimeBindings(record.bindings)
+  return {
+    runtimeCount: source.length,
+    runtimes,
+    ...(source.length > runtimes.length
+      ? { omittedRuntimeCount: source.length - runtimes.length }
+      : {}),
+    ...(bindings ? { bindings } : {})
+  }
+}
+
+const compactRuntimeBindingResult = (raw: unknown): unknown => {
+  const record = asRecord(raw)
+  if (!record) return raw
+  const bound = compactRuntimeBinding(record.bound)
+  return bound ? { bound } : {}
+}
+
+const compactShutdownResult = (raw: unknown): unknown => {
+  const record = asRecord(raw)
+  return record ? pickDefined(record, ['sessionId', 'status']) : raw
+}
+
+const compactInspectPackagesResult = (raw: unknown): unknown => {
+  const record = asRecord(raw)
+  if (!record) return raw
+  const source = Array.isArray(record.packages) ? record.packages : []
+  const packages = source.slice(0, MAX_PACKAGE_RESULTS).flatMap((entry) => {
+    const item = asRecord(entry)
+    return item
+      ? [
+          pickDefined(item, [
+            'requested',
+            'name',
+            'status',
+            'version',
+            'versionStatus',
+            'ecosystem',
+            'loadedState',
+            'builtForRuntime'
+          ])
+        ]
+      : []
+  })
+  const inventory = asRecord(record.inventory)
+  const warnings = Array.isArray(record.warnings)
+    ? record.warnings
+        .filter((warning): warning is string => typeof warning === 'string')
+        .slice(0, 5)
+        .map((warning) => clipAgentText(warning, 500).text)
+    : []
+  return {
+    ...pickDefined(record, ['language', 'environmentName', 'runtimeSource', 'runtimeLabel']),
+    ...(inventory
+      ? { inventory: pickDefined(inventory, ['capturedAt', 'source', 'validation']) }
+      : {}),
+    packages,
+    ...(source.length > packages.length
+      ? { omittedPackageCount: source.length - packages.length }
+      : {}),
+    ...(warnings.length ? { warnings } : {})
+  }
+}
+
+const compactManageEnvironmentsResult = (raw: unknown): unknown => {
+  const record = asRecord(raw)
+  if (!record) return raw
+  const source = Array.isArray(record.environments) ? record.environments : []
+  const environments = source.slice(0, MAX_ENVIRONMENT_RESULTS).flatMap((environment) => {
+    const item = asRecord(environment)
+    return item ? [pickDefined(item, ['name', 'language', 'ready', 'isDefault', 'sizeBytes'])] : []
+  })
+  return {
+    environmentCount: source.length,
+    environments,
+    ...(source.length > environments.length
+      ? { omittedEnvironmentCount: source.length - environments.length }
+      : {})
+  }
+}
+
 // Package installers retain their full stdout/stderr in the main process for diagnostics and
 // provenance, but micromamba's JSON transaction can contain hundreds of FETCH/LINK records. The
 // agent only needs the outcome and actionable error, not the solver's package metadata.
 const compactManagePackagesResult = (raw: unknown): unknown => {
   if (typeof raw !== 'object' || raw === null) return raw
   const result = raw as Record<string, unknown>
+  const packageChanges = Array.isArray(result.packageChanges)
+    ? result.packageChanges.slice(0, MAX_PACKAGE_RESULTS).flatMap((change) => {
+        const item = asRecord(change)
+        return item
+          ? [
+              pickDefined(item, [
+                'name',
+                'ecosystem',
+                'relationship',
+                'change',
+                'beforeVersion',
+                'afterVersion'
+              ])
+            ]
+          : []
+      })
+    : undefined
   return {
     ok: result.ok,
     needsRestart: result.needsRestart,
     ...(result.method !== undefined ? { method: result.method } : {}),
-    ...(result.prefix !== undefined ? { prefix: result.prefix } : {}),
     ...(result.fallbackUsed !== undefined ? { fallbackUsed: result.fallbackUsed } : {}),
-    ...(result.packageChanges !== undefined ? { packageChanges: result.packageChanges } : {}),
-    ...(result.error !== undefined ? { error: result.error } : {})
+    ...(packageChanges !== undefined ? { packageChanges } : {}),
+    ...(Array.isArray(result.packageChanges) &&
+    result.packageChanges.length > (packageChanges?.length ?? 0)
+      ? { omittedPackageChangeCount: result.packageChanges.length - (packageChanges?.length ?? 0) }
+      : {}),
+    ...(typeof result.error === 'string'
+      ? { error: clipAgentText(result.error, 2_000).text }
+      : result.error !== undefined
+        ? { error: result.error }
+        : {})
   }
 }
 
@@ -686,21 +858,27 @@ const NOTEBOOK_RPC_TOOLS: NotebookRpcToolDefinition[] = [
     title: 'List notebook runtimes',
     description: LIST_NOTEBOOK_RUNTIMES_DOC,
     method: 'listRuntimes',
-    inputSchema: listRuntimesToolSchema
+    inputSchema: listRuntimesToolSchema,
+    mapResult: compactListRuntimesResult,
+    resultLimitChars: NOTEBOOK_MCP_CONTROL_RESULT_LIMIT
   },
   {
     name: 'notebook_bind_runtime',
     title: 'Bind a notebook runtime',
     description: BIND_RUNTIME_DOC,
     method: 'bindRuntime',
-    inputSchema: bindRuntimeToolSchema
+    inputSchema: bindRuntimeToolSchema,
+    mapResult: compactRuntimeBindingResult,
+    resultLimitChars: NOTEBOOK_MCP_CONTROL_RESULT_LIMIT
   },
   {
     name: 'notebook_switch_runtime',
     title: 'Switch a notebook runtime',
     description: SWITCH_RUNTIME_DOC,
     method: 'switchRuntime',
-    inputSchema: bindRuntimeToolSchema
+    inputSchema: bindRuntimeToolSchema,
+    mapResult: compactRuntimeBindingResult,
+    resultLimitChars: NOTEBOOK_MCP_CONTROL_RESULT_LIMIT
   },
   {
     name: 'notebook_restart',
@@ -709,21 +887,26 @@ const NOTEBOOK_RPC_TOOLS: NotebookRpcToolDefinition[] = [
       'Restart the shared notebook interpreter, clearing in-memory variables (run history is preserved). RARELY NEEDED: hangs and crashes recover on their own, and installing a package does NOT require a restart — a running kernel picks it up on its next import/library(). Use it only to (a) deliberately wipe the namespace / free memory, or (b) reload a NEWER version of a package you already imported this session.',
     method: 'restart',
     inputSchema: {},
-    mapResult: compactRestartResult
+    mapResult: compactRestartResult,
+    resultLimitChars: NOTEBOOK_MCP_CONTROL_RESULT_LIMIT
   },
   {
     name: 'notebook_shutdown',
     title: 'Shutdown notebook interpreter',
     description: 'Shutdown the shared notebook interpreter without deleting run.json or artifacts.',
     method: 'shutdown',
-    inputSchema: {}
+    inputSchema: {},
+    mapResult: compactShutdownResult,
+    resultLimitChars: NOTEBOOK_MCP_CONTROL_RESULT_LIMIT
   },
   {
     name: 'inspect_packages',
     title: 'Inspect notebook packages',
     description: INSPECT_PACKAGES_DOC,
     method: 'inspectPackages',
-    inputSchema: inspectPackagesToolSchema
+    inputSchema: inspectPackagesToolSchema,
+    mapResult: compactInspectPackagesResult,
+    resultLimitChars: NOTEBOOK_MCP_CONTROL_RESULT_LIMIT
   },
   {
     name: 'manage_packages',
@@ -731,14 +914,17 @@ const NOTEBOOK_RPC_TOOLS: NotebookRpcToolDefinition[] = [
     description: MANAGE_PACKAGES_DOC,
     method: 'managePackages',
     inputSchema: managePackagesToolSchema,
-    mapResult: compactManagePackagesResult
+    mapResult: compactManagePackagesResult,
+    resultLimitChars: NOTEBOOK_MCP_CONTROL_RESULT_LIMIT
   },
   {
     name: 'manage_environments',
     title: 'Manage named notebook environments',
     description: MANAGE_ENVIRONMENTS_DOC,
     method: 'manageEnvironments',
-    inputSchema: manageEnvironmentsToolSchema
+    inputSchema: manageEnvironmentsToolSchema,
+    mapResult: compactManageEnvironmentsResult,
+    resultLimitChars: NOTEBOOK_MCP_CONTROL_RESULT_LIMIT
   }
 ]
 
@@ -774,6 +960,7 @@ export {
   REPL_EXECUTE_DOC,
   BASH_EXECUTE_DOC,
   buildShellExecuteDoc,
+  NOTEBOOK_MCP_CONTROL_RESULT_LIMIT,
   NOTEBOOK_MCP_EXECUTION_RESULT_LIMIT,
   NOTEBOOK_MCP_STATE_RESULT_LIMIT,
   NOTEBOOK_MCP_SERVER_ARG,
@@ -784,6 +971,11 @@ export {
   compactNotebookExecutionResult,
   compactNotebookStateResult,
   compactManagePackagesResult,
+  compactInspectPackagesResult,
+  compactListRuntimesResult,
+  compactManageEnvironmentsResult,
+  compactRuntimeBindingResult,
+  compactShutdownResult,
   compactRestartResult,
   createNotebookMcpEnvironmentFromProcess,
   createNotebookMcpServer,

--- a/src/main/notebook/mcp-server.ts
+++ b/src/main/notebook/mcp-server.ts
@@ -6,6 +6,8 @@ import { z } from 'zod'
 import { NOTEBOOK_MCP_SERVER_ARG } from '../mcp-server-args'
 
 const NOTEBOOK_MCP_SERVER_NAME = 'open-science-notebook'
+const MAX_RUNTIME_RESULTS = 40
+const MAX_ENVIRONMENT_RESULTS = 30
 
 // Scoped prompt addendum that only applies when the agent is given notebook tools.
 const NOTEBOOK_SYSTEM_PROMPT_APPEND = [
@@ -78,10 +80,15 @@ const manageEnvironmentsToolSchema = {
   action: z.enum(['create', 'list', 'remove']),
   language: z.enum(['python', 'r']).optional(),
   name: z.string().optional(),
-  packages: z.array(z.string().min(1)).optional()
+  packages: z.array(z.string().min(1)).optional(),
+  offset: z.number().int().nonnegative().optional(),
+  limit: z.number().int().positive().max(MAX_ENVIRONMENT_RESULTS).optional()
 }
 
-const listRuntimesToolSchema = {}
+const listRuntimesToolSchema = {
+  offset: z.number().int().nonnegative().optional(),
+  limit: z.number().int().positive().max(MAX_RUNTIME_RESULTS).optional()
+}
 
 const bindRuntimeToolSchema = {
   language: z.enum(['python', 'r']),
@@ -106,13 +113,13 @@ const MANAGE_PACKAGES_DOC = [
 
 const MANAGE_ENVIRONMENTS_DOC = [
   'Create, list, or remove named persistent Python/R environments. Each is a separate process and namespace.',
-  'action:"create" needs language and name (optional initial packages); action:"list" reports provisioned environments; action:"remove" accepts a name.',
+  `action:"create" needs language and name (optional initial packages); action:"list" reports provisioned environments in pages of at most ${MAX_ENVIRONMENT_RESULTS} using optional offset/limit and nextOffset; action:"remove" accepts a name.`,
   'Create before bind/switch. Removal is limited to agent-created, idle named environments; defaults, app-managed versioned environments, and external interpreters cannot be removed.',
   'Named data kernels cannot call connectors; use repl_execute and ./handoff/.'
 ].join('\n')
 
 const LIST_NOTEBOOK_RUNTIMES_DOC = [
-  'List enabled managed/external Python/R runtimes and their runtimeId, source, version, runnable, and bound status. Disabled runtimes are omitted.',
+  `List enabled managed/external Python/R runtimes and their runtimeId, source, version, runnable, and bound status in pages of at most ${MAX_RUNTIME_RESULTS} using optional offset/limit and nextOffset. Disabled runtimes are omitted.`,
   'No binding is required for the app-managed default; bind only to select another listed runtime.'
 ].join('\n')
 
@@ -183,7 +190,7 @@ type NotebookRpcToolDefinition = {
   inputSchema: NotebookToolSchema
   // Optional projection of the raw RPC result before it is serialized for the agent. Used to keep
   // a verbose result (e.g. restart returning the whole session state) compact and to-the-point.
-  mapResult?: (raw: unknown) => unknown
+  mapResult?: (raw: unknown, input: unknown) => unknown
   resultLimitChars?: number
 }
 
@@ -279,9 +286,7 @@ const MAX_EXECUTION_OUTPUTS = 6
 const MAX_EXECUTION_FILES = 10
 const MAX_STATE_CELLS = 20
 const MAX_STATE_RUNS = 10
-const MAX_RUNTIME_RESULTS = 40
 const MAX_PACKAGE_RESULTS = 50
-const MAX_ENVIRONMENT_RESULTS = 30
 
 const isImageMime = (mime: string): boolean => mime.startsWith('image/')
 
@@ -292,6 +297,11 @@ const clipAgentText = (text: string, limit: number): { text: string; clipped: bo
     clipped: true
   }
 }
+
+const clipToolDiagnostic = (text: string, limit: number): string =>
+  text.length <= limit
+    ? text
+    : `${text.slice(0, limit)}\n…[${text.length - limit} chars omitted from this tool response]`
 
 const asRecord = (value: unknown): Record<string, unknown> | undefined =>
   typeof value === 'object' && value !== null ? (value as Record<string, unknown>) : undefined
@@ -582,7 +592,11 @@ const compactNotebookStateResult = (raw: unknown): unknown => {
     recentRuns: recentRuns.map((run, index) =>
       compactStateRun(run, index === recentRuns.length - 1)
     ),
+    environmentCount: Array.isArray(record.environments) ? record.environments.length : 0,
     ...(environments.length ? { environments } : {}),
+    ...(Array.isArray(record.environments) && record.environments.length > environments.length
+      ? { omittedEnvironmentCount: record.environments.length - environments.length }
+      : {}),
     historyCompacted: true,
     note: 'Only recent run metadata and the latest output preview are returned; full history remains in the notebook preview.'
   }
@@ -595,7 +609,17 @@ const serializeNotebookToolResult = (value: unknown, limitChars?: number): strin
   if (limitChars === undefined || serialized.length <= limitChars) return serialized
 
   const record = asRecord(value) ?? {}
-  const identity = pickDefined(record, ['status', 'runId', 'sessionId', 'kernelStatus', 'exitCode'])
+  const identity = pickDefined(record, [
+    'status',
+    'runId',
+    'sessionId',
+    'kernelStatus',
+    'exitCode',
+    'offset',
+    'nextOffset',
+    'runtimeCount',
+    'environmentCount'
+  ])
   for (const [key, fieldValue] of Object.entries(identity)) {
     if (typeof fieldValue === 'string') identity[key] = clipAgentText(fieldValue, 256).text
   }
@@ -639,7 +663,7 @@ const registerNotebookRpcTool = (
     },
     async (input) => {
       const raw = await callNotebookRpc(environment, definition.method, input)
-      const result = definition.mapResult ? definition.mapResult(raw) : raw
+      const result = definition.mapResult ? definition.mapResult(raw, input) : raw
       return {
         content: [
           {
@@ -667,11 +691,26 @@ const compactRestartResult = (raw: unknown): unknown => {
   }
 }
 
-const compactListRuntimesResult = (raw: unknown): unknown => {
+const resultPage = (input: unknown, defaultLimit: number): { offset: number; limit: number } => {
+  const record = asRecord(input)
+  const offset =
+    typeof record?.offset === 'number' && Number.isInteger(record.offset) && record.offset >= 0
+      ? record.offset
+      : 0
+  const requestedLimit =
+    typeof record?.limit === 'number' && Number.isInteger(record.limit) && record.limit > 0
+      ? record.limit
+      : defaultLimit
+  return { offset, limit: Math.min(requestedLimit, defaultLimit) }
+}
+
+const compactListRuntimesResult = (raw: unknown, input: unknown = {}): unknown => {
   const record = asRecord(raw)
   if (!record) return raw
   const source = Array.isArray(record.runtimes) ? record.runtimes : []
-  const runtimes = source.slice(0, MAX_RUNTIME_RESULTS).flatMap((runtime) => {
+  const { offset, limit } = resultPage(input, MAX_RUNTIME_RESULTS)
+  const pageSource = source.slice(offset, offset + limit)
+  const runtimes = pageSource.flatMap((runtime) => {
     const item = asRecord(runtime)
     return item
       ? [
@@ -694,9 +733,10 @@ const compactListRuntimesResult = (raw: unknown): unknown => {
   const bindings = compactRuntimeBindings(record.bindings)
   return {
     runtimeCount: source.length,
+    offset,
     runtimes,
-    ...(source.length > runtimes.length
-      ? { omittedRuntimeCount: source.length - runtimes.length }
+    ...(offset + pageSource.length < source.length
+      ? { nextOffset: offset + pageSource.length }
       : {}),
     ...(bindings ? { bindings } : {})
   }
@@ -740,7 +780,7 @@ const compactInspectPackagesResult = (raw: unknown): unknown => {
     ? record.warnings
         .filter((warning): warning is string => typeof warning === 'string')
         .slice(0, 5)
-        .map((warning) => clipAgentText(warning, 500).text)
+        .map((warning) => clipToolDiagnostic(warning, 500))
     : []
   return {
     ...pickDefined(record, ['language', 'environmentName', 'runtimeSource', 'runtimeLabel']),
@@ -751,23 +791,29 @@ const compactInspectPackagesResult = (raw: unknown): unknown => {
     ...(source.length > packages.length
       ? { omittedPackageCount: source.length - packages.length }
       : {}),
-    ...(warnings.length ? { warnings } : {})
+    ...(warnings.length ? { warnings } : {}),
+    ...(Array.isArray(record.warnings) && record.warnings.length > warnings.length
+      ? { omittedWarningCount: record.warnings.length - warnings.length }
+      : {})
   }
 }
 
-const compactManageEnvironmentsResult = (raw: unknown): unknown => {
+const compactManageEnvironmentsResult = (raw: unknown, input: unknown = {}): unknown => {
   const record = asRecord(raw)
   if (!record) return raw
   const source = Array.isArray(record.environments) ? record.environments : []
-  const environments = source.slice(0, MAX_ENVIRONMENT_RESULTS).flatMap((environment) => {
+  const { offset, limit } = resultPage(input, MAX_ENVIRONMENT_RESULTS)
+  const pageSource = source.slice(offset, offset + limit)
+  const environments = pageSource.flatMap((environment) => {
     const item = asRecord(environment)
     return item ? [pickDefined(item, ['name', 'language', 'ready', 'isDefault', 'sizeBytes'])] : []
   })
   return {
     environmentCount: source.length,
+    offset,
     environments,
-    ...(source.length > environments.length
-      ? { omittedEnvironmentCount: source.length - environments.length }
+    ...(offset + pageSource.length < source.length
+      ? { nextOffset: offset + pageSource.length }
       : {})
   }
 }
@@ -806,7 +852,7 @@ const compactManagePackagesResult = (raw: unknown): unknown => {
       ? { omittedPackageChangeCount: result.packageChanges.length - (packageChanges?.length ?? 0) }
       : {}),
     ...(typeof result.error === 'string'
-      ? { error: clipAgentText(result.error, 2_000).text }
+      ? { error: clipToolDiagnostic(result.error, 2_000) }
       : result.error !== undefined
         ? { error: result.error }
         : {})

--- a/src/main/settings/native-responses-compatibility.test.ts
+++ b/src/main/settings/native-responses-compatibility.test.ts
@@ -237,6 +237,27 @@ describe('native Responses compatibility', () => {
     expect(fetchImpl).not.toHaveBeenCalled()
   })
 
+  it('finds a named connector outside the bounded inference catalog', async () => {
+    const fetchImpl = vi.fn<typeof fetch>()
+    const proxy = new NativeResponsesCompatibilityProxy(
+      { baseUrl: 'https://api.minimaxi.com/v1', model: 'MiniMax-M3' },
+      fetchImpl
+    )
+    const catalog = [
+      ...Array.from({ length: 140 }, (_, index) => ({
+        name: `skill-${index}`,
+        description: `Description ${index}`,
+        path: `/skills/${index}/SKILL.md`
+      })),
+      { name: 'mcp-pubmed', description: 'Search PubMed.', path: '/skills/pubmed/SKILL.md' }
+    ]
+
+    await expect(proxy.selectSkills('用 PubMed 搜索文章', catalog)).resolves.toEqual([
+      { name: 'mcp-pubmed', path: '/skills/pubmed/SKILL.md' }
+    ])
+    expect(fetchImpl).not.toHaveBeenCalled()
+  })
+
   it('continues scanning for smaller Skills after a candidate exceeds the catalog byte budget', async () => {
     const fetchImpl = vi.fn(
       async (_url: Parameters<typeof fetch>[0], init?: Parameters<typeof fetch>[1]) => {

--- a/src/main/settings/native-responses-compatibility.test.ts
+++ b/src/main/settings/native-responses-compatibility.test.ts
@@ -198,8 +198,18 @@ describe('native Responses compatibility', () => {
       fetchImpl
     )
     const catalog = [
-      { name: 'mcp-pubmed', description: 'Search PubMed.', path: '/skills/pubmed/SKILL.md' },
-      { name: 'mcp-chemistry', description: 'Search chemistry.', path: '/skills/chem/SKILL.md' }
+      {
+        name: 'mcp-pubmed',
+        description: 'Search PubMed.',
+        path: '/skills/pubmed/SKILL.md',
+        source: 'connector' as const
+      },
+      {
+        name: 'mcp-chemistry',
+        description: 'Search chemistry.',
+        path: '/skills/chem/SKILL.md',
+        source: 'connector' as const
+      }
     ]
 
     await expect(proxy.selectSkills('查找肿瘤免疫相关的生物医学文献', catalog)).resolves.toEqual([
@@ -227,8 +237,18 @@ describe('native Responses compatibility', () => {
       fetchImpl
     )
     const catalog = [
-      { name: 'mcp-pubmed', description: 'Search PubMed.', path: '/skills/pubmed/SKILL.md' },
-      { name: 'mcp-chemistry', description: 'Search chemistry.', path: '/skills/chem/SKILL.md' }
+      {
+        name: 'mcp-pubmed',
+        description: 'Search PubMed.',
+        path: '/skills/pubmed/SKILL.md',
+        source: 'connector' as const
+      },
+      {
+        name: 'mcp-chemistry',
+        description: 'Search chemistry.',
+        path: '/skills/chem/SKILL.md',
+        source: 'connector' as const
+      }
     ]
 
     await expect(proxy.selectSkills('用 PubMed 搜索肿瘤免疫文章', catalog)).resolves.toEqual([
@@ -249,7 +269,12 @@ describe('native Responses compatibility', () => {
         description: `Description ${index}`,
         path: `/skills/${index}/SKILL.md`
       })),
-      { name: 'mcp-pubmed', description: 'Search PubMed.', path: '/skills/pubmed/SKILL.md' }
+      {
+        name: 'mcp-pubmed',
+        description: 'Search PubMed.',
+        path: '/skills/pubmed/SKILL.md',
+        source: 'connector' as const
+      }
     ]
 
     await expect(proxy.selectSkills('用 PubMed 搜索文章', catalog)).resolves.toEqual([

--- a/src/main/settings/native-responses-compatibility.test.ts
+++ b/src/main/settings/native-responses-compatibility.test.ts
@@ -202,7 +202,7 @@ describe('native Responses compatibility', () => {
       { name: 'mcp-chemistry', description: 'Search chemistry.', path: '/skills/chem/SKILL.md' }
     ]
 
-    await expect(proxy.selectSkills('用 PubMed 搜索肿瘤免疫文章', catalog)).resolves.toEqual([
+    await expect(proxy.selectSkills('查找肿瘤免疫相关的生物医学文献', catalog)).resolves.toEqual([
       { name: 'mcp-pubmed', path: '/skills/pubmed/SKILL.md' }
     ])
     expect(fetchImpl).toHaveBeenCalledOnce()
@@ -216,8 +216,25 @@ describe('native Responses compatibility', () => {
       tools: [expect.objectContaining({ type: 'function', name: 'select_skills' })]
     })
     const serializedLogs = JSON.stringify(Object.values(logSpies).flatMap((spy) => spy.mock.calls))
-    expect(serializedLogs).not.toContain('用 PubMed 搜索肿瘤免疫文章')
+    expect(serializedLogs).not.toContain('查找肿瘤免疫相关的生物医学文献')
     expect(serializedLogs).not.toContain('mcp-pubmed')
+  })
+
+  it('selects an explicitly named connector Skill locally without an upstream request', async () => {
+    const fetchImpl = vi.fn<typeof fetch>()
+    const proxy = new NativeResponsesCompatibilityProxy(
+      { baseUrl: 'https://api.minimaxi.com/v1', model: 'MiniMax-M3' },
+      fetchImpl
+    )
+    const catalog = [
+      { name: 'mcp-pubmed', description: 'Search PubMed.', path: '/skills/pubmed/SKILL.md' },
+      { name: 'mcp-chemistry', description: 'Search chemistry.', path: '/skills/chem/SKILL.md' }
+    ]
+
+    await expect(proxy.selectSkills('用 PubMed 搜索肿瘤免疫文章', catalog)).resolves.toEqual([
+      { name: 'mcp-pubmed', path: '/skills/pubmed/SKILL.md' }
+    ])
+    expect(fetchImpl).not.toHaveBeenCalled()
   })
 
   it('continues scanning for smaller Skills after a candidate exceeds the catalog byte budget', async () => {
@@ -225,10 +242,12 @@ describe('native Responses compatibility', () => {
       async (_url: Parameters<typeof fetch>[0], init?: Parameters<typeof fetch>[1]) => {
         const request = JSON.parse(String(init?.body)) as {
           tools: Array<{
-            parameters: { properties: { skill_names: { items: { enum: string[] } } } }
+            parameters: { properties: { skill_names: { items: Record<string, unknown> } } }
           }>
+          instructions: string
         }
-        expect(request.tools[0].parameters.properties.skill_names.items.enum).toContain('mcp-late')
+        expect(request.tools[0].parameters.properties.skill_names.items).toEqual({ type: 'string' })
+        expect(request.instructions).toContain('mcp-late')
         return new Response(
           JSON.stringify({
             output: [
@@ -261,9 +280,9 @@ describe('native Responses compatibility', () => {
       { name: 'mcp-late', description: 'Relevant small Skill.', path: '/skills/late/SKILL.md' }
     ]
 
-    await expect(proxy.selectSkills('use the late Skill', catalog)).resolves.toEqual([
-      { name: 'mcp-late', path: '/skills/late/SKILL.md' }
-    ])
+    await expect(
+      proxy.selectSkills('route this request to a delayed capability', catalog)
+    ).resolves.toEqual([{ name: 'mcp-late', path: '/skills/late/SKILL.md' }])
   })
 
   it('replaces reviewer-session tools with only the scope-bounded reviewer surface', async () => {

--- a/src/main/settings/native-responses-compatibility.ts
+++ b/src/main/settings/native-responses-compatibility.ts
@@ -12,7 +12,7 @@ import {
   boundedSkillSelectorCatalog,
   renderSkillSelectorCatalog,
   resolveSelectedSkills,
-  selectExplicitSkills
+  selectExplicitConnectorSkills
 } from './skill-selector-routing'
 
 // Responses payloads are intentionally open-ended across providers. Keep the compatibility boundary
@@ -342,10 +342,10 @@ export class NativeResponsesCompatibilityProxy {
     signal?: AbortSignal
   ): Promise<ResponsesBridgeSkillInput[]> {
     if (!text.trim() || catalog.length === 0 || signal?.aborted) return []
+    const explicit = selectExplicitConnectorSkills(text, catalog)
+    if (explicit.length > 0) return explicit
     const selectorCatalog = boundedSkillSelectorCatalog(catalog)
     if (selectorCatalog.length === 0) return []
-    const explicit = selectExplicitSkills(text, selectorCatalog)
-    if (explicit.length > 0) return explicit
     if (!this.target.model) return []
 
     const timeout = new AbortController()

--- a/src/main/settings/native-responses-compatibility.ts
+++ b/src/main/settings/native-responses-compatibility.ts
@@ -8,6 +8,12 @@ import type {
   ResponsesBridgeSkillCandidate,
   ResponsesBridgeSkillInput
 } from './responses-bridge'
+import {
+  boundedSkillSelectorCatalog,
+  renderSkillSelectorCatalog,
+  resolveSelectedSkills,
+  selectExplicitSkills
+} from './skill-selector-routing'
 
 // Responses payloads are intentionally open-ended across providers. Keep the compatibility boundary
 // permissive, then validate the fields this module rewrites before touching them.
@@ -40,10 +46,6 @@ type NativeFetch = typeof fetch
 // replayed history, and tool declarations. Match the app's 64 MiB local request envelope so those
 // valid multimodal turns fit while this authenticated loopback boundary remains memory-bounded.
 const MAX_REQUEST_BODY_BYTES = 64 * 1024 * 1024
-const MAX_SKILL_SELECTOR_CANDIDATES = 128
-const MAX_SKILL_SELECTOR_NAME_BYTES = 128
-const MAX_SKILL_SELECTOR_DESCRIPTION_BYTES = 2 * 1024
-const MAX_SKILL_SELECTOR_CATALOG_BYTES = 256 * 1024
 const log = createLogger('native-responses-compatibility')
 const SAFE_NETWORK_ERROR_CODES = new Set([
   'EAI_AGAIN',
@@ -302,31 +304,6 @@ const streamResponse = async (
   response.end()
 }
 
-const boundedSkillCatalog = (
-  catalog: ResponsesBridgeSkillCandidate[]
-): ResponsesBridgeSkillCandidate[] => {
-  const bounded: ResponsesBridgeSkillCandidate[] = []
-  let totalBytes = 2
-  for (const candidate of catalog) {
-    if (bounded.length === MAX_SKILL_SELECTOR_CANDIDATES) break
-    if (
-      !candidate.name ||
-      Buffer.byteLength(candidate.name, 'utf8') > MAX_SKILL_SELECTOR_NAME_BYTES ||
-      Buffer.byteLength(candidate.description, 'utf8') > MAX_SKILL_SELECTOR_DESCRIPTION_BYTES
-    ) {
-      continue
-    }
-    const candidateBytes = Buffer.byteLength(
-      JSON.stringify({ name: candidate.name, description: candidate.description }),
-      'utf8'
-    )
-    if (totalBytes + candidateBytes + 1 > MAX_SKILL_SELECTOR_CATALOG_BYTES) continue
-    totalBytes += candidateBytes + 1
-    bounded.push(candidate)
-  }
-  return bounded
-}
-
 const namespaceToolDeclarations = (tools: ResponsesBridgeNamespacedTool[]): JsonObject[] => {
   const byNamespace = new Map<string, JsonObject[]>()
   for (const tool of tools) {
@@ -364,9 +341,12 @@ export class NativeResponsesCompatibilityProxy {
     catalog: ResponsesBridgeSkillCandidate[],
     signal?: AbortSignal
   ): Promise<ResponsesBridgeSkillInput[]> {
-    if (!text.trim() || catalog.length === 0 || signal?.aborted || !this.target.model) return []
-    const selectorCatalog = boundedSkillCatalog(catalog)
+    if (!text.trim() || catalog.length === 0 || signal?.aborted) return []
+    const selectorCatalog = boundedSkillSelectorCatalog(catalog)
     if (selectorCatalog.length === 0) return []
+    const explicit = selectExplicitSkills(text, selectorCatalog)
+    if (explicit.length > 0) return explicit
+    if (!this.target.model) return []
 
     const timeout = new AbortController()
     let timedOut = false
@@ -389,7 +369,7 @@ export class NativeResponsesCompatibilityProxy {
           stream: false,
           instructions:
             'Select only the Skills needed to execute the current user request. Do not perform the task. Call select_skills exactly once using only catalog names. Return an empty list when no Skill applies.\n\nSkill catalog:\n' +
-            JSON.stringify(selectorCatalog.map(({ name, description }) => ({ name, description }))),
+            renderSkillSelectorCatalog(selectorCatalog),
           input: text,
           tools: [
             {
@@ -402,7 +382,7 @@ export class NativeResponsesCompatibilityProxy {
                   skill_names: {
                     type: 'array',
                     maxItems: 3,
-                    items: { type: 'string', enum: selectorCatalog.map(({ name }) => name) }
+                    items: { type: 'string' }
                   }
                 },
                 required: ['skill_names'],
@@ -433,19 +413,7 @@ export class NativeResponsesCompatibilityProxy {
       const argumentsValue = JSON.parse(call.arguments) as unknown
       if (!isObject(argumentsValue) || !Array.isArray(argumentsValue.skill_names)) return []
 
-      const byName = new Map(
-        selectorCatalog.map((candidate) => [candidate.name, candidate] as const)
-      )
-      const selected: ResponsesBridgeSkillInput[] = []
-      const seen = new Set<string>()
-      for (const name of argumentsValue.skill_names) {
-        if (typeof name !== 'string' || seen.has(name)) continue
-        const candidate = byName.get(name)
-        if (!candidate) continue
-        seen.add(name)
-        selected.push({ name: candidate.name, path: candidate.path })
-        if (selected.length === 3) break
-      }
+      const selected = resolveSelectedSkills(argumentsValue.skill_names, selectorCatalog)
       log.info('native Responses Skill selection completed', {
         model: this.target.model,
         catalogCount: catalog.length,

--- a/src/main/settings/responses-bridge.test.ts
+++ b/src/main/settings/responses-bridge.test.ts
@@ -1710,6 +1710,64 @@ describe('Responses bridge Skill selector', () => {
     expect(upstreamFetch).not.toHaveBeenCalled()
   })
 
+  it('does not treat an ordinary Skill name in natural text as an explicit local selection', async () => {
+    const upstreamFetch = vi.fn(
+      async () =>
+        new Response(
+          JSON.stringify({
+            choices: [
+              {
+                message: {
+                  tool_calls: [
+                    {
+                      function: {
+                        name: 'select_skills',
+                        arguments: JSON.stringify({ skill_names: ['research'] })
+                      }
+                    }
+                  ]
+                }
+              }
+            ]
+          })
+        )
+    )
+    const bridge = new ResponsesBridge(
+      { baseUrl: 'https://vendor.example/v1', model: 'model-a' },
+      upstreamFetch
+    )
+    const mixedCatalog = [
+      ...catalog,
+      { name: 'research', description: 'Research a topic.', path: '/skills/research/SKILL.md' }
+    ]
+
+    await expect(bridge.selectSkills('research cancer treatments', mixedCatalog)).resolves.toEqual([
+      { name: 'research', path: '/skills/research/SKILL.md' }
+    ])
+    expect(upstreamFetch).toHaveBeenCalledOnce()
+  })
+
+  it('finds an explicitly named connector before bounding the inference catalog', async () => {
+    const upstreamFetch = vi.fn<typeof fetch>()
+    const bridge = new ResponsesBridge(
+      { baseUrl: 'https://vendor.example/v1', model: 'model-a' },
+      upstreamFetch
+    )
+    const largeCatalog = [
+      ...Array.from({ length: 140 }, (_, index) => ({
+        name: `skill-${index}`,
+        description: `Description ${index}`,
+        path: `/skills/${index}/SKILL.md`
+      })),
+      { name: 'mcp-pubmed', description: 'Search PubMed.', path: '/skills/pubmed/SKILL.md' }
+    ]
+
+    await expect(bridge.selectSkills('用 PubMed 搜索文章', largeCatalog)).resolves.toEqual([
+      { name: 'mcp-pubmed', path: '/skills/pubmed/SKILL.md' }
+    ])
+    expect(upstreamFetch).not.toHaveBeenCalled()
+  })
+
   it.each([
     ['an upstream error', new Response('provider unavailable', { status: 503 })],
     ['a malformed function result', new Response(JSON.stringify({ choices: [{ message: {} }] }))]

--- a/src/main/settings/responses-bridge.test.ts
+++ b/src/main/settings/responses-bridge.test.ts
@@ -11,6 +11,7 @@ import {
   toolsToChat,
   upstreamErrorMessage
 } from './responses-bridge'
+import { selectExplicitConnectorSkills } from './skill-selector-routing'
 
 describe('Responses-compatible bridge conversion', () => {
   const legacyReviewerMarker = '<open_science_reviewer_session>'
@@ -1608,7 +1609,8 @@ describe('Responses bridge Skill selector', () => {
     {
       name: 'mcp-pubmed',
       description: 'Search biomedical literature.',
-      path: '/private/pubmed/SKILL.md'
+      path: '/private/pubmed/SKILL.md',
+      source: 'connector' as const
     },
     {
       name: 'literature-review',
@@ -1747,6 +1749,18 @@ describe('Responses bridge Skill selector', () => {
     expect(upstreamFetch).toHaveBeenCalledOnce()
   })
 
+  it('does not infer connector provenance from a user-controlled mcp-* name', () => {
+    expect(
+      selectExplicitConnectorSkills('use personal for this task', [
+        {
+          name: 'mcp-personal',
+          description: 'A user-authored Skill.',
+          path: '/skills/personal/SKILL.md'
+        }
+      ])
+    ).toEqual([])
+  })
+
   it('finds an explicitly named connector before bounding the inference catalog', async () => {
     const upstreamFetch = vi.fn<typeof fetch>()
     const bridge = new ResponsesBridge(
@@ -1759,7 +1773,12 @@ describe('Responses bridge Skill selector', () => {
         description: `Description ${index}`,
         path: `/skills/${index}/SKILL.md`
       })),
-      { name: 'mcp-pubmed', description: 'Search PubMed.', path: '/skills/pubmed/SKILL.md' }
+      {
+        name: 'mcp-pubmed',
+        description: 'Search PubMed.',
+        path: '/skills/pubmed/SKILL.md',
+        source: 'connector' as const
+      }
     ]
 
     await expect(bridge.selectSkills('用 PubMed 搜索文章', largeCatalog)).resolves.toEqual([

--- a/src/main/settings/responses-bridge.test.ts
+++ b/src/main/settings/responses-bridge.test.ts
@@ -1661,7 +1661,7 @@ describe('Responses bridge Skill selector', () => {
       upstreamFetch
     )
 
-    const selected = await bridge.selectSkills('用 PubMed 搜索肿瘤免疫文章', catalog)
+    const selected = await bridge.selectSkills('查找肿瘤免疫相关的生物医学文献', catalog)
 
     expect(selected).toEqual(catalog.slice(0, 3).map(({ name, path }) => ({ name, path })))
     expect(upstreamUrl).toBe('https://vendor.example/v1/chat/completions')
@@ -1673,7 +1673,7 @@ describe('Responses bridge Skill selector', () => {
       max_tokens: 512,
       messages: [
         expect.objectContaining({ role: 'system' }),
-        { role: 'user', content: '用 PubMed 搜索肿瘤免疫文章' }
+        { role: 'user', content: '查找肿瘤免疫相关的生物医学文献' }
       ],
       tools: [
         {
@@ -1692,8 +1692,22 @@ describe('Responses bridge Skill selector', () => {
     expect(upstreamBody).not.toHaveProperty('tool_choice')
     const serialized = JSON.stringify(upstreamBody)
     expect(serialized).toContain('Search biomedical literature.')
+    expect(serialized.match(/mcp-pubmed/g)).toHaveLength(1)
     expect(serialized).not.toContain('/private/')
     expect(serialized).not.toContain('secret-key')
+  })
+
+  it('selects an explicitly named connector Skill locally without an upstream request', async () => {
+    const upstreamFetch = vi.fn<typeof fetch>()
+    const bridge = new ResponsesBridge(
+      { baseUrl: 'https://vendor.example/v1', model: 'deepseek-v4-flash' },
+      upstreamFetch
+    )
+
+    await expect(bridge.selectSkills('用 PubMed 搜索肿瘤免疫文章', catalog)).resolves.toEqual([
+      { name: 'mcp-pubmed', path: '/private/pubmed/SKILL.md' }
+    ])
+    expect(upstreamFetch).not.toHaveBeenCalled()
   })
 
   it.each([
@@ -1749,12 +1763,18 @@ describe('Responses bridge Skill selector', () => {
     const request = JSON.parse(upstreamBody) as {
       messages: Array<{ content: string }>
       tools: Array<{
-        function: { parameters: { properties: { skill_names: { items: { enum: string[] } } } } }
+        function: {
+          parameters: { properties: { skill_names: { items: Record<string, unknown> } } }
+        }
       }>
     }
-    const names = request.tools[0].function.parameters.properties.skill_names.items.enum
+    const catalogJson = request.messages[0].content.split('Skill catalog:\n')[1]
+    const names = (JSON.parse(catalogJson) as Array<{ name: string }>).map(({ name }) => name)
     expect(names).toHaveLength(128)
     expect(names).not.toContain('oversized')
+    expect(request.tools[0].function.parameters.properties.skill_names.items).toEqual({
+      type: 'string'
+    })
     expect(request.messages[0].content).not.toContain('x'.repeat(10_000))
     expect(Buffer.byteLength(upstreamBody, 'utf8')).toBeLessThan(300 * 1024)
   })

--- a/src/main/settings/responses-bridge.ts
+++ b/src/main/settings/responses-bridge.ts
@@ -64,6 +64,7 @@ export type ResponsesBridgeSkillCandidate = {
   name: string
   description: string
   path: string
+  source?: 'connector'
 }
 
 export type ResponsesBridgeSkillInput = Pick<ResponsesBridgeSkillCandidate, 'name' | 'path'>

--- a/src/main/settings/responses-bridge.ts
+++ b/src/main/settings/responses-bridge.ts
@@ -13,7 +13,7 @@ import {
   boundedSkillSelectorCatalog,
   renderSkillSelectorCatalog,
   resolveSelectedSkills,
-  selectExplicitSkills
+  selectExplicitConnectorSkills
 } from './skill-selector-routing'
 
 // The bridge deliberately keeps protocol payloads open-ended; validation rejects unsupported shapes
@@ -1059,10 +1059,10 @@ export class ResponsesBridge {
     signal?: AbortSignal
   ): Promise<ResponsesBridgeSkillInput[]> {
     if (!text.trim() || catalog.length === 0 || signal?.aborted) return []
+    const explicit = selectExplicitConnectorSkills(text, catalog)
+    if (explicit.length > 0) return explicit
     const selectorCatalog = boundedSkillSelectorCatalog(catalog)
     if (selectorCatalog.length === 0) return []
-    const explicit = selectExplicitSkills(text, selectorCatalog)
-    if (explicit.length > 0) return explicit
 
     const timeout = new AbortController()
     let timedOut = false

--- a/src/main/settings/responses-bridge.ts
+++ b/src/main/settings/responses-bridge.ts
@@ -9,6 +9,12 @@ import type {
   CustomReasoningEffortTransport,
   ModelReasoningEffort
 } from '../../shared/reasoning-effort'
+import {
+  boundedSkillSelectorCatalog,
+  renderSkillSelectorCatalog,
+  resolveSelectedSkills,
+  selectExplicitSkills
+} from './skill-selector-routing'
 
 // The bridge deliberately keeps protocol payloads open-ended; validation rejects unsupported shapes
 // at the boundary before values reach the upstream request.
@@ -67,36 +73,6 @@ type ResponsesBridgeOptions = {
 }
 
 type BridgeFetch = typeof fetch
-
-const MAX_SKILL_SELECTOR_CANDIDATES = 128
-const MAX_SKILL_SELECTOR_NAME_BYTES = 128
-const MAX_SKILL_SELECTOR_DESCRIPTION_BYTES = 2 * 1024
-const MAX_SKILL_SELECTOR_CATALOG_BYTES = 256 * 1024
-
-const boundedSkillSelectorCatalog = (
-  catalog: ResponsesBridgeSkillCandidate[]
-): ResponsesBridgeSkillCandidate[] => {
-  const bounded: ResponsesBridgeSkillCandidate[] = []
-  let catalogBytes = 2 // JSON array brackets
-  for (const candidate of catalog) {
-    if (bounded.length === MAX_SKILL_SELECTOR_CANDIDATES) break
-    if (
-      !candidate.name ||
-      Buffer.byteLength(candidate.name, 'utf8') > MAX_SKILL_SELECTOR_NAME_BYTES ||
-      Buffer.byteLength(candidate.description, 'utf8') > MAX_SKILL_SELECTOR_DESCRIPTION_BYTES
-    ) {
-      continue
-    }
-    const projectedBytes = Buffer.byteLength(
-      JSON.stringify({ name: candidate.name, description: candidate.description }),
-      'utf8'
-    )
-    if (catalogBytes + projectedBytes + 1 > MAX_SKILL_SELECTOR_CATALOG_BYTES) continue
-    catalogBytes += projectedBytes + 1
-    bounded.push(candidate)
-  }
-  return bounded
-}
 
 class BridgeHttpError extends Error {
   constructor(
@@ -1085,6 +1061,8 @@ export class ResponsesBridge {
     if (!text.trim() || catalog.length === 0 || signal?.aborted) return []
     const selectorCatalog = boundedSkillSelectorCatalog(catalog)
     if (selectorCatalog.length === 0) return []
+    const explicit = selectExplicitSkills(text, selectorCatalog)
+    if (explicit.length > 0) return explicit
 
     const timeout = new AbortController()
     let timedOut = false
@@ -1112,9 +1090,7 @@ export class ResponsesBridge {
               role: 'system',
               content:
                 'You are a Skill routing classifier. Select only the Skills needed to execute the current user request. Do not perform the task. Call select_skills exactly once. Use only catalog names. Return an empty list when no Skill applies.\n\nSkill catalog:\n' +
-                JSON.stringify(
-                  selectorCatalog.map(({ name, description }) => ({ name, description }))
-                )
+                renderSkillSelectorCatalog(selectorCatalog)
             },
             { role: 'user', content: text }
           ],
@@ -1130,7 +1106,7 @@ export class ResponsesBridge {
                     skill_names: {
                       type: 'array',
                       maxItems: 3,
-                      items: { type: 'string', enum: selectorCatalog.map(({ name }) => name) }
+                      items: { type: 'string' }
                     }
                   },
                   required: ['skill_names'],
@@ -1166,19 +1142,7 @@ export class ResponsesBridge {
 
       const args = JSON.parse(call.function.arguments) as JsonObject
       const requested = Array.isArray(args.skill_names) ? args.skill_names : []
-      const byName = new Map(
-        selectorCatalog.map((candidate) => [candidate.name, candidate] as const)
-      )
-      const selected: ResponsesBridgeSkillInput[] = []
-      const seen = new Set<string>()
-      for (const name of requested) {
-        if (typeof name !== 'string' || seen.has(name)) continue
-        const candidate = byName.get(name)
-        if (!candidate) continue
-        seen.add(name)
-        selected.push({ name: candidate.name, path: candidate.path })
-        if (selected.length === 3) break
-      }
+      const selected = resolveSelectedSkills(requested, selectorCatalog)
       log.info('bridge skill selection completed', {
         model: this.target.model,
         catalogCount: catalog.length,

--- a/src/main/settings/service.test.ts
+++ b/src/main/settings/service.test.ts
@@ -3778,7 +3778,8 @@ describe('SettingsService: skills', () => {
           expect.objectContaining({
             name: 'mcp-pubmed',
             description: expect.stringContaining('biomedical literature'),
-            path: join(storageRoot, 'codex', 'skills', 'mcp-pubmed', 'SKILL.md')
+            path: join(storageRoot, 'codex', 'skills', 'mcp-pubmed', 'SKILL.md'),
+            source: 'connector'
           })
         ])
       )

--- a/src/main/settings/service.test.ts
+++ b/src/main/settings/service.test.ts
@@ -1162,7 +1162,8 @@ describe('SettingsService: providers', () => {
       'utf8'
     )
     expect(chemistrySkill).toContain('pubchem_get_compounds')
-    expect(chemistrySkill).toContain('```json')
+    expect(chemistrySkill).toContain('**Input:**')
+    expect(chemistrySkill).not.toContain('```json')
   })
 
   it('rejects an invalid custom context window when IPC bypasses the form', async () => {

--- a/src/main/settings/service.ts
+++ b/src/main/settings/service.ts
@@ -495,7 +495,7 @@ class SettingsService {
 
   async codexSkillCatalog(
     codexHome: string | undefined
-  ): Promise<Array<{ name: string; description: string; path: string }>> {
+  ): Promise<Array<{ name: string; description: string; path: string; source?: 'connector' }>> {
     return this.skills.codexSkillCatalog(codexHome, (settings) => {
       return this.connectors.enabledConnectorIds(settings.connectors).flatMap((id) => {
         const connector = CONNECTOR_CATALOG.find((candidate) => candidate.id === id)
@@ -504,7 +504,8 @@ class SettingsService {
               {
                 directory: `mcp-${id}`,
                 name: `mcp-${id}`,
-                description: connector.useWhen
+                description: connector.useWhen,
+                source: 'connector' as const
               }
             ]
           : []

--- a/src/main/settings/skill-catalog.ts
+++ b/src/main/settings/skill-catalog.ts
@@ -41,7 +41,12 @@ import { provisionAppClaudeConfigDir } from './claude-config-provision'
 import type { SettingsRepository } from './repository'
 import type { StoredSettings } from './types'
 
-type SkillCatalogEntry = { name: string; description: string; path: string }
+type SkillCatalogEntry = {
+  name: string
+  description: string
+  path: string
+  source?: 'connector'
+}
 type AdditionalSkillCatalogEntry = Omit<SkillCatalogEntry, 'path'> & { directory: string }
 type AdditionalSkillCatalogEntries =
   | readonly AdditionalSkillCatalogEntry[]
@@ -178,7 +183,7 @@ class SkillCatalogModule {
         ? await additionalEntries(settings)
         : additionalEntries
     const disabled = new Set(settings.disabledSkillIds ?? [])
-    const enabled = [
+    const enabled: AdditionalSkillCatalogEntry[] = [
       ...skills
         .filter((skill) => !disabled.has(skill.id))
         .map((skill) => ({
@@ -196,7 +201,12 @@ class SkillCatalogModule {
       const filePath = join(skillsRoot, item.directory, 'SKILL.md')
       const realFile = await realpath(filePath).catch(() => undefined)
       if (!realFile || !realFile.startsWith(rootWithSep)) continue
-      result.push({ name: item.name, description: item.description, path: filePath })
+      result.push({
+        name: item.name,
+        description: item.description,
+        path: filePath,
+        ...(item.source ? { source: item.source } : {})
+      })
     }
     return result.sort((a, b) => a.name.localeCompare(b.name))
   }

--- a/src/main/settings/skill-selector-routing.ts
+++ b/src/main/settings/skill-selector-routing.ts
@@ -2,6 +2,7 @@ export type SkillSelectorCandidate = {
   name: string
   description: string
   path: string
+  source?: 'connector'
 }
 
 export type SkillSelectorInput = Pick<SkillSelectorCandidate, 'name' | 'path'>
@@ -65,6 +66,7 @@ export const selectExplicitConnectorSkills = <T extends SkillSelectorCandidate>(
   const normalizedText = normalize(text)
   const selected: SkillSelectorInput[] = []
   for (const candidate of catalog) {
+    if (candidate.source !== 'connector') continue
     const matches = connectorAliasesFor(candidate.name).some((alias) => {
       if (!alias) return false
       return new RegExp(`(?:^|[^a-z0-9])${escapeRegExp(alias)}(?:$|[^a-z0-9])`, 'i').test(

--- a/src/main/settings/skill-selector-routing.ts
+++ b/src/main/settings/skill-selector-routing.ts
@@ -1,0 +1,100 @@
+export type SkillSelectorCandidate = {
+  name: string
+  description: string
+  path: string
+}
+
+export type SkillSelectorInput = Pick<SkillSelectorCandidate, 'name' | 'path'>
+
+const MAX_CANDIDATES = 128
+const MAX_NAME_BYTES = 128
+const MAX_DESCRIPTION_BYTES = 2 * 1024
+const MAX_CATALOG_BYTES = 256 * 1024
+
+const compactDescription = (description: string): string => description.replace(/\s+/g, ' ').trim()
+
+export const boundedSkillSelectorCatalog = <T extends SkillSelectorCandidate>(
+  catalog: T[]
+): T[] => {
+  const bounded: T[] = []
+  let catalogBytes = 2
+  for (const original of catalog) {
+    if (bounded.length === MAX_CANDIDATES) break
+    const description = compactDescription(original.description)
+    if (
+      !original.name ||
+      Buffer.byteLength(original.name, 'utf8') > MAX_NAME_BYTES ||
+      Buffer.byteLength(description, 'utf8') > MAX_DESCRIPTION_BYTES
+    ) {
+      continue
+    }
+    const candidate =
+      description === original.description ? original : ({ ...original, description } as T)
+    const projectedBytes = Buffer.byteLength(
+      JSON.stringify({ name: candidate.name, description: candidate.description }),
+      'utf8'
+    )
+    if (catalogBytes + projectedBytes + 1 > MAX_CATALOG_BYTES) continue
+    catalogBytes += projectedBytes + 1
+    bounded.push(candidate)
+  }
+  return bounded
+}
+
+const normalize = (value: string): string =>
+  value.normalize('NFKC').toLowerCase().replace(/[-_]+/g, ' ')
+
+const escapeRegExp = (value: string): string => value.replace(/[.*+?^${}()|[\]\\]/g, '\\$&')
+
+const aliasesFor = (name: string): string[] => {
+  const normalized = normalize(name).trim()
+  const aliases = [normalized]
+  if (normalized.startsWith('mcp ')) {
+    const connectorName = normalized.slice('mcp '.length).trim()
+    if (connectorName.length >= 4) aliases.push(connectorName)
+  }
+  return aliases
+}
+
+// Exact Skill names (and the familiar connector name without `mcp-`) need no model inference. The
+// ASCII boundary guards prevent names such as `r` or `write` from matching inside ordinary words.
+export const selectExplicitSkills = <T extends SkillSelectorCandidate>(
+  text: string,
+  catalog: T[]
+): SkillSelectorInput[] => {
+  const normalizedText = normalize(text)
+  const selected: SkillSelectorInput[] = []
+  for (const candidate of catalog) {
+    const matches = aliasesFor(candidate.name).some((alias) => {
+      if (!alias) return false
+      return new RegExp(`(?:^|[^a-z0-9])${escapeRegExp(alias)}(?:$|[^a-z0-9])`, 'i').test(
+        normalizedText
+      )
+    })
+    if (!matches) continue
+    selected.push({ name: candidate.name, path: candidate.path })
+    if (selected.length === 3) break
+  }
+  return selected
+}
+
+export const renderSkillSelectorCatalog = (catalog: SkillSelectorCandidate[]): string =>
+  JSON.stringify(catalog.map(({ name, description }) => ({ name, description })))
+
+export const resolveSelectedSkills = <T extends SkillSelectorCandidate>(
+  requested: unknown[],
+  catalog: T[]
+): SkillSelectorInput[] => {
+  const byName = new Map(catalog.map((candidate) => [candidate.name, candidate] as const))
+  const selected: SkillSelectorInput[] = []
+  const seen = new Set<string>()
+  for (const name of requested) {
+    if (typeof name !== 'string' || seen.has(name)) continue
+    const candidate = byName.get(name)
+    if (!candidate) continue
+    seen.add(name)
+    selected.push({ name: candidate.name, path: candidate.path })
+    if (selected.length === 3) break
+  }
+  return selected
+}

--- a/src/main/settings/skill-selector-routing.ts
+++ b/src/main/settings/skill-selector-routing.ts
@@ -46,26 +46,26 @@ const normalize = (value: string): string =>
 
 const escapeRegExp = (value: string): string => value.replace(/[.*+?^${}()|[\]\\]/g, '\\$&')
 
-const aliasesFor = (name: string): string[] => {
+const connectorAliasesFor = (name: string): string[] => {
   const normalized = normalize(name).trim()
+  if (!normalized.startsWith('mcp ')) return []
   const aliases = [normalized]
-  if (normalized.startsWith('mcp ')) {
-    const connectorName = normalized.slice('mcp '.length).trim()
-    if (connectorName.length >= 4) aliases.push(connectorName)
-  }
+  const connectorName = normalized.slice('mcp '.length).trim()
+  if (connectorName.length >= 4) aliases.push(connectorName)
   return aliases
 }
 
-// Exact Skill names (and the familiar connector name without `mcp-`) need no model inference. The
-// ASCII boundary guards prevent names such as `r` or `write` from matching inside ordinary words.
-export const selectExplicitSkills = <T extends SkillSelectorCandidate>(
+// Exact connector Skill names (and the familiar connector name without `mcp-`) need no model
+// inference. Ordinary Skill names still use semantic routing because words such as "research" are
+// often request content rather than an explicit selection. ASCII guards prevent substring matches.
+export const selectExplicitConnectorSkills = <T extends SkillSelectorCandidate>(
   text: string,
   catalog: T[]
 ): SkillSelectorInput[] => {
   const normalizedText = normalize(text)
   const selected: SkillSelectorInput[] = []
   for (const candidate of catalog) {
-    const matches = aliasesFor(candidate.name).some((alias) => {
+    const matches = connectorAliasesFor(candidate.name).some((alias) => {
       if (!alias) return false
       return new RegExp(`(?:^|[^a-z0-9])${escapeRegExp(alias)}(?:$|[^a-z0-9])`, 'i').test(
         normalizedText


### PR DESCRIPTION
## Problem

ACP agents repeatedly receive duplicated connector guidance and verbose Notebook results. Codex compatibility paths also spend a separate model request selecting a Skill when the user already names a connector such as PubMed.

## Proposed change

- Compact generated connector Skills while retaining exact tool schemas, return shapes, examples, reuse guidance, and the custom MCP security boundary.
- Project every Notebook MCP result to the fields needed for the next step. Bound execution results to 12,000 characters, state to 6,000 characters with 10 recent runs, and control results to 8,000 characters.
- Keep runtime and environment discovery complete through bounded offset/limit pagination with nextOffset.
- Route explicitly named mcp-* connector Skills locally before building the bounded inference catalog. Preserve semantic model selection for ordinary Skills and unnamed connectors.
- Correct existing connector examples that used Python boolean literals in JavaScript REPL calls.

## Scope and non-goals

- No renderer, database, persisted Notebook data, or data-relationship changes.
- No unified connector gateway or extra describe inference.
- Full execution history and artifacts remain persisted; only agent-facing tool receipts are shortened.
- Existing sessions may need a new agent session to rematerialize updated Skill documents.

## Acceptance criteria and validation

All checks below ran after the final rebase onto main:

- Connector Skill compaction, calling guidance, and custom MCP security boundary -> targeted Vitest files in the command below -> passed.
- Notebook execution/state/control projection and discovery pagination -> src/main/notebook/mcp-server.test.ts -> passed.
- Explicit connector routing, bounded semantic fallback, and bridge parity -> both selector/compatibility test files -> passed.
- `npm test -- --run src/main/connectors/skill-doc.test.ts src/main/connectors/custom-skill-doc.test.ts src/main/notebook/mcp-server.test.ts src/main/settings/responses-bridge.test.ts src/main/settings/native-responses-compatibility.test.ts src/main/settings/service.test.ts` -> 371 passed.
- `npm run typecheck` -> passed.
- `npm run lint` -> 0 errors; 19 pre-existing warnings in unmodified files.
- `npm test` -> 9,944 passed, 184 skipped.

Independent standards and specification reviews reported no remaining findings.

## Review focus

- Whether projected Notebook fields preserve every next-step decision while removing duplicated payloads.
- Whether pagination preserves runtime/environment discoverability under the response budgets.
- Whether local connector matching remains narrow enough to avoid bypassing semantic selection for ordinary Skills.

## Uncovered risk

Actual token savings vary by provider tokenizer, cache accounting, loaded connector, and tool payload shape. Unit tests enforce payload budgets and routing behavior, but do not reproduce provider-side billing counters.