### PR TITLE
refactor(settings): define integration application commands

### DIFF
--- a/src/main/settings/integration-application-commands.test.ts
+++ b/src/main/settings/integration-application-commands.test.ts
@@ -1,0 +1,509 @@
+import { describe, expect, it, vi } from 'vitest'
+
+import { RENDERER_CONTRACT_GROUPS } from '../../shared/renderer-contract-catalog'
+import {
+  createApplicationCommandRouter,
+  type ApplicationCallerLease,
+  type ApplicationInvocation
+} from '../application-command-router'
+import {
+  createCallerContext,
+  createElectronCallerContext,
+  createTaskCallerContext,
+  createWebCallerContext,
+  type CallerContext
+} from '../caller-context'
+import { ApprovalBroker } from '../connectors/approval-broker'
+import {
+  SkillImportApprovalBroker,
+  type SkillImportApprovalInfo
+} from '../skills/conversation-import'
+import {
+  registerIntegrationSettingsApplicationCommands,
+  settingsApprovalApplicationCommandGroup,
+  settingsConnectorApplicationCommandGroup,
+  settingsIntegrationApplicationCommands,
+  settingsSkillApplicationCommandGroup,
+  type IntegrationSettingsApplicationCommandDependencies
+} from './integration-application-commands'
+
+const expectedSkillChannels = [
+  'settings:set-conversation-skill-import-enabled',
+  'settings:set-skill-enabled',
+  'settings:create-skill',
+  'settings:update-skill',
+  'settings:delete-skill',
+  'settings:import-skill',
+  'settings:import-skill-zip',
+  'settings:import-skill-zip-batch'
+] as const
+
+const expectedConnectorChannels = [
+  'settings:set-connector-enabled',
+  'settings:set-connector-auto-allow',
+  'settings:set-tool-permission',
+  'settings:set-ncbi-credentials',
+  'settings:add-custom-server',
+  'settings:set-custom-server-enabled',
+  'settings:remove-custom-server',
+  'settings:update-custom-server'
+] as const
+
+const expectedApprovalChannels = [
+  'connectors:approval-respond',
+  'skills:conversation-import-respond',
+  'skills:conversation-import-replay-pending'
+] as const
+
+const callerLease = (leaseId = 'settings-integration-client'): ApplicationCallerLease =>
+  Object.freeze({
+    leaseId,
+    generation: 1,
+    signal: new AbortController().signal,
+    isCurrent: () => true
+  })
+
+const invocation = <Args extends readonly unknown[]>(
+  args: Args,
+  callerContext: CallerContext = createWebCallerContext('settings-integration-client', {
+    location: 'remote'
+  })
+): ApplicationInvocation<Args> =>
+  Object.freeze({
+    callerContext,
+    callerLease: callerLease(callerContext.leaseId),
+    args
+  })
+
+const createMethodPort = <Port extends object>(): Readonly<{
+  port: Port
+  method: (name: keyof Port) => ReturnType<typeof vi.fn>
+}> => {
+  const methods = new Map<PropertyKey, ReturnType<typeof vi.fn>>()
+  const port = new Proxy(
+    {},
+    {
+      get: (_target, property) => {
+        let method = methods.get(property)
+        if (!method) {
+          method = vi.fn()
+          methods.set(property, method)
+        }
+        return method
+      }
+    }
+  ) as Port
+
+  return { port, method: (name) => port[name] as ReturnType<typeof vi.fn> }
+}
+
+const createDependencies = (): Readonly<{
+  dependencies: IntegrationSettingsApplicationCommandDependencies
+  skillMethod: (
+    name: keyof IntegrationSettingsApplicationCommandDependencies['skills']
+  ) => ReturnType<typeof vi.fn>
+  connectorMethod: (
+    name: keyof IntegrationSettingsApplicationCommandDependencies['connectors']
+  ) => ReturnType<typeof vi.fn>
+}> => {
+  const skills = createMethodPort<IntegrationSettingsApplicationCommandDependencies['skills']>()
+  const connectors =
+    createMethodPort<IntegrationSettingsApplicationCommandDependencies['connectors']>()
+
+  return {
+    dependencies: {
+      skills: skills.port,
+      connectors: connectors.port,
+      connectorApprovals: { respond: vi.fn() },
+      skillImportApprovals: { respond: vi.fn(), replayPending: vi.fn() }
+    },
+    skillMethod: skills.method,
+    connectorMethod: connectors.method
+  }
+}
+
+describe('Settings integration application commands', () => {
+  it('defines the exact 19-command Skill, Connector, and approval inventory', () => {
+    const groups = [
+      settingsSkillApplicationCommandGroup,
+      settingsConnectorApplicationCommandGroup,
+      settingsApprovalApplicationCommandGroup
+    ]
+    const settingsChannels = RENDERER_CONTRACT_GROUPS.find(
+      (group) => group.capability === 'settings'
+    )?.contracts.map((contract) => contract.channel)
+    const expectedChannels = [
+      ...expectedSkillChannels,
+      ...expectedConnectorChannels,
+      ...expectedApprovalChannels
+    ]
+    const integrationContracts = RENDERER_CONTRACT_GROUPS.find(
+      (group) => group.capability === 'settings'
+    )?.contracts.filter((contract) =>
+      expectedChannels.includes(contract.channel as (typeof expectedChannels)[number])
+    )
+    const router = createApplicationCommandRouter()
+    registerIntegrationSettingsApplicationCommands(
+      router.registrar,
+      createDependencies().dependencies
+    )
+
+    expect(settingsSkillApplicationCommandGroup.commands.map((command) => command.name)).toEqual(
+      expectedSkillChannels
+    )
+    expect(
+      settingsConnectorApplicationCommandGroup.commands.map((command) => command.name)
+    ).toEqual(expectedConnectorChannels)
+    expect(settingsApprovalApplicationCommandGroup.commands.map((command) => command.name)).toEqual(
+      expectedApprovalChannels
+    )
+    expect(groups.reduce((count, group) => count + group.commands.length, 0)).toBe(19)
+    expect(router.dispatcher.commandNames()).toEqual([...expectedChannels].sort())
+    expect(settingsChannels).toEqual(
+      expect.arrayContaining([
+        ...expectedSkillChannels,
+        ...expectedConnectorChannels,
+        ...expectedApprovalChannels
+      ])
+    )
+    expect(integrationContracts).toHaveLength(19)
+    expect(
+      integrationContracts?.every(
+        (contract) =>
+          contract.kind === 'method' &&
+          contract.surfaceInstallation.localWeb === 'web-rpc' &&
+          contract.surfaceInstallation.remoteWeb === 'web-rpc'
+      )
+    ).toBe(true)
+    for (const eventChannel of [
+      'connectors:approval-request',
+      'settings:install-log',
+      'skills:conversation-import-request',
+      'skills:conversation-import-settled'
+    ]) {
+      expect(router.dispatcher.commandNames()).not.toContain(eventChannel)
+    }
+  })
+
+  it('delegates all eight remote Skill mutations through the Skill workflow owner', async () => {
+    const { dependencies, skillMethod } = createDependencies()
+    const router = createApplicationCommandRouter()
+    registerIntegrationSettingsApplicationCommands(router.registrar, dependencies)
+
+    await router.dispatcher.invoke(
+      settingsIntegrationApplicationCommands.setConversationSkillImportEnabled,
+      invocation([{ enabled: true }] as const)
+    )
+    await router.dispatcher.invoke(
+      settingsIntegrationApplicationCommands.setSkillEnabled,
+      invocation([{ id: 'skill-1', enabled: false }] as const)
+    )
+    await router.dispatcher.invoke(
+      settingsIntegrationApplicationCommands.createSkill,
+      invocation([{ name: 'Skill', description: 'Description', body: 'Body' }] as const)
+    )
+    await router.dispatcher.invoke(
+      settingsIntegrationApplicationCommands.updateSkill,
+      invocation([
+        { id: 'personal-skill', name: 'Skill', description: 'Updated', body: 'Body' }
+      ] as const)
+    )
+    await router.dispatcher.invoke(
+      settingsIntegrationApplicationCommands.deleteSkill,
+      invocation([{ id: 'personal-skill' }] as const)
+    )
+    await router.dispatcher.invoke(
+      settingsIntegrationApplicationCommands.importSkill,
+      invocation([{ url: 'https://github.com/org/repo/tree/main/skill' }] as const)
+    )
+    await router.dispatcher.invoke(
+      settingsIntegrationApplicationCommands.importSkillZip,
+      invocation([{ dataBase64: 'AA==', filename: 'skill.zip' }] as const)
+    )
+    await router.dispatcher.invoke(
+      settingsIntegrationApplicationCommands.importSkillZipBatch,
+      invocation([{ dataBase64: 'AA==', items: [{ subPath: 'skill' }] }] as const)
+    )
+
+    expect(skillMethod('setConversationSkillImportEnabled')).toHaveBeenCalledWith({ enabled: true })
+    expect(skillMethod('setSkillEnabled')).toHaveBeenCalledWith({
+      id: 'skill-1',
+      enabled: false
+    })
+    expect(skillMethod('createSkill')).toHaveBeenCalledWith({
+      name: 'Skill',
+      description: 'Description',
+      body: 'Body'
+    })
+    expect(skillMethod('updateSkill')).toHaveBeenCalledWith({
+      id: 'personal-skill',
+      name: 'Skill',
+      description: 'Updated',
+      body: 'Body'
+    })
+    expect(skillMethod('deleteSkill')).toHaveBeenCalledWith({ id: 'personal-skill' })
+    expect(skillMethod('importSkill')).toHaveBeenCalledWith({
+      url: 'https://github.com/org/repo/tree/main/skill'
+    })
+    expect(skillMethod('importSkillZip')).toHaveBeenCalledWith({
+      dataBase64: 'AA==',
+      filename: 'skill.zip'
+    })
+    expect(skillMethod('importSkillZipBatch')).toHaveBeenCalledWith({
+      dataBase64: 'AA==',
+      items: [{ subPath: 'skill' }]
+    })
+  })
+
+  it('preserves conversation Skill-import validation before workflow delegation', async () => {
+    const { dependencies, skillMethod } = createDependencies()
+    const router = createApplicationCommandRouter()
+    registerIntegrationSettingsApplicationCommands(router.registrar, dependencies)
+
+    await expect(
+      router.dispatcher.invoke(
+        settingsIntegrationApplicationCommands.setConversationSkillImportEnabled,
+        invocation([{ enabled: 'yes' } as never] as const)
+      )
+    ).rejects.toThrow('Invalid conversation-skill-import-enabled flag: yes')
+    expect(skillMethod('setConversationSkillImportEnabled')).not.toHaveBeenCalled()
+  })
+
+  it('delegates all eight remote Connector mutations through the Connector workflow owner', async () => {
+    const { connectorMethod, dependencies } = createDependencies()
+    const router = createApplicationCommandRouter()
+    registerIntegrationSettingsApplicationCommands(router.registrar, dependencies)
+
+    await router.dispatcher.invoke(
+      settingsIntegrationApplicationCommands.setConnectorEnabled,
+      invocation([{ id: 'pubchem', enabled: false }] as const)
+    )
+    await router.dispatcher.invoke(
+      settingsIntegrationApplicationCommands.setConnectorAutoAllow,
+      invocation([{ id: 'pubchem', autoAllow: true }] as const)
+    )
+    await router.dispatcher.invoke(
+      settingsIntegrationApplicationCommands.setToolPermission,
+      invocation([{ toolId: 'pubchem/search', permission: 'allow' }] as const)
+    )
+    await router.dispatcher.invoke(
+      settingsIntegrationApplicationCommands.setNcbiCredentials,
+      invocation([{ contactEmail: 'researcher@example.test', apiKey: 'secret' }] as const)
+    )
+    await router.dispatcher.invoke(
+      settingsIntegrationApplicationCommands.addCustomServer,
+      invocation([{ name: 'custom', transport: 'stdio', command: 'custom-mcp' }] as const)
+    )
+    await router.dispatcher.invoke(
+      settingsIntegrationApplicationCommands.setCustomServerEnabled,
+      invocation([{ id: 'server-1', enabled: false }] as const)
+    )
+    await router.dispatcher.invoke(
+      settingsIntegrationApplicationCommands.removeCustomServer,
+      invocation([{ id: 'server-1' }] as const)
+    )
+    await router.dispatcher.invoke(
+      settingsIntegrationApplicationCommands.updateCustomServer,
+      invocation([
+        {
+          id: 'server-2',
+          description: 'Updated',
+          transport: 'streamable_http',
+          url: 'https://mcp.example.test'
+        }
+      ] as const)
+    )
+
+    expect(connectorMethod('setConnectorEnabled')).toHaveBeenCalledWith({
+      id: 'pubchem',
+      enabled: false
+    })
+    expect(connectorMethod('setConnectorAutoAllow')).toHaveBeenCalledWith({
+      id: 'pubchem',
+      autoAllow: true
+    })
+    expect(connectorMethod('setToolPermission')).toHaveBeenCalledWith({
+      toolId: 'pubchem/search',
+      permission: 'allow'
+    })
+    expect(connectorMethod('setNcbiCredentials')).toHaveBeenCalledWith({
+      contactEmail: 'researcher@example.test',
+      apiKey: 'secret'
+    })
+    expect(connectorMethod('addCustomServer')).toHaveBeenCalledWith({
+      name: 'custom',
+      transport: 'stdio',
+      command: 'custom-mcp'
+    })
+    expect(connectorMethod('setCustomServerEnabled')).toHaveBeenCalledWith({
+      id: 'server-1',
+      enabled: false
+    })
+    expect(connectorMethod('removeCustomServer')).toHaveBeenCalledWith({ id: 'server-1' })
+    expect(connectorMethod('updateCustomServer')).toHaveBeenCalledWith({
+      id: 'server-2',
+      description: 'Updated',
+      transport: 'streamable_http',
+      url: 'https://mcp.example.test'
+    })
+  })
+
+  it('allows only current human callers to settle Connector and Skill-import approvals', async () => {
+    const { dependencies } = createDependencies()
+    const respondConnector = dependencies.connectorApprovals.respond as ReturnType<typeof vi.fn>
+    const respondSkill = dependencies.skillImportApprovals.respond as ReturnType<typeof vi.fn>
+    const router = createApplicationCommandRouter()
+    registerIntegrationSettingsApplicationCommands(router.registrar, dependencies)
+
+    const localHuman = createWebCallerContext('local-human')
+    const remoteHuman = createWebCallerContext('remote-human', { location: 'remote' })
+    const electronHuman = createElectronCallerContext(7)
+
+    await router.dispatcher.invoke(
+      settingsIntegrationApplicationCommands.respondConnectorApproval,
+      invocation([{ id: 'connector-local', decision: 'once' }] as const, localHuman)
+    )
+    await router.dispatcher.invoke(
+      settingsIntegrationApplicationCommands.respondSkillImportApproval,
+      invocation([{ id: 'skill-remote', items: [] }] as const, remoteHuman)
+    )
+    await router.dispatcher.invoke(
+      settingsIntegrationApplicationCommands.respondConnectorApproval,
+      invocation([{ id: 'connector-electron', decision: 'deny' }] as const, electronHuman)
+    )
+
+    expect(respondConnector.mock.calls).toEqual([
+      ['connector-local', 'once'],
+      ['connector-electron', 'deny']
+    ])
+    expect(respondSkill).toHaveBeenCalledWith({ id: 'skill-remote', items: [] })
+
+    const deniedCallers = [
+      createCallerContext({
+        clientId: 'agent-session',
+        lifecycleClientId: 'web:agent-session',
+        leaseId: 'agent-session',
+        surface: 'web',
+        location: 'local',
+        principalKind: 'agent-session',
+        actionOrigin: 'agent-session'
+      }),
+      createTaskCallerContext()
+    ]
+
+    for (const callerContext of deniedCallers) {
+      await expect(
+        router.dispatcher.invoke(
+          settingsIntegrationApplicationCommands.respondConnectorApproval,
+          invocation([{ id: 'blocked', decision: 'global' }] as const, callerContext)
+        )
+      ).rejects.toThrow('Only a current human caller can respond to connector approval requests.')
+      await expect(
+        router.dispatcher.invoke(
+          settingsIntegrationApplicationCommands.respondSkillImportApproval,
+          invocation([{ id: 'blocked', cancelled: true }] as const, callerContext)
+        )
+      ).rejects.toThrow(
+        'Only a current human caller can respond to Skill import approval requests.'
+      )
+    }
+
+    const expiredHuman = createWebCallerContext('expired-human', {
+      isAuthorizationCurrent: () => false
+    })
+    await expect(
+      router.dispatcher.invoke(
+        settingsIntegrationApplicationCommands.respondConnectorApproval,
+        invocation([{ id: 'blocked', decision: 'global' }] as const, expiredHuman)
+      )
+    ).rejects.toThrow('Caller authorization is no longer current.')
+    await expect(
+      router.dispatcher.invoke(
+        settingsIntegrationApplicationCommands.respondSkillImportApproval,
+        invocation([{ id: 'blocked', cancelled: true }] as const, expiredHuman)
+      )
+    ).rejects.toThrow('Caller authorization is no longer current.')
+
+    expect(respondConnector).toHaveBeenCalledTimes(2)
+    expect(respondSkill).toHaveBeenCalledTimes(1)
+  })
+
+  it('preserves owner-held late-ID, pending replay, and settled-event ordering', async () => {
+    const { dependencies } = createDependencies()
+    const connectorApprovalBroker = new ApprovalBroker({
+      generateId: () => 'connector-1',
+      broadcast: vi.fn(),
+      setTimer: () => 1 as unknown as ReturnType<typeof setTimeout>,
+      clearTimer: vi.fn()
+    })
+    let sequence = 0
+    const skillBroadcasts: string[] = []
+    const settledIds: string[] = []
+    const skillImportApprovalBroker = new SkillImportApprovalBroker({
+      generateId: () => `skill-${++sequence}`,
+      broadcast: (request) => skillBroadcasts.push(request.id),
+      onSettled: (id) => settledIds.push(id),
+      setTimer: () => 1 as unknown as ReturnType<typeof setTimeout>,
+      clearTimer: vi.fn()
+    })
+    const router = createApplicationCommandRouter()
+    registerIntegrationSettingsApplicationCommands(router.registrar, {
+      ...dependencies,
+      connectorApprovals: connectorApprovalBroker,
+      skillImportApprovals: skillImportApprovalBroker
+    })
+    const human = createWebCallerContext('approval-human', { location: 'remote' })
+    const approvalInfo = (sessionId: string): SkillImportApprovalInfo => ({
+      sessionId,
+      source: { kind: 'attachment', label: `${sessionId}.skill` },
+      previews: [],
+      skipped: []
+    })
+
+    const connectorDecision = connectorApprovalBroker.request({
+      connector: 'pubchem',
+      method: 'search',
+      argsPreview: '{}'
+    })
+    const firstSkillResponse = skillImportApprovalBroker.request(approvalInfo('session-1'))
+    const secondSkillResponse = skillImportApprovalBroker.request(approvalInfo('session-2'))
+    expect(skillBroadcasts).toEqual(['skill-1', 'skill-2'])
+    skillBroadcasts.length = 0
+
+    await router.dispatcher.invoke(
+      settingsIntegrationApplicationCommands.replayPendingSkillImportApprovals,
+      invocation([] as const, human)
+    )
+    expect(skillBroadcasts).toEqual(['skill-1', 'skill-2'])
+
+    await router.dispatcher.invoke(
+      settingsIntegrationApplicationCommands.respondConnectorApproval,
+      invocation([{ id: 'unknown', decision: 'global' }] as const, human)
+    )
+    await router.dispatcher.invoke(
+      settingsIntegrationApplicationCommands.respondSkillImportApproval,
+      invocation([{ id: 'unknown', cancelled: true }] as const, human)
+    )
+    await router.dispatcher.invoke(
+      settingsIntegrationApplicationCommands.respondConnectorApproval,
+      invocation([{ id: 'connector-1', decision: 'once' }] as const, human)
+    )
+    await router.dispatcher.invoke(
+      settingsIntegrationApplicationCommands.respondSkillImportApproval,
+      invocation([{ id: 'skill-1', items: [] }] as const, human)
+    )
+    await router.dispatcher.invoke(
+      settingsIntegrationApplicationCommands.respondSkillImportApproval,
+      invocation([{ id: 'skill-1', cancelled: true }] as const, human)
+    )
+    await router.dispatcher.invoke(
+      settingsIntegrationApplicationCommands.respondSkillImportApproval,
+      invocation([{ id: 'skill-2', cancelled: true }] as const, human)
+    )
+
+    await expect(connectorDecision).resolves.toBe('once')
+    await expect(firstSkillResponse).resolves.toEqual({ id: 'skill-1', items: [] })
+    await expect(secondSkillResponse).resolves.toEqual({ id: 'skill-2', cancelled: true })
+    expect(settledIds).toEqual(['skill-1', 'skill-2'])
+  })
+})

