### PR TITLE
refactor(notebook): extract export reader

### DIFF
--- a/src/main/notebook/export-reader.ts
+++ b/src/main/notebook/export-reader.ts
@@ -1,0 +1,190 @@
+import { readFile, realpath } from 'node:fs/promises'
+import { isAbsolute, relative, resolve, sep } from 'node:path'
+
+import type {
+  ExportNotebookAllRequest,
+  ExportNotebookKernelRequest,
+  NotebookRunDocument,
+  NotebookRunRecord
+} from '../../shared/notebook'
+import { resolveDataKernelForTab } from '../../shared/notebook'
+import {
+  runDocumentToIpynbByKernel,
+  runDocumentToIpynbForKernel,
+  type NbformatOutput,
+  type ResolvedArtifact
+} from './ipynb-export'
+import type { NotebookRunRepository } from './repository'
+
+type NotebookExportFile = {
+  kernel: 'python' | 'r'
+  name: string
+  data: string
+}
+
+type ResolveArtifactPath = (request: {
+  path: string
+  projectName: string
+  sessionId: string
+}) => Promise<string>
+
+type NotebookExportReaderOptions = {
+  repository: Pick<NotebookRunRepository, 'findExisting'>
+  defaultProjectName: string
+  appVersion?: string
+  resolveArtifactPath?: ResolveArtifactPath
+}
+
+const isPathInside = (root: string, candidate: string): boolean => {
+  const relativePath = relative(resolve(root), resolve(candidate))
+  return (
+    relativePath !== '' &&
+    relativePath !== '..' &&
+    !relativePath.startsWith(`..${sep}`) &&
+    !isAbsolute(relativePath)
+  )
+}
+
+const artifactMimeData = async (
+  root: string,
+  artifact: NotebookRunRecord['artifacts'][number],
+  resolveManagedPath?: ResolveArtifactPath
+): Promise<ResolvedArtifact | null> => {
+  const mimeType = artifact.mimeType
+  if (!mimeType) return null
+
+  let filePath: string | undefined
+  if (isPathInside(root, artifact.path)) {
+    const [realRoot, realFilePath] = await Promise.all([realpath(root), realpath(artifact.path)])
+    if (!isPathInside(realRoot, realFilePath)) {
+      throw new Error(`Artifact escapes the notebook session root: ${artifact.name}`)
+    }
+    filePath = realFilePath
+  } else {
+    filePath = await resolveManagedPath?.({
+      path: artifact.path,
+      projectName: artifact.projectName,
+      sessionId: artifact.sessionId
+    })
+  }
+  if (!filePath) return null
+
+  const binary = await readFile(filePath)
+  if (mimeType === 'image/svg+xml') {
+    return { mimeType, data: binary.toString('utf8') }
+  }
+  if (mimeType.startsWith('image/')) {
+    return { mimeType, data: binary.toString('base64') }
+  }
+  if (mimeType === 'application/json') {
+    return { mimeType, data: JSON.parse(binary.toString('utf8')) as unknown }
+  }
+  if (mimeType.startsWith('text/')) {
+    return { mimeType, data: binary.toString('utf8') }
+  }
+  return null
+}
+
+const resolveArtifactOutputs = async (
+  document: NotebookRunDocument,
+  resolveManagedPath?: ResolveArtifactPath
+): Promise<Map<string, NbformatOutput[]>> => {
+  const outputsByRun = new Map<string, NbformatOutput[]>()
+  const artifactSessionId = document.artifactSessionId ?? document.sessionId
+
+  for (const run of document.runs) {
+    if (run.artifacts.length === 0) continue
+
+    const outputs: NbformatOutput[] = []
+    for (const artifact of run.artifacts) {
+      try {
+        const belongsToDocument =
+          artifact.projectName === document.projectName && artifact.sessionId === artifactSessionId
+        const resolved = belongsToDocument
+          ? await artifactMimeData(document.notebookSessionRoot, artifact, resolveManagedPath)
+          : null
+        if (resolved) {
+          outputs.push({
+            output_type: 'display_data',
+            data: { [resolved.mimeType]: resolved.data },
+            metadata: {}
+          })
+        }
+      } catch {
+        outputs.push({
+          output_type: 'stream',
+          name: 'stderr',
+          text: [`[Open Science] Could not inline artifact: ${artifact.name}\n`]
+        })
+      }
+    }
+    outputsByRun.set(run.runId, outputs)
+  }
+
+  return outputsByRun
+}
+
+const serialize = (value: unknown): string => `${JSON.stringify(value, null, 2)}\n`
+
+// Owns durable snapshot loading, fail-closed artifact resolution, kernel selection, pure nbformat
+// projection, and byte-stable serialization; Electron's native save action stays in the facade.
+class NotebookExportReader {
+  constructor(private readonly options: NotebookExportReaderOptions) {}
+
+  async readKernel(request: ExportNotebookKernelRequest): Promise<NotebookExportFile> {
+    const document = await this.loadDocument(request)
+    const kernel = resolveDataKernelForTab(document.runs, request.kernel)
+    if (!kernel) {
+      throw new Error(
+        `No ${request.kernel === 'repl' || request.kernel === 'bash' ? 'data-kernel' : request.kernel} runs in this session. Run a Python or R cell first.`
+      )
+    }
+
+    const artifactOutputs = await resolveArtifactOutputs(document, this.options.resolveArtifactPath)
+    const notebook = runDocumentToIpynbForKernel(document, kernel, {
+      appVersion: this.options.appVersion,
+      artifactOutputs
+    })
+
+    return {
+      kernel,
+      name: `session-${request.sessionId.slice(0, 8)}-${kernel}.ipynb`,
+      data: serialize(notebook)
+    }
+  }
+
+  async readAll(request: ExportNotebookAllRequest): Promise<NotebookExportFile[]> {
+    const document = await this.loadDocument(request)
+    const artifactOutputs = await resolveArtifactOutputs(document, this.options.resolveArtifactPath)
+    const notebooks = runDocumentToIpynbByKernel(document, {
+      appVersion: this.options.appVersion,
+      artifactOutputs
+    })
+    const prefix = `session-${request.sessionId.slice(0, 8)}`
+    const files = (['python', 'r'] as const)
+      .filter((kernel) => notebooks[kernel] !== undefined)
+      .map((kernel) => ({
+        kernel,
+        name: `${prefix}-${kernel}.ipynb`,
+        data: serialize(notebooks[kernel])
+      }))
+
+    if (files.length === 0) {
+      throw new Error('No data-kernel runs in this session. Run a Python or R cell first.')
+    }
+    return files
+  }
+
+  private async loadDocument(
+    request: ExportNotebookAllRequest | ExportNotebookKernelRequest
+  ): Promise<NotebookRunDocument> {
+    const projectName = request.projectName ?? this.options.defaultProjectName
+    const document = await this.options.repository.findExisting(projectName, request.sessionId)
+    if (!document) {
+      throw new Error(`Notebook session not found: ${request.sessionId}`)
+    }
+    return document
+  }
+}
+
+export { NotebookExportReader }

