### PR TITLE
refactor(settings): define core application commands

### DIFF
--- a/src/main/settings/application-commands.test.ts
+++ b/src/main/settings/application-commands.test.ts
@@ -1,0 +1,323 @@
+import { describe, expect, it, vi } from 'vitest'
+
+import { RENDERER_CONTRACT_GROUPS } from '../../shared/renderer-contract-catalog'
+import {
+  createApplicationCommandRouter,
+  type ApplicationCallerLease,
+  type ApplicationCommand,
+  type ApplicationInvocation
+} from '../application-command-router'
+import { createWebCallerContext } from '../caller-context'
+import {
+  registerCoreSettingsApplicationCommands,
+  settingsCoreApplicationCommandGroup,
+  settingsCoreApplicationCommands,
+  type CoreSettingsApplicationCommandDependencies
+} from './application-commands'
+
+const expectedChannels = [
+  'settings:cancel-claude-login',
+  'settings:cancel-codex-login',
+  'settings:cancel-isolated-claude-login',
+  'settings:check-environment',
+  'settings:detect-claude',
+  'settings:detect-codex',
+  'settings:detect-opencode',
+  'settings:get-connector-detail',
+  'settings:get-package-mirror',
+  'settings:get-preflight',
+  'settings:get-settings',
+  'settings:get-skill-detail',
+  'settings:install-claude',
+  'settings:install-codex',
+  'settings:install-opencode',
+  'settings:encryption-available',
+  'settings:npm-available',
+  'settings:list-app-icons',
+  'settings:list-connectors',
+  'settings:list-skills',
+  'settings:mark-onboarding-complete',
+  'settings:preview-agent-home-skill',
+  'settings:preview-github-skill',
+  'settings:preview-skill-zip',
+  'settings:refresh-provider-models',
+  'settings:scan-repo-skills',
+  'settings:set-app-icon-variant',
+  'settings:set-close-preference',
+  'settings:set-notifications-enabled',
+  'settings:set-package-mirror',
+  'settings:validate-provider'
+] as const
+
+type CommandArgs<Command> =
+  Command extends ApplicationCommand<string, infer Args, unknown> ? Args : never
+
+const callerLease = (): ApplicationCallerLease =>
+  Object.freeze({
+    leaseId: 'settings-client',
+    generation: 1,
+    signal: new AbortController().signal,
+    isCurrent: () => true
+  })
+
+const invocation = <Args extends readonly unknown[]>(
+  args: Args,
+  location: 'local' | 'remote' = 'local'
+): ApplicationInvocation<Args> =>
+  Object.freeze({
+    callerContext: createWebCallerContext('settings-client', { location }),
+    callerLease: callerLease(),
+    args
+  })
+
+const createDependencies = (): Readonly<{
+  appearance: ReturnType<typeof vi.fn>
+  dependencies: CoreSettingsApplicationCommandDependencies
+  emitInstallEvent: ReturnType<typeof vi.fn>
+  serviceMethod: (
+    name: keyof CoreSettingsApplicationCommandDependencies['service']
+  ) => ReturnType<typeof vi.fn>
+}> => {
+  const methods = new Map<PropertyKey, ReturnType<typeof vi.fn>>()
+  const service = new Proxy(
+    {},
+    {
+      get: (_target, property) => {
+        let method = methods.get(property)
+        if (!method) {
+          method = vi.fn()
+          methods.set(property, method)
+        }
+        return method
+      }
+    }
+  ) as CoreSettingsApplicationCommandDependencies['service']
+  const appearance = vi.fn()
+  const emitInstallEvent = vi.fn()
+
+  return {
+    appearance,
+    dependencies: {
+      service,
+      appearance: { setAppIconVariant: appearance },
+      emitInstallEvent,
+      listAppIconPreviews: vi.fn(() => [])
+    },
+    emitInstallEvent,
+    serviceMethod: (name) => service[name] as ReturnType<typeof vi.fn>
+  }
+}
+
+describe('Settings core application commands', () => {
+  it('installs the exact 31-command inventory and dispatches a remote-safe preflight query', async () => {
+    const { dependencies, serviceMethod } = createDependencies()
+    const preflight = { agentReady: true }
+    serviceMethod('getPreflight').mockResolvedValue(preflight)
+    const router = createApplicationCommandRouter()
+    registerCoreSettingsApplicationCommands(router.registrar, dependencies)
+    const settingsChannels = RENDERER_CONTRACT_GROUPS.find(
+      (group) => group.capability === 'settings'
+    )?.contracts.map((contract) => contract.channel)
+
+    expect(settingsCoreApplicationCommandGroup.commands.map((command) => command.name)).toEqual(
+      expectedChannels
+    )
+    expect(settingsChannels).toEqual(expect.arrayContaining([...expectedChannels]))
+    expect(router.dispatcher.commandNames()).toEqual([...expectedChannels].sort())
+    await expect(
+      router.dispatcher.invoke(
+        settingsCoreApplicationCommands.getPreflight,
+        invocation([] as const, 'remote')
+      )
+    ).resolves.toBe(preflight)
+    expect(serviceMethod('getPreflight')).toHaveBeenCalledOnce()
+  })
+
+  it('delegates canonical requests for every direct remote-safe owner command', async () => {
+    const { dependencies, serviceMethod } = createDependencies()
+    const router = createApplicationCommandRouter()
+    registerCoreSettingsApplicationCommands(router.registrar, dependencies)
+    const invoke = <Command extends keyof typeof settingsCoreApplicationCommands>(
+      command: Command,
+      args: CommandArgs<(typeof settingsCoreApplicationCommands)[Command]>
+    ): Promise<unknown> =>
+      router.dispatcher.invoke(settingsCoreApplicationCommands[command], invocation(args, 'remote'))
+
+    await invoke('checkEnvironment', [])
+    await invoke('detectClaude', [])
+    await invoke('detectCodex', [])
+    await invoke('detectOpencode', [])
+    await invoke('getConnectorDetail', ['connector-1'])
+    await invoke('getPackageMirror', [])
+    await invoke('getSettings', [])
+    await invoke('getSkillDetail', ['skill-1'])
+    await invoke('isEncryptionAvailable', [])
+    await invoke('isNpmAvailable', [])
+    await invoke('listAppIcons', [])
+    await invoke('listConnectors', [])
+    await invoke('listSkills', [])
+    await invoke('markOnboardingComplete', [])
+    await invoke('previewAgentHomeSkill', [{ source: 'agents', slug: 'demo' }])
+    await invoke('previewGitHubSkill', [{ url: 'https://github.com/org/repo' }])
+    await invoke('previewSkillZip', [{ dataBase64: 'AA==' }])
+    await invoke('refreshProviderModels', [{ providerId: 'provider-1' }])
+    await invoke('scanRepoSkills', [{ repo: 'org/repo' }])
+    await invoke('validateProvider', [{ providerId: 'provider-1' }])
+
+    expect(serviceMethod('getConnectorDetail')).toHaveBeenCalledWith('connector-1')
+    expect(serviceMethod('getSkillDetail')).toHaveBeenCalledWith('skill-1')
+    expect(serviceMethod('previewAgentHomeSkill')).toHaveBeenCalledWith({
+      source: 'agents',
+      slug: 'demo'
+    })
+    expect(serviceMethod('previewGitHubSkill')).toHaveBeenCalledWith({
+      url: 'https://github.com/org/repo'
+    })
+    expect(serviceMethod('previewSkillZip')).toHaveBeenCalledWith({ dataBase64: 'AA==' })
+    expect(serviceMethod('refreshProviderModels')).toHaveBeenCalledWith({
+      providerId: 'provider-1'
+    })
+    expect(serviceMethod('scanRepoSkills')).toHaveBeenCalledWith({ repo: 'org/repo' })
+    expect(serviceMethod('validateProvider')).toHaveBeenCalledWith({ providerId: 'provider-1' })
+  })
+
+  it('rejects all ten local-only commands before an owner can run', async () => {
+    const { appearance, dependencies, serviceMethod } = createDependencies()
+    const router = createApplicationCommandRouter()
+    registerCoreSettingsApplicationCommands(router.registrar, dependencies)
+
+    const attempts = [
+      [settingsCoreApplicationCommands.cancelClaudeLogin, []],
+      [settingsCoreApplicationCommands.cancelCodexLogin, []],
+      [settingsCoreApplicationCommands.cancelIsolatedClaudeLogin, []],
+      [settingsCoreApplicationCommands.installClaude, [{ source: 'managed' }]],
+      [settingsCoreApplicationCommands.installCodex, [{ source: 'managed' }]],
+      [settingsCoreApplicationCommands.installOpencode, [{ source: 'managed' }]],
+      [settingsCoreApplicationCommands.setAppIconVariant, [{ variant: 'dark' }]],
+      [settingsCoreApplicationCommands.setClosePreference, [{ preference: 'quit' }]],
+      [settingsCoreApplicationCommands.setNotificationsEnabled, [{ enabled: true }]],
+      [settingsCoreApplicationCommands.setPackageMirror, [{}]]
+    ] as const
+
+    for (const [command, args] of attempts) {
+      await expect(router.dispatcher.invoke(command, invocation(args, 'remote'))).rejects.toThrow(
+        `Channel only available from the local app: ${command.name}`
+      )
+    }
+    expect(serviceMethod('cancelClaudeLogin')).not.toHaveBeenCalled()
+    expect(serviceMethod('cancelCodexLogin')).not.toHaveBeenCalled()
+    expect(serviceMethod('cancelClaudeIsolatedLogin')).not.toHaveBeenCalled()
+    expect(serviceMethod('installClaude')).not.toHaveBeenCalled()
+    expect(serviceMethod('installCodex')).not.toHaveBeenCalled()
+    expect(serviceMethod('installOpencode')).not.toHaveBeenCalled()
+    expect(appearance).not.toHaveBeenCalled()
+    expect(serviceMethod('setClosePreference')).not.toHaveBeenCalled()
+    expect(serviceMethod('setNotificationsEnabled')).not.toHaveBeenCalled()
+    expect(serviceMethod('setPackageMirror')).not.toHaveBeenCalled()
+  })
+
+  it('delegates local requests without taking persistence or native-effect ownership', async () => {
+    const { appearance, dependencies, emitInstallEvent, serviceMethod } = createDependencies()
+    const installEvent = {
+      kind: 'log' as const,
+      installId: 'install-1',
+      stream: 'system' as const,
+      chunk: 'started'
+    }
+    serviceMethod('installClaude').mockImplementation(async (_request, onEvent) => {
+      onEvent(installEvent)
+      return { installId: 'install-1', ok: true }
+    })
+    const router = createApplicationCommandRouter()
+    registerCoreSettingsApplicationCommands(router.registrar, dependencies)
+
+    await router.dispatcher.invoke(
+      settingsCoreApplicationCommands.cancelClaudeLogin,
+      invocation([] as const)
+    )
+    await router.dispatcher.invoke(
+      settingsCoreApplicationCommands.cancelCodexLogin,
+      invocation([] as const)
+    )
+    await router.dispatcher.invoke(
+      settingsCoreApplicationCommands.cancelIsolatedClaudeLogin,
+      invocation([] as const)
+    )
+    await router.dispatcher.invoke(
+      settingsCoreApplicationCommands.installClaude,
+      invocation([{ source: 'managed' }] as const)
+    )
+    await router.dispatcher.invoke(
+      settingsCoreApplicationCommands.installCodex,
+      invocation([{ source: 'npm' }] as const)
+    )
+    await router.dispatcher.invoke(
+      settingsCoreApplicationCommands.installOpencode,
+      invocation([{ source: 'official-script' }] as const)
+    )
+    await router.dispatcher.invoke(
+      settingsCoreApplicationCommands.setAppIconVariant,
+      invocation([{ variant: 'dark' }] as const)
+    )
+    await router.dispatcher.invoke(
+      settingsCoreApplicationCommands.setClosePreference,
+      invocation([{}] as const)
+    )
+    await router.dispatcher.invoke(
+      settingsCoreApplicationCommands.setNotificationsEnabled,
+      invocation([{ enabled: false }] as const)
+    )
+    const mirror = { pypiIndex: 'https://pypi.example/simple' }
+    await router.dispatcher.invoke(
+      settingsCoreApplicationCommands.setPackageMirror,
+      invocation([mirror] as const)
+    )
+
+    expect(serviceMethod('cancelClaudeLogin')).toHaveBeenCalledOnce()
+    expect(serviceMethod('cancelCodexLogin')).toHaveBeenCalledOnce()
+    expect(serviceMethod('cancelClaudeIsolatedLogin')).toHaveBeenCalledOnce()
+    expect(serviceMethod('installClaude')).toHaveBeenCalledWith(
+      { source: 'managed' },
+      emitInstallEvent
+    )
+    expect(serviceMethod('installCodex')).toHaveBeenCalledWith({ source: 'npm' }, emitInstallEvent)
+    expect(serviceMethod('installOpencode')).toHaveBeenCalledWith(
+      { source: 'official-script' },
+      emitInstallEvent
+    )
+    expect(emitInstallEvent).toHaveBeenCalledWith(installEvent)
+    expect(appearance).toHaveBeenCalledWith('dark')
+    expect(serviceMethod('setClosePreference')).toHaveBeenCalledWith(undefined)
+    expect(serviceMethod('setNotificationsEnabled')).toHaveBeenCalledWith(false)
+    expect(serviceMethod('setPackageMirror')).toHaveBeenCalledWith(mirror)
+  })
+
+  it('preserves exact validation errors before Settings or appearance owners run', async () => {
+    const { appearance, dependencies, serviceMethod } = createDependencies()
+    const router = createApplicationCommandRouter()
+    registerCoreSettingsApplicationCommands(router.registrar, dependencies)
+
+    await expect(
+      router.dispatcher.invoke(
+        settingsCoreApplicationCommands.setAppIconVariant,
+        invocation([{ variant: 'sparkle' } as never] as const)
+      )
+    ).rejects.toThrow('Unknown app icon variant: sparkle')
+    await expect(
+      router.dispatcher.invoke(
+        settingsCoreApplicationCommands.setClosePreference,
+        invocation([{ preference: 'close' } as never] as const)
+      )
+    ).rejects.toThrow('Invalid close preference: close')
+    await expect(
+      router.dispatcher.invoke(
+        settingsCoreApplicationCommands.setNotificationsEnabled,
+        invocation([{ enabled: 'yes' } as never] as const)
+      )
+    ).rejects.toThrow('Invalid notifications-enabled flag: yes')
+
+    expect(appearance).not.toHaveBeenCalled()
+    expect(serviceMethod('setClosePreference')).not.toHaveBeenCalled()
+    expect(serviceMethod('setNotificationsEnabled')).not.toHaveBeenCalled()
+  })
+})