--- a/src/main/settings/integration-application-commands.ts
+++ b/src/main/settings/integration-application-commands.ts
@@ -1,0 +1,267 @@
+import type {
+  ConversationSkillImportApprovalResponse,
+  RespondApprovalRequest
+} from '../../shared/settings'
+import {
+  defineApplicationCommand,
+  defineApplicationCommandGroup,
+  type ApplicationCommandInstallation,
+  type ApplicationCommandRegistrar
+} from '../application-command-router'
+import { canSatisfyHumanApproval } from '../caller-context'
+import type { ApprovalBroker } from '../connectors/approval-broker'
+import type { SkillImportApprovalBroker } from '../skills/conversation-import'
+import { readConversationSkillImportEnabled } from './transport-validation'
+import type { ConnectorSettingsWorkflows } from './workflows/connectors'
+import type { SkillSettingsWorkflows } from './workflows/skills'
+
+type SkillIntegrationWorkflows = Pick<
+  SkillSettingsWorkflows,
+  | 'setConversationSkillImportEnabled'
+  | 'setSkillEnabled'
+  | 'createSkill'
+  | 'updateSkill'
+  | 'deleteSkill'
+  | 'importSkill'
+  | 'importSkillZip'
+  | 'importSkillZipBatch'
+>
+
+type ConnectorIntegrationWorkflows = Pick<
+  ConnectorSettingsWorkflows,
+  | 'setConnectorEnabled'
+  | 'setConnectorAutoAllow'
+  | 'setToolPermission'
+  | 'setNcbiCredentials'
+  | 'addCustomServer'
+  | 'setCustomServerEnabled'
+  | 'removeCustomServer'
+  | 'updateCustomServer'
+>
+
+type OwnerArgs<Owner, Method extends keyof Owner> = Owner[Method] extends (
+  ...args: infer Args
+) => unknown
+  ? Readonly<Args>
+  : never
+
+type OwnerResult<Owner, Method extends keyof Owner> = Owner[Method] extends (
+  ...args: never[]
+) => infer Result
+  ? Awaited<Result>
+  : never
+
+const settingsIntegrationApplicationCommands = Object.freeze({
+  setConversationSkillImportEnabled: defineApplicationCommand<
+    'settings:set-conversation-skill-import-enabled',
+    OwnerArgs<SkillIntegrationWorkflows, 'setConversationSkillImportEnabled'>,
+    OwnerResult<SkillIntegrationWorkflows, 'setConversationSkillImportEnabled'>
+  >('settings:set-conversation-skill-import-enabled'),
+  setSkillEnabled: defineApplicationCommand<
+    'settings:set-skill-enabled',
+    OwnerArgs<SkillIntegrationWorkflows, 'setSkillEnabled'>,
+    OwnerResult<SkillIntegrationWorkflows, 'setSkillEnabled'>
+  >('settings:set-skill-enabled'),
+  createSkill: defineApplicationCommand<
+    'settings:create-skill',
+    OwnerArgs<SkillIntegrationWorkflows, 'createSkill'>,
+    OwnerResult<SkillIntegrationWorkflows, 'createSkill'>
+  >('settings:create-skill'),
+  updateSkill: defineApplicationCommand<
+    'settings:update-skill',
+    OwnerArgs<SkillIntegrationWorkflows, 'updateSkill'>,
+    OwnerResult<SkillIntegrationWorkflows, 'updateSkill'>
+  >('settings:update-skill'),
+  deleteSkill: defineApplicationCommand<
+    'settings:delete-skill',
+    OwnerArgs<SkillIntegrationWorkflows, 'deleteSkill'>,
+    OwnerResult<SkillIntegrationWorkflows, 'deleteSkill'>
+  >('settings:delete-skill'),
+  importSkill: defineApplicationCommand<
+    'settings:import-skill',
+    OwnerArgs<SkillIntegrationWorkflows, 'importSkill'>,
+    OwnerResult<SkillIntegrationWorkflows, 'importSkill'>
+  >('settings:import-skill'),
+  importSkillZip: defineApplicationCommand<
+    'settings:import-skill-zip',
+    OwnerArgs<SkillIntegrationWorkflows, 'importSkillZip'>,
+    OwnerResult<SkillIntegrationWorkflows, 'importSkillZip'>
+  >('settings:import-skill-zip'),
+  importSkillZipBatch: defineApplicationCommand<
+    'settings:import-skill-zip-batch',
+    OwnerArgs<SkillIntegrationWorkflows, 'importSkillZipBatch'>,
+    OwnerResult<SkillIntegrationWorkflows, 'importSkillZipBatch'>
+  >('settings:import-skill-zip-batch'),
+  setConnectorEnabled: defineApplicationCommand<
+    'settings:set-connector-enabled',
+    OwnerArgs<ConnectorIntegrationWorkflows, 'setConnectorEnabled'>,
+    OwnerResult<ConnectorIntegrationWorkflows, 'setConnectorEnabled'>
+  >('settings:set-connector-enabled'),
+  setConnectorAutoAllow: defineApplicationCommand<
+    'settings:set-connector-auto-allow',
+    OwnerArgs<ConnectorIntegrationWorkflows, 'setConnectorAutoAllow'>,
+    OwnerResult<ConnectorIntegrationWorkflows, 'setConnectorAutoAllow'>
+  >('settings:set-connector-auto-allow'),
+  setToolPermission: defineApplicationCommand<
+    'settings:set-tool-permission',
+    OwnerArgs<ConnectorIntegrationWorkflows, 'setToolPermission'>,
+    OwnerResult<ConnectorIntegrationWorkflows, 'setToolPermission'>
+  >('settings:set-tool-permission'),
+  setNcbiCredentials: defineApplicationCommand<
+    'settings:set-ncbi-credentials',
+    OwnerArgs<ConnectorIntegrationWorkflows, 'setNcbiCredentials'>,
+    OwnerResult<ConnectorIntegrationWorkflows, 'setNcbiCredentials'>
+  >('settings:set-ncbi-credentials'),
+  addCustomServer: defineApplicationCommand<
+    'settings:add-custom-server',
+    OwnerArgs<ConnectorIntegrationWorkflows, 'addCustomServer'>,
+    OwnerResult<ConnectorIntegrationWorkflows, 'addCustomServer'>
+  >('settings:add-custom-server'),
+  setCustomServerEnabled: defineApplicationCommand<
+    'settings:set-custom-server-enabled',
+    OwnerArgs<ConnectorIntegrationWorkflows, 'setCustomServerEnabled'>,
+    OwnerResult<ConnectorIntegrationWorkflows, 'setCustomServerEnabled'>
+  >('settings:set-custom-server-enabled'),
+  removeCustomServer: defineApplicationCommand<
+    'settings:remove-custom-server',
+    OwnerArgs<ConnectorIntegrationWorkflows, 'removeCustomServer'>,
+    OwnerResult<ConnectorIntegrationWorkflows, 'removeCustomServer'>
+  >('settings:remove-custom-server'),
+  updateCustomServer: defineApplicationCommand<
+    'settings:update-custom-server',
+    OwnerArgs<ConnectorIntegrationWorkflows, 'updateCustomServer'>,
+    OwnerResult<ConnectorIntegrationWorkflows, 'updateCustomServer'>
+  >('settings:update-custom-server'),
+  respondConnectorApproval: defineApplicationCommand<
+    'connectors:approval-respond',
+    readonly [request: RespondApprovalRequest],
+    ReturnType<ApprovalBroker['respond']>
+  >('connectors:approval-respond'),
+  respondSkillImportApproval: defineApplicationCommand<
+    'skills:conversation-import-respond',
+    readonly [response: ConversationSkillImportApprovalResponse],
+    ReturnType<SkillImportApprovalBroker['respond']>
+  >('skills:conversation-import-respond'),
+  replayPendingSkillImportApprovals: defineApplicationCommand<
+    'skills:conversation-import-replay-pending',
+    readonly [],
+    ReturnType<SkillImportApprovalBroker['replayPending']>
+  >('skills:conversation-import-replay-pending')
+})
+
+const settingsSkillApplicationCommandGroup = defineApplicationCommandGroup('settings-skills', [
+  settingsIntegrationApplicationCommands.setConversationSkillImportEnabled,
+  settingsIntegrationApplicationCommands.setSkillEnabled,
+  settingsIntegrationApplicationCommands.createSkill,
+  settingsIntegrationApplicationCommands.updateSkill,
+  settingsIntegrationApplicationCommands.deleteSkill,
+  settingsIntegrationApplicationCommands.importSkill,
+  settingsIntegrationApplicationCommands.importSkillZip,
+  settingsIntegrationApplicationCommands.importSkillZipBatch
+] as const)
+
+const settingsConnectorApplicationCommandGroup = defineApplicationCommandGroup(
+  'settings-connectors',
+  [
+    settingsIntegrationApplicationCommands.setConnectorEnabled,
+    settingsIntegrationApplicationCommands.setConnectorAutoAllow,
+    settingsIntegrationApplicationCommands.setToolPermission,
+    settingsIntegrationApplicationCommands.setNcbiCredentials,
+    settingsIntegrationApplicationCommands.addCustomServer,
+    settingsIntegrationApplicationCommands.setCustomServerEnabled,
+    settingsIntegrationApplicationCommands.removeCustomServer,
+    settingsIntegrationApplicationCommands.updateCustomServer
+  ] as const
+)
+
+const settingsApprovalApplicationCommandGroup = defineApplicationCommandGroup(
+  'settings-approvals',
+  [
+    settingsIntegrationApplicationCommands.respondConnectorApproval,
+    settingsIntegrationApplicationCommands.respondSkillImportApproval,
+    settingsIntegrationApplicationCommands.replayPendingSkillImportApprovals
+  ] as const
+)
+
+type IntegrationSettingsApplicationCommandDependencies = Readonly<{
+  skills: SkillIntegrationWorkflows
+  connectors: ConnectorIntegrationWorkflows
+  connectorApprovals: Pick<ApprovalBroker, 'respond'>
+  skillImportApprovals: Pick<SkillImportApprovalBroker, 'respond' | 'replayPending'>
+}>
+
+const registerIntegrationSettingsApplicationCommands = (
+  registrar: ApplicationCommandRegistrar,
+  dependencies: IntegrationSettingsApplicationCommandDependencies
+): ApplicationCommandInstallation => {
+  const scope = registrar.createScope()
+
+  try {
+    scope.registerGroup(settingsSkillApplicationCommandGroup, {
+      'settings:set-conversation-skill-import-enabled': ({ args }) =>
+        dependencies.skills.setConversationSkillImportEnabled({
+          enabled: readConversationSkillImportEnabled(args[0])
+        }),
+      'settings:set-skill-enabled': ({ args }) => dependencies.skills.setSkillEnabled(args[0]),
+      'settings:create-skill': ({ args }) => dependencies.skills.createSkill(args[0]),
+      'settings:update-skill': ({ args }) => dependencies.skills.updateSkill(args[0]),
+      'settings:delete-skill': ({ args }) => dependencies.skills.deleteSkill(args[0]),
+      'settings:import-skill': ({ args }) => dependencies.skills.importSkill(args[0]),
+      'settings:import-skill-zip': ({ args }) => dependencies.skills.importSkillZip(args[0]),
+      'settings:import-skill-zip-batch': ({ args }) =>
+        dependencies.skills.importSkillZipBatch(args[0])
+    })
+    scope.registerGroup(settingsConnectorApplicationCommandGroup, {
+      'settings:set-connector-enabled': ({ args }) =>
+        dependencies.connectors.setConnectorEnabled(args[0]),
+      'settings:set-connector-auto-allow': ({ args }) =>
+        dependencies.connectors.setConnectorAutoAllow(args[0]),
+      'settings:set-tool-permission': ({ args }) =>
+        dependencies.connectors.setToolPermission(args[0]),
+      'settings:set-ncbi-credentials': ({ args }) =>
+        dependencies.connectors.setNcbiCredentials(args[0]),
+      'settings:add-custom-server': ({ args }) => dependencies.connectors.addCustomServer(args[0]),
+      'settings:set-custom-server-enabled': ({ args }) =>
+        dependencies.connectors.setCustomServerEnabled(args[0]),
+      'settings:remove-custom-server': ({ args }) =>
+        dependencies.connectors.removeCustomServer(args[0]),
+      'settings:update-custom-server': ({ args }) =>
+        dependencies.connectors.updateCustomServer(args[0])
+    })
+    scope.registerGroup(settingsApprovalApplicationCommandGroup, {
+      'connectors:approval-respond': ({ args, callerContext }) => {
+        if (!canSatisfyHumanApproval(callerContext)) {
+          throw new Error('Only a current human caller can respond to connector approval requests.')
+        }
+        return dependencies.connectorApprovals.respond(args[0].id, args[0].decision)
+      },
+      'skills:conversation-import-respond': ({ args, callerContext }) => {
+        if (!canSatisfyHumanApproval(callerContext)) {
+          throw new Error(
+            'Only a current human caller can respond to Skill import approval requests.'
+          )
+        }
+        return dependencies.skillImportApprovals.respond(args[0])
+      },
+      'skills:conversation-import-replay-pending': () =>
+        dependencies.skillImportApprovals.replayPending()
+    })
+    return scope.complete()
+  } catch (error) {
+    scope.rollback()
+    throw error
+  }
+}
+
+export {
+  registerIntegrationSettingsApplicationCommands,
+  settingsApprovalApplicationCommandGroup,
+  settingsConnectorApplicationCommandGroup,
+  settingsIntegrationApplicationCommands,
+  settingsSkillApplicationCommandGroup
+}
+export type {
+  ConnectorIntegrationWorkflows,
+  IntegrationSettingsApplicationCommandDependencies,
+  SkillIntegrationWorkflows
+}


