### PR TITLE
refactor(notebook): extract local RPC adapter

### DIFF
--- a/src/main/notebook/local-rpc-notebook-adapter.test.ts
+++ b/src/main/notebook/local-rpc-notebook-adapter.test.ts
@@ -1,0 +1,140 @@
+import { describe, expect, it, vi } from 'vitest'
+
+import {
+  NOTEBOOK_LOCAL_RPC_METHODS,
+  isNotebookLocalRpcMethod,
+  opensNotebookInputRun,
+  resolveNotebookLocalRpcHandler,
+  type NotebookLocalRpcCapability,
+  type NotebookLocalRpcMethod
+} from './local-rpc-notebook-adapter'
+
+const createCapability = (): NotebookLocalRpcCapability =>
+  Object.fromEntries(
+    NOTEBOOK_LOCAL_RPC_METHODS.map((method) => [
+      method,
+      vi.fn(async (request: unknown) => ({ method, request }))
+    ])
+  ) as unknown as NotebookLocalRpcCapability
+
+const request = {
+  sessionId: 'session-1',
+  workspaceCwd: '/workspace',
+  provenanceContext: { promptMessageId: 'message-user-1' },
+  registeredInputFiles: [{ inputFileVersionId: 'input-1' }],
+  inputRunLeaseId: 'input-run-1'
+}
+
+describe('notebook local RPC adapter', () => {
+  it('owns exactly the notebook capability method surface', () => {
+    expect(NOTEBOOK_LOCAL_RPC_METHODS).toEqual([
+      'beginCodeCell',
+      'appendCodeCell',
+      'finishCodeCell',
+      'runCell',
+      'execute',
+      'executeControl',
+      'executeShell',
+      'state',
+      'restart',
+      'shutdown',
+      'inspectPackages',
+      'managePackages',
+      'manageEnvironments',
+      'listRuntimes',
+      'bindRuntime',
+      'switchRuntime'
+    ])
+    expect(new Set(NOTEBOOK_LOCAL_RPC_METHODS).size).toBe(16)
+
+    for (const method of [
+      'listPackages',
+      'listPackageCounts',
+      'resolveNotebookInput',
+      'mcpCall',
+      'computeCall',
+      'agentsCall',
+      'skillImport',
+      'artifactCreateVersion',
+      'artifactReplayVersion',
+      'toString',
+      'constructor',
+      '__proto__',
+      null,
+      1
+    ]) {
+      expect(isNotebookLocalRpcMethod(method)).toBe(false)
+    }
+  })
+
+  it.each(NOTEBOOK_LOCAL_RPC_METHODS)(
+    'preserves request, result and error identity for %s',
+    async (method) => {
+      const capability = createCapability()
+      const handler = resolveNotebookLocalRpcHandler(capability, method, request)
+      const methodMock = (
+        capability as unknown as Record<NotebookLocalRpcMethod, ReturnType<typeof vi.fn>>
+      )[method]
+      const result = { method }
+      methodMock.mockResolvedValueOnce(result)
+
+      await expect(handler(request)).resolves.toBe(result)
+      expect(methodMock).toHaveBeenCalledTimes(1)
+      expect(methodMock.mock.calls[0]?.[0]).toBe(request)
+      for (const otherMethod of NOTEBOOK_LOCAL_RPC_METHODS) {
+        if (otherMethod === method) continue
+        expect(
+          (capability as unknown as Record<NotebookLocalRpcMethod, ReturnType<typeof vi.fn>>)[
+            otherMethod
+          ]
+        ).not.toHaveBeenCalled()
+      }
+
+      const failure = new Error(`${method} failed`)
+      methodMock.mockRejectedValueOnce(failure)
+      await expect(handler(request)).rejects.toBe(failure)
+    }
+  )
+
+  it('validates common notebook routing fields before resolving a handler', () => {
+    const capability = createCapability()
+
+    for (const field of ['sessionId', 'workspaceCwd'] as const) {
+      for (const invalid of [undefined, null, 1, [], {}]) {
+        expect(() =>
+          resolveNotebookLocalRpcHandler(capability, 'execute', {
+            ...request,
+            [field]: invalid
+          })
+        ).toThrow('Notebook RPC params must include sessionId and workspaceCwd.')
+      }
+    }
+
+    expect(() =>
+      resolveNotebookLocalRpcHandler(capability, 'execute', {
+        ...request,
+        sessionId: '',
+        workspaceCwd: ''
+      })
+    ).not.toThrow()
+  })
+
+  it('rejects unknown methods after validating common routing fields', () => {
+    const capability = createCapability()
+
+    for (const method of ['unknown', 'listPackages', 'listPackageCounts']) {
+      expect(() => resolveNotebookLocalRpcHandler(capability, method, request)).toThrow(
+        `Unknown notebook RPC method: ${method}`
+      )
+    }
+    expect(() => resolveNotebookLocalRpcHandler(capability, 'unknown', {})).toThrow(
+      'Notebook RPC params must include sessionId and workspaceCwd.'
+    )
+  })
+
+  it('identifies only execution methods as input-run lease owners', () => {
+    const leaseMethods = NOTEBOOK_LOCAL_RPC_METHODS.filter(opensNotebookInputRun)
+
+    expect(leaseMethods).toEqual(['runCell', 'execute', 'executeControl', 'executeShell'])
+  })
+})