--- a/src/main/settings/application-commands.ts
+++ b/src/main/settings/application-commands.ts
@@ -1,0 +1,361 @@
+import type {
+  AppIconPreview,
+  ClaudeInstallEvent,
+  InstallClaudeRequest,
+  InstallCodexRequest,
+  InstallOpencodeRequest,
+  PreviewAgentHomeSkillRequest,
+  PreviewGitHubSkillRequest,
+  PreviewSkillZipRequest,
+  RefreshProviderModelsRequest,
+  ScanRepoRequest,
+  SetAppIconVariantRequest,
+  SetClosePreferenceRequest,
+  SetNotificationsEnabledRequest,
+  SetPackageMirrorRequest,
+  ValidateProviderRequest
+} from '../../shared/settings'
+import {
+  defineApplicationCommand,
+  defineApplicationCommandGroup,
+  type ApplicationCommandInstallation,
+  type ApplicationCommandRegistrar
+} from '../application-command-router'
+import type { CallerContext } from '../caller-context'
+import type { SettingsService } from './service'
+import {
+  readAppIconVariant,
+  readClosePreference,
+  readNotificationsEnabled
+} from './transport-validation'
+import type { AppearanceSettingsWorkflows } from './workflows/appearance'
+
+type CoreSettingsCommandStore = Pick<
+  SettingsService,
+  | 'cancelClaudeLogin'
+  | 'cancelCodexLogin'
+  | 'cancelClaudeIsolatedLogin'
+  | 'checkEnvironment'
+  | 'detectClaude'
+  | 'detectCodex'
+  | 'detectOpencode'
+  | 'getConnectorDetail'
+  | 'getPackageMirror'
+  | 'getPreflight'
+  | 'getSettingsView'
+  | 'getSkillDetail'
+  | 'installClaude'
+  | 'installCodex'
+  | 'installOpencode'
+  | 'isEncryptionAvailable'
+  | 'isNpmAvailable'
+  | 'listConnectors'
+  | 'listSkills'
+  | 'markOnboardingComplete'
+  | 'previewAgentHomeSkill'
+  | 'previewGitHubSkill'
+  | 'previewSkillZip'
+  | 'refreshProviderModels'
+  | 'scanRepoSkills'
+  | 'setClosePreference'
+  | 'setNotificationsEnabled'
+  | 'setPackageMirror'
+  | 'validateProvider'
+>
+
+type StoreResult<Method extends keyof CoreSettingsCommandStore> =
+  CoreSettingsCommandStore[Method] extends (...args: infer _Args) => infer Result
+    ? Awaited<Result>
+    : never
+type AppearanceResult = Awaited<ReturnType<AppearanceSettingsWorkflows['setAppIconVariant']>>
+
+const settingsCoreApplicationCommands = Object.freeze({
+  cancelClaudeLogin: defineApplicationCommand<
+    'settings:cancel-claude-login',
+    readonly [],
+    StoreResult<'cancelClaudeLogin'>
+  >('settings:cancel-claude-login'),
+  cancelCodexLogin: defineApplicationCommand<
+    'settings:cancel-codex-login',
+    readonly [],
+    StoreResult<'cancelCodexLogin'>
+  >('settings:cancel-codex-login'),
+  cancelIsolatedClaudeLogin: defineApplicationCommand<
+    'settings:cancel-isolated-claude-login',
+    readonly [],
+    StoreResult<'cancelClaudeIsolatedLogin'>
+  >('settings:cancel-isolated-claude-login'),
+  checkEnvironment: defineApplicationCommand<
+    'settings:check-environment',
+    readonly [],
+    StoreResult<'checkEnvironment'>
+  >('settings:check-environment'),
+  detectClaude: defineApplicationCommand<
+    'settings:detect-claude',
+    readonly [],
+    StoreResult<'detectClaude'>
+  >('settings:detect-claude'),
+  detectCodex: defineApplicationCommand<
+    'settings:detect-codex',
+    readonly [],
+    StoreResult<'detectCodex'>
+  >('settings:detect-codex'),
+  detectOpencode: defineApplicationCommand<
+    'settings:detect-opencode',
+    readonly [],
+    StoreResult<'detectOpencode'>
+  >('settings:detect-opencode'),
+  getConnectorDetail: defineApplicationCommand<
+    'settings:get-connector-detail',
+    readonly [id: string],
+    StoreResult<'getConnectorDetail'>
+  >('settings:get-connector-detail'),
+  getPackageMirror: defineApplicationCommand<
+    'settings:get-package-mirror',
+    readonly [],
+    StoreResult<'getPackageMirror'>
+  >('settings:get-package-mirror'),
+  getPreflight: defineApplicationCommand<
+    'settings:get-preflight',
+    readonly [],
+    StoreResult<'getPreflight'>
+  >('settings:get-preflight'),
+  getSettings: defineApplicationCommand<
+    'settings:get-settings',
+    readonly [],
+    StoreResult<'getSettingsView'>
+  >('settings:get-settings'),
+  getSkillDetail: defineApplicationCommand<
+    'settings:get-skill-detail',
+    readonly [id: string],
+    StoreResult<'getSkillDetail'>
+  >('settings:get-skill-detail'),
+  installClaude: defineApplicationCommand<
+    'settings:install-claude',
+    readonly [request: InstallClaudeRequest],
+    StoreResult<'installClaude'>
+  >('settings:install-claude'),
+  installCodex: defineApplicationCommand<
+    'settings:install-codex',
+    readonly [request: InstallCodexRequest],
+    StoreResult<'installCodex'>
+  >('settings:install-codex'),
+  installOpencode: defineApplicationCommand<
+    'settings:install-opencode',
+    readonly [request: InstallOpencodeRequest],
+    StoreResult<'installOpencode'>
+  >('settings:install-opencode'),
+  isEncryptionAvailable: defineApplicationCommand<
+    'settings:encryption-available',
+    readonly [],
+    StoreResult<'isEncryptionAvailable'>
+  >('settings:encryption-available'),
+  isNpmAvailable: defineApplicationCommand<
+    'settings:npm-available',
+    readonly [],
+    StoreResult<'isNpmAvailable'>
+  >('settings:npm-available'),
+  listAppIcons: defineApplicationCommand<'settings:list-app-icons', readonly [], AppIconPreview[]>(
+    'settings:list-app-icons'
+  ),
+  listConnectors: defineApplicationCommand<
+    'settings:list-connectors',
+    readonly [],
+    StoreResult<'listConnectors'>
+  >('settings:list-connectors'),
+  listSkills: defineApplicationCommand<
+    'settings:list-skills',
+    readonly [],
+    StoreResult<'listSkills'>
+  >('settings:list-skills'),
+  markOnboardingComplete: defineApplicationCommand<
+    'settings:mark-onboarding-complete',
+    readonly [],
+    StoreResult<'markOnboardingComplete'>
+  >('settings:mark-onboarding-complete'),
+  previewAgentHomeSkill: defineApplicationCommand<
+    'settings:preview-agent-home-skill',
+    readonly [request: PreviewAgentHomeSkillRequest],
+    StoreResult<'previewAgentHomeSkill'>
+  >('settings:preview-agent-home-skill'),
+  previewGitHubSkill: defineApplicationCommand<
+    'settings:preview-github-skill',
+    readonly [request: PreviewGitHubSkillRequest],
+    StoreResult<'previewGitHubSkill'>
+  >('settings:preview-github-skill'),
+  previewSkillZip: defineApplicationCommand<
+    'settings:preview-skill-zip',
+    readonly [request: PreviewSkillZipRequest],
+    StoreResult<'previewSkillZip'>
+  >('settings:preview-skill-zip'),
+  refreshProviderModels: defineApplicationCommand<
+    'settings:refresh-provider-models',
+    readonly [request: RefreshProviderModelsRequest],
+    StoreResult<'refreshProviderModels'>
+  >('settings:refresh-provider-models'),
+  scanRepoSkills: defineApplicationCommand<
+    'settings:scan-repo-skills',
+    readonly [request: ScanRepoRequest],
+    StoreResult<'scanRepoSkills'>
+  >('settings:scan-repo-skills'),
+  setAppIconVariant: defineApplicationCommand<
+    'settings:set-app-icon-variant',
+    readonly [request: SetAppIconVariantRequest],
+    AppearanceResult
+  >('settings:set-app-icon-variant'),
+  setClosePreference: defineApplicationCommand<
+    'settings:set-close-preference',
+    readonly [request: SetClosePreferenceRequest],
+    StoreResult<'setClosePreference'>
+  >('settings:set-close-preference'),
+  setNotificationsEnabled: defineApplicationCommand<
+    'settings:set-notifications-enabled',
+    readonly [request: SetNotificationsEnabledRequest],
+    StoreResult<'setNotificationsEnabled'>
+  >('settings:set-notifications-enabled'),
+  setPackageMirror: defineApplicationCommand<
+    'settings:set-package-mirror',
+    readonly [request: SetPackageMirrorRequest],
+    StoreResult<'setPackageMirror'>
+  >('settings:set-package-mirror'),
+  validateProvider: defineApplicationCommand<
+    'settings:validate-provider',
+    readonly [request: ValidateProviderRequest],
+    StoreResult<'validateProvider'>
+  >('settings:validate-provider')
+})
+
+const settingsCoreApplicationCommandGroup = defineApplicationCommandGroup('settings-core', [
+  settingsCoreApplicationCommands.cancelClaudeLogin,
+  settingsCoreApplicationCommands.cancelCodexLogin,
+  settingsCoreApplicationCommands.cancelIsolatedClaudeLogin,
+  settingsCoreApplicationCommands.checkEnvironment,
+  settingsCoreApplicationCommands.detectClaude,
+  settingsCoreApplicationCommands.detectCodex,
+  settingsCoreApplicationCommands.detectOpencode,
+  settingsCoreApplicationCommands.getConnectorDetail,
+  settingsCoreApplicationCommands.getPackageMirror,
+  settingsCoreApplicationCommands.getPreflight,
+  settingsCoreApplicationCommands.getSettings,
+  settingsCoreApplicationCommands.getSkillDetail,
+  settingsCoreApplicationCommands.installClaude,
+  settingsCoreApplicationCommands.installCodex,
+  settingsCoreApplicationCommands.installOpencode,
+  settingsCoreApplicationCommands.isEncryptionAvailable,
+  settingsCoreApplicationCommands.isNpmAvailable,
+  settingsCoreApplicationCommands.listAppIcons,
+  settingsCoreApplicationCommands.listConnectors,
+  settingsCoreApplicationCommands.listSkills,
+  settingsCoreApplicationCommands.markOnboardingComplete,
+  settingsCoreApplicationCommands.previewAgentHomeSkill,
+  settingsCoreApplicationCommands.previewGitHubSkill,
+  settingsCoreApplicationCommands.previewSkillZip,
+  settingsCoreApplicationCommands.refreshProviderModels,
+  settingsCoreApplicationCommands.scanRepoSkills,
+  settingsCoreApplicationCommands.setAppIconVariant,
+  settingsCoreApplicationCommands.setClosePreference,
+  settingsCoreApplicationCommands.setNotificationsEnabled,
+  settingsCoreApplicationCommands.setPackageMirror,
+  settingsCoreApplicationCommands.validateProvider
+] as const)
+
+type CoreSettingsApplicationCommandDependencies = Readonly<{
+  service: CoreSettingsCommandStore
+  appearance: Pick<AppearanceSettingsWorkflows, 'setAppIconVariant'>
+  emitInstallEvent: (event: ClaudeInstallEvent) => void
+  listAppIconPreviews?: () => AppIconPreview[]
+}>
+
+const requireLocalCaller = (context: CallerContext, channel: string): void => {
+  if (context.location !== 'local') {
+    throw new Error(`Channel only available from the local app: ${channel}`)
+  }
+}
+
+const registerCoreSettingsApplicationCommands = (
+  registrar: ApplicationCommandRegistrar,
+  dependencies: CoreSettingsApplicationCommandDependencies
+): ApplicationCommandInstallation => {
+  const scope = registrar.createScope()
+
+  try {
+    scope.registerGroup(settingsCoreApplicationCommandGroup, {
+      'settings:cancel-claude-login': ({ callerContext }) => {
+        requireLocalCaller(callerContext, 'settings:cancel-claude-login')
+        return dependencies.service.cancelClaudeLogin()
+      },
+      'settings:cancel-codex-login': ({ callerContext }) => {
+        requireLocalCaller(callerContext, 'settings:cancel-codex-login')
+        return dependencies.service.cancelCodexLogin()
+      },
+      'settings:cancel-isolated-claude-login': ({ callerContext }) => {
+        requireLocalCaller(callerContext, 'settings:cancel-isolated-claude-login')
+        return dependencies.service.cancelClaudeIsolatedLogin()
+      },
+      'settings:check-environment': () => dependencies.service.checkEnvironment(),
+      'settings:detect-claude': () => dependencies.service.detectClaude(),
+      'settings:detect-codex': () => dependencies.service.detectCodex(),
+      'settings:detect-opencode': () => dependencies.service.detectOpencode(),
+      'settings:get-connector-detail': ({ args }) =>
+        dependencies.service.getConnectorDetail(args[0]),
+      'settings:get-package-mirror': () => dependencies.service.getPackageMirror(),
+      'settings:get-preflight': () => dependencies.service.getPreflight(),
+      'settings:get-settings': () => dependencies.service.getSettingsView(),
+      'settings:get-skill-detail': ({ args }) => dependencies.service.getSkillDetail(args[0]),
+      'settings:install-claude': ({ args, callerContext }) => {
+        requireLocalCaller(callerContext, 'settings:install-claude')
+        return dependencies.service.installClaude(args[0], dependencies.emitInstallEvent)
+      },
+      'settings:install-codex': ({ args, callerContext }) => {
+        requireLocalCaller(callerContext, 'settings:install-codex')
+        return dependencies.service.installCodex(args[0], dependencies.emitInstallEvent)
+      },
+      'settings:install-opencode': ({ args, callerContext }) => {
+        requireLocalCaller(callerContext, 'settings:install-opencode')
+        return dependencies.service.installOpencode(args[0], dependencies.emitInstallEvent)
+      },
+      'settings:encryption-available': () => dependencies.service.isEncryptionAvailable(),
+      'settings:npm-available': () => dependencies.service.isNpmAvailable(),
+      'settings:list-app-icons': () => dependencies.listAppIconPreviews?.() ?? [],
+      'settings:list-connectors': () => dependencies.service.listConnectors(),
+      'settings:list-skills': () => dependencies.service.listSkills(),
+      'settings:mark-onboarding-complete': () => dependencies.service.markOnboardingComplete(),
+      'settings:preview-agent-home-skill': ({ args }) =>
+        dependencies.service.previewAgentHomeSkill(args[0]),
+      'settings:preview-github-skill': ({ args }) =>
+        dependencies.service.previewGitHubSkill(args[0]),
+      'settings:preview-skill-zip': ({ args }) => dependencies.service.previewSkillZip(args[0]),
+      'settings:refresh-provider-models': ({ args }) =>
+        dependencies.service.refreshProviderModels(args[0]),
+      'settings:scan-repo-skills': ({ args }) => dependencies.service.scanRepoSkills(args[0]),
+      'settings:set-app-icon-variant': ({ args, callerContext }) => {
+        requireLocalCaller(callerContext, 'settings:set-app-icon-variant')
+        return dependencies.appearance.setAppIconVariant(readAppIconVariant(args[0]))
+      },
+      'settings:set-close-preference': ({ args, callerContext }) => {
+        requireLocalCaller(callerContext, 'settings:set-close-preference')
+        return dependencies.service.setClosePreference(readClosePreference(args[0]))
+      },
+      'settings:set-notifications-enabled': ({ args, callerContext }) => {
+        requireLocalCaller(callerContext, 'settings:set-notifications-enabled')
+        return dependencies.service.setNotificationsEnabled(readNotificationsEnabled(args[0]))
+      },
+      'settings:set-package-mirror': ({ args, callerContext }) => {
+        requireLocalCaller(callerContext, 'settings:set-package-mirror')
+        return dependencies.service.setPackageMirror(args[0])
+      },
+      'settings:validate-provider': ({ args }) => dependencies.service.validateProvider(args[0])
+    })
+    return scope.complete()
+  } catch (error) {
+    scope.rollback()
+    throw error
+  }
+}
+
+export {
+  registerCoreSettingsApplicationCommands,
+  settingsCoreApplicationCommandGroup,
+  settingsCoreApplicationCommands
+}
+export type { CoreSettingsApplicationCommandDependencies, CoreSettingsCommandStore }