### PR DESCRIPTION
# T2d3 pull request

Title: `refactor(settings): define integration application commands`

## Problem

Skill, Connector, and human-approval integration flows still lack a bounded application command
group. They must become composable without moving catalog, reload, permission, pending-request,
replay, or settlement state out of the existing workflows and broker.

## Proposed change

- Define the exact 19-command group: eight Skill, eight Connector, and three approval/replay commands.
- Delegate every command to the existing integration workflows or permission broker.
- Preserve all 19 as local/remote Web-safe and fail closed when a caller cannot satisfy human approval.
- Preserve unknown/late request no-op behavior, replay insertion order, and settlement ordering.

## Scope and non-goals

- This is a staged command group; T2h0 owns atomic composition and T2h1 owns transport cutover.
- No live IPC, renderer catalog, workflow/broker ownership, persistence, wire/data/UI, or
  Electron/Web/Task/CLI availability changes.
- Specialist, Permission, and Compute capability asymmetry and Issue #458 orchestration are unchanged.

## Acceptance criteria and validation

- Exact 19-command inventory and owner delegation -> command tests -> passed.
- Local and remote human callers remain allowed; agent-session, Task/automation, stale authorization,
  and stale lease callers fail closed before approval mutation -> command/router tests -> passed.
- Unknown/late ID no-op, replay insertion order, and resolve/onSettled order -> broker tests -> passed.
- Focused integration/workflow/IPC/broker regression -> 5 files / 96 tests passed.
- `npm run typecheck:node`, targeted ESLint, Prettier, and `git diff --check` -> passed.
- Independent Standards and Spec reviews -> 0 actionable findings.
- Full and cross-platform suites are delegated to online CI.

## Review focus

- Handlers remain stateless delegates; human approval remains fail-closed.
- Production churn is 267 lines, below the 500-line hard stop.

## Uncovered risk

Global collision, dependency injection, and live adapter codecs remain T2h0/T2h1 responsibilities.
