### PR TITLE
refactor(runtime): define application commands

### DIFF
--- a/src/main/notebook/runtime-application-commands.test.ts
+++ b/src/main/notebook/runtime-application-commands.test.ts
@@ -1,0 +1,256 @@
+import { describe, expect, it, vi } from 'vitest'
+
+import type { NotebookLanguage } from '../../shared/notebook'
+import type {
+  RuntimeReadiness,
+  RuntimeSelection,
+  RuntimeSurvey
+} from '../../shared/notebook-runtime'
+import { RENDERER_CONTRACT_GROUPS } from '../../shared/renderer-contract-catalog'
+import {
+  createApplicationCommandRouter,
+  type ApplicationCallerLease,
+  type ApplicationCommandInstallation,
+  type ApplicationCommandRouter,
+  type ApplicationInvocation
+} from '../application-command-router'
+import { createWebCallerContext, type CallerContext } from '../caller-context'
+import type { RuntimeSelectionWorkflows } from './runtime-selection-workflows'
+import {
+  registerRuntimeApplicationCommands,
+  runtimeApplicationCommandGroup,
+  runtimeApplicationCommands
+} from './runtime-application-commands'
+
+const caller = (location: CallerContext['location'] = 'local'): CallerContext =>
+  createWebCallerContext('runtime-client', { location })
+
+const lease = (): ApplicationCallerLease =>
+  Object.freeze({
+    leaseId: 'runtime-client',
+    generation: 1,
+    signal: new AbortController().signal,
+    isCurrent: () => true
+  })
+
+const invocation = <Args extends readonly unknown[]>(
+  args: Args,
+  location: CallerContext['location'] = 'local'
+): ApplicationInvocation<Args> =>
+  Object.freeze({ callerContext: caller(location), callerLease: lease(), args })
+
+const readiness = (language: NotebookLanguage): RuntimeReadiness => ({
+  language,
+  source: 'managed',
+  detected: true,
+  selected: true,
+  runnable: true,
+  packageMutable: true
+})
+
+const survey: RuntimeSurvey = {
+  language: 'python',
+  selection: { source: 'managed' },
+  managed: readiness('python'),
+  external: { ...readiness('python'), source: 'external' }
+}
+
+const createWorkflows = (): RuntimeSelectionWorkflows => ({
+  survey: vi.fn(async () => [survey]),
+  listEnvironments: vi.fn(async () => ({ python: [], r: [] })),
+  listPackages: vi.fn(async () => [{ name: 'numpy', version: '2.1.3' }]),
+  listPackageCounts: vi.fn(async () => ({ managed: 1 })),
+  setSelection: vi.fn(async () => survey),
+  getEnablement: vi.fn(async () => ({ enabled: {}, installAuthorized: {} })),
+  describeUsage: vi.fn(async () => ({ running: 1, idle: 2, dormant: 3 })),
+  setEnvironmentEnabled: vi.fn(async () => ({
+    enabled: { managed: false },
+    installAuthorized: {}
+  })),
+  setInstallAuthorized: vi.fn(async () => ({
+    enabled: {},
+    installAuthorized: { managed: true }
+  })),
+  register: vi.fn(async () => ['/opt/python']),
+  unregister: vi.fn(async () => [])
+})
+
+const install = (
+  workflows = createWorkflows(),
+  pickInterpreter = vi.fn(async (): Promise<string | null> => '/opt/python')
+): Readonly<{
+  installation: ApplicationCommandInstallation
+  pickInterpreter: () => Promise<string | null>
+  router: ApplicationCommandRouter
+  workflows: RuntimeSelectionWorkflows
+}> => {
+  const router = createApplicationCommandRouter()
+  const installation = registerRuntimeApplicationCommands(router.registrar, {
+    workflows,
+    pickInterpreter
+  })
+  return { installation, pickInterpreter, router, workflows }
+}
+
+describe('runtime application commands', () => {
+  it('installs the exact 12-command group and dispatches a remote-safe survey', async () => {
+    const { router, workflows } = install()
+    const runtimeChannels = RENDERER_CONTRACT_GROUPS.find(
+      (group) => group.capability === 'runtime'
+    )?.contracts.map((contract) => contract.channel)
+
+    expect(runtimeChannels).toHaveLength(12)
+    expect(runtimeApplicationCommandGroup.commands.map((command) => command.name)).toEqual(
+      runtimeChannels
+    )
+    await expect(
+      router.dispatcher.invoke(runtimeApplicationCommands.survey, invocation([] as const, 'remote'))
+    ).resolves.toEqual([survey])
+    expect(workflows.survey).toHaveBeenCalledOnce()
+  })
+
+  it('passes canonical request objects to the runtime workflows', async () => {
+    const { router, workflows } = install()
+    const selection: RuntimeSelection = { source: 'managed' }
+
+    await router.dispatcher.invoke(
+      runtimeApplicationCommands.listEnvironments,
+      invocation([] as const)
+    )
+    await router.dispatcher.invoke(
+      runtimeApplicationCommands.listPackages,
+      invocation([{ language: 'python', envId: 'managed' }] as const)
+    )
+    await router.dispatcher.invoke(
+      runtimeApplicationCommands.listPackageCounts,
+      invocation([{ language: 'python' }] as const)
+    )
+    await router.dispatcher.invoke(
+      runtimeApplicationCommands.setSelection,
+      invocation([{ language: 'python', selection }] as const)
+    )
+    await router.dispatcher.invoke(
+      runtimeApplicationCommands.getEnablement,
+      invocation([{ language: 'python' }] as const)
+    )
+    await router.dispatcher.invoke(
+      runtimeApplicationCommands.describeUsage,
+      invocation([{ language: 'python', envId: 'managed' }] as const)
+    )
+    await router.dispatcher.invoke(
+      runtimeApplicationCommands.setEnvironmentEnabled,
+      invocation([{ language: 'python', envId: 'managed', enabled: false, force: true }] as const)
+    )
+    await router.dispatcher.invoke(
+      runtimeApplicationCommands.setInstallAuthorized,
+      invocation([{ language: 'python', envId: 'managed', authorized: true }] as const)
+    )
+    await router.dispatcher.invoke(
+      runtimeApplicationCommands.registerInterpreter,
+      invocation([{ language: 'python', path: '/opt/python' }] as const)
+    )
+    await router.dispatcher.invoke(
+      runtimeApplicationCommands.unregisterInterpreter,
+      invocation([{ language: 'python', path: '/opt/python' }] as const)
+    )
+
+    expect(workflows.listEnvironments).toHaveBeenCalledWith()
+    expect(workflows.listPackages).toHaveBeenCalledWith({ language: 'python', envId: 'managed' })
+    expect(workflows.listPackageCounts).toHaveBeenCalledWith({ language: 'python' })
+    expect(workflows.setSelection).toHaveBeenCalledWith({ language: 'python', selection })
+    expect(workflows.getEnablement).toHaveBeenCalledWith({ language: 'python' })
+    expect(workflows.describeUsage).toHaveBeenCalledWith({ language: 'python', envId: 'managed' })
+    expect(workflows.setEnvironmentEnabled).toHaveBeenCalledWith({
+      language: 'python',
+      envId: 'managed',
+      enabled: false,
+      force: true
+    })
+    expect(workflows.setInstallAuthorized).toHaveBeenCalledWith({
+      language: 'python',
+      envId: 'managed',
+      authorized: true
+    })
+    expect(workflows.register).toHaveBeenCalledWith({ language: 'python', path: '/opt/python' })
+    expect(workflows.unregister).toHaveBeenCalledWith({ language: 'python', path: '/opt/python' })
+  })
+
+  it('rejects all six local-only commands before invoking their owners', async () => {
+    const { pickInterpreter, router, workflows } = install()
+    const selection: RuntimeSelection = { source: 'managed' }
+
+    await expect(
+      router.dispatcher.invoke(
+        runtimeApplicationCommands.setSelection,
+        invocation([{ language: 'python', selection }] as const, 'remote')
+      )
+    ).rejects.toThrow('Runtime command is only available to local callers.')
+    await expect(
+      router.dispatcher.invoke(
+        runtimeApplicationCommands.setEnvironmentEnabled,
+        invocation([{ language: 'python', envId: 'managed', enabled: false }] as const, 'remote')
+      )
+    ).rejects.toThrow('Runtime command is only available to local callers.')
+    await expect(
+      router.dispatcher.invoke(
+        runtimeApplicationCommands.setInstallAuthorized,
+        invocation([{ language: 'python', envId: 'managed', authorized: true }] as const, 'remote')
+      )
+    ).rejects.toThrow('Runtime command is only available to local callers.')
+    await expect(
+      router.dispatcher.invoke(
+        runtimeApplicationCommands.pickInterpreter,
+        invocation([] as const, 'remote')
+      )
+    ).rejects.toThrow('Runtime command is only available to local callers.')
+    await expect(
+      router.dispatcher.invoke(
+        runtimeApplicationCommands.registerInterpreter,
+        invocation([{ language: 'python', path: '/opt/python' }] as const, 'remote')
+      )
+    ).rejects.toThrow('Runtime command is only available to local callers.')
+    await expect(
+      router.dispatcher.invoke(
+        runtimeApplicationCommands.unregisterInterpreter,
+        invocation([{ language: 'python', path: '/opt/python' }] as const, 'remote')
+      )
+    ).rejects.toThrow('Runtime command is only available to local callers.')
+
+    expect(workflows.setSelection).not.toHaveBeenCalled()
+    expect(workflows.setEnvironmentEnabled).not.toHaveBeenCalled()
+    expect(workflows.setInstallAuthorized).not.toHaveBeenCalled()
+    expect(workflows.register).not.toHaveBeenCalled()
+    expect(workflows.unregister).not.toHaveBeenCalled()
+    expect(pickInterpreter).not.toHaveBeenCalled()
+  })
+
+  it('returns picker cancellation and converts picker failures to null', async () => {
+    const pickerFailure = new Error('dialog unavailable')
+    const pickInterpreter = vi
+      .fn<() => Promise<string | null>>()
+      .mockResolvedValueOnce(null)
+      .mockRejectedValueOnce(pickerFailure)
+    const log = vi.spyOn(console, 'error').mockImplementation(() => undefined)
+    const { router } = install(createWorkflows(), pickInterpreter)
+
+    await expect(
+      router.dispatcher.invoke(runtimeApplicationCommands.pickInterpreter, invocation([] as const))
+    ).resolves.toBeNull()
+    await expect(
+      router.dispatcher.invoke(runtimeApplicationCommands.pickInterpreter, invocation([] as const))
+    ).resolves.toBeNull()
+    expect(log).toHaveBeenCalledWith('[runtime-commands] pick-interpreter failed', pickerFailure)
+    log.mockRestore()
+  })
+
+  it('uninstalls only the Runtime command group', async () => {
+    const { installation, router } = install()
+
+    installation.uninstall()
+
+    expect(router.dispatcher.commandNames()).toEqual([])
+    await expect(
+      router.dispatcher.invoke(runtimeApplicationCommands.survey, invocation([] as const))
+    ).rejects.toThrow('Unknown application command: runtime:survey')
+  })
+})

