### PR TITLE
refactor(notebook): define application commands

### DIFF
--- a/src/main/notebook/application-commands.test.ts
+++ b/src/main/notebook/application-commands.test.ts
@@ -1,0 +1,335 @@
+import { describe, expect, it, vi } from 'vitest'
+
+import {
+  createApplicationCommandRouter,
+  type ApplicationInvocation
+} from '../application-command-router'
+import { createCallerContext, type CallerContext } from '../caller-context'
+import {
+  installNotebookApplicationCommands,
+  notebookAppendCodeCellCommand,
+  notebookApplicationCommands,
+  notebookBeginCodeCellCommand,
+  notebookExecuteCommand,
+  notebookExportIpynbAllCommand,
+  notebookExportIpynbCommand,
+  notebookFinishCodeCellCommand,
+  notebookReadInputPreviewCommand,
+  notebookReferenceCommand,
+  notebookRestartCommand,
+  notebookRunCellCommand,
+  notebookShutdownCommand,
+  notebookStateCommand
+} from './application-commands'
+import {
+  installNotebookEnvironmentApplicationCommands,
+  notebookEnvironmentApplicationCommands,
+  notebookEnvironmentCancelCommand,
+  notebookEnvironmentProvisionCommand,
+  notebookEnvironmentRepairCommand,
+  notebookEnvironmentStatusCommand
+} from './environment-application-commands'
+import type { NotebookEnvironmentLifecycle } from './environment-lifecycle-workflows'
+import {
+  createNotebookCommandWorkflows,
+  type NotebookCommandRuntime,
+  type NotebookCommandWorkflows
+} from './notebook-workflows'
+
+const localCaller = createCallerContext({
+  clientId: 'renderer-1',
+  lifecycleClientId: 'web:renderer-1',
+  leaseId: 'renderer-lease-1',
+  surface: 'web',
+  location: 'local',
+  principalKind: 'human',
+  actionOrigin: 'human'
+})
+
+const remoteCaller = createCallerContext({
+  clientId: 'renderer-remote',
+  lifecycleClientId: 'web:renderer-remote',
+  leaseId: 'renderer-remote-lease',
+  surface: 'web',
+  location: 'remote',
+  principalKind: 'human',
+  actionOrigin: 'human'
+})
+
+const invocation = <Args extends readonly unknown[]>(
+  args: Args,
+  callerContext: CallerContext = localCaller
+): ApplicationInvocation<Args> => ({
+  callerContext,
+  callerLease: {
+    leaseId: callerContext.leaseId,
+    generation: 1,
+    signal: new AbortController().signal,
+    isCurrent: () => true
+  },
+  args
+})
+
+describe('Notebook application commands', () => {
+  it('owns exactly the 16 renderer-callable Notebook and Environment commands', () => {
+    expect([
+      ...notebookApplicationCommands.commands,
+      ...notebookEnvironmentApplicationCommands.commands
+    ]).toEqual([
+      expect.objectContaining({ name: 'notebook:state' }),
+      expect.objectContaining({ name: 'notebook:reference' }),
+      expect.objectContaining({ name: 'notebook:begin-code-cell' }),
+      expect.objectContaining({ name: 'notebook:append-code-cell' }),
+      expect.objectContaining({ name: 'notebook:finish-code-cell' }),
+      expect.objectContaining({ name: 'notebook:run-cell' }),
+      expect.objectContaining({ name: 'notebook:execute' }),
+      expect.objectContaining({ name: 'notebook:export-ipynb' }),
+      expect.objectContaining({ name: 'notebook:export-ipynb-all' }),
+      expect.objectContaining({ name: 'notebook:restart' }),
+      expect.objectContaining({ name: 'notebook:shutdown' }),
+      expect.objectContaining({ name: 'notebook:read-input-preview' }),
+      expect.objectContaining({ name: 'notebook-env:status' }),
+      expect.objectContaining({ name: 'notebook-env:provision' }),
+      expect.objectContaining({ name: 'notebook-env:repair' }),
+      expect.objectContaining({ name: 'notebook-env:cancel' })
+    ])
+  })
+
+  it('routes Notebook commands through the owner workflows and input-preview port', async () => {
+    const workflowMethods = [
+      'state',
+      'reference',
+      'beginCodeCell',
+      'appendCodeCell',
+      'finishCodeCell',
+      'runCell',
+      'execute',
+      'exportIpynb',
+      'exportIpynbAll',
+      'restart',
+      'shutdown'
+    ] as const
+    const workflows = Object.fromEntries(
+      workflowMethods.map((method) => [
+        method,
+        vi.fn(async (request: unknown) => ({ method, request }))
+      ])
+    ) as unknown as NotebookCommandWorkflows
+    const readInputPreview = vi.fn(async (request: unknown) => ({
+      content: JSON.stringify(request),
+      encoding: 'utf8' as const,
+      size: 1,
+      truncated: false
+    }))
+    const router = createApplicationCommandRouter()
+    installNotebookApplicationCommands(router.registrar, { workflows, readInputPreview })
+    const session = { sessionId: 'session-1', workspaceCwd: '/workspace' }
+    const cases = [
+      [notebookStateCommand, [session], 'state'],
+      [notebookReferenceCommand, [session], 'reference'],
+      [notebookBeginCodeCellCommand, [session], 'beginCodeCell'],
+      [
+        notebookAppendCodeCellCommand,
+        [{ ...session, cellId: 'cell-1', writeId: 'write-1', delta: 'print(1)' }],
+        'appendCodeCell'
+      ],
+      [
+        notebookFinishCodeCellCommand,
+        [{ ...session, cellId: 'cell-1', writeId: 'write-1' }],
+        'finishCodeCell'
+      ],
+      [notebookRunCellCommand, [{ ...session, cellId: 'cell-1' }], 'runCell'],
+      [notebookExecuteCommand, [{ ...session, code: 'print(1)' }], 'execute'],
+      [notebookExportIpynbCommand, [{ ...session, kernel: 'python' }], 'exportIpynb'],
+      [notebookExportIpynbAllCommand, [session], 'exportIpynbAll'],
+      [notebookRestartCommand, [session], 'restart'],
+      [notebookShutdownCommand, [session], 'shutdown']
+    ] as const
+
+    for (const [command, args, method] of cases) {
+      await expect(
+        router.dispatcher.invoke(command as never, invocation(args) as never)
+      ).resolves.toEqual({ method, request: args[0] })
+      expect(
+        (workflows as unknown as Record<string, ReturnType<typeof vi.fn>>)[method]
+      ).toHaveBeenCalledWith(args[0])
+    }
+
+    const previewRequest = { path: 'notebook-input:key', maxBytes: 1024 }
+    await router.dispatcher.invoke(
+      notebookReadInputPreviewCommand,
+      invocation([previewRequest] as const)
+    )
+    expect(readInputPreview).toHaveBeenCalledWith(previewRequest)
+    expect(router.dispatcher.commandNames()).toEqual(
+      notebookApplicationCommands.commands.map(({ name }) => name).sort()
+    )
+  })
+
+  it('strips renderer-supplied provenance and input leases before runtime execution', async () => {
+    const runtime = {
+      runCell: vi.fn(async () => ({ runId: 'run-1' })),
+      execute: vi.fn(async () => ({ runId: 'run-2' }))
+    } as unknown as NotebookCommandRuntime
+    const router = createApplicationCommandRouter()
+    installNotebookApplicationCommands(router.registrar, {
+      workflows: createNotebookCommandWorkflows(runtime),
+      readInputPreview: vi.fn()
+    })
+    const trustedFields = {
+      provenanceContext: {
+        rootFrameId: 'forged-root',
+        agentFrameId: 'forged-agent',
+        messageBranchId: 'forged-branch',
+        runtimeSegmentId: 'forged-runtime',
+        promptMessageId: 'forged-prompt'
+      },
+      registeredInputFiles: [],
+      inputRunLeaseId: 'forged-lease'
+    }
+    const runRequest = {
+      sessionId: 'session-1',
+      workspaceCwd: '/workspace',
+      cellId: 'cell-1',
+      ...trustedFields
+    }
+    const executeRequest = {
+      sessionId: 'session-1',
+      workspaceCwd: '/workspace',
+      code: 'print(1)',
+      ...trustedFields
+    }
+
+    await router.dispatcher.invoke(notebookRunCellCommand, invocation([runRequest] as const))
+    await router.dispatcher.invoke(notebookExecuteCommand, invocation([executeRequest] as const))
+
+    expect(runtime.runCell).toHaveBeenCalledWith({
+      sessionId: 'session-1',
+      workspaceCwd: '/workspace',
+      cellId: 'cell-1'
+    })
+    expect(runtime.execute).toHaveBeenCalledWith({
+      sessionId: 'session-1',
+      workspaceCwd: '/workspace',
+      code: 'print(1)'
+    })
+  })
+
+  it('rejects both export commands for remote callers before invoking workflows', async () => {
+    const exportIpynb = vi.fn()
+    const exportIpynbAll = vi.fn()
+    const workflows = {
+      exportIpynb,
+      exportIpynbAll
+    } as unknown as NotebookCommandWorkflows
+    const router = createApplicationCommandRouter()
+    installNotebookApplicationCommands(router.registrar, {
+      workflows,
+      readInputPreview: vi.fn()
+    })
+    const session = { sessionId: 'session-1', workspaceCwd: '/workspace' }
+
+    await expect(
+      router.dispatcher.invoke(
+        notebookExportIpynbCommand,
+        invocation([{ ...session, kernel: 'python' }] as const, remoteCaller)
+      )
+    ).rejects.toThrow('Channel only available from the local app: notebook:export-ipynb')
+    await expect(
+      router.dispatcher.invoke(
+        notebookExportIpynbAllCommand,
+        invocation([session] as const, remoteCaller)
+      )
+    ).rejects.toThrow('Channel only available from the local app: notebook:export-ipynb-all')
+    expect(exportIpynb).not.toHaveBeenCalled()
+    expect(exportIpynbAll).not.toHaveBeenCalled()
+  })
+
+  it('routes Environment commands through the owner lifecycle and preserves optional cancel', async () => {
+    const status = vi.fn(async () => ({
+      pythonReady: true,
+      rReady: false,
+      version: 1,
+      provisioning: false
+    }))
+    const provision = vi.fn(async () => undefined)
+    const repair = vi.fn(async () => undefined)
+    const cancel = vi.fn()
+    const lifecycle = {
+      status,
+      provision,
+      repair,
+      cancel,
+      startup: vi.fn()
+    } as NotebookEnvironmentLifecycle
+    const router = createApplicationCommandRouter()
+    installNotebookEnvironmentApplicationCommands(router.registrar, lifecycle)
+
+    await expect(
+      router.dispatcher.invoke(notebookEnvironmentStatusCommand, invocation([] as const))
+    ).resolves.toMatchObject({ pythonReady: true })
+    await router.dispatcher.invoke(notebookEnvironmentProvisionCommand, invocation(['r'] as const))
+    await router.dispatcher.invoke(
+      notebookEnvironmentRepairCommand,
+      invocation(['python'] as const)
+    )
+    await router.dispatcher.invoke(notebookEnvironmentCancelCommand, invocation([] as const))
+
+    expect(provision).toHaveBeenCalledWith('r')
+    expect(repair).toHaveBeenCalledWith('python')
+    expect(cancel).toHaveBeenCalledWith(undefined)
+    expect(lifecycle.startup).not.toHaveBeenCalled()
+    expect(router.dispatcher.commandNames()).toEqual(
+      notebookEnvironmentApplicationCommands.commands.map(({ name }) => name).sort()
+    )
+  })
+
+  it('keeps Environment status remote-readable but rejects remote mutations before the lifecycle', async () => {
+    const status = vi.fn(async () => ({
+      pythonReady: false,
+      rReady: false,
+      version: 1,
+      provisioning: false
+    }))
+    const provision = vi.fn()
+    const repair = vi.fn()
+    const cancel = vi.fn()
+    const router = createApplicationCommandRouter()
+    installNotebookEnvironmentApplicationCommands(router.registrar, {
+      status,
+      provision,
+      repair,
+      cancel,
+      startup: vi.fn()
+    })
+
+    await expect(
+      router.dispatcher.invoke(
+        notebookEnvironmentStatusCommand,
+        invocation([] as const, remoteCaller)
+      )
+    ).resolves.toMatchObject({ provisioning: false })
+    await expect(
+      router.dispatcher.invoke(
+        notebookEnvironmentProvisionCommand,
+        invocation(['python'] as const, remoteCaller)
+      )
+    ).rejects.toThrow('Channel only available from the local app: notebook-env:provision')
+    await expect(
+      router.dispatcher.invoke(
+        notebookEnvironmentRepairCommand,
+        invocation(['r'] as const, remoteCaller)
+      )
+    ).rejects.toThrow('Channel only available from the local app: notebook-env:repair')
+    await expect(
+      router.dispatcher.invoke(
+        notebookEnvironmentCancelCommand,
+        invocation([] as const, remoteCaller)
+      )
+    ).rejects.toThrow('Channel only available from the local app: notebook-env:cancel')
+    expect(status).toHaveBeenCalledOnce()
+    expect(provision).not.toHaveBeenCalled()
+    expect(repair).not.toHaveBeenCalled()
+    expect(cancel).not.toHaveBeenCalled()
+  })
+})

