### PR TITLE
test(transport): certify renderer surface contracts

### DIFF
--- a/packages/open-science/cli.test.ts
+++ b/packages/open-science/cli.test.ts
@@ -1,5 +1,6 @@
 import { describe, expect, it, vi } from 'vitest'
 
+import { PUBLIC_TERMINAL_FIXTURE } from '../../test/fixtures/renderer-contract-certification'
 import {
   CliUsageError,
   parseCliArgs,
@@ -261,7 +262,7 @@ describe('task CLI', () => {
   it('reads stdin, emits JSONL events, and sets a failed-run exit code', async () => {
     const client = {
       events: async function* () {
-        yield { type: 'run.event', data: { sessionId: 'session-1', kind: 'tool' } }
+        yield PUBLIC_TERMINAL_FIXTURE
       },
       startRun: vi.fn().mockResolvedValue({
         id: 'run-1',
@@ -303,7 +304,7 @@ describe('task CLI', () => {
       prompt: 'Research from stdin.'
     })
     expect(log.mock.calls.map(([line]) => JSON.parse(line))).toEqual([
-      { type: 'run.event', data: { sessionId: 'session-1', kind: 'tool' } },
+      PUBLIC_TERMINAL_FIXTURE,
       expect.objectContaining({ id: 'run-1', status: 'failed' })
     ])
     expect(setExitCode).toHaveBeenCalledWith(1)

--- a/packages/open-science/client.test.ts
+++ b/packages/open-science/client.test.ts
@@ -4,6 +4,7 @@ import { join } from 'node:path'
 
 import { afterEach, describe, expect, it, vi } from 'vitest'
 
+import { PUBLIC_TERMINAL_FIXTURE } from '../../test/fixtures/renderer-contract-certification'
 import { connectToOpenScience, OpenScienceClient } from './index.mjs'
 
 const response = (status: number, payload: unknown): Response =>
@@ -274,7 +275,7 @@ describe('OpenScienceClient', () => {
     FakeWebSocket.instance.emit('open')
     const first = events.next()
     FakeWebSocket.instance.emit('message', {
-      data: JSON.stringify({ type: 'run.event', data: { sessionId: 'session-1' } })
+      data: JSON.stringify(PUBLIC_TERMINAL_FIXTURE)
     })
     const second = events.next()
     FakeWebSocket.instance.emit('message', {
@@ -285,7 +286,7 @@ describe('OpenScienceClient', () => {
     })
 
     await expect(first).resolves.toEqual({
-      value: { type: 'run.event', data: { sessionId: 'session-1' } },
+      value: PUBLIC_TERMINAL_FIXTURE,
       done: false
     })
     await expect(second).resolves.toEqual({

--- a/src/renderer/web/api-installer.test.ts
+++ b/src/renderer/web/api-installer.test.ts
@@ -1,4 +1,13 @@
 import { describe, expect, it, vi } from 'vitest'
+
+import {
+  composeRendererContractCatalog,
+  defineRendererContractGroup
+} from '../../shared/renderer-contract'
+import {
+  RENDERER_CONTRACT_CATALOG,
+  RENDERER_CONTRACT_GROUPS
+} from '../../shared/renderer-contract-catalog'
 import { installWebRendererContracts } from './api-installer'
 
 const methodAt = (
@@ -11,6 +20,11 @@ const methodAt = (
     value = (value as Record<string, unknown>)[part]
   }
   return typeof value === 'function' ? (value as (...args: unknown[]) => unknown) : undefined
+}
+
+type Surface<Electron, Web> = { electron: Electron; localWeb: Web; remoteWeb: Web }
+function surface<Electron, Web>(electron: Electron, web: Web): Surface<Electron, Web> {
+  return { electron, localWeb: web, remoteWeb: web }
 }
 
 describe('installWebRendererContracts', () => {
@@ -98,5 +112,66 @@ describe('installWebRendererContracts', () => {
     )
     expect(methodAt(api, 'compute.revealInFolder')).toBeUndefined()
     expect(methodAt(api, 'projects.list')).toBeUndefined()
+  })
+
+  it('accepts one test-local neutral descriptor in both renderer adapters', async () => {
+    const productionPaths = RENDERER_CONTRACT_CATALOG.map(({ publicPath }) => publicPath)
+    const injectedCatalog = composeRendererContractCatalog([
+      ...RENDERER_CONTRACT_GROUPS,
+      defineRendererContractGroup('sample-extension', [
+        {
+          publicPath: 'sampleExtension.echo',
+          channel: 'sample-extension:echo',
+          kind: 'method',
+          parameterCodec: { electron: 'positional', web: 'positional' },
+          surfaceInstallation: surface('preload', 'web-rpc'),
+          dispatchPolicy: surface('electron-ipc-request', 'captured-ipc-request'),
+          eventDeliverability: surface('not-event', 'not-event'),
+          authorityFlow: surface('electron-sender', 'caller-context'),
+          mapProjection: 'invoke'
+        }
+      ])
+    ])
+
+    vi.resetModules()
+    vi.doMock('../../shared/renderer-contract-catalog', () => ({
+      RENDERER_CONTRACT_CATALOG: injectedCatalog
+    }))
+    const [{ createElectronRendererContractAdapter }, { installWebRendererContracts }] =
+      await Promise.all([
+        import('../../preload/electron-renderer-contract-adapter'),
+        import('./api-installer')
+      ])
+    const payload = { value: 'sample' }
+    const electronInvoke = vi.fn().mockResolvedValue(payload)
+    const electronPort = {
+      invoke: electronInvoke,
+      send: vi.fn(),
+      on: vi.fn(),
+      removeListener: vi.fn(),
+      getPathForFile: vi.fn(() => '')
+    }
+    await createElectronRendererContractAdapter(electronPort).invoke(
+      'sampleExtension.echo',
+      payload
+    )
+
+    const webInvoke = vi.fn().mockResolvedValue(payload)
+    const webApi: Record<string, unknown> = {}
+    installWebRendererContracts(webApi, {
+      availableRpcChannels: new Set(['sample-extension:echo']),
+      restrictedRpcChannels: new Set(),
+      invoke: webInvoke,
+      subscribe: vi.fn(),
+      nativeAdapters: {}
+    })
+    await methodAt(webApi, 'sampleExtension.echo')?.(payload)
+
+    expect(electronInvoke).toHaveBeenCalledWith('sample-extension:echo', payload)
+    expect(webInvoke).toHaveBeenCalledWith('sample-extension:echo', [payload])
+    expect(RENDERER_CONTRACT_CATALOG.map(({ publicPath }) => publicPath)).toEqual(productionPaths)
+    expect(productionPaths).not.toContain('sampleExtension.echo')
+    vi.doUnmock('../../shared/renderer-contract-catalog')
+    vi.resetModules()
   })
 })

--- a/src/shared/renderer-surface-matrix.test.ts
+++ b/src/shared/renderer-surface-matrix.test.ts
@@ -1,4 +1,9 @@
-import { describe, expect, it } from 'vitest'
+import { describe, expect, it, vi } from 'vitest'
+
+import {
+  SKILL_IMPORT_APPROVAL_FIXTURE,
+  TERMINAL_EVENT_FIXTURE
+} from '../../test/fixtures/renderer-contract-certification'
 
 import {
   canSatisfyHumanApproval,
@@ -13,8 +18,8 @@ import {
   projectWebRendererEvent
 } from '../main/web-service/application-event-projections'
 import { REMOTE_LOCAL_ONLY_RPC_CHANNELS } from '../main/web-service/http-server'
+import { createElectronRendererContractAdapter } from '../preload/electron-renderer-contract-adapter'
 import { installWebRendererContracts } from '../renderer/web/api-installer'
-import type { AcpRuntimeEvent } from './acp'
 import { RENDERER_CONTRACT_CATALOG } from './renderer-contract-catalog'
 import { SPECIALIST_IPC } from './specialist'
 import type { StartTaskRunRequest } from './task-api'
@@ -69,6 +74,50 @@ const computeEventPaths = ['compute.onApprovalRequest', 'compute.onJobUpdated'] 
 
 const pathsWithPrefix = (paths: readonly string[], prefix: string): string[] =>
   paths.filter((path) => path.startsWith(prefix)).sort()
+
+const projectThroughRendererAdapters = (
+  publicPath: string,
+  channel: string,
+  payload: unknown
+): { electronPayload: unknown; webPayload: unknown } => {
+  let electronIpcListener: ((event: unknown, payload: unknown) => void) | undefined
+  let electronPayload: unknown
+  const electronPort = {
+    invoke: vi.fn().mockResolvedValue(undefined),
+    send: vi.fn(),
+    on: vi.fn((_channel, listener) => (electronIpcListener = listener)),
+    removeListener: vi.fn(),
+    getPathForFile: vi.fn(() => '')
+  }
+  createElectronRendererContractAdapter(electronPort).subscribe(
+    publicPath,
+    (value) => (electronPayload = value)
+  )
+  electronIpcListener?.({}, payload)
+
+  let webIpcListener: ((payload: unknown) => void) | undefined
+  let webPayload: unknown
+  const webApi: Record<string, unknown> = {}
+  installWebRendererContracts(webApi, {
+    availableRpcChannels: new Set(),
+    restrictedRpcChannels: new Set(),
+    invoke: vi.fn(),
+    subscribe: (installedChannel, listener) => {
+      if (installedChannel === channel) webIpcListener = listener
+      return vi.fn()
+    },
+    nativeAdapters: {}
+  })
+  const webSubscribe = publicPath
+    .split('.')
+    .reduce<unknown>((value, member) => (value as Record<string, unknown>)[member], webApi) as (
+    listener: (value: unknown) => void
+  ) => void
+  webSubscribe((value) => (webPayload = value))
+  webIpcListener?.(payload)
+
+  return { electronPayload, webPayload }
+}
 
 describe('renderer surface compatibility matrix', () => {
   it('derives remote Web rejecting channels from the renderer catalog', () => {
@@ -216,32 +265,39 @@ describe('renderer surface compatibility matrix', () => {
     expect(REMOTE_LOCAL_ONLY_RPC_CHANNELS.has('project-files:search-artifacts')).toBe(false)
   })
 
-  it('passes terminal ACP metadata through Web and Task projections without recomputation', () => {
-    const payload: AcpRuntimeEvent = {
-      id: 'terminal-1',
-      timestamp: 1_700_000_000_123,
-      kind: 'stop',
-      level: 'info',
-      sessionId: 'session-1',
-      promptMessageId: 'prompt-1',
-      terminalOutput: 'complete',
-      terminalExitCode: 0,
-      turnUsage: {
-        inputTokens: 17,
-        cacheTokens: 5,
-        cachedReadTokens: 3,
-        cachedWriteTokens: 2,
-        outputTokens: 9,
-        turnCount: 4
-      },
-      raw: { providerSessionId: 'provider-session' }
+  it('passes complete terminal metadata through Electron, Web, and Task without recomputation', () => {
+    const event: ApplicationEvent<'acp:event'> = {
+      channel: 'acp:event',
+      payload: TERMINAL_EVENT_FIXTURE
     }
-    const event: ApplicationEvent<'acp:event'> = { channel: 'acp:event', payload }
-
-    expect(projectTaskRuntimeEvent(event)).toBe(payload)
-    expect(projectPublicTaskEvent(event)).toEqual({ type: 'run.event', data: payload })
     const webEvent = projectWebRendererEvent(event)
     expect(webEvent).toMatchObject({ protocolVersion: 1, channel: 'acp:event' })
-    expect(webEvent?.payload).toBe(payload)
+    const projected = projectThroughRendererAdapters('acp.onEvent', 'acp:event', webEvent?.payload)
+
+    expect(projected.electronPayload).toEqual(TERMINAL_EVENT_FIXTURE)
+    expect(projected.webPayload).toEqual(TERMINAL_EVENT_FIXTURE)
+    expect(projectTaskRuntimeEvent(event)).toEqual(TERMINAL_EVENT_FIXTURE)
+    expect(projectPublicTaskEvent(event)).toEqual({
+      type: 'run.event',
+      data: TERMINAL_EVENT_FIXTURE
+    })
+  })
+
+  it('preserves Skill import approval identity on Electron/Web and excludes Task', () => {
+    const event: ApplicationEvent<'skills:conversation-import-request'> = {
+      channel: 'skills:conversation-import-request',
+      payload: SKILL_IMPORT_APPROVAL_FIXTURE
+    }
+    const webEvent = projectWebRendererEvent(event)
+    const projected = projectThroughRendererAdapters(
+      'settings.onSkillImportApprovalRequest',
+      'skills:conversation-import-request',
+      webEvent?.payload
+    )
+
+    expect(projected.electronPayload).toBe(SKILL_IMPORT_APPROVAL_FIXTURE)
+    expect(projected.webPayload).toBe(SKILL_IMPORT_APPROVAL_FIXTURE)
+    expect(projectTaskRuntimeEvent(event)).toBeUndefined()
+    expect(projectPublicTaskEvent(event)).toBeUndefined()
   })
 })

--- a/src/shared/renderer-surface-matrix.test.ts
+++ b/src/shared/renderer-surface-matrix.test.ts
@@ -85,7 +85,7 @@ const projectThroughRendererAdapters = (
   const electronPort = {
     invoke: vi.fn().mockResolvedValue(undefined),
     send: vi.fn(),
-    on: vi.fn((_channel, listener) => (electronIpcListener = listener)),
+    on: vi.fn((ch, listener) => (electronIpcListener = ch === channel ? listener : undefined)),
     removeListener: vi.fn(),
     getPathForFile: vi.fn(() => '')
   }

--- a/test/fixtures/renderer-contract-certification.ts
+++ b/test/fixtures/renderer-contract-certification.ts
@@ -1,0 +1,42 @@
+import type { AcpRuntimeEvent } from '../../src/shared/acp'
+import type { ConversationSkillImportApprovalRequest } from '../../src/shared/settings'
+
+export const TERMINAL_EVENT_FIXTURE = {
+  id: 'terminal-certification',
+  timestamp: 1_700_000_000_123,
+  kind: 'stop',
+  level: 'info',
+  sessionId: 'session-1',
+  promptMessageId: 'prompt-message',
+  terminalOutput: 'analysis complete',
+  terminalExitCode: 0,
+  turnUsage: {
+    inputTokens: 17,
+    cacheTokens: 5,
+    cachedReadTokens: 3,
+    cachedWriteTokens: 2,
+    outputTokens: 9,
+    turnCount: 4
+  }
+} satisfies AcpRuntimeEvent
+
+export const PUBLIC_TERMINAL_FIXTURE = { type: 'run.event', data: TERMINAL_EVENT_FIXTURE } as const
+
+export const SKILL_IMPORT_APPROVAL_FIXTURE = {
+  id: 'skill-approval',
+  sessionId: 'session-1',
+  source: { kind: 'github', label: 'research-tools' },
+  previews: [
+    {
+      subPath: 'skills/research-tools',
+      name: 'research-tools',
+      description: 'Research helpers',
+      metadata: {},
+      body: '# Research tools',
+      files: ['SKILL.md'],
+      alreadyImported: false,
+      githubUrl: 'https://github.com/example/research-tools'
+    }
+  ],
+  skipped: []
+} satisfies ConversationSkillImportApprovalRequest


### PR DESCRIPTION
# T1f pull request

Title: `test(transport): certify renderer surface contracts`

## Problem

The Electron and Web renderer adapters are catalog-driven, but the final cross-surface evidence does
not yet exercise one complete terminal event through every public projection, the full Settings skill
import approval payload across eligible surfaces, or additive neutral descriptors through both
adapter algorithms.

## Proposed change

- Add one shared terminal and Settings approval fixture used by existing surface, SDK, and CLI tests.
- Deep-compare the terminal timestamp, prompt link, exit facts, every token category, and turn count
  across Electron, Web, Task, SDK, and CLI.
- Preserve Settings `source` and optional `githubUrl` identity on Electron/Web while proving the
  event remains absent from Task/public projection.
- Inject one neutral test-only descriptor into both adapters without changing the production catalog.

## Scope and non-goals

- Tests only; no production, data-model, public API, UI, or user-interaction change.
- No Specialist/Permission/Compute availability change.
- No Issue #458 orchestration fields, methods, events, or vocabulary.
- No duplicate hard-coded surface inventory.

## Acceptance criteria and validation

- Complete terminal metadata across Electron/Web/Task/SDK/CLI -> shared fixture through the four
  focused suites -> 4 files / 30 tests passed.
- Settings approval `source` and present optional `githubUrl` identity on Electron/Web, absent from
  Task/public projection -> `renderer-surface-matrix.test.ts` in the same focused run -> passed.
- Neutral future descriptor through Electron/Web adapters with unchanged production catalog ->
  `api-installer.test.ts` in the same focused run -> passed.
- Node and Web type checking -> `npm run typecheck:node` and `npm run typecheck:web` -> passed.
- ESLint over all five changed test/fixture files -> passed.
- `git diff --check` -> passed.
- Independent contract and standards reviews -> 0 actionable findings.
- Full and cross-platform suites are intentionally delegated to online CI.

## Review focus

- The shared fixture is the single source for Electron/Web/Task/SDK/CLI terminal assertions.
- Future-descriptor injection is isolated to the test module and leaves the production catalog
  unchanged before and after the test.
- Production churn remains zero and total test churn stays at or below 235 lines.

## Uncovered risk

The future-descriptor proof uses Vitest module mocking rather than a production catalog-injection
parameter. File isolation and explicit successful-path cleanup prevent test leakage; online CI remains
the full-suite and cross-platform gate.
