### PR TITLE
refactor(notebook): extract run terminalization owner

### DIFF
--- a/src/main/notebook/run-terminalization.test.ts
+++ b/src/main/notebook/run-terminalization.test.ts
@@ -1,0 +1,360 @@
+import { describe, expect, it } from 'vitest'
+
+import type {
+  NotebookEnvironmentManifest,
+  NotebookOutput,
+  NotebookRunDocument,
+  NotebookRunRecord,
+  NotebookRunStatus
+} from '../../shared/notebook'
+import { NotebookRunTerminalizationOwner } from './run-terminalization'
+
+const session = {
+  projectName: 'project-1',
+  sessionId: 'session-1',
+  notebookSessionRoot: '/storage/notebooks/project-1/session-1',
+  dataRoot: '/storage/notebooks/project-1/session-1/data'
+}
+
+const runningRun = (
+  runId: string,
+  kernelKind: NotebookRunRecord['kernelKind'] = 'python'
+): NotebookRunRecord =>
+  ({
+    runId,
+    cellId: 'cell-1',
+    source: 'agent',
+    inputKind: 'cell',
+    kernelKind,
+    script: 'print("hello")',
+    status: 'running',
+    startedAt: 100,
+    cwdBefore: session.dataRoot,
+    executionCount: 1,
+    text: { stdout: '', stderr: '', traceback: '', plain: [] },
+    outputs: [],
+    artifacts: [],
+    workingFiles: [],
+    inputFiles: []
+  }) satisfies NotebookRunRecord
+
+const documentWith = (runs: NotebookRunRecord[]): NotebookRunDocument => ({
+  version: 1,
+  projectName: session.projectName,
+  sessionId: session.sessionId,
+  workspaceCwd: '/workspace',
+  notebookSessionRoot: session.notebookSessionRoot,
+  dataRoot: session.dataRoot,
+  kernel: {
+    language: 'python',
+    kernelName: 'python3',
+    runtimeRoot: '/storage/runtime',
+    lastKnownStatus: 'running'
+  },
+  runs,
+  updatedAt: 100
+})
+
+const completedResult = (
+  status: NotebookRunStatus = 'completed'
+): {
+  status: NotebookRunStatus
+  stdout: string
+  stderr: string
+  traceback: string
+  cwdAfter: string
+  outputs: NotebookOutput[]
+} => ({
+  status,
+  stdout: 'hello\n',
+  stderr: '',
+  traceback: '',
+  cwdAfter: session.dataRoot,
+  outputs: [{ type: 'stream' as const, name: 'stdout' as const, text: 'hello\n' }]
+})
+
+const environmentManifest: NotebookEnvironmentManifest = {
+  schemaVersion: 1,
+  captureKind: 'completed-run',
+  capturedAt: '2026-08-03T00:00:00.000Z',
+  installedInventory: {
+    capturedAt: '2026-08-03T00:00:00.000Z',
+    source: 'full-scan',
+    validation: 'full-scan'
+  },
+  kernelKind: 'python',
+  environmentName: 'default-python',
+  runtimeSource: 'managed',
+  inventorySources: ['kernel-native'],
+  packages: [],
+  complete: true,
+  captureStatus: 'complete'
+}
+
+const createHarness = (
+  options: {
+    now?: () => number
+    appendFailure?: Error
+    updateFailure?: Error
+    omitUpdatedRun?: boolean
+  } = {}
+): {
+  owner: NotebookRunTerminalizationOwner
+  events: string[]
+  document: () => NotebookRunDocument
+} => {
+  const events: string[] = []
+  let document = documentWith([])
+  const owner = new NotebookRunTerminalizationOwner({
+    repository: {
+      appendRun: async ({ run }) => {
+        events.push(`append:${run.status}`)
+        if (options.appendFailure) throw options.appendFailure
+        document = documentWith([...document.runs, run])
+        return document
+      },
+      updateRun: async ({ run }) => {
+        events.push(`update:${run.status}`)
+        if (options.updateFailure) throw options.updateFailure
+        document = documentWith(
+          document.runs.map((candidate) => (candidate.runId === run.runId ? run : candidate))
+        )
+        return options.omitUpdatedRun ? documentWith([]) : document
+      }
+    },
+    notifyChanged: () => events.push(`notify:${document.runs[0]?.status}`),
+    now: options.now ?? (() => 200)
+  })
+  return { owner, events, document: () => document }
+}
+
+describe('NotebookRunTerminalizationOwner', () => {
+  it('allocates distinct run identities while preserving the shared sequence value', () => {
+    const owner = new NotebookRunTerminalizationOwner({
+      repository: {
+        appendRun: async () => {
+          throw new Error('not used')
+        },
+        updateRun: async () => {
+          throw new Error('not used')
+        }
+      },
+      notifyChanged: () => undefined,
+      now: () => 123
+    })
+
+    expect(owner.allocateRunIdentity()).toEqual({
+      runId: 'notebook-run-123-1',
+      sequence: 1
+    })
+    expect(owner.allocateRunIdentity()).toEqual({
+      runId: 'notebook-run-123-2',
+      sequence: 2
+    })
+  })
+
+  it('commits one terminal record before post-commit work and the final notification', async () => {
+    const harness = createHarness()
+    const running = runningRun('run-1')
+
+    const terminalized = await harness.owner.run({
+      session,
+      runningRun: running,
+      invoke: async () => {
+        harness.events.push('invoke')
+        return completedResult()
+      },
+      postCommit: (result, run) => {
+        harness.events.push(`post-commit:${result.status}:${run.status}`)
+      }
+    })
+
+    expect(harness.events).toEqual([
+      'append:running',
+      'notify:running',
+      'invoke',
+      'update:completed',
+      'post-commit:completed:completed',
+      'notify:completed'
+    ])
+    const document = harness.document()
+    expect(document.runs).toHaveLength(1)
+    expect(document.runs[0]).toMatchObject({
+      runId: 'run-1',
+      status: 'completed',
+      endedAt: 200,
+      text: { stdout: 'hello\n', plain: ['hello\n'] },
+      environmentCapture: { state: 'unavailable', reason: 'environment-capture-failed' }
+    })
+    expect(terminalized.run).toEqual(document.runs[0])
+    expect(terminalized.result.status).toBe('completed')
+  })
+
+  it.each(['failed', 'timeout', 'cancelled'] as const)(
+    'persists a normalized %s result as the terminal status',
+    async (status) => {
+      const harness = createHarness()
+
+      await harness.owner.run({
+        session,
+        runningRun: runningRun(`run-${status}`),
+        invoke: async () => completedResult(status)
+      })
+
+      expect(harness.document().runs[0]).toMatchObject({
+        runId: `run-${status}`,
+        status,
+        endedAt: 200
+      })
+      expect(harness.events.filter((event) => event.startsWith('update:'))).toEqual([
+        `update:${status}`
+      ])
+    }
+  )
+
+  it.each(['repl', 'bash'] as const)(
+    'uses the unsupported evidence fallback for %s runs',
+    async (kernelKind) => {
+      const harness = createHarness()
+
+      await harness.owner.run({
+        session,
+        runningRun: runningRun(`run-${kernelKind}`, kernelKind),
+        invoke: async () => completedResult()
+      })
+
+      expect(harness.document().runs[0]?.environmentCapture).toEqual({
+        state: 'unavailable',
+        reason: 'environment-not-supported'
+      })
+    }
+  )
+
+  it('persists available environment evidence and omits stale evidence when unavailable', async () => {
+    const available = createHarness()
+    await available.owner.run({
+      session,
+      runningRun: runningRun('run-available'),
+      invoke: async () => ({
+        ...completedResult(),
+        environmentCapture: { state: 'available' as const, manifestChecksum: 'checksum-1' },
+        environmentManifest,
+        environmentManifestChecksum: 'checksum-1'
+      })
+    })
+    expect(available.document().runs[0]).toMatchObject({
+      environmentCapture: { state: 'available', manifestChecksum: 'checksum-1' },
+      environmentManifest,
+      environmentManifestChecksum: 'checksum-1'
+    })
+
+    const unavailable = createHarness()
+    await unavailable.owner.run({
+      session,
+      runningRun: runningRun('run-unavailable'),
+      invoke: async () => ({
+        ...completedResult(),
+        environmentCapture: { state: 'unavailable' as const, reason: 'environment-capture-failed' },
+        environmentManifest,
+        environmentManifestChecksum: 'stale-checksum'
+      })
+    })
+    expect(unavailable.document().runs[0]).not.toHaveProperty('environmentManifest')
+    expect(unavailable.document().runs[0]).not.toHaveProperty('environmentManifestChecksum')
+  })
+
+  it('keeps the running record when invocation rejects unexpectedly', async () => {
+    const harness = createHarness()
+
+    await expect(
+      harness.owner.run({
+        session,
+        runningRun: runningRun('run-rejected'),
+        invoke: async () => {
+          harness.events.push('invoke')
+          throw new Error('unexpected rejection')
+        }
+      })
+    ).rejects.toThrow('unexpected rejection')
+
+    expect(harness.events).toEqual(['append:running', 'notify:running', 'invoke'])
+    expect(harness.document().runs[0]).toMatchObject({ runId: 'run-rejected', status: 'running' })
+  })
+
+  it('does not invoke or notify when the initial append fails', async () => {
+    const harness = createHarness({ appendFailure: new Error('append failed') })
+
+    await expect(
+      harness.owner.run({
+        session,
+        runningRun: runningRun('run-append-failed'),
+        invoke: async () => {
+          harness.events.push('invoke')
+          return completedResult()
+        }
+      })
+    ).rejects.toThrow('append failed')
+
+    expect(harness.events).toEqual(['append:running'])
+    expect(harness.document().runs).toEqual([])
+  })
+
+  it('keeps the running record when the terminal update fails', async () => {
+    const harness = createHarness({ updateFailure: new Error('update failed') })
+
+    await expect(
+      harness.owner.run({
+        session,
+        runningRun: runningRun('run-update-failed'),
+        invoke: async () => completedResult()
+      })
+    ).rejects.toThrow('update failed')
+
+    expect(harness.events).toEqual(['append:running', 'notify:running', 'update:completed'])
+    expect(harness.document().runs[0]).toMatchObject({
+      runId: 'run-update-failed',
+      status: 'running'
+    })
+  })
+
+  it('leaves the terminal update committed when post-commit work fails', async () => {
+    const harness = createHarness()
+
+    await expect(
+      harness.owner.run({
+        session,
+        runningRun: runningRun('run-post-commit-failed'),
+        invoke: async () => completedResult(),
+        postCommit: () => {
+          harness.events.push('post-commit')
+          throw new Error('post-commit failed')
+        }
+      })
+    ).rejects.toThrow('post-commit failed')
+
+    expect(harness.events).toEqual([
+      'append:running',
+      'notify:running',
+      'update:completed',
+      'post-commit'
+    ])
+    expect(harness.document().runs[0]).toMatchObject({
+      runId: 'run-post-commit-failed',
+      status: 'completed'
+    })
+  })
+
+  it('reports a missing same-id record returned by the repository', async () => {
+    const harness = createHarness({ omitUpdatedRun: true })
+
+    await expect(
+      harness.owner.run({
+        session,
+        runningRun: runningRun('run-missing'),
+        invoke: async () => completedResult()
+      })
+    ).rejects.toThrow('Notebook run not found after update: run-missing')
+
+    expect(harness.events).toEqual(['append:running', 'notify:running', 'update:completed'])
+  })
+})

