### PR TITLE
fix(transport): preserve optional renderer argument shapes

### DIFF
--- a/src/renderer/web/renderer-argument-shape-characterization.test.ts
+++ b/src/renderer/web/renderer-argument-shape-characterization.test.ts
@@ -2,6 +2,7 @@
 
 import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest'
 
+import { RENDERER_CONTRACT_CATALOG } from '../../shared/renderer-contract-catalog'
 import { WEB_EVENT_CHANNELS, WEB_INVOKE_CHANNELS } from '../../shared/web-api-map.generated'
 import { WEB_RPC_ALLOWED_CHANNELS, WEB_RPC_PROTOCOL_VERSION } from '../../shared/web-rpc-contract'
 
@@ -60,6 +61,12 @@ const BROWSER_NATIVE_CALLABLE_PATHS = [
 ] as const
 
 const webInvocations: CapturedInvocation[] = []
+
+const codecAt = (path: string): (typeof RENDERER_CONTRACT_CATALOG)[number]['parameterCodec'] => {
+  const contract = RENDERER_CONTRACT_CATALOG.find(({ publicPath }) => publicPath === path)
+  if (!contract) throw new Error(`Missing renderer contract: ${path}`)
+  return contract.parameterCodec
+}
 
 const methodAt = (api: ApiRoot, path: string): ((...args: unknown[]) => Promise<unknown>) => {
   let value: unknown = api
@@ -288,10 +295,53 @@ describe('renderer argument-shape characterization', () => {
     })
   })
 
