### PR TITLE
fix(session-persistence): coalesce backpressured writes

### DIFF
--- a/src/renderer/src/lib/session-persistence/session-persistence.test.ts
+++ b/src/renderer/src/lib/session-persistence/session-persistence.test.ts
@@ -665,6 +665,8 @@ describe('renderer session persistence bridge', () => {
       cwd: '/workspace/project'
     })
     void save(useSessionStore.getState())
+    await flushMicrotasks()
+    expect(saveSession).toHaveBeenCalledTimes(1)
 
     useSessionStore.getState().appendUserMessage({
       sessionId: 'session-1',
@@ -682,6 +684,46 @@ describe('renderer session persistence bridge', () => {
 
     secondSave.resolve(saveSession.mock.calls[1][0])
     await flushMicrotasks()
+  })
+
+  it('coalesces backpressured Store writes to the latest Session snapshot', async () => {
+    const firstSave = createDeferred<void>()
+    const saveSession = vi.fn<SessionPersistenceApi['saveSession']>(async (submitted) => {
+      if (submitted.title === 'First queued') await firstSave.promise
+      return submitted
+    })
+    const api = createApi({ saveSession })
+
+    useSessionStore.getState().appendUserMessage({
+      sessionId: 'session-1',
+      content: 'First',
+      cwd: '/workspace/project',
+      projectId: 'project-a'
+    })
+    const save = createStoreSaver(api, useSessionStore.getState())
+
+    useSessionStore.getState().renameSession('session-1', 'First queued')
+    const first = save(useSessionStore.getState())
+    await flushMicrotasks()
+
+    useSessionStore.getState().renameSession('session-1', 'Latest')
+    const renamed = save(useSessionStore.getState())
+    useSessionStore.getState().appendUserMessage({
+      sessionId: 'session-1',
+      content: 'Keep only this pending snapshot',
+      cwd: '/workspace/project'
+    })
+    const latest = save(useSessionStore.getState())
+
+    await flushMicrotasks()
+    expect(saveSession).toHaveBeenCalledOnce()
+
+    firstSave.resolve()
+    await Promise.all([first, renamed, latest])
+
+    expect(saveSession).toHaveBeenCalledTimes(2)
+    expect(saveSession.mock.calls[1][0].title).toBe('Latest')
+    expect(saveSession.mock.calls[1][1]).toEqual({ conflictRebaseFields: ['title'] })
   })
 
   it('reports an earlier failed write even when a later queued write succeeds', async () => {
@@ -724,6 +766,7 @@ describe('renderer session persistence bridge', () => {
 
     useSessionStore.getState().renameSession('session-1', 'Queued first')
     const queuedFirst = save(useSessionStore.getState())
+    await flushMicrotasks()
     useSessionStore.getState().renameSession('session-1', 'Queued stale')
     const queuedStale = save(useSessionStore.getState())
     useSessionStore.getState().renameSession('session-1', 'Artifact latest')

--- a/src/renderer/src/lib/session-persistence/session-persistence.ts
+++ b/src/renderer/src/lib/session-persistence/session-persistence.ts
@@ -27,7 +27,15 @@ type SessionPersistenceApi = {
   saveManifest: (request: SaveSessionManifestRequest) => Promise<void>
 }
 
-type OrderedSessionPersistence = Pick<SessionPersistenceApi, 'saveSession' | 'saveManifest'>
+type LatestSessionSaveTask = (options?: SaveSessionOptions) => Promise<PersistedChatSession>
+
+type OrderedSessionPersistence = Pick<SessionPersistenceApi, 'saveSession' | 'saveManifest'> & {
+  saveLatestSession: (
+    target: string,
+    task: LatestSessionSaveTask,
+    options?: SaveSessionOptions
+  ) => Promise<PersistedChatSession>
+}
 
 const SESSION_CONFLICT_REBASE_FIELDS = [
   'title',
@@ -52,15 +60,35 @@ const conflictRebaseFieldChanged = (
   )
 }
 
-// Serializes every renderer-originated Session write through one ordering seam. Callers enqueue the
-// snapshot immediately, so a later explicit Artifact save cannot be overtaken by an older store save
-// that was still waiting behind an in-flight write.
+const mergeSaveSessionOptions = (
+  previous: SaveSessionOptions | undefined,
+  next: SaveSessionOptions | undefined
+): SaveSessionOptions | undefined => {
+  const conflictRebaseFields = [
+    ...new Set([...(previous?.conflictRebaseFields ?? []), ...(next?.conflictRebaseFields ?? [])])
+  ]
+  return conflictRebaseFields.length > 0 ? { conflictRebaseFields } : undefined
+}
+
+// Serializes every renderer-originated Session write through one ordering seam. Store snapshots at
+// the queue tail use latest-wins coalescing; explicit Session and Manifest writes remain barriers, so
+// Artifact finalization cannot be overtaken by an older store snapshot.
 const createOrderedSessionPersistence = (
-  api: OrderedSessionPersistence
+  api: Pick<SessionPersistenceApi, 'saveSession' | 'saveManifest'>
 ): OrderedSessionPersistence => {
   let queue: Promise<unknown> = Promise.resolve()
+  let pendingLatest:
+    | {
+        target: string
+        task: LatestSessionSaveTask
+        options: SaveSessionOptions | undefined
+      }
+    | undefined
+  let pendingLatestPromise: Promise<PersistedChatSession> | undefined
 
   const enqueue = <Result>(task: () => Promise<Result>): Promise<Result> => {
+    pendingLatest = undefined
+    pendingLatestPromise = undefined
     const run = queue.then(task, task)
     queue = run.then(
       () => undefined,
@@ -69,7 +97,37 @@ const createOrderedSessionPersistence = (
     return run
   }
 
+  const saveLatestSession = (
+    target: string,
+    task: LatestSessionSaveTask,
+    options?: SaveSessionOptions
+  ): Promise<PersistedChatSession> => {
+    if (pendingLatest?.target === target && pendingLatestPromise) {
+      pendingLatest.task = task
+      pendingLatest.options = mergeSaveSessionOptions(pendingLatest.options, options)
+      return pendingLatestPromise
+    }
+
+    const entry = { target, task, options }
+    const runTask = (): Promise<PersistedChatSession> => {
+      if (pendingLatest === entry) {
+        pendingLatest = undefined
+        pendingLatestPromise = undefined
+      }
+      return entry.task(entry.options)
+    }
+    const run = queue.then(runTask, runTask)
+    pendingLatest = entry
+    pendingLatestPromise = run
+    queue = run.then(
+      () => undefined,
+      () => undefined
+    )
+    return run
+  }
+
   return {
+    saveLatestSession,
     saveSession: (session, options) =>
       enqueue(() => (options ? api.saveSession(session, options) : api.saveSession(session))),
     saveManifest: (request) => enqueue(() => api.saveManifest(request))
@@ -270,7 +328,6 @@ const createStoreSaver = (
         // is no longer proven to match the immutable Branch graph. Preserve the last durable copy.
         !session.conversationGraphSyncBlocked
       ) {
-        const persisted = toPersistedSession(session)
         const previousSession = previousById.get(session.id)
         const changedConflictRebaseFields = previousSession
           ? SESSION_CONFLICT_REBASE_FIELDS.filter((field) =>
@@ -284,23 +341,45 @@ const createStoreSaver = (
           ])
         ]
 
+        const saveOptions = conflictRebaseFields.length > 0 ? { conflictRebaseFields } : undefined
+        const applyDurableSession = (
+          durableSession: PersistedChatSession,
+          options: SaveSessionOptions | undefined
+        ): void => {
+          useSessionStore.getState().applyDurableSessionProjection({
+            source: session,
+            session: durableSession,
+            mode:
+              (options?.conflictRebaseFields?.length ?? 0) > 0
+                ? 'replace-persisted-if-current'
+                : 'merge-upload-identities'
+          })
+        }
+
         tasks.push({
           target,
           failureContext: { conflictRebaseFields },
-          run: async () => {
-            const durableSession = await persistence.saveSession(
-              persisted,
-              conflictRebaseFields.length > 0 ? { conflictRebaseFields } : undefined
-            )
-            useSessionStore.getState().applyDurableSessionProjection({
-              source: session,
-              session: durableSession,
-              mode:
-                conflictRebaseFields.length > 0
-                  ? 'replace-persisted-if-current'
-                  : 'merge-upload-identities'
-            })
-          }
+          run: isForced
+            ? async () => {
+                const durableSession = await persistence.saveSession(
+                  toPersistedSession(session),
+                  saveOptions
+                )
+                applyDurableSession(durableSession, saveOptions)
+              }
+            : () =>
+                persistence.saveLatestSession(
+                  target,
+                  async (coalescedOptions) => {
+                    const persisted = toPersistedSession(session)
+                    const durableSession = await (coalescedOptions
+                      ? api.saveSession(persisted, coalescedOptions)
+                      : api.saveSession(persisted))
+                    applyDurableSession(durableSession, coalescedOptions)
+                    return durableSession
+                  },
+                  saveOptions
+                )
         })
       }
     }


### PR DESCRIPTION
## Problem

During long or high-frequency agent streams, every Zustand Session update immediately materialized a complete persisted Session and queued it behind any in-flight renderer-to-main save. When persistence fell behind streaming, historical full snapshots accumulated in renderer memory and could end in an OOM renderer exit; the existing crash recovery then reloaded the renderer at Home.

## Proposed change

- Reuse the existing ordered persistence seam and coalesce consecutive Store-originated writes for the same Session at the queue tail.
- Keep only the latest pending task and defer full Session materialization until that task actually runs.
- Merge conflict-rebase fields from superseded tasks so user preference edits are not lost.
- Preserve explicit Session/Artifact saves, Manifest writes, and forced retries as FIFO ordering barriers.

```mermaid
flowchart LR
  A[Streaming Store updates] --> B[Latest pending Session task]
  B --> C[Ordered persistence queue]
  C --> D[Persist one full snapshot]
  E[Explicit Artifact or Session save] --> F[FIFO barrier]
  G[Manifest or forced retry] --> F
  F --> C
```

## Scope / non-goals

- No persisted JSON/schema, conversation graph, Artifact ownership, or data relationship changes.
- No UI, navigation, recovery copy, or other user-interaction changes.
- No dependency or cross-module abstraction additions.
- This PR does not yet batch stream chunks, change runtime IPC snapshots, or throttle Markdown rendering.

## Acceptance / validation

- Backpressured Store writes persist the first in-flight snapshot and only the latest pending snapshot.
- Conflict-rebase intent survives coalescing.
- Explicit Artifact persistence remains ordered after older Store writes.
- npm run typecheck — passed.
- npm run lint — passed with 18 pre-existing warnings and 0 errors.
- npm test — passed: 683 files / 10,017 tests; 15 files / 184 tests skipped.
- Focused persistence + Artifact ordering suites — passed: 86 tests.

## Review focus

- The tail replacement and barrier reset in createOrderedSessionPersistence.
- Deferred toPersistedSession materialization in createStoreSaver.
- Preservation of conflict-rebase options and durable projection modes after coalescing.

Residual risk: coalescing intentionally applies only to consecutive queue-tail writes for the same Session. Writes for different Sessions remain fully ordered and are not reordered or merged.