--- a/src/main/notebook/local-rpc-notebook-adapter.ts
+++ b/src/main/notebook/local-rpc-notebook-adapter.ts
@@ -1,0 +1,140 @@
+import type {
+  AppendNotebookCodeCellRequest,
+  BeginNotebookCodeCellRequest,
+  ExecuteNotebookCodeRequest,
+  ExecuteNotebookControlRequest,
+  ExecuteShellRequest,
+  FinishNotebookCodeCellRequest,
+  NotebookLanguage,
+  NotebookSessionRequest,
+  RunNotebookCellRequest
+} from '../../shared/notebook'
+import type { ManageEnvironmentsRequest, ManageEnvironmentsResult } from '../../shared/notebook-env'
+import type { InstallRequest, InstallResult } from './package-manager'
+
+type InspectPackagesRequest = NotebookSessionRequest & {
+  language: NotebookLanguage
+  packages: string[]
+}
+
+type NotebookRuntimeBindingRequest = NotebookSessionRequest & {
+  language: NotebookLanguage
+  runtimeId: string
+}
+
+type NotebookLocalRpcCapability = {
+  beginCodeCell(request: BeginNotebookCodeCellRequest): Promise<unknown>
+  appendCodeCell(request: AppendNotebookCodeCellRequest): Promise<unknown>
+  finishCodeCell(request: FinishNotebookCodeCellRequest): Promise<unknown>
+  runCell(request: RunNotebookCellRequest): Promise<unknown>
+  execute(request: ExecuteNotebookCodeRequest): Promise<unknown>
+  executeControl(request: ExecuteNotebookControlRequest): Promise<unknown>
+  executeShell(request: ExecuteShellRequest): Promise<unknown>
+  state(request: NotebookSessionRequest): Promise<unknown>
+  restart(request: NotebookSessionRequest): Promise<unknown>
+  shutdown(request: NotebookSessionRequest): Promise<unknown>
+  inspectPackages(request: InspectPackagesRequest): Promise<unknown>
+  managePackages(request: InstallRequest): Promise<InstallResult>
+  manageEnvironments(request: ManageEnvironmentsRequest): Promise<ManageEnvironmentsResult>
+  listRuntimes(request: NotebookSessionRequest): Promise<unknown>
+  bindRuntime(request: NotebookRuntimeBindingRequest): Promise<unknown>
+  switchRuntime(request: NotebookRuntimeBindingRequest): Promise<unknown>
+}
+
+const NOTEBOOK_LOCAL_RPC_METHODS = [
+  'beginCodeCell',
+  'appendCodeCell',
+  'finishCodeCell',
+  'runCell',
+  'execute',
+  'executeControl',
+  'executeShell',
+  'state',
+  'restart',
+  'shutdown',
+  'inspectPackages',
+  'managePackages',
+  'manageEnvironments',
+  'listRuntimes',
+  'bindRuntime',
+  'switchRuntime'
+] as const
+
+type NotebookLocalRpcMethod = (typeof NOTEBOOK_LOCAL_RPC_METHODS)[number]
+type NotebookLocalRpcHandler = (request: Record<string, unknown>) => Promise<unknown>
+
+const NOTEBOOK_LOCAL_RPC_METHOD_SET = new Set<string>(NOTEBOOK_LOCAL_RPC_METHODS)
+const NOTEBOOK_INPUT_RUN_METHODS = new Set<NotebookLocalRpcMethod>([
+  'runCell',
+  'execute',
+  'executeControl',
+  'executeShell'
+])
+
+const isNotebookLocalRpcMethod = (method: unknown): method is NotebookLocalRpcMethod =>
+  typeof method === 'string' && NOTEBOOK_LOCAL_RPC_METHOD_SET.has(method)
+
+const opensNotebookInputRun = (method: unknown): method is NotebookLocalRpcMethod =>
+  isNotebookLocalRpcMethod(method) && NOTEBOOK_INPUT_RUN_METHODS.has(method)
+
+const assertSessionParams = (params: Record<string, unknown>): void => {
+  if (typeof params.sessionId !== 'string' || typeof params.workspaceCwd !== 'string') {
+    throw new Error('Notebook RPC params must include sessionId and workspaceCwd.')
+  }
+}
+
+const resolveNotebookLocalRpcHandler = (
+  capability: NotebookLocalRpcCapability,
+  method: string,
+  params: Record<string, unknown>
+): NotebookLocalRpcHandler => {
+  assertSessionParams(params)
+
+  if (!isNotebookLocalRpcMethod(method)) {
+    throw new Error(`Unknown notebook RPC method: ${method}`)
+  }
+
+  switch (method) {
+    case 'beginCodeCell':
+      return (request) => capability.beginCodeCell(request as BeginNotebookCodeCellRequest)
+    case 'appendCodeCell':
+      return (request) => capability.appendCodeCell(request as AppendNotebookCodeCellRequest)
+    case 'finishCodeCell':
+      return (request) => capability.finishCodeCell(request as FinishNotebookCodeCellRequest)
+    case 'runCell':
+      return (request) => capability.runCell(request as RunNotebookCellRequest)
+    case 'execute':
+      return (request) => capability.execute(request as ExecuteNotebookCodeRequest)
+    case 'executeControl':
+      return (request) => capability.executeControl(request as ExecuteNotebookControlRequest)
+    case 'executeShell':
+      return (request) => capability.executeShell(request as ExecuteShellRequest)
+    case 'state':
+      return (request) => capability.state(request as NotebookSessionRequest)
+    case 'restart':
+      return (request) => capability.restart(request as NotebookSessionRequest)
+    case 'shutdown':
+      return (request) => capability.shutdown(request as NotebookSessionRequest)
+    case 'inspectPackages':
+      return (request) => capability.inspectPackages(request as InspectPackagesRequest)
+    case 'managePackages':
+      return (request) => capability.managePackages(request as unknown as InstallRequest)
+    case 'manageEnvironments':
+      return (request) =>
+        capability.manageEnvironments(request as unknown as ManageEnvironmentsRequest)
+    case 'listRuntimes':
+      return (request) => capability.listRuntimes(request as NotebookSessionRequest)
+    case 'bindRuntime':
+      return (request) => capability.bindRuntime(request as NotebookRuntimeBindingRequest)
+    case 'switchRuntime':
+      return (request) => capability.switchRuntime(request as NotebookRuntimeBindingRequest)
+  }
+}
+
+export {
+  NOTEBOOK_LOCAL_RPC_METHODS,
+  isNotebookLocalRpcMethod,
+  opensNotebookInputRun,
+  resolveNotebookLocalRpcHandler
+}
+export type { NotebookLocalRpcCapability, NotebookLocalRpcHandler, NotebookLocalRpcMethod }

