### PR TITLE
feat(files): open files in preview panel

### DIFF
--- a/src/renderer/src/pages/workspace/ManagedFileDownloadButton.tsx
+++ b/src/renderer/src/pages/workspace/ManagedFileDownloadButton.tsx
@@ -10,6 +10,7 @@ type ManagedFileDownloadButtonProps = SaveManagedFileRequest & {
   appearance?: 'icon' | 'primary'
   className?: string
   disabled?: boolean
+  iconSize?: 'icon-xs' | 'icon-sm' | 'icon'
   revealOnParentHover?: boolean
   wrapperClassName?: string
 }
@@ -24,6 +25,7 @@ const ManagedFileDownloadButtonState = ({
   appearance = 'icon',
   className,
   disabled = false,
+  iconSize = 'icon-xs',
   revealOnParentHover = false,
   wrapperClassName
 }: ManagedFileDownloadButtonProps): React.JSX.Element => {
@@ -116,7 +118,7 @@ const ManagedFileDownloadButtonState = ({
             <Button
               type="button"
               variant={isPrimary ? 'default' : 'ghost'}
-              size={isPrimary ? 'sm' : 'icon-xs'}
+              size={isPrimary ? 'sm' : iconSize}
               className={cn(
                 isPrimary ? 'w-24' : 'bg-bg-000/90 shadow-sm',
                 !isPrimary &&

--- a/src/renderer/src/pages/workspace/ProjectFilesView.test.tsx
+++ b/src/renderer/src/pages/workspace/ProjectFilesView.test.tsx
@@ -672,7 +672,53 @@ describe('ProjectFilesView', () => {
       '[aria-label="Preview generated file result.txt"]'
     )
     expect(listRowButton?.className).toContain('focus-visible:outline-none')
-    expect(listRow?.className).toContain('focus-within:ring-3')
+    expect(listRowButton?.className).toContain('cursor-pointer')
+    expect(listRow?.className).toContain('has-[:focus-visible]:ring-3')
+  })
+
+  it('uses matching two-button file actions in grid and list views', async () => {
+    await renderView([
+      createSession({
+        artifacts: [
+          {
+            id: 'artifact-1',
+            kind: 'managed-file',
+            path: '/workspace/result.txt',
+            name: 'result.txt'
+          }
+        ]
+      })
+    ])
+
+    const expectFileActions = (): void => {
+      const buttons = [
+        container.querySelector<HTMLButtonElement>('[aria-label="Download result.txt"]'),
+        container.querySelector<HTMLButtonElement>(
+          '[aria-label="Open result.txt in split view beside the session"]'
+        )
+      ]
+
+      expect(buttons.every(Boolean)).toBe(true)
+      expect(buttons.every((button) => button?.dataset.size === 'icon-sm')).toBe(true)
+      expect(buttons.every((button) => button?.className.includes('cursor-pointer'))).toBe(true)
+      expect(container.querySelector('[aria-label="More actions for result.txt"]')).toBeNull()
+      expect(buttons[1]?.parentElement?.className).toContain('flex')
+    }
+
+    expectFileActions()
+    await act(async () => {
+      container
+        .querySelector<HTMLButtonElement>(
+          '[aria-label="Open result.txt in split view beside the session"]'
+        )
+        ?.focus()
+    })
+    expect(document.body.textContent).toContain('Open in split view beside the session')
+
+    await act(async () => {
+      container.querySelector<HTMLButtonElement>('[aria-label="List view"]')?.click()
+    })
+    expectFileActions()
   })
 
   it('removes the divider only from the first visible file group', async () => {
@@ -745,8 +791,8 @@ describe('ProjectFilesView', () => {
     expect(metadata?.className).toContain('group-hover:invisible')
     expect(metadata?.className).not.toContain('w-16')
     expect(metadata?.className).not.toContain('w-20')
-    expect(downloadWrapper?.className).toContain('absolute')
-    expect(downloadWrapper?.className).toContain('right-2')
+    expect(downloadWrapper?.parentElement?.className).toContain('absolute')
+    expect(downloadWrapper?.parentElement?.className).toContain('right-2')
   })
 
   it('uses a dark neutral clear button with a light neutral hover surface', async () => {
@@ -942,10 +988,14 @@ describe('ProjectFilesView', () => {
     expect(container.textContent).toContain('iso621_bridge_recombinase.fasta')
     expect(container.querySelector('[title="iso621_bridge_recombinase.fasta"]')).not.toBeNull()
     expect(container.textContent).not.toContain('Hidden session title')
-    expect(
-      container.querySelector('[data-testid="project-file-preview"]')?.parentElement?.parentElement
-        ?.className
-    ).toContain('focus-within:ring')
+    const tileClassName = container.querySelector('[data-testid="project-file-preview"]')
+      ?.parentElement?.parentElement?.className
+    const tileButtonClassName = container.querySelector<HTMLButtonElement>(
+      '[aria-label="Preview uploaded file iso621_bridge_recombinase.fasta"]'
+    )?.className
+    expect(tileClassName).toContain('has-[:focus-visible]:ring-2')
+    expect(tileClassName).not.toContain('focus-within:ring')
+    expect(tileButtonClassName).toContain('cursor-pointer')
   })
 
   it('downloads an uploaded file without opening its preview', async () => {
@@ -961,7 +1011,7 @@ describe('ProjectFilesView', () => {
     )
     expect(downloadButton).not.toBeNull()
     expect(
-      downloadButton?.closest('[data-testid="download-tooltip-trigger"]')?.className
+      downloadButton?.closest('[data-testid="download-tooltip-trigger"]')?.parentElement?.className
     ).toContain('absolute')
 
     await act(async () => {
@@ -3199,6 +3249,46 @@ describe('ProjectFilesView', () => {
       name: 'tree.png'
     })
     expect(usePreviewWorkbenchStore.getState().items).toEqual([])
+  })
+
+  it('opens a generated file directly in the preview panel', async () => {
+    await renderView([
+      createSession({
+        id: 'session-1',
+        title: 'Generated session',
+        artifacts: [
+          {
+            id: 'artifact-1',
+            kind: 'managed-file',
+            path: '/workspace/tree.png',
+            fileUrl: 'file:///workspace/tree.png',
+            name: 'tree.png',
+            mimeType: 'image/png',
+            size: 4096,
+            mtimeMs: 1710000002000
+          }
+        ]
+      })
+    ])
+
+    await act(async () => {
+      container
+        .querySelector<HTMLButtonElement>(
+          '[aria-label="Open tree.png in split view beside the session"]'
+        )
+        ?.click()
+    })
+
+    expect(usePreviewWorkbenchStore.getState()).toMatchObject({
+      activeItemId: expect.any(String),
+      panelState: 'open',
+      fileDialogItem: undefined
+    })
+    expect(usePreviewWorkbenchStore.getState().items[0]).toMatchObject({
+      projectId: 'default',
+      sessionId: 'session-1',
+      name: 'tree.png'
+    })
   })
 
   it('does not acquire a TIFF thumbnail until its grid tile is near the viewport', async () => {

--- a/src/renderer/src/pages/workspace/ProjectFilesView.tsx
+++ b/src/renderer/src/pages/workspace/ProjectFilesView.tsx
@@ -1,4 +1,6 @@
+// Hallmark · pre-emit critique: P5 H5 E4 S5 R5 V4
 import {
+  ArrowUpRight,
   Boxes,
   Check,
   ChevronDown,
@@ -520,6 +522,58 @@ const FilePageFooter = ({
   )
 }
 
+// Hallmark · component: file-actions · genre: modern-minimal · theme: workspace tokens
+// states: default · hover · focus · active · disabled · download loading/error/success
+const FileActionButtons = ({
+  source,
+  path,
+  name,
+  disabled,
+  className,
+  onOpenInPanel
+}: {
+  source: 'artifact' | 'upload'
+  path: string
+  name: string
+  disabled: boolean
+  className: string
+  onOpenInPanel: () => void
+}): React.JSX.Element => (
+  <div
+    className={cn(
+      'absolute z-10 flex items-center gap-1 opacity-0 transition-opacity duration-150 group-hover:opacity-100 focus-within:opacity-100 motion-reduce:transition-none [@media(hover:none)]:opacity-100',
+      className
+    )}
+  >
+    <ManagedFileDownloadButton
+      source={source}
+      path={path}
+      suggestedName={name}
+      disabled={disabled}
+      iconSize="icon-sm"
+      className="cursor-pointer border-border bg-bg-000/95 shadow-sm"
+    />
+    <TooltipProvider delayDuration={200}>
+      <Tooltip>
+        <TooltipTrigger asChild>
+          <Button
+            type="button"
+            variant="outline"
+            size="icon-sm"
+            className="cursor-pointer bg-bg-000/95 text-text-100 shadow-sm"
+            aria-label={`Open ${name} in split view beside the session`}
+            disabled={disabled}
+            onClick={onOpenInPanel}
+          >
+            <ArrowUpRight aria-hidden="true" />
+          </Button>
+        </TooltipTrigger>
+        <TooltipContent>Open in split view beside the session</TooltipContent>
+      </Tooltip>
+    </TooltipProvider>
+  </div>
+)
+
 const FileTile = ({
   name,
   previewArtifact,
@@ -530,7 +584,8 @@ const FileTile = ({
   size,
   timestamp,
   previewLabel,
-  onPreview
+  onPreview,
+  onOpenInPanel
 }: {
   name: string
   previewArtifact: MessageArtifact
@@ -542,6 +597,7 @@ const FileTile = ({
   timestamp?: number
   previewLabel: string
   onPreview: () => void
+  onOpenInPanel: () => void
 }): React.JSX.Element => {
   const sizeLabel = formatByteSize(size)
   const relativeTimeLabel = formatRelativeFileTime(timestamp)
@@ -555,11 +611,11 @@ const FileTile = ({
   })
 
   return (
-    <div className="group relative h-[128px] min-w-0 overflow-hidden rounded-lg border border-border-300/50 bg-bg-000 shadow-sm hover:border-border-200 hover:bg-bg-100 focus-within:ring-2 focus-within:ring-ring/50 focus-within:ring-inset">
+    <div className="group relative h-[128px] min-w-0 overflow-hidden rounded-lg border border-border-300/50 bg-bg-000 shadow-sm hover:border-border-200 hover:bg-bg-100 has-[:focus-visible]:ring-2 has-[:focus-visible]:ring-ring/50 has-[:focus-visible]:ring-inset">
       <button
         ref={setTileElement}
         type="button"
-        className="flex h-[128px] w-full min-w-0 flex-col text-left"
+        className="flex h-[128px] w-full min-w-0 cursor-pointer flex-col text-left"
         aria-label={previewLabel}
         title={name}
         onClick={onPreview}
@@ -606,13 +662,13 @@ const FileTile = ({
           ) : null}
         </span>
       </button>
-      <ManagedFileDownloadButton
+      <FileActionButtons
         source={source}
         path={previewArtifact.path}
-        suggestedName={name}
+        name={name}
         disabled={missing}
-        revealOnParentHover
-        wrapperClassName="absolute right-1.5 top-1.5 z-10"
+        className="right-1.5 top-1.5"
+        onOpenInPanel={onOpenInPanel}
       />
     </div>
   )
@@ -623,11 +679,13 @@ const FileTile = ({
 const FileListRow = ({
   file,
   previewLabel,
-  onPreview
+  onPreview,
+  onOpenInPanel
 }: {
   file: ProjectFileItem
   previewLabel: string
   onPreview: () => void
+  onOpenInPanel: () => void
 }): React.JSX.Element => {
   const [setRowElement, isNearViewport] = useNearViewport<HTMLButtonElement>()
   const missing = useUnavailablePreviewProbe({
@@ -641,11 +699,11 @@ const FileListRow = ({
   const relativeTimeLabel = formatRelativeFileTime(file.mtimeMs ?? file.sortAtMs)
 
   return (
-    <div className="group relative flex h-9 min-w-0 items-center rounded-md text-text-000 transition-colors duration-150 hover:bg-bg-200 focus-within:ring-3 focus-within:ring-ring/50 focus-within:ring-inset motion-reduce:transition-none">
+    <div className="group relative flex h-9 min-w-0 items-center rounded-md text-text-000 transition-colors duration-150 hover:bg-bg-200 has-[:focus-visible]:ring-3 has-[:focus-visible]:ring-ring/50 has-[:focus-visible]:ring-inset motion-reduce:transition-none">
       <button
         ref={setRowElement}
         type="button"
-        className="flex h-full min-w-0 flex-1 items-center gap-2.5 px-2 text-left focus-visible:outline-none"
+        className="flex h-full min-w-0 flex-1 cursor-pointer items-center gap-2.5 px-2 text-left focus-visible:outline-none"
         aria-label={previewLabel}
         title={file.name}
         onClick={onPreview}
@@ -673,13 +731,13 @@ const FileListRow = ({
           </span>
         ) : null}
       </button>
-      <ManagedFileDownloadButton
+      <FileActionButtons
         source={file.source}
         path={file.path}
-        suggestedName={file.name}
+        name={file.name}
         disabled={missing}
-        revealOnParentHover
-        wrapperClassName="absolute right-2 top-1/2 z-10 -translate-y-1/2"
+        className="right-2 top-1/2 -translate-y-1/2"
+        onOpenInPanel={onOpenInPanel}
       />
     </div>
   )
@@ -691,12 +749,14 @@ const ProjectFileItems = ({
   files,
   viewMode,
   previewById,
-  onPreview
+  onPreview,
+  onOpenInPanel
 }: {
   files: ProjectFileItem[]
   viewMode: ProjectFilesViewMode
   previewById: Map<string, ArtifactPreviewResult | undefined>
   onPreview: (file: ProjectFileItem) => void
+  onOpenInPanel: (file: ProjectFileItem) => void
 }): React.JSX.Element => (
   <div
     data-view-mode={viewMode}
@@ -715,6 +775,7 @@ const ProjectFileItems = ({
             file={file}
             previewLabel={previewLabel}
             onPreview={() => onPreview(file)}
+            onOpenInPanel={() => onOpenInPanel(file)}
           />
         )
       }
@@ -732,6 +793,7 @@ const ProjectFileItems = ({
           timestamp={file.mtimeMs ?? file.sortAtMs}
           previewLabel={previewLabel}
           onPreview={() => onPreview(file)}
+          onOpenInPanel={() => onOpenInPanel(file)}
         />
       )
     })}
@@ -980,7 +1042,8 @@ const ProjectArtifactGroupSection = ({
   onManualLoadMore,
   viewMode,
   previewById,
-  onPreview
+  onPreview,
+  onOpenInPanel
 }: {
   group: ArtifactGroupItem
   title: string
@@ -995,6 +1058,7 @@ const ProjectArtifactGroupSection = ({
   viewMode: ProjectFilesViewMode
   previewById: Map<string, ArtifactPreviewResult | undefined>
   onPreview: (file: ProjectFileItem) => void
+  onOpenInPanel: (file: ProjectFileItem) => void
 }): React.JSX.Element => {
   const sectionId = `session:${group.sessionId}`
   const loadPage = useCallback(() => loadMore(group.sessionId), [group.sessionId, loadMore])
@@ -1030,6 +1094,7 @@ const ProjectArtifactGroupSection = ({
               viewMode={viewMode}
               previewById={previewById}
               onPreview={onPreview}
+              onOpenInPanel={onOpenInPanel}
             />
           ) : null}
           {page?.error ? (
@@ -1479,24 +1544,29 @@ const ProjectFilesViewContent = ({
     }
   }
 
-  const previewFile = (file: ProjectFileItem): void => {
-    // Keep the indexed file identity and source so the dialog uses the same bounded preview IPC path.
-    openFileDialog(
-      createPreviewFileItem({
-        id: file.id,
-        projectId: activeProjectId,
-        sessionId: file.sessionId,
-        path: file.path,
-        name: file.name,
-        mimeType: file.mimeType,
-        source: file.source === 'upload' ? 'upload' : undefined,
-        size: file.size,
-        mtimeMs: file.mtimeMs,
-        artifactId: file.source === 'artifact' ? file.sourceFileId : undefined,
-        selectedVersionId: file.source === 'artifact' ? file.sourceVersionId : undefined,
-        originSession: file.originSession
-      })
-    )
+  // Keep the indexed file identity and source so both destinations use the same bounded preview path.
+  const toPreviewFile = (file: ProjectFileItem): ReturnType<typeof createPreviewFileItem> =>
+    createPreviewFileItem({
+      id: file.id,
+      projectId: activeProjectId,
+      sessionId: file.sessionId,
+      path: file.path,
+      name: file.name,
+      mimeType: file.mimeType,
+      source: file.source === 'upload' ? 'upload' : undefined,
+      size: file.size,
+      mtimeMs: file.mtimeMs,
+      artifactId: file.source === 'artifact' ? file.sourceFileId : undefined,
+      selectedVersionId: file.source === 'artifact' ? file.sourceVersionId : undefined,
+      originSession: file.originSession
+    })
+
+  const previewFile = (file: ProjectFileItem): void => openFileDialog(toPreviewFile(file))
+
+  const openFileInPanel = (file: ProjectFileItem): void => {
+    const workbench = usePreviewWorkbenchStore.getState()
+    workbench.upsertAndActivateItem(toPreviewFile(file))
+    workbench.openPanel()
   }
 
   const supportsIntersectionObserver = typeof IntersectionObserver !== 'undefined'
@@ -1746,6 +1816,7 @@ const ProjectFilesViewContent = ({
                       viewMode={viewMode}
                       previewById={currentFilePreviewById}
                       onPreview={previewFile}
+                      onOpenInPanel={openFileInPanel}
                     />
                   ) : null}
                   <div
@@ -1821,6 +1892,7 @@ const ProjectFilesViewContent = ({
                   viewMode={viewMode}
                   previewById={currentFilePreviewById}
                   onPreview={previewFile}
+                  onOpenInPanel={openFileInPanel}
                 />
               ))}
               <div ref={groupsSentinelRef} data-testid="group-page-sentinel" className="h-px" />


### PR DESCRIPTION
## Problem

Project Files only opened files in a modal. Returning from that modal could also leave the file container with a mouse-triggered green focus ring, and the inline actions did not match the compact file-action treatment used elsewhere.

## Proposed change

- Add a direct action that opens an uploaded or generated file in the PreviewPanel split view beside the session.
- Use the same two-action treatment in grid and list modes: download plus split-view preview.
- Size both action buttons at 28px, expose a pointer cursor for clickable rows/cards and actions, and show `Open in split view beside the session` on hover/focus.
- Restrict the container focus ring to descendants with `:focus-visible`, preserving keyboard feedback without showing a green ring after mouse-driven modal close.

## Scope and non-goals

- No architecture, data-model, persistence, or file-identity changes.
- No rename, delete, or additional overflow-menu actions.
- Existing modal preview behavior remains the default when the file card or row is clicked.

## Acceptance criteria and validation

The following checks ran after the final interaction/style edit:

- Two-button sizing, pointer affordance, tooltip copy, and grid/list behavior -> `rtk npm test -- src/renderer/src/pages/workspace/ProjectFilesView.test.tsx -t "uses the requested search, list-row, and view-mode interaction styling|uses matching two-button file actions in grid and list views|renders uploaded files under Your uploads without a session group" --testTimeout 30000` -> 3 passed.
- Renderer typing -> `rtk npm run typecheck:web` -> passed.
- Repository typing -> `rtk npm run typecheck` -> passed before the final rebase; the rebase only added upstream transport characterization tests.
- Lint -> `rtk npm run lint` -> 0 errors, 18 pre-existing warnings outside this change.

Full-suite note: `rtk npm test` completed with 10,277 passing tests and 44 failures in `ProjectFilesView.test.tsx`. The first test exceeded the default 15-second timeout under full concurrency and its incomplete cleanup cascaded into the remaining failures. The complete Files test file passed 68/68 independently with a 30-second timeout before the final CSS-only size/cursor edit, and the directly affected tests above passed after that edit.

Uncovered risk: there is no pixel-level screenshot assertion for the exact button proportions.

## Review focus

- The direct PreviewPanel state transition and preservation of modal preview as the row/card default.
- Consistent action sizing and pointer affordances across grid and list modes.
- `:focus-visible` behavior for mouse versus keyboard navigation.
