### PR TITLE
refactor(transport): define renderer contract catalog

### DIFF
--- a/scripts/generate-web-api-map.mjs
+++ b/scripts/generate-web-api-map.mjs
@@ -16,9 +16,11 @@ const stringLiteral = (node, label) => {
   throw new Error(`Renderer contract ${label} must be a string literal.`)
 }
 
-const invokeProfiles = new Set(['WEB', 'LOCAL', 'MAPPED_ELECTRON', 'MAPPED_NATIVE'])
-const eventProfiles = new Set(['EVENT', 'DORMANT_EVENT'])
-const unprojectedProfiles = new Set(['ELECTRON', 'SEND', 'ELECTRON_EVENT', 'NATIVE'])
+// prettier-ignore
+const invokeProfiles = new Set(['WEB', 'LOCAL', 'MAPPED_ELECTRON', 'MAPPED_NATIVE', 'DELEGATED_NATIVE'])
+const eventProfiles = new Set(['EVENT', 'DORMANT_EVENT', 'CLOSE_PANE_EVENT'])
+// prettier-ignore
+const unprojectedProfiles = new Set(['ELECTRON', 'SEND', 'WINDOW_FIND_READY', 'ELECTRON_EVENT', 'NATIVE'])
 
 const projectionFor = (node) => {
   if (!node) return 'invoke'

--- a/scripts/generate-web-api-map.mjs
+++ b/scripts/generate-web-api-map.mjs
@@ -5,82 +5,74 @@ import { format } from 'prettier'
 import ts from 'typescript'
 
 const root = resolve(import.meta.dirname, '..')
-const preloadPath = resolve(root, 'src/preload/index.ts')
+const catalogPath = resolve(root, 'src/shared/renderer-contract-catalog.ts')
 const outputPath = resolve(root, 'src/shared/web-api-map.generated.ts')
 
-const specialChannels = {
-  'REVIEWER_IPC.RUN': 'reviewer:run',
-  'REVIEWER_IPC.GET_FOR_SESSION': 'reviewer:get-for-session',
-  'REVIEWER_IPC.ABORT_FIX_LOOP': 'reviewer:abort-fix-loop',
-  'REVIEWER_IPC.UPDATED': 'reviewer:updated',
-  'REVIEWER_IPC.SUPPRESS_NEXT_AUTO_REVIEW': 'reviewer:suppress-next-auto-review',
-  'REVIEWER_IPC.FIX_LOOP_START': 'reviewer:fix-loop-start',
-  'REVIEWER_IPC.FIX_LOOP_END': 'reviewer:fix-loop-end',
-  WINDOW_CLOSE_CHANNEL: 'window:close'
-}
+const sourceText = await readFile(catalogPath, 'utf8')
+const source = ts.createSourceFile(catalogPath, sourceText, ts.ScriptTarget.Latest, true)
 
-const sourceText = await readFile(preloadPath, 'utf8')
-const source = ts.createSourceFile(preloadPath, sourceText, ts.ScriptTarget.Latest, true)
-
-const channelFromExpression = (node) => {
+const stringLiteral = (node, label) => {
   if (ts.isStringLiteral(node) || ts.isNoSubstitutionTemplateLiteral(node)) return node.text
-  return specialChannels[node.getText(source)]
+  throw new Error(`Renderer contract ${label} must be a string literal.`)
 }
 
-const findChannelCall = (node) => {
-  let found
-  const visit = (child) => {
-    if (found) return
-    if (ts.isCallExpression(child)) {
-      const callee = child.expression.getText(source)
-      if (callee === 'ipcRenderer.invoke' || callee === 'onIpcMessage') {
-        const channel = child.arguments[0] && channelFromExpression(child.arguments[0])
-        if (channel) found = { kind: callee === 'ipcRenderer.invoke' ? 'invoke' : 'event', channel }
-      }
-    }
-    ts.forEachChild(child, visit)
-  }
-  visit(node)
-  return found
-}
+const invokeProfiles = new Set(['WEB', 'LOCAL', 'MAPPED_ELECTRON', 'MAPPED_NATIVE'])
+const eventProfiles = new Set(['EVENT', 'DORMANT_EVENT'])
+const unprojectedProfiles = new Set(['ELECTRON', 'SEND', 'ELECTRON_EVENT', 'NATIVE'])
 
-const propertyName = (node) => {
-  if (ts.isIdentifier(node) || ts.isStringLiteral(node)) return node.text
-  return node.getText(source)
+const projectionFor = (node) => {
+  if (!node) return 'invoke'
+  if (!ts.isIdentifier(node)) throw new Error('Renderer contract profile must be an identifier.')
+  if (invokeProfiles.has(node.text)) return 'invoke'
+  if (eventProfiles.has(node.text)) return 'event'
+  if (unprojectedProfiles.has(node.text)) return 'none'
+  throw new Error(`Unknown renderer contract profile: ${node.text}`)
 }
 
 const invoke = {}
 const events = {}
 
-const walkObject = (object, prefix = []) => {
-  for (const property of object.properties) {
-    if (!ts.isPropertyAssignment(property)) continue
-    const path = [...prefix, propertyName(property.name)]
-    if (ts.isObjectLiteralExpression(property.initializer)) {
-      walkObject(property.initializer, path)
-      continue
+let groups
+const findCatalog = (node) => {
+  if (
+    ts.isVariableDeclaration(node) &&
+    ts.isIdentifier(node.name) &&
+    node.name.text === 'RENDERER_CONTRACT_GROUPS' &&
+    node.initializer &&
+    ts.isCallExpression(node.initializer) &&
+    node.initializer.arguments[0] &&
+    ts.isArrayLiteralExpression(node.initializer.arguments[0])
+  ) {
+    groups = node.initializer.arguments[0]
+  }
+  ts.forEachChild(node, findCatalog)
+}
+findCatalog(source)
+if (!groups) throw new Error('Renderer contract group manifest was not found.')
+
+for (const group of groups.elements) {
+  if (!ts.isCallExpression(group) || group.expression.getText(source) !== 'group') {
+    throw new Error('Renderer contract manifest may only contain group(...) calls.')
+  }
+  const publicRoot = stringLiteral(group.arguments[1], 'public root')
+  const entries = group.arguments[2]
+  if (!entries || !ts.isArrayLiteralExpression(entries)) {
+    throw new Error('Renderer contract group entries must be an array literal.')
+  }
+  for (const entry of entries.elements) {
+    if (!ts.isArrayLiteralExpression(entry)) {
+      throw new Error('Renderer contract entries must be tuple literals.')
     }
-    const match = findChannelCall(property.initializer)
-    if (match?.kind === 'invoke') invoke[path.join('.')] = match.channel
-    if (match?.kind === 'event') events[path.join('.')] = match.channel
+    const member = stringLiteral(entry.elements[0], 'member')
+    const projection = projectionFor(entry.elements[2])
+    if (projection === 'none') continue
+    const channel = stringLiteral(entry.elements[1], 'channel')
+    const path = publicRoot ? `${publicRoot}.${member}` : member
+    const target = projection === 'invoke' ? invoke : events
+    if (Object.hasOwn(target, path)) throw new Error(`Duplicate projected renderer path: ${path}`)
+    target[path] = channel
   }
 }
-
-for (const statement of source.statements) {
-  if (!ts.isVariableStatement(statement)) continue
-  for (const declaration of statement.declarationList.declarations) {
-    if (
-      ts.isIdentifier(declaration.name) &&
-      declaration.name.text === 'api' &&
-      declaration.initializer &&
-      ts.isObjectLiteralExpression(declaration.initializer)
-    ) {
-      walkObject(declaration.initializer)
-    }
-  }
-}
-
-events['window.onCloseActivePane'] = 'shortcut:close-active-pane'
 
 const sorted = (value) =>
   Object.fromEntries(Object.entries(value).sort(([a], [b]) => a.localeCompare(b)))

--- a/src/renderer/web/api-map.generated.test.ts
+++ b/src/renderer/web/api-map.generated.test.ts
@@ -6,7 +6,7 @@ import { expect, it } from 'vitest'
 
 const execFileAsync = promisify(execFile)
 
-it('keeps the generated web API map synchronized with preload', async () => {
+it('keeps the generated web API map synchronized with the renderer contract catalog', async () => {
   await expect(
     execFileAsync(process.execPath, [resolve('scripts/generate-web-api-map.mjs'), '--check'])
   ).resolves.toBeDefined()

--- a/src/shared/renderer-contract-catalog.test.ts
+++ b/src/shared/renderer-contract-catalog.test.ts
@@ -1,0 +1,139 @@
+import { describe, expect, it } from 'vitest'
+
+import { WEB_EVENT_CHANNELS, WEB_INVOKE_CHANNELS } from './web-api-map.generated'
+import { RENDERER_CONTRACT_CATALOG, RENDERER_CONTRACT_GROUPS } from './renderer-contract-catalog'
+import { projectRendererContractMaps } from './renderer-contract'
+
+const paths = (predicate: (contract: (typeof RENDERER_CONTRACT_CATALOG)[number]) => boolean) =>
+  RENDERER_CONTRACT_CATALOG.filter(predicate).map(({ publicPath }) => publicPath)
+
+describe('renderer contract catalog', () => {
+  it('pins the complete capability-owned inventory and legacy map projection', () => {
+    const projection = projectRendererContractMaps(RENDERER_CONTRACT_CATALOG)
+
+    expect(RENDERER_CONTRACT_GROUPS).toHaveLength(30)
+    expect(RENDERER_CONTRACT_CATALOG).toHaveLength(291)
+    expect(projection.invoke).toEqual(WEB_INVOKE_CHANNELS)
+    expect(projection.event).toEqual(WEB_EVENT_CHANNELS)
+    expect(Object.keys(projection.invoke)).toHaveLength(222)
+    expect(Object.keys(projection.event)).toHaveLength(32)
+  })
+
+  it('separates actual Web installation from the generated compatibility projection', () => {
+    expect(
+      paths(({ surfaceInstallation }) => surfaceInstallation.localWeb !== 'unavailable')
+    ).toHaveLength(250)
+    expect(
+      paths(({ surfaceInstallation }) => surfaceInstallation.localWeb === 'browser-native')
+    ).toEqual(['getRuntimeVersions', 'saveBlobFile', 'saveManagedFile', 'window.close'])
+    expect(
+      RENDERER_CONTRACT_CATALOG.filter(({ publicPath }) =>
+        ['saveBlobFile', 'saveManagedFile', 'window.close'].includes(publicPath)
+      ).every(
+        ({ dispatchPolicy, authorityFlow }) =>
+          dispatchPolicy.electron === 'electron-ipc-request' &&
+          dispatchPolicy.localWeb === 'surface-native' &&
+          authorityFlow.electron === 'electron-sender'
+      )
+    ).toBe(true)
+    expect(
+      paths(({ surfaceInstallation }) => surfaceInstallation.localWeb === 'unavailable')
+    ).toHaveLength(41)
+    expect(
+      paths(({ surfaceInstallation }) => surfaceInstallation.remoteWeb === 'rejecting-stub')
+    ).toHaveLength(56)
+    expect(
+      paths(({ eventDeliverability }) =>
+        Object.values(eventDeliverability).includes('installed-undelivered')
+      )
+    ).toEqual([
+      'notebookEnv.onProgress',
+      'notifications.onOpenSession',
+      'notifications.onViewProbe',
+      'uploads.onTransferProgress',
+      'window.onCloseActivePane'
+    ])
+  })
+
+  it('records every intentional and known-deviating argument codec without normalizing it', () => {
+    expect(
+      paths(
+        ({ parameterCodec, surfaceInstallation }) =>
+          surfaceInstallation.localWeb === 'web-rpc' &&
+          parameterCodec.electron !== parameterCodec.web
+      )
+    ).toEqual([
+      'runtime.describeUsage',
+      'runtime.getEnablement',
+      'runtime.listPackageCounts',
+      'runtime.listPackages',
+      'runtime.registerInterpreter',
+      'runtime.setEnvironmentEnabled',
+      'runtime.setInstallAuthorized',
+      'runtime.setSelection',
+      'runtime.unregisterInterpreter',
+      'sessions.saveSession'
+    ])
+
+    const explicitEquivalentTransforms = paths(
+      ({ parameterCodec }) =>
+        parameterCodec.electron === parameterCodec.web &&
+        parameterCodec.web !== 'positional' &&
+        parameterCodec.web !== 'event-listener' &&
+        parameterCodec.web !== 'surface-native'
+    )
+    expect(explicitEquivalentTransforms).toEqual([
+      'acp.connect',
+      'acp.createSession',
+      'storage.commitAndRelaunch',
+      'storage.discardMigratedCopy',
+      'storage.inspectDataRoot',
+      'storage.migrate',
+      'storage.setDataRootAndRelaunch',
+      'storage.validateDataRoot'
+    ])
+  })
+
+  it('preserves Specialist, Permission, and Compute surface asymmetry', () => {
+    const specialist = RENDERER_CONTRACT_CATALOG.filter(({ publicPath }) =>
+      publicPath.startsWith('specialist.')
+    )
+    expect(specialist).toHaveLength(14)
+    expect(
+      specialist.every(
+        ({ surfaceInstallation }) =>
+          surfaceInstallation.localWeb === 'unavailable' &&
+          surfaceInstallation.remoteWeb === 'unavailable'
+      )
+    ).toBe(true)
+
+    const permissionPaths = [
+      'acp.respondToPermission',
+      'acp.revokePermissionGrant',
+      'acp.setPermissionProfile',
+      'permissions.extendUndo',
+      'permissions.list',
+      'permissions.restore',
+      'permissions.revoke'
+    ]
+    expect(
+      RENDERER_CONTRACT_CATALOG.filter(({ publicPath }) =>
+        permissionPaths.includes(publicPath)
+      ).every(
+        ({ surfaceInstallation, authorityFlow }) =>
+          surfaceInstallation.remoteWeb === 'web-rpc' &&
+          authorityFlow.remoteWeb === 'caller-context'
+      )
+    ).toBe(true)
+
+    const compute = RENDERER_CONTRACT_CATALOG.filter(({ publicPath }) =>
+      publicPath.startsWith('compute.')
+    )
+    expect(compute).toHaveLength(23)
+    expect(
+      compute
+        .filter(({ surfaceInstallation }) => surfaceInstallation.remoteWeb === 'rejecting-stub')
+        .map(({ publicPath }) => publicPath)
+    ).toEqual(['compute.download', 'compute.revealInFolder'])
+  })
+})

--- a/src/shared/renderer-contract-catalog.test.ts
+++ b/src/shared/renderer-contract-catalog.test.ts
@@ -4,8 +4,9 @@ import { WEB_EVENT_CHANNELS, WEB_INVOKE_CHANNELS } from './web-api-map.generated
 import { RENDERER_CONTRACT_CATALOG, RENDERER_CONTRACT_GROUPS } from './renderer-contract-catalog'
 import { projectRendererContractMaps } from './renderer-contract'
 
-const paths = (predicate: (contract: (typeof RENDERER_CONTRACT_CATALOG)[number]) => boolean) =>
-  RENDERER_CONTRACT_CATALOG.filter(predicate).map(({ publicPath }) => publicPath)
+const paths = (
+  predicate: (contract: (typeof RENDERER_CONTRACT_CATALOG)[number]) => boolean
+): string[] => RENDERER_CONTRACT_CATALOG.filter(predicate).map(({ publicPath }) => publicPath)
 
 describe('renderer contract catalog', () => {
   it('pins the complete capability-owned inventory and legacy map projection', () => {
@@ -28,7 +29,7 @@ describe('renderer contract catalog', () => {
     ).toEqual(['getRuntimeVersions', 'saveBlobFile', 'saveManagedFile', 'window.close'])
     expect(
       RENDERER_CONTRACT_CATALOG.filter(({ publicPath }) =>
-        ['saveBlobFile', 'saveManagedFile', 'window.close'].includes(publicPath)
+        ['saveBlobFile', 'window.close'].includes(publicPath)
       ).every(
         ({ dispatchPolicy, authorityFlow }) =>
           dispatchPolicy.electron === 'electron-ipc-request' &&
@@ -36,6 +37,20 @@ describe('renderer contract catalog', () => {
           authorityFlow.electron === 'electron-sender'
       )
     ).toBe(true)
+    expect(
+      RENDERER_CONTRACT_CATALOG.find(({ publicPath }) => publicPath === 'saveManagedFile')
+    ).toMatchObject({
+      dispatchPolicy: {
+        electron: 'electron-ipc-request',
+        localWeb: 'browser-native-with-captured-ipc',
+        remoteWeb: 'browser-native-with-captured-ipc'
+      },
+      authorityFlow: {
+        electron: 'electron-sender',
+        localWeb: 'caller-context',
+        remoteWeb: 'caller-context'
+      }
+    })
     expect(
       paths(({ surfaceInstallation }) => surfaceInstallation.localWeb === 'unavailable')
     ).toHaveLength(41)
@@ -56,6 +71,11 @@ describe('renderer contract catalog', () => {
   })
 
   it('records every intentional and known-deviating argument codec without normalizing it', () => {
+    expect(
+      RENDERER_CONTRACT_CATALOG.find(({ publicPath }) => publicPath === 'uploads.stageLocalFile')
+        ?.parameterCodec
+    ).toEqual({ electron: 'native-file-upload-request', web: 'native-file-upload-request' })
+
     expect(
       paths(
         ({ parameterCodec, surfaceInstallation }) =>
@@ -90,7 +110,8 @@ describe('renderer contract catalog', () => {
       'storage.inspectDataRoot',
       'storage.migrate',
       'storage.setDataRootAndRelaunch',
-      'storage.validateDataRoot'
+      'storage.validateDataRoot',
+      'uploads.stageLocalFile'
     ])
   })
 
@@ -135,5 +156,24 @@ describe('renderer contract catalog', () => {
         .filter(({ surfaceInstallation }) => surfaceInstallation.remoteWeb === 'rejecting-stub')
         .map(({ publicPath }) => publicPath)
     ).toEqual(['compute.download', 'compute.revealInFolder'])
+  })
+
+  it('records the paired window lifecycle channels and teardown ordering', () => {
+    const lifecycleFor = (publicPath: string): unknown =>
+      RENDERER_CONTRACT_CATALOG.find((contract) => contract.publicPath === publicPath)
+        ?.lifecycleDispatch
+
+    expect(lifecycleFor('window.onCloseActivePane')).toEqual({
+      activateChannel: 'shortcut:close-active-pane-ready',
+      activate: 'after-subscribe',
+      deactivateChannel: 'shortcut:close-active-pane-unready',
+      deactivate: 'after-unsubscribe'
+    })
+    expect(lifecycleFor('window.announceWindowFindReady')).toEqual({
+      activateChannel: 'shortcut:window-find-ready',
+      activate: 'on-call',
+      deactivateChannel: 'shortcut:window-find-unready',
+      deactivate: 'on-dispose'
+    })
   })
 })

--- a/src/shared/renderer-contract-catalog.ts
+++ b/src/shared/renderer-contract-catalog.ts
@@ -1,0 +1,361 @@
+import {
+  composeRendererContractCatalog,
+  defineRendererContractGroup,
+  type RendererContractGroup,
+  type RendererContractSeed,
+  type RendererParameterCodec,
+  type RendererSurfaceProfile
+} from './renderer-contract'
+
+const WEB = 'web'
+const LOCAL = 'local'
+const EVENT = 'event'
+const DORMANT_EVENT = 'dormant-event'
+const ELECTRON = 'electron'
+const MAPPED_ELECTRON = 'mapped-electron'
+const SEND = 'send'
+const ELECTRON_EVENT = 'electron-event'
+const NATIVE = 'native'
+const MAPPED_NATIVE = 'mapped-native'
+
+const POSITIONAL = 'positional'
+const DEFAULT_EMPTY = 'default-empty-object'
+const STORAGE_PARENT = 'storage-parent-object'
+const STORAGE_ROOT = 'storage-data-root-object'
+const RUNTIME_SELECTION = 'runtime-selection-object'
+const RUNTIME_LANGUAGE_ENV = 'runtime-language-environment-object'
+const RUNTIME_LANGUAGE = 'runtime-language-object'
+const RUNTIME_ENABLEMENT = 'runtime-enablement-object'
+const RUNTIME_INSTALL_AUTH = 'runtime-install-authorization-object'
+const RUNTIME_INTERPRETER = 'runtime-interpreter-path-object'
+const SESSION_SAVE = 'session-save-optional-argument'
+const SESSION_SAVE_JSON = 'session-save-json-undefined'
+
+type ContractProfile =
+  | typeof WEB
+  | typeof LOCAL
+  | typeof EVENT
+  | typeof DORMANT_EVENT
+  | typeof ELECTRON
+  | typeof MAPPED_ELECTRON
+  | typeof SEND
+  | typeof ELECTRON_EVENT
+  | typeof NATIVE
+  | typeof MAPPED_NATIVE
+
+type ContractEntry = readonly [
+  member: string,
+  channel: string | null,
+  profile?: ContractProfile,
+  electronCodec?: RendererParameterCodec,
+  webCodec?: RendererParameterCodec
+]
+
+const surface = <Value>(
+  electron: Value,
+  localWeb: Value,
+  remoteWeb: Value
+): RendererSurfaceProfile<Value> => ({ electron, localWeb, remoteWeb })
+
+const expandEntry = (
+  publicRoot: string,
+  [member, channel, profile = WEB, electronCodec, webCodec]: ContractEntry
+): RendererContractSeed => {
+  const isWebRequest = profile === WEB || profile === LOCAL
+  const isWebEvent = profile === EVENT || profile === DORMANT_EVENT
+  const isElectronEvent = profile === ELECTRON_EVENT
+  const isNative = profile === NATIVE || profile === MAPPED_NATIVE
+  const kind = isWebEvent || isElectronEvent ? 'event' : 'method'
+  const defaultElectronCodec =
+    kind === 'event' ? 'event-listener' : profile === NATIVE ? 'surface-native' : POSITIONAL
+  const defaultWebCodec = isNative ? 'surface-native' : defaultElectronCodec
+  const localInstallation = isWebRequest
+    ? 'web-rpc'
+    : isWebEvent
+      ? 'web-event'
+      : isNative
+        ? 'browser-native'
+        : 'unavailable'
+  const localDispatch = isWebRequest
+    ? 'captured-ipc-request'
+    : isWebEvent
+      ? 'web-event-subscription'
+      : isNative
+        ? 'surface-native'
+        : 'none'
+  const electronDispatch =
+    profile === SEND
+      ? 'electron-ipc-send'
+      : kind === 'event'
+        ? 'electron-ipc-subscription'
+        : profile === NATIVE
+          ? 'surface-native'
+          : 'electron-ipc-request'
+
+  return {
+    publicPath: publicRoot ? `${publicRoot}.${member}` : member,
+    channel,
+    kind,
+    parameterCodec: {
+      electron: electronCodec ?? defaultElectronCodec,
+      web: webCodec ?? electronCodec ?? defaultWebCodec
+    },
+    surfaceInstallation: surface(
+      'preload',
+      localInstallation,
+      profile === LOCAL ? 'rejecting-stub' : localInstallation
+    ),
+    dispatchPolicy: surface(
+      electronDispatch,
+      localDispatch,
+      profile === LOCAL ? 'rejecting-stub' : localDispatch
+    ),
+    eventDeliverability: surface(
+      kind === 'event' ? 'electron-ipc' : 'not-event',
+      profile === EVENT
+        ? 'application-event'
+        : profile === DORMANT_EVENT
+          ? 'installed-undelivered'
+          : kind === 'event'
+            ? 'unavailable'
+            : 'not-event',
+      profile === EVENT
+        ? 'application-event'
+        : profile === DORMANT_EVENT
+          ? 'installed-undelivered'
+          : kind === 'event'
+            ? 'unavailable'
+            : 'not-event'
+    ),
+    authorityFlow: surface(
+      kind === 'event' || profile === NATIVE ? 'none' : 'electron-sender',
+      isWebRequest ? 'caller-context' : 'none',
+      profile === WEB ? 'caller-context' : 'none'
+    ),
+    mapProjection:
+      isWebRequest || profile === MAPPED_ELECTRON || profile === MAPPED_NATIVE
+        ? 'invoke'
+        : isWebEvent
+          ? 'event'
+          : 'none'
+  }
+}
+
+const group = (
+  capability: string,
+  publicRoot: string,
+  entries: readonly ContractEntry[]
+): RendererContractGroup =>
+  defineRendererContractGroup(
+    capability,
+    entries.map((entry) => expandEntry(publicRoot, entry))
+  )
+
+// Compact tuple manifest: [member, channel, surface profile?, Electron codec?, Web codec?].
+// prettier-ignore
+export const RENDERER_CONTRACT_GROUPS = Object.freeze([
+  group('acp', 'acp', [
+    ['onEvent', 'acp:event', EVENT], ['onPermissionRequest', 'acp:permission-request', EVENT], ['onState', 'acp:state', EVENT], ['cancel', 'acp:cancel'],
+    ['compactSession', 'acp:compact-session'], ['connect', 'acp:connect', WEB, DEFAULT_EMPTY], ['createSession', 'acp:create-session', WEB, DEFAULT_EMPTY],
+    ['deleteSession', 'acp:delete-session'], ['disconnect', 'acp:disconnect'], ['getState', 'acp:get-state'],
+    ['resetSessionContext', 'acp:reset-session-context'], ['respondToPermission', 'acp:respond-permission'], ['resumeSession', 'acp:resume-session'],
+    ['revokePermissionGrant', 'acp:revoke-permission-grant'], ['sendPrompt', 'acp:send-prompt'], ['setPermissionProfile', 'acp:set-permission-profile'],
+  ]),
+  group('artifacts', 'artifacts', [
+    ['finalizeRunArtifacts', 'artifacts:finalize-run'], ['getLineage', 'artifacts:get-lineage'], ['getVersionExecution', 'artifacts:get-version-execution'],
+    ['getVersionMessages', 'artifacts:get-version-messages'], ['getVersionProvenance', 'artifacts:get-version-provenance'],
+    ['getVersionReview', 'artifacts:get-version-review'], ['listProjectFiles', 'artifacts:list-project-files'], ['openFile', 'artifacts:open-file', LOCAL],
+    ['readPreview', 'artifacts:read-preview'], ['reconcilePendingArtifacts', 'artifacts:reconcile-pending'],
+  ]),
+  group('cli', 'cli', [
+    ['getStatus', 'cli:get-status'], ['install', 'cli:install', LOCAL], ['uninstall', 'cli:uninstall', LOCAL],
+  ]),
+  group('compute', 'compute', [
+    ['onApprovalRequest', 'compute:approval-request', EVENT], ['onJobUpdated', 'compute:job-updated', EVENT], ['bookmarksGet', 'compute:bookmarks:get'],
+    ['bookmarksSet', 'compute:bookmarks:set'], ['concurrencySet', 'compute:concurrency:set'], ['create', 'compute:create'], ['delete', 'compute:delete'],
+    ['detailsGet', 'compute:details:get'], ['detailsSave', 'compute:details:save'], ['download', 'compute:download', LOCAL],
+    ['enabledHostsGet', 'compute:enabled-hosts:get'], ['enabledHostsSet', 'compute:enabled-hosts:set'], ['get', 'compute:get'],
+    ['jobsList', 'compute:jobs:list'], ['jobsMarkConsumed', 'compute:jobs:mark-consumed'], ['jobsPendingNotification', 'compute:jobs:pending-notification'],
+    ['list', 'compute:list'], ['listDir', 'compute:list-dir'], ['probe', 'compute:probe'], ['respondApproval', 'compute:approval-respond'],
+    ['revealInFolder', 'compute:reveal-in-folder', LOCAL], ['scratchSet', 'compute:scratch:set'], ['sshConfigAliases', 'compute:ssh-config-aliases'],
+  ]),
+  group('diagnostics', 'diagnostics', [
+    ['reportRendererFailure', 'diagnostics:renderer-failure', SEND],
+  ]),
+  group('github', 'github', [
+    ['getStars', 'github:get-stars'],
+  ]),
+  group('handoff', 'handoff', [
+    ['list', 'handoff-lifecycle:list', ELECTRON], ['onChanged', 'handoff-lifecycle:changed', ELECTRON_EVENT], ['retry', 'handoff-lifecycle:retry', ELECTRON],
+  ]),
+  group('lifecycle', 'lifecycle', [
+    ['getClientId', 'lifecycle:client-id'],
+  ]),
+  group('local-fs', 'localFs', [
+    ['getRoots', 'local-fs:get-roots', LOCAL], ['listDir', 'local-fs:list-dir', LOCAL], ['openPath', 'local-fs:open-path', LOCAL],
+    ['readPreview', 'local-fs:read-preview', LOCAL], ['reveal', 'local-fs:reveal', LOCAL],
+  ]),
+  group('logs', 'logs', [
+    ['getPath', 'logs:get-path'], ['openFile', 'logs:open-file', LOCAL], ['revealInFolder', 'logs:reveal-in-folder', LOCAL],
+  ]),
+  group('notebook', 'notebook', [
+    ['onAvailable', 'notebook:available', EVENT], ['onChanged', 'notebook:changed', EVENT], ['appendCodeCell', 'notebook:append-code-cell'],
+    ['beginCodeCell', 'notebook:begin-code-cell'], ['execute', 'notebook:execute'], ['exportIpynb', 'notebook:export-ipynb', LOCAL],
+    ['exportIpynbAll', 'notebook:export-ipynb-all', LOCAL], ['finishCodeCell', 'notebook:finish-code-cell'], ['getReference', 'notebook:reference'],
+    ['readInputPreview', 'notebook:read-input-preview'], ['restart', 'notebook:restart'], ['runCell', 'notebook:run-cell'], ['shutdown', 'notebook:shutdown'],
+    ['state', 'notebook:state'],
+  ]),
+  group('notebook-environment', 'notebookEnv', [
+    ['onProgress', 'notebook-env:progress', DORMANT_EVENT], ['cancel', 'notebook-env:cancel', LOCAL], ['getStatus', 'notebook-env:status'],
+    ['provision', 'notebook-env:provision', LOCAL], ['repair', 'notebook-env:repair', LOCAL],
+  ]),
+  group('notifications', 'notifications', [
+    ['onOpenSession', 'notifications:open-session', DORMANT_EVENT], ['onViewProbe', 'notifications:probe-unread-view', DORMANT_EVENT],
+    ['peekPendingOpenSession', 'notifications:peek-pending-open-session'], ['syncViewState', 'notifications:sync-unread-view', SEND],
+    ['takePendingOpenSession', 'notifications:take-pending-open-session'],
+  ]),
+  group('office-preview', 'officePreview', [
+    ['attachFrame', 'office-preview:attach-frame', ELECTRON], ['close', 'office-preview:close', ELECTRON], ['onState', 'office-preview:state', ELECTRON_EVENT],
+    ['open', 'office-preview:open', ELECTRON], ['reportState', 'office-preview:report-state', SEND],
+  ]),
+  group('permissions', 'permissions', [
+    ['onChanged', 'permissions:changed', EVENT], ['extendUndo', 'permissions:extend-undo'], ['list', 'permissions:list'], ['restore', 'permissions:restore'],
+    ['revoke', 'permissions:revoke'],
+  ]),
+  group('platform-file-save', '', [
+    ['getRuntimeVersions', null, NATIVE], ['saveBlobFile', 'file:save-blob', MAPPED_NATIVE], ['saveManagedFile', 'file:save-managed', MAPPED_NATIVE],
+    ['saveSessionArtifacts', 'file:save-session-artifacts', MAPPED_ELECTRON],
+  ]),
+  group('preview', 'preview', [
+    ['delete', 'preview:delete'], ['load', 'preview:load'], ['save', 'preview:save'],
+  ]),
+  group('preview-resources', 'previewResources', [
+    ['acquire', 'preview-resources:acquire'], ['readRange', 'preview-resources:read-range'], ['release', 'preview-resources:release'],
+  ]),
+  group('project-files', 'projectFiles', [
+    ['onChanged', 'project-files:changed', EVENT], ['getOverview', 'project-files:get-overview'], ['listArtifactGroups', 'project-files:list-artifact-groups'],
+    ['listFiles', 'project-files:list-files'], ['repairIndex', 'project-files:repair-index'], ['searchArtifacts', 'project-files:search-artifacts'],
+  ]),
+  group('projects', 'projects', [
+    ['onCreated', 'project:created', EVENT], ['onDeleted', 'project:deleted', EVENT], ['onUpdated', 'project:updated', EVENT], ['create', 'projects:create'],
+    ['delete', 'projects:delete'], ['get', 'projects:get'], ['list', 'projects:list'], ['update', 'projects:update'],
+  ]),
+  group('remote-access', 'remoteAccess', [
+    ['onChanged', 'remote-access:changed', EVENT], ['approve', 'remote-access:approve'], ['detect', 'remote-access:detect'],
+    ['disable', 'remote-access:disable'], ['getSnapshot', 'remote-access:get-snapshot'], ['reject', 'remote-access:reject'],
+    ['revokeBrowser', 'remote-access:revoke-browser'], ['setMode', 'remote-access:set-mode'],
+  ]),
+  group('reviewer', 'reviewer', [
+    ['onFixLoopEnd', 'reviewer:fix-loop-end', EVENT], ['onFixLoopStart', 'reviewer:fix-loop-start', EVENT],
+    ['onSuppressNextAutoReview', 'reviewer:suppress-next-auto-review', EVENT], ['onUpdated', 'reviewer:updated', EVENT],
+    ['abortFixLoop', 'reviewer:abort-fix-loop'], ['getForSession', 'reviewer:get-for-session'], ['run', 'reviewer:run'],
+  ]),
+  group('runtime', 'runtime', [
+    ['describeUsage', 'runtime:describe-usage', WEB, RUNTIME_LANGUAGE_ENV, POSITIONAL],
+    ['getEnablement', 'runtime:get-enablement', WEB, RUNTIME_LANGUAGE, POSITIONAL], ['listEnvironments', 'runtime:list-environments'],
+    ['listPackageCounts', 'runtime:list-package-counts', WEB, RUNTIME_LANGUAGE, POSITIONAL],
+    ['listPackages', 'runtime:list-packages', WEB, RUNTIME_LANGUAGE_ENV, POSITIONAL], ['pickInterpreter', 'runtime:pick-interpreter', LOCAL],
+    ['registerInterpreter', 'runtime:register-interpreter', LOCAL, RUNTIME_INTERPRETER, POSITIONAL],
+    [
+      'setEnvironmentEnabled',
+      'runtime:set-environment-enabled',
+      LOCAL,
+      RUNTIME_ENABLEMENT,
+      POSITIONAL
+    ],
+    [
+      'setInstallAuthorized',
+      'runtime:set-install-authorized',
+      LOCAL,
+      RUNTIME_INSTALL_AUTH,
+      POSITIONAL
+    ],
+    ['setSelection', 'runtime:set-selection', LOCAL, RUNTIME_SELECTION, POSITIONAL], ['survey', 'runtime:survey'],
+    [
+      'unregisterInterpreter',
+      'runtime:unregister-interpreter',
+      LOCAL,
+      RUNTIME_INTERPRETER,
+      POSITIONAL
+    ],
+  ]),
+  group('sessions', 'sessions', [
+    ['exportConversation', 'sessions:export-conversation', MAPPED_ELECTRON], ['onCreated', 'session:created', EVENT], ['onDeleted', 'session:deleted', EVENT],
+    ['onFlushRequest', 'sessions:flush-request', ELECTRON_EVENT], ['onUpdated', 'session:updated', EVENT], ['deleteSession', 'sessions:delete-session'],
+    ['loadAll', 'sessions:load-all'], ['saveManifest', 'sessions:save-manifest'],
+    ['saveSession', 'sessions:save-session', WEB, SESSION_SAVE, SESSION_SAVE_JSON], ['sendFlushResponse', 'sessions:flush-response', SEND],
+  ]),
+  group('settings', 'settings', [
+    ['addCustomServer', 'settings:add-custom-server'], ['cancelClaudeLogin', 'settings:cancel-claude-login', LOCAL],
+    ['cancelCodexLogin', 'settings:cancel-codex-login', LOCAL], ['cancelIsolatedClaudeLogin', 'settings:cancel-isolated-claude-login', LOCAL],
+    ['checkEnvironment', 'settings:check-environment'], ['createSkill', 'settings:create-skill'], ['deleteProvider', 'settings:delete-provider'],
+    ['deleteSkill', 'settings:delete-skill'], ['detectClaude', 'settings:detect-claude'], ['detectCodex', 'settings:detect-codex'],
+    ['detectOpencode', 'settings:detect-opencode'], ['getConnectorDetail', 'settings:get-connector-detail'],
+    ['getPackageMirror', 'settings:get-package-mirror'], ['getPreflight', 'settings:get-preflight'], ['getSettings', 'settings:get-settings'],
+    ['getSkillDetail', 'settings:get-skill-detail'], ['importAgentHomeSkills', 'settings:import-agent-home-skills', MAPPED_ELECTRON],
+    ['importSkill', 'settings:import-skill'], ['importSkillZip', 'settings:import-skill-zip'], ['importSkillZipBatch', 'settings:import-skill-zip-batch'],
+    ['installClaude', 'settings:install-claude', LOCAL], ['installCodex', 'settings:install-codex', LOCAL],
+    ['installOpencode', 'settings:install-opencode', LOCAL], ['isEncryptionAvailable', 'settings:encryption-available'],
+    ['isNpmAvailable', 'settings:npm-available'], ['listAgentHomeSkills', 'settings:list-agent-home-skills', MAPPED_ELECTRON],
+    ['listAppIcons', 'settings:list-app-icons'], ['listConnectors', 'settings:list-connectors'], ['listSkills', 'settings:list-skills'],
+    ['loginIsolatedClaude', 'settings:login-isolated-claude', LOCAL], ['loginIsolatedClaudeBrowser', 'settings:login-isolated-claude-browser', LOCAL],
+    ['loginIsolatedCodex', 'settings:login-isolated-codex', LOCAL], ['loginSharedClaude', 'settings:login-shared-claude', LOCAL],
+    ['logoutIsolatedClaude', 'settings:logout-isolated-claude', LOCAL], ['logoutIsolatedCodex', 'settings:logout-isolated-codex', LOCAL],
+    ['logoutSharedClaude', 'settings:logout-shared-claude', LOCAL], ['markOnboardingComplete', 'settings:mark-onboarding-complete'],
+    ['onConnectorApprovalRequest', 'connectors:approval-request', EVENT], ['onInstallLog', 'settings:install-log', EVENT],
+    ['onSkillImportApprovalRequest', 'skills:conversation-import-request', EVENT],
+    ['onSkillImportApprovalSettled', 'skills:conversation-import-settled', EVENT], ['previewAgentHomeSkill', 'settings:preview-agent-home-skill'],
+    ['previewGitHubSkill', 'settings:preview-github-skill'], ['previewSkillZip', 'settings:preview-skill-zip'],
+    ['refreshProviderModels', 'settings:refresh-provider-models'], ['removeCustomServer', 'settings:remove-custom-server'],
+    ['replayPendingSkillImportApprovals', 'skills:conversation-import-replay-pending'], ['respondConnectorApproval', 'connectors:approval-respond'],
+    ['respondSkillImportApproval', 'skills:conversation-import-respond'], ['scanRepoSkills', 'settings:scan-repo-skills'],
+    ['setActiveProvider', 'settings:set-active-provider'], ['setAgentFramework', 'settings:set-agent-framework'],
+    ['setAppIconVariant', 'settings:set-app-icon-variant', LOCAL], ['setClosePreference', 'settings:set-close-preference', LOCAL],
+    ['setConnectorAutoAllow', 'settings:set-connector-auto-allow'], ['setConnectorEnabled', 'settings:set-connector-enabled'],
+    ['setConversationSkillImportEnabled', 'settings:set-conversation-skill-import-enabled'], ['setCustomServerEnabled', 'settings:set-custom-server-enabled'],
+    ['setNcbiCredentials', 'settings:set-ncbi-credentials'], ['setNotificationsEnabled', 'settings:set-notifications-enabled', LOCAL],
+    ['setPackageMirror', 'settings:set-package-mirror', LOCAL], ['setReasoningEffort', 'settings:set-reasoning-effort'],
+    ['setSkillEnabled', 'settings:set-skill-enabled'], ['setToolPermission', 'settings:set-tool-permission'],
+    ['uninstallClaude', 'settings:uninstall-claude', LOCAL], ['uninstallCodex', 'settings:uninstall-codex', LOCAL],
+    ['uninstallOpencode', 'settings:uninstall-opencode', LOCAL], ['updateCustomServer', 'settings:update-custom-server'],
+    ['updateSkill', 'settings:update-skill'], ['upsertProvider', 'settings:upsert-provider'], ['validateProvider', 'settings:validate-provider'],
+  ]),
+  group('specialist', 'specialist', [
+    ['cancelHandoff', 'specialist:cancel-handoff', ELECTRON], ['create', 'specialist:create', ELECTRON], ['delete', 'specialist:delete', ELECTRON],
+    ['duplicate', 'specialist:duplicate', ELECTRON], ['getHandoffEvents', 'specialist:get-handoff-events', ELECTRON], ['list', 'specialist:list', ELECTRON],
+    ['onCatalogChanged', 'specialist:catalog-changed', ELECTRON_EVENT], ['onHandoffLifecycleEvent', 'specialist:handoff-lifecycle-changed', ELECTRON_EVENT],
+    ['onPendingSwitch', 'specialist:pending-switch', ELECTRON_EVENT], ['resolveSessionSpecialist', 'specialist:resolve-session-specialist', ELECTRON],
+    ['retryHandoff', 'specialist:retry-handoff', ELECTRON], ['setEnabled', 'specialist:set-enabled', ELECTRON],
+    ['setSessionSpecialist', 'specialist:set-session-specialist', ELECTRON], ['update', 'specialist:update', ELECTRON],
+  ]),
+  group('storage', 'storage', [
+    ['cancelMigrate', 'storage:cancel-migrate', LOCAL], ['commitAndRelaunch', 'storage:commit-and-relaunch', LOCAL, STORAGE_PARENT],
+    ['detectActive', 'storage:detect-active'], ['discardMigratedCopy', 'storage:discard-migrated-copy', LOCAL, STORAGE_PARENT],
+    ['dismissLegacyMovePrompt', 'storage:dismiss-legacy-move-prompt'], ['getInfo', 'storage:get-info'],
+    ['inspectDataRoot', 'storage:inspect-data-root', LOCAL, STORAGE_PARENT], ['migrate', 'storage:migrate', LOCAL, STORAGE_PARENT],
+    ['onProgress', 'storage:migrate-progress', EVENT], ['pickDirectory', 'storage:pick-directory', LOCAL],
+    ['revealAppStorage', 'storage:reveal-app-storage', LOCAL], ['setDataRootAndRelaunch', 'storage:set-data-root-and-relaunch', LOCAL, STORAGE_ROOT],
+    ['validateDataRoot', 'storage:validate-data-root', LOCAL, STORAGE_PARENT],
+  ]),
+  group('update', 'update', [
+    ['apply', 'update:apply', LOCAL], ['cancel', 'update:cancel', LOCAL], ['check', 'update:check'], ['download', 'update:download', LOCAL],
+    ['getAppInfo', 'update:get-app-info'], ['getStatus', 'update:get-status'], ['onProgress', 'update:progress', EVENT], ['onStatus', 'update:status', EVENT],
+  ]),
+  group('uploads', 'uploads', [
+    ['abortTransfer', 'uploads:abort-transfer'], ['appendTransfer', 'uploads:append-transfer'], ['beginTransfer', 'uploads:begin-transfer'],
+    ['claimLocalFile', 'uploads:claim-local-file'], ['deleteUpload', 'uploads:delete'], ['finalizeSession', 'uploads:finalize-session'],
+    ['finishTransfer', 'uploads:finish-transfer'], ['getTransferStatus', 'uploads:transfer-status'],
+    ['onTransferProgress', 'uploads:transfer-progress', DORMANT_EVENT], ['readPreview', 'uploads:read-preview'],
+    ['stageLocalFile', 'uploads:stage-local-file', MAPPED_ELECTRON], ['stageLocalPath', 'uploads:stage-local-path', LOCAL],
+  ]),
+  group('window', 'window', [
+    ['announceWindowFindAppearance', 'window:find-appearance-changed', SEND], ['announceWindowFindReady', 'shortcut:window-find-ready', SEND],
+    ['clearFind', 'window:clear-find-in-page', SEND], ['close', 'window:close', MAPPED_NATIVE], ['closeFind', 'window:find-close', SEND],
+    ['findInPage', 'window:find-in-page', SEND], ['onCloseActivePane', 'shortcut:close-active-pane', DORMANT_EVENT],
+    ['onCloseConfirmRequest', 'window:close-confirm-request', ELECTRON_EVENT], ['onFindInPageResult', 'window:find-in-page-result', ELECTRON_EVENT],
+    ['onShowWindowFind', 'window:find-show', ELECTRON_EVENT], ['onWindowFindAppearance', 'window:find-appearance', ELECTRON_EVENT],
+    ['sendCloseConfirmResponse', 'window:close-confirm-response', SEND],
+  ]),
+])
+
+export const RENDERER_CONTRACT_CATALOG = composeRendererContractCatalog(RENDERER_CONTRACT_GROUPS)

--- a/src/shared/renderer-contract-catalog.ts
+++ b/src/shared/renderer-contract-catalog.ts
@@ -11,12 +11,15 @@ const WEB = 'web'
 const LOCAL = 'local'
 const EVENT = 'event'
 const DORMANT_EVENT = 'dormant-event'
+const CLOSE_PANE_EVENT = 'close-pane-event'
 const ELECTRON = 'electron'
 const MAPPED_ELECTRON = 'mapped-electron'
 const SEND = 'send'
+const WINDOW_FIND_READY = 'window-find-ready'
 const ELECTRON_EVENT = 'electron-event'
 const NATIVE = 'native'
 const MAPPED_NATIVE = 'mapped-native'
+const DELEGATED_NATIVE = 'delegated-native'
 
 const POSITIONAL = 'positional'
 const DEFAULT_EMPTY = 'default-empty-object'
@@ -28,28 +31,20 @@ const RUNTIME_LANGUAGE = 'runtime-language-object'
 const RUNTIME_ENABLEMENT = 'runtime-enablement-object'
 const RUNTIME_INSTALL_AUTH = 'runtime-install-authorization-object'
 const RUNTIME_INTERPRETER = 'runtime-interpreter-path-object'
+const NATIVE_FILE_UPLOAD = 'native-file-upload-request'
 const SESSION_SAVE = 'session-save-optional-argument'
 const SESSION_SAVE_JSON = 'session-save-json-undefined'
 
-type ContractProfile =
-  | typeof WEB
-  | typeof LOCAL
-  | typeof EVENT
-  | typeof DORMANT_EVENT
-  | typeof ELECTRON
-  | typeof MAPPED_ELECTRON
-  | typeof SEND
-  | typeof ELECTRON_EVENT
-  | typeof NATIVE
-  | typeof MAPPED_NATIVE
+// prettier-ignore
+type ContractProfile = typeof WEB | typeof LOCAL | typeof EVENT | typeof DORMANT_EVENT | typeof CLOSE_PANE_EVENT | typeof ELECTRON | typeof MAPPED_ELECTRON | typeof SEND | typeof WINDOW_FIND_READY | typeof ELECTRON_EVENT | typeof NATIVE | typeof MAPPED_NATIVE | typeof DELEGATED_NATIVE
 
-type ContractEntry = readonly [
-  member: string,
-  channel: string | null,
-  profile?: ContractProfile,
-  electronCodec?: RendererParameterCodec,
-  webCodec?: RendererParameterCodec
-]
+// prettier-ignore
+type ContractEntry = readonly [member: string, channel: string | null, profile?: ContractProfile, electronCodec?: RendererParameterCodec, webCodec?: RendererParameterCodec]
+
+// prettier-ignore
+const CLOSE_PANE_LIFECYCLE = { activateChannel: 'shortcut:close-active-pane-ready', activate: 'after-subscribe', deactivateChannel: 'shortcut:close-active-pane-unready', deactivate: 'after-unsubscribe' } as const
+// prettier-ignore
+const WINDOW_FIND_LIFECYCLE = { activateChannel: 'shortcut:window-find-ready', activate: 'on-call', deactivateChannel: 'shortcut:window-find-unready', deactivate: 'on-dispose' } as const
 
 const surface = <Value>(
   electron: Value,
@@ -62,9 +57,10 @@ const expandEntry = (
   [member, channel, profile = WEB, electronCodec, webCodec]: ContractEntry
 ): RendererContractSeed => {
   const isWebRequest = profile === WEB || profile === LOCAL
-  const isWebEvent = profile === EVENT || profile === DORMANT_EVENT
+  const isDormantEvent = profile === DORMANT_EVENT || profile === CLOSE_PANE_EVENT
+  const isWebEvent = profile === EVENT || isDormantEvent
   const isElectronEvent = profile === ELECTRON_EVENT
-  const isNative = profile === NATIVE || profile === MAPPED_NATIVE
+  const isNative = profile === NATIVE || profile === MAPPED_NATIVE || profile === DELEGATED_NATIVE
   const kind = isWebEvent || isElectronEvent ? 'event' : 'method'
   const defaultElectronCodec =
     kind === 'event' ? 'event-listener' : profile === NATIVE ? 'surface-native' : POSITIONAL
@@ -80,11 +76,13 @@ const expandEntry = (
     ? 'captured-ipc-request'
     : isWebEvent
       ? 'web-event-subscription'
-      : isNative
-        ? 'surface-native'
-        : 'none'
+      : profile === DELEGATED_NATIVE
+        ? 'browser-native-with-captured-ipc'
+        : isNative
+          ? 'surface-native'
+          : 'none'
   const electronDispatch =
-    profile === SEND
+    profile === SEND || profile === WINDOW_FIND_READY
       ? 'electron-ipc-send'
       : kind === 'event'
         ? 'electron-ipc-subscription'
@@ -114,14 +112,14 @@ const expandEntry = (
       kind === 'event' ? 'electron-ipc' : 'not-event',
       profile === EVENT
         ? 'application-event'
-        : profile === DORMANT_EVENT
+        : isDormantEvent
           ? 'installed-undelivered'
           : kind === 'event'
             ? 'unavailable'
             : 'not-event',
       profile === EVENT
         ? 'application-event'
-        : profile === DORMANT_EVENT
+        : isDormantEvent
           ? 'installed-undelivered'
           : kind === 'event'
             ? 'unavailable'
@@ -129,11 +127,20 @@ const expandEntry = (
     ),
     authorityFlow: surface(
       kind === 'event' || profile === NATIVE ? 'none' : 'electron-sender',
-      isWebRequest ? 'caller-context' : 'none',
-      profile === WEB ? 'caller-context' : 'none'
+      isWebRequest || profile === DELEGATED_NATIVE ? 'caller-context' : 'none',
+      profile === WEB || profile === DELEGATED_NATIVE ? 'caller-context' : 'none'
     ),
+    lifecycleDispatch:
+      profile === CLOSE_PANE_EVENT
+        ? CLOSE_PANE_LIFECYCLE
+        : profile === WINDOW_FIND_READY
+          ? WINDOW_FIND_LIFECYCLE
+          : undefined,
     mapProjection:
-      isWebRequest || profile === MAPPED_ELECTRON || profile === MAPPED_NATIVE
+      isWebRequest ||
+      profile === MAPPED_ELECTRON ||
+      profile === MAPPED_NATIVE ||
+      profile === DELEGATED_NATIVE
         ? 'invoke'
         : isWebEvent
           ? 'event'
@@ -223,7 +230,7 @@ export const RENDERER_CONTRACT_GROUPS = Object.freeze([
     ['revoke', 'permissions:revoke'],
   ]),
   group('platform-file-save', '', [
-    ['getRuntimeVersions', null, NATIVE], ['saveBlobFile', 'file:save-blob', MAPPED_NATIVE], ['saveManagedFile', 'file:save-managed', MAPPED_NATIVE],
+    ['getRuntimeVersions', null, NATIVE], ['saveBlobFile', 'file:save-blob', MAPPED_NATIVE], ['saveManagedFile', 'file:save-managed', DELEGATED_NATIVE],
     ['saveSessionArtifacts', 'file:save-session-artifacts', MAPPED_ELECTRON],
   ]),
   group('preview', 'preview', [
@@ -346,12 +353,12 @@ export const RENDERER_CONTRACT_GROUPS = Object.freeze([
     ['claimLocalFile', 'uploads:claim-local-file'], ['deleteUpload', 'uploads:delete'], ['finalizeSession', 'uploads:finalize-session'],
     ['finishTransfer', 'uploads:finish-transfer'], ['getTransferStatus', 'uploads:transfer-status'],
     ['onTransferProgress', 'uploads:transfer-progress', DORMANT_EVENT], ['readPreview', 'uploads:read-preview'],
-    ['stageLocalFile', 'uploads:stage-local-file', MAPPED_ELECTRON], ['stageLocalPath', 'uploads:stage-local-path', LOCAL],
+    ['stageLocalFile', 'uploads:stage-local-file', MAPPED_ELECTRON, NATIVE_FILE_UPLOAD], ['stageLocalPath', 'uploads:stage-local-path', LOCAL],
   ]),
   group('window', 'window', [
-    ['announceWindowFindAppearance', 'window:find-appearance-changed', SEND], ['announceWindowFindReady', 'shortcut:window-find-ready', SEND],
+    ['announceWindowFindAppearance', 'window:find-appearance-changed', SEND], ['announceWindowFindReady', 'shortcut:window-find-ready', WINDOW_FIND_READY],
     ['clearFind', 'window:clear-find-in-page', SEND], ['close', 'window:close', MAPPED_NATIVE], ['closeFind', 'window:find-close', SEND],
-    ['findInPage', 'window:find-in-page', SEND], ['onCloseActivePane', 'shortcut:close-active-pane', DORMANT_EVENT],
+    ['findInPage', 'window:find-in-page', SEND], ['onCloseActivePane', 'shortcut:close-active-pane', CLOSE_PANE_EVENT],
     ['onCloseConfirmRequest', 'window:close-confirm-request', ELECTRON_EVENT], ['onFindInPageResult', 'window:find-in-page-result', ELECTRON_EVENT],
     ['onShowWindowFind', 'window:find-show', ELECTRON_EVENT], ['onWindowFindAppearance', 'window:find-appearance', ELECTRON_EVENT],
     ['sendCloseConfirmResponse', 'window:close-confirm-response', SEND],

--- a/src/shared/renderer-contract.test.ts
+++ b/src/shared/renderer-contract.test.ts
@@ -34,7 +34,17 @@ const seed = (publicPath: string, channel: string): RendererContractSeed => ({
 describe('renderer contract composition', () => {
   it('builds a deterministic deeply immutable catalog and projections', () => {
     const second = defineRendererContractGroup('projects', [seed('projects.list', 'projects:list')])
-    const first = defineRendererContractGroup('acp', [seed('acp.cancel', 'acp:cancel')])
+    const first = defineRendererContractGroup('acp', [
+      {
+        ...seed('acp.cancel', 'acp:cancel'),
+        lifecycleDispatch: {
+          activateChannel: 'acp:ready',
+          activate: 'after-subscribe',
+          deactivateChannel: 'acp:unready',
+          deactivate: 'after-unsubscribe'
+        }
+      }
+    ])
     const catalog = composeRendererContractCatalog([second, first])
     const projection = projectRendererContractMaps(catalog)
 
@@ -48,6 +58,7 @@ describe('renderer contract composition', () => {
     expect(Object.isFrozen(first.contracts)).toBe(true)
     expect(Object.isFrozen(first.contracts[0])).toBe(true)
     expect(Object.isFrozen(first.contracts[0].surfaceInstallation)).toBe(true)
+    expect(Object.isFrozen(first.contracts[0].lifecycleDispatch)).toBe(true)
     expect(Object.isFrozen(catalog)).toBe(true)
     expect(Object.isFrozen(projection.invoke)).toBe(true)
   })
@@ -73,18 +84,46 @@ describe('renderer contract composition', () => {
         defineRendererContractGroup('second', [seed('second.path', 'shared:channel')])
       ])
     ).toThrow('Duplicate renderer contract channel: shared:channel')
+
+    expect(() =>
+      composeRendererContractCatalog([
+        defineRendererContractGroup('first', [
+          {
+            ...seed('first.path', 'first:channel'),
+            lifecycleDispatch: {
+              activateChannel: 'shared:lifecycle-channel',
+              activate: 'on-call',
+              deactivateChannel: 'first:unready',
+              deactivate: 'on-dispose'
+            }
+          }
+        ]),
+        defineRendererContractGroup('second', [seed('second.path', 'shared:lifecycle-channel')])
+      ])
+    ).toThrow('Duplicate renderer contract channel: shared:lifecycle-channel')
   })
 
   it('copies nested profiles before freezing declarations', () => {
-    const mutable = seed('projects.list', 'projects:list') as {
+    const mutable = {
+      ...seed('projects.list', 'projects:list'),
+      lifecycleDispatch: {
+        activateChannel: 'projects:ready',
+        activate: 'on-call' as const,
+        deactivateChannel: 'projects:unready',
+        deactivate: 'on-dispose' as const
+      }
+    } as {
       publicPath: string
       surfaceInstallation: { localWeb: string }
+      lifecycleDispatch: { activateChannel: string }
     }
     const group = defineRendererContractGroup('projects', [mutable as RendererContractSeed])
     mutable.publicPath = 'projects.changed'
     mutable.surfaceInstallation.localWeb = 'changed'
+    mutable.lifecycleDispatch.activateChannel = 'changed'
 
     expect(group.contracts[0].publicPath).toBe('projects.list')
     expect(group.contracts[0].surfaceInstallation.localWeb).toBe('web-rpc')
+    expect(group.contracts[0].lifecycleDispatch?.activateChannel).toBe('projects:ready')
   })
 })

--- a/src/shared/renderer-contract.test.ts
+++ b/src/shared/renderer-contract.test.ts
@@ -1,0 +1,90 @@
+import { describe, expect, it } from 'vitest'
+
+import {
+  composeRendererContractCatalog,
+  defineRendererContractGroup,
+  projectRendererContractMaps,
+  type RendererContractSeed
+} from './renderer-contract'
+
+const seed = (publicPath: string, channel: string): RendererContractSeed => ({
+  publicPath,
+  channel,
+  kind: 'method',
+  parameterCodec: { electron: 'positional', web: 'positional' },
+  surfaceInstallation: { electron: 'preload', localWeb: 'web-rpc', remoteWeb: 'web-rpc' },
+  dispatchPolicy: {
+    electron: 'electron-ipc-request',
+    localWeb: 'captured-ipc-request',
+    remoteWeb: 'captured-ipc-request'
+  },
+  eventDeliverability: {
+    electron: 'not-event',
+    localWeb: 'not-event',
+    remoteWeb: 'not-event'
+  },
+  authorityFlow: {
+    electron: 'electron-sender',
+    localWeb: 'caller-context',
+    remoteWeb: 'caller-context'
+  },
+  mapProjection: 'invoke'
+})
+
+describe('renderer contract composition', () => {
+  it('builds a deterministic deeply immutable catalog and projections', () => {
+    const second = defineRendererContractGroup('projects', [seed('projects.list', 'projects:list')])
+    const first = defineRendererContractGroup('acp', [seed('acp.cancel', 'acp:cancel')])
+    const catalog = composeRendererContractCatalog([second, first])
+    const projection = projectRendererContractMaps(catalog)
+
+    expect(catalog.map(({ publicPath }) => publicPath)).toEqual(['acp.cancel', 'projects.list'])
+    expect(projection.invoke).toEqual({
+      'acp.cancel': 'acp:cancel',
+      'projects.list': 'projects:list'
+    })
+    expect(projection.event).toEqual({})
+    expect(Object.isFrozen(first)).toBe(true)
+    expect(Object.isFrozen(first.contracts)).toBe(true)
+    expect(Object.isFrozen(first.contracts[0])).toBe(true)
+    expect(Object.isFrozen(first.contracts[0].surfaceInstallation)).toBe(true)
+    expect(Object.isFrozen(catalog)).toBe(true)
+    expect(Object.isFrozen(projection.invoke)).toBe(true)
+  })
+
+  it('rejects duplicate capabilities, public paths, and channels', () => {
+    expect(() =>
+      composeRendererContractCatalog([
+        defineRendererContractGroup('same', [seed('first.path', 'first:channel')]),
+        defineRendererContractGroup('same', [seed('second.path', 'second:channel')])
+      ])
+    ).toThrow('Duplicate renderer contract capability: same')
+
+    expect(() =>
+      composeRendererContractCatalog([
+        defineRendererContractGroup('first', [seed('shared.path', 'first:channel')]),
+        defineRendererContractGroup('second', [seed('shared.path', 'second:channel')])
+      ])
+    ).toThrow('Duplicate renderer contract path: shared.path')
+
+    expect(() =>
+      composeRendererContractCatalog([
+        defineRendererContractGroup('first', [seed('first.path', 'shared:channel')]),
+        defineRendererContractGroup('second', [seed('second.path', 'shared:channel')])
+      ])
+    ).toThrow('Duplicate renderer contract channel: shared:channel')
+  })
+
+  it('copies nested profiles before freezing declarations', () => {
+    const mutable = seed('projects.list', 'projects:list') as {
+      publicPath: string
+      surfaceInstallation: { localWeb: string }
+    }
+    const group = defineRendererContractGroup('projects', [mutable as RendererContractSeed])
+    mutable.publicPath = 'projects.changed'
+    mutable.surfaceInstallation.localWeb = 'changed'
+
+    expect(group.contracts[0].publicPath).toBe('projects.list')
+    expect(group.contracts[0].surfaceInstallation.localWeb).toBe('web-rpc')
+  })
+})

--- a/src/shared/renderer-contract.ts
+++ b/src/shared/renderer-contract.ts
@@ -1,0 +1,146 @@
+export type RendererContractKind = 'method' | 'event'
+
+export type RendererParameterCodec =
+  | 'positional'
+  | 'default-empty-object'
+  | 'storage-parent-object'
+  | 'storage-data-root-object'
+  | 'runtime-selection-object'
+  | 'runtime-language-environment-object'
+  | 'runtime-language-object'
+  | 'runtime-enablement-object'
+  | 'runtime-install-authorization-object'
+  | 'runtime-interpreter-path-object'
+  | 'session-save-optional-argument'
+  | 'session-save-json-undefined'
+  | 'event-listener'
+  | 'surface-native'
+
+export type RendererSurfaceInstallation =
+  'preload' | 'web-rpc' | 'web-event' | 'browser-native' | 'rejecting-stub' | 'unavailable'
+
+export type RendererDispatchPolicy =
+  | 'electron-ipc-request'
+  | 'electron-ipc-send'
+  | 'electron-ipc-subscription'
+  | 'captured-ipc-request'
+  | 'web-event-subscription'
+  | 'surface-native'
+  | 'rejecting-stub'
+  | 'none'
+
+export type RendererEventDeliverability =
+  'not-event' | 'electron-ipc' | 'application-event' | 'installed-undelivered' | 'unavailable'
+
+export type RendererAuthorityFlow = 'electron-sender' | 'caller-context' | 'none'
+export type RendererMapProjection = 'invoke' | 'event' | 'none'
+
+export type RendererSurfaceProfile<Value> = Readonly<{
+  electron: Value
+  localWeb: Value
+  remoteWeb: Value
+}>
+
+export type RendererParameterCodecProfile = Readonly<{
+  electron: RendererParameterCodec
+  web: RendererParameterCodec
+}>
+
+export type RendererContractSeed = Readonly<{
+  publicPath: string
+  channel: string | null
+  kind: RendererContractKind
+  parameterCodec: RendererParameterCodecProfile
+  surfaceInstallation: RendererSurfaceProfile<RendererSurfaceInstallation>
+  dispatchPolicy: RendererSurfaceProfile<RendererDispatchPolicy>
+  eventDeliverability: RendererSurfaceProfile<RendererEventDeliverability>
+  authorityFlow: RendererSurfaceProfile<RendererAuthorityFlow>
+  mapProjection: RendererMapProjection
+}>
+
+export type RendererContractDescriptor = Readonly<RendererContractSeed & { capability: string }>
+
+export type RendererContractGroup = Readonly<{
+  capability: string
+  contracts: readonly RendererContractDescriptor[]
+}>
+
+const compareText = (left: string, right: string): number =>
+  left < right ? -1 : left > right ? 1 : 0
+
+const freezeContract = (
+  capability: string,
+  seed: RendererContractSeed
+): RendererContractDescriptor =>
+  Object.freeze({
+    ...seed,
+    capability,
+    parameterCodec: Object.freeze({ ...seed.parameterCodec }),
+    surfaceInstallation: Object.freeze({ ...seed.surfaceInstallation }),
+    dispatchPolicy: Object.freeze({ ...seed.dispatchPolicy }),
+    eventDeliverability: Object.freeze({ ...seed.eventDeliverability }),
+    authorityFlow: Object.freeze({ ...seed.authorityFlow })
+  })
+
+export const defineRendererContractGroup = (
+  capability: string,
+  seeds: readonly RendererContractSeed[]
+): RendererContractGroup => {
+  if (!capability) throw new Error('Renderer contract capability must not be empty.')
+  return Object.freeze({
+    capability,
+    contracts: Object.freeze(seeds.map((seed) => freezeContract(capability, seed)))
+  })
+}
+
+export const composeRendererContractCatalog = (
+  groups: readonly RendererContractGroup[]
+): readonly RendererContractDescriptor[] => {
+  const capabilities = new Set<string>()
+  const paths = new Set<string>()
+  const channels = new Set<string>()
+  const catalog: RendererContractDescriptor[] = []
+
+  for (const group of groups) {
+    if (capabilities.has(group.capability)) {
+      throw new Error(`Duplicate renderer contract capability: ${group.capability}`)
+    }
+    capabilities.add(group.capability)
+    for (const contract of group.contracts) {
+      if (paths.has(contract.publicPath)) {
+        throw new Error(`Duplicate renderer contract path: ${contract.publicPath}`)
+      }
+      if (contract.channel !== null && channels.has(contract.channel)) {
+        throw new Error(`Duplicate renderer contract channel: ${contract.channel}`)
+      }
+      if (contract.mapProjection !== 'none' && contract.channel === null) {
+        throw new Error(`Projected renderer contract has no channel: ${contract.publicPath}`)
+      }
+      paths.add(contract.publicPath)
+      if (contract.channel !== null) channels.add(contract.channel)
+      catalog.push(contract)
+    }
+  }
+
+  return Object.freeze(
+    catalog.sort((left, right) => compareText(left.publicPath, right.publicPath))
+  )
+}
+
+export const projectRendererContractMaps = (
+  catalog: readonly RendererContractDescriptor[]
+): Readonly<{
+  invoke: Readonly<Record<string, string>>
+  event: Readonly<Record<string, string>>
+}> => {
+  const invoke: Record<string, string> = {}
+  const event: Record<string, string> = {}
+
+  for (const contract of catalog) {
+    if (contract.mapProjection === 'none' || contract.channel === null) continue
+    const target = contract.mapProjection === 'invoke' ? invoke : event
+    target[contract.publicPath] = contract.channel
+  }
+
+  return Object.freeze({ invoke: Object.freeze(invoke), event: Object.freeze(event) })
+}

--- a/src/shared/renderer-contract.ts
+++ b/src/shared/renderer-contract.ts
@@ -1,39 +1,22 @@
 export type RendererContractKind = 'method' | 'event'
 
-export type RendererParameterCodec =
-  | 'positional'
-  | 'default-empty-object'
-  | 'storage-parent-object'
-  | 'storage-data-root-object'
-  | 'runtime-selection-object'
-  | 'runtime-language-environment-object'
-  | 'runtime-language-object'
-  | 'runtime-enablement-object'
-  | 'runtime-install-authorization-object'
-  | 'runtime-interpreter-path-object'
-  | 'session-save-optional-argument'
-  | 'session-save-json-undefined'
-  | 'event-listener'
-  | 'surface-native'
+// prettier-ignore
+export type RendererParameterCodec = 'positional' | 'default-empty-object' | 'storage-parent-object' | 'storage-data-root-object' | 'runtime-selection-object' | 'runtime-language-environment-object' | 'runtime-language-object' | 'runtime-enablement-object' | 'runtime-install-authorization-object' | 'runtime-interpreter-path-object' | 'native-file-upload-request' | 'session-save-optional-argument' | 'session-save-json-undefined' | 'event-listener' | 'surface-native'
 
 export type RendererSurfaceInstallation =
   'preload' | 'web-rpc' | 'web-event' | 'browser-native' | 'rejecting-stub' | 'unavailable'
 
-export type RendererDispatchPolicy =
-  | 'electron-ipc-request'
-  | 'electron-ipc-send'
-  | 'electron-ipc-subscription'
-  | 'captured-ipc-request'
-  | 'web-event-subscription'
-  | 'surface-native'
-  | 'rejecting-stub'
-  | 'none'
+// prettier-ignore
+export type RendererDispatchPolicy = 'electron-ipc-request' | 'electron-ipc-send' | 'electron-ipc-subscription' | 'captured-ipc-request' | 'browser-native-with-captured-ipc' | 'web-event-subscription' | 'surface-native' | 'rejecting-stub' | 'none'
 
 export type RendererEventDeliverability =
   'not-event' | 'electron-ipc' | 'application-event' | 'installed-undelivered' | 'unavailable'
 
 export type RendererAuthorityFlow = 'electron-sender' | 'caller-context' | 'none'
 export type RendererMapProjection = 'invoke' | 'event' | 'none'
+
+// prettier-ignore
+export type RendererLifecycleDispatch = Readonly<{ activateChannel: string; activate: 'after-subscribe' | 'on-call'; deactivateChannel: string; deactivate: 'after-unsubscribe' | 'on-dispose' }>
 
 export type RendererSurfaceProfile<Value> = Readonly<{
   electron: Value
@@ -55,6 +38,7 @@ export type RendererContractSeed = Readonly<{
   dispatchPolicy: RendererSurfaceProfile<RendererDispatchPolicy>
   eventDeliverability: RendererSurfaceProfile<RendererEventDeliverability>
   authorityFlow: RendererSurfaceProfile<RendererAuthorityFlow>
+  lifecycleDispatch?: RendererLifecycleDispatch
   mapProjection: RendererMapProjection
 }>
 
@@ -79,7 +63,10 @@ const freezeContract = (
     surfaceInstallation: Object.freeze({ ...seed.surfaceInstallation }),
     dispatchPolicy: Object.freeze({ ...seed.dispatchPolicy }),
     eventDeliverability: Object.freeze({ ...seed.eventDeliverability }),
-    authorityFlow: Object.freeze({ ...seed.authorityFlow })
+    authorityFlow: Object.freeze({ ...seed.authorityFlow }),
+    lifecycleDispatch: seed.lifecycleDispatch
+      ? Object.freeze({ ...seed.lifecycleDispatch })
+      : undefined
   })
 
 export const defineRendererContractGroup = (
@@ -110,14 +97,23 @@ export const composeRendererContractCatalog = (
       if (paths.has(contract.publicPath)) {
         throw new Error(`Duplicate renderer contract path: ${contract.publicPath}`)
       }
-      if (contract.channel !== null && channels.has(contract.channel)) {
-        throw new Error(`Duplicate renderer contract channel: ${contract.channel}`)
+      const contractChannels = new Set(
+        [
+          contract.channel,
+          contract.lifecycleDispatch?.activateChannel,
+          contract.lifecycleDispatch?.deactivateChannel
+        ].filter((channel): channel is string => channel != null)
+      )
+      for (const channel of contractChannels) {
+        if (channels.has(channel)) {
+          throw new Error(`Duplicate renderer contract channel: ${channel}`)
+        }
+        channels.add(channel)
       }
       if (contract.mapProjection !== 'none' && contract.channel === null) {
         throw new Error(`Projected renderer contract has no channel: ${contract.publicPath}`)
       }
       paths.add(contract.publicPath)
-      if (contract.channel !== null) channels.add(contract.channel)
       catalog.push(contract)
     }
   }

--- a/src/shared/renderer-surface-inventory.test.ts
+++ b/src/shared/renderer-surface-inventory.test.ts
@@ -2,6 +2,7 @@ import { beforeAll, describe, expect, it, vi } from 'vitest'
 
 import type { ApplicationEventChannel } from '../main/application-events'
 import { REMOTE_LOCAL_ONLY_RPC_CHANNELS } from '../main/web-service/http-server'
+import { RENDERER_CONTRACT_CATALOG } from './renderer-contract-catalog'
 import { WEB_EVENT_CHANNELS, WEB_INVOKE_CHANNELS } from './web-api-map.generated'
 import { WEB_RPC_ALLOWED_CHANNELS, WEB_RPC_UNAVAILABLE_CHANNELS } from './web-rpc-contract'
 
@@ -198,6 +199,10 @@ describe('renderer surface inventory', () => {
     ])
 
     expect(electronPaths).toHaveLength(291)
+    expectSameSet(
+      electronPaths,
+      RENDERER_CONTRACT_CATALOG.map(({ publicPath }) => publicPath)
+    )
     expect(Object.keys(WEB_INVOKE_CHANNELS)).toHaveLength(222)
     expect(Object.keys(WEB_EVENT_CHANNELS)).toHaveLength(32)
     expectSameSet(


### PR DESCRIPTION
## Problem

Electron, local Web, and remote Web currently expose a 291-callable renderer surface through separate preload, RPC, event, and browser-native paths. The generated Web path/channel maps do not describe parameter transforms, installation, dispatch, event delivery, authority, or deliberate surface asymmetry, so later adapter extraction cannot be reviewed against one capability-owned source of truth.

## Proposed change

- Add immutable renderer contract descriptors for public path/channel, parameter codec, per-surface installation, dispatch policy, event deliverability, authority flow, map projection, and the two existing window READY/UNREADY lifecycles.
- Compose 30 capability-owned groups into a deterministic 291-callable catalog with duplicate capability/path/channel rejection and deep freezing.
- Generate the existing 222-invoke / 32-event Web maps from the compact catalog manifest through a fail-closed TypeScript AST reader.
- Describe existing special cases without normalizing them: the Runtime and Session argument deviations, native-file upload request reshaping, and `saveManagedFile` browser-native download delegated through captured IPC.

```mermaid
flowchart LR
  G["30 capability descriptor groups"] --> C["Immutable deterministic catalog"]
  C --> P["Invoke/event projection"]
  P --> M["Existing generated Web maps<br/>byte-identical output"]
  C -. "metadata seam for T1c–T1e" .-> A["Future Electron/Web adapters"]
  E["Current preload + Web bootstrap"] --> D["Current dispatch behavior unchanged"]
```

## Scope and non-goals

- Internal architecture changes only: the catalog becomes the metadata source of truth and the generator reads it. No adapter consumes the catalog in this PR.
- No public API, data model, data relationship, persisted state, UI, or user interaction change.
- Preserve current surface asymmetry:
  - Specialist management remains Electron-only.
  - Permission remains available on Electron/Web; Task/CLI keep their current subset.
  - Compute remains complete on Electron/local Web; remote Web still rejects download/reveal; CLI gains no management API.
- Keep all Electron, local Web, remote Web, CLI, Task, and local-RPC runtime dispatch unchanged.
- Do not add Issue #458 orchestration methods, fields, state, or public interfaces. This is only a forward-compatible descriptor seam.
- Production churn is exactly 620, at the T1b soft stop and below the 700 hard stop.

## Acceptance criteria and validation

All commands below ran against final HEAD after the last material edit.

- Catalog composition, deep immutability, duplicate detection, path/channel projections, argument codecs, native/delegated behavior, window lifecycle ordering, and Specialist/Permission/Compute asymmetry -> `npm test -- --run src/shared/renderer-contract.test.ts src/shared/renderer-contract-catalog.test.ts src/shared/renderer-surface-inventory.test.ts src/shared/web-rpc-contract.test.ts src/renderer/web/api-map.generated.test.ts src/renderer/web/renderer-argument-shape-characterization.test.ts src/renderer/web/api-installer.test.ts src/renderer/web/bootstrap.test.ts` -> 8 files / 28 tests passed.
- Generated Web map compatibility -> `npm run check:web-api-map` -> passed; generated file has zero diff from `origin/main` and SHA-256 `dc36c167f5553c54b572a03bb971324687b1d8deca729c3dc3f5849f49a1bd22`.
- Type contracts -> `npm run typecheck` -> passed.
- Lint -> `npm run lint` -> passed with 0 errors and 18 pre-existing warnings.
- Web production integration -> `npm run build:web` -> passed.
- Full regression suite -> `npm test -- --maxWorkers=25%` -> 710 files / 10,346 tests passed; 15 files / 184 tests skipped.

Independent Standards, Spec, and generator/cross-surface reviews reported 0 findings on final HEAD.

## Review focus

- Whether descriptors describe current behavior instead of granting or normalizing capabilities.
- Whether lifecycle and native/delegated metadata are sufficient for T1c–T1e without special-casing.
- Whether catalog composition remains deterministic, deeply immutable, and fail-closed.
- Whether the AST generator remains the only migration of the generated map source while preserving byte-identical output.

## Uncovered risk

No UI E2E suite was run because neither Electron nor Web adapters consume the catalog yet and no user interaction changes. T1c–T1e will require adapter-level integration and certification before captured IPC can be replaced.

Related: #458
Depends on: #674
