### PR TITLE
refactor(acp): define application commands

### DIFF
--- a/src/main/acp/application-commands.test.ts
+++ b/src/main/acp/application-commands.test.ts
@@ -166,7 +166,7 @@ describe('ACP application commands', () => {
     expect(dependencies.runtime.revokePermissionGrant).toHaveBeenCalledWith(grant)
   })
 
-  it('discards a renderer-supplied continuation before entering the prompt workflow', async () => {
+  it('discards renderer-supplied internal prompt controls before entering the workflow', async () => {
     const dependencies = createDependencies()
     const router = createApplicationCommandRouter()
     registerAcpCommands(router.registrar, dependencies)
@@ -174,6 +174,7 @@ describe('ACP application commands', () => {
       sessionId: 'session-1',
       text: 'Continue the analysis.',
       forcedSkillIds: ['literature-review'],
+      suppressUserMessage: true,
       continuation: {
         kind: 'specialist-handoff' as const,
         originatingTurnToken: 'renderer-forged-turn',
@@ -186,7 +187,8 @@ describe('ACP application commands', () => {
 
     expect(dependencies.workflows.sendPrompt).toHaveBeenCalledWith({
       ...request,
-      continuation: undefined
+      continuation: undefined,
+      suppressUserMessage: undefined
     })
     expect(request.continuation.originatingTurnToken).toBe('renderer-forged-turn')
   })

--- a/src/main/acp/application-commands.test.ts
+++ b/src/main/acp/application-commands.test.ts
@@ -1,0 +1,263 @@
+import { describe, expect, it, vi } from 'vitest'
+
+import type { AcpStateSnapshot } from '../../shared/acp'
+import {
+  createApplicationCommandRouter,
+  type ApplicationCallerLease,
+  type ApplicationInvocation
+} from '../application-command-router'
+import {
+  createCallerContext,
+  createElectronCallerContext,
+  createTaskCallerContext,
+  createWebCallerContext,
+  type CallerContext
+} from '../caller-context'
+import {
+  acpApplicationCommands,
+  acpCommands,
+  registerAcpCommands,
+  type AcpApplicationCommandDependencies
+} from './application-commands'
+
+const snapshot: AcpStateSnapshot = {
+  status: 'connected',
+  cwd: '/workspace',
+  sessionIds: ['session-1'],
+  events: [],
+  pendingPermissions: [],
+  permissionProfiles: {},
+  permissionGrants: {},
+  contextUsageBySession: {},
+  promptInFlight: false,
+  promptInFlightSessionIds: []
+}
+
+const sessionResponse = {
+  sessionId: 'session-1',
+  cwd: '/workspace',
+  frameworkId: 'codex' as const,
+  backendId: 'codex:shared'
+}
+
+const createDependencies = (): AcpApplicationCommandDependencies => ({
+  runtime: {
+    getSnapshot: vi.fn(() => snapshot),
+    connect: vi.fn(async () => snapshot),
+    disconnect: vi.fn(async () => snapshot),
+    resetSessionContext: vi.fn(async () => ({ ...sessionResponse, contextReset: true })),
+    compactSession: vi.fn(async () => snapshot),
+    cancelPrompt: vi.fn(async () => snapshot),
+    deleteSession: vi.fn(async () => snapshot),
+    respondToPermission: vi.fn(async () => snapshot),
+    setPermissionProfile: vi.fn(async () => snapshot),
+    revokePermissionGrant: vi.fn(async () => snapshot)
+  },
+  workflows: {
+    createSession: vi.fn(async () => sessionResponse),
+    resumeSession: vi.fn(async () => sessionResponse),
+    sendPrompt: vi.fn(async () => snapshot)
+  }
+})
+
+const invocation = <Args extends readonly unknown[]>(
+  args: Args,
+  callerContext: CallerContext = createElectronCallerContext(7)
+): ApplicationInvocation<Args> => {
+  const callerLease: ApplicationCallerLease = Object.freeze({
+    leaseId: callerContext.leaseId,
+    generation: 1,
+    signal: new AbortController().signal,
+    isCurrent: () => true
+  })
+  return Object.freeze({ args, callerContext, callerLease })
+}
+
+describe('ACP application commands', () => {
+  it('registers the exact renderer command inventory as one installable group', () => {
+    const router = createApplicationCommandRouter()
+
+    const installation = registerAcpCommands(router.registrar, createDependencies())
+
+    expect(acpApplicationCommands.commands.map(({ name }) => name).sort()).toEqual([
+      'acp:cancel',
+      'acp:compact-session',
+      'acp:connect',
+      'acp:create-session',
+      'acp:delete-session',
+      'acp:disconnect',
+      'acp:get-state',
+      'acp:reset-session-context',
+      'acp:respond-permission',
+      'acp:resume-session',
+      'acp:revoke-permission-grant',
+      'acp:send-prompt',
+      'acp:set-permission-profile'
+    ])
+    expect(router.dispatcher.commandNames()).toEqual(
+      acpApplicationCommands.commands.map(({ name }) => name).sort()
+    )
+
+    installation.uninstall()
+    expect(router.dispatcher.commandNames()).toEqual([])
+  })
+
+  it('delegates canonical argument tuples through the existing ACP owners', async () => {
+    const dependencies = createDependencies()
+    const router = createApplicationCommandRouter()
+    registerAcpCommands(router.registrar, dependencies)
+    const connect = { cwd: '/workspace' }
+    const createSession = { projectName: 'project-1', permissionProfile: 'ask' as const }
+    const resumeSession = { sessionId: 'session-1', cwd: '/workspace' }
+    const compactSession = { sessionId: 'session-1', reason: 'manual' as const }
+    const cancel = { sessionId: 'session-1' }
+    const deleteSession = { sessionId: 'session-2' }
+    const permission = { requestId: 'permission-1', optionId: 'allow-once' }
+    const profile = { sessionId: 'session-1', profile: 'auto' as const }
+    const grant = { sessionId: 'session-1', categoryKey: 'mcp:literature/search' }
+
+    await expect(router.dispatcher.invoke(acpCommands.getState, invocation([]))).resolves.toBe(
+      snapshot
+    )
+    await expect(
+      router.dispatcher.invoke(acpCommands.connect, invocation([connect]))
+    ).resolves.toBe(snapshot)
+    await expect(router.dispatcher.invoke(acpCommands.disconnect, invocation([]))).resolves.toBe(
+      snapshot
+    )
+    await expect(
+      router.dispatcher.invoke(acpCommands.createSession, invocation([createSession]))
+    ).resolves.toBe(sessionResponse)
+    await expect(
+      router.dispatcher.invoke(acpCommands.resumeSession, invocation([resumeSession]))
+    ).resolves.toBe(sessionResponse)
+    await expect(
+      router.dispatcher.invoke(acpCommands.resetSessionContext, invocation([resumeSession]))
+    ).resolves.toMatchObject({ sessionId: 'session-1', contextReset: true })
+    await expect(
+      router.dispatcher.invoke(acpCommands.compactSession, invocation([compactSession]))
+    ).resolves.toBe(snapshot)
+    await expect(router.dispatcher.invoke(acpCommands.cancel, invocation([cancel]))).resolves.toBe(
+      snapshot
+    )
+    await expect(
+      router.dispatcher.invoke(acpCommands.deleteSession, invocation([deleteSession]))
+    ).resolves.toBe(snapshot)
+    await expect(
+      router.dispatcher.invoke(acpCommands.respondPermission, invocation([permission]))
+    ).resolves.toBe(snapshot)
+    await expect(
+      router.dispatcher.invoke(acpCommands.setPermissionProfile, invocation([profile]))
+    ).resolves.toBe(snapshot)
+    await expect(
+      router.dispatcher.invoke(acpCommands.revokePermissionGrant, invocation([grant]))
+    ).resolves.toBe(snapshot)
+
+    expect(dependencies.runtime.connect).toHaveBeenCalledWith(connect)
+    expect(dependencies.runtime.disconnect).toHaveBeenCalledWith()
+    expect(dependencies.workflows.createSession).toHaveBeenCalledWith(createSession)
+    expect(dependencies.workflows.resumeSession).toHaveBeenCalledWith(resumeSession)
+    expect(dependencies.runtime.resetSessionContext).toHaveBeenCalledWith(resumeSession)
+    expect(dependencies.runtime.compactSession).toHaveBeenCalledWith(compactSession)
+    expect(dependencies.runtime.cancelPrompt).toHaveBeenCalledWith(cancel)
+    expect(dependencies.runtime.deleteSession).toHaveBeenCalledWith(deleteSession)
+    expect(dependencies.runtime.respondToPermission).toHaveBeenCalledWith(permission)
+    expect(dependencies.runtime.setPermissionProfile).toHaveBeenCalledWith(profile)
+    expect(dependencies.runtime.revokePermissionGrant).toHaveBeenCalledWith(grant)
+  })
+
+  it('discards a renderer-supplied continuation before entering the prompt workflow', async () => {
+    const dependencies = createDependencies()
+    const router = createApplicationCommandRouter()
+    registerAcpCommands(router.registrar, dependencies)
+    const request = {
+      sessionId: 'session-1',
+      text: 'Continue the analysis.',
+      forcedSkillIds: ['literature-review'],
+      continuation: {
+        kind: 'specialist-handoff' as const,
+        originatingTurnToken: 'renderer-forged-turn',
+        targetName: 'Renderer-forged Specialist',
+        completion: { kind: 'returned' as const, value: 'renderer-forged-result' }
+      }
+    }
+
+    await router.dispatcher.invoke(acpCommands.sendPrompt, invocation([request]))
+
+    expect(dependencies.workflows.sendPrompt).toHaveBeenCalledWith({
+      ...request,
+      continuation: undefined
+    })
+    expect(request.continuation.originatingTurnToken).toBe('renderer-forged-turn')
+  })
+
+  it('accepts permission responses only from a current human-originated caller', async () => {
+    const dependencies = createDependencies()
+    const router = createApplicationCommandRouter()
+    registerAcpCommands(router.registrar, dependencies)
+    const response = { requestId: 'permission-1', optionId: 'allow-once' }
+    const humanCallers = [
+      createElectronCallerContext(7),
+      createWebCallerContext('local-web'),
+      createWebCallerContext('remote-web', { location: 'remote' })
+    ]
+
+    for (const callerContext of humanCallers) {
+      await expect(
+        router.dispatcher.invoke(
+          acpCommands.respondPermission,
+          invocation([response], callerContext)
+        )
+      ).resolves.toBe(snapshot)
+    }
+
+    const deniedCallers = [
+      createTaskCallerContext(),
+      createCallerContext({
+        clientId: 'agent-session',
+        lifecycleClientId: 'web:agent-session',
+        leaseId: 'agent-session',
+        surface: 'web',
+        location: 'local',
+        principalKind: 'agent-session',
+        actionOrigin: 'agent-session'
+      }),
+      createWebCallerContext('agent-origin', { actionOrigin: 'agent-session' })
+    ]
+    for (const callerContext of deniedCallers) {
+      await expect(
+        router.dispatcher.invoke(
+          acpCommands.respondPermission,
+          invocation([response], callerContext)
+        )
+      ).rejects.toThrow('Only a current human caller can respond to permission requests.')
+    }
+    await expect(
+      router.dispatcher.invoke(
+        acpCommands.respondPermission,
+        invocation(
+          [response],
+          createWebCallerContext('stale', { isAuthorizationCurrent: () => false })
+        )
+      )
+    ).rejects.toThrow('Caller authorization is no longer current.')
+
+    expect(dependencies.runtime.respondToPermission).toHaveBeenCalledTimes(humanCallers.length)
+  })
+
+  it('keeps permission-profile changes on their separate current policy', async () => {
+    const dependencies = createDependencies()
+    const router = createApplicationCommandRouter()
+    registerAcpCommands(router.registrar, dependencies)
+    const request = { sessionId: 'session-1', profile: 'full' as const }
+
+    await expect(
+      router.dispatcher.invoke(
+        acpCommands.setPermissionProfile,
+        invocation([request], createTaskCallerContext())
+      )
+    ).resolves.toBe(snapshot)
+
+    expect(dependencies.runtime.setPermissionProfile).toHaveBeenCalledWith(request)
+  })
+})

--- a/src/main/acp/application-commands.ts
+++ b/src/main/acp/application-commands.ts
@@ -140,7 +140,11 @@ const registerAcpCommands = (
       'acp:compact-session': (invocation) =>
         dependencies.runtime.compactSession(invocation.args[0]),
       'acp:send-prompt': (invocation) =>
-        dependencies.workflows.sendPrompt({ ...invocation.args[0], continuation: undefined }),
+        dependencies.workflows.sendPrompt({
+          ...invocation.args[0],
+          continuation: undefined,
+          suppressUserMessage: undefined
+        }),
       'acp:cancel': (invocation) => dependencies.runtime.cancelPrompt(invocation.args[0]),
       'acp:delete-session': (invocation) => dependencies.runtime.deleteSession(invocation.args[0]),
       'acp:respond-permission': (invocation) => {

--- a/src/main/acp/application-commands.ts
+++ b/src/main/acp/application-commands.ts
@@ -1,0 +1,165 @@
+import type {
+  AcpCancelPromptRequest,
+  AcpCompactSessionRequest,
+  AcpConnectRequest,
+  AcpCreateSessionRequest,
+  AcpCreateSessionResponse,
+  AcpDeleteSessionRequest,
+  AcpPermissionResponse,
+  AcpPromptRequest,
+  AcpResumeSessionRequest,
+  AcpRevokePermissionGrantRequest,
+  AcpSetPermissionProfileRequest,
+  AcpStateSnapshot
+} from '../../shared/acp'
+import {
+  defineApplicationCommand,
+  defineApplicationCommandGroup,
+  type ApplicationCommandInstallation,
+  type ApplicationCommandRegistrar
+} from '../application-command-router'
+import { canSatisfyHumanApproval } from '../caller-context'
+import type { AcpHandlerWorkflows } from './handler-workflows'
+import type { AcpRuntimeCoordinator } from './runtime-coordinator'
+
+const acpCommands = Object.freeze({
+  getState: defineApplicationCommand<'acp:get-state', readonly [], AcpStateSnapshot>(
+    'acp:get-state'
+  ),
+  connect: defineApplicationCommand<
+    'acp:connect',
+    readonly [request: AcpConnectRequest],
+    AcpStateSnapshot
+  >('acp:connect'),
+  disconnect: defineApplicationCommand<'acp:disconnect', readonly [], AcpStateSnapshot>(
+    'acp:disconnect'
+  ),
+  createSession: defineApplicationCommand<
+    'acp:create-session',
+    readonly [request: AcpCreateSessionRequest],
+    AcpCreateSessionResponse
+  >('acp:create-session'),
+  resumeSession: defineApplicationCommand<
+    'acp:resume-session',
+    readonly [request: AcpResumeSessionRequest],
+    AcpCreateSessionResponse
+  >('acp:resume-session'),
+  resetSessionContext: defineApplicationCommand<
+    'acp:reset-session-context',
+    readonly [request: AcpResumeSessionRequest],
+    AcpCreateSessionResponse
+  >('acp:reset-session-context'),
+  compactSession: defineApplicationCommand<
+    'acp:compact-session',
+    readonly [request: AcpCompactSessionRequest],
+    AcpStateSnapshot
+  >('acp:compact-session'),
+  sendPrompt: defineApplicationCommand<
+    'acp:send-prompt',
+    readonly [request: AcpPromptRequest],
+    AcpStateSnapshot
+  >('acp:send-prompt'),
+  cancel: defineApplicationCommand<
+    'acp:cancel',
+    readonly [request: AcpCancelPromptRequest],
+    AcpStateSnapshot
+  >('acp:cancel'),
+  deleteSession: defineApplicationCommand<
+    'acp:delete-session',
+    readonly [request: AcpDeleteSessionRequest],
+    AcpStateSnapshot
+  >('acp:delete-session'),
+  respondPermission: defineApplicationCommand<
+    'acp:respond-permission',
+    readonly [response: AcpPermissionResponse],
+    AcpStateSnapshot
+  >('acp:respond-permission'),
+  setPermissionProfile: defineApplicationCommand<
+    'acp:set-permission-profile',
+    readonly [request: AcpSetPermissionProfileRequest],
+    AcpStateSnapshot
+  >('acp:set-permission-profile'),
+  revokePermissionGrant: defineApplicationCommand<
+    'acp:revoke-permission-grant',
+    readonly [request: AcpRevokePermissionGrantRequest],
+    AcpStateSnapshot
+  >('acp:revoke-permission-grant')
+})
+
+const acpApplicationCommands = defineApplicationCommandGroup('acp', [
+  acpCommands.getState,
+  acpCommands.connect,
+  acpCommands.disconnect,
+  acpCommands.createSession,
+  acpCommands.resumeSession,
+  acpCommands.resetSessionContext,
+  acpCommands.compactSession,
+  acpCommands.sendPrompt,
+  acpCommands.cancel,
+  acpCommands.deleteSession,
+  acpCommands.respondPermission,
+  acpCommands.setPermissionProfile,
+  acpCommands.revokePermissionGrant
+] as const)
+
+type AcpApplicationCommandRuntime = Pick<
+  AcpRuntimeCoordinator,
+  | 'getSnapshot'
+  | 'connect'
+  | 'disconnect'
+  | 'resetSessionContext'
+  | 'compactSession'
+  | 'cancelPrompt'
+  | 'deleteSession'
+  | 'respondToPermission'
+  | 'setPermissionProfile'
+  | 'revokePermissionGrant'
+>
+
+type AcpApplicationCommandDependencies = Readonly<{
+  runtime: AcpApplicationCommandRuntime
+  workflows: AcpHandlerWorkflows
+}>
+
+const registerAcpCommands = (
+  registrar: ApplicationCommandRegistrar,
+  dependencies: AcpApplicationCommandDependencies
+): ApplicationCommandInstallation => {
+  const scope = registrar.createScope()
+  try {
+    scope.registerGroup(acpApplicationCommands, {
+      'acp:get-state': () => dependencies.runtime.getSnapshot(),
+      'acp:connect': (invocation) => dependencies.runtime.connect(invocation.args[0]),
+      'acp:disconnect': () => dependencies.runtime.disconnect(),
+      'acp:create-session': (invocation) =>
+        dependencies.workflows.createSession(invocation.args[0]),
+      'acp:resume-session': (invocation) =>
+        dependencies.workflows.resumeSession(invocation.args[0]),
+      'acp:reset-session-context': (invocation) =>
+        dependencies.runtime.resetSessionContext(invocation.args[0]),
+      'acp:compact-session': (invocation) =>
+        dependencies.runtime.compactSession(invocation.args[0]),
+      'acp:send-prompt': (invocation) =>
+        dependencies.workflows.sendPrompt({ ...invocation.args[0], continuation: undefined }),
+      'acp:cancel': (invocation) => dependencies.runtime.cancelPrompt(invocation.args[0]),
+      'acp:delete-session': (invocation) => dependencies.runtime.deleteSession(invocation.args[0]),
+      'acp:respond-permission': (invocation) => {
+        if (!canSatisfyHumanApproval(invocation.callerContext)) {
+          throw new Error('Only a current human caller can respond to permission requests.')
+        }
+        return dependencies.runtime.respondToPermission(invocation.args[0])
+      },
+      'acp:set-permission-profile': (invocation) =>
+        dependencies.runtime.setPermissionProfile(invocation.args[0]),
+      'acp:revoke-permission-grant': (invocation) =>
+        dependencies.runtime.revokePermissionGrant(invocation.args[0])
+    })
+    return scope.complete()
+  } catch (error) {
+    scope.rollback()
+    throw error
+  }
+}
+
+export { acpApplicationCommands, acpCommands, registerAcpCommands }
+export type { AcpApplicationCommandDependencies, AcpApplicationCommandRuntime }


### PR DESCRIPTION
# T2c1 pull request

Title: `refactor(acp): define application commands`

## Problem

ACP behavior is still reached through transport-owned handlers. The application-command router now
exists, but ACP needs a bounded, typed capability group before composition and transport cutover can
stop depending on captured Electron IPC handlers.

## Proposed change

- Define the exact 13-command ACP application group with canonical request and result types.
- Add an owner-local registrar over the existing ACP handler, create-session, and runtime-coordinator
  workflows; this PR installs no production call path.
- Strip renderer-supplied application-only prompt `continuation` and `suppressUserMessage` before
  workflow delegation.
- Require a current Electron/Web human caller for permission responses while preserving the separate
  permission-profile policy and Task's existing narrow port.

```mermaid
flowchart LR
  C["Future transport codec"] --> G["ACP command group - 13 commands"]
  G --> H["Existing ACP handler workflows"]
  G --> S["Create-session workflow"]
  G --> R["Narrow runtime coordinator"]
  T["Task agent port"] -. "unchanged narrow path" .-> R
```

## Scope and non-goals

- Delivery boundary: this is intentionally a compile-time preparatory module PR. Production
  installation is not an acceptance criterion. T2h0 composes every bounded capability group in one
  atomic router and certifies the complete command inventory; T2h1 then cuts over adapters. Wiring
  only ACP here would create temporary dual ownership and bypass that collision/lifecycle gate.
- Internal architecture changes: yes; this adds a typed owner-local command boundary.
- Persisted data model, relationships, and migrations: no change.
- User interaction and Electron/Web/Task/CLI/local-RPC contracts: no change; no adapter or composition
  is switched in this PR.
- Specialist, Permission, and Compute surface asymmetry remains unchanged.
- Provider Session adoption, context reset, transcript replay, cleanup, prompt association, Permission
  event ordering, and Codex non-UUID adoption remain owned by existing workflows.
- Issue #458 orchestration vocabulary, state, and public interfaces are not introduced.

## Acceptance criteria and validation

The checks below ran after the last material edit.

- Exact 13-command inventory and typed owner delegation -> focused application-command tests ->
  passed.
- Application-only prompt continuation and user-message suppression cannot cross the ACP command
  boundary -> focused application-command tests -> passed.
- Permission responses allow only current human Electron/Web callers and fail closed for Task,
  automation, agent-session, and stale callers -> focused application-command tests -> passed.
- Existing ACP IPC, create-session, Task port, coordinator, adoption, and Permission behavior remains
  green -> focused ACP regression suites -> passed.
- Five related test files / 98 tests -> passed.
- `npm run typecheck:node` -> passed.
- Targeted ESLint and Prettier checks -> passed.
- `git diff --check` -> passed.
- Independent Spec and Standards review -> 0 actionable findings.
- Full and cross-platform suites are intentionally delegated to online CI.

## Review focus

- The command group must remain an owner-local definition; this PR must not edit IPC, Web, Task,
  CLI, local-RPC, or global composition.
- `send-prompt` must clear caller-supplied continuation and user-message suppression before entering
  existing workflows.
- The human-approval guard applies only to `respond-permission`; permission-profile changes retain
  their current policy.
- Production churn is 169 lines and the group contains exactly 13 commands.

## Uncovered risk

No real transport consumes this command group yet, so global descriptor collisions, real dependency
composition, and adapter codecs are not exercised here. T2h0 owns composition certification and T2h1
owns Web/Task transport cutover. The absence of production routing here is the explicit
staged-delivery boundary, not a claim that the new guards already protect live IPC calls.
