### PR TITLE
refactor(notebook): extract environment operation foundation

### DIFF
--- a/src/main/notebook/env-ipc.ts
+++ b/src/main/notebook/env-ipc.ts
@@ -1,4 +1,3 @@
-import { randomUUID } from 'node:crypto'
 import { existsSync } from 'node:fs'
 
 import { BrowserWindow } from 'electron'
@@ -6,8 +5,12 @@ import { BrowserWindow } from 'electron'
 import { ipcMainHandle } from '../ipc-handler-registry'
 
 import type { NotebookLanguage } from '../../shared/notebook'
-import { createLogger, errorLogFields } from '../logger'
 import { withDataRootWrite } from '../storage/migration-state'
+import {
+  logStartupGateFailure,
+  runLoggedRuntimeOperation,
+  serializeProvisioner
+} from './environment-operation-foundation'
 import {
   planStartupAction,
   type ProvisionProgress,
@@ -21,199 +24,12 @@ import {
 // (out of this task's scope).
 import { DEFAULT_ENV_VERSION, DEFAULT_PY_ENV, envPrefix, readReadyMarker } from './runtime-paths'
 
-const log = createLogger('notebook-env')
-
-type LoggedRuntimeOperation = 'provision' | 'repair'
-
-type RuntimeLogContext = {
-  operation: LoggedRuntimeOperation
-  language: NotebookLanguage
-  root: string
-  operationId: string
-}
-
-const redactRuntimeLogText = (value: string): string =>
-  value
-    .replace(/https?:\/\/[^\s"'<>]+/gi, (rawUrl) => {
-      try {
-        const url = new URL(rawUrl)
-        url.username = ''
-        url.password = ''
-        url.pathname = url.pathname.replace(
-          /\/(t|token|auth|api[_-]?key|secret|password)\/[^/]+/gi,
-          '/$1/[redacted]'
-        )
-        for (const key of [...url.searchParams.keys()]) url.searchParams.set(key, '[redacted]')
-        url.hash = ''
-        return url.toString()
-      } catch {
-        return rawUrl
-      }
-    })
-    .replace(/\bBearer\s+[^\s"']+/gi, 'Bearer [redacted]')
-    .replace(/\b(api[_-]?key|token|secret|password)\b(\s*[:=]\s*)[^\s,"'&]+/gi, '$1$2[redacted]')
-    .replace(/\bsk-[A-Za-z0-9_-]{8,}\b/g, '[redacted]')
-
-const redactRuntimeLogValue = (value: unknown): unknown => {
-  if (typeof value === 'string') return redactRuntimeLogText(value)
-  if (Array.isArray(value)) return value.map(redactRuntimeLogValue)
-  if (value === null || typeof value !== 'object') return value
-  return Object.fromEntries(
-    Object.entries(value).map(([key, nested]) => [key, redactRuntimeLogValue(nested)])
-  )
-}
-
-const runtimeErrorLogFields = (error: unknown): Record<string, unknown> =>
-  redactRuntimeLogValue(errorLogFields(error)) as Record<string, unknown>
-
-const logRuntimeInfo = (message: string, fields: Record<string, unknown>): void => {
-  try {
-    log.info(message, redactRuntimeLogValue(fields) as Record<string, unknown>)
-  } catch {
-    // Diagnostics are best-effort and must not interrupt provisioning or progress delivery.
-  }
-}
-
-const logRuntimeFailure = (context: RuntimeLogContext, startedAt: number, error: unknown): void => {
-  try {
-    log.error('runtime operation failed', {
-      ...runtimeErrorLogFields(error),
-      ...context,
-      durationMs: Date.now() - startedAt
-    })
-  } catch {
-    // Diagnostics must never replace the provisioning error returned to the renderer.
-  }
-}
-
-const runLoggedRuntimeOperation = async (
-  operation: LoggedRuntimeOperation,
-  language: NotebookLanguage,
-  root: string,
-  run: (onProgress: (progress: ProvisionProgress) => void) => Promise<void>,
-  broadcast: (progress: ProvisionProgress) => void
-): Promise<void> => {
-  const context: RuntimeLogContext = { operation, language, root, operationId: randomUUID() }
-  const startedAt = Date.now()
-  let lastPhase: string | undefined
-  let lastReconnectAttempt: number | undefined
-  logRuntimeInfo('runtime operation started', context)
-
-  const onProgress = (progress: ProvisionProgress): void => {
-    broadcast(progress)
-    const reconnectAttempt =
-      progress.download?.phase === 'reconnecting' ? progress.download.attempt : undefined
-    const phaseChanged = progress.phase !== lastPhase
-    const reconnectChanged =
-      reconnectAttempt !== undefined && reconnectAttempt !== lastReconnectAttempt
-    lastPhase = progress.phase
-    if (reconnectAttempt !== undefined) lastReconnectAttempt = reconnectAttempt
-    if (!phaseChanged && !reconnectChanged) return
-
-    logRuntimeInfo('runtime operation progress', {
-      ...context,
-      phase: progress.phase,
-      message: progress.message,
-      progress: progress.progress,
-      ...(progress.download ? { download: progress.download } : {})
-    })
-  }
-
-  try {
-    await run(onProgress)
-    logRuntimeInfo('runtime operation completed', {
-      ...context,
-      durationMs: Date.now() - startedAt,
-      lastPhase
-    })
-  } catch (error) {
-    logRuntimeFailure(context, startedAt, error)
-    throw error
-  }
-}
-
 // A small delegating surface so IPC behavior tests run without Electron wiring.
 export type NotebookEnvHandlers = {
   status: () => Promise<ProvisionStatus>
   provision: (lang: NotebookLanguage, onProgress: (p: ProvisionProgress) => void) => Promise<void>
   repair: (lang: NotebookLanguage, onProgress: (p: ProvisionProgress) => void) => Promise<void>
   cancel: (language?: NotebookLanguage) => void
-}
-
-// The provisioner shares a single `provisioning` flag across python/R (A3 review carry-forward), so
-// two concurrent provision/upgrade/repair calls would race that flag. Wraps a RuntimeProvisioner so
-// every provisioning-affecting call is chained behind an in-flight promise: a call that arrives while
-// one is still running waits for it to settle (success or failure) before starting its own run,
-// instead of firing a conflicting run in parallel. `status` passes through unserialized (read-only).
-// Brands a serialized wrapper so serializeProvisioner is IDEMPOTENT. The provisioner is wrapped at
-// three sites (main/ipc.ts, registerNotebookEnvIpcHandlers, createNotebookEnvHandlers); without this,
-// each layer would own a SEPARATE queue + pending map, and a request queued at the OUTERMOST layer
-// would not yet exist in an inner layer's pending set — so cancel() routed inward would be dropped as
-// "idle" and never reach the provisioner. Collapsing to one wrapper gives one queue and one pending
-// map, so cancel(lang) sees the same in-flight state the provision was enqueued into.
-const SERIALIZED = Symbol('serializedProvisioner')
-
-export const serializeProvisioner = (provisioner: RuntimeProvisioner): RuntimeProvisioner => {
-  // Already serialized (wrapped by an outer call): return as-is so re-wrapping is a no-op and there is
-  // exactly one queue + one pending map for the whole chain.
-  if ((provisioner as { [SERIALIZED]?: true })[SERIALIZED]) return provisioner
-
-  let inFlight: Promise<void> = Promise.resolve()
-  // Per-language COUNT of in-flight provisions (running OR queued behind the chain). A count, not a Set:
-  // two same-language requests must both be tracked, or the first to settle would delete the language
-  // while the second is still pending and a later cancel would be wrongly dropped as idle. This is the
-  // only layer that sees the queue, so it's where "No-op when idle" lives: cancel(lang) forwards only
-  // when count>0. Incremented synchronously when a language provision is requested (before it queues),
-  // decremented when that run settles.
-  const pending = new Map<NotebookLanguage, number>()
-  const retain = (language: NotebookLanguage): void => {
-    pending.set(language, (pending.get(language) ?? 0) + 1)
-  }
-  const release = (language: NotebookLanguage): void => {
-    const next = (pending.get(language) ?? 0) - 1
-    if (next <= 0) pending.delete(language)
-    else pending.set(language, next)
-  }
-
-  const serialize = (run: () => Promise<void>): Promise<void> => {
-    const next = inFlight.then(run, run)
-    // Swallow rejections in the chain tracker itself (each caller still awaits `next` and sees the real
-    // error) so one failed run doesn't permanently poison the queue for later callers.
-    inFlight = next.catch(() => undefined)
-    return next
-  }
-
-  const serializeLanguage = (
-    language: NotebookLanguage,
-    run: () => Promise<void>
-  ): Promise<void> => {
-    retain(language)
-    return serialize(() => run().finally(() => release(language)))
-  }
-
-  const wrapped: RuntimeProvisioner = {
-    status: () => provisioner.status(),
-    provisionPython: (onProgress) =>
-      serializeLanguage('python', () => provisioner.provisionPython(onProgress)),
-    provisionR: (onProgress) => serializeLanguage('r', () => provisioner.provisionR(onProgress)),
-    upgradeIfNeeded: (onProgress) => serialize(() => provisioner.upgradeIfNeeded(onProgress)),
-    // repair runs per-LANGUAGE (serializeLanguage, not plain serialize) so it bumps the pending count
-    // and cancel(lang) — the Cancel button shown during a Reset — actually forwards instead of being
-    // dropped as idle. A Reset that can't be cancelled would be a locked, un-abortable state.
-    repair: (lang, onProgress, opts) =>
-      serializeLanguage(lang, () => provisioner.repair(lang, onProgress, opts)),
-    restoreRelocatedEnvs: (onProgress) =>
-      serialize(() => provisioner.restoreRelocatedEnvs(onProgress)),
-    // cancel is NOT serialized — it must interrupt the in-flight run immediately, not queue behind it.
-    // No-op when the language is idle (count 0); otherwise forward so the provisioner aborts a running
-    // run or arms a one-shot skip for a queued one. `undefined` (global cancel) always forwards.
-    cancel: (language) => {
-      if (language !== undefined && (pending.get(language) ?? 0) === 0) return
-      provisioner.cancel(language)
-    }
-  }
-  ;(wrapped as { [SERIALIZED]?: true })[SERIALIZED] = true
-  return wrapped
 }
 
 export const createNotebookEnvHandlers = (
@@ -317,11 +133,7 @@ export const runStartupGate = async (
     // This is the automatic (no per-op logging) path, so record the FULL diagnostics here — including
     // the structured micromamba tails on `error.data` — before broadcasting only the short UI message.
     // Otherwise a launch-time restore/upgrade/repair failure would leave nothing but a truncated excerpt.
-    try {
-      log.error('startup gate failed', runtimeErrorLogFields(error))
-    } catch {
-      // Diagnostics are best-effort and must never suppress the progress broadcast below.
-    }
+    logStartupGateFailure(error)
     broadcast({
       phase: 'error',
       message: `Environment preparation failed: ${(error as Error).message}`,
@@ -416,3 +228,6 @@ export const registerNotebookEnvIpcHandlers = (
   if (serialized)
     void runStartupGate(serialized, root, broadcastNotebookEnvProgress, waitForRecovery)
 }
+
+// Preserve the composition-root import until N7e owns construction at the application seam.
+export { serializeProvisioner }

--- a/src/main/notebook/environment-operation-foundation.test.ts
+++ b/src/main/notebook/environment-operation-foundation.test.ts
@@ -1,0 +1,150 @@
+import { describe, expect, it, vi } from 'vitest'
+
+const loggerSpies = vi.hoisted(() => ({ info: vi.fn(), error: vi.fn() }))
+vi.mock('../logger', async (importOriginal) => {
+  const actual = await importOriginal<typeof import('../logger')>()
+  return {
+    ...actual,
+    createLogger: () => ({
+      debug: vi.fn(),
+      info: loggerSpies.info,
+      warn: vi.fn(),
+      error: loggerSpies.error
+    })
+  }
+})
+
+import type { ProvisionProgress, RuntimeProvisioner } from './provisioner'
+import { runLoggedRuntimeOperation, serializeProvisioner } from './environment-operation-foundation'
+
+const fakeProvisioner = (over: Partial<RuntimeProvisioner> = {}): RuntimeProvisioner => ({
+  status: vi
+    .fn()
+    .mockReturnValue({ pythonReady: false, rReady: false, version: 0, provisioning: false }),
+  provisionPython: vi.fn().mockResolvedValue(undefined),
+  provisionR: vi.fn().mockResolvedValue(undefined),
+  upgradeIfNeeded: vi.fn().mockResolvedValue(undefined),
+  repair: vi.fn().mockResolvedValue(undefined),
+  restoreRelocatedEnvs: vi.fn().mockResolvedValue(undefined),
+  cancel: vi.fn(),
+  ...over
+})
+
+describe('serializeProvisioner', () => {
+  it('serializes mutations while keeping queued language cancellation immediate', async () => {
+    const started: string[] = []
+    let releasePython: (() => void) | undefined
+    const base = fakeProvisioner({
+      provisionPython: vi.fn().mockImplementation(
+        () =>
+          new Promise<void>((resolve) => {
+            started.push('python')
+            releasePython = resolve
+          })
+      ),
+      provisionR: vi.fn().mockImplementation(async () => {
+        started.push('r')
+      })
+    })
+    const provisioner = serializeProvisioner(base)
+
+    const python = provisioner.provisionPython(vi.fn())
+    const r = provisioner.provisionR(vi.fn())
+    await Promise.resolve()
+    await Promise.resolve()
+
+    expect(started).toEqual(['python'])
+    provisioner.cancel('r')
+    expect(base.cancel).toHaveBeenCalledWith('r')
+
+    releasePython?.()
+    await Promise.all([python, r])
+    expect(started).toEqual(['python', 'r'])
+  })
+
+  it('recovers the queue and pending count when a provisioner throws synchronously', async () => {
+    const failure = new Error('synchronous provision failure')
+    let attempts = 0
+    const base = fakeProvisioner({
+      provisionR: vi.fn().mockImplementation(() => {
+        attempts += 1
+        if (attempts === 1) throw failure
+        return Promise.resolve()
+      })
+    })
+    const provisioner = serializeProvisioner(base)
+
+    const failed = provisioner.provisionR(vi.fn())
+    const recovered = provisioner.provisionR(vi.fn())
+
+    await expect(failed).rejects.toBe(failure)
+    await expect(recovered).resolves.toBeUndefined()
+    expect(attempts).toBe(2)
+
+    provisioner.cancel('r')
+    expect(base.cancel).not.toHaveBeenCalled()
+  })
+})
+
+describe('runLoggedRuntimeOperation', () => {
+  it('projects every progress tick while redacting deduplicated diagnostics and preserving the error', async () => {
+    const channel = 'https://user:basic-secret@example.com/t/path-secret/conda?token=query-secret'
+    const failure = Object.assign(new Error(`micromamba timed out (${channel})`), {
+      code: 'MICROMAMBA_TIMEOUT',
+      data: { stderrTail: 'api_key=stderr-secret', stdoutTail: 'Bearer stdout-secret' }
+    })
+    const projected: ProvisionProgress[] = []
+
+    await expect(
+      runLoggedRuntimeOperation(
+        'provision',
+        'python',
+        '/runtime',
+        async (report) => {
+          report({ phase: 'fetch-python', message: `Retrying ${channel}`, progress: 0.1 })
+          report({ phase: 'fetch-python', message: 'Downloading 20%', progress: 0.2 })
+          report({
+            phase: 'fetch-python',
+            message: 'Reconnecting',
+            progress: 0.2,
+            download: {
+              phase: 'reconnecting',
+              transferred: 20,
+              total: 100,
+              percent: 20,
+              bytesPerSecond: 0,
+              attempt: 1
+            }
+          })
+          report({ phase: 'create-python', message: 'Creating Python', progress: 0.45 })
+          throw failure
+        },
+        (progress) => projected.push(progress)
+      )
+    ).rejects.toBe(failure)
+
+    expect(projected).toHaveLength(4)
+    expect(loggerSpies.info.mock.calls.map(([message]) => message)).toEqual([
+      'runtime operation started',
+      'runtime operation progress',
+      'runtime operation progress',
+      'runtime operation progress'
+    ])
+    expect(loggerSpies.error).toHaveBeenCalledOnce()
+    const persisted = JSON.stringify({
+      info: loggerSpies.info.mock.calls,
+      error: loggerSpies.error.mock.calls
+    })
+    for (const secret of [
+      'basic-secret',
+      'path-secret',
+      'query-secret',
+      'stderr-secret',
+      'stdout-secret'
+    ]) {
+      expect(persisted).not.toContain(secret)
+    }
+    expect(persisted).toContain('[redacted]')
+    expect(failure.message).toContain('basic-secret')
+  })
+})

--- a/src/main/notebook/environment-operation-foundation.ts
+++ b/src/main/notebook/environment-operation-foundation.ts
@@ -1,0 +1,183 @@
+import { randomUUID } from 'node:crypto'
+
+import type { NotebookLanguage } from '../../shared/notebook'
+import { createLogger, errorLogFields } from '../logger'
+import type { ProvisionProgress, RuntimeProvisioner } from './provisioner'
+
+type LoggedRuntimeOperation = 'provision' | 'repair'
+type RuntimeLogContext = {
+  operation: LoggedRuntimeOperation
+  language: NotebookLanguage
+  root: string
+  operationId: string
+}
+
+const log = createLogger('notebook-env')
+
+const redactRuntimeLogText = (value: string): string =>
+  value
+    .replace(/https?:\/\/[^\s"'<>]+/gi, (rawUrl) => {
+      try {
+        const url = new URL(rawUrl)
+        url.username = ''
+        url.password = ''
+        url.pathname = url.pathname.replace(
+          /\/(t|token|auth|api[_-]?key|secret|password)\/[^/]+/gi,
+          '/$1/[redacted]'
+        )
+        for (const key of [...url.searchParams.keys()]) url.searchParams.set(key, '[redacted]')
+        url.hash = ''
+        return url.toString()
+      } catch {
+        return rawUrl
+      }
+    })
+    .replace(/\bBearer\s+[^\s"']+/gi, 'Bearer [redacted]')
+    .replace(/\b(api[_-]?key|token|secret|password)\b(\s*[:=]\s*)[^\s,"'&]+/gi, '$1$2[redacted]')
+    .replace(/\bsk-[A-Za-z0-9_-]{8,}\b/g, '[redacted]')
+
+const redactRuntimeLogValue = (value: unknown): unknown => {
+  if (typeof value === 'string') return redactRuntimeLogText(value)
+  if (Array.isArray(value)) return value.map(redactRuntimeLogValue)
+  if (value === null || typeof value !== 'object') return value
+  return Object.fromEntries(
+    Object.entries(value).map(([key, nested]) => [key, redactRuntimeLogValue(nested)])
+  )
+}
+
+const runtimeErrorLogFields = (error: unknown): Record<string, unknown> =>
+  redactRuntimeLogValue(errorLogFields(error)) as Record<string, unknown>
+
+const logRuntimeInfo = (message: string, fields: Record<string, unknown>): void => {
+  try {
+    log.info(message, redactRuntimeLogValue(fields) as Record<string, unknown>)
+  } catch {
+    // Diagnostics are best-effort and never interrupt progress delivery.
+  }
+}
+
+const runLoggedRuntimeOperation = async (
+  operation: LoggedRuntimeOperation,
+  language: NotebookLanguage,
+  root: string,
+  run: (report: (progress: ProvisionProgress) => void) => Promise<void>,
+  projectProgress: (progress: ProvisionProgress) => void
+): Promise<void> => {
+  const context: RuntimeLogContext = { operation, language, root, operationId: randomUUID() }
+  const startedAt = Date.now()
+  let lastPhase: string | undefined
+  let lastReconnectAttempt: number | undefined
+  logRuntimeInfo('runtime operation started', context)
+
+  const report = (progress: ProvisionProgress): void => {
+    projectProgress(progress)
+    const reconnectAttempt =
+      progress.download?.phase === 'reconnecting' ? progress.download.attempt : undefined
+    const phaseChanged = progress.phase !== lastPhase
+    const reconnectChanged =
+      reconnectAttempt !== undefined && reconnectAttempt !== lastReconnectAttempt
+    lastPhase = progress.phase
+    if (reconnectAttempt !== undefined) lastReconnectAttempt = reconnectAttempt
+    if (!phaseChanged && !reconnectChanged) return
+
+    logRuntimeInfo('runtime operation progress', {
+      ...context,
+      phase: progress.phase,
+      message: progress.message,
+      progress: progress.progress,
+      ...(progress.download ? { download: progress.download } : {})
+    })
+  }
+
+  try {
+    await run(report)
+    logRuntimeInfo('runtime operation completed', {
+      ...context,
+      durationMs: Date.now() - startedAt,
+      lastPhase
+    })
+  } catch (error) {
+    try {
+      log.error('runtime operation failed', {
+        ...runtimeErrorLogFields(error),
+        ...context,
+        durationMs: Date.now() - startedAt
+      })
+    } catch {
+      // Diagnostics must never replace the original operation error.
+    }
+    throw error
+  }
+}
+
+const logStartupGateFailure = (error: unknown): void => {
+  try {
+    log.error('startup gate failed', runtimeErrorLogFields(error))
+  } catch {
+    // Diagnostics are best-effort and never suppress the startup progress projection.
+  }
+}
+
+const SERIALIZED = Symbol('serializedProvisioner')
+
+// RuntimeProvisioner has one shared provisioning flag for Python and R. This wrapper owns the single
+// mutation queue used by startup, renderer commands, and lazy default-environment materialization.
+const serializeProvisioner = (provisioner: RuntimeProvisioner): RuntimeProvisioner => {
+  if ((provisioner as { [SERIALIZED]?: true })[SERIALIZED]) return provisioner
+
+  let inFlight: Promise<void> = Promise.resolve()
+  // Counts include running and queued operations. A Set would release a language too early when two
+  // requests for the same language overlap.
+  const pending = new Map<NotebookLanguage, number>()
+  const retain = (language: NotebookLanguage): void => {
+    pending.set(language, (pending.get(language) ?? 0) + 1)
+  }
+  const release = (language: NotebookLanguage): void => {
+    const next = (pending.get(language) ?? 0) - 1
+    if (next <= 0) pending.delete(language)
+    else pending.set(language, next)
+  }
+
+  const serialize = (run: () => Promise<void>): Promise<void> => {
+    const next = inFlight.then(run, run)
+    // The caller still receives `next` and its original rejection. Only the internal chain tracker
+    // swallows it so a failed operation cannot poison every later request.
+    inFlight = next.catch(() => undefined)
+    return next
+  }
+  const serializeLanguage = (
+    language: NotebookLanguage,
+    run: () => Promise<void>
+  ): Promise<void> => {
+    retain(language)
+    return serialize(async () => {
+      try {
+        await run()
+      } finally {
+        release(language)
+      }
+    })
+  }
+
+  const wrapped: RuntimeProvisioner = {
+    status: () => provisioner.status(),
+    provisionPython: (onProgress) =>
+      serializeLanguage('python', () => provisioner.provisionPython(onProgress)),
+    provisionR: (onProgress) => serializeLanguage('r', () => provisioner.provisionR(onProgress)),
+    upgradeIfNeeded: (onProgress) => serialize(() => provisioner.upgradeIfNeeded(onProgress)),
+    repair: (language, onProgress, options) =>
+      serializeLanguage(language, () => provisioner.repair(language, onProgress, options)),
+    restoreRelocatedEnvs: (onProgress) =>
+      serialize(() => provisioner.restoreRelocatedEnvs(onProgress)),
+    // Cancellation must interrupt immediately rather than wait behind the operation it is aborting.
+    // A language-specific idle cancel remains a no-op so it cannot arm an unrelated future operation.
+    cancel: (language) => {
+      if (language !== undefined && (pending.get(language) ?? 0) === 0) return
+      provisioner.cancel(language)
+    }
+  }
+  ;(wrapped as { [SERIALIZED]?: true })[SERIALIZED] = true
+  return wrapped
+}
+
+export { logStartupGateFailure, runLoggedRuntimeOperation, serializeProvisioner }


### PR DESCRIPTION
## Problem

Notebook environment provisioning used one critical operation queue and diagnostic pipeline embedded in `env-ipc.ts`. The queue is shared by startup, renderer commands, and lazy environment materialization, but its idempotent wrapping, per-language pending counts, cancellation, failure recovery, redaction, and progress-log behavior had no narrow owner.

The original combined N7c extraction measured 707 production changed lines and crossed the 700 hard stop. N7c1 therefore extracts only the operation foundation; lifecycle handlers and Electron projection remain for N7c2.

## Proposed change

Introduce `environment-operation-foundation.ts` and make `env-ipc.ts` delegate only operation serialization and diagnostics to it.

```mermaid
flowchart LR
  C["startup / UI / lazy materialization"] --> Q["Idempotent operation queue"]
  Q --> P["RuntimeProvisioner"]
  Q --> N["Per-language pending counts"]
  N --> X["Immediate cancel / idle no-op"]
  P --> D["Redacted operation diagnostics"]
  D --> E["Original result or Error"]
```

The foundation owns:

- one serialized mutation chain and idempotent provisioner branding;
- per-language pending counts and immediate language/global cancellation;
- recovery of the queue after rejection;
- operation IDs, durations, phase/reconnect deduplication, redaction, and best-effort logging;
- original result/Error identity.

Review also exposed and this PR fixes one internal failure-recovery defect: if a provisioner synchronously threw before returning its Promise, the previous `run().finally(...)` never installed cleanup and leaked the pending count. Async `try/finally` now releases it while preserving the same Error and allowing queued work to continue.

## Scope and non-goals

- Keep `createNotebookEnvHandlers`, recovery/write leases, startup planning, unavailable fallback, BrowserWindow progress, and all four channels in `env-ipc.ts`.
- Keep `notebook-env:progress` Electron-only; do not publish it through ApplicationEventHub.
- Preserve Electron/local Web methods and remote Web status/read versus provision/repair/cancel denial.
- Do not change main composition, preload/Web/HTTP, CLI/local RPC, renderer, persisted data, relationships, or UI.
- Specialist, Permission, Compute, and issue #458 behavior remain unchanged.

## Commits and size

1. `refactor(notebook): extract environment operation foundation`

Final diff: three Notebook files; 386 production changed lines and 150 test lines. This is within the 360–420 target and below the 700 hard stop.

## Acceptance criteria and validation

Branch head `0aa4890` is based on `origin/main` `0ad1928`, ahead/behind `1/0`, with a clean worktree.

- Queue/idempotence/pending counts/cancel/failure recovery and diagnostic behavior -> focused foundation/env/provisioner/runtime suites -> 8 files / 329 tests passed on the final base.
- Synchronous throw cleanup -> regression test -> RED reproduced pending leakage, then GREEN verified original Error identity, queued successor success, two attempts, pending release, and idle cancel no-op.
- Node/Web compile compatibility -> `npm run typecheck` -> passed after rebase.
- Changed-file static policy and patch integrity -> ESLint `--max-warnings=0` plus `git diff --check` -> passed.
- Latest Global Search shortcut base delta -> renderer shortcut/global-search smoke -> 4 files / 92 tests passed.
- Repository lint and full regression -> `npm run lint` and `npm test` -> passed before the non-overlapping renderer-only `0ad1928` rebase; exact affected/typecheck/renderer-delta suites then passed after rebase.
- Independent final review -> Spec: 0 findings; Standards: 0 findings. The initial two Spec P2 findings were closed before final review.

The named pre-rebase stash remains only as a temporary recoverable backup and is not part of this commit.

## Review focus

- Confirm N7c1 owns only operation foundation concerns and leaves lifecycle/transport behavior in `env-ipc.ts`.
- Confirm repeated `serializeProvisioner` calls share one queue and pending map.
- Confirm synchronous and asynchronous failures preserve their Error while never poisoning the queue or leaking pending state.
- Confirm diagnostic failures/redaction cannot alter progress or operation results.

## Residual risk

No live micromamba cancellation or packaged Electron environment journey was run locally. Focused suites exercise the real queue/provisioner interfaces in-process; exact-head CI remains the merge gate.