--- a/src/main/notebook/runtime-service.export.test.ts
+++ b/src/main/notebook/runtime-service.export.test.ts
@@ -65,11 +65,13 @@ describe('NotebookRuntimeService exportIpynb', () => {
     expect(repository.findExisting).toHaveBeenCalledWith('default-project', '12345678-abcd')
     expect(saveIpynb).toHaveBeenCalledOnce()
     expect(saveIpynb.mock.calls[0][0]).toBe('session-12345678-python.ipynb')
-    const exported = JSON.parse(saveIpynb.mock.calls[0][1]) as {
+    const serialized = saveIpynb.mock.calls[0][1] as string
+    const exported = JSON.parse(serialized) as {
       nbformat: number
       metadata: { open_science: { appVersion: string } }
       cells: Array<{ source: string[] }>
     }
+    expect(serialized).toBe(`${JSON.stringify(exported, null, 2)}\n`)
     expect(exported).toMatchObject({
       nbformat: 4,
       metadata: { open_science: { appVersion: '1.2.3' } }
@@ -95,6 +97,83 @@ describe('NotebookRuntimeService exportIpynb', () => {
       service.exportIpynb({ sessionId: 'missing', workspaceCwd: '/workspace', kernel: 'python' })
     ).rejects.toThrow('Notebook session not found: missing')
     expect(saveIpynb).not.toHaveBeenCalled()
+  })
+
+  it('keeps the existing no-data-kernel error and does not open the save dialog', async () => {
+    const repository = {
+      findExisting: vi.fn().mockResolvedValue({
+        ...document,
+        runs: [{ ...document.runs[0], kernelKind: 'repl' }]
+      })
+    } as unknown as NotebookRunRepository
+    const saveIpynb = vi.fn()
+    const service = new NotebookRuntimeService({
+      configRoot: '/config',
+      dataRoot: '/storage',
+      projectName: 'default-project',
+      repository,
+      saveIpynb
+    })
+
+    await expect(
+      service.exportIpynb({
+        sessionId: '12345678-abcd',
+        workspaceCwd: '/workspace',
+        kernel: 'repl'
+      })
+    ).rejects.toThrow('No data-kernel runs in this session. Run a Python or R cell first.')
+    expect(saveIpynb).not.toHaveBeenCalled()
+  })
+
+  it('keeps multi-kernel filenames, byte serialization, and control-run attribution', async () => {
+    const run = document.runs[0]!
+    const mixedDocument: NotebookRunDocument = {
+      ...document,
+      runs: [
+        { ...run, runId: 'bash-before', cellId: 'bash-before', kernelKind: 'bash', script: 'pwd' },
+        { ...run, runId: 'python', cellId: 'python', kernelKind: 'python', script: 'print(1)' },
+        { ...run, runId: 'repl', cellId: 'repl', kernelKind: 'repl', script: 'await task()' },
+        { ...run, runId: 'r', cellId: 'r', kernelKind: 'r', script: 'print(2)' },
+        { ...run, runId: 'bash-after', cellId: 'bash-after', kernelKind: 'bash', script: 'ls' }
+      ]
+    }
+    const repository = {
+      findExisting: vi.fn().mockResolvedValue(mixedDocument)
+    } as unknown as NotebookRunRepository
+    const saveIpynbAll = vi.fn().mockResolvedValue({ saved: true, filePaths: [] })
+    const service = new NotebookRuntimeService({
+      configRoot: '/config',
+      dataRoot: '/storage',
+      projectName: 'default-project',
+      repository,
+      saveIpynbAll
+    })
+
+    await service.exportIpynbAll({
+      sessionId: '12345678-abcd',
+      workspaceCwd: '/workspace'
+    })
+
+    const files = saveIpynbAll.mock.calls[0][0] as Array<{
+      kernel: 'python' | 'r'
+      name: string
+      data: string
+    }>
+    expect(files.map(({ kernel, name }) => ({ kernel, name }))).toEqual([
+      { kernel: 'python', name: 'session-12345678-python.ipynb' },
+      { kernel: 'r', name: 'session-12345678-r.ipynb' }
+    ])
+
+    const python = JSON.parse(files[0]!.data) as { cells: Array<{ source: string[] }> }
+    const r = JSON.parse(files[1]!.data) as { cells: Array<{ source: string[] }> }
+    expect(files[0]!.data).toBe(`${JSON.stringify(python, null, 2)}\n`)
+    expect(files[1]!.data).toBe(`${JSON.stringify(r, null, 2)}\n`)
+    expect(python.cells.map((cell) => cell.source.join(''))).toEqual([
+      '%%bash\npwd',
+      'print(1)',
+      '%%javascript\nawait task()'
+    ])
+    expect(r.cells.map((cell) => cell.source.join(''))).toEqual(['print(2)', '%%bash\nls'])
   })
 
   describe('artifact inlining', () => {
@@ -162,7 +241,11 @@ describe('NotebookRuntimeService exportIpynb', () => {
         ...(options.resolveArtifactPath ? { resolveArtifactPath: options.resolveArtifactPath } : {})
       })
 
-      await service.exportIpynb({ sessionId: '12345678-abcd', workspaceCwd: '/workspace', kernel: 'python' })
+      await service.exportIpynb({
+        sessionId: '12345678-abcd',
+        workspaceCwd: '/workspace',
+        kernel: 'python'
+      })
 
       const json = saveIpynb.mock.calls[0][1] as string
       const notebook = JSON.parse(json) as {
@@ -287,6 +370,90 @@ describe('NotebookRuntimeService exportIpynb', () => {
         output_type: 'stream',
         name: 'stderr',
         text: ['[Open Science] Could not inline artifact: plot.png\n']
+      })
+    })
+
+    it('does not resolve an artifact whose persisted identity does not match the document', async () => {
+      const root = await createSessionRoot()
+      const resolveArtifactPath = vi.fn(async (request: { path: string }) => request.path)
+
+      const result = await exportWithArtifact(
+        root,
+        makeArtifact({ path: '/managed/plot.png', projectName: 'other-project' }),
+        { resolveArtifactPath }
+      )
+
+      expect(resolveArtifactPath).not.toHaveBeenCalled()
+      expect(result.outputs.some((output) => output.output_type === 'display_data')).toBe(false)
+    })
+
+    it('uses artifactSessionId as the fail-closed artifact identity when present', async () => {
+      const root = await createSessionRoot()
+      const managedRoot = await mkdtemp(join(tmpdir(), 'open-science-ipynb-identity-'))
+      try {
+        const managedPath = join(managedRoot, 'managed-artifact.png')
+        await writeFile(managedPath, Buffer.from([0x89, 0x50, 0x4e, 0x47]))
+        const resolveArtifactPath = vi.fn(async () => managedPath)
+        const documentWithArtifactSession: NotebookRunDocument = {
+          ...document,
+          artifactSessionId: 'artifact-session',
+          notebookSessionRoot: root,
+          runs: [
+            {
+              ...document.runs[0],
+              artifacts: [
+                makeArtifact({
+                  path: managedPath,
+                  sessionId: 'artifact-session',
+                  size: 4
+                })
+              ]
+            }
+          ]
+        }
+        const repository = {
+          findExisting: vi.fn().mockResolvedValue(documentWithArtifactSession)
+        } as unknown as NotebookRunRepository
+        const saveIpynb = vi.fn().mockResolvedValue({ saved: true, filePath: '/out/session.ipynb' })
+        const service = new NotebookRuntimeService({
+          configRoot: '/config',
+          dataRoot: '/storage',
+          projectName: 'default-project',
+          repository,
+          saveIpynb,
+          resolveArtifactPath
+        })
+
+        await service.exportIpynb({
+          sessionId: '12345678-abcd',
+          workspaceCwd: '/workspace',
+          kernel: 'python'
+        })
+
+        expect(resolveArtifactPath).toHaveBeenCalledWith({
+          path: managedPath,
+          projectName: 'default-project',
+          sessionId: 'artifact-session'
+        })
+      } finally {
+        await rm(managedRoot, { recursive: true, force: true })
+      }
+    })
+
+    it('degrades malformed JSON artifacts to the existing stderr marker', async () => {
+      const root = await createSessionRoot()
+      const jsonPath = join(root, 'broken.json')
+      await writeFile(jsonPath, '{broken')
+
+      const result = await exportWithArtifact(
+        root,
+        makeArtifact({ name: 'broken.json', path: jsonPath, mimeType: 'application/json' })
+      )
+
+      expect(result.outputs).toContainEqual({
+        output_type: 'stream',
+        name: 'stderr',
+        text: ['[Open Science] Could not inline artifact: broken.json\n']
       })
     })
   })

--- a/src/main/notebook/runtime-service.ts
+++ b/src/main/notebook/runtime-service.ts
@@ -1,8 +1,8 @@
 import { spawn, type ChildProcess } from 'node:child_process'
 import { randomUUID } from 'node:crypto'
 import { existsSync, realpathSync } from 'node:fs'
-import { readFile, realpath, writeFile } from 'node:fs/promises'
-import { isAbsolute, join, relative, resolve, sep, win32 } from 'node:path'
+import { writeFile } from 'node:fs/promises'
+import { join, win32 } from 'node:path'
 
 import type {
   NotebookCell,
@@ -20,7 +20,6 @@ import type {
   NotebookKernelMetadata,
   NotebookLanguage,
   NotebookOutput,
-  NotebookRunDocument,
   NotebookRunRecord,
   NotebookRunSource,
   NotebookRunStatus,
@@ -31,7 +30,6 @@ import type {
   RunNotebookCellRequest,
   NotebookWorkingFile
 } from '../../shared/notebook'
-import { resolveDataKernelForTab } from '../../shared/notebook'
 import type {
   EnvironmentInfo,
   ManageEnvironmentsRequest,
@@ -39,12 +37,7 @@ import type {
   ProvisionProgress
 } from '../../shared/notebook-env'
 import type { PackageMirror } from '../../shared/mirror'
-import {
-  runDocumentToIpynbByKernel,
-  runDocumentToIpynbForKernel,
-  type NbformatOutput,
-  type ResolvedArtifact
-} from './ipynb-export'
+import { NotebookExportReader } from './export-reader'
 import { NotebookKernelExecutor, type NotebookKernelExecutorOptions } from './kernel-executor'
 import { saveIpynbAll } from './save-ipynb-all'
 import type { KernelProcessKind } from './kernel-executor'
@@ -390,110 +383,6 @@ const saveIpynbWithDialog = async (
 // the per-tab path (a single .ipynb) goes through `saveIpynbWithDialog` instead. The actual
 // orchestration (directory picker, conflict check, partial-write cleanup) lives in save-ipynb-all
 // so tests can exercise the real path with a mocked electron instead of bypassing via the seam.
-
-const isPathInside = (root: string, candidate: string): boolean => {
-  const relativePath = relative(resolve(root), resolve(candidate))
-  return (
-    relativePath !== '' &&
-    relativePath !== '..' &&
-    !relativePath.startsWith(`..${sep}`) &&
-    !isAbsolute(relativePath)
-  )
-}
-
-const artifactMimeData = async (
-  root: string,
-  artifact: NotebookRunRecord['artifacts'][number],
-  resolveManagedPath?: (request: {
-    path: string
-    projectName: string
-    sessionId: string
-  }) => Promise<string>
-): Promise<ResolvedArtifact | null> => {
-  const mimeType = artifact.mimeType
-  if (!mimeType) return null
-
-  let filePath: string | undefined
-  if (isPathInside(root, artifact.path)) {
-    // Lexical containment is not enough — a symlink inside the notebook root can point anywhere.
-    // Canonicalize both sides and require the real path to stay inside the real notebook root.
-    const [realRoot, realFilePath] = await Promise.all([realpath(root), realpath(artifact.path)])
-    if (!isPathInside(realRoot, realFilePath)) {
-      throw new Error(`Artifact escapes the notebook session root: ${artifact.name}`)
-    }
-    filePath = realFilePath
-  } else {
-    filePath = await resolveManagedPath?.({
-      path: artifact.path,
-      projectName: artifact.projectName,
-      sessionId: artifact.sessionId
-    })
-  }
-  if (!filePath) return null
-
-  const binary = await readFile(filePath)
-  // nbformat stores SVG as raw text; only binary images (png/jpeg/…) are base64-encoded.
-  if (mimeType === 'image/svg+xml') {
-    return { mimeType, data: binary.toString('utf8') }
-  }
-  if (mimeType.startsWith('image/')) {
-    return { mimeType, data: binary.toString('base64') }
-  }
-  if (mimeType === 'application/json') {
-    return { mimeType, data: JSON.parse(binary.toString('utf8')) as unknown }
-  }
-  if (mimeType.startsWith('text/')) {
-    return { mimeType, data: binary.toString('utf8') }
-  }
-  return null
-}
-
-// The IO phase of an ipynb export: resolves every run's artifacts into nbformat outputs up front,
-// so the projection itself (runDocumentToIpynb) is a pure function that never touches the
-// filesystem. Only artifacts belonging to this document are inlined; read/parse failures degrade
-// to a stderr marker output rather than aborting the export.
-const resolveNotebookArtifactOutputs = async (
-  document: NotebookRunDocument,
-  resolveManagedPath?: (request: {
-    path: string
-    projectName: string
-    sessionId: string
-  }) => Promise<string>
-): Promise<Map<string, NbformatOutput[]>> => {
-  const outputsByRun = new Map<string, NbformatOutput[]>()
-  const artifactSessionId = document.artifactSessionId ?? document.sessionId
-
-  for (const run of document.runs) {
-    if (run.artifacts.length === 0) continue
-
-    const outputs: NbformatOutput[] = []
-    for (const artifact of run.artifacts) {
-      try {
-        const belongsToDocument =
-          artifact.projectName === document.projectName && artifact.sessionId === artifactSessionId
-        const resolved = belongsToDocument
-          ? await artifactMimeData(document.notebookSessionRoot, artifact, resolveManagedPath)
-          : null
-        if (resolved) {
-          outputs.push({
-            output_type: 'display_data',
-            data: { [resolved.mimeType]: resolved.data },
-            metadata: {}
-          })
-        }
-      } catch {
-        outputs.push({
-          output_type: 'stream',
-          name: 'stderr',
-          text: [`[Open Science] Could not inline artifact: ${artifact.name}\n`]
-        })
-      }
-    }
-    outputsByRun.set(run.runId, outputs)
-  }
-
-  return outputsByRun
-}
 
 // Turns unexpected executor exceptions into ordinary run results for the agent to inspect.
 const errorToExecutionResult = (error: unknown, cwd: string): NotebookExecutionResult => {
@@ -884,6 +773,7 @@ const resolveDefaultExecutorOptions = (): NotebookKernelExecutorOptions => {
 // Coordinates notebook cells, shared interpreters, persisted run history, and UI notifications.
 class NotebookRuntimeService {
   private readonly repository: NotebookRunRepository
+  private readonly exportReader: NotebookExportReader
   private readonly runTerminalization: NotebookRunTerminalizationOwner
   private readonly sessions: NotebookSessionRegistry<RuntimeSession>
   private readonly announcedAgentSessionIds = new Set<string>()
@@ -921,6 +811,12 @@ class NotebookRuntimeService {
 
   constructor(private readonly options: NotebookRuntimeServiceOptions) {
     this.repository = options.repository ?? new NotebookRunRepository(options.dataRoot)
+    this.exportReader = new NotebookExportReader({
+      repository: this.repository,
+      defaultProjectName: options.projectName,
+      appVersion: options.appVersion,
+      resolveArtifactPath: options.resolveArtifactPath
+    })
     this.sessions = new NotebookSessionRegistry({
       beforeTeardown: async () => {
         await this.environmentOperations.waitForRevocationDrains().catch(() => undefined)
@@ -1968,33 +1864,8 @@ class NotebookRuntimeService {
   // file to come back as `kernelspec.name='ir'`, and a user on the repl tab gets the .ipynb
   // scoped to whichever data kernel was most recently active when repl ran.
   async exportIpynb(request: ExportNotebookKernelRequest): Promise<ExportNotebookResult> {
-    const projectName = request.projectName ?? this.options.projectName
-    const document = await this.repository.findExisting(projectName, request.sessionId)
-    if (!document) {
-      throw new Error(`Notebook session not found: ${request.sessionId}`)
-    }
-
-    const dataKernel = resolveDataKernelForTab(document.runs, request.kernel)
-    if (!dataKernel) {
-      // The session has no python/r runs at all — every run is a control-plane run, so there is no
-      // kernelspec we'd be honest about. Refuse rather than synthesize a phantom notebook.
-      throw new Error(
-        `No ${request.kernel === 'repl' || request.kernel === 'bash' ? 'data-kernel' : request.kernel} runs in this session. Run a Python or R cell first.`
-      )
-    }
-
-    const artifactOutputs = await resolveNotebookArtifactOutputs(
-      document,
-      this.options.resolveArtifactPath
-    )
-    const notebook = runDocumentToIpynbForKernel(document, dataKernel, {
-      appVersion: this.options.appVersion,
-      artifactOutputs
-    })
-    const suggestedName = `session-${request.sessionId.slice(0, 8)}-${dataKernel}.ipynb`
-    const serialized = `${JSON.stringify(notebook, null, 2)}\n`
-
-    return (this.options.saveIpynb ?? saveIpynbWithDialog)(suggestedName, serialized)
+    const file = await this.exportReader.readKernel(request)
+    return (this.options.saveIpynb ?? saveIpynbWithDialog)(file.name, file.data)
   }
 
   // The "Download all" path: writes one .ipynb per data kernel that has runs to a directory the
@@ -2002,36 +1873,7 @@ class NotebookRuntimeService {
   // data kernels — a single-kernel session's "Download all" would be a confusing duplicate of the
   // main button, so the renderer gates the secondary button on `kindsWithRuns.has('python') && has('r')`.
   async exportIpynbAll(request: ExportNotebookAllRequest): Promise<ExportNotebookAllResult> {
-    const projectName = request.projectName ?? this.options.projectName
-    const document = await this.repository.findExisting(projectName, request.sessionId)
-    if (!document) {
-      throw new Error(`Notebook session not found: ${request.sessionId}`)
-    }
-
-    const artifactOutputs = await resolveNotebookArtifactOutputs(
-      document,
-      this.options.resolveArtifactPath
-    )
-    const notebooks = runDocumentToIpynbByKernel(document, {
-      appVersion: this.options.appVersion,
-      artifactOutputs
-    })
-
-    const prefix = `session-${request.sessionId.slice(0, 8)}`
-    const files: Array<{ kernel: 'python' | 'r'; name: string; data: string }> = (
-      ['python', 'r'] as const
-    )
-      .filter((kernel) => notebooks[kernel] !== undefined)
-      .map((kernel) => ({
-        kernel,
-        name: `${prefix}-${kernel}.ipynb`,
-        data: `${JSON.stringify(notebooks[kernel], null, 2)}\n`
-      }))
-
-    if (files.length === 0) {
-      throw new Error('No data-kernel runs in this session. Run a Python or R cell first.')
-    }
-
+    const files = await this.exportReader.readAll(request)
     return (this.options.saveIpynbAll ?? saveIpynbAll)(files)
   }
 


### PR DESCRIPTION
## Problem

Notebook export reads still live inside the large runtime façade. Durable snapshot loading, artifact lookup, kernel attribution, and byte serialization are coupled to native save-dialog and file-write actions, which obscures state ownership and makes later execution/export work harder to isolate.

Related issue: #458 is a forward-compatibility constraint only. This pull request does not add orchestration state, persistence, APIs, events, or user interaction.

## Proposed change

Extract a read-only `NotebookExportReader` behind the existing `NotebookRuntimeService` façade.

```mermaid
flowchart LR
  C["Electron / local Web callers"] --> F["NotebookRuntimeService façade"]
  F --> R["NotebookExportReader"]
  R --> S["durable run snapshot"]
  R --> A["managed artifacts"]
  R --> P["pure IPYNB projection"]
  F --> D["native save dialog + file writes"]
```

The reader owns durable snapshot loading, artifact-safe resolution, kernel selection, pure projection input, and byte serialization. The façade continues to own native save dialogs and filesystem writes.

## Scope and non-goals

- Preserve JSON bytes as `JSON.stringify(value, null, 2) + "\n"`.
- Preserve filenames, ordering, Python/R selection, and REPL/Bash attribution.
- Preserve `artifactSessionId ?? sessionId`, project matching, and lexical/realpath containment checks.
- Preserve stderr markers for artifact read/JSON failures.
- Preserve the existing Electron, local Web, remote Web, CLI/local RPC, Task, and IPC behavior and capability asymmetry.
- No public/shared contract, persistence model, data relationship, UI, save-dialog, transport, Specialist, Permission, or Compute change.
- Remote Web native export remains denied.

## Acceptance criteria and validation

All listed checks ran after the last material file edit. The final rebase changed ancestry only and left the three-file branch diff unchanged.

- Export byte, filename, kernel, attribution, artifact identity, containment, MIME, and stderr behavior -> `npm test -- --run src/main/notebook/runtime-service.export.test.ts src/main/notebook/ipynb-export.test.ts src/main/notebook/save-ipynb-all.test.ts` -> 37/37 passed on `ed0ba65`.
- Node and Web compile compatibility -> `npm run typecheck` -> passed on `ed0ba65`.
- Repository lint -> `npm run lint` -> passed with 0 errors and 18 existing warnings on `ed0ba65`.
- Repository regression suite -> `npm test` -> 9,977 passed / 184 skipped on the same material file state before the clean ancestry-only rebase.
- Independent final review -> Spec: 0 findings; Standards: 0 findings.

Uncovered risk: the unchanged native Electron save-dialog interaction was not exercised manually. Exact-head CI remains the merge gate.

## Review focus

- Confirm the new module is read-only and the façade retains every native side effect.
- Confirm fail-closed artifact containment and identity semantics are unchanged.
- Confirm serialized bytes and kernel attribution are byte-for-byte compatible.
- Confirm no public surface or issue #458 orchestration contract has been introduced.
