### PR TITLE
refactor(acp): own connection teardown

### DIFF
--- a/src/main/acp/connection-resource-owner.test.ts
+++ b/src/main/acp/connection-resource-owner.test.ts
@@ -13,7 +13,15 @@ const terminateProcessTree = vi.hoisted(() =>
     return { reaped: true }
   })
 )
+const ownerErrorLog = vi.hoisted(() => vi.fn())
 vi.mock('../process-tree', () => ({ terminateProcessTree }))
+vi.mock('../logger', async (importOriginal) => {
+  const actual = await importOriginal<typeof import('../logger')>()
+  return {
+    ...actual,
+    createLogger: () => ({ ...actual.createLogger('acp'), error: ownerErrorLog })
+  }
+})
 
 afterEach(() => {
   vi.clearAllMocks()
@@ -274,12 +282,19 @@ describe('AcpConnectionResourceOwner', () => {
       return attempt.publish({ close: true, delete: false, resume: true })
     })
 
-    expect(() => owner.shutdownSynchronously(vi.fn())).not.toThrow()
-    await vi.waitFor(() => expect(release).toHaveBeenCalledOnce())
-    expect(close).toHaveBeenCalledOnce()
-    expect(kill).toHaveBeenCalledOnce()
-    expect(owner.isShuttingDown).toBe(true)
-    expect(owner.connection).toBeUndefined()
+    ownerErrorLog.mockImplementation(() => {
+      throw new Error('logger failed')
+    })
+    try {
+      expect(() => owner.shutdownSynchronously(vi.fn())).not.toThrow()
+      await vi.waitFor(() => expect(release).toHaveBeenCalledOnce())
+      expect(close).toHaveBeenCalledOnce()
+      expect(kill).toHaveBeenCalledOnce()
+      expect(owner.isShuttingDown).toBe(true)
+      expect(owner.connection).toBeUndefined()
+    } finally {
+      ownerErrorLog.mockReset()
+    }
   })
 
   it('marks detached processes expected before async and synchronous connection close', async () => {

--- a/src/main/acp/connection-resource-owner.test.ts
+++ b/src/main/acp/connection-resource-owner.test.ts
@@ -1,11 +1,23 @@
 import type { ClientConnection } from '@agentclientprotocol/sdk'
 import type { ChildProcessWithoutNullStreams } from 'node:child_process'
-import { describe, expect, it, vi } from 'vitest'
+import { afterEach, describe, expect, it, vi } from 'vitest'
 
 import {
   AcpConnectionResourceOwner,
   type AcpConnectionResourceAttempt
 } from './connection-resource-owner'
+
+const terminateProcessTree = vi.hoisted(() =>
+  vi.fn(async (child?: ChildProcessWithoutNullStreams) => {
+    void child
+    return { reaped: true }
+  })
+)
+vi.mock('../process-tree', () => ({ terminateProcessTree }))
+
+afterEach(() => {
+  vi.clearAllMocks()
+})
 
 type Deferred = {
   promise: Promise<void>
@@ -93,9 +105,10 @@ describe('AcpConnectionResourceOwner', () => {
     const owner = new AcpConnectionResourceOwner()
     const attached = createDeferred()
     const canPublish = createDeferred()
+    const staleProcess = process('stale')
     const pending = owner.connect(async (attempt) => {
       attempt.attach({
-        process: process('stale'),
+        process: staleProcess,
         connection: connection('stale'),
         framework: 'codex',
         bridgeLease: undefined
@@ -110,7 +123,8 @@ describe('AcpConnectionResourceOwner', () => {
     canPublish.resolve()
 
     await expect(pending).rejects.toThrow('ACP connection was superseded.')
-    expect(owner.detach(teardownEpoch)?.connection).toMatchObject({ id: 'stale' })
+    await owner.teardown(teardownEpoch, vi.fn())
+    expect(terminateProcessTree.mock.calls[0]?.[0]).toBe(staleProcess)
   })
 
   it('transfers each resource once and ignores a stale detach after replacement', async () => {
@@ -118,19 +132,23 @@ describe('AcpConnectionResourceOwner', () => {
     const first = await owner.connect(async (attempt) => attachAndPublish(attempt, 'first'))
     const firstTeardownEpoch = owner.supersede()
     expect(owner.connection).toBeUndefined()
-    const detachedFirst = owner.detach(firstTeardownEpoch)
-    expect(detachedFirst?.connection).toBe(first.connection)
-    expect(owner.detach(firstTeardownEpoch)).toBeUndefined()
+    await owner.teardown(firstTeardownEpoch, vi.fn())
+    expect(terminateProcessTree).toHaveBeenCalledOnce()
+    await owner.teardown(firstTeardownEpoch, vi.fn())
+    expect(terminateProcessTree).toHaveBeenCalledOnce()
 
     const replacement = await owner.connect(async (attempt) =>
       attachAndPublish(attempt, 'replacement')
     )
-    expect(owner.detach(firstTeardownEpoch)).toBeUndefined()
+    await owner.teardown(firstTeardownEpoch, vi.fn())
+    expect(terminateProcessTree).toHaveBeenCalledOnce()
     replacement.assertCurrent()
     expect(owner.connection).toBe(replacement.connection)
 
-    expect(owner.detach(owner.epoch)?.connection).toBe(replacement.connection)
+    await owner.teardown(owner.epoch, vi.fn())
+    expect(terminateProcessTree).toHaveBeenCalledTimes(2)
     expect(() => replacement.assertCurrent()).toThrow('ACP connection was superseded.')
+    expect(first.connection).not.toBe(replacement.connection)
   })
 
   it('restores only a still-attached published resource after teardown fails', async () => {
@@ -145,9 +163,29 @@ describe('AcpConnectionResourceOwner', () => {
     const staleEpoch = teardownEpoch
     const replacementTeardownEpoch = owner.supersede()
     expect(owner.restorePublished(staleEpoch)).toBe(false)
-    expect(owner.detach(replacementTeardownEpoch)?.connection).toBe(handle.connection)
+    await owner.teardown(replacementTeardownEpoch, vi.fn())
     expect(owner.restorePublished(replacementTeardownEpoch)).toBe(false)
     expect(owner.connection).toBeUndefined()
+  })
+
+  it('keeps restored published process events current after teardown rollback', async () => {
+    const owner = new AcpConnectionResourceOwner()
+    const child = process('restored-process')
+    let attemptEpoch = 0
+    await owner.connect(async (attempt) => {
+      attemptEpoch = attempt.epoch
+      attempt.attach({
+        process: child,
+        connection: connection('restored-process'),
+        framework: 'claude-code',
+        bridgeLease: undefined
+      })
+      return attempt.publish({ close: true, delete: false, resume: true })
+    })
+    const teardownEpoch = owner.supersede()
+    expect(owner.restorePublished(teardownEpoch)).toBe(true)
+
+    expect(owner.processEventDisposition(child, attemptEpoch)).toBe('current')
   })
 
   it('never promotes a provisional resource through teardown rollback', async () => {
@@ -173,7 +211,179 @@ describe('AcpConnectionResourceOwner', () => {
 
     canPublish.resolve()
     await expect(pending).rejects.toThrow('ACP connection was superseded.')
-    expect(owner.detach(teardownEpoch)?.connection).toMatchObject({ id: 'provisional' })
+    await owner.teardown(teardownEpoch, vi.fn())
+    expect(terminateProcessTree).toHaveBeenCalledOnce()
+  })
+
+  it('detaches and releases one physical resource before teardown settles', async () => {
+    const owner = new AcpConnectionResourceOwner()
+    const child = process('physical')
+    const close = vi.fn()
+    const release = vi.fn(async () => undefined)
+    const handle = await owner.connect(async (attempt) => {
+      attempt.attach({
+        process: child,
+        connection: { close } as unknown as ClientConnection,
+        framework: 'claude-code',
+        bridgeLease: {
+          selectSkills: vi.fn(async () => []),
+          registerReviewerSession: vi.fn(),
+          unregisterReviewerSession: vi.fn(() => true),
+          release
+        }
+      })
+      return attempt.publish({ close: true, delete: false, resume: true })
+    })
+    const teardownEpoch = owner.supersede()
+
+    await owner.teardown(teardownEpoch, vi.fn())
+
+    expect(owner.connection).toBeUndefined()
+    expect(close).toHaveBeenCalledOnce()
+    expect(terminateProcessTree).toHaveBeenCalledOnce()
+    expect(release).toHaveBeenCalledOnce()
+    expect(() => handle.assertCurrent()).toThrow('ACP connection was superseded.')
+
+    await owner.teardown(teardownEpoch, vi.fn())
+    expect(close).toHaveBeenCalledOnce()
+    expect(terminateProcessTree).toHaveBeenCalledOnce()
+    expect(release).toHaveBeenCalledOnce()
+  })
+
+  it('keeps synchronous shutdown terminal when close and kill both throw', async () => {
+    const owner = new AcpConnectionResourceOwner()
+    const close = vi.fn(() => {
+      throw new Error('close failed')
+    })
+    const kill = vi.fn(() => {
+      throw new Error('kill failed')
+    })
+    const release = vi.fn(async () => undefined)
+    await owner.connect(async (attempt) => {
+      attempt.attach({
+        process: { killed: false, kill } as unknown as ChildProcessWithoutNullStreams,
+        connection: { close } as unknown as ClientConnection,
+        framework: 'claude-code',
+        bridgeLease: {
+          selectSkills: vi.fn(async () => []),
+          registerReviewerSession: vi.fn(),
+          unregisterReviewerSession: vi.fn(() => true),
+          release
+        }
+      })
+      return attempt.publish({ close: true, delete: false, resume: true })
+    })
+
+    expect(() => owner.shutdownSynchronously(vi.fn())).not.toThrow()
+    await vi.waitFor(() => expect(release).toHaveBeenCalledOnce())
+    expect(close).toHaveBeenCalledOnce()
+    expect(kill).toHaveBeenCalledOnce()
+    expect(owner.isShuttingDown).toBe(true)
+    expect(owner.connection).toBeUndefined()
+  })
+
+  it('marks detached processes expected before async and synchronous connection close', async () => {
+    const asyncOwner = new AcpConnectionResourceOwner()
+    const asyncProcess = process('async-order')
+    let asyncAttemptEpoch = 0
+    const asyncClose = vi.fn(() => {
+      expect(asyncOwner.processEventDisposition(asyncProcess, asyncAttemptEpoch)).toBe('expected')
+    })
+    await asyncOwner.connect(async (attempt) => {
+      asyncAttemptEpoch = attempt.epoch
+      attempt.attach({
+        process: asyncProcess,
+        connection: { close: asyncClose } as unknown as ClientConnection,
+        framework: 'claude-code',
+        bridgeLease: undefined
+      })
+      return attempt.publish({ close: true, delete: false, resume: true })
+    })
+    await asyncOwner.teardown(asyncOwner.supersede())
+
+    const syncOwner = new AcpConnectionResourceOwner()
+    const syncProcess = process('sync-order')
+    let syncAttemptEpoch = 0
+    const syncClose = vi.fn(() => {
+      expect(syncOwner.processEventDisposition(syncProcess, syncAttemptEpoch)).toBe('expected')
+    })
+    await syncOwner.connect(async (attempt) => {
+      syncAttemptEpoch = attempt.epoch
+      attempt.attach({
+        process: syncProcess,
+        connection: { close: syncClose } as unknown as ClientConnection,
+        framework: 'claude-code',
+        bridgeLease: undefined
+      })
+      return attempt.publish({ close: true, delete: false, resume: true })
+    })
+    syncOwner.shutdownSynchronously(vi.fn())
+
+    expect(asyncClose).toHaveBeenCalledOnce()
+    expect(syncClose).toHaveBeenCalledOnce()
+  })
+
+  it('aggregates assigned and mid-spawn tree reap outcomes for awaitable shutdown', async () => {
+    const owner = new AcpConnectionResourceOwner()
+    await owner.connect(async (attempt) => attachAndPublish(attempt, 'assigned'))
+    const releaseMidSpawn = createDeferred()
+    const midSpawn = process('mid-spawn')
+    const pending = owner.connect(async (attempt) => {
+      await releaseMidSpawn.promise
+      await owner.cleanupUnattached({ process: midSpawn })
+      attempt.assertCurrent()
+      return attachAndPublish(attempt, 'must-not-publish')
+    })
+    const shutdown = owner.beginAwaitableShutdown(true)
+    const teardownEpoch = owner.supersede()
+    terminateProcessTree
+      .mockResolvedValueOnce({ reaped: false })
+      .mockResolvedValueOnce({ reaped: true })
+
+    await owner.teardown(teardownEpoch)
+    releaseMidSpawn.resolve()
+
+    await expect(shutdown.finish()).resolves.toEqual({ reaped: false })
+    expect(terminateProcessTree).toHaveBeenCalledTimes(2)
+    await expect(pending).rejects.toThrow('ACP connection was superseded.')
+  })
+
+  it('cleans unexpected-close resources exactly once across repeated notifications', async () => {
+    const closeMcpHost = vi.fn(async () => undefined)
+    const owner = new AcpConnectionResourceOwner({ closeMcpHost })
+    const release = vi.fn(async () => undefined)
+    await owner.connect(async (attempt) => {
+      attempt.attach({
+        process: process('unexpected'),
+        connection: connection('already-closed'),
+        framework: 'claude-code',
+        bridgeLease: {
+          selectSkills: vi.fn(async () => []),
+          registerReviewerSession: vi.fn(),
+          unregisterReviewerSession: vi.fn(() => true),
+          release
+        }
+      })
+      return attempt.publish({ close: true, delete: false, resume: true })
+    })
+
+    owner.cleanupUnexpectedClose(owner.epoch)
+    owner.cleanupUnexpectedClose(owner.epoch)
+    await owner.closeMcp(owner.epoch)
+
+    await vi.waitFor(() => expect(release).toHaveBeenCalledOnce())
+    expect(terminateProcessTree).toHaveBeenCalledOnce()
+    expect(closeMcpHost).toHaveBeenCalledOnce()
+  })
+
+  it('accepts only the current epoch while a spawned process is not attached yet', () => {
+    const owner = new AcpConnectionResourceOwner()
+    const child = process('pre-attach')
+    const spawningEpoch = owner.epoch
+
+    expect(owner.processEventDisposition(child, spawningEpoch)).toBe('current')
+    owner.supersede()
+    expect(owner.processEventDisposition(child, spawningEpoch)).toBe('stale')
   })
 
   it('exposes an immutable ready handle without process or bridge release authority', async () => {

--- a/src/main/acp/connection-resource-owner.ts
+++ b/src/main/acp/connection-resource-owner.ts
@@ -2,8 +2,13 @@ import type { ClientConnection } from '@agentclientprotocol/sdk'
 import type { ChildProcessWithoutNullStreams } from 'node:child_process'
 
 import type { AgentFramework, ResolvedAgentBackend } from '../agent-framework'
+import { createLogger, errorLogFields } from '../logger'
+import { terminateProcessTree } from '../process-tree'
 
 type ResponsesBridgeLease = ResolvedAgentBackend['responsesBridgeLease']
+type CleanupFailure = (stage: 'connection' | 'agent-process', error: unknown) => void
+
+const log = createLogger('acp')
 
 export type AcpConnectionCapabilities = Readonly<{
   close: boolean
@@ -16,10 +21,6 @@ export type AcpAttachedConnectionResource = {
   connection: ClientConnection
   framework: AgentFramework['id']
   bridgeLease: ResponsesBridgeLease
-}
-
-export type AcpDetachedConnectionResource = AcpAttachedConnectionResource & {
-  capabilities: AcpConnectionCapabilities
 }
 
 export type AcpConnectionResourceReadyHandle = Readonly<{
@@ -38,6 +39,20 @@ export type AcpConnectionResourceAttempt = Readonly<{
   owns: (connection: ClientConnection) => boolean
 }>
 
+export type AcpUnattachedConnectionResource = Readonly<{
+  process?: ChildProcessWithoutNullStreams
+  connection?: ClientConnection
+  bridgeLease?: ResponsesBridgeLease
+}>
+
+export type AcpConnectionShutdownHandle = Readonly<{
+  finish: () => Promise<{ reaped: boolean }>
+}>
+
+type AcpConnectionResourceOwnerOptions = Readonly<{
+  closeMcpHost?: () => Promise<void>
+}>
+
 type CurrentResource = AcpAttachedConnectionResource & {
   epoch: number
   capabilities: AcpConnectionCapabilities
@@ -49,14 +64,19 @@ const EMPTY_CAPABILITIES: AcpConnectionCapabilities = Object.freeze({
   resume: false
 })
 
-// Owns connection publication, identity, and exclusive resource transfer. Runtime ports still perform
-// spawn/initialize and physical teardown in A9.1a1; attach/detach prevents either side from retaining a
-// second mutable owner while those effects move behind this module in A9.1a2.
+// Owns connection publication, physical resource teardown, process-exit identity, and exclusive
+// transfer. Runtime supplies protocol startup plus Session/Permission/Notebook cleanup and projection.
 export class AcpConnectionResourceOwner {
   private resourceEpoch = 0
   private provisional: CurrentResource | undefined
   private current: CurrentResource | undefined
   private connectInFlight: Promise<AcpConnectionResourceReadyHandle> | undefined
+  private readonly expectedProcessExits = new WeakSet<ChildProcessWithoutNullStreams>()
+  private readonly releasedBridgeLeases = new WeakSet<object>()
+  private shuttingDown = false
+  private lastTreeKillReaped = true
+
+  constructor(private readonly options: AcpConnectionResourceOwnerOptions = {}) {}
 
   get epoch(): number {
     return this.resourceEpoch
@@ -70,12 +90,12 @@ export class AcpConnectionResourceOwner {
     return this.currentResource()?.capabilities ?? EMPTY_CAPABILITIES
   }
 
-  get inFlight(): Promise<AcpConnectionResourceReadyHandle> | undefined {
-    return this.connectInFlight
-  }
-
   get bridgeSkillsAvailable(): boolean {
     return Boolean(this.currentResource()?.bridgeLease?.selectSkills)
+  }
+
+  get isShuttingDown(): boolean {
+    return this.shuttingDown
   }
 
   connect(
@@ -119,7 +139,125 @@ export class AcpConnectionResourceOwner {
     return true
   }
 
-  detach(expectedEpoch = this.resourceEpoch): AcpDetachedConnectionResource | undefined {
+  async teardown(
+    expectedEpoch: number,
+    onFailure: CleanupFailure = (stage, error) =>
+      log.error(`ACP ${stage} cleanup failed`, errorLogFields(error))
+  ): Promise<void> {
+    // Ownership transfers synchronously before the first cleanup await, so a successor may attach
+    // without an older process or lease remaining reachable through this owner.
+    const resource = this.detach(expectedEpoch)
+    if (!resource) return
+    this.expectedProcessExits.add(resource.process)
+
+    try {
+      resource.connection.close()
+    } catch (error) {
+      this.reportCleanupFailure(onFailure, 'connection', error)
+    }
+
+    try {
+      await this.reapProcessTree(resource.process)
+    } catch (error) {
+      this.reportCleanupFailure(onFailure, 'agent-process', error)
+    }
+    await this.releaseBridgeLease(resource.bridgeLease)
+  }
+
+  async cleanupUnattached(
+    resource: AcpUnattachedConnectionResource,
+    onFailure: CleanupFailure = (stage, error) =>
+      log.error(`unattached ACP ${stage} cleanup failed`, errorLogFields(error))
+  ): Promise<void> {
+    if (resource.process) this.expectedProcessExits.add(resource.process)
+    try {
+      resource.connection?.close()
+    } catch (error) {
+      this.reportCleanupFailure(onFailure, 'connection', error)
+    }
+
+    if (resource.process) {
+      try {
+        await this.reapProcessTree(resource.process)
+      } catch (error) {
+        this.reportCleanupFailure(onFailure, 'agent-process', error)
+      }
+    }
+    await this.releaseBridgeLease(resource.bridgeLease)
+  }
+
+  cleanupUnexpectedClose(expectedEpoch: number): void {
+    const resource = this.detach(expectedEpoch)
+    if (!resource) return
+    this.expectedProcessExits.add(resource.process)
+    void this.reapProcessTree(resource.process).catch((error) => {
+      log.error('agent process cleanup after unexpected close failed', errorLogFields(error))
+    })
+    void this.releaseBridgeLease(resource.bridgeLease)
+  }
+
+  shutdownSynchronously(onSuperseded: () => void): void {
+    this.shuttingDown = true
+    const teardownEpoch = this.supersede()
+    try {
+      onSuperseded()
+    } finally {
+      const resource = this.detach(teardownEpoch)
+      if (resource?.process) this.expectedProcessExits.add(resource.process)
+      try {
+        resource?.connection.close()
+      } catch (error) {
+        log.error('ACP connection close during shutdown failed', errorLogFields(error))
+      }
+      if (resource?.process) {
+        try {
+          if (!resource.process.killed) resource.process.kill()
+        } catch (error) {
+          log.error('agent process kill during shutdown failed', errorLogFields(error))
+        }
+      }
+      void this.releaseBridgeLease(resource?.bridgeLease)
+      void this.closeMcp()
+    }
+  }
+
+  beginAwaitableShutdown(latch: boolean): AcpConnectionShutdownHandle {
+    this.lastTreeKillReaped = true
+    if (latch) this.shuttingDown = true
+    const inFlight = this.connectInFlight
+
+    return Object.freeze({
+      finish: async () => {
+        if (inFlight) await inFlight.catch(() => undefined)
+        return { reaped: this.lastTreeKillReaped }
+      }
+    })
+  }
+
+  processEventDisposition(
+    process: ChildProcessWithoutNullStreams,
+    epoch: number
+  ): 'current' | 'expected' | 'stale' {
+    if (this.expectedProcessExits.has(process)) return 'expected'
+    const currentProcess =
+      this.currentResource()?.process ??
+      (this.provisional?.epoch === this.resourceEpoch ? this.provisional.process : undefined)
+    if (currentProcess === process) return 'current'
+    // Between spawn and attach the attempt still owns its local process, but it is not yet present in
+    // either owner slot. Its epoch is sufficient only while no attached resource occupies the owner.
+    return !currentProcess && epoch === this.resourceEpoch ? 'current' : 'stale'
+  }
+
+  async closeMcp(expectedEpoch?: number): Promise<void> {
+    if (expectedEpoch !== undefined && expectedEpoch !== this.resourceEpoch) return
+    try {
+      await this.options.closeMcpHost?.()
+    } catch (error) {
+      log.error('MCP HTTP host close failed', errorLogFields(error))
+    }
+  }
+
+  private detach(expectedEpoch = this.resourceEpoch): CurrentResource | undefined {
     if (expectedEpoch !== this.resourceEpoch) return undefined
     const resource = this.provisional ?? this.current
     this.provisional = undefined
@@ -154,6 +292,34 @@ export class AcpConnectionResourceOwner {
     signal?: Parameters<NonNullable<ResponsesBridgeLease>['selectSkills']>[2]
   ): Promise<Awaited<ReturnType<NonNullable<ResponsesBridgeLease>['selectSkills']>> | undefined> {
     return this.currentResource()?.bridgeLease?.selectSkills(text, catalog, signal)
+  }
+
+  private async reapProcessTree(process: ChildProcessWithoutNullStreams): Promise<void> {
+    this.expectedProcessExits.add(process)
+    const result = await terminateProcessTree(process, undefined, log)
+    this.lastTreeKillReaped = this.lastTreeKillReaped && result.reaped
+  }
+
+  private async releaseBridgeLease(lease: ResponsesBridgeLease): Promise<void> {
+    if (!lease || this.releasedBridgeLeases.has(lease)) return
+    this.releasedBridgeLeases.add(lease)
+    try {
+      await lease.release()
+    } catch (error) {
+      log.error('responses bridge lease release failed', errorLogFields(error))
+    }
+  }
+
+  private reportCleanupFailure(
+    onFailure: CleanupFailure,
+    stage: Parameters<CleanupFailure>[0],
+    error: unknown
+  ): void {
+    try {
+      onFailure(stage, error)
+    } catch (callbackError) {
+      log.error('ACP connection cleanup failure callback failed', errorLogFields(callbackError))
+    }
   }
 
   private currentResource(): CurrentResource | undefined {

--- a/src/main/acp/connection-resource-owner.ts
+++ b/src/main/acp/connection-resource-owner.ts
@@ -9,6 +9,13 @@ type ResponsesBridgeLease = ResolvedAgentBackend['responsesBridgeLease']
 type CleanupFailure = (stage: 'connection' | 'agent-process', error: unknown) => void
 
 const log = createLogger('acp')
+const safeLogCleanupError = (message: string, error: unknown): void => {
+  try {
+    log.error(message, errorLogFields(error))
+  } catch {
+    // Physical cleanup and the original failure take precedence over diagnostic sinks.
+  }
+}
 
 export type AcpConnectionCapabilities = Readonly<{
   close: boolean
@@ -142,7 +149,7 @@ export class AcpConnectionResourceOwner {
   async teardown(
     expectedEpoch: number,
     onFailure: CleanupFailure = (stage, error) =>
-      log.error(`ACP ${stage} cleanup failed`, errorLogFields(error))
+      safeLogCleanupError(`ACP ${stage} cleanup failed`, error)
   ): Promise<void> {
     // Ownership transfers synchronously before the first cleanup await, so a successor may attach
     // without an older process or lease remaining reachable through this owner.
@@ -167,7 +174,7 @@ export class AcpConnectionResourceOwner {
   async cleanupUnattached(
     resource: AcpUnattachedConnectionResource,
     onFailure: CleanupFailure = (stage, error) =>
-      log.error(`unattached ACP ${stage} cleanup failed`, errorLogFields(error))
+      safeLogCleanupError(`unattached ACP ${stage} cleanup failed`, error)
   ): Promise<void> {
     if (resource.process) this.expectedProcessExits.add(resource.process)
     try {
@@ -191,7 +198,7 @@ export class AcpConnectionResourceOwner {
     if (!resource) return
     this.expectedProcessExits.add(resource.process)
     void this.reapProcessTree(resource.process).catch((error) => {
-      log.error('agent process cleanup after unexpected close failed', errorLogFields(error))
+      safeLogCleanupError('agent process cleanup after unexpected close failed', error)
     })
     void this.releaseBridgeLease(resource.bridgeLease)
   }
@@ -207,13 +214,13 @@ export class AcpConnectionResourceOwner {
       try {
         resource?.connection.close()
       } catch (error) {
-        log.error('ACP connection close during shutdown failed', errorLogFields(error))
+        safeLogCleanupError('ACP connection close during shutdown failed', error)
       }
       if (resource?.process) {
         try {
           if (!resource.process.killed) resource.process.kill()
         } catch (error) {
-          log.error('agent process kill during shutdown failed', errorLogFields(error))
+          safeLogCleanupError('agent process kill during shutdown failed', error)
         }
       }
       void this.releaseBridgeLease(resource?.bridgeLease)
@@ -253,7 +260,7 @@ export class AcpConnectionResourceOwner {
     try {
       await this.options.closeMcpHost?.()
     } catch (error) {
-      log.error('MCP HTTP host close failed', errorLogFields(error))
+      safeLogCleanupError('MCP HTTP host close failed', error)
     }
   }
 
@@ -306,7 +313,7 @@ export class AcpConnectionResourceOwner {
     try {
       await lease.release()
     } catch (error) {
-      log.error('responses bridge lease release failed', errorLogFields(error))
+      safeLogCleanupError('responses bridge lease release failed', error)
     }
   }
 
@@ -318,7 +325,7 @@ export class AcpConnectionResourceOwner {
     try {
       onFailure(stage, error)
     } catch (callbackError) {
-      log.error('ACP connection cleanup failure callback failed', errorLogFields(callbackError))
+      safeLogCleanupError('ACP connection cleanup failure callback failed', callbackError)
     }
   }
 

--- a/src/main/acp/runtime.test.ts
+++ b/src/main/acp/runtime.test.ts
@@ -16745,7 +16745,7 @@ describe('ACP runtime — session-creation and spawn diagnostics', () => {
     })
   })
 
-  it('does not let a bridge release rejection mask the original spawn error', async () => {
+  it('does not let bridge release and logger failures mask the original spawn error', async () => {
     const release = vi.fn().mockRejectedValue(new Error('bridge release failed'))
     const runtime = new AcpRuntime({
       appVersion: '0.1.0',
@@ -16768,14 +16768,17 @@ describe('ACP runtime — session-creation and spawn diagnostics', () => {
       })
     })
 
-    await expect(runtime.createSession({ cwd: '/workspace' })).rejects.toThrow(
-      'primary spawn failed'
-    )
-    expect(release).toHaveBeenCalledOnce()
-    expect(errorLogSpy).toHaveBeenCalledWith(
-      'responses bridge lease release failed',
-      expect.objectContaining({ error: 'bridge release failed' })
-    )
+    errorLogSpy.mockImplementation(() => {
+      throw new Error('cleanup logger failed')
+    })
+    try {
+      await expect(runtime.createSession({ cwd: '/workspace' })).rejects.toThrow(
+        'primary spawn failed'
+      )
+      expect(release).toHaveBeenCalledOnce()
+    } finally {
+      errorLogSpy.mockReset()
+    }
   })
 
   it('survives a hostile Error (throwing message getter) through the real connectFresh path', async () => {

--- a/src/main/acp/runtime.test.ts
+++ b/src/main/acp/runtime.test.ts
@@ -1066,6 +1066,37 @@ describe('ACP runtime migration write-gate', () => {
     await runtime.disconnect()
   })
 
+  it('ignores detached process events after a replacement connection is published', async () => {
+    const oldProcess = new FakeAgentProcess()
+    const replacementProcess = new FakeAgentProcess()
+    startFakeAgent(oldProcess, ['old-session'])
+    startFakeAgent(replacementProcess, ['replacement-session'])
+    const events: AcpRuntimeEvent[] = []
+    let spawnCount = 0
+    const runtime = new AcpRuntime({
+      appVersion: '0.1.0',
+      defaultCwd: '/workspace',
+      callbacks: { onEvent: (event) => events.push(event) },
+      spawnAgent: () => asAgentProcess(spawnCount++ === 0 ? oldProcess : replacementProcess)
+    })
+
+    await runtime.createSession({ cwd: '/workspace' })
+    await runtime.disconnect()
+    await runtime.createSession({ cwd: '/workspace' })
+    events.length = 0
+
+    oldProcess.stderr.emit('data', Buffer.from('late detached stderr'))
+    oldProcess.emit('error', new Error('late detached error'))
+    oldProcess.emit('exit', 1, null)
+
+    expect(runtime.getSnapshot()).toMatchObject({
+      status: 'connected',
+      sessionIds: ['replacement-session']
+    })
+    expect(events).toEqual([])
+    await runtime.disconnect()
+  })
+
   it('keeps using a published connection when teardown fails before resource detach', async () => {
     const process = new FakeAgentProcess()
     const fakeAgent = startFakeAgent(process, ['first-session', 'successor-session'])
@@ -1863,6 +1894,29 @@ describe('ACP runtime session management', () => {
 
     runtime.shutdown()
     expect(release).toHaveBeenCalledOnce()
+  })
+
+  it('releases the backend lease once when synchronous shutdown overlaps protocol close', async () => {
+    const process = new FakeAgentProcess()
+    const { lease, release } = createBackendLeaseHarness()
+    startFakeAgent(process, ['overlapping-close-session'])
+    const runtime = new AcpRuntime({
+      appVersion: '0.2.0',
+      defaultCwd: '/workspace',
+      resolveBackend: () => ({
+        framework: { ...claudeCodeFramework, spawn: () => asAgentProcess(process) },
+        executablePath: '/bin/agent',
+        env: {},
+        responsesBridgeLease: lease
+      })
+    })
+
+    await runtime.createSession({ cwd: '/workspace' })
+    process.stdout.end()
+    runtime.shutdown()
+
+    await vi.waitFor(() => expect(release).toHaveBeenCalledOnce())
+    expect(process.killed).toBe(true)
   })
 
   it('releases notebook RPC capabilities after an unexpected protocol close', async () => {

--- a/src/main/acp/runtime.test.ts
+++ b/src/main/acp/runtime.test.ts
@@ -8681,20 +8681,22 @@ describe('ACP runtime session management', () => {
   it('does not let an older teardown complete a newer reconnect intent', async () => {
     const process = new FakeAgentProcess()
     startFakeAgent(process, [])
-    const runtime = new AcpRuntime({
-      appVersion: '0.1.0',
-      defaultCwd: '/workspace',
-      spawnAgent: () => asAgentProcess(process)
-    })
-    await runtime.connect({ cwd: '/workspace' })
     const oldCloseStarted = createDeferred()
     const releaseOldClose = createDeferred()
-    const closeMcpHttpHostSpy = vi
-      .spyOn(runtime as unknown as { closeMcpHttpHost: () => Promise<void> }, 'closeMcpHttpHost')
-      .mockImplementationOnce(async () => {
+    const mcpHttpHost = {
+      clear: vi.fn(),
+      close: vi.fn(async () => {
         oldCloseStarted.resolve()
         await releaseOldClose.promise
       })
+    } as unknown as AgentMcpHttpHost
+    const runtime = new AcpRuntime({
+      appVersion: '0.1.0',
+      defaultCwd: '/workspace',
+      mcpHttpHost,
+      spawnAgent: () => asAgentProcess(process)
+    })
+    await runtime.connect({ cwd: '/workspace' })
     const oldDisconnect = runtime.disconnect()
     await oldCloseStarted.promise
     const releaseActivity = createDeferred()
@@ -8730,7 +8732,6 @@ describe('ACP runtime session management', () => {
       releaseActivity.resolve()
       await oldDisconnect.catch(() => undefined)
       await activity.catch(() => undefined)
-      closeMcpHttpHostSpy.mockRestore()
       await runtime.disconnect().catch(() => undefined)
     }
   })
@@ -8921,6 +8922,20 @@ describe('ACP runtime session management', () => {
       const releaseStaleMode = createDeferred()
       const capabilityReleases: ReturnType<typeof vi.fn>[] = []
       const releaseSessionCapabilities = vi.fn()
+      const mcpHttpHost = {
+        ensureStarted: vi.fn(async () => ({
+          endpoint: 'http://127.0.0.1:4321',
+          token: 'host-token'
+        })),
+        registerNotebook: vi.fn(),
+        urlFor: vi.fn(
+          (kind: string, routingId: string) =>
+            `http://127.0.0.1:4321/mcp/${kind}/${encodeURIComponent(routingId)}`
+        ),
+        unregister: vi.fn(),
+        clear: vi.fn(),
+        close: vi.fn(async () => undefined)
+      } as unknown as AgentMcpHttpHost
       const fakeAgent = startFakeAgent(process, ['stale-provider', 'successor-provider'], {
         modes: createModes(['read-only', 'agent', 'agent-full-access'], 'agent'),
         onSetMode: async ({ modeId }) => {
@@ -8942,20 +8957,7 @@ describe('ACP runtime session management', () => {
           executablePath: '/bin/codex-acp',
           env: {}
         }),
-        mcpHttpHost: {
-          ensureStarted: vi.fn(async () => ({
-            endpoint: 'http://127.0.0.1:4321',
-            token: 'host-token'
-          })),
-          registerNotebook: vi.fn(),
-          urlFor: vi.fn(
-            (kind: string, routingId: string) =>
-              `http://127.0.0.1:4321/mcp/${kind}/${encodeURIComponent(routingId)}`
-          ),
-          unregister: vi.fn(),
-          clear: vi.fn(),
-          close: vi.fn(async () => undefined)
-        } as unknown as AgentMcpHttpHost,
+        mcpHttpHost,
         notebook: {
           projectName: 'default-project',
           mcpEntryPath: '/app/out/main/index.js',
@@ -9021,9 +9023,7 @@ describe('ACP runtime session management', () => {
         expect(fakeAgent.prompts.at(-1)?.text).toContain('successor turn')
         expect(fakeAgent.prompts.at(-1)?.text).not.toContain('stale-specialist prefix')
         expect(runtime.getSnapshot().sessionIds).toEqual([sessionId])
-        expect(
-          (runtime as unknown as { mcpHttpHost: AgentMcpHttpHost }).mcpHttpHost.unregister
-        ).not.toHaveBeenCalled()
+        expect(mcpHttpHost.unregister).not.toHaveBeenCalled()
         expect(capabilityReleases).toHaveLength(2)
         expect(capabilityReleases[0]).toHaveBeenCalledOnce()
         expect(capabilityReleases[1]).not.toHaveBeenCalled()
@@ -16743,6 +16743,39 @@ describe('ACP runtime — session-creation and spawn diagnostics', () => {
       generation: 1,
       status: 'connecting'
     })
+  })
+
+  it('does not let a bridge release rejection mask the original spawn error', async () => {
+    const release = vi.fn().mockRejectedValue(new Error('bridge release failed'))
+    const runtime = new AcpRuntime({
+      appVersion: '0.1.0',
+      defaultCwd: '/workspace',
+      resolveBackend: () => ({
+        framework: {
+          ...claudeCodeFramework,
+          spawn: () => {
+            throw new Error('primary spawn failed')
+          }
+        },
+        executablePath: '/bin/agent',
+        env: {},
+        responsesBridgeLease: {
+          selectSkills: vi.fn(async () => []),
+          registerReviewerSession: vi.fn(),
+          unregisterReviewerSession: vi.fn(() => true),
+          release
+        }
+      })
+    })
+
+    await expect(runtime.createSession({ cwd: '/workspace' })).rejects.toThrow(
+      'primary spawn failed'
+    )
+    expect(release).toHaveBeenCalledOnce()
+    expect(errorLogSpy).toHaveBeenCalledWith(
+      'responses bridge lease release failed',
+      expect.objectContaining({ error: 'bridge release failed' })
+    )
   })
 
   it('survives a hostile Error (throwing message getter) through the real connectFresh path', async () => {

--- a/src/main/acp/runtime.ts
+++ b/src/main/acp/runtime.ts
@@ -516,7 +516,7 @@ class AcpRuntime {
   // arbitration share one owner. The runtime retains only protocol/resource orchestration.
   private readonly sessionRegistry: AcpSessionRegistry
   // App-owned MCP construction, routing aliases, and bearer lease ownership are kept behind one
-  // explicit role policy. Connection/process lifetime remains with this runtime.
+  // explicit role policy. Connection/process lifetime remains with the connection resource owner.
   private readonly sessionCapabilities: AcpSessionCapabilityOwner
   private readonly sessionInteractions: AcpSessionInteractionOwner
   // Ephemeral Reviewer identity, isolation, permission, and resource state lives behind one owner.

--- a/src/main/acp/runtime.ts
+++ b/src/main/acp/runtime.ts
@@ -61,7 +61,6 @@ import {
 } from '../agent-framework'
 import { resolveCanonicalMcpToolIdentity } from '../agent-framework/app-mcp-names'
 import { createLogger, diagnosticErrorFields, errorLogFields } from '../logger'
-import { terminateProcessTree } from '../process-tree'
 import {
   extractProviderToolName,
   extractToolFailureText,
@@ -504,22 +503,15 @@ const isUnresumableSessionError = (error: unknown): boolean => {
   )
 }
 
-// ACP Session facade. Connection publication and resource identity have their own epoch owner while
-// spawn/initialize and physical teardown remain runtime ports until A9.1a2.
+// ACP Session facade. Connection publication and physical teardown live behind their epoch owner;
+// Runtime retains protocol startup, Session/Permission/Notebook cleanup, and status/event projection.
 class AcpRuntime {
   private readonly snapshotOwner: AcpRuntimeSnapshotOwner
   private readonly contextUsageTracker: ContextUsageTracker
   // Prompt lifecycle stays with the runtime: this marks turns that received provider-side
   // context-bearing updates so a rejected prompt rolls back only when the provider saw no turn data.
   private readonly contextUsageUpdatedPromptTurnsBySession = new Map<string, number>()
-  private readonly connectionResources = new AcpConnectionResourceOwner()
-  // Latched by shutdown() on app quit. A connect can be mid-spawn (resolveSpawnConfig is async) when
-  // quit fires, so this lets the post-spawn path kill a child that was created after killAgentProcess ran.
-  private shuttingDown = false
-  // AND-accumulated reaped result of the tree kills performed during the current teardown. Reset to true
-  // at the start of shutdownForQuit/shutdownForUpdateGate, then narrowed by each terminateProcessTree so
-  // those methods can report whether the agent tree was cleanly reaped (vs a degraded taskkill fallback).
-  private lastTreeKillReaped = true
+  private readonly connectionResources: AcpConnectionResourceOwner
   // Stable app identities, provider aliases, publication order, selection, and startup/delete
   // arbitration share one owner. The runtime retains only protocol/resource orchestration.
   private readonly sessionRegistry: AcpSessionRegistry
@@ -562,7 +554,6 @@ class AcpRuntime {
   private reconnectBarrier: Promise<void> | undefined
   private reconnectBarrierResolve: (() => void) | undefined
   private reconnectBarrierGeneration = 0
-  private expectedProcessExits = new WeakSet<ChildProcessWithoutNullStreams>()
   private readonly permissionContext: AcpPermissionContext
   private readonly callbacks: AcpRuntimeCallbacks
   private readonly spawnAgent: (() => ChildProcessWithoutNullStreams) | undefined
@@ -572,7 +563,6 @@ class AcpRuntime {
   private backendId: string | undefined
   private codexHome: string | undefined
   private readonly codexSkillActivity = new CodexSkillActivityProjector()
-  private readonly mcpHttpHost: AgentMcpHttpHost | undefined
   // A Chat Completions provider uses the local Responses bridge. App-owned notebook, artifact, and
   // reviewer MCPs have explicit namespaced bridge mappings; other MCP tools still require Responses.
   private nativeMcpEnabled = true
@@ -612,10 +602,14 @@ class AcpRuntime {
   constructor(private readonly options: AcpRuntimeOptions) {
     this.snapshotOwner = new AcpRuntimeSnapshotOwner(resolve(options.defaultCwd))
     this.callbacks = options.callbacks ?? {}
+    this.connectionResources = new AcpConnectionResourceOwner({
+      closeMcpHost: async () => {
+        await options.mcpHttpHost?.close()
+      }
+    })
     this.spawnAgent = options.spawnAgent
     this.skillsHooks = options.skills
     this.framework = options.framework ?? claudeCodeFramework
-    this.mcpHttpHost = options.mcpHttpHost
     this.resumeTimeoutMs = options.resumeTimeoutMs ?? 30_000
     this.contextUsageTracker = options.contextUsageTracker ?? new ContextUsageTracker()
     this.setTimer = options.setTimer ?? ((fn, ms) => setTimeout(fn, ms))
@@ -1253,17 +1247,20 @@ class AcpRuntime {
       // late spawn without holding a shuttingDown latch it might never release if it is itself abandoned
       // on timeout. Awaited (not a bare kill) so a teardown that awaits this in-flight connect does not
       // resolve before the child's whole tree is reaped on Windows.
-      if (this.shuttingDown || generation !== this.connectionGeneration) {
-        try {
-          const result = await terminateProcessTree(agentProcess, undefined, log)
-          this.lastTreeKillReaped = this.lastTreeKillReaped && result.reaped
-        } finally {
-          await spawned.backend.responsesBridgeLease?.release()
-          agentProcess = undefined
-          unattachedBridgeLease = undefined
-        }
+      if (this.connectionResources.isShuttingDown || generation !== this.connectionGeneration) {
+        await this.connectionResources.cleanupUnattached(
+          { process: agentProcess, bridgeLease: unattachedBridgeLease },
+          (stage, error) => {
+            safeLogError(`unattached ACP ${stage} cleanup failed`, {
+              ...diagnosticErrorFields(error),
+              ...this.diagnosticContext(spawnedFramework, generation)
+            })
+          }
+        )
+        agentProcess = undefined
+        unattachedBridgeLease = undefined
         throw new Error(
-          this.shuttingDown
+          this.connectionResources.isShuttingDown
             ? 'ACP runtime is shutting down.'
             : 'ACP connection superseded during spawn.'
         )
@@ -1375,27 +1372,21 @@ class AcpRuntime {
       // Before attach(), the owner cannot detach the candidate for failure cleanup. Keep that
       // pre-publication resource local and transfer-or-release it exactly once.
       if (!resourceAttached && agentProcess) {
-        this.expectedProcessExits.add(agentProcess)
-        try {
-          unattachedConnection?.close()
-        } catch (cleanupError) {
-          safeLogError('unattached ACP connection cleanup failed', {
-            ...diagnosticErrorFields(cleanupError),
-            ...this.diagnosticContext(spawnedFramework, generation)
-          })
-        }
+        await this.connectionResources.cleanupUnattached(
+          {
+            process: agentProcess,
+            connection: unattachedConnection,
+            bridgeLease: unattachedBridgeLease
+          },
+          (stage, cleanupError) => {
+            safeLogError(`unattached ACP ${stage} cleanup failed`, {
+              ...diagnosticErrorFields(cleanupError),
+              ...this.diagnosticContext(spawnedFramework, generation)
+            })
+          }
+        )
         unattachedConnection = undefined
-        try {
-          const result = await terminateProcessTree(agentProcess, undefined, log)
-          this.lastTreeKillReaped = this.lastTreeKillReaped && result.reaped
-        } catch (cleanupError) {
-          safeLogError('unattached agent process cleanup failed', {
-            ...diagnosticErrorFields(cleanupError),
-            ...this.diagnosticContext(spawnedFramework, generation)
-          })
-        }
         agentProcess = undefined
-        await this.releaseResponsesBridgeLease(unattachedBridgeLease)
         unattachedBridgeLease = undefined
       }
 
@@ -2681,7 +2672,7 @@ class AcpRuntime {
       throw error
     } finally {
       try {
-        await this.closeMcpHttpHost(teardownGeneration)
+        await this.connectionResources.closeMcp(teardownGeneration)
       } finally {
         this.completePendingReconnectTeardown(reconnectBarrierGeneration)
       }
@@ -2693,18 +2684,11 @@ class AcpRuntime {
   // the app is gone would be an orphaned process still holding its network connection open. The OS
   // reclaims the remaining connection/session state as the process exits.
   shutdown(): void {
-    this.shuttingDown = true
-    const teardownGeneration = this.connectionResources.supersede()
-    this.invalidatePendingSessionStartups()
-    const resource = this.connectionResources.detach(teardownGeneration)
-    resource?.connection.close()
+    this.connectionResources.shutdownSynchronously(() => this.invalidatePendingSessionStartups())
     this.completePendingReconnectTeardown()
-    this.killAgentProcess(resource?.process)
     this.contextUsageTracker.clear()
     this.contextUsageUpdatedPromptTurnsBySession.clear()
     this.clearAppliedSessionModels()
-    void this.closeMcpHttpHost()
-    void this.releaseResponsesBridgeLease(resource?.bridgeLease)
   }
 
   // Awaitable quit/relaunch teardown. Latches shuttingDown FIRST so a connect that is mid-spawn when
@@ -2713,10 +2697,7 @@ class AcpRuntime {
   // remains — assigned, connecting, or mid-spawn. Returns { reaped } so the caller can tell a clean
   // teardown from a degraded one (taskkill fallback left grandchildren) before committing to app.exit.
   async shutdownForQuit(): Promise<{ reaped: boolean }> {
-    this.lastTreeKillReaped = true
-    this.shuttingDown = true
-    // Capture the in-flight connect before disconnect() clears it.
-    const inFlight = this.connectionResources.inFlight
+    const shutdown = this.connectionResources.beginAwaitableShutdown(true)
     // Kill the currently-assigned agent tree right away. Do NOT wait on the in-flight connect first: it
     // may be stalled on ACP initialize with the child already assigned, and waiting would let
     // shutdownBackends time out and app.exit orphan it. disconnect() reaps that child's tree and closes
@@ -2725,8 +2706,7 @@ class AcpRuntime {
     // Cover the child that had not been assigned yet when disconnect ran: a connect still mid-spawn hits
     // the shutting-down check and tree-kills its freshly-spawned child. Await it (swallowing its
     // rejection, bounded by shutdownBackends' timeout) so that kill completes before we resolve.
-    if (inFlight) await inFlight.catch(() => undefined)
-    return { reaped: this.lastTreeKillReaped }
+    return shutdown.finish()
   }
 
   // Teardown for the pre-update-install gate. Reaps the current agent tree (so the NSIS installer can
@@ -2740,14 +2720,10 @@ class AcpRuntime {
   // signal (so a degraded reap makes the caller refuse the install); if that await is abandoned on
   // timeout the caller refuses on !completed and the stale-generation self-reap still collects the child.
   async shutdownForUpdateGate(): Promise<{ reaped: boolean }> {
-    this.lastTreeKillReaped = true
-    // Capture the in-flight connect before disconnect() clears it. disconnect() bumps the generation, so
-    // a connect still mid-spawn will self-reap on the stale-generation check regardless of this await.
-    const inFlight = this.connectionResources.inFlight
+    const shutdown = this.connectionResources.beginAwaitableShutdown(false)
     await this.disconnect(false)
     // Await so the mid-spawn child's kill settles before we report the reaped signal.
-    if (inFlight) await inFlight.catch(() => undefined)
-    return { reaped: this.lastTreeKillReaped }
+    return shutdown.finish()
   }
 
   // Retires this framework generation without interrupting active turns or background workflows. The
@@ -2832,21 +2808,11 @@ class AcpRuntime {
       // old backend; the re-check there will fall through to a fresh connect(). Set status directly
       // rather than via setStatus — the throw may have come from emitState itself.
       const teardownGeneration = this.connectionResources.supersede()
-      const detached = this.connectionResources.detach(teardownGeneration)
-      try {
-        detached?.connection.close()
-      } catch (closeError) {
-        safeLogError('connection close after failed deferred disconnect failed', {
-          ...diagnosticErrorFields(closeError)
+      void this.connectionResources.teardown(teardownGeneration, (stage, cleanupError) => {
+        safeLogError(`${stage} cleanup after failed deferred disconnect failed`, {
+          ...diagnosticErrorFields(cleanupError)
         })
-      }
-      void this.killAgentProcessTree(detached?.process)
-        .catch((cleanupError) =>
-          safeLogError('agent process cleanup after failed deferred disconnect failed', {
-            ...diagnosticErrorFields(cleanupError)
-          })
-        )
-        .then(() => this.releaseResponsesBridgeLease(detached?.bridgeLease))
+      })
       this.snapshotOwner.transitionStatus('closed')
       // Broadcast the closed status defensively so the renderer doesn't keep showing the prior
       // 'connected' state when no createSession follows to re-emit it. Guarded because emitState may
@@ -3013,18 +2979,7 @@ class AcpRuntime {
     runCleanup('MCP HTTP routes', () => this.sessionCapabilities.clearHttpRoutes())
     this.sessionRegistry.select(undefined)
 
-    // Detach generation-owned resources before the first teardown await. A newer connect may publish
-    // replacements while process/lease cleanup is still settling; the old teardown must never close or
-    // release those replacements when it resumes.
-    const resource = this.connectionResources.detach(teardownGeneration)
-    runCleanup('connection', () => resource?.connection.close())
-
-    try {
-      await this.killAgentProcessTree(resource?.process)
-    } catch (error) {
-      recordFailure('agent-process', error)
-    }
-    await this.releaseResponsesBridgeLease(resource?.bridgeLease)
+    await this.connectionResources.teardown(teardownGeneration, recordFailure)
 
     if (emitClosedStatus && teardownGeneration === this.connectionGeneration) {
       runCleanup('closed-status', () => this.setStatus('closed'))
@@ -3032,33 +2987,6 @@ class AcpRuntime {
 
     if (teardownFailed) throw teardownFailure
     return this.getSnapshot()
-  }
-
-  // Signals the current agent child to exit and marks the exit expected so the stderr/error/exit
-  // handlers stay quiet. Synchronous: used by the will-quit backstop (shutdown()), which Electron
-  // cannot await. It only signals the immediate child — the awaited disconnect path below reaps the
-  // whole tree.
-  private killAgentProcess(child: ChildProcessWithoutNullStreams | undefined): void {
-    if (child) {
-      this.expectedProcessExits.add(child)
-
-      if (!child.killed) {
-        child.kill()
-      }
-    }
-  }
-
-  // Awaitable tree teardown for the async disconnect path: marks the exit expected, then hands the
-  // whole process tree to terminateProcessTree so a Windows grandchild (taskkill /T) is reaped before
-  // the caller (before-quit shutdownBackends) proceeds to app.exit.
-  private async killAgentProcessTree(
-    child: ChildProcessWithoutNullStreams | undefined
-  ): Promise<void> {
-    if (!child) return
-    this.expectedProcessExits.add(child)
-    const result = await terminateProcessTree(child, undefined, log)
-    // Narrow the current teardown's reaped accumulator (reset by shutdownForQuit/shutdownForUpdateGate).
-    this.lastTreeKillReaped = this.lastTreeKillReaped && result.reaped
   }
 
   // Creates the agent process, preferring an injected spawner (tests) and otherwise resolving the
@@ -3109,7 +3037,9 @@ class AcpRuntime {
       // Wrap (never mutate) the failure with the framework this spawn targeted: the connect-level catch
       // would otherwise fall back to this.framework.id, which an overlapping reconnect could move before
       // the log is written. connectFresh unwraps this and re-throws the original `error` value.
-      await backend.responsesBridgeLease?.release()
+      await this.connectionResources.cleanupUnattached({
+        bridgeLease: backend.responsesBridgeLease
+      })
       throw new SpawnFailure(backend.framework.id, error)
     }
 
@@ -3143,30 +3073,6 @@ class AcpRuntime {
     this.pendingAuthentication = backend.authentication
     this.pendingProviderConfiguration = backend.providerConfiguration
     this.opencodeUsageApi = backend.opencodeUsageApi
-  }
-
-  private async releaseResponsesBridgeLease(
-    lease: ResolvedAgentBackend['responsesBridgeLease']
-  ): Promise<void> {
-    try {
-      await lease?.release()
-    } catch (error) {
-      safeLogError('responses bridge lease release failed', errorLogFields(error))
-    }
-  }
-
-  private async closeMcpHttpHost(expectedGeneration?: number): Promise<void> {
-    // The host instance is shared across reconnects. An older disconnect may finish after a successor
-    // has already registered routes on it, so only the generation that initiated teardown may close it.
-    // shutdown() omits the guard because it latches the runtime terminal before calling this helper.
-    if (expectedGeneration !== undefined && expectedGeneration !== this.connectionGeneration) {
-      return
-    }
-    try {
-      await this.mcpHttpHost?.close()
-    } catch (error) {
-      safeLogError('MCP HTTP host close failed', errorLogFields(error))
-    }
   }
 
   // Sends one prompt turn to the targeted session and streams updates until stop.
@@ -4834,9 +4740,8 @@ class AcpRuntime {
         })
       }
 
-      if (this.expectedProcessExits.has(agentProcess)) {
+      if (this.connectionResources.processEventDisposition(agentProcess, generation) !== 'current')
         return
-      }
 
       if (text) {
         // Attribute stderr to a session only when exactly one prompt is in flight — then it's
@@ -4859,9 +4764,8 @@ class AcpRuntime {
         ...this.diagnosticContext(framework, generation)
       })
 
-      if (this.expectedProcessExits.has(agentProcess)) {
+      if (this.connectionResources.processEventDisposition(agentProcess, generation) !== 'current')
         return
-      }
 
       this.snapshotOwner.updateError(errorMessage(error))
       this.pushEvent({
@@ -4874,19 +4778,18 @@ class AcpRuntime {
     })
 
     agentProcess.on('exit', (code, signal) => {
+      const disposition = this.connectionResources.processEventDisposition(agentProcess, generation)
       log.info('agent process exit', {
         code,
         signal,
         framework,
         status: this.snapshotOwner.status,
-        expected: this.expectedProcessExits.has(agentProcess),
+        expected: disposition === 'expected',
         sessionCount: this.activeSessionIds().length,
         pid: agentProcess.pid
       })
 
-      if (this.expectedProcessExits.has(agentProcess)) {
-        return
-      }
+      if (disposition !== 'current') return
 
       if (this.snapshotOwner.status === 'connected' || this.snapshotOwner.status === 'connecting') {
         this.pushEvent({
@@ -4906,11 +4809,7 @@ class AcpRuntime {
     this.invalidatePendingSessionStartups()
     this.permissionContext.dispose()
     this.reviewerSessions.clear()
-    const resource = this.connectionResources.detach(teardownGeneration)
-    if (resource?.process) {
-      this.expectedProcessExits.add(resource.process)
-      void terminateProcessTree(resource.process, undefined, log)
-    }
+    this.connectionResources.cleanupUnexpectedClose(teardownGeneration)
     this.sessionCapabilities.dispose(this.activeSessionIds())
     for (const entry of this.sessionRegistry.entries()) {
       if (entry.attachment) this.sessionRegistry.detach(entry.attachment, 'connection')
@@ -4931,8 +4830,7 @@ class AcpRuntime {
     // and pick up the new backend from resolveBackend. A fresh spawn re-provisions
     // skills too, so clear both pending flags to avoid a spurious later reconnect.
     this.completePendingReconnectTeardown()
-    void this.closeMcpHttpHost(teardownGeneration)
-    void this.releaseResponsesBridgeLease(resource?.bridgeLease)
+    void this.connectionResources.closeMcp(teardownGeneration)
     try {
       this.setStatus('closed')
     } finally {


### PR DESCRIPTION
## Problem

`AcpRuntime` still owned physical connection teardown, process-exit classification, process-tree reaping, Responses bridge release, and MCP host epoch guards after connection publication moved behind `AcpConnectionResourceOwner`. That split ownership made disconnect, reconnect, quit, update-gate, and unexpected-close races difficult to prove safe.

## Proposed change

Move physical lifecycle authority into `AcpConnectionResourceOwner`:

- exclusive detach-before-await transfer;
- connection close and process-tree reap;
- expected/current/stale process event classification;
- bridge lease release-once behavior;
- MCP close epoch guards;
- synchronous quit backstop and awaitable quit/update-gate teardown.

`AcpRuntime` remains the facade and retains Session, Permission, Notebook capability, status, event, reconnect-intent, and protocol-startup policy.

```mermaid
flowchart LR
  Runtime["AcpRuntime facade"] -->|supersede / teardown epoch| Owner["Connection resource owner"]
  Owner -->|exclusive detach| Resource["connection + agent process + bridge lease"]
  Owner -->|epoch-guarded close| MCP["MCP HTTP host"]
  Owner -->|current / expected / stale| Events["process events"]
  Runtime -->|business-state cleanup| Policy["Session + Permission + Notebook + status/events"]
```

## Scope and non-goals

- No IPC, shared type, public API, data-model, data-relationship, or UI change.
- Electron, Web, remote Web, CLI, and Task behavior remains unchanged.
- Specialist, Permission, and Compute capability asymmetry remains unchanged.
- Reconnect/skills/retirement intent arbitration remains in Runtime for A9.1b.
- This keeps a forward-compatible resource ownership seam for #458 without adding orchestration state or public interfaces.

One intentional internal failure-path hardening is included: synchronous shutdown continues best-effort process, bridge, and MCP cleanup if connection close, process kill, or diagnostic logging throws. The public success path and projected state/events are unchanged.

## Acceptance criteria and validation

The branch was rebased again after #635 merged onto the latest `origin/main` (`0fbffe8`, including #634 and #635), then updated with `--force-with-lease`. The exact rebased head passed the focused owner/runtime suite and full typecheck. Before that clean rebase, the same A9 change set plus the final comment-only ownership correction passed the full test, typecheck, and lint suites; PR CI provides the full exact-head certification.

- Detach-before-await, stale epoch isolation, expected exit ordering, release-once, MCP guard, shutdown/update gate, unexpected close, and rollback -> `npm test -- --run src/main/acp/connection-resource-owner.test.ts src/main/acp/runtime.test.ts` -> 397 passed after the last material code edit.
- Coordinator/activity compatibility -> affected focused suites -> 50 passed; total affected coverage 447 passed.
- Repository regression coverage before the clean final-main rebase -> `npm test -- --run` -> 677 files / 9,955 tests passed; 15 files / 184 tests skipped.
- Node and renderer type compatibility on the exact rebased head -> `npm run typecheck` -> passed.
- Repository lint contract before the clean final-main rebase -> `npm run lint` -> passed with 0 errors and 19 pre-existing unrelated warnings.
- Independent Spec review -> 0 Hard findings; 3 documented nonblocking ownership/failure-path judgements.
- Independent Standards review -> 0 Hard findings; the stale ownership comment it identified is corrected in the final commit.

## Review focus

- Verify every physical resource transfers once before cleanup awaits and a stale epoch cannot touch a replacement.
- Verify intentional teardown marks the child expected before connection close can synchronously emit process events.
- Verify assigned and mid-spawn process reaping contributes to quit/update-gate results.
- Verify cleanup and logger failures never mask the original connect error or prevent later best-effort cleanup.
- Verify Runtime still owns business-state cleanup and public event/status projection.

Uncovered risk: validation is automated and does not include a manual Electron/Web/CLI journey. The changed owner sits below those adapters and changes no transport contract.
