### PR TITLE
refactor(compute): define permission-aware commands

### DIFF
--- a/src/main/compute/application-commands.test.ts
+++ b/src/main/compute/application-commands.test.ts
@@ -1,0 +1,303 @@
+import { describe, expect, it, vi } from 'vitest'
+
+import type { ComputeHost } from '../../shared/compute'
+import { decodeRemoteFsError } from '../../shared/remote-fs'
+import { RENDERER_CONTRACT_GROUPS } from '../../shared/renderer-contract-catalog'
+import {
+  createApplicationCommandRouter,
+  type ApplicationCallerLease,
+  type ApplicationInvocation
+} from '../application-command-router'
+import {
+  createCallerContext,
+  createElectronCallerContext,
+  createTaskCallerContext,
+  createWebCallerContext,
+  type CallerContext
+} from '../caller-context'
+import {
+  computeApplicationCommandGroup,
+  computeApplicationCommands,
+  registerComputeApplicationCommands,
+  type ComputeApplicationCommandDependencies,
+  type ComputeCommandOwner
+} from './application-commands'
+
+const host = { providerId: 'ssh:cluster', displayName: 'Cluster' } as ComputeHost
+
+const createDependencies = (): ComputeApplicationCommandDependencies => ({
+  compute: {
+    list: vi.fn(async () => [host]),
+    get: vi.fn(async () => host),
+    create: vi.fn(async () => host),
+    delete: vi.fn(async () => undefined),
+    sshConfigAliases: vi.fn(async () => ['cluster']),
+    probe: vi.fn(async () => ({ ok: true })),
+    detailsGet: vi.fn(async () => ({ doc: '# Cluster', isSkeleton: false })),
+    detailsSave: vi.fn(async () => undefined),
+    scratchSet: vi.fn(async () => undefined),
+    concurrencySet: vi.fn(async () => undefined),
+    listDir: vi.fn(async () => ({ path: '/work', entries: [] })),
+    download: vi.fn(async () => ({ path: '/tmp/result.csv', name: 'result.csv', size: 10 })),
+    revealInFolder: vi.fn(() => undefined),
+    approvalRespond: vi.fn(() => undefined),
+    jobsList: vi.fn(async () => []),
+    jobsPendingNotification: vi.fn(async () => []),
+    jobsMarkConsumed: vi.fn(async () => undefined)
+  } as unknown as ComputeCommandOwner,
+  bookmarks: {
+    get: vi.fn(async () => ['/work']),
+    set: vi.fn(async () => undefined)
+  },
+  enabledHosts: {
+    get: vi.fn(() => ['ssh:cluster']),
+    set: vi.fn(() => undefined)
+  }
+})
+
+const invocation = <Args extends readonly unknown[]>(
+  args: Args,
+  callerContext: CallerContext = createElectronCallerContext(7)
+): ApplicationInvocation<Args> => {
+  const callerLease: ApplicationCallerLease = Object.freeze({
+    leaseId: callerContext.leaseId,
+    generation: 1,
+    signal: new AbortController().signal,
+    isCurrent: () => true
+  })
+  return Object.freeze({ args, callerContext, callerLease })
+}
+
+describe('Compute application commands', () => {
+  it('defines exactly the 21 public Compute commands without session-internal handlers', () => {
+    const publicComputeChannels = RENDERER_CONTRACT_GROUPS.find(
+      (group) => group.capability === 'compute'
+    )
+      ?.contracts.filter((contract) => contract.kind === 'method')
+      .map((contract) => contract.channel)
+
+    expect(publicComputeChannels).toHaveLength(21)
+    expect(computeApplicationCommandGroup.commands.map(({ name }) => name)).toEqual(
+      publicComputeChannels
+    )
+    expect(
+      computeApplicationCommandGroup.commands.some(({ name }) =>
+        name.startsWith('compute:session:')
+      )
+    ).toBe(false)
+  })
+
+  it('delegates every canonical argument tuple to its existing owner', async () => {
+    const dependencies = createDependencies()
+    const router = createApplicationCommandRouter()
+    registerComputeApplicationCommands(router.registrar, dependencies)
+    const createRequest = { sshAlias: 'cluster', displayName: 'Cluster' }
+    const destination = { kind: 'os-downloads' as const }
+
+    await router.dispatcher.invoke(computeApplicationCommands.list, invocation([]))
+    await router.dispatcher.invoke(computeApplicationCommands.get, invocation(['ssh:cluster']))
+    await router.dispatcher.invoke(computeApplicationCommands.create, invocation([createRequest]))
+    await router.dispatcher.invoke(
+      computeApplicationCommands.delete,
+      invocation([{ providerId: 'ssh:cluster' }])
+    )
+    await router.dispatcher.invoke(computeApplicationCommands.sshConfigAliases, invocation([]))
+    await router.dispatcher.invoke(computeApplicationCommands.probe, invocation(['ssh:cluster']))
+    await router.dispatcher.invoke(
+      computeApplicationCommands.detailsGet,
+      invocation(['ssh:cluster'])
+    )
+    await router.dispatcher.invoke(
+      computeApplicationCommands.detailsSave,
+      invocation(['ssh:cluster', 'new', 'old', 'user'])
+    )
+    await router.dispatcher.invoke(
+      computeApplicationCommands.scratchSet,
+      invocation(['ssh:cluster', '/scratch'])
+    )
+    await router.dispatcher.invoke(
+      computeApplicationCommands.concurrencySet,
+      invocation(['ssh:cluster', 8])
+    )
+    await router.dispatcher.invoke(
+      computeApplicationCommands.listDir,
+      invocation(['ssh:cluster', '/work'])
+    )
+    await router.dispatcher.invoke(
+      computeApplicationCommands.download,
+      invocation(['ssh:cluster', '/work/result.csv', destination])
+    )
+    await router.dispatcher.invoke(
+      computeApplicationCommands.revealInFolder,
+      invocation(['/tmp/result.csv'])
+    )
+    await router.dispatcher.invoke(
+      computeApplicationCommands.approvalRespond,
+      invocation([{ id: 'approval-1', decision: 'once' }])
+    )
+    const filter = { sessionId: 'session-1', status: ['done'] }
+    await router.dispatcher.invoke(computeApplicationCommands.jobsList, invocation([filter]))
+    await router.dispatcher.invoke(
+      computeApplicationCommands.jobsPendingNotification,
+      invocation(['session-1'])
+    )
+    await router.dispatcher.invoke(
+      computeApplicationCommands.jobsMarkConsumed,
+      invocation(['session-1', ['job-1']])
+    )
+    await router.dispatcher.invoke(
+      computeApplicationCommands.enabledHostsGet,
+      invocation(['session-1'])
+    )
+    await router.dispatcher.invoke(
+      computeApplicationCommands.enabledHostsSet,
+      invocation(['session-1', ['ssh:cluster']])
+    )
+    await router.dispatcher.invoke(
+      computeApplicationCommands.bookmarksGet,
+      invocation(['ssh:cluster'])
+    )
+    await router.dispatcher.invoke(
+      computeApplicationCommands.bookmarksSet,
+      invocation(['ssh:cluster', ['/work']])
+    )
+
+    expect(dependencies.compute.create).toHaveBeenCalledWith(createRequest)
+    expect(dependencies.compute.delete).toHaveBeenCalledWith('ssh:cluster')
+    expect(dependencies.compute.detailsSave).toHaveBeenCalledWith(
+      'ssh:cluster',
+      'new',
+      'old',
+      'user'
+    )
+    expect(dependencies.compute.download).toHaveBeenCalledWith(
+      'ssh:cluster',
+      '/work/result.csv',
+      destination
+    )
+    expect(dependencies.compute.approvalRespond).toHaveBeenCalledWith('approval-1', 'once')
+    expect(dependencies.compute.jobsList).toHaveBeenCalledWith(filter)
+    expect(dependencies.compute.jobsMarkConsumed).toHaveBeenCalledWith('session-1', ['job-1'])
+    expect(dependencies.enabledHosts.set).toHaveBeenCalledWith('session-1', ['ssh:cluster'])
+    expect(dependencies.bookmarks.set).toHaveBeenCalledWith('ssh:cluster', ['/work'])
+  })
+
+  it('serializes RemoteFsError details for both remote filesystem commands', async () => {
+    const dependencies = createDependencies()
+    const router = createApplicationCommandRouter()
+    registerComputeApplicationCommands(router.registrar, dependencies)
+    const remoteFsError = {
+      detail: 'remote path is missing',
+      remoteKind: 'not_found' as const,
+      retry_after_user_action: true
+    }
+    const failure = Object.assign(new Error('remote path is missing'), { remoteFsError })
+    vi.mocked(dependencies.compute.listDir).mockRejectedValueOnce(failure)
+    vi.mocked(dependencies.compute.download).mockRejectedValueOnce(failure)
+
+    for (const operation of [
+      () =>
+        router.dispatcher.invoke(
+          computeApplicationCommands.listDir,
+          invocation(['ssh:cluster', '/missing'])
+        ),
+      () =>
+        router.dispatcher.invoke(
+          computeApplicationCommands.download,
+          invocation(['ssh:cluster', '/missing', { kind: 'os-downloads' }])
+        )
+    ]) {
+      const error = await operation().then(
+        () => {
+          throw new Error('Expected remote filesystem command to reject.')
+        },
+        (caught: unknown) => caught as Error
+      )
+      expect(error.message).toContain('remote path is missing')
+      expect(decodeRemoteFsError(error.message)).toEqual(remoteFsError)
+    }
+
+    const plainFailure = new Error('plain failure')
+    vi.mocked(dependencies.compute.listDir).mockRejectedValueOnce(plainFailure)
+    await expect(
+      router.dispatcher.invoke(
+        computeApplicationCommands.listDir,
+        invocation(['ssh:cluster', '/unavailable'])
+      )
+    ).rejects.toBe(plainFailure)
+  })
+
+  it('rejects native filesystem commands from remote callers before invoking their owners', async () => {
+    const dependencies = createDependencies()
+    const router = createApplicationCommandRouter()
+    registerComputeApplicationCommands(router.registrar, dependencies)
+    const callerContext = createWebCallerContext('remote-web', { location: 'remote' })
+
+    await expect(
+      router.dispatcher.invoke(
+        computeApplicationCommands.download,
+        invocation(['ssh:cluster', '/work/result.csv', { kind: 'os-downloads' }], callerContext)
+      )
+    ).rejects.toThrow('Channel only available from the local app: compute:download')
+    await expect(
+      router.dispatcher.invoke(
+        computeApplicationCommands.revealInFolder,
+        invocation(['/tmp/result.csv'], callerContext)
+      )
+    ).rejects.toThrow('Channel only available from the local app: compute:reveal-in-folder')
+
+    expect(dependencies.compute.download).not.toHaveBeenCalled()
+    expect(dependencies.compute.revealInFolder).not.toHaveBeenCalled()
+  })
+
+  it('accepts Compute approval responses only from current human-originated callers', async () => {
+    const dependencies = createDependencies()
+    const router = createApplicationCommandRouter()
+    registerComputeApplicationCommands(router.registrar, dependencies)
+    const args = [{ id: 'approval-1', decision: 'once' }] as const
+    const allowedCallers = [
+      createElectronCallerContext(7),
+      createWebCallerContext('local-web'),
+      createWebCallerContext('remote-web', { location: 'remote' })
+    ]
+
+    for (const callerContext of allowedCallers) {
+      await expect(
+        router.dispatcher.invoke(
+          computeApplicationCommands.approvalRespond,
+          invocation(args, callerContext)
+        )
+      ).resolves.toBeUndefined()
+    }
+
+    const deniedCallers = [
+      createTaskCallerContext(),
+      createCallerContext({
+        clientId: 'agent-session',
+        lifecycleClientId: 'web:agent-session',
+        leaseId: 'agent-session',
+        surface: 'web',
+        location: 'local',
+        principalKind: 'agent-session',
+        actionOrigin: 'agent-session'
+      }),
+      createWebCallerContext('agent-origin', { actionOrigin: 'agent-session' })
+    ]
+    for (const callerContext of deniedCallers) {
+      await expect(
+        router.dispatcher.invoke(
+          computeApplicationCommands.approvalRespond,
+          invocation(args, callerContext)
+        )
+      ).rejects.toThrow('Only a current human caller can respond to compute approval requests.')
+    }
+    await expect(
+      router.dispatcher.invoke(
+        computeApplicationCommands.approvalRespond,
+        invocation(args, createWebCallerContext('stale', { isAuthorizationCurrent: () => false }))
+      )
+    ).rejects.toThrow('Caller authorization is no longer current.')
+
+    expect(dependencies.compute.approvalRespond).toHaveBeenCalledTimes(allowedCallers.length)
+  })
+})

