### PR TITLE
refactor(acp): extract handler application workflows

### DIFF
--- a/src/main/acp/handler-workflows.ts
+++ b/src/main/acp/handler-workflows.ts
@@ -1,0 +1,158 @@
+import { createHmac, randomBytes, randomUUID } from 'node:crypto'
+
+import type {
+  AcpCreateSessionRequest,
+  AcpCreateSessionResponse,
+  AcpPromptRequest,
+  AcpResumeSessionRequest,
+  AcpStateSnapshot
+} from '../../shared/acp'
+import { createLogger, diagnosticErrorFields, errorLogFields } from '../logger'
+import type { TaskNotificationService } from '../notifications/task-notifications'
+import type { AcpCreateSessionWorkflow } from './create-session-workflow'
+
+const log = createLogger('acp')
+const resumeLogHashKey = randomBytes(32)
+const SAFE_RESUME_RPC_CODES = new Set([-32700, -32600, -32601, -32602, -32603, -32002])
+const SAFE_RESUME_ERROR_KINDS = new Set([
+  'resource_not_found',
+  'not_found',
+  'session_not_found',
+  'conversation_not_found',
+  'session_missing',
+  'conversation_missing',
+  'session_resume_failed',
+  'conversation_restore_failed'
+])
+const SAFE_RESUME_SERVICES = new Set(['session', 'provider', 'mcp', 'transport'])
+
+type AcpHandlerWorkflowRuntime = {
+  getSnapshot(): AcpStateSnapshot
+  resumeSession(request: AcpResumeSessionRequest): Promise<AcpCreateSessionResponse>
+  sendPrompt(request: AcpPromptRequest): Promise<unknown>
+}
+
+type PromptNotifications = Pick<TaskNotificationService, 'trackPrompt' | 'untrackPrompt'>
+
+type AcpHandlerWorkflows = {
+  createSession(request: AcpCreateSessionRequest): Promise<AcpCreateSessionResponse>
+  resumeSession(request: AcpResumeSessionRequest): Promise<AcpCreateSessionResponse>
+  sendPrompt(request: AcpPromptRequest): Promise<AcpStateSnapshot>
+}
+
+const safeRead = (value: object, key: string): unknown => {
+  try {
+    return (value as Record<string, unknown>)[key]
+  } catch {
+    return undefined
+  }
+}
+
+const normalizedDiagnosticToken = (value: unknown): string | undefined => {
+  if (typeof value !== 'string') return undefined
+  const normalized = value
+    .trim()
+    .toLowerCase()
+    .replace(/[^a-z0-9]+/g, '_')
+    .replace(/^_|_$/g, '')
+  return normalized || undefined
+}
+
+const resumeSessionHash = (sessionId: string): string =>
+  createHmac('sha256', resumeLogHashKey).update(sessionId).digest('hex').slice(0, 12)
+
+const resumeErrorDiagnosticFields = (error: unknown): Record<string, unknown> => {
+  const fields: Record<string, unknown> = diagnosticErrorFields(error)
+  if (typeof error !== 'object' || error === null) return fields
+
+  const code = safeRead(error, 'code')
+  if (typeof code === 'number' && Number.isFinite(code)) {
+    fields.rpcCode = SAFE_RESUME_RPC_CODES.has(code) ? code : 'other'
+  }
+
+  const data = safeRead(error, 'data')
+  if (typeof data !== 'object' || data === null) return fields
+
+  const errorKind = normalizedDiagnosticToken(safeRead(data, 'errorKind'))
+  if (errorKind) fields.errorKind = SAFE_RESUME_ERROR_KINDS.has(errorKind) ? errorKind : 'other'
+  const service = normalizedDiagnosticToken(safeRead(data, 'service'))
+  if (service) fields.service = SAFE_RESUME_SERVICES.has(service) ? service : 'other'
+  return fields
+}
+
+const logResumeDiagnostic = (
+  level: 'info' | 'error',
+  message: string,
+  data: Record<string, unknown>
+): void => {
+  try {
+    log[level](message, data)
+  } catch {
+    // Diagnostics must never change the Resume result observed by the caller.
+  }
+}
+
+// Owns the application side effects shared by Electron and its captured Web compatibility adapter.
+// Transport handlers translate untrusted payloads before invoking this narrow interface.
+const createAcpHandlerWorkflows = (
+  runtime: AcpHandlerWorkflowRuntime,
+  createSessionWorkflow: AcpCreateSessionWorkflow,
+  taskNotifications?: PromptNotifications
+): AcpHandlerWorkflows => ({
+  async createSession(request): Promise<AcpCreateSessionResponse> {
+    try {
+      return await createSessionWorkflow.create(request)
+    } catch (error) {
+      // Persist create failures without letting a broken diagnostic sink mask the authoritative error.
+      try {
+        log.error('acp:create-session failed', errorLogFields(error))
+      } catch {
+        /* diagnostics must never mask the real error */
+      }
+      throw error
+    }
+  },
+
+  async resumeSession(request): Promise<AcpCreateSessionResponse> {
+    const startedAt = Date.now()
+    const context = {
+      operationId: randomUUID(),
+      sessionHash: resumeSessionHash(request.sessionId)
+    }
+    logResumeDiagnostic('info', 'acp:resume-session started', context)
+
+    try {
+      const result = await runtime.resumeSession(request)
+      logResumeDiagnostic('info', 'acp:resume-session completed', {
+        ...context,
+        durationMs: Math.max(0, Date.now() - startedAt),
+        frameworkId: result.frameworkId,
+        contextReset: result.contextReset === true
+      })
+      return result
+    } catch (error) {
+      logResumeDiagnostic('error', 'acp:resume-session failed', {
+        ...context,
+        durationMs: Math.max(0, Date.now() - startedAt),
+        ...resumeErrorDiagnosticFields(error)
+      })
+      throw error
+    }
+  },
+
+  async sendPrompt(request): Promise<AcpStateSnapshot> {
+    // Track before invoking so the terminal event can name this prompt. A rejected admission rolls
+    // back only its own token, preserving any older in-flight prompt tracked for the same Session.
+    const tracked = taskNotifications?.trackPrompt(request)
+    try {
+      await runtime.sendPrompt(request)
+    } catch (error) {
+      if (tracked) taskNotifications?.untrackPrompt(request.sessionId, tracked)
+      throw error
+    }
+    return runtime.getSnapshot()
+  }
+})
+
+export { createAcpHandlerWorkflows }
+export type { AcpHandlerWorkflows }

