### PR TITLE
refactor(acp): move managed workspace into session workflow

### DIFF
--- a/src/main/acp/create-session-workflow.test.ts
+++ b/src/main/acp/create-session-workflow.test.ts
@@ -1,12 +1,27 @@
-import { describe, expect, it, vi } from 'vitest'
+import { describe, expect, it, type Mock, vi } from 'vitest'
 
-import type { AcpCreateSessionRequest } from '../../shared/acp'
+import type { AcpCreateSessionRequest, AcpCreateSessionResponse } from '../../shared/acp'
 import { createAcpCreateSessionWorkflow } from './create-session-workflow'
 import type { ManagedSessionWorkspaceLease } from './managed-session-workspace'
 
-const createHarness = (createSessionResult: 'success' | Error = 'success') => {
+type AcpCreateSessionWorkflowHarness = {
+  workflow: ReturnType<typeof createAcpCreateSessionWorkflow>
+  createSession: Mock<(request: AcpCreateSessionRequest) => Promise<AcpCreateSessionResponse>>
+  lease: ManagedSessionWorkspaceLease
+  workspaces: {
+    acquire: Mock<() => Promise<ManagedSessionWorkspaceLease>>
+  }
+  dataRootWriteCalls: () => number
+  events: string[]
+}
+
+const createHarness = (
+  createSessionResult: 'success' | Error = 'success'
+): AcpCreateSessionWorkflowHarness => {
   const events: string[] = []
-  const createSession = vi.fn(async (request: AcpCreateSessionRequest) => {
+  const createSession = vi.fn<
+    (request: AcpCreateSessionRequest) => Promise<AcpCreateSessionResponse>
+  >(async (request) => {
     events.push('session')
     if (createSessionResult instanceof Error) throw createSessionResult
     return { sessionId: 'session-1', cwd: request.cwd }
@@ -18,8 +33,8 @@ const createHarness = (createSessionResult: 'success' | Error = 'success') => {
       events.push('release')
     })
   }
-  const workspaces = {
-    acquire: vi.fn(async () => {
+  const workspaces: AcpCreateSessionWorkflowHarness['workspaces'] = {
+    acquire: vi.fn<() => Promise<ManagedSessionWorkspaceLease>>(async () => {
       events.push('acquire')
       return lease
     })

--- a/src/main/acp/create-session-workflow.test.ts
+++ b/src/main/acp/create-session-workflow.test.ts
@@ -1,0 +1,112 @@
+import { describe, expect, it, vi } from 'vitest'
+
+import type { AcpCreateSessionRequest } from '../../shared/acp'
+import { createAcpCreateSessionWorkflow } from './create-session-workflow'
+import type { ManagedSessionWorkspaceLease } from './managed-session-workspace'
+
+const createHarness = (createSessionResult: 'success' | Error = 'success') => {
+  const events: string[] = []
+  const createSession = vi.fn(async (request: AcpCreateSessionRequest) => {
+    events.push('session')
+    if (createSessionResult instanceof Error) throw createSessionResult
+    return { sessionId: 'session-1', cwd: request.cwd }
+  })
+  const lease: ManagedSessionWorkspaceLease = {
+    cwd: '/data/workspaces/managed-1',
+    commit: vi.fn(() => events.push('commit')),
+    release: vi.fn(async () => {
+      events.push('release')
+    })
+  }
+  const workspaces = {
+    acquire: vi.fn(async () => {
+      events.push('acquire')
+      return lease
+    })
+  }
+  let dataRootWriteCalls = 0
+  const withDataRootWrite = async <Result>(write: () => Promise<Result>): Promise<Result> => {
+    dataRootWriteCalls += 1
+    events.push('guard:start')
+    try {
+      return await write()
+    } finally {
+      events.push('guard:end')
+    }
+  }
+  const workflow = createAcpCreateSessionWorkflow(
+    { createSession },
+    { workspaces, withDataRootWrite }
+  )
+  return {
+    workflow,
+    createSession,
+    lease,
+    workspaces,
+    dataRootWriteCalls: () => dataRootWriteCalls,
+    events
+  }
+}
+
+describe('ACP create-Session workflow', () => {
+  it('trims and uses an explicit workspace without acquiring managed storage', async () => {
+    const harness = createHarness()
+    const request = {
+      cwd: '  /chosen/workspace  ',
+      projectName: 'project-1',
+      permissionProfile: 'ask' as const
+    }
+
+    await expect(harness.workflow.create(request)).resolves.toEqual({
+      sessionId: 'session-1',
+      cwd: '/chosen/workspace'
+    })
+
+    expect(harness.createSession).toHaveBeenCalledWith({
+      ...request,
+      cwd: '/chosen/workspace'
+    })
+    expect(harness.workspaces.acquire).not.toHaveBeenCalled()
+    expect(harness.dataRootWriteCalls()).toBe(0)
+  })
+
+  it.each([{ cwd: undefined }, { cwd: '   ' }])(
+    'publishes a Session before committing a managed workspace for $cwd',
+    async ({ cwd }) => {
+      const harness = createHarness()
+
+      await expect(
+        harness.workflow.create({ cwd, projectName: 'project-1', permissionProfile: 'ask' })
+      ).resolves.toEqual({
+        sessionId: 'session-1',
+        cwd: harness.lease.cwd
+      })
+
+      expect(harness.createSession).toHaveBeenCalledWith({
+        cwd: harness.lease.cwd,
+        projectName: 'project-1',
+        permissionProfile: 'ask'
+      })
+      expect(harness.events).toEqual([
+        'guard:start',
+        'acquire',
+        'session',
+        'commit',
+        'release',
+        'guard:end'
+      ])
+    }
+  )
+
+  it.each([new Error('session creation failed'), new Error('ACP session startup was superseded')])(
+    'releases a provisional workspace when creation rejects with %s',
+    async (failure) => {
+      const harness = createHarness(failure)
+
+      await expect(harness.workflow.create({ projectName: 'project-1' })).rejects.toBe(failure)
+
+      expect(harness.lease.commit).not.toHaveBeenCalled()
+      expect(harness.events).toEqual(['guard:start', 'acquire', 'session', 'release', 'guard:end'])
+    }
+  )
+})

--- a/src/main/acp/create-session-workflow.ts
+++ b/src/main/acp/create-session-workflow.ts
@@ -1,0 +1,55 @@
+import type { AcpCreateSessionRequest, AcpCreateSessionResponse } from '../../shared/acp'
+import { withDataRootWrite } from '../storage/migration-state'
+import {
+  createManagedSessionWorkspaceCapability,
+  type ManagedSessionWorkspaceCapability
+} from './managed-session-workspace'
+
+type AcpSessionCreator = {
+  createSession(request: AcpCreateSessionRequest): Promise<AcpCreateSessionResponse>
+}
+
+type DataRootWrite = <Result>(write: () => Promise<Result>) => Promise<Result>
+
+type AcpCreateSessionWorkflowDependencies = {
+  workspaces: ManagedSessionWorkspaceCapability
+  withDataRootWrite: DataRootWrite
+}
+
+type AcpCreateSessionWorkflow = {
+  create(request: AcpCreateSessionRequest): Promise<AcpCreateSessionResponse>
+}
+
+// Keeps transport-independent Session startup ordering behind one application seam. Explicit
+// workspaces bypass managed storage; managed workspaces hold the relocation writer guard across
+// allocation, Session publication, and any rollback.
+const createAcpCreateSessionWorkflow = (
+  sessions: AcpSessionCreator,
+  dependencies: Partial<AcpCreateSessionWorkflowDependencies> = {}
+): AcpCreateSessionWorkflow => {
+  const workspaces = dependencies.workspaces ?? createManagedSessionWorkspaceCapability()
+  const runDataRootWrite = dependencies.withDataRootWrite ?? withDataRootWrite
+
+  return {
+    async create(request: AcpCreateSessionRequest): Promise<AcpCreateSessionResponse> {
+      const explicitCwd = request.cwd?.trim()
+      if (explicitCwd) {
+        return sessions.createSession({ ...request, cwd: explicitCwd })
+      }
+
+      return runDataRootWrite(async () => {
+        const workspace = await workspaces.acquire()
+        try {
+          const response = await sessions.createSession({ ...request, cwd: workspace.cwd })
+          workspace.commit()
+          return response
+        } finally {
+          await workspace.release()
+        }
+      })
+    }
+  }
+}
+
+export { createAcpCreateSessionWorkflow }
+export type { AcpCreateSessionWorkflow }

--- a/src/main/acp/ipc.test.ts
+++ b/src/main/acp/ipc.test.ts
@@ -120,6 +120,7 @@ vi.mock('../storage-root', () => ({
 }))
 
 const { createAcpRuntime, installAcpIpcHandlers, registerAcpIpcHandlers } = await import('./ipc')
+const { createAcpCreateSessionWorkflow } = await import('./create-session-workflow')
 type AcpTestOptions = Parameters<typeof registerAcpIpcHandlers>[0]
 
 // Minimal options — createRuntime just forwards them into the mocked AcpRuntime constructor.
@@ -203,7 +204,11 @@ describe('ACP module transport seam', () => {
 
     expect(handlers.size).toBe(0)
 
-    installAcpIpcHandlers(runtime, options.taskNotifications)
+    installAcpIpcHandlers(
+      runtime,
+      createAcpCreateSessionWorkflow(runtime),
+      options.taskNotifications
+    )
 
     expect(handlers.has('acp:get-state')).toBe(true)
     expect(handlers.has('acp:respond-permission')).toBe(true)

--- a/src/main/acp/ipc.test.ts
+++ b/src/main/acp/ipc.test.ts
@@ -464,6 +464,7 @@ describe('registerAcpIpcHandlers — managed session workspace', () => {
     expect(secondRequest.cwd).not.toBe(firstRequest.cwd)
     expect(mkdir).toHaveBeenNthCalledWith(1, firstRequest.cwd, { recursive: true })
     expect(mkdir).toHaveBeenNthCalledWith(2, secondRequest.cwd, { recursive: true })
+    expect(rm).not.toHaveBeenCalled()
     expect(firstResult).toEqual({ sessionId: 's-new', cwd: firstRequest.cwd })
     expect(secondResult).toEqual({ sessionId: 's-new', cwd: secondRequest.cwd })
   })
@@ -576,6 +577,69 @@ describe('registerAcpIpcHandlers — managed session workspace', () => {
     const request = createSession.mock.calls[0][0]
     expect(mkdir).toHaveBeenCalledWith(request.cwd, { recursive: true })
     expect(rm).toHaveBeenCalledWith(request.cwd, { recursive: true, force: true })
+  })
+
+  it('removes a managed workspace when session creation is superseded', async () => {
+    registerWithFakes()
+    const superseded = new Error('ACP session startup was superseded')
+    createSession.mockRejectedValueOnce(superseded)
+
+    await expect(
+      handlers.get('acp:create-session')?.(
+        {},
+        { projectName: 'project-1', permissionProfile: 'ask' }
+      )
+    ).rejects.toBe(superseded)
+
+    const request = createSession.mock.calls[0][0]
+    expect(rm).toHaveBeenCalledWith(request.cwd, { recursive: true, force: true })
+  })
+
+  it('keeps the data-root writer until failed-session workspace rollback finishes', async () => {
+    registerWithFakes()
+    const failure = new Error('session creation failed')
+    createSession.mockRejectedValueOnce(failure)
+    let finishRollback!: () => void
+    rm.mockImplementationOnce(
+      () =>
+        new Promise<void>((resolve) => {
+          finishRollback = resolve
+        })
+    )
+
+    const createPromise = handlers.get('acp:create-session')?.(
+      {},
+      { projectName: 'project-1', permissionProfile: 'ask' }
+    )
+    await vi.waitFor(() => expect(rm).toHaveBeenCalledTimes(1))
+
+    beginMigration()
+    let drained = false
+    const drainPromise = waitForDataRootWriters().then(() => {
+      drained = true
+    })
+    await Promise.resolve()
+
+    expect(drained).toBe(false)
+
+    finishRollback()
+    await expect(createPromise).rejects.toBe(failure)
+    await drainPromise
+    expect(drained).toBe(true)
+  })
+
+  it('keeps the session creation error when managed workspace rollback also fails', async () => {
+    registerWithFakes()
+    const failure = new Error('session creation failed')
+    createSession.mockRejectedValueOnce(failure)
+    rm.mockRejectedValueOnce(new Error('workspace rollback failed'))
+
+    await expect(
+      handlers.get('acp:create-session')?.(
+        {},
+        { projectName: 'project-1', permissionProfile: 'ask' }
+      )
+    ).rejects.toBe(failure)
   })
 })
 

--- a/src/main/acp/ipc.ts
+++ b/src/main/acp/ipc.ts
@@ -1,7 +1,5 @@
 import { createHmac, randomBytes, randomUUID } from 'node:crypto'
-import { mkdir, rm } from 'node:fs/promises'
 import { homedir } from 'node:os'
-import { join } from 'node:path'
 
 import { app } from 'electron'
 
@@ -29,6 +27,10 @@ import type {
 import { DEFAULT_ARTIFACT_PROJECT_NAME } from '../../shared/artifacts'
 import { AcpRuntime, type AcpRuntimeCallbacks } from './runtime'
 import { AcpRuntimeCoordinator } from './runtime-coordinator'
+import {
+  createAcpCreateSessionWorkflow,
+  type AcpCreateSessionWorkflow
+} from './create-session-workflow'
 import { installAgentShutdownGuard } from './shutdown-guard'
 import { AgentMcpHttpHost } from './mcp-http-host'
 import { ArtifactRepository } from '../artifacts/repository'
@@ -50,7 +52,6 @@ import type { UploadRepository } from '../uploads/repository'
 import type { PermissionGrantRegistry } from '../permission-grants/registry'
 import { projectRegistrySessionGrants } from './permission-broker'
 import { broadcastToRenderers } from '../renderer-broadcast'
-import { withDataRootWrite } from '../storage/migration-state'
 import { createLogger, diagnosticErrorFields, errorLogFields } from '../logger'
 import type { ProfileService } from '../specialist/service'
 import {
@@ -174,15 +175,6 @@ type AcpIpcOptions = AcpIpcArtifacts & {
 
 // Sends one runtime payload through the typed application-event compatibility facade.
 const broadcast = broadcastToRenderers
-
-// Gives every new conversation an isolated working directory under the relocatable data root.
-// Persisted sessions keep this returned path as their cwd, so resumes return to the same workspace.
-const createManagedSessionWorkspace = async (): Promise<string> => {
-  const workspace = join(resolveDataRoot(), 'workspaces', randomUUID())
-
-  await mkdir(workspace, { recursive: true })
-  return workspace
-}
 
 // Creates the runtime coordinator used by all ACP IPC handlers and artifact claims. Each child runtime
 // captures one framework generation so sessions on different frameworks can remain live concurrently.
@@ -371,6 +363,7 @@ const createAcpRuntime = ({
 
 const registerAcpIpcHandlerSet = (
   runtime: AcpRuntimeCoordinator,
+  createSessionWorkflow: AcpCreateSessionWorkflow,
   taskNotifications?: TaskNotificationService
 ): void => {
   ipcMainHandle('acp:get-state', () => runtime.getSnapshot())
@@ -378,20 +371,7 @@ const registerAcpIpcHandlerSet = (
   ipcMainHandle('acp:disconnect', () => runtime.disconnect())
   ipcMainHandle('acp:create-session', async (_event, request: AcpCreateSessionRequest) => {
     try {
-      const explicitCwd = request.cwd?.trim()
-      if (explicitCwd) {
-        return await runtime.createSession({ ...request, cwd: explicitCwd })
-      }
-
-      return await withDataRootWrite(async () => {
-        const managedCwd = await createManagedSessionWorkspace()
-        try {
-          return await runtime.createSession({ ...request, cwd: managedCwd })
-        } catch (error) {
-          await rm(managedCwd, { recursive: true, force: true }).catch(() => undefined)
-          throw error
-        }
-      })
+      return await createSessionWorkflow.create(request)
     } catch (error) {
       // Route through the file logger (rotating main.log) so the failure survives in a packaged build,
       // not just the dev console. errorLogFields keeps the message + stack out of a `{}`. Guarded so a
@@ -477,11 +457,12 @@ const registerAcpIpcHandlerSet = (
 // Installs the renderer-callable Electron adapter over an already-constructed ACP coordinator.
 const installAcpIpcHandlers = (
   runtime: AcpRuntimeCoordinator,
+  createSessionWorkflow: AcpCreateSessionWorkflow,
   taskNotifications?: TaskNotificationService
 ): IpcHandlerInstallation => {
   const scope = createIpcHandlerInstallationScope()
   try {
-    registerAcpIpcHandlerSet(runtime, taskNotifications)
+    registerAcpIpcHandlerSet(runtime, createSessionWorkflow, taskNotifications)
     // Kill the agent child on quit so it never outlives the app as an orphaned process.
     return scope.complete(installAgentShutdownGuard(app, runtime))
   } catch (error) {
@@ -493,7 +474,7 @@ const installAcpIpcHandlers = (
 // Compatibility wrapper for isolated callers; application composition uses the two-phase seam above.
 const registerAcpIpcHandlers = (options: AcpIpcOptions): AcpRuntimeCoordinator => {
   const runtime = createAcpRuntime(options)
-  installAcpIpcHandlers(runtime, options.taskNotifications)
+  installAcpIpcHandlers(runtime, createAcpCreateSessionWorkflow(runtime), options.taskNotifications)
   return runtime
 }
 

--- a/src/main/acp/managed-session-workspace.test.ts
+++ b/src/main/acp/managed-session-workspace.test.ts
@@ -1,0 +1,74 @@
+import { join } from 'node:path'
+
+import { describe, expect, it, vi } from 'vitest'
+
+import { createManagedSessionWorkspaceCapability } from './managed-session-workspace'
+
+const createCapability = () => {
+  const createDirectory = vi.fn().mockResolvedValue(undefined)
+  const removeDirectory = vi.fn().mockResolvedValue(undefined)
+  const capability = createManagedSessionWorkspaceCapability({
+    resolveRoot: () => '/relocatable/data',
+    createId: () => 'workspace-id',
+    createDirectory,
+    removeDirectory
+  })
+  return { capability, createDirectory, removeDirectory }
+}
+
+describe('managed Session workspace capability', () => {
+  it('allocates a unique provisional workspace under the current data root', async () => {
+    const { capability, createDirectory } = createCapability()
+
+    const lease = await capability.acquire()
+
+    expect(lease.cwd).toBe(join('/relocatable/data', 'workspaces', 'workspace-id'))
+    expect(createDirectory).toHaveBeenCalledOnce()
+    expect(createDirectory).toHaveBeenCalledWith(lease.cwd)
+  })
+
+  it('resolves the data root when each workspace is acquired', async () => {
+    let dataRoot = '/data-before-relocation'
+    const createDirectory = vi.fn().mockResolvedValue(undefined)
+    const capability = createManagedSessionWorkspaceCapability({
+      resolveRoot: () => dataRoot,
+      createId: () => 'workspace-id',
+      createDirectory
+    })
+    dataRoot = '/data-after-relocation'
+
+    const lease = await capability.acquire()
+
+    expect(lease.cwd).toBe(join(dataRoot, 'workspaces', 'workspace-id'))
+    expect(createDirectory).toHaveBeenCalledWith(lease.cwd)
+  })
+
+  it('releases an uncommitted workspace at most once', async () => {
+    const { capability, removeDirectory } = createCapability()
+    const lease = await capability.acquire()
+
+    await lease.release()
+    await lease.release()
+
+    expect(removeDirectory).toHaveBeenCalledOnce()
+    expect(removeDirectory).toHaveBeenCalledWith(lease.cwd)
+  })
+
+  it('retains a committed workspace when the lease is released', async () => {
+    const { capability, removeDirectory } = createCapability()
+    const lease = await capability.acquire()
+
+    lease.commit()
+    await lease.release()
+
+    expect(removeDirectory).not.toHaveBeenCalled()
+  })
+
+  it('keeps rollback best effort when directory removal fails', async () => {
+    const { capability, removeDirectory } = createCapability()
+    const lease = await capability.acquire()
+    removeDirectory.mockRejectedValueOnce(new Error('remove failed'))
+
+    await expect(lease.release()).resolves.toBeUndefined()
+  })
+})

--- a/src/main/acp/managed-session-workspace.test.ts
+++ b/src/main/acp/managed-session-workspace.test.ts
@@ -1,12 +1,18 @@
 import { join } from 'node:path'
 
-import { describe, expect, it, vi } from 'vitest'
+import { describe, expect, it, type Mock, vi } from 'vitest'
 
 import { createManagedSessionWorkspaceCapability } from './managed-session-workspace'
 
-const createCapability = () => {
-  const createDirectory = vi.fn().mockResolvedValue(undefined)
-  const removeDirectory = vi.fn().mockResolvedValue(undefined)
+type ManagedSessionWorkspaceHarness = {
+  capability: ReturnType<typeof createManagedSessionWorkspaceCapability>
+  createDirectory: Mock<(path: string) => Promise<void>>
+  removeDirectory: Mock<(path: string) => Promise<void>>
+}
+
+const createCapability = (): ManagedSessionWorkspaceHarness => {
+  const createDirectory = vi.fn<(path: string) => Promise<void>>().mockResolvedValue(undefined)
+  const removeDirectory = vi.fn<(path: string) => Promise<void>>().mockResolvedValue(undefined)
   const capability = createManagedSessionWorkspaceCapability({
     resolveRoot: () => '/relocatable/data',
     createId: () => 'workspace-id',

--- a/src/main/acp/managed-session-workspace.ts
+++ b/src/main/acp/managed-session-workspace.ts
@@ -1,0 +1,67 @@
+import { randomUUID } from 'node:crypto'
+import { mkdir, rm } from 'node:fs/promises'
+import { join } from 'node:path'
+
+import { resolveDataRoot } from '../storage-root'
+
+type ManagedSessionWorkspaceLease = {
+  readonly cwd: string
+  commit(): void
+  release(): Promise<void>
+}
+
+type ManagedSessionWorkspaceCapability = {
+  acquire(): Promise<ManagedSessionWorkspaceLease>
+}
+
+type ManagedSessionWorkspaceDependencies = {
+  resolveRoot: () => string
+  createId: () => string
+  createDirectory: (path: string) => Promise<void>
+  removeDirectory: (path: string) => Promise<void>
+}
+
+const defaultDependencies: ManagedSessionWorkspaceDependencies = {
+  resolveRoot: resolveDataRoot,
+  createId: randomUUID,
+  createDirectory: (path) => mkdir(path, { recursive: true }).then(() => undefined),
+  removeDirectory: (path) => rm(path, { recursive: true, force: true })
+}
+
+// Owns the provisional directory from allocation until the application workflow either publishes the
+// Session or releases it. A committed directory becomes ordinary user workspace storage; an
+// uncommitted directory is removed best effort so cleanup can never replace the Session startup error.
+const createManagedSessionWorkspaceCapability = (
+  dependencies: Partial<ManagedSessionWorkspaceDependencies> = {}
+): ManagedSessionWorkspaceCapability => {
+  const resolvedDependencies = { ...defaultDependencies, ...dependencies }
+
+  return {
+    async acquire(): Promise<ManagedSessionWorkspaceLease> {
+      const cwd = join(
+        resolvedDependencies.resolveRoot(),
+        'workspaces',
+        resolvedDependencies.createId()
+      )
+      await resolvedDependencies.createDirectory(cwd)
+
+      let committed = false
+      let released = false
+      return {
+        cwd,
+        commit: () => {
+          if (!released) committed = true
+        },
+        release: async () => {
+          if (released) return
+          released = true
+          if (committed) return
+          await resolvedDependencies.removeDirectory(cwd).catch(() => undefined)
+        }
+      }
+    }
+  }
+}
+
+export { createManagedSessionWorkspaceCapability }
+export type { ManagedSessionWorkspaceCapability, ManagedSessionWorkspaceLease }

--- a/src/main/ipc.ts
+++ b/src/main/ipc.ts
@@ -12,6 +12,7 @@ import {
 import { createApplicationEventModule, type ApplicationEventSource } from './application-events'
 
 import { createAcpRuntime, createDefaultNotebookRuntimeService } from './acp/ipc'
+import { createAcpCreateSessionWorkflow } from './acp/create-session-workflow'
 import { createDefaultArtifactRepository, registerArtifactIpcHandlers } from './artifacts/ipc'
 import { ArtifactProvenanceRepository } from './artifacts/provenance-repository'
 import { ProvenanceMessageSnapshotRepository } from './artifacts/provenance-message-snapshot'
@@ -883,6 +884,7 @@ const createApplicationModules = async (
   )
   surfaceAdapters = afterAcpAdapters
   runtimeRef.current = runtime
+  const createSessionWorkflow = createAcpCreateSessionWorkflow(runtime)
   {
     // Framework-specific adapters declare their own session selector. The registry resolves those
     // selectors before its generic fallback, so registration order cannot route a Codex/OpenCode
@@ -1337,7 +1339,7 @@ const createApplicationModules = async (
       beforeCompute: beforeComputeAdapters,
       compute: computeIpcModule,
       beforeAcp: beforeAcpAdapters,
-      acp: { runtime, taskNotifications },
+      acp: { runtime, createSessionWorkflow, taskNotifications },
       afterAcp: afterAcpAdapters
     }
   }

--- a/src/main/runtime-electron-wiring.test.ts
+++ b/src/main/runtime-electron-wiring.test.ts
@@ -32,6 +32,7 @@ describe('production Electron runtime wiring', () => {
   it('installs the constructed Compute and ACP modules before remaining surfaces', async () => {
     const compute = { handlers: {}, enabledComputeHostsRegistry: {} } as never
     const runtime = {} as never
+    const createSessionWorkflow = {} as never
     const taskNotifications = {} as never
 
     await installElectronRuntimeAdapters({
@@ -54,7 +55,7 @@ describe('production Electron runtime wiring', () => {
           }
         }
       ],
-      acp: { runtime, taskNotifications },
+      acp: { runtime, createSessionWorkflow, taskNotifications },
       afterAcp: [
         {
           name: 'settings',
@@ -67,7 +68,11 @@ describe('production Electron runtime wiring', () => {
     })
 
     expect(installComputeIpcHandlers).toHaveBeenCalledWith(compute)
-    expect(installAcpIpcHandlers).toHaveBeenCalledWith(runtime, taskNotifications)
+    expect(installAcpIpcHandlers).toHaveBeenCalledWith(
+      runtime,
+      createSessionWorkflow,
+      taskNotifications
+    )
     expect(order).toEqual(['notifications', 'compute', 'connectors', 'acp', 'settings'])
   })
 
@@ -75,6 +80,7 @@ describe('production Electron runtime wiring', () => {
     const rollbackOrder: string[] = []
     const compute = { handlers: {}, enabledComputeHostsRegistry: {} } as never
     const runtime = {} as never
+    const createSessionWorkflow = {} as never
     const taskNotifications = {} as never
     installComputeIpcHandlers.mockReturnValueOnce({
       uninstall: vi.fn(() => {
@@ -103,7 +109,7 @@ describe('production Electron runtime wiring', () => {
             }
           }
         ],
-        acp: { runtime, taskNotifications },
+        acp: { runtime, createSessionWorkflow, taskNotifications },
         afterAcp: []
       })
     ).rejects.toThrow('adapter install failed')

--- a/src/main/runtime-electron-wiring.ts
+++ b/src/main/runtime-electron-wiring.ts
@@ -1,4 +1,5 @@
 import { installAcpIpcHandlers } from './acp/ipc'
+import type { AcpCreateSessionWorkflow } from './acp/create-session-workflow'
 import type { AcpRuntimeCoordinator } from './acp/runtime-coordinator'
 import { installComputeIpcHandlers, type ComputeIpcModule } from './compute/ipc'
 import type { TaskNotificationService } from './notifications/task-notifications'
@@ -20,6 +21,7 @@ export type ElectronRuntimeAdapterInterfaces = {
   readonly beforeAcp: readonly NamedElectronSurfaceAdapter[]
   readonly acp: {
     runtime: AcpRuntimeCoordinator
+    createSessionWorkflow: AcpCreateSessionWorkflow
     taskNotifications: TaskNotificationService
   }
   readonly afterAcp: readonly NamedElectronSurfaceAdapter[]
@@ -60,7 +62,9 @@ export const installElectronRuntimeAdapters = async ({
     for (const surface of beforeCompute) await install(surface.name, () => surface.install())
     await install('compute', () => installComputeIpcHandlers(compute))
     for (const surface of beforeAcp) await install(surface.name, () => surface.install())
-    await install('acp', () => installAcpIpcHandlers(acp.runtime, acp.taskNotifications))
+    await install('acp', () =>
+      installAcpIpcHandlers(acp.runtime, acp.createSessionWorkflow, acp.taskNotifications)
+    )
     for (const surface of afterAcp) await install(surface.name, () => surface.install())
   } catch (error) {
     try {


### PR DESCRIPTION
## Problem

The ACP Electron handler currently owns application behavior: trimming explicit workspaces, allocating a managed workspace under the data-root writer guard, publishing the Session, and rolling the provisional directory back on failure. Transport code therefore owns a durable-resource lifecycle.

Related issue: #458 remains forward compatibility only. This pull request adds no orchestration state, persistence, API, event, or user interaction.

## Proposed change

Introduce a managed Session workspace lease capability and a transport-independent create-Session workflow.

```mermaid
flowchart LR
  E["Electron ACP handler"] --> W["CreateSessionWorkflow"]
  W -->|"explicit cwd"| S["Runtime createSession"]
  W -->|"blank / missing cwd"| G["data-root writer guard"]
  G --> L["workspace lease acquire"]
  L --> S
  S -->|"success"| C["commit lease"]
  S -->|"failure / superseded"| R["release provisional workspace"]
```

The Electron handler keeps validation/error logging and delegates the application workflow. The lease capability exclusively owns allocation, commit, and best-effort release.

## Scope and non-goals

- Preserve trimmed, non-empty `cwd` without managed allocation.
- Preserve blank/missing `cwd` allocation under the current data-root writer guard.
- Preserve successful Session publication before lease commit.
- Preserve failed/superseded rollback and ensure cleanup cannot mask the original error.
- Preserve data-root relocation/drain ordering and dynamically resolve the current root at acquire time.
- No workspace path/relationship persistence, data-model, UI, IPC channel/payload/error-envelope, Specialist, Permission, or Compute change.
- Preserve Electron/local Web behavior and remote Web/CLI/Task/local RPC capability asymmetry.

## Acceptance criteria and validation

The full local suite ran on rebased implementation head `6613773` against `origin/main` `4a703c4`. The final test-only static-policy fix at `27cf498` then passed targeted ESLint, 42/42 focused tests, node typecheck, and diff-check; exact-head CI is the merge gate.

- Explicit/blank/missing cwd, success, ordinary failure, supersede, cleanup failure, and data-root drain ordering -> focused workflow/lease/IPC/Web/HTTP suites -> 140/140 passed.
- Node and Web compile compatibility -> `npm run typecheck` -> passed.
- Repository lint -> `npm run lint` -> passed.
- Repository regression suite -> `npm test -- --run` -> passed.
- Added-test static return-type policy -> targeted ESLint on both new harness files -> 0 errors / 0 warnings on `27cf498`.
- Independent review -> Spec: 0 findings; Standards: 0 findings.

Uncovered risk: no manual Electron Session creation was raced against a real on-disk data-root relocation. The existing migration-state, IPC, Web contract, and full repository suites cover the ordering mechanically; exact-head CI remains the merge gate.

## Review focus

- Confirm the writer guard covers allocation, Session publication, commit/release, and rollback completion.
- Confirm cleanup is best effort and cannot replace the Session startup error.
- Confirm the handler is transport-only and all public contracts remain unchanged.
- Confirm the new seam carries no issue #458 orchestration state or persisted relationship.