--- a/src/main/settings/ipc.ts
+++ b/src/main/settings/ipc.ts
@@ -1,8 +1,6 @@
 import { ipcMainHandle } from '../ipc-handler-registry'
 
 import {
-  isAppIconVariant,
-  isReasoningEffort,
   type AppIconPreview,
   type SetAppIconVariantRequest,
   type CreateSkillRequest,
@@ -45,6 +43,14 @@ import { SettingsService } from './service'
 import type { SettingsWorkflows } from './workflows'
 import { createLogger } from '../logger'
 import { broadcastToRenderers } from '../renderer-broadcast'
+import {
+  readAppIconVariant,
+  readClosePreference,
+  readConversationSkillImportEnabled,
+  readIsolatedClaudeToken,
+  readNotificationsEnabled,
+  readReasoningEffort
+} from './transport-validation'
 
 const log = createLogger('settings-ipc')
 
@@ -122,49 +128,31 @@ const registerSettingsIpcHandlers = ({
   ipcMainHandle(
     'settings:set-reasoning-effort',
     async (_event, request: SetReasoningEffortRequest) => {
-      // Renderer payloads are untyped at runtime: reject anything outside the known levels instead
-      // of persisting a value the agent-mapping layers can't interpret.
-      if (!isReasoningEffort(request?.effort)) {
-        throw new Error(`Unknown reasoning effort: ${String(request?.effort)}`)
-      }
-
-      log.info('set reasoning effort requested', { effort: request.effort })
-      return workflows.runtime.setReasoningEffort(request)
+      const effort = readReasoningEffort(request)
+      log.info('set reasoning effort requested', { effort })
+      return workflows.runtime.setReasoningEffort({ effort })
     }
   )
   ipcMainHandle(
     'settings:set-notifications-enabled',
     async (_event, request: SetNotificationsEnabledRequest) => {
-      // Renderer payloads are untyped at runtime: only a real boolean may persist.
-      if (typeof request?.enabled !== 'boolean') {
-        throw new Error(`Invalid notifications-enabled flag: ${String(request?.enabled)}`)
-      }
-
-      log.info('set notifications enabled requested', { enabled: request.enabled })
-      return service.setNotificationsEnabled(request.enabled)
+      const enabled = readNotificationsEnabled(request)
+      log.info('set notifications enabled requested', { enabled })
+      return service.setNotificationsEnabled(enabled)
     }
   )
   ipcMainHandle(
     'settings:set-conversation-skill-import-enabled',
     async (_event, request: SetConversationSkillImportEnabledRequest) => {
-      if (typeof request?.enabled !== 'boolean') {
-        throw new Error(
-          `Invalid conversation-skill-import-enabled flag: ${String(request?.enabled)}`
-        )
-      }
-
-      log.info('set conversation Skill import enabled requested', { enabled: request.enabled })
-      return workflows.skills.setConversationSkillImportEnabled(request)
+      const enabled = readConversationSkillImportEnabled(request)
+      log.info('set conversation Skill import enabled requested', { enabled })
+      return workflows.skills.setConversationSkillImportEnabled({ enabled })
     }
   )
   ipcMainHandle(
     'settings:set-close-preference',
     async (_event, request: SetClosePreferenceRequest) => {
-      const preference = request?.preference
-      if (preference !== undefined && preference !== 'minimize' && preference !== 'quit') {
-        throw new Error(`Invalid close preference: ${String(preference)}`)
-      }
-
+      const preference = readClosePreference(request)
       log.info('set close preference requested', { preference: preference ?? 'ask' })
       return service.setClosePreference(preference)
     }
@@ -173,13 +161,9 @@ const registerSettingsIpcHandlers = ({
   ipcMainHandle(
     'settings:set-app-icon-variant',
     async (_event, request: SetAppIconVariantRequest) => {
-      // Renderer payloads are untyped at runtime: only a known variant may persist.
-      if (!isAppIconVariant(request?.variant)) {
-        throw new Error(`Unknown app icon variant: ${String(request?.variant)}`)
-      }
-
-      log.info('set app icon variant requested', { variant: request.variant })
-      return workflows.appearance.setAppIconVariant(request.variant)
+      const variant = readAppIconVariant(request)
+      log.info('set app icon variant requested', { variant })
+      return workflows.appearance.setAppIconVariant(variant)
     }
   )
   ipcMainHandle('settings:validate-provider', (_event, request: ValidateProviderRequest) =>
@@ -189,15 +173,9 @@ const registerSettingsIpcHandlers = ({
   ipcMainHandle('settings:cancel-claude-login', () => service.cancelClaudeLogin())
   ipcMainHandle('settings:login-shared-claude', () => workflows.runtime.loginClaudeShared())
   ipcMainHandle('settings:logout-shared-claude', () => workflows.runtime.logoutClaudeShared())
-  ipcMainHandle('settings:login-isolated-claude', async (_event, token: string) => {
-    // Renderer payloads are untyped at runtime: reject anything that isn't a string before it
-    // reaches the controller, so a malicious or corrupt payload can never be coerced into a save.
-    if (typeof token !== 'string') {
-      throw new Error('Claude sign-in token must be a string.')
-    }
-
-    return workflows.runtime.loginIsolatedClaude(token)
-  })
+  ipcMainHandle('settings:login-isolated-claude', (_event, token: string) =>
+    workflows.runtime.loginIsolatedClaude(readIsolatedClaudeToken(token))
+  )
   ipcMainHandle('settings:login-isolated-claude-browser', () =>
     workflows.runtime.loginIsolatedClaudeBrowser()
   )

--- a/src/main/settings/transport-validation.test.ts
+++ b/src/main/settings/transport-validation.test.ts
@@ -1,0 +1,66 @@
+import { describe, expect, it } from 'vitest'
+
+import {
+  readClosePreference,
+  readConversationSkillImportEnabled,
+  readAppIconVariant,
+  readIsolatedClaudeToken,
+  readNotificationsEnabled,
+  readReasoningEffort
+} from './transport-validation'
+
+describe('Settings transport validation', () => {
+  it('accepts only boolean notification preferences with the Electron error contract', () => {
+    expect(readNotificationsEnabled({ enabled: false })).toBe(false)
+    expect(() => readNotificationsEnabled({ enabled: 'yes' })).toThrow(
+      'Invalid notifications-enabled flag: yes'
+    )
+    expect(() => readNotificationsEnabled(undefined)).toThrow(
+      'Invalid notifications-enabled flag: undefined'
+    )
+  })
+
+  it('accepts only known reasoning efforts with the Electron error contract', () => {
+    expect(readReasoningEffort({ effort: 'high' })).toBe('high')
+    expect(() => readReasoningEffort({ effort: 'ultra' })).toThrow(
+      'Unknown reasoning effort: ultra'
+    )
+    expect(() => readReasoningEffort({ effort: 3 })).toThrow('Unknown reasoning effort: 3')
+    expect(() => readReasoningEffort({})).toThrow('Unknown reasoning effort: undefined')
+  })
+
+  it('accepts only boolean conversation Skill import preferences', () => {
+    expect(readConversationSkillImportEnabled({ enabled: true })).toBe(true)
+    expect(() => readConversationSkillImportEnabled({ enabled: 'yes' })).toThrow(
+      'Invalid conversation-skill-import-enabled flag: yes'
+    )
+    expect(() => readConversationSkillImportEnabled(null)).toThrow(
+      'Invalid conversation-skill-import-enabled flag: undefined'
+    )
+  })
+
+  it('accepts minimize, quit, or an omitted close preference', () => {
+    expect(readClosePreference({ preference: 'minimize' })).toBe('minimize')
+    expect(readClosePreference({ preference: 'quit' })).toBe('quit')
+    expect(readClosePreference({})).toBeUndefined()
+    expect(() => readClosePreference({ preference: 'close' })).toThrow(
+      'Invalid close preference: close'
+    )
+  })
+
+  it('accepts only known app icon variants with the Electron error contract', () => {
+    expect(readAppIconVariant({ variant: 'dark' })).toBe('dark')
+    expect(() => readAppIconVariant({ variant: 'sparkle' })).toThrow(
+      'Unknown app icon variant: sparkle'
+    )
+    expect(() => readAppIconVariant({})).toThrow('Unknown app icon variant: undefined')
+  })
+
+  it('accepts only a string isolated Claude token', () => {
+    expect(readIsolatedClaudeToken('sk-ant-test')).toBe('sk-ant-test')
+    expect(() => readIsolatedClaudeToken(42)).toThrow('Claude sign-in token must be a string.')
+    expect(() => readIsolatedClaudeToken(undefined)).toThrow(
+      'Claude sign-in token must be a string.'
+    )
+  })
+})

--- a/src/main/settings/transport-validation.ts
+++ b/src/main/settings/transport-validation.ts
@@ -1,0 +1,68 @@
+import {
+  isAppIconVariant,
+  isReasoningEffort,
+  type AppIconVariant,
+  type ReasoningEffort
+} from '../../shared/settings'
+import type { CloseActionPreference } from '../../shared/window-controls'
+
+const readField = (value: unknown, field: string): unknown =>
+  typeof value === 'object' && value !== null
+    ? (value as Readonly<Record<string, unknown>>)[field]
+    : undefined
+
+const readNotificationsEnabled = (request: unknown): boolean => {
+  const enabled = readField(request, 'enabled')
+  if (typeof enabled !== 'boolean') {
+    throw new Error(`Invalid notifications-enabled flag: ${String(enabled)}`)
+  }
+  return enabled
+}
+
+const readReasoningEffort = (request: unknown): ReasoningEffort => {
+  const effort = readField(request, 'effort')
+  if (!isReasoningEffort(effort)) {
+    throw new Error(`Unknown reasoning effort: ${String(effort)}`)
+  }
+  return effort
+}
+
+const readConversationSkillImportEnabled = (request: unknown): boolean => {
+  const enabled = readField(request, 'enabled')
+  if (typeof enabled !== 'boolean') {
+    throw new Error(`Invalid conversation-skill-import-enabled flag: ${String(enabled)}`)
+  }
+  return enabled
+}
+
+const readClosePreference = (request: unknown): CloseActionPreference | undefined => {
+  const preference = readField(request, 'preference')
+  if (preference !== undefined && preference !== 'minimize' && preference !== 'quit') {
+    throw new Error(`Invalid close preference: ${String(preference)}`)
+  }
+  return preference
+}
+
+const readAppIconVariant = (request: unknown): AppIconVariant => {
+  const variant = readField(request, 'variant')
+  if (!isAppIconVariant(variant)) {
+    throw new Error(`Unknown app icon variant: ${String(variant)}`)
+  }
+  return variant
+}
+
+const readIsolatedClaudeToken = (token: unknown): string => {
+  if (typeof token !== 'string') {
+    throw new Error('Claude sign-in token must be a string.')
+  }
+  return token
+}
+
+export {
+  readAppIconVariant,
+  readClosePreference,
+  readConversationSkillImportEnabled,
+  readIsolatedClaudeToken,
+  readNotificationsEnabled,
+  readReasoningEffort
+}


### PR DESCRIPTION
# T2d1 pull request

Title: `refactor(settings): define core application commands`

## Problem

Settings core and appearance behavior is still expressed through transport-owned handlers, and six
transport-time validations are embedded in Electron IPC. Before atomic command composition, the
bounded core group needs typed owner delegation without duplicating validation or native icon side
effects.

## Proposed change

- Define the exact 31-command Settings core/appearance application group.
- Reuse one transport-neutral validation seam from both the existing Electron IPC and staged command
  handlers, preserving exact validation errors.
- Delegate credential/persistence operations to the Settings service and app-icon persistence/native
  effects to the appearance workflow.
- Enforce the characterized 21 remote-safe / 10 local-only split before owner invocation.

```mermaid
flowchart LR
  E["Existing Electron IPC"] --> V["Shared Settings validation"]
  C["Staged core commands - 31"] --> V
  V --> S["Settings service"]
  V --> A["Appearance workflow"]
  H["T2h0 atomic composition - future"] -.-> C
```

## Scope and non-goals

- Delivery boundary: this is a compile-time preparatory command-group PR. T2h0 installs all bounded
  groups atomically and certifies the complete inventory; T2h1 cuts over adapters. This PR does not
  claim the staged group protects live transport calls.
- Internal architecture changes: typed command boundary plus shared validation seam.
- Existing Electron IPC behavior changes: none intended; it now calls the same validation functions
  with exact error parity.
- Persisted data, relationships, migrations, UI, public types/events, Web/Task/CLI contracts, and
  capability availability: no change.
- Agent Home skill list/import remain Electron-only and excluded. Compute bookmarks remain T2e-owned.
- Global composition, renderer catalogs, event projection, and Issue #458 orchestration are unchanged.

## Acceptance criteria and validation

All checks below ran after the last material edit.

- Exact 31-command inventory, typed Args/Results, and owner delegation -> focused command tests ->
  passed.
- Six shared validations preserve exact Electron/staged errors -> validation and Settings IPC tests ->
  passed.
- Twenty-one remote-safe and ten local-only commands reject/allow before owner invocation -> focused
  command tests -> passed.
- Settings service retains credential/persistence ownership and appearance workflow retains native
  icon side effects -> focused owner tests -> passed.
- Command/validation/Settings focused set -> 4 files / 78 tests passed.
- Settings preferences/service regressions -> 23 passed, 208 skipped by focus filter.
- `npm run typecheck:node` -> passed.
- Targeted ESLint, Prettier, and `git diff --check` -> passed.
- Independent Standards and Spec reviews -> 0 actionable findings.
- Full and cross-platform suites are delegated to online CI.

## Review focus

- Shared validation must preserve exact messages and avoid moving persistence/native effects into the
  command adapter.
- Agent Home list/import and Compute bookmarks must remain outside the 31-command group.
- Production raw churn is 499 lines (453 additions / 46 deletions), at but not over the 500-line hard
  stop; net production growth is 407 lines within the brief estimate.

## Uncovered risk

The staged group has no production consumer until T2h0. Complete command collision/lifecycle
certification and transport codecs remain T2h0/T2h1 responsibilities; full cross-platform behavior is
covered by online CI.
