### PR TITLE
refactor(content): register data application commands

### DIFF
--- a/src/main/data-content-application-commands.test.ts
+++ b/src/main/data-content-application-commands.test.ts
@@ -1,0 +1,737 @@
+import { describe, expect, it, vi } from 'vitest'
+
+import {
+  createApplicationCommandRouter,
+  type ApplicationCommandRouter,
+  type ApplicationInvocation
+} from './application-command-router'
+import { createCallerContext, type CallerContext } from './caller-context'
+import { ArtifactOwnershipPersistenceRaceError } from './artifacts/provenance-repository'
+import {
+  dataContentApplicationCommandGroups,
+  dataContentApplicationCommands,
+  registerDataContentApplicationCommands,
+  type DataContentApplicationCommandDependencies
+} from './data-content-application-commands'
+
+const callerContext = createCallerContext({
+  clientId: 'renderer-1',
+  lifecycleClientId: 'web:renderer-1',
+  leaseId: 'renderer-lease-1',
+  surface: 'web',
+  location: 'local',
+  principalKind: 'human',
+  actionOrigin: 'human'
+})
+
+const electronCaller = createCallerContext({
+  clientId: 'renderer-electron',
+  lifecycleClientId: 'electron:renderer-electron',
+  leaseId: 'electron-lease-1',
+  surface: 'electron',
+  location: 'local',
+  principalKind: 'human',
+  actionOrigin: 'human'
+})
+
+const remoteCaller = createCallerContext({
+  clientId: 'renderer-remote',
+  lifecycleClientId: 'web:renderer-remote',
+  leaseId: 'remote-lease-1',
+  surface: 'web',
+  location: 'remote',
+  principalKind: 'human',
+  actionOrigin: 'human'
+})
+
+const invocation = <Args extends readonly unknown[]>(
+  args: Args,
+  caller: CallerContext = callerContext
+): ApplicationInvocation<Args> => ({
+  callerContext: caller,
+  callerLease: {
+    leaseId: caller.leaseId,
+    generation: 7,
+    signal: new AbortController().signal,
+    isCurrent: () => true
+  },
+  args
+})
+
+const registeredCommands = (): Array<{ name: string }> => {
+  const commands: Array<{ name: string }> = []
+  for (const group of dataContentApplicationCommandGroups) commands.push(...group.commands)
+  return commands
+}
+
+// The inferred spy surface is intentionally retained so each assertion keeps its exact Vitest type.
+// eslint-disable-next-line @typescript-eslint/explicit-function-return-type
+const createDependencies = () => {
+  const artifacts = {
+    finalizeRunArtifacts: vi.fn(async () => []),
+    listProjectFiles: vi.fn(async () => []),
+    reconcilePendingArtifacts: vi.fn(async () => []),
+    openFile: vi.fn(async () => undefined),
+    readPreview: vi.fn(async () => ({ content: '', encoding: 'utf8', size: 0, truncated: false })),
+    getLineage: vi.fn(async () => undefined),
+    getVersionProvenance: vi.fn(),
+    getVersionExecution: vi.fn(),
+    getVersionMessages: vi.fn(),
+    getVersionReview: vi.fn()
+  }
+  const events = { publish: vi.fn() }
+  const managedPreview = {
+    acquire: vi.fn(async () => ({
+      id: 'resource-1',
+      url: 'open-science-preview://resource-1/file',
+      size: 10,
+      mimeType: 'text/plain',
+      version: 1
+    })),
+    readRange: vi.fn(async () => ({ begin: 0, end: 1, total: 1, data: new Uint8Array([1]) })),
+    release: vi.fn()
+  }
+  const preview = { load: vi.fn(), save: vi.fn(), delete: vi.fn() }
+  const projectFiles = {
+    getOverview: vi.fn(),
+    listArtifactGroups: vi.fn(),
+    listFiles: vi.fn(),
+    repairIndex: vi.fn(),
+    searchArtifacts: vi.fn()
+  }
+  const project = {
+    id: 'project-1',
+    name: 'Project',
+    description: '',
+    isExample: false,
+    createdAt: 1,
+    updatedAt: 1
+  }
+  const projects = {
+    create: vi.fn(async () => project),
+    delete: vi.fn(async () => undefined),
+    get: vi.fn(async () => project),
+    list: vi.fn(async () => [project]),
+    update: vi.fn(async () => project)
+  }
+  const session = {
+    id: 'session-1',
+    projectId: 'project-1',
+    title: 'Session',
+    cwd: '/workspace',
+    status: 'idle' as const,
+    createdAt: 1,
+    updatedAt: 1,
+    messages: []
+  }
+  const sessions = {
+    loadAll: vi.fn(),
+    saveSession: vi.fn(async () => ({ created: true, session })),
+    deleteSession: vi.fn(),
+    saveManifest: vi.fn()
+  }
+  const attachment = {
+    id: 'upload-1',
+    sessionId: 'standalone-uploads',
+    name: 'report.txt',
+    originalName: 'report.txt',
+    path: 'upload-version:version-1',
+    size: 10
+  }
+  const uploads = {
+    claimLocalFile: vi.fn(),
+    stageLocalPath: vi.fn(async () => attachment),
+    beginTransfer: vi.fn(),
+    appendTransfer: vi.fn(),
+    transferStatus: vi.fn(),
+    finishTransfer: vi.fn(),
+    abortTransfer: vi.fn(),
+    deleteUpload: vi.fn(),
+    finalizeSession: vi.fn(),
+    readPreview: vi.fn()
+  }
+  const electron = {
+    exportConversationFromInvokingWindow: vi.fn(async () => ({ saved: false as const })),
+    stageLocalFileWithProgress: vi.fn(async () => attachment)
+  }
+  const withDataRootWrite = vi.fn(async <Result>(operation: () => Promise<Result>) => operation())
+  const dependencies = {
+    artifacts,
+    electron,
+    events,
+    managedPreview,
+    preview,
+    projectFiles,
+    projects,
+    sessions,
+    uploads,
+    withDataRootWrite
+  } as unknown as DataContentApplicationCommandDependencies
+  return {
+    dependencies,
+    artifacts,
+    attachment,
+    electron,
+    events,
+    managedPreview,
+    preview,
+    project,
+    projectFiles,
+    projects,
+    session,
+    sessions,
+    uploads,
+    withDataRootWrite
+  }
+}
+
+type DataContentCommandKey = keyof typeof dataContentApplicationCommands
+const WRAPPED_COMMAND_KEYS = [
+  'artifactFinalizeRun',
+  'artifactOpenFile',
+  'lifecycleClientId',
+  'projectCreate',
+  'projectDelete',
+  'projectUpdate',
+  'sessionDelete',
+  'sessionExportConversation',
+  'sessionLoadAll',
+  'sessionSaveManifest',
+  'sessionSave',
+  'uploadStageLocalFile',
+  'uploadStageLocalPath'
+] as const satisfies readonly DataContentCommandKey[]
+type DispatchedCommand = {
+  invocation: ApplicationInvocation<readonly unknown[]>
+  result: Promise<unknown>
+}
+
+const dispatchCommand = (
+  router: ApplicationCommandRouter,
+  key: DataContentCommandKey,
+  args: readonly unknown[],
+  caller: CallerContext = callerContext
+): DispatchedCommand => {
+  const commandInvocation = invocation(args, caller)
+  const invoke = router.dispatcher.invoke as unknown as (
+    command: { name: string },
+    currentInvocation: ApplicationInvocation<readonly unknown[]>
+  ) => Promise<unknown>
+  return {
+    invocation: commandInvocation,
+    result: invoke(dataContentApplicationCommands[key], commandInvocation)
+  }
+}
+
+describe('Data and content application commands', () => {
+  it('owns exactly the 43 current data and content invoke channels', () => {
+    expect(registeredCommands()).toEqual(
+      [
+        'artifacts:finalize-run',
+        'artifacts:get-lineage',
+        'artifacts:get-version-execution',
+        'artifacts:get-version-messages',
+        'artifacts:get-version-provenance',
+        'artifacts:get-version-review',
+        'artifacts:list-project-files',
+        'artifacts:open-file',
+        'artifacts:read-preview',
+        'artifacts:reconcile-pending',
+        'lifecycle:client-id',
+        'preview:delete',
+        'preview:load',
+        'preview:save',
+        'preview-resources:acquire',
+        'preview-resources:read-range',
+        'preview-resources:release',
+        'project-files:get-overview',
+        'project-files:list-artifact-groups',
+        'project-files:list-files',
+        'project-files:repair-index',
+        'project-files:search-artifacts',
+        'projects:create',
+        'projects:delete',
+        'projects:get',
+        'projects:list',
+        'projects:update',
+        'sessions:delete-session',
+        'sessions:export-conversation',
+        'sessions:load-all',
+        'sessions:save-manifest',
+        'sessions:save-session',
+        'uploads:abort-transfer',
+        'uploads:append-transfer',
+        'uploads:begin-transfer',
+        'uploads:claim-local-file',
+        'uploads:delete',
+        'uploads:finalize-session',
+        'uploads:finish-transfer',
+        'uploads:read-preview',
+        'uploads:stage-local-file',
+        'uploads:stage-local-path',
+        'uploads:transfer-status'
+      ].map((name) => expect.objectContaining({ name }))
+    )
+  })
+
+  it('registers the exact inventory and resolves lifecycle identity from caller authority', async () => {
+    const router = createApplicationCommandRouter()
+    const installation = registerDataContentApplicationCommands(
+      router.registrar,
+      createDependencies().dependencies
+    )
+
+    expect(router.dispatcher.commandNames()).toEqual(
+      registeredCommands()
+        .map((command) => command.name)
+        .sort()
+    )
+    await expect(
+      router.dispatcher.invoke(dataContentApplicationCommands.lifecycleClientId, invocation([]))
+    ).resolves.toBe('web:renderer-1')
+
+    installation.uninstall()
+    expect(router.dispatcher.commandNames()).toEqual([])
+  })
+
+  it('maps every pass-through command to its exact existing owner method', async () => {
+    const router = createApplicationCommandRouter()
+    const deps = createDependencies()
+    registerDataContentApplicationCommands(router.registrar, deps.dependencies)
+    const request = (key: string): Readonly<{ key: string }> => Object.freeze({ key })
+    const cases = [
+      {
+        key: 'artifactGetLineage',
+        args: [request('lineage')],
+        owner: deps.artifacts.getLineage
+      },
+      {
+        key: 'artifactGetVersionExecution',
+        args: [request('version-execution')],
+        owner: deps.artifacts.getVersionExecution
+      },
+      {
+        key: 'artifactGetVersionMessages',
+        args: [request('version-messages')],
+        owner: deps.artifacts.getVersionMessages
+      },
+      {
+        key: 'artifactGetVersionProvenance',
+        args: [request('version-provenance')],
+        owner: deps.artifacts.getVersionProvenance
+      },
+      {
+        key: 'artifactGetVersionReview',
+        args: [request('version-review')],
+        owner: deps.artifacts.getVersionReview
+      },
+      {
+        key: 'artifactListProjectFiles',
+        args: [request('artifact-list')],
+        owner: deps.artifacts.listProjectFiles
+      },
+      {
+        key: 'artifactReadPreview',
+        args: [request('artifact-preview')],
+        owner: deps.artifacts.readPreview
+      },
+      {
+        key: 'artifactReconcilePending',
+        args: [request('artifact-reconcile')],
+        owner: deps.artifacts.reconcilePendingArtifacts
+      },
+      { key: 'previewDelete', args: [request('preview-delete')], owner: deps.preview.delete },
+      { key: 'previewLoad', args: [request('preview-load')], owner: deps.preview.load },
+      { key: 'previewSave', args: [request('preview-save')], owner: deps.preview.save },
+      {
+        key: 'previewResourceAcquire',
+        args: [request('preview-resource-acquire')],
+        owner: deps.managedPreview.acquire,
+        passInvocation: true
+      },
+      {
+        key: 'previewResourceReadRange',
+        args: [request('preview-resource-read')],
+        owner: deps.managedPreview.readRange,
+        passInvocation: true
+      },
+      {
+        key: 'previewResourceRelease',
+        args: [request('preview-resource-release')],
+        owner: deps.managedPreview.release,
+        passInvocation: true
+      },
+      {
+        key: 'projectFilesGetOverview',
+        args: [request('project-files-overview')],
+        owner: deps.projectFiles.getOverview
+      },
+      {
+        key: 'projectFilesListArtifactGroups',
+        args: [request('project-files-groups')],
+        owner: deps.projectFiles.listArtifactGroups
+      },
+      {
+        key: 'projectFilesListFiles',
+        args: [request('project-files-list')],
+        owner: deps.projectFiles.listFiles
+      },
+      {
+        key: 'projectFilesRepairIndex',
+        args: [request('project-files-repair')],
+        owner: deps.projectFiles.repairIndex
+      },
+      {
+        key: 'projectFilesSearchArtifacts',
+        args: [request('project-files-search')],
+        owner: deps.projectFiles.searchArtifacts
+      },
+      { key: 'projectGet', args: ['project-1'], owner: deps.projects.get },
+      { key: 'projectList', args: [], owner: deps.projects.list },
+      {
+        key: 'uploadAbortTransfer',
+        args: [request('upload-abort')],
+        owner: deps.uploads.abortTransfer,
+        passInvocation: true
+      },
+      {
+        key: 'uploadAppendTransfer',
+        args: [request('upload-append')],
+        owner: deps.uploads.appendTransfer,
+        passInvocation: true
+      },
+      {
+        key: 'uploadBeginTransfer',
+        args: [request('upload-begin')],
+        owner: deps.uploads.beginTransfer,
+        passInvocation: true
+      },
+      {
+        key: 'uploadClaimLocalFile',
+        args: [request('upload-claim')],
+        owner: deps.uploads.claimLocalFile,
+        passInvocation: true
+      },
+      {
+        key: 'uploadDelete',
+        args: [request('upload-delete')],
+        owner: deps.uploads.deleteUpload,
+        passInvocation: true
+      },
+      {
+        key: 'uploadFinalizeSession',
+        args: [request('upload-finalize')],
+        owner: deps.uploads.finalizeSession,
+        passInvocation: true
+      },
+      {
+        key: 'uploadFinishTransfer',
+        args: [request('upload-finish')],
+        owner: deps.uploads.finishTransfer,
+        passInvocation: true
+      },
+      {
+        key: 'uploadReadPreview',
+        args: [request('upload-preview')],
+        owner: deps.uploads.readPreview,
+        passInvocation: true
+      },
+      {
+        key: 'uploadTransferStatus',
+        args: [request('upload-status')],
+        owner: deps.uploads.transferStatus,
+        passInvocation: true
+      }
+    ] as const
+
+    for (const testCase of cases) {
+      const dispatched = dispatchCommand(router, testCase.key, testCase.args)
+      await dispatched.result
+      const expectedArgs = 'passInvocation' in testCase ? [dispatched.invocation] : testCase.args
+      expect(testCase.owner, testCase.key).toHaveBeenCalledWith(...expectedArgs)
+    }
+
+    expect(
+      [...cases.map(({ key }) => key), ...WRAPPED_COMMAND_KEYS]
+        .map((key) => dataContentApplicationCommands[key].name)
+        .sort()
+    ).toEqual(
+      registeredCommands()
+        .map(({ name }) => name)
+        .sort()
+    )
+  })
+
+  it('routes existing owner seams and passes the exact caller lease to owned resources', async () => {
+    const router = createApplicationCommandRouter()
+    const deps = createDependencies()
+    registerDataContentApplicationCommands(router.registrar, deps.dependencies)
+    const managedInvocation = invocation([
+      { source: 'artifact' as const, path: 'artifact://report' }
+    ] as const)
+    const uploadInvocation = invocation([
+      { transferId: 'transfer-1', offset: 0, chunk: new Uint8Array([1]) }
+    ] as const)
+
+    await router.dispatcher.invoke(
+      dataContentApplicationCommands.previewResourceAcquire,
+      managedInvocation
+    )
+    await router.dispatcher.invoke(
+      dataContentApplicationCommands.uploadAppendTransfer,
+      uploadInvocation
+    )
+    await router.dispatcher.invoke(
+      dataContentApplicationCommands.projectFilesRepairIndex,
+      invocation([{ projectId: 'project-1' }] as const)
+    )
+    await router.dispatcher.invoke(
+      dataContentApplicationCommands.previewLoad,
+      invocation([{ projectId: 'project-1' }] as const)
+    )
+
+    expect(deps.managedPreview.acquire).toHaveBeenCalledWith(managedInvocation)
+    expect(deps.uploads.appendTransfer).toHaveBeenCalledWith(uploadInvocation)
+    expect(deps.projectFiles.repairIndex).toHaveBeenCalledWith({ projectId: 'project-1' })
+    expect(deps.preview.load).toHaveBeenCalledWith({ projectId: 'project-1' })
+  })
+
+  it('keeps artifact finalization recovery and local-file authority unchanged', async () => {
+    const router = createApplicationCommandRouter()
+    const deps = createDependencies()
+    registerDataContentApplicationCommands(router.registrar, deps.dependencies)
+    const finalizeRequest = { claimId: 'claim-1', messageId: 'message-1' }
+
+    await expect(
+      router.dispatcher.invoke(
+        dataContentApplicationCommands.artifactFinalizeRun,
+        invocation([finalizeRequest] as const)
+      )
+    ).resolves.toEqual({ ok: true, artifacts: [] })
+
+    deps.artifacts.finalizeRunArtifacts.mockRejectedValueOnce(
+      new ArtifactOwnershipPersistenceRaceError('ownership is pending')
+    )
+    await expect(
+      router.dispatcher.invoke(
+        dataContentApplicationCommands.artifactFinalizeRun,
+        invocation([finalizeRequest] as const)
+      )
+    ).resolves.toEqual({
+      ok: false,
+      code: 'ownership-persistence-race',
+      message: 'ownership is pending'
+    })
+
+    await expect(
+      router.dispatcher.invoke(
+        dataContentApplicationCommands.artifactOpenFile,
+        invocation([{ path: 'artifact://report' }] as const, remoteCaller)
+      )
+    ).rejects.toThrow('Channel only available from the local app: artifacts:open-file')
+    expect(deps.artifacts.openFile).not.toHaveBeenCalled()
+
+    await router.dispatcher.invoke(
+      dataContentApplicationCommands.artifactOpenFile,
+      invocation([{ path: 'artifact://report' }] as const)
+    )
+    expect(deps.artifacts.openFile).toHaveBeenCalledWith({ path: 'artifact://report' })
+  })
+
+  it('publishes project and session mutations after durable owner completion without failing commits', async () => {
+    const order: string[] = []
+    const router = createApplicationCommandRouter()
+    const deps = createDependencies()
+    deps.projects.create.mockImplementationOnce(async () => {
+      order.push('project:commit')
+      return deps.project
+    })
+    deps.sessions.saveSession.mockImplementationOnce(async () => {
+      order.push('session:commit')
+      return { created: true, session: deps.session }
+    })
+    deps.events.publish.mockImplementation((channel: string) => {
+      order.push(`publish:${channel}`)
+      throw new Error('renderer disconnected')
+    })
+    deps.withDataRootWrite.mockImplementation(async <Result>(operation: () => Promise<Result>) => {
+      order.push('write:start')
+      const result = await operation()
+      order.push('write:end')
+      return result
+    })
+    registerDataContentApplicationCommands(router.registrar, deps.dependencies)
+
+    await expect(
+      router.dispatcher.invoke(
+        dataContentApplicationCommands.projectCreate,
+        invocation([{ name: 'Project' }] as const)
+      )
+    ).resolves.toBe(deps.project)
+    await expect(
+      router.dispatcher.invoke(
+        dataContentApplicationCommands.sessionSave,
+        invocation([deps.session] as const)
+      )
+    ).resolves.toBe(deps.session)
+
+    expect(order).toEqual([
+      'project:commit',
+      'publish:project:created',
+      'write:start',
+      'session:commit',
+      'publish:session:created',
+      'write:end'
+    ])
+    expect(deps.events.publish).toHaveBeenLastCalledWith('session:created', {
+      session: deps.session,
+      originClientId: 'web:renderer-1'
+    })
+  })
+
+  it('dispatches every remaining Project and Session wrapper to its existing owner', async () => {
+    const router = createApplicationCommandRouter()
+    const deps = createDependencies()
+    const loadResult = { sessions: [], manifest: { version: 1 as const } }
+    deps.sessions.loadAll.mockResolvedValueOnce(loadResult)
+    registerDataContentApplicationCommands(router.registrar, deps.dependencies)
+    const updateRequest = { id: 'project-1', name: 'Updated project' }
+    const deleteProjectRequest = { id: 'project-1' }
+    const manifestRequest = { lastProjectId: 'project-1', lastSessionId: 'session-1' }
+    const deleteSessionRequest = { projectId: 'project-1', sessionId: 'session-1' }
+
+    await expect(
+      router.dispatcher.invoke(
+        dataContentApplicationCommands.projectUpdate,
+        invocation([updateRequest] as const)
+      )
+    ).resolves.toBe(deps.project)
+    await router.dispatcher.invoke(
+      dataContentApplicationCommands.projectDelete,
+      invocation([deleteProjectRequest] as const)
+    )
+    await expect(
+      router.dispatcher.invoke(dataContentApplicationCommands.sessionLoadAll, invocation([]))
+    ).resolves.toBe(loadResult)
+    await router.dispatcher.invoke(
+      dataContentApplicationCommands.sessionSaveManifest,
+      invocation([manifestRequest] as const)
+    )
+    await router.dispatcher.invoke(
+      dataContentApplicationCommands.sessionDelete,
+      invocation([deleteSessionRequest] as const)
+    )
+
+    expect(deps.projects.update).toHaveBeenCalledWith(updateRequest)
+    expect(deps.projects.delete).toHaveBeenCalledWith('project-1')
+    expect(deps.sessions.loadAll).toHaveBeenCalledOnce()
+    expect(deps.sessions.saveManifest).toHaveBeenCalledWith(manifestRequest)
+    expect(deps.sessions.deleteSession).toHaveBeenCalledWith(deleteSessionRequest)
+    expect(deps.withDataRootWrite).toHaveBeenCalledTimes(3)
+    expect(deps.events.publish).toHaveBeenCalledWith('project:updated', deps.project)
+    expect(deps.events.publish).toHaveBeenCalledWith('project:deleted', {
+      projectId: 'project-1'
+    })
+    expect(deps.events.publish).toHaveBeenCalledWith('session:deleted', deleteSessionRequest)
+  })
+
+  it('keeps native and local upload/export capability restrictions and standalone invalidation', async () => {
+    const router = createApplicationCommandRouter()
+    const deps = createDependencies()
+    registerDataContentApplicationCommands(router.registrar, deps.dependencies)
+    const nativeUpload = {
+      transferId: 'transfer-1',
+      sourcePath: '/tmp/report.txt',
+      name: 'report.txt',
+      size: 10
+    }
+    const pathUpload = {
+      transferId: 'transfer-2',
+      sourcePath: '/tmp/report.txt',
+      name: 'report.txt',
+      projectId: 'project-1'
+    }
+
+    await expect(
+      router.dispatcher.invoke(
+        dataContentApplicationCommands.uploadStageLocalFile,
+        invocation([nativeUpload] as const)
+      )
+    ).rejects.toThrow('Channel only available from the Electron app: uploads:stage-local-file')
+    await expect(
+      router.dispatcher.invoke(
+        dataContentApplicationCommands.sessionExportConversation,
+        invocation([
+          { projectId: 'project-1', sessionId: 'session-1', format: 'markdown' }
+        ] as const)
+      )
+    ).rejects.toThrow('Channel only available from the Electron app: sessions:export-conversation')
+    await expect(
+      router.dispatcher.invoke(
+        dataContentApplicationCommands.uploadStageLocalPath,
+        invocation([pathUpload] as const, remoteCaller)
+      )
+    ).rejects.toThrow('Channel only available from the local app: uploads:stage-local-path')
+
+    const exportRequest = {
+      projectId: 'project-1',
+      sessionId: 'session-1',
+      format: 'markdown' as const
+    }
+    const exportInvocation = invocation([exportRequest] as const, electronCaller)
+    await expect(
+      router.dispatcher.invoke(
+        dataContentApplicationCommands.sessionExportConversation,
+        exportInvocation
+      )
+    ).resolves.toEqual({ saved: false })
+    expect(deps.electron.exportConversationFromInvokingWindow).toHaveBeenCalledWith(
+      exportInvocation
+    )
+    const nativeUploadInvocation = invocation([nativeUpload] as const, electronCaller)
+    await expect(
+      router.dispatcher.invoke(
+        dataContentApplicationCommands.uploadStageLocalFile,
+        nativeUploadInvocation
+      )
+    ).resolves.toBe(deps.attachment)
+    expect(deps.electron.stageLocalFileWithProgress).toHaveBeenCalledWith(nativeUploadInvocation)
+    await expect(
+      router.dispatcher.invoke(
+        dataContentApplicationCommands.uploadStageLocalPath,
+        invocation([pathUpload] as const)
+      )
+    ).resolves.toBe(deps.attachment)
+    expect(deps.events.publish).toHaveBeenCalledWith('project-files:changed', {
+      projectId: 'project-1',
+      sessionId: 'standalone-uploads',
+      sources: ['upload'],
+      kind: 'upsert'
+    })
+  })
+
+  it('preserves standalone upload publication failures after the upload commits', async () => {
+    const router = createApplicationCommandRouter()
+    const deps = createDependencies()
+    const publicationFailure = new Error('renderer broadcast failed')
+    deps.events.publish.mockImplementationOnce(() => {
+      throw publicationFailure
+    })
+    registerDataContentApplicationCommands(router.registrar, deps.dependencies)
+    const request = {
+      transferId: 'transfer-standalone',
+      sourcePath: '/tmp/report.txt',
+      name: 'report.txt',
+      projectId: 'project-1'
+    }
+
+    await expect(
+      router.dispatcher.invoke(
+        dataContentApplicationCommands.uploadStageLocalPath,
+        invocation([request] as const)
+      )
+    ).rejects.toBe(publicationFailure)
+    expect(deps.uploads.stageLocalPath).toHaveBeenCalledOnce()
+    expect(deps.events.publish).toHaveBeenCalledOnce()
+  })
+})