-  it('keeps every explicit Web transform equivalent to its Electron wrapper', async () => {
+  it('records ACP optional requests by call absence instead of normalizing explicit undefined', async () => {
+    for (const { path, channel } of [
+      { path: 'acp.connect', channel: 'acp:connect' },
+      { path: 'acp.createSession', channel: 'acp:create-session' }
+    ]) {
+      const electronWithoutArgument = await invokeElectron(electronApi, path, [])
+      const webWithoutArgument = await invokeWeb(webApi, path, [])
+      const electronWithUndefined = await invokeElectron(electronApi, path, [undefined])
+      const webWithUndefined = await invokeWeb(webApi, path, [undefined])
+
+      expect(electronWithoutArgument).toEqual({ channel, args: [{}] })
+      expect(webWithoutArgument).toEqual({ channel, args: [{}] })
+      expect(electronWithUndefined).toEqual({ channel, args: [{}] })
+      expect(webWithUndefined).toEqual({ channel, args: [null] })
+      expect(codecAt(path)).toEqual({
+        electron: 'default-empty-object',
+        web: 'default-empty-object-absent-only'
+      })
+    }
+  })
+
+  it('records the Electron-only optional notebook environment argument slot', async () => {
+    const electronWithoutArgument = await invokeElectron(electronApi, 'notebookEnv.cancel', [])
+    const webWithoutArgument = await invokeWeb(webApi, 'notebookEnv.cancel', [])
+    const electronWithUndefined = await invokeElectron(electronApi, 'notebookEnv.cancel', [
+      undefined
+    ])
+    const webWithUndefined = await invokeWeb(webApi, 'notebookEnv.cancel', [undefined])
+
+    expect(electronWithoutArgument).toEqual({
+      channel: 'notebook-env:cancel',
+      args: [undefined]
+    })
+    expect(webWithoutArgument).toEqual({ channel: 'notebook-env:cancel', args: [] })
+    expect(electronWithUndefined).toEqual({
+      channel: 'notebook-env:cancel',
+      args: [undefined]
+    })
+    expect(webWithUndefined).toEqual({ channel: 'notebook-env:cancel', args: [null] })
+    expect(codecAt('notebookEnv.cancel')).toEqual({
+      electron: 'optional-argument-slot',
+      web: 'positional'
+    })
+  })
+
+  it('keeps storage Web transforms equivalent to their Electron wrappers', async () => {
     const cases = [
-      { path: 'acp.connect', args: [] },
-      { path: 'acp.createSession', args: [] },
       { path: 'storage.validateDataRoot', args: ['/data'] },
       { path: 'storage.inspectDataRoot', args: ['/data'] },
       { path: 'storage.migrate', args: ['/data'] },

--- a/src/shared/renderer-contract-catalog.test.ts
+++ b/src/shared/renderer-contract-catalog.test.ts
@@ -77,12 +77,41 @@ describe('renderer contract catalog', () => {
     ).toEqual({ electron: 'native-file-upload-request', web: 'native-file-upload-request' })
 
     expect(
+      RENDERER_CONTRACT_CATALOG.filter(({ publicPath }) =>
+        ['acp.connect', 'acp.createSession'].includes(publicPath)
+      ).map(({ publicPath, parameterCodec }) => ({ publicPath, parameterCodec }))
+    ).toEqual([
+      {
+        publicPath: 'acp.connect',
+        parameterCodec: {
+          electron: 'default-empty-object',
+          web: 'default-empty-object-absent-only'
+        }
+      },
+      {
+        publicPath: 'acp.createSession',
+        parameterCodec: {
+          electron: 'default-empty-object',
+          web: 'default-empty-object-absent-only'
+        }
+      }
+    ])
+
+    expect(
+      RENDERER_CONTRACT_CATALOG.find(({ publicPath }) => publicPath === 'notebookEnv.cancel')
+        ?.parameterCodec
+    ).toEqual({ electron: 'optional-argument-slot', web: 'positional' })
+
+    expect(
       paths(
         ({ parameterCodec, surfaceInstallation }) =>
           surfaceInstallation.localWeb === 'web-rpc' &&
           parameterCodec.electron !== parameterCodec.web
       )
     ).toEqual([
+      'acp.connect',
+      'acp.createSession',
+      'notebookEnv.cancel',
       'runtime.describeUsage',
       'runtime.getEnablement',
       'runtime.listPackageCounts',
@@ -103,8 +132,6 @@ describe('renderer contract catalog', () => {
         parameterCodec.web !== 'surface-native'
     )
     expect(explicitEquivalentTransforms).toEqual([
-      'acp.connect',
-      'acp.createSession',
       'storage.commitAndRelaunch',
       'storage.discardMigratedCopy',
       'storage.inspectDataRoot',

--- a/src/shared/renderer-contract-catalog.ts
+++ b/src/shared/renderer-contract-catalog.ts
@@ -23,6 +23,8 @@ const DELEGATED_NATIVE = 'delegated-native'
 
 const POSITIONAL = 'positional'
 const DEFAULT_EMPTY = 'default-empty-object'
+const DEFAULT_EMPTY_ABSENT_ONLY = 'default-empty-object-absent-only'
+const OPTIONAL_ARGUMENT_SLOT = 'optional-argument-slot'
 const STORAGE_PARENT = 'storage-parent-object'
 const STORAGE_ROOT = 'storage-data-root-object'
 const RUNTIME_SELECTION = 'runtime-selection-object'
@@ -163,7 +165,7 @@ const group = (
 export const RENDERER_CONTRACT_GROUPS = Object.freeze([
   group('acp', 'acp', [
     ['onEvent', 'acp:event', EVENT], ['onPermissionRequest', 'acp:permission-request', EVENT], ['onState', 'acp:state', EVENT], ['cancel', 'acp:cancel'],
-    ['compactSession', 'acp:compact-session'], ['connect', 'acp:connect', WEB, DEFAULT_EMPTY], ['createSession', 'acp:create-session', WEB, DEFAULT_EMPTY],
+    ['compactSession', 'acp:compact-session'], ['connect', 'acp:connect', WEB, DEFAULT_EMPTY, DEFAULT_EMPTY_ABSENT_ONLY], ['createSession', 'acp:create-session', WEB, DEFAULT_EMPTY, DEFAULT_EMPTY_ABSENT_ONLY],
     ['deleteSession', 'acp:delete-session'], ['disconnect', 'acp:disconnect'], ['getState', 'acp:get-state'],
     ['resetSessionContext', 'acp:reset-session-context'], ['respondToPermission', 'acp:respond-permission'], ['resumeSession', 'acp:resume-session'],
     ['revokePermissionGrant', 'acp:revoke-permission-grant'], ['sendPrompt', 'acp:send-prompt'], ['setPermissionProfile', 'acp:set-permission-profile'],
@@ -213,7 +215,7 @@ export const RENDERER_CONTRACT_GROUPS = Object.freeze([
     ['state', 'notebook:state'],
   ]),
   group('notebook-environment', 'notebookEnv', [
-    ['onProgress', 'notebook-env:progress', DORMANT_EVENT], ['cancel', 'notebook-env:cancel', LOCAL], ['getStatus', 'notebook-env:status'],
+    ['onProgress', 'notebook-env:progress', DORMANT_EVENT], ['cancel', 'notebook-env:cancel', LOCAL, OPTIONAL_ARGUMENT_SLOT, POSITIONAL], ['getStatus', 'notebook-env:status'],
     ['provision', 'notebook-env:provision', LOCAL], ['repair', 'notebook-env:repair', LOCAL],
   ]),
   group('notifications', 'notifications', [

--- a/src/shared/renderer-contract.ts
+++ b/src/shared/renderer-contract.ts
@@ -1,7 +1,7 @@
 export type RendererContractKind = 'method' | 'event'
 
 // prettier-ignore
-export type RendererParameterCodec = 'positional' | 'default-empty-object' | 'storage-parent-object' | 'storage-data-root-object' | 'runtime-selection-object' | 'runtime-language-environment-object' | 'runtime-language-object' | 'runtime-enablement-object' | 'runtime-install-authorization-object' | 'runtime-interpreter-path-object' | 'native-file-upload-request' | 'session-save-optional-argument' | 'session-save-json-undefined' | 'event-listener' | 'surface-native'
+export type RendererParameterCodec = 'positional' | 'default-empty-object' | 'default-empty-object-absent-only' | 'optional-argument-slot' | 'storage-parent-object' | 'storage-data-root-object' | 'runtime-selection-object' | 'runtime-language-environment-object' | 'runtime-language-object' | 'runtime-enablement-object' | 'runtime-install-authorization-object' | 'runtime-interpreter-path-object' | 'native-file-upload-request' | 'session-save-optional-argument' | 'session-save-json-undefined' | 'event-listener' | 'surface-native'
 
 export type RendererSurfaceInstallation =
   'preload' | 'web-rpc' | 'web-event' | 'browser-native' | 'rejecting-stub' | 'unavailable'


### PR DESCRIPTION
## Problem

T1c/T1d adapter preflight found two observable optional-argument shapes that the renderer catalog could not distinguish without normalizing current Electron/Web behavior.

- Electron `acp.connect(undefined)` / `acp.createSession(undefined)` apply the default parameter and send `[{}]`; Web only defaults a missing argument and serializes an explicit `undefined` slot as `[null]`.
- Electron `notebookEnv.cancel()` always sends one explicit `undefined` slot; Web sends zero arguments, while an explicit `undefined` serializes as `[null]`.

## Proposed change

- Add real preload + Web bootstrap characterization for missing and explicit-undefined calls.
- Add `default-empty-object-absent-only` for the current Web ACP behavior while retaining Electron `default-empty-object`.
- Add `optional-argument-slot` for Electron Notebook environment cancellation while retaining Web positional behavior.
- Update the catalog deviation inventory to make these shapes reviewable by T1c/T1d.

## Scope and non-goals

- Metadata and characterization only; production churn is 8 lines.
- No preload/bootstrap runtime implementation, generated map, public API, data model, data relationship, UI, or user interaction change.
- No behavior repair or cross-surface normalization.
- No change to Electron/local Web/remote Web/CLI/Task capability availability, including Specialist/Permission/Compute asymmetry.
- No Issue #458 orchestration method, state, or interface.

## Acceptance criteria and validation

All checks ran against final HEAD after the last material edit.

- Missing/explicit-undefined forwarding and catalog codecs -> `npm test -- --run src/renderer/web/renderer-argument-shape-characterization.test.ts src/shared/renderer-contract-catalog.test.ts` -> 2 files / 12 tests passed.
- Generated map -> `npm run check:web-api-map` -> passed; zero diff and unchanged SHA-256 `dc36c167f5553c54b572a03bb971324687b1d8deca729c3dc3f5849f49a1bd22`.
- Type contracts -> `npm run typecheck` -> passed.
- Lint -> `npm run lint` -> 0 errors and 18 pre-existing warnings.
- Web production integration -> `npm run build:web` -> passed.
- Full regression suite -> `npm test -- --maxWorkers=25%` -> 710 files / 10,348 tests passed; 15 files / 184 tests skipped.

Independent Standards and Spec reviews reported 0 findings.

## Review focus

- Whether the labels describe existing observable behavior rather than fixing it.
- Whether T1c/T1d now have enough surface-specific metadata to preserve these calls through generic adapters.
- Whether generated path/channel output remains byte-identical.

## Uncovered risk

The follow-up adapters must implement these codec labels exactly; this PR intentionally does not change runtime dispatch.

Follow-up to: #677
Blocks: T1c Web renderer adapter and T1d Electron runtime adapter