--- a/src/main/notebook/runtime-application-commands.ts
+++ b/src/main/notebook/runtime-application-commands.ts
@@ -1,0 +1,183 @@
+import type { NotebookLanguage } from '../../shared/notebook'
+import type {
+  DiscoveredInterpreter,
+  EnvPackage,
+  RuntimeEnablement,
+  RuntimeSelection,
+  RuntimeSurvey,
+  RuntimeUsage
+} from '../../shared/notebook-runtime'
+import {
+  defineApplicationCommand,
+  defineApplicationCommandGroup,
+  type ApplicationCommandInstallation,
+  type ApplicationCommandRegistrar
+} from '../application-command-router'
+import type { CallerContext } from '../caller-context'
+import type { RuntimeSelectionWorkflows } from './runtime-selection-workflows'
+
+type RuntimeLanguageRequest = Readonly<{ language: NotebookLanguage }>
+type RuntimeEnvironmentRequest = Readonly<{ language: NotebookLanguage; envId: string }>
+type RuntimeSelectionRequest = Readonly<{
+  language: NotebookLanguage
+  selection: RuntimeSelection | null
+}>
+type RuntimeEnvironmentEnablementRequest = Readonly<{
+  language: NotebookLanguage
+  envId: string
+  enabled: boolean
+  force?: boolean
+}>
+type RuntimeInstallAuthorizationRequest = Readonly<{
+  language: NotebookLanguage
+  envId: string
+  authorized: boolean
+}>
+type RuntimeInterpreterRequest = Readonly<{ language: NotebookLanguage; path: string }>
+
+const runtimeApplicationCommands = Object.freeze({
+  survey: defineApplicationCommand<'runtime:survey', readonly [], RuntimeSurvey[]>(
+    'runtime:survey'
+  ),
+  listEnvironments: defineApplicationCommand<
+    'runtime:list-environments',
+    readonly [],
+    Readonly<{ python: DiscoveredInterpreter[]; r: DiscoveredInterpreter[] }>
+  >('runtime:list-environments'),
+  listPackages: defineApplicationCommand<
+    'runtime:list-packages',
+    readonly [request: RuntimeEnvironmentRequest],
+    EnvPackage[]
+  >('runtime:list-packages'),
+  listPackageCounts: defineApplicationCommand<
+    'runtime:list-package-counts',
+    readonly [request: RuntimeLanguageRequest],
+    Record<string, number | null>
+  >('runtime:list-package-counts'),
+  setSelection: defineApplicationCommand<
+    'runtime:set-selection',
+    readonly [request: RuntimeSelectionRequest],
+    RuntimeSurvey
+  >('runtime:set-selection'),
+  getEnablement: defineApplicationCommand<
+    'runtime:get-enablement',
+    readonly [request: RuntimeLanguageRequest],
+    RuntimeEnablement
+  >('runtime:get-enablement'),
+  describeUsage: defineApplicationCommand<
+    'runtime:describe-usage',
+    readonly [request: RuntimeEnvironmentRequest],
+    RuntimeUsage
+  >('runtime:describe-usage'),
+  setEnvironmentEnabled: defineApplicationCommand<
+    'runtime:set-environment-enabled',
+    readonly [request: RuntimeEnvironmentEnablementRequest],
+    RuntimeEnablement
+  >('runtime:set-environment-enabled'),
+  setInstallAuthorized: defineApplicationCommand<
+    'runtime:set-install-authorized',
+    readonly [request: RuntimeInstallAuthorizationRequest],
+    RuntimeEnablement
+  >('runtime:set-install-authorized'),
+  pickInterpreter: defineApplicationCommand<'runtime:pick-interpreter', readonly [], string | null>(
+    'runtime:pick-interpreter'
+  ),
+  registerInterpreter: defineApplicationCommand<
+    'runtime:register-interpreter',
+    readonly [request: RuntimeInterpreterRequest],
+    string[]
+  >('runtime:register-interpreter'),
+  unregisterInterpreter: defineApplicationCommand<
+    'runtime:unregister-interpreter',
+    readonly [request: RuntimeInterpreterRequest],
+    string[]
+  >('runtime:unregister-interpreter')
+})
+
+const runtimeApplicationCommandGroup = defineApplicationCommandGroup('runtime', [
+  runtimeApplicationCommands.describeUsage,
+  runtimeApplicationCommands.getEnablement,
+  runtimeApplicationCommands.listEnvironments,
+  runtimeApplicationCommands.listPackageCounts,
+  runtimeApplicationCommands.listPackages,
+  runtimeApplicationCommands.pickInterpreter,
+  runtimeApplicationCommands.registerInterpreter,
+  runtimeApplicationCommands.setEnvironmentEnabled,
+  runtimeApplicationCommands.setInstallAuthorized,
+  runtimeApplicationCommands.setSelection,
+  runtimeApplicationCommands.survey,
+  runtimeApplicationCommands.unregisterInterpreter
+] as const)
+
+type RuntimeApplicationCommandDependencies = Readonly<{
+  workflows: RuntimeSelectionWorkflows
+  pickInterpreter: () => Promise<string | null>
+}>
+
+const requireLocalCaller = (context: CallerContext): void => {
+  if (context.location !== 'local') {
+    throw new Error('Runtime command is only available to local callers.')
+  }
+}
+
+const registerRuntimeApplicationCommands = (
+  registrar: ApplicationCommandRegistrar,
+  dependencies: RuntimeApplicationCommandDependencies
+): ApplicationCommandInstallation => {
+  const scope = registrar.createScope()
+
+  try {
+    scope.registerGroup(runtimeApplicationCommandGroup, {
+      'runtime:survey': () => dependencies.workflows.survey(),
+      'runtime:list-environments': () => dependencies.workflows.listEnvironments(),
+      'runtime:list-packages': (invocation) =>
+        dependencies.workflows.listPackages(invocation.args[0]),
+      'runtime:list-package-counts': (invocation) =>
+        dependencies.workflows.listPackageCounts(invocation.args[0]),
+      'runtime:set-selection': (invocation) => {
+        requireLocalCaller(invocation.callerContext)
+        return dependencies.workflows.setSelection(invocation.args[0])
+      },
+      'runtime:get-enablement': (invocation) =>
+        dependencies.workflows.getEnablement(invocation.args[0]),
+      'runtime:describe-usage': (invocation) =>
+        dependencies.workflows.describeUsage(invocation.args[0]),
+      'runtime:set-environment-enabled': (invocation) => {
+        requireLocalCaller(invocation.callerContext)
+        return dependencies.workflows.setEnvironmentEnabled(invocation.args[0])
+      },
+      'runtime:set-install-authorized': (invocation) => {
+        requireLocalCaller(invocation.callerContext)
+        return dependencies.workflows.setInstallAuthorized(invocation.args[0])
+      },
+      'runtime:pick-interpreter': async ({ callerContext }) => {
+        requireLocalCaller(callerContext)
+        try {
+          return await dependencies.pickInterpreter()
+        } catch (error) {
+          console.error('[runtime-commands] pick-interpreter failed', error)
+          return null
+        }
+      },
+      'runtime:register-interpreter': (invocation) => {
+        requireLocalCaller(invocation.callerContext)
+        return dependencies.workflows.register(invocation.args[0])
+      },
+      'runtime:unregister-interpreter': (invocation) => {
+        requireLocalCaller(invocation.callerContext)
+        return dependencies.workflows.unregister(invocation.args[0])
+      }
+    })
+    return scope.complete()
+  } catch (error) {
+    scope.rollback()
+    throw error
+  }
+}
+
+export {
+  registerRuntimeApplicationCommands,
+  runtimeApplicationCommandGroup,
+  runtimeApplicationCommands
+}
+export type { RuntimeApplicationCommandDependencies }