--- a/src/main/data-content-application-commands.ts
+++ b/src/main/data-content-application-commands.ts
@@ -1,0 +1,484 @@
+import {
+  defineApplicationCommand,
+  defineApplicationCommandGroup,
+  type ApplicationCommandInstallation,
+  type ApplicationCommandRegistrar,
+  type ApplicationInvocation
+} from './application-command-router'
+import type { ApplicationEventMap, ApplicationEventPublisher } from './application-events'
+import type { ArtifactHandlers } from './artifacts/ipc'
+import { ArtifactOwnershipPersistenceRaceError } from './artifacts/provenance-repository'
+import type { ProjectFilesHandlers } from './project-files/ipc'
+import type { ProjectHandlers } from './projects/ipc'
+import type { SessionPersistenceHandlers } from './session-persistence/ipc'
+
+import * as Artifacts from '../shared/artifacts'
+import type * as ConversationExport from '../shared/conversation-export'
+import { LIFECYCLE_CHANNELS } from '../shared/lifecycle-events'
+import type * as PreviewResources from '../shared/preview-resources'
+import type * as PreviewState from '../shared/preview-state'
+import type * as Projects from '../shared/projects'
+import type * as SessionPersistence from '../shared/session-persistence'
+import * as Uploads from '../shared/uploads'
+
+type OwnerArgs<Owner, Method extends keyof Owner> = Owner[Method] extends (
+  ...args: infer Args
+) => unknown
+  ? Readonly<Args>
+  : never
+
+type OwnerResult<Owner, Method extends keyof Owner> = Owner[Method] extends (
+  ...args: never[]
+) => infer Result
+  ? Awaited<Result>
+  : never
+
+const commandFor =
+  <Owner>() =>
+  <const Name extends string, Method extends keyof Owner>(name: Name, method: Method) => {
+    void method
+    return defineApplicationCommand<Name, OwnerArgs<Owner, Method>, OwnerResult<Owner, Method>>(
+      name
+    )
+  }
+
+type InvocationArgs<Owner, Method extends keyof Owner> = Owner[Method] extends (
+  invocation: ApplicationInvocation<infer Args>
+) => unknown
+  ? Args
+  : never
+
+const invocationCommandFor =
+  <Owner>() =>
+  <const Name extends string, Method extends keyof Owner>(name: Name, method: Method) => {
+    void method
+    return defineApplicationCommand<
+      Name,
+      InvocationArgs<Owner, Method>,
+      OwnerResult<Owner, Method>
+    >(name)
+  }
+
+type PreviewApplicationCommandOwner = Readonly<{
+  load(
+    request: PreviewState.LoadPreviewStateRequest
+  ): Promise<PreviewState.PersistedPreviewState | null>
+  save(request: PreviewState.SavePreviewStateRequest): Promise<void>
+  delete(request: PreviewState.DeletePreviewStateRequest): Promise<void>
+}>
+
+type SessionApplicationCommandOwner = SessionPersistenceHandlers
+
+type InvocationOwner<Owner> = Readonly<{
+  [Method in keyof Owner]: Owner[Method] extends (...args: infer Args) => infer Result
+    ? (invocation: ApplicationInvocation<Readonly<Args>>) => Result
+    : never
+}>
+
+// T2h0 injects this adapter; it resolves native window/progress targets without putting Electron
+// objects in transport-neutral application invocations.
+type ElectronDataContentApplicationCommandAdapter = InvocationOwner<{
+  exportConversationFromInvokingWindow: (
+    request: ConversationExport.ExportConversationRequest
+  ) => Promise<ConversationExport.ExportConversationResult>
+  stageLocalFileWithProgress: (
+    request: Uploads.StageLocalUploadRequest
+  ) => Promise<Uploads.UploadedAttachment>
+}>
+
+type ManagedPreviewApplicationCommandOwner = InvocationOwner<{
+  acquire: (
+    request: PreviewResources.AcquireManagedPreviewRequest
+  ) => Promise<PreviewResources.ManagedPreviewResource>
+  readRange: (
+    request: PreviewResources.ReadManagedPreviewRangeRequest
+  ) => Promise<PreviewResources.ManagedPreviewRangeResult>
+  release: (request: PreviewResources.ReleaseManagedPreviewRequest) => void
+}>
+
+type UploadApplicationCommandOwner = InvocationOwner<{
+  claimLocalFile: (request: Uploads.UploadTransferRequest) => void
+  stageLocalPath: (
+    request: Uploads.StageLocalPathUploadRequest
+  ) => Promise<Uploads.UploadedAttachment>
+  beginTransfer: (
+    request: Uploads.BeginUploadTransferRequest
+  ) => Promise<Uploads.UploadTransferStatus>
+  appendTransfer: (
+    request: Uploads.AppendUploadTransferRequest
+  ) => Promise<Uploads.UploadTransferStatus>
+  transferStatus: (
+    request: Uploads.UploadTransferRequest
+  ) => Promise<Uploads.UploadTransferStatus | null>
+  finishTransfer: (request: Uploads.UploadTransferRequest) => Promise<Uploads.UploadedAttachment>
+  abortTransfer: (request: Uploads.UploadTransferRequest) => Promise<void>
+  deleteUpload: (request: Uploads.DeleteUploadRequest) => Promise<void>
+  finalizeSession: (
+    request: Uploads.FinalizeUploadSessionRequest
+  ) => Promise<Uploads.UploadedAttachment[]>
+  readPreview: (
+    request: Artifacts.ReadArtifactPreviewRequest
+  ) => Promise<Artifacts.ArtifactPreviewResult>
+}>
+
+type DataRootWrite = <Result>(operation: () => Promise<Result>) => Promise<Result>
+
+type DataContentApplicationCommandDependencies = Readonly<{
+  artifacts: ArtifactHandlers
+  electron: ElectronDataContentApplicationCommandAdapter
+  events: ApplicationEventPublisher
+  managedPreview: ManagedPreviewApplicationCommandOwner
+  preview: PreviewApplicationCommandOwner
+  projectFiles: ProjectFilesHandlers
+  projects: ProjectHandlers
+  sessions: SessionApplicationCommandOwner
+  uploads: UploadApplicationCommandOwner
+  withDataRootWrite: DataRootWrite
+}>
+
+const artifactCommand = commandFor<ArtifactHandlers>()
+const previewCommand = commandFor<PreviewApplicationCommandOwner>()
+const projectFilesCommand = commandFor<ProjectFilesHandlers>()
+const projectCommand = commandFor<ProjectHandlers>()
+const sessionCommand = commandFor<SessionApplicationCommandOwner>()
+const electronCommand = invocationCommandFor<ElectronDataContentApplicationCommandAdapter>()
+const managedPreviewCommand = invocationCommandFor<ManagedPreviewApplicationCommandOwner>()
+const uploadCommand = invocationCommandFor<UploadApplicationCommandOwner>()
+
+const dataContentApplicationCommands = Object.freeze({
+  artifactFinalizeRun: defineApplicationCommand<
+    'artifacts:finalize-run',
+    readonly [request: Artifacts.FinalizeRunArtifactsRequest],
+    Artifacts.FinalizeRunArtifactsResult
+  >('artifacts:finalize-run'),
+  artifactGetLineage: artifactCommand('artifacts:get-lineage', 'getLineage'),
+  artifactGetVersionExecution: artifactCommand(
+    'artifacts:get-version-execution',
+    'getVersionExecution'
+  ),
+  artifactGetVersionMessages: artifactCommand(
+    'artifacts:get-version-messages',
+    'getVersionMessages'
+  ),
+  artifactGetVersionProvenance: artifactCommand(
+    'artifacts:get-version-provenance',
+    'getVersionProvenance'
+  ),
+  artifactGetVersionReview: artifactCommand('artifacts:get-version-review', 'getVersionReview'),
+  artifactListProjectFiles: artifactCommand('artifacts:list-project-files', 'listProjectFiles'),
+  artifactOpenFile: artifactCommand('artifacts:open-file', 'openFile'),
+  artifactReadPreview: artifactCommand('artifacts:read-preview', 'readPreview'),
+  artifactReconcilePending: artifactCommand(
+    'artifacts:reconcile-pending',
+    'reconcilePendingArtifacts'
+  ),
+  lifecycleClientId: defineApplicationCommand<'lifecycle:client-id', readonly [], string>(
+    'lifecycle:client-id'
+  ),
+  previewDelete: previewCommand('preview:delete', 'delete'),
+  previewLoad: previewCommand('preview:load', 'load'),
+  previewSave: previewCommand('preview:save', 'save'),
+  previewResourceAcquire: managedPreviewCommand('preview-resources:acquire', 'acquire'),
+  previewResourceReadRange: managedPreviewCommand('preview-resources:read-range', 'readRange'),
+  previewResourceRelease: managedPreviewCommand('preview-resources:release', 'release'),
+  projectFilesGetOverview: projectFilesCommand('project-files:get-overview', 'getOverview'),
+  projectFilesListArtifactGroups: projectFilesCommand(
+    'project-files:list-artifact-groups',
+    'listArtifactGroups'
+  ),
+  projectFilesListFiles: projectFilesCommand('project-files:list-files', 'listFiles'),
+  projectFilesRepairIndex: projectFilesCommand('project-files:repair-index', 'repairIndex'),
+  projectFilesSearchArtifacts: projectFilesCommand(
+    'project-files:search-artifacts',
+    'searchArtifacts'
+  ),
+  projectCreate: projectCommand('projects:create', 'create'),
+  projectDelete: defineApplicationCommand<
+    'projects:delete',
+    readonly [request: Projects.DeleteProjectRequest],
+    void
+  >('projects:delete'),
+  projectGet: projectCommand('projects:get', 'get'),
+  projectList: projectCommand('projects:list', 'list'),
+  projectUpdate: projectCommand('projects:update', 'update'),
+  sessionDelete: sessionCommand('sessions:delete-session', 'deleteSession'),
+  sessionExportConversation: electronCommand(
+    'sessions:export-conversation',
+    'exportConversationFromInvokingWindow'
+  ),
+  sessionLoadAll: sessionCommand('sessions:load-all', 'loadAll'),
+  sessionSaveManifest: sessionCommand('sessions:save-manifest', 'saveManifest'),
+  sessionSave: defineApplicationCommand<
+    'sessions:save-session',
+    readonly [
+      session: SessionPersistence.PersistedChatSession,
+      options?: SessionPersistence.SaveSessionOptions
+    ],
+    SessionPersistence.PersistedChatSession
+  >('sessions:save-session'),
+  uploadAbortTransfer: uploadCommand('uploads:abort-transfer', 'abortTransfer'),
+  uploadAppendTransfer: uploadCommand('uploads:append-transfer', 'appendTransfer'),
+  uploadBeginTransfer: uploadCommand('uploads:begin-transfer', 'beginTransfer'),
+  uploadClaimLocalFile: uploadCommand('uploads:claim-local-file', 'claimLocalFile'),
+  uploadDelete: uploadCommand('uploads:delete', 'deleteUpload'),
+  uploadFinalizeSession: uploadCommand('uploads:finalize-session', 'finalizeSession'),
+  uploadFinishTransfer: uploadCommand('uploads:finish-transfer', 'finishTransfer'),
+  uploadReadPreview: uploadCommand('uploads:read-preview', 'readPreview'),
+  uploadStageLocalFile: electronCommand('uploads:stage-local-file', 'stageLocalFileWithProgress'),
+  uploadStageLocalPath: uploadCommand('uploads:stage-local-path', 'stageLocalPath'),
+  uploadTransferStatus: uploadCommand('uploads:transfer-status', 'transferStatus')
+})
+
+const dataContentApplicationCommandGroups = Object.freeze([
+  defineApplicationCommandGroup('artifacts', [
+    dataContentApplicationCommands.artifactFinalizeRun,
+    dataContentApplicationCommands.artifactGetLineage,
+    dataContentApplicationCommands.artifactGetVersionExecution,
+    dataContentApplicationCommands.artifactGetVersionMessages,
+    dataContentApplicationCommands.artifactGetVersionProvenance,
+    dataContentApplicationCommands.artifactGetVersionReview,
+    dataContentApplicationCommands.artifactListProjectFiles,
+    dataContentApplicationCommands.artifactOpenFile,
+    dataContentApplicationCommands.artifactReadPreview,
+    dataContentApplicationCommands.artifactReconcilePending
+  ] as const),
+  defineApplicationCommandGroup('lifecycle', [
+    dataContentApplicationCommands.lifecycleClientId
+  ] as const),
+  defineApplicationCommandGroup('preview', [
+    dataContentApplicationCommands.previewDelete,
+    dataContentApplicationCommands.previewLoad,
+    dataContentApplicationCommands.previewSave
+  ] as const),
+  defineApplicationCommandGroup('preview-resources', [
+    dataContentApplicationCommands.previewResourceAcquire,
+    dataContentApplicationCommands.previewResourceReadRange,
+    dataContentApplicationCommands.previewResourceRelease
+  ] as const),
+  defineApplicationCommandGroup('project-files', [
+    dataContentApplicationCommands.projectFilesGetOverview,
+    dataContentApplicationCommands.projectFilesListArtifactGroups,
+    dataContentApplicationCommands.projectFilesListFiles,
+    dataContentApplicationCommands.projectFilesRepairIndex,
+    dataContentApplicationCommands.projectFilesSearchArtifacts
+  ] as const),
+  defineApplicationCommandGroup('projects', [
+    dataContentApplicationCommands.projectCreate,
+    dataContentApplicationCommands.projectDelete,
+    dataContentApplicationCommands.projectGet,
+    dataContentApplicationCommands.projectList,
+    dataContentApplicationCommands.projectUpdate
+  ] as const),
+  defineApplicationCommandGroup('sessions', [
+    dataContentApplicationCommands.sessionDelete,
+    dataContentApplicationCommands.sessionExportConversation,
+    dataContentApplicationCommands.sessionLoadAll,
+    dataContentApplicationCommands.sessionSaveManifest,
+    dataContentApplicationCommands.sessionSave
+  ] as const),
+  defineApplicationCommandGroup('uploads', [
+    dataContentApplicationCommands.uploadAbortTransfer,
+    dataContentApplicationCommands.uploadAppendTransfer,
+    dataContentApplicationCommands.uploadBeginTransfer,
+    dataContentApplicationCommands.uploadClaimLocalFile,
+    dataContentApplicationCommands.uploadDelete,
+    dataContentApplicationCommands.uploadFinalizeSession,
+    dataContentApplicationCommands.uploadFinishTransfer,
+    dataContentApplicationCommands.uploadReadPreview,
+    dataContentApplicationCommands.uploadStageLocalFile,
+    dataContentApplicationCommands.uploadStageLocalPath,
+    dataContentApplicationCommands.uploadTransferStatus
+  ] as const)
+] as const)
+
+const assertLocalCaller = (
+  invocation: ApplicationInvocation<readonly unknown[]>,
+  name: string
+): void => {
+  if (invocation.callerContext.location !== 'local') {
+    throw new Error(`Channel only available from the local app: ${name}`)
+  }
+}
+
+const assertElectronCaller = (
+  invocation: ApplicationInvocation<readonly unknown[]>,
+  name: string
+): void => {
+  if (invocation.callerContext.surface !== 'electron') {
+    throw new Error(`Channel only available from the Electron app: ${name}`)
+  }
+}
+
+// Repository commits remain authoritative if compatibility publication fails, matching the current
+// lifecycle broadcaster's non-fatal behavior.
+const publishLifecycle = <Channel extends keyof ApplicationEventMap>(
+  events: ApplicationEventPublisher,
+  channel: Channel,
+  payload: ApplicationEventMap[Channel]
+): void => {
+  try {
+    events.publish(channel, payload)
+  } catch {
+    // A disconnected renderer cannot turn an already-committed mutation into a failed command.
+  }
+}
+
+// Production composition registers all bounded command groups atomically; this group must not be
+// exposed through a live transport in isolation.
+const registerDataContentApplicationCommands = (
+  registrar: ApplicationCommandRegistrar,
+  dependencies: DataContentApplicationCommandDependencies
+): ApplicationCommandInstallation => {
+  const scope = registrar.createScope()
+
+  try {
+    scope.registerGroup(dataContentApplicationCommandGroups[0], {
+      'artifacts:finalize-run': async ({ args }) => {
+        try {
+          return {
+            ok: true as const,
+            artifacts: await dependencies.artifacts.finalizeRunArtifacts(args[0])
+          }
+        } catch (error) {
+          if (!(error instanceof ArtifactOwnershipPersistenceRaceError)) throw error
+          return {
+            ok: false as const,
+            code: Artifacts.ARTIFACT_OWNERSHIP_PERSISTENCE_RACE,
+            message: error.message
+          }
+        }
+      },
+      'artifacts:get-lineage': ({ args }) => dependencies.artifacts.getLineage(args[0]),
+      'artifacts:get-version-execution': ({ args }) =>
+        dependencies.artifacts.getVersionExecution(args[0]),
+      'artifacts:get-version-messages': ({ args }) =>
+        dependencies.artifacts.getVersionMessages(args[0]),
+      'artifacts:get-version-provenance': ({ args }) =>
+        dependencies.artifacts.getVersionProvenance(args[0]),
+      'artifacts:get-version-review': ({ args }) =>
+        dependencies.artifacts.getVersionReview(args[0]),
+      'artifacts:list-project-files': ({ args }) =>
+        dependencies.artifacts.listProjectFiles(args[0]),
+      'artifacts:open-file': (invocation) => {
+        assertLocalCaller(invocation, dataContentApplicationCommands.artifactOpenFile.name)
+        return dependencies.artifacts.openFile(invocation.args[0])
+      },
+      'artifacts:read-preview': ({ args }) => dependencies.artifacts.readPreview(args[0]),
+      'artifacts:reconcile-pending': ({ args }) =>
+        dependencies.artifacts.reconcilePendingArtifacts(args[0])
+    })
+    scope.registerGroup(dataContentApplicationCommandGroups[1], {
+      'lifecycle:client-id': ({ callerContext }) => callerContext.lifecycleClientId
+    })
+    scope.registerGroup(dataContentApplicationCommandGroups[2], {
+      'preview:delete': ({ args }) => dependencies.preview.delete(args[0]),
+      'preview:load': ({ args }) => dependencies.preview.load(args[0]),
+      'preview:save': ({ args }) => dependencies.preview.save(args[0])
+    })
+    scope.registerGroup(dataContentApplicationCommandGroups[3], {
+      'preview-resources:acquire': (invocation) => dependencies.managedPreview.acquire(invocation),
+      'preview-resources:read-range': (invocation) =>
+        dependencies.managedPreview.readRange(invocation),
+      'preview-resources:release': (invocation) => dependencies.managedPreview.release(invocation)
+    })
+    scope.registerGroup(dataContentApplicationCommandGroups[4], {
+      'project-files:get-overview': ({ args }) => dependencies.projectFiles.getOverview(args[0]),
+      'project-files:list-artifact-groups': ({ args }) =>
+        dependencies.projectFiles.listArtifactGroups(args[0]),
+      'project-files:list-files': ({ args }) => dependencies.projectFiles.listFiles(args[0]),
+      'project-files:repair-index': ({ args }) => dependencies.projectFiles.repairIndex(args[0]),
+      'project-files:search-artifacts': ({ args }) =>
+        dependencies.projectFiles.searchArtifacts(args[0])
+    })
+    scope.registerGroup(dataContentApplicationCommandGroups[5], {
+      'projects:create': async ({ args }) => {
+        const project = await dependencies.projects.create(args[0])
+        publishLifecycle(dependencies.events, LIFECYCLE_CHANNELS.projectCreated, project)
+        return project
+      },
+      'projects:delete': async ({ args }) => {
+        await dependencies.projects.delete(args[0].id)
+        publishLifecycle(dependencies.events, LIFECYCLE_CHANNELS.projectDeleted, {
+          projectId: args[0].id
+        })
+      },
+      'projects:get': ({ args }) => dependencies.projects.get(args[0]),
+      'projects:list': () => dependencies.projects.list(),
+      'projects:update': async ({ args }) => {
+        const project = await dependencies.projects.update(args[0])
+        publishLifecycle(dependencies.events, LIFECYCLE_CHANNELS.projectUpdated, project)
+        return project
+      }
+    })
+    scope.registerGroup(dataContentApplicationCommandGroups[6], {
+      'sessions:delete-session': ({ args }) =>
+        dependencies.withDataRootWrite(async () => {
+          await dependencies.sessions.deleteSession(args[0])
+          publishLifecycle(dependencies.events, LIFECYCLE_CHANNELS.sessionDeleted, args[0])
+        }),
+      'sessions:export-conversation': (invocation) => {
+        assertElectronCaller(
+          invocation,
+          dataContentApplicationCommands.sessionExportConversation.name
+        )
+        return dependencies.electron.exportConversationFromInvokingWindow(invocation)
+      },
+      'sessions:load-all': () =>
+        dependencies.withDataRootWrite(() => dependencies.sessions.loadAll()),
+      'sessions:save-manifest': ({ args }) =>
+        dependencies.withDataRootWrite(() => dependencies.sessions.saveManifest(args[0])),
+      'sessions:save-session': (invocation) => {
+        const originClientId = invocation.callerContext.lifecycleClientId
+        return dependencies.withDataRootWrite(async () => {
+          const result = await dependencies.sessions.saveSession(
+            invocation.args[0],
+            invocation.args[1]
+          )
+          publishLifecycle(
+            dependencies.events,
+            result.created ? LIFECYCLE_CHANNELS.sessionCreated : LIFECYCLE_CHANNELS.sessionUpdated,
+            { session: result.session, originClientId }
+          )
+          return result.session
+        })
+      }
+    })
+    scope.registerGroup(dataContentApplicationCommandGroups[7], {
+      'uploads:abort-transfer': (invocation) => dependencies.uploads.abortTransfer(invocation),
+      'uploads:append-transfer': (invocation) => dependencies.uploads.appendTransfer(invocation),
+      'uploads:begin-transfer': (invocation) => dependencies.uploads.beginTransfer(invocation),
+      'uploads:claim-local-file': (invocation) => dependencies.uploads.claimLocalFile(invocation),
+      'uploads:delete': (invocation) => dependencies.uploads.deleteUpload(invocation),
+      'uploads:finalize-session': (invocation) => dependencies.uploads.finalizeSession(invocation),
+      'uploads:finish-transfer': (invocation) => dependencies.uploads.finishTransfer(invocation),
+      'uploads:read-preview': (invocation) => dependencies.uploads.readPreview(invocation),
+      'uploads:stage-local-file': (invocation) => {
+        assertElectronCaller(invocation, dataContentApplicationCommands.uploadStageLocalFile.name)
+        return dependencies.electron.stageLocalFileWithProgress(invocation)
+      },
+      'uploads:stage-local-path': async (invocation) => {
+        assertLocalCaller(invocation, dataContentApplicationCommands.uploadStageLocalPath.name)
+        const attachment = await dependencies.uploads.stageLocalPath(invocation)
+        dependencies.events.publish('project-files:changed', {
+          projectId: invocation.args[0].projectId ?? Uploads.DEFAULT_UPLOAD_PROJECT_NAME,
+          sessionId: Uploads.STANDALONE_UPLOAD_SESSION_ID,
+          sources: ['upload'],
+          kind: 'upsert'
+        })
+        return attachment
+      },
+      'uploads:transfer-status': (invocation) => dependencies.uploads.transferStatus(invocation)
+    })
+    return scope.complete()
+  } catch (error) {
+    scope.rollback()
+    throw error
+  }
+}
+
+export {
+  dataContentApplicationCommandGroups,
+  dataContentApplicationCommands,
+  registerDataContentApplicationCommands
+}
+export type { DataContentApplicationCommandDependencies }

