### PR TITLE
fix(local-paths): support Windows absolute paths

### DIFF
--- a/src/main/local-fs/service.ts
+++ b/src/main/local-fs/service.ts
@@ -24,7 +24,7 @@ const buildMachineName = (): string => {
 
 // Throws a tagged error when the path fails the shared validation (non-absolute / control chars).
 const assertValidLocalPath = (path: string): void => {
-  const problem = validateLocalPath(path)
+  const problem = validateLocalPath(path, process.platform)
   if (problem === 'not_absolute') throw new Error('Local path must be absolute.')
   if (problem === 'control_chars') throw new Error('Local path contains invalid characters.')
 }

--- a/src/main/notebook/package-listing.test.ts
+++ b/src/main/notebook/package-listing.test.ts
@@ -40,9 +40,9 @@ describe('packageListingVia', () => {
 describe('condaPrefixFromInterpreter', () => {
   it('derives the prefix from a Unix interpreter two levels up', () => {
     expect(
-      condaPrefixFromInterpreter('/data/runtime/envs/default-python/bin/python', 'python')
+      condaPrefixFromInterpreter('/data/runtime/envs/default-python/bin/python', 'python', 'linux')
     ).toBe('/data/runtime/envs/default-python')
-    expect(condaPrefixFromInterpreter('/data/runtime/envs/default-r/bin/R', 'r')).toBe(
+    expect(condaPrefixFromInterpreter('/data/runtime/envs/default-r/bin/R', 'r', 'linux')).toBe(
       '/data/runtime/envs/default-r'
     )
   })
@@ -135,7 +135,8 @@ describe('listEnvPackages dispatch', () => {
     const packages = await listEnvPackages(target, {
       exec,
       micromamba: '/mm',
-      runtimeRoot: '/data/runtime'
+      runtimeRoot: '/data/runtime',
+      platform: 'linux'
     })
 
     expect(packages).toEqual([

--- a/src/main/uploads/ipc.ts
+++ b/src/main/uploads/ipc.ts
@@ -240,7 +240,7 @@ const registerUploadIpcHandlers = (
       typeof request.sourcePath !== 'string' ||
       // The renderer hands over a raw host path, so it gets the same shape checks the local-fs
       // browser applies — absolute, no control characters — before stat() or any copy sees it.
-      validateLocalPath(request.sourcePath) !== undefined
+      validateLocalPath(request.sourcePath, process.platform) !== undefined
     ) {
       throw new Error('Invalid local path upload request.')
     }

--- a/src/renderer/src/pages/workspace/LocalFileBrowser.tsx
+++ b/src/renderer/src/pages/workspace/LocalFileBrowser.tsx
@@ -13,9 +13,12 @@ import { useCallback, useEffect, useRef, useState } from 'react'
 import type { LocalDirEntry, LocalListingProblem, LocalRoots } from '../../../../shared/local-fs'
 import {
   describeLocalListingError,
+  isLocalPathRoot,
   isSensitiveLocalPath,
   LOCAL_BOOKMARKS_KEY,
+  parentLocalPath,
   resolveLocalPath,
+  sameLocalDirectory,
   validateLocalPath
 } from '../../../../shared/local-fs'
 import { Button } from '@/components/ui/button'
@@ -30,13 +33,6 @@ import { Tooltip, TooltipContent, TooltipProvider, TooltipTrigger } from '@/comp
 import { usePreviewWorkbenchStore } from '@/stores/preview-workbench-store'
 
 import { createPreviewFileItemFromLocal, LOCAL_PREVIEW_SESSION_ID } from './preview-file-item'
-
-// True when two paths name the same directory, so equivalent spellings ("/a/b" vs "/a/b/") don't
-// trigger a redundant listing call. Root stays "/".
-const sameDirectory = (a: string, b: string): boolean => {
-  const strip = (path: string): string => (path.length > 1 ? path.replace(/\/+$/, '') : path)
-  return strip(a) === strip(b)
-}
 
 // Formats a byte count as a short human-readable string.
 const formatSize = (bytes: number): string => {
@@ -55,13 +51,6 @@ const relativeTime = (mtimeMs: number): string => {
   if (sec < 3600) return `${Math.round(sec / 60)}m`
   if (sec < 86400) return `${Math.round(sec / 3600)}h`
   return `${Math.round(sec / 86400)}d`
-}
-
-// Parent path (removes the last component); returns '/' at the root.
-const parentPath = (p: string): string => {
-  if (p === '/') return '/'
-  const idx = p.replace(/\/$/, '').lastIndexOf('/')
-  return idx <= 0 ? '/' : p.slice(0, idx)
 }
 
 // Shared look for the three icon-only toolbar buttons. They sit above a dense listing, so they read
@@ -356,7 +345,7 @@ export const LocalFileBrowser = ({
 
   const listing = state.kind === 'ok' ? state : null
   const currentPath = listing?.resolvedPath ?? cwd
-  const isAtRoot = currentPath === '/'
+  const isAtRoot = isLocalPathRoot(currentPath)
 
   // Submit/blur only re-reads the directory when the typed path actually resolves somewhere new, so
   // tabbing out of an untouched address bar costs no listing call. A no-op edit (trailing slash,
@@ -377,7 +366,7 @@ export const LocalFileBrowser = ({
       })
       return
     }
-    if (sameDirectory(resolved, currentPath)) {
+    if (sameLocalDirectory(resolved, currentPath)) {
       setAddressInput(currentPath)
       return
     }
@@ -387,7 +376,7 @@ export const LocalFileBrowser = ({
   // Directory → navigate in; file → open a preview-workbench tab. Sensitive paths (credential dirs
   // like .ssh, private keys, dotenv files) warn first, whether entering or opening.
   const handleOpenEntry = (entry: LocalDirEntry): void => {
-    const path = `${currentPath.replace(/\/$/, '')}/${entry.name}`
+    const path = resolveLocalPath(currentPath, entry.name)
     if (isSensitiveLocalPath(path)) {
       const prompt = entry.isDirectory
         ? `"${entry.name}" may contain credentials or secrets. Open this folder anyway?`
@@ -442,7 +431,7 @@ export const LocalFileBrowser = ({
               size="icon-sm"
               className={TOOLBAR_ICON_BUTTON}
               disabled={isAtRoot}
-              onClick={() => void navigate(parentPath(currentPath))}
+              onClick={() => void navigate(parentLocalPath(currentPath))}
               aria-label="Go to parent directory"
             >
               <ArrowLeft className="size-4" strokeWidth={TOOLBAR_ICON_STROKE} />

--- a/src/renderer/src/pages/workspace/LocalFileBrowser.tsx
+++ b/src/renderer/src/pages/workspace/LocalFileBrowser.tsx
@@ -352,8 +352,8 @@ export const LocalFileBrowser = ({
   // relative form of the same dir) snaps the field back to the canonical path instead.
   const handleAddressSubmit = (e: React.FormEvent): void => {
     e.preventDefault()
-    const resolved = resolveLocalPath(currentPath, addressInput.trim())
-    const invalid = validateLocalPath(resolved)
+    const resolved = resolveLocalPath(currentPath, addressInput.trim(), window.api.platform)
+    const invalid = validateLocalPath(resolved, window.api.platform)
     if (invalid) {
       setState({
         kind: 'error',
@@ -376,7 +376,7 @@ export const LocalFileBrowser = ({
   // Directory → navigate in; file → open a preview-workbench tab. Sensitive paths (credential dirs
   // like .ssh, private keys, dotenv files) warn first, whether entering or opening.
   const handleOpenEntry = (entry: LocalDirEntry): void => {
-    const path = resolveLocalPath(currentPath, entry.name)
+    const path = resolveLocalPath(currentPath, entry.name, window.api.platform)
     if (isSensitiveLocalPath(path)) {
       const prompt = entry.isDirectory
         ? `"${entry.name}" may contain credentials or secrets. Open this folder anyway?`

--- a/src/renderer/src/pages/workspace/LocalFileBrowser.tsx
+++ b/src/renderer/src/pages/workspace/LocalFileBrowser.tsx
@@ -345,7 +345,7 @@ export const LocalFileBrowser = ({
 
   const listing = state.kind === 'ok' ? state : null
   const currentPath = listing?.resolvedPath ?? cwd
-  const isAtRoot = isLocalPathRoot(currentPath)
+  const isAtRoot = isLocalPathRoot(currentPath, window.api.platform)
 
   // Submit/blur only re-reads the directory when the typed path actually resolves somewhere new, so
   // tabbing out of an untouched address bar costs no listing call. A no-op edit (trailing slash,
@@ -366,7 +366,7 @@ export const LocalFileBrowser = ({
       })
       return
     }
-    if (sameLocalDirectory(resolved, currentPath)) {
+    if (sameLocalDirectory(resolved, currentPath, window.api.platform)) {
       setAddressInput(currentPath)
       return
     }
@@ -377,7 +377,7 @@ export const LocalFileBrowser = ({
   // like .ssh, private keys, dotenv files) warn first, whether entering or opening.
   const handleOpenEntry = (entry: LocalDirEntry): void => {
     const path = resolveLocalPath(currentPath, entry.name, window.api.platform)
-    if (isSensitiveLocalPath(path)) {
+    if (isSensitiveLocalPath(path, window.api.platform)) {
       const prompt = entry.isDirectory
         ? `"${entry.name}" may contain credentials or secrets. Open this folder anyway?`
         : `"${entry.name}" may contain credentials or secrets. Open it anyway?`
@@ -431,7 +431,7 @@ export const LocalFileBrowser = ({
               size="icon-sm"
               className={TOOLBAR_ICON_BUTTON}
               disabled={isAtRoot}
-              onClick={() => void navigate(parentLocalPath(currentPath))}
+              onClick={() => void navigate(parentLocalPath(currentPath, window.api.platform))}
               aria-label="Go to parent directory"
             >
               <ArrowLeft className="size-4" strokeWidth={TOOLBAR_ICON_STROKE} />

--- a/src/shared/local-fs.test.ts
+++ b/src/shared/local-fs.test.ts
@@ -13,10 +13,16 @@ describe('validateLocalPath', () => {
   it('accepts absolute paths', () => {
     expect(validateLocalPath('/Users/roxi/Documents')).toBeUndefined()
     expect(validateLocalPath('/')).toBeUndefined()
+    expect(validateLocalPath('C:\\Users\\roxi\\Documents')).toBeUndefined()
+    expect(validateLocalPath('C:/Users/roxi/Documents')).toBeUndefined()
+    expect(validateLocalPath('\\\\server\\share\\Documents')).toBeUndefined()
   })
 
   it('rejects non-absolute or empty input', () => {
     expect(validateLocalPath('relative/path')).toBe('not_absolute')
+    expect(validateLocalPath('C:relative\\path')).toBe('not_absolute')
+    expect(validateLocalPath('\\root-relative')).toBe('not_absolute')
+    expect(validateLocalPath('\\\\server')).toBe('not_absolute')
     expect(validateLocalPath('')).toBe('not_absolute')
     // @ts-expect-error runtime guard for non-string IPC input
     expect(validateLocalPath(undefined)).toBe('not_absolute')

--- a/src/shared/local-fs.test.ts
+++ b/src/shared/local-fs.test.ts
@@ -68,6 +68,7 @@ describe('isSensitiveLocalPath', () => {
     expect(isSensitiveLocalPath('/Users/roxi/Documents/notes.md')).toBe(false)
     expect(isSensitiveLocalPath('/Users/roxi/data.csv')).toBe(false)
     expect(isSensitiveLocalPath('/')).toBe(false)
+    expect(isSensitiveLocalPath('/tmp/folder\\.ssh')).toBe(false)
   })
 })
 
@@ -126,6 +127,7 @@ describe('resolveLocalPath', () => {
 describe('local path navigation', () => {
   it('finds parents and roots with host path semantics', () => {
     expect(parentLocalPath('/Users/roxi/Documents')).toBe('/Users/roxi')
+    expect(parentLocalPath('/tmp/folder\\name')).toBe('/tmp')
     expect(parentLocalPath('/')).toBe('/')
     expect(parentLocalPath('C:\\Users\\roxi')).toBe('C:\\Users')
     expect(parentLocalPath('C:\\')).toBe('C:\\')
@@ -138,6 +140,7 @@ describe('local path navigation', () => {
 
   it('compares Windows directories case-insensitively and ignores trailing separators', () => {
     expect(sameLocalDirectory('/Users/roxi/', '/Users/roxi')).toBe(true)
+    expect(sameLocalDirectory('/tmp/folder\\', '/tmp/folder')).toBe(false)
     expect(sameLocalDirectory('C:\\Users\\Roxi\\', 'c:\\users\\roxi')).toBe(true)
     expect(sameLocalDirectory('C:/Users/Roxi', 'c:\\users\\roxi')).toBe(true)
     expect(sameLocalDirectory('C:\\Users', 'D:\\Users')).toBe(false)

--- a/src/shared/local-fs.test.ts
+++ b/src/shared/local-fs.test.ts
@@ -14,26 +14,28 @@ import {
 
 describe('validateLocalPath', () => {
   it('accepts absolute paths', () => {
-    expect(validateLocalPath('/Users/roxi/Documents')).toBeUndefined()
-    expect(validateLocalPath('/')).toBeUndefined()
-    expect(validateLocalPath('C:\\Users\\roxi\\Documents')).toBeUndefined()
-    expect(validateLocalPath('C:/Users/roxi/Documents')).toBeUndefined()
-    expect(validateLocalPath('\\\\server\\share\\Documents')).toBeUndefined()
+    expect(validateLocalPath('/Users/roxi/Documents', 'darwin')).toBeUndefined()
+    expect(validateLocalPath('/', 'linux')).toBeUndefined()
+    expect(validateLocalPath('C:\\Users\\roxi\\Documents', 'win32')).toBeUndefined()
+    expect(validateLocalPath('C:/Users/roxi/Documents', 'win32')).toBeUndefined()
+    expect(validateLocalPath('\\\\server\\share\\Documents', 'win32')).toBeUndefined()
   })
 
   it('rejects non-absolute or empty input', () => {
-    expect(validateLocalPath('relative/path')).toBe('not_absolute')
-    expect(validateLocalPath('C:relative\\path')).toBe('not_absolute')
-    expect(validateLocalPath('\\root-relative')).toBe('not_absolute')
-    expect(validateLocalPath('\\\\server')).toBe('not_absolute')
-    expect(validateLocalPath('')).toBe('not_absolute')
+    expect(validateLocalPath('relative/path', 'linux')).toBe('not_absolute')
+    expect(validateLocalPath('C:relative\\path', 'win32')).toBe('not_absolute')
+    expect(validateLocalPath('\\root-relative', 'win32')).toBe('not_absolute')
+    expect(validateLocalPath('\\\\server', 'win32')).toBe('not_absolute')
+    expect(validateLocalPath('C:\\Users\\roxi', 'linux')).toBe('not_absolute')
+    expect(validateLocalPath('/Users/roxi', 'win32')).toBe('not_absolute')
+    expect(validateLocalPath('', 'linux')).toBe('not_absolute')
     // @ts-expect-error runtime guard for non-string IPC input
-    expect(validateLocalPath(undefined)).toBe('not_absolute')
+    expect(validateLocalPath(undefined, 'linux')).toBe('not_absolute')
   })
 
   it('rejects paths with control characters', () => {
-    expect(validateLocalPath('/Users/roxi/\x00evil')).toBe('control_chars')
-    expect(validateLocalPath('/Users/roxi/\x1ffile')).toBe('control_chars')
+    expect(validateLocalPath('/Users/roxi/\x00evil', 'linux')).toBe('control_chars')
+    expect(validateLocalPath('/Users/roxi/\x1ffile', 'linux')).toBe('control_chars')
   })
 })
 
@@ -97,23 +99,27 @@ describe('sortLocalEntries', () => {
 
 describe('resolveLocalPath', () => {
   it('returns absolute input unchanged', () => {
-    expect(resolveLocalPath('/Users/roxi', '/etc/hosts')).toBe('/etc/hosts')
+    expect(resolveLocalPath('/Users/roxi', '/etc/hosts', 'linux')).toBe('/etc/hosts')
   })
 
   it('joins relative input onto cwd', () => {
-    expect(resolveLocalPath('/Users/roxi', 'Documents')).toBe('/Users/roxi/Documents')
-    expect(resolveLocalPath('/Users/roxi/', 'Documents')).toBe('/Users/roxi/Documents')
-    expect(resolveLocalPath('/', 'etc')).toBe('/etc')
+    expect(resolveLocalPath('/Users/roxi', 'Documents', 'linux')).toBe('/Users/roxi/Documents')
+    expect(resolveLocalPath('/Users/roxi/', 'Documents', 'linux')).toBe('/Users/roxi/Documents')
+    expect(resolveLocalPath('/', 'etc', 'linux')).toBe('/etc')
   })
 
   it('returns cwd for empty input', () => {
-    expect(resolveLocalPath('/Users/roxi', '')).toBe('/Users/roxi')
+    expect(resolveLocalPath('/Users/roxi', '', 'linux')).toBe('/Users/roxi')
   })
 
   it('resolves Windows drive and UNC paths', () => {
-    expect(resolveLocalPath('C:\\Users\\roxi', 'Documents')).toBe('C:\\Users\\roxi\\Documents')
-    expect(resolveLocalPath('C:\\Users\\roxi', 'D:\\Data')).toBe('D:\\Data')
-    expect(resolveLocalPath('\\\\server\\share', 'Documents')).toBe('\\\\server\\share\\Documents')
+    expect(resolveLocalPath('C:\\Users\\roxi', 'Documents', 'win32')).toBe(
+      'C:\\Users\\roxi\\Documents'
+    )
+    expect(resolveLocalPath('C:\\Users\\roxi', 'D:\\Data', 'win32')).toBe('D:\\Data')
+    expect(resolveLocalPath('\\\\server\\share', 'Documents', 'win32')).toBe(
+      '\\\\server\\share\\Documents'
+    )
   })
 })
 

--- a/src/shared/local-fs.test.ts
+++ b/src/shared/local-fs.test.ts
@@ -2,8 +2,11 @@ import { describe, expect, it } from 'vitest'
 
 import {
   describeLocalListingError,
+  isLocalPathRoot,
   isSensitiveLocalPath,
+  parentLocalPath,
   resolveLocalPath,
+  sameLocalDirectory,
   sortLocalEntries,
   validateLocalPath,
   type LocalDirEntry
@@ -41,6 +44,7 @@ describe('isSensitiveLocalPath', () => {
     expect(isSensitiveLocalPath('/Users/roxi/.env.local')).toBe(true)
     expect(isSensitiveLocalPath('/etc/ssl/private/server.key')).toBe(true)
     expect(isSensitiveLocalPath('/Users/roxi/cert.pem')).toBe(true)
+    expect(isSensitiveLocalPath('C:\\Users\\roxi\\.ssh')).toBe(true)
   })
 
   it('flags suffix-less secret files (SSH keys, cloud credentials)', () => {
@@ -104,6 +108,33 @@ describe('resolveLocalPath', () => {
 
   it('returns cwd for empty input', () => {
     expect(resolveLocalPath('/Users/roxi', '')).toBe('/Users/roxi')
+  })
+
+  it('resolves Windows drive and UNC paths', () => {
+    expect(resolveLocalPath('C:\\Users\\roxi', 'Documents')).toBe('C:\\Users\\roxi\\Documents')
+    expect(resolveLocalPath('C:\\Users\\roxi', 'D:\\Data')).toBe('D:\\Data')
+    expect(resolveLocalPath('\\\\server\\share', 'Documents')).toBe('\\\\server\\share\\Documents')
+  })
+})
+
+describe('local path navigation', () => {
+  it('finds parents and roots with host path semantics', () => {
+    expect(parentLocalPath('/Users/roxi/Documents')).toBe('/Users/roxi')
+    expect(parentLocalPath('/')).toBe('/')
+    expect(parentLocalPath('C:\\Users\\roxi')).toBe('C:\\Users')
+    expect(parentLocalPath('C:\\')).toBe('C:\\')
+    expect(parentLocalPath('\\\\server\\share\\Documents')).toBe('\\\\server\\share')
+    expect(parentLocalPath('\\\\server\\share')).toBe('\\\\server\\share')
+    expect(isLocalPathRoot('C:\\')).toBe(true)
+    expect(isLocalPathRoot('\\\\server\\share\\')).toBe(true)
+    expect(isLocalPathRoot('C:\\Users')).toBe(false)
+  })
+
+  it('compares Windows directories case-insensitively and ignores trailing separators', () => {
+    expect(sameLocalDirectory('/Users/roxi/', '/Users/roxi')).toBe(true)
+    expect(sameLocalDirectory('C:\\Users\\Roxi\\', 'c:\\users\\roxi')).toBe(true)
+    expect(sameLocalDirectory('C:/Users/Roxi', 'c:\\users\\roxi')).toBe(true)
+    expect(sameLocalDirectory('C:\\Users', 'D:\\Users')).toBe(false)
   })
 })
 

--- a/src/shared/local-fs.test.ts
+++ b/src/shared/local-fs.test.ts
@@ -19,6 +19,7 @@ describe('validateLocalPath', () => {
     expect(validateLocalPath('C:\\Users\\roxi\\Documents', 'win32')).toBeUndefined()
     expect(validateLocalPath('C:/Users/roxi/Documents', 'win32')).toBeUndefined()
     expect(validateLocalPath('\\\\server\\share\\Documents', 'win32')).toBeUndefined()
+    expect(validateLocalPath('//server/share/Documents', 'win32')).toBeUndefined()
   })
 
   it('rejects non-absolute or empty input', () => {
@@ -41,34 +42,34 @@ describe('validateLocalPath', () => {
 
 describe('isSensitiveLocalPath', () => {
   it('flags credential dirs and files', () => {
-    expect(isSensitiveLocalPath('/Users/roxi/.ssh')).toBe(true)
-    expect(isSensitiveLocalPath('/Users/roxi/project/.env')).toBe(true)
-    expect(isSensitiveLocalPath('/Users/roxi/.env.local')).toBe(true)
-    expect(isSensitiveLocalPath('/etc/ssl/private/server.key')).toBe(true)
-    expect(isSensitiveLocalPath('/Users/roxi/cert.pem')).toBe(true)
-    expect(isSensitiveLocalPath('C:\\Users\\roxi\\.ssh')).toBe(true)
+    expect(isSensitiveLocalPath('/Users/roxi/.ssh', 'linux')).toBe(true)
+    expect(isSensitiveLocalPath('/Users/roxi/project/.env', 'linux')).toBe(true)
+    expect(isSensitiveLocalPath('/Users/roxi/.env.local', 'linux')).toBe(true)
+    expect(isSensitiveLocalPath('/etc/ssl/private/server.key', 'linux')).toBe(true)
+    expect(isSensitiveLocalPath('/Users/roxi/cert.pem', 'linux')).toBe(true)
+    expect(isSensitiveLocalPath('C:\\Users\\roxi\\.ssh', 'win32')).toBe(true)
   })
 
   it('flags suffix-less secret files (SSH keys, cloud credentials)', () => {
-    expect(isSensitiveLocalPath('/Users/roxi/.ssh/id_rsa')).toBe(true)
-    expect(isSensitiveLocalPath('/Users/roxi/.ssh/id_ed25519')).toBe(true)
-    expect(isSensitiveLocalPath('/Users/roxi/.aws/credentials')).toBe(true)
-    expect(isSensitiveLocalPath('/Users/roxi/.pgpass')).toBe(true)
-    expect(isSensitiveLocalPath('/Users/roxi/keystore.p12')).toBe(true)
+    expect(isSensitiveLocalPath('/Users/roxi/.ssh/id_rsa', 'linux')).toBe(true)
+    expect(isSensitiveLocalPath('/Users/roxi/.ssh/id_ed25519', 'linux')).toBe(true)
+    expect(isSensitiveLocalPath('/Users/roxi/.aws/credentials', 'linux')).toBe(true)
+    expect(isSensitiveLocalPath('/Users/roxi/.pgpass', 'linux')).toBe(true)
+    expect(isSensitiveLocalPath('/Users/roxi/keystore.p12', 'linux')).toBe(true)
     // case-insensitive on the basename
-    expect(isSensitiveLocalPath('/Users/roxi/.ssh/ID_RSA')).toBe(true)
+    expect(isSensitiveLocalPath('/Users/roxi/.ssh/ID_RSA', 'linux')).toBe(true)
   })
 
   it('does not flag lookalikes that are not secrets', () => {
-    expect(isSensitiveLocalPath('/Users/roxi/.ssh/id_rsa.pub')).toBe(false)
-    expect(isSensitiveLocalPath('/Users/roxi/credentials.md')).toBe(false)
+    expect(isSensitiveLocalPath('/Users/roxi/.ssh/id_rsa.pub', 'linux')).toBe(false)
+    expect(isSensitiveLocalPath('/Users/roxi/credentials.md', 'linux')).toBe(false)
   })
 
   it('treats ordinary files as non-sensitive', () => {
-    expect(isSensitiveLocalPath('/Users/roxi/Documents/notes.md')).toBe(false)
-    expect(isSensitiveLocalPath('/Users/roxi/data.csv')).toBe(false)
-    expect(isSensitiveLocalPath('/')).toBe(false)
-    expect(isSensitiveLocalPath('/tmp/folder\\.ssh')).toBe(false)
+    expect(isSensitiveLocalPath('/Users/roxi/Documents/notes.md', 'linux')).toBe(false)
+    expect(isSensitiveLocalPath('/Users/roxi/data.csv', 'linux')).toBe(false)
+    expect(isSensitiveLocalPath('/', 'linux')).toBe(false)
+    expect(isSensitiveLocalPath('/tmp/folder\\.ssh', 'linux')).toBe(false)
   })
 })
 
@@ -121,29 +122,32 @@ describe('resolveLocalPath', () => {
     expect(resolveLocalPath('\\\\server\\share', 'Documents', 'win32')).toBe(
       '\\\\server\\share\\Documents'
     )
+    expect(resolveLocalPath('C:\\Users\\roxi', '//server/share', 'win32')).toBe('//server/share')
   })
 })
 
 describe('local path navigation', () => {
   it('finds parents and roots with host path semantics', () => {
-    expect(parentLocalPath('/Users/roxi/Documents')).toBe('/Users/roxi')
-    expect(parentLocalPath('/tmp/folder\\name')).toBe('/tmp')
-    expect(parentLocalPath('/')).toBe('/')
-    expect(parentLocalPath('C:\\Users\\roxi')).toBe('C:\\Users')
-    expect(parentLocalPath('C:\\')).toBe('C:\\')
-    expect(parentLocalPath('\\\\server\\share\\Documents')).toBe('\\\\server\\share')
-    expect(parentLocalPath('\\\\server\\share')).toBe('\\\\server\\share')
-    expect(isLocalPathRoot('C:\\')).toBe(true)
-    expect(isLocalPathRoot('\\\\server\\share\\')).toBe(true)
-    expect(isLocalPathRoot('C:\\Users')).toBe(false)
+    expect(parentLocalPath('/Users/roxi/Documents', 'linux')).toBe('/Users/roxi')
+    expect(parentLocalPath('/tmp/folder\\name', 'linux')).toBe('/tmp')
+    expect(parentLocalPath('/', 'linux')).toBe('/')
+    expect(parentLocalPath('C:\\Users\\roxi', 'win32')).toBe('C:\\Users')
+    expect(parentLocalPath('C:\\', 'win32')).toBe('C:\\')
+    expect(parentLocalPath('\\\\server\\share\\Documents', 'win32')).toBe('\\\\server\\share')
+    expect(parentLocalPath('//server/share/Documents', 'win32')).toBe('//server/share')
+    expect(parentLocalPath('\\\\server\\share', 'win32')).toBe('\\\\server\\share')
+    expect(isLocalPathRoot('C:\\', 'win32')).toBe(true)
+    expect(isLocalPathRoot('//server/share/', 'win32')).toBe(true)
+    expect(isLocalPathRoot('C:\\Users', 'win32')).toBe(false)
   })
 
   it('compares Windows directories case-insensitively and ignores trailing separators', () => {
-    expect(sameLocalDirectory('/Users/roxi/', '/Users/roxi')).toBe(true)
-    expect(sameLocalDirectory('/tmp/folder\\', '/tmp/folder')).toBe(false)
-    expect(sameLocalDirectory('C:\\Users\\Roxi\\', 'c:\\users\\roxi')).toBe(true)
-    expect(sameLocalDirectory('C:/Users/Roxi', 'c:\\users\\roxi')).toBe(true)
-    expect(sameLocalDirectory('C:\\Users', 'D:\\Users')).toBe(false)
+    expect(sameLocalDirectory('/Users/roxi/', '/Users/roxi', 'linux')).toBe(true)
+    expect(sameLocalDirectory('/tmp/folder\\', '/tmp/folder', 'linux')).toBe(false)
+    expect(sameLocalDirectory('C:\\Users\\Roxi\\', 'c:\\users\\roxi', 'win32')).toBe(true)
+    expect(sameLocalDirectory('C:/Users/Roxi', 'c:\\users\\roxi', 'win32')).toBe(true)
+    expect(sameLocalDirectory('//server/share', '\\\\SERVER\\share\\', 'win32')).toBe(true)
+    expect(sameLocalDirectory('C:\\Users', 'D:\\Users', 'win32')).toBe(false)
   })
 })
 

--- a/src/shared/local-fs.ts
+++ b/src/shared/local-fs.ts
@@ -40,6 +40,11 @@ export const LOCAL_BOOKMARKS_KEY = 'local'
 // renderer responsive on huge directories (e.g. node_modules).
 export const LOCAL_DIR_ENTRY_CAP = 5000
 
+const isWindowsDrivePath = (path: string): boolean => /^[A-Za-z]:[\\/]/.test(path)
+const isWindowsUncPath = (path: string): boolean => /^\\\\[^\\/]+[\\/][^\\/]+/.test(path)
+const isWindowsLocalPath = (path: string): boolean =>
+  isWindowsDrivePath(path) || isWindowsUncPath(path)
+
 // Validates a local path before touching the filesystem. Returns an error kind or undefined.
 // The security model is "Home start, full-disk navigable": we do NOT restrict to a root, but we
 // reject non-absolute paths and paths containing ASCII control characters (which are never valid
@@ -52,10 +57,7 @@ export const validateLocalPath = (
   // eslint-disable-next-line no-control-regex
   if (/[\x00-\x1f]/.test(path)) return 'control_chars'
   const isPosixAbsolute = path.startsWith('/')
-  const isWindowsDriveAbsolute = /^[A-Za-z]:[\\/]/.test(path)
-  const isWindowsUncAbsolute = /^\\\\[^\\/]+[\\/][^\\/]+/.test(path)
-  const isAbsolute =
-    platform === 'win32' ? isWindowsDriveAbsolute || isWindowsUncAbsolute : isPosixAbsolute
+  const isAbsolute = platform === 'win32' ? isWindowsLocalPath(path) : isPosixAbsolute
   if (!isAbsolute) return 'not_absolute'
   return undefined
 }
@@ -84,7 +86,7 @@ const SENSITIVE_SUFFIXES = ['.pem', '.key', '.env', '.p12', '.pfx']
 // Returns true when a path's basename looks security-sensitive (keys, credentials, dotenv). Pure
 // so both the browser listing and the preview open path can share one definition.
 export const isSensitiveLocalPath = (path: string): boolean => {
-  const base = (path.split(/[\\/]/).pop() ?? '').toLowerCase()
+  const base = (path.split(isWindowsLocalPath(path) ? /[\\/]/ : '/').pop() ?? '').toLowerCase()
   if (!base) return false
   if (SENSITIVE_BASENAMES.has(base)) return true
   if (base.startsWith('.env')) return true
@@ -130,25 +132,27 @@ export const describeLocalListingError = (
 export const resolveLocalPath = (cwd: string, input: string, platform: string): string => {
   if (validateLocalPath(input, platform) === undefined) return input
   if (input === '') return cwd
-  const separator = /^[A-Za-z]:[\\/]|^\\\\/.test(cwd) ? '\\' : '/'
-  const base = cwd.replace(/[\\/]+$/, '')
+  const windows = isWindowsLocalPath(cwd)
+  const separator = windows ? '\\' : '/'
+  const base = cwd.replace(windows ? /[\\/]+$/ : /\/+$/, '')
   return `${base}${separator}${input}`
 }
 
 const localPathRoot = (path: string): string => {
-  if (/^[A-Za-z]:[\\/]/.test(path)) return path.slice(0, 3)
+  if (isWindowsDrivePath(path)) return path.slice(0, 3)
   return path.match(/^\\\\[^\\/]+[\\/][^\\/]+/)?.[0] ?? '/'
 }
 
 const withoutTrailingSeparators = (path: string): string => {
   const root = localPathRoot(path)
-  return path.length > root.length ? path.replace(/[\\/]+$/, '') : root
+  if (path.length <= root.length) return root
+  return path.replace(isWindowsLocalPath(path) ? /[\\/]+$/ : /\/+$/, '')
 }
 
 export const sameLocalDirectory = (a: string, b: string): boolean => {
   const left = withoutTrailingSeparators(a)
   const right = withoutTrailingSeparators(b)
-  if (!/^[A-Za-z]:[\\/]|^\\\\/.test(left)) return left === right
+  if (!isWindowsLocalPath(left)) return left === right
   return left.replace(/\//g, '\\').toLowerCase() === right.replace(/\//g, '\\').toLowerCase()
 }
 
@@ -156,7 +160,9 @@ export const parentLocalPath = (path: string): string => {
   const root = localPathRoot(path)
   const normalized = withoutTrailingSeparators(path)
   if (sameLocalDirectory(normalized, root)) return root
-  const separator = Math.max(normalized.lastIndexOf('/'), normalized.lastIndexOf('\\'))
+  const separator = isWindowsLocalPath(normalized)
+    ? Math.max(normalized.lastIndexOf('/'), normalized.lastIndexOf('\\'))
+    : normalized.lastIndexOf('/')
   return separator < root.length ? root : normalized.slice(0, separator)
 }
 

--- a/src/shared/local-fs.ts
+++ b/src/shared/local-fs.ts
@@ -79,7 +79,7 @@ const SENSITIVE_SUFFIXES = ['.pem', '.key', '.env', '.p12', '.pfx']
 // Returns true when a path's basename looks security-sensitive (keys, credentials, dotenv). Pure
 // so both the browser listing and the preview open path can share one definition.
 export const isSensitiveLocalPath = (path: string): boolean => {
-  const base = (path.split('/').pop() ?? '').toLowerCase()
+  const base = (path.split(/[\\/]/).pop() ?? '').toLowerCase()
   if (!base) return false
   if (SENSITIVE_BASENAMES.has(base)) return true
   if (base.startsWith('.env')) return true
@@ -123,8 +123,37 @@ export const describeLocalListingError = (
 // Resolves an address-bar input to an absolute path, lexically joining relative input onto cwd.
 // The main process still calls realpath to canonicalize '..' and symlinks.
 export const resolveLocalPath = (cwd: string, input: string): string => {
-  if (input.startsWith('/')) return input
+  if (validateLocalPath(input) === undefined) return input
   if (input === '') return cwd
-  const base = cwd.endsWith('/') ? cwd.slice(0, -1) : cwd
-  return `${base}/${input}`
+  const separator = /^[A-Za-z]:[\\/]|^\\\\/.test(cwd) ? '\\' : '/'
+  const base = cwd.replace(/[\\/]+$/, '')
+  return `${base}${separator}${input}`
 }
+
+const localPathRoot = (path: string): string => {
+  if (/^[A-Za-z]:[\\/]/.test(path)) return path.slice(0, 3)
+  return path.match(/^\\\\[^\\/]+[\\/][^\\/]+/)?.[0] ?? '/'
+}
+
+const withoutTrailingSeparators = (path: string): string => {
+  const root = localPathRoot(path)
+  return path.length > root.length ? path.replace(/[\\/]+$/, '') : root
+}
+
+export const sameLocalDirectory = (a: string, b: string): boolean => {
+  const left = withoutTrailingSeparators(a)
+  const right = withoutTrailingSeparators(b)
+  if (!/^[A-Za-z]:[\\/]|^\\\\/.test(left)) return left === right
+  return left.replace(/\//g, '\\').toLowerCase() === right.replace(/\//g, '\\').toLowerCase()
+}
+
+export const parentLocalPath = (path: string): string => {
+  const root = localPathRoot(path)
+  const normalized = withoutTrailingSeparators(path)
+  if (sameLocalDirectory(normalized, root)) return root
+  const separator = Math.max(normalized.lastIndexOf('/'), normalized.lastIndexOf('\\'))
+  return separator < root.length ? root : normalized.slice(0, separator)
+}
+
+export const isLocalPathRoot = (path: string): boolean =>
+  sameLocalDirectory(path, localPathRoot(path))

--- a/src/shared/local-fs.ts
+++ b/src/shared/local-fs.ts
@@ -44,14 +44,19 @@ export const LOCAL_DIR_ENTRY_CAP = 5000
 // The security model is "Home start, full-disk navigable": we do NOT restrict to a root, but we
 // reject non-absolute paths and paths containing ASCII control characters (which are never valid
 // path components and would indicate a crafted/garbled input).
-export const validateLocalPath = (path: string): 'not_absolute' | 'control_chars' | undefined => {
+export const validateLocalPath = (
+  path: string,
+  platform: string
+): 'not_absolute' | 'control_chars' | undefined => {
   if (typeof path !== 'string' || path.length === 0) return 'not_absolute'
   // eslint-disable-next-line no-control-regex
   if (/[\x00-\x1f]/.test(path)) return 'control_chars'
   const isPosixAbsolute = path.startsWith('/')
   const isWindowsDriveAbsolute = /^[A-Za-z]:[\\/]/.test(path)
   const isWindowsUncAbsolute = /^\\\\[^\\/]+[\\/][^\\/]+/.test(path)
-  if (!isPosixAbsolute && !isWindowsDriveAbsolute && !isWindowsUncAbsolute) return 'not_absolute'
+  const isAbsolute =
+    platform === 'win32' ? isWindowsDriveAbsolute || isWindowsUncAbsolute : isPosixAbsolute
+  if (!isAbsolute) return 'not_absolute'
   return undefined
 }
 
@@ -122,8 +127,8 @@ export const describeLocalListingError = (
 
 // Resolves an address-bar input to an absolute path, lexically joining relative input onto cwd.
 // The main process still calls realpath to canonicalize '..' and symlinks.
-export const resolveLocalPath = (cwd: string, input: string): string => {
-  if (validateLocalPath(input) === undefined) return input
+export const resolveLocalPath = (cwd: string, input: string, platform: string): string => {
+  if (validateLocalPath(input, platform) === undefined) return input
   if (input === '') return cwd
   const separator = /^[A-Za-z]:[\\/]|^\\\\/.test(cwd) ? '\\' : '/'
   const base = cwd.replace(/[\\/]+$/, '')

--- a/src/shared/local-fs.ts
+++ b/src/shared/local-fs.ts
@@ -41,9 +41,9 @@ export const LOCAL_BOOKMARKS_KEY = 'local'
 export const LOCAL_DIR_ENTRY_CAP = 5000
 
 const isWindowsDrivePath = (path: string): boolean => /^[A-Za-z]:[\\/]/.test(path)
-const isWindowsUncPath = (path: string): boolean => /^\\\\[^\\/]+[\\/][^\\/]+/.test(path)
-const isWindowsLocalPath = (path: string): boolean =>
-  isWindowsDrivePath(path) || isWindowsUncPath(path)
+const isWindowsUncPath = (path: string): boolean => /^[\\/]{2}[^\\/]+[\\/][^\\/]+/.test(path)
+const isWindowsLocalPath = (path: string, platform: string): boolean =>
+  platform === 'win32' && (isWindowsDrivePath(path) || isWindowsUncPath(path))
 
 // Validates a local path before touching the filesystem. Returns an error kind or undefined.
 // The security model is "Home start, full-disk navigable": we do NOT restrict to a root, but we
@@ -57,7 +57,7 @@ export const validateLocalPath = (
   // eslint-disable-next-line no-control-regex
   if (/[\x00-\x1f]/.test(path)) return 'control_chars'
   const isPosixAbsolute = path.startsWith('/')
-  const isAbsolute = platform === 'win32' ? isWindowsLocalPath(path) : isPosixAbsolute
+  const isAbsolute = platform === 'win32' ? isWindowsLocalPath(path, platform) : isPosixAbsolute
   if (!isAbsolute) return 'not_absolute'
   return undefined
 }
@@ -85,8 +85,10 @@ const SENSITIVE_SUFFIXES = ['.pem', '.key', '.env', '.p12', '.pfx']
 
 // Returns true when a path's basename looks security-sensitive (keys, credentials, dotenv). Pure
 // so both the browser listing and the preview open path can share one definition.
-export const isSensitiveLocalPath = (path: string): boolean => {
-  const base = (path.split(isWindowsLocalPath(path) ? /[\\/]/ : '/').pop() ?? '').toLowerCase()
+export const isSensitiveLocalPath = (path: string, platform: string): boolean => {
+  const base = (
+    path.split(isWindowsLocalPath(path, platform) ? /[\\/]/ : '/').pop() ?? ''
+  ).toLowerCase()
   if (!base) return false
   if (SENSITIVE_BASENAMES.has(base)) return true
   if (base.startsWith('.env')) return true
@@ -132,39 +134,39 @@ export const describeLocalListingError = (
 export const resolveLocalPath = (cwd: string, input: string, platform: string): string => {
   if (validateLocalPath(input, platform) === undefined) return input
   if (input === '') return cwd
-  const windows = isWindowsLocalPath(cwd)
+  const windows = isWindowsLocalPath(cwd, platform)
   const separator = windows ? '\\' : '/'
   const base = cwd.replace(windows ? /[\\/]+$/ : /\/+$/, '')
   return `${base}${separator}${input}`
 }
 
-const localPathRoot = (path: string): string => {
+const localPathRoot = (path: string, platform: string): string => {
   if (isWindowsDrivePath(path)) return path.slice(0, 3)
-  return path.match(/^\\\\[^\\/]+[\\/][^\\/]+/)?.[0] ?? '/'
+  return (platform === 'win32' ? path.match(/^[\\/]{2}[^\\/]+[\\/][^\\/]+/)?.[0] : undefined) ?? '/'
 }
 
-const withoutTrailingSeparators = (path: string): string => {
-  const root = localPathRoot(path)
+const withoutTrailingSeparators = (path: string, platform: string): string => {
+  const root = localPathRoot(path, platform)
   if (path.length <= root.length) return root
-  return path.replace(isWindowsLocalPath(path) ? /[\\/]+$/ : /\/+$/, '')
+  return path.replace(isWindowsLocalPath(path, platform) ? /[\\/]+$/ : /\/+$/, '')
 }
 
-export const sameLocalDirectory = (a: string, b: string): boolean => {
-  const left = withoutTrailingSeparators(a)
-  const right = withoutTrailingSeparators(b)
-  if (!isWindowsLocalPath(left)) return left === right
+export const sameLocalDirectory = (a: string, b: string, platform: string): boolean => {
+  const left = withoutTrailingSeparators(a, platform)
+  const right = withoutTrailingSeparators(b, platform)
+  if (!isWindowsLocalPath(left, platform)) return left === right
   return left.replace(/\//g, '\\').toLowerCase() === right.replace(/\//g, '\\').toLowerCase()
 }
 
-export const parentLocalPath = (path: string): string => {
-  const root = localPathRoot(path)
-  const normalized = withoutTrailingSeparators(path)
-  if (sameLocalDirectory(normalized, root)) return root
-  const separator = isWindowsLocalPath(normalized)
+export const parentLocalPath = (path: string, platform: string): string => {
+  const root = localPathRoot(path, platform)
+  const normalized = withoutTrailingSeparators(path, platform)
+  if (sameLocalDirectory(normalized, root, platform)) return root
+  const separator = isWindowsLocalPath(normalized, platform)
     ? Math.max(normalized.lastIndexOf('/'), normalized.lastIndexOf('\\'))
     : normalized.lastIndexOf('/')
   return separator < root.length ? root : normalized.slice(0, separator)
 }
 
-export const isLocalPathRoot = (path: string): boolean =>
-  sameLocalDirectory(path, localPathRoot(path))
+export const isLocalPathRoot = (path: string, platform: string): boolean =>
+  sameLocalDirectory(path, localPathRoot(path, platform), platform)

--- a/src/shared/local-fs.ts
+++ b/src/shared/local-fs.ts
@@ -45,9 +45,13 @@ export const LOCAL_DIR_ENTRY_CAP = 5000
 // reject non-absolute paths and paths containing ASCII control characters (which are never valid
 // path components and would indicate a crafted/garbled input).
 export const validateLocalPath = (path: string): 'not_absolute' | 'control_chars' | undefined => {
-  if (typeof path !== 'string' || path.length === 0 || !path.startsWith('/')) return 'not_absolute'
+  if (typeof path !== 'string' || path.length === 0) return 'not_absolute'
   // eslint-disable-next-line no-control-regex
   if (/[\x00-\x1f]/.test(path)) return 'control_chars'
+  const isPosixAbsolute = path.startsWith('/')
+  const isWindowsDriveAbsolute = /^[A-Za-z]:[\\/]/.test(path)
+  const isWindowsUncAbsolute = /^\\\\[^\\/]+[\\/][^\\/]+/.test(path)
+  if (!isPosixAbsolute && !isWindowsDriveAbsolute && !isWindowsUncAbsolute) return 'not_absolute'
   return undefined
 }
 


### PR DESCRIPTION
## Problem

The advisory Windows full-test workflow repeatedly failed nine tests across local filesystem browsing, local-path uploads, and notebook package listing. The shared local-path validator only recognized POSIX absolute paths, while Unix notebook fixtures implicitly used the host runner's Windows path semantics.

## Proposed change

- Accept POSIX, Windows drive, and Windows UNC absolute paths in `validateLocalPath`.
- Keep rejecting drive-relative, root-relative, incomplete UNC, empty, and control-character paths.
- Make Unix notebook package-listing tests explicitly simulate Linux path semantics.

## Scope and non-goals

This change is limited to cross-platform path validation and test platform isolation. It does not change filesystem access policy, upload ownership, or package-listing dispatch behavior.

## Acceptance criteria and validation

All checks below ran after the final material edit:

- Windows absolute local paths are accepted and malformed variants remain rejected -> `node /Users/eweno/projects/aipoch/open-science/node_modules/vitest/vitest.mjs run src/shared/local-fs.test.ts src/main/local-fs/service.test.ts src/main/notebook/package-listing.test.ts src/main/uploads/ipc.test.ts` -> 4 files passed, 61 tests passed.
- Node and renderer types remain valid -> `npm run typecheck` -> passed.
- Changed code satisfies repository lint rules -> `npm run lint` -> passed.
- Repository behavior remains green -> `npm test` -> passed.

Uncovered risk: the fix was validated on macOS with explicit Windows path fixtures; the GitHub-hosted Windows workflow provides the final native-Windows confirmation.

## Review focus

- Windows drive and UNC absolute-path recognition boundaries.
- Explicit Linux platform injection in POSIX notebook fixtures.