### PR DESCRIPTION
# T2c3 pull request

Title: `refactor(runtime): define application commands`

## Problem

Runtime selection still exposes only Electron IPC-shaped handlers. The later Web direct-dispatch
cutover needs one typed application interface, but the current Electron and Web adapters intentionally
use nine different wire argument shapes and the native interpreter picker is host-specific.

## Proposed change

- Define the exact 12 Runtime application commands from the frozen renderer contract catalog.
- Accept only canonical request objects and delegate stateful behavior to the existing
  `RuntimeSelectionWorkflows` owner.
- Inject the interpreter picker as a narrow host adapter; picker cancellation and failure continue to
  resolve to `null` without importing Electron into the command module.
- Recheck the six existing local-only mutations at handler entry while leaving transport rejection to
  T2h1.
- Provide an owner-local installer for the T2h0 composition PR. No live call path switches here.

```mermaid
flowchart LR
  E["Electron IPC - unchanged"] --> W["RuntimeSelectionWorkflows"]
  C["Runtime command group - staged"] --> W
  C --> P["Injected interpreter picker"]
  H["T2h0 composition - future"] -.-> C
  X["T2h1 Web codec - future"] -.-> H
```

## Scope and non-goals

- Internal architecture: adds a typed, installable Runtime command module and picker adapter seam.
- No persisted data model, data relationship, UI, public method/event, or user-interaction change.
- No `ipc.ts`, global composition, Electron/Web/Task/CLI/local-RPC adapter, or renderer catalog change.
- The nine characterized Electron-object/Web-positional wire deviations remain unchanged and belong
  to T2h1. This PR does not repair or broaden Web Runtime behavior.
