### PR TITLE
fix(compute): restore hover submenu and align its chevron with siblings

### DIFF
--- a/src/renderer/src/pages/workspace/ComposerAgentControlsMenu.interaction.test.tsx
+++ b/src/renderer/src/pages/workspace/ComposerAgentControlsMenu.interaction.test.tsx
@@ -36,11 +36,13 @@ vi.mock('@/components/ui/dropdown-menu', () => ({
     <div data-testid="dropdown-group">{children}</div>
   ),
   DropdownMenuSub: ({ children }: PropsWithChildren): React.JSX.Element => <div>{children}</div>,
+  // testids let tests tell a hover submenu trigger/content apart from an inline label/group,
+  // so a regression that flattens a submenu into the primary panel is caught.
   DropdownMenuSubTrigger: ({ children }: PropsWithChildren): React.JSX.Element => (
-    <div>{children}</div>
+    <div data-testid="submenu-trigger">{children}</div>
   ),
   DropdownMenuSubContent: ({ children }: PropsWithChildren): React.JSX.Element => (
-    <div>{children}</div>
+    <div data-testid="submenu-content">{children}</div>
   ),
   DropdownMenuItem: ({
     children,
@@ -755,6 +757,60 @@ describe('ComposerAgentControlsMenu', () => {
     // SSH hosts + Manage compute stay nested under that single Compute submenu.
     expect(container.textContent).toContain('SSH')
     expect(container.textContent).toContain('Manage compute...')
+  })
+
+  it('folds Compute into a hover submenu that holds the SSH hosts and Manage compute', () => {
+    // Regression guard (#545 flattened Compute into the primary panel): Compute must be a
+    // single hover-expandable row whose content holds the host list, and the top-level order
+    // stays permission mode -> auto-review -> specialist -> compute.
+    act(() => {
+      root.render(
+        <ComposerAgentControlsMenu
+          profile="ask"
+          autoReviewEnabled={false}
+          enabledComputeHosts={[]}
+          showSpecialist
+          onProfileChange={vi.fn()}
+          onAutoReviewChange={vi.fn()}
+          onComputeHostToggle={vi.fn()}
+        />
+      )
+    })
+
+    // The Compute row is a hover submenu trigger, never a static label in the primary panel.
+    const computeTriggers = Array.from(
+      container.querySelectorAll('[data-testid="submenu-trigger"]')
+    ).filter((el) => el.textContent?.includes('Compute'))
+    expect(computeTriggers).toHaveLength(1)
+
+    // SSH hosts and Manage compute live inside that submenu's content, reached on hover.
+    const computeSubContents = Array.from(
+      container.querySelectorAll('[data-testid="submenu-content"]')
+    ).filter((el) => el.textContent?.includes('cluster-1'))
+    expect(computeSubContents).toHaveLength(1)
+    expect(computeSubContents[0]?.textContent).toContain('Manage compute...')
+
+    // Top-level order: permission mode -> auto-review -> specialist -> compute.
+    const orderAnchor = (needle: string): Element => {
+      const match = Array.from(container.querySelectorAll('[data-testid="submenu-trigger"]')).find(
+        (el) => el.textContent?.includes(needle)
+      )
+      if (!match) throw new Error(`submenu trigger not found: ${needle}`)
+      return match
+    }
+    const permissionTrigger = orderAnchor('Permission mode')
+    const computeTrigger = computeTriggers[0] as Element
+    const autoReviewRow = findButton(
+      'Auto-reviewA reviewer agent checks every change before it lands.'
+    )
+    const specialistStub = container.querySelector('[data-testid="specialist-submenu-stub"]')
+    expect(specialistStub).not.toBeNull()
+
+    const precedes = (a: Element, b: Element): boolean =>
+      (a.compareDocumentPosition(b) & Node.DOCUMENT_POSITION_FOLLOWING) !== 0
+    expect(precedes(permissionTrigger, autoReviewRow)).toBe(true)
+    expect(precedes(autoReviewRow, specialistStub as Element)).toBe(true)
+    expect(precedes(specialistStub as Element, computeTrigger)).toBe(true)
   })
 
   it('does not render the specialist submenu when showSpecialist is false', () => {

--- a/src/renderer/src/pages/workspace/ComposerAgentControlsMenu.tsx
+++ b/src/renderer/src/pages/workspace/ComposerAgentControlsMenu.tsx
@@ -442,6 +442,9 @@ const ComposerAgentControlsMenu = ({
                 </div>
               ) : null}
 
+              {/* Specialist + Compute are one resource-selection group: a single divider leads
+                  the group (above Specialist when present, above Compute otherwise), so the two
+                  hover submenus stay adjacent with nothing between them. */}
               {showSpecialist ? (
                 <>
                   <DropdownMenuSeparator />
@@ -452,74 +455,96 @@ const ComposerAgentControlsMenu = ({
                     readOnly={specialistReadOnly || readOnly}
                   />
                 </>
-              ) : null}
-
-              {/* Keep compute controls visible in the viewport-safe primary panel. */}
-              <DropdownMenuSeparator />
-              <DropdownMenuLabel className="flex items-center gap-2 px-2 py-1.5">
-                <Server
-                  className="size-4 shrink-0 text-text-200"
-                  strokeWidth={2}
-                  aria-hidden="true"
-                />
-                <span className="min-w-0 flex-1">
-                  <span className="block text-[13px] font-medium leading-5">Compute</span>
-                  <span className="block text-[11px] leading-4 text-text-300">
-                    Run jobs on a remote SSH host, or manage hosts.
-                  </span>
-                </span>
-              </DropdownMenuLabel>
-              {sshHosts.length > 0 ? (
-                <>
-                  <DropdownMenuLabel className="text-[10.5px] font-normal uppercase tracking-wide text-text-300">
-                    SSH
-                  </DropdownMenuLabel>
-                  <DropdownMenuGroup>
-                    {sshHosts.map((host) => {
-                      const isEnabled = enabledComputeHosts?.includes(host.providerId) ?? false
-                      return (
-                        <DropdownMenuItem
-                          key={host.providerId}
-                          disabled={readOnly}
-                          onSelect={(event) => {
-                            event.preventDefault()
-                            handleHostToggle(host.providerId, isEnabled)
-                          }}
-                          className="items-center gap-2 px-2 py-1.5"
-                        >
-                          <span
-                            className={cn(
-                              'min-w-0 flex-1 truncate text-[13px] leading-5',
-                              isEnabled ? 'font-medium text-text-100' : 'font-normal text-text-200'
-                            )}
-                          >
-                            {host.displayName}
-                          </span>
-                          <Switch
-                            size="sm"
-                            checked={isEnabled}
-                            aria-hidden="true"
-                            tabIndex={-1}
-                            className="pointer-events-none"
-                          />
-                        </DropdownMenuItem>
-                      )
-                    })}
-                  </DropdownMenuGroup>
-                </>
               ) : (
-                <DropdownMenuItem disabled className="px-2 py-1.5 text-[13px] text-text-300">
-                  {isLoaded ? 'No SSH hosts registered' : 'Loading…'}
-                </DropdownMenuItem>
+                <DropdownMenuSeparator />
               )}
-              <DropdownMenuSeparator />
-              <DropdownMenuItem
-                onSelect={() => openSettingsToCompute()}
-                className="items-center gap-2 px-2 py-1.5 text-[13px] text-text-200"
-              >
-                <Settings className="size-4 shrink-0" aria-hidden="true" />
-                Manage compute...
-              </DropdownMenuItem>
+
+              <DropdownMenuSub>
+                <DropdownMenuSubTrigger className="items-center gap-2 px-2 py-1.5">
+                  <Server
+                    className="size-4 shrink-0 text-text-200"
+                    strokeWidth={2}
+                    aria-hidden="true"
+                  />
+                  <span className="min-w-0 flex-1">
+                    <span className="block text-[13px] font-medium leading-5">Compute</span>
+                    <span className="block text-[11px] leading-4 text-text-300">
+                      Run jobs on a remote SSH host, or manage hosts.
+                    </span>
+                  </span>
+                  {/* Align the chevron with the capsule chevrons on the Permission/Specialist
+                      rows: same px-2 (one vertical line) and text-text-100 (depth) as the
+                      capsule chevrons — Compute has no capsule, so the color is set here. */}
+                  <span className="flex shrink-0 items-center px-2 py-0.5 text-text-100">
+                    <ChevronRight
+                      className="size-3 shrink-0 opacity-60"
+                      strokeWidth={2}
+                      aria-hidden="true"
+                    />
+                  </span>
+                </DropdownMenuSubTrigger>
+                <DropdownMenuSubContent
+                  collisionPadding={8}
+                  className="max-h-[calc(100dvh-1rem)] w-72 max-w-[calc(100vw-1rem)] overflow-y-auto p-1"
+                >
+                  {/* SSH hosts are single-select; Manage compute opens the settings panel. */}
+                  {sshHosts.length > 0 ? (
+                    <>
+                      <DropdownMenuLabel className="text-[10.5px] font-normal uppercase tracking-wide text-text-300">
+                        SSH
+                      </DropdownMenuLabel>
+                      <DropdownMenuGroup>
+                        {sshHosts.map((host) => {
+                          const isEnabled = enabledComputeHosts?.includes(host.providerId) ?? false
+                          return (
+                            <DropdownMenuItem
+                              key={host.providerId}
+                              disabled={readOnly}
+                              onSelect={(event) => {
+                                event.preventDefault()
+                                handleHostToggle(host.providerId, isEnabled)
+                              }}
+                              className="items-center gap-2 px-2 py-1.5"
+                            >
+                              <span
+                                className={cn(
+                                  'min-w-0 flex-1 truncate text-[13px] leading-5',
+                                  isEnabled
+                                    ? 'font-medium text-text-100'
+                                    : 'font-normal text-text-200'
+                                )}
+                              >
+                                {host.displayName}
+                              </span>
+                              {/* pointer-events-none: the Switch is a visual indicator only;
+                                  the row's onSelect is the single toggle entry point. */}
+                              <Switch
+                                size="sm"
+                                checked={isEnabled}
+                                aria-hidden="true"
+                                tabIndex={-1}
+                                className="pointer-events-none"
+                              />
+                            </DropdownMenuItem>
+                          )
+                        })}
+                      </DropdownMenuGroup>
+                    </>
+                  ) : (
+                    <DropdownMenuItem disabled className="px-2 py-1.5 text-[13px] text-text-300">
+                      {isLoaded ? 'No SSH hosts registered' : 'Loading…'}
+                    </DropdownMenuItem>
+                  )}
+                  <DropdownMenuSeparator />
+                  <DropdownMenuItem
+                    onSelect={() => openSettingsToCompute()}
+                    className="items-center gap-2 px-2 py-1.5 text-[13px] text-text-200"
+                  >
+                    <Settings className="size-4 shrink-0" aria-hidden="true" />
+                    Manage compute...
+                  </DropdownMenuItem>
+                </DropdownMenuSubContent>
+              </DropdownMenuSub>
             </>
           )}
         </DropdownMenuContent>

--- a/src/renderer/src/pages/workspace/SpecialistSubmenu.tsx
+++ b/src/renderer/src/pages/workspace/SpecialistSubmenu.tsx
@@ -116,9 +116,7 @@ const SpecialistSubmenu = ({
             'flex shrink-0 items-center gap-1 whitespace-nowrap rounded-full px-2 py-0.5 text-[11px] font-medium leading-4',
             unavailable
               ? 'bg-amber-500/10 text-amber-600 dark:text-amber-400'
-              : showValue
-                ? 'bg-bg-200 text-text-100'
-                : 'text-text-300'
+              : 'bg-bg-200 text-text-100'
           )}
         >
           <span className="max-w-[120px] truncate">{label}</span>


### PR DESCRIPTION
## Problem

PR #530 designed the composer's agent-controls menu so Specialist and Compute are hover-expanded submenus, ordered permission mode → auto-review → specialist → compute. PR #545 (mobile remote access) flattened the Compute section into a static label plus an inline SSH host list in the primary panel, and added a separator between Specialist and Compute that #530 never had — so the menu no longer matched the intended layout. The Compute expand chevron also drifted from its siblings: `size-4` (they use `size-3`), sat bare at the row end while theirs live inside a `px-2` capsule (so ~8px further right, not on one vertical line), and inherited the menu's darker `popover-foreground`.

## Proposed change

- Restore Compute as a `DropdownMenuSub` (hover submenu); the SSH host list and "Manage compute…" expand from the Compute row. Top-level order stays permission mode → auto-review → specialist → compute, with no divider between Specialist and Compute.
- Align the Compute expand chevron with Permission/Specialist: `size-3`, wrapped in the same `px-2 py-0.5` padding (one vertical line), and `text-text-100` (matching depth).
- Specialist "None" capsule: `text-text-300` → `bg-bg-200 text-text-100` (same as a selected value), so every submenu's `›` reads alike.

## Scope and non-goals

- **In scope**: Compute submenu structure/order, chevron size/position/color, Specialist None capsule color.
- **Non-goals**: no schema changes; no change to compute host selection or specialist binding logic; mobile-specific menu interactions unchanged.

## Acceptance criteria and validation

| behavior | command | result |
| --- | --- | --- |
| Compute renders as a hover submenu (not an inline label) | `vitest` `.../ComposerAgentControlsMenu.interaction.test.tsx` | 26 passed |
| Renderer types | `npm run typecheck:web` | pass |
| Lint | `npm run lint` (changed files) | 0 errors / 0 warnings |
| Full unit suite | `npm run test` | 10009 passed / 0 failed |

Notes:
- Pixel-level alignment (chevron size/position/color) is visual and not covered by jsdom unit tests; verified via an HTML prototype during development. Recommend a visual once-over or `npm run test:e2e:visual`.
- In the worktree the 6 preview/pdf test files can intermittently fail on a missing-`node_modules` vite `fs.allow` artifact; confirmed 122/122 green on the main-repo baseline (not a regression).

## Review focus

- The Compute chevron wrapper (`px-2 py-0.5`, no background) mirrors only the capsule's padding, not its background — Compute keeps no pill, by design.
- Specialist "None" capsule now always shows the selected-value style (`bg-bg-200` + `text-text-100`); confirm that's the intended look vs. the previous dimmed None.

Refs: #530, #545.