--- a/src/main/acp/ipc.test.ts
+++ b/src/main/acp/ipc.test.ts
@@ -123,6 +123,7 @@ vi.mock('../storage-root', () => ({
 const { installAcpIpcHandlers } = await import('./ipc')
 const { createAcpRuntime } = await import('./runtime-composition')
 const { createAcpCreateSessionWorkflow } = await import('./create-session-workflow')
+const { createAcpHandlerWorkflows } = await import('./handler-workflows')
 type AcpTestOptions = Parameters<typeof createAcpRuntime>[0]
 
 // Minimal options — createRuntime just forwards them into the mocked AcpRuntime constructor.
@@ -174,7 +175,11 @@ const registerWithFakes = (overrides?: {
   }
 
   const runtime = createAcpRuntime(options)
-  installAcpIpcHandlers(runtime, createAcpCreateSessionWorkflow(runtime), options.taskNotifications)
+  const createSessionWorkflow = createAcpCreateSessionWorkflow(runtime)
+  installAcpIpcHandlers(
+    runtime,
+    createAcpHandlerWorkflows(runtime, createSessionWorkflow, options.taskNotifications)
+  )
   return options as AcpTestOptions
 }
 
@@ -238,10 +243,10 @@ describe('ACP module transport seam', () => {
 
     expect(handlers.size).toBe(0)
 
+    const createSessionWorkflow = createAcpCreateSessionWorkflow(runtime)
     installAcpIpcHandlers(
       runtime,
-      createAcpCreateSessionWorkflow(runtime),
-      options.taskNotifications
+      createAcpHandlerWorkflows(runtime, createSessionWorkflow, options.taskNotifications)
     )
 
     expect(handlers.has('acp:get-state')).toBe(true)

--- a/src/main/acp/ipc.test.ts
+++ b/src/main/acp/ipc.test.ts
@@ -825,7 +825,7 @@ describe('installAcpIpcHandlers — resume-session diagnostics', () => {
       cwd: request.cwd,
       frameworkId: 'codex' as const
     }
-    infoLogSpy.mockImplementation(() => {
+    infoLogSpy.mockImplementationOnce(() => {
       throw new Error('diagnostic sink failed')
     })
     resumeSession.mockResolvedValueOnce(result)
@@ -833,8 +833,7 @@ describe('installAcpIpcHandlers — resume-session diagnostics', () => {
     await expect(handlers.get('acp:resume-session')?.({}, request)).resolves.toBe(result)
 
     const failure = new Error('resume failed')
-    infoLogSpy.mockReset()
-    errorLogSpy.mockImplementation(() => {
+    errorLogSpy.mockImplementationOnce(() => {
       throw new Error('diagnostic sink failed')
     })
     resumeSession.mockRejectedValueOnce(failure)
@@ -894,7 +893,7 @@ describe('installAcpIpcHandlers — create-session failure logging', () => {
 })
 
 // Pins the IPC send-prompt → notification-tracking wire-up. TaskNotificationService has its own
-// unit tests for the token/untrack primitives, but the orchestration in `acp/ipc.ts` — calling
+// unit tests for the token/untrack primitives, but the orchestration in `acp/handler-workflows.ts` — calling
 // trackPrompt before sendPrompt and reverting via untrackPrompt if the runtime rejects before the
 // turn starts — is what protects a still-running turn's notification name from being overwritten
 // by a rejected prompt's tracking. An earlier spec review flagged exactly this kind of seam as the

--- a/src/main/acp/ipc.test.ts
+++ b/src/main/acp/ipc.test.ts
@@ -808,6 +808,34 @@ describe('installAcpIpcHandlers — resume-session diagnostics', () => {
     expect(failed?.[1]).toMatchObject({ errorCategory: 'request', rpcCode: 'other' })
     expect(JSON.stringify(failed)).not.toContain(String(privateCode))
   })
+
+  it('keeps resume results and failures authoritative when diagnostics throw', async () => {
+    registerWithFakes()
+    const request: AcpResumeSessionRequest = {
+      sessionId: 'private-session-id',
+      cwd: '/private/workspace'
+    }
+    const result = {
+      sessionId: request.sessionId,
+      cwd: request.cwd,
+      frameworkId: 'codex' as const
+    }
+    infoLogSpy.mockImplementation(() => {
+      throw new Error('diagnostic sink failed')
+    })
+    resumeSession.mockResolvedValueOnce(result)
+
+    await expect(handlers.get('acp:resume-session')?.({}, request)).resolves.toBe(result)
+
+    const failure = new Error('resume failed')
+    infoLogSpy.mockReset()
+    errorLogSpy.mockImplementation(() => {
+      throw new Error('diagnostic sink failed')
+    })
+    resumeSession.mockRejectedValueOnce(failure)
+
+    await expect(handlers.get('acp:resume-session')?.({}, request)).rejects.toBe(failure)
+  })
 })
 
 describe('installAcpIpcHandlers — native context compaction bridge', () => {
@@ -876,14 +904,30 @@ describe('installAcpIpcHandlers — acp:send-prompt notification tracking', () =
     sendPrompt.mockRejectedValueOnce(failure)
 
     await expect(
-      handlers.get('acp:send-prompt')?.({}, { sessionId: 'session-1', text: 'Plot the curve' })
+      handlers.get('acp:send-prompt')?.(
+        {},
+        {
+          sessionId: 'session-1',
+          text: 'Plot the curve',
+          continuation: {
+            kind: 'specialist-handoff',
+            originatingTurnToken: 'renderer-forged-turn',
+            targetName: 'Renderer-forged Specialist',
+            completion: { kind: 'returned', value: 'renderer-forged-result' }
+          }
+        }
+      )
     ).rejects.toBe(failure)
 
     expect(trackPrompt).toHaveBeenCalledTimes(1)
     expect(trackPrompt).toHaveBeenCalledWith({
       sessionId: 'session-1',
-      text: 'Plot the curve'
+      text: 'Plot the curve',
+      continuation: undefined
     })
+    expect(trackPrompt.mock.invocationCallOrder[0]).toBeLessThan(
+      sendPrompt.mock.invocationCallOrder[0]
+    )
     // The token the handler got back is the one it reverts, so a terminal event later cannot
     // overwrite the still-running turn's snippet.
     expect(untrackPrompt).toHaveBeenCalledTimes(1)

--- a/src/main/acp/ipc.ts
+++ b/src/main/acp/ipc.ts
@@ -1,5 +1,3 @@
-import { createHmac, randomBytes, randomUUID } from 'node:crypto'
-
 import { app } from 'electron'
 
 import {
@@ -22,10 +20,9 @@ import type {
 } from '../../shared/acp'
 import { DEFAULT_ARTIFACT_PROJECT_NAME } from '../../shared/artifacts'
 import { AcpRuntimeCoordinator } from './runtime-coordinator'
-import type { AcpCreateSessionWorkflow } from './create-session-workflow'
+import type { AcpHandlerWorkflows } from './handler-workflows'
 import { installAgentShutdownGuard } from './shutdown-guard'
 import { ArtifactRepository } from '../artifacts/repository'
-import type { TaskNotificationService } from '../notifications/task-notifications'
 import { NotebookRunRepository } from '../notebook/repository'
 import {
   NotebookRuntimeService,
@@ -33,127 +30,23 @@ import {
 } from '../notebook/runtime-service'
 import { resolveConfigRoot, resolveDataRoot } from '../storage-root'
 import { broadcastToRenderers } from '../renderer-broadcast'
-import { createLogger, diagnosticErrorFields, errorLogFields } from '../logger'
-
-const log = createLogger('acp')
-const resumeLogHashKey = randomBytes(32)
-const SAFE_RESUME_RPC_CODES = new Set([-32700, -32600, -32601, -32602, -32603, -32002])
-const SAFE_RESUME_ERROR_KINDS = new Set([
-  'resource_not_found',
-  'not_found',
-  'session_not_found',
-  'conversation_not_found',
-  'session_missing',
-  'conversation_missing',
-  'session_resume_failed',
-  'conversation_restore_failed'
-])
-const SAFE_RESUME_SERVICES = new Set(['session', 'provider', 'mcp', 'transport'])
-
-const safeRead = (value: object, key: string): unknown => {
-  try {
-    return (value as Record<string, unknown>)[key]
-  } catch {
-    return undefined
-  }
-}
-
-const normalizedDiagnosticToken = (value: unknown): string | undefined => {
-  if (typeof value !== 'string') return undefined
-  const normalized = value
-    .trim()
-    .toLowerCase()
-    .replace(/[^a-z0-9]+/g, '_')
-    .replace(/^_|_$/g, '')
-  return normalized || undefined
-}
-
-const resumeSessionHash = (sessionId: string): string =>
-  createHmac('sha256', resumeLogHashKey).update(sessionId).digest('hex').slice(0, 12)
-
-const resumeErrorDiagnosticFields = (error: unknown): Record<string, unknown> => {
-  const fields: Record<string, unknown> = diagnosticErrorFields(error)
-  if (typeof error !== 'object' || error === null) return fields
-
-  const code = safeRead(error, 'code')
-  if (typeof code === 'number' && Number.isFinite(code)) {
-    fields.rpcCode = SAFE_RESUME_RPC_CODES.has(code) ? code : 'other'
-  }
-
-  const data = safeRead(error, 'data')
-  if (typeof data !== 'object' || data === null) return fields
-
-  const errorKind = normalizedDiagnosticToken(safeRead(data, 'errorKind'))
-  if (errorKind) fields.errorKind = SAFE_RESUME_ERROR_KINDS.has(errorKind) ? errorKind : 'other'
-  const service = normalizedDiagnosticToken(safeRead(data, 'service'))
-  if (service) fields.service = SAFE_RESUME_SERVICES.has(service) ? service : 'other'
-  return fields
-}
-
-const logResumeDiagnostic = (
-  level: 'info' | 'error',
-  message: string,
-  data: Record<string, unknown>
-): void => {
-  try {
-    log[level](message, data)
-  } catch {
-    // Diagnostics must never change the Resume result observed by the renderer.
-  }
-}
 
 // Sends one runtime payload through the typed application-event compatibility facade.
 const broadcast = broadcastToRenderers
 
 const registerAcpIpcHandlerSet = (
   runtime: AcpRuntimeCoordinator,
-  createSessionWorkflow: AcpCreateSessionWorkflow,
-  taskNotifications?: TaskNotificationService
+  workflows: AcpHandlerWorkflows
 ): void => {
   ipcMainHandle('acp:get-state', () => runtime.getSnapshot())
   ipcMainHandle('acp:connect', (_event, request: AcpConnectRequest) => runtime.connect(request))
   ipcMainHandle('acp:disconnect', () => runtime.disconnect())
-  ipcMainHandle('acp:create-session', async (_event, request: AcpCreateSessionRequest) => {
-    try {
-      return await createSessionWorkflow.create(request)
-    } catch (error) {
-      // Route through the file logger (rotating main.log) so the failure survives in a packaged build,
-      // not just the dev console. errorLogFields keeps the message + stack out of a `{}`. Guarded so a
-      // throwing logger can never mask the original error the renderer must still receive.
-      try {
-        log.error('acp:create-session failed', errorLogFields(error))
-      } catch {
-        /* logging must never mask the real error */
-      }
-      throw error
-    }
-  })
-  ipcMainHandle('acp:resume-session', async (_event, request: AcpResumeSessionRequest) => {
-    const startedAt = Date.now()
-    const context = {
-      operationId: randomUUID(),
-      sessionHash: resumeSessionHash(request.sessionId)
-    }
-    logResumeDiagnostic('info', 'acp:resume-session started', context)
-
-    try {
-      const result = await runtime.resumeSession(request)
-      logResumeDiagnostic('info', 'acp:resume-session completed', {
-        ...context,
-        durationMs: Math.max(0, Date.now() - startedAt),
-        frameworkId: result.frameworkId,
-        contextReset: result.contextReset === true
-      })
-      return result
-    } catch (error) {
-      logResumeDiagnostic('error', 'acp:resume-session failed', {
-        ...context,
-        durationMs: Math.max(0, Date.now() - startedAt),
-        ...resumeErrorDiagnosticFields(error)
-      })
-      throw error
-    }
-  })
+  ipcMainHandle('acp:create-session', (_event, request: AcpCreateSessionRequest) =>
+    workflows.createSession(request)
+  )
+  ipcMainHandle('acp:resume-session', (_event, request: AcpResumeSessionRequest) =>
+    workflows.resumeSession(request)
+  )
   ipcMainHandle('acp:reset-session-context', (_event, request: AcpResumeSessionRequest) =>
     runtime.resetSessionContext(request)
   )
@@ -161,23 +54,11 @@ const registerAcpIpcHandlerSet = (
     runtime.compactSession(request)
   )
   // Prompt calls wait for the turn to stop, then return the latest snapshot.
-  ipcMainHandle('acp:send-prompt', async (_event, request: AcpPromptRequest) => {
+  ipcMainHandle('acp:send-prompt', (_event, request: AcpPromptRequest) => {
     // Continuations are main-process-owned. A renderer-supplied marker must never suppress a visible
     // user message or impersonate the handoff path.
     const rendererRequest = { ...request, continuation: undefined }
-    // Remember the prompt's first line so a completion/failure notification can name the task.
-    // If the runtime rejects before the turn starts (unknown session, another prompt in flight),
-    // revert so a still-running turn keeps its own prompt's name.
-    const tracked = taskNotifications?.trackPrompt(rendererRequest)
-
-    try {
-      await runtime.sendPrompt(rendererRequest)
-    } catch (error) {
-      if (tracked) taskNotifications?.untrackPrompt(rendererRequest.sessionId, tracked)
-      throw error
-    }
-
-    return runtime.getSnapshot()
+    return workflows.sendPrompt(rendererRequest)
   })
   ipcMainHandle('acp:cancel', (_event, request: AcpCancelPromptRequest) =>
     runtime.cancelPrompt(request)
@@ -201,12 +82,11 @@ const registerAcpIpcHandlerSet = (
 // Installs the renderer-callable Electron adapter over an already-constructed ACP coordinator.
 const installAcpIpcHandlers = (
   runtime: AcpRuntimeCoordinator,
-  createSessionWorkflow: AcpCreateSessionWorkflow,
-  taskNotifications?: TaskNotificationService
+  workflows: AcpHandlerWorkflows
 ): IpcHandlerInstallation => {
   const scope = createIpcHandlerInstallationScope()
   try {
-    registerAcpIpcHandlerSet(runtime, createSessionWorkflow, taskNotifications)
+    registerAcpIpcHandlerSet(runtime, workflows)
     // Kill the agent child on quit so it never outlives the app as an orphaned process.
     return scope.complete(installAgentShutdownGuard(app, runtime))
   } catch (error) {

--- a/src/main/ipc.ts
+++ b/src/main/ipc.ts
@@ -14,6 +14,7 @@ import { createApplicationEventModule, type ApplicationEventSource } from './app
 import { createDefaultNotebookRuntimeService } from './acp/ipc'
 import { createAcpRuntime } from './acp/runtime-composition'
 import { createAcpCreateSessionWorkflow } from './acp/create-session-workflow'
+import { createAcpHandlerWorkflows } from './acp/handler-workflows'
 import { createAcpTaskAgentPort } from './acp/task-agent-port'
 import { createDefaultArtifactRepository, registerArtifactIpcHandlers } from './artifacts/ipc'
 import { ArtifactProvenanceRepository } from './artifacts/provenance-repository'
@@ -889,6 +890,11 @@ const createApplicationModules = async (
   surfaceAdapters = afterAcpAdapters
   runtimeRef.current = runtime
   const createSessionWorkflow = createAcpCreateSessionWorkflow(runtime)
+  const acpHandlerWorkflows = createAcpHandlerWorkflows(
+    runtime,
+    createSessionWorkflow,
+    taskNotifications
+  )
   const taskAgent = createAcpTaskAgentPort(runtime, createSessionWorkflow, taskNotifications)
   {
     // Framework-specific adapters declare their own session selector. The registry resolves those
@@ -1345,7 +1351,7 @@ const createApplicationModules = async (
       beforeCompute: beforeComputeAdapters,
       compute: computeIpcModule,
       beforeAcp: beforeAcpAdapters,
-      acp: { runtime, createSessionWorkflow, taskNotifications },
+      acp: { runtime, workflows: acpHandlerWorkflows },
       afterAcp: afterAcpAdapters
     }
   }

--- a/src/main/runtime-electron-wiring.test.ts
+++ b/src/main/runtime-electron-wiring.test.ts
@@ -32,8 +32,7 @@ describe('production Electron runtime wiring', () => {
   it('installs the constructed Compute and ACP modules before remaining surfaces', async () => {
     const compute = { handlers: {}, enabledComputeHostsRegistry: {} } as never
     const runtime = {} as never
-    const createSessionWorkflow = {} as never
-    const taskNotifications = {} as never
+    const workflows = {} as never
 
     await installElectronRuntimeAdapters({
       compute,
@@ -55,7 +54,7 @@ describe('production Electron runtime wiring', () => {
           }
         }
       ],
-      acp: { runtime, createSessionWorkflow, taskNotifications },
+      acp: { runtime, workflows },
       afterAcp: [
         {
           name: 'settings',
@@ -68,11 +67,7 @@ describe('production Electron runtime wiring', () => {
     })
 
     expect(installComputeIpcHandlers).toHaveBeenCalledWith(compute)
-    expect(installAcpIpcHandlers).toHaveBeenCalledWith(
-      runtime,
-      createSessionWorkflow,
-      taskNotifications
-    )
+    expect(installAcpIpcHandlers).toHaveBeenCalledWith(runtime, workflows)
     expect(order).toEqual(['notifications', 'compute', 'connectors', 'acp', 'settings'])
   })
 
@@ -80,8 +75,7 @@ describe('production Electron runtime wiring', () => {
     const rollbackOrder: string[] = []
     const compute = { handlers: {}, enabledComputeHostsRegistry: {} } as never
     const runtime = {} as never
-    const createSessionWorkflow = {} as never
-    const taskNotifications = {} as never
+    const workflows = {} as never
     installComputeIpcHandlers.mockReturnValueOnce({
       uninstall: vi.fn(() => {
         rollbackOrder.push('compute')
@@ -109,7 +103,7 @@ describe('production Electron runtime wiring', () => {
             }
           }
         ],
-        acp: { runtime, createSessionWorkflow, taskNotifications },
+        acp: { runtime, workflows },
         afterAcp: []
       })
     ).rejects.toThrow('adapter install failed')

--- a/src/main/runtime-electron-wiring.ts
+++ b/src/main/runtime-electron-wiring.ts
@@ -1,8 +1,7 @@
 import { installAcpIpcHandlers } from './acp/ipc'
-import type { AcpCreateSessionWorkflow } from './acp/create-session-workflow'
+import type { AcpHandlerWorkflows } from './acp/handler-workflows'
 import type { AcpRuntimeCoordinator } from './acp/runtime-coordinator'
 import { installComputeIpcHandlers, type ComputeIpcModule } from './compute/ipc'
-import type { TaskNotificationService } from './notifications/task-notifications'
 
 type Awaitable<T> = T | Promise<T>
 
@@ -21,8 +20,7 @@ export type ElectronRuntimeAdapterInterfaces = {
   readonly beforeAcp: readonly NamedElectronSurfaceAdapter[]
   readonly acp: {
     runtime: AcpRuntimeCoordinator
-    createSessionWorkflow: AcpCreateSessionWorkflow
-    taskNotifications: TaskNotificationService
+    workflows: AcpHandlerWorkflows
   }
   readonly afterAcp: readonly NamedElectronSurfaceAdapter[]
 }
@@ -62,9 +60,7 @@ export const installElectronRuntimeAdapters = async ({
     for (const surface of beforeCompute) await install(surface.name, () => surface.install())
     await install('compute', () => installComputeIpcHandlers(compute))
     for (const surface of beforeAcp) await install(surface.name, () => surface.install())
-    await install('acp', () =>
-      installAcpIpcHandlers(acp.runtime, acp.createSessionWorkflow, acp.taskNotifications)
-    )
+    await install('acp', () => installAcpIpcHandlers(acp.runtime, acp.workflows))
     for (const surface of afterAcp) await install(surface.name, () => surface.install())
   } catch (error) {
     try {


### PR DESCRIPTION
## Problem

A9.4a moved ACP runtime construction out of Electron IPC, but create/resume diagnostic policy and prompt notification tracking/rollback still lived in handler bodies. That left the adapter owning application side effects instead of limiting it to transport translation and invocation.

## Proposed change

Introduce `AcpHandlerWorkflows` with three application operations:

- `createSession(request)` invokes the managed-workspace workflow and owns existing failure diagnostics.
- `resumeSession(request)` owns operation correlation, privacy-safe Session hashing, timing, success/failure logs, and error classification.
- `sendPrompt(request)` tracks notification identity before invocation and rolls it back only when invocation rejects.

Electron handlers strip the renderer-only `continuation` field where required, invoke the workflow, and return its result. The other ten ACP handlers remain direct adapter forwarding.

```mermaid
flowchart LR
  E["Electron / captured Web handler"] --> T["validate + translate"]
  T --> W["AcpHandlerWorkflows"]
  W --> R["AcpRuntimeCoordinator"]
  W --> D["privacy-safe diagnostics"]
  W --> N["notification tracking / reject rollback"]
```

## Compatibility boundaries

- Preserve all 13 ACP calls and 3 events, payloads, snapshots, errors, and shutdown guard behavior.
- Preserve create failure and resume started/completed/failed diagnostic fields, HMAC Session hash, operation ID, timing, and privacy-safe error categories.
- Preserve prompt track-before-invoke and rollback only when the runtime rejects.
- Preserve preload/generated Web maps and captured local/remote Web handler registry.
- Preserve remote authorization/expiry and Compute download/reveal denial.
- Preserve Specialist Electron-only and current Permission/Compute asymmetry.
- Preserve TaskAgentPort, CLI, Task, and local RPC behavior; Task does not gain renderer diagnostics or notification behavior.
- No public schema, persistence/data relationship, UI, or issue #458 orchestration change.

## Commits and size

1. `test(acp): characterize handler application side effects`
2. `refactor(acp): extract handler application workflows`
3. `test(acp): isolate handler workflow logging mock`

Production churn is 320; test churn is 76; total churn is 396. The new workflow has only the three operations consumed by handlers.

## Validation

- Changed-file Prettier and ESLint with zero warnings: passed.
- Full Node/Web typecheck: passed.
- Focused Electron/Web/Task/shutdown tests: 135/135 passed.
- Web HTTP authorization/denial tests: 15/15 passed in an environment permitted to bind loopback.
- Full Vitest: 683 files passed / 15 skipped; 10,017 tests passed / 184 skipped.
- Full lint: 0 errors; 18 warnings are unchanged baseline files.
- `git diff --check`: passed.
- Independent review: Spec 0 findings; one Standards test-isolation P2 was fixed with one-shot logger mocks, then the IPC suite passed in normal and two shuffled orders.
- Worktree clean; ahead/behind `2/0` from `origin/main` `a6904f6`.

## Review focus

- Confirm handler bodies no longer own logging or notification state transitions.
- Confirm create/resume diagnostic values and timing are mechanically equivalent.
- Confirm prompt notification rollback happens on rejection only and never overwrites an active turn's token.
- Confirm no Task/CLI/local RPC or remote authorization/capability boundary changed.

## Residual risk

No real packaged Electron, operating-system notification, or manually paired remote-browser journey was run locally. Existing integration tests and exact-head CI cover their contracts.