--- a/src/main/projects/ipc.ts
+++ b/src/main/projects/ipc.ts
@@ -115,3 +115,4 @@ export {
   createProjectHandlers,
   registerProjectIpcHandlers
 }
+export type { ProjectHandlers }

--- a/src/main/session-persistence/ipc.ts
+++ b/src/main/session-persistence/ipc.ts
@@ -173,4 +173,4 @@ export {
   loadSessionsAfterProjectRecovery,
   registerSessionPersistenceIpcHandlers
 }
-export type { SessionPersistenceBackend }
+export type { SessionPersistenceBackend, SessionPersistenceHandlers }


### PR DESCRIPTION
# T2f pull request

Title: `refactor(content): register data application commands`

## Problem

Data/content behavior is still organized as transport handler sets. The staged application router
needs one exact command inventory that delegates to existing Artifact, Preview, Project, Session,
Upload, and Lifecycle owners without reclaiming their state or caller-resource lifetime.

## Proposed change

- Register the latest exact 43-command inventory: Artifact 10, Lifecycle 1, Preview 3, Preview
  Resources 3, Project Files 5, Projects 5, Sessions 5, and Uploads 11.
- Update the brief's earlier “about 41” estimate for the later provenance/native-path additions.
- Preserve recovery-before-query, caller-lease Upload ownership, Preview ownership, graceful quit,
  persistence order, and best-effort event publication.
