### PR TITLE
refactor(uploads): bind writers to caller leases

### DIFF
--- a/src/main/uploads/ipc.test.ts
+++ b/src/main/uploads/ipc.test.ts
@@ -27,15 +27,18 @@ import {
   clearMigrationPending,
   waitForDataRootWriters
 } from '../storage/migration-state'
+import { createWebCallerContext, type CallerContext } from '../caller-context'
 import { createDefaultUploadRepository, registerUploadIpcHandlers } from './ipc'
 import type { UploadRepository } from './repository'
 import { stageUploadFixtures } from './repository.test-utils'
 
 const createIpcEvent = (
-  id: number = 1
+  id: number = 1,
+  callerContext?: CallerContext
 ): {
   event: unknown
   emit: (channel: string, ...args: unknown[]) => void
+  send: ReturnType<typeof vi.fn>
 } => {
   const listeners = new Map<string, Set<(...args: unknown[]) => void>>()
   const on = (channel: string, listener: (...args: unknown[]) => void): void => {
@@ -46,9 +49,11 @@ const createIpcEvent = (
   const removeListener = (channel: string, listener: (...args: unknown[]) => void): void => {
     listeners.get(channel)?.delete(listener)
   }
+  const send = vi.fn()
   const sender = {
     id,
-    send: vi.fn(),
+    callerContext,
+    send,
     on: vi.fn(on),
     once: vi.fn((channel: string, listener: (...args: unknown[]) => void) => {
       const onceListener = (...args: unknown[]): void => {
@@ -62,6 +67,7 @@ const createIpcEvent = (
 
   return {
     event: { sender },
+    send,
     emit: (channel, ...args) => {
       for (const listener of [...(listeners.get(channel) ?? [])]) listener(...args)
     }
@@ -250,6 +256,80 @@ describe('default upload repository', () => {
     expect(repository.abortTransfer).toHaveBeenCalledWith({ transferId: 'transfer-3' })
   })
 
+  it('isolates a same-ID replacement from the stale renderer lifecycle', async () => {
+    const repository = {
+      beginTransfer: vi.fn(async (request: { transferId: string; name: string; size: number }) => ({
+        transferId: request.transferId,
+        name: request.name,
+        receivedBytes: 0,
+        totalBytes: request.size
+      })),
+      finishTransfer: vi.fn(async () => undefined),
+      abortTransfer: vi.fn(async () => undefined)
+    } as unknown as UploadRepository
+    registerUploadIpcHandlers(repository)
+    const begin = ipcHandlers.get('uploads:begin-transfer')!
+    const finish = ipcHandlers.get('uploads:finish-transfer')!
+    const staleRenderer = createIpcEvent(17)
+    const replacement = createIpcEvent(17)
+
+    await begin(staleRenderer.event, {
+      transferId: 'stale-generation',
+      name: 'old.csv',
+      size: 5
+    })
+    await begin(replacement.event, {
+      transferId: 'replacement-generation',
+      name: 'new.csv',
+      size: 7
+    })
+    await new Promise((resolve) => setImmediate(resolve))
+
+    expect(repository.abortTransfer).toHaveBeenCalledTimes(1)
+    expect(repository.abortTransfer).toHaveBeenCalledWith({ transferId: 'stale-generation' })
+
+    staleRenderer.emit('destroyed')
+    await new Promise((resolve) => setImmediate(resolve))
+    expect(repository.abortTransfer).not.toHaveBeenCalledWith({
+      transferId: 'replacement-generation'
+    })
+
+    await expect(
+      finish(replacement.event, { transferId: 'replacement-generation' })
+    ).resolves.toBeUndefined()
+    expect(repository.finishTransfer).toHaveBeenCalledWith({
+      transferId: 'replacement-generation'
+    })
+  })
+
+  it('releases a crashed caller generation exactly once', async () => {
+    const repository = {
+      beginTransfer: vi.fn(async () => ({
+        transferId: 'crashed-transfer',
+        name: 'data.csv',
+        receivedBytes: 0,
+        totalBytes: 10
+      })),
+      abortTransfer: vi.fn(async () => undefined)
+    } as unknown as UploadRepository
+    registerUploadIpcHandlers(repository)
+    const begin = ipcHandlers.get('uploads:begin-transfer')!
+    const caller = createIpcEvent(23)
+
+    await begin(caller.event, {
+      transferId: 'crashed-transfer',
+      name: 'data.csv',
+      size: 10
+    })
+    caller.emit('render-process-gone')
+    caller.emit('destroyed')
+
+    await vi.waitFor(() => {
+      expect(repository.abortTransfer).toHaveBeenCalledTimes(1)
+    })
+    expect(repository.abortTransfer).toHaveBeenCalledWith({ transferId: 'crashed-transfer' })
+  })
+
   it('keeps the teardown lease until an in-flight append has settled', async () => {
     let finishAppend: ((status: unknown) => void) | undefined
     const repository = {
@@ -329,6 +409,31 @@ describe('default upload repository', () => {
     sender.emit('did-start-navigation', {}, 'http://localhost/', false, true)
     await drainPromise
     expect(repository.abortTransfer).toHaveBeenCalledWith({ transferId: 'transfer-4' })
+  })
+
+  it('does not compose Electron navigation cleanup into Web callers', async () => {
+    const repository = {
+      beginTransfer: vi.fn(async () => ({
+        transferId: 'web-transfer',
+        name: 'data.csv',
+        receivedBytes: 0,
+        totalBytes: 10
+      })),
+      abortTransfer: vi.fn(async () => undefined)
+    } as unknown as UploadRepository
+    registerUploadIpcHandlers(repository)
+    const begin = ipcHandlers.get('uploads:begin-transfer')!
+    const caller = createIpcEvent(-1, createWebCallerContext('browser-1'))
+
+    await begin(caller.event, { transferId: 'web-transfer', name: 'data.csv', size: 10 })
+    caller.emit('did-start-navigation', {}, 'http://localhost/', false, true)
+    await new Promise((resolve) => setImmediate(resolve))
+    expect(repository.abortTransfer).not.toHaveBeenCalled()
+
+    caller.emit('destroyed')
+    await vi.waitFor(() => {
+      expect(repository.abortTransfer).toHaveBeenCalledWith({ transferId: 'web-transfer' })
+    })
   })
 
   it('aborts a native-path upload and releases its migration lease when its renderer is destroyed', async () => {
@@ -488,6 +593,44 @@ describe('default upload repository', () => {
     sender.emit('destroyed')
 
     expect(repository.deleteUpload).not.toHaveBeenCalled()
+  })
+
+  it('routes native-path progress through the owning caller sender', async () => {
+    const progress = {
+      transferId: 'local-transfer-progress',
+      receivedBytes: 4,
+      totalBytes: 10
+    }
+    const attachment = {
+      id: 'attachment-progress',
+      sessionId: '.pending',
+      name: 'data.csv',
+      originalName: 'data.csv',
+      path: '/managed/.pending/data.csv',
+      size: 10
+    }
+    const repository = {
+      stageLocalFile: vi.fn(async (_request, onProgress: (value: typeof progress) => void) => {
+        onProgress(progress)
+        return attachment
+      }),
+      abortTransfer: vi.fn(async () => undefined),
+      deleteUpload: vi.fn(async () => undefined)
+    } as unknown as UploadRepository
+    registerUploadIpcHandlers(repository)
+    const stageLocalFile = ipcHandlers.get('uploads:stage-local-file')!
+    const claim = ipcHandlers.get('uploads:claim-local-file')!
+    const caller = createIpcEvent(29)
+
+    await stageLocalFile(caller.event, {
+      transferId: 'local-transfer-progress',
+      sourcePath: '/fixtures/data.csv',
+      name: 'data.csv',
+      size: 10
+    })
+
+    expect(caller.send).toHaveBeenCalledWith('uploads:transfer-progress', progress)
+    await claim(caller.event, { transferId: 'local-transfer-progress' })
   })
 
   it('does not let another renderer cancel an active native-path upload', async () => {

--- a/src/main/uploads/ipc.ts
+++ b/src/main/uploads/ipc.ts
@@ -1,6 +1,9 @@
 import { type Event as ElectronEvent, type IpcMainInvokeEvent } from 'electron'
 import { stat } from 'node:fs/promises'
 
+import type { ApplicationCallerLease } from '../application-command-router'
+import { callerContextForEvent } from '../caller-context'
+import { callerLeaseForEvent } from '../caller-lifecycle'
 import { ipcMainHandle } from '../ipc-handler-registry'
 
 import type { ReadArtifactPreviewRequest } from '../../shared/artifacts'
@@ -45,7 +48,7 @@ const registerUploadIpcHandlers = (
   // A chunk transfer spans several IPC calls but is one logical write. Holding the writer lease from
   // begin through finish/abort makes data-root migration wait across the gaps between chunks.
   type UploadOwner = {
-    senderId: number
+    lease: ApplicationCallerLease
     transferIds: Set<string>
   }
   type ChunkWriter = {
@@ -65,7 +68,7 @@ const registerUploadIpcHandlers = (
     attachment?: UploadedAttachment
     cleanup?: Promise<void>
   }
-  const uploadOwners = new Map<number, UploadOwner>()
+  const uploadOwners = new WeakMap<ApplicationCallerLease, UploadOwner>()
   const chunkWriters = new Map<string, ChunkWriter>()
   const localWriters = new Map<string, LocalWriter>()
   const releaseChunkWriter = (transferId: string, writer: ChunkWriter): void => {
@@ -113,17 +116,22 @@ const registerUploadIpcHandlers = (
     return writer.cleanup
   }
   const registerUploadOwner = (event: IpcMainInvokeEvent): UploadOwner => {
-    const existing = uploadOwners.get(event.sender.id)
+    const lease = callerLeaseForEvent(event)
+    const existing = uploadOwners.get(lease)
     if (existing) return existing
+    if (lease.signal.aborted || !lease.isCurrent()) {
+      throw new Error('Upload renderer is no longer available.')
+    }
 
-    const owner: UploadOwner = { senderId: event.sender.id, transferIds: new Set() }
-    uploadOwners.set(owner.senderId, owner)
+    const releaseOnNavigation = callerContextForEvent(event).surface === 'electron'
+    const owner: UploadOwner = { lease, transferIds: new Set() }
     const releaseOwner = (): void => {
-      if (uploadOwners.get(owner.senderId) !== owner) return
-      uploadOwners.delete(owner.senderId)
-      event.sender.removeListener('destroyed', releaseOwner)
-      event.sender.removeListener('render-process-gone', releaseOwner)
-      event.sender.removeListener('did-start-navigation', releaseOnMainFrameNavigation)
+      if (uploadOwners.get(lease) !== owner) return
+      uploadOwners.delete(lease)
+      lease.signal.removeEventListener('abort', releaseOwner)
+      if (releaseOnNavigation) {
+        event.sender.removeListener('did-start-navigation', releaseOnMainFrameNavigation)
+      }
       for (const transferId of [...owner.transferIds]) {
         const chunkWriter = chunkWriters.get(transferId)
         if (chunkWriter?.owner === owner && !chunkWriter.settling) {
@@ -141,9 +149,15 @@ const registerUploadIpcHandlers = (
     ): void => {
       if (isMainFrame) releaseOwner()
     }
-    event.sender.once('destroyed', releaseOwner)
-    event.sender.once('render-process-gone', releaseOwner)
-    event.sender.on('did-start-navigation', releaseOnMainFrameNavigation)
+    uploadOwners.set(lease, owner)
+    lease.signal.addEventListener('abort', releaseOwner, { once: true })
+    if (releaseOnNavigation) {
+      event.sender.on('did-start-navigation', releaseOnMainFrameNavigation)
+    }
+    if (lease.signal.aborted || !lease.isCurrent()) {
+      releaseOwner()
+      throw new Error('Upload renderer is no longer available.')
+    }
     return owner
   }
   const getOwnedChunkWriter = (


### PR DESCRIPTION
# T2b2 pull request

Title: `refactor(uploads): bind writers to caller leases`

## Problem

Upload chunk and local writers are still owned by numeric sender IDs and sender lifecycle callbacks.
That identity cannot distinguish a replacement caller generation, so stale destroyed/crash callbacks
can target a reconnect's resources after T2b1 makes caller lifetime explicit.

## Proposed change

- Bind Upload writer ownership to the T2b1 caller lease and generation.
- Abort and release each writer exactly once when the owning lease ends.
- Keep an old generation's teardown isolated from replacement writers with the same public caller ID.
- Preserve main-frame navigation cleanup only in the Electron Upload adapter.

```mermaid
flowchart LR
  E["Electron Upload invocation"] --> L["Caller lease generation"]
  W["Web or Task Upload invocation"] --> L
  L --> C["Chunk and local writers"]
  A["Lease abort"] --> R["Idempotent writer release"]
  N["Electron main-frame navigation"] --> R
```

## Scope and non-goals

- Internal ephemeral resource ownership changes from numeric sender ID to caller lease generation.
- Writer, repository, staging, migration, claim/release, native-path, progress, and error algorithms
  remain unchanged.
- Electron progress keeps the existing sender adapter; event publication remains T2f/T2h1-owned.
- Persisted data, relationships, migrations, UI, public wire contracts, and
  Electron/Web/Task/CLI availability do not change.
- Specialist, Permission, and Compute capability asymmetry and Issue #458 orchestration are unchanged.

## Acceptance criteria and validation

All checks below ran after the last material edit.

- Same-ID caller replacement isolates new writers from stale destroyed/crash callbacks -> Upload IPC
  tests -> passed.
- Lease abort releases owned chunk/local writers exactly once -> Upload IPC tests -> passed.
- Electron main-frame navigation retains Upload cleanup without adding that behavior to Web/Task ->
  Upload IPC tests -> passed.
- In-flight append drain, late native-path cleanup, standalone release, claim release, progress routing,
  and cross-owner denial preserve existing results/errors -> Upload IPC tests -> passed.
- Focused Upload IPC set -> 23 tests passed.
- `npm run typecheck:node` -> passed.
- Targeted ESLint, Prettier, and `git diff --check` -> passed.
- Independent Standards and Spec reviews -> 0 actionable findings.
- Full and cross-platform suites are delegated to online CI.

## Review focus

- A stale caller generation must never release replacement writers.
- Navigation remains an Electron Upload-only lifecycle input.
- Production churn is 40 lines (27 additions / 13 deletions), below the 500-line hard stop.

## Uncovered risk

Real Task/CLI end-to-end coverage remains online. This PR does not change their router or public
contract. T2f must consume this ownership seam rather than reintroducing sender IDs.
