### PR TITLE
feat(project-files): show session age in artifact list

### DIFF
--- a/src/renderer/src/pages/workspace/PreviewPanel.test.tsx
+++ b/src/renderer/src/pages/workspace/PreviewPanel.test.tsx
@@ -148,6 +148,7 @@ describe('PreviewPanel', () => {
     expect(chromeRow).not.toBeNull()
     expect(chromeRow?.contains(tabBar)).toBe(true)
     expect(tabBar?.parentElement).toBe(chromeRow)
+    expect(chromeRow?.className).toContain('pl-2')
     expect(chromeRow?.className).toContain('pr-14')
     expect(tabBar?.className).toContain('flex-1')
     expect(container.querySelector('[data-testid="preview-panel-toggle-slot"]')).toBeNull()

--- a/src/renderer/src/pages/workspace/PreviewPanel.tsx
+++ b/src/renderer/src/pages/workspace/PreviewPanel.tsx
@@ -494,7 +494,7 @@ const PreviewPanelSurface = ({ className }: PreviewPanelSurfaceProps): React.JSX
       {items.length > 0 ? (
         <div
           data-testid="preview-panel-top-bar"
-          className="flex min-w-0 w-full shrink-0 items-start pr-14"
+          className="flex min-w-0 w-full shrink-0 items-start pl-2 pr-14"
         >
           <PreviewTabBar
             tabs={items}

--- a/src/renderer/src/pages/workspace/ProjectFilesView.test.tsx
+++ b/src/renderer/src/pages/workspace/ProjectFilesView.test.tsx
@@ -758,6 +758,53 @@ describe('ProjectFilesView', () => {
     expect(sectionHeaders[1]?.className).toContain('border-t')
   })
 
+  it('shows the Session artifact count and update age with the default cursor in list view', async () => {
+    const now = 1710061200000
+    vi.spyOn(Date, 'now').mockReturnValue(now)
+    await renderView([
+      createSession({
+        title: 'Recent analysis',
+        updatedAt: now,
+        artifacts: [
+          {
+            id: 'artifact-now',
+            kind: 'managed-file',
+            path: '/workspace/current.txt',
+            name: 'current.txt'
+          }
+        ]
+      }),
+      createSession({
+        id: 'session-older',
+        title: 'Earlier analysis',
+        updatedAt: now - 15 * 60 * 60 * 1000,
+        artifacts: [
+          {
+            id: 'artifact-older',
+            kind: 'managed-file',
+            path: '/workspace/earlier.txt',
+            name: 'earlier.txt'
+          }
+        ]
+      })
+    ])
+
+    await act(async () => {
+      container.querySelector<HTMLButtonElement>('[aria-label="List view"]')?.click()
+    })
+
+    const headers = Array.from(
+      container.querySelectorAll<HTMLButtonElement>('[data-testid="project-file-section-header"]')
+    )
+    const recentHeader = headers.find((header) => header.textContent?.includes('Recent analysis'))
+    const earlierHeader = headers.find((header) => header.textContent?.includes('Earlier analysis'))
+
+    expect(recentHeader?.lastElementChild?.textContent).toBe('1 · now')
+    expect(earlierHeader?.lastElementChild?.textContent).toBe('1 · 15h ago')
+    expect(recentHeader?.className).toContain('cursor-default')
+    expect(recentHeader?.getAttribute('aria-expanded')).toBe('true')
+  })
+
   it('replaces compact list metadata with the row action on hover', async () => {
     vi.spyOn(Date, 'now').mockReturnValue(1710007202000)
     await renderView([

--- a/src/renderer/src/pages/workspace/ProjectFilesView.tsx
+++ b/src/renderer/src/pages/workspace/ProjectFilesView.tsx
@@ -32,6 +32,7 @@ import {
 import { Button } from '@/components/ui/button'
 import { Input } from '@/components/ui/input'
 import { Tooltip, TooltipContent, TooltipProvider, TooltipTrigger } from '@/components/ui/tooltip'
+import { formatRelativeTime } from '@/lib/format-relative-time'
 import { cn, formatByteSize } from '@/lib/utils'
 import { useNavigationStore } from '@/stores/navigation-store'
 import {
@@ -440,6 +441,7 @@ const SectionHeader = ({
     data-testid="project-file-section-header"
     className={cn(
       'flex w-full min-w-0 items-center gap-1.5 px-4 py-2 text-left text-sm text-text-000 hover:bg-bg-100',
+      id.startsWith('session:') && 'cursor-default',
       !hideTopBorder && 'border-t border-border-300/40'
     )}
     aria-expanded={!isCollapsed}
@@ -1032,6 +1034,7 @@ const ProjectFilesFilterMenu = ({
 const ProjectArtifactGroupSection = ({
   group,
   title,
+  timestamp,
   page,
   loadMode,
   manualVisibleItemLimit,
@@ -1047,6 +1050,7 @@ const ProjectArtifactGroupSection = ({
 }: {
   group: ArtifactGroupItem
   title: string
+  timestamp: number | undefined
   page: PageState<ProjectFileItem> | undefined
   loadMode: FilePageLoadMode
   manualVisibleItemLimit: number
@@ -1061,6 +1065,7 @@ const ProjectArtifactGroupSection = ({
   onOpenInPanel: (file: ProjectFileItem) => void
 }): React.JSX.Element => {
   const sectionId = `session:${group.sessionId}`
+  const relativeTimeLabel = timestamp === undefined ? undefined : formatRelativeTime(timestamp)
   const loadPage = useCallback(() => loadMore(group.sessionId), [group.sessionId, loadMore])
   const supportsIntersectionObserver = typeof IntersectionObserver !== 'undefined'
   const effectiveLoadMode =
@@ -1081,7 +1086,11 @@ const ProjectArtifactGroupSection = ({
       <SectionHeader
         id={sectionId}
         title={title}
-        countLabel={formatFileCount(group.artifactCount)}
+        countLabel={
+          relativeTimeLabel
+            ? `${group.artifactCount} · ${relativeTimeLabel}${relativeTimeLabel === 'now' ? '' : ' ago'}`
+            : formatFileCount(group.artifactCount)
+        }
         isCollapsed={isCollapsed}
         hideTopBorder={hideTopBorder}
         onToggle={onToggle}
@@ -1236,19 +1245,19 @@ const ProjectFilesViewContent = ({
     { kind: 'artifactGroups' }
   )
   const isSearchActive = debouncedSearchQuery.length > 0
-  const sessionTitleById = useMemo(
+  const sessionById = useMemo(
     () =>
       new Map(
         allSessions
           .filter((session) => session.projectId === activeProjectId)
-          .map((session) => [session.id, session.title] as const)
+          .map((session) => [session.id, session] as const)
       ),
     [activeProjectId, allSessions]
   )
   const getSessionTitle = useCallback(
     (sessionId: string): string =>
-      sessionTitleById.get(sessionId) ?? `Session ${sessionId.slice(0, 8)}`,
-    [sessionTitleById]
+      sessionById.get(sessionId)?.title ?? `Session ${sessionId.slice(0, 8)}`,
+    [sessionById]
   )
   const filterGroupItems =
     showAllSessionOptions && sessionOptionsIndex.groups.items.length > 0
@@ -1870,6 +1879,7 @@ const ProjectFilesViewContent = ({
                   key={group.sessionId}
                   group={group}
                   title={getArtifactGroupTitle(group)}
+                  timestamp={sessionById.get(group.sessionId)?.updatedAt}
                   page={index.artifactsBySession[group.sessionId]}
                   loadMode={isAllFilter ? 'manual' : 'scroll'}
                   manualVisibleItemLimit={


### PR DESCRIPTION
## Problem

The Preview tab strip sits too close to the conversation/preview divider. In Project Files List View, generated-file Session headers show only an Artifact count and use a pointer cursor, so users cannot see when the Session was last active and the header overstates its click affordance.

## Proposed solution

- Add the workspace-standard 8px left inset to the Preview tab strip.
- Reuse each existing Session's `updatedAt` value and the shared compact relative-time formatter to render metadata such as `1 · 15h ago`.
- Apply `cursor-default` to Session section headers while preserving their existing expand/collapse behavior and accessible state.
- Preserve the previous file-count fallback when Session timing data is unavailable.

## Scope and non-goals

- Renderer-only component and test changes.
- No architecture, persistence, data-model, IPC, or data-relation changes.
- No changes to Artifact loading, grouping, filtering, or preview behavior.

## Acceptance criteria

- [x] Preview tabs have visible separation from the adjacent column.
- [x] List View Session headers show Artifact count plus compact relative age.
- [x] Session headers retain expand/collapse behavior with the normal arrow cursor.
- [x] Missing Session timing data retains the existing file-count label.

## Validation

- [x] Targeted renderer tests: 2 files, 90 tests passed.
- [x] `npm run typecheck` equivalent: Node and Web TypeScript configurations passed.
- [x] ESLint: 0 errors; 18 pre-existing warnings outside the changed files.
- [x] Full Vitest suite: 711 files passed, 15 skipped; 10,366 tests passed, 184 skipped.
- [x] Local Chromium verification at 1600×900: Preview inset measured 8px; Session labels rendered `1 · 3h ago` / `1 · 2w ago`; computed Session cursor was `default`.

## Review focus

Please focus on the compact Session metadata grammar, the missing-timestamp fallback, and whether the Preview tab inset matches the surrounding workspace rhythm.
