### PR TITLE
feat(global-search): add project-scoped command palette

### DIFF
--- a/src/main/project-files/ipc.test.ts
+++ b/src/main/project-files/ipc.test.ts
@@ -33,10 +33,16 @@ describe('project files IPC handlers', () => {
     }
     const filePage = { items: [], totalCount: 1 }
     const groupPage = { items: [], totalCount: 1 }
+    const artifactSearch = {
+      primary: { items: [], totalCount: 0 },
+      other: [],
+      isIndexComplete: true
+    }
     const repository = {
       getOverview: vi.fn().mockResolvedValue(overview),
       listFiles: vi.fn().mockResolvedValue(filePage),
-      listArtifactGroups: vi.fn().mockResolvedValue(groupPage)
+      listArtifactGroups: vi.fn().mockResolvedValue(groupPage),
+      searchArtifacts: vi.fn().mockResolvedValue(artifactSearch)
     }
     const handlers = createProjectFilesHandlers(
       repository,
@@ -53,6 +59,13 @@ describe('project files IPC handlers', () => {
       limit: 24
     }
     const groupsRequest = { projectId: 'project-1', limit: 10 }
+    const artifactSearchRequest = {
+      primaryProjectId: 'project-1',
+      otherProjectIds: ['project-2'],
+      filenameContains: 'sin',
+      primaryLimit: 8,
+      otherLimit: 1 as const
+    }
 
     const overviewRequest = {
       projectId: 'project-1',
@@ -61,16 +74,19 @@ describe('project files IPC handlers', () => {
     await expect(handlers.getOverview(overviewRequest)).resolves.toBe(overview)
     await expect(handlers.listFiles(filesRequest)).resolves.toBe(filePage)
     await expect(handlers.listArtifactGroups(groupsRequest)).resolves.toBe(groupPage)
+    await expect(handlers.searchArtifacts(artifactSearchRequest)).resolves.toBe(artifactSearch)
     expect(repository.listFiles).toHaveBeenCalledWith(filesRequest)
     expect(repository.listArtifactGroups).toHaveBeenCalledWith(groupsRequest)
     expect(repository.getOverview).toHaveBeenCalledWith(overviewRequest)
+    expect(repository.searchArtifacts).toHaveBeenCalledWith(artifactSearchRequest)
   })
 
   it('routes an explicit index repair through the session coordinator', async () => {
     const repository = {
       getOverview: vi.fn(),
       listFiles: vi.fn(),
-      listArtifactGroups: vi.fn()
+      listArtifactGroups: vi.fn(),
+      searchArtifacts: vi.fn()
     }
     const repair = { repairProjectFiles: vi.fn().mockResolvedValue(undefined) }
     const handlers = createProjectFilesHandlers(repository, repair, {
@@ -102,6 +118,10 @@ describe('project files IPC handlers', () => {
       listArtifactGroups: vi.fn(async () => {
         order.push('groups')
         return { items: [], totalCount: 0 }
+      }),
+      searchArtifacts: vi.fn(async () => {
+        order.push('search')
+        return { primary: { items: [], totalCount: 0 }, other: [], isIndexComplete: true }
       })
     }
     const repair = {
@@ -123,6 +143,12 @@ describe('project files IPC handlers', () => {
       limit: 20
     })
     await handlers.listArtifactGroups({ projectId: 'project-1', limit: 10 })
+    await handlers.searchArtifacts({
+      primaryProjectId: 'project-1',
+      otherProjectIds: [],
+      primaryLimit: 8,
+      otherLimit: 0
+    })
     await handlers.repairIndex({ projectId: 'project-1' })
 
     expect(order).toEqual([
@@ -132,6 +158,8 @@ describe('project files IPC handlers', () => {
       'files',
       'recover',
       'groups',
+      'recover',
+      'search',
       'recover',
       'repair'
     ])
@@ -154,7 +182,12 @@ describe('registerProjectFilesIpcHandlers', () => {
         isIndexComplete: true
       }),
       listFiles: vi.fn().mockResolvedValue({ items: [], totalCount: 0 }),
-      listArtifactGroups: vi.fn().mockResolvedValue({ items: [], totalCount: 0 })
+      listArtifactGroups: vi.fn().mockResolvedValue({ items: [], totalCount: 0 }),
+      searchArtifacts: vi.fn().mockResolvedValue({
+        primary: { items: [], totalCount: 0 },
+        other: [],
+        isIndexComplete: true
+      })
     }
     repairBackend = { repairProjectFiles: vi.fn().mockResolvedValue(undefined) }
     recoveryBackend = { recoverPendingDeletions: vi.fn().mockResolvedValue(undefined) }
@@ -166,6 +199,7 @@ describe('registerProjectFilesIpcHandlers', () => {
     expect(handlers.has('project-files:get-overview')).toBe(true)
     expect(handlers.has('project-files:list-files')).toBe(true)
     expect(handlers.has('project-files:list-artifact-groups')).toBe(true)
+    expect(handlers.has('project-files:search-artifacts')).toBe(true)
     expect(handlers.has('project-files:repair-index')).toBe(true)
   })
 
@@ -183,7 +217,8 @@ describe('registerProjectFilesIpcHandlers', () => {
         }
       }),
       listFiles: vi.fn(),
-      listArtifactGroups: vi.fn()
+      listArtifactGroups: vi.fn(),
+      searchArtifacts: vi.fn()
     }
     const localRepair: ProjectFilesRepairBackend = {
       repairProjectFiles: vi.fn()
@@ -209,7 +244,8 @@ describe('registerProjectFilesIpcHandlers', () => {
         order.push('files')
         return { items: [], totalCount: 0 }
       }),
-      listArtifactGroups: vi.fn()
+      listArtifactGroups: vi.fn(),
+      searchArtifacts: vi.fn()
     }
     const localRepair: ProjectFilesRepairBackend = {
       repairProjectFiles: vi.fn()
@@ -240,7 +276,8 @@ describe('registerProjectFilesIpcHandlers', () => {
       listArtifactGroups: vi.fn(async () => {
         order.push('groups')
         return { items: [], totalCount: 0 }
-      })
+      }),
+      searchArtifacts: vi.fn()
     }
     const localRepair: ProjectFilesRepairBackend = {
       repairProjectFiles: vi.fn()
@@ -264,7 +301,8 @@ describe('registerProjectFilesIpcHandlers', () => {
     const localRepository: ProjectFilesQueryRepository = {
       getOverview: vi.fn(),
       listFiles: vi.fn(),
-      listArtifactGroups: vi.fn()
+      listArtifactGroups: vi.fn(),
+      searchArtifacts: vi.fn()
     }
     const localRepair: ProjectFilesRepairBackend = {
       repairProjectFiles: vi.fn(async () => {

--- a/src/main/project-files/ipc.ts
+++ b/src/main/project-files/ipc.ts
@@ -6,13 +6,16 @@ import type {
   ListArtifactGroupsRequest,
   ListProjectFilesRequest,
   ProjectFilesOverview,
-  ProjectFilesPage
+  ProjectFilesPage,
+  SearchArtifactsRequest,
+  SearchArtifactsResult
 } from '../../shared/project-files'
 
 type ProjectFilesQueryRepository = {
   getOverview(request: GetProjectFilesOverviewRequest): Promise<ProjectFilesOverview>
   listFiles(request: ListProjectFilesRequest): Promise<ProjectFilesPage>
   listArtifactGroups(request: ListArtifactGroupsRequest): Promise<ArtifactGroupPage>
+  searchArtifacts(request: SearchArtifactsRequest): Promise<SearchArtifactsResult>
 }
 
 type ProjectFilesRepairBackend = {
@@ -27,6 +30,7 @@ type ProjectFilesHandlers = {
   getOverview(request: GetProjectFilesOverviewRequest): Promise<ProjectFilesOverview>
   listFiles(request: ListProjectFilesRequest): Promise<ProjectFilesPage>
   listArtifactGroups(request: ListArtifactGroupsRequest): Promise<ArtifactGroupPage>
+  searchArtifacts(request: SearchArtifactsRequest): Promise<SearchArtifactsResult>
   repairIndex(request: { projectId: string }): Promise<void>
 }
 
@@ -48,6 +52,10 @@ const createProjectFilesHandlers = (
   listArtifactGroups: async (request) => {
     await recoveryBackend.recoverPendingDeletions()
     return repository.listArtifactGroups(request)
+  },
+  searchArtifacts: async (request) => {
+    await recoveryBackend.recoverPendingDeletions()
+    return repository.searchArtifacts(request)
   },
   repairIndex: async ({ projectId }) => {
     await recoveryBackend.recoverPendingDeletions()
@@ -73,6 +81,9 @@ const registerProjectFilesIpcHandlers = (
   ipcMainHandle(
     'project-files:list-artifact-groups',
     (_event, request: ListArtifactGroupsRequest) => handlers.listArtifactGroups(request)
+  )
+  ipcMainHandle('project-files:search-artifacts', (_event, request: SearchArtifactsRequest) =>
+    handlers.searchArtifacts(request)
   )
   ipcMainHandle('project-files:repair-index', (_event, request: { projectId: string }) =>
     handlers.repairIndex(request)

--- a/src/main/project-files/repository.test.ts
+++ b/src/main/project-files/repository.test.ts
@@ -305,6 +305,25 @@ describe('ManagedFileIndexRepository', () => {
         }
       ]
     })
+    await expect(
+      repository.searchArtifacts({
+        primaryProjectId: PROJECT_ID,
+        otherProjectIds: [],
+        filenameContains: 'sin.png',
+        primaryLimit: 8,
+        otherLimit: 0
+      })
+    ).resolves.toMatchObject({
+      primary: {
+        items: [
+          {
+            sourceFileId: lineageId,
+            sourceVersionId: versionTwoId,
+            sortAtMs: new Date('2026-07-28T00:00:02.000Z').getTime()
+          }
+        ]
+      }
+    })
   })
 
   it('exposes immutable uploads as project-and-session-scoped Version references', async () => {

--- a/src/main/project-files/repository.test.ts
+++ b/src/main/project-files/repository.test.ts
@@ -1670,6 +1670,132 @@ describe('ManagedFileIndexRepository', () => {
     ).rejects.toThrow(/cursor.*search/i)
   })
 
+  it('searches generated artifacts with a primary cursor and one combined other-project result', async () => {
+    const primaryFiles = [
+      ['sin-old', 'sin-old.png', 100],
+      ['sin-new', 'sin-new.png', 300],
+      ['sin-mid', 'sin-mid.csv', 200]
+    ] as const
+    const otherPath = join(
+      storageRoot,
+      'artifacts',
+      'project-b',
+      'session-b',
+      'message-1',
+      'sin-other.png'
+    )
+    const uploadPath = join(storageRoot, 'uploads', 'default-project', SESSION_ID, 'sin-input.csv')
+
+    await Promise.all([
+      ...primaryFiles.map(([id, name]) =>
+        writeManagedFile(
+          join(
+            storageRoot,
+            'artifacts',
+            'default-project',
+            SESSION_ID,
+            'message-1',
+            `${id}-${name}`
+          ),
+          id
+        )
+      ),
+      writeManagedFile(otherPath, 'other'),
+      writeManagedFile(uploadPath, 'upload')
+    ])
+    await repository.syncSession(
+      createSession({
+        messages: [
+          {
+            id: 'message-user',
+            role: 'user',
+            content: 'Analyze',
+            status: 'complete',
+            eventIds: [],
+            uploads: [
+              {
+                id: 'sin-upload',
+                sessionId: SESSION_ID,
+                name: 'sin-input.csv',
+                originalName: 'sin-input.csv',
+                path: uploadPath,
+                size: 6
+              }
+            ],
+            createdAt: 50,
+            updatedAt: 50
+          }
+        ],
+        artifacts: primaryFiles.map(([id, name, mtimeMs]) => ({
+          id,
+          kind: 'managed-file' as const,
+          path: join(
+            storageRoot,
+            'artifacts',
+            'default-project',
+            SESSION_ID,
+            'message-1',
+            `${id}-${name}`
+          ),
+          name,
+          mtimeMs
+        }))
+      })
+    )
+    await repository.syncSession(
+      createSession({
+        id: 'session-b',
+        projectId: 'project-b',
+        artifacts: [
+          {
+            id: 'sin-other',
+            kind: 'managed-file',
+            path: otherPath,
+            name: 'sin-other.png',
+            mtimeMs: 400
+          }
+        ]
+      })
+    )
+
+    const first = await repository.searchArtifacts({
+      primaryProjectId: PROJECT_ID,
+      otherProjectIds: ['project-b'],
+      filenameContains: 'SIN',
+      primaryLimit: 2,
+      otherLimit: 1
+    })
+
+    expect(first.primary).toMatchObject({
+      totalCount: 3,
+      items: [
+        expect.objectContaining({ name: 'sin-new.png', source: 'artifact' }),
+        expect.objectContaining({ name: 'sin-mid.csv', source: 'artifact' })
+      ]
+    })
+    expect(first.primary.nextCursor).toBeDefined()
+    expect(first.other).toEqual([expect.objectContaining({ name: 'sin-other.png' })])
+    expect(first.isIndexComplete).toBe(true)
+
+    await expect(
+      repository.searchArtifacts({
+        primaryProjectId: PROJECT_ID,
+        otherProjectIds: ['project-b'],
+        filenameContains: 'sin',
+        primaryLimit: 2,
+        primaryCursor: first.primary.nextCursor,
+        otherLimit: 0
+      })
+    ).resolves.toMatchObject({
+      primary: {
+        totalCount: 3,
+        items: [expect.objectContaining({ name: 'sin-old.png' })],
+        nextCursor: undefined
+      },
+      other: []
+    })
+  })
+
   it('indexes readable files while retrying an unreadable file from the same session', async () => {
     const uploadPath = join(storageRoot, 'uploads', 'default-project', SESSION_ID, 'input.csv')
     const missingArtifactPath = join(

--- a/src/main/project-files/repository.ts
+++ b/src/main/project-files/repository.ts
@@ -13,7 +13,9 @@ import type {
   ProjectFilesOverview,
   ProjectFilesPage,
   ProjectFileSource,
-  ProjectFileOriginSession
+  ProjectFileOriginSession,
+  SearchArtifactsRequest,
+  SearchArtifactsResult
 } from '../../shared/project-files'
 import { createArtifactVersionLocator } from '../../shared/artifact-provenance'
 import type { PersistedChatSession } from '../../shared/session-persistence'
@@ -82,6 +84,15 @@ type GroupCursor = {
   queryKey: string
   groupSortAtMs: string
   sessionId: string
+}
+
+type SearchArtifactCursor = {
+  version: 2
+  kind: 'globalArtifacts'
+  primaryProjectId: string
+  queryKey: string
+  sortAtMs: string
+  seq: number
 }
 
 type NormalizedSearch = {
@@ -735,6 +746,87 @@ class ManagedFileIndexRepository {
     }
   }
 
+  // Global search keeps its cross-project scope deliberately bounded: the primary project is
+  // independently paged while every other project shares a single latest-artifact sample.
+  async searchArtifacts(request: SearchArtifactsRequest): Promise<SearchArtifactsResult> {
+    requireIdentifier(request.primaryProjectId, 'primaryProjectId')
+    if (!Array.isArray(request.otherProjectIds)) {
+      throw new Error('Project files otherProjectIds must be an array.')
+    }
+    const otherProjectIds = [...new Set(request.otherProjectIds)]
+      .filter((projectId) => projectId !== request.primaryProjectId)
+      .map((projectId) => {
+        requireIdentifier(projectId, 'otherProjectId')
+        return projectId
+      })
+    if (request.otherLimit !== 0 && request.otherLimit !== 1) {
+      throw new Error('Project files otherLimit must be 0 or 1.')
+    }
+
+    const primaryLimit = normalizeLimit(request.primaryLimit)
+    const search =
+      request.filenameContains === undefined
+        ? undefined
+        : normalizeSearch({ filenameContains: request.filenameContains })
+    const cursor = request.primaryCursor
+      ? decodeSearchArtifactCursor(request.primaryCursor, request.primaryProjectId, search)
+      : undefined
+    const client = await this.getClient()
+    const [primaryRows, primaryTotalCount, otherRows] = await Promise.all([
+      listMatchingArtifacts(client, request.primaryProjectId, search, cursor, primaryLimit),
+      countMatchingArtifacts(client, request.primaryProjectId, search),
+      request.otherLimit === 1 && otherProjectIds.length > 0
+        ? listOtherProjectArtifacts(client, otherProjectIds, search)
+        : Promise.resolve([])
+    ])
+    const primaryPageRows = primaryRows.slice(0, primaryLimit)
+    const lastPrimaryRow = primaryPageRows.at(-1)
+    const rows = [...primaryPageRows, ...otherRows]
+    const origins =
+      rows.length === 0
+        ? []
+        : await client.fileOriginSession.findMany({
+            where: {
+              OR: [
+                ...new Map(rows.map((row) => [`${row.projectId}:${row.sessionId}`, row])).values()
+              ].map((row) => ({ projectId: row.projectId, sessionId: row.sessionId }))
+            }
+          })
+    const originsBySession = new Map(
+      origins.map((origin) => [`${origin.projectId}:${origin.sessionId}`, origin])
+    )
+    const toItem = (row: ManagedFile): ProjectFileItem =>
+      toProjectFileItem(
+        row,
+        this.dataRoot,
+        originsBySession.get(`${row.projectId}:${row.sessionId}`)
+      )
+
+    return {
+      primary: {
+        items: primaryPageRows.map(toItem),
+        totalCount: primaryTotalCount,
+        nextCursor:
+          primaryRows.length > primaryLimit && lastPrimaryRow
+            ? encodeCursor({
+                version: 2,
+                kind: 'globalArtifacts',
+                primaryProjectId: request.primaryProjectId,
+                queryKey: search?.queryKey ?? '',
+                sortAtMs: lastPrimaryRow.sortAtMs.toString(),
+                seq: lastPrimaryRow.seq
+              })
+            : undefined
+      },
+      other: otherRows.map(toItem),
+      isIndexComplete: [request.primaryProjectId, ...otherProjectIds].every(
+        (projectId) =>
+          !this.isReconciliationIncomplete &&
+          ![...this.incompleteSessions.keys()].some((key) => key.startsWith(`${projectId}:`))
+      )
+    }
+  }
+
   // Pages session headers independently from files. groupSortAtMs is changed only by artifact
   // mutations, while sessionId provides deterministic ordering when timestamps collide.
   async listArtifactGroups(request: ListArtifactGroupsRequest): Promise<ArtifactGroupPage> {
@@ -1274,6 +1366,83 @@ const countMatchingFiles = async (
   return toSafeCount(rows[0]?.count ?? 0n, 'search result count')
 }
 
+// The global-search projection is intentionally Artifact-only. Keep its predicate and keyset local
+// instead of widening listFiles' collections, whose cursor contract serves the Files surface.
+const listMatchingArtifacts = async (
+  client: ProjectFilesClient,
+  projectId: string,
+  search: NormalizedSearch | undefined,
+  cursor: SearchArtifactCursor | undefined,
+  limit: number
+): Promise<ManagedFile[]> => {
+  const filenamePredicate = search
+    ? Prisma.sql`AND ${filenameContainsPredicate(Prisma.sql`"displayName"`, search)}`
+    : Prisma.empty
+  const cursorPredicate = cursor
+    ? Prisma.sql`AND ("sortAtMs" < ${BigInt(cursor.sortAtMs)} OR ("sortAtMs" = ${BigInt(cursor.sortAtMs)} AND "seq" < ${cursor.seq}))`
+    : Prisma.empty
+
+  return client.$queryRaw<ManagedFile[]>(Prisma.sql`
+    SELECT
+      "seq", "source", "sourceFileId", "sourceVersionId", "checksum",
+      "projectId", "sessionId", "messageId",
+      "displayName", "storageKey", "mimeType", "sizeBytes", "mtimeMs", "sortAtMs",
+      "createdAt", "updatedAt", "deletedAt", "deleteOperationId"
+    FROM "ManagedFile"
+    WHERE "projectId" = ${projectId}
+      AND "source" = 'artifact'
+      AND "deletedAt" IS NULL
+      ${filenamePredicate}
+      ${cursorPredicate}
+    ORDER BY "sortAtMs" DESC, "seq" DESC
+    LIMIT ${limit + 1}
+  `)
+}
+
+const countMatchingArtifacts = async (
+  client: ProjectFilesClient,
+  projectId: string,
+  search: NormalizedSearch | undefined
+): Promise<number> => {
+  const filenamePredicate = search
+    ? Prisma.sql`AND ${filenameContainsPredicate(Prisma.sql`"displayName"`, search)}`
+    : Prisma.empty
+  const rows = await client.$queryRaw<Array<{ count: bigint }>>(Prisma.sql`
+    SELECT COUNT(*) AS "count"
+    FROM "ManagedFile"
+    WHERE "projectId" = ${projectId}
+      AND "source" = 'artifact'
+      AND "deletedAt" IS NULL
+      ${filenamePredicate}
+  `)
+  return toSafeCount(rows[0]?.count ?? 0n, 'artifact search result count')
+}
+
+const listOtherProjectArtifacts = async (
+  client: ProjectFilesClient,
+  projectIds: string[],
+  search: NormalizedSearch | undefined
+): Promise<ManagedFile[]> => {
+  const filenamePredicate = search
+    ? Prisma.sql`AND ${filenameContainsPredicate(Prisma.sql`"displayName"`, search)}`
+    : Prisma.empty
+
+  return client.$queryRaw<ManagedFile[]>(Prisma.sql`
+    SELECT
+      "seq", "source", "sourceFileId", "sourceVersionId", "checksum",
+      "projectId", "sessionId", "messageId",
+      "displayName", "storageKey", "mimeType", "sizeBytes", "mtimeMs", "sortAtMs",
+      "createdAt", "updatedAt", "deletedAt", "deleteOperationId"
+    FROM "ManagedFile"
+    WHERE "projectId" IN (${Prisma.join(projectIds)})
+      AND "source" = 'artifact'
+      AND "deletedAt" IS NULL
+      ${filenamePredicate}
+    ORDER BY "sortAtMs" DESC, "seq" DESC
+    LIMIT 1
+  `)
+}
+
 // Counts only session groups that still own at least one active artifact matching the search.
 const countMatchingArtifactGroups = async (
   client: ProjectFilesClient,
@@ -1416,7 +1585,7 @@ const describeError = (error: unknown): string =>
 
 // Cursors are opaque transport tokens, not security credentials; decoders below provide the required
 // collection and shape validation before any value reaches Prisma.
-const encodeCursor = (cursor: FileCursor | GroupCursor): string =>
+const encodeCursor = (cursor: FileCursor | GroupCursor | SearchArtifactCursor): string =>
   Buffer.from(JSON.stringify(cursor), 'utf8').toString('base64url')
 
 const parseCursor = (cursor: string): unknown => {
@@ -1477,6 +1646,34 @@ const decodeGroupCursor = (cursor: string, request: ListArtifactGroupsRequest): 
   }
 
   return value as GroupCursor
+}
+
+const decodeSearchArtifactCursor = (
+  cursor: string,
+  primaryProjectId: string,
+  search: NormalizedSearch | undefined
+): SearchArtifactCursor => {
+  const value = parseCursor(cursor)
+  const expectedQueryKey = search?.queryKey ?? ''
+
+  if (
+    !isRecord(value) ||
+    value.version !== 2 ||
+    value.kind !== 'globalArtifacts' ||
+    value.primaryProjectId !== primaryProjectId ||
+    typeof value.queryKey !== 'string' ||
+    typeof value.sortAtMs !== 'string' ||
+    !/^-?\d+$/.test(value.sortAtMs) ||
+    typeof value.seq !== 'number' ||
+    !Number.isInteger(value.seq)
+  ) {
+    throw new Error('Project files cursor does not match the global artifact search.')
+  }
+  if (value.queryKey !== expectedQueryKey) {
+    throw new Error('Project files cursor does not match the requested search.')
+  }
+
+  return value as SearchArtifactCursor
 }
 
 const isRecord = (value: unknown): value is Record<string, unknown> =>

--- a/src/preload/index.d.ts
+++ b/src/preload/index.d.ts
@@ -135,7 +135,9 @@ import type {
   ListProjectFilesRequest,
   ProjectFilesChangedEvent,
   ProjectFilesOverview,
-  ProjectFilesPage
+  ProjectFilesPage,
+  SearchArtifactsRequest,
+  SearchArtifactsResult
 } from '../shared/project-files'
 import type {
   DeleteSessionRequest,
@@ -492,6 +494,7 @@ interface OpenScienceAPI {
     getOverview(request: GetProjectFilesOverviewRequest): Promise<ProjectFilesOverview>
     listFiles(request: ListProjectFilesRequest): Promise<ProjectFilesPage>
     listArtifactGroups(request: ListArtifactGroupsRequest): Promise<ArtifactGroupPage>
+    searchArtifacts(request: SearchArtifactsRequest): Promise<SearchArtifactsResult>
     repairIndex(request: { projectId: string }): Promise<void>
     onChanged(listener: AcpListener<ProjectFilesChangedEvent>): RemoveListener
   }

--- a/src/preload/index.test.ts
+++ b/src/preload/index.test.ts
@@ -252,6 +252,7 @@ describe('preload bridge — public surface inventory', () => {
       'projectFiles.listFiles',
       'projectFiles.onChanged',
       'projectFiles.repairIndex',
+      'projectFiles.searchArtifacts',
       'projects.create',
       'projects.delete',
       'projects.get',

--- a/src/preload/index.ts
+++ b/src/preload/index.ts
@@ -138,7 +138,9 @@ import type {
   ListProjectFilesRequest,
   ProjectFilesChangedEvent,
   ProjectFilesOverview,
-  ProjectFilesPage
+  ProjectFilesPage,
+  SearchArtifactsRequest,
+  SearchArtifactsResult
 } from '../shared/project-files'
 import type {
   DeleteSessionRequest,
@@ -544,6 +546,7 @@ type OpenScienceAPI = {
     getOverview: (request: GetProjectFilesOverviewRequest) => Promise<ProjectFilesOverview>
     listFiles: (request: ListProjectFilesRequest) => Promise<ProjectFilesPage>
     listArtifactGroups: (request: ListArtifactGroupsRequest) => Promise<ArtifactGroupPage>
+    searchArtifacts: (request: SearchArtifactsRequest) => Promise<SearchArtifactsResult>
     repairIndex: (request: { projectId: string }) => Promise<void>
     onChanged: (listener: AcpListener<ProjectFilesChangedEvent>) => RemoveListener
   }
@@ -1187,6 +1190,11 @@ const api: OpenScienceAPI = {
         'project-files:list-artifact-groups',
         request
       ) as Promise<ArtifactGroupPage>,
+    searchArtifacts: (request) =>
+      ipcRenderer.invoke(
+        'project-files:search-artifacts',
+        request
+      ) as Promise<SearchArtifactsResult>,
     repairIndex: (request) =>
       ipcRenderer.invoke('project-files:repair-index', request) as Promise<void>,
     onChanged: (listener) => onIpcMessage('project-files:changed', listener)

--- a/src/renderer/src/App.test.tsx
+++ b/src/renderer/src/App.test.tsx
@@ -34,6 +34,7 @@ const mocks = vi.hoisted(() => {
       init: vi.fn().mockResolvedValue(undefined),
       retry: vi.fn().mockResolvedValue(undefined)
     },
+    preview: { fileDialogItem: undefined as unknown | undefined },
     loadProjects: vi.fn().mockResolvedValue(undefined),
     deepLinkNavigation: vi.fn(),
     lifecycleSync: vi.fn(() => ({
@@ -69,7 +70,8 @@ const mocks = vi.hoisted(() => {
     startupView: 'app' as 'app' | 'onboarding',
     getInfo: vi.fn(),
     syncWindowFindAppearance: vi.fn(),
-    syncUnreadTaskView: vi.fn()
+    syncUnreadTaskView: vi.fn(),
+    globalSearch: { props: undefined as { open: boolean } | undefined }
   }
 })
 
@@ -90,6 +92,12 @@ vi.mock('@/hooks/useWindowFindAppearanceSync', () => ({
 }))
 vi.mock('@/hooks/useUnreadTaskViewSync', () => ({
   useUnreadTaskViewSync: mocks.syncUnreadTaskView
+}))
+vi.mock('@/components/global-search/GlobalSearchDialog', () => ({
+  GlobalSearchDialog: (props: { open: boolean }) => {
+    mocks.globalSearch.props = props
+    return null
+  }
 }))
 vi.mock('@/stores/navigation-store', () => ({
   useNavigationStore: Object.assign(
@@ -112,6 +120,10 @@ vi.mock('@/stores/session-store', () => ({
 vi.mock('@/stores/notebook-env-store', () => ({
   useNotebookEnvStore: <T,>(selector: (state: typeof mocks.environment) => T): T =>
     selector(mocks.environment)
+}))
+vi.mock('@/stores/preview-workbench-store', () => ({
+  usePreviewWorkbenchStore: <T,>(selector: (state: typeof mocks.preview) => T): T =>
+    selector(mocks.preview)
 }))
 vi.mock('@/stores/compute-store', () => ({
   useComputeStore: <T,>(selector: (state: typeof mocks.compute) => T): T => selector(mocks.compute)
@@ -258,6 +270,7 @@ describe('App startup routing', () => {
     mocks.settings.pendingApprovals = []
     mocks.compute.pendingApprovals = []
     mocks.skillImport.pending = []
+    mocks.preview.fileDialogItem = undefined
     mocks.deepLinkNavigation.mockClear()
     mocks.lifecycleSync.mockClear()
     mocks.syncWindowFindAppearance.mockClear()
@@ -293,6 +306,7 @@ describe('App startup routing', () => {
     mocks.notifications.peekPendingOpenSession.mockReset().mockResolvedValue(null)
     mocks.notifications.takePendingOpenSession.mockReset().mockResolvedValue(null)
     mocks.notificationNudgeBox.current = undefined
+    mocks.globalSearch.props = undefined
   })
 
   afterEach(async () => {
@@ -304,6 +318,40 @@ describe('App startup routing', () => {
     root = createRoot(container)
     await act(async () => root.render(<App />))
   }
+
+  it('toggles global search with Cmd/Ctrl+K after startup is interactive', async () => {
+    mocks.settings.isLoaded = true
+    await render()
+
+    expect(mocks.globalSearch.props?.open).toBe(false)
+    await act(async () => {
+      window.dispatchEvent(
+        new KeyboardEvent('keydown', { key: 'k', metaKey: true, cancelable: true })
+      )
+    })
+    expect(mocks.globalSearch.props?.open).toBe(true)
+
+    await act(async () => {
+      window.dispatchEvent(
+        new KeyboardEvent('keydown', { key: 'k', ctrlKey: true, cancelable: true })
+      )
+    })
+    expect(mocks.globalSearch.props?.open).toBe(false)
+  })
+
+  it('does not open global search while a file preview modal is open', async () => {
+    mocks.settings.isLoaded = true
+    mocks.preview.fileDialogItem = { id: 'previewed-file' }
+    await render()
+
+    await act(async () => {
+      window.dispatchEvent(
+        new KeyboardEvent('keydown', { key: 'k', metaKey: true, cancelable: true })
+      )
+    })
+
+    expect(mocks.globalSearch.props?.open).toBe(false)
+  })
 
   it('shows startup progress until settings have loaded', async () => {
     await render()

--- a/src/renderer/src/App.tsx
+++ b/src/renderer/src/App.tsx
@@ -11,6 +11,7 @@ import { LifecycleToast } from '@/components/LifecycleToast'
 import { PermissionUndoSnackbar } from '@/components/PermissionUndoSnackbar'
 import { SessionPersistenceAlert } from '@/components/SessionPersistenceAlert'
 import { UpdateDialog } from '@/components/UpdateDialog'
+import { GlobalSearchDialog } from '@/components/global-search/GlobalSearchDialog'
 import { Button } from '@/components/ui/button'
 import { HomePage } from '@/pages/home/HomePage'
 import { OnboardingWizard } from '@/pages/onboarding/OnboardingWizard'
@@ -35,6 +36,7 @@ import { useSessionJobStore } from '@/stores/session-job-store'
 import { useSkillImportStore } from '@/stores/skill-import-store'
 import { useUpdateStore } from '@/stores/update-store'
 import { usePermissionGrantsStore } from '@/stores/permission-grants-store'
+import { usePreviewWorkbenchStore } from '@/stores/preview-workbench-store'
 
 type NotificationOpenIntent = {
   generation: number
@@ -75,6 +77,7 @@ const App = (): React.JSX.Element | null => {
   const applyJobUpdate = useSessionJobStore((state) => state.applyUpdate)
   const initUpdates = useUpdateStore((state) => state.init)
   const isUpdateDialogOpen = useUpdateStore((state) => state.isDialogOpen)
+  const isFilePreviewOpen = usePreviewWorkbenchStore((state) => state.fileDialogItem !== undefined)
   const initEnv = useNotebookEnvStore((state) => state.init)
   const envUi = useNotebookEnvStore((state) => state.ui)
   const listenForPermissionChanges = usePermissionGrantsStore((state) => state.listen)
@@ -105,6 +108,7 @@ const App = (): React.JSX.Element | null => {
     userNavigationRevision: useNavigationStore.getState().userNavigationRevision
   })
   const [isCloseConfirmOpen, setIsCloseConfirmOpen] = useState(false)
+  const [isGlobalSearchOpen, setIsGlobalSearchOpen] = useState(false)
   const startupView = isSettingsLoaded
     ? resolveStartupView({ onboardingDone: onboardingCompletedAt !== undefined })
     : undefined
@@ -130,6 +134,49 @@ const App = (): React.JSX.Element | null => {
     legacyMove === undefined
 
   useUnreadTaskViewSync({ isSessionContentVisible })
+
+  useEffect(() => {
+    const toggleGlobalSearch = (event: KeyboardEvent): void => {
+      if (
+        event.defaultPrevented ||
+        event.isComposing ||
+        event.key.toLowerCase() !== 'k' ||
+        !(event.metaKey || event.ctrlKey) ||
+        !isSettingsLoaded ||
+        startupView !== 'app' ||
+        !isSessionPersistenceHydrated ||
+        isSettingsOpen ||
+        hasConnectorApproval ||
+        hasComputeApproval ||
+        hasSkillImportApproval ||
+        isUpdateDialogOpen ||
+        isFilePreviewOpen ||
+        isCloseConfirmOpen ||
+        missingDataRoot !== undefined ||
+        legacyMove !== undefined
+      ) {
+        return
+      }
+      event.preventDefault()
+      setIsGlobalSearchOpen((current) => !current)
+    }
+
+    window.addEventListener('keydown', toggleGlobalSearch)
+    return () => window.removeEventListener('keydown', toggleGlobalSearch)
+  }, [
+    hasComputeApproval,
+    hasConnectorApproval,
+    hasSkillImportApproval,
+    isCloseConfirmOpen,
+    isSessionPersistenceHydrated,
+    isFilePreviewOpen,
+    isSettingsLoaded,
+    isSettingsOpen,
+    isUpdateDialogOpen,
+    legacyMove,
+    missingDataRoot,
+    startupView
+  ])
 
   // Load app info and subscribe to update-status broadcasts once at startup.
   useEffect(() => {
@@ -443,6 +490,12 @@ const App = (): React.JSX.Element | null => {
       <ComputeApprovalDialog />
       <UpdateDialog />
       <CloseConfirmModal onOpenChange={setIsCloseConfirmOpen} />
+      <GlobalSearchDialog
+        key={String(isGlobalSearchOpen)}
+        open={isGlobalSearchOpen}
+        onOpenChange={setIsGlobalSearchOpen}
+        isSessionPersistenceReady={isSessionPersistenceReady}
+      />
       <DataRootMissingDialog
         open={missingDataRoot !== undefined}
         dataRoot={missingDataRoot ?? ''}

--- a/src/renderer/src/components/global-search/GlobalSearchDialog.test.tsx
+++ b/src/renderer/src/components/global-search/GlobalSearchDialog.test.tsx
@@ -168,14 +168,37 @@ describe('GlobalSearchDialog', () => {
     expect(dialog?.classList).toContain('h-[calc(100dvh_-_1rem)]')
     expect(input?.classList).toContain('focus-visible:ring-0')
     expect(input?.classList).not.toContain('focus-visible:outline-ring')
-    expect(searchHeader?.classList).toContain('focus-within:ring-[3px]')
-    expect(searchHeader?.classList).toContain('focus-within:ring-inset')
+    expect(searchHeader?.classList).not.toContain('focus-within:ring-[3px]')
+    expect(searchHeader?.classList).not.toContain('focus-within:ring-inset')
     expect(results?.classList).toContain('min-h-0')
     expect(results?.classList).toContain('flex-1')
     expect(footer?.classList).toContain('shrink-0')
     expect(footer?.classList).toContain('grid-cols-2')
     expect(footer?.querySelectorAll('kbd')).toHaveLength(4)
     expect(results?.contains(footer ?? null)).toBe(false)
+  })
+
+  it('closes with Escape when an artifact row action holds focus', async () => {
+    const onOpenChange = vi.fn()
+    await act(async () => {
+      root.render(<GlobalSearchDialog open onOpenChange={onOpenChange} isSessionPersistenceReady />)
+      await new Promise((resolve) => window.setTimeout(resolve, 20))
+    })
+
+    const artifactRow = [...document.body.querySelectorAll('[role="option"]')].find((element) =>
+      element.textContent?.includes('sin.png')
+    ) as HTMLElement
+    act(() => artifactRow.dispatchEvent(new MouseEvent('mouseenter', { bubbles: true })))
+    const mention = document.body.querySelector<HTMLButtonElement>('[aria-label="Mention sin.png"]')
+    mention?.focus()
+
+    await act(async () => {
+      mention?.dispatchEvent(
+        new KeyboardEvent('keydown', { key: 'Escape', bubbles: true, cancelable: true })
+      )
+    })
+
+    expect(onOpenChange).toHaveBeenCalledWith(false)
   })
 
   it('uses the source message creation time for a legacy artifact', async () => {

--- a/src/renderer/src/components/global-search/GlobalSearchDialog.test.tsx
+++ b/src/renderer/src/components/global-search/GlobalSearchDialog.test.tsx
@@ -1,0 +1,170 @@
+// @vitest-environment jsdom
+import { act } from 'react'
+import { createRoot, type Root } from 'react-dom/client'
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest'
+
+import type { ChatSession } from '@/stores/session-store'
+import {
+  createInitialPreviewWorkbenchState,
+  usePreviewWorkbenchStore
+} from '@/stores/preview-workbench-store'
+import { createInitialProjectState, useProjectStore } from '@/stores/project-store'
+import { createInitialSessionState, useSessionStore } from '@/stores/session-store'
+import { useNavigationStore } from '@/stores/navigation-store'
+
+import { GlobalSearchDialog } from './GlobalSearchDialog'
+
+let container: HTMLDivElement
+let root: Root
+
+const artifact = {
+  id: 'artifact-1',
+  source: 'artifact' as const,
+  sourceFileId: 'artifact-1',
+  sourceVersionId: 'version-1',
+  projectId: 'project-a',
+  sessionId: 'session-a',
+  name: 'sin.png',
+  path: 'artifact-version:project-a/session-a/artifact-1/version-1',
+  size: 12,
+  sortAtMs: Date.now(),
+  originSession: { state: 'active' as const, title: 'Draw sin' }
+}
+
+beforeEach(() => {
+  container = document.createElement('div')
+  document.body.appendChild(container)
+  root = createRoot(container)
+  window.localStorage.clear()
+  useProjectStore.setState({
+    ...createInitialProjectState(),
+    isLoaded: true,
+    projects: [
+      {
+        id: 'project-a',
+        name: 'Alpha',
+        description: '',
+        isExample: false,
+        createdAt: 1,
+        updatedAt: 2
+      },
+      {
+        id: 'project-b',
+        name: 'Beta',
+        description: '',
+        isExample: false,
+        createdAt: 1,
+        updatedAt: 1
+      }
+    ]
+  })
+  useSessionStore.setState({
+    ...createInitialSessionState(),
+    sessions: [
+      {
+        id: 'session-a',
+        projectId: 'project-a',
+        title: 'Python 绘制 sin 函数图',
+        cwd: '/workspace',
+        status: 'idle',
+        createdAt: Date.now(),
+        updatedAt: Date.now(),
+        messages: [],
+        artifacts: []
+      },
+      {
+        id: 'session-b',
+        projectId: 'project-b',
+        title: 'Other sin session',
+        cwd: '/workspace',
+        status: 'idle',
+        createdAt: Date.now() - 1,
+        updatedAt: Date.now() - 1,
+        messages: [],
+        artifacts: []
+      }
+    ] as ChatSession[]
+  })
+  useNavigationStore.setState({
+    view: 'workspace',
+    activeProjectId: 'project-a',
+    userNavigationRevision: 0,
+    explicitNavigationRevision: 0,
+    pendingCustomizePrefill: undefined,
+    pendingArtifactMention: undefined,
+    artifactMentionAvailability: { projectId: 'project-a', canMention: true }
+  })
+  usePreviewWorkbenchStore.setState(createInitialPreviewWorkbenchState())
+  Object.defineProperty(window, 'api', {
+    configurable: true,
+    value: {
+      projectFiles: {
+        searchArtifacts: vi.fn().mockResolvedValue({
+          primary: { items: [artifact], totalCount: 1 },
+          other: [],
+          isIndexComplete: true
+        })
+      }
+    }
+  })
+})
+
+afterEach(() => {
+  act(() => root.unmount())
+  container.remove()
+  vi.restoreAllMocks()
+})
+
+describe('GlobalSearchDialog', () => {
+  it('shows recent groups and sends a current-Project artifact to the composer mention handoff', async () => {
+    await act(async () => {
+      root.render(<GlobalSearchDialog open onOpenChange={vi.fn()} isSessionPersistenceReady />)
+      await new Promise((resolve) => window.setTimeout(resolve, 20))
+    })
+
+    expect(document.body.textContent).toContain('Recent artifacts')
+    expect(document.body.textContent).toContain('Recent sessions')
+    expect(document.body.textContent).toContain('New session')
+
+    const artifactRow = [...document.body.querySelectorAll('[role="option"]')].find((element) =>
+      element.textContent?.includes('sin.png')
+    ) as HTMLElement
+    act(() => artifactRow.dispatchEvent(new MouseEvent('mouseenter', { bubbles: true })))
+    const mention = document.body.querySelector<HTMLElement>('[aria-label="Mention sin.png"]')
+    expect(mention).not.toBeNull()
+    act(() => mention?.dispatchEvent(new MouseEvent('click', { bubbles: true })))
+
+    expect(useNavigationStore.getState().pendingArtifactMention).toMatchObject({ id: 'artifact-1' })
+  })
+
+  it('disables the current-Project mention action when the composer cannot accept another Artifact', async () => {
+    useNavigationStore.setState({
+      artifactMentionAvailability: { projectId: 'project-a', canMention: false }
+    })
+    await act(async () => {
+      root.render(<GlobalSearchDialog open onOpenChange={vi.fn()} isSessionPersistenceReady />)
+      await new Promise((resolve) => window.setTimeout(resolve, 20))
+    })
+
+    const artifactRow = [...document.body.querySelectorAll('[role="option"]')].find((element) =>
+      element.textContent?.includes('sin.png')
+    ) as HTMLElement
+    act(() => artifactRow.dispatchEvent(new MouseEvent('mouseenter', { bubbles: true })))
+    const mention = document.body.querySelector<HTMLButtonElement>('[aria-label="Mention sin.png"]')
+    expect(mention?.disabled).toBe(true)
+    act(() => mention?.dispatchEvent(new MouseEvent('click', { bubbles: true })))
+
+    expect(useNavigationStore.getState().pendingArtifactMention).toBeUndefined()
+  })
+
+  it('uses the valid last-opened Project as Home search scope', async () => {
+    window.localStorage.setItem('open-science:last-opened-project', 'project-b')
+    useNavigationStore.setState({ view: 'home', activeProjectId: undefined })
+    await act(async () => {
+      root.render(<GlobalSearchDialog open onOpenChange={vi.fn()} isSessionPersistenceReady />)
+      await new Promise((resolve) => window.setTimeout(resolve, 20))
+    })
+
+    expect(document.body.textContent).toContain('Beta')
+  })
+})

--- a/src/renderer/src/components/global-search/GlobalSearchDialog.test.tsx
+++ b/src/renderer/src/components/global-search/GlobalSearchDialog.test.tsx
@@ -104,6 +104,14 @@ beforeEach(() => {
           other: [],
           isIndexComplete: true
         })
+      },
+      previewResources: {
+        acquire: vi.fn().mockResolvedValue({
+          id: 'preview-resource-1',
+          url: 'open-science-preview://preview-resource-1',
+          mimeType: 'image/png'
+        }),
+        release: vi.fn().mockResolvedValue(undefined)
       }
     }
   })
@@ -129,12 +137,38 @@ describe('GlobalSearchDialog', () => {
     const artifactRow = [...document.body.querySelectorAll('[role="option"]')].find((element) =>
       element.textContent?.includes('sin.png')
     ) as HTMLElement
+    expect(artifactRow.classList).toContain('cursor-pointer')
+    expect(artifactRow.classList).toContain('select-none')
+    expect(
+      artifactRow.querySelector<HTMLImageElement>('img[alt="Preview of sin.png"]')
+    ).not.toBeNull()
     act(() => artifactRow.dispatchEvent(new MouseEvent('mouseenter', { bubbles: true })))
     const mention = document.body.querySelector<HTMLElement>('[aria-label="Mention sin.png"]')
     expect(mention).not.toBeNull()
     act(() => mention?.dispatchEvent(new MouseEvent('click', { bubbles: true })))
 
     expect(useNavigationStore.getState().pendingArtifactMention).toMatchObject({ id: 'artifact-1' })
+  })
+
+  it('keeps the result list scrollable and the shortcut footer outside the scroll viewport', async () => {
+    await act(async () => {
+      root.render(<GlobalSearchDialog open onOpenChange={vi.fn()} isSessionPersistenceReady />)
+      await new Promise((resolve) => window.setTimeout(resolve, 20))
+    })
+
+    const dialog = document.body.querySelector<HTMLElement>('[data-testid="global-search-dialog"]')
+    const results = document.body.querySelector<HTMLElement>(
+      '[data-testid="global-search-results"]'
+    )
+    const footer = document.body.querySelector<HTMLElement>('[data-testid="global-search-footer"]')
+
+    expect(dialog?.classList).toContain('h-[calc(100dvh_-_1rem)]')
+    expect(results?.classList).toContain('min-h-0')
+    expect(results?.classList).toContain('flex-1')
+    expect(footer?.classList).toContain('shrink-0')
+    expect(footer?.classList).toContain('grid-cols-2')
+    expect(footer?.querySelectorAll('kbd')).toHaveLength(4)
+    expect(results?.contains(footer ?? null)).toBe(false)
   })
 
   it('disables the current-Project mention action when the composer cannot accept another Artifact', async () => {

--- a/src/renderer/src/components/global-search/GlobalSearchDialog.test.tsx
+++ b/src/renderer/src/components/global-search/GlobalSearchDialog.test.tsx
@@ -27,8 +27,8 @@ const artifact = {
   name: 'sin.png',
   path: 'artifact-version:project-a/session-a/artifact-1/version-1',
   size: 12,
-  sortAtMs: Date.now(),
-  originSession: { state: 'active' as const, title: 'Draw sin' }
+  sortAtMs: Date.now() - 3 * 24 * 60 * 60 * 1_000,
+  originSession: { state: 'active' as const }
 }
 
 beforeEach(() => {
@@ -142,6 +142,7 @@ describe('GlobalSearchDialog', () => {
     expect(
       artifactRow.querySelector<HTMLImageElement>('img[alt="Preview of sin.png"]')
     ).not.toBeNull()
+    expect(artifactRow.textContent).toContain('Python 绘制 sin 函数图 · 3 days ago')
     act(() => artifactRow.dispatchEvent(new MouseEvent('mouseenter', { bubbles: true })))
     const mention = document.body.querySelector<HTMLElement>('[aria-label="Mention sin.png"]')
     expect(mention).not.toBeNull()
@@ -169,6 +170,57 @@ describe('GlobalSearchDialog', () => {
     expect(footer?.classList).toContain('grid-cols-2')
     expect(footer?.querySelectorAll('kbd')).toHaveLength(4)
     expect(results?.contains(footer ?? null)).toBe(false)
+  })
+
+  it('uses the source message creation time for a legacy artifact', async () => {
+    const createdAt = Date.now() - 4 * 24 * 60 * 60 * 1_000
+    useSessionStore.setState((state) => ({
+      sessions: state.sessions.map((session) =>
+        session.id === 'session-a'
+          ? {
+              ...session,
+              messages: [
+                {
+                  id: 'message-a',
+                  role: 'agent',
+                  content: 'Created legacy artifact',
+                  status: 'complete',
+                  eventIds: [],
+                  artifactIds: ['artifact-1'],
+                  createdAt,
+                  updatedAt: Date.now()
+                }
+              ]
+            }
+          : session
+      )
+    }))
+    vi.mocked(window.api.projectFiles.searchArtifacts).mockResolvedValueOnce({
+      primary: {
+        items: [
+          {
+            ...artifact,
+            sourceVersionId: undefined,
+            messageId: 'message-a',
+            path: '/workspace/sin.png',
+            sortAtMs: Date.now()
+          }
+        ],
+        totalCount: 1
+      },
+      other: [],
+      isIndexComplete: true
+    })
+
+    await act(async () => {
+      root.render(<GlobalSearchDialog open onOpenChange={vi.fn()} isSessionPersistenceReady />)
+      await new Promise((resolve) => window.setTimeout(resolve, 20))
+    })
+
+    const artifactRow = [...document.body.querySelectorAll('[role="option"]')].find((element) =>
+      element.textContent?.includes('sin.png')
+    )
+    expect(artifactRow?.textContent).toContain('Python 绘制 sin 函数图 · 4 days ago')
   })
 
   it('disables the current-Project mention action when the composer cannot accept another Artifact', async () => {

--- a/src/renderer/src/components/global-search/GlobalSearchDialog.test.tsx
+++ b/src/renderer/src/components/global-search/GlobalSearchDialog.test.tsx
@@ -152,6 +152,44 @@ describe('GlobalSearchDialog', () => {
     expect(useNavigationStore.getState().pendingArtifactMention).toMatchObject({ id: 'artifact-1' })
   })
 
+  it('prioritizes Artifacts and selects the first Artifact for a keyword search', async () => {
+    await act(async () => {
+      root.render(<GlobalSearchDialog open onOpenChange={vi.fn()} isSessionPersistenceReady />)
+      await new Promise((resolve) => window.setTimeout(resolve, 20))
+    })
+
+    const input = document.body.querySelector<HTMLInputElement>('input[role="combobox"]')
+    const valueSetter = Object.getOwnPropertyDescriptor(
+      window.HTMLInputElement.prototype,
+      'value'
+    )?.set
+    await act(async () => {
+      valueSetter?.call(input, 'sin')
+      input?.dispatchEvent(new Event('input', { bubbles: true }))
+      await new Promise((resolve) => window.setTimeout(resolve, 180))
+    })
+
+    const groupHeadings = [...document.body.querySelectorAll('[role="group"] h2')].map(
+      (heading) => heading.textContent
+    )
+    const selectedOption = document.body.querySelector<HTMLElement>(
+      '[role="option"][aria-selected="true"]'
+    )
+
+    expect(groupHeadings.slice(0, 2)).toEqual(['Artifacts', 'Sessions'])
+    expect(selectedOption?.textContent).toContain('sin.png')
+
+    await act(async () => {
+      input?.dispatchEvent(
+        new KeyboardEvent('keydown', { key: 'Enter', bubbles: true, cancelable: true })
+      )
+    })
+    expect(usePreviewWorkbenchStore.getState().fileDialogItem).toMatchObject({
+      artifactId: 'artifact-1',
+      projectId: 'project-a'
+    })
+  })
+
   it('keeps the result list scrollable and the shortcut footer outside the scroll viewport', async () => {
     await act(async () => {
       root.render(<GlobalSearchDialog open onOpenChange={vi.fn()} isSessionPersistenceReady />)

--- a/src/renderer/src/components/global-search/GlobalSearchDialog.test.tsx
+++ b/src/renderer/src/components/global-search/GlobalSearchDialog.test.tsx
@@ -162,8 +162,14 @@ describe('GlobalSearchDialog', () => {
       '[data-testid="global-search-results"]'
     )
     const footer = document.body.querySelector<HTMLElement>('[data-testid="global-search-footer"]')
+    const input = dialog?.querySelector<HTMLInputElement>('input[role="combobox"]')
+    const searchHeader = input?.parentElement
 
     expect(dialog?.classList).toContain('h-[calc(100dvh_-_1rem)]')
+    expect(input?.classList).toContain('focus-visible:ring-0')
+    expect(input?.classList).not.toContain('focus-visible:outline-ring')
+    expect(searchHeader?.classList).toContain('focus-within:ring-[3px]')
+    expect(searchHeader?.classList).toContain('focus-within:ring-inset')
     expect(results?.classList).toContain('min-h-0')
     expect(results?.classList).toContain('flex-1')
     expect(footer?.classList).toContain('shrink-0')

--- a/src/renderer/src/components/global-search/GlobalSearchDialog.test.tsx
+++ b/src/renderer/src/components/global-search/GlobalSearchDialog.test.tsx
@@ -60,6 +60,7 @@ beforeEach(() => {
   })
   useSessionStore.setState({
     ...createInitialSessionState(),
+    selectedSessionId: 'session-a',
     sessions: [
       {
         id: 'session-a',
@@ -198,6 +199,146 @@ describe('GlobalSearchDialog', () => {
       )
     })
 
+    expect(onOpenChange).toHaveBeenCalledWith(false)
+  })
+
+  it('opens the active Artifact on Shift+Enter when no Session is active', async () => {
+    window.localStorage.setItem('open-science:last-opened-project', 'project-a')
+    useNavigationStore.setState({ view: 'home', activeProjectId: undefined })
+    const onOpenChange = vi.fn()
+    await act(async () => {
+      root.render(<GlobalSearchDialog open onOpenChange={onOpenChange} isSessionPersistenceReady />)
+      await new Promise((resolve) => window.setTimeout(resolve, 20))
+    })
+
+    const input = document.body.querySelector<HTMLInputElement>('input[role="combobox"]')
+    await act(async () => {
+      input?.dispatchEvent(
+        new KeyboardEvent('keydown', {
+          key: 'Enter',
+          shiftKey: true,
+          bubbles: true,
+          cancelable: true
+        })
+      )
+    })
+
+    expect(useNavigationStore.getState().pendingArtifactMention).toBeUndefined()
+    expect(usePreviewWorkbenchStore.getState().fileDialogItem).toMatchObject({
+      artifactId: 'artifact-1',
+      projectId: 'project-a'
+    })
+    expect(onOpenChange).toHaveBeenCalledWith(false)
+  })
+
+  it('opens the active Artifact on Shift+Enter from a Project draft without a Session', async () => {
+    useSessionStore.setState({ selectedSessionId: undefined })
+    const onOpenChange = vi.fn()
+    await act(async () => {
+      root.render(<GlobalSearchDialog open onOpenChange={onOpenChange} isSessionPersistenceReady />)
+      await new Promise((resolve) => window.setTimeout(resolve, 20))
+    })
+
+    const input = document.body.querySelector<HTMLInputElement>('input[role="combobox"]')
+    await act(async () => {
+      input?.dispatchEvent(
+        new KeyboardEvent('keydown', {
+          key: 'Enter',
+          shiftKey: true,
+          bubbles: true,
+          cancelable: true
+        })
+      )
+    })
+
+    expect(useNavigationStore.getState().pendingArtifactMention).toBeUndefined()
+    expect(usePreviewWorkbenchStore.getState().fileDialogItem).toMatchObject({
+      artifactId: 'artifact-1',
+      projectId: 'project-a'
+    })
+    expect(onOpenChange).toHaveBeenCalledWith(false)
+  })
+
+  it('mentions the active Artifact on Shift+Enter inside the current Session', async () => {
+    const onOpenChange = vi.fn()
+    await act(async () => {
+      root.render(<GlobalSearchDialog open onOpenChange={onOpenChange} isSessionPersistenceReady />)
+      await new Promise((resolve) => window.setTimeout(resolve, 20))
+    })
+
+    const input = document.body.querySelector<HTMLInputElement>('input[role="combobox"]')
+    await act(async () => {
+      input?.dispatchEvent(
+        new KeyboardEvent('keydown', {
+          key: 'Enter',
+          shiftKey: true,
+          bubbles: true,
+          cancelable: true
+        })
+      )
+    })
+
+    expect(useNavigationStore.getState().pendingArtifactMention).toMatchObject({
+      id: 'artifact-1',
+      projectId: 'project-a'
+    })
+    expect(usePreviewWorkbenchStore.getState().fileDialogItem).toBeUndefined()
+    expect(onOpenChange).toHaveBeenCalledWith(false)
+  })
+
+  it('opens a cross-Project Artifact on Shift+Enter instead of mentioning it', async () => {
+    vi.mocked(window.api.projectFiles.searchArtifacts).mockResolvedValue({
+      primary: { items: [], totalCount: 0 },
+      other: [
+        {
+          ...artifact,
+          id: 'artifact-2',
+          sourceFileId: 'artifact-2',
+          sourceVersionId: 'version-2',
+          projectId: 'project-b',
+          sessionId: 'session-b',
+          name: 'other.png',
+          path: 'artifact-version:project-b/session-b/artifact-2/version-2'
+        }
+      ],
+      isIndexComplete: true
+    })
+    const onOpenChange = vi.fn()
+    await act(async () => {
+      root.render(<GlobalSearchDialog open onOpenChange={onOpenChange} isSessionPersistenceReady />)
+      await new Promise((resolve) => window.setTimeout(resolve, 20))
+    })
+
+    const input = document.body.querySelector<HTMLInputElement>('input[role="combobox"]')
+    const valueSetter = Object.getOwnPropertyDescriptor(
+      window.HTMLInputElement.prototype,
+      'value'
+    )?.set
+    await act(async () => {
+      valueSetter?.call(input, 'other.png')
+      input?.dispatchEvent(new Event('input', { bubbles: true }))
+      await new Promise((resolve) => window.setTimeout(resolve, 180))
+    })
+    await act(async () => {
+      input?.dispatchEvent(
+        new KeyboardEvent('keydown', {
+          key: 'Enter',
+          shiftKey: true,
+          bubbles: true,
+          cancelable: true
+        })
+      )
+    })
+
+    expect(useNavigationStore.getState()).toMatchObject({
+      view: 'workspace',
+      activeProjectId: 'project-b',
+      pendingArtifactMention: undefined
+    })
+    expect(usePreviewWorkbenchStore.getState().fileDialogItem).toMatchObject({
+      artifactId: 'artifact-2',
+      projectId: 'project-b'
+    })
     expect(onOpenChange).toHaveBeenCalledWith(false)
   })
 

--- a/src/renderer/src/components/global-search/GlobalSearchDialog.test.tsx
+++ b/src/renderer/src/components/global-search/GlobalSearchDialog.test.tsx
@@ -286,6 +286,36 @@ describe('GlobalSearchDialog', () => {
     expect(onOpenChange).toHaveBeenCalledWith(false)
   })
 
+  it('opens the active Artifact on Shift+Enter when the current Session cannot accept a mention', async () => {
+    useNavigationStore.setState({
+      artifactMentionAvailability: { projectId: 'project-a', canMention: false }
+    })
+    const onOpenChange = vi.fn()
+    await act(async () => {
+      root.render(<GlobalSearchDialog open onOpenChange={onOpenChange} isSessionPersistenceReady />)
+      await new Promise((resolve) => window.setTimeout(resolve, 20))
+    })
+
+    const input = document.body.querySelector<HTMLInputElement>('input[role="combobox"]')
+    await act(async () => {
+      input?.dispatchEvent(
+        new KeyboardEvent('keydown', {
+          key: 'Enter',
+          shiftKey: true,
+          bubbles: true,
+          cancelable: true
+        })
+      )
+    })
+
+    expect(useNavigationStore.getState().pendingArtifactMention).toBeUndefined()
+    expect(usePreviewWorkbenchStore.getState().fileDialogItem).toMatchObject({
+      artifactId: 'artifact-1',
+      projectId: 'project-a'
+    })
+    expect(onOpenChange).toHaveBeenCalledWith(false)
+  })
+
   it('opens a cross-Project Artifact on Shift+Enter instead of mentioning it', async () => {
     vi.mocked(window.api.projectFiles.searchArtifacts).mockResolvedValue({
       primary: { items: [], totalCount: 0 },

--- a/src/renderer/src/components/global-search/GlobalSearchDialog.tsx
+++ b/src/renderer/src/components/global-search/GlobalSearchDialog.tsx
@@ -64,15 +64,18 @@ const emptyArtifactState: ArtifactState = {
 const getErrorMessage = (error: unknown): string =>
   error instanceof Error ? error.message : 'Could not load artifacts.'
 
+const pluralizeTime = (value: number, unit: string): string =>
+  `${value} ${unit}${value === 1 ? '' : 's'} ago`
+
 const formatRelativeTime = (timestamp: number): string => {
   const elapsed = Math.max(0, Date.now() - timestamp)
   const minutes = Math.floor(elapsed / 60_000)
   if (minutes < 1) return 'just now'
-  if (minutes < 60) return `${minutes}m ago`
+  if (minutes < 60) return pluralizeTime(minutes, 'minute')
   const hours = Math.floor(minutes / 60)
-  if (hours < 24) return `${hours}h ago`
+  if (hours < 24) return pluralizeTime(hours, 'hour')
   const days = Math.floor(hours / 24)
-  return days < 7 ? `${days}d ago` : `${Math.floor(days / 7)}w ago`
+  return days < 7 ? pluralizeTime(days, 'day') : pluralizeTime(Math.floor(days / 7), 'week')
 }
 
 const artifactToPreviewItem = (
@@ -154,6 +157,23 @@ export const GlobalSearchDialog = ({
     () => new Map(projects.map((project) => [project.id, project.name])),
     [projects]
   )
+  const sessionTitles = useMemo(
+    () =>
+      new Map(
+        sessions.map((session) => [`${session.projectId}:${session.id}`, session.title] as const)
+      ),
+    [sessions]
+  )
+  const sessionMessageCreatedTimes = useMemo(() => {
+    const createdTimes = new Map<string, number>()
+    for (const session of sessions) {
+      const messages = [...(session.conversationGraph?.messages ?? []), ...session.messages]
+      for (const message of messages) {
+        createdTimes.set(`${session.projectId}:${session.id}:${message.id}`, message.createdAt)
+      }
+    }
+    return createdTimes
+  }, [sessions])
   const trimmedQuery = query.trim()
   const isSearchMode = trimmedQuery.length > 0
   const otherProjectIds = useMemo(
@@ -491,6 +511,13 @@ export const GlobalSearchDialog = ({
 
   const renderArtifactRow = (artifact: ProjectFileItem, rowIndex: number): React.JSX.Element => {
     const active = rowIndex === activeRowIndex
+    const createdAt = artifact.sourceVersionId
+      ? artifact.sortAtMs
+      : artifact.messageId
+        ? sessionMessageCreatedTimes.get(
+            `${artifact.projectId}:${artifact.sessionId}:${artifact.messageId}`
+          )
+        : undefined
     const isCurrentWorkspaceArtifact =
       view === 'workspace' && activeProjectId === artifact.projectId
     const canMention =
@@ -528,8 +555,11 @@ export const GlobalSearchDialog = ({
             {artifact.projectId !== primaryProject?.id
               ? `${projectNames.get(artifact.projectId) ?? 'Unknown project'} · `
               : ''}
-            {artifact.originSession?.title ?? 'Unknown session'} ·{' '}
-            {formatRelativeTime(artifact.sortAtMs)}
+            {artifact.originSession?.title ??
+              sessionTitles.get(`${artifact.projectId}:${artifact.sessionId}`) ??
+              'Unknown session'}{' '}
+            ·{' '}
+            {createdAt === undefined ? 'Creation time unavailable' : formatRelativeTime(createdAt)}
           </span>
         </span>
         {active ? (

--- a/src/renderer/src/components/global-search/GlobalSearchDialog.tsx
+++ b/src/renderer/src/components/global-search/GlobalSearchDialog.tsx
@@ -634,7 +634,7 @@ export const GlobalSearchDialog = ({
           )}
         >
           <Dialog.Title className="sr-only">Command palette</Dialog.Title>
-          <div className="flex min-h-16 shrink-0 items-center gap-3 border-b border-border px-4 py-3">
+          <div className="flex min-h-16 shrink-0 items-center gap-3 border-b border-border px-4 py-3 transition-shadow duration-150 focus-within:ring-[3px] focus-within:ring-inset focus-within:ring-ring/50 motion-reduce:transition-none">
             <Search className="size-5 shrink-0 text-muted-foreground" aria-hidden="true" />
             <Input
               ref={inputRef}
@@ -647,7 +647,7 @@ export const GlobalSearchDialog = ({
               aria-activedescendant={selectableRows.length > 0 ? activeRowId : undefined}
               placeholder="Search this project…"
               maxLength={256}
-              className="h-auto min-w-0 flex-1 rounded-none border-0 bg-transparent px-0 text-xl text-foreground outline-2 outline-transparent placeholder:text-muted-foreground focus-visible:border-transparent focus-visible:outline-ring focus-visible:outline-offset-1 focus-visible:ring-0"
+              className="h-auto min-w-0 flex-1 rounded-none border-0 bg-transparent px-0 text-xl text-foreground placeholder:text-muted-foreground focus-visible:border-transparent focus-visible:ring-0"
             />
             {primaryProject ? (
               <span className="max-w-[35%] shrink-0 truncate rounded-lg bg-bg-200 px-3 py-1.5 text-sm font-medium text-muted-foreground">

--- a/src/renderer/src/components/global-search/GlobalSearchDialog.tsx
+++ b/src/renderer/src/components/global-search/GlobalSearchDialog.tsx
@@ -363,6 +363,13 @@ export const GlobalSearchDialog = ({
       ),
     [activeProjectId, selectedSessionId, sessions, view]
   )
+  const canMentionArtifact = useCallback(
+    (artifact: ProjectFileItem): boolean =>
+      isArtifactMentionTarget(artifact) &&
+      artifactMentionAvailability?.projectId === artifact.projectId &&
+      artifactMentionAvailability.canMention,
+    [artifactMentionAvailability, isArtifactMentionTarget]
+  )
   const previewArtifact = useCallback(
     (artifact: ProjectFileItem): void => {
       if (activeProjectId !== artifact.projectId || view !== 'workspace') {
@@ -375,17 +382,11 @@ export const GlobalSearchDialog = ({
   )
   const mentionArtifact = useCallback(
     (artifact: ProjectFileItem): void => {
-      if (
-        !isArtifactMentionTarget(artifact) ||
-        artifactMentionAvailability?.projectId !== artifact.projectId ||
-        !artifactMentionAvailability.canMention
-      ) {
-        return
-      }
+      if (!canMentionArtifact(artifact)) return
       requestArtifactMention(artifact)
       close()
     },
-    [artifactMentionAvailability, close, isArtifactMentionTarget, requestArtifactMention]
+    [canMentionArtifact, close, requestArtifactMention]
   )
   const activate = useCallback(
     (row: SelectableRow | undefined, action?: 'mention' | 'preview'): void => {
@@ -406,7 +407,7 @@ export const GlobalSearchDialog = ({
         return
       }
       if (row.kind === 'artifact') {
-        if (action === 'mention' && isArtifactMentionTarget(row.artifact)) {
+        if (action === 'mention' && canMentionArtifact(row.artifact)) {
           mentionArtifact(row.artifact)
         } else previewArtifact(row.artifact)
         return
@@ -431,10 +432,10 @@ export const GlobalSearchDialog = ({
     },
     [
       artifacts.nextCursor,
+      canMentionArtifact,
       close,
       failedArtifactCursor,
       isSessionPersistenceReady,
-      isArtifactMentionTarget,
       mentionArtifact,
       openProject,
       openSession,
@@ -530,10 +531,7 @@ export const GlobalSearchDialog = ({
           )
         : undefined
     const isCurrentSessionArtifact = isArtifactMentionTarget(artifact)
-    const canMention =
-      isCurrentSessionArtifact &&
-      artifactMentionAvailability?.projectId === artifact.projectId &&
-      artifactMentionAvailability.canMention
+    const canMention = canMentionArtifact(artifact)
     return (
       <div
         id={`global-search-option-${rowIndex}`}

--- a/src/renderer/src/components/global-search/GlobalSearchDialog.tsx
+++ b/src/renderer/src/components/global-search/GlobalSearchDialog.tsx
@@ -135,6 +135,7 @@ export const GlobalSearchDialog = ({
 
   const projects = useProjectStore((state) => state.projects)
   const sessions = useSessionStore((state) => state.sessions)
+  const selectedSessionId = useSessionStore((state) => state.selectedSessionId)
   const activeProjectId = useNavigationStore((state) => state.activeProjectId)
   const view = useNavigationStore((state) => state.view)
   const openProject = useNavigationStore((state) => state.openProject)
@@ -353,6 +354,15 @@ export const GlobalSearchDialog = ({
   }, [activeRowId, open, selectableRows.length])
 
   const close = useCallback(() => onOpenChange(false), [onOpenChange])
+  const isArtifactMentionTarget = useCallback(
+    (artifact: ProjectFileItem): boolean =>
+      view === 'workspace' &&
+      activeProjectId === artifact.projectId &&
+      sessions.some(
+        (session) => session.id === selectedSessionId && session.projectId === artifact.projectId
+      ),
+    [activeProjectId, selectedSessionId, sessions, view]
+  )
   const previewArtifact = useCallback(
     (artifact: ProjectFileItem): void => {
       if (activeProjectId !== artifact.projectId || view !== 'workspace') {
@@ -366,8 +376,7 @@ export const GlobalSearchDialog = ({
   const mentionArtifact = useCallback(
     (artifact: ProjectFileItem): void => {
       if (
-        activeProjectId !== artifact.projectId ||
-        view !== 'workspace' ||
+        !isArtifactMentionTarget(artifact) ||
         artifactMentionAvailability?.projectId !== artifact.projectId ||
         !artifactMentionAvailability.canMention
       ) {
@@ -376,7 +385,7 @@ export const GlobalSearchDialog = ({
       requestArtifactMention(artifact)
       close()
     },
-    [activeProjectId, artifactMentionAvailability, close, requestArtifactMention, view]
+    [artifactMentionAvailability, close, isArtifactMentionTarget, requestArtifactMention]
   )
   const activate = useCallback(
     (row: SelectableRow | undefined, action?: 'mention' | 'preview'): void => {
@@ -397,8 +406,9 @@ export const GlobalSearchDialog = ({
         return
       }
       if (row.kind === 'artifact') {
-        if (action === 'mention') mentionArtifact(row.artifact)
-        else previewArtifact(row.artifact)
+        if (action === 'mention' && isArtifactMentionTarget(row.artifact)) {
+          mentionArtifact(row.artifact)
+        } else previewArtifact(row.artifact)
         return
       }
       if (row.kind === 'more-sessions') {
@@ -424,6 +434,7 @@ export const GlobalSearchDialog = ({
       close,
       failedArtifactCursor,
       isSessionPersistenceReady,
+      isArtifactMentionTarget,
       mentionArtifact,
       openProject,
       openSession,
@@ -518,10 +529,9 @@ export const GlobalSearchDialog = ({
             `${artifact.projectId}:${artifact.sessionId}:${artifact.messageId}`
           )
         : undefined
-    const isCurrentWorkspaceArtifact =
-      view === 'workspace' && activeProjectId === artifact.projectId
+    const isCurrentSessionArtifact = isArtifactMentionTarget(artifact)
     const canMention =
-      isCurrentWorkspaceArtifact &&
+      isCurrentSessionArtifact &&
       artifactMentionAvailability?.projectId === artifact.projectId &&
       artifactMentionAvailability.canMention
     return (
@@ -565,7 +575,7 @@ export const GlobalSearchDialog = ({
         {active ? (
           <TooltipProvider delayDuration={800}>
             <span className="flex shrink-0 items-center gap-1">
-              {isCurrentWorkspaceArtifact ? (
+              {isCurrentSessionArtifact ? (
                 <Tooltip>
                   <TooltipTrigger asChild>
                     <span>

--- a/src/renderer/src/components/global-search/GlobalSearchDialog.tsx
+++ b/src/renderer/src/components/global-search/GlobalSearchDialog.tsx
@@ -324,13 +324,13 @@ export const GlobalSearchDialog = ({
       ]
     }
     return [
-      ...(sessionGroups?.primary.map((session) => ({ kind: 'session' as const, session })) ?? []),
-      ...(sessionMoreCount > 0 ? [{ kind: 'more-sessions' as const }] : []),
       ...artifacts.items.map((artifact) => ({ kind: 'artifact' as const, artifact })),
       ...(artifactError ? [{ kind: 'retry-artifacts' as const }] : []),
       ...(canLoadMoreArtifacts ? [{ kind: 'more-artifacts' as const }] : []),
-      ...(sessionGroups?.other.map((session) => ({ kind: 'session' as const, session })) ?? []),
-      ...artifacts.other.map((artifact) => ({ kind: 'artifact' as const, artifact }))
+      ...(sessionGroups?.primary.map((session) => ({ kind: 'session' as const, session })) ?? []),
+      ...(sessionMoreCount > 0 ? [{ kind: 'more-sessions' as const }] : []),
+      ...artifacts.other.map((artifact) => ({ kind: 'artifact' as const, artifact })),
+      ...(sessionGroups?.other.map((session) => ({ kind: 'session' as const, session })) ?? [])
     ]
   }, [
     canLoadMoreArtifacts,
@@ -718,31 +718,6 @@ export const GlobalSearchDialog = ({
                 </>
               ) : (
                 <>
-                  {sessionGroups?.primary.length ? (
-                    <section role="group" aria-label="Sessions">
-                      <h2 className={sectionTitleClassName}>Sessions</h2>
-                      {sessionGroups.primary.map((session) =>
-                        renderSessionRow(session, nextIndex())
-                      )}
-                      {sessionMoreCount > 0 ? (
-                        <Button
-                          id={`global-search-option-${nextIndex()}`}
-                          type="button"
-                          role="option"
-                          aria-selected={activeRowIndex === rowIndex - 1}
-                          variant="ghost"
-                          className={cn(
-                            'flex h-11 w-full cursor-pointer select-none items-center justify-start px-4 text-left text-sm font-medium text-primary outline-none',
-                            activeRowIndex === rowIndex - 1 && 'bg-bg-200'
-                          )}
-                          onMouseEnter={() => setActiveIndex(rowIndex - 1)}
-                          onClick={() => activate({ kind: 'more-sessions' })}
-                        >
-                          +{sessionMoreCount} more matches — show more
-                        </Button>
-                      ) : null}
-                    </section>
-                  ) : null}
                   {artifacts.items.length || artifactStatus === 'loading' || artifactError ? (
                     <section role="group" aria-label="Artifacts">
                       <h2 className={sectionTitleClassName}>Artifacts</h2>
@@ -788,13 +763,38 @@ export const GlobalSearchDialog = ({
                       ) : null}
                     </section>
                   ) : null}
+                  {sessionGroups?.primary.length ? (
+                    <section role="group" aria-label="Sessions">
+                      <h2 className={sectionTitleClassName}>Sessions</h2>
+                      {sessionGroups.primary.map((session) =>
+                        renderSessionRow(session, nextIndex())
+                      )}
+                      {sessionMoreCount > 0 ? (
+                        <Button
+                          id={`global-search-option-${nextIndex()}`}
+                          type="button"
+                          role="option"
+                          aria-selected={activeRowIndex === rowIndex - 1}
+                          variant="ghost"
+                          className={cn(
+                            'flex h-11 w-full cursor-pointer select-none items-center justify-start px-4 text-left text-sm font-medium text-primary outline-none',
+                            activeRowIndex === rowIndex - 1 && 'bg-bg-200'
+                          )}
+                          onMouseEnter={() => setActiveIndex(rowIndex - 1)}
+                          onClick={() => activate({ kind: 'more-sessions' })}
+                        >
+                          +{sessionMoreCount} more matches — show more
+                        </Button>
+                      ) : null}
+                    </section>
+                  ) : null}
                   {sessionGroups?.other.length || artifacts.other.length ? (
                     <section role="group" aria-label="Other projects">
                       <h2 className={sectionTitleClassName}>Other projects</h2>
+                      {artifacts.other.map((artifact) => renderArtifactRow(artifact, nextIndex()))}
                       {sessionGroups?.other.map((session) =>
                         renderSessionRow(session, nextIndex())
                       )}
-                      {artifacts.other.map((artifact) => renderArtifactRow(artifact, nextIndex()))}
                     </section>
                   ) : null}
                   {selectableRows.length === 0 && artifactStatus !== 'loading' ? (

--- a/src/renderer/src/components/global-search/GlobalSearchDialog.tsx
+++ b/src/renderer/src/components/global-search/GlobalSearchDialog.tsx
@@ -1,5 +1,11 @@
+/* Hallmark · pre-emit critique: P5 H5 E4 S5 R5 V4
+ * component: command palette · genre: modern-minimal · theme: Open Science tokens
+ * structural fingerprint: fixed header / single scroll plane / fixed shortcut footer
+ * states: default · hover · focus · active · disabled · loading · error · success
+ * contrast: inherited from the app's verified semantic tokens · slop: pass
+ */
 import { useCallback, useEffect, useId, useMemo, useRef, useState } from 'react'
-import { ArrowUpRight, AtSign, File, Hash, MessageCircle, Search } from 'lucide-react'
+import { ArrowUpRight, AtSign, Hash, MessageCircle, Search } from 'lucide-react'
 import { Dialog } from 'radix-ui'
 
 import type { ProjectFileItem } from '../../../../shared/project-files'
@@ -10,7 +16,9 @@ import { ScrollArea } from '@/components/ui/scroll-area'
 import { Tooltip, TooltipContent, TooltipProvider, TooltipTrigger } from '@/components/ui/tooltip'
 import { resolveCustomizeProjectId } from '@/lib/last-opened-project'
 import { cn } from '@/lib/utils'
+import { ArtifactPreview } from '@/pages/workspace/artifact-preview'
 import { createPreviewFileItem } from '@/pages/workspace/preview-file-item'
+import type { MessageArtifact } from '@/pages/workspace/preview-file-item'
 import { usePreviewWorkbenchStore } from '@/stores/preview-workbench-store'
 import { useNavigationStore } from '@/stores/navigation-store'
 import { useProjectStore } from '@/stores/project-store'
@@ -85,10 +93,25 @@ const artifactToPreviewItem = (
     originSession: artifact.originSession
   })
 
+const artifactToThumbnailItem = (artifact: ProjectFileItem): MessageArtifact => ({
+  id: artifact.sourceVersionId ?? artifact.sourceFileId,
+  artifactId: artifact.source === 'artifact' ? artifact.sourceFileId : undefined,
+  versionId: artifact.sourceVersionId,
+  kind: 'managed-file',
+  path: artifact.path,
+  name: artifact.name,
+  mimeType: artifact.mimeType,
+  size: artifact.size,
+  mtimeMs: artifact.mtimeMs
+})
+
 const sectionTitleClassName =
-  'sticky top-0 z-10 bg-card px-4 py-2 text-sm font-medium text-muted-foreground'
+  'sticky top-0 z-10 bg-card px-4 pb-2 pt-3 text-sm font-medium text-muted-foreground'
 const rowClassName =
-  'relative flex h-11 w-full min-w-0 items-center gap-3 px-4 text-left outline-none before:absolute before:left-2 before:h-6 before:w-[3px] before:rounded-full before:bg-primary before:opacity-0'
+  'relative flex min-h-12 w-full min-w-0 cursor-pointer select-none items-center justify-start gap-3 px-4 text-left outline-none transition-colors duration-150 before:absolute before:left-2 before:h-6 before:w-[3px] before:rounded-full before:bg-primary before:opacity-0 before:transition-opacity before:duration-150 hover:bg-bg-200 active:bg-bg-300 motion-reduce:transition-none motion-reduce:before:transition-none'
+const shortcutClassName = 'inline-flex min-w-0 items-center gap-1.5 whitespace-nowrap'
+const keycapClassName =
+  'inline-flex h-6 min-w-6 shrink-0 items-center justify-center rounded-md border border-border bg-bg-000 px-1.5 font-mono text-[11px] leading-none text-foreground shadow-sm'
 
 export const GlobalSearchDialog = ({
   open,
@@ -302,6 +325,12 @@ export const GlobalSearchDialog = ({
   ])
 
   const activeRowIndex = Math.max(0, Math.min(activeIndex, selectableRows.length - 1))
+  const activeRowId = `global-search-option-${activeRowIndex}`
+
+  useEffect(() => {
+    if (!open || selectableRows.length === 0) return
+    document.getElementById(activeRowId)?.scrollIntoView?.({ block: 'nearest' })
+  }, [activeRowId, open, selectableRows.length])
 
   const close = useCallback(() => onOpenChange(false), [onOpenChange])
   const previewArtifact = useCallback(
@@ -425,8 +454,6 @@ export const GlobalSearchDialog = ({
       (sessionGroups?.other.length ?? 0) +
       artifacts.other.length
     : artifacts.items.length + recentSessions.length + (primaryProject ? 1 : 0)
-  const activeRowId = `global-search-option-${activeRowIndex}`
-
   const renderSessionRow = (session: SessionSearchResult, rowIndex: number): React.JSX.Element => {
     const active = rowIndex === activeRowIndex
     return (
@@ -481,7 +508,18 @@ export const GlobalSearchDialog = ({
         onMouseEnter={() => setActiveIndex(rowIndex)}
         onClick={() => previewArtifact(artifact)}
       >
-        <File className="size-5 shrink-0 text-muted-foreground" aria-hidden="true" />
+        <span
+          data-testid="global-search-artifact-thumbnail"
+          className="size-10 shrink-0 overflow-hidden rounded-md border border-border-300/50 bg-bg-200"
+          aria-hidden="true"
+        >
+          <ArtifactPreview
+            artifact={artifactToThumbnailItem(artifact)}
+            source={artifact.source}
+            projectId={artifact.projectId}
+            sessionId={artifact.sessionId}
+          />
+        </span>
         <span className="min-w-0 flex-1">
           <span className="block truncate text-sm font-medium text-foreground">
             {artifact.name}
@@ -495,7 +533,7 @@ export const GlobalSearchDialog = ({
           </span>
         </span>
         {active ? (
-          <TooltipProvider delayDuration={200}>
+          <TooltipProvider delayDuration={800}>
             <span className="flex shrink-0 items-center gap-1">
               {isCurrentWorkspaceArtifact ? (
                 <Tooltip>
@@ -506,6 +544,7 @@ export const GlobalSearchDialog = ({
                         variant="ghost"
                         size="icon-xs"
                         tabIndex={-1}
+                        className="cursor-pointer"
                         aria-label={`Mention ${artifact.name}`}
                         disabled={!canMention}
                         onClick={(event) => {
@@ -531,6 +570,7 @@ export const GlobalSearchDialog = ({
                     variant="ghost"
                     size="icon-xs"
                     tabIndex={-1}
+                    className="cursor-pointer"
                     aria-label={`Open ${artifact.name}`}
                     onClick={(event) => {
                       event.stopPropagation()
@@ -557,13 +597,14 @@ export const GlobalSearchDialog = ({
       <Dialog.Portal>
         <Dialog.Overlay className={dialogOverlayClassName} />
         <Dialog.Content
+          data-testid="global-search-dialog"
           aria-describedby={undefined}
           className={dialogPanelClassName(
-            'top-[15vh] flex w-[min(640px,calc(100vw-2rem))] max-w-none -translate-y-0 flex-col overflow-hidden p-0'
+            'flex h-[calc(100dvh_-_1rem)] w-[calc(100%_-_1rem)] max-w-[680px] flex-col overflow-hidden p-0 sm:h-[min(760px,calc(100dvh_-_2rem))] sm:w-[calc(100%_-_2rem)]'
           )}
         >
           <Dialog.Title className="sr-only">Command palette</Dialog.Title>
-          <div className="flex shrink-0 items-center gap-3 border-b border-border px-4 py-3">
+          <div className="flex min-h-16 shrink-0 items-center gap-3 border-b border-border px-4 py-3">
             <Search className="size-5 shrink-0 text-muted-foreground" aria-hidden="true" />
             <Input
               ref={inputRef}
@@ -576,10 +617,10 @@ export const GlobalSearchDialog = ({
               aria-activedescendant={selectableRows.length > 0 ? activeRowId : undefined}
               placeholder="Search this project…"
               maxLength={256}
-              className="h-auto min-w-0 flex-1 rounded-none border-0 bg-transparent px-0 text-xl text-foreground placeholder:text-muted-foreground"
+              className="h-auto min-w-0 flex-1 rounded-none border-0 bg-transparent px-0 text-xl text-foreground outline-2 outline-transparent placeholder:text-muted-foreground focus-visible:border-transparent focus-visible:outline-ring focus-visible:outline-offset-1 focus-visible:ring-0"
             />
             {primaryProject ? (
-              <span className="max-w-60 truncate rounded-lg bg-bg-200 px-3 py-1 text-sm font-medium text-muted-foreground">
+              <span className="max-w-[35%] shrink-0 truncate rounded-lg bg-bg-200 px-3 py-1.5 text-sm font-medium text-muted-foreground">
                 {primaryProject.name}
               </span>
             ) : null}
@@ -592,7 +633,10 @@ export const GlobalSearchDialog = ({
               {actionError}
             </p>
           ) : null}
-          <ScrollArea className="max-h-[60vh]">
+          <ScrollArea
+            data-testid="global-search-results"
+            className="min-h-0 flex-1 overscroll-contain"
+          >
             <div id={listboxId} role="listbox" className="py-1.5">
               {!primaryProject ? (
                 <p className="px-4 py-8 text-center text-sm text-muted-foreground">
@@ -650,7 +694,7 @@ export const GlobalSearchDialog = ({
                           aria-selected={activeRowIndex === rowIndex - 1}
                           variant="ghost"
                           className={cn(
-                            'flex h-11 w-full items-center px-4 text-left text-sm font-medium text-primary outline-none',
+                            'flex h-11 w-full cursor-pointer select-none items-center justify-start px-4 text-left text-sm font-medium text-primary outline-none',
                             activeRowIndex === rowIndex - 1 && 'bg-bg-200'
                           )}
                           onMouseEnter={() => setActiveIndex(rowIndex - 1)}
@@ -677,7 +721,7 @@ export const GlobalSearchDialog = ({
                           role="option"
                           aria-selected={activeRowIndex === rowIndex - 1}
                           variant="ghost"
-                          className="h-11 px-4 text-sm font-medium text-primary"
+                          className="h-11 cursor-pointer justify-start px-4 text-sm font-medium text-primary"
                           onMouseEnter={() => setActiveIndex(rowIndex - 1)}
                           onClick={() => void reloadArtifacts(failedArtifactCursor)}
                         >
@@ -695,7 +739,7 @@ export const GlobalSearchDialog = ({
                           variant="ghost"
                           disabled={artifactStatus === 'loading'}
                           className={cn(
-                            'flex h-11 w-full items-center px-4 text-left text-sm font-medium text-primary outline-none disabled:opacity-50',
+                            'flex h-11 w-full cursor-pointer select-none items-center justify-start px-4 text-left text-sm font-medium text-primary outline-none disabled:cursor-not-allowed disabled:opacity-50',
                             activeRowIndex === rowIndex - 1 && 'bg-bg-200'
                           )}
                           onMouseEnter={() => setActiveIndex(rowIndex - 1)}
@@ -729,12 +773,27 @@ export const GlobalSearchDialog = ({
               ) : null}
             </div>
           </ScrollArea>
-          <div className="flex shrink-0 items-center gap-4 border-t border-border px-4 py-3 text-xs text-muted-foreground">
-            <span>↑↓ navigate</span>
-            <span>↵ open</span>
-            <span>⇧↵ mention</span>
-            <span>esc close</span>
-          </div>
+          <footer
+            data-testid="global-search-footer"
+            className="grid min-h-14 shrink-0 grid-cols-2 items-center gap-x-4 gap-y-2 border-t border-border bg-card px-4 py-2 text-xs text-muted-foreground sm:flex sm:flex-wrap"
+          >
+            <span className={shortcutClassName}>
+              <kbd className={keycapClassName}>↑↓</kbd>
+              <span>navigate</span>
+            </span>
+            <span className={shortcutClassName}>
+              <kbd className={keycapClassName}>↵</kbd>
+              <span>open</span>
+            </span>
+            <span className={shortcutClassName}>
+              <kbd className={keycapClassName}>⇧↵</kbd>
+              <span>mention</span>
+            </span>
+            <span className={shortcutClassName}>
+              <kbd className={keycapClassName}>esc</kbd>
+              <span>close</span>
+            </span>
+          </footer>
         </Dialog.Content>
       </Dialog.Portal>
     </Dialog.Root>

--- a/src/renderer/src/components/global-search/GlobalSearchDialog.tsx
+++ b/src/renderer/src/components/global-search/GlobalSearchDialog.tsx
@@ -634,7 +634,7 @@ export const GlobalSearchDialog = ({
           )}
         >
           <Dialog.Title className="sr-only">Command palette</Dialog.Title>
-          <div className="flex min-h-16 shrink-0 items-center gap-3 border-b border-border px-4 py-3 transition-shadow duration-150 focus-within:ring-[3px] focus-within:ring-inset focus-within:ring-ring/50 motion-reduce:transition-none">
+          <div className="flex min-h-16 shrink-0 items-center gap-3 border-b border-border px-4 py-3">
             <Search className="size-5 shrink-0 text-muted-foreground" aria-hidden="true" />
             <Input
               ref={inputRef}

--- a/src/renderer/src/components/global-search/GlobalSearchDialog.tsx
+++ b/src/renderer/src/components/global-search/GlobalSearchDialog.tsx
@@ -1,0 +1,742 @@
+import { useCallback, useEffect, useId, useMemo, useRef, useState } from 'react'
+import { ArrowUpRight, AtSign, File, Hash, MessageCircle, Search } from 'lucide-react'
+import { Dialog } from 'radix-ui'
+
+import type { ProjectFileItem } from '../../../../shared/project-files'
+import { Button } from '@/components/ui/button'
+import { dialogOverlayClassName, dialogPanelClassName } from '@/components/ui/dialog-chrome'
+import { Input } from '@/components/ui/input'
+import { ScrollArea } from '@/components/ui/scroll-area'
+import { Tooltip, TooltipContent, TooltipProvider, TooltipTrigger } from '@/components/ui/tooltip'
+import { resolveCustomizeProjectId } from '@/lib/last-opened-project'
+import { cn } from '@/lib/utils'
+import { createPreviewFileItem } from '@/pages/workspace/preview-file-item'
+import { usePreviewWorkbenchStore } from '@/stores/preview-workbench-store'
+import { useNavigationStore } from '@/stores/navigation-store'
+import { useProjectStore } from '@/stores/project-store'
+import { useSessionStore } from '@/stores/session-store'
+
+import {
+  getNextBatchCount,
+  getRecentSessions,
+  GLOBAL_SEARCH_PAGE_SIZE,
+  searchSessionTitles,
+  type SessionSearchResult
+} from './global-search-catalog'
+
+type GlobalSearchDialogProps = {
+  open: boolean
+  onOpenChange: (open: boolean) => void
+  isSessionPersistenceReady: boolean
+}
+
+type ArtifactState = {
+  items: ProjectFileItem[]
+  totalCount: number
+  nextCursor?: string
+  other: ProjectFileItem[]
+  isIndexComplete: boolean
+}
+
+type SelectableRow =
+  | { kind: 'session'; session: SessionSearchResult }
+  | { kind: 'artifact'; artifact: ProjectFileItem }
+  | { kind: 'more-sessions' }
+  | { kind: 'more-artifacts' }
+  | { kind: 'retry-artifacts' }
+  | { kind: 'new-session' }
+
+const emptyArtifactState: ArtifactState = {
+  items: [],
+  totalCount: 0,
+  other: [],
+  isIndexComplete: true
+}
+
+const getErrorMessage = (error: unknown): string =>
+  error instanceof Error ? error.message : 'Could not load artifacts.'
+
+const formatRelativeTime = (timestamp: number): string => {
+  const elapsed = Math.max(0, Date.now() - timestamp)
+  const minutes = Math.floor(elapsed / 60_000)
+  if (minutes < 1) return 'just now'
+  if (minutes < 60) return `${minutes}m ago`
+  const hours = Math.floor(minutes / 60)
+  if (hours < 24) return `${hours}h ago`
+  const days = Math.floor(hours / 24)
+  return days < 7 ? `${days}d ago` : `${Math.floor(days / 7)}w ago`
+}
+
+const artifactToPreviewItem = (
+  artifact: ProjectFileItem
+): ReturnType<typeof createPreviewFileItem> =>
+  createPreviewFileItem({
+    id: artifact.id,
+    projectId: artifact.projectId,
+    sessionId: artifact.sessionId,
+    path: artifact.path,
+    name: artifact.name,
+    mimeType: artifact.mimeType,
+    source: artifact.source === 'upload' ? 'upload' : undefined,
+    size: artifact.size,
+    mtimeMs: artifact.mtimeMs,
+    artifactId: artifact.source === 'artifact' ? artifact.sourceFileId : undefined,
+    selectedVersionId: artifact.source === 'artifact' ? artifact.sourceVersionId : undefined,
+    originSession: artifact.originSession
+  })
+
+const sectionTitleClassName =
+  'sticky top-0 z-10 bg-card px-4 py-2 text-sm font-medium text-muted-foreground'
+const rowClassName =
+  'relative flex h-11 w-full min-w-0 items-center gap-3 px-4 text-left outline-none before:absolute before:left-2 before:h-6 before:w-[3px] before:rounded-full before:bg-primary before:opacity-0'
+
+export const GlobalSearchDialog = ({
+  open,
+  onOpenChange,
+  isSessionPersistenceReady
+}: GlobalSearchDialogProps): React.JSX.Element => {
+  const inputRef = useRef<HTMLInputElement>(null)
+  const requestVersionRef = useRef(0)
+  const listboxId = useId()
+  const [query, setQuery] = useState('')
+  const [visibleSessionCount, setVisibleSessionCount] = useState(GLOBAL_SEARCH_PAGE_SIZE)
+  const [artifacts, setArtifacts] = useState<ArtifactState>(emptyArtifactState)
+  const [artifactStatus, setArtifactStatus] = useState<'idle' | 'loading' | 'error'>('idle')
+  const [artifactError, setArtifactError] = useState<string | undefined>()
+  const [failedArtifactCursor, setFailedArtifactCursor] = useState<string | undefined>()
+  const [actionError, setActionError] = useState<string | undefined>()
+  const [activeIndex, setActiveIndex] = useState(0)
+
+  const projects = useProjectStore((state) => state.projects)
+  const sessions = useSessionStore((state) => state.sessions)
+  const activeProjectId = useNavigationStore((state) => state.activeProjectId)
+  const view = useNavigationStore((state) => state.view)
+  const openProject = useNavigationStore((state) => state.openProject)
+  const openSession = useNavigationStore((state) => state.openSession)
+  const requestArtifactMention = useNavigationStore((state) => state.requestArtifactMention)
+  const artifactMentionAvailability = useNavigationStore(
+    (state) => state.artifactMentionAvailability
+  )
+  const openFileDialog = usePreviewWorkbenchStore((state) => state.openFileDialog)
+
+  const primaryProjectId = useMemo(
+    () => activeProjectId ?? resolveCustomizeProjectId(projects),
+    [activeProjectId, projects]
+  )
+  const primaryProject = useMemo(
+    () => projects.find((project) => project.id === primaryProjectId),
+    [primaryProjectId, projects]
+  )
+  const projectNames = useMemo(
+    () => new Map(projects.map((project) => [project.id, project.name])),
+    [projects]
+  )
+  const trimmedQuery = query.trim()
+  const isSearchMode = trimmedQuery.length > 0
+  const otherProjectIds = useMemo(
+    () =>
+      projects.filter((project) => project.id !== primaryProject?.id).map((project) => project.id),
+    [primaryProject?.id, projects]
+  )
+
+  const sessionGroups = useMemo(
+    () =>
+      primaryProject && isSearchMode
+        ? searchSessionTitles({
+            sessions: sessions.map((session) => ({
+              id: session.id,
+              projectId: session.projectId,
+              title: session.title,
+              updatedAt: session.updatedAt,
+              artifactCount: session.artifacts?.length ?? 0,
+              isPending: session.isPending
+            })),
+            projectNames,
+            primaryProjectId: primaryProject.id,
+            query: trimmedQuery,
+            visiblePrimaryCount: visibleSessionCount
+          })
+        : undefined,
+    [isSearchMode, primaryProject, projectNames, sessions, trimmedQuery, visibleSessionCount]
+  )
+  const recentSessions = useMemo(
+    () =>
+      primaryProject
+        ? getRecentSessions(
+            sessions.map((session) => ({
+              id: session.id,
+              projectId: session.projectId,
+              title: session.title,
+              updatedAt: session.updatedAt,
+              artifactCount: session.artifacts?.length ?? 0,
+              isPending: session.isPending
+            })),
+            primaryProject.id
+          ).map((session) => ({
+            ...session,
+            kind: 'session' as const,
+            projectName: primaryProject.name
+          }))
+        : [],
+    [primaryProject, sessions]
+  )
+
+  const reloadArtifacts = useCallback(
+    async (cursor?: string): Promise<void> => {
+      if (!primaryProject) {
+        setArtifacts(emptyArtifactState)
+        return
+      }
+      const version = ++requestVersionRef.current
+      setArtifactStatus('loading')
+      setArtifactError(undefined)
+      setFailedArtifactCursor(undefined)
+      try {
+        const result = await window.api.projectFiles.searchArtifacts({
+          primaryProjectId: primaryProject.id,
+          otherProjectIds,
+          ...(trimmedQuery ? { filenameContains: trimmedQuery } : {}),
+          primaryLimit: GLOBAL_SEARCH_PAGE_SIZE,
+          ...(cursor ? { primaryCursor: cursor } : {}),
+          otherLimit: isSearchMode && !cursor ? 1 : 0
+        })
+        if (version !== requestVersionRef.current) return
+        setArtifacts((current) =>
+          cursor
+            ? {
+                items: [...current.items, ...result.primary.items],
+                totalCount: result.primary.totalCount,
+                nextCursor: result.primary.nextCursor,
+                other: current.other,
+                isIndexComplete: current.isIndexComplete && result.isIndexComplete
+              }
+            : {
+                items: result.primary.items,
+                totalCount: result.primary.totalCount,
+                nextCursor: result.primary.nextCursor,
+                other: result.other,
+                isIndexComplete: result.isIndexComplete
+              }
+        )
+        setArtifactStatus('idle')
+        setFailedArtifactCursor(undefined)
+      } catch (error) {
+        if (version !== requestVersionRef.current) return
+        setArtifactStatus('error')
+        setArtifactError(getErrorMessage(error))
+        setFailedArtifactCursor(cursor)
+      }
+    },
+    [isSearchMode, otherProjectIds, primaryProject, trimmedQuery]
+  )
+
+  useEffect(() => {
+    // IPC cannot be cancelled. Advance the generation before the debounce so a response for the
+    // previous query, Project, or modal lifetime can never overwrite the new result set.
+    requestVersionRef.current += 1
+    if (!open) return
+    if (!isSearchMode) {
+      queueMicrotask(() => void reloadArtifacts())
+      return
+    }
+    const timer = window.setTimeout(() => void reloadArtifacts(), 150)
+    return () => window.clearTimeout(timer)
+  }, [isSearchMode, open, reloadArtifacts, trimmedQuery])
+
+  const handleQueryChange = (nextQuery: string): void => {
+    // Clear synchronously with the input event, before the next debounced Artifact request starts.
+    requestVersionRef.current += 1
+    setQuery(nextQuery)
+    setVisibleSessionCount(GLOBAL_SEARCH_PAGE_SIZE)
+    setArtifacts(emptyArtifactState)
+    setArtifactStatus('idle')
+    setArtifactError(undefined)
+    setFailedArtifactCursor(undefined)
+    setActionError(undefined)
+    setActiveIndex(0)
+  }
+
+  useEffect(() => {
+    if (!open) return
+    window.requestAnimationFrame(() => {
+      inputRef.current?.focus()
+      inputRef.current?.select()
+    })
+  }, [open])
+
+  const sessionMoreCount = sessionGroups
+    ? getNextBatchCount(sessionGroups.primaryTotalCount, sessionGroups.primary.length)
+    : 0
+  const artifactMoreCount = getNextBatchCount(artifacts.totalCount, artifacts.items.length)
+  const canLoadMoreArtifacts =
+    artifactError === undefined && artifactMoreCount > 0 && artifacts.nextCursor !== undefined
+  const selectableRows = useMemo<SelectableRow[]>(() => {
+    if (!primaryProject) return []
+    if (!isSearchMode) {
+      return [
+        ...artifacts.items.map((artifact) => ({ kind: 'artifact' as const, artifact })),
+        ...recentSessions.map((session) => ({ kind: 'session' as const, session })),
+        { kind: 'new-session' as const }
+      ]
+    }
+    return [
+      ...(sessionGroups?.primary.map((session) => ({ kind: 'session' as const, session })) ?? []),
+      ...(sessionMoreCount > 0 ? [{ kind: 'more-sessions' as const }] : []),
+      ...artifacts.items.map((artifact) => ({ kind: 'artifact' as const, artifact })),
+      ...(artifactError ? [{ kind: 'retry-artifacts' as const }] : []),
+      ...(canLoadMoreArtifacts ? [{ kind: 'more-artifacts' as const }] : []),
+      ...(sessionGroups?.other.map((session) => ({ kind: 'session' as const, session })) ?? []),
+      ...artifacts.other.map((artifact) => ({ kind: 'artifact' as const, artifact }))
+    ]
+  }, [
+    canLoadMoreArtifacts,
+    artifacts.items,
+    artifacts.other,
+    artifactError,
+    isSearchMode,
+    primaryProject,
+    recentSessions,
+    sessionGroups?.other,
+    sessionGroups?.primary,
+    sessionMoreCount
+  ])
+
+  const activeRowIndex = Math.max(0, Math.min(activeIndex, selectableRows.length - 1))
+
+  const close = useCallback(() => onOpenChange(false), [onOpenChange])
+  const previewArtifact = useCallback(
+    (artifact: ProjectFileItem): void => {
+      if (activeProjectId !== artifact.projectId || view !== 'workspace') {
+        openProject(artifact.projectId, 'user')
+      }
+      openFileDialog(artifactToPreviewItem(artifact))
+      close()
+    },
+    [activeProjectId, close, openFileDialog, openProject, view]
+  )
+  const mentionArtifact = useCallback(
+    (artifact: ProjectFileItem): void => {
+      if (
+        activeProjectId !== artifact.projectId ||
+        view !== 'workspace' ||
+        artifactMentionAvailability?.projectId !== artifact.projectId ||
+        !artifactMentionAvailability.canMention
+      ) {
+        return
+      }
+      requestArtifactMention(artifact)
+      close()
+    },
+    [activeProjectId, artifactMentionAvailability, close, requestArtifactMention, view]
+  )
+  const activate = useCallback(
+    (row: SelectableRow | undefined, action?: 'mention' | 'preview'): void => {
+      if (!row) return
+      if (row.kind === 'session') {
+        const isStillAvailable = sessions.some(
+          (session) =>
+            session.id === row.session.id &&
+            session.projectId === row.session.projectId &&
+            !session.isPending
+        )
+        if (!isStillAvailable) {
+          setActionError('This session is no longer available.')
+          return
+        }
+        openSession(row.session.projectId, row.session.id, 'user')
+        close()
+        return
+      }
+      if (row.kind === 'artifact') {
+        if (action === 'mention') mentionArtifact(row.artifact)
+        else previewArtifact(row.artifact)
+        return
+      }
+      if (row.kind === 'more-sessions') {
+        setVisibleSessionCount((count) => count + GLOBAL_SEARCH_PAGE_SIZE)
+        return
+      }
+      if (row.kind === 'more-artifacts' && artifacts.nextCursor) {
+        void reloadArtifacts(artifacts.nextCursor)
+        return
+      }
+      if (row.kind === 'retry-artifacts') {
+        void reloadArtifacts(failedArtifactCursor)
+        return
+      }
+      if (row.kind === 'new-session' && primaryProject && isSessionPersistenceReady) {
+        openProject(primaryProject.id, 'user')
+        useSessionStore.getState().clearSelection()
+        close()
+      }
+    },
+    [
+      artifacts.nextCursor,
+      close,
+      failedArtifactCursor,
+      isSessionPersistenceReady,
+      mentionArtifact,
+      openProject,
+      openSession,
+      previewArtifact,
+      primaryProject,
+      reloadArtifacts,
+      sessions
+    ]
+  )
+
+  const handleInputKeyDown = (event: React.KeyboardEvent<HTMLInputElement>): void => {
+    if (event.isDefaultPrevented() || event.nativeEvent.isComposing) return
+    if (event.key === 'ArrowDown' || event.key === 'ArrowUp') {
+      event.preventDefault()
+      if (selectableRows.length === 0) return
+      setActiveIndex((current) => {
+        const normalized = Math.max(0, Math.min(current, selectableRows.length - 1))
+        return event.key === 'ArrowDown'
+          ? (normalized + 1) % selectableRows.length
+          : (normalized - 1 + selectableRows.length) % selectableRows.length
+      })
+      return
+    }
+    if (event.key === 'Home') {
+      event.preventDefault()
+      setActiveIndex(0)
+      return
+    }
+    if (event.key === 'End') {
+      event.preventDefault()
+      setActiveIndex(Math.max(0, selectableRows.length - 1))
+      return
+    }
+    if (event.key === 'Enter') {
+      event.preventDefault()
+      activate(selectableRows[activeRowIndex], event.shiftKey ? 'mention' : 'preview')
+      return
+    }
+    if (event.key === 'Escape') {
+      event.preventDefault()
+      close()
+    }
+  }
+
+  const resultCount = isSearchMode
+    ? (sessionGroups?.primaryTotalCount ?? 0) +
+      artifacts.totalCount +
+      (sessionGroups?.other.length ?? 0) +
+      artifacts.other.length
+    : artifacts.items.length + recentSessions.length + (primaryProject ? 1 : 0)
+  const activeRowId = `global-search-option-${activeRowIndex}`
+
+  const renderSessionRow = (session: SessionSearchResult, rowIndex: number): React.JSX.Element => {
+    const active = rowIndex === activeRowIndex
+    return (
+      <div
+        id={`global-search-option-${rowIndex}`}
+        key={`${session.projectId}:${session.id}`}
+        role="option"
+        tabIndex={-1}
+        aria-selected={active}
+        className={cn(rowClassName, active && 'bg-bg-200 before:opacity-100')}
+        onMouseEnter={() => setActiveIndex(rowIndex)}
+        onClick={() => activate({ kind: 'session', session })}
+      >
+        <MessageCircle className="size-5 shrink-0 text-primary" aria-hidden="true" />
+        <span className="min-w-0 flex-1">
+          <span className="block truncate text-sm font-medium text-foreground">
+            {session.title}
+          </span>
+          <span className="block truncate text-xs text-muted-foreground">
+            {session.projectId !== primaryProject?.id ? `${session.projectName} · ` : ''}
+            {session.artifactCount} artifact{session.artifactCount === 1 ? '' : 's'} ·{' '}
+            {formatRelativeTime(session.updatedAt)}
+          </span>
+        </span>
+        {active ? (
+          <Hash className="size-5 shrink-0 text-foreground" aria-label="Session" />
+        ) : (
+          <span className="rounded bg-primary/15 px-2 py-0.5 text-xs font-medium text-primary">
+            Session
+          </span>
+        )}
+      </div>
+    )
+  }
+
+  const renderArtifactRow = (artifact: ProjectFileItem, rowIndex: number): React.JSX.Element => {
+    const active = rowIndex === activeRowIndex
+    const isCurrentWorkspaceArtifact =
+      view === 'workspace' && activeProjectId === artifact.projectId
+    const canMention =
+      isCurrentWorkspaceArtifact &&
+      artifactMentionAvailability?.projectId === artifact.projectId &&
+      artifactMentionAvailability.canMention
+    return (
+      <div
+        id={`global-search-option-${rowIndex}`}
+        key={`${artifact.projectId}:${artifact.id}:${artifact.sourceVersionId ?? ''}`}
+        role="option"
+        tabIndex={-1}
+        aria-selected={active}
+        className={cn(rowClassName, active && 'bg-bg-200 before:opacity-100')}
+        onMouseEnter={() => setActiveIndex(rowIndex)}
+        onClick={() => previewArtifact(artifact)}
+      >
+        <File className="size-5 shrink-0 text-muted-foreground" aria-hidden="true" />
+        <span className="min-w-0 flex-1">
+          <span className="block truncate text-sm font-medium text-foreground">
+            {artifact.name}
+          </span>
+          <span className="block truncate text-xs text-muted-foreground">
+            {artifact.projectId !== primaryProject?.id
+              ? `${projectNames.get(artifact.projectId) ?? 'Unknown project'} · `
+              : ''}
+            {artifact.originSession?.title ?? 'Unknown session'} ·{' '}
+            {formatRelativeTime(artifact.sortAtMs)}
+          </span>
+        </span>
+        {active ? (
+          <TooltipProvider delayDuration={200}>
+            <span className="flex shrink-0 items-center gap-1">
+              {isCurrentWorkspaceArtifact ? (
+                <Tooltip>
+                  <TooltipTrigger asChild>
+                    <span>
+                      <Button
+                        type="button"
+                        variant="ghost"
+                        size="icon-xs"
+                        tabIndex={-1}
+                        aria-label={`Mention ${artifact.name}`}
+                        disabled={!canMention}
+                        onClick={(event) => {
+                          event.stopPropagation()
+                          mentionArtifact(artifact)
+                        }}
+                      >
+                        <AtSign className="size-4" aria-hidden="true" />
+                      </Button>
+                    </span>
+                  </TooltipTrigger>
+                  <TooltipContent>
+                    {canMention
+                      ? `Mention ${artifact.name}`
+                      : 'Mention is unavailable while the composer cannot accept another artifact.'}
+                  </TooltipContent>
+                </Tooltip>
+              ) : null}
+              <Tooltip>
+                <TooltipTrigger asChild>
+                  <Button
+                    type="button"
+                    variant="ghost"
+                    size="icon-xs"
+                    tabIndex={-1}
+                    aria-label={`Open ${artifact.name}`}
+                    onClick={(event) => {
+                      event.stopPropagation()
+                      previewArtifact(artifact)
+                    }}
+                  >
+                    <ArrowUpRight className="size-4" aria-hidden="true" />
+                  </Button>
+                </TooltipTrigger>
+                <TooltipContent>Open {artifact.name}</TooltipContent>
+              </Tooltip>
+            </span>
+          </TooltipProvider>
+        ) : null}
+      </div>
+    )
+  }
+
+  let rowIndex = 0
+  const nextIndex = (): number => rowIndex++
+
+  return (
+    <Dialog.Root open={open} onOpenChange={onOpenChange}>
+      <Dialog.Portal>
+        <Dialog.Overlay className={dialogOverlayClassName} />
+        <Dialog.Content
+          aria-describedby={undefined}
+          className={dialogPanelClassName(
+            'top-[15vh] flex w-[min(640px,calc(100vw-2rem))] max-w-none -translate-y-0 flex-col overflow-hidden p-0'
+          )}
+        >
+          <Dialog.Title className="sr-only">Command palette</Dialog.Title>
+          <div className="flex shrink-0 items-center gap-3 border-b border-border px-4 py-3">
+            <Search className="size-5 shrink-0 text-muted-foreground" aria-hidden="true" />
+            <Input
+              ref={inputRef}
+              value={query}
+              onChange={(event) => handleQueryChange(event.target.value)}
+              onKeyDown={handleInputKeyDown}
+              role="combobox"
+              aria-autocomplete="list"
+              aria-controls={listboxId}
+              aria-activedescendant={selectableRows.length > 0 ? activeRowId : undefined}
+              placeholder="Search this project…"
+              maxLength={256}
+              className="h-auto min-w-0 flex-1 rounded-none border-0 bg-transparent px-0 text-xl text-foreground placeholder:text-muted-foreground"
+            />
+            {primaryProject ? (
+              <span className="max-w-60 truncate rounded-lg bg-bg-200 px-3 py-1 text-sm font-medium text-muted-foreground">
+                {primaryProject.name}
+              </span>
+            ) : null}
+          </div>
+          <p className="sr-only" aria-live="polite">
+            {resultCount} results
+          </p>
+          {actionError ? (
+            <p role="alert" className="border-b border-border px-4 py-2 text-sm text-destructive">
+              {actionError}
+            </p>
+          ) : null}
+          <ScrollArea className="max-h-[60vh]">
+            <div id={listboxId} role="listbox" className="py-1.5">
+              {!primaryProject ? (
+                <p className="px-4 py-8 text-center text-sm text-muted-foreground">
+                  Create a project to search sessions and artifacts.
+                </p>
+              ) : !isSearchMode ? (
+                <>
+                  {artifacts.items.length > 0 ? (
+                    <section role="group" aria-label="Recent artifacts">
+                      <h2 className={sectionTitleClassName}>Recent artifacts</h2>
+                      {artifacts.items.map((artifact) => renderArtifactRow(artifact, nextIndex()))}
+                    </section>
+                  ) : null}
+                  {recentSessions.length > 0 ? (
+                    <section role="group" aria-label="Recent sessions">
+                      <h2 className={sectionTitleClassName}>Recent sessions</h2>
+                      {recentSessions.map((session) => renderSessionRow(session, nextIndex()))}
+                    </section>
+                  ) : null}
+                  <section role="group" aria-label="Commands">
+                    <h2 className={sectionTitleClassName}>Commands</h2>
+                    <Button
+                      id={`global-search-option-${nextIndex()}`}
+                      type="button"
+                      role="option"
+                      aria-selected={activeRowIndex === rowIndex - 1}
+                      variant="ghost"
+                      disabled={!isSessionPersistenceReady}
+                      className={cn(
+                        rowClassName,
+                        activeRowIndex === rowIndex - 1 && 'bg-bg-200 before:opacity-100',
+                        !isSessionPersistenceReady && 'opacity-50'
+                      )}
+                      onMouseEnter={() => setActiveIndex(rowIndex - 1)}
+                      onClick={() => activate({ kind: 'new-session' })}
+                    >
+                      <MessageCircle className="size-5 text-primary" aria-hidden="true" />
+                      <span className="text-sm font-medium">New session</span>
+                    </Button>
+                  </section>
+                </>
+              ) : (
+                <>
+                  {sessionGroups?.primary.length ? (
+                    <section role="group" aria-label="Sessions">
+                      <h2 className={sectionTitleClassName}>Sessions</h2>
+                      {sessionGroups.primary.map((session) =>
+                        renderSessionRow(session, nextIndex())
+                      )}
+                      {sessionMoreCount > 0 ? (
+                        <Button
+                          id={`global-search-option-${nextIndex()}`}
+                          type="button"
+                          role="option"
+                          aria-selected={activeRowIndex === rowIndex - 1}
+                          variant="ghost"
+                          className={cn(
+                            'flex h-11 w-full items-center px-4 text-left text-sm font-medium text-primary outline-none',
+                            activeRowIndex === rowIndex - 1 && 'bg-bg-200'
+                          )}
+                          onMouseEnter={() => setActiveIndex(rowIndex - 1)}
+                          onClick={() => activate({ kind: 'more-sessions' })}
+                        >
+                          +{sessionMoreCount} more matches — show more
+                        </Button>
+                      ) : null}
+                    </section>
+                  ) : null}
+                  {artifacts.items.length || artifactStatus === 'loading' || artifactError ? (
+                    <section role="group" aria-label="Artifacts">
+                      <h2 className={sectionTitleClassName}>Artifacts</h2>
+                      {artifacts.items.map((artifact) => renderArtifactRow(artifact, nextIndex()))}
+                      {artifactStatus === 'loading' && artifacts.items.length === 0 ? (
+                        <p className="px-4 py-3 text-sm text-muted-foreground">
+                          Searching artifacts…
+                        </p>
+                      ) : null}
+                      {artifactError ? (
+                        <Button
+                          id={`global-search-option-${nextIndex()}`}
+                          type="button"
+                          role="option"
+                          aria-selected={activeRowIndex === rowIndex - 1}
+                          variant="ghost"
+                          className="h-11 px-4 text-sm font-medium text-primary"
+                          onMouseEnter={() => setActiveIndex(rowIndex - 1)}
+                          onClick={() => void reloadArtifacts(failedArtifactCursor)}
+                        >
+                          {failedArtifactCursor
+                            ? 'Could not load more — retry'
+                            : 'Could not load artifacts — retry'}
+                        </Button>
+                      ) : null}
+                      {canLoadMoreArtifacts ? (
+                        <Button
+                          id={`global-search-option-${nextIndex()}`}
+                          type="button"
+                          role="option"
+                          aria-selected={activeRowIndex === rowIndex - 1}
+                          variant="ghost"
+                          disabled={artifactStatus === 'loading'}
+                          className={cn(
+                            'flex h-11 w-full items-center px-4 text-left text-sm font-medium text-primary outline-none disabled:opacity-50',
+                            activeRowIndex === rowIndex - 1 && 'bg-bg-200'
+                          )}
+                          onMouseEnter={() => setActiveIndex(rowIndex - 1)}
+                          onClick={() => activate({ kind: 'more-artifacts' })}
+                        >
+                          +{artifactMoreCount} more matches — show more
+                        </Button>
+                      ) : null}
+                    </section>
+                  ) : null}
+                  {sessionGroups?.other.length || artifacts.other.length ? (
+                    <section role="group" aria-label="Other projects">
+                      <h2 className={sectionTitleClassName}>Other projects</h2>
+                      {sessionGroups?.other.map((session) =>
+                        renderSessionRow(session, nextIndex())
+                      )}
+                      {artifacts.other.map((artifact) => renderArtifactRow(artifact, nextIndex()))}
+                    </section>
+                  ) : null}
+                  {selectableRows.length === 0 && artifactStatus !== 'loading' ? (
+                    <p className="px-4 py-8 text-center text-sm text-muted-foreground">
+                      No sessions or artifacts match “{query}”.
+                    </p>
+                  ) : null}
+                </>
+              )}
+              {!artifacts.isIndexComplete ? (
+                <p className="px-4 py-2 text-xs text-muted-foreground">
+                  Some artifact results may be missing.
+                </p>
+              ) : null}
+            </div>
+          </ScrollArea>
+          <div className="flex shrink-0 items-center gap-4 border-t border-border px-4 py-3 text-xs text-muted-foreground">
+            <span>↑↓ navigate</span>
+            <span>↵ open</span>
+            <span>⇧↵ mention</span>
+            <span>esc close</span>
+          </div>
+        </Dialog.Content>
+      </Dialog.Portal>
+    </Dialog.Root>
+  )
+}

--- a/src/renderer/src/components/global-search/global-search-catalog.test.ts
+++ b/src/renderer/src/components/global-search/global-search-catalog.test.ts
@@ -1,0 +1,84 @@
+import { describe, expect, it } from 'vitest'
+
+import {
+  getNextBatchCount,
+  getRecentSessions,
+  searchSessionTitles,
+  type SearchableSession
+} from './global-search-catalog'
+
+const sessions = (count: number, projectId = 'project-a'): SearchableSession[] =>
+  Array.from({ length: count }, (_, index) => ({
+    id: `session-${index}`,
+    projectId,
+    title: `Python sin ${index}`,
+    updatedAt: 1_000 - index,
+    artifactCount: index,
+    isPending: false
+  }))
+
+describe('global search catalog', () => {
+  it('matches Session titles, partitions other projects, and reveals primary results in batches of eight', () => {
+    const result = searchSessionTitles({
+      sessions: [
+        ...sessions(14),
+        ...sessions(2, 'project-b'),
+        {
+          id: 'pending-match',
+          projectId: 'project-a',
+          title: 'Python sin pending',
+          updatedAt: 2_000,
+          artifactCount: 0,
+          isPending: true
+        },
+        {
+          id: 'body-only',
+          projectId: 'project-a',
+          title: 'Unrelated title',
+          updatedAt: 3_000,
+          artifactCount: 0,
+          isPending: false
+        }
+      ],
+      projectNames: new Map([
+        ['project-a', 'Alpha'],
+        ['project-b', 'Beta']
+      ]),
+      primaryProjectId: 'project-a',
+      query: 'SIN',
+      visiblePrimaryCount: 8
+    })
+
+    expect(result.primary).toHaveLength(8)
+    expect(result.primaryTotalCount).toBe(14)
+    expect(result.other).toEqual([
+      expect.objectContaining({ id: 'session-0', projectId: 'project-b', projectName: 'Beta' })
+    ])
+    expect(getNextBatchCount(result.primaryTotalCount, result.primary.length)).toBe(6)
+  })
+
+  it('returns recent non-pending sessions in recency order with a five-row cap', () => {
+    const recent = getRecentSessions(
+      [
+        ...sessions(7),
+        {
+          id: 'pending',
+          projectId: 'project-a',
+          title: 'Pending',
+          updatedAt: 9_999,
+          artifactCount: 0,
+          isPending: true
+        }
+      ],
+      'project-a'
+    )
+
+    expect(recent.map((session) => session.id)).toEqual([
+      'session-0',
+      'session-1',
+      'session-2',
+      'session-3',
+      'session-4'
+    ])
+  })
+})

--- a/src/renderer/src/components/global-search/global-search-catalog.ts
+++ b/src/renderer/src/components/global-search/global-search-catalog.ts
@@ -1,0 +1,88 @@
+export const GLOBAL_SEARCH_PAGE_SIZE = 8
+export const RECENT_SESSION_LIMIT = 5
+
+export type SearchableSession = {
+  id: string
+  projectId: string
+  title: string
+  updatedAt: number
+  artifactCount: number
+  isPending?: boolean
+}
+
+export type SessionSearchResult = SearchableSession & {
+  kind: 'session'
+  projectName: string
+}
+
+export type SessionSearchGroups = {
+  primary: SessionSearchResult[]
+  primaryTotalCount: number
+  other: SessionSearchResult[]
+}
+
+const foldAsciiCase = (value: string): string =>
+  value.replace(/[A-Z]/g, (character) => character.toLowerCase())
+
+const compareByRecency = (left: SearchableSession, right: SearchableSession): number =>
+  right.updatedAt - left.updatedAt || right.id.localeCompare(left.id)
+
+const toResult = (
+  session: SearchableSession,
+  projectNames: Map<string, string>
+): SessionSearchResult => ({
+  ...session,
+  kind: 'session',
+  projectName: projectNames.get(session.projectId) ?? 'Unknown project'
+})
+
+// Session titles are already hydrated in the renderer. Keep this local filter deliberately narrow
+// so global search does not accidentally become message-body or metadata search.
+export const searchSessionTitles = ({
+  sessions,
+  projectNames,
+  primaryProjectId,
+  query,
+  visiblePrimaryCount
+}: {
+  sessions: SearchableSession[]
+  projectNames: Map<string, string>
+  primaryProjectId: string
+  query: string
+  visiblePrimaryCount: number
+}): SessionSearchGroups => {
+  const foldedQuery = foldAsciiCase(query.trim())
+  const matches = sessions
+    .filter(
+      (session) =>
+        !session.isPending &&
+        projectNames.has(session.projectId) &&
+        foldAsciiCase(session.title).includes(foldedQuery)
+    )
+    .sort(compareByRecency)
+  const primaryMatches = matches.filter((session) => session.projectId === primaryProjectId)
+
+  return {
+    primary: primaryMatches
+      .slice(0, visiblePrimaryCount)
+      .map((session) => toResult(session, projectNames)),
+    primaryTotalCount: primaryMatches.length,
+    other: matches
+      .filter((session) => session.projectId !== primaryProjectId)
+      .slice(0, 1)
+      .map((session) => toResult(session, projectNames))
+  }
+}
+
+export const getRecentSessions = (
+  sessions: SearchableSession[],
+  projectId: string
+): SearchableSession[] =>
+  sessions
+    .filter((session) => session.projectId === projectId && !session.isPending)
+    .sort(compareByRecency)
+    .slice(0, RECENT_SESSION_LIMIT)
+
+// The count advertises what the next click reveals, never every remaining match.
+export const getNextBatchCount = (totalCount: number, visibleCount: number): number =>
+  Math.max(0, Math.min(GLOBAL_SEARCH_PAGE_SIZE, totalCount - visibleCount))

--- a/src/renderer/src/hooks/useUnreadTaskViewSync.ts
+++ b/src/renderer/src/hooks/useUnreadTaskViewSync.ts
@@ -55,7 +55,8 @@ const projectVisibleSessionId = (isSessionContentVisible: boolean): string | und
     !isBlockingOverlayOpen() &&
     navigationState.view === 'workspace' &&
     navigationState.activeProjectId !== undefined &&
-    selectedSession?.projectId === navigationState.activeProjectId
+    selectedSession !== undefined &&
+    selectedSession.projectId === navigationState.activeProjectId
     ? selectedSession.id
     : undefined
 }

--- a/src/renderer/src/lib/preview-persistence/preview-persistence.test.tsx
+++ b/src/renderer/src/lib/preview-persistence/preview-persistence.test.tsx
@@ -453,12 +453,17 @@ describe('usePreviewPersistence per-project save/restore', () => {
       root.render(<PersistenceHarness projectId="project-a" />)
     })
 
+    const fileDialogItem = createStoredFileItem()
+    if (fileDialogItem.type !== 'file') throw new Error('expected a file preview fixture')
     act(() => {
       usePreviewWorkbenchStore.setState({
         panelState: 'open',
         activeItemId: 'file:session-1:/workspace/project/report.md',
-        items: [createStoredFileItem()]
+        items: [fileDialogItem]
       })
+      usePreviewWorkbenchStore
+        .getState()
+        .openFileDialog({ ...fileDialogItem, projectId: 'project-a' })
     })
 
     save.mockClear()
@@ -487,5 +492,6 @@ describe('usePreviewPersistence per-project save/restore', () => {
         ]
       }
     })
+    expect(usePreviewWorkbenchStore.getState().fileDialogItem).toBeUndefined()
   })
 })

--- a/src/renderer/src/lib/preview-persistence/preview-persistence.ts
+++ b/src/renderer/src/lib/preview-persistence/preview-persistence.ts
@@ -157,7 +157,7 @@ export const usePreviewPersistence = (
     }
   }, [activeProjectId, isSessionPersistenceReady])
 
-  // Flush the active project when the workspace unmounts (navigating Home does not change the id).
+  // Flush the active project and close its transient dialog when the workspace unmounts.
   useEffect(
     () => () => {
       const state = usePreviewWorkbenchStore.getState()
@@ -167,6 +167,7 @@ export const usePreviewPersistence = (
           .save({ projectId: state.activeProjectId, state: toPersistedPreviewState(state) })
           .catch(reportPersistenceError)
       }
+      state.closeFileDialog()
     },
     []
   )

--- a/src/renderer/src/pages/workspace/FilePreviewDialog.escape.test.tsx
+++ b/src/renderer/src/pages/workspace/FilePreviewDialog.escape.test.tsx
@@ -1,0 +1,64 @@
+// @vitest-environment jsdom
+import { act } from 'react'
+import { createRoot, type Root } from 'react-dom/client'
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest'
+
+import type { PreviewFileItem } from '@/stores/preview-workbench-store'
+
+;(globalThis as { IS_REACT_ACT_ENVIRONMENT?: boolean }).IS_REACT_ACT_ENVIRONMENT = true
+
+vi.mock('./PreviewFileSurface', () => ({
+  PreviewFileSurface: ({ item, onClose }: { item: PreviewFileItem; onClose: () => void }) => (
+    <button type="button" data-testid="preview-surface" onClick={onClose}>
+      {item.title}
+    </button>
+  )
+}))
+
+import { FilePreviewDialog } from './FilePreviewDialog'
+
+const item: PreviewFileItem = {
+  id: 'preview-1',
+  sessionId: 'session-1',
+  type: 'file',
+  title: 'report.pdf',
+  name: 'report.pdf',
+  path: '/workspace/report.pdf',
+  format: 'pdf',
+  source: 'artifact'
+}
+
+let container: HTMLDivElement
+let root: Root
+
+beforeEach(() => {
+  container = document.createElement('div')
+  container.id = 'root'
+  document.body.appendChild(container)
+  root = createRoot(container)
+})
+
+afterEach(() => {
+  act(() => root.unmount())
+  container.remove()
+  vi.restoreAllMocks()
+})
+
+describe('FilePreviewDialog Escape dismissal', () => {
+  it('closes the artifact preview when Escape is pressed from its content', async () => {
+    const onClose = vi.fn()
+    await act(async () => root.render(<FilePreviewDialog item={item} onClose={onClose} />))
+
+    const surface = document.body.querySelector<HTMLButtonElement>(
+      '[data-testid="preview-surface"]'
+    )
+    surface?.focus()
+    await act(async () => {
+      surface?.dispatchEvent(
+        new KeyboardEvent('keydown', { key: 'Escape', bubbles: true, cancelable: true })
+      )
+    })
+
+    expect(onClose).toHaveBeenCalledOnce()
+  })
+})

--- a/src/renderer/src/pages/workspace/PreviewPanel.tsx
+++ b/src/renderer/src/pages/workspace/PreviewPanel.tsx
@@ -397,7 +397,7 @@ const PreviewFilePanel = ({
 // Tool tabs (files/notebook/reviewer) reuse the same panel/modal layout switch as file previews.
 // The expanded state lives in the workbench store because the expand button is rendered by the
 // tool content itself (ProjectFilesView), not by this chrome. Overlay/panel stay below z-[60] so
-// dialogs opened from inside the tool content (FilePreviewDialog) stack above the modal.
+// workspace-level dialogs such as FilePreviewDialog stack above the modal.
 const PreviewToolPanel = ({ item }: { item: PreviewToolItem }): React.JSX.Element => {
   const isExpanded = usePreviewWorkbenchStore((state) => state.expandedToolItemId === item.id)
   const setToolItemExpanded = usePreviewWorkbenchStore((state) => state.setToolItemExpanded)

--- a/src/renderer/src/pages/workspace/ProjectFilesView.test.tsx
+++ b/src/renderer/src/pages/workspace/ProjectFilesView.test.tsx
@@ -5,6 +5,7 @@ import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest'
 
 import {
   createInitialPreviewWorkbenchState,
+  type PreviewFileItem,
   usePreviewWorkbenchStore
 } from '@/stores/preview-workbench-store'
 import { createInitialComputeState, useComputeStore } from '@/stores/compute-store'
@@ -356,7 +357,11 @@ describe('ProjectFilesView', () => {
     vi.unstubAllGlobals()
   })
 
-  const renderView = async (sessions: ChatSession[], strict = false): Promise<void> => {
+  const renderView = async (
+    sessions: ChatSession[],
+    strict = false,
+    beforeRender?: () => void
+  ): Promise<void> => {
     const { useSessionStore } = await import('@/stores/session-store')
     const { useNavigationStore } = await import('@/stores/navigation-store')
     const { ProjectFilesView } = await import('./ProjectFilesView')
@@ -466,6 +471,7 @@ describe('ProjectFilesView', () => {
     // The view lists only the active project's files; test sessions use the 'default' projectId.
     useNavigationStore.setState({ view: 'workspace', activeProjectId: 'default' })
     root = createRoot(container)
+    beforeRender?.()
     await act(async () => {
       root.render(strict ? <StrictMode>{<ProjectFilesView />}</StrictMode> : <ProjectFilesView />)
       await Promise.resolve()
@@ -2186,6 +2192,45 @@ describe('ProjectFilesView', () => {
     ).toContain('Artifacts')
     expect(nextScrollContainer).not.toBe(scrollContainer)
     expect(nextScrollContainer?.scrollTop).toBe(0)
+  })
+
+  it('preserves queued dialogs and clears only the one owned by the unmounting Files surface', async () => {
+    const otherProjectFile: PreviewFileItem = {
+      id: 'other-artifact',
+      type: 'file',
+      source: 'artifact',
+      projectId: 'other-project',
+      sessionId: 'other-session',
+      title: 'other.png',
+      name: 'other.png',
+      path: '/workspace/other.png',
+      format: 'image',
+      mimeType: 'image/png',
+      size: 1024
+    }
+    const currentProjectFile = { ...otherProjectFile, projectId: 'default' }
+
+    await renderView([], true, () => {
+      usePreviewWorkbenchStore.getState().openFileDialog(currentProjectFile)
+    })
+    expect(usePreviewWorkbenchStore.getState().fileDialogItem).toEqual(currentProjectFile)
+
+    await act(async () => {
+      usePreviewWorkbenchStore.getState().openFileDialog(otherProjectFile)
+    })
+
+    const { useNavigationStore } = await import('@/stores/navigation-store')
+    await act(async () => {
+      useNavigationStore.setState({ activeProjectId: 'other-project' })
+      await Promise.resolve()
+    })
+    expect(usePreviewWorkbenchStore.getState().fileDialogItem).toEqual(otherProjectFile)
+
+    await act(async () => {
+      root.render(<div />)
+      await Promise.resolve()
+    })
+    expect(usePreviewWorkbenchStore.getState().fileDialogItem).toBeUndefined()
   })
 
   it('drops queued thumbnail reads from the previous project during a project switch', async () => {

--- a/src/renderer/src/pages/workspace/ProjectFilesView.test.tsx
+++ b/src/renderer/src/pages/workspace/ProjectFilesView.test.tsx
@@ -3131,7 +3131,7 @@ describe('ProjectFilesView', () => {
     expect(previewSurface?.className).toContain('h-[82px]')
   })
 
-  it('opens an uploaded file in a large dialog without adding a workbench tab', async () => {
+  it('queues an uploaded file dialog without adding a workbench tab', async () => {
     await renderView([
       createSession({
         id: 'session-1',
@@ -3150,27 +3150,23 @@ describe('ProjectFilesView', () => {
         ?.dispatchEvent(new MouseEvent('click', { bubbles: true }))
     })
 
-    const dialog = document.body.querySelector<HTMLElement>('[role="dialog"]')
-    expect(dialog).not.toBeNull()
-    expect(dialog?.className).toContain('h-[90vh]')
-    expect(dialog?.className).toContain('w-[90vw]')
-    expect(dialog?.querySelector('[aria-label="Download user upload.png"]')).not.toBeNull()
-    expect(
-      dialog?.querySelector('[aria-label="Open full screen preview of user upload.png"]')
-    ).toBeNull()
+    expect(usePreviewWorkbenchStore.getState().fileDialogItem).toMatchObject({
+      projectId: 'default',
+      sessionId: 'session-1',
+      source: 'upload',
+      name: 'user upload.png'
+    })
     expect(usePreviewWorkbenchStore.getState().items).toEqual([])
 
     await act(async () => {
-      dialog
-        ?.querySelector<HTMLButtonElement>('[aria-label="Close preview of user upload.png"]')
-        ?.dispatchEvent(new MouseEvent('click', { bubbles: true }))
+      usePreviewWorkbenchStore.getState().closeFileDialog()
     })
 
-    expect(document.body.querySelector('[role="dialog"]')).toBeNull()
+    expect(usePreviewWorkbenchStore.getState().fileDialogItem).toBeUndefined()
     expect(container.querySelector('[data-testid="files-view"]')).not.toBeNull()
   })
 
-  it('opens a generated file in a large dialog without adding a workbench tab', async () => {
+  it('queues a generated file dialog without adding a workbench tab', async () => {
     await renderView([
       createSession({
         id: 'session-1',
@@ -3196,10 +3192,11 @@ describe('ProjectFilesView', () => {
         ?.dispatchEvent(new MouseEvent('click', { bubbles: true }))
     })
 
-    const dialog = document.body.querySelector<HTMLElement>('[role="dialog"]')
-    expect(dialog).not.toBeNull()
-    expect(dialog?.querySelector('[aria-label="Download tree.png"]')).not.toBeNull()
-    expect(dialog?.querySelector('[aria-label="Open full screen preview of tree.png"]')).toBeNull()
+    expect(usePreviewWorkbenchStore.getState().fileDialogItem).toMatchObject({
+      projectId: 'default',
+      sessionId: 'session-1',
+      name: 'tree.png'
+    })
     expect(usePreviewWorkbenchStore.getState().items).toEqual([])
   })
 

--- a/src/renderer/src/pages/workspace/ProjectFilesView.test.tsx
+++ b/src/renderer/src/pages/workspace/ProjectFilesView.test.tsx
@@ -403,6 +403,7 @@ describe('ProjectFilesView', () => {
     })
 
     window.api.projectFiles = {
+      searchArtifacts: vi.fn(),
       getOverview: vi.fn(async (request) => {
         const library = getLibrary()
         const query = request.search

--- a/src/renderer/src/pages/workspace/ProjectFilesView.tsx
+++ b/src/renderer/src/pages/workspace/ProjectFilesView.tsx
@@ -55,7 +55,6 @@ import {
 } from './artifact-preview-utils'
 import { ManagedFileDownloadButton } from './ManagedFileDownloadButton'
 import { createPreviewFileItem } from './preview-file-item'
-import { FilePreviewDialog } from './FilePreviewDialog'
 import type { MessageArtifact } from './preview-file-item'
 import { FileBrowserModal } from '../settings/FileBrowserModal'
 import { getPreviewThumbnailReadEncoding } from './preview-support'
@@ -1034,8 +1033,6 @@ const ProjectFilesViewContent = ({
   const [viewMode, setViewMode] = useState<ProjectFilesViewMode>('grid')
   const [showAllSessionOptions, setShowAllSessionOptions] = useState(false)
   const openFileDialog = usePreviewWorkbenchStore((state) => state.openFileDialog)
-  const fileDialogItem = usePreviewWorkbenchStore((state) => state.fileDialogItem)
-  const closeFileDialog = usePreviewWorkbenchStore((state) => state.closeFileDialog)
   const fileDialogCleanupState = useRef({ version: 0 })
 
   useEffect(() => {
@@ -1747,7 +1744,6 @@ const ProjectFilesViewContent = ({
           </section>
         ) : null}
       </div>
-      <FilePreviewDialog item={fileDialogItem} onClose={closeFileDialog} />
       <FileBrowserModal
         open={browseProviderId !== undefined}
         onClose={() => setBrowseProviderId(undefined)}

--- a/src/renderer/src/pages/workspace/ProjectFilesView.tsx
+++ b/src/renderer/src/pages/workspace/ProjectFilesView.tsx
@@ -31,7 +31,6 @@ import { Input } from '@/components/ui/input'
 import { Tooltip, TooltipContent, TooltipProvider, TooltipTrigger } from '@/components/ui/tooltip'
 import { cn, formatByteSize } from '@/lib/utils'
 import { useNavigationStore } from '@/stores/navigation-store'
-import type { PreviewFileItem } from '@/stores/preview-workbench-store'
 import {
   PROJECT_FILES_PREVIEW_ID,
   usePreviewWorkbenchStore
@@ -56,8 +55,8 @@ import {
 } from './artifact-preview-utils'
 import { ManagedFileDownloadButton } from './ManagedFileDownloadButton'
 import { createPreviewFileItem } from './preview-file-item'
-import type { MessageArtifact } from './preview-file-item'
 import { FilePreviewDialog } from './FilePreviewDialog'
+import type { MessageArtifact } from './preview-file-item'
 import { FileBrowserModal } from '../settings/FileBrowserModal'
 import { getPreviewThumbnailReadEncoding } from './preview-support'
 import { createKeyedRequestReader } from './project-file-preview-queue'
@@ -1034,8 +1033,9 @@ const ProjectFilesViewContent = ({
   const [debouncedSearchQuery, setDebouncedSearchQuery] = useState('')
   const [viewMode, setViewMode] = useState<ProjectFilesViewMode>('grid')
   const [showAllSessionOptions, setShowAllSessionOptions] = useState(false)
-  // Files-tab previews are transient dialog state; opening a file must not create a workbench tab.
-  const [dialogItem, setDialogItem] = useState<PreviewFileItem | undefined>(undefined)
+  const openFileDialog = usePreviewWorkbenchStore((state) => state.openFileDialog)
+  const fileDialogItem = usePreviewWorkbenchStore((state) => state.fileDialogItem)
+  const closeFileDialog = usePreviewWorkbenchStore((state) => state.closeFileDialog)
 
   // Remote file browser modal state — set to a providerId when a REMOTE host is selected.
   const [browseProviderId, setBrowseProviderId] = useState<string | undefined>(undefined)
@@ -1397,7 +1397,7 @@ const ProjectFilesViewContent = ({
 
   const previewFile = (file: ProjectFileItem): void => {
     // Keep the indexed file identity and source so the dialog uses the same bounded preview IPC path.
-    setDialogItem(
+    openFileDialog(
       createPreviewFileItem({
         id: file.id,
         projectId: activeProjectId,
@@ -1729,7 +1729,7 @@ const ProjectFilesViewContent = ({
           </section>
         ) : null}
       </div>
-      <FilePreviewDialog item={dialogItem} onClose={() => setDialogItem(undefined)} />
+      <FilePreviewDialog item={fileDialogItem} onClose={closeFileDialog} />
       <FileBrowserModal
         open={browseProviderId !== undefined}
         onClose={() => setBrowseProviderId(undefined)}

--- a/src/renderer/src/pages/workspace/ProjectFilesView.tsx
+++ b/src/renderer/src/pages/workspace/ProjectFilesView.tsx
@@ -1036,6 +1036,24 @@ const ProjectFilesViewContent = ({
   const openFileDialog = usePreviewWorkbenchStore((state) => state.openFileDialog)
   const fileDialogItem = usePreviewWorkbenchStore((state) => state.fileDialogItem)
   const closeFileDialog = usePreviewWorkbenchStore((state) => state.closeFileDialog)
+  const fileDialogCleanupState = useRef({ version: 0 })
+
+  useEffect(() => {
+    const cleanupState = fileDialogCleanupState.current
+    const cleanupVersion = ++cleanupState.version
+
+    return () => {
+      // StrictMode immediately remounts effects; defer so that pass can cancel this cleanup.
+      queueMicrotask(() => {
+        if (cleanupState.version !== cleanupVersion) return
+
+        const workbench = usePreviewWorkbenchStore.getState()
+        if (workbench.fileDialogItem?.projectId === activeProjectId) {
+          workbench.closeFileDialog()
+        }
+      })
+    }
+  }, [activeProjectId])
 
   // Remote file browser modal state — set to a providerId when a REMOTE host is selected.
   const [browseProviderId, setBrowseProviderId] = useState<string | undefined>(undefined)

--- a/src/renderer/src/pages/workspace/WorkspacePage.preview-panel-resize.test.tsx
+++ b/src/renderer/src/pages/workspace/WorkspacePage.preview-panel-resize.test.tsx
@@ -7,7 +7,7 @@ import type { PanelImperativeHandle, PanelSize } from 'react-resizable-panels'
 
 import {
   createInitialPreviewWorkbenchState,
-  PROJECT_FILES_PREVIEW_ID,
+  type PreviewFileItem,
   usePreviewWorkbenchStore
 } from '@/stores/preview-workbench-store'
 import { useNavigationStore } from '@/stores/navigation-store'
@@ -71,6 +71,10 @@ const motionHarness = vi.hoisted(() => ({
       stop: vi.fn()
     })
   )
+}))
+
+const filePreviewDialogHarness = vi.hoisted(() => ({
+  item: undefined as PreviewFileItem | undefined
 }))
 
 vi.mock('motion', () => ({
@@ -191,6 +195,13 @@ vi.mock('./MobilePreviewSheet', () => ({
   )
 }))
 
+vi.mock('./FilePreviewDialog', () => ({
+  FilePreviewDialog: ({ item }: { item: PreviewFileItem | undefined }): React.JSX.Element => {
+    filePreviewDialogHarness.item = item
+    return <div data-testid="file-preview-dialog" data-open={item ? 'true' : 'false'} />
+  }
+}))
+
 vi.mock('./PreviewPanel', () => ({
   PreviewPanel: ({
     panelRef,
@@ -249,6 +260,7 @@ describe('WorkspacePage preview panel resize sync', () => {
     workspacePageHarness.previewPanelMinSize = undefined
     workspacePageHarness.previewOnResize = undefined
     workspacePageHarness.previewPanelRef = undefined
+    filePreviewDialogHarness.item = undefined
     vi.clearAllMocks()
     vi.spyOn(window, 'requestAnimationFrame').mockImplementation((callback) => {
       callback(0)
@@ -467,7 +479,7 @@ describe('WorkspacePage preview panel resize sync', () => {
     expect(usePreviewWorkbenchStore.getState().panelState).toBe('collapsed')
   })
 
-  it('waits for the target preview slice before consuming a cross-Project file dialog', async () => {
+  it('hosts a cross-Project file dialog without creating or activating a Files tab', async () => {
     const fileDialogItem = {
       id: 'artifact-b',
       projectId: 'project-b',
@@ -487,16 +499,19 @@ describe('WorkspacePage preview panel resize sync', () => {
     await renderPage(false)
 
     expect(usePreviewWorkbenchStore.getState().items).toEqual([])
+    expect(filePreviewDialogHarness.item).toEqual(fileDialogItem)
 
     act(() => usePreviewWorkbenchStore.getState().activateProject('project-b'))
     expect(usePreviewWorkbenchStore.getState()).toMatchObject({
       activeProjectId: 'project-b',
-      activeItemId: PROJECT_FILES_PREVIEW_ID,
+      activeItemId: undefined,
+      items: [],
       fileDialogItem
     })
 
     act(() => usePreviewWorkbenchStore.getState().activateProject('project-c'))
     expect(usePreviewWorkbenchStore.getState().fileDialogItem).toBeUndefined()
+    expect(filePreviewDialogHarness.item).toBeUndefined()
   })
 
   it('uses only background treatment to show the expanded preview toggle state', async () => {

--- a/src/renderer/src/pages/workspace/WorkspacePage.preview-panel-resize.test.tsx
+++ b/src/renderer/src/pages/workspace/WorkspacePage.preview-panel-resize.test.tsx
@@ -7,8 +7,10 @@ import type { PanelImperativeHandle, PanelSize } from 'react-resizable-panels'
 
 import {
   createInitialPreviewWorkbenchState,
+  PROJECT_FILES_PREVIEW_ID,
   usePreviewWorkbenchStore
 } from '@/stores/preview-workbench-store'
+import { useNavigationStore } from '@/stores/navigation-store'
 import { createInitialSessionState, useSessionStore } from '@/stores/session-store'
 
 const workspacePageHarness = vi.hoisted(() => ({
@@ -136,6 +138,10 @@ vi.mock('@/lib/session-persistence/session-persistence', () => ({
   useSessionPersistence: () => true
 }))
 
+vi.mock('@/lib/preview-persistence/preview-persistence', () => ({
+  usePreviewPersistence: vi.fn()
+}))
+
 vi.mock('@/lib/acp/useWorkspaceAgentRuntime', () => ({
   useWorkspaceAgentRuntime: () => ({
     actionError: null,
@@ -230,6 +236,7 @@ describe('WorkspacePage preview panel resize sync', () => {
 
   beforeEach(() => {
     usePreviewWorkbenchStore.setState(createInitialPreviewWorkbenchState())
+    useNavigationStore.setState({ view: 'home', activeProjectId: undefined })
     useSessionStore.setState(createInitialSessionState())
     workspacePageHarness.sidebarSize = 16
     workspacePageHarness.sidebarPanelDefaultSize = undefined
@@ -458,6 +465,38 @@ describe('WorkspacePage preview panel resize sync', () => {
     expect(container.querySelector('[data-testid="workspace-preview-toggle"]')).toBeNull()
     expect(workspacePageHarness.previewPanelDefaultSize).toBe('0%')
     expect(usePreviewWorkbenchStore.getState().panelState).toBe('collapsed')
+  })
+
+  it('waits for the target preview slice before consuming a cross-Project file dialog', async () => {
+    const fileDialogItem = {
+      id: 'artifact-b',
+      projectId: 'project-b',
+      sessionId: 'session-b',
+      type: 'file' as const,
+      title: 'result.png',
+      path: 'artifact-version:project-b/session-b/artifact-b/version-1',
+      format: 'image' as const,
+      name: 'result.png'
+    }
+    useNavigationStore.setState({ view: 'workspace', activeProjectId: 'project-b' })
+    usePreviewWorkbenchStore.setState({
+      activeProjectId: 'project-a',
+      fileDialogItem
+    })
+
+    await renderPage(false)
+
+    expect(usePreviewWorkbenchStore.getState().items).toEqual([])
+
+    act(() => usePreviewWorkbenchStore.getState().activateProject('project-b'))
+    expect(usePreviewWorkbenchStore.getState()).toMatchObject({
+      activeProjectId: 'project-b',
+      activeItemId: PROJECT_FILES_PREVIEW_ID,
+      fileDialogItem
+    })
+
+    act(() => usePreviewWorkbenchStore.getState().activateProject('project-c'))
+    expect(usePreviewWorkbenchStore.getState().fileDialogItem).toBeUndefined()
   })
 
   it('uses only background treatment to show the expanded preview toggle state', async () => {

--- a/src/renderer/src/pages/workspace/WorkspacePage.tsx
+++ b/src/renderer/src/pages/workspace/WorkspacePage.tsx
@@ -52,6 +52,7 @@ import { ConversationPanel } from './ConversationPanel'
 import { DeleteSessionDialog } from './DeleteSessionDialog'
 import { MobilePreviewSheet } from './MobilePreviewSheet'
 import { DownloadSessionArtifactsDialog } from './DownloadSessionArtifactsDialog'
+import { FilePreviewDialog } from './FilePreviewDialog'
 import { PreviewPanel } from './PreviewPanel'
 import { RenameSessionDialog } from './RenameSessionDialog'
 import { SessionNotebookDialog } from './SessionNotebookDialog'
@@ -442,8 +443,8 @@ const WorkspacePage = ({
   )
   const activePreviewItemId = usePreviewWorkbenchStore((state) => state.activeItemId)
   const previewOpenRequestVersion = usePreviewWorkbenchStore((state) => state.openRequestVersion)
-  const previewProjectId = usePreviewWorkbenchStore((state) => state.activeProjectId)
   const fileDialogItem = usePreviewWorkbenchStore((state) => state.fileDialogItem)
+  const closeFileDialog = usePreviewWorkbenchStore((state) => state.closeFileDialog)
   const upsertPreviewItem = usePreviewWorkbenchStore((state) => state.upsertItem)
   const upsertAndActivatePreviewItem = usePreviewWorkbenchStore(
     (state) => state.upsertAndActivateItem
@@ -852,19 +853,6 @@ const WorkspacePage = ({
   // Switches the preview panel to the active project's own tabs (never another project's stale
   // previews) and persists/restores each project's panel state across switches and restarts.
   usePreviewPersistence(activeProjectId, isSessionPersistenceReady)
-
-  // A global Artifact open may arrive before a cross-Project navigation has activated that Project's
-  // preview slice. Once this workspace owns the target Project, reveal Files so its shared dialog can
-  // consume the already-validated immutable preview item.
-  useEffect(() => {
-    if (
-      !fileDialogItem ||
-      fileDialogItem.projectId !== activeProjectId ||
-      previewProjectId !== activeProjectId
-    )
-      return
-    upsertAndActivatePreviewItem(createProjectFilesPreviewItem())
-  }, [activeProjectId, fileDialogItem, previewProjectId, upsertAndActivatePreviewItem])
 
   // Clear the consumed `Chat with agent` prefill intent from the store once it has been applied in the
   // render phase above, so a later normal open starts fresh. (Calling a store action — not a React
@@ -2253,6 +2241,11 @@ const WorkspacePage = ({
       <DownloadSessionArtifactsDialog
         session={sessionToDownloadArtifacts}
         onClose={() => setSessionToDownloadArtifacts(undefined)}
+      />
+
+      <FilePreviewDialog
+        item={fileDialogItem?.projectId === activeProjectId ? fileDialogItem : undefined}
+        onClose={closeFileDialog}
       />
 
       <SessionNotebookDialog

--- a/src/renderer/src/pages/workspace/WorkspacePage.tsx
+++ b/src/renderer/src/pages/workspace/WorkspacePage.tsx
@@ -37,11 +37,14 @@ import type { CompletionHandoffLifecycleEvent } from '../../../../shared/special
 import { planComposerAttachmentIntake } from './composer-attachment-intake'
 import { stageComposerFile, type ComposerUploadTransfer } from './composer-upload-transfer'
 import {
+  appendArtifactMention,
+  docArtifactCount,
   docIsEmpty,
   docToArtifactRefs,
   docToSkillIds,
   docToText,
   emptyDoc,
+  MAX_COMPOSER_ARTIFACT_MENTIONS,
   type ComposerDoc
 } from './composer/composer-doc'
 import { buildCustomizePrefillDoc } from '@/lib/customize-chat'
@@ -393,7 +396,12 @@ const WorkspacePage = ({
   // matches no session and triggers the redirect below.
   const activeProjectId = useNavigationStore((state) => state.activeProjectId)
   const pendingCustomizePrefill = useNavigationStore((state) => state.pendingCustomizePrefill)
+  const pendingArtifactMention = useNavigationStore((state) => state.pendingArtifactMention)
   const consumeCustomizePrefill = useNavigationStore((state) => state.consumeCustomizePrefill)
+  const consumeArtifactMention = useNavigationStore((state) => state.consumeArtifactMention)
+  const setArtifactMentionAvailability = useNavigationStore(
+    (state) => state.setArtifactMentionAvailability
+  )
   const goHome = useNavigationStore((state) => state.goHome)
   const openSettings = useSettingsStore((state) => state.openSettings)
   const activeProviderId = useSettingsStore((state) => state.activeProviderId)
@@ -434,6 +442,7 @@ const WorkspacePage = ({
   )
   const activePreviewItemId = usePreviewWorkbenchStore((state) => state.activeItemId)
   const previewOpenRequestVersion = usePreviewWorkbenchStore((state) => state.openRequestVersion)
+  const fileDialogItem = usePreviewWorkbenchStore((state) => state.fileDialogItem)
   const upsertPreviewItem = usePreviewWorkbenchStore((state) => state.upsertItem)
   const upsertAndActivatePreviewItem = usePreviewWorkbenchStore(
     (state) => state.upsertAndActivateItem
@@ -583,14 +592,17 @@ const WorkspacePage = ({
   // Tracks user-authored mutations separately from optimistic send clearing and conversation switches.
   // A failed prepared send may restore its captured draft only if this version has not advanced.
   const composerDraftVersionsRef = useRef<Record<string, number>>({})
-  const markComposerDraftChanged = (draftKey = previousDraftKeyRef.current): void => {
+  const markComposerDraftChanged = useCallback((draftKey = previousDraftKeyRef.current): void => {
     composerDraftVersionsRef.current[draftKey] =
       (composerDraftVersionsRef.current[draftKey] ?? 0) + 1
-  }
-  const changeComposerDraftDoc = (doc: ComposerDoc): void => {
-    markComposerDraftChanged()
-    setDraftDoc(doc)
-  }
+  }, [])
+  const changeComposerDraftDoc = useCallback(
+    (doc: ComposerDoc): void => {
+      markComposerDraftChanged()
+      setDraftDoc(doc)
+    },
+    [markComposerDraftChanged]
+  )
   const [attachments, setAttachments] = useState<UploadedAttachment[]>([])
   const [attachmentTransfers, setAttachmentTransfers] = useState<ComposerUploadTransfer[]>([])
   const attachmentTransfersRef = useRef<ComposerUploadTransfer[]>([])
@@ -740,6 +752,48 @@ const WorkspacePage = ({
     // Block while the reconfigure barrier is running (async, between Enter and sendMessage). This
     // prevents a second Enter press from racing the first one through the same pending-switch barrier.
     !barrierInFlightSessions.has(activeSession?.id ?? '')
+
+  // Make the composer-owned mention capability available to Global Search without exposing its draft.
+  // The value is transient and Project-scoped; cleanup prevents a stale Project from accepting an
+  // Artifact after navigation.
+  useEffect(() => {
+    if (!activeProjectId) {
+      setArtifactMentionAvailability(undefined)
+      return
+    }
+    setArtifactMentionAvailability({
+      projectId: activeProjectId,
+      canMention: canEditDraft && docArtifactCount(draftDoc) < MAX_COMPOSER_ARTIFACT_MENTIONS
+    })
+    return () => setArtifactMentionAvailability(undefined)
+  }, [activeProjectId, canEditDraft, draftDoc, setArtifactMentionAvailability])
+
+  // Global Search can only request a same-Project mention. Consume it once in the composer owner so
+  // a palette never reaches into this page's local draft state or carries a reference across routing.
+  useEffect(() => {
+    if (!pendingArtifactMention) return
+    const file = consumeArtifactMention()
+    if (!file || file.projectId !== activeProjectId || !canEditDraft) return
+
+    // eslint-disable-next-line react-hooks/set-state-in-effect -- consume a one-shot user intent in its state owner.
+    changeComposerDraftDoc(
+      appendArtifactMention(draftDoc, {
+        id: file.id,
+        name: file.name,
+        path: file.path,
+        source: file.source,
+        mimeType: file.mimeType,
+        versionId: file.sourceVersionId
+      })
+    )
+  }, [
+    activeProjectId,
+    canEditDraft,
+    changeComposerDraftDoc,
+    consumeArtifactMention,
+    draftDoc,
+    pendingArtifactMention
+  ])
   // Re-editing a sent prompt is allowed under the same settled-run conditions as sending, so the
   // resent prompt can never overlap an in-flight turn, permission wait, fix loop, or compaction.
   const canEditMessage =
@@ -797,6 +851,14 @@ const WorkspacePage = ({
   // Switches the preview panel to the active project's own tabs (never another project's stale
   // previews) and persists/restores each project's panel state across switches and restarts.
   usePreviewPersistence(activeProjectId, isSessionPersistenceReady)
+
+  // A global Artifact open may arrive before a cross-Project navigation has activated that Project's
+  // preview slice. Once this workspace owns the target Project, reveal Files so its shared dialog can
+  // consume the already-validated immutable preview item.
+  useEffect(() => {
+    if (!fileDialogItem || fileDialogItem.projectId !== activeProjectId) return
+    upsertAndActivatePreviewItem(createProjectFilesPreviewItem())
+  }, [activeProjectId, fileDialogItem, upsertAndActivatePreviewItem])
 
   // Clear the consumed `Chat with agent` prefill intent from the store once it has been applied in the
   // render phase above, so a later normal open starts fresh. (Calling a store action — not a React

--- a/src/renderer/src/pages/workspace/WorkspacePage.tsx
+++ b/src/renderer/src/pages/workspace/WorkspacePage.tsx
@@ -442,6 +442,7 @@ const WorkspacePage = ({
   )
   const activePreviewItemId = usePreviewWorkbenchStore((state) => state.activeItemId)
   const previewOpenRequestVersion = usePreviewWorkbenchStore((state) => state.openRequestVersion)
+  const previewProjectId = usePreviewWorkbenchStore((state) => state.activeProjectId)
   const fileDialogItem = usePreviewWorkbenchStore((state) => state.fileDialogItem)
   const upsertPreviewItem = usePreviewWorkbenchStore((state) => state.upsertItem)
   const upsertAndActivatePreviewItem = usePreviewWorkbenchStore(
@@ -856,9 +857,14 @@ const WorkspacePage = ({
   // preview slice. Once this workspace owns the target Project, reveal Files so its shared dialog can
   // consume the already-validated immutable preview item.
   useEffect(() => {
-    if (!fileDialogItem || fileDialogItem.projectId !== activeProjectId) return
+    if (
+      !fileDialogItem ||
+      fileDialogItem.projectId !== activeProjectId ||
+      previewProjectId !== activeProjectId
+    )
+      return
     upsertAndActivatePreviewItem(createProjectFilesPreviewItem())
-  }, [activeProjectId, fileDialogItem, upsertAndActivatePreviewItem])
+  }, [activeProjectId, fileDialogItem, previewProjectId, upsertAndActivatePreviewItem])
 
   // Clear the consumed `Chat with agent` prefill intent from the store once it has been applied in the
   // render phase above, so a later normal open starts fresh. (Calling a store action — not a React

--- a/src/renderer/src/pages/workspace/composer/composer-doc.test.ts
+++ b/src/renderer/src/pages/workspace/composer/composer-doc.test.ts
@@ -2,6 +2,7 @@
 import { describe, expect, it } from 'vitest'
 
 import {
+  appendArtifactMention,
   applyDocToDom,
   docArtifactCount,
   docFromMessageParts,
@@ -151,6 +152,51 @@ describe('docArtifactCount', () => {
       ]
     }
     expect(docArtifactCount(doc)).toBe(2)
+  })
+})
+
+describe('appendArtifactMention', () => {
+  it('appends one separating space only when the preceding node is not whitespace', () => {
+    const reference = {
+      id: 'artifact-1',
+      name: 'sin.png',
+      path: 'artifact-version:project-a/session-a/artifact-1/version-1',
+      source: 'artifact' as const,
+      versionId: 'version-1'
+    }
+
+    expect(appendArtifactMention(docFromText('plot'), reference)).toEqual({
+      nodes: [
+        { type: 'text', text: 'plot' },
+        { type: 'text', text: ' ' },
+        { type: 'artifact', ...reference }
+      ]
+    })
+    expect(appendArtifactMention(docFromText('plot '), reference).nodes).toEqual([
+      { type: 'text', text: 'plot ' },
+      { type: 'artifact', ...reference }
+    ])
+  })
+
+  it('does not exceed the Artifact mention cap', () => {
+    const fullDoc: ComposerDoc = {
+      nodes: Array.from({ length: 10 }, (_, index) => ({
+        type: 'artifact' as const,
+        id: `artifact-${index}`,
+        name: `${index}.png`,
+        path: `/artifact-${index}`,
+        source: 'artifact' as const
+      }))
+    }
+
+    expect(
+      appendArtifactMention(fullDoc, {
+        id: 'extra',
+        name: 'extra.png',
+        path: '/extra',
+        source: 'artifact'
+      })
+    ).toBe(fullDoc)
   })
 })
 

--- a/src/renderer/src/pages/workspace/composer/composer-doc.ts
+++ b/src/renderer/src/pages/workspace/composer/composer-doc.ts
@@ -84,6 +84,25 @@ export const docToArtifactRefs = (doc: ComposerDoc): FileReference[] => {
 export const docArtifactCount = (doc: ComposerDoc): number =>
   doc.nodes.reduce((total, node) => (node.type === 'artifact' ? total + 1 : total), 0)
 
+// Adds a complete immutable Artifact reference from a global action without routing it through the
+// contenteditable's caret-based mention trigger. Keep the operation pure so Workspace can preserve
+// its existing per-draft ownership and tests can cover the spacing/cap behavior directly.
+export const appendArtifactMention = (doc: ComposerDoc, reference: FileReference): ComposerDoc => {
+  if (docArtifactCount(doc) >= MAX_COMPOSER_ARTIFACT_MENTIONS) return doc
+
+  const previous = doc.nodes.at(-1)
+  const needsSpace =
+    previous !== undefined && (previous.type !== 'text' || !/\s$/.test(previous.text))
+
+  return {
+    nodes: [
+      ...doc.nodes,
+      ...(needsSpace ? [{ type: 'text' as const, text: ' ' }] : []),
+      { type: 'artifact', ...reference }
+    ]
+  }
+}
+
 // Hydrate a plain-text draft into a single text node; empty text yields the empty doc.
 export const docFromText = (text: string): ComposerDoc =>
   text === '' ? emptyDoc : { nodes: [{ type: 'text', text }] }

--- a/src/renderer/src/stores/navigation-store.test.ts
+++ b/src/renderer/src/stores/navigation-store.test.ts
@@ -33,7 +33,9 @@ beforeEach(() => {
     activeProjectId: undefined,
     userNavigationRevision: 0,
     explicitNavigationRevision: 0,
-    pendingCustomizePrefill: undefined
+    pendingCustomizePrefill: undefined,
+    pendingArtifactMention: undefined,
+    artifactMentionAvailability: undefined
   })
   vi.mocked(recordLastOpenedProject).mockClear()
 })
@@ -180,5 +182,32 @@ describe('navigation store customize conversation', () => {
 
     useNavigationStore.getState().consumeCustomizePrefill()
     expect(useNavigationStore.getState().pendingCustomizePrefill).toBeUndefined()
+  })
+})
+
+describe('navigation store global Artifact actions', () => {
+  it('accepts an Artifact mention only for the active workspace project and clears it after consumption', () => {
+    useNavigationStore.getState().openProject('project-a', 'user')
+    const file = {
+      id: 'artifact-1',
+      source: 'artifact' as const,
+      sourceFileId: 'artifact-1',
+      sourceVersionId: 'version-1',
+      projectId: 'project-a',
+      sessionId: 'session-1',
+      name: 'sin.png',
+      path: 'artifact-version:project-a/session-1/artifact-1/version-1',
+      size: 12,
+      sortAtMs: 1
+    }
+
+    useNavigationStore.getState().requestArtifactMention(file)
+    expect(useNavigationStore.getState().pendingArtifactMention).toMatchObject(file)
+
+    expect(useNavigationStore.getState().consumeArtifactMention()).toMatchObject(file)
+    expect(useNavigationStore.getState().pendingArtifactMention).toBeUndefined()
+
+    useNavigationStore.getState().requestArtifactMention({ ...file, projectId: 'project-b' })
+    expect(useNavigationStore.getState().pendingArtifactMention).toBeUndefined()
   })
 })

--- a/src/renderer/src/stores/navigation-store.ts
+++ b/src/renderer/src/stores/navigation-store.ts
@@ -3,9 +3,17 @@ import { create } from 'zustand'
 import { recordLastOpenedProject } from '@/lib/last-opened-project'
 
 import { useSessionStore } from './session-store'
+import type { ProjectFileItem } from '../../../shared/project-files'
 
 export type NavigationView = 'home' | 'workspace'
 export type NavigationOrigin = 'user' | 'notification' | 'automatic'
+
+// Workspace owns the mutable composer draft. It projects only the capability Global Search needs,
+// avoiding a second draft model or cross-Project mention handoff.
+export type ArtifactMentionAvailability = {
+  projectId: string
+  canMention: boolean
+}
 
 type NavigationStore = {
   view: NavigationView
@@ -19,6 +27,11 @@ type NavigationStore = {
   // Project id targeted by a pending `Chat with agent` prefill, consumed once by WorkspacePage when it
   // opens that project's New Conversation draft. Undefined means no prefill is pending.
   pendingCustomizePrefill: string | undefined
+  // A same-Project Artifact selected from global search. WorkspacePage consumes it once and appends
+  // its immutable Version reference to the currently active composer draft.
+  pendingArtifactMention: ProjectFileItem | undefined
+  // The active Workspace composer publishes whether it can currently accept one more Artifact.
+  artifactMentionAvailability: ArtifactMentionAvailability | undefined
   recordUserNavigation: () => void
   goHome: (origin: NavigationOrigin) => void
   openProject: (projectId: string, origin: NavigationOrigin) => void
@@ -31,6 +44,9 @@ type NavigationStore = {
   // prefill once and clears it.
   startCustomizeConversation: (projectId: string) => void
   consumeCustomizePrefill: () => void
+  requestArtifactMention: (file: ProjectFileItem) => void
+  consumeArtifactMention: () => ProjectFileItem | undefined
+  setArtifactMentionAvailability: (availability: ArtifactMentionAvailability | undefined) => void
 }
 
 const navigationState = (
@@ -67,6 +83,8 @@ export const useNavigationStore = create<NavigationStore>((set) => ({
   userNavigationRevision: 0,
   explicitNavigationRevision: 0,
   pendingCustomizePrefill: undefined,
+  pendingArtifactMention: undefined,
+  artifactMentionAvailability: undefined,
 
   // Records user-owned navigation that changes another store (for example, opening the local New
   // Conversation draft clears Session selection without changing the top-level view).
@@ -143,5 +161,23 @@ export const useNavigationStore = create<NavigationStore>((set) => ({
   },
 
   // Clears the consumed prefill intent so a later normal open starts fresh.
-  consumeCustomizePrefill: () => set({ pendingCustomizePrefill: undefined })
+  consumeCustomizePrefill: () => set({ pendingCustomizePrefill: undefined }),
+
+  // Mentions never route between Projects. Keeping this guard at the Navigation boundary prevents a
+  // dialog caller from leaking an Artifact locator into whichever composer happens to mount next.
+  requestArtifactMention: (file) =>
+    set((state) =>
+      state.view === 'workspace' && state.activeProjectId === file.projectId
+        ? { pendingArtifactMention: file }
+        : state
+    ),
+
+  consumeArtifactMention: () => {
+    const file = useNavigationStore.getState().pendingArtifactMention
+    set({ pendingArtifactMention: undefined })
+    return file
+  },
+
+  setArtifactMentionAvailability: (availability) =>
+    set({ artifactMentionAvailability: availability })
 }))

--- a/src/renderer/src/stores/preview-workbench-store.test.ts
+++ b/src/renderer/src/stores/preview-workbench-store.test.ts
@@ -414,9 +414,20 @@ describe('preview workbench store', () => {
     expect(usePreviewWorkbenchStore.getState().expandedToolItemId).toBeNull()
 
     usePreviewWorkbenchStore.getState().setToolItemExpanded(PROJECT_FILES_PREVIEW_ID)
+    usePreviewWorkbenchStore.getState().openFileDialog({
+      id: 'artifact-1',
+      projectId: 'project-a',
+      sessionId: 'session-1',
+      type: 'file',
+      title: 'result.png',
+      path: 'artifact-version:project-a/session-1/artifact-1/version-1',
+      format: 'image',
+      name: 'result.png'
+    })
     usePreviewWorkbenchStore.getState().removeItem(PROJECT_FILES_PREVIEW_ID)
 
     expect(usePreviewWorkbenchStore.getState().expandedToolItemId).toBeNull()
+    expect(usePreviewWorkbenchStore.getState().fileDialogItem).toBeUndefined()
   })
 
   it('clears the expanded tool item when its session is removed', () => {

--- a/src/renderer/src/stores/preview-workbench-store.test.ts
+++ b/src/renderer/src/stores/preview-workbench-store.test.ts
@@ -30,6 +30,29 @@ describe('preview workbench store', () => {
     })
   })
 
+  it('owns one transient file dialog independent of preview tabs', () => {
+    const item = {
+      id: 'artifact-1',
+      projectId: 'project-a',
+      sessionId: 'session-1',
+      type: 'file' as const,
+      title: 'sin.png',
+      path: 'artifact-version:project-a/session-1/artifact-1/version-1',
+      format: 'image' as const,
+      name: 'sin.png'
+    }
+
+    usePreviewWorkbenchStore.getState().openFileDialog(item)
+
+    expect(usePreviewWorkbenchStore.getState()).toMatchObject({
+      fileDialogItem: item,
+      items: []
+    })
+
+    usePreviewWorkbenchStore.getState().closeFileDialog()
+    expect(usePreviewWorkbenchStore.getState().fileDialogItem).toBeUndefined()
+  })
+
   it('stores file preview items in one ordered list', () => {
     usePreviewWorkbenchStore.getState().upsertAndActivateItem({
       id: 'file:session-1:/workspace/project/report.md',

--- a/src/renderer/src/stores/preview-workbench-store.ts
+++ b/src/renderer/src/stores/preview-workbench-store.ts
@@ -89,6 +89,9 @@ type PreviewWorkbenchStoreData = PreviewSlice & {
   byProject: Record<string, PreviewSlice>
   // Tool tab currently shown as a large modal instead of inline panel content (files tab only).
   expandedToolItemId: string | null
+  // A one-off file preview stays outside the tab list so Files and Global Search can open the same
+  // dialog without creating a durable workbench tab.
+  fileDialogItem: PreviewFileItem | undefined
 }
 
 type PreviewWorkbenchStore = PreviewWorkbenchStoreData & {
@@ -100,6 +103,8 @@ type PreviewWorkbenchStore = PreviewWorkbenchStoreData & {
   removeItem: (itemId: string) => void
   removeSessionItems: (sessionId: string) => void
   setToolItemExpanded: (itemId: string | null) => void
+  openFileDialog: (item: PreviewFileItem) => void
+  closeFileDialog: () => void
   openPanel: () => void
   collapsePanel: () => void
   togglePanel: () => void
@@ -114,7 +119,8 @@ export const createInitialPreviewWorkbenchState = (): PreviewWorkbenchStoreData 
   openRequestVersion: 0,
   activeProjectId: undefined,
   byProject: {},
-  expandedToolItemId: null
+  expandedToolItemId: null,
+  fileDialogItem: undefined
 })
 
 // The empty slice a project starts from before any preview tabs are opened.
@@ -397,6 +403,10 @@ export const usePreviewWorkbenchStore = create<PreviewWorkbenchStore>((set, get)
   setToolItemExpanded: (itemId) => {
     set({ expandedToolItemId: itemId })
   },
+
+  openFileDialog: (item) => set({ fileDialogItem: item }),
+
+  closeFileDialog: () => set({ fileDialogItem: undefined }),
 
   // Records an explicit open request so the resizable panel can expand even if it is already open.
   openPanel: () => {

--- a/src/renderer/src/stores/preview-workbench-store.ts
+++ b/src/renderer/src/stores/preview-workbench-store.ts
@@ -273,7 +273,9 @@ export const usePreviewWorkbenchStore = create<PreviewWorkbenchStore>((set, get)
         panelState: targetSlice.items.length > 0 ? targetSlice.panelState : 'collapsed',
         activeProjectId: projectId,
         byProject,
-        expandedToolItemId: null
+        expandedToolItemId: null,
+        fileDialogItem:
+          state.fileDialogItem?.projectId === projectId ? state.fileDialogItem : undefined
       }
     })
   },

--- a/src/renderer/src/stores/preview-workbench-store.ts
+++ b/src/renderer/src/stores/preview-workbench-store.ts
@@ -372,7 +372,8 @@ export const usePreviewWorkbenchStore = create<PreviewWorkbenchStore>((set, get)
         items,
         activeItemId,
         panelState: items.length > 0 ? state.panelState : 'collapsed',
-        expandedToolItemId: state.expandedToolItemId === itemId ? null : state.expandedToolItemId
+        expandedToolItemId: state.expandedToolItemId === itemId ? null : state.expandedToolItemId,
+        fileDialogItem: itemId === PROJECT_FILES_PREVIEW_ID ? undefined : state.fileDialogItem
       }
     })
   },

--- a/src/shared/project-files.ts
+++ b/src/shared/project-files.ts
@@ -54,6 +54,23 @@ export type ProjectFilesPage = {
   totalCount: number
 }
 
+// Bounded global-search projection. The primary Project is independently paged; Other Projects
+// deliberately return only a small combined sample so the command palette remains responsive.
+export type SearchArtifactsRequest = {
+  primaryProjectId: string
+  otherProjectIds: string[]
+  filenameContains?: string
+  primaryLimit: number
+  primaryCursor?: string
+  otherLimit: 0 | 1
+}
+
+export type SearchArtifactsResult = {
+  primary: ProjectFilesPage
+  other: ProjectFileItem[]
+  isIndexComplete: boolean
+}
+
 export type ListArtifactGroupsRequest = {
   projectId: string
   search?: ProjectFilesSearch

--- a/src/shared/web-api-map.generated.ts
+++ b/src/shared/web-api-map.generated.ts
@@ -84,6 +84,7 @@ export const WEB_INVOKE_CHANNELS = {
   'projectFiles.listArtifactGroups': 'project-files:list-artifact-groups',
   'projectFiles.listFiles': 'project-files:list-files',
   'projectFiles.repairIndex': 'project-files:repair-index',
+  'projectFiles.searchArtifacts': 'project-files:search-artifacts',
   'projects.create': 'projects:create',
   'projects.delete': 'projects:delete',
   'projects.get': 'projects:get',


### PR DESCRIPTION
## Problem

Sessions and generated artifacts cannot currently be found from one project-scoped command palette.

## Proposed change

- Add Cmd+K / Ctrl+K command palette with recent and title/filename search results.
- Page current-project sessions and artifacts in batches of eight; show one combined session and artifact sample from other projects.
- Add direct session navigation, same-project Artifact mention, and cross-project Artifact preview navigation.
- Add the typed Project Files IPC query over existing ManagedFile rows; no new schema or migration.
- Keep results in one bounded scroll plane with a fixed shortcut footer, clickable row affordances, and real ArtifactPreview thumbnails.
- Render Artifact metadata as `source Session · created relative time`: versioned Artifacts use `ArtifactVersion.createdAt`; legacy Artifacts use the linked source Message timestamp and otherwise report that creation time is unavailable.
- Keep the search input visually continuous with its header: no standalone input or header focus frame.
- Preserve modal-level Escape dismissal for both Cmd+K search and Artifact preview, including when row actions or preview content hold focus.
- Route Artifact `Shift+Enter` by context: mention into the selected same-project Session only when its composer can accept the Artifact; otherwise use the normal Open flow. Home, Project drafts without a selected Session, unavailable composers, and cross-project results therefore navigate/open instead of silently doing nothing.
- Prioritize Artifacts for keyword searches: render the Artifact group first, make its first row keyboard-active by default, and keep Artifact rows before Session rows inside Other projects. Empty-query Recent ordering remains unchanged.
- Host one Project-guarded `FilePreviewDialog` at Workspace level so cross-project Artifact opens remain transient and never create, activate, or persist a Files tab; discard transient dialogs owned by a different activated Project.
- Clear the transient file dialog when its Workspace, Files tab, or owning Files surface unmounts, while preserving a dialog queued for a different Project and preserving pre-mount intent under React StrictMode.

## Scope and non-goals

- Generated Artifacts only; uploads, message content, fuzzy search, and cross-project mentions are excluded.
- No new database table, migration, dependency, or parallel design-token system.
- No new IPC contract or persisted store shape for the `Shift+Enter` routing; it reuses the existing selected-Session and mention-availability state.

## Acceptance criteria and validation

The affected interaction checks and static checks below ran after the final material UI change:

- No search focus frame plus Cmd+K and Artifact-preview Escape dismissal -> focused real-dialog renderer tests -> 7/7 pass.
- Artifact `Shift+Enter` routing across Home, Project draft, editable selected Session, unavailable composer, and cross-project contexts -> focused command-palette tests -> 11/11 pass.
- Keyword result ordering, default keyboard selection, and Enter activation of the first Artifact -> focused command-palette tests -> 12/12 pass.
- Artifact source Session fallback, versioned/legacy creation timestamps, hover/click affordance, thumbnails, and fixed-footer/scroll-plane structure -> focused renderer + Project Files repository tests -> 41/41 pass.
- Renderer and Node type safety -> `npm run typecheck` -> pass.
- Generated Web RPC contract -> `npm run check:web-api-map` -> pass.
- Production Web bundle -> `npm run build:web` -> pass.
- Changed-file ESLint -> pass. Latest full-repository lint -> 0 errors; 18 unrelated pre-existing warnings.
- Responsive geometry -> authenticated browser checks at 320/375/414/768 px -> no horizontal overflow, no footer overlap, result region scrollable, row cursor `pointer` and `user-select: none`.
- Workspace-level cross-project dialog hosting with unchanged preview items/selection, plus Files/Global Search and modal lifecycle coverage -> focused tests -> 104/104 pass.
- Workspace and Files-surface teardown cleanup -> focused preview-persistence/workbench/Workspace tests -> 54/54 pass.
- Files-surface owner cleanup, cross-Project queue preservation, and StrictMode pre-mount preservation -> focused Project Files tests -> 63/63 pass.
- Latest branch-wide Vitest run -> 683 files / 10,019 tests passed; 15 files / 184 tests skipped.
- Independent standards and specification reviews -> pass; no blocking issue.

Uncovered risks: this change reuses the existing ArtifactPreview resource lifecycle but does not add a high-volume image/PDF/TIFF scrolling performance test. The truthful `Creation time unavailable` fallback and a legacy Message found only in ConversationGraph are implemented but not separately asserted.

## Review focus

- The fixed header / single result scroll plane / fixed footer structure.
- The intentionally frameless search header and modal-level Escape dismissal coverage.
- ArtifactPreview resource reuse and the generated `projectFiles.searchArtifacts` Web API mapping.
- Artifact source Session and creation-time provenance, especially the legacy Message fallback.
- Cross-project preview handoff and the one-per-type other-project cap.
- Artifact `Shift+Enter` fallback behavior when there is no eligible current Session.
- Keyword-search Artifact-first visual and keyboard ordering.
- Workspace-level transient dialog hosting, unchanged Files-tab selection, and file-dialog Project ownership.
- Transient dialog cleanup when the owning Workspace, Files tab, or Files surface is removed, including StrictMode replay behavior.
- Keyset cursor ownership and stale-result guards.
