### PR TITLE
refactor(notebook): extract command workflows

### DIFF
--- a/src/main/notebook/ipc.test.ts
+++ b/src/main/notebook/ipc.test.ts
@@ -132,6 +132,7 @@ describe('notebook IPC handlers', () => {
       runCell: vi.fn().mockResolvedValue({ runId: 'run-1', status: 'completed' }),
       execute: vi.fn().mockResolvedValue({ runId: 'run-2', status: 'completed' }),
       exportIpynb: vi.fn().mockResolvedValue({ saved: false }),
+      exportIpynbAll: vi.fn().mockResolvedValue({ saved: false }),
       restart: vi.fn().mockResolvedValue({ sessionId: 'session-1' }),
       shutdown: vi.fn().mockResolvedValue({ sessionId: 'session-1', status: 'shutdown' })
     } as unknown as NotebookRuntimeService
@@ -165,7 +166,8 @@ describe('notebook IPC handlers', () => {
         runtimeSegmentId: 'forged-runtime',
         promptMessageId: 'forged-prompt'
       },
-      registeredInputFiles: []
+      registeredInputFiles: [],
+      inputRunLeaseId: 'forged-input-run-lease'
     }
     const run = { ...publicRun, ...forgedTurnContext }
     const execute = { ...publicExecute, ...forgedTurnContext }
@@ -178,6 +180,7 @@ describe('notebook IPC handlers', () => {
     await ipcHandlers.get('notebook:run-cell')?.(undefined, run)
     await ipcHandlers.get('notebook:execute')?.(undefined, execute)
     await ipcHandlers.get('notebook:export-ipynb')?.(undefined, session)
+    await ipcHandlers.get('notebook:export-ipynb-all')?.(undefined, session)
     await ipcHandlers.get('notebook:restart')?.(undefined, session)
     await ipcHandlers.get('notebook:shutdown')?.(undefined, session)
 
@@ -189,6 +192,7 @@ describe('notebook IPC handlers', () => {
     expect(service.runCell).toHaveBeenCalledWith(publicRun)
     expect(service.execute).toHaveBeenCalledWith(publicExecute)
     expect(service.exportIpynb).toHaveBeenCalledWith(session)
+    expect(service.exportIpynbAll).toHaveBeenCalledWith(session)
     expect(service.restart).toHaveBeenCalledWith(session)
     expect(service.shutdown).toHaveBeenCalledWith(session)
   })

--- a/src/main/notebook/ipc.ts
+++ b/src/main/notebook/ipc.ts
@@ -5,69 +5,23 @@ import type {
   BeginNotebookCodeCellRequest,
   ExecuteNotebookCodeRequest,
   ExportNotebookAllRequest,
-  ExportNotebookAllResult,
   ExportNotebookKernelRequest,
-  ExportNotebookResult,
   FinishNotebookCodeCellRequest,
-  NotebookRunSummary,
-  NotebookSessionReference,
   NotebookSessionRequest,
-  NotebookSessionState,
   RunNotebookCellRequest
 } from '../../shared/notebook'
-import type { NotebookRuntimeService } from './runtime-service'
-import { withDataRootWrite } from '../storage/migration-state'
-
-type NotebookHandlers = {
-  state: (request: NotebookSessionRequest) => Promise<NotebookSessionState>
-  reference: (request: NotebookSessionRequest) => Promise<NotebookSessionReference | null>
-  beginCodeCell: (
-    request: BeginNotebookCodeCellRequest
-  ) => ReturnType<NotebookRuntimeService['beginCodeCell']>
-  appendCodeCell: (
-    request: AppendNotebookCodeCellRequest
-  ) => ReturnType<NotebookRuntimeService['appendCodeCell']>
-  finishCodeCell: (
-    request: FinishNotebookCodeCellRequest
-  ) => ReturnType<NotebookRuntimeService['finishCodeCell']>
-  runCell: (request: RunNotebookCellRequest) => ReturnType<NotebookRuntimeService['runCell']>
-  execute: (request: ExecuteNotebookCodeRequest) => Promise<NotebookRunSummary>
-  exportIpynb: (request: ExportNotebookKernelRequest) => Promise<ExportNotebookResult>
-  exportIpynbAll: (request: ExportNotebookAllRequest) => Promise<ExportNotebookAllResult>
-  restart: (request: NotebookSessionRequest) => Promise<NotebookSessionState>
-  shutdown: (request: NotebookSessionRequest) => ReturnType<NotebookRuntimeService['shutdown']>
-}
-
-const withoutTrustedTurnContext = <Request extends NotebookSessionRequest>(
-  request: Request
-): Request => {
-  const { provenanceContext, registeredInputFiles, inputRunLeaseId, ...publicRequest } = request
-  void provenanceContext
-  void registeredInputFiles
-  void inputRunLeaseId
-  return publicRequest as Request
-}
+import {
+  createNotebookCommandWorkflows,
+  type NotebookCommandRuntime,
+  type NotebookCommandWorkflows
+} from './notebook-workflows'
 
 // Builds a small delegating surface so tests can validate IPC behavior without Electron wiring.
-const createNotebookHandlers = (service: NotebookRuntimeService): NotebookHandlers => ({
-  state: (request) => service.state(request),
-  reference: (request) => service.getSessionReference(request),
-  beginCodeCell: (request) => withDataRootWrite(() => service.beginCodeCell(request)),
-  appendCodeCell: (request) => withDataRootWrite(() => service.appendCodeCell(request)),
-  finishCodeCell: (request) => withDataRootWrite(() => service.finishCodeCell(request)),
-  runCell: (request) =>
-    withDataRootWrite(() => service.runCell(withoutTrustedTurnContext(request))),
-  execute: (request) =>
-    withDataRootWrite(() => service.execute(withoutTrustedTurnContext(request))),
-  exportIpynb: (request) => service.exportIpynb(request),
-  exportIpynbAll: (request) => service.exportIpynbAll(request),
-  restart: (request) => withDataRootWrite(() => service.restart(request)),
-  shutdown: (request) => withDataRootWrite(() => service.shutdown(request))
-})
+const createNotebookHandlers = createNotebookCommandWorkflows
 
 // Registers renderer-callable notebook commands on the main-process IPC bus.
-const registerNotebookIpcHandlers = (service: NotebookRuntimeService): void => {
-  const handlers = createNotebookHandlers(service)
+const registerNotebookIpcHandlers = (runtime: NotebookCommandRuntime): void => {
+  const handlers = createNotebookHandlers(runtime)
 
   ipcMainHandle('notebook:state', (_event, request: NotebookSessionRequest) =>
     handlers.state(request)
@@ -105,4 +59,4 @@ const registerNotebookIpcHandlers = (service: NotebookRuntimeService): void => {
 }
 
 export { createNotebookHandlers, registerNotebookIpcHandlers }
-export type { NotebookHandlers }
+export type { NotebookCommandWorkflows as NotebookHandlers }

--- a/src/main/notebook/notebook-workflows.test.ts
+++ b/src/main/notebook/notebook-workflows.test.ts
@@ -1,0 +1,209 @@
+import { afterEach, describe, expect, it, vi } from 'vitest'
+
+import type {
+  ExportNotebookAllResult,
+  ExportNotebookResult,
+  NotebookRunSummary,
+  NotebookSessionReference,
+  NotebookSessionState
+} from '../../shared/notebook'
+import { beginMigration, clearMigrationPending } from '../storage/migration-state'
+import { createNotebookCommandWorkflows, type NotebookCommandRuntime } from './notebook-workflows'
+
+afterEach(() => clearMigrationPending())
+
+const unavailable = (operation: string): (() => Promise<never>) =>
+  vi.fn(() => Promise.reject(new Error(`Unexpected ${operation} call`)))
+
+const createRuntime = (
+  overrides: Partial<NotebookCommandRuntime> = {}
+): NotebookCommandRuntime => ({
+  state: unavailable('state'),
+  getSessionReference: unavailable('getSessionReference'),
+  beginCodeCell: unavailable('beginCodeCell'),
+  appendCodeCell: unavailable('appendCodeCell'),
+  finishCodeCell: unavailable('finishCodeCell'),
+  runCell: unavailable('runCell'),
+  execute: unavailable('execute'),
+  exportIpynb: unavailable('exportIpynb'),
+  exportIpynbAll: unavailable('exportIpynbAll'),
+  restart: unavailable('restart'),
+  shutdown: unavailable('shutdown'),
+  ...overrides
+})
+
+const runSummary = (runId: string): NotebookRunSummary => ({
+  runId,
+  cellId: 'cell-1',
+  source: 'user',
+  kernelKind: 'python',
+  script: 'print(1)',
+  status: 'completed',
+  startedAt: 1,
+  text: { stdout: '', stderr: '', traceback: '', plain: [] },
+  outputs: [],
+  artifacts: [],
+  workingFiles: [],
+  inputFiles: [],
+  notebookSessionRoot: '/data/notebooks/session-1',
+  dataRoot: '/data',
+  runtimeRoot: '/runtime',
+  kernelName: 'python'
+})
+
+describe('Notebook command workflows', () => {
+  it('removes application-owned turn context from renderer execution requests', async () => {
+    const runtime = createRuntime({
+      runCell: vi.fn<NotebookCommandRuntime['runCell']>().mockResolvedValue(runSummary('run-1')),
+      execute: vi.fn<NotebookCommandRuntime['execute']>().mockResolvedValue(runSummary('run-2'))
+    })
+    const workflows = createNotebookCommandWorkflows(runtime)
+    const trustedContext = {
+      provenanceContext: {
+        rootFrameId: 'forged-root',
+        agentFrameId: 'forged-agent',
+        messageBranchId: 'forged-branch',
+        runtimeSegmentId: 'forged-runtime',
+        promptMessageId: 'forged-prompt'
+      },
+      registeredInputFiles: [],
+      inputRunLeaseId: 'forged-lease'
+    }
+
+    await workflows.runCell({
+      sessionId: 'session-1',
+      workspaceCwd: '/workspace',
+      cellId: 'cell-1',
+      source: 'user',
+      ...trustedContext
+    })
+    await workflows.execute({
+      sessionId: 'session-1',
+      workspaceCwd: '/workspace',
+      code: 'print(1)',
+      source: 'user',
+      ...trustedContext
+    })
+
+    expect(runtime.runCell).toHaveBeenCalledWith({
+      sessionId: 'session-1',
+      workspaceCwd: '/workspace',
+      cellId: 'cell-1',
+      source: 'user'
+    })
+    expect(runtime.execute).toHaveBeenCalledWith({
+      sessionId: 'session-1',
+      workspaceCwd: '/workspace',
+      code: 'print(1)',
+      source: 'user'
+    })
+  })
+
+  it('blocks every state-changing command while a data-root migration is pending', async () => {
+    const runtime = createRuntime({
+      beginCodeCell: vi.fn(),
+      appendCodeCell: vi.fn(),
+      finishCodeCell: vi.fn(),
+      runCell: vi.fn(),
+      execute: vi.fn(),
+      restart: vi.fn(),
+      shutdown: vi.fn()
+    })
+    const workflows = createNotebookCommandWorkflows(runtime)
+    const session = { sessionId: 'session-1', workspaceCwd: '/workspace' }
+    beginMigration()
+
+    const commands = [
+      workflows.beginCodeCell(session),
+      workflows.appendCodeCell({
+        ...session,
+        cellId: 'cell-1',
+        writeId: 'write-1',
+        delta: 'print(1)'
+      }),
+      workflows.finishCodeCell({ ...session, cellId: 'cell-1', writeId: 'write-1' }),
+      workflows.runCell({ ...session, cellId: 'cell-1', source: 'user' }),
+      workflows.execute({ ...session, code: 'print(1)', source: 'user' }),
+      workflows.restart(session),
+      workflows.shutdown(session)
+    ]
+
+    await Promise.all(
+      commands.map((command) => expect(command).rejects.toThrow(/moving your data/i))
+    )
+    for (const operation of Object.values(runtime)) expect(operation).not.toHaveBeenCalled()
+  })
+
+  it('keeps read-only state, reference, and export commands available during migration', async () => {
+    const state: NotebookSessionState = {
+      id: 'session-1',
+      sessionId: 'session-1',
+      cwd: '/workspace',
+      notebookSessionRoot: '/data/notebooks/session-1',
+      dataRoot: '/data',
+      runtimeRoot: '/runtime',
+      kernelStatus: 'idle',
+      runJsonPath: '/data/notebooks/session-1/run.json',
+      cells: [],
+      runs: [],
+      recentRuns: [],
+      environments: []
+    }
+    const reference: NotebookSessionReference = {
+      sessionId: 'session-1',
+      projectName: 'Project',
+      workspaceCwd: '/workspace',
+      notebookSessionRoot: '/data/notebooks/session-1',
+      dataRoot: '/data',
+      runtimeRoot: '/runtime',
+      runJsonPath: '/data/notebooks/session-1/run.json'
+    }
+    const singleExport: ExportNotebookResult = {
+      saved: true,
+      filePath: '/tmp/python.ipynb'
+    }
+    const allExport: ExportNotebookAllResult = {
+      saved: true,
+      directory: '/tmp',
+      files: [
+        { kernel: 'python', filePath: '/tmp/python.ipynb' },
+        { kernel: 'r', filePath: '/tmp/r.ipynb' }
+      ]
+    }
+    const runtime = createRuntime({
+      state: vi.fn<NotebookCommandRuntime['state']>().mockResolvedValue(state),
+      getSessionReference: vi
+        .fn<NotebookCommandRuntime['getSessionReference']>()
+        .mockResolvedValue(reference),
+      exportIpynb: vi.fn<NotebookCommandRuntime['exportIpynb']>().mockResolvedValue(singleExport),
+      exportIpynbAll: vi.fn<NotebookCommandRuntime['exportIpynbAll']>().mockResolvedValue(allExport)
+    })
+    const workflows = createNotebookCommandWorkflows(runtime)
+    const session = { sessionId: 'session-1', workspaceCwd: '/workspace' }
+    beginMigration()
+
+    await expect(workflows.state(session)).resolves.toBe(state)
+    await expect(workflows.reference(session)).resolves.toBe(reference)
+    await expect(workflows.exportIpynb({ ...session, kernel: 'python' })).resolves.toBe(
+      singleExport
+    )
+    await expect(workflows.exportIpynbAll(session)).resolves.toBe(allExport)
+  })
+
+  it('preserves the runtime error object for callers', async () => {
+    const failure = new Error('kernel unavailable')
+    const runtime = createRuntime({
+      execute: vi.fn<NotebookCommandRuntime['execute']>().mockRejectedValue(failure)
+    })
+    const workflows = createNotebookCommandWorkflows(runtime)
+
+    await expect(
+      workflows.execute({
+        sessionId: 'session-1',
+        workspaceCwd: '/workspace',
+        code: 'print(1)',
+        source: 'user'
+      })
+    ).rejects.toBe(failure)
+  })
+})

--- a/src/main/notebook/notebook-workflows.ts
+++ b/src/main/notebook/notebook-workflows.ts
@@ -1,0 +1,101 @@
+import type {
+  AppendNotebookCodeCellRequest,
+  BeginNotebookCodeCellRequest,
+  ExecuteNotebookCodeRequest,
+  ExportNotebookAllRequest,
+  ExportNotebookAllResult,
+  ExportNotebookKernelRequest,
+  ExportNotebookResult,
+  FinishNotebookCodeCellRequest,
+  NotebookCell,
+  NotebookRunSummary,
+  NotebookSessionReference,
+  NotebookSessionRequest,
+  NotebookSessionState,
+  RunNotebookCellRequest
+} from '../../shared/notebook'
+import { withDataRootWrite } from '../storage/migration-state'
+
+type BeginNotebookCodeCellResult = {
+  sessionId: string
+  cellId: string
+  writeId: string
+  status: NotebookCell['status']
+}
+
+type AppendNotebookCodeCellResult = {
+  sessionId: string
+  cellId: string
+  writeId: string
+  receivedBytes: number
+}
+
+type FinishNotebookCodeCellResult = {
+  sessionId: string
+  cellId: string
+  code: string
+  status: NotebookCell['status']
+}
+
+type NotebookShutdownResult = { sessionId: string; status: 'shutdown' }
+
+type NotebookCommandRuntime = {
+  state(request: NotebookSessionRequest): Promise<NotebookSessionState>
+  getSessionReference(request: NotebookSessionRequest): Promise<NotebookSessionReference | null>
+  beginCodeCell(request: BeginNotebookCodeCellRequest): Promise<BeginNotebookCodeCellResult>
+  appendCodeCell(request: AppendNotebookCodeCellRequest): Promise<AppendNotebookCodeCellResult>
+  finishCodeCell(request: FinishNotebookCodeCellRequest): Promise<FinishNotebookCodeCellResult>
+  runCell(request: RunNotebookCellRequest): Promise<NotebookRunSummary>
+  execute(request: ExecuteNotebookCodeRequest): Promise<NotebookRunSummary>
+  exportIpynb(request: ExportNotebookKernelRequest): Promise<ExportNotebookResult>
+  exportIpynbAll(request: ExportNotebookAllRequest): Promise<ExportNotebookAllResult>
+  restart(request: NotebookSessionRequest): Promise<NotebookSessionState>
+  shutdown(request: NotebookSessionRequest): Promise<NotebookShutdownResult>
+}
+
+type NotebookCommandWorkflows = {
+  state(request: NotebookSessionRequest): Promise<NotebookSessionState>
+  reference(request: NotebookSessionRequest): Promise<NotebookSessionReference | null>
+  beginCodeCell(request: BeginNotebookCodeCellRequest): Promise<BeginNotebookCodeCellResult>
+  appendCodeCell(request: AppendNotebookCodeCellRequest): Promise<AppendNotebookCodeCellResult>
+  finishCodeCell(request: FinishNotebookCodeCellRequest): Promise<FinishNotebookCodeCellResult>
+  runCell(request: RunNotebookCellRequest): Promise<NotebookRunSummary>
+  execute(request: ExecuteNotebookCodeRequest): Promise<NotebookRunSummary>
+  exportIpynb(request: ExportNotebookKernelRequest): Promise<ExportNotebookResult>
+  exportIpynbAll(request: ExportNotebookAllRequest): Promise<ExportNotebookAllResult>
+  restart(request: NotebookSessionRequest): Promise<NotebookSessionState>
+  shutdown(request: NotebookSessionRequest): Promise<NotebookShutdownResult>
+}
+
+const withoutTrustedTurnContext = <
+  Request extends RunNotebookCellRequest | ExecuteNotebookCodeRequest
+>(
+  request: Request
+): Request => {
+  const { provenanceContext, registeredInputFiles, inputRunLeaseId, ...publicRequest } = request
+  void provenanceContext
+  void registeredInputFiles
+  void inputRunLeaseId
+  return publicRequest as Request
+}
+
+const createNotebookCommandWorkflows = (
+  runtime: NotebookCommandRuntime
+): NotebookCommandWorkflows => ({
+  state: (request) => runtime.state(request),
+  reference: (request) => runtime.getSessionReference(request),
+  beginCodeCell: (request) => withDataRootWrite(() => runtime.beginCodeCell(request)),
+  appendCodeCell: (request) => withDataRootWrite(() => runtime.appendCodeCell(request)),
+  finishCodeCell: (request) => withDataRootWrite(() => runtime.finishCodeCell(request)),
+  runCell: (request) =>
+    withDataRootWrite(() => runtime.runCell(withoutTrustedTurnContext(request))),
+  execute: (request) =>
+    withDataRootWrite(() => runtime.execute(withoutTrustedTurnContext(request))),
+  exportIpynb: (request) => runtime.exportIpynb(request),
+  exportIpynbAll: (request) => runtime.exportIpynbAll(request),
+  restart: (request) => withDataRootWrite(() => runtime.restart(request)),
+  shutdown: (request) => withDataRootWrite(() => runtime.shutdown(request))
+})
+
+export { createNotebookCommandWorkflows }
+export type { NotebookCommandRuntime, NotebookCommandWorkflows }


### PR DESCRIPTION
## Problem

The Electron Notebook adapter still owned application behavior for all 11 Notebook commands: data-root migration admission, removal of renderer-supplied trusted turn context, and delegation to the large runtime façade. That made IPC both a transport and the implicit command interface needed by later Web/local-RPC composition work.

## Proposed change

Introduce a transport-neutral `NotebookCommandWorkflows` interface over an 11-operation `NotebookCommandRuntime` port, then reduce `notebook/ipc.ts` to channel registration and payload forwarding.

```mermaid
flowchart LR
  E["Electron IPC: validate + translate"] --> W["NotebookCommandWorkflows"]
  W -->|"7 mutations: data-root write lease"| R["NotebookCommandRuntime port"]
  W -->|"state/reference/2 exports"| R
  W -->|"strip trusted turn context"| X["runCell / execute"]
  X --> R
```

The workflow preserves all 11 commands:

- `state`, `reference`, `beginCodeCell`, `appendCodeCell`, `finishCodeCell`;
- `runCell`, `execute`, `exportIpynb`, `exportIpynbAll`, `restart`, and `shutdown`.

## Scope and non-goals

- Preserve all Electron channel names, request/response values, and error identity.
- Preserve `withDataRootWrite` for the seven state-changing commands while state/reference/exports remain readable during migration.
- Preserve stripping of renderer-supplied `provenanceContext`, `registeredInputFiles`, and `inputRunLeaseId` before `runCell`/`execute` reach the runtime.
- Do not change main composition, ACP, preload, local/remote Web, local RPC, CLI/SDK, events, persistence, data relationships, or UI.
- Specialist, Permission, and Compute surface asymmetry is unchanged.
- Issue #458 remains forward-compatible only; no orchestration state, method, event, or relationship is added.

## Commits and size

1. `refactor(notebook): extract command workflows`

Final diff: four Notebook files, 165 production changed lines, 215 test changed lines, 380 total changed lines. The production diff is below the original estimate and is not padded.

## Acceptance criteria and validation

Branch head `f0de59e` is based on `origin/main` `3dccf6a`, ahead/behind `1/0`, with a clean worktree.

- All 11 commands, migration admission, trusted-field stripping, read/export availability, and error identity -> `npm test -- src/main/notebook/notebook-workflows.test.ts src/main/notebook/ipc.test.ts` -> 2 files / 7 tests passed on the final head.
- Notebook Node contracts -> `npm run typecheck:node` -> passed on the final head.
- Changed-file formatting and static policy -> Prettier plus ESLint `--max-warnings=0` -> passed with zero findings on the final head.
- Patch integrity -> `git diff --check` -> passed on the final head.
- Repository regression suite after the final production edit -> `npm test` -> 684 files passed / 15 skipped; 10,022 tests passed / 184 skipped.
- Repository compile/static checks after the final production edit -> `npm run typecheck` passed; `npm run lint` completed with 0 errors and 18 unchanged baseline warnings.
- Independent final review -> Spec: 0 findings; Standards: 0 findings. A Standards P3 in the new test fake was fixed before the final review.

The branch was then rebased without conflict from `3941eb7` to `3dccf6a`; that base delta is A9.5's test-only `http-server.test.ts` certification. The final head reran the affected focused suite, Node typecheck, changed-file format/lint, and diff check. Exact-head CI remains the merge gate.

## Review focus

- Confirm IPC now only registers channels and forwards payloads.
- Confirm the workflow, not the adapter, owns migration admission and trusted-field stripping.
- Confirm the narrow port contains only the 11 existing commands and exposes no runtime state.
- Confirm no transport availability or public contract changed.

## Residual risk

No packaged Electron or manual data-root migration smoke test was run locally. Focused tests exercise the adapter/workflow boundary in-process; exact-head CI is required before merge.
