### PR TITLE
refactor(security): own caller lifecycle leases

### DIFF
--- a/src/main/caller-lifecycle.test.ts
+++ b/src/main/caller-lifecycle.test.ts
@@ -1,13 +1,15 @@
 import { describe, expect, it } from 'vitest'
 
+import { createElectronCallerContext, createWebCallerContext } from './caller-context'
 import { ApplicationCallerLeaseRegistry } from './caller-lifecycle'
 
 describe('application caller lease registry', () => {
   it('replaces a released stable lease id with a new generation and signal', () => {
     const registry = new ApplicationCallerLeaseRegistry()
-    const first = registry.acquire('web:browser-1')
+    const context = createWebCallerContext('browser-1')
+    const first = registry.acquire(context)
 
-    expect(first.lease).toMatchObject({ leaseId: 'web:browser-1', generation: 1 })
+    expect(first.lease).toMatchObject({ leaseId: 'browser-1', generation: 1 })
     expect(first.lease.signal.aborted).toBe(false)
     expect(first.lease.isCurrent()).toBe(true)
 
@@ -15,7 +17,7 @@ describe('application caller lease registry', () => {
     expect(first.lease.signal.aborted).toBe(true)
     expect(first.lease.isCurrent()).toBe(false)
 
-    const replacement = registry.acquire('web:browser-1')
+    const replacement = registry.acquire(context)
     expect(replacement.lease.generation).toBe(2)
     expect(replacement.lease.signal).not.toBe(first.lease.signal)
     expect(replacement.lease.signal.aborted).toBe(false)
@@ -24,8 +26,9 @@ describe('application caller lease registry', () => {
 
   it('prevents a stale release from aborting the replacement generation', () => {
     const registry = new ApplicationCallerLeaseRegistry()
-    const first = registry.acquire('electron:7')
-    const replacement = registry.acquire('electron:7')
+    const context = createElectronCallerContext(7)
+    const first = registry.acquire(context)
+    const replacement = registry.acquire(context)
 
     expect(first.lease.signal.aborted).toBe(true)
     expect(replacement.lease.isCurrent()).toBe(true)
@@ -34,15 +37,24 @@ describe('application caller lease registry', () => {
     expect(replacement.lease.signal.aborted).toBe(false)
   })
 
+  it('allocates generations monotonically across released caller identities', () => {
+    const registry = new ApplicationCallerLeaseRegistry()
+    const first = registry.acquire(createElectronCallerContext(1))
+    first.release()
+    const second = registry.acquire(createElectronCallerContext(2))
+
+    expect(second.lease.generation).toBeGreaterThan(first.lease.generation)
+  })
+
   it('aborts every active lease when the surface registry is disposed', () => {
     const registry = new ApplicationCallerLeaseRegistry()
-    const first = registry.acquire('electron:1')
-    const second = registry.acquire('web:browser-1')
+    const first = registry.acquire(createElectronCallerContext(1))
+    const second = registry.acquire(createWebCallerContext('browser-1'))
 
     registry.dispose()
 
     expect(first.lease.signal.aborted).toBe(true)
     expect(second.lease.signal.aborted).toBe(true)
-    expect(() => registry.acquire('electron:2')).toThrow('registry is disposed')
+    expect(() => registry.acquire(createElectronCallerContext(2))).toThrow('registry is disposed')
   })
 })

--- a/src/main/caller-lifecycle.test.ts
+++ b/src/main/caller-lifecycle.test.ts
@@ -1,0 +1,48 @@
+import { describe, expect, it } from 'vitest'
+
+import { ApplicationCallerLeaseRegistry } from './caller-lifecycle'
+
+describe('application caller lease registry', () => {
+  it('replaces a released stable lease id with a new generation and signal', () => {
+    const registry = new ApplicationCallerLeaseRegistry()
+    const first = registry.acquire('web:browser-1')
+
+    expect(first.lease).toMatchObject({ leaseId: 'web:browser-1', generation: 1 })
+    expect(first.lease.signal.aborted).toBe(false)
+    expect(first.lease.isCurrent()).toBe(true)
+
+    first.release()
+    expect(first.lease.signal.aborted).toBe(true)
+    expect(first.lease.isCurrent()).toBe(false)
+
+    const replacement = registry.acquire('web:browser-1')
+    expect(replacement.lease.generation).toBe(2)
+    expect(replacement.lease.signal).not.toBe(first.lease.signal)
+    expect(replacement.lease.signal.aborted).toBe(false)
+    expect(replacement.lease.isCurrent()).toBe(true)
+  })
+
+  it('prevents a stale release from aborting the replacement generation', () => {
+    const registry = new ApplicationCallerLeaseRegistry()
+    const first = registry.acquire('electron:7')
+    const replacement = registry.acquire('electron:7')
+
+    expect(first.lease.signal.aborted).toBe(true)
+    expect(replacement.lease.isCurrent()).toBe(true)
+
+    first.release()
+    expect(replacement.lease.signal.aborted).toBe(false)
+  })
+
+  it('aborts every active lease when the surface registry is disposed', () => {
+    const registry = new ApplicationCallerLeaseRegistry()
+    const first = registry.acquire('electron:1')
+    const second = registry.acquire('web:browser-1')
+
+    registry.dispose()
+
+    expect(first.lease.signal.aborted).toBe(true)
+    expect(second.lease.signal.aborted).toBe(true)
+    expect(() => registry.acquire('electron:2')).toThrow('registry is disposed')
+  })
+})

--- a/src/main/caller-lifecycle.ts
+++ b/src/main/caller-lifecycle.ts
@@ -16,6 +16,10 @@ type CallerLeaseEvent = Readonly<{ sender: object }>
 const eventLeases = new WeakMap<object, ApplicationCallerLease>()
 const leaseOwnershipKeys = new WeakMap<ApplicationCallerLease, string>()
 
+const callerLeaseOwnershipKeyForContext = (
+  identity: Pick<CallerContext, 'leaseId' | 'surface'>
+): string => `${identity.surface}\u0000${identity.leaseId}`
+
 const bindCallerLeaseToEvent = (event: CallerLeaseEvent, lease: ApplicationCallerLease): void => {
   eventLeases.set(event, lease)
 }
@@ -41,8 +45,8 @@ class ApplicationCallerLeaseRegistry {
 
   acquire(identity: Pick<CallerContext, 'leaseId' | 'surface'>): OwnedApplicationCallerLease {
     if (this.disposed) throw new Error('Application caller lease registry is disposed.')
-    const { leaseId, surface } = identity
-    const ownershipKey = `${surface}\u0000${leaseId}`
+    const { leaseId } = identity
+    const ownershipKey = callerLeaseOwnershipKeyForContext(identity)
 
     const previous = this.active.get(ownershipKey)
     if (previous) {
@@ -86,6 +90,7 @@ export {
   ApplicationCallerLeaseRegistry,
   bindCallerLeaseToEvent,
   callerLeaseForEvent,
-  callerLeaseOwnershipKey
+  callerLeaseOwnershipKey,
+  callerLeaseOwnershipKeyForContext
 }
 export type { OwnedApplicationCallerLease }

--- a/src/main/caller-lifecycle.ts
+++ b/src/main/caller-lifecycle.ts
@@ -1,0 +1,76 @@
+import type { ApplicationCallerLease } from './application-command-router'
+
+type OwnedApplicationCallerLease = Readonly<{
+  lease: ApplicationCallerLease
+  release: () => void
+}>
+
+type LeaseState = Readonly<{
+  token: object
+  controller: AbortController
+}>
+
+type CallerLeaseEvent = Readonly<{ sender: object }>
+
+const eventLeases = new WeakMap<object, ApplicationCallerLease>()
+
+const bindCallerLeaseToEvent = (event: CallerLeaseEvent, lease: ApplicationCallerLease): void => {
+  eventLeases.set(event.sender, lease)
+}
+
+const callerLeaseForEvent = (event: CallerLeaseEvent): ApplicationCallerLease => {
+  const lease = eventLeases.get(event.sender)
+  if (!lease) throw new Error('Application caller lease is not bound to this event.')
+  return lease
+}
+
+// Owns disconnect state for application callers. Surface adapters retain the release capability;
+// command handlers receive only the immutable lease and its read-only AbortSignal.
+class ApplicationCallerLeaseRegistry {
+  private readonly active = new Map<string, LeaseState>()
+  private readonly generations = new Map<string, number>()
+  private disposed = false
+
+  acquire(leaseId: string): OwnedApplicationCallerLease {
+    if (this.disposed) throw new Error('Application caller lease registry is disposed.')
+
+    const previous = this.active.get(leaseId)
+    if (previous) {
+      this.active.delete(leaseId)
+      previous.controller.abort()
+    }
+
+    const generation = (this.generations.get(leaseId) ?? 0) + 1
+    this.generations.set(leaseId, generation)
+    const controller = new AbortController()
+    const token = Object.freeze({})
+    const lease: ApplicationCallerLease = Object.freeze({
+      leaseId,
+      generation,
+      signal: controller.signal,
+      isCurrent: () => this.active.get(leaseId)?.token === token && !controller.signal.aborted
+    })
+    const state: LeaseState = { token, controller }
+    this.active.set(leaseId, state)
+
+    return Object.freeze({
+      lease,
+      release: () => {
+        if (this.active.get(leaseId) !== state) return
+        this.active.delete(leaseId)
+        controller.abort()
+      }
+    })
+  }
+
+  dispose(): void {
+    if (this.disposed) return
+    this.disposed = true
+    const active = [...this.active.values()]
+    this.active.clear()
+    for (const state of active) state.controller.abort()
+  }
+}
+
+export { ApplicationCallerLeaseRegistry, bindCallerLeaseToEvent, callerLeaseForEvent }
+export type { OwnedApplicationCallerLease }

--- a/src/main/caller-lifecycle.ts
+++ b/src/main/caller-lifecycle.ts
@@ -1,4 +1,5 @@
 import type { ApplicationCallerLease } from './application-command-router'
+import type { CallerContext } from './caller-context'
 
 type OwnedApplicationCallerLease = Readonly<{
   lease: ApplicationCallerLease
@@ -13,51 +14,60 @@ type LeaseState = Readonly<{
 type CallerLeaseEvent = Readonly<{ sender: object }>
 
 const eventLeases = new WeakMap<object, ApplicationCallerLease>()
+const leaseOwnershipKeys = new WeakMap<ApplicationCallerLease, string>()
 
 const bindCallerLeaseToEvent = (event: CallerLeaseEvent, lease: ApplicationCallerLease): void => {
-  eventLeases.set(event.sender, lease)
+  eventLeases.set(event, lease)
 }
 
 const callerLeaseForEvent = (event: CallerLeaseEvent): ApplicationCallerLease => {
-  const lease = eventLeases.get(event.sender)
+  const lease = eventLeases.get(event)
   if (!lease) throw new Error('Application caller lease is not bound to this event.')
   return lease
+}
+
+const callerLeaseOwnershipKey = (lease: ApplicationCallerLease): string => {
+  const ownershipKey = leaseOwnershipKeys.get(lease)
+  if (!ownershipKey) throw new Error('Application caller lease has no ownership key.')
+  return ownershipKey
 }
 
 // Owns disconnect state for application callers. Surface adapters retain the release capability;
 // command handlers receive only the immutable lease and its read-only AbortSignal.
 class ApplicationCallerLeaseRegistry {
   private readonly active = new Map<string, LeaseState>()
-  private readonly generations = new Map<string, number>()
+  private nextGeneration = 0
   private disposed = false
 
-  acquire(leaseId: string): OwnedApplicationCallerLease {
+  acquire(identity: Pick<CallerContext, 'leaseId' | 'surface'>): OwnedApplicationCallerLease {
     if (this.disposed) throw new Error('Application caller lease registry is disposed.')
+    const { leaseId, surface } = identity
+    const ownershipKey = `${surface}\u0000${leaseId}`
 
-    const previous = this.active.get(leaseId)
+    const previous = this.active.get(ownershipKey)
     if (previous) {
-      this.active.delete(leaseId)
+      this.active.delete(ownershipKey)
       previous.controller.abort()
     }
 
-    const generation = (this.generations.get(leaseId) ?? 0) + 1
-    this.generations.set(leaseId, generation)
+    const generation = ++this.nextGeneration
     const controller = new AbortController()
     const token = Object.freeze({})
     const lease: ApplicationCallerLease = Object.freeze({
       leaseId,
       generation,
       signal: controller.signal,
-      isCurrent: () => this.active.get(leaseId)?.token === token && !controller.signal.aborted
+      isCurrent: () => this.active.get(ownershipKey)?.token === token && !controller.signal.aborted
     })
+    leaseOwnershipKeys.set(lease, ownershipKey)
     const state: LeaseState = { token, controller }
-    this.active.set(leaseId, state)
+    this.active.set(ownershipKey, state)
 
     return Object.freeze({
       lease,
       release: () => {
-        if (this.active.get(leaseId) !== state) return
-        this.active.delete(leaseId)
+        if (this.active.get(ownershipKey) !== state) return
+        this.active.delete(ownershipKey)
         controller.abort()
       }
     })
@@ -72,5 +82,10 @@ class ApplicationCallerLeaseRegistry {
   }
 }
 
-export { ApplicationCallerLeaseRegistry, bindCallerLeaseToEvent, callerLeaseForEvent }
+export {
+  ApplicationCallerLeaseRegistry,
+  bindCallerLeaseToEvent,
+  callerLeaseForEvent,
+  callerLeaseOwnershipKey
+}
 export type { OwnedApplicationCallerLease }

--- a/src/main/ipc-handler-registry.test.ts
+++ b/src/main/ipc-handler-registry.test.ts
@@ -257,6 +257,85 @@ describe('createIpcHandlerRegistry', () => {
     registry.webRpc.dispose()
   })
 
+  it('starts fresh Web and Task lease epochs when handlers are registered after disposal', async () => {
+    const registry = createIpcHandlerRegistry({ handle: vi.fn() } as never)
+    registry.ipcMainHandle('projects:list', (event) => callerLeaseForEvent(event))
+
+    const disposedWebLease = (await registry.webRpc.invoke(
+      'projects:list',
+      createWebCallerContext('browser-1'),
+      []
+    )) as ApplicationCallerLease
+    const disposedTaskLease = (await registry.webRpc.invoke(
+      'projects:list',
+      createTaskCallerContext(),
+      []
+    )) as ApplicationCallerLease
+    registry.webRpc.dispose()
+
+    expect(disposedWebLease.signal.aborted).toBe(true)
+    expect(disposedWebLease.isCurrent()).toBe(false)
+    expect(disposedTaskLease.signal.aborted).toBe(true)
+    expect(disposedTaskLease.isCurrent()).toBe(false)
+
+    registry.ipcMainHandle('projects:list', (event) => callerLeaseForEvent(event))
+    const replacementWebLease = (await registry.webRpc.invoke(
+      'projects:list',
+      createWebCallerContext('browser-1'),
+      []
+    )) as ApplicationCallerLease
+    const replacementTaskLease = (await registry.webRpc.invoke(
+      'projects:list',
+      createTaskCallerContext(),
+      []
+    )) as ApplicationCallerLease
+
+    expect(replacementWebLease).not.toBe(disposedWebLease)
+    expect(replacementWebLease.signal).not.toBe(disposedWebLease.signal)
+    expect(replacementWebLease.signal.aborted).toBe(false)
+    expect(replacementWebLease.isCurrent()).toBe(true)
+    expect(replacementTaskLease).not.toBe(disposedTaskLease)
+    expect(replacementTaskLease.signal).not.toBe(disposedTaskLease.signal)
+    expect(replacementTaskLease.signal.aborted).toBe(false)
+    expect(replacementTaskLease.isCurrent()).toBe(true)
+
+    registry.webRpc.releaseClient('browser-1')
+    expect(replacementWebLease.signal.aborted).toBe(true)
+    expect(replacementTaskLease.signal.aborted).toBe(false)
+  })
+
+  it('keeps disposed native handler epochs terminal after later registrations', () => {
+    const nativeHandlers = new Map<string, (...args: unknown[]) => unknown>()
+    const registry = createIpcHandlerRegistry({
+      handle: (channel: string, handler: (...args: unknown[]) => unknown) =>
+        nativeHandlers.set(channel, handler)
+    } as never)
+    const initialHandler = vi.fn((event) => callerLeaseForEvent(event))
+    registry.ipcMainHandle('projects:list', initialHandler)
+    const disposedWrapper = nativeHandlers.get('projects:list')
+    const sender = { id: 42 }
+
+    const disposedLease = disposedWrapper?.({ sender }) as ApplicationCallerLease
+    registry.webRpc.dispose()
+
+    expect(() => disposedWrapper?.({ sender })).toThrow('registry is disposed')
+    expect(initialHandler).toHaveBeenCalledOnce()
+
+    const replacementHandler = vi.fn((event) => callerLeaseForEvent(event))
+    registry.ipcMainHandle('projects:list', replacementHandler)
+    const replacementLease = nativeHandlers.get('projects:list')?.({
+      sender
+    }) as ApplicationCallerLease
+
+    expect(() => disposedWrapper?.({ sender })).toThrow('registry is disposed')
+    expect(initialHandler).toHaveBeenCalledOnce()
+    expect(replacementHandler).toHaveBeenCalledOnce()
+    expect(disposedLease.signal.aborted).toBe(true)
+    expect(disposedLease.isCurrent()).toBe(false)
+    expect(replacementLease.signal.aborted).toBe(false)
+    expect(replacementLease.isCurrent()).toBe(true)
+  })
+
   it('lets in-flight Web work observe final client release without cancelling its result', async () => {
     const registry = createIpcHandlerRegistry({ handle: vi.fn() } as never)
     let resolve!: (value: string) => void

--- a/src/main/ipc-handler-registry.test.ts
+++ b/src/main/ipc-handler-registry.test.ts
@@ -30,6 +30,50 @@ describe('createIpcHandlerRegistry', () => {
     expect(handler).toHaveBeenCalledOnce()
   })
 
+  it('renews a crashed WebContents lease but keeps destroyed terminal', () => {
+    const nativeHandlers = new Map<string, (...args: unknown[]) => unknown>()
+    const registry = createIpcHandlerRegistry({
+      handle: (channel: string, handler: (...args: unknown[]) => unknown) =>
+        nativeHandlers.set(channel, handler)
+    } as never)
+    const listeners = new Map<string, Array<() => void>>()
+    const sender = {
+      id: 42,
+      once: (name: string, listener: () => void): void => {
+        const registered = listeners.get(name) ?? []
+        registered.push(listener)
+        listeners.set(name, registered)
+      }
+    }
+    const dispatchedEvents: Array<{ sender: object }> = []
+    const handler = vi.fn((event: { sender: object }) => {
+      dispatchedEvents.push(event)
+      return callerLeaseForEvent(event)
+    })
+    registry.ipcMainHandle('projects:list', handler)
+
+    const first = nativeHandlers.get('projects:list')?.({ sender }) as {
+      generation: number
+      signal: AbortSignal
+    }
+    listeners.get('render-process-gone')?.[0]?.()
+    const replacement = nativeHandlers.get('projects:list')?.({ sender }) as typeof first
+
+    expect(replacement.generation).toBeGreaterThan(first.generation)
+    expect(replacement.signal.aborted).toBe(false)
+    expect(callerLeaseForEvent(dispatchedEvents[0])).toBe(first)
+    expect(callerLeaseForEvent(dispatchedEvents[1])).toBe(replacement)
+    listeners.get('render-process-gone')?.[0]?.()
+    expect(replacement.signal.aborted).toBe(false)
+
+    for (const destroyed of listeners.get('destroyed') ?? []) destroyed()
+    expect(replacement.signal.aborted).toBe(true)
+    expect(() => nativeHandlers.get('projects:list')?.({ sender })).toThrow(
+      'Caller lease is no longer current.'
+    )
+    expect(handler).toHaveBeenCalledTimes(2)
+  })
+
   it('keeps a replacement Electron generation isolated from stale teardown callbacks', () => {
     const nativeHandlers = new Map<string, (...args: unknown[]) => unknown>()
     const registry = createIpcHandlerRegistry({
@@ -61,6 +105,32 @@ describe('createIpcHandlerRegistry', () => {
 
     expect(replacement.generation).toBeGreaterThan(first.generation)
     expect(replacement.signal.aborted).toBe(false)
+  })
+
+  it('keeps caller-controlled Web lease ids isolated from Electron ownership', async () => {
+    const nativeHandlers = new Map<string, (...args: unknown[]) => unknown>()
+    const registry = createIpcHandlerRegistry({
+      handle: (channel: string, handler: (...args: unknown[]) => unknown) =>
+        nativeHandlers.set(channel, handler)
+    } as never)
+    registry.ipcMainHandle('projects:list', (event) => callerLeaseForEvent(event))
+
+    const electronLease = nativeHandlers.get('projects:list')?.({ sender: { id: 7 } }) as {
+      leaseId: string
+      signal: AbortSignal
+      isCurrent: () => boolean
+    }
+    const webLease = (await registry.webRpc.invoke(
+      'projects:list',
+      createWebCallerContext('electron:7'),
+      []
+    )) as typeof electronLease
+
+    expect(electronLease.leaseId).toBe('electron:7')
+    expect(webLease.leaseId).toBe('electron:7')
+    expect(electronLease.signal.aborted).toBe(false)
+    expect(electronLease.isCurrent()).toBe(true)
+    expect(webLease.isCurrent()).toBe(true)
   })
 
   it('registers every native handler but routes only allowlisted Web RPC channels', async () => {

--- a/src/main/ipc-handler-registry.test.ts
+++ b/src/main/ipc-handler-registry.test.ts
@@ -1,9 +1,68 @@
 import { describe, expect, it, vi } from 'vitest'
 
+import { callerLeaseForEvent } from './caller-lifecycle'
 import { createWebCallerContext } from './caller-context'
 import { createIpcHandlerRegistry } from './ipc-handler-registry'
 
 describe('createIpcHandlerRegistry', () => {
+  it('aborts a native surface lease before a destroyed sender can dispatch again', () => {
+    const nativeHandlers = new Map<string, (...args: unknown[]) => unknown>()
+    const registry = createIpcHandlerRegistry({
+      handle: (channel: string, handler: (...args: unknown[]) => unknown) =>
+        nativeHandlers.set(channel, handler)
+    } as never)
+    const listeners = new Map<string, () => void>()
+    const sender = {
+      id: 42,
+      once: (name: string, listener: () => void) => listeners.set(name, listener)
+    }
+    const handler = vi.fn((event) => callerLeaseForEvent(event))
+    registry.ipcMainHandle('projects:list', handler)
+
+    const lease = nativeHandlers.get('projects:list')?.({ sender })
+    expect(lease).toMatchObject({ leaseId: 'electron:42', generation: 1 })
+
+    listeners.get('destroyed')?.()
+    expect((lease as { signal: AbortSignal }).signal.aborted).toBe(true)
+    expect(() => nativeHandlers.get('projects:list')?.({ sender })).toThrow(
+      'Caller lease is no longer current.'
+    )
+    expect(handler).toHaveBeenCalledOnce()
+  })
+
+  it('keeps a replacement Electron generation isolated from stale teardown callbacks', () => {
+    const nativeHandlers = new Map<string, (...args: unknown[]) => unknown>()
+    const registry = createIpcHandlerRegistry({
+      handle: (channel: string, handler: (...args: unknown[]) => unknown) =>
+        nativeHandlers.set(channel, handler)
+    } as never)
+    const sender = (
+      listeners: Map<string, () => void>
+    ): { id: number; once: (name: string, listener: () => void) => void } => ({
+      id: 7,
+      once: (name: string, listener: () => void) => {
+        listeners.set(name, listener)
+      }
+    })
+    registry.ipcMainHandle('projects:list', (event) => callerLeaseForEvent(event))
+
+    const firstListeners = new Map<string, () => void>()
+    const first = nativeHandlers.get('projects:list')?.({ sender: sender(firstListeners) }) as {
+      generation: number
+      signal: AbortSignal
+    }
+    firstListeners.get('destroyed')?.()
+
+    const replacementListeners = new Map<string, () => void>()
+    const replacement = nativeHandlers.get('projects:list')?.({
+      sender: sender(replacementListeners)
+    }) as typeof first
+    firstListeners.get('render-process-gone')?.()
+
+    expect(replacement.generation).toBeGreaterThan(first.generation)
+    expect(replacement.signal.aborted).toBe(false)
+  })
+
   it('registers every native handler but routes only allowlisted Web RPC channels', async () => {
     const nativeHandlers = new Map<string, (...args: unknown[]) => unknown>()
     const handle = vi.fn((channel: string, handler: (...args: unknown[]) => unknown) => {
@@ -70,6 +129,32 @@ describe('createIpcHandlerRegistry', () => {
     expect(reconnected.lifecycleClientId).toBe(first.lifecycleClientId)
     expect(handle).toHaveBeenCalledTimes(1)
     registry.webRpc.dispose()
+  })
+
+  it('lets in-flight Web work observe final client release without cancelling its result', async () => {
+    const registry = createIpcHandlerRegistry({ handle: vi.fn() } as never)
+    let resolve!: (value: string) => void
+    const pending = new Promise<string>((complete) => (resolve = complete))
+    const observedRelease = vi.fn()
+    registry.ipcMainHandle('projects:list', (event: unknown) => {
+      callerLeaseForEvent(event as { sender: object }).signal.addEventListener(
+        'abort',
+        observedRelease,
+        { once: true }
+      )
+      return pending
+    })
+
+    const invocation = registry.webRpc.invoke(
+      'projects:list',
+      createWebCallerContext('browser-1'),
+      []
+    )
+    registry.webRpc.releaseClient('browser-1')
+    resolve('complete')
+
+    await expect(invocation).resolves.toBe('complete')
+    expect(observedRelease).toHaveBeenCalledOnce()
   })
 
   it('scopes remote pairing authority to the current Web RPC invocation', async () => {

--- a/src/main/ipc-handler-registry.test.ts
+++ b/src/main/ipc-handler-registry.test.ts
@@ -1,8 +1,10 @@
 import { describe, expect, it, vi } from 'vitest'
 
+import type { ApplicationCallerLease } from './application-command-router'
 import { callerLeaseForEvent } from './caller-lifecycle'
-import { createWebCallerContext } from './caller-context'
+import { createTaskCallerContext, createWebCallerContext } from './caller-context'
 import { createIpcHandlerRegistry } from './ipc-handler-registry'
+import { createManagedPreviewOwnerRegistry } from './managed-preview-ipc'
 
 describe('createIpcHandlerRegistry', () => {
   it('aborts a native surface lease before a destroyed sender can dispatch again', () => {
@@ -131,6 +133,47 @@ describe('createIpcHandlerRegistry', () => {
     expect(electronLease.signal.aborted).toBe(false)
     expect(electronLease.isCurrent()).toBe(true)
     expect(webLease.isCurrent()).toBe(true)
+  })
+
+  it('keeps colliding Web and Task callers isolated when the Web client is released', async () => {
+    const registry = createIpcHandlerRegistry({ handle: vi.fn() } as never)
+    registry.ipcMainHandle('projects:list', (event) => callerLeaseForEvent(event))
+
+    const webLease = (await registry.webRpc.invoke(
+      'projects:list',
+      createWebCallerContext('headless-task-api'),
+      []
+    )) as ApplicationCallerLease
+    const taskLease = (await registry.webRpc.invoke(
+      'projects:list',
+      createTaskCallerContext(),
+      []
+    )) as ApplicationCallerLease
+    const resources = {
+      acquire: vi.fn(),
+      readRange: vi.fn(),
+      release: vi.fn(),
+      releaseOwner: vi.fn()
+    }
+    const owners = createManagedPreviewOwnerRegistry(resources as never)
+    const webOwner = owners.register(webLease)
+    const taskOwner = owners.register(taskLease)
+
+    expect(taskLease).not.toBe(webLease)
+    expect(taskLease.signal).not.toBe(webLease.signal)
+    expect(taskOwner.ownerId).not.toBe(webOwner.ownerId)
+
+    registry.webRpc.releaseClient('headless-task-api')
+
+    expect(webLease.signal.aborted).toBe(true)
+    expect(taskLease.signal.aborted).toBe(false)
+    expect(taskLease.isCurrent()).toBe(true)
+    expect(resources.releaseOwner).toHaveBeenCalledOnce()
+    expect(resources.releaseOwner).toHaveBeenCalledWith(webOwner.ownerId)
+    expect(owners.register(taskLease)).toBe(taskOwner)
+
+    registry.webRpc.dispose()
+    expect(taskLease.signal.aborted).toBe(true)
   })
 
   it('registers every native handler but routes only allowlisted Web RPC channels', async () => {

--- a/src/main/ipc-handler-registry.test.ts
+++ b/src/main/ipc-handler-registry.test.ts
@@ -7,6 +7,19 @@ import { createIpcHandlerRegistry } from './ipc-handler-registry'
 import { createManagedPreviewOwnerRegistry } from './managed-preview-ipc'
 
 describe('createIpcHandlerRegistry', () => {
+  it('keeps injected handler registrars callable without an Electron event', () => {
+    const nativeHandlers = new Map<string, (...args: unknown[]) => unknown>()
+    const registry = createIpcHandlerRegistry({
+      handle: (channel: string, handler: (...args: unknown[]) => unknown) =>
+        nativeHandlers.set(channel, handler)
+    } as never)
+    const handler = vi.fn(() => 'complete')
+    registry.ipcMainHandle('test:direct-handler', handler)
+
+    expect(nativeHandlers.get('test:direct-handler')?.(undefined)).toBe('complete')
+    expect(handler).toHaveBeenCalledWith(undefined)
+  })
+
   it('aborts a native surface lease before a destroyed sender can dispatch again', () => {
     const nativeHandlers = new Map<string, (...args: unknown[]) => unknown>()
     const registry = createIpcHandlerRegistry({

--- a/src/main/ipc-handler-registry.ts
+++ b/src/main/ipc-handler-registry.ts
@@ -191,10 +191,16 @@ const createIpcHandlerRegistry = (
         channel,
         callerContext: diagnosticCallerContextForEvent(event),
         invoke: () => {
-          const { lease } = nativeCallerLease(event)
-          bindCallerLeaseToEvent(event, lease)
+          // Electron always supplies an invoke event. Isolated handler registrars historically call
+          // their injected target without Electron, so keep that pure test seam lease-neutral.
+          const invokedEvent = event as IpcMainInvokeEvent | undefined
+          if (!invokedEvent?.sender || typeof invokedEvent.sender !== 'object') {
+            return listener(event, ...args)
+          }
+          const { lease } = nativeCallerLease(invokedEvent)
+          bindCallerLeaseToEvent(invokedEvent, lease)
           assertCurrentLease(lease)
-          return listener(event, ...args)
+          return listener(invokedEvent, ...args)
         },
         log: diagnosticLog,
         now: diagnostics.now

--- a/src/main/ipc-handler-registry.ts
+++ b/src/main/ipc-handler-registry.ts
@@ -3,7 +3,12 @@ import { EventEmitter } from 'node:events'
 import { ipcMain, type IpcMain, type IpcMainInvokeEvent } from 'electron'
 
 import { isWebRpcChannel } from '../shared/web-rpc-contract'
-import { callerContextForEvent, hasCallerAuthority, type CallerContext } from './caller-context'
+import { callerContextForEvent, type CallerContext } from './caller-context'
+import {
+  ApplicationCallerLeaseRegistry,
+  bindCallerLeaseToEvent,
+  type OwnedApplicationCallerLease
+} from './caller-lifecycle'
 import {
   invokeWithIpcRejectionDiagnostics,
   type IpcRejectionLogger
@@ -101,22 +106,58 @@ const createIpcHandlerRegistry = (
     } satisfies IpcRejectionLogger)
   const webHandlers = new Map<string, IpcHandler>()
   const registeredChannels = new Set<string>()
-  const clients = new Map<string, { id: number; lifecycle: EventEmitter }>()
+  const clients = new Map<
+    string,
+    { id: number; lifecycle: EventEmitter; callerLease: OwnedApplicationCallerLease }
+  >()
+  const callerLeases = new ApplicationCallerLeaseRegistry()
+  const nativeCallers = new WeakMap<object, OwnedApplicationCallerLease>()
   let nextSenderId = -1
 
-  const senderFor = (callerContext: CallerContext): WebIpcSender => {
+  const nativeCallerLease = (event: IpcMainInvokeEvent): OwnedApplicationCallerLease => {
+    const sender = event.sender as object
+    const existing = nativeCallers.get(sender)
+    if (existing) return existing
+
+    const ownedLease = callerLeases.acquire(callerContextForEvent(event).leaseId)
+    nativeCallers.set(sender, ownedLease)
+    const lifecycleSender = event.sender as typeof event.sender & {
+      once?: (name: string, listener: () => void) => unknown
+    }
+    lifecycleSender.once?.('destroyed', ownedLease.release)
+    lifecycleSender.once?.('render-process-gone', ownedLease.release)
+    return ownedLease
+  }
+
+  const assertCurrentLease = (lease: OwnedApplicationCallerLease['lease']): void => {
+    if (lease.signal.aborted || !lease.isCurrent()) {
+      throw new Error('Caller lease is no longer current.')
+    }
+  }
+
+  const senderFor = (
+    callerContext: CallerContext
+  ): { sender: WebIpcSender; lease: OwnedApplicationCallerLease['lease'] } => {
     let client = clients.get(callerContext.clientId)
     if (!client) {
-      client = { id: nextSenderId--, lifecycle: new EventEmitter() }
+      client = {
+        id: nextSenderId--,
+        lifecycle: new EventEmitter(),
+        callerLease: callerLeases.acquire(callerContext.leaseId)
+      }
       clients.set(callerContext.clientId, client)
     }
-    return new WebIpcSender(client.id, callerContext, client.lifecycle)
+    return {
+      sender: new WebIpcSender(client.id, callerContext, client.lifecycle),
+      lease: client.callerLease.lease
+    }
   }
 
   const destroyClient = (clientId: string): void => {
     const client = clients.get(clientId)
     if (!client) return
     clients.delete(clientId)
+    client.callerLease.release()
     client.lifecycle.emit('destroyed')
     client.lifecycle.removeAllListeners()
   }
@@ -126,7 +167,12 @@ const createIpcHandlerRegistry = (
       invokeWithIpcRejectionDiagnostics({
         channel,
         callerContext: diagnosticCallerContextForEvent(event),
-        invoke: () => listener(event, ...args),
+        invoke: () => {
+          const { lease } = nativeCallerLease(event)
+          bindCallerLeaseToEvent(event, lease)
+          assertCurrentLease(lease)
+          return listener(event, ...args)
+        },
         log: diagnosticLog,
         now: diagnostics.now
       })
@@ -183,8 +229,10 @@ const createIpcHandlerRegistry = (
         if (!callerContext.isAuthorizationCurrent()) {
           throw new Error('Caller authorization is no longer current.')
         }
-        const sender = senderFor(callerContext)
+        const { sender, lease } = senderFor(callerContext)
         const event = { sender } as unknown as IpcMainInvokeEvent
+        bindCallerLeaseToEvent(event, lease)
+        assertCurrentLease(lease)
         return invokeWithIpcRejectionDiagnostics({
           channel,
           callerContext,
@@ -196,15 +244,13 @@ const createIpcHandlerRegistry = (
       releaseClient: destroyClient,
       dispose: () => {
         for (const clientId of [...clients.keys()]) destroyClient(clientId)
+        callerLeases.dispose()
         webHandlers.clear()
       },
       channels: () => [...webHandlers.keys()].sort()
     }
   }
 }
-
-const isRemotePairingManagerSender = (event: IpcMainInvokeEvent): boolean =>
-  hasCallerAuthority(callerContextForEvent(event), 'manage-remote-pairing')
 
 const defaultRegistry = createIpcHandlerRegistry(ipcMain)
 
@@ -213,11 +259,5 @@ const webRpc = defaultRegistry.webRpc
 const createIpcHandlerInstallationScope = (): IpcHandlerInstallationScope =>
   defaultRegistry.createInstallationScope()
 
-export {
-  createIpcHandlerInstallationScope,
-  createIpcHandlerRegistry,
-  ipcMainHandle,
-  isRemotePairingManagerSender,
-  webRpc
-}
+export { createIpcHandlerInstallationScope, createIpcHandlerRegistry, ipcMainHandle, webRpc }
 export type { IpcHandlerInstallation, IpcHandlerInstallationScope, IpcHandlerRegistryDiagnostics }

--- a/src/main/ipc-handler-registry.ts
+++ b/src/main/ipc-handler-registry.ts
@@ -81,6 +81,18 @@ type IpcHandlerRegistryDiagnostics = {
   now?: () => number
 }
 
+type CallerLeaseEpoch = {
+  registry: ApplicationCallerLeaseRegistry
+  nativeCallers: WeakMap<object, OwnedApplicationCallerLease>
+  disposed: boolean
+}
+
+const createCallerLeaseEpoch = (): CallerLeaseEpoch => ({
+  registry: new ApplicationCallerLeaseRegistry(),
+  nativeCallers: new WeakMap(),
+  disposed: false
+})
+
 const diagnosticCallerContextForEvent = (
   event: IpcMainInvokeEvent
 ): Pick<CallerContext, 'surface' | 'location' | 'principalKind' | 'actionOrigin'> => {
@@ -117,21 +129,28 @@ const createIpcHandlerRegistry = (
       callerLease: OwnedApplicationCallerLease
     }
   >()
-  const callerLeases = new ApplicationCallerLeaseRegistry()
-  const nativeCallers = new WeakMap<object, OwnedApplicationCallerLease>()
+  let activeCallerLeaseEpoch = createCallerLeaseEpoch()
   const destroyedNativeCallers = new WeakSet<object>()
   let nextSenderId = -1
 
-  const nativeCallerLease = (event: IpcMainInvokeEvent): OwnedApplicationCallerLease => {
+  const callerLeaseEpochForRegistration = (): CallerLeaseEpoch => {
+    if (activeCallerLeaseEpoch.disposed) activeCallerLeaseEpoch = createCallerLeaseEpoch()
+    return activeCallerLeaseEpoch
+  }
+
+  const nativeCallerLease = (
+    epoch: CallerLeaseEpoch,
+    event: IpcMainInvokeEvent
+  ): OwnedApplicationCallerLease => {
     const sender = event.sender as object
     if (destroyedNativeCallers.has(sender)) {
       throw new Error('Caller lease is no longer current.')
     }
-    const existing = nativeCallers.get(sender)
+    const existing = epoch.nativeCallers.get(sender)
     if (existing && !existing.lease.signal.aborted && existing.lease.isCurrent()) return existing
 
-    const ownedLease = callerLeases.acquire(callerContextForEvent(event))
-    nativeCallers.set(sender, ownedLease)
+    const ownedLease = epoch.registry.acquire(callerContextForEvent(event))
+    epoch.nativeCallers.set(sender, ownedLease)
     const lifecycleSender = event.sender as typeof event.sender & {
       once?: (name: string, listener: () => void) => unknown
     }
@@ -160,7 +179,7 @@ const createIpcHandlerRegistry = (
         clientId: callerContext.clientId,
         surface: callerContext.surface,
         lifecycle: new EventEmitter(),
-        callerLease: callerLeases.acquire(callerContext)
+        callerLease: activeCallerLeaseEpoch.registry.acquire(callerContext)
       }
       clients.set(ownershipKey, client)
     }
@@ -186,6 +205,7 @@ const createIpcHandlerRegistry = (
   }
 
   const ipcMainHandle: IpcMain['handle'] = (channel, listener) => {
+    const callerLeaseEpoch = callerLeaseEpochForRegistration()
     target.handle(channel, (event, ...args) =>
       invokeWithIpcRejectionDiagnostics({
         channel,
@@ -197,7 +217,7 @@ const createIpcHandlerRegistry = (
           if (!invokedEvent?.sender || typeof invokedEvent.sender !== 'object') {
             return listener(event, ...args)
           }
-          const { lease } = nativeCallerLease(invokedEvent)
+          const { lease } = nativeCallerLease(callerLeaseEpoch, invokedEvent)
           bindCallerLeaseToEvent(invokedEvent, lease)
           assertCurrentLease(lease)
           return listener(invokedEvent, ...args)
@@ -273,7 +293,8 @@ const createIpcHandlerRegistry = (
       releaseClient: releaseWebClient,
       dispose: () => {
         for (const ownershipKey of [...clients.keys()]) destroyClient(ownershipKey)
-        callerLeases.dispose()
+        activeCallerLeaseEpoch.registry.dispose()
+        activeCallerLeaseEpoch.disposed = true
         webHandlers.clear()
       },
       channels: () => [...webHandlers.keys()].sort()

--- a/src/main/ipc-handler-registry.ts
+++ b/src/main/ipc-handler-registry.ts
@@ -7,6 +7,7 @@ import { callerContextForEvent, type CallerContext } from './caller-context'
 import {
   ApplicationCallerLeaseRegistry,
   bindCallerLeaseToEvent,
+  callerLeaseOwnershipKeyForContext,
   type OwnedApplicationCallerLease
 } from './caller-lifecycle'
 import {
@@ -108,7 +109,13 @@ const createIpcHandlerRegistry = (
   const registeredChannels = new Set<string>()
   const clients = new Map<
     string,
-    { id: number; lifecycle: EventEmitter; callerLease: OwnedApplicationCallerLease }
+    {
+      id: number
+      clientId: string
+      surface: CallerContext['surface']
+      lifecycle: EventEmitter
+      callerLease: OwnedApplicationCallerLease
+    }
   >()
   const callerLeases = new ApplicationCallerLeaseRegistry()
   const nativeCallers = new WeakMap<object, OwnedApplicationCallerLease>()
@@ -145,14 +152,17 @@ const createIpcHandlerRegistry = (
   const senderFor = (
     callerContext: CallerContext
   ): { sender: WebIpcSender; lease: OwnedApplicationCallerLease['lease'] } => {
-    let client = clients.get(callerContext.clientId)
+    const ownershipKey = callerLeaseOwnershipKeyForContext(callerContext)
+    let client = clients.get(ownershipKey)
     if (!client) {
       client = {
         id: nextSenderId--,
+        clientId: callerContext.clientId,
+        surface: callerContext.surface,
         lifecycle: new EventEmitter(),
         callerLease: callerLeases.acquire(callerContext)
       }
-      clients.set(callerContext.clientId, client)
+      clients.set(ownershipKey, client)
     }
     return {
       sender: new WebIpcSender(client.id, callerContext, client.lifecycle),
@@ -160,13 +170,19 @@ const createIpcHandlerRegistry = (
     }
   }
 
-  const destroyClient = (clientId: string): void => {
-    const client = clients.get(clientId)
+  const destroyClient = (ownershipKey: string): void => {
+    const client = clients.get(ownershipKey)
     if (!client) return
-    clients.delete(clientId)
+    clients.delete(ownershipKey)
     client.callerLease.release()
     client.lifecycle.emit('destroyed')
     client.lifecycle.removeAllListeners()
+  }
+
+  const releaseWebClient = (clientId: string): void => {
+    for (const [ownershipKey, client] of clients) {
+      if (client.surface === 'web' && client.clientId === clientId) destroyClient(ownershipKey)
+    }
   }
 
   const ipcMainHandle: IpcMain['handle'] = (channel, listener) => {
@@ -248,9 +264,9 @@ const createIpcHandlerRegistry = (
           now: diagnostics.now
         })
       },
-      releaseClient: destroyClient,
+      releaseClient: releaseWebClient,
       dispose: () => {
-        for (const clientId of [...clients.keys()]) destroyClient(clientId)
+        for (const ownershipKey of [...clients.keys()]) destroyClient(ownershipKey)
         callerLeases.dispose()
         webHandlers.clear()
       },

--- a/src/main/ipc-handler-registry.ts
+++ b/src/main/ipc-handler-registry.ts
@@ -112,19 +112,26 @@ const createIpcHandlerRegistry = (
   >()
   const callerLeases = new ApplicationCallerLeaseRegistry()
   const nativeCallers = new WeakMap<object, OwnedApplicationCallerLease>()
+  const destroyedNativeCallers = new WeakSet<object>()
   let nextSenderId = -1
 
   const nativeCallerLease = (event: IpcMainInvokeEvent): OwnedApplicationCallerLease => {
     const sender = event.sender as object
+    if (destroyedNativeCallers.has(sender)) {
+      throw new Error('Caller lease is no longer current.')
+    }
     const existing = nativeCallers.get(sender)
-    if (existing) return existing
+    if (existing && !existing.lease.signal.aborted && existing.lease.isCurrent()) return existing
 
-    const ownedLease = callerLeases.acquire(callerContextForEvent(event).leaseId)
+    const ownedLease = callerLeases.acquire(callerContextForEvent(event))
     nativeCallers.set(sender, ownedLease)
     const lifecycleSender = event.sender as typeof event.sender & {
       once?: (name: string, listener: () => void) => unknown
     }
-    lifecycleSender.once?.('destroyed', ownedLease.release)
+    lifecycleSender.once?.('destroyed', () => {
+      destroyedNativeCallers.add(sender)
+      ownedLease.release()
+    })
     lifecycleSender.once?.('render-process-gone', ownedLease.release)
     return ownedLease
   }
@@ -143,7 +150,7 @@ const createIpcHandlerRegistry = (
       client = {
         id: nextSenderId--,
         lifecycle: new EventEmitter(),
-        callerLease: callerLeases.acquire(callerContext.leaseId)
+        callerLease: callerLeases.acquire(callerContext)
       }
       clients.set(callerContext.clientId, client)
     }

--- a/src/main/lifecycle-broadcast.test.ts
+++ b/src/main/lifecycle-broadcast.test.ts
@@ -17,7 +17,7 @@ vi.mock('./renderer-broadcast', () => ({
   broadcastToRenderers: vi.fn()
 }))
 
-import { registerLifecycleIpcHandlers } from './lifecycle-broadcast'
+import { getLifecycleClientId, registerLifecycleIpcHandlers } from './lifecycle-broadcast'
 
 describe('lifecycle broadcast IPC', () => {
   beforeEach(() => ipcHandlers.clear())
@@ -29,6 +29,12 @@ describe('lifecycle broadcast IPC', () => {
     expect(getClientId?.({ sender: { id: 42 } })).toBe('electron:42')
     expect(getClientId?.({ sender: { id: -2, lifecycleClientId: 'web:browser-1' } })).toBe(
       'web:browser-1'
+    )
+  })
+
+  it('requires the surface adapter to bind a caller lease', () => {
+    expect(() => getLifecycleClientId({ sender: { id: 42 } })).toThrow(
+      'Application caller lease is not bound to this event'
     )
   })
 })

--- a/src/main/lifecycle-broadcast.ts
+++ b/src/main/lifecycle-broadcast.ts
@@ -1,6 +1,7 @@
 import { ipcMainHandle } from './ipc-handler-registry'
 
 import { LIFECYCLE_CHANNELS } from '../shared/lifecycle-events'
+import { callerLeaseForEvent } from './caller-lifecycle'
 import { callerContextForEvent, type CallerContext } from './caller-context'
 import { createLogger } from './logger'
 import type { ApplicationEventChannel, ApplicationEventMap } from './application-events'
@@ -26,7 +27,14 @@ const broadcastLifecycleEvent = <Channel extends ApplicationEventChannel>(
 
 const getLifecycleClientId = (event: {
   sender: { id: number; callerContext?: CallerContext; lifecycleClientId?: string }
-}): string => callerContextForEvent(event).lifecycleClientId
+}): string => {
+  const context = callerContextForEvent(event)
+  const lease = callerLeaseForEvent(event)
+  if (lease.leaseId !== context.leaseId || !lease.isCurrent()) {
+    throw new Error('Application caller lease is no longer current.')
+  }
+  return context.lifecycleClientId
+}
 
 const registerLifecycleIpcHandlers = (): void => {
   ipcMainHandle(LIFECYCLE_CHANNELS.clientId, (event) => getLifecycleClientId(event))

--- a/src/main/managed-preview-ipc.test.ts
+++ b/src/main/managed-preview-ipc.test.ts
@@ -3,6 +3,7 @@ import type { IpcMainInvokeEvent } from 'electron'
 import { describe, expect, it, vi } from 'vitest'
 
 import type { ManagedPreviewResource } from '../shared/preview-resources'
+import { createElectronCallerContext, createWebCallerContext } from './caller-context'
 import { ApplicationCallerLeaseRegistry } from './caller-lifecycle'
 import type { ManagedPreviewResources } from './managed-preview-resources'
 import {
@@ -61,7 +62,7 @@ describe('managed preview IPC handlers', () => {
   it('uses an opaque negative owner scoped to the caller lease', () => {
     const resources = createResources()
     const lifecycle = new ApplicationCallerLeaseRegistry()
-    const caller = lifecycle.acquire('electron:42')
+    const caller = lifecycle.acquire(createElectronCallerContext(42))
     const owners = createManagedPreviewOwnerRegistry(resources)
 
     const ticket = owners.register(caller.lease)
@@ -85,7 +86,7 @@ describe('managed preview IPC handlers', () => {
       )
     })
     const lifecycle = new ApplicationCallerLeaseRegistry()
-    const caller = lifecycle.acquire('electron:42')
+    const caller = lifecycle.acquire(createElectronCallerContext(42))
     const owners = createManagedPreviewOwnerRegistry(resources)
 
     const acquire = owners.acquire(caller.lease, {
@@ -104,7 +105,7 @@ describe('managed preview IPC handlers', () => {
     const resource = previewResource('fresh-resource')
     const resources = createResources({ acquire: vi.fn().mockResolvedValue(resource) })
     const lifecycle = new ApplicationCallerLeaseRegistry()
-    const caller = lifecycle.acquire('electron:99')
+    const caller = lifecycle.acquire(createElectronCallerContext(99))
     const owners = createManagedPreviewOwnerRegistry(resources)
 
     await expect(
@@ -116,7 +117,7 @@ describe('managed preview IPC handlers', () => {
   it('reuses one preview owner for the same active caller generation', () => {
     const resources = createResources()
     const lifecycle = new ApplicationCallerLeaseRegistry()
-    const caller = lifecycle.acquire('electron:7')
+    const caller = lifecycle.acquire(createElectronCallerContext(7))
     const owners = createManagedPreviewOwnerRegistry(resources)
 
     const ticketA = owners.register(caller.lease)
@@ -126,14 +127,30 @@ describe('managed preview IPC handlers', () => {
     expect(resources.releaseOwner).not.toHaveBeenCalled()
   })
 
+  it('keeps preview owners distinct when public lease ids collide across surfaces', () => {
+    const resources = createResources()
+    const lifecycle = new ApplicationCallerLeaseRegistry()
+    const owners = createManagedPreviewOwnerRegistry(resources)
+    const electron = lifecycle.acquire(createElectronCallerContext(7))
+    const web = lifecycle.acquire(createWebCallerContext('electron:7'))
+
+    const electronTicket = owners.register(electron.lease)
+    const webTicket = owners.register(web.lease)
+
+    expect(webTicket.ownerId).not.toBe(electronTicket.ownerId)
+    expect(owners.register(electron.lease)).toBe(electronTicket)
+    expect(resources.releaseOwner).not.toHaveBeenCalled()
+  })
+
   it('isolates a replacement generation from a stale release', () => {
     const resources = createResources()
     const lifecycle = new ApplicationCallerLeaseRegistry()
     const owners = createManagedPreviewOwnerRegistry(resources)
-    const first = lifecycle.acquire('electron:13')
+    const context = createElectronCallerContext(13)
+    const first = lifecycle.acquire(context)
     const initialTicket = owners.register(first.lease)
 
-    const replacement = lifecycle.acquire('electron:13')
+    const replacement = lifecycle.acquire(context)
     const replacementTicket = owners.register(replacement.lease)
     first.release()
 
@@ -141,6 +158,10 @@ describe('managed preview IPC handlers', () => {
     expect(replacementTicket.ownerId).not.toBe(initialTicket.ownerId)
     expect(resources.releaseOwner).toHaveBeenCalledOnce()
     expect(resources.releaseOwner).toHaveBeenCalledWith(initialTicket.ownerId)
+
+    expect(() => owners.register(first.lease)).toThrow(/owner is no longer available/i)
+    expect(owners.register(replacement.lease)).toBe(replacementTicket)
+    expect(resources.releaseOwner).toHaveBeenCalledOnce()
 
     replacement.release()
     expect(resources.releaseOwner).toHaveBeenLastCalledWith(replacementTicket.ownerId)
@@ -153,7 +174,7 @@ describe('managed preview IPC handlers', () => {
     })
     const resources = createResources({ acquire: vi.fn().mockImplementation(() => pendingAcquire) })
     const lifecycle = new ApplicationCallerLeaseRegistry()
-    const caller = lifecycle.acquire('electron:31')
+    const caller = lifecycle.acquire(createElectronCallerContext(31))
     const owners = createManagedPreviewOwnerRegistry(resources)
 
     const acquire = owners.acquire(caller.lease, {

--- a/src/main/managed-preview-ipc.test.ts
+++ b/src/main/managed-preview-ipc.test.ts
@@ -3,6 +3,7 @@ import type { IpcMainInvokeEvent } from 'electron'
 import { describe, expect, it, vi } from 'vitest'
 
 import type { ManagedPreviewResource } from '../shared/preview-resources'
+import { ApplicationCallerLeaseRegistry } from './caller-lifecycle'
 import type { ManagedPreviewResources } from './managed-preview-resources'
 import {
   createManagedPreviewOwnerRegistry,
@@ -37,279 +38,217 @@ const createFakeEvent = (
   }
 }
 
+const previewResource = (id: string): ManagedPreviewResource => ({
+  id,
+  url: `open-science-preview://${id}/report.pdf`,
+  size: 8,
+  mimeType: 'application/pdf',
+  version: 1
+})
+
+const createResources = (
+  overrides: Partial<ManagedPreviewResources> = {}
+): ManagedPreviewResources =>
+  ({
+    acquire: vi.fn(),
+    readRange: vi.fn(),
+    release: vi.fn(),
+    releaseOwner: vi.fn(),
+    ...overrides
+  }) as unknown as ManagedPreviewResources
+
 describe('managed preview IPC handlers', () => {
-  it('releases owner resources once when the renderer process exits', () => {
-    const resources = {
-      acquire: vi.fn(),
-      readRange: vi.fn(),
-      release: vi.fn(),
-      releaseOwner: vi.fn()
-    } as unknown as ManagedPreviewResources
-    const { event, listeners } = createFakeEvent(42)
+  it('uses an opaque negative owner scoped to the caller lease', () => {
+    const resources = createResources()
+    const lifecycle = new ApplicationCallerLeaseRegistry()
+    const caller = lifecycle.acquire('electron:42')
     const owners = createManagedPreviewOwnerRegistry(resources)
 
-    expect(owners.register(event as never).ownerId).toBe(42)
-    expect(event.sender.once).toHaveBeenCalledWith('destroyed', expect.any(Function))
-    expect(event.sender.once).toHaveBeenCalledWith('render-process-gone', expect.any(Function))
+    const ticket = owners.register(caller.lease)
+    expect(ticket.ownerId).toBeLessThan(0)
 
-    listeners.get('render-process-gone')?.()
-    listeners.get('destroyed')?.()
-    expect(resources.releaseOwner).toHaveBeenCalledTimes(1)
-    expect(resources.releaseOwner).toHaveBeenCalledWith(42)
+    caller.release()
+    caller.release()
+    expect(resources.releaseOwner).toHaveBeenCalledOnce()
+    expect(resources.releaseOwner).toHaveBeenCalledWith(ticket.ownerId)
   })
 
-  it('releases a resource acquired after its owner process has exited', async () => {
+  it('releases a resource acquired after its caller lease ends', async () => {
     let resolveAcquire: ((resource: ManagedPreviewResource) => void) | undefined
-    const resource = {
-      id: 'late-resource',
-      url: 'open-science-preview://late-resource/report.pdf',
-      size: 8,
-      mimeType: 'application/pdf',
-      version: 1
-    }
-    const resources = {
+    const resource = previewResource('late-resource')
+    const resources = createResources({
       acquire: vi.fn(
         () =>
           new Promise<ManagedPreviewResource>((resolve) => {
             resolveAcquire = resolve
           })
-      ),
-      readRange: vi.fn(),
-      release: vi.fn(),
-      releaseOwner: vi.fn()
-    } as unknown as ManagedPreviewResources
-    const { event, listeners } = createFakeEvent(42)
+      )
+    })
+    const lifecycle = new ApplicationCallerLeaseRegistry()
+    const caller = lifecycle.acquire('electron:42')
     const owners = createManagedPreviewOwnerRegistry(resources)
 
-    const acquire = owners.acquire(event as never, {
+    const acquire = owners.acquire(caller.lease, {
       source: 'artifact',
       path: '/managed/report.pdf'
     })
-    listeners.get('render-process-gone')?.()
+    const ownerId = (resources.acquire as ReturnType<typeof vi.fn>).mock.calls[0]?.[0] as number
+    caller.release()
     resolveAcquire?.(resource)
 
     await expect(acquire).rejects.toThrow(/owner is no longer available/i)
-    expect(resources.release).toHaveBeenCalledWith(42, { resourceId: 'late-resource' })
+    expect(resources.release).toHaveBeenCalledWith(ownerId, { resourceId: 'late-resource' })
   })
 
-  it('returns the capability when the owner is still active when the acquire resolves', async () => {
-    const resource: ManagedPreviewResource = {
-      id: 'fresh-resource',
-      url: 'open-science-preview://fresh-resource/report.pdf',
-      size: 12,
-      mimeType: 'application/pdf',
-      version: 1
-    }
-    const resources = {
-      acquire: vi.fn().mockResolvedValue(resource),
-      readRange: vi.fn(),
-      release: vi.fn(),
-      releaseOwner: vi.fn()
-    } as unknown as ManagedPreviewResources
-    const { event } = createFakeEvent(99)
+  it('returns the capability while the caller lease is current', async () => {
+    const resource = previewResource('fresh-resource')
+    const resources = createResources({ acquire: vi.fn().mockResolvedValue(resource) })
+    const lifecycle = new ApplicationCallerLeaseRegistry()
+    const caller = lifecycle.acquire('electron:99')
     const owners = createManagedPreviewOwnerRegistry(resources)
 
     await expect(
-      owners.acquire(event as never, { source: 'artifact', path: '/managed/report.pdf' })
+      owners.acquire(caller.lease, { source: 'artifact', path: '/managed/report.pdf' })
     ).resolves.toEqual(resource)
     expect(resources.release).not.toHaveBeenCalled()
   })
 
-  it('reuses the active generation when the same owner is re-registered', () => {
-    const resources = {
-      acquire: vi.fn(),
-      readRange: vi.fn(),
-      release: vi.fn(),
-      releaseOwner: vi.fn()
-    } as unknown as ManagedPreviewResources
-    const first = createFakeEvent(7)
-    const second = createFakeEvent(7)
+  it('reuses one preview owner for the same active caller generation', () => {
+    const resources = createResources()
+    const lifecycle = new ApplicationCallerLeaseRegistry()
+    const caller = lifecycle.acquire('electron:7')
     const owners = createManagedPreviewOwnerRegistry(resources)
 
-    const ticketA = owners.register(first.event as never)
-    const ticketB = owners.register(second.event as never)
+    const ticketA = owners.register(caller.lease)
+    const ticketB = owners.register(caller.lease)
 
-    expect(ticketA.generation).toBe(ticketB.generation)
-    expect(ticketA.ownerId).toBe(7)
-    // Re-registering an already-tracked owner must not attach new lifetime listeners.
-    expect(second.event.sender.once).not.toHaveBeenCalled()
+    expect(ticketB).toBe(ticketA)
+    expect(resources.releaseOwner).not.toHaveBeenCalled()
   })
 
-  it('increments the generation once a previous owner has been fully released', () => {
-    const resources = {
-      acquire: vi.fn(),
-      readRange: vi.fn(),
-      release: vi.fn(),
-      releaseOwner: vi.fn()
-    } as unknown as ManagedPreviewResources
+  it('isolates a replacement generation from a stale release', () => {
+    const resources = createResources()
+    const lifecycle = new ApplicationCallerLeaseRegistry()
     const owners = createManagedPreviewOwnerRegistry(resources)
+    const first = lifecycle.acquire('electron:13')
+    const initialTicket = owners.register(first.lease)
 
-    const first = createFakeEvent(11)
-    const ticketA = owners.register(first.event as never)
-    first.listeners.get('destroyed')?.()
-
-    const second = createFakeEvent(11)
-    const ticketB = owners.register(second.event as never)
-
-    expect(ticketB.generation).toBeGreaterThan(ticketA.generation)
-    expect(resources.releaseOwner).toHaveBeenCalledTimes(1)
-    expect(resources.releaseOwner).toHaveBeenCalledWith(11)
-  })
-
-  it('releases owner resources at most once when multiple teardown events fire', () => {
-    const resources = {
-      acquire: vi.fn(),
-      readRange: vi.fn(),
-      release: vi.fn(),
-      releaseOwner: vi.fn()
-    } as unknown as ManagedPreviewResources
-    const { event, listeners } = createFakeEvent(5)
-    const owners = createManagedPreviewOwnerRegistry(resources)
-    owners.register(event as never)
-
-    listeners.get('destroyed')?.()
-    listeners.get('render-process-gone')?.()
-    listeners.get('destroyed')?.()
-
-    expect(resources.releaseOwner).toHaveBeenCalledTimes(1)
-  })
-
-  it('ignores late teardown listeners from a stale registration', () => {
-    const resources = {
-      acquire: vi.fn(),
-      readRange: vi.fn(),
-      release: vi.fn(),
-      releaseOwner: vi.fn()
-    } as unknown as ManagedPreviewResources
-    const owners = createManagedPreviewOwnerRegistry(resources)
-    const first = createFakeEvent(13)
-    const initialTicket = owners.register(first.event as never)
-    // Fire teardown so the active generation entry is cleared.
-    first.listeners.get('render-process-gone')?.()
-
-    const replacement = createFakeEvent(13)
-    const replacementTicket = owners.register(replacement.event as never)
+    const replacement = lifecycle.acquire('electron:13')
+    const replacementTicket = owners.register(replacement.lease)
+    first.release()
 
     expect(replacementTicket.generation).toBeGreaterThan(initialTicket.generation)
-    // The original listener must not retroactively revoke the replacement registration.
-    first.listeners.get('destroyed')?.()
-    expect(resources.releaseOwner).toHaveBeenCalledTimes(1)
-    expect(resources.releaseOwner).toHaveBeenCalledWith(13)
+    expect(replacementTicket.ownerId).not.toBe(initialTicket.ownerId)
+    expect(resources.releaseOwner).toHaveBeenCalledOnce()
+    expect(resources.releaseOwner).toHaveBeenCalledWith(initialTicket.ownerId)
+
+    replacement.release()
+    expect(resources.releaseOwner).toHaveBeenLastCalledWith(replacementTicket.ownerId)
   })
 
-  it('propagates backend errors without triggering a late release when the owner has torn down', async () => {
+  it('propagates backend errors after the caller lease ends without releasing a nonexistent resource', async () => {
     let rejectAcquire: ((reason: Error) => void) | undefined
     const pendingAcquire = new Promise<ManagedPreviewResource>((_resolve, reject) => {
       rejectAcquire = reject
     })
-    const resources = {
-      acquire: vi.fn().mockImplementation(() => pendingAcquire),
-      readRange: vi.fn(),
-      release: vi.fn(),
-      releaseOwner: vi.fn()
-    } as unknown as ManagedPreviewResources
-    const { event, listeners } = createFakeEvent(31)
+    const resources = createResources({ acquire: vi.fn().mockImplementation(() => pendingAcquire) })
+    const lifecycle = new ApplicationCallerLeaseRegistry()
+    const caller = lifecycle.acquire('electron:31')
     const owners = createManagedPreviewOwnerRegistry(resources)
 
-    const acquire = owners.acquire(event as never, {
+    const acquire = owners.acquire(caller.lease, {
       source: 'artifact',
       path: '/managed/report.pdf'
     })
-    // Backend rejects before any resolution: the original error must propagate as-is.
     rejectAcquire?.(new Error('backend exploded'))
-    listeners.get('destroyed')?.()
+    caller.release()
 
     await expect(acquire).rejects.toThrow('backend exploded')
-    // We never resolved a resource, so no idempotent release call is issued either.
     expect(resources.release).not.toHaveBeenCalled()
-    expect(resources.releaseOwner).toHaveBeenCalledTimes(1)
+    expect(resources.releaseOwner).toHaveBeenCalledOnce()
   })
 
-  it('wires ipcMain handlers with owner-scoped acquire, readRange, and release', async () => {
+  it('wires acquire, read, and release to one lease-owned preview handle', async () => {
     handlers.clear()
-    const resource: ManagedPreviewResource = {
-      id: 'wired-resource',
-      url: 'open-science-preview://wired-resource/report.html',
-      size: 4,
-      mimeType: 'text/html; charset=utf-8',
-      version: 1
-    }
+    const resource = previewResource('wired-resource')
     const rangeResult = {
       begin: 0,
       end: 1,
       total: 4,
       data: new Uint8Array([104, 105])
     }
-    const resources = {
+    const resources = createResources({
       acquire: vi.fn().mockResolvedValue(resource),
-      readRange: vi.fn().mockResolvedValue(rangeResult),
-      release: vi.fn(),
-      releaseOwner: vi.fn()
-    } as unknown as ManagedPreviewResources
-
+      readRange: vi.fn().mockResolvedValue(rangeResult)
+    })
     registerManagedPreviewIpcHandlers(resources)
 
-    expect(handlers.has('preview-resources:acquire')).toBe(true)
-    expect(handlers.has('preview-resources:read-range')).toBe(true)
-    expect(handlers.has('preview-resources:release')).toBe(true)
-
-    const { event: acquireEvent, listeners: acquireListeners } = createFakeEvent(91)
+    const { event, listeners } = createFakeEvent(91)
     const acquireHandler = handlers.get('preview-resources:acquire') as (
       event: unknown,
       payload: unknown
     ) => Promise<ManagedPreviewResource>
     await expect(
-      acquireHandler(acquireEvent, { source: 'artifact', path: '/managed/report.html' })
+      acquireHandler(event, { source: 'artifact', path: '/managed/report.html' })
     ).resolves.toEqual(resource)
-    expect(resources.acquire).toHaveBeenCalledWith(91, {
-      source: 'artifact',
-      path: '/managed/report.html'
-    })
+    const ownerId = (resources.acquire as ReturnType<typeof vi.fn>).mock.calls[0]?.[0] as number
+    expect(ownerId).toBeLessThan(0)
 
-    const { event: readEvent } = createFakeEvent(92)
     const readHandler = handlers.get('preview-resources:read-range') as (
       event: unknown,
       payload: unknown
     ) => Promise<unknown>
-    await readHandler(readEvent, { resourceId: 'wired-resource', begin: 0, end: 1 })
-    expect(resources.readRange).toHaveBeenCalledWith(92, {
+    await readHandler(event, { resourceId: 'wired-resource', begin: 0, end: 1 })
+    expect(resources.readRange).toHaveBeenCalledWith(ownerId, {
       resourceId: 'wired-resource',
       begin: 0,
       end: 1
     })
 
-    const { event: releaseEvent } = createFakeEvent(93)
     const releaseHandler = handlers.get('preview-resources:release') as (
       event: unknown,
       payload: unknown
     ) => unknown
-    releaseHandler(releaseEvent, { resourceId: 'wired-resource' })
-    expect(resources.release).toHaveBeenCalledWith(93, { resourceId: 'wired-resource' })
+    releaseHandler(event, { resourceId: 'wired-resource' })
+    expect(resources.release).toHaveBeenCalledWith(ownerId, { resourceId: 'wired-resource' })
 
-    // Releasing the ipcMain-registered acquire owner must trigger a single releaseOwner call.
-    acquireListeners.get('render-process-gone')?.()
-    expect(resources.releaseOwner).toHaveBeenCalledTimes(1)
-    expect(resources.releaseOwner).toHaveBeenCalledWith(91)
+    listeners.get('render-process-gone')?.()
+    listeners.get('destroyed')?.()
+    expect(resources.releaseOwner).toHaveBeenCalledOnce()
+    expect(resources.releaseOwner).toHaveBeenCalledWith(ownerId)
+  })
+
+  it('assigns distinct preview owners to distinct callers', async () => {
+    handlers.clear()
+    const resources = createResources({
+      readRange: vi.fn().mockResolvedValue({ begin: 0, end: 0, total: 1, data: new Uint8Array() })
+    })
+    registerManagedPreviewIpcHandlers(resources)
+    const readHandler = handlers.get('preview-resources:read-range') as (
+      event: unknown,
+      payload: unknown
+    ) => Promise<unknown>
+
+    await readHandler(createFakeEvent(92).event, { resourceId: 'resource', begin: 0, end: 0 })
+    await readHandler(createFakeEvent(93).event, { resourceId: 'resource', begin: 0, end: 0 })
+
+    const [firstOwner] = (resources.readRange as ReturnType<typeof vi.fn>).mock.calls[0] as [number]
+    const [secondOwner] = (resources.readRange as ReturnType<typeof vi.fn>).mock.calls[1] as [
+      number
+    ]
+    expect(firstOwner).toBeLessThan(0)
+    expect(secondOwner).toBeLessThan(0)
+    expect(secondOwner).not.toBe(firstOwner)
   })
 
   it('uses a strict inspected snapshot when acquire specifies a byte limit', async () => {
     handlers.clear()
-    const resource: ManagedPreviewResource = {
-      id: 'strict-resource',
-      url: 'open-science-preview://strict-resource/chart.tiff',
-      size: 128,
-      mimeType: 'image/tiff',
-      version: 7
-    }
-    const resources = {
-      inspect: vi
-        .fn()
-        .mockResolvedValue({ size: 128, version: 7, dev: 8n, ino: 9n, mtimeNs: 7_000_000n }),
-      acquire: vi.fn().mockResolvedValue(resource),
-      readRange: vi.fn(),
-      release: vi.fn(),
-      releaseOwner: vi.fn()
-    } as unknown as ManagedPreviewResources
+    const resource = previewResource('strict-resource')
+    const snapshot = { size: 128, version: 7, dev: 8n, ino: 9n, mtimeNs: 7_000_000n }
+    const resources = createResources({
+      inspect: vi.fn().mockResolvedValue(snapshot),
+      acquire: vi.fn().mockResolvedValue(resource)
+    })
     registerManagedPreviewIpcHandlers(resources)
     const { event } = createFakeEvent(101)
     const acquireHandler = handlers.get('preview-resources:acquire') as (
@@ -331,22 +270,17 @@ describe('managed preview IPC handlers', () => {
       path: '/managed/chart.tiff',
       mimeType: 'image/tiff'
     }
+    const ownerId = (resources.acquire as ReturnType<typeof vi.fn>).mock.calls[0]?.[0] as number
     expect(resources.inspect).toHaveBeenCalledWith(request)
-    expect(resources.acquire).toHaveBeenCalledWith(101, request, {
-      snapshot: { size: 128, version: 7, dev: 8n, ino: 9n, mtimeNs: 7_000_000n },
+    expect(resources.acquire).toHaveBeenCalledWith(ownerId, request, {
+      snapshot,
       maxBytes: 40 * 1024 * 1024
     })
   })
 
   it('rejects an invalid strict byte limit before inspecting the file', async () => {
     handlers.clear()
-    const resources = {
-      inspect: vi.fn(),
-      acquire: vi.fn(),
-      readRange: vi.fn(),
-      release: vi.fn(),
-      releaseOwner: vi.fn()
-    } as unknown as ManagedPreviewResources
+    const resources = createResources({ inspect: vi.fn() })
     registerManagedPreviewIpcHandlers(resources)
     const { event } = createFakeEvent(102)
     const acquireHandler = handlers.get('preview-resources:acquire') as (

--- a/src/main/managed-preview-ipc.ts
+++ b/src/main/managed-preview-ipc.ts
@@ -1,5 +1,7 @@
 import { type IpcMainInvokeEvent } from 'electron'
 
+import type { ApplicationCallerLease } from './application-command-router'
+import { callerLeaseForEvent } from './caller-lifecycle'
 import { ipcMainHandle } from './ipc-handler-registry'
 
 import type {
@@ -26,54 +28,67 @@ type ManagedPreviewHandlers = {
   releaseOwner: (ownerId: number) => void
 }
 
-type OwnerTicket = { ownerId: number; generation: number }
+type OwnerTicket = { ownerId: number; leaseId: string; generation: number }
 type ManagedPreviewOwnerRegistry = {
   acquire: (
-    event: IpcMainInvokeEvent,
+    lease: ApplicationCallerLease,
     request: AcquireManagedPreviewRequest,
     prepareOptions?: () => Promise<AcquireManagedPreviewOptions>
   ) => Promise<ManagedPreviewResource>
-  register: (event: IpcMainInvokeEvent) => OwnerTicket
+  register: (lease: ApplicationCallerLease) => OwnerTicket
 }
 
-// Couples every capability to the renderer process that acquired it.
+// Couples every capability to the current surface-owned caller lease.
 const createManagedPreviewOwnerRegistry = (
   handlers: ManagedPreviewHandlers
 ): ManagedPreviewOwnerRegistry => {
-  const activeGenerations = new Map<number, number>()
-  let nextGeneration = 0
+  const active = new Map<string, OwnerTicket>()
+  let nextOwnerId = 0
 
-  // Generations prevent a stale crash listener from releasing resources after an owner id is reused.
-  const register = (event: IpcMainInvokeEvent): OwnerTicket => {
-    const ownerId = event.sender.id
-    const activeGeneration = activeGenerations.get(ownerId)
-    if (activeGeneration !== undefined) return { ownerId, generation: activeGeneration }
-
-    const ticket = { ownerId, generation: ++nextGeneration }
-    activeGenerations.set(ownerId, ticket.generation)
-    const releaseOwner = (): void => {
-      if (activeGenerations.get(ownerId) !== ticket.generation) return
-      activeGenerations.delete(ownerId)
-      handlers.releaseOwner(ownerId)
+  // Preview resources use opaque negative handles; renderer ids remain transport details.
+  const register = (lease: ApplicationCallerLease): OwnerTicket => {
+    const current = active.get(lease.leaseId)
+    if (current?.generation === lease.generation && lease.isCurrent()) return current
+    if (current) {
+      active.delete(lease.leaseId)
+      handlers.releaseOwner(current.ownerId)
     }
-    event.sender.once('destroyed', releaseOwner)
-    event.sender.once('render-process-gone', releaseOwner)
+    if (lease.signal.aborted || !lease.isCurrent()) {
+      throw new Error('Managed preview owner is no longer available.')
+    }
+
+    const ticket = {
+      ownerId: --nextOwnerId,
+      leaseId: lease.leaseId,
+      generation: lease.generation
+    }
+    active.set(lease.leaseId, ticket)
+    const releaseOwner = (): void => {
+      if (active.get(lease.leaseId) !== ticket) return
+      active.delete(lease.leaseId)
+      handlers.releaseOwner(ticket.ownerId)
+    }
+    lease.signal.addEventListener('abort', releaseOwner, { once: true })
+    if (lease.signal.aborted || !lease.isCurrent()) {
+      releaseOwner()
+      throw new Error('Managed preview owner is no longer available.')
+    }
     return ticket
   }
 
-  const isActive = (ticket: OwnerTicket): boolean =>
-    activeGenerations.get(ticket.ownerId) === ticket.generation
+  const isActive = (ticket: OwnerTicket, lease: ApplicationCallerLease): boolean =>
+    active.get(ticket.leaseId) === ticket && !lease.signal.aborted && lease.isCurrent()
 
   const acquire = async (
-    event: IpcMainInvokeEvent,
+    lease: ApplicationCallerLease,
     request: AcquireManagedPreviewRequest,
     prepareOptions?: () => Promise<AcquireManagedPreviewOptions>
   ): Promise<ManagedPreviewResource> => {
-    const ticket = register(event)
+    const ticket = register(lease)
     let resource: ManagedPreviewResource
     if (prepareOptions) {
       const options = await prepareOptions()
-      if (!isActive(ticket)) {
+      if (!isActive(ticket, lease)) {
         throw new Error('Managed preview owner is no longer available.')
       }
       resource = await handlers.acquire(ticket.ownerId, request, options)
@@ -82,7 +97,7 @@ const createManagedPreviewOwnerRegistry = (
     }
 
     // Acquisition may finish after renderer teardown; immediately revoke that late capability.
-    if (!isActive(ticket)) {
+    if (!isActive(ticket, lease)) {
       handlers.release(ticket.ownerId, { resourceId: resource.id })
       throw new Error('Managed preview owner is no longer available.')
     }
@@ -95,17 +110,20 @@ const createManagedPreviewOwnerRegistry = (
 
 const registerManagedPreviewIpcHandlers = (resources: ManagedPreviewResources): void => {
   const owners = createManagedPreviewOwnerRegistry(resources)
-  const ownerId = (event: IpcMainInvokeEvent): number => owners.register(event).ownerId
+  const callerLease = (event: IpcMainInvokeEvent): ApplicationCallerLease =>
+    callerLeaseForEvent(event)
+  const ownerId = (event: IpcMainInvokeEvent): number => owners.register(callerLease(event)).ownerId
 
   ipcMainHandle(
     'preview-resources:acquire',
     async (event, { maxBytes, ...request }: AcquireManagedPreviewRequest) => {
-      if (maxBytes === undefined) return owners.acquire(event, request)
+      const lease = callerLease(event)
+      if (maxBytes === undefined) return owners.acquire(lease, request)
       if (!Number.isSafeInteger(maxBytes) || maxBytes <= 0) {
         throw new Error('Invalid managed preview byte limit.')
       }
 
-      return owners.acquire(event, request, async () => ({
+      return owners.acquire(lease, request, async () => ({
         snapshot: await resources.inspect(request),
         maxBytes
       }))

--- a/src/main/managed-preview-ipc.ts
+++ b/src/main/managed-preview-ipc.ts
@@ -1,7 +1,7 @@
 import { type IpcMainInvokeEvent } from 'electron'
 
 import type { ApplicationCallerLease } from './application-command-router'
-import { callerLeaseForEvent } from './caller-lifecycle'
+import { callerLeaseForEvent, callerLeaseOwnershipKey } from './caller-lifecycle'
 import { ipcMainHandle } from './ipc-handler-registry'
 
 import type {
@@ -28,7 +28,7 @@ type ManagedPreviewHandlers = {
   releaseOwner: (ownerId: number) => void
 }
 
-type OwnerTicket = { ownerId: number; leaseId: string; generation: number }
+type OwnerTicket = { ownerId: number; ownershipKey: string; generation: number }
 type ManagedPreviewOwnerRegistry = {
   acquire: (
     lease: ApplicationCallerLease,
@@ -47,25 +47,25 @@ const createManagedPreviewOwnerRegistry = (
 
   // Preview resources use opaque negative handles; renderer ids remain transport details.
   const register = (lease: ApplicationCallerLease): OwnerTicket => {
-    const current = active.get(lease.leaseId)
-    if (current?.generation === lease.generation && lease.isCurrent()) return current
-    if (current) {
-      active.delete(lease.leaseId)
-      handlers.releaseOwner(current.ownerId)
-    }
     if (lease.signal.aborted || !lease.isCurrent()) {
       throw new Error('Managed preview owner is no longer available.')
     }
-
+    const ownershipKey = callerLeaseOwnershipKey(lease)
+    const current = active.get(ownershipKey)
+    if (current?.generation === lease.generation) return current
+    if (current) {
+      active.delete(ownershipKey)
+      handlers.releaseOwner(current.ownerId)
+    }
     const ticket = {
       ownerId: --nextOwnerId,
-      leaseId: lease.leaseId,
+      ownershipKey,
       generation: lease.generation
     }
-    active.set(lease.leaseId, ticket)
+    active.set(ownershipKey, ticket)
     const releaseOwner = (): void => {
-      if (active.get(lease.leaseId) !== ticket) return
-      active.delete(lease.leaseId)
+      if (active.get(ownershipKey) !== ticket) return
+      active.delete(ownershipKey)
       handlers.releaseOwner(ticket.ownerId)
     }
     lease.signal.addEventListener('abort', releaseOwner, { once: true })
@@ -77,7 +77,7 @@ const createManagedPreviewOwnerRegistry = (
   }
 
   const isActive = (ticket: OwnerTicket, lease: ApplicationCallerLease): boolean =>
-    active.get(ticket.leaseId) === ticket && !lease.signal.aborted && lease.isCurrent()
+    active.get(ticket.ownershipKey) === ticket && !lease.signal.aborted && lease.isCurrent()
 
   const acquire = async (
     lease: ApplicationCallerLease,

--- a/src/main/remote-access/ipc.test.ts
+++ b/src/main/remote-access/ipc.test.ts
@@ -1,33 +1,47 @@
-import type { IpcMainInvokeEvent } from 'electron'
 import { describe, expect, it, vi } from 'vitest'
 
 vi.mock('electron', () => ({ ipcMain: { handle: vi.fn() } }))
 
 import {
   canManagePairing,
-  isDesktopSender,
+  isDesktopCaller,
   registerRemoteAccessIpcHandlers,
-  requireDesktopSender,
+  requireDesktopCaller,
   requirePairingManager
 } from './ipc'
 import { createElectronCallerContext, createWebCallerContext } from '../caller-context'
 import { webRpc } from '../ipc-handler-registry'
 
-const eventWithSenderId = (id: number, remotePairingManager = false): IpcMainInvokeEvent =>
-  ({
-    sender: {
-      id,
-      callerContext:
-        id > 0
-          ? createElectronCallerContext(id)
-          : createWebCallerContext(`browser-${Math.abs(id)}`, {
-              location: 'remote',
-              authorities: remotePairingManager ? ['manage-remote-pairing'] : []
-            })
-    }
-  }) as unknown as IpcMainInvokeEvent
-
 describe('remote access IPC authorization', () => {
+  it.each([
+    ['Electron desktop', createElectronCallerContext(7), true],
+    ['local Web', createWebCallerContext('local-browser'), false],
+    [
+      'ordinary remote Web',
+      createWebCallerContext('remote-browser', { location: 'remote' }),
+      false
+    ],
+    [
+      'current remote pairing manager',
+      createWebCallerContext('pairing-manager', {
+        location: 'remote',
+        authorities: ['manage-remote-pairing']
+      }),
+      true
+    ],
+    [
+      'stale remote pairing manager',
+      createWebCallerContext('stale-manager', {
+        location: 'remote',
+        authorities: ['manage-remote-pairing'],
+        isAuthorizationCurrent: () => false
+      }),
+      false
+    ]
+  ])('keeps the %s pairing-management decision', (_name, context, expected) => {
+    expect(canManagePairing(context)).toBe(expected)
+  })
+
   it('registers remote access handlers with the Web RPC router', async () => {
     const snapshot = vi.fn(() => ({ mode: 'off' }))
     registerRemoteAccessIpcHandlers({ snapshot } as never)
@@ -50,28 +64,31 @@ describe('remote access IPC authorization', () => {
   })
 
   it('allows a real Electron WebContents sender', () => {
-    const event = eventWithSenderId(7)
-    expect(isDesktopSender(event)).toBe(true)
-    expect(canManagePairing(event)).toBe(true)
-    expect(() => requireDesktopSender(event)).not.toThrow()
-    expect(() => requirePairingManager(event)).not.toThrow()
+    const context = createElectronCallerContext(7)
+    expect(isDesktopCaller(context)).toBe(true)
+    expect(canManagePairing(context)).toBe(true)
+    expect(() => requireDesktopCaller(context)).not.toThrow()
+    expect(() => requirePairingManager(context)).not.toThrow()
   })
 
   it('rejects the synthetic negative sender used by every Web RPC client', () => {
-    const event = eventWithSenderId(-1)
-    expect(isDesktopSender(event)).toBe(false)
-    expect(canManagePairing(event)).toBe(false)
-    expect(() => requireDesktopSender(event)).toThrow(
+    const context = createWebCallerContext('browser-1', { location: 'remote' })
+    expect(isDesktopCaller(context)).toBe(false)
+    expect(canManagePairing(context)).toBe(false)
+    expect(() => requireDesktopCaller(context)).toThrow(
       'must be approved from the Open Science desktop app'
     )
-    expect(() => requirePairingManager(event)).toThrow('approved browser')
+    expect(() => requirePairingManager(context)).toThrow('approved browser')
   })
 
   it('allows an approved Web browser to manage pairing only', () => {
-    const event = eventWithSenderId(-1, true)
-    expect(isDesktopSender(event)).toBe(false)
-    expect(canManagePairing(event)).toBe(true)
-    expect(() => requireDesktopSender(event)).toThrow()
-    expect(() => requirePairingManager(event)).not.toThrow()
+    const context = createWebCallerContext('browser-1', {
+      location: 'remote',
+      authorities: ['manage-remote-pairing']
+    })
+    expect(isDesktopCaller(context)).toBe(false)
+    expect(canManagePairing(context)).toBe(true)
+    expect(() => requireDesktopCaller(context)).toThrow()
+    expect(() => requirePairingManager(context)).not.toThrow()
   })
 })

--- a/src/main/remote-access/ipc.ts
+++ b/src/main/remote-access/ipc.ts
@@ -1,29 +1,29 @@
-import type { IpcMainInvokeEvent } from 'electron'
-
 import type {
   ApproveRemotePairingRequest,
   RemotePairingRequestId,
   RevokeRemoteBrowserRequest,
   SetRemoteAccessModeRequest
 } from '../../shared/remote-access'
-import { callerContextForEvent } from '../caller-context'
-import { ipcMainHandle, isRemotePairingManagerSender } from '../ipc-handler-registry'
+import { callerContextForEvent, hasCallerAuthority, type CallerContext } from '../caller-context'
+import { ipcMainHandle } from '../ipc-handler-registry'
 import { RemoteAccessService } from './service'
 
-const isDesktopSender = (event: IpcMainInvokeEvent): boolean =>
-  callerContextForEvent(event).surface === 'electron'
+const isDesktopCaller = (context: CallerContext): boolean => context.surface === 'electron'
 
-const requireDesktopSender = (event: IpcMainInvokeEvent): void => {
-  if (!isDesktopSender(event)) {
+const requireDesktopCaller = (context: CallerContext): void => {
+  if (!isDesktopCaller(context)) {
     throw new Error('This action must be approved from the Open Science desktop app.')
   }
 }
 
-const canManagePairing = (event: IpcMainInvokeEvent): boolean =>
-  isDesktopSender(event) || isRemotePairingManagerSender(event)
+const canManagePairing = (context: CallerContext): boolean =>
+  isDesktopCaller(context) ||
+  (context.surface === 'web' &&
+    context.location === 'remote' &&
+    hasCallerAuthority(context, 'manage-remote-pairing'))
 
-const requirePairingManager = (event: IpcMainInvokeEvent): void => {
-  if (!canManagePairing(event)) {
+const requirePairingManager = (context: CallerContext): void => {
+  if (!canManagePairing(context)) {
     throw new Error(
       'Pairing can only be managed from the Open Science desktop app or an approved browser.'
     )
@@ -32,39 +32,43 @@ const requirePairingManager = (event: IpcMainInvokeEvent): void => {
 
 export const registerRemoteAccessIpcHandlers = (service: RemoteAccessService): void => {
   ipcMainHandle('remote-access:get-snapshot', (event) => {
-    const desktop = isDesktopSender(event)
-    return service.snapshot(desktop, canManagePairing(event))
+    const context = callerContextForEvent(event)
+    const desktop = isDesktopCaller(context)
+    return service.snapshot(desktop, canManagePairing(context))
   })
   ipcMainHandle('remote-access:detect', async (event) => {
-    requireDesktopSender(event)
+    requireDesktopCaller(callerContextForEvent(event))
     return service.detect()
   })
   ipcMainHandle('remote-access:set-mode', async (event, request: SetRemoteAccessModeRequest) => {
-    requireDesktopSender(event)
+    requireDesktopCaller(callerContextForEvent(event))
     return service.setMode(request.mode)
   })
   ipcMainHandle('remote-access:disable', async (event) => {
-    requireDesktopSender(event)
+    requireDesktopCaller(callerContextForEvent(event))
     return service.disable()
   })
   ipcMainHandle('remote-access:approve', async (event, request: ApproveRemotePairingRequest) => {
-    requirePairingManager(event)
-    const desktop = isDesktopSender(event)
-    return service.approve(request, desktop, canManagePairing(event))
+    const context = callerContextForEvent(event)
+    requirePairingManager(context)
+    const desktop = isDesktopCaller(context)
+    return service.approve(request, desktop, canManagePairing(context))
   })
   ipcMainHandle('remote-access:reject', (event, request: RemotePairingRequestId) => {
-    requirePairingManager(event)
-    const desktop = isDesktopSender(event)
-    return service.reject(request.requestId, desktop, canManagePairing(event))
+    const context = callerContextForEvent(event)
+    requirePairingManager(context)
+    const desktop = isDesktopCaller(context)
+    return service.reject(request.requestId, desktop, canManagePairing(context))
   })
   ipcMainHandle(
     'remote-access:revoke-browser',
     async (event, request: RevokeRemoteBrowserRequest) => {
-      requirePairingManager(event)
-      const desktop = isDesktopSender(event)
-      return service.revoke(request.browserId, desktop, canManagePairing(event))
+      const context = callerContextForEvent(event)
+      requirePairingManager(context)
+      const desktop = isDesktopCaller(context)
+      return service.revoke(request.browserId, desktop, canManagePairing(context))
     }
   )
 }
 
-export { canManagePairing, isDesktopSender, requireDesktopSender, requirePairingManager }
+export { canManagePairing, isDesktopCaller, requireDesktopCaller, requirePairingManager }

--- a/src/main/session-persistence/ipc.test.ts
+++ b/src/main/session-persistence/ipc.test.ts
@@ -4,8 +4,12 @@ import type { PersistedChatSession } from '../../shared/session-persistence'
 import type { Logger } from '../logger'
 import type { ReviewRepository } from '../reviewer/repository'
 
-const { broadcastLifecycleEvent, ipcHandlers } = vi.hoisted(() => ({
+const { broadcastLifecycleEvent, getLifecycleClientId, ipcHandlers } = vi.hoisted(() => ({
   broadcastLifecycleEvent: vi.fn(),
+  getLifecycleClientId: vi.fn(
+    (event: { sender: { id: number; lifecycleClientId?: string } }) =>
+      event.sender.lifecycleClientId ?? `electron:${event.sender.id}`
+  ),
   ipcHandlers: new Map<string, (...args: unknown[]) => unknown>()
 }))
 
@@ -17,8 +21,7 @@ vi.mock('electron', () => ({
 }))
 vi.mock('../lifecycle-broadcast', () => ({
   broadcastLifecycleEvent,
-  getLifecycleClientId: (event: { sender: { id: number; lifecycleClientId?: string } }) =>
-    event.sender.lifecycleClientId ?? `electron:${event.sender.id}`
+  getLifecycleClientId
 }))
 
 import {
@@ -33,6 +36,7 @@ import { beginMigration, clearMigrationPending } from '../storage/migration-stat
 beforeEach(() => {
   ipcHandlers.clear()
   broadcastLifecycleEvent.mockClear()
+  getLifecycleClientId.mockClear()
 })
 afterEach(() => clearMigrationPending())
 
@@ -355,6 +359,34 @@ describe('session persistence IPC handlers', () => {
       )
     ).rejects.toBe(failure)
     expect(broadcastLifecycleEvent).not.toHaveBeenCalled()
+  })
+
+  it('captures the lifecycle origin before awaiting a durable save', async () => {
+    const session = createSession()
+    let completeSave!: () => void
+    const savePending = new Promise<void>((resolve) => {
+      completeSave = resolve
+    })
+    const repository: SessionPersistenceBackend = {
+      loadAll: vi.fn().mockResolvedValue({ sessions: [], manifest: { version: 1 as const } }),
+      saveSession: vi.fn(async () => {
+        await savePending
+        return { created: false, session }
+      }),
+      deleteSession: vi.fn().mockResolvedValue(undefined),
+      saveManifest: vi.fn().mockResolvedValue(undefined)
+    }
+    registerSessionPersistenceIpcHandlers(repository, createMockReviewRepository())
+
+    const save = ipcHandlers.get('sessions:save-session')?.(
+      { sender: { id: 1, lifecycleClientId: 'electron:origin' } },
+      session
+    )
+
+    expect(getLifecycleClientId).toHaveBeenCalledOnce()
+    expect(getLifecycleClientId).toHaveReturnedWith('electron:origin')
+    completeSave()
+    await expect(save).resolves.toBe(session)
   })
 
   it('publishes a lifecycle event only after the durable Session transition is readable', async () => {

--- a/src/main/session-persistence/ipc.ts
+++ b/src/main/session-persistence/ipc.ts
@@ -140,13 +140,14 @@ const registerSessionPersistenceIpcHandlers = (
   ipcMainHandle(
     'sessions:save-session',
     async (event, session: PersistedChatSession, options?: SaveSessionOptions) => {
+      const originClientId = getLifecycleClientId(event)
       return withDataRootWrite(async () => {
         const result = await handlers.saveSession(session, options)
         broadcastLifecycleEvent(
           result.created ? LIFECYCLE_CHANNELS.sessionCreated : LIFECYCLE_CHANNELS.sessionUpdated,
           {
             session: result.session,
-            originClientId: getLifecycleClientId(event)
+            originClientId
           }
         )
         return result.session


### PR DESCRIPTION
# T2b1 pull request

Title: `refactor(security): own caller lifecycle leases`

## Problem

Caller lifetime was implicit in Electron/Web sender objects and resource callbacks. The application
command seam needs one surface-owned lease that stays alive for the surface lifetime, separates
authorization from liveness, and prevents stale teardown callbacks from revoking replacement callers.

## Proposed change

- Add a surface-owned caller lease registry with a stable lease ID, increasing generation, unique
  read-only `AbortSignal`, and current-generation validation.
- Bind Electron destroyed/crash and final Web-client release to the matching lease generation; release
  happens before legacy lifecycle callbacks and in-flight work may observe abort without losing its
  already-produced result.
- Express Remote Access policy only through `CallerContext`, preserving the existing five-state truth
  table.
- Require Lifecycle to consume the lease bound by the surface adapter.
- Move Managed Preview ownership onto caller leases using opaque negative resource handles while
  preserving late-acquire cleanup, cross-owner isolation, and stale-generation safety.

```mermaid
flowchart LR
  E["Electron sender"] --> O["Surface lease owner"]
  W["Final Web client socket"] --> O
  O --> L["Stable lease ID + generation"]
  L --> S["Read-only abort signal"]
  L --> C["Current-generation check"]
  L --> P["Managed Preview owner handle"]
  X["CallerContext"] --> R["Remote Access policy"]
```

## Scope and non-goals

- Internal architecture and resource ownership change: yes.
- Persisted data, relationships, migrations, UI, and public wire contracts: no change.
- Electron/local Web/remote Web/Task/CLI availability and Specialist/Permission/Compute asymmetry: no
  change.
- Upload ownership remains T2b2; `web-service/http-server.ts`, global `ipc.ts`, application-runtime
  shutdown, managed-preview storage, Office Preview, and transport composition are unchanged.
- Captured `WebIpcSender` fallback and negative sender IDs remain until T2i.
- Issue #458 orchestration state, vocabulary, and public interfaces are not introduced.

## Acceptance criteria and validation

The checks below ran after the last material edit.

- Same stable ID receives increasing generations and unique signals; stale release cannot abort a
  replacement -> caller-lifecycle tests -> passed.
- Surface-owned registry keys are isolated from exposed caller lease IDs; a Web client ID cannot
  revoke an Electron/Task lease with the same text -> caller/IPC/Preview collision tests -> passed.
- Web and Task callers with the same public client ID use distinct cache entries, leases, signals,
  and Preview owners; Web final-client release cannot revoke Task -> IPC/Task tests -> passed.
- Electron destroyed/crash and final Web client release abort exactly the matching generation;
  in-flight work observes abort without forced result cancellation -> IPC registry tests -> passed.
- Native Electron invocation events still acquire, bind, and validate a caller lease; direct injected
  handler registrars without a structured Electron event remain a lease-neutral test seam -> IPC
  registry tests -> passed.
- Disposing the reusable Web RPC router aborts every lease in the retired epoch; later handler
  registration starts a fresh lease registry, while native wrappers remain bound to their original
  terminal epoch and cannot revive it -> Electron/Web/Task IPC registry and local-filesystem reset
  tests -> passed.
- A crashed Electron renderer can obtain a replacement generation on the same `WebContents`, while
  old invocation events remain bound to their original generation -> IPC registry tests -> passed.
- Desktop/local Web/ordinary remote Web/current manager/stale manager truth table remains unchanged ->
  Remote Access tests -> passed.
- Lifecycle requires the adapter-bound current lease -> lifecycle tests -> passed.
- Preview late acquire cleanup, cross-owner denial, opaque handles, destroyed/crash cleanup, and old
  generation replay isolation -> Managed Preview/resource tests -> passed.
- Registry generations use bounded identity-independent history -> caller lifecycle tests -> passed.
- Session save captures its caller origin before the durable await, so a disconnect cannot turn an
  already-committed save into an RPC failure -> session persistence ordering test -> passed.
- Twelve representative caller/IPC/Remote/Lifecycle/Preview/Task/feature files / 121 tests -> passed.
- Latest reusable-epoch remediation: four focused registry/lifecycle/session/local-filesystem files /
  37 tests -> passed.
- Final WebSocket release and server-close cleanup -> two focused HTTP/WebSocket tests -> passed.
- `npm run typecheck:node` -> passed.
- Targeted ESLint, Prettier, and `git diff --check` -> passed.
- Independent Standards and Spec reviews -> 0 actionable findings after the race/collision and CI
  compatibility fixes.
- Full and cross-platform suites are intentionally delegated to online CI.

## Review focus

- Lease identity is liveness/resource ownership only and must never grant Remote Access authority.
- Surface adapters retain release capability; handlers receive only the immutable lease and signal.
- Release callbacks must be generation-safe and resource cleanup idempotent.
- Production churn is 379 changed lines, below the 500-line hard stop.

## Uncovered risk

The first online coverage run exposed 143 isolated handler tests that intentionally call an injected
registrar without an Electron event; the compatibility seam above fixes that without weakening real
Electron lease validation. A later AI review exposed the reusable default Web RPC router retaining a
terminally disposed lease registry; it now retires the old epoch and creates a fresh one only on later
registration. Native wrappers capture their registration epoch, so an old wrapper remains terminal
before and after reload. Electron E2E and the complete multi-surface matrix remain delegated to online
CI. Upload is deliberately not migrated here and remains the next dependent PR, T2b2; application-
command composition remains T2h0-owned.
