### PR TITLE
fix(acp): strip renderer prompt controls

### DIFF
--- a/src/main/acp/ipc.test.ts
+++ b/src/main/acp/ipc.test.ts
@@ -913,6 +913,7 @@ describe('installAcpIpcHandlers — acp:send-prompt notification tracking', () =
         {
           sessionId: 'session-1',
           text: 'Plot the curve',
+          suppressUserMessage: true,
           continuation: {
             kind: 'specialist-handoff',
             originatingTurnToken: 'renderer-forged-turn',
@@ -927,8 +928,18 @@ describe('installAcpIpcHandlers — acp:send-prompt notification tracking', () =
     expect(trackPrompt).toHaveBeenCalledWith({
       sessionId: 'session-1',
       text: 'Plot the curve',
-      continuation: undefined
+      continuation: undefined,
+      suppressUserMessage: undefined
     })
+    expect(sendPrompt).toHaveBeenCalledWith(
+      expect.objectContaining({
+        sessionId: 'session-1',
+        text: 'Plot the curve',
+        continuation: undefined,
+        suppressUserMessage: undefined
+      }),
+      expect.any(String)
+    )
     expect(trackPrompt.mock.invocationCallOrder[0]).toBeLessThan(
       sendPrompt.mock.invocationCallOrder[0]
     )

--- a/src/main/acp/ipc.ts
+++ b/src/main/acp/ipc.ts
@@ -43,9 +43,13 @@ const registerAcpIpcHandlerSet = (
   )
   // Prompt calls wait for the turn to stop, then return the latest snapshot.
   ipcMainHandle('acp:send-prompt', (_event, request: AcpPromptRequest) => {
-    // Continuations are main-process-owned. A renderer-supplied marker must never suppress a visible
+    // Continuation controls are main-process-owned. Renderer input must never suppress a visible
     // user message or impersonate the handoff path.
-    const rendererRequest = { ...request, continuation: undefined }
+    const rendererRequest = {
+      ...request,
+      continuation: undefined,
+      suppressUserMessage: undefined
+    }
     return workflows.sendPrompt(rendererRequest)
   })
   ipcMainHandle('acp:cancel', (_event, request: AcpCancelPromptRequest) =>


### PR DESCRIPTION
# N1 ACP prompt controls pull request

Title: `fix(acp): strip renderer prompt controls`

## Problem

The live ACP IPC adapter already strips renderer-supplied continuation metadata, but it still forwards
the related application-only `suppressUserMessage` flag. A renderer can therefore make an ordinary
prompt skip its visible user-message projection even though that control belongs only to trusted
main-process continuation paths.

## Proposed change

- Clear both application-owned prompt controls at the live renderer IPC boundary before entering
  `AcpHandlerWorkflows`.
- Strengthen the existing live IPC/notification regression test so the sanitized request is observed
  both by prompt tracking and runtime delegation.

## Scope and compatibility

- Security/behavior fix: renderer calls can no longer supply internal continuation or message-
  suppression controls.
- Trusted app-owned continuation behavior is unchanged because it uses the coordinator/runtime
  internal path rather than renderer IPC.
- No public method/event shape, persisted data, relationship, UI, Provider Session adoption,
  Specialist/Permission/Compute matrix, Web/Task/CLI availability, or Issue #458 API changes.
- No application-command composition or transport cutover is introduced; T2h0/T2h1 remain separate.

## Acceptance criteria and validation

All checks below ran after the last material edit.

- Renderer-provided continuation and message suppression are removed before prompt tracking and
  runtime delegation -> `src/main/acp/ipc.test.ts` -> 34 tests passed.
- Rejected sends still revert the exact notification token and rethrow the original error -> same
  focused suite -> passed.
- `npm run typecheck:node` -> passed.
- Targeted ESLint and Prettier checks -> passed.
- `git diff --check` -> passed.
- Independent Standards and Spec review -> 0 actionable findings; trusted continuation regression
  remained green.
- Full and cross-platform suites are delegated to online CI.

## Review focus

- Sanitization must happen before `AcpHandlerWorkflows` so both notification tracking and runtime see
  the same safe request.
- Internal app-owned continuations must not be routed through or changed by renderer IPC.

## Uncovered risk

Focused tests exercise the real installed handler with faked owner dependencies. Electron/Web E2E and
the complete cross-platform suite remain online CI responsibilities.
