### PR TITLE
fix(providers): align Bailian reasoning capabilities

### DIFF
--- a/src/shared/provider-registry.test.ts
+++ b/src/shared/provider-registry.test.ts
@@ -303,11 +303,16 @@ describe('provider registry', () => {
     expect(defaultVendorModel('stepfun')).toBe('step-3.7-flash')
   })
 
-  it('routes Bailian through all three APIs per region with the curated 1M catalog', () => {
+  it('routes Bailian Responses only for the documented Qwen models', () => {
     const bailianId = 'bailian' as OfficialVendorId
 
     expect(isOfficialVendorId('bailian')).toBe(true)
-    expect(resolveVendorApiEndpoints(bailianId)).toEqual(['anthropic', 'openai', 'responses'])
+    expect(resolveVendorApiEndpoints(bailianId)).toEqual(['anthropic', 'openai'])
+    expect(isVendorModelResponsesSupported(bailianId, 'qwen3.8-max')).toBe(true)
+    expect(isVendorModelResponsesSupported(bailianId, 'qwen3.7-max')).toBe(true)
+    expect(isVendorModelResponsesSupported(bailianId, 'qwen3.6-flash')).toBe(true)
+    expect(isVendorModelResponsesSupported(bailianId, 'deepseek-v4-pro')).toBe(false)
+    expect(isVendorModelResponsesSupported(bailianId, 'deepseek-v4-flash')).toBe(false)
     expect(vendorHasRegions(bailianId)).toBe(true)
 
     // Mainland China is the default; the overseas region swaps only the DashScope host.
@@ -330,24 +335,24 @@ describe('provider registry', () => {
       'https://modelstudio.console.alibabacloud.com/us-east-1?tab=model#/api-key'
     )
 
-    expect(getOfficialVendor(bailianId)?.models).toEqual(
-      [
-        'qwen3.8-max',
-        'qwen3.7-plus',
-        'qwen3.7-max',
-        'qwen3.7-flash',
-        'qwen3.6-plus',
-        'qwen3.6-flash',
-        'deepseek-v4-flash-0731',
-        'deepseek-v4-pro',
-        'deepseek-v4-flash'
-      ].map((id) => ({ id, contextWindow: 1_000_000 }))
-    )
+    expect(
+      getOfficialVendor(bailianId)?.models.map(({ id, contextWindow }) => ({ id, contextWindow }))
+    ).toEqual([
+      { id: 'qwen3.8-max', contextWindow: 983_616 },
+      { id: 'qwen3.7-plus', contextWindow: 1_000_000 },
+      { id: 'qwen3.7-max', contextWindow: 1_000_000 },
+      { id: 'qwen3.7-flash', contextWindow: 1_000_000 },
+      { id: 'qwen3.6-plus', contextWindow: 1_000_000 },
+      { id: 'qwen3.6-flash', contextWindow: 1_000_000 },
+      { id: 'deepseek-v4-flash-0731', contextWindow: 1_000_000 },
+      { id: 'deepseek-v4-pro', contextWindow: 1_000_000 },
+      { id: 'deepseek-v4-flash', contextWindow: 1_000_000 }
+    ])
     expect(defaultVendorModel(bailianId)).toBe('qwen3.8-max')
     expect(resolveVendorModelsUrl(bailianId)).toBeUndefined()
   })
 
-  it('routes Bailian for Plan through its fixed endpoints without Responses support', () => {
+  it('routes Bailian for Plan Responses only for its documented Qwen models', () => {
     const planId = 'bailianplan' as OfficialVendorId
 
     expect(isOfficialVendorId('bailianplan')).toBe(true)
@@ -363,25 +368,73 @@ describe('provider registry', () => {
       'https://bailian.console.aliyun.com/cn-beijing?tab=plan#/efm/subscription/overview'
     )
 
-    expect(getOfficialVendor(planId)?.models).toEqual(
-      [
-        'qwen3.8-max',
-        'qwen3.8-max-preview',
-        'qwen3.7-max',
-        'qwen3.7-plus',
-        'qwen3.6-flash',
-        'glm-5.2',
-        'deepseek-v4-pro',
-        'deepseek-v4-flash-0731'
-      ].map((id) => ({ id, contextWindow: 1_000_000 }))
-    )
+    expect(
+      getOfficialVendor(planId)?.models.map(({ id, contextWindow }) => ({ id, contextWindow }))
+    ).toEqual([
+      { id: 'qwen3.8-max', contextWindow: 983_616 },
+      { id: 'qwen3.8-max-preview', contextWindow: 983_616 },
+      { id: 'qwen3.7-max', contextWindow: 1_000_000 },
+      { id: 'qwen3.7-plus', contextWindow: 1_000_000 },
+      { id: 'qwen3.6-flash', contextWindow: 1_000_000 },
+      { id: 'glm-5.2', contextWindow: 1_000_000 },
+      { id: 'deepseek-v4-pro', contextWindow: 1_000_000 },
+      { id: 'deepseek-v4-flash-0731', contextWindow: 1_000_000 }
+    ])
     expect(defaultVendorModel(planId)).toBe('qwen3.8-max')
     expect(resolveVendorModelsUrl(planId)).toBeUndefined()
 
-    expect(isVendorModelResponsesSupported(planId, 'qwen3.8-max')).toBe(false)
+    expect(isVendorModelResponsesSupported(planId, 'qwen3.8-max')).toBe(true)
+    expect(isVendorModelResponsesSupported(planId, 'qwen3.8-max-preview')).toBe(true)
+    expect(isVendorModelResponsesSupported(planId, 'qwen3.7-max')).toBe(true)
+    expect(isVendorModelResponsesSupported(planId, 'qwen3.7-plus')).toBe(true)
+    expect(isVendorModelResponsesSupported(planId, 'qwen3.6-flash')).toBe(true)
     expect(isVendorModelResponsesSupported(planId, 'glm-5.2')).toBe(false)
     expect(isVendorModelResponsesSupported(planId, 'deepseek-v4-pro')).toBe(false)
     expect(isVendorModelResponsesSupported(planId, 'deepseek-v4-flash-0731')).toBe(false)
+  })
+
+  it('exposes the documented qwen3.8 reasoning effort levels for both Bailian plans', () => {
+    const expectedProfile = {
+      supported: true,
+      slots: ['low', 'medium', 'xhigh', 'xhigh', 'xhigh']
+    }
+
+    expect(resolveVendorModelReasoningEffort('bailian', 'qwen3.8-max')).toEqual(expectedProfile)
+    expect(resolveVendorModelReasoningEffort('bailianplan', 'qwen3.8-max')).toEqual(expectedProfile)
+    expect(resolveVendorModelReasoningEffort('bailianplan', 'qwen3.8-max-preview')).toEqual(
+      expectedProfile
+    )
+  })
+
+  it('limits Bailian Chat reasoning effort to the documented model families', () => {
+    const highMaxProfile = {
+      supported: true,
+      slots: ['high', 'max', 'max', 'max', 'max']
+    }
+
+    expect(resolveVendorModelReasoningEffort('bailian', 'deepseek-v4-pro')).toEqual(highMaxProfile)
+    expect(resolveVendorModelReasoningEffort('bailian', 'deepseek-v4-flash')).toEqual(
+      highMaxProfile
+    )
+    expect(resolveVendorModelReasoningEffort('bailian', 'deepseek-v4-flash-0731')).toEqual(
+      highMaxProfile
+    )
+    expect(resolveVendorModelReasoningEffort('bailianplan', 'glm-5.2')).toEqual(highMaxProfile)
+    expect(resolveVendorModelReasoningEffort('bailianplan', 'deepseek-v4-pro')).toEqual(
+      highMaxProfile
+    )
+    expect(resolveVendorModelReasoningEffort('bailianplan', 'deepseek-v4-flash-0731')).toEqual(
+      highMaxProfile
+    )
+    expect(resolveVendorModelReasoningEffort('bailian', 'qwen3.7-plus')).toEqual({
+      supported: false
+    })
+  })
+
+  it('uses the qwen3.8 context window published for Codex integrations', () => {
+    expect(resolveModelContextWindow('bailian', 'qwen3.8-max')).toBe(983_616)
+    expect(resolveModelContextWindow('bailianplan', 'qwen3.8-max')).toBe(983_616)
+    expect(resolveModelContextWindow('bailianplan', 'qwen3.8-max-preview')).toBe(983_616)
   })
 
   it('routes Step Plan over Anthropic and OpenAI under /step_plan, no live model list', () => {

--- a/src/shared/provider-registry.test.ts
+++ b/src/shared/provider-registry.test.ts
@@ -352,7 +352,7 @@ describe('provider registry', () => {
     expect(resolveVendorModelsUrl(bailianId)).toBeUndefined()
   })
 
-  it('routes Bailian for Plan Responses only for its documented Qwen models', () => {
+  it('does not advertise Responses support for Bailian for Plan', () => {
     const planId = 'bailianplan' as OfficialVendorId
 
     expect(isOfficialVendorId('bailianplan')).toBe(true)
@@ -383,11 +383,11 @@ describe('provider registry', () => {
     expect(defaultVendorModel(planId)).toBe('qwen3.8-max')
     expect(resolveVendorModelsUrl(planId)).toBeUndefined()
 
-    expect(isVendorModelResponsesSupported(planId, 'qwen3.8-max')).toBe(true)
-    expect(isVendorModelResponsesSupported(planId, 'qwen3.8-max-preview')).toBe(true)
-    expect(isVendorModelResponsesSupported(planId, 'qwen3.7-max')).toBe(true)
-    expect(isVendorModelResponsesSupported(planId, 'qwen3.7-plus')).toBe(true)
-    expect(isVendorModelResponsesSupported(planId, 'qwen3.6-flash')).toBe(true)
+    expect(isVendorModelResponsesSupported(planId, 'qwen3.8-max')).toBe(false)
+    expect(isVendorModelResponsesSupported(planId, 'qwen3.8-max-preview')).toBe(false)
+    expect(isVendorModelResponsesSupported(planId, 'qwen3.7-max')).toBe(false)
+    expect(isVendorModelResponsesSupported(planId, 'qwen3.7-plus')).toBe(false)
+    expect(isVendorModelResponsesSupported(planId, 'qwen3.6-flash')).toBe(false)
     expect(isVendorModelResponsesSupported(planId, 'glm-5.2')).toBe(false)
     expect(isVendorModelResponsesSupported(planId, 'deepseek-v4-pro')).toBe(false)
     expect(isVendorModelResponsesSupported(planId, 'deepseek-v4-flash-0731')).toBe(false)

--- a/src/shared/provider-registry.ts
+++ b/src/shared/provider-registry.ts
@@ -317,13 +317,6 @@ export const OFFICIAL_VENDORS: OfficialVendor[] = [
         reasoningEffort: 'high-max'
       }
     ],
-    responsesModels: [
-      'qwen3.8-max',
-      'qwen3.8-max-preview',
-      'qwen3.7-max',
-      'qwen3.7-plus',
-      'qwen3.6-flash'
-    ],
     multimodal: {
       multimodalModels: ['qwen3.8-max', 'qwen3.8-max-preview', 'qwen3.7-plus', 'qwen3.6-flash']
     }

--- a/src/shared/provider-registry.ts
+++ b/src/shared/provider-registry.ts
@@ -223,13 +223,14 @@ export const OFFICIAL_VENDORS: OfficialVendor[] = [
   {
     id: 'bailian',
     label: 'Bailian',
-    // Bailian exposes a thinking toggle rather than the cross-vendor reasoning_effort vocabulary.
-    // Leave effort control hidden while the models keep their service-defined thinking defaults.
+    // Keep effort hidden for models that only expose protocol-specific thinking controls. Models
+    // with a documented cross-protocol effort vocabulary override this default below.
     reasoningEffort: 'unsupported',
-    // Both regions expose Anthropic Messages plus OpenAI-compatible Chat Completions and Responses.
+    // Both regions expose Anthropic Messages plus OpenAI-compatible Chat Completions. Responses is
+    // available only for the Qwen models listed below.
     // The Anthropic URL is kept in its documented full-endpoint form; the shared URL normalizer strips
     // `/v1/messages` before Claude Code/OpenCode append their own protocol suffix.
-    apiEndpoints: ['anthropic', 'openai', 'responses'],
+    apiEndpoints: ['anthropic', 'openai'],
     regions: [
       {
         id: 'china',
@@ -249,15 +250,31 @@ export const OFFICIAL_VENDORS: OfficialVendor[] = [
     // Curated from Bailian's model marketplace. Keep refresh hidden because the full catalog also
     // contains image, audio, video, embedding, and other models outside this chat-provider surface.
     models: [
-      { id: 'qwen3.8-max', contextWindow: 1_000_000 },
+      {
+        id: 'qwen3.8-max',
+        contextWindow: 983_616,
+        reasoningEffort: 'low-medium-xhigh'
+      },
       { id: 'qwen3.7-plus', contextWindow: 1_000_000 },
       { id: 'qwen3.7-max', contextWindow: 1_000_000 },
       { id: 'qwen3.7-flash', contextWindow: 1_000_000 },
       { id: 'qwen3.6-plus', contextWindow: 1_000_000 },
       { id: 'qwen3.6-flash', contextWindow: 1_000_000 },
-      { id: 'deepseek-v4-flash-0731', contextWindow: 1_000_000 },
-      { id: 'deepseek-v4-pro', contextWindow: 1_000_000 },
-      { id: 'deepseek-v4-flash', contextWindow: 1_000_000 }
+      {
+        id: 'deepseek-v4-flash-0731',
+        contextWindow: 1_000_000,
+        reasoningEffort: 'high-max'
+      },
+      { id: 'deepseek-v4-pro', contextWindow: 1_000_000, reasoningEffort: 'high-max' },
+      { id: 'deepseek-v4-flash', contextWindow: 1_000_000, reasoningEffort: 'high-max' }
+    ],
+    responsesModels: [
+      'qwen3.8-max',
+      'qwen3.7-plus',
+      'qwen3.7-max',
+      'qwen3.7-flash',
+      'qwen3.6-plus',
+      'qwen3.6-flash'
     ],
     multimodal: {
       multimodalModels: [
@@ -272,20 +289,40 @@ export const OFFICIAL_VENDORS: OfficialVendor[] = [
   {
     id: 'bailianplan',
     label: 'Bailian for Plan',
+    // The qwen3.8, GLM, and DeepSeek entries below override this conservative default.
     reasoningEffort: 'unsupported',
     apiEndpoints: ['anthropic', 'openai'],
     baseUrl: 'https://token-plan.cn-beijing.maas.aliyuncs.com/apps/anthropic',
     openaiBaseUrl: 'https://token-plan.cn-beijing.maas.aliyuncs.com/compatible-mode/v1',
     apiKeyUrl: 'https://bailian.console.aliyun.com/cn-beijing?tab=plan#/efm/subscription/overview',
     models: [
-      { id: 'qwen3.8-max', contextWindow: 1_000_000 },
-      { id: 'qwen3.8-max-preview', contextWindow: 1_000_000 },
+      {
+        id: 'qwen3.8-max',
+        contextWindow: 983_616,
+        reasoningEffort: 'low-medium-xhigh'
+      },
+      {
+        id: 'qwen3.8-max-preview',
+        contextWindow: 983_616,
+        reasoningEffort: 'low-medium-xhigh'
+      },
       { id: 'qwen3.7-max', contextWindow: 1_000_000 },
       { id: 'qwen3.7-plus', contextWindow: 1_000_000 },
       { id: 'qwen3.6-flash', contextWindow: 1_000_000 },
-      { id: 'glm-5.2', contextWindow: 1_000_000 },
-      { id: 'deepseek-v4-pro', contextWindow: 1_000_000 },
-      { id: 'deepseek-v4-flash-0731', contextWindow: 1_000_000 }
+      { id: 'glm-5.2', contextWindow: 1_000_000, reasoningEffort: 'high-max' },
+      { id: 'deepseek-v4-pro', contextWindow: 1_000_000, reasoningEffort: 'high-max' },
+      {
+        id: 'deepseek-v4-flash-0731',
+        contextWindow: 1_000_000,
+        reasoningEffort: 'high-max'
+      }
+    ],
+    responsesModels: [
+      'qwen3.8-max',
+      'qwen3.8-max-preview',
+      'qwen3.7-max',
+      'qwen3.7-plus',
+      'qwen3.6-flash'
     ],
     multimodal: {
       multimodalModels: ['qwen3.8-max', 'qwen3.8-max-preview', 'qwen3.7-plus', 'qwen3.6-flash']

--- a/src/shared/reasoning-effort.test.ts
+++ b/src/shared/reasoning-effort.test.ts
@@ -11,6 +11,7 @@ import {
 describe('isReasoningEffortPresetSetting', () => {
   it('accepts supported presets and the explicit unsupported setting', () => {
     expect(isReasoningEffortPresetSetting('standard-5')).toBe(true)
+    expect(isReasoningEffortPresetSetting('low-medium-xhigh')).toBe(true)
     expect(isReasoningEffortPresetSetting('none-high')).toBe(true)
     expect(isReasoningEffortPresetSetting('unsupported')).toBe(true)
   })
@@ -27,6 +28,14 @@ describe('resolveReasoningEffortControl', () => {
 
     expect(control.options.map((option) => option.value)).toEqual(['low', 'medium', 'high'])
     expect(control.selectedValue).toBe('high')
+    expect(control.options.at(-1)?.intent).toBe('max')
+  })
+
+  it('shows the three qwen3.8 effort levels documented for Codex integrations', () => {
+    const control = resolveReasoningEffortControl('max', reasoningEffortProfile('low-medium-xhigh'))
+
+    expect(control.options.map((option) => option.value)).toEqual(['low', 'medium', 'xhigh'])
+    expect(control.selectedValue).toBe('xhigh')
     expect(control.options.at(-1)?.intent).toBe('max')
   })
 

--- a/src/shared/reasoning-effort.ts
+++ b/src/shared/reasoning-effort.ts
@@ -9,6 +9,7 @@ export type ResolvedReasoningEffort = ModelReasoningEffort | 'default'
 
 export type ReasoningEffortPresetId =
   | 'standard-5'
+  | 'low-medium-xhigh'
   | 'low-medium-high-xhigh'
   | 'low-medium-high-xhigh-ultra'
   | 'low-medium-high-max'
@@ -57,6 +58,7 @@ export const CUSTOM_REASONING_EFFORT_PRESETS: ReadonlyArray<{
   label: string
 }> = [
   { id: 'standard-5', label: 'Low / Medium / High / XHigh / Max' },
+  { id: 'low-medium-xhigh', label: 'Low / Medium / XHigh' },
   { id: 'low-medium-high-xhigh-ultra', label: 'Low / Medium / High / XHigh / Ultra' },
   { id: 'low-medium-high-max', label: 'Low / Medium / High / Max' },
   { id: 'low-medium-high-xhigh', label: 'Low / Medium / High / XHigh' },
@@ -109,6 +111,10 @@ const PROFILES: Record<ReasoningEffortPresetId, ReasoningEffortProfile> = {
   'standard-5': {
     supported: true,
     slots: ['low', 'medium', 'high', 'xhigh', 'max']
+  },
+  'low-medium-xhigh': {
+    supported: true,
+    slots: ['low', 'medium', 'xhigh', 'xhigh', 'xhigh']
   },
   'low-medium-high-xhigh': {
     supported: true,


### PR DESCRIPTION
## Problem

The merged Bailian providers hid documented reasoning controls and treated Responses support too broadly for standard Bailian. Bailian for Plan must remain on its documented Anthropic and OpenAI-compatible Chat surfaces rather than being advertised as Responses-compatible. Qwen 3.8 also used the rounded 1M context value instead of the 983,616-token Codex integration limit.

## Proposed change

- Add a `low / medium / xhigh` reasoning preset for Qwen 3.8 Max and Preview.
- Expose `high / max` for the documented GLM 5.2 and DeepSeek V4 Chat models.
- Route Responses at model level for standard Bailian's documented Qwen subset, while Bailian for Plan does not advertise Responses support.
- Set Qwen 3.8 Max and Preview context windows to 983,616 tokens.
- Add focused coverage for every changed model capability and preserve exact catalog metadata coverage.

Official references:

- https://help.aliyun.com/zh/model-studio/compatibility-with-openai-responses-api
- https://help.aliyun.com/zh/model-studio/qwen-api-via-openai-chat-completions
- https://help.aliyun.com/zh/model-studio/anthropic-api-messages
- https://help.aliyun.com/zh/model-studio/codex
- https://bailian.console.aliyun.com/cn-beijing?tab=doc#/doc/?type=model&url=2841718

## Scope and non-goals

This is a provider capability metadata correction. It does not change architecture, persistence schemas, data relationships, or endpoint construction. Qwen 3.7/3.6 remain conservative in the cross-protocol reasoning selector because their documented Chat controls are protocol-specific and do not fit the current model-wide effort seam.

## Acceptance criteria and validation

All commands below ran after the final edit:

- Standard Bailian's Responses allowlist, Bailian for Plan's unsupported Responses status, reasoning profiles, catalog metadata, and Qwen 3.8 context -> `npm test -- src/shared/provider-registry.test.ts src/shared/reasoning-effort.test.ts` -> 69 passed.
- Type safety -> `npm run typecheck` -> passed.
- Repository lint -> `npm run lint` -> passed with 18 pre-existing warnings outside the changed files; changed files are clean.
- Full regression suite -> `npm test` -> 697 files and 10,211 tests passed; 15 files and 184 tests skipped by the existing suite.
- Independent standards and specification reviews -> no remaining findings.

Uncovered risk: validation is based on the current official documentation and project-owned tests; no production API-key smoke test was performed, so future provider-side capability changes remain external risk.

## Review focus

Please verify the Responses boundary between standard Bailian and Bailian for Plan, plus the distinction between Qwen 3.8's `low / medium / xhigh` vocabulary and GLM/DeepSeek's `high / max` vocabulary.