- Specialist, Permission, Compute, and Issue #458 orchestration stay outside this PR.

## Acceptance criteria and validation

- Exact 12 command names -> frozen Runtime catalog compared through the command group -> passed.
- Canonical request objects -> command dispatcher delegates all workflow methods unchanged -> passed.
- Six local-only commands -> remote caller fixture rejects before picker/workflow invocation -> passed.
- Remote-safe read -> remote survey dispatch succeeds -> passed.
- Native picker seam -> cancellation and failure both resolve `null`; failure remains logged -> passed.
- Scoped installation -> uninstall removes only the Runtime group -> passed.
- New command suite plus existing Runtime IPC/workflow suites -> 3 files / 30 tests passed.
- `npm run typecheck:node` -> passed.
- Targeted ESLint and Prettier over both added files -> passed.
- `git diff --check` -> passed.
- Independent Spec and Standards reviews -> 0 actionable findings.
- Full and cross-platform suites are intentionally delegated to online CI.

All listed checks ran after the last material edit.

## Review focus

- Command Args are canonical application objects; handlers never branch on surface or interpret raw
  wire argument lists.
- The command module owns no Runtime selection, discovery, package, enablement, or persistence state.
- Local-only defense is additive and does not replace the unchanged remote Web pre-dispatch rejection.
- Production churn is 183 lines, below the 500-line hard stop.

## Uncovered risk

The group is deliberately staged and has no production consumer until T2h0. Real dependency
composition and the complete 214-command collision/lifecycle proof are therefore deferred to T2h0;
wire codec and Web/Task behavior remain T2h1-owned.