--- a/src/main/compute/application-commands.ts
+++ b/src/main/compute/application-commands.ts
@@ -1,0 +1,277 @@
+import type { ComputeApprovalDecision, DeleteComputeHostRequest } from '../../shared/compute'
+import { encodeRemoteFsError, type SerializableRemoteFsError } from '../../shared/remote-fs'
+import {
+  defineApplicationCommand,
+  defineApplicationCommandGroup,
+  type ApplicationCommandInstallation,
+  type ApplicationCommandRegistrar
+} from '../application-command-router'
+import { canSatisfyHumanApproval, type CallerContext } from '../caller-context'
+import type { ComputeHandlers } from './ipc'
+
+type ComputeCommandOwner = Pick<
+  ComputeHandlers,
+  | 'list'
+  | 'get'
+  | 'create'
+  | 'delete'
+  | 'sshConfigAliases'
+  | 'probe'
+  | 'detailsGet'
+  | 'detailsSave'
+  | 'scratchSet'
+  | 'concurrencySet'
+  | 'listDir'
+  | 'download'
+  | 'revealInFolder'
+  | 'approvalRespond'
+  | 'jobsList'
+  | 'jobsPendingNotification'
+  | 'jobsMarkConsumed'
+>
+
+type ComputeBookmarksOwner = Readonly<{
+  get(providerId: string): Promise<string[]>
+  set(providerId: string, folders: string[]): Promise<void>
+}>
+
+type ComputeEnabledHostsOwner = Readonly<{
+  get(sessionId: string): string[]
+  set(sessionId: string, providerIds: string[]): void
+}>
+
+type OwnerArgs<Owner, Method extends keyof Owner> = Owner[Method] extends (
+  ...args: infer Args
+) => unknown
+  ? Readonly<Args>
+  : never
+
+type OwnerResult<Owner, Method extends keyof Owner> = Owner[Method] extends (
+  ...args: never[]
+) => infer Result
+  ? Awaited<Result>
+  : never
+
+const computeApplicationCommands = Object.freeze({
+  list: defineApplicationCommand<
+    'compute:list',
+    OwnerArgs<ComputeCommandOwner, 'list'>,
+    OwnerResult<ComputeCommandOwner, 'list'>
+  >('compute:list'),
+  get: defineApplicationCommand<
+    'compute:get',
+    OwnerArgs<ComputeCommandOwner, 'get'>,
+    OwnerResult<ComputeCommandOwner, 'get'>
+  >('compute:get'),
+  create: defineApplicationCommand<
+    'compute:create',
+    OwnerArgs<ComputeCommandOwner, 'create'>,
+    OwnerResult<ComputeCommandOwner, 'create'>
+  >('compute:create'),
+  delete: defineApplicationCommand<
+    'compute:delete',
+    readonly [DeleteComputeHostRequest],
+    OwnerResult<ComputeCommandOwner, 'delete'>
+  >('compute:delete'),
+  sshConfigAliases: defineApplicationCommand<
+    'compute:ssh-config-aliases',
+    OwnerArgs<ComputeCommandOwner, 'sshConfigAliases'>,
+    OwnerResult<ComputeCommandOwner, 'sshConfigAliases'>
+  >('compute:ssh-config-aliases'),
+  probe: defineApplicationCommand<
+    'compute:probe',
+    OwnerArgs<ComputeCommandOwner, 'probe'>,
+    OwnerResult<ComputeCommandOwner, 'probe'>
+  >('compute:probe'),
+  detailsGet: defineApplicationCommand<
+    'compute:details:get',
+    OwnerArgs<ComputeCommandOwner, 'detailsGet'>,
+    OwnerResult<ComputeCommandOwner, 'detailsGet'>
+  >('compute:details:get'),
+  detailsSave: defineApplicationCommand<
+    'compute:details:save',
+    OwnerArgs<ComputeCommandOwner, 'detailsSave'>,
+    OwnerResult<ComputeCommandOwner, 'detailsSave'>
+  >('compute:details:save'),
+  scratchSet: defineApplicationCommand<
+    'compute:scratch:set',
+    OwnerArgs<ComputeCommandOwner, 'scratchSet'>,
+    OwnerResult<ComputeCommandOwner, 'scratchSet'>
+  >('compute:scratch:set'),
+  concurrencySet: defineApplicationCommand<
+    'compute:concurrency:set',
+    OwnerArgs<ComputeCommandOwner, 'concurrencySet'>,
+    OwnerResult<ComputeCommandOwner, 'concurrencySet'>
+  >('compute:concurrency:set'),
+  listDir: defineApplicationCommand<
+    'compute:list-dir',
+    OwnerArgs<ComputeCommandOwner, 'listDir'>,
+    OwnerResult<ComputeCommandOwner, 'listDir'>
+  >('compute:list-dir'),
+  download: defineApplicationCommand<
+    'compute:download',
+    OwnerArgs<ComputeCommandOwner, 'download'>,
+    OwnerResult<ComputeCommandOwner, 'download'>
+  >('compute:download'),
+  revealInFolder: defineApplicationCommand<
+    'compute:reveal-in-folder',
+    OwnerArgs<ComputeCommandOwner, 'revealInFolder'>,
+    OwnerResult<ComputeCommandOwner, 'revealInFolder'>
+  >('compute:reveal-in-folder'),
+  approvalRespond: defineApplicationCommand<
+    'compute:approval-respond',
+    readonly [{ id: string; decision: ComputeApprovalDecision }],
+    OwnerResult<ComputeCommandOwner, 'approvalRespond'>
+  >('compute:approval-respond'),
+  jobsList: defineApplicationCommand<
+    'compute:jobs:list',
+    OwnerArgs<ComputeCommandOwner, 'jobsList'>,
+    OwnerResult<ComputeCommandOwner, 'jobsList'>
+  >('compute:jobs:list'),
+  jobsPendingNotification: defineApplicationCommand<
+    'compute:jobs:pending-notification',
+    OwnerArgs<ComputeCommandOwner, 'jobsPendingNotification'>,
+    OwnerResult<ComputeCommandOwner, 'jobsPendingNotification'>
+  >('compute:jobs:pending-notification'),
+  jobsMarkConsumed: defineApplicationCommand<
+    'compute:jobs:mark-consumed',
+    OwnerArgs<ComputeCommandOwner, 'jobsMarkConsumed'>,
+    OwnerResult<ComputeCommandOwner, 'jobsMarkConsumed'>
+  >('compute:jobs:mark-consumed'),
+  enabledHostsGet: defineApplicationCommand<
+    'compute:enabled-hosts:get',
+    OwnerArgs<ComputeEnabledHostsOwner, 'get'>,
+    OwnerResult<ComputeEnabledHostsOwner, 'get'>
+  >('compute:enabled-hosts:get'),
+  enabledHostsSet: defineApplicationCommand<
+    'compute:enabled-hosts:set',
+    OwnerArgs<ComputeEnabledHostsOwner, 'set'>,
+    OwnerResult<ComputeEnabledHostsOwner, 'set'>
+  >('compute:enabled-hosts:set'),
+  bookmarksGet: defineApplicationCommand<
+    'compute:bookmarks:get',
+    OwnerArgs<ComputeBookmarksOwner, 'get'>,
+    OwnerResult<ComputeBookmarksOwner, 'get'>
+  >('compute:bookmarks:get'),
+  bookmarksSet: defineApplicationCommand<
+    'compute:bookmarks:set',
+    OwnerArgs<ComputeBookmarksOwner, 'set'>,
+    OwnerResult<ComputeBookmarksOwner, 'set'>
+  >('compute:bookmarks:set')
+})
+
+const computeApplicationCommandGroup = defineApplicationCommandGroup('compute', [
+  computeApplicationCommands.bookmarksGet,
+  computeApplicationCommands.bookmarksSet,
+  computeApplicationCommands.concurrencySet,
+  computeApplicationCommands.create,
+  computeApplicationCommands.delete,
+  computeApplicationCommands.detailsGet,
+  computeApplicationCommands.detailsSave,
+  computeApplicationCommands.download,
+  computeApplicationCommands.enabledHostsGet,
+  computeApplicationCommands.enabledHostsSet,
+  computeApplicationCommands.get,
+  computeApplicationCommands.jobsList,
+  computeApplicationCommands.jobsMarkConsumed,
+  computeApplicationCommands.jobsPendingNotification,
+  computeApplicationCommands.list,
+  computeApplicationCommands.listDir,
+  computeApplicationCommands.probe,
+  computeApplicationCommands.approvalRespond,
+  computeApplicationCommands.revealInFolder,
+  computeApplicationCommands.scratchSet,
+  computeApplicationCommands.sshConfigAliases
+] as const)
+
+type ComputeApplicationCommandDependencies = Readonly<{
+  compute: ComputeCommandOwner
+  bookmarks: ComputeBookmarksOwner
+  enabledHosts: ComputeEnabledHostsOwner
+}>
+
+const withSerializedRemoteFsError = async <Result>(
+  operation: () => Promise<Result>
+): Promise<Result> => {
+  try {
+    return await operation()
+  } catch (error) {
+    const failure = error as Error & { remoteFsError?: SerializableRemoteFsError }
+    if (failure.remoteFsError) {
+      throw new Error(encodeRemoteFsError(failure.message, failure.remoteFsError))
+    }
+    throw error
+  }
+}
+
+const assertLocalCommand = (context: CallerContext, channel: string): void => {
+  if (context.location !== 'local') {
+    throw new Error(`Channel only available from the local app: ${channel}`)
+  }
+}
+
+const registerComputeApplicationCommands = (
+  registrar: ApplicationCommandRegistrar,
+  dependencies: ComputeApplicationCommandDependencies
+): ApplicationCommandInstallation => {
+  const scope = registrar.createScope()
+  try {
+    scope.registerGroup(computeApplicationCommandGroup, {
+      'compute:list': () => dependencies.compute.list(),
+      'compute:get': ({ args }) => dependencies.compute.get(args[0]),
+      'compute:create': ({ args }) => dependencies.compute.create(args[0]),
+      'compute:delete': ({ args }) => dependencies.compute.delete(args[0].providerId),
+      'compute:ssh-config-aliases': () => dependencies.compute.sshConfigAliases(),
+      'compute:probe': ({ args }) => dependencies.compute.probe(args[0]),
+      'compute:details:get': ({ args }) => dependencies.compute.detailsGet(args[0]),
+      'compute:details:save': ({ args }) =>
+        dependencies.compute.detailsSave(args[0], args[1], args[2], args[3]),
+      'compute:scratch:set': ({ args }) => dependencies.compute.scratchSet(args[0], args[1]),
+      'compute:concurrency:set': ({ args }) =>
+        dependencies.compute.concurrencySet(args[0], args[1]),
+      'compute:list-dir': ({ args }) =>
+        withSerializedRemoteFsError(() => dependencies.compute.listDir(args[0], args[1])),
+      'compute:download': ({ args, callerContext }) => {
+        assertLocalCommand(callerContext, 'compute:download')
+        return withSerializedRemoteFsError(() =>
+          dependencies.compute.download(args[0], args[1], args[2])
+        )
+      },
+      'compute:reveal-in-folder': ({ args, callerContext }) => {
+        assertLocalCommand(callerContext, 'compute:reveal-in-folder')
+        return dependencies.compute.revealInFolder(args[0])
+      },
+      'compute:approval-respond': ({ args, callerContext }) => {
+        if (!canSatisfyHumanApproval(callerContext)) {
+          throw new Error('Only a current human caller can respond to compute approval requests.')
+        }
+        return dependencies.compute.approvalRespond(args[0].id, args[0].decision)
+      },
+      'compute:jobs:list': ({ args }) => dependencies.compute.jobsList(args[0]),
+      'compute:jobs:pending-notification': ({ args }) =>
+        dependencies.compute.jobsPendingNotification(args[0]),
+      'compute:jobs:mark-consumed': ({ args }) =>
+        dependencies.compute.jobsMarkConsumed(args[0], args[1]),
+      'compute:enabled-hosts:get': ({ args }) => dependencies.enabledHosts.get(args[0]),
+      'compute:enabled-hosts:set': ({ args }) => dependencies.enabledHosts.set(args[0], args[1]),
+      'compute:bookmarks:get': ({ args }) => dependencies.bookmarks.get(args[0]),
+      'compute:bookmarks:set': ({ args }) => dependencies.bookmarks.set(args[0], args[1])
+    })
+    return scope.complete()
+  } catch (error) {
+    scope.rollback()
+    throw error
+  }
+}
+
+export {
+  computeApplicationCommandGroup,
+  computeApplicationCommands,
+  registerComputeApplicationCommands
+}
+export type {
+  ComputeApplicationCommandDependencies,
+  ComputeBookmarksOwner,
+  ComputeCommandOwner,
+  ComputeEnabledHostsOwner
+}

