### PR TITLE
refactor(notebook): extract data execution admission

### DIFF
--- a/src/main/notebook/data-execution-admission.ts
+++ b/src/main/notebook/data-execution-admission.ts
@@ -1,0 +1,236 @@
+import { realpathSync } from 'node:fs'
+
+import type { NotebookCell, NotebookLanguage } from '../../shared/notebook'
+import type { RuntimeEnablement } from '../../shared/notebook-runtime'
+import { NotebookEnvironmentOperations } from './environment-operations'
+import { detectManagedRuntimeMutation } from './managed-runtime-guard'
+import { NotebookRecoveryCoordinator } from './recovery-coordinator'
+import {
+  DEFAULT_PY_ENV,
+  DEFAULT_R_ENV,
+  envPrefix,
+  isRepairRequired,
+  managedRepairRegistryKey,
+  pythonBin,
+  rBin,
+  resolveEnvName
+} from './runtime-paths'
+import type {
+  NotebookSessionAggregate,
+  NotebookSessionResolvedInterpreter,
+  NotebookSessionRuntimeBinding
+} from './session-aggregate'
+
+type NotebookDataExecutionRoute = Readonly<{
+  environment: string
+  processKey: string
+}>
+
+type NotebookDataExecutionAdmission = Readonly<{
+  language: NotebookLanguage
+  route: NotebookDataExecutionRoute
+  binding?: NotebookSessionRuntimeBinding
+  resolvedInterpreter?: NotebookSessionResolvedInterpreter
+  rejection?: unknown
+  repairKeys: readonly string[]
+}>
+
+type NotebookDataExecutionAdmissionOwnerOptions = {
+  runtimeRoot: string
+  environmentOperations: Pick<
+    NotebookEnvironmentOperations,
+    'ensureDefaultEnvironmentReady' | 'isRepairBlocked' | 'runShared'
+  >
+  recovery: Pick<
+    NotebookRecoveryCoordinator,
+    'isGloballyBlocked' | 'isPrefixBlocked' | 'isRuntimeIdBlocked'
+  >
+  ensureRecovered: () => Promise<void>
+  resolveRuntimeEnablement: (language: NotebookLanguage) => Promise<RuntimeEnablement | undefined>
+}
+
+const defaultEnvironment = (language: NotebookLanguage): string =>
+  language === 'r' ? DEFAULT_R_ENV : DEFAULT_PY_ENV
+
+const processKey = (language: NotebookLanguage, environment: string): string =>
+  `${language === 'r' ? 'r' : 'python'}:${resolveEnvName(language, environment)}`
+
+const repairBlockKey = (
+  language: NotebookLanguage,
+  environment: string,
+  binding: NotebookSessionRuntimeBinding | undefined
+): string =>
+  binding?.source === 'external'
+    ? `external:${language}:${binding.runtimeId}`
+    : processKey(language, environment)
+
+const repairRequiredError = (language: NotebookLanguage): Error =>
+  new Error(
+    `RUNTIME_REPAIR_REQUIRED: the bound ${language} runtime failed a protected-package ` +
+      'integrity check. Run the runtime Repair workflow before executing another cell.'
+  )
+
+/** Owns data-cell routing plus every fail-closed gate before the executor may be dispatched. */
+class NotebookDataExecutionAdmissionOwner {
+  constructor(private readonly options: NotebookDataExecutionAdmissionOwnerOptions) {}
+
+  route(session: NotebookSessionAggregate, language: NotebookLanguage): NotebookDataExecutionRoute {
+    const binding = session.runtimeBinding(language)
+    const environment =
+      binding?.source === 'managed' && binding.envName
+        ? binding.envName
+        : defaultEnvironment(language)
+    return { environment, processKey: processKey(language, environment) }
+  }
+
+  async admit(
+    session: NotebookSessionAggregate,
+    cell: Readonly<NotebookCell>
+  ): Promise<NotebookDataExecutionAdmission> {
+    const route = this.route(session, cell.language)
+    const runtimeRoot = this.options.runtimeRoot
+    await this.options.ensureRecovered()
+    const binding = session.runtimeBinding(cell.language)
+    const repairKeys = this.repairRegistryKeys(cell.language, route.environment, binding)
+    let resolvedInterpreter: NotebookSessionResolvedInterpreter | undefined
+    let rejection: unknown
+    const isExternal = binding?.source === 'external'
+    const recoveryBlocked =
+      (binding?.runtimeId && this.options.recovery.isRuntimeIdBlocked(binding.runtimeId)) ||
+      (!isExternal &&
+        this.options.recovery.isPrefixBlocked(envPrefix(runtimeRoot, route.environment))) ||
+      (isExternal && this.options.recovery.isGloballyBlocked())
+    const repairRequired =
+      this.options.environmentOperations.isRepairBlocked(
+        repairBlockKey(cell.language, route.environment, binding)
+      ) || repairKeys.some((key) => isRepairRequired(runtimeRoot, key))
+
+    if (recoveryBlocked) {
+      rejection = new Error(
+        `RUNTIME_RECOVERY_BLOCKED: the bound ${cell.language} runtime is recovering from an interrupted ` +
+          'operation whose worker process could not be confirmed stopped, so running it now could ' +
+          'corrupt it. Restart the app to re-check and recover it before running cells.'
+      )
+    } else if (repairRequired) {
+      rejection = repairRequiredError(cell.language)
+    } else if (binding && (binding.status ?? 'active') !== 'active') {
+      rejection = new Error(
+        `RUNTIME_BINDING_UNAVAILABLE: the bound ${cell.language} runtime is ${binding.status}` +
+          (binding.reason ? ` (${binding.reason})` : '') +
+          '. Call list_notebook_runtimes then notebook_switch_runtime to choose another runtime ' +
+          '(an unspecified choice falls back to the app-managed default). Any prior kernel memory ' +
+          '(variables, imports) for this language was lost.'
+      )
+    } else if (binding?.resolvedInterpreter) {
+      resolvedInterpreter = binding.resolvedInterpreter
+    } else {
+      try {
+        if (
+          route.environment === defaultEnvironment(cell.language) &&
+          (await this.isDefaultEnvironmentDisabled(cell.language, session.runtimeRoot))
+        ) {
+          throw new Error(
+            `No enabled ${cell.language} runtime: the app-managed default is disabled and no runtime ` +
+              'is bound. Enable a runtime in Settings → Runtimes, or bind one with ' +
+              'list_notebook_runtimes then notebook_bind_runtime, before running cells.'
+          )
+        }
+        await this.ensureDefaultEnvironmentReady(session, cell.language, route.environment)
+      } catch (error) {
+        rejection = error
+      }
+    }
+
+    const blockedMutation = detectManagedRuntimeMutation({
+      source: cell.code,
+      surface: cell.language,
+      runtimeRoot: session.runtimeRoot,
+      cwd: session.cwd
+    })
+    if (blockedMutation && rejection === undefined) {
+      rejection = new Error(`MANAGED_RUNTIME_MUTATION_BLOCKED: ${blockedMutation.message}`)
+    }
+    return { language: cell.language, route, binding, resolvedInterpreter, rejection, repairKeys }
+  }
+
+  runShared<Result>(
+    admission: NotebookDataExecutionAdmission,
+    operation: (rejection: unknown | undefined) => Promise<Result>
+  ): Promise<Result> {
+    return this.options.environmentOperations.runShared(
+      'execution',
+      admission.route.environment,
+      () => {
+        const postLockRepairRequired =
+          this.options.environmentOperations.isRepairBlocked(
+            repairBlockKey(admission.language, admission.route.environment, admission.binding)
+          ) || admission.repairKeys.some((key) => isRepairRequired(this.options.runtimeRoot, key))
+        return operation(
+          postLockRepairRequired ? repairRequiredError(admission.language) : admission.rejection
+        )
+      }
+    )
+  }
+
+  private async isDefaultEnvironmentDisabled(
+    language: NotebookLanguage,
+    runtimeRoot: string
+  ): Promise<boolean> {
+    const enablement = await this.options.resolveRuntimeEnablement(language)
+    if (!enablement) return false
+    const prefix = envPrefix(runtimeRoot, defaultEnvironment(language))
+    const interpreter = language === 'r' ? rBin(prefix) : pythonBin(prefix)
+    let environmentId = interpreter
+    try {
+      environmentId = realpathSync(interpreter)
+    } catch {
+      // The raw path is authoritative until the default runtime is materialized.
+    }
+    return enablement.enabled[environmentId] === false || enablement.enabled[interpreter] === false
+  }
+
+  private ensureDefaultEnvironmentReady(
+    session: NotebookSessionAggregate,
+    language: NotebookLanguage,
+    environment: string
+  ): Promise<void> {
+    return this.options.environmentOperations.ensureDefaultEnvironmentReady({
+      language,
+      environment,
+      runtimeRoot: session.runtimeRoot,
+      sessionId: session.sessionId,
+      ensureRecovered: this.options.ensureRecovered,
+      assertRecoverable: () => {
+        const prefix = envPrefix(session.runtimeRoot, environment)
+        if (this.options.recovery.isPrefixBlocked(prefix)) {
+          throw new Error(
+            `RUNTIME_RECOVERY_BLOCKED: a previous operation on "${prefix}" was interrupted and its worker ` +
+              'process could not be confirmed stopped, so writing this environment now could corrupt it. ' +
+              'Restart the app to re-check and recover it, then try again.'
+          )
+        }
+      }
+    })
+  }
+
+  private repairRegistryKeys(
+    language: NotebookLanguage,
+    environment: string,
+    binding: NotebookSessionRuntimeBinding | undefined
+  ): string[] {
+    if (binding?.source === 'external') return [binding.runtimeId]
+    const keys = new Set([environment, managedRepairRegistryKey(environment, language)])
+    if (binding?.source === 'managed') keys.add(binding.runtimeId)
+    const prefix = envPrefix(this.options.runtimeRoot, environment)
+    const interpreter = language === 'r' ? rBin(prefix) : pythonBin(prefix)
+    keys.add(interpreter)
+    try {
+      keys.add(realpathSync(interpreter))
+    } catch {
+      // The raw path still covers repair markers for an unmaterialized runtime.
+    }
+    return [...keys]
+  }
+}
+
+export { NotebookDataExecutionAdmissionOwner }

