### PR TITLE
refactor(acp): extract connection transition owner

### DIFF
--- a/src/main/acp/connection-transition-owner.test.ts
+++ b/src/main/acp/connection-transition-owner.test.ts
@@ -1,0 +1,127 @@
+import { describe, expect, it, vi } from 'vitest'
+
+import { AcpConnectionTransitionOwner } from './connection-transition-owner'
+
+describe('AcpConnectionTransitionOwner', () => {
+  it('coalesces blocked provider and skills intents into one planned reconnect', async () => {
+    let reconnectBlocked = true
+    const disconnect = vi.fn(async () => undefined)
+    const publishIdle = vi.fn()
+    const owner = new AcpConnectionTransitionOwner({
+      blockers: () => ({ reconnect: reconnectBlocked, retirement: reconnectBlocked }),
+      connectionGeneration: () => 1,
+      disconnect,
+      onRetired: vi.fn(),
+      publishIdle,
+      recoverFailedDeferredDisconnect: vi.fn(),
+      reportFailure: vi.fn()
+    })
+
+    await owner.requestProviderReconnect()
+    owner.requestSkillsReload()
+
+    expect(owner.barrier).toBeDefined()
+    expect(disconnect).not.toHaveBeenCalled()
+
+    reconnectBlocked = false
+    owner.activityChanged()
+    await vi.waitFor(() => expect(owner.barrier).toBeUndefined())
+
+    expect(disconnect).toHaveBeenCalledOnce()
+    expect(publishIdle).toHaveBeenCalledOnce()
+    expect(owner.providerReconnectPending).toBe(false)
+  })
+
+  it('lets retirement win over queued reconnect intents and retires once', async () => {
+    let blocked = true
+    const disconnect = vi.fn(async () => undefined)
+    const onRetired = vi.fn()
+    const publishIdle = vi.fn()
+    const owner = new AcpConnectionTransitionOwner({
+      blockers: () => ({ reconnect: blocked, retirement: blocked }),
+      connectionGeneration: () => 1,
+      disconnect,
+      onRetired,
+      publishIdle,
+      recoverFailedDeferredDisconnect: vi.fn(),
+      reportFailure: vi.fn()
+    })
+
+    await owner.requestProviderReconnect()
+    owner.requestSkillsReload()
+    await owner.requestRetirement()
+    await owner.requestRetirement()
+    expect(disconnect).not.toHaveBeenCalled()
+
+    blocked = false
+    owner.activityChanged()
+    await vi.waitFor(() => expect(onRetired).toHaveBeenCalledOnce())
+
+    expect(disconnect).toHaveBeenCalledOnce()
+    expect(publishIdle).not.toHaveBeenCalled()
+    expect(owner.barrier).toBeUndefined()
+    await owner.requestRetirement()
+    expect(onRetired).toHaveBeenCalledOnce()
+  })
+
+  it('does not let stale teardown release a newer reconnect barrier', async () => {
+    let blocked = true
+    let releaseTeardown!: () => void
+    const teardownGate = new Promise<void>((resolve) => {
+      releaseTeardown = resolve
+    })
+    const disconnect = vi.fn(async () => undefined)
+    const owner = new AcpConnectionTransitionOwner({
+      blockers: () => ({ reconnect: blocked, retirement: blocked }),
+      connectionGeneration: () => 1,
+      disconnect,
+      onRetired: vi.fn(),
+      publishIdle: vi.fn(),
+      recoverFailedDeferredDisconnect: vi.fn(),
+      reportFailure: vi.fn()
+    })
+
+    await owner.requestProviderReconnect()
+    const staleTeardown = owner.settleTeardown(() => teardownGate)
+    await owner.requestProviderReconnect()
+
+    releaseTeardown()
+    await staleTeardown
+    expect(owner.barrier).toBeDefined()
+
+    blocked = false
+    owner.activityChanged()
+    await vi.waitFor(() => expect(owner.barrier).toBeUndefined())
+    expect(disconnect).toHaveBeenCalledOnce()
+  })
+
+  it('recovers a failed deferred disconnect and always releases its barrier', async () => {
+    let blocked = true
+    const disconnectFailure = new Error('disconnect failed')
+    const recoverFailedDeferredDisconnect = vi.fn(async () => undefined)
+    const reportFailure = vi.fn()
+    const owner = new AcpConnectionTransitionOwner({
+      blockers: () => ({ reconnect: blocked, retirement: blocked }),
+      connectionGeneration: () => 1,
+      disconnect: vi.fn(async () => {
+        throw disconnectFailure
+      }),
+      onRetired: vi.fn(),
+      publishIdle: vi.fn(),
+      recoverFailedDeferredDisconnect,
+      reportFailure
+    })
+
+    await owner.requestProviderReconnect()
+    blocked = false
+    owner.activityChanged()
+    await vi.waitFor(() => expect(owner.barrier).toBeUndefined())
+
+    expect(recoverFailedDeferredDisconnect).toHaveBeenCalledOnce()
+    expect(recoverFailedDeferredDisconnect).toHaveBeenCalledWith(disconnectFailure)
+    expect(reportFailure).toHaveBeenCalledWith(
+      'deferred reconnect disconnect failed',
+      disconnectFailure
+    )
+  })
+})

