### PR TITLE
refactor(settings): define runtime application commands

### DIFF
--- a/src/main/settings/application-commands.test.ts
+++ b/src/main/settings/application-commands.test.ts
@@ -224,8 +224,15 @@ describe('Settings core application commands', () => {
       stream: 'system' as const,
       chunk: 'started'
     }
+    const installProgressEvent = {
+      kind: 'progress' as const,
+      installId: 'install-1',
+      phase: 'download' as const,
+      percent: 50
+    }
     serviceMethod('installClaude').mockImplementation(async (_request, onEvent) => {
       onEvent(installEvent)
+      onEvent(installProgressEvent)
       return { installId: 'install-1', ok: true }
     })
     const router = createApplicationCommandRouter()
@@ -285,7 +292,12 @@ describe('Settings core application commands', () => {
       { source: 'official-script' },
       emitInstallEvent
     )
-    expect(emitInstallEvent).toHaveBeenCalledWith(installEvent)
+    expect(emitInstallEvent.mock.calls.map(([event]) => event)).toEqual([
+      installEvent,
+      installProgressEvent
+    ])
+    expect(emitInstallEvent.mock.calls[0]?.[0]).toBe(installEvent)
+    expect(emitInstallEvent.mock.calls[1]?.[0]).toBe(installProgressEvent)
     expect(appearance).toHaveBeenCalledWith('dark')
     expect(serviceMethod('setClosePreference')).toHaveBeenCalledWith(undefined)
     expect(serviceMethod('setNotificationsEnabled')).toHaveBeenCalledWith(false)

--- a/src/main/settings/runtime-application-commands.test.ts
+++ b/src/main/settings/runtime-application-commands.test.ts
@@ -1,0 +1,259 @@
+import { describe, expect, it, vi } from 'vitest'
+
+import { RENDERER_CONTRACT_GROUPS } from '../../shared/renderer-contract-catalog'
+import {
+  createApplicationCommandRouter,
+  type ApplicationCallerLease,
+  type ApplicationInvocation
+} from '../application-command-router'
+import { createWebCallerContext } from '../caller-context'
+import {
+  registerRuntimeSettingsApplicationCommands,
+  settingsRuntimeApplicationCommandGroup,
+  settingsRuntimeApplicationCommands,
+  type RuntimeSettingsApplicationCommandDependencies
+} from './runtime-application-commands'
+
+const expectedChannels = [
+  'settings:uninstall-claude',
+  'settings:uninstall-codex',
+  'settings:uninstall-opencode',
+  'settings:upsert-provider',
+  'settings:delete-provider',
+  'settings:set-active-provider',
+  'settings:set-agent-framework',
+  'settings:set-reasoning-effort',
+  'settings:login-shared-claude',
+  'settings:logout-shared-claude',
+  'settings:login-isolated-claude',
+  'settings:login-isolated-claude-browser',
+  'settings:logout-isolated-claude',
+  'settings:login-isolated-codex',
+  'settings:logout-isolated-codex'
+] as const
+
+const callerLease = (): ApplicationCallerLease =>
+  Object.freeze({
+    leaseId: 'settings-runtime-client',
+    generation: 1,
+    signal: new AbortController().signal,
+    isCurrent: () => true
+  })
+
+const invocation = <Args extends readonly unknown[]>(
+  args: Args,
+  location: 'local' | 'remote' = 'local'
+): ApplicationInvocation<Args> =>
+  Object.freeze({
+    callerContext: createWebCallerContext('settings-runtime-client', { location }),
+    callerLease: callerLease(),
+    args
+  })
+
+const createDependencies = (): Readonly<{
+  dependencies: RuntimeSettingsApplicationCommandDependencies
+  workflowMethod: (
+    name: keyof RuntimeSettingsApplicationCommandDependencies['workflows']
+  ) => ReturnType<typeof vi.fn>
+}> => {
+  const methods = new Map<PropertyKey, ReturnType<typeof vi.fn>>()
+  const workflows = new Proxy(
+    {},
+    {
+      get: (_target, property) => {
+        let method = methods.get(property)
+        if (!method) {
+          method = vi.fn()
+          methods.set(property, method)
+        }
+        return method
+      }
+    }
+  ) as RuntimeSettingsApplicationCommandDependencies['workflows']
+
+  return {
+    dependencies: { workflows },
+    workflowMethod: (name) => workflows[name] as ReturnType<typeof vi.fn>
+  }
+}
+
+describe('Settings runtime application commands', () => {
+  it('installs the exact 15-command inventory and dispatches a remote-safe selection', async () => {
+    const { dependencies, workflowMethod } = createDependencies()
+    const selected = { activeProviderId: 'provider-1' }
+    workflowMethod('setActiveProvider').mockResolvedValue(selected)
+    const router = createApplicationCommandRouter()
+    registerRuntimeSettingsApplicationCommands(router.registrar, dependencies)
+    const settingsChannels = RENDERER_CONTRACT_GROUPS.find(
+      (group) => group.capability === 'settings'
+    )?.contracts.map((contract) => contract.channel)
+
+    expect(settingsRuntimeApplicationCommandGroup.commands.map((command) => command.name)).toEqual(
+      expectedChannels
+    )
+    expect(settingsChannels).toEqual(expect.arrayContaining([...expectedChannels]))
+    expect(router.dispatcher.commandNames()).toEqual([...expectedChannels].sort())
+    await expect(
+      router.dispatcher.invoke(
+        settingsRuntimeApplicationCommands.setActiveProvider,
+        invocation([{ id: 'provider-1' }] as const, 'remote')
+      )
+    ).resolves.toBe(selected)
+    expect(workflowMethod('setActiveProvider')).toHaveBeenCalledWith({ id: 'provider-1' })
+  })
+
+  it('delegates the five remote-safe mutations through the runtime workflow', async () => {
+    const { dependencies, workflowMethod } = createDependencies()
+    const router = createApplicationCommandRouter()
+    registerRuntimeSettingsApplicationCommands(router.registrar, dependencies)
+
+    await router.dispatcher.invoke(
+      settingsRuntimeApplicationCommands.upsertProvider,
+      invocation([{ type: 'custom', name: 'Provider' }] as const, 'remote')
+    )
+    await router.dispatcher.invoke(
+      settingsRuntimeApplicationCommands.deleteProvider,
+      invocation([{ id: 'provider-1' }] as const, 'remote')
+    )
+    await router.dispatcher.invoke(
+      settingsRuntimeApplicationCommands.setActiveProvider,
+      invocation([{ id: 'provider-2', model: 'model-1' }] as const, 'remote')
+    )
+    await router.dispatcher.invoke(
+      settingsRuntimeApplicationCommands.setAgentFramework,
+      invocation([{ id: 'opencode' }] as const, 'remote')
+    )
+    await router.dispatcher.invoke(
+      settingsRuntimeApplicationCommands.setReasoningEffort,
+      invocation([{ effort: 'high' }] as const, 'remote')
+    )
+
+    expect(workflowMethod('upsertProvider')).toHaveBeenCalledWith({
+      type: 'custom',
+      name: 'Provider'
+    })
+    expect(workflowMethod('deleteProvider')).toHaveBeenCalledWith('provider-1')
+    expect(workflowMethod('setActiveProvider')).toHaveBeenCalledWith({
+      id: 'provider-2',
+      model: 'model-1'
+    })
+    expect(workflowMethod('setAgentFramework')).toHaveBeenCalledWith({ id: 'opencode' })
+    expect(workflowMethod('setReasoningEffort')).toHaveBeenCalledWith({ effort: 'high' })
+  })
+
+  it('rejects all ten local-only commands before a runtime workflow can run', async () => {
+    const { dependencies, workflowMethod } = createDependencies()
+    const router = createApplicationCommandRouter()
+    registerRuntimeSettingsApplicationCommands(router.registrar, dependencies)
+
+    const attempts = [
+      [settingsRuntimeApplicationCommands.uninstallClaude, []],
+      [settingsRuntimeApplicationCommands.uninstallCodex, []],
+      [settingsRuntimeApplicationCommands.uninstallOpencode, []],
+      [settingsRuntimeApplicationCommands.loginSharedClaude, []],
+      [settingsRuntimeApplicationCommands.logoutSharedClaude, []],
+      [settingsRuntimeApplicationCommands.loginIsolatedClaude, ['token']],
+      [settingsRuntimeApplicationCommands.loginIsolatedClaudeBrowser, []],
+      [settingsRuntimeApplicationCommands.logoutIsolatedClaude, []],
+      [settingsRuntimeApplicationCommands.loginIsolatedCodex, []],
+      [settingsRuntimeApplicationCommands.logoutIsolatedCodex, []]
+    ] as const
+
+    for (const [command, args] of attempts) {
+      await expect(router.dispatcher.invoke(command, invocation(args, 'remote'))).rejects.toThrow(
+        `Channel only available from the local app: ${command.name}`
+      )
+    }
+
+    expect(workflowMethod('uninstallRuntime')).not.toHaveBeenCalled()
+    expect(workflowMethod('loginClaudeShared')).not.toHaveBeenCalled()
+    expect(workflowMethod('logoutClaudeShared')).not.toHaveBeenCalled()
+    expect(workflowMethod('loginIsolatedClaude')).not.toHaveBeenCalled()
+    expect(workflowMethod('loginIsolatedClaudeBrowser')).not.toHaveBeenCalled()
+    expect(workflowMethod('logoutIsolatedClaude')).not.toHaveBeenCalled()
+    expect(workflowMethod('loginIsolatedCodex')).not.toHaveBeenCalled()
+    expect(workflowMethod('logoutIsolatedCodex')).not.toHaveBeenCalled()
+  })
+
+  it('delegates local runtime and authentication requests without taking effect ownership', async () => {
+    const { dependencies, workflowMethod } = createDependencies()
+    const router = createApplicationCommandRouter()
+    registerRuntimeSettingsApplicationCommands(router.registrar, dependencies)
+
+    await router.dispatcher.invoke(
+      settingsRuntimeApplicationCommands.uninstallClaude,
+      invocation([] as const)
+    )
+    await router.dispatcher.invoke(
+      settingsRuntimeApplicationCommands.uninstallCodex,
+      invocation([] as const)
+    )
+    await router.dispatcher.invoke(
+      settingsRuntimeApplicationCommands.uninstallOpencode,
+      invocation([] as const)
+    )
+    await router.dispatcher.invoke(
+      settingsRuntimeApplicationCommands.loginSharedClaude,
+      invocation([] as const)
+    )
+    await router.dispatcher.invoke(
+      settingsRuntimeApplicationCommands.logoutSharedClaude,
+      invocation([] as const)
+    )
+    await router.dispatcher.invoke(
+      settingsRuntimeApplicationCommands.loginIsolatedClaude,
+      invocation(['token'] as const)
+    )
+    await router.dispatcher.invoke(
+      settingsRuntimeApplicationCommands.loginIsolatedClaudeBrowser,
+      invocation([] as const)
+    )
+    await router.dispatcher.invoke(
+      settingsRuntimeApplicationCommands.logoutIsolatedClaude,
+      invocation([] as const)
+    )
+    await router.dispatcher.invoke(
+      settingsRuntimeApplicationCommands.loginIsolatedCodex,
+      invocation([] as const)
+    )
+    await router.dispatcher.invoke(
+      settingsRuntimeApplicationCommands.logoutIsolatedCodex,
+      invocation([] as const)
+    )
+
+    expect(workflowMethod('uninstallRuntime').mock.calls).toEqual([
+      ['uninstallClaude', 'claude-code'],
+      ['uninstallCodex', 'codex'],
+      ['uninstallOpencode', 'opencode']
+    ])
+    expect(workflowMethod('loginClaudeShared')).toHaveBeenCalledOnce()
+    expect(workflowMethod('logoutClaudeShared')).toHaveBeenCalledOnce()
+    expect(workflowMethod('loginIsolatedClaude')).toHaveBeenCalledWith('token')
+    expect(workflowMethod('loginIsolatedClaudeBrowser')).toHaveBeenCalledOnce()
+    expect(workflowMethod('logoutIsolatedClaude')).toHaveBeenCalledOnce()
+    expect(workflowMethod('loginIsolatedCodex')).toHaveBeenCalledOnce()
+    expect(workflowMethod('logoutIsolatedCodex')).toHaveBeenCalledOnce()
+  })
+
+  it('preserves reasoning and isolated-token transport validation before workflow delegation', async () => {
+    const { dependencies, workflowMethod } = createDependencies()
+    const router = createApplicationCommandRouter()
+    registerRuntimeSettingsApplicationCommands(router.registrar, dependencies)
+
+    await expect(
+      router.dispatcher.invoke(
+        settingsRuntimeApplicationCommands.setReasoningEffort,
+        invocation([{ effort: 'ultra' } as never] as const)
+      )
+    ).rejects.toThrow('Unknown reasoning effort: ultra')
+    await expect(
+      router.dispatcher.invoke(
+        settingsRuntimeApplicationCommands.loginIsolatedClaude,
+        invocation([42 as never] as const)
+      )
+    ).rejects.toThrow('Claude sign-in token must be a string.')
+
+    expect(workflowMethod('setReasoningEffort')).not.toHaveBeenCalled()
+    expect(workflowMethod('loginIsolatedClaude')).not.toHaveBeenCalled()
+  })
+})

--- a/src/main/settings/runtime-application-commands.ts
+++ b/src/main/settings/runtime-application-commands.ts
@@ -1,0 +1,214 @@
+import type { DeleteProviderRequest } from '../../shared/settings'
+import {
+  defineApplicationCommand,
+  defineApplicationCommandGroup,
+  type ApplicationCommandInstallation,
+  type ApplicationCommandRegistrar
+} from '../application-command-router'
+import type { CallerContext } from '../caller-context'
+import { readIsolatedClaudeToken, readReasoningEffort } from './transport-validation'
+import type { RuntimeSettingsWorkflows } from './workflows/runtime'
+
+type RuntimeSettingsCommandWorkflows = Pick<
+  RuntimeSettingsWorkflows,
+  | 'deleteProvider'
+  | 'loginClaudeShared'
+  | 'loginIsolatedClaude'
+  | 'loginIsolatedClaudeBrowser'
+  | 'loginIsolatedCodex'
+  | 'logoutClaudeShared'
+  | 'logoutIsolatedClaude'
+  | 'logoutIsolatedCodex'
+  | 'setActiveProvider'
+  | 'setAgentFramework'
+  | 'setReasoningEffort'
+  | 'uninstallRuntime'
+  | 'upsertProvider'
+>
+
+type WorkflowArgs<Method extends keyof RuntimeSettingsCommandWorkflows> =
+  RuntimeSettingsCommandWorkflows[Method] extends (...args: infer Args) => unknown
+    ? Readonly<Args>
+    : never
+
+type WorkflowResult<Method extends keyof RuntimeSettingsCommandWorkflows> =
+  RuntimeSettingsCommandWorkflows[Method] extends (...args: never[]) => infer Result
+    ? Awaited<Result>
+    : never
+
+const settingsRuntimeApplicationCommands = Object.freeze({
+  uninstallClaude: defineApplicationCommand<
+    'settings:uninstall-claude',
+    readonly [],
+    WorkflowResult<'uninstallRuntime'>
+  >('settings:uninstall-claude'),
+  uninstallCodex: defineApplicationCommand<
+    'settings:uninstall-codex',
+    readonly [],
+    WorkflowResult<'uninstallRuntime'>
+  >('settings:uninstall-codex'),
+  uninstallOpencode: defineApplicationCommand<
+    'settings:uninstall-opencode',
+    readonly [],
+    WorkflowResult<'uninstallRuntime'>
+  >('settings:uninstall-opencode'),
+  upsertProvider: defineApplicationCommand<
+    'settings:upsert-provider',
+    WorkflowArgs<'upsertProvider'>,
+    WorkflowResult<'upsertProvider'>
+  >('settings:upsert-provider'),
+  deleteProvider: defineApplicationCommand<
+    'settings:delete-provider',
+    readonly [request: DeleteProviderRequest],
+    WorkflowResult<'deleteProvider'>
+  >('settings:delete-provider'),
+  setActiveProvider: defineApplicationCommand<
+    'settings:set-active-provider',
+    WorkflowArgs<'setActiveProvider'>,
+    WorkflowResult<'setActiveProvider'>
+  >('settings:set-active-provider'),
+  setAgentFramework: defineApplicationCommand<
+    'settings:set-agent-framework',
+    WorkflowArgs<'setAgentFramework'>,
+    WorkflowResult<'setAgentFramework'>
+  >('settings:set-agent-framework'),
+  setReasoningEffort: defineApplicationCommand<
+    'settings:set-reasoning-effort',
+    WorkflowArgs<'setReasoningEffort'>,
+    WorkflowResult<'setReasoningEffort'>
+  >('settings:set-reasoning-effort'),
+  loginSharedClaude: defineApplicationCommand<
+    'settings:login-shared-claude',
+    readonly [],
+    WorkflowResult<'loginClaudeShared'>
+  >('settings:login-shared-claude'),
+  logoutSharedClaude: defineApplicationCommand<
+    'settings:logout-shared-claude',
+    readonly [],
+    WorkflowResult<'logoutClaudeShared'>
+  >('settings:logout-shared-claude'),
+  loginIsolatedClaude: defineApplicationCommand<
+    'settings:login-isolated-claude',
+    WorkflowArgs<'loginIsolatedClaude'>,
+    WorkflowResult<'loginIsolatedClaude'>
+  >('settings:login-isolated-claude'),
+  loginIsolatedClaudeBrowser: defineApplicationCommand<
+    'settings:login-isolated-claude-browser',
+    readonly [],
+    WorkflowResult<'loginIsolatedClaudeBrowser'>
+  >('settings:login-isolated-claude-browser'),
+  logoutIsolatedClaude: defineApplicationCommand<
+    'settings:logout-isolated-claude',
+    readonly [],
+    WorkflowResult<'logoutIsolatedClaude'>
+  >('settings:logout-isolated-claude'),
+  loginIsolatedCodex: defineApplicationCommand<
+    'settings:login-isolated-codex',
+    readonly [],
+    WorkflowResult<'loginIsolatedCodex'>
+  >('settings:login-isolated-codex'),
+  logoutIsolatedCodex: defineApplicationCommand<
+    'settings:logout-isolated-codex',
+    readonly [],
+    WorkflowResult<'logoutIsolatedCodex'>
+  >('settings:logout-isolated-codex')
+})
+
+const settingsRuntimeApplicationCommandGroup = defineApplicationCommandGroup('settings-runtime', [
+  settingsRuntimeApplicationCommands.uninstallClaude,
+  settingsRuntimeApplicationCommands.uninstallCodex,
+  settingsRuntimeApplicationCommands.uninstallOpencode,
+  settingsRuntimeApplicationCommands.upsertProvider,
+  settingsRuntimeApplicationCommands.deleteProvider,
+  settingsRuntimeApplicationCommands.setActiveProvider,
+  settingsRuntimeApplicationCommands.setAgentFramework,
+  settingsRuntimeApplicationCommands.setReasoningEffort,
+  settingsRuntimeApplicationCommands.loginSharedClaude,
+  settingsRuntimeApplicationCommands.logoutSharedClaude,
+  settingsRuntimeApplicationCommands.loginIsolatedClaude,
+  settingsRuntimeApplicationCommands.loginIsolatedClaudeBrowser,
+  settingsRuntimeApplicationCommands.logoutIsolatedClaude,
+  settingsRuntimeApplicationCommands.loginIsolatedCodex,
+  settingsRuntimeApplicationCommands.logoutIsolatedCodex
+] as const)
+
+type RuntimeSettingsApplicationCommandDependencies = Readonly<{
+  workflows: RuntimeSettingsCommandWorkflows
+}>
+
+const requireLocalCaller = (context: CallerContext, channel: string): void => {
+  if (context.location !== 'local') {
+    throw new Error(`Channel only available from the local app: ${channel}`)
+  }
+}
+
+const registerRuntimeSettingsApplicationCommands = (
+  registrar: ApplicationCommandRegistrar,
+  dependencies: RuntimeSettingsApplicationCommandDependencies
+): ApplicationCommandInstallation => {
+  const scope = registrar.createScope()
+
+  try {
+    scope.registerGroup(settingsRuntimeApplicationCommandGroup, {
+      'settings:uninstall-claude': ({ callerContext }) => {
+        requireLocalCaller(callerContext, 'settings:uninstall-claude')
+        return dependencies.workflows.uninstallRuntime('uninstallClaude', 'claude-code')
+      },
+      'settings:uninstall-codex': ({ callerContext }) => {
+        requireLocalCaller(callerContext, 'settings:uninstall-codex')
+        return dependencies.workflows.uninstallRuntime('uninstallCodex', 'codex')
+      },
+      'settings:uninstall-opencode': ({ callerContext }) => {
+        requireLocalCaller(callerContext, 'settings:uninstall-opencode')
+        return dependencies.workflows.uninstallRuntime('uninstallOpencode', 'opencode')
+      },
+      'settings:upsert-provider': ({ args }) => dependencies.workflows.upsertProvider(args[0]),
+      'settings:delete-provider': ({ args }) => dependencies.workflows.deleteProvider(args[0].id),
+      'settings:set-active-provider': ({ args }) =>
+        dependencies.workflows.setActiveProvider(args[0]),
+      'settings:set-agent-framework': ({ args }) =>
+        dependencies.workflows.setAgentFramework(args[0]),
+      'settings:set-reasoning-effort': ({ args }) =>
+        dependencies.workflows.setReasoningEffort({ effort: readReasoningEffort(args[0]) }),
+      'settings:login-shared-claude': ({ callerContext }) => {
+        requireLocalCaller(callerContext, 'settings:login-shared-claude')
+        return dependencies.workflows.loginClaudeShared()
+      },
+      'settings:logout-shared-claude': ({ callerContext }) => {
+        requireLocalCaller(callerContext, 'settings:logout-shared-claude')
+        return dependencies.workflows.logoutClaudeShared()
+      },
+      'settings:login-isolated-claude': ({ args, callerContext }) => {
+        requireLocalCaller(callerContext, 'settings:login-isolated-claude')
+        return dependencies.workflows.loginIsolatedClaude(readIsolatedClaudeToken(args[0]))
+      },
+      'settings:login-isolated-claude-browser': ({ callerContext }) => {
+        requireLocalCaller(callerContext, 'settings:login-isolated-claude-browser')
+        return dependencies.workflows.loginIsolatedClaudeBrowser()
+      },
+      'settings:logout-isolated-claude': ({ callerContext }) => {
+        requireLocalCaller(callerContext, 'settings:logout-isolated-claude')
+        return dependencies.workflows.logoutIsolatedClaude()
+      },
+      'settings:login-isolated-codex': ({ callerContext }) => {
+        requireLocalCaller(callerContext, 'settings:login-isolated-codex')
+        return dependencies.workflows.loginIsolatedCodex()
+      },
+      'settings:logout-isolated-codex': ({ callerContext }) => {
+        requireLocalCaller(callerContext, 'settings:logout-isolated-codex')
+        return dependencies.workflows.logoutIsolatedCodex()
+      }
+    })
+    return scope.complete()
+  } catch (error) {
+    scope.rollback()
+    throw error
+  }
+}
+
+export {
+  registerRuntimeSettingsApplicationCommands,
+  settingsRuntimeApplicationCommandGroup,
+  settingsRuntimeApplicationCommands
+}
+export type { RuntimeSettingsApplicationCommandDependencies, RuntimeSettingsCommandWorkflows }


### PR DESCRIPTION
# T2d2 pull request

Title: `refactor(settings): define runtime application commands`

## Problem

Settings runtime operations remain transport-shaped even after T2d1 defines the core Settings group.
The staged application router needs one bounded runtime command group that delegates to the existing
workflow without taking ownership of Provider records, credentials, processes, auth controllers, or
event state.

## Proposed change

- Define the exact 15-command Settings runtime application group.
- Preserve the characterized five remote-safe and ten local-only capability split, including the
  existing local-only rejection message and pre-workflow rejection order.
- Delegate Provider, Framework, Reasoning, authentication, install, and uninstall behavior to the
  current runtime workflow.
- Forward the same install event object in the same order through the existing application event owner.

```mermaid
flowchart LR
  C["Staged runtime commands - 15"] --> G["Remote-safe or local-only gate"]
  G --> W["Settings runtime workflow"]
  W --> S["Settings service and runtime owners"]
  W --> E["Existing application event owner"]
  H["T2h0 atomic composition - future"] -.-> C
```

## Scope and non-goals

- Delivery boundary: this is a compile-time preparatory command group. T2h0 installs all groups
  atomically and T2h1 cuts over adapters; this PR does not change live routing.
- Provider reconnect, immutable runtime selection, inspection, install/uninstall, backend projection,
  validation generation, Reasoning/token validation, and event ordering remain workflow-owned.
- Persisted data, relationships, migrations, UI, public wire/events, renderer catalogs, global
  composition, and Electron/Web/Task/CLI availability do not change.
- Specialist, Permission, and Compute capability asymmetry and Issue #458 orchestration are unchanged.

## Acceptance criteria and validation

All checks below ran after the last material edit.

- Exact 15-command inventory and typed owner delegation -> Settings application-command tests ->
  passed.
- Five remote-safe and ten local-only commands allow/reject before workflow invocation with the
  existing error -> command and IPC tests -> passed.
- Provider/Framework/Reasoning/auth/install/uninstall delegate to the current runtime workflow ->
  focused workflow tests -> passed.
- Reasoning and isolated Claude token validation preserve current transport errors -> focused tests ->
  passed.
- Install events preserve object identity and publication order -> focused event test -> passed.
- Settings command/workflow/IPC/runtime focused regression -> 6 files / 92 tests passed.
- Settings service runtime/auth/install focused regression -> 56 tests passed; unrelated tests skipped
  by the focus filter.
- `npm run typecheck:node` -> passed.
- Targeted ESLint, Prettier, and `git diff --check` -> passed.
- Independent Standards and Spec reviews -> 0 actionable findings.
- Full and cross-platform suites are delegated to online CI.

## Review focus

- Command handlers must remain thin workflow delegates and must not acquire durable/runtime state.
- The five/ten capability split, rejection text, validation, and install event order are compatibility
  contracts.
- Production churn is 214 lines, below the 500-line hard stop and within the brief estimate.

## Uncovered risk

The group has no production consumer until T2h0. Complete collision/lifecycle certification and
transport codecs remain T2h0/T2h1 responsibilities; cross-platform behavior remains covered online.
