### PR TITLE
ci(release): enforce desktop release provenance

### DIFF
--- a/.github/workflows/mirror-to-website.yml
+++ b/.github/workflows/mirror-to-website.yml
@@ -24,7 +24,7 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - name: Checkout (for the manifest script)
-        uses: actions/checkout@v7
+        uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7
 
       # Tag from the Release event, or the manual input; version is the tag without a leading 'v'.
       - name: Resolve tag and version
@@ -45,9 +45,12 @@ jobs:
         run: gh release download "${{ steps.ref.outputs.tag }}" --repo "${{ github.repository }}" --dir dist-assets
 
       - name: Set up Node
-        uses: actions/setup-node@v7
+        uses: actions/setup-node@820762786026740c76f36085b0efc47a31fe5020 # v7
         with:
           node-version: 20
+
+      - name: Install manifest dependencies
+        run: npm ci --ignore-scripts --omit=dev --omit=optional --no-audit --no-fund
 
       # Build version.json from the downloaded files. Missing platforms warn (not fail) inside the
       # script, so a partial release still yields a usable manifest. Notes/date are pulled from the
@@ -69,9 +72,52 @@ jobs:
           export NOTES RELEASE_DATE
           node scripts/generate-version-manifest.mjs
 
-      # Credentials + region for aws-cli. The region alone lets aws-cli resolve the correct AWS S3
-      # endpoint on its own — do NOT pass --endpoint-url: a bucket/website-style endpoint there makes
-      # ListObjectsV2 return NoSuchKey and breaks the sync.
+      # electron-updater feed files (win latest.yml, linux latest-linux.yml, and the per-arch mac
+      # feeds arm64-mac.yml / x64-mac.yml) must live at the channel root (a stable url the updater
+      # always polls), but the installers + blockmaps they reference live under releases/<version>/.
+      # Rewrite each feed's bare `path:`/`url:` filenames to that versioned subpath so the updater
+      # resolves them against the channel root. Missing feeds (e.g. a mac-only backfill) are skipped.
+      - name: Rewrite update feed paths
+        env:
+          VERSION: ${{ steps.ref.outputs.version }}
+        run: |
+          shopt -s nullglob
+          for yml in dist-assets/latest.yml dist-assets/latest-linux.yml dist-assets/*-mac.yml; do
+            [ -f "$yml" ] || continue
+            node -e '
+              const fs = require("fs");
+              const file = process.argv[1];
+              const version = process.env.VERSION;
+              const text = fs.readFileSync(file, "utf8").replace(
+                /^(\s*(?:- )?(?:path|url):\s*)(?!https?:|releases\/)([^\s].*)$/gm,
+                (_m, prefix, name) => `${prefix}releases/${version}/${name}`
+              );
+              fs.writeFileSync(file, text);
+              process.stdout.write(text);
+            ' "$yml"
+          done
+
+      # electron-builder never writes releaseNotes into the feeds, so already-installed clients (which
+      # read update notes only from the feed) show an empty "What's new" and only a GitHub link. Inject
+      # the same condensed notes version.json carries into each feed's releaseNotes. inject-feed-notes
+      # parses + re-serializes with js-yaml (never hand-writes YAML) and re-parses its own output, so a
+      # malformed feed fails the job here — before any upload — rather than reaching the installed base.
+      # js-yaml comes from the committed lockfile installed above with package scripts disabled.
+      - name: Inject release notes into update feeds
+        run: |
+          shopt -s nullglob
+          feeds=()
+          for yml in dist-assets/latest.yml dist-assets/latest-linux.yml dist-assets/*-mac.yml; do
+            [ -f "$yml" ] && feeds+=("$yml")
+          done
+          if [ ${#feeds[@]} -eq 0 ]; then
+            echo "no update feeds present, skipping notes injection"
+            exit 0
+          fi
+          node scripts/inject-feed-notes.mjs version.json "${feeds[@]}"
+
+      # Credentials + region are configured only after dependency installation and every local
+      # manifest/feed transformation succeeds. The region lets aws-cli resolve the S3 endpoint.
       - name: Configure AWS credentials
         env:
           S3_ACCESS_KEY_ID: ${{ secrets.S3_ACCESS_KEY_ID }}
@@ -107,52 +153,6 @@ jobs:
           aws s3 cp version.json \
             "s3://$S3_BUCKET/$S3_PREFIX/version.json" \
             --cache-control "no-cache" --content-type "application/json" --only-show-errors
-
-      # electron-updater feed files (win latest.yml, linux latest-linux.yml, and the per-arch mac
-      # feeds arm64-mac.yml / x64-mac.yml) must live at the channel root (a stable url the updater
-      # always polls), but the installers + blockmaps they reference live under releases/<version>/.
-      # Rewrite each feed's bare `path:`/`url:` filenames to that versioned subpath so the updater
-      # resolves them against the channel root. Missing feeds (e.g. a mac-only backfill) are skipped.
-      - name: Rewrite update feed paths
-        env:
-          VERSION: ${{ steps.ref.outputs.version }}
-        run: |
-          shopt -s nullglob
-          for yml in dist-assets/latest.yml dist-assets/latest-linux.yml dist-assets/*-mac.yml; do
-            [ -f "$yml" ] || continue
-            node -e '
-              const fs = require("fs");
-              const file = process.argv[1];
-              const version = process.env.VERSION;
-              const text = fs.readFileSync(file, "utf8").replace(
-                /^(\s*(?:- )?(?:path|url):\s*)(?!https?:|releases\/)([^\s].*)$/gm,
-                (_m, prefix, name) => `${prefix}releases/${version}/${name}`
-              );
-              fs.writeFileSync(file, text);
-              process.stdout.write(text);
-            ' "$yml"
-          done
-
-      # electron-builder never writes releaseNotes into the feeds, so already-installed clients (which
-      # read update notes only from the feed) show an empty "What's new" and only a GitHub link. Inject
-      # the same condensed notes version.json carries into each feed's releaseNotes. inject-feed-notes
-      # parses + re-serializes with js-yaml (never hand-writes YAML) and re-parses its own output, so a
-      # malformed feed fails the job here — before any upload — rather than reaching the installed base.
-      # js-yaml is installed on its own (this job never runs npm ci) with scripts off so no electron
-      # postinstall fires.
-      - name: Inject release notes into update feeds
-        run: |
-          npm install js-yaml@^4 --no-save --no-package-lock --no-audit --no-fund --ignore-scripts
-          shopt -s nullglob
-          feeds=()
-          for yml in dist-assets/latest.yml dist-assets/latest-linux.yml dist-assets/*-mac.yml; do
-            [ -f "$yml" ] && feeds+=("$yml")
-          done
-          if [ ${#feeds[@]} -eq 0 ]; then
-            echo "no update feeds present, skipping notes injection"
-            exit 0
-          fi
-          node scripts/inject-feed-notes.mjs version.json "${feeds[@]}"
 
       # Publish the rewritten feeds to the channel root as mutable, no-cache objects (same policy as
       # version.json), so the updater always sees the latest version immediately.

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -18,10 +18,35 @@ concurrency:
   cancel-in-progress: true
 
 jobs:
+  release-preflight:
+    name: Release preflight
+    runs-on: ubuntu-latest
+    permissions:
+      contents: read
+    steps:
+      - name: Checkout
+        uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7
+        with:
+          fetch-depth: 0
+
+      - name: Validate desktop release tag
+        if: github.event_name == 'push' && startsWith(github.ref, 'refs/tags/')
+        run: |
+          expected_tag="v$(node -p "require('./package.json').version")"
+          if [ "$GITHUB_REF_NAME" != "$expected_tag" ]; then
+            echo "Release tag $GITHUB_REF_NAME does not match $expected_tag." >&2
+            exit 1
+          fi
+
+      - name: Verify release commit is on main
+        if: github.event_name == 'push' && startsWith(github.ref, 'refs/tags/')
+        run: git merge-base --is-ancestor "$GITHUB_SHA" origin/main
+
   # Build the platform matrix (macOS arm64/x64 + Linux + Windows x64) via the reusable workflow.
   # secrets: inherit forwards the optional signing/notarization secrets. macOS is signed but NOT
   # notarized here — notarization is decoupled into the notarize-mac job below.
   build:
+    needs: release-preflight
     uses: ./.github/workflows/build.yml
     secrets: inherit
 
@@ -31,7 +56,7 @@ jobs:
   # time-capped and re-runnable (see notarize-mac.yml). No-ops when signing secrets aren't configured.
   notarize-mac:
     needs: build
-    if: startsWith(github.ref, 'refs/tags/')
+    if: github.event_name == 'push' && startsWith(github.ref, 'refs/tags/')
     uses: ./.github/workflows/notarize-mac.yml
     secrets: inherit
 
@@ -40,22 +65,22 @@ jobs:
   # macOS notarization, so its few minutes normally do not extend the release critical path.
   windows-upgrade-smoke:
     needs: build
-    if: startsWith(github.ref, 'refs/tags/')
+    if: github.event_name == 'push' && startsWith(github.ref, 'refs/tags/')
     runs-on: windows-latest
     timeout-minutes: 20
     permissions:
       contents: read
     steps:
       - name: Checkout
-        uses: actions/checkout@v7
+        uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7
 
       - name: Setup Node
-        uses: actions/setup-node@v7
+        uses: actions/setup-node@820762786026740c76f36085b0efc47a31fe5020 # v7
         with:
           node-version: 22
 
       - name: Download current Windows installer
-        uses: actions/download-artifact@v8
+        uses: actions/download-artifact@3e5f45b2cfb9172054b4087a40e8e0b5a5461e7c # v8
         with:
           name: windows-x64
           path: current
@@ -92,7 +117,7 @@ jobs:
   # notarize-mac so the mac dmg/zip it downloads are the stapled versions.
   publish:
     needs: [build, notarize-mac, windows-upgrade-smoke]
-    if: startsWith(github.ref, 'refs/tags/')
+    if: github.event_name == 'push' && startsWith(github.ref, 'refs/tags/')
     runs-on: ubuntu-latest
     # Job-level permissions fully override the workflow-level block, so contents:write is restated
     # alongside the two scopes the SLSA attestation needs: id-token to sign via Sigstore OIDC, and
@@ -105,10 +130,10 @@ jobs:
       # Checkout first (before downloading artifacts): the mac-feed merge step runs a repo script, and
       # actions/checkout cleans the working dir, which would wipe a pre-downloaded artifacts/.
       - name: Checkout (for the mac-feed merge script)
-        uses: actions/checkout@v7
+        uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7
 
       - name: Download all build artifacts
-        uses: actions/download-artifact@v8
+        uses: actions/download-artifact@3e5f45b2cfb9172054b4087a40e8e0b5a5461e7c # v8
         with:
           path: artifacts
           merge-multiple: true # flatten every platform's files into one directory
@@ -135,7 +160,7 @@ jobs:
       # digest list, not a build product. The attestation lives in the repo's Attestations, not as a
       # Release asset, so it doesn't clutter the download list.
       - name: Attest build provenance
-        uses: actions/attest-build-provenance@v4
+        uses: actions/attest-build-provenance@0f67c3f4856b2e3261c31976d6725780e5e4c373 # v4
         with:
           subject-path: |
             artifacts/*.dmg
@@ -151,7 +176,7 @@ jobs:
       # arm64/x64-mac.yml intermediates it was built from. Blockmaps are win/linux only (mac does
       # full-zip updates in v1).
       - name: Publish GitHub Release
-        uses: softprops/action-gh-release@v3
+        uses: softprops/action-gh-release@3d0d9888cb7fd7b750713d6e236d1fcb99157228 # v3
         with:
           draft: false
           prerelease: false

--- a/scripts/windows-release-workflows.test.ts
+++ b/scripts/windows-release-workflows.test.ts
@@ -18,6 +18,7 @@ type WorkflowJob = {
   'continue-on-error'?: boolean
   if?: string
   needs?: string | string[]
+  permissions?: Record<string, string>
   'runs-on'?: string
   steps?: WorkflowStep[]
   strategy?: { matrix?: Record<string, unknown> }
@@ -83,11 +84,11 @@ describe('post-merge Windows validation', () => {
     expect(upgrade.needs).toBe('build')
     expect(upgrade['timeout-minutes']).toBe(20)
     expect(findStep(upgrade, 'Setup Node')).toMatchObject({
-      uses: 'actions/setup-node@v7',
+      uses: 'actions/setup-node@820762786026740c76f36085b0efc47a31fe5020',
       with: { 'node-version': 22 }
     })
     expect(findStep(upgrade, 'Download current Windows installer').uses).toBe(
-      'actions/download-artifact@v8'
+      'actions/download-artifact@3e5f45b2cfb9172054b4087a40e8e0b5a5461e7c'
     )
     const previous = findStep(upgrade, 'Download previous stable Windows installer')
     expect(previous.env?.CURRENT_TAG).toBe('${{ github.ref_name }}')
@@ -99,4 +100,34 @@ describe('post-merge Windows validation', () => {
     )
     expect(release.jobs.publish.needs).toEqual(['build', 'notarize-mac', 'windows-upgrade-smoke'])
   })
+
+  it('validates stable desktop tags on main before starting platform builds', () => {
+    const release = readWorkflow('release.yml')
+    const preflight = release.jobs['release-preflight']
+    const checkout = findStep(preflight, 'Checkout')
+    const validateTag = findStep(preflight, 'Validate desktop release tag')
+    const verifyMain = findStep(preflight, 'Verify release commit is on main')
+    const stableTagCondition = "github.event_name == 'push' && startsWith(github.ref, 'refs/tags/')"
+
+    expect(preflight).toMatchObject({
+      permissions: { contents: 'read' },
+      'runs-on': 'ubuntu-latest'
+    })
+    expect(checkout).toMatchObject({
+      uses: 'actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1',
+      with: { 'fetch-depth': 0 }
+    })
+    expect(validateTag.if).toBe(stableTagCondition)
+    expect(validateTag.run).toContain("require('./package.json').version")
+    expect(validateTag.run).toContain('$GITHUB_REF_NAME')
+    expect(verifyMain).toMatchObject({
+      if: stableTagCondition,
+      run: 'git merge-base --is-ancestor "$GITHUB_SHA" origin/main'
+    })
+    expect(release.jobs.build.needs).toBe('release-preflight')
+    expect(release.jobs['notarize-mac'].if).toBe(stableTagCondition)
+    expect(release.jobs['windows-upgrade-smoke'].if).toBe(stableTagCondition)
+    expect(release.jobs.publish.if).toBe(stableTagCondition)
+  })
+
 })

--- a/scripts/windows-release-workflows.test.ts
+++ b/scripts/windows-release-workflows.test.ts
@@ -130,4 +130,36 @@ describe('post-merge Windows validation', () => {
     expect(release.jobs.publish.if).toBe(stableTagCondition)
   })
 
+  it('locks mirror dependencies and completes local transforms before configuring credentials', () => {
+    const mirror = readWorkflow('mirror-to-website.yml').jobs.mirror
+    const stepNames = mirror.steps?.map(({ name }) => name) ?? []
+    const install = findStep(mirror, 'Install manifest dependencies')
+    const configureIndex = stepNames.indexOf('Configure AWS credentials')
+
+    expect(install.run).toBe(
+      'npm ci --ignore-scripts --omit=dev --omit=optional --no-audit --no-fund'
+    )
+    expect(mirror.steps?.filter(({ run }) => run?.includes('npm install'))).toEqual([])
+    expect(configureIndex).toBeGreaterThan(stepNames.indexOf('Install manifest dependencies'))
+    expect(configureIndex).toBeGreaterThan(stepNames.indexOf('Generate version.json'))
+    expect(configureIndex).toBeGreaterThan(stepNames.indexOf('Rewrite update feed paths'))
+    expect(configureIndex).toBeGreaterThan(
+      stepNames.indexOf('Inject release notes into update feeds')
+    )
+    expect(stepNames.indexOf('Sync installers to versioned path')).toBeGreaterThan(configureIndex)
+    expect(stepNames.indexOf('Upload version.json')).toBeGreaterThan(configureIndex)
+    expect(stepNames.indexOf('Upload update feed to channel root')).toBeGreaterThan(configureIndex)
+  })
+
+  it('pins external actions in every changed release workflow', () => {
+    for (const workflowName of ['release.yml', 'mirror-to-website.yml']) {
+      const workflow = readWorkflow(workflowName)
+      const references = Object.values(workflow.jobs).flatMap((job) =>
+        (job.steps ?? []).flatMap(({ uses }) => (uses?.startsWith('./') || !uses ? [] : [uses]))
+      )
+
+      expect(references.length).toBeGreaterThan(0)
+      expect(references.every((reference) => /@[0-9a-f]{40}$/i.test(reference))).toBe(true)
+    }
+  })
 })


### PR DESCRIPTION
## Problem

The desktop release workflow accepts any `v*` tag without checking the application version or proving that the tagged commit belongs to `main`. The website mirror installs a mutable runtime package after cloud credentials are configured, and the changed workflows still contain mutable Action tags.

## Proposed change

- Add a preflight before platform builds that validates `v${package.json.version}` and `origin/main` ancestry for pushed tags.
- Keep manual dispatch as a build-only path rather than publishing, notarizing, or running release upgrade smoke from a selected tag.
- Install mirror dependencies from the committed lockfile with scripts disabled, complete local transformations, and only then configure AWS credentials and upload.
- Pin every external Action in the two changed workflows to its verified 40-character commit SHA.
- Add structural tests for the release guards, mirror ordering, and immutable references.

## Scope and non-goals

This changes release and mirror orchestration only. It does not change application runtime behavior, package versions, release assets, upload paths, Nightly cadence, PR Gate topology, or repository rulesets.

## Acceptance criteria and validation

- Workflow and CI Integrity tests — 47/47 passed after rebasing onto current `main`
- Full `npm test` — 692 files and 10,117 tests passed; 184 tests skipped
- Node and Web typecheck
- ESLint — 0 errors; 18 existing warnings
- CI Integrity policy against both changed workflows — 0 violations
- Prettier and `git diff --check`

Real tag publishing and credentialed website mirroring remain protected-environment verification steps.

## Review focus

Please focus on the preflight dependency chain, manual-dispatch conditions, the boundary between local transformation and credential configuration, and the pinned SHAs for annotated Action tags.