--- a/src/main/notebook/application-commands.ts
+++ b/src/main/notebook/application-commands.ts
@@ -1,0 +1,159 @@
+import type { ArtifactPreviewResult, ReadArtifactPreviewRequest } from '../../shared/artifacts'
+import {
+  defineApplicationCommand,
+  defineApplicationCommandGroup,
+  type ApplicationCommandInstallation,
+  type ApplicationCommandRegistrar
+} from '../application-command-router'
+import type { CallerContext } from '../caller-context'
+import type { NotebookCommandWorkflows } from './notebook-workflows'
+
+type NotebookApplicationCommandDependencies = Readonly<{
+  workflows: NotebookCommandWorkflows
+  readInputPreview: (request: ReadArtifactPreviewRequest) => Promise<ArtifactPreviewResult>
+}>
+
+type WorkflowArgs<Method extends keyof NotebookCommandWorkflows> =
+  NotebookCommandWorkflows[Method] extends (...args: infer Args) => unknown ? Readonly<Args> : never
+
+type WorkflowResult<Method extends keyof NotebookCommandWorkflows> =
+  NotebookCommandWorkflows[Method] extends (...args: never[]) => infer Result
+    ? Awaited<Result>
+    : never
+
+const assertLocalCaller = (callerContext: CallerContext, commandName: string): void => {
+  if (callerContext.location !== 'local') {
+    throw new Error(`Channel only available from the local app: ${commandName}`)
+  }
+}
+
+const notebookStateCommand = defineApplicationCommand<
+  'notebook:state',
+  WorkflowArgs<'state'>,
+  WorkflowResult<'state'>
+>('notebook:state')
+const notebookReferenceCommand = defineApplicationCommand<
+  'notebook:reference',
+  WorkflowArgs<'reference'>,
+  WorkflowResult<'reference'>
+>('notebook:reference')
+const notebookBeginCodeCellCommand = defineApplicationCommand<
+  'notebook:begin-code-cell',
+  WorkflowArgs<'beginCodeCell'>,
+  WorkflowResult<'beginCodeCell'>
+>('notebook:begin-code-cell')
+const notebookAppendCodeCellCommand = defineApplicationCommand<
+  'notebook:append-code-cell',
+  WorkflowArgs<'appendCodeCell'>,
+  WorkflowResult<'appendCodeCell'>
+>('notebook:append-code-cell')
+const notebookFinishCodeCellCommand = defineApplicationCommand<
+  'notebook:finish-code-cell',
+  WorkflowArgs<'finishCodeCell'>,
+  WorkflowResult<'finishCodeCell'>
+>('notebook:finish-code-cell')
+const notebookRunCellCommand = defineApplicationCommand<
+  'notebook:run-cell',
+  WorkflowArgs<'runCell'>,
+  WorkflowResult<'runCell'>
+>('notebook:run-cell')
+const notebookExecuteCommand = defineApplicationCommand<
+  'notebook:execute',
+  WorkflowArgs<'execute'>,
+  WorkflowResult<'execute'>
+>('notebook:execute')
+const notebookExportIpynbCommand = defineApplicationCommand<
+  'notebook:export-ipynb',
+  WorkflowArgs<'exportIpynb'>,
+  WorkflowResult<'exportIpynb'>
+>('notebook:export-ipynb')
+const notebookExportIpynbAllCommand = defineApplicationCommand<
+  'notebook:export-ipynb-all',
+  WorkflowArgs<'exportIpynbAll'>,
+  WorkflowResult<'exportIpynbAll'>
+>('notebook:export-ipynb-all')
+const notebookRestartCommand = defineApplicationCommand<
+  'notebook:restart',
+  WorkflowArgs<'restart'>,
+  WorkflowResult<'restart'>
+>('notebook:restart')
+const notebookShutdownCommand = defineApplicationCommand<
+  'notebook:shutdown',
+  WorkflowArgs<'shutdown'>,
+  WorkflowResult<'shutdown'>
+>('notebook:shutdown')
+const notebookReadInputPreviewCommand = defineApplicationCommand<
+  'notebook:read-input-preview',
+  readonly [request: ReadArtifactPreviewRequest],
+  ArtifactPreviewResult
+>('notebook:read-input-preview')
+
+const notebookApplicationCommands = defineApplicationCommandGroup('notebook', [
+  notebookStateCommand,
+  notebookReferenceCommand,
+  notebookBeginCodeCellCommand,
+  notebookAppendCodeCellCommand,
+  notebookFinishCodeCellCommand,
+  notebookRunCellCommand,
+  notebookExecuteCommand,
+  notebookExportIpynbCommand,
+  notebookExportIpynbAllCommand,
+  notebookRestartCommand,
+  notebookShutdownCommand,
+  notebookReadInputPreviewCommand
+] as const)
+
+const installNotebookApplicationCommands = (
+  registrar: ApplicationCommandRegistrar,
+  dependencies: NotebookApplicationCommandDependencies
+): ApplicationCommandInstallation => {
+  const scope = registrar.createScope()
+  try {
+    scope.registerGroup(notebookApplicationCommands, {
+      'notebook:state': (invocation) => dependencies.workflows.state(invocation.args[0]),
+      'notebook:reference': (invocation) => dependencies.workflows.reference(invocation.args[0]),
+      'notebook:begin-code-cell': (invocation) =>
+        dependencies.workflows.beginCodeCell(invocation.args[0]),
+      'notebook:append-code-cell': (invocation) =>
+        dependencies.workflows.appendCodeCell(invocation.args[0]),
+      'notebook:finish-code-cell': (invocation) =>
+        dependencies.workflows.finishCodeCell(invocation.args[0]),
+      'notebook:run-cell': (invocation) => dependencies.workflows.runCell(invocation.args[0]),
+      'notebook:execute': (invocation) => dependencies.workflows.execute(invocation.args[0]),
+      'notebook:export-ipynb': (invocation) => {
+        assertLocalCaller(invocation.callerContext, notebookExportIpynbCommand.name)
+        return dependencies.workflows.exportIpynb(invocation.args[0])
+      },
+      'notebook:export-ipynb-all': (invocation) => {
+        assertLocalCaller(invocation.callerContext, notebookExportIpynbAllCommand.name)
+        return dependencies.workflows.exportIpynbAll(invocation.args[0])
+      },
+      'notebook:restart': (invocation) => dependencies.workflows.restart(invocation.args[0]),
+      'notebook:shutdown': (invocation) => dependencies.workflows.shutdown(invocation.args[0]),
+      'notebook:read-input-preview': (invocation) =>
+        dependencies.readInputPreview(invocation.args[0])
+    })
+    return scope.complete()
+  } catch (error) {
+    scope.rollback()
+    throw error
+  }
+}
+
+export {
+  installNotebookApplicationCommands,
+  notebookAppendCodeCellCommand,
+  notebookApplicationCommands,
+  notebookBeginCodeCellCommand,
+  notebookExecuteCommand,
+  notebookExportIpynbAllCommand,
+  notebookExportIpynbCommand,
+  notebookFinishCodeCellCommand,
+  notebookReadInputPreviewCommand,
+  notebookReferenceCommand,
+  notebookRestartCommand,
+  notebookRunCellCommand,
+  notebookShutdownCommand,
+  notebookStateCommand
+}
+export type { NotebookApplicationCommandDependencies }

