### PR TITLE
test(transport): characterize renderer surface contracts

### DIFF
--- a/packages/open-science/client.test.ts
+++ b/packages/open-science/client.test.ts
@@ -19,6 +19,27 @@ afterEach(async () => {
 })
 
 describe('OpenScienceClient', () => {
+  it('pins the SDK method inventory without exposing management capabilities', () => {
+    expect(Object.getOwnPropertyNames(OpenScienceClient.prototype).sort()).toEqual(
+      [
+        'constructor',
+        'health',
+        'listProjects',
+        'createProject',
+        'listSessions',
+        'getSession',
+        'startRun',
+        'getRun',
+        'waitForRun',
+        'listArtifacts',
+        'downloadArtifact',
+        'events',
+        'request',
+        'throwResponseError'
+      ].sort()
+    )
+  })
+
   it('starts and waits for a run through the authenticated versioned API', async () => {
     const fetch = vi
       .fn()

--- a/src/main/renderer-broadcast.test.ts
+++ b/src/main/renderer-broadcast.test.ts
@@ -67,10 +67,12 @@ describe('broadcastToRenderers', () => {
     live.webContents.send.mockImplementation(() => order.push('electron'))
     const uninstall = installRendererBroadcastEventHub(hub)
     const remove = addRendererBroadcastSink(() => order.push('sink'))
+    const payload = { sessionId: 'session-1', targetName: 'ANALYST' }
 
-    broadcastToRenderers('specialist:catalog-changed', undefined)
+    hub.publish('specialist:pending-switch', payload)
 
     expect(order).toEqual(['electron', 'sink'])
+    expect(live.webContents.send).toHaveBeenCalledWith('specialist:pending-switch', payload)
     remove()
     uninstall()
     hub.dispose()

--- a/src/main/session-persistence/renderer-flush.test.ts
+++ b/src/main/session-persistence/renderer-flush.test.ts
@@ -1,7 +1,26 @@
 import { describe, expect, it, vi } from 'vitest'
 
-import { requestRendererSessionPersistenceFlush } from './renderer-flush'
+import {
+  SESSION_PERSISTENCE_FLUSH_REQUEST_CHANNEL,
+  SESSION_PERSISTENCE_FLUSH_RESPONSE_CHANNEL
+} from '../../shared/session-persistence-flush'
+import {
+  createElectronSessionPersistenceFlush,
+  requestRendererSessionPersistenceFlush
+} from './renderer-flush'
 import type { RendererSessionPersistenceFlushOutcome } from './renderer-flush'
+
+const electronMocks = vi.hoisted(() => ({
+  on: vi.fn(),
+  removeListener: vi.fn()
+}))
+
+vi.mock('electron', () => ({
+  ipcMain: {
+    on: electronMocks.on,
+    removeListener: electronMocks.removeListener
+  }
+}))
 
 type Listener = (requestId: string) => void
 
@@ -99,5 +118,60 @@ describe('requestRendererSessionPersistenceFlush', () => {
     })
 
     await expect(harness.request()).resolves.toBe('send-failed')
+  })
+})
+
+describe('createElectronSessionPersistenceFlush', () => {
+  it('accepts only the target renderer acknowledgement with the matching request ID', async () => {
+    electronMocks.on.mockClear()
+    electronMocks.removeListener.mockClear()
+
+    const webContents = {
+      isDestroyed: vi.fn(() => false),
+      send: vi.fn(),
+      on: vi.fn(),
+      removeListener: vi.fn()
+    }
+    const window = {
+      isDestroyed: vi.fn(() => false),
+      webContents
+    }
+    const flush = createElectronSessionPersistenceFlush(() => window as never, 1_000)
+    const request = flush()
+    let settled = false
+    void request.then(() => {
+      settled = true
+    })
+
+    expect(webContents.send).toHaveBeenCalledWith(
+      SESSION_PERSISTENCE_FLUSH_REQUEST_CHANNEL,
+      expect.objectContaining({ requestId: expect.any(String) })
+    )
+    const sentRequest = webContents.send.mock.calls[0][1] as { requestId: string }
+    const responseRegistration = electronMocks.on.mock.calls.find(
+      ([channel]) => channel === SESSION_PERSISTENCE_FLUSH_RESPONSE_CHANNEL
+    )
+    const responseHandler = responseRegistration?.[1] as
+      ((event: { sender: unknown }, response: { requestId: string }) => void) | undefined
+    expect(responseHandler).toBeTypeOf('function')
+
+    responseHandler?.({ sender: {} }, { requestId: sentRequest.requestId })
+    await Promise.resolve()
+    expect(settled).toBe(false)
+
+    responseHandler?.({ sender: webContents }, { requestId: 'other-request' })
+    await Promise.resolve()
+    expect(settled).toBe(false)
+
+    responseHandler?.({ sender: webContents }, { requestId: sentRequest.requestId })
+    await expect(request).resolves.toBe('completed')
+    expect(electronMocks.removeListener).toHaveBeenCalledWith(
+      SESSION_PERSISTENCE_FLUSH_RESPONSE_CHANNEL,
+      responseHandler
+    )
+    expect(webContents.removeListener).toHaveBeenCalledWith(
+      'render-process-gone',
+      expect.any(Function)
+    )
   })
 })

--- a/src/main/session-persistence/renderer-flush.test.ts
+++ b/src/main/session-persistence/renderer-flush.test.ts
@@ -154,6 +154,11 @@ describe('createElectronSessionPersistenceFlush', () => {
     const responseHandler = responseRegistration?.[1] as
       ((event: { sender: unknown }, response: { requestId: string }) => void) | undefined
     expect(responseHandler).toBeTypeOf('function')
+    const rendererGoneRegistration = webContents.on.mock.calls.find(
+      ([event]) => event === 'render-process-gone'
+    )
+    const rendererGoneListener = rendererGoneRegistration?.[1] as (() => void) | undefined
+    expect(rendererGoneListener).toBeTypeOf('function')
 
     responseHandler?.({ sender: {} }, { requestId: sentRequest.requestId })
     await Promise.resolve()
@@ -171,7 +176,7 @@ describe('createElectronSessionPersistenceFlush', () => {
     )
     expect(webContents.removeListener).toHaveBeenCalledWith(
       'render-process-gone',
-      expect.any(Function)
+      rendererGoneListener
     )
   })
 })

--- a/src/preload/index.test.ts
+++ b/src/preload/index.test.ts
@@ -86,6 +86,10 @@ type PreloadApi = {
     syncViewState: (state: unknown) => void
     onViewProbe: (listener: (challengeId: number) => void) => () => void
   }
+  specialist: {
+    list: () => unknown
+    onPendingSwitch: (listener: (payload: unknown) => void) => () => void
+  }
   cli: {
     getStatus: () => unknown
     install: () => unknown
@@ -826,6 +830,21 @@ describe('preload bridge — sessions + agent-framework IPC channels', () => {
 
     api.sessions.sendFlushResponse(response)
     expect(sendMock).toHaveBeenCalledWith('sessions:flush-response', response)
+  })
+
+  it('keeps Specialist management and pending-switch delivery on the Electron bridge', () => {
+    const listener = vi.fn()
+    const payload = { sessionId: 'session-1', targetName: 'ANALYST' }
+
+    api.specialist.list()
+    expect(invokeMock).toHaveBeenCalledWith('specialist:list')
+
+    api.specialist.onPendingSwitch(listener)
+    expect(onMock).toHaveBeenCalledWith('specialist:pending-switch', expect.any(Function))
+    const wrappedListener = onMock.mock.calls.at(-1)?.[1] as
+      ((_event: unknown, value: unknown) => void) | undefined
+    wrappedListener?.({}, payload)
+    expect(listener).toHaveBeenCalledWith(payload)
   })
 
   it.each(cases)('$name', ({ invoke, channel, args }) => {

--- a/src/renderer/web/renderer-argument-shape-characterization.test.ts
+++ b/src/renderer/web/renderer-argument-shape-characterization.test.ts
@@ -2,8 +2,8 @@
 
 import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest'
 
-import { WEB_INVOKE_CHANNELS } from '../../shared/web-api-map.generated'
-import { WEB_RPC_PROTOCOL_VERSION } from '../../shared/web-rpc-contract'
+import { WEB_EVENT_CHANNELS, WEB_INVOKE_CHANNELS } from '../../shared/web-api-map.generated'
+import { WEB_RPC_ALLOWED_CHANNELS, WEB_RPC_PROTOCOL_VERSION } from '../../shared/web-rpc-contract'
 
 const electronMocks = vi.hoisted(() => ({
   exposeInMainWorld: vi.fn(),
@@ -52,28 +52,12 @@ type CapturedInvocation = {
   args: unknown[]
 }
 
-const characterizedPaths = [
-  'acp.connect',
-  'acp.createSession',
-  'runtime.describeUsage',
-  'runtime.getEnablement',
-  'runtime.listPackageCounts',
-  'runtime.listPackages',
-  'runtime.registerInterpreter',
-  'runtime.setEnvironmentEnabled',
-  'runtime.setInstallAuthorized',
-  'runtime.setSelection',
-  'runtime.unregisterInterpreter',
-  'sessions.saveSession',
-  'storage.commitAndRelaunch',
-  'storage.discardMigratedCopy',
-  'storage.inspectDataRoot',
-  'storage.migrate',
-  'storage.setDataRootAndRelaunch',
-  'storage.validateDataRoot'
+const BROWSER_NATIVE_CALLABLE_PATHS = [
+  'getRuntimeVersions',
+  'saveBlobFile',
+  'saveManagedFile',
+  'window.close'
 ] as const
-
-const rpcChannels = characterizedPaths.map((path) => WEB_INVOKE_CHANNELS[path])
 
 const webInvocations: CapturedInvocation[] = []
 
@@ -82,6 +66,15 @@ const methodAt = (api: ApiRoot, path: string): ((...args: unknown[]) => Promise<
   for (const part of path.split('.')) value = (value as ApiRoot)[part]
   if (typeof value !== 'function') throw new Error(`Missing API method: ${path}`)
   return value as (...args: unknown[]) => Promise<unknown>
+}
+
+const collectFunctionPaths = (value: unknown, prefix = ''): string[] => {
+  if (typeof value === 'function') return [prefix]
+  if (!value || typeof value !== 'object') return []
+
+  return Object.entries(value).flatMap(([key, child]) =>
+    collectFunctionPaths(child, prefix ? `${prefix}.${key}` : key)
+  )
 }
 
 const loadElectronApi = async (): Promise<ApiRoot> => {
@@ -142,7 +135,7 @@ beforeEach(async () => {
             platform: 'test',
             versions: { electron: '1', chrome: '1', node: '1' },
             rpcProtocolVersion: WEB_RPC_PROTOCOL_VERSION,
-            rpcChannels
+            rpcChannels: WEB_RPC_ALLOWED_CHANNELS
           }),
           { status: 200, headers: { 'content-type': 'application/json' } }
         )
@@ -176,6 +169,21 @@ afterEach(() => {
 })
 
 describe('renderer argument-shape characterization', () => {
+  it('loads the complete local Web callable surface from the real bootstrap', () => {
+    const expectedPaths = [
+      ...Object.entries(WEB_INVOKE_CHANNELS)
+        .filter(([, channel]) => WEB_RPC_ALLOWED_CHANNELS.includes(channel))
+        .map(([path]) => path),
+      ...Object.keys(WEB_EVENT_CHANNELS),
+      ...BROWSER_NATIVE_CALLABLE_PATHS
+    ].sort()
+    const actualPaths = collectFunctionPaths(webApi).sort()
+
+    expect(new Set(actualPaths).size).toBe(actualPaths.length)
+    expect(actualPaths).toHaveLength(250)
+    expect(actualPaths).toEqual(expectedPaths)
+  })
+
   it('records the nine known Runtime deviations without treating them as equivalences', async () => {
     const selection = { kind: 'interpreter', path: '/opt/python' }
     const cases = [
@@ -300,5 +308,21 @@ describe('renderer argument-shape characterization', () => {
         electron
       )
     }
+  })
+
+  it('keeps projectFiles.searchArtifacts request forwarding equivalent', async () => {
+    const request = {
+      projectId: 'project-1',
+      query: 'analysis',
+      limit: 24
+    }
+    const electron = await invokeElectron(electronApi, 'projectFiles.searchArtifacts', [request])
+    const web = await invokeWeb(webApi, 'projectFiles.searchArtifacts', [request])
+
+    expect(electron).toEqual({
+      channel: 'project-files:search-artifacts',
+      args: [request]
+    })
+    expect(web).toEqual(electron)
   })
 })

--- a/src/renderer/web/renderer-argument-shape-characterization.test.ts
+++ b/src/renderer/web/renderer-argument-shape-characterization.test.ts
@@ -1,0 +1,304 @@
+// @vitest-environment jsdom
+
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest'
+
+import { WEB_INVOKE_CHANNELS } from '../../shared/web-api-map.generated'
+import { WEB_RPC_PROTOCOL_VERSION } from '../../shared/web-rpc-contract'
+
+const electronMocks = vi.hoisted(() => ({
+  exposeInMainWorld: vi.fn(),
+  invoke: vi.fn().mockResolvedValue(null),
+  on: vi.fn()
+}))
+
+const themeMocks = vi.hoisted(() => ({
+  applyTheme: vi.fn(),
+  resolveInitialTheme: vi.fn(() => 'light')
+}))
+
+vi.mock('electron', () => ({
+  contextBridge: { exposeInMainWorld: electronMocks.exposeInMainWorld },
+  webUtils: { getPathForFile: vi.fn() },
+  ipcRenderer: {
+    invoke: electronMocks.invoke,
+    on: electronMocks.on,
+    off: vi.fn(),
+    send: vi.fn(),
+    removeListener: vi.fn()
+  }
+}))
+vi.mock('@/lib/theme', () => themeMocks)
+vi.mock('../src/main', () => ({}))
+vi.mock('../../main/remote-access/openscience-logo.svg?raw', () => ({
+  default: '<svg viewBox="0 0 1 1"></svg>'
+}))
+
+type SocketListener = (event: { data?: unknown }) => void
+
+class FakeWebSocket {
+  readonly listeners = new Map<string, Set<SocketListener>>()
+
+  addEventListener(name: string, listener: SocketListener): void {
+    const listeners = this.listeners.get(name) ?? new Set<SocketListener>()
+    listeners.add(listener)
+    this.listeners.set(name, listeners)
+  }
+}
+
+type ApiRoot = Record<string, unknown>
+
+type CapturedInvocation = {
+  channel: string
+  args: unknown[]
+}
+
+const characterizedPaths = [
+  'acp.connect',
+  'acp.createSession',
+  'runtime.describeUsage',
+  'runtime.getEnablement',
+  'runtime.listPackageCounts',
+  'runtime.listPackages',
+  'runtime.registerInterpreter',
+  'runtime.setEnvironmentEnabled',
+  'runtime.setInstallAuthorized',
+  'runtime.setSelection',
+  'runtime.unregisterInterpreter',
+  'sessions.saveSession',
+  'storage.commitAndRelaunch',
+  'storage.discardMigratedCopy',
+  'storage.inspectDataRoot',
+  'storage.migrate',
+  'storage.setDataRootAndRelaunch',
+  'storage.validateDataRoot'
+] as const
+
+const rpcChannels = characterizedPaths.map((path) => WEB_INVOKE_CHANNELS[path])
+
+const webInvocations: CapturedInvocation[] = []
+
+const methodAt = (api: ApiRoot, path: string): ((...args: unknown[]) => Promise<unknown>) => {
+  let value: unknown = api
+  for (const part of path.split('.')) value = (value as ApiRoot)[part]
+  if (typeof value !== 'function') throw new Error(`Missing API method: ${path}`)
+  return value as (...args: unknown[]) => Promise<unknown>
+}
+
+const loadElectronApi = async (): Promise<ApiRoot> => {
+  await import('../../preload/index')
+  const exposure = electronMocks.exposeInMainWorld.mock.calls.find(([name]) => name === 'api')
+  if (!exposure) throw new Error('Preload did not expose window.api')
+  return exposure[1] as ApiRoot
+}
+
+const loadWebApi = async (): Promise<ApiRoot> => {
+  await import('./bootstrap')
+  return (window as unknown as { api: ApiRoot }).api
+}
+
+const invokeElectron = async (
+  api: ApiRoot,
+  path: string,
+  args: unknown[]
+): Promise<CapturedInvocation> => {
+  electronMocks.invoke.mockClear()
+  await methodAt(api, path)(...args)
+  const [channel, ...forwardedArgs] = electronMocks.invoke.mock.calls.at(-1) ?? []
+  return { channel: String(channel), args: forwardedArgs }
+}
+
+const invokeWeb = async (
+  api: ApiRoot,
+  path: string,
+  args: unknown[]
+): Promise<CapturedInvocation> => {
+  webInvocations.length = 0
+  await methodAt(api, path)(...args)
+  const invocation = webInvocations.at(-1)
+  if (!invocation) throw new Error(`Web API did not invoke an RPC channel for ${path}`)
+  return invocation
+}
+
+let electronApi: ApiRoot
+let webApi: ApiRoot
+
+beforeEach(async () => {
+  vi.useFakeTimers()
+  vi.resetModules()
+  Object.defineProperty(process, 'contextIsolated', { value: true, configurable: true })
+  electronMocks.exposeInMainWorld.mockClear()
+  electronMocks.invoke.mockReset().mockResolvedValue(null)
+  webInvocations.length = 0
+  sessionStorage.clear()
+  sessionStorage.setItem('open-science-web-client', 'argument-shape-client')
+  delete (window as unknown as { api?: unknown }).api
+  vi.stubGlobal('WebSocket', FakeWebSocket)
+  vi.stubGlobal(
+    'fetch',
+    vi.fn(async (input: RequestInfo | URL, init?: RequestInit) => {
+      if (String(input) === '/api/bootstrap') {
+        return new Response(
+          JSON.stringify({
+            platform: 'test',
+            versions: { electron: '1', chrome: '1', node: '1' },
+            rpcProtocolVersion: WEB_RPC_PROTOCOL_VERSION,
+            rpcChannels
+          }),
+          { status: 200, headers: { 'content-type': 'application/json' } }
+        )
+      }
+
+      const match = String(input).match(/^\/rpc\/(.+)$/)
+      if (!match) throw new Error(`Unexpected fetch: ${String(input)}`)
+      const payload = JSON.parse(String(init?.body)) as { args: unknown[] }
+      webInvocations.push({ channel: decodeURIComponent(match[1]), args: payload.args })
+      return new Response(
+        JSON.stringify({
+          protocolVersion: WEB_RPC_PROTOCOL_VERSION,
+          ok: true,
+          result: null
+        }),
+        { status: 200, headers: { 'content-type': 'application/json' } }
+      )
+    })
+  )
+
+  electronApi = await loadElectronApi()
+  webApi = await loadWebApi()
+})
+
+afterEach(() => {
+  vi.clearAllTimers()
+  vi.useRealTimers()
+  vi.unstubAllGlobals()
+  sessionStorage.clear()
+  delete (window as unknown as { api?: unknown }).api
+})
+
+describe('renderer argument-shape characterization', () => {
+  it('records the nine known Runtime deviations without treating them as equivalences', async () => {
+    const selection = { kind: 'interpreter', path: '/opt/python' }
+    const cases = [
+      {
+        path: 'runtime.setSelection',
+        args: ['python', selection],
+        channel: 'runtime:set-selection',
+        electronArgs: [{ language: 'python', selection }]
+      },
+      {
+        path: 'runtime.listPackages',
+        args: ['python', 'python-env'],
+        channel: 'runtime:list-packages',
+        electronArgs: [{ language: 'python', envId: 'python-env' }]
+      },
+      {
+        path: 'runtime.listPackageCounts',
+        args: ['python'],
+        channel: 'runtime:list-package-counts',
+        electronArgs: [{ language: 'python' }]
+      },
+      {
+        path: 'runtime.getEnablement',
+        args: ['python'],
+        channel: 'runtime:get-enablement',
+        electronArgs: [{ language: 'python' }]
+      },
+      {
+        path: 'runtime.describeUsage',
+        args: ['python', 'python-env'],
+        channel: 'runtime:describe-usage',
+        electronArgs: [{ language: 'python', envId: 'python-env' }]
+      },
+      {
+        path: 'runtime.setEnvironmentEnabled',
+        args: ['python', 'python-env', true, true],
+        channel: 'runtime:set-environment-enabled',
+        electronArgs: [{ language: 'python', envId: 'python-env', enabled: true, force: true }]
+      },
+      {
+        path: 'runtime.setInstallAuthorized',
+        args: ['python', 'python-env', true],
+        channel: 'runtime:set-install-authorized',
+        electronArgs: [{ language: 'python', envId: 'python-env', authorized: true }]
+      },
+      {
+        path: 'runtime.registerInterpreter',
+        args: ['python', '/opt/python'],
+        channel: 'runtime:register-interpreter',
+        electronArgs: [{ language: 'python', path: '/opt/python' }]
+      },
+      {
+        path: 'runtime.unregisterInterpreter',
+        args: ['python', '/opt/python'],
+        channel: 'runtime:unregister-interpreter',
+        electronArgs: [{ language: 'python', path: '/opt/python' }]
+      }
+    ] as const
+
+    for (const testCase of cases) {
+      const electron = await invokeElectron(electronApi, testCase.path, [...testCase.args])
+      const web = await invokeWeb(webApi, testCase.path, [...testCase.args])
+
+      expect(electron, `${testCase.path}: Electron wraps a request object`).toEqual({
+        channel: testCase.channel,
+        args: testCase.electronArgs
+      })
+      expect(web, `${testCase.path}: Web currently forwards positional arguments`).toEqual({
+        channel: testCase.channel,
+        args: testCase.args
+      })
+      expect(web.args, `${testCase.path}: known deviation must remain explicit`).not.toEqual(
+        electron.args
+      )
+    }
+  })
+
+  it('records equivalent session-save calls and the explicit-undefined JSON deviation', async () => {
+    const session = { id: 'session-1', projectId: 'project-1', title: 'Characterization' }
+    const options = { conflictRebaseFields: ['title'] }
+
+    for (const args of [[session], [session, options]]) {
+      const electron = await invokeElectron(electronApi, 'sessions.saveSession', args)
+      const web = await invokeWeb(webApi, 'sessions.saveSession', args)
+
+      expect(web, 'ordinary optional-options usage is intentionally equivalent').toEqual(electron)
+    }
+
+    const electronWithUndefined = await invokeElectron(electronApi, 'sessions.saveSession', [
+      session,
+      undefined
+    ])
+    const webWithUndefined = await invokeWeb(webApi, 'sessions.saveSession', [session, undefined])
+
+    expect(electronWithUndefined).toEqual({
+      channel: 'sessions:save-session',
+      args: [session]
+    })
+    expect(webWithUndefined).toEqual({
+      channel: 'sessions:save-session',
+      args: [session, null]
+    })
+  })
+
+  it('keeps every explicit Web transform equivalent to its Electron wrapper', async () => {
+    const cases = [
+      { path: 'acp.connect', args: [] },
+      { path: 'acp.createSession', args: [] },
+      { path: 'storage.validateDataRoot', args: ['/data'] },
+      { path: 'storage.inspectDataRoot', args: ['/data'] },
+      { path: 'storage.migrate', args: ['/data'] },
+      { path: 'storage.commitAndRelaunch', args: ['/data'] },
+      { path: 'storage.discardMigratedCopy', args: ['/data'] },
+      { path: 'storage.setDataRootAndRelaunch', args: ['/data', true] }
+    ] as const
+
+    for (const testCase of cases) {
+      const electron = await invokeElectron(electronApi, testCase.path, [...testCase.args])
+      const web = await invokeWeb(webApi, testCase.path, [...testCase.args])
+
+      expect(web, `${testCase.path}: explicit Web transform is an intended equivalence`).toEqual(
+        electron
+      )
+    }
+  })
+})

--- a/src/shared/renderer-surface-inventory.test.ts
+++ b/src/shared/renderer-surface-inventory.test.ts
@@ -216,22 +216,18 @@ describe('renderer surface inventory', () => {
     ])
   })
 
-  it('distinguishes browser-native replacements from Electron-only callables', () => {
+  it('pins browser-native replacements and Electron-only categories', () => {
     expectSameSet(WEB_RPC_UNAVAILABLE_CHANNELS, WEB_UNAVAILABLE_CHANNELS)
 
-    const localWebPaths = new Set([
-      ...Object.entries(WEB_INVOKE_CHANNELS)
-        .filter(([, channel]) => WEB_RPC_ALLOWED_CHANNELS.includes(channel))
-        .map(([path]) => path),
-      ...Object.keys(WEB_EVENT_CHANNELS),
-      ...BROWSER_NATIVE_CALLABLE_PATHS
-    ])
-    const electronOnlyPaths = collectFunctionPaths(exposedApi).filter(
-      (path) => !localWebPaths.has(path)
-    )
+    const electronPaths = new Set(collectFunctionPaths(exposedApi))
+    const browserNativePaths = new Set<string>(BROWSER_NATIVE_CALLABLE_PATHS)
+    const electronOnlyPaths = new Set<string>(ELECTRON_ONLY_CALLABLE_PATHS)
 
-    expect(localWebPaths).toHaveLength(250)
-    expectSameSet(electronOnlyPaths, ELECTRON_ONLY_CALLABLE_PATHS)
+    expect(browserNativePaths.size).toBe(BROWSER_NATIVE_CALLABLE_PATHS.length)
+    expect(electronOnlyPaths.size).toBe(ELECTRON_ONLY_CALLABLE_PATHS.length)
+    expect([...browserNativePaths].every((path) => electronPaths.has(path))).toBe(true)
+    expect([...electronOnlyPaths].every((path) => electronPaths.has(path))).toBe(true)
+    expect([...browserNativePaths].every((path) => !electronOnlyPaths.has(path))).toBe(true)
   })
 
   it('pins remote local-only policy as an exact subset of local Web RPC', () => {

--- a/src/shared/renderer-surface-inventory.test.ts
+++ b/src/shared/renderer-surface-inventory.test.ts
@@ -1,0 +1,246 @@
+import { beforeAll, describe, expect, it, vi } from 'vitest'
+
+import type { ApplicationEventChannel } from '../main/application-events'
+import { REMOTE_LOCAL_ONLY_RPC_CHANNELS } from '../main/web-service/http-server'
+import { WEB_EVENT_CHANNELS, WEB_INVOKE_CHANNELS } from './web-api-map.generated'
+import { WEB_RPC_ALLOWED_CHANNELS, WEB_RPC_UNAVAILABLE_CHANNELS } from './web-rpc-contract'
+
+const { exposeMock } = vi.hoisted(() => ({ exposeMock: vi.fn() }))
+
+vi.mock('electron', () => ({
+  contextBridge: { exposeInMainWorld: exposeMock },
+  ipcRenderer: {
+    invoke: vi.fn(),
+    on: vi.fn(),
+    removeListener: vi.fn(),
+    send: vi.fn()
+  },
+  net: { fetch: vi.fn() },
+  webUtils: { getPathForFile: vi.fn() }
+}))
+
+type GroupedInventory = Readonly<Record<string, readonly string[]>>
+
+const expand = (groups: GroupedInventory, separator: string): string[] =>
+  Object.entries(groups).flatMap(([prefix, names]) =>
+    names.map((name) => (prefix ? `${prefix}${separator}${name}` : name))
+  )
+
+const expectSameSet = (actual: Iterable<string>, expected: Iterable<string>): void => {
+  const actualValues = [...actual]
+  const expectedValues = [...expected]
+
+  expect(new Set(actualValues).size).toBe(actualValues.length)
+  expect(new Set(expectedValues).size).toBe(expectedValues.length)
+  expect(actualValues.sort()).toEqual(expectedValues.sort())
+}
+
+type InstalledWebEventChannel = (typeof WEB_EVENT_CHANNELS)[keyof typeof WEB_EVENT_CHANNELS]
+type InstalledButNotDeliveredEventChannel = Exclude<
+  InstalledWebEventChannel,
+  ApplicationEventChannel
+>
+
+const INSTALLED_BUT_NOT_DELIVERED_EVENTS = {
+  'notebook-env:progress': true,
+  'notifications:open-session': true,
+  'notifications:probe-unread-view': true,
+  'shortcut:close-active-pane': true,
+  'uploads:transfer-progress': true
+} as const satisfies Record<InstalledButNotDeliveredEventChannel, true>
+
+// These functions exist on the real Electron preload API but the current AST generator does not
+// recognize their implementation shape or channel constants. T1b must make each omission explicit.
+const GENERATED_SOURCE_OMISSIONS = [
+  'diagnostics.reportRendererFailure',
+  'getRuntimeVersions',
+  'handoff.list',
+  'handoff.onChanged',
+  'handoff.retry',
+  'notifications.syncViewState',
+  'officePreview.attachFrame',
+  'officePreview.close',
+  'officePreview.onState',
+  'officePreview.open',
+  'officePreview.reportState',
+  'sessions.onFlushRequest',
+  'sessions.sendFlushResponse',
+  'specialist.cancelHandoff',
+  'specialist.create',
+  'specialist.delete',
+  'specialist.duplicate',
+  'specialist.getHandoffEvents',
+  'specialist.list',
+  'specialist.onCatalogChanged',
+  'specialist.onHandoffLifecycleEvent',
+  'specialist.onPendingSwitch',
+  'specialist.resolveSessionSpecialist',
+  'specialist.retryHandoff',
+  'specialist.setEnabled',
+  'specialist.setSessionSpecialist',
+  'specialist.update',
+  'window.announceWindowFindAppearance',
+  'window.announceWindowFindReady',
+  'window.clearFind',
+  'window.closeFind',
+  'window.findInPage',
+  'window.onCloseConfirmRequest',
+  'window.onFindInPageResult',
+  'window.onShowWindowFind',
+  'window.onWindowFindAppearance',
+  'window.sendCloseConfirmResponse'
+] as const
+
+const BROWSER_NATIVE_CALLABLE_PATHS = [
+  'getRuntimeVersions',
+  'saveBlobFile',
+  'saveManagedFile',
+  'window.close'
+] as const
+
+const WEB_UNAVAILABLE_CHANNELS = [
+  'file:save-blob',
+  'file:save-managed',
+  'file:save-session-artifacts',
+  'sessions:export-conversation',
+  'settings:import-agent-home-skills',
+  'settings:list-agent-home-skills',
+  'uploads:stage-local-file',
+  'window:close'
+] as const
+
+const REMOTE_LOCAL_ONLY_CHANNELS: GroupedInventory = {
+  artifacts: ['open-file'],
+  cli: ['install', 'uninstall'],
+  compute: ['download', 'reveal-in-folder'],
+  'local-fs': ['get-roots', 'list-dir', 'open-path', 'read-preview', 'reveal'],
+  logs: ['open-file', 'reveal-in-folder'],
+  'notebook-env': ['cancel', 'provision', 'repair'],
+  notebook: ['export-ipynb', 'export-ipynb-all'],
+  runtime: [
+    'pick-interpreter',
+    'register-interpreter',
+    'set-environment-enabled',
+    'set-install-authorized',
+    'set-selection',
+    'unregister-interpreter'
+  ],
+  settings: [
+    'cancel-claude-login',
+    'cancel-codex-login',
+    'cancel-isolated-claude-login',
+    'install-claude',
+    'install-codex',
+    'install-opencode',
+    'login-isolated-claude',
+    'login-isolated-claude-browser',
+    'login-isolated-codex',
+    'login-shared-claude',
+    'logout-isolated-claude',
+    'logout-isolated-codex',
+    'logout-shared-claude',
+    'set-app-icon-variant',
+    'set-close-preference',
+    'set-notifications-enabled',
+    'set-package-mirror',
+    'uninstall-claude',
+    'uninstall-codex',
+    'uninstall-opencode'
+  ],
+  storage: [
+    'cancel-migrate',
+    'commit-and-relaunch',
+    'discard-migrated-copy',
+    'inspect-data-root',
+    'migrate',
+    'pick-directory',
+    'reveal-app-storage',
+    'set-data-root-and-relaunch',
+    'validate-data-root'
+  ],
+  update: ['apply', 'cancel', 'download'],
+  uploads: ['stage-local-path']
+}
+
+const ELECTRON_ONLY_CALLABLE_PATHS = [
+  ...GENERATED_SOURCE_OMISSIONS.filter((path) => path !== 'getRuntimeVersions'),
+  'saveSessionArtifacts',
+  'sessions.exportConversation',
+  'settings.importAgentHomeSkills',
+  'settings.listAgentHomeSkills',
+  'uploads.stageLocalFile'
+] as const
+
+const collectFunctionPaths = (value: unknown, prefix = ''): string[] => {
+  if (typeof value === 'function') return [prefix]
+  if (!value || typeof value !== 'object') return []
+
+  return Object.entries(value).flatMap(([key, child]) =>
+    collectFunctionPaths(child, prefix ? `${prefix}.${key}` : key)
+  )
+}
+
+let exposedApi: unknown
+
+beforeAll(async () => {
+  Object.defineProperty(process, 'contextIsolated', { value: true, configurable: true })
+  await import('../preload/index')
+  exposedApi = exposeMock.mock.calls.find(([name]) => name === 'api')?.[1]
+  if (!exposedApi) throw new Error('preload did not expose window.api')
+})
+
+describe('renderer surface inventory', () => {
+  it('pins the cross-surface inventory and every generator omission', () => {
+    const electronPaths = collectFunctionPaths(exposedApi)
+    const generatedPaths = new Set([
+      ...Object.keys(WEB_INVOKE_CHANNELS),
+      ...Object.keys(WEB_EVENT_CHANNELS)
+    ])
+
+    expect(electronPaths).toHaveLength(291)
+    expect(Object.keys(WEB_INVOKE_CHANNELS)).toHaveLength(222)
+    expect(Object.keys(WEB_EVENT_CHANNELS)).toHaveLength(32)
+    expectSameSet(
+      electronPaths.filter((path) => !generatedPaths.has(path)),
+      GENERATED_SOURCE_OMISSIONS
+    )
+  })
+
+  it('pins subscriptions installed in Web but not published through ApplicationEventHub', () => {
+    expectSameSet(Object.keys(INSTALLED_BUT_NOT_DELIVERED_EVENTS), [
+      'notebook-env:progress',
+      'notifications:open-session',
+      'notifications:probe-unread-view',
+      'shortcut:close-active-pane',
+      'uploads:transfer-progress'
+    ])
+  })
+
+  it('distinguishes browser-native replacements from Electron-only callables', () => {
+    expectSameSet(WEB_RPC_UNAVAILABLE_CHANNELS, WEB_UNAVAILABLE_CHANNELS)
+
+    const localWebPaths = new Set([
+      ...Object.entries(WEB_INVOKE_CHANNELS)
+        .filter(([, channel]) => WEB_RPC_ALLOWED_CHANNELS.includes(channel))
+        .map(([path]) => path),
+      ...Object.keys(WEB_EVENT_CHANNELS),
+      ...BROWSER_NATIVE_CALLABLE_PATHS
+    ])
+    const electronOnlyPaths = collectFunctionPaths(exposedApi).filter(
+      (path) => !localWebPaths.has(path)
+    )
+
+    expect(localWebPaths).toHaveLength(250)
+    expectSameSet(electronOnlyPaths, ELECTRON_ONLY_CALLABLE_PATHS)
+  })
+
+  it('pins remote local-only policy as an exact subset of local Web RPC', () => {
+    const expectedRemoteLocalOnly = expand(REMOTE_LOCAL_ONLY_CHANNELS, ':')
+
+    expectSameSet(REMOTE_LOCAL_ONLY_RPC_CHANNELS, expectedRemoteLocalOnly)
+    expect(expectedRemoteLocalOnly).toHaveLength(56)
+    expect(
+      expectedRemoteLocalOnly.every((channel) => WEB_RPC_ALLOWED_CHANNELS.includes(channel))
+    ).toBe(true)
+  })
+})

--- a/src/shared/renderer-surface-matrix.test.ts
+++ b/src/shared/renderer-surface-matrix.test.ts
@@ -1,0 +1,312 @@
+import { readFile } from 'node:fs/promises'
+import { resolve } from 'node:path'
+
+import { describe, expect, it } from 'vitest'
+
+import {
+  canSatisfyHumanApproval,
+  createElectronCallerContext,
+  createTaskCallerContext,
+  createWebCallerContext
+} from '../main/caller-context'
+import { ApplicationEventHub, type ApplicationEvent } from '../main/application-events'
+import {
+  projectPublicTaskEvent,
+  projectTaskRuntimeEvent,
+  projectWebRendererEvent
+} from '../main/web-service/application-event-projections'
+import { REMOTE_LOCAL_ONLY_RPC_CHANNELS } from '../main/web-service/http-server'
+import { installWebInvokeChannels } from '../renderer/web/api-installer'
+import type { AcpRuntimeEvent } from './acp'
+import { SPECIALIST_IPC } from './specialist'
+import { WEB_EVENT_CHANNELS, WEB_INVOKE_CHANNELS } from './web-api-map.generated'
+import { isWebRpcChannel, isWebRpcEventChannel } from './web-rpc-contract'
+
+const permissionPaths = [
+  'acp.respondToPermission',
+  'acp.revokePermissionGrant',
+  'acp.setPermissionProfile',
+  'permissions.extendUndo',
+  'permissions.list',
+  'permissions.restore',
+  'permissions.revoke'
+] as const
+
+const permissionEventPaths = ['acp.onPermissionRequest', 'permissions.onChanged'] as const
+
+const computePaths = [
+  'compute.bookmarksGet',
+  'compute.bookmarksSet',
+  'compute.concurrencySet',
+  'compute.create',
+  'compute.delete',
+  'compute.detailsGet',
+  'compute.detailsSave',
+  'compute.download',
+  'compute.enabledHostsGet',
+  'compute.enabledHostsSet',
+  'compute.get',
+  'compute.jobsList',
+  'compute.jobsMarkConsumed',
+  'compute.jobsPendingNotification',
+  'compute.list',
+  'compute.listDir',
+  'compute.probe',
+  'compute.respondApproval',
+  'compute.revealInFolder',
+  'compute.scratchSet',
+  'compute.sshConfigAliases'
+] as const
+
+const computeEventPaths = ['compute.onApprovalRequest', 'compute.onJobUpdated'] as const
+
+const source = (path: string): Promise<string> => readFile(resolve(path), 'utf8')
+
+const pathsWithPrefix = (paths: readonly string[], prefix: string): string[] =>
+  paths.filter((path) => path.startsWith(prefix)).sort()
+
+describe('renderer surface compatibility matrix', () => {
+  it('keeps Specialist management and pending-switch delivery Electron-only', async () => {
+    const invokePaths = Object.keys(WEB_INVOKE_CHANNELS)
+    const eventPaths = Object.keys(WEB_EVENT_CHANNELS)
+    const specialistChannels = Object.values(SPECIALIST_IPC)
+
+    expect(pathsWithPrefix(invokePaths, 'specialist.')).toEqual([])
+    expect(pathsWithPrefix(eventPaths, 'specialist.')).toEqual([])
+    expect(specialistChannels.every((channel) => !isWebRpcChannel(channel))).toBe(true)
+    expect(specialistChannels.every((channel) => !isWebRpcEventChannel(channel))).toBe(true)
+
+    const hub = new ApplicationEventHub()
+    const installedEvents: ApplicationEvent[] = []
+    hub.subscribe((event) => installedEvents.push(event))
+    hub.publish('specialist:catalog-changed', undefined)
+    hub.publish('specialist:pending-switch', {
+      sessionId: 'session-1',
+      targetName: 'ANALYST'
+    })
+
+    expect(installedEvents.map((event) => event.channel)).toEqual([
+      'specialist:catalog-changed',
+      'specialist:pending-switch'
+    ])
+    for (const event of installedEvents) {
+      expect(projectWebRendererEvent(event)).toBeUndefined()
+      expect(projectPublicTaskEvent(event)).toBeUndefined()
+      expect(projectTaskRuntimeEvent(event)).toBeUndefined()
+    }
+
+    const [preloadSource, rendererBroadcastSource] = await Promise.all([
+      source('src/preload/index.ts'),
+      source('src/main/renderer-broadcast.ts')
+    ])
+    expect(preloadSource).toContain('specialist: {')
+    expect(preloadSource).toContain(
+      'onPendingSwitch: (listener) => onIpcMessage(SPECIALIST_IPC.PENDING_SWITCH, listener)'
+    )
+    // Electron receives every installed application event; only the Web projection applies an
+    // allowlist. This is intentionally different from an event that was never installed.
+    expect(rendererBroadcastSource).toContain('projectToElectron(event.channel, event.payload)')
+  })
+
+  it('keeps Permission available on Electron and both Web locations without granting Task human authority', () => {
+    const invokePaths = Object.keys(WEB_INVOKE_CHANNELS)
+    const eventPaths = Object.keys(WEB_EVENT_CHANNELS)
+
+    expect(
+      pathsWithPrefix(invokePaths, 'permissions.').map(
+        (path) => path as (typeof permissionPaths)[number]
+      )
+    ).toEqual(permissionPaths.filter((path) => path.startsWith('permissions.')))
+    expect(permissionPaths.map((path) => WEB_INVOKE_CHANNELS[path])).toEqual([
+      'acp:respond-permission',
+      'acp:revoke-permission-grant',
+      'acp:set-permission-profile',
+      'permissions:extend-undo',
+      'permissions:list',
+      'permissions:restore',
+      'permissions:revoke'
+    ])
+    expect(permissionPaths.map((path) => WEB_INVOKE_CHANNELS[path]).every(isWebRpcChannel)).toBe(
+      true
+    )
+    expect(permissionEventPaths.map((path) => WEB_EVENT_CHANNELS[path])).toEqual([
+      'acp:permission-request',
+      'permissions:changed'
+    ])
+    expect(
+      permissionEventPaths.map((path) => WEB_EVENT_CHANNELS[path]).every(isWebRpcEventChannel)
+    ).toBe(true)
+    expect(pathsWithPrefix(eventPaths, 'permissions.')).toEqual(['permissions.onChanged'])
+    expect(
+      permissionPaths
+        .map((path) => WEB_INVOKE_CHANNELS[path])
+        .filter((channel) => REMOTE_LOCAL_ONLY_RPC_CHANNELS.has(channel))
+    ).toEqual([])
+
+    expect(canSatisfyHumanApproval(createElectronCallerContext(1))).toBe(true)
+    expect(canSatisfyHumanApproval(createWebCallerContext('local-browser'))).toBe(true)
+    expect(
+      canSatisfyHumanApproval(createWebCallerContext('remote-browser', { location: 'remote' }))
+    ).toBe(true)
+    expect(canSatisfyHumanApproval(createTaskCallerContext())).toBe(false)
+    expect(
+      canSatisfyHumanApproval(
+        createWebCallerContext('expired-browser', {
+          location: 'remote',
+          isAuthorizationCurrent: () => false
+        })
+      )
+    ).toBe(false)
+  })
+
+  it('keeps Compute complete locally and rejects only native download/reveal on remote Web', async () => {
+    const invokePaths = Object.keys(WEB_INVOKE_CHANNELS)
+    const eventPaths = Object.keys(WEB_EVENT_CHANNELS)
+
+    expect(pathsWithPrefix(invokePaths, 'compute.')).toEqual(computePaths)
+    expect(computePaths.map((path) => WEB_INVOKE_CHANNELS[path]).every(isWebRpcChannel)).toBe(true)
+    expect(pathsWithPrefix(eventPaths, 'compute.')).toEqual(computeEventPaths)
+    expect(computeEventPaths.map((path) => WEB_EVENT_CHANNELS[path])).toEqual([
+      'compute:approval-request',
+      'compute:job-updated'
+    ])
+
+    const remoteRestrictedCompute = computePaths
+      .map((path) => WEB_INVOKE_CHANNELS[path])
+      .filter((channel) => REMOTE_LOCAL_ONLY_RPC_CHANNELS.has(channel))
+    expect(remoteRestrictedCompute).toEqual(['compute:download', 'compute:reveal-in-folder'])
+
+    const remoteApi: Record<string, unknown> = {}
+    installWebInvokeChannels(
+      remoteApi,
+      {
+        'compute.download': WEB_INVOKE_CHANNELS['compute.download'],
+        'compute.revealInFolder': WEB_INVOKE_CHANNELS['compute.revealInFolder']
+      },
+      new Set(),
+      new Set(remoteRestrictedCompute),
+      () => async () => undefined
+    )
+    const remoteCompute = remoteApi.compute as {
+      download(): Promise<unknown>
+      revealInFolder(): Promise<unknown>
+    }
+    await expect(remoteCompute.download()).rejects.toThrow(
+      'This action is only available in the local desktop app (compute:download).'
+    )
+    await expect(remoteCompute.revealInFolder()).rejects.toThrow(
+      'This action is only available in the local desktop app (compute:reveal-in-folder).'
+    )
+  })
+
+  it('keeps CLI, Task, SDK, and local RPC capability subsets explicit', async () => {
+    const [cliSource, sdkSource, taskContractSource, localRpcSource] = await Promise.all([
+      source('packages/open-science/cli.mjs'),
+      source('packages/open-science/index.mjs'),
+      source('src/shared/task-api.ts'),
+      source('src/main/notebook/local-rpc-server.ts')
+    ])
+
+    expect(cliSource).toContain('--approval-profile <profile>')
+    expect(cliSource).toContain("event.type === 'permission.requested'")
+    expect(cliSource).not.toMatch(/--(?:specialist|compute|permission-grant)\b/)
+    expect(taskContractSource).toContain('permissionProfile?: PermissionProfileId')
+    expect(taskContractSource).not.toMatch(/\b(?:specialist|compute|permissionGrant)\w*\??:/i)
+
+    const sdkClass = sdkSource.slice(
+      sdkSource.indexOf('export class OpenScienceClient'),
+      sdkSource.indexOf('export const connectToOpenScience')
+    )
+    const sdkMethods = [...sdkClass.matchAll(/^ {2}(?:async )?([a-zA-Z][a-zA-Z0-9_]*)\(/gm)].map(
+      ([, method]) => method
+    )
+    expect(sdkMethods).toEqual([
+      'constructor',
+      'health',
+      'listProjects',
+      'createProject',
+      'listSessions',
+      'getSession',
+      'startRun',
+      'getRun',
+      'waitForRun',
+      'listArtifacts',
+      'downloadArtifact',
+      'events',
+      'request',
+      'throwResponseError'
+    ])
+
+    expect(localRpcSource).toContain(
+      "const CONTROL_RPC_METHODS = new Set(['mcpCall', 'computeCall', 'agentsCall'])"
+    )
+    const computeBlock = localRpcSource.slice(
+      localRpcSource.indexOf("if (method === 'computeCall')"),
+      localRpcSource.indexOf('// agentsCall:')
+    )
+    expect([...computeBlock.matchAll(/if \(op === '([^']+)'\)/g)].map(([, op]) => op)).toEqual([
+      'call_command',
+      'list',
+      'details',
+      'download',
+      'submit_job',
+      'job_status',
+      'job_result',
+      'list_compute',
+      'set_concurrency_limit',
+      'concurrency_status'
+    ])
+    expect(localRpcSource).toContain('session-bound RPC capability')
+    expect(computeBlock).not.toMatch(/\b(?:create|delete|probe|reveal_in_folder|bookmarks)\b/)
+  })
+
+  it('keeps projectFiles.searchArtifacts on Electron and both Web locations only', async () => {
+    expect(WEB_INVOKE_CHANNELS['projectFiles.searchArtifacts']).toBe(
+      'project-files:search-artifacts'
+    )
+    expect(isWebRpcChannel('project-files:search-artifacts')).toBe(true)
+    expect(REMOTE_LOCAL_ONLY_RPC_CHANNELS.has('project-files:search-artifacts')).toBe(false)
+
+    const [preloadSource, taskContractSource, sdkSource, localRpcSource] = await Promise.all([
+      source('src/preload/index.ts'),
+      source('src/shared/task-api.ts'),
+      source('packages/open-science/index.mjs'),
+      source('src/main/notebook/local-rpc-server.ts')
+    ])
+    expect(preloadSource).toMatch(
+      /searchArtifacts: \(request\) =>\s+ipcRenderer\.invoke\(\s*'project-files:search-artifacts',\s*request\s*\)/
+    )
+    expect(taskContractSource).not.toContain('searchArtifacts')
+    expect(sdkSource).not.toContain('searchArtifacts')
+    expect(localRpcSource).not.toContain('searchArtifacts')
+  })
+
+  it('passes terminal ACP metadata through Web and Task projections without recomputation', () => {
+    const payload: AcpRuntimeEvent = {
+      id: 'terminal-1',
+      timestamp: 1_700_000_000_123,
+      kind: 'stop',
+      level: 'info',
+      sessionId: 'session-1',
+      promptMessageId: 'prompt-1',
+      terminalOutput: 'complete',
+      terminalExitCode: 0,
+      turnUsage: {
+        inputTokens: 17,
+        cacheTokens: 5,
+        cachedReadTokens: 3,
+        cachedWriteTokens: 2,
+        outputTokens: 9,
+        turnCount: 4
+      },
+      raw: { providerSessionId: 'provider-session' }
+    }
+    const event: ApplicationEvent<'acp:event'> = { channel: 'acp:event', payload }
+
+    expect(projectTaskRuntimeEvent(event)).toBe(payload)
+    expect(projectPublicTaskEvent(event)).toEqual({ type: 'run.event', data: payload })
+    const webEvent = projectWebRendererEvent(event)
+    expect(webEvent).toMatchObject({ protocolVersion: 1, channel: 'acp:event' })
+    expect(webEvent?.payload).toBe(payload)
+  })
+})

--- a/src/shared/renderer-surface-matrix.test.ts
+++ b/src/shared/renderer-surface-matrix.test.ts
@@ -1,6 +1,3 @@
-import { readFile } from 'node:fs/promises'
-import { resolve } from 'node:path'
-
 import { describe, expect, it } from 'vitest'
 
 import {
@@ -19,8 +16,17 @@ import { REMOTE_LOCAL_ONLY_RPC_CHANNELS } from '../main/web-service/http-server'
 import { installWebInvokeChannels } from '../renderer/web/api-installer'
 import type { AcpRuntimeEvent } from './acp'
 import { SPECIALIST_IPC } from './specialist'
+import type { StartTaskRunRequest } from './task-api'
 import { WEB_EVENT_CHANNELS, WEB_INVOKE_CHANNELS } from './web-api-map.generated'
 import { isWebRpcChannel, isWebRpcEventChannel } from './web-rpc-contract'
+
+const TASK_RUN_REQUEST_FIELDS = {
+  project: true,
+  prompt: true,
+  sessionId: true,
+  permissionProfile: true,
+  skillIds: true
+} as const satisfies Record<keyof StartTaskRunRequest, true>
 
 const permissionPaths = [
   'acp.respondToPermission',
@@ -60,13 +66,11 @@ const computePaths = [
 
 const computeEventPaths = ['compute.onApprovalRequest', 'compute.onJobUpdated'] as const
 
-const source = (path: string): Promise<string> => readFile(resolve(path), 'utf8')
-
 const pathsWithPrefix = (paths: readonly string[], prefix: string): string[] =>
   paths.filter((path) => path.startsWith(prefix)).sort()
 
 describe('renderer surface compatibility matrix', () => {
-  it('keeps Specialist management and pending-switch delivery Electron-only', async () => {
+  it('keeps Specialist management and pending-switch delivery Electron-only', () => {
     const invokePaths = Object.keys(WEB_INVOKE_CHANNELS)
     const eventPaths = Object.keys(WEB_EVENT_CHANNELS)
     const specialistChannels = Object.values(SPECIALIST_IPC)
@@ -94,18 +98,6 @@ describe('renderer surface compatibility matrix', () => {
       expect(projectPublicTaskEvent(event)).toBeUndefined()
       expect(projectTaskRuntimeEvent(event)).toBeUndefined()
     }
-
-    const [preloadSource, rendererBroadcastSource] = await Promise.all([
-      source('src/preload/index.ts'),
-      source('src/main/renderer-broadcast.ts')
-    ])
-    expect(preloadSource).toContain('specialist: {')
-    expect(preloadSource).toContain(
-      'onPendingSwitch: (listener) => onIpcMessage(SPECIALIST_IPC.PENDING_SWITCH, listener)'
-    )
-    // Electron receives every installed application event; only the Web projection applies an
-    // allowlist. This is intentionally different from an event that was never installed.
-    expect(rendererBroadcastSource).toContain('projectToElectron(event.channel, event.payload)')
   })
 
   it('keeps Permission available on Electron and both Web locations without granting Task human authority', () => {
@@ -157,6 +149,13 @@ describe('renderer surface compatibility matrix', () => {
         })
       )
     ).toBe(false)
+    expect(Object.keys(TASK_RUN_REQUEST_FIELDS).sort()).toEqual([
+      'permissionProfile',
+      'project',
+      'prompt',
+      'sessionId',
+      'skillIds'
+    ])
   })
 
   it('keeps Compute complete locally and rejects only native download/reveal on remote Web', async () => {
@@ -199,86 +198,12 @@ describe('renderer surface compatibility matrix', () => {
     )
   })
 
-  it('keeps CLI, Task, SDK, and local RPC capability subsets explicit', async () => {
-    const [cliSource, sdkSource, taskContractSource, localRpcSource] = await Promise.all([
-      source('packages/open-science/cli.mjs'),
-      source('packages/open-science/index.mjs'),
-      source('src/shared/task-api.ts'),
-      source('src/main/notebook/local-rpc-server.ts')
-    ])
-
-    expect(cliSource).toContain('--approval-profile <profile>')
-    expect(cliSource).toContain("event.type === 'permission.requested'")
-    expect(cliSource).not.toMatch(/--(?:specialist|compute|permission-grant)\b/)
-    expect(taskContractSource).toContain('permissionProfile?: PermissionProfileId')
-    expect(taskContractSource).not.toMatch(/\b(?:specialist|compute|permissionGrant)\w*\??:/i)
-
-    const sdkClass = sdkSource.slice(
-      sdkSource.indexOf('export class OpenScienceClient'),
-      sdkSource.indexOf('export const connectToOpenScience')
-    )
-    const sdkMethods = [...sdkClass.matchAll(/^ {2}(?:async )?([a-zA-Z][a-zA-Z0-9_]*)\(/gm)].map(
-      ([, method]) => method
-    )
-    expect(sdkMethods).toEqual([
-      'constructor',
-      'health',
-      'listProjects',
-      'createProject',
-      'listSessions',
-      'getSession',
-      'startRun',
-      'getRun',
-      'waitForRun',
-      'listArtifacts',
-      'downloadArtifact',
-      'events',
-      'request',
-      'throwResponseError'
-    ])
-
-    expect(localRpcSource).toContain(
-      "const CONTROL_RPC_METHODS = new Set(['mcpCall', 'computeCall', 'agentsCall'])"
-    )
-    const computeBlock = localRpcSource.slice(
-      localRpcSource.indexOf("if (method === 'computeCall')"),
-      localRpcSource.indexOf('// agentsCall:')
-    )
-    expect([...computeBlock.matchAll(/if \(op === '([^']+)'\)/g)].map(([, op]) => op)).toEqual([
-      'call_command',
-      'list',
-      'details',
-      'download',
-      'submit_job',
-      'job_status',
-      'job_result',
-      'list_compute',
-      'set_concurrency_limit',
-      'concurrency_status'
-    ])
-    expect(localRpcSource).toContain('session-bound RPC capability')
-    expect(computeBlock).not.toMatch(/\b(?:create|delete|probe|reveal_in_folder|bookmarks)\b/)
-  })
-
-  it('keeps projectFiles.searchArtifacts on Electron and both Web locations only', async () => {
+  it('keeps projectFiles.searchArtifacts on local and remote Web', () => {
     expect(WEB_INVOKE_CHANNELS['projectFiles.searchArtifacts']).toBe(
       'project-files:search-artifacts'
     )
     expect(isWebRpcChannel('project-files:search-artifacts')).toBe(true)
     expect(REMOTE_LOCAL_ONLY_RPC_CHANNELS.has('project-files:search-artifacts')).toBe(false)
-
-    const [preloadSource, taskContractSource, sdkSource, localRpcSource] = await Promise.all([
-      source('src/preload/index.ts'),
-      source('src/shared/task-api.ts'),
-      source('packages/open-science/index.mjs'),
-      source('src/main/notebook/local-rpc-server.ts')
-    ])
-    expect(preloadSource).toMatch(
-      /searchArtifacts: \(request\) =>\s+ipcRenderer\.invoke\(\s*'project-files:search-artifacts',\s*request\s*\)/
-    )
-    expect(taskContractSource).not.toContain('searchArtifacts')
-    expect(sdkSource).not.toContain('searchArtifacts')
-    expect(localRpcSource).not.toContain('searchArtifacts')
   })
 
   it('passes terminal ACP metadata through Web and Task projections without recomputation', () => {


### PR DESCRIPTION
## Problem

Electron, local Web, remote Web, CLI, SDK, Task, and notebook local-RPC expose intentionally different runtime capabilities. Before extracting shared renderer transport catalogs, the current surface and argument semantics need executable characterization so later refactors cannot silently change capability ownership or cross-surface behavior.

## Proposed change

- Pin the real Electron preload callable inventory, generated Web invoke/event inventory, Web exclusions, remote local-only policy, and currently installed-but-undelivered Web events.
- Load the real Web bootstrap and compare its installed callable surface with the local Web contract.
- Record nine existing Runtime argument-shape deviations and the `sessions.saveSession(session, undefined)` Electron/Web JSON deviation without repairing them.
- Pin Specialist, Permission, Compute, Task, SDK, CLI, local-RPC, ACP terminal metadata, `projectFiles.searchArtifacts`, and graceful renderer flush compatibility boundaries with behavioral or structured contract tests.
- Verify Electron renderer flush acknowledgements require the target sender and matching request ID, and remove the exact listeners that were registered.

## Scope and non-goals

- Tests only: no production code, public API, data model, data relationship, UI, or user interaction changes.
- Preserve the current capability asymmetry:
  - Specialist management and pending-switch delivery remain Electron-only.
  - Permission remains available to Electron/Web; Task keeps its current profile/event subset and no human-approval authority.
  - Compute remains complete on Electron/local Web; remote Web still rejects download/reveal; CLI receives no direct management API.
- Do not normalize the known Web argument deviations in this PR.
- Do not introduce Issue #458 orchestration fields, methods, metadata, or public interfaces.

## Acceptance criteria and validation

All commands below ran against the final rebased head after the last material edit unless explicitly noted.

- Cross-surface inventory, argument deviations, authority/event matrices, Specialist delivery, Task/SDK/CLI/local-RPC subsets, `searchArtifacts`, renderer flush, and the rebased provider baseline -> focused Vitest command covering 17 files -> 283 tests passed.
- Generated Web API map remains current -> `npm run check:web-api-map` -> passed.
- Type contracts -> `npm run typecheck` -> passed.
- Lint -> `npm run lint` -> passed with 0 errors and 18 pre-existing warnings.
- Full regression suite -> `npm test -- --maxWorkers=25%` -> 708 files / 10,336 tests passed; 15 files / 184 tests skipped.

Independent spec, test-quality, and preflight reviews reported 0 findings on the rebased head.

## Review focus

- Whether exact inventories describe current behavior without granting new capabilities.
- Whether known argument differences remain explicit deviations rather than accidental equivalences.
- Whether tests rely on real preload/bootstrap/IPC/RPC behavior instead of source-text layout.
- Whether the characterization leaves T1b-T1f free to move implementation behind stable contracts.

## Uncovered risk

No UI E2E suite was run because this PR is tests-only and changes no renderer interaction. Cross-platform execution remains covered by CI; exact inventory tests are intentionally expected to require review whenever a callable surface changes.
