### PR TITLE
test(transport): certify remote acp compatibility

### DIFF
--- a/src/main/web-service/http-server.test.ts
+++ b/src/main/web-service/http-server.test.ts
@@ -12,6 +12,7 @@ vi.mock('electron', () => ({
   net: { fetch: vi.fn() }
 }))
 
+import { WEB_INVOKE_CHANNELS } from '../../shared/web-api-map.generated'
 import { WEB_RPC_PROTOCOL_VERSION } from '../../shared/web-rpc-contract'
 import { ApplicationEventHub } from '../application-events'
 import type { CallerContext } from '../caller-context'
@@ -705,21 +706,11 @@ describe('startWebHttpServer', () => {
     const staticRoot = await mkdtemp(join(tmpdir(), 'open-science-web-static-'))
     roots.push(staticRoot)
     await writeFile(join(staticRoot, 'index.html'), '<!doctype html>')
-    const acpChannels = [
-      'acp:cancel',
-      'acp:compact-session',
-      'acp:connect',
-      'acp:create-session',
-      'acp:delete-session',
-      'acp:disconnect',
-      'acp:get-state',
-      'acp:reset-session-context',
-      'acp:respond-permission',
-      'acp:resume-session',
-      'acp:revoke-permission-grant',
-      'acp:send-prompt',
-      'acp:set-permission-profile'
-    ]
+    const acpChannels = Object.entries(WEB_INVOKE_CHANNELS)
+      .filter(([path]) => path.startsWith('acp.'))
+      .map(([, channel]) => channel)
+      .sort()
+    expect(acpChannels).toHaveLength(13)
     const permissionChannels = [
       'permissions:extend-undo',
       'permissions:list',

--- a/src/main/web-service/http-server.test.ts
+++ b/src/main/web-service/http-server.test.ts
@@ -501,7 +501,7 @@ describe('startWebHttpServer', () => {
       }
     })
     const rpc = {
-      channels: () => ['projects:list'],
+      channels: () => ['acp:get-state'],
       invoke: vi.fn(async () => ({ ok: true })),
       releaseClient: vi.fn(),
       dispose: vi.fn()
@@ -588,7 +588,7 @@ describe('startWebHttpServer', () => {
 
     expect(
       await postAfterExpiringAuthorization(
-        '/rpc/projects%3Alist',
+        '/rpc/acp%3Aget-state',
         { protocolVersion: WEB_RPC_PROTOCOL_VERSION, args: [] },
         1
       )
@@ -705,10 +705,22 @@ describe('startWebHttpServer', () => {
     const staticRoot = await mkdtemp(join(tmpdir(), 'open-science-web-static-'))
     roots.push(staticRoot)
     await writeFile(join(staticRoot, 'index.html'), '<!doctype html>')
-    const permissionChannels = [
+    const acpChannels = [
+      'acp:cancel',
+      'acp:compact-session',
+      'acp:connect',
+      'acp:create-session',
+      'acp:delete-session',
+      'acp:disconnect',
+      'acp:get-state',
+      'acp:reset-session-context',
       'acp:respond-permission',
-      'acp:set-permission-profile',
+      'acp:resume-session',
       'acp:revoke-permission-grant',
+      'acp:send-prompt',
+      'acp:set-permission-profile'
+    ]
+    const permissionChannels = [
       'permissions:extend-undo',
       'permissions:list',
       'permissions:restore',
@@ -739,10 +751,16 @@ describe('startWebHttpServer', () => {
     ]
     const remoteDeniedComputeChannels = ['compute:download', 'compute:reveal-in-folder']
     const remoteAllowedChannels = [
+      ...acpChannels,
       ...permissionChannels,
       ...computeChannels.filter((channel) => !remoteDeniedComputeChannels.includes(channel))
     ]
-    const rpcChannels = ['specialist:list', ...permissionChannels, ...computeChannels]
+    const rpcChannels = [
+      'specialist:list',
+      ...acpChannels,
+      ...permissionChannels,
+      ...computeChannels
+    ]
     const rpc = {
       channels: () => rpcChannels,
       invoke: vi.fn(async (channel: string) => ({ channel })),
@@ -806,7 +824,11 @@ describe('startWebHttpServer', () => {
       rpcChannels: string[]
       restrictedRpcChannels: string[]
     }
-    expect(localBootstrapBody.rpcChannels).toEqual([...permissionChannels, ...computeChannels])
+    expect(localBootstrapBody.rpcChannels).toEqual([
+      ...acpChannels,
+      ...permissionChannels,
+      ...computeChannels
+    ])
     expect(localBootstrapBody.restrictedRpcChannels).toEqual([])
 
     expect((await invoke('specialist:list')).status).toBe(404)


### PR DESCRIPTION
## Problem

The ACP refactor already had strong compatibility coverage for Electron, local Web, Task/SDK/CLI, Notebook local RPC, Session adoption, and the intentional Specialist/Permission/Compute asymmetry. One transport gap remained: the remote Web capability matrix explicitly exercised only the Permission-related ACP calls, and authorization expiry used a generic project RPC rather than an ACP call.

That left the final 13-call ACP surface insufficiently certified for both one-time and trusted remote-browser authorization.

## Proposed change

Extend the existing Web HTTP contract suite without changing production code:

- derive the complete ACP call set from the canonical generated `WEB_INVOKE_CHANNELS` map and pin its current size at 13;
- expose and invoke every ACP call through the simulated remote router for both one-time and trusted authorization;
- confirm local Web still exposes the same 13 calls;
- retain the existing remote Compute download/reveal denial and Specialist absence assertions; and
- use `acp:get-state` to prove expired remote authorization rejects before ACP dispatch.

```mermaid
flowchart LR
  M["Canonical Web invoke map"] --> A["13 ACP calls"]
  A --> O["One-time remote authorization"]
  A --> T["Trusted remote authorization"]
  O --> H["Web HTTP RPC seam"]
  T --> H
  H --> R["Captured ACP handler router"]
  X["Expired authorization"] -->|"401, no invoke"| H
```

## Scope and non-goals

- Test-only change: production churn is zero.
- Preserve Electron/local Web 13 calls and 3 events.
- Preserve Task/SDK/CLI schemas, stable Session IDs, timeouts, outputs, exit codes, and current Permission event/profile subset.
- Preserve Notebook capability/alias/`host.agents`/Agent Compute behavior.
- Preserve Specialist/Permission/Compute surface asymmetry, including remote Compute download/reveal denial.
- No schema, persistence, data relationship, user interaction, or UI change.
- Issue #458 remains forward-compatible only; no orchestration interface, state, event, or relationship is introduced.

## Commits and size

1. `test(transport): certify remote acp compatibility`
2. `test(transport): derive acp matrix from web contract`

Final diff: one test file, `+20/-7`; production changed lines: `0`.

## Acceptance criteria and validation

Final branch head `94c3c8a` is rebased on `origin/main` `3941eb7`, with ahead/behind `2/0` and a clean worktree.

- One-time/trusted remote authorization for all 13 ACP calls, local Web parity, remote denial, and ACP expiry -> `src/main/web-service/http-server.test.ts` -> 15/15 passed on the rebased final head.
- Cross-surface ACP/Electron/preload/Web/Task/SDK/CLI/Notebook/adoption contracts -> focused 14-file suite -> 608/608 passed on the rebased final head.
- Canonical generated map derivation and current 13-call inventory -> focused Web-map/ACP-inventory/remote tests -> 5/5 passed after the review fix.
- Node and Web compile compatibility -> `npm run typecheck` -> passed on the rebased final head.
- Changed-file formatting and static policy -> Prettier plus ESLint `--max-warnings=0` -> passed with zero findings on the rebased final head.
- Repository regression suite -> `npm test` -> 683 files passed / 15 skipped; 10,017 tests passed / 184 skipped.
- Repository lint -> `npm run lint` -> 0 errors; 18 warnings are unchanged baseline files, while the changed file has zero warnings.
- Patch integrity -> `git diff --check` -> passed on the rebased final head.
- Independent final review -> Spec: 0 findings; Standards: 0 findings. The original Standards P2 was closed by deriving ACP calls from the canonical generated map.

The full suite and repository lint ran before the review-only test-data derivation and the non-overlapping Session Persistence rebase. The rebased final head then passed the complete affected focused suite, typecheck, changed-file format/lint, and diff check. Exact-head CI remains the merge gate.

## Review focus

- Confirm every canonical `acp.*` Web method participates in both remote authorization cases.
- Confirm the explicit length assertion still pins the current 13-call contract while avoiding a second hand-maintained channel list.
- Confirm expired remote authorization cannot reach `acp:get-state` dispatch.
- Confirm local Web parity and existing Specialist/Permission/Compute denial behavior remain intact.
- Confirm no production or issue #458 orchestration surface changed.

## Residual risk

No manually paired remote browser or packaged Electron journey was run locally. The HTTP integration suite exercises authorization outcomes and router dispatch in-process; exact-head CI is required before merge.
