### PR TITLE
feat(diagnostics): cover user-visible failure boundaries

### DIFF
--- a/src/main/acp/runtime-coordinator.test.ts
+++ b/src/main/acp/runtime-coordinator.test.ts
@@ -709,7 +709,7 @@ describe('AcpRuntimeCoordinator', () => {
     const running = coordinator.sendPrompt({ sessionId: session.sessionId, text: 'never stops' })
     await Promise.resolve()
 
-    await expect(coordinator.prepareForQuit(0)).resolves.toBeUndefined()
+    await expect(coordinator.prepareForQuit(0)).resolves.toBe('timeout')
     expect(created.cancelPrompt).toHaveBeenCalledWith({ sessionId: 'session-1' })
 
     prompt.resolve({ stopReason: 'cancelled' })
@@ -728,7 +728,7 @@ describe('AcpRuntimeCoordinator', () => {
     })
     const session = await coordinator.createSession({ cwd: '/workspace' })
 
-    await coordinator.prepareForQuit()
+    await expect(coordinator.prepareForQuit()).resolves.toBe('completed')
 
     await expect(
       coordinator.sendPrompt({ sessionId: session.sessionId, text: 'late user turn' })

--- a/src/main/acp/runtime-coordinator.ts
+++ b/src/main/acp/runtime-coordinator.ts
@@ -23,6 +23,7 @@ import { AcpRuntime, type AcpRuntimeCallbacks } from './runtime'
 import type { AcpRuntimeActivity, AcpRuntimeActivityOptions } from './runtime-activity'
 import { ConversationPermissionGrantStore } from './permission-broker'
 import type { ApprovedSwitchReadBack, ClaudeCodeReplayInput } from '../agents/claude-code-handoff'
+import type { ShutdownStepOutcome } from '../lifecycle-shutdown'
 
 const MAX_EVENTS = 500
 const QUIT_PREPARATION_TIMEOUT_MS = 4_000
@@ -285,7 +286,9 @@ class AcpRuntimeCoordinator {
   // Gives active agents a bounded chance to return their terminal stop response before process-tree
   // teardown. Those responses carry the final usage available from Claude Code/OpenCode/managed Codex;
   // an unresponsive agent cannot hold app quit indefinitely.
-  async prepareForQuit(timeoutMs = QUIT_PREPARATION_TIMEOUT_MS): Promise<void> {
+  async prepareForQuit(
+    timeoutMs = QUIT_PREPARATION_TIMEOUT_MS
+  ): Promise<Extract<ShutdownStepOutcome, 'completed' | 'timeout' | 'failed'>> {
     this.promptAdmissionClosedForQuit = true
     const sessionIds = Array.from(
       new Set([
@@ -294,7 +297,7 @@ class AcpRuntimeCoordinator {
         ...this.getSnapshot().promptInFlightSessionIds
       ])
     )
-    if (sessionIds.length === 0) return
+    if (sessionIds.length === 0) return 'completed'
 
     const cancelAndDrain = async (): Promise<void> => {
       await Promise.allSettled(
@@ -305,16 +308,19 @@ class AcpRuntimeCoordinator {
       )
     }
 
-    await new Promise<void>((resolve) => {
+    return new Promise<'completed' | 'timeout' | 'failed'>((resolve) => {
       let settled = false
-      const finish = (): void => {
+      const finish = (outcome: 'completed' | 'timeout' | 'failed'): void => {
         if (settled) return
         settled = true
         clearTimeout(timer)
-        resolve()
+        resolve(outcome)
       }
-      const timer = setTimeout(finish, Math.max(0, timeoutMs))
-      void cancelAndDrain().then(finish, finish)
+      const timer = setTimeout(() => finish('timeout'), Math.max(0, timeoutMs))
+      void cancelAndDrain().then(
+        () => finish('completed'),
+        () => finish('failed')
+      )
     })
   }
 

--- a/src/main/app-lifecycle.test.ts
+++ b/src/main/app-lifecycle.test.ts
@@ -1,7 +1,13 @@
-import { describe, expect, it, vi } from 'vitest'
+import { afterEach, describe, expect, it, vi } from 'vitest'
 
 import { installAppLifecycle, type AppLifecycleDeps, type TrayHandlers } from './app-lifecycle'
+import {
+  clearApplicationShutdownTrigger,
+  markApplicationShutdownTrigger
+} from './application-shutdown-trigger'
 import type { ActiveSessionInfo } from '../shared/storage'
+import type { RendererSessionPersistenceFlushOutcome } from './session-persistence/renderer-flush'
+import type { ShutdownStepOutcome } from './lifecycle-shutdown'
 import type {
   CloseClassification,
   CloseConfirmChoice,
@@ -10,6 +16,8 @@ import type {
 
 type QuitEvent = { preventDefault: () => void; defaultPrevented: boolean }
 type Handler = (event: QuitEvent) => void
+
+afterEach(() => clearApplicationShutdownTrigger())
 
 type FakeApp = {
   on: (event: string, handler: Handler) => void
@@ -110,9 +118,9 @@ type Harness = {
   windows: FakeWindow[]
   tray: { destroy: ReturnType<typeof vi.fn> } | undefined
   trayHandlers: TrayHandlers | undefined
-  shutdownBackends: () => Promise<void>
-  prepareForQuit: () => Promise<void>
-  flushSessionPersistence: () => Promise<void>
+  shutdownBackends: () => Promise<ShutdownStepOutcome | void>
+  prepareForQuit: () => Promise<ShutdownStepOutcome | void>
+  flushSessionPersistence: () => Promise<RendererSessionPersistenceFlushOutcome | void>
   quit: ReturnType<typeof vi.fn>
   showMainWindow: () => void
   getMainWindow: () => import('electron').BrowserWindow | undefined
@@ -128,6 +136,10 @@ const setup = (
       | 'shutdownBackends'
       | 'prepareForQuit'
       | 'flushSessionPersistence'
+      | 'log'
+      | 'flushLogs'
+      | 'logFlushTimeoutMs'
+      | 'shutdownTrigger'
       | 'isMigrationInProgress'
       | 'platform'
       | 'createInitialWindow'
@@ -148,7 +160,8 @@ const setup = (
   let trayHandlers: TrayHandlers | undefined
   const shutdownBackends = overrides.shutdownBackends ?? vi.fn(async () => undefined)
   const prepareForQuit = overrides.prepareForQuit ?? vi.fn(async () => undefined)
-  const flushSessionPersistence = overrides.flushSessionPersistence ?? vi.fn(async () => undefined)
+  const flushSessionPersistence =
+    overrides.flushSessionPersistence ?? vi.fn(async () => 'completed' as const)
   const quit = vi.fn()
   const closeOpts: CapturedCloseOpts[] = []
   const confirmClose = vi.fn(
@@ -171,6 +184,10 @@ const setup = (
     shutdownBackends,
     prepareForQuit,
     flushSessionPersistence,
+    log: overrides.log,
+    flushLogs: overrides.flushLogs,
+    logFlushTimeoutMs: overrides.logFlushTimeoutMs,
+    shutdownTrigger: overrides.shutdownTrigger,
     isMigrationInProgress: overrides.isMigrationInProgress ?? ((): boolean => false),
     quit,
     countWindows: () => windows.filter((w) => !w.destroyed).length,
@@ -385,6 +402,98 @@ describe('installAppLifecycle', () => {
 
     expect(calls).toEqual(['prepare', 'flush', 'shutdown'])
     expect(app.exit).toHaveBeenCalledWith(0)
+  })
+
+  it('records a degraded renderer persistence flush and drains terminal logs before exit', async () => {
+    const log = { debug: vi.fn(), info: vi.fn(), warn: vi.fn(), error: vi.fn() }
+    const flushLogs = vi.fn(async () => undefined)
+    const { app, closeOpts } = setup({
+      log,
+      flushLogs,
+      flushSessionPersistence: vi.fn(async () => 'timeout' as const)
+    })
+    closeOpts[0].requestQuit()
+
+    app.emit('before-quit')
+    await flush()
+
+    expect(log.info).toHaveBeenCalledWith(
+      'operation completed',
+      expect.objectContaining({
+        operation: 'application-shutdown',
+        outcome: 'completed',
+        degraded: true,
+        usageDrainResult: 'completed',
+        rendererFlushResult: 'timeout',
+        backendTeardownResult: 'completed'
+      })
+    )
+    expect(flushLogs).toHaveBeenCalledOnce()
+    expect(flushLogs.mock.invocationCallOrder[0]).toBeLessThan(app.exit.mock.invocationCallOrder[0])
+  })
+
+  it.each(['migration-relaunch', 'update'] as const)(
+    'classifies a %s handoff without changing shutdown ordering',
+    async (trigger) => {
+      const log = { debug: vi.fn(), info: vi.fn(), warn: vi.fn(), error: vi.fn() }
+      markApplicationShutdownTrigger(trigger)
+      const { app, confirmClose } = setup({
+        log,
+        detectActiveSessions: () => [
+          { projectId: 'project-1', sessionId: 'session-1', kind: 'agent' }
+        ]
+      })
+
+      app.emit('before-quit')
+      await flush()
+
+      expect(confirmClose).not.toHaveBeenCalled()
+      expect(log.info).toHaveBeenCalledWith(
+        'operation completed',
+        expect.objectContaining({
+          operation: 'application-shutdown',
+          trigger,
+          outcome: 'completed'
+        })
+      )
+    }
+  )
+
+  it('records fixed outcomes for every shutdown step and never reports a degraded shutdown as clean', async () => {
+    const log = { debug: vi.fn(), info: vi.fn(), warn: vi.fn(), error: vi.fn() }
+    const { app, closeOpts } = setup({
+      log,
+      prepareForQuit: vi.fn(async () => 'timeout' as const),
+      flushSessionPersistence: vi.fn(async () => 'send-failed' as const),
+      shutdownBackends: vi.fn(async () => 'degraded' as const)
+    })
+    closeOpts[0].requestQuit()
+
+    app.emit('before-quit')
+    await flush()
+
+    expect(log.info).toHaveBeenCalledWith(
+      'operation phase',
+      expect.objectContaining({ phase: 'usage-drain', result: 'timeout' })
+    )
+    expect(log.info).toHaveBeenCalledWith(
+      'operation phase',
+      expect.objectContaining({ phase: 'renderer-session-flush', result: 'failed' })
+    )
+    expect(log.info).toHaveBeenCalledWith(
+      'operation phase',
+      expect.objectContaining({ phase: 'backend-teardown', result: 'degraded' })
+    )
+    expect(log.info).toHaveBeenCalledWith(
+      'operation completed',
+      expect.objectContaining({
+        operation: 'application-shutdown',
+        degraded: true,
+        usageDrainResult: 'timeout',
+        rendererFlushResult: 'failed',
+        backendTeardownResult: 'degraded'
+      })
+    )
   })
 
   it('quits on window-all-closed only when non-darwin and no tray host', () => {

--- a/src/main/app-lifecycle.test.ts
+++ b/src/main/app-lifecycle.test.ts
@@ -3,6 +3,7 @@ import { afterEach, describe, expect, it, vi } from 'vitest'
 import { installAppLifecycle, type AppLifecycleDeps, type TrayHandlers } from './app-lifecycle'
 import {
   clearApplicationShutdownTrigger,
+  currentApplicationShutdownTrigger,
   markApplicationShutdownTrigger
 } from './application-shutdown-trigger'
 import type { ActiveSessionInfo } from '../shared/storage'
@@ -746,6 +747,19 @@ describe('installAppLifecycle', () => {
     expect(event.defaultPrevented).toBe(false)
     expect(confirmClose).not.toHaveBeenCalled()
     expect(quit).not.toHaveBeenCalled()
+    expect(shutdownBackends).not.toHaveBeenCalled()
+  })
+
+  it('clears an update shutdown trigger when migration aborts the quit', async () => {
+    markApplicationShutdownTrigger('update')
+    const { app, shutdownBackends } = setup({
+      isMigrationInProgress: (): boolean => true
+    })
+
+    app.emit('before-quit')
+    await flush()
+
+    expect(currentApplicationShutdownTrigger()).toBe('quit')
     expect(shutdownBackends).not.toHaveBeenCalled()
   })
 

--- a/src/main/app-lifecycle.ts
+++ b/src/main/app-lifecycle.ts
@@ -1,6 +1,15 @@
 import type { App, BrowserWindow, Tray } from 'electron'
 
 import type { ActiveSessionInfo } from '../shared/storage'
+import type { RendererSessionPersistenceFlushOutcome } from './session-persistence/renderer-flush'
+import type { ShutdownStepOutcome } from './lifecycle-shutdown'
+import { flushDiagnosticsWithTimeout } from './diagnostics/flush'
+import { diagnosticErrorFields, type Logger } from './logger'
+import { startDiagnosticOperation } from './diagnostics/operation'
+import {
+  currentApplicationShutdownTrigger,
+  type ApplicationShutdownTrigger
+} from './application-shutdown-trigger'
 import type {
   CloseClassification,
   CloseConfirmChoice,
@@ -25,11 +34,18 @@ export type AppLifecycleDeps = {
   // Builds the tray; returns undefined on hosts without a tray (e.g. some Linux desktops).
   createTray: (handlers: TrayHandlers) => Tray | undefined
   // Bounded, best-effort backend teardown (agent tree + notebook kernels); never throws.
-  shutdownBackends: () => Promise<void>
+  shutdownBackends: () => Promise<ShutdownStepOutcome | void>
   // Requests active ACP turns to cancel, then waits a bounded interval for terminal usage events.
-  prepareForQuit: () => Promise<void>
+  prepareForQuit: () => Promise<ShutdownStepOutcome | void>
   // Drains renderer runtime events and its ordered Session write queue before the window disappears.
-  flushSessionPersistence: () => Promise<void>
+  flushSessionPersistence: () => Promise<RendererSessionPersistenceFlushOutcome | void>
+  // Local structured diagnostics remain optional for the dependency-injected lifecycle tests.
+  log?: Logger
+  // Drains the logger's serialized write queue after the shutdown terminal record.
+  flushLogs?: () => Promise<void>
+  logFlushTimeoutMs?: number
+  // Classifies an orderly shutdown without changing its cleanup sequence.
+  shutdownTrigger?: () => ApplicationShutdownTrigger
   // True while a data-root migration is copying; a quit during it is owned by the migration guard.
   isMigrationInProgress: () => boolean
   // Requests an app quit (app.quit); the before-quit handler below turns it into an awaited teardown.
@@ -62,6 +78,7 @@ export const installAppLifecycle = (
   isMainWindowHidden: () => boolean
 } => {
   const platform = deps.platform ?? process.platform
+  const logFlushTimeoutMs = deps.logFlushTimeoutMs ?? 1_000
 
   let mainWindow: BrowserWindow | undefined
   const hiddenWindows = new WeakSet<BrowserWindow>()
@@ -78,6 +95,24 @@ export const installAppLifecycle = (
   // confirmation modal is ever open at a time. The renderer holds a single request slot; a second
   // dispatch would silently overwrite the first and strand its promise forever (see app-lifecycle.test.ts).
   let confirmInFlight = false
+
+  const normalizeStepOutcome = (outcome: ShutdownStepOutcome | void): ShutdownStepOutcome =>
+    outcome ?? 'completed'
+  const rendererStepOutcome = (
+    outcome: RendererSessionPersistenceFlushOutcome
+  ): ShutdownStepOutcome => {
+    if (outcome === 'timeout') return 'timeout'
+    if (outcome === 'send-failed') return 'failed'
+    if (outcome === 'renderer-gone') return 'degraded'
+    return 'completed'
+  }
+  const shutdownTrigger = (): ApplicationShutdownTrigger => {
+    try {
+      return deps.shutdownTrigger?.() ?? currentApplicationShutdownTrigger()
+    } catch {
+      return 'quit'
+    }
+  }
 
   const confirmClose = deps.createConfirmClose(() => mainWindow)
 
@@ -170,10 +205,11 @@ export const installAppLifecycle = (
       quitConfirmed = false
       return
     }
+    const trigger = shutdownTrigger()
 
     // Confirmation gate: unless the user already confirmed (e.g. Windows X -> Quit), confirm the
     // quit. An empty active-session list makes confirmClose('quit', []) resolve 'quit' with no modal.
-    if (!quitConfirmed) {
+    if (!quitConfirmed && trigger === 'quit') {
       event.preventDefault()
       if (confirmInFlight) return
       confirmInFlight = true
@@ -204,10 +240,70 @@ export const installAppLifecycle = (
     event.preventDefault()
     shutdownStarted = true
     void (async () => {
+      const diagnostics = deps.log
+        ? startDiagnosticOperation(deps.log, {
+            operation: 'application-shutdown',
+            fields: { trigger }
+          })
+        : undefined
+      let usageDrainResult: ShutdownStepOutcome = 'completed'
+      let rendererFlushOutcome: RendererSessionPersistenceFlushOutcome = 'unavailable'
+      let rendererFlushResult: ShutdownStepOutcome = 'completed'
+      let backendTeardownResult: ShutdownStepOutcome = 'completed'
       try {
-        await deps.prepareForQuit().catch(() => undefined)
-        await deps.flushSessionPersistence().catch(() => undefined)
-        await deps.shutdownBackends()
+        diagnostics?.phase('usage-drain')
+        try {
+          usageDrainResult = normalizeStepOutcome(await deps.prepareForQuit())
+          diagnostics?.phase('usage-drain', { result: usageDrainResult })
+        } catch (error) {
+          usageDrainResult = 'failed'
+          diagnostics?.phase('usage-drain', {
+            result: usageDrainResult,
+            ...diagnosticErrorFields(error)
+          })
+        }
+
+        diagnostics?.phase('renderer-session-flush')
+        try {
+          rendererFlushOutcome = (await deps.flushSessionPersistence()) ?? 'completed'
+          rendererFlushResult = rendererStepOutcome(rendererFlushOutcome)
+          diagnostics?.phase('renderer-session-flush', { result: rendererFlushResult })
+        } catch (error) {
+          rendererFlushOutcome = 'send-failed'
+          rendererFlushResult = 'failed'
+          diagnostics?.phase('renderer-session-flush', {
+            result: rendererFlushResult,
+            ...diagnosticErrorFields(error)
+          })
+        }
+
+        diagnostics?.phase('backend-teardown')
+        try {
+          backendTeardownResult = normalizeStepOutcome(await deps.shutdownBackends())
+          diagnostics?.phase('backend-teardown', { result: backendTeardownResult })
+        } catch (error) {
+          backendTeardownResult = 'failed'
+          diagnostics?.phase('backend-teardown', {
+            result: backendTeardownResult,
+            ...diagnosticErrorFields(error)
+          })
+        }
+        const degraded =
+          usageDrainResult !== 'completed' ||
+          rendererFlushResult !== 'completed' ||
+          backendTeardownResult !== 'completed'
+        diagnostics?.complete({
+          degraded,
+          usageDrainResult,
+          rendererFlushResult,
+          rendererFlushOutcome,
+          backendTeardownResult
+        })
+
+        if (deps.flushLogs) {
+          const result = await flushDiagnosticsWithTimeout(deps.flushLogs, logFlushTimeoutMs)
+          if (result === 'timeout') console.warn('[shutdown] final log flush timed out')
+        }
       } finally {
         trayBox.current?.destroy()
         shutdownFinished = true

--- a/src/main/app-lifecycle.ts
+++ b/src/main/app-lifecycle.ts
@@ -7,6 +7,7 @@ import { flushDiagnosticsWithTimeout } from './diagnostics/flush'
 import { diagnosticErrorFields, type Logger } from './logger'
 import { startDiagnosticOperation } from './diagnostics/operation'
 import {
+  clearApplicationShutdownTrigger,
   currentApplicationShutdownTrigger,
   type ApplicationShutdownTrigger
 } from './application-shutdown-trigger'
@@ -200,8 +201,9 @@ export const installAppLifecycle = (
     }
     if (event.defaultPrevented || deps.isMigrationInProgress()) {
       // This quit is being aborted (e.g. the migration guard cancelled it). Clear any prior
-      // confirmation so it doesn't leak into a later close: otherwise classifyClose would return
-      // 'close' and the next Windows X would bypass the dialog and destroy the window.
+      // confirmation and shutdown trigger so neither leaks into a later close: otherwise a later
+      // ordinary quit could bypass its active-session confirmation.
+      clearApplicationShutdownTrigger()
       quitConfirmed = false
       return
     }
@@ -246,10 +248,10 @@ export const installAppLifecycle = (
             fields: { trigger }
           })
         : undefined
-      let usageDrainResult: ShutdownStepOutcome = 'completed'
-      let rendererFlushOutcome: RendererSessionPersistenceFlushOutcome = 'unavailable'
-      let rendererFlushResult: ShutdownStepOutcome = 'completed'
-      let backendTeardownResult: ShutdownStepOutcome = 'completed'
+      let usageDrainResult: ShutdownStepOutcome
+      let rendererFlushOutcome: RendererSessionPersistenceFlushOutcome
+      let rendererFlushResult: ShutdownStepOutcome
+      let backendTeardownResult: ShutdownStepOutcome
       try {
         diagnostics?.phase('usage-drain')
         try {

--- a/src/main/app-startup.test.ts
+++ b/src/main/app-startup.test.ts
@@ -123,4 +123,26 @@ describe('orchestrateAppStartup', () => {
     signal(['app'])
     expect(onSecondInstance).toHaveBeenCalledWith(['app'])
   })
+
+  it('terminalizes startup diagnostics at the phase that rejects without changing the failure', async () => {
+    const failure = new Error('backend import failed')
+    const diagnostics = {
+      phase: vi.fn(),
+      complete: vi.fn(),
+      cancel: vi.fn(),
+      fail: vi.fn()
+    }
+    const deps = makeDeps({
+      prepare: vi.fn(async () => {
+        throw failure
+      }),
+      diagnostics
+    })
+
+    await expect(orchestrateAppStartup(deps)).rejects.toBe(failure)
+
+    expect(diagnostics.phase).toHaveBeenCalledWith('prepare-runtime')
+    expect(diagnostics.fail).toHaveBeenCalledWith(failure)
+    expect(diagnostics.complete).not.toHaveBeenCalled()
+  })
 })

--- a/src/main/app-startup.ts
+++ b/src/main/app-startup.ts
@@ -1,3 +1,5 @@
+import type { DiagnosticOperation } from './diagnostics/operation'
+
 // Startup orchestration for the UI process, kept as a dependency-injected unit (no Electron imports) so
 // the single-instance gate, the second-instance-during-startup handoff, and the ordering of the
 // migration quit-guard relative to the lifecycle can be exercised together in a unit test — the real
@@ -47,6 +49,7 @@ export type AppStartupDeps<Context> = {
   // Installs the tray/window/quit lifecycle; returns the second-instance handler for the relay to drain.
   // The handler decides per forwarded argv whether to surface the window or start the web service.
   installAppLifecycle: (context: Context) => { onSecondInstance: (argv: string[]) => void }
+  diagnostics?: DiagnosticOperation
 }
 
 // Runs the ordered startup sequence: gate on the single-instance lock (quitting a secondary launch
@@ -57,13 +60,23 @@ export const orchestrateAppStartup = async <Context>(
 ): Promise<void> => {
   const relay = createSecondInstanceRelay()
 
-  if (!deps.acquireSingleInstanceLock({ onSecondInstance: relay.signal })) {
-    deps.quit()
-    return
-  }
+  try {
+    deps.diagnostics?.phase('single-instance-lock')
+    if (!deps.acquireSingleInstanceLock({ onSecondInstance: relay.signal })) {
+      deps.quit()
+      deps.diagnostics?.complete({ instance: 'secondary' })
+      return
+    }
 
-  const context = await deps.prepare()
-  deps.installMigrationQuitGuard(context)
-  const { onSecondInstance } = deps.installAppLifecycle(context)
-  relay.bind(onSecondInstance)
+    deps.diagnostics?.phase('prepare-runtime')
+    const context = await deps.prepare()
+    deps.diagnostics?.phase('install-lifecycle')
+    deps.installMigrationQuitGuard(context)
+    const { onSecondInstance } = deps.installAppLifecycle(context)
+    relay.bind(onSecondInstance)
+    deps.diagnostics?.complete({ instance: 'primary' })
+  } catch (error) {
+    deps.diagnostics?.fail(error)
+    throw error
+  }
 }

--- a/src/main/application-runtime.test.ts
+++ b/src/main/application-runtime.test.ts
@@ -6,6 +6,7 @@ import {
   shutdownApplicationSurfaces,
   withApplicationRuntimeShutdown
 } from './application-runtime'
+import { BackendShutdownOutcomeError } from './lifecycle-shutdown'
 import { createApplicationEventModule } from './application-events'
 
 describe('application runtime composition', () => {
@@ -300,7 +301,7 @@ describe('application surface shutdown', () => {
         }
       }
     )
-    await lifecycle.shutdownBackends()
+    await expect(lifecycle.shutdownBackends()).resolves.toBe('completed')
 
     expect(lifecycle.marker).toBe('electron-lifecycle')
     expect(order).toEqual(['application-runtime', 'remote-access', 'web-controller', 'web-rpc'])
@@ -321,14 +322,68 @@ describe('application surface shutdown', () => {
         disposeWebRpc,
         log
       })
-    ).resolves.toBeUndefined()
+    ).resolves.toBe('failed')
 
-    expect(log.error).toHaveBeenCalledWith(
-      'application runtime disposal failed during application shutdown: Error: backend shutdown failed',
-      failure
-    )
+    expect(log.error).toHaveBeenCalledWith('application surface shutdown failed', {
+      surface: 'application-runtime',
+      result: 'failed',
+      errorCategory: 'error'
+    })
+    expect(JSON.stringify(log.error.mock.calls)).not.toContain('backend shutdown failed')
     expect(shutdownRemoteAccess).toHaveBeenCalledOnce()
     expect(closeWebController).toHaveBeenCalledOnce()
     expect(disposeWebRpc).toHaveBeenCalledOnce()
   })
+
+  it('continues closing surfaces when the shutdown diagnostic sink throws', async () => {
+    const shutdownRemoteAccess = vi.fn()
+    const closeWebController = vi.fn()
+    const disposeWebRpc = vi.fn()
+
+    await expect(
+      shutdownApplicationSurfaces({
+        disposeApplicationRuntime: () => Promise.reject(new Error('runtime failure')),
+        shutdownRemoteAccess,
+        closeWebController,
+        disposeWebRpc,
+        log: {
+          error: () => {
+            throw new Error('sink failure')
+          }
+        }
+      })
+    ).resolves.toBe('failed')
+
+    expect(shutdownRemoteAccess).toHaveBeenCalledOnce()
+    expect(closeWebController).toHaveBeenCalledOnce()
+    expect(disposeWebRpc).toHaveBeenCalledOnce()
+  })
+
+  it.each([
+    ['timeout', 'timeout'],
+    ['degraded', 'degraded']
+  ] as const)(
+    'preserves the fixed %s backend outcome without logging raw error details',
+    async (backendOutcome, expected) => {
+      const log = { error: vi.fn() }
+
+      await expect(
+        shutdownApplicationSurfaces({
+          disposeApplicationRuntime: () =>
+            Promise.reject(new BackendShutdownOutcomeError(expected)),
+          shutdownRemoteAccess: vi.fn(),
+          closeWebController: vi.fn(),
+          disposeWebRpc: vi.fn(),
+          log
+        })
+      ).resolves.toBe(backendOutcome)
+
+      expect(log.error).toHaveBeenCalledWith('application surface shutdown failed', {
+        surface: 'application-runtime',
+        result: expected,
+        errorCategory: 'object'
+      })
+      expect(JSON.stringify(log.error.mock.calls)).not.toContain('Backend shutdown')
+    }
+  )
 })

--- a/src/main/application-runtime.ts
+++ b/src/main/application-runtime.ts
@@ -1,3 +1,6 @@
+import { diagnosticErrorFields, type Logger } from './logger'
+import { BackendShutdownOutcomeError, type ShutdownStepOutcome } from './lifecycle-shutdown'
+
 type Awaitable<T> = T | Promise<T>
 
 export const APPLICATION_MODULE_DISPOSAL_BUDGET_MS = 1000
@@ -44,7 +47,7 @@ export type ApplicationSurfaceShutdown = {
   shutdownRemoteAccess(): Awaitable<void>
   closeWebController(): Awaitable<void>
   disposeWebRpc(): Awaitable<void>
-  log?: { error(message: string, error: unknown): void }
+  log?: Pick<Logger, 'error'>
 }
 
 export type ApplicationLifecycleShutdownDependencies = {
@@ -63,30 +66,52 @@ export const shutdownApplicationSurfaces = async ({
   closeWebController,
   disposeWebRpc,
   log
-}: ApplicationSurfaceShutdown): Promise<void> => {
+}: ApplicationSurfaceShutdown): Promise<ShutdownStepOutcome> => {
   const flattenErrors = (error: unknown): unknown[] =>
     error instanceof AggregateError ? error.errors.flatMap(flattenErrors) : [error]
-  const describeError = (error: unknown): string =>
-    error instanceof Error ? `${error.name}: ${error.message}` : String(error)
-  const dispose = async (name: string, operation: () => Awaitable<void>): Promise<void> => {
+  const classifyError = (error: unknown): Exclude<ShutdownStepOutcome, 'completed'> => {
+    if (error instanceof BackendShutdownOutcomeError) return error.outcome
+    if (error instanceof ApplicationModuleDisposalTimeoutError) return 'timeout'
+    return 'failed'
+  }
+  const combineOutcomes = (
+    current: ShutdownStepOutcome,
+    next: ShutdownStepOutcome
+  ): ShutdownStepOutcome => {
+    const priority: Record<ShutdownStepOutcome, number> = {
+      completed: 0,
+      degraded: 1,
+      timeout: 2,
+      failed: 3
+    }
+    return priority[next] > priority[current] ? next : current
+  }
+  let overallOutcome: ShutdownStepOutcome = 'completed'
+  const dispose = async (surface: string, operation: () => Awaitable<void>): Promise<void> => {
     try {
       await operation()
     } catch (error) {
       for (const cause of flattenErrors(error)) {
-        // Put the cause summary in the top-level message: the production logger intentionally serializes
-        // an Error as name/message/stack and does not retain AggregateError.errors or custom properties.
-        log?.error(
-          `${name} disposal failed during application shutdown: ${describeError(cause)}`,
-          cause
-        )
+        const result = classifyError(cause)
+        overallOutcome = combineOutcomes(overallOutcome, result)
+        try {
+          log?.error('application surface shutdown failed', {
+            surface,
+            result,
+            ...diagnosticErrorFields(cause)
+          })
+        } catch {
+          // A diagnostic sink failure must not prevent the remaining surfaces from closing.
+        }
       }
     }
   }
 
-  await dispose('application runtime', disposeApplicationRuntime)
-  await dispose('remote access', shutdownRemoteAccess)
-  await dispose('web controller', closeWebController)
-  await dispose('web RPC', disposeWebRpc)
+  await dispose('application-runtime', disposeApplicationRuntime)
+  await dispose('remote-access', shutdownRemoteAccess)
+  await dispose('web-controller', closeWebController)
+  await dispose('web-rpc', disposeWebRpc)
+  return overallOutcome
 }
 
 // Builds the exact callback passed to the Electron lifecycle. Requiring the application disposer here
@@ -97,7 +122,7 @@ export const createApplicationLifecycleShutdown = ({
   webController,
   webRpc,
   log
-}: ApplicationLifecycleShutdownDependencies): (() => Promise<void>) => {
+}: ApplicationLifecycleShutdownDependencies): (() => Promise<ShutdownStepOutcome>) => {
   return () =>
     shutdownApplicationSurfaces({
       disposeApplicationRuntime,
@@ -111,7 +136,7 @@ export const createApplicationLifecycleShutdown = ({
 export const withApplicationRuntimeShutdown = <Options extends object>(
   options: Options,
   dependencies: ApplicationLifecycleShutdownDependencies
-): NoInfer<Options> & { shutdownBackends: () => Promise<void> } => ({
+): NoInfer<Options> & { shutdownBackends: () => Promise<ShutdownStepOutcome> } => ({
   ...options,
   shutdownBackends: createApplicationLifecycleShutdown(dependencies)
 })

--- a/src/main/application-shutdown-trigger.ts
+++ b/src/main/application-shutdown-trigger.ts
@@ -1,0 +1,20 @@
+export type ApplicationShutdownTrigger = 'quit' | 'update' | 'migration-relaunch'
+
+let requestedTrigger: ApplicationShutdownTrigger = 'quit'
+
+// Records the reason for the next orderly app shutdown. The returned rollback is used when the API
+// that was expected to initiate quitting throws synchronously and the current process stays alive.
+export const markApplicationShutdownTrigger = (
+  trigger: Exclude<ApplicationShutdownTrigger, 'quit'>
+): (() => void) => {
+  requestedTrigger = trigger
+  return () => {
+    if (requestedTrigger === trigger) requestedTrigger = 'quit'
+  }
+}
+
+export const currentApplicationShutdownTrigger = (): ApplicationShutdownTrigger => requestedTrigger
+
+export const clearApplicationShutdownTrigger = (): void => {
+  requestedTrigger = 'quit'
+}

--- a/src/main/diagnostics/flush.test.ts
+++ b/src/main/diagnostics/flush.test.ts
@@ -1,0 +1,30 @@
+import { afterEach, describe, expect, it, vi } from 'vitest'
+
+import { flushDiagnosticsWithTimeout } from './flush'
+
+afterEach(() => {
+  vi.useRealTimers()
+})
+
+describe('flushDiagnosticsWithTimeout', () => {
+  it('reports a completed flush', async () => {
+    await expect(flushDiagnosticsWithTimeout(async () => undefined, 50)).resolves.toBe('flushed')
+  })
+
+  it('contains a rejected diagnostic sink', async () => {
+    await expect(
+      flushDiagnosticsWithTimeout(async () => {
+        throw new Error('sink failed')
+      }, 50)
+    ).resolves.toBe('failed')
+  })
+
+  it('bounds a stalled diagnostic sink', async () => {
+    vi.useFakeTimers()
+    const result = flushDiagnosticsWithTimeout(() => new Promise<void>(() => undefined), 50)
+
+    await vi.advanceTimersByTimeAsync(50)
+
+    await expect(result).resolves.toBe('timeout')
+  })
+})

--- a/src/main/diagnostics/flush.ts
+++ b/src/main/diagnostics/flush.ts
@@ -1,0 +1,23 @@
+export type DiagnosticFlushOutcome = 'flushed' | 'failed' | 'timeout'
+
+export const flushDiagnosticsWithTimeout = async (
+  flush: () => Promise<void>,
+  timeoutMs: number
+): Promise<DiagnosticFlushOutcome> => {
+  let timer: ReturnType<typeof setTimeout> | undefined
+  const timeout = new Promise<'timeout'>((resolve) => {
+    timer = setTimeout(() => resolve('timeout'), timeoutMs)
+    timer.unref?.()
+  })
+  const result = await Promise.race([
+    Promise.resolve()
+      .then(flush)
+      .then(
+        () => 'flushed' as const,
+        () => 'failed' as const
+      ),
+    timeout
+  ])
+  if (timer) clearTimeout(timer)
+  return result
+}

--- a/src/main/diagnostics/ipc-rejection.test.ts
+++ b/src/main/diagnostics/ipc-rejection.test.ts
@@ -1,0 +1,132 @@
+import { describe, expect, it, vi } from 'vitest'
+
+import { createWebCallerContext } from '../caller-context'
+import { invokeWithIpcRejectionDiagnostics } from './ipc-rejection'
+
+describe('invokeWithIpcRejectionDiagnostics', () => {
+  it('records only allowlisted caller metadata for a rejection and rethrows the same value', async () => {
+    const warn = vi.fn()
+    const secretError = Object.assign(new Error('secret provider failure'), {
+      code: 'EACCES',
+      data: { token: 'secret-token' }
+    })
+    const invoke = vi.fn(async (_payload: unknown) => {
+      void _payload
+      throw secretError
+    })
+    const now = vi.fn().mockReturnValueOnce(10).mockReturnValueOnce(34)
+
+    const rejected = invokeWithIpcRejectionDiagnostics({
+      channel: 'projects:list',
+      callerContext: createWebCallerContext('secret-client-id', {
+        location: 'remote',
+        principalKind: 'automation',
+        actionOrigin: 'agent-session'
+      }),
+      invoke: () => invoke({ path: '/private/research.txt', token: 'secret-token' }),
+      log: { warn },
+      now
+    })
+
+    await expect(rejected).rejects.toBe(secretError)
+    expect(warn).toHaveBeenCalledOnce()
+    expect(warn).toHaveBeenCalledWith('ipc handler rejected', {
+      channel: 'projects:list',
+      surface: 'web',
+      location: 'remote',
+      principalKind: 'automation',
+      actionOrigin: 'agent-session',
+      durationMs: 24,
+      errorCategory: 'permission'
+    })
+    expect(JSON.stringify(warn.mock.calls)).not.toContain('secret-client-id')
+    expect(JSON.stringify(warn.mock.calls)).not.toContain('secret-token')
+    expect(JSON.stringify(warn.mock.calls)).not.toContain('/private/research.txt')
+    expect(JSON.stringify(warn.mock.calls)).not.toContain('secret provider failure')
+  })
+
+  it('preserves successful synchronous values without writing diagnostics', () => {
+    const warn = vi.fn()
+    const result = { secretResult: true }
+
+    expect(
+      invokeWithIpcRejectionDiagnostics({
+        channel: 'projects:list',
+        callerContext: createWebCallerContext('client-a'),
+        invoke: () => result,
+        log: { warn }
+      })
+    ).toBe(result)
+    expect(warn).not.toHaveBeenCalled()
+  })
+
+  it('records rejected custom thenables without changing the rejection value', async () => {
+    const warn = vi.fn()
+    const rejection = new Error('private thenable failure')
+    const thenable = {
+      then: (_onFulfilled: unknown, onRejected: (reason: unknown) => unknown): void => {
+        onRejected(rejection)
+      }
+    }
+
+    const result = invokeWithIpcRejectionDiagnostics({
+      channel: 'projects:list',
+      callerContext: createWebCallerContext('client-a'),
+      invoke: () => thenable,
+      log: { warn }
+    })
+
+    await expect(Promise.resolve(result)).rejects.toBe(rejection)
+    expect(warn).toHaveBeenCalledWith(
+      'ipc handler rejected',
+      expect.objectContaining({ channel: 'projects:list', errorCategory: 'error' })
+    )
+  })
+
+  it('reads a side-effectful then getter once and preserves its original rejection', async () => {
+    const warn = vi.fn()
+    const rejection = new Error('original private rejection')
+    const replacement = new Error('second getter must not win')
+    let reads = 0
+    const thenable = Object.defineProperty({}, 'then', {
+      get: () => {
+        reads += 1
+        if (reads > 1) throw replacement
+        return (_resolve: unknown, reject: (reason: unknown) => void): void => reject(rejection)
+      }
+    })
+
+    const result = invokeWithIpcRejectionDiagnostics({
+      channel: 'projects:list',
+      callerContext: createWebCallerContext('client-a'),
+      invoke: () => thenable,
+      log: { warn }
+    })
+
+    await expect(Promise.resolve(result)).rejects.toBe(rejection)
+    expect(reads).toBe(1)
+    expect(warn).toHaveBeenCalledOnce()
+  })
+
+  it('does not let diagnostic sink or clock failures change a synchronous rejection', () => {
+    const rejection = new TypeError('private detail')
+
+    expect(() =>
+      invokeWithIpcRejectionDiagnostics({
+        channel: 'projects:list',
+        callerContext: createWebCallerContext('client-a'),
+        invoke: () => {
+          throw rejection
+        },
+        log: {
+          warn: () => {
+            throw new Error('sink unavailable')
+          }
+        },
+        now: () => {
+          throw new Error('clock unavailable')
+        }
+      })
+    ).toThrow(rejection)
+  })
+})

--- a/src/main/diagnostics/ipc-rejection.ts
+++ b/src/main/diagnostics/ipc-rejection.ts
@@ -1,0 +1,81 @@
+import type { CallerContext } from '../caller-context'
+import { diagnosticErrorFields, type Logger } from '../logger'
+
+type IpcRejectionLogger = Pick<Logger, 'warn'>
+
+type IpcRejectionDiagnosticInput<T> = {
+  channel: string
+  callerContext: Pick<CallerContext, 'surface' | 'location' | 'principalKind' | 'actionOrigin'>
+  invoke: () => T | PromiseLike<T>
+  log: IpcRejectionLogger
+  now?: () => number
+}
+
+const safeNow = (now: () => number): number => {
+  try {
+    const value = now()
+    return Number.isFinite(value) ? value : 0
+  } catch {
+    return 0
+  }
+}
+
+/**
+ * Adds the universal rejected-request floor around an IPC invocation.
+ *
+ * This adapter deliberately has no access to the request arguments or result. Its entire diagnostic
+ * vocabulary is fixed caller metadata plus a coarse error category, and all diagnostic work is
+ * best-effort so it can never replace the handler's authoritative result or rejection.
+ */
+export const invokeWithIpcRejectionDiagnostics = <T>(
+  input: IpcRejectionDiagnosticInput<T>
+): T | PromiseLike<T> => {
+  const now = input.now ?? performance.now.bind(performance)
+  const startedAt = safeNow(now)
+  const recordRejection = (error: unknown): void => {
+    try {
+      input.log.warn('ipc handler rejected', {
+        channel: input.channel,
+        surface: input.callerContext.surface,
+        location: input.callerContext.location,
+        principalKind: input.callerContext.principalKind,
+        actionOrigin: input.callerContext.actionOrigin,
+        durationMs: Math.max(0, safeNow(now) - startedAt),
+        ...diagnosticErrorFields(error)
+      })
+    } catch {
+      // Diagnostic failures must never replace the handler's original rejection.
+    }
+  }
+
+  try {
+    const result = input.invoke()
+    if (result !== null && (typeof result === 'object' || typeof result === 'function')) {
+      const then = (result as { then?: unknown }).then
+      if (typeof then !== 'function') return result
+
+      // Promise.resolve(result) would read a thenable's `then` getter a second time. Assimilate the
+      // cached function on a microtask instead, matching native timing while preserving one-shot or
+      // side-effectful thenables and their authoritative rejection value.
+      const assimilated = new Promise<T>((resolve, reject) => {
+        queueMicrotask(() => {
+          try {
+            Reflect.apply(then, result, [resolve, reject])
+          } catch (error) {
+            reject(error)
+          }
+        })
+      })
+      return assimilated.catch((error: unknown) => {
+        recordRejection(error)
+        throw error
+      })
+    }
+    return result
+  } catch (error) {
+    recordRejection(error)
+    throw error
+  }
+}
+
+export type { IpcRejectionDiagnosticInput, IpcRejectionLogger }

--- a/src/main/diagnostics/operation.test.ts
+++ b/src/main/diagnostics/operation.test.ts
@@ -1,0 +1,295 @@
+import { describe, expect, it } from 'vitest'
+
+import type { Logger } from '../logger'
+import {
+  type DiagnosticFields,
+  type DiagnosticOperationInput,
+  startDiagnosticOperation
+} from './operation'
+
+type CapturedRecord = {
+  level: keyof Logger
+  message: string
+  data: unknown
+}
+
+const createRecordingLogger = (): { logger: Logger; records: CapturedRecord[] } => {
+  const records: CapturedRecord[] = []
+  const capture =
+    (level: keyof Logger) =>
+    (message: string, data?: unknown): void => {
+      records.push({ level, message, data })
+    }
+
+  return {
+    logger: {
+      debug: capture('debug'),
+      info: capture('info'),
+      warn: capture('warn'),
+      error: capture('error')
+    },
+    records
+  }
+}
+
+describe('diagnostic operation', () => {
+  it('starts once with a stable operation ID and scalar context', () => {
+    const { logger, records } = createRecordingLogger()
+
+    startDiagnosticOperation(logger, {
+      operation: 'data-root-migration',
+      operationId: 'migration-1',
+      fields: { source: 'legacy', retry: false }
+    })
+
+    expect(records).toEqual([
+      {
+        level: 'info',
+        message: 'operation started',
+        data: {
+          source: 'legacy',
+          retry: false,
+          operation: 'data-root-migration',
+          operationId: 'migration-1',
+          outcome: 'started'
+        }
+      }
+    ])
+  })
+
+  it('records a phase with the operation context', () => {
+    const { logger, records } = createRecordingLogger()
+    const operation = startDiagnosticOperation(logger, {
+      operation: 'data-root-migration',
+      operationId: 'migration-1',
+      fields: { source: 'legacy' }
+    })
+
+    operation.phase('copy', { filesCopied: 3 })
+
+    expect(records[1]).toEqual({
+      level: 'info',
+      message: 'operation phase',
+      data: {
+        source: 'legacy',
+        filesCopied: 3,
+        operation: 'data-root-migration',
+        operationId: 'migration-1',
+        phase: 'copy'
+      }
+    })
+  })
+
+  it('completes with duration and the latest phase', () => {
+    const { logger, records } = createRecordingLogger()
+    let timestamp = 100
+    const operation = startDiagnosticOperation(logger, {
+      operation: 'data-root-migration',
+      operationId: 'migration-1',
+      fields: { source: 'legacy' },
+      now: () => timestamp
+    })
+    operation.phase('verify-target')
+
+    timestamp = 145
+    operation.complete({ filesCopied: 3 })
+
+    expect(records[2]).toEqual({
+      level: 'info',
+      message: 'operation completed',
+      data: {
+        source: 'legacy',
+        filesCopied: 3,
+        operation: 'data-root-migration',
+        operationId: 'migration-1',
+        phase: 'verify-target',
+        outcome: 'completed',
+        durationMs: 45
+      }
+    })
+  })
+
+  it('fails with a coarse error category and no raw error payload', () => {
+    const { logger, records } = createRecordingLogger()
+    let timestamp = 10
+    const operation = startDiagnosticOperation(logger, {
+      operation: 'data-root-migration',
+      operationId: 'migration-1',
+      now: () => timestamp
+    })
+    operation.phase('copy')
+
+    timestamp = 34
+    operation.fail(
+      Object.assign(new Error('secret target path'), {
+        code: 'EACCES',
+        path: '/private/secret'
+      }),
+      { recoverable: true }
+    )
+
+    expect(records[2]).toEqual({
+      level: 'error',
+      message: 'operation failed',
+      data: {
+        recoverable: true,
+        operation: 'data-root-migration',
+        operationId: 'migration-1',
+        phase: 'copy',
+        outcome: 'failed',
+        durationMs: 24,
+        errorCategory: 'permission'
+      }
+    })
+    expect(JSON.stringify(records[2])).not.toContain('secret')
+  })
+
+  it('emits at most one terminal record and ignores every call after it', () => {
+    const { logger, records } = createRecordingLogger()
+    const operation = startDiagnosticOperation(logger, {
+      operation: 'update-check',
+      operationId: 'update-1',
+      now: () => 10
+    })
+
+    operation.complete()
+    operation.phase('late-phase')
+    operation.complete()
+    operation.cancel()
+    operation.fail(new Error('late failure'))
+
+    expect(records).toHaveLength(2)
+    expect(records[1]).toMatchObject({
+      message: 'operation completed',
+      data: { outcome: 'completed' }
+    })
+  })
+
+  it('records cancellation separately from failure', () => {
+    const { logger, records } = createRecordingLogger()
+    let timestamp = 20
+    const operation = startDiagnosticOperation(logger, {
+      operation: 'update-download',
+      operationId: 'update-1',
+      now: () => timestamp
+    })
+    operation.phase('download')
+
+    timestamp = 32
+    operation.cancel({ requestedByUser: true })
+
+    expect(records[2]).toEqual({
+      level: 'warn',
+      message: 'operation cancelled',
+      data: {
+        requestedByUser: true,
+        operation: 'update-download',
+        operationId: 'update-1',
+        phase: 'download',
+        outcome: 'cancelled',
+        durationMs: 12
+      }
+    })
+  })
+
+  it('keeps only scalar fields and protects diagnostic-owned fields', () => {
+    const { logger, records } = createRecordingLogger()
+
+    startDiagnosticOperation(logger, {
+      operation: 'session-hydration',
+      operationId: 'session-1',
+      fields: {
+        safe: 'kept',
+        operation: 'spoofed',
+        nested: { research: 'private' },
+        list: ['private']
+      } as unknown as DiagnosticFields
+    })
+
+    expect(records[0].data).toEqual({
+      safe: 'kept',
+      operation: 'session-hydration',
+      operationId: 'session-1',
+      outcome: 'started'
+    })
+  })
+
+  it('sanitizes scalar fields supplied to phase and terminal calls', () => {
+    const { logger, records } = createRecordingLogger()
+    const operation = startDiagnosticOperation(logger, {
+      operation: 'update-check',
+      operationId: 'update-1',
+      now: () => 5
+    })
+
+    operation.phase('checking', {
+      scalar: 1,
+      phase: 'spoofed',
+      nested: { secret: true }
+    } as unknown as DiagnosticFields)
+    operation.complete({
+      result: true,
+      outcome: 'spoofed',
+      nested: { secret: true }
+    } as unknown as DiagnosticFields)
+
+    expect(records[1].data).toEqual({
+      scalar: 1,
+      operation: 'update-check',
+      operationId: 'update-1',
+      phase: 'checking'
+    })
+    expect(records[2].data).toEqual({
+      result: true,
+      operation: 'update-check',
+      operationId: 'update-1',
+      phase: 'checking',
+      outcome: 'completed',
+      durationMs: 0
+    })
+  })
+
+  it('never throws when the diagnostic clock or sink fails', () => {
+    const throwFromSink = (): never => {
+      throw new Error('sink unavailable')
+    }
+    const logger: Logger = {
+      debug: throwFromSink,
+      info: throwFromSink,
+      warn: throwFromSink,
+      error: throwFromSink
+    }
+    let operation: ReturnType<typeof startDiagnosticOperation> | undefined
+
+    expect(() => {
+      operation = startDiagnosticOperation(logger, {
+        operation: 'startup',
+        operationId: 'startup-1',
+        now: () => {
+          throw new Error('clock unavailable')
+        }
+      })
+    }).not.toThrow()
+
+    expect(() => operation?.phase('compose')).not.toThrow()
+    expect(() => operation?.complete()).not.toThrow()
+    expect(() => operation?.cancel()).not.toThrow()
+    expect(() => operation?.fail(new Error('authoritative failure'))).not.toThrow()
+  })
+
+  it('never throws when the operation input has hostile property access', () => {
+    const { logger } = createRecordingLogger()
+    const hostileInput = new Proxy({} as DiagnosticOperationInput, {
+      get() {
+        throw new Error('input getter failed')
+      }
+    })
+    let operation: ReturnType<typeof startDiagnosticOperation> | undefined
+
+    expect(() => {
+      operation = startDiagnosticOperation(logger, hostileInput)
+    }).not.toThrow()
+    expect(() => operation?.phase('fallback')).not.toThrow()
+    expect(() => operation?.fail(new Error('original failure'))).not.toThrow()
+  })
+})

--- a/src/main/diagnostics/operation.ts
+++ b/src/main/diagnostics/operation.ts
@@ -1,0 +1,151 @@
+import { randomUUID } from 'node:crypto'
+
+import { diagnosticErrorFields, type Logger } from '../logger'
+
+export type DiagnosticValue = string | number | boolean | null | undefined
+export type DiagnosticFields = Record<string, DiagnosticValue>
+
+export type DiagnosticOperation = {
+  phase: (name: string, fields?: DiagnosticFields) => void
+  complete: (fields?: DiagnosticFields) => void
+  cancel: (fields?: DiagnosticFields) => void
+  fail: (error: unknown, fields?: DiagnosticFields) => void
+}
+
+export type DiagnosticOperationInput = {
+  operation: string
+  fields?: DiagnosticFields
+  now?: () => number
+  operationId?: string
+}
+
+const scalarFields = (fields: DiagnosticFields | undefined): DiagnosticFields => {
+  try {
+    if (!fields || typeof fields !== 'object' || Array.isArray(fields)) return {}
+
+    const safe: DiagnosticFields = Object.create(null) as DiagnosticFields
+    for (const key of Object.keys(fields)) {
+      let value: unknown
+      try {
+        value = (fields as Record<string, unknown>)[key]
+      } catch {
+        continue
+      }
+      if (
+        value === null ||
+        value === undefined ||
+        typeof value === 'string' ||
+        typeof value === 'boolean' ||
+        (typeof value === 'number' && Number.isFinite(value))
+      ) {
+        safe[key] = value as DiagnosticValue
+      }
+    }
+    return safe
+  } catch {
+    return {}
+  }
+}
+
+let fallbackOperationId = 0
+
+const inputValue = (
+  input: DiagnosticOperationInput,
+  key: keyof DiagnosticOperationInput
+): unknown => {
+  try {
+    return input[key]
+  } catch {
+    return undefined
+  }
+}
+
+const createOperationId = (): string => {
+  try {
+    return randomUUID()
+  } catch {
+    fallbackOperationId += 1
+    return `diagnostic-${fallbackOperationId}`
+  }
+}
+
+const emitSafely = (
+  logger: Logger,
+  level: keyof Logger,
+  message: string,
+  data: Record<string, unknown>
+): void => {
+  try {
+    logger[level](message, data)
+  } catch {
+    // Diagnostics must never alter the authoritative operation.
+  }
+}
+
+export const startDiagnosticOperation = (
+  logger: Logger,
+  input: DiagnosticOperationInput
+): DiagnosticOperation => {
+  const rawOperation = inputValue(input, 'operation')
+  const operation = typeof rawOperation === 'string' && rawOperation ? rawOperation : 'unknown'
+  const rawOperationId = inputValue(input, 'operationId')
+  const operationId =
+    typeof rawOperationId === 'string' && rawOperationId ? rawOperationId : createOperationId()
+  const rawNow = inputValue(input, 'now')
+  const now = typeof rawNow === 'function' ? (rawNow as () => number) : Date.now
+  const readNow = (): number => {
+    try {
+      const value = now()
+      return Number.isFinite(value) ? value : 0
+    } catch {
+      return 0
+    }
+  }
+  const startedAt = readNow()
+  const baseFields = scalarFields(inputValue(input, 'fields') as DiagnosticFields | undefined)
+  let latestPhase: string | undefined
+  let terminal = false
+
+  const eventFields = (fields?: DiagnosticFields): Record<string, unknown> => ({
+    ...baseFields,
+    ...scalarFields(fields),
+    operation,
+    operationId
+  })
+  const finish = (
+    level: keyof Logger,
+    message: string,
+    outcome: 'completed' | 'cancelled' | 'failed',
+    fields?: DiagnosticFields,
+    extraFields?: Record<string, unknown>
+  ): void => {
+    if (terminal) return
+    terminal = true
+    emitSafely(logger, level, message, {
+      ...eventFields(fields),
+      ...(latestPhase === undefined ? {} : { phase: latestPhase }),
+      outcome,
+      durationMs: Math.max(0, readNow() - startedAt),
+      ...extraFields
+    })
+  }
+
+  emitSafely(logger, 'info', 'operation started', {
+    ...baseFields,
+    operation,
+    operationId,
+    outcome: 'started'
+  })
+
+  return {
+    phase: (name, fields) => {
+      if (terminal) return
+      latestPhase = name
+      emitSafely(logger, 'info', 'operation phase', { ...eventFields(fields), phase: name })
+    },
+    complete: (fields) => finish('info', 'operation completed', 'completed', fields),
+    cancel: (fields) => finish('warn', 'operation cancelled', 'cancelled', fields),
+    fail: (error, fields) =>
+      finish('error', 'operation failed', 'failed', fields, diagnosticErrorFields(error))
+  }
+}

--- a/src/main/diagnostics/privacy-canary.test.ts
+++ b/src/main/diagnostics/privacy-canary.test.ts
@@ -1,0 +1,75 @@
+import { describe, expect, it } from 'vitest'
+
+import { createWebCallerContext } from '../caller-context'
+import { createRendererFailureReporter } from '../renderer-diagnostics'
+import type { Logger } from '../logger'
+import { invokeWithIpcRejectionDiagnostics } from './ipc-rejection'
+import { startDiagnosticOperation } from './operation'
+
+const PRIVACY_CANARIES = [
+  'sk-diagnostic-secret',
+  'Authorization: Bearer diagnostic-token',
+  '/Users/example/private-study/patient.csv',
+  'C:\\Users\\example\\private-study\\patient.csv',
+  'private prompt marker',
+  'private provider response marker',
+  'https://example.test/file?token=diagnostic-token'
+] as const
+
+const createCapturingLogger = (): { log: Logger; records: unknown[] } => {
+  const records: unknown[] = []
+  const capture = (message: string, data?: unknown): void => {
+    records.push({ message, data })
+  }
+  return {
+    log: { debug: capture, info: capture, warn: capture, error: capture },
+    records
+  }
+}
+
+describe('shared diagnostic privacy canary', () => {
+  it('keeps raw failures and request/report payloads out of every shared boundary', async () => {
+    const { log, records } = createCapturingLogger()
+    const privateText = PRIVACY_CANARIES.join(' | ')
+    const privateError = Object.assign(new Error(privateText), {
+      code: 'EACCES',
+      data: { prompt: privateText },
+      path: PRIVACY_CANARIES[2]
+    })
+
+    for (const operationName of [
+      'application-startup',
+      'data-root-copy',
+      'data-root-commit',
+      'update-check',
+      'application-shutdown'
+    ]) {
+      startDiagnosticOperation(log, { operation: operationName }).fail(privateError)
+    }
+
+    await expect(
+      invokeWithIpcRejectionDiagnostics({
+        channel: 'projects:list',
+        callerContext: createWebCallerContext('private-client'),
+        invoke: async () => {
+          void privateText
+          throw privateError
+        },
+        log
+      })
+    ).rejects.toBe(privateError)
+
+    const reporter = createRendererFailureReporter({ log })
+    reporter.report('private-sender', {
+      source: 'window-error',
+      surface: 'workspace',
+      errorCategory: 'error',
+      message: privateText
+    })
+
+    const serialized = JSON.stringify(records)
+    for (const canary of PRIVACY_CANARIES) expect(serialized).not.toContain(canary)
+    expect(serialized).not.toContain('private-client')
+    expect(serialized).not.toContain('private-sender')
+  })
+})

--- a/src/main/diagnostics/startup.test.ts
+++ b/src/main/diagnostics/startup.test.ts
@@ -1,0 +1,68 @@
+import { mkdtemp, readFile, rm } from 'node:fs/promises'
+import { tmpdir } from 'node:os'
+import { join } from 'node:path'
+import { afterEach, describe, expect, it } from 'vitest'
+
+import { initializeApplicationDiagnostics, reportApplicationStartupFailure } from './startup'
+
+let logDir: string | undefined
+
+afterEach(async () => {
+  if (logDir) await rm(logDir, { recursive: true, force: true })
+  logDir = undefined
+})
+
+describe('application startup diagnostics integration', () => {
+  it('flushes the last startup phase to JSONL without retaining the original failure', async () => {
+    logDir = await mkdtemp(join(tmpdir(), 'os-startup-diagnostics-'))
+    const diagnostics = initializeApplicationDiagnostics({
+      logDir,
+      runId: 'startup-run',
+      mirrorToConsole: false,
+      version: '1.2.3',
+      isPackaged: true,
+      platform: 'darwin',
+      arch: 'arm64',
+      electronVersion: '38.0.0',
+      nodeVersion: '22.0.0'
+    })
+    diagnostics.operation.phase('electron-ready')
+    const failure = Object.assign(
+      new Error('failed at /Users/example/private-study/patient.csv?token=diagnostic-token'),
+      { code: 'EACCES', data: { prompt: 'private prompt marker' } }
+    )
+
+    await expect(
+      reportApplicationStartupFailure({
+        operation: diagnostics.operation,
+        error: failure,
+        flush: diagnostics.flush,
+        timeoutMs: 1_000
+      })
+    ).resolves.toBe('flushed')
+
+    const jsonl = await readFile(join(logDir, 'main.log'), 'utf8')
+    const records = jsonl
+      .trim()
+      .split('\n')
+      .map((line) => JSON.parse(line) as Record<string, unknown>)
+    expect(records.length).toBeGreaterThanOrEqual(4)
+    expect(new Set(records.map((record) => record.runId))).toEqual(new Set(['startup-run']))
+    expect(records).toContainEqual(
+      expect.objectContaining({
+        level: 'error',
+        scope: 'main',
+        msg: 'operation failed',
+        data: expect.objectContaining({
+          operation: 'application-startup',
+          phase: 'electron-ready',
+          outcome: 'failed',
+          errorCategory: 'permission'
+        })
+      })
+    )
+    expect(jsonl).not.toContain('patient.csv')
+    expect(jsonl).not.toContain('diagnostic-token')
+    expect(jsonl).not.toContain('private prompt marker')
+  })
+})

--- a/src/main/diagnostics/startup.ts
+++ b/src/main/diagnostics/startup.ts
@@ -1,0 +1,60 @@
+import { createLogger, flushLogs, initLogger, type Logger } from '../logger'
+import { flushDiagnosticsWithTimeout, type DiagnosticFlushOutcome } from './flush'
+import { startDiagnosticOperation, type DiagnosticOperation } from './operation'
+
+type ApplicationDiagnosticMetadata = {
+  logDir: string
+  runId?: string
+  mirrorToConsole?: boolean
+  version: string
+  isPackaged: boolean
+  platform: NodeJS.Platform
+  arch: string
+  electronVersion: string
+  nodeVersion: string
+}
+
+export type ApplicationDiagnostics = {
+  log: Logger
+  operation: DiagnosticOperation
+  flush: () => Promise<void>
+}
+
+export const initializeApplicationDiagnostics = (
+  metadata: ApplicationDiagnosticMetadata
+): ApplicationDiagnostics => {
+  initLogger({
+    logDir: metadata.logDir,
+    ...(metadata.runId === undefined ? {} : { runId: metadata.runId }),
+    ...(metadata.mirrorToConsole === undefined ? {} : { mirrorToConsole: metadata.mirrorToConsole })
+  })
+  const log = createLogger('main')
+  const operation = startDiagnosticOperation(log, {
+    operation: 'application-startup',
+    fields: {
+      platform: metadata.platform,
+      arch: metadata.arch,
+      isPackaged: metadata.isPackaged
+    }
+  })
+  log.info('app starting', {
+    logSchemaVersion: 1,
+    version: metadata.version,
+    isPackaged: metadata.isPackaged,
+    platform: metadata.platform,
+    arch: metadata.arch,
+    electron: metadata.electronVersion,
+    node: metadata.nodeVersion
+  })
+  return { log, operation, flush: flushLogs }
+}
+
+export const reportApplicationStartupFailure = async (input: {
+  operation?: DiagnosticOperation
+  error: unknown
+  flush: () => Promise<void>
+  timeoutMs?: number
+}): Promise<DiagnosticFlushOutcome> => {
+  input.operation?.fail(input.error)
+  return flushDiagnosticsWithTimeout(input.flush, input.timeoutMs ?? 1_000)
+}

--- a/src/main/index.ts
+++ b/src/main/index.ts
@@ -1,8 +1,7 @@
 import { fileURLToPath } from 'node:url'
 
-// Only the lightweight argv flags are imported statically here. The MCP server modules (and their heavy
-// SDK graph) are imported lazily inside the matching branch, and the Electron backend is imported only
-// after the single-instance lock is held — so no backend module loads before the lock in UI mode.
+// Only lightweight, Electron-free diagnostics and argv flags are imported statically here. The MCP
+// server modules (and their heavy SDK graph) remain lazy inside the matching execution branch.
 import {
   ARTIFACT_MCP_SERVER_ARG,
   NOTEBOOK_MCP_SERVER_ARG,
@@ -10,12 +9,24 @@ import {
 } from './mcp-server-args'
 import { withApplicationRuntimeShutdown } from './application-runtime'
 import { installChildProcessGoneLogging, startLocalCrashReporting } from './crash-diagnostics'
+import type { DiagnosticOperation } from './diagnostics/operation'
+import {
+  initializeApplicationDiagnostics,
+  reportApplicationStartupFailure
+} from './diagnostics/startup'
+import { createLogger, diagnosticErrorFields, flushLogs } from './logger'
+import {
+  createRendererFailureReporter,
+  registerRendererDiagnosticsIpc
+} from './renderer-diagnostics'
 
 const APP_NAME = 'Open Science'
 const APP_USER_MODEL_ID = 'com.aipoch.open-science'
 const shouldRunArtifactMcpServer = process.argv.includes(ARTIFACT_MCP_SERVER_ARG)
 const shouldRunNotebookMcpServer = process.argv.includes(NOTEBOOK_MCP_SERVER_ARG)
 const shouldRunSkillImportMcpServer = process.argv.includes(SKILL_IMPORT_MCP_SERVER_ARG)
+let startupDiagnostics: DiagnosticOperation | undefined
+let startupFlush = flushLogs
 
 if (shouldRunArtifactMcpServer) {
   // Reuse the packaged entry point as a Node stdio MCP server; import it only in this mode.
@@ -41,7 +52,12 @@ if (shouldRunArtifactMcpServer) {
       process.exitCode = 1
     })
 } else {
-  void startElectronApp(fileURLToPath(import.meta.url)).catch((error: unknown) => {
+  void startElectronApp(fileURLToPath(import.meta.url)).catch(async (error: unknown) => {
+    await reportApplicationStartupFailure({
+      operation: startupDiagnostics,
+      error,
+      flush: startupFlush
+    })
     console.error(error)
     process.exitCode = 1
   })
@@ -49,8 +65,41 @@ if (shouldRunArtifactMcpServer) {
 
 // Boots the Electron app only in normal UI mode, keeping artifact MCP mode free of Electron imports.
 async function startElectronApp(mainEntryPath: string): Promise<void> {
+  const { app, BrowserWindow, crashReporter, ipcMain, nativeImage, protocol } =
+    await import('electron')
+
+  // Establish the app identity and file sink before loading the backend graph. This captures failures
+  // in asset/module loading and app.whenReady instead of leaving packaged startup failures console-only.
+  app.setName(app.isPackaged ? APP_NAME : `${APP_NAME} (DEV)`)
+  const diagnostics = initializeApplicationDiagnostics({
+    logDir: app.getPath('logs'),
+    version: app.getVersion(),
+    isPackaged: app.isPackaged,
+    platform: process.platform,
+    arch: process.arch,
+    electronVersion: process.versions.electron,
+    nodeVersion: process.versions.node
+  })
+  const { log } = diagnostics
+  startupDiagnostics = diagnostics.operation
+  startupFlush = diagnostics.flush
+
+  // Register process-level failure capture before loading the application modules. Keep renderer
+  // diagnostics on a separate, one-way channel while the central IPC registry is being refactored.
+  installChildProcessGoneLogging((listener) => app.on('child-process-gone', listener), log)
+  process.on('uncaughtException', (error) =>
+    log.error('uncaughtException', diagnosticErrorFields(error))
+  )
+  process.on('unhandledRejection', (reason) =>
+    log.error('unhandledRejection', diagnosticErrorFields(reason))
+  )
+  registerRendererDiagnosticsIpc(
+    ipcMain,
+    createRendererFailureReporter({ log: createLogger('renderer') })
+  )
+
+  startupDiagnostics.phase('load-bootstrap-modules')
   const [
-    { app, BrowserWindow, crashReporter, nativeImage, protocol },
     { electronApp },
     { default: icon },
     { default: iconDark },
@@ -62,7 +111,6 @@ async function startElectronApp(mainEntryPath: string): Promise<void> {
     { acquireSingleInstanceLock },
     { orchestrateAppStartup }
   ] = await Promise.all([
-    import('electron'),
     import('@electron-toolkit/utils'),
     import('../../resources/icon.png?asset'),
     import('../../resources/icon-dark.png?asset'),
@@ -91,6 +139,7 @@ async function startElectronApp(mainEntryPath: string): Promise<void> {
   // lifecycle so its before-quit runs first. A second launch that arrives mid-startup is recorded by the
   // relay and surfaced once the window exists.
   await orchestrateAppStartup({
+    diagnostics: startupDiagnostics,
     acquireSingleInstanceLock: (opts) => acquireSingleInstanceLock(opts),
     quit: () => app.quit(),
     prepare: async () => {
@@ -105,7 +154,9 @@ async function startElectronApp(mainEntryPath: string): Promise<void> {
         appVersion: app.getVersion(),
         start: (options) => crashReporter.start(options)
       })
+      startupDiagnostics?.phase('crash-reporting', { enabled: crashReporting.enabled })
 
+      startupDiagnostics?.phase('load-application-modules')
       const [
         { registerIpcHandlers },
         { createMainWindow },
@@ -156,44 +207,14 @@ async function startElectronApp(mainEntryPath: string): Promise<void> {
         import('./storage-root')
       ])
 
-      // Dev runs get a "(DEV)" suffix so the app name, macOS menu, and per-app paths (logs, userData)
-      // are visibly distinct from an installed build — and don't collide with it.
-      app.setName(app.isPackaged ? APP_NAME : `${APP_NAME} (DEV)`)
-
       protocol.registerSchemesAsPrivileged([
         MANAGED_PREVIEW_SCHEME,
         OFFICE_PREVIEW_RUNTIME_SCHEME_CONFIG
       ])
 
+      startupDiagnostics?.phase('electron-ready')
       await app.whenReady()
-
-      // Initialize file logging as early as possible so startup and agent-spawn issues are captured for
-      // later troubleshooting (especially in packaged builds where console output is not visible).
-      const { createLogger, getLogFilePath, initLogger } = await import('./logger')
-      initLogger({ logDir: app.getPath('logs') })
-      const log = createLogger('main')
-
-      log.info('app starting', {
-        version: app.getVersion(),
-        isPackaged: app.isPackaged,
-        platform: process.platform,
-        electron: process.versions.electron,
-        node: process.versions.node,
-        execPath: process.execPath,
-        logFile: getLogFilePath(),
-        crashReporting: crashReporting.enabled
-          ? { ...crashReporting, dumpsDirectory: app.getPath('crashDumps') }
-          : crashReporting
-      })
-
-      // Renderer exits are logged by each BrowserWindow. This complementary app-level event catches
-      // GPU and utility-process failures, which can also leave a window blank but are otherwise absent
-      // from main.log. Keep only Electron lifecycle vocabulary and numeric exit metadata.
-      installChildProcessGoneLogging((listener) => app.on('child-process-gone', listener), log)
-
-      // Capture otherwise-silent crashes so a hang or unexpected exit leaves a trail in the log file.
-      process.on('uncaughtException', (error) => log.error('uncaughtException', error))
-      process.on('unhandledRejection', (reason) => log.error('unhandledRejection', reason))
+      startupDiagnostics?.phase('compose-runtime')
 
       // Set app user model id for windows
       electronApp.setAppUserModelId(APP_USER_MODEL_ID)
@@ -390,7 +411,9 @@ async function startElectronApp(mainEntryPath: string): Promise<void> {
             flushSessionPersistence: ctx.createSessionPersistenceFlush(() =>
               ctx.mainWindowGetterBox.current?.()
             ),
-            createConfirmClose: ctx.createConfirmClose
+            createConfirmClose: ctx.createConfirmClose,
+            log: ctx.log,
+            flushLogs
           },
           {
             // Application composition owns the one bounded ACP/Notebook shutdown. Remaining surfaces

--- a/src/main/index.ts
+++ b/src/main/index.ts
@@ -68,9 +68,24 @@ async function startElectronApp(mainEntryPath: string): Promise<void> {
   const { app, BrowserWindow, crashReporter, ipcMain, nativeImage, protocol } =
     await import('electron')
 
-  // Establish the app identity and file sink before loading the backend graph. This captures failures
-  // in asset/module loading and app.whenReady instead of leaving packaged startup failures console-only.
+  // Establish identity and single-writer ownership before opening main.log. A secondary launch must
+  // never rotate or append to the primary process's file sink. These two modules are lightweight; all
+  // backend imports remain behind the lock.
   app.setName(app.isPackaged ? APP_NAME : `${APP_NAME} (DEV)`)
+  const [{ acquireSingleInstanceLock }, { createSecondInstanceRelay, orchestrateAppStartup }] =
+    await Promise.all([import('./single-instance'), import('./app-startup')])
+  const preStartupSecondInstanceRelay = createSecondInstanceRelay()
+  if (
+    !acquireSingleInstanceLock({
+      onSecondInstance: (argv) => preStartupSecondInstanceRelay.signal(argv)
+    })
+  ) {
+    app.quit()
+    return
+  }
+
+  // Initialize the file sink after the primary lock but before assets, the backend graph, and
+  // app.whenReady so packaged startup failures remain locally diagnosable.
   const diagnostics = initializeApplicationDiagnostics({
     logDir: app.getPath('logs'),
     version: app.getVersion(),
@@ -107,9 +122,7 @@ async function startElectronApp(mainEntryPath: string): Promise<void> {
     { default: iconDarkWindows },
     { default: trayMacTemplate },
     { default: trayWindows },
-    { default: trayLinux },
-    { acquireSingleInstanceLock },
-    { orchestrateAppStartup }
+    { default: trayLinux }
   ] = await Promise.all([
     import('@electron-toolkit/utils'),
     import('../../resources/icon.png?asset'),
@@ -118,9 +131,7 @@ async function startElectronApp(mainEntryPath: string): Promise<void> {
     import('../../resources/icon-dark.ico?asset'),
     import('../../resources/trayTemplate.png?asset'),
     import('../../resources/tray.ico?asset'),
-    import('../../resources/tray.png?asset'),
-    import('./single-instance'),
-    import('./app-startup')
+    import('../../resources/tray.png?asset')
   ])
 
   // Windows gets multi-resolution ICOs for title-bar and Alt-Tab fidelity; macOS Dock and Linux use
@@ -140,7 +151,12 @@ async function startElectronApp(mainEntryPath: string): Promise<void> {
   // relay and surfaced once the window exists.
   await orchestrateAppStartup({
     diagnostics: startupDiagnostics,
-    acquireSingleInstanceLock: (opts) => acquireSingleInstanceLock(opts),
+    // The OS lock is already held. Bind the orchestrator's relay to the pre-logger relay so any
+    // second-instance signal received during bootstrap is preserved until the lifecycle is ready.
+    acquireSingleInstanceLock: ({ onSecondInstance }) => {
+      preStartupSecondInstanceRelay.bind(onSecondInstance)
+      return true
+    },
     quit: () => app.quit(),
     prepare: async () => {
       // Start Windows Crashpad after the single-instance lock but before any BrowserWindow can create

--- a/src/main/ipc-handler-registry.test.ts
+++ b/src/main/ipc-handler-registry.test.ts
@@ -173,4 +173,74 @@ describe('createIpcHandlerRegistry', () => {
 
     expect(removeHandler).toHaveBeenCalledWith('test:partial')
   })
+
+  it('records a rejected native handler once without retaining its payload', async () => {
+    const nativeHandlers = new Map<string, (...args: unknown[]) => unknown>()
+    const handle = vi.fn((channel: string, handler: (...args: unknown[]) => unknown) => {
+      nativeHandlers.set(channel, handler)
+    })
+    const warn = vi.fn()
+    const now = vi.fn().mockReturnValueOnce(100).mockReturnValueOnce(125)
+    const registry = createIpcHandlerRegistry({ handle } as never, { log: { warn }, now })
+    const rejection = new Error('private native failure')
+    registry.ipcMainHandle('projects:list', async () => {
+      throw rejection
+    })
+
+    await expect(
+      nativeHandlers.get('projects:list')?.(
+        { sender: { id: 42 } },
+        { token: 'native-secret', path: '/private/native.txt' }
+      )
+    ).rejects.toBe(rejection)
+    expect(warn).toHaveBeenCalledOnce()
+    expect(warn).toHaveBeenCalledWith('ipc handler rejected', {
+      channel: 'projects:list',
+      surface: 'electron',
+      location: 'local',
+      principalKind: 'human',
+      actionOrigin: 'human',
+      durationMs: 25,
+      errorCategory: 'error'
+    })
+    expect(JSON.stringify(warn.mock.calls)).not.toContain('native-secret')
+    expect(JSON.stringify(warn.mock.calls)).not.toContain('/private/native.txt')
+    expect(JSON.stringify(warn.mock.calls)).not.toContain('private native failure')
+    expect(JSON.stringify(warn.mock.calls)).not.toContain('42')
+  })
+
+  it('records a rejected Web RPC handler once using the supplied caller vocabulary', async () => {
+    const warn = vi.fn()
+    const now = vi.fn().mockReturnValueOnce(10).mockReturnValueOnce(18)
+    const registry = createIpcHandlerRegistry({ handle: vi.fn() } as never, { log: { warn }, now })
+    const rejection = new TypeError('private Web failure')
+    registry.ipcMainHandle('projects:list', async () => {
+      throw rejection
+    })
+
+    await expect(
+      registry.webRpc.invoke(
+        'projects:list',
+        createWebCallerContext('secret-client-id', {
+          location: 'remote',
+          principalKind: 'automation',
+          actionOrigin: 'agent-session'
+        }),
+        [{ token: 'web-secret' }]
+      )
+    ).rejects.toBe(rejection)
+    expect(warn).toHaveBeenCalledOnce()
+    expect(warn).toHaveBeenCalledWith('ipc handler rejected', {
+      channel: 'projects:list',
+      surface: 'web',
+      location: 'remote',
+      principalKind: 'automation',
+      actionOrigin: 'agent-session',
+      durationMs: 8,
+      errorCategory: 'type'
+    })
+    expect(JSON.stringify(warn.mock.calls)).not.toContain('secret-client-id')
+    expect(JSON.stringify(warn.mock.calls)).not.toContain('web-secret')
+    expect(JSON.stringify(warn.mock.calls)).not.toContain('private Web failure')
+  })
 })

--- a/src/main/ipc-handler-registry.ts
+++ b/src/main/ipc-handler-registry.ts
@@ -4,6 +4,11 @@ import { ipcMain, type IpcMain, type IpcMainInvokeEvent } from 'electron'
 
 import { isWebRpcChannel } from '../shared/web-rpc-contract'
 import { callerContextForEvent, hasCallerAuthority, type CallerContext } from './caller-context'
+import {
+  invokeWithIpcRejectionDiagnostics,
+  type IpcRejectionLogger
+} from './diagnostics/ipc-rejection'
+import { createLogger } from './logger'
 
 type IpcHandler = Parameters<IpcMain['handle']>[1]
 
@@ -65,9 +70,35 @@ type IpcHandlerRegistry = {
   createInstallationScope(): IpcHandlerInstallationScope
 }
 
+type IpcHandlerRegistryDiagnostics = {
+  log?: IpcRejectionLogger
+  now?: () => number
+}
+
+const diagnosticCallerContextForEvent = (
+  event: IpcMainInvokeEvent
+): Pick<CallerContext, 'surface' | 'location' | 'principalKind' | 'actionOrigin'> => {
+  try {
+    return callerContextForEvent(event)
+  } catch {
+    return {
+      surface: 'electron',
+      location: 'local',
+      principalKind: 'human',
+      actionOrigin: 'human'
+    }
+  }
+}
+
 const createIpcHandlerRegistry = (
-  target: Pick<IpcMain, 'handle'> & Partial<Pick<IpcMain, 'removeHandler'>>
+  target: Pick<IpcMain, 'handle'> & Partial<Pick<IpcMain, 'removeHandler'>>,
+  diagnostics: IpcHandlerRegistryDiagnostics = {}
 ): IpcHandlerRegistry => {
+  const diagnosticLog =
+    diagnostics.log ??
+    ({
+      warn: (message, data) => createLogger('ipc').warn(message, data)
+    } satisfies IpcRejectionLogger)
   const webHandlers = new Map<string, IpcHandler>()
   const registeredChannels = new Set<string>()
   const clients = new Map<string, { id: number; lifecycle: EventEmitter }>()
@@ -91,7 +122,15 @@ const createIpcHandlerRegistry = (
   }
 
   const ipcMainHandle: IpcMain['handle'] = (channel, listener) => {
-    target.handle(channel, listener)
+    target.handle(channel, (event, ...args) =>
+      invokeWithIpcRejectionDiagnostics({
+        channel,
+        callerContext: diagnosticCallerContextForEvent(event),
+        invoke: () => listener(event, ...args),
+        log: diagnosticLog,
+        now: diagnostics.now
+      })
+    )
     registeredChannels.add(channel)
     if (isWebRpcChannel(channel)) webHandlers.set(channel, listener)
   }
@@ -146,7 +185,13 @@ const createIpcHandlerRegistry = (
         }
         const sender = senderFor(callerContext)
         const event = { sender } as unknown as IpcMainInvokeEvent
-        return handler(event, ...args)
+        return invokeWithIpcRejectionDiagnostics({
+          channel,
+          callerContext,
+          invoke: () => handler(event, ...args),
+          log: diagnosticLog,
+          now: diagnostics.now
+        })
       },
       releaseClient: destroyClient,
       dispose: () => {
@@ -175,4 +220,4 @@ export {
   isRemotePairingManagerSender,
   webRpc
 }
-export type { IpcHandlerInstallation, IpcHandlerInstallationScope }
+export type { IpcHandlerInstallation, IpcHandlerInstallationScope, IpcHandlerRegistryDiagnostics }

--- a/src/main/ipc.ts
+++ b/src/main/ipc.ts
@@ -35,9 +35,11 @@ import { createSessionArtifactFileResolver } from './session-artifact-file-resol
 import { registerCliInstallIpcHandlers } from './cli-install/ipc'
 import { registerGithubIpcHandlers } from './github-ipc'
 import {
+  BackendShutdownOutcomeError,
   BackendShutdownCoordinator,
   QUIT_SHUTDOWN_BUDGET_MS,
-  UPDATE_SHUTDOWN_BUDGET_MS
+  UPDATE_SHUTDOWN_BUDGET_MS,
+  type ShutdownStepOutcome
 } from './lifecycle-shutdown'
 import { registerLifecycleIpcHandlers } from './lifecycle-broadcast'
 import { registerLogsIpcHandlers } from './logs-ipc'
@@ -49,7 +51,8 @@ import {
   buildConnectorApprovalBroadcast,
   buildTaskNotificationShow
 } from './notifications/electron-wiring'
-import { createLogger, errorLogFields } from './logger'
+import { createLogger, diagnosticErrorFields, errorLogFields } from './logger'
+import { startDiagnosticOperation } from './diagnostics/operation'
 import {
   broadcastNotebookEnvProgress,
   registerNotebookEnvIpcHandlers,
@@ -199,7 +202,7 @@ export type ApplicationRuntimeInterfaces = {
   taskAgent: TaskAgentPort
   sessionDeletionCapability: Pick<SessionPersistenceCoordinator, 'setSessionDeletionHandlers'>
   detectActiveSessions: () => ReturnType<typeof detectActiveSessions>
-  prepareForQuit: () => Promise<void>
+  prepareForQuit: () => Promise<Extract<ShutdownStepOutcome, 'completed' | 'timeout' | 'failed'>>
 }
 
 type ApplicationModuleInterfaces = ApplicationRuntimeInterfaces & {
@@ -260,15 +263,14 @@ const createApplicationModules = async (
     capability: createDefaultSettingsService()
   }))
   const storedSettings = await settingsService.getStoredSettings()
+  const storageLog = createLogger('storage')
   // Prime the data-root cache from settings before any data repository is constructed below. A change
   // to this value only takes effect after a restart, so reading it once here is sufficient.
   initDataRoot(storedSettings.dataRoot)
-  // Recovery breadcrumb: if settings.json is ever lost/corrupted, the resolved dataRoot from the
-  // last successful launch is still findable in the logs, so a user with data at a non-default
-  // location isn't left guessing where it went.
-  createLogger('storage').info('data root resolved', {
-    dataRoot: resolveDataRoot(),
-    isDefault: samePath(resolveDataRoot(), computeDefaultDataRoot())
+  // Record only the location class. Absolute paths (including reversible code-point renderings) can
+  // expose usernames and folder names in a support bundle.
+  storageLog.info('data root resolved', {
+    location: samePath(resolveDataRoot(), computeDefaultDataRoot()) ? 'default' : 'custom'
   })
 
   // Constructed once here (rather than left to each register*IpcHandlers' own default) so the
@@ -279,9 +281,9 @@ const createApplicationModules = async (
   } catch (error) {
     // Ready bytes remain fail-closed; keep startup available so Files can surface unaffected rows and
     // the next launch can retry any recoverable staging Version.
-    createLogger('storage').error(
+    storageLog.error(
       'staging upload recovery incomplete; will retry next launch',
-      error
+      diagnosticErrorFields(error)
     )
   }
   const sessionRepository = createDefaultSessionRepository()
@@ -293,6 +295,11 @@ const createApplicationModules = async (
   // startup on failure: an error is logged and the marker stays unset, so the pass simply retries on
   // the next launch.
   if (!storedSettings.pathsNormalizedAt) {
+    const normalizationOperation = startDiagnosticOperation(storageLog, {
+      operation: 'legacy-data-root-normalization',
+      fields: { mode: 'legacy-normalize' }
+    })
+    normalizationOperation.phase('rewrite-paths')
     try {
       await normalizeLegacyDataPaths({
         sessionRepository,
@@ -301,12 +308,11 @@ const createApplicationModules = async (
         projectRepository,
         dataRoot: resolveDataRoot()
       })
+      normalizationOperation.phase('persist-marker')
       await settingsService.markPathsNormalized()
+      normalizationOperation.complete()
     } catch (error) {
-      createLogger('storage').error(
-        'legacy path normalization failed; will retry next launch',
-        error
-      )
+      normalizationOperation.fail(error)
     }
   }
 
@@ -1363,7 +1369,7 @@ const createApplicationModules = async (
     name: 'backend-shutdown-coordinator',
     capability: undefined,
     disposeTimeoutMs: QUIT_SHUTDOWN_BUDGET_MS + APPLICATION_MODULE_DISPOSAL_BUDGET_MS,
-    dispose: () => coordinator.runForQuit().then(() => undefined)
+    dispose: async () => BackendShutdownOutcomeError.assertClean(await coordinator.runForQuit())
   }))
   backendTeardownOwnedByCoordinator = true
 

--- a/src/main/lifecycle-shutdown.test.ts
+++ b/src/main/lifecycle-shutdown.test.ts
@@ -1,5 +1,6 @@
 import { afterEach, describe, expect, it, vi } from 'vitest'
 import {
+  BackendShutdownOutcomeError,
   BackendShutdownCoordinator,
   shutdownBackends,
   UPDATE_SHUTDOWN_BUDGET_MS,
@@ -44,7 +45,13 @@ describe('shutdownBackends', () => {
     })
     await expect(shutdownBackends(deps)).resolves.toBeUndefined()
     expect(deps.notebook.dispose).toHaveBeenCalledTimes(1)
-    expect(deps.log?.error).toHaveBeenCalledWith(expect.any(String), err)
+    expect(deps.log?.error).toHaveBeenCalledWith('backend shutdown failed', {
+      backend: 'runtime',
+      errorCategory: 'error'
+    })
+    const errorLog = deps.log?.error
+    if (!errorLog) throw new Error('Expected a shutdown logger.')
+    expect(JSON.stringify(vi.mocked(errorLog).mock.calls)).not.toContain('runtime boom')
   })
 
   it('resolves and logs even when notebook shutdown rejects', async () => {
@@ -57,7 +64,30 @@ describe('shutdownBackends', () => {
     })
     await expect(shutdownBackends(deps)).resolves.toBeUndefined()
     expect(deps.runtime.shutdownForQuit).toHaveBeenCalledTimes(1)
-    expect(deps.log?.error).toHaveBeenCalledWith(expect.any(String), err)
+    expect(deps.log?.error).toHaveBeenCalledWith('backend shutdown failed', {
+      backend: 'notebook',
+      errorCategory: 'error'
+    })
+    const errorLog = deps.log?.error
+    if (!errorLog) throw new Error('Expected a shutdown logger.')
+    expect(JSON.stringify(vi.mocked(errorLog).mock.calls)).not.toContain('notebook boom')
+  })
+
+  it('still resolves when backend teardown and the diagnostic sink both fail', async () => {
+    const deps = makeDeps({
+      runtime: {
+        shutdownForQuit: vi.fn(async () => Promise.reject(new Error('runtime boom'))),
+        shutdownForUpdateGate: vi.fn(async () => ({ reaped: true }))
+      },
+      log: {
+        error: () => {
+          throw new Error('sink unavailable')
+        }
+      }
+    })
+
+    await expect(shutdownBackends(deps)).resolves.toBeUndefined()
+    expect(deps.notebook.dispose).toHaveBeenCalledOnce()
   })
 
   it('resolves via the timeout when a backend never settles', async () => {
@@ -148,4 +178,16 @@ describe('BackendShutdownCoordinator', () => {
 
     await expect(pending).resolves.toEqual({ completed: false, reaped: false })
   })
+
+  it.each([
+    ['timeout', { completed: false, reaped: false }],
+    ['degraded', { completed: true, reaped: false }]
+  ] as const)(
+    'converts a non-clean quit result into the fixed %s category',
+    (expected, outcome) => {
+      expect(() => BackendShutdownOutcomeError.assertClean(outcome)).toThrowError(
+        expect.objectContaining({ outcome: expected })
+      )
+    }
+  )
 })

--- a/src/main/lifecycle-shutdown.ts
+++ b/src/main/lifecycle-shutdown.ts
@@ -4,6 +4,10 @@
 // that refuses to settle, and reports { reaped } so the update-install gate can tell a clean teardown
 // (all process trees gone, file handles released) from a degraded one (taskkill fell back to the parent).
 
+import { diagnosticErrorFields, type Logger } from './logger'
+
+export type ShutdownStepOutcome = 'completed' | 'timeout' | 'failed' | 'degraded'
+
 export type ShutdownOutcome = {
   // The two backend teardowns settled within the budget (false = the deadline elapsed first).
   completed: boolean
@@ -11,7 +15,20 @@ export type ShutdownOutcome = {
   reaped: boolean
 }
 
-type ShutdownLogger = { error: (msg: string, err?: unknown) => void }
+export class BackendShutdownOutcomeError extends Error {
+  readonly name = 'BackendShutdownOutcomeError'
+
+  constructor(readonly outcome: Extract<ShutdownStepOutcome, 'timeout' | 'degraded'>) {
+    super('Backend shutdown did not complete cleanly.')
+  }
+
+  static assertClean(outcome: ShutdownOutcome): void {
+    if (!outcome.completed) throw new BackendShutdownOutcomeError('timeout')
+    if (!outcome.reaped) throw new BackendShutdownOutcomeError('degraded')
+  }
+}
+
+type ShutdownLogger = Pick<Logger, 'error'>
 
 // Deps for the quit/relaunch helper: only the latching teardown is needed. Kept narrow so the migration
 // relaunch path (storage/ipc.ts) does not have to expose the non-latching gate method it never uses.
@@ -58,15 +75,25 @@ const runBounded = async (
   log?: BackendShutdownDeps['log']
 ): Promise<ShutdownOutcome> => {
   let reaped = false
+  const logFailure = (backend: 'runtime' | 'notebook', error: unknown): void => {
+    try {
+      log?.error('backend shutdown failed', {
+        backend,
+        ...diagnosticErrorFields(error)
+      })
+    } catch {
+      // Shutdown progress is authoritative; diagnostics are best-effort.
+    }
+  }
 
   // allSettled ensures one rejection never short-circuits the other.
   const settleAll = Promise.allSettled([runtimeTeardown, notebookTeardown]).then(
     ([runtimeResult, notebookResult]) => {
       if (runtimeResult.status === 'rejected') {
-        log?.error('runtime shutdown failed during shutdown', runtimeResult.reason)
+        logFailure('runtime', runtimeResult.reason)
       }
       if (notebookResult.status === 'rejected') {
-        log?.error('notebook shutdown failed during shutdown', notebookResult.reason)
+        logFailure('notebook', notebookResult.reason)
       }
 
       // Optional chaining keeps the never-throw invariant even if a teardown resolves a malformed value.

--- a/src/main/logger.test.ts
+++ b/src/main/logger.test.ts
@@ -67,6 +67,34 @@ describe('logger: formatLine', () => {
   })
 })
 
+describe('logger: process run context', () => {
+  it('adds the configured run ID to every emitted JSONL record without changing existing keys', async () => {
+    logDir = await mkdtemp(join(tmpdir(), 'os-logger-run-'))
+    initLogger({
+      logDir,
+      fileName: 'main.log',
+      mirrorToConsole: false,
+      runId: 'test-run-id'
+    })
+
+    createLogger('startup').info('ready', { phase: 'ready' })
+    await flushLogs()
+
+    const record = JSON.parse(await readFile(join(logDir, 'main.log'), 'utf8')) as Record<
+      string,
+      unknown
+    >
+    expect(record).toMatchObject({
+      level: 'info',
+      runId: 'test-run-id',
+      scope: 'startup',
+      msg: 'ready',
+      data: { phase: 'ready' }
+    })
+    expect(typeof record.t).toBe('string')
+  })
+})
+
 describe('logger: diagnosticErrorFields', () => {
   it('classifies a provider request error without retaining its payload', () => {
     const secret = 'provider-secret-value'
@@ -938,7 +966,7 @@ describe('logger: errorLogFields', () => {
 })
 
 describe('logger: application shutdown diagnostics', () => {
-  it('persists every aggregate cause with the timed-out module name and budget', async () => {
+  it('persists fixed surface outcomes without aggregate error details', async () => {
     logDir = await mkdtemp(join(tmpdir(), 'os-logger-shutdown-'))
     initLogger({ logDir, fileName: 'main.log', mirrorToConsole: false })
     const log = createLogger('shutdown')
@@ -948,7 +976,7 @@ describe('logger: application shutdown diagnostics', () => {
         Promise.reject(
           new AggregateError([
             new ApplicationModuleDisposalTimeoutError('mcp-client-manager', 1000),
-            new Error('compute poller stop failed')
+            new Error('compute poller stop failed at /private/project')
           ])
         ),
       shutdownRemoteAccess: () => undefined,
@@ -961,13 +989,37 @@ describe('logger: application shutdown diagnostics', () => {
     const records = (await readFile(join(logDir, 'main.log'), 'utf8'))
       .trim()
       .split('\n')
-      .map((line) => JSON.parse(line) as { msg: string })
+      .map(
+        (line) =>
+          JSON.parse(line) as {
+            msg: string
+            data: { surface: string; result: string; errorCategory: string }
+          }
+      )
 
-    expect(records.map((record) => record.msg)).toEqual([
-      expect.stringContaining('mcp-client-manager'),
-      expect.stringContaining('compute poller stop failed')
+    expect(records).toEqual([
+      expect.objectContaining({
+        msg: 'application surface shutdown failed',
+        data: {
+          surface: 'application-runtime',
+          result: 'timeout',
+          errorCategory: 'object'
+        }
+      }),
+      expect.objectContaining({
+        msg: 'application surface shutdown failed',
+        data: {
+          surface: 'application-runtime',
+          result: 'failed',
+          errorCategory: 'error'
+        }
+      })
     ])
-    expect(records[0].msg).toContain('1000ms')
+    const json = JSON.stringify(records)
+    expect(json).not.toContain('mcp-client-manager')
+    expect(json).not.toContain('1000ms')
+    expect(json).not.toContain('compute poller stop failed')
+    expect(json).not.toContain('/private/project')
   })
 })
 

--- a/src/main/logger.ts
+++ b/src/main/logger.ts
@@ -1,4 +1,5 @@
 import { appendFile, mkdir, rename, rm, stat } from 'node:fs/promises'
+import { randomUUID } from 'node:crypto'
 import { extname, join } from 'node:path'
 
 // Lightweight structured file logger for the main process. Kept free of Electron imports so it stays
@@ -16,6 +17,7 @@ const LEVEL_ORDER: Record<LogLevel, number> = { debug: 10, info: 20, warn: 30, e
 
 export type LoggerConfig = {
   logDir: string
+  runId: string
   fileName: string
   minLevel: LogLevel
   mirrorToConsole: boolean
@@ -530,7 +532,13 @@ const errorLogFields = (error: unknown): Record<string, unknown> => {
   }
 }
 
-const formatLine = (level: LogLevel, scope: string, message: string, data?: unknown): string => {
+const formatLine = (
+  level: LogLevel,
+  scope: string,
+  message: string,
+  data?: unknown,
+  runId?: string
+): string => {
   const record: Record<string, unknown> = {
     t: new Date().toISOString(),
     level,
@@ -538,13 +546,21 @@ const formatLine = (level: LogLevel, scope: string, message: string, data?: unkn
     msg: message
   }
 
+  if (runId !== undefined) record.runId = runId
   if (data !== undefined) record.data = toSerializable(data)
 
   try {
     return JSON.stringify(record)
   } catch {
     // Fall back to a best-effort line if the payload has circular refs.
-    return JSON.stringify({ t: record.t, level, scope, msg: message, data: '[unserializable]' })
+    return JSON.stringify({
+      t: record.t,
+      level,
+      ...(runId === undefined ? {} : { runId }),
+      scope,
+      msg: message,
+      data: '[unserializable]'
+    })
   }
 }
 
@@ -625,6 +641,7 @@ const appendLine = (line: string): void => {
 // Initializes the sink. Safe to call once at startup; later calls replace the config and re-seed size.
 const initLogger = (options: { logDir: string } & Partial<Omit<LoggerConfig, 'logDir'>>): void => {
   config = {
+    runId: randomUUID(),
     fileName: 'main.log',
     minLevel: 'debug',
     mirrorToConsole: true,
@@ -652,7 +669,7 @@ const emit = (level: LogLevel, scope: string, message: string, data?: unknown): 
 
   if (config && LEVEL_ORDER[level] < LEVEL_ORDER[config.minLevel]) return
 
-  appendLine(formatLine(level, scope, message, data))
+  appendLine(formatLine(level, scope, message, data, config?.runId))
 }
 
 export type Logger = {

--- a/src/main/renderer-diagnostics.test.ts
+++ b/src/main/renderer-diagnostics.test.ts
@@ -1,0 +1,276 @@
+import { describe, expect, it, vi } from 'vitest'
+
+import type { RendererFailureReport } from '../shared/diagnostics'
+import {
+  createRendererFailureReporter,
+  registerRendererDiagnosticsIpc
+} from './renderer-diagnostics'
+
+describe('createRendererFailureReporter', () => {
+  it('records a validated renderer failure without retaining extra renderer data', () => {
+    const error = vi.fn()
+    const reporter = createRendererFailureReporter({
+      log: { error, warn: vi.fn() },
+      now: () => 100
+    })
+
+    expect(
+      reporter.report('renderer-a', {
+        source: 'window-error',
+        surface: 'workspace',
+        errorCategory: 'type',
+        fingerprint: 'a1b2c3d4'
+      })
+    ).toBe('recorded')
+    expect(error).toHaveBeenCalledWith('renderer javascript failure', {
+      source: 'window-error',
+      surface: 'workspace',
+      errorCategory: 'type',
+      fingerprint: 'a1b2c3d4'
+    })
+  })
+
+  it('rejects renderer payloads that contain fields outside the diagnostics contract', () => {
+    const error = vi.fn()
+    const warn = vi.fn()
+    const reporter = createRendererFailureReporter({ log: { error, warn } })
+
+    expect(
+      reporter.report('renderer-a', {
+        source: 'window-error',
+        surface: 'workspace',
+        errorCategory: 'type',
+        fingerprint: 'a1b2c3d4',
+        message: 'private research path /Users/example/study.csv'
+      })
+    ).toBe('rejected')
+    expect(error).not.toHaveBeenCalled()
+    expect(warn).toHaveBeenCalledWith('renderer failure report rejected', {
+      errorCategory: 'invalid-payload'
+    })
+  })
+
+  it('limits invalid payloads before repeatedly inspecting hostile renderer values', () => {
+    const warn = vi.fn()
+    let inspections = 0
+    const invalidPayload = new Proxy(
+      {},
+      {
+        ownKeys: () => {
+          inspections += 1
+          return ['message']
+        },
+        getOwnPropertyDescriptor: () => ({ configurable: true, enumerable: true })
+      }
+    )
+    const reporter = createRendererFailureReporter({
+      log: { error: vi.fn(), warn },
+      now: () => 100,
+      maxReportsPerWindow: 1
+    })
+
+    expect(reporter.report('renderer-a', invalidPayload)).toBe('rejected')
+    expect(reporter.report('renderer-a', invalidPayload)).toBe('suppressed')
+    expect(reporter.report('renderer-a', invalidPayload)).toBe('suppressed')
+    expect(inspections).toBe(1)
+    expect(warn).toHaveBeenCalledTimes(1)
+  })
+
+  it('suppresses repeated fingerprints and reports the bounded summary in the next window', () => {
+    let now = 100
+    const error = vi.fn()
+    const warn = vi.fn()
+    const reporter = createRendererFailureReporter({
+      log: { error, warn },
+      now: () => now,
+      windowMs: 60_000
+    })
+    const report = {
+      source: 'unhandled-rejection' as const,
+      surface: 'settings' as const,
+      errorCategory: 'error' as const,
+      fingerprint: 'deadbeef'
+    }
+
+    expect(reporter.report('renderer-a', report)).toBe('recorded')
+    expect(reporter.report('renderer-a', report)).toBe('suppressed')
+    expect(error).toHaveBeenCalledTimes(1)
+
+    now += 60_001
+    expect(reporter.report('renderer-a', report)).toBe('recorded')
+    expect(warn).toHaveBeenCalledWith('renderer failure reports suppressed', {
+      suppressedCount: 1,
+      windowMs: 60_000
+    })
+    expect(error).toHaveBeenCalledTimes(2)
+  })
+
+  it('bounds distinct renderer failures per reporting window', () => {
+    const error = vi.fn()
+    const reporter = createRendererFailureReporter({
+      log: { error, warn: vi.fn() },
+      maxReportsPerWindow: 2
+    })
+    const report = (fingerprint: string): RendererFailureReport => ({
+      source: 'window-error' as const,
+      surface: 'home' as const,
+      errorCategory: 'error' as const,
+      fingerprint
+    })
+
+    expect(reporter.report('renderer-a', report('00000001'))).toBe('recorded')
+    expect(reporter.report('renderer-a', report('00000002'))).toBe('recorded')
+    expect(reporter.report('renderer-a', report('00000003'))).toBe('suppressed')
+    expect(error).toHaveBeenCalledTimes(2)
+  })
+
+  it('does not throw when the clock or logging sink fails', () => {
+    const reporter = createRendererFailureReporter({
+      log: {
+        error: () => {
+          throw new Error('sink unavailable')
+        },
+        warn: () => {
+          throw new Error('sink unavailable')
+        }
+      },
+      now: () => {
+        throw new Error('clock unavailable')
+      }
+    })
+
+    expect(
+      reporter.report('renderer-a', {
+        source: 'window-error',
+        surface: 'home',
+        errorCategory: 'error',
+        fingerprint: '00000001'
+      })
+    ).toBe('recorded')
+    expect(reporter.report('renderer-a', { message: 'private' })).toBe('rejected')
+  })
+
+  it('rejects a renderer payload whose properties cannot be inspected without throwing', () => {
+    const warn = vi.fn()
+    const reporter = createRendererFailureReporter({ log: { error: vi.fn(), warn } })
+    const hostilePayload = new Proxy(
+      {},
+      {
+        ownKeys: () => {
+          throw new Error('hostile payload')
+        }
+      }
+    )
+
+    expect(reporter.report('renderer-a', hostilePayload)).toBe('rejected')
+    expect(warn).toHaveBeenCalledWith('renderer failure report rejected', {
+      errorCategory: 'invalid-payload'
+    })
+  })
+
+  it('records an immutable projection without reading renderer-controlled getters twice', () => {
+    const error = vi.fn()
+    const reporter = createRendererFailureReporter({ log: { error, warn: vi.fn() } })
+    const accessCounts = new Map<string, number>()
+    const payload = Object.defineProperties(
+      {},
+      Object.fromEntries(
+        Object.entries({
+          source: 'window-error',
+          surface: 'workspace',
+          errorCategory: 'type',
+          fingerprint: 'a1b2c3d4'
+        }).map(([key, value]) => [
+          key,
+          {
+            enumerable: true,
+            get: () => {
+              const count = (accessCounts.get(key) ?? 0) + 1
+              accessCounts.set(key, count)
+              if (count > 1) throw new Error('getter read twice')
+              return value
+            }
+          }
+        ])
+      )
+    )
+
+    expect(reporter.report('renderer-a', payload)).toBe('recorded')
+    expect(error).toHaveBeenCalledWith('renderer javascript failure', {
+      source: 'window-error',
+      surface: 'workspace',
+      errorCategory: 'type',
+      fingerprint: 'a1b2c3d4'
+    })
+    expect([...accessCounts.values()]).toEqual([1, 1, 1, 1])
+  })
+
+  it('adapts the one-way Electron channel and removes its listener on disposal', () => {
+    let listener: ((event: { sender: { id: number } }, value: unknown) => void) | undefined
+    const target = {
+      on: vi.fn((_channel: string, next: typeof listener) => {
+        listener = next
+      }),
+      removeListener: vi.fn()
+    }
+    const report = vi.fn()
+    const dispose = registerRendererDiagnosticsIpc(target, { report })
+    const value = {
+      source: 'window-error',
+      surface: 'home',
+      errorCategory: 'error'
+    }
+
+    listener?.({ sender: { id: 42 } }, value)
+    expect(report).toHaveBeenCalledWith('42', value)
+
+    dispose()
+    expect(target.removeListener).toHaveBeenCalledWith(
+      'diagnostics:renderer-failure',
+      expect.any(Function)
+    )
+  })
+
+  it('does not throw from the Electron listener when sender access or reporting fails', () => {
+    let listener: ((event: { sender: { id: number } }, value: unknown) => void) | undefined
+    const target = {
+      on: (_channel: string, next: typeof listener) => {
+        listener = next
+      },
+      removeListener: vi.fn()
+    }
+    const report = vi.fn(() => {
+      throw new Error('reporter unavailable')
+    })
+    registerRendererDiagnosticsIpc(target, { report })
+
+    const inaccessibleSender = {} as { sender: { id: number } }
+    Object.defineProperty(inaccessibleSender, 'sender', {
+      get: () => {
+        throw new Error('sender unavailable')
+      }
+    })
+
+    expect(() => listener?.(inaccessibleSender, {})).not.toThrow()
+    expect(report).not.toHaveBeenCalled()
+    expect(() => listener?.({ sender: { id: 42 } }, {})).not.toThrow()
+    expect(report).toHaveBeenCalledWith('42', {})
+  })
+
+  it('does not affect startup or teardown when Electron listener registration fails', () => {
+    const target = {
+      on: () => {
+        throw new Error('registration unavailable')
+      },
+      removeListener: () => {
+        throw new Error('removal unavailable')
+      }
+    }
+    let dispose: (() => void) | undefined
+
+    expect(() => {
+      dispose = registerRendererDiagnosticsIpc(target, { report: vi.fn() })
+    }).not.toThrow()
+    expect(() => dispose?.()).not.toThrow()
+  })
+})

--- a/src/main/renderer-diagnostics.ts
+++ b/src/main/renderer-diagnostics.ts
@@ -1,0 +1,170 @@
+import type { Logger } from './logger'
+import {
+  RENDERER_FAILURE_CHANNEL,
+  isRendererFailureReport,
+  type RendererFailureReport
+} from '../shared/diagnostics'
+
+type RendererFailureReporter = {
+  report(senderKey: string, value: unknown): 'recorded' | 'rejected' | 'suppressed'
+}
+
+type RendererFailureReporterOptions = {
+  log: Pick<Logger, 'error' | 'warn'>
+  now?: () => number
+  windowMs?: number
+  maxReportsPerWindow?: number
+}
+
+const projectRendererFailureReport = (value: unknown): RendererFailureReport | undefined => {
+  try {
+    if (!value || typeof value !== 'object' || Array.isArray(value)) return undefined
+
+    const record = value as Record<string, unknown>
+    const keys = Object.keys(record)
+    if (keys.some((key) => !['source', 'surface', 'errorCategory', 'fingerprint'].includes(key))) {
+      return undefined
+    }
+    if (!keys.includes('source') || !keys.includes('surface') || !keys.includes('errorCategory')) {
+      return undefined
+    }
+
+    const candidate = {
+      source: record.source,
+      surface: record.surface,
+      errorCategory: record.errorCategory,
+      ...(keys.includes('fingerprint') ? { fingerprint: record.fingerprint } : {})
+    }
+    return isRendererFailureReport(candidate) ? candidate : undefined
+  } catch {
+    return undefined
+  }
+}
+
+export const createRendererFailureReporter = (
+  options: RendererFailureReporterOptions
+): RendererFailureReporter => {
+  const now = options.now ?? Date.now
+  const windowMs = options.windowMs ?? 60_000
+  const maxReportsPerWindow = options.maxReportsPerWindow ?? 10
+  const readNow = (): number => {
+    try {
+      const timestamp = now()
+      return Number.isFinite(timestamp) ? timestamp : 0
+    } catch {
+      return 0
+    }
+  }
+  const warn = (message: string, fields: Record<string, unknown>): void => {
+    try {
+      options.log.warn(message, fields)
+    } catch {
+      // Diagnostics must never affect the failure path being observed.
+    }
+  }
+  const error = (message: string, fields: Record<string, unknown>): void => {
+    try {
+      options.log.error(message, fields)
+    } catch {
+      // Diagnostics must never affect the failure path being observed.
+    }
+  }
+  const windows = new Map<
+    string,
+    {
+      startedAt: number
+      fingerprints: Set<string>
+      reportCount: number
+      suppressedCount: number
+    }
+  >()
+
+  return {
+    report: (senderKey, value) => {
+      const timestamp = readNow()
+      let window = windows.get(senderKey)
+      if (!window || timestamp - window.startedAt >= windowMs) {
+        if (window?.suppressedCount) {
+          warn('renderer failure reports suppressed', {
+            suppressedCount: window.suppressedCount,
+            windowMs
+          })
+        }
+        window = {
+          startedAt: timestamp,
+          fingerprints: new Set(),
+          reportCount: 0,
+          suppressedCount: 0
+        }
+        windows.set(senderKey, window)
+      }
+
+      if (window.reportCount >= maxReportsPerWindow) {
+        window.suppressedCount += 1
+        return 'suppressed'
+      }
+      window.reportCount += 1
+
+      const report = projectRendererFailureReport(value)
+      if (!report) {
+        warn('renderer failure report rejected', {
+          errorCategory: 'invalid-payload'
+        })
+        return 'rejected'
+      }
+
+      const fingerprint = [
+        report.source,
+        report.surface,
+        report.errorCategory,
+        report.fingerprint ?? 'none'
+      ].join(':')
+      if (window.fingerprints.has(fingerprint)) {
+        window.suppressedCount += 1
+        return 'suppressed'
+      }
+      window.fingerprints.add(fingerprint)
+      error('renderer javascript failure', report)
+      return 'recorded'
+    }
+  }
+}
+
+type RendererDiagnosticsIpcTarget = {
+  on(
+    channel: string,
+    listener: (event: { sender: { id: number } }, value: unknown) => void
+  ): unknown
+  removeListener(
+    channel: string,
+    listener: (event: { sender: { id: number } }, value: unknown) => void
+  ): unknown
+}
+
+export const registerRendererDiagnosticsIpc = (
+  target: RendererDiagnosticsIpcTarget,
+  reporter: RendererFailureReporter
+): (() => void) => {
+  const listener = (event: { sender: { id: number } }, value: unknown): void => {
+    try {
+      reporter.report(String(event.sender.id), value)
+    } catch {
+      // A diagnostics adapter must not escape back into Electron's event dispatch.
+    }
+  }
+  let installed = false
+  try {
+    target.on(RENDERER_FAILURE_CHANNEL, listener)
+    installed = true
+  } catch {
+    // Diagnostics are optional and must not block main-process startup.
+  }
+  return () => {
+    if (!installed) return
+    try {
+      target.removeListener(RENDERER_FAILURE_CHANNEL, listener)
+    } catch {
+      // Removal remains best effort during main-process teardown.
+    }
+  }
+}

--- a/src/main/session-persistence/coordinator.test.ts
+++ b/src/main/session-persistence/coordinator.test.ts
@@ -11,6 +11,7 @@ import {
 } from '../../shared/session-persistence'
 import type { ArtifactProjectReconciliationSnapshot } from '../artifacts/provenance-repository'
 import { FinalizedArtifactBindingConflictError } from '../artifacts/provenance-message-snapshot'
+import type { Logger } from '../logger'
 import { createProjectDbClient, ensureProjectSchema } from '../projects/prisma-client'
 import {
   OrphanLegacyUploadAuthorityMissingError,
@@ -413,33 +414,73 @@ describe('SessionPersistenceCoordinator', () => {
   })
 
   it('keeps JSON-first durability when pre-save provenance lookup is unavailable', async () => {
-    const validationError = new Error('artifact database unavailable')
+    const validationError = new Error('artifact database unavailable at /private/session.json')
     const repository = createSessionRepository()
     const provenance = createProvenancePersistence({
       validateFinalizedMessageBindings: vi.fn().mockRejectedValue(validationError)
     })
-    const warn = vi.spyOn(console, 'warn').mockImplementation(() => undefined)
+    const log = createTestLogger()
     const coordinator = new SessionPersistenceCoordinator(
       repository,
       createFileIndex(),
       undefined,
-      provenance
+      provenance,
+      undefined,
+      undefined,
+      undefined,
+      log
     )
 
-    try {
-      await expect(coordinator.saveSession(createSession())).resolves.toMatchObject({
-        id: 'session-1'
-      })
-      await expect(
-        coordinator.saveSession(createSession({ title: 'Retry validation' }))
-      ).resolves.toMatchObject({ id: 'session-1' })
-    } finally {
-      warn.mockRestore()
-    }
+    await expect(
+      coordinator.saveSession(createSession({ title: 'Private research' }))
+    ).resolves.toMatchObject({
+      id: 'session-1'
+    })
+    await expect(
+      coordinator.saveSession(createSession({ title: 'Retry validation' }))
+    ).resolves.toMatchObject({ id: 'session-1' })
 
     expect(provenance.validateFinalizedMessageBindings).toHaveBeenCalledTimes(2)
     expect(repository.saveSession).toHaveBeenCalledTimes(2)
     expect(provenance.captureFinalizedMessages).toHaveBeenCalledTimes(2)
+    expect(log.warn).toHaveBeenCalledTimes(2)
+    expect(log.warn).toHaveBeenCalledWith('pre-save provenance validation unavailable', {
+      operation: 'session-save',
+      phase: 'validate-provenance',
+      outcome: 'degraded',
+      errorCategory: 'error'
+    })
+    expect(JSON.stringify(log.warn.mock.calls)).not.toContain('artifact database unavailable')
+    expect(JSON.stringify(log.warn.mock.calls)).not.toContain('Private research')
+    expect(JSON.stringify(log.warn.mock.calls)).not.toContain('/private/session.json')
+  })
+
+  it('keeps JSON-first durability when degraded diagnostics cannot be emitted', async () => {
+    const repository = createSessionRepository()
+    const provenance = createProvenancePersistence({
+      validateFinalizedMessageBindings: vi.fn().mockRejectedValue(new Error('lookup unavailable'))
+    })
+    const log = createTestLogger()
+    log.warn.mockImplementation(() => {
+      throw new Error('diagnostic sink unavailable')
+    })
+    const coordinator = new SessionPersistenceCoordinator(
+      repository,
+      createFileIndex(),
+      undefined,
+      provenance,
+      undefined,
+      undefined,
+      undefined,
+      log
+    )
+
+    await expect(coordinator.saveSession(createSession())).resolves.toMatchObject({
+      id: 'session-1'
+    })
+
+    expect(repository.saveSession).toHaveBeenCalledOnce()
+    expect(provenance.captureFinalizedMessages).toHaveBeenCalledOnce()
   })
 
   it('revalidates finalized bindings only when topology or artifact bindings change', async () => {
@@ -929,8 +970,142 @@ describe('SessionPersistenceCoordinator', () => {
     expect(fileIndex.reconcileActiveSessions).toHaveBeenCalledWith([session])
   })
 
+  it('records a phased terminal aggregate for complete Session hydration', async () => {
+    const session = createSession({ title: 'Private analysis', cwd: '/private/workspace' })
+    const result = { sessions: [session], manifest: { version: 1 as const } }
+    const repository = createSessionRepository({
+      loadAllWithDiagnostics: vi.fn().mockResolvedValue({ result, isComplete: true })
+    })
+    const log = createTestLogger()
+    const coordinator = new SessionPersistenceCoordinator(
+      repository,
+      createFileIndex(),
+      undefined,
+      undefined,
+      undefined,
+      undefined,
+      undefined,
+      log
+    )
+
+    await expect(coordinator.loadAll()).resolves.toBe(result)
+
+    expect(log.info.mock.calls.map(([message]) => message)).toEqual([
+      'operation started',
+      'operation phase',
+      'operation phase',
+      'operation phase',
+      'operation completed'
+    ])
+    expect(
+      log.info.mock.calls
+        .map(([, fields]) => (fields as { phase?: string } | undefined)?.phase)
+        .filter(Boolean)
+    ).toEqual([
+      'load-authority',
+      'reconcile-unread-deletions',
+      'reconcile-derived-state',
+      'reconcile-derived-state'
+    ])
+    expect(log.info).toHaveBeenLastCalledWith(
+      'operation completed',
+      expect.objectContaining({
+        operation: 'session-hydration',
+        operationId: expect.any(String),
+        mode: 'reconcile',
+        startupCleanupEligible: true,
+        phase: 'reconcile-derived-state',
+        outcome: 'completed',
+        status: 'ready',
+        sessionCount: 1,
+        warningCount: 0,
+        durationMs: expect.any(Number)
+      })
+    )
+    const diagnosticPayload = JSON.stringify(log.info.mock.calls)
+    expect(diagnosticPayload).not.toContain('Private analysis')
+    expect(diagnosticPayload).not.toContain('/private/workspace')
+  })
+
+  it('records a terminal failure when the Session authority scan rejects', async () => {
+    const repository = createSessionRepository({
+      loadAllWithDiagnostics: vi
+        .fn()
+        .mockRejectedValue(new Error('Session authority unavailable at /private/sessions'))
+    })
+    const log = createTestLogger()
+    const coordinator = new SessionPersistenceCoordinator(
+      repository,
+      createFileIndex(),
+      undefined,
+      undefined,
+      undefined,
+      undefined,
+      undefined,
+      log
+    )
+
+    await expect(coordinator.loadAll()).rejects.toThrow('Session authority unavailable')
+
+    expect(log.error).toHaveBeenCalledWith(
+      'operation failed',
+      expect.objectContaining({
+        operation: 'session-hydration',
+        phase: 'load-authority',
+        outcome: 'failed',
+        status: 'failed',
+        hydrationAvailable: false,
+        errorCategory: 'error'
+      })
+    )
+    expect(JSON.stringify(log.error.mock.calls)).not.toContain('Session authority unavailable')
+    expect(JSON.stringify(log.error.mock.calls)).not.toContain('/private/sessions')
+  })
+
+  it('keeps hydration available and records unread deletion reconciliation degradation', async () => {
+    const session = createSession({ title: 'Private analysis' })
+    const result = { sessions: [session], manifest: { version: 1 as const } }
+    const repository = createSessionRepository({
+      loadAllWithDiagnostics: vi.fn().mockResolvedValue({ result, isComplete: true })
+    })
+    const log = createTestLogger()
+    const coordinator = new SessionPersistenceCoordinator(
+      repository,
+      createFileIndex(),
+      undefined,
+      undefined,
+      undefined,
+      undefined,
+      undefined,
+      log
+    )
+    coordinator.setSessionDeletionHandlers(
+      createSessionDeletionHandlers({
+        reconcile: vi
+          .fn()
+          .mockRejectedValue(new Error('unread database unavailable at /private/unread.sqlite'))
+      })
+    )
+
+    await expect(coordinator.loadAll()).resolves.toBe(result)
+
+    expect(log.warn).toHaveBeenCalledWith('unread deletion reconciliation failed', {
+      operation: 'session-hydration',
+      phase: 'reconcile-unread-deletions',
+      outcome: 'degraded',
+      errorCategory: 'error'
+    })
+    expect(JSON.stringify(log.warn.mock.calls)).not.toContain('Private analysis')
+    expect(JSON.stringify(log.warn.mock.calls)).not.toContain('unread database unavailable')
+    expect(JSON.stringify(log.warn.mock.calls)).not.toContain('/private/unread.sqlite')
+    expect(log.info).toHaveBeenLastCalledWith(
+      'operation completed',
+      expect.objectContaining({ status: 'degraded', degradedReconciliationCount: 1 })
+    )
+  })
+
   it('hydrates a read-only snapshot without running startup reconciliation', async () => {
-    const session = createSession()
+    const session = createSession({ title: 'Private analysis', cwd: '/private/workspace' })
     const result = { sessions: [session], manifest: { version: 1 as const } }
     const repository = createSessionRepository({
       loadAllWithDiagnostics: vi.fn().mockResolvedValue({
@@ -953,13 +1128,16 @@ describe('SessionPersistenceCoordinator', () => {
       prepareProjectReconciliation: vi.fn(),
       reconcileSession: vi.fn()
     }
+    const log = createTestLogger()
     const coordinator = new SessionPersistenceCoordinator(
       repository,
       fileIndex,
       undefined,
       provenance,
       uploads,
-      artifactStorage
+      artifactStorage,
+      undefined,
+      log
     )
 
     await expect(coordinator.loadAllReadOnly()).resolves.toEqual({
@@ -980,6 +1158,28 @@ describe('SessionPersistenceCoordinator', () => {
     expect(uploads.upgradeLegacySessionUploads).not.toHaveBeenCalled()
     expect(artifactStorage.prepareProjectReconciliation).not.toHaveBeenCalled()
     expect(artifactStorage.reconcileSession).not.toHaveBeenCalled()
+    expect(log.info.mock.calls.map(([message]) => message)).toEqual([
+      'operation started',
+      'operation phase',
+      'operation completed'
+    ])
+    expect(log.info).toHaveBeenLastCalledWith(
+      'operation completed',
+      expect.objectContaining({
+        operation: 'session-hydration',
+        operationId: expect.any(String),
+        mode: 'read-only',
+        phase: 'load-authority',
+        outcome: 'completed',
+        status: 'degraded',
+        sessionCount: 1,
+        warningCount: 0,
+        durationMs: expect.any(Number)
+      })
+    )
+    const diagnosticPayload = JSON.stringify(log.info.mock.calls)
+    expect(diagnosticPayload).not.toContain('Private analysis')
+    expect(diagnosticPayload).not.toContain('/private/workspace')
   })
 
   it('reconciles durable Session grants only on the first complete startup scan', async () => {
@@ -1006,6 +1206,44 @@ describe('SessionPersistenceCoordinator', () => {
     expect(reconcileSessions).toHaveBeenCalledWith([
       { projectId: 'project-1', sessionId: 'session-1' }
     ])
+  })
+
+  it('keeps hydration available and records permission grant reconciliation degradation', async () => {
+    const session = createSession({ title: 'Private analysis' })
+    const result = { sessions: [session], manifest: { version: 1 as const } }
+    const repository = createSessionRepository({
+      loadAllWithDiagnostics: vi.fn().mockResolvedValue({ result, isComplete: true })
+    })
+    const log = createTestLogger()
+    const coordinator = new SessionPersistenceCoordinator(
+      repository,
+      createFileIndex(),
+      undefined,
+      undefined,
+      undefined,
+      undefined,
+      {
+        reconcileSessions: vi
+          .fn()
+          .mockRejectedValue(new Error('permission registry unavailable for Private analysis'))
+      },
+      log
+    )
+
+    await expect(coordinator.loadAll()).resolves.toBe(result)
+
+    expect(log.warn).toHaveBeenCalledWith('permission grant reconciliation failed', {
+      operation: 'session-hydration',
+      phase: 'reconcile-permission-grants',
+      outcome: 'degraded',
+      errorCategory: 'error'
+    })
+    expect(JSON.stringify(log.warn.mock.calls)).not.toContain('Private analysis')
+    expect(JSON.stringify(log.warn.mock.calls)).not.toContain('permission registry unavailable')
+    expect(log.info).toHaveBeenLastCalledWith(
+      'operation completed',
+      expect.objectContaining({ status: 'degraded', degradedReconciliationCount: 1 })
+    )
   })
 
   it('does not prune durable Session grants from a partial startup scan', async () => {
@@ -2046,7 +2284,7 @@ describe('SessionPersistenceCoordinator', () => {
   })
 
   it('marks startup reconciliation incomplete when a Session file-index sync fails', async () => {
-    const session = createSession()
+    const session = createSession({ title: 'Private analysis', cwd: '/private/workspace' })
     const result = { sessions: [session], manifest: { version: 1 as const } }
     const repository = createSessionRepository({
       loadAllWithDiagnostics: vi.fn().mockResolvedValue({ result, isComplete: true })
@@ -2054,9 +2292,21 @@ describe('SessionPersistenceCoordinator', () => {
     const markReconciliationIncomplete = vi.fn()
     const fileIndex = createFileIndex({
       markReconciliationIncomplete,
-      syncSession: vi.fn().mockRejectedValue(new Error('file index database is locked'))
+      syncSession: vi
+        .fn()
+        .mockRejectedValue(new Error('file index database is locked at /private/files.sqlite'))
     })
-    const coordinator = new SessionPersistenceCoordinator(repository, fileIndex)
+    const log = createTestLogger()
+    const coordinator = new SessionPersistenceCoordinator(
+      repository,
+      fileIndex,
+      undefined,
+      undefined,
+      undefined,
+      undefined,
+      undefined,
+      log
+    )
 
     await expect(coordinator.loadAll()).resolves.toMatchObject({
       diagnostics: {
@@ -2065,10 +2315,31 @@ describe('SessionPersistenceCoordinator', () => {
       }
     })
     await expect(coordinator.sessionMetadataSnapshot()).resolves.toEqual({
-      sessions: [{ id: 'session-1', projectId: 'project-1', title: 'Session' }],
+      sessions: [{ id: 'session-1', projectId: 'project-1', title: 'Private analysis' }],
       isComplete: false
     })
     expect(markReconciliationIncomplete).toHaveBeenCalledOnce()
+    expect(log.error).toHaveBeenCalledWith(
+      'operation failed',
+      expect.objectContaining({
+        operation: 'session-hydration',
+        operationId: expect.any(String),
+        mode: 'reconcile',
+        startupCleanupEligible: true,
+        phase: 'reconcile-derived-state',
+        outcome: 'failed',
+        status: 'degraded',
+        hydrationAvailable: true,
+        sessionCount: 1,
+        warningCount: 0,
+        errorCategory: 'error',
+        durationMs: expect.any(Number)
+      })
+    )
+    const diagnosticPayload = JSON.stringify(log.error.mock.calls)
+    expect(diagnosticPayload).not.toContain('Private analysis')
+    expect(diagnosticPayload).not.toContain('file index database is locked')
+    expect(diagnosticPayload).not.toContain('/private/files.sqlite')
   })
 
   it('retries surviving project sessions after deleting a collision owner', async () => {
@@ -2110,13 +2381,13 @@ describe('SessionPersistenceCoordinator', () => {
   })
 
   it('marks the index incomplete when the sessions scan is partial', async () => {
-    const session = createSession()
+    const session = createSession({ title: 'Private analysis' })
     const result = { sessions: [session], manifest: { version: 1 as const } }
     const warnings = [
       {
         kind: 'unreadable' as const,
         projectId: 'project-1',
-        fileName: 'session-2.json',
+        fileName: 'private-session-2.json',
         recovered: false
       }
     ]
@@ -2125,7 +2396,17 @@ describe('SessionPersistenceCoordinator', () => {
     })
     const markReconciliationIncomplete = vi.fn()
     const fileIndex = createFileIndex({ markReconciliationIncomplete })
-    const coordinator = new SessionPersistenceCoordinator(repository, fileIndex)
+    const log = createTestLogger()
+    const coordinator = new SessionPersistenceCoordinator(
+      repository,
+      fileIndex,
+      undefined,
+      undefined,
+      undefined,
+      undefined,
+      undefined,
+      log
+    )
     const reconcile = vi.fn(async () => undefined)
     coordinator.setSessionDeletionHandlers(createSessionDeletionHandlers({ reconcile }))
 
@@ -2136,6 +2417,20 @@ describe('SessionPersistenceCoordinator', () => {
     expect(markReconciliationIncomplete).toHaveBeenCalledOnce()
     expect(fileIndex.reconcileActiveSessions).not.toHaveBeenCalled()
     expect(reconcile).not.toHaveBeenCalled()
+    expect(log.info).toHaveBeenLastCalledWith(
+      'operation completed',
+      expect.objectContaining({
+        operation: 'session-hydration',
+        phase: 'load-authority',
+        outcome: 'completed',
+        status: 'partial',
+        sessionCount: 1,
+        warningCount: 1
+      })
+    )
+    const diagnosticPayload = JSON.stringify(log.info.mock.calls)
+    expect(diagnosticPayload).not.toContain('Private analysis')
+    expect(diagnosticPayload).not.toContain('private-session-2.json')
   })
 
   it('marks reconciliation incomplete when startup Provenance recovery fails', async () => {
@@ -2959,6 +3254,18 @@ const createDeferred = <T>(): { promise: Promise<T>; resolve: (value: T) => void
   })
   return { promise, resolve }
 }
+
+type TestLogger = Logger & {
+  [Method in keyof Logger]: ReturnType<typeof vi.fn<Logger[Method]>>
+}
+
+const createTestLogger = (): TestLogger =>
+  ({
+    debug: vi.fn<Logger['debug']>(),
+    info: vi.fn<Logger['info']>(),
+    warn: vi.fn<Logger['warn']>(),
+    error: vi.fn<Logger['error']>()
+  }) satisfies Logger
 
 const flushMicrotasks = async (): Promise<void> => {
   await Promise.resolve()

--- a/src/main/session-persistence/coordinator.ts
+++ b/src/main/session-persistence/coordinator.ts
@@ -20,7 +20,9 @@ import {
   type SessionDeletionReceipt
 } from '../artifacts/provenance-message-snapshot'
 import type { ArtifactProjectReconciliationSnapshot } from '../artifacts/provenance-repository'
+import { createLogger, diagnosticErrorFields, type Logger } from '../logger'
 import { repairHistoricalArtifactAliases } from './artifact-alias-repair'
+import { startDiagnosticOperation } from '../diagnostics/operation'
 import {
   OrphanLegacyUploadAuthorityMissingError,
   UnsafeLegacyUploadResidualError
@@ -228,7 +230,8 @@ type FinalizedArtifactBindingValidation =
 
 const validateFinalizedArtifactBindings = async (
   provenance: SessionProvenancePersistence | undefined,
-  session: PersistedChatSession
+  session: PersistedChatSession,
+  log: Logger
 ): Promise<FinalizedArtifactBindingValidation> => {
   if (!provenance) return { status: 'valid' }
 
@@ -241,8 +244,25 @@ const validateFinalizedArtifactBindings = async (
     }
     // Provenance is derived from authoritative Session JSON. A transient lookup failure must not
     // regress the JSON-first durability guarantee; capture/indexing keep their post-save retry path.
-    console.warn('[session-persistence] pre-save provenance validation unavailable', error)
+    emitRecoverableDiagnostic(log, 'pre-save provenance validation unavailable', {
+      operation: 'session-save',
+      phase: 'validate-provenance',
+      outcome: 'degraded',
+      ...diagnosticErrorFields(error)
+    })
     return { status: 'unavailable' }
+  }
+}
+
+const emitRecoverableDiagnostic = (
+  log: Logger,
+  message: string,
+  fields: Record<string, string | number | boolean | null | undefined>
+): void => {
+  try {
+    log.warn(message, fields)
+  } catch {
+    // Diagnostics must never change Session durability or recovery behavior.
   }
 }
 
@@ -341,7 +361,8 @@ class SessionPersistenceCoordinator {
     private readonly provenance?: SessionProvenancePersistence,
     private readonly uploads?: SessionUploadPersistence,
     private readonly artifactStorage?: ArtifactStorageReconciler,
-    private readonly permissionGrants?: SessionPermissionGrantReconciliation
+    private readonly permissionGrants?: SessionPermissionGrantReconciliation,
+    private readonly log: Logger = createLogger('session-persistence')
   ) {}
 
   // Binds unread cleanup to authoritative Session mutations. Reconciliation is called only with a
@@ -400,8 +421,24 @@ class SessionPersistenceCoordinator {
       // treat the process as an untouched startup boundary for destructive cleanup.
       this.destructiveStartupWindowOpen = false
       this.fileIndex.markReconciliationIncomplete()
-      const scan = await this.repository.loadAllWithDiagnostics({ mode: 'read-only' })
+      const operation = startDiagnosticOperation(this.log, {
+        operation: 'session-hydration',
+        fields: { mode: 'read-only', startupCleanupEligible: false }
+      })
+      operation.phase('load-authority')
+      let scan: Awaited<ReturnType<SessionMutationRepository['loadAllWithDiagnostics']>>
+      try {
+        scan = await this.repository.loadAllWithDiagnostics({ mode: 'read-only' })
+      } catch (error) {
+        operation.fail(error, { status: 'failed', hydrationAvailable: false })
+        throw error
+      }
       this.replaceSessionMetadata(scan.result.sessions, false)
+      operation.complete({
+        status: 'degraded',
+        sessionCount: scan.result.sessions.length,
+        warningCount: scan.warnings?.length ?? 0
+      })
 
       return {
         ...scan.result,
@@ -426,7 +463,21 @@ class SessionPersistenceCoordinator {
       // reopen destructive cleanup while live clients may already hold the legacy projection.
       const mayRunDestructiveStartupCleanup = this.destructiveStartupWindowOpen
       this.destructiveStartupWindowOpen = false
-      const scan = await this.repository.loadAllWithDiagnostics()
+      const operation = startDiagnosticOperation(this.log, {
+        operation: 'session-hydration',
+        fields: {
+          mode: 'reconcile',
+          startupCleanupEligible: mayRunDestructiveStartupCleanup
+        }
+      })
+      operation.phase('load-authority')
+      let scan: Awaited<ReturnType<SessionMutationRepository['loadAllWithDiagnostics']>>
+      try {
+        scan = await this.repository.loadAllWithDiagnostics()
+      } catch (error) {
+        operation.fail(error, { status: 'failed', hydrationAvailable: false })
+        throw error
+      }
       this.replaceSessionMetadata(scan.result.sessions, scan.isComplete)
       scan.result.diagnostics = {
         isComplete: scan.isComplete,
@@ -440,28 +491,49 @@ class SessionPersistenceCoordinator {
         // Without the full active-session set, syncing could let a readable duplicate steal a row from
         // a soft-deleted owner whose JSON was merely unreadable during this scan.
         this.fileIndex.markReconciliationIncomplete()
+        operation.complete({
+          status: 'partial',
+          sessionCount: sessions.length,
+          warningCount: scan.warnings?.length ?? 0
+        })
         return result
       }
 
+      let degradedReconciliationCount = 0
+      operation.phase('reconcile-unread-deletions')
       try {
         await this.sessionDeletionHandlers?.reconcile(sessions.map((session) => session.id))
       } catch (error) {
+        degradedReconciliationCount += 1
         // Unread metadata is a recoverable projection and must not block Session hydration.
-        console.error('[session-persistence] unread deletion reconciliation failed', error)
+        emitRecoverableDiagnostic(this.log, 'unread deletion reconciliation failed', {
+          operation: 'session-hydration',
+          phase: 'reconcile-unread-deletions',
+          outcome: 'degraded',
+          ...diagnosticErrorFields(error)
+        })
       }
 
-      if (mayRunDestructiveStartupCleanup) {
+      if (mayRunDestructiveStartupCleanup && this.permissionGrants) {
+        operation.phase('reconcile-permission-grants')
         try {
-          await this.permissionGrants?.reconcileSessions(
+          await this.permissionGrants.reconcileSessions(
             sessions.map((session) => ({ projectId: session.projectId, sessionId: session.id }))
           )
         } catch (error) {
+          degradedReconciliationCount += 1
           // Chat hydration remains available. The Registry is still fail-closed by exact live scope
           // matching, and the complete scan will retry cleanup on the next process startup.
-          console.error('[session-persistence] permission grant reconciliation failed', error)
+          emitRecoverableDiagnostic(this.log, 'permission grant reconciliation failed', {
+            operation: 'session-hydration',
+            phase: 'reconcile-permission-grants',
+            outcome: 'degraded',
+            ...diagnosticErrorFields(error)
+          })
         }
       }
 
+      operation.phase('reconcile-derived-state')
       try {
         if (this.uploads) {
           for (let index = 0; index < sessions.length; index += 1) {
@@ -547,7 +619,13 @@ class SessionPersistenceCoordinator {
       } catch (error) {
         this.isSessionMetadataComplete = false
         this.fileIndex.markReconciliationIncomplete()
-        console.error('[session-persistence] startup reconciliation failed', error)
+        operation.fail(error, {
+          status: 'degraded',
+          hydrationAvailable: true,
+          sessionCount: sessions.length,
+          warningCount: scan.warnings?.length ?? 0,
+          degradedReconciliationCount
+        })
         // Keep chat hydration available while Files remains explicitly incomplete and retryable.
         result.diagnostics = {
           isComplete: false,
@@ -557,6 +635,12 @@ class SessionPersistenceCoordinator {
         return result
       }
 
+      operation.complete({
+        status: degradedReconciliationCount > 0 ? 'degraded' : 'ready',
+        sessionCount: sessions.length,
+        warningCount: scan.warnings?.length ?? 0,
+        degradedReconciliationCount
+      })
       return result
     })
   }
@@ -587,7 +671,7 @@ class SessionPersistenceCoordinator {
       let bindingValidation: FinalizedArtifactBindingValidation =
         this.validatedBindingTopologies.get(key) === bindingTopology
           ? { status: 'valid' }
-          : await validateFinalizedArtifactBindings(this.provenance, durableSession)
+          : await validateFinalizedArtifactBindings(this.provenance, durableSession, this.log)
       // Reject a stale graph before it can replace the authoritative Session JSON. Capture remains
       // after the durable write so immutable evidence never includes Message bytes that were not saved.
       // Streaming payload changes preserve this topology, avoiding a database lookup on every chunk.
@@ -613,7 +697,7 @@ class SessionPersistenceCoordinator {
         bindingValidation =
           this.validatedBindingTopologies.get(key) === bindingTopology
             ? { status: 'valid' }
-            : await validateFinalizedArtifactBindings(this.provenance, durableSession)
+            : await validateFinalizedArtifactBindings(this.provenance, durableSession, this.log)
         if (bindingValidation.status === 'conflict') throw bindingValidation.error
       }
       await this.repository.saveSession(durableSession)

--- a/src/main/session-persistence/ipc.test.ts
+++ b/src/main/session-persistence/ipc.test.ts
@@ -1,6 +1,7 @@
 import { afterEach, beforeEach, describe, expect, expectTypeOf, it, vi } from 'vitest'
 
 import type { PersistedChatSession } from '../../shared/session-persistence'
+import type { Logger } from '../logger'
 import type { ReviewRepository } from '../reviewer/repository'
 
 const { broadcastLifecycleEvent, ipcHandlers } = vi.hoisted(() => ({
@@ -92,8 +93,8 @@ describe('session persistence IPC handlers', () => {
   })
 
   it('hydrates a read-only Session snapshot when Project deletion recovery fails', async () => {
-    const failure = new Error('Project deletion journal is locked')
-    const consoleError = vi.spyOn(console, 'error').mockImplementation(() => undefined)
+    const failure = new Error('Project deletion journal is locked at /private/sessions')
+    const warn = vi.fn<Logger['warn']>()
     const degraded = {
       sessions: [createSession()],
       manifest: { version: 1 as const },
@@ -111,23 +112,26 @@ describe('session persistence IPC handlers', () => {
       loadAllReadOnly: vi.fn().mockResolvedValue(degraded)
     }
 
-    await expect(loadSessionsAfterProjectRecovery(projectRecovery, sessionLoader)).resolves.toEqual(
-      {
-        ...degraded,
-        diagnostics: {
-          ...degraded.diagnostics,
-          isProjectDeletionRecoveryComplete: false
-        }
+    await expect(
+      loadSessionsAfterProjectRecovery(projectRecovery, sessionLoader, { warn })
+    ).resolves.toEqual({
+      ...degraded,
+      diagnostics: {
+        ...degraded.diagnostics,
+        isProjectDeletionRecoveryComplete: false
       }
-    )
+    })
 
     expect(sessionLoader.loadAll).not.toHaveBeenCalled()
     expect(sessionLoader.loadAllReadOnly).toHaveBeenCalledOnce()
-    expect(consoleError).toHaveBeenCalledWith(
-      '[session-persistence] Project deletion recovery failed',
-      failure
-    )
-    consoleError.mockRestore()
+    expect(warn).toHaveBeenCalledWith('project deletion recovery failed', {
+      operation: 'session-hydration',
+      phase: 'recover-project-deletions',
+      outcome: 'degraded',
+      errorCategory: 'error'
+    })
+    expect(JSON.stringify(warn.mock.calls)).not.toContain('journal is locked')
+    expect(JSON.stringify(warn.mock.calls)).not.toContain('/private/sessions')
   })
 
   it('runs ordinary startup loading after Project deletion recovery succeeds', async () => {

--- a/src/main/session-persistence/ipc.ts
+++ b/src/main/session-persistence/ipc.ts
@@ -9,6 +9,7 @@ import type {
 } from '../../shared/session-persistence'
 import { LIFECYCLE_CHANNELS } from '../../shared/lifecycle-events'
 import { broadcastLifecycleEvent, getLifecycleClientId } from '../lifecycle-broadcast'
+import { createLogger, diagnosticErrorFields, type Logger } from '../logger'
 import { resolveStorageRoot } from '../storage-root'
 import { SessionRepository } from './repository'
 import { ReviewRepository } from '../reviewer/repository'
@@ -77,12 +78,22 @@ const loadSessionMetadataAfterProjectRecovery = async (
 // without allowing partially recovered Project authority to drive cleanup or derived-state writes.
 const loadSessionsAfterProjectRecovery = async (
   projectRecovery: ProjectDeletionRecoveryBackend,
-  sessionLoader: SessionStartupLoader
+  sessionLoader: SessionStartupLoader,
+  log: Pick<Logger, 'warn'> = createLogger('session-persistence')
 ): Promise<LoadAllSessionsResult> => {
   try {
     await projectRecovery.recoverPendingDeletions()
   } catch (error) {
-    console.error('[session-persistence] Project deletion recovery failed', error)
+    try {
+      log.warn('project deletion recovery failed', {
+        operation: 'session-hydration',
+        phase: 'recover-project-deletions',
+        outcome: 'degraded',
+        ...diagnosticErrorFields(error)
+      })
+    } catch {
+      // Diagnostics must never prevent the explicit read-only recovery path.
+    }
     return withProjectDeletionRecoveryStatus(await sessionLoader.loadAllReadOnly(), false)
   }
 

--- a/src/main/session-persistence/renderer-flush.test.ts
+++ b/src/main/session-persistence/renderer-flush.test.ts
@@ -1,6 +1,7 @@
 import { describe, expect, it, vi } from 'vitest'
 
 import { requestRendererSessionPersistenceFlush } from './renderer-flush'
+import type { RendererSessionPersistenceFlushOutcome } from './renderer-flush'
 
 type Listener = (requestId: string) => void
 
@@ -12,7 +13,7 @@ const createHarness = (
   rendererGone: () => void
   cleanupResponse: ReturnType<typeof vi.fn>
   cleanupGone: ReturnType<typeof vi.fn>
-  request: () => Promise<void>
+  request: () => Promise<RendererSessionPersistenceFlushOutcome>
 } => {
   let responseListener: Listener = () => undefined
   let goneListener = (): void => undefined
@@ -59,14 +60,14 @@ describe('requestRendererSessionPersistenceFlush', () => {
     expect(settled).toBe(false)
 
     harness.respond('flush-1')
-    await request
+    await expect(request).resolves.toBe('completed')
     expect(harness.cleanupResponse).toHaveBeenCalledOnce()
     expect(harness.cleanupGone).toHaveBeenCalledOnce()
   })
 
   it('does not wait when no renderer is available', async () => {
     const harness = createHarness(false)
-    await expect(harness.request()).resolves.toBeUndefined()
+    await expect(harness.request()).resolves.toBe('unavailable')
     expect(harness.sendRequest).not.toHaveBeenCalled()
   })
 
@@ -74,7 +75,7 @@ describe('requestRendererSessionPersistenceFlush', () => {
     const harness = createHarness()
     const request = harness.request()
     harness.rendererGone()
-    await expect(request).resolves.toBeUndefined()
+    await expect(request).resolves.toBe('renderer-gone')
   })
 
   it('bounds the wait when the renderer never acknowledges', async () => {
@@ -83,11 +84,20 @@ describe('requestRendererSessionPersistenceFlush', () => {
       const harness = createHarness()
       const request = harness.request()
       await vi.advanceTimersByTimeAsync(1_000)
-      await expect(request).resolves.toBeUndefined()
+      await expect(request).resolves.toBe('timeout')
       expect(harness.cleanupResponse).toHaveBeenCalledOnce()
       expect(harness.cleanupGone).toHaveBeenCalledOnce()
     } finally {
       vi.useRealTimers()
     }
+  })
+
+  it('classifies a send failure without rejecting quit', async () => {
+    const harness = createHarness()
+    harness.sendRequest.mockImplementation(() => {
+      throw new Error('renderer unavailable')
+    })
+
+    await expect(harness.request()).resolves.toBe('send-failed')
   })
 })

--- a/src/main/session-persistence/renderer-flush.ts
+++ b/src/main/session-persistence/renderer-flush.ts
@@ -19,34 +19,37 @@ type RendererSessionPersistenceFlushDeps = {
 
 const DEFAULT_RENDERER_FLUSH_TIMEOUT_MS = 1_500
 
+export type RendererSessionPersistenceFlushOutcome =
+  'completed' | 'unavailable' | 'renderer-gone' | 'send-failed' | 'timeout'
+
 export const requestRendererSessionPersistenceFlush = async (
   deps: RendererSessionPersistenceFlushDeps
-): Promise<void> => {
-  if (!deps.isRendererAvailable()) return
+): Promise<RendererSessionPersistenceFlushOutcome> => {
+  if (!deps.isRendererAvailable()) return 'unavailable'
 
   const requestId = deps.createRequestId()
-  await new Promise<void>((resolve) => {
+  return new Promise<RendererSessionPersistenceFlushOutcome>((resolve) => {
     let settled = false
     let removeResponse = (): void => undefined
     let removeRendererGone = (): void => undefined
-    const finish = (): void => {
+    const finish = (outcome: RendererSessionPersistenceFlushOutcome): void => {
       if (settled) return
       settled = true
       clearTimeout(timer)
       removeResponse()
       removeRendererGone()
-      resolve()
+      resolve(outcome)
     }
-    const timer = setTimeout(finish, deps.timeoutMs)
+    const timer = setTimeout(() => finish('timeout'), deps.timeoutMs)
     removeResponse = deps.onResponse((responseId) => {
-      if (responseId === requestId) finish()
+      if (responseId === requestId) finish('completed')
     })
-    removeRendererGone = deps.onRendererGone(finish)
+    removeRendererGone = deps.onRendererGone(() => finish('renderer-gone'))
 
     try {
       deps.sendRequest(requestId)
     } catch {
-      finish()
+      finish('send-failed')
     }
   })
 }
@@ -54,7 +57,7 @@ export const requestRendererSessionPersistenceFlush = async (
 export const createElectronSessionPersistenceFlush = (
   getWindow: () => BrowserWindow | undefined,
   timeoutMs = DEFAULT_RENDERER_FLUSH_TIMEOUT_MS
-): (() => Promise<void>) => {
+): (() => Promise<RendererSessionPersistenceFlushOutcome>) => {
   return () => {
     const window = getWindow()
     const webContents = window?.webContents

--- a/src/main/storage/ipc.test.ts
+++ b/src/main/storage/ipc.test.ts
@@ -2,7 +2,9 @@ import { existsSync } from 'node:fs'
 import { mkdir, mkdtemp, rm, writeFile } from 'node:fs/promises'
 import { tmpdir } from 'node:os'
 import { join } from 'node:path'
-import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest'
+import { afterEach, beforeEach, describe, expect, it, type Mock, vi } from 'vitest'
+
+import type { Logger } from '../logger'
 
 // Capture ipcMain.handle registrations; stub dialog/BrowserWindow/app so handlers can be invoked
 // directly without a real Electron runtime. isPackaged: true means dataFolderName() === 'OpenScience'.
@@ -14,6 +16,7 @@ const sentWindows: {
 }[] = []
 const appRelaunch = vi.fn()
 const appExit = vi.fn()
+const appQuit = vi.fn()
 const openPath = vi.fn<(path: string) => Promise<string>>().mockResolvedValue('')
 // Home is mutable so a few tests can point it at a real temp dir (legacy-in-place detection reads
 // the config root under home); it defaults to /home/user so every other test is unaffected.
@@ -28,13 +31,21 @@ vi.mock('electron', () => ({
   BrowserWindow: { getAllWindows: () => sentWindows },
   dialog: { showOpenDialog: (...args: unknown[]) => showOpenDialog(...args) },
   shell: { openPath: (path: string) => openPath(path) },
-  app: { getPath: () => electronHome.path, isPackaged: true, relaunch: appRelaunch, exit: appExit }
+  app: {
+    getPath: () => electronHome.path,
+    isPackaged: true,
+    relaunch: appRelaunch,
+    exit: appExit,
+    quit: appQuit
+  }
 }))
 
 const { initDataRoot } = await import('../storage-root')
 const { registerStorageIpcHandlers } = await import('./ipc')
 const { clearMigrationPending, isMigrationPending } = await import('./migration-state')
-const { writeMigrationMarker } = await import('./migration-marker')
+const { clearApplicationShutdownTrigger, currentApplicationShutdownTrigger } =
+  await import('../application-shutdown-trigger')
+const { readMigrationMarker, writeMigrationMarker } = await import('./migration-marker')
 
 // Writes the verified staging marker a completed copy phase would leave, so commit/discard gates pass.
 const seedVerifiedMarker = async (targetDir: string, source: string): Promise<void> => {
@@ -56,7 +67,7 @@ const seedVerifiedMarker = async (targetDir: string, source: string): Promise<vo
 }
 
 const invoke = (channel: string, payload?: unknown): Promise<unknown> =>
-  Promise.resolve(handlers.get(channel)!(undefined, payload))
+  Promise.resolve(handlers.get(channel)!({ sender: { id: 1 } }, payload))
 
 // Real fs calls inside validateNewDataRoot/classifyDataRoot need an actual event-loop turn, not
 // just a microtask flush, before the mocked runtime.disconnect() (the next await) is reached.
@@ -85,6 +96,18 @@ const fakeDeps = (overrides: Partial<FakeDeps> = {}): FakeDeps => ({
   ...overrides
 })
 
+const fakeDiagnosticLogger = (): Logger => ({
+  debug: vi.fn(),
+  info: vi.fn(),
+  warn: vi.fn(),
+  error: vi.fn()
+})
+
+const diagnosticRecords = (logger: Logger): Record<string, unknown>[] =>
+  [logger.debug, logger.info, logger.warn, logger.error].flatMap((method) =>
+    (method as Mock).mock.calls.map((call) => call[1] as Record<string, unknown>)
+  )
+
 // Data folder name mirrors dataFolderName() for a packaged build (see the electron mock above).
 const dataRootFor = (parent: string): string => join(parent, 'OpenScience')
 
@@ -98,6 +121,7 @@ beforeEach(async () => {
   showOpenDialog.mockReset()
   appRelaunch.mockClear()
   appExit.mockClear()
+  appQuit.mockClear()
   openPath.mockClear()
   sentWindows.length = 0
   currentParent = await mkdtemp(join(tmpdir(), 'ds-storage-ipc-current-'))
@@ -111,6 +135,7 @@ afterEach(async () => {
   initDataRoot(undefined)
   // migration-state is a module singleton; reset it so a pending write-gate can't leak between tests.
   clearMigrationPending()
+  clearApplicationShutdownTrigger()
   await rm(currentParent, { recursive: true, force: true })
   await rm(targetParent, { recursive: true, force: true })
 })
@@ -384,13 +409,38 @@ describe('storage IPC handlers', () => {
   })
 
   it('pick-directory returns null when the injected showOpenDialog throws', async () => {
+    const logger = fakeDiagnosticLogger()
     const deps = fakeDeps({
-      showOpenDialog: vi.fn().mockRejectedValue(new Error('picker failed'))
+      showOpenDialog: vi.fn().mockRejectedValue(new Error('picker-secret')),
+      logger
     })
     registerStorageIpcHandlers(deps)
 
     await expect(invoke('storage:pick-directory')).resolves.toBeNull()
     expect(showOpenDialog).not.toHaveBeenCalled()
+    expect(logger.warn).toHaveBeenCalledWith('directory picker failed', {
+      errorCategory: 'error'
+    })
+    expect(JSON.stringify(diagnosticRecords(logger))).not.toContain('picker-secret')
+  })
+
+  it('keeps the picker fallback authoritative when the diagnostic sink throws', async () => {
+    const sinkFailure = (): never => {
+      throw new Error('sink unavailable')
+    }
+    registerStorageIpcHandlers(
+      fakeDeps({
+        showOpenDialog: vi.fn().mockRejectedValue(new Error('picker failed')),
+        logger: {
+          debug: sinkFailure,
+          info: sinkFailure,
+          warn: sinkFailure,
+          error: sinkFailure
+        }
+      })
+    )
+
+    await expect(invoke('storage:pick-directory')).resolves.toBeNull()
   })
 
   it('migrate copies into the target without committing (no setDataRoot, no relaunch)', async () => {
@@ -406,6 +456,31 @@ describe('storage IPC handlers', () => {
     // clicks "Restart now" (storage:commit-and-relaunch).
     expect(deps.settingsService.setDataRoot).not.toHaveBeenCalled()
     expect(deps.relaunch).not.toHaveBeenCalled()
+  })
+
+  it('correlates production copy and commit diagnostics without logging the marker token', async () => {
+    initDataRoot(dataRoot)
+    const logger = fakeDiagnosticLogger()
+    const deps = fakeDeps({ logger })
+    registerStorageIpcHandlers(deps)
+
+    await expect(invoke('storage:migrate', { parent: targetParent })).resolves.toEqual({ ok: true })
+    const markerToken = (await readMigrationMarker(target))?.token
+    expect(markerToken).toBeTruthy()
+
+    await expect(invoke('storage:commit-and-relaunch', { parent: targetParent })).resolves.toEqual({
+      ok: true
+    })
+
+    const completed = diagnosticRecords(logger).filter((record) => record.outcome === 'completed')
+    expect(completed.map((record) => record.operation)).toEqual([
+      'data-root-copy',
+      'data-root-commit'
+    ])
+    expect(new Set(completed.map((record) => record.operationId)).size).toBe(2)
+    expect(new Set(completed.map((record) => record.correlationId)).size).toBe(1)
+    expect(completed[0]?.correlationId).toEqual(expect.any(String))
+    expect(JSON.stringify(diagnosticRecords(logger))).not.toContain(markerToken)
   })
 
   it('commit-and-relaunch refuses a verified marker not staged by this process', async () => {
@@ -436,17 +511,19 @@ describe('storage IPC handlers', () => {
     expect(deps.relaunch).not.toHaveBeenCalled()
   })
 
-  it('commit-and-relaunch runs the production cleanup (shutdown backends, then relaunch+exit) with no relaunch override', async () => {
+  it('commit-and-relaunch delegates production cleanup to the orderly app quit lifecycle', async () => {
     initDataRoot(dataRoot)
-    // No injected relaunch: exercise the real cleanRelaunch path (shutdownBackends -> app.relaunch ->
-    // app.exit) instead of the test short-circuit.
+    // No injected relaunch: exercise the real app.relaunch -> app.quit handoff.
     const cleanupRuntimeCache = vi.fn()
     const deps = fakeDeps({ relaunch: undefined, cleanupRuntimeCache })
+    appQuit.mockImplementationOnce(() => {
+      expect(currentApplicationShutdownTrigger()).toBe('migration-relaunch')
+    })
     registerStorageIpcHandlers(deps)
 
     // Stage a verified copy first (two-phase flow) so the commit actually switches over and relaunches.
-    // migrate itself interrupts the notebook (shutdownAll), so clear the mocks to isolate the commit's
-    // own cleanup below.
+    // migrate itself interrupts the notebook (shutdownAll), so clear the mocks to prove the commit
+    // leaves terminal cleanup to app-lifecycle.
     await invoke('storage:migrate', { parent: targetParent })
     vi.mocked(deps.notebook.shutdownAll).mockClear()
     vi.mocked(deps.runtime.shutdownForQuit).mockClear()
@@ -455,19 +532,16 @@ describe('storage IPC handlers', () => {
       ok: true
     })
 
-    expect(deps.runtime.shutdownForQuit).toHaveBeenCalledTimes(1)
-    expect(deps.notebook.dispose).toHaveBeenCalledTimes(1)
+    expect(deps.runtime.shutdownForQuit).not.toHaveBeenCalled()
+    expect(deps.notebook.dispose).not.toHaveBeenCalled()
     expect(deps.notebook.shutdownAll).not.toHaveBeenCalled()
     expect(appRelaunch).toHaveBeenCalledTimes(1)
-    expect(appExit).toHaveBeenCalledWith(0)
+    expect(appQuit).toHaveBeenCalledTimes(1)
+    expect(appExit).not.toHaveBeenCalled()
     expect(cleanupRuntimeCache).toHaveBeenCalledWith(join(dataRoot, 'runtime'))
-    // Backends are torn down before the relaunch is triggered.
-    expect(vi.mocked(deps.runtime.shutdownForQuit).mock.invocationCallOrder[0]).toBeLessThan(
-      appRelaunch.mock.invocationCallOrder[0]
-    )
   })
 
-  it('set-data-root-and-relaunch runs the production cleanup before relaunch+exit with no relaunch override', async () => {
+  it('set-data-root-and-relaunch delegates production cleanup to the orderly app quit lifecycle', async () => {
     initDataRoot(dataRoot)
     const deps = fakeDeps({ relaunch: undefined })
     registerStorageIpcHandlers(deps)
@@ -476,11 +550,12 @@ describe('storage IPC handlers', () => {
       invoke('storage:set-data-root-and-relaunch', { parent: targetParent })
     ).resolves.toEqual({ ok: true })
 
-    expect(deps.runtime.shutdownForQuit).toHaveBeenCalledTimes(1)
-    expect(deps.notebook.dispose).toHaveBeenCalledTimes(1)
+    expect(deps.runtime.shutdownForQuit).not.toHaveBeenCalled()
+    expect(deps.notebook.dispose).not.toHaveBeenCalled()
     expect(deps.notebook.shutdownAll).not.toHaveBeenCalled()
     expect(appRelaunch).toHaveBeenCalledTimes(1)
-    expect(appExit).toHaveBeenCalledWith(0)
+    expect(appQuit).toHaveBeenCalledTimes(1)
+    expect(appExit).not.toHaveBeenCalled()
   })
 
   it('commit-and-relaunch returns switchoverFailed and does NOT relaunch when setDataRoot throws', async () => {
@@ -917,6 +992,26 @@ describe('storage IPC handlers', () => {
     ).resolves.toEqual({ ok: true })
     expect(deps.settingsService.setDataRoot).toHaveBeenCalledWith(target)
     expect(deps.relaunch).toHaveBeenCalledTimes(1)
+  })
+
+  it('diagnoses an adopted data root without retaining its path', async () => {
+    initDataRoot(dataRoot)
+    await mkdir(join(target, 'artifacts'), { recursive: true })
+    const logger = fakeDiagnosticLogger()
+    registerStorageIpcHandlers(fakeDeps({ logger }))
+
+    await expect(
+      invoke('storage:set-data-root-and-relaunch', { parent: targetParent })
+    ).resolves.toEqual({ ok: true })
+
+    expect(diagnosticRecords(logger)).toContainEqual(
+      expect.objectContaining({
+        operation: 'data-root-selection',
+        mode: 'adopt',
+        outcome: 'completed'
+      })
+    )
+    expect(JSON.stringify(diagnosticRecords(logger))).not.toContain(target)
   })
 
   it('set-data-root-and-relaunch marks onboarding complete only when markOnboarding is true', async () => {

--- a/src/main/storage/ipc.ts
+++ b/src/main/storage/ipc.ts
@@ -1,5 +1,6 @@
 import { existsSync } from 'node:fs'
 import { mkdir } from 'node:fs/promises'
+import { randomUUID } from 'node:crypto'
 import { join } from 'node:path'
 
 import { app, dialog, shell } from 'electron'
@@ -27,7 +28,6 @@ import { removeMicromambaCacheForRoot } from '../notebook/micromamba-cache'
 import { detectActiveSessions } from './detect-active'
 import { isDataRootMissing } from './path-presence'
 import { beginMigration, clearMigrationPending, endMigrationCopy } from './migration-state'
-import { shutdownBackends } from '../lifecycle-shutdown'
 import {
   classifyDataRoot,
   commitDataRootSwitch,
@@ -39,6 +39,9 @@ import {
 import { availableBytes, computeStorageUsage } from './usage'
 import { broadcastToRenderers } from '../renderer-broadcast'
 import { RELOCATABLE_DATA_DIRS } from './data-directories'
+import { createLogger, diagnosticErrorFields, type Logger } from '../logger'
+import { startDiagnosticOperation } from '../diagnostics/operation'
+import { markApplicationShutdownTrigger } from '../application-shutdown-trigger'
 
 type SessionSource = { projectName: string; sessionId: string }
 
@@ -75,6 +78,7 @@ type StorageIpcDeps = {
   relaunch?: () => void
   broadcastProgress?: (progress: MigrationProgress) => void
   cleanupRuntimeCache?: (runtimeRoot: string) => void
+  logger?: Logger
 }
 
 // Pushes migration progress to every live window, mirroring the acp/update broadcast pattern.
@@ -89,9 +93,23 @@ const registerStorageIpcHandlers = (deps: StorageIpcDeps): void => {
   let activeMigration: AbortController | undefined
   // The token + target of the copy THIS session staged (set when a copy verifies, cleared when the
   // migration resolves). commit/discard require it so a stale renderer call can't act on a foreign copy.
-  let activeStaged: { token: string; target: string } | undefined
+  let activeStaged: { token: string; target: string; correlationId: string } | undefined
   let resolutionInProgress = false
   const cleanupRuntimeCache = deps.cleanupRuntimeCache ?? removeMicromambaCacheForRoot
+  const unsafeLogger = deps.logger ?? createLogger('storage:ipc')
+  const emitSafely = (level: keyof Logger, message: string, data?: unknown): void => {
+    try {
+      unsafeLogger[level](message, data)
+    } catch {
+      // Storage behavior and return values remain authoritative when diagnostics are unavailable.
+    }
+  }
+  const logger: Logger = {
+    debug: (message, data) => emitSafely('debug', message, data),
+    info: (message, data) => emitSafely('info', message, data),
+    warn: (message, data) => emitSafely('warn', message, data),
+    error: (message, data) => emitSafely('error', message, data)
+  }
 
   ipcMainHandle('storage:get-info', async () => {
     const dataRoot = resolveDataRoot()
@@ -99,7 +117,7 @@ const registerStorageIpcHandlers = (deps: StorageIpcDeps): void => {
     try {
       available = await availableBytes(dataRoot)
     } catch (err) {
-      console.error('[storage-ipc] availableBytes failed', err)
+      logger.warn('available storage lookup failed', diagnosticErrorFields(err))
     }
 
     // Only an explicitly-configured-but-now-gone root counts as "missing"; a fresh install's unset
@@ -123,7 +141,7 @@ const registerStorageIpcHandlers = (deps: StorageIpcDeps): void => {
       legacyDataMovePrompt =
         legacyInPlace && hasUserData && storedSettings.legacyDataMovePromptDismissedAt === undefined
     } catch (err) {
-      console.error('[storage-ipc] dataRootMissing/legacy detection failed', err)
+      logger.warn('data root status detection failed', diagnosticErrorFields(err))
     }
 
     return {
@@ -142,8 +160,10 @@ const registerStorageIpcHandlers = (deps: StorageIpcDeps): void => {
     // The renderer supplies no path: main resolves the single trusted config root at invocation time.
     try {
       const error = await shell.openPath(resolveConfigRoot())
+      if (error) logger.warn('application storage reveal failed', { errorCategory: 'shell' })
       return error ? { revealed: false, error } : { revealed: true }
     } catch (error) {
+      logger.warn('application storage reveal failed', diagnosticErrorFields(error))
       return {
         revealed: false,
         error: error instanceof Error ? error.message : 'Could not reveal application storage.'
@@ -158,7 +178,7 @@ const registerStorageIpcHandlers = (deps: StorageIpcDeps): void => {
     try {
       await deps.settingsService.dismissLegacyDataMovePrompt()
     } catch (err) {
-      console.error('[storage-ipc] dismiss-legacy-move-prompt failed', err)
+      logger.warn('legacy move prompt dismissal failed', diagnosticErrorFields(err))
     }
   })
 
@@ -182,7 +202,7 @@ const registerStorageIpcHandlers = (deps: StorageIpcDeps): void => {
     } catch (err) {
       // Never let a picker failure surface as a raw rejection to the renderer; Browse
       // becomes a no-op instead.
-      console.error('[storage-ipc] pick-directory failed', err)
+      logger.warn('directory picker failed', diagnosticErrorFields(err))
       return null
     }
   })
@@ -201,6 +221,7 @@ const registerStorageIpcHandlers = (deps: StorageIpcDeps): void => {
       }
 
       const controller = new AbortController()
+      const correlationId = randomUUID()
       activeMigration = controller
       // Flag the copy: sets both the quit guard (Cmd+Q warning) and the write-gate (blocks ACP/notebook
       // writes to the old root for the whole copy→commit window).
@@ -212,6 +233,8 @@ const registerStorageIpcHandlers = (deps: StorageIpcDeps): void => {
         const result = await runDataRootMigration(
           {
             currentDataRoot: resolveDataRoot(),
+            logger,
+            diagnosticCorrelationId: correlationId,
             runtime: deps.runtime,
             notebook: deps.notebook,
             // Preserve the runtime across the move by exporting each env to an offline lock at the
@@ -227,7 +250,7 @@ const registerStorageIpcHandlers = (deps: StorageIpcDeps): void => {
             signal: controller.signal,
             onProgress: (progress) => (deps.broadcastProgress ?? defaultBroadcast)(progress),
             onVerified: (staged) => {
-              activeStaged = staged
+              activeStaged = { ...staged, correlationId }
             }
           }
         )
@@ -240,7 +263,7 @@ const registerStorageIpcHandlers = (deps: StorageIpcDeps): void => {
       } catch (err) {
         // runDataRootMigration never rejects; guard the IPC boundary anyway so a renderer call
         // never sees a raw thrown error. Nothing was committed, so lift the write-gate.
-        console.error('[storage-ipc] migrate failed unexpectedly', err)
+        logger.error('data root copy boundary failed', diagnosticErrorFields(err))
         clearMigrationPending()
         activeStaged = undefined
         return { ok: false, error: err instanceof Error ? err.message : String(err) }
@@ -270,11 +293,11 @@ const registerStorageIpcHandlers = (deps: StorageIpcDeps): void => {
     async (_event, request: { parent: string }): Promise<void> => {
       if (activeMigration || resolutionInProgress) {
         // A copy is still running; discarding would race the writer. Ignore the (stale) request.
-        console.error('[storage-ipc] discard-migrated-copy ignored: a copy is in progress')
+        logger.warn('staged data root discard ignored', { reason: 'copy-in-progress' })
         return
       }
       if (!activeStaged || !samePath(activeStaged.target, dataRootForPicked(request.parent))) {
-        console.error('[storage-ipc] discard-migrated-copy ignored: no matching staged copy')
+        logger.warn('staged data root discard ignored', { reason: 'no-matching-copy' })
         return
       }
       const staged = activeStaged
@@ -288,28 +311,32 @@ const registerStorageIpcHandlers = (deps: StorageIpcDeps): void => {
           clearMigrationPending()
           activeStaged = undefined
         } else {
-          console.error('[storage-ipc] discard-migrated-copy refused', { error: result.error })
+          logger.warn('staged data root discard refused', { reason: 'validation-failed' })
         }
       } catch (err) {
-        console.error('[storage-ipc] discard-migrated-copy failed', err)
+        logger.error('staged data root discard failed', diagnosticErrorFields(err))
       } finally {
         resolutionInProgress = false
       }
     }
   )
 
-  // Shuts the backends down (agent process tree + notebook kernels) before relaunching, so a data-root
-  // switch never leaves an orphaned backend from the old process attached to the app it relaunches into.
-  // The injected deps.relaunch (tests) replaces the whole relaunch+exit, so it short-circuits ahead of
-  // any real shutdown. shutdownBackends is bounded and never throws, so relaunch always makes progress.
+  // Production relaunches through app.quit(), allowing the single application lifecycle owner to
+  // drain usage, flush renderer persistence, stop backends, write a terminal diagnostic, and flush
+  // main.log before exit. The injected callback remains a narrow test seam.
   const cleanRelaunch = async (): Promise<void> => {
     if (deps.relaunch) {
       deps.relaunch()
       return
     }
-    await shutdownBackends({ runtime: deps.runtime, notebook: deps.notebook })
     app.relaunch()
-    app.exit(0)
+    const rollbackTrigger = markApplicationShutdownTrigger('migration-relaunch')
+    try {
+      app.quit()
+    } catch (error) {
+      rollbackTrigger()
+      throw error
+    }
   }
 
   // Phase 2 (commit): invoked by the modal's "Restart now" once the copy is done. Flips
@@ -340,12 +367,14 @@ const registerStorageIpcHandlers = (deps: StorageIpcDeps): void => {
             // Arrow-wrapped so setDataRoot is called as a method (it reads `this.repository`).
             setDataRoot: (path) => deps.settingsService.setDataRoot(path),
             // Prove the on-disk copy is the one this session staged (guards against a stale marker).
-            expectedToken: staged.token
+            expectedToken: staged.token,
+            logger,
+            diagnosticCorrelationId: staged.correlationId
           },
           request.parent
         )
       } catch (err) {
-        console.error('[storage-ipc] commit-and-relaunch failed unexpectedly', err)
+        logger.error('data root commit boundary failed', diagnosticErrorFields(err))
         // The commit didn't complete; keep the app usable on the old root by lifting the write-gate.
         clearMigrationPending()
         activeStaged = undefined
@@ -387,7 +416,7 @@ const registerStorageIpcHandlers = (deps: StorageIpcDeps): void => {
       try {
         return await validateNewDataRoot(request.parent, resolveDataRoot())
       } catch (err) {
-        console.error('[storage-ipc] validate-data-root failed unexpectedly', err)
+        logger.warn('data root validation boundary failed', diagnosticErrorFields(err))
         return { ok: false, error: err instanceof Error ? err.message : String(err) }
       }
     }
@@ -405,7 +434,7 @@ const registerStorageIpcHandlers = (deps: StorageIpcDeps): void => {
         const result = await classifyDataRoot(request.parent, resolveDataRoot())
         return { ...result, dataRoot }
       } catch (err) {
-        console.error('[storage-ipc] inspect-data-root failed unexpectedly', err)
+        logger.warn('data root inspection boundary failed', diagnosticErrorFields(err))
         return {
           kind: 'invalid',
           dataRoot,
@@ -435,9 +464,15 @@ const registerStorageIpcHandlers = (deps: StorageIpcDeps): void => {
       _event,
       request: { parent: string; markOnboarding?: boolean }
     ): Promise<ValidateResult> => {
+      const operation = startDiagnosticOperation(logger, {
+        operation: 'data-root-selection',
+        fields: { onboarding: request.markOnboarding === true }
+      })
+      operation.phase('classify-target')
       try {
         const classification = await classifyDataRoot(request.parent, resolveDataRoot())
         if (classification.kind === 'invalid') {
+          operation.fail(new Error(classification.error ?? 'invalid target'), { mode: 'invalid' })
           return { ok: false, error: classification.error ?? 'The selected folder is not usable.' }
         }
 
@@ -448,16 +483,21 @@ const registerStorageIpcHandlers = (deps: StorageIpcDeps): void => {
         // read that explicitly-configured-but-absent root as deleted and wrongly show "Data folder not
         // found". For an 'adopt' target the folder already exists, so this is a no-op. classifyDataRoot
         // has already proven the parent writable, so failure here is genuinely unexpected.
+        operation.phase('prepare-target', { mode: classification.kind })
         await mkdir(target, { recursive: true })
+        operation.phase('persist-pointer', { mode: classification.kind })
         await deps.settingsService.setDataRoot(target)
         if (request.markOnboarding) {
           await deps.settingsService.markOnboardingComplete()
         }
+        operation.phase('request-relaunch', { mode: classification.kind })
         await cleanRelaunch()
+        operation.complete({ mode: classification.kind })
 
         return { ok: true }
       } catch (err) {
-        console.error('[storage-ipc] set-data-root-and-relaunch failed unexpectedly', err)
+        operation.fail(err)
+        logger.error('data root selection boundary failed', diagnosticErrorFields(err))
         return { ok: false, error: err instanceof Error ? err.message : String(err) }
       }
     }

--- a/src/main/storage/migration-service.test.ts
+++ b/src/main/storage/migration-service.test.ts
@@ -32,6 +32,7 @@ import {
 } from './migration-marker'
 import { withDataRootWrite } from './migration-state'
 import { operationJournalPath, RuntimeOperationJournal } from '../notebook/operation-journal'
+import type { Logger } from '../logger'
 
 // Writes a verified staging marker for `<parent>/OpenScience`, as a completed copy phase would have.
 const seedVerifiedMarker = async (
@@ -450,9 +451,150 @@ const runOpts = (): { signal: AbortSignal; onProgress: (p: MigrationProgress) =>
   onProgress: () => {}
 })
 
+const fakeDiagnosticLogger = (): Logger => ({
+  debug: vi.fn(),
+  info: vi.fn(),
+  warn: vi.fn(),
+  error: vi.fn()
+})
+
+const diagnosticRecords = (logger: Logger): Record<string, unknown>[] =>
+  [logger.debug, logger.info, logger.warn, logger.error].flatMap((method) =>
+    (method as Mock).mock.calls.map((call) => call[1] as Record<string, unknown>)
+  )
+
 type DeleteResult = { deleted: string[]; failed: { dir: string; error: string }[] }
 
 describe('runDataRootMigration (copy phase)', () => {
+  it('diagnoses target validation failure without changing the result or retaining sensitive values', async () => {
+    const deps = fakeDeps()
+    const logger = fakeDiagnosticLogger()
+
+    const result = await runDataRootMigration(
+      { ...deps, currentDataRoot, logger },
+      currentParent,
+      runOpts()
+    )
+
+    const validationError = 'The new location is the same as the current one.'
+    expect(result).toEqual({
+      ok: false,
+      error: validationError
+    })
+    expect(diagnosticRecords(logger)).toContainEqual(
+      expect.objectContaining({
+        operation: 'data-root-copy',
+        phase: 'validate-target',
+        outcome: 'failed',
+        errorCategory: 'error'
+      })
+    )
+    const serializedDiagnostics = JSON.stringify(diagnosticRecords(logger))
+    expect(serializedDiagnostics).not.toContain(currentDataRoot)
+    expect(serializedDiagnostics).not.toContain(currentParent)
+    expect(serializedDiagnostics).not.toContain(validationError)
+  })
+
+  it('records the successful copy lifecycle through staging verification', async () => {
+    const deps = fakeDeps()
+    const logger = fakeDiagnosticLogger()
+    const copyAndVerify = vi.fn(async (): Promise<MigrationResult> => ({ ok: true }))
+
+    const result = await runDataRootMigration(
+      { ...deps, currentDataRoot, copyAndVerify, logger },
+      emptyParent,
+      runOpts()
+    )
+
+    expect(result).toEqual({ ok: true })
+    const records = diagnosticRecords(logger)
+    expect(
+      records.filter((record) => record.phase && !record.outcome).map((record) => record.phase)
+    ).toEqual([
+      'validate-target',
+      'prepare-staging',
+      'pause-writers',
+      'validate-source',
+      'preserve-runtime',
+      'copy',
+      'verify-target'
+    ])
+    expect(records).toContainEqual(
+      expect.objectContaining({
+        operation: 'data-root-copy',
+        phase: 'verify-target',
+        outcome: 'completed',
+        preservedEnvironmentCount: 0
+      })
+    )
+  })
+
+  it('records bounded copy quartiles without retaining the current file path', async () => {
+    const deps = fakeDeps()
+    const logger = fakeDiagnosticLogger()
+    const onProgress = vi.fn()
+    const copyAndVerify = vi.fn(
+      async (opts: { onProgress: (progress: MigrationProgress) => void }) => {
+        opts.onProgress({ phase: 'scan', copiedBytes: 0, totalBytes: 400 })
+        opts.onProgress({
+          phase: 'copy',
+          copiedBytes: 110,
+          totalBytes: 400,
+          currentPath: 'secret/project-name.txt'
+        })
+        opts.onProgress({ phase: 'copy', copiedBytes: 400, totalBytes: 400 })
+        return { ok: true } as const
+      }
+    )
+
+    await runDataRootMigration({ ...deps, currentDataRoot, copyAndVerify, logger }, emptyParent, {
+      ...runOpts(),
+      onProgress
+    })
+
+    expect(onProgress).toHaveBeenCalledTimes(3)
+    expect(
+      diagnosticRecords(logger)
+        .filter((record) => record.progressPercent !== undefined)
+        .map((record) => record.progressPercent)
+    ).toEqual([0, 25, 50, 75, 100])
+    expect(JSON.stringify(diagnosticRecords(logger))).not.toContain('secret/project-name.txt')
+  })
+
+  it.skipIf(process.platform === 'win32')(
+    'diagnoses staging preparation failure without retaining the target path',
+    async () => {
+      const deps = fakeDeps()
+      const logger = fakeDiagnosticLogger()
+      const target = dataRootFor(emptyParent)
+      await mkdir(join(target, 'runtime'), { recursive: true })
+      await chmod(target, 0o500)
+
+      try {
+        const result = await runDataRootMigration(
+          { ...deps, currentDataRoot, logger },
+          emptyParent,
+          runOpts()
+        )
+
+        expect(result).toEqual({
+          ok: false,
+          error: 'Could not prepare the new data location. Please try again.'
+        })
+        expect(diagnosticRecords(logger)).toContainEqual(
+          expect.objectContaining({
+            operation: 'data-root-copy',
+            phase: 'prepare-staging',
+            outcome: 'failed'
+          })
+        )
+        expect(JSON.stringify(diagnosticRecords(logger))).not.toContain(target)
+      } finally {
+        if (existsSync(target)) await chmod(target, 0o700)
+      }
+    }
+  )
+
   it('interrupts sessions then copies+verifies into the target, committing nothing', async () => {
     const order: string[] = []
     const deps = fakeDeps()
@@ -539,20 +681,56 @@ describe('runDataRootMigration (copy phase)', () => {
 
   it('returns the copy failure untouched', async () => {
     const deps = fakeDeps()
+    const logger = fakeDiagnosticLogger()
     const copyAndVerify = vi.fn(async (): Promise<MigrationResult> => ({ ok: false, error: 'x' }))
 
     const result = await runDataRootMigration(
-      { currentDataRoot, runtime: deps.runtime, notebook: deps.notebook, copyAndVerify },
+      { currentDataRoot, runtime: deps.runtime, notebook: deps.notebook, copyAndVerify, logger },
       emptyParent,
       runOpts()
     )
 
     expect(result).toEqual({ ok: false, error: 'x' })
     expect(deps.setDataRoot).not.toHaveBeenCalled()
+    expect(diagnosticRecords(logger)).toContainEqual(
+      expect.objectContaining({
+        operation: 'data-root-copy',
+        phase: 'copy',
+        outcome: 'failed',
+        errorCategory: 'error'
+      })
+    )
+    expect(JSON.stringify(diagnosticRecords(logger))).not.toContain('"x"')
+  })
+
+  it('diagnoses an unexpected copy engine rejection without exposing its error', async () => {
+    const deps = fakeDeps()
+    const logger = fakeDiagnosticLogger()
+    const copyAndVerify = vi.fn(async (): Promise<MigrationResult> => {
+      throw new Error('copy-secret')
+    })
+
+    const result = await runDataRootMigration(
+      { currentDataRoot, runtime: deps.runtime, notebook: deps.notebook, copyAndVerify, logger },
+      emptyParent,
+      runOpts()
+    )
+
+    expect(result).toEqual({ ok: false, error: 'Could not copy your data. Please try again.' })
+    expect(diagnosticRecords(logger)).toContainEqual(
+      expect.objectContaining({
+        operation: 'data-root-copy',
+        phase: 'copy',
+        outcome: 'failed',
+        errorCategory: 'error'
+      })
+    )
+    expect(JSON.stringify(diagnosticRecords(logger))).not.toContain('copy-secret')
   })
 
   it('refuses to stage a migration when the frozen source has unresolved durable provenance', async () => {
     const deps = fakeDeps()
+    const logger = fakeDiagnosticLogger()
     const copyAndVerify = vi.fn(async (): Promise<MigrationResult> => ({ ok: true }))
     const validateProvenanceState = vi.fn(async () => {
       throw new Error('unfinished Artifact staging')
@@ -564,7 +742,8 @@ describe('runDataRootMigration (copy phase)', () => {
         runtime: deps.runtime,
         notebook: deps.notebook,
         copyAndVerify,
-        validateProvenanceState
+        validateProvenanceState,
+        logger
       },
       emptyParent,
       runOpts()
@@ -576,6 +755,53 @@ describe('runDataRootMigration (copy phase)', () => {
     })
     expect(validateProvenanceState).toHaveBeenCalledWith(currentDataRoot)
     expect(copyAndVerify).not.toHaveBeenCalled()
+    expect(diagnosticRecords(logger)).toContainEqual(
+      expect.objectContaining({
+        operation: 'data-root-copy',
+        phase: 'validate-source',
+        outcome: 'failed',
+        errorCategory: 'error'
+      })
+    )
+    expect(JSON.stringify(diagnosticRecords(logger))).not.toContain('unfinished Artifact staging')
+  })
+
+  it('diagnoses target provenance verification failure without retaining its error', async () => {
+    const deps = fakeDeps()
+    const logger = fakeDiagnosticLogger()
+    const copyAndVerify = vi.fn(async (): Promise<MigrationResult> => ({ ok: true }))
+    let validationCount = 0
+    const validateProvenanceState = vi.fn(async () => {
+      validationCount += 1
+      if (validationCount === 2) throw new Error('target-provenance-secret')
+    })
+
+    const result = await runDataRootMigration(
+      {
+        currentDataRoot,
+        runtime: deps.runtime,
+        notebook: deps.notebook,
+        copyAndVerify,
+        validateProvenanceState,
+        logger
+      },
+      emptyParent,
+      runOpts()
+    )
+
+    expect(result).toEqual({
+      ok: false,
+      error: 'Could not verify provenance data: target-provenance-secret'
+    })
+    expect(diagnosticRecords(logger)).toContainEqual(
+      expect.objectContaining({
+        operation: 'data-root-copy',
+        phase: 'verify-target',
+        outcome: 'failed',
+        errorCategory: 'error'
+      })
+    )
+    expect(JSON.stringify(diagnosticRecords(logger))).not.toContain('target-provenance-secret')
   })
 
   it('refuses to copy while the source runtime recovery journal has a pending operation', async () => {
@@ -693,8 +919,86 @@ describe('runDataRootMigration (copy phase)', () => {
     })
   })
 
+  it('diagnoses staged-copy finalization failure without retaining callback error details', async () => {
+    const deps = fakeDeps()
+    const logger = fakeDiagnosticLogger()
+    const copyAndVerify = vi.fn(async (): Promise<MigrationResult> => ({ ok: true }))
+
+    const result = await runDataRootMigration(
+      { currentDataRoot, runtime: deps.runtime, notebook: deps.notebook, copyAndVerify, logger },
+      emptyParent,
+      {
+        signal: new AbortController().signal,
+        onProgress: () => {},
+        onVerified: () => {
+          throw new Error('verification-callback-secret')
+        }
+      }
+    )
+
+    expect(result).toEqual({
+      ok: false,
+      error: 'Could not finalize the copied data. Please run the move again.'
+    })
+    expect(diagnosticRecords(logger)).toContainEqual(
+      expect.objectContaining({
+        operation: 'data-root-copy',
+        phase: 'verify-target',
+        outcome: 'failed',
+        errorCategory: 'error'
+      })
+    )
+    expect(JSON.stringify(diagnosticRecords(logger))).not.toContain('verification-callback-secret')
+  })
+
+  it.skipIf(process.platform === 'win32')(
+    'diagnoses staged inventory failure at target verification',
+    async () => {
+      const deps = fakeDeps()
+      const logger = fakeDiagnosticLogger()
+      const target = dataRootFor(emptyParent)
+      const unreadableDir = join(target, 'artifacts')
+      const copyAndVerify = vi.fn(async (): Promise<MigrationResult> => {
+        await mkdir(unreadableDir, { recursive: true })
+        await writeFile(join(unreadableDir, 'private.txt'), 'private')
+        await chmod(unreadableDir, 0o000)
+        return { ok: true }
+      })
+
+      try {
+        const result = await runDataRootMigration(
+          {
+            currentDataRoot,
+            runtime: deps.runtime,
+            notebook: deps.notebook,
+            copyAndVerify,
+            validateProvenanceState: async () => undefined,
+            logger
+          },
+          emptyParent,
+          runOpts()
+        )
+
+        expect(result).toEqual({
+          ok: false,
+          error: 'Could not verify the copied data. Please run the move again.'
+        })
+        expect(diagnosticRecords(logger)).toContainEqual(
+          expect.objectContaining({
+            operation: 'data-root-copy',
+            phase: 'verify-target',
+            outcome: 'failed'
+          })
+        )
+      } finally {
+        if (existsSync(unreadableDir)) await chmod(unreadableDir, 0o700)
+      }
+    }
+  )
+
   it('removes the marker and cleans up the empty target on copy failure/cancel', async () => {
     const deps = fakeDeps()
+    const logger = fakeDiagnosticLogger()
     const target = dataRootFor(emptyParent)
     const copyAndVerify = vi.fn(async (): Promise<MigrationResult> => ({
       ok: false,
@@ -703,7 +1007,7 @@ describe('runDataRootMigration (copy phase)', () => {
     }))
 
     await runDataRootMigration(
-      { currentDataRoot, runtime: deps.runtime, notebook: deps.notebook, copyAndVerify },
+      { currentDataRoot, runtime: deps.runtime, notebook: deps.notebook, copyAndVerify, logger },
       emptyParent,
       runOpts()
     )
@@ -711,6 +1015,40 @@ describe('runDataRootMigration (copy phase)', () => {
     // No marker, and the empty staging shell is gone — a cancelled move leaves no trace.
     expect(await readMigrationMarker(target)).toBeNull()
     expect(existsSync(target)).toBe(false)
+    expect(diagnosticRecords(logger)).toContainEqual(
+      expect.objectContaining({
+        operation: 'data-root-copy',
+        phase: 'copy',
+        outcome: 'cancelled',
+        cancelRequested: true
+      })
+    )
+  })
+
+  it('records cancellation requested while the copy engine is finishing as cancelled', async () => {
+    const deps = fakeDeps()
+    const logger = fakeDiagnosticLogger()
+    const controller = new AbortController()
+    const copyAndVerify = vi.fn(async (): Promise<MigrationResult> => {
+      controller.abort()
+      return { ok: true }
+    })
+
+    const result = await runDataRootMigration(
+      { currentDataRoot, runtime: deps.runtime, notebook: deps.notebook, copyAndVerify, logger },
+      emptyParent,
+      { signal: controller.signal, onProgress: () => {} }
+    )
+
+    expect(result).toEqual({ ok: false, error: 'migration cancelled', cancelled: true })
+    expect(diagnosticRecords(logger)).toContainEqual(
+      expect.objectContaining({
+        operation: 'data-root-copy',
+        phase: 'copy',
+        outcome: 'cancelled',
+        cancelRequested: true
+      })
+    )
   })
 
   it('short-circuits on validation failure without interrupting or copying', async () => {
@@ -735,11 +1073,12 @@ describe('runDataRootMigration (copy phase)', () => {
 
   it('aborts (and does not copy) when a writer cannot be paused', async () => {
     const deps = fakeDeps()
+    const logger = fakeDiagnosticLogger()
     deps.runtime.disconnect.mockRejectedValue(new Error('disconnect boom'))
     const copyAndVerify = vi.fn(async (): Promise<MigrationResult> => ({ ok: true }))
 
     const result = await runDataRootMigration(
-      { currentDataRoot, runtime: deps.runtime, notebook: deps.notebook, copyAndVerify },
+      { currentDataRoot, runtime: deps.runtime, notebook: deps.notebook, copyAndVerify, logger },
       emptyParent,
       runOpts()
     )
@@ -749,10 +1088,74 @@ describe('runDataRootMigration (copy phase)', () => {
     expect(copyAndVerify).not.toHaveBeenCalled()
     // The staging dir (marker) we created is cleaned up on abort.
     expect(existsSync(dataRootFor(emptyParent))).toBe(false)
+    expect(diagnosticRecords(logger)).toContainEqual(
+      expect.objectContaining({
+        operation: 'data-root-copy',
+        phase: 'pause-writers',
+        outcome: 'failed',
+        errorCategory: 'error'
+      })
+    )
+    expect(JSON.stringify(diagnosticRecords(logger))).not.toContain('disconnect boom')
   })
 })
 
 describe('commitDataRootSwitch (commit phase)', () => {
+  it('correlates distinct copy and commit operations without reusing the marker token', async () => {
+    const deps = fakeDeps()
+    const logger = fakeDiagnosticLogger()
+    const diagnosticCorrelationId = 'diagnostic-migration-id'
+    let markerToken = ''
+
+    await runDataRootMigration(
+      {
+        currentDataRoot,
+        runtime: deps.runtime,
+        notebook: deps.notebook,
+        copyAndVerify: async () => ({ ok: true }),
+        validateProvenanceState: async () => undefined,
+        logger,
+        diagnosticCorrelationId
+      },
+      emptyParent,
+      {
+        ...runOpts(),
+        onVerified: ({ token }) => {
+          markerToken = token
+        }
+      }
+    )
+
+    const result = await commitDataRootSwitch(
+      {
+        currentDataRoot,
+        setDataRoot: deps.setDataRoot,
+        deleteSources: async () => ({ deleted: [], failed: [] }),
+        validateProvenanceState: async () => undefined,
+        expectedToken: markerToken,
+        logger,
+        diagnosticCorrelationId
+      },
+      emptyParent
+    )
+
+    expect(result).toEqual({ ok: true })
+    const terminalRecords = diagnosticRecords(logger).filter(
+      (record) => record.outcome === 'completed'
+    )
+    expect(terminalRecords).toHaveLength(2)
+    expect(terminalRecords.map((record) => record.operation)).toEqual([
+      'data-root-copy',
+      'data-root-commit'
+    ])
+    expect(
+      terminalRecords.every((record) => record.correlationId === diagnosticCorrelationId)
+    ).toBe(true)
+    expect(new Set(terminalRecords.map((record) => record.operationId)).size).toBe(2)
+    expect(markerToken).not.toBe(diagnosticCorrelationId)
+    expect(JSON.stringify(diagnosticRecords(logger))).not.toContain(markerToken)
+  })
+
   it('keeps the fixed config-root SQLite authority out of the relocatable data set', async () => {
     const deps = fakeDeps()
     const copyAndVerify = vi.fn(async (): Promise<MigrationResult> => ({ ok: true }))
@@ -774,6 +1177,7 @@ describe('commitDataRootSwitch (commit phase)', () => {
     const target = await seedVerifiedMarker(emptyParent, currentDataRoot)
     const order: string[] = []
     const deps = fakeDeps()
+    const logger = fakeDiagnosticLogger()
     deps.setDataRoot.mockImplementation(async () => {
       order.push('setDataRoot')
     })
@@ -783,7 +1187,13 @@ describe('commitDataRootSwitch (commit phase)', () => {
     })
 
     const result = await commitDataRootSwitch(
-      { currentDataRoot, setDataRoot: deps.setDataRoot, deleteSources, expectedToken: 'tok-test' },
+      {
+        currentDataRoot,
+        setDataRoot: deps.setDataRoot,
+        deleteSources,
+        expectedToken: 'tok-test',
+        logger
+      },
       emptyParent
     )
 
@@ -795,21 +1205,52 @@ describe('commitDataRootSwitch (commit phase)', () => {
     expect(deleteSources).toHaveBeenCalledWith(currentDataRoot, [...MIGRATED_DIRS])
     // The committed (now-live) root must carry NO marker.
     expect(existsSync(join(target, MIGRATION_MARKER_FILENAME))).toBe(false)
+    const records = diagnosticRecords(logger)
+    expect(
+      records.filter((record) => record.phase && !record.outcome).map((record) => record.phase)
+    ).toEqual(['recheck-inventory', 'validate-provenance', 'persist-pointer', 'cleanup-source'])
+    expect(records).toContainEqual(
+      expect.objectContaining({
+        operation: 'data-root-commit',
+        phase: 'cleanup-source',
+        outcome: 'completed',
+        cleanupDegraded: false,
+        cleanupFailureCount: 0
+      })
+    )
+    expect(JSON.stringify(records)).not.toContain(currentDataRoot)
+    expect(JSON.stringify(records)).not.toContain(target)
+    expect(JSON.stringify(records)).not.toContain('tok-test')
   })
 
   it('refuses to commit when no marker is present (setDataRoot and delete never run)', async () => {
     await mkdir(dataRootFor(emptyParent), { recursive: true }) // staging dir, but no marker
     const deps = fakeDeps()
+    const logger = fakeDiagnosticLogger()
     const deleteSources = vi.fn(async (): Promise<DeleteResult> => ({ deleted: [], failed: [] }))
 
     const result = await commitDataRootSwitch(
-      { currentDataRoot, setDataRoot: deps.setDataRoot, deleteSources, expectedToken: 'tok-test' },
+      {
+        currentDataRoot,
+        setDataRoot: deps.setDataRoot,
+        deleteSources,
+        expectedToken: 'tok-test',
+        logger
+      },
       emptyParent
     )
 
     expect(result).toEqual({ ok: false, error: 'No completed migration copy was found to commit.' })
     expect(deps.setDataRoot).not.toHaveBeenCalled()
     expect(deleteSources).not.toHaveBeenCalled()
+    expect(diagnosticRecords(logger)).toContainEqual(
+      expect.objectContaining({
+        operation: 'data-root-commit',
+        phase: 'recheck-inventory',
+        outcome: 'failed',
+        errorCategory: 'error'
+      })
+    )
   })
 
   it("refuses to commit a marker that is only 'copying' (not verified)", async () => {
@@ -867,11 +1308,18 @@ describe('commitDataRootSwitch (commit phase)', () => {
   it('returns switchoverFailed, skips delete, and KEEPS the marker when setDataRoot fails', async () => {
     const target = await seedVerifiedMarker(emptyParent, currentDataRoot)
     const deps = fakeDeps()
+    const logger = fakeDiagnosticLogger()
     deps.setDataRoot.mockRejectedValue(new Error('disk full'))
     const deleteSources = vi.fn(async (): Promise<DeleteResult> => ({ deleted: [], failed: [] }))
 
     const result = await commitDataRootSwitch(
-      { currentDataRoot, setDataRoot: deps.setDataRoot, deleteSources, expectedToken: 'tok-test' },
+      {
+        currentDataRoot,
+        setDataRoot: deps.setDataRoot,
+        deleteSources,
+        expectedToken: 'tok-test',
+        logger
+      },
       emptyParent
     )
 
@@ -883,22 +1331,152 @@ describe('commitDataRootSwitch (commit phase)', () => {
     expect(deleteSources).not.toHaveBeenCalled()
     // The copy stays discardable/retryable, so the marker must survive a failed switchover.
     expect(existsSync(join(target, MIGRATION_MARKER_FILENAME))).toBe(true)
+    expect(diagnosticRecords(logger)).toContainEqual(
+      expect.objectContaining({
+        operation: 'data-root-commit',
+        phase: 'persist-pointer',
+        outcome: 'failed',
+        switchoverFailed: true,
+        errorCategory: 'error'
+      })
+    )
+    expect(JSON.stringify(diagnosticRecords(logger))).not.toContain('disk full')
+    expect(JSON.stringify(diagnosticRecords(logger))).not.toContain(target)
+  })
+
+  it('diagnoses commit provenance validation failure without retaining its error', async () => {
+    await seedVerifiedMarker(emptyParent, currentDataRoot)
+    const deps = fakeDeps()
+    const logger = fakeDiagnosticLogger()
+    const validateProvenanceState = vi.fn(async () => {
+      throw new Error('commit-provenance-secret')
+    })
+
+    const result = await commitDataRootSwitch(
+      {
+        currentDataRoot,
+        setDataRoot: deps.setDataRoot,
+        expectedToken: 'tok-test',
+        validateProvenanceState,
+        logger
+      },
+      emptyParent
+    )
+
+    expect(result).toEqual({
+      ok: false,
+      error: 'Could not verify provenance data: commit-provenance-secret'
+    })
+    expect(deps.setDataRoot).not.toHaveBeenCalled()
+    expect(diagnosticRecords(logger)).toContainEqual(
+      expect.objectContaining({
+        operation: 'data-root-commit',
+        phase: 'validate-provenance',
+        outcome: 'failed',
+        errorCategory: 'error'
+      })
+    )
+    expect(JSON.stringify(diagnosticRecords(logger))).not.toContain('commit-provenance-secret')
   })
 
   it('still succeeds when deleteSources reports per-dir failures (harmless leftovers)', async () => {
     await seedVerifiedMarker(emptyParent, currentDataRoot)
     const deps = fakeDeps()
+    const logger = fakeDiagnosticLogger()
     const deleteSources = vi.fn(async (): Promise<DeleteResult> => ({
       deleted: ['artifacts'],
       failed: [{ dir: 'uploads', error: 'EACCES' }]
     }))
 
     const result = await commitDataRootSwitch(
-      { currentDataRoot, setDataRoot: deps.setDataRoot, deleteSources, expectedToken: 'tok-test' },
+      {
+        currentDataRoot,
+        setDataRoot: deps.setDataRoot,
+        deleteSources,
+        expectedToken: 'tok-test',
+        logger
+      },
       emptyParent
     )
 
     expect(result).toEqual({ ok: true })
+    expect(diagnosticRecords(logger)).toContainEqual(
+      expect.objectContaining({
+        operation: 'data-root-commit',
+        phase: 'cleanup-source',
+        outcome: 'completed',
+        cleanupDegraded: true,
+        cleanupFailureCount: 1
+      })
+    )
+    expect(JSON.stringify(diagnosticRecords(logger))).not.toContain('uploads')
+    expect(JSON.stringify(diagnosticRecords(logger))).not.toContain('EACCES')
+  })
+
+  it.skipIf(process.platform === 'win32')(
+    'reports marker cleanup failure as degraded success after pointer persistence',
+    async () => {
+      const target = await seedVerifiedMarker(emptyParent, currentDataRoot)
+      const logger = fakeDiagnosticLogger()
+      const setDataRoot = vi.fn(async () => {
+        await chmod(target, 0o500)
+      })
+      const deleteSources = vi.fn(async (): Promise<DeleteResult> => ({
+        deleted: [...MIGRATED_DIRS],
+        failed: []
+      }))
+
+      try {
+        const result = await commitDataRootSwitch(
+          { currentDataRoot, setDataRoot, deleteSources, expectedToken: 'tok-test', logger },
+          emptyParent
+        )
+
+        expect(result).toEqual({ ok: true })
+        expect(diagnosticRecords(logger)).toContainEqual(
+          expect.objectContaining({
+            operation: 'data-root-commit',
+            phase: 'cleanup-source',
+            outcome: 'completed',
+            cleanupDegraded: true,
+            cleanupFailureCount: 0
+          })
+        )
+      } finally {
+        await chmod(target, 0o700)
+      }
+    }
+  )
+
+  it('preserves an unexpected cleanup rejection while diagnosing its phase', async () => {
+    await seedVerifiedMarker(emptyParent, currentDataRoot)
+    const deps = fakeDeps()
+    const logger = fakeDiagnosticLogger()
+    const deleteSources = vi.fn(async (): Promise<DeleteResult> => {
+      throw new Error('cleanup-secret')
+    })
+
+    await expect(
+      commitDataRootSwitch(
+        {
+          currentDataRoot,
+          setDataRoot: deps.setDataRoot,
+          deleteSources,
+          expectedToken: 'tok-test',
+          logger
+        },
+        emptyParent
+      )
+    ).rejects.toThrow('cleanup-secret')
+    expect(diagnosticRecords(logger)).toContainEqual(
+      expect.objectContaining({
+        operation: 'data-root-commit',
+        phase: 'cleanup-source',
+        outcome: 'failed',
+        errorCategory: 'error'
+      })
+    )
+    expect(JSON.stringify(diagnosticRecords(logger))).not.toContain('cleanup-secret')
   })
   it('refuses when the marker token does not match the session token', async () => {
     await seedVerifiedMarker(emptyParent, currentDataRoot) // token 'tok-test'
@@ -966,6 +1544,7 @@ describe('commitDataRootSwitch (commit phase)', () => {
     await writeFile(join(target, 'artifacts', 'keep.txt'), 'hello')
     await writeFile(join(currentDataRoot, 'artifacts', 'late.txt'), 'late write')
     const setDataRoot = vi.fn(async () => {})
+    const logger = fakeDiagnosticLogger()
     const deleteSources = vi.fn(async (): Promise<DeleteResult> => ({
       deleted: [...MIGRATED_DIRS],
       failed: []
@@ -976,7 +1555,8 @@ describe('commitDataRootSwitch (commit phase)', () => {
         currentDataRoot,
         setDataRoot,
         deleteSources,
-        expectedToken: 'tok-test'
+        expectedToken: 'tok-test',
+        logger
       },
       emptyParent
     )
@@ -987,6 +1567,14 @@ describe('commitDataRootSwitch (commit phase)', () => {
     })
     expect(setDataRoot).not.toHaveBeenCalled()
     expect(deleteSources).not.toHaveBeenCalled()
+    expect(diagnosticRecords(logger)).toContainEqual(
+      expect.objectContaining({
+        operation: 'data-root-commit',
+        phase: 'recheck-inventory',
+        outcome: 'failed',
+        errorCategory: 'error'
+      })
+    )
   })
 })
 
@@ -1118,6 +1706,7 @@ describe('runtime preservation + old-runtime cleanup', () => {
 
   it('still copies user data when exportRuntimeLocks throws (best-effort)', async () => {
     const deps = fakeDeps()
+    const logger = fakeDiagnosticLogger()
     const exportRuntimeLocks = vi.fn(async () => {
       throw new Error('micromamba boom')
     })
@@ -1129,7 +1718,8 @@ describe('runtime preservation + old-runtime cleanup', () => {
         runtime: deps.runtime,
         notebook: deps.notebook,
         exportRuntimeLocks,
-        copyAndVerify
+        copyAndVerify,
+        logger
       },
       emptyParent,
       runOpts()
@@ -1141,6 +1731,16 @@ describe('runtime preservation + old-runtime cleanup', () => {
         dirs: [...MIGRATED_DIRS, RUNTIME_ENVIRONMENT_MANIFESTS_DIR]
       })
     )
+    expect(diagnosticRecords(logger)).toContainEqual(
+      expect.objectContaining({
+        operation: 'data-root-copy',
+        phase: 'verify-target',
+        outcome: 'completed',
+        preservedEnvironmentCount: 0,
+        runtimePreservationDegraded: true
+      })
+    )
+    expect(JSON.stringify(diagnosticRecords(logger))).not.toContain('micromamba boom')
   })
 
   it('deletes the old runtime too when the new root has a reconstructable bundle', async () => {

--- a/src/main/storage/migration-service.ts
+++ b/src/main/storage/migration-service.ts
@@ -30,6 +30,8 @@ import { windowsDefaultEnvPrefixReserve } from '../notebook/runtime-paths'
 import { RELOCATABLE_DATA_DIRS } from './data-directories'
 import { validateProvenanceMigrationState } from './provenance-migration-validation'
 import { disconnectProjectDbClient } from '../projects/prisma-client'
+import { createLogger, type Logger } from '../logger'
+import { startDiagnosticOperation } from '../diagnostics/operation'
 
 export { DATA_ROOT_DIRS } from './data-directories'
 
@@ -301,6 +303,8 @@ const sameInventory = (left: MigrationInventory, right: MigrationInventory): boo
 
 type MigrationCopyDeps = {
   currentDataRoot: string
+  logger?: Logger
+  diagnosticCorrelationId?: string
   runtime: { disconnect: () => Promise<unknown> }
   // Return ignored (awaited only), so kept as Promise<unknown> — mirrors runtime.disconnect above and
   // stays compatible with both the real service (now returns { reaped }) and void test fakes.
@@ -326,6 +330,8 @@ type MigrationCopyDeps = {
 
 type MigrationCommitDeps = {
   currentDataRoot: string
+  logger?: Logger
+  diagnosticCorrelationId?: string
   setDataRoot: (path: string) => Promise<void>
   // Marker token the IPC layer captured when THIS session's copy completed. Commit refuses unless the
   // on-disk marker still carries the same token, so a stale/foreign copy can never be committed.
@@ -354,9 +360,17 @@ export const runDataRootMigration = async (
     onVerified?: (staged: { token: string; target: string }) => void
   }
 ): Promise<MigrationResult> => {
+  const operation = startDiagnosticOperation(deps.logger ?? createLogger('storage:migration'), {
+    operation: 'data-root-copy',
+    fields: { mode: 'move', correlationId: deps.diagnosticCorrelationId }
+  })
+  operation.phase('validate-target')
   const validation = await validateNewDataRoot(parent, deps.currentDataRoot)
 
-  if (!validation.ok) return { ok: false, error: validation.error }
+  if (!validation.ok) {
+    operation.fail(new Error(validation.error))
+    return { ok: false, error: validation.error }
+  }
 
   const target = dataRootForPicked(parent)
 
@@ -371,6 +385,7 @@ export const runDataRootMigration = async (
     createdAt: Date.now(),
     status: 'copying'
   }
+  operation.phase('prepare-staging')
   try {
     await mkdir(target, { recursive: true })
     // A runtime-only destination is a valid move target and may be residue from an earlier location.
@@ -379,22 +394,23 @@ export const runDataRootMigration = async (
     await rm(join(target, RUNTIME_ENVIRONMENT_INVENTORY_DIR), { recursive: true, force: true })
     await writeMigrationMarker(target, marker)
   } catch (err) {
-    console.error('[migration-service] failed to initialize staging dir', err)
     await rm(target, { recursive: true, force: true }).catch(() => undefined)
+    operation.fail(err)
     return { ok: false, error: 'Could not prepare the new data location. Please try again.' }
   }
 
   // Freeze in-flight writers before copying. If either interrupt fails we must NOT copy an unfrozen
   // tree — a surviving write would land outside the snapshot and be lost on the commit's delete — so
   // clean up the staging dir and abort rather than swallow the failure and press on.
+  operation.phase('pause-writers')
   try {
     await deps.runtime.disconnect()
     await deps.notebook.shutdownAll()
     await (deps.disconnectProjectDb ?? disconnectProjectDbClient)()
     await waitForDataRootWriters()
   } catch (err) {
-    console.error('[migration-service] failed to pause writers; aborting migration', err)
     await rm(target, { recursive: true, force: true }).catch(() => undefined)
+    operation.fail(err)
     return {
       ok: false,
       error: 'Could not pause running work to copy your data safely. Please try again in a moment.'
@@ -402,10 +418,12 @@ export const runDataRootMigration = async (
   }
 
   const validateProvenanceState = deps.validateProvenanceState ?? defaultValidateProvenanceState
+  operation.phase('validate-source')
   try {
     await validateProvenanceState(deps.currentDataRoot)
   } catch (error) {
     await rm(target, { recursive: true, force: true }).catch(() => undefined)
+    operation.fail(error)
     return {
       ok: false,
       error: `Could not verify provenance data: ${error instanceof Error ? error.message : String(error)}`
@@ -416,12 +434,14 @@ export const runDataRootMigration = async (
   // (relocatable) pkgs cache alongside the user data so the envs can be rebuilt offline there. Both
   // are best-effort — a failure just leaves the new root to re-provision defaults, never blocks the
   // user-data copy. pkgs is copied only when at least one env was actually preserved.
+  operation.phase('preserve-runtime')
   let preservedEnvs: string[] = []
+  let runtimePreservationDegraded = false
   if (deps.exportRuntimeLocks) {
     try {
       preservedEnvs = await deps.exportRuntimeLocks(deps.currentDataRoot, target)
-    } catch (err) {
-      console.error('[migration-service] exportRuntimeLocks failed', err)
+    } catch {
+      runtimePreservationDegraded = true
     }
   }
   const migrateDirs =
@@ -429,17 +449,37 @@ export const runDataRootMigration = async (
 
   const doCopyAndVerify = deps.copyAndVerify ?? copyAndVerify
   let result: MigrationResult
+  operation.phase('copy')
+  const progressMilestones = new Set<number>()
+  const reportProgress = (progress: MigrationProgress): void => {
+    runOpts.onProgress(progress)
+    if (!Number.isFinite(progress.copiedBytes) || !Number.isFinite(progress.totalBytes)) return
+    const percent =
+      progress.totalBytes <= 0
+        ? 0
+        : Math.max(0, Math.min(100, Math.floor((progress.copiedBytes / progress.totalBytes) * 100)))
+    for (const milestone of [0, 25, 50, 75, 100]) {
+      if (milestone > percent || progressMilestones.has(milestone)) continue
+      progressMilestones.add(milestone)
+      operation.phase('copy', {
+        progressPhase: progress.phase,
+        progressPercent: milestone,
+        copiedBytes: Math.max(0, progress.copiedBytes),
+        totalBytes: Math.max(0, progress.totalBytes)
+      })
+    }
+  }
   try {
     result = await doCopyAndVerify({
       from: deps.currentDataRoot,
       to: target,
       dirs: migrateDirs,
       signal: runOpts.signal,
-      onProgress: runOpts.onProgress
+      onProgress: reportProgress
     })
   } catch (err) {
-    console.error('[migration-service] copy engine failed unexpectedly', err)
     await rm(target, { recursive: true, force: true }).catch(() => undefined)
+    operation.fail(err)
     return { ok: false, error: 'Could not copy your data. Please try again.' }
   }
 
@@ -447,21 +487,30 @@ export const runDataRootMigration = async (
     // Remove the whole staging dir we created (marker + anything copyAndVerify's rollback missed) so a
     // half-baked, marker-less folder can never later be mistaken for a committed data root. Safe: a
     // 'move' target only ever holds our copy plus at most a rebuildable runtime/, never user data.
-    await rm(target, { recursive: true, force: true }).catch((err) =>
-      console.error('[migration-service] failed to clean up staging dir after failed copy', err)
-    )
+    let stagingCleanupDegraded = false
+    await rm(target, { recursive: true, force: true }).catch(() => {
+      stagingCleanupDegraded = true
+    })
+    if (result.cancelled) {
+      operation.cancel({ cancelRequested: true, stagingCleanupDegraded })
+    } else {
+      operation.fail(new Error(result.error), { stagingCleanupDegraded })
+    }
     return result
   }
 
   if (runOpts.signal.aborted) {
     await rm(target, { recursive: true, force: true }).catch(() => undefined)
+    operation.cancel({ cancelRequested: true })
     return { ok: false, error: 'migration cancelled', cancelled: true }
   }
 
+  operation.phase('verify-target')
   try {
     await validateProvenanceState(target)
   } catch (error) {
     await rm(target, { recursive: true, force: true }).catch(() => undefined)
+    operation.fail(error)
     return {
       ok: false,
       error: `Could not verify provenance data: ${error instanceof Error ? error.message : String(error)}`
@@ -473,12 +522,13 @@ export const runDataRootMigration = async (
   try {
     inventory = await scanInventory(target, migrateDirs)
   } catch (err) {
-    console.error('[migration-service] failed to inventory staged copy', err)
     await rm(target, { recursive: true, force: true }).catch(() => undefined)
+    operation.fail(err)
     return { ok: false, error: 'Could not verify the copied data. Please run the move again.' }
   }
   if (runOpts.signal.aborted) {
     await rm(target, { recursive: true, force: true }).catch(() => undefined)
+    operation.cancel({ cancelRequested: true })
     return { ok: false, error: 'migration cancelled', cancelled: true }
   }
   try {
@@ -490,10 +540,16 @@ export const runDataRootMigration = async (
     })
     runOpts.onVerified?.({ token: marker.token, target })
   } catch (err) {
-    console.error('[migration-service] failed to finalize staged copy', err)
     await rm(target, { recursive: true, force: true }).catch(() => undefined)
+    operation.fail(err)
     return { ok: false, error: 'Could not finalize the copied data. Please run the move again.' }
   }
+  operation.complete({
+    preservedEnvironmentCount: preservedEnvs.length,
+    runtimePreservationDegraded,
+    fileCount: inventory.fileCount,
+    totalBytes: inventory.totalBytes
+  })
   return result
 }
 
@@ -508,27 +564,42 @@ export const commitDataRootSwitch = async (
   deps: MigrationCommitDeps,
   parent: string
 ): Promise<MigrationOutcome> => {
+  const operation = startDiagnosticOperation(deps.logger ?? createLogger('storage:migration'), {
+    operation: 'data-root-commit',
+    fields: { mode: 'move', correlationId: deps.diagnosticCorrelationId }
+  })
+  const failResult = <T extends { ok: false; error: string }>(result: T): T => {
+    operation.fail(new Error(result.error))
+    return result
+  }
   const target = dataRootForPicked(parent)
 
   // Commit gate: only ever promote a fully-staged copy whose marker matches THIS exact source→target
   // pair. This blocks committing a half-copied dir (crash mid-copy), a stale marker from an earlier
   // aborted move, or a copy staged against a different current root — any of which could delete the
   // wrong data on the delete step below.
+  operation.phase('recheck-inventory')
   const marker = await readMigrationMarker(target)
   if (!marker || marker.status !== 'verified') {
-    return { ok: false, error: 'No completed migration copy was found to commit.' }
+    return failResult({ ok: false, error: 'No completed migration copy was found to commit.' })
   }
   if (!samePath(marker.source, deps.currentDataRoot)) {
-    return { ok: false, error: 'The staged copy does not match your current data location.' }
+    return failResult({
+      ok: false,
+      error: 'The staged copy does not match your current data location.'
+    })
   }
   if (!samePath(marker.target, target)) {
-    return { ok: false, error: 'The staged copy is for a different destination.' }
+    return failResult({ ok: false, error: 'The staged copy is for a different destination.' })
   }
   if (!deps.expectedToken || marker.token !== deps.expectedToken) {
-    return { ok: false, error: 'The staged copy is from a different migration attempt.' }
+    return failResult({
+      ok: false,
+      error: 'The staged copy is from a different migration attempt.'
+    })
   }
   if (!marker.inventory) {
-    return { ok: false, error: 'The staged copy has no verified inventory.' }
+    return failResult({ ok: false, error: 'The staged copy has no verified inventory.' })
   }
 
   const migratedDirs = marker.migratedDirs ?? [...MIGRATED_DIRS]
@@ -536,10 +607,10 @@ export const commitDataRootSwitch = async (
     existsSync(join(deps.currentDataRoot, path))
   )
   if (requiredPaths.some((path) => !migratedDirs.includes(path))) {
-    return {
+    return failResult({
       ok: false,
       error: 'The staged copy does not include all required provenance data. Run the move again.'
-    }
+    })
   }
   let inventories: [MigrationInventory, MigrationInventory]
   try {
@@ -548,7 +619,7 @@ export const commitDataRootSwitch = async (
       scanInventory(target, migratedDirs)
     ])
   } catch (err) {
-    console.error('[migration-service] failed to recheck staged copy inventory', err)
+    operation.fail(err)
     return { ok: false, error: 'Could not recheck the copied data. Run the move again.' }
   }
   const [sourceInventory, targetInventory] = inventories
@@ -556,10 +627,14 @@ export const commitDataRootSwitch = async (
     !sameInventory(marker.inventory, sourceInventory) ||
     !sameInventory(marker.inventory, targetInventory)
   ) {
-    return { ok: false, error: 'The staged copy changed after verification. Run the move again.' }
+    return failResult({
+      ok: false,
+      error: 'The staged copy changed after verification. Run the move again.'
+    })
   }
 
   const validateProvenanceState = deps.validateProvenanceState ?? defaultValidateProvenanceState
+  operation.phase('validate-provenance')
   try {
     // Both roots are checked against the same fixed config-root SQLite authority. Run them in
     // sequence so two FULL WAL checkpoints cannot contend with each other and manufacture a busy
@@ -567,18 +642,20 @@ export const commitDataRootSwitch = async (
     await validateProvenanceState(deps.currentDataRoot)
     await validateProvenanceState(target)
   } catch (error) {
+    operation.fail(error)
     return {
       ok: false,
       error: `Could not verify provenance data: ${error instanceof Error ? error.message : String(error)}`
     }
   }
 
+  operation.phase('persist-pointer')
   try {
     await deps.setDataRoot(target)
   } catch (err) {
     // Leave the marker in place: the copy stays a discardable staging dir the user can retry or throw
     // away, exactly as before the failed switch.
-    console.error('[migration-service] failed to persist new dataRoot', err)
+    operation.fail(err, { switchoverFailed: true })
     return {
       ok: false,
       error: `Your data was copied to ${target}, but the app could not finish switching over. Please try again; your current data is untouched.`,
@@ -591,10 +668,12 @@ export const commitDataRootSwitch = async (
   // leave settings pointing at the new root while this process still used the old one (split brain). A
   // leftover marker is benign: discardStagedCopy refuses the live root, and computeDefaultDataRoot only
   // consults it for a legacy fallback the committed settings.dataRoot overrides anyway.
+  operation.phase('cleanup-source')
+  let cleanupDegraded = false
   try {
     await removeMigrationMarker(target)
-  } catch (err) {
-    console.error('[migration-service] failed to remove marker after commit (benign leftover)', err)
+  } catch {
+    cleanupDegraded = true
   }
 
   // Clean up the old runtime too, but ONLY when the new root holds a reconstructable bundle (exported
@@ -607,13 +686,21 @@ export const commitDataRootSwitch = async (
   const dirsToDelete = runtimePreserved ? [...MIGRATED_DIRS, 'runtime'] : migratedDirs
 
   const doDeleteSources = deps.deleteSources ?? deleteSources
-  const deleteResult = await doDeleteSources(deps.currentDataRoot, dirsToDelete)
+  let deleteResult: Awaited<ReturnType<NonNullable<MigrationCommitDeps['deleteSources']>>>
+  try {
+    deleteResult = await doDeleteSources(deps.currentDataRoot, dirsToDelete)
+  } catch (error) {
+    operation.fail(error)
+    throw error
+  }
   if (deleteResult.failed.length > 0) {
-    console.error('[migration-service] some old data-root dirs could not be deleted', {
-      failed: deleteResult.failed
-    })
+    cleanupDegraded = true
   }
 
+  operation.complete({
+    cleanupDegraded,
+    cleanupFailureCount: deleteResult.failed.length
+  })
   return { ok: true }
 }
 

--- a/src/main/storage/path-presence.test.ts
+++ b/src/main/storage/path-presence.test.ts
@@ -49,17 +49,32 @@ describe('isDataRootMissing', () => {
     expect(logger.warn).toHaveBeenCalledTimes(4)
   })
 
+  it('does not let a diagnostic sink failure change an indeterminate result', async () => {
+    const statFn = vi.fn().mockRejectedValue(errno('EIO'))
+
+    await expect(
+      isDataRootMissing('/mnt/data/OpenScience', {
+        statFn,
+        logger: {
+          warn: () => {
+            throw new Error('sink unavailable')
+          }
+        }
+      })
+    ).resolves.toBe(false)
+  })
+
   it('regression: a non-ASCII (CJK) path whose stat throws a non-ENOENT error is not missing', async () => {
     const logger = { warn: vi.fn() }
     const cjkPath = 'F:\\openscience产生数据\\OpenScience'
     const statFn = vi.fn().mockRejectedValue(errno('EINVAL'))
 
     expect(await isDataRootMissing(cjkPath, { statFn, logger })).toBe(false)
-    // The diagnostic logs code points so a non-ASCII path failure is decodable from a packaged log.
-    expect(logger.warn).toHaveBeenCalledWith(
-      expect.any(String),
-      expect.objectContaining({ code: 'EINVAL', pathCodePoints: expect.stringContaining('U+4EA7') })
-    )
+    // Diagnostics retain only a fixed category: code points are reversible and would still disclose
+    // the user's absolute data-root path.
+    expect(logger.warn).toHaveBeenCalledWith(expect.any(String), { errorCategory: 'system' })
+    expect(JSON.stringify(logger.warn.mock.calls)).not.toContain(cjkPath)
+    expect(JSON.stringify(logger.warn.mock.calls)).not.toContain('U+4EA7')
   })
 
   it('reports missing for a CJK path that genuinely does not exist (ENOENT)', async () => {

--- a/src/main/storage/path-presence.ts
+++ b/src/main/storage/path-presence.ts
@@ -1,6 +1,6 @@
 import { stat } from 'node:fs/promises'
 
-import { createLogger } from '../logger'
+import { createLogger, diagnosticErrorFields } from '../logger'
 
 // Errno codes that unambiguously mean "the path is not there": the leaf is gone (ENOENT) or a path
 // segment is a file rather than a directory (ENOTDIR). On Windows a genuinely disconnected drive or
@@ -11,14 +11,6 @@ const MISSING_CODES = new Set(['ENOENT', 'ENOTDIR'])
 // Minimal logger shape so callers can inject one (and tests can assert) without importing electron.
 type PresenceLogger = Pick<ReturnType<typeof createLogger>, 'warn'>
 
-// Renders a string as its Unicode code points (e.g. "F:\\产" -> "U+0046 U+003A U+005C U+4EA7") so a
-// non-ASCII path that trips a stat failure on Windows can be diagnosed from logs without leaking the
-// raw path text into every field. Kept off the hot path — only built when a stat error is logged.
-const toCodePoints = (value: string): string =>
-  Array.from(value)
-    .map((ch) => `U+${(ch.codePointAt(0) ?? 0).toString(16).toUpperCase().padStart(4, '0')}`)
-    .join(' ')
-
 // Decides whether a configured data root should be reported as MISSING (which drives the destructive
 // "Data folder not found -> continue with an empty folder" prompt). This exists because a bare
 // existsSync/statSync-in-try-catch collapses EVERY failure into "false", so a non-ENOENT stat error
@@ -28,7 +20,7 @@ const toCodePoints = (value: string): string =>
 //
 // Contract: return true ONLY when stat proves the path is absent (ENOENT/ENOTDIR). Any other error is
 // indeterminate — we cannot conclude the data is gone, and wrongly offering to start empty risks
-// abandoning the user's real data — so we return false (don't nag) and log the code + code points.
+// abandoning the user's real data — so we return false (don't nag) and log only a fixed category.
 export const isDataRootMissing = async (
   path: string,
   deps: { statFn?: (p: string) => Promise<unknown>; logger?: PresenceLogger } = {}
@@ -42,10 +34,14 @@ export const isDataRootMissing = async (
     const code = (err as NodeJS.ErrnoException).code
     if (code && MISSING_CODES.has(code)) return true
 
-    logger.warn('data root existence check inconclusive; not treating as missing', {
-      code: code ?? 'UNKNOWN',
-      pathCodePoints: toCodePoints(path)
-    })
+    try {
+      logger.warn(
+        'data root existence check inconclusive; not treating as missing',
+        diagnosticErrorFields(err)
+      )
+    } catch {
+      // Diagnostics must not turn an indeterminate path check into a rejected storage request.
+    }
     return false
   }
 }

--- a/src/main/update/create-strategy.test.ts
+++ b/src/main/update/create-strategy.test.ts
@@ -2,8 +2,16 @@ import { beforeEach, describe, expect, it, vi } from 'vitest'
 
 const spawnSync = vi.hoisted(() => vi.fn())
 const quitAndInstall = vi.hoisted(() => vi.fn())
+const loggerMocks = vi.hoisted(() => {
+  const log = { debug: vi.fn(), info: vi.fn(), warn: vi.fn(), error: vi.fn() }
+  return { log, createLogger: vi.fn(() => log) }
+})
 
 vi.mock('node:child_process', () => ({ spawnSync }))
+vi.mock('../logger', async (importOriginal) => ({
+  ...(await importOriginal<typeof import('../logger')>()),
+  createLogger: loggerMocks.createLogger
+}))
 
 // createUpdateStrategy constructs a concrete strategy per platform. Both strategies touch native
 // modules at construction (UpdateService reads app.getVersion(); ElectronUpdaterStrategy subscribes to
@@ -14,7 +22,8 @@ vi.mock('electron', () => ({
     getVersion: () => '0.0.0',
     isPackaged: false
   },
-  BrowserWindow: { getAllWindows: () => [] }
+  BrowserWindow: { getAllWindows: () => [] },
+  shell: { openExternal: vi.fn(async () => {}), openPath: vi.fn(async () => '') }
 }))
 vi.mock('electron-updater', () => ({
   autoUpdater: {
@@ -33,6 +42,8 @@ describe('createUpdateStrategy', () => {
   beforeEach(() => {
     spawnSync.mockReset()
     quitAndInstall.mockReset()
+    loggerMocks.createLogger.mockClear()
+    for (const log of Object.values(loggerMocks.log)) log.mockClear()
     spawnSync.mockReturnValue({
       status: 0,
       stdout: '',
@@ -47,6 +58,24 @@ describe('createUpdateStrategy', () => {
   it('uses ElectronUpdaterStrategy on linux', () => {
     expect(createUpdateStrategy('linux')).toBeInstanceOf(ElectronUpdaterStrategy)
   })
+
+  it.each([
+    ['in-place', 'win32', { isPackaged: true }],
+    ['manifest', 'darwin', { isPackaged: false }]
+  ] as const)(
+    'injects the production update logger into the %s strategy',
+    async (_, platform, opts) => {
+      const strategy = createUpdateStrategy(platform, opts)
+
+      await strategy.apply()
+
+      expect(loggerMocks.createLogger).toHaveBeenCalledWith('update')
+      expect(loggerMocks.log.info).toHaveBeenCalledWith(
+        'operation completed',
+        expect.objectContaining({ operation: 'update-apply', outcome: 'completed' })
+      )
+    }
+  )
 
   it('constructs the in-place strategy with its install gate', async () => {
     const installGate = vi.fn(async () => ({ completed: true, reaped: true }))

--- a/src/main/update/create-strategy.ts
+++ b/src/main/update/create-strategy.ts
@@ -3,6 +3,7 @@ import { dirname, resolve } from 'node:path'
 
 import { app } from 'electron'
 
+import { createLogger } from '../logger'
 import { ElectronUpdaterStrategy } from './electron-updater-strategy'
 import { UpdateService } from './service'
 import type { InstallGate, UpdateStrategy } from './strategy'
@@ -53,8 +54,12 @@ export const createUpdateStrategy = (
   platform: NodeJS.Platform = process.platform,
   opts: CreateStrategyOptions = {}
 ): UpdateStrategy => {
+  const log = createLogger('update')
   const createInPlaceStrategy = (): ElectronUpdaterStrategy =>
-    new ElectronUpdaterStrategy(opts.installGate ? { installGate: opts.installGate } : {})
+    new ElectronUpdaterStrategy({
+      ...(opts.installGate ? { installGate: opts.installGate } : {}),
+      log
+    })
 
   if (platform === 'win32' || platform === 'linux') return createInPlaceStrategy()
 
@@ -63,5 +68,5 @@ export const createUpdateStrategy = (
   if (platform === 'darwin' && macCanAutoUpdate(isPackaged, version)) {
     return createInPlaceStrategy()
   }
-  return new UpdateService()
+  return new UpdateService({ log })
 }

--- a/src/main/update/electron-updater-strategy.test.ts
+++ b/src/main/update/electron-updater-strategy.test.ts
@@ -1,8 +1,15 @@
 import { EventEmitter } from 'node:events'
 
-import { describe, expect, it, vi } from 'vitest'
+import { afterEach, describe, expect, it, vi } from 'vitest'
 
+import type { Logger } from '../logger'
 import { ElectronUpdaterStrategy } from './electron-updater-strategy'
+import {
+  clearApplicationShutdownTrigger,
+  currentApplicationShutdownTrigger
+} from '../application-shutdown-trigger'
+
+afterEach(() => clearApplicationShutdownTrigger())
 
 // The default autoUpdater is never exercised here (every test injects a FakeUpdater); mock the module
 // so importing the strategy doesn't pull a real Electron runtime into the test process. A stub
@@ -67,6 +74,18 @@ const offlineFetch = (): typeof fetch =>
     throw new Error('no network in test')
   }) as unknown as typeof fetch
 
+const createLogSpy = (): Logger => ({
+  debug: vi.fn(),
+  info: vi.fn(),
+  warn: vi.fn(),
+  error: vi.fn()
+})
+
+const diagnosticRecords = (log: Logger): Record<string, unknown>[] =>
+  (['debug', 'info', 'warn', 'error'] as const).flatMap((level) =>
+    vi.mocked(log[level]).mock.calls.map(([, data]) => data as Record<string, unknown>)
+  )
+
 describe('ElectronUpdaterStrategy', () => {
   it('disables auto download/install on construction', () => {
     const updater = new FakeUpdater()
@@ -94,16 +113,48 @@ describe('ElectronUpdaterStrategy', () => {
     )
   })
 
+  it('records a completed in-place check without release notes or feed URLs', async () => {
+    const updater = new FakeUpdater()
+    const log = createLogSpy()
+    const strategy = new ElectronUpdaterStrategy({
+      updater,
+      currentVersion: '0.2.0',
+      broadcast: vi.fn(),
+      fetchImpl: offlineFetch(),
+      manifestUrl: 'https://diagnostic-private.example/version.json?token=secret',
+      log
+    })
+
+    await strategy.check()
+
+    const records = diagnosticRecords(log)
+    expect(records).toEqual(
+      expect.arrayContaining([
+        expect.objectContaining({
+          operation: 'update-check',
+          outcome: 'completed',
+          result: 'available'
+        })
+      ])
+    )
+    const serialized = JSON.stringify(records)
+    expect(serialized).not.toContain('diagnostic-private')
+    expect(serialized).not.toContain('notes')
+  })
+
   it('maps download → progress then ready', async () => {
     const broadcast = vi.fn()
     const updater = new FakeUpdater()
+    const log = createLogSpy()
     const strategy = new ElectronUpdaterStrategy({
       updater,
       currentVersion: '0.2.0',
       broadcast,
-      fetchImpl: offlineFetch()
+      fetchImpl: offlineFetch(),
+      log
     })
     await strategy.check()
+    vi.mocked(log.info).mockClear()
     const status = await strategy.download()
     expect(broadcast).toHaveBeenCalledWith('update:progress', {
       phase: 'downloading',
@@ -114,6 +165,50 @@ describe('ElectronUpdaterStrategy', () => {
       attempt: 0
     })
     expect(status.state).toBe('ready')
+    expect(diagnosticRecords(log)).toEqual(
+      expect.arrayContaining([
+        expect.objectContaining({
+          operation: 'update-download',
+          outcome: 'completed',
+          result: 'ready'
+        })
+      ])
+    )
+  })
+
+  it('records a failed in-place download without the provider error message', async () => {
+    const updater = new FakeUpdater()
+    updater.runDownload = async () => {
+      throw new Error('private updater diagnostic detail')
+    }
+    const log = createLogSpy()
+    const strategy = new ElectronUpdaterStrategy({
+      updater,
+      currentVersion: '0.2.0',
+      broadcast: vi.fn(),
+      fetchImpl: offlineFetch(),
+      log
+    })
+    await strategy.check()
+    for (const level of ['debug', 'info', 'warn', 'error'] as const) {
+      vi.mocked(log[level]).mockClear()
+    }
+
+    const status = await strategy.download()
+
+    expect(status.error).toBe('private updater diagnostic detail')
+    const records = diagnosticRecords(log)
+    expect(records).toEqual(
+      expect.arrayContaining([
+        expect.objectContaining({
+          operation: 'update-download',
+          outcome: 'failed',
+          phase: 'transfer',
+          errorCategory: 'error'
+        })
+      ])
+    )
+    expect(JSON.stringify(records)).not.toContain('private updater diagnostic detail')
   })
 
   it('cancel aborts an in-flight download and resets the status to available', async () => {
@@ -126,13 +221,18 @@ describe('ElectronUpdaterStrategy', () => {
       await new Promise<void>((resolve) => (release = resolve))
       if (token?.cancelled) throw new Error('cancelled')
     }
+    const log = createLogSpy()
     const strategy = new ElectronUpdaterStrategy({
       updater,
       currentVersion: '0.2.0',
       broadcast: vi.fn(),
-      fetchImpl: offlineFetch()
+      fetchImpl: offlineFetch(),
+      log
     })
     await strategy.check()
+    for (const level of ['debug', 'info', 'warn', 'error'] as const) {
+      vi.mocked(log[level]).mockClear()
+    }
 
     const downloading = strategy.download()
     const cancelled = await strategy.cancel()
@@ -144,6 +244,15 @@ describe('ElectronUpdaterStrategy', () => {
     const final = await downloading
     expect(final.state).toBe('available')
     expect(final.error).toBeUndefined()
+    expect(diagnosticRecords(log)).toEqual(
+      expect.arrayContaining([
+        expect.objectContaining({
+          operation: 'update-download',
+          outcome: 'cancelled',
+          reason: 'user'
+        })
+      ])
+    )
   })
 
   it('cancel is a no-op when nothing is downloading', async () => {
@@ -243,28 +352,72 @@ describe('ElectronUpdaterStrategy', () => {
   it('surfaces errors as status error', async () => {
     const updater = new FakeUpdater()
     updater.checkForUpdates = vi.fn(async () => {
-      updater.emit('error', new Error('boom'))
+      updater.emit('error', new Error('raw provider diagnostic detail'))
     })
+    const log = createLogSpy()
     const strategy = new ElectronUpdaterStrategy({
       updater,
       currentVersion: '0.2.0',
-      broadcast: vi.fn()
+      broadcast: vi.fn(),
+      log
     })
     const status = await strategy.check()
     expect(status.state).toBe('error')
-    expect(status.error).toBe('boom')
+    expect(status.error).toBe('raw provider diagnostic detail')
+    const records = diagnosticRecords(log)
+    expect(records).toEqual(
+      expect.arrayContaining([
+        expect.objectContaining({
+          operation: 'update-check',
+          outcome: 'failed',
+          phase: 'query-provider',
+          errorCategory: 'error'
+        })
+      ])
+    )
+    expect(JSON.stringify(records)).not.toContain('raw provider diagnostic detail')
   })
 
   it('apply shows installer progress and relaunches (quitAndInstall(false, true))', async () => {
     const updater = new FakeUpdater()
+    const log = createLogSpy()
+    const strategy = new ElectronUpdaterStrategy({
+      updater,
+      currentVersion: '0.2.0',
+      broadcast: vi.fn(),
+      log
+    })
+    await strategy.apply()
+    expect(updater.quitAndInstall).toHaveBeenCalledTimes(1)
+    expect(updater.quitAndInstall).toHaveBeenCalledWith(false, true)
+    expect(currentApplicationShutdownTrigger()).toBe('update')
+    expect(diagnosticRecords(log)).toEqual(
+      expect.arrayContaining([
+        expect.objectContaining({
+          operation: 'update-apply',
+          outcome: 'completed',
+          result: 'restart-triggered'
+        })
+      ])
+    )
+  })
+
+  it('rolls back the update shutdown trigger when quitAndInstall throws', async () => {
+    const updater = new FakeUpdater()
+    updater.quitAndInstall.mockImplementation(() => {
+      throw new Error('installer unavailable')
+    })
     const strategy = new ElectronUpdaterStrategy({
       updater,
       currentVersion: '0.2.0',
       broadcast: vi.fn()
     })
-    await strategy.apply()
+
+    const status = await strategy.apply()
     expect(updater.quitAndInstall).toHaveBeenCalledTimes(1)
     expect(updater.quitAndInstall).toHaveBeenCalledWith(false, true)
+    expect(status.state).toBe('error')
+    expect(currentApplicationShutdownTrigger()).toBe('quit')
   })
 
   it('apply runs the install gate before quitAndInstall when the teardown is clean', async () => {
@@ -325,17 +478,60 @@ describe('ElectronUpdaterStrategy', () => {
   it('apply refuses to install and reports an error when the teardown times out', async () => {
     const updater = new FakeUpdater()
     const gate = vi.fn(async () => ({ completed: false, reaped: false }))
+    const log = createLogSpy()
     const strategy = new ElectronUpdaterStrategy({
       updater,
       currentVersion: '0.2.0',
       broadcast: vi.fn(),
-      installGate: gate
+      installGate: gate,
+      log
     })
 
     const status = await strategy.apply()
 
     expect(updater.quitAndInstall).not.toHaveBeenCalled()
     expect(status.state).toBe('error')
+    expect(diagnosticRecords(log)).toEqual(
+      expect.arrayContaining([
+        expect.objectContaining({
+          operation: 'update-apply',
+          outcome: 'failed',
+          phase: 'install-gate',
+          reason: 'install-gate-refused',
+          gateCompleted: false,
+          processTreesReaped: false
+        })
+      ])
+    )
+  })
+
+  it('records a thrown install-gate failure without its error message', async () => {
+    const updater = new FakeUpdater()
+    const log = createLogSpy()
+    const strategy = new ElectronUpdaterStrategy({
+      updater,
+      currentVersion: '0.2.0',
+      broadcast: vi.fn(),
+      installGate: () => Promise.reject(new Error('private teardown diagnostic detail')),
+      log
+    })
+
+    const status = await strategy.apply()
+
+    expect(status.state).toBe('error')
+
+    const records = diagnosticRecords(log)
+    expect(records).toEqual(
+      expect.arrayContaining([
+        expect.objectContaining({
+          operation: 'update-apply',
+          outcome: 'failed',
+          phase: 'install-gate',
+          errorCategory: 'error'
+        })
+      ])
+    )
+    expect(JSON.stringify(records)).not.toContain('private teardown diagnostic detail')
   })
 
   it('ignores stale updater errors during preparation', async () => {

--- a/src/main/update/electron-updater-strategy.test.ts
+++ b/src/main/update/electron-updater-strategy.test.ts
@@ -396,7 +396,7 @@ describe('ElectronUpdaterStrategy', () => {
         expect.objectContaining({
           operation: 'update-apply',
           outcome: 'completed',
-          result: 'restart-triggered'
+          result: 'handoff-requested'
         })
       ])
     )
@@ -559,17 +559,31 @@ describe('ElectronUpdaterStrategy', () => {
 
   it('restores an actionable error after the installer handoff starts', async () => {
     const updater = new FakeUpdater()
+    const log = createLogSpy()
     const strategy = new ElectronUpdaterStrategy({
       updater,
       currentVersion: '0.2.0',
-      broadcast: vi.fn()
+      broadcast: vi.fn(),
+      log
     })
 
     await strategy.apply()
+    expect(currentApplicationShutdownTrigger()).toBe('update')
     updater.emit('error', new Error('installer failed'))
 
     expect(strategy.getStatus().state).toBe('error')
     expect(strategy.getStatus().error).toBe('installer failed')
+    expect(currentApplicationShutdownTrigger()).toBe('quit')
+    expect(diagnosticRecords(log)).toEqual(
+      expect.arrayContaining([
+        expect.objectContaining({
+          operation: 'update-installer',
+          outcome: 'failed',
+          phase: 'handoff',
+          errorCategory: 'error'
+        })
+      ])
+    )
   })
 
   it('restores an actionable error when quitAndInstall throws', async () => {

--- a/src/main/update/electron-updater-strategy.ts
+++ b/src/main/update/electron-updater-strategy.ts
@@ -188,6 +188,7 @@ export class ElectronUpdaterStrategy implements UpdateStrategy {
   private status: UpdateStatus
   private applying = false
   private installerStarted = false
+  private pendingInstallRollback?: () => void
   // In-flight manifest notes fetch for the current update, awaited by check() so the returned
   // status reflects the hydrated notes.
   private notesHydration?: Promise<void>
@@ -284,6 +285,16 @@ export class ElectronUpdaterStrategy implements UpdateStrategy {
     })
     this.updater.on('error', (err) => {
       if (this.applying && !this.installerStarted) return
+      if (this.installerStarted) {
+        this.pendingInstallRollback?.()
+        this.pendingInstallRollback = undefined
+        const operation = startDiagnosticOperation(this.log, {
+          operation: 'update-installer',
+          fields: { strategy: 'in-place' }
+        })
+        operation.phase('handoff')
+        operation.fail(err, { result: 'error' })
+      }
       this.applying = false
       this.installerStarted = false
       this.setStatus({
@@ -494,11 +505,13 @@ export class ElectronUpdaterStrategy implements UpdateStrategy {
 
     operation.phase('install')
     const rollbackTrigger = this.markUpdateShutdown()
+    this.pendingInstallRollback = rollbackTrigger
     this.installerStarted = true
     try {
       this.updater.quitAndInstall(false, true)
     } catch (error) {
       rollbackTrigger()
+      this.pendingInstallRollback = undefined
       this.applying = false
       this.installerStarted = false
       this.setStatus({
@@ -509,7 +522,7 @@ export class ElectronUpdaterStrategy implements UpdateStrategy {
       operation.fail(error, { result: 'error' })
       return this.status
     }
-    operation.complete({ result: 'restart-triggered' })
+    operation.complete({ result: 'handoff-requested' })
     return this.status
   }
 }

--- a/src/main/update/electron-updater-strategy.ts
+++ b/src/main/update/electron-updater-strategy.ts
@@ -4,18 +4,25 @@ import { autoUpdater, CancellationToken } from 'electron-updater'
 
 import { APP } from '../../shared/app-config'
 import type { UpdateStatus } from '../../shared/update'
+import { startDiagnosticOperation, type DiagnosticOperation } from '../diagnostics/operation'
+import type { Logger } from '../logger'
 import { fetchManifest } from './manifest'
 import type { InstallGate, UpdateStrategy } from './strategy'
 import type { ApplicationEventMap } from '../application-events'
 import { broadcastToRenderers } from '../renderer-broadcast'
+import { markApplicationShutdownTrigger } from '../application-shutdown-trigger'
 
 type UpdateBroadcast = <Channel extends 'update:status' | 'update:progress'>(
   channel: Channel,
   payload: ApplicationEventMap[Channel]
 ) => void
 
-// Minimal logger surface so tests inject a spy without pulling electron-log.
-type UpdaterLogger = { info: (msg: string) => void; error: (msg: string, err?: unknown) => void }
+const NOOP_LOGGER: Logger = {
+  debug: () => {},
+  info: () => {},
+  warn: () => {},
+  error: () => {}
+}
 
 // The slice of electron-updater's CancellationToken we drive: pass it to downloadUpdate() so the
 // in-flight HTTP download can be aborted, and read `cancelled` to distinguish a user cancel from a
@@ -51,8 +58,10 @@ export type ElectronUpdaterDeps = {
   manifestUrl?: string
   // Pre-install backend-shutdown gate, fixed when the strategy is constructed.
   installGate?: InstallGate
-  // Diagnostics sink for the apply path; defaults to a no-op so unit tests stay quiet.
-  log?: UpdaterLogger
+  // Diagnostics sink for update lifecycle operations; defaults to a no-op so unit tests stay quiet.
+  log?: Logger
+  // Marks the app lifecycle handoff immediately before quitAndInstall. Injectable for tests.
+  markUpdateShutdown?: () => () => void
   // True when an x64 process is running under Rosetta 2 on Apple Silicon; false when definitively not;
   // undefined when the probe could not determine it. Electron-updater detects this via
   // sysctl.proc_translated and selects the arm64 artifact, so we must match that to show the correct
@@ -164,7 +173,7 @@ export class ElectronUpdaterStrategy implements UpdateStrategy {
   private readonly broadcast: UpdateBroadcast
   private readonly fetchImpl?: typeof fetch
   private readonly manifestUrl: string
-  private readonly log: UpdaterLogger
+  private readonly log: Logger
   private readonly createCancellationToken: () => MinimalCancellationToken
   // The token for the current download, held so cancel() can abort it. Cleared once download() settles.
   private downloadToken?: MinimalCancellationToken
@@ -175,6 +184,7 @@ export class ElectronUpdaterStrategy implements UpdateStrategy {
   // Monotonic id per started download; the finally only clears downloadLifecycle when it is still the
   // latest, so an older (drained) download can't clear a newer one's lifecycle.
   private downloadGeneration = 0
+  private downloadOperation?: DiagnosticOperation
   private status: UpdateStatus
   private applying = false
   private installerStarted = false
@@ -183,6 +193,7 @@ export class ElectronUpdaterStrategy implements UpdateStrategy {
   private notesHydration?: Promise<void>
   // Pre-install backend-shutdown gate, owned immutably for the strategy lifetime.
   private readonly installGate?: InstallGate
+  private readonly markUpdateShutdown: () => () => void
 
   constructor(deps: ElectronUpdaterDeps = {}) {
     this.updater = deps.updater ?? (autoUpdater as unknown as MinimalAutoUpdater)
@@ -206,9 +217,11 @@ export class ElectronUpdaterStrategy implements UpdateStrategy {
     this.broadcast = deps.broadcast ?? defaultBroadcast
     this.fetchImpl = deps.fetchImpl
     this.manifestUrl = deps.manifestUrl ?? APP.update.manifestUrl
-    this.log = deps.log ?? { info: () => {}, error: () => {} }
+    this.log = deps.log ?? NOOP_LOGGER
     this.createCancellationToken = deps.createCancellationToken ?? (() => new CancellationToken())
     this.installGate = deps.installGate
+    this.markUpdateShutdown =
+      deps.markUpdateShutdown ?? (() => markApplicationShutdownTrigger('update'))
     this.status = { state: 'idle', current: this.currentVersion, applyKind: 'restart' }
 
     this.updater.autoDownload = false
@@ -314,6 +327,11 @@ export class ElectronUpdaterStrategy implements UpdateStrategy {
 
   async check(): Promise<UpdateStatus> {
     if (this.applying) return this.status
+    const operation = startDiagnosticOperation(this.log, {
+      operation: 'update-check',
+      fields: { strategy: 'in-place' }
+    })
+    operation.phase('query-provider')
     try {
       await this.updater.checkForUpdates()
     } catch (error) {
@@ -321,9 +339,15 @@ export class ElectronUpdaterStrategy implements UpdateStrategy {
         state: 'error',
         error: error instanceof Error ? error.message : 'Update check failed'
       })
+      operation.fail(error, { result: 'error' })
     }
     // Wait for the notes fetch triggered by update-available so the returned status carries them.
     await this.notesHydration
+    if (this.status.state === 'error') {
+      operation.fail(new Error('Updater check failed'), { result: 'error' })
+    } else {
+      operation.complete({ result: this.status.state })
+    }
     return this.status
   }
 
@@ -332,6 +356,12 @@ export class ElectronUpdaterStrategy implements UpdateStrategy {
     // would overwrite downloadToken and orphan the first (cancel() could no longer stop it). This guard
     // and the token claim below are synchronous so a racing download()/cancel() sees a consistent slot.
     if (this.applying || this.downloadToken) return this.status
+
+    const operation = startDiagnosticOperation(this.log, {
+      operation: 'update-download',
+      fields: { strategy: 'in-place' }
+    })
+    this.downloadOperation = operation
 
     // A just-cancelled download may still be settling: cancel() returns before electron-updater's
     // underlying downloadPromise rejects. downloadUpdate() reuses that live promise and ignores a fresh
@@ -348,10 +378,19 @@ export class ElectronUpdaterStrategy implements UpdateStrategy {
       try {
         // Let the prior cancelled download's promise clear (and its cleanup finish) before starting.
         // Swallow its outcome — it is owned by its own lifecycle.
-        if (previous) await previous.catch(() => {})
+        if (previous) {
+          operation.phase('wait-for-previous')
+          await previous.catch(() => {})
+        }
         // A cancel() during the drain means never start this download.
         if (token.cancelled) return
+        operation.phase('transfer')
         await this.updater.downloadUpdate(token)
+        if (this.status.state === 'error') {
+          operation.fail(new Error('Updater download failed'), { result: 'error' })
+        } else {
+          operation.complete({ result: this.status.state })
+        }
       } catch (error) {
         // A user cancel rejects downloadUpdate too; don't surface it as an error. cancel() has already
         // reset the status to 'available', so leave it untouched here. Caught so the lifecycle never
@@ -361,9 +400,11 @@ export class ElectronUpdaterStrategy implements UpdateStrategy {
             state: 'error',
             error: error instanceof Error ? error.message : 'Download failed'
           })
+          operation.fail(error, { result: 'error' })
         }
       } finally {
         if (this.downloadToken === token) this.downloadToken = undefined
+        if (this.downloadOperation === operation) this.downloadOperation = undefined
       }
     })()
     this.downloadLifecycle = lifecycle
@@ -386,6 +427,7 @@ export class ElectronUpdaterStrategy implements UpdateStrategy {
     if (this.status.state === 'downloading') {
       this.setStatus({ ...this.status, state: 'available', progress: undefined })
     }
+    this.downloadOperation?.cancel({ reason: 'user' })
     return this.status
   }
 
@@ -401,6 +443,11 @@ export class ElectronUpdaterStrategy implements UpdateStrategy {
     this.installerStarted = false
     this.setStatus({ ...this.status, state: 'applying' })
 
+    const operation = startDiagnosticOperation(this.log, {
+      operation: 'update-apply',
+      fields: { strategy: 'in-place' }
+    })
+
     // Stop the agent + notebook process trees BEFORE handing off to the installer. Its uninstall step
     // deletes the running app's files, and on Windows an executable/DLL still mapped by a background
     // child (agent CLI, python kernel, conda) is locked — the classic "Failed to uninstall old
@@ -408,6 +455,7 @@ export class ElectronUpdaterStrategy implements UpdateStrategy {
     // may have left grandchildren), refuse the install rather than fail mid-uninstall: the gate is
     // non-latching, so the app stays usable and the user can retry (fewer live processes next time).
     if (this.installGate) {
+      operation.phase('install-gate')
       let readiness: Awaited<ReturnType<InstallGate>>
       try {
         readiness = await this.installGate()
@@ -419,9 +467,13 @@ export class ElectronUpdaterStrategy implements UpdateStrategy {
           state: 'error',
           error: 'Could not stop background processes before updating. Please try again.'
         })
+        operation.fail(error, { result: 'error' })
         return this.status
       }
-      if (!this.applying) return this.status
+      if (!this.applying) {
+        operation.cancel({ reason: 'apply-interrupted' })
+        return this.status
+      }
       if (!readiness.completed || !readiness.reaped) {
         this.log.error('update install gate refused: backend teardown degraded', readiness)
         this.applying = false
@@ -430,15 +482,23 @@ export class ElectronUpdaterStrategy implements UpdateStrategy {
           state: 'error',
           error: 'Could not fully stop background processes before updating. Please try again.'
         })
+        operation.fail(new Error('Install gate refused'), {
+          reason: 'install-gate-refused',
+          gateCompleted: readiness.completed,
+          processTreesReaped: readiness.reaped
+        })
         return this.status
       }
       this.log.info('update install gate cleared; proceeding to quitAndInstall')
     }
 
+    operation.phase('install')
+    const rollbackTrigger = this.markUpdateShutdown()
     this.installerStarted = true
     try {
       this.updater.quitAndInstall(false, true)
     } catch (error) {
+      rollbackTrigger()
       this.applying = false
       this.installerStarted = false
       this.setStatus({
@@ -446,7 +506,10 @@ export class ElectronUpdaterStrategy implements UpdateStrategy {
         state: 'error',
         error: error instanceof Error ? error.message : 'Could not start the update installer.'
       })
+      operation.fail(error, { result: 'error' })
+      return this.status
     }
+    operation.complete({ result: 'restart-triggered' })
     return this.status
   }
 }

--- a/src/main/update/service.test.ts
+++ b/src/main/update/service.test.ts
@@ -7,6 +7,7 @@ import { join } from 'node:path'
 import { afterEach, describe, expect, it, vi } from 'vitest'
 
 import type { UpdateManifest } from '../../shared/update'
+import type { Logger } from '../logger'
 import { UpdateService } from './service'
 
 const manifest: UpdateManifest = {
@@ -19,7 +20,47 @@ const manifest: UpdateManifest = {
 const jsonResponse = (body: unknown): Response =>
   ({ ok: true, status: 200, json: () => Promise.resolve(body) }) as unknown as Response
 
+const createLogSpy = (): Logger => ({
+  debug: vi.fn(),
+  info: vi.fn(),
+  warn: vi.fn(),
+  error: vi.fn()
+})
+
+const diagnosticRecords = (log: Logger): Record<string, unknown>[] =>
+  (['debug', 'info', 'warn', 'error'] as const).flatMap((level) =>
+    vi.mocked(log[level]).mock.calls.map(([, data]) => data as Record<string, unknown>)
+  )
+
 describe('UpdateService.check', () => {
+  it('records a completed manifest check without manifest payloads', async () => {
+    const log = createLogSpy()
+    const service = new UpdateService({
+      fetchImpl: (() => Promise.resolve(jsonResponse(manifest))) as unknown as typeof fetch,
+      platform: 'darwin',
+      arch: 'arm64',
+      currentVersion: '0.2.0',
+      manifestUrl: 'https://diagnostic-secret.example/version.json?token=secret',
+      broadcast: vi.fn(),
+      log
+    })
+
+    await service.check()
+
+    const records = diagnosticRecords(log)
+    expect(records).toEqual(
+      expect.arrayContaining([
+        expect.objectContaining({
+          operation: 'update-check',
+          outcome: 'completed',
+          result: 'available'
+        })
+      ])
+    )
+    expect(JSON.stringify(records)).not.toContain('diagnostic-secret')
+    expect(JSON.stringify(records)).not.toContain('release notes')
+  })
+
   it('reports available with the platform download when newer', async () => {
     const broadcast = vi.fn()
     const service = new UpdateService({
@@ -65,6 +106,33 @@ describe('UpdateService.check', () => {
     const status = await service.check()
     expect(status.state).toBe('error')
     expect(status.error).toBe('offline')
+  })
+
+  it('records a failed manifest check without the provider error message', async () => {
+    const log = createLogSpy()
+    const service = new UpdateService({
+      fetchImpl: (() =>
+        Promise.reject(new Error('raw provider diagnostic secret'))) as unknown as typeof fetch,
+      currentVersion: '0.2.0',
+      broadcast: vi.fn(),
+      log
+    })
+
+    const status = await service.check()
+
+    expect(status.error).toBe('raw provider diagnostic secret')
+    const records = diagnosticRecords(log)
+    expect(records).toEqual(
+      expect.arrayContaining([
+        expect.objectContaining({
+          operation: 'update-check',
+          outcome: 'failed',
+          phase: 'fetch-manifest',
+          errorCategory: 'error'
+        })
+      ])
+    )
+    expect(JSON.stringify(records)).not.toContain('raw provider diagnostic secret')
   })
 
   it('stamps applyKind "installer" on every emitted status', async () => {
@@ -138,6 +206,49 @@ describe('UpdateService.download', () => {
     expect(status.state).toBe('ready')
     expect(status.localPath).toBe(target)
     expect(existsSync(target)).toBe(true)
+  })
+
+  it('records a completed installer download without its URL or local path', async () => {
+    dir = await mkdtemp(join(tmpdir(), 'diagnostic-private-'))
+    const target = join(dir, 'private-installer.dmg')
+    const body = Buffer.from('installer-bytes')
+    const manifestForCheck = downloadManifest(
+      body.byteLength,
+      createHash('sha256').update(body).digest('hex')
+    )
+    const fetchImpl = ((input: unknown) =>
+      String(input).endsWith('version.json')
+        ? Promise.resolve(jsonResponse(manifestForCheck))
+        : Promise.resolve(new Response(body, { status: 200 }))) as unknown as typeof fetch
+    const log = createLogSpy()
+    const service = new UpdateService({
+      fetchImpl,
+      platform: 'darwin',
+      arch: 'arm64',
+      currentVersion: '0.2.0',
+      manifestUrl: 'https://statics.aipoch.com/version.json',
+      broadcast: vi.fn(),
+      promptSavePath: () => Promise.resolve(target),
+      log
+    })
+    await service.check()
+    vi.mocked(log.info).mockClear()
+
+    await service.download()
+
+    const records = diagnosticRecords(log)
+    expect(records).toEqual(
+      expect.arrayContaining([
+        expect.objectContaining({
+          operation: 'update-download',
+          outcome: 'completed',
+          result: 'ready'
+        })
+      ])
+    )
+    const serialized = JSON.stringify(records)
+    expect(serialized).not.toContain('private-installer.dmg')
+    expect(serialized).not.toContain('statics.aipoch.com')
   })
 
   it('drops a prior-session <target>.part on the first download so a restart starts fresh', async () => {
@@ -379,6 +490,75 @@ describe('UpdateService.download', () => {
     expect(fetchMock).not.toHaveBeenCalled()
   })
 
+  it('records a failed installer download without the shell error message', async () => {
+    const manifestForCheck = downloadManifest(100, 'irrelevant')
+    const fetchImpl = (() =>
+      Promise.resolve(jsonResponse(manifestForCheck))) as unknown as typeof fetch
+    const log = createLogSpy()
+    const service = new UpdateService({
+      fetchImpl,
+      platform: 'darwin',
+      arch: 'arm64',
+      currentVersion: '0.2.0',
+      manifestUrl: 'https://statics.aipoch.com/version.json',
+      broadcast: vi.fn(),
+      promptSavePath: () => Promise.reject(new Error('private shell diagnostic detail')),
+      log
+    })
+    await service.check()
+    vi.mocked(log.info).mockClear()
+
+    const status = await service.download()
+
+    expect(status.error).toBe('private shell diagnostic detail')
+    const records = diagnosticRecords(log)
+    expect(records).toEqual(
+      expect.arrayContaining([
+        expect.objectContaining({
+          operation: 'update-download',
+          outcome: 'failed',
+          phase: 'select-target',
+          errorCategory: 'error'
+        })
+      ])
+    )
+    expect(JSON.stringify(records)).not.toContain('private shell diagnostic detail')
+  })
+
+  it('records manifest URL validation failure without the invalid URL', async () => {
+    const manifestForCheck = downloadManifest(100, 'irrelevant')
+    const log = createLogSpy()
+    const service = new UpdateService({
+      fetchImpl: (() => Promise.resolve(jsonResponse(manifestForCheck))) as unknown as typeof fetch,
+      platform: 'darwin',
+      arch: 'arm64',
+      currentVersion: '0.2.0',
+      manifestUrl: 'not-a-url-private-diagnostic-detail',
+      broadcast: vi.fn(),
+      promptSavePath: () => Promise.resolve('/unused'),
+      log
+    })
+    await service.check()
+    for (const level of ['debug', 'info', 'warn', 'error'] as const) {
+      vi.mocked(log[level]).mockClear()
+    }
+
+    await expect(service.download()).rejects.toThrow()
+
+    const records = diagnosticRecords(log)
+    expect(records).toEqual(
+      expect.arrayContaining([
+        expect.objectContaining({
+          operation: 'update-download',
+          outcome: 'failed',
+          phase: 'validate-source',
+          errorCategory: 'system'
+        })
+      ])
+    )
+    expect(JSON.stringify(records)).not.toContain('not-a-url-private-diagnostic-detail')
+  })
+
   it('cancel aborts an in-flight download, resets to available, and leaves no partial file', async () => {
     dir = await mkdtemp(join(tmpdir(), 'svc-'))
     const target = join(dir, 'installer.dmg')
@@ -401,6 +581,7 @@ describe('UpdateService.download', () => {
       onInstallerFetch?.()
       return Promise.resolve(new Response(body, { status: 200 }))
     }) as unknown as typeof fetch
+    const log = createLogSpy()
     const service = new UpdateService({
       fetchImpl,
       platform: 'darwin',
@@ -408,10 +589,12 @@ describe('UpdateService.download', () => {
       currentVersion: '0.2.0',
       manifestUrl: 'https://statics.aipoch.com/version.json',
       broadcast: vi.fn(),
-      promptSavePath: () => Promise.resolve(target)
+      promptSavePath: () => Promise.resolve(target),
+      log
     })
 
     await service.check()
+    vi.mocked(log.info).mockClear()
     const downloading = service.download()
     await fetched
     const cancelled = await service.cancel()
@@ -421,6 +604,15 @@ describe('UpdateService.download', () => {
     expect(final.state).toBe('available')
     expect(final.error).toBeUndefined()
     expect(existsSync(target)).toBe(false)
+    expect(diagnosticRecords(log)).toEqual(
+      expect.arrayContaining([
+        expect.objectContaining({
+          operation: 'update-download',
+          outcome: 'cancelled',
+          reason: 'user'
+        })
+      ])
+    )
   })
 
   it('ignores a second download() while one is already in flight', async () => {
@@ -674,7 +866,11 @@ describe('UpdateService.apply', () => {
   // Drives a service to the 'ready' state (checked + downloaded to `target`), with injected shell hooks.
   const downloadedService = async (
     target: string,
-    overrides: { openPath?: () => Promise<string>; fileExists?: (path: string) => boolean }
+    overrides: {
+      openPath?: () => Promise<string>
+      fileExists?: (path: string) => boolean
+      log?: Logger
+    }
   ): Promise<UpdateService> => {
     const body = Buffer.from('installer-bytes')
     const manifestForCheck: UpdateManifest = {
@@ -720,16 +916,57 @@ describe('UpdateService.apply', () => {
     expect(status.state).toBe('ready')
   })
 
+  it('records a completed installer apply without its local path', async () => {
+    dir = await mkdtemp(join(tmpdir(), 'private-apply-'))
+    const target = join(dir, 'private-installer.dmg')
+    const log = createLogSpy()
+    const service = await downloadedService(target, {
+      openPath: () => Promise.resolve(''),
+      log
+    })
+    for (const level of ['debug', 'info', 'warn', 'error'] as const) {
+      vi.mocked(log[level]).mockClear()
+    }
+
+    await service.apply()
+
+    const records = diagnosticRecords(log)
+    expect(records).toEqual(
+      expect.arrayContaining([
+        expect.objectContaining({
+          operation: 'update-apply',
+          outcome: 'completed',
+          result: 'installer-opened'
+        })
+      ])
+    )
+    expect(JSON.stringify(records)).not.toContain('private-installer.dmg')
+  })
+
   it('returns to available when the downloaded file is missing (e.g. the user deleted it)', async () => {
     dir = await mkdtemp(join(tmpdir(), 'open-'))
     const target = join(dir, 'installer.dmg')
     const openPath = vi.fn(() => Promise.resolve(''))
-    const service = await downloadedService(target, { openPath, fileExists: () => false })
+    const log = createLogSpy()
+    const service = await downloadedService(target, { openPath, fileExists: () => false, log })
+    for (const level of ['debug', 'info', 'warn', 'error'] as const) {
+      vi.mocked(log[level]).mockClear()
+    }
 
     const status = await service.apply()
 
     expect(openPath).not.toHaveBeenCalled()
     expect(status.state).toBe('available')
     expect(status.localPath).toBeUndefined()
+    expect(diagnosticRecords(log)).toEqual(
+      expect.arrayContaining([
+        expect.objectContaining({
+          operation: 'update-apply',
+          outcome: 'failed',
+          phase: 'verify-installer',
+          reason: 'installer-missing'
+        })
+      ])
+    )
   })
 })

--- a/src/main/update/service.ts
+++ b/src/main/update/service.ts
@@ -6,6 +6,8 @@ import { app, BrowserWindow, dialog, shell } from 'electron'
 
 import { APP } from '../../shared/app-config'
 import { isNewer, selectDownload, type UpdateStatus } from '../../shared/update'
+import { startDiagnosticOperation, type DiagnosticOperation } from '../diagnostics/operation'
+import type { Logger } from '../logger'
 import { downloadInstaller } from './downloader'
 import { fetchManifest } from './manifest'
 import type { UpdateStrategy } from './strategy'
@@ -35,6 +37,14 @@ export type UpdateServiceDeps = {
   // prior session's <target>.part the FIRST time a target path is downloaded this session, so a restart
   // starts the installer download from scratch rather than resuming last session's fragment via Range.
   removeFile?: (path: string) => Promise<void>
+  log?: Logger
+}
+
+const NOOP_LOGGER: Logger = {
+  debug: () => {},
+  info: () => {},
+  warn: () => {},
+  error: () => {}
 }
 
 // Default broadcast pushes to every live window, mirroring the connector approval-broker pattern.
@@ -64,6 +74,7 @@ export class UpdateService implements UpdateStrategy {
   // Monotonic id per started download; the finally only clears downloadLifecycle when it is still the
   // latest, so an older (drained) download can't clear a newer one's lifecycle.
   private downloadGeneration = 0
+  private downloadOperation?: DiagnosticOperation
   private readonly fetchImpl?: typeof fetch
   private readonly platform: NodeJS.Platform
   private readonly arch: string
@@ -75,6 +86,7 @@ export class UpdateService implements UpdateStrategy {
   private readonly openPath: (path: string) => Promise<string>
   private readonly openExternal: (url: string) => Promise<void>
   private readonly removeFile: (path: string) => Promise<void>
+  private readonly log: Logger
   // Per-session set of target paths that have already been downloaded once this run. The first
   // download to a given path removes any pre-existing <target>.part so a restart starts fresh
   // (design: "app closes → start from scratch"). Within a session the path stays in the set and
@@ -93,6 +105,7 @@ export class UpdateService implements UpdateStrategy {
     this.openPath = deps.openPath ?? ((path) => shell.openPath(path))
     this.openExternal = deps.openExternal ?? ((url) => shell.openExternal(url))
     this.removeFile = deps.removeFile ?? ((path) => rm(path, { force: true }))
+    this.log = deps.log ?? NOOP_LOGGER
     this.status = { state: 'idle', current: this.currentVersion, applyKind: 'installer' }
   }
 
@@ -124,7 +137,12 @@ export class UpdateService implements UpdateStrategy {
   }
 
   async check(): Promise<UpdateStatus> {
+    const operation = startDiagnosticOperation(this.log, {
+      operation: 'update-check',
+      fields: { strategy: 'manifest' }
+    })
     this.setStatus({ state: 'checking', current: this.currentVersion })
+    operation.phase('fetch-manifest')
     try {
       const manifest = await fetchManifest(this.manifestUrl, this.fetchImpl)
       if (!isNewer(manifest.version, this.currentVersion)) {
@@ -133,6 +151,7 @@ export class UpdateService implements UpdateStrategy {
           current: this.currentVersion,
           latest: manifest.version
         })
+        operation.complete({ result: 'up-to-date' })
         return this.status
       }
       const download = selectDownload(manifest, this.platform, this.arch) ?? undefined
@@ -144,12 +163,14 @@ export class UpdateService implements UpdateStrategy {
         download,
         totalBytes: download?.size
       })
+      operation.complete({ result: 'available', artifactAvailable: download !== undefined })
     } catch (error) {
       this.setStatus({
         state: 'error',
         current: this.currentVersion,
         error: error instanceof Error ? error.message : 'Update check failed'
       })
+      operation.fail(error, { result: 'error' })
     }
     return this.status
   }
@@ -163,9 +184,23 @@ export class UpdateService implements UpdateStrategy {
     const { download } = this.status
     if (!download) return this.status
 
+    const operation = startDiagnosticOperation(this.log, {
+      operation: 'update-download',
+      fields: { strategy: 'manifest' }
+    })
+    this.downloadOperation = operation
+    operation.phase('validate-source')
+
     // Defense-in-depth: the sha256 comes from the same manifest as the URL, so it can't catch a
     // tampered manifest pointing at a hostile host. Require the download to stay on the trusted host.
-    const trustedHost = new URL(this.manifestUrl).host
+    let trustedHost: string
+    try {
+      trustedHost = new URL(this.manifestUrl).host
+    } catch (error) {
+      operation.fail(error, { reason: 'invalid-manifest-url' })
+      if (this.downloadOperation === operation) this.downloadOperation = undefined
+      throw error
+    }
     let downloadHost: string
     try {
       downloadHost = new URL(download.url).host
@@ -174,6 +209,8 @@ export class UpdateService implements UpdateStrategy {
     }
     if (downloadHost !== trustedHost) {
       this.setStatus({ ...this.status, state: 'error', error: 'Untrusted download host' })
+      operation.fail(new URIError('Untrusted update source'), { reason: 'untrusted-source' })
+      if (this.downloadOperation === operation) this.downloadOperation = undefined
       return this.status
     }
 
@@ -188,14 +225,22 @@ export class UpdateService implements UpdateStrategy {
       try {
         // Drain any prior (e.g. just-cancelled) download so its partial-file rm can't delete a same-path
         // retry's installer. Swallow its outcome — it is owned by its own lifecycle.
-        if (previous) await previous.catch(() => {})
+        if (previous) {
+          operation.phase('wait-for-previous')
+          await previous.catch(() => {})
+        }
         // A cancel() during the drain means never start this download.
         if (abort.signal.aborted) return
 
         // Ask where to save (platform-aware). A dialog cancel — or a cancel() during the prompt —
         // leaves the status untouched (stays 'available').
+        operation.phase('select-target')
         const targetPath = await this.promptSavePath(installerFileName(download.url))
-        if (!targetPath || abort.signal.aborted) return
+        if (!targetPath) {
+          operation.cancel({ reason: 'target-selection' })
+          return
+        }
+        if (abort.signal.aborted) return
 
         // First time this session that we download to this exact path: drop any <target>.part left by
         // a PRIOR session so the resilient core can't Range-resume a stale fragment (the user may
@@ -206,6 +251,7 @@ export class UpdateService implements UpdateStrategy {
         // cross-restart resume). Subsequent downloads to the same path this session are left alone so
         // an in-session cancel/retry still resumes via Range.
         if (!this.freshTargets.has(targetPath)) {
+          operation.phase('prepare-target')
           await this.removeFile(`${targetPath}.part`)
           this.freshTargets.add(targetPath)
           if (abort.signal.aborted) return
@@ -218,6 +264,7 @@ export class UpdateService implements UpdateStrategy {
           downloadedBytes: 0,
           totalBytes: download.size
         })
+        operation.phase('transfer')
         const localPath = await downloadInstaller(download, targetPath, {
           fetchImpl: this.fetchImpl,
           onProgress: (progress) => this.broadcast('update:progress', progress),
@@ -231,6 +278,7 @@ export class UpdateService implements UpdateStrategy {
           totalBytes: download.size,
           localPath
         })
+        operation.complete({ result: 'ready' })
       } catch (error) {
         // A user cancel aborts the fetch (rejects here); cancel() already reset the status to
         // 'available', so leave it. Any other failure — including a save-dialog rejection — surfaces as
@@ -242,9 +290,11 @@ export class UpdateService implements UpdateStrategy {
             state: 'error',
             error: error instanceof Error ? error.message : 'Download failed'
           })
+          operation.fail(error, { result: 'error' })
         }
       } finally {
         if (this.downloadAbort === abort) this.downloadAbort = undefined
+        if (this.downloadOperation === operation) this.downloadOperation = undefined
       }
     })()
     this.downloadLifecycle = lifecycle
@@ -261,6 +311,7 @@ export class UpdateService implements UpdateStrategy {
   async cancel(): Promise<UpdateStatus> {
     this.downloadAbort?.abort()
     this.downloadAbort = undefined
+    this.downloadOperation?.cancel({ reason: 'user' })
     if (this.status.state === 'downloading') {
       this.setStatus({ ...this.status, state: 'available', progress: undefined })
     }
@@ -271,21 +322,45 @@ export class UpdateService implements UpdateStrategy {
   // drop back to 'available' so the user can re-download in place — the download metadata is still on
   // the status. With no installer for this platform at all, send them to the public download page.
   async apply(): Promise<UpdateStatus> {
-    const { localPath, download } = this.status
-    if (localPath && this.fileExists(localPath)) {
-      const error = await this.openPath(localPath)
-      if (!error) return this.status
+    const operation = startDiagnosticOperation(this.log, {
+      operation: 'update-apply',
+      fields: { strategy: 'manifest' }
+    })
+    try {
+      const { localPath, download } = this.status
+      if (localPath) {
+        operation.phase('verify-installer')
+        if (this.fileExists(localPath)) {
+          operation.phase('open-installer')
+          const error = await this.openPath(localPath)
+          if (!error) {
+            operation.complete({ result: 'installer-opened' })
+            return this.status
+          }
+          operation.fail(new Error('Installer open failed'), { reason: 'open-failed' })
+        } else {
+          operation.fail(new Error('Installer unavailable'), { reason: 'installer-missing' })
+        }
+      } else if (download) {
+        operation.fail(new Error('Installer unavailable'), { reason: 'installer-missing' })
+      }
+
+      if (download) {
+        this.setStatus({
+          ...this.status,
+          state: 'available',
+          localPath: undefined,
+          progress: undefined
+        })
+      } else {
+        operation.phase('open-download-page')
+        await this.openExternal(APP.update.downloadPage)
+        operation.complete({ result: 'download-page-opened' })
+      }
+      return this.status
+    } catch (error) {
+      operation.fail(error, { result: 'error' })
+      throw error
     }
-    if (download) {
-      this.setStatus({
-        ...this.status,
-        state: 'available',
-        localPath: undefined,
-        progress: undefined
-      })
-    } else {
-      await this.openExternal(APP.update.downloadPage)
-    }
-    return this.status
   }
 }

--- a/src/preload/index.d.ts
+++ b/src/preload/index.d.ts
@@ -53,6 +53,7 @@ import type {
 } from '../shared/compute'
 import type { DirListing, DownloadDest, LocalFile } from '../shared/remote-fs'
 import type { LocalDirListing, LocalRoots } from '../shared/local-fs'
+import type { RendererFailureReport } from '../shared/diagnostics'
 import type { OpenLogFileResult, RevealLogFileResult } from '../shared/logs'
 import type {
   OpenSessionFromNotificationRequest,
@@ -295,6 +296,9 @@ interface OpenScienceAPI {
   }
   lifecycle: {
     getClientId(): Promise<string>
+  }
+  diagnostics?: {
+    reportRendererFailure(report: RendererFailureReport): void
   }
   acp: {
     getState(): Promise<AcpStateSnapshot>

--- a/src/preload/index.test.ts
+++ b/src/preload/index.test.ts
@@ -33,6 +33,9 @@ vi.mock('electron', () => ({
 // The subset of the bridge these tests exercise. Args are unknown — forwarding, not shape, is asserted.
 type PreloadApi = {
   saveSessionArtifacts: (request: unknown) => unknown
+  diagnostics: {
+    reportRendererFailure: (report: unknown) => void
+  }
   lifecycle: {
     getClientId: () => unknown
   }
@@ -200,6 +203,7 @@ describe('preload bridge — public surface inventory', () => {
       'compute.revealInFolder',
       'compute.scratchSet',
       'compute.sshConfigAliases',
+      'diagnostics.reportRendererFailure',
       'getRuntimeVersions',
       'github.getStars',
       'handoff.list',
@@ -439,6 +443,21 @@ describe('preload bridge — public surface inventory', () => {
       'window.onWindowFindAppearance',
       'window.sendCloseConfirmResponse'
     ])
+  })
+})
+
+describe('preload bridge — renderer diagnostics', () => {
+  it('sends the bounded renderer failure report over its one-way channel', () => {
+    const report = {
+      source: 'window-error',
+      surface: 'workspace',
+      errorCategory: 'type',
+      fingerprint: 'a1b2c3d4'
+    }
+
+    api.diagnostics.reportRendererFailure(report)
+
+    expect(sendMock).toHaveBeenCalledWith('diagnostics:renderer-failure', report)
   })
 })
 

--- a/src/preload/index.ts
+++ b/src/preload/index.ts
@@ -55,6 +55,7 @@ import type {
 } from '../shared/compute'
 import type { DirListing, DownloadDest, LocalFile } from '../shared/remote-fs'
 import type { LocalDirListing, LocalRoots } from '../shared/local-fs'
+import { RENDERER_FAILURE_CHANNEL, type RendererFailureReport } from '../shared/diagnostics'
 import type { OpenLogFileResult, RevealLogFileResult } from '../shared/logs'
 import type {
   OpenSessionFromNotificationRequest,
@@ -336,6 +337,9 @@ type OpenScienceAPI = {
   }
   lifecycle: {
     getClientId: () => Promise<string>
+  }
+  diagnostics?: {
+    reportRendererFailure: (report: RendererFailureReport) => void
   }
   acp: {
     getState: () => Promise<AcpStateSnapshot>
@@ -857,6 +861,9 @@ const api: OpenScienceAPI = {
   }),
   lifecycle: {
     getClientId: () => ipcRenderer.invoke('lifecycle:client-id') as Promise<string>
+  },
+  diagnostics: {
+    reportRendererFailure: (report) => ipcRenderer.send(RENDERER_FAILURE_CHANNEL, report)
   },
   acp: {
     getState: () => ipcRenderer.invoke('acp:get-state') as Promise<AcpStateSnapshot>,

--- a/src/renderer/src/main.tsx
+++ b/src/renderer/src/main.tsx
@@ -5,6 +5,23 @@ import { createRoot } from 'react-dom/client'
 import App from './App'
 import { installStreamdown } from '@/components/streamdown/install-streamdown'
 import { applyTheme, resolveInitialTheme } from '@/lib/theme'
+import { installRendererFailureDiagnostics } from './renderer-diagnostics'
+import { useNavigationStore } from '@/stores/navigation-store'
+import { useSettingsStore } from '@/stores/settings-store'
+
+// Keep renderer JavaScript failures distinct from native renderer-process exits without relaying raw
+// messages, stacks, URLs, or application state across preload. The bridge is Electron-only; the Web
+// surface intentionally keeps this local diagnostics channel absent.
+installRendererFailureDiagnostics({
+  target: window,
+  getSurface: () => {
+    const settings = useSettingsStore.getState()
+    if (settings.isSettingsOpen) return 'settings'
+    if (settings.isLoaded && settings.onboardingCompletedAt === undefined) return 'onboarding'
+    return useNavigationStore.getState().view
+  },
+  report: (report) => window.api.diagnostics?.reportRendererFailure(report)
+})
 
 // Apply the saved theme to <html> before the first paint so dark mode doesn't flash light on startup.
 applyTheme(resolveInitialTheme())

--- a/src/renderer/src/renderer-diagnostics.test.ts
+++ b/src/renderer/src/renderer-diagnostics.test.ts
@@ -1,0 +1,129 @@
+import { describe, expect, it } from 'vitest'
+
+import { installRendererFailureDiagnostics, projectRendererFailure } from './renderer-diagnostics'
+
+describe('projectRendererFailure', () => {
+  it('projects a renderer error to fixed vocabulary without retaining its message or stack', () => {
+    const failure = new TypeError('private study /Users/example/patient.csv')
+    failure.stack = 'TypeError: private study\n at /Users/example/private.ts:10:2'
+
+    const report = projectRendererFailure('window-error', failure, 'workspace')
+
+    expect(report).toEqual({
+      source: 'window-error',
+      surface: 'workspace',
+      errorCategory: 'type',
+      fingerprint: expect.stringMatching(/^[a-f0-9]{8}$/)
+    })
+    expect(JSON.stringify(report)).not.toContain('private study')
+    expect(JSON.stringify(report)).not.toContain('/Users/example')
+  })
+
+  it('reports top-level errors through the supplied diagnostics sink and can be uninstalled', () => {
+    const listeners = new Map<string, EventListener>()
+    const target = {
+      addEventListener: (type: string, listener: EventListener) => listeners.set(type, listener),
+      removeEventListener: (type: string, listener: EventListener) => {
+        if (listeners.get(type) === listener) listeners.delete(type)
+      }
+    }
+    const reports: unknown[] = []
+    const uninstall = installRendererFailureDiagnostics({
+      target,
+      getSurface: () => 'settings',
+      report: (value) => reports.push(value)
+    })
+
+    const event = Object.assign(new Event('error'), { error: new ReferenceError('secret') })
+    listeners.get('error')?.(event)
+    expect(reports).toEqual([
+      expect.objectContaining({
+        source: 'window-error',
+        surface: 'settings',
+        errorCategory: 'reference'
+      })
+    ])
+
+    uninstall()
+    expect(listeners.size).toBe(0)
+  })
+
+  it('does not throw from a renderer listener when event access, surface detection, or reporting fails', () => {
+    const listeners = new Map<string, EventListener>()
+    const target = {
+      addEventListener: (type: string, listener: EventListener) => listeners.set(type, listener),
+      removeEventListener: () => undefined
+    }
+    const reports: unknown[] = []
+    installRendererFailureDiagnostics({
+      target,
+      getSurface: () => {
+        throw new Error('surface unavailable')
+      },
+      report: (value) => {
+        reports.push(value)
+        throw new Error('bridge unavailable')
+      }
+    })
+    const inaccessibleEvent = new Event('error')
+    Object.defineProperty(inaccessibleEvent, 'error', {
+      get: () => {
+        throw new Error('event unavailable')
+      }
+    })
+
+    expect(() => listeners.get('error')?.(inaccessibleEvent)).not.toThrow()
+    expect(reports).toEqual([
+      expect.objectContaining({
+        source: 'window-error',
+        surface: 'unknown',
+        errorCategory: 'unknown'
+      })
+    ])
+  })
+
+  it('remains safe when event listener registration or removal fails', () => {
+    let registrationCount = 0
+    let uninstall: (() => void) | undefined
+    const target = {
+      addEventListener: () => {
+        registrationCount += 1
+        if (registrationCount === 2) throw new Error('registration unavailable')
+      },
+      removeEventListener: () => {
+        throw new Error('removal unavailable')
+      }
+    }
+
+    expect(() => {
+      uninstall = installRendererFailureDiagnostics({
+        target,
+        getSurface: () => 'home',
+        report: () => undefined
+      })
+    }).not.toThrow()
+    expect(registrationCount).toBe(2)
+    expect(() => uninstall?.()).not.toThrow()
+  })
+
+  it('does not recursively report an error raised by the diagnostics bridge', () => {
+    const listeners = new Map<string, EventListener>()
+    const target = {
+      addEventListener: (type: string, listener: EventListener) => listeners.set(type, listener),
+      removeEventListener: () => undefined
+    }
+    let reportCount = 0
+    installRendererFailureDiagnostics({
+      target,
+      getSurface: () => 'home',
+      report: () => {
+        reportCount += 1
+        listeners.get('error')?.(new Event('error'))
+        throw new Error('bridge unavailable')
+      }
+    })
+
+    expect(() => listeners.get('error')?.(new Event('error'))).not.toThrow()
+    expect(reportCount).toBe(1)
+  })
+})

--- a/src/renderer/src/renderer-diagnostics.ts
+++ b/src/renderer/src/renderer-diagnostics.ts
@@ -1,0 +1,139 @@
+import type {
+  RendererErrorCategory,
+  RendererFailureReport,
+  RendererFailureSource,
+  RendererFailureSurface
+} from '../../shared/diagnostics'
+
+const errorCategoryFor = (value: unknown): RendererErrorCategory => {
+  try {
+    const name = value instanceof Error ? value.name : undefined
+    const byName: Record<string, RendererErrorCategory> = {
+      Error: 'error',
+      TypeError: 'type',
+      ReferenceError: 'reference',
+      RangeError: 'range',
+      SyntaxError: 'syntax'
+    }
+    return name && Object.hasOwn(byName, name) ? byName[name] : 'unknown'
+  } catch {
+    return 'unknown'
+  }
+}
+
+const normalizedStackSignature = (value: unknown): string => {
+  try {
+    if (!(value instanceof Error) || typeof value.stack !== 'string') {
+      return errorCategoryFor(value)
+    }
+    return value.stack
+      .split(/\r?\n/)
+      .slice(1, 5)
+      .join('\n')
+      .replace(/https?:\/\/\S+/gi, '[url]')
+      .replace(/[A-Za-z]:\\[^\s)]+/g, '[path]')
+      .replace(/\/(?:[^\s/]+\/)+[^\s)]+/g, '[path]')
+      .replace(/\d+/g, '#')
+      .slice(0, 512)
+  } catch {
+    return 'unknown'
+  }
+}
+
+const fingerprint = (value: string): string => {
+  let hash = 0x811c9dc5
+  for (let index = 0; index < value.length; index += 1) {
+    hash ^= value.charCodeAt(index)
+    hash = Math.imul(hash, 0x01000193)
+  }
+  return (hash >>> 0).toString(16).padStart(8, '0')
+}
+
+export const projectRendererFailure = (
+  source: RendererFailureSource,
+  value: unknown,
+  surface: RendererFailureSurface
+): RendererFailureReport => ({
+  source,
+  surface,
+  errorCategory: errorCategoryFor(value),
+  fingerprint: fingerprint(normalizedStackSignature(value))
+})
+
+type RendererFailureEventTarget = {
+  addEventListener(type: string, listener: EventListener): void
+  removeEventListener(type: string, listener: EventListener): void
+}
+
+type InstallRendererFailureDiagnosticsOptions = {
+  target: RendererFailureEventTarget
+  getSurface: () => RendererFailureSurface
+  report: (report: RendererFailureReport) => void
+}
+
+export const installRendererFailureDiagnostics = (
+  options: InstallRendererFailureDiagnosticsOptions
+): (() => void) => {
+  let reporting = false
+  const reportFailure = (source: RendererFailureSource, readValue: () => unknown): void => {
+    if (reporting) return
+    let value: unknown
+    let surface: RendererFailureSurface = 'unknown'
+    try {
+      value = readValue()
+    } catch {
+      value = undefined
+    }
+    try {
+      surface = options.getSurface()
+    } catch {
+      surface = 'unknown'
+    }
+    reporting = true
+    try {
+      options.report(projectRendererFailure(source, value, surface))
+    } catch {
+      // Never let a failing diagnostics bridge create another top-level renderer error.
+    } finally {
+      reporting = false
+    }
+  }
+  const onError: EventListener = (event) => {
+    reportFailure('window-error', () => (event as ErrorEvent).error)
+  }
+  const onUnhandledRejection: EventListener = (event) => {
+    reportFailure('unhandled-rejection', () => (event as PromiseRejectionEvent).reason)
+  }
+
+  let errorListenerInstalled = false
+  let rejectionListenerInstalled = false
+  try {
+    options.target.addEventListener('error', onError)
+    errorListenerInstalled = true
+  } catch {
+    // Diagnostics are optional and must not block renderer startup.
+  }
+  try {
+    options.target.addEventListener('unhandledrejection', onUnhandledRejection)
+    rejectionListenerInstalled = true
+  } catch {
+    // Diagnostics are optional and must not block renderer startup.
+  }
+
+  return () => {
+    if (errorListenerInstalled) {
+      try {
+        options.target.removeEventListener('error', onError)
+      } catch {
+        // Removal remains best effort during renderer teardown.
+      }
+    }
+    if (rejectionListenerInstalled) {
+      try {
+        options.target.removeEventListener('unhandledrejection', onUnhandledRejection)
+      } catch {
+        // Removal remains best effort during renderer teardown.
+      }
+    }
+  }
+}

--- a/src/renderer/src/renderer-diagnostics.ts
+++ b/src/renderer/src/renderer-diagnostics.ts
@@ -78,7 +78,7 @@ export const installRendererFailureDiagnostics = (
   const reportFailure = (source: RendererFailureSource, readValue: () => unknown): void => {
     if (reporting) return
     let value: unknown
-    let surface: RendererFailureSurface = 'unknown'
+    let surface: RendererFailureSurface
     try {
       value = readValue()
     } catch {

--- a/src/shared/diagnostics.ts
+++ b/src/shared/diagnostics.ts
@@ -1,0 +1,54 @@
+export const RENDERER_FAILURE_CHANNEL = 'diagnostics:renderer-failure'
+
+export const RENDERER_FAILURE_SOURCES = ['window-error', 'unhandled-rejection'] as const
+export type RendererFailureSource = (typeof RENDERER_FAILURE_SOURCES)[number]
+
+export const RENDERER_FAILURE_SURFACES = [
+  'home',
+  'workspace',
+  'settings',
+  'onboarding',
+  'unknown'
+] as const
+export type RendererFailureSurface = (typeof RENDERER_FAILURE_SURFACES)[number]
+
+export const RENDERER_ERROR_CATEGORIES = [
+  'error',
+  'type',
+  'reference',
+  'range',
+  'syntax',
+  'unknown'
+] as const
+export type RendererErrorCategory = (typeof RENDERER_ERROR_CATEGORIES)[number]
+
+export type RendererFailureReport = {
+  source: RendererFailureSource
+  surface: RendererFailureSurface
+  errorCategory: RendererErrorCategory
+  fingerprint?: string
+}
+
+const isOneOf = <Value extends string>(values: readonly Value[], value: unknown): value is Value =>
+  typeof value === 'string' && values.includes(value as Value)
+
+export const isRendererFailureReport = (value: unknown): value is RendererFailureReport => {
+  if (!value || typeof value !== 'object' || Array.isArray(value)) return false
+
+  const record = value as Record<string, unknown>
+  const keys = Object.keys(record)
+  if (keys.some((key) => !['source', 'surface', 'errorCategory', 'fingerprint'].includes(key))) {
+    return false
+  }
+  if (!keys.includes('source') || !keys.includes('surface') || !keys.includes('errorCategory')) {
+    return false
+  }
+
+  return (
+    isOneOf(RENDERER_FAILURE_SOURCES, record.source) &&
+    isOneOf(RENDERER_FAILURE_SURFACES, record.surface) &&
+    isOneOf(RENDERER_ERROR_CATEGORIES, record.errorCategory) &&
+    (record.fingerprint === undefined ||
+      (typeof record.fingerprint === 'string' && /^[a-f0-9]{8,64}$/.test(record.fingerprint)))
+  )
+}


### PR DESCRIPTION
## Problem

`main.log` is a reliable JSONL sink, but its diagnostic coverage is uneven. Failures before Electron readiness, caught storage migration failures, structured session/update failures, top-level renderer JavaScript errors, and degraded shutdown steps can leave support without enough evidence to locate the user-visible failure.

## Proposed change

- add per-process `runId` values and a privacy-safe diagnostic operation vocabulary (`started`, bounded phases, one terminal outcome)
- initialize startup diagnostics before heavy main-process composition and bound failure/shutdown log flushing
- add a rejection-only diagnostic floor to the existing native Electron and Web RPC handler registry without logging arguments or results
- cover storage copy/commit/adopt/legacy normalization, fixed copy quartiles, session persistence recovery, updater lifecycle, renderer top-level failures, and orderly shutdown
- classify shutdown handoffs as `quit`, `update`, or `migration-relaunch`; storage relaunch now reuses the authoritative usage drain -> renderer persistence -> backend teardown -> final log flush path
- validate, rate-limit, sanitize, and privacy-test every shared renderer/IPC diagnostic seam

```mermaid
flowchart LR
  Startup["Startup lifecycle"] --> Owner["Diagnostic operation owner"]
  Native["Native IPC"] --> Registry["Existing IPC registry"]
  Web["Web RPC"] --> Registry
  Registry -->|"rejections only"| Log["local main.log JSONL"]
  Owner -->|"bounded phases + terminal outcome"| Log
  Renderer["Top-level renderer failures"] -->|"validated + rate-limited"| Main["Main-process adapter"]
  Main --> Log
  Shutdown["Quit / update / migration relaunch"] --> Owner
```

The detailed design and coverage inventory are in `docs/internal/2026-08-03-diagnostic-logging-coverage-design.md`.

## Scope and non-goals

- no Prisma, settings, Session, Project, Artifact, or Notebook schema changes
- no user-facing UI, prompt, error-string, or return-shape changes
- no remote telemetry or automatic log upload; diagnostics remain local
- ordinary successful IPC requests stay silent
- the current IPC refactor surface is kept narrow: the central registry adapter plus existing composition seams; the latest `local-fs` bridge and handler registration from `main` are preserved
- P1 recovered/background owners (notebook provisioning, Office preview, project-file reconciliation, connector projection, and artifact legacy fallback) remain follow-up work and retain the universal rejection floor

## Acceptance criteria and validation

All commands below ran after the final material edit and rebase onto `origin/main@4057819`.

- early startup phases, bounded flush, IPC rejection floor, renderer bridge/rate limit, and privacy canary -> targeted Vitest command over 9 files -> **101 passed**
- session hydration/reconciliation, renderer persistence flush, update strategies, and runtime coordination -> targeted Vitest command over 7 files -> **215 passed**
- preload conflict integration, thenable rejection identity, storage migration/adopt/quartiles/relaunch, shutdown ordering, and no-throw sinks -> targeted Vitest command over 9 files -> **291 passed**
- node + renderer TypeScript contracts -> `npm run typecheck` -> **passed**
- repository lint -> `npm run lint` -> **passed with 0 errors** (18 warnings, all outside this diff)
- complete regression suite -> `npm test` -> **703 files passed, 15 skipped; 10,247 tests passed, 184 skipped**
- whitespace/conflict residue -> `git diff --check origin/main...HEAD` -> **passed**
- independent requirements and standards reviews -> **no remaining actionable findings**

## Review focus

- privacy allowlists: no paths, URLs, request/result payloads, renderer console output, provider details, or migration marker tokens at shared seams
- storage relaunch behavior: `app.relaunch()` + classified orderly `app.quit()` must preserve the existing no-confirmation handoff while gaining final persistence/log flushing
- IPC wrapper behavior: synchronous values remain synchronous and identical; thrown/rejected values, including one-shot thenables, remain authoritative
- preload conflict resolution: both the latest `localFs` API and renderer diagnostics bridge remain exposed and covered

## Uncovered risk

A failure before Electron can be imported and the platform log directory resolved cannot reach `main.log`; that earliest bootstrap floor remains stderr plus local native crash dumps where available. No UI E2E was run because this change intentionally adds no user interaction, but the preload contract and full unit suite cover the changed cross-process behavior.
