### PR TITLE
ci(actions): pin and maintain workflow dependencies

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -17,4 +17,4 @@ updates:
     directory: /
     schedule:
       interval: weekly
-    open-pull-requests-limit: 0
+    open-pull-requests-limit: 2

--- a/.github/workflows/ai-codex-review.yml
+++ b/.github/workflows/ai-codex-review.yml
@@ -312,7 +312,7 @@ jobs:
           } >> "$GITHUB_OUTPUT"
 
       - name: Checkout pull request review commit
-        uses: actions/checkout@v7
+        uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7
         with:
           ref: ${{ inputs.review_event == 'pull_request_target' && format('refs/pull/{0}/merge', inputs.pull_request_number) || inputs.review_sha }}
           fetch-depth: 0
@@ -711,7 +711,7 @@ jobs:
 
       - name: Normalize Codex review
         id: normalize
-        uses: actions/github-script@v9
+        uses: actions/github-script@3a2844b7e9c422d3c10d287c895573f7108da1b3 # v9
         env:
           CODEX_FINAL_MESSAGE: ${{ steps.run_codex.outputs.final-message }}
           REVIEW_HEADER: ${{ steps.review_inputs.outputs.review_header }}

--- a/.github/workflows/ai-post-review.yml
+++ b/.github/workflows/ai-post-review.yml
@@ -44,7 +44,7 @@ jobs:
     steps:
       - name: Post Codex review
         id: post
-        uses: actions/github-script@v9
+        uses: actions/github-script@3a2844b7e9c422d3c10d287c895573f7108da1b3 # v9
         env:
           REVIEW_BODY: ${{ inputs.review_body }}
           REVIEW_HEADER: ${{ inputs.header }}

--- a/.github/workflows/ai-review-labels.yml
+++ b/.github/workflows/ai-review-labels.yml
@@ -22,7 +22,7 @@ jobs:
       pull-requests: write
     steps:
       - name: Remove stale review outcome labels
-        uses: actions/github-script@v9
+        uses: actions/github-script@3a2844b7e9c422d3c10d287c895573f7108da1b3 # v9
         with:
           github-token: ${{ github.token }}
           script: |
@@ -54,7 +54,7 @@ jobs:
       pull-requests: write
     steps:
       - name: Label the pull request from its conventional type
-        uses: actions/github-script@v9
+        uses: actions/github-script@3a2844b7e9c422d3c10d287c895573f7108da1b3 # v9
         with:
           github-token: ${{ github.token }}
           script: |

--- a/.github/workflows/ai-review-single.yml
+++ b/.github/workflows/ai-review-single.yml
@@ -288,7 +288,7 @@ jobs:
       pull-requests: write
     steps:
       - name: Apply ready-to-merge from published review outputs
-        uses: actions/github-script@v9
+        uses: actions/github-script@3a2844b7e9c422d3c10d287c895573f7108da1b3 # v9
         env:
           PR_NUMBER: ${{ needs.review_target.outputs.number }}
           REVIEW_HEAD_SHA: ${{ needs.review_target.outputs.head_sha }}

--- a/.github/workflows/ai-review.yml
+++ b/.github/workflows/ai-review.yml
@@ -352,7 +352,7 @@ jobs:
       pull-requests: write
     steps:
       - name: Apply ready-to-merge from published review outputs
-        uses: actions/github-script@v9
+        uses: actions/github-script@3a2844b7e9c422d3c10d287c895573f7108da1b3 # v9
         env:
           PR_NUMBER: ${{ needs.review_target.outputs.number }}
           REVIEW_HEAD_SHA: ${{ needs.review_target.outputs.head_sha }}

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -42,10 +42,10 @@ jobs:
     runs-on: macos-14
     steps:
       - name: Checkout
-        uses: actions/checkout@v7
+        uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7
 
       - name: Setup Node
-        uses: actions/setup-node@v7
+        uses: actions/setup-node@820762786026740c76f36085b0efc47a31fe5020 # v7
         with:
           node-version: 22
           cache: npm
@@ -114,10 +114,10 @@ jobs:
 
     steps:
       - name: Checkout
-        uses: actions/checkout@v7
+        uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7
 
       - name: Setup Node
-        uses: actions/setup-node@v7
+        uses: actions/setup-node@820762786026740c76f36085b0efc47a31fe5020 # v7
         with:
           node-version: 22
           cache: npm
@@ -234,7 +234,7 @@ jobs:
 
       # Upload only the distributables + electron-updater metadata for the caller's publish job.
       - name: Upload build artifacts
-        uses: actions/upload-artifact@v7
+        uses: actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a # v7
         with:
           name: ${{ matrix.name }}
           retention-days: 1

--- a/.github/workflows/nightly.yml
+++ b/.github/workflows/nightly.yml
@@ -36,10 +36,10 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - name: Checkout
-        uses: actions/checkout@v7
+        uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7
 
       - name: Download all build artifacts
-        uses: actions/download-artifact@v8
+        uses: actions/download-artifact@3e5f45b2cfb9172054b4087a40e8e0b5a5461e7c # v8
         with:
           path: artifacts
           merge-multiple: true
@@ -62,7 +62,7 @@ jobs:
         run: gh release delete nightly --cleanup-tag --yes || true
 
       - name: Publish nightly pre-release
-        uses: softprops/action-gh-release@v3
+        uses: softprops/action-gh-release@3d0d9888cb7fd7b750713d6e236d1fcb99157228 # v3
         with:
           tag_name: nightly
           target_commitish: ${{ github.sha }}