--- a/src/main/notebook/local-rpc-server.test.ts
+++ b/src/main/notebook/local-rpc-server.test.ts
@@ -1049,6 +1049,88 @@ describe('notebook local RPC server', () => {
     }
   })
 
+  it('closes and revokes an input-run lease when notebook execution rejects', async () => {
+    const root = await createStorageRoot()
+    const failure = new Error('execution failed')
+    let inputRunLeaseId: string | undefined
+    const close = vi.fn()
+    const service = new NotebookRuntimeService({
+      configRoot: root,
+      dataRoot: root,
+      projectName: 'default-project',
+      repository: new NotebookRunRepository(root)
+    })
+    vi.spyOn(service, 'execute').mockImplementation(async (executeRequest) => {
+      inputRunLeaseId = executeRequest.inputRunLeaseId
+      throw failure
+    })
+    const server = new NotebookLocalRpcServer(service, {
+      token: 'secret-token',
+      inputRegistry: {
+        registerTurn: vi.fn().mockResolvedValue(undefined),
+        getTurnInputs: () => [registeredInput],
+        openRun: vi.fn().mockResolvedValue({
+          getRunInputFiles: () => [registeredInput],
+          resolve: vi.fn().mockResolvedValue('/managed/groups.csv'),
+          close
+        }),
+        clearSession: vi.fn()
+      }
+    })
+    const connection = await server.ensureStarted()
+    server.setArtifactProvenanceContext('session-1', {
+      rootFrameId: 'root-frame-1',
+      agentFrameId: 'root-frame-1',
+      messageBranchId: 'branch-1',
+      runtimeSegmentId: 'runtime-1',
+      promptMessageId: 'message-user-1'
+    })
+    await server.registerNotebookTurnInputs({
+      projectId: 'default-project',
+      appSessionId: 'session-1',
+      promptMessageId: 'message-user-1',
+      uploads: [],
+      references: []
+    })
+
+    try {
+      const response = await fetch(connection.endpoint, {
+        method: 'POST',
+        headers: {
+          authorization: 'Bearer secret-token',
+          'content-type': 'application/json'
+        },
+        body: JSON.stringify({
+          method: 'execute',
+          params: {
+            sessionId: 'session-1',
+            workspaceCwd: '/workspace',
+            code: 'throw new Error()'
+          }
+        })
+      })
+
+      expect(response.status).toBe(500)
+      await expect(response.json()).resolves.toEqual({ error: failure.message })
+      expect(inputRunLeaseId).toEqual(expect.any(String))
+      expect(close).toHaveBeenCalledTimes(1)
+
+      const internals = server as unknown as {
+        dispatch(method: string, params: Record<string, unknown>): Promise<unknown>
+      }
+      await expect(
+        internals.dispatch('resolveNotebookInput', {
+          sessionId: 'session-1',
+          inputRunLeaseId,
+          sourceKind: 'upload-version',
+          inputFileVersionId: 'upload-version-1'
+        })
+      ).rejects.toThrow('Notebook input resolution requires an active run lease.')
+    } finally {
+      await server.close()
+    }
+  })
+
   it('resolves an immutable input only for the calling run while leases overlap', async () => {
     const root = await createStorageRoot()
     const server = new NotebookLocalRpcServer(

--- a/src/main/notebook/local-rpc-server.ts
+++ b/src/main/notebook/local-rpc-server.ts
@@ -1,19 +1,14 @@
 import { randomUUID } from 'node:crypto'
 import { createServer, type IncomingMessage, type Server, type ServerResponse } from 'node:http'
 
-import type {
-  AppendNotebookCodeCellRequest,
-  BeginNotebookCodeCellRequest,
-  ExecuteNotebookCodeRequest,
-  FinishNotebookCodeCellRequest,
-  NotebookRunProvenanceContext,
-  RunNotebookCellRequest
-} from '../../shared/notebook'
+import type { NotebookRunProvenanceContext } from '../../shared/notebook'
 import type { NotebookRpcConnection } from './mcp-server'
+import { NotebookControlCompletionCapturedError } from './execution-owner'
 import {
-  NotebookControlCompletionCapturedError,
-  type NotebookRuntimeService
-} from './runtime-service'
+  opensNotebookInputRun,
+  resolveNotebookLocalRpcHandler,
+  type NotebookLocalRpcCapability
+} from './local-rpc-notebook-adapter'
 import type {
   NotebookInputRegistry,
   NotebookInputRunLease,
@@ -184,13 +179,6 @@ const writeJson = (response: ServerResponse, statusCode: number, payload: unknow
   response.end(`${JSON.stringify(payload)}\n`)
 }
 
-// Ensures every runtime command carries the session routing fields the service needs.
-const assertSessionParams = (params: Record<string, unknown>): void => {
-  if (typeof params.sessionId !== 'string' || typeof params.workspaceCwd !== 'string') {
-    throw new Error('Notebook RPC params must include sessionId and workspaceCwd.')
-  }
-}
-
 // Hosts an app-local authenticated HTTP bridge between MCP stdio tools and the runtime service.
 class NotebookLocalRpcServer {
   private readonly token: string
@@ -220,7 +208,7 @@ class NotebookLocalRpcServer {
   private readonly drainingArtifactRpcCapabilities = new Map<string, Promise<void>>()
 
   constructor(
-    private readonly service: NotebookRuntimeService,
+    private readonly service: NotebookLocalRpcCapability,
     options: NotebookLocalRpcServerOptions = {}
   ) {
     this.token = options.token ?? randomUUID()
@@ -975,67 +963,14 @@ class NotebookLocalRpcServer {
       )
     }
 
-    assertSessionParams(params)
-
-    const handlers: Record<string, (request: Record<string, unknown>) => Promise<unknown>> = {
-      beginCodeCell: (request) =>
-        this.service.beginCodeCell(request as unknown as BeginNotebookCodeCellRequest),
-      appendCodeCell: (request) =>
-        this.service.appendCodeCell(request as unknown as AppendNotebookCodeCellRequest),
-      finishCodeCell: (request) =>
-        this.service.finishCodeCell(request as unknown as FinishNotebookCodeCellRequest),
-      runCell: (request) => this.service.runCell(request as unknown as RunNotebookCellRequest),
-      execute: (request) => this.service.execute(request as unknown as ExecuteNotebookCodeRequest),
-      executeControl: (request) =>
-        this.service.executeControl(
-          request as unknown as Parameters<NotebookRuntimeService['executeControl']>[0]
-        ),
-      executeShell: (request) =>
-        this.service.executeShell(
-          request as unknown as Parameters<NotebookRuntimeService['executeShell']>[0]
-        ),
-      state: (request) =>
-        this.service.state(request as Parameters<NotebookRuntimeService['state']>[0]),
-      restart: (request) =>
-        this.service.restart(request as Parameters<NotebookRuntimeService['restart']>[0]),
-      shutdown: (request) =>
-        this.service.shutdown(request as Parameters<NotebookRuntimeService['shutdown']>[0]),
-      inspectPackages: (request) =>
-        this.service.inspectPackages(
-          request as unknown as Parameters<NotebookRuntimeService['inspectPackages']>[0]
-        ),
-      managePackages: (request) =>
-        this.service.managePackages(
-          request as unknown as Parameters<NotebookRuntimeService['managePackages']>[0]
-        ),
-      manageEnvironments: (request) =>
-        this.service.manageEnvironments(
-          request as unknown as Parameters<NotebookRuntimeService['manageEnvironments']>[0]
-        ),
-      listRuntimes: (request) =>
-        this.service.listRuntimes(request as Parameters<NotebookRuntimeService['listRuntimes']>[0]),
-      bindRuntime: (request) =>
-        this.service.bindRuntime(
-          request as unknown as Parameters<NotebookRuntimeService['bindRuntime']>[0]
-        ),
-      switchRuntime: (request) =>
-        this.service.switchRuntime(
-          request as unknown as Parameters<NotebookRuntimeService['switchRuntime']>[0]
-        )
-    }
-
-    const handler = handlers[method]
-
-    if (!handler) {
-      throw new Error(`Unknown notebook RPC method: ${method}`)
-    }
+    const handler = resolveNotebookLocalRpcHandler(this.service, method, params)
 
     const projectId =
       typeof params.sessionId === 'string'
         ? this.activeTurnProjectIds.get(params.sessionId)
         : undefined
     const provenanceContext = params.provenanceContext
-    const opensInputRun = ['runCell', 'execute', 'executeControl', 'executeShell'].includes(method)
+    const opensInputRun = opensNotebookInputRun(method)
     if (
       opensInputRun &&
       projectId &&


### PR DESCRIPTION
## Problem

`NotebookLocalRpcServer` owned both transport concerns and the concrete `NotebookRuntimeService` dispatch table. That coupled authentication, trusted context injection, and input-run lease lifetime to 16 Notebook capability methods, making the local RPC boundary harder to evolve safely.

## Proposed change

- Add a narrow `NotebookLocalRpcCapability` contract for exactly the 16 existing Notebook methods.
- Move the method allowlist, common `sessionId`/`workspaceCwd` validation, method-to-capability translation, and four execution-method classification into `local-rpc-notebook-adapter.ts`.
- Keep HTTP transport, tokens, aliases, trusted provenance/input injection, Specialist/Compute/Agents/Artifact/Skill routes, and input-run lease ownership in `NotebookLocalRpcServer`.
- Import captured-completion identity from its defining module instead of the large runtime-service facade.

```mermaid
flowchart LR
  A["Local HTTP / MCP caller"] --> B["NotebookLocalRpcServer<br/>auth, alias, trusted context, lease lifetime"]
  B --> C["Notebook local RPC adapter<br/>16-method allowlist, validation, translation"]
  C --> D["NotebookLocalRpcCapability"]
  B --> E["Artifact / Skill / MCP / Compute / Agents routes"]
```

## Scope and non-goals

- No data-model, data-relationship, persistence, or user-interaction changes.
- No public IPC, preload, Web RPC, CLI, Task, or MCP schema changes.
- Preserve the current Electron/Web/CLI/Task capability asymmetry for Specialist, Permission, and Compute.
- `runtime:list-packages` and `runtime:list-package-counts` remain Settings/runtime-selection APIs and do not enter local Notebook RPC.
- Related to #458 only as a forward-compatible ownership seam; this PR adds no orchestration state or public orchestration interface.

Production churn: 223 lines (`local-rpc-server.ts` 9 additions/74 deletions plus the 140-line adapter), below the 450-line re-review threshold.

## Acceptance criteria and validation

All commands below ran after the final material edit.

- 16-method mapping, validation, exact allowlist, request/result/error identity, and four lease-opening methods -> `npm test -- --run src/main/notebook/local-rpc-notebook-adapter.test.ts` -> 20 passed.
- HTTP dispatch, trusted provenance/input injection, captured completion, and rejection-path lease cleanup/revocation -> `npm test -- --run src/main/notebook/local-rpc-server.test.ts` -> 22 passed.
- Local RPC/MCP/Specialist/Compute compatibility -> targeted 9-file Notebook matrix -> 115 passed, 15 environment-gated skipped.
- Latest-main package listing/runtime selection/Electron preload/Web RPC and updater contracts -> rebase-targeted 17-file matrix -> 266 passed, 15 environment-gated skipped.
- Type safety -> `npm run typecheck` -> passed.
- Repository lint -> `npm run lint` -> 0 errors; 18 pre-existing warnings in unchanged files.
- Full regression on exact head `9f9f75b` -> `npm test` -> 697 files / 10,188 tests passed; 15 files / 184 tests environment-gated skipped.
- Independent Spec review -> 0 findings.
- Independent Standards review -> 0 findings.

Uncovered risk: environment-gated host integration/certification cases remain skipped locally and are delegated to CI; no production behavior or platform-specific code changed.

## Review focus

- Confirm auth/alias/trusted-context/input-lease ordering remains in the server.
- Confirm the adapter surface contains only the existing 16 Notebook methods.
- Confirm package listing and Specialist/Permission/Compute cross-surface behavior remain unchanged.
