### PR TITLE
refactor(notebook): extract runtime selection workflows

### DIFF
--- a/src/main/notebook/runtime-ipc.test.ts
+++ b/src/main/notebook/runtime-ipc.test.ts
@@ -1,16 +1,14 @@
 import { beforeEach, describe, expect, it, vi } from 'vitest'
 
 import type { NotebookLanguage } from '../../shared/notebook'
-import type { DetectionResult, EnvironmentAdapter, RuntimeRegistryDeps } from './runtime-registry'
 import type {
-  DiscoveredInterpreter,
   RuntimeEnablement,
-  RuntimeSelection,
-  RuntimeSurvey
+  RuntimeReadiness,
+  RuntimeSelection
 } from '../../shared/notebook-runtime'
+import type { DiscoveredInterpreter } from './environment-discovery'
+import type { RuntimeIpcDeps } from './runtime-ipc'
 
-// Capture ipcMain.handle registrations and stub the native dialog so handlers can be invoked without
-// a real Electron runtime (mirrors storage/ipc.test.ts).
 const handlers = new Map<string, (event: unknown, payload?: unknown) => unknown>()
 const showOpenDialog = vi.fn()
 
@@ -23,126 +21,68 @@ vi.mock('electron', () => ({
   dialog: { showOpenDialog: (...args: unknown[]) => showOpenDialog(...args) }
 }))
 
-// Controllable discovery so the enablement-invariant handler never enumerates the real machine.
 const discoveryState = vi.hoisted(() => ({
-  python: [] as unknown[],
-  r: [] as unknown[]
+  python: [] as DiscoveredInterpreter[],
+  r: [] as DiscoveredInterpreter[]
 }))
 
 vi.mock('./environment-discovery', () => ({
   defaultDiscoveryDeps: () => ({}),
-  discoverInterpreters: async (language: 'python' | 'r') => discoveryState[language]
+  discoverInterpreters: async (language: NotebookLanguage) => discoveryState[language]
 }))
 
-const fakeEnv = (
-  provenance: DiscoveredInterpreter['provenance'],
-  envId: string
-): DiscoveredInterpreter => ({
-  language: 'python',
-  provenance,
-  envId,
-  interpreterPath: envId,
-  label: envId,
-  runnable: true
-})
-
-const { RuntimeRegistry } = await import('./runtime-registry')
 const { registerRuntimeIpcHandlers } = await import('./runtime-ipc')
 
-const invoke = (channel: string, payload?: unknown): Promise<unknown> =>
-  Promise.resolve(handlers.get(channel)!(undefined, payload))
+type SettingsPort = RuntimeIpcDeps['settingsService']
 