--- a/src/main/notebook/environment-application-commands.ts
+++ b/src/main/notebook/environment-application-commands.ts
@@ -1,0 +1,92 @@
+import {
+  defineApplicationCommand,
+  defineApplicationCommandGroup,
+  type ApplicationCommandInstallation,
+  type ApplicationCommandRegistrar
+} from '../application-command-router'
+import type { CallerContext } from '../caller-context'
+import type { NotebookEnvironmentLifecycle } from './environment-lifecycle-workflows'
+
+type LifecycleArgs<Method extends keyof NotebookEnvironmentLifecycle> =
+  NotebookEnvironmentLifecycle[Method] extends (...args: infer Args) => unknown
+    ? Readonly<Args>
+    : never
+
+type LifecycleResult<Method extends keyof NotebookEnvironmentLifecycle> =
+  NotebookEnvironmentLifecycle[Method] extends (...args: never[]) => infer Result
+    ? Awaited<Result>
+    : never
+
+const assertLocalCaller = (callerContext: CallerContext, commandName: string): void => {
+  if (callerContext.location !== 'local') {
+    throw new Error(`Channel only available from the local app: ${commandName}`)
+  }
+}
+
+const notebookEnvironmentStatusCommand = defineApplicationCommand<
+  'notebook-env:status',
+  LifecycleArgs<'status'>,
+  LifecycleResult<'status'>
+>('notebook-env:status')
+const notebookEnvironmentProvisionCommand = defineApplicationCommand<
+  'notebook-env:provision',
+  LifecycleArgs<'provision'>,
+  LifecycleResult<'provision'>
+>('notebook-env:provision')
+const notebookEnvironmentRepairCommand = defineApplicationCommand<
+  'notebook-env:repair',
+  LifecycleArgs<'repair'>,
+  LifecycleResult<'repair'>
+>('notebook-env:repair')
+const notebookEnvironmentCancelCommand = defineApplicationCommand<
+  'notebook-env:cancel',
+  LifecycleArgs<'cancel'>,
+  LifecycleResult<'cancel'>
+>('notebook-env:cancel')
+
+const notebookEnvironmentApplicationCommands = defineApplicationCommandGroup(
+  'notebook-environment',
+  [
+    notebookEnvironmentStatusCommand,
+    notebookEnvironmentProvisionCommand,
+    notebookEnvironmentRepairCommand,
+    notebookEnvironmentCancelCommand
+  ] as const
+)
+
+const installNotebookEnvironmentApplicationCommands = (
+  registrar: ApplicationCommandRegistrar,
+  lifecycle: NotebookEnvironmentLifecycle
+): ApplicationCommandInstallation => {
+  const scope = registrar.createScope()
+  try {
+    scope.registerGroup(notebookEnvironmentApplicationCommands, {
+      'notebook-env:status': () => lifecycle.status(),
+      'notebook-env:provision': (invocation) => {
+        assertLocalCaller(invocation.callerContext, notebookEnvironmentProvisionCommand.name)
+        return lifecycle.provision(invocation.args[0])
+      },
+      'notebook-env:repair': (invocation) => {
+        assertLocalCaller(invocation.callerContext, notebookEnvironmentRepairCommand.name)
+        return lifecycle.repair(invocation.args[0])
+      },
+      'notebook-env:cancel': (invocation) => {
+        assertLocalCaller(invocation.callerContext, notebookEnvironmentCancelCommand.name)
+        return lifecycle.cancel(invocation.args[0])
+      }
+    })
+    return scope.complete()
+  } catch (error) {
+    scope.rollback()
+    throw error
+  }
+}
+
+export {
+  installNotebookEnvironmentApplicationCommands,
+  notebookEnvironmentApplicationCommands,
+  notebookEnvironmentCancelCommand,
+  notebookEnvironmentProvisionCommand,
+  notebookEnvironmentRepairCommand,
+  notebookEnvironmentStatusCommand
+}


