### PR TITLE
refactor(task): inject narrow agent execution port

### DIFF
--- a/src/main/acp/task-agent-port.test.ts
+++ b/src/main/acp/task-agent-port.test.ts
@@ -1,0 +1,116 @@
+import { describe, expect, it, vi } from 'vitest'
+
+import { createAcpTaskAgentPort } from './task-agent-port'
+
+describe('ACP Task Agent port', () => {
+  it('translates only the Task execution contract to ACP session operations', async () => {
+    const create = vi.fn(async () => ({
+      sessionId: 'session-created',
+      cwd: '/workspace/created',
+      frameworkId: 'codex' as const,
+      backendId: 'codex:shared'
+    }))
+    const runtime = {
+      getSnapshot: vi.fn(() => ({ sessionIds: ['session-attached'] })),
+      resumeSession: vi.fn(async () => ({
+        sessionId: 'session-resumed',
+        cwd: '/workspace/resumed',
+        frameworkId: 'opencode' as const,
+        backendId: 'opencode:shared',
+        contextReset: true
+      })),
+      setPermissionProfile: vi.fn(async () => undefined),
+      sendPrompt: vi.fn(async () => undefined)
+    }
+    const port = createAcpTaskAgentPort(runtime, { create })
+
+    await expect(port.listAttachedSessionIds()).resolves.toEqual(['session-attached'])
+    await expect(
+      port.createSession({ projectId: 'project-1', permissionProfile: 'auto' })
+    ).resolves.toMatchObject({
+      sessionId: 'session-created',
+      frameworkId: 'codex',
+      backendId: 'codex:shared'
+    })
+    await expect(
+      port.resumeSession({
+        sessionId: 'session-stable',
+        cwd: '/workspace/stable',
+        projectId: 'project-1',
+        permissionProfile: 'ask',
+        previousFrameworkId: 'codex',
+        previousBackendId: 'codex:shared'
+      })
+    ).resolves.toMatchObject({
+      sessionId: 'session-resumed',
+      contextReset: true
+    })
+    await port.setPermissionProfile('session-stable', 'full')
+    await port.prompt({
+      sessionId: 'session-stable',
+      text: 'Continue the research.',
+      skillIds: ['literature-review'],
+      historyPreamble: 'Previous conversation.',
+      resumeFallback: { historyPreamble: 'Fallback conversation.' }
+    })
+
+    expect(create).toHaveBeenCalledWith({
+      projectName: 'project-1',
+      permissionProfile: 'auto'
+    })
+    expect(runtime.resumeSession).toHaveBeenCalledWith({
+      sessionId: 'session-stable',
+      cwd: '/workspace/stable',
+      projectName: 'project-1',
+      permissionProfile: 'ask',
+      previousFrameworkId: 'codex',
+      previousBackendId: 'codex:shared'
+    })
+    expect(runtime.setPermissionProfile).toHaveBeenCalledWith({
+      sessionId: 'session-stable',
+      profile: 'full'
+    })
+    expect(runtime.sendPrompt).toHaveBeenCalledWith({
+      sessionId: 'session-stable',
+      text: 'Continue the research.',
+      forcedSkillIds: ['literature-review'],
+      historyPreamble: 'Previous conversation.',
+      resumeFallback: { historyPreamble: 'Fallback conversation.' }
+    })
+  })
+
+  it('keeps Task prompt notification tracking equivalent on success and failure', async () => {
+    const prompt = {
+      sessionId: 'session-1',
+      text: 'Research this.',
+      skillIds: ['literature-review']
+    }
+    const sendPrompt = vi.fn(async () => undefined)
+    const trackPrompt = vi.fn(() => 'tracked-prompt')
+    const untrackPrompt = vi.fn()
+    const port = createAcpTaskAgentPort(
+      {
+        getSnapshot: () => ({ sessionIds: [] }),
+        resumeSession: vi.fn(),
+        setPermissionProfile: vi.fn(),
+        sendPrompt
+      },
+      { create: vi.fn() },
+      { trackPrompt, untrackPrompt }
+    )
+
+    await port.prompt(prompt)
+
+    expect(trackPrompt).toHaveBeenCalledWith({
+      sessionId: 'session-1',
+      text: 'Research this.',
+      forcedSkillIds: ['literature-review']
+    })
+    expect(untrackPrompt).not.toHaveBeenCalled()
+
+    const failure = new Error('prompt failed')
+    sendPrompt.mockRejectedValueOnce(failure)
+    await expect(port.prompt(prompt)).rejects.toBe(failure)
+    expect(untrackPrompt).toHaveBeenCalledWith('session-1', 'tracked-prompt')
+  })
+})

--- a/src/main/acp/task-agent-port.test.ts
+++ b/src/main/acp/task-agent-port.test.ts
@@ -1,8 +1,19 @@
-import { describe, expect, it, vi } from 'vitest'
+import { describe, expect, expectTypeOf, it, vi } from 'vitest'
 
