### PR TITLE
refactor(notebook): compose application-owned runtime capabilities

### DIFF
--- a/packages/open-science/cli.test.ts
+++ b/packages/open-science/cli.test.ts
@@ -5,6 +5,7 @@ import {
   parseCliArgs,
   reportCliError,
   rollbackCommand,
+  runCli,
   runTaskCommand
 } from './cli.mjs'
 
@@ -466,13 +467,16 @@ describe('task CLI', () => {
     expect(client).not.toHaveProperty('cancelRun')
   })
 
-  it('keeps permission approval, Specialist, and Compute management outside the CLI', async () => {
-    const connect = vi.fn().mockResolvedValue({})
-
-    for (const command of ['permission', 'specialist', 'compute']) {
-      await expect(
-        runTaskCommand({ command, options: { json: false } }, { connect, stdinIsTTY: true })
-      ).rejects.toThrow(`Unknown command: ${command}`)
+  it('keeps capability management surfaces outside the CLI', async () => {
+    for (const command of [
+      'permission',
+      'specialist',
+      'compute',
+      'notebook',
+      'notebook-env',
+      'runtime'
+    ]) {
+      await expect(runCli([command])).rejects.toThrow(`Unknown command: ${command}`)
     }
   })
 

--- a/packages/open-science/client.test.ts
+++ b/packages/open-science/client.test.ts
@@ -151,6 +151,9 @@ describe('OpenScienceClient', () => {
     expect(client).not.toHaveProperty('permissions')
     expect(client).not.toHaveProperty('specialists')
     expect(client).not.toHaveProperty('compute')
+    expect(client).not.toHaveProperty('notebook')
+    expect(client).not.toHaveProperty('notebookEnv')
+    expect(client).not.toHaveProperty('runtime')
   })
 
   it('surfaces stable API errors without including the authentication token', async () => {

--- a/src/main/acp/ipc.ts
+++ b/src/main/acp/ipc.ts
@@ -18,21 +18,9 @@ import type {
   AcpRevokePermissionGrantRequest,
   AcpSetPermissionProfileRequest
 } from '../../shared/acp'
-import { DEFAULT_ARTIFACT_PROJECT_NAME } from '../../shared/artifacts'
 import { AcpRuntimeCoordinator } from './runtime-coordinator'
 import type { AcpHandlerWorkflows } from './handler-workflows'
 import { installAgentShutdownGuard } from './shutdown-guard'
-import { ArtifactRepository } from '../artifacts/repository'
-import { NotebookRunRepository } from '../notebook/repository'
-import {
-  NotebookRuntimeService,
-  type NotebookRuntimeServiceOptions
-} from '../notebook/runtime-service'
-import { resolveConfigRoot, resolveDataRoot } from '../storage-root'
-import { broadcastToRenderers } from '../renderer-broadcast'
-
-// Sends one runtime payload through the typed application-event compatibility facade.
-const broadcast = broadcastToRenderers
 
 const registerAcpIpcHandlerSet = (
   runtime: AcpRuntimeCoordinator,
@@ -95,38 +83,4 @@ const installAcpIpcHandlers = (
   }
 }
 
-// Creates the shared notebook runtime used by both renderer IPC and agent MCP calls.
-type DefaultNotebookRuntimeServiceDeps = Pick<
-  NotebookRuntimeServiceOptions,
-  'getPackageMirror' | 'notebookRuntimeSettings'
->
-
-const createDefaultNotebookRuntimeService = (
-  deps: DefaultNotebookRuntimeServiceDeps = {}
-): NotebookRuntimeService => {
-  const dataRoot = resolveDataRoot()
-  const artifactRepository = new ArtifactRepository(dataRoot)
-
-  return new NotebookRuntimeService({
-    configRoot: resolveConfigRoot(),
-    dataRoot,
-    projectName: DEFAULT_ARTIFACT_PROJECT_NAME,
-    repository: new NotebookRunRepository(dataRoot),
-    ...deps,
-    // Region default for manage_packages when no mirror is configured.
-    locale: app.getLocale(),
-    appVersion: app.getVersion(),
-    resolveArtifactPath: (request) =>
-      artifactRepository.resolveSessionArtifactFilePath(
-        request.projectName,
-        request.sessionId,
-        request.path
-      ),
-    callbacks: {
-      onNotebookAvailable: (event) => broadcast('notebook:available', event),
-      onNotebookChanged: (event) => broadcast('notebook:changed', event)
-    }
-  })
-}
-
-export { createDefaultNotebookRuntimeService, installAcpIpcHandlers }
+export { installAcpIpcHandlers }

--- a/src/main/ipc.ts
+++ b/src/main/ipc.ts
@@ -11,7 +11,6 @@ import {
 } from './application-runtime'
 import { createApplicationEventModule, type ApplicationEventSource } from './application-events'
 
-import { createDefaultNotebookRuntimeService } from './acp/ipc'
 import { createAcpRuntime } from './acp/runtime-composition'
 import { createAcpCreateSessionWorkflow } from './acp/create-session-workflow'
 import { createAcpHandlerWorkflows } from './acp/handler-workflows'
@@ -53,11 +52,14 @@ import {
 } from './notifications/electron-wiring'
 import { createLogger, diagnosticErrorFields, errorLogFields } from './logger'
 import { startDiagnosticOperation } from './diagnostics/operation'
+import { broadcastNotebookEnvProgress, registerNotebookEnvIpcHandlers } from './notebook/env-ipc'
 import {
-  broadcastNotebookEnvProgress,
-  registerNotebookEnvIpcHandlers,
-  serializeProvisioner
-} from './notebook/env-ipc'
+  createNotebookApplicationModule,
+  createNotebookLocalRpcModule,
+  installNotebookEnvironmentSurface
+} from './notebook/application'
+import { serializeProvisioner } from './notebook/environment-operation-foundation'
+import { createNotebookEnvironmentLifecycle } from './notebook/environment-lifecycle-workflows'
 import { registerManagedPreviewIpcHandlers } from './managed-preview-ipc'
 import { registerManagedPreviewProtocol } from './managed-preview-protocol'
 import { ManagedPreviewResources } from './managed-preview-resources'
@@ -74,11 +76,12 @@ import {
 import { OfficePreviewSupervisor } from './office-preview/office-preview-supervisor'
 import { registerNotebookIpcHandlers } from './notebook/ipc'
 import { registerRuntimeIpcHandlers } from './notebook/runtime-ipc'
-import { getRuntimeRoot } from './notebook/repository'
+import { NotebookRunRepository, getRuntimeRoot } from './notebook/repository'
 import { NotebookLocalRpcServer } from './notebook/local-rpc-server'
 import { NotebookInputRegistry } from './notebook/input-registry'
 import { effectiveMirrorAsync } from './notebook/mirror-probe'
 import { createProductionProvisioner, type RuntimeProvisioner } from './notebook/provisioner'
+import { createRuntimeSelectionWorkflows } from './notebook/runtime-selection-workflows'
 import { runtimeRoot } from './notebook/runtime-paths'
 import type { NotebookEnvironmentManager } from './notebook/runtime-service'
 import { parseArtifactVersionLocator } from '../shared/artifact-provenance'
@@ -158,6 +161,7 @@ import { detectActiveSessions } from './storage/detect-active'
 import {
   computeDefaultDataRoot,
   initDataRoot,
+  resolveConfigRoot,
   resolveDataRoot,
   resolveStorageRoot,
   samePath
@@ -482,24 +486,33 @@ const createApplicationModules = async (
       }
     }
   }
-  const notebookService = await modules.add(
+  const notebookApplication = await modules.add(
     {
+      configRoot: resolveConfigRoot(),
+      dataRoot: resolveDataRoot(),
+      projectName: DEFAULT_ARTIFACT_PROJECT_NAME,
+      repository: new NotebookRunRepository(resolveDataRoot()),
       getPackageMirror: () => settingsService.getPackageMirror(),
-      notebookRuntimeSettings
+      notebookRuntimeSettings,
+      locale: app.getLocale(),
+      appVersion: app.getVersion(),
+      resolveArtifactPath: (request: { projectName: string; sessionId: string; path: string }) =>
+        artifactRepository.resolveSessionArtifactFilePath(
+          request.projectName,
+          request.sessionId,
+          request.path
+        ),
+      events: applicationEvents,
+      disposeTimeoutMs: QUIT_SHUTDOWN_BUDGET_MS,
+      isBackendTeardownOwned: () => backendTeardownOwnedByCoordinator
     },
-    (settings) => {
-      const notebook = createDefaultNotebookRuntimeService(settings)
-      return {
-        name: 'notebook-runtime',
-        capability: notebook,
-        disposeTimeoutMs: QUIT_SHUTDOWN_BUDGET_MS,
-        rollback: () =>
-          backendTeardownOwnedByCoordinator
-            ? undefined
-            : notebook.shutdownAll().then(() => undefined)
-      }
-    }
+    createNotebookApplicationModule
   )
+  const {
+    runtime: notebookService,
+    commands: notebookCommands,
+    localRpc: notebookLocalRpc
+  } = notebookApplication
 
   // Resolved lazily per connector call so dispatch always sees the latest persisted Specialist profile.
   const profileService = createProfileService(resolveStorageRoot())
@@ -780,28 +793,34 @@ const createApplicationModules = async (
       await sessionPersistenceCoordinator.saveSessionSpecialistBinding(session, specialistId)
     }
   })
-  const notebookRpcServer = new NotebookLocalRpcServer(notebookService, {
-    onSessionReleased: (sessionId) => completionGateCoordinator.releaseSession(sessionId),
-    connectorService,
-    computeService: computeServiceWithRegistry,
-    skillImporter: conversationSkillImporter,
-    artifactProvenance: {
-      createVersion: (request) =>
-        sessionPersistenceCoordinator.runSessionMutation(
-          request.projectId,
-          request.appSessionId,
-          () => artifactProvenanceRepository.createVersion(request)
-        ),
-      replayVersion: (request) =>
-        sessionPersistenceCoordinator.runSessionMutation(
-          request.projectId,
-          request.appSessionId,
-          () => artifactProvenanceRepository.replayVersion(request)
-        )
-    },
-    inputRegistry: notebookInputRegistry,
-    agentsService
-  })
+  const notebookRpcServer = await modules.add(
+    new NotebookLocalRpcServer(notebookLocalRpc, {
+      onSessionReleased: (sessionId) => completionGateCoordinator.releaseSession(sessionId),
+      connectorService,
+      computeService: computeServiceWithRegistry,
+      skillImporter: conversationSkillImporter,
+      artifactProvenance: {
+        createVersion: (request) =>
+          sessionPersistenceCoordinator.runSessionMutation(
+            request.projectId,
+            request.appSessionId,
+            () => artifactProvenanceRepository.createVersion(request)
+          ),
+        replayVersion: (request) =>
+          sessionPersistenceCoordinator.runSessionMutation(
+            request.projectId,
+            request.appSessionId,
+            () => artifactProvenanceRepository.replayVersion(request)
+          )
+      },
+      inputRegistry: notebookInputRegistry,
+      agentsService
+    }),
+    createNotebookLocalRpcModule
+  )
+  // Register ownership before ACP construction. Reverse disposal therefore drains ACP + Notebook
+  // through the coordinator first, then releases the local bridge without creating a second runtime
+  // shutdown owner; rollback also closes a server started during partial composition.
   // The RPC server needs the runtime service to dispatch to, and the runtime service needs the RPC
   // server's (lazily-started) connection for host.mcp() env injection — wire the second half here to
   // avoid a construction cycle.
@@ -1044,7 +1063,7 @@ const createApplicationModules = async (
       listAppIconPreviews
     })
   )
-  declareElectronAdapter('notebook', () => registerNotebookIpcHandlers(notebookService))
+  declareElectronAdapter('notebook', () => registerNotebookIpcHandlers(notebookCommands))
   // Wire session deletion to the binding store so stale in-memory bindings do not accumulate.
   // The renderer calls sessions:delete-session (via sessionPersistenceBackend) and acp:delete-session
   // separately; both paths should clear the binding. Override the backend deleteSession callback here
@@ -1095,25 +1114,26 @@ const createApplicationModules = async (
   // Runtime selection UI (Settings/Onboarding): survey managed+external per language, persist the
   // choice, and pick an interpreter file. The runtime root MUST match the executor/service's
   // (getRuntimeRoot(<dataRoot>)); read lazily so a data-root switch is reflected without re-register.
+  const runtimeSelectionWorkflows = createRuntimeSelectionWorkflows({
+    settingsService,
+    runtimeRoot: () => getRuntimeRoot(resolveDataRoot()),
+    // WS10: revoke a disabled runtime from any live session bound to it (mark binding unavailable).
+    onRuntimeDisabled: (language, envId, force) =>
+      notebookService.revokeRuntime(language, envId, { force }),
+    // WS11: live-session usage of a runtime, for the disable-impact warning.
+    describeRuntimeUsage: (language, envId) =>
+      notebookService.describeRuntimeUsage(language, envId),
+    prepareExternalPython: async (selection, root) => {
+      const configuredMirror = await settingsService.getPackageMirror()
+      const mirror = await effectiveMirrorAsync(configuredMirror, app.getLocale())
+      await prepareExternalPythonRuntime(selection, root, {
+        pypiIndex: mirror.pypiIndex,
+        caBundle: mirror.caBundle
+      })
+    }
+  })
   declareElectronAdapter('notebook-runtime', () =>
-    registerRuntimeIpcHandlers({
-      settingsService,
-      runtimeRoot: () => getRuntimeRoot(resolveDataRoot()),
-      // WS10: revoke a disabled runtime from any live session bound to it (mark binding unavailable).
-      onRuntimeDisabled: (language, envId, force) =>
-        notebookService.revokeRuntime(language, envId, { force }),
-      // WS11: live-session usage of a runtime, for the disable-impact warning.
-      describeRuntimeUsage: (language, envId) =>
-        notebookService.describeRuntimeUsage(language, envId),
-      prepareExternalPython: async (selection, root) => {
-        const configuredMirror = await settingsService.getPackageMirror()
-        const mirror = await effectiveMirrorAsync(configuredMirror, app.getLocale())
-        await prepareExternalPythonRuntime(selection, root, {
-          pypiIndex: mirror.pypiIndex,
-          caBundle: mirror.caBundle
-        })
-      }
-    })
+    registerRuntimeIpcHandlers(runtimeSelectionWorkflows)
   )
   declareElectronAdapter('managed-preview', () => {
     registerManagedPreviewIpcHandlers(previewResources)
@@ -1228,17 +1248,20 @@ const createApplicationModules = async (
     }
   }
 
-  // Always register the handlers (serialized is undefined when the provisioner could not be built). The
-  // recovery barrier is threaded in so the startup gate and UI provision/repair await recovery first.
-  declareElectronAdapter('notebook-environment', () =>
-    registerNotebookEnvIpcHandlers(
-      serialized,
-      provisioningRoot,
-      waitForRecovery,
-      assertProvisionAllowed,
-      (language) => notebookService.completeRuntimeRepair(language)
-    )
-  )
+  const notebookEnvironmentLifecycle = createNotebookEnvironmentLifecycle({
+    provisioner: serialized,
+    root: provisioningRoot,
+    projectProgress: broadcastNotebookEnvProgress,
+    waitForRecovery,
+    assertProvisionAllowed,
+    onRepairCompleted: (language) => notebookService.completeRuntimeRepair(language)
+  })
+  // Always register the handlers (serialized is undefined when the provisioner could not be built).
+  // Start maintenance only after all four Electron channels exist, preserving the previous startup
+  // ordering while construction remains application-owned and single-instance.
+  declareElectronAdapter('notebook-environment', () => {
+    installNotebookEnvironmentSurface(notebookEnvironmentLifecycle, registerNotebookEnvIpcHandlers)
+  })
   if (provisioner && serialized) {
     // Back the notebook service's manage_environments tool with the same provisioner that owns the env
     // gate (it is a DefaultRuntimeProvisioner, which implements createNamedEnvironment/listEnvironments/

--- a/src/main/notebook/application.test.ts
+++ b/src/main/notebook/application.test.ts
@@ -1,0 +1,170 @@
+import { describe, expect, it, vi } from 'vitest'
+
+import type { NotebookRuntimeServiceOptions } from './runtime-service'
+
+const runtimeConstruction = vi.hoisted(() => ({
+  options: undefined as NotebookRuntimeServiceOptions | undefined
+}))
+
+vi.mock('./runtime-service', () => ({
+  NotebookRuntimeService: class MockNotebookRuntimeService {
+    state = vi.fn().mockResolvedValue({ sessionId: 'session-1', cells: [] })
+    dispose = vi.fn().mockResolvedValue({ reaped: true })
+
+    constructor(options: NotebookRuntimeServiceOptions) {
+      runtimeConstruction.options = options
+    }
+  }
+}))
+
+import { composeApplicationRuntime } from '../application-runtime'
+import type { NotebookEnvironmentLifecycle } from './environment-lifecycle-workflows'
+import {
+  createNotebookApplication,
+  createNotebookApplicationModule,
+  createNotebookLocalRpcModule,
+  installNotebookEnvironmentSurface
+} from './application'
+
+describe('Notebook application composition', () => {
+  it('constructs one runtime and exposes prebuilt command and local-RPC capabilities', async () => {
+    const publish = vi.fn()
+    const application = createNotebookApplication({
+      configRoot: '/config',
+      dataRoot: '/data',
+      projectName: 'Open Science',
+      repository: {} as never,
+      locale: 'en-US',
+      appVersion: '1.2.3',
+      getPackageMirror: vi.fn(),
+      notebookRuntimeSettings: { getSnapshot: vi.fn() },
+      resolveArtifactPath: vi.fn(),
+      events: { publish }
+    })
+
+    expect(application.localRpc).toBe(application.runtime)
+    await expect(
+      application.commands.state({ sessionId: 'session-1', workspaceCwd: '/workspace' })
+    ).resolves.toEqual({ sessionId: 'session-1', cells: [] })
+    expect(application.runtime.state).toHaveBeenCalledOnce()
+    expect(runtimeConstruction.options).toMatchObject({
+      configRoot: '/config',
+      dataRoot: '/data',
+      projectName: 'Open Science',
+      locale: 'en-US',
+      appVersion: '1.2.3'
+    })
+  })
+
+  it('publishes Notebook state events through the application event owner', () => {
+    const publish = vi.fn()
+    createNotebookApplication({
+      configRoot: '/config',
+      dataRoot: '/data',
+      projectName: 'Open Science',
+      repository: {} as never,
+      events: { publish }
+    })
+    const callbacks = runtimeConstruction.options?.callbacks
+    const available = { sessionId: 'session-1', kernels: ['python'] } as never
+    const changed = { sessionId: 'session-1', revision: 2 } as never
+
+    callbacks?.onNotebookAvailable?.(available)
+    callbacks?.onNotebookChanged?.(changed)
+
+    expect(publish.mock.calls).toEqual([
+      ['notebook:available', available],
+      ['notebook:changed', changed]
+    ])
+  })
+
+  it('uses terminal runtime disposal when partial application construction rolls back', async () => {
+    const module = createNotebookApplicationModule({
+      configRoot: '/config',
+      dataRoot: '/data',
+      projectName: 'Open Science',
+      events: { publish: vi.fn() },
+      disposeTimeoutMs: 25,
+      isBackendTeardownOwned: () => false
+    })
+
+    await module.rollback?.()
+
+    expect(module.capability.runtime.dispose).toHaveBeenCalledOnce()
+  })
+
+  it('leaves normal Notebook teardown with the backend coordinator', async () => {
+    const module = createNotebookApplicationModule({
+      configRoot: '/config',
+      dataRoot: '/data',
+      projectName: 'Open Science',
+      events: { publish: vi.fn() },
+      disposeTimeoutMs: 25,
+      isBackendTeardownOwned: () => true
+    })
+
+    await module.rollback?.()
+
+    expect(module.capability.runtime.dispose).not.toHaveBeenCalled()
+    expect(module.dispose).toBeUndefined()
+  })
+
+  it('registers the environment surface before starting its lifecycle once', () => {
+    const order: string[] = []
+    const startup = vi.fn().mockImplementation(async () => {
+      order.push('startup')
+    })
+    const lifecycle = {
+      startup
+    } as unknown as NotebookEnvironmentLifecycle
+
+    installNotebookEnvironmentSurface(lifecycle, () => order.push('register'))
+
+    expect(order).toEqual(['register', 'startup'])
+    expect(startup).toHaveBeenCalledOnce()
+  })
+
+  it('closes local RPC after backend drain and before application events', async () => {
+    const order: string[] = []
+    const close = vi.fn().mockImplementation(async () => {
+      order.push('local-rpc')
+    })
+    const runtime = await composeApplicationRuntime(async (modules) => {
+      await modules.add(undefined, () => ({
+        name: 'application-events',
+        capability: undefined,
+        dispose: () => {
+          order.push('application-events')
+        }
+      }))
+      await modules.add({ close }, createNotebookLocalRpcModule)
+      await modules.add(undefined, () => ({
+        name: 'backend-shutdown-coordinator',
+        capability: undefined,
+        dispose: () => {
+          order.push('backend-shutdown-coordinator')
+        }
+      }))
+      return {}
+    })
+
+    await runtime.dispose()
+    await runtime.dispose()
+
+    expect(order).toEqual(['backend-shutdown-coordinator', 'local-rpc', 'application-events'])
+    expect(close).toHaveBeenCalledOnce()
+  })
+
+  it('closes local RPC once when later composition rolls back', async () => {
+    const close = vi.fn().mockResolvedValue(undefined)
+
+    await expect(
+      composeApplicationRuntime(async (modules) => {
+        await modules.add({ close }, createNotebookLocalRpcModule)
+        throw new Error('later module failed')
+      })
+    ).rejects.toThrow('later module failed')
+
+    expect(close).toHaveBeenCalledOnce()
+  })
+})

--- a/src/main/notebook/application.ts
+++ b/src/main/notebook/application.ts
@@ -1,0 +1,111 @@
+import type { ApplicationEventPublisher } from '../application-events'
+import type { ApplicationModule } from '../application-runtime'
+import type { NotebookEnvironmentLifecycle } from './environment-lifecycle-workflows'
+import type { NotebookLocalRpcCapability } from './local-rpc-notebook-adapter'
+import { createNotebookCommandWorkflows, type NotebookCommandWorkflows } from './notebook-workflows'
+import { NotebookRuntimeService, type NotebookRuntimeServiceOptions } from './runtime-service'
+
+type NotebookApplicationDeps = Pick<
+  NotebookRuntimeServiceOptions,
+  | 'configRoot'
+  | 'dataRoot'
+  | 'projectName'
+  | 'repository'
+  | 'getPackageMirror'
+  | 'notebookRuntimeSettings'
+  | 'locale'
+  | 'appVersion'
+  | 'resolveArtifactPath'
+> & {
+  events: ApplicationEventPublisher
+}
+
+type NotebookApplication = {
+  // Retained as the internal compatibility surface while later Notebook slices narrow remaining
+  // application integrations. New transports consume the purpose-built capabilities below.
+  runtime: NotebookRuntimeService
+  commands: NotebookCommandWorkflows
+  localRpc: NotebookLocalRpcCapability
+}
+
+type NotebookApplicationModuleDeps = NotebookApplicationDeps & {
+  disposeTimeoutMs: number
+  isBackendTeardownOwned: () => boolean
+}
+
+type NotebookLocalRpcLifecycle = {
+  close(): Promise<void>
+}
+
+// Owns the single Notebook runtime generation and projects the narrow capabilities consumed by each
+// transport. Host metadata and publication are injected so this module has no Electron or ACP
+// dependency and cannot become a second renderer/event owner.
+const createNotebookApplication = (deps: NotebookApplicationDeps): NotebookApplication => {
+  const { events, ...runtimeOptions } = deps
+  const runtime = new NotebookRuntimeService({
+    ...runtimeOptions,
+    callbacks: {
+      onNotebookAvailable: (event) => events.publish('notebook:available', event),
+      onNotebookChanged: (event) => events.publish('notebook:changed', event)
+    }
+  })
+  const localRpc: NotebookLocalRpcCapability = runtime
+
+  return {
+    runtime,
+    commands: createNotebookCommandWorkflows(runtime),
+    localRpc
+  }
+}
+
+// Partial construction has no coordinator to finish teardown, so rollback terminally disposes the
+// runtime. Normal shutdown deliberately has no module disposer: the later-owned backend coordinator
+// remains the sole owner and runs before supporting modules are released in reverse order.
+const createNotebookApplicationModule = (
+  deps: NotebookApplicationModuleDeps
+): ApplicationModule<NotebookApplication> => {
+  const { disposeTimeoutMs, isBackendTeardownOwned, ...applicationDeps } = deps
+  const application = createNotebookApplication(applicationDeps)
+
+  return {
+    name: 'notebook-runtime',
+    capability: application,
+    disposeTimeoutMs,
+    rollback: () =>
+      isBackendTeardownOwned() ? undefined : application.runtime.dispose().then(() => undefined)
+  }
+}
+
+// The local server remains an integration adapter constructed by the application root. This small
+// descriptor only certifies lifecycle ownership: close on rollback and after later backends drain.
+const createNotebookLocalRpcModule = <Server extends NotebookLocalRpcLifecycle>(
+  server: Server
+): ApplicationModule<Server> => ({
+  name: 'notebook-local-rpc',
+  capability: server,
+  rollback: () => server.close(),
+  dispose: () => server.close()
+})
+
+// Transport registration must complete before startup can publish progress or accept cancellation.
+// Keeping this order in one tested composition seam prevents adapters from recreating the lifecycle.
+const installNotebookEnvironmentSurface = (
+  lifecycle: NotebookEnvironmentLifecycle,
+  register: (lifecycle: NotebookEnvironmentLifecycle) => void
+): void => {
+  register(lifecycle)
+  void lifecycle.startup()
+}
+
+export {
+  createNotebookApplication,
+  createNotebookApplicationModule,
+  createNotebookLocalRpcModule,
+  installNotebookEnvironmentSurface
+}
+export type {
+  NotebookApplication,
+  NotebookApplicationDeps,
+  NotebookApplicationModuleDeps,
+  NotebookLocalRpcLifecycle
+}

--- a/src/main/notebook/env-ipc.test.ts
+++ b/src/main/notebook/env-ipc.test.ts
@@ -24,7 +24,11 @@ vi.mock('electron', () => ({
   }
 }))
 
-import { registerNotebookEnvIpcHandlers } from './env-ipc'
+import { broadcastNotebookEnvProgress, registerNotebookEnvIpcHandlers } from './env-ipc'
+import {
+  createNotebookEnvironmentLifecycle,
+  type NotebookEnvironmentLifecycle
+} from './environment-lifecycle-workflows'
 
 const fakeProvisioner = (over: Partial<RuntimeProvisioner> = {}): RuntimeProvisioner => ({
   status: vi
@@ -39,6 +43,15 @@ const fakeProvisioner = (over: Partial<RuntimeProvisioner> = {}): RuntimeProvisi
   ...over
 })
 
+const createLifecycle = (
+  provisioner: RuntimeProvisioner | undefined
+): NotebookEnvironmentLifecycle =>
+  createNotebookEnvironmentLifecycle({
+    provisioner,
+    root: '/runtime',
+    projectProgress: broadcastNotebookEnvProgress
+  })
+
 describe('registerNotebookEnvIpcHandlers', () => {
   beforeEach(() => {
     registered.clear()
@@ -47,7 +60,7 @@ describe('registerNotebookEnvIpcHandlers', () => {
   })
 
   it('registers the exact four channels even when the backend is unavailable', async () => {
-    registerNotebookEnvIpcHandlers(undefined, '/runtime')
+    registerNotebookEnvIpcHandlers(createLifecycle(undefined))
 
     expect([...registered.keys()].sort()).toEqual([
       'notebook-env:cancel',
@@ -74,7 +87,7 @@ describe('registerNotebookEnvIpcHandlers', () => {
         report({ phase: 'repair', message: 'Repairing Python', progress: 0.2 })
       })
     })
-    registerNotebookEnvIpcHandlers(provisioner, '/runtime')
+    registerNotebookEnvIpcHandlers(createLifecycle(provisioner))
 
     await registered.get('notebook-env:provision')?.({}, 'r')
     await registered.get('notebook-env:repair')?.({}, 'python')
@@ -102,7 +115,10 @@ describe('registerNotebookEnvIpcHandlers', () => {
       )
     })
 
-    registerNotebookEnvIpcHandlers(provisioner, '/runtime')
+    const lifecycle = createLifecycle(provisioner)
+    registerNotebookEnvIpcHandlers(lifecycle)
+    expect(provisioner.restoreRelocatedEnvs).not.toHaveBeenCalled()
+    void lifecycle.startup()
     const operation = registered.get('notebook-env:provision')?.({}, 'r') as Promise<void>
     registered.get('notebook-env:cancel')?.({}, 'r')
 

--- a/src/main/notebook/env-ipc.ts
+++ b/src/main/notebook/env-ipc.ts
@@ -2,9 +2,8 @@ import { BrowserWindow } from 'electron'
 
 import type { NotebookLanguage } from '../../shared/notebook'
 import { ipcMainHandle } from '../ipc-handler-registry'
-import { serializeProvisioner } from './environment-operation-foundation'
-import { createNotebookEnvironmentLifecycle } from './environment-lifecycle-workflows'
-import type { ProvisionProgress, RuntimeProvisioner } from './provisioner'
+import type { NotebookEnvironmentLifecycle } from './environment-lifecycle-workflows'
+import type { ProvisionProgress } from './provisioner'
 
 // Broadcasts a progress event to every live renderer window.
 export const broadcastNotebookEnvProgress = (progress: ProvisionProgress): void => {
@@ -15,22 +14,7 @@ export const broadcastNotebookEnvProgress = (progress: ProvisionProgress): void 
 
 // Registers the stable renderer surface while lifecycle ordering and state stay behind the workflow
 // interface. An unavailable provisioner still yields registered handlers with actionable results.
-export const registerNotebookEnvIpcHandlers = (
-  provisioner: RuntimeProvisioner | undefined,
-  root: string,
-  waitForRecovery?: () => Promise<void>,
-  assertProvisionAllowed?: (language: NotebookLanguage) => void,
-  onRepairCompleted?: (language: NotebookLanguage) => Promise<void> | void
-): void => {
-  const lifecycle = createNotebookEnvironmentLifecycle({
-    provisioner,
-    root,
-    projectProgress: broadcastNotebookEnvProgress,
-    waitForRecovery,
-    assertProvisionAllowed,
-    onRepairCompleted
-  })
-
+export const registerNotebookEnvIpcHandlers = (lifecycle: NotebookEnvironmentLifecycle): void => {
   ipcMainHandle('notebook-env:status', () => lifecycle.status())
   ipcMainHandle('notebook-env:provision', (_event, language: NotebookLanguage) =>
     lifecycle.provision(language)
@@ -41,8 +25,4 @@ export const registerNotebookEnvIpcHandlers = (
   ipcMainHandle('notebook-env:cancel', (_event, language?: NotebookLanguage) =>
     lifecycle.cancel(language)
   )
-  void lifecycle.startup()
 }
-
-// Preserve the composition-root import until N7e owns construction at the application seam.
-export { serializeProvisioner }

--- a/src/main/notebook/ipc.test.ts
+++ b/src/main/notebook/ipc.test.ts
@@ -13,7 +13,8 @@ vi.mock('electron', () => ({
   }
 }))
 
-import { createNotebookHandlers, registerNotebookIpcHandlers } from './ipc'
+import { registerNotebookIpcHandlers } from './ipc'
+import { createNotebookCommandWorkflows } from './notebook-workflows'
 import { beginMigration, clearMigrationPending } from '../storage/migration-state'
 
 beforeEach(() => {
@@ -26,7 +27,7 @@ describe('notebook IPC handlers', () => {
     const service = {
       execute: vi.fn().mockResolvedValue({ runId: 'run-1', status: 'completed' })
     } as unknown as NotebookRuntimeService
-    const handlers = createNotebookHandlers(service)
+    const handlers = createNotebookCommandWorkflows(service)
     beginMigration()
 
     await expect(
@@ -57,7 +58,7 @@ describe('notebook IPC handlers', () => {
       restart: vi.fn().mockResolvedValue({ sessionId: 'session-1' }),
       shutdown: vi.fn().mockResolvedValue({ sessionId: 'session-1', status: 'shutdown' })
     } as unknown as NotebookRuntimeService
-    const handlers = createNotebookHandlers(service)
+    const handlers = createNotebookCommandWorkflows(service)
 
     await handlers.state({ sessionId: 'session-1', workspaceCwd: '/workspace' })
     await handlers.reference({ sessionId: 'session-1', workspaceCwd: '/workspace' })
@@ -136,7 +137,7 @@ describe('notebook IPC handlers', () => {
       restart: vi.fn().mockResolvedValue({ sessionId: 'session-1' }),
       shutdown: vi.fn().mockResolvedValue({ sessionId: 'session-1', status: 'shutdown' })
     } as unknown as NotebookRuntimeService
-    registerNotebookIpcHandlers(service)
+    registerNotebookIpcHandlers(createNotebookCommandWorkflows(service))
 
     expect([...ipcHandlers.keys()]).toEqual([
       'notebook:state',

--- a/src/main/notebook/ipc.ts
+++ b/src/main/notebook/ipc.ts
@@ -10,19 +10,10 @@ import type {
   NotebookSessionRequest,
   RunNotebookCellRequest
 } from '../../shared/notebook'
-import {
-  createNotebookCommandWorkflows,
-  type NotebookCommandRuntime,
-  type NotebookCommandWorkflows
-} from './notebook-workflows'
-
-// Builds a small delegating surface so tests can validate IPC behavior without Electron wiring.
-const createNotebookHandlers = createNotebookCommandWorkflows
+import type { NotebookCommandWorkflows } from './notebook-workflows'
 
 // Registers renderer-callable notebook commands on the main-process IPC bus.
-const registerNotebookIpcHandlers = (runtime: NotebookCommandRuntime): void => {
-  const handlers = createNotebookHandlers(runtime)
-
+const registerNotebookIpcHandlers = (handlers: NotebookCommandWorkflows): void => {
   ipcMainHandle('notebook:state', (_event, request: NotebookSessionRequest) =>
     handlers.state(request)
   )
@@ -58,5 +49,5 @@ const registerNotebookIpcHandlers = (runtime: NotebookCommandRuntime): void => {
   )
 }
 
-export { createNotebookHandlers, registerNotebookIpcHandlers }
+export { registerNotebookIpcHandlers }
 export type { NotebookCommandWorkflows as NotebookHandlers }

--- a/src/main/notebook/provisioner.test.ts
+++ b/src/main/notebook/provisioner.test.ts
@@ -34,7 +34,7 @@ import {
 } from './provisioner'
 import { CHILD_UNCONFIRMED } from './provisioner-runtime'
 import { envsLockDir } from './runtime-relocation'
-import { serializeProvisioner } from './env-ipc'
+import { serializeProvisioner } from './environment-operation-foundation'
 import { withExclusiveCacheLock, withSharedCacheLock } from './pkgs-cache-lock'
 import { micromambaCacheLockKey, selectMicromambaCache } from './micromamba-cache'
 import {

--- a/src/main/notebook/runtime-ipc.test.ts
+++ b/src/main/notebook/runtime-ipc.test.ts
@@ -8,7 +8,10 @@ import type {
   RuntimeSelection
 } from '../../shared/notebook-runtime'
 import type { DiscoveredInterpreter } from './environment-discovery'
-import type { RuntimeIpcDeps } from './runtime-ipc'
+import {
+  createRuntimeSelectionWorkflows,
+  type RuntimeSelectionWorkflowDeps
+} from './runtime-selection-workflows'
 
 const handlers = new Map<string, (event: unknown, payload?: unknown) => unknown>()
 const showOpenDialog = vi.fn()
@@ -34,7 +37,7 @@ vi.mock('./environment-discovery', () => ({
 
 const { registerRuntimeIpcHandlers } = await import('./runtime-ipc')
 
-type SettingsPort = RuntimeIpcDeps['settingsService']
+type SettingsPort = RuntimeSelectionWorkflowDeps['settingsService']
 
 const readiness = (
   language: NotebookLanguage,
@@ -48,7 +51,7 @@ const readiness = (
   packageMutable: source === 'managed'
 })
 
-const fakeRegistry = (): NonNullable<RuntimeIpcDeps['registry']> => ({
+const fakeRegistry = (): NonNullable<RuntimeSelectionWorkflowDeps['registry']> => ({
   survey: async (language) => ({
     managed: readiness(language, 'managed'),
     external: readiness(language, 'external')
@@ -113,7 +116,9 @@ const fakeSettingsService = (): SettingsPort & {
   }
 }
 
-const fakeDeps = (overrides: Partial<RuntimeIpcDeps> = {}): RuntimeIpcDeps => ({
+const fakeDeps = (
+  overrides: Partial<RuntimeSelectionWorkflowDeps> = {}
+): RuntimeSelectionWorkflowDeps => ({
   settingsService: fakeSettingsService(),
   runtimeRoot: () => '/data/runtime',
   registry: fakeRegistry(),
@@ -122,6 +127,11 @@ const fakeDeps = (overrides: Partial<RuntimeIpcDeps> = {}): RuntimeIpcDeps => ({
 
 const invoke = (channel: string, payload?: unknown): Promise<unknown> =>
   Promise.resolve(handlers.get(channel)!(undefined, payload))
+
+const registerRuntime = (
+  deps: RuntimeSelectionWorkflowDeps,
+  options?: { showOpenDialog?: () => Promise<string | null> }
+): void => registerRuntimeIpcHandlers(createRuntimeSelectionWorkflows(deps), options)
 
 beforeEach(() => {
   handlers.clear()
@@ -132,7 +142,7 @@ beforeEach(() => {
 
 describe('runtime IPC adapter', () => {
   it('registers the exact runtime command surface', () => {
-    registerRuntimeIpcHandlers(fakeDeps())
+    registerRuntime(fakeDeps())
 
     expect([...handlers.keys()]).toEqual([
       'runtime:survey',
@@ -164,7 +174,7 @@ describe('runtime IPC adapter', () => {
         runnable: true
       }
     ]
-    registerRuntimeIpcHandlers(
+    registerRuntime(
       fakeDeps({
         settingsService,
         describeRuntimeUsage: () => usage,
@@ -221,29 +231,27 @@ describe('runtime IPC adapter', () => {
     const settingsService = fakeSettingsService()
     const failure = new Error('settings unavailable')
     settingsService.getRuntimeEnablement = vi.fn().mockRejectedValue(failure)
-    registerRuntimeIpcHandlers(fakeDeps({ settingsService }))
+    registerRuntime(fakeDeps({ settingsService }))
 
     await expect(invoke('runtime:get-enablement', { language: 'python' })).rejects.toBe(failure)
   })
 
   it('returns an injected interpreter path', async () => {
-    registerRuntimeIpcHandlers(fakeDeps({ showOpenDialog: async () => '/opt/python/bin/python3' }))
+    registerRuntime(fakeDeps(), { showOpenDialog: async () => '/opt/python/bin/python3' })
 
     await expect(invoke('runtime:pick-interpreter')).resolves.toBe('/opt/python/bin/python3')
   })
 
   it('returns null when the picker is cancelled or fails', async () => {
     const log = vi.spyOn(console, 'error').mockImplementation(() => undefined)
-    registerRuntimeIpcHandlers(fakeDeps({ showOpenDialog: async () => null }))
+    registerRuntime(fakeDeps(), { showOpenDialog: async () => null })
     await expect(invoke('runtime:pick-interpreter')).resolves.toBeNull()
 
-    registerRuntimeIpcHandlers(
-      fakeDeps({
-        showOpenDialog: async () => {
-          throw new Error('dialog blew up')
-        }
-      })
-    )
+    registerRuntime(fakeDeps(), {
+      showOpenDialog: async () => {
+        throw new Error('dialog blew up')
+      }
+    })
 
     await expect(invoke('runtime:pick-interpreter')).resolves.toBeNull()
     expect(log).toHaveBeenCalled()
@@ -252,7 +260,7 @@ describe('runtime IPC adapter', () => {
 
   it('uses the Electron open-file picker when no override is injected', async () => {
     showOpenDialog.mockResolvedValue({ filePaths: ['/usr/local/bin/python3'] })
-    registerRuntimeIpcHandlers(fakeDeps())
+    registerRuntime(fakeDeps())
 
     await expect(invoke('runtime:pick-interpreter')).resolves.toBe('/usr/local/bin/python3')
     expect(showOpenDialog).toHaveBeenCalledWith({ properties: ['openFile'] })
@@ -270,7 +278,7 @@ describe('runtime IPC adapter', () => {
       }
     ]
     const packages: EnvPackage[] = [{ name: 'numpy', version: '2.1.3', build: 'b0' }]
-    registerRuntimeIpcHandlers(fakeDeps({ listPackages: async () => packages }))
+    registerRuntime(fakeDeps({ listPackages: async () => packages }))
 
     await expect(
       invoke('runtime:list-packages', { language: 'python', envId: '/managed/a' })

--- a/src/main/notebook/runtime-ipc.ts
+++ b/src/main/notebook/runtime-ipc.ts
@@ -4,21 +4,19 @@ import { ipcMainHandle } from '../ipc-handler-registry'
 
 import type { NotebookLanguage } from '../../shared/notebook'
 import type { RuntimeSelection } from '../../shared/notebook-runtime'
-import {
-  createRuntimeSelectionWorkflows,
-  type RuntimeSelectionWorkflowDeps
-} from './runtime-selection-workflows'
+import type { RuntimeSelectionWorkflows } from './runtime-selection-workflows'
 
-export type RuntimeIpcDeps = RuntimeSelectionWorkflowDeps & {
+export type RuntimeIpcOptions = {
   // Injectable for tests; production defaults to the Electron native open-file dialog.
   showOpenDialog?: () => Promise<string | null>
 }
 
 // Registers renderer-callable runtime-selection commands while keeping native host interaction in
 // the Electron adapter. Application ordering and state ownership live behind the workflow interface.
-const registerRuntimeIpcHandlers = (deps: RuntimeIpcDeps): void => {
-  const workflows = createRuntimeSelectionWorkflows(deps)
-
+const registerRuntimeIpcHandlers = (
+  workflows: RuntimeSelectionWorkflows,
+  options: RuntimeIpcOptions = {}
+): void => {
   ipcMainHandle('runtime:survey', () => workflows.survey())
 
   ipcMainHandle('runtime:list-environments', () => workflows.listEnvironments())
@@ -65,7 +63,7 @@ const registerRuntimeIpcHandlers = (deps: RuntimeIpcDeps): void => {
 
   ipcMainHandle('runtime:pick-interpreter', async (): Promise<string | null> => {
     try {
-      if (deps.showOpenDialog) return await deps.showOpenDialog()
+      if (options.showOpenDialog) return await options.showOpenDialog()
       const result = await dialog.showOpenDialog({ properties: ['openFile'] })
       return result.filePaths[0] ?? null
     } catch (err) {

--- a/src/main/web-service/http-server.test.ts
+++ b/src/main/web-service/http-server.test.ts
@@ -705,6 +705,64 @@ describe('startWebHttpServer', () => {
     expect(rpc.invoke).toHaveBeenCalledOnce()
   })
 
+  it('pins the remote Web Notebook capability matrix', () => {
+    const channelsFor = (prefix: string): string[] =>
+      Object.entries(WEB_INVOKE_CHANNELS)
+        .filter(([path]) => path.startsWith(prefix))
+        .map(([, channel]) => channel)
+
+    const notebookChannels = channelsFor('notebook.')
+    const environmentChannels = channelsFor('notebookEnv.')
+    const runtimeChannels = channelsFor('runtime.')
+    const localOnly = (channels: string[]): string[] =>
+      channels.filter((channel) => REMOTE_LOCAL_ONLY_RPC_CHANNELS.has(channel))
+
+    expect(localOnly(notebookChannels)).toEqual([
+      'notebook:export-ipynb',
+      'notebook:export-ipynb-all'
+    ])
+    expect(
+      notebookChannels.filter((channel) => !localOnly(notebookChannels).includes(channel))
+    ).toEqual([
+      'notebook:append-code-cell',
+      'notebook:begin-code-cell',
+      'notebook:execute',
+      'notebook:finish-code-cell',
+      'notebook:reference',
+      'notebook:read-input-preview',
+      'notebook:restart',
+      'notebook:run-cell',
+      'notebook:shutdown',
+      'notebook:state'
+    ])
+    expect(localOnly(environmentChannels)).toEqual([
+      'notebook-env:cancel',
+      'notebook-env:provision',
+      'notebook-env:repair'
+    ])
+    expect(
+      environmentChannels.filter((channel) => !localOnly(environmentChannels).includes(channel))
+    ).toEqual(['notebook-env:status'])
+    expect(localOnly(runtimeChannels)).toEqual([
+      'runtime:pick-interpreter',
+      'runtime:register-interpreter',
+      'runtime:set-environment-enabled',
+      'runtime:set-install-authorized',
+      'runtime:set-selection',
+      'runtime:unregister-interpreter'
+    ])
+    expect(
+      runtimeChannels.filter((channel) => !localOnly(runtimeChannels).includes(channel))
+    ).toEqual([
+      'runtime:describe-usage',
+      'runtime:get-enablement',
+      'runtime:list-environments',
+      'runtime:list-package-counts',
+      'runtime:list-packages',
+      'runtime:survey'
+    ])
+  })
+
   it.each([
     ['one-time', accessOnlyExternalAccess],
     ['trusted', authorizedExternalAccess]

--- a/src/shared/web-rpc-contract.test.ts
+++ b/src/shared/web-rpc-contract.test.ts
@@ -91,6 +91,55 @@ describe('Web RPC contract', () => {
     ])
   })
 
+  it('pins the local Web Notebook, environment, and runtime surfaces', () => {
+    const invokePaths = Object.keys(WEB_INVOKE_CHANNELS)
+    const eventPaths = Object.keys(WEB_EVENT_CHANNELS)
+
+    expect(invokePaths.filter((path) => path.startsWith('notebook.'))).toEqual([
+      'notebook.appendCodeCell',
+      'notebook.beginCodeCell',
+      'notebook.execute',
+      'notebook.exportIpynb',
+      'notebook.exportIpynbAll',
+      'notebook.finishCodeCell',
+      'notebook.getReference',
+      'notebook.readInputPreview',
+      'notebook.restart',
+      'notebook.runCell',
+      'notebook.shutdown',
+      'notebook.state'
+    ])
+    expect(invokePaths.filter((path) => path.startsWith('notebookEnv.'))).toEqual([
+      'notebookEnv.cancel',
+      'notebookEnv.getStatus',
+      'notebookEnv.provision',
+      'notebookEnv.repair'
+    ])
+    expect(invokePaths.filter((path) => path.startsWith('runtime.'))).toEqual([
+      'runtime.describeUsage',
+      'runtime.getEnablement',
+      'runtime.listEnvironments',
+      'runtime.listPackageCounts',
+      'runtime.listPackages',
+      'runtime.pickInterpreter',
+      'runtime.registerInterpreter',
+      'runtime.setEnvironmentEnabled',
+      'runtime.setInstallAuthorized',
+      'runtime.setSelection',
+      'runtime.survey',
+      'runtime.unregisterInterpreter'
+    ])
+    expect(eventPaths.filter((path) => path.startsWith('notebook.'))).toEqual([
+      'notebook.onAvailable',
+      'notebook.onChanged'
+    ])
+    // This generated mapping remains dormant for Web: production publishes environment progress
+    // directly to Electron BrowserWindows and never adds it to ApplicationEventMap.
+    expect(eventPaths.filter((path) => path.startsWith('notebookEnv.'))).toEqual([
+      'notebookEnv.onProgress'
+    ])
+  })
+
   it('validates versioned request and response envelopes at runtime', () => {
     expect(
       webRpcRequestSchema.safeParse({


### PR DESCRIPTION
## Problem

Notebook construction crossed through ACP IPC, while Electron adapters created command, runtime-selection, and environment workflows during transport registration. The authenticated local Notebook RPC server also had no application-owned close path.

## Proposed change

Create one Notebook application module at the application root, inject its narrow capabilities into Electron and local RPC adapters, and certify construction, startup, rollback, and disposal ordering.

```mermaid
flowchart LR
  Root["Application composition root"] --> Notebook["Notebook application"]
  Notebook --> Runtime["NotebookRuntimeService"]
  Notebook --> Commands["Notebook command workflows"]
  Notebook --> RpcCapability["16-method local RPC capability"]
  Root --> Selection["Runtime-selection workflows"]
  Root --> Environment["Environment lifecycle"]
  Commands --> Electron["Electron Notebook IPC"]
  Selection --> Electron
  Environment --> Electron
  RpcCapability --> LocalRpc["Authenticated local RPC server"]
  Cross["Specialist / Permission / Compute integrations"] --> LocalRpc
```

Normal shutdown remains ordered as Electron adapter uninstall, backend coordinator drain, local RPC close, and ApplicationEventHub disposal last. Partial construction instead performs terminal Notebook disposal and closes any started local RPC server.

## Scope and non-goals

- No IPC, MCP, HTTP channel or payload changes.
- No Electron, local Web, remote Web, CLI, SDK, or Task capability widening.
- No changes to Specialist, Permission, or Compute behavior/asymmetry.
- No data-model, persistence-relation, UI, or user-interaction changes.
- No orchestration/session-tree state or public interface from #458; this only leaves a stable future capability seam.

## Acceptance criteria and validation

All local checks below ran on rebased head `a193bc2` against `origin/main@cc8f515`. GitHub exact-head checks are running for the same commit.

- Single construction and lifecycle ownership -> `npm test -- --run src/main/notebook/application.test.ts` -> 7/7 passed.
- Electron Notebook/environment/runtime forwarding and guards -> focused Notebook adapter/workflow tests -> passed; final independent spec review found 0 findings.
- Local RPC exact 16-method boundary and teardown -> local-RPC adapter/server tests plus application lifecycle tests -> passed.
- Local/remote Web capability matrix and event boundary -> Web RPC contract and HTTP server tests -> passed, including 16/16 listener tests outside the restricted sandbox.
- CLI/SDK absence and Electron preload inventory -> CLI, client, and preload tests -> passed.
- Type safety -> `npm run typecheck` -> passed.
- Lint -> `npm run lint` -> passed with 0 errors and 18 pre-existing warnings.
- Post-conflict lifecycle certification -> application composition, application runtime, shutdown, app lifecycle, and IPC handler registry tests -> 82/82 passed; the resolution preserves `BackendShutdownOutcomeError.assertClean(await coordinator.runForQuit())` from #664.
- Full regression suite -> `npm test` outside the restricted localhost sandbox -> 705 files / 10,315 tests passed; 15 files / 184 tests skipped. The earlier sandboxed attempt failed only because localhost listeners were denied with `listen EPERM 127.0.0.1`.
- Independent exact-head reviews -> specification, architecture, and preflight reviews found 0 findings for `a193bc2`.

## Review focus

- `createNotebookApplicationModule` rollback versus coordinator-owned normal teardown.
- Reverse disposal order around the local RPC server and ApplicationEventHub.
- Preservation of trusted renderer-field stripping and data-root write guards in command workflows.
- Remote Web deny rules and Specialist/Permission/Compute capability asymmetry.
- Future #309/#310 changes should extend command workflows instead of passing the raw runtime back into Electron IPC.

Residual risk: no full Electron startup E2E was run. An active local RPC connection could make `server.close()` reach the application module's existing one-second disposal budget; disposal is bounded and continues, while server close behavior remains covered by its focused tests.

Related: #458 (forward-compatibility boundary only; no orchestration implementation).