--- a/src/main/notebook/runtime-service.test.ts
+++ b/src/main/notebook/runtime-service.test.ts
@@ -489,6 +489,57 @@ describe('notebook runtime service', () => {
     expect(state.activeRunId).toBe(document.runs[0]?.runId)
   })
 
+  it('persists a fail-closed default-runtime admission without dispatching or capturing evidence', async () => {
+    const root = await createStorageRoot()
+    const defaultInterpreter = pythonBin(envPrefix(getRuntimeRoot(root), DEFAULT_PY_ENV))
+    const execute = vi.fn(
+      async (request: NotebookExecutionRequest): Promise<NotebookExecutionResult> => ({
+        status: 'completed',
+        stdout: '',
+        stderr: '',
+        traceback: '',
+        cwdAfter: request.cwd,
+        outputs: []
+      })
+    )
+    const environmentStateTracker = verifiedPackageMutationTracker()
+    const service = new NotebookRuntimeService({
+      configRoot: root,
+      dataRoot: root,
+      projectName: 'default-project',
+      repository: new NotebookRunRepository(root),
+      getRuntimeEnablement: async () => ({
+        enabled: { [defaultInterpreter]: false },
+        installAuthorized: {}
+      }),
+      environmentStateTracker,
+      executorFactory: () => ({ execute, shutdown: async () => ({ reaped: true }) })
+    })
+
+    const summary = await service.execute({
+      sessionId: 'session-1',
+      workspaceCwd: root,
+      language: 'python',
+      code: 'print(1)'
+    })
+    const state = await service.state({ sessionId: 'session-1', workspaceCwd: root })
+
+    expect(summary).toMatchObject({
+      status: 'failed',
+      environment: DEFAULT_PY_ENV,
+      text: { traceback: expect.stringMatching(/No enabled python runtime/i) }
+    })
+    expect(state.runs).toHaveLength(1)
+    expect(state.runs[0]).toMatchObject({
+      runId: summary.runId,
+      status: 'failed',
+      environment: DEFAULT_PY_ENV
+    })
+    expect(execute).not.toHaveBeenCalled()
+    expect(environmentStateTracker.prepareRun).not.toHaveBeenCalled()
+    expect(environmentStateTracker.captureCompletedRun).not.toHaveBeenCalled()
+  })
+
   it('rejects install.packages in an R cell before the managed kernel executes it', async () => {
     const root = await createStorageRoot()
     const execute = vi.fn(async () => ({

--- a/src/main/notebook/runtime-service.ts
+++ b/src/main/notebook/runtime-service.ts
@@ -33,6 +33,7 @@ import type {
   ProvisionProgress
 } from '../../shared/notebook-env'
 import type { PackageMirror } from '../../shared/mirror'
+import { NotebookDataExecutionAdmissionOwner } from './data-execution-admission'
 import { NotebookExportReader } from './export-reader'
 import { NotebookKernelExecutor, type NotebookKernelExecutorOptions } from './kernel-executor'
 import { saveIpynbAll } from './save-ipynb-all'
@@ -44,7 +45,6 @@ import {
   type InstallRequest,
   type InstallResult
 } from './package-manager'
-import { detectManagedRuntimeMutation } from './managed-runtime-guard'
 import { NotebookRunRepository, getNotebookRunJsonPath, getRuntimeRoot } from './repository'
 import {
   addRepairRequired,
@@ -54,7 +54,6 @@ import {
   DEFAULT_PY_ENV,
   DEFAULT_R_ENV,
   envPrefix,
-  isRepairRequired,
   managedRepairRegistryKey,
   pythonBin,
   pythonReady,
@@ -434,6 +433,7 @@ class NotebookRuntimeService {
   private readonly exportReader: NotebookExportReader
   private readonly runTerminalization: NotebookRunTerminalizationOwner
   private readonly executionOwner: NotebookExecutionOwner
+  private readonly dataExecutionAdmission: NotebookDataExecutionAdmissionOwner
   private readonly sessions: NotebookSessionRegistry<RuntimeSession>
   private readonly announcedAgentSessionIds = new Set<string>()
   // Owns process-global operation admission, provisioning progress, restart recommendations,
@@ -514,6 +514,13 @@ class NotebookRuntimeService {
         platform: options.platform,
         logger: this.runtimeLogger
       })
+    this.dataExecutionAdmission = new NotebookDataExecutionAdmissionOwner({
+      runtimeRoot: getRuntimeRoot(options.dataRoot),
+      environmentOperations: this.environmentOperations,
+      recovery: this.recoveryCoordinator,
+      ensureRecovered: () => this.ensureRecovered(),
+      resolveRuntimeEnablement: (language) => this.resolveRuntimeEnablement(language)
+    })
     this.environmentManager = options.environmentManager
     this.runTerminalization = new NotebookRunTerminalizationOwner({
       repository: this.repository,
@@ -600,24 +607,6 @@ class NotebookRuntimeService {
       // Not on disk yet — keep the raw path.
     }
     return enablement.enabled[envId] === false || enablement.enabled[interp] === false
-  }
-
-  // A provision failure is broadcast and rethrown so the run path records the actionable root cause
-  // as a failed run rather than spawning the executor against a missing prefix.
-  private async ensureDefaultEnvReady(
-    language: NotebookLanguage,
-    env: string,
-    runtimeRootDir: string,
-    sessionId: string
-  ): Promise<void> {
-    return this.environmentOperations.ensureDefaultEnvironmentReady({
-      language,
-      environment: env,
-      runtimeRoot: runtimeRootDir,
-      sessionId,
-      ensureRecovered: () => this.ensureRecovered(),
-      assertRecoverable: () => this.assertPrefixRecoverable(envPrefix(runtimeRootDir, env))
-    })
   }
 
   // The DEFAULT env name / process key for a language, matching resolveEnvName / dataProcessKey.
@@ -846,8 +835,10 @@ class NotebookRuntimeService {
     // after any in-flight run on the SAME (kind, env) so that env's kernel processes one cell at a
     // time, while a different env or language (e.g. python:my-analysis vs python:default-python vs r)
     // proceeds on its own independent chain (§5/D4, generalizes G5's per-kind queue to per-env).
-    const processKey = dataProcessKey(cell.language, this.resolveRunEnv(session, cell.language))
-    return session.enqueueExecution(processKey, () => this.runCellExclusive(session, cell, request))
+    const route = this.dataExecutionAdmission.route(session, cell.language)
+    return session.enqueueExecution(route.processKey, () =>
+      this.runCellExclusive(session, cell, request)
+    )
   }
 
   // Runs one cell to completion while holding its (kind, env) execution slot. Only ever invoked through
@@ -863,122 +854,12 @@ class NotebookRuntimeService {
     const startedAt = Date.now()
     const executionCount = session.nextExecutionCount()
     const cwdBefore = session.cwd
-    // Resolve the env at the run boundary from the SESSION BINDING (not a per-call argument): the run
-    // uses this env's process/queue/lock and it is recorded on the run so history/replay and the UI
-    // know which env produced it (D1/D6).
-    const env = this.resolveRunEnv(session, cell.language)
-    const processKey = dataProcessKey(cell.language, env)
-
-    // Resolve which interpreter backs this run. v4 unified model: the session BINDING decides. A
-    // MANAGED binding (app-managed default OR an agent-created named env) runs via the executor's
-    // managed-prefix lookup for `env` (resolved above from the binding). An EXTERNAL binding runs the
-    // user's own interpreter directly. No binding -> the app-managed default. There is no implicit
-    // external default and no per-call env override anymore.
-    let resolvedInterpreter: ResolvedInterpreter | undefined
-    // Deferred so a first-use overlay-build failure (bad base interpreter, ensurepip failure, an
-    // interpreter moved after selection) is normalized into a FAILED run record with a traceback below,
-    // exactly like an executor spawn/crash — rather than throwing raw out of the run path and leaving no
-    // run history for the agent to inspect.
-    let interpreterResolveError: unknown
-    // Recovery starts before IPC registration but completes asynchronously. Wait before consulting its
-    // block sets so an external or named run cannot start while an unknown orphan is still being found.
-    await this.ensureRecovered()
-    const binding = session.runtimeBinding(cell.language)
-    // A managed/default run is gated by its real prefix via isPrefixRecoveryBlocked, which folds in the
-    // corrupt-journal barrier AND honours a force Reset's per-prefix allowlist — so a reset (allowlisted)
-    // env runs cells again without a restart. An EXTERNAL run has no managed prefix, so it keeps the raw
-    // corrupt catch-all (plus its runtimeId block). resolveRunEnv gave us the env name above.
-    const isExternal = binding?.source === 'external'
-    const prefixBlocked =
-      !isExternal &&
-      this.isPrefixRecoveryBlocked(envPrefix(getRuntimeRoot(this.options.dataRoot), env))
-    // Managed repair state is keyed by the canonical conda env name, so an explicit binding and an
-    // unbound/default session cannot refer to the same prefix under two different registry keys.
-    // External runtimes have no app-owned prefix and remain keyed by their discovered runtime id.
-    const repairRegistryRoot = getRuntimeRoot(this.options.dataRoot)
-    const repairKeys = this.repairRegistryKeys(cell.language, env, binding, repairRegistryRoot)
-    const repairRequired =
-      this.environmentOperations.isRepairBlocked(repairBlockKey(cell.language, env, binding)) ||
-      repairKeys.some((key) => isRepairRequired(repairRegistryRoot, key))
-    if (
-      (binding?.runtimeId && this.recoveryCoordinator.isRuntimeIdBlocked(binding.runtimeId)) ||
-      prefixBlocked ||
-      (isExternal && this.recoveryCoordinator.isGloballyBlocked())
-    ) {
-      // Recovery flagged this BOUND runtime possibly-live after an interrupted install (external or a
-      // managed named env) — OR its managed prefix is recovery-blocked (per-prefix block or a not-yet-
-      // reset corrupt journal) — OR an external run under a corrupt journal we can't enumerate.
-      // ensureDefaultEnvReady only guards the DEFAULT prefix, so without this check a named/external run
-      // would proceed over an env a survivor may still be writing. Fail with the actionable message.
-      interpreterResolveError = new Error(
-        `RUNTIME_RECOVERY_BLOCKED: the bound ${cell.language} runtime is recovering from an interrupted ` +
-          'operation whose worker process could not be confirmed stopped, so running it now could ' +
-          'corrupt it. Restart the app to re-check and recover it before running cells.'
-      )
-    } else if (repairRequired) {
-      interpreterResolveError = new Error(
-        `RUNTIME_REPAIR_REQUIRED: the bound ${cell.language} runtime failed a protected-package ` +
-          'integrity check. Run the runtime Repair workflow before executing another cell.'
-      )
-    } else if (binding && (binding.status ?? 'active') !== 'active') {
-      // No silent fallback: a disabled/unavailable bound runtime FAILS the run with an actionable
-      // message rather than quietly running a different interpreter (the user would wrongly assume
-      // their vars/packages/interpreter are unchanged). The agent recovers via list → switch. See
-      // [[notebook-runtime-disable-binding-lifecycle]] / [[notebook-runtime-crash-recovery]].
-      interpreterResolveError = new Error(
-        `RUNTIME_BINDING_UNAVAILABLE: the bound ${cell.language} runtime is ${binding.status}` +
-          (binding.reason ? ` (${binding.reason})` : '') +
-          '. Call list_notebook_runtimes then notebook_switch_runtime to choose another runtime ' +
-          '(an unspecified choice falls back to the app-managed default). Any prior kernel memory ' +
-          '(variables, imports) for this language was lost.'
-      )
-    } else if (binding?.resolvedInterpreter) {
-      // An ENABLED external binding runs the user's own interpreter directly.
-      resolvedInterpreter = binding.resolvedInterpreter
-    } else {
-      // No binding, or an app-managed MANAGED binding (default or an agent-created named env): build the
-      // default env from the offline bundle on first use (R is lazy) before dispatching, so the agent
-      // doesn't hit "still being prepared" and go create its own env. No-op for named envs and for an
-      // already-materialized default.
-      try {
-        // No silent fallback (same guarantee as the binding path above): if the app-managed default is
-        // explicitly DISABLED, refuse rather than provision + run it. Otherwise disabling the last
-        // runtime in Settings would leave "no available runtime" showing there while notebook_execute
-        // still ran the disabled default.
-        //
-        // But ONLY gate on the default's enablement when this run actually targets the default env. A
-        // managed binding to an agent-created NAMED env (my-analysis) also lands here (no
-        // resolvedInterpreter), and its `env` is that named env — disabling `default-python` must not
-        // block it. The named env has its own enablement, checked where it is disabled/revoked (the
-        // status branch above), so here we guard the default only.
-        const isDefaultEnvRun = env === this.defaultEnvNameFor(cell.language)
-        if (
-          isDefaultEnvRun &&
-          (await this.isDefaultEnvDisabled(cell.language, session.runtimeRoot))
-        ) {
-          throw new Error(
-            `No enabled ${cell.language} runtime: the app-managed default is disabled and no runtime ` +
-              'is bound. Enable a runtime in Settings → Runtimes, or bind one with ' +
-              'list_notebook_runtimes then notebook_bind_runtime, before running cells.'
-          )
-        }
-        await this.ensureDefaultEnvReady(cell.language, env, session.runtimeRoot, session.sessionId)
-      } catch (error) {
-        interpreterResolveError = error
-      }
-    }
-
-    const blockedMutation = detectManagedRuntimeMutation({
-      source: cell.code,
-      surface: cell.language,
-      runtimeRoot: session.runtimeRoot,
-      cwd: session.cwd
-    })
-    if (blockedMutation && interpreterResolveError === undefined) {
-      interpreterResolveError = new Error(
-        `MANAGED_RUNTIME_MUTATION_BLOCKED: ${blockedMutation.message}`
-      )
-    }
+    // Admission re-resolves at the exclusive run boundary, matching the former façade behavior while
+    // the pre-queue route above continues to choose the serialization slot. A binding switch while
+    // queued therefore retains the legacy dual-resolution behavior rather than hardening this refactor.
+    const admission = await this.dataExecutionAdmission.admit(session, cell)
+    const { environment: env, processKey } = admission.route
+    const { binding, resolvedInterpreter } = admission
 
     // Mark the cell as running before execution so the preview can show immediate progress.
     session.markCellRunning(cell.id, runId, executionCount)
@@ -1019,7 +900,7 @@ class NotebookRuntimeService {
     // lifecycle status instead of briefly publishing a false 'running'. For a viable dispatch, clear
     // any stale terminated flag so a completing run can settle back to 'idle'. No notify: the run
     // terminalization owner's append notification surfaces the fresh status to the renderer.
-    const kernelMarkedRunning = interpreterResolveError === undefined
+    const kernelMarkedRunning = admission.rejection === undefined
     if (kernelMarkedRunning) {
       session.clearKernelTerminated(processKey)
       await this.persistKernelStatus(session, 'running', processKey)
@@ -1036,29 +917,10 @@ class NotebookRuntimeService {
       session,
       runningRun,
       invoke: () =>
-        this.environmentOperations.runShared('execution', env, async () => {
-          // The run may have waited behind an installer after computing interpreterResolveError above.
-          // Re-read the repair gate only after the shared run lease is acquired so a transaction that
-          // quarantined this env while we waited cannot release the lock and let a stale decision spawn it.
-          const repairRequiredAfterLock =
-            this.environmentOperations.isRepairBlocked(
-              repairBlockKey(cell.language, env, binding)
-            ) || repairKeys.some((key) => isRepairRequired(repairRegistryRoot, key))
-          if (repairRequiredAfterLock) {
+        this.dataExecutionAdmission.runShared(admission, async (rejection) => {
+          if (rejection !== undefined) {
             executedOnLiveKernel = false
-            return errorToExecutionResult(
-              new Error(
-                `RUNTIME_REPAIR_REQUIRED: the bound ${cell.language} runtime failed a protected-package ` +
-                  'integrity check. Run the runtime Repair workflow before executing another cell.'
-              ),
-              cwdBefore
-            )
-          }
-          // A failed interpreter resolve (external overlay build) never reached a live kernel; surface
-          // it through the same normalization the executor uses so it becomes a failed run, not a throw.
-          if (interpreterResolveError !== undefined) {
-            executedOnLiveKernel = false
-            return Promise.resolve(errorToExecutionResult(interpreterResolveError, cwdBefore))
+            return errorToExecutionResult(rejection, cwdBefore)
           }
           const environmentTarget = this.environmentCaptureTarget(
             cell.language,


### PR DESCRIPTION
## Problem

Notebook data-cell admission remains embedded in the runtime façade: route selection, binding and runtime availability, recovery barriers, repair registry compatibility, default provisioning, managed-runtime mutation policy, and the post-lock repair recheck are maintained in the same method as execution lifecycle and terminal projection.

The original cohesive N6.5 extraction measured 747 production changed lines and was withdrawn without an implementation commit. This PR is the first serial slice; N6.5b owns execution lifecycle only after this PR is squash-merged.

## Proposed change

Introduce an internal `NotebookDataExecutionAdmissionOwner` with three operations:

- synchronously select the route/process key before enqueue;
- resolve binding, environment, recovery, repair, provisioning, and mutation admission at exclusive execution;
- hold the existing shared environment lease and repeat repair admission after locking.

The runtime façade retains receiving state, queueing, run identity, durable records, kernel/evidence/executor/terminalization, cell/cwd projection, and notifications for N6.5b.

## Compatibility boundaries

- Preserve selected-process-key queueing and the legacy late route/binding re-resolution at the queue head.
- Preserve binding-unavailable, disabled-default, recovery-blocked, repair-required, provisioning, and managed-mutation errors and ordering.
- Preserve legacy and canonical repair registry keys and the fail-closed post-lock recheck.
- Preserve running/terminal persistence order, failed cell projection, evidence best-effort behavior, and coarse `activeRunId`.
- Preserve local RPC begin/append/finish/run/data ordering and provenance.
- Preserve Electron/Web/remote Web/CLI/Task/local RPC and Specialist/Permission/Compute capability asymmetry.
- No public union/schema, persistence/data relationship, IPC, UI, or issue #458 orchestration change.

## Commits and size

1. `test(notebook): characterize data execution admission`
2. `refactor(notebook): extract data execution admission`

Production churn is exactly 420: new owner `+236`, runtime façade `+23/-161`. The owner depends on environment/recovery capabilities, runtime-path helpers, and the pure managed-mutation policy helper; it has no repository, terminalization, or evidence dependency.

## Validation

- Changed-file Prettier and ESLint with zero warnings: passed.
- Full Node/Web typecheck: passed.
- Admission/recovery/environment-operation suites: 188/188 passed.
- Local RPC cross-entry/provenance tests: 3/3 passed.
- Full Vitest: 683 files passed / 15 skipped; 10,015 tests passed / 184 skipped.
- Full lint: 0 errors; 18 warnings are unchanged baseline files.
- `git diff --check`: passed.
- Independent review: Standards 0 findings, behavior defects 0; a brief-only dependency-list ambiguity was corrected in the ignored planning document.

## Review focus

- Confirm the owner controls admission only; execution/terminal state remains in the runtime for N6.5b.
- Confirm the second repair check still occurs after acquiring the shared environment lease.
- Confirm external/managed/default binding and legacy repair-key behavior is mechanically equivalent.
- Confirm no cross-surface or durable contract changes.

## Pre-existing residual risk

The existing façade selects a process key before enqueue, then reads binding again at exclusive execution. A binding switch while queued can therefore leave a request on the old queue while dispatching the newly resolved environment. This PR deliberately preserves that observable race instead of adding fail-closed hardening; it should be addressed separately if product behavior is allowed to change.