-// A fake adapter that returns a fixed detection per language, so survey never spawns an interpreter.
-const fakeAdapter = (
-  source: EnvironmentAdapter['source'],
-  byLanguage: Partial<Record<NotebookLanguage, DetectionResult>>
-): EnvironmentAdapter => ({
+const readiness = (
+  language: NotebookLanguage,
+  source: RuntimeReadiness['source']
+): RuntimeReadiness => ({
+  language,
   source,
-  detect: async (language) =>
-    byLanguage[language] ?? { detected: false, runnable: false, detail: 'not found' }
+  detected: true,
+  selected: false,
+  runnable: true,
+  packageMutable: source === 'managed'
 })
 
-const fakeRegistry = (): InstanceType<typeof RuntimeRegistry> => {
-  const deps: RuntimeRegistryDeps = {
-    managed: fakeAdapter('managed', {
-      python: { detected: true, runnable: true, interpreterPath: '/managed/py/bin/python' },
-      r: { detected: false, runnable: false, detail: 'Managed environment is not built yet.' }
-    }),
-    external: fakeAdapter('external', {
-      python: {
-        detected: true,
-        runnable: true,
-        interpreterPath: '/usr/bin/python3',
-        version: '3.12.0'
-      },
-      r: { detected: false, runnable: false, detail: 'No system R found.' }
-    })
-  }
-  return new RuntimeRegistry(deps)
-}
+const fakeRegistry = (): NonNullable<RuntimeIpcDeps['registry']> => ({
+  survey: async (language) => ({
+    managed: readiness(language, 'managed'),
+    external: readiness(language, 'external')
+  }),
+  readiness: async (language) => ({ ...readiness(language, 'external'), selected: true })
+})
 
-// In-memory settings seam mirroring SettingsService.get/setRuntimeSelection (external R rejected) and
-// the v4 get/set enablement read-modify-write.
-const fakeSettingsService = (): {
-  store: Map<NotebookLanguage, RuntimeSelection>
+const fakeSettingsService = (): SettingsPort & {
+  selections: Map<NotebookLanguage, RuntimeSelection>
   enablement: Map<NotebookLanguage, RuntimeEnablement>
-  getRuntimeSelection: (language: NotebookLanguage) => Promise<RuntimeSelection | undefined>
-  setRuntimeSelection: (
-    language: NotebookLanguage,
-    selection: RuntimeSelection | null
-  ) => Promise<RuntimeSelection | undefined>
-  getRuntimeEnablement: (language: NotebookLanguage) => Promise<RuntimeEnablement>
-  setEnvironmentEnabled: (
-    language: NotebookLanguage,
-    envId: string,
-    enabled: boolean
-  ) => Promise<RuntimeEnablement>
-  setInstallAuthorized: (
-    language: NotebookLanguage,
-    envId: string,
-    authorized: boolean
-  ) => Promise<RuntimeEnablement>
   manual: Map<NotebookLanguage, string[]>
-  getManualInterpreters: (language: NotebookLanguage) => Promise<string[]>
-  addManualInterpreter: (language: NotebookLanguage, path: string) => Promise<string[]>
-  removeManualInterpreter: (language: NotebookLanguage, path: string) => Promise<string[]>
 } => {
-  const store = new Map<NotebookLanguage, RuntimeSelection>()
+  const selections = new Map<NotebookLanguage, RuntimeSelection>()
   const enablement = new Map<NotebookLanguage, RuntimeEnablement>()
   const manual = new Map<NotebookLanguage, string[]>()
-  const read = (language: NotebookLanguage): RuntimeEnablement =>
+  const readEnablement = (language: NotebookLanguage): RuntimeEnablement =>
     enablement.get(language) ?? { enabled: {}, installAuthorized: {} }
+
   return {
-    store,
+    selections,
     enablement,
     manual,
-    getManualInterpreters: async (language) => manual.get(language) ?? [],
-    addManualInterpreter: async (language, path) => {
-      const next = [...new Set([...(manual.get(language) ?? []), path])]
-      manual.set(language, next)
-      return next
-    },
-    removeManualInterpreter: async (language, path) => {
-      const next = (manual.get(language) ?? []).filter((p) => p !== path)
-      manual.set(language, next)
-      return next
-    },
-    getRuntimeSelection: async (language) => store.get(language),
+    getRuntimeSelection: async (language) => selections.get(language),
     setRuntimeSelection: async (language, selection) => {
       if (selection === null) {
-        store.delete(language)
+        selections.delete(language)
         return undefined
       }
-      if (language === 'r' && selection.source === 'external') {
-        throw new Error('R only supports the managed runtime.')
-      }
-      store.set(language, selection)
+      selections.set(language, selection)
       return selection
     },
-    getRuntimeEnablement: async (language) => read(language),
+    getRuntimeEnablement: async (language) => readEnablement(language),
     setEnvironmentEnabled: async (language, envId, enabled) => {
-      const current = read(language)
-      const next: RuntimeEnablement = {
+      const current = readEnablement(language)
+      const next = {
         enabled: { ...current.enabled, [envId]: enabled },
         installAuthorized: { ...current.installAuthorized }
       }
@@ -150,25 +90,37 @@ const fakeSettingsService = (): {
       return next
     },
     setInstallAuthorized: async (language, envId, authorized) => {
-      const current = read(language)
-      const next: RuntimeEnablement = {
+      const current = readEnablement(language)
+      const next = {
         enabled: { ...current.enabled },
         installAuthorized: { ...current.installAuthorized, [envId]: authorized }
       }
       enablement.set(language, next)
       return next
+    },
+    getManualInterpreters: async (language) => manual.get(language) ?? [],
+    addManualInterpreter: async (language, path) => {
+      const next = [...new Set([...(manual.get(language) ?? []), path])]
+      manual.set(language, next)
+      return next
+    },
+    removeManualInterpreter: async (language, path) => {
+      const next = (manual.get(language) ?? []).filter((candidate) => candidate !== path)
+      manual.set(language, next)
+      return next
     }
   }
 }
 
-type Deps = Parameters<typeof registerRuntimeIpcHandlers>[0]
-
-const fakeDeps = (overrides: Partial<Deps> = {}): Deps => ({
+const fakeDeps = (overrides: Partial<RuntimeIpcDeps> = {}): RuntimeIpcDeps => ({
   settingsService: fakeSettingsService(),
-  runtimeRoot: () => '/tmp/runtime',
+  runtimeRoot: () => '/data/runtime',
   registry: fakeRegistry(),
   ...overrides
 })
+
+const invoke = (channel: string, payload?: unknown): Promise<unknown> =>
+  Promise.resolve(handlers.get(channel)!(undefined, payload))
 
 beforeEach(() => {
   handlers.clear()
@@ -177,165 +129,111 @@ beforeEach(() => {
   discoveryState.r = []
 })
 
-describe('runtime IPC handlers', () => {
-  it('registers every runtime channel', () => {
+describe('runtime IPC adapter', () => {
+  it('registers the exact runtime command surface', () => {
     registerRuntimeIpcHandlers(fakeDeps())
 
-    for (const channel of ['runtime:survey', 'runtime:set-selection', 'runtime:pick-interpreter']) {
-      expect(handlers.has(channel)).toBe(true)
-    }
+    expect([...handlers.keys()]).toEqual([
+      'runtime:survey',
+      'runtime:list-environments',
+      'runtime:set-selection',
+      'runtime:get-enablement',
+      'runtime:describe-usage',
+      'runtime:set-environment-enabled',
+      'runtime:set-install-authorized',
+      'runtime:pick-interpreter',
+      'runtime:register-interpreter',
+      'runtime:unregister-interpreter'
+    ])
   })
 
-  it('survey returns both languages with managed + external readiness and the persisted selection', async () => {
+  it('routes all nine application commands through their existing payloads', async () => {
     const settingsService = fakeSettingsService()
-    settingsService.store.set('python', { source: 'managed' })
-    registerRuntimeIpcHandlers(fakeDeps({ settingsService }))
-
-    const surveys = (await invoke('runtime:survey')) as RuntimeSurvey[]
-
-    expect(surveys.map((s) => s.language)).toEqual(['python', 'r'])
-
-    const python = surveys.find((s) => s.language === 'python')!
-    expect(python.selection).toEqual({ source: 'managed' })
-    expect(python.managed).toMatchObject({ source: 'managed', detected: true, runnable: true })
-    expect(python.external).toMatchObject({
-      source: 'external',
-      detected: true,
-      runnable: true,
-      version: '3.12.0'
-    })
-
-    const r = surveys.find((s) => s.language === 'r')!
-    expect(r.selection).toBeUndefined()
-    expect(r.managed).toMatchObject({ source: 'managed', detected: false })
-    expect(r.external).toMatchObject({ source: 'external', detected: false })
-  })
-
-  it('set-selection persists the choice and returns the refreshed survey for that language', async () => {
-    const settingsService = fakeSettingsService()
-    registerRuntimeIpcHandlers(fakeDeps({ settingsService }))
-
-    const selection: RuntimeSelection = {
-      source: 'external',
-      interpreterPath: '/usr/bin/python3',
-      appOwnedOverlay: false,
-      packageInstallAuthorized: false
-    }
-    const survey = (await invoke('runtime:set-selection', {
-      language: 'python',
-      selection
-    })) as RuntimeSurvey
-
-    expect(settingsService.store.get('python')).toEqual(selection)
-    expect(survey.language).toBe('python')
-    expect(survey.selection).toEqual(selection)
-    // The survey still carries both sources' readiness (unaffected by the selection).
-    expect(survey.managed.detected).toBe(true)
-    expect(survey.external.detected).toBe(true)
-  })
-
-  it('set-selection rejects a non-runnable external interpreter and does NOT persist it', async () => {
-    const settingsService = fakeSettingsService()
-    // External Python detected but NOT runnable (e.g. python2 / not a valid Python 3).
-    const registry = new RuntimeRegistry({
-      managed: fakeAdapter('managed', {
-        python: { detected: true, runnable: true, interpreterPath: '/managed/py/bin/python' }
-      }),
-      external: fakeAdapter('external', {
-        python: { detected: true, runnable: false, detail: 'not a runnable Python 3' }
-      })
-    })
-    registerRuntimeIpcHandlers(fakeDeps({ settingsService, registry }))
-
-    await expect(
-      invoke('runtime:set-selection', {
+    const usage = { running: 1, idle: 2, dormant: 3 }
+    const onRuntimeDisabled = vi.fn().mockResolvedValue(undefined)
+    discoveryState.python = [
+      {
         language: 'python',
-        selection: {
-          source: 'external',
-          interpreterPath: '/usr/bin/python2',
-          appOwnedOverlay: false,
-          packageInstallAuthorized: false
-        }
-      })
-    ).rejects.toThrow(/not a runnable Python 3/)
-    // Crucially, the bad selection was never saved.
-    expect(settingsService.store.has('python')).toBe(false)
-  })
-
-  it('prepares an app-owned overlay before persisting the external selection', async () => {
-    const settingsService = fakeSettingsService()
-    const order: string[] = []
-    const originalSet = settingsService.setRuntimeSelection
-    settingsService.setRuntimeSelection = async (language, selection) => {
-      order.push('persist')
-      return originalSet(language, selection)
-    }
-    const prepareExternalPython = vi.fn(async () => void order.push('prepare'))
-    registerRuntimeIpcHandlers(fakeDeps({ settingsService, prepareExternalPython }))
-
-    await invoke('runtime:set-selection', {
-      language: 'python',
-      selection: {
-        source: 'external',
+        provenance: 'user-own',
+        envId: '/usr/bin/python3',
         interpreterPath: '/usr/bin/python3',
-        appOwnedOverlay: true,
-        packageInstallAuthorized: true
+        label: 'System Python',
+        runnable: true
       }
-    })
-
-    expect(order).toEqual(['prepare', 'persist'])
-    expect(prepareExternalPython).toHaveBeenCalledWith(
-      expect.objectContaining({ interpreterPath: '/usr/bin/python3' }),
-      '/tmp/runtime'
-    )
-  })
-
-  it('does not persist an app-owned selection when overlay preparation fails', async () => {
-    const settingsService = fakeSettingsService()
+    ]
     registerRuntimeIpcHandlers(
       fakeDeps({
         settingsService,
-        prepareExternalPython: async () => {
-          throw new Error('matplotlib import failed')
-        }
+        describeRuntimeUsage: () => usage,
+        onRuntimeDisabled
       })
     )
 
+    await expect(invoke('runtime:survey')).resolves.toHaveLength(2)
+    await expect(invoke('runtime:list-environments')).resolves.toEqual({
+      python: discoveryState.python,
+      r: []
+    })
     await expect(
-      invoke('runtime:set-selection', {
+      invoke('runtime:set-selection', { language: 'python', selection: { source: 'managed' } })
+    ).resolves.toMatchObject({ language: 'python', selection: { source: 'managed' } })
+    await expect(invoke('runtime:get-enablement', { language: 'python' })).resolves.toEqual({
+      enabled: {},
+      installAuthorized: {}
+    })
+    await expect(
+      invoke('runtime:describe-usage', { language: 'python', envId: '/usr/bin/python3' })
+    ).resolves.toBe(usage)
+    await expect(
+      invoke('runtime:set-environment-enabled', {
         language: 'python',
-        selection: {
-          source: 'external',
-          interpreterPath: '/usr/bin/python3',
-          appOwnedOverlay: true,
-          packageInstallAuthorized: true
-        }
+        envId: '/usr/bin/python3',
+        enabled: false,
+        force: true
       })
-    ).rejects.toThrow(/selection was not saved.*matplotlib import failed/)
-    expect(settingsService.store.has('python')).toBe(false)
+    ).resolves.toMatchObject({ enabled: { '/usr/bin/python3': false } })
+    expect(onRuntimeDisabled).toHaveBeenCalledWith('python', '/usr/bin/python3', true)
+    await expect(
+      invoke('runtime:set-install-authorized', {
+        language: 'python',
+        envId: '/usr/bin/python3',
+        authorized: true
+      })
+    ).resolves.toMatchObject({ installAuthorized: { '/usr/bin/python3': true } })
+    await expect(
+      invoke('runtime:register-interpreter', {
+        language: 'python',
+        path: '/usr/bin/python3'
+      })
+    ).resolves.toEqual(['/usr/bin/python3'])
+    await expect(
+      invoke('runtime:unregister-interpreter', {
+        language: 'python',
+        path: '/usr/bin/python3'
+      })
+    ).resolves.toEqual([])
   })
 
-  it('set-selection with null clears the persisted choice', async () => {
+  it('preserves application errors for transport callers', async () => {
     const settingsService = fakeSettingsService()
-    settingsService.store.set('python', { source: 'managed' })
+    const failure = new Error('settings unavailable')
+    settingsService.getRuntimeEnablement = vi.fn().mockRejectedValue(failure)
     registerRuntimeIpcHandlers(fakeDeps({ settingsService }))
 
-    const survey = (await invoke('runtime:set-selection', {
-      language: 'python',
-      selection: null
-    })) as RuntimeSurvey
-
-    expect(settingsService.store.has('python')).toBe(false)
-    expect(survey.selection).toBeUndefined()
+    await expect(invoke('runtime:get-enablement', { language: 'python' })).rejects.toBe(failure)
   })
 
-  it('pick-interpreter returns the injected dialog path', async () => {
+  it('returns an injected interpreter path', async () => {
     registerRuntimeIpcHandlers(fakeDeps({ showOpenDialog: async () => '/opt/python/bin/python3' }))
 
     await expect(invoke('runtime:pick-interpreter')).resolves.toBe('/opt/python/bin/python3')
   })
 
-  it('pick-interpreter returns null on cancel and never throws on dialog failure', async () => {
+  it('returns null when the picker is cancelled or fails', async () => {
+    const log = vi.spyOn(console, 'error').mockImplementation(() => undefined)
+    registerRuntimeIpcHandlers(fakeDeps({ showOpenDialog: async () => null }))
+    await expect(invoke('runtime:pick-interpreter')).resolves.toBeNull()
+
     registerRuntimeIpcHandlers(
       fakeDeps({
         showOpenDialog: async () => {
@@ -345,135 +243,15 @@ describe('runtime IPC handlers', () => {
     )
 
     await expect(invoke('runtime:pick-interpreter')).resolves.toBeNull()
+    expect(log).toHaveBeenCalled()
+    log.mockRestore()
   })
 
-  it('pick-interpreter uses the native openFile dialog when no override is injected', async () => {
+  it('uses the Electron open-file picker when no override is injected', async () => {
     showOpenDialog.mockResolvedValue({ filePaths: ['/usr/local/bin/python3'] })
     registerRuntimeIpcHandlers(fakeDeps())
 
     await expect(invoke('runtime:pick-interpreter')).resolves.toBe('/usr/local/bin/python3')
     expect(showOpenDialog).toHaveBeenCalledWith({ properties: ['openFile'] })
-  })
-})
-
-describe('runtime enablement handlers', () => {
-  it('registers the enablement channels', () => {
-    registerRuntimeIpcHandlers(fakeDeps())
-
-    expect(handlers.has('runtime:set-environment-enabled')).toBe(true)
-    expect(handlers.has('runtime:set-install-authorized')).toBe(true)
-  })
-
-  it('enables a user-own env and returns the refreshed enablement', async () => {
-    const settingsService = fakeSettingsService()
-    discoveryState.python = [
-      fakeEnv('app-managed', '/managed/py'),
-      fakeEnv('user-own', '/usr/bin/python3')
-    ]
-    registerRuntimeIpcHandlers(fakeDeps({ settingsService }))
-
-    const result = (await invoke('runtime:set-environment-enabled', {
-      language: 'python',
-      envId: '/usr/bin/python3',
-      enabled: true
-    })) as RuntimeEnablement
-
-    expect(result.enabled['/usr/bin/python3']).toBe(true)
-    expect(settingsService.enablement.get('python')?.enabled['/usr/bin/python3']).toBe(true)
-  })
-
-  it('disables a non-last env while another stays effective-enabled', async () => {
-    const settingsService = fakeSettingsService()
-    // Two app-managed envs are on by default; disabling one leaves the other enabled.
-    discoveryState.python = [
-      fakeEnv('app-managed', '/managed/a'),
-      fakeEnv('app-managed', '/managed/b')
-    ]
-    registerRuntimeIpcHandlers(fakeDeps({ settingsService }))
-
-    const result = (await invoke('runtime:set-environment-enabled', {
-      language: 'python',
-      envId: '/managed/a',
-      enabled: false
-    })) as RuntimeEnablement
-
-    expect(result.enabled['/managed/a']).toBe(false)
-    expect(settingsService.enablement.get('python')?.enabled['/managed/a']).toBe(false)
-  })
-
-  it('allows disabling the LAST effective-enabled env (a language may have zero enabled)', async () => {
-    const settingsService = fakeSettingsService()
-    // Only one app-managed env (default ON): disabling it leaves the language with zero enabled — a
-    // valid choice. It persists and revokes; the agent bind path surfaces the "enable one" guidance.
-    discoveryState.python = [fakeEnv('app-managed', '/managed/only')]
-    const revoked: Array<[NotebookLanguage, string, boolean | undefined]> = []
-    registerRuntimeIpcHandlers(
-      fakeDeps({
-        settingsService,
-        onRuntimeDisabled: (language, envId, force) => {
-          revoked.push([language, envId, force])
-          return Promise.resolve()
-        }
-      })
-    )
-
-    const result = (await invoke('runtime:set-environment-enabled', {
-      language: 'python',
-      envId: '/managed/only',
-      enabled: false
-    })) as RuntimeEnablement
-
-    expect(result.enabled['/managed/only']).toBe(false)
-    expect(settingsService.enablement.get('python')?.enabled['/managed/only']).toBe(false)
-    expect(revoked).toEqual([['python', '/managed/only', undefined]])
-  })
-
-  it('set-install-authorized records the per-env opt-in without touching enabled', async () => {
-    const settingsService = fakeSettingsService()
-    registerRuntimeIpcHandlers(fakeDeps({ settingsService }))
-
-    const result = (await invoke('runtime:set-install-authorized', {
-      language: 'python',
-      envId: '/usr/bin/python3',
-      authorized: true
-    })) as RuntimeEnablement
-
-    expect(result.installAuthorized['/usr/bin/python3']).toBe(true)
-    expect(result.enabled).toEqual({})
-  })
-})
-
-describe('manual-interpreter catalog handlers', () => {
-  beforeEach(() => {
-    handlers.clear()
-  })
-
-  it('registers the catalog channels', () => {
-    registerRuntimeIpcHandlers(fakeDeps())
-    expect(handlers.has('runtime:register-interpreter')).toBe(true)
-    expect(handlers.has('runtime:unregister-interpreter')).toBe(true)
-  })
-
-  it('register/unregister add and drop a path in the per-language catalog', async () => {
-    const settingsService = fakeSettingsService()
-    registerRuntimeIpcHandlers(fakeDeps({ settingsService }))
-
-    const added = (await invoke('runtime:register-interpreter', {
-      language: 'python',
-      path: '/opt/py/bin/python3'
-    })) as string[]
-    expect(added).toEqual(['/opt/py/bin/python3'])
-    // Idempotent: registering the same path again does not duplicate it.
-    const again = (await invoke('runtime:register-interpreter', {
-      language: 'python',
-      path: '/opt/py/bin/python3'
-    })) as string[]
-    expect(again).toEqual(['/opt/py/bin/python3'])
-
-    const removed = (await invoke('runtime:unregister-interpreter', {
-      language: 'python',
-      path: '/opt/py/bin/python3'
-    })) as string[]
-    expect(removed).toEqual([])
   })
 })

--- a/src/main/notebook/runtime-ipc.ts
+++ b/src/main/notebook/runtime-ipc.ts
@@ -3,228 +3,54 @@ import { dialog } from 'electron'
 import { ipcMainHandle } from '../ipc-handler-registry'
 
 import type { NotebookLanguage } from '../../shared/notebook'
-import type {
-  RuntimeEnablement,
-  RuntimeSelection,
-  RuntimeSurvey,
-  RuntimeUsage
-} from '../../shared/notebook-runtime'
+import type { RuntimeSelection } from '../../shared/notebook-runtime'
 import {
-  createExternalAdapter,
-  createManagedAdapter,
-  defaultExternalAdapterDeps
-} from './runtime-adapters'
-import {
-  defaultDiscoveryDeps,
-  discoverInterpreters,
-  type DiscoveredInterpreter
-} from './environment-discovery'
-import { RuntimeRegistry } from './runtime-registry'
-import { prepareExternalPythonRuntime, type AppOwnedExternalSelection } from './venv-overlay'
+  createRuntimeSelectionWorkflows,
+  type RuntimeSelectionWorkflowDeps
+} from './runtime-selection-workflows'
 
-// The languages the Runtime Selection UI surveys, in display order. R stays managed-only in v1 (the
-// external resolver + overlay are Python-specific), enforced at persistence in the settings layer.
-const RUNTIME_LANGUAGES: readonly NotebookLanguage[] = ['python', 'r']
-
-// What the runtime IPC surface needs. `runtimeRoot` is a lazy getter (not a value) so a data-root
-// switch is picked up without re-registering; it MUST resolve to the same root the executor/service
-// use (getRuntimeRoot(<dataRoot>)). `settingsService` is the read/write seam for the persisted choice.
-export type RuntimeIpcDeps = {
-  settingsService: {
-    getRuntimeSelection: (language: NotebookLanguage) => Promise<RuntimeSelection | undefined>
-    setRuntimeSelection: (
-      language: NotebookLanguage,
-      selection: RuntimeSelection | null
-    ) => Promise<RuntimeSelection | undefined>
-    // v4 environment enablement (per-env enabled override + install-auth, keyed by envId).
-    getRuntimeEnablement: (language: NotebookLanguage) => Promise<RuntimeEnablement>
-    setEnvironmentEnabled: (
-      language: NotebookLanguage,
-      envId: string,
-      enabled: boolean
-    ) => Promise<RuntimeEnablement>
-    setInstallAuthorized: (
-      language: NotebookLanguage,
-      envId: string,
-      authorized: boolean
-    ) => Promise<RuntimeEnablement>
-    // v4 manual-interpreter catalog (paths added via "Add interpreter…"), merged into discovery.
-    getManualInterpreters: (language: NotebookLanguage) => Promise<string[]>
-    addManualInterpreter: (language: NotebookLanguage, path: string) => Promise<string[]>
-    removeManualInterpreter: (language: NotebookLanguage, path: string) => Promise<string[]>
-  }
-  // The app runtime root (<dataRoot>/runtime); read lazily so a data-root switch is picked up.
-  runtimeRoot: () => string
+export type RuntimeIpcDeps = RuntimeSelectionWorkflowDeps & {
   // Injectable for tests; production defaults to the Electron native open-file dialog.
   showOpenDialog?: () => Promise<string | null>
-  // Injectable for tests so survey never spawns a real interpreter; defaults to the managed +
-  // external adapters wired to the real detectors.
-  registry?: RuntimeRegistry
-  // Prepares an app-owned overlay before its selection is persisted. Production injects mirror/CA
-  // policy; tests inject a hermetic implementation.
-  prepareExternalPython?: (
-    selection: AppOwnedExternalSelection,
-    runtimeRoot: string
-  ) => Promise<void>
-  // WS10: called after a runtime is DISABLED, so the notebook service can revoke it from any live
-  // session bound to it (mark the binding unavailable/disabled; no silent fallback). Optional so tests
-  // that don't exercise the lifecycle can omit it.
-  onRuntimeDisabled?: (language: NotebookLanguage, envId: string, force?: boolean) => Promise<void>
-  // WS11: how many live sessions are bound to a runtime (running/idle/dormant), so the disable
-  // affordance can warn about impact before revoking. Optional; defaults to all-zero when unwired.
-  describeRuntimeUsage?: (language: NotebookLanguage, envId: string) => RuntimeUsage
 }
 
-// Registers the renderer-callable runtime-selection commands: survey both languages, persist a
-// per-language choice (returning the refreshed survey so the UI updates in one shot), and pick an
-// interpreter file via the native dialog. Mirrors the storage IPC module.
+// Registers renderer-callable runtime-selection commands while keeping native host interaction in
+// the Electron adapter. Application ordering and state ownership live behind the workflow interface.
 const registerRuntimeIpcHandlers = (deps: RuntimeIpcDeps): void => {
-  const registry =
-    deps.registry ??
-    new RuntimeRegistry({
-      managed: createManagedAdapter({ runtimeRoot: deps.runtimeRoot }),
-      external: createExternalAdapter(defaultExternalAdapterDeps())
-    })
+  const workflows = createRuntimeSelectionWorkflows(deps)
 
-  // One language's full picture: the persisted choice plus a survey of BOTH sources. When an external
-  // interpreter is actually SELECTED, its readiness must reflect THAT interpreter — survey()'s external
-  // branch auto-detects a PATH interpreter (selection-less), which may differ from the chosen path — so
-  // fold in readiness(selection), which passes the persisted path through to the adapter.
-  const buildSurvey = async (language: NotebookLanguage): Promise<RuntimeSurvey> => {
-    const [selection, surveyed] = await Promise.all([
-      deps.settingsService.getRuntimeSelection(language),
-      registry.survey(language)
-    ])
-    const external =
-      selection?.source === 'external'
-        ? await registry.readiness(language, selection)
-        : surveyed.external
+  ipcMainHandle('runtime:survey', () => workflows.survey())
 
-    return { language, selection, managed: surveyed.managed, external }
-  }
-
-  ipcMainHandle('runtime:survey', (): Promise<RuntimeSurvey[]> =>
-    Promise.all(RUNTIME_LANGUAGES.map(buildSurvey))
-  )
-
-  // v4 environment discovery: every detected interpreter (PATH / common dirs / pyenv / conda / app
-  // envs) per language, for the Settings cards. Standard-location-only enumeration (no disk walk).
-  ipcMainHandle(
-    'runtime:list-environments',
-    async (): Promise<{ python: DiscoveredInterpreter[]; r: DiscoveredInterpreter[] }> => {
-      // Snapshot the manual-interpreter catalog for both languages, then feed it into discovery as a
-      // sync getter so a manually-added interpreter is probed + surfaced alongside detected ones.
-      const [manualPy, manualR] = await Promise.all([
-        deps.settingsService.getManualInterpreters('python'),
-        deps.settingsService.getManualInterpreters('r')
-      ])
-      const discovery = defaultDiscoveryDeps(deps.runtimeRoot(), (language) =>
-        language === 'python' ? manualPy : manualR
-      )
-      const [python, r] = await Promise.all([
-        discoverInterpreters('python', discovery),
-        discoverInterpreters('r', discovery)
-      ])
-      return { python, r }
-    }
-  )
+  ipcMainHandle('runtime:list-environments', () => workflows.listEnvironments())
 
   ipcMainHandle(
     'runtime:set-selection',
-    async (
-      _event,
-      request: { language: NotebookLanguage; selection: RuntimeSelection | null }
-    ): Promise<RuntimeSurvey> => {
-      // Validate an external (BYO) selection BEFORE persisting: an interpreter that is not a runnable
-      // Python 3 (a non-Python file, python2, a wrong/too-old version, a moved path) must never be
-      // saved, or a later cell run would try to execute it. readiness() probes the selected path via the
-      // external adapter. The managed source is runnable-by-provisioning, so it skips the probe.
-      if (request.selection?.source === 'external') {
-        if (request.language !== 'python') {
-          throw new Error('R only supports the app-managed runtime.')
-        }
-        const readiness = await registry.readiness(request.language, request.selection)
-        if (!readiness.runnable) {
-          throw new Error(
-            readiness.detail
-              ? `That interpreter can't be used as a notebook runtime: ${readiness.detail}`
-              : "That interpreter can't be used as a notebook runtime (not a runnable Python 3)."
-          )
-        }
-        if (request.selection.appOwnedOverlay) {
-          try {
-            await (deps.prepareExternalPython ?? prepareExternalPythonRuntime)(
-              request.selection as AppOwnedExternalSelection,
-              deps.runtimeRoot()
-            )
-          } catch (error) {
-            throw new Error(
-              `Could not prepare an isolated notebook runtime, so the selection was not saved: ${error instanceof Error ? error.message : String(error)}`
-            )
-          }
-        }
-      }
-      await deps.settingsService.setRuntimeSelection(request.language, request.selection)
-
-      return buildSurvey(request.language)
-    }
+    (_event, request: { language: NotebookLanguage; selection: RuntimeSelection | null }) =>
+      workflows.setSelection(request)
   )
 
-  // v4: the persisted per-language enablement (explicit enabled-overrides + install-auth), so the
-  // Settings cards reflect the SAVED state on load rather than re-deriving from provenance defaults.
-  ipcMainHandle(
-    'runtime:get-enablement',
-    async (_event, request: { language: NotebookLanguage }): Promise<RuntimeEnablement> =>
-      deps.settingsService.getRuntimeEnablement(request.language)
+  ipcMainHandle('runtime:get-enablement', (_event, request: { language: NotebookLanguage }) =>
+    workflows.getEnablement(request)
   )
 
-  // WS11: live-session usage of a runtime (running/idle/dormant), so the disable affordance can warn
-  // about impact before revoking. Unwired -> all-zero (no live sessions to consider).
   ipcMainHandle(
     'runtime:describe-usage',
-    async (_event, request: { language: NotebookLanguage; envId: string }): Promise<RuntimeUsage> =>
-      deps.describeRuntimeUsage?.(request.language, request.envId) ?? {
-        running: 0,
-        idle: 0,
-        dormant: 0
-      }
+    (_event, request: { language: NotebookLanguage; envId: string }) =>
+      workflows.describeUsage(request)
   )
 
-  // v4: set one env's explicit enabled override for a language. Disabling any env — including the last
-  // enabled one — is allowed: a language with zero enabled runtimes is a valid user choice (R is
-  // optional; a user may want only their own interpreter). The agent is not left broken silently —
-  // resolveEnabledRuntime refuses a bind/execute with an actionable "enable one in Settings" message —
-  // so there is no need to trap the user in an undisablable toggle here. Returns the refreshed
-  // enablement so the UI updates in one shot.
   ipcMainHandle(
     'runtime:set-environment-enabled',
-    async (
+    (
       _event,
       request: { language: NotebookLanguage; envId: string; enabled: boolean; force?: boolean }
-    ): Promise<RuntimeEnablement> => {
-      const next = await deps.settingsService.setEnvironmentEnabled(
-        request.language,
-        request.envId,
-        request.enabled
-      )
-      // WS10: revoke a just-disabled runtime from any live session bound to it. force -> abort the
-      // running cell now ("stop running work"); default -> drain then close.
-      if (!request.enabled) {
-        await deps.onRuntimeDisabled?.(request.language, request.envId, request.force)
-      }
-      return next
-    }
+    ) => workflows.setEnvironmentEnabled(request)
   )
 
-  // v4: set one env's high-risk package-install authorization for a language. Independent of the enabled
-  // gate (execute-after-enable stays read-only until this is turned on). Returns the refreshed enablement.
   ipcMainHandle(
     'runtime:set-install-authorized',
-    async (
-      _event,
-      request: { language: NotebookLanguage; envId: string; authorized: boolean }
-    ): Promise<RuntimeEnablement> =>
-      deps.settingsService.setInstallAuthorized(request.language, request.envId, request.authorized)
+    (_event, request: { language: NotebookLanguage; envId: string; authorized: boolean }) =>
+      workflows.setInstallAuthorized(request)
   )
 
   ipcMainHandle('runtime:pick-interpreter', async (): Promise<string | null> => {
@@ -240,20 +66,14 @@ const registerRuntimeIpcHandlers = (deps: RuntimeIpcDeps): void => {
     }
   })
 
-  // v4: add a manually-picked interpreter path to the Settings catalog so discovery surfaces it as an
-  // (initially user-own, disabled) runtime card. Returns the refreshed catalog for that language.
   ipcMainHandle(
     'runtime:register-interpreter',
-    async (_event, request: { language: NotebookLanguage; path: string }): Promise<string[]> =>
-      deps.settingsService.addManualInterpreter(request.language, request.path)
+    (_event, request: { language: NotebookLanguage; path: string }) => workflows.register(request)
   )
 
-  // v4: drop a manually-added interpreter from the catalog (it disappears from discovery unless it is
-  // still detected by another source). Returns the refreshed catalog.
   ipcMainHandle(
     'runtime:unregister-interpreter',
-    async (_event, request: { language: NotebookLanguage; path: string }): Promise<string[]> =>
-      deps.settingsService.removeManualInterpreter(request.language, request.path)
+    (_event, request: { language: NotebookLanguage; path: string }) => workflows.unregister(request)
   )
 }
 

--- a/src/main/notebook/runtime-selection-workflows.test.ts
+++ b/src/main/notebook/runtime-selection-workflows.test.ts
@@ -1,0 +1,457 @@
+import { beforeEach, describe, expect, it, vi } from 'vitest'
+
+import type { NotebookLanguage } from '../../shared/notebook'
+import type {
+  RuntimeEnablement,
+  RuntimeReadiness,
+  RuntimeSelection
+} from '../../shared/notebook-runtime'
+import type { DiscoveredInterpreter } from './environment-discovery'
+
+const discoveryState = vi.hoisted(() => ({
+  python: [] as DiscoveredInterpreter[],
+  r: [] as DiscoveredInterpreter[],
+  snapshots: [] as Array<{ runtimeRoot: string; python: string[]; r: string[] }>
+}))
+
+vi.mock('./environment-discovery', () => ({
+  defaultDiscoveryDeps: (
+    runtimeRoot: string,
+    getManualInterpreters: (language: NotebookLanguage) => string[]
+  ) => {
+    discoveryState.snapshots.push({
+      runtimeRoot,
+      python: getManualInterpreters('python'),
+      r: getManualInterpreters('r')
+    })
+    return {}
+  },
+  discoverInterpreters: async (language: NotebookLanguage) => discoveryState[language]
+}))
+
+import {
+  createRuntimeSelectionWorkflows,
+  type RuntimeSelectionWorkflowDeps
+} from './runtime-selection-workflows'
+
+type SettingsPort = RuntimeSelectionWorkflowDeps['settingsService']
+
+const emptyEnablement = (): RuntimeEnablement => ({ enabled: {}, installAuthorized: {} })
+
+const fakeSettingsService = (): SettingsPort & {
+  selections: Map<NotebookLanguage, RuntimeSelection>
+  enablement: Map<NotebookLanguage, RuntimeEnablement>
+  manual: Map<NotebookLanguage, string[]>
+} => {
+  const selections = new Map<NotebookLanguage, RuntimeSelection>()
+  const enablement = new Map<NotebookLanguage, RuntimeEnablement>()
+  const manual = new Map<NotebookLanguage, string[]>()
+  const readEnablement = (language: NotebookLanguage): RuntimeEnablement =>
+    enablement.get(language) ?? emptyEnablement()
+
+  return {
+    selections,
+    enablement,
+    manual,
+    getRuntimeSelection: async (language) => selections.get(language),
+    setRuntimeSelection: async (language, selection) => {
+      if (selection === null) {
+        selections.delete(language)
+        return undefined
+      }
+      selections.set(language, selection)
+      return selection
+    },
+    getRuntimeEnablement: async (language) => readEnablement(language),
+    setEnvironmentEnabled: async (language, envId, enabled) => {
+      const current = readEnablement(language)
+      const next = {
+        enabled: { ...current.enabled, [envId]: enabled },
+        installAuthorized: { ...current.installAuthorized }
+      }
+      enablement.set(language, next)
+      return next
+    },
+    setInstallAuthorized: async (language, envId, authorized) => {
+      const current = readEnablement(language)
+      const next = {
+        enabled: { ...current.enabled },
+        installAuthorized: { ...current.installAuthorized, [envId]: authorized }
+      }
+      enablement.set(language, next)
+      return next
+    },
+    getManualInterpreters: async (language) => manual.get(language) ?? [],
+    addManualInterpreter: async (language, path) => {
+      const next = [...new Set([...(manual.get(language) ?? []), path])]
+      manual.set(language, next)
+      return next
+    },
+    removeManualInterpreter: async (language, path) => {
+      const next = (manual.get(language) ?? []).filter((candidate) => candidate !== path)
+      manual.set(language, next)
+      return next
+    }
+  }
+}
+
+const runtimeReadiness = (
+  language: NotebookLanguage,
+  source: RuntimeReadiness['source'],
+  overrides: Partial<RuntimeReadiness> = {}
+): RuntimeReadiness => ({
+  language,
+  source,
+  detected: true,
+  selected: false,
+  runnable: true,
+  packageMutable: source === 'managed',
+  ...overrides
+})
+
+const fakeRegistry = (
+  order: string[] = []
+): NonNullable<RuntimeSelectionWorkflowDeps['registry']> => ({
+  survey: vi.fn(async (language: NotebookLanguage) => {
+    order.push('survey')
+    return {
+      managed: runtimeReadiness(language, 'managed'),
+      external: runtimeReadiness(language, 'external')
+    }
+  }),
+  readiness: vi.fn(async (language: NotebookLanguage) => {
+    order.push('readiness')
+    return runtimeReadiness(language, 'external', { selected: true })
+  })
+})
+
+beforeEach(() => {
+  discoveryState.python = []
+  discoveryState.r = []
+  discoveryState.snapshots = []
+})
+
+describe('runtime selection workflows', () => {
+  it('returns the persisted runtime enablement unchanged', async () => {
+    const settingsService = fakeSettingsService()
+    const persisted: RuntimeEnablement = {
+      enabled: { '/managed/python': false },
+      installAuthorized: { '/user/python': true }
+    }
+    settingsService.enablement.set('python', persisted)
+    const workflows = createRuntimeSelectionWorkflows({
+      settingsService,
+      runtimeRoot: () => '/data/runtime',
+      registry: fakeRegistry()
+    })
+
+    await expect(workflows.getEnablement({ language: 'python' })).resolves.toBe(persisted)
+  })
+
+  it('reports zero live usage when runtime usage is not wired', async () => {
+    const workflows = createRuntimeSelectionWorkflows({
+      settingsService: fakeSettingsService(),
+      runtimeRoot: () => '/data/runtime',
+      registry: fakeRegistry()
+    })
+
+    await expect(
+      workflows.describeUsage({ language: 'python', envId: '/managed/python' })
+    ).resolves.toEqual({ running: 0, idle: 0, dormant: 0 })
+  })
+
+  it('returns the live runtime usage object unchanged when usage is wired', async () => {
+    const usage = { running: 1, idle: 2, dormant: 3 }
+    const describeRuntimeUsage = vi.fn(() => usage)
+    const workflows = createRuntimeSelectionWorkflows({
+      settingsService: fakeSettingsService(),
+      runtimeRoot: () => '/data/runtime',
+      registry: fakeRegistry(),
+      describeRuntimeUsage
+    })
+
+    await expect(workflows.describeUsage({ language: 'r', envId: '/managed/r' })).resolves.toBe(
+      usage
+    )
+    expect(describeRuntimeUsage).toHaveBeenCalledWith('r', '/managed/r')
+  })
+
+  it('updates install authorization without changing enabled state', async () => {
+    const settingsService = fakeSettingsService()
+    settingsService.enablement.set('python', {
+      enabled: { '/user/python': true },
+      installAuthorized: {}
+    })
+    const workflows = createRuntimeSelectionWorkflows({
+      settingsService,
+      runtimeRoot: () => '/data/runtime',
+      registry: fakeRegistry()
+    })
+
+    const enablement = await workflows.setInstallAuthorized({
+      language: 'python',
+      envId: '/user/python',
+      authorized: true
+    })
+
+    expect(enablement).toEqual({
+      enabled: { '/user/python': true },
+      installAuthorized: { '/user/python': true }
+    })
+  })
+
+  it('registers and unregisters a manual interpreter without duplicating its path', async () => {
+    const settingsService = fakeSettingsService()
+    const workflows = createRuntimeSelectionWorkflows({
+      settingsService,
+      runtimeRoot: () => '/data/runtime',
+      registry: fakeRegistry()
+    })
+    const request = { language: 'python' as const, path: '/manual/python3' }
+
+    await expect(workflows.register(request)).resolves.toEqual(['/manual/python3'])
+    await expect(workflows.register(request)).resolves.toEqual(['/manual/python3'])
+    await expect(workflows.unregister(request)).resolves.toEqual([])
+  })
+
+  it('persists a disabled runtime before revoking it and preserves that state on revoke failure', async () => {
+    const order: string[] = []
+    const settingsService = fakeSettingsService()
+    const persist = settingsService.setEnvironmentEnabled
+    settingsService.setEnvironmentEnabled = async (language, envId, enabled) => {
+      order.push('persist-disabled')
+      return persist(language, envId, enabled)
+    }
+    const failure = new Error('kernel drain failed')
+    const onRuntimeDisabled = vi.fn(async () => {
+      order.push('revoke')
+      throw failure
+    })
+    const workflows = createRuntimeSelectionWorkflows({
+      settingsService,
+      runtimeRoot: () => '/data/runtime',
+      registry: fakeRegistry(),
+      onRuntimeDisabled
+    })
+
+    await expect(
+      workflows.setEnvironmentEnabled({
+        language: 'python',
+        envId: '/managed/python',
+        enabled: false,
+        force: true
+      })
+    ).rejects.toBe(failure)
+
+    expect(order).toEqual(['persist-disabled', 'revoke'])
+    expect(settingsService.enablement.get('python')?.enabled['/managed/python']).toBe(false)
+    expect(onRuntimeDisabled).toHaveBeenCalledWith('python', '/managed/python', true)
+  })
+
+  it('does not revoke a runtime when enabling it', async () => {
+    const settingsService = fakeSettingsService()
+    const onRuntimeDisabled = vi.fn()
+    const workflows = createRuntimeSelectionWorkflows({
+      settingsService,
+      runtimeRoot: () => '/data/runtime',
+      registry: fakeRegistry(),
+      onRuntimeDisabled
+    })
+
+    const result = await workflows.setEnvironmentEnabled({
+      language: 'python',
+      envId: '/user/python',
+      enabled: true
+    })
+
+    expect(result.enabled['/user/python']).toBe(true)
+    expect(onRuntimeDisabled).not.toHaveBeenCalled()
+  })
+
+  it('discovers both languages from one manual-catalog and runtime-root snapshot', async () => {
+    const settingsService = fakeSettingsService()
+    settingsService.manual.set('python', ['/manual/python3'])
+    settingsService.manual.set('r', ['/manual/R'])
+    discoveryState.python = [
+      {
+        language: 'python',
+        provenance: 'user-own',
+        envId: '/manual/python3',
+        interpreterPath: '/manual/python3',
+        label: 'Manual Python',
+        runnable: true
+      }
+    ]
+    discoveryState.r = [
+      {
+        language: 'r',
+        provenance: 'user-own',
+        envId: '/manual/R',
+        interpreterPath: '/manual/R',
+        label: 'Manual R',
+        runnable: true
+      }
+    ]
+    const workflows = createRuntimeSelectionWorkflows({
+      settingsService,
+      runtimeRoot: () => '/data/runtime',
+      registry: fakeRegistry()
+    })
+
+    const environments = await workflows.listEnvironments()
+
+    expect(environments).toEqual({ python: discoveryState.python, r: discoveryState.r })
+    expect(discoveryState.snapshots.at(-1)).toEqual({
+      runtimeRoot: '/data/runtime',
+      python: ['/manual/python3'],
+      r: ['/manual/R']
+    })
+  })
+
+  it('surveys both languages and refreshes readiness for the selected external runtime', async () => {
+    const settingsService = fakeSettingsService()
+    const selection: RuntimeSelection = {
+      source: 'external',
+      interpreterPath: '/selected/python3',
+      appOwnedOverlay: false,
+      packageInstallAuthorized: false
+    }
+    settingsService.selections.set('python', selection)
+    const registry = fakeRegistry()
+    const workflows = createRuntimeSelectionWorkflows({
+      settingsService,
+      runtimeRoot: () => '/data/runtime',
+      registry
+    })
+
+    const surveys = await workflows.survey()
+
+    expect(surveys.map((survey) => survey.language)).toEqual(['python', 'r'])
+    expect(registry.readiness).toHaveBeenCalledWith('python', selection)
+    expect(surveys[0]?.external).toMatchObject({ source: 'external', selected: true })
+    expect(surveys[1]?.selection).toBeUndefined()
+  })
+
+  it('prepares an app-owned external runtime before persisting its selection', async () => {
+    const order: string[] = []
+    const settingsService = fakeSettingsService()
+    const persist = settingsService.setRuntimeSelection
+    settingsService.setRuntimeSelection = async (language, selection) => {
+      order.push('persist')
+      return persist(language, selection)
+    }
+    const prepareExternalPython = vi.fn(async () => void order.push('prepare'))
+    const workflows = createRuntimeSelectionWorkflows({
+      settingsService,
+      runtimeRoot: () => '/data/runtime',
+      registry: fakeRegistry(order),
+      prepareExternalPython
+    })
+    const selection: RuntimeSelection = {
+      source: 'external',
+      interpreterPath: '/usr/bin/python3',
+      appOwnedOverlay: true,
+      packageInstallAuthorized: true
+    }
+
+    const survey = await workflows.setSelection({ language: 'python', selection })
+
+    expect(order).toEqual(['readiness', 'prepare', 'persist', 'survey', 'readiness'])
+    expect(prepareExternalPython).toHaveBeenCalledWith(selection, '/data/runtime')
+    expect(settingsService.selections.get('python')).toBe(selection)
+    expect(survey.selection).toBe(selection)
+  })
+
+  it('does not persist an app-owned selection when overlay preparation fails', async () => {
+    const settingsService = fakeSettingsService()
+    const workflows = createRuntimeSelectionWorkflows({
+      settingsService,
+      runtimeRoot: () => '/data/runtime',
+      registry: fakeRegistry(),
+      prepareExternalPython: async () => {
+        throw new Error('matplotlib import failed')
+      }
+    })
+
+    await expect(
+      workflows.setSelection({
+        language: 'python',
+        selection: {
+          source: 'external',
+          interpreterPath: '/usr/bin/python3',
+          appOwnedOverlay: true,
+          packageInstallAuthorized: true
+        }
+      })
+    ).rejects.toThrow(/selection was not saved.*matplotlib import failed/)
+    expect(settingsService.selections.has('python')).toBe(false)
+  })
+
+  it('rejects an unusable external runtime without persisting it', async () => {
+    const settingsService = fakeSettingsService()
+    const registry = fakeRegistry()
+    vi.mocked(registry.readiness).mockResolvedValue(
+      runtimeReadiness('python', 'external', {
+        runnable: false,
+        detail: 'not a runnable Python 3'
+      })
+    )
+    const workflows = createRuntimeSelectionWorkflows({
+      settingsService,
+      runtimeRoot: () => '/data/runtime',
+      registry
+    })
+
+    await expect(
+      workflows.setSelection({
+        language: 'python',
+        selection: {
+          source: 'external',
+          interpreterPath: '/usr/bin/python2',
+          appOwnedOverlay: false,
+          packageInstallAuthorized: false
+        }
+      })
+    ).rejects.toThrow(/not a runnable Python 3/)
+    expect(settingsService.selections.has('python')).toBe(false)
+  })
+
+  it('rejects external R before probing or persisting it', async () => {
+    const settingsService = fakeSettingsService()
+    const registry = fakeRegistry()
+    const workflows = createRuntimeSelectionWorkflows({
+      settingsService,
+      runtimeRoot: () => '/data/runtime',
+      registry
+    })
+
+    await expect(
+      workflows.setSelection({
+        language: 'r',
+        selection: {
+          source: 'external',
+          interpreterPath: '/usr/bin/R',
+          appOwnedOverlay: false,
+          packageInstallAuthorized: false
+        }
+      })
+    ).rejects.toThrow('R only supports the app-managed runtime.')
+    expect(registry.readiness).not.toHaveBeenCalled()
+    expect(settingsService.selections.has('r')).toBe(false)
+  })
+
+  it('clears a persisted selection and returns its refreshed survey', async () => {
+    const settingsService = fakeSettingsService()
+    settingsService.selections.set('python', { source: 'managed' })
+    const workflows = createRuntimeSelectionWorkflows({
+      settingsService,
+      runtimeRoot: () => '/data/runtime',
+      registry: fakeRegistry()
+    })
+
+    const survey = await workflows.setSelection({ language: 'python', selection: null })
+
+    expect(settingsService.selections.has('python')).toBe(false)
+    expect(survey.selection).toBeUndefined()
+  })
+})

--- a/src/main/notebook/runtime-selection-workflows.ts
+++ b/src/main/notebook/runtime-selection-workflows.ts
@@ -1,0 +1,203 @@
+import type { NotebookLanguage } from '../../shared/notebook'
+import type {
+  RuntimeEnablement,
+  RuntimeSelection,
+  RuntimeSurvey,
+  RuntimeUsage
+} from '../../shared/notebook-runtime'
+import {
+  createExternalAdapter,
+  createManagedAdapter,
+  defaultExternalAdapterDeps
+} from './runtime-adapters'
+import {
+  defaultDiscoveryDeps,
+  discoverInterpreters,
+  type DiscoveredInterpreter
+} from './environment-discovery'
+import { RuntimeRegistry } from './runtime-registry'
+import { prepareExternalPythonRuntime, type AppOwnedExternalSelection } from './venv-overlay'
+
+type RuntimeRegistryPort = Pick<RuntimeRegistry, 'survey' | 'readiness'>
+
+// Settings presents languages in this order; keep survey results stable for existing callers.
+const RUNTIME_LANGUAGES: readonly NotebookLanguage[] = ['python', 'r']
+
+// Persisted runtime state remains Settings-owned. This narrow port keeps the workflows independent of
+// the broader Settings module while preserving its normalized read-after-write behavior.
+type RuntimeSelectionSettings = {
+  getRuntimeSelection(language: NotebookLanguage): Promise<RuntimeSelection | undefined>
+  setRuntimeSelection(
+    language: NotebookLanguage,
+    selection: RuntimeSelection | null
+  ): Promise<RuntimeSelection | undefined>
+  getRuntimeEnablement(language: NotebookLanguage): Promise<RuntimeEnablement>
+  setEnvironmentEnabled(
+    language: NotebookLanguage,
+    envId: string,
+    enabled: boolean
+  ): Promise<RuntimeEnablement>
+  setInstallAuthorized(
+    language: NotebookLanguage,
+    envId: string,
+    authorized: boolean
+  ): Promise<RuntimeEnablement>
+  getManualInterpreters(language: NotebookLanguage): Promise<string[]>
+  addManualInterpreter(language: NotebookLanguage, path: string): Promise<string[]>
+  removeManualInterpreter(language: NotebookLanguage, path: string): Promise<string[]>
+}
+
+type RuntimeSelectionWorkflowDeps = {
+  settingsService: RuntimeSelectionSettings
+  // Resolve lazily so a data-root switch reaches discovery and overlay preparation immediately.
+  runtimeRoot: () => string
+  // Production uses the managed/external registry; tests use the same two-operation seam.
+  registry?: RuntimeRegistryPort
+  // An app-owned overlay must be ready before its selection becomes durable.
+  prepareExternalPython?: (
+    selection: AppOwnedExternalSelection,
+    runtimeRoot: string
+  ) => Promise<void>
+  // Called only after disabled state is durable; force chooses stop-now instead of drain-and-close.
+  onRuntimeDisabled?: (language: NotebookLanguage, envId: string, force?: boolean) => Promise<void>
+  // Optional because sessions may not be composed yet during startup; absence means no live usage.
+  describeRuntimeUsage?: (language: NotebookLanguage, envId: string) => RuntimeUsage
+}
+
+type RuntimeSelectionWorkflows = {
+  survey(): Promise<RuntimeSurvey[]>
+  listEnvironments(): Promise<{
+    python: DiscoveredInterpreter[]
+    r: DiscoveredInterpreter[]
+  }>
+  getEnablement(request: { language: NotebookLanguage }): Promise<RuntimeEnablement>
+  describeUsage(request: { language: NotebookLanguage; envId: string }): Promise<RuntimeUsage>
+  setSelection(request: {
+    language: NotebookLanguage
+    selection: RuntimeSelection | null
+  }): Promise<RuntimeSurvey>
+  setEnvironmentEnabled(request: {
+    language: NotebookLanguage
+    envId: string
+    enabled: boolean
+    force?: boolean
+  }): Promise<RuntimeEnablement>
+  setInstallAuthorized(request: {
+    language: NotebookLanguage
+    envId: string
+    authorized: boolean
+  }): Promise<RuntimeEnablement>
+  register(request: { language: NotebookLanguage; path: string }): Promise<string[]>
+  unregister(request: { language: NotebookLanguage; path: string }): Promise<string[]>
+}
+
+const createRuntimeSelectionWorkflows = (
+  deps: RuntimeSelectionWorkflowDeps
+): RuntimeSelectionWorkflows => {
+  const registry =
+    deps.registry ??
+    new RuntimeRegistry({
+      managed: createManagedAdapter({ runtimeRoot: deps.runtimeRoot }),
+      external: createExternalAdapter(defaultExternalAdapterDeps())
+    })
+
+  // A selected external runtime must report readiness for its persisted path, not the unrelated PATH
+  // interpreter returned by the source-wide survey.
+  const buildSurvey = async (language: NotebookLanguage): Promise<RuntimeSurvey> => {
+    const [selection, surveyed] = await Promise.all([
+      deps.settingsService.getRuntimeSelection(language),
+      registry.survey(language)
+    ])
+    const external =
+      selection?.source === 'external'
+        ? await registry.readiness(language, selection)
+        : surveyed.external
+
+    return { language, selection, managed: surveyed.managed, external }
+  }
+
+  return {
+    survey: () => Promise.all(RUNTIME_LANGUAGES.map(buildSurvey)),
+    listEnvironments: async () => {
+      // Discovery expects a synchronous manual-path lookup, so snapshot both persisted catalogs first.
+      const [manualPython, manualR] = await Promise.all([
+        deps.settingsService.getManualInterpreters('python'),
+        deps.settingsService.getManualInterpreters('r')
+      ])
+      const discovery = defaultDiscoveryDeps(deps.runtimeRoot(), (language) =>
+        language === 'python' ? manualPython : manualR
+      )
+      const [python, r] = await Promise.all([
+        discoverInterpreters('python', discovery),
+        discoverInterpreters('r', discovery)
+      ])
+      return { python, r }
+    },
+    getEnablement: (request) => deps.settingsService.getRuntimeEnablement(request.language),
+    describeUsage: async (request) =>
+      deps.describeRuntimeUsage?.(request.language, request.envId) ?? {
+        running: 0,
+        idle: 0,
+        dormant: 0
+      },
+    setSelection: async (request): Promise<RuntimeSurvey> => {
+      // Validate the exact external interpreter before persistence. R stays managed-only, and managed
+      // selections remain runnable-by-provisioning without an eager interpreter probe.
+      if (request.selection?.source === 'external') {
+        if (request.language !== 'python') {
+          throw new Error('R only supports the app-managed runtime.')
+        }
+        const readiness = await registry.readiness(request.language, request.selection)
+        if (!readiness.runnable) {
+          throw new Error(
+            readiness.detail
+              ? `That interpreter can't be used as a notebook runtime: ${readiness.detail}`
+              : "That interpreter can't be used as a notebook runtime (not a runnable Python 3)."
+          )
+        }
+        if (request.selection.appOwnedOverlay) {
+          try {
+            // Overlay creation and its protocol probe are a precondition: failure leaves Settings
+            // unchanged, so later execution never observes a half-prepared runtime.
+            await (deps.prepareExternalPython ?? prepareExternalPythonRuntime)(
+              request.selection as AppOwnedExternalSelection,
+              deps.runtimeRoot()
+            )
+          } catch (error) {
+            throw new Error(
+              `Could not prepare an isolated notebook runtime, so the selection was not saved: ${error instanceof Error ? error.message : String(error)}`
+            )
+          }
+        }
+      }
+      await deps.settingsService.setRuntimeSelection(request.language, request.selection)
+      return buildSurvey(request.language)
+    },
+    setEnvironmentEnabled: async (request) => {
+      const next = await deps.settingsService.setEnvironmentEnabled(
+        request.language,
+        request.envId,
+        request.enabled
+      )
+      // Persist disable before revocation. A revoke failure is surfaced without rolling the setting
+      // back, preventing a failed drain from silently re-enabling the runtime for new work.
+      if (!request.enabled) {
+        await deps.onRuntimeDisabled?.(request.language, request.envId, request.force)
+      }
+      return next
+    },
+    setInstallAuthorized: (request) =>
+      deps.settingsService.setInstallAuthorized(
+        request.language,
+        request.envId,
+        request.authorized
+      ),
+    register: (request) =>
+      deps.settingsService.addManualInterpreter(request.language, request.path),
+    unregister: (request) =>
+      deps.settingsService.removeManualInterpreter(request.language, request.path)
+  }
+}
+
+export { createRuntimeSelectionWorkflows }
+export type { RuntimeSelectionWorkflowDeps, RuntimeSelectionWorkflows }


### PR DESCRIPTION
## Problem

Notebook runtime selection behavior still lived inside Electron IPC registration: discovery, external-runtime validation, overlay preparation, persistence ordering, enablement, disable/revoke sequencing, usage projection, installation authorization, and manual interpreter catalog mutation. This made transport code the implicit application interface and obscured which component owned failure semantics.

## Proposed change

Extract a transport-neutral `RuntimeSelectionWorkflows` module with nine application commands, then reduce `runtime-ipc.ts` to unchanged channel registration plus the one genuine Electron host adapter: the native interpreter picker.

```mermaid
flowchart LR
  E["Electron/local Web channels"] --> A["runtime-ipc adapter"]
  A --> W["RuntimeSelectionWorkflows: 9 commands"]
  A --> P["Electron native picker"]
  W --> S["Settings-owned persisted state"]
  W --> R["Runtime registry/discovery"]
  W --> O["Overlay preparation"]
  W --> V["Runtime revoke callback"]
```

The workflow owns:

- `survey`, `listEnvironments`, `setSelection`, `getEnablement`, and `describeUsage`;
- `setEnvironmentEnabled`, `setInstallAuthorized`, `register`, and `unregister`.

## Scope and non-goals

- Preserve the exact ten Electron/local Web channels: nine application commands plus `runtime:pick-interpreter`.
- Preserve Remote Web availability: four reads remain available; five mutations and the native picker remain denied.
- Preserve external Python validation and R managed-only rejection before persistence.
- Preserve `readiness -> prepare -> persist -> fresh survey -> selected-runtime readiness` ordering.
- Preserve disable persistence before revoke; revoke failure propagates without rolling back the durable disabled state.
- Preserve native picker cancel/error-to-null behavior and application error identity through IPC.
- Do not change `src/main/ipc.ts`, preload/Web/HTTP/CLI/shared contracts, wire schemas, persistence format, data relationships, UI, or capability availability.
- Specialist, Permission, and Compute asymmetry is unchanged.
- Issue #458 remains forward-compatible only; no orchestration state, method, event, or relationship is added.

## Commits and size

1. `refactor(notebook): extract runtime selection workflows`

Final diff: four Notebook files. Production churn is 427 changed lines; test churn is 945 changed lines because behavior coverage moved from the IPC harness to the workflow seam. The production diff is within the 425–505 preflight estimate and below the 520 re-review stop and 700 hard stop.

## Acceptance criteria and validation

Branch head `3274846` is based on `origin/main` `5cfd4d1`, ahead/behind `1/0`, with a clean worktree.

- Nine-command workflow and exact ten-channel/picker/error adapter behavior -> focused workflow + IPC tests -> 20/20 passed.
- Registry, runtime adapters, discovery, and overlay compatibility -> four focused files -> 49/49 passed.
- Latest preload/generated Web/remote HTTP surface, including Global Search's new map entry -> final 10-file affected/surface suite -> 140/140 passed on `5cfd4d1`.
- Node/Web compile compatibility -> `npm run typecheck` -> passed on the final head.
- Changed-file formatting/static policy -> Prettier plus ESLint `--max-warnings=0` -> passed with zero findings.
- Repository static policy -> `npm run lint` -> 0 errors; 18 warnings are unchanged baseline files.
- Repository regression suite -> `npm test` -> passed on the final head. The pre-rebase full run reported 685 files passed / 15 skipped and 10,024 tests passed / 184 skipped; after the non-overlapping Global Search rebase, the exact final suite again exited successfully.
- Patch integrity -> `git diff --check` -> passed.
- Independent final review -> Spec: 0 findings; Standards: 0 findings. The initial Spec P2/P3 test-evidence gaps were fixed before final review.

The branch rebased without production/test conflicts from `38be3a8` to `5cfd4d1`. The named pre-rebase stash remains as a temporary recoverable backup and is not part of the commit.

## Review focus

- Confirm application ordering has left IPC and the adapter only translates/forwards.
- Confirm the native picker remains transport-owned without a speculative one-implementation port.
- Confirm disable persists before revoke and revoke failure does not silently re-enable the runtime.
- Confirm no remote capability, public contract, persisted state, or UI changed.

## Residual risk

No live interpreter selection, packaged Electron picker, or manually paired remote-browser journey was run locally. Focused integration tests cover the workflow/adapter and surface contracts; exact-head CI remains the merge gate.
