### PR TITLE
refactor(main): add application command router

### DIFF
--- a/src/main/application-command-router.test.ts
+++ b/src/main/application-command-router.test.ts
@@ -1,4 +1,4 @@
-import { describe, expect, it, vi } from 'vitest'
+import { describe, expect, expectTypeOf, it, vi } from 'vitest'
 
 import { createCallerContext, type CallerContext } from './caller-context'
 import {
@@ -76,6 +76,17 @@ describe('application command router', () => {
     expect(read).toHaveBeenCalledWith(expect.objectContaining({ args: ['one'] }))
   })
 
+  it('exposes an immutable copy of a mutable command list', () => {
+    const mutableCommands = [readValue]
+    const group = defineApplicationCommandGroup('mutable-input', mutableCommands)
+    type CommandsAreMutable = typeof group.commands extends unknown[] ? true : false
+
+    expectTypeOf<CommandsAreMutable>().toEqualTypeOf<false>()
+    mutableCommands.push(writeValue as never)
+    expect(group.commands).toEqual([readValue])
+    expect(Object.isFrozen(group.commands)).toBe(true)
+  })
+
   it('preflights an entire group before rejecting a duplicate or missing handler', () => {
     const router = createApplicationCommandRouter()
     const first = router.registrar.createScope()
@@ -99,6 +110,35 @@ describe('application command router', () => {
       )
     ).toThrow('Application command handler is missing: sample.write')
     expect(router.dispatcher.commandNames()).toEqual(['sample.read'])
+  })
+
+  it('rejects inherited handlers and retains the handler validated during preflight', async () => {
+    const router = createApplicationCommandRouter()
+    const inherited = router.registrar.createScope()
+    const inheritedHandlers = Object.create({ 'sample.write': vi.fn() })
+
+    expect(() =>
+      inherited.registerGroup(
+        defineApplicationCommandGroup('inherited', [writeValue] as const),
+        inheritedHandlers
+      )
+    ).toThrow('Application command handler is missing: sample.write')
+
+    const validatedHandler = vi.fn(() => 'value')
+    const handlers: Record<string, unknown> = {}
+    const readHandler = vi.fn(() => validatedHandler)
+    Object.defineProperty(handlers, 'sample.read', { enumerable: true, get: readHandler })
+    const registered = router.registrar.createScope()
+    registered.registerGroup(
+      defineApplicationCommandGroup('validated', [readValue] as const),
+      handlers as never
+    )
+
+    await expect(router.dispatcher.invoke(readValue, invocation(['one'] as const))).resolves.toBe(
+      'value'
+    )
+    expect(readHandler).toHaveBeenCalledOnce()
+    expect(validatedHandler).toHaveBeenCalledOnce()
   })
 
   it('keeps scopes isolated across rollback, uninstall, and concurrent late registration', () => {

--- a/src/main/application-command-router.test.ts
+++ b/src/main/application-command-router.test.ts
@@ -1,0 +1,315 @@
+import { describe, expect, it, vi } from 'vitest'
+
+import { createCallerContext, type CallerContext } from './caller-context'
+import {
+  createApplicationCommandRouter,
+  defineApplicationCommand,
+  defineApplicationCommandGroup,
+  type ApplicationCallerLease,
+  type ApplicationInvocation
+} from './application-command-router'
+
+const readValue = defineApplicationCommand<'sample.read', readonly [id: string], string>(
+  'sample.read'
+)
+const writeValue = defineApplicationCommand<
+  'sample.write',
+  readonly [id: string, value: string],
+  boolean
+>('sample.write')
+const sampleCommands = defineApplicationCommandGroup('sample', [readValue, writeValue] as const)
+
+const caller = (overrides: Partial<CallerContext> = {}): CallerContext =>
+  createCallerContext({
+    clientId: 'web-client',
+    lifecycleClientId: 'web:web-client',
+    leaseId: 'lease-1',
+    surface: 'web',
+    location: 'remote',
+    principalKind: 'automation',
+    actionOrigin: 'automation',
+    ...overrides
+  })
+
+const lease = (overrides: Partial<ApplicationCallerLease> = {}): ApplicationCallerLease =>
+  Object.freeze({
+    leaseId: 'lease-1',
+    generation: 1,
+    signal: new AbortController().signal,
+    isCurrent: () => true,
+    ...overrides
+  })
+
+const invocation = <Args extends readonly unknown[]>(
+  args: Args,
+  options: Readonly<{
+    callerContext?: CallerContext
+    callerLease?: ApplicationCallerLease
+  }> = {}
+): ApplicationInvocation<Args> =>
+  Object.freeze({
+    callerContext: options.callerContext ?? caller(),
+    callerLease: options.callerLease ?? lease(),
+    args
+  })
+
+describe('application command router', () => {
+  it('registers a typed group atomically and dispatches late registrations', async () => {
+    const router = createApplicationCommandRouter()
+    const scope = router.registrar.createScope()
+    const read = vi.fn(({ args }: ApplicationInvocation<readonly [string]>) => `value:${args[0]}`)
+    const write = vi.fn().mockResolvedValue(true)
+
+    expect(router.dispatcher.commandNames()).toEqual([])
+    scope.registerGroup(sampleCommands, {
+      'sample.read': read,
+      'sample.write': write
+    })
+
+    expect(router.dispatcher.commandNames()).toEqual(['sample.read', 'sample.write'])
+    await expect(router.dispatcher.invoke(readValue, invocation(['one'] as const))).resolves.toBe(
+      'value:one'
+    )
+    await expect(
+      router.dispatcher.invoke(writeValue, invocation(['one', 'next'] as const))
+    ).resolves.toBe(true)
+    expect(read).toHaveBeenCalledWith(expect.objectContaining({ args: ['one'] }))
+  })
+
+  it('preflights an entire group before rejecting a duplicate or missing handler', () => {
+    const router = createApplicationCommandRouter()
+    const first = router.registrar.createScope()
+    first.registerGroup(defineApplicationCommandGroup('first', [readValue] as const), {
+      'sample.read': vi.fn()
+    })
+    const second = router.registrar.createScope()
+
+    expect(() =>
+      second.registerGroup(sampleCommands, {
+        'sample.read': vi.fn(),
+        'sample.write': vi.fn()
+      })
+    ).toThrow('Application command is already registered: sample.read')
+    expect(router.dispatcher.commandNames()).toEqual(['sample.read'])
+
+    expect(() =>
+      second.registerGroup(
+        defineApplicationCommandGroup('missing', [writeValue] as const),
+        {} as never
+      )
+    ).toThrow('Application command handler is missing: sample.write')
+    expect(router.dispatcher.commandNames()).toEqual(['sample.read'])
+  })
+
+  it('keeps scopes isolated across rollback, uninstall, and concurrent late registration', () => {
+    const router = createApplicationCommandRouter()
+    const first = router.registrar.createScope()
+    first.registerGroup(defineApplicationCommandGroup('first', [readValue] as const), {
+      'sample.read': vi.fn()
+    })
+    const firstInstallation = first.complete()
+    const second = router.registrar.createScope()
+    second.registerGroup(defineApplicationCommandGroup('second', [writeValue] as const), {
+      'sample.write': vi.fn()
+    })
+
+    firstInstallation.uninstall()
+    firstInstallation.uninstall()
+    expect(router.dispatcher.commandNames()).toEqual(['sample.write'])
+
+    second.rollback()
+    second.rollback()
+    expect(router.dispatcher.commandNames()).toEqual([])
+  })
+
+  it('rejects unknown commands before consulting caller freshness', async () => {
+    const isAuthorizationCurrent = vi.fn(() => false)
+    const router = createApplicationCommandRouter()
+
+    await expect(
+      router.dispatcher.invoke(
+        readValue,
+        invocation(['one'] as const, { callerContext: caller({ isAuthorizationCurrent }) })
+      )
+    ).rejects.toThrow('Unknown application command: sample.read')
+    expect(isAuthorizationCurrent).not.toHaveBeenCalled()
+
+    const scope = router.registrar.createScope()
+    scope.registerGroup(defineApplicationCommandGroup('read', [readValue] as const), {
+      'sample.read': vi.fn()
+    })
+    const forgedRead = defineApplicationCommand<'sample.read', readonly [number], number>(
+      'sample.read'
+    )
+    await expect(router.dispatcher.invoke(forgedRead, invocation([1] as const))).rejects.toThrow(
+      'Unknown application command: sample.read'
+    )
+  })
+
+  it('fails closed for stale authorization, mismatched leases, and stale generations', async () => {
+    const handler = vi.fn(() => 'value')
+    const router = createApplicationCommandRouter()
+    const scope = router.registrar.createScope()
+    scope.registerGroup(defineApplicationCommandGroup('read', [readValue] as const), {
+      'sample.read': handler
+    })
+
+    await expect(
+      router.dispatcher.invoke(
+        readValue,
+        invocation(['one'] as const, {
+          callerContext: caller({ isAuthorizationCurrent: () => false })
+        })
+      )
+    ).rejects.toThrow('Caller authorization is no longer current.')
+    await expect(
+      router.dispatcher.invoke(
+        readValue,
+        invocation(['one'] as const, { callerLease: lease({ leaseId: 'other' }) })
+      )
+    ).rejects.toThrow('Caller lease does not match caller context.')
+    await expect(
+      router.dispatcher.invoke(
+        readValue,
+        invocation(['one'] as const, { callerLease: lease({ isCurrent: () => false }) })
+      )
+    ).rejects.toThrow('Caller lease is no longer current.')
+    const releasedLease = new AbortController()
+    releasedLease.abort()
+    await expect(
+      router.dispatcher.invoke(
+        readValue,
+        invocation(['one'] as const, { callerLease: lease({ signal: releasedLease.signal }) })
+      )
+    ).rejects.toThrow('Caller lease is no longer current.')
+    expect(handler).not.toHaveBeenCalled()
+  })
+
+  it('lets in-flight work observe lease release and finish after uninstall', async () => {
+    let resolve!: (value: string) => void
+    const pending = new Promise<string>((complete) => (resolve = complete))
+    const release = new AbortController()
+    const onRelease = vi.fn()
+    const router = createApplicationCommandRouter()
+    const scope = router.registrar.createScope()
+    scope.registerGroup(defineApplicationCommandGroup('read', [readValue] as const), {
+      'sample.read': ({ callerLease }) => {
+        callerLease.signal.addEventListener('abort', onRelease, { once: true })
+        return pending
+      }
+    })
+    const installation = scope.complete()
+
+    const result = router.dispatcher.invoke(
+      readValue,
+      invocation(['one'] as const, { callerLease: lease({ signal: release.signal }) })
+    )
+    installation.uninstall()
+    release.abort()
+    release.abort()
+    resolve('complete')
+
+    await expect(result).resolves.toBe('complete')
+    expect(onRelease).toHaveBeenCalledOnce()
+    await expect(router.dispatcher.invoke(readValue, invocation(['two'] as const))).rejects.toThrow(
+      'Unknown application command: sample.read'
+    )
+  })
+
+  it('keeps a replacement lease generation independent from a released signal', async () => {
+    const handler = vi.fn(() => 'value')
+    const previous = new AbortController()
+    const replacement = new AbortController()
+    const router = createApplicationCommandRouter()
+    const scope = router.registrar.createScope()
+    scope.registerGroup(defineApplicationCommandGroup('read', [readValue] as const), {
+      'sample.read': handler
+    })
+
+    await expect(
+      router.dispatcher.invoke(
+        readValue,
+        invocation(['one'] as const, {
+          callerLease: lease({ generation: 1, signal: previous.signal })
+        })
+      )
+    ).resolves.toBe('value')
+    previous.abort()
+    await expect(
+      router.dispatcher.invoke(
+        readValue,
+        invocation(['two'] as const, {
+          callerLease: lease({ generation: 2, signal: replacement.signal })
+        })
+      )
+    ).resolves.toBe('value')
+    expect(replacement.signal.aborted).toBe(false)
+    expect(handler).toHaveBeenCalledTimes(2)
+  })
+
+  it('disposes scopes in reverse order and aggregates cleanup failures', () => {
+    const order: string[] = []
+    const router = createApplicationCommandRouter()
+    const first = router.registrar.createScope()
+    first.registerGroup(defineApplicationCommandGroup('first', [readValue] as const), {
+      'sample.read': vi.fn()
+    })
+    first.complete(() => {
+      order.push('first')
+      throw new Error('first cleanup')
+    })
+    const second = router.registrar.createScope()
+    second.registerGroup(defineApplicationCommandGroup('second', [writeValue] as const), {
+      'sample.write': vi.fn()
+    })
+    second.complete(() => {
+      order.push('second')
+      throw new Error('second cleanup')
+    })
+
+    expect(() => router.dispose()).toThrow(
+      new AggregateError(
+        [expect.anything(), expect.anything()],
+        'Application command cleanup failed.'
+      )
+    )
+    expect(order).toEqual(['second', 'first'])
+    expect(() => router.dispose()).not.toThrow()
+    expect(() => router.registrar.createScope()).toThrow('Application command router is disposed.')
+  })
+
+  it('rejects settling a pre-created scope after router disposal', () => {
+    const cleanup = vi.fn()
+    const router = createApplicationCommandRouter()
+    const scope = router.registrar.createScope()
+
+    router.dispose()
+
+    expect(() => scope.complete(cleanup)).toThrow('Application command router is disposed.')
+    expect(() => scope.rollback()).toThrow('Application command router is disposed.')
+    expect(cleanup).not.toHaveBeenCalled()
+  })
+
+  it('reports privacy-safe rejection diagnostics without allowing diagnostics to mask errors', async () => {
+    const diagnostics: unknown[] = []
+    const onDiagnostic = vi.fn((diagnostic) => {
+      diagnostics.push(diagnostic)
+      throw new Error('diagnostic failed')
+    })
+    const privateError = new Error('private handler detail')
+    const router = createApplicationCommandRouter(onDiagnostic)
+    const scope = router.registrar.createScope()
+    scope.registerGroup(defineApplicationCommandGroup('read', [readValue] as const), {
+      'sample.read': () => Promise.reject(privateError)
+    })
+
+    await expect(router.dispatcher.invoke(readValue, invocation(['secret'] as const))).rejects.toBe(
+      privateError
+    )
+    expect(diagnostics).toEqual([{ code: 'handler-rejected', commandName: 'sample.read' }])
+    expect(JSON.stringify(diagnostics)).not.toContain('secret')
+    expect(JSON.stringify(diagnostics)).not.toContain('web-client')
+    expect(JSON.stringify(diagnostics)).not.toContain('lease-1')
+    expect(JSON.stringify(diagnostics)).not.toContain('private handler detail')
+  })
+})

--- a/src/main/application-command-router.ts
+++ b/src/main/application-command-router.ts
@@ -43,7 +43,7 @@ export type ApplicationCommandGroup<
   Commands extends readonly AnyApplicationCommand[]
 > = Readonly<{
   name: Name
-  commands: Commands
+  commands: Readonly<Commands>
 }>
 
 export type ApplicationCommandHandlers<Commands extends readonly AnyApplicationCommand[]> = {
@@ -134,7 +134,7 @@ export const defineApplicationCommandGroup = <
   name: Name,
   commands: Commands
 ): ApplicationCommandGroup<Name, Commands> =>
-  Object.freeze({ name, commands: Object.freeze([...commands]) as unknown as Commands })
+  Object.freeze({ name, commands: Object.freeze([...commands]) as unknown as Readonly<Commands> })
 
 export const createApplicationCommandRouter = (
   onDiagnostic?: (diagnostic: ApplicationCommandDiagnostic) => void
@@ -180,24 +180,32 @@ export const createApplicationCommandRouter = (
         if (disposed) throw new Error('Application command router is disposed.')
         if (state.settled) throw new Error('Application command registration scope is settled.')
 
+        const registrations: Array<
+          Readonly<{ command: AnyApplicationCommand; handler: RegisteredHandler }>
+        > = []
         const groupNames = new Set<string>()
         const runtimeHandlers = handlers as unknown as Readonly<Record<string, RegisteredHandler>>
         for (const command of group.commands) {
           if (groupNames.has(command.name) || commands.has(command.name)) {
             throw new Error(`Application command is already registered: ${command.name}`)
           }
-          if (typeof runtimeHandlers[command.name] !== 'function') {
+          if (!Object.hasOwn(runtimeHandlers, command.name)) {
+            throw new Error(`Application command handler is missing: ${command.name}`)
+          }
+          const handler = runtimeHandlers[command.name]
+          if (typeof handler !== 'function') {
             throw new Error(`Application command handler is missing: ${command.name}`)
           }
           groupNames.add(command.name)
+          registrations.push({ command, handler })
         }
 
-        for (const command of group.commands) {
+        for (const { command, handler } of registrations) {
           const registrationToken = Symbol(`${group.name}:${command.name}`)
           commands.set(command.name, {
             command,
             registrationToken,
-            handler: runtimeHandlers[command.name]
+            handler
           })
           state.registrations.push({ commandName: command.name, registrationToken })
         }

--- a/src/main/application-command-router.ts
+++ b/src/main/application-command-router.ts
@@ -1,0 +1,275 @@
+import type { CallerContext } from './caller-context'
+
+declare const applicationCommandTypes: unique symbol
+
+type Awaitable<Value> = Value | PromiseLike<Value>
+
+type AnyApplicationCommand = Readonly<{ name: string }>
+
+export type ApplicationCommand<
+  Name extends string,
+  Args extends readonly unknown[],
+  Result
+> = Readonly<{
+  name: Name
+  [applicationCommandTypes]?: Readonly<{ args: Args; result: Result }>
+}>
+
+type CommandArgs<Command> =
+  Command extends ApplicationCommand<string, infer Args, unknown> ? Args : never
+
+type CommandResult<Command> =
+  Command extends ApplicationCommand<string, readonly unknown[], infer Result> ? Result : never
+
+export type ApplicationCallerLease = Readonly<{
+  leaseId: string
+  generation: number
+  signal: AbortSignal
+  isCurrent: () => boolean
+}>
+
+export type ApplicationInvocation<Args extends readonly unknown[]> = Readonly<{
+  callerContext: CallerContext
+  callerLease: ApplicationCallerLease
+  args: Args
+}>
+
+export type ApplicationCommandHandler<Args extends readonly unknown[], Result> = (
+  invocation: ApplicationInvocation<Args>
+) => Awaitable<Result>
+
+export type ApplicationCommandGroup<
+  Name extends string,
+  Commands extends readonly AnyApplicationCommand[]
+> = Readonly<{
+  name: Name
+  commands: Commands
+}>
+
+export type ApplicationCommandHandlers<Commands extends readonly AnyApplicationCommand[]> = {
+  readonly [Command in Commands[number] as Command['name']]: Command extends ApplicationCommand<
+    string,
+    infer Args,
+    infer Result
+  >
+    ? ApplicationCommandHandler<Args, Result>
+    : never
+}
+
+export type ApplicationCommandInstallation = Readonly<{
+  uninstall: () => void
+}>
+
+export type ApplicationCommandRegistrationScope = Readonly<{
+  registerGroup: <Name extends string, Commands extends readonly AnyApplicationCommand[]>(
+    group: ApplicationCommandGroup<Name, Commands>,
+    handlers: ApplicationCommandHandlers<Commands>
+  ) => void
+  complete: (cleanup?: () => void) => ApplicationCommandInstallation
+  rollback: () => void
+}>
+
+export type ApplicationCommandRegistrar = Readonly<{
+  createScope: () => ApplicationCommandRegistrationScope
+}>
+
+export type ApplicationCommandDispatcher = Readonly<{
+  invoke: <Command extends AnyApplicationCommand>(
+    command: Command,
+    invocation: ApplicationInvocation<CommandArgs<Command>>
+  ) => Promise<CommandResult<Command>>
+  commandNames: () => readonly string[]
+}>
+
+export type ApplicationCommandDiagnosticCode =
+  | 'unknown-command'
+  | 'authorization-stale'
+  | 'lease-mismatch'
+  | 'lease-stale'
+  | 'handler-rejected'
+  | 'router-disposed'
+
+export type ApplicationCommandDiagnostic = Readonly<{
+  code: ApplicationCommandDiagnosticCode
+  commandName: string
+}>
+
+export type ApplicationCommandRouter = Readonly<{
+  registrar: ApplicationCommandRegistrar
+  dispatcher: ApplicationCommandDispatcher
+  dispose: () => void
+}>
+
+type RegisteredHandler = (
+  invocation: ApplicationInvocation<readonly unknown[]>
+) => Awaitable<unknown>
+
+type RegisteredCommand = Readonly<{
+  command: AnyApplicationCommand
+  registrationToken: symbol
+  handler: RegisteredHandler
+}>
+
+type ScopeState = {
+  registrations: Array<Readonly<{ commandName: string; registrationToken: symbol }>>
+  settled: boolean
+  active: boolean
+  cleanup?: () => void
+  cleanupCalled: boolean
+}
+
+export const defineApplicationCommand = <
+  const Name extends string,
+  Args extends readonly unknown[],
+  Result
+>(
+  name: Name
+): ApplicationCommand<Name, Args, Result> =>
+  Object.freeze({ name }) as ApplicationCommand<Name, Args, Result>
+
+export const defineApplicationCommandGroup = <
+  const Name extends string,
+  const Commands extends readonly AnyApplicationCommand[]
+>(
+  name: Name,
+  commands: Commands
+): ApplicationCommandGroup<Name, Commands> =>
+  Object.freeze({ name, commands: Object.freeze([...commands]) as unknown as Commands })
+
+export const createApplicationCommandRouter = (
+  onDiagnostic?: (diagnostic: ApplicationCommandDiagnostic) => void
+): ApplicationCommandRouter => {
+  const commands = new Map<string, RegisteredCommand>()
+  const scopes: ScopeState[] = []
+  let disposed = false
+
+  const report = (code: ApplicationCommandDiagnosticCode, commandName: string): void => {
+    try {
+      onDiagnostic?.(Object.freeze({ code, commandName }))
+    } catch {
+      // Diagnostics must never mask or replace the command result.
+    }
+  }
+
+  const removeScope = (state: ScopeState, runCleanup: boolean): void => {
+    if (!state.active) return
+    state.active = false
+    for (const registration of [...state.registrations].reverse()) {
+      const current = commands.get(registration.commandName)
+      if (current?.registrationToken === registration.registrationToken) {
+        commands.delete(registration.commandName)
+      }
+    }
+    if (!runCleanup || state.cleanupCalled || !state.cleanup) return
+    state.cleanupCalled = true
+    state.cleanup()
+  }
+
+  const createScope = (): ApplicationCommandRegistrationScope => {
+    if (disposed) throw new Error('Application command router is disposed.')
+    const state: ScopeState = {
+      registrations: [],
+      settled: false,
+      active: true,
+      cleanupCalled: false
+    }
+    scopes.push(state)
+
+    return Object.freeze({
+      registerGroup: (group, handlers): void => {
+        if (disposed) throw new Error('Application command router is disposed.')
+        if (state.settled) throw new Error('Application command registration scope is settled.')
+
+        const groupNames = new Set<string>()
+        const runtimeHandlers = handlers as unknown as Readonly<Record<string, RegisteredHandler>>
+        for (const command of group.commands) {
+          if (groupNames.has(command.name) || commands.has(command.name)) {
+            throw new Error(`Application command is already registered: ${command.name}`)
+          }
+          if (typeof runtimeHandlers[command.name] !== 'function') {
+            throw new Error(`Application command handler is missing: ${command.name}`)
+          }
+          groupNames.add(command.name)
+        }
+
+        for (const command of group.commands) {
+          const registrationToken = Symbol(`${group.name}:${command.name}`)
+          commands.set(command.name, {
+            command,
+            registrationToken,
+            handler: runtimeHandlers[command.name]
+          })
+          state.registrations.push({ commandName: command.name, registrationToken })
+        }
+      },
+      complete: (cleanup): ApplicationCommandInstallation => {
+        if (disposed) throw new Error('Application command router is disposed.')
+        if (state.settled) throw new Error('Application command registration scope is settled.')
+        state.settled = true
+        state.cleanup = cleanup
+        return Object.freeze({ uninstall: () => removeScope(state, true) })
+      },
+      rollback: (): void => {
+        if (disposed) throw new Error('Application command router is disposed.')
+        if (state.settled) return
+        state.settled = true
+        removeScope(state, false)
+      }
+    })
+  }
+
+  const invoke: ApplicationCommandDispatcher['invoke'] = async (command, invocation) => {
+    if (disposed) {
+      report('router-disposed', command.name)
+      throw new Error('Application command router is disposed.')
+    }
+    const registered = commands.get(command.name)
+    if (!registered || registered.command !== command) {
+      report('unknown-command', command.name)
+      throw new Error(`Unknown application command: ${command.name}`)
+    }
+    if (!invocation.callerContext.isAuthorizationCurrent()) {
+      report('authorization-stale', command.name)
+      throw new Error('Caller authorization is no longer current.')
+    }
+    if (invocation.callerLease.leaseId !== invocation.callerContext.leaseId) {
+      report('lease-mismatch', command.name)
+      throw new Error('Caller lease does not match caller context.')
+    }
+    if (invocation.callerLease.signal.aborted || !invocation.callerLease.isCurrent()) {
+      report('lease-stale', command.name)
+      throw new Error('Caller lease is no longer current.')
+    }
+
+    try {
+      return (await registered.handler(invocation)) as CommandResult<typeof command>
+    } catch (error) {
+      report('handler-rejected', command.name)
+      throw error
+    }
+  }
+
+  return Object.freeze({
+    registrar: Object.freeze({ createScope }),
+    dispatcher: Object.freeze({
+      invoke,
+      commandNames: (): readonly string[] => [...commands.keys()].sort()
+    }),
+    dispose: (): void => {
+      if (disposed) return
+      disposed = true
+      const failures: unknown[] = []
+      for (const state of [...scopes].reverse()) {
+        try {
+          removeScope(state, state.settled)
+        } catch (error) {
+          failures.push(error)
+        }
+      }
+      commands.clear()
+      if (failures.length > 0) {
+        throw new AggregateError(failures, 'Application command cleanup failed.')
+      }
+    }
+  })
+}


### PR DESCRIPTION
# T2a pull request

Title: `refactor(main): add application command router`

## Problem

Web and internal callers still depend on captured Electron IPC handlers. Before capability groups can
move away from that fallback, the main process needs a typed, transport-neutral command seam with
explicit caller authority and lifecycle ownership. A name-only dispatcher would be unsound because
another module could manufacture a command descriptor with the same name but incompatible argument
and result types.

## Proposed change

- Add immutable typed command and command-group descriptors, validating descriptor identity at
  dispatch as well as the command name.
- Separate registration from dispatch and support atomic group registration, isolated late scopes,
  rollback, uninstall, and deterministic reverse-order disposal.
- Require every invocation to carry an explicit `CallerContext` and a surface-owned caller lease.
  Reject stale authorization, mismatched ownership, released signals, and stale generations before
  entering a handler.
- Give handlers a read-only `AbortSignal` so lifecycle-owned resources can observe disconnect without
  receiving the power to release or replace the caller lease.
- Emit only privacy-safe rejection diagnostics (`code` and `commandName`).

```mermaid
flowchart LR
  E["Electron adapter"] --> D["Application command dispatcher"]
  W["Web adapter - future T2h"] --> D
  T["Task / CLI narrow ports"] -. "declared groups only" .-> D
  R["Capability registrars"] --> C["Scoped command registry"]
  C --> D
  D --> A["CallerContext freshness"]
  D --> L["Caller lease identity + signal"]
  D --> H["Typed application handler"]
```

## Architecture and compatibility impact

- Internal architecture changes: yes. This introduces the direct application-command ownership seam
  and a read-only lifecycle release signal.
- Persisted data model or data relationships: no change.
- Public Electron, Web, Task, SDK, CLI/local-RPC contracts: no change; this PR switches no call path.
- User interaction or surface capability availability: no change. Specialist, Permission, and Compute
  retain their current Electron/Web/CLI asymmetry.
- Issue #458 orchestration: no methods, state, vocabulary, or public adapter is introduced. Future MCP
  callers may receive only explicitly declared command groups through a separate adapter.
- Captured IPC remains the unchanged fallback until T2h/T2i.

## Acceptance criteria and validation

- Typed registration, late dispatch, and atomic duplicate/missing-handler rejection -> focused router
  suite -> passed.
- Descriptor identity rejects a same-name command with incompatible phantom types -> focused router
  suite -> passed.
- Authorization, lease-ID, release-signal, and generation freshness fail closed before handler entry ->
  focused router suite -> passed.
- An in-flight handler observes release once while allowed to finish; a replacement generation with
  the same lease ID remains isolated from the old signal -> focused router suite -> passed.
- Rollback/uninstall isolation, reverse disposal, aggregate cleanup failure, and dispose-after-scope
  settlement -> focused router suite -> passed.
- Privacy-safe diagnostics do not expose arguments, client IDs, lease IDs, authority, or private
  errors and cannot mask the original result -> focused router suite -> passed.
- `src/main/application-command-router.test.ts`: 1 file / 12 tests passed.
- `npm run typecheck:node`: passed.
- Targeted ESLint and Prettier check over both added files: passed.
- `git diff --check`: passed.
- Independent Spec and Standards reviews: 0 remaining actionable findings.
- Full and cross-platform suites are intentionally delegated to online CI.

## Review focus

- Dispatch must require the exact registered descriptor identity, not only its string name.
- Unknown-command rejection must happen before caller freshness checks.
- The router validates caller and lease freshness but does not infer human/local authority or own
  release; authorization policy remains in capability/application handlers.
- Scope cleanup belongs only to its registrations and remains deterministic across rollback,
  uninstall, and router disposal.
- Production churn is 283 lines, below the 500-line hard limit, and only the foundation module plus
  its tests are added.

## Uncovered risk

No production call path consumes the router yet, so adapter integration and real lifecycle owners are
not exercised in this PR. T2b adds caller lifecycle ownership; T2c–T2g add bounded command groups;
T2h/T2i perform and certify the transport cutover.
