### PR TITLE
perf(workspace-runtime): isolate session event drains

### DIFF
--- a/src/renderer/src/lib/acp/useWorkspaceAgentRuntime.test.ts
+++ b/src/renderer/src/lib/acp/useWorkspaceAgentRuntime.test.ts
@@ -181,9 +181,12 @@ describe('workspace agent runtime event processing', () => {
     expect(processedEventIds.has('stop-event-1')).toBe(true)
   })
 
-  it('serializes overlapping snapshots so stop waits for an in-flight artifact event', async () => {
-    const artifactEvent = createEvent({ id: 'artifact-event-1', kind: 'artifact' })
-    const stopEvent = createEvent({ id: 'stop-event-1', kind: 'stop' })
+  it.each([
+    ['one session', 'transport-session-1'],
+    ['unscoped events', undefined]
+  ] as const)('serializes overlapping snapshots for %s', async (_scope, sessionId) => {
+    const artifactEvent = createEvent({ id: 'artifact-event-1', kind: 'artifact', sessionId })
+    const stopEvent = createEvent({ id: 'stop-event-1', kind: 'stop', sessionId })
     let finishArtifact: ((wasApplied: boolean) => void) | undefined
     const applyEvent = vi.fn<(runtimeEvent: AcpRuntimeEvent) => Promise<boolean>>((event) => {
       if (event.id === 'artifact-event-1') {
@@ -210,6 +213,241 @@ describe('workspace agent runtime event processing', () => {
       'artifact-event-1',
       'stop-event-1'
     ])
+  })
+
+  it('processes another session while an earlier session event is still in flight', async () => {
+    const artifactEvent = createEvent({
+      id: 'artifact-event-1',
+      kind: 'artifact',
+      sessionId: 'transport-session-1'
+    })
+    const messageEvent = createEvent({
+      id: 'message-event-2',
+      sessionId: 'transport-session-2'
+    })
+    const artifact = createDeferred<boolean>()
+    const applyEvent = vi.fn<(runtimeEvent: AcpRuntimeEvent) => Promise<boolean>>((event) =>
+      event.id === artifactEvent.id ? artifact.promise : Promise.resolve(true)
+    )
+    const processor = createWorkspaceRuntimeEventProcessor(applyEvent)
+
+    const firstDrain = processor.process([artifactEvent])
+    const secondDrain = processor.process([artifactEvent, messageEvent])
+
+    await Promise.resolve()
+
+    expect(applyEvent.mock.calls.map(([event]) => event.id)).toEqual([
+      'artifact-event-1',
+      'message-event-2'
+    ])
+
+    artifact.resolve(true)
+    await Promise.all([firstDrain, secondDrain])
+  })
+
+  it('keeps an accepted session event when a newer snapshot no longer contains it', async () => {
+    const artifactEvent = createEvent({ id: 'artifact-event-1', kind: 'artifact' })
+    const stopEvent = createEvent({ id: 'stop-event-1', kind: 'stop' })
+    const artifact = createDeferred<boolean>()
+    const applyEvent = vi.fn<(runtimeEvent: AcpRuntimeEvent) => Promise<boolean>>((event) =>
+      event.id === artifactEvent.id ? artifact.promise : Promise.resolve(true)
+    )
+    const processor = createWorkspaceRuntimeEventProcessor(applyEvent)
+
+    const firstDrain = processor.process([artifactEvent])
+    const secondDrain = processor.process([artifactEvent, stopEvent])
+    const emptySnapshotDrain = processor.process([])
+
+    artifact.resolve(true)
+    await Promise.all([firstDrain, secondDrain, emptySnapshotDrain])
+
+    expect(applyEvent.mock.calls.map(([event]) => event.id)).toEqual([
+      'artifact-event-1',
+      'stop-event-1'
+    ])
+  })
+
+  it('retries an accepted event that fails after a newer snapshot evicts it', async () => {
+    const artifactEvent = createEvent({ id: 'artifact-event-1', kind: 'artifact' })
+    let rejectFirstAttempt!: (reason: Error) => void
+    const firstAttempt = new Promise<boolean>((_resolve, reject) => {
+      rejectFirstAttempt = reject
+    })
+    const retryStarted = createDeferred<void>()
+    const applyEvent = vi
+      .fn<(runtimeEvent: AcpRuntimeEvent) => Promise<boolean>>()
+      .mockImplementationOnce(() => firstAttempt)
+      .mockImplementationOnce(async () => {
+        retryStarted.resolve()
+        return true
+      })
+    const processor = createWorkspaceRuntimeEventProcessor(applyEvent)
+
+    const firstDrain = processor.process([artifactEvent])
+    void processor.process([])
+    rejectFirstAttempt(new Error('move failed'))
+    await firstDrain
+
+    void processor.process([])
+    const didRetry = await Promise.race([
+      retryStarted.promise.then(() => true),
+      new Promise<false>((resolve) => setTimeout(() => resolve(false), 0))
+    ])
+
+    expect(didRetry).toBe(true)
+    expect(applyEvent).toHaveBeenCalledTimes(2)
+  })
+
+  it('releases an evicted event after its deferred retry also fails', async () => {
+    const artifactEvent = createEvent({ id: 'artifact-event-1', kind: 'artifact' })
+    let rejectFirstAttempt!: (reason: Error) => void
+    let rejectRetry!: (reason: Error) => void
+    const firstAttempt = new Promise<boolean>((_resolve, reject) => {
+      rejectFirstAttempt = reject
+    })
+    const retry = new Promise<boolean>((_resolve, reject) => {
+      rejectRetry = reject
+    })
+    const applyEvent = vi
+      .fn<(runtimeEvent: AcpRuntimeEvent) => Promise<boolean>>()
+      .mockImplementationOnce(() => firstAttempt)
+      .mockImplementationOnce(() => retry)
+      .mockResolvedValue(true)
+    const processor = createWorkspaceRuntimeEventProcessor(applyEvent)
+
+    const firstDrain = processor.process([artifactEvent])
+    void processor.process([])
+    rejectFirstAttempt(new Error('move failed'))
+    await vi.waitFor(() => expect(applyEvent).toHaveBeenCalledTimes(2))
+    rejectRetry(new Error('move still failing'))
+    await firstDrain
+
+    await processor.process([])
+    await processor.drain()
+
+    expect(applyEvent).toHaveBeenCalledTimes(2)
+  })
+
+  it('resolves a snapshot without waiting for an in-flight lane that is no longer visible', async () => {
+    const artifactEvent = createEvent({
+      id: 'artifact-event-1',
+      kind: 'artifact',
+      sessionId: 'transport-session-1'
+    })
+    const messageEvent = createEvent({
+      id: 'message-event-2',
+      sessionId: 'transport-session-2'
+    })
+    const artifact = createDeferred<boolean>()
+    const applyEvent = vi.fn<(runtimeEvent: AcpRuntimeEvent) => Promise<boolean>>((event) =>
+      event.id === artifactEvent.id ? artifact.promise : Promise.resolve(true)
+    )
+    const processor = createWorkspaceRuntimeEventProcessor(applyEvent)
+
+    const firstDrain = processor.process([artifactEvent])
+    const secondDrain = processor.process([messageEvent])
+    const secondDrainFinished = await Promise.race([
+      secondDrain.then(() => true),
+      new Promise<false>((resolve) => setTimeout(() => resolve(false), 0))
+    ])
+
+    expect(applyEvent.mock.calls.map(([event]) => event.id)).toEqual([
+      'artifact-event-1',
+      'message-event-2'
+    ])
+    expect(secondDrainFinished).toBe(true)
+
+    artifact.resolve(true)
+    await Promise.all([firstDrain, secondDrain])
+  })
+
+  it('waits for every accepted lane at an explicit persistence barrier', async () => {
+    const artifactEvent = createEvent({
+      id: 'artifact-event-1',
+      kind: 'artifact',
+      sessionId: 'transport-session-1'
+    })
+    const artifact = createDeferred<boolean>()
+    const processor = createWorkspaceRuntimeEventProcessor(() => artifact.promise)
+
+    const firstDrain = processor.process([artifactEvent])
+    await processor.process([])
+    const persistenceDrain = processor.drain()
+    let persistenceFinished = false
+    void persistenceDrain.then(() => (persistenceFinished = true))
+
+    await Promise.resolve()
+    expect(persistenceFinished).toBe(false)
+
+    artifact.resolve(true)
+    await Promise.all([firstDrain, persistenceDrain])
+    expect(persistenceFinished).toBe(true)
+  })
+
+  it('waits for a lane accepted while the persistence barrier is in progress', async () => {
+    const firstSessionEvent = createEvent({
+      id: 'artifact-event-1',
+      kind: 'artifact',
+      sessionId: 'transport-session-1'
+    })
+    const secondSessionEvent = createEvent({
+      id: 'artifact-event-2',
+      kind: 'artifact',
+      sessionId: 'transport-session-2'
+    })
+    const firstArtifact = createDeferred<boolean>()
+    const secondArtifact = createDeferred<boolean>()
+    const applyEvent = vi.fn<(runtimeEvent: AcpRuntimeEvent) => Promise<boolean>>((event) =>
+      event.sessionId === firstSessionEvent.sessionId
+        ? firstArtifact.promise
+        : secondArtifact.promise
+    )
+    const processor = createWorkspaceRuntimeEventProcessor(applyEvent)
+
+    const firstDrain = processor.process([firstSessionEvent])
+    const persistenceDrain = processor.drain()
+    let persistenceFinished = false
+    void persistenceDrain.then(() => (persistenceFinished = true))
+    const secondDrain = processor.process([secondSessionEvent])
+
+    firstArtifact.resolve(true)
+    await firstDrain
+    await Promise.resolve()
+    expect(persistenceFinished).toBe(false)
+
+    secondArtifact.resolve(true)
+    await Promise.all([persistenceDrain, secondDrain])
+  })
+
+  it('waits only for the requested session at an explicit resume barrier', async () => {
+    const firstSessionEvent = createEvent({
+      id: 'artifact-event-1',
+      kind: 'artifact',
+      sessionId: 'transport-session-1'
+    })
+    const secondSessionEvent = createEvent({
+      id: 'artifact-event-2',
+      kind: 'artifact',
+      sessionId: 'transport-session-2'
+    })
+    const firstArtifact = createDeferred<boolean>()
+    const secondArtifact = createDeferred<boolean>()
+    const applyEvent = vi.fn<(runtimeEvent: AcpRuntimeEvent) => Promise<boolean>>((event) =>
+      event.sessionId === firstSessionEvent.sessionId
+        ? firstArtifact.promise
+        : secondArtifact.promise
+    )
+    const processor = createWorkspaceRuntimeEventProcessor(applyEvent)
+
+    const visibleDrain = processor.process([firstSessionEvent, secondSessionEvent])
+    const firstSessionDrain = processor.drain('transport-session-1')
+    firstArtifact.resolve(true)
+
+    await firstSessionDrain
+    expect(applyEvent).toHaveBeenCalledTimes(2)
+
+    secondArtifact.resolve(true)
+    await visibleDrain
   })
 })
 
@@ -666,6 +904,7 @@ describe('workspace agent message sending', () => {
     )
 
     expect(drainRuntimeEvents).toHaveBeenCalledOnce()
+    expect(drainRuntimeEvents).toHaveBeenCalledWith('transport-session-1')
     expect(sendPrompt.mock.calls[0]?.[5]).toContain('Accepted final answer')
     expect(useSessionStore.getState().sessions[0]).toMatchObject({
       status: 'running',

--- a/src/renderer/src/lib/acp/useWorkspaceAgentRuntime.ts
+++ b/src/renderer/src/lib/acp/useWorkspaceAgentRuntime.ts
@@ -86,7 +86,7 @@ type SendWorkspaceMessageResult = {
 }
 
 type SendPreparationStateChange = (sessionId: string, inFlight: boolean) => void
-type RuntimeEventDrain = () => Promise<void>
+type RuntimeEventDrain = (sessionId?: string) => Promise<void>
 
 // Payload of an inline edit resend: the adjusted prompt text plus the mentions it carries. The
 // session/message ids stay separate because they address the truncation point, not the prompt.
@@ -130,6 +130,7 @@ type RuntimeEventApplier = (event: AcpRuntimeEvent) => Promise<boolean>
 
 type WorkspaceRuntimeEventProcessor = {
   process: (events: AcpRuntimeEvent[]) => Promise<void>
+  drain: (sessionId?: string) => Promise<void>
 }
 
 // Runtime adoption and Branch reset intentionally complete before appendUserMessage creates the next
@@ -361,42 +362,149 @@ const processVisibleWorkspaceRuntimeEvents = async (
 const createWorkspaceRuntimeEventProcessor = (
   applyEvent: RuntimeEventApplier = applyWorkspaceRuntimeEvent
 ): WorkspaceRuntimeEventProcessor => {
-  const processedEventIds = new Set<string>()
-  const processingEventIds = new Set<string>()
-  let latestEvents: AcpRuntimeEvent[] = []
-  let drainInFlight: Promise<void> | undefined
-  let drainAgain = false
+  type EventLane = {
+    acceptedEvents: Map<string, AcpRuntimeEvent>
+    failedEventIds: Set<string>
+    processedEventIds: Set<string>
+    processingEventIds: Set<string>
+    drainInFlight?: Promise<void>
+    drainAgain: boolean
+  }
 
-  // Coalesces rapid runtime snapshots while preserving a single ordered drain loop.
-  const drain = async (): Promise<void> => {
-    if (drainInFlight) {
-      drainAgain = true
-      return drainInFlight
+  const unscopedEventLane = Symbol('unscoped-workspace-runtime-events')
+  const eventLanes = new Map<string | symbol, EventLane>()
+  let latestEvents: AcpRuntimeEvent[] = []
+  let acceptedEventVersion = 0
+
+  const getEventLaneKey = (event: AcpRuntimeEvent): string | symbol =>
+    event.sessionId ?? unscopedEventLane
+
+  const getEventLane = (laneKey: string | symbol): EventLane => {
+    let lane = eventLanes.get(laneKey)
+    if (!lane) {
+      lane = {
+        acceptedEvents: new Map<string, AcpRuntimeEvent>(),
+        failedEventIds: new Set<string>(),
+        processedEventIds: new Set<string>(),
+        processingEventIds: new Set<string>(),
+        drainAgain: false
+      }
+      eventLanes.set(laneKey, lane)
     }
 
-    drainInFlight = (async () => {
+    return lane
+  }
+
+  const cleanEventLane = (laneKey: string | symbol, lane: EventLane): void => {
+    const visibleEventIds = new Set(
+      latestEvents.filter((event) => getEventLaneKey(event) === laneKey).map((event) => event.id)
+    )
+
+    for (const eventId of lane.acceptedEvents.keys()) {
+      if (!visibleEventIds.has(eventId) && lane.processedEventIds.has(eventId)) {
+        lane.acceptedEvents.delete(eventId)
+        lane.failedEventIds.delete(eventId)
+        lane.processedEventIds.delete(eventId)
+        lane.processingEventIds.delete(eventId)
+      }
+    }
+
+    if (lane.acceptedEvents.size === 0 && !lane.drainInFlight) {
+      eventLanes.delete(laneKey)
+    }
+  }
+
+  const drainLane = async (laneKey: string | symbol): Promise<void> => {
+    const lane = getEventLane(laneKey)
+
+    if (lane.drainInFlight) {
+      lane.drainAgain = true
+      return lane.drainInFlight
+    }
+
+    lane.drainInFlight = (async () => {
       do {
-        drainAgain = false
+        lane.drainAgain = false
         await processVisibleWorkspaceRuntimeEvents(
-          latestEvents,
-          processedEventIds,
-          applyEvent,
-          processingEventIds
+          [...lane.acceptedEvents.values()],
+          lane.processedEventIds,
+          async (event) => {
+            const hadFailed = lane.failedEventIds.has(event.id)
+            try {
+              const applied = await applyEvent(event)
+              lane.failedEventIds.delete(event.id)
+              return applied
+            } catch (error) {
+              const isVisible = latestEvents.some(
+                (candidate) => candidate.id === event.id && getEventLaneKey(candidate) === laneKey
+              )
+              if (hadFailed && !isVisible) {
+                lane.acceptedEvents.delete(event.id)
+                lane.failedEventIds.delete(event.id)
+              } else {
+                lane.failedEventIds.add(event.id)
+              }
+              throw error
+            }
+          },
+          lane.processingEventIds
         )
-      } while (drainAgain)
+      } while (lane.drainAgain)
     })()
 
     try {
-      await drainInFlight
+      await lane.drainInFlight
     } finally {
-      drainInFlight = undefined
+      lane.drainInFlight = undefined
+      cleanEventLane(laneKey, lane)
     }
   }
 
   return {
     process: (events) => {
       latestEvents = events
-      return drain()
+      const visibleLaneKeys = new Set<string | symbol>()
+
+      for (const event of events) {
+        const laneKey = getEventLaneKey(event)
+        const lane = getEventLane(laneKey)
+        visibleLaneKeys.add(laneKey)
+
+        if (
+          !lane.processedEventIds.has(event.id) &&
+          !lane.processingEventIds.has(event.id) &&
+          !lane.acceptedEvents.has(event.id)
+        ) {
+          // A bounded source snapshot may evict this event before a slow predecessor finishes.
+          lane.acceptedEvents.set(event.id, event)
+          acceptedEventVersion += 1
+        }
+      }
+
+      for (const [laneKey, lane] of eventLanes) {
+        cleanEventLane(laneKey, lane)
+      }
+
+      const drains = [...visibleLaneKeys].map((laneKey) => drainLane(laneKey))
+      for (const [laneKey, lane] of eventLanes) {
+        if (!visibleLaneKeys.has(laneKey) && lane.acceptedEvents.size > 0) {
+          void drainLane(laneKey)
+        }
+      }
+
+      return Promise.all(drains).then(() => undefined)
+    },
+    drain: async (sessionId) => {
+      if (sessionId !== undefined) {
+        if (eventLanes.has(sessionId)) await drainLane(sessionId)
+        return
+      }
+
+      let drainedVersion: number
+      do {
+        drainedVersion = acceptedEventVersion
+        await Promise.all([...eventLanes.keys()].map((laneKey) => drainLane(laneKey)))
+      } while (drainedVersion !== acceptedEventVersion)
     }
   }
 }
@@ -695,7 +803,7 @@ const sendWorkspaceMessage = async (
         // The coordinator waits for the prior owner to stop before committing adoption, but its
         // retained events still cross the asynchronous renderer bridge. Apply the latest accepted
         // snapshot before opening the new optimistic run so a terminal event cannot settle that run.
-        await drainRuntimeEvents?.()
+        await drainRuntimeEvents?.(targetSessionId)
       }
     } catch (error) {
       useSessionStore.getState().failRun(targetSessionId, getResumeFailureMessage(error))
@@ -1393,9 +1501,10 @@ const syncWorkspaceContextUsage = (
   }
 }
 
-const drainWorkspaceRuntimeEventsForPersistence = async (): Promise<void> => {
+const drainWorkspaceRuntimeEventsForPersistence = async (sessionId?: string): Promise<void> => {
   const snapshot = await window.api.acp.getState()
-  await liveWorkspaceRuntimeEventProcessor.process(snapshot.events)
+  void liveWorkspaceRuntimeEventProcessor.process(snapshot.events)
+  await liveWorkspaceRuntimeEventProcessor.drain(sessionId)
   syncWorkspaceContextUsage(snapshot.sessionIds, snapshot.contextUsageBySession)
 }
 


### PR DESCRIPTION
## Problem

The renderer drained all visible ACP runtime events through one global ordered loop. A slow
asynchronous event, such as artifact finalization in one active session, could therefore delay model
output from another active session even though the main-process runtime was producing both streams
concurrently.

## Proposed change

- Process runtime events through independent ordered lanes keyed by `sessionId`.
- Keep same-session and unscoped events sequential while allowing different sessions to advance
  concurrently.
- Retain accepted lane events until they apply, even if a newer bounded runtime snapshot evicts them.
- Keep a failed event retryable while it remains visible; after eviction, make one final retry and
  release it if that retry also fails.
- Resolve `process(events)` after the lanes visible to that call settle, without waiting for an
  unrelated lane that is no longer present.
- Add an explicit `drain(sessionId?)` barrier so quit persistence waits for all accepted lanes while
  resume/send preparation waits only for its target session.
- Recheck the accepted-event version at the all-lane barrier so it also waits for lanes accepted
  while the barrier is in progress.

The existing snapshot-scoped `process(events)` behavior remains unchanged; `drain(sessionId?)` is an
internal renderer-only consistency seam.

## Scope and non-goals

This changes renderer event scheduling and focused tests only. It does not change ACP protocols,
session or artifact data models, persistence schemas or queues, backend concurrency limits, subagent
modeling, or user workflows.

## Acceptance criteria and validation

All checks below ran after the last material implementation edit:

- Cross-session progress, same-session/unscoped ordering, accepted-event retention, retry, and
  deduplication -> `npm test -- --run src/renderer/src/lib/acp/useWorkspaceAgentRuntime.test.ts` ->
  101 passed.
- Repository type contracts -> `npm run typecheck` -> passed.
- Static rules -> `npm run lint` -> passed with 0 errors and 18 unrelated baseline warnings.
- Full regression suite -> `npm test` -> 10,200 passed and 184 skipped.

Uncovered risk: a third-party agent backend may still serialize event production upstream. A lane
also retains accepted events while a predecessor is slow, so prolonged upstream stalls can increase
the lane's temporary in-memory backlog.

## Review focus

Please focus on cross-session independence, same-session ordering, bounded-snapshot retention,
failure retry behavior, explicit quit/resume barriers, unscoped event ordering, and lane cleanup.
