### PR TITLE
refactor(notebook): extract environment lifecycle workflows

### DIFF
--- a/src/main/notebook/env-ipc.test.ts
+++ b/src/main/notebook/env-ipc.test.ts
@@ -1,16 +1,11 @@
-import { existsSync, mkdtempSync, mkdirSync, writeFileSync } from 'node:fs'
-import { tmpdir } from 'node:os'
-import { join } from 'node:path'
+import { beforeEach, describe, expect, it, vi } from 'vitest'
 
-import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest'
+import type { ProvisionProgress, RuntimeProvisioner } from './provisioner'
 
-// Capture ipcMain.handle registrations so registerNotebookEnvIpcHandlers can be exercised headless.
 const registered = new Map<string, (event: unknown, ...args: unknown[]) => unknown>()
-const sentProgress: ProvisionProgress[] = []
-const loggerSpies = vi.hoisted(() => ({
-  info: vi.fn(),
-  error: vi.fn()
-}))
+const sent: Array<{ channel: string; progress: ProvisionProgress }> = []
+const destroyedSend = vi.fn()
+
 vi.mock('electron', () => ({
   ipcMain: { handle: (channel: string, handler: never) => registered.set(channel, handler) },
   BrowserWindow: {
@@ -18,35 +13,18 @@ vi.mock('electron', () => ({
       {
         isDestroyed: () => false,
         webContents: {
-          send: (_channel: string, progress: ProvisionProgress) => sentProgress.push(progress)
+          send: (channel: string, progress: ProvisionProgress) => sent.push({ channel, progress })
         }
+      },
+      {
+        isDestroyed: () => true,
+        webContents: { send: destroyedSend }
       }
     ]
   }
 }))
-vi.mock('../logger', async (importOriginal) => {
-  const actual = await importOriginal<typeof import('../logger')>()
-  return {
-    ...actual,
-    createLogger: () => ({
-      debug: vi.fn(),
-      info: loggerSpies.info,
-      warn: vi.fn(),
-      error: loggerSpies.error
-    })
-  }
-})
 
-import type { ProvisionProgress, RuntimeProvisioner } from './provisioner'
-import {
-  createNotebookEnvHandlers,
-  registerNotebookEnvIpcHandlers,
-  runStartupGate,
-  serializeProvisioner
-} from './env-ipc'
-import { beginMigration, clearMigrationPending } from '../storage/migration-state'
-
-afterEach(() => clearMigrationPending())
+import { registerNotebookEnvIpcHandlers } from './env-ipc'
 
 const fakeProvisioner = (over: Partial<RuntimeProvisioner> = {}): RuntimeProvisioner => ({
   status: vi
@@ -61,660 +39,77 @@ const fakeProvisioner = (over: Partial<RuntimeProvisioner> = {}): RuntimeProvisi
   ...over
 })
 
-describe('createNotebookEnvHandlers', () => {
-  it('status returns the provisioner status', async () => {
-    const provisioner = fakeProvisioner()
-    const handlers = createNotebookEnvHandlers(provisioner)
-    expect(await handlers.status()).toEqual({
-      pythonReady: false,
-      rReady: false,
-      version: 0,
-      provisioning: false
-    })
-    expect(provisioner.status).toHaveBeenCalledOnce()
-  })
-
-  it('provision dispatches python vs R by language and forwards progress', async () => {
-    const provisioner = fakeProvisioner({
-      provisionPython: vi.fn().mockImplementation(async (cb: (p: ProvisionProgress) => void) => {
-        cb({ phase: 'done', message: 'ok', progress: 1 })
-      })
-    })
-    const emitted: ProvisionProgress[] = []
-    const handlers = createNotebookEnvHandlers(provisioner)
-    await handlers.provision('python', (p) => emitted.push(p))
-    expect(provisioner.provisionPython).toHaveBeenCalledOnce()
-    expect(emitted).toEqual([{ phase: 'done', message: 'ok', progress: 1 }])
-    await handlers.provision('r', () => {})
-    expect(provisioner.provisionR).toHaveBeenCalledOnce()
-  })
-
-  it('repair delegates by language as an explicit force-recovery', async () => {
-    const provisioner = fakeProvisioner()
-    const handlers = createNotebookEnvHandlers(provisioner)
-    await handlers.repair('r', () => {})
-    // UI repair is the user's Reset: it force-clears the quarantine (force: true).
-    expect(provisioner.repair).toHaveBeenCalledWith('r', expect.any(Function), { force: true })
-  })
-
-  it('publishes a successful verified repair back to the runtime service', async () => {
-    const provisioner = fakeProvisioner()
-    const onRepairCompleted = vi.fn().mockResolvedValue(undefined)
-    const handlers = createNotebookEnvHandlers(provisioner, undefined, undefined, onRepairCompleted)
-
-    await handlers.repair('r', () => {})
-
-    expect(onRepairCompleted).toHaveBeenCalledOnce()
-    expect(onRepairCompleted).toHaveBeenCalledWith('r')
-  })
-
-  it('does not release runtime-service quarantine when the rebuild fails', async () => {
-    const provisioner = fakeProvisioner({
-      repair: vi.fn().mockRejectedValue(new Error('verification failed'))
-    })
-    const onRepairCompleted = vi.fn().mockResolvedValue(undefined)
-    const handlers = createNotebookEnvHandlers(provisioner, undefined, undefined, onRepairCompleted)
-
-    await expect(handlers.repair('r', () => {})).rejects.toThrow('verification failed')
-    expect(onRepairCompleted).not.toHaveBeenCalled()
-  })
-
-  it('blocks new Environment mutations while a data-root migration is pending', async () => {
-    const provisioner = fakeProvisioner()
-    const handlers = createNotebookEnvHandlers(provisioner)
-    beginMigration()
-
-    await expect(handlers.provision('python', () => {})).rejects.toThrow(/moving your data/i)
-    await expect(handlers.repair('r', () => {})).rejects.toThrow(/moving your data/i)
-    expect(provisioner.provisionPython).not.toHaveBeenCalled()
-    expect(provisioner.repair).not.toHaveBeenCalled()
-  })
-
-  it('cancel forwards the language to the provisioner while that language is provisioning', () => {
-    const provisioner = fakeProvisioner({
-      // Keep R provisioning in flight so its language is pending when we cancel.
-      provisionR: vi.fn().mockReturnValue(new Promise<void>(() => {}))
-    })
-    const handlers = createNotebookEnvHandlers(provisioner)
-    void handlers.provision('r', () => {})
-    handlers.cancel('r')
-    expect(provisioner.cancel).toHaveBeenCalledWith('r')
-  })
-
-  it('cancel forwards the language to the provisioner while a Reset (repair) is in flight', () => {
-    // A Reset runs through repair; it must bump the per-language pending count (serializeLanguage), or
-    // the Cancel button shown during a Reset would be dropped as idle and the Reset be un-abortable.
-    const provisioner = fakeProvisioner({
-      repair: vi.fn().mockReturnValue(new Promise<void>(() => {})) // keep the Reset in flight
-    })
-    const handlers = createNotebookEnvHandlers(provisioner)
-    void handlers.repair('python', () => {})
-    handlers.cancel('python')
-    expect(provisioner.cancel).toHaveBeenCalledWith('python')
-  })
-
-  it('cancel is a NO-OP when the language is idle (does not arm the next unrelated provision)', () => {
-    const provisioner = fakeProvisioner()
-    const handlers = createNotebookEnvHandlers(provisioner)
-    handlers.cancel('r') // nothing provisioning -> must not reach the provisioner
-    expect(provisioner.cancel).not.toHaveBeenCalled()
-  })
-
-  it('idempotent: the production triple-wrap still forwards a queued cancel to the base provisioner', () => {
-    // In production the provisioner is wrapped 3x (main/ipc.ts, registerNotebookEnvIpcHandlers,
-    // createNotebookEnvHandlers). If each wrap owned its own queue+pending, a request queued at the
-    // OUTER layer wouldn't exist in an inner layer's pending, so cancel routed inward would be dropped
-    // as idle. Idempotent serialization collapses them to ONE queue, so a queued cancel reaches base.
-    let releasePython!: () => void
-    const base = fakeProvisioner({
-      provisionPython: vi.fn().mockReturnValue(
-        new Promise<void>((resolve) => {
-          releasePython = resolve
-        })
-      )
-    })
-    const wrapped = serializeProvisioner(serializeProvisioner(serializeProvisioner(base)))
-
-    void wrapped.provisionPython(() => {}) // running
-    void wrapped.provisionR(() => {}) // queued behind python (same single queue)
-    wrapped.cancel('r') // must reach base despite the triple wrap
-
-    expect(base.cancel).toHaveBeenCalledWith('r')
-    releasePython()
-  })
-
-  it('idempotent: re-wrapping an already-serialized provisioner returns the same instance', () => {
-    const once = serializeProvisioner(fakeProvisioner())
-    expect(serializeProvisioner(once)).toBe(once)
-  })
-
-  it('counts multiple pending requests for one language (cancel stays live until the last settles)', async () => {
-    // Two same-language requests must both be tracked; if the first to settle deleted the language, a
-    // cancel while the second is still in flight would be wrongly dropped as idle.
-    let releaseFirst!: () => void
-    let firstStarted = false
-    const base = fakeProvisioner({
-      provisionR: vi
-        .fn()
-        .mockImplementationOnce(
-          () =>
-            new Promise<void>((resolve) => {
-              firstStarted = true
-              releaseFirst = resolve
-            })
-        )
-        .mockImplementation(() => new Promise<void>(() => {})) // second stays pending
-    })
-    const wrapped = serializeProvisioner(base)
-
-    const first = wrapped.provisionR(() => {}) // running
-    void wrapped.provisionR(() => {}) // second queued (count = 2)
-    await vi.waitFor(() => expect(firstStarted).toBe(true))
-
-    releaseFirst() // first settles -> count drops to 1, NOT 0
-    await first
-    wrapped.cancel('r') // second still pending -> must still forward
-    expect(base.cancel).toHaveBeenCalledWith('r')
-  })
-
-  it('UI provision awaits recovery BEFORE touching a prefix (barrier)', async () => {
-    // A UI-triggered provision must wait for crash recovery to finish reconciling, or recovery's prefix
-    // cleanup could race the rebuild the user just started.
-    const order: string[] = []
-    const provisioner = fakeProvisioner({
-      provisionPython: vi.fn().mockImplementation(async () => {
-        order.push('provision')
-      })
-    })
-    const waitForRecovery = vi.fn().mockImplementation(async () => {
-      await Promise.resolve()
-      order.push('recovery')
-    })
-    const handlers = createNotebookEnvHandlers(provisioner, waitForRecovery)
-    await handlers.provision('python', () => {})
-    expect(waitForRecovery).toHaveBeenCalledOnce()
-    expect(order).toEqual(['recovery', 'provision'])
-  })
-
-  it('UI repair awaits recovery BEFORE touching a prefix (barrier)', async () => {
-    const order: string[] = []
-    const provisioner = fakeProvisioner({
-      repair: vi.fn().mockImplementation(async () => {
-        order.push('repair')
-      })
-    })
-    const waitForRecovery = vi.fn().mockImplementation(async () => {
-      await Promise.resolve()
-      order.push('recovery')
-    })
-    const handlers = createNotebookEnvHandlers(provisioner, waitForRecovery)
-    await handlers.repair('python', () => {})
-    expect(order).toEqual(['recovery', 'repair'])
-  })
-
-  it('UI provision refuses when the default env is recovery-blocked (but repair is the recovery)', async () => {
-    // After recovery leaves the default prefix blocked (an unknown-liveness orphan may still hold it),
-    // a UI PROVISION must refuse rather than materialize over it. REPAIR is the explicit Reset/recovery
-    // — it deliberately bypasses that gate (force-clears the quarantine), so it must NOT refuse.
-    const provisioner = fakeProvisioner()
-    const assertProvisionAllowed = vi.fn((lang: string) => {
-      if (lang === 'python') throw new Error('RUNTIME_RECOVERY_BLOCKED: python is recovering')
-    })
-    const handlers = createNotebookEnvHandlers(provisioner, async () => {}, assertProvisionAllowed)
-
-    await expect(handlers.provision('python', () => {})).rejects.toThrow(/RUNTIME_RECOVERY_BLOCKED/)
-    expect(provisioner.provisionPython).not.toHaveBeenCalled()
-
-    // Repair (the Reset entry) proceeds — it's the recovery, so it force-clears rather than refusing.
-    await handlers.repair('python', () => {})
-    expect(provisioner.repair).toHaveBeenCalledWith('python', expect.any(Function), { force: true })
-
-    // A non-blocked language still provisions.
-    await handlers.provision('r', () => {})
-    expect(provisioner.provisionR).toHaveBeenCalledOnce()
-  })
-
-  it('serializes concurrent provisioning calls so a second call does not start a conflicting run', async () => {
-    let resolveFirst: (() => void) | undefined
-    const started: string[] = []
-    const provisioner = fakeProvisioner({
-      provisionPython: vi.fn().mockImplementation(async () => {
-        started.push('python')
-        await new Promise<void>((resolve) => {
-          resolveFirst = resolve
-        })
-      }),
-      provisionR: vi.fn().mockImplementation(async () => {
-        started.push('r')
-      })
-    })
-    const handlers = createNotebookEnvHandlers(provisioner)
-
-    const first = handlers.provision('python', () => {})
-    // Second call fires while the first is still in flight (before resolveFirst is called).
-    const second = handlers.provision('r', () => {})
-
-    // The second call must not start provisionR until the first finishes.
-    await Promise.resolve()
-    await Promise.resolve()
-    expect(started).toEqual(['python'])
-    expect(provisioner.provisionR).not.toHaveBeenCalled()
-
-    resolveFirst?.()
-    await Promise.all([first, second])
-
-    expect(started).toEqual(['python', 'r'])
-    expect(provisioner.provisionPython).toHaveBeenCalledOnce()
-    expect(provisioner.provisionR).toHaveBeenCalledOnce()
-  })
-
-  it('serializes provision and repair calls against each other', async () => {
-    let resolveFirst: (() => void) | undefined
-    const started: string[] = []
-    const provisioner = fakeProvisioner({
-      provisionPython: vi.fn().mockImplementation(async () => {
-        started.push('provision-python')
-        await new Promise<void>((resolve) => {
-          resolveFirst = resolve
-        })
-      }),
-      repair: vi.fn().mockImplementation(async () => {
-        started.push('repair')
-      })
-    })
-    const handlers = createNotebookEnvHandlers(provisioner)
-
-    const first = handlers.provision('python', () => {})
-    const second = handlers.repair('python', () => {})
-
-    await Promise.resolve()
-    await Promise.resolve()
-    expect(started).toEqual(['provision-python'])
-    expect(provisioner.repair).not.toHaveBeenCalled()
-
-    resolveFirst?.()
-    await Promise.all([first, second])
-
-    expect(started).toEqual(['provision-python', 'repair'])
-  })
-})
-
 describe('registerNotebookEnvIpcHandlers', () => {
   beforeEach(() => {
     registered.clear()
-    sentProgress.length = 0
-    loggerSpies.info.mockReset()
-    loggerSpies.error.mockReset()
-  })
-  afterEach(() => {
-    registered.clear()
-    sentProgress.length = 0
+    sent.length = 0
+    destroyedSend.mockReset()
   })
 
-  it('still registers every channel when the provisioner could not be built', () => {
-    registerNotebookEnvIpcHandlers(undefined, '/tmp/nope')
+  it('registers the exact four channels even when the backend is unavailable', async () => {
+    registerNotebookEnvIpcHandlers(undefined, '/runtime')
+
     expect([...registered.keys()].sort()).toEqual([
       'notebook-env:cancel',
       'notebook-env:provision',
       'notebook-env:repair',
       'notebook-env:status'
     ])
-  })
-
-  it('status reports not-ready and provision/repair reject with an actionable reason', async () => {
-    registerNotebookEnvIpcHandlers(undefined, '/tmp/nope')
-    const status = await registered.get('notebook-env:status')?.({})
-    expect(status).toMatchObject({ pythonReady: false, rReady: false, provisioning: false })
+    await expect(registered.get('notebook-env:status')?.({})).resolves.toMatchObject({
+      pythonReady: false,
+      rReady: false,
+      provisioning: false
+    })
     await expect(registered.get('notebook-env:provision')?.({}, 'python')).rejects.toThrow(
       /micromamba/i
     )
-    await expect(registered.get('notebook-env:repair')?.({}, 'python')).rejects.toThrow(
-      /micromamba/i
-    )
   })
 
-  it('broadcasts the requested language scope for UI provision and repair', async () => {
+  it('projects scoped progress only through live Electron BrowserWindows', async () => {
     const provisioner = fakeProvisioner({
-      provisionR: vi.fn().mockImplementation(async (report: (p: ProvisionProgress) => void) => {
+      provisionR: vi.fn().mockImplementation(async (report) => {
         report({ phase: 'fetch-r', message: 'Downloading R', progress: 0.4 })
       }),
-      repair: vi.fn().mockImplementation(async (_lang, report) => {
+      repair: vi.fn().mockImplementation(async (_language, report) => {
         report({ phase: 'repair', message: 'Repairing Python', progress: 0.2 })
       })
     })
-    registerNotebookEnvIpcHandlers(provisioner, '/tmp/nope')
+    registerNotebookEnvIpcHandlers(provisioner, '/runtime')
 
     await registered.get('notebook-env:provision')?.({}, 'r')
     await registered.get('notebook-env:repair')?.({}, 'python')
 
-    expect(sentProgress).toEqual([
-      { phase: 'fetch-r', message: 'Downloading R', progress: 0.4, scope: 'r' },
-      { phase: 'repair', message: 'Repairing Python', progress: 0.2, scope: 'python' }
-    ])
-  })
-
-  it('logs a provision failure with diagnostics and rethrows the original error', async () => {
-    const failure = Object.assign(new Error('micromamba timed out after 600000ms'), {
-      code: 'MICROMAMBA_TIMEOUT',
-      data: { timeoutMs: 600_000, offline: true }
-    })
-    const provisioner = fakeProvisioner({
-      provisionPython: vi.fn().mockRejectedValue(failure)
-    })
-    registerNotebookEnvIpcHandlers(provisioner, 'F:\\openScience\\data\\OpenScience\\runtime')
-
-    await expect(registered.get('notebook-env:provision')?.({}, 'python')).rejects.toBe(failure)
-
-    expect(loggerSpies.error).toHaveBeenCalledOnce()
-    const [message, fields] = loggerSpies.error.mock.calls[0] as [string, Record<string, unknown>]
-    expect(message).toBe('runtime operation failed')
-    expect(fields).toMatchObject({
-      operation: 'provision',
-      language: 'python',
-      root: 'F:\\openScience\\data\\OpenScience\\runtime',
-      error: 'micromamba timed out after 600000ms',
-      code: 'MICROMAMBA_TIMEOUT',
-      data: { timeoutMs: 600_000, offline: true }
-    })
-    expect(fields.operationId).toEqual(expect.any(String))
-    expect(fields.durationMs).toEqual(expect.any(Number))
-  })
-
-  it('redacts credentials from persisted runtime diagnostics without changing the thrown error', async () => {
-    const channel = 'https://user:basic-secret@example.com/t/path-secret/conda?token=query-secret'
-    const failure = Object.assign(new Error(`micromamba timed out (${channel})`), {
-      code: 'MICROMAMBA_TIMEOUT',
-      data: {
-        argv: ['micromamba', '-c', channel],
-        stderrTail: 'api_key=stderr-secret',
-        stdoutTail: 'Bearer stdout-secret'
-      }
-    })
-    const provisioner = fakeProvisioner({
-      provisionPython: vi
-        .fn()
-        .mockImplementation(async (report: (p: ProvisionProgress) => void) => {
-          report({ phase: 'fetch-python', message: `Retrying ${channel}`, progress: 0.1 })
-          throw failure
-        })
-    })
-    registerNotebookEnvIpcHandlers(provisioner, '/runtime')
-
-    await expect(registered.get('notebook-env:provision')?.({}, 'python')).rejects.toBe(failure)
-
-    const persisted = JSON.stringify({
-      info: loggerSpies.info.mock.calls,
-      error: loggerSpies.error.mock.calls
-    })
-    for (const secret of [
-      'basic-secret',
-      'path-secret',
-      'query-secret',
-      'stderr-secret',
-      'stdout-secret'
-    ]) {
-      expect(persisted).not.toContain(secret)
-    }
-    expect(persisted).toContain('[redacted]')
-    expect(failure.message).toContain('basic-secret')
-  })
-
-  it('logs operation lifecycle and phase changes without logging every download chunk', async () => {
-    const provisioner = fakeProvisioner({
-      provisionPython: vi
-        .fn()
-        .mockImplementation(async (report: (p: ProvisionProgress) => void) => {
-          report({ phase: 'fetch-python', message: 'Downloading Python (10%)', progress: 0.1 })
-          report({ phase: 'fetch-python', message: 'Downloading Python (20%)', progress: 0.2 })
-          report({
-            phase: 'fetch-python',
-            message: 'Downloading Python (resuming…)',
-            progress: 0.2,
-            download: {
-              phase: 'reconnecting',
-              transferred: 20,
-              total: 100,
-              percent: 20,
-              bytesPerSecond: 0,
-              attempt: 1
-            }
-          })
-          report({ phase: 'create-python', message: 'Creating Python', progress: 0.45 })
-        })
-    })
-    registerNotebookEnvIpcHandlers(provisioner, '/runtime')
-
-    await registered.get('notebook-env:provision')?.({}, 'python')
-
-    expect(loggerSpies.info.mock.calls.map(([message]) => message)).toEqual([
-      'runtime operation started',
-      'runtime operation progress',
-      'runtime operation progress',
-      'runtime operation progress',
-      'runtime operation completed'
-    ])
-    const progressFields = loggerSpies.info.mock.calls
-      .filter(([message]) => message === 'runtime operation progress')
-      .map(([, fields]) => fields as Record<string, unknown>)
-    expect(progressFields).toMatchObject([
-      { phase: 'fetch-python', message: 'Downloading Python (10%)' },
+    expect(sent).toEqual([
       {
-        phase: 'fetch-python',
-        message: 'Downloading Python (resuming…)',
-        download: { phase: 'reconnecting', attempt: 1, transferred: 20, total: 100 }
+        channel: 'notebook-env:progress',
+        progress: { phase: 'fetch-r', message: 'Downloading R', progress: 0.4, scope: 'r' }
       },
-      { phase: 'create-python', message: 'Creating Python' }
-    ])
-    const operationIds = new Set(
-      loggerSpies.info.mock.calls.map(
-        ([, fields]) => (fields as { operationId: string }).operationId
-      )
-    )
-    expect(operationIds.size).toBe(1)
-  })
-})
-
-describe('runStartupGate', () => {
-  it('does not mutate runtime storage while a data-root migration is pending', async () => {
-    const provisioner = fakeProvisioner()
-    const dir = mkdtempSync(join(tmpdir(), 'os-gate-migration-'))
-    const broadcast = vi.fn()
-    beginMigration()
-
-    await runStartupGate(provisioner, dir, broadcast)
-
-    expect(provisioner.restoreRelocatedEnvs).not.toHaveBeenCalled()
-    expect(broadcast).toHaveBeenCalledWith(
-      expect.objectContaining({
-        phase: 'error',
-        message: expect.stringMatching(/moving your data/i)
-      })
-    )
-  })
-
-  it('is detect-only on a fresh empty root: restores relocated envs but does not provision python', async () => {
-    const provisioner = fakeProvisioner()
-    const dir = mkdtempSync(join(tmpdir(), 'os-gate-'))
-    await runStartupGate(provisioner, dir, () => {})
-    // Fresh envs are built lazily on first notebook use, not eagerly here.
-    expect(provisioner.provisionPython).not.toHaveBeenCalled()
-    expect(provisioner.upgradeIfNeeded).not.toHaveBeenCalled()
-    expect(provisioner.repair).not.toHaveBeenCalled()
-    // restoreRelocatedEnvs still runs (needed for data-root relocations).
-    expect(provisioner.restoreRelocatedEnvs).toHaveBeenCalledOnce()
-  })
-
-  it('does nothing when already ready', async () => {
-    const { writeReadyMarker, envPrefix, pythonBin, DEFAULT_ENV_VERSION, DEFAULT_PY_ENV } =
-      await import('./runtime-paths')
-    const dir = mkdtempSync(join(tmpdir(), 'os-gate2-'))
-    const bin = pythonBin(envPrefix(dir, DEFAULT_PY_ENV))
-    mkdirSync(join(bin, '..'), { recursive: true })
-    writeFileSync(bin, 'x')
-    writeReadyMarker(dir, DEFAULT_ENV_VERSION, 't')
-    const provisioner = fakeProvisioner()
-    await runStartupGate(provisioner, dir, () => {})
-    expect(provisioner.provisionPython).not.toHaveBeenCalled()
-    expect(provisioner.upgradeIfNeeded).not.toHaveBeenCalled()
-    expect(provisioner.repair).not.toHaveBeenCalled()
-  })
-
-  it('upgrades when an older-version marker with an existing python bin is found', async () => {
-    const { writeReadyMarker, envPrefix, pythonBin, DEFAULT_PY_ENV } =
-      await import('./runtime-paths')
-    const dir = mkdtempSync(join(tmpdir(), 'os-gate3-'))
-    const bin = pythonBin(envPrefix(dir, DEFAULT_PY_ENV))
-    mkdirSync(join(bin, '..'), { recursive: true })
-    writeFileSync(bin, 'x')
-    writeReadyMarker(dir, 0, 't')
-    const provisioner = fakeProvisioner()
-    await runStartupGate(provisioner, dir, () => {})
-    expect(provisioner.upgradeIfNeeded).toHaveBeenCalledOnce()
-    expect(provisioner.provisionPython).not.toHaveBeenCalled()
-    expect(provisioner.repair).not.toHaveBeenCalled()
-  })
-
-  it('repairs when a marker exists but the python bin is missing', async () => {
-    const { writeReadyMarker } = await import('./runtime-paths')
-    const dir = mkdtempSync(join(tmpdir(), 'os-gate4-'))
-    writeReadyMarker(dir, 0, 't')
-    const provisioner = fakeProvisioner()
-    await runStartupGate(provisioner, dir, () => {})
-    expect(provisioner.repair).toHaveBeenCalledWith('python', expect.any(Function))
-    expect(provisioner.provisionPython).not.toHaveBeenCalled()
-    expect(provisioner.upgradeIfNeeded).not.toHaveBeenCalled()
-  })
-
-  it('never provisions R at startup', async () => {
-    const provisioner = fakeProvisioner()
-    const dir = mkdtempSync(join(tmpdir(), 'os-gate5-'))
-    await runStartupGate(provisioner, dir, () => {})
-    expect(provisioner.provisionR).not.toHaveBeenCalled()
-  })
-
-  it('does NOT eagerly repair Python for an R-first user (residual default-r, no marker, no python)', async () => {
-    // A user who ran R first has a lazily-built default-r dir but no Python and no ready marker
-    // (provisionR never writes it). needsRepair keys off the residual default-r, so the action is
-    // 'repair' — but there is no Python to repair, so startup must stay detect-only (no eager DL).
-    const { rBin, envPrefix, DEFAULT_R_ENV } = await import('./runtime-paths')
-    const dir = mkdtempSync(join(tmpdir(), 'os-gate-rfirst-'))
-    const rbin = rBin(envPrefix(dir, DEFAULT_R_ENV))
-    mkdirSync(join(rbin, '..'), { recursive: true })
-    writeFileSync(rbin, 'x')
-    const provisioner = fakeProvisioner()
-    await runStartupGate(provisioner, dir, () => {})
-    expect(provisioner.repair).not.toHaveBeenCalled()
-    expect(provisioner.provisionPython).not.toHaveBeenCalled()
-  })
-
-  it('reports failure via broadcast instead of throwing', async () => {
-    // restoreRelocatedEnvs always runs, so failing it exercises the gate's try/catch on a fresh root.
-    const provisioner = fakeProvisioner({
-      restoreRelocatedEnvs: vi.fn().mockRejectedValue(new Error('boom'))
-    })
-    const dir = mkdtempSync(join(tmpdir(), 'os-gate6-'))
-    const broadcast = vi.fn()
-    await expect(runStartupGate(provisioner, dir, broadcast)).resolves.toBeUndefined()
-    expect(broadcast).toHaveBeenCalledWith(
-      expect.objectContaining({ phase: 'error', message: expect.stringContaining('boom') })
-    )
-  })
-
-  it('logs the FULL micromamba diagnostics (data tails) even though it broadcasts only the short message', async () => {
-    // This automatic path has no per-op logging, so the gate itself must record the structured
-    // `error.data` tails. Otherwise a launch-time failure leaves only a truncated UI excerpt and the
-    // real micromamba output never crosses the main-process boundary (regression the reviewers flagged).
-    loggerSpies.error.mockReset()
-    const micromambaError = Object.assign(
-      new Error('micromamba failed (exit 1; mm create): …tail-excerpt'),
       {
-        code: 'MICROMAMBA_EXIT',
-        data: { argv: ['mm', 'create'], exitCode: 1, stderrTail: 'Invalid package cache signature' }
+        channel: 'notebook-env:progress',
+        progress: { phase: 'repair', message: 'Repairing Python', progress: 0.2, scope: 'python' }
       }
-    )
-    const provisioner = fakeProvisioner({
-      restoreRelocatedEnvs: vi.fn().mockRejectedValue(micromambaError)
-    })
-    const dir = mkdtempSync(join(tmpdir(), 'os-gate-log-'))
-    await runStartupGate(provisioner, dir, vi.fn())
-
-    expect(loggerSpies.error).toHaveBeenCalledOnce()
-    const [, fields] = loggerSpies.error.mock.calls[0] as [string, Record<string, unknown>]
-    // errorLogFields lifts the error's own `data`/`code` keys, so the tails are present in the log.
-    expect(fields.code).toBe('MICROMAMBA_EXIT')
-    expect(JSON.stringify(fields)).toContain('Invalid package cache signature')
+    ])
+    expect(destroyedSend).not.toHaveBeenCalled()
   })
 
-  it('refuses to rebuild over a recovery-blocked prefix through the REAL provisioner self-guard', async () => {
-    // The startup gate drives repair/upgrade/restore through the provisioner, so the block guarantee
-    // must survive that real path — not just a mock guard on the UI handlers. Wire a real
-    // DefaultRuntimeProvisioner with the isPrefixBlocked dep ipc.ts injects (← isPrefixRecoveryBlocked),
-    // set up a marker-but-no-bin state so the planner picks 'repair', and assert the gate refuses:
-    // nothing is spawned, the (possibly-live) prefix is not deleted, and the error is broadcast.
-    const { writeReadyMarker, envPrefix, DEFAULT_PY_ENV } = await import('./runtime-paths')
-    const { DefaultRuntimeProvisioner } = await import('./provisioner')
-    const dir = mkdtempSync(join(tmpdir(), 'os-gate-blocked-'))
-    const prefix = envPrefix(dir, DEFAULT_PY_ENV)
-    mkdirSync(prefix, { recursive: true }) // a partial prefix an orphan may still be writing
-    writeReadyMarker(dir, 0, 't') // marker present + no bin => planStartupAction === 'repair'
-
-    const runArgv = vi.fn().mockResolvedValue(undefined)
-    const provisioner = new DefaultRuntimeProvisioner({
-      root: dir,
-      mm: '/mm',
-      channel: 'conda-forge',
-      fetchBundle: async (spec) => ({ lockPath: join(dir, `${spec.name}.lock`) }),
-      runArgv,
-      verify: async () => undefined,
-      isPrefixBlocked: (p) => p === prefix
-    })
-    const broadcast = vi.fn()
-    await runStartupGate(provisioner, dir, broadcast)
-
-    expect(runArgv).not.toHaveBeenCalled() // no rebuild spawned
-    expect(existsSync(prefix)).toBe(true) // prefix not rm -rf'd out from under a possible survivor
-    expect(broadcast).toHaveBeenCalledWith(
-      expect.objectContaining({
-        phase: 'error',
-        message: expect.stringMatching(/RUNTIME_RECOVERY_BLOCKED/)
-      })
-    )
-  })
-
-  it('awaits recovery BEFORE touching any prefix (restore/upgrade/repair)', async () => {
-    // The barrier must resolve before the gate's first prefix op, or recovery's cleanup could race a
-    // rebuild. Use an existing-but-stale marker so the gate would call upgradeIfNeeded, and assert
-    // recovery settled first.
-    const { writeReadyMarker, envPrefix, pythonBin, DEFAULT_PY_ENV } =
-      await import('./runtime-paths')
-    const dir = mkdtempSync(join(tmpdir(), 'os-gate-barrier-'))
-    const bin = pythonBin(envPrefix(dir, DEFAULT_PY_ENV))
-    mkdirSync(join(bin, '..'), { recursive: true })
-    writeFileSync(bin, 'x')
-    writeReadyMarker(dir, 0, 't')
-
-    const order: string[] = []
+  it('forwards cancel synchronously and starts maintenance after registration', async () => {
+    let settleProvision!: () => void
     const provisioner = fakeProvisioner({
-      restoreRelocatedEnvs: vi.fn().mockImplementation(async () => {
-        order.push('restore')
-      }),
-      upgradeIfNeeded: vi.fn().mockImplementation(async () => {
-        order.push('upgrade')
-      })
-    })
-    let recovered = false
-    const waitForRecovery = vi.fn().mockImplementation(async () => {
-      await Promise.resolve()
-      recovered = true
-      order.push('recovery')
+      provisionR: vi.fn().mockReturnValue(
+        new Promise<void>((resolve) => {
+          settleProvision = resolve
+        })
+      )
     })
 
-    await runStartupGate(provisioner, dir, () => {}, waitForRecovery)
+    registerNotebookEnvIpcHandlers(provisioner, '/runtime')
+    const operation = registered.get('notebook-env:provision')?.({}, 'r') as Promise<void>
+    registered.get('notebook-env:cancel')?.({}, 'r')
 
-    expect(waitForRecovery).toHaveBeenCalledOnce()
-    // Recovery ran, and it ran before ANY provisioner prefix op.
-    expect(recovered).toBe(true)
-    expect(order[0]).toBe('recovery')
-    expect(order).toEqual(['recovery', 'restore', 'upgrade'])
+    expect(provisioner.cancel).toHaveBeenCalledWith('r')
+    await vi.waitFor(() => expect(provisioner.restoreRelocatedEnvs).toHaveBeenCalledOnce())
+    await vi.waitFor(() => expect(provisioner.provisionR).toHaveBeenCalledOnce())
+    settleProvision()
+    await operation
   })
 })

--- a/src/main/notebook/env-ipc.ts
+++ b/src/main/notebook/env-ipc.ts
@@ -1,146 +1,10 @@
-import { existsSync } from 'node:fs'
-
 import { BrowserWindow } from 'electron'
 
-import { ipcMainHandle } from '../ipc-handler-registry'
-
 import type { NotebookLanguage } from '../../shared/notebook'
-import { withDataRootWrite } from '../storage/migration-state'
-import {
-  logStartupGateFailure,
-  runLoggedRuntimeOperation,
-  serializeProvisioner
-} from './environment-operation-foundation'
-import {
-  planStartupAction,
-  type ProvisionProgress,
-  type ProvisionStatus,
-  type RuntimeProvisioner
-} from './provisioner'
-// NOTE: DEFAULT_ENV_VERSION is imported into provisioner.ts but not re-exported from it (brief's
-// example code imports it `from './provisioner'`, which resolves to `undefined` at runtime under
-// vitest's transpile-only mode — a real type error under `tsc` that transpile-only silently allows
-// through). Sourcing it from its actual home, runtime-paths.ts, instead of touching provisioner.ts
-// (out of this task's scope).
-import { DEFAULT_ENV_VERSION, DEFAULT_PY_ENV, envPrefix, readReadyMarker } from './runtime-paths'
-
-// A small delegating surface so IPC behavior tests run without Electron wiring.
-export type NotebookEnvHandlers = {
-  status: () => Promise<ProvisionStatus>
-  provision: (lang: NotebookLanguage, onProgress: (p: ProvisionProgress) => void) => Promise<void>
-  repair: (lang: NotebookLanguage, onProgress: (p: ProvisionProgress) => void) => Promise<void>
-  cancel: (language?: NotebookLanguage) => void
-}
-
-export const createNotebookEnvHandlers = (
-  provisioner: RuntimeProvisioner,
-  // Awaited before a UI-triggered provision/repair so recovery's prefix cleanup can't race a rebuild
-  // the user just kicked off. Optional so existing behavior tests construct handlers unchanged.
-  waitForRecovery?: () => Promise<void>,
-  // Throws if the default env for a language is recovery-blocked (an unknown-liveness orphan may still
-  // be writing its prefix), so a UI provision/repair refuses instead of materializing over a live env.
-  // Checked AFTER waitForRecovery, so the blocked set is populated. Optional for existing tests.
-  assertProvisionAllowed?: (language: NotebookLanguage) => void,
-  // Called only after the provisioner has rebuilt and verified an explicit UI Repair. The runtime
-  // service owns its separate durable repair marker, process-local execution gate, and bindings; this
-  // handoff lets it release those states only at the verified Reset boundary.
-  onRepairCompleted?: (language: NotebookLanguage) => Promise<void> | void
-): NotebookEnvHandlers => {
-  const serialized = serializeProvisioner(provisioner)
-  const afterRecovery = async (
-    language: NotebookLanguage,
-    run: () => Promise<void>
-  ): Promise<void> => {
-    await withDataRootWrite(async () => {
-      if (waitForRecovery) await waitForRecovery()
-      assertProvisionAllowed?.(language)
-      await run()
-    })
-  }
-  return {
-    // AWAIT recovery before reading status: recovery populates the blocked-prefix set (and hence
-    // status.*RecoveryBlocked) asynchronously. A renderer that reads status before recovery settles
-    // would see blocked=false and never surface Reset — the startup gate produces no progress event for
-    // an already-ready env, so there is no other signal that would later correct it.
-    status: () =>
-      withDataRootWrite(async () => {
-        if (waitForRecovery) await waitForRecovery()
-        return serialized.status()
-      }),
-    provision: (lang, onProgress) =>
-      afterRecovery(lang, () =>
-        lang === 'r' ? serialized.provisionR(onProgress) : serialized.provisionPython(onProgress)
-      ),
-    // A UI-triggered repair is the EXPLICIT user recovery / Reset: it awaits recovery for ordering but
-    // does NOT assertProvisionAllowed (that would refuse a blocked runtime — the whole point of Reset is
-    // to clear the block), and it force-clears the quarantine before rebuilding. Auto/startup repair
-    // (runStartupGate) calls the provisioner directly without force and stays gated by the block.
-    repair: async (lang, onProgress) => {
-      await withDataRootWrite(async () => {
-        if (waitForRecovery) await waitForRecovery()
-        await serialized.repair(lang, onProgress, { force: true })
-        await onRepairCompleted?.(lang)
-      })
-    },
-    cancel: (language) => serialized.cancel(language)
-  }
-}
-
-// The app-usable gate: on startup, maintain an already-existing managed python env (restore relocated
-// envs, upgrade/repair) but do NOT eagerly provision a fresh one — that is detect-only, built lazily
-// on first notebook use. R stays lazy. Never throws — a failure leaves the app usable (non-notebook
-// features) and is reported via progress/status (spec §6.4).
-export const runStartupGate = async (
-  provisioner: RuntimeProvisioner,
-  root: string,
-  broadcast: (p: ProvisionProgress) => void,
-  // Awaited BEFORE any prefix-touching maintenance (restore/upgrade/repair) so crash recovery has
-  // finished reconciling first. Otherwise recovery could delete a prefix this gate is mid-rebuild on
-  // (or vice-versa). Optional: when unset (tests) the gate runs as before.
-  waitForRecovery?: () => Promise<void>
-): Promise<void> => {
-  try {
-    await withDataRootWrite(async () => {
-      // Let crash recovery settle under the same lease as subsequent prefix maintenance; recovery
-      // itself may clear journals or quarantines under the old data root.
-      if (waitForRecovery) await waitForRecovery()
-      // Rebuild any envs a data-root relocation left as offline locks BEFORE planning: a restored
-      // default-python stamps the ready marker, so the plan below then reads 'ready' instead of
-      // re-provisioning the pristine defaults (which would drop the user's relocated packages).
-      await provisioner.restoreRelocatedEnvs(broadcast)
-
-      const action = planStartupAction(root, DEFAULT_ENV_VERSION)
-      if (action === 'ready') return
-      if (action === 'upgrade') return void (await provisioner.upgradeIfNeeded(broadcast))
-      if (action === 'repair') {
-        // `needsRepair` also fires from a residual default-r dir with NO Python at all (an R-first user
-        // whose lazy R build left default-r behind; provisionR never writes the Python marker). Repair
-        // (an eager rebuild) only when Python was genuinely provisioned before — a ready marker exists,
-        // or the default-python prefix is on disk (present-but-corrupt). Otherwise this is effectively a
-        // first-time Python and must stay detect-only (built lazily on first use).
-        const pythonWasProvisioned =
-          readReadyMarker(root) !== undefined || existsSync(envPrefix(root, DEFAULT_PY_ENV))
-        if (pythonWasProvisioned) {
-          return void (await provisioner.repair('python', broadcast))
-        }
-        return
-      }
-      // Fresh case: detect-only — do NOT eagerly provision. upgrade/repair above still maintain an
-      // already-existing managed env; a first-time env is built lazily on first notebook use
-      // (ensureDefaultEnvReady), so there is nothing to provision here.
-    })
-  } catch (error) {
-    // This is the automatic (no per-op logging) path, so record the FULL diagnostics here — including
-    // the structured micromamba tails on `error.data` — before broadcasting only the short UI message.
-    // Otherwise a launch-time restore/upgrade/repair failure would leave nothing but a truncated excerpt.
-    logStartupGateFailure(error)
-    broadcast({
-      phase: 'error',
-      message: `Environment preparation failed: ${(error as Error).message}`,
-      progress: 0
-    })
-  }
-}
+import { ipcMainHandle } from '../ipc-handler-registry'
+import { serializeProvisioner } from './environment-operation-foundation'
+import { createNotebookEnvironmentLifecycle } from './environment-lifecycle-workflows'
+import type { ProvisionProgress, RuntimeProvisioner } from './provisioner'
 
 // Broadcasts a progress event to every live renderer window.
 export const broadcastNotebookEnvProgress = (progress: ProvisionProgress): void => {
@@ -149,84 +13,35 @@ export const broadcastNotebookEnvProgress = (progress: ProvisionProgress): void 
   }
 }
 
-// Shown when the runtime backend could not be constructed (e.g. micromamba missing — common in dev
-// without a staged binary). Actionable so the renderer surfaces a real reason instead of a raw
-// "No handler registered" IPC crash.
-const RUNTIME_UNAVAILABLE_MESSAGE =
-  'The notebook runtime is unavailable: micromamba was not found. In a packaged build it ships with the app; for development, set OPEN_SCIENCE_MICROMAMBA_BIN to a micromamba binary and restart.'
-
-// Handlers used when no provisioner could be built: status reports "not ready, not provisioning" so the
-// UI shows an actionable setup state, and provision/repair reject with a clear reason rather than the
-// channel being absent entirely (which would surface as a "No handler registered" crash in the renderer).
-const createUnavailableHandlers = (): NotebookEnvHandlers => ({
-  status: () =>
-    Promise.resolve({
-      pythonReady: false,
-      rReady: false,
-      version: DEFAULT_ENV_VERSION,
-      provisioning: false
-    }),
-  provision: () => Promise.reject(new Error(RUNTIME_UNAVAILABLE_MESSAGE)),
-  repair: () => Promise.reject(new Error(RUNTIME_UNAVAILABLE_MESSAGE)),
-  cancel: () => undefined // unavailable backend: no in-flight run to cancel (language ignored)
-})
-
-// Registers the notebook-env IPC surface and kicks off the startup readiness gate. Both the gate and
-// the IPC-triggered provision/repair calls share ONE serialized provisioner instance, so a renderer
-// calling notebook-env:provision while the startup gate is still running queues behind it instead of
-// racing the provisioner's shared `provisioning` flag.
-//
-// The handlers are ALWAYS registered, even when `provisioner` is undefined (the backend could not be
-// built): a missing handler would make every renderer call throw "No handler registered", turning a
-// recoverable "runtime not set up" state into a hard crash. With no provisioner we register the
-// unavailable stubs and skip the startup gate instead.
+// Registers the stable renderer surface while lifecycle ordering and state stay behind the workflow
+// interface. An unavailable provisioner still yields registered handlers with actionable results.
 export const registerNotebookEnvIpcHandlers = (
   provisioner: RuntimeProvisioner | undefined,
   root: string,
-  // Awaited before the startup gate and any UI provision/repair touches a prefix, so crash recovery
-  // (kicked off in the caller BEFORE this registration) finishes reconciling first. Optional so the
-  // "no provisioner" path and existing tests keep their signatures.
   waitForRecovery?: () => Promise<void>,
-  // Throws if the default env for a language is recovery-blocked, so UI provision/repair refuses rather
-  // than materializing over a prefix an unknown-liveness orphan may still hold.
   assertProvisionAllowed?: (language: NotebookLanguage) => void,
   onRepairCompleted?: (language: NotebookLanguage) => Promise<void> | void
 ): void => {
-  const serialized = provisioner ? serializeProvisioner(provisioner) : undefined
-  const handlers = serialized
-    ? createNotebookEnvHandlers(
-        serialized,
-        waitForRecovery,
-        assertProvisionAllowed,
-        onRepairCompleted
-      )
-    : createUnavailableHandlers()
-  ipcMainHandle('notebook-env:status', () => handlers.status())
-  ipcMainHandle('notebook-env:provision', (_event, lang: NotebookLanguage) =>
-    runLoggedRuntimeOperation(
-      'provision',
-      lang,
-      root,
-      (onProgress) => handlers.provision(lang, onProgress),
-      (progress) => broadcastNotebookEnvProgress({ ...progress, scope: lang })
-    )
+  const lifecycle = createNotebookEnvironmentLifecycle({
+    provisioner,
+    root,
+    projectProgress: broadcastNotebookEnvProgress,
+    waitForRecovery,
+    assertProvisionAllowed,
+    onRepairCompleted
+  })
+
+  ipcMainHandle('notebook-env:status', () => lifecycle.status())
+  ipcMainHandle('notebook-env:provision', (_event, language: NotebookLanguage) =>
+    lifecycle.provision(language)
   )
-  ipcMainHandle('notebook-env:repair', (_event, lang: NotebookLanguage) =>
-    runLoggedRuntimeOperation(
-      'repair',
-      lang,
-      root,
-      (onProgress) => handlers.repair(lang, onProgress),
-      (progress) => broadcastNotebookEnvProgress({ ...progress, scope: lang })
-    )
+  ipcMainHandle('notebook-env:repair', (_event, language: NotebookLanguage) =>
+    lifecycle.repair(language)
   )
-  // Synchronous best-effort abort of an in-flight provision; returns immediately (the aborted run
-  // settles on its own and broadcasts its terminal progress).
   ipcMainHandle('notebook-env:cancel', (_event, language?: NotebookLanguage) =>
-    handlers.cancel(language)
+    lifecycle.cancel(language)
   )
-  if (serialized)
-    void runStartupGate(serialized, root, broadcastNotebookEnvProgress, waitForRecovery)
+  void lifecycle.startup()
 }
 
 // Preserve the composition-root import until N7e owns construction at the application seam.

--- a/src/main/notebook/environment-lifecycle-workflows.test.ts
+++ b/src/main/notebook/environment-lifecycle-workflows.test.ts
@@ -1,0 +1,760 @@
+import { existsSync, mkdtempSync, mkdirSync, writeFileSync } from 'node:fs'
+import { tmpdir } from 'node:os'
+import { join } from 'node:path'
+
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest'
+
+const loggerSpies = vi.hoisted(() => ({
+  info: vi.fn(),
+  error: vi.fn()
+}))
+vi.mock('../logger', async (importOriginal) => {
+  const actual = await importOriginal<typeof import('../logger')>()
+  return {
+    ...actual,
+    createLogger: () => ({
+      debug: vi.fn(),
+      info: loggerSpies.info,
+      warn: vi.fn(),
+      error: loggerSpies.error
+    })
+  }
+})
+
+import { beginMigration, clearMigrationPending } from '../storage/migration-state'
+import { serializeProvisioner } from './environment-operation-foundation'
+import {
+  createNotebookEnvironmentLifecycle,
+  type NotebookEnvironmentLifecycle
+} from './environment-lifecycle-workflows'
+import type { ProvisionProgress, RuntimeProvisioner } from './provisioner'
+
+afterEach(() => clearMigrationPending())
+
+const fakeProvisioner = (over: Partial<RuntimeProvisioner> = {}): RuntimeProvisioner => ({
+  status: vi
+    .fn()
+    .mockReturnValue({ pythonReady: false, rReady: false, version: 0, provisioning: false }),
+  provisionPython: vi.fn().mockResolvedValue(undefined),
+  provisionR: vi.fn().mockResolvedValue(undefined),
+  upgradeIfNeeded: vi.fn().mockResolvedValue(undefined),
+  repair: vi.fn().mockResolvedValue(undefined),
+  restoreRelocatedEnvs: vi.fn().mockResolvedValue(undefined),
+  cancel: vi.fn(),
+  ...over
+})
+
+const createLifecycle = (
+  provisioner: RuntimeProvisioner | undefined,
+  options: {
+    root?: string
+    projectProgress?: (progress: ProvisionProgress) => void
+    waitForRecovery?: () => Promise<void>
+    assertProvisionAllowed?: (language: 'python' | 'r') => void
+    onRepairCompleted?: (language: 'python' | 'r') => Promise<void> | void
+  } = {}
+): NotebookEnvironmentLifecycle =>
+  createNotebookEnvironmentLifecycle({
+    provisioner,
+    root: options.root ?? '/runtime',
+    projectProgress: options.projectProgress ?? (() => undefined),
+    waitForRecovery: options.waitForRecovery,
+    assertProvisionAllowed: options.assertProvisionAllowed,
+    onRepairCompleted: options.onRepairCompleted
+  })
+
+const startLifecycle = (
+  provisioner: RuntimeProvisioner,
+  root: string,
+  projectProgress: (progress: ProvisionProgress) => void = () => undefined,
+  waitForRecovery?: () => Promise<void>
+): Promise<void> =>
+  createLifecycle(provisioner, { root, projectProgress, waitForRecovery }).startup()
+
+describe('createNotebookEnvironmentLifecycle', () => {
+  it('status returns the provisioner status', async () => {
+    const provisioner = fakeProvisioner()
+    const lifecycle = createLifecycle(provisioner)
+    expect(await lifecycle.status()).toEqual({
+      pythonReady: false,
+      rReady: false,
+      version: 0,
+      provisioning: false
+    })
+    expect(provisioner.status).toHaveBeenCalledOnce()
+  })
+
+  it('provision dispatches python vs R by language and forwards progress', async () => {
+    const provisioner = fakeProvisioner({
+      provisionPython: vi.fn().mockImplementation(async (cb: (p: ProvisionProgress) => void) => {
+        cb({ phase: 'done', message: 'ok', progress: 1 })
+      })
+    })
+    const emitted: ProvisionProgress[] = []
+    const lifecycle = createLifecycle(provisioner, { projectProgress: (p) => emitted.push(p) })
+    await lifecycle.provision('python')
+    expect(provisioner.provisionPython).toHaveBeenCalledOnce()
+    expect(emitted).toEqual([{ phase: 'done', message: 'ok', progress: 1, scope: 'python' }])
+    await lifecycle.provision('r')
+    expect(provisioner.provisionR).toHaveBeenCalledOnce()
+  })
+
+  it('repair delegates by language as an explicit force-recovery', async () => {
+    const provisioner = fakeProvisioner()
+    const lifecycle = createLifecycle(provisioner)
+    await lifecycle.repair('r')
+    // UI repair is the user's Reset: it force-clears the quarantine (force: true).
+    expect(provisioner.repair).toHaveBeenCalledWith('r', expect.any(Function), { force: true })
+  })
+
+  it('publishes a successful verified repair back to the runtime service', async () => {
+    const provisioner = fakeProvisioner()
+    const onRepairCompleted = vi.fn().mockResolvedValue(undefined)
+    const lifecycle = createLifecycle(provisioner, { onRepairCompleted })
+
+    await lifecycle.repair('r')
+
+    expect(onRepairCompleted).toHaveBeenCalledOnce()
+    expect(onRepairCompleted).toHaveBeenCalledWith('r')
+  })
+
+  it('does not release runtime-service quarantine when the rebuild fails', async () => {
+    const provisioner = fakeProvisioner({
+      repair: vi.fn().mockRejectedValue(new Error('verification failed'))
+    })
+    const onRepairCompleted = vi.fn().mockResolvedValue(undefined)
+    const lifecycle = createLifecycle(provisioner, { onRepairCompleted })
+
+    await expect(lifecycle.repair('r')).rejects.toThrow('verification failed')
+    expect(onRepairCompleted).not.toHaveBeenCalled()
+  })
+
+  it('blocks new Environment mutations while a data-root migration is pending', async () => {
+    const provisioner = fakeProvisioner()
+    const lifecycle = createLifecycle(provisioner)
+    beginMigration()
+
+    await expect(lifecycle.provision('python')).rejects.toThrow(/moving your data/i)
+    await expect(lifecycle.repair('r')).rejects.toThrow(/moving your data/i)
+    expect(provisioner.provisionPython).not.toHaveBeenCalled()
+    expect(provisioner.repair).not.toHaveBeenCalled()
+  })
+
+  it('cancel forwards the language to the provisioner while that language is provisioning', async () => {
+    let settleProvision!: () => void
+    const provisioner = fakeProvisioner({
+      // Keep R provisioning in flight so its language is pending when we cancel.
+      provisionR: vi.fn().mockReturnValue(
+        new Promise<void>((resolve) => {
+          settleProvision = resolve
+        })
+      )
+    })
+    const lifecycle = createLifecycle(provisioner)
+    const operation = lifecycle.provision('r')
+    lifecycle.cancel('r')
+    expect(provisioner.cancel).toHaveBeenCalledWith('r')
+    settleProvision()
+    await operation
+  })
+
+  it('cancel forwards the language to the provisioner while a Reset (repair) is in flight', async () => {
+    // A Reset runs through repair; it must bump the per-language pending count (serializeLanguage), or
+    // the Cancel button shown during a Reset would be dropped as idle and the Reset be un-abortable.
+    let settleRepair!: () => void
+    const provisioner = fakeProvisioner({
+      repair: vi.fn().mockReturnValue(
+        new Promise<void>((resolve) => {
+          settleRepair = resolve
+        })
+      )
+    })
+    const lifecycle = createLifecycle(provisioner)
+    const operation = lifecycle.repair('python')
+    lifecycle.cancel('python')
+    expect(provisioner.cancel).toHaveBeenCalledWith('python')
+    settleRepair()
+    await operation
+  })
+
+  it('cancel is a NO-OP when the language is idle (does not arm the next unrelated provision)', () => {
+    const provisioner = fakeProvisioner()
+    const lifecycle = createLifecycle(provisioner)
+    lifecycle.cancel('r') // nothing provisioning -> must not reach the provisioner
+    expect(provisioner.cancel).not.toHaveBeenCalled()
+  })
+
+  it('idempotent: repeated wrapping still forwards a queued cancel to the base provisioner', () => {
+    // Composition and the lifecycle may both request serialization. If each wrap owned an independent
+    // queue+pending map, a request queued at the
+    // OUTER layer wouldn't exist in an inner layer's pending, so cancel routed inward would be dropped
+    // as idle. Idempotent serialization collapses them to ONE queue, so a queued cancel reaches base.
+    let releasePython!: () => void
+    const base = fakeProvisioner({
+      provisionPython: vi.fn().mockReturnValue(
+        new Promise<void>((resolve) => {
+          releasePython = resolve
+        })
+      )
+    })
+    const wrapped = serializeProvisioner(serializeProvisioner(serializeProvisioner(base)))
+
+    void wrapped.provisionPython(() => {}) // running
+    void wrapped.provisionR(() => {}) // queued behind python (same single queue)
+    wrapped.cancel('r') // must reach base despite the triple wrap
+
+    expect(base.cancel).toHaveBeenCalledWith('r')
+    releasePython()
+  })
+
+  it('idempotent: re-wrapping an already-serialized provisioner returns the same instance', () => {
+    const once = serializeProvisioner(fakeProvisioner())
+    expect(serializeProvisioner(once)).toBe(once)
+  })
+
+  it('counts multiple pending requests for one language (cancel stays live until the last settles)', async () => {
+    // Two same-language requests must both be tracked; if the first to settle deleted the language, a
+    // cancel while the second is still in flight would be wrongly dropped as idle.
+    let releaseFirst!: () => void
+    let firstStarted = false
+    const base = fakeProvisioner({
+      provisionR: vi
+        .fn()
+        .mockImplementationOnce(
+          () =>
+            new Promise<void>((resolve) => {
+              firstStarted = true
+              releaseFirst = resolve
+            })
+        )
+        .mockImplementation(() => new Promise<void>(() => {})) // second stays pending
+    })
+    const wrapped = serializeProvisioner(base)
+
+    const first = wrapped.provisionR(() => {}) // running
+    void wrapped.provisionR(() => {}) // second queued (count = 2)
+    await vi.waitFor(() => expect(firstStarted).toBe(true))
+
+    releaseFirst() // first settles -> count drops to 1, NOT 0
+    await first
+    wrapped.cancel('r') // second still pending -> must still forward
+    expect(base.cancel).toHaveBeenCalledWith('r')
+  })
+
+  it('UI provision awaits recovery BEFORE touching a prefix (barrier)', async () => {
+    // A UI-triggered provision must wait for crash recovery to finish reconciling, or recovery's prefix
+    // cleanup could race the rebuild the user just started.
+    const order: string[] = []
+    const provisioner = fakeProvisioner({
+      provisionPython: vi.fn().mockImplementation(async () => {
+        order.push('provision')
+      })
+    })
+    const waitForRecovery = vi.fn().mockImplementation(async () => {
+      await Promise.resolve()
+      order.push('recovery')
+    })
+    const lifecycle = createLifecycle(provisioner, { waitForRecovery })
+    await lifecycle.provision('python')
+    expect(waitForRecovery).toHaveBeenCalledOnce()
+    expect(order).toEqual(['recovery', 'provision'])
+  })
+
+  it('UI repair awaits recovery BEFORE touching a prefix (barrier)', async () => {
+    const order: string[] = []
+    const provisioner = fakeProvisioner({
+      repair: vi.fn().mockImplementation(async () => {
+        order.push('repair')
+      })
+    })
+    const waitForRecovery = vi.fn().mockImplementation(async () => {
+      await Promise.resolve()
+      order.push('recovery')
+    })
+    const lifecycle = createLifecycle(provisioner, { waitForRecovery })
+    await lifecycle.repair('python')
+    expect(order).toEqual(['recovery', 'repair'])
+  })
+
+  it('UI provision refuses when the default env is recovery-blocked (but repair is the recovery)', async () => {
+    // After recovery leaves the default prefix blocked (an unknown-liveness orphan may still hold it),
+    // a UI PROVISION must refuse rather than materialize over it. REPAIR is the explicit Reset/recovery
+    // — it deliberately bypasses that gate (force-clears the quarantine), so it must NOT refuse.
+    const provisioner = fakeProvisioner()
+    const assertProvisionAllowed = vi.fn((lang: string) => {
+      if (lang === 'python') throw new Error('RUNTIME_RECOVERY_BLOCKED: python is recovering')
+    })
+    const lifecycle = createLifecycle(provisioner, {
+      waitForRecovery: async () => undefined,
+      assertProvisionAllowed
+    })
+
+    await expect(lifecycle.provision('python')).rejects.toThrow(/RUNTIME_RECOVERY_BLOCKED/)
+    expect(provisioner.provisionPython).not.toHaveBeenCalled()
+
+    // Repair (the Reset entry) proceeds — it's the recovery, so it force-clears rather than refusing.
+    await lifecycle.repair('python')
+    expect(provisioner.repair).toHaveBeenCalledWith('python', expect.any(Function), { force: true })
+
+    // A non-blocked language still provisions.
+    await lifecycle.provision('r')
+    expect(provisioner.provisionR).toHaveBeenCalledOnce()
+  })
+
+  it('serializes concurrent provisioning calls so a second call does not start a conflicting run', async () => {
+    let resolveFirst: (() => void) | undefined
+    const started: string[] = []
+    const provisioner = fakeProvisioner({
+      provisionPython: vi.fn().mockImplementation(async () => {
+        started.push('python')
+        await new Promise<void>((resolve) => {
+          resolveFirst = resolve
+        })
+      }),
+      provisionR: vi.fn().mockImplementation(async () => {
+        started.push('r')
+      })
+    })
+    const lifecycle = createLifecycle(provisioner)
+
+    const first = lifecycle.provision('python')
+    // Second call fires while the first is still in flight (before resolveFirst is called).
+    const second = lifecycle.provision('r')
+
+    // The second call must not start provisionR until the first finishes.
+    await Promise.resolve()
+    await Promise.resolve()
+    expect(started).toEqual(['python'])
+    expect(provisioner.provisionR).not.toHaveBeenCalled()
+
+    resolveFirst?.()
+    await Promise.all([first, second])
+
+    expect(started).toEqual(['python', 'r'])
+    expect(provisioner.provisionPython).toHaveBeenCalledOnce()
+    expect(provisioner.provisionR).toHaveBeenCalledOnce()
+  })
+
+  it('serializes provision and repair calls against each other', async () => {
+    let resolveFirst: (() => void) | undefined
+    const started: string[] = []
+    const provisioner = fakeProvisioner({
+      provisionPython: vi.fn().mockImplementation(async () => {
+        started.push('provision-python')
+        await new Promise<void>((resolve) => {
+          resolveFirst = resolve
+        })
+      }),
+      repair: vi.fn().mockImplementation(async () => {
+        started.push('repair')
+      })
+    })
+    const lifecycle = createLifecycle(provisioner)
+
+    const first = lifecycle.provision('python')
+    const second = lifecycle.repair('python')
+
+    await Promise.resolve()
+    await Promise.resolve()
+    expect(started).toEqual(['provision-python'])
+    expect(provisioner.repair).not.toHaveBeenCalled()
+
+    resolveFirst?.()
+    await Promise.all([first, second])
+
+    expect(started).toEqual(['provision-python', 'repair'])
+  })
+})
+
+describe('environment lifecycle command projection', () => {
+  beforeEach(() => {
+    loggerSpies.info.mockReset()
+    loggerSpies.error.mockReset()
+  })
+
+  it('keeps every command available with stable results when the backend is unavailable', async () => {
+    const lifecycle = createLifecycle(undefined)
+    const status = await lifecycle.status()
+    expect(status).toMatchObject({ pythonReady: false, rReady: false, provisioning: false })
+    await expect(lifecycle.provision('python')).rejects.toThrow(/micromamba/i)
+    await expect(lifecycle.repair('python')).rejects.toThrow(/micromamba/i)
+    expect(lifecycle.cancel('python')).toBeUndefined()
+    await expect(lifecycle.startup()).resolves.toBeUndefined()
+  })
+
+  it('logs unavailable operations with the same structured command context', async () => {
+    const lifecycle = createLifecycle(undefined, { root: '/unavailable-runtime' })
+
+    await expect(lifecycle.provision('python')).rejects.toThrow(/micromamba/i)
+
+    expect(loggerSpies.info).toHaveBeenCalledWith(
+      'runtime operation started',
+      expect.objectContaining({
+        operation: 'provision',
+        language: 'python',
+        root: '/unavailable-runtime',
+        operationId: expect.any(String)
+      })
+    )
+    expect(loggerSpies.error).toHaveBeenCalledWith(
+      'runtime operation failed',
+      expect.objectContaining({
+        operation: 'provision',
+        language: 'python',
+        root: '/unavailable-runtime',
+        durationMs: expect.any(Number),
+        error: expect.stringMatching(/micromamba/i)
+      })
+    )
+  })
+
+  it('projects the requested language scope for provision and repair', async () => {
+    const projected: ProvisionProgress[] = []
+    const provisioner = fakeProvisioner({
+      provisionR: vi.fn().mockImplementation(async (report: (p: ProvisionProgress) => void) => {
+        report({ phase: 'fetch-r', message: 'Downloading R', progress: 0.4 })
+      }),
+      repair: vi.fn().mockImplementation(async (_lang, report) => {
+        report({ phase: 'repair', message: 'Repairing Python', progress: 0.2 })
+      })
+    })
+    const lifecycle = createLifecycle(provisioner, {
+      projectProgress: (progress) => projected.push(progress)
+    })
+
+    await lifecycle.provision('r')
+    await lifecycle.repair('python')
+
+    expect(projected).toEqual([
+      { phase: 'fetch-r', message: 'Downloading R', progress: 0.4, scope: 'r' },
+      { phase: 'repair', message: 'Repairing Python', progress: 0.2, scope: 'python' }
+    ])
+  })
+
+  it('logs a provision failure with diagnostics and rethrows the original error', async () => {
+    const failure = Object.assign(new Error('micromamba timed out after 600000ms'), {
+      code: 'MICROMAMBA_TIMEOUT',
+      data: { timeoutMs: 600_000, offline: true }
+    })
+    const provisioner = fakeProvisioner({
+      provisionPython: vi.fn().mockRejectedValue(failure)
+    })
+    const lifecycle = createLifecycle(provisioner, {
+      root: 'F:\\openScience\\data\\OpenScience\\runtime'
+    })
+
+    await expect(lifecycle.provision('python')).rejects.toBe(failure)
+
+    expect(loggerSpies.error).toHaveBeenCalledOnce()
+    const [message, fields] = loggerSpies.error.mock.calls[0] as [string, Record<string, unknown>]
+    expect(message).toBe('runtime operation failed')
+    expect(fields).toMatchObject({
+      operation: 'provision',
+      language: 'python',
+      root: 'F:\\openScience\\data\\OpenScience\\runtime',
+      error: 'micromamba timed out after 600000ms',
+      code: 'MICROMAMBA_TIMEOUT',
+      data: { timeoutMs: 600_000, offline: true }
+    })
+    expect(fields.operationId).toEqual(expect.any(String))
+    expect(fields.durationMs).toEqual(expect.any(Number))
+  })
+
+  it('redacts credentials from persisted runtime diagnostics without changing the thrown error', async () => {
+    const channel = 'https://user:basic-secret@example.com/t/path-secret/conda?token=query-secret'
+    const failure = Object.assign(new Error(`micromamba timed out (${channel})`), {
+      code: 'MICROMAMBA_TIMEOUT',
+      data: {
+        argv: ['micromamba', '-c', channel],
+        stderrTail: 'api_key=stderr-secret',
+        stdoutTail: 'Bearer stdout-secret'
+      }
+    })
+    const provisioner = fakeProvisioner({
+      provisionPython: vi
+        .fn()
+        .mockImplementation(async (report: (p: ProvisionProgress) => void) => {
+          report({ phase: 'fetch-python', message: `Retrying ${channel}`, progress: 0.1 })
+          throw failure
+        })
+    })
+    const lifecycle = createLifecycle(provisioner)
+
+    await expect(lifecycle.provision('python')).rejects.toBe(failure)
+
+    const persisted = JSON.stringify({
+      info: loggerSpies.info.mock.calls,
+      error: loggerSpies.error.mock.calls
+    })
+    for (const secret of [
+      'basic-secret',
+      'path-secret',
+      'query-secret',
+      'stderr-secret',
+      'stdout-secret'
+    ]) {
+      expect(persisted).not.toContain(secret)
+    }
+    expect(persisted).toContain('[redacted]')
+    expect(failure.message).toContain('basic-secret')
+  })
+
+  it('logs operation lifecycle and phase changes without logging every download chunk', async () => {
+    const provisioner = fakeProvisioner({
+      provisionPython: vi
+        .fn()
+        .mockImplementation(async (report: (p: ProvisionProgress) => void) => {
+          report({ phase: 'fetch-python', message: 'Downloading Python (10%)', progress: 0.1 })
+          report({ phase: 'fetch-python', message: 'Downloading Python (20%)', progress: 0.2 })
+          report({
+            phase: 'fetch-python',
+            message: 'Downloading Python (resuming…)',
+            progress: 0.2,
+            download: {
+              phase: 'reconnecting',
+              transferred: 20,
+              total: 100,
+              percent: 20,
+              bytesPerSecond: 0,
+              attempt: 1
+            }
+          })
+          report({ phase: 'create-python', message: 'Creating Python', progress: 0.45 })
+        })
+    })
+    const lifecycle = createLifecycle(provisioner)
+
+    await lifecycle.provision('python')
+
+    expect(loggerSpies.info.mock.calls.map(([message]) => message)).toEqual([
+      'runtime operation started',
+      'runtime operation progress',
+      'runtime operation progress',
+      'runtime operation progress',
+      'runtime operation completed'
+    ])
+    const progressFields = loggerSpies.info.mock.calls
+      .filter(([message]) => message === 'runtime operation progress')
+      .map(([, fields]) => fields as Record<string, unknown>)
+    expect(progressFields).toMatchObject([
+      { phase: 'fetch-python', message: 'Downloading Python (10%)' },
+      {
+        phase: 'fetch-python',
+        message: 'Downloading Python (resuming…)',
+        download: { phase: 'reconnecting', attempt: 1, transferred: 20, total: 100 }
+      },
+      { phase: 'create-python', message: 'Creating Python' }
+    ])
+    const operationIds = new Set(
+      loggerSpies.info.mock.calls.map(
+        ([, fields]) => (fields as { operationId: string }).operationId
+      )
+    )
+    expect(operationIds.size).toBe(1)
+  })
+})
+
+describe('environment lifecycle startup', () => {
+  it('does not mutate runtime storage while a data-root migration is pending', async () => {
+    const provisioner = fakeProvisioner()
+    const dir = mkdtempSync(join(tmpdir(), 'os-gate-migration-'))
+    const broadcast = vi.fn()
+    beginMigration()
+
+    await startLifecycle(provisioner, dir, broadcast)
+
+    expect(provisioner.restoreRelocatedEnvs).not.toHaveBeenCalled()
+    expect(broadcast).toHaveBeenCalledWith(
+      expect.objectContaining({
+        phase: 'error',
+        message: expect.stringMatching(/moving your data/i)
+      })
+    )
+  })
+
+  it('is detect-only on a fresh empty root: restores relocated envs but does not provision python', async () => {
+    const provisioner = fakeProvisioner()
+    const dir = mkdtempSync(join(tmpdir(), 'os-gate-'))
+    await startLifecycle(provisioner, dir)
+    // Fresh envs are built lazily on first notebook use, not eagerly here.
+    expect(provisioner.provisionPython).not.toHaveBeenCalled()
+    expect(provisioner.upgradeIfNeeded).not.toHaveBeenCalled()
+    expect(provisioner.repair).not.toHaveBeenCalled()
+    // restoreRelocatedEnvs still runs (needed for data-root relocations).
+    expect(provisioner.restoreRelocatedEnvs).toHaveBeenCalledOnce()
+  })
+
+  it('does nothing when already ready', async () => {
+    const { writeReadyMarker, envPrefix, pythonBin, DEFAULT_ENV_VERSION, DEFAULT_PY_ENV } =
+      await import('./runtime-paths')
+    const dir = mkdtempSync(join(tmpdir(), 'os-gate2-'))
+    const bin = pythonBin(envPrefix(dir, DEFAULT_PY_ENV))
+    mkdirSync(join(bin, '..'), { recursive: true })
+    writeFileSync(bin, 'x')
+    writeReadyMarker(dir, DEFAULT_ENV_VERSION, 't')
+    const provisioner = fakeProvisioner()
+    await startLifecycle(provisioner, dir)
+    expect(provisioner.provisionPython).not.toHaveBeenCalled()
+    expect(provisioner.upgradeIfNeeded).not.toHaveBeenCalled()
+    expect(provisioner.repair).not.toHaveBeenCalled()
+  })
+
+  it('upgrades when an older-version marker with an existing python bin is found', async () => {
+    const { writeReadyMarker, envPrefix, pythonBin, DEFAULT_PY_ENV } =
+      await import('./runtime-paths')
+    const dir = mkdtempSync(join(tmpdir(), 'os-gate3-'))
+    const bin = pythonBin(envPrefix(dir, DEFAULT_PY_ENV))
+    mkdirSync(join(bin, '..'), { recursive: true })
+    writeFileSync(bin, 'x')
+    writeReadyMarker(dir, 0, 't')
+    const provisioner = fakeProvisioner()
+    await startLifecycle(provisioner, dir)
+    expect(provisioner.upgradeIfNeeded).toHaveBeenCalledOnce()
+    expect(provisioner.provisionPython).not.toHaveBeenCalled()
+    expect(provisioner.repair).not.toHaveBeenCalled()
+  })
+
+  it('repairs when a marker exists but the python bin is missing', async () => {
+    const { writeReadyMarker } = await import('./runtime-paths')
+    const dir = mkdtempSync(join(tmpdir(), 'os-gate4-'))
+    writeReadyMarker(dir, 0, 't')
+    const provisioner = fakeProvisioner()
+    await startLifecycle(provisioner, dir)
+    expect(provisioner.repair).toHaveBeenCalledWith('python', expect.any(Function), undefined)
+    expect(provisioner.provisionPython).not.toHaveBeenCalled()
+    expect(provisioner.upgradeIfNeeded).not.toHaveBeenCalled()
+  })
+
+  it('never provisions R at startup', async () => {
+    const provisioner = fakeProvisioner()
+    const dir = mkdtempSync(join(tmpdir(), 'os-gate5-'))
+    await startLifecycle(provisioner, dir)
+    expect(provisioner.provisionR).not.toHaveBeenCalled()
+  })
+
+  it('does NOT eagerly repair Python for an R-first user (residual default-r, no marker, no python)', async () => {
+    // A user who ran R first has a lazily-built default-r dir but no Python and no ready marker
+    // (provisionR never writes it). needsRepair keys off the residual default-r, so the action is
+    // 'repair' — but there is no Python to repair, so startup must stay detect-only (no eager DL).
+    const { rBin, envPrefix, DEFAULT_R_ENV } = await import('./runtime-paths')
+    const dir = mkdtempSync(join(tmpdir(), 'os-gate-rfirst-'))
+    const rbin = rBin(envPrefix(dir, DEFAULT_R_ENV))
+    mkdirSync(join(rbin, '..'), { recursive: true })
+    writeFileSync(rbin, 'x')
+    const provisioner = fakeProvisioner()
+    await startLifecycle(provisioner, dir)
+    expect(provisioner.repair).not.toHaveBeenCalled()
+    expect(provisioner.provisionPython).not.toHaveBeenCalled()
+  })
+
+  it('reports failure via broadcast instead of throwing', async () => {
+    // restoreRelocatedEnvs always runs, so failing it exercises the gate's try/catch on a fresh root.
+    const provisioner = fakeProvisioner({
+      restoreRelocatedEnvs: vi.fn().mockRejectedValue(new Error('boom'))
+    })
+    const dir = mkdtempSync(join(tmpdir(), 'os-gate6-'))
+    const broadcast = vi.fn()
+    await expect(startLifecycle(provisioner, dir, broadcast)).resolves.toBeUndefined()
+    expect(broadcast).toHaveBeenCalledWith(
+      expect.objectContaining({ phase: 'error', message: expect.stringContaining('boom') })
+    )
+  })
+
+  it('logs the FULL micromamba diagnostics (data tails) even though it broadcasts only the short message', async () => {
+    // This automatic path has no per-op logging, so the gate itself must record the structured
+    // `error.data` tails. Otherwise a launch-time failure leaves only a truncated UI excerpt and the
+    // real micromamba output never crosses the main-process boundary (regression the reviewers flagged).
+    loggerSpies.error.mockReset()
+    const micromambaError = Object.assign(
+      new Error('micromamba failed (exit 1; mm create): …tail-excerpt'),
+      {
+        code: 'MICROMAMBA_EXIT',
+        data: { argv: ['mm', 'create'], exitCode: 1, stderrTail: 'Invalid package cache signature' }
+      }
+    )
+    const provisioner = fakeProvisioner({
+      restoreRelocatedEnvs: vi.fn().mockRejectedValue(micromambaError)
+    })
+    const dir = mkdtempSync(join(tmpdir(), 'os-gate-log-'))
+    await startLifecycle(provisioner, dir, vi.fn())
+
+    expect(loggerSpies.error).toHaveBeenCalledOnce()
+    const [, fields] = loggerSpies.error.mock.calls[0] as [string, Record<string, unknown>]
+    // errorLogFields lifts the error's own `data`/`code` keys, so the tails are present in the log.
+    expect(fields.code).toBe('MICROMAMBA_EXIT')
+    expect(JSON.stringify(fields)).toContain('Invalid package cache signature')
+  })
+
+  it('refuses to rebuild over a recovery-blocked prefix through the REAL provisioner self-guard', async () => {
+    // The startup gate drives repair/upgrade/restore through the provisioner, so the block guarantee
+    // must survive that real path — not just a mock guard on the UI handlers. Wire a real
+    // DefaultRuntimeProvisioner with the isPrefixBlocked dep ipc.ts injects (← isPrefixRecoveryBlocked),
+    // set up a marker-but-no-bin state so the planner picks 'repair', and assert the gate refuses:
+    // nothing is spawned, the (possibly-live) prefix is not deleted, and the error is broadcast.
+    const { writeReadyMarker, envPrefix, DEFAULT_PY_ENV } = await import('./runtime-paths')
+    const { DefaultRuntimeProvisioner } = await import('./provisioner')
+    const dir = mkdtempSync(join(tmpdir(), 'os-gate-blocked-'))
+    const prefix = envPrefix(dir, DEFAULT_PY_ENV)
+    mkdirSync(prefix, { recursive: true }) // a partial prefix an orphan may still be writing
+    writeReadyMarker(dir, 0, 't') // marker present + no bin => planStartupAction === 'repair'
+
+    const runArgv = vi.fn().mockResolvedValue(undefined)
+    const provisioner = new DefaultRuntimeProvisioner({
+      root: dir,
+      mm: '/mm',
+      channel: 'conda-forge',
+      fetchBundle: async (spec) => ({ lockPath: join(dir, `${spec.name}.lock`) }),
+      runArgv,
+      verify: async () => undefined,
+      isPrefixBlocked: (p) => p === prefix
+    })
+    const broadcast = vi.fn()
+    await startLifecycle(provisioner, dir, broadcast)
+
+    expect(runArgv).not.toHaveBeenCalled() // no rebuild spawned
+    expect(existsSync(prefix)).toBe(true) // prefix not rm -rf'd out from under a possible survivor
+    expect(broadcast).toHaveBeenCalledWith(
+      expect.objectContaining({
+        phase: 'error',
+        message: expect.stringMatching(/RUNTIME_RECOVERY_BLOCKED/)
+      })
+    )
+  })
+
+  it('awaits recovery BEFORE touching any prefix (restore/upgrade/repair)', async () => {
+    // The barrier must resolve before the gate's first prefix op, or recovery's cleanup could race a
+    // rebuild. Use an existing-but-stale marker so the gate would call upgradeIfNeeded, and assert
+    // recovery settled first.
+    const { writeReadyMarker, envPrefix, pythonBin, DEFAULT_PY_ENV } =
+      await import('./runtime-paths')
+    const dir = mkdtempSync(join(tmpdir(), 'os-gate-barrier-'))
+    const bin = pythonBin(envPrefix(dir, DEFAULT_PY_ENV))
+    mkdirSync(join(bin, '..'), { recursive: true })
+    writeFileSync(bin, 'x')
+    writeReadyMarker(dir, 0, 't')
+
+    const order: string[] = []
+    const provisioner = fakeProvisioner({
+      restoreRelocatedEnvs: vi.fn().mockImplementation(async () => {
+        order.push('restore')
+      }),
+      upgradeIfNeeded: vi.fn().mockImplementation(async () => {
+        order.push('upgrade')
+      })
+    })
+    let recovered = false
+    const waitForRecovery = vi.fn().mockImplementation(async () => {
+      await Promise.resolve()
+      recovered = true
+      order.push('recovery')
+    })
+
+    await startLifecycle(provisioner, dir, () => undefined, waitForRecovery)
+
+    expect(waitForRecovery).toHaveBeenCalledOnce()
+    // Recovery ran, and it ran before ANY provisioner prefix op.
+    expect(recovered).toBe(true)
+    expect(order[0]).toBe('recovery')
+    expect(order).toEqual(['recovery', 'restore', 'upgrade'])
+  })
+})

--- a/src/main/notebook/environment-lifecycle-workflows.ts
+++ b/src/main/notebook/environment-lifecycle-workflows.ts
@@ -1,0 +1,151 @@
+import { existsSync } from 'node:fs'
+
+import type { NotebookLanguage } from '../../shared/notebook'
+import { withDataRootWrite } from '../storage/migration-state'
+import {
+  logStartupGateFailure,
+  runLoggedRuntimeOperation,
+  serializeProvisioner
+} from './environment-operation-foundation'
+import {
+  planStartupAction,
+  type ProvisionProgress,
+  type ProvisionStatus,
+  type RuntimeProvisioner
+} from './provisioner'
+import { DEFAULT_ENV_VERSION, DEFAULT_PY_ENV, envPrefix, readReadyMarker } from './runtime-paths'
+
+type NotebookEnvironmentLifecycle = {
+  status: () => Promise<ProvisionStatus>
+  provision: (language: NotebookLanguage) => Promise<void>
+  repair: (language: NotebookLanguage) => Promise<void>
+  cancel: (language?: NotebookLanguage) => void
+  startup: () => Promise<void>
+}
+
+type NotebookEnvironmentLifecycleDeps = {
+  provisioner: RuntimeProvisioner | undefined
+  root: string
+  projectProgress: (progress: ProvisionProgress) => void
+  waitForRecovery?: () => Promise<void>
+  assertProvisionAllowed?: (language: NotebookLanguage) => void
+  onRepairCompleted?: (language: NotebookLanguage) => Promise<void> | void
+}
+
+const RUNTIME_UNAVAILABLE_MESSAGE =
+  'The notebook runtime is unavailable: micromamba was not found. In a packaged build it ships with the app; for development, set OPEN_SCIENCE_MICROMAMBA_BIN to a micromamba binary and restart.'
+
+const runUnavailableOperation = (
+  deps: NotebookEnvironmentLifecycleDeps,
+  operation: 'provision' | 'repair',
+  language: NotebookLanguage
+): Promise<void> =>
+  runLoggedRuntimeOperation(
+    operation,
+    language,
+    deps.root,
+    () => Promise.reject(new Error(RUNTIME_UNAVAILABLE_MESSAGE)),
+    () => undefined
+  )
+
+const createUnavailableLifecycle = (
+  deps: NotebookEnvironmentLifecycleDeps
+): NotebookEnvironmentLifecycle => ({
+  status: () =>
+    Promise.resolve({
+      pythonReady: false,
+      rReady: false,
+      version: DEFAULT_ENV_VERSION,
+      provisioning: false
+    }),
+  provision: (language) => runUnavailableOperation(deps, 'provision', language),
+  repair: (language) => runUnavailableOperation(deps, 'repair', language),
+  cancel: () => undefined,
+  startup: () => Promise.resolve()
+})
+
+const createNotebookEnvironmentLifecycle = (
+  deps: NotebookEnvironmentLifecycleDeps
+): NotebookEnvironmentLifecycle => {
+  if (!deps.provisioner) return createUnavailableLifecycle(deps)
+
+  const provisioner = serializeProvisioner(deps.provisioner)
+
+  const status = (): Promise<ProvisionStatus> =>
+    withDataRootWrite(async () => {
+      if (deps.waitForRecovery) await deps.waitForRecovery()
+      return provisioner.status()
+    })
+
+  const provision = (language: NotebookLanguage): Promise<void> =>
+    runLoggedRuntimeOperation(
+      'provision',
+      language,
+      deps.root,
+      (report) =>
+        withDataRootWrite(async () => {
+          if (deps.waitForRecovery) await deps.waitForRecovery()
+          deps.assertProvisionAllowed?.(language)
+          await (language === 'r'
+            ? provisioner.provisionR(report)
+            : provisioner.provisionPython(report))
+        }),
+      (progress) => deps.projectProgress({ ...progress, scope: language })
+    )
+
+  const repair = (language: NotebookLanguage): Promise<void> =>
+    runLoggedRuntimeOperation(
+      'repair',
+      language,
+      deps.root,
+      (report) =>
+        withDataRootWrite(async () => {
+          if (deps.waitForRecovery) await deps.waitForRecovery()
+          await provisioner.repair(language, report, { force: true })
+          await deps.onRepairCompleted?.(language)
+        }),
+      (progress) => deps.projectProgress({ ...progress, scope: language })
+    )
+
+  const startup = async (): Promise<void> => {
+    try {
+      await withDataRootWrite(async () => {
+        if (deps.waitForRecovery) await deps.waitForRecovery()
+        await provisioner.restoreRelocatedEnvs(deps.projectProgress)
+
+        const action = planStartupAction(deps.root, DEFAULT_ENV_VERSION)
+        if (action === 'ready') return
+        if (action === 'upgrade') {
+          await provisioner.upgradeIfNeeded(deps.projectProgress)
+          return
+        }
+        if (action !== 'repair') return
+
+        // A residual default-r prefix makes the planner report repair even for an R-first user. Only
+        // maintain Python eagerly when it was actually provisioned before; fresh Python stays lazy.
+        const pythonWasProvisioned =
+          readReadyMarker(deps.root) !== undefined ||
+          existsSync(envPrefix(deps.root, DEFAULT_PY_ENV))
+        if (pythonWasProvisioned) await provisioner.repair('python', deps.projectProgress)
+      })
+    } catch (error) {
+      logStartupGateFailure(error)
+      deps.projectProgress({
+        phase: 'error',
+        message: `Environment preparation failed: ${(error as Error).message}`,
+        progress: 0
+      })
+    }
+  }
+
+  return {
+    status,
+    provision,
+    repair,
+    cancel: (language) => provisioner.cancel(language),
+    startup
+  }
+}
+
+export { createNotebookEnvironmentLifecycle }
+export type { NotebookEnvironmentLifecycle, NotebookEnvironmentLifecycleDeps }


### PR DESCRIPTION
## Problem

Notebook environment status, provision, repair, cancel, and startup maintenance were embedded in `env-ipc.ts` beside Electron window projection and channel registration. This left recovery ordering, write leases, startup planning, unavailable behavior, and command progress without a narrow application owner.

The original combined N7c extraction measured 707 production changed lines and crossed the 700 hard stop. N7c1 therefore landed the shared operation foundation first; N7c2 now extracts only the five-command lifecycle and its Electron adapter.

## Proposed change

Introduce `environment-lifecycle-workflows.ts` with an Electron-independent five-command interface, and reduce `env-ipc.ts` to stable channel registration plus direct BrowserWindow progress projection.

```mermaid
flowchart LR
  E["Electron / local Web invoke"] --> A["env-ipc adapter"]
  A --> L["Environment lifecycle"]
  L --> F["N7c1 operation foundation"]
  L --> W["Data-root write lease + recovery"]
  L --> P["RuntimeProvisioner"]
  L --> G["Startup restore / plan / maintain"]
  A --> B["Live BrowserWindow progress only"]
```

The workflow owns:

- authoritative status after the recovery barrier;
- provision guard and Python/R dispatch;
- force repair and verified `onRepairCompleted` handoff;
- synchronous cancel delegation over the N7c1 pending-operation foundation;
- startup restore, ready/upgrade/conditional Python repair, fresh-root and R-first detect-only behavior;
- stable unavailable results and scoped command progress.

The adapter owns exactly four channels and fire-and-forget startup:

- `notebook-env:status`
- `notebook-env:provision`
- `notebook-env:repair`
- `notebook-env:cancel`

## Compatibility and non-goals

| Surface | Preserved behavior |
|---|---|
| Electron | Four invoke channels; progress sent directly to live BrowserWindows |
| local Web | Existing four RPC methods; mutations remain allowed |
| remote Web | Status remains readable; provision/repair/cancel remain denied with 403 |
| Web progress | Dormant contract remains dormant; no ApplicationEventHub projection |
| CLI / Task / local RPC | No direct environment lifecycle API added |
| Specialist / Permission / Compute | Existing logic and capability asymmetry unchanged |

No main composition, preload, generated Web map, HTTP policy, renderer, persisted data, data relationship, UI, or public interaction changes. Issue #458 receives no orchestration state or public interface in this PR.

## Commit and size

1. `refactor(notebook): extract environment lifecycle workflows`

Commit `be81f1a` changes four Notebook files. Production churn is exactly 380 (`env-ipc.ts` 229 plus the new workflow 151), at but not above the brief hard stop. The existing behavior suite moves to its new owner with 33 tests retained; one unavailable-diagnostics regression was added, and three narrow adapter tests cover exact channels, live/destroyed windows, synchronous cancel, and startup.

## Acceptance criteria and validation

Branch head `be81f1a` is based on `origin/main` `ef8de2b`, ahead/behind `1/0`, with a clean worktree.

- Test-first extraction -> RED failed on the absent workflow module; GREEN passed 2 files / 36 tests.
- Queue/lifecycle/adapter regression -> 3 files / 40 tests passed after closing a Standards P2 about unresolved test operations and the Codex P2 about unavailable operation diagnostics.
- Notebook/IPC/preload/Web capability matrix -> 14 files / 430 tests passed; the Web HTTP suite passed 15/15 outside the sandbox that blocks local listening.
- Latest-main application/shutdown/search delta -> 6 files / 110 tests passed.
- Full regression after the Codex fix -> `npm test` outside the sandbox passed 693 files / 10,117 tests; 15 files / 184 tests skipped.
- Final-base Bailian provider delta plus core -> 6 files / 127 tests passed after rebase.
- Final Compute/Specialist UI delta plus core -> 4 files / 65 tests passed after the last rebase.
- Notebook package-listing/runtime-selection/runtime-IPC/preload/Web-map/UI delta plus core -> 10 files / 180 tests passed.
- Final local-file/main-IPC/preload/Web-HTTP/UI delta plus core -> 13 files / 290 tests passed after the final rebase.
- Compile and static policy -> Node/Web typecheck passed; repository lint 0 errors with 18 unrelated existing warnings; changed-file ESLint 0 warnings; `git diff --check` passed.
- Independent review after the Codex diagnostics P2 fix -> Spec: 0 findings; Standards: 0 findings.

The named pre-rebase stash remains only as a recoverable backup and is not part of the commit.

## Review focus

- Confirm lifecycle ownership stops before Electron, Web, CLI, Task, and local-RPC transport policy.
- Confirm `withDataRootWrite` contains recovery plus each prefix mutation in the original order.
- Confirm repair remains forceful and calls `onRepairCompleted` only after a verified rebuild.
- Confirm startup restores before planning, never eagerly provisions fresh Python or R, and repairs Python only when it existed before.
- Confirm progress stays Electron-only and remote Web mutation denial is unchanged.

## Residual risk

No live micromamba operation or packaged Electron journey was run locally. Focused suites exercise the real provisioner, lease, recovery, IPC registry, preload, and Web policy in-process; exact-head CI remains the merge gate.