### PR DESCRIPTION
# T2c2 pull request

Title: `refactor(notebook): define application commands`

## Problem

Notebook and Notebook Environment behavior is still exposed through transport-owned handlers. Before
the later composition and Web cutover, these capabilities need a typed owner-local command boundary
that preserves the workflow owner's provenance and lifecycle rules.

## Proposed change

- Define the exact 12 Notebook and four Notebook Environment application commands with canonical
  request and result types derived from existing owners.
- Delegate Notebook run/execute behavior through `NotebookCommandWorkflows`, preserving its removal of
  transport-supplied provenance and run-lease fields.
- Keep both exports and Environment provision/repair/cancel local-only with defense-in-depth checks
  before owner invocation; Environment status remains remotely readable.
- Add owner-local installers for future T2h0 composition without switching a production call path.

```mermaid
flowchart LR
  C["Future transport codec"] --> N["Notebook commands - 12"]
  C --> E["Environment commands - 4"]
  N --> W["NotebookCommandWorkflows"]
  E --> L["NotebookEnvironmentLifecycle"]
  R["Trusted local RPC"] -. "unchanged capability" .-> W
```

## Scope and non-goals

- Delivery boundary: this is intentionally a compile-time preparatory module PR. Production
  installation is not an acceptance criterion. T2h0 composes all bounded capability groups in one
  atomic router and certifies the complete command inventory; T2h1 then cuts over adapters. Wiring
  only Notebook here would create temporary dual ownership and bypass that collision/lifecycle gate.
