### PR TITLE
refactor(acp): extract runtime composition

### DIFF
--- a/src/main/acp/ipc.test.ts
+++ b/src/main/acp/ipc.test.ts
@@ -8,6 +8,7 @@ import { join } from 'node:path'
 import { afterEach, describe, expect, it, vi } from 'vitest'
 
 import type { AcpCompactSessionRequest, AcpResumeSessionRequest } from '../../shared/acp'
+import { WEB_EVENT_CHANNELS, WEB_INVOKE_CHANNELS } from '../../shared/web-api-map.generated'
 import {
   beginMigration,
   clearMigrationPending,
@@ -196,6 +197,37 @@ afterEach(() => {
 })
 
 describe('ACP module transport seam', () => {
+  it('pins the complete ACP call and event inventory shared by Electron and Web', () => {
+    registerWithFakes()
+
+    const invokeChannels = Object.entries(WEB_INVOKE_CHANNELS)
+      .filter(([path]) => path.startsWith('acp.'))
+      .map(([, channel]) => channel)
+      .sort()
+    const eventChannels = Object.entries(WEB_EVENT_CHANNELS)
+      .filter(([path]) => path.startsWith('acp.'))
+      .map(([, channel]) => channel)
+      .sort()
+
+    expect([...handlers.keys()].sort()).toEqual([
+      'acp:cancel',
+      'acp:compact-session',
+      'acp:connect',
+      'acp:create-session',
+      'acp:delete-session',
+      'acp:disconnect',
+      'acp:get-state',
+      'acp:reset-session-context',
+      'acp:respond-permission',
+      'acp:resume-session',
+      'acp:revoke-permission-grant',
+      'acp:send-prompt',
+      'acp:set-permission-profile'
+    ])
+    expect(invokeChannels).toEqual([...handlers.keys()].sort())
+    expect(eventChannels).toEqual(['acp:event', 'acp:permission-request', 'acp:state'])
+  })
+
   it('constructs the coordinator before installing Electron handlers', () => {
     const options = registerWithFakes()
     handlers.clear()

--- a/src/main/acp/ipc.test.ts
+++ b/src/main/acp/ipc.test.ts
@@ -120,9 +120,10 @@ vi.mock('../storage-root', () => ({
   resolveDataRoot: () => '/tmp/data'
 }))
 
-const { createAcpRuntime, installAcpIpcHandlers, registerAcpIpcHandlers } = await import('./ipc')
+const { installAcpIpcHandlers } = await import('./ipc')
+const { createAcpRuntime } = await import('./runtime-composition')
 const { createAcpCreateSessionWorkflow } = await import('./create-session-workflow')
-type AcpTestOptions = Parameters<typeof registerAcpIpcHandlers>[0]
+type AcpTestOptions = Parameters<typeof createAcpRuntime>[0]
 
 // Minimal options — createRuntime just forwards them into the mocked AcpRuntime constructor.
 const registerWithFakes = (overrides?: {
@@ -172,7 +173,8 @@ const registerWithFakes = (overrides?: {
     profileService: overrides?.profileService as never
   }
 
-  registerAcpIpcHandlers(options)
+  const runtime = createAcpRuntime(options)
+  installAcpIpcHandlers(runtime, createAcpCreateSessionWorkflow(runtime), options.taskNotifications)
   return options as AcpTestOptions
 }
 
@@ -247,7 +249,7 @@ describe('ACP module transport seam', () => {
   })
 })
 
-describe('registerAcpIpcHandlers — Specialist identity resolver', () => {
+describe('ACP runtime composition — Specialist identity resolver', () => {
   it('passes a ProfileService-backed resolver into each runtime', async () => {
     const profile = {
       name: 'RNA-seq Reviewer',
@@ -354,7 +356,7 @@ describe('registerAcpIpcHandlers — Specialist identity resolver', () => {
   })
 })
 
-describe('registerAcpIpcHandlers — Skill import cancellation lifecycle', () => {
+describe('installAcpIpcHandlers — Skill import cancellation lifecycle', () => {
   it('invalidates a stopped prompt and deleted session before runtime teardown starts', async () => {
     const onSessionCancellationRequested = vi.fn()
     const onSessionUnavailable = vi.fn()
@@ -452,7 +454,7 @@ describe('registerAcpIpcHandlers — Skill import cancellation lifecycle', () =>
   })
 })
 
-describe('registerAcpIpcHandlers — managed session workspace', () => {
+describe('installAcpIpcHandlers — managed session workspace', () => {
   it('registers immediately but waits for initialization before creating the first session', async () => {
     let finishInitialization: (() => void) | undefined
     const initializationBarrier = new Promise<void>((resolve) => {
@@ -680,7 +682,7 @@ describe('registerAcpIpcHandlers — managed session workspace', () => {
   })
 })
 
-describe('registerAcpIpcHandlers — reset-session-context bridge', () => {
+describe('installAcpIpcHandlers — reset-session-context bridge', () => {
   it('registers the acp:reset-session-context channel', () => {
     registerWithFakes()
     expect(handlers.has('acp:reset-session-context')).toBe(true)
@@ -700,7 +702,7 @@ describe('registerAcpIpcHandlers — reset-session-context bridge', () => {
   })
 })
 
-describe('registerAcpIpcHandlers — resume-session diagnostics', () => {
+describe('installAcpIpcHandlers — resume-session diagnostics', () => {
   it('logs a privacy-safe correlated lifecycle on success', async () => {
     registerWithFakes()
     const request: AcpResumeSessionRequest = {
@@ -808,7 +810,7 @@ describe('registerAcpIpcHandlers — resume-session diagnostics', () => {
   })
 })
 
-describe('registerAcpIpcHandlers — native context compaction bridge', () => {
+describe('installAcpIpcHandlers — native context compaction bridge', () => {
   it('forwards the session to its runtime and returns the refreshed snapshot', async () => {
     registerWithFakes()
     const request: AcpCompactSessionRequest = { sessionId: 's-1' }
@@ -821,7 +823,7 @@ describe('registerAcpIpcHandlers — native context compaction bridge', () => {
   })
 })
 
-describe('registerAcpIpcHandlers — create-session failure logging', () => {
+describe('installAcpIpcHandlers — create-session failure logging', () => {
   it('logs the failure via the file logger and re-throws so the renderer still sees the error', async () => {
     registerWithFakes()
     const failure = Object.assign(new Error('Internal error'), { code: -32603 })
@@ -864,7 +866,7 @@ describe('registerAcpIpcHandlers — create-session failure logging', () => {
 // turn starts — is what protects a still-running turn's notification name from being overwritten
 // by a rejected prompt's tracking. An earlier spec review flagged exactly this kind of seam as the
 // gap that let a connector-sessionId regression slip through green.
-describe('registerAcpIpcHandlers — acp:send-prompt notification tracking', () => {
+describe('installAcpIpcHandlers — acp:send-prompt notification tracking', () => {
   it('reverts the tracked prompt when the runtime rejects the send', async () => {
     const trackPrompt = vi.fn().mockReturnValue({ token: 1 })
     const untrackPrompt = vi.fn()

--- a/src/main/acp/ipc.ts
+++ b/src/main/acp/ipc.ts
@@ -1,5 +1,4 @@
 import { createHmac, randomBytes, randomUUID } from 'node:crypto'
-import { homedir } from 'node:os'
 
 import { app } from 'electron'
 
@@ -14,54 +13,27 @@ import type {
   AcpCompactSessionRequest,
   AcpConnectRequest,
   AcpCreateSessionRequest,
-  AcpRuntimeEvent,
   AcpDeleteSessionRequest,
-  AcpPermissionRequest,
   AcpPermissionResponse,
   AcpPromptRequest,
   AcpResumeSessionRequest,
   AcpRevokePermissionGrantRequest,
-  AcpSetPermissionProfileRequest,
-  AcpStateSnapshot
+  AcpSetPermissionProfileRequest
 } from '../../shared/acp'
 import { DEFAULT_ARTIFACT_PROJECT_NAME } from '../../shared/artifacts'
-import { AcpRuntime, type AcpRuntimeCallbacks } from './runtime'
 import { AcpRuntimeCoordinator } from './runtime-coordinator'
-import {
-  createAcpCreateSessionWorkflow,
-  type AcpCreateSessionWorkflow
-} from './create-session-workflow'
+import type { AcpCreateSessionWorkflow } from './create-session-workflow'
 import { installAgentShutdownGuard } from './shutdown-guard'
-import { AgentMcpHttpHost } from './mcp-http-host'
 import { ArtifactRepository } from '../artifacts/repository'
-import type { ArtifactProvenanceRepository } from '../artifacts/provenance-repository'
-import type { ArtifactRunRegistry } from '../artifacts/run-registry'
-import {
-  runTaskNotificationInBackground,
-  type TaskNotificationService
-} from '../notifications/task-notifications'
-import { NotebookLocalRpcServer } from '../notebook/local-rpc-server'
+import type { TaskNotificationService } from '../notifications/task-notifications'
 import { NotebookRunRepository } from '../notebook/repository'
 import {
   NotebookRuntimeService,
   type NotebookRuntimeServiceOptions
 } from '../notebook/runtime-service'
 import { resolveConfigRoot, resolveDataRoot } from '../storage-root'
-import type { AcpSettingsCapabilities } from '../settings/service-capabilities'
-import type { UploadRepository } from '../uploads/repository'
-import type { PermissionGrantRegistry } from '../permission-grants/registry'
-import { projectRegistrySessionGrants } from './permission-broker'
 import { broadcastToRenderers } from '../renderer-broadcast'
 import { createLogger, diagnosticErrorFields, errorLogFields } from '../logger'
-import type { ProfileService } from '../specialist/service'
-import {
-  buildSpecialistIdentityAppend,
-  buildSpecialistIdentityPrefix
-} from '../specialist/identity'
-import {
-  resolveEffectiveSpecialistSkills,
-  filterSpecialistConnectorSkills
-} from '../../shared/specialist'
 
 const log = createLogger('acp')
 const resumeLogHashKey = randomBytes(32)
@@ -130,236 +102,8 @@ const logResumeDiagnostic = (
   }
 }
 
-type AcpIpcArtifacts = {
-  repository: ArtifactRepository
-  runRegistry: ArtifactRunRegistry
-  provenanceRepository?: Pick<
-    ArtifactProvenanceRepository,
-    'listRunVersions' | 'writeAppGeneratedVersion'
-  > &
-    Partial<Pick<ArtifactProvenanceRepository, 'resolveVersionContent'>>
-}
-
-type AcpIpcOptions = AcpIpcArtifacts & {
-  mcpEntryPath: string
-  uploadRepository: UploadRepository
-  notebookRpcServer: NotebookLocalRpcServer
-  authorizeSkillImportReferencedUploads: (
-    projectId: string,
-    sessionId: string,
-    paths: string[]
-  ) => Promise<() => void>
-  // Drives the agent spawn env from the active provider so switching takes effect on reconnect.
-  settingsService: AcpSettingsCapabilities
-  permissionGrantRegistry?: PermissionGrantRegistry
-  initializationBarrier?: Promise<unknown>
-  // Observes prompt starts and terminal turn events for desktop notifications. Optional so tests
-  // and headless setups can run without a notification surface.
-  taskNotifications?: TaskNotificationService
-  onSessionTurnStarted?: (sessionId: string, turnToken: string) => void
-  onSessionTurnEnded?: (sessionId: string, turnToken: string) => void
-  onSkillImportAttachmentEligible?: (
-    sessionId: string,
-    turnToken: string,
-    attachmentUri: string
-  ) => void
-  onSessionCancellationRequested?: (sessionId: string) => void
-  onSessionUnavailable?: (sessionId: string) => void
-  onAllSessionsCancellationRequested?: () => void
-  onDisconnected?: () => void
-  beforeSessionDelete?: (sessionId: string) => Promise<void>
-  // Provides fresh Specialist Profiles for first-turn identity injection. Optional so existing
-  // tests and headless setups that construct the runtime without specialist support are unaffected.
-  profileService?: ProfileService
-}
-
 // Sends one runtime payload through the typed application-event compatibility facade.
 const broadcast = broadcastToRenderers
-
-// Creates the runtime coordinator used by all ACP IPC handlers and artifact claims. Each child runtime
-// captures one framework generation so sessions on different frameworks can remain live concurrently.
-const createAcpRuntime = ({
-  mcpEntryPath,
-  repository,
-  runRegistry,
-  provenanceRepository,
-  uploadRepository,
-  notebookRpcServer,
-  authorizeSkillImportReferencedUploads,
-  settingsService,
-  permissionGrantRegistry,
-  initializationBarrier,
-  taskNotifications,
-  onSessionTurnStarted,
-  onSessionTurnEnded,
-  onSkillImportAttachmentEligible,
-  onSessionCancellationRequested,
-  onSessionUnavailable,
-  onAllSessionsCancellationRequested,
-  onDisconnected,
-  beforeSessionDelete,
-  profileService
-}: AcpIpcOptions): AcpRuntimeCoordinator => {
-  const configRoot = resolveConfigRoot()
-  const dataRoot = resolveDataRoot()
-  const defaultCwd = homedir()
-  const callbacks: AcpRuntimeCallbacks = {
-    onStateChanged: (state: AcpStateSnapshot) => broadcast('acp:state', state),
-    onEvent: (event: AcpRuntimeEvent) => {
-      broadcast('acp:event', event)
-      // Fire-and-forget: a notification hiccup must never stall the renderer event stream.
-      if (taskNotifications) {
-        runTaskNotificationInBackground(
-          () => taskNotifications.handleRuntimeEvent(event),
-          (error) => log.warn('task notification event failed', errorLogFields(error))
-        )
-      }
-    },
-    onPermissionRequest: (request: AcpPermissionRequest) => {
-      broadcast('acp:permission-request', request)
-      // A pending approval parks the turn; an unfocused user gets a desktop nudge.
-      if (taskNotifications) {
-        runTaskNotificationInBackground(
-          () => taskNotifications.handlePermissionRequest(request),
-          (error) => log.warn('permission notification failed', errorLogFields(error))
-        )
-      }
-    }
-  }
-
-  return new AcpRuntimeCoordinator(
-    (runtimeCallbacks, permissionGrantStore) => {
-      // Capture only the non-secret selection per generation. Credentials are resolved fresh at spawn
-      // and released by AcpRuntime after authentication instead of living in this coordinator closure.
-      const selection = settingsService.captureActiveAgentBackendSelection()
-      return new AcpRuntime({
-        appVersion: app.getVersion(),
-        // Packaged macOS apps often start with cwd at "/" or the app bundle; use home instead.
-        defaultCwd,
-        resolveBackend: async (context) =>
-          settingsService.resolveAgentBackend(await selection, context),
-        // HTTP MCP registrations are runtime-owned. Sharing one host would let an old runtime teardown
-        // clear routes belonging to sessions on the newly selected framework.
-        mcpHttpHost: new AgentMcpHttpHost(),
-        skills: {
-          needForceLoad: (ids) => settingsService.skillsNeedingForceLoad(ids),
-          namesForIds: (ids) => settingsService.skillNudgeNamesForIds(ids),
-          descriptorsForIds: (ids, codexHome) =>
-            settingsService.codexSkillDescriptorsForIds(ids, codexHome),
-          catalogForCodexHome: (codexHome) => settingsService.codexSkillCatalog(codexHome)
-        },
-        artifacts: {
-          configRoot,
-          dataRoot,
-          projectName: DEFAULT_ARTIFACT_PROJECT_NAME,
-          mcpEntryPath,
-          repository,
-          runRegistry,
-          provenance: provenanceRepository,
-          getRpcConnection: () => notebookRpcServer.ensureStarted(),
-          issueRpcCapability: (binding) => notebookRpcServer.issueArtifactRunCapability(binding),
-          revokeRpcCapability: (token) => notebookRpcServer.revokeArtifactRunCapability(token)
-        },
-        uploads: { repository: uploadRepository },
-        notebook: {
-          projectName: DEFAULT_ARTIFACT_PROJECT_NAME,
-          mcpEntryPath,
-          getRpcConnection: ({ sessionId, projectId }) =>
-            notebookRpcServer.issueSessionConnection(sessionId, projectId),
-          registerSessionAlias: (aliasSessionId, sessionId) =>
-            notebookRpcServer.registerSessionAlias(aliasSessionId, sessionId),
-          releaseSessionCapabilities: (sessionId) =>
-            notebookRpcServer.releaseSessionCapabilities(sessionId),
-          registerSessionSpecialist: (sessionId, specialistId) =>
-            notebookRpcServer.registerSessionSpecialist(sessionId, specialistId),
-          setArtifactProvenanceContext: (sessionId, context) =>
-            notebookRpcServer.setArtifactProvenanceContext(sessionId, context),
-          registerTurnInputs: (request) => notebookRpcServer.registerNotebookTurnInputs(request)
-        },
-        skillImport: {
-          mcpEntryPath,
-          isEnabled: () => settingsService.getConversationSkillImportEnabled(),
-          getRpcConnection: () => notebookRpcServer.ensureStarted(),
-          registerSessionAlias: (aliasSessionId, sessionId) =>
-            notebookRpcServer.registerSessionAlias(aliasSessionId, sessionId),
-          authorizeReferencedUploads: authorizeSkillImportReferencedUploads
-        },
-        callbacks: runtimeCallbacks,
-        permissionGrantStore,
-        permissionGrantRegistry,
-        // Main process resolves the latest Profile so the renderer never needs to send systemPrompt.
-        resolveSpecialistIdentity: profileService
-          ? async (specialistId: string, frameworkId: string) => {
-              let profile
-              try {
-                profile = await profileService.getById(specialistId)
-              } catch {
-                // Profile not found or corrupt
-                return undefined
-              }
-              if (!profile.enabled) return undefined
-              const append = buildSpecialistIdentityAppend(profile)
-              const prefix = buildSpecialistIdentityPrefix(profile)
-              // For Claude, only the append matters (session-level meta).
-              // For Codex/OpenCode, only the prefix matters (per-turn).
-              // Return both so the runtime can choose by framework.
-              if (frameworkId === 'claude-code') return { append, prefix: '' }
-              return { append: '', prefix }
-            }
-          : undefined,
-        resolveSpecialistSkills: profileService
-          ? async (specialistId) => {
-              try {
-                const profile = await profileService.getById(specialistId)
-                if (!profile.enabled) {
-                  return { kind: 'unavailable', reason: 'The bound specialist is disabled.' }
-                }
-                const effective = resolveEffectiveSpecialistSkills(
-                  profile,
-                  await settingsService.listSpecialistSkillCatalog()
-                )
-                if (effective.kind === 'specialist') {
-                  // Connector tools are delivered as mcp-<id> skills on disk. Claude's options.skills
-                  // whitelist is restrictive, so without these names the agent cannot load the connector
-                  // skill docs and never discovers the tools. Include only the connectors this specialist
-                  // is allowed to use (selectedCapabilities.connectorIds, or all minus full-access
-                  // exclusions) so discovery matches the capability scope; the per-call ConnectorService
-                  // gate still enforces the same config at call time.
-                  const provisioned = await settingsService.provisionedConnectorSkillNames()
-                  const connectorSkills = filterSpecialistConnectorSkills(provisioned, profile)
-                  if (connectorSkills.length > 0) {
-                    return {
-                      ...effective,
-                      frameworkNames: [...effective.frameworkNames, ...connectorSkills]
-                    }
-                  }
-                }
-                return effective
-              } catch {
-                return { kind: 'unavailable', reason: 'The bound specialist is unavailable.' }
-              }
-            }
-          : undefined
-      })
-    },
-    callbacks,
-    defaultCwd,
-    initializationBarrier,
-    onDisconnected,
-    onSessionUnavailable,
-    {
-      onSessionTurnStarted,
-      onSessionTurnEnded,
-      onSkillImportAttachmentEligible,
-      onSessionCancellationRequested,
-      onAllSessionsCancellationRequested,
-      beforeSessionDelete
-    },
-    permissionGrantRegistry
-      ? () => projectRegistrySessionGrants(permissionGrantRegistry.listCached())
-      : undefined
-  )
-}
 
 const registerAcpIpcHandlerSet = (
   runtime: AcpRuntimeCoordinator,
@@ -471,13 +215,6 @@ const installAcpIpcHandlers = (
   }
 }
 
-// Compatibility wrapper for isolated callers; application composition uses the two-phase seam above.
-const registerAcpIpcHandlers = (options: AcpIpcOptions): AcpRuntimeCoordinator => {
-  const runtime = createAcpRuntime(options)
-  installAcpIpcHandlers(runtime, createAcpCreateSessionWorkflow(runtime), options.taskNotifications)
-  return runtime
-}
-
 // Creates the shared notebook runtime used by both renderer IPC and agent MCP calls.
 type DefaultNotebookRuntimeServiceDeps = Pick<
   NotebookRuntimeServiceOptions,
@@ -512,10 +249,4 @@ const createDefaultNotebookRuntimeService = (
   })
 }
 
-export {
-  createAcpRuntime,
-  createDefaultNotebookRuntimeService,
-  installAcpIpcHandlers,
-  registerAcpIpcHandlers
-}
-export type { AcpIpcOptions }
+export { createDefaultNotebookRuntimeService, installAcpIpcHandlers }

--- a/src/main/acp/runtime-composition.ts
+++ b/src/main/acp/runtime-composition.ts
@@ -1,0 +1,246 @@
+import { homedir } from 'node:os'
+
+import { app } from 'electron'
+
+import type { AcpPermissionRequest, AcpRuntimeEvent, AcpStateSnapshot } from '../../shared/acp'
+import { DEFAULT_ARTIFACT_PROJECT_NAME } from '../../shared/artifacts'
+import {
+  filterSpecialistConnectorSkills,
+  resolveEffectiveSpecialistSkills
+} from '../../shared/specialist'
+import type { ArtifactProvenanceRepository } from '../artifacts/provenance-repository'
+import { ArtifactRepository } from '../artifacts/repository'
+import type { ArtifactRunRegistry } from '../artifacts/run-registry'
+import { createLogger, errorLogFields } from '../logger'
+import { NotebookLocalRpcServer } from '../notebook/local-rpc-server'
+import {
+  runTaskNotificationInBackground,
+  type TaskNotificationService
+} from '../notifications/task-notifications'
+import type { PermissionGrantRegistry } from '../permission-grants/registry'
+import { broadcastToRenderers } from '../renderer-broadcast'
+import type { AcpSettingsCapabilities } from '../settings/service-capabilities'
+import {
+  buildSpecialistIdentityAppend,
+  buildSpecialistIdentityPrefix
+} from '../specialist/identity'
+import type { ProfileService } from '../specialist/service'
+import { resolveConfigRoot, resolveDataRoot } from '../storage-root'
+import type { UploadRepository } from '../uploads/repository'
+import { AgentMcpHttpHost } from './mcp-http-host'
+import { projectRegistrySessionGrants } from './permission-broker'
+import { AcpRuntime, type AcpRuntimeCallbacks } from './runtime'
+import { AcpRuntimeCoordinator } from './runtime-coordinator'
+
+const log = createLogger('acp')
+
+type AcpRuntimeArtifacts = {
+  repository: ArtifactRepository
+  runRegistry: ArtifactRunRegistry
+  provenanceRepository?: Pick<
+    ArtifactProvenanceRepository,
+    'listRunVersions' | 'writeAppGeneratedVersion'
+  > &
+    Partial<Pick<ArtifactProvenanceRepository, 'resolveVersionContent'>>
+}
+
+type AcpRuntimeCompositionOptions = AcpRuntimeArtifacts & {
+  mcpEntryPath: string
+  uploadRepository: UploadRepository
+  notebookRpcServer: NotebookLocalRpcServer
+  authorizeSkillImportReferencedUploads: (
+    projectId: string,
+    sessionId: string,
+    paths: string[]
+  ) => Promise<() => void>
+  settingsService: AcpSettingsCapabilities
+  permissionGrantRegistry?: PermissionGrantRegistry
+  initializationBarrier?: Promise<unknown>
+  taskNotifications?: TaskNotificationService
+  onSessionTurnStarted?: (sessionId: string, turnToken: string) => void
+  onSessionTurnEnded?: (sessionId: string, turnToken: string) => void
+  onSkillImportAttachmentEligible?: (
+    sessionId: string,
+    turnToken: string,
+    attachmentUri: string
+  ) => void
+  onSessionCancellationRequested?: (sessionId: string) => void
+  onSessionUnavailable?: (sessionId: string) => void
+  onAllSessionsCancellationRequested?: () => void
+  onDisconnected?: () => void
+  beforeSessionDelete?: (sessionId: string) => Promise<void>
+  profileService?: ProfileService
+}
+
+// Composes the compatibility façade while the coordinator remains the cross-generation Session owner.
+const createAcpRuntime = ({
+  mcpEntryPath,
+  repository,
+  runRegistry,
+  provenanceRepository,
+  uploadRepository,
+  notebookRpcServer,
+  authorizeSkillImportReferencedUploads,
+  settingsService,
+  permissionGrantRegistry,
+  initializationBarrier,
+  taskNotifications,
+  onSessionTurnStarted,
+  onSessionTurnEnded,
+  onSkillImportAttachmentEligible,
+  onSessionCancellationRequested,
+  onSessionUnavailable,
+  onAllSessionsCancellationRequested,
+  onDisconnected,
+  beforeSessionDelete,
+  profileService
+}: AcpRuntimeCompositionOptions): AcpRuntimeCoordinator => {
+  const configRoot = resolveConfigRoot()
+  const dataRoot = resolveDataRoot()
+  const defaultCwd = homedir()
+  const callbacks: AcpRuntimeCallbacks = {
+    onStateChanged: (state: AcpStateSnapshot) => broadcastToRenderers('acp:state', state),
+    onEvent: (event: AcpRuntimeEvent) => {
+      broadcastToRenderers('acp:event', event)
+      // Fire-and-forget: a notification hiccup must never stall the renderer event stream.
+      if (taskNotifications) {
+        runTaskNotificationInBackground(
+          () => taskNotifications.handleRuntimeEvent(event),
+          (error) => log.warn('task notification event failed', errorLogFields(error))
+        )
+      }
+    },
+    onPermissionRequest: (request: AcpPermissionRequest) => {
+      broadcastToRenderers('acp:permission-request', request)
+      // A pending approval parks the turn; an unfocused user gets a desktop nudge.
+      if (taskNotifications) {
+        runTaskNotificationInBackground(
+          () => taskNotifications.handlePermissionRequest(request),
+          (error) => log.warn('permission notification failed', errorLogFields(error))
+        )
+      }
+    }
+  }
+
+  return new AcpRuntimeCoordinator(
+    (runtimeCallbacks, permissionGrantStore) => {
+      const selection = settingsService.captureActiveAgentBackendSelection()
+      return new AcpRuntime({
+        appVersion: app.getVersion(),
+        // Packaged macOS apps often start with cwd at "/" or the app bundle; use home instead.
+        defaultCwd,
+        resolveBackend: async (context) =>
+          settingsService.resolveAgentBackend(await selection, context),
+        mcpHttpHost: new AgentMcpHttpHost(),
+        skills: {
+          needForceLoad: (ids) => settingsService.skillsNeedingForceLoad(ids),
+          namesForIds: (ids) => settingsService.skillNudgeNamesForIds(ids),
+          descriptorsForIds: (ids, codexHome) =>
+            settingsService.codexSkillDescriptorsForIds(ids, codexHome),
+          catalogForCodexHome: (codexHome) => settingsService.codexSkillCatalog(codexHome)
+        },
+        artifacts: {
+          configRoot,
+          dataRoot,
+          projectName: DEFAULT_ARTIFACT_PROJECT_NAME,
+          mcpEntryPath,
+          repository,
+          runRegistry,
+          provenance: provenanceRepository,
+          getRpcConnection: () => notebookRpcServer.ensureStarted(),
+          issueRpcCapability: (binding) => notebookRpcServer.issueArtifactRunCapability(binding),
+          revokeRpcCapability: (token) => notebookRpcServer.revokeArtifactRunCapability(token)
+        },
+        uploads: { repository: uploadRepository },
+        notebook: {
+          projectName: DEFAULT_ARTIFACT_PROJECT_NAME,
+          mcpEntryPath,
+          getRpcConnection: ({ sessionId, projectId }) =>
+            notebookRpcServer.issueSessionConnection(sessionId, projectId),
+          registerSessionAlias: (aliasSessionId, sessionId) =>
+            notebookRpcServer.registerSessionAlias(aliasSessionId, sessionId),
+          releaseSessionCapabilities: (sessionId) =>
+            notebookRpcServer.releaseSessionCapabilities(sessionId),
+          registerSessionSpecialist: (sessionId, specialistId) =>
+            notebookRpcServer.registerSessionSpecialist(sessionId, specialistId),
+          setArtifactProvenanceContext: (sessionId, context) =>
+            notebookRpcServer.setArtifactProvenanceContext(sessionId, context),
+          registerTurnInputs: (request) => notebookRpcServer.registerNotebookTurnInputs(request)
+        },
+        skillImport: {
+          mcpEntryPath,
+          isEnabled: () => settingsService.getConversationSkillImportEnabled(),
+          getRpcConnection: () => notebookRpcServer.ensureStarted(),
+          registerSessionAlias: (aliasSessionId, sessionId) =>
+            notebookRpcServer.registerSessionAlias(aliasSessionId, sessionId),
+          authorizeReferencedUploads: authorizeSkillImportReferencedUploads
+        },
+        callbacks: runtimeCallbacks,
+        permissionGrantStore,
+        permissionGrantRegistry,
+        resolveSpecialistIdentity: profileService
+          ? async (specialistId: string, frameworkId: string) => {
+              let profile
+              try {
+                profile = await profileService.getById(specialistId)
+              } catch {
+                // Profile not found or corrupt
+                return undefined
+              }
+              if (!profile.enabled) return undefined
+              const append = buildSpecialistIdentityAppend(profile)
+              const prefix = buildSpecialistIdentityPrefix(profile)
+              if (frameworkId === 'claude-code') return { append, prefix: '' }
+              return { append: '', prefix }
+            }
+          : undefined,
+        resolveSpecialistSkills: profileService
+          ? async (specialistId) => {
+              try {
+                const profile = await profileService.getById(specialistId)
+                if (!profile.enabled) {
+                  return { kind: 'unavailable', reason: 'The bound specialist is disabled.' }
+                }
+                const effective = resolveEffectiveSpecialistSkills(
+                  profile,
+                  await settingsService.listSpecialistSkillCatalog()
+                )
+                if (effective.kind === 'specialist') {
+                  const provisioned = await settingsService.provisionedConnectorSkillNames()
+                  const connectorSkills = filterSpecialistConnectorSkills(provisioned, profile)
+                  if (connectorSkills.length > 0) {
+                    return {
+                      ...effective,
+                      frameworkNames: [...effective.frameworkNames, ...connectorSkills]
+                    }
+                  }
+                }
+                return effective
+              } catch {
+                return { kind: 'unavailable', reason: 'The bound specialist is unavailable.' }
+              }
+            }
+          : undefined
+      })
+    },
+    callbacks,
+    defaultCwd,
+    initializationBarrier,
+    onDisconnected,
+    onSessionUnavailable,
+    {
+      onSessionTurnStarted,
+      onSessionTurnEnded,
+      onSkillImportAttachmentEligible,
+      onSessionCancellationRequested,
+      onAllSessionsCancellationRequested,
+      beforeSessionDelete
+    },
+    permissionGrantRegistry
+      ? () => projectRegistrySessionGrants(permissionGrantRegistry.listCached())
+      : undefined
+  )
+}
+
+export { createAcpRuntime }
+export type { AcpRuntimeCompositionOptions }

--- a/src/main/acp/runtime-coordinator.test.ts
+++ b/src/main/acp/runtime-coordinator.test.ts
@@ -678,7 +678,7 @@ describe('AcpRuntimeCoordinator', () => {
     await Promise.resolve()
     expect(createdRuntime.sendPrompt).not.toHaveBeenCalled()
 
-    await coordinator.sendPromptForHandoff({
+    await coordinator.sendAppContinuation({
       sessionId: session.sessionId,
       text: 'approved recovery continuation'
     })

--- a/src/main/acp/runtime-coordinator.ts
+++ b/src/main/acp/runtime-coordinator.ts
@@ -482,10 +482,6 @@ class AcpRuntimeCoordinator {
     return this.dispatchPrompt(request, undefined, 'sendAppContinuation')
   }
 
-  sendPromptForHandoff(request: AcpPromptRequest): ReturnType<AcpRuntime['sendAppContinuation']> {
-    return this.dispatchPrompt(request, undefined, 'sendAppContinuation')
-  }
-
   // Starts an app-owned continuation and resolves only once the provider produces its first update.
   // A rejection before that point remains a handoff-start failure owned by CompletionGateCoordinator.
   startContinuation(request: AcpPromptRequest): Promise<void> {

--- a/src/main/acp/runtime.ts
+++ b/src/main/acp/runtime.ts
@@ -2979,14 +2979,6 @@ class AcpRuntime {
     )
   }
 
-  // Backwards-compatible entry point for an application-owned continuation. It deliberately shares
-  // the normal prompt, capability, and identity projection path without emitting a second user message.
-  async continuePrompt(request: AcpPromptRequest): Promise<PromptResponse> {
-    return this.withOperationLease(() =>
-      withDataRootWrite(() => this.sendPromptTurn(request, undefined, false))
-    )
-  }
-
   private async sendPromptTurn(
     request: AcpPromptRequest,
     promptAttemptId: string | undefined,

--- a/src/main/ipc.ts
+++ b/src/main/ipc.ts
@@ -11,7 +11,8 @@ import {
 } from './application-runtime'
 import { createApplicationEventModule, type ApplicationEventSource } from './application-events'
 
-import { createAcpRuntime, createDefaultNotebookRuntimeService } from './acp/ipc'
+import { createDefaultNotebookRuntimeService } from './acp/ipc'
+import { createAcpRuntime } from './acp/runtime-composition'
 import { createAcpCreateSessionWorkflow } from './acp/create-session-workflow'
 import { createAcpTaskAgentPort } from './acp/task-agent-port'
 import { createDefaultArtifactRepository, registerArtifactIpcHandlers } from './artifacts/ipc'
@@ -950,7 +951,7 @@ const createApplicationModules = async (
     switchSpecialist: (sessionId, specialistId) =>
       runtime.switchSpecialist(sessionId, specialistId),
     createContinuationRequest: (input) => runtime.createClaudeCodeContinuationRequest(input),
-    sendAppContinuation: (request) => runtime.sendPromptForHandoff(request),
+    sendAppContinuation: (request) => runtime.sendAppContinuation(request),
     reportHandoffFailure: async (_error, _handoff, context) => {
       runtime.reportApprovedHandoffFailure(context.sessionId)
     }
@@ -1054,8 +1055,8 @@ const createApplicationModules = async (
         }
         await sessionPersistenceCoordinator.saveSessionSpecialistBinding(session, specialistId)
       },
-      // Apply the switch to the live agent runtime. `runtime` is assigned above (registerAcpIpcHandlers),
-      // but the closure is invoked per-request so a late-bound reference is unnecessary.
+      // Apply the switch to the live agent runtime. The closure is invoked per-request, so a
+      // late-bound reference is unnecessary.
       (sessionId, specialistId) => runtime.switchSpecialist(sessionId, specialistId),
       // A specialist capability edit (skills/connectors/enabled) must reach live sessions on the next
       // turn: reconnect so the agent respawns (re-provisioning skills) and resumes with the updated


### PR DESCRIPTION
## Problem

ACP Electron IPC owns construction of the cross-framework runtime coordinator as well as transport registration. That mixes application composition with handler registration and leaves duplicate compatibility forwarding in `AcpRuntime` and `AcpRuntimeCoordinator`.

Issue #458 remains forward compatibility only. This pull request adds no orchestration state, parent/child relationship, budget, plan, persistence, method, event, or public API.

## Proposed change

Move runtime/coordinator construction into main-owned `runtime-composition.ts`. Keep `ipc.ts` responsible for registering the unchanged ACP handler inventory against an already-composed runtime. Remove unused compatibility wrappers and duplicate continuation aliases.

```mermaid
flowchart LR
  M["Main application composition"] --> C["ACP runtime composition"]
  C --> R["AcpRuntimeCoordinator"]
  M --> I["Electron ACP adapter"]
  I --> R
  W["Local / remote Web captured handler registry"] --> I
  R --> E["3 unchanged ACP events"]
```

Handler-owned create/resume diagnostics and prompt notification tracking/rollback remain behaviorally unchanged here and are explicitly assigned to A9.4b. This PR does not claim the final side-effect-free handler boundary.

## Compatibility boundaries

- Preserve all 13 ACP calls and 3 events, including payloads, snapshots, rejection behavior, and event names.
- Preserve Electron preload and generated Web maps.
- Preserve local Web and remote Web use of the captured handler registry.
- Preserve remote authorization/expiry and remote Compute download/reveal denial.
- Preserve Specialist as Electron-only and the current Permission/Compute surface asymmetry.
- Preserve Task, CLI, local RPC, Session identity/adoption, transcript replay, and notification behavior.
- No public schema, persistence/data relationship, UI, or user-interaction change.

## Commits and size

1. `test(transport): pin acp handler inventory`
2. `refactor(acp): extract runtime composition`

Production churn is `+255/-289 = 544`, within the 300–550 target. The new composition module replaces construction removed from the IPC adapter.

## Validation

- Changed-file Prettier: passed.
- Changed-file ESLint with `--max-warnings=0`: passed with 0 findings.
- Node and full typecheck: passed.
- Focused ACP/Electron/preload/Web handler tests: 143/143 passed.
- Focused Web HTTP tests: 15/15 passed.
- Focused ACP runtime tests: 384/384 passed.
- Focused Task/handoff tests: 10/10 passed.
- Full Vitest: 683 files passed / 15 skipped; 10,015 tests passed / 184 skipped.
- Full lint: exit 0; 18 warnings are unchanged baseline files, while changed files have zero warnings.
- `git diff --check`: passed.
- Independent review: Standards 0 findings; the single Spec P2 identified the A9.4b follow-up boundary instead of expanding this PR toward the 700-line hard stop.

## Review focus

- Confirm application composition, not Electron IPC, owns runtime construction.
- Confirm removed `registerAcpIpcHandlers`, `continuePrompt`, and `sendPromptForHandoff` aliases have no remaining consumers and their canonical operations are unchanged.
- Confirm existing handler diagnostics and notification side effects are unchanged and clearly deferred to A9.4b.
- Confirm no renderer/Web/Task/CLI capability or authorization boundary changed.
- Confirm no module cycle or issue #458 speculative interface was introduced.