--- a/src/main/permission-grants/application-commands.test.ts
+++ b/src/main/permission-grants/application-commands.test.ts
@@ -1,0 +1,81 @@
+import { describe, expect, it, vi } from 'vitest'
+
+import type { PermissionGrantSnapshot } from '../../shared/permission-grants'
+import { RENDERER_CONTRACT_GROUPS } from '../../shared/renderer-contract-catalog'
+import {
+  createApplicationCommandRouter,
+  type ApplicationCallerLease,
+  type ApplicationInvocation
+} from '../application-command-router'
+import { createWebCallerContext } from '../caller-context'
+import {
+  permissionGrantApplicationCommandGroup,
+  permissionGrantApplicationCommands,
+  registerPermissionGrantApplicationCommands,
+  type PermissionGrantCommandOwner
+} from './application-commands'
+
+const snapshot: PermissionGrantSnapshot = {
+  version: 4,
+  incompleteStores: [],
+  grants: [],
+  counts: { all: 0, global: 0, project: 0, session: 0 }
+}
+
+const createOwner = (): PermissionGrantCommandOwner => ({
+  list: vi.fn(async () => snapshot),
+  revoke: vi.fn(async () => ({ ...snapshot, receipt: undefined, conflicts: [] })),
+  extendUndo: vi.fn(async () => ({ undoToken: 'undo-1', expiresAt: 10, revokedCount: 1 })),
+  restore: vi.fn(async () => ({ ...snapshot, conflicts: [] }))
+})
+
+const invocation = <Args extends readonly unknown[]>(args: Args): ApplicationInvocation<Args> => {
+  const callerContext = createWebCallerContext('remote-web', { location: 'remote' })
+  const callerLease: ApplicationCallerLease = Object.freeze({
+    leaseId: callerContext.leaseId,
+    generation: 1,
+    signal: new AbortController().signal,
+    isCurrent: () => true
+  })
+  return Object.freeze({ args, callerContext, callerLease })
+}
+
+describe('Permission Grant application commands', () => {
+  it('defines exactly the four registry-management commands', () => {
+    const publicPermissionChannels = RENDERER_CONTRACT_GROUPS.find(
+      (group) => group.capability === 'permissions'
+    )
+      ?.contracts.filter((contract) => contract.kind === 'method')
+      .map((contract) => contract.channel)
+
+    expect(publicPermissionChannels).toHaveLength(4)
+    expect(permissionGrantApplicationCommandGroup.commands.map(({ name }) => name)).toEqual(
+      publicPermissionChannels
+    )
+  })
+
+  it('delegates management to one injected projection owner without adding a caller guard', async () => {
+    const owner = createOwner()
+    const router = createApplicationCommandRouter()
+    const installation = registerPermissionGrantApplicationCommands(router.registrar, owner)
+    const revoke = { grants: [{ id: 'grant-1', revision: 2 }] }
+    const undo = { undoToken: 'undo-1' }
+
+    await expect(
+      router.dispatcher.invoke(permissionGrantApplicationCommands.list, invocation([]))
+    ).resolves.toBe(snapshot)
+    await router.dispatcher.invoke(permissionGrantApplicationCommands.revoke, invocation([revoke]))
+    await router.dispatcher.invoke(
+      permissionGrantApplicationCommands.extendUndo,
+      invocation([undo])
+    )
+    await router.dispatcher.invoke(permissionGrantApplicationCommands.restore, invocation([undo]))
+
+    expect(owner.revoke).toHaveBeenCalledWith(revoke)
+    expect(owner.extendUndo).toHaveBeenCalledWith(undo)
+    expect(owner.restore).toHaveBeenCalledWith(undo)
+
+    installation.uninstall()
+    expect(router.dispatcher.commandNames()).toEqual([])
+  })
+})

