### PR TITLE
refactor(web): adapt renderer contracts from shared catalog

### DIFF
--- a/src/main/web-service/http-server.ts
+++ b/src/main/web-service/http-server.ts
@@ -23,6 +23,7 @@ import {
   WEB_RPC_PROTOCOL_VERSION,
   webRpcRequestSchema
 } from '../../shared/web-rpc-contract'
+import { RENDERER_CONTRACT_CATALOG } from '../../shared/renderer-contract-catalog'
 import { projectPublicTaskEvent, projectWebRendererEvent } from './application-event-projections'
 import { authenticateRequest, persistAuthCookie } from './auth'
 import type { StartTaskRunRequest } from '../../shared/task-api'
@@ -33,68 +34,16 @@ const MIN_GZIP_BYTES = 1_024
 const gzipAsync = promisify(gzip)
 
 // Remote Browser access is an application session, not authority over native host lifecycle and
-// shell integration. Keep these channels available to the loopback-token Web client while rejecting
-// them when authentication came from the external access adapter.
-export const REMOTE_LOCAL_ONLY_RPC_CHANNELS = new Set([
-  'artifacts:open-file',
-  'cli:install',
-  'cli:uninstall',
-  'compute:download',
-  'compute:reveal-in-folder',
-  // The "This computer" browser reads and opens the host filesystem, so it stays with the local app.
-  'local-fs:get-roots',
-  'local-fs:list-dir',
-  'local-fs:open-path',
-  'local-fs:read-preview',
-  'local-fs:reveal',
-  'logs:open-file',
-  'logs:reveal-in-folder',
-  'notebook-env:cancel',
-  'notebook-env:provision',
-  'notebook-env:repair',
-  'notebook:export-ipynb',
-  'notebook:export-ipynb-all',
-  'runtime:pick-interpreter',
-  'runtime:register-interpreter',
-  'runtime:set-environment-enabled',
-  'runtime:set-install-authorized',
-  'runtime:set-selection',
-  'runtime:unregister-interpreter',
-  'settings:cancel-claude-login',
-  'settings:cancel-codex-login',
-  'settings:cancel-isolated-claude-login',
-  'settings:install-claude',
-  'settings:install-codex',
-  'settings:install-opencode',
-  'settings:login-isolated-claude',
-  'settings:login-isolated-claude-browser',
-  'settings:login-isolated-codex',
-  'settings:login-shared-claude',
-  'settings:logout-isolated-claude',
-  'settings:logout-isolated-codex',
-  'settings:logout-shared-claude',
-  'settings:set-app-icon-variant',
-  'settings:set-close-preference',
-  'settings:set-notifications-enabled',
-  'settings:set-package-mirror',
-  'settings:uninstall-claude',
-  'settings:uninstall-codex',
-  'settings:uninstall-opencode',
-  'storage:cancel-migrate',
-  'storage:commit-and-relaunch',
-  'storage:discard-migrated-copy',
-  'storage:inspect-data-root',
-  'storage:migrate',
-  'storage:pick-directory',
-  'storage:reveal-app-storage',
-  'storage:set-data-root-and-relaunch',
-  'storage:validate-data-root',
-  'update:apply',
-  'update:cancel',
-  'update:download',
-  // Copies bytes from an arbitrary host path; the sibling stage-local-file is web-unavailable.
-  'uploads:stage-local-path'
-])
+// shell integration. The catalog keeps that authority decision aligned with renderer installation.
+export const REMOTE_LOCAL_ONLY_RPC_CHANNELS = new Set(
+  RENDERER_CONTRACT_CATALOG.flatMap(({ channel, surfaceInstallation }) =>
+    channel !== null &&
+    surfaceInstallation.localWeb === 'web-rpc' &&
+    surfaceInstallation.remoteWeb === 'rejecting-stub'
+      ? [channel]
+      : []
+  )
+)
 
 const MIME_TYPES: Record<string, string> = {
   '.css': 'text/css; charset=utf-8',

--- a/src/renderer/web/api-installer.test.ts
+++ b/src/renderer/web/api-installer.test.ts
@@ -1,25 +1,102 @@
 import { describe, expect, it, vi } from 'vitest'
-import { WEB_INVOKE_CHANNELS } from '../../shared/web-api-map.generated'
-import { installWebInvokeChannels } from './api-installer'
+import { installWebRendererContracts } from './api-installer'
 
-describe('installWebInvokeChannels', () => {
-  it('installs a rejecting stub for a real restricted Web API channel', async () => {
+const methodAt = (
+  api: Record<string, unknown>,
+  path: string
+): ((...args: unknown[]) => unknown) | undefined => {
+  let value: unknown = api
+  for (const part of path.split('.')) {
+    if (!value || typeof value !== 'object') return undefined
+    value = (value as Record<string, unknown>)[part]
+  }
+  return typeof value === 'function' ? (value as (...args: unknown[]) => unknown) : undefined
+}
+
+describe('installWebRendererContracts', () => {
+  it('installs an available local Web RPC contract from the merged catalog', async () => {
     const api: Record<string, unknown> = {}
-    const createInvoker = vi.fn()
+    const invoke = vi.fn().mockResolvedValue({ id: 'project-1' })
 
-    installWebInvokeChannels(
-      api,
-      WEB_INVOKE_CHANNELS,
-      new Set(),
-      new Set(['runtime:set-selection']),
-      createInvoker
-    )
+    installWebRendererContracts(api, {
+      availableRpcChannels: new Set(['projects:list']),
+      restrictedRpcChannels: new Set(),
+      invoke,
+      subscribe: vi.fn(),
+      nativeAdapters: {}
+    })
 
-    const setSelection = (api.runtime as { setSelection: (...args: unknown[]) => Promise<unknown> })
-      .setSelection
-    await expect(setSelection({ language: 'python', interpreter: '/tmp/python' })).rejects.toThrow(
-      'This action is only available in the local desktop app (runtime:set-selection).'
+    const list = (api.projects as { list: (...args: unknown[]) => Promise<unknown> }).list
+    await expect(list({ includeArchived: false })).resolves.toEqual({ id: 'project-1' })
+    expect(invoke).toHaveBeenCalledWith('projects:list', [{ includeArchived: false }])
+  })
+
+  it('preserves the Web optional-argument codecs when dispatching RPC', async () => {
+    const api: Record<string, unknown> = {}
+    const invoke = vi.fn().mockResolvedValue(undefined)
+
+    installWebRendererContracts(api, {
+      availableRpcChannels: new Set(['acp:connect', 'acp:create-session', 'notebook-env:cancel']),
+      restrictedRpcChannels: new Set(),
+      invoke,
+      subscribe: vi.fn(),
+      nativeAdapters: {}
+    })
+
+    await methodAt(api, 'acp.connect')?.()
+    await methodAt(api, 'acp.connect')?.(undefined)
+    await methodAt(api, 'acp.createSession')?.()
+    await methodAt(api, 'notebookEnv.cancel')?.()
+    await methodAt(api, 'notebookEnv.cancel')?.(undefined)
+
+    expect(invoke.mock.calls).toEqual([
+      ['acp:connect', [{}]],
+      ['acp:connect', [undefined]],
+      ['acp:create-session', [{}]],
+      ['notebook-env:cancel', []],
+      ['notebook-env:cancel', [undefined]]
+    ])
+  })
+
+  it('installs browser-native and inert event adapters without Electron lifecycle dispatch', () => {
+    const api: Record<string, unknown> = {}
+    const close = vi.fn()
+    const subscribe = vi.fn(() => vi.fn())
+    const listener = vi.fn()
+
+    installWebRendererContracts(api, {
+      availableRpcChannels: new Set(),
+      restrictedRpcChannels: new Set(),
+      invoke: vi.fn(),
+      subscribe,
+      nativeAdapters: { 'window.close': close }
+    })
+
+    expect(methodAt(api, 'window.close')).toBe(close)
+    expect(methodAt(api, 'specialist.list')).toBeUndefined()
+    expect(methodAt(api, 'uploads.stageLocalFile')).toBeUndefined()
+    expect(methodAt(api, 'window.announceWindowFindReady')).toBeUndefined()
+
+    const unsubscribe = methodAt(api, 'window.onCloseActivePane')?.(listener)
+    expect(subscribe).toHaveBeenCalledWith('shortcut:close-active-pane', listener)
+    expect(unsubscribe).toBe(subscribe.mock.results[0]?.value)
+  })
+
+  it('installs catalog-declared rejecting stubs only when bootstrap marks them restricted', async () => {
+    const api: Record<string, unknown> = {}
+
+    installWebRendererContracts(api, {
+      availableRpcChannels: new Set(),
+      restrictedRpcChannels: new Set(['compute:download']),
+      invoke: vi.fn(),
+      subscribe: vi.fn(),
+      nativeAdapters: {}
+    })
+
+    await expect(methodAt(api, 'compute.download')?.()).rejects.toThrow(
+      'This action is only available in the local desktop app (compute:download).'
     )
-    expect(createInvoker).not.toHaveBeenCalled()
+    expect(methodAt(api, 'compute.revealInFolder')).toBeUndefined()
+    expect(methodAt(api, 'projects.list')).toBeUndefined()
   })
 })

--- a/src/renderer/web/api-installer.ts
+++ b/src/renderer/web/api-installer.ts
@@ -1,10 +1,17 @@
-type InvokeHandler = (...args: unknown[]) => Promise<unknown>
+import { RENDERER_CONTRACT_CATALOG } from '../../shared/renderer-contract-catalog'
+import type { RendererContractDescriptor } from '../../shared/renderer-contract'
 
-export const assignApiPath = (
-  root: Record<string, unknown>,
-  path: string,
-  value: unknown
-): void => {
+type Listener = (payload: unknown) => void
+
+type WebRendererAdapters = Readonly<{
+  availableRpcChannels: ReadonlySet<string>
+  restrictedRpcChannels: ReadonlySet<string>
+  invoke: (channel: string, args: unknown[]) => Promise<unknown>
+  subscribe: (channel: string, listener: Listener) => () => void
+  nativeAdapters: Readonly<Record<string, unknown>>
+}>
+
+const assignApiPath = (root: Record<string, unknown>, path: string, value: unknown): void => {
   const parts = path.split('.')
   const key = parts.pop()!
   let target = root
@@ -15,22 +22,50 @@ export const assignApiPath = (
   target[key] = value
 }
 
-export const installWebInvokeChannels = (
+const transformArguments = (contract: RendererContractDescriptor, args: unknown[]): unknown[] => {
+  switch (contract.parameterCodec.web) {
+    case 'default-empty-object':
+      return args.length === 0 || (args.length === 1 && args[0] === undefined) ? [{}] : args
+    case 'default-empty-object-absent-only':
+      return args.length === 0 ? [{}] : args
+    case 'storage-parent-object':
+      return [{ parent: args[0] }]
+    case 'storage-data-root-object':
+      return [{ parent: args[0], markOnboarding: args[1] }]
+    default:
+      return args
+  }
+}
+
+export const installWebRendererContracts = (
   api: Record<string, unknown>,
-  channels: Record<string, string>,
-  availableRpcChannels: ReadonlySet<string>,
-  restrictedRpcChannels: ReadonlySet<string>,
-  createInvoker: (path: string, channel: string) => InvokeHandler
+  adapters: WebRendererAdapters
 ): void => {
-  for (const [path, channel] of Object.entries(channels)) {
-    if (availableRpcChannels.has(channel)) {
-      assignApiPath(api, path, createInvoker(path, channel))
-    } else if (restrictedRpcChannels.has(channel)) {
-      assignApiPath(api, path, () =>
+  for (const contract of RENDERER_CONTRACT_CATALOG) {
+    const { channel, publicPath } = contract
+    if (
+      channel !== null &&
+      contract.surfaceInstallation.localWeb === 'web-rpc' &&
+      adapters.availableRpcChannels.has(channel)
+    ) {
+      assignApiPath(api, publicPath, (...args: unknown[]) =>
+        adapters.invoke(channel, transformArguments(contract, args))
+      )
+    } else if (
+      channel !== null &&
+      contract.surfaceInstallation.remoteWeb === 'rejecting-stub' &&
+      adapters.restrictedRpcChannels.has(channel)
+    ) {
+      assignApiPath(api, publicPath, () =>
         Promise.reject(
           new Error(`This action is only available in the local desktop app (${channel}).`)
         )
       )
+    } else if (channel !== null && contract.surfaceInstallation.localWeb === 'web-event') {
+      assignApiPath(api, publicPath, (listener: Listener) => adapters.subscribe(channel, listener))
+    } else if (contract.surfaceInstallation.localWeb === 'browser-native') {
+      const nativeAdapter = adapters.nativeAdapters[publicPath]
+      if (nativeAdapter !== undefined) assignApiPath(api, publicPath, nativeAdapter)
     }
   }
 }

--- a/src/renderer/web/bootstrap.ts
+++ b/src/renderer/web/bootstrap.ts
@@ -1,11 +1,10 @@
-import { WEB_EVENT_CHANNELS, WEB_INVOKE_CHANNELS } from '../../shared/web-api-map.generated'
 import {
   WEB_RPC_PROTOCOL_VERSION,
   webRpcBootstrapSchema,
   webRpcEventSchema,
   webRpcResponseSchema
 } from '../../shared/web-rpc-contract'
-import { assignApiPath, installWebInvokeChannels } from './api-installer'
+import { installWebRendererContracts } from './api-installer'
 import { applyTheme, resolveInitialTheme } from '@/lib/theme'
 import openScienceLogoSvg from '../../main/remote-access/openscience-logo.svg?raw'
 
@@ -227,25 +226,6 @@ const downloadBlob = (blob: Blob, name: string): void => {
   window.setTimeout(() => URL.revokeObjectURL(url), 0)
 }
 
-const transformArgs = (path: string, args: unknown[]): unknown[] => {
-  if (
-    [
-      'storage.validateDataRoot',
-      'storage.inspectDataRoot',
-      'storage.migrate',
-      'storage.commitAndRelaunch',
-      'storage.discardMigratedCopy'
-    ].includes(path)
-  ) {
-    return [{ parent: args[0] }]
-  }
-  if (path === 'storage.setDataRootAndRelaunch') {
-    return [{ parent: args[0], markOnboarding: args[1] }]
-  }
-  if ((path === 'acp.connect' || path === 'acp.createSession') && args.length === 0) return [{}]
-  return args
-}
-
 const installWebApi = async (): Promise<void> => {
   const parsedBootstrap = webRpcBootstrapSchema.safeParse(await fetchBootstrap())
   if (!parsedBootstrap.success) {
@@ -254,50 +234,43 @@ const installWebApi = async (): Promise<void> => {
     )
   }
   const bootstrap = parsedBootstrap.data
-  const api: Record<string, unknown> = {
-    platform: bootstrap.platform,
-    getRuntimeVersions: () => bootstrap.versions
-  }
+  const api: Record<string, unknown> = { platform: bootstrap.platform }
   const availableRpcChannels = new Set(bootstrap.rpcChannels)
   const restrictedRpcChannels = new Set(bootstrap.restrictedRpcChannels ?? [])
 
-  installWebInvokeChannels(
-    api,
-    WEB_INVOKE_CHANNELS,
+  installWebRendererContracts(api, {
     availableRpcChannels,
     restrictedRpcChannels,
-    (path, channel) =>
-      (...args: unknown[]) =>
-        invoke(channel, transformArgs(path, args))
-  )
-  for (const [path, channel] of Object.entries(WEB_EVENT_CHANNELS)) {
-    assignApiPath(api, path, (listener: Listener) => subscribe(channel, listener))
-  }
-
-  api.saveBlobFile = (request: { suggestedName: string; mimeType: string; data: ArrayBuffer }) => {
-    downloadBlob(new Blob([request.data], { type: request.mimeType }), request.suggestedName)
-    return Promise.resolve({ saved: true })
-  }
-  api.saveManagedFile = async (request: {
-    source: 'artifact' | 'upload'
-    path: string
-    suggestedName: string
-  }) => {
-    const resource = (await invoke('preview-resources:acquire', [
-      { source: request.source, path: request.path }
-    ])) as { id: string; url: string }
-    try {
-      const response = await fetch(resource.url)
-      if (!response.ok) throw new Error(`Download failed: HTTP ${response.status}`)
-      downloadBlob(await response.blob(), request.suggestedName)
-      return { saved: true }
-    } finally {
-      await invoke('preview-resources:release', [{ resourceId: resource.id }])
+    invoke,
+    subscribe,
+    nativeAdapters: {
+      getRuntimeVersions: () => bootstrap.versions,
+      saveBlobFile: (request: { suggestedName: string; mimeType: string; data: ArrayBuffer }) => {
+        downloadBlob(new Blob([request.data], { type: request.mimeType }), request.suggestedName)
+        return Promise.resolve({ saved: true })
+      },
+      saveManagedFile: async (request: {
+        source: 'artifact' | 'upload'
+        path: string
+        suggestedName: string
+      }) => {
+        const resource = (await invoke('preview-resources:acquire', [
+          { source: request.source, path: request.path }
+        ])) as { id: string; url: string }
+        try {
+          const response = await fetch(resource.url)
+          if (!response.ok) throw new Error(`Download failed: HTTP ${response.status}`)
+          downloadBlob(await response.blob(), request.suggestedName)
+          return { saved: true }
+        } finally {
+          await invoke('preview-resources:release', [{ resourceId: resource.id }])
+        }
+      },
+      'window.close': () => {
+        window.close()
+        return Promise.resolve()
+      }
     }
-  }
-  assignApiPath(api, 'window.close', () => {
-    window.close()
-    return Promise.resolve()
   })
 
   ;(window as unknown as { api: unknown }).api = api

--- a/src/shared/renderer-surface-matrix.test.ts
+++ b/src/shared/renderer-surface-matrix.test.ts
@@ -13,8 +13,9 @@ import {
   projectWebRendererEvent
 } from '../main/web-service/application-event-projections'
 import { REMOTE_LOCAL_ONLY_RPC_CHANNELS } from '../main/web-service/http-server'
-import { installWebInvokeChannels } from '../renderer/web/api-installer'
+import { installWebRendererContracts } from '../renderer/web/api-installer'
 import type { AcpRuntimeEvent } from './acp'
+import { RENDERER_CONTRACT_CATALOG } from './renderer-contract-catalog'
 import { SPECIALIST_IPC } from './specialist'
 import type { StartTaskRunRequest } from './task-api'
 import { WEB_EVENT_CHANNELS, WEB_INVOKE_CHANNELS } from './web-api-map.generated'
@@ -70,6 +71,18 @@ const pathsWithPrefix = (paths: readonly string[], prefix: string): string[] =>
   paths.filter((path) => path.startsWith(prefix)).sort()
 
 describe('renderer surface compatibility matrix', () => {
+  it('derives remote Web rejecting channels from the renderer catalog', () => {
+    const expected = RENDERER_CONTRACT_CATALOG.flatMap(({ channel, surfaceInstallation }) =>
+      channel !== null &&
+      surfaceInstallation.localWeb === 'web-rpc' &&
+      surfaceInstallation.remoteWeb === 'rejecting-stub'
+        ? [channel]
+        : []
+    ).sort()
+
+    expect([...REMOTE_LOCAL_ONLY_RPC_CHANNELS].sort()).toEqual(expected)
+  })
+
   it('keeps Specialist management and pending-switch delivery Electron-only', () => {
     const invokePaths = Object.keys(WEB_INVOKE_CHANNELS)
     const eventPaths = Object.keys(WEB_EVENT_CHANNELS)
@@ -176,16 +189,13 @@ describe('renderer surface compatibility matrix', () => {
     expect(remoteRestrictedCompute).toEqual(['compute:download', 'compute:reveal-in-folder'])
 
     const remoteApi: Record<string, unknown> = {}
-    installWebInvokeChannels(
-      remoteApi,
-      {
-        'compute.download': WEB_INVOKE_CHANNELS['compute.download'],
-        'compute.revealInFolder': WEB_INVOKE_CHANNELS['compute.revealInFolder']
-      },
-      new Set(),
-      new Set(remoteRestrictedCompute),
-      () => async () => undefined
-    )
+    installWebRendererContracts(remoteApi, {
+      availableRpcChannels: new Set(),
+      restrictedRpcChannels: new Set(remoteRestrictedCompute),
+      invoke: async () => undefined,
+      subscribe: () => () => undefined,
+      nativeAdapters: {}
+    })
     const remoteCompute = remoteApi.compute as {
       download(): Promise<unknown>
       revealInFolder(): Promise<unknown>


### PR DESCRIPTION
# T1c pull request

Title: `refactor(web): adapt renderer contracts from shared catalog`

## Problem

The Web bootstrap still installed renderer methods and events from generated maps, transformed
arguments with path-specific conditionals, and maintained remote-only denials as a separate channel
list. Those copies could drift from the renderer contract catalog introduced by T1b/T1b.1.

## Proposed change

- Install local and remote Web RPC methods, event subscriptions, browser-native methods, and
  rejecting stubs through one catalog-driven Web adapter.
- Consume the catalog's Web parameter codecs while preserving the existing RPC v1 envelope and
  captured caller context.
- Derive remote local-only channels from descriptors whose local surface is `web-rpc` and remote
  surface is `rejecting-stub`.

```mermaid
flowchart LR
  C["Renderer contract catalog"] --> A["Web renderer adapter"]
  B["Authenticated bootstrap availability"] --> A
  A --> W["window.api"]
  W --> R["Captured Web RPC dispatcher"]
  W --> E["Existing event subscription"]
  W --> N["Browser-native adapters"]
  C --> D["Remote denial projection"]
  D --> H["Web HTTP bootstrap"]
```

## Scope and non-goals

- No public API, RPC protocol, persisted data model, data relationship, or user interaction changes.
- No preload, IPC registry, CLI/local RPC, Task, Specialist availability, or Issue #458 orchestration
  changes.
- Specialist remains absent from Web; Permission remains available on local/remote Web; remote
  Compute still rejects only download and reveal-in-folder.
- Installed-but-undelivered Web events remain inert, including the close-pane event without the
  Electron READY/UNREADY lifecycle.

## Acceptance criteria and validation

The checks below ran after the last material edit.

- Complete local Web callable surface, catalog installation, optional-argument codecs, and surface
  asymmetry -> focused renderer/catalog tests -> 4 files, 22 tests passed.
- HTTP bootstrap, remote denial, caller freshness, and event behavior ->
  `npm test -- src/main/web-service/http-server.test.ts` -> 16 tests passed outside the sandbox
  listener restriction.
- Node and Web type safety -> `npm run typecheck:node` and `npm run typecheck:web` -> passed.
- Generated compatibility maps -> `npm run check:web-api-map` -> passed with no generated diff.
- Web bundle integration -> `npm run build:web` -> passed.
- Repository static policy -> `npm run lint` -> 0 errors; 18 unchanged baseline warnings.
- Cross-platform/full regression -> required GitHub Actions checks -> pending at PR creation.

The focused checks intentionally replace a local full `npm test` run for this delivery; the required
online CI suite remains the merge gate.

## Review focus

- Catalog declarations are intersected with authenticated bootstrap availability rather than treated
  as registered runtime handlers.
- ACP absent-versus-explicit-undefined and Notebook Environment positional argument shapes remain
  unchanged.
- Remote restricted methods stay present as rejecting stubs and never reach the captured dispatcher.
- `saveManagedFile` keeps its existing acquire/fetch/release behavior and caller-context boundary.

## Uncovered risk

No new browser E2E directly exercises the native download interaction for `saveManagedFile`; its
implementation is moved without semantic changes. Existing focused characterization plus GitHub CI
cover the broader regression surface.