- Internal architecture changes: yes; this adds typed owner-local command boundaries.
- Persisted data model, data relationships, UI, and public method/event contracts: no change.
- Electron/Web/Task/CLI/local-RPC capability availability: no change; no transport or composition is
  modified.
- Local RPC keeps its trusted provenance and `host.agents` Specialist behavior.
- Environment progress and ACP/Notebook event publication remain owned by their current paths.
- Issue #458 orchestration state, vocabulary, and interfaces are not introduced.

## Acceptance criteria and validation

The checks below ran after the last material edit.

- Exact 16-command inventory and typed delegation -> focused application-command tests -> passed.
- Run/execute remove `provenanceContext`, `registeredInputFiles`, and `inputRunLeaseId` through the
  existing workflow owner -> focused workflow/application tests -> passed.
- Notebook exports reject remote callers before workflow entry -> focused application tests -> passed.
- Environment status remains remote-safe while provision/repair/cancel reject remote callers before
  lifecycle entry -> focused application tests -> passed.
- Optional Environment cancel preserves `undefined`; installer never calls lifecycle startup ->
  focused application tests -> passed.
- Six related Notebook/Environment test files / 70 tests -> passed.
- `npm run typecheck:node` -> passed.
- Targeted ESLint and Prettier checks -> passed.
- `git diff --check` -> passed.
- Independent Spec and Standards reviews -> 0 actionable findings.
- Full and cross-platform suites are intentionally delegated to online CI.

## Review focus

- Notebook commands must delegate through `NotebookCommandWorkflows`, never directly to the runtime.
- Canonical application args must not encode Electron or Web wire-shape differences.
- Local-only checks are additive defense-in-depth and do not broaden any surface.
- Production churn is 251 lines, inside the 160–280 estimate and below the 500-line hard stop.

## Uncovered risk

The command groups have no production consumer until T2h0, so real dependency composition and the
complete command-collision proof are deferred. T2h1 owns Web codecs and transport cutover; trusted
local-RPC behavior remains outside this change. The absence of production routing in this PR is the
explicit staged-delivery boundary, not a claim that the new policy already protects live calls.