+import type { TaskAgentPort } from '../tasks/task-runner'
 import { createAcpTaskAgentPort } from './task-agent-port'
 
 describe('ACP Task Agent port', () => {
+  it('exposes only the Task execution capabilities', () => {
+    expectTypeOf<keyof TaskAgentPort>().toEqualTypeOf<
+      | 'listAttachedSessionIds'
+      | 'createSession'
+      | 'resumeSession'
+      | 'setPermissionProfile'
+      | 'prompt'
+    >()
+  })
+
   it('translates only the Task execution contract to ACP session operations', async () => {
     const create = vi.fn(async () => ({
       sessionId: 'session-created',
@@ -86,7 +97,8 @@ describe('ACP Task Agent port', () => {
       skillIds: ['literature-review']
     }
     const sendPrompt = vi.fn(async () => undefined)
-    const trackPrompt = vi.fn(() => 'tracked-prompt')
+    const trackedPrompt = { token: 1 }
+    const trackPrompt = vi.fn(() => trackedPrompt)
     const untrackPrompt = vi.fn()
     const port = createAcpTaskAgentPort(
       {
@@ -111,6 +123,6 @@ describe('ACP Task Agent port', () => {
     const failure = new Error('prompt failed')
     sendPrompt.mockRejectedValueOnce(failure)
     await expect(port.prompt(prompt)).rejects.toBe(failure)
-    expect(untrackPrompt).toHaveBeenCalledWith('session-1', 'tracked-prompt')
+    expect(untrackPrompt).toHaveBeenCalledWith('session-1', trackedPrompt)
   })
 })

--- a/src/main/acp/task-agent-port.ts
+++ b/src/main/acp/task-agent-port.ts
@@ -1,0 +1,64 @@
+import type {
+  AcpCreateSessionResponse,
+  AcpPromptRequest,
+  AcpResumeSessionRequest,
+  AcpSetPermissionProfileRequest
+} from '../../shared/acp'
+import type { TaskNotificationService } from '../notifications/task-notifications'
+import type { TaskAgentPort, TaskAgentPromptRequest } from '../tasks/task-runner'
+import type { AcpCreateSessionWorkflow } from './create-session-workflow'
+
+type AcpTaskAgentRuntime = {
+  getSnapshot(): { sessionIds: string[] }
+  resumeSession(request: AcpResumeSessionRequest): Promise<AcpCreateSessionResponse>
+  setPermissionProfile(request: AcpSetPermissionProfileRequest): Promise<unknown>
+  sendPrompt(request: AcpPromptRequest): Promise<unknown>
+}
+
+type TaskPromptNotifications = Pick<TaskNotificationService, 'trackPrompt' | 'untrackPrompt'>
+
+const toAcpPromptRequest = (request: TaskAgentPromptRequest): AcpPromptRequest => ({
+  sessionId: request.sessionId,
+  text: request.text,
+  ...(request.skillIds?.length ? { forcedSkillIds: request.skillIds } : {}),
+  ...(request.historyPreamble ? { historyPreamble: request.historyPreamble } : {}),
+  ...(request.resumeFallback ? { resumeFallback: request.resumeFallback } : {})
+})
+
+// Adapts the provider-neutral Task seam to the existing ACP owner without exposing the coordinator,
+// renderer commands, Specialist controls, or Compute management to Task automation.
+const createAcpTaskAgentPort = (
+  runtime: AcpTaskAgentRuntime,
+  createSessionWorkflow: AcpCreateSessionWorkflow,
+  notifications?: TaskPromptNotifications
+): TaskAgentPort => ({
+  listAttachedSessionIds: async () => [...runtime.getSnapshot().sessionIds],
+  createSession: (request) =>
+    createSessionWorkflow.create({
+      projectName: request.projectId,
+      permissionProfile: request.permissionProfile
+    }),
+  resumeSession: (request) =>
+    runtime.resumeSession({
+      sessionId: request.sessionId,
+      cwd: request.cwd,
+      projectName: request.projectId,
+      permissionProfile: request.permissionProfile,
+      previousFrameworkId: request.previousFrameworkId,
+      previousBackendId: request.previousBackendId
+    }),
+  setPermissionProfile: (sessionId, profile) =>
+    runtime.setPermissionProfile({ sessionId, profile }).then(() => undefined),
+  prompt: async (request) => {
+    const acpRequest = toAcpPromptRequest(request)
+    const tracked = notifications?.trackPrompt(acpRequest)
+    try {
+      await runtime.sendPrompt(acpRequest)
+    } catch (error) {
+      if (tracked) notifications?.untrackPrompt(acpRequest.sessionId, tracked)
+      throw error
+    }
+  }
+})
+
+export { createAcpTaskAgentPort }

--- a/src/main/index.ts
+++ b/src/main/index.ts
@@ -222,6 +222,7 @@ async function startElectronApp(mainEntryPath: string): Promise<void> {
         applicationEvents,
         taskNotifications,
         settingsService,
+        taskAgent,
         sessionDeletionCapability,
         detectActiveSessions,
         dispose: disposeApplicationRuntime
@@ -295,7 +296,8 @@ async function startElectronApp(mainEntryPath: string): Promise<void> {
         rpc: webRpc,
         requestQuit: () => app.quit(),
         externalAccess: remoteAccess.webAccess,
-        applicationEvents
+        applicationEvents,
+        taskAgent
       })
       remoteAccess.attachWebController(webController)
       registerRemoteAccessIpcHandlers(remoteAccess)

--- a/src/main/ipc.ts
+++ b/src/main/ipc.ts
@@ -13,6 +13,7 @@ import { createApplicationEventModule, type ApplicationEventSource } from './app
 
 import { createAcpRuntime, createDefaultNotebookRuntimeService } from './acp/ipc'
 import { createAcpCreateSessionWorkflow } from './acp/create-session-workflow'
+import { createAcpTaskAgentPort } from './acp/task-agent-port'
 import { createDefaultArtifactRepository, registerArtifactIpcHandlers } from './artifacts/ipc'
 import { ArtifactProvenanceRepository } from './artifacts/provenance-repository'
 import { ProvenanceMessageSnapshotRepository } from './artifacts/provenance-message-snapshot'
@@ -165,6 +166,7 @@ import {
 } from './runtime-electron-wiring'
 import { ConversationSkillImporter, SkillImportApprovalBroker } from './skills/conversation-import'
 import type { ConversationSkillImportApprovalResponse } from '../shared/settings'
+import type { TaskAgentPort } from './tasks/task-runner'
 
 const permissionGrantsLog = createLogger('permission-grants')
 
@@ -189,6 +191,7 @@ export type ApplicationRuntimeInterfaces = {
     'setActivationHandler' | 'setAttentionHandlers' | 'setPendingOpenSession' | 'setUnreadHandler'
   >
   settingsService: WindowSettingsCapabilities
+  taskAgent: TaskAgentPort
   sessionDeletionCapability: Pick<SessionPersistenceCoordinator, 'setSessionDeletionHandlers'>
   detectActiveSessions: () => ReturnType<typeof detectActiveSessions>
 }
@@ -885,6 +888,7 @@ const createApplicationModules = async (
   surfaceAdapters = afterAcpAdapters
   runtimeRef.current = runtime
   const createSessionWorkflow = createAcpCreateSessionWorkflow(runtime)
+  const taskAgent = createAcpTaskAgentPort(runtime, createSessionWorkflow, taskNotifications)
   {
     // Framework-specific adapters declare their own session selector. The registry resolves those
     // selectors before its generic fallback, so registration order cannot route a Codex/OpenCode
@@ -1333,6 +1337,7 @@ const createApplicationModules = async (
     applicationEvents,
     taskNotifications,
     settingsService,
+    taskAgent,
     sessionDeletionCapability: sessionPersistenceCoordinator,
     detectActiveSessions: () => detectActiveSessions({ runtime, notebook: notebookService }),
     electronAdapters: {

--- a/src/main/tasks/task-runner.test.ts
+++ b/src/main/tasks/task-runner.test.ts
@@ -48,7 +48,7 @@ const createRunner = (overrides: Partial<TaskRunnerDependencies> = {}): TaskRunn
       createSession: async () => ({ sessionId: 'session-created' }),
       resumeSession: async (request) => ({ sessionId: request.sessionId }),
       setPermissionProfile: async () => undefined,
-      sendPrompt: async () => undefined
+      prompt: async () => undefined
     },
     artifacts: {
       finalizeRun: async () => ({ ok: true, artifacts: [] })
@@ -216,7 +216,7 @@ describe('TaskRunner', () => {
         }),
         resumeSession: async (request) => ({ sessionId: request.sessionId }),
         setPermissionProfile: async () => undefined,
-        sendPrompt: async () => {
+        prompt: async () => {
           emitEvent?.({
             id: 'event-1',
             timestamp: 10,
@@ -298,7 +298,7 @@ describe('TaskRunner', () => {
         createSession: async () => ({ sessionId: 'unused' }),
         resumeSession: async (request) => ({ sessionId: request.sessionId }),
         setPermissionProfile: async () => undefined,
-        sendPrompt: async () => promptGate
+        prompt: async () => promptGate
       },
       createId: () => ids.shift() ?? 'generated-id'
     })
@@ -351,7 +351,7 @@ describe('TaskRunner', () => {
       ]
     }
     const resumeRequests: Parameters<TaskRunnerDependencies['agent']['resumeSession']>[0][] = []
-    const prompts: Parameters<TaskRunnerDependencies['agent']['sendPrompt']>[0][] = []
+    const prompts: Parameters<TaskRunnerDependencies['agent']['prompt']>[0][] = []
     const ids = ['new-user', 'run-2', 'new-agent']
     const runner = createRunner({
       sessions: { list: async () => [existing], save: async () => undefined },
@@ -363,7 +363,7 @@ describe('TaskRunner', () => {
           return { sessionId: existing.id, cwd: existing.cwd, contextReset: true }
         },
         setPermissionProfile: async () => undefined,
-        sendPrompt: async (request) => {
+        prompt: async (request) => {
           prompts.push(request)
         }
       },
@@ -415,7 +415,7 @@ describe('TaskRunner', () => {
         }
       ]
     }
-    const prompts: Parameters<TaskRunnerDependencies['agent']['sendPrompt']>[0][] = []
+    const prompts: Parameters<TaskRunnerDependencies['agent']['prompt']>[0][] = []
     const ids = ['skill-user', 'skill-run', 'skill-agent']
     const runner = createRunner({
       sessions: { list: async () => [existing], save: async () => undefined },
@@ -424,7 +424,7 @@ describe('TaskRunner', () => {
         createSession: async () => ({ sessionId: 'unused' }),
         resumeSession: async (request) => ({ sessionId: request.sessionId }),
         setPermissionProfile: async () => undefined,
-        sendPrompt: async (request) => {
+        prompt: async (request) => {
           prompts.push(request)
         }
       },
@@ -443,7 +443,7 @@ describe('TaskRunner', () => {
       {
         sessionId: existing.id,
         text: 'Use the selected skill.',
-        forcedSkillIds: ['literature-review'],
+        skillIds: ['literature-review'],
         resumeFallback: {
           historyPreamble:
             'Previous conversation:\n\nUser: Prior question\n\nAssistant: Prior answer'
@@ -468,7 +468,7 @@ describe('TaskRunner', () => {
         createSession: async () => ({ sessionId: 'session-artifact', cwd: '/workspace/artifact' }),
         resumeSession: async (request) => ({ sessionId: request.sessionId }),
         setPermissionProfile: async () => undefined,
-        sendPrompt: async () => {
+        prompt: async () => {
           emitEvent?.({
             id: 'artifact-event',
             timestamp: 10,
@@ -549,7 +549,7 @@ describe('TaskRunner', () => {
         createSession: async () => ({ sessionId: 'session-save', cwd: '/workspace/save' }),
         resumeSession: async (request) => ({ sessionId: request.sessionId }),
         setPermissionProfile: async () => undefined,
-        sendPrompt: async () => {
+        prompt: async () => {
           emitEvent?.({
             id: 'save-event',
             timestamp: 10,
@@ -599,7 +599,7 @@ describe('TaskRunner', () => {
         createSession: async () => ({ sessionId: 'session-partial', cwd: '/workspace/partial' }),
         resumeSession: async (request) => ({ sessionId: request.sessionId }),
         setPermissionProfile: async () => undefined,
-        sendPrompt: async () => {
+        prompt: async () => {
           emitEvent?.({
             id: 'artifact-first',
             timestamp: 10,
@@ -702,7 +702,7 @@ describe('TaskRunner', () => {
         createSession: async () => ({ sessionId: 'session-tool', cwd: '/workspace/tool' }),
         resumeSession: async (request) => ({ sessionId: request.sessionId }),
         setPermissionProfile: async () => undefined,
-        sendPrompt: async () => {
+        prompt: async () => {
           emitEvent?.({
             id: 'tool-start',
             timestamp: 10,
@@ -794,7 +794,7 @@ describe('TaskRunner', () => {
         createSession: async () => ({ sessionId: `session-${++sessionCounter}` }),
         resumeSession: async (request) => ({ sessionId: request.sessionId }),
         setPermissionProfile: async () => undefined,
-        sendPrompt: async () => undefined
+        prompt: async () => undefined
       },
       createId: () => `id-${++idCounter}`,
       now: () => ++time

--- a/src/main/tasks/task-runner.ts
+++ b/src/main/tasks/task-runner.ts
@@ -1,11 +1,4 @@
-import type {
-  AcpCreateSessionRequest,
-  AcpCreateSessionResponse,
-  AcpPromptRequest,
-  AcpResumeSessionRequest,
-  AcpRuntimeEvent,
-  AcpSetPermissionProfileRequest
-} from '../../shared/acp'
+import type { AcpRuntimeEvent } from '../../shared/acp'
 import { getAcpRuntimeEventImage, getAcpRuntimeEventText } from '../../shared/acp'
 import type {
   ArtifactFile,
@@ -14,7 +7,9 @@ import type {
 } from '../../shared/artifacts'
 import { ARTIFACT_OWNERSHIP_PERSISTENCE_RACE } from '../../shared/artifacts'
 import { DEFAULT_PERMISSION_PROFILE } from '../../shared/permission-profiles'
+import type { PermissionProfileId } from '../../shared/permission-profiles'
 import type { Project } from '../../shared/projects'
+import type { AgentFrameworkId } from '../../shared/settings'
 import type {
   PersistedArtifact,
   PersistedChatMessage,
@@ -54,12 +49,42 @@ type TaskPreviewResourcePort = {
   release(resourceId: string): Promise<void>
 }
 
+type TaskAgentSession = {
+  sessionId: string
+  cwd?: string
+  frameworkId?: AgentFrameworkId
+  backendId?: string
+  contextReset?: boolean
+}
+
+type TaskAgentCreateSessionRequest = {
+  projectId: string
+  permissionProfile: PermissionProfileId
+}
+
+type TaskAgentResumeSessionRequest = {
+  sessionId: string
+  cwd: string
+  projectId: string
+  permissionProfile: PermissionProfileId
+  previousFrameworkId?: AgentFrameworkId
+  previousBackendId?: string
+}
+
+type TaskAgentPromptRequest = {
+  sessionId: string
+  text: string
+  skillIds?: string[]
+  historyPreamble?: string
+  resumeFallback?: { historyPreamble?: string }
+}
+
 type TaskAgentPort = {
   listAttachedSessionIds(): Promise<string[]>
-  createSession(request: AcpCreateSessionRequest): Promise<AcpCreateSessionResponse>
-  resumeSession(request: AcpResumeSessionRequest): Promise<AcpCreateSessionResponse>
-  setPermissionProfile(request: AcpSetPermissionProfileRequest): Promise<void>
-  sendPrompt(request: AcpPromptRequest): Promise<void>
+  createSession(request: TaskAgentCreateSessionRequest): Promise<TaskAgentSession>
+  resumeSession(request: TaskAgentResumeSessionRequest): Promise<TaskAgentSession>
+  setPermissionProfile(sessionId: string, profile: PermissionProfileId): Promise<void>
+  prompt(request: TaskAgentPromptRequest): Promise<void>
 }
 
 type TaskArtifactPort = {
@@ -357,21 +382,18 @@ class TaskRunner {
   ): Promise<{
     session: PersistedChatSession
     historyPreamble?: string
-    resumeFallback?: AcpPromptRequest['resumeFallback']
+    resumeFallback?: TaskAgentPromptRequest['resumeFallback']
   }> {
     const now = this.dependencies.now()
     const permissionProfile =
       request.permissionProfile ?? existing?.permissionProfile ?? DEFAULT_PERMISSION_PROFILE
-    let sessionInfo: AcpCreateSessionResponse
+    let sessionInfo: TaskAgentSession
 
     if (existing) {
       const attachedSessionIds = await this.dependencies.agent.listAttachedSessionIds()
       if (attachedSessionIds.includes(existing.id)) {
         if (request.permissionProfile && request.permissionProfile !== existing.permissionProfile) {
-          await this.dependencies.agent.setPermissionProfile({
-            sessionId: existing.id,
-            profile: request.permissionProfile
-          })
+          await this.dependencies.agent.setPermissionProfile(existing.id, request.permissionProfile)
         }
         sessionInfo = {
           sessionId: existing.id,
@@ -383,7 +405,7 @@ class TaskRunner {
         sessionInfo = await this.dependencies.agent.resumeSession({
           sessionId: existing.id,
           cwd: existing.cwd,
-          projectName: project.id,
+          projectId: project.id,
           permissionProfile,
           previousFrameworkId: existing.agentFrameworkId,
           previousBackendId: existing.agentBackendId
@@ -391,7 +413,7 @@ class TaskRunner {
       }
     } else {
       sessionInfo = await this.dependencies.agent.createSession({
-        projectName: project.id,
+        projectId: project.id,
         permissionProfile
       })
     }
@@ -443,14 +465,14 @@ class TaskRunner {
     request: StartTaskRunRequest,
     prompt: string,
     historyPreamble?: string,
-    resumeFallback?: AcpPromptRequest['resumeFallback']
+    resumeFallback?: TaskAgentPromptRequest['resumeFallback']
   ): Promise<void> {
     let promptError: unknown
     try {
-      await this.dependencies.agent.sendPrompt({
+      await this.dependencies.agent.prompt({
         sessionId: session.id,
         text: prompt,
-        ...(request.skillIds?.length ? { forcedSkillIds: request.skillIds } : {}),
+        ...(request.skillIds?.length ? { skillIds: request.skillIds } : {}),
         ...(historyPreamble ? { historyPreamble } : {}),
         ...(resumeFallback ? { resumeFallback } : {})
       })
@@ -693,7 +715,11 @@ class TaskRunner {
 export { TaskRunner, TaskRunnerError, summarizeSession }
 export type {
   CreateTaskProjectRequest,
+  TaskAgentCreateSessionRequest,
   TaskAgentPort,
+  TaskAgentPromptRequest,
+  TaskAgentResumeSessionRequest,
+  TaskAgentSession,
   TaskArtifactPort,
   TaskProjectPort,
   TaskPreviewResourcePort,

--- a/src/main/web-service/controller.test.ts
+++ b/src/main/web-service/controller.test.ts
@@ -36,7 +36,8 @@ const makeController = (
     {
       rpc: {} as WebRpcRouter,
       requestQuit,
-      applicationEvents: new ApplicationEventHub()
+      applicationEvents: new ApplicationEventHub(),
+      taskAgent: {} as never
     },
     {
       startServer,

--- a/src/main/web-service/index.ts
+++ b/src/main/web-service/index.ts
@@ -5,6 +5,7 @@ import { app } from 'electron'
 import type { WebRpcRouter } from '../ipc-handler-registry'
 import { createLogger } from '../logger'
 import type { ApplicationEventSource } from '../application-events'
+import type { TaskAgentPort } from '../tasks/task-runner'
 import { resolveConfigRoot } from '../storage-root'
 import { loadOrCreateWebToken } from './auth'
 import { startWebHttpServer, type ExternalWebAccess, type RunningWebServer } from './http-server'
@@ -64,12 +65,14 @@ const createWebServiceController = (
     rpc,
     requestQuit,
     externalAccess,
-    applicationEvents
+    applicationEvents,
+    taskAgent
   }: {
     rpc: WebRpcRouter
     requestQuit: () => void
     externalAccess?: ExternalWebAccess
     applicationEvents: ApplicationEventSource
+    taskAgent: TaskAgentPort
   },
   deps: Partial<WebServiceControllerDeps> = {}
 ): WebServiceController => {
@@ -91,13 +94,16 @@ const createWebServiceController = (
       },
       pid: process.pid
     }))
-  const tasks = new HeadlessTaskApi(rpc, {
-    subscribeEvents: (listener) =>
-      applicationEvents.subscribe((event) => {
-        const runtimeEvent = projectTaskRuntimeEvent(event)
-        if (runtimeEvent) listener(runtimeEvent)
-      })
-  })
+  const tasks = new HeadlessTaskApi(
+    { rpc, agent: taskAgent },
+    {
+      subscribeEvents: (listener) =>
+        applicationEvents.subscribe((event) => {
+          const runtimeEvent = projectTaskRuntimeEvent(event)
+          if (runtimeEvent) listener(runtimeEvent)
+        })
+    }
+  )
 
   let running:
     | {

--- a/src/main/web-service/task-api.test.ts
+++ b/src/main/web-service/task-api.test.ts
@@ -274,4 +274,31 @@ describe('HeadlessTaskApi adapter', () => {
     )
     expect(invoke.mock.calls.at(-1)?.[1].isAuthorizationCurrent()).toBe(true)
   })
+
+  it('does not enter the direct Agent port after captured remote authorization expires', async () => {
+    let authorizationCurrent = true
+    const invoke = vi.fn(async (channel: string) => {
+      if (channel === 'projects:list') return [project]
+      if (channel === 'sessions:load-all') {
+        authorizationCurrent = false
+        return { sessions: [], manifest: { version: 1 } }
+      }
+      throw new Error(`Unexpected RPC channel: ${channel}`)
+    })
+    const agent = createAgent()
+    const api = new HeadlessTaskApi({ rpc: { invoke }, agent })
+    const context = createTaskCallerContext({
+      location: 'remote',
+      isAuthorizationCurrent: () => authorizationCurrent
+    })
+
+    await expect(
+      api.runWithCallerContext(context, () =>
+        api.startRun({ project: project.id, prompt: 'Research after revocation.' })
+      )
+    ).rejects.toThrow('Caller authorization is no longer current.')
+    expect(agent.listAttachedSessionIds).not.toHaveBeenCalled()
+    expect(agent.createSession).not.toHaveBeenCalled()
+    expect(agent.prompt).not.toHaveBeenCalled()
+  })
 })

--- a/src/main/web-service/task-api.test.ts
+++ b/src/main/web-service/task-api.test.ts
@@ -1,8 +1,9 @@
-import { describe, expect, it, vi } from 'vitest'
+import { describe, expect, it, vi, type MockedFunction } from 'vitest'
 
 import type { AcpRuntimeEvent } from '../../shared/acp'
 import type { PersistedChatSession } from '../../shared/session-persistence'
 import { createTaskCallerContext, type CallerContext } from '../caller-context'
+import type { TaskAgentPort } from '../tasks/task-runner'
 import { HeadlessTaskApi } from './task-api'
 
 const project = {
@@ -23,14 +24,20 @@ const taskCallerContext = (): ReturnType<typeof expect.objectContaining> =>
     actionOrigin: 'automation'
   })
 
-const createAgent = (overrides: Record<string, unknown> = {}) => ({
-  listAttachedSessionIds: vi.fn(async () => [] as string[]),
-  createSession: vi.fn(async () => ({ sessionId: 'session-created' })),
-  resumeSession: vi.fn(async (request: { sessionId: string }) => ({
+type TaskAgentMock = {
+  [Method in keyof TaskAgentPort]: MockedFunction<TaskAgentPort[Method]>
+}
+
+const createAgent = (overrides: Partial<TaskAgentMock> = {}): TaskAgentMock => ({
+  listAttachedSessionIds: vi.fn<TaskAgentPort['listAttachedSessionIds']>(async () => []),
+  createSession: vi.fn<TaskAgentPort['createSession']>(async () => ({
+    sessionId: 'session-created'
+  })),
+  resumeSession: vi.fn<TaskAgentPort['resumeSession']>(async (request) => ({
     sessionId: request.sessionId
   })),
-  setPermissionProfile: vi.fn(async () => undefined),
-  prompt: vi.fn(async () => undefined),
+  setPermissionProfile: vi.fn<TaskAgentPort['setPermissionProfile']>(async () => undefined),
+  prompt: vi.fn<TaskAgentPort['prompt']>(async () => undefined),
   ...overrides
 })
 

--- a/src/main/web-service/task-api.test.ts
+++ b/src/main/web-service/task-api.test.ts
@@ -23,6 +23,17 @@ const taskCallerContext = (): ReturnType<typeof expect.objectContaining> =>
     actionOrigin: 'automation'
   })
 
+const createAgent = (overrides: Record<string, unknown> = {}) => ({
+  listAttachedSessionIds: vi.fn(async () => [] as string[]),
+  createSession: vi.fn(async () => ({ sessionId: 'session-created' })),
+  resumeSession: vi.fn(async (request: { sessionId: string }) => ({
+    sessionId: request.sessionId
+  })),
+  setPermissionProfile: vi.fn(async () => undefined),
+  prompt: vi.fn(async () => undefined),
+  ...overrides
+})
+
 describe('HeadlessTaskApi adapter', () => {
   it('maps public query and artifact commands to the compatibility façade', async () => {
     const session: PersistedChatSession = {
@@ -64,7 +75,7 @@ describe('HeadlessTaskApi adapter', () => {
       if (channel === 'preview-resources:release') return undefined
       throw new Error(`Unexpected RPC channel: ${channel}`)
     })
-    const api = new HeadlessTaskApi({ invoke })
+    const api = new HeadlessTaskApi({ rpc: { invoke }, agent: createAgent() })
 
     await expect(api.createProject({ name: 'Created' })).resolves.toMatchObject({
       id: 'project-created',
@@ -93,7 +104,7 @@ describe('HeadlessTaskApi adapter', () => {
     ])
   })
 
-  it('maps attached-session and artifact-finalization ports to façade channels', async () => {
+  it('uses the direct Agent port for an attached session and keeps artifact finalization on the façade', async () => {
     let emitEvent: ((event: AcpRuntimeEvent) => void) | undefined
     const existing: PersistedChatSession = {
       id: 'session-attached',
@@ -110,10 +121,13 @@ describe('HeadlessTaskApi adapter', () => {
       void callerContext
       if (channel === 'projects:list') return [project]
       if (channel === 'sessions:load-all') return { sessions: [existing], manifest: { version: 1 } }
-      if (channel === 'acp:get-state') return { sessionIds: [existing.id] }
-      if (channel === 'acp:set-permission-profile') return undefined
       if (channel === 'sessions:save-session') return undefined
-      if (channel === 'acp:send-prompt') {
+      if (channel === 'artifacts:finalize-run') return { ok: true, artifacts: [] }
+      throw new Error(`Unexpected RPC channel: ${channel} ${JSON.stringify(args)}`)
+    })
+    const agent = createAgent({
+      listAttachedSessionIds: vi.fn(async () => [existing.id]),
+      prompt: vi.fn(async () => {
         emitEvent?.({
           id: 'artifact-event',
           timestamp: 10,
@@ -123,14 +137,11 @@ describe('HeadlessTaskApi adapter', () => {
           artifactClaimId: 'artifact-claim',
           artifacts: []
         })
-        return undefined
-      }
-      if (channel === 'artifacts:finalize-run') return { ok: true, artifacts: [] }
-      throw new Error(`Unexpected RPC channel: ${channel} ${JSON.stringify(args)}`)
+      })
     })
     const ids = ['attached-user', 'attached-run', 'attached-agent']
     const api = new HeadlessTaskApi(
-      { invoke },
+      { rpc: { invoke }, agent },
       {
         createId: () => ids.shift() ?? 'generated-id',
         subscribeEvents: (listener) => {
@@ -148,16 +159,19 @@ describe('HeadlessTaskApi adapter', () => {
     })
     await api.waitForRun(run.id)
 
-    expect(invoke).toHaveBeenCalledWith('acp:get-state', taskCallerContext(), [])
-    expect(invoke).toHaveBeenCalledWith('acp:set-permission-profile', taskCallerContext(), [
-      { sessionId: existing.id, profile: 'auto' }
-    ])
+    expect(agent.listAttachedSessionIds).toHaveBeenCalledOnce()
+    expect(agent.setPermissionProfile).toHaveBeenCalledWith(existing.id, 'auto')
+    expect(agent.prompt).toHaveBeenCalledWith({
+      sessionId: existing.id,
+      text: 'Continue research.'
+    })
+    expect(invoke.mock.calls.every(([channel]) => !String(channel).startsWith('acp:'))).toBe(true)
     expect(invoke).toHaveBeenCalledWith('artifacts:finalize-run', taskCallerContext(), [
       { claimId: 'artifact-claim', messageId: 'attached-agent' }
     ])
   })
 
-  it('maps detached-session resume to the façade with its durable Agent binding', async () => {
+  it('resumes a detached session through the direct Agent port with its durable binding', async () => {
     const existing: PersistedChatSession = {
       id: 'session-detached',
       projectId: project.id,
@@ -175,15 +189,17 @@ describe('HeadlessTaskApi adapter', () => {
       void callerContext
       if (channel === 'projects:list') return [project]
       if (channel === 'sessions:load-all') return { sessions: [existing], manifest: { version: 1 } }
-      if (channel === 'acp:get-state') return { sessionIds: [] }
-      if (channel === 'acp:resume-session') {
-        return { sessionId: existing.id, cwd: existing.cwd }
-      }
-      if (channel === 'sessions:save-session' || channel === 'acp:send-prompt') return undefined
+      if (channel === 'sessions:save-session') return undefined
       throw new Error(`Unexpected RPC channel: ${channel} ${JSON.stringify(args)}`)
     })
+    const agent = createAgent({
+      resumeSession: vi.fn(async () => ({ sessionId: existing.id, cwd: existing.cwd }))
+    })
     const ids = ['detached-user', 'detached-run', 'detached-agent']
-    const api = new HeadlessTaskApi({ invoke }, { createId: () => ids.shift() ?? 'generated-id' })
+    const api = new HeadlessTaskApi(
+      { rpc: { invoke }, agent },
+      { createId: () => ids.shift() ?? 'generated-id' }
+    )
 
     const run = await api.startRun({
       project: project.id,
@@ -192,16 +208,15 @@ describe('HeadlessTaskApi adapter', () => {
     })
     await api.waitForRun(run.id)
 
-    expect(invoke).toHaveBeenCalledWith('acp:resume-session', taskCallerContext(), [
-      {
-        sessionId: existing.id,
-        cwd: existing.cwd,
-        projectName: project.id,
-        permissionProfile: 'ask',
-        previousFrameworkId: 'codex',
-        previousBackendId: 'codex:shared'
-      }
-    ])
+    expect(agent.resumeSession).toHaveBeenCalledWith({
+      sessionId: existing.id,
+      cwd: existing.cwd,
+      projectId: project.id,
+      permissionProfile: 'ask',
+      previousFrameworkId: 'codex',
+      previousBackendId: 'codex:shared'
+    })
+    expect(invoke.mock.calls.every(([channel]) => !String(channel).startsWith('acp:'))).toBe(true)
   })
 
   it('keeps the captured request caller across asynchronous run façade calls', async () => {
@@ -214,15 +229,18 @@ describe('HeadlessTaskApi adapter', () => {
       void args
       if (channel === 'projects:list') return [project]
       if (channel === 'sessions:load-all') return { sessions: [], manifest: { version: 1 } }
-      if (channel === 'acp:create-session') {
-        return { sessionId: 'session-context', cwd: '/workspace/context' }
-      }
-      if (channel === 'acp:send-prompt') return promptGate
       if (channel === 'sessions:save-session') return undefined
       if (channel === 'preview-resources:release') return undefined
       throw new Error(`Unexpected RPC channel: ${channel}`)
     })
-    const api = new HeadlessTaskApi({ invoke })
+    const agent = createAgent({
+      createSession: vi.fn(async () => ({
+        sessionId: 'session-context',
+        cwd: '/workspace/context'
+      })),
+      prompt: vi.fn(async () => promptGate)
+    })
+    const api = new HeadlessTaskApi({ rpc: { invoke }, agent })
     let authorizationCurrent = true
     const context = createTaskCallerContext({
       location: 'remote',
@@ -238,6 +256,14 @@ describe('HeadlessTaskApi adapter', () => {
 
     expect(invoke).toHaveBeenCalled()
     expect(invoke.mock.calls.every(([, callerContext]) => callerContext === context)).toBe(true)
+    expect(agent.createSession).toHaveBeenCalledWith({
+      projectId: project.id,
+      permissionProfile: 'ask'
+    })
+    expect(agent.prompt).toHaveBeenCalledWith({
+      sessionId: 'session-context',
+      text: 'Research with remote context.'
+    })
     expect(context.isAuthorizationCurrent()).toBe(false)
 
     await api.runWithCallerContext(context, () => api.releaseArtifact('resource-context'))

--- a/src/main/web-service/task-api.ts
+++ b/src/main/web-service/task-api.ts
@@ -1,14 +1,7 @@
 import { AsyncLocalStorage } from 'node:async_hooks'
 import { randomUUID } from 'node:crypto'
 
-import type {
-  AcpCreateSessionRequest,
-  AcpCreateSessionResponse,
-  AcpPromptRequest,
-  AcpResumeSessionRequest,
-  AcpRuntimeEvent,
-  AcpSetPermissionProfileRequest
-} from '../../shared/acp'
+import type { AcpRuntimeEvent } from '../../shared/acp'
 import type {
   FinalizeRunArtifactsRequest,
   FinalizeRunArtifactsResult
@@ -27,6 +20,7 @@ import {
   TaskRunnerError,
   summarizeSession,
   type CreateTaskProjectRequest,
+  type TaskAgentPort,
   type TaskRunnerDependencies
 } from '../tasks/task-runner'
 
@@ -34,6 +28,11 @@ const TASK_CALLER_CONTEXT = createTaskCallerContext()
 
 type TaskRpc = {
   invoke(channel: string, callerContext: CallerContext, args: unknown[]): Promise<unknown>
+}
+
+type TaskApiPorts = {
+  rpc: TaskRpc
+  agent: TaskAgentPort
 }
 
 type TaskApiDependencies = {
@@ -47,12 +46,12 @@ class HeadlessTaskApi {
   private readonly runner: TaskRunner
 
   constructor(
-    private readonly rpc: TaskRpc,
+    private readonly ports: TaskApiPorts,
     dependencies: Partial<TaskApiDependencies> = {}
   ) {
     const subscribeEvents = dependencies.subscribeEvents ?? (() => () => undefined)
-    // Compatibility removal target: A6/T2 replace these façade channel mappings with direct owner
-    // adapters while TaskRunner keeps the same narrow ports.
+    // Non-Agent compatibility channels remain temporary façade adapters. Agent execution crosses a
+    // direct, narrow port so Task never impersonates an Electron caller for runtime operations.
     this.runner = new TaskRunner({
       projects: {
         list: () => this.invoke('projects:list') as Promise<Project[]>,
@@ -70,20 +69,15 @@ class HeadlessTaskApi {
         }
       },
       agent: {
-        listAttachedSessionIds: async () => {
-          const state = (await this.invoke('acp:get-state')) as { sessionIds?: string[] }
-          return state.sessionIds ?? []
-        },
-        createSession: (request: AcpCreateSessionRequest) =>
-          this.invoke('acp:create-session', request) as Promise<AcpCreateSessionResponse>,
-        resumeSession: (request: AcpResumeSessionRequest) =>
-          this.invoke('acp:resume-session', request) as Promise<AcpCreateSessionResponse>,
-        setPermissionProfile: async (request: AcpSetPermissionProfileRequest) => {
-          await this.invoke('acp:set-permission-profile', request)
-        },
-        sendPrompt: async (request: AcpPromptRequest) => {
-          await this.invoke('acp:send-prompt', request)
-        }
+        listAttachedSessionIds: () =>
+          this.withCurrentCaller(() => this.ports.agent.listAttachedSessionIds()),
+        createSession: (request) =>
+          this.withCurrentCaller(() => this.ports.agent.createSession(request)),
+        resumeSession: (request) =>
+          this.withCurrentCaller(() => this.ports.agent.resumeSession(request)),
+        setPermissionProfile: (sessionId, profile) =>
+          this.withCurrentCaller(() => this.ports.agent.setPermissionProfile(sessionId, profile)),
+        prompt: (request) => this.withCurrentCaller(() => this.ports.agent.prompt(request))
       },
       artifacts: {
         finalizeRun: (request: FinalizeRunArtifactsRequest) =>
@@ -100,7 +94,9 @@ class HeadlessTaskApi {
         // Capability cleanup must remain available if request authorization is revoked while a
         // response stream drains. The fixed local automation context grants no new access.
         release: async (resourceId) => {
-          await this.rpc.invoke('preview-resources:release', TASK_CALLER_CONTEXT, [{ resourceId }])
+          await this.ports.rpc.invoke('preview-resources:release', TASK_CALLER_CONTEXT, [
+            { resourceId }
+          ])
         }
       },
       runtimeEvents: { subscribe: subscribeEvents },
@@ -158,9 +154,20 @@ class HeadlessTaskApi {
   }
 
   private invoke(channel: string, ...args: unknown[]): Promise<unknown> {
-    return this.rpc.invoke(channel, this.callerContexts.getStore() ?? TASK_CALLER_CONTEXT, args)
+    return this.ports.rpc.invoke(channel, this.currentCallerContext(), args)
+  }
+
+  private currentCallerContext(): CallerContext {
+    return this.callerContexts.getStore() ?? TASK_CALLER_CONTEXT
+  }
+
+  private withCurrentCaller<Result>(operation: () => Promise<Result>): Promise<Result> {
+    if (!this.currentCallerContext().isAuthorizationCurrent()) {
+      return Promise.reject(new Error('Caller authorization is no longer current.'))
+    }
+    return operation()
   }
 }
 
 export { HeadlessTaskApi, TaskRunnerError as TaskApiError, summarizeSession }
-export type { TaskApiDependencies, TaskRpc }
+export type { TaskApiDependencies, TaskApiPorts, TaskRpc }


### PR DESCRIPTION
## Problem

Headless Task already consumes a narrow Agent capability but `HeadlessTaskApi` still simulates renderer-facing `acp:*` string RPC calls internally. That reverses the dependency direction and couples REST/SDK/CLI automation to the Electron/Web transport façade.

Related issue: #458 remains forward compatibility only. This pull request carries no parent/child, budget, plan, depth, orchestration result, persistence, or public API state.

## Proposed change

Define a provider-neutral `TaskAgentPort` and inject it directly into `HeadlessTaskApi`.

```mermaid
flowchart LR
  H["REST / SDK / CLI HeadlessTaskApi"] --> T["TaskRunner"]
  T --> P["TaskAgentPort"]
  P --> A["ACP Task adapter"]
  A --> C["create-session workflow"]
  A --> R["ACP coordinator"]
  H --> X["remaining non-Agent RPC compatibility"]
```

The port exposes only attached Session IDs, create, resume, permission profile, and prompt. ACP-specific project/skill field translation and notification bookkeeping remain in the adapter; non-Agent compatibility RPC remains unchanged for later slices.

## Scope and non-goals

- Preserve REST, Node SDK, and CLI schemas, events, timeouts, exit codes, and stable application Session IDs.
- Preserve resume framework/backend selection, Codex fresh adoption, `contextReset`, and transcript replay.
- Preserve prompt notification tracking/untracking and captured remote authorization-current checks.
- Preserve Task's existing Permission profile/event subset.
- Do not expose Specialist or Compute management to Task.
- Preserve renderer ACP command/snapshot/event surfaces and Electron/local Web/remote Web capability asymmetry.
- No persistence/data relationship, UI, or issue #458 orchestration change.

## Acceptance criteria and validation

The full local suite ran on rebased implementation head `5270d0e` against `origin/main` `0a01ceb`. The final test-only static-policy fix at `1f23014` then passed targeted formatting/lint, 24 focused tests, node typecheck, and diff-check; exact-head CI is the merge gate.

- Direct port injection, ACP translation, attached/resumed paths, profile, prompt, notification rollback, and remote authorization expiry -> focused ACP/Task/API/SDK/CLI suites -> 166/166 passed.
- REST/Web Task contract -> focused HTTP suites -> 15/15 passed.
- Node and Web compile compatibility -> `npm run typecheck` -> passed.
- Repository lint -> uncached `npm run lint` -> 0 findings.
- Repository regression suite -> `npm test -- --run` -> passed.
- Added-test static return-type policy -> targeted Prettier/ESLint on `task-api.test.ts` -> passed with no findings on `1f23014`.
- Independent review -> Spec: 0 findings; Standards: 0 findings.

Production churn is 230 lines, below the 300–500 target because the new port models only actual Task use instead of introducing a coordinator-forwarding façade.

Uncovered risk: no real provider/daemon Task run was started. Adapter contract tests and the full suite cover Session/resume/prompt lifecycles; exact-head CI is the merge gate.

## Review focus

- Confirm no Agent `acp:*` string RPC remains in `HeadlessTaskApi`.
- Confirm Task receives no renderer, Specialist, Compute, or orchestration capability.
- Confirm resume identity/context recovery and transcript replay are unchanged.
- Confirm authorization-current and notification tracking behavior remains equivalent.