--- a/.github/workflows/notarize-mac.yml
+++ b/.github/workflows/notarize-mac.yml
@@ -80,7 +80,7 @@ jobs:
       # Call path (from_run): pull this run's signed artifacts for the arch (uploaded by build.yml).
       - name: Download signed mac artifact (from this run)
         if: steps.gate.outputs.enabled == 'true' && inputs.from_run
-        uses: actions/download-artifact@v8
+        uses: actions/download-artifact@3e5f45b2cfb9172054b4087a40e8e0b5a5461e7c # v8
         with:
           name: macos-${{ matrix.arch }}
           path: mac
@@ -222,7 +222,7 @@ jobs:
       # (v1 does full-zip mac updates), leaving the dmg, zip, and per-arch feed.
       - name: Re-emit stapled artifact (for publish)
         if: steps.gate.outputs.enabled == 'true' && inputs.from_run
-        uses: actions/upload-artifact@v7
+        uses: actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a # v7
         with:
           name: macos-${{ matrix.arch }}
           overwrite: true
@@ -254,7 +254,7 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - name: Checkout (for the mac-feed merge script)
-        uses: actions/checkout@v7
+        uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7
 
       - name: Recompute + upload SHA256SUMS.txt
         env:

--- a/.github/workflows/publish-npm.yml
+++ b/.github/workflows/publish-npm.yml
@@ -22,12 +22,12 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - name: Checkout
-        uses: actions/checkout@v7
+        uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7
         with:
           fetch-depth: 0
 
       - name: Setup Node
-        uses: actions/setup-node@v7
+        uses: actions/setup-node@820762786026740c76f36085b0efc47a31fe5020 # v7
         with:
           # npm trusted publishing requires npm CLI 11.5.1 or later; Node 24 ships a compatible CLI.
           node-version: 24
@@ -64,7 +64,7 @@ jobs:
         run: npm publish npm-package/*.tgz --dry-run --access public
 
       - name: Upload verified tarball
-        uses: actions/upload-artifact@v7
+        uses: actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a # v7
         with:
           name: open-science-npm-package
           path: npm-package/*.tgz
@@ -82,13 +82,13 @@ jobs:
       id-token: write
     steps:
       - name: Download verified tarball
-        uses: actions/download-artifact@v8
+        uses: actions/download-artifact@3e5f45b2cfb9172054b4087a40e8e0b5a5461e7c # v8
         with:
           name: open-science-npm-package
           path: npm-package
 
       - name: Setup Node
-        uses: actions/setup-node@v7
+        uses: actions/setup-node@820762786026740c76f36085b0efc47a31fe5020 # v7
         with:
           node-version: 24
 

--- a/.github/workflows/stage-runtime-bundle.yml
+++ b/.github/workflows/stage-runtime-bundle.yml
@@ -57,10 +57,10 @@ jobs:
             runner_subdir: win-64
     steps:
       - name: Checkout
-        uses: actions/checkout@v7
+        uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7
 
       - name: Setup Node
-        uses: actions/setup-node@v7
+        uses: actions/setup-node@820762786026740c76f36085b0efc47a31fe5020 # v7
         with:
           node-version: 22
           cache: npm

--- a/.github/workflows/windows-full-test.yml
+++ b/.github/workflows/windows-full-test.yml
@@ -37,10 +37,10 @@ jobs:
         shard: [1, 2]
     steps:
       - name: Checkout
-        uses: actions/checkout@v7
+        uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7
 
       - name: Setup Node
-        uses: actions/setup-node@v7
+        uses: actions/setup-node@820762786026740c76f36085b0efc47a31fe5020 # v7
         with:
           node-version: 22
           cache: npm


### PR DESCRIPTION
## Problem

Eleven workflows still referenced 27 external Actions through mutable major-version tags. Those tags can move independently of this repository, so the same repository commit can execute different upstream code over time. GitHub Actions Dependabot was also configured with `open-pull-requests-limit: 0`, which disabled automated Action update PRs.

## Proposed change

- Pin all 27 remaining mutable external Action references to freshly verified 40-character commit SHAs while preserving readable version comments.
- Use the peeled commit for the annotated `actions/github-script@v9` and `softprops/action-gh-release@v3` tags.
- Change only the GitHub Actions Dependabot `open-pull-requests-limit` from `0` to `2` so pinned references can receive bounded update PRs.

## Scope and non-goals

This is a mechanical supply-chain change. It does not change workflow triggers, jobs, steps, permissions, runners, Node versions, local reusable workflow references, or application behavior. The npm Dependabot limit remains `0`, and no Action major version is upgraded.

## Acceptance criteria and validation

- Mutable external Action references: 27 before, 0 after.
- All 67 external references across the repository use full commit SHAs; all 11 local `./` references remain local.
- Direct CI Integrity check against the complete branch diff: pass, 0 violations.
- Workflow and CI Integrity tests: 106/106 passed.
- Structured YAML comparison confirms the 11 workflows differ only in external `uses` references.
- Upstream tags were re-resolved immediately before the change; annotated tags use their peeled commits.
- Prettier, typecheck, ESLint, and `git diff --check` passed.

## Review focus

Please focus on the Action tag-to-commit mapping, especially the two annotated tags, and confirm that `.github/dependabot.yml` changes only the GitHub Actions ecosystem limit. GitHub-hosted PR checks are the final execution proof for the pinned references.