--- a/src/main/notebook/run-terminalization.ts
+++ b/src/main/notebook/run-terminalization.ts
@@ -1,0 +1,124 @@
+import type {
+  NotebookEnvironmentManifest,
+  NotebookOutput,
+  NotebookRunEnvironmentCapture,
+  NotebookRunRecord,
+  NotebookRunStatus,
+  NotebookWorkingFile
+} from '../../shared/notebook'
+import type { NotebookRunRepository } from './repository'
+
+type NotebookRunIdentity = Readonly<{
+  runId: string
+  sequence: number
+}>
+
+type NotebookRunTerminalizationSession = Readonly<{
+  projectName: string
+  sessionId: string
+}>
+
+type NotebookRunTerminalResult = {
+  status: NotebookRunStatus
+  stdout: string
+  stderr: string
+  traceback: string
+  cwdAfter?: string
+  outputs: NotebookOutput[]
+  workingFiles?: NotebookWorkingFile[]
+  environmentManifest?: NotebookEnvironmentManifest
+  environmentManifestChecksum?: string
+  environmentCapture?: NotebookRunEnvironmentCapture
+}
+
+type TerminalizeNotebookRunRequest<Result extends NotebookRunTerminalResult> = {
+  session: NotebookRunTerminalizationSession
+  runningRun: NotebookRunRecord
+  invoke: () => Promise<Result>
+  postCommit?: (result: Result, run: NotebookRunRecord) => void
+}
+
+type NotebookRunTerminalizationOwnerOptions = {
+  repository: Pick<NotebookRunRepository, 'appendRun' | 'updateRun'>
+  notifyChanged: (session: NotebookRunTerminalizationSession) => void
+  now?: () => number
+}
+
+const outputPlainText = (stdout: string, stderr: string): string[] =>
+  [stdout, stderr].filter((text) => text.trim().length > 0)
+
+class NotebookRunTerminalizationOwner {
+  private sequence = 0
+  private readonly now: () => number
+
+  constructor(private readonly options: NotebookRunTerminalizationOwnerOptions) {
+    this.now = options.now ?? (() => Date.now())
+  }
+
+  allocateRunIdentity(): NotebookRunIdentity {
+    this.sequence += 1
+    return {
+      runId: `notebook-run-${this.now()}-${this.sequence}`,
+      sequence: this.sequence
+    }
+  }
+
+  async run<Result extends NotebookRunTerminalResult>(
+    request: TerminalizeNotebookRunRequest<Result>
+  ): Promise<{ run: NotebookRunRecord; result: Result }> {
+    const { session, runningRun } = request
+    await this.options.repository.appendRun({
+      projectName: session.projectName,
+      sessionId: session.sessionId,
+      run: runningRun
+    })
+    this.options.notifyChanged(session)
+
+    const result = await request.invoke()
+    const environmentCapture: NotebookRunEnvironmentCapture =
+      result.environmentCapture ??
+      (runningRun.kernelKind === 'python' || runningRun.kernelKind === 'r'
+        ? { state: 'unavailable', reason: 'environment-capture-failed' }
+        : { state: 'unavailable', reason: 'environment-not-supported' })
+    const terminalRun: NotebookRunRecord = {
+      ...runningRun,
+      status: result.status,
+      endedAt: this.now(),
+      cwdAfter: result.cwdAfter,
+      text: {
+        stdout: result.stdout,
+        stderr: result.stderr,
+        traceback: result.traceback,
+        plain: outputPlainText(result.stdout, result.stderr)
+      },
+      // The normalized outputs already include any traceback; appending another error output would
+      // make the preview render it twice.
+      outputs: result.outputs,
+      workingFiles: result.workingFiles ?? [],
+      environmentCapture,
+      ...(environmentCapture.state !== 'unavailable' && result.environmentManifest
+        ? { environmentManifest: result.environmentManifest }
+        : {}),
+      ...(environmentCapture.state !== 'unavailable' && result.environmentManifestChecksum
+        ? { environmentManifestChecksum: result.environmentManifestChecksum }
+        : {})
+    }
+    const document = await this.options.repository.updateRun({
+      projectName: session.projectName,
+      sessionId: session.sessionId,
+      run: terminalRun
+    })
+    const run = document.runs.find((candidate) => candidate.runId === runningRun.runId)
+
+    if (!run) {
+      throw new Error(`Notebook run not found after update: ${runningRun.runId}`)
+    }
+
+    request.postCommit?.(result, run)
+    this.options.notifyChanged(session)
+
+    return { run, result }
+  }
+}
+
+export { NotebookRunTerminalizationOwner }