--- a/src/main/acp/connection-transition-owner.ts
+++ b/src/main/acp/connection-transition-owner.ts
@@ -1,0 +1,164 @@
+export type AcpConnectionTransitionBlockers = Readonly<{
+  reconnect: boolean
+  retirement: boolean
+}>
+
+type AcpConnectionTransitionOwnerOptions = Readonly<{
+  blockers: () => AcpConnectionTransitionBlockers
+  connectionGeneration: () => number
+  disconnect: (emitClosedStatus: boolean) => Promise<unknown>
+  onRetired: () => void
+  publishIdle: () => void
+  recoverFailedDeferredDisconnect: (error: unknown) => void | Promise<void>
+  reportFailure: (message: string, error: unknown) => void
+}>
+
+// Owns provider, skills, and retirement replacement intents plus the barrier awaited by connection
+// startup. Prompt/Reviewer/startup/activity leases remain with Runtime and are observed as one narrow
+// blocker snapshot; physical resources remain exclusively owned by AcpConnectionResourceOwner.
+export class AcpConnectionTransitionOwner {
+  private providerIntent = false
+  private skillsIntent = false
+  private retirementIntent = false
+  private retirementStarted = false
+  private barrierPromise: Promise<void> | undefined
+  private resolveBarrier: (() => void) | undefined
+  private barrierGeneration = 0
+
+  constructor(private readonly options: AcpConnectionTransitionOwnerOptions) {}
+
+  get barrier(): Promise<void> | undefined {
+    return this.barrierPromise
+  }
+
+  get providerReconnectPending(): boolean {
+    return this.providerIntent
+  }
+
+  async requestProviderReconnect(): Promise<void> {
+    if (this.options.blockers().reconnect) {
+      this.providerIntent = true
+      this.armBarrier()
+      return
+    }
+
+    this.providerIntent = false
+    await this.disconnectPlanned()
+  }
+
+  requestSkillsReload(): void {
+    this.skillsIntent = true
+    this.activityChanged()
+  }
+
+  async requestRetirement(): Promise<void> {
+    if (this.retirementStarted) return
+    this.retirementIntent = true
+    if (this.options.blockers().retirement) return
+    await this.startRetirement()
+  }
+
+  activityChanged(): void {
+    if (this.retirementIntent) {
+      if (this.options.blockers().retirement) return
+      void this.startRetirement()
+      return
+    }
+
+    if (this.options.blockers().reconnect) return
+    if (!this.providerIntent && !this.skillsIntent) return
+
+    this.providerIntent = false
+    this.skillsIntent = false
+    void this.disconnectDeferred()
+  }
+
+  async settleTeardown<T>(teardown: () => Promise<T>): Promise<T> {
+    const expectedBarrierGeneration = this.barrierGeneration
+    try {
+      return await teardown()
+    } finally {
+      this.completeReconnect(expectedBarrierGeneration)
+    }
+  }
+
+  resetReconnect(): void {
+    this.completeReconnect()
+  }
+
+  private async disconnectDeferred(): Promise<void> {
+    const expectedBarrierGeneration = this.barrierGeneration
+    try {
+      await this.disconnectPlanned()
+    } catch (error) {
+      this.reportFailure('deferred reconnect disconnect failed', error)
+      try {
+        await this.options.recoverFailedDeferredDisconnect(error)
+      } catch (recoveryError) {
+        this.reportFailure('failed deferred reconnect recovery failed', recoveryError)
+      }
+    } finally {
+      // A newer provider intent may have armed another generation while teardown settled.
+      this.completeReconnect(expectedBarrierGeneration)
+    }
+  }
+
+  private async disconnectPlanned(): Promise<void> {
+    const disconnect = this.options.disconnect(false)
+    const teardownGeneration = this.options.connectionGeneration()
+    await disconnect
+    if (teardownGeneration === this.options.connectionGeneration()) this.options.publishIdle()
+  }
+
+  private async startRetirement(): Promise<void> {
+    if (this.retirementStarted) return
+    this.retirementStarted = true
+    this.retirementIntent = false
+    this.providerIntent = false
+    this.skillsIntent = false
+
+    try {
+      await this.options.disconnect(false)
+    } catch (error) {
+      this.reportFailure('retired runtime disconnect failed', error)
+    } finally {
+      this.completeReconnect()
+      try {
+        this.options.onRetired()
+      } catch (error) {
+        this.reportFailure('retired runtime callback failed', error)
+      }
+    }
+  }
+
+  private armBarrier(): void {
+    this.barrierGeneration += 1
+    if (this.barrierPromise) return
+    this.barrierPromise = new Promise<void>((resolve) => {
+      this.resolveBarrier = resolve
+    })
+  }
+
+  private completeReconnect(expectedBarrierGeneration?: number): void {
+    if (
+      expectedBarrierGeneration !== undefined &&
+      expectedBarrierGeneration !== this.barrierGeneration
+    ) {
+      return
+    }
+    this.providerIntent = false
+    this.skillsIntent = false
+    const resolve = this.resolveBarrier
+    this.barrierPromise = undefined
+    this.resolveBarrier = undefined
+    resolve?.()
+  }
+
+  private reportFailure(message: string, error: unknown): void {
+    try {
+      this.options.reportFailure(message, error)
+    } catch {
+      // Intent cleanup and barrier release take precedence over diagnostic sinks.
+    }
+  }
+}

