### PR TITLE
test(e2e): harden workspace journey coverage

### DIFF
--- a/e2e/fixtures/electron-app.ts
+++ b/e2e/fixtures/electron-app.ts
@@ -270,7 +270,7 @@ class ElectronAppHarness implements ElectronApp {
   async dispose(): Promise<void> {
     await this.close().catch(() => undefined)
     await makeTreeWritable(this.testRoot)
-    await rm(this.testRoot, { force: true, recursive: true })
+    await rm(this.testRoot, { force: true, maxRetries: 5, recursive: true, retryDelay: 200 })
     this.rendererFailures.assertNoFailures()
   }
 

--- a/e2e/workspace-conversation.spec.ts
+++ b/e2e/workspace-conversation.spec.ts
@@ -4,6 +4,7 @@ import { test } from './fixtures/electron-app'
 
 const PROJECT_NAME = 'Agent journey project'
 const USER_MESSAGE = 'Summarize the deterministic fixture.'
+const EDITED_USER_MESSAGE = 'Summarize the revised deterministic fixture.'
 const AGENT_REPLY = `Deterministic reply: ${USER_MESSAGE}`
 const PERMISSION_PROMPT = 'Request fixture permission.'
 
@@ -15,9 +16,7 @@ const createProject = async (page: Page): Promise<void> => {
   await expect(page.getByRole('heading', { name: 'New conversation' })).toBeVisible()
 }
 
-test('sends a message through ACP and restores the conversation after relaunch', async ({
-  app
-}) => {
+test('edits and navigates message revisions that persist after relaunch', async ({ app }) => {
   let page = await app.completeOnboarding()
   page = await app.configureFakeAgent()
   await createProject(page)
@@ -30,6 +29,34 @@ test('sends a message through ACP and restores the conversation after relaunch',
   await expect(conversation.getByText(USER_MESSAGE, { exact: true })).toBeVisible()
   await expect(conversation.getByText(AGENT_REPLY, { exact: true })).toBeVisible()
 
+  await conversation.getByText(USER_MESSAGE, { exact: true }).hover()
+  await conversation.getByRole('button', { name: 'Edit message' }).click()
+  await conversation.getByRole('textbox', { name: 'Edit message' }).fill(EDITED_USER_MESSAGE)
+  await conversation.getByRole('button', { name: 'Send', exact: true }).click()
+
+  const revision = conversation.getByLabel('Message revision', { exact: true })
+  const previousRevision = conversation.getByRole('button', {
+    name: 'Previous message revision'
+  })
+  const nextRevision = conversation.getByRole('button', { name: 'Next message revision' })
+  await expect(conversation.getByText(EDITED_USER_MESSAGE, { exact: true })).toBeVisible()
+  await expect(revision).toHaveText('2/2')
+  await expect(previousRevision).toBeEnabled()
+  await expect(nextRevision).toBeDisabled()
+
+  await previousRevision.click()
+  await expect(conversation.getByText(USER_MESSAGE, { exact: true })).toBeVisible()
+  await expect(revision).toHaveText('1/2')
+  await expect(previousRevision).toBeDisabled()
+  await expect(nextRevision).toBeEnabled()
+
+  await nextRevision.click()
+  await expect(conversation.getByText(EDITED_USER_MESSAGE, { exact: true })).toBeVisible()
+  await expect(revision).toHaveText('2/2')
+  await previousRevision.click()
+  await expect(conversation.getByText(USER_MESSAGE, { exact: true })).toBeVisible()
+  await expect(revision).toHaveText('1/2')
+
   page = await app.restart()
   await page
     .getByRole('region', { name: 'Recent sessions' })
@@ -38,6 +65,15 @@ test('sends a message through ACP and restores the conversation after relaunch',
   conversation = page.getByRole('region', { name: 'Conversation' })
   await expect(conversation.getByText(USER_MESSAGE, { exact: true })).toBeVisible()
   await expect(conversation.getByText(AGENT_REPLY, { exact: true })).toBeVisible()
+  await expect(conversation.getByLabel('Message revision', { exact: true })).toHaveText('1/2')
+  await expect(
+    conversation.getByRole('button', { name: 'Previous message revision' })
+  ).toBeDisabled()
+  await expect(conversation.getByRole('button', { name: 'Next message revision' })).toBeEnabled()
+
+  await conversation.getByRole('button', { name: 'Next message revision' }).click()
+  await expect(conversation.getByText(EDITED_USER_MESSAGE, { exact: true })).toBeVisible()
+  await expect(conversation.getByLabel('Message revision', { exact: true })).toHaveText('2/2')
 })
 
 test('resolves Agent permission requests through both Allow and Deny decisions', async ({


### PR DESCRIPTION
## Problem

Windows E2E workers can fail during teardown when Chromium briefly keeps the profile `DIPS` file locked. The desktop journey also did not verify that edited message revisions and the selected revision survive an Electron relaunch.

## Proposed change

- Use Node's bounded recursive `rm` retry options for transient Windows profile locks.
- Extend the existing workspace conversation journey to edit a user message, navigate both revisions, relaunch, and verify the active revision is restored.

## Scope and non-goals

This changes only the Playwright fixture and an existing E2E specification. It does not change production code, onboarding, providers, data models, or user interaction.

## Acceptance criteria and validation

- `npm run build:e2e`
- `npm run test:e2e:workspace` — 4/4 passed after rebasing onto current `main`
- `npm run typecheck`
- `npm run lint` — 0 errors; 18 existing warnings outside the changed files
- `npm test` — 692 files and 10,114 tests passed; 184 tests skipped
- Prettier and `git diff --check`

Windows CI remains the final proof for the original `EBUSY` failure mode.

## Review focus

Please focus on whether the retry window remains bounded enough to expose persistent process leaks, and whether the revision journey proves both navigation and relaunch persistence without relying on production-only test APIs.