- Preserve native/local restrictions for export and local-file/local-path staging.
- Preserve invoking-window dialog parenting and targeted native upload progress through an explicit
  Electron adapter that receives the transport-neutral invocation.

## Scope and non-goals

- This is a compile-time preparatory command group and deliberately has no production consumer in
  this PR. `registerDataContentApplicationCommands` only registers into a supplied router.
- T2h0 installs every bounded command group into the live router atomically and certifies the full
  inventory; T2h1 then cuts over the Web/Task adapters. Wiring this group by itself would expose a
  partial command catalog and violate the staged dependency/capability contract.
- T2h0/T2h1 also own progress/navigation adapter wiring and transport cutover.
- No persisted schema, data relationship, filesystem authority, public wire, UI, or
  Electron/Web/Task/CLI capability change.
- Specialist, Permission, and Compute asymmetry and Issue #458 orchestration are unchanged.

## Acceptance criteria and validation

- Exact 43-command inventory and typed owner delegation -> new command contract tests -> passed.
- Native/local-only commands reject before owner invocation with existing surface distinctions ->
  command tests -> passed.
- Electron-only export and native staging forward the exact invocation to their native adapter;
  application commands contain no `BrowserWindow` or `event.sender` types -> passed.
- Recovery, persistence, event publication, Preview and Upload lease semantics -> focused owner
  regressions -> passed.
- All 43 mappings are directly exercised as 30 pass-through mappings and 13 behavior wrappers;
  Project/Session adaptation and Upload publication failure paths are included -> passed.
- Focused regression set -> 9 files / 105 tests passed.
- `npm run typecheck:node`, targeted ESLint, Prettier, and `git diff --check` -> passed.
- Independent Standards and Spec review found two P2 issues; both were fixed and final re-review found
  0 actionable findings.
- Full and cross-platform suites are delegated to online CI.

## Review focus

- Registration must not duplicate data state or regress caller lease ownership.
- Production churn is 487 lines, below but close to the 500-line hard stop.

## Uncovered risk

Real dependency composition, Upload progress/navigation adapter ownership, and Web/Task cutover remain
T2h0/T2h1 responsibilities.