--- a/src/main/acp/runtime.test.ts
+++ b/src/main/acp/runtime.test.ts
@@ -12485,6 +12485,46 @@ describe('ACP runtime session management', () => {
     expect(onRetired).toHaveBeenCalledOnce()
   })
 
+  it('lets retirement supersede a deferred provider reconnect exactly once', async () => {
+    const process = new FakeAgentProcess()
+    const promptStarted = createDeferred()
+    const releasePrompt = createDeferred()
+    const onRetired = vi.fn()
+    const states: string[] = []
+    startFakeAgent(process, ['s1'], {
+      onPrompt: async () => {
+        promptStarted.resolve()
+        await releasePrompt.promise
+      }
+    })
+    const runtime = new AcpRuntime({
+      appVersion: '0.1.0',
+      defaultCwd: '/workspace',
+      spawnAgent: () => asAgentProcess(process),
+      callbacks: {
+        onRetired,
+        onStateChanged: (snapshot) => states.push(snapshot.status)
+      }
+    })
+
+    await runtime.createSession({ cwd: '/workspace' })
+    const prompt = runtime.sendPrompt({ sessionId: 's1', text: 'hi' })
+    await promptStarted.promise
+    states.length = 0
+
+    await runtime.requestProviderReconnect()
+    await runtime.requestRetirement()
+    expect(process.killed).toBe(false)
+    expect(onRetired).not.toHaveBeenCalled()
+
+    releasePrompt.resolve()
+    await prompt
+    await vi.waitFor(() => expect(onRetired).toHaveBeenCalledOnce())
+
+    expect(process.killed).toBe(true)
+    expect(states).not.toContain('idle')
+  })
+
   it('does not retire while createSession is resolving its backend', async () => {
     const process = new FakeAgentProcess()
     const backendEntered = createDeferred()

--- a/src/main/acp/runtime.ts
+++ b/src/main/acp/runtime.ts
@@ -138,6 +138,7 @@ import {
   type AcpConnectionResourceAttempt,
   type AcpConnectionResourceReadyHandle
 } from './connection-resource-owner'
+import { AcpConnectionTransitionOwner } from './connection-transition-owner'
 
 export type AcpRuntimeCallbacks = {
   onStateChanged?: (state: AcpStateSnapshot) => void
@@ -512,6 +513,7 @@ class AcpRuntime {
   // context-bearing updates so a rejected prompt rolls back only when the provider saw no turn data.
   private readonly contextUsageUpdatedPromptTurnsBySession = new Map<string, number>()
   private readonly connectionResources: AcpConnectionResourceOwner
+  private readonly connectionTransitions: AcpConnectionTransitionOwner
   // Stable app identities, provider aliases, publication order, selection, and startup/delete
   // arbitration share one owner. The runtime retains only protocol/resource orchestration.
   private readonly sessionRegistry: AcpSessionRegistry
@@ -542,18 +544,6 @@ class AcpRuntime {
   private readonly handoffPromptRequests = new Map<string, AcpPromptRequest>()
   private readonly handoffUserTasks = new Map<string, HandoffUserTask[]>()
   private readonly pendingClaudeCodeHandoffAppends = new Map<string, string>()
-  // A provider change requested while a prompt was running, applied when the session next goes idle.
-  private pendingProviderReconnect = false
-  private pendingSkillsReload = false
-  // A coordinator-owned framework generation retires after its last active turn or background workflow.
-  // Unlike a provider reconnect, it must never spawn again: future work uses the coordinator's current
-  // runtime.
-  private pendingRetirement = false
-  // Barrier awaited by ensureConnected so a createSession called while a deferred reconnect is
-  // queued blocks until the reconnect completes rather than reusing the stale connection.
-  private reconnectBarrier: Promise<void> | undefined
-  private reconnectBarrierResolve: (() => void) | undefined
-  private reconnectBarrierGeneration = 0
   private readonly permissionContext: AcpPermissionContext
   private readonly callbacks: AcpRuntimeCallbacks
   private readonly spawnAgent: (() => ChildProcessWithoutNullStreams) | undefined
@@ -606,6 +596,18 @@ class AcpRuntime {
       closeMcpHost: async () => {
         await options.mcpHttpHost?.close()
       }
+    })
+    this.connectionTransitions = new AcpConnectionTransitionOwner({
+      blockers: () => ({
+        reconnect: this.hasBlockingActivity(),
+        retirement: this.hasRetirementBlockingActivity()
+      }),
+      connectionGeneration: () => this.connectionGeneration,
+      disconnect: (emitClosedStatus) => this.disconnect(emitClosedStatus),
+      onRetired: () => this.callbacks.onRetired?.(),
+      publishIdle: () => this.setStatus('idle'),
+      recoverFailedDeferredDisconnect: () => this.recoverFailedDeferredDisconnect(),
+      reportFailure: (message, error) => safeLogError(message, errorLogFields(error))
     })
     this.spawnAgent = options.spawnAgent
     this.skillsHooks = options.skills
@@ -715,7 +717,7 @@ class AcpRuntime {
         this.permissionContext.clearCorrelationsForSession(sessionId),
       currentStartupGeneration: () => this.sessionRegistry.startupGeneration,
       isPrimarySessionIdClaimed: (sessionId) => this.sessionRegistry.isIdentityClaimed(sessionId),
-      onActiveSessionReleased: () => this.maybeApplyPendingProviderReconnect(),
+      onActiveSessionReleased: () => this.connectionTransitions.activityChanged(),
       registerBridgeSession: (sessionId) =>
         this.connectionResources.registerBridgeReviewerSession(sessionId),
       removeStartupBlocker: (token) => this.pendingSessionStartupBlockers.delete(token),
@@ -726,6 +728,14 @@ class AcpRuntime {
 
   private get connection(): ClientConnection | undefined {
     return this.connectionResources.connection
+  }
+
+  private get pendingProviderReconnect(): boolean {
+    return this.connectionTransitions.providerReconnectPending
+  }
+
+  private get reconnectBarrier(): Promise<void> | undefined {
+    return this.connectionTransitions.barrier
   }
 
   private get connectionGeneration(): number {
@@ -2658,25 +2668,22 @@ class AcpRuntime {
 
   // Tears down every local session route and closes the underlying agent process.
   async disconnect(emitClosedStatus = true): Promise<AcpStateSnapshot> {
-    const teardownGeneration = this.connectionResources.supersede()
-    const reconnectBarrierGeneration = this.reconnectBarrierGeneration
-    this.invalidatePendingSessionStartups()
+    return this.connectionTransitions.settleTeardown(async () => {
+      const teardownGeneration = this.connectionResources.supersede()
+      this.invalidatePendingSessionStartups()
 
-    try {
-      return await this.disconnectCurrent(emitClosedStatus, teardownGeneration)
-    } catch (error) {
-      // disconnectCurrent transfers the resource with detach before physical teardown. If it failed
-      // earlier, the owner still holds a live published connection: restore only that exact teardown
-      // epoch so callers retain the pre-refactor recovery behavior. Once detached, rollback is a no-op.
-      this.connectionResources.restorePublished(teardownGeneration)
-      throw error
-    } finally {
       try {
-        await this.connectionResources.closeMcp(teardownGeneration)
+        return await this.disconnectCurrent(emitClosedStatus, teardownGeneration)
+      } catch (error) {
+        // disconnectCurrent transfers the resource with detach before physical teardown. If it failed
+        // earlier, the owner still holds a live published connection: restore only that exact teardown
+        // epoch so callers retain the pre-refactor recovery behavior. Once detached, rollback is a no-op.
+        this.connectionResources.restorePublished(teardownGeneration)
+        throw error
       } finally {
-        this.completePendingReconnectTeardown(reconnectBarrierGeneration)
+        await this.connectionResources.closeMcp(teardownGeneration)
       }
-    }
+    })
   }
 
   // Synchronously terminates the agent child for app shutdown. Electron's `will-quit` cannot await, so
@@ -2685,7 +2692,7 @@ class AcpRuntime {
   // reclaims the remaining connection/session state as the process exits.
   shutdown(): void {
     this.connectionResources.shutdownSynchronously(() => this.invalidatePendingSessionStartups())
-    this.completePendingReconnectTeardown()
+    this.connectionTransitions.resetReconnect()
     this.contextUsageTracker.clear()
     this.contextUsageUpdatedPromptTurnsBySession.clear()
     this.clearAppliedSessionModels()
@@ -2729,13 +2736,7 @@ class AcpRuntime {
   // Retires this framework generation without interrupting active turns or background workflows. The
   // coordinator stops routing new work here immediately; teardown waits for every prompt and lease.
   async requestRetirement(): Promise<void> {
-    this.pendingRetirement = true
-    if (this.hasRetirementBlockingActivity()) return
-
-    this.pendingRetirement = false
-    this.pendingProviderReconnect = false
-    this.pendingSkillsReload = false
-    await this.disconnectForRetirement()
+    await this.connectionTransitions.requestRetirement()
   }
 
   // Applies an active-provider change without interrupting the user. The agent bakes its provider env in
@@ -2753,109 +2754,23 @@ class AcpRuntime {
       this.emitState()
     }
 
-    if (this.hasBlockingActivity()) {
-      this.pendingProviderReconnect = true
-      // Arm the barrier so any concurrent createSession waits for the reconnect
-      // rather than reusing the stale connection with the old backend.
-      this.armReconnectBarrier()
-      return
-    }
-
-    this.pendingProviderReconnect = false
-    await this.disconnectForPlannedReconnect()
+    await this.connectionTransitions.requestProviderReconnect()
   }
 
-  // If a provider reconnect was deferred while a prompt ran, apply it once nothing is in flight.
-  private maybeApplyPendingProviderReconnect(): void {
-    if (this.pendingRetirement) {
-      if (this.hasRetirementBlockingActivity()) return
-
-      this.pendingRetirement = false
-      this.pendingProviderReconnect = false
-      this.pendingSkillsReload = false
-      void this.disconnectForRetirement()
-      return
-    }
-
-    if (this.hasBlockingActivity()) return
-
-    // A single reconnect satisfies both a pending provider switch and a pending skills reload: the
-    // fresh spawn picks up the new backend AND re-provisions the current skill set. So clear both
-    // flags before tearing down — leaving one set would fire a second, redundant disconnect on the
-    // next idle turn, needlessly killing the just-established connection.
-    if (this.pendingProviderReconnect || this.pendingSkillsReload) {
-      this.pendingProviderReconnect = false
-      this.pendingSkillsReload = false
-      // Resolve the barrier once teardown settles so ensureConnected falls through to a fresh
-      // connect with the new backend, not back onto the stale connection. disconnectForDeferredReconnect
-      // resolves the barrier even if disconnect() rejects — otherwise it strands and every later
-      // createSession hangs forever — and swallows the rejection so it never surfaces as unhandled.
-      void this.disconnectForDeferredReconnect()
-    }
-  }
-
-  // Tears down the connection for a deferred provider/skills reconnect, always releasing the
-  // reconnect barrier — even if the disconnect rejects — and never leaking an unhandled rejection.
-  private async disconnectForDeferredReconnect(): Promise<void> {
-    const reconnectBarrierGeneration = this.reconnectBarrierGeneration
-    try {
-      await this.disconnectForPlannedReconnect()
-    } catch (error) {
-      safeLogError('deferred reconnect disconnect failed', errorLogFields(error))
-      // disconnect() rejected — its synchronous teardown may have thrown before clearing the
-      // connection (e.g. session.dispose or connection.close). Force the connection invalid so the
-      // barrier-release below cannot let a blocked ensureConnected reuse the STALE connection on the
-      // old backend; the re-check there will fall through to a fresh connect(). Set status directly
-      // rather than via setStatus — the throw may have come from emitState itself.
-      const teardownGeneration = this.connectionResources.supersede()
-      void this.connectionResources.teardown(teardownGeneration, (stage, cleanupError) => {
-        safeLogError(`${stage} cleanup after failed deferred disconnect failed`, {
-          ...diagnosticErrorFields(cleanupError)
-        })
+  private recoverFailedDeferredDisconnect(): void {
+    // A failed Runtime teardown may still expose the stale connection. Supersede it before releasing
+    // the transition barrier so the next startup must resolve and connect a fresh backend.
+    const teardownGeneration = this.connectionResources.supersede()
+    void this.connectionResources.teardown(teardownGeneration, (stage, cleanupError) => {
+      safeLogError(`${stage} cleanup after failed deferred disconnect failed`, {
+        ...diagnosticErrorFields(cleanupError)
       })
-      this.snapshotOwner.transitionStatus('closed')
-      // Broadcast the closed status defensively so the renderer doesn't keep showing the prior
-      // 'connected' state when no createSession follows to re-emit it. Guarded because emitState may
-      // be the very thing that threw — the barrier release below must still run.
-      try {
-        this.emitState()
-      } catch (emitError) {
-        safeLogError('emitState after failed deferred disconnect failed', errorLogFields(emitError))
-      }
-    } finally {
-      // Tests and embedders may replace disconnect(), and a newer provider intent can arrive while
-      // this one is settling. Complete only the barrier generation this teardown was started for.
-      this.completePendingReconnectTeardown(reconnectBarrierGeneration)
-    }
-  }
-
-  // A provider/model change deliberately detaches the current native sessions so the next prompt can
-  // resume them on a freshly configured process. Publish `idle`, not `closed`: renderer treats a
-  // running-session transition to closed/error as an unexpected transport loss and offers Resume.
-  // The main-process turn can already be terminal while its renderer event is still queued, so even an
-  // otherwise idle reconnect must not expose that race as a false interruption.
-  private async disconnectForPlannedReconnect(): Promise<void> {
-    const disconnect = this.disconnect(false)
-    const teardownGeneration = this.connectionGeneration
-    await disconnect
-    if (teardownGeneration === this.connectionGeneration) this.setStatus('idle')
-  }
-
-  // Retirement is terminal for this runtime generation. Swallow teardown failures just like deferred
-  // reconnect cleanup so a late dispose error cannot become an unhandled rejection after a prompt ends.
-  private async disconnectForRetirement(): Promise<void> {
+    })
+    this.snapshotOwner.transitionStatus('closed')
     try {
-      // Retirement is an intentional handoff after all blocking activity has finished. Suppress the
-      // abnormal-drop status so the renderer does not mark the just-completed turn as interrupted.
-      await this.disconnect(false)
+      this.emitState()
     } catch (error) {
-      safeLogError('retired runtime disconnect failed', errorLogFields(error))
-    } finally {
-      try {
-        this.callbacks.onRetired?.()
-      } catch (error) {
-        safeLogError('retired runtime callback failed', errorLogFields(error))
-      }
+      safeLogError('emitState after failed deferred disconnect failed', errorLogFields(error))
     }
   }
 
@@ -2869,7 +2784,7 @@ class AcpRuntime {
       return await work(this)
     } finally {
       this.activityLeaseCount = Math.max(0, this.activityLeaseCount - 1)
-      this.maybeApplyPendingProviderReconnect()
+      this.connectionTransitions.activityChanged()
     }
   }
 
@@ -2879,7 +2794,7 @@ class AcpRuntime {
       return await work()
     } finally {
       this.operationLeaseCount = Math.max(0, this.operationLeaseCount - 1)
-      this.maybeApplyPendingProviderReconnect()
+      this.connectionTransitions.activityChanged()
     }
   }
 
@@ -2894,36 +2809,6 @@ class AcpRuntime {
 
   private hasRetirementBlockingActivity(): boolean {
     return this.operationLeaseCount > 0 || this.hasBlockingActivity()
-  }
-
-  // Creates the reconnect barrier promise if one is not already pending.
-  private armReconnectBarrier(): void {
-    this.reconnectBarrierGeneration += 1
-    if (!this.reconnectBarrier) {
-      this.reconnectBarrier = new Promise<void>((resolve) => {
-        this.reconnectBarrierResolve = resolve
-      })
-    }
-  }
-
-  // Resolves and clears the reconnect barrier, unblocking any ensureConnected callers.
-  private resolveReconnectBarrier(): void {
-    const resolve = this.reconnectBarrierResolve
-    this.reconnectBarrier = undefined
-    this.reconnectBarrierResolve = undefined
-    resolve?.()
-  }
-
-  private completePendingReconnectTeardown(expectedBarrierGeneration?: number): void {
-    if (
-      expectedBarrierGeneration !== undefined &&
-      expectedBarrierGeneration !== this.reconnectBarrierGeneration
-    ) {
-      return
-    }
-    this.pendingProviderReconnect = false
-    this.pendingSkillsReload = false
-    this.resolveReconnectBarrier()
   }
 
   private async disconnectCurrent(
@@ -3720,8 +3605,7 @@ class AcpRuntime {
         }
       }
       // emitState invokes the renderer onStateChanged callback; guard it so a throw there cannot skip
-      // the reconnect below. maybeApplyPendingProviderReconnect is what resolves an armed reconnect
-      // barrier, so skipping it would strand the barrier and hang every later createSession.
+      // transition arbitration and strand a barrier awaited by a later createSession.
       try {
         this.emitState()
       } catch (error) {
@@ -3732,10 +3616,11 @@ class AcpRuntime {
       // must happen before the reconnect is applied so the fresh spawn no longer sees the forced ids.
       if (didForceReload) {
         this.turnForcedSkillIds.clear()
-        this.pendingSkillsReload = true
+        this.connectionTransitions.requestSkillsReload()
+      } else {
+        // A provider switch requested mid-turn is applied now that the session is idle.
+        this.connectionTransitions.activityChanged()
       }
-      // A provider switch requested mid-turn is applied now that the session is idle.
-      this.maybeApplyPendingProviderReconnect()
     }
   }
 
@@ -4829,7 +4714,7 @@ class AcpRuntime {
     // the reconnect barrier must unblock now — it will fall through to connect()
     // and pick up the new backend from resolveBackend. A fresh spawn re-provisions
     // skills too, so clear both pending flags to avoid a spurious later reconnect.
-    this.completePendingReconnectTeardown()
+    this.connectionTransitions.resetReconnect()
     void this.connectionResources.closeMcp(teardownGeneration)
     try {
       this.setStatus('closed')
@@ -4852,7 +4737,7 @@ class AcpRuntime {
       }
       // An unexpected close satisfies any pending reconnect, but retirement remains terminal. Re-run
       // its evaluator now and again when outstanding operation/activity leases drain.
-      this.maybeApplyPendingProviderReconnect()
+      this.connectionTransitions.activityChanged()
     }
   }
 


### PR DESCRIPTION
## Problem

ACP Runtime still owns provider-change, skills-reload, retirement, and reconnect-barrier arbitration directly. These correlated intents span asynchronous Prompt, Reviewer, startup, and background leases, making their single-winner and stale-generation behavior difficult to see and protect.

Related issue: #458 remains forward compatibility only. This pull request adds no orchestration state, persistence, API, event, or user interaction.

## Proposed change

Extract an `AcpConnectionTransitionOwner` behind the existing Runtime façade.

```mermaid
flowchart LR
  P["provider intent"] --> O["ConnectionTransitionOwner"]
  S["skills intent"] --> O
  R["retirement intent"] --> O
  B["Runtime blocker snapshot"] --> O
  O --> D["planned disconnect"]
  O --> G["generation-fenced barrier"]
  D --> C["ConnectionResourceOwner"]
```

The owner coalesces provider and skills intents into one reconnect, gives retirement priority, and releases only the matching reconnect-barrier generation. Runtime retains Prompt, Reviewer, startup, activity/operation lease, identity, and physical resource ownership.

## Scope and non-goals

- Preserve deferred provider reconnect and skills reload timing.
- Preserve retirement-after-last-blocker behavior and exactly-once retirement callback.
- Preserve stale teardown fencing, failed-disconnect recovery, and planned `idle` publication.
- Preserve stable application Session IDs, replaceable Provider protocol IDs, Codex non-UUID adoption, `contextReset`, transcript replay, and cleanup semantics.
- Preserve Specialist, Permission, and Compute behavior and current capability asymmetry.
- Preserve Electron, local Web, remote Web, CLI, Task, local RPC, and IPC behavior.
- No public/shared contract, persistence/data relationship, UI, transport, or issue #458 orchestration change.

## Acceptance criteria and validation

All checks ran against final head `4bbec6e` after the clean rebase to `c618c60`.

- Provider/skills coalescing, retirement priority, blockers, stale barrier generations, failure recovery, and idle publication -> focused ACP owner/resource/runtime/coordinator/activity suite -> 452/452 passed.
- Node and Web compile compatibility -> `npm run typecheck` -> passed.
- Repository lint -> `npm run lint` -> passed with 0 errors and 18 existing warnings.
- Repository regression suite -> `npm test -- --run` -> passed.
- Independent review -> Spec: 0 findings; Standards: 0 Hard / 1 accepted judgement.

Uncovered risk: real-provider manual switching on every surface is not automated here. FakeAgent lifecycle tests and the full suite cover this slice; A9.5 remains the dedicated five-surface certification.

## Review focus

- Confirm retirement wins over pending reconnect intents without publishing `idle`.
- Confirm a stale teardown cannot release a newer barrier generation.
- Confirm failed deferred disconnect cannot expose the stale backend or strand startup.
- Confirm no Session/Provider identity, cross-surface, or issue #458 contract moved into this owner.