--- a/src/main/permission-grants/application-commands.ts
+++ b/src/main/permission-grants/application-commands.ts
@@ -1,0 +1,80 @@
+import type {
+  PermissionGrantMutationView,
+  PermissionGrantRestoreRequest,
+  PermissionGrantRevokeRequest,
+  PermissionGrantSnapshot,
+  PermissionGrantUndoExtendRequest,
+  PermissionGrantUndoReceipt
+} from '../../shared/permission-grants'
+import {
+  defineApplicationCommand,
+  defineApplicationCommandGroup,
+  type ApplicationCommandInstallation,
+  type ApplicationCommandRegistrar
+} from '../application-command-router'
+
+// Composition injects one projection owner. Command registration deliberately does not subscribe,
+// publish permissions:changed, or dispose the owner, so Electron and application adapters cannot
+// create competing revision controllers.
+type PermissionGrantCommandOwner = Readonly<{
+  list(): Promise<PermissionGrantSnapshot>
+  revoke(request: PermissionGrantRevokeRequest): Promise<PermissionGrantMutationView>
+  extendUndo(
+    request: PermissionGrantUndoExtendRequest
+  ): Promise<PermissionGrantUndoReceipt | undefined>
+  restore(request: PermissionGrantRestoreRequest): Promise<PermissionGrantMutationView>
+}>
+
+const permissionGrantApplicationCommands = Object.freeze({
+  list: defineApplicationCommand<'permissions:list', readonly [], PermissionGrantSnapshot>(
+    'permissions:list'
+  ),
+  revoke: defineApplicationCommand<
+    'permissions:revoke',
+    readonly [request: PermissionGrantRevokeRequest],
+    PermissionGrantMutationView
+  >('permissions:revoke'),
+  extendUndo: defineApplicationCommand<
+    'permissions:extend-undo',
+    readonly [request: PermissionGrantUndoExtendRequest],
+    PermissionGrantUndoReceipt | undefined
+  >('permissions:extend-undo'),
+  restore: defineApplicationCommand<
+    'permissions:restore',
+    readonly [request: PermissionGrantRestoreRequest],
+    PermissionGrantMutationView
+  >('permissions:restore')
+})
+
+const permissionGrantApplicationCommandGroup = defineApplicationCommandGroup('permission-grants', [
+  permissionGrantApplicationCommands.extendUndo,
+  permissionGrantApplicationCommands.list,
+  permissionGrantApplicationCommands.restore,
+  permissionGrantApplicationCommands.revoke
+] as const)
+
+const registerPermissionGrantApplicationCommands = (
+  registrar: ApplicationCommandRegistrar,
+  owner: PermissionGrantCommandOwner
+): ApplicationCommandInstallation => {
+  const scope = registrar.createScope()
+  try {
+    scope.registerGroup(permissionGrantApplicationCommandGroup, {
+      'permissions:list': () => owner.list(),
+      'permissions:revoke': ({ args }) => owner.revoke(args[0]),
+      'permissions:extend-undo': ({ args }) => owner.extendUndo(args[0]),
+      'permissions:restore': ({ args }) => owner.restore(args[0])
+    })
+    return scope.complete()
+  } catch (error) {
+    scope.rollback()
+    throw error
+  }
+}
+
+export {
+  permissionGrantApplicationCommandGroup,
+  permissionGrantApplicationCommands,
+  registerPermissionGrantApplicationCommands
+}
+export type { PermissionGrantCommandOwner }

