### PR TITLE
fix(acp): persist usage during graceful shutdown

### DIFF
--- a/src/main/acp/runtime-coordinator.test.ts
+++ b/src/main/acp/runtime-coordinator.test.ts
@@ -660,6 +660,60 @@ describe('AcpRuntimeCoordinator', () => {
     expect(released).toBe(true)
   })
 
+  it('cancels active prompts and waits for their terminal responses before quit teardown', async () => {
+    const prompt = createDeferred<unknown>()
+    let created!: ReturnType<typeof createFakeRuntime>
+    const coordinator = new AcpRuntimeCoordinator((callbacks) => {
+      created = createFakeRuntime({
+        frameworkId: 'claude-code',
+        sessionIds: ['session-1'],
+        callbacks,
+        prompt: () => prompt.promise
+      })
+      return created.runtime
+    })
+    const session = await coordinator.createSession({ cwd: '/workspace' })
+    const running = coordinator.sendPrompt({ sessionId: session.sessionId, text: 'keep usage' })
+    await Promise.resolve()
+
+    let prepared = false
+    const preparing = coordinator.prepareForQuit(1_000).then(() => {
+      prepared = true
+    })
+    await Promise.resolve()
+
+    expect(created.cancelPrompt).toHaveBeenCalledWith({ sessionId: 'session-1' })
+    expect(prepared).toBe(false)
+
+    prompt.resolve({ stopReason: 'cancelled' })
+    await running
+    await preparing
+    expect(prepared).toBe(true)
+  })
+
+  it('bounds quit preparation when an agent never returns a terminal response', async () => {
+    const prompt = createDeferred<unknown>()
+    let created!: ReturnType<typeof createFakeRuntime>
+    const coordinator = new AcpRuntimeCoordinator((callbacks) => {
+      created = createFakeRuntime({
+        frameworkId: 'codex',
+        sessionIds: ['session-1'],
+        callbacks,
+        prompt: () => prompt.promise
+      })
+      return created.runtime
+    })
+    const session = await coordinator.createSession({ cwd: '/workspace' })
+    const running = coordinator.sendPrompt({ sessionId: session.sessionId, text: 'never stops' })
+    await Promise.resolve()
+
+    await expect(coordinator.prepareForQuit(0)).resolves.toBeUndefined()
+    expect(created.cancelPrompt).toHaveBeenCalledWith({ sessionId: 'session-1' })
+
+    prompt.resolve({ stopReason: 'cancelled' })
+    await running
+  })
+
   it('blocks user prompts on startup admission while allowing recovery continuations through', async () => {
     const admission = createDeferred<void>()
     let createdRuntime!: ReturnType<typeof createFakeRuntime>

--- a/src/main/acp/runtime-coordinator.test.ts
+++ b/src/main/acp/runtime-coordinator.test.ts
@@ -39,6 +39,7 @@ const createFakeRuntime = (options: {
   permissionGrantStore?: ConversationPermissionGrantStore
   beforePromptStart?: () => Promise<void>
   beforeProviderPromptAccepted?: () => Promise<void>
+  beforeReviewerSession?: () => Promise<void>
   beforeResume?: () => Promise<void>
   afterResumeAttached?: () => Promise<void>
   eligibleAttachmentUri?: string
@@ -191,9 +192,10 @@ const createFakeRuntime = (options: {
       async (_activityOptions: unknown, work: (scopedRuntime: AcpRuntime) => Promise<unknown>) =>
         work(runtime)
     ),
-    buildReviewerSession: vi.fn(async () => ({
-      session: { sessionId: `reviewer-${options.frameworkId}` }
-    })),
+    buildReviewerSession: vi.fn(async () => {
+      await options.beforeReviewerSession?.()
+      return { session: { sessionId: `reviewer-${options.frameworkId}` } }
+    }),
     disposeReviewerSession: vi.fn(() => ({
       rejectedToolCalls: 0,
       reviewerBridgeScoped: undefined
@@ -712,6 +714,137 @@ describe('AcpRuntimeCoordinator', () => {
 
     prompt.resolve({ stopReason: 'cancelled' })
     await running
+  })
+
+  it('closes user, continuation, and reviewer prompt admission before the quit snapshot', async () => {
+    let created!: ReturnType<typeof createFakeRuntime>
+    const coordinator = new AcpRuntimeCoordinator((callbacks) => {
+      created = createFakeRuntime({
+        frameworkId: 'claude-code',
+        sessionIds: ['session-1'],
+        callbacks
+      })
+      return created.runtime
+    })
+    const session = await coordinator.createSession({ cwd: '/workspace' })
+
+    await coordinator.prepareForQuit()
+
+    await expect(
+      coordinator.sendPrompt({ sessionId: session.sessionId, text: 'late user turn' })
+    ).rejects.toThrow(/quitting/i)
+    await expect(
+      coordinator.sendAppContinuation({
+        sessionId: session.sessionId,
+        text: 'late app continuation'
+      })
+    ).rejects.toThrow(/quitting/i)
+    await expect(
+      coordinator.startContinuation({
+        sessionId: session.sessionId,
+        text: 'late accepted continuation'
+      })
+    ).rejects.toThrow(/quitting/i)
+    await expect(
+      coordinator.withActivity({}, (runtime) =>
+        runtime.buildReviewerSession({ cwd: '/workspace', mcpServers: [] })
+      )
+    ).rejects.toThrow(/quitting/i)
+    await expect(
+      coordinator.buildReviewerSession({ cwd: '/workspace', mcpServers: [] })
+    ).rejects.toThrow(/quitting/i)
+    await expect(coordinator.compactSession({ sessionId: session.sessionId })).rejects.toThrow(
+      /quitting/i
+    )
+
+    expect(created.sendPrompt).not.toHaveBeenCalled()
+    expect(created.sendAppContinuation).not.toHaveBeenCalled()
+    expect(vi.mocked(created.runtime.buildReviewerSession)).not.toHaveBeenCalled()
+    expect(created.compactSession).not.toHaveBeenCalled()
+  })
+
+  it('rejects a user prompt still waiting on admission when quit begins', async () => {
+    const admission = createDeferred<void>()
+    let created!: ReturnType<typeof createFakeRuntime>
+    const coordinator = new AcpRuntimeCoordinator((callbacks) => {
+      created = createFakeRuntime({
+        frameworkId: 'codex',
+        sessionIds: ['session-1'],
+        callbacks
+      })
+      return created.runtime
+    })
+    const session = await coordinator.createSession({ cwd: '/workspace' })
+    coordinator.setPromptAdmissionGuard(async () => admission.promise)
+
+    const prompting = coordinator.sendPrompt({
+      sessionId: session.sessionId,
+      text: 'waiting at startup gate'
+    })
+    await Promise.resolve()
+    await coordinator.prepareForQuit()
+    admission.resolve()
+
+    await expect(prompting).rejects.toThrow(/quitting/i)
+    expect(created.sendPrompt).not.toHaveBeenCalled()
+  })
+
+  it('tracks and drains a reviewer correction admitted just before quit', async () => {
+    const promptStart = createDeferred<void>()
+    const beforePromptStart = vi.fn(async () => promptStart.promise)
+    let created!: ReturnType<typeof createFakeRuntime>
+    const coordinator = new AcpRuntimeCoordinator((callbacks) => {
+      created = createFakeRuntime({
+        frameworkId: 'claude-code',
+        sessionIds: ['session-1'],
+        callbacks,
+        beforePromptStart
+      })
+      return created.runtime
+    })
+    const session = await coordinator.createSession({ cwd: '/workspace' })
+    const activity = coordinator.withActivity({}, (runtime) =>
+      runtime.sendPrompt({ sessionId: session.sessionId, text: '[Auditor] correction' })
+    )
+    await Promise.resolve()
+    await Promise.resolve()
+
+    let prepared = false
+    const preparing = coordinator.prepareForQuit().then(() => {
+      prepared = true
+    })
+    await Promise.resolve()
+
+    expect(beforePromptStart).toHaveBeenCalledOnce()
+    expect(created.cancelPrompt).toHaveBeenCalledWith({ sessionId: session.sessionId })
+    expect(prepared).toBe(false)
+
+    promptStart.resolve()
+    await activity
+    await preparing
+    expect(prepared).toBe(true)
+  })
+
+  it('disposes a reviewer session whose build finishes after quit begins', async () => {
+    const reviewerSession = createDeferred<void>()
+    let created!: ReturnType<typeof createFakeRuntime>
+    const coordinator = new AcpRuntimeCoordinator((callbacks) => {
+      created = createFakeRuntime({
+        frameworkId: 'codex',
+        sessionIds: [],
+        callbacks,
+        beforeReviewerSession: async () => reviewerSession.promise
+      })
+      return created.runtime
+    })
+
+    const building = coordinator.buildReviewerSession({ cwd: '/workspace', mcpServers: [] })
+    await Promise.resolve()
+    await coordinator.prepareForQuit()
+    reviewerSession.resolve()
+
+    await expect(building).rejects.toThrow(/quitting/i)
+    expect(vi.mocked(created.runtime.disposeReviewerSession)).toHaveBeenCalledOnce()
   })
 
   it('blocks user prompts on startup admission while allowing recovery continuations through', async () => {
@@ -2101,11 +2234,15 @@ describe('AcpRuntimeCoordinator', () => {
       projectName: 'project-1',
       previousFrameworkId: 'claude-code'
     })
-    expect(vi.mocked(created[1].runtime.sendPrompt)).toHaveBeenCalledWith({
-      sessionId: 'old-session',
-      text: '[Auditor] fix this',
-      historyPreamble: 'prior transcript'
-    })
+    expect(vi.mocked(created[1].runtime.sendPrompt)).toHaveBeenCalledWith(
+      {
+        sessionId: 'old-session',
+        text: '[Auditor] fix this',
+        historyPreamble: 'prior transcript',
+        provenanceContext: { promptMessageId: expect.stringMatching(/^prompt-/u) }
+      },
+      'prompt-attempt-1'
+    )
     expect(vi.mocked(created[0].runtime.sendPrompt)).not.toHaveBeenCalled()
   })
 

--- a/src/main/acp/runtime-coordinator.ts
+++ b/src/main/acp/runtime-coordinator.ts
@@ -25,6 +25,7 @@ import { ConversationPermissionGrantStore } from './permission-broker'
 import type { ApprovedSwitchReadBack, ClaudeCodeReplayInput } from '../agents/claude-code-handoff'
 
 const MAX_EVENTS = 500
+const QUIT_PREPARATION_TIMEOUT_MS = 4_000
 
 const isOwnershipScopedControlEvent = (event: AcpRuntimeEvent): boolean =>
   event.kind === 'compaction' || event.recoverable === 'context-overflow'
@@ -278,6 +279,41 @@ class AcpRuntimeCoordinator {
     this.invalidateAllSessionTurns()
     this.supersedeInitializationRequests()
     return this.shutdownAll((runtime) => runtime.shutdownForQuit())
+  }
+
+  // Gives active agents a bounded chance to return their terminal stop response before process-tree
+  // teardown. Those responses carry the final usage available from Claude Code/OpenCode/managed Codex;
+  // an unresponsive agent cannot hold app quit indefinitely.
+  async prepareForQuit(timeoutMs = QUIT_PREPARATION_TIMEOUT_MS): Promise<void> {
+    const sessionIds = Array.from(
+      new Set([
+        ...this.activePromptRequests.keys(),
+        ...this.pendingPromptStarts.keys(),
+        ...this.getSnapshot().promptInFlightSessionIds
+      ])
+    )
+    if (sessionIds.length === 0) return
+
+    const cancelAndDrain = async (): Promise<void> => {
+      await Promise.allSettled(
+        sessionIds.map((sessionId) => this.cancelPrompt({ sessionId }).then(() => undefined))
+      )
+      await Promise.all(
+        sessionIds.map((sessionId) => this.waitForSessionInteractionRelease(sessionId))
+      )
+    }
+
+    await new Promise<void>((resolve) => {
+      let settled = false
+      const finish = (): void => {
+        if (settled) return
+        settled = true
+        clearTimeout(timer)
+        resolve()
+      }
+      const timer = setTimeout(finish, Math.max(0, timeoutMs))
+      void cancelAndDrain().then(finish, finish)
+    })
   }
 
   async shutdownForUpdateGate(): Promise<{ reaped: boolean }> {

--- a/src/main/acp/runtime-coordinator.ts
+++ b/src/main/acp/runtime-coordinator.ts
@@ -107,6 +107,7 @@ class AcpRuntimeCoordinator {
   private readonly activePromptCounts = new Map<string, number>()
   private readonly interactionReleaseWaiters = new Map<string, Set<() => void>>()
   private promptAdmissionGuard?: (sessionId: string) => Promise<void>
+  private promptAdmissionClosedForQuit = false
   private readonly pendingSessionAdoptions = new Map<string, AcpRuntime>()
   private readonly pendingSessionDrains = new Map<string, PendingSessionDrain>()
   // The latest user-originated prompt is retained only long enough to construct an app-owned
@@ -285,6 +286,7 @@ class AcpRuntimeCoordinator {
   // teardown. Those responses carry the final usage available from Claude Code/OpenCode/managed Codex;
   // an unresponsive agent cannot hold app quit indefinitely.
   async prepareForQuit(timeoutMs = QUIT_PREPARATION_TIMEOUT_MS): Promise<void> {
+    this.promptAdmissionClosedForQuit = true
     const sessionIds = Array.from(
       new Set([
         ...this.activePromptRequests.keys(),
@@ -498,7 +500,9 @@ class AcpRuntimeCoordinator {
   }
 
   async compactSession(request: AcpCompactSessionRequest): Promise<AcpStateSnapshot> {
+    this.assertPromptAdmissionOpen()
     await this.waitForInitialization()
+    this.assertPromptAdmissionOpen()
     await this.runtimeForSession(request.sessionId).compactSession(request)
     return this.getSnapshot()
   }
@@ -508,6 +512,7 @@ class AcpRuntimeCoordinator {
   }
 
   sendPrompt(request: AcpPromptRequest): ReturnType<AcpRuntime['sendPrompt']> {
+    if (this.promptAdmissionClosedForQuit) return this.rejectPromptForQuit()
     if (!this.promptAdmissionGuard) return this.dispatchPrompt(request, undefined, 'sendPrompt')
     return this.promptAdmissionGuard(request.sessionId).then(() =>
       this.dispatchPrompt(request, undefined, 'sendPrompt')
@@ -552,10 +557,13 @@ class AcpRuntimeCoordinator {
   private dispatchPrompt(
     request: AcpPromptRequest,
     acceptance: PromptAcceptance | undefined,
-    operation: 'sendPrompt' | 'sendAppContinuation'
+    operation: 'sendPrompt' | 'sendAppContinuation',
+    pinnedRuntime?: AcpRuntime,
+    retainAsLatestUserPrompt = operation === 'sendPrompt'
   ): ReturnType<AcpRuntime['sendPrompt']> {
-    const owner = this.findRuntimeForSession(request.sessionId)
-    if (owner && this.retiredRuntimes.has(owner)) {
+    if (this.promptAdmissionClosedForQuit) return this.rejectPromptForQuit()
+    const owner = pinnedRuntime ?? this.findRuntimeForSession(request.sessionId)
+    if (!pinnedRuntime && owner && this.retiredRuntimes.has(owner)) {
       return Promise.reject(new Error('ACP session must resume before sending a prompt'))
     }
 
@@ -586,7 +594,7 @@ class AcpRuntimeCoordinator {
       acceptance
     }
     this.activePromptRequests.set(request.sessionId, activePrompt)
-    if (operation === 'sendPrompt') this.latestPromptRequests.set(request.sessionId, taskRequest)
+    if (retainAsLatestUserPrompt) this.latestPromptRequests.set(request.sessionId, taskRequest)
     return runtime[operation](taskRequest, attempt.id).finally(() => {
       this.removePendingPromptStart(request.sessionId, attempt)
       if (this.activePromptRequests.get(request.sessionId) === activePrompt) {
@@ -733,19 +741,20 @@ class AcpRuntimeCoordinator {
     options: AcpRuntimeActivityOptions,
     work: (runtime: AcpRuntimeActivity) => Promise<T>
   ): Promise<T> {
+    this.assertPromptAdmissionOpen()
     const runtime = this.getActiveRuntime()
     const scopedRuntime = this.createScopedActivityRuntime(runtime, options)
 
-    return runtime.withActivity(options, () => work(scopedRuntime))
+    return runtime.withActivity(options, () => {
+      this.assertPromptAdmissionOpen()
+      return work(scopedRuntime)
+    })
   }
 
   async buildReviewerSession(
     request: Parameters<AcpRuntime['buildReviewerSession']>[0]
   ): ReturnType<AcpRuntime['buildReviewerSession']> {
-    const runtime = this.getActiveRuntime()
-    const built = await runtime.buildReviewerSession(request)
-    this.reviewerRuntimes.set(built.session, runtime)
-    return built
+    return this.buildReviewerSessionOnRuntime(this.getActiveRuntime(), request)
   }
 
   disposeReviewerSession(session: ActiveSession): ReturnType<AcpRuntime['disposeReviewerSession']> {
@@ -794,25 +803,43 @@ class AcpRuntimeCoordinator {
     }
 
     return {
-      buildReviewerSession: async (request) => {
-        const built = await runtime.buildReviewerSession(request)
-        this.reviewerRuntimes.set(built.session, runtime)
-        return built
-      },
+      buildReviewerSession: (request) => this.buildReviewerSessionOnRuntime(runtime, request),
       disposeReviewerSession: (session) => {
         this.reviewerRuntimes.delete(session)
         return runtime.disposeReviewerSession(session)
       },
       sendPrompt: async (request) => {
+        this.assertPromptAdmissionOpen()
         const contextReset = await ensureActivitySession(request.sessionId)
         const historyPreamble = options.session?.historyPreamble
-        return runtime.sendPrompt(
+        return this.dispatchPrompt(
           contextReset && historyPreamble && !request.historyPreamble
             ? { ...request, historyPreamble }
-            : request
+            : request,
+          undefined,
+          'sendPrompt',
+          runtime,
+          false
         )
       }
     }
+  }
+
+  private async buildReviewerSessionOnRuntime(
+    runtime: AcpRuntime,
+    request: Parameters<AcpRuntime['buildReviewerSession']>[0]
+  ): ReturnType<AcpRuntime['buildReviewerSession']> {
+    this.assertPromptAdmissionOpen()
+    const built = await runtime.buildReviewerSession(request)
+    if (this.promptAdmissionClosedForQuit) {
+      try {
+        runtime.disposeReviewerSession(built.session)
+      } finally {
+        this.assertPromptAdmissionOpen()
+      }
+    }
+    this.reviewerRuntimes.set(built.session, runtime)
+    return built
   }
 
   private async waitForInitialization(): Promise<void> {
@@ -825,6 +852,16 @@ class AcpRuntimeCoordinator {
 
   private supersedeInitializationRequests(): void {
     this.initializationGeneration += 1
+  }
+
+  private assertPromptAdmissionOpen(): void {
+    if (this.promptAdmissionClosedForQuit) {
+      throw new Error('ACP prompt admission is closed because the app is quitting.')
+    }
+  }
+
+  private rejectPromptForQuit(): Promise<never> {
+    return Promise.reject(new Error('ACP prompt admission is closed because the app is quitting.'))
   }
 
   private invalidateSessionTurn(sessionId: string, notifyCancellation = true): void {

--- a/src/main/acp/runtime.test.ts
+++ b/src/main/acp/runtime.test.ts
@@ -15027,7 +15027,15 @@ describe('ACP runtime session management', () => {
         if (prompts.length === 1) {
           promptStarted.resolve()
           await promptCanStop.promise
-          return { stopReason: 'cancelled' }
+          return {
+            stopReason: 'cancelled',
+            usage: {
+              totalTokens: 27,
+              inputTokens: 19,
+              cachedReadTokens: 5,
+              outputTokens: 3
+            }
+          }
         }
 
         return { stopReason: 'end_turn' }
@@ -15067,6 +15075,9 @@ describe('ACP runtime session management', () => {
 
     expect(runtime.getSnapshot().promptInFlightSessionIds).toEqual([])
     expect(prompts).toEqual(['first prompt'])
+    expect(runtime.getSnapshot().events.find((event) => event.kind === 'stop')).toMatchObject({
+      turnUsage: { inputTokens: 19, cacheTokens: 5, outputTokens: 3 }
+    })
   })
 })
 

--- a/src/main/acp/session-interaction-owner.test.ts
+++ b/src/main/acp/session-interaction-owner.test.ts
@@ -161,6 +161,21 @@ describe('AcpSessionInteractionOwner', () => {
     expect(owner.current('session-1')).toBe(scope)
   })
 
+  it('cancels a prompt reservation that is still in preflight', async () => {
+    const owner = new AcpSessionInteractionOwner()
+    const scope = owner.reservePrompt({ sessionId: 'session-1', kind: 'prompt' })
+
+    await owner.cancelPrompt({
+      sessionId: 'session-1',
+      notify: async () => undefined,
+      onAccepted: vi.fn(),
+      onTimeout: vi.fn()
+    })
+    owner.activatePrompt(scope)
+
+    await expect(owner.cancellationCheckpoint(scope)).resolves.toBe('cancelled')
+  })
+
   it('keeps cancellation inactive and clears its timer when notify fails', async () => {
     const clearTimer = vi.fn()
     const owner = new AcpSessionInteractionOwner({

--- a/src/main/acp/session-interaction-owner.ts
+++ b/src/main/acp/session-interaction-owner.ts
@@ -234,7 +234,9 @@ export class AcpSessionInteractionOwner {
     }
     this.pendingCancellations.set(request.sessionId, attempt)
 
-    const active = this.activeInteractions.get(request.sessionId)
+    const active =
+      this.activeInteractions.get(request.sessionId) ??
+      this.pendingPromptReservations.get(request.sessionId)
     const scope = active?.scope
     active?.abortController.abort()
     this.clearCancellationTimer(request.sessionId)
@@ -250,7 +252,11 @@ export class AcpSessionInteractionOwner {
     let accepted = false
     try {
       await request.notify()
-      if (active && this.activeInteractions.get(request.sessionId) === active) {
+      if (
+        active &&
+        (this.activeInteractions.get(request.sessionId) === active ||
+          this.pendingPromptReservations.get(request.sessionId) === active)
+      ) {
         active.cancelled = true
       }
       accepted = true

--- a/src/main/app-lifecycle.test.ts
+++ b/src/main/app-lifecycle.test.ts
@@ -111,6 +111,8 @@ type Harness = {
   tray: { destroy: ReturnType<typeof vi.fn> } | undefined
   trayHandlers: TrayHandlers | undefined
   shutdownBackends: () => Promise<void>
+  prepareForQuit: () => Promise<void>
+  flushSessionPersistence: () => Promise<void>
   quit: ReturnType<typeof vi.fn>
   showMainWindow: () => void
   getMainWindow: () => import('electron').BrowserWindow | undefined
@@ -123,7 +125,12 @@ const setup = (
   overrides: Partial<
     Pick<
       AppLifecycleDeps,
-      'shutdownBackends' | 'isMigrationInProgress' | 'platform' | 'createInitialWindow'
+      | 'shutdownBackends'
+      | 'prepareForQuit'
+      | 'flushSessionPersistence'
+      | 'isMigrationInProgress'
+      | 'platform'
+      | 'createInitialWindow'
     >
   > & {
     trayHost?: boolean
@@ -140,6 +147,8 @@ const setup = (
   const tray = trayHost ? { destroy: vi.fn() } : undefined
   let trayHandlers: TrayHandlers | undefined
   const shutdownBackends = overrides.shutdownBackends ?? vi.fn(async () => undefined)
+  const prepareForQuit = overrides.prepareForQuit ?? vi.fn(async () => undefined)
+  const flushSessionPersistence = overrides.flushSessionPersistence ?? vi.fn(async () => undefined)
   const quit = vi.fn()
   const closeOpts: CapturedCloseOpts[] = []
   const confirmClose = vi.fn(
@@ -160,6 +169,8 @@ const setup = (
       return tray as unknown as import('electron').Tray | undefined
     },
     shutdownBackends,
+    prepareForQuit,
+    flushSessionPersistence,
     isMigrationInProgress: overrides.isMigrationInProgress ?? ((): boolean => false),
     quit,
     countWindows: () => windows.filter((w) => !w.destroyed).length,
@@ -174,6 +185,8 @@ const setup = (
     tray,
     trayHandlers,
     shutdownBackends,
+    prepareForQuit,
+    flushSessionPersistence,
     quit,
     showMainWindow,
     getMainWindow,
@@ -291,6 +304,8 @@ describe('installAppLifecycle', () => {
       createMainWindow: () => asWindow(makeFakeWindow()),
       createTray: () => ({ destroy: vi.fn() }) as unknown as import('electron').Tray,
       shutdownBackends,
+      prepareForQuit: async () => undefined,
+      flushSessionPersistence: async () => undefined,
       isMigrationInProgress: (): boolean => false,
       quit: vi.fn(),
       countWindows: (): number => 1,
@@ -319,10 +334,33 @@ describe('installAppLifecycle', () => {
     app.emit('before-quit') // starts cleanup (pending)
     const second = app.emit('before-quit') // re-issued while running
     expect(second.defaultPrevented).toBe(true)
+    await flush()
     expect(shutdownBackends).toHaveBeenCalledTimes(1)
 
     release?.()
     await flush()
+    expect(app.exit).toHaveBeenCalledWith(0)
+  })
+
+  it('waits for ACP cancellation and Session persistence before backend teardown', async () => {
+    const calls: string[] = []
+    const { app, closeOpts } = setup({
+      prepareForQuit: vi.fn(async () => {
+        calls.push('prepare')
+      }),
+      flushSessionPersistence: vi.fn(async () => {
+        calls.push('flush')
+      }),
+      shutdownBackends: vi.fn(async () => {
+        calls.push('shutdown')
+      })
+    })
+    closeOpts[0].requestQuit()
+
+    app.emit('before-quit')
+    await flush()
+
+    expect(calls).toEqual(['prepare', 'flush', 'shutdown'])
     expect(app.exit).toHaveBeenCalledWith(0)
   })
 

--- a/src/main/app-lifecycle.test.ts
+++ b/src/main/app-lifecycle.test.ts
@@ -102,7 +102,7 @@ const asWindow = (w: FakeWindow): import('electron').BrowserWindow =>
 type CapturedCloseOpts = {
   classifyClose: () => CloseClassification
   resolveCloseAction: () => Promise<CloseConfirmChoice>
-  requestQuit: () => void
+  requestQuit: (confirmed?: boolean) => void
 }
 
 type Harness = {
@@ -437,9 +437,9 @@ describe('installAppLifecycle', () => {
     expect(captured.classifyClose()).toBe('hide')
   })
 
-  it('classifyClose returns "close" when no tray', () => {
+  it('classifyClose returns "quit" when no tray so the renderer survives through flush', () => {
     const captured = installWithCapturedOpts({ platform: 'win32', hasTray: false })
-    expect(captured.classifyClose()).toBe('close')
+    expect(captured.classifyClose()).toBe('quit')
   })
 
   it('resolveCloseAction resolves via confirmClose("close-to-tray", sessions)', async () => {
@@ -456,6 +456,22 @@ describe('installAppLifecycle', () => {
     const { closeOpts, quit } = setup()
     closeOpts[0].requestQuit()
     expect(quit).toHaveBeenCalledTimes(1)
+  })
+
+  it('keeps a no-tray close unconfirmed so active work still prompts before quit', async () => {
+    const sessions: ActiveSessionInfo[] = [{ projectId: 'demo', sessionId: 's1', kind: 'agent' }]
+    const confirmClose = vi.fn(async (): Promise<CloseConfirmChoice> => 'cancel')
+    const { app, closeOpts } = setup({
+      trayHost: false,
+      detectActiveSessions: () => sessions,
+      confirmClose
+    })
+
+    closeOpts[0].requestQuit(false)
+    app.emit('before-quit')
+    await flush()
+
+    expect(confirmClose).toHaveBeenCalledWith('quit', sessions)
   })
 
   it('before-quit with no active work proceeds to shutdown (confirmClose resolves quit)', async () => {

--- a/src/main/app-lifecycle.test.ts
+++ b/src/main/app-lifecycle.test.ts
@@ -342,6 +342,29 @@ describe('installAppLifecycle', () => {
     expect(app.exit).toHaveBeenCalledWith(0)
   })
 
+  it('keeps the renderer alive when the window is closed again during quit cleanup', async () => {
+    let release: (() => void) | undefined
+    const prepareForQuit = vi.fn(
+      () =>
+        new Promise<void>((resolve) => {
+          release = resolve
+        })
+    )
+    const { app, closeOpts } = setup({
+      platform: 'linux',
+      trayHost: false,
+      prepareForQuit
+    })
+    closeOpts[0].requestQuit()
+
+    app.emit('before-quit')
+
+    expect(closeOpts[0].classifyClose()).toBe('quit')
+
+    release?.()
+    await flush()
+  })
+
   it('waits for ACP cancellation and Session persistence before backend teardown', async () => {
     const calls: string[] = []
     const { app, closeOpts } = setup({

--- a/src/main/app-lifecycle.ts
+++ b/src/main/app-lifecycle.ts
@@ -26,6 +26,10 @@ export type AppLifecycleDeps = {
   createTray: (handlers: TrayHandlers) => Tray | undefined
   // Bounded, best-effort backend teardown (agent tree + notebook kernels); never throws.
   shutdownBackends: () => Promise<void>
+  // Requests active ACP turns to cancel, then waits a bounded interval for terminal usage events.
+  prepareForQuit: () => Promise<void>
+  // Drains renderer runtime events and its ordered Session write queue before the window disappears.
+  flushSessionPersistence: () => Promise<void>
   // True while a data-root migration is copying; a quit during it is owned by the migration guard.
   isMigrationInProgress: () => boolean
   // Requests an app quit (app.quit); the before-quit handler below turns it into an awaited teardown.
@@ -197,6 +201,8 @@ export const installAppLifecycle = (
     shutdownStarted = true
     void (async () => {
       try {
+        await deps.prepareForQuit().catch(() => undefined)
+        await deps.flushSessionPersistence().catch(() => undefined)
         await deps.shutdownBackends()
       } finally {
         trayBox.current?.destroy()

--- a/src/main/app-lifecycle.ts
+++ b/src/main/app-lifecycle.ts
@@ -81,12 +81,14 @@ export const installAppLifecycle = (
 
   const confirmClose = deps.createConfirmClose(() => mainWindow)
 
-  // Synchronous close classification, evaluated at close time. darwin keeps its dock convention (real
-  // close); a mid-quit proceeds; no-tray hosts retain the renderer while requesting app quit; Windows
-  // asks (confirm); Linux keeps silent hide-to-tray.
+  // Synchronous close classification, evaluated at close time. A mid-quit close is held so the
+  // renderer survives persistence flushing; otherwise darwin keeps its dock convention (real close),
+  // no-tray hosts retain the renderer while requesting app quit, Windows asks (confirm), and Linux
+  // keeps silent hide-to-tray.
   const classifyClose = (): CloseClassification => {
+    if (shutdownStarted) return 'quit'
     if (platform === 'darwin') return 'close'
-    if (shutdownStarted || quitConfirmed) return 'close'
+    if (quitConfirmed) return 'close'
     if (!trayBox.current) return 'quit'
     if (platform === 'win32') return 'confirm'
     return 'hide'

--- a/src/main/app-lifecycle.ts
+++ b/src/main/app-lifecycle.ts
@@ -20,7 +20,7 @@ export type AppLifecycleDeps = {
   createMainWindow: (opts: {
     classifyClose: () => CloseClassification
     resolveCloseAction: () => Promise<CloseConfirmChoice>
-    requestQuit: () => void
+    requestQuit: (confirmed?: boolean) => void
   }) => BrowserWindow
   // Builds the tray; returns undefined on hosts without a tray (e.g. some Linux desktops).
   createTray: (handlers: TrayHandlers) => Tray | undefined
@@ -82,10 +82,12 @@ export const installAppLifecycle = (
   const confirmClose = deps.createConfirmClose(() => mainWindow)
 
   // Synchronous close classification, evaluated at close time. darwin keeps its dock convention (real
-  // close); a mid-quit or no-tray close proceeds; Windows asks (confirm); Linux keeps silent hide-to-tray.
+  // close); a mid-quit proceeds; no-tray hosts retain the renderer while requesting app quit; Windows
+  // asks (confirm); Linux keeps silent hide-to-tray.
   const classifyClose = (): CloseClassification => {
     if (platform === 'darwin') return 'close'
-    if (!trayBox.current || shutdownStarted || quitConfirmed) return 'close'
+    if (shutdownStarted || quitConfirmed) return 'close'
+    if (!trayBox.current) return 'quit'
     if (platform === 'win32') return 'confirm'
     return 'hide'
   }
@@ -106,8 +108,8 @@ export const installAppLifecycle = (
     const window = deps.createMainWindow({
       classifyClose,
       resolveCloseAction,
-      requestQuit: () => {
-        quitConfirmed = true
+      requestQuit: (confirmed = true) => {
+        quitConfirmed = confirmed
         deps.quit()
       }
     })

--- a/src/main/index.ts
+++ b/src/main/index.ts
@@ -118,6 +118,7 @@ async function startElectronApp(mainEntryPath: string): Promise<void> {
         { parseWebModeOptions, createWebServiceController, buildAuthenticatedWebUrl },
         { routeSecondInstance },
         { createElectronCloseConfirm },
+        { createElectronSessionPersistenceFlush },
         { installWindowShortcuts },
         { createAppIconController, buildAppIconPreviews },
         { RemoteAccessService, registerRemoteAccessIpcHandlers },
@@ -141,6 +142,7 @@ async function startElectronApp(mainEntryPath: string): Promise<void> {
         import('./web-service'),
         import('./second-instance-router'),
         import('./window-close-confirm'),
+        import('./session-persistence/renderer-flush'),
         import('./window-shortcuts'),
         import('./app-icon'),
         import('./remote-access'),
@@ -225,6 +227,7 @@ async function startElectronApp(mainEntryPath: string): Promise<void> {
         taskAgent,
         sessionDeletionCapability,
         detectActiveSessions,
+        prepareForQuit,
         dispose: disposeApplicationRuntime
       } = await registerIpcHandlers({
         mainEntryPath,
@@ -321,6 +324,10 @@ async function startElectronApp(mainEntryPath: string): Promise<void> {
         settingsService,
         disposeApplicationRuntime,
         detectActiveSessions,
+        prepareForQuit,
+        createSessionPersistenceFlush: (
+          getWindow: () => InstanceType<typeof BrowserWindow> | undefined
+        ) => createElectronSessionPersistenceFlush(getWindow),
         createConfirmClose: (getWindow: () => InstanceType<typeof BrowserWindow> | undefined) =>
           createElectronCloseConfirm(getWindow, {
             get: () => settingsService.getClosePreference(),
@@ -379,6 +386,10 @@ async function startElectronApp(mainEntryPath: string): Promise<void> {
             countWindows: () => BrowserWindow.getAllWindows().length,
             createInitialWindow: !ctx.webMode.headless,
             detectActiveSessions: ctx.detectActiveSessions,
+            prepareForQuit: ctx.prepareForQuit,
+            flushSessionPersistence: ctx.createSessionPersistenceFlush(() =>
+              ctx.mainWindowGetterBox.current?.()
+            ),
             createConfirmClose: ctx.createConfirmClose
           },
           {

--- a/src/main/ipc.ts
+++ b/src/main/ipc.ts
@@ -194,6 +194,7 @@ export type ApplicationRuntimeInterfaces = {
   taskAgent: TaskAgentPort
   sessionDeletionCapability: Pick<SessionPersistenceCoordinator, 'setSessionDeletionHandlers'>
   detectActiveSessions: () => ReturnType<typeof detectActiveSessions>
+  prepareForQuit: () => Promise<void>
 }
 
 type ApplicationModuleInterfaces = ApplicationRuntimeInterfaces & {
@@ -1340,6 +1341,7 @@ const createApplicationModules = async (
     taskAgent,
     sessionDeletionCapability: sessionPersistenceCoordinator,
     detectActiveSessions: () => detectActiveSessions({ runtime, notebook: notebookService }),
+    prepareForQuit: () => runtime.prepareForQuit(),
     electronAdapters: {
       beforeCompute: beforeComputeAdapters,
       compute: computeIpcModule,

--- a/src/main/session-persistence/renderer-flush.test.ts
+++ b/src/main/session-persistence/renderer-flush.test.ts
@@ -1,0 +1,93 @@
+import { describe, expect, it, vi } from 'vitest'
+
+import { requestRendererSessionPersistenceFlush } from './renderer-flush'
+
+type Listener = (requestId: string) => void
+
+const createHarness = (
+  available = true
+): {
+  sendRequest: ReturnType<typeof vi.fn>
+  respond: Listener
+  rendererGone: () => void
+  cleanupResponse: ReturnType<typeof vi.fn>
+  cleanupGone: ReturnType<typeof vi.fn>
+  request: () => Promise<void>
+} => {
+  let responseListener: Listener = () => undefined
+  let goneListener = (): void => undefined
+  const cleanupResponse = vi.fn()
+  const cleanupGone = vi.fn()
+  const sendRequest = vi.fn()
+
+  return {
+    sendRequest,
+    respond: (requestId) => responseListener(requestId),
+    rendererGone: () => goneListener(),
+    cleanupResponse,
+    cleanupGone,
+    request: () =>
+      requestRendererSessionPersistenceFlush({
+        isRendererAvailable: () => available,
+        sendRequest,
+        onResponse: (listener) => {
+          responseListener = listener
+          return cleanupResponse
+        },
+        onRendererGone: (listener) => {
+          goneListener = listener
+          return cleanupGone
+        },
+        createRequestId: () => 'flush-1',
+        timeoutMs: 1_000
+      })
+  }
+}
+
+describe('requestRendererSessionPersistenceFlush', () => {
+  it('waits for the matching renderer acknowledgement and removes listeners', async () => {
+    const harness = createHarness()
+    const request = harness.request()
+    let settled = false
+    void request.then(() => {
+      settled = true
+    })
+
+    expect(harness.sendRequest).toHaveBeenCalledWith('flush-1')
+    harness.respond('other')
+    await Promise.resolve()
+    expect(settled).toBe(false)
+
+    harness.respond('flush-1')
+    await request
+    expect(harness.cleanupResponse).toHaveBeenCalledOnce()
+    expect(harness.cleanupGone).toHaveBeenCalledOnce()
+  })
+
+  it('does not wait when no renderer is available', async () => {
+    const harness = createHarness(false)
+    await expect(harness.request()).resolves.toBeUndefined()
+    expect(harness.sendRequest).not.toHaveBeenCalled()
+  })
+
+  it('releases the quit when the renderer disappears', async () => {
+    const harness = createHarness()
+    const request = harness.request()
+    harness.rendererGone()
+    await expect(request).resolves.toBeUndefined()
+  })
+
+  it('bounds the wait when the renderer never acknowledges', async () => {
+    vi.useFakeTimers()
+    try {
+      const harness = createHarness()
+      const request = harness.request()
+      await vi.advanceTimersByTimeAsync(1_000)
+      await expect(request).resolves.toBeUndefined()
+      expect(harness.cleanupResponse).toHaveBeenCalledOnce()
+      expect(harness.cleanupGone).toHaveBeenCalledOnce()
+    } finally {
+      vi.useRealTimers()
+    }
+  })
+})

--- a/src/main/session-persistence/renderer-flush.ts
+++ b/src/main/session-persistence/renderer-flush.ts
@@ -1,0 +1,87 @@
+import { randomUUID } from 'node:crypto'
+import { ipcMain, type BrowserWindow } from 'electron'
+
+import {
+  SESSION_PERSISTENCE_FLUSH_REQUEST_CHANNEL,
+  SESSION_PERSISTENCE_FLUSH_RESPONSE_CHANNEL,
+  type SessionPersistenceFlushRequest,
+  type SessionPersistenceFlushResponse
+} from '../../shared/session-persistence-flush'
+
+type RendererSessionPersistenceFlushDeps = {
+  isRendererAvailable: () => boolean
+  sendRequest: (requestId: string) => void
+  onResponse: (listener: (requestId: string) => void) => () => void
+  onRendererGone: (listener: () => void) => () => void
+  createRequestId: () => string
+  timeoutMs: number
+}
+
+const DEFAULT_RENDERER_FLUSH_TIMEOUT_MS = 1_500
+
+export const requestRendererSessionPersistenceFlush = async (
+  deps: RendererSessionPersistenceFlushDeps
+): Promise<void> => {
+  if (!deps.isRendererAvailable()) return
+
+  const requestId = deps.createRequestId()
+  await new Promise<void>((resolve) => {
+    let settled = false
+    let removeResponse = (): void => undefined
+    let removeRendererGone = (): void => undefined
+    const finish = (): void => {
+      if (settled) return
+      settled = true
+      clearTimeout(timer)
+      removeResponse()
+      removeRendererGone()
+      resolve()
+    }
+    const timer = setTimeout(finish, deps.timeoutMs)
+    removeResponse = deps.onResponse((responseId) => {
+      if (responseId === requestId) finish()
+    })
+    removeRendererGone = deps.onRendererGone(finish)
+
+    try {
+      deps.sendRequest(requestId)
+    } catch {
+      finish()
+    }
+  })
+}
+
+export const createElectronSessionPersistenceFlush = (
+  getWindow: () => BrowserWindow | undefined,
+  timeoutMs = DEFAULT_RENDERER_FLUSH_TIMEOUT_MS
+): (() => Promise<void>) => {
+  return () => {
+    const window = getWindow()
+    const webContents = window?.webContents
+    return requestRendererSessionPersistenceFlush({
+      isRendererAvailable: () =>
+        Boolean(window && !window.isDestroyed() && webContents && !webContents.isDestroyed()),
+      sendRequest: (requestId) => {
+        const request: SessionPersistenceFlushRequest = { requestId }
+        webContents?.send(SESSION_PERSISTENCE_FLUSH_REQUEST_CHANNEL, request)
+      },
+      onResponse: (listener) => {
+        const handler = (
+          event: Electron.IpcMainEvent,
+          response: SessionPersistenceFlushResponse | undefined
+        ): void => {
+          if (event.sender !== webContents || typeof response?.requestId !== 'string') return
+          listener(response.requestId)
+        }
+        ipcMain.on(SESSION_PERSISTENCE_FLUSH_RESPONSE_CHANNEL, handler)
+        return () => ipcMain.removeListener(SESSION_PERSISTENCE_FLUSH_RESPONSE_CHANNEL, handler)
+      },
+      onRendererGone: (listener) => {
+        webContents?.on('render-process-gone', listener)
+        return () => webContents?.removeListener('render-process-gone', listener)
+      },
+      createRequestId: randomUUID,
+      timeoutMs
+    })
+  }
+}

--- a/src/main/windows.test.ts
+++ b/src/main/windows.test.ts
@@ -877,6 +877,18 @@ describe('createMainWindow close-to-tray interceptor', () => {
     expect(window.isDestroyed()).toBe(true)
   })
 
+  it('requests app quit without destroying the renderer when classifyClose returns "quit"', () => {
+    const requestQuit = vi.fn()
+    createMainWindow({ classifyClose: () => 'quit', resolveCloseAction: vi.fn(), requestQuit })
+    const window = lastWindow!
+
+    const event = emitClose(window)
+
+    expect(event.defaultPrevented).toBe(true)
+    expect(requestQuit).toHaveBeenCalledWith(false)
+    expect(window.isDestroyed()).toBe(false)
+  })
+
   it('lets the window close when no options are provided', () => {
     createMainWindow()
     const window = lastWindow!

--- a/src/main/windows.ts
+++ b/src/main/windows.ts
@@ -91,12 +91,13 @@ const createAppWindow = (options: BrowserWindowConstructorOptions): BrowserWindo
 }
 
 // How the main window resolves a close: classifyClose decides synchronously at close time
-// ('close' = let it close, 'hide' = minimize to tray, 'confirm' = ask via resolveCloseAction).
+// ('close' = let it close, 'hide' = minimize to tray, 'quit' = retain the renderer while app quit
+// flushes it, 'confirm' = ask via resolveCloseAction).
 // resolveCloseAction is awaited only for 'confirm'; requestQuit is called when the choice is quit.
 type MainWindowCloseOptions = {
   classifyClose: () => CloseClassification
   resolveCloseAction: () => Promise<CloseConfirmChoice>
-  requestQuit: () => void
+  requestQuit: (confirmed?: boolean) => void
 }
 
 const createMainWindow = (opts?: MainWindowCloseOptions): BrowserWindow => {
@@ -334,8 +335,9 @@ const createMainWindow = (opts?: MainWindowCloseOptions): BrowserWindow => {
     }
   })
 
-  // Close handling. classifyClose decides synchronously so darwin / no-tray / mid-quit still close
-  // instantly; 'hide' minimizes to tray (Linux); 'confirm' (Windows X) asks the user. The
+  // Close handling. classifyClose decides synchronously: darwin and mid-quit close instantly; 'hide'
+  // minimizes to tray (Linux); 'quit' retains a no-tray renderer through app teardown; 'confirm'
+  // (Windows X) asks the user. The
   // Cmd/Ctrl+W fallback window.close() routes through here unchanged.
   let awaitingChoice = false
   window.on('close', (event) => {
@@ -344,6 +346,10 @@ const createMainWindow = (opts?: MainWindowCloseOptions): BrowserWindow => {
     event.preventDefault()
     if (action === 'hide') {
       window.hide()
+      return
+    }
+    if (action === 'quit') {
+      opts!.requestQuit(false)
       return
     }
     if (awaitingChoice) return

--- a/src/preload/index.d.ts
+++ b/src/preload/index.d.ts
@@ -145,6 +145,10 @@ import type {
   SaveSessionManifestRequest
 } from '../shared/session-persistence'
 import type {
+  SessionPersistenceFlushRequest,
+  SessionPersistenceFlushResponse
+} from '../shared/session-persistence-flush'
+import type {
   ExportConversationRequest,
   ExportConversationResult
 } from '../shared/conversation-export'
@@ -323,6 +327,8 @@ interface OpenScienceAPI {
     deleteSession(request: DeleteSessionRequest): Promise<void>
     saveManifest(request: SaveSessionManifestRequest): Promise<void>
     exportConversation(request: ExportConversationRequest): Promise<ExportConversationResult>
+    onFlushRequest?(listener: AcpListener<SessionPersistenceFlushRequest>): RemoveListener
+    sendFlushResponse?(response: SessionPersistenceFlushResponse): void
     onCreated(listener: AcpListener<SessionUpsertEvent>): RemoveListener
     onUpdated(listener: AcpListener<SessionUpsertEvent>): RemoveListener
     onDeleted(listener: AcpListener<SessionDeletedEvent>): RemoveListener

--- a/src/preload/index.test.ts
+++ b/src/preload/index.test.ts
@@ -42,6 +42,8 @@ type PreloadApi = {
     deleteSession: (request: unknown) => unknown
     saveManifest: (request: unknown) => unknown
     exportConversation: (request: unknown) => unknown
+    onFlushRequest: (listener: (request: { requestId: string }) => void) => unknown
+    sendFlushResponse: (response: { requestId: string }) => void
   }
   settings: {
     detectOpencode: () => unknown
@@ -293,9 +295,11 @@ describe('preload bridge — public surface inventory', () => {
       'sessions.loadAll',
       'sessions.onCreated',
       'sessions.onDeleted',
+      'sessions.onFlushRequest',
       'sessions.onUpdated',
       'sessions.saveManifest',
       'sessions.saveSession',
+      'sessions.sendFlushResponse',
       'settings.addCustomServer',
       'settings.cancelClaudeLogin',
       'settings.cancelCodexLogin',
@@ -779,6 +783,21 @@ describe('preload bridge — sessions + agent-framework IPC channels', () => {
 
   it('does not expose the legacy half-delete project-session command', () => {
     expect(api.sessions).not.toHaveProperty('deleteProjectSessions')
+  })
+
+  it('bridges the bounded Session flush request and acknowledgement channels', () => {
+    const listener = vi.fn()
+    const response = { requestId: 'flush-1' }
+
+    api.sessions.onFlushRequest(listener)
+    expect(onMock).toHaveBeenCalledWith('sessions:flush-request', expect.any(Function))
+    const wrappedListener = onMock.mock.calls.at(-1)?.[1] as
+      ((_event: unknown, request: { requestId: string }) => void) | undefined
+    wrappedListener?.({}, response)
+    expect(listener).toHaveBeenCalledWith(response)
+
+    api.sessions.sendFlushResponse(response)
+    expect(sendMock).toHaveBeenCalledWith('sessions:flush-response', response)
   })
 
   it.each(cases)('$name', ({ invoke, channel, args }) => {

--- a/src/preload/index.ts
+++ b/src/preload/index.ts
@@ -147,6 +147,12 @@ import type {
   SaveSessionOptions,
   SaveSessionManifestRequest
 } from '../shared/session-persistence'
+import {
+  SESSION_PERSISTENCE_FLUSH_REQUEST_CHANNEL,
+  SESSION_PERSISTENCE_FLUSH_RESPONSE_CHANNEL,
+  type SessionPersistenceFlushRequest,
+  type SessionPersistenceFlushResponse
+} from '../shared/session-persistence-flush'
 import type {
   ExportConversationRequest,
   ExportConversationResult
@@ -362,6 +368,8 @@ type OpenScienceAPI = {
     deleteSession: (request: DeleteSessionRequest) => Promise<void>
     saveManifest: (request: SaveSessionManifestRequest) => Promise<void>
     exportConversation: (request: ExportConversationRequest) => Promise<ExportConversationResult>
+    onFlushRequest?: (listener: AcpListener<SessionPersistenceFlushRequest>) => RemoveListener
+    sendFlushResponse?: (response: SessionPersistenceFlushResponse) => void
     onCreated: (listener: AcpListener<SessionUpsertEvent>) => RemoveListener
     onUpdated: (listener: AcpListener<SessionUpsertEvent>) => RemoveListener
     onDeleted: (listener: AcpListener<SessionDeletedEvent>) => RemoveListener
@@ -885,6 +893,9 @@ const api: OpenScienceAPI = {
         'sessions:export-conversation',
         request
       ) as Promise<ExportConversationResult>,
+    onFlushRequest: (listener) => onIpcMessage(SESSION_PERSISTENCE_FLUSH_REQUEST_CHANNEL, listener),
+    sendFlushResponse: (response) =>
+      ipcRenderer.send(SESSION_PERSISTENCE_FLUSH_RESPONSE_CHANNEL, response),
     onCreated: (listener) => onIpcMessage('session:created', listener),
     onUpdated: (listener) => onIpcMessage('session:updated', listener),
     onDeleted: (listener) => onIpcMessage('session:deleted', listener)

--- a/src/renderer/src/App.tsx
+++ b/src/renderer/src/App.tsx
@@ -23,6 +23,7 @@ import { EnvStatusBanner } from '@/pages/workspace/EnvStatusBanner'
 import { WorkspacePage } from '@/pages/workspace/WorkspacePage'
 import { useCloseActivePaneShortcut } from '@/hooks/useCloseActivePaneShortcut'
 import { useLifecycleSync } from '@/hooks/useLifecycleSync'
+import { useQuitPersistenceFlush } from '@/hooks/useQuitPersistenceFlush'
 import { useUnreadTaskViewSync } from '@/hooks/useUnreadTaskViewSync'
 import { useWindowFindAppearanceSync } from '@/hooks/useWindowFindAppearanceSync'
 import { useNavigationStore } from '@/stores/navigation-store'
@@ -44,6 +45,7 @@ type NotificationOpenIntent = {
 const App = (): React.JSX.Element | null => {
   // Persistence is started once at the top so sessions stay loaded for both Home and Workspace.
   const sessionPersistence = useSessionPersistence()
+  useQuitPersistenceFlush()
   const isSessionPersistenceHydrated = sessionPersistence.isHydrated
   const isSessionPersistenceLoading = sessionPersistence.isLoading
   const isSessionPersistenceReady = sessionPersistence.isReady

--- a/src/renderer/src/hooks/useQuitPersistenceFlush.test.ts
+++ b/src/renderer/src/hooks/useQuitPersistenceFlush.test.ts
@@ -1,0 +1,44 @@
+import { describe, expect, it, vi } from 'vitest'
+
+import { completeQuitPersistenceFlush } from './useQuitPersistenceFlush'
+
+describe('completeQuitPersistenceFlush', () => {
+  it('drains terminal runtime events before flushing and acknowledging', async () => {
+    const calls: string[] = []
+
+    await completeQuitPersistenceFlush(
+      { requestId: 'flush-1' },
+      {
+        drainRuntimeEvents: async () => {
+          calls.push('drain')
+        },
+        flushPersistence: async () => {
+          calls.push('flush')
+        },
+        acknowledge: () => {
+          calls.push('acknowledge')
+        }
+      }
+    )
+
+    expect(calls).toEqual(['drain', 'flush', 'acknowledge'])
+  })
+
+  it('always acknowledges so a failed renderer flush cannot strand app quit', async () => {
+    const acknowledge = vi.fn()
+
+    await expect(
+      completeQuitPersistenceFlush(
+        { requestId: 'flush-1' },
+        {
+          drainRuntimeEvents: async () => {
+            throw new Error('renderer unavailable')
+          },
+          flushPersistence: async () => undefined,
+          acknowledge
+        }
+      )
+    ).rejects.toThrow('renderer unavailable')
+    expect(acknowledge).toHaveBeenCalledWith({ requestId: 'flush-1' })
+  })
+})

--- a/src/renderer/src/hooks/useQuitPersistenceFlush.test.ts
+++ b/src/renderer/src/hooks/useQuitPersistenceFlush.test.ts
@@ -9,6 +9,9 @@ describe('completeQuitPersistenceFlush', () => {
     await completeQuitPersistenceFlush(
       { requestId: 'flush-1' },
       {
+        suppressAutoReviews: () => {
+          calls.push('suppress-auto-reviews')
+        },
         drainRuntimeEvents: async () => {
           calls.push('drain')
         },
@@ -21,7 +24,7 @@ describe('completeQuitPersistenceFlush', () => {
       }
     )
 
-    expect(calls).toEqual(['drain', 'flush', 'acknowledge'])
+    expect(calls).toEqual(['suppress-auto-reviews', 'drain', 'flush', 'acknowledge'])
   })
 
   it('always acknowledges so a failed renderer flush cannot strand app quit', async () => {
@@ -31,6 +34,7 @@ describe('completeQuitPersistenceFlush', () => {
       completeQuitPersistenceFlush(
         { requestId: 'flush-1' },
         {
+          suppressAutoReviews: () => undefined,
           drainRuntimeEvents: async () => {
             throw new Error('renderer unavailable')
           },

--- a/src/renderer/src/hooks/useQuitPersistenceFlush.ts
+++ b/src/renderer/src/hooks/useQuitPersistenceFlush.ts
@@ -4,10 +4,12 @@ import type {
   SessionPersistenceFlushRequest,
   SessionPersistenceFlushResponse
 } from '../../../shared/session-persistence-flush'
+import { suppressAutoReviewsForQuit } from '../lib/acp/workspace-events'
 import { drainWorkspaceRuntimeEventsForPersistence } from '../lib/acp/useWorkspaceAgentRuntime'
 import { flushSessionPersistence } from '../lib/session-persistence/session-persistence'
 
 type QuitPersistenceFlushDeps = {
+  suppressAutoReviews: () => void
   drainRuntimeEvents: () => Promise<void>
   flushPersistence: () => Promise<void>
   acknowledge: (response: SessionPersistenceFlushResponse) => void
@@ -18,6 +20,7 @@ export const completeQuitPersistenceFlush = async (
   deps: QuitPersistenceFlushDeps
 ): Promise<void> => {
   try {
+    deps.suppressAutoReviews()
     await deps.drainRuntimeEvents()
     await deps.flushPersistence()
   } finally {
@@ -34,6 +37,7 @@ export const useQuitPersistenceFlush = (): void => {
 
     return onFlushRequest((request) => {
       void completeQuitPersistenceFlush(request, {
+        suppressAutoReviews: suppressAutoReviewsForQuit,
         drainRuntimeEvents: drainWorkspaceRuntimeEventsForPersistence,
         flushPersistence: flushSessionPersistence,
         acknowledge: sendFlushResponse

--- a/src/renderer/src/hooks/useQuitPersistenceFlush.ts
+++ b/src/renderer/src/hooks/useQuitPersistenceFlush.ts
@@ -27,8 +27,8 @@ export const completeQuitPersistenceFlush = async (
 
 export const useQuitPersistenceFlush = (): void => {
   useEffect(() => {
-    const onFlushRequest = window.api.sessions.onFlushRequest
-    const sendFlushResponse = window.api.sessions.sendFlushResponse
+    const onFlushRequest = window.api.sessions?.onFlushRequest
+    const sendFlushResponse = window.api.sessions?.sendFlushResponse
     // Web/headless renderers do not participate in Electron's before-quit handshake.
     if (!onFlushRequest || !sendFlushResponse) return
 

--- a/src/renderer/src/hooks/useQuitPersistenceFlush.ts
+++ b/src/renderer/src/hooks/useQuitPersistenceFlush.ts
@@ -1,0 +1,43 @@
+import { useEffect } from 'react'
+
+import type {
+  SessionPersistenceFlushRequest,
+  SessionPersistenceFlushResponse
+} from '../../../shared/session-persistence-flush'
+import { drainWorkspaceRuntimeEventsForPersistence } from '../lib/acp/useWorkspaceAgentRuntime'
+import { flushSessionPersistence } from '../lib/session-persistence/session-persistence'
+
+type QuitPersistenceFlushDeps = {
+  drainRuntimeEvents: () => Promise<void>
+  flushPersistence: () => Promise<void>
+  acknowledge: (response: SessionPersistenceFlushResponse) => void
+}
+
+export const completeQuitPersistenceFlush = async (
+  request: SessionPersistenceFlushRequest,
+  deps: QuitPersistenceFlushDeps
+): Promise<void> => {
+  try {
+    await deps.drainRuntimeEvents()
+    await deps.flushPersistence()
+  } finally {
+    deps.acknowledge({ requestId: request.requestId })
+  }
+}
+
+export const useQuitPersistenceFlush = (): void => {
+  useEffect(() => {
+    const onFlushRequest = window.api.sessions.onFlushRequest
+    const sendFlushResponse = window.api.sessions.sendFlushResponse
+    // Web/headless renderers do not participate in Electron's before-quit handshake.
+    if (!onFlushRequest || !sendFlushResponse) return
+
+    return onFlushRequest((request) => {
+      void completeQuitPersistenceFlush(request, {
+        drainRuntimeEvents: drainWorkspaceRuntimeEventsForPersistence,
+        flushPersistence: flushSessionPersistence,
+        acknowledge: sendFlushResponse
+      }).catch(() => undefined)
+    })
+  }, [])
+}

--- a/src/renderer/src/lib/acp/useWorkspaceAgentRuntime.ts
+++ b/src/renderer/src/lib/acp/useWorkspaceAgentRuntime.ts
@@ -1474,7 +1474,7 @@ const useWorkspaceAgentRuntime = (): {
     },
     []
   )
-  const drainRuntimeEvents = useCallback(drainWorkspaceRuntimeEventsForPersistence, [])
+  const drainRuntimeEvents = drainWorkspaceRuntimeEventsForPersistence
   // Tracks the last connection status so the disconnect effect fires only on a transition, not on
   // every unrelated snapshot re-render.
   const previousStatusRef = useRef(runtime.state.status)

--- a/src/renderer/src/lib/acp/useWorkspaceAgentRuntime.ts
+++ b/src/renderer/src/lib/acp/useWorkspaceAgentRuntime.ts
@@ -401,6 +401,8 @@ const createWorkspaceRuntimeEventProcessor = (
   }
 }
 
+const liveWorkspaceRuntimeEventProcessor = createWorkspaceRuntimeEventProcessor()
+
 // Finishes the ACP session handshake for a prompt that is already visible locally.
 const startPendingSessionPrompt = (
   runtime: WorkspaceMessageRuntime,
@@ -1391,6 +1393,12 @@ const syncWorkspaceContextUsage = (
   }
 }
 
+const drainWorkspaceRuntimeEventsForPersistence = async (): Promise<void> => {
+  const snapshot = await window.api.acp.getState()
+  await liveWorkspaceRuntimeEventProcessor.process(snapshot.events)
+  syncWorkspaceContextUsage(snapshot.sessionIds, snapshot.contextUsageBySession)
+}
+
 // Deletes in three ordered ownership layers: agent runtime, durable JSON/DB coordinator, then renderer
 // state. A failure in either authoritative layer leaves the session visible with an actionable error.
 const deleteWorkspaceSession = async (
@@ -1466,11 +1474,7 @@ const useWorkspaceAgentRuntime = (): {
     },
     []
   )
-  const eventProcessor = useRef(createWorkspaceRuntimeEventProcessor())
-  const drainRuntimeEvents = useCallback(async (): Promise<void> => {
-    const snapshot = await window.api.acp.getState()
-    await eventProcessor.current.process(snapshot.events)
-  }, [])
+  const drainRuntimeEvents = useCallback(drainWorkspaceRuntimeEventsForPersistence, [])
   // Tracks the last connection status so the disconnect effect fires only on a transition, not on
   // every unrelated snapshot re-render.
   const previousStatusRef = useRef(runtime.state.status)
@@ -1509,7 +1513,7 @@ const useWorkspaceAgentRuntime = (): {
 
   // Applies each visible runtime event once and trims ids that fell out of the runtime window.
   useEffect(() => {
-    void eventProcessor.current.process(runtime.state.events)
+    void liveWorkspaceRuntimeEventProcessor.process(runtime.state.events)
   }, [runtime.state.events])
 
   // Mirrors pending permission requests into per-session store status.
@@ -1695,6 +1699,7 @@ export {
   cancelWorkspaceRun,
   compactWorkspaceSession,
   createWorkspaceRuntimeEventProcessor,
+  drainWorkspaceRuntimeEventsForPersistence,
   getResumeFailureMessage,
   deleteWorkspaceSession,
   markRunningSessionsDisconnectedOnDrop,

--- a/src/renderer/src/lib/acp/workspace-events.test.ts
+++ b/src/renderer/src/lib/acp/workspace-events.test.ts
@@ -19,6 +19,7 @@ import {
   applyWorkspaceRuntimeEvent,
   assembleReviewRunRequest,
   syncWorkspacePermissionState,
+  suppressAutoReviewsForQuit,
   suppressNextAutoReview,
   clearSuppressNextAutoReview,
   resetDeferredArtifactEventsForTests
@@ -1791,6 +1792,29 @@ describe('workspace runtime events', () => {
   })
 
   describe('auto-review gate on stop event', () => {
+    it('cancels pending and future auto-reviews once quit begins', async () => {
+      const reviewerRun = vi.fn().mockResolvedValue(undefined)
+
+      vi.stubGlobal('window', { api: { reviewer: { run: reviewerRun } } })
+      useSessionStore.getState().setAutoReviewEnabled('transport-session-1', true)
+      useSessionStore.getState().appendAgentMessageChunk({
+        sessionId: 'transport-session-1',
+        streamId: 'stream-1',
+        eventId: 'event-agent-1',
+        content: 'Analysis complete'
+      })
+
+      await applyWorkspaceRuntimeEvent(createEvent({ id: 'stop-1', kind: 'stop' }))
+      suppressAutoReviewsForQuit()
+      await vi.runAllTimersAsync()
+
+      await applyWorkspaceRuntimeEvent(createEvent({ id: 'stop-2', kind: 'stop' }))
+      await vi.runAllTimersAsync()
+
+      expect(reviewerRun).not.toHaveBeenCalled()
+      vi.unstubAllGlobals()
+    })
+
     it('triggers a review via window.api.reviewer.run when autoReviewEnabled is true', async () => {
       const reviewerRun = vi.fn().mockResolvedValue(undefined)
 

--- a/src/renderer/src/lib/acp/workspace-events.ts
+++ b/src/renderer/src/lib/acp/workspace-events.ts
@@ -58,6 +58,7 @@ const deferredArtifactEventsBySession = new Map<string, DeferredArtifactEvent[]>
 const pendingArtifactTurnUsageBySession = new Map<string, Map<string, PendingArtifactTurnUsage>>()
 const MAX_PENDING_ARTIFACT_TURNS_PER_SESSION = 16
 const scheduledAutoReviewsBySession = new Map<string, ReturnType<typeof setTimeout>>()
+let autoReviewsSuppressedForQuit = false
 const AUTO_REVIEW_ARTIFACT_SETTLE_DELAY_MS = 100
 
 const resetDeferredArtifactEventsForTests = (): void => {
@@ -65,6 +66,7 @@ const resetDeferredArtifactEventsForTests = (): void => {
   pendingArtifactTurnUsageBySession.clear()
   for (const timer of scheduledAutoReviewsBySession.values()) clearTimeout(timer)
   scheduledAutoReviewsBySession.clear()
+  autoReviewsSuppressedForQuit = false
 }
 
 const isActivityGroupControlEvent = (event: AcpRuntimeEvent): boolean => {
@@ -314,6 +316,8 @@ const delay = (ms: number): Promise<void> => new Promise((resolve) => setTimeout
 // Fire-and-forget: errors are caught and silently dropped so the main session is never blocked.
 const triggerAutoReview = async (sessionId: string): Promise<void> => {
   try {
+    if (autoReviewsSuppressedForQuit) return
+
     // Loop guard: if this session's next review was suppressed (e.g. because the stop comes from
     // the [Auditor] correction turn), skip exactly this one call and clear the flag.
     if (suppressAutoReviewOnceFor.has(sessionId)) {
@@ -344,6 +348,7 @@ const triggerAutoReview = async (sessionId: string): Promise<void> => {
     // main and comes back 'already-reviewed' rather than launching a duplicate. A renderer-local store
     // check could only race that cross-process window, so we rely on main's verdict.
     for (let attempt = 0; attempt < AUTO_REVIEW_START_ATTEMPTS; attempt++) {
+      if (autoReviewsSuppressedForQuit) return
       const result = await window.api.reviewer.run({ ...request, origin: 'auto' })
       if (result?.started !== false) return
       if (!result.reason || !RETRYABLE_START_FAILURE_REASONS.has(result.reason)) return
@@ -360,10 +365,17 @@ const cancelScheduledAutoReview = (sessionId: string): void => {
   scheduledAutoReviewsBySession.delete(sessionId)
 }
 
+const suppressAutoReviewsForQuit = (): void => {
+  autoReviewsSuppressedForQuit = true
+  for (const timer of scheduledAutoReviewsBySession.values()) clearTimeout(timer)
+  scheduledAutoReviewsBySession.clear()
+}
+
 // Stop and artifact events normally arrive together, but some providers publish the Artifact just
 // after stop. A short debounced barrier lets that claim finalize before Reviewer freezes its scope.
 // A post-stop Artifact cancels this timer immediately and schedules a fresh review after finalization.
 const scheduleAutoReview = (sessionId: string): void => {
+  if (autoReviewsSuppressedForQuit) return
   cancelScheduledAutoReview(sessionId)
   const timer = setTimeout(() => {
     scheduledAutoReviewsBySession.delete(sessionId)
@@ -663,6 +675,7 @@ export {
   applyWorkspaceRuntimeEvent,
   assembleReviewRunRequest,
   syncWorkspacePermissionState,
+  suppressAutoReviewsForQuit,
   suppressNextAutoReview,
   clearSuppressNextAutoReview,
   resetDeferredArtifactEventsForTests

--- a/src/renderer/src/lib/session-persistence/session-persistence.test.ts
+++ b/src/renderer/src/lib/session-persistence/session-persistence.test.ts
@@ -739,6 +739,28 @@ describe('renderer session persistence bridge', () => {
     expect(saveSession).toHaveBeenCalledTimes(3)
     expect(durableTitle).toBe('Artifact latest')
   })
+
+  it('flushes only after every previously queued Session write settles', async () => {
+    const firstSave = createDeferred<PersistedChatSession>()
+    const api = createApi({
+      saveSession: vi.fn(() => firstSave.promise)
+    })
+    const persistence = createOrderedSessionPersistence(api)
+    const session = createPersistedSession()
+
+    const saving = persistence.saveSession(session)
+    let flushed = false
+    const flushing = persistence.flush().then(() => {
+      flushed = true
+    })
+    await flushMicrotasks()
+
+    expect(flushed).toBe(false)
+    firstSave.resolve(session)
+    await saving
+    await flushing
+    expect(flushed).toBe(true)
+  })
 })
 
 type Deferred<T> = {

--- a/src/renderer/src/lib/session-persistence/session-persistence.ts
+++ b/src/renderer/src/lib/session-persistence/session-persistence.ts
@@ -27,7 +27,11 @@ type SessionPersistenceApi = {
   saveManifest: (request: SaveSessionManifestRequest) => Promise<void>
 }
 
-type OrderedSessionPersistence = Pick<SessionPersistenceApi, 'saveSession' | 'saveManifest'>
+type SessionWriteApi = Pick<SessionPersistenceApi, 'saveSession' | 'saveManifest'>
+
+type OrderedSessionPersistence = SessionWriteApi & {
+  flush: () => Promise<void>
+}
 
 const SESSION_CONFLICT_REBASE_FIELDS = [
   'title',
@@ -55,9 +59,7 @@ const conflictRebaseFieldChanged = (
 // Serializes every renderer-originated Session write through one ordering seam. Callers enqueue the
 // snapshot immediately, so a later explicit Artifact save cannot be overtaken by an older store save
 // that was still waiting behind an in-flight write.
-const createOrderedSessionPersistence = (
-  api: OrderedSessionPersistence
-): OrderedSessionPersistence => {
+const createOrderedSessionPersistence = (api: SessionWriteApi): OrderedSessionPersistence => {
   let queue: Promise<unknown> = Promise.resolve()
 
   const enqueue = <Result>(task: () => Promise<Result>): Promise<Result> => {
@@ -72,7 +74,8 @@ const createOrderedSessionPersistence = (
   return {
     saveSession: (session, options) =>
       enqueue(() => (options ? api.saveSession(session, options) : api.saveSession(session))),
-    saveManifest: (request) => enqueue(() => api.saveManifest(request))
+    saveManifest: (request) => enqueue(() => api.saveManifest(request)),
+    flush: () => queue.then(() => undefined)
   }
 }
 
@@ -88,6 +91,8 @@ const liveSessionPersistence = createOrderedSessionPersistence({
 
 const saveSessionInOrder = (session: PersistedChatSession): Promise<PersistedChatSession> =>
   liveSessionPersistence.saveSession(session)
+
+const flushSessionPersistence = (): Promise<void> => liveSessionPersistence.flush()
 
 // The one artifact command startup reconciliation needs; kept narrow so it is trivial to fake in tests.
 type ArtifactReconcileApi = {
@@ -596,6 +601,7 @@ const useSessionPersistence = (): SessionPersistenceState => {
 export {
   createOrderedSessionPersistence,
   createStoreSaver,
+  flushSessionPersistence,
   loadPersistedSessions,
   reconcilePendingArtifacts,
   saveSessionInOrder,

--- a/src/shared/session-persistence-flush.ts
+++ b/src/shared/session-persistence-flush.ts
@@ -1,0 +1,5 @@
+export const SESSION_PERSISTENCE_FLUSH_REQUEST_CHANNEL = 'sessions:flush-request'
+export const SESSION_PERSISTENCE_FLUSH_RESPONSE_CHANNEL = 'sessions:flush-response'
+
+export type SessionPersistenceFlushRequest = { requestId: string }
+export type SessionPersistenceFlushResponse = { requestId: string }

--- a/src/shared/window-controls.ts
+++ b/src/shared/window-controls.ts
@@ -156,8 +156,9 @@ export const WINDOW_CLOSE_CONFIRM_REQUEST_CHANNEL = 'window:close-confirm-reques
 export const WINDOW_CLOSE_CONFIRM_RESPONSE_CHANNEL = 'window:close-confirm-response'
 
 // How a titlebar close resolves synchronously at close time: 'close' lets the window close, 'hide'
-// minimizes to tray, 'confirm' asks the user via the confirmation modal.
-export type CloseClassification = 'close' | 'hide' | 'confirm'
+// minimizes to tray, 'quit' requests app quit while retaining the renderer for teardown, and 'confirm'
+// asks the user via the confirmation modal.
+export type CloseClassification = 'close' | 'hide' | 'confirm' | 'quit'
 
 // 'close-to-tray' = Windows X (Minimize vs Quit); 'quit' = explicit quit (Quit vs Cancel).
 export type CloseConfirmVariant = 'close-to-tray' | 'quit'


### PR DESCRIPTION
## Problem

Graceful app quit reaped ACP runtimes before terminal stop responses and renderer Session writes were guaranteed to settle. This could lose the latest context usage or completed-turn usage even though the agent returned it during cancellation.

## Proposed change

- Cancel active ACP prompts and wait for interaction ownership release before backend teardown, bounded to four seconds.
- Ask the live Electron renderer to fetch the final ACP snapshot, process terminal events, synchronize context usage, and flush the ordered Session persistence queue.
- Bound the renderer acknowledgement to 1.5 seconds and continue teardown if the renderer disappears or does not respond.
- Keep Claude Code, OpenCode, and managed Codex usage calculation in their existing adapters; coordinate them at their shared terminal-response boundary.

Quit flow: confirmation → ACP cancel and drain → renderer final snapshot drain → Session queue flush → backend teardown.

## Scope and non-goals

- No Session schema, data relationship, or UI changes.
- Hard process termination cannot produce exact final usage; existing last-known context usage remains authoritative.
- This change does not replace framework-specific usage reconciliation.

## Acceptance criteria and validation

All listed checks ran after the final material edit and after rebasing onto the latest main branch.

- Cancelled ACP response retains terminal usage → npm test -- --run src/main/acp/runtime.test.ts -t "keeps a cancelling prompt in flight until the agent returns its stop response" → passed.
- Quit preparation cancels and waits, with timeout fallback → npm test -- --run src/main/acp/runtime-coordinator.test.ts → passed.
- Renderer writes flush in order → npm test -- --run src/renderer/src/lib/session-persistence/session-persistence.test.ts → passed.
- Renderer acknowledgement ordering and main timeout cleanup → npm test -- --run src/renderer/src/hooks/useQuitPersistenceFlush.test.ts src/main/session-persistence/renderer-flush.test.ts → passed.
- App quit ordering → npm test -- --run src/main/app-lifecycle.test.ts → passed.
- Full regression suite → npm test → passed.
- Type safety → npm run typecheck → passed.
- Static analysis → npm run lint → passed.
- Web API surface remains stable → npm run check:web-api-map → passed.

## Review focus

Independent review found one blocker to resolve before marking this ready:

- When no Electron renderer exists, including headless mode or macOS after the final window closes, cancel and drain can receive terminal usage but no renderer projects it into Session JSON. A main-owned persistence path or retained renderer is still required.

Additional uncovered risks:

- No adapter-specific Stop → cancelled response → stop event → Session JSON integration test yet for Claude Code, OpenCode, and managed Codex.
- Connection loss and cancel timeout persistence are not covered end to end.
- The Electron-specific IPC wrapper and final runtime-snapshot drain are covered through lower-level fakes rather than a production-wrapper integration test.