--- a/src/main/notebook/runtime-service.test.ts
+++ b/src/main/notebook/runtime-service.test.ts
@@ -528,6 +528,117 @@ describe('notebook runtime service', () => {
     })
   })
 
+  it('does not invoke the executor when the initial running record cannot be persisted', async () => {
+    const root = await createStorageRoot()
+    const repository = new NotebookRunRepository(root)
+    const appendError = new Error('could not append running run')
+    vi.spyOn(repository, 'appendRun').mockRejectedValue(appendError)
+    const execute = vi.fn(async (request: NotebookExecutionRequest) => ({
+      status: 'completed' as const,
+      stdout: '',
+      stderr: '',
+      traceback: '',
+      cwdAfter: request.cwd,
+      outputs: []
+    }))
+    const service = new NotebookRuntimeService({
+      configRoot: root,
+      dataRoot: root,
+      projectName: 'default-project',
+      repository,
+      executorFactory: () => ({
+        execute,
+        shutdown: async () => ({ reaped: true })
+      })
+    })
+    const begin = await service.beginCodeCell({ sessionId: 'session-1', workspaceCwd: root })
+    await service.appendCodeCell({
+      sessionId: 'session-1',
+      workspaceCwd: root,
+      cellId: begin.cellId,
+      writeId: begin.writeId,
+      delta: '1 + 1'
+    })
+    await service.finishCodeCell({
+      sessionId: 'session-1',
+      workspaceCwd: root,
+      cellId: begin.cellId,
+      writeId: begin.writeId
+    })
+
+    await expect(
+      service.runCell({ sessionId: 'session-1', workspaceCwd: root, cellId: begin.cellId })
+    ).rejects.toBe(appendError)
+
+    expect(execute).not.toHaveBeenCalled()
+    const state = await service.state({ sessionId: 'session-1', workspaceCwd: root })
+    expect(state.runs).toEqual([])
+    expect(state.activeRunId).toMatch(/^notebook-run-/)
+  })
+
+  it('leaves the running record recoverable when its terminal update cannot be persisted', async () => {
+    const root = await createStorageRoot()
+    const repository = new NotebookRunRepository(root)
+    const updateError = new Error('could not persist terminal run')
+    vi.spyOn(repository, 'updateRun').mockRejectedValue(updateError)
+    const execute = vi.fn(async (request: NotebookExecutionRequest) => ({
+      status: 'completed' as const,
+      stdout: 'done\n',
+      stderr: '',
+      traceback: '',
+      cwdAfter: request.cwd,
+      outputs: [{ type: 'stream' as const, name: 'stdout' as const, text: 'done\n' }]
+    }))
+    const service = new NotebookRuntimeService({
+      configRoot: root,
+      dataRoot: root,
+      projectName: 'default-project',
+      repository,
+      environmentStateTracker: {
+        ...verifiedPackageMutationTracker(),
+        prepareRun: vi.fn().mockResolvedValue(undefined),
+        captureCompletedRun: vi.fn().mockRejectedValue(new Error('capture unavailable'))
+      },
+      executorFactory: () => ({
+        execute,
+        shutdown: async () => ({ reaped: true })
+      })
+    })
+    const begin = await service.beginCodeCell({ sessionId: 'session-1', workspaceCwd: root })
+    await service.appendCodeCell({
+      sessionId: 'session-1',
+      workspaceCwd: root,
+      cellId: begin.cellId,
+      writeId: begin.writeId,
+      delta: 'print("done")'
+    })
+    await service.finishCodeCell({
+      sessionId: 'session-1',
+      workspaceCwd: root,
+      cellId: begin.cellId,
+      writeId: begin.writeId
+    })
+
+    await expect(
+      service.runCell({ sessionId: 'session-1', workspaceCwd: root, cellId: begin.cellId })
+    ).rejects.toBe(updateError)
+
+    expect(execute).toHaveBeenCalledOnce()
+    const document = await repository.loadOrCreate({
+      projectName: 'default-project',
+      sessionId: 'session-1',
+      workspaceCwd: root
+    })
+    expect(document.runs).toHaveLength(1)
+    expect(document.runs[0]).toMatchObject({
+      runId: expect.stringMatching(/^notebook-run-/),
+      status: 'running',
+      script: 'print("done")'
+    })
+    const state = await service.state({ sessionId: 'session-1', workspaceCwd: root })
+    expect(state.activeRunId).toBe(document.runs[0]?.runId)
+  })
+
   it('rejects install.packages in an R cell before the managed kernel executes it', async () => {
     const root = await createStorageRoot()
     const execute = vi.fn(async () => ({

--- a/src/main/notebook/runtime-service.test.ts
+++ b/src/main/notebook/runtime-service.test.ts
@@ -418,14 +418,17 @@ describe('notebook runtime service', () => {
       cellId: begin.cellId
     })
 
+    const now = vi.spyOn(Date, 'now').mockReturnValue(42)
     const summary = await service.runCell({
       projectName: 'default-project',
       sessionId: 'session-1',
       workspaceCwd: '/workspace',
       cellId: begin.cellId
     })
+    now.mockRestore()
 
     expect(summary).toMatchObject({
+      runId: 'notebook-run-42-1',
       cellId: begin.cellId,
       source: 'agent',
       script: "print('hello')",
@@ -1516,11 +1519,13 @@ describe('notebook runtime service', () => {
       const root = await createStorageRoot()
       const service = createShellService(root)
 
+      const now = vi.spyOn(Date, 'now').mockReturnValue(42)
       const result = await service.executeShell({
         sessionId: 'session-1',
         workspaceCwd: root,
         command: 'echo hi'
       })
+      now.mockRestore()
 
       expect(result.stdout).toContain('hi')
       expect(result.exitCode).toBe(0)
@@ -1528,6 +1533,7 @@ describe('notebook runtime service', () => {
       const state = await service.state({ sessionId: 'session-1', workspaceCwd: root })
       expect(state.runs).toHaveLength(1)
       expect(state.runs[0]).toMatchObject({
+        runId: 'notebook-run-42-1',
         kernelKind: 'bash',
         script: 'echo hi',
         status: 'completed',

--- a/src/main/notebook/runtime-service.ts
+++ b/src/main/notebook/runtime-service.ts
@@ -17,8 +17,6 @@ import type {
   ExportNotebookResult,
   FinishNotebookCodeCellRequest,
   NotebookEnvironmentStatus,
-  NotebookEnvironmentManifest,
-  NotebookRunEnvironmentCapture,
   NotebookKernelMetadata,
   NotebookLanguage,
   NotebookOutput,
@@ -124,6 +122,7 @@ import {
 import { startWorkingFileObservation } from './working-file-observer'
 import { NotebookRuntimeBindingOwner } from './runtime-binding'
 import type { RuntimeDiagnosticLogger } from './runtime-diagnostics'
+import { NotebookRunTerminalizationOwner } from './run-terminalization'
 
 // Locale fallback when no explicit locale is injected (see shared/mirror.ts: non-CN locales resolve
 // to public hosts, so this default never silently forces a CN mirror).
@@ -495,10 +494,6 @@ const resolveNotebookArtifactOutputs = async (
 
   return outputsByRun
 }
-
-// Builds the compact plain text output list shown in the preview panel.
-const outputPlainText = (stdout: string, stderr: string): string[] =>
-  [stdout, stderr].filter((text) => text.trim().length > 0)
 
 // Turns unexpected executor exceptions into ordinary run results for the agent to inspect.
 const errorToExecutionResult = (error: unknown, cwd: string): NotebookExecutionResult => {
@@ -889,13 +884,13 @@ const resolveDefaultExecutorOptions = (): NotebookKernelExecutorOptions => {
 // Coordinates notebook cells, shared interpreters, persisted run history, and UI notifications.
 class NotebookRuntimeService {
   private readonly repository: NotebookRunRepository
+  private readonly runTerminalization: NotebookRunTerminalizationOwner
   private readonly sessions: NotebookSessionRegistry<RuntimeSession>
   private readonly announcedAgentSessionIds = new Set<string>()
   // Owns process-global operation admission, provisioning progress, restart recommendations,
   // revocation drains, repair blocks, and installer diagnostics. The service remains the compatibility
   // facade and chooses which execution/package path enters each environment operation.
   private readonly environmentOperations: NotebookEnvironmentOperations
-  private runSequence = 0
   private mcpRpcConnectionResolver:
     ((binding: McpRpcConnectionBinding) => Promise<McpRpcConnection>) | undefined
   private controlCompletionInterceptor: NotebookControlCompletionInterceptor | undefined
@@ -966,6 +961,10 @@ class NotebookRuntimeService {
         logger: this.runtimeLogger
       })
     this.environmentManager = options.environmentManager
+    this.runTerminalization = new NotebookRunTerminalizationOwner({
+      repository: this.repository,
+      notifyChanged: (session) => this.notifyNotebookChanged(session as RuntimeSession)
+    })
   }
 
   private legacyRuntimeSettingsCapability(
@@ -1297,8 +1296,7 @@ class NotebookRuntimeService {
     request: RunNotebookCellRequest
   ): Promise<NotebookRunSummary> {
     this.notifyNotebookAvailable(session, request.source ?? 'agent')
-    this.runSequence += 1
-    const runId = `notebook-run-${Date.now()}-${this.runSequence}`
+    const { runId } = this.runTerminalization.allocateRunIdentity()
     const startedAt = Date.now()
     const executionCount = session.nextExecutionCount()
     const cwdBefore = session.cwd
@@ -1457,7 +1455,7 @@ class NotebookRuntimeService {
     // A policy/binding/interpreter rejection never reaches the kernel, so preserve its current
     // lifecycle status instead of briefly publishing a false 'running'. For a viable dispatch, clear
     // any stale terminated flag so a completing run can settle back to 'idle'. No notify: the run
-    // record's own appendRun notify (in persistRun below) surfaces the fresh status to the renderer.
+    // terminalization owner's append notification surfaces the fresh status to the renderer.
     const kernelMarkedRunning = interpreterResolveError === undefined
     if (kernelMarkedRunning) {
       session.clearKernelTerminated(processKey)
@@ -1471,10 +1469,10 @@ class NotebookRuntimeService {
     // per-ENV lock, so it can never overlap an install into that same env (§5, G2/D5).
     let executedOnLiveKernel = true
     let reachedExecutor = false
-    const { run } = await this.persistRun(
+    const { run } = await this.runTerminalization.run({
       session,
       runningRun,
-      () =>
+      invoke: () =>
         this.environmentOperations.runShared('execution', env, async () => {
           // The run may have waited behind an installer after computing interpreterResolveError above.
           // Re-read the repair gate only after the shared run lease is acquired so a transaction that
@@ -1575,11 +1573,11 @@ class NotebookRuntimeService {
             }
           }
         }),
-      (result) => {
+      postCommit: (result) => {
         // The next run starts in whatever directory the shared interpreter ended in.
         session.completeCellRun(cell.id, result.status, result.cwdAfter ?? cwdBefore)
       }
-    )
+    })
 
     // A run that completed through the executor proves the kernel is alive. A dispatch that was
     // marked running but failed during a post-lock preflight never touched the kernel and must also
@@ -1623,9 +1621,8 @@ class NotebookRuntimeService {
   // repl_execute calls run one at a time on the single control process.
   async executeControl(request: ExecuteNotebookControlRequest): Promise<NotebookControlResult> {
     const session = await this.ensureSession(request)
-    this.runSequence += 1
-    const controlInvocationGeneration = this.runSequence
-    const controlInvocationId = `notebook-run-${Date.now()}-${this.runSequence}`
+    const { runId: controlInvocationId, sequence: controlInvocationGeneration } =
+      this.runTerminalization.allocateRunIdentity()
     const execute = (): Promise<NotebookControlResult> =>
       this.executeControlExclusive(
         session,
@@ -1722,46 +1719,49 @@ class NotebookRuntimeService {
     }
 
     let executedOnLiveKernel = !blockedMutation
-    const { result } = await this.persistRun(session, runningRun, () =>
-      (blockedMutation
-        ? Promise.resolve(
-            errorToExecutionResult(
-              new Error(`MANAGED_RUNTIME_MUTATION_BLOCKED: ${blockedMutation.message}`),
-              session.cwd
+    const { result } = await this.runTerminalization.run({
+      session,
+      runningRun,
+      invoke: () =>
+        (blockedMutation
+          ? Promise.resolve(
+              errorToExecutionResult(
+                new Error(`MANAGED_RUNTIME_MUTATION_BLOCKED: ${blockedMutation.message}`),
+                session.cwd
+              )
             )
-          )
-        : (() => {
-            const releaseControlInvocation = mcpRpc?.beginControlInvocation?.({
-              turnId: runId,
-              controlInvocationGeneration,
-              toolInvocationId: runId
-            })
-            return session
-              .execute({
-                code: request.code,
-                kind: 'repl',
-                cwd: session.cwd,
-                notebookSessionRoot: session.notebookSessionRoot,
-                dataRoot: session.dataRoot,
-                runtimeRoot: session.runtimeRoot,
-                protectedDirs: [getAppClaudeConfigDir(this.options.configRoot)],
-                timeoutMs: request.timeoutMs,
-                mcpRpcEndpoint: mcpRpc?.endpoint,
-                mcpRpcToken: mcpRpc?.token,
-                // Grant-scope identity for host.compute (This conversation / This project). The executor
-                // forwards these into the repl kernel's spawn env; only the control path carries them.
-                sessionId: session.sessionId,
-                projectName: session.projectName,
-                inputRunLeaseId: request.inputRunLeaseId,
-                controlInvocationId: runId
+          : (() => {
+              const releaseControlInvocation = mcpRpc?.beginControlInvocation?.({
+                turnId: runId,
+                controlInvocationGeneration,
+                toolInvocationId: runId
               })
-              .finally(() => releaseControlInvocation?.())
-          })()
-      ).catch((error: unknown) => {
-        executedOnLiveKernel = false
-        return errorToExecutionResult(error, session.cwd)
-      })
-    )
+              return session
+                .execute({
+                  code: request.code,
+                  kind: 'repl',
+                  cwd: session.cwd,
+                  notebookSessionRoot: session.notebookSessionRoot,
+                  dataRoot: session.dataRoot,
+                  runtimeRoot: session.runtimeRoot,
+                  protectedDirs: [getAppClaudeConfigDir(this.options.configRoot)],
+                  timeoutMs: request.timeoutMs,
+                  mcpRpcEndpoint: mcpRpc?.endpoint,
+                  mcpRpcToken: mcpRpc?.token,
+                  // Grant-scope identity for host.compute (This conversation / This project). The executor
+                  // forwards these into the repl kernel's spawn env; only the control path carries them.
+                  sessionId: session.sessionId,
+                  projectName: session.projectName,
+                  inputRunLeaseId: request.inputRunLeaseId,
+                  controlInvocationId: runId
+                })
+                .finally(() => releaseControlInvocation?.())
+            })()
+        ).catch((error: unknown) => {
+          executedOnLiveKernel = false
+          return errorToExecutionResult(error, session.cwd)
+        })
+    })
 
     // Same live-kernel signal as runCellExclusive: a control run that reached the executor settles the
     // kernel back to 'idle', unless it was lost mid-flight (then 'terminated' survives to the next run).
@@ -1789,8 +1789,7 @@ class NotebookRuntimeService {
   async executeShell(request: ExecuteShellRequest): Promise<NotebookShellResult> {
     const session = await this.ensureSession(request)
 
-    this.runSequence += 1
-    const runId = `notebook-run-${Date.now()}-${this.runSequence}`
+    const { runId } = this.runTerminalization.allocateRunIdentity()
     const runningRun: NotebookRunRecord = {
       runId,
       cellId: `bash-${runId}`,
@@ -1814,61 +1813,65 @@ class NotebookRuntimeService {
       inputFiles: request.provenanceContext ? (request.registeredInputFiles ?? []) : []
     }
 
-    const { result } = await this.persistRun(session, runningRun, async () => {
-      const workingFileObservation = await startWorkingFileObservation(session)
-      let workingFiles: NotebookWorkingFile[] = []
-      const blockedMutation = detectManagedRuntimeMutation({
-        source: request.command,
-        surface: this.options.platform === 'win32' ? 'powershell' : 'bash',
-        runtimeRoot: session.runtimeRoot,
-        cwd: session.cwd
-      })
-      const shellResult = await (
-        blockedMutation
-          ? Promise.resolve<NotebookShellResult>({
-              stdout: '',
-              stderr: `MANAGED_RUNTIME_MUTATION_BLOCKED: ${blockedMutation.message}`,
-              exitCode: 1
-            })
-          : runShellCommand({
-              command: request.command,
-              cwd: session.cwd,
-              handoffDir: join(session.notebookSessionRoot, 'handoff'),
-              runtimeRoot: session.runtimeRoot,
-              platform: this.options.platform,
-              timeoutMs: request.timeoutMs
-            })
-      ).finally(async () => {
-        workingFiles = await workingFileObservation.finish()
-      })
-      // No status/traceback classification for the caller-facing NotebookShellResult (the shell is
-      // expected to fail non-zero sometimes), but the run-history record still needs one: exitCode 0
-      // is 'completed', a null exitCode means runShellCommand hit its own timeout, and anything else
-      // (including a signal-kill) is 'failed'.
-      const status: NotebookRunStatus =
-        shellResult.exitCode === 0
-          ? 'completed'
-          : shellResult.exitCode === null
-            ? 'timeout'
-            : 'failed'
-      const outputs: NotebookOutput[] = [
-        ...(shellResult.stdout
-          ? [{ type: 'stream' as const, name: 'stdout' as const, text: shellResult.stdout }]
-          : []),
-        ...(shellResult.stderr
-          ? [{ type: 'stream' as const, name: 'stderr' as const, text: shellResult.stderr }]
-          : [])
-      ]
+    const { result } = await this.runTerminalization.run({
+      session,
+      runningRun,
+      invoke: async () => {
+        const workingFileObservation = await startWorkingFileObservation(session)
+        let workingFiles: NotebookWorkingFile[] = []
+        const blockedMutation = detectManagedRuntimeMutation({
+          source: request.command,
+          surface: this.options.platform === 'win32' ? 'powershell' : 'bash',
+          runtimeRoot: session.runtimeRoot,
+          cwd: session.cwd
+        })
+        const shellResult = await (
+          blockedMutation
+            ? Promise.resolve<NotebookShellResult>({
+                stdout: '',
+                stderr: `MANAGED_RUNTIME_MUTATION_BLOCKED: ${blockedMutation.message}`,
+                exitCode: 1
+              })
+            : runShellCommand({
+                command: request.command,
+                cwd: session.cwd,
+                handoffDir: join(session.notebookSessionRoot, 'handoff'),
+                runtimeRoot: session.runtimeRoot,
+                platform: this.options.platform,
+                timeoutMs: request.timeoutMs
+              })
+        ).finally(async () => {
+          workingFiles = await workingFileObservation.finish()
+        })
+        // No status/traceback classification for the caller-facing NotebookShellResult (the shell is
+        // expected to fail non-zero sometimes), but the run-history record still needs one: exitCode 0
+        // is 'completed', a null exitCode means runShellCommand hit its own timeout, and anything else
+        // (including a signal-kill) is 'failed'.
+        const status: NotebookRunStatus =
+          shellResult.exitCode === 0
+            ? 'completed'
+            : shellResult.exitCode === null
+              ? 'timeout'
+              : 'failed'
+        const outputs: NotebookOutput[] = [
+          ...(shellResult.stdout
+            ? [{ type: 'stream' as const, name: 'stdout' as const, text: shellResult.stdout }]
+            : []),
+          ...(shellResult.stderr
+            ? [{ type: 'stream' as const, name: 'stderr' as const, text: shellResult.stderr }]
+            : [])
+        ]
 
-      return {
-        status,
-        stdout: shellResult.stdout,
-        stderr: shellResult.stderr,
-        traceback: '',
-        cwdAfter: session.cwd,
-        outputs,
-        workingFiles,
-        exitCode: shellResult.exitCode
+        return {
+          status,
+          stdout: shellResult.stdout,
+          stderr: shellResult.stderr,
+          traceback: '',
+          cwdAfter: session.cwd,
+          outputs,
+          workingFiles,
+          exitCode: shellResult.exitCode
+        }
       }
     })
 
@@ -3178,87 +3181,6 @@ class NotebookRuntimeService {
     } catch {
       return
     }
-  }
-
-  // Shared append-running -> execute -> update-completed -> notify sequence used by cell, repl, and
-  // shell runs so none of the three reimplements it. `execute` is expected to never reject (each caller
-  // pre-catches its own executor/process failure into a normal result, matching every kernel's
-  // "don't throw on failure" contract); `afterUpdate` lets the caller mutate session/cell state (e.g.
-  // session.cwd, cell.status) from the result before the single trailing notify fires.
-  private async persistRun<
-    R extends {
-      status: NotebookRunStatus
-      stdout: string
-      stderr: string
-      traceback: string
-      cwdAfter?: string
-      outputs: NotebookOutput[]
-      workingFiles?: NotebookWorkingFile[]
-      environmentManifest?: NotebookEnvironmentManifest
-      environmentManifestChecksum?: string
-      environmentCapture?: NotebookRunEnvironmentCapture
-    }
-  >(
-    session: RuntimeSession,
-    runningRun: NotebookRunRecord,
-    execute: () => Promise<R>,
-    afterUpdate?: (result: R, run: NotebookRunRecord) => void
-  ): Promise<{ run: NotebookRunRecord; result: R }> {
-    // The initial history entry lets users see in-progress runs before execution returns.
-    await this.repository.appendRun({
-      projectName: session.projectName,
-      sessionId: session.sessionId,
-      run: runningRun
-    })
-    this.notifyNotebookChanged(session)
-
-    const result = await execute()
-
-    // Replace the running record instead of appending so each run id has one durable entry.
-    const environmentCapture: NotebookRunEnvironmentCapture =
-      result.environmentCapture ??
-      (runningRun.kernelKind === 'python' || runningRun.kernelKind === 'r'
-        ? { state: 'unavailable', reason: 'environment-capture-failed' }
-        : { state: 'unavailable', reason: 'environment-not-supported' })
-    const completedRun: NotebookRunRecord = {
-      ...runningRun,
-      status: result.status,
-      endedAt: Date.now(),
-      cwdAfter: result.cwdAfter,
-      text: {
-        stdout: result.stdout,
-        stderr: result.stderr,
-        traceback: result.traceback,
-        plain: outputPlainText(result.stdout, result.stderr)
-      },
-      // result.outputs already carries the mapped error output when there's a traceback (see
-      // mapLoopOutputs / errorToExecutionResult); do NOT append a second one or the panel renders
-      // the traceback twice.
-      outputs: result.outputs,
-      workingFiles: result.workingFiles ?? [],
-      environmentCapture,
-      ...(environmentCapture.state !== 'unavailable' && result.environmentManifest
-        ? { environmentManifest: result.environmentManifest }
-        : {}),
-      ...(environmentCapture.state !== 'unavailable' && result.environmentManifestChecksum
-        ? { environmentManifestChecksum: result.environmentManifestChecksum }
-        : {})
-    }
-    const document = await this.repository.updateRun({
-      projectName: session.projectName,
-      sessionId: session.sessionId,
-      run: completedRun
-    })
-    const run = document.runs.find((candidate) => candidate.runId === runningRun.runId)
-
-    if (!run) {
-      throw new Error(`Notebook run not found after update: ${runningRun.runId}`)
-    }
-
-    afterUpdate?.(result, run)
-    this.notifyNotebookChanged(session)
-
-    return { run, result }
   }
 
   // Best-effort lookup of the configured package mirror: an install falls back to the region default


### PR DESCRIPTION
## Problem

`NotebookRuntimeService` owned the same durable run lifecycle for cell, control, and shell execution in addition to admission, dispatch, kernel state, and transport compatibility. This made run identity and terminal persistence ordering difficult to review independently.

## Proposed change

Extract an internal `NotebookRunTerminalizationOwner` that owns:

- monotonically sequenced run identity allocation;
- append-running -> notify -> invoke -> update-the-same-run -> post-commit -> notify ordering;
- terminal timestamp, output projection, working-file evidence, and environment-capture fallback.

Execution dispatch and all public projections remain in `NotebookRuntimeService`.

```mermaid
flowchart LR
  Facade["NotebookRuntimeService facade"] -->|prepared running run + invoke callback| Owner["Run terminalization owner"]
  Facade -->|cell / control / shell dispatch| Executor["Existing executors"]
  Owner -->|append running + update same ID| Repository["Notebook run repository"]
  Owner -->|before and after execution| Notify["Existing notebook notifications"]
```

## Scope and non-goals

- No shared type, IPC, local-RPC, data-model, run.json, or UI change.
- Electron, Web, remote Web, CLI, and Task behavior remains unchanged.
- Specialist, Permission, and Compute capability asymmetry remains unchanged.
- Session queues/cells/kernel/force-stop state, environment leases, repository implementation, transport, export, and public run projection stay outside the owner.
- No public cancel command and no stronger recovery semantics are introduced.
- This keeps a forward-compatible ownership seam for #458 without adding orchestration state or public interfaces.

## Acceptance criteria and validation

All commands below ran on the final branch state after the last material edit. The final rebase onto `origin/main` was a no-op at `2796c9a`; the focused suite was rerun afterward.

- Cell/control/shell retain exact run ID and sequence behavior -> `npm test -- --run src/main/notebook/run-terminalization.test.ts src/main/notebook/runtime-service.test.ts` -> 197 passed.
- Same-ID terminal update, notification order, normalized failed/timeout/cancelled results, evidence fallback, and persistence recovery -> owner/facade suite above -> 197 passed.
- Node and renderer type compatibility -> `npm run typecheck` -> passed.
- Repository lint contract -> `npm run lint` -> passed with 0 errors and 19 pre-existing unrelated warnings.
- Repository regression coverage -> `npm test -- --run` -> 678 files / 9,960 tests passed; 15 files / 184 tests skipped.
- Independent Spec review -> 0 Hard / 0 Judgement findings; reviewer independently reran 197 focused tests.
- Independent Standards review -> 0 Hard / 0 Judgement findings.

## Review focus

- Verify the owner preserves append/notify/invoke/update/post-commit ordering and updates one existing run ID rather than appending a terminal duplicate.
- Verify unexpected invoke or persistence failures retain the pre-existing recovery behavior.
- Verify cell, control, and shell dispatch remain in the facade and no transport/public boundary moved.

Uncovered risk: validation is automated and does not include a manual Electron/Web/CLI journey. The touched code is below those adapters and changes no transport contract.