--- a/src/main/permission-grants/ipc.test.ts
+++ b/src/main/permission-grants/ipc.test.ts
@@ -104,6 +104,29 @@ describe('permission grant IPC', () => {
     expect(broadcast).toHaveBeenLastCalledWith('permissions:changed', { revision: 2 })
   })
 
+  it('owns one Registry subscription and releases that subscription on disposal', () => {
+    const unsubscribe = vi.fn()
+    const registry = {
+      subscribe: vi.fn(() => unsubscribe)
+    } as unknown as PermissionGrantRegistry
+    const broadcast = vi.fn()
+
+    const controller = registerPermissionGrantIpcHandlers({
+      registry,
+      projects: { list: vi.fn().mockResolvedValue([]) },
+      sessions: { metadataSnapshot: vi.fn().mockResolvedValue({ sessions: [], isComplete: true }) },
+      broadcast
+    })
+
+    expect(registry.subscribe).toHaveBeenCalledOnce()
+    controller.invalidateProjection()
+    expect(broadcast).toHaveBeenCalledOnce()
+    expect(broadcast).toHaveBeenCalledWith('permissions:changed', { revision: 1 })
+
+    controller.dispose()
+    expect(unsubscribe).toHaveBeenCalledOnce()
+  })
+
   it('rejects an empty revoke request at the IPC boundary', async () => {
     const registry = {
       subscribe: vi.fn(() => () => undefined)


### PR DESCRIPTION
# T2e pull request

Title: `refactor(compute): define permission-aware commands`

## Problem

Compute and Permission capabilities need typed owner-local command groups before atomic composition.
The boundary must preserve the intentionally asymmetric Electron/Web/Task/CLI matrix and keep human
approval authority separate from Permission grant-registry management.

## Proposed change

- Define exactly 21 public Compute commands: 19 Compute handlers plus the two Settings-owned bookmark
  operations through a narrow port.
- Define exactly four Permission grant-registry commands while preserving a single projection owner
  for subscription, revision, validation, retry, and disposal.
- Preserve the public object codecs for Compute delete and approval response while unpacking them into
  the existing owner methods.
- Reuse the existing serialized RemoteFsError translation.
- Enforce the existing local-only boundary for Compute download/reveal in the command layer, in
  addition to the current remote-Web transport rejection.
- Require a current human-originated caller only for Compute approval response; do not add an
  unrelated local-only guard to Permission management.

```mermaid
flowchart LR
  C["Compute commands - 21"] --> O["Existing Compute owners"]
  C --> B["Settings bookmark port"]
  P["Permission commands - 4"] --> G["Single grant projection owner"]
  H["T2h0 atomic composition - future"] -.-> C
  H -.-> P
```

## Scope and non-goals

- Delivery boundary: these are intentionally staged compile-time groups. T2h0 installs all groups in
  one atomic router and T2h1 cuts over adapters; this PR does not claim live transports use the new
  guards yet.
- `compute:session:*` remains non-public and excluded.
- Electron/local Web Compute remains complete; remote callers reject download/reveal before owner
  invocation at both transport and application-command boundaries; CLI retains no direct Compute
  management API.
- Permission stays complete on Electron/Web; Task/CLI retain their current run-profile/event subset;
  Specialist remains Electron-only.
- No global composition/transport, public wire/type/event, persisted data, UI, capability expansion,
  or Issue #458 orchestration change.

## Acceptance criteria and validation

All checks below ran after the last material edit.

- Exact Compute 21 / Permission 4 inventories and `compute:session:*` exclusion -> focused command
  tests -> passed.
- Args/Results, RemoteFsError serialization, and bookmark narrow port -> focused Compute tests ->
  passed.
- Delete `{ providerId }` and approval `{ id, decision }` public request objects unpack to the existing
  owner positional methods -> focused codec test -> passed.
- Compute approval allows current human callers and rejects agent-session, Task/automation, and stale
  callers before owner invocation -> focused authority matrix -> passed.
- Compute download/reveal reject remote callers before owner invocation with the existing local-app
  error, while Electron/local Web remain allowed -> focused command test -> passed.
- Permission commands preserve the single subscription/revision/disposal owner without a local-only
  guard or duplicate event publication -> focused Permission tests -> passed.
- Compute/Permission focused set -> 5 files / 68 tests passed.
- Latest changed command/IPC set -> 3 files / 12 tests passed.
- Remote Web capability/pre-dispatch matrix -> 2 tests passed.
- `npm run typecheck:node` -> passed.
- Targeted ESLint, Prettier, and `git diff --check` -> passed.
- Independent Standards and Spec reviews -> 0 actionable findings.
- Full and cross-platform suites are delegated to online CI.

## Review focus

- Only Compute approval response receives the human guard; Permission registry management retains its
  current Electron/Web policy.
- The command adapter must not own Permission subscriptions/revisions or double-publish changes.
- Production churn is 357 lines, below the 500-line hard stop.

## Uncovered risk

Real dependency composition and the single production Permission projection injection are deferred
to T2h0; Web codecs and transport cutover remain T2h1-owned. Full cross-platform behavior is covered
by online CI.
